### PR TITLE
Berry `webserver.html_escape()` reusing the internal HTML escaping function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Matter support for Light and Relays on ESP32 by Stephan Hadinger (#18320)
 - ESP32 WIP support for 16 shutters using `#define USE_SHUTTER_ESP32` in addition to `USE_SHUTTER` by Stefan Bode (#18295)
+- Berry `webserver.html_escape()` reusing the internal HTML escaping function
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
@@ -24,6 +24,8 @@ extern int w_webserver_content_flush(bvm *vm);
 extern int w_webserver_content_stop(bvm *vm);
 extern int w_webserver_content_button(bvm *vm);
 
+extern int w_webserver_html_escape(bvm *vm);
+
 extern int w_webserver_argsize(bvm *vm);
 extern int w_webserver_arg(bvm *vm);
 extern int w_webserver_arg_name(bvm *vm);
@@ -47,6 +49,8 @@ module webserver (scope: global) {
     content_start, func(w_webserver_content_start)
     content_stop, func(w_webserver_content_stop)
     content_button, func(w_webserver_content_button)
+
+    html_escape, func(w_webserver_html_escape)
 
     arg_size, func(w_webserver_argsize)
     arg, func(w_webserver_arg)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
@@ -247,6 +247,20 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
+  // Berry: `webserver.html_escape(string) -> string`
+  //
+  int32_t w_webserver_html_escape(struct bvm *vm);
+  int32_t w_webserver_html_escape(struct bvm *vm) {
+    int32_t argc = be_top(vm); // Get the number of arguments
+    if (argc >= 1 && be_isstring(vm, 1)) {
+      const char * text = be_tostring(vm, 1);
+      String html = HtmlEscape(text);
+      be_pushstring(vm, html.c_str());
+      be_return(vm);
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
+
   // Berry: `webserver.args() -> int`
   //
   // Returns the number of arguments


### PR DESCRIPTION
## Description:

I just realized that Berry didn't have any function to escape HTML...

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
