### PR TITLE
Matter support for Light and Relays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Matter support simple Relay on Apple Homekit by Stephan Hadinger (#18239)
 - VSC Pio menu bar extensions by @Jason2866 (#18233)
 - Command ``SwitchMode0`` to show or set all SwitchModes
+- Matter support for Light and Relays
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_matter/src/be_matter_module.c
+++ b/lib/libesp32/berry_matter/src/be_matter_module.c
@@ -151,6 +151,8 @@ extern const bclass be_class_Matter_TLV;   // need to declare it upfront because
 #include "solidify/solidified_Matter_Plugin_Root.h"
 #include "solidify/solidified_Matter_Plugin_Device.h"
 #include "solidify/solidified_Matter_Plugin_OnOff.h"
+#include "solidify/solidified_Matter_Plugin_Light1.h"
+#include "solidify/solidified_Matter_Plugin_Light2.h"
 #include "solidify/solidified_Matter_Plugin_Light3.h"
 #include "solidify/solidified_Matter_Plugin_Temp_Sensor.h"
 
@@ -320,7 +322,9 @@ module matter (scope: global, strings: weak) {
   Plugin_Root, class(be_class_Matter_Plugin_Root)       // Generic behavior common to all devices
   Plugin_Device, class(be_class_Matter_Plugin_Device)   // Generic device (abstract)
   Plugin_OnOff, class(be_class_Matter_Plugin_OnOff)     // Relay/Light behavior (OnOff)
-  Plugin_Light3, class(be_class_Matter_Plugin_Light3)     // Relay/Light behavior (OnOff)
+  Plugin_Light1, class(be_class_Matter_Plugin_Light1)     // Dimmable Light
+  Plugin_Light2, class(be_class_Matter_Plugin_Light2)     // Color Temperature Light
+  Plugin_Light3, class(be_class_Matter_Plugin_Light3)     // Extended Color Light
   Plugin_Temp_Sensor, class(be_class_Matter_Plugin_Temp_Sensor)   // Temperature Sensor
 }
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
@@ -380,8 +380,10 @@ class Matter_IM
         ctx.status = matter.UNSUPPORTED_COMMAND   #default error if returned `nil`
 
         var cmd_name = matter.get_command_name(ctx.cluster, ctx.command)
-        tasmota.log(string.format("MTR: >Command   (%6i) %s %s from [%s]:%i", msg.session.local_session_id, str(ctx), cmd_name ? cmd_name : "", msg.remote_ip, msg.remote_port), 2)
         var res = self.device.invoke_request(msg.session, q.command_fields, ctx)
+        var params_log = (ctx.log != nil) ? "(" + str(ctx.log) + ") " : ""
+        tasmota.log(string.format("MTR: >Command   (%6i) %s %s %s", msg.session.local_session_id, str(ctx), cmd_name ? cmd_name : "", params_log), 2)
+        ctx.log = nil
         var a1 = matter.InvokeResponseIB()
         if res == true || ctx.status == matter.SUCCESS      # special case, just respond ok
           a1.status = matter.CommandStatusIB()
@@ -584,7 +586,7 @@ class Matter_IM
     var query = matter.TimedRequestMessage().from_TLV(val)
     tasmota.log("MTR: received TimedRequestMessage=" + str(query), 3)
 
-    tasmota.log(string.format("MTR: >Command   (%6i) TimedRequest=%i from [%s]:%i", msg.session.local_session_id, query.timeout, msg.remote_ip, msg.remote_port), 2)
+    tasmota.log(string.format("MTR: >Command   (%6i) TimedRequest=%i", msg.session.local_session_id, query.timeout), 2)
     
     # Send success status report
     self.send_status(msg, matter.SUCCESS)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
@@ -39,6 +39,7 @@ class Matter_Path
   var attribute               # attribute or `nil` if expansion
   var command                 # command
   var status                  # status to be returned (matter.SUCCESS or matter.<ERROR>)
+  var log                     # any string that needs to be logged (used to show significant parameters for commands)
 
   def tostring()
     try

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light2.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light2.be
@@ -1,5 +1,5 @@
 #
-# Matter_Plugin_Light3.be - implements the behavior for a Light with 3 channels (RGB)
+# Matter_Plugin_Light2.be - implements the behavior for a Light with 2 channel (CT)
 #
 # Copyright (C) 2023  Stephan Hadinger & Theo Arends
 #
@@ -22,9 +22,9 @@
 # dummy declaration for solidification
 class Matter_Plugin end
 
-#@ solidify:Matter_Plugin_Light3,weak
+#@ solidify:Matter_Plugin_Light2,weak
 
-class Matter_Plugin_Light3 : Matter_Plugin
+class Matter_Plugin_Light2 : Matter_Plugin
   static var CLUSTERS  = {
     # 0x001D: inherited                             # Descriptor Cluster 9.5 p.453
     0x0003: [0,1,0xFFFC,0xFFFD],                    # Identify 1.2 p.16
@@ -32,21 +32,21 @@ class Matter_Plugin_Light3 : Matter_Plugin
     0x0005: [0,1,2,3,4,5,0xFFFC,0xFFFD],            # Scenes 1.4 p.30 - no writable
     0x0006: [0,0xFFFC,0xFFFD],                      # On/Off 1.5 p.48
     0x0008: [0,2,3,0x0F,0x11,0xFFFC,0xFFFD],                # Level Control 1.6 p.57
-    0x0300: [0,1,7,8,0xF,0x4001,0x400A,0xFFFC,0xFFFD],# Color Control 3.2 p.111
   }
-  static var TYPES = { 0x010D: 2 }                  # Extended Color Light
+  static var TYPES = { 0x010C: 2 }                  # Color Temperature Light
 
-  var shadow_hue, shadow_bri, shadow_sat
+  var shadow_bri, shadow_ct
+  var ct_min, ct_max
   var shadow_onoff
 
   #############################################################
   # Constructor
   def init(device, endpoint)
     super(self).init(device, endpoint)
-    self.shadow_hue = 0
     self.shadow_bri = 0
-    self.shadow_sat = 0
+    self.shadow_ct = 325
     self.shadow_onoff = false
+    self.update_ct_minmax()
   end
 
   #############################################################
@@ -54,18 +54,25 @@ class Matter_Plugin_Light3 : Matter_Plugin
   #
   def update_shadow()
     import light
+    self.update_ct_minmax()
     var light_status = light.get()
-    var bri = light_status.find('bri', nil)
-    var hue = light_status.find('hue', nil)
-    var sat = light_status.find('sat', nil)
     var pow = light_status.find('power', nil)
+    var bri = light_status.find('bri', nil)
+    var ct = light_status.find('ct', nil)
     if bri != nil     bri = tasmota.scale_uint(bri, 0, 255, 0, 254)   else bri = self.shadow_bri      end
-    if hue != nil     hue = tasmota.scale_uint(hue, 0, 360, 0, 254)   else bri = self.shadow_hue      end
-    if sat != nil     sat = tasmota.scale_uint(sat, 0, 255, 0, 254)   else bri = self.shadow_sat      end
+    if ct  == nil     ct = self.shadow_ct      end
     if pow != self.shadow_onoff self.attribute_updated(nil, 0x0006, 0x0000)   self.shadow_onoff = pow end
     if bri != self.shadow_bri   self.attribute_updated(nil, 0x0008, 0x0000)   self.shadow_bri = bri   end
-    if hue != self.shadow_hue   self.attribute_updated(nil, 0x0300, 0x0000)   self.shadow_hue = hue   end
-    if sat != self.shadow_sat   self.attribute_updated(nil, 0x0300, 0x0001)   self.shadow_sat = sat   end
+    if ct  != self.shadow_ct    self.attribute_updated(nil, 0x0300, 0x0007)   self.shadow_ct = ct   end
+  end
+
+  #############################################################
+  # Update ct_min/max
+  #
+  def update_ct_minmax()
+    var ct_alexa_mode = tasmota.get_option(82)      # if set, range is 200..380 instead of 153...500
+    self.ct_min = ct_alexa_mode ? 200 : 153
+    self.ct_max = ct_alexa_mode ? 380 : 500
   end
 
   #############################################################
@@ -137,31 +144,23 @@ class Matter_Plugin_Light3 : Matter_Plugin
       
     # ====================================================================================================
     elif cluster == 0x0300              # ========== Color Control 3.2 p.111 ==========
-      if   attribute == 0x0000          #  ---------- CurrentHue / u1 ----------
-        return TLV.create_TLV(TLV.U1, self.shadow_hue)
-      elif attribute == 0x0001          #  ---------- CurrentSaturation / u2 ----------
-        return TLV.create_TLV(TLV.U1, self.shadow_sat)
-      elif attribute == 0x0007          #  ---------- ColorTemperatureMireds / u2 ----------
-        return TLV.create_TLV(TLV.U1, 0)
+      if   attribute == 0x0007          #  ---------- ColorTemperatureMireds / u2 ----------
+        return TLV.create_TLV(TLV.U1, self.shadow_ct)
       elif attribute == 0x0008          #  ---------- ColorMode / u1 ----------
-        return TLV.create_TLV(TLV.U1, 0)# 0 = CurrentHue and CurrentSaturation
+        return TLV.create_TLV(TLV.U1, 2)# 2 = ColorTemperatureMireds
       elif attribute == 0x000F          #  ---------- Options / u1 ----------
         return TLV.create_TLV(TLV.U1, 0)
-      elif attribute == 0x4001          #  ---------- EnhancedColorMode / u1 ----------
-        return TLV.create_TLV(TLV.U1, 0)
-      elif attribute == 0x400A          #  ---------- ColorCapabilities / map2 ----------
-        return TLV.create_TLV(TLV.U1, 0)
+      elif attribute == 0x400B          #  ---------- ColorTempPhysicalMinMireds / u2 ----------
+        return TLV.create_TLV(TLV.U1, self.ct_min)
+      elif attribute == 0x400C          #  ---------- ColorTempPhysicalMaxMireds / u2 ----------
+        return TLV.create_TLV(TLV.U1, self.ct_max)
       
-      # Defined Primaries Information Attribute Set
-      elif attribute == 0x0010          #  ---------- NumberOfPrimaries / u1 ----------
-        return TLV.create_TLV(TLV.U1, 0)
-
       elif attribute == 0xFFFC          #  ---------- FeatureMap / map32 ----------
-        return TLV.create_TLV(TLV.U4, 0x01)    # HS
+        return TLV.create_TLV(TLV.U4, 0x10)    # CT
       elif attribute == 0xFFFD          #  ---------- ClusterRevision / u2 ----------
         return TLV.create_TLV(TLV.U4, 5)    # "new data model format and notation, FeatureMap support"
       end
-
+        
     else
       return super(self).read_attribute(session, ctx)
     end
@@ -255,44 +254,24 @@ class Matter_Plugin_Light3 : Matter_Plugin
         # TODO, we don't really support it
         return true
       end
+      
     # ====================================================================================================
     elif cluster == 0x0300              # ========== Color Control 3.2 p.111 ==========
-      if   command == 0x0000            # ---------- MoveToHue ----------
-        var hue_in = val.findsubval(0)  # Hue 0..254
-        var hue = tasmota.scale_uint(hue_in, 0, 254, 0, 360)
-        light.set({'hue': hue})
+      if   command == 0x000A            # ---------- MoveToColorTemperature ----------
+        var ct_in = val.findsubval(0)  # CT
+        if ct_in < self.ct_min  ct_in = self.ct_min   end
+        if ct_in > self.ct_max  ct_in = self.ct_max   end
+        light.set({'ct': ct_in})
         self.update_shadow()
-        ctx.log = "hue:"+str(hue_in)
-        return true
-      elif command == 0x0001            # ---------- MoveHue ----------
-        # TODO, we don't really support it
-        return true
-      elif command == 0x0002            # ---------- StepHue ----------
-        # TODO, we don't really support it
-        return true
-      elif command == 0x0003            # ---------- MoveToSaturation ----------
-        var sat_in = val.findsubval(0)  # Sat 0..254
-        var sat = tasmota.scale_uint(sat_in, 0, 254, 0, 255)
-        light.set({'sat': sat})
-        self.update_shadow()
-        ctx.log = "sat:"+str(sat_in)
-        return true
-      elif command == 0x0004            # ---------- MoveSaturation ----------
-        # TODO, we don't really support it
-        return true
-      elif command == 0x0005            # ---------- StepSaturation ----------
-        # TODO, we don't really support it
-        return true
-      elif command == 0x0006            # ---------- MoveToHueAndSaturation ----------
-        var hue_in = val.findsubval(0)  # Hue 0..254
-        var hue = tasmota.scale_uint(hue_in, 0, 254, 0, 360)
-        var sat_in = val.findsubval(1)  # Sat 0..254
-        var sat = tasmota.scale_uint(sat_in, 0, 254, 0, 255)
-        light.set({'hue': hue, 'sat': sat})
-        self.update_shadow()
-        ctx.log = "hue:"+str(hue_in)+" sat:"+str(sat_in)
+        ctx.log = "ct:"+str(ct_in)
         return true
       elif command == 0x0047            # ---------- StopMoveStep ----------
+        # TODO, we don't really support it
+        return true
+      elif command == 0x004B            # ---------- MoveColorTemperature ----------
+        # TODO, we don't really support it
+        return true
+      elif command == 0x004C            # ---------- StepColorTemperature ----------
         # TODO, we don't really support it
         return true
       end
@@ -306,4 +285,4 @@ class Matter_Plugin_Light3 : Matter_Plugin
     self.update_shadow()                    # force reading value and sending subscriptions
   end
 end
-matter.Plugin_Light3 = Matter_Plugin_Light3
+matter.Plugin_Light2 = Matter_Plugin_Light2

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
@@ -528,6 +528,7 @@ class Matter_Plugin_Root : Matter_Plugin
         end
         tasmota.log("MTR: RemoveFabric fabric("+str(index)+") not found", 2)
         ctx.status = matter.INVALID_ACTION
+        ctx.log = "fabric_index:"+str(index)
         return nil                      # trigger a standalone ack
 
       end

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
@@ -7,221 +7,9 @@
 extern const bclass be_class_Matter_Device;
 
 /********************************************************************
-** Solidified function: is_root_commissioning_open
+** Solidified function: start_operational_discovery
 ********************************************************************/
-be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(commissioning_admin_fabric),
-    }),
-    be_str_weak(is_root_commissioning_open),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060003,  //  0003  JMPF	R1	#0008
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x4C080000,  //  0005  LDNIL	R2
-      0x1C040202,  //  0006  EQ	R1	R1	R2
-      0x74060000,  //  0007  JMPT	R1	#0009
-      0x50040001,  //  0008  LDBOOL	R1	0	1
-      0x50040200,  //  0009  LDBOOL	R1	1	0
-      0x80040200,  //  000A  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_announce_op_discovery
-********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
-  be_nested_proto(
-    15,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(reverse),
-    /* K5   */  be_nested_str_weak(get_fabric_compressed),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_nested_str_weak(_X2D),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(eth),
-    /* K13  */  be_nested_str_weak(find),
-    /* K14  */  be_nested_str_weak(up),
-    /* K15  */  be_nested_str_weak(format),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K17  */  be_nested_str_weak(hostname_eth),
-    /* K18  */  be_const_int(3),
-    /* K19  */  be_nested_str_weak(add_service),
-    /* K20  */  be_nested_str_weak(_matter),
-    /* K21  */  be_nested_str_weak(_tcp),
-    /* K22  */  be_nested_str_weak(_I),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
-    /* K24  */  be_nested_str_weak(add_subtype),
-    /* K25  */  be_nested_str_weak(wifi),
-    /* K26  */  be_nested_str_weak(hostname_wifi),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K28  */  be_nested_str_weak(_X7C),
-    }),
-    be_str_weak(mdns_announce_op_discovery),
-    &be_const_str_solidified,
-    ( &(const binstruction[122]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA8020064,  //  0002  EXBLK	0	#0068
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x7C100200,  //  0004  CALL	R4	1
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C140305,  //  0009  GETMET	R5	R1	K5
-      0x7C140200,  //  000A  CALL	R5	1
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
-      0x7C180200,  //  000C  CALL	R6	1
-      0x00180D07,  //  000D  ADD	R6	R6	K7
-      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
-      0x7C1C0200,  //  000F  CALL	R7	1
-      0x00180C07,  //  0010  ADD	R6	R6	R7
-      0xB81E1000,  //  0011  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
-      0x00261406,  //  0013  ADD	R9	K10	R6
-      0x5828000B,  //  0014  LDCONST	R10	K11
-      0x7C1C0600,  //  0015  CALL	R7	3
-      0xB81E1000,  //  0016  GETNGBL	R7	K8
-      0x8C1C0F0C,  //  0017  GETMET	R7	R7	K12
-      0x7C1C0200,  //  0018  CALL	R7	1
-      0x8C1C0F0D,  //  0019  GETMET	R7	R7	K13
-      0x5824000E,  //  001A  LDCONST	R9	K14
-      0x7C1C0400,  //  001B  CALL	R7	2
-      0x781E0020,  //  001C  JMPF	R7	#003E
-      0xB81E1000,  //  001D  GETNGBL	R7	K8
-      0x8C1C0F09,  //  001E  GETMET	R7	R7	K9
-      0x8C24070F,  //  001F  GETMET	R9	R3	K15
-      0x582C0010,  //  0020  LDCONST	R11	K16
-      0x5830000C,  //  0021  LDCONST	R12	K12
-      0x5C340C00,  //  0022  MOVE	R13	R6
-      0x88380111,  //  0023  GETMBR	R14	R0	K17
-      0x7C240A00,  //  0024  CALL	R9	5
-      0x58280012,  //  0025  LDCONST	R10	K18
-      0x7C1C0600,  //  0026  CALL	R7	3
-      0x8C1C0513,  //  0027  GETMET	R7	R2	K19
-      0x58240014,  //  0028  LDCONST	R9	K20
-      0x58280015,  //  0029  LDCONST	R10	K21
-      0x542E15A3,  //  002A  LDINT	R11	5540
-      0x4C300000,  //  002B  LDNIL	R12
-      0x5C340C00,  //  002C  MOVE	R13	R6
-      0x88380111,  //  002D  GETMBR	R14	R0	K17
-      0x7C1C0E00,  //  002E  CALL	R7	7
-      0x8C1C0B06,  //  002F  GETMET	R7	R5	K6
-      0x7C1C0200,  //  0030  CALL	R7	1
-      0x001E2C07,  //  0031  ADD	R7	K22	R7
-      0xB8221000,  //  0032  GETNGBL	R8	K8
-      0x8C201109,  //  0033  GETMET	R8	R8	K9
-      0x002A2E07,  //  0034  ADD	R10	K23	R7
-      0x582C0012,  //  0035  LDCONST	R11	K18
-      0x7C200600,  //  0036  CALL	R8	3
-      0x8C200518,  //  0037  GETMET	R8	R2	K24
-      0x58280014,  //  0038  LDCONST	R10	K20
-      0x582C0015,  //  0039  LDCONST	R11	K21
-      0x5C300C00,  //  003A  MOVE	R12	R6
-      0x88340111,  //  003B  GETMBR	R13	R0	K17
-      0x5C380E00,  //  003C  MOVE	R14	R7
-      0x7C200C00,  //  003D  CALL	R8	6
-      0xB81E1000,  //  003E  GETNGBL	R7	K8
-      0x8C1C0F19,  //  003F  GETMET	R7	R7	K25
-      0x7C1C0200,  //  0040  CALL	R7	1
-      0x8C1C0F0D,  //  0041  GETMET	R7	R7	K13
-      0x5824000E,  //  0042  LDCONST	R9	K14
-      0x7C1C0400,  //  0043  CALL	R7	2
-      0x781E0020,  //  0044  JMPF	R7	#0066
-      0xB81E1000,  //  0045  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0046  GETMET	R7	R7	K9
-      0x8C24070F,  //  0047  GETMET	R9	R3	K15
-      0x582C0010,  //  0048  LDCONST	R11	K16
-      0x58300019,  //  0049  LDCONST	R12	K25
-      0x5C340C00,  //  004A  MOVE	R13	R6
-      0x8838011A,  //  004B  GETMBR	R14	R0	K26
-      0x7C240A00,  //  004C  CALL	R9	5
-      0x58280012,  //  004D  LDCONST	R10	K18
-      0x7C1C0600,  //  004E  CALL	R7	3
-      0x8C1C0513,  //  004F  GETMET	R7	R2	K19
-      0x58240014,  //  0050  LDCONST	R9	K20
-      0x58280015,  //  0051  LDCONST	R10	K21
-      0x542E15A3,  //  0052  LDINT	R11	5540
-      0x4C300000,  //  0053  LDNIL	R12
-      0x5C340C00,  //  0054  MOVE	R13	R6
-      0x8838011A,  //  0055  GETMBR	R14	R0	K26
-      0x7C1C0E00,  //  0056  CALL	R7	7
-      0x8C1C0B06,  //  0057  GETMET	R7	R5	K6
-      0x7C1C0200,  //  0058  CALL	R7	1
-      0x001E2C07,  //  0059  ADD	R7	K22	R7
-      0xB8221000,  //  005A  GETNGBL	R8	K8
-      0x8C201109,  //  005B  GETMET	R8	R8	K9
-      0x002A2E07,  //  005C  ADD	R10	K23	R7
-      0x582C0012,  //  005D  LDCONST	R11	K18
-      0x7C200600,  //  005E  CALL	R8	3
-      0x8C200518,  //  005F  GETMET	R8	R2	K24
-      0x58280014,  //  0060  LDCONST	R10	K20
-      0x582C0015,  //  0061  LDCONST	R11	K21
-      0x5C300C00,  //  0062  MOVE	R12	R6
-      0x8834011A,  //  0063  GETMBR	R13	R0	K26
-      0x5C380E00,  //  0064  MOVE	R14	R7
-      0x7C200C00,  //  0065  CALL	R8	6
-      0xA8040001,  //  0066  EXBLK	1	1
-      0x70020010,  //  0067  JMP		#0079
-      0xAC100002,  //  0068  CATCH	R4	0	2
-      0x7002000D,  //  0069  JMP		#0078
-      0xB81A1000,  //  006A  GETNGBL	R6	K8
-      0x8C180D09,  //  006B  GETMET	R6	R6	K9
-      0x60200008,  //  006C  GETGBL	R8	G8
-      0x5C240800,  //  006D  MOVE	R9	R4
-      0x7C200200,  //  006E  CALL	R8	1
-      0x00223608,  //  006F  ADD	R8	K27	R8
-      0x0020111C,  //  0070  ADD	R8	R8	K28
-      0x60240008,  //  0071  GETGBL	R9	G8
-      0x5C280A00,  //  0072  MOVE	R10	R5
-      0x7C240200,  //  0073  CALL	R9	1
-      0x00201009,  //  0074  ADD	R8	R8	R9
-      0x5824000B,  //  0075  LDCONST	R9	K11
-      0x7C180600,  //  0076  CALL	R6	3
-      0x70020000,  //  0077  JMP		#0079
-      0xB0080000,  //  0078  RAISE	2	R0	R0
-      0x80000000,  //  0079  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_active_endpoints
-********************************************************************/
-be_local_closure(Matter_Device_get_active_endpoints,   /* name */
+be_local_closure(Matter_Device_start_operational_discovery,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
@@ -231,45 +19,37 @@ be_local_closure(Matter_Device_get_active_endpoints,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins),
-    /* K1   */  be_nested_str_weak(get_endpoint),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(find),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_nested_str_weak(stop_iteration),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(mdns),
+    /* K2   */  be_nested_str_weak(string),
+    /* K3   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K4   */  be_nested_str_weak(root_w0),
+    /* K5   */  be_nested_str_weak(root_L),
+    /* K6   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K7   */  be_nested_str_weak(mdns_announce_op_discovery),
+    /* K8   */  be_nested_str_weak(get_fabric),
     }),
-    be_str_weak(get_active_endpoints),
+    be_str_weak(start_operational_discovery),
     &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x88100100,  //  0003  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0xA8020011,  //  0005  EXBLK	0	#0018
-      0x5C100600,  //  0006  MOVE	R4	R3
-      0x7C100000,  //  0007  CALL	R4	0
-      0x8C140901,  //  0008  GETMET	R5	R4	K1
-      0x7C140200,  //  0009  CALL	R5	1
-      0x78060002,  //  000A  JMPF	R1	#000E
-      0x1C180B02,  //  000B  EQ	R6	R5	K2
-      0x781A0000,  //  000C  JMPF	R6	#000E
-      0x7001FFF7,  //  000D  JMP		#0006
-      0x8C180503,  //  000E  GETMET	R6	R2	K3
-      0x5C200A00,  //  000F  MOVE	R8	R5
-      0x7C180400,  //  0010  CALL	R6	2
-      0x4C1C0000,  //  0011  LDNIL	R7
-      0x1C180C07,  //  0012  EQ	R6	R6	R7
-      0x781A0002,  //  0013  JMPF	R6	#0017
-      0x8C180504,  //  0014  GETMET	R6	R2	K4
-      0x5C200A00,  //  0015  MOVE	R8	R5
-      0x7C180400,  //  0016  CALL	R6	2
-      0x7001FFED,  //  0017  JMP		#0006
-      0x580C0005,  //  0018  LDCONST	R3	K5
-      0xAC0C0200,  //  0019  CATCH	R3	1	0
-      0xB0080000,  //  001A  RAISE	2	R0	R0
-      0x80040400,  //  001B  RET	1	R2
+    ( &(const binstruction[17]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xA4120400,  //  0002  IMPORT	R4	K2
+      0x8C140103,  //  0003  GETMET	R5	R0	K3
+      0x7C140200,  //  0004  CALL	R5	1
+      0x4C140000,  //  0005  LDNIL	R5
+      0x90020805,  //  0006  SETMBR	R0	K4	R5
+      0x4C140000,  //  0007  LDNIL	R5
+      0x90020A05,  //  0008  SETMBR	R0	K5	R5
+      0x8C140306,  //  0009  GETMET	R5	R1	K6
+      0x541E003B,  //  000A  LDINT	R7	60
+      0x7C140400,  //  000B  CALL	R5	2
+      0x8C140107,  //  000C  GETMET	R5	R0	K7
+      0x8C1C0308,  //  000D  GETMET	R7	R1	K8
+      0x7C1C0200,  //  000E  CALL	R7	1
+      0x7C140400,  //  000F  CALL	R5	2
+      0x80000000,  //  0010  RET	0
     })
   )
 );
@@ -313,140 +93,11 @@ be_local_closure(Matter_Device__init_basic_commissioning,   /* name */
 
 
 /********************************************************************
-** Solidified function: mdns_remove_op_discovery
+** Solidified function: compute_manual_pairing_code
 ********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
+be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(reverse),
-    /* K5   */  be_nested_str_weak(get_fabric_compressed),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_nested_str_weak(_X2D),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(eth),
-    /* K10  */  be_nested_str_weak(find),
-    /* K11  */  be_nested_str_weak(up),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(format),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_nested_str_weak(remove_service),
-    /* K17  */  be_nested_str_weak(_matter),
-    /* K18  */  be_nested_str_weak(_tcp),
-    /* K19  */  be_nested_str_weak(hostname_eth),
-    /* K20  */  be_nested_str_weak(wifi),
-    /* K21  */  be_nested_str_weak(hostname_wifi),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K23  */  be_nested_str_weak(_X7C),
-    }),
-    be_str_weak(mdns_remove_op_discovery),
-    &be_const_str_solidified,
-    ( &(const binstruction[81]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA802003B,  //  0002  EXBLK	0	#003F
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x7C100200,  //  0004  CALL	R4	1
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C140305,  //  0009  GETMET	R5	R1	K5
-      0x7C140200,  //  000A  CALL	R5	1
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
-      0x7C180200,  //  000C  CALL	R6	1
-      0x00180D07,  //  000D  ADD	R6	R6	K7
-      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
-      0x7C1C0200,  //  000F  CALL	R7	1
-      0x00180C07,  //  0010  ADD	R6	R6	R7
-      0xB81E1000,  //  0011  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
-      0x7C1C0200,  //  0013  CALL	R7	1
-      0x8C1C0F0A,  //  0014  GETMET	R7	R7	K10
-      0x5824000B,  //  0015  LDCONST	R9	K11
-      0x7C1C0400,  //  0016  CALL	R7	2
-      0x781E000E,  //  0017  JMPF	R7	#0027
-      0xB81E1000,  //  0018  GETNGBL	R7	K8
-      0x8C1C0F0C,  //  0019  GETMET	R7	R7	K12
-      0x8C24070D,  //  001A  GETMET	R9	R3	K13
-      0x582C000E,  //  001B  LDCONST	R11	K14
-      0x58300009,  //  001C  LDCONST	R12	K9
-      0x5C340C00,  //  001D  MOVE	R13	R6
-      0x7C240800,  //  001E  CALL	R9	4
-      0x5828000F,  //  001F  LDCONST	R10	K15
-      0x7C1C0600,  //  0020  CALL	R7	3
-      0x8C1C0510,  //  0021  GETMET	R7	R2	K16
-      0x58240011,  //  0022  LDCONST	R9	K17
-      0x58280012,  //  0023  LDCONST	R10	K18
-      0x5C2C0C00,  //  0024  MOVE	R11	R6
-      0x88300113,  //  0025  GETMBR	R12	R0	K19
-      0x7C1C0A00,  //  0026  CALL	R7	5
-      0xB81E1000,  //  0027  GETNGBL	R7	K8
-      0x8C1C0F14,  //  0028  GETMET	R7	R7	K20
-      0x7C1C0200,  //  0029  CALL	R7	1
-      0x8C1C0F0A,  //  002A  GETMET	R7	R7	K10
-      0x5824000B,  //  002B  LDCONST	R9	K11
-      0x7C1C0400,  //  002C  CALL	R7	2
-      0x781E000E,  //  002D  JMPF	R7	#003D
-      0xB81E1000,  //  002E  GETNGBL	R7	K8
-      0x8C1C0F0C,  //  002F  GETMET	R7	R7	K12
-      0x8C24070D,  //  0030  GETMET	R9	R3	K13
-      0x582C000E,  //  0031  LDCONST	R11	K14
-      0x58300014,  //  0032  LDCONST	R12	K20
-      0x5C340C00,  //  0033  MOVE	R13	R6
-      0x7C240800,  //  0034  CALL	R9	4
-      0x5828000F,  //  0035  LDCONST	R10	K15
-      0x7C1C0600,  //  0036  CALL	R7	3
-      0x8C1C0510,  //  0037  GETMET	R7	R2	K16
-      0x58240011,  //  0038  LDCONST	R9	K17
-      0x58280012,  //  0039  LDCONST	R10	K18
-      0x5C2C0C00,  //  003A  MOVE	R11	R6
-      0x88300115,  //  003B  GETMBR	R12	R0	K21
-      0x7C1C0A00,  //  003C  CALL	R7	5
-      0xA8040001,  //  003D  EXBLK	1	1
-      0x70020010,  //  003E  JMP		#0050
-      0xAC100002,  //  003F  CATCH	R4	0	2
-      0x7002000D,  //  0040  JMP		#004F
-      0xB81A1000,  //  0041  GETNGBL	R6	K8
-      0x8C180D0C,  //  0042  GETMET	R6	R6	K12
-      0x60200008,  //  0043  GETGBL	R8	G8
-      0x5C240800,  //  0044  MOVE	R9	R4
-      0x7C200200,  //  0045  CALL	R8	1
-      0x00222C08,  //  0046  ADD	R8	K22	R8
-      0x00201117,  //  0047  ADD	R8	R8	K23
-      0x60240008,  //  0048  GETGBL	R9	G8
-      0x5C280A00,  //  0049  MOVE	R10	R5
-      0x7C240200,  //  004A  CALL	R9	1
-      0x00201009,  //  004B  ADD	R8	R8	R9
-      0x5824000F,  //  004C  LDCONST	R9	K15
-      0x7C180600,  //  004D  CALL	R6	3
-      0x70020000,  //  004E  JMP		#0050
-      0xB0080000,  //  004F  RAISE	2	R0	R0
-      0x80000000,  //  0050  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_announce_op_discovery_all_fabrics
-********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
+    11,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -454,168 +105,212 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(active_fabrics),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(mdns_announce_op_discovery),
-    /* K5   */  be_nested_str_weak(stop_iteration),
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(root_discriminator),
+    /* K2   */  be_nested_str_weak(root_passcode),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(_X251i_X2505i_X2504i),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(Verhoeff),
+    /* K7   */  be_nested_str_weak(checksum),
     }),
-    be_str_weak(mdns_announce_op_discovery_all_fabrics),
+    be_str_weak(compute_manual_pairing_code),
     &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000B,  //  0005  EXBLK	0	#0012
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x780E0005,  //  000A  JMPF	R3	#0011
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x780E0002,  //  000D  JMPF	R3	#0011
-      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x7001FFF3,  //  0011  JMP		#0006
-      0x58040005,  //  0012  LDCONST	R1	K5
-      0xAC040200,  //  0013  CATCH	R1	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_remove_PASE
-********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(mdns_pase_eth),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eremove_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
-    /* K7   */  be_nested_str_weak(_matterc),
-    /* K8   */  be_nested_str_weak(_udp),
-    /* K9   */  be_nested_str_weak(commissioning_instance_eth),
-    /* K10  */  be_nested_str_weak(hostname_eth),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
-    /* K13  */  be_nested_str_weak(eth),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_nested_str_weak(remove_service),
-    /* K16  */  be_nested_str_weak(mdns_pase_wifi),
-    /* K17  */  be_nested_str_weak(commissioning_instance_wifi),
-    /* K18  */  be_nested_str_weak(hostname_wifi),
-    /* K19  */  be_nested_str_weak(wifi),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K21  */  be_nested_str_weak(_X7C),
-    }),
-    be_str_weak(mdns_remove_PASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[83]) {  /* code */
+    ( &(const binstruction[31]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xA802003D,  //  0002  EXBLK	0	#0041
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
-      0x780E001B,  //  0004  JMPF	R3	#0021
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x540E0FFE,  //  0002  LDINT	R3	4095
+      0x2C080403,  //  0003  AND	R2	R2	R3
+      0x540E0009,  //  0004  LDINT	R3	10
+      0x3C080403,  //  0005  SHR	R2	R2	R3
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x541202FF,  //  0007  LDINT	R4	768
+      0x2C0C0604,  //  0008  AND	R3	R3	R4
+      0x54120005,  //  0009  LDINT	R4	6
+      0x380C0604,  //  000A  SHL	R3	R3	R4
+      0x88100102,  //  000B  GETMBR	R4	R0	K2
+      0x54163FFE,  //  000C  LDINT	R5	16383
+      0x2C100805,  //  000D  AND	R4	R4	R5
+      0x300C0604,  //  000E  OR	R3	R3	R4
+      0x88100102,  //  000F  GETMBR	R4	R0	K2
+      0x5416000D,  //  0010  LDINT	R5	14
+      0x3C100805,  //  0011  SHR	R4	R4	R5
+      0x8C140303,  //  0012  GETMET	R5	R1	K3
+      0x581C0004,  //  0013  LDCONST	R7	K4
+      0x5C200400,  //  0014  MOVE	R8	R2
+      0x5C240600,  //  0015  MOVE	R9	R3
+      0x5C280800,  //  0016  MOVE	R10	R4
+      0x7C140A00,  //  0017  CALL	R5	5
+      0xB81A0A00,  //  0018  GETNGBL	R6	K5
+      0x88180D06,  //  0019  GETMBR	R6	R6	K6
+      0x8C180D07,  //  001A  GETMET	R6	R6	K7
+      0x5C200A00,  //  001B  MOVE	R8	R5
+      0x7C180400,  //  001C  CALL	R6	2
+      0x00140A06,  //  001D  ADD	R5	R5	R6
+      0x80040A00,  //  001E  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _trigger_read_sensors
+********************************************************************/
+be_local_closure(Matter_Device__trigger_read_sensors,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(read_sensors),
+    /* K3   */  be_nested_str_weak(load),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(plugins),
+    /* K6   */  be_nested_str_weak(parse_sensors),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
+    /* K10  */  be_const_int(3),
+    }),
+    be_str_weak(_trigger_read_sensors),
+    &be_const_str_solidified,
+    ( &(const binstruction[37]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x7C080200,  //  0003  CALL	R2	1
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x1C0C0403,  //  0005  EQ	R3	R2	R3
+      0x780E0000,  //  0006  JMPF	R3	#0008
+      0x80000600,  //  0007  RET	0
+      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
+      0x5C140400,  //  0009  MOVE	R5	R2
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x4C100000,  //  000B  LDNIL	R4
+      0x20100604,  //  000C  NE	R4	R3	R4
+      0x7812000D,  //  000D  JMPF	R4	#001C
+      0x58100004,  //  000E  LDCONST	R4	K4
+      0x6014000C,  //  000F  GETGBL	R5	G12
+      0x88180105,  //  0010  GETMBR	R6	R0	K5
+      0x7C140200,  //  0011  CALL	R5	1
+      0x14140805,  //  0012  LT	R5	R4	R5
+      0x78160006,  //  0013  JMPF	R5	#001B
+      0x88140105,  //  0014  GETMBR	R5	R0	K5
+      0x94140A04,  //  0015  GETIDX	R5	R5	R4
+      0x8C140B06,  //  0016  GETMET	R5	R5	K6
+      0x5C1C0600,  //  0017  MOVE	R7	R3
+      0x7C140400,  //  0018  CALL	R5	2
+      0x00100907,  //  0019  ADD	R4	R4	K7
+      0x7001FFF3,  //  001A  JMP		#000F
+      0x70020007,  //  001B  JMP		#0024
+      0xB8120200,  //  001C  GETNGBL	R4	K1
+      0x8C100908,  //  001D  GETMET	R4	R4	K8
+      0x60180008,  //  001E  GETGBL	R6	G8
+      0x5C1C0400,  //  001F  MOVE	R7	R2
+      0x7C180200,  //  0020  CALL	R6	1
+      0x001A1206,  //  0021  ADD	R6	K9	R6
+      0x581C000A,  //  0022  LDCONST	R7	K10
+      0x7C100600,  //  0023  CALL	R4	3
+      0x80000000,  //  0024  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(Matter_Device_start,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_trigger_read_sensors),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80000000,  //  0003  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(started),
+    /* K1   */  be_nested_str_weak(plugins),
+    /* K2   */  be_nested_str_weak(push),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(Plugin_Root),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(autoconf_device),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(add_cron),
+    /* K9   */  be_nested_str_weak(_X2A_X2F5_X20_X2A_X20_X2A_X20_X2A_X20_X2A_X20_X2A),
+    /* K10  */  be_nested_str_weak(matter_sensors_5s),
+    /* K11  */  be_nested_str_weak(_start_udp),
+    /* K12  */  be_nested_str_weak(UDP_PORT),
+    /* K13  */  be_nested_str_weak(start_mdns_announce_hostnames),
+    }),
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060000,  //  0001  JMPF	R1	#0003
+      0x80000200,  //  0002  RET	0
+      0x88040101,  //  0003  GETMBR	R1	R0	K1
+      0x8C040302,  //  0004  GETMET	R1	R1	K2
       0xB80E0600,  //  0005  GETNGBL	R3	K3
       0x8C0C0704,  //  0006  GETMET	R3	R3	K4
-      0x8C140505,  //  0007  GETMET	R5	R2	K5
-      0x581C0006,  //  0008  LDCONST	R7	K6
-      0x58200007,  //  0009  LDCONST	R8	K7
-      0x58240008,  //  000A  LDCONST	R9	K8
-      0x88280109,  //  000B  GETMBR	R10	R0	K9
-      0x882C010A,  //  000C  GETMBR	R11	R0	K10
-      0x7C140C00,  //  000D  CALL	R5	6
-      0x5818000B,  //  000E  LDCONST	R6	K11
-      0x7C0C0600,  //  000F  CALL	R3	3
-      0xB80E0600,  //  0010  GETNGBL	R3	K3
-      0x8C0C0704,  //  0011  GETMET	R3	R3	K4
-      0x8C140505,  //  0012  GETMET	R5	R2	K5
-      0x581C000C,  //  0013  LDCONST	R7	K12
-      0x5820000D,  //  0014  LDCONST	R8	K13
-      0x88240109,  //  0015  GETMBR	R9	R0	K9
-      0x7C140800,  //  0016  CALL	R5	4
-      0x5818000E,  //  0017  LDCONST	R6	K14
-      0x7C0C0600,  //  0018  CALL	R3	3
-      0x500C0000,  //  0019  LDBOOL	R3	0	0
-      0x90020403,  //  001A  SETMBR	R0	K2	R3
-      0x8C0C030F,  //  001B  GETMET	R3	R1	K15
-      0x58140007,  //  001C  LDCONST	R5	K7
-      0x58180008,  //  001D  LDCONST	R6	K8
-      0x881C0109,  //  001E  GETMBR	R7	R0	K9
-      0x8820010A,  //  001F  GETMBR	R8	R0	K10
-      0x7C0C0A00,  //  0020  CALL	R3	5
-      0x880C0110,  //  0021  GETMBR	R3	R0	K16
-      0x780E001B,  //  0022  JMPF	R3	#003F
-      0xB80E0600,  //  0023  GETNGBL	R3	K3
-      0x8C0C0704,  //  0024  GETMET	R3	R3	K4
-      0x8C140505,  //  0025  GETMET	R5	R2	K5
-      0x581C0006,  //  0026  LDCONST	R7	K6
-      0x58200007,  //  0027  LDCONST	R8	K7
-      0x58240008,  //  0028  LDCONST	R9	K8
-      0x88280111,  //  0029  GETMBR	R10	R0	K17
-      0x882C0112,  //  002A  GETMBR	R11	R0	K18
-      0x7C140C00,  //  002B  CALL	R5	6
-      0x5818000B,  //  002C  LDCONST	R6	K11
-      0x7C0C0600,  //  002D  CALL	R3	3
-      0xB80E0600,  //  002E  GETNGBL	R3	K3
-      0x8C0C0704,  //  002F  GETMET	R3	R3	K4
-      0x8C140505,  //  0030  GETMET	R5	R2	K5
-      0x581C000C,  //  0031  LDCONST	R7	K12
-      0x58200013,  //  0032  LDCONST	R8	K19
-      0x88240111,  //  0033  GETMBR	R9	R0	K17
-      0x7C140800,  //  0034  CALL	R5	4
-      0x5818000E,  //  0035  LDCONST	R6	K14
-      0x7C0C0600,  //  0036  CALL	R3	3
-      0x500C0000,  //  0037  LDBOOL	R3	0	0
-      0x90022003,  //  0038  SETMBR	R0	K16	R3
-      0x8C0C030F,  //  0039  GETMET	R3	R1	K15
-      0x58140007,  //  003A  LDCONST	R5	K7
-      0x58180008,  //  003B  LDCONST	R6	K8
-      0x881C0111,  //  003C  GETMBR	R7	R0	K17
-      0x88200112,  //  003D  GETMBR	R8	R0	K18
-      0x7C0C0A00,  //  003E  CALL	R3	5
-      0xA8040001,  //  003F  EXBLK	1	1
-      0x70020010,  //  0040  JMP		#0052
-      0xAC0C0002,  //  0041  CATCH	R3	0	2
-      0x7002000D,  //  0042  JMP		#0051
-      0xB8160600,  //  0043  GETNGBL	R5	K3
-      0x8C140B04,  //  0044  GETMET	R5	R5	K4
-      0x601C0008,  //  0045  GETGBL	R7	G8
-      0x5C200600,  //  0046  MOVE	R8	R3
-      0x7C1C0200,  //  0047  CALL	R7	1
-      0x001E2807,  //  0048  ADD	R7	K20	R7
-      0x001C0F15,  //  0049  ADD	R7	R7	K21
-      0x60200008,  //  004A  GETGBL	R8	G8
-      0x5C240800,  //  004B  MOVE	R9	R4
-      0x7C200200,  //  004C  CALL	R8	1
-      0x001C0E08,  //  004D  ADD	R7	R7	R8
-      0x5820000E,  //  004E  LDCONST	R8	K14
-      0x7C140600,  //  004F  CALL	R5	3
-      0x70020000,  //  0050  JMP		#0052
-      0xB0080000,  //  0051  RAISE	2	R0	R0
-      0x80000000,  //  0052  RET	0
+      0x5C140000,  //  0007  MOVE	R5	R0
+      0x58180005,  //  0008  LDCONST	R6	K5
+      0x7C0C0600,  //  0009  CALL	R3	3
+      0x7C040400,  //  000A  CALL	R1	2
+      0x8C040106,  //  000B  GETMET	R1	R0	K6
+      0x7C040200,  //  000C  CALL	R1	1
+      0xB8060E00,  //  000D  GETNGBL	R1	K7
+      0x8C040308,  //  000E  GETMET	R1	R1	K8
+      0x580C0009,  //  000F  LDCONST	R3	K9
+      0x84100000,  //  0010  CLOSURE	R4	P0
+      0x5814000A,  //  0011  LDCONST	R5	K10
+      0x7C040800,  //  0012  CALL	R1	4
+      0x8C04010B,  //  0013  GETMET	R1	R0	K11
+      0x880C010C,  //  0014  GETMBR	R3	R0	K12
+      0x7C040400,  //  0015  CALL	R1	2
+      0x8C04010D,  //  0016  GETMET	R1	R0	K13
+      0x7C040200,  //  0017  CALL	R1	1
+      0x50040200,  //  0018  LDBOOL	R1	1	0
+      0x90020001,  //  0019  SETMBR	R0	K0	R1
+      0xA0000000,  //  001A  CLOSE	R0
+      0x80000000,  //  001B  RET	0
     })
   )
 );
@@ -623,9 +318,9 @@ be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
 
 
 /********************************************************************
-** Solidified function: save_before_restart
+** Solidified function: stop_basic_commissioning
 ********************************************************************/
-be_local_closure(Matter_Device_save_before_restart,   /* name */
+be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -635,254 +330,35 @@ be_local_closure(Matter_Device_save_before_restart,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K1   */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
-    }),
-    be_str_weak(save_before_restart),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
-      0x7C040200,  //  0003  CALL	R1	1
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_mdns_announce_hostnames
-********************************************************************/
-be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_mdns_host),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[10]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x50080000,  //  0002  LDBOOL	R2	0	0
-          0x7C000400,  //  0003  CALL	R0	2
-          0xB8020200,  //  0004  GETNGBL	R0	K1
-          0x8C000102,  //  0005  GETMET	R0	R0	K2
-          0x58080003,  //  0006  LDCONST	R2	K3
-          0x580C0004,  //  0007  LDCONST	R3	K4
-          0x7C000600,  //  0008  CALL	R0	3
-          0x80000000,  //  0009  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_mdns_host),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[10]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x50080200,  //  0002  LDBOOL	R2	1	0
-          0x7C000400,  //  0003  CALL	R0	2
-          0xB8020200,  //  0004  GETNGBL	R0	K1
-          0x8C000102,  //  0005  GETMET	R0	R0	K2
-          0x58080003,  //  0006  LDCONST	R2	K3
-          0x580C0004,  //  0007  LDCONST	R3	K4
-          0x7C000600,  //  0008  CALL	R0	3
-          0x80000000,  //  0009  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(wifi),
-    /* K2   */  be_nested_str_weak(up),
-    /* K3   */  be_nested_str_weak(_mdns_announce_hostname),
-    /* K4   */  be_nested_str_weak(add_rule),
-    /* K5   */  be_nested_str_weak(Wifi_X23Connected),
-    /* K6   */  be_nested_str_weak(matter_mdns_host),
-    /* K7   */  be_nested_str_weak(eth),
-    /* K8   */  be_nested_str_weak(Eth_X23Connected),
-    }),
-    be_str_weak(start_mdns_announce_hostnames),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x94040302,  //  0003  GETIDX	R1	R1	K2
-      0x78060003,  //  0004  JMPF	R1	#0009
-      0x8C040103,  //  0005  GETMET	R1	R0	K3
-      0x500C0000,  //  0006  LDBOOL	R3	0	0
-      0x7C040400,  //  0007  CALL	R1	2
-      0x70020005,  //  0008  JMP		#000F
-      0xB8060000,  //  0009  GETNGBL	R1	K0
-      0x8C040304,  //  000A  GETMET	R1	R1	K4
-      0x580C0005,  //  000B  LDCONST	R3	K5
-      0x84100000,  //  000C  CLOSURE	R4	P0
-      0x58140006,  //  000D  LDCONST	R5	K6
-      0x7C040800,  //  000E  CALL	R1	4
-      0xB8060000,  //  000F  GETNGBL	R1	K0
-      0x8C040307,  //  0010  GETMET	R1	R1	K7
-      0x7C040200,  //  0011  CALL	R1	1
-      0x94040302,  //  0012  GETIDX	R1	R1	K2
-      0x78060003,  //  0013  JMPF	R1	#0018
-      0x8C040103,  //  0014  GETMET	R1	R0	K3
-      0x500C0200,  //  0015  LDBOOL	R3	1	0
-      0x7C040400,  //  0016  CALL	R1	2
-      0x70020005,  //  0017  JMP		#001E
-      0xB8060000,  //  0018  GETNGBL	R1	K0
-      0x8C040304,  //  0019  GETMET	R1	R1	K4
-      0x580C0008,  //  001A  LDCONST	R3	K8
-      0x84100001,  //  001B  CLOSURE	R4	P1
-      0x58140006,  //  001C  LDCONST	R5	K6
-      0x7C040800,  //  001D  CALL	R1	4
-      0xA0000000,  //  001E  CLOSE	R0
-      0x80000000,  //  001F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(Matter_Device_invoke_request,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(plugins),
-    /* K3   */  be_nested_str_weak(invoke_request),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(status),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    /* K1   */  be_nested_str_weak(mdns_remove_PASE),
+    /* K2   */  be_nested_str_weak(commissioning_iterations),
+    /* K3   */  be_nested_str_weak(commissioning_discriminator),
+    /* K4   */  be_nested_str_weak(commissioning_salt),
+    /* K5   */  be_nested_str_weak(commissioning_w0),
+    /* K6   */  be_nested_str_weak(commissioning_L),
+    /* K7   */  be_nested_str_weak(commissioning_admin_fabric),
     }),
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58100000,  //  0000  LDCONST	R4	K0
-      0x88140701,  //  0001  GETMBR	R5	R3	K1
-      0x6018000C,  //  0002  GETGBL	R6	G12
-      0x881C0102,  //  0003  GETMBR	R7	R0	K2
-      0x7C180200,  //  0004  CALL	R6	1
-      0x14180806,  //  0005  LT	R6	R4	R6
-      0x781A000C,  //  0006  JMPF	R6	#0014
-      0x88180102,  //  0007  GETMBR	R6	R0	K2
-      0x94180C04,  //  0008  GETIDX	R6	R6	R4
-      0x881C0D01,  //  0009  GETMBR	R7	R6	K1
-      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0D03,  //  000C  GETMET	R7	R6	K3
-      0x5C240200,  //  000D  MOVE	R9	R1
-      0x5C280400,  //  000E  MOVE	R10	R2
-      0x5C2C0600,  //  000F  MOVE	R11	R3
-      0x7C1C0800,  //  0010  CALL	R7	4
-      0x80040E00,  //  0011  RET	1	R7
-      0x00100904,  //  0012  ADD	R4	R4	K4
-      0x7001FFED,  //  0013  JMP		#0002
-      0xB81A0C00,  //  0014  GETNGBL	R6	K6
-      0x88180D07,  //  0015  GETMBR	R6	R6	K7
-      0x900E0A06,  //  0016  SETMBR	R3	K5	R6
-      0x80000000,  //  0017  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_fabric
-********************************************************************/
-be_local_closure(Matter_Device_remove_fabric,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(im),
-    /* K2   */  be_nested_str_weak(subs_shop),
-    /* K3   */  be_nested_str_weak(remove_by_fabric),
-    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K5   */  be_nested_str_weak(sessions),
-    /* K6   */  be_nested_str_weak(remove_fabric),
-    /* K7   */  be_nested_str_weak(save_fabrics),
-    }),
-    be_str_weak(remove_fabric),
+    be_str_weak(stop_basic_commissioning),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x88080501,  //  0001  GETMBR	R2	R2	K1
-      0x88080502,  //  0002  GETMBR	R2	R2	K2
-      0x8C080503,  //  0003  GETMET	R2	R2	K3
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x8C080104,  //  0006  GETMET	R2	R0	K4
-      0x5C100200,  //  0007  MOVE	R4	R1
-      0x7C080400,  //  0008  CALL	R2	2
-      0x88080105,  //  0009  GETMBR	R2	R0	K5
-      0x8C080506,  //  000A  GETMET	R2	R2	K6
-      0x5C100200,  //  000B  MOVE	R4	R1
-      0x7C080400,  //  000C  CALL	R2	2
-      0x88080105,  //  000D  GETMBR	R2	R0	K5
-      0x8C080507,  //  000E  GETMET	R2	R2	K7
-      0x7C080200,  //  000F  CALL	R2	1
+      0x4C040000,  //  0000  LDNIL	R1
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x7C040200,  //  0003  CALL	R1	1
+      0x4C040000,  //  0004  LDNIL	R1
+      0x90020401,  //  0005  SETMBR	R0	K2	R1
+      0x4C040000,  //  0006  LDNIL	R1
+      0x90020601,  //  0007  SETMBR	R0	K3	R1
+      0x4C040000,  //  0008  LDNIL	R1
+      0x90020801,  //  0009  SETMBR	R0	K4	R1
+      0x4C040000,  //  000A  LDNIL	R1
+      0x90020A01,  //  000B  SETMBR	R0	K5	R1
+      0x4C040000,  //  000C  LDNIL	R1
+      0x90020C01,  //  000D  SETMBR	R0	K6	R1
+      0x4C040000,  //  000E  LDNIL	R1
+      0x90020E01,  //  000F  SETMBR	R0	K7	R1
       0x80000000,  //  0010  RET	0
     })
   )
@@ -944,6 +420,198 @@ be_local_closure(Matter_Device_start_operational_discovery_deferred,   /* name *
       0x7C080600,  //  0004  CALL	R2	3
       0xA0000000,  //  0005  CLOSE	R0
       0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_fabric
+********************************************************************/
+be_local_closure(Matter_Device_remove_fabric,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(im),
+    /* K2   */  be_nested_str_weak(subs_shop),
+    /* K3   */  be_nested_str_weak(remove_by_fabric),
+    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K5   */  be_nested_str_weak(sessions),
+    /* K6   */  be_nested_str_weak(remove_fabric),
+    /* K7   */  be_nested_str_weak(save_fabrics),
+    }),
+    be_str_weak(remove_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080501,  //  0001  GETMBR	R2	R2	K1
+      0x88080502,  //  0002  GETMBR	R2	R2	K2
+      0x8C080503,  //  0003  GETMET	R2	R2	K3
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x8C080104,  //  0006  GETMET	R2	R0	K4
+      0x5C100200,  //  0007  MOVE	R4	R1
+      0x7C080400,  //  0008  CALL	R2	2
+      0x88080105,  //  0009  GETMBR	R2	R0	K5
+      0x8C080506,  //  000A  GETMET	R2	R2	K6
+      0x5C100200,  //  000B  MOVE	R4	R1
+      0x7C080400,  //  000C  CALL	R2	2
+      0x88080105,  //  000D  GETMBR	R2	R0	K5
+      0x8C080507,  //  000E  GETMET	R2	R2	K7
+      0x7C080200,  //  000F  CALL	R2	1
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: received_ack
+********************************************************************/
+be_local_closure(Matter_Device_received_ack,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(received_ack),
+    }),
+    be_str_weak(received_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_root_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[19]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(PASE_TIMEOUT),
+    /* K2   */  be_nested_str_weak(compute_manual_pairing_code),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(format),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s_X2D_X25s_X2D_X25s),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_const_int(3),
+    /* K9   */  be_const_int(2147483647),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(_compute_pbkdf),
+    /* K12  */  be_nested_str_weak(root_passcode),
+    /* K13  */  be_nested_str_weak(root_iterations),
+    /* K14  */  be_nested_str_weak(root_salt),
+    /* K15  */  be_nested_str_weak(start_basic_commissioning),
+    /* K16  */  be_nested_str_weak(root_discriminator),
+    /* K17  */  be_nested_str_weak(root_w0),
+    /* K18  */  be_nested_str_weak(root_L),
+    }),
+    be_str_weak(start_root_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[38]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x1C0C0203,  //  0002  EQ	R3	R1	R3
+      0x780E0000,  //  0003  JMPF	R3	#0005
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x8C0C0102,  //  0005  GETMET	R3	R0	K2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0xB8120600,  //  0007  GETNGBL	R4	K3
+      0x8C100904,  //  0008  GETMET	R4	R4	K4
+      0x8C180505,  //  0009  GETMET	R6	R2	K5
+      0x58200006,  //  000A  LDCONST	R8	K6
+      0x40260F08,  //  000B  CONNECT	R9	K7	K8
+      0x94240609,  //  000C  GETIDX	R9	R3	R9
+      0x542A0003,  //  000D  LDINT	R10	4
+      0x542E0005,  //  000E  LDINT	R11	6
+      0x4028140B,  //  000F  CONNECT	R10	R10	R11
+      0x9428060A,  //  0010  GETIDX	R10	R3	R10
+      0x542E0006,  //  0011  LDINT	R11	7
+      0x402C1709,  //  0012  CONNECT	R11	R11	K9
+      0x942C060B,  //  0013  GETIDX	R11	R3	R11
+      0x7C180A00,  //  0014  CALL	R6	5
+      0x581C000A,  //  0015  LDCONST	R7	K10
+      0x7C100600,  //  0016  CALL	R4	3
+      0x8C10010B,  //  0017  GETMET	R4	R0	K11
+      0x8818010C,  //  0018  GETMBR	R6	R0	K12
+      0x881C010D,  //  0019  GETMBR	R7	R0	K13
+      0x8820010E,  //  001A  GETMBR	R8	R0	K14
+      0x7C100800,  //  001B  CALL	R4	4
+      0x8C10010F,  //  001C  GETMET	R4	R0	K15
+      0x5C180200,  //  001D  MOVE	R6	R1
+      0x881C010D,  //  001E  GETMBR	R7	R0	K13
+      0x88200110,  //  001F  GETMBR	R8	R0	K16
+      0x8824010E,  //  0020  GETMBR	R9	R0	K14
+      0x88280111,  //  0021  GETMBR	R10	R0	K17
+      0x882C0112,  //  0022  GETMBR	R11	R0	K18
+      0x4C300000,  //  0023  LDNIL	R12
+      0x7C101000,  //  0024  CALL	R4	8
+      0x80000000,  //  0025  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_before_restart
+********************************************************************/
+be_local_closure(Matter_Device_save_before_restart,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K1   */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
+    }),
+    be_str_weak(save_before_restart),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x7C040200,  //  0003  CALL	R1	1
+      0x80000000,  //  0004  RET	0
     })
   )
 );
@@ -1027,893 +695,20 @@ be_local_closure(Matter_Device_compute_qrcode_content,   /* name */
 
 
 /********************************************************************
-** Solidified function: sort_distinct
+** Solidified function: _start_udp
 ********************************************************************/
-be_local_closure(Matter_Device_sort_distinct,   /* name */
+be_local_closure(Matter_Device__start_udp,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_nested_str_weak(remove),
-    }),
-    be_str_weak(sort_distinct),
-    &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080010,  //  0001  GETGBL	R2	G16
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x040C0701,  //  0005  SUB	R3	R3	K1
-      0x400E0203,  //  0006  CONNECT	R3	K1	R3
-      0x7C080200,  //  0007  CALL	R2	1
-      0xA8020010,  //  0008  EXBLK	0	#001A
-      0x5C0C0400,  //  0009  MOVE	R3	R2
-      0x7C0C0000,  //  000A  CALL	R3	0
-      0x94100003,  //  000B  GETIDX	R4	R0	R3
-      0x5C140600,  //  000C  MOVE	R5	R3
-      0x24180B02,  //  000D  GT	R6	R5	K2
-      0x781A0008,  //  000E  JMPF	R6	#0018
-      0x04180B01,  //  000F  SUB	R6	R5	K1
-      0x94180006,  //  0010  GETIDX	R6	R0	R6
-      0x24180C04,  //  0011  GT	R6	R6	R4
-      0x781A0004,  //  0012  JMPF	R6	#0018
-      0x04180B01,  //  0013  SUB	R6	R5	K1
-      0x94180006,  //  0014  GETIDX	R6	R0	R6
-      0x98000A06,  //  0015  SETIDX	R0	R5	R6
-      0x04140B01,  //  0016  SUB	R5	R5	K1
-      0x7001FFF4,  //  0017  JMP		#000D
-      0x98000A04,  //  0018  SETIDX	R0	R5	R4
-      0x7001FFEE,  //  0019  JMP		#0009
-      0x58080003,  //  001A  LDCONST	R2	K3
-      0xAC080200,  //  001B  CATCH	R2	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x58080001,  //  001D  LDCONST	R2	K1
-      0x600C000C,  //  001E  GETGBL	R3	G12
-      0x5C100000,  //  001F  MOVE	R4	R0
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x180C0701,  //  0021  LE	R3	R3	K1
-      0x780E0000,  //  0022  JMPF	R3	#0024
-      0x80040000,  //  0023  RET	1	R0
-      0x940C0102,  //  0024  GETIDX	R3	R0	K2
-      0x6010000C,  //  0025  GETGBL	R4	G12
-      0x5C140000,  //  0026  MOVE	R5	R0
-      0x7C100200,  //  0027  CALL	R4	1
-      0x14100404,  //  0028  LT	R4	R2	R4
-      0x78120009,  //  0029  JMPF	R4	#0034
-      0x94100002,  //  002A  GETIDX	R4	R0	R2
-      0x1C100803,  //  002B  EQ	R4	R4	R3
-      0x78120003,  //  002C  JMPF	R4	#0031
-      0x8C100104,  //  002D  GETMET	R4	R0	K4
-      0x5C180400,  //  002E  MOVE	R6	R2
-      0x7C100400,  //  002F  CALL	R4	2
-      0x70020001,  //  0030  JMP		#0033
-      0x940C0002,  //  0031  GETIDX	R3	R0	R2
-      0x00080501,  //  0032  ADD	R2	R2	K1
-      0x7001FFF0,  //  0033  JMP		#0025
-      0x80040000,  //  0034  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _trigger_read_sensors
-********************************************************************/
-be_local_closure(Matter_Device__trigger_read_sensors,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(read_sensors),
-    /* K3   */  be_nested_str_weak(load),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(plugins),
-    /* K6   */  be_nested_str_weak(parse_sensors),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
-    /* K10  */  be_const_int(3),
-    }),
-    be_str_weak(_trigger_read_sensors),
-    &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x1C0C0403,  //  0005  EQ	R3	R2	R3
-      0x780E0000,  //  0006  JMPF	R3	#0008
-      0x80000600,  //  0007  RET	0
-      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
-      0x5C140400,  //  0009  MOVE	R5	R2
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x4C100000,  //  000B  LDNIL	R4
-      0x20100604,  //  000C  NE	R4	R3	R4
-      0x7812000D,  //  000D  JMPF	R4	#001C
-      0x58100004,  //  000E  LDCONST	R4	K4
-      0x6014000C,  //  000F  GETGBL	R5	G12
-      0x88180105,  //  0010  GETMBR	R6	R0	K5
-      0x7C140200,  //  0011  CALL	R5	1
-      0x14140805,  //  0012  LT	R5	R4	R5
-      0x78160006,  //  0013  JMPF	R5	#001B
-      0x88140105,  //  0014  GETMBR	R5	R0	K5
-      0x94140A04,  //  0015  GETIDX	R5	R5	R4
-      0x8C140B06,  //  0016  GETMET	R5	R5	K6
-      0x5C1C0600,  //  0017  MOVE	R7	R3
-      0x7C140400,  //  0018  CALL	R5	2
-      0x00100907,  //  0019  ADD	R4	R4	K7
-      0x7001FFF3,  //  001A  JMP		#000F
-      0x70020007,  //  001B  JMP		#0024
-      0xB8120200,  //  001C  GETNGBL	R4	K1
-      0x8C100908,  //  001D  GETMET	R4	R4	K8
-      0x60180008,  //  001E  GETGBL	R6	G8
-      0x5C1C0400,  //  001F  MOVE	R7	R2
-      0x7C180200,  //  0020  CALL	R6	1
-      0x001A1206,  //  0021  ADD	R6	K9	R6
-      0x581C000A,  //  0022  LDCONST	R7	K10
-      0x7C100600,  //  0023  CALL	R4	3
-      0x80000000,  //  0024  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_operational_discovery
-********************************************************************/
-be_local_closure(Matter_Device_start_operational_discovery,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
+    6,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(mdns),
-    /* K2   */  be_nested_str_weak(string),
-    /* K3   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K4   */  be_nested_str_weak(root_w0),
-    /* K5   */  be_nested_str_weak(root_L),
-    /* K6   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K7   */  be_nested_str_weak(mdns_announce_op_discovery),
-    /* K8   */  be_nested_str_weak(get_fabric),
-    }),
-    be_str_weak(start_operational_discovery),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA4120400,  //  0002  IMPORT	R4	K2
-      0x8C140103,  //  0003  GETMET	R5	R0	K3
-      0x7C140200,  //  0004  CALL	R5	1
-      0x4C140000,  //  0005  LDNIL	R5
-      0x90020805,  //  0006  SETMBR	R0	K4	R5
-      0x4C140000,  //  0007  LDNIL	R5
-      0x90020A05,  //  0008  SETMBR	R0	K5	R5
-      0x8C140306,  //  0009  GETMET	R5	R1	K6
-      0x541E003B,  //  000A  LDINT	R7	60
-      0x7C140400,  //  000B  CALL	R5	2
-      0x8C140107,  //  000C  GETMET	R5	R0	K7
-      0x8C1C0308,  //  000D  GETMET	R7	R1	K8
-      0x7C1C0200,  //  000E  CALL	R7	1
-      0x7C140400,  //  000F  CALL	R5	2
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: compute_manual_pairing_code
-********************************************************************/
-be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(root_discriminator),
-    /* K2   */  be_nested_str_weak(root_passcode),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(_X251i_X2505i_X2504i),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(Verhoeff),
-    /* K7   */  be_nested_str_weak(checksum),
-    }),
-    be_str_weak(compute_manual_pairing_code),
-    &be_const_str_solidified,
-    ( &(const binstruction[31]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x540E0FFE,  //  0002  LDINT	R3	4095
-      0x2C080403,  //  0003  AND	R2	R2	R3
-      0x540E0009,  //  0004  LDINT	R3	10
-      0x3C080403,  //  0005  SHR	R2	R2	R3
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x541202FF,  //  0007  LDINT	R4	768
-      0x2C0C0604,  //  0008  AND	R3	R3	R4
-      0x54120005,  //  0009  LDINT	R4	6
-      0x380C0604,  //  000A  SHL	R3	R3	R4
-      0x88100102,  //  000B  GETMBR	R4	R0	K2
-      0x54163FFE,  //  000C  LDINT	R5	16383
-      0x2C100805,  //  000D  AND	R4	R4	R5
-      0x300C0604,  //  000E  OR	R3	R3	R4
-      0x88100102,  //  000F  GETMBR	R4	R0	K2
-      0x5416000D,  //  0010  LDINT	R5	14
-      0x3C100805,  //  0011  SHR	R4	R4	R5
-      0x8C140303,  //  0012  GETMET	R5	R1	K3
-      0x581C0004,  //  0013  LDCONST	R7	K4
-      0x5C200400,  //  0014  MOVE	R8	R2
-      0x5C240600,  //  0015  MOVE	R9	R3
-      0x5C280800,  //  0016  MOVE	R10	R4
-      0x7C140A00,  //  0017  CALL	R5	5
-      0xB81A0A00,  //  0018  GETNGBL	R6	K5
-      0x88180D06,  //  0019  GETMBR	R6	R6	K6
-      0x8C180D07,  //  001A  GETMET	R6	R6	K7
-      0x5C200A00,  //  001B  MOVE	R8	R5
-      0x7C180400,  //  001C  CALL	R6	2
-      0x00140A06,  //  001D  ADD	R5	R5	R6
-      0x80040A00,  //  001E  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _compute_pbkdf
-********************************************************************/
-be_local_closure(Matter_Device__compute_pbkdf,   /* name */
-  be_nested_proto(
-    20,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(add),
-    /* K3   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
-    /* K4   */  be_nested_str_weak(derive),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(root_w0),
-    /* K7   */  be_nested_str_weak(EC_P256),
-    /* K8   */  be_nested_str_weak(mod),
-    /* K9   */  be_nested_str_weak(root_L),
-    /* K10  */  be_nested_str_weak(public_key),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20salt_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K15  */  be_nested_str_weak(root_salt),
-    /* K16  */  be_nested_str_weak(tohex),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20passcode_hex_X20_X20_X3D_X20),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20w0_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20L_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K20  */  be_nested_str_weak(compute_manual_pairing_code),
-    /* K21  */  be_nested_str_weak(format),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s_X2D_X25s_X2D_X25s),
-    /* K23  */  be_const_int(3),
-    /* K24  */  be_const_int(2147483647),
-    /* K25  */  be_const_int(2),
-    }),
-    be_str_weak(_compute_pbkdf),
-    &be_const_str_solidified,
-    ( &(const binstruction[100]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0xA4160200,  //  0001  IMPORT	R5	K1
-      0x60180015,  //  0002  GETGBL	R6	G21
-      0x7C180000,  //  0003  CALL	R6	0
-      0x8C180D02,  //  0004  GETMET	R6	R6	K2
-      0x5C200200,  //  0005  MOVE	R8	R1
-      0x54260003,  //  0006  LDINT	R9	4
-      0x7C180600,  //  0007  CALL	R6	3
-      0x8C1C0903,  //  0008  GETMET	R7	R4	K3
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x8C1C0F04,  //  000A  GETMET	R7	R7	K4
-      0x5C240C00,  //  000B  MOVE	R9	R6
-      0x5C280600,  //  000C  MOVE	R10	R3
-      0x5C2C0400,  //  000D  MOVE	R11	R2
-      0x5432004F,  //  000E  LDINT	R12	80
-      0x7C1C0A00,  //  000F  CALL	R7	5
-      0x54220026,  //  0010  LDINT	R8	39
-      0x40220A08,  //  0011  CONNECT	R8	K5	R8
-      0x94200E08,  //  0012  GETIDX	R8	R7	R8
-      0x54260027,  //  0013  LDINT	R9	40
-      0x542A004E,  //  0014  LDINT	R10	79
-      0x4024120A,  //  0015  CONNECT	R9	R9	R10
-      0x94240E09,  //  0016  GETIDX	R9	R7	R9
-      0x8C280907,  //  0017  GETMET	R10	R4	K7
-      0x7C280200,  //  0018  CALL	R10	1
-      0x8C281508,  //  0019  GETMET	R10	R10	K8
-      0x5C301000,  //  001A  MOVE	R12	R8
-      0x7C280400,  //  001B  CALL	R10	2
-      0x90020C0A,  //  001C  SETMBR	R0	K6	R10
-      0x8C280907,  //  001D  GETMET	R10	R4	K7
-      0x7C280200,  //  001E  CALL	R10	1
-      0x8C281508,  //  001F  GETMET	R10	R10	K8
-      0x5C301200,  //  0020  MOVE	R12	R9
-      0x7C280400,  //  0021  CALL	R10	2
-      0x8C2C0907,  //  0022  GETMET	R11	R4	K7
-      0x7C2C0200,  //  0023  CALL	R11	1
-      0x8C2C170A,  //  0024  GETMET	R11	R11	K10
-      0x5C341400,  //  0025  MOVE	R13	R10
-      0x7C2C0400,  //  0026  CALL	R11	2
-      0x9002120B,  //  0027  SETMBR	R0	K9	R11
-      0xB82E1600,  //  0028  GETNGBL	R11	K11
-      0x8C2C170C,  //  0029  GETMET	R11	R11	K12
-      0x5834000D,  //  002A  LDCONST	R13	K13
-      0x543A0003,  //  002B  LDINT	R14	4
-      0x7C2C0600,  //  002C  CALL	R11	3
-      0xB82E1600,  //  002D  GETNGBL	R11	K11
-      0x8C2C170C,  //  002E  GETMET	R11	R11	K12
-      0x8834010F,  //  002F  GETMBR	R13	R0	K15
-      0x8C341B10,  //  0030  GETMET	R13	R13	K16
-      0x7C340200,  //  0031  CALL	R13	1
-      0x00361C0D,  //  0032  ADD	R13	K14	R13
-      0x543A0003,  //  0033  LDINT	R14	4
-      0x7C2C0600,  //  0034  CALL	R11	3
-      0xB82E1600,  //  0035  GETNGBL	R11	K11
-      0x8C2C170C,  //  0036  GETMET	R11	R11	K12
-      0x8C340D10,  //  0037  GETMET	R13	R6	K16
-      0x7C340200,  //  0038  CALL	R13	1
-      0x0036220D,  //  0039  ADD	R13	K17	R13
-      0x543A0003,  //  003A  LDINT	R14	4
-      0x7C2C0600,  //  003B  CALL	R11	3
-      0xB82E1600,  //  003C  GETNGBL	R11	K11
-      0x8C2C170C,  //  003D  GETMET	R11	R11	K12
-      0x88340106,  //  003E  GETMBR	R13	R0	K6
-      0x8C341B10,  //  003F  GETMET	R13	R13	K16
-      0x7C340200,  //  0040  CALL	R13	1
-      0x0036240D,  //  0041  ADD	R13	K18	R13
-      0x543A0003,  //  0042  LDINT	R14	4
-      0x7C2C0600,  //  0043  CALL	R11	3
-      0xB82E1600,  //  0044  GETNGBL	R11	K11
-      0x8C2C170C,  //  0045  GETMET	R11	R11	K12
-      0x88340109,  //  0046  GETMBR	R13	R0	K9
-      0x8C341B10,  //  0047  GETMET	R13	R13	K16
-      0x7C340200,  //  0048  CALL	R13	1
-      0x0036260D,  //  0049  ADD	R13	K19	R13
-      0x543A0003,  //  004A  LDINT	R14	4
-      0x7C2C0600,  //  004B  CALL	R11	3
-      0xB82E1600,  //  004C  GETNGBL	R11	K11
-      0x8C2C170C,  //  004D  GETMET	R11	R11	K12
-      0x5834000D,  //  004E  LDCONST	R13	K13
-      0x543A0003,  //  004F  LDINT	R14	4
-      0x7C2C0600,  //  0050  CALL	R11	3
-      0x8C2C0114,  //  0051  GETMET	R11	R0	K20
-      0x7C2C0200,  //  0052  CALL	R11	1
-      0xB8321600,  //  0053  GETNGBL	R12	K11
-      0x8C30190C,  //  0054  GETMET	R12	R12	K12
-      0x8C380B15,  //  0055  GETMET	R14	R5	K21
-      0x58400016,  //  0056  LDCONST	R16	K22
-      0x40460B17,  //  0057  CONNECT	R17	K5	K23
-      0x94441611,  //  0058  GETIDX	R17	R11	R17
-      0x544A0003,  //  0059  LDINT	R18	4
-      0x544E0005,  //  005A  LDINT	R19	6
-      0x40482413,  //  005B  CONNECT	R18	R18	R19
-      0x94481612,  //  005C  GETIDX	R18	R11	R18
-      0x544E0006,  //  005D  LDINT	R19	7
-      0x404C2718,  //  005E  CONNECT	R19	R19	K24
-      0x944C1613,  //  005F  GETIDX	R19	R11	R19
-      0x7C380A00,  //  0060  CALL	R14	5
-      0x583C0019,  //  0061  LDCONST	R15	K25
-      0x7C300600,  //  0062  CALL	R12	3
-      0x80000000,  //  0063  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_announce_PASE
-********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_PASE,   /* name */
-  be_nested_proto(
-    16,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[44]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(crypto),
-    /* K3   */  be_nested_str_weak(VP),
-    /* K4   */  be_nested_str_weak(vendorid),
-    /* K5   */  be_nested_str_weak(_X2B),
-    /* K6   */  be_nested_str_weak(productid),
-    /* K7   */  be_nested_str_weak(D),
-    /* K8   */  be_nested_str_weak(commissioning_discriminator),
-    /* K9   */  be_nested_str_weak(CM),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_nested_str_weak(T),
-    /* K12  */  be_const_int(0),
-    /* K13  */  be_nested_str_weak(SII),
-    /* K14  */  be_nested_str_weak(SAI),
-    /* K15  */  be_nested_str_weak(commissioning_instance_wifi),
-    /* K16  */  be_nested_str_weak(random),
-    /* K17  */  be_nested_str_weak(tohex),
-    /* K18  */  be_nested_str_weak(commissioning_instance_eth),
-    /* K19  */  be_nested_str_weak(hostname_eth),
-    /* K20  */  be_nested_str_weak(tasmota),
-    /* K21  */  be_nested_str_weak(log),
-    /* K22  */  be_nested_str_weak(format),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eadd_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25i_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
-    /* K24  */  be_nested_str_weak(_matterc),
-    /* K25  */  be_nested_str_weak(_udp),
-    /* K26  */  be_const_int(3),
-    /* K27  */  be_nested_str_weak(add_service),
-    /* K28  */  be_nested_str_weak(mdns_pase_eth),
-    /* K29  */  be_nested_str_weak(MTR_X3A_X20announce_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K30  */  be_nested_str_weak(eth),
-    /* K31  */  be_const_int(2),
-    /* K32  */  be_nested_str_weak(_L),
-    /* K33  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
-    /* K34  */  be_nested_str_weak(add_subtype),
-    /* K35  */  be_nested_str_weak(_S),
-    /* K36  */  be_nested_str_weak(_V),
-    /* K37  */  be_nested_str_weak(_CM1),
-    /* K38  */  be_nested_str_weak(hostname_wifi),
-    /* K39  */  be_nested_str_weak(mdns_pase_wifi),
-    /* K40  */  be_nested_str_weak(MTR_X3A_X20starting_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K41  */  be_nested_str_weak(wifi),
-    /* K42  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K43  */  be_nested_str_weak(_X7C),
-    }),
-    be_str_weak(mdns_announce_PASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[267]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xA40E0400,  //  0002  IMPORT	R3	K2
-      0x60100013,  //  0003  GETGBL	R4	G19
-      0x7C100000,  //  0004  CALL	R4	0
-      0x60140008,  //  0005  GETGBL	R5	G8
-      0x88180104,  //  0006  GETMBR	R6	R0	K4
-      0x7C140200,  //  0007  CALL	R5	1
-      0x00140B05,  //  0008  ADD	R5	R5	K5
-      0x60180008,  //  0009  GETGBL	R6	G8
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x7C180200,  //  000B  CALL	R6	1
-      0x00140A06,  //  000C  ADD	R5	R5	R6
-      0x98120605,  //  000D  SETIDX	R4	K3	R5
-      0x88140108,  //  000E  GETMBR	R5	R0	K8
-      0x98120E05,  //  000F  SETIDX	R4	K7	R5
-      0x9812130A,  //  0010  SETIDX	R4	K9	K10
-      0x9812170C,  //  0011  SETIDX	R4	K11	K12
-      0x54161387,  //  0012  LDINT	R5	5000
-      0x98121A05,  //  0013  SETIDX	R4	K13	R5
-      0x5416012B,  //  0014  LDINT	R5	300
-      0x98121C05,  //  0015  SETIDX	R4	K14	R5
-      0x8C140710,  //  0016  GETMET	R5	R3	K16
-      0x541E0007,  //  0017  LDINT	R7	8
-      0x7C140400,  //  0018  CALL	R5	2
-      0x8C140B11,  //  0019  GETMET	R5	R5	K17
-      0x7C140200,  //  001A  CALL	R5	1
-      0x90021E05,  //  001B  SETMBR	R0	K15	R5
-      0x8C140710,  //  001C  GETMET	R5	R3	K16
-      0x541E0007,  //  001D  LDINT	R7	8
-      0x7C140400,  //  001E  CALL	R5	2
-      0x8C140B11,  //  001F  GETMET	R5	R5	K17
-      0x7C140200,  //  0020  CALL	R5	1
-      0x90022405,  //  0021  SETMBR	R0	K18	R5
-      0xA80200D5,  //  0022  EXBLK	0	#00F9
-      0x88140113,  //  0023  GETMBR	R5	R0	K19
-      0x78160067,  //  0024  JMPF	R5	#008D
-      0xB8162800,  //  0025  GETNGBL	R5	K20
-      0x8C140B15,  //  0026  GETMET	R5	R5	K21
-      0x8C1C0516,  //  0027  GETMET	R7	R2	K22
-      0x58240017,  //  0028  LDCONST	R9	K23
-      0x58280018,  //  0029  LDCONST	R10	K24
-      0x582C0019,  //  002A  LDCONST	R11	K25
-      0x543215A3,  //  002B  LDINT	R12	5540
-      0x60340008,  //  002C  GETGBL	R13	G8
-      0x5C380800,  //  002D  MOVE	R14	R4
-      0x7C340200,  //  002E  CALL	R13	1
-      0x88380112,  //  002F  GETMBR	R14	R0	K18
-      0x883C0113,  //  0030  GETMBR	R15	R0	K19
-      0x7C1C1000,  //  0031  CALL	R7	8
-      0x5820001A,  //  0032  LDCONST	R8	K26
-      0x7C140600,  //  0033  CALL	R5	3
-      0x8C14031B,  //  0034  GETMET	R5	R1	K27
-      0x581C0018,  //  0035  LDCONST	R7	K24
-      0x58200019,  //  0036  LDCONST	R8	K25
-      0x542615A3,  //  0037  LDINT	R9	5540
-      0x5C280800,  //  0038  MOVE	R10	R4
-      0x882C0112,  //  0039  GETMBR	R11	R0	K18
-      0x88300113,  //  003A  GETMBR	R12	R0	K19
-      0x7C140E00,  //  003B  CALL	R5	7
-      0x50140200,  //  003C  LDBOOL	R5	1	0
-      0x90023805,  //  003D  SETMBR	R0	K28	R5
-      0xB8162800,  //  003E  GETNGBL	R5	K20
-      0x8C140B15,  //  003F  GETMET	R5	R5	K21
-      0x8C1C0516,  //  0040  GETMET	R7	R2	K22
-      0x5824001D,  //  0041  LDCONST	R9	K29
-      0x5828001E,  //  0042  LDCONST	R10	K30
-      0x882C0112,  //  0043  GETMBR	R11	R0	K18
-      0x88300113,  //  0044  GETMBR	R12	R0	K19
-      0x7C1C0A00,  //  0045  CALL	R7	5
-      0x5820001F,  //  0046  LDCONST	R8	K31
-      0x7C140600,  //  0047  CALL	R5	3
-      0x60140008,  //  0048  GETGBL	R5	G8
-      0x88180108,  //  0049  GETMBR	R6	R0	K8
-      0x541E0FFE,  //  004A  LDINT	R7	4095
-      0x2C180C07,  //  004B  AND	R6	R6	R7
-      0x7C140200,  //  004C  CALL	R5	1
-      0x00164005,  //  004D  ADD	R5	K32	R5
-      0xB81A2800,  //  004E  GETNGBL	R6	K20
-      0x8C180D15,  //  004F  GETMET	R6	R6	K21
-      0x00224205,  //  0050  ADD	R8	K33	R5
-      0x5824001F,  //  0051  LDCONST	R9	K31
-      0x7C180600,  //  0052  CALL	R6	3
-      0x8C180322,  //  0053  GETMET	R6	R1	K34
-      0x58200018,  //  0054  LDCONST	R8	K24
-      0x58240019,  //  0055  LDCONST	R9	K25
-      0x88280112,  //  0056  GETMBR	R10	R0	K18
-      0x882C0113,  //  0057  GETMBR	R11	R0	K19
-      0x5C300A00,  //  0058  MOVE	R12	R5
-      0x7C180C00,  //  0059  CALL	R6	6
-      0x60180008,  //  005A  GETGBL	R6	G8
-      0x881C0108,  //  005B  GETMBR	R7	R0	K8
-      0x54220EFF,  //  005C  LDINT	R8	3840
-      0x2C1C0E08,  //  005D  AND	R7	R7	R8
-      0x54220007,  //  005E  LDINT	R8	8
-      0x3C1C0E08,  //  005F  SHR	R7	R7	R8
-      0x7C180200,  //  0060  CALL	R6	1
-      0x001A4606,  //  0061  ADD	R6	K35	R6
-      0x5C140C00,  //  0062  MOVE	R5	R6
-      0xB81A2800,  //  0063  GETNGBL	R6	K20
-      0x8C180D15,  //  0064  GETMET	R6	R6	K21
-      0x00224205,  //  0065  ADD	R8	K33	R5
-      0x5824001F,  //  0066  LDCONST	R9	K31
-      0x7C180600,  //  0067  CALL	R6	3
-      0x8C180322,  //  0068  GETMET	R6	R1	K34
-      0x58200018,  //  0069  LDCONST	R8	K24
-      0x58240019,  //  006A  LDCONST	R9	K25
-      0x88280112,  //  006B  GETMBR	R10	R0	K18
-      0x882C0113,  //  006C  GETMBR	R11	R0	K19
-      0x5C300A00,  //  006D  MOVE	R12	R5
-      0x7C180C00,  //  006E  CALL	R6	6
-      0x60180008,  //  006F  GETGBL	R6	G8
-      0x881C0104,  //  0070  GETMBR	R7	R0	K4
-      0x7C180200,  //  0071  CALL	R6	1
-      0x001A4806,  //  0072  ADD	R6	K36	R6
-      0x5C140C00,  //  0073  MOVE	R5	R6
-      0xB81A2800,  //  0074  GETNGBL	R6	K20
-      0x8C180D15,  //  0075  GETMET	R6	R6	K21
-      0x00224205,  //  0076  ADD	R8	K33	R5
-      0x5824001F,  //  0077  LDCONST	R9	K31
-      0x7C180600,  //  0078  CALL	R6	3
-      0x8C180322,  //  0079  GETMET	R6	R1	K34
-      0x58200018,  //  007A  LDCONST	R8	K24
-      0x58240019,  //  007B  LDCONST	R9	K25
-      0x88280112,  //  007C  GETMBR	R10	R0	K18
-      0x882C0113,  //  007D  GETMBR	R11	R0	K19
-      0x5C300A00,  //  007E  MOVE	R12	R5
-      0x7C180C00,  //  007F  CALL	R6	6
-      0x58140025,  //  0080  LDCONST	R5	K37
-      0xB81A2800,  //  0081  GETNGBL	R6	K20
-      0x8C180D15,  //  0082  GETMET	R6	R6	K21
-      0x00224205,  //  0083  ADD	R8	K33	R5
-      0x5824001F,  //  0084  LDCONST	R9	K31
-      0x7C180600,  //  0085  CALL	R6	3
-      0x8C180322,  //  0086  GETMET	R6	R1	K34
-      0x58200018,  //  0087  LDCONST	R8	K24
-      0x58240019,  //  0088  LDCONST	R9	K25
-      0x88280112,  //  0089  GETMBR	R10	R0	K18
-      0x882C0113,  //  008A  GETMBR	R11	R0	K19
-      0x5C300A00,  //  008B  MOVE	R12	R5
-      0x7C180C00,  //  008C  CALL	R6	6
-      0x88140126,  //  008D  GETMBR	R5	R0	K38
-      0x78160067,  //  008E  JMPF	R5	#00F7
-      0xB8162800,  //  008F  GETNGBL	R5	K20
-      0x8C140B15,  //  0090  GETMET	R5	R5	K21
-      0x8C1C0516,  //  0091  GETMET	R7	R2	K22
-      0x58240017,  //  0092  LDCONST	R9	K23
-      0x58280018,  //  0093  LDCONST	R10	K24
-      0x582C0019,  //  0094  LDCONST	R11	K25
-      0x543215A3,  //  0095  LDINT	R12	5540
-      0x60340008,  //  0096  GETGBL	R13	G8
-      0x5C380800,  //  0097  MOVE	R14	R4
-      0x7C340200,  //  0098  CALL	R13	1
-      0x8838010F,  //  0099  GETMBR	R14	R0	K15
-      0x883C0126,  //  009A  GETMBR	R15	R0	K38
-      0x7C1C1000,  //  009B  CALL	R7	8
-      0x5820001A,  //  009C  LDCONST	R8	K26
-      0x7C140600,  //  009D  CALL	R5	3
-      0x8C14031B,  //  009E  GETMET	R5	R1	K27
-      0x581C0018,  //  009F  LDCONST	R7	K24
-      0x58200019,  //  00A0  LDCONST	R8	K25
-      0x542615A3,  //  00A1  LDINT	R9	5540
-      0x5C280800,  //  00A2  MOVE	R10	R4
-      0x882C010F,  //  00A3  GETMBR	R11	R0	K15
-      0x88300126,  //  00A4  GETMBR	R12	R0	K38
-      0x7C140E00,  //  00A5  CALL	R5	7
-      0x50140200,  //  00A6  LDBOOL	R5	1	0
-      0x90024E05,  //  00A7  SETMBR	R0	K39	R5
-      0xB8162800,  //  00A8  GETNGBL	R5	K20
-      0x8C140B15,  //  00A9  GETMET	R5	R5	K21
-      0x8C1C0516,  //  00AA  GETMET	R7	R2	K22
-      0x58240028,  //  00AB  LDCONST	R9	K40
-      0x58280029,  //  00AC  LDCONST	R10	K41
-      0x882C010F,  //  00AD  GETMBR	R11	R0	K15
-      0x88300126,  //  00AE  GETMBR	R12	R0	K38
-      0x7C1C0A00,  //  00AF  CALL	R7	5
-      0x5820001F,  //  00B0  LDCONST	R8	K31
-      0x7C140600,  //  00B1  CALL	R5	3
-      0x60140008,  //  00B2  GETGBL	R5	G8
-      0x88180108,  //  00B3  GETMBR	R6	R0	K8
-      0x541E0FFE,  //  00B4  LDINT	R7	4095
-      0x2C180C07,  //  00B5  AND	R6	R6	R7
-      0x7C140200,  //  00B6  CALL	R5	1
-      0x00164005,  //  00B7  ADD	R5	K32	R5
-      0xB81A2800,  //  00B8  GETNGBL	R6	K20
-      0x8C180D15,  //  00B9  GETMET	R6	R6	K21
-      0x00224205,  //  00BA  ADD	R8	K33	R5
-      0x5824001F,  //  00BB  LDCONST	R9	K31
-      0x7C180600,  //  00BC  CALL	R6	3
-      0x8C180322,  //  00BD  GETMET	R6	R1	K34
-      0x58200018,  //  00BE  LDCONST	R8	K24
-      0x58240019,  //  00BF  LDCONST	R9	K25
-      0x8828010F,  //  00C0  GETMBR	R10	R0	K15
-      0x882C0126,  //  00C1  GETMBR	R11	R0	K38
-      0x5C300A00,  //  00C2  MOVE	R12	R5
-      0x7C180C00,  //  00C3  CALL	R6	6
-      0x60180008,  //  00C4  GETGBL	R6	G8
-      0x881C0108,  //  00C5  GETMBR	R7	R0	K8
-      0x54220EFF,  //  00C6  LDINT	R8	3840
-      0x2C1C0E08,  //  00C7  AND	R7	R7	R8
-      0x54220007,  //  00C8  LDINT	R8	8
-      0x3C1C0E08,  //  00C9  SHR	R7	R7	R8
-      0x7C180200,  //  00CA  CALL	R6	1
-      0x001A4606,  //  00CB  ADD	R6	K35	R6
-      0x5C140C00,  //  00CC  MOVE	R5	R6
-      0xB81A2800,  //  00CD  GETNGBL	R6	K20
-      0x8C180D15,  //  00CE  GETMET	R6	R6	K21
-      0x00224205,  //  00CF  ADD	R8	K33	R5
-      0x5824001F,  //  00D0  LDCONST	R9	K31
-      0x7C180600,  //  00D1  CALL	R6	3
-      0x8C180322,  //  00D2  GETMET	R6	R1	K34
-      0x58200018,  //  00D3  LDCONST	R8	K24
-      0x58240019,  //  00D4  LDCONST	R9	K25
-      0x8828010F,  //  00D5  GETMBR	R10	R0	K15
-      0x882C0126,  //  00D6  GETMBR	R11	R0	K38
-      0x5C300A00,  //  00D7  MOVE	R12	R5
-      0x7C180C00,  //  00D8  CALL	R6	6
-      0x60180008,  //  00D9  GETGBL	R6	G8
-      0x881C0104,  //  00DA  GETMBR	R7	R0	K4
-      0x7C180200,  //  00DB  CALL	R6	1
-      0x001A4806,  //  00DC  ADD	R6	K36	R6
-      0x5C140C00,  //  00DD  MOVE	R5	R6
-      0xB81A2800,  //  00DE  GETNGBL	R6	K20
-      0x8C180D15,  //  00DF  GETMET	R6	R6	K21
-      0x00224205,  //  00E0  ADD	R8	K33	R5
-      0x5824001F,  //  00E1  LDCONST	R9	K31
-      0x7C180600,  //  00E2  CALL	R6	3
-      0x8C180322,  //  00E3  GETMET	R6	R1	K34
-      0x58200018,  //  00E4  LDCONST	R8	K24
-      0x58240019,  //  00E5  LDCONST	R9	K25
-      0x8828010F,  //  00E6  GETMBR	R10	R0	K15
-      0x882C0126,  //  00E7  GETMBR	R11	R0	K38
-      0x5C300A00,  //  00E8  MOVE	R12	R5
-      0x7C180C00,  //  00E9  CALL	R6	6
-      0x58140025,  //  00EA  LDCONST	R5	K37
-      0xB81A2800,  //  00EB  GETNGBL	R6	K20
-      0x8C180D15,  //  00EC  GETMET	R6	R6	K21
-      0x00224205,  //  00ED  ADD	R8	K33	R5
-      0x5824001F,  //  00EE  LDCONST	R9	K31
-      0x7C180600,  //  00EF  CALL	R6	3
-      0x8C180322,  //  00F0  GETMET	R6	R1	K34
-      0x58200018,  //  00F1  LDCONST	R8	K24
-      0x58240019,  //  00F2  LDCONST	R9	K25
-      0x8828010F,  //  00F3  GETMBR	R10	R0	K15
-      0x882C0126,  //  00F4  GETMBR	R11	R0	K38
-      0x5C300A00,  //  00F5  MOVE	R12	R5
-      0x7C180C00,  //  00F6  CALL	R6	6
-      0xA8040001,  //  00F7  EXBLK	1	1
-      0x70020010,  //  00F8  JMP		#010A
-      0xAC140002,  //  00F9  CATCH	R5	0	2
-      0x7002000D,  //  00FA  JMP		#0109
-      0xB81E2800,  //  00FB  GETNGBL	R7	K20
-      0x8C1C0F15,  //  00FC  GETMET	R7	R7	K21
-      0x60240008,  //  00FD  GETGBL	R9	G8
-      0x5C280A00,  //  00FE  MOVE	R10	R5
-      0x7C240200,  //  00FF  CALL	R9	1
-      0x00265409,  //  0100  ADD	R9	K42	R9
-      0x0024132B,  //  0101  ADD	R9	R9	K43
-      0x60280008,  //  0102  GETGBL	R10	G8
-      0x5C2C0C00,  //  0103  MOVE	R11	R6
-      0x7C280200,  //  0104  CALL	R10	1
-      0x0024120A,  //  0105  ADD	R9	R9	R10
-      0x5828001F,  //  0106  LDCONST	R10	K31
-      0x7C1C0600,  //  0107  CALL	R7	3
-      0x70020000,  //  0108  JMP		#010A
-      0xB0080000,  //  0109  RAISE	2	R0	R0
-      0x80000000,  //  010A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_param
-********************************************************************/
-be_local_closure(Matter_Device_save_param,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(dump),
-    /* K2   */  be_nested_str_weak(distinguish),
-    /* K3   */  be_nested_str_weak(root_discriminator),
-    /* K4   */  be_nested_str_weak(passcode),
-    /* K5   */  be_nested_str_weak(root_passcode),
-    /* K6   */  be_nested_str_weak(ipv4only),
-    /* K7   */  be_nested_str_weak(string),
-    /* K8   */  be_nested_str_weak(FILENAME),
-    /* K9   */  be_nested_str_weak(w),
-    /* K10  */  be_nested_str_weak(write),
-    /* K11  */  be_nested_str_weak(close),
-    /* K12  */  be_nested_str_weak(tasmota),
-    /* K13  */  be_nested_str_weak(log),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K15  */  be_nested_str_weak(_X7C),
-    /* K16  */  be_const_int(2),
-    }),
-    be_str_weak(save_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x60100013,  //  0002  GETGBL	R4	G19
-      0x7C100000,  //  0003  CALL	R4	0
-      0x88140103,  //  0004  GETMBR	R5	R0	K3
-      0x98120405,  //  0005  SETIDX	R4	K2	R5
-      0x88140105,  //  0006  GETMBR	R5	R0	K5
-      0x98120805,  //  0007  SETIDX	R4	K4	R5
-      0x88140106,  //  0008  GETMBR	R5	R0	K6
-      0x98120C05,  //  0009  SETIDX	R4	K6	R5
-      0x7C080400,  //  000A  CALL	R2	2
-      0xA802000D,  //  000B  EXBLK	0	#001A
-      0xA40E0E00,  //  000C  IMPORT	R3	K7
-      0x60100011,  //  000D  GETGBL	R4	G17
-      0x88140108,  //  000E  GETMBR	R5	R0	K8
-      0x58180009,  //  000F  LDCONST	R6	K9
-      0x7C100400,  //  0010  CALL	R4	2
-      0x8C14090A,  //  0011  GETMET	R5	R4	K10
-      0x5C1C0400,  //  0012  MOVE	R7	R2
-      0x7C140400,  //  0013  CALL	R5	2
-      0x8C14090B,  //  0014  GETMET	R5	R4	K11
-      0x7C140200,  //  0015  CALL	R5	1
-      0xA8040001,  //  0016  EXBLK	1	1
-      0x80040400,  //  0017  RET	1	R2
-      0xA8040001,  //  0018  EXBLK	1	1
-      0x70020011,  //  0019  JMP		#002C
-      0xAC0C0002,  //  001A  CATCH	R3	0	2
-      0x7002000E,  //  001B  JMP		#002B
-      0xB8161800,  //  001C  GETNGBL	R5	K12
-      0x8C140B0D,  //  001D  GETMET	R5	R5	K13
-      0x601C0008,  //  001E  GETGBL	R7	G8
-      0x5C200600,  //  001F  MOVE	R8	R3
-      0x7C1C0200,  //  0020  CALL	R7	1
-      0x001E1C07,  //  0021  ADD	R7	K14	R7
-      0x001C0F0F,  //  0022  ADD	R7	R7	K15
-      0x60200008,  //  0023  GETGBL	R8	G8
-      0x5C240800,  //  0024  MOVE	R9	R4
-      0x7C200200,  //  0025  CALL	R8	1
-      0x001C0E08,  //  0026  ADD	R7	R7	R8
-      0x58200010,  //  0027  LDCONST	R8	K16
-      0x7C140600,  //  0028  CALL	R5	3
-      0x80040400,  //  0029  RET	1	R2
-      0x70020000,  //  002A  JMP		#002C
-      0xB0080000,  //  002B  RAISE	2	R0	R0
-      0x80000000,  //  002C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: msg_send
-********************************************************************/
-be_local_closure(Matter_Device_msg_send,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    6,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(send_response),
-    }),
-    be_str_weak(msg_send),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x88180100,  //  0000  GETMBR	R6	R0	K0
-      0x8C180D01,  //  0001  GETMET	R6	R6	K1
-      0x5C200200,  //  0002  MOVE	R8	R1
-      0x5C240400,  //  0003  MOVE	R9	R2
-      0x5C280600,  //  0004  MOVE	R10	R3
-      0x5C2C0800,  //  0005  MOVE	R11	R4
-      0x5C300A00,  //  0006  MOVE	R12	R5
-      0x7C180C00,  //  0007  CALL	R6	6
-      0x80040C00,  //  0008  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Device_init,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 3]) {
+    ( &(const struct bproto*[ 1]) {
       be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
+        8,                          /* nstack */
+        3,                          /* argc */
         0,                          /* varg */
         1,                          /* has upvals */
         ( &(const bupvaldesc[ 1]) {  /* upvals */
@@ -1923,248 +718,144 @@ be_local_closure(Matter_Device_init,   /* name */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_trigger_read_sensors),
+        /* K0   */  be_nested_str_weak(msg_received),
         }),
-        be_str_weak(_anonymous_),
+        be_str_weak(_X3Clambda_X3E),
         &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80000000,  //  0003  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 6]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_start_udp),
-        /* K1   */  be_nested_str_weak(UDP_PORT),
-        /* K2   */  be_nested_str_weak(tasmota),
-        /* K3   */  be_nested_str_weak(remove_rule),
-        /* K4   */  be_nested_str_weak(Wifi_X23Connected),
-        /* K5   */  be_nested_str_weak(matter_device_udp),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[11]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080000,  //  0002  GETUPV	R2	U0
-          0x88080501,  //  0003  GETMBR	R2	R2	K1
-          0x7C000400,  //  0004  CALL	R0	2
-          0xB8020400,  //  0005  GETNGBL	R0	K2
-          0x8C000103,  //  0006  GETMET	R0	R0	K3
-          0x58080004,  //  0007  LDCONST	R2	K4
-          0x580C0005,  //  0008  LDCONST	R3	K5
-          0x7C000600,  //  0009  CALL	R0	3
-          0x80000000,  //  000A  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 6]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_start_udp),
-        /* K1   */  be_nested_str_weak(UDP_PORT),
-        /* K2   */  be_nested_str_weak(tasmota),
-        /* K3   */  be_nested_str_weak(remove_rule),
-        /* K4   */  be_nested_str_weak(Eth_X23Connected),
-        /* K5   */  be_nested_str_weak(matter_device_udp),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[11]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080000,  //  0002  GETUPV	R2	U0
-          0x88080501,  //  0003  GETMBR	R2	R2	K1
-          0x7C000400,  //  0004  CALL	R0	2
-          0xB8020400,  //  0005  GETNGBL	R0	K2
-          0x8C000103,  //  0006  GETMET	R0	R0	K3
-          0x58080004,  //  0007  LDCONST	R2	K4
-          0x580C0005,  //  0008  LDCONST	R3	K5
-          0x7C000600,  //  0009  CALL	R0	3
-          0x80000000,  //  000A  RET	0
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
         })
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[44]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(get_option),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(MATTER_OPTION),
-    /* K6   */  be_nested_str_weak(UI),
-    /* K7   */  be_nested_str_weak(plugins),
-    /* K8   */  be_nested_str_weak(vendorid),
-    /* K9   */  be_nested_str_weak(VENDOR_ID),
-    /* K10  */  be_nested_str_weak(productid),
-    /* K11  */  be_nested_str_weak(PRODUCT_ID),
-    /* K12  */  be_nested_str_weak(root_iterations),
-    /* K13  */  be_nested_str_weak(PBKDF_ITERATIONS),
-    /* K14  */  be_nested_str_weak(root_salt),
-    /* K15  */  be_nested_str_weak(random),
-    /* K16  */  be_nested_str_weak(ipv4only),
-    /* K17  */  be_nested_str_weak(load_param),
-    /* K18  */  be_nested_str_weak(sessions),
-    /* K19  */  be_nested_str_weak(Session_Store),
-    /* K20  */  be_nested_str_weak(load_fabrics),
-    /* K21  */  be_nested_str_weak(message_handler),
-    /* K22  */  be_nested_str_weak(MessageHandler),
-    /* K23  */  be_nested_str_weak(ui),
-    /* K24  */  be_nested_str_weak(push),
-    /* K25  */  be_nested_str_weak(Plugin_Root),
-    /* K26  */  be_const_int(0),
-    /* K27  */  be_nested_str_weak(Plugin_OnOff),
-    /* K28  */  be_const_int(1),
-    /* K29  */  be_nested_str_weak(add_cron),
-    /* K30  */  be_nested_str_weak(_X2A_X2F5_X20_X2A_X20_X2A_X20_X2A_X20_X2A_X20_X2A),
-    /* K31  */  be_nested_str_weak(matter_sensors_5s),
-    /* K32  */  be_nested_str_weak(start_mdns_announce_hostnames),
-    /* K33  */  be_nested_str_weak(wifi),
-    /* K34  */  be_nested_str_weak(up),
-    /* K35  */  be_nested_str_weak(_start_udp),
-    /* K36  */  be_nested_str_weak(UDP_PORT),
-    /* K37  */  be_nested_str_weak(add_rule),
-    /* K38  */  be_nested_str_weak(Wifi_X23Connected),
-    /* K39  */  be_nested_str_weak(matter_device_udp),
-    /* K40  */  be_nested_str_weak(eth),
-    /* K41  */  be_nested_str_weak(Eth_X23Connected),
-    /* K42  */  be_nested_str_weak(_init_basic_commissioning),
-    /* K43  */  be_nested_str_weak(add_driver),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20starting_X20UDP_X20server_X20on_X20port_X3A_X20),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(UDPServer),
+    /* K7   */  be_nested_str_weak(),
+    /* K8   */  be_nested_str_weak(start),
     }),
-    be_str_weak(init),
+    be_str_weak(_start_udp),
     &be_const_str_solidified,
-    ( &(const binstruction[110]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x8C0C0703,  //  0003  GETMET	R3	R3	K3
-      0xB8160800,  //  0004  GETNGBL	R5	K4
-      0x88140B05,  //  0005  GETMBR	R5	R5	K5
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x740E0004,  //  0007  JMPT	R3	#000D
-      0xB80E0800,  //  0008  GETNGBL	R3	K4
-      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
-      0x5C140000,  //  000A  MOVE	R5	R0
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x80000600,  //  000C  RET	0
-      0x600C0012,  //  000D  GETGBL	R3	G18
-      0x7C0C0000,  //  000E  CALL	R3	0
-      0x90020E03,  //  000F  SETMBR	R0	K7	R3
-      0x880C0109,  //  0010  GETMBR	R3	R0	K9
-      0x90021003,  //  0011  SETMBR	R0	K8	R3
-      0x880C010B,  //  0012  GETMBR	R3	R0	K11
-      0x90021403,  //  0013  SETMBR	R0	K10	R3
-      0x880C010D,  //  0014  GETMBR	R3	R0	K13
-      0x90021803,  //  0015  SETMBR	R0	K12	R3
-      0x8C0C030F,  //  0016  GETMET	R3	R1	K15
-      0x5416000F,  //  0017  LDINT	R5	16
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x90021C03,  //  0019  SETMBR	R0	K14	R3
-      0x500C0000,  //  001A  LDBOOL	R3	0	0
-      0x90022003,  //  001B  SETMBR	R0	K16	R3
-      0x8C0C0111,  //  001C  GETMET	R3	R0	K17
-      0x7C0C0200,  //  001D  CALL	R3	1
-      0xB80E0800,  //  001E  GETNGBL	R3	K4
-      0x8C0C0713,  //  001F  GETMET	R3	R3	K19
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x90022403,  //  0021  SETMBR	R0	K18	R3
-      0x880C0112,  //  0022  GETMBR	R3	R0	K18
-      0x8C0C0714,  //  0023  GETMET	R3	R3	K20
-      0x7C0C0200,  //  0024  CALL	R3	1
-      0xB80E0800,  //  0025  GETNGBL	R3	K4
-      0x8C0C0716,  //  0026  GETMET	R3	R3	K22
-      0x5C140000,  //  0027  MOVE	R5	R0
-      0x7C0C0400,  //  0028  CALL	R3	2
-      0x90022A03,  //  0029  SETMBR	R0	K21	R3
-      0xB80E0800,  //  002A  GETNGBL	R3	K4
-      0x8C0C0706,  //  002B  GETMET	R3	R3	K6
-      0x5C140000,  //  002C  MOVE	R5	R0
-      0x7C0C0400,  //  002D  CALL	R3	2
-      0x90022E03,  //  002E  SETMBR	R0	K23	R3
-      0x880C0107,  //  002F  GETMBR	R3	R0	K7
-      0x8C0C0718,  //  0030  GETMET	R3	R3	K24
-      0xB8160800,  //  0031  GETNGBL	R5	K4
-      0x8C140B19,  //  0032  GETMET	R5	R5	K25
-      0x5C1C0000,  //  0033  MOVE	R7	R0
-      0x5820001A,  //  0034  LDCONST	R8	K26
-      0x7C140600,  //  0035  CALL	R5	3
-      0x7C0C0400,  //  0036  CALL	R3	2
-      0x880C0107,  //  0037  GETMBR	R3	R0	K7
-      0x8C0C0718,  //  0038  GETMET	R3	R3	K24
-      0xB8160800,  //  0039  GETNGBL	R5	K4
-      0x8C140B1B,  //  003A  GETMET	R5	R5	K27
-      0x5C1C0000,  //  003B  MOVE	R7	R0
-      0x5820001C,  //  003C  LDCONST	R8	K28
-      0x5824001A,  //  003D  LDCONST	R9	K26
-      0x7C140800,  //  003E  CALL	R5	4
-      0x7C0C0400,  //  003F  CALL	R3	2
-      0xB80E0400,  //  0040  GETNGBL	R3	K2
-      0x8C0C071D,  //  0041  GETMET	R3	R3	K29
-      0x5814001E,  //  0042  LDCONST	R5	K30
-      0x84180000,  //  0043  CLOSURE	R6	P0
-      0x581C001F,  //  0044  LDCONST	R7	K31
-      0x7C0C0800,  //  0045  CALL	R3	4
-      0x8C0C0120,  //  0046  GETMET	R3	R0	K32
-      0x7C0C0200,  //  0047  CALL	R3	1
-      0xB80E0400,  //  0048  GETNGBL	R3	K2
-      0x8C0C0721,  //  0049  GETMET	R3	R3	K33
-      0x7C0C0200,  //  004A  CALL	R3	1
-      0x940C0722,  //  004B  GETIDX	R3	R3	K34
-      0x780E0003,  //  004C  JMPF	R3	#0051
-      0x8C0C0123,  //  004D  GETMET	R3	R0	K35
-      0x88140124,  //  004E  GETMBR	R5	R0	K36
-      0x7C0C0400,  //  004F  CALL	R3	2
-      0x70020005,  //  0050  JMP		#0057
-      0xB80E0400,  //  0051  GETNGBL	R3	K2
-      0x8C0C0725,  //  0052  GETMET	R3	R3	K37
-      0x58140026,  //  0053  LDCONST	R5	K38
-      0x84180001,  //  0054  CLOSURE	R6	P1
-      0x581C0027,  //  0055  LDCONST	R7	K39
-      0x7C0C0800,  //  0056  CALL	R3	4
-      0xB80E0400,  //  0057  GETNGBL	R3	K2
-      0x8C0C0728,  //  0058  GETMET	R3	R3	K40
-      0x7C0C0200,  //  0059  CALL	R3	1
-      0x940C0722,  //  005A  GETIDX	R3	R3	K34
-      0x780E0003,  //  005B  JMPF	R3	#0060
-      0x8C0C0123,  //  005C  GETMET	R3	R0	K35
-      0x88140124,  //  005D  GETMBR	R5	R0	K36
-      0x7C0C0400,  //  005E  CALL	R3	2
-      0x70020005,  //  005F  JMP		#0066
-      0xB80E0400,  //  0060  GETNGBL	R3	K2
-      0x8C0C0725,  //  0061  GETMET	R3	R3	K37
-      0x58140029,  //  0062  LDCONST	R5	K41
-      0x84180002,  //  0063  CLOSURE	R6	P2
-      0x581C0027,  //  0064  LDCONST	R7	K39
-      0x7C0C0800,  //  0065  CALL	R3	4
-      0x8C0C012A,  //  0066  GETMET	R3	R0	K42
-      0x7C0C0200,  //  0067  CALL	R3	1
-      0xB80E0400,  //  0068  GETNGBL	R3	K2
-      0x8C0C072B,  //  0069  GETMET	R3	R3	K43
-      0x5C140000,  //  006A  MOVE	R5	R0
-      0x7C0C0400,  //  006B  CALL	R3	2
-      0xA0000000,  //  006C  CLOSE	R0
-      0x80000000,  //  006D  RET	0
+    ( &(const binstruction[27]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80000400,  //  0002  RET	0
+      0x4C080000,  //  0003  LDNIL	R2
+      0x1C080202,  //  0004  EQ	R2	R1	R2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x540615A3,  //  0006  LDINT	R1	5540
+      0xB80A0200,  //  0007  GETNGBL	R2	K1
+      0x8C080502,  //  0008  GETMET	R2	R2	K2
+      0x60100008,  //  0009  GETGBL	R4	G8
+      0x5C140200,  //  000A  MOVE	R5	R1
+      0x7C100200,  //  000B  CALL	R4	1
+      0x00120604,  //  000C  ADD	R4	K3	R4
+      0x58140004,  //  000D  LDCONST	R5	K4
+      0x7C080600,  //  000E  CALL	R2	3
+      0xB80A0A00,  //  000F  GETNGBL	R2	K5
+      0x8C080506,  //  0010  GETMET	R2	R2	K6
+      0x58100007,  //  0011  LDCONST	R4	K7
+      0x5C140200,  //  0012  MOVE	R5	R1
+      0x7C080600,  //  0013  CALL	R2	3
+      0x90020002,  //  0014  SETMBR	R0	K0	R2
+      0x88080100,  //  0015  GETMBR	R2	R0	K0
+      0x8C080508,  //  0016  GETMET	R2	R2	K8
+      0x84100000,  //  0017  CLOSURE	R4	P0
+      0x7C080400,  //  0018  CALL	R2	2
+      0xA0000000,  //  0019  CLOSE	R0
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: attribute_updated
+********************************************************************/
+be_local_closure(Matter_Device_attribute_updated,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Path),
+    /* K2   */  be_nested_str_weak(endpoint),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_nested_str_weak(message_handler),
+    /* K6   */  be_nested_str_weak(im),
+    /* K7   */  be_nested_str_weak(subs_shop),
+    /* K8   */  be_nested_str_weak(attribute_updated_ctx),
+    }),
+    be_str_weak(attribute_updated),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140805,  //  0001  EQ	R5	R4	R5
+      0x78160000,  //  0002  JMPF	R5	#0004
+      0x50100000,  //  0003  LDBOOL	R4	0	0
+      0xB8160000,  //  0004  GETNGBL	R5	K0
+      0x8C140B01,  //  0005  GETMET	R5	R5	K1
+      0x7C140200,  //  0006  CALL	R5	1
+      0x90160401,  //  0007  SETMBR	R5	K2	R1
+      0x90160602,  //  0008  SETMBR	R5	K3	R2
+      0x90160803,  //  0009  SETMBR	R5	K4	R3
+      0x88180105,  //  000A  GETMBR	R6	R0	K5
+      0x88180D06,  //  000B  GETMBR	R6	R6	K6
+      0x88180D07,  //  000C  GETMBR	R6	R6	K7
+      0x8C180D08,  //  000D  GETMET	R6	R6	K8
+      0x5C200A00,  //  000E  MOVE	R8	R5
+      0x5C240800,  //  000F  MOVE	R9	R4
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(Matter_Device_every_250ms,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(every_250ms),
+    }),
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
     })
   )
 );
@@ -2560,11 +1251,11 @@ be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
 
 
 /********************************************************************
-** Solidified function: is_commissioning_open
+** Solidified function: save_param
 ********************************************************************/
-be_local_closure(Matter_Device_is_commissioning_open,   /* name */
+be_local_closure(Matter_Device_save_param,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2572,16 +1263,73 @@ be_local_closure(Matter_Device_is_commissioning_open,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
+    ( &(const bvalue[17]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(dump),
+    /* K2   */  be_nested_str_weak(distinguish),
+    /* K3   */  be_nested_str_weak(root_discriminator),
+    /* K4   */  be_nested_str_weak(passcode),
+    /* K5   */  be_nested_str_weak(root_passcode),
+    /* K6   */  be_nested_str_weak(ipv4only),
+    /* K7   */  be_nested_str_weak(string),
+    /* K8   */  be_nested_str_weak(FILENAME),
+    /* K9   */  be_nested_str_weak(w),
+    /* K10  */  be_nested_str_weak(write),
+    /* K11  */  be_nested_str_weak(close),
+    /* K12  */  be_nested_str_weak(tasmota),
+    /* K13  */  be_nested_str_weak(log),
+    /* K14  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+    /* K15  */  be_nested_str_weak(_X7C),
+    /* K16  */  be_const_int(2),
     }),
-    be_str_weak(is_commissioning_open),
+    be_str_weak(save_param),
     &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
+    ( &(const binstruction[45]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x60100013,  //  0002  GETGBL	R4	G19
+      0x7C100000,  //  0003  CALL	R4	0
+      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x98120405,  //  0005  SETIDX	R4	K2	R5
+      0x88140105,  //  0006  GETMBR	R5	R0	K5
+      0x98120805,  //  0007  SETIDX	R4	K4	R5
+      0x88140106,  //  0008  GETMBR	R5	R0	K6
+      0x98120C05,  //  0009  SETIDX	R4	K6	R5
+      0x7C080400,  //  000A  CALL	R2	2
+      0xA802000D,  //  000B  EXBLK	0	#001A
+      0xA40E0E00,  //  000C  IMPORT	R3	K7
+      0x60100011,  //  000D  GETGBL	R4	G17
+      0x88140108,  //  000E  GETMBR	R5	R0	K8
+      0x58180009,  //  000F  LDCONST	R6	K9
+      0x7C100400,  //  0010  CALL	R4	2
+      0x8C14090A,  //  0011  GETMET	R5	R4	K10
+      0x5C1C0400,  //  0012  MOVE	R7	R2
+      0x7C140400,  //  0013  CALL	R5	2
+      0x8C14090B,  //  0014  GETMET	R5	R4	K11
+      0x7C140200,  //  0015  CALL	R5	1
+      0xA8040001,  //  0016  EXBLK	1	1
+      0x80040400,  //  0017  RET	1	R2
+      0xA8040001,  //  0018  EXBLK	1	1
+      0x70020011,  //  0019  JMP		#002C
+      0xAC0C0002,  //  001A  CATCH	R3	0	2
+      0x7002000E,  //  001B  JMP		#002B
+      0xB8161800,  //  001C  GETNGBL	R5	K12
+      0x8C140B0D,  //  001D  GETMET	R5	R5	K13
+      0x601C0008,  //  001E  GETGBL	R7	G8
+      0x5C200600,  //  001F  MOVE	R8	R3
+      0x7C1C0200,  //  0020  CALL	R7	1
+      0x001E1C07,  //  0021  ADD	R7	K14	R7
+      0x001C0F0F,  //  0022  ADD	R7	R7	K15
+      0x60200008,  //  0023  GETGBL	R8	G8
+      0x5C240800,  //  0024  MOVE	R9	R4
+      0x7C200200,  //  0025  CALL	R8	1
+      0x001C0E08,  //  0026  ADD	R7	R7	R8
+      0x58200010,  //  0027  LDCONST	R8	K16
+      0x7C140600,  //  0028  CALL	R5	3
+      0x80040400,  //  0029  RET	1	R2
+      0x70020000,  //  002A  JMP		#002C
+      0xB0080000,  //  002B  RAISE	2	R0	R0
+      0x80000000,  //  002C  RET	0
     })
   )
 );
@@ -2589,30 +1337,692 @@ be_local_closure(Matter_Device_is_commissioning_open,   /* name */
 
 
 /********************************************************************
-** Solidified function: received_ack
+** Solidified function: mdns_announce_PASE
 ********************************************************************/
-be_local_closure(Matter_Device_received_ack,   /* name */
+be_local_closure(Matter_Device_mdns_announce_PASE,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
+    16,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(received_ack),
+    ( &(const bvalue[44]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(crypto),
+    /* K3   */  be_nested_str_weak(VP),
+    /* K4   */  be_nested_str_weak(vendorid),
+    /* K5   */  be_nested_str_weak(_X2B),
+    /* K6   */  be_nested_str_weak(productid),
+    /* K7   */  be_nested_str_weak(D),
+    /* K8   */  be_nested_str_weak(commissioning_discriminator),
+    /* K9   */  be_nested_str_weak(CM),
+    /* K10  */  be_const_int(1),
+    /* K11  */  be_nested_str_weak(T),
+    /* K12  */  be_const_int(0),
+    /* K13  */  be_nested_str_weak(SII),
+    /* K14  */  be_nested_str_weak(SAI),
+    /* K15  */  be_nested_str_weak(commissioning_instance_wifi),
+    /* K16  */  be_nested_str_weak(random),
+    /* K17  */  be_nested_str_weak(tohex),
+    /* K18  */  be_nested_str_weak(commissioning_instance_eth),
+    /* K19  */  be_nested_str_weak(hostname_eth),
+    /* K20  */  be_nested_str_weak(tasmota),
+    /* K21  */  be_nested_str_weak(log),
+    /* K22  */  be_nested_str_weak(format),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eadd_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25i_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
+    /* K24  */  be_nested_str_weak(_matterc),
+    /* K25  */  be_nested_str_weak(_udp),
+    /* K26  */  be_const_int(3),
+    /* K27  */  be_nested_str_weak(add_service),
+    /* K28  */  be_nested_str_weak(mdns_pase_eth),
+    /* K29  */  be_nested_str_weak(MTR_X3A_X20announce_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K30  */  be_nested_str_weak(eth),
+    /* K31  */  be_const_int(2),
+    /* K32  */  be_nested_str_weak(_L),
+    /* K33  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
+    /* K34  */  be_nested_str_weak(add_subtype),
+    /* K35  */  be_nested_str_weak(_S),
+    /* K36  */  be_nested_str_weak(_V),
+    /* K37  */  be_nested_str_weak(_CM1),
+    /* K38  */  be_nested_str_weak(hostname_wifi),
+    /* K39  */  be_nested_str_weak(mdns_pase_wifi),
+    /* K40  */  be_nested_str_weak(MTR_X3A_X20starting_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K41  */  be_nested_str_weak(wifi),
+    /* K42  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K43  */  be_nested_str_weak(_X7C),
     }),
-    be_str_weak(received_ack),
+    be_str_weak(mdns_announce_PASE),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
+    ( &(const binstruction[267]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xA40E0400,  //  0002  IMPORT	R3	K2
+      0x60100013,  //  0003  GETGBL	R4	G19
+      0x7C100000,  //  0004  CALL	R4	0
+      0x60140008,  //  0005  GETGBL	R5	G8
+      0x88180104,  //  0006  GETMBR	R6	R0	K4
+      0x7C140200,  //  0007  CALL	R5	1
+      0x00140B05,  //  0008  ADD	R5	R5	K5
+      0x60180008,  //  0009  GETGBL	R6	G8
+      0x881C0106,  //  000A  GETMBR	R7	R0	K6
+      0x7C180200,  //  000B  CALL	R6	1
+      0x00140A06,  //  000C  ADD	R5	R5	R6
+      0x98120605,  //  000D  SETIDX	R4	K3	R5
+      0x88140108,  //  000E  GETMBR	R5	R0	K8
+      0x98120E05,  //  000F  SETIDX	R4	K7	R5
+      0x9812130A,  //  0010  SETIDX	R4	K9	K10
+      0x9812170C,  //  0011  SETIDX	R4	K11	K12
+      0x54161387,  //  0012  LDINT	R5	5000
+      0x98121A05,  //  0013  SETIDX	R4	K13	R5
+      0x5416012B,  //  0014  LDINT	R5	300
+      0x98121C05,  //  0015  SETIDX	R4	K14	R5
+      0x8C140710,  //  0016  GETMET	R5	R3	K16
+      0x541E0007,  //  0017  LDINT	R7	8
+      0x7C140400,  //  0018  CALL	R5	2
+      0x8C140B11,  //  0019  GETMET	R5	R5	K17
+      0x7C140200,  //  001A  CALL	R5	1
+      0x90021E05,  //  001B  SETMBR	R0	K15	R5
+      0x8C140710,  //  001C  GETMET	R5	R3	K16
+      0x541E0007,  //  001D  LDINT	R7	8
+      0x7C140400,  //  001E  CALL	R5	2
+      0x8C140B11,  //  001F  GETMET	R5	R5	K17
+      0x7C140200,  //  0020  CALL	R5	1
+      0x90022405,  //  0021  SETMBR	R0	K18	R5
+      0xA80200D5,  //  0022  EXBLK	0	#00F9
+      0x88140113,  //  0023  GETMBR	R5	R0	K19
+      0x78160067,  //  0024  JMPF	R5	#008D
+      0xB8162800,  //  0025  GETNGBL	R5	K20
+      0x8C140B15,  //  0026  GETMET	R5	R5	K21
+      0x8C1C0516,  //  0027  GETMET	R7	R2	K22
+      0x58240017,  //  0028  LDCONST	R9	K23
+      0x58280018,  //  0029  LDCONST	R10	K24
+      0x582C0019,  //  002A  LDCONST	R11	K25
+      0x543215A3,  //  002B  LDINT	R12	5540
+      0x60340008,  //  002C  GETGBL	R13	G8
+      0x5C380800,  //  002D  MOVE	R14	R4
+      0x7C340200,  //  002E  CALL	R13	1
+      0x88380112,  //  002F  GETMBR	R14	R0	K18
+      0x883C0113,  //  0030  GETMBR	R15	R0	K19
+      0x7C1C1000,  //  0031  CALL	R7	8
+      0x5820001A,  //  0032  LDCONST	R8	K26
+      0x7C140600,  //  0033  CALL	R5	3
+      0x8C14031B,  //  0034  GETMET	R5	R1	K27
+      0x581C0018,  //  0035  LDCONST	R7	K24
+      0x58200019,  //  0036  LDCONST	R8	K25
+      0x542615A3,  //  0037  LDINT	R9	5540
+      0x5C280800,  //  0038  MOVE	R10	R4
+      0x882C0112,  //  0039  GETMBR	R11	R0	K18
+      0x88300113,  //  003A  GETMBR	R12	R0	K19
+      0x7C140E00,  //  003B  CALL	R5	7
+      0x50140200,  //  003C  LDBOOL	R5	1	0
+      0x90023805,  //  003D  SETMBR	R0	K28	R5
+      0xB8162800,  //  003E  GETNGBL	R5	K20
+      0x8C140B15,  //  003F  GETMET	R5	R5	K21
+      0x8C1C0516,  //  0040  GETMET	R7	R2	K22
+      0x5824001D,  //  0041  LDCONST	R9	K29
+      0x5828001E,  //  0042  LDCONST	R10	K30
+      0x882C0112,  //  0043  GETMBR	R11	R0	K18
+      0x88300113,  //  0044  GETMBR	R12	R0	K19
+      0x7C1C0A00,  //  0045  CALL	R7	5
+      0x5820001F,  //  0046  LDCONST	R8	K31
+      0x7C140600,  //  0047  CALL	R5	3
+      0x60140008,  //  0048  GETGBL	R5	G8
+      0x88180108,  //  0049  GETMBR	R6	R0	K8
+      0x541E0FFE,  //  004A  LDINT	R7	4095
+      0x2C180C07,  //  004B  AND	R6	R6	R7
+      0x7C140200,  //  004C  CALL	R5	1
+      0x00164005,  //  004D  ADD	R5	K32	R5
+      0xB81A2800,  //  004E  GETNGBL	R6	K20
+      0x8C180D15,  //  004F  GETMET	R6	R6	K21
+      0x00224205,  //  0050  ADD	R8	K33	R5
+      0x5824001F,  //  0051  LDCONST	R9	K31
+      0x7C180600,  //  0052  CALL	R6	3
+      0x8C180322,  //  0053  GETMET	R6	R1	K34
+      0x58200018,  //  0054  LDCONST	R8	K24
+      0x58240019,  //  0055  LDCONST	R9	K25
+      0x88280112,  //  0056  GETMBR	R10	R0	K18
+      0x882C0113,  //  0057  GETMBR	R11	R0	K19
+      0x5C300A00,  //  0058  MOVE	R12	R5
+      0x7C180C00,  //  0059  CALL	R6	6
+      0x60180008,  //  005A  GETGBL	R6	G8
+      0x881C0108,  //  005B  GETMBR	R7	R0	K8
+      0x54220EFF,  //  005C  LDINT	R8	3840
+      0x2C1C0E08,  //  005D  AND	R7	R7	R8
+      0x54220007,  //  005E  LDINT	R8	8
+      0x3C1C0E08,  //  005F  SHR	R7	R7	R8
+      0x7C180200,  //  0060  CALL	R6	1
+      0x001A4606,  //  0061  ADD	R6	K35	R6
+      0x5C140C00,  //  0062  MOVE	R5	R6
+      0xB81A2800,  //  0063  GETNGBL	R6	K20
+      0x8C180D15,  //  0064  GETMET	R6	R6	K21
+      0x00224205,  //  0065  ADD	R8	K33	R5
+      0x5824001F,  //  0066  LDCONST	R9	K31
+      0x7C180600,  //  0067  CALL	R6	3
+      0x8C180322,  //  0068  GETMET	R6	R1	K34
+      0x58200018,  //  0069  LDCONST	R8	K24
+      0x58240019,  //  006A  LDCONST	R9	K25
+      0x88280112,  //  006B  GETMBR	R10	R0	K18
+      0x882C0113,  //  006C  GETMBR	R11	R0	K19
+      0x5C300A00,  //  006D  MOVE	R12	R5
+      0x7C180C00,  //  006E  CALL	R6	6
+      0x60180008,  //  006F  GETGBL	R6	G8
+      0x881C0104,  //  0070  GETMBR	R7	R0	K4
+      0x7C180200,  //  0071  CALL	R6	1
+      0x001A4806,  //  0072  ADD	R6	K36	R6
+      0x5C140C00,  //  0073  MOVE	R5	R6
+      0xB81A2800,  //  0074  GETNGBL	R6	K20
+      0x8C180D15,  //  0075  GETMET	R6	R6	K21
+      0x00224205,  //  0076  ADD	R8	K33	R5
+      0x5824001F,  //  0077  LDCONST	R9	K31
+      0x7C180600,  //  0078  CALL	R6	3
+      0x8C180322,  //  0079  GETMET	R6	R1	K34
+      0x58200018,  //  007A  LDCONST	R8	K24
+      0x58240019,  //  007B  LDCONST	R9	K25
+      0x88280112,  //  007C  GETMBR	R10	R0	K18
+      0x882C0113,  //  007D  GETMBR	R11	R0	K19
+      0x5C300A00,  //  007E  MOVE	R12	R5
+      0x7C180C00,  //  007F  CALL	R6	6
+      0x58140025,  //  0080  LDCONST	R5	K37
+      0xB81A2800,  //  0081  GETNGBL	R6	K20
+      0x8C180D15,  //  0082  GETMET	R6	R6	K21
+      0x00224205,  //  0083  ADD	R8	K33	R5
+      0x5824001F,  //  0084  LDCONST	R9	K31
+      0x7C180600,  //  0085  CALL	R6	3
+      0x8C180322,  //  0086  GETMET	R6	R1	K34
+      0x58200018,  //  0087  LDCONST	R8	K24
+      0x58240019,  //  0088  LDCONST	R9	K25
+      0x88280112,  //  0089  GETMBR	R10	R0	K18
+      0x882C0113,  //  008A  GETMBR	R11	R0	K19
+      0x5C300A00,  //  008B  MOVE	R12	R5
+      0x7C180C00,  //  008C  CALL	R6	6
+      0x88140126,  //  008D  GETMBR	R5	R0	K38
+      0x78160067,  //  008E  JMPF	R5	#00F7
+      0xB8162800,  //  008F  GETNGBL	R5	K20
+      0x8C140B15,  //  0090  GETMET	R5	R5	K21
+      0x8C1C0516,  //  0091  GETMET	R7	R2	K22
+      0x58240017,  //  0092  LDCONST	R9	K23
+      0x58280018,  //  0093  LDCONST	R10	K24
+      0x582C0019,  //  0094  LDCONST	R11	K25
+      0x543215A3,  //  0095  LDINT	R12	5540
+      0x60340008,  //  0096  GETGBL	R13	G8
+      0x5C380800,  //  0097  MOVE	R14	R4
+      0x7C340200,  //  0098  CALL	R13	1
+      0x8838010F,  //  0099  GETMBR	R14	R0	K15
+      0x883C0126,  //  009A  GETMBR	R15	R0	K38
+      0x7C1C1000,  //  009B  CALL	R7	8
+      0x5820001A,  //  009C  LDCONST	R8	K26
+      0x7C140600,  //  009D  CALL	R5	3
+      0x8C14031B,  //  009E  GETMET	R5	R1	K27
+      0x581C0018,  //  009F  LDCONST	R7	K24
+      0x58200019,  //  00A0  LDCONST	R8	K25
+      0x542615A3,  //  00A1  LDINT	R9	5540
+      0x5C280800,  //  00A2  MOVE	R10	R4
+      0x882C010F,  //  00A3  GETMBR	R11	R0	K15
+      0x88300126,  //  00A4  GETMBR	R12	R0	K38
+      0x7C140E00,  //  00A5  CALL	R5	7
+      0x50140200,  //  00A6  LDBOOL	R5	1	0
+      0x90024E05,  //  00A7  SETMBR	R0	K39	R5
+      0xB8162800,  //  00A8  GETNGBL	R5	K20
+      0x8C140B15,  //  00A9  GETMET	R5	R5	K21
+      0x8C1C0516,  //  00AA  GETMET	R7	R2	K22
+      0x58240028,  //  00AB  LDCONST	R9	K40
+      0x58280029,  //  00AC  LDCONST	R10	K41
+      0x882C010F,  //  00AD  GETMBR	R11	R0	K15
+      0x88300126,  //  00AE  GETMBR	R12	R0	K38
+      0x7C1C0A00,  //  00AF  CALL	R7	5
+      0x5820001F,  //  00B0  LDCONST	R8	K31
+      0x7C140600,  //  00B1  CALL	R5	3
+      0x60140008,  //  00B2  GETGBL	R5	G8
+      0x88180108,  //  00B3  GETMBR	R6	R0	K8
+      0x541E0FFE,  //  00B4  LDINT	R7	4095
+      0x2C180C07,  //  00B5  AND	R6	R6	R7
+      0x7C140200,  //  00B6  CALL	R5	1
+      0x00164005,  //  00B7  ADD	R5	K32	R5
+      0xB81A2800,  //  00B8  GETNGBL	R6	K20
+      0x8C180D15,  //  00B9  GETMET	R6	R6	K21
+      0x00224205,  //  00BA  ADD	R8	K33	R5
+      0x5824001F,  //  00BB  LDCONST	R9	K31
+      0x7C180600,  //  00BC  CALL	R6	3
+      0x8C180322,  //  00BD  GETMET	R6	R1	K34
+      0x58200018,  //  00BE  LDCONST	R8	K24
+      0x58240019,  //  00BF  LDCONST	R9	K25
+      0x8828010F,  //  00C0  GETMBR	R10	R0	K15
+      0x882C0126,  //  00C1  GETMBR	R11	R0	K38
+      0x5C300A00,  //  00C2  MOVE	R12	R5
+      0x7C180C00,  //  00C3  CALL	R6	6
+      0x60180008,  //  00C4  GETGBL	R6	G8
+      0x881C0108,  //  00C5  GETMBR	R7	R0	K8
+      0x54220EFF,  //  00C6  LDINT	R8	3840
+      0x2C1C0E08,  //  00C7  AND	R7	R7	R8
+      0x54220007,  //  00C8  LDINT	R8	8
+      0x3C1C0E08,  //  00C9  SHR	R7	R7	R8
+      0x7C180200,  //  00CA  CALL	R6	1
+      0x001A4606,  //  00CB  ADD	R6	K35	R6
+      0x5C140C00,  //  00CC  MOVE	R5	R6
+      0xB81A2800,  //  00CD  GETNGBL	R6	K20
+      0x8C180D15,  //  00CE  GETMET	R6	R6	K21
+      0x00224205,  //  00CF  ADD	R8	K33	R5
+      0x5824001F,  //  00D0  LDCONST	R9	K31
+      0x7C180600,  //  00D1  CALL	R6	3
+      0x8C180322,  //  00D2  GETMET	R6	R1	K34
+      0x58200018,  //  00D3  LDCONST	R8	K24
+      0x58240019,  //  00D4  LDCONST	R9	K25
+      0x8828010F,  //  00D5  GETMBR	R10	R0	K15
+      0x882C0126,  //  00D6  GETMBR	R11	R0	K38
+      0x5C300A00,  //  00D7  MOVE	R12	R5
+      0x7C180C00,  //  00D8  CALL	R6	6
+      0x60180008,  //  00D9  GETGBL	R6	G8
+      0x881C0104,  //  00DA  GETMBR	R7	R0	K4
+      0x7C180200,  //  00DB  CALL	R6	1
+      0x001A4806,  //  00DC  ADD	R6	K36	R6
+      0x5C140C00,  //  00DD  MOVE	R5	R6
+      0xB81A2800,  //  00DE  GETNGBL	R6	K20
+      0x8C180D15,  //  00DF  GETMET	R6	R6	K21
+      0x00224205,  //  00E0  ADD	R8	K33	R5
+      0x5824001F,  //  00E1  LDCONST	R9	K31
+      0x7C180600,  //  00E2  CALL	R6	3
+      0x8C180322,  //  00E3  GETMET	R6	R1	K34
+      0x58200018,  //  00E4  LDCONST	R8	K24
+      0x58240019,  //  00E5  LDCONST	R9	K25
+      0x8828010F,  //  00E6  GETMBR	R10	R0	K15
+      0x882C0126,  //  00E7  GETMBR	R11	R0	K38
+      0x5C300A00,  //  00E8  MOVE	R12	R5
+      0x7C180C00,  //  00E9  CALL	R6	6
+      0x58140025,  //  00EA  LDCONST	R5	K37
+      0xB81A2800,  //  00EB  GETNGBL	R6	K20
+      0x8C180D15,  //  00EC  GETMET	R6	R6	K21
+      0x00224205,  //  00ED  ADD	R8	K33	R5
+      0x5824001F,  //  00EE  LDCONST	R9	K31
+      0x7C180600,  //  00EF  CALL	R6	3
+      0x8C180322,  //  00F0  GETMET	R6	R1	K34
+      0x58200018,  //  00F1  LDCONST	R8	K24
+      0x58240019,  //  00F2  LDCONST	R9	K25
+      0x8828010F,  //  00F3  GETMBR	R10	R0	K15
+      0x882C0126,  //  00F4  GETMBR	R11	R0	K38
+      0x5C300A00,  //  00F5  MOVE	R12	R5
+      0x7C180C00,  //  00F6  CALL	R6	6
+      0xA8040001,  //  00F7  EXBLK	1	1
+      0x70020010,  //  00F8  JMP		#010A
+      0xAC140002,  //  00F9  CATCH	R5	0	2
+      0x7002000D,  //  00FA  JMP		#0109
+      0xB81E2800,  //  00FB  GETNGBL	R7	K20
+      0x8C1C0F15,  //  00FC  GETMET	R7	R7	K21
+      0x60240008,  //  00FD  GETGBL	R9	G8
+      0x5C280A00,  //  00FE  MOVE	R10	R5
+      0x7C240200,  //  00FF  CALL	R9	1
+      0x00265409,  //  0100  ADD	R9	K42	R9
+      0x0024132B,  //  0101  ADD	R9	R9	K43
+      0x60280008,  //  0102  GETGBL	R10	G8
+      0x5C2C0C00,  //  0103  MOVE	R11	R6
+      0x7C280200,  //  0104  CALL	R10	1
+      0x0024120A,  //  0105  ADD	R9	R9	R10
+      0x5828001F,  //  0106  LDCONST	R10	K31
+      0x7C1C0600,  //  0107  CALL	R7	3
+      0x70020000,  //  0108  JMP		#010A
+      0xB0080000,  //  0109  RAISE	2	R0	R0
+      0x80000000,  //  010A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    8,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 4]) {     /* constants */
+        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0000,  //  0006  LDCONST	R3	K0
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 4]) {     /* constants */
+        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Eth_X23Connected),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0000,  //  0006  LDCONST	R3	K0
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(millis),
+    /* K3   */  be_nested_str_weak(commissioning_iterations),
+    /* K4   */  be_nested_str_weak(commissioning_discriminator),
+    /* K5   */  be_nested_str_weak(commissioning_salt),
+    /* K6   */  be_nested_str_weak(commissioning_w0),
+    /* K7   */  be_nested_str_weak(commissioning_L),
+    /* K8   */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K9   */  be_nested_str_weak(wifi),
+    /* K10  */  be_nested_str_weak(up),
+    /* K11  */  be_nested_str_weak(eth),
+    /* K12  */  be_nested_str_weak(mdns_announce_PASE),
+    /* K13  */  be_nested_str_weak(add_rule),
+    /* K14  */  be_nested_str_weak(Wifi_X23Connected),
+    /* K15  */  be_nested_str_weak(Eth_X23Connected),
+    }),
+    be_str_weak(start_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0xB8220200,  //  0000  GETNGBL	R8	K1
+      0x8C201102,  //  0001  GETMET	R8	R8	K2
+      0x7C200200,  //  0002  CALL	R8	1
+      0x542603E7,  //  0003  LDINT	R9	1000
+      0x08240209,  //  0004  MUL	R9	R1	R9
+      0x00201009,  //  0005  ADD	R8	R8	R9
+      0x90020008,  //  0006  SETMBR	R0	K0	R8
+      0x90020602,  //  0007  SETMBR	R0	K3	R2
+      0x90020803,  //  0008  SETMBR	R0	K4	R3
+      0x90020A04,  //  0009  SETMBR	R0	K5	R4
+      0x90020C05,  //  000A  SETMBR	R0	K6	R5
+      0x90020E06,  //  000B  SETMBR	R0	K7	R6
+      0x90021007,  //  000C  SETMBR	R0	K8	R7
+      0xB8220200,  //  000D  GETNGBL	R8	K1
+      0x8C201109,  //  000E  GETMET	R8	R8	K9
+      0x7C200200,  //  000F  CALL	R8	1
+      0x9420110A,  //  0010  GETIDX	R8	R8	K10
+      0x74220004,  //  0011  JMPT	R8	#0017
+      0xB8220200,  //  0012  GETNGBL	R8	K1
+      0x8C20110B,  //  0013  GETMET	R8	R8	K11
+      0x7C200200,  //  0014  CALL	R8	1
+      0x9420110A,  //  0015  GETIDX	R8	R8	K10
+      0x78220002,  //  0016  JMPF	R8	#001A
+      0x8C20010C,  //  0017  GETMET	R8	R0	K12
+      0x7C200200,  //  0018  CALL	R8	1
+      0x7002000B,  //  0019  JMP		#0026
+      0xB8220200,  //  001A  GETNGBL	R8	K1
+      0x8C20110D,  //  001B  GETMET	R8	R8	K13
+      0x5828000E,  //  001C  LDCONST	R10	K14
+      0x842C0000,  //  001D  CLOSURE	R11	P0
+      0x5830000C,  //  001E  LDCONST	R12	K12
+      0x7C200800,  //  001F  CALL	R8	4
+      0xB8220200,  //  0020  GETNGBL	R8	K1
+      0x8C20110D,  //  0021  GETMET	R8	R8	K13
+      0x5828000F,  //  0022  LDCONST	R10	K15
+      0x842C0001,  //  0023  CLOSURE	R11	P1
+      0x5830000C,  //  0024  LDCONST	R12	K12
+      0x7C200800,  //  0025  CALL	R8	4
+      0xA0000000,  //  0026  CLOSE	R0
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Device_init,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_start),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0004,  //  0006  LDCONST	R3	K4
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Eth_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_start),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0004,  //  0006  LDCONST	R3	K4
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[35]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(get_option),
+    /* K4   */  be_nested_str_weak(matter),
+    /* K5   */  be_nested_str_weak(MATTER_OPTION),
+    /* K6   */  be_nested_str_weak(UI),
+    /* K7   */  be_nested_str_weak(started),
+    /* K8   */  be_nested_str_weak(plugins),
+    /* K9   */  be_nested_str_weak(vendorid),
+    /* K10  */  be_nested_str_weak(VENDOR_ID),
+    /* K11  */  be_nested_str_weak(productid),
+    /* K12  */  be_nested_str_weak(PRODUCT_ID),
+    /* K13  */  be_nested_str_weak(root_iterations),
+    /* K14  */  be_nested_str_weak(PBKDF_ITERATIONS),
+    /* K15  */  be_nested_str_weak(root_salt),
+    /* K16  */  be_nested_str_weak(random),
+    /* K17  */  be_nested_str_weak(ipv4only),
+    /* K18  */  be_nested_str_weak(load_param),
+    /* K19  */  be_nested_str_weak(sessions),
+    /* K20  */  be_nested_str_weak(Session_Store),
+    /* K21  */  be_nested_str_weak(load_fabrics),
+    /* K22  */  be_nested_str_weak(message_handler),
+    /* K23  */  be_nested_str_weak(MessageHandler),
+    /* K24  */  be_nested_str_weak(ui),
+    /* K25  */  be_nested_str_weak(wifi),
+    /* K26  */  be_nested_str_weak(up),
+    /* K27  */  be_nested_str_weak(eth),
+    /* K28  */  be_nested_str_weak(start),
+    /* K29  */  be_nested_str_weak(add_rule),
+    /* K30  */  be_nested_str_weak(Wifi_X23Connected),
+    /* K31  */  be_nested_str_weak(matter_start),
+    /* K32  */  be_nested_str_weak(Eth_X23Connected),
+    /* K33  */  be_nested_str_weak(_init_basic_commissioning),
+    /* K34  */  be_nested_str_weak(add_driver),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[91]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xB80E0400,  //  0002  GETNGBL	R3	K2
+      0x8C0C0703,  //  0003  GETMET	R3	R3	K3
+      0xB8160800,  //  0004  GETNGBL	R5	K4
+      0x88140B05,  //  0005  GETMBR	R5	R5	K5
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x740E0004,  //  0007  JMPT	R3	#000D
+      0xB80E0800,  //  0008  GETNGBL	R3	K4
+      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
+      0x5C140000,  //  000A  MOVE	R5	R0
+      0x7C0C0400,  //  000B  CALL	R3	2
+      0x80000600,  //  000C  RET	0
+      0x500C0000,  //  000D  LDBOOL	R3	0	0
+      0x90020E03,  //  000E  SETMBR	R0	K7	R3
+      0x600C0012,  //  000F  GETGBL	R3	G18
+      0x7C0C0000,  //  0010  CALL	R3	0
+      0x90021003,  //  0011  SETMBR	R0	K8	R3
+      0x880C010A,  //  0012  GETMBR	R3	R0	K10
+      0x90021203,  //  0013  SETMBR	R0	K9	R3
+      0x880C010C,  //  0014  GETMBR	R3	R0	K12
+      0x90021603,  //  0015  SETMBR	R0	K11	R3
+      0x880C010E,  //  0016  GETMBR	R3	R0	K14
+      0x90021A03,  //  0017  SETMBR	R0	K13	R3
+      0x8C0C0310,  //  0018  GETMET	R3	R1	K16
+      0x5416000F,  //  0019  LDINT	R5	16
+      0x7C0C0400,  //  001A  CALL	R3	2
+      0x90021E03,  //  001B  SETMBR	R0	K15	R3
+      0x500C0000,  //  001C  LDBOOL	R3	0	0
+      0x90022203,  //  001D  SETMBR	R0	K17	R3
+      0x8C0C0112,  //  001E  GETMET	R3	R0	K18
+      0x7C0C0200,  //  001F  CALL	R3	1
+      0xB80E0800,  //  0020  GETNGBL	R3	K4
+      0x8C0C0714,  //  0021  GETMET	R3	R3	K20
+      0x7C0C0200,  //  0022  CALL	R3	1
+      0x90022603,  //  0023  SETMBR	R0	K19	R3
+      0x880C0113,  //  0024  GETMBR	R3	R0	K19
+      0x8C0C0715,  //  0025  GETMET	R3	R3	K21
+      0x7C0C0200,  //  0026  CALL	R3	1
+      0xB80E0800,  //  0027  GETNGBL	R3	K4
+      0x8C0C0717,  //  0028  GETMET	R3	R3	K23
+      0x5C140000,  //  0029  MOVE	R5	R0
+      0x7C0C0400,  //  002A  CALL	R3	2
+      0x90022C03,  //  002B  SETMBR	R0	K22	R3
+      0xB80E0800,  //  002C  GETNGBL	R3	K4
+      0x8C0C0706,  //  002D  GETMET	R3	R3	K6
+      0x5C140000,  //  002E  MOVE	R5	R0
+      0x7C0C0400,  //  002F  CALL	R3	2
+      0x90023003,  //  0030  SETMBR	R0	K24	R3
+      0xB80E0400,  //  0031  GETNGBL	R3	K2
+      0x8C0C0719,  //  0032  GETMET	R3	R3	K25
+      0x7C0C0200,  //  0033  CALL	R3	1
+      0x940C071A,  //  0034  GETIDX	R3	R3	K26
+      0x740E0004,  //  0035  JMPT	R3	#003B
+      0xB80E0400,  //  0036  GETNGBL	R3	K2
+      0x8C0C071B,  //  0037  GETMET	R3	R3	K27
+      0x7C0C0200,  //  0038  CALL	R3	1
+      0x940C071A,  //  0039  GETIDX	R3	R3	K26
+      0x780E0001,  //  003A  JMPF	R3	#003D
+      0x8C0C011C,  //  003B  GETMET	R3	R0	K28
+      0x7C0C0200,  //  003C  CALL	R3	1
+      0xB80E0400,  //  003D  GETNGBL	R3	K2
+      0x8C0C0719,  //  003E  GETMET	R3	R3	K25
+      0x7C0C0200,  //  003F  CALL	R3	1
+      0x940C071A,  //  0040  GETIDX	R3	R3	K26
+      0x740E0005,  //  0041  JMPT	R3	#0048
+      0xB80E0400,  //  0042  GETNGBL	R3	K2
+      0x8C0C071D,  //  0043  GETMET	R3	R3	K29
+      0x5814001E,  //  0044  LDCONST	R5	K30
+      0x84180000,  //  0045  CLOSURE	R6	P0
+      0x581C001F,  //  0046  LDCONST	R7	K31
+      0x7C0C0800,  //  0047  CALL	R3	4
+      0xB80E0400,  //  0048  GETNGBL	R3	K2
+      0x8C0C071B,  //  0049  GETMET	R3	R3	K27
+      0x7C0C0200,  //  004A  CALL	R3	1
+      0x940C071A,  //  004B  GETIDX	R3	R3	K26
+      0x740E0005,  //  004C  JMPT	R3	#0053
+      0xB80E0400,  //  004D  GETNGBL	R3	K2
+      0x8C0C071D,  //  004E  GETMET	R3	R3	K29
+      0x58140020,  //  004F  LDCONST	R5	K32
+      0x84180001,  //  0050  CLOSURE	R6	P1
+      0x581C001F,  //  0051  LDCONST	R7	K31
+      0x7C0C0800,  //  0052  CALL	R3	4
+      0x8C0C0121,  //  0053  GETMET	R3	R0	K33
+      0x7C0C0200,  //  0054  CALL	R3	1
+      0xB80E0400,  //  0055  GETNGBL	R3	K2
+      0x8C0C0722,  //  0056  GETMET	R3	R3	K34
+      0x5C140000,  //  0057  MOVE	R5	R0
+      0x7C0C0400,  //  0058  CALL	R3	2
+      0xA0000000,  //  0059  CLOSE	R0
+      0x80000000,  //  005A  RET	0
     })
   )
 );
@@ -2657,148 +2067,9 @@ be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
 
 
 /********************************************************************
-** Solidified function: _start_udp
+** Solidified function: is_root_commissioning_open
 ********************************************************************/
-be_local_closure(Matter_Device__start_udp,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        8,                          /* nstack */
-        3,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(msg_received),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 7]) {  /* code */
-          0x680C0000,  //  0000  GETUPV	R3	U0
-          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
-          0x5C140000,  //  0002  MOVE	R5	R0
-          0x5C180200,  //  0003  MOVE	R6	R1
-          0x5C1C0400,  //  0004  MOVE	R7	R2
-          0x7C0C0800,  //  0005  CALL	R3	4
-          0x80040600,  //  0006  RET	1	R3
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20starting_X20UDP_X20server_X20on_X20port_X3A_X20),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(UDPServer),
-    /* K7   */  be_nested_str_weak(),
-    /* K8   */  be_nested_str_weak(start),
-    }),
-    be_str_weak(_start_udp),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80000400,  //  0002  RET	0
-      0x4C080000,  //  0003  LDNIL	R2
-      0x1C080202,  //  0004  EQ	R2	R1	R2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x540615A3,  //  0006  LDINT	R1	5540
-      0xB80A0200,  //  0007  GETNGBL	R2	K1
-      0x8C080502,  //  0008  GETMET	R2	R2	K2
-      0x60100008,  //  0009  GETGBL	R4	G8
-      0x5C140200,  //  000A  MOVE	R5	R1
-      0x7C100200,  //  000B  CALL	R4	1
-      0x00120604,  //  000C  ADD	R4	K3	R4
-      0x58140004,  //  000D  LDCONST	R5	K4
-      0x7C080600,  //  000E  CALL	R2	3
-      0xB80A0A00,  //  000F  GETNGBL	R2	K5
-      0x8C080506,  //  0010  GETMET	R2	R2	K6
-      0x58100007,  //  0011  LDCONST	R4	K7
-      0x5C140200,  //  0012  MOVE	R5	R1
-      0x7C080600,  //  0013  CALL	R2	3
-      0x90020002,  //  0014  SETMBR	R0	K0	R2
-      0x88080100,  //  0015  GETMBR	R2	R0	K0
-      0x8C080508,  //  0016  GETMET	R2	R2	K8
-      0x84100000,  //  0017  CLOSURE	R4	P0
-      0x7C080400,  //  0018  CALL	R2	2
-      0xA0000000,  //  0019  CLOSE	R0
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_root_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(PASE_TIMEOUT),
-    /* K1   */  be_nested_str_weak(_compute_pbkdf),
-    /* K2   */  be_nested_str_weak(root_passcode),
-    /* K3   */  be_nested_str_weak(root_iterations),
-    /* K4   */  be_nested_str_weak(root_salt),
-    /* K5   */  be_nested_str_weak(start_basic_commissioning),
-    /* K6   */  be_nested_str_weak(root_discriminator),
-    /* K7   */  be_nested_str_weak(root_w0),
-    /* K8   */  be_nested_str_weak(root_L),
-    }),
-    be_str_weak(start_root_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0x88040100,  //  0003  GETMBR	R1	R0	K0
-      0x8C080101,  //  0004  GETMET	R2	R0	K1
-      0x88100102,  //  0005  GETMBR	R4	R0	K2
-      0x88140103,  //  0006  GETMBR	R5	R0	K3
-      0x88180104,  //  0007  GETMBR	R6	R0	K4
-      0x7C080800,  //  0008  CALL	R2	4
-      0x8C080105,  //  0009  GETMET	R2	R0	K5
-      0x5C100200,  //  000A  MOVE	R4	R1
-      0x88140103,  //  000B  GETMBR	R5	R0	K3
-      0x88180106,  //  000C  GETMBR	R6	R0	K6
-      0x881C0104,  //  000D  GETMBR	R7	R0	K4
-      0x88200107,  //  000E  GETMBR	R8	R0	K7
-      0x88240108,  //  000F  GETMBR	R9	R0	K8
-      0x4C280000,  //  0010  LDNIL	R10
-      0x7C081000,  //  0011  CALL	R2	8
-      0x80000000,  //  0012  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
+be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -2808,36 +2079,24 @@ be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
+    ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(mdns_remove_PASE),
-    /* K2   */  be_nested_str_weak(commissioning_iterations),
-    /* K3   */  be_nested_str_weak(commissioning_discriminator),
-    /* K4   */  be_nested_str_weak(commissioning_salt),
-    /* K5   */  be_nested_str_weak(commissioning_w0),
-    /* K6   */  be_nested_str_weak(commissioning_L),
-    /* K7   */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K1   */  be_nested_str_weak(commissioning_admin_fabric),
     }),
-    be_str_weak(stop_basic_commissioning),
+    be_str_weak(is_root_commissioning_open),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x4C040000,  //  0000  LDNIL	R1
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
-      0x7C040200,  //  0003  CALL	R1	1
-      0x4C040000,  //  0004  LDNIL	R1
-      0x90020401,  //  0005  SETMBR	R0	K2	R1
-      0x4C040000,  //  0006  LDNIL	R1
-      0x90020601,  //  0007  SETMBR	R0	K3	R1
-      0x4C040000,  //  0008  LDNIL	R1
-      0x90020801,  //  0009  SETMBR	R0	K4	R1
-      0x4C040000,  //  000A  LDNIL	R1
-      0x90020A01,  //  000B  SETMBR	R0	K5	R1
-      0x4C040000,  //  000C  LDNIL	R1
-      0x90020C01,  //  000D  SETMBR	R0	K6	R1
-      0x4C040000,  //  000E  LDNIL	R1
-      0x90020E01,  //  000F  SETMBR	R0	K7	R1
-      0x80000000,  //  0010  RET	0
+    ( &(const binstruction[11]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060003,  //  0003  JMPF	R1	#0008
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x4C080000,  //  0005  LDNIL	R2
+      0x1C040202,  //  0006  EQ	R1	R1	R2
+      0x74060000,  //  0007  JMPT	R1	#0009
+      0x50040001,  //  0008  LDBOOL	R1	0	1
+      0x50040200,  //  0009  LDBOOL	R1	1	0
+      0x80040200,  //  000A  RET	1	R1
     })
   )
 );
@@ -2845,50 +2104,28 @@ be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
 
 
 /********************************************************************
-** Solidified function: attribute_updated
+** Solidified function: is_commissioning_open
 ********************************************************************/
-be_local_closure(Matter_Device_attribute_updated,   /* name */
+be_local_closure(Matter_Device_is_commissioning_open,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
+    3,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Path),
-    /* K2   */  be_nested_str_weak(endpoint),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(message_handler),
-    /* K6   */  be_nested_str_weak(im),
-    /* K7   */  be_nested_str_weak(subs_shop),
-    /* K8   */  be_nested_str_weak(attribute_updated_ctx),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
     }),
-    be_str_weak(attribute_updated),
+    be_str_weak(is_commissioning_open),
     &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x1C140805,  //  0001  EQ	R5	R4	R5
-      0x78160000,  //  0002  JMPF	R5	#0004
-      0x50100000,  //  0003  LDBOOL	R4	0	0
-      0xB8160000,  //  0004  GETNGBL	R5	K0
-      0x8C140B01,  //  0005  GETMET	R5	R5	K1
-      0x7C140200,  //  0006  CALL	R5	1
-      0x90160401,  //  0007  SETMBR	R5	K2	R1
-      0x90160602,  //  0008  SETMBR	R5	K3	R2
-      0x90160803,  //  0009  SETMBR	R5	K4	R3
-      0x88180105,  //  000A  GETMBR	R6	R0	K5
-      0x88180D06,  //  000B  GETMBR	R6	R6	K6
-      0x88180D07,  //  000C  GETMBR	R6	R6	K7
-      0x8C180D08,  //  000D  GETMET	R6	R6	K8
-      0x5C200A00,  //  000E  MOVE	R8	R5
-      0x5C240800,  //  000F  MOVE	R9	R4
-      0x7C180600,  //  0010  CALL	R6	3
-      0x80000000,  //  0011  RET	0
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
     })
   )
 );
@@ -2896,12 +2133,50 @@ be_local_closure(Matter_Device_attribute_updated,   /* name */
 
 
 /********************************************************************
-** Solidified function: load_param
+** Solidified function: stop
 ********************************************************************/
-be_local_closure(Matter_Device_load_param,   /* name */
+be_local_closure(Matter_Device_stop,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(remove_driver),
+    /* K2   */  be_nested_str_weak(udp_server),
+    /* K3   */  be_nested_str_weak(stop),
+    }),
+    be_str_weak(stop),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x88040102,  //  0004  GETMBR	R1	R0	K2
+      0x78060002,  //  0005  JMPF	R1	#0009
+      0x88040102,  //  0006  GETMBR	R1	R0	K2
+      0x8C040303,  //  0007  GETMET	R1	R1	K3
+      0x7C040200,  //  0008  CALL	R1	1
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_remove_op_discovery
+********************************************************************/
+be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -2909,225 +2184,115 @@ be_local_closure(Matter_Device_load_param,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(FILENAME),
-    /* K3   */  be_nested_str_weak(read),
-    /* K4   */  be_nested_str_weak(close),
-    /* K5   */  be_nested_str_weak(json),
-    /* K6   */  be_nested_str_weak(load),
-    /* K7   */  be_nested_str_weak(root_discriminator),
-    /* K8   */  be_nested_str_weak(find),
-    /* K9   */  be_nested_str_weak(distinguish),
-    /* K10  */  be_nested_str_weak(root_passcode),
-    /* K11  */  be_nested_str_weak(passcode),
-    /* K12  */  be_nested_str_weak(ipv4only),
-    /* K13  */  be_nested_str_weak(io_error),
-    /* K14  */  be_nested_str_weak(tasmota),
-    /* K15  */  be_nested_str_weak(log),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
-    /* K17  */  be_nested_str_weak(_X7C),
-    /* K18  */  be_const_int(2),
-    /* K19  */  be_nested_str_weak(random),
-    /* K20  */  be_nested_str_weak(get),
-    /* K21  */  be_const_int(0),
-    /* K22  */  be_nested_str_weak(PASSCODE_DEFAULT),
-    /* K23  */  be_nested_str_weak(save_param),
-    }),
-    be_str_weak(load_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[79]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xA802001D,  //  0002  EXBLK	0	#0021
-      0x600C0011,  //  0003  GETGBL	R3	G17
-      0x88100102,  //  0004  GETMBR	R4	R0	K2
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C100703,  //  0006  GETMET	R4	R3	K3
-      0x7C100200,  //  0007  CALL	R4	1
-      0x8C140704,  //  0008  GETMET	R5	R3	K4
-      0x7C140200,  //  0009  CALL	R5	1
-      0xA4160A00,  //  000A  IMPORT	R5	K5
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
-      0x5C200800,  //  000C  MOVE	R8	R4
-      0x7C180400,  //  000D  CALL	R6	2
-      0x8C1C0D08,  //  000E  GETMET	R7	R6	K8
-      0x58240009,  //  000F  LDCONST	R9	K9
-      0x88280107,  //  0010  GETMBR	R10	R0	K7
-      0x7C1C0600,  //  0011  CALL	R7	3
-      0x90020E07,  //  0012  SETMBR	R0	K7	R7
-      0x8C1C0D08,  //  0013  GETMET	R7	R6	K8
-      0x5824000B,  //  0014  LDCONST	R9	K11
-      0x8828010A,  //  0015  GETMBR	R10	R0	K10
-      0x7C1C0600,  //  0016  CALL	R7	3
-      0x90021407,  //  0017  SETMBR	R0	K10	R7
-      0x601C0017,  //  0018  GETGBL	R7	G23
-      0x8C200D08,  //  0019  GETMET	R8	R6	K8
-      0x5828000C,  //  001A  LDCONST	R10	K12
-      0x502C0000,  //  001B  LDBOOL	R11	0	0
-      0x7C200600,  //  001C  CALL	R8	3
-      0x7C1C0200,  //  001D  CALL	R7	1
-      0x90021807,  //  001E  SETMBR	R0	K12	R7
-      0xA8040001,  //  001F  EXBLK	1	1
-      0x70020012,  //  0020  JMP		#0034
-      0xAC0C0002,  //  0021  CATCH	R3	0	2
-      0x7002000F,  //  0022  JMP		#0033
-      0x2014070D,  //  0023  NE	R5	R3	K13
-      0x7816000C,  //  0024  JMPF	R5	#0032
-      0xB8161C00,  //  0025  GETNGBL	R5	K14
-      0x8C140B0F,  //  0026  GETMET	R5	R5	K15
-      0x601C0008,  //  0027  GETGBL	R7	G8
-      0x5C200600,  //  0028  MOVE	R8	R3
-      0x7C1C0200,  //  0029  CALL	R7	1
-      0x001E2007,  //  002A  ADD	R7	K16	R7
-      0x001C0F11,  //  002B  ADD	R7	R7	K17
-      0x60200008,  //  002C  GETGBL	R8	G8
-      0x5C240800,  //  002D  MOVE	R9	R4
-      0x7C200200,  //  002E  CALL	R8	1
-      0x001C0E08,  //  002F  ADD	R7	R7	R8
-      0x58200012,  //  0030  LDCONST	R8	K18
-      0x7C140600,  //  0031  CALL	R5	3
-      0x70020000,  //  0032  JMP		#0034
-      0xB0080000,  //  0033  RAISE	2	R0	R0
-      0x500C0000,  //  0034  LDBOOL	R3	0	0
-      0x88100107,  //  0035  GETMBR	R4	R0	K7
-      0x4C140000,  //  0036  LDNIL	R5
-      0x1C100805,  //  0037  EQ	R4	R4	R5
-      0x7812000A,  //  0038  JMPF	R4	#0044
-      0x8C100513,  //  0039  GETMET	R4	R2	K19
-      0x58180012,  //  003A  LDCONST	R6	K18
-      0x7C100400,  //  003B  CALL	R4	2
-      0x8C100914,  //  003C  GETMET	R4	R4	K20
-      0x58180015,  //  003D  LDCONST	R6	K21
-      0x581C0012,  //  003E  LDCONST	R7	K18
-      0x7C100600,  //  003F  CALL	R4	3
-      0x54160FFE,  //  0040  LDINT	R5	4095
-      0x2C100805,  //  0041  AND	R4	R4	R5
-      0x90020E04,  //  0042  SETMBR	R0	K7	R4
-      0x500C0200,  //  0043  LDBOOL	R3	1	0
-      0x8810010A,  //  0044  GETMBR	R4	R0	K10
-      0x4C140000,  //  0045  LDNIL	R5
-      0x1C100805,  //  0046  EQ	R4	R4	R5
-      0x78120002,  //  0047  JMPF	R4	#004B
-      0x88100116,  //  0048  GETMBR	R4	R0	K22
-      0x90021404,  //  0049  SETMBR	R0	K10	R4
-      0x500C0200,  //  004A  LDBOOL	R3	1	0
-      0x780E0001,  //  004B  JMPF	R3	#004E
-      0x8C100117,  //  004C  GETMET	R4	R0	K23
-      0x7C100200,  //  004D  CALL	R4	1
-      0x80000000,  //  004E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_commissioning_complete_deferred
-********************************************************************/
-be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        3,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 2]) {  /* upvals */
-          be_local_const_upval(1, 0),
-          be_local_const_upval(1, 1),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_commissioning_complete),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080001,  //  0002  GETUPV	R2	U1
-          0x7C000400,  //  0003  CALL	R0	2
-          0x80040000,  //  0004  RET	1	R0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(set_timer),
-    /* K2   */  be_const_int(0),
-    }),
-    be_str_weak(start_commissioning_complete_deferred),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x84140000,  //  0003  CLOSURE	R5	P0
-      0x7C080600,  //  0004  CALL	R2	3
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_remove_op_discovery_all_fabrics
-********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(active_fabrics),
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K5   */  be_nested_str_weak(stop_iteration),
+    /* K3   */  be_nested_str_weak(copy),
+    /* K4   */  be_nested_str_weak(reverse),
+    /* K5   */  be_nested_str_weak(get_fabric_compressed),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_nested_str_weak(_X2D),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(eth),
+    /* K10  */  be_nested_str_weak(find),
+    /* K11  */  be_nested_str_weak(up),
+    /* K12  */  be_nested_str_weak(log),
+    /* K13  */  be_nested_str_weak(format),
+    /* K14  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
+    /* K15  */  be_const_int(2),
+    /* K16  */  be_nested_str_weak(remove_service),
+    /* K17  */  be_nested_str_weak(_matter),
+    /* K18  */  be_nested_str_weak(_tcp),
+    /* K19  */  be_nested_str_weak(hostname_eth),
+    /* K20  */  be_nested_str_weak(wifi),
+    /* K21  */  be_nested_str_weak(hostname_wifi),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K23  */  be_nested_str_weak(_X7C),
     }),
-    be_str_weak(mdns_remove_op_discovery_all_fabrics),
+    be_str_weak(mdns_remove_op_discovery),
     &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000B,  //  0005  EXBLK	0	#0012
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x780E0005,  //  000A  JMPF	R3	#0011
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x780E0002,  //  000D  JMPF	R3	#0011
-      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x7001FFF3,  //  0011  JMP		#0006
-      0x58040005,  //  0012  LDCONST	R1	K5
-      0xAC040200,  //  0013  CATCH	R1	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x80000000,  //  0015  RET	0
+    ( &(const binstruction[81]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xA802003B,  //  0002  EXBLK	0	#003F
+      0x8C100302,  //  0003  GETMET	R4	R1	K2
+      0x7C100200,  //  0004  CALL	R4	1
+      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C140305,  //  0009  GETMET	R5	R1	K5
+      0x7C140200,  //  000A  CALL	R5	1
+      0x8C180B06,  //  000B  GETMET	R6	R5	K6
+      0x7C180200,  //  000C  CALL	R6	1
+      0x00180D07,  //  000D  ADD	R6	R6	K7
+      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
+      0x7C1C0200,  //  000F  CALL	R7	1
+      0x00180C07,  //  0010  ADD	R6	R6	R7
+      0xB81E1000,  //  0011  GETNGBL	R7	K8
+      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
+      0x7C1C0200,  //  0013  CALL	R7	1
+      0x8C1C0F0A,  //  0014  GETMET	R7	R7	K10
+      0x5824000B,  //  0015  LDCONST	R9	K11
+      0x7C1C0400,  //  0016  CALL	R7	2
+      0x781E000E,  //  0017  JMPF	R7	#0027
+      0xB81E1000,  //  0018  GETNGBL	R7	K8
+      0x8C1C0F0C,  //  0019  GETMET	R7	R7	K12
+      0x8C24070D,  //  001A  GETMET	R9	R3	K13
+      0x582C000E,  //  001B  LDCONST	R11	K14
+      0x58300009,  //  001C  LDCONST	R12	K9
+      0x5C340C00,  //  001D  MOVE	R13	R6
+      0x7C240800,  //  001E  CALL	R9	4
+      0x5828000F,  //  001F  LDCONST	R10	K15
+      0x7C1C0600,  //  0020  CALL	R7	3
+      0x8C1C0510,  //  0021  GETMET	R7	R2	K16
+      0x58240011,  //  0022  LDCONST	R9	K17
+      0x58280012,  //  0023  LDCONST	R10	K18
+      0x5C2C0C00,  //  0024  MOVE	R11	R6
+      0x88300113,  //  0025  GETMBR	R12	R0	K19
+      0x7C1C0A00,  //  0026  CALL	R7	5
+      0xB81E1000,  //  0027  GETNGBL	R7	K8
+      0x8C1C0F14,  //  0028  GETMET	R7	R7	K20
+      0x7C1C0200,  //  0029  CALL	R7	1
+      0x8C1C0F0A,  //  002A  GETMET	R7	R7	K10
+      0x5824000B,  //  002B  LDCONST	R9	K11
+      0x7C1C0400,  //  002C  CALL	R7	2
+      0x781E000E,  //  002D  JMPF	R7	#003D
+      0xB81E1000,  //  002E  GETNGBL	R7	K8
+      0x8C1C0F0C,  //  002F  GETMET	R7	R7	K12
+      0x8C24070D,  //  0030  GETMET	R9	R3	K13
+      0x582C000E,  //  0031  LDCONST	R11	K14
+      0x58300014,  //  0032  LDCONST	R12	K20
+      0x5C340C00,  //  0033  MOVE	R13	R6
+      0x7C240800,  //  0034  CALL	R9	4
+      0x5828000F,  //  0035  LDCONST	R10	K15
+      0x7C1C0600,  //  0036  CALL	R7	3
+      0x8C1C0510,  //  0037  GETMET	R7	R2	K16
+      0x58240011,  //  0038  LDCONST	R9	K17
+      0x58280012,  //  0039  LDCONST	R10	K18
+      0x5C2C0C00,  //  003A  MOVE	R11	R6
+      0x88300115,  //  003B  GETMBR	R12	R0	K21
+      0x7C1C0A00,  //  003C  CALL	R7	5
+      0xA8040001,  //  003D  EXBLK	1	1
+      0x70020010,  //  003E  JMP		#0050
+      0xAC100002,  //  003F  CATCH	R4	0	2
+      0x7002000D,  //  0040  JMP		#004F
+      0xB81A1000,  //  0041  GETNGBL	R6	K8
+      0x8C180D0C,  //  0042  GETMET	R6	R6	K12
+      0x60200008,  //  0043  GETGBL	R8	G8
+      0x5C240800,  //  0044  MOVE	R9	R4
+      0x7C200200,  //  0045  CALL	R8	1
+      0x00222C08,  //  0046  ADD	R8	K22	R8
+      0x00201117,  //  0047  ADD	R8	R8	K23
+      0x60240008,  //  0048  GETGBL	R9	G8
+      0x5C280A00,  //  0049  MOVE	R10	R5
+      0x7C240200,  //  004A  CALL	R9	1
+      0x00201009,  //  004B  ADD	R8	R8	R9
+      0x5824000F,  //  004C  LDCONST	R9	K15
+      0x7C180600,  //  004D  CALL	R6	3
+      0x70020000,  //  004E  JMP		#0050
+      0xB0080000,  //  004F  RAISE	2	R0	R0
+      0x80000000,  //  0050  RET	0
     })
   )
 );
@@ -3161,6 +2326,220 @@ be_local_closure(Matter_Device_msg_received,   /* name */
       0x5C200600,  //  0004  MOVE	R8	R3
       0x7C100800,  //  0005  CALL	R4	4
       0x80040800,  //  0006  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sort_distinct
+********************************************************************/
+be_local_closure(Matter_Device_sort_distinct,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Device),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_nested_str_weak(remove),
+    }),
+    be_str_weak(sort_distinct),
+    &be_const_str_solidified,
+    ( &(const binstruction[53]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x60080010,  //  0001  GETGBL	R2	G16
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x040C0701,  //  0005  SUB	R3	R3	K1
+      0x400E0203,  //  0006  CONNECT	R3	K1	R3
+      0x7C080200,  //  0007  CALL	R2	1
+      0xA8020010,  //  0008  EXBLK	0	#001A
+      0x5C0C0400,  //  0009  MOVE	R3	R2
+      0x7C0C0000,  //  000A  CALL	R3	0
+      0x94100003,  //  000B  GETIDX	R4	R0	R3
+      0x5C140600,  //  000C  MOVE	R5	R3
+      0x24180B02,  //  000D  GT	R6	R5	K2
+      0x781A0008,  //  000E  JMPF	R6	#0018
+      0x04180B01,  //  000F  SUB	R6	R5	K1
+      0x94180006,  //  0010  GETIDX	R6	R0	R6
+      0x24180C04,  //  0011  GT	R6	R6	R4
+      0x781A0004,  //  0012  JMPF	R6	#0018
+      0x04180B01,  //  0013  SUB	R6	R5	K1
+      0x94180006,  //  0014  GETIDX	R6	R0	R6
+      0x98000A06,  //  0015  SETIDX	R0	R5	R6
+      0x04140B01,  //  0016  SUB	R5	R5	K1
+      0x7001FFF4,  //  0017  JMP		#000D
+      0x98000A04,  //  0018  SETIDX	R0	R5	R4
+      0x7001FFEE,  //  0019  JMP		#0009
+      0x58080003,  //  001A  LDCONST	R2	K3
+      0xAC080200,  //  001B  CATCH	R2	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x58080001,  //  001D  LDCONST	R2	K1
+      0x600C000C,  //  001E  GETGBL	R3	G12
+      0x5C100000,  //  001F  MOVE	R4	R0
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x180C0701,  //  0021  LE	R3	R3	K1
+      0x780E0000,  //  0022  JMPF	R3	#0024
+      0x80040000,  //  0023  RET	1	R0
+      0x940C0102,  //  0024  GETIDX	R3	R0	K2
+      0x6010000C,  //  0025  GETGBL	R4	G12
+      0x5C140000,  //  0026  MOVE	R5	R0
+      0x7C100200,  //  0027  CALL	R4	1
+      0x14100404,  //  0028  LT	R4	R2	R4
+      0x78120009,  //  0029  JMPF	R4	#0034
+      0x94100002,  //  002A  GETIDX	R4	R0	R2
+      0x1C100803,  //  002B  EQ	R4	R4	R3
+      0x78120003,  //  002C  JMPF	R4	#0031
+      0x8C100104,  //  002D  GETMET	R4	R0	K4
+      0x5C180400,  //  002E  MOVE	R6	R2
+      0x7C100400,  //  002F  CALL	R4	2
+      0x70020001,  //  0030  JMP		#0033
+      0x940C0002,  //  0031  GETIDX	R3	R0	R2
+      0x00080501,  //  0032  ADD	R2	R2	K1
+      0x7001FFF0,  //  0033  JMP		#0025
+      0x80040000,  //  0034  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_mdns_announce_hostnames
+********************************************************************/
+be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_mdns_host),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[10]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x50080000,  //  0002  LDBOOL	R2	0	0
+          0x7C000400,  //  0003  CALL	R0	2
+          0xB8020200,  //  0004  GETNGBL	R0	K1
+          0x8C000102,  //  0005  GETMET	R0	R0	K2
+          0x58080003,  //  0006  LDCONST	R2	K3
+          0x580C0004,  //  0007  LDCONST	R3	K4
+          0x7C000600,  //  0008  CALL	R0	3
+          0x80000000,  //  0009  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Eth_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_mdns_host),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[10]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x50080200,  //  0002  LDBOOL	R2	1	0
+          0x7C000400,  //  0003  CALL	R0	2
+          0xB8020200,  //  0004  GETNGBL	R0	K1
+          0x8C000102,  //  0005  GETMET	R0	R0	K2
+          0x58080003,  //  0006  LDCONST	R2	K3
+          0x580C0004,  //  0007  LDCONST	R3	K4
+          0x7C000600,  //  0008  CALL	R0	3
+          0x80000000,  //  0009  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(wifi),
+    /* K2   */  be_nested_str_weak(up),
+    /* K3   */  be_nested_str_weak(_mdns_announce_hostname),
+    /* K4   */  be_nested_str_weak(add_rule),
+    /* K5   */  be_nested_str_weak(Wifi_X23Connected),
+    /* K6   */  be_nested_str_weak(matter_mdns_host),
+    /* K7   */  be_nested_str_weak(eth),
+    /* K8   */  be_nested_str_weak(Eth_X23Connected),
+    }),
+    be_str_weak(start_mdns_announce_hostnames),
+    &be_const_str_solidified,
+    ( &(const binstruction[32]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x94040302,  //  0003  GETIDX	R1	R1	K2
+      0x78060003,  //  0004  JMPF	R1	#0009
+      0x8C040103,  //  0005  GETMET	R1	R0	K3
+      0x500C0000,  //  0006  LDBOOL	R3	0	0
+      0x7C040400,  //  0007  CALL	R1	2
+      0x70020005,  //  0008  JMP		#000F
+      0xB8060000,  //  0009  GETNGBL	R1	K0
+      0x8C040304,  //  000A  GETMET	R1	R1	K4
+      0x580C0005,  //  000B  LDCONST	R3	K5
+      0x84100000,  //  000C  CLOSURE	R4	P0
+      0x58140006,  //  000D  LDCONST	R5	K6
+      0x7C040800,  //  000E  CALL	R1	4
+      0xB8060000,  //  000F  GETNGBL	R1	K0
+      0x8C040307,  //  0010  GETMET	R1	R1	K7
+      0x7C040200,  //  0011  CALL	R1	1
+      0x94040302,  //  0012  GETIDX	R1	R1	K2
+      0x78060003,  //  0013  JMPF	R1	#0018
+      0x8C040103,  //  0014  GETMET	R1	R0	K3
+      0x500C0200,  //  0015  LDBOOL	R3	1	0
+      0x7C040400,  //  0016  CALL	R1	2
+      0x70020005,  //  0017  JMP		#001E
+      0xB8060000,  //  0018  GETNGBL	R1	K0
+      0x8C040304,  //  0019  GETMET	R1	R1	K4
+      0x580C0008,  //  001A  LDCONST	R3	K8
+      0x84100001,  //  001B  CLOSURE	R4	P1
+      0x58140006,  //  001C  LDCONST	R5	K6
+      0x7C040800,  //  001D  CALL	R1	4
+      0xA0000000,  //  001E  CLOSE	R0
+      0x80000000,  //  001F  RET	0
     })
   )
 );
@@ -3392,11 +2771,11 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
 
 
 /********************************************************************
-** Solidified function: stop
+** Solidified function: load_param
 ********************************************************************/
-be_local_closure(Matter_Device_stop,   /* name */
+be_local_closure(Matter_Device_load_param,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    12,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3404,25 +2783,114 @@ be_local_closure(Matter_Device_stop,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(remove_driver),
-    /* K2   */  be_nested_str_weak(udp_server),
-    /* K3   */  be_nested_str_weak(stop),
+    ( &(const bvalue[24]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(crypto),
+    /* K2   */  be_nested_str_weak(FILENAME),
+    /* K3   */  be_nested_str_weak(read),
+    /* K4   */  be_nested_str_weak(close),
+    /* K5   */  be_nested_str_weak(json),
+    /* K6   */  be_nested_str_weak(load),
+    /* K7   */  be_nested_str_weak(root_discriminator),
+    /* K8   */  be_nested_str_weak(find),
+    /* K9   */  be_nested_str_weak(distinguish),
+    /* K10  */  be_nested_str_weak(root_passcode),
+    /* K11  */  be_nested_str_weak(passcode),
+    /* K12  */  be_nested_str_weak(ipv4only),
+    /* K13  */  be_nested_str_weak(io_error),
+    /* K14  */  be_nested_str_weak(tasmota),
+    /* K15  */  be_nested_str_weak(log),
+    /* K16  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
+    /* K17  */  be_nested_str_weak(_X7C),
+    /* K18  */  be_const_int(2),
+    /* K19  */  be_nested_str_weak(random),
+    /* K20  */  be_nested_str_weak(get),
+    /* K21  */  be_const_int(0),
+    /* K22  */  be_nested_str_weak(PASSCODE_DEFAULT),
+    /* K23  */  be_nested_str_weak(save_param),
     }),
-    be_str_weak(stop),
+    be_str_weak(load_param),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x88040102,  //  0004  GETMBR	R1	R0	K2
-      0x78060002,  //  0005  JMPF	R1	#0009
-      0x88040102,  //  0006  GETMBR	R1	R0	K2
-      0x8C040303,  //  0007  GETMET	R1	R1	K3
-      0x7C040200,  //  0008  CALL	R1	1
-      0x80000000,  //  0009  RET	0
+    ( &(const binstruction[79]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xA802001D,  //  0002  EXBLK	0	#0021
+      0x600C0011,  //  0003  GETGBL	R3	G17
+      0x88100102,  //  0004  GETMBR	R4	R0	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C100703,  //  0006  GETMET	R4	R3	K3
+      0x7C100200,  //  0007  CALL	R4	1
+      0x8C140704,  //  0008  GETMET	R5	R3	K4
+      0x7C140200,  //  0009  CALL	R5	1
+      0xA4160A00,  //  000A  IMPORT	R5	K5
+      0x8C180B06,  //  000B  GETMET	R6	R5	K6
+      0x5C200800,  //  000C  MOVE	R8	R4
+      0x7C180400,  //  000D  CALL	R6	2
+      0x8C1C0D08,  //  000E  GETMET	R7	R6	K8
+      0x58240009,  //  000F  LDCONST	R9	K9
+      0x88280107,  //  0010  GETMBR	R10	R0	K7
+      0x7C1C0600,  //  0011  CALL	R7	3
+      0x90020E07,  //  0012  SETMBR	R0	K7	R7
+      0x8C1C0D08,  //  0013  GETMET	R7	R6	K8
+      0x5824000B,  //  0014  LDCONST	R9	K11
+      0x8828010A,  //  0015  GETMBR	R10	R0	K10
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x90021407,  //  0017  SETMBR	R0	K10	R7
+      0x601C0017,  //  0018  GETGBL	R7	G23
+      0x8C200D08,  //  0019  GETMET	R8	R6	K8
+      0x5828000C,  //  001A  LDCONST	R10	K12
+      0x502C0000,  //  001B  LDBOOL	R11	0	0
+      0x7C200600,  //  001C  CALL	R8	3
+      0x7C1C0200,  //  001D  CALL	R7	1
+      0x90021807,  //  001E  SETMBR	R0	K12	R7
+      0xA8040001,  //  001F  EXBLK	1	1
+      0x70020012,  //  0020  JMP		#0034
+      0xAC0C0002,  //  0021  CATCH	R3	0	2
+      0x7002000F,  //  0022  JMP		#0033
+      0x2014070D,  //  0023  NE	R5	R3	K13
+      0x7816000C,  //  0024  JMPF	R5	#0032
+      0xB8161C00,  //  0025  GETNGBL	R5	K14
+      0x8C140B0F,  //  0026  GETMET	R5	R5	K15
+      0x601C0008,  //  0027  GETGBL	R7	G8
+      0x5C200600,  //  0028  MOVE	R8	R3
+      0x7C1C0200,  //  0029  CALL	R7	1
+      0x001E2007,  //  002A  ADD	R7	K16	R7
+      0x001C0F11,  //  002B  ADD	R7	R7	K17
+      0x60200008,  //  002C  GETGBL	R8	G8
+      0x5C240800,  //  002D  MOVE	R9	R4
+      0x7C200200,  //  002E  CALL	R8	1
+      0x001C0E08,  //  002F  ADD	R7	R7	R8
+      0x58200012,  //  0030  LDCONST	R8	K18
+      0x7C140600,  //  0031  CALL	R5	3
+      0x70020000,  //  0032  JMP		#0034
+      0xB0080000,  //  0033  RAISE	2	R0	R0
+      0x500C0000,  //  0034  LDBOOL	R3	0	0
+      0x88100107,  //  0035  GETMBR	R4	R0	K7
+      0x4C140000,  //  0036  LDNIL	R5
+      0x1C100805,  //  0037  EQ	R4	R4	R5
+      0x7812000A,  //  0038  JMPF	R4	#0044
+      0x8C100513,  //  0039  GETMET	R4	R2	K19
+      0x58180012,  //  003A  LDCONST	R6	K18
+      0x7C100400,  //  003B  CALL	R4	2
+      0x8C100914,  //  003C  GETMET	R4	R4	K20
+      0x58180015,  //  003D  LDCONST	R6	K21
+      0x581C0012,  //  003E  LDCONST	R7	K18
+      0x7C100600,  //  003F  CALL	R4	3
+      0x54160FFE,  //  0040  LDINT	R5	4095
+      0x2C100805,  //  0041  AND	R4	R4	R5
+      0x90020E04,  //  0042  SETMBR	R0	K7	R4
+      0x500C0200,  //  0043  LDBOOL	R3	1	0
+      0x8810010A,  //  0044  GETMBR	R4	R0	K10
+      0x4C140000,  //  0045  LDNIL	R5
+      0x1C100805,  //  0046  EQ	R4	R4	R5
+      0x78120002,  //  0047  JMPF	R4	#004B
+      0x88100116,  //  0048  GETMBR	R4	R0	K22
+      0x90021404,  //  0049  SETMBR	R0	K10	R4
+      0x500C0200,  //  004A  LDBOOL	R3	1	0
+      0x780E0001,  //  004B  JMPF	R3	#004E
+      0x8C100117,  //  004C  GETMET	R4	R0	K23
+      0x7C100200,  //  004D  CALL	R4	1
+      0x80000000,  //  004E  RET	0
     })
   )
 );
@@ -3430,12 +2898,536 @@ be_local_closure(Matter_Device_stop,   /* name */
 
 
 /********************************************************************
-** Solidified function: every_250ms
+** Solidified function: _compute_pbkdf
 ********************************************************************/
-be_local_closure(Matter_Device_every_250ms,   /* name */
+be_local_closure(Matter_Device__compute_pbkdf,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
+    14,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(add),
+    /* K3   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
+    /* K4   */  be_nested_str_weak(derive),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(root_w0),
+    /* K7   */  be_nested_str_weak(EC_P256),
+    /* K8   */  be_nested_str_weak(mod),
+    /* K9   */  be_nested_str_weak(root_L),
+    /* K10  */  be_nested_str_weak(public_key),
+    }),
+    be_str_weak(_compute_pbkdf),
+    &be_const_str_solidified,
+    ( &(const binstruction[41]) {  /* code */
+      0xA4120000,  //  0000  IMPORT	R4	K0
+      0xA4160200,  //  0001  IMPORT	R5	K1
+      0x60180015,  //  0002  GETGBL	R6	G21
+      0x7C180000,  //  0003  CALL	R6	0
+      0x8C180D02,  //  0004  GETMET	R6	R6	K2
+      0x5C200200,  //  0005  MOVE	R8	R1
+      0x54260003,  //  0006  LDINT	R9	4
+      0x7C180600,  //  0007  CALL	R6	3
+      0x8C1C0903,  //  0008  GETMET	R7	R4	K3
+      0x7C1C0200,  //  0009  CALL	R7	1
+      0x8C1C0F04,  //  000A  GETMET	R7	R7	K4
+      0x5C240C00,  //  000B  MOVE	R9	R6
+      0x5C280600,  //  000C  MOVE	R10	R3
+      0x5C2C0400,  //  000D  MOVE	R11	R2
+      0x5432004F,  //  000E  LDINT	R12	80
+      0x7C1C0A00,  //  000F  CALL	R7	5
+      0x54220026,  //  0010  LDINT	R8	39
+      0x40220A08,  //  0011  CONNECT	R8	K5	R8
+      0x94200E08,  //  0012  GETIDX	R8	R7	R8
+      0x54260027,  //  0013  LDINT	R9	40
+      0x542A004E,  //  0014  LDINT	R10	79
+      0x4024120A,  //  0015  CONNECT	R9	R9	R10
+      0x94240E09,  //  0016  GETIDX	R9	R7	R9
+      0x8C280907,  //  0017  GETMET	R10	R4	K7
+      0x7C280200,  //  0018  CALL	R10	1
+      0x8C281508,  //  0019  GETMET	R10	R10	K8
+      0x5C301000,  //  001A  MOVE	R12	R8
+      0x7C280400,  //  001B  CALL	R10	2
+      0x90020C0A,  //  001C  SETMBR	R0	K6	R10
+      0x8C280907,  //  001D  GETMET	R10	R4	K7
+      0x7C280200,  //  001E  CALL	R10	1
+      0x8C281508,  //  001F  GETMET	R10	R10	K8
+      0x5C301200,  //  0020  MOVE	R12	R9
+      0x7C280400,  //  0021  CALL	R10	2
+      0x8C2C0907,  //  0022  GETMET	R11	R4	K7
+      0x7C2C0200,  //  0023  CALL	R11	1
+      0x8C2C170A,  //  0024  GETMET	R11	R11	K10
+      0x5C341400,  //  0025  MOVE	R13	R10
+      0x7C2C0400,  //  0026  CALL	R11	2
+      0x9002120B,  //  0027  SETMBR	R0	K9	R11
+      0x80000000,  //  0028  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Device_invoke_request,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(endpoint),
+    /* K2   */  be_nested_str_weak(plugins),
+    /* K3   */  be_nested_str_weak(invoke_request),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(status),
+    /* K6   */  be_nested_str_weak(matter),
+    /* K7   */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+    }),
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58100000,  //  0000  LDCONST	R4	K0
+      0x88140701,  //  0001  GETMBR	R5	R3	K1
+      0x6018000C,  //  0002  GETGBL	R6	G12
+      0x881C0102,  //  0003  GETMBR	R7	R0	K2
+      0x7C180200,  //  0004  CALL	R6	1
+      0x14180806,  //  0005  LT	R6	R4	R6
+      0x781A000C,  //  0006  JMPF	R6	#0014
+      0x88180102,  //  0007  GETMBR	R6	R0	K2
+      0x94180C04,  //  0008  GETIDX	R6	R6	R4
+      0x881C0D01,  //  0009  GETMBR	R7	R6	K1
+      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
+      0x781E0005,  //  000B  JMPF	R7	#0012
+      0x8C1C0D03,  //  000C  GETMET	R7	R6	K3
+      0x5C240200,  //  000D  MOVE	R9	R1
+      0x5C280400,  //  000E  MOVE	R10	R2
+      0x5C2C0600,  //  000F  MOVE	R11	R3
+      0x7C1C0800,  //  0010  CALL	R7	4
+      0x80040E00,  //  0011  RET	1	R7
+      0x00100904,  //  0012  ADD	R4	R4	K4
+      0x7001FFED,  //  0013  JMP		#0002
+      0xB81A0C00,  //  0014  GETNGBL	R6	K6
+      0x88180D07,  //  0015  GETMBR	R6	R6	K7
+      0x900E0A06,  //  0016  SETMBR	R3	K5	R6
+      0x80000000,  //  0017  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_remove_PASE
+********************************************************************/
+be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
     1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[22]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(mdns_pase_eth),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(format),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eremove_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
+    /* K7   */  be_nested_str_weak(_matterc),
+    /* K8   */  be_nested_str_weak(_udp),
+    /* K9   */  be_nested_str_weak(commissioning_instance_eth),
+    /* K10  */  be_nested_str_weak(hostname_eth),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
+    /* K13  */  be_nested_str_weak(eth),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(remove_service),
+    /* K16  */  be_nested_str_weak(mdns_pase_wifi),
+    /* K17  */  be_nested_str_weak(commissioning_instance_wifi),
+    /* K18  */  be_nested_str_weak(hostname_wifi),
+    /* K19  */  be_nested_str_weak(wifi),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K21  */  be_nested_str_weak(_X7C),
+    }),
+    be_str_weak(mdns_remove_PASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[83]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xA802003D,  //  0002  EXBLK	0	#0041
+      0x880C0102,  //  0003  GETMBR	R3	R0	K2
+      0x780E001B,  //  0004  JMPF	R3	#0021
+      0xB80E0600,  //  0005  GETNGBL	R3	K3
+      0x8C0C0704,  //  0006  GETMET	R3	R3	K4
+      0x8C140505,  //  0007  GETMET	R5	R2	K5
+      0x581C0006,  //  0008  LDCONST	R7	K6
+      0x58200007,  //  0009  LDCONST	R8	K7
+      0x58240008,  //  000A  LDCONST	R9	K8
+      0x88280109,  //  000B  GETMBR	R10	R0	K9
+      0x882C010A,  //  000C  GETMBR	R11	R0	K10
+      0x7C140C00,  //  000D  CALL	R5	6
+      0x5818000B,  //  000E  LDCONST	R6	K11
+      0x7C0C0600,  //  000F  CALL	R3	3
+      0xB80E0600,  //  0010  GETNGBL	R3	K3
+      0x8C0C0704,  //  0011  GETMET	R3	R3	K4
+      0x8C140505,  //  0012  GETMET	R5	R2	K5
+      0x581C000C,  //  0013  LDCONST	R7	K12
+      0x5820000D,  //  0014  LDCONST	R8	K13
+      0x88240109,  //  0015  GETMBR	R9	R0	K9
+      0x7C140800,  //  0016  CALL	R5	4
+      0x5818000E,  //  0017  LDCONST	R6	K14
+      0x7C0C0600,  //  0018  CALL	R3	3
+      0x500C0000,  //  0019  LDBOOL	R3	0	0
+      0x90020403,  //  001A  SETMBR	R0	K2	R3
+      0x8C0C030F,  //  001B  GETMET	R3	R1	K15
+      0x58140007,  //  001C  LDCONST	R5	K7
+      0x58180008,  //  001D  LDCONST	R6	K8
+      0x881C0109,  //  001E  GETMBR	R7	R0	K9
+      0x8820010A,  //  001F  GETMBR	R8	R0	K10
+      0x7C0C0A00,  //  0020  CALL	R3	5
+      0x880C0110,  //  0021  GETMBR	R3	R0	K16
+      0x780E001B,  //  0022  JMPF	R3	#003F
+      0xB80E0600,  //  0023  GETNGBL	R3	K3
+      0x8C0C0704,  //  0024  GETMET	R3	R3	K4
+      0x8C140505,  //  0025  GETMET	R5	R2	K5
+      0x581C0006,  //  0026  LDCONST	R7	K6
+      0x58200007,  //  0027  LDCONST	R8	K7
+      0x58240008,  //  0028  LDCONST	R9	K8
+      0x88280111,  //  0029  GETMBR	R10	R0	K17
+      0x882C0112,  //  002A  GETMBR	R11	R0	K18
+      0x7C140C00,  //  002B  CALL	R5	6
+      0x5818000B,  //  002C  LDCONST	R6	K11
+      0x7C0C0600,  //  002D  CALL	R3	3
+      0xB80E0600,  //  002E  GETNGBL	R3	K3
+      0x8C0C0704,  //  002F  GETMET	R3	R3	K4
+      0x8C140505,  //  0030  GETMET	R5	R2	K5
+      0x581C000C,  //  0031  LDCONST	R7	K12
+      0x58200013,  //  0032  LDCONST	R8	K19
+      0x88240111,  //  0033  GETMBR	R9	R0	K17
+      0x7C140800,  //  0034  CALL	R5	4
+      0x5818000E,  //  0035  LDCONST	R6	K14
+      0x7C0C0600,  //  0036  CALL	R3	3
+      0x500C0000,  //  0037  LDBOOL	R3	0	0
+      0x90022003,  //  0038  SETMBR	R0	K16	R3
+      0x8C0C030F,  //  0039  GETMET	R3	R1	K15
+      0x58140007,  //  003A  LDCONST	R5	K7
+      0x58180008,  //  003B  LDCONST	R6	K8
+      0x881C0111,  //  003C  GETMBR	R7	R0	K17
+      0x88200112,  //  003D  GETMBR	R8	R0	K18
+      0x7C0C0A00,  //  003E  CALL	R3	5
+      0xA8040001,  //  003F  EXBLK	1	1
+      0x70020010,  //  0040  JMP		#0052
+      0xAC0C0002,  //  0041  CATCH	R3	0	2
+      0x7002000D,  //  0042  JMP		#0051
+      0xB8160600,  //  0043  GETNGBL	R5	K3
+      0x8C140B04,  //  0044  GETMET	R5	R5	K4
+      0x601C0008,  //  0045  GETGBL	R7	G8
+      0x5C200600,  //  0046  MOVE	R8	R3
+      0x7C1C0200,  //  0047  CALL	R7	1
+      0x001E2807,  //  0048  ADD	R7	K20	R7
+      0x001C0F15,  //  0049  ADD	R7	R7	K21
+      0x60200008,  //  004A  GETGBL	R8	G8
+      0x5C240800,  //  004B  MOVE	R9	R4
+      0x7C200200,  //  004C  CALL	R8	1
+      0x001C0E08,  //  004D  ADD	R7	R7	R8
+      0x5820000E,  //  004E  LDCONST	R8	K14
+      0x7C140600,  //  004F  CALL	R5	3
+      0x70020000,  //  0050  JMP		#0052
+      0xB0080000,  //  0051  RAISE	2	R0	R0
+      0x80000000,  //  0052  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_announce_op_discovery_all_fabrics
+********************************************************************/
+be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(active_fabrics),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(mdns_announce_op_discovery),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(mdns_announce_op_discovery_all_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000B,  //  0005  EXBLK	0	#0012
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x780E0005,  //  000A  JMPF	R3	#0011
+      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x780E0002,  //  000D  JMPF	R3	#0011
+      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x7001FFF3,  //  0011  JMP		#0006
+      0x58040005,  //  0012  LDCONST	R1	K5
+      0xAC040200,  //  0013  CATCH	R1	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_active_endpoints
+********************************************************************/
+be_local_closure(Matter_Device_get_active_endpoints,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins),
+    /* K1   */  be_nested_str_weak(get_endpoint),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(find),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(get_active_endpoints),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x88100100,  //  0003  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0xA8020011,  //  0005  EXBLK	0	#0018
+      0x5C100600,  //  0006  MOVE	R4	R3
+      0x7C100000,  //  0007  CALL	R4	0
+      0x8C140901,  //  0008  GETMET	R5	R4	K1
+      0x7C140200,  //  0009  CALL	R5	1
+      0x78060002,  //  000A  JMPF	R1	#000E
+      0x1C180B02,  //  000B  EQ	R6	R5	K2
+      0x781A0000,  //  000C  JMPF	R6	#000E
+      0x7001FFF7,  //  000D  JMP		#0006
+      0x8C180503,  //  000E  GETMET	R6	R2	K3
+      0x5C200A00,  //  000F  MOVE	R8	R5
+      0x7C180400,  //  0010  CALL	R6	2
+      0x4C1C0000,  //  0011  LDNIL	R7
+      0x1C180C07,  //  0012  EQ	R6	R6	R7
+      0x781A0002,  //  0013  JMPF	R6	#0017
+      0x8C180504,  //  0014  GETMET	R6	R2	K4
+      0x5C200A00,  //  0015  MOVE	R8	R5
+      0x7C180400,  //  0016  CALL	R6	2
+      0x7001FFED,  //  0017  JMP		#0006
+      0x580C0005,  //  0018  LDCONST	R3	K5
+      0xAC0C0200,  //  0019  CATCH	R3	1	0
+      0xB0080000,  //  001A  RAISE	2	R0	R0
+      0x80040400,  //  001B  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: autoconf_device
+********************************************************************/
+be_local_closure(Matter_Device_autoconf_device,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[24]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_nested_str_weak(light),
+    /* K3   */  be_nested_str_weak(get),
+    /* K4   */  be_nested_str_weak(find),
+    /* K5   */  be_nested_str_weak(channels),
+    /* K6   */  be_nested_str_weak(),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_nested_str_weak(plugins),
+    /* K9   */  be_nested_str_weak(push),
+    /* K10  */  be_nested_str_weak(matter),
+    /* K11  */  be_nested_str_weak(Plugin_Light1),
+    /* K12  */  be_nested_str_weak(tasmota),
+    /* K13  */  be_nested_str_weak(log),
+    /* K14  */  be_nested_str_weak(format),
+    /* K15  */  be_nested_str_weak(MTR_X3A_X20Endpoint_X3A_X25i_X20Light_Dimmer),
+    /* K16  */  be_const_int(2),
+    /* K17  */  be_nested_str_weak(Plugin_Light2),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20Endpoint_X3A_X25i_X20Light_CT),
+    /* K19  */  be_nested_str_weak(Plugin_Light3),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20Endpoint_X3A_X25i_X20Light_RGB),
+    /* K21  */  be_nested_str_weak(get_power),
+    /* K22  */  be_nested_str_weak(Plugin_OnOff),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20Endpoint_X3A_X25i_X20Relay__X25i),
+    }),
+    be_str_weak(autoconf_device),
+    &be_const_str_solidified,
+    ( &(const binstruction[105]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x58080001,  //  0001  LDCONST	R2	K1
+      0x500C0000,  //  0002  LDBOOL	R3	0	0
+      0xA4120400,  //  0003  IMPORT	R4	K2
+      0x8C140903,  //  0004  GETMET	R5	R4	K3
+      0x7C140200,  //  0005  CALL	R5	1
+      0x4C180000,  //  0006  LDNIL	R6
+      0x20180A06,  //  0007  NE	R6	R5	R6
+      0x781A003F,  //  0008  JMPF	R6	#0049
+      0x6018000C,  //  0009  GETGBL	R6	G12
+      0x8C1C0B04,  //  000A  GETMET	R7	R5	K4
+      0x58240005,  //  000B  LDCONST	R9	K5
+      0x58280006,  //  000C  LDCONST	R10	K6
+      0x7C1C0600,  //  000D  CALL	R7	3
+      0x7C180200,  //  000E  CALL	R6	1
+      0x241C0D07,  //  000F  GT	R7	R6	K7
+      0x781E0037,  //  0010  JMPF	R7	#0049
+      0x1C1C0D01,  //  0011  EQ	R7	R6	K1
+      0x781E0010,  //  0012  JMPF	R7	#0024
+      0x881C0108,  //  0013  GETMBR	R7	R0	K8
+      0x8C1C0F09,  //  0014  GETMET	R7	R7	K9
+      0xB8261400,  //  0015  GETNGBL	R9	K10
+      0x8C24130B,  //  0016  GETMET	R9	R9	K11
+      0x5C2C0000,  //  0017  MOVE	R11	R0
+      0x5C300400,  //  0018  MOVE	R12	R2
+      0x7C240600,  //  0019  CALL	R9	3
+      0x7C1C0400,  //  001A  CALL	R7	2
+      0xB81E1800,  //  001B  GETNGBL	R7	K12
+      0x8C1C0F0D,  //  001C  GETMET	R7	R7	K13
+      0x8C24030E,  //  001D  GETMET	R9	R1	K14
+      0x582C000F,  //  001E  LDCONST	R11	K15
+      0x5C300400,  //  001F  MOVE	R12	R2
+      0x7C240600,  //  0020  CALL	R9	3
+      0x58280010,  //  0021  LDCONST	R10	K16
+      0x7C1C0600,  //  0022  CALL	R7	3
+      0x70020022,  //  0023  JMP		#0047
+      0x1C1C0D10,  //  0024  EQ	R7	R6	K16
+      0x781E0010,  //  0025  JMPF	R7	#0037
+      0x881C0108,  //  0026  GETMBR	R7	R0	K8
+      0x8C1C0F09,  //  0027  GETMET	R7	R7	K9
+      0xB8261400,  //  0028  GETNGBL	R9	K10
+      0x8C241311,  //  0029  GETMET	R9	R9	K17
+      0x5C2C0000,  //  002A  MOVE	R11	R0
+      0x5C300400,  //  002B  MOVE	R12	R2
+      0x7C240600,  //  002C  CALL	R9	3
+      0x7C1C0400,  //  002D  CALL	R7	2
+      0xB81E1800,  //  002E  GETNGBL	R7	K12
+      0x8C1C0F0D,  //  002F  GETMET	R7	R7	K13
+      0x8C24030E,  //  0030  GETMET	R9	R1	K14
+      0x582C0012,  //  0031  LDCONST	R11	K18
+      0x5C300400,  //  0032  MOVE	R12	R2
+      0x7C240600,  //  0033  CALL	R9	3
+      0x58280010,  //  0034  LDCONST	R10	K16
+      0x7C1C0600,  //  0035  CALL	R7	3
+      0x7002000F,  //  0036  JMP		#0047
+      0x881C0108,  //  0037  GETMBR	R7	R0	K8
+      0x8C1C0F09,  //  0038  GETMET	R7	R7	K9
+      0xB8261400,  //  0039  GETNGBL	R9	K10
+      0x8C241313,  //  003A  GETMET	R9	R9	K19
+      0x5C2C0000,  //  003B  MOVE	R11	R0
+      0x5C300400,  //  003C  MOVE	R12	R2
+      0x7C240600,  //  003D  CALL	R9	3
+      0x7C1C0400,  //  003E  CALL	R7	2
+      0xB81E1800,  //  003F  GETNGBL	R7	K12
+      0x8C1C0F0D,  //  0040  GETMET	R7	R7	K13
+      0x8C24030E,  //  0041  GETMET	R9	R1	K14
+      0x582C0014,  //  0042  LDCONST	R11	K20
+      0x5C300400,  //  0043  MOVE	R12	R2
+      0x7C240600,  //  0044  CALL	R9	3
+      0x58280010,  //  0045  LDCONST	R10	K16
+      0x7C1C0600,  //  0046  CALL	R7	3
+      0x500C0200,  //  0047  LDBOOL	R3	1	0
+      0x00080501,  //  0048  ADD	R2	R2	K1
+      0x6018000C,  //  0049  GETGBL	R6	G12
+      0xB81E1800,  //  004A  GETNGBL	R7	K12
+      0x8C1C0F15,  //  004B  GETMET	R7	R7	K21
+      0x7C1C0200,  //  004C  CALL	R7	1
+      0x7C180200,  //  004D  CALL	R6	1
+      0x581C0007,  //  004E  LDCONST	R7	K7
+      0x780E0000,  //  004F  JMPF	R3	#0051
+      0x04180D01,  //  0050  SUB	R6	R6	K1
+      0x14200E06,  //  0051  LT	R8	R7	R6
+      0x78220014,  //  0052  JMPF	R8	#0068
+      0x88200108,  //  0053  GETMBR	R8	R0	K8
+      0x8C201109,  //  0054  GETMET	R8	R8	K9
+      0xB82A1400,  //  0055  GETNGBL	R10	K10
+      0x8C281516,  //  0056  GETMET	R10	R10	K22
+      0x5C300000,  //  0057  MOVE	R12	R0
+      0x5C340400,  //  0058  MOVE	R13	R2
+      0x5C380E00,  //  0059  MOVE	R14	R7
+      0x7C280800,  //  005A  CALL	R10	4
+      0x7C200400,  //  005B  CALL	R8	2
+      0xB8221800,  //  005C  GETNGBL	R8	K12
+      0x8C20110D,  //  005D  GETMET	R8	R8	K13
+      0x8C28030E,  //  005E  GETMET	R10	R1	K14
+      0x58300017,  //  005F  LDCONST	R12	K23
+      0x5C340400,  //  0060  MOVE	R13	R2
+      0x00380F01,  //  0061  ADD	R14	R7	K1
+      0x7C280800,  //  0062  CALL	R10	4
+      0x582C0010,  //  0063  LDCONST	R11	K16
+      0x7C200600,  //  0064  CALL	R8	3
+      0x001C0F01,  //  0065  ADD	R7	R7	K1
+      0x00080501,  //  0066  ADD	R2	R2	K1
+      0x7001FFE8,  //  0067  JMP		#0051
+      0x80000000,  //  0068  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: msg_send
+********************************************************************/
+be_local_closure(Matter_Device_msg_send,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    6,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -3443,159 +3435,21 @@ be_local_closure(Matter_Device_every_250ms,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(every_250ms),
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(send_response),
     }),
-    be_str_weak(every_250ms),
+    be_str_weak(msg_send),
     &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    8,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
-        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
-        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(commissioning_iterations),
-    /* K4   */  be_nested_str_weak(commissioning_discriminator),
-    /* K5   */  be_nested_str_weak(commissioning_salt),
-    /* K6   */  be_nested_str_weak(commissioning_w0),
-    /* K7   */  be_nested_str_weak(commissioning_L),
-    /* K8   */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K9   */  be_nested_str_weak(wifi),
-    /* K10  */  be_nested_str_weak(up),
-    /* K11  */  be_nested_str_weak(eth),
-    /* K12  */  be_nested_str_weak(mdns_announce_PASE),
-    /* K13  */  be_nested_str_weak(add_rule),
-    /* K14  */  be_nested_str_weak(Wifi_X23Connected),
-    /* K15  */  be_nested_str_weak(Eth_X23Connected),
-    }),
-    be_str_weak(start_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0xB8220200,  //  0000  GETNGBL	R8	K1
-      0x8C201102,  //  0001  GETMET	R8	R8	K2
-      0x7C200200,  //  0002  CALL	R8	1
-      0x542603E7,  //  0003  LDINT	R9	1000
-      0x08240209,  //  0004  MUL	R9	R1	R9
-      0x00201009,  //  0005  ADD	R8	R8	R9
-      0x90020008,  //  0006  SETMBR	R0	K0	R8
-      0x90020602,  //  0007  SETMBR	R0	K3	R2
-      0x90020803,  //  0008  SETMBR	R0	K4	R3
-      0x90020A04,  //  0009  SETMBR	R0	K5	R4
-      0x90020C05,  //  000A  SETMBR	R0	K6	R5
-      0x90020E06,  //  000B  SETMBR	R0	K7	R6
-      0x90021007,  //  000C  SETMBR	R0	K8	R7
-      0xB8220200,  //  000D  GETNGBL	R8	K1
-      0x8C201109,  //  000E  GETMET	R8	R8	K9
-      0x7C200200,  //  000F  CALL	R8	1
-      0x9420110A,  //  0010  GETIDX	R8	R8	K10
-      0x74220004,  //  0011  JMPT	R8	#0017
-      0xB8220200,  //  0012  GETNGBL	R8	K1
-      0x8C20110B,  //  0013  GETMET	R8	R8	K11
-      0x7C200200,  //  0014  CALL	R8	1
-      0x9420110A,  //  0015  GETIDX	R8	R8	K10
-      0x78220002,  //  0016  JMPF	R8	#001A
-      0x8C20010C,  //  0017  GETMET	R8	R0	K12
-      0x7C200200,  //  0018  CALL	R8	1
-      0x7002000B,  //  0019  JMP		#0026
-      0xB8220200,  //  001A  GETNGBL	R8	K1
-      0x8C20110D,  //  001B  GETMET	R8	R8	K13
-      0x5828000E,  //  001C  LDCONST	R10	K14
-      0x842C0000,  //  001D  CLOSURE	R11	P0
-      0x5830000C,  //  001E  LDCONST	R12	K12
-      0x7C200800,  //  001F  CALL	R8	4
-      0xB8220200,  //  0020  GETNGBL	R8	K1
-      0x8C20110D,  //  0021  GETMET	R8	R8	K13
-      0x5828000F,  //  0022  LDCONST	R10	K15
-      0x842C0001,  //  0023  CLOSURE	R11	P1
-      0x5830000C,  //  0024  LDCONST	R12	K12
-      0x7C200800,  //  0025  CALL	R8	4
-      0xA0000000,  //  0026  CLOSE	R0
-      0x80000000,  //  0027  RET	0
+    ( &(const binstruction[ 9]) {  /* code */
+      0x88180100,  //  0000  GETMBR	R6	R0	K0
+      0x8C180D01,  //  0001  GETMET	R6	R6	K1
+      0x5C200200,  //  0002  MOVE	R8	R1
+      0x5C240400,  //  0003  MOVE	R9	R2
+      0x5C280600,  //  0004  MOVE	R10	R3
+      0x5C2C0800,  //  0005  MOVE	R11	R4
+      0x5C300A00,  //  0006  MOVE	R12	R5
+      0x7C180C00,  //  0007  CALL	R6	6
+      0x80040C00,  //  0008  RET	1	R6
     })
   )
 );
@@ -3666,86 +3520,376 @@ be_local_closure(Matter_Device_every_second,   /* name */
 
 
 /********************************************************************
+** Solidified function: mdns_remove_op_discovery_all_fabrics
+********************************************************************/
+be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(active_fabrics),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(mdns_remove_op_discovery_all_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000B,  //  0005  EXBLK	0	#0012
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x780E0005,  //  000A  JMPF	R3	#0011
+      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x780E0002,  //  000D  JMPF	R3	#0011
+      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x7001FFF3,  //  0011  JMP		#0006
+      0x58040005,  //  0012  LDCONST	R1	K5
+      0xAC040200,  //  0013  CATCH	R1	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_announce_op_discovery
+********************************************************************/
+be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[29]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(copy),
+    /* K4   */  be_nested_str_weak(reverse),
+    /* K5   */  be_nested_str_weak(get_fabric_compressed),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_nested_str_weak(_X2D),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(log),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_nested_str_weak(eth),
+    /* K13  */  be_nested_str_weak(find),
+    /* K14  */  be_nested_str_weak(up),
+    /* K15  */  be_nested_str_weak(format),
+    /* K16  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K17  */  be_nested_str_weak(hostname_eth),
+    /* K18  */  be_const_int(3),
+    /* K19  */  be_nested_str_weak(add_service),
+    /* K20  */  be_nested_str_weak(_matter),
+    /* K21  */  be_nested_str_weak(_tcp),
+    /* K22  */  be_nested_str_weak(_I),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
+    /* K24  */  be_nested_str_weak(add_subtype),
+    /* K25  */  be_nested_str_weak(wifi),
+    /* K26  */  be_nested_str_weak(hostname_wifi),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K28  */  be_nested_str_weak(_X7C),
+    }),
+    be_str_weak(mdns_announce_op_discovery),
+    &be_const_str_solidified,
+    ( &(const binstruction[122]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xA8020064,  //  0002  EXBLK	0	#0068
+      0x8C100302,  //  0003  GETMET	R4	R1	K2
+      0x7C100200,  //  0004  CALL	R4	1
+      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C140305,  //  0009  GETMET	R5	R1	K5
+      0x7C140200,  //  000A  CALL	R5	1
+      0x8C180B06,  //  000B  GETMET	R6	R5	K6
+      0x7C180200,  //  000C  CALL	R6	1
+      0x00180D07,  //  000D  ADD	R6	R6	K7
+      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
+      0x7C1C0200,  //  000F  CALL	R7	1
+      0x00180C07,  //  0010  ADD	R6	R6	R7
+      0xB81E1000,  //  0011  GETNGBL	R7	K8
+      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
+      0x00261406,  //  0013  ADD	R9	K10	R6
+      0x5828000B,  //  0014  LDCONST	R10	K11
+      0x7C1C0600,  //  0015  CALL	R7	3
+      0xB81E1000,  //  0016  GETNGBL	R7	K8
+      0x8C1C0F0C,  //  0017  GETMET	R7	R7	K12
+      0x7C1C0200,  //  0018  CALL	R7	1
+      0x8C1C0F0D,  //  0019  GETMET	R7	R7	K13
+      0x5824000E,  //  001A  LDCONST	R9	K14
+      0x7C1C0400,  //  001B  CALL	R7	2
+      0x781E0020,  //  001C  JMPF	R7	#003E
+      0xB81E1000,  //  001D  GETNGBL	R7	K8
+      0x8C1C0F09,  //  001E  GETMET	R7	R7	K9
+      0x8C24070F,  //  001F  GETMET	R9	R3	K15
+      0x582C0010,  //  0020  LDCONST	R11	K16
+      0x5830000C,  //  0021  LDCONST	R12	K12
+      0x5C340C00,  //  0022  MOVE	R13	R6
+      0x88380111,  //  0023  GETMBR	R14	R0	K17
+      0x7C240A00,  //  0024  CALL	R9	5
+      0x58280012,  //  0025  LDCONST	R10	K18
+      0x7C1C0600,  //  0026  CALL	R7	3
+      0x8C1C0513,  //  0027  GETMET	R7	R2	K19
+      0x58240014,  //  0028  LDCONST	R9	K20
+      0x58280015,  //  0029  LDCONST	R10	K21
+      0x542E15A3,  //  002A  LDINT	R11	5540
+      0x4C300000,  //  002B  LDNIL	R12
+      0x5C340C00,  //  002C  MOVE	R13	R6
+      0x88380111,  //  002D  GETMBR	R14	R0	K17
+      0x7C1C0E00,  //  002E  CALL	R7	7
+      0x8C1C0B06,  //  002F  GETMET	R7	R5	K6
+      0x7C1C0200,  //  0030  CALL	R7	1
+      0x001E2C07,  //  0031  ADD	R7	K22	R7
+      0xB8221000,  //  0032  GETNGBL	R8	K8
+      0x8C201109,  //  0033  GETMET	R8	R8	K9
+      0x002A2E07,  //  0034  ADD	R10	K23	R7
+      0x582C0012,  //  0035  LDCONST	R11	K18
+      0x7C200600,  //  0036  CALL	R8	3
+      0x8C200518,  //  0037  GETMET	R8	R2	K24
+      0x58280014,  //  0038  LDCONST	R10	K20
+      0x582C0015,  //  0039  LDCONST	R11	K21
+      0x5C300C00,  //  003A  MOVE	R12	R6
+      0x88340111,  //  003B  GETMBR	R13	R0	K17
+      0x5C380E00,  //  003C  MOVE	R14	R7
+      0x7C200C00,  //  003D  CALL	R8	6
+      0xB81E1000,  //  003E  GETNGBL	R7	K8
+      0x8C1C0F19,  //  003F  GETMET	R7	R7	K25
+      0x7C1C0200,  //  0040  CALL	R7	1
+      0x8C1C0F0D,  //  0041  GETMET	R7	R7	K13
+      0x5824000E,  //  0042  LDCONST	R9	K14
+      0x7C1C0400,  //  0043  CALL	R7	2
+      0x781E0020,  //  0044  JMPF	R7	#0066
+      0xB81E1000,  //  0045  GETNGBL	R7	K8
+      0x8C1C0F09,  //  0046  GETMET	R7	R7	K9
+      0x8C24070F,  //  0047  GETMET	R9	R3	K15
+      0x582C0010,  //  0048  LDCONST	R11	K16
+      0x58300019,  //  0049  LDCONST	R12	K25
+      0x5C340C00,  //  004A  MOVE	R13	R6
+      0x8838011A,  //  004B  GETMBR	R14	R0	K26
+      0x7C240A00,  //  004C  CALL	R9	5
+      0x58280012,  //  004D  LDCONST	R10	K18
+      0x7C1C0600,  //  004E  CALL	R7	3
+      0x8C1C0513,  //  004F  GETMET	R7	R2	K19
+      0x58240014,  //  0050  LDCONST	R9	K20
+      0x58280015,  //  0051  LDCONST	R10	K21
+      0x542E15A3,  //  0052  LDINT	R11	5540
+      0x4C300000,  //  0053  LDNIL	R12
+      0x5C340C00,  //  0054  MOVE	R13	R6
+      0x8838011A,  //  0055  GETMBR	R14	R0	K26
+      0x7C1C0E00,  //  0056  CALL	R7	7
+      0x8C1C0B06,  //  0057  GETMET	R7	R5	K6
+      0x7C1C0200,  //  0058  CALL	R7	1
+      0x001E2C07,  //  0059  ADD	R7	K22	R7
+      0xB8221000,  //  005A  GETNGBL	R8	K8
+      0x8C201109,  //  005B  GETMET	R8	R8	K9
+      0x002A2E07,  //  005C  ADD	R10	K23	R7
+      0x582C0012,  //  005D  LDCONST	R11	K18
+      0x7C200600,  //  005E  CALL	R8	3
+      0x8C200518,  //  005F  GETMET	R8	R2	K24
+      0x58280014,  //  0060  LDCONST	R10	K20
+      0x582C0015,  //  0061  LDCONST	R11	K21
+      0x5C300C00,  //  0062  MOVE	R12	R6
+      0x8834011A,  //  0063  GETMBR	R13	R0	K26
+      0x5C380E00,  //  0064  MOVE	R14	R7
+      0x7C200C00,  //  0065  CALL	R8	6
+      0xA8040001,  //  0066  EXBLK	1	1
+      0x70020010,  //  0067  JMP		#0079
+      0xAC100002,  //  0068  CATCH	R4	0	2
+      0x7002000D,  //  0069  JMP		#0078
+      0xB81A1000,  //  006A  GETNGBL	R6	K8
+      0x8C180D09,  //  006B  GETMET	R6	R6	K9
+      0x60200008,  //  006C  GETGBL	R8	G8
+      0x5C240800,  //  006D  MOVE	R9	R4
+      0x7C200200,  //  006E  CALL	R8	1
+      0x00223608,  //  006F  ADD	R8	K27	R8
+      0x0020111C,  //  0070  ADD	R8	R8	K28
+      0x60240008,  //  0071  GETGBL	R9	G8
+      0x5C280A00,  //  0072  MOVE	R10	R5
+      0x7C240200,  //  0073  CALL	R9	1
+      0x00201009,  //  0074  ADD	R8	R8	R9
+      0x5824000B,  //  0075  LDCONST	R9	K11
+      0x7C180600,  //  0076  CALL	R6	3
+      0x70020000,  //  0077  JMP		#0079
+      0xB0080000,  //  0078  RAISE	2	R0	R0
+      0x80000000,  //  0079  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_commissioning_complete_deferred
+********************************************************************/
+be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        3,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 2]) {  /* upvals */
+          be_local_const_upval(1, 0),
+          be_local_const_upval(1, 1),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start_commissioning_complete),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x68080001,  //  0002  GETUPV	R2	U1
+          0x7C000400,  //  0003  CALL	R0	2
+          0x80040000,  //  0004  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(set_timer),
+    /* K2   */  be_const_int(0),
+    }),
+    be_str_weak(start_commissioning_complete_deferred),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x84140000,  //  0003  CLOSURE	R5	P0
+      0x7C080600,  //  0004  CALL	R2	3
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_Device
 ********************************************************************/
 be_local_class(Matter_Device,
-    27,
+    28,
     NULL,
-    be_nested_map(73,
+    be_nested_map(76,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(every_second, 44), be_const_closure(Matter_Device_every_second_closure) },
-        { be_const_key_weak(plugins, 71), be_const_var(0) },
-        { be_const_key_weak(commissioning_open, 46), be_const_var(5) },
-        { be_const_key_weak(start_basic_commissioning, 21), be_const_closure(Matter_Device_start_basic_commissioning_closure) },
-        { be_const_key_weak(mdns_announce_op_discovery, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_closure) },
-        { be_const_key_weak(get_active_endpoints, 3), be_const_closure(Matter_Device_get_active_endpoints_closure) },
-        { be_const_key_weak(_init_basic_commissioning, 47), be_const_closure(Matter_Device__init_basic_commissioning_closure) },
-        { be_const_key_weak(mdns_remove_op_discovery, 50), be_const_closure(Matter_Device_mdns_remove_op_discovery_closure) },
-        { be_const_key_weak(mdns_announce_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics_closure) },
-        { be_const_key_weak(mdns_remove_PASE, 22), be_const_closure(Matter_Device_mdns_remove_PASE_closure) },
-        { be_const_key_weak(start_operational_discovery_deferred, -1), be_const_closure(Matter_Device_start_operational_discovery_deferred_closure) },
-        { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_Device_every_250ms_closure) },
-        { be_const_key_weak(save_before_restart, 41), be_const_closure(Matter_Device_save_before_restart_closure) },
-        { be_const_key_weak(start_mdns_announce_hostnames, -1), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
-        { be_const_key_weak(mdns_pase_wifi, -1), be_const_var(19) },
-        { be_const_key_weak(commissioning_w0, -1), be_const_var(9) },
-        { be_const_key_weak(_mdns_announce_hostname, -1), be_const_closure(Matter_Device__mdns_announce_hostname_closure) },
-        { be_const_key_weak(commissioning_discriminator, 39), be_const_var(7) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Device_invoke_request_closure) },
-        { be_const_key_weak(remove_fabric, -1), be_const_closure(Matter_Device_remove_fabric_closure) },
-        { be_const_key_weak(msg_received, 25), be_const_closure(Matter_Device_msg_received_closure) },
-        { be_const_key_weak(mdns_remove_op_discovery_all_fabrics, 59), be_const_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics_closure) },
-        { be_const_key_weak(_compute_pbkdf, -1), be_const_closure(Matter_Device__compute_pbkdf_closure) },
-        { be_const_key_weak(load_param, 38), be_const_closure(Matter_Device_load_param_closure) },
-        { be_const_key_weak(root_salt, 51), be_const_var(24) },
-        { be_const_key_weak(save_param, -1), be_const_closure(Matter_Device_save_param_closure) },
-        { be_const_key_weak(sessions, -1), be_const_var(3) },
-        { be_const_key_weak(start_operational_discovery, -1), be_const_closure(Matter_Device_start_operational_discovery_closure) },
-        { be_const_key_weak(commissioning_L, -1), be_const_var(10) },
-        { be_const_key_weak(udp_server, 14), be_const_var(1) },
-        { be_const_key_weak(PASE_TIMEOUT, 55), be_const_int(600) },
         { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
-        { be_const_key_weak(sort_distinct, 65), be_const_static_closure(Matter_Device_sort_distinct_closure) },
-        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
-        { be_const_key_weak(mdns_announce_PASE, -1), be_const_closure(Matter_Device_mdns_announce_PASE_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Device_init_closure) },
-        { be_const_key_weak(hostname_wifi, 20), be_const_var(14) },
-        { be_const_key_weak(compute_qrcode_content, 26), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
-        { be_const_key_weak(stop_basic_commissioning, 42), be_const_closure(Matter_Device_stop_basic_commissioning_closure) },
-        { be_const_key_weak(root_w0, -1), be_const_var(25) },
-        { be_const_key_weak(is_root_commissioning_open, 57), be_const_closure(Matter_Device_is_root_commissioning_open_closure) },
-        { be_const_key_weak(ui, 35), be_const_var(4) },
-        { be_const_key_weak(PASSCODE_DEFAULT, -1), be_const_int(20202021) },
-        { be_const_key_weak(productid, 54), be_const_var(17) },
-        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
-        { be_const_key_weak(commissioning_admin_fabric, 33), be_const_var(11) },
-        { be_const_key_weak(received_ack, -1), be_const_closure(Matter_Device_received_ack_closure) },
-        { be_const_key_weak(_start_udp, 10), be_const_closure(Matter_Device__start_udp_closure) },
-        { be_const_key_weak(message_handler, -1), be_const_var(2) },
-        { be_const_key_weak(commissioning_iterations, -1), be_const_var(6) },
-        { be_const_key_weak(commissioning_instance_eth, -1), be_const_var(13) },
-        { be_const_key_weak(start_commissioning_complete, -1), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
-        { be_const_key_weak(root_passcode, -1), be_const_var(21) },
-        { be_const_key_weak(vendorid, -1), be_const_var(16) },
-        { be_const_key_weak(mdns_pase_eth, 66), be_const_var(18) },
+        { be_const_key_weak(start_operational_discovery, 57), be_const_closure(Matter_Device_start_operational_discovery_closure) },
+        { be_const_key_weak(root_L, 14), be_const_var(27) },
+        { be_const_key_weak(commissioning_discriminator, 10), be_const_var(8) },
+        { be_const_key_weak(FILENAME, 41), be_nested_str_weak(_matter_device_X2Ejson) },
+        { be_const_key_weak(_init_basic_commissioning, -1), be_const_closure(Matter_Device__init_basic_commissioning_closure) },
         { be_const_key_weak(compute_manual_pairing_code, -1), be_const_closure(Matter_Device_compute_manual_pairing_code_closure) },
-        { be_const_key_weak(start_root_basic_commissioning, -1), be_const_closure(Matter_Device_start_root_basic_commissioning_closure) },
-        { be_const_key_weak(process_attribute_expansion, -1), be_const_closure(Matter_Device_process_attribute_expansion_closure) },
-        { be_const_key_weak(root_L, 11), be_const_var(26) },
-        { be_const_key_weak(PBKDF_ITERATIONS, -1), be_const_int(1000) },
-        { be_const_key_weak(root_iterations, 31), be_const_var(23) },
-        { be_const_key_weak(commissioning_salt, -1), be_const_var(8) },
-        { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Device_attribute_updated_closure) },
-        { be_const_key_weak(root_discriminator, 23), be_const_var(20) },
-        { be_const_key_weak(start_commissioning_complete_deferred, -1), be_const_closure(Matter_Device_start_commissioning_complete_deferred_closure) },
-        { be_const_key_weak(hostname_eth, 69), be_const_var(15) },
-        { be_const_key_weak(commissioning_instance_wifi, -1), be_const_var(12) },
-        { be_const_key_weak(is_commissioning_open, 16), be_const_closure(Matter_Device_is_commissioning_open_closure) },
-        { be_const_key_weak(stop, -1), be_const_closure(Matter_Device_stop_closure) },
         { be_const_key_weak(_trigger_read_sensors, -1), be_const_closure(Matter_Device__trigger_read_sensors_closure) },
-        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
-        { be_const_key_weak(ipv4only, -1), be_const_var(22) },
-        { be_const_key_weak(msg_send, 0), be_const_closure(Matter_Device_msg_send_closure) },
+        { be_const_key_weak(hostname_eth, -1), be_const_var(16) },
+        { be_const_key_weak(productid, 44), be_const_var(18) },
+        { be_const_key_weak(start, -1), be_const_closure(Matter_Device_start_closure) },
+        { be_const_key_weak(root_salt, -1), be_const_var(25) },
+        { be_const_key_weak(mdns_announce_op_discovery, 65), be_const_closure(Matter_Device_mdns_announce_op_discovery_closure) },
+        { be_const_key_weak(start_operational_discovery_deferred, -1), be_const_closure(Matter_Device_start_operational_discovery_deferred_closure) },
+        { be_const_key_weak(mdns_remove_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics_closure) },
+        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
+        { be_const_key_weak(compute_qrcode_content, 71), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
+        { be_const_key_weak(msg_send, 42), be_const_closure(Matter_Device_msg_send_closure) },
+        { be_const_key_weak(commissioning_instance_eth, -1), be_const_var(14) },
+        { be_const_key_weak(PBKDF_ITERATIONS, 16), be_const_int(1000) },
+        { be_const_key_weak(received_ack, -1), be_const_closure(Matter_Device_received_ack_closure) },
+        { be_const_key_weak(start_root_basic_commissioning, -1), be_const_closure(Matter_Device_start_root_basic_commissioning_closure) },
+        { be_const_key_weak(save_before_restart, -1), be_const_closure(Matter_Device_save_before_restart_closure) },
+        { be_const_key_weak(plugins, 40), be_const_var(1) },
+        { be_const_key_weak(commissioning_admin_fabric, -1), be_const_var(12) },
+        { be_const_key_weak(commissioning_iterations, 17), be_const_var(7) },
+        { be_const_key_weak(root_passcode, 63), be_const_var(22) },
+        { be_const_key_weak(mdns_pase_eth, 36), be_const_var(19) },
+        { be_const_key_weak(autoconf_device, 33), be_const_closure(Matter_Device_autoconf_device_closure) },
+        { be_const_key_weak(mdns_announce_PASE, -1), be_const_closure(Matter_Device_mdns_announce_PASE_closure) },
+        { be_const_key_weak(get_active_endpoints, 29), be_const_closure(Matter_Device_get_active_endpoints_closure) },
+        { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Device_attribute_updated_closure) },
+        { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_Device_every_250ms_closure) },
+        { be_const_key_weak(mdns_announce_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics_closure) },
+        { be_const_key_weak(save_param, 12), be_const_closure(Matter_Device_save_param_closure) },
+        { be_const_key_weak(process_attribute_expansion, 30), be_const_closure(Matter_Device_process_attribute_expansion_closure) },
+        { be_const_key_weak(commissioning_L, -1), be_const_var(11) },
+        { be_const_key_weak(root_w0, -1), be_const_var(26) },
+        { be_const_key_weak(started, 64), be_const_var(0) },
+        { be_const_key_weak(message_handler, -1), be_const_var(3) },
+        { be_const_key_weak(PASSCODE_DEFAULT, -1), be_const_int(20202021) },
+        { be_const_key_weak(stop_basic_commissioning, -1), be_const_closure(Matter_Device_stop_basic_commissioning_closure) },
+        { be_const_key_weak(_compute_pbkdf, -1), be_const_closure(Matter_Device__compute_pbkdf_closure) },
+        { be_const_key_weak(is_root_commissioning_open, -1), be_const_closure(Matter_Device_is_root_commissioning_open_closure) },
+        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
+        { be_const_key_weak(commissioning_open, -1), be_const_var(6) },
+        { be_const_key_weak(commissioning_instance_wifi, 60), be_const_var(13) },
+        { be_const_key_weak(mdns_remove_op_discovery, 62), be_const_closure(Matter_Device_mdns_remove_op_discovery_closure) },
+        { be_const_key_weak(sessions, -1), be_const_var(4) },
+        { be_const_key_weak(stop, -1), be_const_closure(Matter_Device_stop_closure) },
+        { be_const_key_weak(root_discriminator, -1), be_const_var(21) },
+        { be_const_key_weak(init, 55), be_const_closure(Matter_Device_init_closure) },
+        { be_const_key_weak(msg_received, -1), be_const_closure(Matter_Device_msg_received_closure) },
+        { be_const_key_weak(commissioning_salt, -1), be_const_var(9) },
+        { be_const_key_weak(sort_distinct, -1), be_const_static_closure(Matter_Device_sort_distinct_closure) },
+        { be_const_key_weak(ui, 47), be_const_var(5) },
+        { be_const_key_weak(hostname_wifi, -1), be_const_var(15) },
+        { be_const_key_weak(start_mdns_announce_hostnames, 13), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
+        { be_const_key_weak(_mdns_announce_hostname, -1), be_const_closure(Matter_Device__mdns_announce_hostname_closure) },
+        { be_const_key_weak(load_param, -1), be_const_closure(Matter_Device_load_param_closure) },
+        { be_const_key_weak(vendorid, 73), be_const_var(17) },
+        { be_const_key_weak(mdns_pase_wifi, -1), be_const_var(20) },
+        { be_const_key_weak(start_commissioning_complete, -1), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
+        { be_const_key_weak(commissioning_w0, 68), be_const_var(10) },
+        { be_const_key_weak(start_basic_commissioning, -1), be_const_closure(Matter_Device_start_basic_commissioning_closure) },
+        { be_const_key_weak(PASE_TIMEOUT, -1), be_const_int(600) },
+        { be_const_key_weak(udp_server, -1), be_const_var(2) },
+        { be_const_key_weak(invoke_request, 28), be_const_closure(Matter_Device_invoke_request_closure) },
+        { be_const_key_weak(_start_udp, -1), be_const_closure(Matter_Device__start_udp_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Device_every_second_closure) },
+        { be_const_key_weak(mdns_remove_PASE, 15), be_const_closure(Matter_Device_mdns_remove_PASE_closure) },
+        { be_const_key_weak(remove_fabric, -1), be_const_closure(Matter_Device_remove_fabric_closure) },
+        { be_const_key_weak(ipv4only, -1), be_const_var(23) },
+        { be_const_key_weak(root_iterations, -1), be_const_var(24) },
+        { be_const_key_weak(is_commissioning_open, 11), be_const_closure(Matter_Device_is_commissioning_open_closure) },
+        { be_const_key_weak(start_commissioning_complete_deferred, -1), be_const_closure(Matter_Device_start_commissioning_complete_deferred_closure) },
     })),
     be_str_weak(Matter_Device)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -1405,7 +1405,7 @@ be_local_closure(Matter_IM_process_incoming,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_process_timed_request,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    12,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1413,7 +1413,7 @@ be_local_closure(Matter_IM_process_timed_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
+    ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TimedRequestMessage),
@@ -1423,19 +1423,17 @@ be_local_closure(Matter_IM_process_timed_request,   /* name */
     /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20TimedRequestMessage_X3D),
     /* K7   */  be_const_int(3),
     /* K8   */  be_nested_str_weak(format),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20TimedRequest_X3D_X25i_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20TimedRequest_X3D_X25i),
     /* K10  */  be_nested_str_weak(session),
     /* K11  */  be_nested_str_weak(local_session_id),
     /* K12  */  be_nested_str_weak(timeout),
-    /* K13  */  be_nested_str_weak(remote_ip),
-    /* K14  */  be_nested_str_weak(remote_port),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_nested_str_weak(send_status),
-    /* K17  */  be_nested_str_weak(SUCCESS),
+    /* K13  */  be_const_int(2),
+    /* K14  */  be_nested_str_weak(send_status),
+    /* K15  */  be_nested_str_weak(SUCCESS),
     }),
     be_str_weak(process_timed_request),
     &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
+    ( &(const binstruction[32]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0xB8120200,  //  0001  GETNGBL	R4	K1
       0x8C100902,  //  0002  GETMET	R4	R4	K2
@@ -1458,18 +1456,16 @@ be_local_closure(Matter_IM_process_timed_request,   /* name */
       0x8828030A,  //  0013  GETMBR	R10	R1	K10
       0x8828150B,  //  0014  GETMBR	R10	R10	K11
       0x882C090C,  //  0015  GETMBR	R11	R4	K12
-      0x8830030D,  //  0016  GETMBR	R12	R1	K13
-      0x8834030E,  //  0017  GETMBR	R13	R1	K14
-      0x7C1C0C00,  //  0018  CALL	R7	6
-      0x5820000F,  //  0019  LDCONST	R8	K15
-      0x7C140600,  //  001A  CALL	R5	3
-      0x8C140110,  //  001B  GETMET	R5	R0	K16
-      0x5C1C0200,  //  001C  MOVE	R7	R1
-      0xB8220200,  //  001D  GETNGBL	R8	K1
-      0x88201111,  //  001E  GETMBR	R8	R8	K17
-      0x7C140600,  //  001F  CALL	R5	3
-      0x50140200,  //  0020  LDBOOL	R5	1	0
-      0x80040A00,  //  0021  RET	1	R5
+      0x7C1C0800,  //  0016  CALL	R7	4
+      0x5820000D,  //  0017  LDCONST	R8	K13
+      0x7C140600,  //  0018  CALL	R5	3
+      0x8C14010E,  //  0019  GETMET	R5	R0	K14
+      0x5C1C0200,  //  001A  MOVE	R7	R1
+      0xB8220200,  //  001B  GETNGBL	R8	K1
+      0x8820110F,  //  001C  GETMBR	R8	R8	K15
+      0x7C140600,  //  001D  CALL	R5	3
+      0x50140200,  //  001E  LDBOOL	R5	1	0
+      0x80040A00,  //  001F  RET	1	R5
     })
   )
 );
@@ -1548,7 +1544,7 @@ be_local_closure(Matter_IM_every_250ms,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_process_invoke_request,   /* name */
   be_nested_proto(
-    20,                          /* nstack */
+    21,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1576,17 +1572,17 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
     /* K16  */  be_nested_str_weak(status),
     /* K17  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
     /* K18  */  be_nested_str_weak(get_command_name),
-    /* K19  */  be_nested_str_weak(format),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K19  */  be_nested_str_weak(device),
+    /* K20  */  be_nested_str_weak(invoke_request),
     /* K21  */  be_nested_str_weak(session),
-    /* K22  */  be_nested_str_weak(local_session_id),
-    /* K23  */  be_nested_str_weak(),
-    /* K24  */  be_nested_str_weak(remote_ip),
-    /* K25  */  be_nested_str_weak(remote_port),
-    /* K26  */  be_const_int(2),
-    /* K27  */  be_nested_str_weak(device),
-    /* K28  */  be_nested_str_weak(invoke_request),
-    /* K29  */  be_nested_str_weak(command_fields),
+    /* K22  */  be_nested_str_weak(command_fields),
+    /* K23  */  be_nested_str_weak(_X28),
+    /* K24  */  be_nested_str_weak(_X29_X20),
+    /* K25  */  be_nested_str_weak(),
+    /* K26  */  be_nested_str_weak(format),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20_X25s),
+    /* K28  */  be_nested_str_weak(local_session_id),
+    /* K29  */  be_const_int(2),
     /* K30  */  be_nested_str_weak(InvokeResponseIB),
     /* K31  */  be_nested_str_weak(SUCCESS),
     /* K32  */  be_nested_str_weak(CommandStatusIB),
@@ -1610,7 +1606,7 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
     }),
     be_str_weak(process_invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[288]) {  /* code */
+    ( &(const binstruction[300]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0xB8120200,  //  0001  GETNGBL	R4	K1
       0x8C100902,  //  0002  GETMET	R4	R4	K2
@@ -1629,7 +1625,7 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
       0x88180B08,  //  000F  GETMBR	R6	R5	K8
       0x4C1C0000,  //  0010  LDNIL	R7
       0x20180C07,  //  0011  NE	R6	R6	R7
-      0x781A010B,  //  0012  JMPF	R6	#011F
+      0x781A0117,  //  0012  JMPF	R6	#012B
       0xB81A0800,  //  0013  GETNGBL	R6	K4
       0x8C180D09,  //  0014  GETMET	R6	R6	K9
       0x7C180200,  //  0015  CALL	R6	1
@@ -1641,7 +1637,7 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
       0x601C0010,  //  001B  GETGBL	R7	G16
       0x88200B08,  //  001C  GETMBR	R8	R5	K8
       0x7C1C0200,  //  001D  CALL	R7	1
-      0xA80200D5,  //  001E  EXBLK	0	#00F5
+      0xA80200E1,  //  001E  EXBLK	0	#0101
       0x5C200E00,  //  001F  MOVE	R8	R7
       0x7C200000,  //  0020  CALL	R8	0
       0x8824110D,  //  0021  GETMBR	R9	R8	K13
@@ -1661,244 +1657,256 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
       0x882C090E,  //  002F  GETMBR	R11	R4	K14
       0x8830090F,  //  0030  GETMBR	R12	R4	K15
       0x7C240600,  //  0031  CALL	R9	3
-      0xB82A0200,  //  0032  GETNGBL	R10	K1
-      0x8C281502,  //  0033  GETMET	R10	R10	K2
-      0x8C300713,  //  0034  GETMET	R12	R3	K19
-      0x58380014,  //  0035  LDCONST	R14	K20
-      0x883C0315,  //  0036  GETMBR	R15	R1	K21
-      0x883C1F16,  //  0037  GETMBR	R15	R15	K22
-      0x60400008,  //  0038  GETGBL	R16	G8
-      0x5C440800,  //  0039  MOVE	R17	R4
-      0x7C400200,  //  003A  CALL	R16	1
-      0x78260001,  //  003B  JMPF	R9	#003E
-      0x5C441200,  //  003C  MOVE	R17	R9
-      0x70020000,  //  003D  JMP		#003F
-      0x58440017,  //  003E  LDCONST	R17	K23
-      0x88480318,  //  003F  GETMBR	R18	R1	K24
-      0x884C0319,  //  0040  GETMBR	R19	R1	K25
-      0x7C300E00,  //  0041  CALL	R12	7
-      0x5834001A,  //  0042  LDCONST	R13	K26
-      0x7C280600,  //  0043  CALL	R10	3
-      0x8828011B,  //  0044  GETMBR	R10	R0	K27
-      0x8C28151C,  //  0045  GETMET	R10	R10	K28
-      0x88300315,  //  0046  GETMBR	R12	R1	K21
-      0x8834111D,  //  0047  GETMBR	R13	R8	K29
-      0x5C380800,  //  0048  MOVE	R14	R4
-      0x7C280800,  //  0049  CALL	R10	4
-      0xB82E0800,  //  004A  GETNGBL	R11	K4
-      0x8C2C171E,  //  004B  GETMET	R11	R11	K30
-      0x7C2C0200,  //  004C  CALL	R11	1
-      0x50300200,  //  004D  LDBOOL	R12	1	0
-      0x1C30140C,  //  004E  EQ	R12	R10	R12
-      0x74320004,  //  004F  JMPT	R12	#0055
-      0x88300910,  //  0050  GETMBR	R12	R4	K16
-      0xB8360800,  //  0051  GETNGBL	R13	K4
-      0x88341B1F,  //  0052  GETMBR	R13	R13	K31
-      0x1C30180D,  //  0053  EQ	R12	R12	R13
-      0x7832002D,  //  0054  JMPF	R12	#0083
-      0xB8320800,  //  0055  GETNGBL	R12	K4
-      0x8C301920,  //  0056  GETMET	R12	R12	K32
-      0x7C300200,  //  0057  CALL	R12	1
-      0x902E200C,  //  0058  SETMBR	R11	K16	R12
-      0x88301710,  //  0059  GETMBR	R12	R11	K16
-      0xB8360800,  //  005A  GETNGBL	R13	K4
-      0x8C341B21,  //  005B  GETMET	R13	R13	K33
-      0x7C340200,  //  005C  CALL	R13	1
-      0x90321A0D,  //  005D  SETMBR	R12	K13	R13
-      0x88301710,  //  005E  GETMBR	R12	R11	K16
-      0x8830190D,  //  005F  GETMBR	R12	R12	K13
-      0x8834090C,  //  0060  GETMBR	R13	R4	K12
-      0x9032180D,  //  0061  SETMBR	R12	K12	R13
-      0x88301710,  //  0062  GETMBR	R12	R11	K16
-      0x8830190D,  //  0063  GETMBR	R12	R12	K13
-      0x8834090E,  //  0064  GETMBR	R13	R4	K14
-      0x90321C0D,  //  0065  SETMBR	R12	K14	R13
-      0x88301710,  //  0066  GETMBR	R12	R11	K16
-      0x8830190D,  //  0067  GETMBR	R12	R12	K13
-      0x8834090F,  //  0068  GETMBR	R13	R4	K15
-      0x90321E0D,  //  0069  SETMBR	R12	K15	R13
-      0x88301710,  //  006A  GETMBR	R12	R11	K16
-      0xB8360800,  //  006B  GETNGBL	R13	K4
-      0x8C341B22,  //  006C  GETMET	R13	R13	K34
-      0x7C340200,  //  006D  CALL	R13	1
-      0x9032200D,  //  006E  SETMBR	R12	K16	R13
-      0x88301710,  //  006F  GETMBR	R12	R11	K16
-      0x88301910,  //  0070  GETMBR	R12	R12	K16
-      0xB8360800,  //  0071  GETNGBL	R13	K4
-      0x88341B1F,  //  0072  GETMBR	R13	R13	K31
-      0x9032200D,  //  0073  SETMBR	R12	K16	R13
-      0x88300D0B,  //  0074  GETMBR	R12	R6	K11
-      0x8C301923,  //  0075  GETMET	R12	R12	K35
-      0x5C381600,  //  0076  MOVE	R14	R11
-      0x7C300400,  //  0077  CALL	R12	2
-      0xB8320200,  //  0078  GETNGBL	R12	K1
-      0x8C301902,  //  0079  GETMET	R12	R12	K2
-      0x8C380713,  //  007A  GETMET	R14	R3	K19
-      0x58400024,  //  007B  LDCONST	R16	K36
-      0x88440315,  //  007C  GETMBR	R17	R1	K21
-      0x88442316,  //  007D  GETMBR	R17	R17	K22
-      0x88480325,  //  007E  GETMBR	R18	R1	K37
-      0x7C380800,  //  007F  CALL	R14	4
-      0x583C001A,  //  0080  LDCONST	R15	K26
-      0x7C300600,  //  0081  CALL	R12	3
-      0x70020070,  //  0082  JMP		#00F4
-      0x4C300000,  //  0083  LDNIL	R12
-      0x2030140C,  //  0084  NE	R12	R10	R12
-      0x78320031,  //  0085  JMPF	R12	#00B8
-      0xB8320800,  //  0086  GETNGBL	R12	K4
-      0x8C301926,  //  0087  GETMET	R12	R12	K38
-      0x7C300200,  //  0088  CALL	R12	1
-      0x902E1E0C,  //  0089  SETMBR	R11	K15	R12
-      0x8830170F,  //  008A  GETMBR	R12	R11	K15
-      0xB8360800,  //  008B  GETNGBL	R13	K4
-      0x8C341B21,  //  008C  GETMET	R13	R13	K33
-      0x7C340200,  //  008D  CALL	R13	1
-      0x90321A0D,  //  008E  SETMBR	R12	K13	R13
-      0x8830170F,  //  008F  GETMBR	R12	R11	K15
-      0x8830190D,  //  0090  GETMBR	R12	R12	K13
-      0x8834090C,  //  0091  GETMBR	R13	R4	K12
-      0x9032180D,  //  0092  SETMBR	R12	K12	R13
-      0x8830170F,  //  0093  GETMBR	R12	R11	K15
-      0x8830190D,  //  0094  GETMBR	R12	R12	K13
-      0x8834090E,  //  0095  GETMBR	R13	R4	K14
-      0x90321C0D,  //  0096  SETMBR	R12	K14	R13
-      0x8830170F,  //  0097  GETMBR	R12	R11	K15
-      0x8830190D,  //  0098  GETMBR	R12	R12	K13
-      0x8834090F,  //  0099  GETMBR	R13	R4	K15
-      0x90321E0D,  //  009A  SETMBR	R12	K15	R13
-      0x8830170F,  //  009B  GETMBR	R12	R11	K15
-      0x90323A0A,  //  009C  SETMBR	R12	K29	R10
-      0x88300D0B,  //  009D  GETMBR	R12	R6	K11
-      0x8C301923,  //  009E  GETMET	R12	R12	K35
-      0x5C381600,  //  009F  MOVE	R14	R11
-      0x7C300400,  //  00A0  CALL	R12	2
-      0xB8320800,  //  00A1  GETNGBL	R12	K4
-      0x8C301912,  //  00A2  GETMET	R12	R12	K18
-      0x8838090E,  //  00A3  GETMBR	R14	R4	K14
-      0x883C090F,  //  00A4  GETMBR	R15	R4	K15
-      0x7C300600,  //  00A5  CALL	R12	3
-      0x5C241800,  //  00A6  MOVE	R9	R12
-      0xB8320200,  //  00A7  GETNGBL	R12	K1
-      0x8C301902,  //  00A8  GETMET	R12	R12	K2
-      0x8C380713,  //  00A9  GETMET	R14	R3	K19
-      0x58400027,  //  00AA  LDCONST	R16	K39
-      0x88440315,  //  00AB  GETMBR	R17	R1	K21
-      0x88442316,  //  00AC  GETMBR	R17	R17	K22
-      0x60480008,  //  00AD  GETGBL	R18	G8
-      0x5C4C0800,  //  00AE  MOVE	R19	R4
-      0x7C480200,  //  00AF  CALL	R18	1
-      0x78260001,  //  00B0  JMPF	R9	#00B3
-      0x5C4C1200,  //  00B1  MOVE	R19	R9
-      0x70020000,  //  00B2  JMP		#00B4
-      0x584C0017,  //  00B3  LDCONST	R19	K23
-      0x7C380A00,  //  00B4  CALL	R14	5
-      0x583C001A,  //  00B5  LDCONST	R15	K26
-      0x7C300600,  //  00B6  CALL	R12	3
-      0x7002003B,  //  00B7  JMP		#00F4
-      0x88300910,  //  00B8  GETMBR	R12	R4	K16
-      0x4C340000,  //  00B9  LDNIL	R13
-      0x2030180D,  //  00BA  NE	R12	R12	R13
-      0x7832002D,  //  00BB  JMPF	R12	#00EA
-      0xB8320800,  //  00BC  GETNGBL	R12	K4
-      0x8C301920,  //  00BD  GETMET	R12	R12	K32
-      0x7C300200,  //  00BE  CALL	R12	1
-      0x902E200C,  //  00BF  SETMBR	R11	K16	R12
-      0x88301710,  //  00C0  GETMBR	R12	R11	K16
-      0xB8360800,  //  00C1  GETNGBL	R13	K4
-      0x8C341B21,  //  00C2  GETMET	R13	R13	K33
-      0x7C340200,  //  00C3  CALL	R13	1
-      0x90321A0D,  //  00C4  SETMBR	R12	K13	R13
-      0x88301710,  //  00C5  GETMBR	R12	R11	K16
-      0x8830190D,  //  00C6  GETMBR	R12	R12	K13
-      0x8834090C,  //  00C7  GETMBR	R13	R4	K12
-      0x9032180D,  //  00C8  SETMBR	R12	K12	R13
-      0x88301710,  //  00C9  GETMBR	R12	R11	K16
-      0x8830190D,  //  00CA  GETMBR	R12	R12	K13
-      0x8834090E,  //  00CB  GETMBR	R13	R4	K14
-      0x90321C0D,  //  00CC  SETMBR	R12	K14	R13
-      0x88301710,  //  00CD  GETMBR	R12	R11	K16
-      0x8830190D,  //  00CE  GETMBR	R12	R12	K13
-      0x8834090F,  //  00CF  GETMBR	R13	R4	K15
-      0x90321E0D,  //  00D0  SETMBR	R12	K15	R13
-      0x88301710,  //  00D1  GETMBR	R12	R11	K16
-      0xB8360800,  //  00D2  GETNGBL	R13	K4
-      0x8C341B22,  //  00D3  GETMET	R13	R13	K34
-      0x7C340200,  //  00D4  CALL	R13	1
-      0x9032200D,  //  00D5  SETMBR	R12	K16	R13
-      0x88301710,  //  00D6  GETMBR	R12	R11	K16
-      0x88301910,  //  00D7  GETMBR	R12	R12	K16
-      0x88340910,  //  00D8  GETMBR	R13	R4	K16
-      0x9032200D,  //  00D9  SETMBR	R12	K16	R13
-      0x88300D0B,  //  00DA  GETMBR	R12	R6	K11
-      0x8C301923,  //  00DB  GETMET	R12	R12	K35
-      0x5C381600,  //  00DC  MOVE	R14	R11
-      0x7C300400,  //  00DD  CALL	R12	2
-      0xB8320200,  //  00DE  GETNGBL	R12	K1
-      0x8C301902,  //  00DF  GETMET	R12	R12	K2
-      0x8C380713,  //  00E0  GETMET	R14	R3	K19
-      0x58400028,  //  00E1  LDCONST	R16	K40
-      0x88440315,  //  00E2  GETMBR	R17	R1	K21
-      0x88442316,  //  00E3  GETMBR	R17	R17	K22
-      0x88480910,  //  00E4  GETMBR	R18	R4	K16
-      0x884C0325,  //  00E5  GETMBR	R19	R1	K37
-      0x7C380A00,  //  00E6  CALL	R14	5
-      0x583C001A,  //  00E7  LDCONST	R15	K26
-      0x7C300600,  //  00E8  CALL	R12	3
-      0x70020009,  //  00E9  JMP		#00F4
-      0xB8320200,  //  00EA  GETNGBL	R12	K1
-      0x8C301902,  //  00EB  GETMET	R12	R12	K2
-      0x8C380713,  //  00EC  GETMET	R14	R3	K19
-      0x58400029,  //  00ED  LDCONST	R16	K41
-      0x88440315,  //  00EE  GETMBR	R17	R1	K21
-      0x88442316,  //  00EF  GETMBR	R17	R17	K22
-      0x88480325,  //  00F0  GETMBR	R18	R1	K37
-      0x7C380800,  //  00F1  CALL	R14	4
-      0x583C001A,  //  00F2  LDCONST	R15	K26
-      0x7C300600,  //  00F3  CALL	R12	3
-      0x7001FF29,  //  00F4  JMP		#001F
-      0x581C002A,  //  00F5  LDCONST	R7	K42
-      0xAC1C0200,  //  00F6  CATCH	R7	1	0
-      0xB0080000,  //  00F7  RAISE	2	R0	R0
-      0xB81E0200,  //  00F8  GETNGBL	R7	K1
-      0x8C1C0F02,  //  00F9  GETMET	R7	R7	K2
-      0x60240008,  //  00FA  GETGBL	R9	G8
-      0x88280D0B,  //  00FB  GETMBR	R10	R6	K11
-      0x7C240200,  //  00FC  CALL	R9	1
-      0x00265609,  //  00FD  ADD	R9	K43	R9
-      0x542A0003,  //  00FE  LDINT	R10	4
-      0x7C1C0600,  //  00FF  CALL	R7	3
-      0x601C000C,  //  0100  GETGBL	R7	G12
-      0x88200D0B,  //  0101  GETMBR	R8	R6	K11
-      0x7C1C0200,  //  0102  CALL	R7	1
-      0x241C0F2C,  //  0103  GT	R7	R7	K44
-      0x781E0015,  //  0104  JMPF	R7	#011B
-      0xB81E0200,  //  0105  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0106  GETMET	R7	R7	K2
-      0x60240008,  //  0107  GETGBL	R9	G8
-      0x5C280C00,  //  0108  MOVE	R10	R6
-      0x7C240200,  //  0109  CALL	R9	1
-      0x00265A09,  //  010A  ADD	R9	K45	R9
-      0x542A0003,  //  010B  LDINT	R10	4
-      0x7C1C0600,  //  010C  CALL	R7	3
-      0xB81E0200,  //  010D  GETNGBL	R7	K1
-      0x8C1C0F02,  //  010E  GETMET	R7	R7	K2
-      0x60240008,  //  010F  GETGBL	R9	G8
-      0x8C280D2F,  //  0110  GETMET	R10	R6	K47
-      0x7C280200,  //  0111  CALL	R10	1
-      0x7C240200,  //  0112  CALL	R9	1
-      0x00265C09,  //  0113  ADD	R9	K46	R9
-      0x58280030,  //  0114  LDCONST	R10	K48
-      0x7C1C0600,  //  0115  CALL	R7	3
-      0x8C1C0131,  //  0116  GETMET	R7	R0	K49
-      0x5C240200,  //  0117  MOVE	R9	R1
-      0x5C280C00,  //  0118  MOVE	R10	R6
-      0x7C1C0600,  //  0119  CALL	R7	3
-      0x70020001,  //  011A  JMP		#011D
-      0x501C0000,  //  011B  LDBOOL	R7	0	0
-      0x80040E00,  //  011C  RET	1	R7
-      0x501C0200,  //  011D  LDBOOL	R7	1	0
-      0x80040E00,  //  011E  RET	1	R7
-      0x80000000,  //  011F  RET	0
+      0x88280113,  //  0032  GETMBR	R10	R0	K19
+      0x8C281514,  //  0033  GETMET	R10	R10	K20
+      0x88300315,  //  0034  GETMBR	R12	R1	K21
+      0x88341116,  //  0035  GETMBR	R13	R8	K22
+      0x5C380800,  //  0036  MOVE	R14	R4
+      0x7C280800,  //  0037  CALL	R10	4
+      0x882C0902,  //  0038  GETMBR	R11	R4	K2
+      0x4C300000,  //  0039  LDNIL	R12
+      0x202C160C,  //  003A  NE	R11	R11	R12
+      0x782E0005,  //  003B  JMPF	R11	#0042
+      0x602C0008,  //  003C  GETGBL	R11	G8
+      0x88300902,  //  003D  GETMBR	R12	R4	K2
+      0x7C2C0200,  //  003E  CALL	R11	1
+      0x002E2E0B,  //  003F  ADD	R11	K23	R11
+      0x002C1718,  //  0040  ADD	R11	R11	K24
+      0x70020000,  //  0041  JMP		#0043
+      0x582C0019,  //  0042  LDCONST	R11	K25
+      0xB8320200,  //  0043  GETNGBL	R12	K1
+      0x8C301902,  //  0044  GETMET	R12	R12	K2
+      0x8C38071A,  //  0045  GETMET	R14	R3	K26
+      0x5840001B,  //  0046  LDCONST	R16	K27
+      0x88440315,  //  0047  GETMBR	R17	R1	K21
+      0x8844231C,  //  0048  GETMBR	R17	R17	K28
+      0x60480008,  //  0049  GETGBL	R18	G8
+      0x5C4C0800,  //  004A  MOVE	R19	R4
+      0x7C480200,  //  004B  CALL	R18	1
+      0x78260001,  //  004C  JMPF	R9	#004F
+      0x5C4C1200,  //  004D  MOVE	R19	R9
+      0x70020000,  //  004E  JMP		#0050
+      0x584C0019,  //  004F  LDCONST	R19	K25
+      0x5C501600,  //  0050  MOVE	R20	R11
+      0x7C380C00,  //  0051  CALL	R14	6
+      0x583C001D,  //  0052  LDCONST	R15	K29
+      0x7C300600,  //  0053  CALL	R12	3
+      0x4C300000,  //  0054  LDNIL	R12
+      0x9012040C,  //  0055  SETMBR	R4	K2	R12
+      0xB8320800,  //  0056  GETNGBL	R12	K4
+      0x8C30191E,  //  0057  GETMET	R12	R12	K30
+      0x7C300200,  //  0058  CALL	R12	1
+      0x50340200,  //  0059  LDBOOL	R13	1	0
+      0x1C34140D,  //  005A  EQ	R13	R10	R13
+      0x74360004,  //  005B  JMPT	R13	#0061
+      0x88340910,  //  005C  GETMBR	R13	R4	K16
+      0xB83A0800,  //  005D  GETNGBL	R14	K4
+      0x88381D1F,  //  005E  GETMBR	R14	R14	K31
+      0x1C341A0E,  //  005F  EQ	R13	R13	R14
+      0x7836002D,  //  0060  JMPF	R13	#008F
+      0xB8360800,  //  0061  GETNGBL	R13	K4
+      0x8C341B20,  //  0062  GETMET	R13	R13	K32
+      0x7C340200,  //  0063  CALL	R13	1
+      0x9032200D,  //  0064  SETMBR	R12	K16	R13
+      0x88341910,  //  0065  GETMBR	R13	R12	K16
+      0xB83A0800,  //  0066  GETNGBL	R14	K4
+      0x8C381D21,  //  0067  GETMET	R14	R14	K33
+      0x7C380200,  //  0068  CALL	R14	1
+      0x90361A0E,  //  0069  SETMBR	R13	K13	R14
+      0x88341910,  //  006A  GETMBR	R13	R12	K16
+      0x88341B0D,  //  006B  GETMBR	R13	R13	K13
+      0x8838090C,  //  006C  GETMBR	R14	R4	K12
+      0x9036180E,  //  006D  SETMBR	R13	K12	R14
+      0x88341910,  //  006E  GETMBR	R13	R12	K16
+      0x88341B0D,  //  006F  GETMBR	R13	R13	K13
+      0x8838090E,  //  0070  GETMBR	R14	R4	K14
+      0x90361C0E,  //  0071  SETMBR	R13	K14	R14
+      0x88341910,  //  0072  GETMBR	R13	R12	K16
+      0x88341B0D,  //  0073  GETMBR	R13	R13	K13
+      0x8838090F,  //  0074  GETMBR	R14	R4	K15
+      0x90361E0E,  //  0075  SETMBR	R13	K15	R14
+      0x88341910,  //  0076  GETMBR	R13	R12	K16
+      0xB83A0800,  //  0077  GETNGBL	R14	K4
+      0x8C381D22,  //  0078  GETMET	R14	R14	K34
+      0x7C380200,  //  0079  CALL	R14	1
+      0x9036200E,  //  007A  SETMBR	R13	K16	R14
+      0x88341910,  //  007B  GETMBR	R13	R12	K16
+      0x88341B10,  //  007C  GETMBR	R13	R13	K16
+      0xB83A0800,  //  007D  GETNGBL	R14	K4
+      0x88381D1F,  //  007E  GETMBR	R14	R14	K31
+      0x9036200E,  //  007F  SETMBR	R13	K16	R14
+      0x88340D0B,  //  0080  GETMBR	R13	R6	K11
+      0x8C341B23,  //  0081  GETMET	R13	R13	K35
+      0x5C3C1800,  //  0082  MOVE	R15	R12
+      0x7C340400,  //  0083  CALL	R13	2
+      0xB8360200,  //  0084  GETNGBL	R13	K1
+      0x8C341B02,  //  0085  GETMET	R13	R13	K2
+      0x8C3C071A,  //  0086  GETMET	R15	R3	K26
+      0x58440024,  //  0087  LDCONST	R17	K36
+      0x88480315,  //  0088  GETMBR	R18	R1	K21
+      0x8848251C,  //  0089  GETMBR	R18	R18	K28
+      0x884C0325,  //  008A  GETMBR	R19	R1	K37
+      0x7C3C0800,  //  008B  CALL	R15	4
+      0x5840001D,  //  008C  LDCONST	R16	K29
+      0x7C340600,  //  008D  CALL	R13	3
+      0x70020070,  //  008E  JMP		#0100
+      0x4C340000,  //  008F  LDNIL	R13
+      0x2034140D,  //  0090  NE	R13	R10	R13
+      0x78360031,  //  0091  JMPF	R13	#00C4
+      0xB8360800,  //  0092  GETNGBL	R13	K4
+      0x8C341B26,  //  0093  GETMET	R13	R13	K38
+      0x7C340200,  //  0094  CALL	R13	1
+      0x90321E0D,  //  0095  SETMBR	R12	K15	R13
+      0x8834190F,  //  0096  GETMBR	R13	R12	K15
+      0xB83A0800,  //  0097  GETNGBL	R14	K4
+      0x8C381D21,  //  0098  GETMET	R14	R14	K33
+      0x7C380200,  //  0099  CALL	R14	1
+      0x90361A0E,  //  009A  SETMBR	R13	K13	R14
+      0x8834190F,  //  009B  GETMBR	R13	R12	K15
+      0x88341B0D,  //  009C  GETMBR	R13	R13	K13
+      0x8838090C,  //  009D  GETMBR	R14	R4	K12
+      0x9036180E,  //  009E  SETMBR	R13	K12	R14
+      0x8834190F,  //  009F  GETMBR	R13	R12	K15
+      0x88341B0D,  //  00A0  GETMBR	R13	R13	K13
+      0x8838090E,  //  00A1  GETMBR	R14	R4	K14
+      0x90361C0E,  //  00A2  SETMBR	R13	K14	R14
+      0x8834190F,  //  00A3  GETMBR	R13	R12	K15
+      0x88341B0D,  //  00A4  GETMBR	R13	R13	K13
+      0x8838090F,  //  00A5  GETMBR	R14	R4	K15
+      0x90361E0E,  //  00A6  SETMBR	R13	K15	R14
+      0x8834190F,  //  00A7  GETMBR	R13	R12	K15
+      0x90362C0A,  //  00A8  SETMBR	R13	K22	R10
+      0x88340D0B,  //  00A9  GETMBR	R13	R6	K11
+      0x8C341B23,  //  00AA  GETMET	R13	R13	K35
+      0x5C3C1800,  //  00AB  MOVE	R15	R12
+      0x7C340400,  //  00AC  CALL	R13	2
+      0xB8360800,  //  00AD  GETNGBL	R13	K4
+      0x8C341B12,  //  00AE  GETMET	R13	R13	K18
+      0x883C090E,  //  00AF  GETMBR	R15	R4	K14
+      0x8840090F,  //  00B0  GETMBR	R16	R4	K15
+      0x7C340600,  //  00B1  CALL	R13	3
+      0x5C241A00,  //  00B2  MOVE	R9	R13
+      0xB8360200,  //  00B3  GETNGBL	R13	K1
+      0x8C341B02,  //  00B4  GETMET	R13	R13	K2
+      0x8C3C071A,  //  00B5  GETMET	R15	R3	K26
+      0x58440027,  //  00B6  LDCONST	R17	K39
+      0x88480315,  //  00B7  GETMBR	R18	R1	K21
+      0x8848251C,  //  00B8  GETMBR	R18	R18	K28
+      0x604C0008,  //  00B9  GETGBL	R19	G8
+      0x5C500800,  //  00BA  MOVE	R20	R4
+      0x7C4C0200,  //  00BB  CALL	R19	1
+      0x78260001,  //  00BC  JMPF	R9	#00BF
+      0x5C501200,  //  00BD  MOVE	R20	R9
+      0x70020000,  //  00BE  JMP		#00C0
+      0x58500019,  //  00BF  LDCONST	R20	K25
+      0x7C3C0A00,  //  00C0  CALL	R15	5
+      0x5840001D,  //  00C1  LDCONST	R16	K29
+      0x7C340600,  //  00C2  CALL	R13	3
+      0x7002003B,  //  00C3  JMP		#0100
+      0x88340910,  //  00C4  GETMBR	R13	R4	K16
+      0x4C380000,  //  00C5  LDNIL	R14
+      0x20341A0E,  //  00C6  NE	R13	R13	R14
+      0x7836002D,  //  00C7  JMPF	R13	#00F6
+      0xB8360800,  //  00C8  GETNGBL	R13	K4
+      0x8C341B20,  //  00C9  GETMET	R13	R13	K32
+      0x7C340200,  //  00CA  CALL	R13	1
+      0x9032200D,  //  00CB  SETMBR	R12	K16	R13
+      0x88341910,  //  00CC  GETMBR	R13	R12	K16
+      0xB83A0800,  //  00CD  GETNGBL	R14	K4
+      0x8C381D21,  //  00CE  GETMET	R14	R14	K33
+      0x7C380200,  //  00CF  CALL	R14	1
+      0x90361A0E,  //  00D0  SETMBR	R13	K13	R14
+      0x88341910,  //  00D1  GETMBR	R13	R12	K16
+      0x88341B0D,  //  00D2  GETMBR	R13	R13	K13
+      0x8838090C,  //  00D3  GETMBR	R14	R4	K12
+      0x9036180E,  //  00D4  SETMBR	R13	K12	R14
+      0x88341910,  //  00D5  GETMBR	R13	R12	K16
+      0x88341B0D,  //  00D6  GETMBR	R13	R13	K13
+      0x8838090E,  //  00D7  GETMBR	R14	R4	K14
+      0x90361C0E,  //  00D8  SETMBR	R13	K14	R14
+      0x88341910,  //  00D9  GETMBR	R13	R12	K16
+      0x88341B0D,  //  00DA  GETMBR	R13	R13	K13
+      0x8838090F,  //  00DB  GETMBR	R14	R4	K15
+      0x90361E0E,  //  00DC  SETMBR	R13	K15	R14
+      0x88341910,  //  00DD  GETMBR	R13	R12	K16
+      0xB83A0800,  //  00DE  GETNGBL	R14	K4
+      0x8C381D22,  //  00DF  GETMET	R14	R14	K34
+      0x7C380200,  //  00E0  CALL	R14	1
+      0x9036200E,  //  00E1  SETMBR	R13	K16	R14
+      0x88341910,  //  00E2  GETMBR	R13	R12	K16
+      0x88341B10,  //  00E3  GETMBR	R13	R13	K16
+      0x88380910,  //  00E4  GETMBR	R14	R4	K16
+      0x9036200E,  //  00E5  SETMBR	R13	K16	R14
+      0x88340D0B,  //  00E6  GETMBR	R13	R6	K11
+      0x8C341B23,  //  00E7  GETMET	R13	R13	K35
+      0x5C3C1800,  //  00E8  MOVE	R15	R12
+      0x7C340400,  //  00E9  CALL	R13	2
+      0xB8360200,  //  00EA  GETNGBL	R13	K1
+      0x8C341B02,  //  00EB  GETMET	R13	R13	K2
+      0x8C3C071A,  //  00EC  GETMET	R15	R3	K26
+      0x58440028,  //  00ED  LDCONST	R17	K40
+      0x88480315,  //  00EE  GETMBR	R18	R1	K21
+      0x8848251C,  //  00EF  GETMBR	R18	R18	K28
+      0x884C0910,  //  00F0  GETMBR	R19	R4	K16
+      0x88500325,  //  00F1  GETMBR	R20	R1	K37
+      0x7C3C0A00,  //  00F2  CALL	R15	5
+      0x5840001D,  //  00F3  LDCONST	R16	K29
+      0x7C340600,  //  00F4  CALL	R13	3
+      0x70020009,  //  00F5  JMP		#0100
+      0xB8360200,  //  00F6  GETNGBL	R13	K1
+      0x8C341B02,  //  00F7  GETMET	R13	R13	K2
+      0x8C3C071A,  //  00F8  GETMET	R15	R3	K26
+      0x58440029,  //  00F9  LDCONST	R17	K41
+      0x88480315,  //  00FA  GETMBR	R18	R1	K21
+      0x8848251C,  //  00FB  GETMBR	R18	R18	K28
+      0x884C0325,  //  00FC  GETMBR	R19	R1	K37
+      0x7C3C0800,  //  00FD  CALL	R15	4
+      0x5840001D,  //  00FE  LDCONST	R16	K29
+      0x7C340600,  //  00FF  CALL	R13	3
+      0x7001FF1D,  //  0100  JMP		#001F
+      0x581C002A,  //  0101  LDCONST	R7	K42
+      0xAC1C0200,  //  0102  CATCH	R7	1	0
+      0xB0080000,  //  0103  RAISE	2	R0	R0
+      0xB81E0200,  //  0104  GETNGBL	R7	K1
+      0x8C1C0F02,  //  0105  GETMET	R7	R7	K2
+      0x60240008,  //  0106  GETGBL	R9	G8
+      0x88280D0B,  //  0107  GETMBR	R10	R6	K11
+      0x7C240200,  //  0108  CALL	R9	1
+      0x00265609,  //  0109  ADD	R9	K43	R9
+      0x542A0003,  //  010A  LDINT	R10	4
+      0x7C1C0600,  //  010B  CALL	R7	3
+      0x601C000C,  //  010C  GETGBL	R7	G12
+      0x88200D0B,  //  010D  GETMBR	R8	R6	K11
+      0x7C1C0200,  //  010E  CALL	R7	1
+      0x241C0F2C,  //  010F  GT	R7	R7	K44
+      0x781E0015,  //  0110  JMPF	R7	#0127
+      0xB81E0200,  //  0111  GETNGBL	R7	K1
+      0x8C1C0F02,  //  0112  GETMET	R7	R7	K2
+      0x60240008,  //  0113  GETGBL	R9	G8
+      0x5C280C00,  //  0114  MOVE	R10	R6
+      0x7C240200,  //  0115  CALL	R9	1
+      0x00265A09,  //  0116  ADD	R9	K45	R9
+      0x542A0003,  //  0117  LDINT	R10	4
+      0x7C1C0600,  //  0118  CALL	R7	3
+      0xB81E0200,  //  0119  GETNGBL	R7	K1
+      0x8C1C0F02,  //  011A  GETMET	R7	R7	K2
+      0x60240008,  //  011B  GETGBL	R9	G8
+      0x8C280D2F,  //  011C  GETMET	R10	R6	K47
+      0x7C280200,  //  011D  CALL	R10	1
+      0x7C240200,  //  011E  CALL	R9	1
+      0x00265C09,  //  011F  ADD	R9	K46	R9
+      0x58280030,  //  0120  LDCONST	R10	K48
+      0x7C1C0600,  //  0121  CALL	R7	3
+      0x8C1C0131,  //  0122  GETMET	R7	R0	K49
+      0x5C240200,  //  0123  MOVE	R9	R1
+      0x5C280C00,  //  0124  MOVE	R10	R6
+      0x7C1C0600,  //  0125  CALL	R7	3
+      0x70020001,  //  0126  JMP		#0129
+      0x501C0000,  //  0127  LDBOOL	R7	0	0
+      0x80040E00,  //  0128  RET	1	R7
+      0x501C0200,  //  0129  LDBOOL	R7	1	0
+      0x80040E00,  //  012A  RET	1	R7
+      0x80000000,  //  012B  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
@@ -124,14 +124,15 @@ be_local_closure(Matter_Path_tostring,   /* name */
 ** Solidified class: Matter_Path
 ********************************************************************/
 be_local_class(Matter_Path,
-    5,
+    6,
     NULL,
-    be_nested_map(6,
+    be_nested_map(7,
     ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(log, 4), be_const_var(5) },
+        { be_const_key_weak(command, 2), be_const_var(3) },
+        { be_const_key_weak(status, -1), be_const_var(4) },
         { be_const_key_weak(tostring, -1), be_const_closure(Matter_Path_tostring_closure) },
-        { be_const_key_weak(cluster, 3), be_const_var(1) },
-        { be_const_key_weak(command, -1), be_const_var(3) },
-        { be_const_key_weak(status, 0), be_const_var(4) },
+        { be_const_key_weak(cluster, 5), be_const_var(1) },
         { be_const_key_weak(endpoint, -1), be_const_var(0) },
         { be_const_key_weak(attribute, -1), be_const_var(2) },
     })),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light1.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light1.h
@@ -1,0 +1,694 @@
+/* Solidification of Matter_Plugin_Light1.h */
+/********************************************************************\
+* Generated code, don't edit                                         *
+\********************************************************************/
+#include "be_constobj.h"
+
+extern const bclass be_class_Matter_Plugin_Light1;
+
+/********************************************************************
+** Solidified function: update_shadow
+********************************************************************/
+be_local_closure(Matter_Plugin_Light1_update_shadow,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(light),
+    /* K1   */  be_nested_str_weak(get),
+    /* K2   */  be_nested_str_weak(find),
+    /* K3   */  be_nested_str_weak(bri),
+    /* K4   */  be_nested_str_weak(power),
+    /* K5   */  be_nested_str_weak(tasmota),
+    /* K6   */  be_nested_str_weak(scale_uint),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_nested_str_weak(shadow_bri),
+    /* K9   */  be_nested_str_weak(shadow_onoff),
+    /* K10  */  be_nested_str_weak(attribute_updated),
+    }),
+    be_str_weak(update_shadow),
+    &be_const_str_solidified,
+    ( &(const binstruction[44]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C0C0502,  //  0003  GETMET	R3	R2	K2
+      0x58140003,  //  0004  LDCONST	R5	K3
+      0x4C180000,  //  0005  LDNIL	R6
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x8C100502,  //  0007  GETMET	R4	R2	K2
+      0x58180004,  //  0008  LDCONST	R6	K4
+      0x4C1C0000,  //  0009  LDNIL	R7
+      0x7C100600,  //  000A  CALL	R4	3
+      0x4C140000,  //  000B  LDNIL	R5
+      0x20140605,  //  000C  NE	R5	R3	R5
+      0x78160009,  //  000D  JMPF	R5	#0018
+      0xB8160A00,  //  000E  GETNGBL	R5	K5
+      0x8C140B06,  //  000F  GETMET	R5	R5	K6
+      0x5C1C0600,  //  0010  MOVE	R7	R3
+      0x58200007,  //  0011  LDCONST	R8	K7
+      0x542600FE,  //  0012  LDINT	R9	255
+      0x58280007,  //  0013  LDCONST	R10	K7
+      0x542E00FD,  //  0014  LDINT	R11	254
+      0x7C140C00,  //  0015  CALL	R5	6
+      0x5C0C0A00,  //  0016  MOVE	R3	R5
+      0x70020000,  //  0017  JMP		#0019
+      0x880C0108,  //  0018  GETMBR	R3	R0	K8
+      0x88140109,  //  0019  GETMBR	R5	R0	K9
+      0x20140805,  //  001A  NE	R5	R4	R5
+      0x78160005,  //  001B  JMPF	R5	#0022
+      0x8C14010A,  //  001C  GETMET	R5	R0	K10
+      0x4C1C0000,  //  001D  LDNIL	R7
+      0x54220005,  //  001E  LDINT	R8	6
+      0x58240007,  //  001F  LDCONST	R9	K7
+      0x7C140800,  //  0020  CALL	R5	4
+      0x90021204,  //  0021  SETMBR	R0	K9	R4
+      0x88140108,  //  0022  GETMBR	R5	R0	K8
+      0x20140605,  //  0023  NE	R5	R3	R5
+      0x78160005,  //  0024  JMPF	R5	#002B
+      0x8C14010A,  //  0025  GETMET	R5	R0	K10
+      0x4C1C0000,  //  0026  LDNIL	R7
+      0x54220007,  //  0027  LDINT	R8	8
+      0x58240007,  //  0028  LDCONST	R9	K7
+      0x7C140800,  //  0029  CALL	R5	4
+      0x90021003,  //  002A  SETMBR	R0	K8	R3
+      0x80000000,  //  002B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Plugin_Light1_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(update_shadow),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Plugin_Light1_invoke_request,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[22]) {     /* constants */
+    /* K0   */  be_nested_str_weak(light),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(command),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(Matter_TLV_struct),
+    /* K9   */  be_nested_str_weak(add_TLV),
+    /* K10  */  be_nested_str_weak(U2),
+    /* K11  */  be_nested_str_weak(set),
+    /* K12  */  be_nested_str_weak(power),
+    /* K13  */  be_nested_str_weak(update_shadow),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(shadow_onoff),
+    /* K16  */  be_nested_str_weak(findsubval),
+    /* K17  */  be_nested_str_weak(tasmota),
+    /* K18  */  be_nested_str_weak(scale_uint),
+    /* K19  */  be_nested_str_weak(bri),
+    /* K20  */  be_nested_str_weak(log),
+    /* K21  */  be_nested_str_weak(bri_X3A),
+    }),
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[182]) {  /* code */
+      0xA4120000,  //  0000  IMPORT	R4	K0
+      0xB8160200,  //  0001  GETNGBL	R5	K1
+      0x88140B02,  //  0002  GETMBR	R5	R5	K2
+      0x88180703,  //  0003  GETMBR	R6	R3	K3
+      0x881C0704,  //  0004  GETMBR	R7	R3	K4
+      0x1C200D05,  //  0005  EQ	R8	R6	K5
+      0x78220016,  //  0006  JMPF	R8	#001E
+      0x1C200F06,  //  0007  EQ	R8	R7	K6
+      0x78220002,  //  0008  JMPF	R8	#000C
+      0x50200200,  //  0009  LDBOOL	R8	1	0
+      0x80041000,  //  000A  RET	1	R8
+      0x70020010,  //  000B  JMP		#001D
+      0x1C200F07,  //  000C  EQ	R8	R7	K7
+      0x78220009,  //  000D  JMPF	R8	#0018
+      0x8C200B08,  //  000E  GETMET	R8	R5	K8
+      0x7C200200,  //  000F  CALL	R8	1
+      0x8C241109,  //  0010  GETMET	R9	R8	K9
+      0x582C0006,  //  0011  LDCONST	R11	K6
+      0x88300B0A,  //  0012  GETMBR	R12	R5	K10
+      0x58340006,  //  0013  LDCONST	R13	K6
+      0x7C240800,  //  0014  CALL	R9	4
+      0x900E0906,  //  0015  SETMBR	R3	K4	K6
+      0x80041000,  //  0016  RET	1	R8
+      0x70020004,  //  0017  JMP		#001D
+      0x5422003F,  //  0018  LDINT	R8	64
+      0x1C200E08,  //  0019  EQ	R8	R7	R8
+      0x78220001,  //  001A  JMPF	R8	#001D
+      0x50200200,  //  001B  LDBOOL	R8	1	0
+      0x80041000,  //  001C  RET	1	R8
+      0x70020096,  //  001D  JMP		#00B5
+      0x54220003,  //  001E  LDINT	R8	4
+      0x1C200C08,  //  001F  EQ	R8	R6	R8
+      0x78220002,  //  0020  JMPF	R8	#0024
+      0x50200200,  //  0021  LDBOOL	R8	1	0
+      0x80041000,  //  0022  RET	1	R8
+      0x70020090,  //  0023  JMP		#00B5
+      0x54220004,  //  0024  LDINT	R8	5
+      0x1C200C08,  //  0025  EQ	R8	R6	R8
+      0x78220002,  //  0026  JMPF	R8	#002A
+      0x50200200,  //  0027  LDBOOL	R8	1	0
+      0x80041000,  //  0028  RET	1	R8
+      0x7002008A,  //  0029  JMP		#00B5
+      0x54220005,  //  002A  LDINT	R8	6
+      0x1C200C08,  //  002B  EQ	R8	R6	R8
+      0x78220029,  //  002C  JMPF	R8	#0057
+      0x1C200F06,  //  002D  EQ	R8	R7	K6
+      0x7822000A,  //  002E  JMPF	R8	#003A
+      0x8C20090B,  //  002F  GETMET	R8	R4	K11
+      0x60280013,  //  0030  GETGBL	R10	G19
+      0x7C280000,  //  0031  CALL	R10	0
+      0x502C0000,  //  0032  LDBOOL	R11	0	0
+      0x982A180B,  //  0033  SETIDX	R10	K12	R11
+      0x7C200400,  //  0034  CALL	R8	2
+      0x8C20010D,  //  0035  GETMET	R8	R0	K13
+      0x7C200200,  //  0036  CALL	R8	1
+      0x50200200,  //  0037  LDBOOL	R8	1	0
+      0x80041000,  //  0038  RET	1	R8
+      0x7002001B,  //  0039  JMP		#0056
+      0x1C200F07,  //  003A  EQ	R8	R7	K7
+      0x7822000A,  //  003B  JMPF	R8	#0047
+      0x8C20090B,  //  003C  GETMET	R8	R4	K11
+      0x60280013,  //  003D  GETGBL	R10	G19
+      0x7C280000,  //  003E  CALL	R10	0
+      0x502C0200,  //  003F  LDBOOL	R11	1	0
+      0x982A180B,  //  0040  SETIDX	R10	K12	R11
+      0x7C200400,  //  0041  CALL	R8	2
+      0x8C20010D,  //  0042  GETMET	R8	R0	K13
+      0x7C200200,  //  0043  CALL	R8	1
+      0x50200200,  //  0044  LDBOOL	R8	1	0
+      0x80041000,  //  0045  RET	1	R8
+      0x7002000E,  //  0046  JMP		#0056
+      0x1C200F0E,  //  0047  EQ	R8	R7	K14
+      0x7822000C,  //  0048  JMPF	R8	#0056
+      0x8C20090B,  //  0049  GETMET	R8	R4	K11
+      0x60280013,  //  004A  GETGBL	R10	G19
+      0x7C280000,  //  004B  CALL	R10	0
+      0x882C010F,  //  004C  GETMBR	R11	R0	K15
+      0x782E0000,  //  004D  JMPF	R11	#004F
+      0x502C0001,  //  004E  LDBOOL	R11	0	1
+      0x502C0200,  //  004F  LDBOOL	R11	1	0
+      0x982A180B,  //  0050  SETIDX	R10	K12	R11
+      0x7C200400,  //  0051  CALL	R8	2
+      0x8C20010D,  //  0052  GETMET	R8	R0	K13
+      0x7C200200,  //  0053  CALL	R8	1
+      0x50200200,  //  0054  LDBOOL	R8	1	0
+      0x80041000,  //  0055  RET	1	R8
+      0x7002005D,  //  0056  JMP		#00B5
+      0x54220007,  //  0057  LDINT	R8	8
+      0x1C200C08,  //  0058  EQ	R8	R6	R8
+      0x7822005A,  //  0059  JMPF	R8	#00B5
+      0x1C200F06,  //  005A  EQ	R8	R7	K6
+      0x78220019,  //  005B  JMPF	R8	#0076
+      0x8C200510,  //  005C  GETMET	R8	R2	K16
+      0x58280006,  //  005D  LDCONST	R10	K6
+      0x7C200400,  //  005E  CALL	R8	2
+      0xB8262200,  //  005F  GETNGBL	R9	K17
+      0x8C241312,  //  0060  GETMET	R9	R9	K18
+      0x5C2C1000,  //  0061  MOVE	R11	R8
+      0x58300006,  //  0062  LDCONST	R12	K6
+      0x543600FD,  //  0063  LDINT	R13	254
+      0x58380006,  //  0064  LDCONST	R14	K6
+      0x543E00FE,  //  0065  LDINT	R15	255
+      0x7C240C00,  //  0066  CALL	R9	6
+      0x8C28090B,  //  0067  GETMET	R10	R4	K11
+      0x60300013,  //  0068  GETGBL	R12	G19
+      0x7C300000,  //  0069  CALL	R12	0
+      0x98322609,  //  006A  SETIDX	R12	K19	R9
+      0x7C280400,  //  006B  CALL	R10	2
+      0x8C28010D,  //  006C  GETMET	R10	R0	K13
+      0x7C280200,  //  006D  CALL	R10	1
+      0x60280008,  //  006E  GETGBL	R10	G8
+      0x5C2C1000,  //  006F  MOVE	R11	R8
+      0x7C280200,  //  0070  CALL	R10	1
+      0x002A2A0A,  //  0071  ADD	R10	K21	R10
+      0x900E280A,  //  0072  SETMBR	R3	K20	R10
+      0x50280200,  //  0073  LDBOOL	R10	1	0
+      0x80041400,  //  0074  RET	1	R10
+      0x7002003E,  //  0075  JMP		#00B5
+      0x1C200F07,  //  0076  EQ	R8	R7	K7
+      0x78220002,  //  0077  JMPF	R8	#007B
+      0x50200200,  //  0078  LDBOOL	R8	1	0
+      0x80041000,  //  0079  RET	1	R8
+      0x70020039,  //  007A  JMP		#00B5
+      0x1C200F0E,  //  007B  EQ	R8	R7	K14
+      0x78220002,  //  007C  JMPF	R8	#0080
+      0x50200200,  //  007D  LDBOOL	R8	1	0
+      0x80041000,  //  007E  RET	1	R8
+      0x70020034,  //  007F  JMP		#00B5
+      0x1C200F05,  //  0080  EQ	R8	R7	K5
+      0x78220002,  //  0081  JMPF	R8	#0085
+      0x50200200,  //  0082  LDBOOL	R8	1	0
+      0x80041000,  //  0083  RET	1	R8
+      0x7002002F,  //  0084  JMP		#00B5
+      0x54220003,  //  0085  LDINT	R8	4
+      0x1C200E08,  //  0086  EQ	R8	R7	R8
+      0x7822001B,  //  0087  JMPF	R8	#00A4
+      0x8C200510,  //  0088  GETMET	R8	R2	K16
+      0x58280006,  //  0089  LDCONST	R10	K6
+      0x7C200400,  //  008A  CALL	R8	2
+      0xB8262200,  //  008B  GETNGBL	R9	K17
+      0x8C241312,  //  008C  GETMET	R9	R9	K18
+      0x5C2C1000,  //  008D  MOVE	R11	R8
+      0x58300006,  //  008E  LDCONST	R12	K6
+      0x543600FD,  //  008F  LDINT	R13	254
+      0x58380006,  //  0090  LDCONST	R14	K6
+      0x543E00FE,  //  0091  LDINT	R15	255
+      0x7C240C00,  //  0092  CALL	R9	6
+      0x24281306,  //  0093  GT	R10	R9	K6
+      0x8C2C090B,  //  0094  GETMET	R11	R4	K11
+      0x60340013,  //  0095  GETGBL	R13	G19
+      0x7C340000,  //  0096  CALL	R13	0
+      0x98362609,  //  0097  SETIDX	R13	K19	R9
+      0x9836180A,  //  0098  SETIDX	R13	K12	R10
+      0x7C2C0400,  //  0099  CALL	R11	2
+      0x8C2C010D,  //  009A  GETMET	R11	R0	K13
+      0x7C2C0200,  //  009B  CALL	R11	1
+      0x602C0008,  //  009C  GETGBL	R11	G8
+      0x5C301000,  //  009D  MOVE	R12	R8
+      0x7C2C0200,  //  009E  CALL	R11	1
+      0x002E2A0B,  //  009F  ADD	R11	K21	R11
+      0x900E280B,  //  00A0  SETMBR	R3	K20	R11
+      0x502C0200,  //  00A1  LDBOOL	R11	1	0
+      0x80041600,  //  00A2  RET	1	R11
+      0x70020010,  //  00A3  JMP		#00B5
+      0x54220004,  //  00A4  LDINT	R8	5
+      0x1C200E08,  //  00A5  EQ	R8	R7	R8
+      0x78220002,  //  00A6  JMPF	R8	#00AA
+      0x50200200,  //  00A7  LDBOOL	R8	1	0
+      0x80041000,  //  00A8  RET	1	R8
+      0x7002000A,  //  00A9  JMP		#00B5
+      0x54220005,  //  00AA  LDINT	R8	6
+      0x1C200E08,  //  00AB  EQ	R8	R7	R8
+      0x78220002,  //  00AC  JMPF	R8	#00B0
+      0x50200200,  //  00AD  LDBOOL	R8	1	0
+      0x80041000,  //  00AE  RET	1	R8
+      0x70020004,  //  00AF  JMP		#00B5
+      0x54220006,  //  00B0  LDINT	R8	7
+      0x1C200E08,  //  00B1  EQ	R8	R7	R8
+      0x78220001,  //  00B2  JMPF	R8	#00B5
+      0x50200200,  //  00B3  LDBOOL	R8	1	0
+      0x80041000,  //  00B4  RET	1	R8
+      0x80000000,  //  00B5  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_attribute
+********************************************************************/
+be_local_closure(Matter_Plugin_Light1_read_attribute,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[17]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(create_TLV),
+    /* K8   */  be_nested_str_weak(U2),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(U1),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_nested_str_weak(BOOL),
+    /* K13  */  be_nested_str_weak(shadow_onoff),
+    /* K14  */  be_nested_str_weak(shadow_bri),
+    /* K15  */  be_const_int(2),
+    /* K16  */  be_nested_str_weak(read_attribute),
+    }),
+    be_str_weak(read_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[189]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x88100902,  //  0002  GETMBR	R4	R4	K2
+      0x88140503,  //  0003  GETMBR	R5	R2	K3
+      0x88180504,  //  0004  GETMBR	R6	R2	K4
+      0x1C1C0B05,  //  0005  EQ	R7	R5	K5
+      0x781E0021,  //  0006  JMPF	R7	#0029
+      0x1C1C0D06,  //  0007  EQ	R7	R6	K6
+      0x781E0005,  //  0008  JMPF	R7	#000F
+      0x8C1C0907,  //  0009  GETMET	R7	R4	K7
+      0x88240908,  //  000A  GETMBR	R9	R4	K8
+      0x58280006,  //  000B  LDCONST	R10	K6
+      0x7C1C0600,  //  000C  CALL	R7	3
+      0x80040E00,  //  000D  RET	1	R7
+      0x70020018,  //  000E  JMP		#0028
+      0x1C1C0D09,  //  000F  EQ	R7	R6	K9
+      0x781E0005,  //  0010  JMPF	R7	#0017
+      0x8C1C0907,  //  0011  GETMET	R7	R4	K7
+      0x8824090A,  //  0012  GETMBR	R9	R4	K10
+      0x58280006,  //  0013  LDCONST	R10	K6
+      0x7C1C0600,  //  0014  CALL	R7	3
+      0x80040E00,  //  0015  RET	1	R7
+      0x70020010,  //  0016  JMP		#0028
+      0x541EFFFB,  //  0017  LDINT	R7	65532
+      0x1C1C0C07,  //  0018  EQ	R7	R6	R7
+      0x781E0005,  //  0019  JMPF	R7	#0020
+      0x8C1C0907,  //  001A  GETMET	R7	R4	K7
+      0x8824090B,  //  001B  GETMBR	R9	R4	K11
+      0x58280006,  //  001C  LDCONST	R10	K6
+      0x7C1C0600,  //  001D  CALL	R7	3
+      0x80040E00,  //  001E  RET	1	R7
+      0x70020007,  //  001F  JMP		#0028
+      0x541EFFFC,  //  0020  LDINT	R7	65533
+      0x1C1C0C07,  //  0021  EQ	R7	R6	R7
+      0x781E0004,  //  0022  JMPF	R7	#0028
+      0x8C1C0907,  //  0023  GETMET	R7	R4	K7
+      0x8824090B,  //  0024  GETMBR	R9	R4	K11
+      0x542A0003,  //  0025  LDINT	R10	4
+      0x7C1C0600,  //  0026  CALL	R7	3
+      0x80040E00,  //  0027  RET	1	R7
+      0x70020092,  //  0028  JMP		#00BC
+      0x541E0003,  //  0029  LDINT	R7	4
+      0x1C1C0A07,  //  002A  EQ	R7	R5	R7
+      0x781E0016,  //  002B  JMPF	R7	#0043
+      0x1C1C0D06,  //  002C  EQ	R7	R6	K6
+      0x781E0002,  //  002D  JMPF	R7	#0031
+      0x4C1C0000,  //  002E  LDNIL	R7
+      0x80040E00,  //  002F  RET	1	R7
+      0x70020010,  //  0030  JMP		#0042
+      0x541EFFFB,  //  0031  LDINT	R7	65532
+      0x1C1C0C07,  //  0032  EQ	R7	R6	R7
+      0x781E0005,  //  0033  JMPF	R7	#003A
+      0x8C1C0907,  //  0034  GETMET	R7	R4	K7
+      0x8824090B,  //  0035  GETMBR	R9	R4	K11
+      0x58280006,  //  0036  LDCONST	R10	K6
+      0x7C1C0600,  //  0037  CALL	R7	3
+      0x80040E00,  //  0038  RET	1	R7
+      0x70020007,  //  0039  JMP		#0042
+      0x541EFFFC,  //  003A  LDINT	R7	65533
+      0x1C1C0C07,  //  003B  EQ	R7	R6	R7
+      0x781E0004,  //  003C  JMPF	R7	#0042
+      0x8C1C0907,  //  003D  GETMET	R7	R4	K7
+      0x8824090B,  //  003E  GETMBR	R9	R4	K11
+      0x542A0003,  //  003F  LDINT	R10	4
+      0x7C1C0600,  //  0040  CALL	R7	3
+      0x80040E00,  //  0041  RET	1	R7
+      0x70020078,  //  0042  JMP		#00BC
+      0x541E0004,  //  0043  LDINT	R7	5
+      0x1C1C0A07,  //  0044  EQ	R7	R5	R7
+      0x781E0011,  //  0045  JMPF	R7	#0058
+      0x541EFFFB,  //  0046  LDINT	R7	65532
+      0x1C1C0C07,  //  0047  EQ	R7	R6	R7
+      0x781E0005,  //  0048  JMPF	R7	#004F
+      0x8C1C0907,  //  0049  GETMET	R7	R4	K7
+      0x8824090B,  //  004A  GETMBR	R9	R4	K11
+      0x58280006,  //  004B  LDCONST	R10	K6
+      0x7C1C0600,  //  004C  CALL	R7	3
+      0x80040E00,  //  004D  RET	1	R7
+      0x70020007,  //  004E  JMP		#0057
+      0x541EFFFC,  //  004F  LDINT	R7	65533
+      0x1C1C0C07,  //  0050  EQ	R7	R6	R7
+      0x781E0004,  //  0051  JMPF	R7	#0057
+      0x8C1C0907,  //  0052  GETMET	R7	R4	K7
+      0x8824090B,  //  0053  GETMBR	R9	R4	K11
+      0x542A0003,  //  0054  LDINT	R10	4
+      0x7C1C0600,  //  0055  CALL	R7	3
+      0x80040E00,  //  0056  RET	1	R7
+      0x70020063,  //  0057  JMP		#00BC
+      0x541E0005,  //  0058  LDINT	R7	6
+      0x1C1C0A07,  //  0059  EQ	R7	R5	R7
+      0x781E0019,  //  005A  JMPF	R7	#0075
+      0x1C1C0D06,  //  005B  EQ	R7	R6	K6
+      0x781E0005,  //  005C  JMPF	R7	#0063
+      0x8C1C0907,  //  005D  GETMET	R7	R4	K7
+      0x8824090C,  //  005E  GETMBR	R9	R4	K12
+      0x8828010D,  //  005F  GETMBR	R10	R0	K13
+      0x7C1C0600,  //  0060  CALL	R7	3
+      0x80040E00,  //  0061  RET	1	R7
+      0x70020010,  //  0062  JMP		#0074
+      0x541EFFFB,  //  0063  LDINT	R7	65532
+      0x1C1C0C07,  //  0064  EQ	R7	R6	R7
+      0x781E0005,  //  0065  JMPF	R7	#006C
+      0x8C1C0907,  //  0066  GETMET	R7	R4	K7
+      0x8824090B,  //  0067  GETMBR	R9	R4	K11
+      0x58280006,  //  0068  LDCONST	R10	K6
+      0x7C1C0600,  //  0069  CALL	R7	3
+      0x80040E00,  //  006A  RET	1	R7
+      0x70020007,  //  006B  JMP		#0074
+      0x541EFFFC,  //  006C  LDINT	R7	65533
+      0x1C1C0C07,  //  006D  EQ	R7	R6	R7
+      0x781E0004,  //  006E  JMPF	R7	#0074
+      0x8C1C0907,  //  006F  GETMET	R7	R4	K7
+      0x8824090B,  //  0070  GETMBR	R9	R4	K11
+      0x542A0003,  //  0071  LDINT	R10	4
+      0x7C1C0600,  //  0072  CALL	R7	3
+      0x80040E00,  //  0073  RET	1	R7
+      0x70020046,  //  0074  JMP		#00BC
+      0x541E0007,  //  0075  LDINT	R7	8
+      0x1C1C0A07,  //  0076  EQ	R7	R5	R7
+      0x781E003B,  //  0077  JMPF	R7	#00B4
+      0x1C1C0D06,  //  0078  EQ	R7	R6	K6
+      0x781E0005,  //  0079  JMPF	R7	#0080
+      0x8C1C0907,  //  007A  GETMET	R7	R4	K7
+      0x8824090A,  //  007B  GETMBR	R9	R4	K10
+      0x8828010E,  //  007C  GETMBR	R10	R0	K14
+      0x7C1C0600,  //  007D  CALL	R7	3
+      0x80040E00,  //  007E  RET	1	R7
+      0x70020032,  //  007F  JMP		#00B3
+      0x1C1C0D0F,  //  0080  EQ	R7	R6	K15
+      0x781E0005,  //  0081  JMPF	R7	#0088
+      0x8C1C0907,  //  0082  GETMET	R7	R4	K7
+      0x8824090A,  //  0083  GETMBR	R9	R4	K10
+      0x58280006,  //  0084  LDCONST	R10	K6
+      0x7C1C0600,  //  0085  CALL	R7	3
+      0x80040E00,  //  0086  RET	1	R7
+      0x7002002A,  //  0087  JMP		#00B3
+      0x1C1C0D05,  //  0088  EQ	R7	R6	K5
+      0x781E0005,  //  0089  JMPF	R7	#0090
+      0x8C1C0907,  //  008A  GETMET	R7	R4	K7
+      0x8824090A,  //  008B  GETMBR	R9	R4	K10
+      0x542A00FD,  //  008C  LDINT	R10	254
+      0x7C1C0600,  //  008D  CALL	R7	3
+      0x80040E00,  //  008E  RET	1	R7
+      0x70020022,  //  008F  JMP		#00B3
+      0x541E000E,  //  0090  LDINT	R7	15
+      0x1C1C0C07,  //  0091  EQ	R7	R6	R7
+      0x781E0005,  //  0092  JMPF	R7	#0099
+      0x8C1C0907,  //  0093  GETMET	R7	R4	K7
+      0x8824090A,  //  0094  GETMBR	R9	R4	K10
+      0x58280006,  //  0095  LDCONST	R10	K6
+      0x7C1C0600,  //  0096  CALL	R7	3
+      0x80040E00,  //  0097  RET	1	R7
+      0x70020019,  //  0098  JMP		#00B3
+      0x541E0010,  //  0099  LDINT	R7	17
+      0x1C1C0C07,  //  009A  EQ	R7	R6	R7
+      0x781E0005,  //  009B  JMPF	R7	#00A2
+      0x8C1C0907,  //  009C  GETMET	R7	R4	K7
+      0x8824090A,  //  009D  GETMBR	R9	R4	K10
+      0x8828010E,  //  009E  GETMBR	R10	R0	K14
+      0x7C1C0600,  //  009F  CALL	R7	3
+      0x80040E00,  //  00A0  RET	1	R7
+      0x70020010,  //  00A1  JMP		#00B3
+      0x541EFFFB,  //  00A2  LDINT	R7	65532
+      0x1C1C0C07,  //  00A3  EQ	R7	R6	R7
+      0x781E0005,  //  00A4  JMPF	R7	#00AB
+      0x8C1C0907,  //  00A5  GETMET	R7	R4	K7
+      0x8824090B,  //  00A6  GETMBR	R9	R4	K11
+      0x58280009,  //  00A7  LDCONST	R10	K9
+      0x7C1C0600,  //  00A8  CALL	R7	3
+      0x80040E00,  //  00A9  RET	1	R7
+      0x70020007,  //  00AA  JMP		#00B3
+      0x541EFFFC,  //  00AB  LDINT	R7	65533
+      0x1C1C0C07,  //  00AC  EQ	R7	R6	R7
+      0x781E0004,  //  00AD  JMPF	R7	#00B3
+      0x8C1C0907,  //  00AE  GETMET	R7	R4	K7
+      0x8824090B,  //  00AF  GETMBR	R9	R4	K11
+      0x542A0004,  //  00B0  LDINT	R10	5
+      0x7C1C0600,  //  00B1  CALL	R7	3
+      0x80040E00,  //  00B2  RET	1	R7
+      0x70020007,  //  00B3  JMP		#00BC
+      0x601C0003,  //  00B4  GETGBL	R7	G3
+      0x5C200000,  //  00B5  MOVE	R8	R0
+      0x7C1C0200,  //  00B6  CALL	R7	1
+      0x8C1C0F10,  //  00B7  GETMET	R7	R7	K16
+      0x5C240200,  //  00B8  MOVE	R9	R1
+      0x5C280400,  //  00B9  MOVE	R10	R2
+      0x7C1C0600,  //  00BA  CALL	R7	3
+      0x80040E00,  //  00BB  RET	1	R7
+      0x80000000,  //  00BC  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Plugin_Light1_init,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(shadow_bri),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(shadow_onoff),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x600C0003,  //  0000  GETGBL	R3	G3
+      0x5C100000,  //  0001  MOVE	R4	R0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
+      0x5C140200,  //  0004  MOVE	R5	R1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x90020302,  //  0007  SETMBR	R0	K1	K2
+      0x500C0000,  //  0008  LDBOOL	R3	0	0
+      0x90020603,  //  0009  SETMBR	R0	K3	R3
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Matter_Plugin_Light1
+********************************************************************/
+extern const bclass be_class_Matter_Plugin;
+be_local_class(Matter_Plugin_Light1,
+    2,
+    &be_class_Matter_Plugin,
+    be_nested_map(9,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Light1_init_closure) },
+        { be_const_key_weak(shadow_onoff, -1), be_const_var(1) },
+        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(257, -1), be_const_int(2) },
+    }))    ) } )) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Plugin_Light1_every_second_closure) },
+        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(5,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(5, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(8,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(1),
+        be_const_int(2),
+        be_const_int(3),
+        be_const_int(4),
+        be_const_int(5),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+        { be_const_key_int(6, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(3,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+        { be_const_key_int(3, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(4,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(1),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+        { be_const_key_int(8, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(7,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(2),
+        be_const_int(3),
+        be_const_int(15),
+        be_const_int(17),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+        { be_const_key_int(4, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(3,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_Light1_invoke_request_closure) },
+        { be_const_key_weak(read_attribute, 0), be_const_closure(Matter_Plugin_Light1_read_attribute_closure) },
+        { be_const_key_weak(update_shadow, 8), be_const_closure(Matter_Plugin_Light1_update_shadow_closure) },
+        { be_const_key_weak(shadow_bri, -1), be_const_var(0) },
+    })),
+    be_str_weak(Matter_Plugin_Light1)
+);
+/*******************************************************************/
+
+void be_load_Matter_Plugin_Light1_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_Matter_Plugin_Light1);
+    be_setglobal(vm, "Matter_Plugin_Light1");
+    be_pop(vm, 1);
+}
+/********************************************************************/
+/* End of solidification */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light2.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light2.h
@@ -1,0 +1,892 @@
+/* Solidification of Matter_Plugin_Light2.h */
+/********************************************************************\
+* Generated code, don't edit                                         *
+\********************************************************************/
+#include "be_constobj.h"
+
+extern const bclass be_class_Matter_Plugin_Light2;
+
+/********************************************************************
+** Solidified function: update_ct_minmax
+********************************************************************/
+be_local_closure(Matter_Plugin_Light2_update_ct_minmax,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(get_option),
+    /* K2   */  be_nested_str_weak(ct_min),
+    /* K3   */  be_nested_str_weak(ct_max),
+    }),
+    be_str_weak(update_ct_minmax),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x540E0051,  //  0002  LDINT	R3	82
+      0x7C040400,  //  0003  CALL	R1	2
+      0x78060001,  //  0004  JMPF	R1	#0007
+      0x540A00C7,  //  0005  LDINT	R2	200
+      0x70020000,  //  0006  JMP		#0008
+      0x540A0098,  //  0007  LDINT	R2	153
+      0x90020402,  //  0008  SETMBR	R0	K2	R2
+      0x78060001,  //  0009  JMPF	R1	#000C
+      0x540A017B,  //  000A  LDINT	R2	380
+      0x70020000,  //  000B  JMP		#000D
+      0x540A01F3,  //  000C  LDINT	R2	500
+      0x90020602,  //  000D  SETMBR	R0	K3	R2
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Plugin_Light2_init,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(shadow_bri),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(shadow_ct),
+    /* K4   */  be_nested_str_weak(shadow_onoff),
+    /* K5   */  be_nested_str_weak(update_ct_minmax),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x600C0003,  //  0000  GETGBL	R3	G3
+      0x5C100000,  //  0001  MOVE	R4	R0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
+      0x5C140200,  //  0004  MOVE	R5	R1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x90020302,  //  0007  SETMBR	R0	K1	K2
+      0x540E0144,  //  0008  LDINT	R3	325
+      0x90020603,  //  0009  SETMBR	R0	K3	R3
+      0x500C0000,  //  000A  LDBOOL	R3	0	0
+      0x90020803,  //  000B  SETMBR	R0	K4	R3
+      0x8C0C0105,  //  000C  GETMET	R3	R0	K5
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Plugin_Light2_invoke_request,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[26]) {     /* constants */
+    /* K0   */  be_nested_str_weak(light),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(command),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(Matter_TLV_struct),
+    /* K9   */  be_nested_str_weak(add_TLV),
+    /* K10  */  be_nested_str_weak(U2),
+    /* K11  */  be_nested_str_weak(set),
+    /* K12  */  be_nested_str_weak(power),
+    /* K13  */  be_nested_str_weak(update_shadow),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(shadow_onoff),
+    /* K16  */  be_nested_str_weak(findsubval),
+    /* K17  */  be_nested_str_weak(tasmota),
+    /* K18  */  be_nested_str_weak(scale_uint),
+    /* K19  */  be_nested_str_weak(bri),
+    /* K20  */  be_nested_str_weak(log),
+    /* K21  */  be_nested_str_weak(bri_X3A),
+    /* K22  */  be_nested_str_weak(ct_min),
+    /* K23  */  be_nested_str_weak(ct_max),
+    /* K24  */  be_nested_str_weak(ct),
+    /* K25  */  be_nested_str_weak(ct_X3A),
+    }),
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[232]) {  /* code */
+      0xA4120000,  //  0000  IMPORT	R4	K0
+      0xB8160200,  //  0001  GETNGBL	R5	K1
+      0x88140B02,  //  0002  GETMBR	R5	R5	K2
+      0x88180703,  //  0003  GETMBR	R6	R3	K3
+      0x881C0704,  //  0004  GETMBR	R7	R3	K4
+      0x1C200D05,  //  0005  EQ	R8	R6	K5
+      0x78220016,  //  0006  JMPF	R8	#001E
+      0x1C200F06,  //  0007  EQ	R8	R7	K6
+      0x78220002,  //  0008  JMPF	R8	#000C
+      0x50200200,  //  0009  LDBOOL	R8	1	0
+      0x80041000,  //  000A  RET	1	R8
+      0x70020010,  //  000B  JMP		#001D
+      0x1C200F07,  //  000C  EQ	R8	R7	K7
+      0x78220009,  //  000D  JMPF	R8	#0018
+      0x8C200B08,  //  000E  GETMET	R8	R5	K8
+      0x7C200200,  //  000F  CALL	R8	1
+      0x8C241109,  //  0010  GETMET	R9	R8	K9
+      0x582C0006,  //  0011  LDCONST	R11	K6
+      0x88300B0A,  //  0012  GETMBR	R12	R5	K10
+      0x58340006,  //  0013  LDCONST	R13	K6
+      0x7C240800,  //  0014  CALL	R9	4
+      0x900E0906,  //  0015  SETMBR	R3	K4	K6
+      0x80041000,  //  0016  RET	1	R8
+      0x70020004,  //  0017  JMP		#001D
+      0x5422003F,  //  0018  LDINT	R8	64
+      0x1C200E08,  //  0019  EQ	R8	R7	R8
+      0x78220001,  //  001A  JMPF	R8	#001D
+      0x50200200,  //  001B  LDBOOL	R8	1	0
+      0x80041000,  //  001C  RET	1	R8
+      0x700200C8,  //  001D  JMP		#00E7
+      0x54220003,  //  001E  LDINT	R8	4
+      0x1C200C08,  //  001F  EQ	R8	R6	R8
+      0x78220002,  //  0020  JMPF	R8	#0024
+      0x50200200,  //  0021  LDBOOL	R8	1	0
+      0x80041000,  //  0022  RET	1	R8
+      0x700200C2,  //  0023  JMP		#00E7
+      0x54220004,  //  0024  LDINT	R8	5
+      0x1C200C08,  //  0025  EQ	R8	R6	R8
+      0x78220002,  //  0026  JMPF	R8	#002A
+      0x50200200,  //  0027  LDBOOL	R8	1	0
+      0x80041000,  //  0028  RET	1	R8
+      0x700200BC,  //  0029  JMP		#00E7
+      0x54220005,  //  002A  LDINT	R8	6
+      0x1C200C08,  //  002B  EQ	R8	R6	R8
+      0x78220029,  //  002C  JMPF	R8	#0057
+      0x1C200F06,  //  002D  EQ	R8	R7	K6
+      0x7822000A,  //  002E  JMPF	R8	#003A
+      0x8C20090B,  //  002F  GETMET	R8	R4	K11
+      0x60280013,  //  0030  GETGBL	R10	G19
+      0x7C280000,  //  0031  CALL	R10	0
+      0x502C0000,  //  0032  LDBOOL	R11	0	0
+      0x982A180B,  //  0033  SETIDX	R10	K12	R11
+      0x7C200400,  //  0034  CALL	R8	2
+      0x8C20010D,  //  0035  GETMET	R8	R0	K13
+      0x7C200200,  //  0036  CALL	R8	1
+      0x50200200,  //  0037  LDBOOL	R8	1	0
+      0x80041000,  //  0038  RET	1	R8
+      0x7002001B,  //  0039  JMP		#0056
+      0x1C200F07,  //  003A  EQ	R8	R7	K7
+      0x7822000A,  //  003B  JMPF	R8	#0047
+      0x8C20090B,  //  003C  GETMET	R8	R4	K11
+      0x60280013,  //  003D  GETGBL	R10	G19
+      0x7C280000,  //  003E  CALL	R10	0
+      0x502C0200,  //  003F  LDBOOL	R11	1	0
+      0x982A180B,  //  0040  SETIDX	R10	K12	R11
+      0x7C200400,  //  0041  CALL	R8	2
+      0x8C20010D,  //  0042  GETMET	R8	R0	K13
+      0x7C200200,  //  0043  CALL	R8	1
+      0x50200200,  //  0044  LDBOOL	R8	1	0
+      0x80041000,  //  0045  RET	1	R8
+      0x7002000E,  //  0046  JMP		#0056
+      0x1C200F0E,  //  0047  EQ	R8	R7	K14
+      0x7822000C,  //  0048  JMPF	R8	#0056
+      0x8C20090B,  //  0049  GETMET	R8	R4	K11
+      0x60280013,  //  004A  GETGBL	R10	G19
+      0x7C280000,  //  004B  CALL	R10	0
+      0x882C010F,  //  004C  GETMBR	R11	R0	K15
+      0x782E0000,  //  004D  JMPF	R11	#004F
+      0x502C0001,  //  004E  LDBOOL	R11	0	1
+      0x502C0200,  //  004F  LDBOOL	R11	1	0
+      0x982A180B,  //  0050  SETIDX	R10	K12	R11
+      0x7C200400,  //  0051  CALL	R8	2
+      0x8C20010D,  //  0052  GETMET	R8	R0	K13
+      0x7C200200,  //  0053  CALL	R8	1
+      0x50200200,  //  0054  LDBOOL	R8	1	0
+      0x80041000,  //  0055  RET	1	R8
+      0x7002008F,  //  0056  JMP		#00E7
+      0x54220007,  //  0057  LDINT	R8	8
+      0x1C200C08,  //  0058  EQ	R8	R6	R8
+      0x7822005B,  //  0059  JMPF	R8	#00B6
+      0x1C200F06,  //  005A  EQ	R8	R7	K6
+      0x78220019,  //  005B  JMPF	R8	#0076
+      0x8C200510,  //  005C  GETMET	R8	R2	K16
+      0x58280006,  //  005D  LDCONST	R10	K6
+      0x7C200400,  //  005E  CALL	R8	2
+      0xB8262200,  //  005F  GETNGBL	R9	K17
+      0x8C241312,  //  0060  GETMET	R9	R9	K18
+      0x5C2C1000,  //  0061  MOVE	R11	R8
+      0x58300006,  //  0062  LDCONST	R12	K6
+      0x543600FD,  //  0063  LDINT	R13	254
+      0x58380006,  //  0064  LDCONST	R14	K6
+      0x543E00FE,  //  0065  LDINT	R15	255
+      0x7C240C00,  //  0066  CALL	R9	6
+      0x8C28090B,  //  0067  GETMET	R10	R4	K11
+      0x60300013,  //  0068  GETGBL	R12	G19
+      0x7C300000,  //  0069  CALL	R12	0
+      0x98322609,  //  006A  SETIDX	R12	K19	R9
+      0x7C280400,  //  006B  CALL	R10	2
+      0x8C28010D,  //  006C  GETMET	R10	R0	K13
+      0x7C280200,  //  006D  CALL	R10	1
+      0x60280008,  //  006E  GETGBL	R10	G8
+      0x5C2C1000,  //  006F  MOVE	R11	R8
+      0x7C280200,  //  0070  CALL	R10	1
+      0x002A2A0A,  //  0071  ADD	R10	K21	R10
+      0x900E280A,  //  0072  SETMBR	R3	K20	R10
+      0x50280200,  //  0073  LDBOOL	R10	1	0
+      0x80041400,  //  0074  RET	1	R10
+      0x7002003E,  //  0075  JMP		#00B5
+      0x1C200F07,  //  0076  EQ	R8	R7	K7
+      0x78220002,  //  0077  JMPF	R8	#007B
+      0x50200200,  //  0078  LDBOOL	R8	1	0
+      0x80041000,  //  0079  RET	1	R8
+      0x70020039,  //  007A  JMP		#00B5
+      0x1C200F0E,  //  007B  EQ	R8	R7	K14
+      0x78220002,  //  007C  JMPF	R8	#0080
+      0x50200200,  //  007D  LDBOOL	R8	1	0
+      0x80041000,  //  007E  RET	1	R8
+      0x70020034,  //  007F  JMP		#00B5
+      0x1C200F05,  //  0080  EQ	R8	R7	K5
+      0x78220002,  //  0081  JMPF	R8	#0085
+      0x50200200,  //  0082  LDBOOL	R8	1	0
+      0x80041000,  //  0083  RET	1	R8
+      0x7002002F,  //  0084  JMP		#00B5
+      0x54220003,  //  0085  LDINT	R8	4
+      0x1C200E08,  //  0086  EQ	R8	R7	R8
+      0x7822001B,  //  0087  JMPF	R8	#00A4
+      0x8C200510,  //  0088  GETMET	R8	R2	K16
+      0x58280006,  //  0089  LDCONST	R10	K6
+      0x7C200400,  //  008A  CALL	R8	2
+      0xB8262200,  //  008B  GETNGBL	R9	K17
+      0x8C241312,  //  008C  GETMET	R9	R9	K18
+      0x5C2C1000,  //  008D  MOVE	R11	R8
+      0x58300006,  //  008E  LDCONST	R12	K6
+      0x543600FD,  //  008F  LDINT	R13	254
+      0x58380006,  //  0090  LDCONST	R14	K6
+      0x543E00FE,  //  0091  LDINT	R15	255
+      0x7C240C00,  //  0092  CALL	R9	6
+      0x24281306,  //  0093  GT	R10	R9	K6
+      0x8C2C090B,  //  0094  GETMET	R11	R4	K11
+      0x60340013,  //  0095  GETGBL	R13	G19
+      0x7C340000,  //  0096  CALL	R13	0
+      0x98362609,  //  0097  SETIDX	R13	K19	R9
+      0x9836180A,  //  0098  SETIDX	R13	K12	R10
+      0x7C2C0400,  //  0099  CALL	R11	2
+      0x8C2C010D,  //  009A  GETMET	R11	R0	K13
+      0x7C2C0200,  //  009B  CALL	R11	1
+      0x602C0008,  //  009C  GETGBL	R11	G8
+      0x5C301000,  //  009D  MOVE	R12	R8
+      0x7C2C0200,  //  009E  CALL	R11	1
+      0x002E2A0B,  //  009F  ADD	R11	K21	R11
+      0x900E280B,  //  00A0  SETMBR	R3	K20	R11
+      0x502C0200,  //  00A1  LDBOOL	R11	1	0
+      0x80041600,  //  00A2  RET	1	R11
+      0x70020010,  //  00A3  JMP		#00B5
+      0x54220004,  //  00A4  LDINT	R8	5
+      0x1C200E08,  //  00A5  EQ	R8	R7	R8
+      0x78220002,  //  00A6  JMPF	R8	#00AA
+      0x50200200,  //  00A7  LDBOOL	R8	1	0
+      0x80041000,  //  00A8  RET	1	R8
+      0x7002000A,  //  00A9  JMP		#00B5
+      0x54220005,  //  00AA  LDINT	R8	6
+      0x1C200E08,  //  00AB  EQ	R8	R7	R8
+      0x78220002,  //  00AC  JMPF	R8	#00B0
+      0x50200200,  //  00AD  LDBOOL	R8	1	0
+      0x80041000,  //  00AE  RET	1	R8
+      0x70020004,  //  00AF  JMP		#00B5
+      0x54220006,  //  00B0  LDINT	R8	7
+      0x1C200E08,  //  00B1  EQ	R8	R7	R8
+      0x78220001,  //  00B2  JMPF	R8	#00B5
+      0x50200200,  //  00B3  LDBOOL	R8	1	0
+      0x80041000,  //  00B4  RET	1	R8
+      0x70020030,  //  00B5  JMP		#00E7
+      0x542202FF,  //  00B6  LDINT	R8	768
+      0x1C200C08,  //  00B7  EQ	R8	R6	R8
+      0x7822002D,  //  00B8  JMPF	R8	#00E7
+      0x54220009,  //  00B9  LDINT	R8	10
+      0x1C200E08,  //  00BA  EQ	R8	R7	R8
+      0x78220019,  //  00BB  JMPF	R8	#00D6
+      0x8C200510,  //  00BC  GETMET	R8	R2	K16
+      0x58280006,  //  00BD  LDCONST	R10	K6
+      0x7C200400,  //  00BE  CALL	R8	2
+      0x88240116,  //  00BF  GETMBR	R9	R0	K22
+      0x14241009,  //  00C0  LT	R9	R8	R9
+      0x78260000,  //  00C1  JMPF	R9	#00C3
+      0x88200116,  //  00C2  GETMBR	R8	R0	K22
+      0x88240117,  //  00C3  GETMBR	R9	R0	K23
+      0x24241009,  //  00C4  GT	R9	R8	R9
+      0x78260000,  //  00C5  JMPF	R9	#00C7
+      0x88200117,  //  00C6  GETMBR	R8	R0	K23
+      0x8C24090B,  //  00C7  GETMET	R9	R4	K11
+      0x602C0013,  //  00C8  GETGBL	R11	G19
+      0x7C2C0000,  //  00C9  CALL	R11	0
+      0x982E3008,  //  00CA  SETIDX	R11	K24	R8
+      0x7C240400,  //  00CB  CALL	R9	2
+      0x8C24010D,  //  00CC  GETMET	R9	R0	K13
+      0x7C240200,  //  00CD  CALL	R9	1
+      0x60240008,  //  00CE  GETGBL	R9	G8
+      0x5C281000,  //  00CF  MOVE	R10	R8
+      0x7C240200,  //  00D0  CALL	R9	1
+      0x00263209,  //  00D1  ADD	R9	K25	R9
+      0x900E2809,  //  00D2  SETMBR	R3	K20	R9
+      0x50240200,  //  00D3  LDBOOL	R9	1	0
+      0x80041200,  //  00D4  RET	1	R9
+      0x70020010,  //  00D5  JMP		#00E7
+      0x54220046,  //  00D6  LDINT	R8	71
+      0x1C200E08,  //  00D7  EQ	R8	R7	R8
+      0x78220002,  //  00D8  JMPF	R8	#00DC
+      0x50200200,  //  00D9  LDBOOL	R8	1	0
+      0x80041000,  //  00DA  RET	1	R8
+      0x7002000A,  //  00DB  JMP		#00E7
+      0x5422004A,  //  00DC  LDINT	R8	75
+      0x1C200E08,  //  00DD  EQ	R8	R7	R8
+      0x78220002,  //  00DE  JMPF	R8	#00E2
+      0x50200200,  //  00DF  LDBOOL	R8	1	0
+      0x80041000,  //  00E0  RET	1	R8
+      0x70020004,  //  00E1  JMP		#00E7
+      0x5422004B,  //  00E2  LDINT	R8	76
+      0x1C200E08,  //  00E3  EQ	R8	R7	R8
+      0x78220001,  //  00E4  JMPF	R8	#00E7
+      0x50200200,  //  00E5  LDBOOL	R8	1	0
+      0x80041000,  //  00E6  RET	1	R8
+      0x80000000,  //  00E7  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_shadow
+********************************************************************/
+be_local_closure(Matter_Plugin_Light2_update_shadow,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(light),
+    /* K1   */  be_nested_str_weak(update_ct_minmax),
+    /* K2   */  be_nested_str_weak(get),
+    /* K3   */  be_nested_str_weak(find),
+    /* K4   */  be_nested_str_weak(power),
+    /* K5   */  be_nested_str_weak(bri),
+    /* K6   */  be_nested_str_weak(ct),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(scale_uint),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_nested_str_weak(shadow_bri),
+    /* K11  */  be_nested_str_weak(shadow_ct),
+    /* K12  */  be_nested_str_weak(shadow_onoff),
+    /* K13  */  be_nested_str_weak(attribute_updated),
+    }),
+    be_str_weak(update_shadow),
+    &be_const_str_solidified,
+    ( &(const binstruction[63]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x7C080200,  //  0004  CALL	R2	1
+      0x8C0C0503,  //  0005  GETMET	R3	R2	K3
+      0x58140004,  //  0006  LDCONST	R5	K4
+      0x4C180000,  //  0007  LDNIL	R6
+      0x7C0C0600,  //  0008  CALL	R3	3
+      0x8C100503,  //  0009  GETMET	R4	R2	K3
+      0x58180005,  //  000A  LDCONST	R6	K5
+      0x4C1C0000,  //  000B  LDNIL	R7
+      0x7C100600,  //  000C  CALL	R4	3
+      0x8C140503,  //  000D  GETMET	R5	R2	K3
+      0x581C0006,  //  000E  LDCONST	R7	K6
+      0x4C200000,  //  000F  LDNIL	R8
+      0x7C140600,  //  0010  CALL	R5	3
+      0x4C180000,  //  0011  LDNIL	R6
+      0x20180806,  //  0012  NE	R6	R4	R6
+      0x781A0009,  //  0013  JMPF	R6	#001E
+      0xB81A0E00,  //  0014  GETNGBL	R6	K7
+      0x8C180D08,  //  0015  GETMET	R6	R6	K8
+      0x5C200800,  //  0016  MOVE	R8	R4
+      0x58240009,  //  0017  LDCONST	R9	K9
+      0x542A00FE,  //  0018  LDINT	R10	255
+      0x582C0009,  //  0019  LDCONST	R11	K9
+      0x543200FD,  //  001A  LDINT	R12	254
+      0x7C180C00,  //  001B  CALL	R6	6
+      0x5C100C00,  //  001C  MOVE	R4	R6
+      0x70020000,  //  001D  JMP		#001F
+      0x8810010A,  //  001E  GETMBR	R4	R0	K10
+      0x4C180000,  //  001F  LDNIL	R6
+      0x1C180A06,  //  0020  EQ	R6	R5	R6
+      0x781A0000,  //  0021  JMPF	R6	#0023
+      0x8814010B,  //  0022  GETMBR	R5	R0	K11
+      0x8818010C,  //  0023  GETMBR	R6	R0	K12
+      0x20180606,  //  0024  NE	R6	R3	R6
+      0x781A0005,  //  0025  JMPF	R6	#002C
+      0x8C18010D,  //  0026  GETMET	R6	R0	K13
+      0x4C200000,  //  0027  LDNIL	R8
+      0x54260005,  //  0028  LDINT	R9	6
+      0x58280009,  //  0029  LDCONST	R10	K9
+      0x7C180800,  //  002A  CALL	R6	4
+      0x90021803,  //  002B  SETMBR	R0	K12	R3
+      0x8818010A,  //  002C  GETMBR	R6	R0	K10
+      0x20180806,  //  002D  NE	R6	R4	R6
+      0x781A0005,  //  002E  JMPF	R6	#0035
+      0x8C18010D,  //  002F  GETMET	R6	R0	K13
+      0x4C200000,  //  0030  LDNIL	R8
+      0x54260007,  //  0031  LDINT	R9	8
+      0x58280009,  //  0032  LDCONST	R10	K9
+      0x7C180800,  //  0033  CALL	R6	4
+      0x90021404,  //  0034  SETMBR	R0	K10	R4
+      0x8818010B,  //  0035  GETMBR	R6	R0	K11
+      0x20180A06,  //  0036  NE	R6	R5	R6
+      0x781A0005,  //  0037  JMPF	R6	#003E
+      0x8C18010D,  //  0038  GETMET	R6	R0	K13
+      0x4C200000,  //  0039  LDNIL	R8
+      0x542602FF,  //  003A  LDINT	R9	768
+      0x542A0006,  //  003B  LDINT	R10	7
+      0x7C180800,  //  003C  CALL	R6	4
+      0x90021605,  //  003D  SETMBR	R0	K11	R5
+      0x80000000,  //  003E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Plugin_Light2_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(update_shadow),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_attribute
+********************************************************************/
+be_local_closure(Matter_Plugin_Light2_read_attribute,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[20]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(create_TLV),
+    /* K8   */  be_nested_str_weak(U2),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(U1),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_nested_str_weak(BOOL),
+    /* K13  */  be_nested_str_weak(shadow_onoff),
+    /* K14  */  be_nested_str_weak(shadow_bri),
+    /* K15  */  be_const_int(2),
+    /* K16  */  be_nested_str_weak(shadow_ct),
+    /* K17  */  be_nested_str_weak(ct_min),
+    /* K18  */  be_nested_str_weak(ct_max),
+    /* K19  */  be_nested_str_weak(read_attribute),
+    }),
+    be_str_weak(read_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[255]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x88100902,  //  0002  GETMBR	R4	R4	K2
+      0x88140503,  //  0003  GETMBR	R5	R2	K3
+      0x88180504,  //  0004  GETMBR	R6	R2	K4
+      0x1C1C0B05,  //  0005  EQ	R7	R5	K5
+      0x781E0021,  //  0006  JMPF	R7	#0029
+      0x1C1C0D06,  //  0007  EQ	R7	R6	K6
+      0x781E0005,  //  0008  JMPF	R7	#000F
+      0x8C1C0907,  //  0009  GETMET	R7	R4	K7
+      0x88240908,  //  000A  GETMBR	R9	R4	K8
+      0x58280006,  //  000B  LDCONST	R10	K6
+      0x7C1C0600,  //  000C  CALL	R7	3
+      0x80040E00,  //  000D  RET	1	R7
+      0x70020018,  //  000E  JMP		#0028
+      0x1C1C0D09,  //  000F  EQ	R7	R6	K9
+      0x781E0005,  //  0010  JMPF	R7	#0017
+      0x8C1C0907,  //  0011  GETMET	R7	R4	K7
+      0x8824090A,  //  0012  GETMBR	R9	R4	K10
+      0x58280006,  //  0013  LDCONST	R10	K6
+      0x7C1C0600,  //  0014  CALL	R7	3
+      0x80040E00,  //  0015  RET	1	R7
+      0x70020010,  //  0016  JMP		#0028
+      0x541EFFFB,  //  0017  LDINT	R7	65532
+      0x1C1C0C07,  //  0018  EQ	R7	R6	R7
+      0x781E0005,  //  0019  JMPF	R7	#0020
+      0x8C1C0907,  //  001A  GETMET	R7	R4	K7
+      0x8824090B,  //  001B  GETMBR	R9	R4	K11
+      0x58280006,  //  001C  LDCONST	R10	K6
+      0x7C1C0600,  //  001D  CALL	R7	3
+      0x80040E00,  //  001E  RET	1	R7
+      0x70020007,  //  001F  JMP		#0028
+      0x541EFFFC,  //  0020  LDINT	R7	65533
+      0x1C1C0C07,  //  0021  EQ	R7	R6	R7
+      0x781E0004,  //  0022  JMPF	R7	#0028
+      0x8C1C0907,  //  0023  GETMET	R7	R4	K7
+      0x8824090B,  //  0024  GETMBR	R9	R4	K11
+      0x542A0003,  //  0025  LDINT	R10	4
+      0x7C1C0600,  //  0026  CALL	R7	3
+      0x80040E00,  //  0027  RET	1	R7
+      0x700200D4,  //  0028  JMP		#00FE
+      0x541E0003,  //  0029  LDINT	R7	4
+      0x1C1C0A07,  //  002A  EQ	R7	R5	R7
+      0x781E0016,  //  002B  JMPF	R7	#0043
+      0x1C1C0D06,  //  002C  EQ	R7	R6	K6
+      0x781E0002,  //  002D  JMPF	R7	#0031
+      0x4C1C0000,  //  002E  LDNIL	R7
+      0x80040E00,  //  002F  RET	1	R7
+      0x70020010,  //  0030  JMP		#0042
+      0x541EFFFB,  //  0031  LDINT	R7	65532
+      0x1C1C0C07,  //  0032  EQ	R7	R6	R7
+      0x781E0005,  //  0033  JMPF	R7	#003A
+      0x8C1C0907,  //  0034  GETMET	R7	R4	K7
+      0x8824090B,  //  0035  GETMBR	R9	R4	K11
+      0x58280006,  //  0036  LDCONST	R10	K6
+      0x7C1C0600,  //  0037  CALL	R7	3
+      0x80040E00,  //  0038  RET	1	R7
+      0x70020007,  //  0039  JMP		#0042
+      0x541EFFFC,  //  003A  LDINT	R7	65533
+      0x1C1C0C07,  //  003B  EQ	R7	R6	R7
+      0x781E0004,  //  003C  JMPF	R7	#0042
+      0x8C1C0907,  //  003D  GETMET	R7	R4	K7
+      0x8824090B,  //  003E  GETMBR	R9	R4	K11
+      0x542A0003,  //  003F  LDINT	R10	4
+      0x7C1C0600,  //  0040  CALL	R7	3
+      0x80040E00,  //  0041  RET	1	R7
+      0x700200BA,  //  0042  JMP		#00FE
+      0x541E0004,  //  0043  LDINT	R7	5
+      0x1C1C0A07,  //  0044  EQ	R7	R5	R7
+      0x781E0011,  //  0045  JMPF	R7	#0058
+      0x541EFFFB,  //  0046  LDINT	R7	65532
+      0x1C1C0C07,  //  0047  EQ	R7	R6	R7
+      0x781E0005,  //  0048  JMPF	R7	#004F
+      0x8C1C0907,  //  0049  GETMET	R7	R4	K7
+      0x8824090B,  //  004A  GETMBR	R9	R4	K11
+      0x58280006,  //  004B  LDCONST	R10	K6
+      0x7C1C0600,  //  004C  CALL	R7	3
+      0x80040E00,  //  004D  RET	1	R7
+      0x70020007,  //  004E  JMP		#0057
+      0x541EFFFC,  //  004F  LDINT	R7	65533
+      0x1C1C0C07,  //  0050  EQ	R7	R6	R7
+      0x781E0004,  //  0051  JMPF	R7	#0057
+      0x8C1C0907,  //  0052  GETMET	R7	R4	K7
+      0x8824090B,  //  0053  GETMBR	R9	R4	K11
+      0x542A0003,  //  0054  LDINT	R10	4
+      0x7C1C0600,  //  0055  CALL	R7	3
+      0x80040E00,  //  0056  RET	1	R7
+      0x700200A5,  //  0057  JMP		#00FE
+      0x541E0005,  //  0058  LDINT	R7	6
+      0x1C1C0A07,  //  0059  EQ	R7	R5	R7
+      0x781E0019,  //  005A  JMPF	R7	#0075
+      0x1C1C0D06,  //  005B  EQ	R7	R6	K6
+      0x781E0005,  //  005C  JMPF	R7	#0063
+      0x8C1C0907,  //  005D  GETMET	R7	R4	K7
+      0x8824090C,  //  005E  GETMBR	R9	R4	K12
+      0x8828010D,  //  005F  GETMBR	R10	R0	K13
+      0x7C1C0600,  //  0060  CALL	R7	3
+      0x80040E00,  //  0061  RET	1	R7
+      0x70020010,  //  0062  JMP		#0074
+      0x541EFFFB,  //  0063  LDINT	R7	65532
+      0x1C1C0C07,  //  0064  EQ	R7	R6	R7
+      0x781E0005,  //  0065  JMPF	R7	#006C
+      0x8C1C0907,  //  0066  GETMET	R7	R4	K7
+      0x8824090B,  //  0067  GETMBR	R9	R4	K11
+      0x58280006,  //  0068  LDCONST	R10	K6
+      0x7C1C0600,  //  0069  CALL	R7	3
+      0x80040E00,  //  006A  RET	1	R7
+      0x70020007,  //  006B  JMP		#0074
+      0x541EFFFC,  //  006C  LDINT	R7	65533
+      0x1C1C0C07,  //  006D  EQ	R7	R6	R7
+      0x781E0004,  //  006E  JMPF	R7	#0074
+      0x8C1C0907,  //  006F  GETMET	R7	R4	K7
+      0x8824090B,  //  0070  GETMBR	R9	R4	K11
+      0x542A0003,  //  0071  LDINT	R10	4
+      0x7C1C0600,  //  0072  CALL	R7	3
+      0x80040E00,  //  0073  RET	1	R7
+      0x70020088,  //  0074  JMP		#00FE
+      0x541E0007,  //  0075  LDINT	R7	8
+      0x1C1C0A07,  //  0076  EQ	R7	R5	R7
+      0x781E003B,  //  0077  JMPF	R7	#00B4
+      0x1C1C0D06,  //  0078  EQ	R7	R6	K6
+      0x781E0005,  //  0079  JMPF	R7	#0080
+      0x8C1C0907,  //  007A  GETMET	R7	R4	K7
+      0x8824090A,  //  007B  GETMBR	R9	R4	K10
+      0x8828010E,  //  007C  GETMBR	R10	R0	K14
+      0x7C1C0600,  //  007D  CALL	R7	3
+      0x80040E00,  //  007E  RET	1	R7
+      0x70020032,  //  007F  JMP		#00B3
+      0x1C1C0D0F,  //  0080  EQ	R7	R6	K15
+      0x781E0005,  //  0081  JMPF	R7	#0088
+      0x8C1C0907,  //  0082  GETMET	R7	R4	K7
+      0x8824090A,  //  0083  GETMBR	R9	R4	K10
+      0x58280006,  //  0084  LDCONST	R10	K6
+      0x7C1C0600,  //  0085  CALL	R7	3
+      0x80040E00,  //  0086  RET	1	R7
+      0x7002002A,  //  0087  JMP		#00B3
+      0x1C1C0D05,  //  0088  EQ	R7	R6	K5
+      0x781E0005,  //  0089  JMPF	R7	#0090
+      0x8C1C0907,  //  008A  GETMET	R7	R4	K7
+      0x8824090A,  //  008B  GETMBR	R9	R4	K10
+      0x542A00FD,  //  008C  LDINT	R10	254
+      0x7C1C0600,  //  008D  CALL	R7	3
+      0x80040E00,  //  008E  RET	1	R7
+      0x70020022,  //  008F  JMP		#00B3
+      0x541E000E,  //  0090  LDINT	R7	15
+      0x1C1C0C07,  //  0091  EQ	R7	R6	R7
+      0x781E0005,  //  0092  JMPF	R7	#0099
+      0x8C1C0907,  //  0093  GETMET	R7	R4	K7
+      0x8824090A,  //  0094  GETMBR	R9	R4	K10
+      0x58280006,  //  0095  LDCONST	R10	K6
+      0x7C1C0600,  //  0096  CALL	R7	3
+      0x80040E00,  //  0097  RET	1	R7
+      0x70020019,  //  0098  JMP		#00B3
+      0x541E0010,  //  0099  LDINT	R7	17
+      0x1C1C0C07,  //  009A  EQ	R7	R6	R7
+      0x781E0005,  //  009B  JMPF	R7	#00A2
+      0x8C1C0907,  //  009C  GETMET	R7	R4	K7
+      0x8824090A,  //  009D  GETMBR	R9	R4	K10
+      0x8828010E,  //  009E  GETMBR	R10	R0	K14
+      0x7C1C0600,  //  009F  CALL	R7	3
+      0x80040E00,  //  00A0  RET	1	R7
+      0x70020010,  //  00A1  JMP		#00B3
+      0x541EFFFB,  //  00A2  LDINT	R7	65532
+      0x1C1C0C07,  //  00A3  EQ	R7	R6	R7
+      0x781E0005,  //  00A4  JMPF	R7	#00AB
+      0x8C1C0907,  //  00A5  GETMET	R7	R4	K7
+      0x8824090B,  //  00A6  GETMBR	R9	R4	K11
+      0x58280009,  //  00A7  LDCONST	R10	K9
+      0x7C1C0600,  //  00A8  CALL	R7	3
+      0x80040E00,  //  00A9  RET	1	R7
+      0x70020007,  //  00AA  JMP		#00B3
+      0x541EFFFC,  //  00AB  LDINT	R7	65533
+      0x1C1C0C07,  //  00AC  EQ	R7	R6	R7
+      0x781E0004,  //  00AD  JMPF	R7	#00B3
+      0x8C1C0907,  //  00AE  GETMET	R7	R4	K7
+      0x8824090B,  //  00AF  GETMBR	R9	R4	K11
+      0x542A0004,  //  00B0  LDINT	R10	5
+      0x7C1C0600,  //  00B1  CALL	R7	3
+      0x80040E00,  //  00B2  RET	1	R7
+      0x70020049,  //  00B3  JMP		#00FE
+      0x541E02FF,  //  00B4  LDINT	R7	768
+      0x1C1C0A07,  //  00B5  EQ	R7	R5	R7
+      0x781E003E,  //  00B6  JMPF	R7	#00F6
+      0x541E0006,  //  00B7  LDINT	R7	7
+      0x1C1C0C07,  //  00B8  EQ	R7	R6	R7
+      0x781E0005,  //  00B9  JMPF	R7	#00C0
+      0x8C1C0907,  //  00BA  GETMET	R7	R4	K7
+      0x8824090A,  //  00BB  GETMBR	R9	R4	K10
+      0x88280110,  //  00BC  GETMBR	R10	R0	K16
+      0x7C1C0600,  //  00BD  CALL	R7	3
+      0x80040E00,  //  00BE  RET	1	R7
+      0x70020034,  //  00BF  JMP		#00F5
+      0x541E0007,  //  00C0  LDINT	R7	8
+      0x1C1C0C07,  //  00C1  EQ	R7	R6	R7
+      0x781E0005,  //  00C2  JMPF	R7	#00C9
+      0x8C1C0907,  //  00C3  GETMET	R7	R4	K7
+      0x8824090A,  //  00C4  GETMBR	R9	R4	K10
+      0x5828000F,  //  00C5  LDCONST	R10	K15
+      0x7C1C0600,  //  00C6  CALL	R7	3
+      0x80040E00,  //  00C7  RET	1	R7
+      0x7002002B,  //  00C8  JMP		#00F5
+      0x541E000E,  //  00C9  LDINT	R7	15
+      0x1C1C0C07,  //  00CA  EQ	R7	R6	R7
+      0x781E0005,  //  00CB  JMPF	R7	#00D2
+      0x8C1C0907,  //  00CC  GETMET	R7	R4	K7
+      0x8824090A,  //  00CD  GETMBR	R9	R4	K10
+      0x58280006,  //  00CE  LDCONST	R10	K6
+      0x7C1C0600,  //  00CF  CALL	R7	3
+      0x80040E00,  //  00D0  RET	1	R7
+      0x70020022,  //  00D1  JMP		#00F5
+      0x541E400A,  //  00D2  LDINT	R7	16395
+      0x1C1C0C07,  //  00D3  EQ	R7	R6	R7
+      0x781E0005,  //  00D4  JMPF	R7	#00DB
+      0x8C1C0907,  //  00D5  GETMET	R7	R4	K7
+      0x8824090A,  //  00D6  GETMBR	R9	R4	K10
+      0x88280111,  //  00D7  GETMBR	R10	R0	K17
+      0x7C1C0600,  //  00D8  CALL	R7	3
+      0x80040E00,  //  00D9  RET	1	R7
+      0x70020019,  //  00DA  JMP		#00F5
+      0x541E400B,  //  00DB  LDINT	R7	16396
+      0x1C1C0C07,  //  00DC  EQ	R7	R6	R7
+      0x781E0005,  //  00DD  JMPF	R7	#00E4
+      0x8C1C0907,  //  00DE  GETMET	R7	R4	K7
+      0x8824090A,  //  00DF  GETMBR	R9	R4	K10
+      0x88280112,  //  00E0  GETMBR	R10	R0	K18
+      0x7C1C0600,  //  00E1  CALL	R7	3
+      0x80040E00,  //  00E2  RET	1	R7
+      0x70020010,  //  00E3  JMP		#00F5
+      0x541EFFFB,  //  00E4  LDINT	R7	65532
+      0x1C1C0C07,  //  00E5  EQ	R7	R6	R7
+      0x781E0005,  //  00E6  JMPF	R7	#00ED
+      0x8C1C0907,  //  00E7  GETMET	R7	R4	K7
+      0x8824090B,  //  00E8  GETMBR	R9	R4	K11
+      0x542A000F,  //  00E9  LDINT	R10	16
+      0x7C1C0600,  //  00EA  CALL	R7	3
+      0x80040E00,  //  00EB  RET	1	R7
+      0x70020007,  //  00EC  JMP		#00F5
+      0x541EFFFC,  //  00ED  LDINT	R7	65533
+      0x1C1C0C07,  //  00EE  EQ	R7	R6	R7
+      0x781E0004,  //  00EF  JMPF	R7	#00F5
+      0x8C1C0907,  //  00F0  GETMET	R7	R4	K7
+      0x8824090B,  //  00F1  GETMBR	R9	R4	K11
+      0x542A0004,  //  00F2  LDINT	R10	5
+      0x7C1C0600,  //  00F3  CALL	R7	3
+      0x80040E00,  //  00F4  RET	1	R7
+      0x70020007,  //  00F5  JMP		#00FE
+      0x601C0003,  //  00F6  GETGBL	R7	G3
+      0x5C200000,  //  00F7  MOVE	R8	R0
+      0x7C1C0200,  //  00F8  CALL	R7	1
+      0x8C1C0F13,  //  00F9  GETMET	R7	R7	K19
+      0x5C240200,  //  00FA  MOVE	R9	R1
+      0x5C280400,  //  00FB  MOVE	R10	R2
+      0x7C1C0600,  //  00FC  CALL	R7	3
+      0x80040E00,  //  00FD  RET	1	R7
+      0x80000000,  //  00FE  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Matter_Plugin_Light2
+********************************************************************/
+extern const bclass be_class_Matter_Plugin;
+be_local_class(Matter_Plugin_Light2,
+    5,
+    &be_class_Matter_Plugin,
+    be_nested_map(13,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(shadow_onoff, 1), be_const_var(4) },
+        { be_const_key_weak(ct_min, -1), be_const_var(2) },
+        { be_const_key_weak(update_ct_minmax, -1), be_const_closure(Matter_Plugin_Light2_update_ct_minmax_closure) },
+        { be_const_key_weak(invoke_request, 2), be_const_closure(Matter_Plugin_Light2_invoke_request_closure) },
+        { be_const_key_weak(shadow_ct, -1), be_const_var(1) },
+        { be_const_key_weak(ct_max, 3), be_const_var(3) },
+        { be_const_key_weak(init, 4), be_const_closure(Matter_Plugin_Light2_init_closure) },
+        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_Light2_update_shadow_closure) },
+        { be_const_key_weak(shadow_bri, -1), be_const_var(0) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Plugin_Light2_every_second_closure) },
+        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(5,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(5, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(8,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(1),
+        be_const_int(2),
+        be_const_int(3),
+        be_const_int(4),
+        be_const_int(5),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+        { be_const_key_int(6, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(3,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+        { be_const_key_int(3, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(4,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(1),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+        { be_const_key_int(8, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(7,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(2),
+        be_const_int(3),
+        be_const_int(15),
+        be_const_int(17),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+        { be_const_key_int(4, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(3,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Light2_read_attribute_closure) },
+        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(268, -1), be_const_int(2) },
+    }))    ) } )) },
+    })),
+    be_str_weak(Matter_Plugin_Light2)
+);
+/*******************************************************************/
+
+void be_load_Matter_Plugin_Light2_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_Matter_Plugin_Light2);
+    be_setglobal(vm, "Matter_Plugin_Light2");
+    be_pop(vm, 1);
+}
+/********************************************************************/
+/* End of solidification */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light3.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light3.h
@@ -7,74 +7,365 @@
 extern const bclass be_class_Matter_Plugin_Light3;
 
 /********************************************************************
-** Solidified function: onoff_changed
+** Solidified function: invoke_request
 ********************************************************************/
-be_local_closure(Matter_Plugin_Light3_onoff_changed,   /* name */
+be_local_closure(Matter_Plugin_Light3_invoke_request,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
+    18,                          /* nstack */
+    4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_updated),
-    /* K1   */  be_const_int(0),
+    ( &(const bvalue[27]) {     /* constants */
+    /* K0   */  be_nested_str_weak(light),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(command),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(Matter_TLV_struct),
+    /* K9   */  be_nested_str_weak(add_TLV),
+    /* K10  */  be_nested_str_weak(U2),
+    /* K11  */  be_nested_str_weak(set),
+    /* K12  */  be_nested_str_weak(power),
+    /* K13  */  be_nested_str_weak(update_shadow),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(shadow_onoff),
+    /* K16  */  be_nested_str_weak(findsubval),
+    /* K17  */  be_nested_str_weak(tasmota),
+    /* K18  */  be_nested_str_weak(scale_uint),
+    /* K19  */  be_nested_str_weak(bri),
+    /* K20  */  be_nested_str_weak(log),
+    /* K21  */  be_nested_str_weak(bri_X3A),
+    /* K22  */  be_nested_str_weak(hue),
+    /* K23  */  be_nested_str_weak(hue_X3A),
+    /* K24  */  be_nested_str_weak(sat),
+    /* K25  */  be_nested_str_weak(sat_X3A),
+    /* K26  */  be_nested_str_weak(_X20sat_X3A),
     }),
-    be_str_weak(onoff_changed),
+    be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x54120005,  //  0002  LDINT	R4	6
-      0x58140001,  //  0003  LDCONST	R5	K1
-      0x7C040800,  //  0004  CALL	R1	4
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Plugin_Light3_init,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(shadow_hue),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(shadow_bri),
-    /* K4   */  be_nested_str_weak(shadow_sat),
-    /* K5   */  be_nested_str_weak(shadow_onoff),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x600C0003,  //  0000  GETGBL	R3	G3
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x90020302,  //  0007  SETMBR	R0	K1	K2
-      0x90020702,  //  0008  SETMBR	R0	K3	K2
-      0x90020902,  //  0009  SETMBR	R0	K4	K2
-      0x500C0000,  //  000A  LDBOOL	R3	0	0
-      0x90020A03,  //  000B  SETMBR	R0	K5	R3
-      0x80000000,  //  000C  RET	0
+    ( &(const binstruction[315]) {  /* code */
+      0xA4120000,  //  0000  IMPORT	R4	K0
+      0xB8160200,  //  0001  GETNGBL	R5	K1
+      0x88140B02,  //  0002  GETMBR	R5	R5	K2
+      0x88180703,  //  0003  GETMBR	R6	R3	K3
+      0x881C0704,  //  0004  GETMBR	R7	R3	K4
+      0x1C200D05,  //  0005  EQ	R8	R6	K5
+      0x78220016,  //  0006  JMPF	R8	#001E
+      0x1C200F06,  //  0007  EQ	R8	R7	K6
+      0x78220002,  //  0008  JMPF	R8	#000C
+      0x50200200,  //  0009  LDBOOL	R8	1	0
+      0x80041000,  //  000A  RET	1	R8
+      0x70020010,  //  000B  JMP		#001D
+      0x1C200F07,  //  000C  EQ	R8	R7	K7
+      0x78220009,  //  000D  JMPF	R8	#0018
+      0x8C200B08,  //  000E  GETMET	R8	R5	K8
+      0x7C200200,  //  000F  CALL	R8	1
+      0x8C241109,  //  0010  GETMET	R9	R8	K9
+      0x582C0006,  //  0011  LDCONST	R11	K6
+      0x88300B0A,  //  0012  GETMBR	R12	R5	K10
+      0x58340006,  //  0013  LDCONST	R13	K6
+      0x7C240800,  //  0014  CALL	R9	4
+      0x900E0906,  //  0015  SETMBR	R3	K4	K6
+      0x80041000,  //  0016  RET	1	R8
+      0x70020004,  //  0017  JMP		#001D
+      0x5422003F,  //  0018  LDINT	R8	64
+      0x1C200E08,  //  0019  EQ	R8	R7	R8
+      0x78220001,  //  001A  JMPF	R8	#001D
+      0x50200200,  //  001B  LDBOOL	R8	1	0
+      0x80041000,  //  001C  RET	1	R8
+      0x7002011B,  //  001D  JMP		#013A
+      0x54220003,  //  001E  LDINT	R8	4
+      0x1C200C08,  //  001F  EQ	R8	R6	R8
+      0x78220002,  //  0020  JMPF	R8	#0024
+      0x50200200,  //  0021  LDBOOL	R8	1	0
+      0x80041000,  //  0022  RET	1	R8
+      0x70020115,  //  0023  JMP		#013A
+      0x54220004,  //  0024  LDINT	R8	5
+      0x1C200C08,  //  0025  EQ	R8	R6	R8
+      0x78220002,  //  0026  JMPF	R8	#002A
+      0x50200200,  //  0027  LDBOOL	R8	1	0
+      0x80041000,  //  0028  RET	1	R8
+      0x7002010F,  //  0029  JMP		#013A
+      0x54220005,  //  002A  LDINT	R8	6
+      0x1C200C08,  //  002B  EQ	R8	R6	R8
+      0x78220029,  //  002C  JMPF	R8	#0057
+      0x1C200F06,  //  002D  EQ	R8	R7	K6
+      0x7822000A,  //  002E  JMPF	R8	#003A
+      0x8C20090B,  //  002F  GETMET	R8	R4	K11
+      0x60280013,  //  0030  GETGBL	R10	G19
+      0x7C280000,  //  0031  CALL	R10	0
+      0x502C0000,  //  0032  LDBOOL	R11	0	0
+      0x982A180B,  //  0033  SETIDX	R10	K12	R11
+      0x7C200400,  //  0034  CALL	R8	2
+      0x8C20010D,  //  0035  GETMET	R8	R0	K13
+      0x7C200200,  //  0036  CALL	R8	1
+      0x50200200,  //  0037  LDBOOL	R8	1	0
+      0x80041000,  //  0038  RET	1	R8
+      0x7002001B,  //  0039  JMP		#0056
+      0x1C200F07,  //  003A  EQ	R8	R7	K7
+      0x7822000A,  //  003B  JMPF	R8	#0047
+      0x8C20090B,  //  003C  GETMET	R8	R4	K11
+      0x60280013,  //  003D  GETGBL	R10	G19
+      0x7C280000,  //  003E  CALL	R10	0
+      0x502C0200,  //  003F  LDBOOL	R11	1	0
+      0x982A180B,  //  0040  SETIDX	R10	K12	R11
+      0x7C200400,  //  0041  CALL	R8	2
+      0x8C20010D,  //  0042  GETMET	R8	R0	K13
+      0x7C200200,  //  0043  CALL	R8	1
+      0x50200200,  //  0044  LDBOOL	R8	1	0
+      0x80041000,  //  0045  RET	1	R8
+      0x7002000E,  //  0046  JMP		#0056
+      0x1C200F0E,  //  0047  EQ	R8	R7	K14
+      0x7822000C,  //  0048  JMPF	R8	#0056
+      0x8C20090B,  //  0049  GETMET	R8	R4	K11
+      0x60280013,  //  004A  GETGBL	R10	G19
+      0x7C280000,  //  004B  CALL	R10	0
+      0x882C010F,  //  004C  GETMBR	R11	R0	K15
+      0x782E0000,  //  004D  JMPF	R11	#004F
+      0x502C0001,  //  004E  LDBOOL	R11	0	1
+      0x502C0200,  //  004F  LDBOOL	R11	1	0
+      0x982A180B,  //  0050  SETIDX	R10	K12	R11
+      0x7C200400,  //  0051  CALL	R8	2
+      0x8C20010D,  //  0052  GETMET	R8	R0	K13
+      0x7C200200,  //  0053  CALL	R8	1
+      0x50200200,  //  0054  LDBOOL	R8	1	0
+      0x80041000,  //  0055  RET	1	R8
+      0x700200E2,  //  0056  JMP		#013A
+      0x54220007,  //  0057  LDINT	R8	8
+      0x1C200C08,  //  0058  EQ	R8	R6	R8
+      0x7822005B,  //  0059  JMPF	R8	#00B6
+      0x1C200F06,  //  005A  EQ	R8	R7	K6
+      0x78220019,  //  005B  JMPF	R8	#0076
+      0x8C200510,  //  005C  GETMET	R8	R2	K16
+      0x58280006,  //  005D  LDCONST	R10	K6
+      0x7C200400,  //  005E  CALL	R8	2
+      0xB8262200,  //  005F  GETNGBL	R9	K17
+      0x8C241312,  //  0060  GETMET	R9	R9	K18
+      0x5C2C1000,  //  0061  MOVE	R11	R8
+      0x58300006,  //  0062  LDCONST	R12	K6
+      0x543600FD,  //  0063  LDINT	R13	254
+      0x58380006,  //  0064  LDCONST	R14	K6
+      0x543E00FE,  //  0065  LDINT	R15	255
+      0x7C240C00,  //  0066  CALL	R9	6
+      0x8C28090B,  //  0067  GETMET	R10	R4	K11
+      0x60300013,  //  0068  GETGBL	R12	G19
+      0x7C300000,  //  0069  CALL	R12	0
+      0x98322609,  //  006A  SETIDX	R12	K19	R9
+      0x7C280400,  //  006B  CALL	R10	2
+      0x8C28010D,  //  006C  GETMET	R10	R0	K13
+      0x7C280200,  //  006D  CALL	R10	1
+      0x60280008,  //  006E  GETGBL	R10	G8
+      0x5C2C1000,  //  006F  MOVE	R11	R8
+      0x7C280200,  //  0070  CALL	R10	1
+      0x002A2A0A,  //  0071  ADD	R10	K21	R10
+      0x900E280A,  //  0072  SETMBR	R3	K20	R10
+      0x50280200,  //  0073  LDBOOL	R10	1	0
+      0x80041400,  //  0074  RET	1	R10
+      0x7002003E,  //  0075  JMP		#00B5
+      0x1C200F07,  //  0076  EQ	R8	R7	K7
+      0x78220002,  //  0077  JMPF	R8	#007B
+      0x50200200,  //  0078  LDBOOL	R8	1	0
+      0x80041000,  //  0079  RET	1	R8
+      0x70020039,  //  007A  JMP		#00B5
+      0x1C200F0E,  //  007B  EQ	R8	R7	K14
+      0x78220002,  //  007C  JMPF	R8	#0080
+      0x50200200,  //  007D  LDBOOL	R8	1	0
+      0x80041000,  //  007E  RET	1	R8
+      0x70020034,  //  007F  JMP		#00B5
+      0x1C200F05,  //  0080  EQ	R8	R7	K5
+      0x78220002,  //  0081  JMPF	R8	#0085
+      0x50200200,  //  0082  LDBOOL	R8	1	0
+      0x80041000,  //  0083  RET	1	R8
+      0x7002002F,  //  0084  JMP		#00B5
+      0x54220003,  //  0085  LDINT	R8	4
+      0x1C200E08,  //  0086  EQ	R8	R7	R8
+      0x7822001B,  //  0087  JMPF	R8	#00A4
+      0x8C200510,  //  0088  GETMET	R8	R2	K16
+      0x58280006,  //  0089  LDCONST	R10	K6
+      0x7C200400,  //  008A  CALL	R8	2
+      0xB8262200,  //  008B  GETNGBL	R9	K17
+      0x8C241312,  //  008C  GETMET	R9	R9	K18
+      0x5C2C1000,  //  008D  MOVE	R11	R8
+      0x58300006,  //  008E  LDCONST	R12	K6
+      0x543600FD,  //  008F  LDINT	R13	254
+      0x58380006,  //  0090  LDCONST	R14	K6
+      0x543E00FE,  //  0091  LDINT	R15	255
+      0x7C240C00,  //  0092  CALL	R9	6
+      0x24281306,  //  0093  GT	R10	R9	K6
+      0x8C2C090B,  //  0094  GETMET	R11	R4	K11
+      0x60340013,  //  0095  GETGBL	R13	G19
+      0x7C340000,  //  0096  CALL	R13	0
+      0x98362609,  //  0097  SETIDX	R13	K19	R9
+      0x9836180A,  //  0098  SETIDX	R13	K12	R10
+      0x7C2C0400,  //  0099  CALL	R11	2
+      0x8C2C010D,  //  009A  GETMET	R11	R0	K13
+      0x7C2C0200,  //  009B  CALL	R11	1
+      0x602C0008,  //  009C  GETGBL	R11	G8
+      0x5C301000,  //  009D  MOVE	R12	R8
+      0x7C2C0200,  //  009E  CALL	R11	1
+      0x002E2A0B,  //  009F  ADD	R11	K21	R11
+      0x900E280B,  //  00A0  SETMBR	R3	K20	R11
+      0x502C0200,  //  00A1  LDBOOL	R11	1	0
+      0x80041600,  //  00A2  RET	1	R11
+      0x70020010,  //  00A3  JMP		#00B5
+      0x54220004,  //  00A4  LDINT	R8	5
+      0x1C200E08,  //  00A5  EQ	R8	R7	R8
+      0x78220002,  //  00A6  JMPF	R8	#00AA
+      0x50200200,  //  00A7  LDBOOL	R8	1	0
+      0x80041000,  //  00A8  RET	1	R8
+      0x7002000A,  //  00A9  JMP		#00B5
+      0x54220005,  //  00AA  LDINT	R8	6
+      0x1C200E08,  //  00AB  EQ	R8	R7	R8
+      0x78220002,  //  00AC  JMPF	R8	#00B0
+      0x50200200,  //  00AD  LDBOOL	R8	1	0
+      0x80041000,  //  00AE  RET	1	R8
+      0x70020004,  //  00AF  JMP		#00B5
+      0x54220006,  //  00B0  LDINT	R8	7
+      0x1C200E08,  //  00B1  EQ	R8	R7	R8
+      0x78220001,  //  00B2  JMPF	R8	#00B5
+      0x50200200,  //  00B3  LDBOOL	R8	1	0
+      0x80041000,  //  00B4  RET	1	R8
+      0x70020083,  //  00B5  JMP		#013A
+      0x542202FF,  //  00B6  LDINT	R8	768
+      0x1C200C08,  //  00B7  EQ	R8	R6	R8
+      0x78220080,  //  00B8  JMPF	R8	#013A
+      0x1C200F06,  //  00B9  EQ	R8	R7	K6
+      0x78220019,  //  00BA  JMPF	R8	#00D5
+      0x8C200510,  //  00BB  GETMET	R8	R2	K16
+      0x58280006,  //  00BC  LDCONST	R10	K6
+      0x7C200400,  //  00BD  CALL	R8	2
+      0xB8262200,  //  00BE  GETNGBL	R9	K17
+      0x8C241312,  //  00BF  GETMET	R9	R9	K18
+      0x5C2C1000,  //  00C0  MOVE	R11	R8
+      0x58300006,  //  00C1  LDCONST	R12	K6
+      0x543600FD,  //  00C2  LDINT	R13	254
+      0x58380006,  //  00C3  LDCONST	R14	K6
+      0x543E0167,  //  00C4  LDINT	R15	360
+      0x7C240C00,  //  00C5  CALL	R9	6
+      0x8C28090B,  //  00C6  GETMET	R10	R4	K11
+      0x60300013,  //  00C7  GETGBL	R12	G19
+      0x7C300000,  //  00C8  CALL	R12	0
+      0x98322C09,  //  00C9  SETIDX	R12	K22	R9
+      0x7C280400,  //  00CA  CALL	R10	2
+      0x8C28010D,  //  00CB  GETMET	R10	R0	K13
+      0x7C280200,  //  00CC  CALL	R10	1
+      0x60280008,  //  00CD  GETGBL	R10	G8
+      0x5C2C1000,  //  00CE  MOVE	R11	R8
+      0x7C280200,  //  00CF  CALL	R10	1
+      0x002A2E0A,  //  00D0  ADD	R10	K23	R10
+      0x900E280A,  //  00D1  SETMBR	R3	K20	R10
+      0x50280200,  //  00D2  LDBOOL	R10	1	0
+      0x80041400,  //  00D3  RET	1	R10
+      0x70020064,  //  00D4  JMP		#013A
+      0x1C200F07,  //  00D5  EQ	R8	R7	K7
+      0x78220002,  //  00D6  JMPF	R8	#00DA
+      0x50200200,  //  00D7  LDBOOL	R8	1	0
+      0x80041000,  //  00D8  RET	1	R8
+      0x7002005F,  //  00D9  JMP		#013A
+      0x1C200F0E,  //  00DA  EQ	R8	R7	K14
+      0x78220002,  //  00DB  JMPF	R8	#00DF
+      0x50200200,  //  00DC  LDBOOL	R8	1	0
+      0x80041000,  //  00DD  RET	1	R8
+      0x7002005A,  //  00DE  JMP		#013A
+      0x1C200F05,  //  00DF  EQ	R8	R7	K5
+      0x78220019,  //  00E0  JMPF	R8	#00FB
+      0x8C200510,  //  00E1  GETMET	R8	R2	K16
+      0x58280006,  //  00E2  LDCONST	R10	K6
+      0x7C200400,  //  00E3  CALL	R8	2
+      0xB8262200,  //  00E4  GETNGBL	R9	K17
+      0x8C241312,  //  00E5  GETMET	R9	R9	K18
+      0x5C2C1000,  //  00E6  MOVE	R11	R8
+      0x58300006,  //  00E7  LDCONST	R12	K6
+      0x543600FD,  //  00E8  LDINT	R13	254
+      0x58380006,  //  00E9  LDCONST	R14	K6
+      0x543E00FE,  //  00EA  LDINT	R15	255
+      0x7C240C00,  //  00EB  CALL	R9	6
+      0x8C28090B,  //  00EC  GETMET	R10	R4	K11
+      0x60300013,  //  00ED  GETGBL	R12	G19
+      0x7C300000,  //  00EE  CALL	R12	0
+      0x98323009,  //  00EF  SETIDX	R12	K24	R9
+      0x7C280400,  //  00F0  CALL	R10	2
+      0x8C28010D,  //  00F1  GETMET	R10	R0	K13
+      0x7C280200,  //  00F2  CALL	R10	1
+      0x60280008,  //  00F3  GETGBL	R10	G8
+      0x5C2C1000,  //  00F4  MOVE	R11	R8
+      0x7C280200,  //  00F5  CALL	R10	1
+      0x002A320A,  //  00F6  ADD	R10	K25	R10
+      0x900E280A,  //  00F7  SETMBR	R3	K20	R10
+      0x50280200,  //  00F8  LDBOOL	R10	1	0
+      0x80041400,  //  00F9  RET	1	R10
+      0x7002003E,  //  00FA  JMP		#013A
+      0x54220003,  //  00FB  LDINT	R8	4
+      0x1C200E08,  //  00FC  EQ	R8	R7	R8
+      0x78220002,  //  00FD  JMPF	R8	#0101
+      0x50200200,  //  00FE  LDBOOL	R8	1	0
+      0x80041000,  //  00FF  RET	1	R8
+      0x70020038,  //  0100  JMP		#013A
+      0x54220004,  //  0101  LDINT	R8	5
+      0x1C200E08,  //  0102  EQ	R8	R7	R8
+      0x78220002,  //  0103  JMPF	R8	#0107
+      0x50200200,  //  0104  LDBOOL	R8	1	0
+      0x80041000,  //  0105  RET	1	R8
+      0x70020032,  //  0106  JMP		#013A
+      0x54220005,  //  0107  LDINT	R8	6
+      0x1C200E08,  //  0108  EQ	R8	R7	R8
+      0x7822002A,  //  0109  JMPF	R8	#0135
+      0x8C200510,  //  010A  GETMET	R8	R2	K16
+      0x58280006,  //  010B  LDCONST	R10	K6
+      0x7C200400,  //  010C  CALL	R8	2
+      0xB8262200,  //  010D  GETNGBL	R9	K17
+      0x8C241312,  //  010E  GETMET	R9	R9	K18
+      0x5C2C1000,  //  010F  MOVE	R11	R8
+      0x58300006,  //  0110  LDCONST	R12	K6
+      0x543600FD,  //  0111  LDINT	R13	254
+      0x58380006,  //  0112  LDCONST	R14	K6
+      0x543E0167,  //  0113  LDINT	R15	360
+      0x7C240C00,  //  0114  CALL	R9	6
+      0x8C280510,  //  0115  GETMET	R10	R2	K16
+      0x58300007,  //  0116  LDCONST	R12	K7
+      0x7C280400,  //  0117  CALL	R10	2
+      0xB82E2200,  //  0118  GETNGBL	R11	K17
+      0x8C2C1712,  //  0119  GETMET	R11	R11	K18
+      0x5C341400,  //  011A  MOVE	R13	R10
+      0x58380006,  //  011B  LDCONST	R14	K6
+      0x543E00FD,  //  011C  LDINT	R15	254
+      0x58400006,  //  011D  LDCONST	R16	K6
+      0x544600FE,  //  011E  LDINT	R17	255
+      0x7C2C0C00,  //  011F  CALL	R11	6
+      0x8C30090B,  //  0120  GETMET	R12	R4	K11
+      0x60380013,  //  0121  GETGBL	R14	G19
+      0x7C380000,  //  0122  CALL	R14	0
+      0x983A2C09,  //  0123  SETIDX	R14	K22	R9
+      0x983A300B,  //  0124  SETIDX	R14	K24	R11
+      0x7C300400,  //  0125  CALL	R12	2
+      0x8C30010D,  //  0126  GETMET	R12	R0	K13
+      0x7C300200,  //  0127  CALL	R12	1
+      0x60300008,  //  0128  GETGBL	R12	G8
+      0x5C341000,  //  0129  MOVE	R13	R8
+      0x7C300200,  //  012A  CALL	R12	1
+      0x00322E0C,  //  012B  ADD	R12	K23	R12
+      0x0030191A,  //  012C  ADD	R12	R12	K26
+      0x60340008,  //  012D  GETGBL	R13	G8
+      0x5C381400,  //  012E  MOVE	R14	R10
+      0x7C340200,  //  012F  CALL	R13	1
+      0x0030180D,  //  0130  ADD	R12	R12	R13
+      0x900E280C,  //  0131  SETMBR	R3	K20	R12
+      0x50300200,  //  0132  LDBOOL	R12	1	0
+      0x80041800,  //  0133  RET	1	R12
+      0x70020004,  //  0134  JMP		#013A
+      0x54220046,  //  0135  LDINT	R8	71
+      0x1C200E08,  //  0136  EQ	R8	R7	R8
+      0x78220001,  //  0137  JMPF	R8	#013A
+      0x50200200,  //  0138  LDBOOL	R8	1	0
+      0x80041000,  //  0139  RET	1	R8
+      0x80000000,  //  013A  RET	0
     })
   )
 );
@@ -543,6 +834,49 @@ be_local_closure(Matter_Plugin_Light3_update_shadow,   /* name */
 
 
 /********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Plugin_Light3_init,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(shadow_hue),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(shadow_bri),
+    /* K4   */  be_nested_str_weak(shadow_sat),
+    /* K5   */  be_nested_str_weak(shadow_onoff),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x600C0003,  //  0000  GETGBL	R3	G3
+      0x5C100000,  //  0001  MOVE	R4	R0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
+      0x5C140200,  //  0004  MOVE	R5	R1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x90020302,  //  0007  SETMBR	R0	K1	K2
+      0x90020702,  //  0008  SETMBR	R0	K3	K2
+      0x90020902,  //  0009  SETMBR	R0	K4	K2
+      0x500C0000,  //  000A  LDBOOL	R3	0	0
+      0x90020A03,  //  000B  SETMBR	R0	K5	R3
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: every_second
 ********************************************************************/
 be_local_closure(Matter_Plugin_Light3_every_second,   /* name */
@@ -571,359 +905,24 @@ be_local_closure(Matter_Plugin_Light3_every_second,   /* name */
 
 
 /********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(Matter_Plugin_Light3_invoke_request,   /* name */
-  be_nested_proto(
-    18,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
-    /* K0   */  be_nested_str_weak(light),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(command),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K9   */  be_nested_str_weak(add_TLV),
-    /* K10  */  be_nested_str_weak(U2),
-    /* K11  */  be_nested_str_weak(set),
-    /* K12  */  be_nested_str_weak(power),
-    /* K13  */  be_nested_str_weak(update_shadow),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_nested_str_weak(shadow_onoff),
-    /* K16  */  be_nested_str_weak(findsubval),
-    /* K17  */  be_nested_str_weak(tasmota),
-    /* K18  */  be_nested_str_weak(scale_uint),
-    /* K19  */  be_nested_str_weak(bri),
-    /* K20  */  be_nested_str_weak(hue),
-    /* K21  */  be_nested_str_weak(sat),
-    }),
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[285]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0xB8160200,  //  0001  GETNGBL	R5	K1
-      0x88140B02,  //  0002  GETMBR	R5	R5	K2
-      0x88180703,  //  0003  GETMBR	R6	R3	K3
-      0x881C0704,  //  0004  GETMBR	R7	R3	K4
-      0x1C200D05,  //  0005  EQ	R8	R6	K5
-      0x78220016,  //  0006  JMPF	R8	#001E
-      0x1C200F06,  //  0007  EQ	R8	R7	K6
-      0x78220002,  //  0008  JMPF	R8	#000C
-      0x50200200,  //  0009  LDBOOL	R8	1	0
-      0x80041000,  //  000A  RET	1	R8
-      0x70020010,  //  000B  JMP		#001D
-      0x1C200F07,  //  000C  EQ	R8	R7	K7
-      0x78220009,  //  000D  JMPF	R8	#0018
-      0x8C200B08,  //  000E  GETMET	R8	R5	K8
-      0x7C200200,  //  000F  CALL	R8	1
-      0x8C241109,  //  0010  GETMET	R9	R8	K9
-      0x582C0006,  //  0011  LDCONST	R11	K6
-      0x88300B0A,  //  0012  GETMBR	R12	R5	K10
-      0x58340006,  //  0013  LDCONST	R13	K6
-      0x7C240800,  //  0014  CALL	R9	4
-      0x900E0906,  //  0015  SETMBR	R3	K4	K6
-      0x80041000,  //  0016  RET	1	R8
-      0x70020004,  //  0017  JMP		#001D
-      0x5422003F,  //  0018  LDINT	R8	64
-      0x1C200E08,  //  0019  EQ	R8	R7	R8
-      0x78220001,  //  001A  JMPF	R8	#001D
-      0x50200200,  //  001B  LDBOOL	R8	1	0
-      0x80041000,  //  001C  RET	1	R8
-      0x700200FD,  //  001D  JMP		#011C
-      0x54220003,  //  001E  LDINT	R8	4
-      0x1C200C08,  //  001F  EQ	R8	R6	R8
-      0x78220002,  //  0020  JMPF	R8	#0024
-      0x50200200,  //  0021  LDBOOL	R8	1	0
-      0x80041000,  //  0022  RET	1	R8
-      0x700200F7,  //  0023  JMP		#011C
-      0x54220004,  //  0024  LDINT	R8	5
-      0x1C200C08,  //  0025  EQ	R8	R6	R8
-      0x78220002,  //  0026  JMPF	R8	#002A
-      0x50200200,  //  0027  LDBOOL	R8	1	0
-      0x80041000,  //  0028  RET	1	R8
-      0x700200F1,  //  0029  JMP		#011C
-      0x54220005,  //  002A  LDINT	R8	6
-      0x1C200C08,  //  002B  EQ	R8	R6	R8
-      0x78220029,  //  002C  JMPF	R8	#0057
-      0x1C200F06,  //  002D  EQ	R8	R7	K6
-      0x7822000A,  //  002E  JMPF	R8	#003A
-      0x8C20090B,  //  002F  GETMET	R8	R4	K11
-      0x60280013,  //  0030  GETGBL	R10	G19
-      0x7C280000,  //  0031  CALL	R10	0
-      0x502C0000,  //  0032  LDBOOL	R11	0	0
-      0x982A180B,  //  0033  SETIDX	R10	K12	R11
-      0x7C200400,  //  0034  CALL	R8	2
-      0x8C20010D,  //  0035  GETMET	R8	R0	K13
-      0x7C200200,  //  0036  CALL	R8	1
-      0x50200200,  //  0037  LDBOOL	R8	1	0
-      0x80041000,  //  0038  RET	1	R8
-      0x7002001B,  //  0039  JMP		#0056
-      0x1C200F07,  //  003A  EQ	R8	R7	K7
-      0x7822000A,  //  003B  JMPF	R8	#0047
-      0x8C20090B,  //  003C  GETMET	R8	R4	K11
-      0x60280013,  //  003D  GETGBL	R10	G19
-      0x7C280000,  //  003E  CALL	R10	0
-      0x502C0200,  //  003F  LDBOOL	R11	1	0
-      0x982A180B,  //  0040  SETIDX	R10	K12	R11
-      0x7C200400,  //  0041  CALL	R8	2
-      0x8C20010D,  //  0042  GETMET	R8	R0	K13
-      0x7C200200,  //  0043  CALL	R8	1
-      0x50200200,  //  0044  LDBOOL	R8	1	0
-      0x80041000,  //  0045  RET	1	R8
-      0x7002000E,  //  0046  JMP		#0056
-      0x1C200F0E,  //  0047  EQ	R8	R7	K14
-      0x7822000C,  //  0048  JMPF	R8	#0056
-      0x8C20090B,  //  0049  GETMET	R8	R4	K11
-      0x60280013,  //  004A  GETGBL	R10	G19
-      0x7C280000,  //  004B  CALL	R10	0
-      0x882C010F,  //  004C  GETMBR	R11	R0	K15
-      0x782E0000,  //  004D  JMPF	R11	#004F
-      0x502C0001,  //  004E  LDBOOL	R11	0	1
-      0x502C0200,  //  004F  LDBOOL	R11	1	0
-      0x982A180B,  //  0050  SETIDX	R10	K12	R11
-      0x7C200400,  //  0051  CALL	R8	2
-      0x8C20010D,  //  0052  GETMET	R8	R0	K13
-      0x7C200200,  //  0053  CALL	R8	1
-      0x50200200,  //  0054  LDBOOL	R8	1	0
-      0x80041000,  //  0055  RET	1	R8
-      0x700200C4,  //  0056  JMP		#011C
-      0x54220007,  //  0057  LDINT	R8	8
-      0x1C200C08,  //  0058  EQ	R8	R6	R8
-      0x78220051,  //  0059  JMPF	R8	#00AC
-      0x1C200F06,  //  005A  EQ	R8	R7	K6
-      0x78220014,  //  005B  JMPF	R8	#0071
-      0x8C200510,  //  005C  GETMET	R8	R2	K16
-      0x58280006,  //  005D  LDCONST	R10	K6
-      0x7C200400,  //  005E  CALL	R8	2
-      0xB8262200,  //  005F  GETNGBL	R9	K17
-      0x8C241312,  //  0060  GETMET	R9	R9	K18
-      0x5C2C1000,  //  0061  MOVE	R11	R8
-      0x58300006,  //  0062  LDCONST	R12	K6
-      0x543600FD,  //  0063  LDINT	R13	254
-      0x58380006,  //  0064  LDCONST	R14	K6
-      0x543E0167,  //  0065  LDINT	R15	360
-      0x7C240C00,  //  0066  CALL	R9	6
-      0x8C28090B,  //  0067  GETMET	R10	R4	K11
-      0x60300013,  //  0068  GETGBL	R12	G19
-      0x7C300000,  //  0069  CALL	R12	0
-      0x98322609,  //  006A  SETIDX	R12	K19	R9
-      0x7C280400,  //  006B  CALL	R10	2
-      0x8C28010D,  //  006C  GETMET	R10	R0	K13
-      0x7C280200,  //  006D  CALL	R10	1
-      0x50280200,  //  006E  LDBOOL	R10	1	0
-      0x80041400,  //  006F  RET	1	R10
-      0x70020039,  //  0070  JMP		#00AB
-      0x1C200F07,  //  0071  EQ	R8	R7	K7
-      0x78220002,  //  0072  JMPF	R8	#0076
-      0x50200200,  //  0073  LDBOOL	R8	1	0
-      0x80041000,  //  0074  RET	1	R8
-      0x70020034,  //  0075  JMP		#00AB
-      0x1C200F0E,  //  0076  EQ	R8	R7	K14
-      0x78220002,  //  0077  JMPF	R8	#007B
-      0x50200200,  //  0078  LDBOOL	R8	1	0
-      0x80041000,  //  0079  RET	1	R8
-      0x7002002F,  //  007A  JMP		#00AB
-      0x1C200F05,  //  007B  EQ	R8	R7	K5
-      0x78220002,  //  007C  JMPF	R8	#0080
-      0x50200200,  //  007D  LDBOOL	R8	1	0
-      0x80041000,  //  007E  RET	1	R8
-      0x7002002A,  //  007F  JMP		#00AB
-      0x54220003,  //  0080  LDINT	R8	4
-      0x1C200E08,  //  0081  EQ	R8	R7	R8
-      0x78220016,  //  0082  JMPF	R8	#009A
-      0x8C200510,  //  0083  GETMET	R8	R2	K16
-      0x58280006,  //  0084  LDCONST	R10	K6
-      0x7C200400,  //  0085  CALL	R8	2
-      0xB8262200,  //  0086  GETNGBL	R9	K17
-      0x8C241312,  //  0087  GETMET	R9	R9	K18
-      0x5C2C1000,  //  0088  MOVE	R11	R8
-      0x58300006,  //  0089  LDCONST	R12	K6
-      0x543600FD,  //  008A  LDINT	R13	254
-      0x58380006,  //  008B  LDCONST	R14	K6
-      0x543E0167,  //  008C  LDINT	R15	360
-      0x7C240C00,  //  008D  CALL	R9	6
-      0x24281306,  //  008E  GT	R10	R9	K6
-      0x8C2C090B,  //  008F  GETMET	R11	R4	K11
-      0x60340013,  //  0090  GETGBL	R13	G19
-      0x7C340000,  //  0091  CALL	R13	0
-      0x98362609,  //  0092  SETIDX	R13	K19	R9
-      0x9836180A,  //  0093  SETIDX	R13	K12	R10
-      0x7C2C0400,  //  0094  CALL	R11	2
-      0x8C2C010D,  //  0095  GETMET	R11	R0	K13
-      0x7C2C0200,  //  0096  CALL	R11	1
-      0x502C0200,  //  0097  LDBOOL	R11	1	0
-      0x80041600,  //  0098  RET	1	R11
-      0x70020010,  //  0099  JMP		#00AB
-      0x54220004,  //  009A  LDINT	R8	5
-      0x1C200E08,  //  009B  EQ	R8	R7	R8
-      0x78220002,  //  009C  JMPF	R8	#00A0
-      0x50200200,  //  009D  LDBOOL	R8	1	0
-      0x80041000,  //  009E  RET	1	R8
-      0x7002000A,  //  009F  JMP		#00AB
-      0x54220005,  //  00A0  LDINT	R8	6
-      0x1C200E08,  //  00A1  EQ	R8	R7	R8
-      0x78220002,  //  00A2  JMPF	R8	#00A6
-      0x50200200,  //  00A3  LDBOOL	R8	1	0
-      0x80041000,  //  00A4  RET	1	R8
-      0x70020004,  //  00A5  JMP		#00AB
-      0x54220006,  //  00A6  LDINT	R8	7
-      0x1C200E08,  //  00A7  EQ	R8	R7	R8
-      0x78220001,  //  00A8  JMPF	R8	#00AB
-      0x50200200,  //  00A9  LDBOOL	R8	1	0
-      0x80041000,  //  00AA  RET	1	R8
-      0x7002006F,  //  00AB  JMP		#011C
-      0x542202FF,  //  00AC  LDINT	R8	768
-      0x1C200C08,  //  00AD  EQ	R8	R6	R8
-      0x7822006C,  //  00AE  JMPF	R8	#011C
-      0x1C200F06,  //  00AF  EQ	R8	R7	K6
-      0x78220014,  //  00B0  JMPF	R8	#00C6
-      0x8C200510,  //  00B1  GETMET	R8	R2	K16
-      0x58280006,  //  00B2  LDCONST	R10	K6
-      0x7C200400,  //  00B3  CALL	R8	2
-      0xB8262200,  //  00B4  GETNGBL	R9	K17
-      0x8C241312,  //  00B5  GETMET	R9	R9	K18
-      0x5C2C1000,  //  00B6  MOVE	R11	R8
-      0x58300006,  //  00B7  LDCONST	R12	K6
-      0x543600FD,  //  00B8  LDINT	R13	254
-      0x58380006,  //  00B9  LDCONST	R14	K6
-      0x543E0167,  //  00BA  LDINT	R15	360
-      0x7C240C00,  //  00BB  CALL	R9	6
-      0x8C28090B,  //  00BC  GETMET	R10	R4	K11
-      0x60300013,  //  00BD  GETGBL	R12	G19
-      0x7C300000,  //  00BE  CALL	R12	0
-      0x98322809,  //  00BF  SETIDX	R12	K20	R9
-      0x7C280400,  //  00C0  CALL	R10	2
-      0x8C28010D,  //  00C1  GETMET	R10	R0	K13
-      0x7C280200,  //  00C2  CALL	R10	1
-      0x50280200,  //  00C3  LDBOOL	R10	1	0
-      0x80041400,  //  00C4  RET	1	R10
-      0x70020055,  //  00C5  JMP		#011C
-      0x1C200F07,  //  00C6  EQ	R8	R7	K7
-      0x78220002,  //  00C7  JMPF	R8	#00CB
-      0x50200200,  //  00C8  LDBOOL	R8	1	0
-      0x80041000,  //  00C9  RET	1	R8
-      0x70020050,  //  00CA  JMP		#011C
-      0x1C200F0E,  //  00CB  EQ	R8	R7	K14
-      0x78220002,  //  00CC  JMPF	R8	#00D0
-      0x50200200,  //  00CD  LDBOOL	R8	1	0
-      0x80041000,  //  00CE  RET	1	R8
-      0x7002004B,  //  00CF  JMP		#011C
-      0x1C200F05,  //  00D0  EQ	R8	R7	K5
-      0x78220014,  //  00D1  JMPF	R8	#00E7
-      0x8C200510,  //  00D2  GETMET	R8	R2	K16
-      0x58280006,  //  00D3  LDCONST	R10	K6
-      0x7C200400,  //  00D4  CALL	R8	2
-      0xB8262200,  //  00D5  GETNGBL	R9	K17
-      0x8C241312,  //  00D6  GETMET	R9	R9	K18
-      0x5C2C1000,  //  00D7  MOVE	R11	R8
-      0x58300006,  //  00D8  LDCONST	R12	K6
-      0x543600FD,  //  00D9  LDINT	R13	254
-      0x58380006,  //  00DA  LDCONST	R14	K6
-      0x543E00FE,  //  00DB  LDINT	R15	255
-      0x7C240C00,  //  00DC  CALL	R9	6
-      0x8C28090B,  //  00DD  GETMET	R10	R4	K11
-      0x60300013,  //  00DE  GETGBL	R12	G19
-      0x7C300000,  //  00DF  CALL	R12	0
-      0x98322A09,  //  00E0  SETIDX	R12	K21	R9
-      0x7C280400,  //  00E1  CALL	R10	2
-      0x8C28010D,  //  00E2  GETMET	R10	R0	K13
-      0x7C280200,  //  00E3  CALL	R10	1
-      0x50280200,  //  00E4  LDBOOL	R10	1	0
-      0x80041400,  //  00E5  RET	1	R10
-      0x70020034,  //  00E6  JMP		#011C
-      0x54220003,  //  00E7  LDINT	R8	4
-      0x1C200E08,  //  00E8  EQ	R8	R7	R8
-      0x78220002,  //  00E9  JMPF	R8	#00ED
-      0x50200200,  //  00EA  LDBOOL	R8	1	0
-      0x80041000,  //  00EB  RET	1	R8
-      0x7002002E,  //  00EC  JMP		#011C
-      0x54220004,  //  00ED  LDINT	R8	5
-      0x1C200E08,  //  00EE  EQ	R8	R7	R8
-      0x78220002,  //  00EF  JMPF	R8	#00F3
-      0x50200200,  //  00F0  LDBOOL	R8	1	0
-      0x80041000,  //  00F1  RET	1	R8
-      0x70020028,  //  00F2  JMP		#011C
-      0x54220005,  //  00F3  LDINT	R8	6
-      0x1C200E08,  //  00F4  EQ	R8	R7	R8
-      0x78220020,  //  00F5  JMPF	R8	#0117
-      0x8C200510,  //  00F6  GETMET	R8	R2	K16
-      0x58280006,  //  00F7  LDCONST	R10	K6
-      0x7C200400,  //  00F8  CALL	R8	2
-      0xB8262200,  //  00F9  GETNGBL	R9	K17
-      0x8C241312,  //  00FA  GETMET	R9	R9	K18
-      0x5C2C1000,  //  00FB  MOVE	R11	R8
-      0x58300006,  //  00FC  LDCONST	R12	K6
-      0x543600FD,  //  00FD  LDINT	R13	254
-      0x58380006,  //  00FE  LDCONST	R14	K6
-      0x543E0167,  //  00FF  LDINT	R15	360
-      0x7C240C00,  //  0100  CALL	R9	6
-      0x8C280510,  //  0101  GETMET	R10	R2	K16
-      0x58300007,  //  0102  LDCONST	R12	K7
-      0x7C280400,  //  0103  CALL	R10	2
-      0xB82E2200,  //  0104  GETNGBL	R11	K17
-      0x8C2C1712,  //  0105  GETMET	R11	R11	K18
-      0x5C341400,  //  0106  MOVE	R13	R10
-      0x58380006,  //  0107  LDCONST	R14	K6
-      0x543E00FD,  //  0108  LDINT	R15	254
-      0x58400006,  //  0109  LDCONST	R16	K6
-      0x544600FE,  //  010A  LDINT	R17	255
-      0x7C2C0C00,  //  010B  CALL	R11	6
-      0x8C30090B,  //  010C  GETMET	R12	R4	K11
-      0x60380013,  //  010D  GETGBL	R14	G19
-      0x7C380000,  //  010E  CALL	R14	0
-      0x983A2809,  //  010F  SETIDX	R14	K20	R9
-      0x983A2A0B,  //  0110  SETIDX	R14	K21	R11
-      0x7C300400,  //  0111  CALL	R12	2
-      0x8C30010D,  //  0112  GETMET	R12	R0	K13
-      0x7C300200,  //  0113  CALL	R12	1
-      0x50300200,  //  0114  LDBOOL	R12	1	0
-      0x80041800,  //  0115  RET	1	R12
-      0x70020004,  //  0116  JMP		#011C
-      0x54220046,  //  0117  LDINT	R8	71
-      0x1C200E08,  //  0118  EQ	R8	R7	R8
-      0x78220001,  //  0119  JMPF	R8	#011C
-      0x50200200,  //  011A  LDBOOL	R8	1	0
-      0x80041000,  //  011B  RET	1	R8
-      0x80000000,  //  011C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_Plugin_Light3
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin;
 be_local_class(Matter_Plugin_Light3,
     4,
     &be_class_Matter_Plugin,
-    be_nested_map(12,
+    be_nested_map(11,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Plugin_Light3_every_second_closure) },
+        { be_const_key_weak(shadow_sat, -1), be_const_var(2) },
+        { be_const_key_weak(shadow_hue, -1), be_const_var(0) },
+        { be_const_key_weak(read_attribute, 7), be_const_closure(Matter_Plugin_Light3_read_attribute_closure) },
+        { be_const_key_weak(TYPES, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(269, -1), be_const_int(2) },
     }))    ) } )) },
-        { be_const_key_weak(shadow_bri, 7), be_const_var(1) },
-        { be_const_key_weak(onoff_changed, 0), be_const_closure(Matter_Plugin_Light3_onoff_changed_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Light3_init_closure) },
-        { be_const_key_weak(shadow_hue, 8), be_const_var(0) },
-        { be_const_key_weak(shadow_sat, -1), be_const_var(2) },
-        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Light3_read_attribute_closure) },
-        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_Light3_update_shadow_closure) },
-        { be_const_key_weak(shadow_onoff, -1), be_const_var(3) },
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Plugin_Light3_every_second_closure) },
+        { be_const_key_weak(update_shadow, 8), be_const_closure(Matter_Plugin_Light3_update_shadow_closure) },
         { be_const_key_weak(CLUSTERS, 5), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
@@ -986,7 +985,10 @@ be_local_class(Matter_Plugin_Light3,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_Light3_invoke_request_closure) },
+        { be_const_key_weak(shadow_onoff, -1), be_const_var(3) },
+        { be_const_key_weak(shadow_bri, -1), be_const_var(1) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Light3_init_closure) },
+        { be_const_key_weak(invoke_request, 0), be_const_closure(Matter_Plugin_Light3_invoke_request_closure) },
     })),
     be_str_weak(Matter_Plugin_Light3)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
@@ -1204,7 +1204,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[98]) {     /* constants */
+    ( &(const bvalue[99]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(matter),
@@ -1293,20 +1293,21 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
     /* K85  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
     /* K86  */  be_nested_str_weak(_X29_X20not_X20found),
     /* K87  */  be_nested_str_weak(INVALID_ACTION),
-    /* K88  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
-    /* K89  */  be_nested_str_weak(INVALID_DATA_TYPE),
-    /* K90  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
-    /* K91  */  be_nested_str_weak(CONSTRAINT_ERROR),
-    /* K92  */  be_nested_str_weak(start_basic_commissioning),
-    /* K93  */  be_nested_str_weak(get_fabric),
-    /* K94  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
-    /* K95  */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K96  */  be_nested_str_weak(stop_basic_commissioning),
-    /* K97  */  be_nested_str_weak(invoke_request),
+    /* K88  */  be_nested_str_weak(fabric_index_X3A),
+    /* K89  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
+    /* K90  */  be_nested_str_weak(INVALID_DATA_TYPE),
+    /* K91  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
+    /* K92  */  be_nested_str_weak(CONSTRAINT_ERROR),
+    /* K93  */  be_nested_str_weak(start_basic_commissioning),
+    /* K94  */  be_nested_str_weak(get_fabric),
+    /* K95  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
+    /* K96  */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K97  */  be_nested_str_weak(stop_basic_commissioning),
+    /* K98  */  be_nested_str_weak(invoke_request),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[728]) {  /* code */
+    ( &(const binstruction[733]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xA4160200,  //  0001  IMPORT	R5	K1
       0xB81A0400,  //  0002  GETNGBL	R6	K2
@@ -1400,10 +1401,10 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x5C300200,  //  005A  MOVE	R12	R1
       0x7C280400,  //  005B  CALL	R10	2
       0x80041200,  //  005C  RET	1	R9
-      0x70020277,  //  005D  JMP		#02D6
+      0x7002027C,  //  005D  JMP		#02DB
       0x5426003D,  //  005E  LDINT	R9	62
       0x1C240E09,  //  005F  EQ	R9	R7	R9
-      0x782601D9,  //  0060  JMPF	R9	#023B
+      0x782601DE,  //  0060  JMPF	R9	#0240
       0x1C24110F,  //  0061  EQ	R9	R8	K15
       0x7826001D,  //  0062  JMPF	R9	#0081
       0x8C240507,  //  0063  GETMET	R9	R2	K7
@@ -1435,7 +1436,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C2C0800,  //  007D  CALL	R11	4
       0x900E0B11,  //  007E  SETMBR	R3	K5	K17
       0x80041400,  //  007F  RET	1	R10
-      0x700201B8,  //  0080  JMP		#023A
+      0x700201BD,  //  0080  JMP		#023F
       0x1C241106,  //  0081  EQ	R9	R8	K6
       0x78260044,  //  0082  JMPF	R9	#00C8
       0x8C240507,  //  0083  GETMET	R9	R2	K7
@@ -1506,7 +1507,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C400800,  //  00C4  CALL	R16	4
       0x900E0B08,  //  00C5  SETMBR	R3	K5	K8
       0x80041E00,  //  00C6  RET	1	R15
-      0x70020171,  //  00C7  JMP		#023A
+      0x70020176,  //  00C7  JMP		#023F
       0x54260003,  //  00C8  LDINT	R9	4
       0x1C241009,  //  00C9  EQ	R9	R8	R9
       0x78260040,  //  00CA  JMPF	R9	#010C
@@ -1574,7 +1575,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x54460004,  //  0108  LDINT	R17	5
       0x900E0A11,  //  0109  SETMBR	R3	K5	R17
       0x80042000,  //  010A  RET	1	R16
-      0x7002012D,  //  010B  JMP		#023A
+      0x70020132,  //  010B  JMP		#023F
       0x5426000A,  //  010C  LDINT	R9	11
       0x1C241009,  //  010D  EQ	R9	R8	R9
       0x78260012,  //  010E  JMPF	R9	#0122
@@ -1596,7 +1597,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x900E2E0A,  //  011E  SETMBR	R3	K23	R10
       0x4C280000,  //  011F  LDNIL	R10
       0x80041400,  //  0120  RET	1	R10
-      0x70020117,  //  0121  JMP		#023A
+      0x7002011C,  //  0121  JMP		#023F
       0x54260005,  //  0122  LDINT	R9	6
       0x1C241009,  //  0123  EQ	R9	R8	R9
       0x782600B5,  //  0124  JMPF	R9	#01DB
@@ -1781,7 +1782,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x54620007,  //  01D7  LDINT	R24	8
       0x900E0A18,  //  01D8  SETMBR	R3	K5	R24
       0x80042E00,  //  01D9  RET	1	R23
-      0x7002005E,  //  01DA  JMP		#023A
+      0x70020063,  //  01DA  JMP		#023F
       0x54260008,  //  01DB  LDINT	R9	9
       0x1C241009,  //  01DC  EQ	R9	R8	R9
       0x7826001E,  //  01DD  JMPF	R9	#01FD
@@ -1815,10 +1816,10 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x900E2E0A,  //  01F9  SETMBR	R3	K23	R10
       0x4C280000,  //  01FA  LDNIL	R10
       0x80041400,  //  01FB  RET	1	R10
-      0x7002003C,  //  01FC  JMP		#023A
+      0x70020041,  //  01FC  JMP		#023F
       0x54260009,  //  01FD  LDINT	R9	10
       0x1C241009,  //  01FE  EQ	R9	R8	R9
-      0x78260039,  //  01FF  JMPF	R9	#023A
+      0x7826003E,  //  01FF  JMPF	R9	#023F
       0x8C240507,  //  0200  GETMET	R9	R2	K7
       0x582C0006,  //  0201  LDCONST	R11	K6
       0x7C240400,  //  0202  CALL	R9	2
@@ -1874,167 +1875,172 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0xB82A0400,  //  0234  GETNGBL	R10	K2
       0x88281557,  //  0235  GETMBR	R10	R10	K87
       0x900E2E0A,  //  0236  SETMBR	R3	K23	R10
-      0x4C280000,  //  0237  LDNIL	R10
-      0xA0000000,  //  0238  CLOSE	R0
-      0x80041400,  //  0239  RET	1	R10
-      0x7002009A,  //  023A  JMP		#02D6
-      0x5426003B,  //  023B  LDINT	R9	60
-      0x1C240E09,  //  023C  EQ	R9	R7	R9
-      0x78260084,  //  023D  JMPF	R9	#02C3
-      0x1C241106,  //  023E  EQ	R9	R8	K6
-      0x78260064,  //  023F  JMPF	R9	#02A5
-      0x8C240507,  //  0240  GETMET	R9	R2	K7
-      0x582C0006,  //  0241  LDCONST	R11	K6
-      0x7C240400,  //  0242  CALL	R9	2
-      0x8C280507,  //  0243  GETMET	R10	R2	K7
-      0x58300008,  //  0244  LDCONST	R12	K8
-      0x7C280400,  //  0245  CALL	R10	2
-      0x8C2C0507,  //  0246  GETMET	R11	R2	K7
-      0x5834000F,  //  0247  LDCONST	R13	K15
-      0x7C2C0400,  //  0248  CALL	R11	2
-      0x8C300507,  //  0249  GETMET	R12	R2	K7
-      0x58380011,  //  024A  LDCONST	R14	K17
-      0x7C300400,  //  024B  CALL	R12	2
-      0x8C340507,  //  024C  GETMET	R13	R2	K7
-      0x543E0003,  //  024D  LDINT	R15	4
-      0x7C340400,  //  024E  CALL	R13	2
-      0xB83A3E00,  //  024F  GETNGBL	R14	K31
-      0x8C381D24,  //  0250  GETMET	R14	R14	K36
-      0x8C400B4C,  //  0251  GETMET	R16	R5	K76
-      0x58480058,  //  0252  LDCONST	R18	K88
-      0x5C4C1200,  //  0253  MOVE	R19	R9
-      0x8C501526,  //  0254  GETMET	R20	R10	K38
-      0x7C500200,  //  0255  CALL	R20	1
-      0x5C541600,  //  0256  MOVE	R21	R11
-      0x5C581800,  //  0257  MOVE	R22	R12
-      0x8C5C1B26,  //  0258  GETMET	R23	R13	K38
-      0x7C5C0200,  //  0259  CALL	R23	1
-      0x7C400E00,  //  025A  CALL	R16	7
-      0x5844000F,  //  025B  LDCONST	R17	K15
-      0x7C380600,  //  025C  CALL	R14	3
-      0x4C380000,  //  025D  LDNIL	R14
-      0x1C38120E,  //  025E  EQ	R14	R9	R14
-      0x743A000B,  //  025F  JMPT	R14	#026C
-      0x4C380000,  //  0260  LDNIL	R14
-      0x1C38140E,  //  0261  EQ	R14	R10	R14
-      0x743A0008,  //  0262  JMPT	R14	#026C
-      0x4C380000,  //  0263  LDNIL	R14
-      0x1C38160E,  //  0264  EQ	R14	R11	R14
-      0x743A0005,  //  0265  JMPT	R14	#026C
-      0x4C380000,  //  0266  LDNIL	R14
-      0x1C38180E,  //  0267  EQ	R14	R12	R14
-      0x743A0002,  //  0268  JMPT	R14	#026C
-      0x4C380000,  //  0269  LDNIL	R14
-      0x1C381A0E,  //  026A  EQ	R14	R13	R14
-      0x783A0005,  //  026B  JMPF	R14	#0272
-      0xB83A0400,  //  026C  GETNGBL	R14	K2
-      0x88381D59,  //  026D  GETMBR	R14	R14	K89
-      0x900E2E0E,  //  026E  SETMBR	R3	K23	R14
-      0x4C380000,  //  026F  LDNIL	R14
-      0xA0000000,  //  0270  CLOSE	R0
-      0x80041C00,  //  0271  RET	1	R14
-      0x6038000C,  //  0272  GETGBL	R14	G12
-      0x5C3C1400,  //  0273  MOVE	R15	R10
-      0x7C380200,  //  0274  CALL	R14	1
-      0x543E001F,  //  0275  LDINT	R15	32
-      0x54420040,  //  0276  LDINT	R16	65
-      0x003C1E10,  //  0277  ADD	R15	R15	R16
-      0x20381C0F,  //  0278  NE	R14	R14	R15
-      0x743A000B,  //  0279  JMPT	R14	#0286
-      0x6038000C,  //  027A  GETGBL	R14	G12
-      0x5C3C1A00,  //  027B  MOVE	R15	R13
-      0x7C380200,  //  027C  CALL	R14	1
-      0x543E000F,  //  027D  LDINT	R15	16
-      0x14381C0F,  //  027E  LT	R14	R14	R15
-      0x743A0005,  //  027F  JMPT	R14	#0286
-      0x6038000C,  //  0280  GETGBL	R14	G12
-      0x5C3C1A00,  //  0281  MOVE	R15	R13
-      0x7C380200,  //  0282  CALL	R14	1
-      0x543E001F,  //  0283  LDINT	R15	32
-      0x24381C0F,  //  0284  GT	R14	R14	R15
-      0x783A0009,  //  0285  JMPF	R14	#0290
-      0xB83A3E00,  //  0286  GETNGBL	R14	K31
-      0x8C381D24,  //  0287  GETMET	R14	R14	K36
-      0x5840005A,  //  0288  LDCONST	R16	K90
-      0x7C380400,  //  0289  CALL	R14	2
-      0xB83A0400,  //  028A  GETNGBL	R14	K2
-      0x88381D5B,  //  028B  GETMBR	R14	R14	K91
-      0x900E2E0E,  //  028C  SETMBR	R3	K23	R14
-      0x4C380000,  //  028D  LDNIL	R14
-      0xA0000000,  //  028E  CLOSE	R0
-      0x80041C00,  //  028F  RET	1	R14
-      0x543A001E,  //  0290  LDINT	R14	31
-      0x403A0C0E,  //  0291  CONNECT	R14	K6	R14
-      0x9438140E,  //  0292  GETIDX	R14	R10	R14
-      0x543E001F,  //  0293  LDINT	R15	32
-      0x403C1F3B,  //  0294  CONNECT	R15	R15	K59
-      0x943C140F,  //  0295  GETIDX	R15	R10	R15
-      0x88400115,  //  0296  GETMBR	R16	R0	K21
-      0x8C40215C,  //  0297  GETMET	R16	R16	K92
-      0x5C481200,  //  0298  MOVE	R18	R9
-      0x5C4C1800,  //  0299  MOVE	R19	R12
-      0x5C501600,  //  029A  MOVE	R20	R11
-      0x5C541A00,  //  029B  MOVE	R21	R13
-      0x5C581C00,  //  029C  MOVE	R22	R14
-      0x5C5C1E00,  //  029D  MOVE	R23	R15
-      0x8C60035D,  //  029E  GETMET	R24	R1	K93
-      0x7C600200,  //  029F  CALL	R24	1
-      0x7C401000,  //  02A0  CALL	R16	8
-      0x50400200,  //  02A1  LDBOOL	R16	1	0
-      0xA0000000,  //  02A2  CLOSE	R0
-      0x80042000,  //  02A3  RET	1	R16
-      0x7002001C,  //  02A4  JMP		#02C2
-      0x1C241108,  //  02A5  EQ	R9	R8	K8
-      0x78260012,  //  02A6  JMPF	R9	#02BA
-      0x8C240507,  //  02A7  GETMET	R9	R2	K7
-      0x582C0006,  //  02A8  LDCONST	R11	K6
-      0x7C240400,  //  02A9  CALL	R9	2
-      0xB82A3E00,  //  02AA  GETNGBL	R10	K31
-      0x8C281524,  //  02AB  GETMET	R10	R10	K36
-      0x60300008,  //  02AC  GETGBL	R12	G8
-      0x5C341200,  //  02AD  MOVE	R13	R9
-      0x7C300200,  //  02AE  CALL	R12	1
-      0x0032BC0C,  //  02AF  ADD	R12	K94	R12
-      0x5834000F,  //  02B0  LDCONST	R13	K15
-      0x7C280600,  //  02B1  CALL	R10	3
-      0x88280115,  //  02B2  GETMBR	R10	R0	K21
-      0x8C28155F,  //  02B3  GETMET	R10	R10	K95
-      0x5C301200,  //  02B4  MOVE	R12	R9
-      0x7C280400,  //  02B5  CALL	R10	2
-      0x50280200,  //  02B6  LDBOOL	R10	1	0
-      0xA0000000,  //  02B7  CLOSE	R0
-      0x80041400,  //  02B8  RET	1	R10
-      0x70020007,  //  02B9  JMP		#02C2
-      0x1C24110F,  //  02BA  EQ	R9	R8	K15
-      0x78260005,  //  02BB  JMPF	R9	#02C2
-      0x88240115,  //  02BC  GETMBR	R9	R0	K21
-      0x8C241360,  //  02BD  GETMET	R9	R9	K96
-      0x7C240200,  //  02BE  CALL	R9	1
-      0x50240200,  //  02BF  LDBOOL	R9	1	0
-      0xA0000000,  //  02C0  CLOSE	R0
-      0x80041200,  //  02C1  RET	1	R9
-      0x70020012,  //  02C2  JMP		#02D6
-      0x54260029,  //  02C3  LDINT	R9	42
-      0x1C240E09,  //  02C4  EQ	R9	R7	R9
-      0x78260005,  //  02C5  JMPF	R9	#02CC
-      0x1C241106,  //  02C6  EQ	R9	R8	K6
-      0x78260002,  //  02C7  JMPF	R9	#02CB
-      0x50240200,  //  02C8  LDBOOL	R9	1	0
-      0xA0000000,  //  02C9  CLOSE	R0
-      0x80041200,  //  02CA  RET	1	R9
-      0x70020009,  //  02CB  JMP		#02D6
-      0x60240003,  //  02CC  GETGBL	R9	G3
-      0x5C280000,  //  02CD  MOVE	R10	R0
-      0x7C240200,  //  02CE  CALL	R9	1
-      0x8C241361,  //  02CF  GETMET	R9	R9	K97
-      0x5C2C0200,  //  02D0  MOVE	R11	R1
-      0x5C300400,  //  02D1  MOVE	R12	R2
-      0x5C340600,  //  02D2  MOVE	R13	R3
-      0x7C240800,  //  02D3  CALL	R9	4
-      0xA0000000,  //  02D4  CLOSE	R0
-      0x80041200,  //  02D5  RET	1	R9
-      0xA0000000,  //  02D6  CLOSE	R0
-      0x80000000,  //  02D7  RET	0
+      0x60280008,  //  0237  GETGBL	R10	G8
+      0x5C2C1200,  //  0238  MOVE	R11	R9
+      0x7C280200,  //  0239  CALL	R10	1
+      0x002AB00A,  //  023A  ADD	R10	K88	R10
+      0x900E480A,  //  023B  SETMBR	R3	K36	R10
+      0x4C280000,  //  023C  LDNIL	R10
+      0xA0000000,  //  023D  CLOSE	R0
+      0x80041400,  //  023E  RET	1	R10
+      0x7002009A,  //  023F  JMP		#02DB
+      0x5426003B,  //  0240  LDINT	R9	60
+      0x1C240E09,  //  0241  EQ	R9	R7	R9
+      0x78260084,  //  0242  JMPF	R9	#02C8
+      0x1C241106,  //  0243  EQ	R9	R8	K6
+      0x78260064,  //  0244  JMPF	R9	#02AA
+      0x8C240507,  //  0245  GETMET	R9	R2	K7
+      0x582C0006,  //  0246  LDCONST	R11	K6
+      0x7C240400,  //  0247  CALL	R9	2
+      0x8C280507,  //  0248  GETMET	R10	R2	K7
+      0x58300008,  //  0249  LDCONST	R12	K8
+      0x7C280400,  //  024A  CALL	R10	2
+      0x8C2C0507,  //  024B  GETMET	R11	R2	K7
+      0x5834000F,  //  024C  LDCONST	R13	K15
+      0x7C2C0400,  //  024D  CALL	R11	2
+      0x8C300507,  //  024E  GETMET	R12	R2	K7
+      0x58380011,  //  024F  LDCONST	R14	K17
+      0x7C300400,  //  0250  CALL	R12	2
+      0x8C340507,  //  0251  GETMET	R13	R2	K7
+      0x543E0003,  //  0252  LDINT	R15	4
+      0x7C340400,  //  0253  CALL	R13	2
+      0xB83A3E00,  //  0254  GETNGBL	R14	K31
+      0x8C381D24,  //  0255  GETMET	R14	R14	K36
+      0x8C400B4C,  //  0256  GETMET	R16	R5	K76
+      0x58480059,  //  0257  LDCONST	R18	K89
+      0x5C4C1200,  //  0258  MOVE	R19	R9
+      0x8C501526,  //  0259  GETMET	R20	R10	K38
+      0x7C500200,  //  025A  CALL	R20	1
+      0x5C541600,  //  025B  MOVE	R21	R11
+      0x5C581800,  //  025C  MOVE	R22	R12
+      0x8C5C1B26,  //  025D  GETMET	R23	R13	K38
+      0x7C5C0200,  //  025E  CALL	R23	1
+      0x7C400E00,  //  025F  CALL	R16	7
+      0x5844000F,  //  0260  LDCONST	R17	K15
+      0x7C380600,  //  0261  CALL	R14	3
+      0x4C380000,  //  0262  LDNIL	R14
+      0x1C38120E,  //  0263  EQ	R14	R9	R14
+      0x743A000B,  //  0264  JMPT	R14	#0271
+      0x4C380000,  //  0265  LDNIL	R14
+      0x1C38140E,  //  0266  EQ	R14	R10	R14
+      0x743A0008,  //  0267  JMPT	R14	#0271
+      0x4C380000,  //  0268  LDNIL	R14
+      0x1C38160E,  //  0269  EQ	R14	R11	R14
+      0x743A0005,  //  026A  JMPT	R14	#0271
+      0x4C380000,  //  026B  LDNIL	R14
+      0x1C38180E,  //  026C  EQ	R14	R12	R14
+      0x743A0002,  //  026D  JMPT	R14	#0271
+      0x4C380000,  //  026E  LDNIL	R14
+      0x1C381A0E,  //  026F  EQ	R14	R13	R14
+      0x783A0005,  //  0270  JMPF	R14	#0277
+      0xB83A0400,  //  0271  GETNGBL	R14	K2
+      0x88381D5A,  //  0272  GETMBR	R14	R14	K90
+      0x900E2E0E,  //  0273  SETMBR	R3	K23	R14
+      0x4C380000,  //  0274  LDNIL	R14
+      0xA0000000,  //  0275  CLOSE	R0
+      0x80041C00,  //  0276  RET	1	R14
+      0x6038000C,  //  0277  GETGBL	R14	G12
+      0x5C3C1400,  //  0278  MOVE	R15	R10
+      0x7C380200,  //  0279  CALL	R14	1
+      0x543E001F,  //  027A  LDINT	R15	32
+      0x54420040,  //  027B  LDINT	R16	65
+      0x003C1E10,  //  027C  ADD	R15	R15	R16
+      0x20381C0F,  //  027D  NE	R14	R14	R15
+      0x743A000B,  //  027E  JMPT	R14	#028B
+      0x6038000C,  //  027F  GETGBL	R14	G12
+      0x5C3C1A00,  //  0280  MOVE	R15	R13
+      0x7C380200,  //  0281  CALL	R14	1
+      0x543E000F,  //  0282  LDINT	R15	16
+      0x14381C0F,  //  0283  LT	R14	R14	R15
+      0x743A0005,  //  0284  JMPT	R14	#028B
+      0x6038000C,  //  0285  GETGBL	R14	G12
+      0x5C3C1A00,  //  0286  MOVE	R15	R13
+      0x7C380200,  //  0287  CALL	R14	1
+      0x543E001F,  //  0288  LDINT	R15	32
+      0x24381C0F,  //  0289  GT	R14	R14	R15
+      0x783A0009,  //  028A  JMPF	R14	#0295
+      0xB83A3E00,  //  028B  GETNGBL	R14	K31
+      0x8C381D24,  //  028C  GETMET	R14	R14	K36
+      0x5840005B,  //  028D  LDCONST	R16	K91
+      0x7C380400,  //  028E  CALL	R14	2
+      0xB83A0400,  //  028F  GETNGBL	R14	K2
+      0x88381D5C,  //  0290  GETMBR	R14	R14	K92
+      0x900E2E0E,  //  0291  SETMBR	R3	K23	R14
+      0x4C380000,  //  0292  LDNIL	R14
+      0xA0000000,  //  0293  CLOSE	R0
+      0x80041C00,  //  0294  RET	1	R14
+      0x543A001E,  //  0295  LDINT	R14	31
+      0x403A0C0E,  //  0296  CONNECT	R14	K6	R14
+      0x9438140E,  //  0297  GETIDX	R14	R10	R14
+      0x543E001F,  //  0298  LDINT	R15	32
+      0x403C1F3B,  //  0299  CONNECT	R15	R15	K59
+      0x943C140F,  //  029A  GETIDX	R15	R10	R15
+      0x88400115,  //  029B  GETMBR	R16	R0	K21
+      0x8C40215D,  //  029C  GETMET	R16	R16	K93
+      0x5C481200,  //  029D  MOVE	R18	R9
+      0x5C4C1800,  //  029E  MOVE	R19	R12
+      0x5C501600,  //  029F  MOVE	R20	R11
+      0x5C541A00,  //  02A0  MOVE	R21	R13
+      0x5C581C00,  //  02A1  MOVE	R22	R14
+      0x5C5C1E00,  //  02A2  MOVE	R23	R15
+      0x8C60035E,  //  02A3  GETMET	R24	R1	K94
+      0x7C600200,  //  02A4  CALL	R24	1
+      0x7C401000,  //  02A5  CALL	R16	8
+      0x50400200,  //  02A6  LDBOOL	R16	1	0
+      0xA0000000,  //  02A7  CLOSE	R0
+      0x80042000,  //  02A8  RET	1	R16
+      0x7002001C,  //  02A9  JMP		#02C7
+      0x1C241108,  //  02AA  EQ	R9	R8	K8
+      0x78260012,  //  02AB  JMPF	R9	#02BF
+      0x8C240507,  //  02AC  GETMET	R9	R2	K7
+      0x582C0006,  //  02AD  LDCONST	R11	K6
+      0x7C240400,  //  02AE  CALL	R9	2
+      0xB82A3E00,  //  02AF  GETNGBL	R10	K31
+      0x8C281524,  //  02B0  GETMET	R10	R10	K36
+      0x60300008,  //  02B1  GETGBL	R12	G8
+      0x5C341200,  //  02B2  MOVE	R13	R9
+      0x7C300200,  //  02B3  CALL	R12	1
+      0x0032BE0C,  //  02B4  ADD	R12	K95	R12
+      0x5834000F,  //  02B5  LDCONST	R13	K15
+      0x7C280600,  //  02B6  CALL	R10	3
+      0x88280115,  //  02B7  GETMBR	R10	R0	K21
+      0x8C281560,  //  02B8  GETMET	R10	R10	K96
+      0x5C301200,  //  02B9  MOVE	R12	R9
+      0x7C280400,  //  02BA  CALL	R10	2
+      0x50280200,  //  02BB  LDBOOL	R10	1	0
+      0xA0000000,  //  02BC  CLOSE	R0
+      0x80041400,  //  02BD  RET	1	R10
+      0x70020007,  //  02BE  JMP		#02C7
+      0x1C24110F,  //  02BF  EQ	R9	R8	K15
+      0x78260005,  //  02C0  JMPF	R9	#02C7
+      0x88240115,  //  02C1  GETMBR	R9	R0	K21
+      0x8C241361,  //  02C2  GETMET	R9	R9	K97
+      0x7C240200,  //  02C3  CALL	R9	1
+      0x50240200,  //  02C4  LDBOOL	R9	1	0
+      0xA0000000,  //  02C5  CLOSE	R0
+      0x80041200,  //  02C6  RET	1	R9
+      0x70020012,  //  02C7  JMP		#02DB
+      0x54260029,  //  02C8  LDINT	R9	42
+      0x1C240E09,  //  02C9  EQ	R9	R7	R9
+      0x78260005,  //  02CA  JMPF	R9	#02D1
+      0x1C241106,  //  02CB  EQ	R9	R8	K6
+      0x78260002,  //  02CC  JMPF	R9	#02D0
+      0x50240200,  //  02CD  LDBOOL	R9	1	0
+      0xA0000000,  //  02CE  CLOSE	R0
+      0x80041200,  //  02CF  RET	1	R9
+      0x70020009,  //  02D0  JMP		#02DB
+      0x60240003,  //  02D1  GETGBL	R9	G3
+      0x5C280000,  //  02D2  MOVE	R10	R0
+      0x7C240200,  //  02D3  CALL	R9	1
+      0x8C241362,  //  02D4  GETMET	R9	R9	K98
+      0x5C2C0200,  //  02D5  MOVE	R11	R1
+      0x5C300400,  //  02D6  MOVE	R12	R2
+      0x5C340600,  //  02D7  MOVE	R13	R3
+      0x7C240800,  //  02D8  CALL	R9	4
+      0xA0000000,  //  02D9  CLOSE	R0
+      0x80041200,  //  02DA  RET	1	R9
+      0xA0000000,  //  02DB  CLOSE	R0
+      0x80000000,  //  02DC  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Matter support for Lights (1/2/3 channels) and Relays.

Endpoints are auto-configured from the Light and Relays from the Template.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
