### PR TITLE
Berry fix rare crash in json parsing

### DIFF
--- a/lib/libesp32/berry/src/be_jsonlib.c
+++ b/lib/libesp32/berry/src/be_jsonlib.c
@@ -183,6 +183,10 @@ static const char* parser_string(bvm *vm, const char *json)
                 }
             }
             be_assert(ch == '"');
+            /* require the stack to have some free space for the string, 
+               since parsing deeply nested objects might
+               crash the VM due to insufficient stack space. */
+            be_stack_require(vm, 1 + BE_STACK_FREE_MIN);
             be_pushnstring(vm, buf, cast_int(dst - buf));
             be_free(vm, buf, len);
             return json + 1; /* skip '"' */

--- a/lib/libesp32/berry/tests/json.be
+++ b/lib/libesp32/berry/tests/json.be
@@ -34,6 +34,12 @@ assert_load_failed('{"ke: 1}')
 assert_load_failed('{"key": 1x}')
 assert_load_failed('{"key"}')
 assert_load_failed('{"key": 1, }')
+# insanely long, nested object
+var text = 'null'
+for i : 0 .. 200
+    text = '{"nested":' + text + ', "num": 1, "bool": true, "str": "abc", "n": null, "arr": [1, 2, 3]}'
+end
+json.load(text) # do nothing, just check that it doesn't crash
 
 # dump tests
 


### PR DESCRIPTION
## Description:

Apply fix from upstream https://github.com/berry-lang/berry/pull/321

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
