### PR TITLE
Matter add fabric parent

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
@@ -154,10 +154,17 @@ class Matter_Device
 
   #####################################################################
   # Remove a fabric and clean all corresponding values and mDNS entries
-  def remove_fabric(fabric)
-    self.message_handler.im.subs_shop.remove_by_fabric(fabric)
-    self.mdns_remove_op_discovery(fabric)
-    self.sessions.remove_fabric(fabric)
+  def remove_fabric(fabric_parent)
+    var sub_fabrics = self.sessions.find_children_fabrics(fabric_parent.get_fabric_index())
+    if sub_fabrics == nil return end
+    for fabric_index : sub_fabrics
+      var fabric = self.sessions.find_fabric_by_index(fabric_index)
+      if fabric != nil
+        self.message_handler.im.subs_shop.remove_by_fabric(fabric)
+        self.mdns_remove_op_discovery(fabric)
+        self.sessions.remove_fabric(fabric)
+      end
+    end
     self.sessions.save_fabrics()
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
@@ -488,7 +488,7 @@ class Matter_Plugin_Root : Matter_Plugin
         var hk = crypto.HKDF_SHA256()
         var fabric_rev = fabric_id.copy().reverse()
         var k_fabric = hk.derive(root_ca, fabric_rev, info, 8)
-        session.set_fabric_device(fabric_id, deviceid, k_fabric)
+        session.set_fabric_device(fabric_id, deviceid, k_fabric, self.device.commissioning_admin_fabric)
 
         # We have a candidate fabric, add it as expirable for 2 minutes
         session.persist_to_fabric()       # fabric object is completed, persist it

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
@@ -431,7 +431,7 @@ be_local_closure(Matter_Device_start_operational_discovery_deferred,   /* name *
 ********************************************************************/
 be_local_closure(Matter_Device_remove_fabric,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
+    9,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -439,36 +439,66 @@ be_local_closure(Matter_Device_remove_fabric,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(im),
-    /* K2   */  be_nested_str_weak(subs_shop),
-    /* K3   */  be_nested_str_weak(remove_by_fabric),
-    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K5   */  be_nested_str_weak(sessions),
-    /* K6   */  be_nested_str_weak(remove_fabric),
-    /* K7   */  be_nested_str_weak(save_fabrics),
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(find_children_fabrics),
+    /* K2   */  be_nested_str_weak(get_fabric_index),
+    /* K3   */  be_nested_str_weak(find_fabric_by_index),
+    /* K4   */  be_nested_str_weak(message_handler),
+    /* K5   */  be_nested_str_weak(im),
+    /* K6   */  be_nested_str_weak(subs_shop),
+    /* K7   */  be_nested_str_weak(remove_by_fabric),
+    /* K8   */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K9   */  be_nested_str_weak(remove_fabric),
+    /* K10  */  be_nested_str_weak(stop_iteration),
+    /* K11  */  be_nested_str_weak(save_fabrics),
     }),
     be_str_weak(remove_fabric),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
+    ( &(const binstruction[43]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x88080501,  //  0001  GETMBR	R2	R2	K1
-      0x88080502,  //  0002  GETMBR	R2	R2	K2
-      0x8C080503,  //  0003  GETMET	R2	R2	K3
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x8C080104,  //  0006  GETMET	R2	R0	K4
-      0x5C100200,  //  0007  MOVE	R4	R1
-      0x7C080400,  //  0008  CALL	R2	2
-      0x88080105,  //  0009  GETMBR	R2	R0	K5
-      0x8C080506,  //  000A  GETMET	R2	R2	K6
-      0x5C100200,  //  000B  MOVE	R4	R1
-      0x7C080400,  //  000C  CALL	R2	2
-      0x88080105,  //  000D  GETMBR	R2	R0	K5
-      0x8C080507,  //  000E  GETMET	R2	R2	K7
-      0x7C080200,  //  000F  CALL	R2	1
-      0x80000000,  //  0010  RET	0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8C100302,  //  0002  GETMET	R4	R1	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x7C080400,  //  0004  CALL	R2	2
+      0x4C0C0000,  //  0005  LDNIL	R3
+      0x1C0C0403,  //  0006  EQ	R3	R2	R3
+      0x780E0000,  //  0007  JMPF	R3	#0009
+      0x80000600,  //  0008  RET	0
+      0x600C0010,  //  0009  GETGBL	R3	G16
+      0x5C100400,  //  000A  MOVE	R4	R2
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0xA8020016,  //  000C  EXBLK	0	#0024
+      0x5C100600,  //  000D  MOVE	R4	R3
+      0x7C100000,  //  000E  CALL	R4	0
+      0x88140100,  //  000F  GETMBR	R5	R0	K0
+      0x8C140B03,  //  0010  GETMET	R5	R5	K3
+      0x5C1C0800,  //  0011  MOVE	R7	R4
+      0x7C140400,  //  0012  CALL	R5	2
+      0x4C180000,  //  0013  LDNIL	R6
+      0x20180A06,  //  0014  NE	R6	R5	R6
+      0x781A000C,  //  0015  JMPF	R6	#0023
+      0x88180104,  //  0016  GETMBR	R6	R0	K4
+      0x88180D05,  //  0017  GETMBR	R6	R6	K5
+      0x88180D06,  //  0018  GETMBR	R6	R6	K6
+      0x8C180D07,  //  0019  GETMET	R6	R6	K7
+      0x5C200A00,  //  001A  MOVE	R8	R5
+      0x7C180400,  //  001B  CALL	R6	2
+      0x8C180108,  //  001C  GETMET	R6	R0	K8
+      0x5C200A00,  //  001D  MOVE	R8	R5
+      0x7C180400,  //  001E  CALL	R6	2
+      0x88180100,  //  001F  GETMBR	R6	R0	K0
+      0x8C180D09,  //  0020  GETMET	R6	R6	K9
+      0x5C200A00,  //  0021  MOVE	R8	R5
+      0x7C180400,  //  0022  CALL	R6	2
+      0x7001FFE8,  //  0023  JMP		#000D
+      0x580C000A,  //  0024  LDCONST	R3	K10
+      0xAC0C0200,  //  0025  CATCH	R3	1	0
+      0xB0080000,  //  0026  RAISE	2	R0	R0
+      0x880C0100,  //  0027  GETMBR	R3	R0	K0
+      0x8C0C070B,  //  0028  GETMET	R3	R3	K11
+      0x7C0C0200,  //  0029  CALL	R3	1
+      0x80000000,  //  002A  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
@@ -1215,7 +1215,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[99]) {     /* constants */
+    ( &(const bvalue[100]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(matter),
@@ -1283,42 +1283,43 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
     /* K64  */  be_nested_str_weak(reverse),
     /* K65  */  be_nested_str_weak(derive),
     /* K66  */  be_nested_str_weak(set_fabric_device),
-    /* K67  */  be_nested_str_weak(persist_to_fabric),
-    /* K68  */  be_nested_str_weak(fabric_candidate),
-    /* K69  */  be_nested_str_weak(start_operational_discovery_deferred),
-    /* K70  */  be_nested_str_weak(MTR_X3A_X20_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D),
-    /* K71  */  be_nested_str_weak(MTR_X3A_X20fabric_X3D),
-    /* K72  */  be_nested_str_weak(inspect),
-    /* K73  */  be_nested_str_weak(_fabric),
-    /* K74  */  be_nested_str_weak(log_new_fabric),
-    /* K75  */  be_nested_str_weak(set_fabric_label),
-    /* K76  */  be_nested_str_weak(format),
-    /* K77  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Update_X20fabric_X20_X27_X25s_X27_X20label_X3D_X27_X25s_X27),
-    /* K78  */  be_nested_str_weak(get_fabric_id),
-    /* K79  */  be_nested_str_weak(sessions),
-    /* K80  */  be_nested_str_weak(active_fabrics),
-    /* K81  */  be_nested_str_weak(get_fabric_index),
-    /* K82  */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
-    /* K83  */  be_nested_str_weak(set_timer),
-    /* K84  */  be_nested_str_weak(stop_iteration),
-    /* K85  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
-    /* K86  */  be_nested_str_weak(_X29_X20not_X20found),
-    /* K87  */  be_nested_str_weak(INVALID_ACTION),
-    /* K88  */  be_nested_str_weak(fabric_index_X3A),
-    /* K89  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
-    /* K90  */  be_nested_str_weak(INVALID_DATA_TYPE),
-    /* K91  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
-    /* K92  */  be_nested_str_weak(CONSTRAINT_ERROR),
-    /* K93  */  be_nested_str_weak(start_basic_commissioning),
-    /* K94  */  be_nested_str_weak(get_fabric),
-    /* K95  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
-    /* K96  */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K97  */  be_nested_str_weak(stop_basic_commissioning),
-    /* K98  */  be_nested_str_weak(invoke_request),
+    /* K67  */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K68  */  be_nested_str_weak(persist_to_fabric),
+    /* K69  */  be_nested_str_weak(fabric_candidate),
+    /* K70  */  be_nested_str_weak(start_operational_discovery_deferred),
+    /* K71  */  be_nested_str_weak(MTR_X3A_X20_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D),
+    /* K72  */  be_nested_str_weak(MTR_X3A_X20fabric_X3D),
+    /* K73  */  be_nested_str_weak(inspect),
+    /* K74  */  be_nested_str_weak(_fabric),
+    /* K75  */  be_nested_str_weak(log_new_fabric),
+    /* K76  */  be_nested_str_weak(set_fabric_label),
+    /* K77  */  be_nested_str_weak(format),
+    /* K78  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Update_X20fabric_X20_X27_X25s_X27_X20label_X3D_X27_X25s_X27),
+    /* K79  */  be_nested_str_weak(get_fabric_id),
+    /* K80  */  be_nested_str_weak(sessions),
+    /* K81  */  be_nested_str_weak(active_fabrics),
+    /* K82  */  be_nested_str_weak(get_fabric_index),
+    /* K83  */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
+    /* K84  */  be_nested_str_weak(set_timer),
+    /* K85  */  be_nested_str_weak(stop_iteration),
+    /* K86  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
+    /* K87  */  be_nested_str_weak(_X29_X20not_X20found),
+    /* K88  */  be_nested_str_weak(INVALID_ACTION),
+    /* K89  */  be_nested_str_weak(fabric_index_X3A),
+    /* K90  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
+    /* K91  */  be_nested_str_weak(INVALID_DATA_TYPE),
+    /* K92  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
+    /* K93  */  be_nested_str_weak(CONSTRAINT_ERROR),
+    /* K94  */  be_nested_str_weak(start_basic_commissioning),
+    /* K95  */  be_nested_str_weak(get_fabric),
+    /* K96  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
+    /* K97  */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K98  */  be_nested_str_weak(stop_basic_commissioning),
+    /* K99  */  be_nested_str_weak(invoke_request),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[733]) {  /* code */
+    ( &(const binstruction[735]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xA4160200,  //  0001  IMPORT	R5	K1
       0xB81A0400,  //  0002  GETNGBL	R6	K2
@@ -1412,10 +1413,10 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x5C300200,  //  005A  MOVE	R12	R1
       0x7C280400,  //  005B  CALL	R10	2
       0x80041200,  //  005C  RET	1	R9
-      0x7002027C,  //  005D  JMP		#02DB
+      0x7002027E,  //  005D  JMP		#02DD
       0x5426003D,  //  005E  LDINT	R9	62
       0x1C240E09,  //  005F  EQ	R9	R7	R9
-      0x782601DE,  //  0060  JMPF	R9	#0240
+      0x782601E0,  //  0060  JMPF	R9	#0242
       0x1C24110F,  //  0061  EQ	R9	R8	K15
       0x7826001D,  //  0062  JMPF	R9	#0081
       0x8C240507,  //  0063  GETMET	R9	R2	K7
@@ -1447,7 +1448,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C2C0800,  //  007D  CALL	R11	4
       0x900E0B11,  //  007E  SETMBR	R3	K5	K17
       0x80041400,  //  007F  RET	1	R10
-      0x700201BD,  //  0080  JMP		#023F
+      0x700201BF,  //  0080  JMP		#0241
       0x1C241106,  //  0081  EQ	R9	R8	K6
       0x78260044,  //  0082  JMPF	R9	#00C8
       0x8C240507,  //  0083  GETMET	R9	R2	K7
@@ -1518,7 +1519,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C400800,  //  00C4  CALL	R16	4
       0x900E0B08,  //  00C5  SETMBR	R3	K5	K8
       0x80041E00,  //  00C6  RET	1	R15
-      0x70020176,  //  00C7  JMP		#023F
+      0x70020178,  //  00C7  JMP		#0241
       0x54260003,  //  00C8  LDINT	R9	4
       0x1C241009,  //  00C9  EQ	R9	R8	R9
       0x78260040,  //  00CA  JMPF	R9	#010C
@@ -1586,7 +1587,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x54460004,  //  0108  LDINT	R17	5
       0x900E0A11,  //  0109  SETMBR	R3	K5	R17
       0x80042000,  //  010A  RET	1	R16
-      0x70020132,  //  010B  JMP		#023F
+      0x70020134,  //  010B  JMP		#0241
       0x5426000A,  //  010C  LDINT	R9	11
       0x1C241009,  //  010D  EQ	R9	R8	R9
       0x78260012,  //  010E  JMPF	R9	#0122
@@ -1608,10 +1609,10 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x900E2E0A,  //  011E  SETMBR	R3	K23	R10
       0x4C280000,  //  011F  LDNIL	R10
       0x80041400,  //  0120  RET	1	R10
-      0x7002011C,  //  0121  JMP		#023F
+      0x7002011E,  //  0121  JMP		#0241
       0x54260005,  //  0122  LDINT	R9	6
       0x1C241009,  //  0123  EQ	R9	R8	R9
-      0x782600B5,  //  0124  JMPF	R9	#01DB
+      0x782600B7,  //  0124  JMPF	R9	#01DD
       0x8C240507,  //  0125  GETMET	R9	R2	K7
       0x582C0006,  //  0126  LDCONST	R11	K6
       0x7C240400,  //  0127  CALL	R9	2
@@ -1746,312 +1747,314 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x5C642000,  //  01A8  MOVE	R25	R16
       0x5C682200,  //  01A9  MOVE	R26	R17
       0x5C6C2C00,  //  01AA  MOVE	R27	R22
-      0x7C5C0800,  //  01AB  CALL	R23	4
-      0x8C5C0343,  //  01AC  GETMET	R23	R1	K67
-      0x7C5C0200,  //  01AD  CALL	R23	1
+      0x88700115,  //  01AB  GETMBR	R28	R0	K21
+      0x88703943,  //  01AC  GETMBR	R28	R28	K67
+      0x7C5C0A00,  //  01AD  CALL	R23	5
       0x8C5C0344,  //  01AE  GETMET	R23	R1	K68
       0x7C5C0200,  //  01AF  CALL	R23	1
-      0x885C0115,  //  01B0  GETMBR	R23	R0	K21
-      0x8C5C2F45,  //  01B1  GETMET	R23	R23	K69
-      0x5C640200,  //  01B2  MOVE	R25	R1
-      0x7C5C0400,  //  01B3  CALL	R23	2
-      0xB85E3E00,  //  01B4  GETNGBL	R23	K31
-      0x8C5C2F24,  //  01B5  GETMET	R23	R23	K36
-      0x58640046,  //  01B6  LDCONST	R25	K70
-      0x58680011,  //  01B7  LDCONST	R26	K17
-      0x7C5C0600,  //  01B8  CALL	R23	3
-      0xB85E3E00,  //  01B9  GETNGBL	R23	K31
-      0x8C5C2F24,  //  01BA  GETMET	R23	R23	K36
-      0xB8660400,  //  01BB  GETNGBL	R25	K2
-      0x8C643348,  //  01BC  GETMET	R25	R25	K72
-      0x886C0349,  //  01BD  GETMBR	R27	R1	K73
-      0x7C640400,  //  01BE  CALL	R25	2
-      0x00668E19,  //  01BF  ADD	R25	K71	R25
-      0x58680011,  //  01C0  LDCONST	R26	K17
-      0x7C5C0600,  //  01C1  CALL	R23	3
-      0xB85E3E00,  //  01C2  GETNGBL	R23	K31
-      0x8C5C2F24,  //  01C3  GETMET	R23	R23	K36
-      0x58640046,  //  01C4  LDCONST	R25	K70
-      0x58680011,  //  01C5  LDCONST	R26	K17
-      0x7C5C0600,  //  01C6  CALL	R23	3
-      0x885C0349,  //  01C7  GETMBR	R23	R1	K73
-      0x8C5C2F4A,  //  01C8  GETMET	R23	R23	K74
-      0x7C5C0200,  //  01C9  CALL	R23	1
-      0x8C5C0D0A,  //  01CA  GETMET	R23	R6	K10
+      0x8C5C0345,  //  01B0  GETMET	R23	R1	K69
+      0x7C5C0200,  //  01B1  CALL	R23	1
+      0x885C0115,  //  01B2  GETMBR	R23	R0	K21
+      0x8C5C2F46,  //  01B3  GETMET	R23	R23	K70
+      0x5C640200,  //  01B4  MOVE	R25	R1
+      0x7C5C0400,  //  01B5  CALL	R23	2
+      0xB85E3E00,  //  01B6  GETNGBL	R23	K31
+      0x8C5C2F24,  //  01B7  GETMET	R23	R23	K36
+      0x58640047,  //  01B8  LDCONST	R25	K71
+      0x58680011,  //  01B9  LDCONST	R26	K17
+      0x7C5C0600,  //  01BA  CALL	R23	3
+      0xB85E3E00,  //  01BB  GETNGBL	R23	K31
+      0x8C5C2F24,  //  01BC  GETMET	R23	R23	K36
+      0xB8660400,  //  01BD  GETNGBL	R25	K2
+      0x8C643349,  //  01BE  GETMET	R25	R25	K73
+      0x886C034A,  //  01BF  GETMBR	R27	R1	K74
+      0x7C640400,  //  01C0  CALL	R25	2
+      0x00669019,  //  01C1  ADD	R25	K72	R25
+      0x58680011,  //  01C2  LDCONST	R26	K17
+      0x7C5C0600,  //  01C3  CALL	R23	3
+      0xB85E3E00,  //  01C4  GETNGBL	R23	K31
+      0x8C5C2F24,  //  01C5  GETMET	R23	R23	K36
+      0x58640047,  //  01C6  LDCONST	R25	K71
+      0x58680011,  //  01C7  LDCONST	R26	K17
+      0x7C5C0600,  //  01C8  CALL	R23	3
+      0x885C034A,  //  01C9  GETMBR	R23	R1	K74
+      0x8C5C2F4B,  //  01CA  GETMET	R23	R23	K75
       0x7C5C0200,  //  01CB  CALL	R23	1
-      0x8C602F0B,  //  01CC  GETMET	R24	R23	K11
-      0x58680006,  //  01CD  LDCONST	R26	K6
-      0x886C0D0C,  //  01CE  GETMBR	R27	R6	K12
-      0xB8720400,  //  01CF  GETNGBL	R28	K2
-      0x8870392E,  //  01D0  GETMBR	R28	R28	K46
-      0x7C600800,  //  01D1  CALL	R24	4
-      0x8C602F0B,  //  01D2  GETMET	R24	R23	K11
-      0x58680008,  //  01D3  LDCONST	R26	K8
-      0x886C0D0C,  //  01D4  GETMBR	R27	R6	K12
-      0x58700008,  //  01D5  LDCONST	R28	K8
-      0x7C600800,  //  01D6  CALL	R24	4
-      0x54620007,  //  01D7  LDINT	R24	8
-      0x900E0A18,  //  01D8  SETMBR	R3	K5	R24
-      0x80042E00,  //  01D9  RET	1	R23
-      0x70020063,  //  01DA  JMP		#023F
-      0x54260008,  //  01DB  LDINT	R9	9
-      0x1C241009,  //  01DC  EQ	R9	R8	R9
-      0x7826001E,  //  01DD  JMPF	R9	#01FD
-      0x8C240507,  //  01DE  GETMET	R9	R2	K7
-      0x582C0006,  //  01DF  LDCONST	R11	K6
-      0x7C240400,  //  01E0  CALL	R9	2
-      0x8C28034B,  //  01E1  GETMET	R10	R1	K75
-      0x5C301200,  //  01E2  MOVE	R12	R9
-      0x7C280400,  //  01E3  CALL	R10	2
-      0xB82A3E00,  //  01E4  GETNGBL	R10	K31
-      0x8C281524,  //  01E5  GETMET	R10	R10	K36
-      0x8C300B4C,  //  01E6  GETMET	R12	R5	K76
-      0x5838004D,  //  01E7  LDCONST	R14	K77
-      0x883C0349,  //  01E8  GETMBR	R15	R1	K73
-      0x8C3C1F4E,  //  01E9  GETMET	R15	R15	K78
-      0x7C3C0200,  //  01EA  CALL	R15	1
-      0x8C3C1F3F,  //  01EB  GETMET	R15	R15	K63
+      0x8C5C0D0A,  //  01CC  GETMET	R23	R6	K10
+      0x7C5C0200,  //  01CD  CALL	R23	1
+      0x8C602F0B,  //  01CE  GETMET	R24	R23	K11
+      0x58680006,  //  01CF  LDCONST	R26	K6
+      0x886C0D0C,  //  01D0  GETMBR	R27	R6	K12
+      0xB8720400,  //  01D1  GETNGBL	R28	K2
+      0x8870392E,  //  01D2  GETMBR	R28	R28	K46
+      0x7C600800,  //  01D3  CALL	R24	4
+      0x8C602F0B,  //  01D4  GETMET	R24	R23	K11
+      0x58680008,  //  01D5  LDCONST	R26	K8
+      0x886C0D0C,  //  01D6  GETMBR	R27	R6	K12
+      0x58700008,  //  01D7  LDCONST	R28	K8
+      0x7C600800,  //  01D8  CALL	R24	4
+      0x54620007,  //  01D9  LDINT	R24	8
+      0x900E0A18,  //  01DA  SETMBR	R3	K5	R24
+      0x80042E00,  //  01DB  RET	1	R23
+      0x70020063,  //  01DC  JMP		#0241
+      0x54260008,  //  01DD  LDINT	R9	9
+      0x1C241009,  //  01DE  EQ	R9	R8	R9
+      0x7826001E,  //  01DF  JMPF	R9	#01FF
+      0x8C240507,  //  01E0  GETMET	R9	R2	K7
+      0x582C0006,  //  01E1  LDCONST	R11	K6
+      0x7C240400,  //  01E2  CALL	R9	2
+      0x8C28034C,  //  01E3  GETMET	R10	R1	K76
+      0x5C301200,  //  01E4  MOVE	R12	R9
+      0x7C280400,  //  01E5  CALL	R10	2
+      0xB82A3E00,  //  01E6  GETNGBL	R10	K31
+      0x8C281524,  //  01E7  GETMET	R10	R10	K36
+      0x8C300B4D,  //  01E8  GETMET	R12	R5	K77
+      0x5838004E,  //  01E9  LDCONST	R14	K78
+      0x883C034A,  //  01EA  GETMBR	R15	R1	K74
+      0x8C3C1F4F,  //  01EB  GETMET	R15	R15	K79
       0x7C3C0200,  //  01EC  CALL	R15	1
-      0x8C3C1F40,  //  01ED  GETMET	R15	R15	K64
+      0x8C3C1F3F,  //  01ED  GETMET	R15	R15	K63
       0x7C3C0200,  //  01EE  CALL	R15	1
-      0x8C3C1F26,  //  01EF  GETMET	R15	R15	K38
+      0x8C3C1F40,  //  01EF  GETMET	R15	R15	K64
       0x7C3C0200,  //  01F0  CALL	R15	1
-      0x60400008,  //  01F1  GETGBL	R16	G8
-      0x5C441200,  //  01F2  MOVE	R17	R9
-      0x7C400200,  //  01F3  CALL	R16	1
-      0x7C300800,  //  01F4  CALL	R12	4
-      0x5834000F,  //  01F5  LDCONST	R13	K15
-      0x7C280600,  //  01F6  CALL	R10	3
-      0xB82A0400,  //  01F7  GETNGBL	R10	K2
-      0x8828152E,  //  01F8  GETMBR	R10	R10	K46
-      0x900E2E0A,  //  01F9  SETMBR	R3	K23	R10
-      0x4C280000,  //  01FA  LDNIL	R10
-      0x80041400,  //  01FB  RET	1	R10
-      0x70020041,  //  01FC  JMP		#023F
-      0x54260009,  //  01FD  LDINT	R9	10
-      0x1C241009,  //  01FE  EQ	R9	R8	R9
-      0x7826003E,  //  01FF  JMPF	R9	#023F
-      0x8C240507,  //  0200  GETMET	R9	R2	K7
-      0x582C0006,  //  0201  LDCONST	R11	K6
-      0x7C240400,  //  0202  CALL	R9	2
-      0x60280010,  //  0203  GETGBL	R10	G16
-      0x882C0115,  //  0204  GETMBR	R11	R0	K21
-      0x882C174F,  //  0205  GETMBR	R11	R11	K79
-      0x8C2C1750,  //  0206  GETMET	R11	R11	K80
-      0x7C2C0200,  //  0207  CALL	R11	1
-      0x7C280200,  //  0208  CALL	R10	1
-      0xA802001D,  //  0209  EXBLK	0	#0228
-      0x5C2C1400,  //  020A  MOVE	R11	R10
-      0x7C2C0000,  //  020B  CALL	R11	0
-      0x8C301751,  //  020C  GETMET	R12	R11	K81
-      0x7C300200,  //  020D  CALL	R12	1
-      0x1C301809,  //  020E  EQ	R12	R12	R9
-      0x78320015,  //  020F  JMPF	R12	#0226
-      0xB8323E00,  //  0210  GETNGBL	R12	K31
-      0x8C301924,  //  0211  GETMET	R12	R12	K36
-      0x8C38174E,  //  0212  GETMET	R14	R11	K78
-      0x7C380200,  //  0213  CALL	R14	1
-      0x8C381D3F,  //  0214  GETMET	R14	R14	K63
+      0x8C3C1F26,  //  01F1  GETMET	R15	R15	K38
+      0x7C3C0200,  //  01F2  CALL	R15	1
+      0x60400008,  //  01F3  GETGBL	R16	G8
+      0x5C441200,  //  01F4  MOVE	R17	R9
+      0x7C400200,  //  01F5  CALL	R16	1
+      0x7C300800,  //  01F6  CALL	R12	4
+      0x5834000F,  //  01F7  LDCONST	R13	K15
+      0x7C280600,  //  01F8  CALL	R10	3
+      0xB82A0400,  //  01F9  GETNGBL	R10	K2
+      0x8828152E,  //  01FA  GETMBR	R10	R10	K46
+      0x900E2E0A,  //  01FB  SETMBR	R3	K23	R10
+      0x4C280000,  //  01FC  LDNIL	R10
+      0x80041400,  //  01FD  RET	1	R10
+      0x70020041,  //  01FE  JMP		#0241
+      0x54260009,  //  01FF  LDINT	R9	10
+      0x1C241009,  //  0200  EQ	R9	R8	R9
+      0x7826003E,  //  0201  JMPF	R9	#0241
+      0x8C240507,  //  0202  GETMET	R9	R2	K7
+      0x582C0006,  //  0203  LDCONST	R11	K6
+      0x7C240400,  //  0204  CALL	R9	2
+      0x60280010,  //  0205  GETGBL	R10	G16
+      0x882C0115,  //  0206  GETMBR	R11	R0	K21
+      0x882C1750,  //  0207  GETMBR	R11	R11	K80
+      0x8C2C1751,  //  0208  GETMET	R11	R11	K81
+      0x7C2C0200,  //  0209  CALL	R11	1
+      0x7C280200,  //  020A  CALL	R10	1
+      0xA802001D,  //  020B  EXBLK	0	#022A
+      0x5C2C1400,  //  020C  MOVE	R11	R10
+      0x7C2C0000,  //  020D  CALL	R11	0
+      0x8C301752,  //  020E  GETMET	R12	R11	K82
+      0x7C300200,  //  020F  CALL	R12	1
+      0x1C301809,  //  0210  EQ	R12	R12	R9
+      0x78320015,  //  0211  JMPF	R12	#0228
+      0xB8323E00,  //  0212  GETNGBL	R12	K31
+      0x8C301924,  //  0213  GETMET	R12	R12	K36
+      0x8C38174F,  //  0214  GETMET	R14	R11	K79
       0x7C380200,  //  0215  CALL	R14	1
-      0x8C381D40,  //  0216  GETMET	R14	R14	K64
+      0x8C381D3F,  //  0216  GETMET	R14	R14	K63
       0x7C380200,  //  0217  CALL	R14	1
-      0x8C381D26,  //  0218  GETMET	R14	R14	K38
+      0x8C381D40,  //  0218  GETMET	R14	R14	K64
       0x7C380200,  //  0219  CALL	R14	1
-      0x003AA40E,  //  021A  ADD	R14	K82	R14
-      0x583C000F,  //  021B  LDCONST	R15	K15
-      0x7C300600,  //  021C  CALL	R12	3
-      0xB8323E00,  //  021D  GETNGBL	R12	K31
-      0x8C301953,  //  021E  GETMET	R12	R12	K83
-      0x543A07CF,  //  021F  LDINT	R14	2000
-      0x843C0000,  //  0220  CLOSURE	R15	P0
-      0x7C300600,  //  0221  CALL	R12	3
-      0x50300200,  //  0222  LDBOOL	R12	1	0
-      0xA0000000,  //  0223  CLOSE	R0
-      0xA8040001,  //  0224  EXBLK	1	1
-      0x80041800,  //  0225  RET	1	R12
-      0xA0280000,  //  0226  CLOSE	R10
-      0x7001FFE1,  //  0227  JMP		#020A
-      0x58280054,  //  0228  LDCONST	R10	K84
-      0xAC280200,  //  0229  CATCH	R10	1	0
-      0xB0080000,  //  022A  RAISE	2	R0	R0
-      0xB82A3E00,  //  022B  GETNGBL	R10	K31
-      0x8C281524,  //  022C  GETMET	R10	R10	K36
-      0x60300008,  //  022D  GETGBL	R12	G8
-      0x5C341200,  //  022E  MOVE	R13	R9
-      0x7C300200,  //  022F  CALL	R12	1
-      0x0032AA0C,  //  0230  ADD	R12	K85	R12
-      0x00301956,  //  0231  ADD	R12	R12	K86
-      0x5834000F,  //  0232  LDCONST	R13	K15
-      0x7C280600,  //  0233  CALL	R10	3
-      0xB82A0400,  //  0234  GETNGBL	R10	K2
-      0x88281557,  //  0235  GETMBR	R10	R10	K87
-      0x900E2E0A,  //  0236  SETMBR	R3	K23	R10
-      0x60280008,  //  0237  GETGBL	R10	G8
-      0x5C2C1200,  //  0238  MOVE	R11	R9
-      0x7C280200,  //  0239  CALL	R10	1
-      0x002AB00A,  //  023A  ADD	R10	K88	R10
-      0x900E480A,  //  023B  SETMBR	R3	K36	R10
-      0x4C280000,  //  023C  LDNIL	R10
-      0xA0000000,  //  023D  CLOSE	R0
-      0x80041400,  //  023E  RET	1	R10
-      0x7002009A,  //  023F  JMP		#02DB
-      0x5426003B,  //  0240  LDINT	R9	60
-      0x1C240E09,  //  0241  EQ	R9	R7	R9
-      0x78260084,  //  0242  JMPF	R9	#02C8
-      0x1C241106,  //  0243  EQ	R9	R8	K6
-      0x78260064,  //  0244  JMPF	R9	#02AA
-      0x8C240507,  //  0245  GETMET	R9	R2	K7
-      0x582C0006,  //  0246  LDCONST	R11	K6
-      0x7C240400,  //  0247  CALL	R9	2
-      0x8C280507,  //  0248  GETMET	R10	R2	K7
-      0x58300008,  //  0249  LDCONST	R12	K8
-      0x7C280400,  //  024A  CALL	R10	2
-      0x8C2C0507,  //  024B  GETMET	R11	R2	K7
-      0x5834000F,  //  024C  LDCONST	R13	K15
-      0x7C2C0400,  //  024D  CALL	R11	2
-      0x8C300507,  //  024E  GETMET	R12	R2	K7
-      0x58380011,  //  024F  LDCONST	R14	K17
-      0x7C300400,  //  0250  CALL	R12	2
-      0x8C340507,  //  0251  GETMET	R13	R2	K7
-      0x543E0003,  //  0252  LDINT	R15	4
-      0x7C340400,  //  0253  CALL	R13	2
-      0xB83A3E00,  //  0254  GETNGBL	R14	K31
-      0x8C381D24,  //  0255  GETMET	R14	R14	K36
-      0x8C400B4C,  //  0256  GETMET	R16	R5	K76
-      0x58480059,  //  0257  LDCONST	R18	K89
-      0x5C4C1200,  //  0258  MOVE	R19	R9
-      0x8C501526,  //  0259  GETMET	R20	R10	K38
-      0x7C500200,  //  025A  CALL	R20	1
-      0x5C541600,  //  025B  MOVE	R21	R11
-      0x5C581800,  //  025C  MOVE	R22	R12
-      0x8C5C1B26,  //  025D  GETMET	R23	R13	K38
-      0x7C5C0200,  //  025E  CALL	R23	1
-      0x7C400E00,  //  025F  CALL	R16	7
-      0x5844000F,  //  0260  LDCONST	R17	K15
-      0x7C380600,  //  0261  CALL	R14	3
-      0x4C380000,  //  0262  LDNIL	R14
-      0x1C38120E,  //  0263  EQ	R14	R9	R14
-      0x743A000B,  //  0264  JMPT	R14	#0271
-      0x4C380000,  //  0265  LDNIL	R14
-      0x1C38140E,  //  0266  EQ	R14	R10	R14
-      0x743A0008,  //  0267  JMPT	R14	#0271
-      0x4C380000,  //  0268  LDNIL	R14
-      0x1C38160E,  //  0269  EQ	R14	R11	R14
-      0x743A0005,  //  026A  JMPT	R14	#0271
-      0x4C380000,  //  026B  LDNIL	R14
-      0x1C38180E,  //  026C  EQ	R14	R12	R14
-      0x743A0002,  //  026D  JMPT	R14	#0271
-      0x4C380000,  //  026E  LDNIL	R14
-      0x1C381A0E,  //  026F  EQ	R14	R13	R14
-      0x783A0005,  //  0270  JMPF	R14	#0277
-      0xB83A0400,  //  0271  GETNGBL	R14	K2
-      0x88381D5A,  //  0272  GETMBR	R14	R14	K90
-      0x900E2E0E,  //  0273  SETMBR	R3	K23	R14
-      0x4C380000,  //  0274  LDNIL	R14
-      0xA0000000,  //  0275  CLOSE	R0
-      0x80041C00,  //  0276  RET	1	R14
-      0x6038000C,  //  0277  GETGBL	R14	G12
-      0x5C3C1400,  //  0278  MOVE	R15	R10
-      0x7C380200,  //  0279  CALL	R14	1
-      0x543E001F,  //  027A  LDINT	R15	32
-      0x54420040,  //  027B  LDINT	R16	65
-      0x003C1E10,  //  027C  ADD	R15	R15	R16
-      0x20381C0F,  //  027D  NE	R14	R14	R15
-      0x743A000B,  //  027E  JMPT	R14	#028B
-      0x6038000C,  //  027F  GETGBL	R14	G12
-      0x5C3C1A00,  //  0280  MOVE	R15	R13
-      0x7C380200,  //  0281  CALL	R14	1
-      0x543E000F,  //  0282  LDINT	R15	16
-      0x14381C0F,  //  0283  LT	R14	R14	R15
-      0x743A0005,  //  0284  JMPT	R14	#028B
-      0x6038000C,  //  0285  GETGBL	R14	G12
-      0x5C3C1A00,  //  0286  MOVE	R15	R13
-      0x7C380200,  //  0287  CALL	R14	1
-      0x543E001F,  //  0288  LDINT	R15	32
-      0x24381C0F,  //  0289  GT	R14	R14	R15
-      0x783A0009,  //  028A  JMPF	R14	#0295
-      0xB83A3E00,  //  028B  GETNGBL	R14	K31
-      0x8C381D24,  //  028C  GETMET	R14	R14	K36
-      0x5840005B,  //  028D  LDCONST	R16	K91
-      0x7C380400,  //  028E  CALL	R14	2
-      0xB83A0400,  //  028F  GETNGBL	R14	K2
-      0x88381D5C,  //  0290  GETMBR	R14	R14	K92
-      0x900E2E0E,  //  0291  SETMBR	R3	K23	R14
-      0x4C380000,  //  0292  LDNIL	R14
-      0xA0000000,  //  0293  CLOSE	R0
-      0x80041C00,  //  0294  RET	1	R14
-      0x543A001E,  //  0295  LDINT	R14	31
-      0x403A0C0E,  //  0296  CONNECT	R14	K6	R14
-      0x9438140E,  //  0297  GETIDX	R14	R10	R14
-      0x543E001F,  //  0298  LDINT	R15	32
-      0x403C1F3B,  //  0299  CONNECT	R15	R15	K59
-      0x943C140F,  //  029A  GETIDX	R15	R10	R15
-      0x88400115,  //  029B  GETMBR	R16	R0	K21
-      0x8C40215D,  //  029C  GETMET	R16	R16	K93
-      0x5C481200,  //  029D  MOVE	R18	R9
-      0x5C4C1800,  //  029E  MOVE	R19	R12
-      0x5C501600,  //  029F  MOVE	R20	R11
-      0x5C541A00,  //  02A0  MOVE	R21	R13
-      0x5C581C00,  //  02A1  MOVE	R22	R14
-      0x5C5C1E00,  //  02A2  MOVE	R23	R15
-      0x8C60035E,  //  02A3  GETMET	R24	R1	K94
-      0x7C600200,  //  02A4  CALL	R24	1
-      0x7C401000,  //  02A5  CALL	R16	8
-      0x50400200,  //  02A6  LDBOOL	R16	1	0
-      0xA0000000,  //  02A7  CLOSE	R0
-      0x80042000,  //  02A8  RET	1	R16
-      0x7002001C,  //  02A9  JMP		#02C7
-      0x1C241108,  //  02AA  EQ	R9	R8	K8
-      0x78260012,  //  02AB  JMPF	R9	#02BF
-      0x8C240507,  //  02AC  GETMET	R9	R2	K7
-      0x582C0006,  //  02AD  LDCONST	R11	K6
-      0x7C240400,  //  02AE  CALL	R9	2
-      0xB82A3E00,  //  02AF  GETNGBL	R10	K31
-      0x8C281524,  //  02B0  GETMET	R10	R10	K36
-      0x60300008,  //  02B1  GETGBL	R12	G8
-      0x5C341200,  //  02B2  MOVE	R13	R9
-      0x7C300200,  //  02B3  CALL	R12	1
-      0x0032BE0C,  //  02B4  ADD	R12	K95	R12
-      0x5834000F,  //  02B5  LDCONST	R13	K15
-      0x7C280600,  //  02B6  CALL	R10	3
-      0x88280115,  //  02B7  GETMBR	R10	R0	K21
-      0x8C281560,  //  02B8  GETMET	R10	R10	K96
-      0x5C301200,  //  02B9  MOVE	R12	R9
-      0x7C280400,  //  02BA  CALL	R10	2
-      0x50280200,  //  02BB  LDBOOL	R10	1	0
-      0xA0000000,  //  02BC  CLOSE	R0
-      0x80041400,  //  02BD  RET	1	R10
-      0x70020007,  //  02BE  JMP		#02C7
-      0x1C24110F,  //  02BF  EQ	R9	R8	K15
-      0x78260005,  //  02C0  JMPF	R9	#02C7
-      0x88240115,  //  02C1  GETMBR	R9	R0	K21
-      0x8C241361,  //  02C2  GETMET	R9	R9	K97
-      0x7C240200,  //  02C3  CALL	R9	1
-      0x50240200,  //  02C4  LDBOOL	R9	1	0
-      0xA0000000,  //  02C5  CLOSE	R0
-      0x80041200,  //  02C6  RET	1	R9
-      0x70020012,  //  02C7  JMP		#02DB
-      0x54260029,  //  02C8  LDINT	R9	42
-      0x1C240E09,  //  02C9  EQ	R9	R7	R9
-      0x78260005,  //  02CA  JMPF	R9	#02D1
-      0x1C241106,  //  02CB  EQ	R9	R8	K6
-      0x78260002,  //  02CC  JMPF	R9	#02D0
-      0x50240200,  //  02CD  LDBOOL	R9	1	0
-      0xA0000000,  //  02CE  CLOSE	R0
-      0x80041200,  //  02CF  RET	1	R9
-      0x70020009,  //  02D0  JMP		#02DB
-      0x60240003,  //  02D1  GETGBL	R9	G3
-      0x5C280000,  //  02D2  MOVE	R10	R0
-      0x7C240200,  //  02D3  CALL	R9	1
-      0x8C241362,  //  02D4  GETMET	R9	R9	K98
-      0x5C2C0200,  //  02D5  MOVE	R11	R1
-      0x5C300400,  //  02D6  MOVE	R12	R2
-      0x5C340600,  //  02D7  MOVE	R13	R3
-      0x7C240800,  //  02D8  CALL	R9	4
-      0xA0000000,  //  02D9  CLOSE	R0
-      0x80041200,  //  02DA  RET	1	R9
+      0x8C381D26,  //  021A  GETMET	R14	R14	K38
+      0x7C380200,  //  021B  CALL	R14	1
+      0x003AA60E,  //  021C  ADD	R14	K83	R14
+      0x583C000F,  //  021D  LDCONST	R15	K15
+      0x7C300600,  //  021E  CALL	R12	3
+      0xB8323E00,  //  021F  GETNGBL	R12	K31
+      0x8C301954,  //  0220  GETMET	R12	R12	K84
+      0x543A07CF,  //  0221  LDINT	R14	2000
+      0x843C0000,  //  0222  CLOSURE	R15	P0
+      0x7C300600,  //  0223  CALL	R12	3
+      0x50300200,  //  0224  LDBOOL	R12	1	0
+      0xA0000000,  //  0225  CLOSE	R0
+      0xA8040001,  //  0226  EXBLK	1	1
+      0x80041800,  //  0227  RET	1	R12
+      0xA0280000,  //  0228  CLOSE	R10
+      0x7001FFE1,  //  0229  JMP		#020C
+      0x58280055,  //  022A  LDCONST	R10	K85
+      0xAC280200,  //  022B  CATCH	R10	1	0
+      0xB0080000,  //  022C  RAISE	2	R0	R0
+      0xB82A3E00,  //  022D  GETNGBL	R10	K31
+      0x8C281524,  //  022E  GETMET	R10	R10	K36
+      0x60300008,  //  022F  GETGBL	R12	G8
+      0x5C341200,  //  0230  MOVE	R13	R9
+      0x7C300200,  //  0231  CALL	R12	1
+      0x0032AC0C,  //  0232  ADD	R12	K86	R12
+      0x00301957,  //  0233  ADD	R12	R12	K87
+      0x5834000F,  //  0234  LDCONST	R13	K15
+      0x7C280600,  //  0235  CALL	R10	3
+      0xB82A0400,  //  0236  GETNGBL	R10	K2
+      0x88281558,  //  0237  GETMBR	R10	R10	K88
+      0x900E2E0A,  //  0238  SETMBR	R3	K23	R10
+      0x60280008,  //  0239  GETGBL	R10	G8
+      0x5C2C1200,  //  023A  MOVE	R11	R9
+      0x7C280200,  //  023B  CALL	R10	1
+      0x002AB20A,  //  023C  ADD	R10	K89	R10
+      0x900E480A,  //  023D  SETMBR	R3	K36	R10
+      0x4C280000,  //  023E  LDNIL	R10
+      0xA0000000,  //  023F  CLOSE	R0
+      0x80041400,  //  0240  RET	1	R10
+      0x7002009A,  //  0241  JMP		#02DD
+      0x5426003B,  //  0242  LDINT	R9	60
+      0x1C240E09,  //  0243  EQ	R9	R7	R9
+      0x78260084,  //  0244  JMPF	R9	#02CA
+      0x1C241106,  //  0245  EQ	R9	R8	K6
+      0x78260064,  //  0246  JMPF	R9	#02AC
+      0x8C240507,  //  0247  GETMET	R9	R2	K7
+      0x582C0006,  //  0248  LDCONST	R11	K6
+      0x7C240400,  //  0249  CALL	R9	2
+      0x8C280507,  //  024A  GETMET	R10	R2	K7
+      0x58300008,  //  024B  LDCONST	R12	K8
+      0x7C280400,  //  024C  CALL	R10	2
+      0x8C2C0507,  //  024D  GETMET	R11	R2	K7
+      0x5834000F,  //  024E  LDCONST	R13	K15
+      0x7C2C0400,  //  024F  CALL	R11	2
+      0x8C300507,  //  0250  GETMET	R12	R2	K7
+      0x58380011,  //  0251  LDCONST	R14	K17
+      0x7C300400,  //  0252  CALL	R12	2
+      0x8C340507,  //  0253  GETMET	R13	R2	K7
+      0x543E0003,  //  0254  LDINT	R15	4
+      0x7C340400,  //  0255  CALL	R13	2
+      0xB83A3E00,  //  0256  GETNGBL	R14	K31
+      0x8C381D24,  //  0257  GETMET	R14	R14	K36
+      0x8C400B4D,  //  0258  GETMET	R16	R5	K77
+      0x5848005A,  //  0259  LDCONST	R18	K90
+      0x5C4C1200,  //  025A  MOVE	R19	R9
+      0x8C501526,  //  025B  GETMET	R20	R10	K38
+      0x7C500200,  //  025C  CALL	R20	1
+      0x5C541600,  //  025D  MOVE	R21	R11
+      0x5C581800,  //  025E  MOVE	R22	R12
+      0x8C5C1B26,  //  025F  GETMET	R23	R13	K38
+      0x7C5C0200,  //  0260  CALL	R23	1
+      0x7C400E00,  //  0261  CALL	R16	7
+      0x5844000F,  //  0262  LDCONST	R17	K15
+      0x7C380600,  //  0263  CALL	R14	3
+      0x4C380000,  //  0264  LDNIL	R14
+      0x1C38120E,  //  0265  EQ	R14	R9	R14
+      0x743A000B,  //  0266  JMPT	R14	#0273
+      0x4C380000,  //  0267  LDNIL	R14
+      0x1C38140E,  //  0268  EQ	R14	R10	R14
+      0x743A0008,  //  0269  JMPT	R14	#0273
+      0x4C380000,  //  026A  LDNIL	R14
+      0x1C38160E,  //  026B  EQ	R14	R11	R14
+      0x743A0005,  //  026C  JMPT	R14	#0273
+      0x4C380000,  //  026D  LDNIL	R14
+      0x1C38180E,  //  026E  EQ	R14	R12	R14
+      0x743A0002,  //  026F  JMPT	R14	#0273
+      0x4C380000,  //  0270  LDNIL	R14
+      0x1C381A0E,  //  0271  EQ	R14	R13	R14
+      0x783A0005,  //  0272  JMPF	R14	#0279
+      0xB83A0400,  //  0273  GETNGBL	R14	K2
+      0x88381D5B,  //  0274  GETMBR	R14	R14	K91
+      0x900E2E0E,  //  0275  SETMBR	R3	K23	R14
+      0x4C380000,  //  0276  LDNIL	R14
+      0xA0000000,  //  0277  CLOSE	R0
+      0x80041C00,  //  0278  RET	1	R14
+      0x6038000C,  //  0279  GETGBL	R14	G12
+      0x5C3C1400,  //  027A  MOVE	R15	R10
+      0x7C380200,  //  027B  CALL	R14	1
+      0x543E001F,  //  027C  LDINT	R15	32
+      0x54420040,  //  027D  LDINT	R16	65
+      0x003C1E10,  //  027E  ADD	R15	R15	R16
+      0x20381C0F,  //  027F  NE	R14	R14	R15
+      0x743A000B,  //  0280  JMPT	R14	#028D
+      0x6038000C,  //  0281  GETGBL	R14	G12
+      0x5C3C1A00,  //  0282  MOVE	R15	R13
+      0x7C380200,  //  0283  CALL	R14	1
+      0x543E000F,  //  0284  LDINT	R15	16
+      0x14381C0F,  //  0285  LT	R14	R14	R15
+      0x743A0005,  //  0286  JMPT	R14	#028D
+      0x6038000C,  //  0287  GETGBL	R14	G12
+      0x5C3C1A00,  //  0288  MOVE	R15	R13
+      0x7C380200,  //  0289  CALL	R14	1
+      0x543E001F,  //  028A  LDINT	R15	32
+      0x24381C0F,  //  028B  GT	R14	R14	R15
+      0x783A0009,  //  028C  JMPF	R14	#0297
+      0xB83A3E00,  //  028D  GETNGBL	R14	K31
+      0x8C381D24,  //  028E  GETMET	R14	R14	K36
+      0x5840005C,  //  028F  LDCONST	R16	K92
+      0x7C380400,  //  0290  CALL	R14	2
+      0xB83A0400,  //  0291  GETNGBL	R14	K2
+      0x88381D5D,  //  0292  GETMBR	R14	R14	K93
+      0x900E2E0E,  //  0293  SETMBR	R3	K23	R14
+      0x4C380000,  //  0294  LDNIL	R14
+      0xA0000000,  //  0295  CLOSE	R0
+      0x80041C00,  //  0296  RET	1	R14
+      0x543A001E,  //  0297  LDINT	R14	31
+      0x403A0C0E,  //  0298  CONNECT	R14	K6	R14
+      0x9438140E,  //  0299  GETIDX	R14	R10	R14
+      0x543E001F,  //  029A  LDINT	R15	32
+      0x403C1F3B,  //  029B  CONNECT	R15	R15	K59
+      0x943C140F,  //  029C  GETIDX	R15	R10	R15
+      0x88400115,  //  029D  GETMBR	R16	R0	K21
+      0x8C40215E,  //  029E  GETMET	R16	R16	K94
+      0x5C481200,  //  029F  MOVE	R18	R9
+      0x5C4C1800,  //  02A0  MOVE	R19	R12
+      0x5C501600,  //  02A1  MOVE	R20	R11
+      0x5C541A00,  //  02A2  MOVE	R21	R13
+      0x5C581C00,  //  02A3  MOVE	R22	R14
+      0x5C5C1E00,  //  02A4  MOVE	R23	R15
+      0x8C60035F,  //  02A5  GETMET	R24	R1	K95
+      0x7C600200,  //  02A6  CALL	R24	1
+      0x7C401000,  //  02A7  CALL	R16	8
+      0x50400200,  //  02A8  LDBOOL	R16	1	0
+      0xA0000000,  //  02A9  CLOSE	R0
+      0x80042000,  //  02AA  RET	1	R16
+      0x7002001C,  //  02AB  JMP		#02C9
+      0x1C241108,  //  02AC  EQ	R9	R8	K8
+      0x78260012,  //  02AD  JMPF	R9	#02C1
+      0x8C240507,  //  02AE  GETMET	R9	R2	K7
+      0x582C0006,  //  02AF  LDCONST	R11	K6
+      0x7C240400,  //  02B0  CALL	R9	2
+      0xB82A3E00,  //  02B1  GETNGBL	R10	K31
+      0x8C281524,  //  02B2  GETMET	R10	R10	K36
+      0x60300008,  //  02B3  GETGBL	R12	G8
+      0x5C341200,  //  02B4  MOVE	R13	R9
+      0x7C300200,  //  02B5  CALL	R12	1
+      0x0032C00C,  //  02B6  ADD	R12	K96	R12
+      0x5834000F,  //  02B7  LDCONST	R13	K15
+      0x7C280600,  //  02B8  CALL	R10	3
+      0x88280115,  //  02B9  GETMBR	R10	R0	K21
+      0x8C281561,  //  02BA  GETMET	R10	R10	K97
+      0x5C301200,  //  02BB  MOVE	R12	R9
+      0x7C280400,  //  02BC  CALL	R10	2
+      0x50280200,  //  02BD  LDBOOL	R10	1	0
+      0xA0000000,  //  02BE  CLOSE	R0
+      0x80041400,  //  02BF  RET	1	R10
+      0x70020007,  //  02C0  JMP		#02C9
+      0x1C24110F,  //  02C1  EQ	R9	R8	K15
+      0x78260005,  //  02C2  JMPF	R9	#02C9
+      0x88240115,  //  02C3  GETMBR	R9	R0	K21
+      0x8C241362,  //  02C4  GETMET	R9	R9	K98
+      0x7C240200,  //  02C5  CALL	R9	1
+      0x50240200,  //  02C6  LDBOOL	R9	1	0
+      0xA0000000,  //  02C7  CLOSE	R0
+      0x80041200,  //  02C8  RET	1	R9
+      0x70020012,  //  02C9  JMP		#02DD
+      0x54260029,  //  02CA  LDINT	R9	42
+      0x1C240E09,  //  02CB  EQ	R9	R7	R9
+      0x78260005,  //  02CC  JMPF	R9	#02D3
+      0x1C241106,  //  02CD  EQ	R9	R8	K6
+      0x78260002,  //  02CE  JMPF	R9	#02D2
+      0x50240200,  //  02CF  LDBOOL	R9	1	0
+      0xA0000000,  //  02D0  CLOSE	R0
+      0x80041200,  //  02D1  RET	1	R9
+      0x70020009,  //  02D2  JMP		#02DD
+      0x60240003,  //  02D3  GETGBL	R9	G3
+      0x5C280000,  //  02D4  MOVE	R10	R0
+      0x7C240200,  //  02D5  CALL	R9	1
+      0x8C241363,  //  02D6  GETMET	R9	R9	K99
+      0x5C2C0200,  //  02D7  MOVE	R11	R1
+      0x5C300400,  //  02D8  MOVE	R12	R2
+      0x5C340600,  //  02D9  MOVE	R13	R3
+      0x7C240800,  //  02DA  CALL	R9	4
       0xA0000000,  //  02DB  CLOSE	R0
-      0x80000000,  //  02DC  RET	0
+      0x80041200,  //  02DC  RET	1	R9
+      0xA0000000,  //  02DD  CLOSE	R0
+      0x80000000,  //  02DE  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
@@ -7,128 +7,6 @@
 extern const bclass be_class_Matter_Fabric;
 
 /********************************************************************
-** Solidified function: get_ca_pub
-********************************************************************/
-be_local_closure(Matter_Fabric_get_ca_pub,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(root_ca_certificate),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(parse),
-    /* K4   */  be_nested_str_weak(findsubval),
-    }),
-    be_str_weak(get_ca_pub),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060008,  //  0001  JMPF	R1	#000B
-      0xB80A0200,  //  0002  GETNGBL	R2	K1
-      0x88080502,  //  0003  GETMBR	R2	R2	K2
-      0x8C080503,  //  0004  GETMET	R2	R2	K3
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x7C080400,  //  0006  CALL	R2	2
-      0x8C0C0504,  //  0007  GETMET	R3	R2	K4
-      0x54160008,  //  0008  LDINT	R5	9
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x80040600,  //  000A  RET	1	R3
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_admin_vendor
-********************************************************************/
-be_local_closure(Matter_Fabric_get_admin_vendor,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(admin_vendor),
-    }),
-    be_str_weak(get_admin_vendor),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric_compressed
-********************************************************************/
-be_local_closure(Matter_Fabric_get_fabric_compressed,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_compressed),
-    }),
-    be_str_weak(get_fabric_compressed),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ipk_epoch_key
-********************************************************************/
-be_local_closure(Matter_Fabric_get_ipk_epoch_key,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ipk_epoch_key),
-    }),
-    be_str_weak(get_ipk_epoch_key),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: tojson
 ********************************************************************/
 be_local_closure(Matter_Fabric_tojson,   /* name */
@@ -302,9 +180,174 @@ be_local_closure(Matter_Fabric_tojson,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_fabric_id
+** Solidified function: before_remove
 ********************************************************************/
-be_local_closure(Matter_Fabric_get_fabric_id,   /* name */
+be_local_closure(Matter_Fabric_before_remove,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2DFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20_X28removed_X29),
+    /* K5   */  be_nested_str_weak(get_fabric_id),
+    /* K6   */  be_nested_str_weak(copy),
+    /* K7   */  be_nested_str_weak(reverse),
+    /* K8   */  be_nested_str_weak(tohex),
+    /* K9   */  be_const_int(2),
+    }),
+    be_str_weak(before_remove),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x8C100303,  //  0003  GETMET	R4	R1	K3
+      0x58180004,  //  0004  LDCONST	R6	K4
+      0x8C1C0105,  //  0005  GETMET	R7	R0	K5
+      0x7C1C0200,  //  0006  CALL	R7	1
+      0x8C1C0F06,  //  0007  GETMET	R7	R7	K6
+      0x7C1C0200,  //  0008  CALL	R7	1
+      0x8C1C0F07,  //  0009  GETMET	R7	R7	K7
+      0x7C1C0200,  //  000A  CALL	R7	1
+      0x8C1C0F08,  //  000B  GETMET	R7	R7	K8
+      0x7C1C0200,  //  000C  CALL	R7	1
+      0x7C100600,  //  000D  CALL	R4	3
+      0x58140009,  //  000E  LDCONST	R5	K9
+      0x7C080600,  //  000F  CALL	R2	3
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_old_recent_session
+********************************************************************/
+be_local_closure(Matter_Fabric_get_old_recent_session,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_sessions),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(last_used),
+    /* K3   */  be_const_int(1),
+    }),
+    be_str_weak(get_old_recent_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x6008000C,  //  0000  GETGBL	R2	G12
+      0x880C0100,  //  0001  GETMBR	R3	R0	K0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x1C080501,  //  0003  EQ	R2	R2	K1
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x4C080000,  //  0005  LDNIL	R2
+      0x80040400,  //  0006  RET	1	R2
+      0x88080100,  //  0007  GETMBR	R2	R0	K0
+      0x94080501,  //  0008  GETIDX	R2	R2	K1
+      0x880C0502,  //  0009  GETMBR	R3	R2	K2
+      0x58100003,  //  000A  LDCONST	R4	K3
+      0x6014000C,  //  000B  GETGBL	R5	G12
+      0x88180100,  //  000C  GETMBR	R6	R0	K0
+      0x7C140200,  //  000D  CALL	R5	1
+      0x14140805,  //  000E  LT	R5	R4	R5
+      0x7816000C,  //  000F  JMPF	R5	#001D
+      0x88140100,  //  0010  GETMBR	R5	R0	K0
+      0x94140A04,  //  0011  GETIDX	R5	R5	R4
+      0x88140B02,  //  0012  GETMBR	R5	R5	K2
+      0x78060001,  //  0013  JMPF	R1	#0016
+      0x14180A03,  //  0014  LT	R6	R5	R3
+      0x70020000,  //  0015  JMP		#0017
+      0x24180A03,  //  0016  GT	R6	R5	R3
+      0x781A0002,  //  0017  JMPF	R6	#001B
+      0x88180100,  //  0018  GETMBR	R6	R0	K0
+      0x94080C04,  //  0019  GETIDX	R2	R6	R4
+      0x5C0C0A00,  //  001A  MOVE	R3	R5
+      0x00100903,  //  001B  ADD	R4	R4	K3
+      0x7001FFED,  //  001C  JMP		#000B
+      0x80040400,  //  001D  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ipk_group_key
+********************************************************************/
+be_local_closure(Matter_Fabric_get_ipk_group_key,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ipk_epoch_key),
+    /* K1   */  be_nested_str_weak(fabric_compressed),
+    /* K2   */  be_nested_str_weak(crypto),
+    /* K3   */  be_nested_str_weak(HKDF_SHA256),
+    /* K4   */  be_nested_str_weak(fromstring),
+    /* K5   */  be_nested_str_weak(_GROUP_KEY),
+    /* K6   */  be_nested_str_weak(derive),
+    }),
+    be_str_weak(get_ipk_group_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x74060003,  //  0003  JMPT	R1	#0008
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x4C080000,  //  0005  LDNIL	R2
+      0x1C040202,  //  0006  EQ	R1	R1	R2
+      0x78060001,  //  0007  JMPF	R1	#000A
+      0x4C040000,  //  0008  LDNIL	R1
+      0x80040200,  //  0009  RET	1	R1
+      0xA4060400,  //  000A  IMPORT	R1	K2
+      0x8C080303,  //  000B  GETMET	R2	R1	K3
+      0x7C080200,  //  000C  CALL	R2	1
+      0x600C0015,  //  000D  GETGBL	R3	G21
+      0x7C0C0000,  //  000E  CALL	R3	0
+      0x8C0C0704,  //  000F  GETMET	R3	R3	K4
+      0x88140105,  //  0010  GETMBR	R5	R0	K5
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x8C100506,  //  0012  GETMET	R4	R2	K6
+      0x88180100,  //  0013  GETMBR	R6	R0	K0
+      0x881C0101,  //  0014  GETMBR	R7	R0	K1
+      0x5C200600,  //  0015  MOVE	R8	R3
+      0x5426000F,  //  0016  LDINT	R9	16
+      0x7C100A00,  //  0017  CALL	R4	5
+      0x80040800,  //  0018  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ipk_epoch_key
+********************************************************************/
+be_local_closure(Matter_Fabric_get_ipk_epoch_key,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -315,9 +358,9 @@ be_local_closure(Matter_Fabric_get_fabric_id,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_id),
+    /* K0   */  be_nested_str_weak(ipk_epoch_key),
     }),
-    be_str_weak(get_fabric_id),
+    be_str_weak(get_ipk_epoch_key),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
@@ -345,6 +388,138 @@ be_local_closure(Matter_Fabric_get_icac,   /* name */
     /* K0   */  be_nested_str_weak(icac),
     }),
     be_str_weak(get_icac),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_fabric_index
+********************************************************************/
+be_local_closure(Matter_Fabric_set_fabric_index,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fabric_index),
+    }),
+    be_str_weak(set_fabric_index),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_compressed
+********************************************************************/
+be_local_closure(Matter_Fabric_get_fabric_compressed,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fabric_compressed),
+    }),
+    be_str_weak(get_fabric_compressed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: log_new_fabric
+********************************************************************/
+be_local_closure(Matter_Fabric_log_new_fabric,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2BFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27),
+    /* K5   */  be_nested_str_weak(get_fabric_id),
+    /* K6   */  be_nested_str_weak(copy),
+    /* K7   */  be_nested_str_weak(reverse),
+    /* K8   */  be_nested_str_weak(tohex),
+    /* K9   */  be_const_int(2),
+    }),
+    be_str_weak(log_new_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x8C100303,  //  0003  GETMET	R4	R1	K3
+      0x58180004,  //  0004  LDCONST	R6	K4
+      0x8C1C0105,  //  0005  GETMET	R7	R0	K5
+      0x7C1C0200,  //  0006  CALL	R7	1
+      0x8C1C0F06,  //  0007  GETMET	R7	R7	K6
+      0x7C1C0200,  //  0008  CALL	R7	1
+      0x8C1C0F07,  //  0009  GETMET	R7	R7	K7
+      0x7C1C0200,  //  000A  CALL	R7	1
+      0x8C1C0F08,  //  000B  GETMET	R7	R7	K8
+      0x7C1C0200,  //  000C  CALL	R7	1
+      0x7C100600,  //  000D  CALL	R4	3
+      0x58140009,  //  000E  LDCONST	R5	K9
+      0x7C080600,  //  000F  CALL	R2	3
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_device_id
+********************************************************************/
+be_local_closure(Matter_Fabric_get_device_id,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device_id),
+    }),
+    be_str_weak(get_device_id),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
@@ -501,11 +676,11 @@ be_local_closure(Matter_Fabric_fromjson,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_newest_session
+** Solidified function: get_fabric_label
 ********************************************************************/
-be_local_closure(Matter_Fabric_get_newest_session,   /* name */
+be_local_closure(Matter_Fabric_get_fabric_label,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    2,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -514,15 +689,61 @@ be_local_closure(Matter_Fabric_get_newest_session,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_old_recent_session),
+    /* K0   */  be_nested_str_weak(fabric_label),
     }),
-    be_str_weak(get_newest_session),
+    be_str_weak(get_fabric_label),
     &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x500C0000,  //  0001  LDBOOL	R3	0	0
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Fabric_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(_store),
+    /* K2   */  be_nested_str_weak(_sessions),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(Expirable_list),
+    /* K5   */  be_nested_str_weak(fabric_label),
+    /* K6   */  be_nested_str_weak(),
+    /* K7   */  be_nested_str_weak(created),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(rtc),
+    /* K10  */  be_nested_str_weak(utc),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x90020201,  //  0001  SETMBR	R0	K1	R1
+      0xB80E0600,  //  0002  GETNGBL	R3	K3
+      0x8C0C0704,  //  0003  GETMET	R3	R3	K4
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x90020403,  //  0005  SETMBR	R0	K2	R3
+      0x90020B06,  //  0006  SETMBR	R0	K5	K6
+      0xB80E1000,  //  0007  GETNGBL	R3	K8
+      0x8C0C0709,  //  0008  GETMET	R3	R3	K9
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x940C070A,  //  000A  GETIDX	R3	R3	K10
+      0x90020E03,  //  000B  SETMBR	R0	K7	R3
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -557,11 +778,11 @@ be_local_closure(Matter_Fabric_get_fabric_index,   /* name */
 
 
 /********************************************************************
-** Solidified function: before_remove
+** Solidified function: get_fabric_id
 ********************************************************************/
-be_local_closure(Matter_Fabric_before_remove,   /* name */
+be_local_closure(Matter_Fabric_get_fabric_id,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    2,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -569,38 +790,68 @@ be_local_closure(Matter_Fabric_before_remove,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2DFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20_X28removed_X29),
-    /* K5   */  be_nested_str_weak(get_fabric_id),
-    /* K6   */  be_nested_str_weak(copy),
-    /* K7   */  be_nested_str_weak(reverse),
-    /* K8   */  be_nested_str_weak(tohex),
-    /* K9   */  be_const_int(2),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fabric_id),
     }),
-    be_str_weak(before_remove),
+    be_str_weak(get_fabric_id),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x8C100303,  //  0003  GETMET	R4	R1	K3
-      0x58180004,  //  0004  LDCONST	R6	K4
-      0x8C1C0105,  //  0005  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0006  CALL	R7	1
-      0x8C1C0F06,  //  0007  GETMET	R7	R7	K6
-      0x7C1C0200,  //  0008  CALL	R7	1
-      0x8C1C0F07,  //  0009  GETMET	R7	R7	K7
-      0x7C1C0200,  //  000A  CALL	R7	1
-      0x8C1C0F08,  //  000B  GETMET	R7	R7	K8
-      0x7C1C0200,  //  000C  CALL	R7	1
-      0x7C100600,  //  000D  CALL	R4	3
-      0x58140009,  //  000E  LDCONST	R5	K9
-      0x7C080600,  //  000F  CALL	R2	3
-      0x80000000,  //  0010  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_admin_vendor
+********************************************************************/
+be_local_closure(Matter_Fabric_get_admin_vendor,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(admin_vendor),
+    }),
+    be_str_weak(get_admin_vendor),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_noc
+********************************************************************/
+be_local_closure(Matter_Fabric_get_noc,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(noc),
+    }),
+    be_str_weak(get_noc),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -635,120 +886,11 @@ be_local_closure(Matter_Fabric_get_ca,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_old_recent_session
+** Solidified function: get_oldest_session
 ********************************************************************/
-be_local_closure(Matter_Fabric_get_old_recent_session,   /* name */
+be_local_closure(Matter_Fabric_get_oldest_session,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(last_used),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(get_old_recent_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x6008000C,  //  0000  GETGBL	R2	G12
-      0x880C0100,  //  0001  GETMBR	R3	R0	K0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x1C080501,  //  0003  EQ	R2	R2	K1
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x4C080000,  //  0005  LDNIL	R2
-      0x80040400,  //  0006  RET	1	R2
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x94080501,  //  0008  GETIDX	R2	R2	K1
-      0x880C0502,  //  0009  GETMBR	R3	R2	K2
-      0x58100003,  //  000A  LDCONST	R4	K3
-      0x6014000C,  //  000B  GETGBL	R5	G12
-      0x88180100,  //  000C  GETMBR	R6	R0	K0
-      0x7C140200,  //  000D  CALL	R5	1
-      0x14140805,  //  000E  LT	R5	R4	R5
-      0x7816000C,  //  000F  JMPF	R5	#001D
-      0x88140100,  //  0010  GETMBR	R5	R0	K0
-      0x94140A04,  //  0011  GETIDX	R5	R5	R4
-      0x88140B02,  //  0012  GETMBR	R5	R5	K2
-      0x78060001,  //  0013  JMPF	R1	#0016
-      0x14180A03,  //  0014  LT	R6	R5	R3
-      0x70020000,  //  0015  JMP		#0017
-      0x24180A03,  //  0016  GT	R6	R5	R3
-      0x781A0002,  //  0017  JMPF	R6	#001B
-      0x88180100,  //  0018  GETMBR	R6	R0	K0
-      0x94080C04,  //  0019  GETIDX	R2	R6	R4
-      0x5C0C0A00,  //  001A  MOVE	R3	R5
-      0x00100903,  //  001B  ADD	R4	R4	K3
-      0x7001FFED,  //  001C  JMP		#000B
-      0x80040400,  //  001D  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: log_new_fabric
-********************************************************************/
-be_local_closure(Matter_Fabric_log_new_fabric,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2BFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27),
-    /* K5   */  be_nested_str_weak(get_fabric_id),
-    /* K6   */  be_nested_str_weak(copy),
-    /* K7   */  be_nested_str_weak(reverse),
-    /* K8   */  be_nested_str_weak(tohex),
-    /* K9   */  be_const_int(2),
-    }),
-    be_str_weak(log_new_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x8C100303,  //  0003  GETMET	R4	R1	K3
-      0x58180004,  //  0004  LDCONST	R6	K4
-      0x8C1C0105,  //  0005  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0006  CALL	R7	1
-      0x8C1C0F06,  //  0007  GETMET	R7	R7	K6
-      0x7C1C0200,  //  0008  CALL	R7	1
-      0x8C1C0F07,  //  0009  GETMET	R7	R7	K7
-      0x7C1C0200,  //  000A  CALL	R7	1
-      0x8C1C0F08,  //  000B  GETMET	R7	R7	K8
-      0x7C1C0200,  //  000C  CALL	R7	1
-      0x7C100600,  //  000D  CALL	R4	3
-      0x58140009,  //  000E  LDCONST	R5	K9
-      0x7C080600,  //  000F  CALL	R2	3
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_device_id
-********************************************************************/
-be_local_closure(Matter_Fabric_get_device_id,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -757,13 +899,85 @@ be_local_closure(Matter_Fabric_get_device_id,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device_id),
+    /* K0   */  be_nested_str_weak(get_old_recent_session),
     }),
-    be_str_weak(get_device_id),
+    be_str_weak(get_oldest_session),
     &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x500C0200,  //  0001  LDBOOL	R3	1	0
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ca_pub
+********************************************************************/
+be_local_closure(Matter_Fabric_get_ca_pub,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(root_ca_certificate),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(parse),
+    /* K4   */  be_nested_str_weak(findsubval),
+    }),
+    be_str_weak(get_ca_pub),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
+      0x78060008,  //  0001  JMPF	R1	#000B
+      0xB80A0200,  //  0002  GETNGBL	R2	K1
+      0x88080502,  //  0003  GETMBR	R2	R2	K2
+      0x8C080503,  //  0004  GETMET	R2	R2	K3
+      0x5C100200,  //  0005  MOVE	R4	R1
+      0x7C080400,  //  0006  CALL	R2	2
+      0x8C0C0504,  //  0007  GETMET	R3	R2	K4
+      0x54160008,  //  0008  LDINT	R5	9
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x80040600,  //  000A  RET	1	R3
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_newest_session
+********************************************************************/
+be_local_closure(Matter_Fabric_get_newest_session,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_old_recent_session),
+    }),
+    be_str_weak(get_newest_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x500C0000,  //  0001  LDBOOL	R3	0	0
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80040200,  //  0003  RET	1	R1
     })
   )
 );
@@ -828,268 +1042,55 @@ be_local_closure(Matter_Fabric_add_session,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_oldest_session
-********************************************************************/
-be_local_closure(Matter_Fabric_get_oldest_session,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_old_recent_session),
-    }),
-    be_str_weak(get_oldest_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x500C0200,  //  0001  LDBOOL	R3	1	0
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric_label
-********************************************************************/
-be_local_closure(Matter_Fabric_get_fabric_label,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_label),
-    }),
-    be_str_weak(get_fabric_label),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_fabric_index
-********************************************************************/
-be_local_closure(Matter_Fabric_set_fabric_index,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_index),
-    }),
-    be_str_weak(set_fabric_index),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Fabric_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(_store),
-    /* K2   */  be_nested_str_weak(_sessions),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Expirable_list),
-    /* K5   */  be_nested_str_weak(fabric_label),
-    /* K6   */  be_nested_str_weak(),
-    /* K7   */  be_nested_str_weak(created),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(rtc),
-    /* K10  */  be_nested_str_weak(utc),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x90020201,  //  0001  SETMBR	R0	K1	R1
-      0xB80E0600,  //  0002  GETNGBL	R3	K3
-      0x8C0C0704,  //  0003  GETMET	R3	R3	K4
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x90020403,  //  0005  SETMBR	R0	K2	R3
-      0x90020B06,  //  0006  SETMBR	R0	K5	K6
-      0xB80E1000,  //  0007  GETNGBL	R3	K8
-      0x8C0C0709,  //  0008  GETMET	R3	R3	K9
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x940C070A,  //  000A  GETIDX	R3	R3	K10
-      0x90020E03,  //  000B  SETMBR	R0	K7	R3
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_noc
-********************************************************************/
-be_local_closure(Matter_Fabric_get_noc,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(noc),
-    }),
-    be_str_weak(get_noc),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ipk_group_key
-********************************************************************/
-be_local_closure(Matter_Fabric_get_ipk_group_key,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ipk_epoch_key),
-    /* K1   */  be_nested_str_weak(fabric_compressed),
-    /* K2   */  be_nested_str_weak(crypto),
-    /* K3   */  be_nested_str_weak(HKDF_SHA256),
-    /* K4   */  be_nested_str_weak(fromstring),
-    /* K5   */  be_nested_str_weak(_GROUP_KEY),
-    /* K6   */  be_nested_str_weak(derive),
-    }),
-    be_str_weak(get_ipk_group_key),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x74060003,  //  0003  JMPT	R1	#0008
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x4C080000,  //  0005  LDNIL	R2
-      0x1C040202,  //  0006  EQ	R1	R1	R2
-      0x78060001,  //  0007  JMPF	R1	#000A
-      0x4C040000,  //  0008  LDNIL	R1
-      0x80040200,  //  0009  RET	1	R1
-      0xA4060400,  //  000A  IMPORT	R1	K2
-      0x8C080303,  //  000B  GETMET	R2	R1	K3
-      0x7C080200,  //  000C  CALL	R2	1
-      0x600C0015,  //  000D  GETGBL	R3	G21
-      0x7C0C0000,  //  000E  CALL	R3	0
-      0x8C0C0704,  //  000F  GETMET	R3	R3	K4
-      0x88140105,  //  0010  GETMBR	R5	R0	K5
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x8C100506,  //  0012  GETMET	R4	R2	K6
-      0x88180100,  //  0013  GETMBR	R6	R0	K0
-      0x881C0101,  //  0014  GETMBR	R7	R0	K1
-      0x5C200600,  //  0015  MOVE	R8	R3
-      0x5426000F,  //  0016  LDINT	R9	16
-      0x7C100A00,  //  0017  CALL	R4	5
-      0x80040800,  //  0018  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_Fabric
 ********************************************************************/
 extern const bclass be_class_Matter_Expirable;
 be_local_class(Matter_Fabric,
-    15,
+    16,
     &be_class_Matter_Expirable,
-    be_nested_map(40,
+    be_nested_map(41,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(fabric_compressed, -1), be_const_var(10) },
-        { be_const_key_weak(get_ipk_epoch_key, -1), be_const_closure(Matter_Fabric_get_ipk_epoch_key_closure) },
         { be_const_key_weak(tojson, -1), be_const_closure(Matter_Fabric_tojson_closure) },
-        { be_const_key_weak(get_fabric_compressed, -1), be_const_closure(Matter_Fabric_get_fabric_compressed_closure) },
-        { be_const_key_weak(get_ca_pub, 1), be_const_closure(Matter_Fabric_get_ca_pub_closure) },
-        { be_const_key_weak(noc, 9), be_const_var(6) },
-        { be_const_key_weak(get_admin_vendor, 2), be_const_closure(Matter_Fabric_get_admin_vendor_closure) },
-        { be_const_key_weak(get_fabric_id, -1), be_const_closure(Matter_Fabric_get_fabric_id_closure) },
-        { be_const_key_weak(get_icac, 37), be_const_closure(Matter_Fabric_get_icac_closure) },
-        { be_const_key_weak(fromjson, -1), be_const_static_closure(Matter_Fabric_fromjson_closure) },
-        { be_const_key_weak(_store, -1), be_const_var(0) },
-        { be_const_key_weak(admin_subject, 5), be_const_var(13) },
-        { be_const_key_weak(fabric_id, -1), be_const_var(9) },
-        { be_const_key_weak(get_newest_session, -1), be_const_closure(Matter_Fabric_get_newest_session_closure) },
-        { be_const_key_weak(get_fabric_index, -1), be_const_closure(Matter_Fabric_get_fabric_index_closure) },
-        { be_const_key_weak(before_remove, -1), be_const_closure(Matter_Fabric_before_remove_closure) },
-        { be_const_key_weak(get_ca, -1), be_const_closure(Matter_Fabric_get_ca_closure) },
-        { be_const_key_weak(fabric_label, -1), be_const_var(12) },
+        { be_const_key_weak(created, 16), be_const_var(1) },
+        { be_const_key_weak(device_id, -1), be_const_var(12) },
         { be_const_key_weak(get_old_recent_session, -1), be_const_closure(Matter_Fabric_get_old_recent_session_closure) },
-        { be_const_key_weak(_sessions, 20), be_const_var(3) },
-        { be_const_key_weak(created, -1), be_const_var(1) },
-        { be_const_key_weak(icac, -1), be_const_var(7) },
-        { be_const_key_weak(root_ca_certificate, -1), be_const_var(5) },
-        { be_const_key_weak(ipk_epoch_key, 10), be_const_var(8) },
-        { be_const_key_weak(log_new_fabric, 32), be_const_closure(Matter_Fabric_log_new_fabric_closure) },
-        { be_const_key_weak(_GROUP_KEY, -1), be_nested_str_weak(GroupKey_X20v1_X2E0) },
-        { be_const_key_weak(get_device_id, -1), be_const_closure(Matter_Fabric_get_device_id_closure) },
-        { be_const_key_weak(add_session, -1), be_const_closure(Matter_Fabric_add_session_closure) },
-        { be_const_key_weak(get_oldest_session, -1), be_const_closure(Matter_Fabric_get_oldest_session_closure) },
-        { be_const_key_weak(_MAX_CASE, -1), be_const_int(5) },
-        { be_const_key_weak(no_private_key, -1), be_const_var(4) },
-        { be_const_key_weak(admin_vendor, -1), be_const_var(14) },
-        { be_const_key_weak(get_fabric_label, -1), be_const_closure(Matter_Fabric_get_fabric_label_closure) },
-        { be_const_key_weak(device_id, 29), be_const_var(11) },
-        { be_const_key_weak(set_fabric_index, -1), be_const_closure(Matter_Fabric_set_fabric_index_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Fabric_init_closure) },
-        { be_const_key_weak(get_noc, -1), be_const_closure(Matter_Fabric_get_noc_closure) },
-        { be_const_key_weak(get_admin_subject, -1), be_const_closure(Matter_Fabric_get_admin_subject_closure) },
         { be_const_key_weak(get_ipk_group_key, -1), be_const_closure(Matter_Fabric_get_ipk_group_key_closure) },
-        { be_const_key_weak(fabric_index, -1), be_const_var(2) },
+        { be_const_key_weak(admin_subject, -1), be_const_var(14) },
+        { be_const_key_weak(ipk_epoch_key, -1), be_const_var(9) },
+        { be_const_key_weak(set_fabric_index, -1), be_const_closure(Matter_Fabric_set_fabric_index_closure) },
+        { be_const_key_weak(get_fabric_compressed, 7), be_const_closure(Matter_Fabric_get_fabric_compressed_closure) },
+        { be_const_key_weak(_sessions, -1), be_const_var(4) },
+        { be_const_key_weak(get_icac, -1), be_const_closure(Matter_Fabric_get_icac_closure) },
+        { be_const_key_weak(icac, 29), be_const_var(8) },
+        { be_const_key_weak(fabric_id, -1), be_const_var(10) },
+        { be_const_key_weak(get_admin_subject, -1), be_const_closure(Matter_Fabric_get_admin_subject_closure) },
+        { be_const_key_weak(no_private_key, -1), be_const_var(5) },
+        { be_const_key_weak(log_new_fabric, 34), be_const_closure(Matter_Fabric_log_new_fabric_closure) },
+        { be_const_key_weak(get_device_id, -1), be_const_closure(Matter_Fabric_get_device_id_closure) },
+        { be_const_key_weak(get_ipk_epoch_key, 13), be_const_closure(Matter_Fabric_get_ipk_epoch_key_closure) },
+        { be_const_key_weak(fromjson, -1), be_const_static_closure(Matter_Fabric_fromjson_closure) },
+        { be_const_key_weak(admin_vendor, -1), be_const_var(15) },
+        { be_const_key_weak(init, 2), be_const_closure(Matter_Fabric_init_closure) },
+        { be_const_key_weak(get_fabric_label, -1), be_const_closure(Matter_Fabric_get_fabric_label_closure) },
+        { be_const_key_weak(noc, -1), be_const_var(7) },
+        { be_const_key_weak(before_remove, 20), be_const_closure(Matter_Fabric_before_remove_closure) },
+        { be_const_key_weak(get_fabric_index, -1), be_const_closure(Matter_Fabric_get_fabric_index_closure) },
+        { be_const_key_weak(_GROUP_KEY, -1), be_nested_str_weak(GroupKey_X20v1_X2E0) },
+        { be_const_key_weak(get_fabric_id, 8), be_const_closure(Matter_Fabric_get_fabric_id_closure) },
+        { be_const_key_weak(fabric_index, 19), be_const_var(2) },
+        { be_const_key_weak(_store, -1), be_const_var(0) },
+        { be_const_key_weak(fabric_label, 31), be_const_var(13) },
+        { be_const_key_weak(get_admin_vendor, -1), be_const_closure(Matter_Fabric_get_admin_vendor_closure) },
+        { be_const_key_weak(fabric_compressed, 26), be_const_var(11) },
+        { be_const_key_weak(get_noc, -1), be_const_closure(Matter_Fabric_get_noc_closure) },
+        { be_const_key_weak(get_ca, -1), be_const_closure(Matter_Fabric_get_ca_closure) },
+        { be_const_key_weak(root_ca_certificate, -1), be_const_var(6) },
+        { be_const_key_weak(get_oldest_session, -1), be_const_closure(Matter_Fabric_get_oldest_session_closure) },
+        { be_const_key_weak(get_ca_pub, -1), be_const_closure(Matter_Fabric_get_ca_pub_closure) },
+        { be_const_key_weak(_MAX_CASE, 9), be_const_int(5) },
+        { be_const_key_weak(get_newest_session, -1), be_const_closure(Matter_Fabric_get_newest_session_closure) },
+        { be_const_key_weak(add_session, -1), be_const_closure(Matter_Fabric_add_session_closure) },
+        { be_const_key_weak(fabric_parent, -1), be_const_var(3) },
     })),
     be_str_weak(Matter_Fabric)
 );
@@ -2502,30 +2503,41 @@ be_local_closure(Matter_Session_set_ca,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Session_set_fabric_device,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
+    8,                          /* nstack */
+    5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
     /* K1   */  be_nested_str_weak(fabric_id),
     /* K2   */  be_nested_str_weak(device_id),
     /* K3   */  be_nested_str_weak(fabric_compressed),
+    /* K4   */  be_nested_str_weak(fabric_parent),
+    /* K5   */  be_nested_str_weak(get_fabric_index),
     }),
     be_str_weak(set_fabric_device),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
-      0x90120201,  //  0001  SETMBR	R4	K1	R1
-      0x88100100,  //  0002  GETMBR	R4	R0	K0
-      0x90120402,  //  0003  SETMBR	R4	K2	R2
-      0x88100100,  //  0004  GETMBR	R4	R0	K0
-      0x90120603,  //  0005  SETMBR	R4	K3	R3
-      0x80000000,  //  0006  RET	0
+    ( &(const binstruction[16]) {  /* code */
+      0x88140100,  //  0000  GETMBR	R5	R0	K0
+      0x90160201,  //  0001  SETMBR	R5	K1	R1
+      0x88140100,  //  0002  GETMBR	R5	R0	K0
+      0x90160402,  //  0003  SETMBR	R5	K2	R2
+      0x88140100,  //  0004  GETMBR	R5	R0	K0
+      0x90160603,  //  0005  SETMBR	R5	K3	R3
+      0x88140100,  //  0006  GETMBR	R5	R0	K0
+      0x4C180000,  //  0007  LDNIL	R6
+      0x20180806,  //  0008  NE	R6	R4	R6
+      0x781A0002,  //  0009  JMPF	R6	#000D
+      0x8C180905,  //  000A  GETMET	R6	R4	K5
+      0x7C180200,  //  000B  CALL	R6	1
+      0x70020000,  //  000C  JMP		#000E
+      0x4C180000,  //  000D  LDNIL	R6
+      0x90160806,  //  000E  SETMBR	R5	K4	R6
+      0x80000000,  //  000F  RET	0
     })
   )
 );
@@ -3175,6 +3187,1039 @@ void be_load_Matter_Session_class(bvm *vm) {
 extern const bclass be_class_Matter_Session_Store;
 
 /********************************************************************
+** Solidified function: gen_local_session_id
+********************************************************************/
+be_local_closure(Matter_Session_Store_gen_local_session_id,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(random),
+    /* K2   */  be_const_int(2),
+    /* K3   */  be_nested_str_weak(get),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(get_session_by_local_session_id),
+    }),
+    be_str_weak(gen_local_session_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x50080200,  //  0001  LDBOOL	R2	1	0
+      0x780A000E,  //  0002  JMPF	R2	#0012
+      0x8C080301,  //  0003  GETMET	R2	R1	K1
+      0x58100002,  //  0004  LDCONST	R4	K2
+      0x7C080400,  //  0005  CALL	R2	2
+      0x8C080503,  //  0006  GETMET	R2	R2	K3
+      0x58100004,  //  0007  LDCONST	R4	K4
+      0x58140002,  //  0008  LDCONST	R5	K2
+      0x7C080600,  //  0009  CALL	R2	3
+      0x8C0C0105,  //  000A  GETMET	R3	R0	K5
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x4C100000,  //  000D  LDNIL	R4
+      0x1C0C0604,  //  000E  EQ	R3	R3	R4
+      0x780E0000,  //  000F  JMPF	R3	#0011
+      0x80040400,  //  0010  RET	1	R2
+      0x7001FFEE,  //  0011  JMP		#0001
+      0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_redundant_fabric
+********************************************************************/
+be_local_closure(Matter_Session_Store_remove_redundant_fabric,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(fabrics),
+    /* K2   */  be_nested_str_weak(fabric_id),
+    /* K3   */  be_nested_str_weak(device_id),
+    /* K4   */  be_nested_str_weak(remove),
+    /* K5   */  be_const_int(1),
+    }),
+    be_str_weak(remove_redundant_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0012,  //  0005  JMPF	R3	#0019
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x20100601,  //  0008  NE	R4	R3	R1
+      0x7812000C,  //  0009  JMPF	R4	#0017
+      0x88100702,  //  000A  GETMBR	R4	R3	K2
+      0x88140302,  //  000B  GETMBR	R5	R1	K2
+      0x1C100805,  //  000C  EQ	R4	R4	R5
+      0x78120008,  //  000D  JMPF	R4	#0017
+      0x88100703,  //  000E  GETMBR	R4	R3	K3
+      0x88140303,  //  000F  GETMBR	R5	R1	K3
+      0x1C100805,  //  0010  EQ	R4	R4	R5
+      0x78120004,  //  0011  JMPF	R4	#0017
+      0x88100101,  //  0012  GETMBR	R4	R0	K1
+      0x8C100904,  //  0013  GETMET	R4	R4	K4
+      0x5C180400,  //  0014  MOVE	R6	R2
+      0x7C100400,  //  0015  CALL	R4	2
+      0x70020000,  //  0016  JMP		#0018
+      0x00080505,  //  0017  ADD	R2	R2	K5
+      0x7001FFE7,  //  0018  JMP		#0001
+      0x80000000,  //  0019  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_session_by_resumption_id
+********************************************************************/
+be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(sessions),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(format),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20session_X2Eresumption_id_X3D_X25s_X20vs_X20_X25s),
+    /* K7   */  be_nested_str_weak(resumption_id),
+    /* K8   */  be_nested_str_weak(shared_secret),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20session_X2Eshared_secret_X3D_X25s),
+    /* K10  */  be_nested_str_weak(update),
+    /* K11  */  be_const_int(1),
+    }),
+    be_str_weak(find_session_by_resumption_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[47]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x740E0001,  //  0002  JMPT	R3	#0005
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x80040600,  //  0004  RET	1	R3
+      0x580C0001,  //  0005  LDCONST	R3	K1
+      0x88100102,  //  0006  GETMBR	R4	R0	K2
+      0x6014000C,  //  0007  GETGBL	R5	G12
+      0x5C180800,  //  0008  MOVE	R6	R4
+      0x7C140200,  //  0009  CALL	R5	1
+      0x14140605,  //  000A  LT	R5	R3	R5
+      0x78160021,  //  000B  JMPF	R5	#002E
+      0x94140803,  //  000C  GETIDX	R5	R4	R3
+      0xB81A0600,  //  000D  GETNGBL	R6	K3
+      0x8C180D04,  //  000E  GETMET	R6	R6	K4
+      0x8C200505,  //  000F  GETMET	R8	R2	K5
+      0x58280006,  //  0010  LDCONST	R10	K6
+      0x602C0008,  //  0011  GETGBL	R11	G8
+      0x88300B07,  //  0012  GETMBR	R12	R5	K7
+      0x7C2C0200,  //  0013  CALL	R11	1
+      0x60300008,  //  0014  GETGBL	R12	G8
+      0x5C340200,  //  0015  MOVE	R13	R1
+      0x7C300200,  //  0016  CALL	R12	1
+      0x7C200800,  //  0017  CALL	R8	4
+      0x7C180400,  //  0018  CALL	R6	2
+      0x88180B07,  //  0019  GETMBR	R6	R5	K7
+      0x1C180C01,  //  001A  EQ	R6	R6	R1
+      0x781A000F,  //  001B  JMPF	R6	#002C
+      0x88180B08,  //  001C  GETMBR	R6	R5	K8
+      0x4C1C0000,  //  001D  LDNIL	R7
+      0x20180C07,  //  001E  NE	R6	R6	R7
+      0x781A000B,  //  001F  JMPF	R6	#002C
+      0xB81A0600,  //  0020  GETNGBL	R6	K3
+      0x8C180D04,  //  0021  GETMET	R6	R6	K4
+      0x8C200505,  //  0022  GETMET	R8	R2	K5
+      0x58280009,  //  0023  LDCONST	R10	K9
+      0x602C0008,  //  0024  GETGBL	R11	G8
+      0x88300B08,  //  0025  GETMBR	R12	R5	K8
+      0x7C2C0200,  //  0026  CALL	R11	1
+      0x7C200600,  //  0027  CALL	R8	3
+      0x7C180400,  //  0028  CALL	R6	2
+      0x8C180B0A,  //  0029  GETMET	R6	R5	K10
+      0x7C180200,  //  002A  CALL	R6	1
+      0x80040A00,  //  002B  RET	1	R5
+      0x000C070B,  //  002C  ADD	R3	R3	K11
+      0x7001FFD8,  //  002D  JMP		#0007
+      0x80000000,  //  002E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_fabric
+********************************************************************/
+be_local_closure(Matter_Session_Store_remove_fabric,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(_fabric),
+    /* K3   */  be_nested_str_weak(remove),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(fabrics),
+    /* K6   */  be_nested_str_weak(find),
+    }),
+    be_str_weak(remove_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E000B,  //  0005  JMPF	R3	#0012
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x880C0702,  //  0008  GETMBR	R3	R3	K2
+      0x1C0C0601,  //  0009  EQ	R3	R3	R1
+      0x780E0004,  //  000A  JMPF	R3	#0010
+      0x880C0101,  //  000B  GETMBR	R3	R0	K1
+      0x8C0C0703,  //  000C  GETMET	R3	R3	K3
+      0x5C140400,  //  000D  MOVE	R5	R2
+      0x7C0C0400,  //  000E  CALL	R3	2
+      0x70020000,  //  000F  JMP		#0011
+      0x00080504,  //  0010  ADD	R2	R2	K4
+      0x7001FFEE,  //  0011  JMP		#0001
+      0x880C0105,  //  0012  GETMBR	R3	R0	K5
+      0x8C0C0703,  //  0013  GETMET	R3	R3	K3
+      0x88140105,  //  0014  GETMBR	R5	R0	K5
+      0x8C140B06,  //  0015  GETMET	R5	R5	K6
+      0x5C1C0200,  //  0016  MOVE	R7	R1
+      0x7C140400,  //  0017  CALL	R5	2
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x80000000,  //  0019  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_session_source_id_unsecure
+********************************************************************/
+be_local_closure(Matter_Session_Store_find_session_source_id_unsecure,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_session_by_source_node_id),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(Session),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(_source_node_id),
+    /* K5   */  be_nested_str_weak(sessions),
+    /* K6   */  be_nested_str_weak(push),
+    /* K7   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K8   */  be_nested_str_weak(update),
+    }),
+    be_str_weak(find_session_source_id_unsecure),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x5C140200,  //  0001  MOVE	R5	R1
+      0x7C0C0400,  //  0002  CALL	R3	2
+      0x4C100000,  //  0003  LDNIL	R4
+      0x1C100604,  //  0004  EQ	R4	R3	R4
+      0x7812000E,  //  0005  JMPF	R4	#0015
+      0xB8120200,  //  0006  GETNGBL	R4	K1
+      0x8C100902,  //  0007  GETMET	R4	R4	K2
+      0x5C180000,  //  0008  MOVE	R6	R0
+      0x581C0003,  //  0009  LDCONST	R7	K3
+      0x58200003,  //  000A  LDCONST	R8	K3
+      0x7C100800,  //  000B  CALL	R4	4
+      0x5C0C0800,  //  000C  MOVE	R3	R4
+      0x900E0801,  //  000D  SETMBR	R3	K4	R1
+      0x88100105,  //  000E  GETMBR	R4	R0	K5
+      0x8C100906,  //  000F  GETMET	R4	R4	K6
+      0x5C180600,  //  0010  MOVE	R6	R3
+      0x7C100400,  //  0011  CALL	R4	2
+      0x8C100707,  //  0012  GETMET	R4	R3	K7
+      0x5C180400,  //  0013  MOVE	R6	R2
+      0x7C100400,  //  0014  CALL	R4	2
+      0x8C100708,  //  0015  GETMET	R4	R3	K8
+      0x7C100200,  //  0016  CALL	R4	1
+      0x80040600,  //  0017  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_session_by_source_node_id
+********************************************************************/
+be_local_closure(Matter_Session_Store_get_session_by_source_node_id,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(_source_node_id),
+    /* K3   */  be_nested_str_weak(update),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(get_session_by_source_node_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0001,  //  0002  JMPF	R2	#0005
+      0x4C080000,  //  0003  LDNIL	R2
+      0x80040400,  //  0004  RET	1	R2
+      0x6008000C,  //  0005  GETGBL	R2	G12
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x7C080200,  //  0007  CALL	R2	1
+      0x580C0001,  //  0008  LDCONST	R3	K1
+      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0x14140602,  //  000A  LT	R5	R3	R2
+      0x78160008,  //  000B  JMPF	R5	#0015
+      0x94140803,  //  000C  GETIDX	R5	R4	R3
+      0x88180B02,  //  000D  GETMBR	R6	R5	K2
+      0x1C180C01,  //  000E  EQ	R6	R6	R1
+      0x781A0002,  //  000F  JMPF	R6	#0013
+      0x8C180B03,  //  0010  GETMET	R6	R5	K3
+      0x7C180200,  //  0011  CALL	R6	1
+      0x80040A00,  //  0012  RET	1	R5
+      0x000C0704,  //  0013  ADD	R3	R3	K4
+      0x7001FFF4,  //  0014  JMP		#000A
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_session
+********************************************************************/
+be_local_closure(Matter_Session_Store_add_session,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(add_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x200C0403,  //  0001  NE	R3	R2	R3
+      0x780E0002,  //  0002  JMPF	R3	#0006
+      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
+      0x5C140200,  //  0008  MOVE	R5	R1
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: count_active_fabrics
+********************************************************************/
+be_local_closure(Matter_Session_Store_count_active_fabrics,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_expired),
+    /* K1   */  be_nested_str_weak(fabrics),
+    /* K2   */  be_nested_str_weak(count_persistables),
+    }),
+    be_str_weak(count_active_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80040200,  //  0005  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_expired
+********************************************************************/
+be_local_closure(Matter_Session_Store_remove_expired,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(every_second),
+    /* K2   */  be_nested_str_weak(fabrics),
+    }),
+    be_str_weak(remove_expired),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040102,  //  0003  GETMBR	R1	R0	K2
+      0x8C040301,  //  0004  GETMET	R1	R1	K1
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_children_fabrics
+********************************************************************/
+be_local_closure(Matter_Session_Store_find_children_fabrics,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        7,                          /* nstack */
+        1,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 3]) {  /* upvals */
+          be_local_const_upval(1, 0),
+          be_local_const_upval(1, 2),
+          be_local_const_upval(1, 3),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 6]) {     /* constants */
+        /* K0   */  be_nested_str_weak(active_fabrics),
+        /* K1   */  be_nested_str_weak(fabric_parent),
+        /* K2   */  be_nested_str_weak(find),
+        /* K3   */  be_nested_str_weak(fabric_index),
+        /* K4   */  be_nested_str_weak(push),
+        /* K5   */  be_nested_str_weak(stop_iteration),
+        }),
+        be_str_weak(find_children_fabrics_inner),
+        &be_const_str_solidified,
+        ( &(const binstruction[30]) {  /* code */
+          0x60040010,  //  0000  GETGBL	R1	G16
+          0x68080000,  //  0001  GETUPV	R2	U0
+          0x8C080500,  //  0002  GETMET	R2	R2	K0
+          0x7C080200,  //  0003  CALL	R2	1
+          0x7C040200,  //  0004  CALL	R1	1
+          0xA8020013,  //  0005  EXBLK	0	#001A
+          0x5C080200,  //  0006  MOVE	R2	R1
+          0x7C080000,  //  0007  CALL	R2	0
+          0x880C0501,  //  0008  GETMBR	R3	R2	K1
+          0x1C0C0600,  //  0009  EQ	R3	R3	R0
+          0x780E000D,  //  000A  JMPF	R3	#0019
+          0x680C0001,  //  000B  GETUPV	R3	U1
+          0x8C0C0702,  //  000C  GETMET	R3	R3	K2
+          0x7C0C0200,  //  000D  CALL	R3	1
+          0x4C100000,  //  000E  LDNIL	R4
+          0x1C0C0604,  //  000F  EQ	R3	R3	R4
+          0x780E0007,  //  0010  JMPF	R3	#0019
+          0x880C0503,  //  0011  GETMBR	R3	R2	K3
+          0x68100001,  //  0012  GETUPV	R4	U1
+          0x8C100904,  //  0013  GETMET	R4	R4	K4
+          0x5C180600,  //  0014  MOVE	R6	R3
+          0x7C100400,  //  0015  CALL	R4	2
+          0x68100002,  //  0016  GETUPV	R4	U2
+          0x5C140600,  //  0017  MOVE	R5	R3
+          0x7C100200,  //  0018  CALL	R4	1
+          0x7001FFEB,  //  0019  JMP		#0006
+          0x58040005,  //  001A  LDCONST	R1	K5
+          0xAC040200,  //  001B  CATCH	R1	1	0
+          0xB0080000,  //  001C  RAISE	2	R0	R0
+          0x80000000,  //  001D  RET	0
+        })
+      ),
+    }),
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(find_children_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0002,  //  0002  JMPF	R2	#0006
+      0x60080012,  //  0003  GETGBL	R2	G18
+      0x7C080000,  //  0004  CALL	R2	0
+      0x80040400,  //  0005  RET	1	R2
+      0x60080012,  //  0006  GETGBL	R2	G18
+      0x7C080000,  //  0007  CALL	R2	0
+      0x400C0401,  //  0008  CONNECT	R3	R2	R1
+      0x840C0000,  //  0009  CLOSURE	R3	P0
+      0x5C100600,  //  000A  MOVE	R4	R3
+      0x5C140200,  //  000B  MOVE	R5	R1
+      0x7C100200,  //  000C  CALL	R4	1
+      0xA0000000,  //  000D  CLOSE	R0
+      0x80040400,  //  000E  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_fabric_by_index
+********************************************************************/
+be_local_closure(Matter_Session_Store_find_fabric_by_index,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(active_fabrics),
+    /* K1   */  be_nested_str_weak(get_fabric_index),
+    /* K2   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(find_fabric_by_index),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0x60080010,  //  0000  GETGBL	R2	G16
+      0x8C0C0100,  //  0001  GETMET	R3	R0	K0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x7C080200,  //  0003  CALL	R2	1
+      0xA8020008,  //  0004  EXBLK	0	#000E
+      0x5C0C0400,  //  0005  MOVE	R3	R2
+      0x7C0C0000,  //  0006  CALL	R3	0
+      0x8C100701,  //  0007  GETMET	R4	R3	K1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x1C100801,  //  0009  EQ	R4	R4	R1
+      0x78120001,  //  000A  JMPF	R4	#000D
+      0xA8040001,  //  000B  EXBLK	1	1
+      0x80040600,  //  000C  RET	1	R3
+      0x7001FFF6,  //  000D  JMP		#0005
+      0x58080002,  //  000E  LDCONST	R2	K2
+      0xAC080200,  //  000F  CATCH	R2	1	0
+      0xB0080000,  //  0010  RAISE	2	R0	R0
+      0x4C080000,  //  0011  LDNIL	R2
+      0x80040400,  //  0012  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: next_fabric_idx
+********************************************************************/
+be_local_closure(Matter_Session_Store_next_fabric_idx,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_expired),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_nested_str_weak(active_fabrics),
+    /* K3   */  be_nested_str_weak(fabric_index),
+    /* K4   */  be_nested_str_weak(int),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(next_fabric_idx),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x58040001,  //  0002  LDCONST	R1	K1
+      0x60080010,  //  0003  GETGBL	R2	G16
+      0x8C0C0102,  //  0004  GETMET	R3	R0	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x7C080200,  //  0006  CALL	R2	1
+      0xA802000C,  //  0007  EXBLK	0	#0015
+      0x5C0C0400,  //  0008  MOVE	R3	R2
+      0x7C0C0000,  //  0009  CALL	R3	0
+      0x88100703,  //  000A  GETMBR	R4	R3	K3
+      0x60140004,  //  000B  GETGBL	R5	G4
+      0x5C180800,  //  000C  MOVE	R6	R4
+      0x7C140200,  //  000D  CALL	R5	1
+      0x1C140B04,  //  000E  EQ	R5	R5	K4
+      0x78160003,  //  000F  JMPF	R5	#0014
+      0x28140801,  //  0010  GE	R5	R4	R1
+      0x78160001,  //  0011  JMPF	R5	#0014
+      0x00140901,  //  0012  ADD	R5	R4	K1
+      0x5C040A00,  //  0013  MOVE	R1	R5
+      0x7001FFF2,  //  0014  JMP		#0008
+      0x58080005,  //  0015  LDCONST	R2	K5
+      0xAC080200,  //  0016  CATCH	R2	1	0
+      0xB0080000,  //  0017  RAISE	2	R0	R0
+      0x80040200,  //  0018  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_session_by_local_session_id
+********************************************************************/
+be_local_closure(Matter_Session_Store_get_session_by_local_session_id,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(local_session_id),
+    /* K3   */  be_nested_str_weak(update),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(get_session_by_local_session_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0001,  //  0002  JMPF	R2	#0005
+      0x4C080000,  //  0003  LDNIL	R2
+      0x80040400,  //  0004  RET	1	R2
+      0x6008000C,  //  0005  GETGBL	R2	G12
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x7C080200,  //  0007  CALL	R2	1
+      0x580C0001,  //  0008  LDCONST	R3	K1
+      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0x14140602,  //  000A  LT	R5	R3	R2
+      0x78160008,  //  000B  JMPF	R5	#0015
+      0x94140803,  //  000C  GETIDX	R5	R4	R3
+      0x88180B02,  //  000D  GETMBR	R6	R5	K2
+      0x1C180C01,  //  000E  EQ	R6	R6	R1
+      0x781A0002,  //  000F  JMPF	R6	#0013
+      0x8C180B03,  //  0010  GETMET	R6	R5	K3
+      0x7C180200,  //  0011  CALL	R6	1
+      0x80040A00,  //  0012  RET	1	R5
+      0x000C0704,  //  0013  ADD	R3	R3	K4
+      0x7001FFF4,  //  0014  JMP		#000A
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: active_fabrics
+********************************************************************/
+be_local_closure(Matter_Session_Store_active_fabrics,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_expired),
+    /* K1   */  be_nested_str_weak(fabrics),
+    /* K2   */  be_nested_str_weak(persistables),
+    }),
+    be_str_weak(active_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80040200,  //  0005  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Session_Store_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_expired),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_session
+********************************************************************/
+be_local_closure(Matter_Session_Store_remove_session,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(remove),
+    /* K3   */  be_const_int(1),
+    }),
+    be_str_weak(remove_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x6010000C,  //  0002  GETGBL	R4	G12
+      0x88140101,  //  0003  GETMBR	R5	R0	K1
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100404,  //  0005  LT	R4	R2	R4
+      0x78120008,  //  0006  JMPF	R4	#0010
+      0x94100602,  //  0007  GETIDX	R4	R3	R2
+      0x1C100801,  //  0008  EQ	R4	R4	R1
+      0x78120003,  //  0009  JMPF	R4	#000E
+      0x8C100702,  //  000A  GETMET	R4	R3	K2
+      0x5C180400,  //  000B  MOVE	R6	R2
+      0x7C100400,  //  000C  CALL	R4	2
+      0x70020000,  //  000D  JMP		#000F
+      0x00080503,  //  000E  ADD	R2	R2	K3
+      0x7001FFF1,  //  000F  JMP		#0002
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Session_Store_init,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(Expirable_list),
+    /* K3   */  be_nested_str_weak(fabrics),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x8C040302,  //  0001  GETMET	R1	R1	K2
+      0x7C040200,  //  0002  CALL	R1	1
+      0x90020001,  //  0003  SETMBR	R0	K0	R1
+      0xB8060200,  //  0004  GETNGBL	R1	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x7C040200,  //  0006  CALL	R1	1
+      0x90020601,  //  0007  SETMBR	R0	K3	R1
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: create_session
+********************************************************************/
+be_local_closure(Matter_Session_Store_create_session,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_session_by_local_session_id),
+    /* K1   */  be_nested_str_weak(remove_session),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(Session),
+    /* K4   */  be_nested_str_weak(sessions),
+    /* K5   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(create_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x5C140200,  //  0001  MOVE	R5	R1
+      0x7C0C0400,  //  0002  CALL	R3	2
+      0x4C100000,  //  0003  LDNIL	R4
+      0x20100604,  //  0004  NE	R4	R3	R4
+      0x78120002,  //  0005  JMPF	R4	#0009
+      0x8C100101,  //  0006  GETMET	R4	R0	K1
+      0x5C180600,  //  0007  MOVE	R6	R3
+      0x7C100400,  //  0008  CALL	R4	2
+      0xB8120400,  //  0009  GETNGBL	R4	K2
+      0x8C100903,  //  000A  GETMET	R4	R4	K3
+      0x5C180000,  //  000B  MOVE	R6	R0
+      0x5C1C0200,  //  000C  MOVE	R7	R1
+      0x5C200400,  //  000D  MOVE	R8	R2
+      0x7C100800,  //  000E  CALL	R4	4
+      0x5C0C0800,  //  000F  MOVE	R3	R4
+      0x88100104,  //  0010  GETMBR	R4	R0	K4
+      0x8C100905,  //  0011  GETMET	R4	R4	K5
+      0x5C180600,  //  0012  MOVE	R6	R3
+      0x7C100400,  //  0013  CALL	R4	2
+      0x80040600,  //  0014  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_fabrics
+********************************************************************/
+be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[26]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(remove_expired),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(fabrics),
+    /* K4   */  be_nested_str_weak(persistables),
+    /* K5   */  be_nested_str_weak(_sessions),
+    /* K6   */  be_const_int(1),
+    /* K7   */  be_nested_str_weak(stop_iteration),
+    /* K8   */  be_nested_str_weak(push),
+    /* K9   */  be_nested_str_weak(tojson),
+    /* K10  */  be_nested_str_weak(_X5B),
+    /* K11  */  be_nested_str_weak(concat),
+    /* K12  */  be_nested_str_weak(_X2C),
+    /* K13  */  be_nested_str_weak(_X5D),
+    /* K14  */  be_nested_str_weak(string),
+    /* K15  */  be_nested_str_weak(_FABRICS),
+    /* K16  */  be_nested_str_weak(w),
+    /* K17  */  be_nested_str_weak(write),
+    /* K18  */  be_nested_str_weak(close),
+    /* K19  */  be_nested_str_weak(tasmota),
+    /* K20  */  be_nested_str_weak(log),
+    /* K21  */  be_nested_str_weak(format),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20_X25i_X20fabric_X28s_X29_X20and_X20_X25i_X20session_X28s_X29),
+    /* K23  */  be_const_int(2),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+    /* K25  */  be_nested_str_weak(_X7C),
+    }),
+    be_str_weak(save_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[84]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x58080002,  //  0003  LDCONST	R2	K2
+      0x600C0012,  //  0004  GETGBL	R3	G18
+      0x7C0C0000,  //  0005  CALL	R3	0
+      0x60100010,  //  0006  GETGBL	R4	G16
+      0x88140103,  //  0007  GETMBR	R5	R0	K3
+      0x8C140B04,  //  0008  GETMET	R5	R5	K4
+      0x7C140200,  //  0009  CALL	R5	1
+      0x7C100200,  //  000A  CALL	R4	1
+      0xA8020013,  //  000B  EXBLK	0	#0020
+      0x5C140800,  //  000C  MOVE	R5	R4
+      0x7C140000,  //  000D  CALL	R5	0
+      0x60180010,  //  000E  GETGBL	R6	G16
+      0x881C0B05,  //  000F  GETMBR	R7	R5	K5
+      0x8C1C0F04,  //  0010  GETMET	R7	R7	K4
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x7C180200,  //  0012  CALL	R6	1
+      0xA8020003,  //  0013  EXBLK	0	#0018
+      0x5C1C0C00,  //  0014  MOVE	R7	R6
+      0x7C1C0000,  //  0015  CALL	R7	0
+      0x00080506,  //  0016  ADD	R2	R2	K6
+      0x7001FFFB,  //  0017  JMP		#0014
+      0x58180007,  //  0018  LDCONST	R6	K7
+      0xAC180200,  //  0019  CATCH	R6	1	0
+      0xB0080000,  //  001A  RAISE	2	R0	R0
+      0x8C180708,  //  001B  GETMET	R6	R3	K8
+      0x8C200B09,  //  001C  GETMET	R8	R5	K9
+      0x7C200200,  //  001D  CALL	R8	1
+      0x7C180400,  //  001E  CALL	R6	2
+      0x7001FFEB,  //  001F  JMP		#000C
+      0x58100007,  //  0020  LDCONST	R4	K7
+      0xAC100200,  //  0021  CATCH	R4	1	0
+      0xB0080000,  //  0022  RAISE	2	R0	R0
+      0x6010000C,  //  0023  GETGBL	R4	G12
+      0x5C140600,  //  0024  MOVE	R5	R3
+      0x7C100200,  //  0025  CALL	R4	1
+      0x8C14070B,  //  0026  GETMET	R5	R3	K11
+      0x581C000C,  //  0027  LDCONST	R7	K12
+      0x7C140400,  //  0028  CALL	R5	2
+      0x00161405,  //  0029  ADD	R5	K10	R5
+      0x00140B0D,  //  002A  ADD	R5	R5	K13
+      0x5C0C0A00,  //  002B  MOVE	R3	R5
+      0xA8020014,  //  002C  EXBLK	0	#0042
+      0xA4161C00,  //  002D  IMPORT	R5	K14
+      0x60180011,  //  002E  GETGBL	R6	G17
+      0x881C010F,  //  002F  GETMBR	R7	R0	K15
+      0x58200010,  //  0030  LDCONST	R8	K16
+      0x7C180400,  //  0031  CALL	R6	2
+      0x8C1C0D11,  //  0032  GETMET	R7	R6	K17
+      0x5C240600,  //  0033  MOVE	R9	R3
+      0x7C1C0400,  //  0034  CALL	R7	2
+      0x8C1C0D12,  //  0035  GETMET	R7	R6	K18
+      0x7C1C0200,  //  0036  CALL	R7	1
+      0xB81E2600,  //  0037  GETNGBL	R7	K19
+      0x8C1C0F14,  //  0038  GETMET	R7	R7	K20
+      0x8C240B15,  //  0039  GETMET	R9	R5	K21
+      0x582C0016,  //  003A  LDCONST	R11	K22
+      0x5C300800,  //  003B  MOVE	R12	R4
+      0x5C340400,  //  003C  MOVE	R13	R2
+      0x7C240800,  //  003D  CALL	R9	4
+      0x58280017,  //  003E  LDCONST	R10	K23
+      0x7C1C0600,  //  003F  CALL	R7	3
+      0xA8040001,  //  0040  EXBLK	1	1
+      0x70020010,  //  0041  JMP		#0053
+      0xAC140002,  //  0042  CATCH	R5	0	2
+      0x7002000D,  //  0043  JMP		#0052
+      0xB81E2600,  //  0044  GETNGBL	R7	K19
+      0x8C1C0F14,  //  0045  GETMET	R7	R7	K20
+      0x60240008,  //  0046  GETGBL	R9	G8
+      0x5C280A00,  //  0047  MOVE	R10	R5
+      0x7C240200,  //  0048  CALL	R9	1
+      0x00263009,  //  0049  ADD	R9	K24	R9
+      0x00241319,  //  004A  ADD	R9	R9	K25
+      0x60280008,  //  004B  GETGBL	R10	G8
+      0x5C2C0C00,  //  004C  MOVE	R11	R6
+      0x7C280200,  //  004D  CALL	R10	1
+      0x0024120A,  //  004E  ADD	R9	R9	R10
+      0x58280017,  //  004F  LDCONST	R10	K23
+      0x7C1C0600,  //  0050  CALL	R7	3
+      0x70020000,  //  0051  JMP		#0053
+      0xB0080000,  //  0052  RAISE	2	R0	R0
+      0x80000000,  //  0053  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: load_fabrics
 ********************************************************************/
 be_local_closure(Matter_Session_Store_load_fabrics,   /* name */
@@ -3346,203 +4391,6 @@ be_local_closure(Matter_Session_Store_load_fabrics,   /* name */
 
 
 /********************************************************************
-** Solidified function: gen_local_session_id
-********************************************************************/
-be_local_closure(Matter_Session_Store_gen_local_session_id,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(random),
-    /* K2   */  be_const_int(2),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(get_session_by_local_session_id),
-    }),
-    be_str_weak(gen_local_session_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x50080200,  //  0001  LDBOOL	R2	1	0
-      0x780A000E,  //  0002  JMPF	R2	#0012
-      0x8C080301,  //  0003  GETMET	R2	R1	K1
-      0x58100002,  //  0004  LDCONST	R4	K2
-      0x7C080400,  //  0005  CALL	R2	2
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
-      0x58100004,  //  0007  LDCONST	R4	K4
-      0x58140002,  //  0008  LDCONST	R5	K2
-      0x7C080600,  //  0009  CALL	R2	3
-      0x8C0C0105,  //  000A  GETMET	R3	R0	K5
-      0x5C140400,  //  000B  MOVE	R5	R2
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x4C100000,  //  000D  LDNIL	R4
-      0x1C0C0604,  //  000E  EQ	R3	R3	R4
-      0x780E0000,  //  000F  JMPF	R3	#0011
-      0x80040400,  //  0010  RET	1	R2
-      0x7001FFEE,  //  0011  JMP		#0001
-      0x80000000,  //  0012  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Session_Store_init,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(Expirable_list),
-    /* K3   */  be_nested_str_weak(fabrics),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x8C040302,  //  0001  GETMET	R1	R1	K2
-      0x7C040200,  //  0002  CALL	R1	1
-      0x90020001,  //  0003  SETMBR	R0	K0	R1
-      0xB8060200,  //  0004  GETNGBL	R1	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x7C040200,  //  0006  CALL	R1	1
-      0x90020601,  //  0007  SETMBR	R0	K3	R1
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: next_fabric_idx
-********************************************************************/
-be_local_closure(Matter_Session_Store_next_fabric_idx,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(active_fabrics),
-    /* K3   */  be_nested_str_weak(fabric_index),
-    /* K4   */  be_nested_str_weak(int),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(next_fabric_idx),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x58040001,  //  0002  LDCONST	R1	K1
-      0x60080010,  //  0003  GETGBL	R2	G16
-      0x8C0C0102,  //  0004  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x7C080200,  //  0006  CALL	R2	1
-      0xA802000C,  //  0007  EXBLK	0	#0015
-      0x5C0C0400,  //  0008  MOVE	R3	R2
-      0x7C0C0000,  //  0009  CALL	R3	0
-      0x88100703,  //  000A  GETMBR	R4	R3	K3
-      0x60140004,  //  000B  GETGBL	R5	G4
-      0x5C180800,  //  000C  MOVE	R6	R4
-      0x7C140200,  //  000D  CALL	R5	1
-      0x1C140B04,  //  000E  EQ	R5	R5	K4
-      0x78160003,  //  000F  JMPF	R5	#0014
-      0x28140801,  //  0010  GE	R5	R4	R1
-      0x78160001,  //  0011  JMPF	R5	#0014
-      0x00140901,  //  0012  ADD	R5	R4	K1
-      0x5C040A00,  //  0013  MOVE	R1	R5
-      0x7001FFF2,  //  0014  JMP		#0008
-      0x58080005,  //  0015  LDCONST	R2	K5
-      0xAC080200,  //  0016  CATCH	R2	1	0
-      0xB0080000,  //  0017  RAISE	2	R0	R0
-      0x80040200,  //  0018  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_redundant_fabric
-********************************************************************/
-be_local_closure(Matter_Session_Store_remove_redundant_fabric,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(fabrics),
-    /* K2   */  be_nested_str_weak(fabric_id),
-    /* K3   */  be_nested_str_weak(device_id),
-    /* K4   */  be_nested_str_weak(remove),
-    /* K5   */  be_const_int(1),
-    }),
-    be_str_weak(remove_redundant_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0012,  //  0005  JMPF	R3	#0019
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x20100601,  //  0008  NE	R4	R3	R1
-      0x7812000C,  //  0009  JMPF	R4	#0017
-      0x88100702,  //  000A  GETMBR	R4	R3	K2
-      0x88140302,  //  000B  GETMBR	R5	R1	K2
-      0x1C100805,  //  000C  EQ	R4	R4	R5
-      0x78120008,  //  000D  JMPF	R4	#0017
-      0x88100703,  //  000E  GETMBR	R4	R3	K3
-      0x88140303,  //  000F  GETMBR	R5	R1	K3
-      0x1C100805,  //  0010  EQ	R4	R4	R5
-      0x78120004,  //  0011  JMPF	R4	#0017
-      0x88100101,  //  0012  GETMBR	R4	R0	K1
-      0x8C100904,  //  0013  GETMET	R4	R4	K4
-      0x5C180400,  //  0014  MOVE	R6	R2
-      0x7C100400,  //  0015  CALL	R4	2
-      0x70020000,  //  0016  JMP		#0018
-      0x00080505,  //  0017  ADD	R2	R2	K5
-      0x7001FFE7,  //  0018  JMP		#0001
-      0x80000000,  //  0019  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: sessions_active
 ********************************************************************/
 be_local_closure(Matter_Session_Store_sessions_active,   /* name */
@@ -3626,439 +4474,6 @@ be_local_closure(Matter_Session_Store_create_fabric,   /* name */
 
 
 /********************************************************************
-** Solidified function: remove_session
-********************************************************************/
-be_local_closure(Matter_Session_Store_remove_session,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(remove),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(remove_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x6010000C,  //  0002  GETGBL	R4	G12
-      0x88140101,  //  0003  GETMBR	R5	R0	K1
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100404,  //  0005  LT	R4	R2	R4
-      0x78120008,  //  0006  JMPF	R4	#0010
-      0x94100602,  //  0007  GETIDX	R4	R3	R2
-      0x1C100801,  //  0008  EQ	R4	R4	R1
-      0x78120003,  //  0009  JMPF	R4	#000E
-      0x8C100702,  //  000A  GETMET	R4	R3	K2
-      0x5C180400,  //  000B  MOVE	R6	R2
-      0x7C100400,  //  000C  CALL	R4	2
-      0x70020000,  //  000D  JMP		#000F
-      0x00080503,  //  000E  ADD	R2	R2	K3
-      0x7001FFF1,  //  000F  JMP		#0002
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(Matter_Session_Store_every_second,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    }),
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: count_active_fabrics
-********************************************************************/
-be_local_closure(Matter_Session_Store_count_active_fabrics,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    /* K1   */  be_nested_str_weak(fabrics),
-    /* K2   */  be_nested_str_weak(count_persistables),
-    }),
-    be_str_weak(count_active_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_session_by_source_node_id
-********************************************************************/
-be_local_closure(Matter_Session_Store_get_session_by_source_node_id,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(_source_node_id),
-    /* K3   */  be_nested_str_weak(update),
-    /* K4   */  be_const_int(1),
-    }),
-    be_str_weak(get_session_by_source_node_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x6008000C,  //  0005  GETGBL	R2	G12
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x7C080200,  //  0007  CALL	R2	1
-      0x580C0001,  //  0008  LDCONST	R3	K1
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
-      0x14140602,  //  000A  LT	R5	R3	R2
-      0x78160008,  //  000B  JMPF	R5	#0015
-      0x94140803,  //  000C  GETIDX	R5	R4	R3
-      0x88180B02,  //  000D  GETMBR	R6	R5	K2
-      0x1C180C01,  //  000E  EQ	R6	R6	R1
-      0x781A0002,  //  000F  JMPF	R6	#0013
-      0x8C180B03,  //  0010  GETMET	R6	R5	K3
-      0x7C180200,  //  0011  CALL	R6	1
-      0x80040A00,  //  0012  RET	1	R5
-      0x000C0704,  //  0013  ADD	R3	R3	K4
-      0x7001FFF4,  //  0014  JMP		#000A
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_session_source_id_unsecure
-********************************************************************/
-be_local_closure(Matter_Session_Store_find_session_source_id_unsecure,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_session_by_source_node_id),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(Session),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(_source_node_id),
-    /* K5   */  be_nested_str_weak(sessions),
-    /* K6   */  be_nested_str_weak(push),
-    /* K7   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K8   */  be_nested_str_weak(update),
-    }),
-    be_str_weak(find_session_source_id_unsecure),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
-      0x5C140200,  //  0001  MOVE	R5	R1
-      0x7C0C0400,  //  0002  CALL	R3	2
-      0x4C100000,  //  0003  LDNIL	R4
-      0x1C100604,  //  0004  EQ	R4	R3	R4
-      0x7812000E,  //  0005  JMPF	R4	#0015
-      0xB8120200,  //  0006  GETNGBL	R4	K1
-      0x8C100902,  //  0007  GETMET	R4	R4	K2
-      0x5C180000,  //  0008  MOVE	R6	R0
-      0x581C0003,  //  0009  LDCONST	R7	K3
-      0x58200003,  //  000A  LDCONST	R8	K3
-      0x7C100800,  //  000B  CALL	R4	4
-      0x5C0C0800,  //  000C  MOVE	R3	R4
-      0x900E0801,  //  000D  SETMBR	R3	K4	R1
-      0x88100105,  //  000E  GETMBR	R4	R0	K5
-      0x8C100906,  //  000F  GETMET	R4	R4	K6
-      0x5C180600,  //  0010  MOVE	R6	R3
-      0x7C100400,  //  0011  CALL	R4	2
-      0x8C100707,  //  0012  GETMET	R4	R3	K7
-      0x5C180400,  //  0013  MOVE	R6	R2
-      0x7C100400,  //  0014  CALL	R4	2
-      0x8C100708,  //  0015  GETMET	R4	R3	K8
-      0x7C100200,  //  0016  CALL	R4	1
-      0x80040600,  //  0017  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_fabrics
-********************************************************************/
-be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(remove_expired),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(fabrics),
-    /* K4   */  be_nested_str_weak(persistables),
-    /* K5   */  be_nested_str_weak(_sessions),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(stop_iteration),
-    /* K8   */  be_nested_str_weak(push),
-    /* K9   */  be_nested_str_weak(tojson),
-    /* K10  */  be_nested_str_weak(_X5B),
-    /* K11  */  be_nested_str_weak(concat),
-    /* K12  */  be_nested_str_weak(_X2C),
-    /* K13  */  be_nested_str_weak(_X5D),
-    /* K14  */  be_nested_str_weak(string),
-    /* K15  */  be_nested_str_weak(_FABRICS),
-    /* K16  */  be_nested_str_weak(w),
-    /* K17  */  be_nested_str_weak(write),
-    /* K18  */  be_nested_str_weak(close),
-    /* K19  */  be_nested_str_weak(tasmota),
-    /* K20  */  be_nested_str_weak(log),
-    /* K21  */  be_nested_str_weak(format),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20_X25i_X20fabric_X28s_X29_X20and_X20_X25i_X20session_X28s_X29),
-    /* K23  */  be_const_int(2),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K25  */  be_nested_str_weak(_X7C),
-    }),
-    be_str_weak(save_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[84]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x58080002,  //  0003  LDCONST	R2	K2
-      0x600C0012,  //  0004  GETGBL	R3	G18
-      0x7C0C0000,  //  0005  CALL	R3	0
-      0x60100010,  //  0006  GETGBL	R4	G16
-      0x88140103,  //  0007  GETMBR	R5	R0	K3
-      0x8C140B04,  //  0008  GETMET	R5	R5	K4
-      0x7C140200,  //  0009  CALL	R5	1
-      0x7C100200,  //  000A  CALL	R4	1
-      0xA8020013,  //  000B  EXBLK	0	#0020
-      0x5C140800,  //  000C  MOVE	R5	R4
-      0x7C140000,  //  000D  CALL	R5	0
-      0x60180010,  //  000E  GETGBL	R6	G16
-      0x881C0B05,  //  000F  GETMBR	R7	R5	K5
-      0x8C1C0F04,  //  0010  GETMET	R7	R7	K4
-      0x7C1C0200,  //  0011  CALL	R7	1
-      0x7C180200,  //  0012  CALL	R6	1
-      0xA8020003,  //  0013  EXBLK	0	#0018
-      0x5C1C0C00,  //  0014  MOVE	R7	R6
-      0x7C1C0000,  //  0015  CALL	R7	0
-      0x00080506,  //  0016  ADD	R2	R2	K6
-      0x7001FFFB,  //  0017  JMP		#0014
-      0x58180007,  //  0018  LDCONST	R6	K7
-      0xAC180200,  //  0019  CATCH	R6	1	0
-      0xB0080000,  //  001A  RAISE	2	R0	R0
-      0x8C180708,  //  001B  GETMET	R6	R3	K8
-      0x8C200B09,  //  001C  GETMET	R8	R5	K9
-      0x7C200200,  //  001D  CALL	R8	1
-      0x7C180400,  //  001E  CALL	R6	2
-      0x7001FFEB,  //  001F  JMP		#000C
-      0x58100007,  //  0020  LDCONST	R4	K7
-      0xAC100200,  //  0021  CATCH	R4	1	0
-      0xB0080000,  //  0022  RAISE	2	R0	R0
-      0x6010000C,  //  0023  GETGBL	R4	G12
-      0x5C140600,  //  0024  MOVE	R5	R3
-      0x7C100200,  //  0025  CALL	R4	1
-      0x8C14070B,  //  0026  GETMET	R5	R3	K11
-      0x581C000C,  //  0027  LDCONST	R7	K12
-      0x7C140400,  //  0028  CALL	R5	2
-      0x00161405,  //  0029  ADD	R5	K10	R5
-      0x00140B0D,  //  002A  ADD	R5	R5	K13
-      0x5C0C0A00,  //  002B  MOVE	R3	R5
-      0xA8020014,  //  002C  EXBLK	0	#0042
-      0xA4161C00,  //  002D  IMPORT	R5	K14
-      0x60180011,  //  002E  GETGBL	R6	G17
-      0x881C010F,  //  002F  GETMBR	R7	R0	K15
-      0x58200010,  //  0030  LDCONST	R8	K16
-      0x7C180400,  //  0031  CALL	R6	2
-      0x8C1C0D11,  //  0032  GETMET	R7	R6	K17
-      0x5C240600,  //  0033  MOVE	R9	R3
-      0x7C1C0400,  //  0034  CALL	R7	2
-      0x8C1C0D12,  //  0035  GETMET	R7	R6	K18
-      0x7C1C0200,  //  0036  CALL	R7	1
-      0xB81E2600,  //  0037  GETNGBL	R7	K19
-      0x8C1C0F14,  //  0038  GETMET	R7	R7	K20
-      0x8C240B15,  //  0039  GETMET	R9	R5	K21
-      0x582C0016,  //  003A  LDCONST	R11	K22
-      0x5C300800,  //  003B  MOVE	R12	R4
-      0x5C340400,  //  003C  MOVE	R13	R2
-      0x7C240800,  //  003D  CALL	R9	4
-      0x58280017,  //  003E  LDCONST	R10	K23
-      0x7C1C0600,  //  003F  CALL	R7	3
-      0xA8040001,  //  0040  EXBLK	1	1
-      0x70020010,  //  0041  JMP		#0053
-      0xAC140002,  //  0042  CATCH	R5	0	2
-      0x7002000D,  //  0043  JMP		#0052
-      0xB81E2600,  //  0044  GETNGBL	R7	K19
-      0x8C1C0F14,  //  0045  GETMET	R7	R7	K20
-      0x60240008,  //  0046  GETGBL	R9	G8
-      0x5C280A00,  //  0047  MOVE	R10	R5
-      0x7C240200,  //  0048  CALL	R9	1
-      0x00263009,  //  0049  ADD	R9	K24	R9
-      0x00241319,  //  004A  ADD	R9	R9	K25
-      0x60280008,  //  004B  GETGBL	R10	G8
-      0x5C2C0C00,  //  004C  MOVE	R11	R6
-      0x7C280200,  //  004D  CALL	R10	1
-      0x0024120A,  //  004E  ADD	R9	R9	R10
-      0x58280017,  //  004F  LDCONST	R10	K23
-      0x7C1C0600,  //  0050  CALL	R7	3
-      0x70020000,  //  0051  JMP		#0053
-      0xB0080000,  //  0052  RAISE	2	R0	R0
-      0x80000000,  //  0053  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_session_by_local_session_id
-********************************************************************/
-be_local_closure(Matter_Session_Store_get_session_by_local_session_id,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(local_session_id),
-    /* K3   */  be_nested_str_weak(update),
-    /* K4   */  be_const_int(1),
-    }),
-    be_str_weak(get_session_by_local_session_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x6008000C,  //  0005  GETGBL	R2	G12
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x7C080200,  //  0007  CALL	R2	1
-      0x580C0001,  //  0008  LDCONST	R3	K1
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
-      0x14140602,  //  000A  LT	R5	R3	R2
-      0x78160008,  //  000B  JMPF	R5	#0015
-      0x94140803,  //  000C  GETIDX	R5	R4	R3
-      0x88180B02,  //  000D  GETMBR	R6	R5	K2
-      0x1C180C01,  //  000E  EQ	R6	R6	R1
-      0x781A0002,  //  000F  JMPF	R6	#0013
-      0x8C180B03,  //  0010  GETMET	R6	R5	K3
-      0x7C180200,  //  0011  CALL	R6	1
-      0x80040A00,  //  0012  RET	1	R5
-      0x000C0704,  //  0013  ADD	R3	R3	K4
-      0x7001FFF4,  //  0014  JMP		#000A
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_expired
-********************************************************************/
-be_local_closure(Matter_Session_Store_remove_expired,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(every_second),
-    /* K2   */  be_nested_str_weak(fabrics),
-    }),
-    be_str_weak(remove_expired),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040102,  //  0003  GETMBR	R1	R0	K2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: add_fabric
 ********************************************************************/
 be_local_closure(Matter_Session_Store_add_fabric,   /* name */
@@ -4113,299 +4528,39 @@ be_local_closure(Matter_Session_Store_add_fabric,   /* name */
 
 
 /********************************************************************
-** Solidified function: find_session_by_resumption_id
-********************************************************************/
-be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(sessions),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20session_X2Eresumption_id_X3D_X25s_X20vs_X20_X25s),
-    /* K7   */  be_nested_str_weak(resumption_id),
-    /* K8   */  be_nested_str_weak(shared_secret),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20session_X2Eshared_secret_X3D_X25s),
-    /* K10  */  be_nested_str_weak(update),
-    /* K11  */  be_const_int(1),
-    }),
-    be_str_weak(find_session_by_resumption_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[47]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x740E0001,  //  0002  JMPT	R3	#0005
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x80040600,  //  0004  RET	1	R3
-      0x580C0001,  //  0005  LDCONST	R3	K1
-      0x88100102,  //  0006  GETMBR	R4	R0	K2
-      0x6014000C,  //  0007  GETGBL	R5	G12
-      0x5C180800,  //  0008  MOVE	R6	R4
-      0x7C140200,  //  0009  CALL	R5	1
-      0x14140605,  //  000A  LT	R5	R3	R5
-      0x78160021,  //  000B  JMPF	R5	#002E
-      0x94140803,  //  000C  GETIDX	R5	R4	R3
-      0xB81A0600,  //  000D  GETNGBL	R6	K3
-      0x8C180D04,  //  000E  GETMET	R6	R6	K4
-      0x8C200505,  //  000F  GETMET	R8	R2	K5
-      0x58280006,  //  0010  LDCONST	R10	K6
-      0x602C0008,  //  0011  GETGBL	R11	G8
-      0x88300B07,  //  0012  GETMBR	R12	R5	K7
-      0x7C2C0200,  //  0013  CALL	R11	1
-      0x60300008,  //  0014  GETGBL	R12	G8
-      0x5C340200,  //  0015  MOVE	R13	R1
-      0x7C300200,  //  0016  CALL	R12	1
-      0x7C200800,  //  0017  CALL	R8	4
-      0x7C180400,  //  0018  CALL	R6	2
-      0x88180B07,  //  0019  GETMBR	R6	R5	K7
-      0x1C180C01,  //  001A  EQ	R6	R6	R1
-      0x781A000F,  //  001B  JMPF	R6	#002C
-      0x88180B08,  //  001C  GETMBR	R6	R5	K8
-      0x4C1C0000,  //  001D  LDNIL	R7
-      0x20180C07,  //  001E  NE	R6	R6	R7
-      0x781A000B,  //  001F  JMPF	R6	#002C
-      0xB81A0600,  //  0020  GETNGBL	R6	K3
-      0x8C180D04,  //  0021  GETMET	R6	R6	K4
-      0x8C200505,  //  0022  GETMET	R8	R2	K5
-      0x58280009,  //  0023  LDCONST	R10	K9
-      0x602C0008,  //  0024  GETGBL	R11	G8
-      0x88300B08,  //  0025  GETMBR	R12	R5	K8
-      0x7C2C0200,  //  0026  CALL	R11	1
-      0x7C200600,  //  0027  CALL	R8	3
-      0x7C180400,  //  0028  CALL	R6	2
-      0x8C180B0A,  //  0029  GETMET	R6	R5	K10
-      0x7C180200,  //  002A  CALL	R6	1
-      0x80040A00,  //  002B  RET	1	R5
-      0x000C070B,  //  002C  ADD	R3	R3	K11
-      0x7001FFD8,  //  002D  JMP		#0007
-      0x80000000,  //  002E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: create_session
-********************************************************************/
-be_local_closure(Matter_Session_Store_create_session,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_session_by_local_session_id),
-    /* K1   */  be_nested_str_weak(remove_session),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Session),
-    /* K4   */  be_nested_str_weak(sessions),
-    /* K5   */  be_nested_str_weak(push),
-    }),
-    be_str_weak(create_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
-      0x5C140200,  //  0001  MOVE	R5	R1
-      0x7C0C0400,  //  0002  CALL	R3	2
-      0x4C100000,  //  0003  LDNIL	R4
-      0x20100604,  //  0004  NE	R4	R3	R4
-      0x78120002,  //  0005  JMPF	R4	#0009
-      0x8C100101,  //  0006  GETMET	R4	R0	K1
-      0x5C180600,  //  0007  MOVE	R6	R3
-      0x7C100400,  //  0008  CALL	R4	2
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x8C100903,  //  000A  GETMET	R4	R4	K3
-      0x5C180000,  //  000B  MOVE	R6	R0
-      0x5C1C0200,  //  000C  MOVE	R7	R1
-      0x5C200400,  //  000D  MOVE	R8	R2
-      0x7C100800,  //  000E  CALL	R4	4
-      0x5C0C0800,  //  000F  MOVE	R3	R4
-      0x88100104,  //  0010  GETMBR	R4	R0	K4
-      0x8C100905,  //  0011  GETMET	R4	R4	K5
-      0x5C180600,  //  0012  MOVE	R6	R3
-      0x7C100400,  //  0013  CALL	R4	2
-      0x80040600,  //  0014  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_session
-********************************************************************/
-be_local_closure(Matter_Session_Store_add_session,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(push),
-    }),
-    be_str_weak(add_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x200C0403,  //  0001  NE	R3	R2	R3
-      0x780E0002,  //  0002  JMPF	R3	#0006
-      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
-      0x5C140200,  //  0008  MOVE	R5	R1
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x80000000,  //  000A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: active_fabrics
-********************************************************************/
-be_local_closure(Matter_Session_Store_active_fabrics,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    /* K1   */  be_nested_str_weak(fabrics),
-    /* K2   */  be_nested_str_weak(persistables),
-    }),
-    be_str_weak(active_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_fabric
-********************************************************************/
-be_local_closure(Matter_Session_Store_remove_fabric,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(_fabric),
-    /* K3   */  be_nested_str_weak(remove),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(fabrics),
-    /* K6   */  be_nested_str_weak(find),
-    }),
-    be_str_weak(remove_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E000B,  //  0005  JMPF	R3	#0012
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x880C0702,  //  0008  GETMBR	R3	R3	K2
-      0x1C0C0601,  //  0009  EQ	R3	R3	R1
-      0x780E0004,  //  000A  JMPF	R3	#0010
-      0x880C0101,  //  000B  GETMBR	R3	R0	K1
-      0x8C0C0703,  //  000C  GETMET	R3	R3	K3
-      0x5C140400,  //  000D  MOVE	R5	R2
-      0x7C0C0400,  //  000E  CALL	R3	2
-      0x70020000,  //  000F  JMP		#0011
-      0x00080504,  //  0010  ADD	R2	R2	K4
-      0x7001FFEE,  //  0011  JMP		#0001
-      0x880C0105,  //  0012  GETMBR	R3	R0	K5
-      0x8C0C0703,  //  0013  GETMET	R3	R3	K3
-      0x88140105,  //  0014  GETMBR	R5	R0	K5
-      0x8C140B06,  //  0015  GETMET	R5	R5	K6
-      0x5C1C0200,  //  0016  MOVE	R7	R1
-      0x7C140400,  //  0017  CALL	R5	2
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x80000000,  //  0019  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_Session_Store
 ********************************************************************/
 be_local_class(Matter_Session_Store,
     2,
     NULL,
-    be_nested_map(24,
+    be_nested_map(26,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(load_fabrics, -1), be_const_closure(Matter_Session_Store_load_fabrics_closure) },
-        { be_const_key_weak(remove_fabric, -1), be_const_closure(Matter_Session_Store_remove_fabric_closure) },
-        { be_const_key_weak(gen_local_session_id, -1), be_const_closure(Matter_Session_Store_gen_local_session_id_closure) },
-        { be_const_key_weak(init, 6), be_const_closure(Matter_Session_Store_init_closure) },
-        { be_const_key_weak(next_fabric_idx, 8), be_const_closure(Matter_Session_Store_next_fabric_idx_closure) },
-        { be_const_key_weak(fabrics, 21), be_const_var(1) },
-        { be_const_key_weak(sessions_active, -1), be_const_closure(Matter_Session_Store_sessions_active_closure) },
-        { be_const_key_weak(create_fabric, 1), be_const_closure(Matter_Session_Store_create_fabric_closure) },
-        { be_const_key_weak(sessions, -1), be_const_var(0) },
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Session_Store_every_second_closure) },
-        { be_const_key_weak(count_active_fabrics, -1), be_const_closure(Matter_Session_Store_count_active_fabrics_closure) },
-        { be_const_key_weak(get_session_by_source_node_id, -1), be_const_closure(Matter_Session_Store_get_session_by_source_node_id_closure) },
-        { be_const_key_weak(add_fabric, -1), be_const_closure(Matter_Session_Store_add_fabric_closure) },
-        { be_const_key_weak(save_fabrics, -1), be_const_closure(Matter_Session_Store_save_fabrics_closure) },
+        { be_const_key_weak(gen_local_session_id, 25), be_const_closure(Matter_Session_Store_gen_local_session_id_closure) },
+        { be_const_key_weak(remove_redundant_fabric, 15), be_const_closure(Matter_Session_Store_remove_redundant_fabric_closure) },
         { be_const_key_weak(find_session_by_resumption_id, -1), be_const_closure(Matter_Session_Store_find_session_by_resumption_id_closure) },
-        { be_const_key_weak(remove_expired, -1), be_const_closure(Matter_Session_Store_remove_expired_closure) },
-        { be_const_key_weak(find_session_source_id_unsecure, 12), be_const_closure(Matter_Session_Store_find_session_source_id_unsecure_closure) },
-        { be_const_key_weak(create_session, 14), be_const_closure(Matter_Session_Store_create_session_closure) },
-        { be_const_key_weak(remove_session, 17), be_const_closure(Matter_Session_Store_remove_session_closure) },
+        { be_const_key_weak(fabrics, 5), be_const_var(1) },
+        { be_const_key_weak(add_fabric, -1), be_const_closure(Matter_Session_Store_add_fabric_closure) },
+        { be_const_key_weak(create_fabric, -1), be_const_closure(Matter_Session_Store_create_fabric_closure) },
+        { be_const_key_weak(sessions_active, -1), be_const_closure(Matter_Session_Store_sessions_active_closure) },
         { be_const_key_weak(add_session, -1), be_const_closure(Matter_Session_Store_add_session_closure) },
+        { be_const_key_weak(count_active_fabrics, -1), be_const_closure(Matter_Session_Store_count_active_fabrics_closure) },
+        { be_const_key_weak(remove_expired, 17), be_const_closure(Matter_Session_Store_remove_expired_closure) },
         { be_const_key_weak(_FABRICS, -1), be_nested_str_weak(_matter_fabrics_X2Ejson) },
-        { be_const_key_weak(get_session_by_local_session_id, 23), be_const_closure(Matter_Session_Store_get_session_by_local_session_id_closure) },
+        { be_const_key_weak(find_fabric_by_index, -1), be_const_closure(Matter_Session_Store_find_fabric_by_index_closure) },
+        { be_const_key_weak(sessions, 4), be_const_var(0) },
+        { be_const_key_weak(get_session_by_source_node_id, 11), be_const_closure(Matter_Session_Store_get_session_by_source_node_id_closure) },
+        { be_const_key_weak(next_fabric_idx, -1), be_const_closure(Matter_Session_Store_next_fabric_idx_closure) },
+        { be_const_key_weak(get_session_by_local_session_id, 24), be_const_closure(Matter_Session_Store_get_session_by_local_session_id_closure) },
         { be_const_key_weak(active_fabrics, -1), be_const_closure(Matter_Session_Store_active_fabrics_closure) },
-        { be_const_key_weak(remove_redundant_fabric, -1), be_const_closure(Matter_Session_Store_remove_redundant_fabric_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Session_Store_every_second_closure) },
+        { be_const_key_weak(remove_session, -1), be_const_closure(Matter_Session_Store_remove_session_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Session_Store_init_closure) },
+        { be_const_key_weak(create_session, -1), be_const_closure(Matter_Session_Store_create_session_closure) },
+        { be_const_key_weak(save_fabrics, -1), be_const_closure(Matter_Session_Store_save_fabrics_closure) },
+        { be_const_key_weak(load_fabrics, -1), be_const_closure(Matter_Session_Store_load_fabrics_closure) },
+        { be_const_key_weak(remove_fabric, 6), be_const_closure(Matter_Session_Store_remove_fabric_closure) },
+        { be_const_key_weak(find_children_fabrics, -1), be_const_closure(Matter_Session_Store_find_children_fabrics_closure) },
+        { be_const_key_weak(find_session_source_id_unsecure, -1), be_const_closure(Matter_Session_Store_find_session_source_id_unsecure_closure) },
     })),
     be_str_weak(Matter_Session_Store)
 );


### PR DESCRIPTION
## Description:

Matter:
- keep track of fabric parent, i.e. when a fabric was provisioned by another. This is typically the case with Apple which provisioned 2 fabrics. When removing the device, Apple remove the parent fabric. Now the sub-fabrics are also removed automatically

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
