### PR TITLE
fix #18331 (Wrong discovery on ESP32_shutter

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_12_discovery.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_12_discovery.ino
@@ -199,7 +199,7 @@ void TasDiscoverMessage(void) {
                         light_controller_isCTRGBLinked,
                         light_subtype);
 
-  for (uint32_t i = 0; i < TasmotaGlobal.shutters_present; i++) {
+  for (uint32_t i = 0; i < tmax(TasmotaGlobal.shutters_present,MAX_SHUTTERS); i++) {
 #ifdef USE_SHUTTER
     ResponseAppend_P(PSTR("%s%d"), (i > 0 ? "," : ""), Settings->shutter_options[i]);
 #else
@@ -209,7 +209,7 @@ void TasDiscoverMessage(void) {
 
   ResponseAppend_P(PSTR("],"                                   // Shutter Options (end)
                         "\"sht\":["));                         // Shutter Tilt (start)
-  for (uint32_t i = 0; i < TasmotaGlobal.shutters_present; i++) {
+  for (uint32_t i = 0; i < tmax(TasmotaGlobal.shutters_present,MAX_SHUTTERS); i++) {
 #ifdef USE_SHUTTER
     ResponseAppend_P(PSTR("%s[%d,%d,%d]"), (i > 0 ? "," : ""),
                           ShutterGetTiltConfig(0,i),

--- a/tasmota/tasmota_xdrv_driver/xdrv_12_discovery.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_12_discovery.ino
@@ -114,11 +114,11 @@ void TasDiscoverMessage(void) {
 
 #ifdef USE_SHUTTER
       if (Settings->flag3.shutter_mode) {
-        for (uint32_t k = 0; k < MAX_SHUTTERS; k++) {
-          if (Settings->shutter_startrelay[k] > 0) {
-            Shutter[Settings->shutter_startrelay[k]-1] = Shutter[Settings->shutter_startrelay[k]] = 1;
+        for (uint32_t k = 0; k < TasmotaGlobal.shutters_present; k++) {
+          if (ShutterGetStartRelay(k) > 0) {
+            Shutter[ShutterGetStartRelay(k)-1] = Shutter[ShutterGetStartRelay(k)] = 1;
           } else {
-            // terminate loop at first INVALID Settings->shutter_startrelay[i].
+            // terminate loop at first INVALID ShutterGetStartRelay(k).
             break;
           }
         }
@@ -199,7 +199,7 @@ void TasDiscoverMessage(void) {
                         light_controller_isCTRGBLinked,
                         light_subtype);
 
-  for (uint32_t i = 0; i < MAX_SHUTTERS; i++) {
+  for (uint32_t i = 0; i < TasmotaGlobal.shutters_present; i++) {
 #ifdef USE_SHUTTER
     ResponseAppend_P(PSTR("%s%d"), (i > 0 ? "," : ""), Settings->shutter_options[i]);
 #else
@@ -209,12 +209,12 @@ void TasDiscoverMessage(void) {
 
   ResponseAppend_P(PSTR("],"                                   // Shutter Options (end)
                         "\"sht\":["));                         // Shutter Tilt (start)
-  for (uint32_t i = 0; i < MAX_SHUTTERS; i++) {
+  for (uint32_t i = 0; i < TasmotaGlobal.shutters_present; i++) {
 #ifdef USE_SHUTTER
     ResponseAppend_P(PSTR("%s[%d,%d,%d]"), (i > 0 ? "," : ""),
-                          Settings->shutter_tilt_config[0][i],
-                          Settings->shutter_tilt_config[1][i],
-                          Settings->shutter_tilt_config[2][i]);
+                          ShutterGetTiltConfig(0,i),
+                          ShutterGetTiltConfig(1,i),
+                          ShutterGetTiltConfig(2,i));
 #else
     ResponseAppend_P(PSTR("%s[0,0,0]"), (i > 0 ? "," : ""));
 #endif  // USE_SHUTTER

--- a/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
@@ -351,6 +351,10 @@ uint8_t ShutterGetStartRelay(uint8_t index) {
   return ShutterSettings.shutter_startrelay[index];
 }
 
+int8_t ShutterGetTiltConfig(uint8_t config_idx,uint8_t index) {
+  return Shutter[index].tilt_config[config_idx];
+}
+
 void ExecuteCommandPowerShutter(uint32_t device, uint32_t state, uint32_t source)
 {
   // first implementation for virtual relays. Avoid switching relay numbers that do not exist.

--- a/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
@@ -189,6 +189,10 @@ uint8_t ShutterGetStartRelay(uint8_t index) {
   return Settings->shutter_startrelay[index];
 }
 
+int8_t ShutterGetTiltConfig(uint8_t config_idx,uint8_t index) {
+  return Shutter[index].tilt_config[config_idx];
+}
+
 void ExecuteCommandPowerShutter(uint32_t device, uint32_t state, uint32_t source)
 {
   // first implementation for virtual relays. Avoid switching relay numbers that do not exist.


### PR DESCRIPTION
## Description:
ESP32_shutter did not report correct discovery. 
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
#18331

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
