### PR TITLE
code cleanup for Nova SDS Sensor

### DIFF
--- a/tasmota/include/tasmota_globals.h
+++ b/tasmota/include/tasmota_globals.h
@@ -379,13 +379,6 @@ String EthernetMacAddress(void);
 #define CORS_ENABLED_ALL            "*"
 #endif
 
-#ifndef WORKING_PERIOD
-#define WORKING_PERIOD              5          // Working period of the SDS Sensor, Takes a reading every X Minutes
-#endif
-#ifndef STARTING_OFFSET
-#define STARTING_OFFSET             30         // NOVA SDS parameter used in settings
-#endif
-
 #ifndef WIFI_RGX_STATE
 #define WIFI_RGX_STATE              0
 #endif

--- a/tasmota/tasmota_xsns_sensor/xsns_20_novasds.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_20_novasds.ino
@@ -31,9 +31,6 @@
 
 #include <TasmotaSerial.h>
 
-#ifndef STARTING_OFFSET
-#define STARTING_OFFSET               30      // Turn on NovaSDS XX-seconds before tele_period is reached
-#endif
 #if STARTING_OFFSET < 10
 #error "Please set STARTING_OFFSET >= 10"
 #endif


### PR DESCRIPTION
## Description:
- Removed obsolete define "WORKING_PERIOD"
- Removed redundant defines "STARTING_OFFSET". Now only one STARTING_OFFSET is left in file "my_user_config.h" where the offset can be set at compile time.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
