### PR TITLE
Improve ADC_CT

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_02_analog.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_02_analog.ino
@@ -469,7 +469,8 @@ void AdcGetCurrentPower(uint8_t idx, uint8_t factor) {
   uint16_t analog_max = 0;
 
   if (0 == Adc[idx].param1) {
-    for (uint32_t i = 0; i < samples; i++) {
+    unsigned long tstart=millis();
+    while (millis()-tstart < 35) {
       analog = analogRead(Adc[idx].pin);
       if (analog < analog_min) {
         analog_min = analog;
@@ -477,9 +478,11 @@ void AdcGetCurrentPower(uint8_t idx, uint8_t factor) {
       if (analog > analog_max) {
         analog_max = analog;
       }
-      delay(1);
     }
+    //AddLog(0, PSTR("min: %u, max:%u, dif:%u"), analog_min, analog_max, analog_max-analog_min);
     Adc[idx].current = (float)(analog_max-analog_min) * ((float)(Adc[idx].param2) / 100000);
+    if (Adc[idx].current < (((float)Adc[idx].param4) / 10000.0))
+        Adc[idx].current = 0.0;
   }
   else {
     analog = AdcRead(Adc[idx].pin, 5);


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** helps with #18172

This improve the ADC_CT mode in 2 ways:
- Instead of reading the ADC 32 times with a 1ms delay, the loop runs as fast as possible for 35ms. This should slighly improve the accuracy of finding min and max of the sinusoid
- A new optional 4th parameter to `AdcParam 7` allow to give a minimum current threshold below which values are forced to 0 A. This helps removing noise when no current goes through.

This has been tested on ESP8266 with the following circuit and a 50A/1V CT (testing on ESP32 to be done later but as it doesn't change much the calculation logic, it should have no impact if it was working before)

_Note: it is important to use a Current => Voltage CT and not a Current => Current model._

![image](https://user-images.githubusercontent.com/2996042/230736501-112c696e-1abe-4e0e-98b5-5e6c242e3a64.png)

New AdcParam command with 4th parameter
`AdcParam 7, 0, <calib>, <voltage/100>, <currentThresold>`
I used my 50A/1V CT with:
`AdcParam 7, 0, 5700, 0.245, 0.060`

Where `calib`=5700 has been determined by trial using a 40W bulb and a hair-dryer and a ACA mutimeter
`currentThreshold` has been set to 0.060 because no load is used, the measured quiescent current is 0.057 A

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
