### PR TITLE
Update xsns_86_tfminiplus.ino: FIX json output

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_86_tfminiplus.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_86_tfminiplus.ino
@@ -191,7 +191,7 @@ void TfmpShow(bool json) {
     float distance = (float)tfminiplus_sensor.distance;  // cm
 
     if (json) {
-        ResponseAppend_P(PSTR(",\"%s\":{\"" D_JSON_DISTANCE "\":\"%1_f\",\"" D_JSON_SIGNALSTRENGTH "\":\"%d\",\"" D_JSON_CHIPTEMPERATURE "\":%d}"),
+        ResponseAppend_P(PSTR(",\"%s\":{\"" D_JSON_DISTANCE "\":%1_f,\"" D_JSON_SIGNALSTRENGTH "\":%d,\"" D_JSON_CHIPTEMPERATURE "\":%d}"),
             sensor_name, &distance, tfminiplus_sensor.sigstrength, tfminiplus_sensor.chiptemp);
 #ifdef USE_DOMOTICZ
         if (0 == TasmotaGlobal.tele_period) {


### PR DESCRIPTION
Fixes JSON measurement output. Output numbers like Distance and SignalStrength were published as a string. Now they have the right data type.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
