### PR TITLE
Matter reduce logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 WIP support for 16 shutters using `#define USE_SHUTTER_ESP32` in addition to `USE_SHUTTER` by Stefan Bode (#18295)
 - Berry `webserver.html_escape()` reusing the internal HTML escaping function
 - Support for GDK101 gamma radiation sensor by Petr Novacek (#18390)
+- Matter support in now stabilized for Apple and Google (not tested with Alexa)
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning.be
@@ -59,7 +59,7 @@ class Matter_Commisioning_Context
       return false
     end
 
-    tasmota.log("MTR: received message " + matter.inspect(msg), 3)
+    # tasmota.log("MTR: received message " + matter.inspect(msg), 3)
     if   msg.opcode == 0x10
       # don't need to do anything, the message is acked already before this call
     elif msg.opcode == 0x20
@@ -144,9 +144,9 @@ class Matter_Commisioning_Context
     pbkdfparamresp.responderSessionId = session.__future_local_session_id
     pbkdfparamresp.pbkdf_parameters_salt = self.device.commissioning_salt
     pbkdfparamresp.pbkdf_parameters_iterations = self.device.commissioning_iterations
-    tasmota.log("MTR: pbkdfparamresp: " + str(matter.inspect(pbkdfparamresp)), 4)
+    # tasmota.log("MTR: pbkdfparamresp: " + str(matter.inspect(pbkdfparamresp)), 4)
     var pbkdfparamresp_raw = pbkdfparamresp.tlv2raw()
-    tasmota.log("MTR: pbkdfparamresp_raw: " + pbkdfparamresp_raw.tohex(), 4)
+    # tasmota.log("MTR: pbkdfparamresp_raw: " + pbkdfparamresp_raw.tohex(), 4)
 
     session.__Msg2 = pbkdfparamresp_raw
 
@@ -319,7 +319,7 @@ class Matter_Commisioning_Context
       return false
     end
     var sigma1 = matter.Sigma1().parse(msg.raw, msg.app_payload_idx)
-    tasmota.log(string.format("MTR: sigma1=%s", matter.inspect(sigma1)), 4)
+    # tasmota.log(string.format("MTR: sigma1=%s", matter.inspect(sigma1)), 4)
 
     session.__initiator_pub = sigma1.initiatorEphPubKey
 
@@ -455,20 +455,20 @@ class Matter_Commisioning_Context
       session.__future_local_session_id = self.device.sessions.gen_local_session_id()
       tasmota.log(string.format("MTR: +Session   (%6i) from '[%s]:%i'", session.__future_local_session_id, msg.remote_ip, msg.remote_port), 2)
 
-      tasmota.log("MTR: fabric="+matter.inspect(session._fabric), 4)
-      tasmota.log("MTR: no_private_key="+session._fabric.no_private_key.tohex(), 4)
-      tasmota.log("MTR: noc           ="+session._fabric.noc.tohex(), 4)
+      # tasmota.log("MTR: fabric="+matter.inspect(session._fabric), 4)
+      # tasmota.log("MTR: no_private_key="+session._fabric.no_private_key.tohex(), 4)
+      # tasmota.log("MTR: noc           ="+session._fabric.noc.tohex(), 4)
       if session._fabric.get_icac()
-        tasmota.log("MTR: icac          ="+session._fabric.get_icac().tohex(), 4)
+        # tasmota.log("MTR: icac          ="+session._fabric.get_icac().tohex(), 4)
       end
-      tasmota.log("MTR: root_ca_cert  ="+session._fabric.root_ca_certificate.tohex(), 4)
+      # tasmota.log("MTR: root_ca_cert  ="+session._fabric.root_ca_certificate.tohex(), 4)
 
       # Compute Sigma2, p.162
       session.resumption_id = crypto.random(16)
       session.__responder_priv = crypto.random(32)
       session.__responder_pub = crypto.EC_P256().public_key(session.__responder_priv)
-      tasmota.log("MTR: ResponderEph_priv  ="+session.__responder_priv.tohex(), 4)
-      tasmota.log("MTR: ResponderEph_pub  ="+session.__responder_pub.tohex(), 4)
+      # tasmota.log("MTR: ResponderEph_priv  ="+session.__responder_priv.tohex(), 4)
+      # tasmota.log("MTR: ResponderEph_pub  ="+session.__responder_pub.tohex(), 4)
       var responderRandom = crypto.random(32)
 
       session.shared_secret = crypto.EC_P256().shared_key(session.__responder_priv, sigma1.initiatorEphPubKey)
@@ -488,40 +488,40 @@ class Matter_Commisioning_Context
       sigma2_tbedata.add_TLV(4, matter.TLV.B2, session.resumption_id)
 
       # compute TranscriptHash = Crypto_Hash(message = Msg1)
-      tasmota.log("****************************************", 4)
+      # tasmota.log("****************************************", 4)
       session.__Msg1 = sigma1.Msg1
-      tasmota.log("MTR: * resumptionid  = " + session.resumption_id.tohex(), 4)
-      tasmota.log("MTR: * MSG1          = " + session.__Msg1.tohex(), 4)
+      # tasmota.log("MTR: * resumptionid  = " + session.resumption_id.tohex(), 4)
+      # tasmota.log("MTR: * MSG1          = " + session.__Msg1.tohex(), 4)
       var TranscriptHash = crypto.SHA256().update(session.__Msg1).out()
-      tasmota.log("MTR: TranscriptHash =" + TranscriptHash.tohex(), 4)
+      # tasmota.log("MTR: TranscriptHash =" + TranscriptHash.tohex(), 4)
 
       # Compute S2K, p.175
       var s2k_info = bytes().fromstring(self.S2K_Info)
       var s2k_salt = session.get_ipk_group_key() + responderRandom + session.__responder_pub + TranscriptHash
 
       var s2k = crypto.HKDF_SHA256().derive(session.shared_secret, s2k_salt, s2k_info, 16)
-      tasmota.log("MTR: * SharedSecret  = " + session.shared_secret.tohex(), 4)
-      tasmota.log("MTR: * s2k_salt      = " + s2k_salt.tohex(), 4)
-      tasmota.log("MTR: * s2k           = " + s2k.tohex(), 4)
+      # tasmota.log("MTR: * SharedSecret  = " + session.shared_secret.tohex(), 4)
+      # tasmota.log("MTR: * s2k_salt      = " + s2k_salt.tohex(), 4)
+      # tasmota.log("MTR: * s2k           = " + s2k.tohex(), 4)
 
       var sigma2_tbedata_raw = sigma2_tbedata.tlv2raw()
-      tasmota.log("MTR: * TBEData2Raw   = " + sigma2_tbedata_raw.tohex(), 4)
+      # tasmota.log("MTR: * TBEData2Raw   = " + sigma2_tbedata_raw.tohex(), 4)
       # // `AES_CCM.init(secret_key:bytes(16 or 32), iv:bytes(7..13), aad:bytes(), data_len:int, tag_len:int) -> instance`
 
       var aes = crypto.AES_CCM(s2k, bytes().fromstring(self.TBEData2_Nonce), bytes(), size(sigma2_tbedata_raw), 16)
       var TBEData2Encrypted = aes.encrypt(sigma2_tbedata_raw) + aes.tag()
-      tasmota.log("MTR: * TBEData2Enc   = " + TBEData2Encrypted.tohex(), 4)
-      tasmota.log("****************************************", 4)
+      # tasmota.log("MTR: * TBEData2Enc   = " + TBEData2Encrypted.tohex(), 4)
+      # tasmota.log("****************************************", 4)
 
       var sigma2 = matter.Sigma2()
       sigma2.responderRandom = responderRandom
       sigma2.responderSessionId = session.__future_local_session_id
       sigma2.responderEphPubKey = session.__responder_pub
       sigma2.encrypted2 = TBEData2Encrypted
-      tasmota.log("MTR: sigma2: " + matter.inspect(sigma2), 4)
+      # tasmota.log("MTR: sigma2: " + matter.inspect(sigma2), 4)
       var sigma2_raw = sigma2.tlv2raw()
       session.__Msg2 = sigma2_raw
-      tasmota.log("MTR: sigma2_raw: " + sigma2_raw.tohex(), 4)
+      # tasmota.log("MTR: sigma2_raw: " + sigma2_raw.tohex(), 4)
   
       # now package the response message
       var resp = msg.build_response(0x31 #-sigma-2-#, true)  # no reliable flag
@@ -545,22 +545,22 @@ class Matter_Commisioning_Context
     var session = msg.session
     var sigma3 = matter.Sigma3().parse(msg.raw, msg.app_payload_idx)
 
-    tasmota.log("****************************************", 4)
+    # tasmota.log("****************************************", 4)
     # compute TranscriptHash = Crypto_Hash(message = Msg1 || Msg2)
     var TranscriptHash = crypto.SHA256().update(session.__Msg1).update(session.__Msg2).out()
-    tasmota.log("MTR: * session       = " + str(session), 4)
-    tasmota.log("MTR:   .ipk_epoch_key=" + str(session.get_ipk_epoch_key()), 4)
-    tasmota.log("MTR:   .fabric_compr = " + str(session.get_fabric_compressed()), 4)
-    tasmota.log("MTR: * ipk_group_key = " + session.get_ipk_group_key().tohex(), 4)
-    tasmota.log("MTR: * TranscriptHash= " + TranscriptHash.tohex(), 4)
+    # tasmota.log("MTR: * session       = " + str(session), 4)
+    # tasmota.log("MTR:   .ipk_epoch_key=" + str(session.get_ipk_epoch_key()), 4)
+    # tasmota.log("MTR:   .fabric_compr = " + str(session.get_fabric_compressed()), 4)
+    # tasmota.log("MTR: * ipk_group_key = " + session.get_ipk_group_key().tohex(), 4)
+    # tasmota.log("MTR: * TranscriptHash= " + TranscriptHash.tohex(), 4)
 
     var s3k_info = bytes().fromstring(self.S3K_Info)
     var s3k = crypto.HKDF_SHA256().derive(session.shared_secret, session.get_ipk_group_key() + TranscriptHash, s3k_info, 16)
 
-    tasmota.log("****************************************", 4)
-    tasmota.log("MTR: * s3k_salt      = " + (session.get_ipk_group_key() + TranscriptHash).tohex(), 4)
-    tasmota.log("MTR: * s3k           = " + s3k.tohex(), 4)
-    tasmota.log("****************************************", 4)
+    # tasmota.log("****************************************", 4)
+    # tasmota.log("MTR: * s3k_salt      = " + (session.get_ipk_group_key() + TranscriptHash).tohex(), 4)
+    # tasmota.log("MTR: * s3k           = " + s3k.tohex(), 4)
+    # tasmota.log("****************************************", 4)
 
     # decrypt
     var encrypted = sigma3.TBEData3Encrypted[0..-17]
@@ -568,10 +568,10 @@ class Matter_Commisioning_Context
     var ec = crypto.AES_CCM(s3k, bytes().fromstring(self.TBEData3_Nonce), bytes(), size(encrypted), 16)
     var TBEData3 = ec.decrypt(encrypted)
     var TBETag3 = ec.tag()
-    tasmota.log("MTR: * TBEData3      = " + TBEData3.tohex(), 4)
-    tasmota.log("MTR: * TBETag3       = " + TBETag3.tohex(), 4)
-    tasmota.log("MTR: * tag_sent      = " + tag.tohex(), 4)
-    tasmota.log("****************************************", 4)
+    # tasmota.log("MTR: * TBEData3      = " + TBEData3.tohex(), 4)
+    # tasmota.log("MTR: * TBETag3       = " + TBETag3.tohex(), 4)
+    # tasmota.log("MTR: * tag_sent      = " + tag.tohex(), 4)
+    # tasmota.log("****************************************", 4)
 
     if TBETag3 != tag
       tasmota.log("MTR: Tag don't match", 2)
@@ -585,9 +585,9 @@ class Matter_Commisioning_Context
     var initiatorNOC = TBEData3TLV.findsubval(1)
     var initiatorICAC = TBEData3TLV.findsubval(2)
     var ec_signature = TBEData3TLV.findsubval(3)
-    tasmota.log("MTR: * initiatorNOC  = " + str(initiatorNOC), 4)
-    tasmota.log("MTR: * initiatorICAC = " + str(initiatorICAC), 4)
-    tasmota.log("MTR: * ec_signature  = " + str(ec_signature), 4)
+    # tasmota.log("MTR: * initiatorNOC  = " + str(initiatorNOC), 4)
+    # tasmota.log("MTR: * initiatorICAC = " + str(initiatorICAC), 4)
+    # tasmota.log("MTR: * ec_signature  = " + str(ec_signature), 4)
     # Success = Crypto_VerifyChain(certificates = [TBEData3.initiatorNOC, TBEData3.initiatorICAC, TrustedRCAC]), when TBEData3.initiatorICAC is present
     # TODO
     var initiatorNOCTLV = matter.TLV.parse(initiatorNOC)
@@ -603,13 +603,13 @@ class Matter_Commisioning_Context
     sigma3_tbs.add_TLV(2, matter.TLV.B1, initiatorICAC)
     sigma3_tbs.add_TLV(3, matter.TLV.B1, session.__initiator_pub)
     sigma3_tbs.add_TLV(4, matter.TLV.B1, session.__responder_pub)
-    tasmota.log("MTR: * sigma3_tbs    = " + str(sigma3_tbs), 4)
+    # tasmota.log("MTR: * sigma3_tbs    = " + str(sigma3_tbs), 4)
     var sigma3_tbs_raw = sigma3_tbs.tlv2raw()
-    tasmota.log("MTR: * sigma3_tbs_raw= " + sigma3_tbs_raw.tohex(), 4)
+    # tasmota.log("MTR: * sigma3_tbs_raw= " + sigma3_tbs_raw.tohex(), 4)
 
-    tasmota.log("MTR: * initiatorNOCPubKey= " + initiatorNOCPubKey.tohex(), 4)
-    tasmota.log("MTR: * ec_signature      = " + ec_signature.tohex(), 4)
-    tasmota.log("****************************************", 4)
+    # tasmota.log("MTR: * initiatorNOCPubKey= " + initiatorNOCPubKey.tohex(), 4)
+    # tasmota.log("MTR: * ec_signature      = " + ec_signature.tohex(), 4)
+    # tasmota.log("****************************************", 4)
 
     # `crypto.EC_P256().ecdsa_verify_sha256(public_key:bytes(65), message:bytes(), hash:bytes()) -> bool`
     var sigma3_tbs_valid = crypto.EC_P256().ecdsa_verify_sha256(initiatorNOCPubKey, sigma3_tbs_raw, ec_signature)
@@ -625,17 +625,17 @@ class Matter_Commisioning_Context
     tasmota.log("MTR: Sigma3 verified, computing new keys", 3)
 
     TranscriptHash = crypto.SHA256().update(session.__Msg1).update(session.__Msg2).update(sigma3.Msg3).out()
-    tasmota.log("MTR: * __Msg1            = " + session.__Msg1.tohex(), 4)
-    tasmota.log("MTR: * __Msg2            = " + session.__Msg2.tohex(), 4)
-    tasmota.log("MTR: * __Msg3            = " + sigma3.Msg3.tohex(), 4)
-    tasmota.log("MTR: * TranscriptHash    = " + TranscriptHash.tohex(), 4)
+    # tasmota.log("MTR: * __Msg1            = " + session.__Msg1.tohex(), 4)
+    # tasmota.log("MTR: * __Msg2            = " + session.__Msg2.tohex(), 4)
+    # tasmota.log("MTR: * __Msg3            = " + sigma3.Msg3.tohex(), 4)
+    # tasmota.log("MTR: * TranscriptHash    = " + TranscriptHash.tohex(), 4)
     # we can now free __Msg1 and __Msg2
     session.__Msg1 = nil
     session.__Msg2 = nil
 
-    tasmota.log("MTR: ******************************", 4)
-    tasmota.log("MTR: shared_secret =" + session.shared_secret.tohex(), 4)
-    tasmota.log("MTR: ipk + hash    =" + (session.get_ipk_group_key() + TranscriptHash).tohex(), 4)
+    # tasmota.log("MTR: ******************************", 4)
+    # tasmota.log("MTR: shared_secret =" + session.shared_secret.tohex(), 4)
+    # tasmota.log("MTR: ipk + hash    =" + (session.get_ipk_group_key() + TranscriptHash).tohex(), 4)
     # compute session key
     var session_keys = crypto.HKDF_SHA256().derive(session.shared_secret #- input key -#,
                                                    session.get_ipk_group_key() + TranscriptHash #- salt -#,
@@ -646,11 +646,11 @@ class Matter_Commisioning_Context
     var ac = session_keys[32..47]
     var created = tasmota.rtc()['utc']
 
-    tasmota.log("MTR: ******************************", 4)
-    tasmota.log("MTR: I2RKey      =" + i2r.tohex(), 4)
-    tasmota.log("MTR: R2IKey      =" + r2i.tohex(), 4)
-    tasmota.log("MTR: AC          =" + ac.tohex(), 4)
-    tasmota.log("MTR: ******************************", 4)
+    # tasmota.log("MTR: ******************************", 4)
+    # tasmota.log("MTR: I2RKey      =" + i2r.tohex(), 4)
+    # tasmota.log("MTR: R2IKey      =" + r2i.tohex(), 4)
+    # tasmota.log("MTR: AC          =" + ac.tohex(), 4)
+    # tasmota.log("MTR: ******************************", 4)
 
     # StatusReport(GeneralCode: SUCCESS, ProtocolId: SECURE_CHANNEL, ProtocolCode: SESSION_ESTABLISHMENT_SUCCESS)
     var raw = self.send_status_report(msg, 0x00, 0x0000, 0x0000, true)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning_Data.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning_Data.be
@@ -98,7 +98,7 @@ class Matter_Pake1
   def parse(b, idx)
     if idx == nil    idx = 0 end
     var val = matter.TLV.parse(b, idx)
-    tasmota.log("MTR: parsed TLV: " + str(val), 4)
+    # tasmota.log("MTR: parsed TLV: " + str(val), 4)
 
     self.pA = val.getsubval(1)
     return self
@@ -130,7 +130,7 @@ class Matter_Pake3
   def parse(b, idx)
     if idx == nil    idx = 0 end
     var val = matter.TLV.parse(b, idx)
-    tasmota.log("MTR: parsed TLV: " + str(val), 4)
+    # tasmota.log("MTR: parsed TLV: " + str(val), 4)
 
     self.cA = val.getsubval(1)
     return self
@@ -157,7 +157,7 @@ class Matter_Sigma1
     if idx == nil    idx = 0 end
     var val = matter.TLV.parse(b, idx)
     self.Msg1 = b[idx..]
-    tasmota.log("MTR: Sigma1 TLV=" + str(val), 4)
+    # tasmota.log("MTR: Sigma1 TLV=" + str(val), 4)
 
     self.initiatorRandom = val.getsubval(1)
     self.initiator_session_id = val.getsubval(2)
@@ -240,7 +240,7 @@ class Matter_Sigma3
     if idx == nil    idx = 0 end
     var val = matter.TLV.parse(b, idx)
     self.Msg3 = b[idx..]
-    tasmota.log("MTR: Sigma3 TLV=" + str(val), 4)
+    # tasmota.log("MTR: Sigma3 TLV=" + str(val), 4)
 
     self.TBEData3Encrypted = val.getsubval(1)
     return self

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
@@ -497,13 +497,13 @@ class Matter_Device
 
     var direct = (ctx.endpoint != nil) && (ctx.cluster != nil) && (ctx.attribute != nil) # true if the target is a precise attribute, false if it results from an expansion and error are ignored
 
-    tasmota.log(string.format("MTR: process_attribute_expansion %s", str(ctx)), 4)
+    # tasmota.log(string.format("MTR: process_attribute_expansion %s", str(ctx)), 4)
 
     # build the list of candidates
 
     # list of all endpoints
     var all = {}                          # map of {endpoint: {cluster: {attributes:[pi]}}
-    tasmota.log(string.format("MTR: endpoint=%s cluster=%s attribute=%s", endpoint, cluster, attribute), 4)
+    # tasmota.log(string.format("MTR: endpoint=%s cluster=%s attribute=%s", endpoint, cluster, attribute), 4)
     for pi: self.plugins
       var ep = pi.get_endpoint()    # get supported endpoints for this plugin
 
@@ -514,7 +514,7 @@ class Matter_Device
 
       # now explore the cluster list for 'ep'
       var cluster_list = pi.get_cluster_list(ep)                      # cluster_list is the actual list of candidate cluster for this pluging and endpoint
-      tasmota.log(string.format("MTR: pi=%s ep=%s cl_list=%s", str(pi), str(ep), str(cluster_list)), 4)
+      # tasmota.log(string.format("MTR: pi=%s ep=%s cl_list=%s", str(pi), str(ep), str(cluster_list)), 4)
       for cl: cluster_list
         if cluster != nil && cl != cluster    continue      end       # skip if specific cluster and no match
         # from now on, 'cl' is a good candidate
@@ -523,7 +523,7 @@ class Matter_Device
 
         # now filter on attributes
         var attr_list = pi.get_attribute_list(ep, cl)
-        tasmota.log(string.format("MTR: pi=%s ep=%s cl=%s at_list=%s", str(pi), str(ep), str(cl), str(attr_list)), 4)
+        # tasmota.log(string.format("MTR: pi=%s ep=%s cl=%s at_list=%s", str(pi), str(ep), str(cl), str(attr_list)), 4)
         for at: attr_list
           if attribute != nil && at != attribute  continue  end       # skip if specific attribute and no match
           # from now on, 'at' is a good candidate

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
@@ -38,7 +38,7 @@ class Matter_IM
 
   def process_incoming(msg)
     # messages are always TLV, decode payload
-    tasmota.log("MTR: received IM message " + matter.inspect(msg), 3)
+    # tasmota.log("MTR: received IM message " + matter.inspect(msg), 3)
 
     var val = matter.TLV.parse(msg.raw, msg.app_payload_idx)
 
@@ -218,7 +218,6 @@ class Matter_IM
       import string
       var attr_name = matter.get_attribute_name(ctx.cluster, ctx.attribute)
       attr_name = attr_name ? " (" + attr_name + ")" : ""
-      # tasmota.log(string.format("MTR: Read Attribute " + str(ctx) + (attr_name ? " (" + attr_name + ")" : ""), 2)
       # Special case to report unsupported item, if pi==nil
       var res = (pi != nil) ? pi.read_attribute(session, ctx) : nil
       if res != nil
@@ -325,7 +324,7 @@ class Matter_IM
       self.subs_shop.remove_by_session(msg.session)      # if `keep_subscriptions`, kill all subscriptions from current session
     end
 
-    tasmota.log("MTR: received SubscribeRequestMessage=" + str(query), 3)
+    # tasmota.log("MTR: received SubscribeRequestMessage=" + str(query), 3)
 
     var sub = self.subs_shop.new_subscription(msg.session, query)
 
@@ -357,7 +356,7 @@ class Matter_IM
   def process_invoke_request(msg, val)
     import string
     # structure is `ReadRequestMessage` 10.6.2 p.558
-    tasmota.log("MTR: IM:invoke_request processing start", 4)
+    # tasmota.log("MTR: IM:invoke_request processing start", 4)
     var ctx = matter.Path()
 
     var query = matter.InvokeRequestMessage().from_TLV(val)
@@ -416,10 +415,10 @@ class Matter_IM
         end
       end
 
-      tasmota.log("MTR: invoke_responses="+str(ret.invoke_responses), 4)
+      # tasmota.log("MTR: invoke_responses="+str(ret.invoke_responses), 4)
       if size(ret.invoke_responses) > 0
-        tasmota.log("MTR: InvokeResponse=" + str(ret), 4)
-        tasmota.log("MTR: InvokeResponseTLV=" + str(ret.to_TLV()), 3)
+        # tasmota.log("MTR: InvokeResponse=" + str(ret), 4)
+        # tasmota.log("MTR: InvokeResponseTLV=" + str(ret.to_TLV()), 3)
 
         self.send_invoke_response(msg, ret)
       else
@@ -455,7 +454,7 @@ class Matter_IM
   def process_write_request(msg, val)
     import string
     var query = matter.WriteRequestMessage().from_TLV(val)
-    tasmota.log("MTR: received WriteRequestMessage=" + str(query), 3)
+    # tasmota.log("MTR: received WriteRequestMessage=" + str(query), 3)
 
     var suppress_response = query.suppress_response
     # var timed_request = query.timed_request   # TODO not supported
@@ -502,7 +501,7 @@ class Matter_IM
     end
 
     # structure is `ReadRequestMessage` 10.6.2 p.558
-    tasmota.log("MTR: IM:write_request processing start", 4)
+    # tasmota.log("MTR: IM:write_request processing start", 4)
     var ctx = matter.Path()
 
     if query.write_requests != nil
@@ -541,8 +540,8 @@ class Matter_IM
         )
       end
 
-      tasmota.log("MTR: ReportWriteMessage=" + str(ret), 4)
-      tasmota.log("MTR: ReportWriteMessageTLV=" + str(ret.to_TLV()), 3)
+      # tasmota.log("MTR: ReportWriteMessage=" + str(ret), 4)
+      # tasmota.log("MTR: ReportWriteMessageTLV=" + str(ret.to_TLV()), 3)
 
       # send the reponse that may need to be chunked if too large to fit in a single UDP message
       if !suppress_response
@@ -578,7 +577,7 @@ class Matter_IM
   def process_timed_request(msg, val)
     import string
     var query = matter.TimedRequestMessage().from_TLV(val)
-    tasmota.log("MTR: received TimedRequestMessage=" + str(query), 3)
+    # tasmota.log("MTR: received TimedRequestMessage=" + str(query), 3)
 
     tasmota.log(string.format("MTR: >Command   (%6i) TimedRequest=%i", msg.session.local_session_id, query.timeout), 2)
     

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
@@ -58,7 +58,7 @@ class Matter_IM_Message
   # ack received for previous message, proceed to next (if any)
   # return true if we manage the ack ourselves, false if it needs to be done upper
   def ack_received(msg)
-    tasmota.log("MTR: IM_Message ack_received exch="+str(self.resp.exchange_id), 3)
+    # tasmota.log("MTR: IM_Message ack_received exch="+str(self.resp.exchange_id), 3)
     self.expiration = tasmota.millis() + self.MSG_TIMEOUT     # give more time
     return false
   end
@@ -67,7 +67,7 @@ class Matter_IM_Message
   # return true if we manage the ack ourselves, false if it needs to be done upper
   def status_ok_received(msg)
     import string
-    tasmota.log(string.format("MTR: IM_Message status_ok_received exch=%i", self.resp.exchange_id), 3)
+    # tasmota.log(string.format("MTR: IM_Message status_ok_received exch=%i", self.resp.exchange_id), 3)
     self.expiration = tasmota.millis() + self.MSG_TIMEOUT     # give more time
     if msg
       self.resp = msg.build_response(self.resp.opcode, self.resp.x_flag_r, self.resp)   # update packet
@@ -88,7 +88,7 @@ class Matter_IM_Message
   # default responder for data
   def send_im(responder)
     import string
-    tasmota.log(string.format("MTR: IM_Message send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    # tasmota.log(string.format("MTR: IM_Message send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
     if !self.ready   return false  end
     var resp = self.resp
     resp.encode_frame(self.data.to_TLV().tlv2raw())    # payload in cleartext
@@ -165,7 +165,7 @@ class Matter_IM_ReportData : Matter_IM_Message
   # default responder for data
   def send_im(responder)
     import string
-    tasmota.log(string.format("MTR: IM_ReportData send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    # tasmota.log(string.format("MTR: IM_ReportData send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
     if !self.ready   return false  end
     var resp = self.resp                          # response frame object
     var data = self.data                          # TLV data of the response (if any)
@@ -189,7 +189,7 @@ class Matter_IM_ReportData : Matter_IM_Message
       end
     end
 
-    tasmota.log(string.format("MTR: exch=%i elements=%i msg_sz=%i total=%i", self.get_exchangeid(), elements, msg_sz, sz_attribute_reports), 3)
+    # tasmota.log(string.format("MTR: exch=%i elements=%i msg_sz=%i total=%i", self.get_exchangeid(), elements, msg_sz, sz_attribute_reports), 3)
     var next_elemnts = []
     if data.attribute_reports != nil
       next_elemnts = data.attribute_reports[elements .. ]
@@ -261,8 +261,8 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
 
   # ack received, confirm the heartbeat
   def ack_received(msg)
-    import string
-    tasmota.log(string.format("MTR: IM_ReportDataSubscribed ack_received sub=%i", self.sub.subscription_id), 3)
+    # import string
+    # tasmota.log(string.format("MTR: IM_ReportDataSubscribed ack_received sub=%i", self.sub.subscription_id), 3)
     super(self).ack_received(msg)
     if !self.report_data_phase
       # if ack is received while all data is sent, means that it finished without error
@@ -277,16 +277,16 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
 
   # we received an ACK error, remove subscription
   def status_error_received(msg)
-    import string
-    tasmota.log(string.format("MTR: IM_ReportDataSubscribed status_error_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
+    # import string
+    # tasmota.log(string.format("MTR: IM_ReportDataSubscribed status_error_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     self.sub.remove_self()
   end
 
   # ack received for previous message, proceed to next (if any)
   # return true if we manage the ack ourselves, false if it needs to be done upper
   def status_ok_received(msg)
-    import string
-    tasmota.log(string.format("MTR: IM_ReportDataSubscribed status_ok_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
+    # import string
+    # tasmota.log(string.format("MTR: IM_ReportDataSubscribed status_ok_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     if self.report_data_phase
       return super(self).status_ok_received(msg)
     else
@@ -300,13 +300,13 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
   # default responder for data
   def send_im(responder)
     import string
-    tasmota.log(string.format("MTR: IM_ReportDataSubscribed send sub=%i exch=%i ready=%i", self.sub.subscription_id, self.resp.exchange_id, self.ready ? 1 : 0), 3)
-    tasmota.log(string.format("MTR: ReportDataSubscribed::send_im size(self.data.attribute_reports)=%i ready=%s report_data_phase=%s", size(self.data.attribute_reports), str(self.ready), str(self.report_data_phase)), 3)
+    # tasmota.log(string.format("MTR: IM_ReportDataSubscribed send sub=%i exch=%i ready=%i", self.sub.subscription_id, self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    # tasmota.log(string.format("MTR: ReportDataSubscribed::send_im size(self.data.attribute_reports)=%i ready=%s report_data_phase=%s", size(self.data.attribute_reports), str(self.ready), str(self.report_data_phase)), 3)
     if !self.ready   return false  end
     if size(self.data.attribute_reports) > 0      # do we have still attributes to send
       if self.report_data_phase
         super(self).send_im(responder)
-        tasmota.log(string.format("MTR: ReportDataSubscribed::send_im called super finish=%i", self.finish), 3)
+        # tasmota.log(string.format("MTR: ReportDataSubscribed::send_im called super finish=%i", self.finish), 3)
         if !self.finish return end              # ReportData needs to continue
         # ReportData is finished
         self.report_data_phase = false
@@ -361,8 +361,8 @@ class Matter_IM_SubscribedHeartbeat : Matter_IM_ReportData
 
   # ack received, confirm the heartbeat
   def ack_received(msg)
-    import string
-    tasmota.log(string.format("MTR: Matter_IM_SubscribedHeartbeat ack_received sub=%i", self.sub.subscription_id), 3)
+    # import string
+    # tasmota.log(string.format("MTR: Matter_IM_SubscribedHeartbeat ack_received sub=%i", self.sub.subscription_id), 3)
     super(self).ack_received(msg)
     self.finish = true
     return true                       # proceed to calling send() which removes the message
@@ -370,8 +370,8 @@ class Matter_IM_SubscribedHeartbeat : Matter_IM_ReportData
 
   # we received an ACK error, remove subscription
   def status_error_received(msg)
-    import string
-    tasmota.log(string.format("MTR: Matter_IM_SubscribedHeartbeat status_error_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
+    # import string
+    # tasmota.log(string.format("MTR: Matter_IM_SubscribedHeartbeat status_error_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     self.sub.remove_self()
     return false                            # let the caller to the ack
   end
@@ -379,15 +379,15 @@ class Matter_IM_SubscribedHeartbeat : Matter_IM_ReportData
   # ack received for previous message, proceed to next (if any)
   # return true if we manage the ack ourselves, false if it needs to be done upper
   def status_ok_received(msg)
-    import string
-    tasmota.log(string.format("MTR: Matter_IM_SubscribedHeartbeat status_ok_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
+    # import string
+    # tasmota.log(string.format("MTR: Matter_IM_SubscribedHeartbeat status_ok_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     return false                            # let the caller to the ack
   end
 
   # default responder for data
   def send_im(responder)
-    import string
-    tasmota.log(string.format("MTR: Matter_IM_SubscribedHeartbeat send sub=%i exch=%i ready=%i", self.sub.subscription_id, self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    # import string
+    # tasmota.log(string.format("MTR: Matter_IM_SubscribedHeartbeat send sub=%i exch=%i ready=%i", self.sub.subscription_id, self.resp.exchange_id, self.ready ? 1 : 0), 3)
     if !self.ready   return false  end
 
     super(self).send_im(responder)
@@ -413,8 +413,8 @@ class Matter_IM_SubscribeResponse : Matter_IM_ReportData
 
   # default responder for data
   def send_im(responder)
-    import string
-    tasmota.log(string.format("MTR: Matter_IM_SubscribeResponse send sub=%i ready=%i", self.sub.subscription_id, self.ready ? 1 : 0), 3)
+    # import string
+    # tasmota.log(string.format("MTR: Matter_IM_SubscribeResponse send sub=%i ready=%i", self.sub.subscription_id, self.ready ? 1 : 0), 3)
     if !self.ready   return false  end
     if self.report_data_phase
       super(self).send_im(responder)
@@ -437,7 +437,7 @@ class Matter_IM_SubscribeResponse : Matter_IM_ReportData
       resp.encrypt()
       responder.send_response_frame(resp)
       self.last_counter = resp.message_counter
-      tasmota.log(string.format("MTR: Send SubscribeResponseMessage sub=%i id=%i", self.sub.subscription_id, resp.message_counter), 3)
+      # tasmota.log(string.format("MTR: Send SubscribeResponseMessage sub=%i id=%i", self.sub.subscription_id, resp.message_counter), 3)
       self.sub.re_arm()
       self.finish = true          # remove exchange
     end
@@ -445,10 +445,10 @@ class Matter_IM_SubscribeResponse : Matter_IM_ReportData
 
   # Status ok received
   def status_ok_received(msg)
-    import string
-    tasmota.log(string.format("MTR: IM_SubscribeResponse status_ok_received sub=%i exch=%i ack=%i last_counter=%i", self.sub.subscription_id, self.resp.exchange_id, msg.ack_message_counter ? msg.ack_message_counter : 0 , self.last_counter), 3)
+    # import string
+    # tasmota.log(string.format("MTR: IM_SubscribeResponse status_ok_received sub=%i exch=%i ack=%i last_counter=%i", self.sub.subscription_id, self.resp.exchange_id, msg.ack_message_counter ? msg.ack_message_counter : 0 , self.last_counter), 3)
     # once we receive ack, open flow for subscriptions
-    tasmota.log(string.format("MTR: >Sub_OK    (%6i) sub=%i", msg.session.local_session_id, self.sub.subscription_id), 2)
+    # tasmota.log(string.format("MTR: >Sub_OK    (%6i) sub=%i", msg.session.local_session_id, self.sub.subscription_id), 2)
     return super(self).status_ok_received(msg)
   end
     

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Message.be
@@ -383,22 +383,22 @@ class Matter_Frame
       n.resize(13)        # add zeros
     end
 
-    tasmota.log("MTR: ******************************", 4)
-    tasmota.log("MTR: i2r         =" + i2r.tohex(), 4)
-    tasmota.log("MTR: p           =" + p.tohex(), 4)
-    tasmota.log("MTR: a           =" + a.tohex(), 4)
-    tasmota.log("MTR: n           =" + n.tohex(), 4)
-    tasmota.log("MTR: mic         =" + mic.tohex(), 4)
+    # tasmota.log("MTR: ******************************", 4)
+    # tasmota.log("MTR: i2r         =" + i2r.tohex(), 4)
+    # tasmota.log("MTR: p           =" + p.tohex(), 4)
+    # tasmota.log("MTR: a           =" + a.tohex(), 4)
+    # tasmota.log("MTR: n           =" + n.tohex(), 4)
+    # tasmota.log("MTR: mic         =" + mic.tohex(), 4)
 
     # decrypt
     var aes = crypto.AES_CCM(i2r, n, a, size(p), 16)
     var cleartext = aes.decrypt(p)
     var tag = aes.tag()
 
-    tasmota.log("MTR: ******************************", 4)
-    tasmota.log("MTR: cleartext   =" + cleartext.tohex(), 4)
-    tasmota.log("MTR: tag         =" + tag.tohex(), 4)
-    tasmota.log("MTR: ******************************", 4)
+    # tasmota.log("MTR: ******************************", 4)
+    # tasmota.log("MTR: cleartext   =" + cleartext.tohex(), 4)
+    # tasmota.log("MTR: tag         =" + tag.tohex(), 4)
+    # tasmota.log("MTR: ******************************", 4)
 
     if tag != mic
       tasmota.log("MTR: rejected packet due to invalid MIC", 2)
@@ -461,6 +461,7 @@ class Matter_Frame
   #############################################################
   # Decode a message we are about to send, to ease debug
   def debug(raw)
+    return      # disable logging for now
     var r = matter.Frame(self.message_handler, raw)
     r.decode_header()
     r.decode_payload()

--- a/lib/libesp32/berry_matter/src/embedded/Matter_MessageHandler.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_MessageHandler.be
@@ -89,15 +89,15 @@ class Matter_MessageHandler
       # do we need decryption?
       if frame.sec_p
         # Control message
-        tasmota.log("MTR: CONTROL MESSAGE=" + matter.inspect(frame))
+        tasmota.log("MTR: CONTROL MESSAGE=" + matter.inspect(frame), 4)
         var session = self.device.sessions.find_session_source_id_unsecure(frame.source_node_id, 90)    # 90 seconds max
-        tasmota.log("MTR: find session by source_node_id = " + str(frame.source_node_id) + " session_id = " + str(session.local_session_id), 2)
+        tasmota.log("MTR: find session by source_node_id = " + str(frame.source_node_id) + " session_id = " + str(session.local_session_id), 4)
         return self.control_message.process_incoming_control_message(frame)
       elif frame.local_session_id == 0 && frame.sec_sesstype == 0
         #############################################################
         ### unencrypted session, handled by commissioning
         var session = self.device.sessions.find_session_source_id_unsecure(frame.source_node_id, 90)    # 90 seconds max
-        tasmota.log("MTR: find session by source_node_id = " + str(frame.source_node_id) + " session_id = " + str(session.local_session_id), 3)
+        tasmota.log("MTR: find session by source_node_id = " + str(frame.source_node_id) + " session_id = " + str(session.local_session_id), 4)
         if addr     session._ip = addr     end
         if port     session._port = port   end
         session._message_handler = self
@@ -166,7 +166,7 @@ class Matter_MessageHandler
         var protocol_id = frame.protocol_id
         if protocol_id == 0x0000    # PROTOCOL_ID_SECURE_CHANNEL
           # it should not be encrypted
-          tasmota.log("MTR: PROTOCOL_ID_SECURE_CHANNEL " + matter.inspect(frame), 3)
+          # tasmota.log("MTR: PROTOCOL_ID_SECURE_CHANNEL " + matter.inspect(frame), 3)
           if frame.opcode == 0x10                             # MRPStandaloneAcknowledgement
             ret = self.im.process_incoming_ack(frame)
             if ret

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
@@ -279,9 +279,9 @@ class Matter_Session_Store
     var sessions = self.sessions
     while i < size(sessions)
       var session = sessions[i]
-      tasmota.log(string.format("MTR: session.resumption_id=%s vs %s", str(session.resumption_id), str(resumption_id)))
+      tasmota.log(string.format("MTR: session.resumption_id=%s vs %s", str(session.resumption_id), str(resumption_id)), 3)
       if session.resumption_id == resumption_id && session.shared_secret != nil
-        tasmota.log(string.format("MTR: session.shared_secret=%s", str(session.shared_secret)))
+        tasmota.log(string.format("MTR: session.shared_secret=%s", str(session.shared_secret)), 3)
         session.update()
         return session
       end

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
@@ -268,7 +268,7 @@ be_local_closure(Matter_Commisioning_Context_parse_PBKDFParamRequest,   /* name 
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[53]) {     /* constants */
+    ( &(const bvalue[49]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(session),
@@ -312,20 +312,16 @@ be_local_closure(Matter_Commisioning_Context_parse_PBKDFParamRequest,   /* name 
     /* K40  */  be_nested_str_weak(commissioning_salt),
     /* K41  */  be_nested_str_weak(pbkdf_parameters_iterations),
     /* K42  */  be_nested_str_weak(commissioning_iterations),
-    /* K43  */  be_nested_str_weak(MTR_X3A_X20pbkdfparamresp_X3A_X20),
-    /* K44  */  be_nested_str_weak(inspect),
-    /* K45  */  be_nested_str_weak(tlv2raw),
-    /* K46  */  be_nested_str_weak(MTR_X3A_X20pbkdfparamresp_raw_X3A_X20),
-    /* K47  */  be_nested_str_weak(tohex),
-    /* K48  */  be_nested_str_weak(__Msg2),
-    /* K49  */  be_nested_str_weak(build_response),
-    /* K50  */  be_nested_str_weak(encode_frame),
-    /* K51  */  be_nested_str_weak(responder),
-    /* K52  */  be_nested_str_weak(send_response_frame),
+    /* K43  */  be_nested_str_weak(tlv2raw),
+    /* K44  */  be_nested_str_weak(__Msg2),
+    /* K45  */  be_nested_str_weak(build_response),
+    /* K46  */  be_nested_str_weak(encode_frame),
+    /* K47  */  be_nested_str_weak(responder),
+    /* K48  */  be_nested_str_weak(send_response_frame),
     }),
     be_str_weak(parse_PBKDFParamRequest),
     &be_const_str_solidified,
-    ( &(const binstruction[137]) {  /* code */
+    ( &(const binstruction[119]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0xA40E0200,  //  0001  IMPORT	R3	K1
       0x88100302,  //  0002  GETMBR	R4	R1	K2
@@ -429,40 +425,22 @@ be_local_closure(Matter_Commisioning_Context_parse_PBKDFParamRequest,   /* name 
       0x881C011B,  //  0064  GETMBR	R7	R0	K27
       0x881C0F2A,  //  0065  GETMBR	R7	R7	K42
       0x901A5207,  //  0066  SETMBR	R6	K41	R7
-      0xB81E0E00,  //  0067  GETNGBL	R7	K7
-      0x8C1C0F08,  //  0068  GETMET	R7	R7	K8
-      0x60240008,  //  0069  GETGBL	R9	G8
-      0xB82A1C00,  //  006A  GETNGBL	R10	K14
-      0x8C28152C,  //  006B  GETMET	R10	R10	K44
-      0x5C300C00,  //  006C  MOVE	R12	R6
-      0x7C280400,  //  006D  CALL	R10	2
-      0x7C240200,  //  006E  CALL	R9	1
-      0x00265609,  //  006F  ADD	R9	K43	R9
-      0x542A0003,  //  0070  LDINT	R10	4
-      0x7C1C0600,  //  0071  CALL	R7	3
-      0x8C1C0D2D,  //  0072  GETMET	R7	R6	K45
-      0x7C1C0200,  //  0073  CALL	R7	1
-      0xB8220E00,  //  0074  GETNGBL	R8	K7
-      0x8C201108,  //  0075  GETMET	R8	R8	K8
-      0x8C280F2F,  //  0076  GETMET	R10	R7	K47
-      0x7C280200,  //  0077  CALL	R10	1
-      0x002A5C0A,  //  0078  ADD	R10	K46	R10
-      0x542E0003,  //  0079  LDINT	R11	4
-      0x7C200600,  //  007A  CALL	R8	3
-      0x90126007,  //  007B  SETMBR	R4	K48	R7
-      0x8C200331,  //  007C  GETMET	R8	R1	K49
-      0x542A0020,  //  007D  LDINT	R10	33
-      0x502C0200,  //  007E  LDBOOL	R11	1	0
-      0x7C200600,  //  007F  CALL	R8	3
-      0x8C241132,  //  0080  GETMET	R9	R8	K50
-      0x5C2C0E00,  //  0081  MOVE	R11	R7
-      0x7C240400,  //  0082  CALL	R9	2
-      0x88280133,  //  0083  GETMBR	R10	R0	K51
-      0x8C281534,  //  0084  GETMET	R10	R10	K52
-      0x5C301000,  //  0085  MOVE	R12	R8
-      0x7C280400,  //  0086  CALL	R10	2
-      0x50280200,  //  0087  LDBOOL	R10	1	0
-      0x80041400,  //  0088  RET	1	R10
+      0x8C1C0D2B,  //  0067  GETMET	R7	R6	K43
+      0x7C1C0200,  //  0068  CALL	R7	1
+      0x90125807,  //  0069  SETMBR	R4	K44	R7
+      0x8C20032D,  //  006A  GETMET	R8	R1	K45
+      0x542A0020,  //  006B  LDINT	R10	33
+      0x502C0200,  //  006C  LDBOOL	R11	1	0
+      0x7C200600,  //  006D  CALL	R8	3
+      0x8C24112E,  //  006E  GETMET	R9	R8	K46
+      0x5C2C0E00,  //  006F  MOVE	R11	R7
+      0x7C240400,  //  0070  CALL	R9	2
+      0x8828012F,  //  0071  GETMBR	R10	R0	K47
+      0x8C281530,  //  0072  GETMET	R10	R10	K48
+      0x5C301000,  //  0073  MOVE	R12	R8
+      0x7C280400,  //  0074  CALL	R10	2
+      0x50280200,  //  0075  LDBOOL	R10	1	0
+      0x80041400,  //  0076  RET	1	R10
     })
   )
 );
@@ -907,7 +885,7 @@ be_local_closure(Matter_Commisioning_Context_parse_Sigma3,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[100]) {     /* constants */
+    ( &(const bvalue[69]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(opcode),
     /* K2   */  be_nested_str_weak(local_session_id),
@@ -925,93 +903,62 @@ be_local_closure(Matter_Commisioning_Context_parse_Sigma3,   /* name */
     /* K14  */  be_nested_str_weak(parse),
     /* K15  */  be_nested_str_weak(raw),
     /* K16  */  be_nested_str_weak(app_payload_idx),
-    /* K17  */  be_nested_str_weak(_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
-    /* K18  */  be_nested_str_weak(SHA256),
-    /* K19  */  be_nested_str_weak(update),
-    /* K20  */  be_nested_str_weak(__Msg1),
-    /* K21  */  be_nested_str_weak(__Msg2),
-    /* K22  */  be_nested_str_weak(out),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20session_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X2Eipk_epoch_key_X3D),
-    /* K25  */  be_nested_str_weak(get_ipk_epoch_key),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X2Efabric_compr_X20_X3D_X20),
-    /* K27  */  be_nested_str_weak(get_fabric_compressed),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20ipk_group_key_X20_X3D_X20),
-    /* K29  */  be_nested_str_weak(get_ipk_group_key),
-    /* K30  */  be_nested_str_weak(tohex),
-    /* K31  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20TranscriptHash_X3D_X20),
-    /* K32  */  be_nested_str_weak(fromstring),
-    /* K33  */  be_nested_str_weak(S3K_Info),
-    /* K34  */  be_nested_str_weak(HKDF_SHA256),
-    /* K35  */  be_nested_str_weak(derive),
-    /* K36  */  be_nested_str_weak(shared_secret),
-    /* K37  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s3k_salt_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K38  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s3k_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K39  */  be_nested_str_weak(TBEData3Encrypted),
-    /* K40  */  be_const_int(2147483647),
-    /* K41  */  be_nested_str_weak(AES_CCM),
-    /* K42  */  be_nested_str_weak(TBEData3_Nonce),
-    /* K43  */  be_nested_str_weak(decrypt),
-    /* K44  */  be_nested_str_weak(tag),
-    /* K45  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20TBEData3_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K46  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20TBETag3_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K47  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20tag_sent_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K48  */  be_nested_str_weak(MTR_X3A_X20Tag_X20don_X27t_X20match),
-    /* K49  */  be_nested_str_weak(TLV),
-    /* K50  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20TBEData3TLV_X20_X20_X20_X3D_X20),
-    /* K51  */  be_nested_str_weak(findsubval),
-    /* K52  */  be_const_int(3),
-    /* K53  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20initiatorNOC_X20_X20_X3D_X20),
-    /* K54  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20initiatorICAC_X20_X3D_X20),
-    /* K55  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20ec_signature_X20_X20_X3D_X20),
-    /* K56  */  be_nested_str_weak(MTR_X3A_X20initiatorNOCTLV_X20_X3D_X20),
-    /* K57  */  be_nested_str_weak(findsub),
-    /* K58  */  be_nested_str_weak(int),
-    /* K59  */  be_nested_str_weak(peer_node_id),
-    /* K60  */  be_nested_str_weak(int64),
-    /* K61  */  be_nested_str_weak(fromu32),
-    /* K62  */  be_nested_str_weak(tobytes),
-    /* K63  */  be_nested_str_weak(MTR_X3A_X20initiatorFabricId_X3D),
-    /* K64  */  be_nested_str_weak(Matter_TLV_struct),
-    /* K65  */  be_nested_str_weak(add_TLV),
-    /* K66  */  be_nested_str_weak(B1),
-    /* K67  */  be_nested_str_weak(__initiator_pub),
-    /* K68  */  be_nested_str_weak(__responder_pub),
-    /* K69  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20sigma3_tbs_X20_X20_X20_X20_X3D_X20),
-    /* K70  */  be_nested_str_weak(tlv2raw),
-    /* K71  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20sigma3_tbs_raw_X3D_X20),
-    /* K72  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20initiatorNOCPubKey_X3D_X20),
-    /* K73  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20ec_signature_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K74  */  be_nested_str_weak(EC_P256),
-    /* K75  */  be_nested_str_weak(ecdsa_verify_sha256),
-    /* K76  */  be_nested_str_weak(MTR_X3A_X20sigma3_tbs_X20does_X20not_X20have_X20a_X20valid_X20signature),
-    /* K77  */  be_nested_str_weak(MTR_X3A_X20Sigma3_X20verified_X2C_X20computing_X20new_X20keys),
-    /* K78  */  be_nested_str_weak(Msg3),
-    /* K79  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20__Msg1_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K80  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20__Msg2_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K81  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20__Msg3_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K82  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20TranscriptHash_X20_X20_X20_X20_X3D_X20),
-    /* K83  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
-    /* K84  */  be_nested_str_weak(MTR_X3A_X20shared_secret_X20_X3D),
-    /* K85  */  be_nested_str_weak(MTR_X3A_X20ipk_X20_X2B_X20hash_X20_X20_X20_X20_X3D),
-    /* K86  */  be_nested_str_weak(SEKeys_Info),
-    /* K87  */  be_nested_str_weak(rtc),
-    /* K88  */  be_nested_str_weak(utc),
-    /* K89  */  be_nested_str_weak(MTR_X3A_X20I2RKey_X20_X20_X20_X20_X20_X20_X3D),
-    /* K90  */  be_nested_str_weak(MTR_X3A_X20R2IKey_X20_X20_X20_X20_X20_X20_X3D),
-    /* K91  */  be_nested_str_weak(MTR_X3A_X20AC_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
-    /* K92  */  be_nested_str_weak(close),
-    /* K93  */  be_nested_str_weak(set_keys),
-    /* K94  */  be_nested_str_weak(_breadcrumb),
-    /* K95  */  be_nested_str_weak(counter_snd_next),
-    /* K96  */  be_nested_str_weak(set_persist),
-    /* K97  */  be_nested_str_weak(set_no_expiration),
-    /* K98  */  be_nested_str_weak(persist_to_fabric),
-    /* K99  */  be_nested_str_weak(save),
+    /* K17  */  be_nested_str_weak(SHA256),
+    /* K18  */  be_nested_str_weak(update),
+    /* K19  */  be_nested_str_weak(__Msg1),
+    /* K20  */  be_nested_str_weak(__Msg2),
+    /* K21  */  be_nested_str_weak(out),
+    /* K22  */  be_nested_str_weak(fromstring),
+    /* K23  */  be_nested_str_weak(S3K_Info),
+    /* K24  */  be_nested_str_weak(HKDF_SHA256),
+    /* K25  */  be_nested_str_weak(derive),
+    /* K26  */  be_nested_str_weak(shared_secret),
+    /* K27  */  be_nested_str_weak(get_ipk_group_key),
+    /* K28  */  be_nested_str_weak(TBEData3Encrypted),
+    /* K29  */  be_const_int(2147483647),
+    /* K30  */  be_nested_str_weak(AES_CCM),
+    /* K31  */  be_nested_str_weak(TBEData3_Nonce),
+    /* K32  */  be_nested_str_weak(decrypt),
+    /* K33  */  be_nested_str_weak(tag),
+    /* K34  */  be_nested_str_weak(MTR_X3A_X20Tag_X20don_X27t_X20match),
+    /* K35  */  be_nested_str_weak(TLV),
+    /* K36  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20TBEData3TLV_X20_X20_X20_X3D_X20),
+    /* K37  */  be_nested_str_weak(findsubval),
+    /* K38  */  be_const_int(3),
+    /* K39  */  be_nested_str_weak(MTR_X3A_X20initiatorNOCTLV_X20_X3D_X20),
+    /* K40  */  be_nested_str_weak(findsub),
+    /* K41  */  be_nested_str_weak(int),
+    /* K42  */  be_nested_str_weak(peer_node_id),
+    /* K43  */  be_nested_str_weak(int64),
+    /* K44  */  be_nested_str_weak(fromu32),
+    /* K45  */  be_nested_str_weak(tobytes),
+    /* K46  */  be_nested_str_weak(MTR_X3A_X20initiatorFabricId_X3D),
+    /* K47  */  be_nested_str_weak(Matter_TLV_struct),
+    /* K48  */  be_nested_str_weak(add_TLV),
+    /* K49  */  be_nested_str_weak(B1),
+    /* K50  */  be_nested_str_weak(__initiator_pub),
+    /* K51  */  be_nested_str_weak(__responder_pub),
+    /* K52  */  be_nested_str_weak(tlv2raw),
+    /* K53  */  be_nested_str_weak(EC_P256),
+    /* K54  */  be_nested_str_weak(ecdsa_verify_sha256),
+    /* K55  */  be_nested_str_weak(MTR_X3A_X20sigma3_tbs_X20does_X20not_X20have_X20a_X20valid_X20signature),
+    /* K56  */  be_nested_str_weak(MTR_X3A_X20Sigma3_X20verified_X2C_X20computing_X20new_X20keys),
+    /* K57  */  be_nested_str_weak(Msg3),
+    /* K58  */  be_nested_str_weak(SEKeys_Info),
+    /* K59  */  be_nested_str_weak(rtc),
+    /* K60  */  be_nested_str_weak(utc),
+    /* K61  */  be_nested_str_weak(close),
+    /* K62  */  be_nested_str_weak(set_keys),
+    /* K63  */  be_nested_str_weak(_breadcrumb),
+    /* K64  */  be_nested_str_weak(counter_snd_next),
+    /* K65  */  be_nested_str_weak(set_persist),
+    /* K66  */  be_nested_str_weak(set_no_expiration),
+    /* K67  */  be_nested_str_weak(persist_to_fabric),
+    /* K68  */  be_nested_str_weak(save),
     }),
     be_str_weak(parse_Sigma3),
     &be_const_str_solidified,
-    ( &(const binstruction[562]) {  /* code */
+    ( &(const binstruction[319]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0x880C0301,  //  0001  GETMBR	R3	R1	K1
       0x54120031,  //  0002  LDINT	R4	50
@@ -1045,535 +992,292 @@ be_local_closure(Matter_Commisioning_Context_parse_Sigma3,   /* name */
       0x8818030F,  //  001E  GETMBR	R6	R1	K15
       0x881C0310,  //  001F  GETMBR	R7	R1	K16
       0x7C100600,  //  0020  CALL	R4	3
-      0xB8160A00,  //  0021  GETNGBL	R5	K5
-      0x8C140B06,  //  0022  GETMET	R5	R5	K6
-      0x581C0011,  //  0023  LDCONST	R7	K17
-      0x54220003,  //  0024  LDINT	R8	4
-      0x7C140600,  //  0025  CALL	R5	3
-      0x8C140512,  //  0026  GETMET	R5	R2	K18
-      0x7C140200,  //  0027  CALL	R5	1
-      0x8C140B13,  //  0028  GETMET	R5	R5	K19
-      0x881C0714,  //  0029  GETMBR	R7	R3	K20
-      0x7C140400,  //  002A  CALL	R5	2
-      0x8C140B13,  //  002B  GETMET	R5	R5	K19
-      0x881C0715,  //  002C  GETMBR	R7	R3	K21
-      0x7C140400,  //  002D  CALL	R5	2
-      0x8C140B16,  //  002E  GETMET	R5	R5	K22
-      0x7C140200,  //  002F  CALL	R5	1
-      0xB81A0A00,  //  0030  GETNGBL	R6	K5
-      0x8C180D06,  //  0031  GETMET	R6	R6	K6
-      0x60200008,  //  0032  GETGBL	R8	G8
-      0x5C240600,  //  0033  MOVE	R9	R3
-      0x7C200200,  //  0034  CALL	R8	1
-      0x00222E08,  //  0035  ADD	R8	K23	R8
-      0x54260003,  //  0036  LDINT	R9	4
-      0x7C180600,  //  0037  CALL	R6	3
-      0xB81A0A00,  //  0038  GETNGBL	R6	K5
-      0x8C180D06,  //  0039  GETMET	R6	R6	K6
-      0x60200008,  //  003A  GETGBL	R8	G8
-      0x8C240719,  //  003B  GETMET	R9	R3	K25
-      0x7C240200,  //  003C  CALL	R9	1
-      0x7C200200,  //  003D  CALL	R8	1
-      0x00223008,  //  003E  ADD	R8	K24	R8
-      0x54260003,  //  003F  LDINT	R9	4
-      0x7C180600,  //  0040  CALL	R6	3
-      0xB81A0A00,  //  0041  GETNGBL	R6	K5
-      0x8C180D06,  //  0042  GETMET	R6	R6	K6
-      0x60200008,  //  0043  GETGBL	R8	G8
-      0x8C24071B,  //  0044  GETMET	R9	R3	K27
-      0x7C240200,  //  0045  CALL	R9	1
-      0x7C200200,  //  0046  CALL	R8	1
-      0x00223408,  //  0047  ADD	R8	K26	R8
-      0x54260003,  //  0048  LDINT	R9	4
-      0x7C180600,  //  0049  CALL	R6	3
-      0xB81A0A00,  //  004A  GETNGBL	R6	K5
-      0x8C180D06,  //  004B  GETMET	R6	R6	K6
-      0x8C20071D,  //  004C  GETMET	R8	R3	K29
-      0x7C200200,  //  004D  CALL	R8	1
-      0x8C20111E,  //  004E  GETMET	R8	R8	K30
-      0x7C200200,  //  004F  CALL	R8	1
-      0x00223808,  //  0050  ADD	R8	K28	R8
-      0x54260003,  //  0051  LDINT	R9	4
-      0x7C180600,  //  0052  CALL	R6	3
-      0xB81A0A00,  //  0053  GETNGBL	R6	K5
-      0x8C180D06,  //  0054  GETMET	R6	R6	K6
-      0x8C200B1E,  //  0055  GETMET	R8	R5	K30
-      0x7C200200,  //  0056  CALL	R8	1
-      0x00223E08,  //  0057  ADD	R8	K31	R8
-      0x54260003,  //  0058  LDINT	R9	4
-      0x7C180600,  //  0059  CALL	R6	3
-      0x60180015,  //  005A  GETGBL	R6	G21
-      0x7C180000,  //  005B  CALL	R6	0
-      0x8C180D20,  //  005C  GETMET	R6	R6	K32
-      0x88200121,  //  005D  GETMBR	R8	R0	K33
-      0x7C180400,  //  005E  CALL	R6	2
-      0x8C1C0522,  //  005F  GETMET	R7	R2	K34
-      0x7C1C0200,  //  0060  CALL	R7	1
-      0x8C1C0F23,  //  0061  GETMET	R7	R7	K35
-      0x88240724,  //  0062  GETMBR	R9	R3	K36
-      0x8C28071D,  //  0063  GETMET	R10	R3	K29
-      0x7C280200,  //  0064  CALL	R10	1
-      0x00281405,  //  0065  ADD	R10	R10	R5
-      0x5C2C0C00,  //  0066  MOVE	R11	R6
-      0x5432000F,  //  0067  LDINT	R12	16
-      0x7C1C0A00,  //  0068  CALL	R7	5
-      0xB8220A00,  //  0069  GETNGBL	R8	K5
-      0x8C201106,  //  006A  GETMET	R8	R8	K6
-      0x58280011,  //  006B  LDCONST	R10	K17
-      0x542E0003,  //  006C  LDINT	R11	4
-      0x7C200600,  //  006D  CALL	R8	3
-      0xB8220A00,  //  006E  GETNGBL	R8	K5
-      0x8C201106,  //  006F  GETMET	R8	R8	K6
-      0x8C28071D,  //  0070  GETMET	R10	R3	K29
-      0x7C280200,  //  0071  CALL	R10	1
-      0x00281405,  //  0072  ADD	R10	R10	R5
-      0x8C28151E,  //  0073  GETMET	R10	R10	K30
-      0x7C280200,  //  0074  CALL	R10	1
-      0x002A4A0A,  //  0075  ADD	R10	K37	R10
-      0x542E0003,  //  0076  LDINT	R11	4
-      0x7C200600,  //  0077  CALL	R8	3
-      0xB8220A00,  //  0078  GETNGBL	R8	K5
-      0x8C201106,  //  0079  GETMET	R8	R8	K6
-      0x8C280F1E,  //  007A  GETMET	R10	R7	K30
-      0x7C280200,  //  007B  CALL	R10	1
-      0x002A4C0A,  //  007C  ADD	R10	K38	R10
-      0x542E0003,  //  007D  LDINT	R11	4
-      0x7C200600,  //  007E  CALL	R8	3
-      0xB8220A00,  //  007F  GETNGBL	R8	K5
-      0x8C201106,  //  0080  GETMET	R8	R8	K6
-      0x58280011,  //  0081  LDCONST	R10	K17
-      0x542E0003,  //  0082  LDINT	R11	4
-      0x7C200600,  //  0083  CALL	R8	3
-      0x5421FFEE,  //  0084  LDINT	R8	-17
-      0x40220608,  //  0085  CONNECT	R8	K3	R8
-      0x88240927,  //  0086  GETMBR	R9	R4	K39
-      0x94201208,  //  0087  GETIDX	R8	R9	R8
-      0x5429FFEF,  //  0088  LDINT	R10	-16
-      0x40281528,  //  0089  CONNECT	R10	R10	K40
-      0x882C0927,  //  008A  GETMBR	R11	R4	K39
-      0x9424160A,  //  008B  GETIDX	R9	R11	R10
-      0x8C300529,  //  008C  GETMET	R12	R2	K41
-      0x5C380E00,  //  008D  MOVE	R14	R7
-      0x603C0015,  //  008E  GETGBL	R15	G21
-      0x7C3C0000,  //  008F  CALL	R15	0
-      0x8C3C1F20,  //  0090  GETMET	R15	R15	K32
-      0x8844012A,  //  0091  GETMBR	R17	R0	K42
-      0x7C3C0400,  //  0092  CALL	R15	2
-      0x60400015,  //  0093  GETGBL	R16	G21
-      0x7C400000,  //  0094  CALL	R16	0
-      0x6044000C,  //  0095  GETGBL	R17	G12
-      0x5C481000,  //  0096  MOVE	R18	R8
-      0x7C440200,  //  0097  CALL	R17	1
-      0x544A000F,  //  0098  LDINT	R18	16
-      0x7C300C00,  //  0099  CALL	R12	6
-      0x5C281800,  //  009A  MOVE	R10	R12
-      0x8C30152B,  //  009B  GETMET	R12	R10	K43
-      0x5C381000,  //  009C  MOVE	R14	R8
-      0x7C300400,  //  009D  CALL	R12	2
-      0x5C2C1800,  //  009E  MOVE	R11	R12
-      0x8C30152C,  //  009F  GETMET	R12	R10	K44
-      0x7C300200,  //  00A0  CALL	R12	1
-      0xB8360A00,  //  00A1  GETNGBL	R13	K5
-      0x8C341B06,  //  00A2  GETMET	R13	R13	K6
-      0x8C3C171E,  //  00A3  GETMET	R15	R11	K30
-      0x7C3C0200,  //  00A4  CALL	R15	1
-      0x003E5A0F,  //  00A5  ADD	R15	K45	R15
-      0x54420003,  //  00A6  LDINT	R16	4
-      0x7C340600,  //  00A7  CALL	R13	3
-      0xB8360A00,  //  00A8  GETNGBL	R13	K5
-      0x8C341B06,  //  00A9  GETMET	R13	R13	K6
-      0x8C3C191E,  //  00AA  GETMET	R15	R12	K30
-      0x7C3C0200,  //  00AB  CALL	R15	1
-      0x003E5C0F,  //  00AC  ADD	R15	K46	R15
-      0x54420003,  //  00AD  LDINT	R16	4
-      0x7C340600,  //  00AE  CALL	R13	3
-      0xB8360A00,  //  00AF  GETNGBL	R13	K5
-      0x8C341B06,  //  00B0  GETMET	R13	R13	K6
-      0x8C3C131E,  //  00B1  GETMET	R15	R9	K30
-      0x7C3C0200,  //  00B2  CALL	R15	1
-      0x003E5E0F,  //  00B3  ADD	R15	K47	R15
-      0x54420003,  //  00B4  LDINT	R16	4
-      0x7C340600,  //  00B5  CALL	R13	3
-      0xB8360A00,  //  00B6  GETNGBL	R13	K5
-      0x8C341B06,  //  00B7  GETMET	R13	R13	K6
-      0x583C0011,  //  00B8  LDCONST	R15	K17
-      0x54420003,  //  00B9  LDINT	R16	4
-      0x7C340600,  //  00BA  CALL	R13	3
-      0x20341809,  //  00BB  NE	R13	R12	R9
-      0x78360012,  //  00BC  JMPF	R13	#00D0
-      0xB8360A00,  //  00BD  GETNGBL	R13	K5
-      0x8C341B06,  //  00BE  GETMET	R13	R13	K6
-      0x583C0030,  //  00BF  LDCONST	R15	K48
-      0x58400008,  //  00C0  LDCONST	R16	K8
-      0x7C340600,  //  00C1  CALL	R13	3
-      0xB8360A00,  //  00C2  GETNGBL	R13	K5
-      0x8C341B06,  //  00C3  GETMET	R13	R13	K6
-      0x583C0007,  //  00C4  LDCONST	R15	K7
-      0x58400008,  //  00C5  LDCONST	R16	K8
-      0x7C340600,  //  00C6  CALL	R13	3
-      0x8C340109,  //  00C7  GETMET	R13	R0	K9
-      0x5C3C0200,  //  00C8  MOVE	R15	R1
-      0x5840000A,  //  00C9  LDCONST	R16	K10
-      0x58440003,  //  00CA  LDCONST	R17	K3
-      0x58480008,  //  00CB  LDCONST	R18	K8
-      0x504C0000,  //  00CC  LDBOOL	R19	0	0
-      0x7C340C00,  //  00CD  CALL	R13	6
-      0x50380000,  //  00CE  LDBOOL	R14	0	0
-      0x80041C00,  //  00CF  RET	1	R14
-      0xB8361800,  //  00D0  GETNGBL	R13	K12
-      0x88341B31,  //  00D1  GETMBR	R13	R13	K49
-      0x8C341B0E,  //  00D2  GETMET	R13	R13	K14
-      0x5C3C1600,  //  00D3  MOVE	R15	R11
-      0x7C340400,  //  00D4  CALL	R13	2
-      0xB83A0A00,  //  00D5  GETNGBL	R14	K5
-      0x8C381D06,  //  00D6  GETMET	R14	R14	K6
-      0x60400008,  //  00D7  GETGBL	R16	G8
-      0x5C441A00,  //  00D8  MOVE	R17	R13
-      0x7C400200,  //  00D9  CALL	R16	1
-      0x00426410,  //  00DA  ADD	R16	K50	R16
-      0x54460003,  //  00DB  LDINT	R17	4
-      0x7C380600,  //  00DC  CALL	R14	3
-      0x8C381B33,  //  00DD  GETMET	R14	R13	K51
-      0x5840000A,  //  00DE  LDCONST	R16	K10
-      0x7C380400,  //  00DF  CALL	R14	2
-      0x8C3C1B33,  //  00E0  GETMET	R15	R13	K51
-      0x58440008,  //  00E1  LDCONST	R17	K8
-      0x7C3C0400,  //  00E2  CALL	R15	2
-      0x8C401B33,  //  00E3  GETMET	R16	R13	K51
-      0x58480034,  //  00E4  LDCONST	R18	K52
-      0x7C400400,  //  00E5  CALL	R16	2
-      0xB8460A00,  //  00E6  GETNGBL	R17	K5
-      0x8C442306,  //  00E7  GETMET	R17	R17	K6
-      0x604C0008,  //  00E8  GETGBL	R19	G8
-      0x5C501C00,  //  00E9  MOVE	R20	R14
-      0x7C4C0200,  //  00EA  CALL	R19	1
-      0x004E6A13,  //  00EB  ADD	R19	K53	R19
-      0x54520003,  //  00EC  LDINT	R20	4
-      0x7C440600,  //  00ED  CALL	R17	3
-      0xB8460A00,  //  00EE  GETNGBL	R17	K5
-      0x8C442306,  //  00EF  GETMET	R17	R17	K6
-      0x604C0008,  //  00F0  GETGBL	R19	G8
-      0x5C501E00,  //  00F1  MOVE	R20	R15
-      0x7C4C0200,  //  00F2  CALL	R19	1
-      0x004E6C13,  //  00F3  ADD	R19	K54	R19
-      0x54520003,  //  00F4  LDINT	R20	4
-      0x7C440600,  //  00F5  CALL	R17	3
-      0xB8460A00,  //  00F6  GETNGBL	R17	K5
-      0x8C442306,  //  00F7  GETMET	R17	R17	K6
-      0x604C0008,  //  00F8  GETGBL	R19	G8
-      0x5C502000,  //  00F9  MOVE	R20	R16
-      0x7C4C0200,  //  00FA  CALL	R19	1
-      0x004E6E13,  //  00FB  ADD	R19	K55	R19
-      0x54520003,  //  00FC  LDINT	R20	4
-      0x7C440600,  //  00FD  CALL	R17	3
-      0xB8461800,  //  00FE  GETNGBL	R17	K12
-      0x88442331,  //  00FF  GETMBR	R17	R17	K49
-      0x8C44230E,  //  0100  GETMET	R17	R17	K14
-      0x5C4C1C00,  //  0101  MOVE	R19	R14
-      0x7C440400,  //  0102  CALL	R17	2
-      0xB84A0A00,  //  0103  GETNGBL	R18	K5
-      0x8C482506,  //  0104  GETMET	R18	R18	K6
-      0x60500008,  //  0105  GETGBL	R20	G8
-      0x5C542200,  //  0106  MOVE	R21	R17
-      0x7C500200,  //  0107  CALL	R20	1
-      0x00527014,  //  0108  ADD	R20	K56	R20
-      0x58540034,  //  0109  LDCONST	R21	K52
-      0x7C480600,  //  010A  CALL	R18	3
-      0x8C482333,  //  010B  GETMET	R18	R17	K51
-      0x54520008,  //  010C  LDINT	R20	9
-      0x7C480400,  //  010D  CALL	R18	2
-      0x8C4C2339,  //  010E  GETMET	R19	R17	K57
-      0x54560005,  //  010F  LDINT	R21	6
-      0x7C4C0400,  //  0110  CALL	R19	2
-      0x8C502733,  //  0111  GETMET	R20	R19	K51
-      0x545A0010,  //  0112  LDINT	R22	17
-      0x7C500400,  //  0113  CALL	R20	2
-      0x60540004,  //  0114  GETGBL	R21	G4
-      0x5C582800,  //  0115  MOVE	R22	R20
-      0x7C540200,  //  0116  CALL	R21	1
-      0x1C542B3A,  //  0117  EQ	R21	R21	K58
-      0x78560007,  //  0118  JMPF	R21	#0121
-      0xB8567800,  //  0119  GETNGBL	R21	K60
-      0x8C542B3D,  //  011A  GETMET	R21	R21	K61
-      0x5C5C2800,  //  011B  MOVE	R23	R20
-      0x7C540400,  //  011C  CALL	R21	2
-      0x8C542B3E,  //  011D  GETMET	R21	R21	K62
-      0x7C540200,  //  011E  CALL	R21	1
-      0x900E7615,  //  011F  SETMBR	R3	K59	R21
-      0x70020002,  //  0120  JMP		#0124
-      0x8C54293E,  //  0121  GETMET	R21	R20	K62
-      0x7C540200,  //  0122  CALL	R21	1
-      0x900E7615,  //  0123  SETMBR	R3	K59	R21
-      0xB8560A00,  //  0124  GETNGBL	R21	K5
-      0x8C542B06,  //  0125  GETMET	R21	R21	K6
-      0x605C0008,  //  0126  GETGBL	R23	G8
-      0x8860073B,  //  0127  GETMBR	R24	R3	K59
-      0x7C5C0200,  //  0128  CALL	R23	1
-      0x005E7E17,  //  0129  ADD	R23	K63	R23
-      0x58600034,  //  012A  LDCONST	R24	K52
-      0x7C540600,  //  012B  CALL	R21	3
-      0xB8561800,  //  012C  GETNGBL	R21	K12
-      0x88542B31,  //  012D  GETMBR	R21	R21	K49
-      0x8C542B40,  //  012E  GETMET	R21	R21	K64
-      0x7C540200,  //  012F  CALL	R21	1
-      0x8C582B41,  //  0130  GETMET	R22	R21	K65
-      0x5860000A,  //  0131  LDCONST	R24	K10
-      0xB8661800,  //  0132  GETNGBL	R25	K12
-      0x88643331,  //  0133  GETMBR	R25	R25	K49
-      0x88643342,  //  0134  GETMBR	R25	R25	K66
-      0x5C681C00,  //  0135  MOVE	R26	R14
-      0x7C580800,  //  0136  CALL	R22	4
-      0x8C582B41,  //  0137  GETMET	R22	R21	K65
-      0x58600008,  //  0138  LDCONST	R24	K8
-      0xB8661800,  //  0139  GETNGBL	R25	K12
-      0x88643331,  //  013A  GETMBR	R25	R25	K49
-      0x88643342,  //  013B  GETMBR	R25	R25	K66
-      0x5C681E00,  //  013C  MOVE	R26	R15
-      0x7C580800,  //  013D  CALL	R22	4
-      0x8C582B41,  //  013E  GETMET	R22	R21	K65
-      0x58600034,  //  013F  LDCONST	R24	K52
-      0xB8661800,  //  0140  GETNGBL	R25	K12
-      0x88643331,  //  0141  GETMBR	R25	R25	K49
-      0x88643342,  //  0142  GETMBR	R25	R25	K66
-      0x88680743,  //  0143  GETMBR	R26	R3	K67
-      0x7C580800,  //  0144  CALL	R22	4
-      0x8C582B41,  //  0145  GETMET	R22	R21	K65
-      0x54620003,  //  0146  LDINT	R24	4
-      0xB8661800,  //  0147  GETNGBL	R25	K12
-      0x88643331,  //  0148  GETMBR	R25	R25	K49
-      0x88643342,  //  0149  GETMBR	R25	R25	K66
-      0x88680744,  //  014A  GETMBR	R26	R3	K68
-      0x7C580800,  //  014B  CALL	R22	4
-      0xB85A0A00,  //  014C  GETNGBL	R22	K5
-      0x8C582D06,  //  014D  GETMET	R22	R22	K6
-      0x60600008,  //  014E  GETGBL	R24	G8
-      0x5C642A00,  //  014F  MOVE	R25	R21
-      0x7C600200,  //  0150  CALL	R24	1
-      0x00628A18,  //  0151  ADD	R24	K69	R24
-      0x54660003,  //  0152  LDINT	R25	4
-      0x7C580600,  //  0153  CALL	R22	3
-      0x8C582B46,  //  0154  GETMET	R22	R21	K70
-      0x7C580200,  //  0155  CALL	R22	1
-      0xB85E0A00,  //  0156  GETNGBL	R23	K5
-      0x8C5C2F06,  //  0157  GETMET	R23	R23	K6
-      0x8C642D1E,  //  0158  GETMET	R25	R22	K30
-      0x7C640200,  //  0159  CALL	R25	1
-      0x00668E19,  //  015A  ADD	R25	K71	R25
-      0x546A0003,  //  015B  LDINT	R26	4
-      0x7C5C0600,  //  015C  CALL	R23	3
-      0xB85E0A00,  //  015D  GETNGBL	R23	K5
-      0x8C5C2F06,  //  015E  GETMET	R23	R23	K6
-      0x8C64251E,  //  015F  GETMET	R25	R18	K30
-      0x7C640200,  //  0160  CALL	R25	1
-      0x00669019,  //  0161  ADD	R25	K72	R25
-      0x546A0003,  //  0162  LDINT	R26	4
-      0x7C5C0600,  //  0163  CALL	R23	3
-      0xB85E0A00,  //  0164  GETNGBL	R23	K5
-      0x8C5C2F06,  //  0165  GETMET	R23	R23	K6
-      0x8C64211E,  //  0166  GETMET	R25	R16	K30
-      0x7C640200,  //  0167  CALL	R25	1
-      0x00669219,  //  0168  ADD	R25	K73	R25
-      0x546A0003,  //  0169  LDINT	R26	4
-      0x7C5C0600,  //  016A  CALL	R23	3
-      0xB85E0A00,  //  016B  GETNGBL	R23	K5
-      0x8C5C2F06,  //  016C  GETMET	R23	R23	K6
-      0x58640011,  //  016D  LDCONST	R25	K17
-      0x546A0003,  //  016E  LDINT	R26	4
-      0x7C5C0600,  //  016F  CALL	R23	3
-      0x8C5C054A,  //  0170  GETMET	R23	R2	K74
-      0x7C5C0200,  //  0171  CALL	R23	1
-      0x8C5C2F4B,  //  0172  GETMET	R23	R23	K75
-      0x5C642400,  //  0173  MOVE	R25	R18
-      0x5C682C00,  //  0174  MOVE	R26	R22
-      0x5C6C2000,  //  0175  MOVE	R27	R16
-      0x7C5C0800,  //  0176  CALL	R23	4
-      0x5C602E00,  //  0177  MOVE	R24	R23
-      0x74620012,  //  0178  JMPT	R24	#018C
-      0xB8620A00,  //  0179  GETNGBL	R24	K5
-      0x8C603106,  //  017A  GETMET	R24	R24	K6
-      0x5868004C,  //  017B  LDCONST	R26	K76
-      0x586C0008,  //  017C  LDCONST	R27	K8
-      0x7C600600,  //  017D  CALL	R24	3
-      0xB8620A00,  //  017E  GETNGBL	R24	K5
-      0x8C603106,  //  017F  GETMET	R24	R24	K6
-      0x58680007,  //  0180  LDCONST	R26	K7
-      0x586C0008,  //  0181  LDCONST	R27	K8
-      0x7C600600,  //  0182  CALL	R24	3
-      0x8C600109,  //  0183  GETMET	R24	R0	K9
-      0x5C680200,  //  0184  MOVE	R26	R1
-      0x586C000A,  //  0185  LDCONST	R27	K10
-      0x58700003,  //  0186  LDCONST	R28	K3
-      0x58740008,  //  0187  LDCONST	R29	K8
-      0x50780000,  //  0188  LDBOOL	R30	0	0
-      0x7C600C00,  //  0189  CALL	R24	6
-      0x50640000,  //  018A  LDBOOL	R25	0	0
-      0x80043200,  //  018B  RET	1	R25
-      0xB8620A00,  //  018C  GETNGBL	R24	K5
-      0x8C603106,  //  018D  GETMET	R24	R24	K6
-      0x5868004D,  //  018E  LDCONST	R26	K77
-      0x586C0034,  //  018F  LDCONST	R27	K52
-      0x7C600600,  //  0190  CALL	R24	3
-      0x8C600512,  //  0191  GETMET	R24	R2	K18
-      0x7C600200,  //  0192  CALL	R24	1
-      0x8C603113,  //  0193  GETMET	R24	R24	K19
-      0x88680714,  //  0194  GETMBR	R26	R3	K20
-      0x7C600400,  //  0195  CALL	R24	2
-      0x8C603113,  //  0196  GETMET	R24	R24	K19
-      0x88680715,  //  0197  GETMBR	R26	R3	K21
-      0x7C600400,  //  0198  CALL	R24	2
-      0x8C603113,  //  0199  GETMET	R24	R24	K19
-      0x8868094E,  //  019A  GETMBR	R26	R4	K78
-      0x7C600400,  //  019B  CALL	R24	2
-      0x8C603116,  //  019C  GETMET	R24	R24	K22
-      0x7C600200,  //  019D  CALL	R24	1
-      0x5C143000,  //  019E  MOVE	R5	R24
-      0xB8620A00,  //  019F  GETNGBL	R24	K5
-      0x8C603106,  //  01A0  GETMET	R24	R24	K6
-      0x88680714,  //  01A1  GETMBR	R26	R3	K20
-      0x8C68351E,  //  01A2  GETMET	R26	R26	K30
-      0x7C680200,  //  01A3  CALL	R26	1
-      0x006A9E1A,  //  01A4  ADD	R26	K79	R26
-      0x546E0003,  //  01A5  LDINT	R27	4
-      0x7C600600,  //  01A6  CALL	R24	3
-      0xB8620A00,  //  01A7  GETNGBL	R24	K5
-      0x8C603106,  //  01A8  GETMET	R24	R24	K6
-      0x88680715,  //  01A9  GETMBR	R26	R3	K21
-      0x8C68351E,  //  01AA  GETMET	R26	R26	K30
-      0x7C680200,  //  01AB  CALL	R26	1
-      0x006AA01A,  //  01AC  ADD	R26	K80	R26
-      0x546E0003,  //  01AD  LDINT	R27	4
-      0x7C600600,  //  01AE  CALL	R24	3
-      0xB8620A00,  //  01AF  GETNGBL	R24	K5
-      0x8C603106,  //  01B0  GETMET	R24	R24	K6
-      0x8868094E,  //  01B1  GETMBR	R26	R4	K78
-      0x8C68351E,  //  01B2  GETMET	R26	R26	K30
-      0x7C680200,  //  01B3  CALL	R26	1
-      0x006AA21A,  //  01B4  ADD	R26	K81	R26
-      0x546E0003,  //  01B5  LDINT	R27	4
-      0x7C600600,  //  01B6  CALL	R24	3
-      0xB8620A00,  //  01B7  GETNGBL	R24	K5
-      0x8C603106,  //  01B8  GETMET	R24	R24	K6
-      0x8C680B1E,  //  01B9  GETMET	R26	R5	K30
-      0x7C680200,  //  01BA  CALL	R26	1
-      0x006AA41A,  //  01BB  ADD	R26	K82	R26
-      0x546E0003,  //  01BC  LDINT	R27	4
-      0x7C600600,  //  01BD  CALL	R24	3
-      0x4C600000,  //  01BE  LDNIL	R24
-      0x900E2818,  //  01BF  SETMBR	R3	K20	R24
-      0x4C600000,  //  01C0  LDNIL	R24
-      0x900E2A18,  //  01C1  SETMBR	R3	K21	R24
-      0xB8620A00,  //  01C2  GETNGBL	R24	K5
-      0x8C603106,  //  01C3  GETMET	R24	R24	K6
-      0x58680053,  //  01C4  LDCONST	R26	K83
-      0x546E0003,  //  01C5  LDINT	R27	4
-      0x7C600600,  //  01C6  CALL	R24	3
-      0xB8620A00,  //  01C7  GETNGBL	R24	K5
-      0x8C603106,  //  01C8  GETMET	R24	R24	K6
-      0x88680724,  //  01C9  GETMBR	R26	R3	K36
-      0x8C68351E,  //  01CA  GETMET	R26	R26	K30
-      0x7C680200,  //  01CB  CALL	R26	1
-      0x006AA81A,  //  01CC  ADD	R26	K84	R26
-      0x546E0003,  //  01CD  LDINT	R27	4
-      0x7C600600,  //  01CE  CALL	R24	3
-      0xB8620A00,  //  01CF  GETNGBL	R24	K5
-      0x8C603106,  //  01D0  GETMET	R24	R24	K6
-      0x8C68071D,  //  01D1  GETMET	R26	R3	K29
-      0x7C680200,  //  01D2  CALL	R26	1
-      0x00683405,  //  01D3  ADD	R26	R26	R5
-      0x8C68351E,  //  01D4  GETMET	R26	R26	K30
-      0x7C680200,  //  01D5  CALL	R26	1
-      0x006AAA1A,  //  01D6  ADD	R26	K85	R26
-      0x546E0003,  //  01D7  LDINT	R27	4
-      0x7C600600,  //  01D8  CALL	R24	3
-      0x8C600522,  //  01D9  GETMET	R24	R2	K34
-      0x7C600200,  //  01DA  CALL	R24	1
-      0x8C603123,  //  01DB  GETMET	R24	R24	K35
-      0x88680724,  //  01DC  GETMBR	R26	R3	K36
-      0x8C6C071D,  //  01DD  GETMET	R27	R3	K29
-      0x7C6C0200,  //  01DE  CALL	R27	1
-      0x006C3605,  //  01DF  ADD	R27	R27	R5
-      0x60700015,  //  01E0  GETGBL	R28	G21
-      0x7C700000,  //  01E1  CALL	R28	0
-      0x8C703920,  //  01E2  GETMET	R28	R28	K32
-      0x88780156,  //  01E3  GETMBR	R30	R0	K86
-      0x7C700400,  //  01E4  CALL	R28	2
-      0x5476002F,  //  01E5  LDINT	R29	48
-      0x7C600A00,  //  01E6  CALL	R24	5
-      0x5466000E,  //  01E7  LDINT	R25	15
-      0x40660619,  //  01E8  CONNECT	R25	K3	R25
-      0x94643019,  //  01E9  GETIDX	R25	R24	R25
-      0x546A000F,  //  01EA  LDINT	R26	16
-      0x546E001E,  //  01EB  LDINT	R27	31
-      0x4068341B,  //  01EC  CONNECT	R26	R26	R27
-      0x9468301A,  //  01ED  GETIDX	R26	R24	R26
-      0x546E001F,  //  01EE  LDINT	R27	32
-      0x5472002E,  //  01EF  LDINT	R28	47
-      0x406C361C,  //  01F0  CONNECT	R27	R27	R28
-      0x946C301B,  //  01F1  GETIDX	R27	R24	R27
-      0xB8720A00,  //  01F2  GETNGBL	R28	K5
-      0x8C703957,  //  01F3  GETMET	R28	R28	K87
-      0x7C700200,  //  01F4  CALL	R28	1
-      0x94703958,  //  01F5  GETIDX	R28	R28	K88
-      0xB8760A00,  //  01F6  GETNGBL	R29	K5
-      0x8C743B06,  //  01F7  GETMET	R29	R29	K6
-      0x587C0053,  //  01F8  LDCONST	R31	K83
-      0x54820003,  //  01F9  LDINT	R32	4
-      0x7C740600,  //  01FA  CALL	R29	3
-      0xB8760A00,  //  01FB  GETNGBL	R29	K5
-      0x8C743B06,  //  01FC  GETMET	R29	R29	K6
-      0x8C7C331E,  //  01FD  GETMET	R31	R25	K30
-      0x7C7C0200,  //  01FE  CALL	R31	1
-      0x007EB21F,  //  01FF  ADD	R31	K89	R31
-      0x54820003,  //  0200  LDINT	R32	4
-      0x7C740600,  //  0201  CALL	R29	3
-      0xB8760A00,  //  0202  GETNGBL	R29	K5
-      0x8C743B06,  //  0203  GETMET	R29	R29	K6
-      0x8C7C351E,  //  0204  GETMET	R31	R26	K30
-      0x7C7C0200,  //  0205  CALL	R31	1
-      0x007EB41F,  //  0206  ADD	R31	K90	R31
-      0x54820003,  //  0207  LDINT	R32	4
-      0x7C740600,  //  0208  CALL	R29	3
-      0xB8760A00,  //  0209  GETNGBL	R29	K5
-      0x8C743B06,  //  020A  GETMET	R29	R29	K6
-      0x8C7C371E,  //  020B  GETMET	R31	R27	K30
-      0x7C7C0200,  //  020C  CALL	R31	1
-      0x007EB61F,  //  020D  ADD	R31	K91	R31
-      0x54820003,  //  020E  LDINT	R32	4
-      0x7C740600,  //  020F  CALL	R29	3
-      0xB8760A00,  //  0210  GETNGBL	R29	K5
-      0x8C743B06,  //  0211  GETMET	R29	R29	K6
-      0x587C0053,  //  0212  LDCONST	R31	K83
-      0x54820003,  //  0213  LDINT	R32	4
-      0x7C740600,  //  0214  CALL	R29	3
-      0x8C740109,  //  0215  GETMET	R29	R0	K9
-      0x5C7C0200,  //  0216  MOVE	R31	R1
-      0x58800003,  //  0217  LDCONST	R32	K3
-      0x58840003,  //  0218  LDCONST	R33	K3
-      0x58880003,  //  0219  LDCONST	R34	K3
-      0x508C0200,  //  021A  LDBOOL	R35	1	0
-      0x7C740C00,  //  021B  CALL	R29	6
-      0x8C78075C,  //  021C  GETMET	R30	R3	K92
-      0x7C780200,  //  021D  CALL	R30	1
-      0x8C78075D,  //  021E  GETMET	R30	R3	K93
-      0x5C803200,  //  021F  MOVE	R32	R25
-      0x5C843400,  //  0220  MOVE	R33	R26
-      0x5C883600,  //  0221  MOVE	R34	R27
-      0x5C8C3800,  //  0222  MOVE	R35	R28
-      0x7C780A00,  //  0223  CALL	R30	5
-      0x900EBD03,  //  0224  SETMBR	R3	K94	K3
-      0x8C78075F,  //  0225  GETMET	R30	R3	K95
-      0x7C780200,  //  0226  CALL	R30	1
-      0x8C780760,  //  0227  GETMET	R30	R3	K96
-      0x50800200,  //  0228  LDBOOL	R32	1	0
-      0x7C780400,  //  0229  CALL	R30	2
-      0x8C780761,  //  022A  GETMET	R30	R3	K97
-      0x7C780200,  //  022B  CALL	R30	1
-      0x8C780762,  //  022C  GETMET	R30	R3	K98
-      0x7C780200,  //  022D  CALL	R30	1
-      0x8C780763,  //  022E  GETMET	R30	R3	K99
-      0x7C780200,  //  022F  CALL	R30	1
-      0x50780200,  //  0230  LDBOOL	R30	1	0
-      0x80043C00,  //  0231  RET	1	R30
+      0x8C140511,  //  0021  GETMET	R5	R2	K17
+      0x7C140200,  //  0022  CALL	R5	1
+      0x8C140B12,  //  0023  GETMET	R5	R5	K18
+      0x881C0713,  //  0024  GETMBR	R7	R3	K19
+      0x7C140400,  //  0025  CALL	R5	2
+      0x8C140B12,  //  0026  GETMET	R5	R5	K18
+      0x881C0714,  //  0027  GETMBR	R7	R3	K20
+      0x7C140400,  //  0028  CALL	R5	2
+      0x8C140B15,  //  0029  GETMET	R5	R5	K21
+      0x7C140200,  //  002A  CALL	R5	1
+      0x60180015,  //  002B  GETGBL	R6	G21
+      0x7C180000,  //  002C  CALL	R6	0
+      0x8C180D16,  //  002D  GETMET	R6	R6	K22
+      0x88200117,  //  002E  GETMBR	R8	R0	K23
+      0x7C180400,  //  002F  CALL	R6	2
+      0x8C1C0518,  //  0030  GETMET	R7	R2	K24
+      0x7C1C0200,  //  0031  CALL	R7	1
+      0x8C1C0F19,  //  0032  GETMET	R7	R7	K25
+      0x8824071A,  //  0033  GETMBR	R9	R3	K26
+      0x8C28071B,  //  0034  GETMET	R10	R3	K27
+      0x7C280200,  //  0035  CALL	R10	1
+      0x00281405,  //  0036  ADD	R10	R10	R5
+      0x5C2C0C00,  //  0037  MOVE	R11	R6
+      0x5432000F,  //  0038  LDINT	R12	16
+      0x7C1C0A00,  //  0039  CALL	R7	5
+      0x5421FFEE,  //  003A  LDINT	R8	-17
+      0x40220608,  //  003B  CONNECT	R8	K3	R8
+      0x8824091C,  //  003C  GETMBR	R9	R4	K28
+      0x94201208,  //  003D  GETIDX	R8	R9	R8
+      0x5429FFEF,  //  003E  LDINT	R10	-16
+      0x4028151D,  //  003F  CONNECT	R10	R10	K29
+      0x882C091C,  //  0040  GETMBR	R11	R4	K28
+      0x9424160A,  //  0041  GETIDX	R9	R11	R10
+      0x8C30051E,  //  0042  GETMET	R12	R2	K30
+      0x5C380E00,  //  0043  MOVE	R14	R7
+      0x603C0015,  //  0044  GETGBL	R15	G21
+      0x7C3C0000,  //  0045  CALL	R15	0
+      0x8C3C1F16,  //  0046  GETMET	R15	R15	K22
+      0x8844011F,  //  0047  GETMBR	R17	R0	K31
+      0x7C3C0400,  //  0048  CALL	R15	2
+      0x60400015,  //  0049  GETGBL	R16	G21
+      0x7C400000,  //  004A  CALL	R16	0
+      0x6044000C,  //  004B  GETGBL	R17	G12
+      0x5C481000,  //  004C  MOVE	R18	R8
+      0x7C440200,  //  004D  CALL	R17	1
+      0x544A000F,  //  004E  LDINT	R18	16
+      0x7C300C00,  //  004F  CALL	R12	6
+      0x5C281800,  //  0050  MOVE	R10	R12
+      0x8C301520,  //  0051  GETMET	R12	R10	K32
+      0x5C381000,  //  0052  MOVE	R14	R8
+      0x7C300400,  //  0053  CALL	R12	2
+      0x5C2C1800,  //  0054  MOVE	R11	R12
+      0x8C301521,  //  0055  GETMET	R12	R10	K33
+      0x7C300200,  //  0056  CALL	R12	1
+      0x20341809,  //  0057  NE	R13	R12	R9
+      0x78360012,  //  0058  JMPF	R13	#006C
+      0xB8360A00,  //  0059  GETNGBL	R13	K5
+      0x8C341B06,  //  005A  GETMET	R13	R13	K6
+      0x583C0022,  //  005B  LDCONST	R15	K34
+      0x58400008,  //  005C  LDCONST	R16	K8
+      0x7C340600,  //  005D  CALL	R13	3
+      0xB8360A00,  //  005E  GETNGBL	R13	K5
+      0x8C341B06,  //  005F  GETMET	R13	R13	K6
+      0x583C0007,  //  0060  LDCONST	R15	K7
+      0x58400008,  //  0061  LDCONST	R16	K8
+      0x7C340600,  //  0062  CALL	R13	3
+      0x8C340109,  //  0063  GETMET	R13	R0	K9
+      0x5C3C0200,  //  0064  MOVE	R15	R1
+      0x5840000A,  //  0065  LDCONST	R16	K10
+      0x58440003,  //  0066  LDCONST	R17	K3
+      0x58480008,  //  0067  LDCONST	R18	K8
+      0x504C0000,  //  0068  LDBOOL	R19	0	0
+      0x7C340C00,  //  0069  CALL	R13	6
+      0x50380000,  //  006A  LDBOOL	R14	0	0
+      0x80041C00,  //  006B  RET	1	R14
+      0xB8361800,  //  006C  GETNGBL	R13	K12
+      0x88341B23,  //  006D  GETMBR	R13	R13	K35
+      0x8C341B0E,  //  006E  GETMET	R13	R13	K14
+      0x5C3C1600,  //  006F  MOVE	R15	R11
+      0x7C340400,  //  0070  CALL	R13	2
+      0xB83A0A00,  //  0071  GETNGBL	R14	K5
+      0x8C381D06,  //  0072  GETMET	R14	R14	K6
+      0x60400008,  //  0073  GETGBL	R16	G8
+      0x5C441A00,  //  0074  MOVE	R17	R13
+      0x7C400200,  //  0075  CALL	R16	1
+      0x00424810,  //  0076  ADD	R16	K36	R16
+      0x54460003,  //  0077  LDINT	R17	4
+      0x7C380600,  //  0078  CALL	R14	3
+      0x8C381B25,  //  0079  GETMET	R14	R13	K37
+      0x5840000A,  //  007A  LDCONST	R16	K10
+      0x7C380400,  //  007B  CALL	R14	2
+      0x8C3C1B25,  //  007C  GETMET	R15	R13	K37
+      0x58440008,  //  007D  LDCONST	R17	K8
+      0x7C3C0400,  //  007E  CALL	R15	2
+      0x8C401B25,  //  007F  GETMET	R16	R13	K37
+      0x58480026,  //  0080  LDCONST	R18	K38
+      0x7C400400,  //  0081  CALL	R16	2
+      0xB8461800,  //  0082  GETNGBL	R17	K12
+      0x88442323,  //  0083  GETMBR	R17	R17	K35
+      0x8C44230E,  //  0084  GETMET	R17	R17	K14
+      0x5C4C1C00,  //  0085  MOVE	R19	R14
+      0x7C440400,  //  0086  CALL	R17	2
+      0xB84A0A00,  //  0087  GETNGBL	R18	K5
+      0x8C482506,  //  0088  GETMET	R18	R18	K6
+      0x60500008,  //  0089  GETGBL	R20	G8
+      0x5C542200,  //  008A  MOVE	R21	R17
+      0x7C500200,  //  008B  CALL	R20	1
+      0x00524E14,  //  008C  ADD	R20	K39	R20
+      0x58540026,  //  008D  LDCONST	R21	K38
+      0x7C480600,  //  008E  CALL	R18	3
+      0x8C482325,  //  008F  GETMET	R18	R17	K37
+      0x54520008,  //  0090  LDINT	R20	9
+      0x7C480400,  //  0091  CALL	R18	2
+      0x8C4C2328,  //  0092  GETMET	R19	R17	K40
+      0x54560005,  //  0093  LDINT	R21	6
+      0x7C4C0400,  //  0094  CALL	R19	2
+      0x8C502725,  //  0095  GETMET	R20	R19	K37
+      0x545A0010,  //  0096  LDINT	R22	17
+      0x7C500400,  //  0097  CALL	R20	2
+      0x60540004,  //  0098  GETGBL	R21	G4
+      0x5C582800,  //  0099  MOVE	R22	R20
+      0x7C540200,  //  009A  CALL	R21	1
+      0x1C542B29,  //  009B  EQ	R21	R21	K41
+      0x78560007,  //  009C  JMPF	R21	#00A5
+      0xB8565600,  //  009D  GETNGBL	R21	K43
+      0x8C542B2C,  //  009E  GETMET	R21	R21	K44
+      0x5C5C2800,  //  009F  MOVE	R23	R20
+      0x7C540400,  //  00A0  CALL	R21	2
+      0x8C542B2D,  //  00A1  GETMET	R21	R21	K45
+      0x7C540200,  //  00A2  CALL	R21	1
+      0x900E5415,  //  00A3  SETMBR	R3	K42	R21
+      0x70020002,  //  00A4  JMP		#00A8
+      0x8C54292D,  //  00A5  GETMET	R21	R20	K45
+      0x7C540200,  //  00A6  CALL	R21	1
+      0x900E5415,  //  00A7  SETMBR	R3	K42	R21
+      0xB8560A00,  //  00A8  GETNGBL	R21	K5
+      0x8C542B06,  //  00A9  GETMET	R21	R21	K6
+      0x605C0008,  //  00AA  GETGBL	R23	G8
+      0x8860072A,  //  00AB  GETMBR	R24	R3	K42
+      0x7C5C0200,  //  00AC  CALL	R23	1
+      0x005E5C17,  //  00AD  ADD	R23	K46	R23
+      0x58600026,  //  00AE  LDCONST	R24	K38
+      0x7C540600,  //  00AF  CALL	R21	3
+      0xB8561800,  //  00B0  GETNGBL	R21	K12
+      0x88542B23,  //  00B1  GETMBR	R21	R21	K35
+      0x8C542B2F,  //  00B2  GETMET	R21	R21	K47
+      0x7C540200,  //  00B3  CALL	R21	1
+      0x8C582B30,  //  00B4  GETMET	R22	R21	K48
+      0x5860000A,  //  00B5  LDCONST	R24	K10
+      0xB8661800,  //  00B6  GETNGBL	R25	K12
+      0x88643323,  //  00B7  GETMBR	R25	R25	K35
+      0x88643331,  //  00B8  GETMBR	R25	R25	K49
+      0x5C681C00,  //  00B9  MOVE	R26	R14
+      0x7C580800,  //  00BA  CALL	R22	4
+      0x8C582B30,  //  00BB  GETMET	R22	R21	K48
+      0x58600008,  //  00BC  LDCONST	R24	K8
+      0xB8661800,  //  00BD  GETNGBL	R25	K12
+      0x88643323,  //  00BE  GETMBR	R25	R25	K35
+      0x88643331,  //  00BF  GETMBR	R25	R25	K49
+      0x5C681E00,  //  00C0  MOVE	R26	R15
+      0x7C580800,  //  00C1  CALL	R22	4
+      0x8C582B30,  //  00C2  GETMET	R22	R21	K48
+      0x58600026,  //  00C3  LDCONST	R24	K38
+      0xB8661800,  //  00C4  GETNGBL	R25	K12
+      0x88643323,  //  00C5  GETMBR	R25	R25	K35
+      0x88643331,  //  00C6  GETMBR	R25	R25	K49
+      0x88680732,  //  00C7  GETMBR	R26	R3	K50
+      0x7C580800,  //  00C8  CALL	R22	4
+      0x8C582B30,  //  00C9  GETMET	R22	R21	K48
+      0x54620003,  //  00CA  LDINT	R24	4
+      0xB8661800,  //  00CB  GETNGBL	R25	K12
+      0x88643323,  //  00CC  GETMBR	R25	R25	K35
+      0x88643331,  //  00CD  GETMBR	R25	R25	K49
+      0x88680733,  //  00CE  GETMBR	R26	R3	K51
+      0x7C580800,  //  00CF  CALL	R22	4
+      0x8C582B34,  //  00D0  GETMET	R22	R21	K52
+      0x7C580200,  //  00D1  CALL	R22	1
+      0x8C5C0535,  //  00D2  GETMET	R23	R2	K53
+      0x7C5C0200,  //  00D3  CALL	R23	1
+      0x8C5C2F36,  //  00D4  GETMET	R23	R23	K54
+      0x5C642400,  //  00D5  MOVE	R25	R18
+      0x5C682C00,  //  00D6  MOVE	R26	R22
+      0x5C6C2000,  //  00D7  MOVE	R27	R16
+      0x7C5C0800,  //  00D8  CALL	R23	4
+      0x5C602E00,  //  00D9  MOVE	R24	R23
+      0x74620012,  //  00DA  JMPT	R24	#00EE
+      0xB8620A00,  //  00DB  GETNGBL	R24	K5
+      0x8C603106,  //  00DC  GETMET	R24	R24	K6
+      0x58680037,  //  00DD  LDCONST	R26	K55
+      0x586C0008,  //  00DE  LDCONST	R27	K8
+      0x7C600600,  //  00DF  CALL	R24	3
+      0xB8620A00,  //  00E0  GETNGBL	R24	K5
+      0x8C603106,  //  00E1  GETMET	R24	R24	K6
+      0x58680007,  //  00E2  LDCONST	R26	K7
+      0x586C0008,  //  00E3  LDCONST	R27	K8
+      0x7C600600,  //  00E4  CALL	R24	3
+      0x8C600109,  //  00E5  GETMET	R24	R0	K9
+      0x5C680200,  //  00E6  MOVE	R26	R1
+      0x586C000A,  //  00E7  LDCONST	R27	K10
+      0x58700003,  //  00E8  LDCONST	R28	K3
+      0x58740008,  //  00E9  LDCONST	R29	K8
+      0x50780000,  //  00EA  LDBOOL	R30	0	0
+      0x7C600C00,  //  00EB  CALL	R24	6
+      0x50640000,  //  00EC  LDBOOL	R25	0	0
+      0x80043200,  //  00ED  RET	1	R25
+      0xB8620A00,  //  00EE  GETNGBL	R24	K5
+      0x8C603106,  //  00EF  GETMET	R24	R24	K6
+      0x58680038,  //  00F0  LDCONST	R26	K56
+      0x586C0026,  //  00F1  LDCONST	R27	K38
+      0x7C600600,  //  00F2  CALL	R24	3
+      0x8C600511,  //  00F3  GETMET	R24	R2	K17
+      0x7C600200,  //  00F4  CALL	R24	1
+      0x8C603112,  //  00F5  GETMET	R24	R24	K18
+      0x88680713,  //  00F6  GETMBR	R26	R3	K19
+      0x7C600400,  //  00F7  CALL	R24	2
+      0x8C603112,  //  00F8  GETMET	R24	R24	K18
+      0x88680714,  //  00F9  GETMBR	R26	R3	K20
+      0x7C600400,  //  00FA  CALL	R24	2
+      0x8C603112,  //  00FB  GETMET	R24	R24	K18
+      0x88680939,  //  00FC  GETMBR	R26	R4	K57
+      0x7C600400,  //  00FD  CALL	R24	2
+      0x8C603115,  //  00FE  GETMET	R24	R24	K21
+      0x7C600200,  //  00FF  CALL	R24	1
+      0x5C143000,  //  0100  MOVE	R5	R24
+      0x4C600000,  //  0101  LDNIL	R24
+      0x900E2618,  //  0102  SETMBR	R3	K19	R24
+      0x4C600000,  //  0103  LDNIL	R24
+      0x900E2818,  //  0104  SETMBR	R3	K20	R24
+      0x8C600518,  //  0105  GETMET	R24	R2	K24
+      0x7C600200,  //  0106  CALL	R24	1
+      0x8C603119,  //  0107  GETMET	R24	R24	K25
+      0x8868071A,  //  0108  GETMBR	R26	R3	K26
+      0x8C6C071B,  //  0109  GETMET	R27	R3	K27
+      0x7C6C0200,  //  010A  CALL	R27	1
+      0x006C3605,  //  010B  ADD	R27	R27	R5
+      0x60700015,  //  010C  GETGBL	R28	G21
+      0x7C700000,  //  010D  CALL	R28	0
+      0x8C703916,  //  010E  GETMET	R28	R28	K22
+      0x8878013A,  //  010F  GETMBR	R30	R0	K58
+      0x7C700400,  //  0110  CALL	R28	2
+      0x5476002F,  //  0111  LDINT	R29	48
+      0x7C600A00,  //  0112  CALL	R24	5
+      0x5466000E,  //  0113  LDINT	R25	15
+      0x40660619,  //  0114  CONNECT	R25	K3	R25
+      0x94643019,  //  0115  GETIDX	R25	R24	R25
+      0x546A000F,  //  0116  LDINT	R26	16
+      0x546E001E,  //  0117  LDINT	R27	31
+      0x4068341B,  //  0118  CONNECT	R26	R26	R27
+      0x9468301A,  //  0119  GETIDX	R26	R24	R26
+      0x546E001F,  //  011A  LDINT	R27	32
+      0x5472002E,  //  011B  LDINT	R28	47
+      0x406C361C,  //  011C  CONNECT	R27	R27	R28
+      0x946C301B,  //  011D  GETIDX	R27	R24	R27
+      0xB8720A00,  //  011E  GETNGBL	R28	K5
+      0x8C70393B,  //  011F  GETMET	R28	R28	K59
+      0x7C700200,  //  0120  CALL	R28	1
+      0x9470393C,  //  0121  GETIDX	R28	R28	K60
+      0x8C740109,  //  0122  GETMET	R29	R0	K9
+      0x5C7C0200,  //  0123  MOVE	R31	R1
+      0x58800003,  //  0124  LDCONST	R32	K3
+      0x58840003,  //  0125  LDCONST	R33	K3
+      0x58880003,  //  0126  LDCONST	R34	K3
+      0x508C0200,  //  0127  LDBOOL	R35	1	0
+      0x7C740C00,  //  0128  CALL	R29	6
+      0x8C78073D,  //  0129  GETMET	R30	R3	K61
+      0x7C780200,  //  012A  CALL	R30	1
+      0x8C78073E,  //  012B  GETMET	R30	R3	K62
+      0x5C803200,  //  012C  MOVE	R32	R25
+      0x5C843400,  //  012D  MOVE	R33	R26
+      0x5C883600,  //  012E  MOVE	R34	R27
+      0x5C8C3800,  //  012F  MOVE	R35	R28
+      0x7C780A00,  //  0130  CALL	R30	5
+      0x900E7F03,  //  0131  SETMBR	R3	K63	K3
+      0x8C780740,  //  0132  GETMET	R30	R3	K64
+      0x7C780200,  //  0133  CALL	R30	1
+      0x8C780741,  //  0134  GETMET	R30	R3	K65
+      0x50800200,  //  0135  LDBOOL	R32	1	0
+      0x7C780400,  //  0136  CALL	R30	2
+      0x8C780742,  //  0137  GETMET	R30	R3	K66
+      0x7C780200,  //  0138  CALL	R30	1
+      0x8C780743,  //  0139  GETMET	R30	R3	K67
+      0x7C780200,  //  013A  CALL	R30	1
+      0x8C780744,  //  013B  GETMET	R30	R3	K68
+      0x7C780200,  //  013C  CALL	R30	1
+      0x50780200,  //  013D  LDBOOL	R30	1	0
+      0x80043C00,  //  013E  RET	1	R30
     })
   )
 );
@@ -1593,7 +1297,7 @@ be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
+    ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
     /* K1   */  be_nested_str_weak(is_commissioning_open),
     /* K2   */  be_nested_str_weak(opcode),
@@ -1601,23 +1305,19 @@ be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
     /* K4   */  be_nested_str_weak(log),
     /* K5   */  be_nested_str_weak(MTR_X3A_X20commissioning_X20not_X20open),
     /* K6   */  be_const_int(2),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20received_X20message_X20),
-    /* K8   */  be_nested_str_weak(matter),
-    /* K9   */  be_nested_str_weak(inspect),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(parse_PBKDFParamRequest),
-    /* K12  */  be_nested_str_weak(parse_Pake1),
-    /* K13  */  be_nested_str_weak(parse_Pake3),
-    /* K14  */  be_nested_str_weak(parse_Sigma1),
-    /* K15  */  be_nested_str_weak(parse_Sigma3),
-    /* K16  */  be_nested_str_weak(parse_StatusReport),
-    /* K17  */  be_nested_str_weak(string),
-    /* K18  */  be_nested_str_weak(format),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28secure_X20channel_X29_X20_X2502X),
+    /* K7   */  be_nested_str_weak(parse_PBKDFParamRequest),
+    /* K8   */  be_nested_str_weak(parse_Pake1),
+    /* K9   */  be_nested_str_weak(parse_Pake3),
+    /* K10  */  be_nested_str_weak(parse_Sigma1),
+    /* K11  */  be_nested_str_weak(parse_Sigma3),
+    /* K12  */  be_nested_str_weak(parse_StatusReport),
+    /* K13  */  be_nested_str_weak(string),
+    /* K14  */  be_nested_str_weak(format),
+    /* K15  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28secure_X20channel_X29_X20_X2502X),
     }),
     be_str_weak(process_incoming),
     &be_const_str_solidified,
-    ( &(const binstruction[100]) {  /* code */
+    ( &(const binstruction[91]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x7C080200,  //  0002  CALL	R2	1
@@ -1637,87 +1337,78 @@ be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
       0x7C080600,  //  0010  CALL	R2	3
       0x50080000,  //  0011  LDBOOL	R2	0	0
       0x80040400,  //  0012  RET	1	R2
-      0xB80A0600,  //  0013  GETNGBL	R2	K3
-      0x8C080504,  //  0014  GETMET	R2	R2	K4
-      0xB8121000,  //  0015  GETNGBL	R4	K8
-      0x8C100909,  //  0016  GETMET	R4	R4	K9
-      0x5C180200,  //  0017  MOVE	R6	R1
-      0x7C100400,  //  0018  CALL	R4	2
-      0x00120E04,  //  0019  ADD	R4	K7	R4
-      0x5814000A,  //  001A  LDCONST	R5	K10
-      0x7C080600,  //  001B  CALL	R2	3
-      0x88080302,  //  001C  GETMBR	R2	R1	K2
-      0x540E000F,  //  001D  LDINT	R3	16
-      0x1C080403,  //  001E  EQ	R2	R2	R3
-      0x780A0000,  //  001F  JMPF	R2	#0021
-      0x70020040,  //  0020  JMP		#0062
+      0x88080302,  //  0013  GETMBR	R2	R1	K2
+      0x540E000F,  //  0014  LDINT	R3	16
+      0x1C080403,  //  0015  EQ	R2	R2	R3
+      0x780A0000,  //  0016  JMPF	R2	#0018
+      0x70020040,  //  0017  JMP		#0059
+      0x88080302,  //  0018  GETMBR	R2	R1	K2
+      0x540E001F,  //  0019  LDINT	R3	32
+      0x1C080403,  //  001A  EQ	R2	R2	R3
+      0x780A0004,  //  001B  JMPF	R2	#0021
+      0x8C080107,  //  001C  GETMET	R2	R0	K7
+      0x5C100200,  //  001D  MOVE	R4	R1
+      0x7C080400,  //  001E  CALL	R2	2
+      0x80040400,  //  001F  RET	1	R2
+      0x70020037,  //  0020  JMP		#0059
       0x88080302,  //  0021  GETMBR	R2	R1	K2
-      0x540E001F,  //  0022  LDINT	R3	32
+      0x540E0021,  //  0022  LDINT	R3	34
       0x1C080403,  //  0023  EQ	R2	R2	R3
       0x780A0004,  //  0024  JMPF	R2	#002A
-      0x8C08010B,  //  0025  GETMET	R2	R0	K11
+      0x8C080108,  //  0025  GETMET	R2	R0	K8
       0x5C100200,  //  0026  MOVE	R4	R1
       0x7C080400,  //  0027  CALL	R2	2
       0x80040400,  //  0028  RET	1	R2
-      0x70020037,  //  0029  JMP		#0062
+      0x7002002E,  //  0029  JMP		#0059
       0x88080302,  //  002A  GETMBR	R2	R1	K2
-      0x540E0021,  //  002B  LDINT	R3	34
+      0x540E0023,  //  002B  LDINT	R3	36
       0x1C080403,  //  002C  EQ	R2	R2	R3
       0x780A0004,  //  002D  JMPF	R2	#0033
-      0x8C08010C,  //  002E  GETMET	R2	R0	K12
+      0x8C080109,  //  002E  GETMET	R2	R0	K9
       0x5C100200,  //  002F  MOVE	R4	R1
       0x7C080400,  //  0030  CALL	R2	2
       0x80040400,  //  0031  RET	1	R2
-      0x7002002E,  //  0032  JMP		#0062
+      0x70020025,  //  0032  JMP		#0059
       0x88080302,  //  0033  GETMBR	R2	R1	K2
-      0x540E0023,  //  0034  LDINT	R3	36
+      0x540E002F,  //  0034  LDINT	R3	48
       0x1C080403,  //  0035  EQ	R2	R2	R3
       0x780A0004,  //  0036  JMPF	R2	#003C
-      0x8C08010D,  //  0037  GETMET	R2	R0	K13
+      0x8C08010A,  //  0037  GETMET	R2	R0	K10
       0x5C100200,  //  0038  MOVE	R4	R1
       0x7C080400,  //  0039  CALL	R2	2
       0x80040400,  //  003A  RET	1	R2
-      0x70020025,  //  003B  JMP		#0062
+      0x7002001C,  //  003B  JMP		#0059
       0x88080302,  //  003C  GETMBR	R2	R1	K2
-      0x540E002F,  //  003D  LDINT	R3	48
+      0x540E0031,  //  003D  LDINT	R3	50
       0x1C080403,  //  003E  EQ	R2	R2	R3
       0x780A0004,  //  003F  JMPF	R2	#0045
-      0x8C08010E,  //  0040  GETMET	R2	R0	K14
+      0x8C08010B,  //  0040  GETMET	R2	R0	K11
       0x5C100200,  //  0041  MOVE	R4	R1
       0x7C080400,  //  0042  CALL	R2	2
       0x80040400,  //  0043  RET	1	R2
-      0x7002001C,  //  0044  JMP		#0062
+      0x70020013,  //  0044  JMP		#0059
       0x88080302,  //  0045  GETMBR	R2	R1	K2
-      0x540E0031,  //  0046  LDINT	R3	50
+      0x540E003F,  //  0046  LDINT	R3	64
       0x1C080403,  //  0047  EQ	R2	R2	R3
       0x780A0004,  //  0048  JMPF	R2	#004E
-      0x8C08010F,  //  0049  GETMET	R2	R0	K15
+      0x8C08010C,  //  0049  GETMET	R2	R0	K12
       0x5C100200,  //  004A  MOVE	R4	R1
       0x7C080400,  //  004B  CALL	R2	2
       0x80040400,  //  004C  RET	1	R2
-      0x70020013,  //  004D  JMP		#0062
-      0x88080302,  //  004E  GETMBR	R2	R1	K2
-      0x540E003F,  //  004F  LDINT	R3	64
-      0x1C080403,  //  0050  EQ	R2	R2	R3
-      0x780A0004,  //  0051  JMPF	R2	#0057
-      0x8C080110,  //  0052  GETMET	R2	R0	K16
-      0x5C100200,  //  0053  MOVE	R4	R1
-      0x7C080400,  //  0054  CALL	R2	2
-      0x80040400,  //  0055  RET	1	R2
-      0x7002000A,  //  0056  JMP		#0062
-      0xA40A2200,  //  0057  IMPORT	R2	K17
-      0xB80E0600,  //  0058  GETNGBL	R3	K3
-      0x8C0C0704,  //  0059  GETMET	R3	R3	K4
-      0x8C140512,  //  005A  GETMET	R5	R2	K18
-      0x581C0013,  //  005B  LDCONST	R7	K19
-      0x88200302,  //  005C  GETMBR	R8	R1	K2
-      0x7C140600,  //  005D  CALL	R5	3
-      0x58180006,  //  005E  LDCONST	R6	K6
-      0x7C0C0600,  //  005F  CALL	R3	3
-      0x500C0000,  //  0060  LDBOOL	R3	0	0
-      0x80040600,  //  0061  RET	1	R3
-      0x50080000,  //  0062  LDBOOL	R2	0	0
-      0x80040400,  //  0063  RET	1	R2
+      0x7002000A,  //  004D  JMP		#0059
+      0xA40A1A00,  //  004E  IMPORT	R2	K13
+      0xB80E0600,  //  004F  GETNGBL	R3	K3
+      0x8C0C0704,  //  0050  GETMET	R3	R3	K4
+      0x8C14050E,  //  0051  GETMET	R5	R2	K14
+      0x581C000F,  //  0052  LDCONST	R7	K15
+      0x88200302,  //  0053  GETMBR	R8	R1	K2
+      0x7C140600,  //  0054  CALL	R5	3
+      0x58180006,  //  0055  LDCONST	R6	K6
+      0x7C0C0600,  //  0056  CALL	R3	3
+      0x500C0000,  //  0057  LDBOOL	R3	0	0
+      0x80040600,  //  0058  RET	1	R3
+      0x50080000,  //  0059  LDBOOL	R2	0	0
+      0x80040400,  //  005A  RET	1	R2
     })
   )
 );
@@ -1737,7 +1428,7 @@ be_local_closure(Matter_Commisioning_Context_parse_Sigma1,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[144]) {     /* constants */
+    ( &(const bvalue[123]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(session),
@@ -1756,136 +1447,115 @@ be_local_closure(Matter_Commisioning_Context_parse_Sigma1,   /* name */
     /* K15  */  be_nested_str_weak(parse),
     /* K16  */  be_nested_str_weak(raw),
     /* K17  */  be_nested_str_weak(app_payload_idx),
-    /* K18  */  be_nested_str_weak(format),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20sigma1_X3D_X25s),
-    /* K20  */  be_nested_str_weak(inspect),
-    /* K21  */  be_nested_str_weak(__initiator_pub),
-    /* K22  */  be_nested_str_weak(initiatorEphPubKey),
-    /* K23  */  be_nested_str_weak(resumptionID),
-    /* K24  */  be_nested_str_weak(initiatorResumeMIC),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20is_resumption_X3D_X25i),
-    /* K26  */  be_nested_str_weak(device),
-    /* K27  */  be_nested_str_weak(sessions),
-    /* K28  */  be_nested_str_weak(find_session_by_resumption_id),
-    /* K29  */  be_nested_str_weak(MTR_X3A_X20session_resumption_X20found_X20session_X3D_X25s_X20session_resumption_X3D_X25s),
-    /* K30  */  be_nested_str_weak(_fabric),
-    /* K31  */  be_nested_str_weak(initiatorRandom),
-    /* K32  */  be_nested_str_weak(fromstring),
-    /* K33  */  be_nested_str_weak(Sigma1_Resume),
-    /* K34  */  be_nested_str_weak(HKDF_SHA256),
-    /* K35  */  be_nested_str_weak(derive),
-    /* K36  */  be_nested_str_weak(shared_secret),
-    /* K37  */  be_nested_str_weak(NCASE_SigmaS1),
-    /* K38  */  be_const_int(2147483647),
-    /* K39  */  be_nested_str_weak(AES_CCM),
-    /* K40  */  be_nested_str_weak(decrypt),
-    /* K41  */  be_nested_str_weak(tag),
-    /* K42  */  be_nested_str_weak(_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
-    /* K43  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s1rk_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K44  */  be_nested_str_weak(tohex),
-    /* K45  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20tag_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K46  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20Resume1MICPayload_X20_X3D_X20),
-    /* K47  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20decrypted_tag_X20_X20_X20_X20_X20_X3D_X20),
-    /* K48  */  be_nested_str_weak(_source_node_id),
-    /* K49  */  be_nested_str_weak(source_node_id),
-    /* K50  */  be_nested_str_weak(set_mode_CASE),
-    /* K51  */  be_nested_str_weak(__future_initiator_session_id),
-    /* K52  */  be_nested_str_weak(initiator_session_id),
-    /* K53  */  be_nested_str_weak(__future_local_session_id),
-    /* K54  */  be_nested_str_weak(gen_local_session_id),
-    /* K55  */  be_nested_str_weak(MTR_X3A_X20_X2BSession_X20_X20_X20_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-    /* K56  */  be_nested_str_weak(remote_ip),
-    /* K57  */  be_nested_str_weak(remote_port),
-    /* K58  */  be_nested_str_weak(resumption_id),
-    /* K59  */  be_nested_str_weak(random),
-    /* K60  */  be_nested_str_weak(Sigma2_Resume),
-    /* K61  */  be_nested_str_weak(NCASE_SigmaS2),
-    /* K62  */  be_nested_str_weak(Sigma2Resume),
-    /* K63  */  be_nested_str_weak(responderSessionID),
-    /* K64  */  be_nested_str_weak(sigma2ResumeMIC),
-    /* K65  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s2rk_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K66  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s2rk_salt_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K67  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20new_resumption_id_X20_X3D_X20),
-    /* K68  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20responderSessionID_X3D_X20),
-    /* K69  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20sigma2ResumeMIC_X20_X20_X20_X3D_X20),
-    /* K70  */  be_nested_str_weak(SessionResumptionKeys),
-    /* K71  */  be_nested_str_weak(rtc),
-    /* K72  */  be_nested_str_weak(utc),
-    /* K73  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
-    /* K74  */  be_nested_str_weak(MTR_X3A_X20I2RKey_X20_X20_X20_X20_X20_X20_X3D),
-    /* K75  */  be_nested_str_weak(MTR_X3A_X20R2IKey_X20_X20_X20_X20_X20_X20_X3D),
-    /* K76  */  be_nested_str_weak(MTR_X3A_X20AC_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
-    /* K77  */  be_nested_str_weak(tlv2raw),
-    /* K78  */  be_nested_str_weak(__Msg1),
-    /* K79  */  be_nested_str_weak(MTR_X3A_X20sigma2resume_X3A_X20),
-    /* K80  */  be_nested_str_weak(MTR_X3A_X20sigma2resume_raw_X3A_X20),
-    /* K81  */  be_nested_str_weak(build_response),
-    /* K82  */  be_nested_str_weak(encode_frame),
-    /* K83  */  be_nested_str_weak(responder),
-    /* K84  */  be_nested_str_weak(send_response_frame),
-    /* K85  */  be_nested_str_weak(close),
-    /* K86  */  be_nested_str_weak(set_keys),
-    /* K87  */  be_nested_str_weak(_breadcrumb),
-    /* K88  */  be_nested_str_weak(counter_snd_next),
-    /* K89  */  be_nested_str_weak(set_persist),
-    /* K90  */  be_nested_str_weak(set_no_expiration),
-    /* K91  */  be_nested_str_weak(persist_to_fabric),
-    /* K92  */  be_nested_str_weak(save),
-    /* K93  */  be_nested_str_weak(find_fabric_by_destination_id),
-    /* K94  */  be_nested_str_weak(destinationId),
-    /* K95  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28GeneralCode_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20NO_SHARED_TRUST_ROOTS_X29),
-    /* K96  */  be_nested_str_weak(MTR_X3A_X20fabric_X3D),
-    /* K97  */  be_nested_str_weak(MTR_X3A_X20no_private_key_X3D),
-    /* K98  */  be_nested_str_weak(no_private_key),
-    /* K99  */  be_nested_str_weak(MTR_X3A_X20noc_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
-    /* K100 */  be_nested_str_weak(noc),
-    /* K101 */  be_nested_str_weak(get_icac),
-    /* K102 */  be_nested_str_weak(MTR_X3A_X20icac_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
-    /* K103 */  be_nested_str_weak(MTR_X3A_X20root_ca_cert_X20_X20_X3D),
-    /* K104 */  be_nested_str_weak(root_ca_certificate),
-    /* K105 */  be_nested_str_weak(__responder_priv),
-    /* K106 */  be_nested_str_weak(__responder_pub),
-    /* K107 */  be_nested_str_weak(EC_P256),
-    /* K108 */  be_nested_str_weak(public_key),
-    /* K109 */  be_nested_str_weak(MTR_X3A_X20ResponderEph_priv_X20_X20_X3D),
-    /* K110 */  be_nested_str_weak(MTR_X3A_X20ResponderEph_pub_X20_X20_X3D),
-    /* K111 */  be_nested_str_weak(shared_key),
-    /* K112 */  be_nested_str_weak(TLV),
-    /* K113 */  be_nested_str_weak(Matter_TLV_struct),
-    /* K114 */  be_nested_str_weak(add_TLV),
-    /* K115 */  be_nested_str_weak(B2),
-    /* K116 */  be_nested_str_weak(get_noc),
-    /* K117 */  be_const_int(3),
-    /* K118 */  be_nested_str_weak(ecdsa_sign_sha256),
-    /* K119 */  be_nested_str_weak(get_pk),
-    /* K120 */  be_nested_str_weak(Msg1),
-    /* K121 */  be_nested_str_weak(MTR_X3A_X20_X2A_X20resumptionid_X20_X20_X3D_X20),
-    /* K122 */  be_nested_str_weak(MTR_X3A_X20_X2A_X20MSG1_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K123 */  be_nested_str_weak(SHA256),
-    /* K124 */  be_nested_str_weak(update),
-    /* K125 */  be_nested_str_weak(out),
-    /* K126 */  be_nested_str_weak(MTR_X3A_X20TranscriptHash_X20_X3D),
-    /* K127 */  be_nested_str_weak(S2K_Info),
-    /* K128 */  be_nested_str_weak(get_ipk_group_key),
-    /* K129 */  be_nested_str_weak(MTR_X3A_X20_X2A_X20SharedSecret_X20_X20_X3D_X20),
-    /* K130 */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s2k_salt_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K131 */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s2k_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K132 */  be_nested_str_weak(MTR_X3A_X20_X2A_X20TBEData2Raw_X20_X20_X20_X3D_X20),
-    /* K133 */  be_nested_str_weak(TBEData2_Nonce),
-    /* K134 */  be_nested_str_weak(encrypt),
-    /* K135 */  be_nested_str_weak(MTR_X3A_X20_X2A_X20TBEData2Enc_X20_X20_X20_X3D_X20),
-    /* K136 */  be_nested_str_weak(Sigma2),
-    /* K137 */  be_nested_str_weak(responderRandom),
-    /* K138 */  be_nested_str_weak(responderSessionId),
-    /* K139 */  be_nested_str_weak(responderEphPubKey),
-    /* K140 */  be_nested_str_weak(encrypted2),
-    /* K141 */  be_nested_str_weak(MTR_X3A_X20sigma2_X3A_X20),
-    /* K142 */  be_nested_str_weak(__Msg2),
-    /* K143 */  be_nested_str_weak(MTR_X3A_X20sigma2_raw_X3A_X20),
+    /* K18  */  be_nested_str_weak(__initiator_pub),
+    /* K19  */  be_nested_str_weak(initiatorEphPubKey),
+    /* K20  */  be_nested_str_weak(resumptionID),
+    /* K21  */  be_nested_str_weak(initiatorResumeMIC),
+    /* K22  */  be_nested_str_weak(format),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20is_resumption_X3D_X25i),
+    /* K24  */  be_nested_str_weak(device),
+    /* K25  */  be_nested_str_weak(sessions),
+    /* K26  */  be_nested_str_weak(find_session_by_resumption_id),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20session_resumption_X20found_X20session_X3D_X25s_X20session_resumption_X3D_X25s),
+    /* K28  */  be_nested_str_weak(inspect),
+    /* K29  */  be_nested_str_weak(_fabric),
+    /* K30  */  be_nested_str_weak(initiatorRandom),
+    /* K31  */  be_nested_str_weak(fromstring),
+    /* K32  */  be_nested_str_weak(Sigma1_Resume),
+    /* K33  */  be_nested_str_weak(HKDF_SHA256),
+    /* K34  */  be_nested_str_weak(derive),
+    /* K35  */  be_nested_str_weak(shared_secret),
+    /* K36  */  be_nested_str_weak(NCASE_SigmaS1),
+    /* K37  */  be_const_int(2147483647),
+    /* K38  */  be_nested_str_weak(AES_CCM),
+    /* K39  */  be_nested_str_weak(decrypt),
+    /* K40  */  be_nested_str_weak(tag),
+    /* K41  */  be_nested_str_weak(_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
+    /* K42  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s1rk_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
+    /* K43  */  be_nested_str_weak(tohex),
+    /* K44  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20tag_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
+    /* K45  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20Resume1MICPayload_X20_X3D_X20),
+    /* K46  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20decrypted_tag_X20_X20_X20_X20_X20_X3D_X20),
+    /* K47  */  be_nested_str_weak(_source_node_id),
+    /* K48  */  be_nested_str_weak(source_node_id),
+    /* K49  */  be_nested_str_weak(set_mode_CASE),
+    /* K50  */  be_nested_str_weak(__future_initiator_session_id),
+    /* K51  */  be_nested_str_weak(initiator_session_id),
+    /* K52  */  be_nested_str_weak(__future_local_session_id),
+    /* K53  */  be_nested_str_weak(gen_local_session_id),
+    /* K54  */  be_nested_str_weak(MTR_X3A_X20_X2BSession_X20_X20_X20_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+    /* K55  */  be_nested_str_weak(remote_ip),
+    /* K56  */  be_nested_str_weak(remote_port),
+    /* K57  */  be_nested_str_weak(resumption_id),
+    /* K58  */  be_nested_str_weak(random),
+    /* K59  */  be_nested_str_weak(Sigma2_Resume),
+    /* K60  */  be_nested_str_weak(NCASE_SigmaS2),
+    /* K61  */  be_nested_str_weak(Sigma2Resume),
+    /* K62  */  be_nested_str_weak(responderSessionID),
+    /* K63  */  be_nested_str_weak(sigma2ResumeMIC),
+    /* K64  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s2rk_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
+    /* K65  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s2rk_salt_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
+    /* K66  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20new_resumption_id_X20_X3D_X20),
+    /* K67  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20responderSessionID_X3D_X20),
+    /* K68  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20sigma2ResumeMIC_X20_X20_X20_X3D_X20),
+    /* K69  */  be_nested_str_weak(SessionResumptionKeys),
+    /* K70  */  be_nested_str_weak(rtc),
+    /* K71  */  be_nested_str_weak(utc),
+    /* K72  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
+    /* K73  */  be_nested_str_weak(MTR_X3A_X20I2RKey_X20_X20_X20_X20_X20_X20_X3D),
+    /* K74  */  be_nested_str_weak(MTR_X3A_X20R2IKey_X20_X20_X20_X20_X20_X20_X3D),
+    /* K75  */  be_nested_str_weak(MTR_X3A_X20AC_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
+    /* K76  */  be_nested_str_weak(tlv2raw),
+    /* K77  */  be_nested_str_weak(__Msg1),
+    /* K78  */  be_nested_str_weak(MTR_X3A_X20sigma2resume_X3A_X20),
+    /* K79  */  be_nested_str_weak(MTR_X3A_X20sigma2resume_raw_X3A_X20),
+    /* K80  */  be_nested_str_weak(build_response),
+    /* K81  */  be_nested_str_weak(encode_frame),
+    /* K82  */  be_nested_str_weak(responder),
+    /* K83  */  be_nested_str_weak(send_response_frame),
+    /* K84  */  be_nested_str_weak(close),
+    /* K85  */  be_nested_str_weak(set_keys),
+    /* K86  */  be_nested_str_weak(_breadcrumb),
+    /* K87  */  be_nested_str_weak(counter_snd_next),
+    /* K88  */  be_nested_str_weak(set_persist),
+    /* K89  */  be_nested_str_weak(set_no_expiration),
+    /* K90  */  be_nested_str_weak(persist_to_fabric),
+    /* K91  */  be_nested_str_weak(save),
+    /* K92  */  be_nested_str_weak(find_fabric_by_destination_id),
+    /* K93  */  be_nested_str_weak(destinationId),
+    /* K94  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28GeneralCode_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20NO_SHARED_TRUST_ROOTS_X29),
+    /* K95  */  be_nested_str_weak(get_icac),
+    /* K96  */  be_nested_str_weak(__responder_priv),
+    /* K97  */  be_nested_str_weak(__responder_pub),
+    /* K98  */  be_nested_str_weak(EC_P256),
+    /* K99  */  be_nested_str_weak(public_key),
+    /* K100 */  be_nested_str_weak(shared_key),
+    /* K101 */  be_nested_str_weak(TLV),
+    /* K102 */  be_nested_str_weak(Matter_TLV_struct),
+    /* K103 */  be_nested_str_weak(add_TLV),
+    /* K104 */  be_nested_str_weak(B2),
+    /* K105 */  be_nested_str_weak(get_noc),
+    /* K106 */  be_const_int(3),
+    /* K107 */  be_nested_str_weak(ecdsa_sign_sha256),
+    /* K108 */  be_nested_str_weak(get_pk),
+    /* K109 */  be_nested_str_weak(Msg1),
+    /* K110 */  be_nested_str_weak(SHA256),
+    /* K111 */  be_nested_str_weak(update),
+    /* K112 */  be_nested_str_weak(out),
+    /* K113 */  be_nested_str_weak(S2K_Info),
+    /* K114 */  be_nested_str_weak(get_ipk_group_key),
+    /* K115 */  be_nested_str_weak(TBEData2_Nonce),
+    /* K116 */  be_nested_str_weak(encrypt),
+    /* K117 */  be_nested_str_weak(Sigma2),
+    /* K118 */  be_nested_str_weak(responderRandom),
+    /* K119 */  be_nested_str_weak(responderSessionId),
+    /* K120 */  be_nested_str_weak(responderEphPubKey),
+    /* K121 */  be_nested_str_weak(encrypted2),
+    /* K122 */  be_nested_str_weak(__Msg2),
     }),
     be_str_weak(parse_Sigma1),
     &be_const_str_solidified,
-    ( &(const binstruction[793]) {  /* code */
+    ( &(const binstruction[635]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0xA40E0200,  //  0001  IMPORT	R3	K1
       0x88100302,  //  0002  GETMBR	R4	R1	K2
@@ -1920,765 +1590,607 @@ be_local_closure(Matter_Commisioning_Context_parse_Sigma1,   /* name */
       0x881C0310,  //  001F  GETMBR	R7	R1	K16
       0x88200311,  //  0020  GETMBR	R8	R1	K17
       0x7C140600,  //  0021  CALL	R5	3
-      0xB81A0E00,  //  0022  GETNGBL	R6	K7
-      0x8C180D08,  //  0023  GETMET	R6	R6	K8
-      0x8C200712,  //  0024  GETMET	R8	R3	K18
-      0x58280013,  //  0025  LDCONST	R10	K19
-      0xB82E1A00,  //  0026  GETNGBL	R11	K13
-      0x8C2C1714,  //  0027  GETMET	R11	R11	K20
-      0x5C340A00,  //  0028  MOVE	R13	R5
-      0x7C2C0400,  //  0029  CALL	R11	2
-      0x7C200600,  //  002A  CALL	R8	3
-      0x54260003,  //  002B  LDINT	R9	4
-      0x7C180600,  //  002C  CALL	R6	3
-      0x88180B16,  //  002D  GETMBR	R6	R5	K22
-      0x90122A06,  //  002E  SETMBR	R4	K21	R6
-      0x88180B17,  //  002F  GETMBR	R6	R5	K23
-      0x4C1C0000,  //  0030  LDNIL	R7
-      0x20180C07,  //  0031  NE	R6	R6	R7
-      0x781A0003,  //  0032  JMPF	R6	#0037
-      0x88180B18,  //  0033  GETMBR	R6	R5	K24
-      0x4C1C0000,  //  0034  LDNIL	R7
-      0x20180C07,  //  0035  NE	R6	R6	R7
-      0x741A0000,  //  0036  JMPT	R6	#0038
-      0x50180001,  //  0037  LDBOOL	R6	0	1
-      0x50180200,  //  0038  LDBOOL	R6	1	0
-      0xB81E0E00,  //  0039  GETNGBL	R7	K7
-      0x8C1C0F08,  //  003A  GETMET	R7	R7	K8
-      0x8C240712,  //  003B  GETMET	R9	R3	K18
-      0x582C0019,  //  003C  LDCONST	R11	K25
-      0x781A0001,  //  003D  JMPF	R6	#0040
-      0x5830000C,  //  003E  LDCONST	R12	K12
-      0x70020000,  //  003F  JMP		#0041
-      0x58300005,  //  0040  LDCONST	R12	K5
-      0x7C240600,  //  0041  CALL	R9	3
-      0x542A0003,  //  0042  LDINT	R10	4
-      0x7C1C0600,  //  0043  CALL	R7	3
-      0x50180000,  //  0044  LDBOOL	R6	0	0
-      0x4C1C0000,  //  0045  LDNIL	R7
-      0x781A001C,  //  0046  JMPF	R6	#0064
-      0x8820011A,  //  0047  GETMBR	R8	R0	K26
-      0x8820111B,  //  0048  GETMBR	R8	R8	K27
-      0x8C20111C,  //  0049  GETMET	R8	R8	K28
-      0x88280B17,  //  004A  GETMBR	R10	R5	K23
-      0x7C200400,  //  004B  CALL	R8	2
-      0x5C1C1000,  //  004C  MOVE	R7	R8
-      0xB8220E00,  //  004D  GETNGBL	R8	K7
-      0x8C201108,  //  004E  GETMET	R8	R8	K8
-      0x8C280712,  //  004F  GETMET	R10	R3	K18
-      0x5830001D,  //  0050  LDCONST	R12	K29
-      0xB8361A00,  //  0051  GETNGBL	R13	K13
-      0x8C341B14,  //  0052  GETMET	R13	R13	K20
-      0x5C3C0800,  //  0053  MOVE	R15	R4
-      0x7C340400,  //  0054  CALL	R13	2
-      0xB83A1A00,  //  0055  GETNGBL	R14	K13
-      0x8C381D14,  //  0056  GETMET	R14	R14	K20
-      0x5C400E00,  //  0057  MOVE	R16	R7
-      0x7C380400,  //  0058  CALL	R14	2
-      0x7C280800,  //  0059  CALL	R10	4
-      0x542E0003,  //  005A  LDINT	R11	4
-      0x7C200600,  //  005B  CALL	R8	3
-      0x4C200000,  //  005C  LDNIL	R8
-      0x1C200E08,  //  005D  EQ	R8	R7	R8
-      0x74220003,  //  005E  JMPT	R8	#0063
-      0x88200F1E,  //  005F  GETMBR	R8	R7	K30
-      0x4C240000,  //  0060  LDNIL	R9
-      0x1C201009,  //  0061  EQ	R8	R8	R9
-      0x78220000,  //  0062  JMPF	R8	#0064
-      0x50180000,  //  0063  LDBOOL	R6	0	0
-      0x781A013A,  //  0064  JMPF	R6	#01A0
-      0x88200B1F,  //  0065  GETMBR	R8	R5	K31
-      0x88240B17,  //  0066  GETMBR	R9	R5	K23
-      0x00201009,  //  0067  ADD	R8	R8	R9
-      0x60240015,  //  0068  GETGBL	R9	G21
-      0x7C240000,  //  0069  CALL	R9	0
-      0x8C241320,  //  006A  GETMET	R9	R9	K32
-      0x582C0021,  //  006B  LDCONST	R11	K33
-      0x7C240400,  //  006C  CALL	R9	2
-      0x8C280522,  //  006D  GETMET	R10	R2	K34
-      0x7C280200,  //  006E  CALL	R10	1
-      0x8C281523,  //  006F  GETMET	R10	R10	K35
-      0x88300F24,  //  0070  GETMBR	R12	R7	K36
-      0x5C341000,  //  0071  MOVE	R13	R8
-      0x5C381200,  //  0072  MOVE	R14	R9
-      0x543E000F,  //  0073  LDINT	R15	16
-      0x7C280A00,  //  0074  CALL	R10	5
-      0x602C0015,  //  0075  GETGBL	R11	G21
-      0x7C2C0000,  //  0076  CALL	R11	0
-      0x8C2C1720,  //  0077  GETMET	R11	R11	K32
-      0x58340025,  //  0078  LDCONST	R13	K37
-      0x7C2C0400,  //  0079  CALL	R11	2
-      0x5431FFEE,  //  007A  LDINT	R12	-17
-      0x40320A0C,  //  007B  CONNECT	R12	K5	R12
-      0x88340B18,  //  007C  GETMBR	R13	R5	K24
-      0x94301A0C,  //  007D  GETIDX	R12	R13	R12
-      0x5439FFEF,  //  007E  LDINT	R14	-16
-      0x40381D26,  //  007F  CONNECT	R14	R14	K38
-      0x883C0B18,  //  0080  GETMBR	R15	R5	K24
-      0x94341E0E,  //  0081  GETIDX	R13	R15	R14
-      0x8C400527,  //  0082  GETMET	R16	R2	K39
-      0x5C481400,  //  0083  MOVE	R18	R10
-      0x5C4C1600,  //  0084  MOVE	R19	R11
-      0x60500015,  //  0085  GETGBL	R20	G21
-      0x7C500000,  //  0086  CALL	R20	0
-      0x6054000C,  //  0087  GETGBL	R21	G12
-      0x5C581800,  //  0088  MOVE	R22	R12
-      0x7C540200,  //  0089  CALL	R21	1
-      0x545A000F,  //  008A  LDINT	R22	16
-      0x7C400C00,  //  008B  CALL	R16	6
-      0x5C382000,  //  008C  MOVE	R14	R16
-      0x8C401D28,  //  008D  GETMET	R16	R14	K40
-      0x5C481800,  //  008E  MOVE	R18	R12
-      0x7C400400,  //  008F  CALL	R16	2
-      0x5C3C2000,  //  0090  MOVE	R15	R16
-      0x8C401D29,  //  0091  GETMET	R16	R14	K41
-      0x7C400200,  //  0092  CALL	R16	1
-      0xB8460E00,  //  0093  GETNGBL	R17	K7
-      0x8C442308,  //  0094  GETMET	R17	R17	K8
-      0x584C002A,  //  0095  LDCONST	R19	K42
-      0x54520003,  //  0096  LDINT	R20	4
-      0x7C440600,  //  0097  CALL	R17	3
-      0xB8460E00,  //  0098  GETNGBL	R17	K7
-      0x8C442308,  //  0099  GETMET	R17	R17	K8
-      0x8C4C152C,  //  009A  GETMET	R19	R10	K44
-      0x7C4C0200,  //  009B  CALL	R19	1
-      0x004E5613,  //  009C  ADD	R19	K43	R19
-      0x54520003,  //  009D  LDINT	R20	4
-      0x7C440600,  //  009E  CALL	R17	3
-      0xB8460E00,  //  009F  GETNGBL	R17	K7
-      0x8C442308,  //  00A0  GETMET	R17	R17	K8
-      0x8C4C1B2C,  //  00A1  GETMET	R19	R13	K44
-      0x7C4C0200,  //  00A2  CALL	R19	1
-      0x004E5A13,  //  00A3  ADD	R19	K45	R19
-      0x54520003,  //  00A4  LDINT	R20	4
-      0x7C440600,  //  00A5  CALL	R17	3
-      0xB8460E00,  //  00A6  GETNGBL	R17	K7
-      0x8C442308,  //  00A7  GETMET	R17	R17	K8
-      0x8C4C1F2C,  //  00A8  GETMET	R19	R15	K44
-      0x7C4C0200,  //  00A9  CALL	R19	1
-      0x004E5C13,  //  00AA  ADD	R19	K46	R19
-      0x54520003,  //  00AB  LDINT	R20	4
-      0x7C440600,  //  00AC  CALL	R17	3
-      0xB8460E00,  //  00AD  GETNGBL	R17	K7
-      0x8C442308,  //  00AE  GETMET	R17	R17	K8
-      0x8C4C212C,  //  00AF  GETMET	R19	R16	K44
-      0x7C4C0200,  //  00B0  CALL	R19	1
-      0x004E5E13,  //  00B1  ADD	R19	K47	R19
-      0x54520003,  //  00B2  LDINT	R20	4
-      0x7C440600,  //  00B3  CALL	R17	3
-      0xB8460E00,  //  00B4  GETNGBL	R17	K7
-      0x8C442308,  //  00B5  GETMET	R17	R17	K8
-      0x584C002A,  //  00B6  LDCONST	R19	K42
-      0x54520003,  //  00B7  LDINT	R20	4
-      0x7C440600,  //  00B8  CALL	R17	3
-      0x1C441A10,  //  00B9  EQ	R17	R13	R16
-      0x784600E3,  //  00BA  JMPF	R17	#019F
-      0x88440F1E,  //  00BB  GETMBR	R17	R7	K30
-      0x90123C11,  //  00BC  SETMBR	R4	K30	R17
-      0x88440331,  //  00BD  GETMBR	R17	R1	K49
-      0x90126011,  //  00BE  SETMBR	R4	K48	R17
-      0x8C440932,  //  00BF  GETMET	R17	R4	K50
-      0x7C440200,  //  00C0  CALL	R17	1
-      0x88440B34,  //  00C1  GETMBR	R17	R5	K52
-      0x90126611,  //  00C2  SETMBR	R4	K51	R17
-      0x8844011A,  //  00C3  GETMBR	R17	R0	K26
-      0x8844231B,  //  00C4  GETMBR	R17	R17	K27
-      0x8C442336,  //  00C5  GETMET	R17	R17	K54
-      0x7C440200,  //  00C6  CALL	R17	1
-      0x90126A11,  //  00C7  SETMBR	R4	K53	R17
-      0xB8460E00,  //  00C8  GETNGBL	R17	K7
-      0x8C442308,  //  00C9  GETMET	R17	R17	K8
-      0x8C4C0712,  //  00CA  GETMET	R19	R3	K18
-      0x58540037,  //  00CB  LDCONST	R21	K55
-      0x88580935,  //  00CC  GETMBR	R22	R4	K53
-      0x885C0338,  //  00CD  GETMBR	R23	R1	K56
-      0x88600339,  //  00CE  GETMBR	R24	R1	K57
-      0x7C4C0A00,  //  00CF  CALL	R19	5
-      0x5850000A,  //  00D0  LDCONST	R20	K10
-      0x7C440600,  //  00D1  CALL	R17	3
-      0x88440F24,  //  00D2  GETMBR	R17	R7	K36
-      0x90124811,  //  00D3  SETMBR	R4	K36	R17
-      0x8C44053B,  //  00D4  GETMET	R17	R2	K59
-      0x544E000F,  //  00D5  LDINT	R19	16
-      0x7C440400,  //  00D6  CALL	R17	2
-      0x90127411,  //  00D7  SETMBR	R4	K58	R17
-      0x60440015,  //  00D8  GETGBL	R17	G21
-      0x7C440000,  //  00D9  CALL	R17	0
-      0x8C442320,  //  00DA  GETMET	R17	R17	K32
-      0x584C003C,  //  00DB  LDCONST	R19	K60
-      0x7C440400,  //  00DC  CALL	R17	2
-      0x88480B1F,  //  00DD  GETMBR	R18	R5	K31
-      0x884C093A,  //  00DE  GETMBR	R19	R4	K58
-      0x00482413,  //  00DF  ADD	R18	R18	R19
-      0x8C4C0522,  //  00E0  GETMET	R19	R2	K34
-      0x7C4C0200,  //  00E1  CALL	R19	1
-      0x8C4C2723,  //  00E2  GETMET	R19	R19	K35
-      0x88540924,  //  00E3  GETMBR	R21	R4	K36
-      0x5C582400,  //  00E4  MOVE	R22	R18
-      0x5C5C2200,  //  00E5  MOVE	R23	R17
-      0x5462000F,  //  00E6  LDINT	R24	16
-      0x7C4C0A00,  //  00E7  CALL	R19	5
-      0x8C500527,  //  00E8  GETMET	R20	R2	K39
-      0x5C582600,  //  00E9  MOVE	R22	R19
-      0x605C0015,  //  00EA  GETGBL	R23	G21
-      0x7C5C0000,  //  00EB  CALL	R23	0
-      0x8C5C2F20,  //  00EC  GETMET	R23	R23	K32
-      0x5864003D,  //  00ED  LDCONST	R25	K61
-      0x7C5C0400,  //  00EE  CALL	R23	2
-      0x60600015,  //  00EF  GETGBL	R24	G21
-      0x7C600000,  //  00F0  CALL	R24	0
-      0x58640005,  //  00F1  LDCONST	R25	K5
-      0x546A000F,  //  00F2  LDINT	R26	16
-      0x7C500C00,  //  00F3  CALL	R20	6
-      0x8C542929,  //  00F4  GETMET	R21	R20	K41
-      0x7C540200,  //  00F5  CALL	R21	1
-      0xB85A1A00,  //  00F6  GETNGBL	R22	K13
-      0x8C582D3E,  //  00F7  GETMET	R22	R22	K62
-      0x7C580200,  //  00F8  CALL	R22	1
-      0x885C093A,  //  00F9  GETMBR	R23	R4	K58
-      0x905A2E17,  //  00FA  SETMBR	R22	K23	R23
-      0x885C0935,  //  00FB  GETMBR	R23	R4	K53
-      0x905A7E17,  //  00FC  SETMBR	R22	K63	R23
-      0x905A8015,  //  00FD  SETMBR	R22	K64	R21
-      0xB85E0E00,  //  00FE  GETNGBL	R23	K7
-      0x8C5C2F08,  //  00FF  GETMET	R23	R23	K8
-      0x5864002A,  //  0100  LDCONST	R25	K42
-      0x546A0003,  //  0101  LDINT	R26	4
-      0x7C5C0600,  //  0102  CALL	R23	3
-      0xB85E0E00,  //  0103  GETNGBL	R23	K7
-      0x8C5C2F08,  //  0104  GETMET	R23	R23	K8
-      0x8C64272C,  //  0105  GETMET	R25	R19	K44
-      0x7C640200,  //  0106  CALL	R25	1
-      0x00668219,  //  0107  ADD	R25	K65	R25
-      0x546A0003,  //  0108  LDINT	R26	4
-      0x7C5C0600,  //  0109  CALL	R23	3
-      0xB85E0E00,  //  010A  GETNGBL	R23	K7
-      0x8C5C2F08,  //  010B  GETMET	R23	R23	K8
-      0x8C64252C,  //  010C  GETMET	R25	R18	K44
-      0x7C640200,  //  010D  CALL	R25	1
-      0x00668419,  //  010E  ADD	R25	K66	R25
-      0x546A0003,  //  010F  LDINT	R26	4
-      0x7C5C0600,  //  0110  CALL	R23	3
-      0xB85E0E00,  //  0111  GETNGBL	R23	K7
-      0x8C5C2F08,  //  0112  GETMET	R23	R23	K8
-      0x8864093A,  //  0113  GETMBR	R25	R4	K58
-      0x8C64332C,  //  0114  GETMET	R25	R25	K44
-      0x7C640200,  //  0115  CALL	R25	1
-      0x00668619,  //  0116  ADD	R25	K67	R25
-      0x546A0003,  //  0117  LDINT	R26	4
-      0x7C5C0600,  //  0118  CALL	R23	3
-      0xB85E0E00,  //  0119  GETNGBL	R23	K7
-      0x8C5C2F08,  //  011A  GETMET	R23	R23	K8
-      0x60640008,  //  011B  GETGBL	R25	G8
-      0x88680935,  //  011C  GETMBR	R26	R4	K53
-      0x7C640200,  //  011D  CALL	R25	1
-      0x00668819,  //  011E  ADD	R25	K68	R25
-      0x546A0003,  //  011F  LDINT	R26	4
-      0x7C5C0600,  //  0120  CALL	R23	3
-      0xB85E0E00,  //  0121  GETNGBL	R23	K7
-      0x8C5C2F08,  //  0122  GETMET	R23	R23	K8
-      0x8C642B2C,  //  0123  GETMET	R25	R21	K44
-      0x7C640200,  //  0124  CALL	R25	1
-      0x00668A19,  //  0125  ADD	R25	K69	R25
-      0x546A0003,  //  0126  LDINT	R26	4
-      0x7C5C0600,  //  0127  CALL	R23	3
-      0xB85E0E00,  //  0128  GETNGBL	R23	K7
-      0x8C5C2F08,  //  0129  GETMET	R23	R23	K8
-      0x5864002A,  //  012A  LDCONST	R25	K42
-      0x546A0003,  //  012B  LDINT	R26	4
-      0x7C5C0600,  //  012C  CALL	R23	3
-      0x8C5C0522,  //  012D  GETMET	R23	R2	K34
-      0x7C5C0200,  //  012E  CALL	R23	1
-      0x8C5C2F23,  //  012F  GETMET	R23	R23	K35
-      0x88640924,  //  0130  GETMBR	R25	R4	K36
-      0x88680B1F,  //  0131  GETMBR	R26	R5	K31
-      0x886C093A,  //  0132  GETMBR	R27	R4	K58
-      0x0068341B,  //  0133  ADD	R26	R26	R27
-      0x606C0015,  //  0134  GETGBL	R27	G21
-      0x7C6C0000,  //  0135  CALL	R27	0
-      0x8C6C3720,  //  0136  GETMET	R27	R27	K32
-      0x58740046,  //  0137  LDCONST	R29	K70
-      0x7C6C0400,  //  0138  CALL	R27	2
-      0x5472002F,  //  0139  LDINT	R28	48
-      0x7C5C0A00,  //  013A  CALL	R23	5
-      0x5462000E,  //  013B  LDINT	R24	15
-      0x40620A18,  //  013C  CONNECT	R24	K5	R24
-      0x94602E18,  //  013D  GETIDX	R24	R23	R24
-      0x5466000F,  //  013E  LDINT	R25	16
-      0x546A001E,  //  013F  LDINT	R26	31
-      0x4064321A,  //  0140  CONNECT	R25	R25	R26
-      0x94642E19,  //  0141  GETIDX	R25	R23	R25
-      0x546A001F,  //  0142  LDINT	R26	32
-      0x546E002E,  //  0143  LDINT	R27	47
-      0x4068341B,  //  0144  CONNECT	R26	R26	R27
-      0x94682E1A,  //  0145  GETIDX	R26	R23	R26
-      0xB86E0E00,  //  0146  GETNGBL	R27	K7
-      0x8C6C3747,  //  0147  GETMET	R27	R27	K71
-      0x7C6C0200,  //  0148  CALL	R27	1
-      0x946C3748,  //  0149  GETIDX	R27	R27	K72
-      0xB8720E00,  //  014A  GETNGBL	R28	K7
-      0x8C703908,  //  014B  GETMET	R28	R28	K8
-      0x58780049,  //  014C  LDCONST	R30	K73
-      0x547E0003,  //  014D  LDINT	R31	4
-      0x7C700600,  //  014E  CALL	R28	3
-      0xB8720E00,  //  014F  GETNGBL	R28	K7
-      0x8C703908,  //  0150  GETMET	R28	R28	K8
-      0x8C78312C,  //  0151  GETMET	R30	R24	K44
-      0x7C780200,  //  0152  CALL	R30	1
-      0x007A941E,  //  0153  ADD	R30	K74	R30
-      0x547E0003,  //  0154  LDINT	R31	4
-      0x7C700600,  //  0155  CALL	R28	3
-      0xB8720E00,  //  0156  GETNGBL	R28	K7
-      0x8C703908,  //  0157  GETMET	R28	R28	K8
-      0x8C78332C,  //  0158  GETMET	R30	R25	K44
-      0x7C780200,  //  0159  CALL	R30	1
-      0x007A961E,  //  015A  ADD	R30	K75	R30
-      0x547E0003,  //  015B  LDINT	R31	4
-      0x7C700600,  //  015C  CALL	R28	3
-      0xB8720E00,  //  015D  GETNGBL	R28	K7
-      0x8C703908,  //  015E  GETMET	R28	R28	K8
-      0x8C78352C,  //  015F  GETMET	R30	R26	K44
-      0x7C780200,  //  0160  CALL	R30	1
-      0x007A981E,  //  0161  ADD	R30	K76	R30
-      0x547E0003,  //  0162  LDINT	R31	4
-      0x7C700600,  //  0163  CALL	R28	3
-      0xB8720E00,  //  0164  GETNGBL	R28	K7
-      0x8C703908,  //  0165  GETMET	R28	R28	K8
-      0x58780049,  //  0166  LDCONST	R30	K73
-      0x547E0003,  //  0167  LDINT	R31	4
-      0x7C700600,  //  0168  CALL	R28	3
-      0x8C702D4D,  //  0169  GETMET	R28	R22	K77
-      0x7C700200,  //  016A  CALL	R28	1
-      0x4C740000,  //  016B  LDNIL	R29
-      0x90129C1D,  //  016C  SETMBR	R4	K78	R29
-      0xB8760E00,  //  016D  GETNGBL	R29	K7
-      0x8C743B08,  //  016E  GETMET	R29	R29	K8
-      0xB87E1A00,  //  016F  GETNGBL	R31	K13
-      0x8C7C3F14,  //  0170  GETMET	R31	R31	K20
-      0x5C842C00,  //  0171  MOVE	R33	R22
-      0x7C7C0400,  //  0172  CALL	R31	2
-      0x007E9E1F,  //  0173  ADD	R31	K79	R31
-      0x54820003,  //  0174  LDINT	R32	4
+      0x88180B13,  //  0022  GETMBR	R6	R5	K19
+      0x90122406,  //  0023  SETMBR	R4	K18	R6
+      0x88180B14,  //  0024  GETMBR	R6	R5	K20
+      0x4C1C0000,  //  0025  LDNIL	R7
+      0x20180C07,  //  0026  NE	R6	R6	R7
+      0x781A0003,  //  0027  JMPF	R6	#002C
+      0x88180B15,  //  0028  GETMBR	R6	R5	K21
+      0x4C1C0000,  //  0029  LDNIL	R7
+      0x20180C07,  //  002A  NE	R6	R6	R7
+      0x741A0000,  //  002B  JMPT	R6	#002D
+      0x50180001,  //  002C  LDBOOL	R6	0	1
+      0x50180200,  //  002D  LDBOOL	R6	1	0
+      0xB81E0E00,  //  002E  GETNGBL	R7	K7
+      0x8C1C0F08,  //  002F  GETMET	R7	R7	K8
+      0x8C240716,  //  0030  GETMET	R9	R3	K22
+      0x582C0017,  //  0031  LDCONST	R11	K23
+      0x781A0001,  //  0032  JMPF	R6	#0035
+      0x5830000C,  //  0033  LDCONST	R12	K12
+      0x70020000,  //  0034  JMP		#0036
+      0x58300005,  //  0035  LDCONST	R12	K5
+      0x7C240600,  //  0036  CALL	R9	3
+      0x542A0003,  //  0037  LDINT	R10	4
+      0x7C1C0600,  //  0038  CALL	R7	3
+      0x50180000,  //  0039  LDBOOL	R6	0	0
+      0x4C1C0000,  //  003A  LDNIL	R7
+      0x781A001C,  //  003B  JMPF	R6	#0059
+      0x88200118,  //  003C  GETMBR	R8	R0	K24
+      0x88201119,  //  003D  GETMBR	R8	R8	K25
+      0x8C20111A,  //  003E  GETMET	R8	R8	K26
+      0x88280B14,  //  003F  GETMBR	R10	R5	K20
+      0x7C200400,  //  0040  CALL	R8	2
+      0x5C1C1000,  //  0041  MOVE	R7	R8
+      0xB8220E00,  //  0042  GETNGBL	R8	K7
+      0x8C201108,  //  0043  GETMET	R8	R8	K8
+      0x8C280716,  //  0044  GETMET	R10	R3	K22
+      0x5830001B,  //  0045  LDCONST	R12	K27
+      0xB8361A00,  //  0046  GETNGBL	R13	K13
+      0x8C341B1C,  //  0047  GETMET	R13	R13	K28
+      0x5C3C0800,  //  0048  MOVE	R15	R4
+      0x7C340400,  //  0049  CALL	R13	2
+      0xB83A1A00,  //  004A  GETNGBL	R14	K13
+      0x8C381D1C,  //  004B  GETMET	R14	R14	K28
+      0x5C400E00,  //  004C  MOVE	R16	R7
+      0x7C380400,  //  004D  CALL	R14	2
+      0x7C280800,  //  004E  CALL	R10	4
+      0x542E0003,  //  004F  LDINT	R11	4
+      0x7C200600,  //  0050  CALL	R8	3
+      0x4C200000,  //  0051  LDNIL	R8
+      0x1C200E08,  //  0052  EQ	R8	R7	R8
+      0x74220003,  //  0053  JMPT	R8	#0058
+      0x88200F1D,  //  0054  GETMBR	R8	R7	K29
+      0x4C240000,  //  0055  LDNIL	R9
+      0x1C201009,  //  0056  EQ	R8	R8	R9
+      0x78220000,  //  0057  JMPF	R8	#0059
+      0x50180000,  //  0058  LDBOOL	R6	0	0
+      0x781A013A,  //  0059  JMPF	R6	#0195
+      0x88200B1E,  //  005A  GETMBR	R8	R5	K30
+      0x88240B14,  //  005B  GETMBR	R9	R5	K20
+      0x00201009,  //  005C  ADD	R8	R8	R9
+      0x60240015,  //  005D  GETGBL	R9	G21
+      0x7C240000,  //  005E  CALL	R9	0
+      0x8C24131F,  //  005F  GETMET	R9	R9	K31
+      0x582C0020,  //  0060  LDCONST	R11	K32
+      0x7C240400,  //  0061  CALL	R9	2
+      0x8C280521,  //  0062  GETMET	R10	R2	K33
+      0x7C280200,  //  0063  CALL	R10	1
+      0x8C281522,  //  0064  GETMET	R10	R10	K34
+      0x88300F23,  //  0065  GETMBR	R12	R7	K35
+      0x5C341000,  //  0066  MOVE	R13	R8
+      0x5C381200,  //  0067  MOVE	R14	R9
+      0x543E000F,  //  0068  LDINT	R15	16
+      0x7C280A00,  //  0069  CALL	R10	5
+      0x602C0015,  //  006A  GETGBL	R11	G21
+      0x7C2C0000,  //  006B  CALL	R11	0
+      0x8C2C171F,  //  006C  GETMET	R11	R11	K31
+      0x58340024,  //  006D  LDCONST	R13	K36
+      0x7C2C0400,  //  006E  CALL	R11	2
+      0x5431FFEE,  //  006F  LDINT	R12	-17
+      0x40320A0C,  //  0070  CONNECT	R12	K5	R12
+      0x88340B15,  //  0071  GETMBR	R13	R5	K21
+      0x94301A0C,  //  0072  GETIDX	R12	R13	R12
+      0x5439FFEF,  //  0073  LDINT	R14	-16
+      0x40381D25,  //  0074  CONNECT	R14	R14	K37
+      0x883C0B15,  //  0075  GETMBR	R15	R5	K21
+      0x94341E0E,  //  0076  GETIDX	R13	R15	R14
+      0x8C400526,  //  0077  GETMET	R16	R2	K38
+      0x5C481400,  //  0078  MOVE	R18	R10
+      0x5C4C1600,  //  0079  MOVE	R19	R11
+      0x60500015,  //  007A  GETGBL	R20	G21
+      0x7C500000,  //  007B  CALL	R20	0
+      0x6054000C,  //  007C  GETGBL	R21	G12
+      0x5C581800,  //  007D  MOVE	R22	R12
+      0x7C540200,  //  007E  CALL	R21	1
+      0x545A000F,  //  007F  LDINT	R22	16
+      0x7C400C00,  //  0080  CALL	R16	6
+      0x5C382000,  //  0081  MOVE	R14	R16
+      0x8C401D27,  //  0082  GETMET	R16	R14	K39
+      0x5C481800,  //  0083  MOVE	R18	R12
+      0x7C400400,  //  0084  CALL	R16	2
+      0x5C3C2000,  //  0085  MOVE	R15	R16
+      0x8C401D28,  //  0086  GETMET	R16	R14	K40
+      0x7C400200,  //  0087  CALL	R16	1
+      0xB8460E00,  //  0088  GETNGBL	R17	K7
+      0x8C442308,  //  0089  GETMET	R17	R17	K8
+      0x584C0029,  //  008A  LDCONST	R19	K41
+      0x54520003,  //  008B  LDINT	R20	4
+      0x7C440600,  //  008C  CALL	R17	3
+      0xB8460E00,  //  008D  GETNGBL	R17	K7
+      0x8C442308,  //  008E  GETMET	R17	R17	K8
+      0x8C4C152B,  //  008F  GETMET	R19	R10	K43
+      0x7C4C0200,  //  0090  CALL	R19	1
+      0x004E5413,  //  0091  ADD	R19	K42	R19
+      0x54520003,  //  0092  LDINT	R20	4
+      0x7C440600,  //  0093  CALL	R17	3
+      0xB8460E00,  //  0094  GETNGBL	R17	K7
+      0x8C442308,  //  0095  GETMET	R17	R17	K8
+      0x8C4C1B2B,  //  0096  GETMET	R19	R13	K43
+      0x7C4C0200,  //  0097  CALL	R19	1
+      0x004E5813,  //  0098  ADD	R19	K44	R19
+      0x54520003,  //  0099  LDINT	R20	4
+      0x7C440600,  //  009A  CALL	R17	3
+      0xB8460E00,  //  009B  GETNGBL	R17	K7
+      0x8C442308,  //  009C  GETMET	R17	R17	K8
+      0x8C4C1F2B,  //  009D  GETMET	R19	R15	K43
+      0x7C4C0200,  //  009E  CALL	R19	1
+      0x004E5A13,  //  009F  ADD	R19	K45	R19
+      0x54520003,  //  00A0  LDINT	R20	4
+      0x7C440600,  //  00A1  CALL	R17	3
+      0xB8460E00,  //  00A2  GETNGBL	R17	K7
+      0x8C442308,  //  00A3  GETMET	R17	R17	K8
+      0x8C4C212B,  //  00A4  GETMET	R19	R16	K43
+      0x7C4C0200,  //  00A5  CALL	R19	1
+      0x004E5C13,  //  00A6  ADD	R19	K46	R19
+      0x54520003,  //  00A7  LDINT	R20	4
+      0x7C440600,  //  00A8  CALL	R17	3
+      0xB8460E00,  //  00A9  GETNGBL	R17	K7
+      0x8C442308,  //  00AA  GETMET	R17	R17	K8
+      0x584C0029,  //  00AB  LDCONST	R19	K41
+      0x54520003,  //  00AC  LDINT	R20	4
+      0x7C440600,  //  00AD  CALL	R17	3
+      0x1C441A10,  //  00AE  EQ	R17	R13	R16
+      0x784600E3,  //  00AF  JMPF	R17	#0194
+      0x88440F1D,  //  00B0  GETMBR	R17	R7	K29
+      0x90123A11,  //  00B1  SETMBR	R4	K29	R17
+      0x88440330,  //  00B2  GETMBR	R17	R1	K48
+      0x90125E11,  //  00B3  SETMBR	R4	K47	R17
+      0x8C440931,  //  00B4  GETMET	R17	R4	K49
+      0x7C440200,  //  00B5  CALL	R17	1
+      0x88440B33,  //  00B6  GETMBR	R17	R5	K51
+      0x90126411,  //  00B7  SETMBR	R4	K50	R17
+      0x88440118,  //  00B8  GETMBR	R17	R0	K24
+      0x88442319,  //  00B9  GETMBR	R17	R17	K25
+      0x8C442335,  //  00BA  GETMET	R17	R17	K53
+      0x7C440200,  //  00BB  CALL	R17	1
+      0x90126811,  //  00BC  SETMBR	R4	K52	R17
+      0xB8460E00,  //  00BD  GETNGBL	R17	K7
+      0x8C442308,  //  00BE  GETMET	R17	R17	K8
+      0x8C4C0716,  //  00BF  GETMET	R19	R3	K22
+      0x58540036,  //  00C0  LDCONST	R21	K54
+      0x88580934,  //  00C1  GETMBR	R22	R4	K52
+      0x885C0337,  //  00C2  GETMBR	R23	R1	K55
+      0x88600338,  //  00C3  GETMBR	R24	R1	K56
+      0x7C4C0A00,  //  00C4  CALL	R19	5
+      0x5850000A,  //  00C5  LDCONST	R20	K10
+      0x7C440600,  //  00C6  CALL	R17	3
+      0x88440F23,  //  00C7  GETMBR	R17	R7	K35
+      0x90124611,  //  00C8  SETMBR	R4	K35	R17
+      0x8C44053A,  //  00C9  GETMET	R17	R2	K58
+      0x544E000F,  //  00CA  LDINT	R19	16
+      0x7C440400,  //  00CB  CALL	R17	2
+      0x90127211,  //  00CC  SETMBR	R4	K57	R17
+      0x60440015,  //  00CD  GETGBL	R17	G21
+      0x7C440000,  //  00CE  CALL	R17	0
+      0x8C44231F,  //  00CF  GETMET	R17	R17	K31
+      0x584C003B,  //  00D0  LDCONST	R19	K59
+      0x7C440400,  //  00D1  CALL	R17	2
+      0x88480B1E,  //  00D2  GETMBR	R18	R5	K30
+      0x884C0939,  //  00D3  GETMBR	R19	R4	K57
+      0x00482413,  //  00D4  ADD	R18	R18	R19
+      0x8C4C0521,  //  00D5  GETMET	R19	R2	K33
+      0x7C4C0200,  //  00D6  CALL	R19	1
+      0x8C4C2722,  //  00D7  GETMET	R19	R19	K34
+      0x88540923,  //  00D8  GETMBR	R21	R4	K35
+      0x5C582400,  //  00D9  MOVE	R22	R18
+      0x5C5C2200,  //  00DA  MOVE	R23	R17
+      0x5462000F,  //  00DB  LDINT	R24	16
+      0x7C4C0A00,  //  00DC  CALL	R19	5
+      0x8C500526,  //  00DD  GETMET	R20	R2	K38
+      0x5C582600,  //  00DE  MOVE	R22	R19
+      0x605C0015,  //  00DF  GETGBL	R23	G21
+      0x7C5C0000,  //  00E0  CALL	R23	0
+      0x8C5C2F1F,  //  00E1  GETMET	R23	R23	K31
+      0x5864003C,  //  00E2  LDCONST	R25	K60
+      0x7C5C0400,  //  00E3  CALL	R23	2
+      0x60600015,  //  00E4  GETGBL	R24	G21
+      0x7C600000,  //  00E5  CALL	R24	0
+      0x58640005,  //  00E6  LDCONST	R25	K5
+      0x546A000F,  //  00E7  LDINT	R26	16
+      0x7C500C00,  //  00E8  CALL	R20	6
+      0x8C542928,  //  00E9  GETMET	R21	R20	K40
+      0x7C540200,  //  00EA  CALL	R21	1
+      0xB85A1A00,  //  00EB  GETNGBL	R22	K13
+      0x8C582D3D,  //  00EC  GETMET	R22	R22	K61
+      0x7C580200,  //  00ED  CALL	R22	1
+      0x885C0939,  //  00EE  GETMBR	R23	R4	K57
+      0x905A2817,  //  00EF  SETMBR	R22	K20	R23
+      0x885C0934,  //  00F0  GETMBR	R23	R4	K52
+      0x905A7C17,  //  00F1  SETMBR	R22	K62	R23
+      0x905A7E15,  //  00F2  SETMBR	R22	K63	R21
+      0xB85E0E00,  //  00F3  GETNGBL	R23	K7
+      0x8C5C2F08,  //  00F4  GETMET	R23	R23	K8
+      0x58640029,  //  00F5  LDCONST	R25	K41
+      0x546A0003,  //  00F6  LDINT	R26	4
+      0x7C5C0600,  //  00F7  CALL	R23	3
+      0xB85E0E00,  //  00F8  GETNGBL	R23	K7
+      0x8C5C2F08,  //  00F9  GETMET	R23	R23	K8
+      0x8C64272B,  //  00FA  GETMET	R25	R19	K43
+      0x7C640200,  //  00FB  CALL	R25	1
+      0x00668019,  //  00FC  ADD	R25	K64	R25
+      0x546A0003,  //  00FD  LDINT	R26	4
+      0x7C5C0600,  //  00FE  CALL	R23	3
+      0xB85E0E00,  //  00FF  GETNGBL	R23	K7
+      0x8C5C2F08,  //  0100  GETMET	R23	R23	K8
+      0x8C64252B,  //  0101  GETMET	R25	R18	K43
+      0x7C640200,  //  0102  CALL	R25	1
+      0x00668219,  //  0103  ADD	R25	K65	R25
+      0x546A0003,  //  0104  LDINT	R26	4
+      0x7C5C0600,  //  0105  CALL	R23	3
+      0xB85E0E00,  //  0106  GETNGBL	R23	K7
+      0x8C5C2F08,  //  0107  GETMET	R23	R23	K8
+      0x88640939,  //  0108  GETMBR	R25	R4	K57
+      0x8C64332B,  //  0109  GETMET	R25	R25	K43
+      0x7C640200,  //  010A  CALL	R25	1
+      0x00668419,  //  010B  ADD	R25	K66	R25
+      0x546A0003,  //  010C  LDINT	R26	4
+      0x7C5C0600,  //  010D  CALL	R23	3
+      0xB85E0E00,  //  010E  GETNGBL	R23	K7
+      0x8C5C2F08,  //  010F  GETMET	R23	R23	K8
+      0x60640008,  //  0110  GETGBL	R25	G8
+      0x88680934,  //  0111  GETMBR	R26	R4	K52
+      0x7C640200,  //  0112  CALL	R25	1
+      0x00668619,  //  0113  ADD	R25	K67	R25
+      0x546A0003,  //  0114  LDINT	R26	4
+      0x7C5C0600,  //  0115  CALL	R23	3
+      0xB85E0E00,  //  0116  GETNGBL	R23	K7
+      0x8C5C2F08,  //  0117  GETMET	R23	R23	K8
+      0x8C642B2B,  //  0118  GETMET	R25	R21	K43
+      0x7C640200,  //  0119  CALL	R25	1
+      0x00668819,  //  011A  ADD	R25	K68	R25
+      0x546A0003,  //  011B  LDINT	R26	4
+      0x7C5C0600,  //  011C  CALL	R23	3
+      0xB85E0E00,  //  011D  GETNGBL	R23	K7
+      0x8C5C2F08,  //  011E  GETMET	R23	R23	K8
+      0x58640029,  //  011F  LDCONST	R25	K41
+      0x546A0003,  //  0120  LDINT	R26	4
+      0x7C5C0600,  //  0121  CALL	R23	3
+      0x8C5C0521,  //  0122  GETMET	R23	R2	K33
+      0x7C5C0200,  //  0123  CALL	R23	1
+      0x8C5C2F22,  //  0124  GETMET	R23	R23	K34
+      0x88640923,  //  0125  GETMBR	R25	R4	K35
+      0x88680B1E,  //  0126  GETMBR	R26	R5	K30
+      0x886C0939,  //  0127  GETMBR	R27	R4	K57
+      0x0068341B,  //  0128  ADD	R26	R26	R27
+      0x606C0015,  //  0129  GETGBL	R27	G21
+      0x7C6C0000,  //  012A  CALL	R27	0
+      0x8C6C371F,  //  012B  GETMET	R27	R27	K31
+      0x58740045,  //  012C  LDCONST	R29	K69
+      0x7C6C0400,  //  012D  CALL	R27	2
+      0x5472002F,  //  012E  LDINT	R28	48
+      0x7C5C0A00,  //  012F  CALL	R23	5
+      0x5462000E,  //  0130  LDINT	R24	15
+      0x40620A18,  //  0131  CONNECT	R24	K5	R24
+      0x94602E18,  //  0132  GETIDX	R24	R23	R24
+      0x5466000F,  //  0133  LDINT	R25	16
+      0x546A001E,  //  0134  LDINT	R26	31
+      0x4064321A,  //  0135  CONNECT	R25	R25	R26
+      0x94642E19,  //  0136  GETIDX	R25	R23	R25
+      0x546A001F,  //  0137  LDINT	R26	32
+      0x546E002E,  //  0138  LDINT	R27	47
+      0x4068341B,  //  0139  CONNECT	R26	R26	R27
+      0x94682E1A,  //  013A  GETIDX	R26	R23	R26
+      0xB86E0E00,  //  013B  GETNGBL	R27	K7
+      0x8C6C3746,  //  013C  GETMET	R27	R27	K70
+      0x7C6C0200,  //  013D  CALL	R27	1
+      0x946C3747,  //  013E  GETIDX	R27	R27	K71
+      0xB8720E00,  //  013F  GETNGBL	R28	K7
+      0x8C703908,  //  0140  GETMET	R28	R28	K8
+      0x58780048,  //  0141  LDCONST	R30	K72
+      0x547E0003,  //  0142  LDINT	R31	4
+      0x7C700600,  //  0143  CALL	R28	3
+      0xB8720E00,  //  0144  GETNGBL	R28	K7
+      0x8C703908,  //  0145  GETMET	R28	R28	K8
+      0x8C78312B,  //  0146  GETMET	R30	R24	K43
+      0x7C780200,  //  0147  CALL	R30	1
+      0x007A921E,  //  0148  ADD	R30	K73	R30
+      0x547E0003,  //  0149  LDINT	R31	4
+      0x7C700600,  //  014A  CALL	R28	3
+      0xB8720E00,  //  014B  GETNGBL	R28	K7
+      0x8C703908,  //  014C  GETMET	R28	R28	K8
+      0x8C78332B,  //  014D  GETMET	R30	R25	K43
+      0x7C780200,  //  014E  CALL	R30	1
+      0x007A941E,  //  014F  ADD	R30	K74	R30
+      0x547E0003,  //  0150  LDINT	R31	4
+      0x7C700600,  //  0151  CALL	R28	3
+      0xB8720E00,  //  0152  GETNGBL	R28	K7
+      0x8C703908,  //  0153  GETMET	R28	R28	K8
+      0x8C78352B,  //  0154  GETMET	R30	R26	K43
+      0x7C780200,  //  0155  CALL	R30	1
+      0x007A961E,  //  0156  ADD	R30	K75	R30
+      0x547E0003,  //  0157  LDINT	R31	4
+      0x7C700600,  //  0158  CALL	R28	3
+      0xB8720E00,  //  0159  GETNGBL	R28	K7
+      0x8C703908,  //  015A  GETMET	R28	R28	K8
+      0x58780048,  //  015B  LDCONST	R30	K72
+      0x547E0003,  //  015C  LDINT	R31	4
+      0x7C700600,  //  015D  CALL	R28	3
+      0x8C702D4C,  //  015E  GETMET	R28	R22	K76
+      0x7C700200,  //  015F  CALL	R28	1
+      0x4C740000,  //  0160  LDNIL	R29
+      0x90129A1D,  //  0161  SETMBR	R4	K77	R29
+      0xB8760E00,  //  0162  GETNGBL	R29	K7
+      0x8C743B08,  //  0163  GETMET	R29	R29	K8
+      0xB87E1A00,  //  0164  GETNGBL	R31	K13
+      0x8C7C3F1C,  //  0165  GETMET	R31	R31	K28
+      0x5C842C00,  //  0166  MOVE	R33	R22
+      0x7C7C0400,  //  0167  CALL	R31	2
+      0x007E9C1F,  //  0168  ADD	R31	K78	R31
+      0x54820003,  //  0169  LDINT	R32	4
+      0x7C740600,  //  016A  CALL	R29	3
+      0xB8760E00,  //  016B  GETNGBL	R29	K7
+      0x8C743B08,  //  016C  GETMET	R29	R29	K8
+      0x8C7C392B,  //  016D  GETMET	R31	R28	K43
+      0x7C7C0200,  //  016E  CALL	R31	1
+      0x007E9E1F,  //  016F  ADD	R31	K79	R31
+      0x54820003,  //  0170  LDINT	R32	4
+      0x7C740600,  //  0171  CALL	R29	3
+      0x8C740350,  //  0172  GETMET	R29	R1	K80
+      0x547E0032,  //  0173  LDINT	R31	51
+      0x50800200,  //  0174  LDBOOL	R32	1	0
       0x7C740600,  //  0175  CALL	R29	3
-      0xB8760E00,  //  0176  GETNGBL	R29	K7
-      0x8C743B08,  //  0177  GETMET	R29	R29	K8
-      0x8C7C392C,  //  0178  GETMET	R31	R28	K44
-      0x7C7C0200,  //  0179  CALL	R31	1
-      0x007EA01F,  //  017A  ADD	R31	K80	R31
-      0x54820003,  //  017B  LDINT	R32	4
-      0x7C740600,  //  017C  CALL	R29	3
-      0x8C740351,  //  017D  GETMET	R29	R1	K81
-      0x547E0032,  //  017E  LDINT	R31	51
-      0x50800200,  //  017F  LDBOOL	R32	1	0
-      0x7C740600,  //  0180  CALL	R29	3
-      0x8C783B52,  //  0181  GETMET	R30	R29	K82
-      0x5C803800,  //  0182  MOVE	R32	R28
-      0x7C780400,  //  0183  CALL	R30	2
-      0x887C0153,  //  0184  GETMBR	R31	R0	K83
-      0x8C7C3F54,  //  0185  GETMET	R31	R31	K84
-      0x5C843A00,  //  0186  MOVE	R33	R29
-      0x7C7C0400,  //  0187  CALL	R31	2
-      0x8C7C0955,  //  0188  GETMET	R31	R4	K85
-      0x7C7C0200,  //  0189  CALL	R31	1
-      0x8C7C0956,  //  018A  GETMET	R31	R4	K86
-      0x5C843000,  //  018B  MOVE	R33	R24
-      0x5C883200,  //  018C  MOVE	R34	R25
-      0x5C8C3400,  //  018D  MOVE	R35	R26
-      0x5C903600,  //  018E  MOVE	R36	R27
-      0x7C7C0A00,  //  018F  CALL	R31	5
-      0x9012AF05,  //  0190  SETMBR	R4	K87	K5
-      0x8C7C0958,  //  0191  GETMET	R31	R4	K88
-      0x7C7C0200,  //  0192  CALL	R31	1
-      0x8C7C0959,  //  0193  GETMET	R31	R4	K89
-      0x50840200,  //  0194  LDBOOL	R33	1	0
-      0x7C7C0400,  //  0195  CALL	R31	2
-      0x8C7C095A,  //  0196  GETMET	R31	R4	K90
-      0x7C7C0200,  //  0197  CALL	R31	1
-      0x8C7C095B,  //  0198  GETMET	R31	R4	K91
-      0x7C7C0200,  //  0199  CALL	R31	1
-      0x8C7C095C,  //  019A  GETMET	R31	R4	K92
-      0x7C7C0200,  //  019B  CALL	R31	1
-      0x507C0200,  //  019C  LDBOOL	R31	1	0
-      0x80043E00,  //  019D  RET	1	R31
-      0x70020000,  //  019E  JMP		#01A0
-      0x50180000,  //  019F  LDBOOL	R6	0	0
-      0x5C200C00,  //  01A0  MOVE	R8	R6
-      0x74220174,  //  01A1  JMPT	R8	#0317
-      0x8C20015D,  //  01A2  GETMET	R8	R0	K93
-      0x88280B5E,  //  01A3  GETMBR	R10	R5	K94
-      0x882C0B1F,  //  01A4  GETMBR	R11	R5	K31
-      0x7C200600,  //  01A5  CALL	R8	3
-      0x90123C08,  //  01A6  SETMBR	R4	K30	R8
-      0x4C240000,  //  01A7  LDNIL	R9
-      0x1C240809,  //  01A8  EQ	R9	R4	R9
-      0x74260003,  //  01A9  JMPT	R9	#01AE
-      0x8824091E,  //  01AA  GETMBR	R9	R4	K30
-      0x4C280000,  //  01AB  LDNIL	R10
-      0x1C24120A,  //  01AC  EQ	R9	R9	R10
-      0x7826000D,  //  01AD  JMPF	R9	#01BC
-      0xB8260E00,  //  01AE  GETNGBL	R9	K7
-      0x8C241308,  //  01AF  GETMET	R9	R9	K8
-      0x582C005F,  //  01B0  LDCONST	R11	K95
-      0x5830000A,  //  01B1  LDCONST	R12	K10
-      0x7C240600,  //  01B2  CALL	R9	3
-      0x8C24010B,  //  01B3  GETMET	R9	R0	K11
-      0x5C2C0200,  //  01B4  MOVE	R11	R1
-      0x5830000C,  //  01B5  LDCONST	R12	K12
-      0x58340005,  //  01B6  LDCONST	R13	K5
-      0x5838000C,  //  01B7  LDCONST	R14	K12
-      0x503C0000,  //  01B8  LDBOOL	R15	0	0
-      0x7C240C00,  //  01B9  CALL	R9	6
-      0x50280000,  //  01BA  LDBOOL	R10	0	0
-      0x80041400,  //  01BB  RET	1	R10
-      0x88240331,  //  01BC  GETMBR	R9	R1	K49
-      0x90126009,  //  01BD  SETMBR	R4	K48	R9
-      0x8C240932,  //  01BE  GETMET	R9	R4	K50
-      0x7C240200,  //  01BF  CALL	R9	1
-      0x88240B34,  //  01C0  GETMBR	R9	R5	K52
-      0x90126609,  //  01C1  SETMBR	R4	K51	R9
-      0x8824011A,  //  01C2  GETMBR	R9	R0	K26
-      0x8824131B,  //  01C3  GETMBR	R9	R9	K27
-      0x8C241336,  //  01C4  GETMET	R9	R9	K54
-      0x7C240200,  //  01C5  CALL	R9	1
-      0x90126A09,  //  01C6  SETMBR	R4	K53	R9
-      0xB8260E00,  //  01C7  GETNGBL	R9	K7
-      0x8C241308,  //  01C8  GETMET	R9	R9	K8
-      0x8C2C0712,  //  01C9  GETMET	R11	R3	K18
-      0x58340037,  //  01CA  LDCONST	R13	K55
-      0x88380935,  //  01CB  GETMBR	R14	R4	K53
-      0x883C0338,  //  01CC  GETMBR	R15	R1	K56
-      0x88400339,  //  01CD  GETMBR	R16	R1	K57
-      0x7C2C0A00,  //  01CE  CALL	R11	5
-      0x5830000A,  //  01CF  LDCONST	R12	K10
-      0x7C240600,  //  01D0  CALL	R9	3
-      0xB8260E00,  //  01D1  GETNGBL	R9	K7
-      0x8C241308,  //  01D2  GETMET	R9	R9	K8
-      0xB82E1A00,  //  01D3  GETNGBL	R11	K13
-      0x8C2C1714,  //  01D4  GETMET	R11	R11	K20
-      0x8834091E,  //  01D5  GETMBR	R13	R4	K30
-      0x7C2C0400,  //  01D6  CALL	R11	2
-      0x002EC00B,  //  01D7  ADD	R11	K96	R11
-      0x54320003,  //  01D8  LDINT	R12	4
-      0x7C240600,  //  01D9  CALL	R9	3
-      0xB8260E00,  //  01DA  GETNGBL	R9	K7
-      0x8C241308,  //  01DB  GETMET	R9	R9	K8
-      0x882C091E,  //  01DC  GETMBR	R11	R4	K30
-      0x882C1762,  //  01DD  GETMBR	R11	R11	K98
-      0x8C2C172C,  //  01DE  GETMET	R11	R11	K44
-      0x7C2C0200,  //  01DF  CALL	R11	1
-      0x002EC20B,  //  01E0  ADD	R11	K97	R11
-      0x54320003,  //  01E1  LDINT	R12	4
-      0x7C240600,  //  01E2  CALL	R9	3
-      0xB8260E00,  //  01E3  GETNGBL	R9	K7
-      0x8C241308,  //  01E4  GETMET	R9	R9	K8
-      0x882C091E,  //  01E5  GETMBR	R11	R4	K30
-      0x882C1764,  //  01E6  GETMBR	R11	R11	K100
-      0x8C2C172C,  //  01E7  GETMET	R11	R11	K44
-      0x7C2C0200,  //  01E8  CALL	R11	1
-      0x002EC60B,  //  01E9  ADD	R11	K99	R11
-      0x54320003,  //  01EA  LDINT	R12	4
-      0x7C240600,  //  01EB  CALL	R9	3
-      0x8824091E,  //  01EC  GETMBR	R9	R4	K30
-      0x8C241365,  //  01ED  GETMET	R9	R9	K101
-      0x7C240200,  //  01EE  CALL	R9	1
-      0x78260009,  //  01EF  JMPF	R9	#01FA
-      0xB8260E00,  //  01F0  GETNGBL	R9	K7
-      0x8C241308,  //  01F1  GETMET	R9	R9	K8
-      0x882C091E,  //  01F2  GETMBR	R11	R4	K30
-      0x8C2C1765,  //  01F3  GETMET	R11	R11	K101
-      0x7C2C0200,  //  01F4  CALL	R11	1
-      0x8C2C172C,  //  01F5  GETMET	R11	R11	K44
-      0x7C2C0200,  //  01F6  CALL	R11	1
-      0x002ECC0B,  //  01F7  ADD	R11	K102	R11
-      0x54320003,  //  01F8  LDINT	R12	4
-      0x7C240600,  //  01F9  CALL	R9	3
-      0xB8260E00,  //  01FA  GETNGBL	R9	K7
-      0x8C241308,  //  01FB  GETMET	R9	R9	K8
-      0x882C091E,  //  01FC  GETMBR	R11	R4	K30
-      0x882C1768,  //  01FD  GETMBR	R11	R11	K104
-      0x8C2C172C,  //  01FE  GETMET	R11	R11	K44
-      0x7C2C0200,  //  01FF  CALL	R11	1
-      0x002ECE0B,  //  0200  ADD	R11	K103	R11
-      0x54320003,  //  0201  LDINT	R12	4
-      0x7C240600,  //  0202  CALL	R9	3
-      0x8C24053B,  //  0203  GETMET	R9	R2	K59
-      0x542E000F,  //  0204  LDINT	R11	16
-      0x7C240400,  //  0205  CALL	R9	2
-      0x90127409,  //  0206  SETMBR	R4	K58	R9
-      0x8C24053B,  //  0207  GETMET	R9	R2	K59
-      0x542E001F,  //  0208  LDINT	R11	32
-      0x7C240400,  //  0209  CALL	R9	2
-      0x9012D209,  //  020A  SETMBR	R4	K105	R9
-      0x8C24056B,  //  020B  GETMET	R9	R2	K107
-      0x7C240200,  //  020C  CALL	R9	1
-      0x8C24136C,  //  020D  GETMET	R9	R9	K108
-      0x882C0969,  //  020E  GETMBR	R11	R4	K105
-      0x7C240400,  //  020F  CALL	R9	2
-      0x9012D409,  //  0210  SETMBR	R4	K106	R9
-      0xB8260E00,  //  0211  GETNGBL	R9	K7
-      0x8C241308,  //  0212  GETMET	R9	R9	K8
-      0x882C0969,  //  0213  GETMBR	R11	R4	K105
-      0x8C2C172C,  //  0214  GETMET	R11	R11	K44
-      0x7C2C0200,  //  0215  CALL	R11	1
-      0x002EDA0B,  //  0216  ADD	R11	K109	R11
-      0x54320003,  //  0217  LDINT	R12	4
-      0x7C240600,  //  0218  CALL	R9	3
-      0xB8260E00,  //  0219  GETNGBL	R9	K7
-      0x8C241308,  //  021A  GETMET	R9	R9	K8
-      0x882C096A,  //  021B  GETMBR	R11	R4	K106
-      0x8C2C172C,  //  021C  GETMET	R11	R11	K44
-      0x7C2C0200,  //  021D  CALL	R11	1
-      0x002EDC0B,  //  021E  ADD	R11	K110	R11
-      0x54320003,  //  021F  LDINT	R12	4
-      0x7C240600,  //  0220  CALL	R9	3
-      0x8C24053B,  //  0221  GETMET	R9	R2	K59
-      0x542E001F,  //  0222  LDINT	R11	32
-      0x7C240400,  //  0223  CALL	R9	2
-      0x8C28056B,  //  0224  GETMET	R10	R2	K107
-      0x7C280200,  //  0225  CALL	R10	1
-      0x8C28156F,  //  0226  GETMET	R10	R10	K111
-      0x88300969,  //  0227  GETMBR	R12	R4	K105
-      0x88340B16,  //  0228  GETMBR	R13	R5	K22
-      0x7C280600,  //  0229  CALL	R10	3
-      0x9012480A,  //  022A  SETMBR	R4	K36	R10
-      0xB82A1A00,  //  022B  GETNGBL	R10	K13
-      0x88281570,  //  022C  GETMBR	R10	R10	K112
-      0x8C281571,  //  022D  GETMET	R10	R10	K113
-      0x7C280200,  //  022E  CALL	R10	1
-      0x8C2C1572,  //  022F  GETMET	R11	R10	K114
-      0x5834000C,  //  0230  LDCONST	R13	K12
-      0xB83A1A00,  //  0231  GETNGBL	R14	K13
-      0x88381D70,  //  0232  GETMBR	R14	R14	K112
-      0x88381D73,  //  0233  GETMBR	R14	R14	K115
-      0x8C3C0974,  //  0234  GETMET	R15	R4	K116
-      0x7C3C0200,  //  0235  CALL	R15	1
-      0x7C2C0800,  //  0236  CALL	R11	4
-      0x8C2C1572,  //  0237  GETMET	R11	R10	K114
-      0x5834000A,  //  0238  LDCONST	R13	K10
-      0xB83A1A00,  //  0239  GETNGBL	R14	K13
-      0x88381D70,  //  023A  GETMBR	R14	R14	K112
-      0x88381D73,  //  023B  GETMBR	R14	R14	K115
-      0x8C3C0965,  //  023C  GETMET	R15	R4	K101
+      0x8C783B51,  //  0176  GETMET	R30	R29	K81
+      0x5C803800,  //  0177  MOVE	R32	R28
+      0x7C780400,  //  0178  CALL	R30	2
+      0x887C0152,  //  0179  GETMBR	R31	R0	K82
+      0x8C7C3F53,  //  017A  GETMET	R31	R31	K83
+      0x5C843A00,  //  017B  MOVE	R33	R29
+      0x7C7C0400,  //  017C  CALL	R31	2
+      0x8C7C0954,  //  017D  GETMET	R31	R4	K84
+      0x7C7C0200,  //  017E  CALL	R31	1
+      0x8C7C0955,  //  017F  GETMET	R31	R4	K85
+      0x5C843000,  //  0180  MOVE	R33	R24
+      0x5C883200,  //  0181  MOVE	R34	R25
+      0x5C8C3400,  //  0182  MOVE	R35	R26
+      0x5C903600,  //  0183  MOVE	R36	R27
+      0x7C7C0A00,  //  0184  CALL	R31	5
+      0x9012AD05,  //  0185  SETMBR	R4	K86	K5
+      0x8C7C0957,  //  0186  GETMET	R31	R4	K87
+      0x7C7C0200,  //  0187  CALL	R31	1
+      0x8C7C0958,  //  0188  GETMET	R31	R4	K88
+      0x50840200,  //  0189  LDBOOL	R33	1	0
+      0x7C7C0400,  //  018A  CALL	R31	2
+      0x8C7C0959,  //  018B  GETMET	R31	R4	K89
+      0x7C7C0200,  //  018C  CALL	R31	1
+      0x8C7C095A,  //  018D  GETMET	R31	R4	K90
+      0x7C7C0200,  //  018E  CALL	R31	1
+      0x8C7C095B,  //  018F  GETMET	R31	R4	K91
+      0x7C7C0200,  //  0190  CALL	R31	1
+      0x507C0200,  //  0191  LDBOOL	R31	1	0
+      0x80043E00,  //  0192  RET	1	R31
+      0x70020000,  //  0193  JMP		#0195
+      0x50180000,  //  0194  LDBOOL	R6	0	0
+      0x5C200C00,  //  0195  MOVE	R8	R6
+      0x742200E1,  //  0196  JMPT	R8	#0279
+      0x8C20015C,  //  0197  GETMET	R8	R0	K92
+      0x88280B5D,  //  0198  GETMBR	R10	R5	K93
+      0x882C0B1E,  //  0199  GETMBR	R11	R5	K30
+      0x7C200600,  //  019A  CALL	R8	3
+      0x90123A08,  //  019B  SETMBR	R4	K29	R8
+      0x4C240000,  //  019C  LDNIL	R9
+      0x1C240809,  //  019D  EQ	R9	R4	R9
+      0x74260003,  //  019E  JMPT	R9	#01A3
+      0x8824091D,  //  019F  GETMBR	R9	R4	K29
+      0x4C280000,  //  01A0  LDNIL	R10
+      0x1C24120A,  //  01A1  EQ	R9	R9	R10
+      0x7826000D,  //  01A2  JMPF	R9	#01B1
+      0xB8260E00,  //  01A3  GETNGBL	R9	K7
+      0x8C241308,  //  01A4  GETMET	R9	R9	K8
+      0x582C005E,  //  01A5  LDCONST	R11	K94
+      0x5830000A,  //  01A6  LDCONST	R12	K10
+      0x7C240600,  //  01A7  CALL	R9	3
+      0x8C24010B,  //  01A8  GETMET	R9	R0	K11
+      0x5C2C0200,  //  01A9  MOVE	R11	R1
+      0x5830000C,  //  01AA  LDCONST	R12	K12
+      0x58340005,  //  01AB  LDCONST	R13	K5
+      0x5838000C,  //  01AC  LDCONST	R14	K12
+      0x503C0000,  //  01AD  LDBOOL	R15	0	0
+      0x7C240C00,  //  01AE  CALL	R9	6
+      0x50280000,  //  01AF  LDBOOL	R10	0	0
+      0x80041400,  //  01B0  RET	1	R10
+      0x88240330,  //  01B1  GETMBR	R9	R1	K48
+      0x90125E09,  //  01B2  SETMBR	R4	K47	R9
+      0x8C240931,  //  01B3  GETMET	R9	R4	K49
+      0x7C240200,  //  01B4  CALL	R9	1
+      0x88240B33,  //  01B5  GETMBR	R9	R5	K51
+      0x90126409,  //  01B6  SETMBR	R4	K50	R9
+      0x88240118,  //  01B7  GETMBR	R9	R0	K24
+      0x88241319,  //  01B8  GETMBR	R9	R9	K25
+      0x8C241335,  //  01B9  GETMET	R9	R9	K53
+      0x7C240200,  //  01BA  CALL	R9	1
+      0x90126809,  //  01BB  SETMBR	R4	K52	R9
+      0xB8260E00,  //  01BC  GETNGBL	R9	K7
+      0x8C241308,  //  01BD  GETMET	R9	R9	K8
+      0x8C2C0716,  //  01BE  GETMET	R11	R3	K22
+      0x58340036,  //  01BF  LDCONST	R13	K54
+      0x88380934,  //  01C0  GETMBR	R14	R4	K52
+      0x883C0337,  //  01C1  GETMBR	R15	R1	K55
+      0x88400338,  //  01C2  GETMBR	R16	R1	K56
+      0x7C2C0A00,  //  01C3  CALL	R11	5
+      0x5830000A,  //  01C4  LDCONST	R12	K10
+      0x7C240600,  //  01C5  CALL	R9	3
+      0x8824091D,  //  01C6  GETMBR	R9	R4	K29
+      0x8C24135F,  //  01C7  GETMET	R9	R9	K95
+      0x7C240200,  //  01C8  CALL	R9	1
+      0x7825FFFF,  //  01C9  JMPF	R9	#01CA
+      0x8C24053A,  //  01CA  GETMET	R9	R2	K58
+      0x542E000F,  //  01CB  LDINT	R11	16
+      0x7C240400,  //  01CC  CALL	R9	2
+      0x90127209,  //  01CD  SETMBR	R4	K57	R9
+      0x8C24053A,  //  01CE  GETMET	R9	R2	K58
+      0x542E001F,  //  01CF  LDINT	R11	32
+      0x7C240400,  //  01D0  CALL	R9	2
+      0x9012C009,  //  01D1  SETMBR	R4	K96	R9
+      0x8C240562,  //  01D2  GETMET	R9	R2	K98
+      0x7C240200,  //  01D3  CALL	R9	1
+      0x8C241363,  //  01D4  GETMET	R9	R9	K99
+      0x882C0960,  //  01D5  GETMBR	R11	R4	K96
+      0x7C240400,  //  01D6  CALL	R9	2
+      0x9012C209,  //  01D7  SETMBR	R4	K97	R9
+      0x8C24053A,  //  01D8  GETMET	R9	R2	K58
+      0x542E001F,  //  01D9  LDINT	R11	32
+      0x7C240400,  //  01DA  CALL	R9	2
+      0x8C280562,  //  01DB  GETMET	R10	R2	K98
+      0x7C280200,  //  01DC  CALL	R10	1
+      0x8C281564,  //  01DD  GETMET	R10	R10	K100
+      0x88300960,  //  01DE  GETMBR	R12	R4	K96
+      0x88340B13,  //  01DF  GETMBR	R13	R5	K19
+      0x7C280600,  //  01E0  CALL	R10	3
+      0x9012460A,  //  01E1  SETMBR	R4	K35	R10
+      0xB82A1A00,  //  01E2  GETNGBL	R10	K13
+      0x88281565,  //  01E3  GETMBR	R10	R10	K101
+      0x8C281566,  //  01E4  GETMET	R10	R10	K102
+      0x7C280200,  //  01E5  CALL	R10	1
+      0x8C2C1567,  //  01E6  GETMET	R11	R10	K103
+      0x5834000C,  //  01E7  LDCONST	R13	K12
+      0xB83A1A00,  //  01E8  GETNGBL	R14	K13
+      0x88381D65,  //  01E9  GETMBR	R14	R14	K101
+      0x88381D68,  //  01EA  GETMBR	R14	R14	K104
+      0x8C3C0969,  //  01EB  GETMET	R15	R4	K105
+      0x7C3C0200,  //  01EC  CALL	R15	1
+      0x7C2C0800,  //  01ED  CALL	R11	4
+      0x8C2C1567,  //  01EE  GETMET	R11	R10	K103
+      0x5834000A,  //  01EF  LDCONST	R13	K10
+      0xB83A1A00,  //  01F0  GETNGBL	R14	K13
+      0x88381D65,  //  01F1  GETMBR	R14	R14	K101
+      0x88381D68,  //  01F2  GETMBR	R14	R14	K104
+      0x8C3C095F,  //  01F3  GETMET	R15	R4	K95
+      0x7C3C0200,  //  01F4  CALL	R15	1
+      0x7C2C0800,  //  01F5  CALL	R11	4
+      0x8C2C1567,  //  01F6  GETMET	R11	R10	K103
+      0x5834006A,  //  01F7  LDCONST	R13	K106
+      0xB83A1A00,  //  01F8  GETNGBL	R14	K13
+      0x88381D65,  //  01F9  GETMBR	R14	R14	K101
+      0x88381D68,  //  01FA  GETMBR	R14	R14	K104
+      0x883C0961,  //  01FB  GETMBR	R15	R4	K97
+      0x7C2C0800,  //  01FC  CALL	R11	4
+      0x8C2C1567,  //  01FD  GETMET	R11	R10	K103
+      0x54360003,  //  01FE  LDINT	R13	4
+      0xB83A1A00,  //  01FF  GETNGBL	R14	K13
+      0x88381D65,  //  0200  GETMBR	R14	R14	K101
+      0x88381D68,  //  0201  GETMBR	R14	R14	K104
+      0x883C0B13,  //  0202  GETMBR	R15	R5	K19
+      0x7C2C0800,  //  0203  CALL	R11	4
+      0x8C2C0562,  //  0204  GETMET	R11	R2	K98
+      0x7C2C0200,  //  0205  CALL	R11	1
+      0x8C2C176B,  //  0206  GETMET	R11	R11	K107
+      0x8C34096C,  //  0207  GETMET	R13	R4	K108
+      0x7C340200,  //  0208  CALL	R13	1
+      0x8C38154C,  //  0209  GETMET	R14	R10	K76
+      0x7C380200,  //  020A  CALL	R14	1
+      0x7C2C0600,  //  020B  CALL	R11	3
+      0xB8321A00,  //  020C  GETNGBL	R12	K13
+      0x88301965,  //  020D  GETMBR	R12	R12	K101
+      0x8C301966,  //  020E  GETMET	R12	R12	K102
+      0x7C300200,  //  020F  CALL	R12	1
+      0x8C341967,  //  0210  GETMET	R13	R12	K103
+      0x583C000C,  //  0211  LDCONST	R15	K12
+      0xB8421A00,  //  0212  GETNGBL	R16	K13
+      0x88402165,  //  0213  GETMBR	R16	R16	K101
+      0x88402168,  //  0214  GETMBR	R16	R16	K104
+      0x8C440969,  //  0215  GETMET	R17	R4	K105
+      0x7C440200,  //  0216  CALL	R17	1
+      0x7C340800,  //  0217  CALL	R13	4
+      0x8C341967,  //  0218  GETMET	R13	R12	K103
+      0x583C000A,  //  0219  LDCONST	R15	K10
+      0xB8421A00,  //  021A  GETNGBL	R16	K13
+      0x88402165,  //  021B  GETMBR	R16	R16	K101
+      0x88402168,  //  021C  GETMBR	R16	R16	K104
+      0x8C44095F,  //  021D  GETMET	R17	R4	K95
+      0x7C440200,  //  021E  CALL	R17	1
+      0x7C340800,  //  021F  CALL	R13	4
+      0x8C341967,  //  0220  GETMET	R13	R12	K103
+      0x583C006A,  //  0221  LDCONST	R15	K106
+      0xB8421A00,  //  0222  GETNGBL	R16	K13
+      0x88402165,  //  0223  GETMBR	R16	R16	K101
+      0x88402168,  //  0224  GETMBR	R16	R16	K104
+      0x5C441600,  //  0225  MOVE	R17	R11
+      0x7C340800,  //  0226  CALL	R13	4
+      0x8C341967,  //  0227  GETMET	R13	R12	K103
+      0x543E0003,  //  0228  LDINT	R15	4
+      0xB8421A00,  //  0229  GETNGBL	R16	K13
+      0x88402165,  //  022A  GETMBR	R16	R16	K101
+      0x88402168,  //  022B  GETMBR	R16	R16	K104
+      0x88440939,  //  022C  GETMBR	R17	R4	K57
+      0x7C340800,  //  022D  CALL	R13	4
+      0x88340B6D,  //  022E  GETMBR	R13	R5	K109
+      0x90129A0D,  //  022F  SETMBR	R4	K77	R13
+      0x8C34056E,  //  0230  GETMET	R13	R2	K110
+      0x7C340200,  //  0231  CALL	R13	1
+      0x8C341B6F,  //  0232  GETMET	R13	R13	K111
+      0x883C094D,  //  0233  GETMBR	R15	R4	K77
+      0x7C340400,  //  0234  CALL	R13	2
+      0x8C341B70,  //  0235  GETMET	R13	R13	K112
+      0x7C340200,  //  0236  CALL	R13	1
+      0x60380015,  //  0237  GETGBL	R14	G21
+      0x7C380000,  //  0238  CALL	R14	0
+      0x8C381D1F,  //  0239  GETMET	R14	R14	K31
+      0x88400171,  //  023A  GETMBR	R16	R0	K113
+      0x7C380400,  //  023B  CALL	R14	2
+      0x8C3C0972,  //  023C  GETMET	R15	R4	K114
       0x7C3C0200,  //  023D  CALL	R15	1
-      0x7C2C0800,  //  023E  CALL	R11	4
-      0x8C2C1572,  //  023F  GETMET	R11	R10	K114
-      0x58340075,  //  0240  LDCONST	R13	K117
-      0xB83A1A00,  //  0241  GETNGBL	R14	K13
-      0x88381D70,  //  0242  GETMBR	R14	R14	K112
-      0x88381D73,  //  0243  GETMBR	R14	R14	K115
-      0x883C096A,  //  0244  GETMBR	R15	R4	K106
-      0x7C2C0800,  //  0245  CALL	R11	4
-      0x8C2C1572,  //  0246  GETMET	R11	R10	K114
-      0x54360003,  //  0247  LDINT	R13	4
-      0xB83A1A00,  //  0248  GETNGBL	R14	K13
-      0x88381D70,  //  0249  GETMBR	R14	R14	K112
-      0x88381D73,  //  024A  GETMBR	R14	R14	K115
-      0x883C0B16,  //  024B  GETMBR	R15	R5	K22
-      0x7C2C0800,  //  024C  CALL	R11	4
-      0x8C2C056B,  //  024D  GETMET	R11	R2	K107
-      0x7C2C0200,  //  024E  CALL	R11	1
-      0x8C2C1776,  //  024F  GETMET	R11	R11	K118
-      0x8C340977,  //  0250  GETMET	R13	R4	K119
-      0x7C340200,  //  0251  CALL	R13	1
-      0x8C38154D,  //  0252  GETMET	R14	R10	K77
-      0x7C380200,  //  0253  CALL	R14	1
-      0x7C2C0600,  //  0254  CALL	R11	3
-      0xB8321A00,  //  0255  GETNGBL	R12	K13
-      0x88301970,  //  0256  GETMBR	R12	R12	K112
-      0x8C301971,  //  0257  GETMET	R12	R12	K113
-      0x7C300200,  //  0258  CALL	R12	1
-      0x8C341972,  //  0259  GETMET	R13	R12	K114
-      0x583C000C,  //  025A  LDCONST	R15	K12
-      0xB8421A00,  //  025B  GETNGBL	R16	K13
-      0x88402170,  //  025C  GETMBR	R16	R16	K112
-      0x88402173,  //  025D  GETMBR	R16	R16	K115
-      0x8C440974,  //  025E  GETMET	R17	R4	K116
-      0x7C440200,  //  025F  CALL	R17	1
-      0x7C340800,  //  0260  CALL	R13	4
-      0x8C341972,  //  0261  GETMET	R13	R12	K114
-      0x583C000A,  //  0262  LDCONST	R15	K10
-      0xB8421A00,  //  0263  GETNGBL	R16	K13
-      0x88402170,  //  0264  GETMBR	R16	R16	K112
-      0x88402173,  //  0265  GETMBR	R16	R16	K115
-      0x8C440965,  //  0266  GETMET	R17	R4	K101
-      0x7C440200,  //  0267  CALL	R17	1
-      0x7C340800,  //  0268  CALL	R13	4
-      0x8C341972,  //  0269  GETMET	R13	R12	K114
-      0x583C0075,  //  026A  LDCONST	R15	K117
-      0xB8421A00,  //  026B  GETNGBL	R16	K13
-      0x88402170,  //  026C  GETMBR	R16	R16	K112
-      0x88402173,  //  026D  GETMBR	R16	R16	K115
-      0x5C441600,  //  026E  MOVE	R17	R11
-      0x7C340800,  //  026F  CALL	R13	4
-      0x8C341972,  //  0270  GETMET	R13	R12	K114
-      0x543E0003,  //  0271  LDINT	R15	4
-      0xB8421A00,  //  0272  GETNGBL	R16	K13
-      0x88402170,  //  0273  GETMBR	R16	R16	K112
-      0x88402173,  //  0274  GETMBR	R16	R16	K115
-      0x8844093A,  //  0275  GETMBR	R17	R4	K58
-      0x7C340800,  //  0276  CALL	R13	4
-      0xB8360E00,  //  0277  GETNGBL	R13	K7
-      0x8C341B08,  //  0278  GETMET	R13	R13	K8
-      0x583C002A,  //  0279  LDCONST	R15	K42
-      0x54420003,  //  027A  LDINT	R16	4
-      0x7C340600,  //  027B  CALL	R13	3
-      0x88340B78,  //  027C  GETMBR	R13	R5	K120
-      0x90129C0D,  //  027D  SETMBR	R4	K78	R13
-      0xB8360E00,  //  027E  GETNGBL	R13	K7
-      0x8C341B08,  //  027F  GETMET	R13	R13	K8
-      0x883C093A,  //  0280  GETMBR	R15	R4	K58
-      0x8C3C1F2C,  //  0281  GETMET	R15	R15	K44
-      0x7C3C0200,  //  0282  CALL	R15	1
-      0x003EF20F,  //  0283  ADD	R15	K121	R15
-      0x54420003,  //  0284  LDINT	R16	4
-      0x7C340600,  //  0285  CALL	R13	3
-      0xB8360E00,  //  0286  GETNGBL	R13	K7
-      0x8C341B08,  //  0287  GETMET	R13	R13	K8
-      0x883C094E,  //  0288  GETMBR	R15	R4	K78
-      0x8C3C1F2C,  //  0289  GETMET	R15	R15	K44
-      0x7C3C0200,  //  028A  CALL	R15	1
-      0x003EF40F,  //  028B  ADD	R15	K122	R15
-      0x54420003,  //  028C  LDINT	R16	4
-      0x7C340600,  //  028D  CALL	R13	3
-      0x8C34057B,  //  028E  GETMET	R13	R2	K123
-      0x7C340200,  //  028F  CALL	R13	1
-      0x8C341B7C,  //  0290  GETMET	R13	R13	K124
-      0x883C094E,  //  0291  GETMBR	R15	R4	K78
-      0x7C340400,  //  0292  CALL	R13	2
-      0x8C341B7D,  //  0293  GETMET	R13	R13	K125
-      0x7C340200,  //  0294  CALL	R13	1
-      0xB83A0E00,  //  0295  GETNGBL	R14	K7
-      0x8C381D08,  //  0296  GETMET	R14	R14	K8
-      0x8C401B2C,  //  0297  GETMET	R16	R13	K44
-      0x7C400200,  //  0298  CALL	R16	1
-      0x0042FC10,  //  0299  ADD	R16	K126	R16
-      0x54460003,  //  029A  LDINT	R17	4
-      0x7C380600,  //  029B  CALL	R14	3
-      0x60380015,  //  029C  GETGBL	R14	G21
-      0x7C380000,  //  029D  CALL	R14	0
-      0x8C381D20,  //  029E  GETMET	R14	R14	K32
-      0x8840017F,  //  029F  GETMBR	R16	R0	K127
-      0x7C380400,  //  02A0  CALL	R14	2
-      0x8C3C0980,  //  02A1  GETMET	R15	R4	K128
-      0x7C3C0200,  //  02A2  CALL	R15	1
-      0x003C1E09,  //  02A3  ADD	R15	R15	R9
-      0x8840096A,  //  02A4  GETMBR	R16	R4	K106
-      0x003C1E10,  //  02A5  ADD	R15	R15	R16
-      0x003C1E0D,  //  02A6  ADD	R15	R15	R13
-      0x8C400522,  //  02A7  GETMET	R16	R2	K34
-      0x7C400200,  //  02A8  CALL	R16	1
-      0x8C402123,  //  02A9  GETMET	R16	R16	K35
-      0x88480924,  //  02AA  GETMBR	R18	R4	K36
-      0x5C4C1E00,  //  02AB  MOVE	R19	R15
-      0x5C501C00,  //  02AC  MOVE	R20	R14
-      0x5456000F,  //  02AD  LDINT	R21	16
-      0x7C400A00,  //  02AE  CALL	R16	5
-      0xB8460E00,  //  02AF  GETNGBL	R17	K7
-      0x8C442308,  //  02B0  GETMET	R17	R17	K8
-      0x884C0924,  //  02B1  GETMBR	R19	R4	K36
-      0x8C4C272C,  //  02B2  GETMET	R19	R19	K44
-      0x7C4C0200,  //  02B3  CALL	R19	1
-      0x004F0213,  //  02B4  ADD	R19	K129	R19
-      0x54520003,  //  02B5  LDINT	R20	4
-      0x7C440600,  //  02B6  CALL	R17	3
-      0xB8460E00,  //  02B7  GETNGBL	R17	K7
-      0x8C442308,  //  02B8  GETMET	R17	R17	K8
-      0x8C4C1F2C,  //  02B9  GETMET	R19	R15	K44
-      0x7C4C0200,  //  02BA  CALL	R19	1
-      0x004F0413,  //  02BB  ADD	R19	K130	R19
-      0x54520003,  //  02BC  LDINT	R20	4
-      0x7C440600,  //  02BD  CALL	R17	3
-      0xB8460E00,  //  02BE  GETNGBL	R17	K7
-      0x8C442308,  //  02BF  GETMET	R17	R17	K8
-      0x8C4C212C,  //  02C0  GETMET	R19	R16	K44
-      0x7C4C0200,  //  02C1  CALL	R19	1
-      0x004F0613,  //  02C2  ADD	R19	K131	R19
-      0x54520003,  //  02C3  LDINT	R20	4
-      0x7C440600,  //  02C4  CALL	R17	3
-      0x8C44194D,  //  02C5  GETMET	R17	R12	K77
-      0x7C440200,  //  02C6  CALL	R17	1
-      0xB84A0E00,  //  02C7  GETNGBL	R18	K7
-      0x8C482508,  //  02C8  GETMET	R18	R18	K8
-      0x8C50232C,  //  02C9  GETMET	R20	R17	K44
-      0x7C500200,  //  02CA  CALL	R20	1
-      0x00530814,  //  02CB  ADD	R20	K132	R20
-      0x54560003,  //  02CC  LDINT	R21	4
-      0x7C480600,  //  02CD  CALL	R18	3
-      0x8C480527,  //  02CE  GETMET	R18	R2	K39
-      0x5C502000,  //  02CF  MOVE	R20	R16
-      0x60540015,  //  02D0  GETGBL	R21	G21
-      0x7C540000,  //  02D1  CALL	R21	0
-      0x8C542B20,  //  02D2  GETMET	R21	R21	K32
-      0x885C0185,  //  02D3  GETMBR	R23	R0	K133
-      0x7C540400,  //  02D4  CALL	R21	2
-      0x60580015,  //  02D5  GETGBL	R22	G21
-      0x7C580000,  //  02D6  CALL	R22	0
-      0x605C000C,  //  02D7  GETGBL	R23	G12
-      0x5C602200,  //  02D8  MOVE	R24	R17
-      0x7C5C0200,  //  02D9  CALL	R23	1
-      0x5462000F,  //  02DA  LDINT	R24	16
-      0x7C480C00,  //  02DB  CALL	R18	6
-      0x8C4C2586,  //  02DC  GETMET	R19	R18	K134
-      0x5C542200,  //  02DD  MOVE	R21	R17
-      0x7C4C0400,  //  02DE  CALL	R19	2
-      0x8C502529,  //  02DF  GETMET	R20	R18	K41
-      0x7C500200,  //  02E0  CALL	R20	1
-      0x004C2614,  //  02E1  ADD	R19	R19	R20
-      0xB8520E00,  //  02E2  GETNGBL	R20	K7
-      0x8C502908,  //  02E3  GETMET	R20	R20	K8
-      0x8C58272C,  //  02E4  GETMET	R22	R19	K44
-      0x7C580200,  //  02E5  CALL	R22	1
-      0x005B0E16,  //  02E6  ADD	R22	K135	R22
-      0x545E0003,  //  02E7  LDINT	R23	4
-      0x7C500600,  //  02E8  CALL	R20	3
-      0xB8520E00,  //  02E9  GETNGBL	R20	K7
-      0x8C502908,  //  02EA  GETMET	R20	R20	K8
-      0x5858002A,  //  02EB  LDCONST	R22	K42
-      0x545E0003,  //  02EC  LDINT	R23	4
-      0x7C500600,  //  02ED  CALL	R20	3
-      0xB8521A00,  //  02EE  GETNGBL	R20	K13
-      0x8C502988,  //  02EF  GETMET	R20	R20	K136
-      0x7C500200,  //  02F0  CALL	R20	1
-      0x90531209,  //  02F1  SETMBR	R20	K137	R9
-      0x88540935,  //  02F2  GETMBR	R21	R4	K53
-      0x90531415,  //  02F3  SETMBR	R20	K138	R21
-      0x8854096A,  //  02F4  GETMBR	R21	R4	K106
-      0x90531615,  //  02F5  SETMBR	R20	K139	R21
-      0x90531813,  //  02F6  SETMBR	R20	K140	R19
-      0xB8560E00,  //  02F7  GETNGBL	R21	K7
-      0x8C542B08,  //  02F8  GETMET	R21	R21	K8
-      0xB85E1A00,  //  02F9  GETNGBL	R23	K13
-      0x8C5C2F14,  //  02FA  GETMET	R23	R23	K20
-      0x5C642800,  //  02FB  MOVE	R25	R20
-      0x7C5C0400,  //  02FC  CALL	R23	2
-      0x005F1A17,  //  02FD  ADD	R23	K141	R23
-      0x54620003,  //  02FE  LDINT	R24	4
-      0x7C540600,  //  02FF  CALL	R21	3
-      0x8C54294D,  //  0300  GETMET	R21	R20	K77
-      0x7C540200,  //  0301  CALL	R21	1
-      0x90131C15,  //  0302  SETMBR	R4	K142	R21
-      0xB85A0E00,  //  0303  GETNGBL	R22	K7
-      0x8C582D08,  //  0304  GETMET	R22	R22	K8
-      0x8C602B2C,  //  0305  GETMET	R24	R21	K44
-      0x7C600200,  //  0306  CALL	R24	1
-      0x00631E18,  //  0307  ADD	R24	K143	R24
-      0x54660003,  //  0308  LDINT	R25	4
-      0x7C580600,  //  0309  CALL	R22	3
-      0x8C580351,  //  030A  GETMET	R22	R1	K81
-      0x54620030,  //  030B  LDINT	R24	49
-      0x50640200,  //  030C  LDBOOL	R25	1	0
-      0x7C580600,  //  030D  CALL	R22	3
-      0x8C5C2D52,  //  030E  GETMET	R23	R22	K82
-      0x5C642A00,  //  030F  MOVE	R25	R21
-      0x7C5C0400,  //  0310  CALL	R23	2
-      0x88600153,  //  0311  GETMBR	R24	R0	K83
-      0x8C603154,  //  0312  GETMET	R24	R24	K84
-      0x5C682C00,  //  0313  MOVE	R26	R22
-      0x7C600400,  //  0314  CALL	R24	2
-      0x50600200,  //  0315  LDBOOL	R24	1	0
-      0x80043000,  //  0316  RET	1	R24
-      0x50200200,  //  0317  LDBOOL	R8	1	0
-      0x80041000,  //  0318  RET	1	R8
+      0x003C1E09,  //  023E  ADD	R15	R15	R9
+      0x88400961,  //  023F  GETMBR	R16	R4	K97
+      0x003C1E10,  //  0240  ADD	R15	R15	R16
+      0x003C1E0D,  //  0241  ADD	R15	R15	R13
+      0x8C400521,  //  0242  GETMET	R16	R2	K33
+      0x7C400200,  //  0243  CALL	R16	1
+      0x8C402122,  //  0244  GETMET	R16	R16	K34
+      0x88480923,  //  0245  GETMBR	R18	R4	K35
+      0x5C4C1E00,  //  0246  MOVE	R19	R15
+      0x5C501C00,  //  0247  MOVE	R20	R14
+      0x5456000F,  //  0248  LDINT	R21	16
+      0x7C400A00,  //  0249  CALL	R16	5
+      0x8C44194C,  //  024A  GETMET	R17	R12	K76
+      0x7C440200,  //  024B  CALL	R17	1
+      0x8C480526,  //  024C  GETMET	R18	R2	K38
+      0x5C502000,  //  024D  MOVE	R20	R16
+      0x60540015,  //  024E  GETGBL	R21	G21
+      0x7C540000,  //  024F  CALL	R21	0
+      0x8C542B1F,  //  0250  GETMET	R21	R21	K31
+      0x885C0173,  //  0251  GETMBR	R23	R0	K115
+      0x7C540400,  //  0252  CALL	R21	2
+      0x60580015,  //  0253  GETGBL	R22	G21
+      0x7C580000,  //  0254  CALL	R22	0
+      0x605C000C,  //  0255  GETGBL	R23	G12
+      0x5C602200,  //  0256  MOVE	R24	R17
+      0x7C5C0200,  //  0257  CALL	R23	1
+      0x5462000F,  //  0258  LDINT	R24	16
+      0x7C480C00,  //  0259  CALL	R18	6
+      0x8C4C2574,  //  025A  GETMET	R19	R18	K116
+      0x5C542200,  //  025B  MOVE	R21	R17
+      0x7C4C0400,  //  025C  CALL	R19	2
+      0x8C502528,  //  025D  GETMET	R20	R18	K40
+      0x7C500200,  //  025E  CALL	R20	1
+      0x004C2614,  //  025F  ADD	R19	R19	R20
+      0xB8521A00,  //  0260  GETNGBL	R20	K13
+      0x8C502975,  //  0261  GETMET	R20	R20	K117
+      0x7C500200,  //  0262  CALL	R20	1
+      0x9052EC09,  //  0263  SETMBR	R20	K118	R9
+      0x88540934,  //  0264  GETMBR	R21	R4	K52
+      0x9052EE15,  //  0265  SETMBR	R20	K119	R21
+      0x88540961,  //  0266  GETMBR	R21	R4	K97
+      0x9052F015,  //  0267  SETMBR	R20	K120	R21
+      0x9052F213,  //  0268  SETMBR	R20	K121	R19
+      0x8C54294C,  //  0269  GETMET	R21	R20	K76
+      0x7C540200,  //  026A  CALL	R21	1
+      0x9012F415,  //  026B  SETMBR	R4	K122	R21
+      0x8C580350,  //  026C  GETMET	R22	R1	K80
+      0x54620030,  //  026D  LDINT	R24	49
+      0x50640200,  //  026E  LDBOOL	R25	1	0
+      0x7C580600,  //  026F  CALL	R22	3
+      0x8C5C2D51,  //  0270  GETMET	R23	R22	K81
+      0x5C642A00,  //  0271  MOVE	R25	R21
+      0x7C5C0400,  //  0272  CALL	R23	2
+      0x88600152,  //  0273  GETMBR	R24	R0	K82
+      0x8C603153,  //  0274  GETMET	R24	R24	K83
+      0x5C682C00,  //  0275  MOVE	R26	R22
+      0x7C600400,  //  0276  CALL	R24	2
+      0x50600200,  //  0277  LDBOOL	R24	1	0
+      0x80043000,  //  0278  RET	1	R24
+      0x50200200,  //  0279  LDBOOL	R8	1	0
+      0x80041000,  //  027A  RET	1	R8
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning_Data.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning_Data.h
@@ -263,7 +263,7 @@ extern const bclass be_class_Matter_Pake1;
 ********************************************************************/
 be_local_closure(Matter_Pake1_parse,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    7,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -271,21 +271,18 @@ be_local_closure(Matter_Pake1_parse,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_const_int(0),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
     /* K3   */  be_nested_str_weak(parse),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20parsed_X20TLV_X3A_X20),
-    /* K7   */  be_nested_str_weak(pA),
-    /* K8   */  be_nested_str_weak(getsubval),
-    /* K9   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(pA),
+    /* K5   */  be_nested_str_weak(getsubval),
+    /* K6   */  be_const_int(1),
     }),
     be_str_weak(parse),
     &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
+    ( &(const binstruction[15]) {  /* code */
       0x4C0C0000,  //  0000  LDNIL	R3
       0x1C0C0403,  //  0001  EQ	R3	R2	R3
       0x780E0000,  //  0002  JMPF	R3	#0004
@@ -296,19 +293,11 @@ be_local_closure(Matter_Pake1_parse,   /* name */
       0x5C140200,  //  0007  MOVE	R5	R1
       0x5C180400,  //  0008  MOVE	R6	R2
       0x7C0C0600,  //  0009  CALL	R3	3
-      0xB8120800,  //  000A  GETNGBL	R4	K4
-      0x8C100905,  //  000B  GETMET	R4	R4	K5
-      0x60180008,  //  000C  GETGBL	R6	G8
-      0x5C1C0600,  //  000D  MOVE	R7	R3
-      0x7C180200,  //  000E  CALL	R6	1
-      0x001A0C06,  //  000F  ADD	R6	K6	R6
-      0x541E0003,  //  0010  LDINT	R7	4
-      0x7C100600,  //  0011  CALL	R4	3
-      0x8C100708,  //  0012  GETMET	R4	R3	K8
-      0x58180009,  //  0013  LDCONST	R6	K9
-      0x7C100400,  //  0014  CALL	R4	2
-      0x90020E04,  //  0015  SETMBR	R0	K7	R4
-      0x80040000,  //  0016  RET	1	R0
+      0x8C100705,  //  000A  GETMET	R4	R3	K5
+      0x58180006,  //  000B  LDCONST	R6	K6
+      0x7C100400,  //  000C  CALL	R4	2
+      0x90020804,  //  000D  SETMBR	R0	K4	R4
+      0x80040000,  //  000E  RET	1	R0
     })
   )
 );
@@ -423,7 +412,7 @@ extern const bclass be_class_Matter_Pake3;
 ********************************************************************/
 be_local_closure(Matter_Pake3_parse,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    7,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -431,21 +420,18 @@ be_local_closure(Matter_Pake3_parse,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_const_int(0),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
     /* K3   */  be_nested_str_weak(parse),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20parsed_X20TLV_X3A_X20),
-    /* K7   */  be_nested_str_weak(cA),
-    /* K8   */  be_nested_str_weak(getsubval),
-    /* K9   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(cA),
+    /* K5   */  be_nested_str_weak(getsubval),
+    /* K6   */  be_const_int(1),
     }),
     be_str_weak(parse),
     &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
+    ( &(const binstruction[15]) {  /* code */
       0x4C0C0000,  //  0000  LDNIL	R3
       0x1C0C0403,  //  0001  EQ	R3	R2	R3
       0x780E0000,  //  0002  JMPF	R3	#0004
@@ -456,19 +442,11 @@ be_local_closure(Matter_Pake3_parse,   /* name */
       0x5C140200,  //  0007  MOVE	R5	R1
       0x5C180400,  //  0008  MOVE	R6	R2
       0x7C0C0600,  //  0009  CALL	R3	3
-      0xB8120800,  //  000A  GETNGBL	R4	K4
-      0x8C100905,  //  000B  GETMET	R4	R4	K5
-      0x60180008,  //  000C  GETGBL	R6	G8
-      0x5C1C0600,  //  000D  MOVE	R7	R3
-      0x7C180200,  //  000E  CALL	R6	1
-      0x001A0C06,  //  000F  ADD	R6	K6	R6
-      0x541E0003,  //  0010  LDINT	R7	4
-      0x7C100600,  //  0011  CALL	R4	3
-      0x8C100708,  //  0012  GETMET	R4	R3	K8
-      0x58180009,  //  0013  LDCONST	R6	K9
-      0x7C100400,  //  0014  CALL	R4	2
-      0x90020E04,  //  0015  SETMBR	R0	K7	R4
-      0x80040000,  //  0016  RET	1	R0
+      0x8C100705,  //  000A  GETMET	R4	R3	K5
+      0x58180006,  //  000B  LDCONST	R6	K6
+      0x7C100400,  //  000C  CALL	R4	2
+      0x90020804,  //  000D  SETMBR	R0	K4	R4
+      0x80040000,  //  000E  RET	1	R0
     })
   )
 );
@@ -511,34 +489,31 @@ be_local_closure(Matter_Sigma1_parse,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
+    ( &(const bvalue[20]) {     /* constants */
     /* K0   */  be_const_int(0),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
     /* K3   */  be_nested_str_weak(parse),
     /* K4   */  be_nested_str_weak(Msg1),
     /* K5   */  be_const_int(2147483647),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20Sigma1_X20TLV_X3D),
-    /* K9   */  be_nested_str_weak(initiatorRandom),
-    /* K10  */  be_nested_str_weak(getsubval),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(initiator_session_id),
-    /* K13  */  be_const_int(2),
-    /* K14  */  be_nested_str_weak(destinationId),
-    /* K15  */  be_const_int(3),
-    /* K16  */  be_nested_str_weak(initiatorEphPubKey),
-    /* K17  */  be_nested_str_weak(findsub),
-    /* K18  */  be_nested_str_weak(SLEEPY_IDLE_INTERVAL),
-    /* K19  */  be_nested_str_weak(findsubval),
-    /* K20  */  be_nested_str_weak(SLEEPY_ACTIVE_INTERVAL),
-    /* K21  */  be_nested_str_weak(resumptionID),
-    /* K22  */  be_nested_str_weak(initiatorResumeMIC),
+    /* K6   */  be_nested_str_weak(initiatorRandom),
+    /* K7   */  be_nested_str_weak(getsubval),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(initiator_session_id),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(destinationId),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_nested_str_weak(initiatorEphPubKey),
+    /* K14  */  be_nested_str_weak(findsub),
+    /* K15  */  be_nested_str_weak(SLEEPY_IDLE_INTERVAL),
+    /* K16  */  be_nested_str_weak(findsubval),
+    /* K17  */  be_nested_str_weak(SLEEPY_ACTIVE_INTERVAL),
+    /* K18  */  be_nested_str_weak(resumptionID),
+    /* K19  */  be_nested_str_weak(initiatorResumeMIC),
     }),
     be_str_weak(parse),
     &be_const_str_solidified,
-    ( &(const binstruction[60]) {  /* code */
+    ( &(const binstruction[52]) {  /* code */
       0x4C0C0000,  //  0000  LDNIL	R3
       0x1C0C0403,  //  0001  EQ	R3	R2	R3
       0x780E0000,  //  0002  JMPF	R3	#0004
@@ -552,53 +527,45 @@ be_local_closure(Matter_Sigma1_parse,   /* name */
       0x40100505,  //  000A  CONNECT	R4	R2	K5
       0x94100204,  //  000B  GETIDX	R4	R1	R4
       0x90020804,  //  000C  SETMBR	R0	K4	R4
-      0xB8120C00,  //  000D  GETNGBL	R4	K6
-      0x8C100907,  //  000E  GETMET	R4	R4	K7
-      0x60180008,  //  000F  GETGBL	R6	G8
-      0x5C1C0600,  //  0010  MOVE	R7	R3
-      0x7C180200,  //  0011  CALL	R6	1
-      0x001A1006,  //  0012  ADD	R6	K8	R6
-      0x541E0003,  //  0013  LDINT	R7	4
-      0x7C100600,  //  0014  CALL	R4	3
-      0x8C10070A,  //  0015  GETMET	R4	R3	K10
-      0x5818000B,  //  0016  LDCONST	R6	K11
+      0x8C100707,  //  000D  GETMET	R4	R3	K7
+      0x58180008,  //  000E  LDCONST	R6	K8
+      0x7C100400,  //  000F  CALL	R4	2
+      0x90020C04,  //  0010  SETMBR	R0	K6	R4
+      0x8C100707,  //  0011  GETMET	R4	R3	K7
+      0x5818000A,  //  0012  LDCONST	R6	K10
+      0x7C100400,  //  0013  CALL	R4	2
+      0x90021204,  //  0014  SETMBR	R0	K9	R4
+      0x8C100707,  //  0015  GETMET	R4	R3	K7
+      0x5818000C,  //  0016  LDCONST	R6	K12
       0x7C100400,  //  0017  CALL	R4	2
-      0x90021204,  //  0018  SETMBR	R0	K9	R4
-      0x8C10070A,  //  0019  GETMET	R4	R3	K10
-      0x5818000D,  //  001A  LDCONST	R6	K13
+      0x90021604,  //  0018  SETMBR	R0	K11	R4
+      0x8C100707,  //  0019  GETMET	R4	R3	K7
+      0x541A0003,  //  001A  LDINT	R6	4
       0x7C100400,  //  001B  CALL	R4	2
-      0x90021804,  //  001C  SETMBR	R0	K12	R4
-      0x8C10070A,  //  001D  GETMET	R4	R3	K10
-      0x5818000F,  //  001E  LDCONST	R6	K15
+      0x90021A04,  //  001C  SETMBR	R0	K13	R4
+      0x8C10070E,  //  001D  GETMET	R4	R3	K14
+      0x541A0004,  //  001E  LDINT	R6	5
       0x7C100400,  //  001F  CALL	R4	2
-      0x90021C04,  //  0020  SETMBR	R0	K14	R4
-      0x8C10070A,  //  0021  GETMET	R4	R3	K10
-      0x541A0003,  //  0022  LDINT	R6	4
-      0x7C100400,  //  0023  CALL	R4	2
-      0x90022004,  //  0024  SETMBR	R0	K16	R4
-      0x8C100711,  //  0025  GETMET	R4	R3	K17
-      0x541A0004,  //  0026  LDINT	R6	5
-      0x7C100400,  //  0027  CALL	R4	2
-      0x4C140000,  //  0028  LDNIL	R5
-      0x20140805,  //  0029  NE	R5	R4	R5
-      0x78160007,  //  002A  JMPF	R5	#0033
-      0x8C140913,  //  002B  GETMET	R5	R4	K19
-      0x581C000B,  //  002C  LDCONST	R7	K11
+      0x4C140000,  //  0020  LDNIL	R5
+      0x20140805,  //  0021  NE	R5	R4	R5
+      0x78160007,  //  0022  JMPF	R5	#002B
+      0x8C140910,  //  0023  GETMET	R5	R4	K16
+      0x581C0008,  //  0024  LDCONST	R7	K8
+      0x7C140400,  //  0025  CALL	R5	2
+      0x90021E05,  //  0026  SETMBR	R0	K15	R5
+      0x8C140910,  //  0027  GETMET	R5	R4	K16
+      0x581C000A,  //  0028  LDCONST	R7	K10
+      0x7C140400,  //  0029  CALL	R5	2
+      0x90022205,  //  002A  SETMBR	R0	K17	R5
+      0x8C140710,  //  002B  GETMET	R5	R3	K16
+      0x541E0005,  //  002C  LDINT	R7	6
       0x7C140400,  //  002D  CALL	R5	2
       0x90022405,  //  002E  SETMBR	R0	K18	R5
-      0x8C140913,  //  002F  GETMET	R5	R4	K19
-      0x581C000D,  //  0030  LDCONST	R7	K13
+      0x8C140710,  //  002F  GETMET	R5	R3	K16
+      0x541E0006,  //  0030  LDINT	R7	7
       0x7C140400,  //  0031  CALL	R5	2
-      0x90022805,  //  0032  SETMBR	R0	K20	R5
-      0x8C140713,  //  0033  GETMET	R5	R3	K19
-      0x541E0005,  //  0034  LDINT	R7	6
-      0x7C140400,  //  0035  CALL	R5	2
-      0x90022A05,  //  0036  SETMBR	R0	K21	R5
-      0x8C140713,  //  0037  GETMET	R5	R3	K19
-      0x541E0006,  //  0038  LDINT	R7	7
-      0x7C140400,  //  0039  CALL	R5	2
-      0x90022C05,  //  003A  SETMBR	R0	K22	R5
-      0x80040000,  //  003B  RET	1	R0
+      0x90022605,  //  0032  SETMBR	R0	K19	R5
+      0x80040000,  //  0033  RET	1	R0
     })
   )
 );
@@ -894,7 +861,7 @@ extern const bclass be_class_Matter_Sigma3;
 ********************************************************************/
 be_local_closure(Matter_Sigma3_parse,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    7,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -902,23 +869,20 @@ be_local_closure(Matter_Sigma3_parse,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
+    ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_const_int(0),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
     /* K3   */  be_nested_str_weak(parse),
     /* K4   */  be_nested_str_weak(Msg3),
     /* K5   */  be_const_int(2147483647),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20Sigma3_X20TLV_X3D),
-    /* K9   */  be_nested_str_weak(TBEData3Encrypted),
-    /* K10  */  be_nested_str_weak(getsubval),
-    /* K11  */  be_const_int(1),
+    /* K6   */  be_nested_str_weak(TBEData3Encrypted),
+    /* K7   */  be_nested_str_weak(getsubval),
+    /* K8   */  be_const_int(1),
     }),
     be_str_weak(parse),
     &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
+    ( &(const binstruction[18]) {  /* code */
       0x4C0C0000,  //  0000  LDNIL	R3
       0x1C0C0403,  //  0001  EQ	R3	R2	R3
       0x780E0000,  //  0002  JMPF	R3	#0004
@@ -932,19 +896,11 @@ be_local_closure(Matter_Sigma3_parse,   /* name */
       0x40100505,  //  000A  CONNECT	R4	R2	K5
       0x94100204,  //  000B  GETIDX	R4	R1	R4
       0x90020804,  //  000C  SETMBR	R0	K4	R4
-      0xB8120C00,  //  000D  GETNGBL	R4	K6
-      0x8C100907,  //  000E  GETMET	R4	R4	K7
-      0x60180008,  //  000F  GETGBL	R6	G8
-      0x5C1C0600,  //  0010  MOVE	R7	R3
-      0x7C180200,  //  0011  CALL	R6	1
-      0x001A1006,  //  0012  ADD	R6	K8	R6
-      0x541E0003,  //  0013  LDINT	R7	4
-      0x7C100600,  //  0014  CALL	R4	3
-      0x8C10070A,  //  0015  GETMET	R4	R3	K10
-      0x5818000B,  //  0016  LDCONST	R6	K11
-      0x7C100400,  //  0017  CALL	R4	2
-      0x90021204,  //  0018  SETMBR	R0	K9	R4
-      0x80040000,  //  0019  RET	1	R0
+      0x8C100707,  //  000D  GETMET	R4	R3	K7
+      0x58180008,  //  000E  LDCONST	R6	K8
+      0x7C100400,  //  000F  CALL	R4	2
+      0x90020C04,  //  0010  SETMBR	R0	K6	R4
+      0x80040000,  //  0011  RET	1	R0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
@@ -897,7 +897,7 @@ be_local_closure(Matter_Device_every_250ms,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
   be_nested_proto(
-    30,                          /* nstack */
+    29,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -972,37 +972,33 @@ be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
+    ( &(const bvalue[22]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(endpoint),
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(format),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20process_attribute_expansion_X20_X25s),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20endpoint_X3D_X25s_X20cluster_X3D_X25s_X20attribute_X3D_X25s),
-    /* K9   */  be_nested_str_weak(plugins),
-    /* K10  */  be_nested_str_weak(get_endpoint),
-    /* K11  */  be_nested_str_weak(contains),
-    /* K12  */  be_nested_str_weak(get_cluster_list),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20pi_X3D_X25s_X20ep_X3D_X25s_X20cl_list_X3D_X25s),
-    /* K14  */  be_nested_str_weak(get_attribute_list),
-    /* K15  */  be_nested_str_weak(MTR_X3A_X20pi_X3D_X25s_X20ep_X3D_X25s_X20cl_X3D_X25s_X20at_list_X3D_X25s),
-    /* K16  */  be_nested_str_weak(push),
-    /* K17  */  be_nested_str_weak(stop_iteration),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20expansion_X20_X5B_X2502X_X5D_X2504X_X2F_X2504X),
-    /* K19  */  be_const_int(3),
-    /* K20  */  be_nested_str_weak(status),
-    /* K21  */  be_nested_str_weak(matter),
-    /* K22  */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
-    /* K23  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
-    /* K24  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    /* K25  */  be_nested_str_weak(UNREPORTABLE_ATTRIBUTE),
+    /* K4   */  be_nested_str_weak(plugins),
+    /* K5   */  be_nested_str_weak(get_endpoint),
+    /* K6   */  be_nested_str_weak(contains),
+    /* K7   */  be_nested_str_weak(get_cluster_list),
+    /* K8   */  be_nested_str_weak(get_attribute_list),
+    /* K9   */  be_nested_str_weak(push),
+    /* K10  */  be_nested_str_weak(stop_iteration),
+    /* K11  */  be_nested_str_weak(tasmota),
+    /* K12  */  be_nested_str_weak(log),
+    /* K13  */  be_nested_str_weak(format),
+    /* K14  */  be_nested_str_weak(MTR_X3A_X20expansion_X20_X5B_X2502X_X5D_X2504X_X2F_X2504X),
+    /* K15  */  be_const_int(3),
+    /* K16  */  be_nested_str_weak(status),
+    /* K17  */  be_nested_str_weak(matter),
+    /* K18  */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+    /* K19  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
+    /* K20  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+    /* K21  */  be_nested_str_weak(UNREPORTABLE_ATTRIBUTE),
     }),
     be_str_weak(process_attribute_expansion),
     &be_const_str_solidified,
-    ( &(const binstruction[271]) {  /* code */
+    ( &(const binstruction[216]) {  /* code */
       0x840C0000,  //  0000  CLOSURE	R3	P0
       0xA4120000,  //  0001  IMPORT	R4	K0
       0x88140301,  //  0002  GETMBR	R5	R1	K1
@@ -1025,255 +1021,200 @@ be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
       0x742E0000,  //  0013  JMPT	R11	#0015
       0x502C0001,  //  0014  LDBOOL	R11	0	1
       0x502C0200,  //  0015  LDBOOL	R11	1	0
-      0xB8320800,  //  0016  GETNGBL	R12	K4
-      0x8C301905,  //  0017  GETMET	R12	R12	K5
-      0x8C380906,  //  0018  GETMET	R14	R4	K6
-      0x58400007,  //  0019  LDCONST	R16	K7
-      0x60440008,  //  001A  GETGBL	R17	G8
-      0x5C480200,  //  001B  MOVE	R18	R1
-      0x7C440200,  //  001C  CALL	R17	1
-      0x7C380600,  //  001D  CALL	R14	3
-      0x543E0003,  //  001E  LDINT	R15	4
-      0x7C300600,  //  001F  CALL	R12	3
-      0x60300013,  //  0020  GETGBL	R12	G19
-      0x7C300000,  //  0021  CALL	R12	0
-      0xB8360800,  //  0022  GETNGBL	R13	K4
-      0x8C341B05,  //  0023  GETMET	R13	R13	K5
-      0x8C3C0906,  //  0024  GETMET	R15	R4	K6
-      0x58440008,  //  0025  LDCONST	R17	K8
-      0x5C480A00,  //  0026  MOVE	R18	R5
-      0x5C4C0E00,  //  0027  MOVE	R19	R7
-      0x5C501200,  //  0028  MOVE	R20	R9
-      0x7C3C0A00,  //  0029  CALL	R15	5
-      0x54420003,  //  002A  LDINT	R16	4
-      0x7C340600,  //  002B  CALL	R13	3
-      0x60340010,  //  002C  GETGBL	R13	G16
-      0x88380109,  //  002D  GETMBR	R14	R0	K9
-      0x7C340200,  //  002E  CALL	R13	1
-      0xA8020078,  //  002F  EXBLK	0	#00A9
-      0x5C381A00,  //  0030  MOVE	R14	R13
-      0x7C380000,  //  0031  CALL	R14	0
-      0x8C3C1D0A,  //  0032  GETMET	R15	R14	K10
-      0x7C3C0200,  //  0033  CALL	R15	1
-      0x4C400000,  //  0034  LDNIL	R16
-      0x20400A10,  //  0035  NE	R16	R5	R16
-      0x78420002,  //  0036  JMPF	R16	#003A
-      0x20401E05,  //  0037  NE	R16	R15	R5
-      0x78420000,  //  0038  JMPF	R16	#003A
-      0x7001FFF5,  //  0039  JMP		#0030
-      0x8C40190B,  //  003A  GETMET	R16	R12	K11
-      0x5C481E00,  //  003B  MOVE	R18	R15
-      0x7C400400,  //  003C  CALL	R16	2
-      0x74420002,  //  003D  JMPT	R16	#0041
-      0x60400013,  //  003E  GETGBL	R16	G19
-      0x7C400000,  //  003F  CALL	R16	0
-      0x98301E10,  //  0040  SETIDX	R12	R15	R16
-      0x50180200,  //  0041  LDBOOL	R6	1	0
-      0x8C401D0C,  //  0042  GETMET	R16	R14	K12
-      0x5C481E00,  //  0043  MOVE	R18	R15
-      0x7C400400,  //  0044  CALL	R16	2
-      0xB8460800,  //  0045  GETNGBL	R17	K4
-      0x8C442305,  //  0046  GETMET	R17	R17	K5
-      0x8C4C0906,  //  0047  GETMET	R19	R4	K6
-      0x5854000D,  //  0048  LDCONST	R21	K13
-      0x60580008,  //  0049  GETGBL	R22	G8
-      0x5C5C1C00,  //  004A  MOVE	R23	R14
-      0x7C580200,  //  004B  CALL	R22	1
-      0x605C0008,  //  004C  GETGBL	R23	G8
-      0x5C601E00,  //  004D  MOVE	R24	R15
-      0x7C5C0200,  //  004E  CALL	R23	1
-      0x60600008,  //  004F  GETGBL	R24	G8
-      0x5C642000,  //  0050  MOVE	R25	R16
-      0x7C600200,  //  0051  CALL	R24	1
-      0x7C4C0A00,  //  0052  CALL	R19	5
-      0x54520003,  //  0053  LDINT	R20	4
-      0x7C440600,  //  0054  CALL	R17	3
-      0x60440010,  //  0055  GETGBL	R17	G16
-      0x5C482000,  //  0056  MOVE	R18	R16
-      0x7C440200,  //  0057  CALL	R17	1
-      0xA802004B,  //  0058  EXBLK	0	#00A5
-      0x5C482200,  //  0059  MOVE	R18	R17
-      0x7C480000,  //  005A  CALL	R18	0
-      0x4C4C0000,  //  005B  LDNIL	R19
-      0x204C0E13,  //  005C  NE	R19	R7	R19
-      0x784E0002,  //  005D  JMPF	R19	#0061
-      0x204C2407,  //  005E  NE	R19	R18	R7
-      0x784E0000,  //  005F  JMPF	R19	#0061
-      0x7001FFF7,  //  0060  JMP		#0059
-      0x944C180F,  //  0061  GETIDX	R19	R12	R15
-      0x8C4C270B,  //  0062  GETMET	R19	R19	K11
-      0x5C542400,  //  0063  MOVE	R21	R18
-      0x7C4C0400,  //  0064  CALL	R19	2
-      0x744E0003,  //  0065  JMPT	R19	#006A
-      0x944C180F,  //  0066  GETIDX	R19	R12	R15
-      0x60500013,  //  0067  GETGBL	R20	G19
-      0x7C500000,  //  0068  CALL	R20	0
-      0x984C2414,  //  0069  SETIDX	R19	R18	R20
-      0x50200200,  //  006A  LDBOOL	R8	1	0
-      0x8C4C1D0E,  //  006B  GETMET	R19	R14	K14
-      0x5C541E00,  //  006C  MOVE	R21	R15
-      0x5C582400,  //  006D  MOVE	R22	R18
-      0x7C4C0600,  //  006E  CALL	R19	3
-      0xB8520800,  //  006F  GETNGBL	R20	K4
-      0x8C502905,  //  0070  GETMET	R20	R20	K5
-      0x8C580906,  //  0071  GETMET	R22	R4	K6
-      0x5860000F,  //  0072  LDCONST	R24	K15
-      0x60640008,  //  0073  GETGBL	R25	G8
-      0x5C681C00,  //  0074  MOVE	R26	R14
-      0x7C640200,  //  0075  CALL	R25	1
-      0x60680008,  //  0076  GETGBL	R26	G8
-      0x5C6C1E00,  //  0077  MOVE	R27	R15
-      0x7C680200,  //  0078  CALL	R26	1
-      0x606C0008,  //  0079  GETGBL	R27	G8
-      0x5C702400,  //  007A  MOVE	R28	R18
-      0x7C6C0200,  //  007B  CALL	R27	1
-      0x60700008,  //  007C  GETGBL	R28	G8
-      0x5C742600,  //  007D  MOVE	R29	R19
-      0x7C700200,  //  007E  CALL	R28	1
-      0x7C580C00,  //  007F  CALL	R22	6
-      0x545E0003,  //  0080  LDINT	R23	4
-      0x7C500600,  //  0081  CALL	R20	3
-      0x60500010,  //  0082  GETGBL	R20	G16
-      0x5C542600,  //  0083  MOVE	R21	R19
-      0x7C500200,  //  0084  CALL	R20	1
-      0xA802001A,  //  0085  EXBLK	0	#00A1
-      0x5C542800,  //  0086  MOVE	R21	R20
-      0x7C540000,  //  0087  CALL	R21	0
-      0x4C580000,  //  0088  LDNIL	R22
-      0x20581216,  //  0089  NE	R22	R9	R22
-      0x785A0002,  //  008A  JMPF	R22	#008E
-      0x20582A09,  //  008B  NE	R22	R21	R9
-      0x785A0000,  //  008C  JMPF	R22	#008E
-      0x7001FFF7,  //  008D  JMP		#0086
-      0x9458180F,  //  008E  GETIDX	R22	R12	R15
-      0x94582C12,  //  008F  GETIDX	R22	R22	R18
-      0x8C582D0B,  //  0090  GETMET	R22	R22	K11
-      0x5C602A00,  //  0091  MOVE	R24	R21
-      0x7C580400,  //  0092  CALL	R22	2
-      0x745A0004,  //  0093  JMPT	R22	#0099
-      0x9458180F,  //  0094  GETIDX	R22	R12	R15
-      0x94582C12,  //  0095  GETIDX	R22	R22	R18
-      0x605C0012,  //  0096  GETGBL	R23	G18
-      0x7C5C0000,  //  0097  CALL	R23	0
-      0x98582A17,  //  0098  SETIDX	R22	R21	R23
-      0x50280200,  //  0099  LDBOOL	R10	1	0
-      0x9458180F,  //  009A  GETIDX	R22	R12	R15
-      0x94582C12,  //  009B  GETIDX	R22	R22	R18
-      0x94582C15,  //  009C  GETIDX	R22	R22	R21
-      0x8C582D10,  //  009D  GETMET	R22	R22	K16
-      0x5C601C00,  //  009E  MOVE	R24	R14
-      0x7C580400,  //  009F  CALL	R22	2
-      0x7001FFE4,  //  00A0  JMP		#0086
-      0x58500011,  //  00A1  LDCONST	R20	K17
-      0xAC500200,  //  00A2  CATCH	R20	1	0
-      0xB0080000,  //  00A3  RAISE	2	R0	R0
-      0x7001FFB3,  //  00A4  JMP		#0059
-      0x58440011,  //  00A5  LDCONST	R17	K17
-      0xAC440200,  //  00A6  CATCH	R17	1	0
-      0xB0080000,  //  00A7  RAISE	2	R0	R0
-      0x7001FF86,  //  00A8  JMP		#0030
-      0x58340011,  //  00A9  LDCONST	R13	K17
-      0xAC340200,  //  00AA  CATCH	R13	1	0
-      0xB0080000,  //  00AB  RAISE	2	R0	R0
-      0x60340010,  //  00AC  GETGBL	R13	G16
-      0x5C380600,  //  00AD  MOVE	R14	R3
-      0x5C3C1800,  //  00AE  MOVE	R15	R12
-      0x7C380200,  //  00AF  CALL	R14	1
-      0x7C340200,  //  00B0  CALL	R13	1
-      0xA802003D,  //  00B1  EXBLK	0	#00F0
-      0x5C381A00,  //  00B2  MOVE	R14	R13
-      0x7C380000,  //  00B3  CALL	R14	0
-      0x603C0010,  //  00B4  GETGBL	R15	G16
-      0x5C400600,  //  00B5  MOVE	R16	R3
-      0x9444180E,  //  00B6  GETIDX	R17	R12	R14
-      0x7C400200,  //  00B7  CALL	R16	1
-      0x7C3C0200,  //  00B8  CALL	R15	1
-      0xA8020031,  //  00B9  EXBLK	0	#00EC
-      0x5C401E00,  //  00BA  MOVE	R16	R15
-      0x7C400000,  //  00BB  CALL	R16	0
-      0x60440010,  //  00BC  GETGBL	R17	G16
-      0x5C480600,  //  00BD  MOVE	R18	R3
-      0x944C180E,  //  00BE  GETIDX	R19	R12	R14
-      0x944C2610,  //  00BF  GETIDX	R19	R19	R16
-      0x7C480200,  //  00C0  CALL	R18	1
-      0x7C440200,  //  00C1  CALL	R17	1
-      0xA8020024,  //  00C2  EXBLK	0	#00E8
-      0x5C482200,  //  00C3  MOVE	R18	R17
-      0x7C480000,  //  00C4  CALL	R18	0
-      0x604C0010,  //  00C5  GETGBL	R19	G16
-      0x9450180E,  //  00C6  GETIDX	R20	R12	R14
-      0x94502810,  //  00C7  GETIDX	R20	R20	R16
-      0x94502812,  //  00C8  GETIDX	R20	R20	R18
-      0x7C4C0200,  //  00C9  CALL	R19	1
-      0xA8020018,  //  00CA  EXBLK	0	#00E4
-      0x5C502600,  //  00CB  MOVE	R20	R19
-      0x7C500000,  //  00CC  CALL	R20	0
-      0xB8560800,  //  00CD  GETNGBL	R21	K4
-      0x8C542B05,  //  00CE  GETMET	R21	R21	K5
-      0x8C5C0906,  //  00CF  GETMET	R23	R4	K6
-      0x58640012,  //  00D0  LDCONST	R25	K18
-      0x5C681C00,  //  00D1  MOVE	R26	R14
-      0x5C6C2000,  //  00D2  MOVE	R27	R16
-      0x5C702400,  //  00D3  MOVE	R28	R18
-      0x7C5C0A00,  //  00D4  CALL	R23	5
-      0x58600013,  //  00D5  LDCONST	R24	K19
-      0x7C540600,  //  00D6  CALL	R21	3
-      0x9006020E,  //  00D7  SETMBR	R1	K1	R14
-      0x90060410,  //  00D8  SETMBR	R1	K2	R16
-      0x90060612,  //  00D9  SETMBR	R1	K3	R18
-      0x5C540400,  //  00DA  MOVE	R21	R2
-      0x5C582800,  //  00DB  MOVE	R22	R20
-      0x5C5C0200,  //  00DC  MOVE	R23	R1
-      0x5C601600,  //  00DD  MOVE	R24	R11
-      0x7C540600,  //  00DE  CALL	R21	3
-      0x782E0002,  //  00DF  JMPF	R11	#00E3
-      0x78560001,  //  00E0  JMPF	R21	#00E3
-      0xA8040004,  //  00E1  EXBLK	1	4
-      0x80002C00,  //  00E2  RET	0
-      0x7001FFE6,  //  00E3  JMP		#00CB
-      0x584C0011,  //  00E4  LDCONST	R19	K17
-      0xAC4C0200,  //  00E5  CATCH	R19	1	0
-      0xB0080000,  //  00E6  RAISE	2	R0	R0
-      0x7001FFDA,  //  00E7  JMP		#00C3
-      0x58440011,  //  00E8  LDCONST	R17	K17
-      0xAC440200,  //  00E9  CATCH	R17	1	0
-      0xB0080000,  //  00EA  RAISE	2	R0	R0
-      0x7001FFCD,  //  00EB  JMP		#00BA
-      0x583C0011,  //  00EC  LDCONST	R15	K17
-      0xAC3C0200,  //  00ED  CATCH	R15	1	0
-      0xB0080000,  //  00EE  RAISE	2	R0	R0
-      0x7001FFC1,  //  00EF  JMP		#00B2
-      0x58340011,  //  00F0  LDCONST	R13	K17
-      0xAC340200,  //  00F1  CATCH	R13	1	0
-      0xB0080000,  //  00F2  RAISE	2	R0	R0
-      0x782E0019,  //  00F3  JMPF	R11	#010E
-      0x5C340C00,  //  00F4  MOVE	R13	R6
-      0x74360003,  //  00F5  JMPT	R13	#00FA
-      0xB8362A00,  //  00F6  GETNGBL	R13	K21
-      0x88341B16,  //  00F7  GETMBR	R13	R13	K22
-      0x9006280D,  //  00F8  SETMBR	R1	K20	R13
-      0x7002000E,  //  00F9  JMP		#0109
-      0x5C341000,  //  00FA  MOVE	R13	R8
-      0x74360003,  //  00FB  JMPT	R13	#0100
-      0xB8362A00,  //  00FC  GETNGBL	R13	K21
-      0x88341B17,  //  00FD  GETMBR	R13	R13	K23
-      0x9006280D,  //  00FE  SETMBR	R1	K20	R13
-      0x70020008,  //  00FF  JMP		#0109
-      0x5C341400,  //  0100  MOVE	R13	R10
-      0x74360003,  //  0101  JMPT	R13	#0106
-      0xB8362A00,  //  0102  GETNGBL	R13	K21
-      0x88341B18,  //  0103  GETMBR	R13	R13	K24
-      0x9006280D,  //  0104  SETMBR	R1	K20	R13
-      0x70020002,  //  0105  JMP		#0109
-      0xB8362A00,  //  0106  GETNGBL	R13	K21
-      0x88341B19,  //  0107  GETMBR	R13	R13	K25
-      0x9006280D,  //  0108  SETMBR	R1	K20	R13
-      0x5C340400,  //  0109  MOVE	R13	R2
-      0x4C380000,  //  010A  LDNIL	R14
-      0x5C3C0200,  //  010B  MOVE	R15	R1
-      0x50400200,  //  010C  LDBOOL	R16	1	0
-      0x7C340600,  //  010D  CALL	R13	3
-      0x80000000,  //  010E  RET	0
+      0x60300013,  //  0016  GETGBL	R12	G19
+      0x7C300000,  //  0017  CALL	R12	0
+      0x60340010,  //  0018  GETGBL	R13	G16
+      0x88380104,  //  0019  GETMBR	R14	R0	K4
+      0x7C340200,  //  001A  CALL	R13	1
+      0xA8020055,  //  001B  EXBLK	0	#0072
+      0x5C381A00,  //  001C  MOVE	R14	R13
+      0x7C380000,  //  001D  CALL	R14	0
+      0x8C3C1D05,  //  001E  GETMET	R15	R14	K5
+      0x7C3C0200,  //  001F  CALL	R15	1
+      0x4C400000,  //  0020  LDNIL	R16
+      0x20400A10,  //  0021  NE	R16	R5	R16
+      0x78420002,  //  0022  JMPF	R16	#0026
+      0x20401E05,  //  0023  NE	R16	R15	R5
+      0x78420000,  //  0024  JMPF	R16	#0026
+      0x7001FFF5,  //  0025  JMP		#001C
+      0x8C401906,  //  0026  GETMET	R16	R12	K6
+      0x5C481E00,  //  0027  MOVE	R18	R15
+      0x7C400400,  //  0028  CALL	R16	2
+      0x74420002,  //  0029  JMPT	R16	#002D
+      0x60400013,  //  002A  GETGBL	R16	G19
+      0x7C400000,  //  002B  CALL	R16	0
+      0x98301E10,  //  002C  SETIDX	R12	R15	R16
+      0x50180200,  //  002D  LDBOOL	R6	1	0
+      0x8C401D07,  //  002E  GETMET	R16	R14	K7
+      0x5C481E00,  //  002F  MOVE	R18	R15
+      0x7C400400,  //  0030  CALL	R16	2
+      0x60440010,  //  0031  GETGBL	R17	G16
+      0x5C482000,  //  0032  MOVE	R18	R16
+      0x7C440200,  //  0033  CALL	R17	1
+      0xA8020038,  //  0034  EXBLK	0	#006E
+      0x5C482200,  //  0035  MOVE	R18	R17
+      0x7C480000,  //  0036  CALL	R18	0
+      0x4C4C0000,  //  0037  LDNIL	R19
+      0x204C0E13,  //  0038  NE	R19	R7	R19
+      0x784E0002,  //  0039  JMPF	R19	#003D
+      0x204C2407,  //  003A  NE	R19	R18	R7
+      0x784E0000,  //  003B  JMPF	R19	#003D
+      0x7001FFF7,  //  003C  JMP		#0035
+      0x944C180F,  //  003D  GETIDX	R19	R12	R15
+      0x8C4C2706,  //  003E  GETMET	R19	R19	K6
+      0x5C542400,  //  003F  MOVE	R21	R18
+      0x7C4C0400,  //  0040  CALL	R19	2
+      0x744E0003,  //  0041  JMPT	R19	#0046
+      0x944C180F,  //  0042  GETIDX	R19	R12	R15
+      0x60500013,  //  0043  GETGBL	R20	G19
+      0x7C500000,  //  0044  CALL	R20	0
+      0x984C2414,  //  0045  SETIDX	R19	R18	R20
+      0x50200200,  //  0046  LDBOOL	R8	1	0
+      0x8C4C1D08,  //  0047  GETMET	R19	R14	K8
+      0x5C541E00,  //  0048  MOVE	R21	R15
+      0x5C582400,  //  0049  MOVE	R22	R18
+      0x7C4C0600,  //  004A  CALL	R19	3
+      0x60500010,  //  004B  GETGBL	R20	G16
+      0x5C542600,  //  004C  MOVE	R21	R19
+      0x7C500200,  //  004D  CALL	R20	1
+      0xA802001A,  //  004E  EXBLK	0	#006A
+      0x5C542800,  //  004F  MOVE	R21	R20
+      0x7C540000,  //  0050  CALL	R21	0
+      0x4C580000,  //  0051  LDNIL	R22
+      0x20581216,  //  0052  NE	R22	R9	R22
+      0x785A0002,  //  0053  JMPF	R22	#0057
+      0x20582A09,  //  0054  NE	R22	R21	R9
+      0x785A0000,  //  0055  JMPF	R22	#0057
+      0x7001FFF7,  //  0056  JMP		#004F
+      0x9458180F,  //  0057  GETIDX	R22	R12	R15
+      0x94582C12,  //  0058  GETIDX	R22	R22	R18
+      0x8C582D06,  //  0059  GETMET	R22	R22	K6
+      0x5C602A00,  //  005A  MOVE	R24	R21
+      0x7C580400,  //  005B  CALL	R22	2
+      0x745A0004,  //  005C  JMPT	R22	#0062
+      0x9458180F,  //  005D  GETIDX	R22	R12	R15
+      0x94582C12,  //  005E  GETIDX	R22	R22	R18
+      0x605C0012,  //  005F  GETGBL	R23	G18
+      0x7C5C0000,  //  0060  CALL	R23	0
+      0x98582A17,  //  0061  SETIDX	R22	R21	R23
+      0x50280200,  //  0062  LDBOOL	R10	1	0
+      0x9458180F,  //  0063  GETIDX	R22	R12	R15
+      0x94582C12,  //  0064  GETIDX	R22	R22	R18
+      0x94582C15,  //  0065  GETIDX	R22	R22	R21
+      0x8C582D09,  //  0066  GETMET	R22	R22	K9
+      0x5C601C00,  //  0067  MOVE	R24	R14
+      0x7C580400,  //  0068  CALL	R22	2
+      0x7001FFE4,  //  0069  JMP		#004F
+      0x5850000A,  //  006A  LDCONST	R20	K10
+      0xAC500200,  //  006B  CATCH	R20	1	0
+      0xB0080000,  //  006C  RAISE	2	R0	R0
+      0x7001FFC6,  //  006D  JMP		#0035
+      0x5844000A,  //  006E  LDCONST	R17	K10
+      0xAC440200,  //  006F  CATCH	R17	1	0
+      0xB0080000,  //  0070  RAISE	2	R0	R0
+      0x7001FFA9,  //  0071  JMP		#001C
+      0x5834000A,  //  0072  LDCONST	R13	K10
+      0xAC340200,  //  0073  CATCH	R13	1	0
+      0xB0080000,  //  0074  RAISE	2	R0	R0
+      0x60340010,  //  0075  GETGBL	R13	G16
+      0x5C380600,  //  0076  MOVE	R14	R3
+      0x5C3C1800,  //  0077  MOVE	R15	R12
+      0x7C380200,  //  0078  CALL	R14	1
+      0x7C340200,  //  0079  CALL	R13	1
+      0xA802003D,  //  007A  EXBLK	0	#00B9
+      0x5C381A00,  //  007B  MOVE	R14	R13
+      0x7C380000,  //  007C  CALL	R14	0
+      0x603C0010,  //  007D  GETGBL	R15	G16
+      0x5C400600,  //  007E  MOVE	R16	R3
+      0x9444180E,  //  007F  GETIDX	R17	R12	R14
+      0x7C400200,  //  0080  CALL	R16	1
+      0x7C3C0200,  //  0081  CALL	R15	1
+      0xA8020031,  //  0082  EXBLK	0	#00B5
+      0x5C401E00,  //  0083  MOVE	R16	R15
+      0x7C400000,  //  0084  CALL	R16	0
+      0x60440010,  //  0085  GETGBL	R17	G16
+      0x5C480600,  //  0086  MOVE	R18	R3
+      0x944C180E,  //  0087  GETIDX	R19	R12	R14
+      0x944C2610,  //  0088  GETIDX	R19	R19	R16
+      0x7C480200,  //  0089  CALL	R18	1
+      0x7C440200,  //  008A  CALL	R17	1
+      0xA8020024,  //  008B  EXBLK	0	#00B1
+      0x5C482200,  //  008C  MOVE	R18	R17
+      0x7C480000,  //  008D  CALL	R18	0
+      0x604C0010,  //  008E  GETGBL	R19	G16
+      0x9450180E,  //  008F  GETIDX	R20	R12	R14
+      0x94502810,  //  0090  GETIDX	R20	R20	R16
+      0x94502812,  //  0091  GETIDX	R20	R20	R18
+      0x7C4C0200,  //  0092  CALL	R19	1
+      0xA8020018,  //  0093  EXBLK	0	#00AD
+      0x5C502600,  //  0094  MOVE	R20	R19
+      0x7C500000,  //  0095  CALL	R20	0
+      0xB8561600,  //  0096  GETNGBL	R21	K11
+      0x8C542B0C,  //  0097  GETMET	R21	R21	K12
+      0x8C5C090D,  //  0098  GETMET	R23	R4	K13
+      0x5864000E,  //  0099  LDCONST	R25	K14
+      0x5C681C00,  //  009A  MOVE	R26	R14
+      0x5C6C2000,  //  009B  MOVE	R27	R16
+      0x5C702400,  //  009C  MOVE	R28	R18
+      0x7C5C0A00,  //  009D  CALL	R23	5
+      0x5860000F,  //  009E  LDCONST	R24	K15
+      0x7C540600,  //  009F  CALL	R21	3
+      0x9006020E,  //  00A0  SETMBR	R1	K1	R14
+      0x90060410,  //  00A1  SETMBR	R1	K2	R16
+      0x90060612,  //  00A2  SETMBR	R1	K3	R18
+      0x5C540400,  //  00A3  MOVE	R21	R2
+      0x5C582800,  //  00A4  MOVE	R22	R20
+      0x5C5C0200,  //  00A5  MOVE	R23	R1
+      0x5C601600,  //  00A6  MOVE	R24	R11
+      0x7C540600,  //  00A7  CALL	R21	3
+      0x782E0002,  //  00A8  JMPF	R11	#00AC
+      0x78560001,  //  00A9  JMPF	R21	#00AC
+      0xA8040004,  //  00AA  EXBLK	1	4
+      0x80002C00,  //  00AB  RET	0
+      0x7001FFE6,  //  00AC  JMP		#0094
+      0x584C000A,  //  00AD  LDCONST	R19	K10
+      0xAC4C0200,  //  00AE  CATCH	R19	1	0
+      0xB0080000,  //  00AF  RAISE	2	R0	R0
+      0x7001FFDA,  //  00B0  JMP		#008C
+      0x5844000A,  //  00B1  LDCONST	R17	K10
+      0xAC440200,  //  00B2  CATCH	R17	1	0
+      0xB0080000,  //  00B3  RAISE	2	R0	R0
+      0x7001FFCD,  //  00B4  JMP		#0083
+      0x583C000A,  //  00B5  LDCONST	R15	K10
+      0xAC3C0200,  //  00B6  CATCH	R15	1	0
+      0xB0080000,  //  00B7  RAISE	2	R0	R0
+      0x7001FFC1,  //  00B8  JMP		#007B
+      0x5834000A,  //  00B9  LDCONST	R13	K10
+      0xAC340200,  //  00BA  CATCH	R13	1	0
+      0xB0080000,  //  00BB  RAISE	2	R0	R0
+      0x782E0019,  //  00BC  JMPF	R11	#00D7
+      0x5C340C00,  //  00BD  MOVE	R13	R6
+      0x74360003,  //  00BE  JMPT	R13	#00C3
+      0xB8362200,  //  00BF  GETNGBL	R13	K17
+      0x88341B12,  //  00C0  GETMBR	R13	R13	K18
+      0x9006200D,  //  00C1  SETMBR	R1	K16	R13
+      0x7002000E,  //  00C2  JMP		#00D2
+      0x5C341000,  //  00C3  MOVE	R13	R8
+      0x74360003,  //  00C4  JMPT	R13	#00C9
+      0xB8362200,  //  00C5  GETNGBL	R13	K17
+      0x88341B13,  //  00C6  GETMBR	R13	R13	K19
+      0x9006200D,  //  00C7  SETMBR	R1	K16	R13
+      0x70020008,  //  00C8  JMP		#00D2
+      0x5C341400,  //  00C9  MOVE	R13	R10
+      0x74360003,  //  00CA  JMPT	R13	#00CF
+      0xB8362200,  //  00CB  GETNGBL	R13	K17
+      0x88341B14,  //  00CC  GETMBR	R13	R13	K20
+      0x9006200D,  //  00CD  SETMBR	R1	K16	R13
+      0x70020002,  //  00CE  JMP		#00D2
+      0xB8362200,  //  00CF  GETNGBL	R13	K17
+      0x88341B15,  //  00D0  GETMBR	R13	R13	K21
+      0x9006200D,  //  00D1  SETMBR	R1	K16	R13
+      0x5C340400,  //  00D2  MOVE	R13	R2
+      0x4C380000,  //  00D3  LDNIL	R14
+      0x5C3C0200,  //  00D4  MOVE	R15	R1
+      0x50400200,  //  00D5  LDBOOL	R16	1	0
+      0x7C340600,  //  00D6  CALL	R13	3
+      0x80000000,  //  00D7  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -75,361 +75,325 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[50]) {     /* constants */
+    ( &(const bvalue[44]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20IM_X3Ainvoke_request_X20processing_X20start),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(Path),
-    /* K6   */  be_nested_str_weak(InvokeRequestMessage),
-    /* K7   */  be_nested_str_weak(from_TLV),
-    /* K8   */  be_nested_str_weak(invoke_requests),
-    /* K9   */  be_nested_str_weak(InvokeResponseMessage),
-    /* K10  */  be_nested_str_weak(suppress_response),
-    /* K11  */  be_nested_str_weak(invoke_responses),
-    /* K12  */  be_nested_str_weak(endpoint),
-    /* K13  */  be_nested_str_weak(command_path),
-    /* K14  */  be_nested_str_weak(cluster),
-    /* K15  */  be_nested_str_weak(command),
-    /* K16  */  be_nested_str_weak(status),
-    /* K17  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
-    /* K18  */  be_nested_str_weak(get_command_name),
-    /* K19  */  be_nested_str_weak(device),
-    /* K20  */  be_nested_str_weak(invoke_request),
-    /* K21  */  be_nested_str_weak(session),
-    /* K22  */  be_nested_str_weak(command_fields),
-    /* K23  */  be_nested_str_weak(_X28),
-    /* K24  */  be_nested_str_weak(_X29_X20),
-    /* K25  */  be_nested_str_weak(),
-    /* K26  */  be_nested_str_weak(format),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20_X25s),
-    /* K28  */  be_nested_str_weak(local_session_id),
-    /* K29  */  be_const_int(2),
-    /* K30  */  be_nested_str_weak(InvokeResponseIB),
-    /* K31  */  be_nested_str_weak(SUCCESS),
-    /* K32  */  be_nested_str_weak(CommandStatusIB),
-    /* K33  */  be_nested_str_weak(CommandPathIB),
-    /* K34  */  be_nested_str_weak(StatusIB),
-    /* K35  */  be_nested_str_weak(push),
-    /* K36  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20OK_X20exch_X3D_X25i),
-    /* K37  */  be_nested_str_weak(exchange_id),
-    /* K38  */  be_nested_str_weak(CommandDataIB),
-    /* K39  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s),
-    /* K40  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20Status_X3D0x_X2502X_X20exch_X3D_X25i),
-    /* K41  */  be_nested_str_weak(MTR_X3A_X20_Ignore_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i),
-    /* K42  */  be_nested_str_weak(stop_iteration),
-    /* K43  */  be_nested_str_weak(MTR_X3A_X20invoke_responses_X3D),
-    /* K44  */  be_const_int(0),
-    /* K45  */  be_nested_str_weak(MTR_X3A_X20InvokeResponse_X3D),
-    /* K46  */  be_nested_str_weak(MTR_X3A_X20InvokeResponseTLV_X3D),
-    /* K47  */  be_nested_str_weak(to_TLV),
-    /* K48  */  be_const_int(3),
-    /* K49  */  be_nested_str_weak(send_invoke_response),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(Path),
+    /* K3   */  be_nested_str_weak(InvokeRequestMessage),
+    /* K4   */  be_nested_str_weak(from_TLV),
+    /* K5   */  be_nested_str_weak(invoke_requests),
+    /* K6   */  be_nested_str_weak(InvokeResponseMessage),
+    /* K7   */  be_nested_str_weak(suppress_response),
+    /* K8   */  be_nested_str_weak(invoke_responses),
+    /* K9   */  be_nested_str_weak(endpoint),
+    /* K10  */  be_nested_str_weak(command_path),
+    /* K11  */  be_nested_str_weak(cluster),
+    /* K12  */  be_nested_str_weak(command),
+    /* K13  */  be_nested_str_weak(status),
+    /* K14  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
+    /* K15  */  be_nested_str_weak(get_command_name),
+    /* K16  */  be_nested_str_weak(device),
+    /* K17  */  be_nested_str_weak(invoke_request),
+    /* K18  */  be_nested_str_weak(session),
+    /* K19  */  be_nested_str_weak(command_fields),
+    /* K20  */  be_nested_str_weak(log),
+    /* K21  */  be_nested_str_weak(_X28),
+    /* K22  */  be_nested_str_weak(_X29_X20),
+    /* K23  */  be_nested_str_weak(),
+    /* K24  */  be_nested_str_weak(tasmota),
+    /* K25  */  be_nested_str_weak(format),
+    /* K26  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20_X25s),
+    /* K27  */  be_nested_str_weak(local_session_id),
+    /* K28  */  be_const_int(2),
+    /* K29  */  be_nested_str_weak(InvokeResponseIB),
+    /* K30  */  be_nested_str_weak(SUCCESS),
+    /* K31  */  be_nested_str_weak(CommandStatusIB),
+    /* K32  */  be_nested_str_weak(CommandPathIB),
+    /* K33  */  be_nested_str_weak(StatusIB),
+    /* K34  */  be_nested_str_weak(push),
+    /* K35  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20OK_X20exch_X3D_X25i),
+    /* K36  */  be_nested_str_weak(exchange_id),
+    /* K37  */  be_nested_str_weak(CommandDataIB),
+    /* K38  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s),
+    /* K39  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20Status_X3D0x_X2502X_X20exch_X3D_X25i),
+    /* K40  */  be_nested_str_weak(MTR_X3A_X20_Ignore_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i),
+    /* K41  */  be_nested_str_weak(stop_iteration),
+    /* K42  */  be_const_int(0),
+    /* K43  */  be_nested_str_weak(send_invoke_response),
     }),
     be_str_weak(process_invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[300]) {  /* code */
+    ( &(const binstruction[270]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0xB8120200,  //  0001  GETNGBL	R4	K1
       0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x58180003,  //  0003  LDCONST	R6	K3
-      0x541E0003,  //  0004  LDINT	R7	4
-      0x7C100600,  //  0005  CALL	R4	3
-      0xB8120800,  //  0006  GETNGBL	R4	K4
-      0x8C100905,  //  0007  GETMET	R4	R4	K5
-      0x7C100200,  //  0008  CALL	R4	1
-      0xB8160800,  //  0009  GETNGBL	R5	K4
-      0x8C140B06,  //  000A  GETMET	R5	R5	K6
-      0x7C140200,  //  000B  CALL	R5	1
-      0x8C140B07,  //  000C  GETMET	R5	R5	K7
-      0x5C1C0400,  //  000D  MOVE	R7	R2
-      0x7C140400,  //  000E  CALL	R5	2
-      0x88180B08,  //  000F  GETMBR	R6	R5	K8
-      0x4C1C0000,  //  0010  LDNIL	R7
-      0x20180C07,  //  0011  NE	R6	R6	R7
-      0x781A0117,  //  0012  JMPF	R6	#012B
-      0xB81A0800,  //  0013  GETNGBL	R6	K4
-      0x8C180D09,  //  0014  GETMET	R6	R6	K9
-      0x7C180200,  //  0015  CALL	R6	1
-      0x501C0000,  //  0016  LDBOOL	R7	0	0
-      0x901A1407,  //  0017  SETMBR	R6	K10	R7
-      0x601C0012,  //  0018  GETGBL	R7	G18
-      0x7C1C0000,  //  0019  CALL	R7	0
-      0x901A1607,  //  001A  SETMBR	R6	K11	R7
-      0x601C0010,  //  001B  GETGBL	R7	G16
-      0x88200B08,  //  001C  GETMBR	R8	R5	K8
-      0x7C1C0200,  //  001D  CALL	R7	1
-      0xA80200E1,  //  001E  EXBLK	0	#0101
-      0x5C200E00,  //  001F  MOVE	R8	R7
-      0x7C200000,  //  0020  CALL	R8	0
-      0x8824110D,  //  0021  GETMBR	R9	R8	K13
-      0x8824130C,  //  0022  GETMBR	R9	R9	K12
-      0x90121809,  //  0023  SETMBR	R4	K12	R9
-      0x8824110D,  //  0024  GETMBR	R9	R8	K13
-      0x8824130E,  //  0025  GETMBR	R9	R9	K14
-      0x90121C09,  //  0026  SETMBR	R4	K14	R9
-      0x8824110D,  //  0027  GETMBR	R9	R8	K13
-      0x8824130F,  //  0028  GETMBR	R9	R9	K15
-      0x90121E09,  //  0029  SETMBR	R4	K15	R9
-      0xB8260800,  //  002A  GETNGBL	R9	K4
-      0x88241311,  //  002B  GETMBR	R9	R9	K17
-      0x90122009,  //  002C  SETMBR	R4	K16	R9
-      0xB8260800,  //  002D  GETNGBL	R9	K4
-      0x8C241312,  //  002E  GETMET	R9	R9	K18
-      0x882C090E,  //  002F  GETMBR	R11	R4	K14
-      0x8830090F,  //  0030  GETMBR	R12	R4	K15
-      0x7C240600,  //  0031  CALL	R9	3
-      0x88280113,  //  0032  GETMBR	R10	R0	K19
-      0x8C281514,  //  0033  GETMET	R10	R10	K20
-      0x88300315,  //  0034  GETMBR	R12	R1	K21
-      0x88341116,  //  0035  GETMBR	R13	R8	K22
-      0x5C380800,  //  0036  MOVE	R14	R4
-      0x7C280800,  //  0037  CALL	R10	4
-      0x882C0902,  //  0038  GETMBR	R11	R4	K2
-      0x4C300000,  //  0039  LDNIL	R12
-      0x202C160C,  //  003A  NE	R11	R11	R12
-      0x782E0005,  //  003B  JMPF	R11	#0042
-      0x602C0008,  //  003C  GETGBL	R11	G8
-      0x88300902,  //  003D  GETMBR	R12	R4	K2
-      0x7C2C0200,  //  003E  CALL	R11	1
-      0x002E2E0B,  //  003F  ADD	R11	K23	R11
-      0x002C1718,  //  0040  ADD	R11	R11	K24
-      0x70020000,  //  0041  JMP		#0043
-      0x582C0019,  //  0042  LDCONST	R11	K25
-      0xB8320200,  //  0043  GETNGBL	R12	K1
-      0x8C301902,  //  0044  GETMET	R12	R12	K2
-      0x8C38071A,  //  0045  GETMET	R14	R3	K26
-      0x5840001B,  //  0046  LDCONST	R16	K27
-      0x88440315,  //  0047  GETMBR	R17	R1	K21
-      0x8844231C,  //  0048  GETMBR	R17	R17	K28
-      0x60480008,  //  0049  GETGBL	R18	G8
-      0x5C4C0800,  //  004A  MOVE	R19	R4
-      0x7C480200,  //  004B  CALL	R18	1
-      0x78260001,  //  004C  JMPF	R9	#004F
-      0x5C4C1200,  //  004D  MOVE	R19	R9
-      0x70020000,  //  004E  JMP		#0050
-      0x584C0019,  //  004F  LDCONST	R19	K25
-      0x5C501600,  //  0050  MOVE	R20	R11
-      0x7C380C00,  //  0051  CALL	R14	6
-      0x583C001D,  //  0052  LDCONST	R15	K29
-      0x7C300600,  //  0053  CALL	R12	3
-      0x4C300000,  //  0054  LDNIL	R12
-      0x9012040C,  //  0055  SETMBR	R4	K2	R12
-      0xB8320800,  //  0056  GETNGBL	R12	K4
-      0x8C30191E,  //  0057  GETMET	R12	R12	K30
-      0x7C300200,  //  0058  CALL	R12	1
-      0x50340200,  //  0059  LDBOOL	R13	1	0
-      0x1C34140D,  //  005A  EQ	R13	R10	R13
-      0x74360004,  //  005B  JMPT	R13	#0061
-      0x88340910,  //  005C  GETMBR	R13	R4	K16
-      0xB83A0800,  //  005D  GETNGBL	R14	K4
-      0x88381D1F,  //  005E  GETMBR	R14	R14	K31
-      0x1C341A0E,  //  005F  EQ	R13	R13	R14
-      0x7836002D,  //  0060  JMPF	R13	#008F
-      0xB8360800,  //  0061  GETNGBL	R13	K4
-      0x8C341B20,  //  0062  GETMET	R13	R13	K32
-      0x7C340200,  //  0063  CALL	R13	1
-      0x9032200D,  //  0064  SETMBR	R12	K16	R13
-      0x88341910,  //  0065  GETMBR	R13	R12	K16
-      0xB83A0800,  //  0066  GETNGBL	R14	K4
-      0x8C381D21,  //  0067  GETMET	R14	R14	K33
-      0x7C380200,  //  0068  CALL	R14	1
-      0x90361A0E,  //  0069  SETMBR	R13	K13	R14
-      0x88341910,  //  006A  GETMBR	R13	R12	K16
-      0x88341B0D,  //  006B  GETMBR	R13	R13	K13
-      0x8838090C,  //  006C  GETMBR	R14	R4	K12
-      0x9036180E,  //  006D  SETMBR	R13	K12	R14
-      0x88341910,  //  006E  GETMBR	R13	R12	K16
-      0x88341B0D,  //  006F  GETMBR	R13	R13	K13
-      0x8838090E,  //  0070  GETMBR	R14	R4	K14
-      0x90361C0E,  //  0071  SETMBR	R13	K14	R14
-      0x88341910,  //  0072  GETMBR	R13	R12	K16
-      0x88341B0D,  //  0073  GETMBR	R13	R13	K13
-      0x8838090F,  //  0074  GETMBR	R14	R4	K15
-      0x90361E0E,  //  0075  SETMBR	R13	K15	R14
-      0x88341910,  //  0076  GETMBR	R13	R12	K16
-      0xB83A0800,  //  0077  GETNGBL	R14	K4
-      0x8C381D22,  //  0078  GETMET	R14	R14	K34
-      0x7C380200,  //  0079  CALL	R14	1
-      0x9036200E,  //  007A  SETMBR	R13	K16	R14
-      0x88341910,  //  007B  GETMBR	R13	R12	K16
-      0x88341B10,  //  007C  GETMBR	R13	R13	K16
-      0xB83A0800,  //  007D  GETNGBL	R14	K4
-      0x88381D1F,  //  007E  GETMBR	R14	R14	K31
-      0x9036200E,  //  007F  SETMBR	R13	K16	R14
-      0x88340D0B,  //  0080  GETMBR	R13	R6	K11
-      0x8C341B23,  //  0081  GETMET	R13	R13	K35
-      0x5C3C1800,  //  0082  MOVE	R15	R12
-      0x7C340400,  //  0083  CALL	R13	2
-      0xB8360200,  //  0084  GETNGBL	R13	K1
-      0x8C341B02,  //  0085  GETMET	R13	R13	K2
-      0x8C3C071A,  //  0086  GETMET	R15	R3	K26
-      0x58440024,  //  0087  LDCONST	R17	K36
-      0x88480315,  //  0088  GETMBR	R18	R1	K21
-      0x8848251C,  //  0089  GETMBR	R18	R18	K28
-      0x884C0325,  //  008A  GETMBR	R19	R1	K37
-      0x7C3C0800,  //  008B  CALL	R15	4
-      0x5840001D,  //  008C  LDCONST	R16	K29
-      0x7C340600,  //  008D  CALL	R13	3
-      0x70020070,  //  008E  JMP		#0100
-      0x4C340000,  //  008F  LDNIL	R13
-      0x2034140D,  //  0090  NE	R13	R10	R13
-      0x78360031,  //  0091  JMPF	R13	#00C4
-      0xB8360800,  //  0092  GETNGBL	R13	K4
-      0x8C341B26,  //  0093  GETMET	R13	R13	K38
-      0x7C340200,  //  0094  CALL	R13	1
-      0x90321E0D,  //  0095  SETMBR	R12	K15	R13
-      0x8834190F,  //  0096  GETMBR	R13	R12	K15
-      0xB83A0800,  //  0097  GETNGBL	R14	K4
-      0x8C381D21,  //  0098  GETMET	R14	R14	K33
-      0x7C380200,  //  0099  CALL	R14	1
-      0x90361A0E,  //  009A  SETMBR	R13	K13	R14
-      0x8834190F,  //  009B  GETMBR	R13	R12	K15
-      0x88341B0D,  //  009C  GETMBR	R13	R13	K13
-      0x8838090C,  //  009D  GETMBR	R14	R4	K12
-      0x9036180E,  //  009E  SETMBR	R13	K12	R14
-      0x8834190F,  //  009F  GETMBR	R13	R12	K15
-      0x88341B0D,  //  00A0  GETMBR	R13	R13	K13
-      0x8838090E,  //  00A1  GETMBR	R14	R4	K14
-      0x90361C0E,  //  00A2  SETMBR	R13	K14	R14
-      0x8834190F,  //  00A3  GETMBR	R13	R12	K15
-      0x88341B0D,  //  00A4  GETMBR	R13	R13	K13
-      0x8838090F,  //  00A5  GETMBR	R14	R4	K15
-      0x90361E0E,  //  00A6  SETMBR	R13	K15	R14
-      0x8834190F,  //  00A7  GETMBR	R13	R12	K15
-      0x90362C0A,  //  00A8  SETMBR	R13	K22	R10
-      0x88340D0B,  //  00A9  GETMBR	R13	R6	K11
-      0x8C341B23,  //  00AA  GETMET	R13	R13	K35
-      0x5C3C1800,  //  00AB  MOVE	R15	R12
-      0x7C340400,  //  00AC  CALL	R13	2
-      0xB8360800,  //  00AD  GETNGBL	R13	K4
-      0x8C341B12,  //  00AE  GETMET	R13	R13	K18
-      0x883C090E,  //  00AF  GETMBR	R15	R4	K14
-      0x8840090F,  //  00B0  GETMBR	R16	R4	K15
-      0x7C340600,  //  00B1  CALL	R13	3
-      0x5C241A00,  //  00B2  MOVE	R9	R13
-      0xB8360200,  //  00B3  GETNGBL	R13	K1
-      0x8C341B02,  //  00B4  GETMET	R13	R13	K2
-      0x8C3C071A,  //  00B5  GETMET	R15	R3	K26
-      0x58440027,  //  00B6  LDCONST	R17	K39
-      0x88480315,  //  00B7  GETMBR	R18	R1	K21
-      0x8848251C,  //  00B8  GETMBR	R18	R18	K28
-      0x604C0008,  //  00B9  GETGBL	R19	G8
-      0x5C500800,  //  00BA  MOVE	R20	R4
-      0x7C4C0200,  //  00BB  CALL	R19	1
-      0x78260001,  //  00BC  JMPF	R9	#00BF
-      0x5C501200,  //  00BD  MOVE	R20	R9
-      0x70020000,  //  00BE  JMP		#00C0
-      0x58500019,  //  00BF  LDCONST	R20	K25
-      0x7C3C0A00,  //  00C0  CALL	R15	5
-      0x5840001D,  //  00C1  LDCONST	R16	K29
-      0x7C340600,  //  00C2  CALL	R13	3
-      0x7002003B,  //  00C3  JMP		#0100
-      0x88340910,  //  00C4  GETMBR	R13	R4	K16
-      0x4C380000,  //  00C5  LDNIL	R14
-      0x20341A0E,  //  00C6  NE	R13	R13	R14
-      0x7836002D,  //  00C7  JMPF	R13	#00F6
-      0xB8360800,  //  00C8  GETNGBL	R13	K4
-      0x8C341B20,  //  00C9  GETMET	R13	R13	K32
-      0x7C340200,  //  00CA  CALL	R13	1
-      0x9032200D,  //  00CB  SETMBR	R12	K16	R13
-      0x88341910,  //  00CC  GETMBR	R13	R12	K16
-      0xB83A0800,  //  00CD  GETNGBL	R14	K4
-      0x8C381D21,  //  00CE  GETMET	R14	R14	K33
-      0x7C380200,  //  00CF  CALL	R14	1
-      0x90361A0E,  //  00D0  SETMBR	R13	K13	R14
-      0x88341910,  //  00D1  GETMBR	R13	R12	K16
-      0x88341B0D,  //  00D2  GETMBR	R13	R13	K13
-      0x8838090C,  //  00D3  GETMBR	R14	R4	K12
-      0x9036180E,  //  00D4  SETMBR	R13	K12	R14
-      0x88341910,  //  00D5  GETMBR	R13	R12	K16
-      0x88341B0D,  //  00D6  GETMBR	R13	R13	K13
-      0x8838090E,  //  00D7  GETMBR	R14	R4	K14
-      0x90361C0E,  //  00D8  SETMBR	R13	K14	R14
-      0x88341910,  //  00D9  GETMBR	R13	R12	K16
-      0x88341B0D,  //  00DA  GETMBR	R13	R13	K13
-      0x8838090F,  //  00DB  GETMBR	R14	R4	K15
-      0x90361E0E,  //  00DC  SETMBR	R13	K15	R14
-      0x88341910,  //  00DD  GETMBR	R13	R12	K16
-      0xB83A0800,  //  00DE  GETNGBL	R14	K4
-      0x8C381D22,  //  00DF  GETMET	R14	R14	K34
-      0x7C380200,  //  00E0  CALL	R14	1
-      0x9036200E,  //  00E1  SETMBR	R13	K16	R14
-      0x88341910,  //  00E2  GETMBR	R13	R12	K16
-      0x88341B10,  //  00E3  GETMBR	R13	R13	K16
-      0x88380910,  //  00E4  GETMBR	R14	R4	K16
-      0x9036200E,  //  00E5  SETMBR	R13	K16	R14
-      0x88340D0B,  //  00E6  GETMBR	R13	R6	K11
-      0x8C341B23,  //  00E7  GETMET	R13	R13	K35
-      0x5C3C1800,  //  00E8  MOVE	R15	R12
-      0x7C340400,  //  00E9  CALL	R13	2
-      0xB8360200,  //  00EA  GETNGBL	R13	K1
-      0x8C341B02,  //  00EB  GETMET	R13	R13	K2
-      0x8C3C071A,  //  00EC  GETMET	R15	R3	K26
-      0x58440028,  //  00ED  LDCONST	R17	K40
-      0x88480315,  //  00EE  GETMBR	R18	R1	K21
-      0x8848251C,  //  00EF  GETMBR	R18	R18	K28
-      0x884C0910,  //  00F0  GETMBR	R19	R4	K16
-      0x88500325,  //  00F1  GETMBR	R20	R1	K37
-      0x7C3C0A00,  //  00F2  CALL	R15	5
-      0x5840001D,  //  00F3  LDCONST	R16	K29
-      0x7C340600,  //  00F4  CALL	R13	3
-      0x70020009,  //  00F5  JMP		#0100
-      0xB8360200,  //  00F6  GETNGBL	R13	K1
-      0x8C341B02,  //  00F7  GETMET	R13	R13	K2
-      0x8C3C071A,  //  00F8  GETMET	R15	R3	K26
-      0x58440029,  //  00F9  LDCONST	R17	K41
-      0x88480315,  //  00FA  GETMBR	R18	R1	K21
-      0x8848251C,  //  00FB  GETMBR	R18	R18	K28
-      0x884C0325,  //  00FC  GETMBR	R19	R1	K37
-      0x7C3C0800,  //  00FD  CALL	R15	4
-      0x5840001D,  //  00FE  LDCONST	R16	K29
-      0x7C340600,  //  00FF  CALL	R13	3
-      0x7001FF1D,  //  0100  JMP		#001F
-      0x581C002A,  //  0101  LDCONST	R7	K42
-      0xAC1C0200,  //  0102  CATCH	R7	1	0
-      0xB0080000,  //  0103  RAISE	2	R0	R0
-      0xB81E0200,  //  0104  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0105  GETMET	R7	R7	K2
-      0x60240008,  //  0106  GETGBL	R9	G8
-      0x88280D0B,  //  0107  GETMBR	R10	R6	K11
-      0x7C240200,  //  0108  CALL	R9	1
-      0x00265609,  //  0109  ADD	R9	K43	R9
-      0x542A0003,  //  010A  LDINT	R10	4
-      0x7C1C0600,  //  010B  CALL	R7	3
-      0x601C000C,  //  010C  GETGBL	R7	G12
-      0x88200D0B,  //  010D  GETMBR	R8	R6	K11
-      0x7C1C0200,  //  010E  CALL	R7	1
-      0x241C0F2C,  //  010F  GT	R7	R7	K44
-      0x781E0015,  //  0110  JMPF	R7	#0127
-      0xB81E0200,  //  0111  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0112  GETMET	R7	R7	K2
-      0x60240008,  //  0113  GETGBL	R9	G8
-      0x5C280C00,  //  0114  MOVE	R10	R6
-      0x7C240200,  //  0115  CALL	R9	1
-      0x00265A09,  //  0116  ADD	R9	K45	R9
-      0x542A0003,  //  0117  LDINT	R10	4
-      0x7C1C0600,  //  0118  CALL	R7	3
-      0xB81E0200,  //  0119  GETNGBL	R7	K1
-      0x8C1C0F02,  //  011A  GETMET	R7	R7	K2
-      0x60240008,  //  011B  GETGBL	R9	G8
-      0x8C280D2F,  //  011C  GETMET	R10	R6	K47
-      0x7C280200,  //  011D  CALL	R10	1
-      0x7C240200,  //  011E  CALL	R9	1
-      0x00265C09,  //  011F  ADD	R9	K46	R9
-      0x58280030,  //  0120  LDCONST	R10	K48
-      0x7C1C0600,  //  0121  CALL	R7	3
-      0x8C1C0131,  //  0122  GETMET	R7	R0	K49
-      0x5C240200,  //  0123  MOVE	R9	R1
-      0x5C280C00,  //  0124  MOVE	R10	R6
-      0x7C1C0600,  //  0125  CALL	R7	3
-      0x70020001,  //  0126  JMP		#0129
-      0x501C0000,  //  0127  LDBOOL	R7	0	0
-      0x80040E00,  //  0128  RET	1	R7
-      0x501C0200,  //  0129  LDBOOL	R7	1	0
-      0x80040E00,  //  012A  RET	1	R7
-      0x80000000,  //  012B  RET	0
+      0x7C100200,  //  0003  CALL	R4	1
+      0xB8160200,  //  0004  GETNGBL	R5	K1
+      0x8C140B03,  //  0005  GETMET	R5	R5	K3
+      0x7C140200,  //  0006  CALL	R5	1
+      0x8C140B04,  //  0007  GETMET	R5	R5	K4
+      0x5C1C0400,  //  0008  MOVE	R7	R2
+      0x7C140400,  //  0009  CALL	R5	2
+      0x88180B05,  //  000A  GETMBR	R6	R5	K5
+      0x4C1C0000,  //  000B  LDNIL	R7
+      0x20180C07,  //  000C  NE	R6	R6	R7
+      0x781A00FE,  //  000D  JMPF	R6	#010D
+      0xB81A0200,  //  000E  GETNGBL	R6	K1
+      0x8C180D06,  //  000F  GETMET	R6	R6	K6
+      0x7C180200,  //  0010  CALL	R6	1
+      0x501C0000,  //  0011  LDBOOL	R7	0	0
+      0x901A0E07,  //  0012  SETMBR	R6	K7	R7
+      0x601C0012,  //  0013  GETGBL	R7	G18
+      0x7C1C0000,  //  0014  CALL	R7	0
+      0x901A1007,  //  0015  SETMBR	R6	K8	R7
+      0x601C0010,  //  0016  GETGBL	R7	G16
+      0x88200B05,  //  0017  GETMBR	R8	R5	K5
+      0x7C1C0200,  //  0018  CALL	R7	1
+      0xA80200E1,  //  0019  EXBLK	0	#00FC
+      0x5C200E00,  //  001A  MOVE	R8	R7
+      0x7C200000,  //  001B  CALL	R8	0
+      0x8824110A,  //  001C  GETMBR	R9	R8	K10
+      0x88241309,  //  001D  GETMBR	R9	R9	K9
+      0x90121209,  //  001E  SETMBR	R4	K9	R9
+      0x8824110A,  //  001F  GETMBR	R9	R8	K10
+      0x8824130B,  //  0020  GETMBR	R9	R9	K11
+      0x90121609,  //  0021  SETMBR	R4	K11	R9
+      0x8824110A,  //  0022  GETMBR	R9	R8	K10
+      0x8824130C,  //  0023  GETMBR	R9	R9	K12
+      0x90121809,  //  0024  SETMBR	R4	K12	R9
+      0xB8260200,  //  0025  GETNGBL	R9	K1
+      0x8824130E,  //  0026  GETMBR	R9	R9	K14
+      0x90121A09,  //  0027  SETMBR	R4	K13	R9
+      0xB8260200,  //  0028  GETNGBL	R9	K1
+      0x8C24130F,  //  0029  GETMET	R9	R9	K15
+      0x882C090B,  //  002A  GETMBR	R11	R4	K11
+      0x8830090C,  //  002B  GETMBR	R12	R4	K12
+      0x7C240600,  //  002C  CALL	R9	3
+      0x88280110,  //  002D  GETMBR	R10	R0	K16
+      0x8C281511,  //  002E  GETMET	R10	R10	K17
+      0x88300312,  //  002F  GETMBR	R12	R1	K18
+      0x88341113,  //  0030  GETMBR	R13	R8	K19
+      0x5C380800,  //  0031  MOVE	R14	R4
+      0x7C280800,  //  0032  CALL	R10	4
+      0x882C0914,  //  0033  GETMBR	R11	R4	K20
+      0x4C300000,  //  0034  LDNIL	R12
+      0x202C160C,  //  0035  NE	R11	R11	R12
+      0x782E0005,  //  0036  JMPF	R11	#003D
+      0x602C0008,  //  0037  GETGBL	R11	G8
+      0x88300914,  //  0038  GETMBR	R12	R4	K20
+      0x7C2C0200,  //  0039  CALL	R11	1
+      0x002E2A0B,  //  003A  ADD	R11	K21	R11
+      0x002C1716,  //  003B  ADD	R11	R11	K22
+      0x70020000,  //  003C  JMP		#003E
+      0x582C0017,  //  003D  LDCONST	R11	K23
+      0xB8323000,  //  003E  GETNGBL	R12	K24
+      0x8C301914,  //  003F  GETMET	R12	R12	K20
+      0x8C380719,  //  0040  GETMET	R14	R3	K25
+      0x5840001A,  //  0041  LDCONST	R16	K26
+      0x88440312,  //  0042  GETMBR	R17	R1	K18
+      0x8844231B,  //  0043  GETMBR	R17	R17	K27
+      0x60480008,  //  0044  GETGBL	R18	G8
+      0x5C4C0800,  //  0045  MOVE	R19	R4
+      0x7C480200,  //  0046  CALL	R18	1
+      0x78260001,  //  0047  JMPF	R9	#004A
+      0x5C4C1200,  //  0048  MOVE	R19	R9
+      0x70020000,  //  0049  JMP		#004B
+      0x584C0017,  //  004A  LDCONST	R19	K23
+      0x5C501600,  //  004B  MOVE	R20	R11
+      0x7C380C00,  //  004C  CALL	R14	6
+      0x583C001C,  //  004D  LDCONST	R15	K28
+      0x7C300600,  //  004E  CALL	R12	3
+      0x4C300000,  //  004F  LDNIL	R12
+      0x9012280C,  //  0050  SETMBR	R4	K20	R12
+      0xB8320200,  //  0051  GETNGBL	R12	K1
+      0x8C30191D,  //  0052  GETMET	R12	R12	K29
+      0x7C300200,  //  0053  CALL	R12	1
+      0x50340200,  //  0054  LDBOOL	R13	1	0
+      0x1C34140D,  //  0055  EQ	R13	R10	R13
+      0x74360004,  //  0056  JMPT	R13	#005C
+      0x8834090D,  //  0057  GETMBR	R13	R4	K13
+      0xB83A0200,  //  0058  GETNGBL	R14	K1
+      0x88381D1E,  //  0059  GETMBR	R14	R14	K30
+      0x1C341A0E,  //  005A  EQ	R13	R13	R14
+      0x7836002D,  //  005B  JMPF	R13	#008A
+      0xB8360200,  //  005C  GETNGBL	R13	K1
+      0x8C341B1F,  //  005D  GETMET	R13	R13	K31
+      0x7C340200,  //  005E  CALL	R13	1
+      0x90321A0D,  //  005F  SETMBR	R12	K13	R13
+      0x8834190D,  //  0060  GETMBR	R13	R12	K13
+      0xB83A0200,  //  0061  GETNGBL	R14	K1
+      0x8C381D20,  //  0062  GETMET	R14	R14	K32
+      0x7C380200,  //  0063  CALL	R14	1
+      0x9036140E,  //  0064  SETMBR	R13	K10	R14
+      0x8834190D,  //  0065  GETMBR	R13	R12	K13
+      0x88341B0A,  //  0066  GETMBR	R13	R13	K10
+      0x88380909,  //  0067  GETMBR	R14	R4	K9
+      0x9036120E,  //  0068  SETMBR	R13	K9	R14
+      0x8834190D,  //  0069  GETMBR	R13	R12	K13
+      0x88341B0A,  //  006A  GETMBR	R13	R13	K10
+      0x8838090B,  //  006B  GETMBR	R14	R4	K11
+      0x9036160E,  //  006C  SETMBR	R13	K11	R14
+      0x8834190D,  //  006D  GETMBR	R13	R12	K13
+      0x88341B0A,  //  006E  GETMBR	R13	R13	K10
+      0x8838090C,  //  006F  GETMBR	R14	R4	K12
+      0x9036180E,  //  0070  SETMBR	R13	K12	R14
+      0x8834190D,  //  0071  GETMBR	R13	R12	K13
+      0xB83A0200,  //  0072  GETNGBL	R14	K1
+      0x8C381D21,  //  0073  GETMET	R14	R14	K33
+      0x7C380200,  //  0074  CALL	R14	1
+      0x90361A0E,  //  0075  SETMBR	R13	K13	R14
+      0x8834190D,  //  0076  GETMBR	R13	R12	K13
+      0x88341B0D,  //  0077  GETMBR	R13	R13	K13
+      0xB83A0200,  //  0078  GETNGBL	R14	K1
+      0x88381D1E,  //  0079  GETMBR	R14	R14	K30
+      0x90361A0E,  //  007A  SETMBR	R13	K13	R14
+      0x88340D08,  //  007B  GETMBR	R13	R6	K8
+      0x8C341B22,  //  007C  GETMET	R13	R13	K34
+      0x5C3C1800,  //  007D  MOVE	R15	R12
+      0x7C340400,  //  007E  CALL	R13	2
+      0xB8363000,  //  007F  GETNGBL	R13	K24
+      0x8C341B14,  //  0080  GETMET	R13	R13	K20
+      0x8C3C0719,  //  0081  GETMET	R15	R3	K25
+      0x58440023,  //  0082  LDCONST	R17	K35
+      0x88480312,  //  0083  GETMBR	R18	R1	K18
+      0x8848251B,  //  0084  GETMBR	R18	R18	K27
+      0x884C0324,  //  0085  GETMBR	R19	R1	K36
+      0x7C3C0800,  //  0086  CALL	R15	4
+      0x5840001C,  //  0087  LDCONST	R16	K28
+      0x7C340600,  //  0088  CALL	R13	3
+      0x70020070,  //  0089  JMP		#00FB
+      0x4C340000,  //  008A  LDNIL	R13
+      0x2034140D,  //  008B  NE	R13	R10	R13
+      0x78360031,  //  008C  JMPF	R13	#00BF
+      0xB8360200,  //  008D  GETNGBL	R13	K1
+      0x8C341B25,  //  008E  GETMET	R13	R13	K37
+      0x7C340200,  //  008F  CALL	R13	1
+      0x9032180D,  //  0090  SETMBR	R12	K12	R13
+      0x8834190C,  //  0091  GETMBR	R13	R12	K12
+      0xB83A0200,  //  0092  GETNGBL	R14	K1
+      0x8C381D20,  //  0093  GETMET	R14	R14	K32
+      0x7C380200,  //  0094  CALL	R14	1
+      0x9036140E,  //  0095  SETMBR	R13	K10	R14
+      0x8834190C,  //  0096  GETMBR	R13	R12	K12
+      0x88341B0A,  //  0097  GETMBR	R13	R13	K10
+      0x88380909,  //  0098  GETMBR	R14	R4	K9
+      0x9036120E,  //  0099  SETMBR	R13	K9	R14
+      0x8834190C,  //  009A  GETMBR	R13	R12	K12
+      0x88341B0A,  //  009B  GETMBR	R13	R13	K10
+      0x8838090B,  //  009C  GETMBR	R14	R4	K11
+      0x9036160E,  //  009D  SETMBR	R13	K11	R14
+      0x8834190C,  //  009E  GETMBR	R13	R12	K12
+      0x88341B0A,  //  009F  GETMBR	R13	R13	K10
+      0x8838090C,  //  00A0  GETMBR	R14	R4	K12
+      0x9036180E,  //  00A1  SETMBR	R13	K12	R14
+      0x8834190C,  //  00A2  GETMBR	R13	R12	K12
+      0x9036260A,  //  00A3  SETMBR	R13	K19	R10
+      0x88340D08,  //  00A4  GETMBR	R13	R6	K8
+      0x8C341B22,  //  00A5  GETMET	R13	R13	K34
+      0x5C3C1800,  //  00A6  MOVE	R15	R12
+      0x7C340400,  //  00A7  CALL	R13	2
+      0xB8360200,  //  00A8  GETNGBL	R13	K1
+      0x8C341B0F,  //  00A9  GETMET	R13	R13	K15
+      0x883C090B,  //  00AA  GETMBR	R15	R4	K11
+      0x8840090C,  //  00AB  GETMBR	R16	R4	K12
+      0x7C340600,  //  00AC  CALL	R13	3
+      0x5C241A00,  //  00AD  MOVE	R9	R13
+      0xB8363000,  //  00AE  GETNGBL	R13	K24
+      0x8C341B14,  //  00AF  GETMET	R13	R13	K20
+      0x8C3C0719,  //  00B0  GETMET	R15	R3	K25
+      0x58440026,  //  00B1  LDCONST	R17	K38
+      0x88480312,  //  00B2  GETMBR	R18	R1	K18
+      0x8848251B,  //  00B3  GETMBR	R18	R18	K27
+      0x604C0008,  //  00B4  GETGBL	R19	G8
+      0x5C500800,  //  00B5  MOVE	R20	R4
+      0x7C4C0200,  //  00B6  CALL	R19	1
+      0x78260001,  //  00B7  JMPF	R9	#00BA
+      0x5C501200,  //  00B8  MOVE	R20	R9
+      0x70020000,  //  00B9  JMP		#00BB
+      0x58500017,  //  00BA  LDCONST	R20	K23
+      0x7C3C0A00,  //  00BB  CALL	R15	5
+      0x5840001C,  //  00BC  LDCONST	R16	K28
+      0x7C340600,  //  00BD  CALL	R13	3
+      0x7002003B,  //  00BE  JMP		#00FB
+      0x8834090D,  //  00BF  GETMBR	R13	R4	K13
+      0x4C380000,  //  00C0  LDNIL	R14
+      0x20341A0E,  //  00C1  NE	R13	R13	R14
+      0x7836002D,  //  00C2  JMPF	R13	#00F1
+      0xB8360200,  //  00C3  GETNGBL	R13	K1
+      0x8C341B1F,  //  00C4  GETMET	R13	R13	K31
+      0x7C340200,  //  00C5  CALL	R13	1
+      0x90321A0D,  //  00C6  SETMBR	R12	K13	R13
+      0x8834190D,  //  00C7  GETMBR	R13	R12	K13
+      0xB83A0200,  //  00C8  GETNGBL	R14	K1
+      0x8C381D20,  //  00C9  GETMET	R14	R14	K32
+      0x7C380200,  //  00CA  CALL	R14	1
+      0x9036140E,  //  00CB  SETMBR	R13	K10	R14
+      0x8834190D,  //  00CC  GETMBR	R13	R12	K13
+      0x88341B0A,  //  00CD  GETMBR	R13	R13	K10
+      0x88380909,  //  00CE  GETMBR	R14	R4	K9
+      0x9036120E,  //  00CF  SETMBR	R13	K9	R14
+      0x8834190D,  //  00D0  GETMBR	R13	R12	K13
+      0x88341B0A,  //  00D1  GETMBR	R13	R13	K10
+      0x8838090B,  //  00D2  GETMBR	R14	R4	K11
+      0x9036160E,  //  00D3  SETMBR	R13	K11	R14
+      0x8834190D,  //  00D4  GETMBR	R13	R12	K13
+      0x88341B0A,  //  00D5  GETMBR	R13	R13	K10
+      0x8838090C,  //  00D6  GETMBR	R14	R4	K12
+      0x9036180E,  //  00D7  SETMBR	R13	K12	R14
+      0x8834190D,  //  00D8  GETMBR	R13	R12	K13
+      0xB83A0200,  //  00D9  GETNGBL	R14	K1
+      0x8C381D21,  //  00DA  GETMET	R14	R14	K33
+      0x7C380200,  //  00DB  CALL	R14	1
+      0x90361A0E,  //  00DC  SETMBR	R13	K13	R14
+      0x8834190D,  //  00DD  GETMBR	R13	R12	K13
+      0x88341B0D,  //  00DE  GETMBR	R13	R13	K13
+      0x8838090D,  //  00DF  GETMBR	R14	R4	K13
+      0x90361A0E,  //  00E0  SETMBR	R13	K13	R14
+      0x88340D08,  //  00E1  GETMBR	R13	R6	K8
+      0x8C341B22,  //  00E2  GETMET	R13	R13	K34
+      0x5C3C1800,  //  00E3  MOVE	R15	R12
+      0x7C340400,  //  00E4  CALL	R13	2
+      0xB8363000,  //  00E5  GETNGBL	R13	K24
+      0x8C341B14,  //  00E6  GETMET	R13	R13	K20
+      0x8C3C0719,  //  00E7  GETMET	R15	R3	K25
+      0x58440027,  //  00E8  LDCONST	R17	K39
+      0x88480312,  //  00E9  GETMBR	R18	R1	K18
+      0x8848251B,  //  00EA  GETMBR	R18	R18	K27
+      0x884C090D,  //  00EB  GETMBR	R19	R4	K13
+      0x88500324,  //  00EC  GETMBR	R20	R1	K36
+      0x7C3C0A00,  //  00ED  CALL	R15	5
+      0x5840001C,  //  00EE  LDCONST	R16	K28
+      0x7C340600,  //  00EF  CALL	R13	3
+      0x70020009,  //  00F0  JMP		#00FB
+      0xB8363000,  //  00F1  GETNGBL	R13	K24
+      0x8C341B14,  //  00F2  GETMET	R13	R13	K20
+      0x8C3C0719,  //  00F3  GETMET	R15	R3	K25
+      0x58440028,  //  00F4  LDCONST	R17	K40
+      0x88480312,  //  00F5  GETMBR	R18	R1	K18
+      0x8848251B,  //  00F6  GETMBR	R18	R18	K27
+      0x884C0324,  //  00F7  GETMBR	R19	R1	K36
+      0x7C3C0800,  //  00F8  CALL	R15	4
+      0x5840001C,  //  00F9  LDCONST	R16	K28
+      0x7C340600,  //  00FA  CALL	R13	3
+      0x7001FF1D,  //  00FB  JMP		#001A
+      0x581C0029,  //  00FC  LDCONST	R7	K41
+      0xAC1C0200,  //  00FD  CATCH	R7	1	0
+      0xB0080000,  //  00FE  RAISE	2	R0	R0
+      0x601C000C,  //  00FF  GETGBL	R7	G12
+      0x88200D08,  //  0100  GETMBR	R8	R6	K8
+      0x7C1C0200,  //  0101  CALL	R7	1
+      0x241C0F2A,  //  0102  GT	R7	R7	K42
+      0x781E0004,  //  0103  JMPF	R7	#0109
+      0x8C1C012B,  //  0104  GETMET	R7	R0	K43
+      0x5C240200,  //  0105  MOVE	R9	R1
+      0x5C280C00,  //  0106  MOVE	R10	R6
+      0x7C1C0600,  //  0107  CALL	R7	3
+      0x70020001,  //  0108  JMP		#010B
+      0x501C0000,  //  0109  LDBOOL	R7	0	0
+      0x80040E00,  //  010A  RET	1	R7
+      0x501C0200,  //  010B  LDBOOL	R7	1	0
+      0x80040E00,  //  010C  RET	1	R7
+      0x80000000,  //  010D  RET	0
     })
   )
 );
@@ -449,7 +413,7 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[33]) {     /* constants */
+    ( &(const bvalue[31]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(SubscribeRequestMessage),
@@ -458,35 +422,33 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
     /* K5   */  be_nested_str_weak(subs_shop),
     /* K6   */  be_nested_str_weak(remove_by_session),
     /* K7   */  be_nested_str_weak(session),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20received_X20SubscribeRequestMessage_X3D),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(new_subscription),
-    /* K13  */  be_nested_str_weak(Path),
-    /* K14  */  be_nested_str_weak(attributes_requests),
-    /* K15  */  be_nested_str_weak(endpoint),
-    /* K16  */  be_nested_str_weak(cluster),
-    /* K17  */  be_nested_str_weak(attribute),
-    /* K18  */  be_nested_str_weak(push),
-    /* K19  */  be_nested_str_weak(stop_iteration),
-    /* K20  */  be_nested_str_weak(format),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X2C_X20keep_X3D_X25i_X29_X20sub_X3D_X25i),
-    /* K22  */  be_nested_str_weak(local_session_id),
-    /* K23  */  be_nested_str_weak(concat),
-    /* K24  */  be_nested_str_weak(_X20),
-    /* K25  */  be_nested_str_weak(min_interval),
-    /* K26  */  be_nested_str_weak(max_interval),
-    /* K27  */  be_const_int(1),
-    /* K28  */  be_const_int(0),
-    /* K29  */  be_nested_str_weak(subscription_id),
-    /* K30  */  be_const_int(2),
-    /* K31  */  be_nested_str_weak(_inner_process_read_request),
-    /* K32  */  be_nested_str_weak(send_subscribe_response),
+    /* K8   */  be_nested_str_weak(new_subscription),
+    /* K9   */  be_nested_str_weak(Path),
+    /* K10  */  be_nested_str_weak(attributes_requests),
+    /* K11  */  be_nested_str_weak(endpoint),
+    /* K12  */  be_nested_str_weak(cluster),
+    /* K13  */  be_nested_str_weak(attribute),
+    /* K14  */  be_nested_str_weak(push),
+    /* K15  */  be_nested_str_weak(stop_iteration),
+    /* K16  */  be_nested_str_weak(tasmota),
+    /* K17  */  be_nested_str_weak(log),
+    /* K18  */  be_nested_str_weak(format),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X2C_X20keep_X3D_X25i_X29_X20sub_X3D_X25i),
+    /* K20  */  be_nested_str_weak(local_session_id),
+    /* K21  */  be_nested_str_weak(concat),
+    /* K22  */  be_nested_str_weak(_X20),
+    /* K23  */  be_nested_str_weak(min_interval),
+    /* K24  */  be_nested_str_weak(max_interval),
+    /* K25  */  be_const_int(1),
+    /* K26  */  be_const_int(0),
+    /* K27  */  be_nested_str_weak(subscription_id),
+    /* K28  */  be_const_int(2),
+    /* K29  */  be_nested_str_weak(_inner_process_read_request),
+    /* K30  */  be_nested_str_weak(send_subscribe_response),
     }),
     be_str_weak(subscribe_request),
     &be_const_str_solidified,
-    ( &(const binstruction[86]) {  /* code */
+    ( &(const binstruction[78]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0xB8120200,  //  0001  GETNGBL	R4	K1
       0x8C100902,  //  0002  GETMET	R4	R4	K2
@@ -500,79 +462,71 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
       0x8C140B06,  //  000A  GETMET	R5	R5	K6
       0x881C0307,  //  000B  GETMBR	R7	R1	K7
       0x7C140400,  //  000C  CALL	R5	2
-      0xB8161000,  //  000D  GETNGBL	R5	K8
-      0x8C140B09,  //  000E  GETMET	R5	R5	K9
-      0x601C0008,  //  000F  GETGBL	R7	G8
+      0x88140105,  //  000D  GETMBR	R5	R0	K5
+      0x8C140B08,  //  000E  GETMET	R5	R5	K8
+      0x881C0307,  //  000F  GETMBR	R7	R1	K7
       0x5C200800,  //  0010  MOVE	R8	R4
-      0x7C1C0200,  //  0011  CALL	R7	1
-      0x001E1407,  //  0012  ADD	R7	K10	R7
-      0x5820000B,  //  0013  LDCONST	R8	K11
-      0x7C140600,  //  0014  CALL	R5	3
-      0x88140105,  //  0015  GETMBR	R5	R0	K5
-      0x8C140B0C,  //  0016  GETMET	R5	R5	K12
-      0x881C0307,  //  0017  GETMBR	R7	R1	K7
-      0x5C200800,  //  0018  MOVE	R8	R4
-      0x7C140600,  //  0019  CALL	R5	3
-      0x60180012,  //  001A  GETGBL	R6	G18
-      0x7C180000,  //  001B  CALL	R6	0
-      0xB81E0200,  //  001C  GETNGBL	R7	K1
-      0x8C1C0F0D,  //  001D  GETMET	R7	R7	K13
-      0x7C1C0200,  //  001E  CALL	R7	1
-      0x60200010,  //  001F  GETGBL	R8	G16
-      0x8824090E,  //  0020  GETMBR	R9	R4	K14
-      0x7C200200,  //  0021  CALL	R8	1
-      0xA802000D,  //  0022  EXBLK	0	#0031
-      0x5C241000,  //  0023  MOVE	R9	R8
-      0x7C240000,  //  0024  CALL	R9	0
-      0x8828130F,  //  0025  GETMBR	R10	R9	K15
-      0x901E1E0A,  //  0026  SETMBR	R7	K15	R10
-      0x88281310,  //  0027  GETMBR	R10	R9	K16
-      0x901E200A,  //  0028  SETMBR	R7	K16	R10
-      0x88281311,  //  0029  GETMBR	R10	R9	K17
-      0x901E220A,  //  002A  SETMBR	R7	K17	R10
-      0x8C280D12,  //  002B  GETMET	R10	R6	K18
-      0x60300008,  //  002C  GETGBL	R12	G8
-      0x5C340E00,  //  002D  MOVE	R13	R7
-      0x7C300200,  //  002E  CALL	R12	1
-      0x7C280400,  //  002F  CALL	R10	2
-      0x7001FFF1,  //  0030  JMP		#0023
-      0x58200013,  //  0031  LDCONST	R8	K19
-      0xAC200200,  //  0032  CATCH	R8	1	0
-      0xB0080000,  //  0033  RAISE	2	R0	R0
-      0xB8221000,  //  0034  GETNGBL	R8	K8
-      0x8C201109,  //  0035  GETMET	R8	R8	K9
-      0x8C280714,  //  0036  GETMET	R10	R3	K20
-      0x58300015,  //  0037  LDCONST	R12	K21
-      0x88340307,  //  0038  GETMBR	R13	R1	K7
-      0x88341B16,  //  0039  GETMBR	R13	R13	K22
-      0x8C380D17,  //  003A  GETMET	R14	R6	K23
-      0x58400018,  //  003B  LDCONST	R16	K24
-      0x7C380400,  //  003C  CALL	R14	2
-      0x883C0B19,  //  003D  GETMBR	R15	R5	K25
-      0x88400B1A,  //  003E  GETMBR	R16	R5	K26
-      0x88440904,  //  003F  GETMBR	R17	R4	K4
-      0x78460001,  //  0040  JMPF	R17	#0043
-      0x5844001B,  //  0041  LDCONST	R17	K27
-      0x70020000,  //  0042  JMP		#0044
-      0x5844001C,  //  0043  LDCONST	R17	K28
-      0x88480B1D,  //  0044  GETMBR	R18	R5	K29
-      0x7C281000,  //  0045  CALL	R10	8
-      0x582C001E,  //  0046  LDCONST	R11	K30
-      0x7C200600,  //  0047  CALL	R8	3
-      0x8C20011F,  //  0048  GETMET	R8	R0	K31
-      0x88280307,  //  0049  GETMBR	R10	R1	K7
-      0x5C2C0800,  //  004A  MOVE	R11	R4
-      0x50300200,  //  004B  LDBOOL	R12	1	0
-      0x7C200800,  //  004C  CALL	R8	4
-      0x88240B1D,  //  004D  GETMBR	R9	R5	K29
-      0x90223A09,  //  004E  SETMBR	R8	K29	R9
-      0x8C240120,  //  004F  GETMET	R9	R0	K32
-      0x5C2C0200,  //  0050  MOVE	R11	R1
-      0x5C301000,  //  0051  MOVE	R12	R8
-      0x5C340A00,  //  0052  MOVE	R13	R5
-      0x7C240800,  //  0053  CALL	R9	4
-      0x50240200,  //  0054  LDBOOL	R9	1	0
-      0x80041200,  //  0055  RET	1	R9
+      0x7C140600,  //  0011  CALL	R5	3
+      0x60180012,  //  0012  GETGBL	R6	G18
+      0x7C180000,  //  0013  CALL	R6	0
+      0xB81E0200,  //  0014  GETNGBL	R7	K1
+      0x8C1C0F09,  //  0015  GETMET	R7	R7	K9
+      0x7C1C0200,  //  0016  CALL	R7	1
+      0x60200010,  //  0017  GETGBL	R8	G16
+      0x8824090A,  //  0018  GETMBR	R9	R4	K10
+      0x7C200200,  //  0019  CALL	R8	1
+      0xA802000D,  //  001A  EXBLK	0	#0029
+      0x5C241000,  //  001B  MOVE	R9	R8
+      0x7C240000,  //  001C  CALL	R9	0
+      0x8828130B,  //  001D  GETMBR	R10	R9	K11
+      0x901E160A,  //  001E  SETMBR	R7	K11	R10
+      0x8828130C,  //  001F  GETMBR	R10	R9	K12
+      0x901E180A,  //  0020  SETMBR	R7	K12	R10
+      0x8828130D,  //  0021  GETMBR	R10	R9	K13
+      0x901E1A0A,  //  0022  SETMBR	R7	K13	R10
+      0x8C280D0E,  //  0023  GETMET	R10	R6	K14
+      0x60300008,  //  0024  GETGBL	R12	G8
+      0x5C340E00,  //  0025  MOVE	R13	R7
+      0x7C300200,  //  0026  CALL	R12	1
+      0x7C280400,  //  0027  CALL	R10	2
+      0x7001FFF1,  //  0028  JMP		#001B
+      0x5820000F,  //  0029  LDCONST	R8	K15
+      0xAC200200,  //  002A  CATCH	R8	1	0
+      0xB0080000,  //  002B  RAISE	2	R0	R0
+      0xB8222000,  //  002C  GETNGBL	R8	K16
+      0x8C201111,  //  002D  GETMET	R8	R8	K17
+      0x8C280712,  //  002E  GETMET	R10	R3	K18
+      0x58300013,  //  002F  LDCONST	R12	K19
+      0x88340307,  //  0030  GETMBR	R13	R1	K7
+      0x88341B14,  //  0031  GETMBR	R13	R13	K20
+      0x8C380D15,  //  0032  GETMET	R14	R6	K21
+      0x58400016,  //  0033  LDCONST	R16	K22
+      0x7C380400,  //  0034  CALL	R14	2
+      0x883C0B17,  //  0035  GETMBR	R15	R5	K23
+      0x88400B18,  //  0036  GETMBR	R16	R5	K24
+      0x88440904,  //  0037  GETMBR	R17	R4	K4
+      0x78460001,  //  0038  JMPF	R17	#003B
+      0x58440019,  //  0039  LDCONST	R17	K25
+      0x70020000,  //  003A  JMP		#003C
+      0x5844001A,  //  003B  LDCONST	R17	K26
+      0x88480B1B,  //  003C  GETMBR	R18	R5	K27
+      0x7C281000,  //  003D  CALL	R10	8
+      0x582C001C,  //  003E  LDCONST	R11	K28
+      0x7C200600,  //  003F  CALL	R8	3
+      0x8C20011D,  //  0040  GETMET	R8	R0	K29
+      0x88280307,  //  0041  GETMBR	R10	R1	K7
+      0x5C2C0800,  //  0042  MOVE	R11	R4
+      0x50300200,  //  0043  LDBOOL	R12	1	0
+      0x7C200800,  //  0044  CALL	R8	4
+      0x88240B1B,  //  0045  GETMBR	R9	R5	K27
+      0x90223609,  //  0046  SETMBR	R8	K27	R9
+      0x8C24011E,  //  0047  GETMET	R9	R0	K30
+      0x5C2C0200,  //  0048  MOVE	R11	R1
+      0x5C301000,  //  0049  MOVE	R12	R8
+      0x5C340A00,  //  004A  MOVE	R13	R5
+      0x7C240800,  //  004B  CALL	R9	4
+      0x50240200,  //  004C  LDBOOL	R9	1	0
+      0x80041200,  //  004D  RET	1	R9
     })
   )
 );
@@ -761,47 +715,41 @@ be_local_closure(Matter_IM_process_write_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[36]) {     /* constants */
+    ( &(const bvalue[30]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(WriteRequestMessage),
     /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20WriteRequestMessage_X3D),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(suppress_response),
-    /* K9   */  be_nested_str_weak(device),
-    /* K10  */  be_nested_str_weak(get_active_endpoints),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20IM_X3Awrite_request_X20processing_X20start),
-    /* K12  */  be_nested_str_weak(Path),
-    /* K13  */  be_nested_str_weak(write_requests),
-    /* K14  */  be_nested_str_weak(WriteResponseMessage),
-    /* K15  */  be_nested_str_weak(write_responses),
-    /* K16  */  be_nested_str_weak(path),
-    /* K17  */  be_nested_str_weak(data),
-    /* K18  */  be_nested_str_weak(endpoint),
-    /* K19  */  be_nested_str_weak(cluster),
-    /* K20  */  be_nested_str_weak(attribute),
-    /* K21  */  be_nested_str_weak(status),
-    /* K22  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    /* K23  */  be_nested_str_weak(INVALID_ACTION),
-    /* K24  */  be_nested_str_weak(get_attribute_name),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
-    /* K26  */  be_nested_str_weak(_X20_X28),
-    /* K27  */  be_nested_str_weak(_X29),
-    /* K28  */  be_nested_str_weak(),
-    /* K29  */  be_const_int(2),
-    /* K30  */  be_nested_str_weak(process_attribute_expansion),
-    /* K31  */  be_nested_str_weak(stop_iteration),
-    /* K32  */  be_nested_str_weak(MTR_X3A_X20ReportWriteMessage_X3D),
-    /* K33  */  be_nested_str_weak(MTR_X3A_X20ReportWriteMessageTLV_X3D),
-    /* K34  */  be_nested_str_weak(to_TLV),
-    /* K35  */  be_nested_str_weak(send_write_response),
+    /* K4   */  be_nested_str_weak(suppress_response),
+    /* K5   */  be_nested_str_weak(device),
+    /* K6   */  be_nested_str_weak(get_active_endpoints),
+    /* K7   */  be_nested_str_weak(Path),
+    /* K8   */  be_nested_str_weak(write_requests),
+    /* K9   */  be_nested_str_weak(WriteResponseMessage),
+    /* K10  */  be_nested_str_weak(write_responses),
+    /* K11  */  be_nested_str_weak(path),
+    /* K12  */  be_nested_str_weak(data),
+    /* K13  */  be_nested_str_weak(endpoint),
+    /* K14  */  be_nested_str_weak(cluster),
+    /* K15  */  be_nested_str_weak(attribute),
+    /* K16  */  be_nested_str_weak(status),
+    /* K17  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+    /* K18  */  be_nested_str_weak(INVALID_ACTION),
+    /* K19  */  be_nested_str_weak(get_attribute_name),
+    /* K20  */  be_nested_str_weak(tasmota),
+    /* K21  */  be_nested_str_weak(log),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
+    /* K23  */  be_nested_str_weak(_X20_X28),
+    /* K24  */  be_nested_str_weak(_X29),
+    /* K25  */  be_nested_str_weak(),
+    /* K26  */  be_const_int(2),
+    /* K27  */  be_nested_str_weak(process_attribute_expansion),
+    /* K28  */  be_nested_str_weak(stop_iteration),
+    /* K29  */  be_nested_str_weak(send_write_response),
     }),
     be_str_weak(process_write_request),
     &be_const_str_solidified,
-    ( &(const binstruction[134]) {  /* code */
+    ( &(const binstruction[104]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0xB8120200,  //  0001  GETNGBL	R4	K1
       0x8C100902,  //  0002  GETMET	R4	R4	K2
@@ -809,133 +757,103 @@ be_local_closure(Matter_IM_process_write_request,   /* name */
       0x8C100903,  //  0004  GETMET	R4	R4	K3
       0x5C180400,  //  0005  MOVE	R6	R2
       0x7C100400,  //  0006  CALL	R4	2
-      0xB8160800,  //  0007  GETNGBL	R5	K4
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x601C0008,  //  0009  GETGBL	R7	G8
-      0x5C200800,  //  000A  MOVE	R8	R4
-      0x7C1C0200,  //  000B  CALL	R7	1
-      0x001E0C07,  //  000C  ADD	R7	K6	R7
-      0x58200007,  //  000D  LDCONST	R8	K7
-      0x7C140600,  //  000E  CALL	R5	3
-      0x88140908,  //  000F  GETMBR	R5	R4	K8
-      0x88180109,  //  0010  GETMBR	R6	R0	K9
-      0x8C180D0A,  //  0011  GETMET	R6	R6	K10
-      0x7C180200,  //  0012  CALL	R6	1
-      0x841C0000,  //  0013  CLOSURE	R7	P0
-      0xB8220800,  //  0014  GETNGBL	R8	K4
-      0x8C201105,  //  0015  GETMET	R8	R8	K5
-      0x5828000B,  //  0016  LDCONST	R10	K11
-      0x542E0003,  //  0017  LDINT	R11	4
-      0x7C200600,  //  0018  CALL	R8	3
-      0xB8220200,  //  0019  GETNGBL	R8	K1
-      0x8C20110C,  //  001A  GETMET	R8	R8	K12
-      0x7C200200,  //  001B  CALL	R8	1
-      0x8824090D,  //  001C  GETMBR	R9	R4	K13
-      0x4C280000,  //  001D  LDNIL	R10
-      0x2024120A,  //  001E  NE	R9	R9	R10
-      0x78260062,  //  001F  JMPF	R9	#0083
-      0xB8260200,  //  0020  GETNGBL	R9	K1
-      0x8C24130E,  //  0021  GETMET	R9	R9	K14
-      0x7C240200,  //  0022  CALL	R9	1
-      0x60280012,  //  0023  GETGBL	R10	G18
-      0x7C280000,  //  0024  CALL	R10	0
-      0x90261E0A,  //  0025  SETMBR	R9	K15	R10
-      0x60280010,  //  0026  GETGBL	R10	G16
-      0x882C090D,  //  0027  GETMBR	R11	R4	K13
-      0x7C280200,  //  0028  CALL	R10	1
-      0xA802003D,  //  0029  EXBLK	0	#0068
-      0x5C2C1400,  //  002A  MOVE	R11	R10
-      0x7C2C0000,  //  002B  CALL	R11	0
-      0x88301710,  //  002C  GETMBR	R12	R11	K16
-      0x88341711,  //  002D  GETMBR	R13	R11	K17
-      0x88381912,  //  002E  GETMBR	R14	R12	K18
-      0x9022240E,  //  002F  SETMBR	R8	K18	R14
-      0x88381913,  //  0030  GETMBR	R14	R12	K19
-      0x9022260E,  //  0031  SETMBR	R8	K19	R14
-      0x88381914,  //  0032  GETMBR	R14	R12	K20
-      0x9022280E,  //  0033  SETMBR	R8	K20	R14
-      0xB83A0200,  //  0034  GETNGBL	R14	K1
-      0x88381D16,  //  0035  GETMBR	R14	R14	K22
-      0x90222A0E,  //  0036  SETMBR	R8	K21	R14
-      0x88381113,  //  0037  GETMBR	R14	R8	K19
-      0x4C3C0000,  //  0038  LDNIL	R15
-      0x1C381C0F,  //  0039  EQ	R14	R14	R15
-      0x743A0003,  //  003A  JMPT	R14	#003F
-      0x88381114,  //  003B  GETMBR	R14	R8	K20
-      0x4C3C0000,  //  003C  LDNIL	R15
-      0x1C381C0F,  //  003D  EQ	R14	R14	R15
-      0x783A000A,  //  003E  JMPF	R14	#004A
-      0xB83A0200,  //  003F  GETNGBL	R14	K1
-      0x88381D17,  //  0040  GETMBR	R14	R14	K23
-      0x90222A0E,  //  0041  SETMBR	R8	K21	R14
-      0x5C380E00,  //  0042  MOVE	R14	R7
-      0x5C3C1200,  //  0043  MOVE	R15	R9
-      0x4C400000,  //  0044  LDNIL	R16
-      0x5C441000,  //  0045  MOVE	R17	R8
-      0x4C480000,  //  0046  LDNIL	R18
-      0x504C0200,  //  0047  LDBOOL	R19	1	0
-      0x7C380A00,  //  0048  CALL	R14	5
-      0x7001FFDF,  //  0049  JMP		#002A
-      0x88381112,  //  004A  GETMBR	R14	R8	K18
-      0x4C3C0000,  //  004B  LDNIL	R15
-      0x1C381C0F,  //  004C  EQ	R14	R14	R15
-      0x783A0012,  //  004D  JMPF	R14	#0061
-      0xB83A0200,  //  004E  GETNGBL	R14	K1
-      0x8C381D18,  //  004F  GETMET	R14	R14	K24
-      0x88401113,  //  0050  GETMBR	R16	R8	K19
-      0x88441114,  //  0051  GETMBR	R17	R8	K20
-      0x7C380600,  //  0052  CALL	R14	3
-      0xB83E0800,  //  0053  GETNGBL	R15	K4
-      0x8C3C1F05,  //  0054  GETMET	R15	R15	K5
-      0x60440008,  //  0055  GETGBL	R17	G8
-      0x5C481000,  //  0056  MOVE	R18	R8
-      0x7C440200,  //  0057  CALL	R17	1
-      0x00463211,  //  0058  ADD	R17	K25	R17
-      0x783A0002,  //  0059  JMPF	R14	#005D
-      0x004A340E,  //  005A  ADD	R18	K26	R14
-      0x0048251B,  //  005B  ADD	R18	R18	K27
-      0x70020000,  //  005C  JMP		#005E
-      0x5848001C,  //  005D  LDCONST	R18	K28
-      0x00442212,  //  005E  ADD	R17	R17	R18
-      0x5848001D,  //  005F  LDCONST	R18	K29
-      0x7C3C0600,  //  0060  CALL	R15	3
-      0x88380109,  //  0061  GETMBR	R14	R0	K9
-      0x8C381D1E,  //  0062  GETMET	R14	R14	K30
-      0x5C401000,  //  0063  MOVE	R16	R8
-      0x84440001,  //  0064  CLOSURE	R17	P1
-      0x7C380600,  //  0065  CALL	R14	3
-      0xA0280000,  //  0066  CLOSE	R10
-      0x7001FFC1,  //  0067  JMP		#002A
-      0x5828001F,  //  0068  LDCONST	R10	K31
-      0xAC280200,  //  0069  CATCH	R10	1	0
-      0xB0080000,  //  006A  RAISE	2	R0	R0
-      0xB82A0800,  //  006B  GETNGBL	R10	K4
-      0x8C281505,  //  006C  GETMET	R10	R10	K5
-      0x60300008,  //  006D  GETGBL	R12	G8
-      0x5C341200,  //  006E  MOVE	R13	R9
-      0x7C300200,  //  006F  CALL	R12	1
-      0x0032400C,  //  0070  ADD	R12	K32	R12
-      0x54360003,  //  0071  LDINT	R13	4
-      0x7C280600,  //  0072  CALL	R10	3
-      0xB82A0800,  //  0073  GETNGBL	R10	K4
-      0x8C281505,  //  0074  GETMET	R10	R10	K5
-      0x60300008,  //  0075  GETGBL	R12	G8
-      0x8C341322,  //  0076  GETMET	R13	R9	K34
-      0x7C340200,  //  0077  CALL	R13	1
-      0x7C300200,  //  0078  CALL	R12	1
-      0x0032420C,  //  0079  ADD	R12	K33	R12
-      0x58340007,  //  007A  LDCONST	R13	K7
-      0x7C280600,  //  007B  CALL	R10	3
-      0x5C280A00,  //  007C  MOVE	R10	R5
-      0x742A0003,  //  007D  JMPT	R10	#0082
-      0x8C280123,  //  007E  GETMET	R10	R0	K35
-      0x5C300200,  //  007F  MOVE	R12	R1
-      0x5C341200,  //  0080  MOVE	R13	R9
-      0x7C280600,  //  0081  CALL	R10	3
-      0xA0240000,  //  0082  CLOSE	R9
-      0x50240200,  //  0083  LDBOOL	R9	1	0
-      0xA0000000,  //  0084  CLOSE	R0
-      0x80041200,  //  0085  RET	1	R9
+      0x88140904,  //  0007  GETMBR	R5	R4	K4
+      0x88180105,  //  0008  GETMBR	R6	R0	K5
+      0x8C180D06,  //  0009  GETMET	R6	R6	K6
+      0x7C180200,  //  000A  CALL	R6	1
+      0x841C0000,  //  000B  CLOSURE	R7	P0
+      0xB8220200,  //  000C  GETNGBL	R8	K1
+      0x8C201107,  //  000D  GETMET	R8	R8	K7
+      0x7C200200,  //  000E  CALL	R8	1
+      0x88240908,  //  000F  GETMBR	R9	R4	K8
+      0x4C280000,  //  0010  LDNIL	R10
+      0x2024120A,  //  0011  NE	R9	R9	R10
+      0x78260051,  //  0012  JMPF	R9	#0065
+      0xB8260200,  //  0013  GETNGBL	R9	K1
+      0x8C241309,  //  0014  GETMET	R9	R9	K9
+      0x7C240200,  //  0015  CALL	R9	1
+      0x60280012,  //  0016  GETGBL	R10	G18
+      0x7C280000,  //  0017  CALL	R10	0
+      0x9026140A,  //  0018  SETMBR	R9	K10	R10
+      0x60280010,  //  0019  GETGBL	R10	G16
+      0x882C0908,  //  001A  GETMBR	R11	R4	K8
+      0x7C280200,  //  001B  CALL	R10	1
+      0xA802003D,  //  001C  EXBLK	0	#005B
+      0x5C2C1400,  //  001D  MOVE	R11	R10
+      0x7C2C0000,  //  001E  CALL	R11	0
+      0x8830170B,  //  001F  GETMBR	R12	R11	K11
+      0x8834170C,  //  0020  GETMBR	R13	R11	K12
+      0x8838190D,  //  0021  GETMBR	R14	R12	K13
+      0x90221A0E,  //  0022  SETMBR	R8	K13	R14
+      0x8838190E,  //  0023  GETMBR	R14	R12	K14
+      0x90221C0E,  //  0024  SETMBR	R8	K14	R14
+      0x8838190F,  //  0025  GETMBR	R14	R12	K15
+      0x90221E0E,  //  0026  SETMBR	R8	K15	R14
+      0xB83A0200,  //  0027  GETNGBL	R14	K1
+      0x88381D11,  //  0028  GETMBR	R14	R14	K17
+      0x9022200E,  //  0029  SETMBR	R8	K16	R14
+      0x8838110E,  //  002A  GETMBR	R14	R8	K14
+      0x4C3C0000,  //  002B  LDNIL	R15
+      0x1C381C0F,  //  002C  EQ	R14	R14	R15
+      0x743A0003,  //  002D  JMPT	R14	#0032
+      0x8838110F,  //  002E  GETMBR	R14	R8	K15
+      0x4C3C0000,  //  002F  LDNIL	R15
+      0x1C381C0F,  //  0030  EQ	R14	R14	R15
+      0x783A000A,  //  0031  JMPF	R14	#003D
+      0xB83A0200,  //  0032  GETNGBL	R14	K1
+      0x88381D12,  //  0033  GETMBR	R14	R14	K18
+      0x9022200E,  //  0034  SETMBR	R8	K16	R14
+      0x5C380E00,  //  0035  MOVE	R14	R7
+      0x5C3C1200,  //  0036  MOVE	R15	R9
+      0x4C400000,  //  0037  LDNIL	R16
+      0x5C441000,  //  0038  MOVE	R17	R8
+      0x4C480000,  //  0039  LDNIL	R18
+      0x504C0200,  //  003A  LDBOOL	R19	1	0
+      0x7C380A00,  //  003B  CALL	R14	5
+      0x7001FFDF,  //  003C  JMP		#001D
+      0x8838110D,  //  003D  GETMBR	R14	R8	K13
+      0x4C3C0000,  //  003E  LDNIL	R15
+      0x1C381C0F,  //  003F  EQ	R14	R14	R15
+      0x783A0012,  //  0040  JMPF	R14	#0054
+      0xB83A0200,  //  0041  GETNGBL	R14	K1
+      0x8C381D13,  //  0042  GETMET	R14	R14	K19
+      0x8840110E,  //  0043  GETMBR	R16	R8	K14
+      0x8844110F,  //  0044  GETMBR	R17	R8	K15
+      0x7C380600,  //  0045  CALL	R14	3
+      0xB83E2800,  //  0046  GETNGBL	R15	K20
+      0x8C3C1F15,  //  0047  GETMET	R15	R15	K21
+      0x60440008,  //  0048  GETGBL	R17	G8
+      0x5C481000,  //  0049  MOVE	R18	R8
+      0x7C440200,  //  004A  CALL	R17	1
+      0x00462C11,  //  004B  ADD	R17	K22	R17
+      0x783A0002,  //  004C  JMPF	R14	#0050
+      0x004A2E0E,  //  004D  ADD	R18	K23	R14
+      0x00482518,  //  004E  ADD	R18	R18	K24
+      0x70020000,  //  004F  JMP		#0051
+      0x58480019,  //  0050  LDCONST	R18	K25
+      0x00442212,  //  0051  ADD	R17	R17	R18
+      0x5848001A,  //  0052  LDCONST	R18	K26
+      0x7C3C0600,  //  0053  CALL	R15	3
+      0x88380105,  //  0054  GETMBR	R14	R0	K5
+      0x8C381D1B,  //  0055  GETMET	R14	R14	K27
+      0x5C401000,  //  0056  MOVE	R16	R8
+      0x84440001,  //  0057  CLOSURE	R17	P1
+      0x7C380600,  //  0058  CALL	R14	3
+      0xA0280000,  //  0059  CLOSE	R10
+      0x7001FFC1,  //  005A  JMP		#001D
+      0x5828001C,  //  005B  LDCONST	R10	K28
+      0xAC280200,  //  005C  CATCH	R10	1	0
+      0xB0080000,  //  005D  RAISE	2	R0	R0
+      0x5C280A00,  //  005E  MOVE	R10	R5
+      0x742A0003,  //  005F  JMPT	R10	#0064
+      0x8C28011D,  //  0060  GETMET	R10	R0	K29
+      0x5C300200,  //  0061  MOVE	R12	R1
+      0x5C341200,  //  0062  MOVE	R13	R9
+      0x7C280600,  //  0063  CALL	R10	3
+      0xA0240000,  //  0064  CLOSE	R9
+      0x50240200,  //  0065  LDBOOL	R9	1	0
+      0xA0000000,  //  0066  CLOSE	R0
+      0x80041200,  //  0067  RET	1	R9
     })
   )
 );
@@ -1298,155 +1216,142 @@ be_local_closure(Matter_IM_process_incoming,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20received_X20IM_X20message_X20),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(inspect),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(TLV),
-    /* K7   */  be_nested_str_weak(parse),
-    /* K8   */  be_nested_str_weak(raw),
-    /* K9   */  be_nested_str_weak(app_payload_idx),
-    /* K10  */  be_nested_str_weak(findsubval),
-    /* K11  */  be_nested_str_weak(opcode),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_nested_str_weak(process_status_response),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_nested_str_weak(send_ack_now),
-    /* K16  */  be_nested_str_weak(process_read_request),
-    /* K17  */  be_nested_str_weak(subscribe_request),
-    /* K18  */  be_nested_str_weak(subscribe_response),
-    /* K19  */  be_nested_str_weak(report_data),
-    /* K20  */  be_nested_str_weak(process_write_request),
-    /* K21  */  be_nested_str_weak(process_write_response),
-    /* K22  */  be_nested_str_weak(process_invoke_request),
-    /* K23  */  be_nested_str_weak(process_invoke_response),
-    /* K24  */  be_nested_str_weak(process_timed_request),
+    ( &(const bvalue[21]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(parse),
+    /* K3   */  be_nested_str_weak(raw),
+    /* K4   */  be_nested_str_weak(app_payload_idx),
+    /* K5   */  be_nested_str_weak(findsubval),
+    /* K6   */  be_nested_str_weak(opcode),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(process_status_response),
+    /* K9   */  be_const_int(2),
+    /* K10  */  be_nested_str_weak(send_ack_now),
+    /* K11  */  be_nested_str_weak(process_read_request),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_nested_str_weak(subscribe_request),
+    /* K14  */  be_nested_str_weak(subscribe_response),
+    /* K15  */  be_nested_str_weak(report_data),
+    /* K16  */  be_nested_str_weak(process_write_request),
+    /* K17  */  be_nested_str_weak(process_write_response),
+    /* K18  */  be_nested_str_weak(process_invoke_request),
+    /* K19  */  be_nested_str_weak(process_invoke_response),
+    /* K20  */  be_nested_str_weak(process_timed_request),
     }),
     be_str_weak(process_incoming),
     &be_const_str_solidified,
-    ( &(const binstruction[119]) {  /* code */
+    ( &(const binstruction[110]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0xB8120600,  //  0002  GETNGBL	R4	K3
-      0x8C100904,  //  0003  GETMET	R4	R4	K4
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x7C100400,  //  0005  CALL	R4	2
-      0x00120404,  //  0006  ADD	R4	K2	R4
-      0x58140005,  //  0007  LDCONST	R5	K5
-      0x7C080600,  //  0008  CALL	R2	3
-      0xB80A0600,  //  0009  GETNGBL	R2	K3
-      0x88080506,  //  000A  GETMBR	R2	R2	K6
-      0x8C080507,  //  000B  GETMET	R2	R2	K7
-      0x88100308,  //  000C  GETMBR	R4	R1	K8
-      0x88140309,  //  000D  GETMBR	R5	R1	K9
-      0x7C080600,  //  000E  CALL	R2	3
-      0x8C0C050A,  //  000F  GETMET	R3	R2	K10
-      0x541600FE,  //  0010  LDINT	R5	255
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x8810030B,  //  0012  GETMBR	R4	R1	K11
-      0x1C14090C,  //  0013  EQ	R5	R4	K12
-      0x78160005,  //  0014  JMPF	R5	#001B
-      0x8C14010D,  //  0015  GETMET	R5	R0	K13
-      0x5C1C0200,  //  0016  MOVE	R7	R1
-      0x5C200400,  //  0017  MOVE	R8	R2
-      0x7C140600,  //  0018  CALL	R5	3
-      0x80040A00,  //  0019  RET	1	R5
-      0x70020059,  //  001A  JMP		#0075
-      0x1C14090E,  //  001B  EQ	R5	R4	K14
-      0x78160008,  //  001C  JMPF	R5	#0026
-      0x8C14010F,  //  001D  GETMET	R5	R0	K15
-      0x5C1C0200,  //  001E  MOVE	R7	R1
-      0x7C140400,  //  001F  CALL	R5	2
-      0x8C140110,  //  0020  GETMET	R5	R0	K16
-      0x5C1C0200,  //  0021  MOVE	R7	R1
-      0x5C200400,  //  0022  MOVE	R8	R2
-      0x7C140600,  //  0023  CALL	R5	3
-      0x80040A00,  //  0024  RET	1	R5
-      0x7002004E,  //  0025  JMP		#0075
-      0x1C140905,  //  0026  EQ	R5	R4	K5
-      0x78160008,  //  0027  JMPF	R5	#0031
-      0x8C14010F,  //  0028  GETMET	R5	R0	K15
-      0x5C1C0200,  //  0029  MOVE	R7	R1
-      0x7C140400,  //  002A  CALL	R5	2
-      0x8C140111,  //  002B  GETMET	R5	R0	K17
+      0x88080501,  //  0001  GETMBR	R2	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x88100303,  //  0003  GETMBR	R4	R1	K3
+      0x88140304,  //  0004  GETMBR	R5	R1	K4
+      0x7C080600,  //  0005  CALL	R2	3
+      0x8C0C0505,  //  0006  GETMET	R3	R2	K5
+      0x541600FE,  //  0007  LDINT	R5	255
+      0x7C0C0400,  //  0008  CALL	R3	2
+      0x88100306,  //  0009  GETMBR	R4	R1	K6
+      0x1C140907,  //  000A  EQ	R5	R4	K7
+      0x78160005,  //  000B  JMPF	R5	#0012
+      0x8C140108,  //  000C  GETMET	R5	R0	K8
+      0x5C1C0200,  //  000D  MOVE	R7	R1
+      0x5C200400,  //  000E  MOVE	R8	R2
+      0x7C140600,  //  000F  CALL	R5	3
+      0x80040A00,  //  0010  RET	1	R5
+      0x70020059,  //  0011  JMP		#006C
+      0x1C140909,  //  0012  EQ	R5	R4	K9
+      0x78160008,  //  0013  JMPF	R5	#001D
+      0x8C14010A,  //  0014  GETMET	R5	R0	K10
+      0x5C1C0200,  //  0015  MOVE	R7	R1
+      0x7C140400,  //  0016  CALL	R5	2
+      0x8C14010B,  //  0017  GETMET	R5	R0	K11
+      0x5C1C0200,  //  0018  MOVE	R7	R1
+      0x5C200400,  //  0019  MOVE	R8	R2
+      0x7C140600,  //  001A  CALL	R5	3
+      0x80040A00,  //  001B  RET	1	R5
+      0x7002004E,  //  001C  JMP		#006C
+      0x1C14090C,  //  001D  EQ	R5	R4	K12
+      0x78160008,  //  001E  JMPF	R5	#0028
+      0x8C14010A,  //  001F  GETMET	R5	R0	K10
+      0x5C1C0200,  //  0020  MOVE	R7	R1
+      0x7C140400,  //  0021  CALL	R5	2
+      0x8C14010D,  //  0022  GETMET	R5	R0	K13
+      0x5C1C0200,  //  0023  MOVE	R7	R1
+      0x5C200400,  //  0024  MOVE	R8	R2
+      0x7C140600,  //  0025  CALL	R5	3
+      0x80040A00,  //  0026  RET	1	R5
+      0x70020043,  //  0027  JMP		#006C
+      0x54160003,  //  0028  LDINT	R5	4
+      0x1C140805,  //  0029  EQ	R5	R4	R5
+      0x78160005,  //  002A  JMPF	R5	#0031
+      0x8C14010E,  //  002B  GETMET	R5	R0	K14
       0x5C1C0200,  //  002C  MOVE	R7	R1
       0x5C200400,  //  002D  MOVE	R8	R2
       0x7C140600,  //  002E  CALL	R5	3
       0x80040A00,  //  002F  RET	1	R5
-      0x70020043,  //  0030  JMP		#0075
-      0x54160003,  //  0031  LDINT	R5	4
+      0x7002003A,  //  0030  JMP		#006C
+      0x54160004,  //  0031  LDINT	R5	5
       0x1C140805,  //  0032  EQ	R5	R4	R5
       0x78160005,  //  0033  JMPF	R5	#003A
-      0x8C140112,  //  0034  GETMET	R5	R0	K18
+      0x8C14010F,  //  0034  GETMET	R5	R0	K15
       0x5C1C0200,  //  0035  MOVE	R7	R1
       0x5C200400,  //  0036  MOVE	R8	R2
       0x7C140600,  //  0037  CALL	R5	3
       0x80040A00,  //  0038  RET	1	R5
-      0x7002003A,  //  0039  JMP		#0075
-      0x54160004,  //  003A  LDINT	R5	5
+      0x70020031,  //  0039  JMP		#006C
+      0x54160005,  //  003A  LDINT	R5	6
       0x1C140805,  //  003B  EQ	R5	R4	R5
-      0x78160005,  //  003C  JMPF	R5	#0043
-      0x8C140113,  //  003D  GETMET	R5	R0	K19
+      0x78160008,  //  003C  JMPF	R5	#0046
+      0x8C14010A,  //  003D  GETMET	R5	R0	K10
       0x5C1C0200,  //  003E  MOVE	R7	R1
-      0x5C200400,  //  003F  MOVE	R8	R2
-      0x7C140600,  //  0040  CALL	R5	3
-      0x80040A00,  //  0041  RET	1	R5
-      0x70020031,  //  0042  JMP		#0075
-      0x54160005,  //  0043  LDINT	R5	6
-      0x1C140805,  //  0044  EQ	R5	R4	R5
-      0x78160008,  //  0045  JMPF	R5	#004F
-      0x8C14010F,  //  0046  GETMET	R5	R0	K15
-      0x5C1C0200,  //  0047  MOVE	R7	R1
-      0x7C140400,  //  0048  CALL	R5	2
-      0x8C140114,  //  0049  GETMET	R5	R0	K20
+      0x7C140400,  //  003F  CALL	R5	2
+      0x8C140110,  //  0040  GETMET	R5	R0	K16
+      0x5C1C0200,  //  0041  MOVE	R7	R1
+      0x5C200400,  //  0042  MOVE	R8	R2
+      0x7C140600,  //  0043  CALL	R5	3
+      0x80040A00,  //  0044  RET	1	R5
+      0x70020025,  //  0045  JMP		#006C
+      0x54160006,  //  0046  LDINT	R5	7
+      0x1C140805,  //  0047  EQ	R5	R4	R5
+      0x78160005,  //  0048  JMPF	R5	#004F
+      0x8C140111,  //  0049  GETMET	R5	R0	K17
       0x5C1C0200,  //  004A  MOVE	R7	R1
       0x5C200400,  //  004B  MOVE	R8	R2
       0x7C140600,  //  004C  CALL	R5	3
       0x80040A00,  //  004D  RET	1	R5
-      0x70020025,  //  004E  JMP		#0075
-      0x54160006,  //  004F  LDINT	R5	7
+      0x7002001C,  //  004E  JMP		#006C
+      0x54160007,  //  004F  LDINT	R5	8
       0x1C140805,  //  0050  EQ	R5	R4	R5
-      0x78160005,  //  0051  JMPF	R5	#0058
-      0x8C140115,  //  0052  GETMET	R5	R0	K21
+      0x78160008,  //  0051  JMPF	R5	#005B
+      0x8C14010A,  //  0052  GETMET	R5	R0	K10
       0x5C1C0200,  //  0053  MOVE	R7	R1
-      0x5C200400,  //  0054  MOVE	R8	R2
-      0x7C140600,  //  0055  CALL	R5	3
-      0x80040A00,  //  0056  RET	1	R5
-      0x7002001C,  //  0057  JMP		#0075
-      0x54160007,  //  0058  LDINT	R5	8
-      0x1C140805,  //  0059  EQ	R5	R4	R5
-      0x78160008,  //  005A  JMPF	R5	#0064
-      0x8C14010F,  //  005B  GETMET	R5	R0	K15
-      0x5C1C0200,  //  005C  MOVE	R7	R1
-      0x7C140400,  //  005D  CALL	R5	2
-      0x8C140116,  //  005E  GETMET	R5	R0	K22
+      0x7C140400,  //  0054  CALL	R5	2
+      0x8C140112,  //  0055  GETMET	R5	R0	K18
+      0x5C1C0200,  //  0056  MOVE	R7	R1
+      0x5C200400,  //  0057  MOVE	R8	R2
+      0x7C140600,  //  0058  CALL	R5	3
+      0x80040A00,  //  0059  RET	1	R5
+      0x70020010,  //  005A  JMP		#006C
+      0x54160008,  //  005B  LDINT	R5	9
+      0x1C140805,  //  005C  EQ	R5	R4	R5
+      0x78160005,  //  005D  JMPF	R5	#0064
+      0x8C140113,  //  005E  GETMET	R5	R0	K19
       0x5C1C0200,  //  005F  MOVE	R7	R1
       0x5C200400,  //  0060  MOVE	R8	R2
       0x7C140600,  //  0061  CALL	R5	3
       0x80040A00,  //  0062  RET	1	R5
-      0x70020010,  //  0063  JMP		#0075
-      0x54160008,  //  0064  LDINT	R5	9
+      0x70020007,  //  0063  JMP		#006C
+      0x54160009,  //  0064  LDINT	R5	10
       0x1C140805,  //  0065  EQ	R5	R4	R5
-      0x78160005,  //  0066  JMPF	R5	#006D
-      0x8C140117,  //  0067  GETMET	R5	R0	K23
+      0x78160004,  //  0066  JMPF	R5	#006C
+      0x8C140114,  //  0067  GETMET	R5	R0	K20
       0x5C1C0200,  //  0068  MOVE	R7	R1
       0x5C200400,  //  0069  MOVE	R8	R2
       0x7C140600,  //  006A  CALL	R5	3
       0x80040A00,  //  006B  RET	1	R5
-      0x70020007,  //  006C  JMP		#0075
-      0x54160009,  //  006D  LDINT	R5	10
-      0x1C140805,  //  006E  EQ	R5	R4	R5
-      0x78160004,  //  006F  JMPF	R5	#0075
-      0x8C140118,  //  0070  GETMET	R5	R0	K24
-      0x5C1C0200,  //  0071  MOVE	R7	R1
-      0x5C200400,  //  0072  MOVE	R8	R2
-      0x7C140600,  //  0073  CALL	R5	3
-      0x80040A00,  //  0074  RET	1	R5
-      0x50140000,  //  0075  LDBOOL	R5	0	0
-      0x80040A00,  //  0076  RET	1	R5
+      0x50140000,  //  006C  LDBOOL	R5	0	0
+      0x80040A00,  //  006D  RET	1	R5
     })
   )
 );
@@ -2372,27 +2277,25 @@ be_local_closure(Matter_IM_process_timed_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
+    ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TimedRequestMessage),
     /* K3   */  be_nested_str_weak(from_TLV),
     /* K4   */  be_nested_str_weak(tasmota),
     /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20TimedRequestMessage_X3D),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(format),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20TimedRequest_X3D_X25i),
-    /* K10  */  be_nested_str_weak(session),
-    /* K11  */  be_nested_str_weak(local_session_id),
-    /* K12  */  be_nested_str_weak(timeout),
-    /* K13  */  be_const_int(2),
-    /* K14  */  be_nested_str_weak(send_status),
-    /* K15  */  be_nested_str_weak(SUCCESS),
+    /* K6   */  be_nested_str_weak(format),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20TimedRequest_X3D_X25i),
+    /* K8   */  be_nested_str_weak(session),
+    /* K9   */  be_nested_str_weak(local_session_id),
+    /* K10  */  be_nested_str_weak(timeout),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_nested_str_weak(send_status),
+    /* K13  */  be_nested_str_weak(SUCCESS),
     }),
     be_str_weak(process_timed_request),
     &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
+    ( &(const binstruction[24]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0xB8120200,  //  0001  GETNGBL	R4	K1
       0x8C100902,  //  0002  GETMET	R4	R4	K2
@@ -2402,29 +2305,21 @@ be_local_closure(Matter_IM_process_timed_request,   /* name */
       0x7C100400,  //  0006  CALL	R4	2
       0xB8160800,  //  0007  GETNGBL	R5	K4
       0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x601C0008,  //  0009  GETGBL	R7	G8
-      0x5C200800,  //  000A  MOVE	R8	R4
-      0x7C1C0200,  //  000B  CALL	R7	1
-      0x001E0C07,  //  000C  ADD	R7	K6	R7
-      0x58200007,  //  000D  LDCONST	R8	K7
-      0x7C140600,  //  000E  CALL	R5	3
-      0xB8160800,  //  000F  GETNGBL	R5	K4
-      0x8C140B05,  //  0010  GETMET	R5	R5	K5
-      0x8C1C0708,  //  0011  GETMET	R7	R3	K8
-      0x58240009,  //  0012  LDCONST	R9	K9
-      0x8828030A,  //  0013  GETMBR	R10	R1	K10
-      0x8828150B,  //  0014  GETMBR	R10	R10	K11
-      0x882C090C,  //  0015  GETMBR	R11	R4	K12
-      0x7C1C0800,  //  0016  CALL	R7	4
-      0x5820000D,  //  0017  LDCONST	R8	K13
-      0x7C140600,  //  0018  CALL	R5	3
-      0x8C14010E,  //  0019  GETMET	R5	R0	K14
-      0x5C1C0200,  //  001A  MOVE	R7	R1
-      0xB8220200,  //  001B  GETNGBL	R8	K1
-      0x8820110F,  //  001C  GETMBR	R8	R8	K15
-      0x7C140600,  //  001D  CALL	R5	3
-      0x50140200,  //  001E  LDBOOL	R5	1	0
-      0x80040A00,  //  001F  RET	1	R5
+      0x8C1C0706,  //  0009  GETMET	R7	R3	K6
+      0x58240007,  //  000A  LDCONST	R9	K7
+      0x88280308,  //  000B  GETMBR	R10	R1	K8
+      0x88281509,  //  000C  GETMBR	R10	R10	K9
+      0x882C090A,  //  000D  GETMBR	R11	R4	K10
+      0x7C1C0800,  //  000E  CALL	R7	4
+      0x5820000B,  //  000F  LDCONST	R8	K11
+      0x7C140600,  //  0010  CALL	R5	3
+      0x8C14010C,  //  0011  GETMET	R5	R0	K12
+      0x5C1C0200,  //  0012  MOVE	R7	R1
+      0xB8220200,  //  0013  GETNGBL	R8	K1
+      0x8820110D,  //  0014  GETMBR	R8	R8	K13
+      0x7C140600,  //  0015  CALL	R5	3
+      0x50140200,  //  0016  LDBOOL	R5	1	0
+      0x80040A00,  //  0017  RET	1	R5
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
@@ -43,84 +43,67 @@ be_local_closure(Matter_IM_Message_send_im,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
+    ( &(const bvalue[21]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_Message_X20send_im_X20exch_X3D_X25i_X20ready_X3D_X25i),
-    /* K5   */  be_nested_str_weak(resp),
-    /* K6   */  be_nested_str_weak(exchange_id),
-    /* K7   */  be_nested_str_weak(ready),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(encode_frame),
-    /* K12  */  be_nested_str_weak(data),
-    /* K13  */  be_nested_str_weak(to_TLV),
-    /* K14  */  be_nested_str_weak(tlv2raw),
-    /* K15  */  be_nested_str_weak(encrypt),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25i_X20exch_X3D_X25i_X20rack_X3D_X25s),
-    /* K17  */  be_nested_str_weak(session),
-    /* K18  */  be_nested_str_weak(local_session_id),
-    /* K19  */  be_nested_str_weak(message_counter),
-    /* K20  */  be_nested_str_weak(ack_message_counter),
-    /* K21  */  be_nested_str_weak(send_response_frame),
-    /* K22  */  be_nested_str_weak(last_counter),
-    /* K23  */  be_nested_str_weak(finish),
+    /* K1   */  be_nested_str_weak(ready),
+    /* K2   */  be_nested_str_weak(resp),
+    /* K3   */  be_nested_str_weak(encode_frame),
+    /* K4   */  be_nested_str_weak(data),
+    /* K5   */  be_nested_str_weak(to_TLV),
+    /* K6   */  be_nested_str_weak(tlv2raw),
+    /* K7   */  be_nested_str_weak(encrypt),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(log),
+    /* K10  */  be_nested_str_weak(format),
+    /* K11  */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25i_X20exch_X3D_X25i_X20rack_X3D_X25s),
+    /* K12  */  be_nested_str_weak(session),
+    /* K13  */  be_nested_str_weak(local_session_id),
+    /* K14  */  be_nested_str_weak(message_counter),
+    /* K15  */  be_nested_str_weak(exchange_id),
+    /* K16  */  be_nested_str_weak(ack_message_counter),
+    /* K17  */  be_const_int(3),
+    /* K18  */  be_nested_str_weak(send_response_frame),
+    /* K19  */  be_nested_str_weak(last_counter),
+    /* K20  */  be_nested_str_weak(finish),
     }),
     be_str_weak(send_im),
     &be_const_str_solidified,
-    ( &(const binstruction[49]) {  /* code */
+    ( &(const binstruction[35]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200105,  //  0005  GETMBR	R8	R0	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x88240107,  //  0007  GETMBR	R9	R0	K7
-      0x78260001,  //  0008  JMPF	R9	#000B
-      0x58240008,  //  0009  LDCONST	R9	K8
-      0x70020000,  //  000A  JMP		#000C
-      0x58240009,  //  000B  LDCONST	R9	K9
-      0x7C140800,  //  000C  CALL	R5	4
-      0x5818000A,  //  000D  LDCONST	R6	K10
-      0x7C0C0600,  //  000E  CALL	R3	3
-      0x880C0107,  //  000F  GETMBR	R3	R0	K7
-      0x740E0001,  //  0010  JMPT	R3	#0013
-      0x500C0000,  //  0011  LDBOOL	R3	0	0
-      0x80040600,  //  0012  RET	1	R3
-      0x880C0105,  //  0013  GETMBR	R3	R0	K5
-      0x8C10070B,  //  0014  GETMET	R4	R3	K11
-      0x8818010C,  //  0015  GETMBR	R6	R0	K12
-      0x8C180D0D,  //  0016  GETMET	R6	R6	K13
-      0x7C180200,  //  0017  CALL	R6	1
-      0x8C180D0E,  //  0018  GETMET	R6	R6	K14
-      0x7C180200,  //  0019  CALL	R6	1
-      0x7C100400,  //  001A  CALL	R4	2
-      0x8C10070F,  //  001B  GETMET	R4	R3	K15
-      0x7C100200,  //  001C  CALL	R4	1
-      0xB8120200,  //  001D  GETNGBL	R4	K1
-      0x8C100902,  //  001E  GETMET	R4	R4	K2
-      0x8C180503,  //  001F  GETMET	R6	R2	K3
-      0x58200010,  //  0020  LDCONST	R8	K16
-      0x88240711,  //  0021  GETMBR	R9	R3	K17
-      0x88241312,  //  0022  GETMBR	R9	R9	K18
-      0x88280713,  //  0023  GETMBR	R10	R3	K19
-      0x882C0706,  //  0024  GETMBR	R11	R3	K6
-      0x88300714,  //  0025  GETMBR	R12	R3	K20
-      0x7C180C00,  //  0026  CALL	R6	6
-      0x581C000A,  //  0027  LDCONST	R7	K10
-      0x7C100600,  //  0028  CALL	R4	3
-      0x8C100315,  //  0029  GETMET	R4	R1	K21
-      0x5C180600,  //  002A  MOVE	R6	R3
-      0x7C100400,  //  002B  CALL	R4	2
-      0x88100713,  //  002C  GETMBR	R4	R3	K19
-      0x90022C04,  //  002D  SETMBR	R0	K22	R4
-      0x50100200,  //  002E  LDBOOL	R4	1	0
-      0x90022E04,  //  002F  SETMBR	R0	K23	R4
-      0x80000000,  //  0030  RET	0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x740E0001,  //  0002  JMPT	R3	#0005
+      0x500C0000,  //  0003  LDBOOL	R3	0	0
+      0x80040600,  //  0004  RET	1	R3
+      0x880C0102,  //  0005  GETMBR	R3	R0	K2
+      0x8C100703,  //  0006  GETMET	R4	R3	K3
+      0x88180104,  //  0007  GETMBR	R6	R0	K4
+      0x8C180D05,  //  0008  GETMET	R6	R6	K5
+      0x7C180200,  //  0009  CALL	R6	1
+      0x8C180D06,  //  000A  GETMET	R6	R6	K6
+      0x7C180200,  //  000B  CALL	R6	1
+      0x7C100400,  //  000C  CALL	R4	2
+      0x8C100707,  //  000D  GETMET	R4	R3	K7
+      0x7C100200,  //  000E  CALL	R4	1
+      0xB8121000,  //  000F  GETNGBL	R4	K8
+      0x8C100909,  //  0010  GETMET	R4	R4	K9
+      0x8C18050A,  //  0011  GETMET	R6	R2	K10
+      0x5820000B,  //  0012  LDCONST	R8	K11
+      0x8824070C,  //  0013  GETMBR	R9	R3	K12
+      0x8824130D,  //  0014  GETMBR	R9	R9	K13
+      0x8828070E,  //  0015  GETMBR	R10	R3	K14
+      0x882C070F,  //  0016  GETMBR	R11	R3	K15
+      0x88300710,  //  0017  GETMBR	R12	R3	K16
+      0x7C180C00,  //  0018  CALL	R6	6
+      0x581C0011,  //  0019  LDCONST	R7	K17
+      0x7C100600,  //  001A  CALL	R4	3
+      0x8C100312,  //  001B  GETMET	R4	R1	K18
+      0x5C180600,  //  001C  MOVE	R6	R3
+      0x7C100400,  //  001D  CALL	R4	2
+      0x8810070E,  //  001E  GETMBR	R4	R3	K14
+      0x90022604,  //  001F  SETMBR	R0	K19	R4
+      0x50100200,  //  0020  LDBOOL	R4	1	0
+      0x90022804,  //  0021  SETMBR	R0	K20	R4
+      0x80000000,  //  0022  RET	0
     })
   )
 );
@@ -212,7 +195,7 @@ be_local_closure(Matter_IM_Message_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_Message_ack_received,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    4,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -220,37 +203,23 @@ be_local_closure(Matter_IM_Message_ack_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20IM_Message_X20ack_received_X20exch_X3D),
-    /* K3   */  be_nested_str_weak(resp),
-    /* K4   */  be_nested_str_weak(exchange_id),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(expiration),
-    /* K7   */  be_nested_str_weak(millis),
-    /* K8   */  be_nested_str_weak(MSG_TIMEOUT),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(expiration),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(millis),
+    /* K3   */  be_nested_str_weak(MSG_TIMEOUT),
     }),
     be_str_weak(ack_received),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x60100008,  //  0002  GETGBL	R4	G8
-      0x88140103,  //  0003  GETMBR	R5	R0	K3
-      0x88140B04,  //  0004  GETMBR	R5	R5	K4
-      0x7C100200,  //  0005  CALL	R4	1
-      0x00120404,  //  0006  ADD	R4	K2	R4
-      0x58140005,  //  0007  LDCONST	R5	K5
-      0x7C080600,  //  0008  CALL	R2	3
-      0xB80A0000,  //  0009  GETNGBL	R2	K0
-      0x8C080507,  //  000A  GETMET	R2	R2	K7
-      0x7C080200,  //  000B  CALL	R2	1
-      0x880C0108,  //  000C  GETMBR	R3	R0	K8
-      0x00080403,  //  000D  ADD	R2	R2	R3
-      0x90020C02,  //  000E  SETMBR	R0	K6	R2
-      0x50080000,  //  000F  LDBOOL	R2	0	0
-      0x80040400,  //  0010  RET	1	R2
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB80A0200,  //  0000  GETNGBL	R2	K1
+      0x8C080502,  //  0001  GETMET	R2	R2	K2
+      0x7C080200,  //  0002  CALL	R2	1
+      0x880C0103,  //  0003  GETMBR	R3	R0	K3
+      0x00080403,  //  0004  ADD	R2	R2	R3
+      0x90020002,  //  0005  SETMBR	R0	K0	R2
+      0x50080000,  //  0006  LDBOOL	R2	0	0
+      0x80040400,  //  0007  RET	1	R2
     })
   )
 );
@@ -286,7 +255,7 @@ be_local_closure(Matter_IM_Message_reached_timeout,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_Message_status_ok_received,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    8,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -294,55 +263,41 @@ be_local_closure(Matter_IM_Message_status_ok_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
+    ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_Message_X20status_ok_received_X20exch_X3D_X25i),
+    /* K1   */  be_nested_str_weak(expiration),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(millis),
+    /* K4   */  be_nested_str_weak(MSG_TIMEOUT),
     /* K5   */  be_nested_str_weak(resp),
-    /* K6   */  be_nested_str_weak(exchange_id),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(expiration),
-    /* K9   */  be_nested_str_weak(millis),
-    /* K10  */  be_nested_str_weak(MSG_TIMEOUT),
-    /* K11  */  be_nested_str_weak(build_response),
-    /* K12  */  be_nested_str_weak(opcode),
-    /* K13  */  be_nested_str_weak(x_flag_r),
-    /* K14  */  be_nested_str_weak(ready),
+    /* K6   */  be_nested_str_weak(build_response),
+    /* K7   */  be_nested_str_weak(opcode),
+    /* K8   */  be_nested_str_weak(x_flag_r),
+    /* K9   */  be_nested_str_weak(ready),
     }),
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
-    ( &(const binstruction[29]) {  /* code */
+    ( &(const binstruction[20]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200105,  //  0005  GETMBR	R8	R0	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x7C140600,  //  0007  CALL	R5	3
-      0x58180007,  //  0008  LDCONST	R6	K7
-      0x7C0C0600,  //  0009  CALL	R3	3
-      0xB80E0200,  //  000A  GETNGBL	R3	K1
-      0x8C0C0709,  //  000B  GETMET	R3	R3	K9
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x8810010A,  //  000D  GETMBR	R4	R0	K10
-      0x000C0604,  //  000E  ADD	R3	R3	R4
-      0x90021003,  //  000F  SETMBR	R0	K8	R3
-      0x78060007,  //  0010  JMPF	R1	#0019
-      0x8C0C030B,  //  0011  GETMET	R3	R1	K11
-      0x88140105,  //  0012  GETMBR	R5	R0	K5
-      0x88140B0C,  //  0013  GETMBR	R5	R5	K12
-      0x88180105,  //  0014  GETMBR	R6	R0	K5
-      0x88180D0D,  //  0015  GETMBR	R6	R6	K13
-      0x881C0105,  //  0016  GETMBR	R7	R0	K5
-      0x7C0C0800,  //  0017  CALL	R3	4
-      0x90020A03,  //  0018  SETMBR	R0	K5	R3
-      0x500C0200,  //  0019  LDBOOL	R3	1	0
-      0x90021C03,  //  001A  SETMBR	R0	K14	R3
-      0x500C0200,  //  001B  LDBOOL	R3	1	0
-      0x80040600,  //  001C  RET	1	R3
+      0xB80E0400,  //  0001  GETNGBL	R3	K2
+      0x8C0C0703,  //  0002  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x88100104,  //  0004  GETMBR	R4	R0	K4
+      0x000C0604,  //  0005  ADD	R3	R3	R4
+      0x90020203,  //  0006  SETMBR	R0	K1	R3
+      0x78060007,  //  0007  JMPF	R1	#0010
+      0x8C0C0306,  //  0008  GETMET	R3	R1	K6
+      0x88140105,  //  0009  GETMBR	R5	R0	K5
+      0x88140B07,  //  000A  GETMBR	R5	R5	K7
+      0x88180105,  //  000B  GETMBR	R6	R0	K5
+      0x88180D08,  //  000C  GETMBR	R6	R6	K8
+      0x881C0105,  //  000D  GETMBR	R7	R0	K5
+      0x7C0C0800,  //  000E  CALL	R3	4
+      0x90020A03,  //  000F  SETMBR	R0	K5	R3
+      0x500C0200,  //  0010  LDBOOL	R3	1	0
+      0x90021203,  //  0011  SETMBR	R0	K9	R3
+      0x500C0200,  //  0012  LDBOOL	R3	1	0
+      0x80040600,  //  0013  RET	1	R3
     })
   )
 );
@@ -582,218 +537,190 @@ be_local_closure(Matter_IM_ReportData_send_im,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[34]) {     /* constants */
+    ( &(const bvalue[32]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_ReportData_X20send_im_X20exch_X3D_X25i_X20ready_X3D_X25i),
-    /* K5   */  be_nested_str_weak(resp),
-    /* K6   */  be_nested_str_weak(exchange_id),
-    /* K7   */  be_nested_str_weak(ready),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(data),
-    /* K12  */  be_nested_str_weak(more_chunked_messages),
-    /* K13  */  be_nested_str_weak(attribute_reports),
-    /* K14  */  be_nested_str_weak(to_TLV),
-    /* K15  */  be_nested_str_weak(encode_len),
-    /* K16  */  be_nested_str_weak(MAX_MESSAGE),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20exch_X3D_X25i_X20elements_X3D_X25i_X20msg_sz_X3D_X25i_X20total_X3D_X25i),
-    /* K18  */  be_nested_str_weak(get_exchangeid),
-    /* K19  */  be_const_int(2147483647),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20_X2ERead_Attr_X20next_chunk_X20exch_X3D_X25i),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20_X2ERead_Attr_X20first_chunk_X20exch_X3D_X25i),
-    /* K22  */  be_nested_str_weak(tlv2raw),
-    /* K23  */  be_nested_str_weak(encode_frame),
-    /* K24  */  be_nested_str_weak(encrypt),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25i_X20exch_X3D_X25i_X20rack_X3D_X25s),
-    /* K26  */  be_nested_str_weak(session),
-    /* K27  */  be_nested_str_weak(local_session_id),
-    /* K28  */  be_nested_str_weak(message_counter),
-    /* K29  */  be_nested_str_weak(ack_message_counter),
-    /* K30  */  be_nested_str_weak(send_response_frame),
-    /* K31  */  be_nested_str_weak(last_counter),
-    /* K32  */  be_nested_str_weak(MTR_X3A_X20to_be_sent_later_X20size_X3D_X25i_X20exch_X3D_X25i),
-    /* K33  */  be_nested_str_weak(finish),
+    /* K1   */  be_nested_str_weak(ready),
+    /* K2   */  be_nested_str_weak(resp),
+    /* K3   */  be_nested_str_weak(data),
+    /* K4   */  be_nested_str_weak(more_chunked_messages),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(attribute_reports),
+    /* K7   */  be_nested_str_weak(to_TLV),
+    /* K8   */  be_nested_str_weak(encode_len),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(MAX_MESSAGE),
+    /* K11  */  be_const_int(2147483647),
+    /* K12  */  be_nested_str_weak(tasmota),
+    /* K13  */  be_nested_str_weak(log),
+    /* K14  */  be_nested_str_weak(format),
+    /* K15  */  be_nested_str_weak(MTR_X3A_X20_X2ERead_Attr_X20next_chunk_X20exch_X3D_X25i),
+    /* K16  */  be_nested_str_weak(get_exchangeid),
+    /* K17  */  be_const_int(3),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X2ERead_Attr_X20first_chunk_X20exch_X3D_X25i),
+    /* K19  */  be_nested_str_weak(tlv2raw),
+    /* K20  */  be_nested_str_weak(encode_frame),
+    /* K21  */  be_nested_str_weak(encrypt),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25i_X20exch_X3D_X25i_X20rack_X3D_X25s),
+    /* K23  */  be_nested_str_weak(session),
+    /* K24  */  be_nested_str_weak(local_session_id),
+    /* K25  */  be_nested_str_weak(message_counter),
+    /* K26  */  be_nested_str_weak(exchange_id),
+    /* K27  */  be_nested_str_weak(ack_message_counter),
+    /* K28  */  be_nested_str_weak(send_response_frame),
+    /* K29  */  be_nested_str_weak(last_counter),
+    /* K30  */  be_nested_str_weak(MTR_X3A_X20to_be_sent_later_X20size_X3D_X25i_X20exch_X3D_X25i),
+    /* K31  */  be_nested_str_weak(finish),
     }),
     be_str_weak(send_im),
     &be_const_str_solidified,
-    ( &(const binstruction[173]) {  /* code */
+    ( &(const binstruction[147]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200105,  //  0005  GETMBR	R8	R0	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x88240107,  //  0007  GETMBR	R9	R0	K7
-      0x78260001,  //  0008  JMPF	R9	#000B
-      0x58240008,  //  0009  LDCONST	R9	K8
-      0x70020000,  //  000A  JMP		#000C
-      0x58240009,  //  000B  LDCONST	R9	K9
-      0x7C140800,  //  000C  CALL	R5	4
-      0x5818000A,  //  000D  LDCONST	R6	K10
-      0x7C0C0600,  //  000E  CALL	R3	3
-      0x880C0107,  //  000F  GETMBR	R3	R0	K7
-      0x740E0001,  //  0010  JMPT	R3	#0013
-      0x500C0000,  //  0011  LDBOOL	R3	0	0
-      0x80040600,  //  0012  RET	1	R3
-      0x880C0105,  //  0013  GETMBR	R3	R0	K5
-      0x8810010B,  //  0014  GETMBR	R4	R0	K11
-      0x8814090C,  //  0015  GETMBR	R5	R4	K12
-      0x58180009,  //  0016  LDCONST	R6	K9
-      0x581C0009,  //  0017  LDCONST	R7	K9
-      0x8820090D,  //  0018  GETMBR	R8	R4	K13
-      0x4C240000,  //  0019  LDNIL	R9
-      0x20201009,  //  001A  NE	R8	R8	R9
-      0x78220003,  //  001B  JMPF	R8	#0020
-      0x6020000C,  //  001C  GETGBL	R8	G12
-      0x8824090D,  //  001D  GETMBR	R9	R4	K13
-      0x7C200200,  //  001E  CALL	R8	1
-      0x70020000,  //  001F  JMP		#0021
-      0x58200009,  //  0020  LDCONST	R8	K9
-      0x24241109,  //  0021  GT	R9	R8	K9
-      0x78260007,  //  0022  JMPF	R9	#002B
-      0x8824090D,  //  0023  GETMBR	R9	R4	K13
-      0x94241309,  //  0024  GETIDX	R9	R9	K9
-      0x8C24130E,  //  0025  GETMET	R9	R9	K14
-      0x7C240200,  //  0026  CALL	R9	1
-      0x8C24130F,  //  0027  GETMET	R9	R9	K15
-      0x7C240200,  //  0028  CALL	R9	1
-      0x5C181200,  //  0029  MOVE	R6	R9
-      0x581C0008,  //  002A  LDCONST	R7	K8
-      0x88240110,  //  002B  GETMBR	R9	R0	K16
-      0x14240C09,  //  002C  LT	R9	R6	R9
-      0x78260010,  //  002D  JMPF	R9	#003F
-      0x14240E08,  //  002E  LT	R9	R7	R8
-      0x7826000E,  //  002F  JMPF	R9	#003F
-      0x8824090D,  //  0030  GETMBR	R9	R4	K13
-      0x94241207,  //  0031  GETIDX	R9	R9	R7
-      0x8C24130E,  //  0032  GETMET	R9	R9	K14
-      0x7C240200,  //  0033  CALL	R9	1
-      0x8C24130F,  //  0034  GETMET	R9	R9	K15
-      0x7C240200,  //  0035  CALL	R9	1
-      0x00280C09,  //  0036  ADD	R10	R6	R9
-      0x882C0110,  //  0037  GETMBR	R11	R0	K16
-      0x1428140B,  //  0038  LT	R10	R10	R11
-      0x782A0002,  //  0039  JMPF	R10	#003D
-      0x00180C09,  //  003A  ADD	R6	R6	R9
-      0x001C0F08,  //  003B  ADD	R7	R7	K8
-      0x70020000,  //  003C  JMP		#003E
-      0x70020000,  //  003D  JMP		#003F
-      0x7001FFEB,  //  003E  JMP		#002B
-      0xB8260200,  //  003F  GETNGBL	R9	K1
-      0x8C241302,  //  0040  GETMET	R9	R9	K2
-      0x8C2C0503,  //  0041  GETMET	R11	R2	K3
-      0x58340011,  //  0042  LDCONST	R13	K17
-      0x8C380112,  //  0043  GETMET	R14	R0	K18
-      0x7C380200,  //  0044  CALL	R14	1
-      0x5C3C0E00,  //  0045  MOVE	R15	R7
-      0x5C400C00,  //  0046  MOVE	R16	R6
-      0x5C441000,  //  0047  MOVE	R17	R8
-      0x7C2C0C00,  //  0048  CALL	R11	6
-      0x5830000A,  //  0049  LDCONST	R12	K10
-      0x7C240600,  //  004A  CALL	R9	3
-      0x60240012,  //  004B  GETGBL	R9	G18
-      0x7C240000,  //  004C  CALL	R9	0
-      0x8828090D,  //  004D  GETMBR	R10	R4	K13
-      0x4C2C0000,  //  004E  LDNIL	R11
-      0x2028140B,  //  004F  NE	R10	R10	R11
-      0x782A000D,  //  0050  JMPF	R10	#005F
-      0x40280F13,  //  0051  CONNECT	R10	R7	K19
-      0x882C090D,  //  0052  GETMBR	R11	R4	K13
-      0x9424160A,  //  0053  GETIDX	R9	R11	R10
-      0x04300F08,  //  0054  SUB	R12	R7	K8
-      0x4032120C,  //  0055  CONNECT	R12	K9	R12
-      0x8834090D,  //  0056  GETMBR	R13	R4	K13
-      0x94301A0C,  //  0057  GETIDX	R12	R13	R12
-      0x90121A0C,  //  0058  SETMBR	R4	K13	R12
-      0x6030000C,  //  0059  GETGBL	R12	G12
-      0x5C341200,  //  005A  MOVE	R13	R9
-      0x7C300200,  //  005B  CALL	R12	1
-      0x24301909,  //  005C  GT	R12	R12	K9
-      0x9012180C,  //  005D  SETMBR	R4	K12	R12
-      0x70020001,  //  005E  JMP		#0061
-      0x50280000,  //  005F  LDBOOL	R10	0	0
-      0x9012180A,  //  0060  SETMBR	R4	K12	R10
-      0x78160008,  //  0061  JMPF	R5	#006B
-      0xB82A0200,  //  0062  GETNGBL	R10	K1
-      0x8C281502,  //  0063  GETMET	R10	R10	K2
-      0x8C300503,  //  0064  GETMET	R12	R2	K3
-      0x58380014,  //  0065  LDCONST	R14	K20
-      0x8C3C0112,  //  0066  GETMET	R15	R0	K18
-      0x7C3C0200,  //  0067  CALL	R15	1
-      0x7C300600,  //  0068  CALL	R12	3
-      0x5834000A,  //  0069  LDCONST	R13	K10
-      0x7C280600,  //  006A  CALL	R10	3
-      0x8828090C,  //  006B  GETMBR	R10	R4	K12
-      0x782A000A,  //  006C  JMPF	R10	#0078
-      0x5C280A00,  //  006D  MOVE	R10	R5
-      0x742A0008,  //  006E  JMPT	R10	#0078
-      0xB82A0200,  //  006F  GETNGBL	R10	K1
-      0x8C281502,  //  0070  GETMET	R10	R10	K2
-      0x8C300503,  //  0071  GETMET	R12	R2	K3
-      0x58380015,  //  0072  LDCONST	R14	K21
-      0x8C3C0112,  //  0073  GETMET	R15	R0	K18
-      0x7C3C0200,  //  0074  CALL	R15	1
-      0x7C300600,  //  0075  CALL	R12	3
-      0x5834000A,  //  0076  LDCONST	R13	K10
-      0x7C280600,  //  0077  CALL	R10	3
-      0x8828010B,  //  0078  GETMBR	R10	R0	K11
-      0x8C28150E,  //  0079  GETMET	R10	R10	K14
-      0x7C280200,  //  007A  CALL	R10	1
-      0x8C2C1516,  //  007B  GETMET	R11	R10	K22
-      0x60340015,  //  007C  GETGBL	R13	G21
-      0x88380110,  //  007D  GETMBR	R14	R0	K16
-      0x7C340200,  //  007E  CALL	R13	1
-      0x7C2C0400,  //  007F  CALL	R11	2
-      0x8C300717,  //  0080  GETMET	R12	R3	K23
-      0x5C381600,  //  0081  MOVE	R14	R11
-      0x7C300400,  //  0082  CALL	R12	2
-      0x8C300718,  //  0083  GETMET	R12	R3	K24
-      0x7C300200,  //  0084  CALL	R12	1
-      0xB8320200,  //  0085  GETNGBL	R12	K1
-      0x8C301902,  //  0086  GETMET	R12	R12	K2
-      0x8C380503,  //  0087  GETMET	R14	R2	K3
-      0x58400019,  //  0088  LDCONST	R16	K25
-      0x8844071A,  //  0089  GETMBR	R17	R3	K26
-      0x8844231B,  //  008A  GETMBR	R17	R17	K27
-      0x8848071C,  //  008B  GETMBR	R18	R3	K28
-      0x884C0706,  //  008C  GETMBR	R19	R3	K6
-      0x8850071D,  //  008D  GETMBR	R20	R3	K29
-      0x7C380C00,  //  008E  CALL	R14	6
-      0x583C000A,  //  008F  LDCONST	R15	K10
-      0x7C300600,  //  0090  CALL	R12	3
-      0x8C30031E,  //  0091  GETMET	R12	R1	K30
-      0x5C380600,  //  0092  MOVE	R14	R3
-      0x7C300400,  //  0093  CALL	R12	2
-      0x8830071C,  //  0094  GETMBR	R12	R3	K28
-      0x90023E0C,  //  0095  SETMBR	R0	K31	R12
-      0x6030000C,  //  0096  GETGBL	R12	G12
-      0x5C341200,  //  0097  MOVE	R13	R9
-      0x7C300200,  //  0098  CALL	R12	1
-      0x24301909,  //  0099  GT	R12	R12	K9
-      0x7832000E,  //  009A  JMPF	R12	#00AA
-      0x90121A09,  //  009B  SETMBR	R4	K13	R9
-      0xB8320200,  //  009C  GETNGBL	R12	K1
-      0x8C301902,  //  009D  GETMET	R12	R12	K2
-      0x8C380503,  //  009E  GETMET	R14	R2	K3
-      0x58400020,  //  009F  LDCONST	R16	K32
-      0x6044000C,  //  00A0  GETGBL	R17	G12
-      0x8848090D,  //  00A1  GETMBR	R18	R4	K13
-      0x7C440200,  //  00A2  CALL	R17	1
-      0x88480706,  //  00A3  GETMBR	R18	R3	K6
-      0x7C380800,  //  00A4  CALL	R14	4
-      0x583C000A,  //  00A5  LDCONST	R15	K10
-      0x7C300600,  //  00A6  CALL	R12	3
-      0x50300000,  //  00A7  LDBOOL	R12	0	0
-      0x90020E0C,  //  00A8  SETMBR	R0	K7	R12
-      0x70020001,  //  00A9  JMP		#00AC
-      0x50300200,  //  00AA  LDBOOL	R12	1	0
-      0x9002420C,  //  00AB  SETMBR	R0	K33	R12
-      0x80000000,  //  00AC  RET	0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x740E0001,  //  0002  JMPT	R3	#0005
+      0x500C0000,  //  0003  LDBOOL	R3	0	0
+      0x80040600,  //  0004  RET	1	R3
+      0x880C0102,  //  0005  GETMBR	R3	R0	K2
+      0x88100103,  //  0006  GETMBR	R4	R0	K3
+      0x88140904,  //  0007  GETMBR	R5	R4	K4
+      0x58180005,  //  0008  LDCONST	R6	K5
+      0x581C0005,  //  0009  LDCONST	R7	K5
+      0x88200906,  //  000A  GETMBR	R8	R4	K6
+      0x4C240000,  //  000B  LDNIL	R9
+      0x20201009,  //  000C  NE	R8	R8	R9
+      0x78220003,  //  000D  JMPF	R8	#0012
+      0x6020000C,  //  000E  GETGBL	R8	G12
+      0x88240906,  //  000F  GETMBR	R9	R4	K6
+      0x7C200200,  //  0010  CALL	R8	1
+      0x70020000,  //  0011  JMP		#0013
+      0x58200005,  //  0012  LDCONST	R8	K5
+      0x24241105,  //  0013  GT	R9	R8	K5
+      0x78260007,  //  0014  JMPF	R9	#001D
+      0x88240906,  //  0015  GETMBR	R9	R4	K6
+      0x94241305,  //  0016  GETIDX	R9	R9	K5
+      0x8C241307,  //  0017  GETMET	R9	R9	K7
+      0x7C240200,  //  0018  CALL	R9	1
+      0x8C241308,  //  0019  GETMET	R9	R9	K8
+      0x7C240200,  //  001A  CALL	R9	1
+      0x5C181200,  //  001B  MOVE	R6	R9
+      0x581C0009,  //  001C  LDCONST	R7	K9
+      0x8824010A,  //  001D  GETMBR	R9	R0	K10
+      0x14240C09,  //  001E  LT	R9	R6	R9
+      0x78260010,  //  001F  JMPF	R9	#0031
+      0x14240E08,  //  0020  LT	R9	R7	R8
+      0x7826000E,  //  0021  JMPF	R9	#0031
+      0x88240906,  //  0022  GETMBR	R9	R4	K6
+      0x94241207,  //  0023  GETIDX	R9	R9	R7
+      0x8C241307,  //  0024  GETMET	R9	R9	K7
+      0x7C240200,  //  0025  CALL	R9	1
+      0x8C241308,  //  0026  GETMET	R9	R9	K8
+      0x7C240200,  //  0027  CALL	R9	1
+      0x00280C09,  //  0028  ADD	R10	R6	R9
+      0x882C010A,  //  0029  GETMBR	R11	R0	K10
+      0x1428140B,  //  002A  LT	R10	R10	R11
+      0x782A0002,  //  002B  JMPF	R10	#002F
+      0x00180C09,  //  002C  ADD	R6	R6	R9
+      0x001C0F09,  //  002D  ADD	R7	R7	K9
+      0x70020000,  //  002E  JMP		#0030
+      0x70020000,  //  002F  JMP		#0031
+      0x7001FFEB,  //  0030  JMP		#001D
+      0x60240012,  //  0031  GETGBL	R9	G18
+      0x7C240000,  //  0032  CALL	R9	0
+      0x88280906,  //  0033  GETMBR	R10	R4	K6
+      0x4C2C0000,  //  0034  LDNIL	R11
+      0x2028140B,  //  0035  NE	R10	R10	R11
+      0x782A000D,  //  0036  JMPF	R10	#0045
+      0x40280F0B,  //  0037  CONNECT	R10	R7	K11
+      0x882C0906,  //  0038  GETMBR	R11	R4	K6
+      0x9424160A,  //  0039  GETIDX	R9	R11	R10
+      0x04300F09,  //  003A  SUB	R12	R7	K9
+      0x40320A0C,  //  003B  CONNECT	R12	K5	R12
+      0x88340906,  //  003C  GETMBR	R13	R4	K6
+      0x94301A0C,  //  003D  GETIDX	R12	R13	R12
+      0x90120C0C,  //  003E  SETMBR	R4	K6	R12
+      0x6030000C,  //  003F  GETGBL	R12	G12
+      0x5C341200,  //  0040  MOVE	R13	R9
+      0x7C300200,  //  0041  CALL	R12	1
+      0x24301905,  //  0042  GT	R12	R12	K5
+      0x9012080C,  //  0043  SETMBR	R4	K4	R12
+      0x70020001,  //  0044  JMP		#0047
+      0x50280000,  //  0045  LDBOOL	R10	0	0
+      0x9012080A,  //  0046  SETMBR	R4	K4	R10
+      0x78160008,  //  0047  JMPF	R5	#0051
+      0xB82A1800,  //  0048  GETNGBL	R10	K12
+      0x8C28150D,  //  0049  GETMET	R10	R10	K13
+      0x8C30050E,  //  004A  GETMET	R12	R2	K14
+      0x5838000F,  //  004B  LDCONST	R14	K15
+      0x8C3C0110,  //  004C  GETMET	R15	R0	K16
+      0x7C3C0200,  //  004D  CALL	R15	1
+      0x7C300600,  //  004E  CALL	R12	3
+      0x58340011,  //  004F  LDCONST	R13	K17
+      0x7C280600,  //  0050  CALL	R10	3
+      0x88280904,  //  0051  GETMBR	R10	R4	K4
+      0x782A000A,  //  0052  JMPF	R10	#005E
+      0x5C280A00,  //  0053  MOVE	R10	R5
+      0x742A0008,  //  0054  JMPT	R10	#005E
+      0xB82A1800,  //  0055  GETNGBL	R10	K12
+      0x8C28150D,  //  0056  GETMET	R10	R10	K13
+      0x8C30050E,  //  0057  GETMET	R12	R2	K14
+      0x58380012,  //  0058  LDCONST	R14	K18
+      0x8C3C0110,  //  0059  GETMET	R15	R0	K16
+      0x7C3C0200,  //  005A  CALL	R15	1
+      0x7C300600,  //  005B  CALL	R12	3
+      0x58340011,  //  005C  LDCONST	R13	K17
+      0x7C280600,  //  005D  CALL	R10	3
+      0x88280103,  //  005E  GETMBR	R10	R0	K3
+      0x8C281507,  //  005F  GETMET	R10	R10	K7
+      0x7C280200,  //  0060  CALL	R10	1
+      0x8C2C1513,  //  0061  GETMET	R11	R10	K19
+      0x60340015,  //  0062  GETGBL	R13	G21
+      0x8838010A,  //  0063  GETMBR	R14	R0	K10
+      0x7C340200,  //  0064  CALL	R13	1
+      0x7C2C0400,  //  0065  CALL	R11	2
+      0x8C300714,  //  0066  GETMET	R12	R3	K20
+      0x5C381600,  //  0067  MOVE	R14	R11
+      0x7C300400,  //  0068  CALL	R12	2
+      0x8C300715,  //  0069  GETMET	R12	R3	K21
+      0x7C300200,  //  006A  CALL	R12	1
+      0xB8321800,  //  006B  GETNGBL	R12	K12
+      0x8C30190D,  //  006C  GETMET	R12	R12	K13
+      0x8C38050E,  //  006D  GETMET	R14	R2	K14
+      0x58400016,  //  006E  LDCONST	R16	K22
+      0x88440717,  //  006F  GETMBR	R17	R3	K23
+      0x88442318,  //  0070  GETMBR	R17	R17	K24
+      0x88480719,  //  0071  GETMBR	R18	R3	K25
+      0x884C071A,  //  0072  GETMBR	R19	R3	K26
+      0x8850071B,  //  0073  GETMBR	R20	R3	K27
+      0x7C380C00,  //  0074  CALL	R14	6
+      0x583C0011,  //  0075  LDCONST	R15	K17
+      0x7C300600,  //  0076  CALL	R12	3
+      0x8C30031C,  //  0077  GETMET	R12	R1	K28
+      0x5C380600,  //  0078  MOVE	R14	R3
+      0x7C300400,  //  0079  CALL	R12	2
+      0x88300719,  //  007A  GETMBR	R12	R3	K25
+      0x90023A0C,  //  007B  SETMBR	R0	K29	R12
+      0x6030000C,  //  007C  GETGBL	R12	G12
+      0x5C341200,  //  007D  MOVE	R13	R9
+      0x7C300200,  //  007E  CALL	R12	1
+      0x24301905,  //  007F  GT	R12	R12	K5
+      0x7832000E,  //  0080  JMPF	R12	#0090
+      0x90120C09,  //  0081  SETMBR	R4	K6	R9
+      0xB8321800,  //  0082  GETNGBL	R12	K12
+      0x8C30190D,  //  0083  GETMET	R12	R12	K13
+      0x8C38050E,  //  0084  GETMET	R14	R2	K14
+      0x5840001E,  //  0085  LDCONST	R16	K30
+      0x6044000C,  //  0086  GETGBL	R17	G12
+      0x88480906,  //  0087  GETMBR	R18	R4	K6
+      0x7C440200,  //  0088  CALL	R17	1
+      0x8848071A,  //  0089  GETMBR	R18	R3	K26
+      0x7C380800,  //  008A  CALL	R14	4
+      0x583C0011,  //  008B  LDCONST	R15	K17
+      0x7C300600,  //  008C  CALL	R12	3
+      0x50300000,  //  008D  LDBOOL	R12	0	0
+      0x9002020C,  //  008E  SETMBR	R0	K1	R12
+      0x70020001,  //  008F  JMP		#0092
+      0x50300200,  //  0090  LDBOOL	R12	1	0
+      0x90023E0C,  //  0091  SETMBR	R0	K31	R12
+      0x80000000,  //  0092  RET	0
     })
   )
 );
@@ -866,7 +793,7 @@ extern const bclass be_class_Matter_IM_ReportDataSubscribed;
 ********************************************************************/
 be_local_closure(Matter_IM_ReportDataSubscribed_ack_received,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -874,53 +801,36 @@ be_local_closure(Matter_IM_ReportDataSubscribed_ack_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_ReportDataSubscribed_X20ack_received_X20sub_X3D_X25i),
-    /* K5   */  be_nested_str_weak(sub),
-    /* K6   */  be_nested_str_weak(subscription_id),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(ack_received),
-    /* K9   */  be_nested_str_weak(report_data_phase),
-    /* K10  */  be_nested_str_weak(is_keep_alive),
-    /* K11  */  be_nested_str_weak(re_arm),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ack_received),
+    /* K1   */  be_nested_str_weak(report_data_phase),
+    /* K2   */  be_nested_str_weak(sub),
+    /* K3   */  be_nested_str_weak(is_keep_alive),
+    /* K4   */  be_nested_str_weak(re_arm),
     }),
     be_str_weak(ack_received),
     &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200105,  //  0005  GETMBR	R8	R0	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x7C140600,  //  0007  CALL	R5	3
-      0x58180007,  //  0008  LDCONST	R6	K7
-      0x7C0C0600,  //  0009  CALL	R3	3
-      0x600C0003,  //  000A  GETGBL	R3	G3
-      0x5C100000,  //  000B  MOVE	R4	R0
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x8C0C0708,  //  000D  GETMET	R3	R3	K8
-      0x5C140200,  //  000E  MOVE	R5	R1
-      0x7C0C0400,  //  000F  CALL	R3	2
-      0x880C0109,  //  0010  GETMBR	R3	R0	K9
-      0x740E0008,  //  0011  JMPT	R3	#001B
-      0x880C0105,  //  0012  GETMBR	R3	R0	K5
-      0x880C070A,  //  0013  GETMBR	R3	R3	K10
-      0x780E0002,  //  0014  JMPF	R3	#0018
-      0x880C0105,  //  0015  GETMBR	R3	R0	K5
-      0x8C0C070B,  //  0016  GETMET	R3	R3	K11
-      0x7C0C0200,  //  0017  CALL	R3	1
-      0x500C0200,  //  0018  LDBOOL	R3	1	0
-      0x80040600,  //  0019  RET	1	R3
-      0x70020001,  //  001A  JMP		#001D
-      0x500C0000,  //  001B  LDBOOL	R3	0	0
-      0x80040600,  //  001C  RET	1	R3
-      0x80000000,  //  001D  RET	0
+    ( &(const binstruction[20]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x88080101,  //  0006  GETMBR	R2	R0	K1
+      0x740A0008,  //  0007  JMPT	R2	#0011
+      0x88080102,  //  0008  GETMBR	R2	R0	K2
+      0x88080503,  //  0009  GETMBR	R2	R2	K3
+      0x780A0002,  //  000A  JMPF	R2	#000E
+      0x88080102,  //  000B  GETMBR	R2	R0	K2
+      0x8C080504,  //  000C  GETMET	R2	R2	K4
+      0x7C080200,  //  000D  CALL	R2	1
+      0x50080200,  //  000E  LDBOOL	R2	1	0
+      0x80040400,  //  000F  RET	1	R2
+      0x70020001,  //  0010  JMP		#0013
+      0x50080000,  //  0011  LDBOOL	R2	0	0
+      0x80040400,  //  0012  RET	1	R2
+      0x80000000,  //  0013  RET	0
     })
   )
 );
@@ -940,152 +850,104 @@ be_local_closure(Matter_IM_ReportDataSubscribed_send_im,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
+    ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_ReportDataSubscribed_X20send_X20sub_X3D_X25i_X20exch_X3D_X25i_X20ready_X3D_X25i),
-    /* K5   */  be_nested_str_weak(sub),
-    /* K6   */  be_nested_str_weak(subscription_id),
-    /* K7   */  be_nested_str_weak(resp),
-    /* K8   */  be_nested_str_weak(exchange_id),
-    /* K9   */  be_nested_str_weak(ready),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20ReportDataSubscribed_X3A_X3Asend_im_X20size_X28self_X2Edata_X2Eattribute_reports_X29_X3D_X25i_X20ready_X3D_X25s_X20report_data_phase_X3D_X25s),
-    /* K14  */  be_nested_str_weak(data),
-    /* K15  */  be_nested_str_weak(attribute_reports),
-    /* K16  */  be_nested_str_weak(report_data_phase),
-    /* K17  */  be_nested_str_weak(send_im),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20ReportDataSubscribed_X3A_X3Asend_im_X20called_X20super_X20finish_X3D_X25i),
-    /* K19  */  be_nested_str_weak(finish),
-    /* K20  */  be_nested_str_weak(build_standalone_ack),
-    /* K21  */  be_nested_str_weak(encode_frame),
-    /* K22  */  be_nested_str_weak(encrypt),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i),
-    /* K24  */  be_nested_str_weak(session),
-    /* K25  */  be_nested_str_weak(local_session_id),
-    /* K26  */  be_nested_str_weak(ack_message_counter),
-    /* K27  */  be_nested_str_weak(message_counter),
-    /* K28  */  be_nested_str_weak(send_response_frame),
-    /* K29  */  be_nested_str_weak(last_counter),
+    /* K1   */  be_nested_str_weak(ready),
+    /* K2   */  be_nested_str_weak(data),
+    /* K3   */  be_nested_str_weak(attribute_reports),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(report_data_phase),
+    /* K6   */  be_nested_str_weak(send_im),
+    /* K7   */  be_nested_str_weak(finish),
+    /* K8   */  be_nested_str_weak(resp),
+    /* K9   */  be_nested_str_weak(build_standalone_ack),
+    /* K10  */  be_nested_str_weak(encode_frame),
+    /* K11  */  be_nested_str_weak(encrypt),
+    /* K12  */  be_nested_str_weak(tasmota),
+    /* K13  */  be_nested_str_weak(log),
+    /* K14  */  be_nested_str_weak(format),
+    /* K15  */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i),
+    /* K16  */  be_nested_str_weak(session),
+    /* K17  */  be_nested_str_weak(local_session_id),
+    /* K18  */  be_nested_str_weak(ack_message_counter),
+    /* K19  */  be_nested_str_weak(message_counter),
+    /* K20  */  be_const_int(3),
+    /* K21  */  be_nested_str_weak(send_response_frame),
+    /* K22  */  be_nested_str_weak(last_counter),
     }),
     be_str_weak(send_im),
     &be_const_str_solidified,
-    ( &(const binstruction[111]) {  /* code */
+    ( &(const binstruction[70]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200105,  //  0005  GETMBR	R8	R0	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x88240107,  //  0007  GETMBR	R9	R0	K7
-      0x88241308,  //  0008  GETMBR	R9	R9	K8
-      0x88280109,  //  0009  GETMBR	R10	R0	K9
-      0x782A0001,  //  000A  JMPF	R10	#000D
-      0x5828000A,  //  000B  LDCONST	R10	K10
-      0x70020000,  //  000C  JMP		#000E
-      0x5828000B,  //  000D  LDCONST	R10	K11
-      0x7C140A00,  //  000E  CALL	R5	5
-      0x5818000C,  //  000F  LDCONST	R6	K12
-      0x7C0C0600,  //  0010  CALL	R3	3
-      0xB80E0200,  //  0011  GETNGBL	R3	K1
-      0x8C0C0702,  //  0012  GETMET	R3	R3	K2
-      0x8C140503,  //  0013  GETMET	R5	R2	K3
-      0x581C000D,  //  0014  LDCONST	R7	K13
-      0x6020000C,  //  0015  GETGBL	R8	G12
-      0x8824010E,  //  0016  GETMBR	R9	R0	K14
-      0x8824130F,  //  0017  GETMBR	R9	R9	K15
-      0x7C200200,  //  0018  CALL	R8	1
-      0x60240008,  //  0019  GETGBL	R9	G8
-      0x88280109,  //  001A  GETMBR	R10	R0	K9
-      0x7C240200,  //  001B  CALL	R9	1
-      0x60280008,  //  001C  GETGBL	R10	G8
-      0x882C0110,  //  001D  GETMBR	R11	R0	K16
-      0x7C280200,  //  001E  CALL	R10	1
-      0x7C140A00,  //  001F  CALL	R5	5
-      0x5818000C,  //  0020  LDCONST	R6	K12
-      0x7C0C0600,  //  0021  CALL	R3	3
-      0x880C0109,  //  0022  GETMBR	R3	R0	K9
-      0x740E0001,  //  0023  JMPT	R3	#0026
-      0x500C0000,  //  0024  LDBOOL	R3	0	0
-      0x80040600,  //  0025  RET	1	R3
-      0x600C000C,  //  0026  GETGBL	R3	G12
-      0x8810010E,  //  0027  GETMBR	R4	R0	K14
-      0x8810090F,  //  0028  GETMBR	R4	R4	K15
-      0x7C0C0200,  //  0029  CALL	R3	1
-      0x240C070B,  //  002A  GT	R3	R3	K11
-      0x780E0034,  //  002B  JMPF	R3	#0061
-      0x880C0110,  //  002C  GETMBR	R3	R0	K16
-      0x780E0017,  //  002D  JMPF	R3	#0046
-      0x600C0003,  //  002E  GETGBL	R3	G3
-      0x5C100000,  //  002F  MOVE	R4	R0
-      0x7C0C0200,  //  0030  CALL	R3	1
-      0x8C0C0711,  //  0031  GETMET	R3	R3	K17
-      0x5C140200,  //  0032  MOVE	R5	R1
-      0x7C0C0400,  //  0033  CALL	R3	2
-      0xB80E0200,  //  0034  GETNGBL	R3	K1
-      0x8C0C0702,  //  0035  GETMET	R3	R3	K2
-      0x8C140503,  //  0036  GETMET	R5	R2	K3
-      0x581C0012,  //  0037  LDCONST	R7	K18
-      0x88200113,  //  0038  GETMBR	R8	R0	K19
-      0x7C140600,  //  0039  CALL	R5	3
-      0x5818000C,  //  003A  LDCONST	R6	K12
-      0x7C0C0600,  //  003B  CALL	R3	3
-      0x880C0113,  //  003C  GETMBR	R3	R0	K19
-      0x740E0000,  //  003D  JMPT	R3	#003F
-      0x80000600,  //  003E  RET	0
-      0x500C0000,  //  003F  LDBOOL	R3	0	0
-      0x90022003,  //  0040  SETMBR	R0	K16	R3
-      0x500C0000,  //  0041  LDBOOL	R3	0	0
-      0x90021203,  //  0042  SETMBR	R0	K9	R3
-      0x500C0000,  //  0043  LDBOOL	R3	0	0
-      0x90022603,  //  0044  SETMBR	R0	K19	R3
-      0x70020019,  //  0045  JMP		#0060
-      0x880C0107,  //  0046  GETMBR	R3	R0	K7
-      0x8C0C0714,  //  0047  GETMET	R3	R3	K20
-      0x50140000,  //  0048  LDBOOL	R5	0	0
-      0x7C0C0400,  //  0049  CALL	R3	2
-      0x8C100715,  //  004A  GETMET	R4	R3	K21
-      0x7C100200,  //  004B  CALL	R4	1
-      0x8C100716,  //  004C  GETMET	R4	R3	K22
-      0x7C100200,  //  004D  CALL	R4	1
-      0xB8120200,  //  004E  GETNGBL	R4	K1
-      0x8C100902,  //  004F  GETMET	R4	R4	K2
-      0x8C180503,  //  0050  GETMET	R6	R2	K3
-      0x58200017,  //  0051  LDCONST	R8	K23
-      0x88240718,  //  0052  GETMBR	R9	R3	K24
-      0x88241319,  //  0053  GETMBR	R9	R9	K25
-      0x8828071A,  //  0054  GETMBR	R10	R3	K26
-      0x882C071B,  //  0055  GETMBR	R11	R3	K27
-      0x7C180A00,  //  0056  CALL	R6	5
-      0x581C000C,  //  0057  LDCONST	R7	K12
-      0x7C100600,  //  0058  CALL	R4	3
-      0x8C10031C,  //  0059  GETMET	R4	R1	K28
-      0x5C180600,  //  005A  MOVE	R6	R3
-      0x7C100400,  //  005B  CALL	R4	2
-      0x8810071B,  //  005C  GETMBR	R4	R3	K27
-      0x90023A04,  //  005D  SETMBR	R0	K29	R4
-      0x50100200,  //  005E  LDBOOL	R4	1	0
-      0x90022604,  //  005F  SETMBR	R0	K19	R4
-      0x7002000C,  //  0060  JMP		#006E
-      0x880C0110,  //  0061  GETMBR	R3	R0	K16
-      0x780E0008,  //  0062  JMPF	R3	#006C
-      0x600C0003,  //  0063  GETGBL	R3	G3
-      0x5C100000,  //  0064  MOVE	R4	R0
-      0x7C0C0200,  //  0065  CALL	R3	1
-      0x8C0C0711,  //  0066  GETMET	R3	R3	K17
-      0x5C140200,  //  0067  MOVE	R5	R1
-      0x7C0C0400,  //  0068  CALL	R3	2
-      0x500C0000,  //  0069  LDBOOL	R3	0	0
-      0x90022003,  //  006A  SETMBR	R0	K16	R3
-      0x70020001,  //  006B  JMP		#006E
-      0x500C0200,  //  006C  LDBOOL	R3	1	0
-      0x90022603,  //  006D  SETMBR	R0	K19	R3
-      0x80000000,  //  006E  RET	0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x740E0001,  //  0002  JMPT	R3	#0005
+      0x500C0000,  //  0003  LDBOOL	R3	0	0
+      0x80040600,  //  0004  RET	1	R3
+      0x600C000C,  //  0005  GETGBL	R3	G12
+      0x88100102,  //  0006  GETMBR	R4	R0	K2
+      0x88100903,  //  0007  GETMBR	R4	R4	K3
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x240C0704,  //  0009  GT	R3	R3	K4
+      0x780E002C,  //  000A  JMPF	R3	#0038
+      0x880C0105,  //  000B  GETMBR	R3	R0	K5
+      0x780E000F,  //  000C  JMPF	R3	#001D
+      0x600C0003,  //  000D  GETGBL	R3	G3
+      0x5C100000,  //  000E  MOVE	R4	R0
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0x8C0C0706,  //  0010  GETMET	R3	R3	K6
+      0x5C140200,  //  0011  MOVE	R5	R1
+      0x7C0C0400,  //  0012  CALL	R3	2
+      0x880C0107,  //  0013  GETMBR	R3	R0	K7
+      0x740E0000,  //  0014  JMPT	R3	#0016
+      0x80000600,  //  0015  RET	0
+      0x500C0000,  //  0016  LDBOOL	R3	0	0
+      0x90020A03,  //  0017  SETMBR	R0	K5	R3
+      0x500C0000,  //  0018  LDBOOL	R3	0	0
+      0x90020203,  //  0019  SETMBR	R0	K1	R3
+      0x500C0000,  //  001A  LDBOOL	R3	0	0
+      0x90020E03,  //  001B  SETMBR	R0	K7	R3
+      0x70020019,  //  001C  JMP		#0037
+      0x880C0108,  //  001D  GETMBR	R3	R0	K8
+      0x8C0C0709,  //  001E  GETMET	R3	R3	K9
+      0x50140000,  //  001F  LDBOOL	R5	0	0
+      0x7C0C0400,  //  0020  CALL	R3	2
+      0x8C10070A,  //  0021  GETMET	R4	R3	K10
+      0x7C100200,  //  0022  CALL	R4	1
+      0x8C10070B,  //  0023  GETMET	R4	R3	K11
+      0x7C100200,  //  0024  CALL	R4	1
+      0xB8121800,  //  0025  GETNGBL	R4	K12
+      0x8C10090D,  //  0026  GETMET	R4	R4	K13
+      0x8C18050E,  //  0027  GETMET	R6	R2	K14
+      0x5820000F,  //  0028  LDCONST	R8	K15
+      0x88240710,  //  0029  GETMBR	R9	R3	K16
+      0x88241311,  //  002A  GETMBR	R9	R9	K17
+      0x88280712,  //  002B  GETMBR	R10	R3	K18
+      0x882C0713,  //  002C  GETMBR	R11	R3	K19
+      0x7C180A00,  //  002D  CALL	R6	5
+      0x581C0014,  //  002E  LDCONST	R7	K20
+      0x7C100600,  //  002F  CALL	R4	3
+      0x8C100315,  //  0030  GETMET	R4	R1	K21
+      0x5C180600,  //  0031  MOVE	R6	R3
+      0x7C100400,  //  0032  CALL	R4	2
+      0x88100713,  //  0033  GETMBR	R4	R3	K19
+      0x90022C04,  //  0034  SETMBR	R0	K22	R4
+      0x50100200,  //  0035  LDBOOL	R4	1	0
+      0x90020E04,  //  0036  SETMBR	R0	K7	R4
+      0x7002000C,  //  0037  JMP		#0045
+      0x880C0105,  //  0038  GETMBR	R3	R0	K5
+      0x780E0008,  //  0039  JMPF	R3	#0043
+      0x600C0003,  //  003A  GETGBL	R3	G3
+      0x5C100000,  //  003B  MOVE	R4	R0
+      0x7C0C0200,  //  003C  CALL	R3	1
+      0x8C0C0706,  //  003D  GETMET	R3	R3	K6
+      0x5C140200,  //  003E  MOVE	R5	R1
+      0x7C0C0400,  //  003F  CALL	R3	2
+      0x500C0000,  //  0040  LDBOOL	R3	0	0
+      0x90020A03,  //  0041  SETMBR	R0	K5	R3
+      0x70020001,  //  0042  JMP		#0045
+      0x500C0200,  //  0043  LDBOOL	R3	1	0
+      0x90020E03,  //  0044  SETMBR	R0	K7	R3
+      0x80000000,  //  0045  RET	0
     })
   )
 );
@@ -1155,7 +1017,7 @@ be_local_closure(Matter_IM_ReportDataSubscribed_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_ReportDataSubscribed_status_error_received,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    4,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1163,38 +1025,17 @@ be_local_closure(Matter_IM_ReportDataSubscribed_status_error_received,   /* name
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_ReportDataSubscribed_X20status_error_received_X20sub_X3D_X25i_X20exch_X3D_X25i),
-    /* K5   */  be_nested_str_weak(sub),
-    /* K6   */  be_nested_str_weak(subscription_id),
-    /* K7   */  be_nested_str_weak(resp),
-    /* K8   */  be_nested_str_weak(exchange_id),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_nested_str_weak(remove_self),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sub),
+    /* K1   */  be_nested_str_weak(remove_self),
     }),
     be_str_weak(status_error_received),
     &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200105,  //  0005  GETMBR	R8	R0	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x88240107,  //  0007  GETMBR	R9	R0	K7
-      0x88241308,  //  0008  GETMBR	R9	R9	K8
-      0x7C140800,  //  0009  CALL	R5	4
-      0x58180009,  //  000A  LDCONST	R6	K9
-      0x7C0C0600,  //  000B  CALL	R3	3
-      0x880C0105,  //  000C  GETMBR	R3	R0	K5
-      0x8C0C070A,  //  000D  GETMET	R3	R3	K10
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0x80000000,  //  000F  RET	0
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x80000000,  //  0003  RET	0
     })
   )
 );
@@ -1236,7 +1077,7 @@ be_local_closure(Matter_IM_ReportDataSubscribed_reached_timeout,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_ReportDataSubscribed_status_ok_received,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1244,58 +1085,37 @@ be_local_closure(Matter_IM_ReportDataSubscribed_status_ok_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_ReportDataSubscribed_X20status_ok_received_X20sub_X3D_X25i_X20exch_X3D_X25i),
-    /* K5   */  be_nested_str_weak(sub),
-    /* K6   */  be_nested_str_weak(subscription_id),
-    /* K7   */  be_nested_str_weak(resp),
-    /* K8   */  be_nested_str_weak(exchange_id),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_nested_str_weak(report_data_phase),
-    /* K11  */  be_nested_str_weak(status_ok_received),
-    /* K12  */  be_nested_str_weak(re_arm),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(report_data_phase),
+    /* K1   */  be_nested_str_weak(status_ok_received),
+    /* K2   */  be_nested_str_weak(sub),
+    /* K3   */  be_nested_str_weak(re_arm),
     }),
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200105,  //  0005  GETMBR	R8	R0	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x88240107,  //  0007  GETMBR	R9	R0	K7
-      0x88241308,  //  0008  GETMBR	R9	R9	K8
-      0x7C140800,  //  0009  CALL	R5	4
-      0x58180009,  //  000A  LDCONST	R6	K9
-      0x7C0C0600,  //  000B  CALL	R3	3
-      0x880C010A,  //  000C  GETMBR	R3	R0	K10
-      0x780E0007,  //  000D  JMPF	R3	#0016
-      0x600C0003,  //  000E  GETGBL	R3	G3
-      0x5C100000,  //  000F  MOVE	R4	R0
-      0x7C0C0200,  //  0010  CALL	R3	1
-      0x8C0C070B,  //  0011  GETMET	R3	R3	K11
-      0x5C140200,  //  0012  MOVE	R5	R1
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x80040600,  //  0014  RET	1	R3
-      0x7002000A,  //  0015  JMP		#0021
-      0x880C0105,  //  0016  GETMBR	R3	R0	K5
-      0x8C0C070C,  //  0017  GETMET	R3	R3	K12
-      0x7C0C0200,  //  0018  CALL	R3	1
-      0x600C0003,  //  0019  GETGBL	R3	G3
-      0x5C100000,  //  001A  MOVE	R4	R0
-      0x7C0C0200,  //  001B  CALL	R3	1
-      0x8C0C070B,  //  001C  GETMET	R3	R3	K11
-      0x4C140000,  //  001D  LDNIL	R5
-      0x7C0C0400,  //  001E  CALL	R3	2
-      0x500C0000,  //  001F  LDBOOL	R3	0	0
-      0x80040600,  //  0020  RET	1	R3
-      0x80000000,  //  0021  RET	0
+    ( &(const binstruction[22]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0007,  //  0001  JMPF	R2	#000A
+      0x60080003,  //  0002  GETGBL	R2	G3
+      0x5C0C0000,  //  0003  MOVE	R3	R0
+      0x7C080200,  //  0004  CALL	R2	1
+      0x8C080501,  //  0005  GETMET	R2	R2	K1
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80040400,  //  0008  RET	1	R2
+      0x7002000A,  //  0009  JMP		#0015
+      0x88080102,  //  000A  GETMBR	R2	R0	K2
+      0x8C080503,  //  000B  GETMET	R2	R2	K3
+      0x7C080200,  //  000C  CALL	R2	1
+      0x60080003,  //  000D  GETGBL	R2	G3
+      0x5C0C0000,  //  000E  MOVE	R3	R0
+      0x7C080200,  //  000F  CALL	R2	1
+      0x8C080501,  //  0010  GETMET	R2	R2	K1
+      0x4C100000,  //  0011  LDNIL	R4
+      0x7C080400,  //  0012  CALL	R2	2
+      0x50080000,  //  0013  LDBOOL	R2	0	0
+      0x80040400,  //  0014  RET	1	R2
+      0x80000000,  //  0015  RET	0
     })
   )
 );
@@ -1337,7 +1157,7 @@ extern const bclass be_class_Matter_IM_SubscribedHeartbeat;
 ********************************************************************/
 be_local_closure(Matter_IM_SubscribedHeartbeat_status_error_received,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    4,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1345,39 +1165,18 @@ be_local_closure(Matter_IM_SubscribedHeartbeat_status_error_received,   /* name 
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20Matter_IM_SubscribedHeartbeat_X20status_error_received_X20sub_X3D_X25i_X20exch_X3D_X25i),
-    /* K5   */  be_nested_str_weak(sub),
-    /* K6   */  be_nested_str_weak(subscription_id),
-    /* K7   */  be_nested_str_weak(resp),
-    /* K8   */  be_nested_str_weak(exchange_id),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_nested_str_weak(remove_self),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sub),
+    /* K1   */  be_nested_str_weak(remove_self),
     }),
     be_str_weak(status_error_received),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200105,  //  0005  GETMBR	R8	R0	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x88240107,  //  0007  GETMBR	R9	R0	K7
-      0x88241308,  //  0008  GETMBR	R9	R9	K8
-      0x7C140800,  //  0009  CALL	R5	4
-      0x58180009,  //  000A  LDCONST	R6	K9
-      0x7C0C0600,  //  000B  CALL	R3	3
-      0x880C0105,  //  000C  GETMBR	R3	R0	K5
-      0x8C0C070A,  //  000D  GETMET	R3	R3	K10
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0x500C0000,  //  000F  LDBOOL	R3	0	0
-      0x80040600,  //  0010  RET	1	R3
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x50080000,  //  0003  LDBOOL	R2	0	0
+      0x80040400,  //  0004  RET	1	R2
     })
   )
 );
@@ -1389,7 +1188,7 @@ be_local_closure(Matter_IM_SubscribedHeartbeat_status_error_received,   /* name 
 ********************************************************************/
 be_local_closure(Matter_IM_SubscribedHeartbeat_send_im,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1397,55 +1196,26 @@ be_local_closure(Matter_IM_SubscribedHeartbeat_send_im,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20Matter_IM_SubscribedHeartbeat_X20send_X20sub_X3D_X25i_X20exch_X3D_X25i_X20ready_X3D_X25i),
-    /* K5   */  be_nested_str_weak(sub),
-    /* K6   */  be_nested_str_weak(subscription_id),
-    /* K7   */  be_nested_str_weak(resp),
-    /* K8   */  be_nested_str_weak(exchange_id),
-    /* K9   */  be_nested_str_weak(ready),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(send_im),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ready),
+    /* K1   */  be_nested_str_weak(send_im),
     }),
     be_str_weak(send_im),
     &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200105,  //  0005  GETMBR	R8	R0	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x88240107,  //  0007  GETMBR	R9	R0	K7
-      0x88241308,  //  0008  GETMBR	R9	R9	K8
-      0x88280109,  //  0009  GETMBR	R10	R0	K9
-      0x782A0001,  //  000A  JMPF	R10	#000D
-      0x5828000A,  //  000B  LDCONST	R10	K10
-      0x70020000,  //  000C  JMP		#000E
-      0x5828000B,  //  000D  LDCONST	R10	K11
-      0x7C140A00,  //  000E  CALL	R5	5
-      0x5818000C,  //  000F  LDCONST	R6	K12
-      0x7C0C0600,  //  0010  CALL	R3	3
-      0x880C0109,  //  0011  GETMBR	R3	R0	K9
-      0x740E0001,  //  0012  JMPT	R3	#0015
-      0x500C0000,  //  0013  LDBOOL	R3	0	0
-      0x80040600,  //  0014  RET	1	R3
-      0x600C0003,  //  0015  GETGBL	R3	G3
-      0x5C100000,  //  0016  MOVE	R4	R0
-      0x7C0C0200,  //  0017  CALL	R3	1
-      0x8C0C070D,  //  0018  GETMET	R3	R3	K13
-      0x5C140200,  //  0019  MOVE	R5	R1
-      0x7C0C0400,  //  001A  CALL	R3	2
-      0x500C0000,  //  001B  LDBOOL	R3	0	0
-      0x90021203,  //  001C  SETMBR	R0	K9	R3
-      0x80000000,  //  001D  RET	0
+    ( &(const binstruction[13]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x740A0001,  //  0001  JMPT	R2	#0004
+      0x50080000,  //  0002  LDBOOL	R2	0	0
+      0x80040400,  //  0003  RET	1	R2
+      0x60080003,  //  0004  GETGBL	R2	G3
+      0x5C0C0000,  //  0005  MOVE	R3	R0
+      0x7C080200,  //  0006  CALL	R2	1
+      0x8C080501,  //  0007  GETMET	R2	R2	K1
+      0x5C100200,  //  0008  MOVE	R4	R1
+      0x7C080400,  //  0009  CALL	R2	2
+      0x50080000,  //  000A  LDBOOL	R2	0	0
+      0x90020002,  //  000B  SETMBR	R0	K0	R2
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -1457,7 +1227,7 @@ be_local_closure(Matter_IM_SubscribedHeartbeat_send_im,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_SubscribedHeartbeat_ack_received,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1465,41 +1235,23 @@ be_local_closure(Matter_IM_SubscribedHeartbeat_ack_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20Matter_IM_SubscribedHeartbeat_X20ack_received_X20sub_X3D_X25i),
-    /* K5   */  be_nested_str_weak(sub),
-    /* K6   */  be_nested_str_weak(subscription_id),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(ack_received),
-    /* K9   */  be_nested_str_weak(finish),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ack_received),
+    /* K1   */  be_nested_str_weak(finish),
     }),
     be_str_weak(ack_received),
     &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200105,  //  0005  GETMBR	R8	R0	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x7C140600,  //  0007  CALL	R5	3
-      0x58180007,  //  0008  LDCONST	R6	K7
-      0x7C0C0600,  //  0009  CALL	R3	3
-      0x600C0003,  //  000A  GETGBL	R3	G3
-      0x5C100000,  //  000B  MOVE	R4	R0
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x8C0C0708,  //  000D  GETMET	R3	R3	K8
-      0x5C140200,  //  000E  MOVE	R5	R1
-      0x7C0C0400,  //  000F  CALL	R3	2
-      0x500C0200,  //  0010  LDBOOL	R3	1	0
-      0x90021203,  //  0011  SETMBR	R0	K9	R3
-      0x500C0200,  //  0012  LDBOOL	R3	1	0
-      0x80040600,  //  0013  RET	1	R3
+    ( &(const binstruction[10]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x50080200,  //  0006  LDBOOL	R2	1	0
+      0x90020202,  //  0007  SETMBR	R0	K1	R2
+      0x50080200,  //  0008  LDBOOL	R2	1	0
+      0x80040400,  //  0009  RET	1	R2
     })
   )
 );
@@ -1541,43 +1293,20 @@ be_local_closure(Matter_IM_SubscribedHeartbeat_reached_timeout,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_SubscribedHeartbeat_status_ok_received,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    3,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20Matter_IM_SubscribedHeartbeat_X20status_ok_received_X20sub_X3D_X25i_X20exch_X3D_X25i),
-    /* K5   */  be_nested_str_weak(sub),
-    /* K6   */  be_nested_str_weak(subscription_id),
-    /* K7   */  be_nested_str_weak(resp),
-    /* K8   */  be_nested_str_weak(exchange_id),
-    /* K9   */  be_const_int(3),
-    }),
+    0,                          /* has constants */
+    NULL,                       /* no const */
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200105,  //  0005  GETMBR	R8	R0	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x88240107,  //  0007  GETMBR	R9	R0	K7
-      0x88241308,  //  0008  GETMBR	R9	R9	K8
-      0x7C140800,  //  0009  CALL	R5	4
-      0x58180009,  //  000A  LDCONST	R6	K9
-      0x7C0C0600,  //  000B  CALL	R3	3
-      0x500C0000,  //  000C  LDBOOL	R3	0	0
-      0x80040600,  //  000D  RET	1	R3
+    ( &(const binstruction[ 2]) {  /* code */
+      0x50080000,  //  0000  LDBOOL	R2	0	0
+      0x80040400,  //  0001  RET	1	R2
     })
   )
 );
@@ -1711,7 +1440,7 @@ be_local_closure(Matter_IM_SubscribeResponse_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_SubscribeResponse_status_ok_received,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1719,65 +1448,19 @@ be_local_closure(Matter_IM_SubscribeResponse_status_ok_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_SubscribeResponse_X20status_ok_received_X20sub_X3D_X25i_X20exch_X3D_X25i_X20ack_X3D_X25i_X20last_counter_X3D_X25i),
-    /* K5   */  be_nested_str_weak(sub),
-    /* K6   */  be_nested_str_weak(subscription_id),
-    /* K7   */  be_nested_str_weak(resp),
-    /* K8   */  be_nested_str_weak(exchange_id),
-    /* K9   */  be_nested_str_weak(ack_message_counter),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(last_counter),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3ESub_OK_X20_X20_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
-    /* K14  */  be_nested_str_weak(session),
-    /* K15  */  be_nested_str_weak(local_session_id),
-    /* K16  */  be_const_int(2),
-    /* K17  */  be_nested_str_weak(status_ok_received),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(status_ok_received),
     }),
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
-    ( &(const binstruction[36]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200105,  //  0005  GETMBR	R8	R0	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x88240107,  //  0007  GETMBR	R9	R0	K7
-      0x88241308,  //  0008  GETMBR	R9	R9	K8
-      0x88280309,  //  0009  GETMBR	R10	R1	K9
-      0x782A0001,  //  000A  JMPF	R10	#000D
-      0x88280309,  //  000B  GETMBR	R10	R1	K9
-      0x70020000,  //  000C  JMP		#000E
-      0x5828000A,  //  000D  LDCONST	R10	K10
-      0x882C010B,  //  000E  GETMBR	R11	R0	K11
-      0x7C140C00,  //  000F  CALL	R5	6
-      0x5818000C,  //  0010  LDCONST	R6	K12
-      0x7C0C0600,  //  0011  CALL	R3	3
-      0xB80E0200,  //  0012  GETNGBL	R3	K1
-      0x8C0C0702,  //  0013  GETMET	R3	R3	K2
-      0x8C140503,  //  0014  GETMET	R5	R2	K3
-      0x581C000D,  //  0015  LDCONST	R7	K13
-      0x8820030E,  //  0016  GETMBR	R8	R1	K14
-      0x8820110F,  //  0017  GETMBR	R8	R8	K15
-      0x88240105,  //  0018  GETMBR	R9	R0	K5
-      0x88241306,  //  0019  GETMBR	R9	R9	K6
-      0x7C140800,  //  001A  CALL	R5	4
-      0x58180010,  //  001B  LDCONST	R6	K16
-      0x7C0C0600,  //  001C  CALL	R3	3
-      0x600C0003,  //  001D  GETGBL	R3	G3
-      0x5C100000,  //  001E  MOVE	R4	R0
-      0x7C0C0200,  //  001F  CALL	R3	1
-      0x8C0C0711,  //  0020  GETMET	R3	R3	K17
-      0x5C140200,  //  0021  MOVE	R5	R1
-      0x7C0C0400,  //  0022  CALL	R3	2
-      0x80040600,  //  0023  RET	1	R3
+    ( &(const binstruction[ 7]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x80040400,  //  0006  RET	1	R2
     })
   )
 );
@@ -1789,7 +1472,7 @@ be_local_closure(Matter_IM_SubscribeResponse_status_ok_received,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_SubscribeResponse_send_im,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    8,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1797,117 +1480,83 @@ be_local_closure(Matter_IM_SubscribeResponse_send_im,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[28]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20Matter_IM_SubscribeResponse_X20send_X20sub_X3D_X25i_X20ready_X3D_X25i),
-    /* K5   */  be_nested_str_weak(sub),
-    /* K6   */  be_nested_str_weak(subscription_id),
-    /* K7   */  be_nested_str_weak(ready),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(report_data_phase),
-    /* K12  */  be_nested_str_weak(send_im),
-    /* K13  */  be_nested_str_weak(finish),
-    /* K14  */  be_nested_str_weak(resp),
-    /* K15  */  be_nested_str_weak(matter),
-    /* K16  */  be_nested_str_weak(SubscribeResponseMessage),
-    /* K17  */  be_nested_str_weak(max_interval),
-    /* K18  */  be_nested_str_weak(opcode),
-    /* K19  */  be_nested_str_weak(encode_frame),
-    /* K20  */  be_nested_str_weak(to_TLV),
-    /* K21  */  be_nested_str_weak(tlv2raw),
-    /* K22  */  be_nested_str_weak(encrypt),
-    /* K23  */  be_nested_str_weak(send_response_frame),
-    /* K24  */  be_nested_str_weak(last_counter),
-    /* K25  */  be_nested_str_weak(message_counter),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20Send_X20SubscribeResponseMessage_X20sub_X3D_X25i_X20id_X3D_X25i),
-    /* K27  */  be_nested_str_weak(re_arm),
+    ( &(const bvalue[19]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ready),
+    /* K1   */  be_nested_str_weak(report_data_phase),
+    /* K2   */  be_nested_str_weak(send_im),
+    /* K3   */  be_nested_str_weak(finish),
+    /* K4   */  be_nested_str_weak(resp),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(SubscribeResponseMessage),
+    /* K7   */  be_nested_str_weak(subscription_id),
+    /* K8   */  be_nested_str_weak(sub),
+    /* K9   */  be_nested_str_weak(max_interval),
+    /* K10  */  be_nested_str_weak(opcode),
+    /* K11  */  be_nested_str_weak(encode_frame),
+    /* K12  */  be_nested_str_weak(to_TLV),
+    /* K13  */  be_nested_str_weak(tlv2raw),
+    /* K14  */  be_nested_str_weak(encrypt),
+    /* K15  */  be_nested_str_weak(send_response_frame),
+    /* K16  */  be_nested_str_weak(last_counter),
+    /* K17  */  be_nested_str_weak(message_counter),
+    /* K18  */  be_nested_str_weak(re_arm),
     }),
     be_str_weak(send_im),
     &be_const_str_solidified,
-    ( &(const binstruction[78]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200105,  //  0005  GETMBR	R8	R0	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x88240107,  //  0007  GETMBR	R9	R0	K7
-      0x78260001,  //  0008  JMPF	R9	#000B
-      0x58240008,  //  0009  LDCONST	R9	K8
-      0x70020000,  //  000A  JMP		#000C
-      0x58240009,  //  000B  LDCONST	R9	K9
-      0x7C140800,  //  000C  CALL	R5	4
-      0x5818000A,  //  000D  LDCONST	R6	K10
-      0x7C0C0600,  //  000E  CALL	R3	3
-      0x880C0107,  //  000F  GETMBR	R3	R0	K7
-      0x740E0001,  //  0010  JMPT	R3	#0013
-      0x500C0000,  //  0011  LDBOOL	R3	0	0
-      0x80040600,  //  0012  RET	1	R3
-      0x880C010B,  //  0013  GETMBR	R3	R0	K11
-      0x780E000E,  //  0014  JMPF	R3	#0024
-      0x600C0003,  //  0015  GETGBL	R3	G3
-      0x5C100000,  //  0016  MOVE	R4	R0
-      0x7C0C0200,  //  0017  CALL	R3	1
-      0x8C0C070C,  //  0018  GETMET	R3	R3	K12
-      0x5C140200,  //  0019  MOVE	R5	R1
-      0x7C0C0400,  //  001A  CALL	R3	2
-      0x880C010D,  //  001B  GETMBR	R3	R0	K13
-      0x780E0003,  //  001C  JMPF	R3	#0021
-      0x500C0000,  //  001D  LDBOOL	R3	0	0
-      0x90021603,  //  001E  SETMBR	R0	K11	R3
-      0x500C0000,  //  001F  LDBOOL	R3	0	0
-      0x90021A03,  //  0020  SETMBR	R0	K13	R3
-      0x500C0000,  //  0021  LDBOOL	R3	0	0
-      0x90020E03,  //  0022  SETMBR	R0	K7	R3
-      0x70020028,  //  0023  JMP		#004D
-      0x880C010E,  //  0024  GETMBR	R3	R0	K14
-      0xB8121E00,  //  0025  GETNGBL	R4	K15
-      0x8C100910,  //  0026  GETMET	R4	R4	K16
-      0x7C100200,  //  0027  CALL	R4	1
-      0x88140105,  //  0028  GETMBR	R5	R0	K5
-      0x88140B06,  //  0029  GETMBR	R5	R5	K6
-      0x90120C05,  //  002A  SETMBR	R4	K6	R5
-      0x88140105,  //  002B  GETMBR	R5	R0	K5
-      0x88140B11,  //  002C  GETMBR	R5	R5	K17
-      0x90122205,  //  002D  SETMBR	R4	K17	R5
-      0x8814010E,  //  002E  GETMBR	R5	R0	K14
-      0x541A0003,  //  002F  LDINT	R6	4
-      0x90162406,  //  0030  SETMBR	R5	K18	R6
-      0x8C140713,  //  0031  GETMET	R5	R3	K19
-      0x8C1C0914,  //  0032  GETMET	R7	R4	K20
-      0x7C1C0200,  //  0033  CALL	R7	1
-      0x8C1C0F15,  //  0034  GETMET	R7	R7	K21
-      0x7C1C0200,  //  0035  CALL	R7	1
-      0x7C140400,  //  0036  CALL	R5	2
-      0x8C140716,  //  0037  GETMET	R5	R3	K22
-      0x7C140200,  //  0038  CALL	R5	1
-      0x8C140317,  //  0039  GETMET	R5	R1	K23
-      0x5C1C0600,  //  003A  MOVE	R7	R3
-      0x7C140400,  //  003B  CALL	R5	2
-      0x88140719,  //  003C  GETMBR	R5	R3	K25
-      0x90023005,  //  003D  SETMBR	R0	K24	R5
-      0xB8160200,  //  003E  GETNGBL	R5	K1
-      0x8C140B02,  //  003F  GETMET	R5	R5	K2
-      0x8C1C0503,  //  0040  GETMET	R7	R2	K3
-      0x5824001A,  //  0041  LDCONST	R9	K26
-      0x88280105,  //  0042  GETMBR	R10	R0	K5
-      0x88281506,  //  0043  GETMBR	R10	R10	K6
-      0x882C0719,  //  0044  GETMBR	R11	R3	K25
-      0x7C1C0800,  //  0045  CALL	R7	4
-      0x5820000A,  //  0046  LDCONST	R8	K10
-      0x7C140600,  //  0047  CALL	R5	3
-      0x88140105,  //  0048  GETMBR	R5	R0	K5
-      0x8C140B1B,  //  0049  GETMET	R5	R5	K27
-      0x7C140200,  //  004A  CALL	R5	1
-      0x50140200,  //  004B  LDBOOL	R5	1	0
-      0x90021A05,  //  004C  SETMBR	R0	K13	R5
-      0x80000000,  //  004D  RET	0
+    ( &(const binstruction[53]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x740A0001,  //  0001  JMPT	R2	#0004
+      0x50080000,  //  0002  LDBOOL	R2	0	0
+      0x80040400,  //  0003  RET	1	R2
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x780A000E,  //  0005  JMPF	R2	#0015
+      0x60080003,  //  0006  GETGBL	R2	G3
+      0x5C0C0000,  //  0007  MOVE	R3	R0
+      0x7C080200,  //  0008  CALL	R2	1
+      0x8C080502,  //  0009  GETMET	R2	R2	K2
+      0x5C100200,  //  000A  MOVE	R4	R1
+      0x7C080400,  //  000B  CALL	R2	2
+      0x88080103,  //  000C  GETMBR	R2	R0	K3
+      0x780A0003,  //  000D  JMPF	R2	#0012
+      0x50080000,  //  000E  LDBOOL	R2	0	0
+      0x90020202,  //  000F  SETMBR	R0	K1	R2
+      0x50080000,  //  0010  LDBOOL	R2	0	0
+      0x90020602,  //  0011  SETMBR	R0	K3	R2
+      0x50080000,  //  0012  LDBOOL	R2	0	0
+      0x90020002,  //  0013  SETMBR	R0	K0	R2
+      0x7002001E,  //  0014  JMP		#0034
+      0x88080104,  //  0015  GETMBR	R2	R0	K4
+      0xB80E0A00,  //  0016  GETNGBL	R3	K5
+      0x8C0C0706,  //  0017  GETMET	R3	R3	K6
+      0x7C0C0200,  //  0018  CALL	R3	1
+      0x88100108,  //  0019  GETMBR	R4	R0	K8
+      0x88100907,  //  001A  GETMBR	R4	R4	K7
+      0x900E0E04,  //  001B  SETMBR	R3	K7	R4
+      0x88100108,  //  001C  GETMBR	R4	R0	K8
+      0x88100909,  //  001D  GETMBR	R4	R4	K9
+      0x900E1204,  //  001E  SETMBR	R3	K9	R4
+      0x88100104,  //  001F  GETMBR	R4	R0	K4
+      0x54160003,  //  0020  LDINT	R5	4
+      0x90121405,  //  0021  SETMBR	R4	K10	R5
+      0x8C10050B,  //  0022  GETMET	R4	R2	K11
+      0x8C18070C,  //  0023  GETMET	R6	R3	K12
+      0x7C180200,  //  0024  CALL	R6	1
+      0x8C180D0D,  //  0025  GETMET	R6	R6	K13
+      0x7C180200,  //  0026  CALL	R6	1
+      0x7C100400,  //  0027  CALL	R4	2
+      0x8C10050E,  //  0028  GETMET	R4	R2	K14
+      0x7C100200,  //  0029  CALL	R4	1
+      0x8C10030F,  //  002A  GETMET	R4	R1	K15
+      0x5C180400,  //  002B  MOVE	R6	R2
+      0x7C100400,  //  002C  CALL	R4	2
+      0x88100511,  //  002D  GETMBR	R4	R2	K17
+      0x90022004,  //  002E  SETMBR	R0	K16	R4
+      0x88100108,  //  002F  GETMBR	R4	R0	K8
+      0x8C100912,  //  0030  GETMET	R4	R4	K18
+      0x7C100200,  //  0031  CALL	R4	1
+      0x50100200,  //  0032  LDBOOL	R4	1	0
+      0x90020604,  //  0033  SETMBR	R0	K3	R4
+      0x80000000,  //  0034  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
@@ -331,25 +331,25 @@ be_local_closure(Matter_Frame_debug,   /* name */
     be_str_weak(debug),
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
-      0x5C140200,  //  0003  MOVE	R5	R1
-      0x7C080600,  //  0004  CALL	R2	3
-      0x8C0C0503,  //  0005  GETMET	R3	R2	K3
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0x8C0C0504,  //  0007  GETMET	R3	R2	K4
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0xB80E0A00,  //  0009  GETNGBL	R3	K5
-      0x8C0C0706,  //  000A  GETMET	R3	R3	K6
-      0xB8160000,  //  000B  GETNGBL	R5	K0
-      0x8C140B08,  //  000C  GETMET	R5	R5	K8
-      0x5C1C0400,  //  000D  MOVE	R7	R2
-      0x7C140400,  //  000E  CALL	R5	2
-      0x00160E05,  //  000F  ADD	R5	K7	R5
-      0x541A0003,  //  0010  LDINT	R6	4
-      0x7C0C0600,  //  0011  CALL	R3	3
-      0x80000000,  //  0012  RET	0
+      0x80000400,  //  0000  RET	0
+      0xB80A0000,  //  0001  GETNGBL	R2	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x88100102,  //  0003  GETMBR	R4	R0	K2
+      0x5C140200,  //  0004  MOVE	R5	R1
+      0x7C080600,  //  0005  CALL	R2	3
+      0x8C0C0503,  //  0006  GETMET	R3	R2	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x8C0C0504,  //  0008  GETMET	R3	R2	K4
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0xB80E0A00,  //  000A  GETNGBL	R3	K5
+      0x8C0C0706,  //  000B  GETMET	R3	R3	K6
+      0xB8160000,  //  000C  GETNGBL	R5	K0
+      0x8C140B08,  //  000D  GETMET	R5	R5	K8
+      0x5C1C0400,  //  000E  MOVE	R7	R2
+      0x7C140400,  //  000F  CALL	R5	2
+      0x00160E05,  //  0010  ADD	R5	K7	R5
+      0x541A0003,  //  0011  LDINT	R6	4
+      0x7C0C0600,  //  0012  CALL	R3	3
     })
   )
 );
@@ -1039,7 +1039,7 @@ be_local_closure(Matter_Frame_decrypt,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[37]) {     /* constants */
+    ( &(const bvalue[28]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(session),
     /* K2   */  be_nested_str_weak(raw),
@@ -1065,22 +1065,13 @@ be_local_closure(Matter_Frame_decrypt,   /* name */
     /* K22  */  be_nested_str_weak(source_node_id),
     /* K23  */  be_nested_str_weak(peer_node_id),
     /* K24  */  be_nested_str_weak(resize),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20i2r_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
-    /* K27  */  be_nested_str_weak(tohex),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20p_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
-    /* K29  */  be_nested_str_weak(MTR_X3A_X20a_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
-    /* K30  */  be_nested_str_weak(MTR_X3A_X20n_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
-    /* K31  */  be_nested_str_weak(MTR_X3A_X20mic_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
-    /* K32  */  be_nested_str_weak(AES_CCM),
-    /* K33  */  be_nested_str_weak(tag),
-    /* K34  */  be_nested_str_weak(MTR_X3A_X20cleartext_X20_X20_X20_X3D),
-    /* K35  */  be_nested_str_weak(MTR_X3A_X20tag_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
-    /* K36  */  be_nested_str_weak(MTR_X3A_X20rejected_X20packet_X20due_X20to_X20invalid_X20MIC),
+    /* K25  */  be_nested_str_weak(AES_CCM),
+    /* K26  */  be_nested_str_weak(tag),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20rejected_X20packet_X20due_X20to_X20invalid_X20MIC),
     }),
     be_str_weak(decrypt),
     &be_const_str_solidified,
-    ( &(const binstruction[170]) {  /* code */
+    ( &(const binstruction[106]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x88080101,  //  0001  GETMBR	R2	R0	K1
       0x880C0102,  //  0002  GETMBR	R3	R0	K2
@@ -1163,94 +1154,30 @@ be_local_closure(Matter_Frame_decrypt,   /* name */
       0x8C241118,  //  004F  GETMET	R9	R8	K24
       0x542E000C,  //  0050  LDINT	R11	13
       0x7C240400,  //  0051  CALL	R9	2
-      0xB8260C00,  //  0052  GETNGBL	R9	K6
-      0x8C241307,  //  0053  GETMET	R9	R9	K7
-      0x582C0019,  //  0054  LDCONST	R11	K25
-      0x54320003,  //  0055  LDINT	R12	4
-      0x7C240600,  //  0056  CALL	R9	3
-      0xB8260C00,  //  0057  GETNGBL	R9	K6
-      0x8C241307,  //  0058  GETMET	R9	R9	K7
-      0x8C2C0B1B,  //  0059  GETMET	R11	R5	K27
-      0x7C2C0200,  //  005A  CALL	R11	1
-      0x002E340B,  //  005B  ADD	R11	K26	R11
-      0x54320003,  //  005C  LDINT	R12	4
-      0x7C240600,  //  005D  CALL	R9	3
-      0xB8260C00,  //  005E  GETNGBL	R9	K6
-      0x8C241307,  //  005F  GETMET	R9	R9	K7
-      0x8C2C0F1B,  //  0060  GETMET	R11	R7	K27
-      0x7C2C0200,  //  0061  CALL	R11	1
-      0x002E380B,  //  0062  ADD	R11	K28	R11
-      0x54320003,  //  0063  LDINT	R12	4
-      0x7C240600,  //  0064  CALL	R9	3
-      0xB8260C00,  //  0065  GETNGBL	R9	K6
-      0x8C241307,  //  0066  GETMET	R9	R9	K7
-      0x8C2C0D1B,  //  0067  GETMET	R11	R6	K27
-      0x7C2C0200,  //  0068  CALL	R11	1
-      0x002E3A0B,  //  0069  ADD	R11	K29	R11
-      0x54320003,  //  006A  LDINT	R12	4
-      0x7C240600,  //  006B  CALL	R9	3
-      0xB8260C00,  //  006C  GETNGBL	R9	K6
-      0x8C241307,  //  006D  GETMET	R9	R9	K7
-      0x8C2C111B,  //  006E  GETMET	R11	R8	K27
-      0x7C2C0200,  //  006F  CALL	R11	1
-      0x002E3C0B,  //  0070  ADD	R11	K30	R11
-      0x54320003,  //  0071  LDINT	R12	4
-      0x7C240600,  //  0072  CALL	R9	3
-      0xB8260C00,  //  0073  GETNGBL	R9	K6
-      0x8C241307,  //  0074  GETMET	R9	R9	K7
-      0x8C2C091B,  //  0075  GETMET	R11	R4	K27
-      0x7C2C0200,  //  0076  CALL	R11	1
-      0x002E3E0B,  //  0077  ADD	R11	K31	R11
-      0x54320003,  //  0078  LDINT	R12	4
-      0x7C240600,  //  0079  CALL	R9	3
-      0x8C240320,  //  007A  GETMET	R9	R1	K32
-      0x5C2C0A00,  //  007B  MOVE	R11	R5
-      0x5C301000,  //  007C  MOVE	R12	R8
-      0x5C340C00,  //  007D  MOVE	R13	R6
-      0x6038000C,  //  007E  GETGBL	R14	G12
-      0x5C3C0E00,  //  007F  MOVE	R15	R7
-      0x7C380200,  //  0080  CALL	R14	1
-      0x543E000F,  //  0081  LDINT	R15	16
-      0x7C240C00,  //  0082  CALL	R9	6
-      0x8C281310,  //  0083  GETMET	R10	R9	K16
-      0x5C300E00,  //  0084  MOVE	R12	R7
-      0x7C280400,  //  0085  CALL	R10	2
-      0x8C2C1321,  //  0086  GETMET	R11	R9	K33
-      0x7C2C0200,  //  0087  CALL	R11	1
-      0xB8320C00,  //  0088  GETNGBL	R12	K6
-      0x8C301907,  //  0089  GETMET	R12	R12	K7
-      0x58380019,  //  008A  LDCONST	R14	K25
-      0x543E0003,  //  008B  LDINT	R15	4
-      0x7C300600,  //  008C  CALL	R12	3
-      0xB8320C00,  //  008D  GETNGBL	R12	K6
-      0x8C301907,  //  008E  GETMET	R12	R12	K7
-      0x8C38151B,  //  008F  GETMET	R14	R10	K27
-      0x7C380200,  //  0090  CALL	R14	1
-      0x003A440E,  //  0091  ADD	R14	K34	R14
-      0x543E0003,  //  0092  LDINT	R15	4
-      0x7C300600,  //  0093  CALL	R12	3
-      0xB8320C00,  //  0094  GETNGBL	R12	K6
-      0x8C301907,  //  0095  GETMET	R12	R12	K7
-      0x8C38171B,  //  0096  GETMET	R14	R11	K27
-      0x7C380200,  //  0097  CALL	R14	1
-      0x003A460E,  //  0098  ADD	R14	K35	R14
-      0x543E0003,  //  0099  LDINT	R15	4
-      0x7C300600,  //  009A  CALL	R12	3
-      0xB8320C00,  //  009B  GETNGBL	R12	K6
-      0x8C301907,  //  009C  GETMET	R12	R12	K7
-      0x58380019,  //  009D  LDCONST	R14	K25
-      0x543E0003,  //  009E  LDINT	R15	4
-      0x7C300600,  //  009F  CALL	R12	3
-      0x20301604,  //  00A0  NE	R12	R11	R4
-      0x78320006,  //  00A1  JMPF	R12	#00A9
-      0xB8320C00,  //  00A2  GETNGBL	R12	K6
-      0x8C301907,  //  00A3  GETMET	R12	R12	K7
-      0x58380024,  //  00A4  LDCONST	R14	K36
-      0x583C0009,  //  00A5  LDCONST	R15	K9
-      0x7C300600,  //  00A6  CALL	R12	3
-      0x4C300000,  //  00A7  LDNIL	R12
-      0x80041800,  //  00A8  RET	1	R12
-      0x80041400,  //  00A9  RET	1	R10
+      0x8C240319,  //  0052  GETMET	R9	R1	K25
+      0x5C2C0A00,  //  0053  MOVE	R11	R5
+      0x5C301000,  //  0054  MOVE	R12	R8
+      0x5C340C00,  //  0055  MOVE	R13	R6
+      0x6038000C,  //  0056  GETGBL	R14	G12
+      0x5C3C0E00,  //  0057  MOVE	R15	R7
+      0x7C380200,  //  0058  CALL	R14	1
+      0x543E000F,  //  0059  LDINT	R15	16
+      0x7C240C00,  //  005A  CALL	R9	6
+      0x8C281310,  //  005B  GETMET	R10	R9	K16
+      0x5C300E00,  //  005C  MOVE	R12	R7
+      0x7C280400,  //  005D  CALL	R10	2
+      0x8C2C131A,  //  005E  GETMET	R11	R9	K26
+      0x7C2C0200,  //  005F  CALL	R11	1
+      0x20301604,  //  0060  NE	R12	R11	R4
+      0x78320006,  //  0061  JMPF	R12	#0069
+      0xB8320C00,  //  0062  GETNGBL	R12	K6
+      0x8C301907,  //  0063  GETMET	R12	R12	K7
+      0x5838001B,  //  0064  LDCONST	R14	K27
+      0x583C0009,  //  0065  LDCONST	R15	K9
+      0x7C300600,  //  0066  CALL	R12	3
+      0x4C300000,  //  0067  LDNIL	R12
+      0x80041800,  //  0068  RET	1	R12
+      0x80041400,  //  0069  RET	1	R10
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
@@ -221,7 +221,7 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[75]) {     /* constants */
+    ( &(const bvalue[74]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(Frame),
@@ -238,30 +238,30 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
     /* K13  */  be_nested_str_weak(MTR_X3A_X20find_X20session_X20by_X20source_node_id_X20_X3D_X20),
     /* K14  */  be_nested_str_weak(_X20session_id_X20_X3D_X20),
     /* K15  */  be_nested_str_weak(local_session_id),
-    /* K16  */  be_const_int(2),
-    /* K17  */  be_nested_str_weak(control_message),
-    /* K18  */  be_nested_str_weak(process_incoming_control_message),
-    /* K19  */  be_const_int(0),
-    /* K20  */  be_nested_str_weak(sec_sesstype),
-    /* K21  */  be_const_int(3),
-    /* K22  */  be_nested_str_weak(_ip),
-    /* K23  */  be_nested_str_weak(_port),
-    /* K24  */  be_nested_str_weak(_message_handler),
-    /* K25  */  be_nested_str_weak(session),
-    /* K26  */  be_nested_str_weak(_counter_insecure_rcv),
-    /* K27  */  be_nested_str_weak(validate),
-    /* K28  */  be_nested_str_weak(message_counter),
-    /* K29  */  be_nested_str_weak(format),
-    /* K30  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Duplicate_X20unencrypted_X20message_X20_X3D_X20_X25i_X20ref_X20_X3D_X20_X25i),
-    /* K31  */  be_nested_str_weak(val),
-    /* K32  */  be_nested_str_weak(send_simple_ack),
-    /* K33  */  be_nested_str_weak(decode_payload),
-    /* K34  */  be_nested_str_weak(received_ack),
-    /* K35  */  be_nested_str_weak(opcode),
-    /* K36  */  be_nested_str_weak(get_opcode_name),
-    /* K37  */  be_nested_str_weak(0x_X2502X),
-    /* K38  */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20_X28_X256i_X29_X20_X25s_X20rid_X3D_X25i_X20exch_X3D_X25i_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K39  */  be_nested_str_weak(exchange_id),
+    /* K16  */  be_nested_str_weak(control_message),
+    /* K17  */  be_nested_str_weak(process_incoming_control_message),
+    /* K18  */  be_const_int(0),
+    /* K19  */  be_nested_str_weak(sec_sesstype),
+    /* K20  */  be_nested_str_weak(_ip),
+    /* K21  */  be_nested_str_weak(_port),
+    /* K22  */  be_nested_str_weak(_message_handler),
+    /* K23  */  be_nested_str_weak(session),
+    /* K24  */  be_nested_str_weak(_counter_insecure_rcv),
+    /* K25  */  be_nested_str_weak(validate),
+    /* K26  */  be_nested_str_weak(message_counter),
+    /* K27  */  be_nested_str_weak(format),
+    /* K28  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Duplicate_X20unencrypted_X20message_X20_X3D_X20_X25i_X20ref_X20_X3D_X20_X25i),
+    /* K29  */  be_nested_str_weak(val),
+    /* K30  */  be_const_int(3),
+    /* K31  */  be_nested_str_weak(send_simple_ack),
+    /* K32  */  be_nested_str_weak(decode_payload),
+    /* K33  */  be_nested_str_weak(received_ack),
+    /* K34  */  be_nested_str_weak(opcode),
+    /* K35  */  be_nested_str_weak(get_opcode_name),
+    /* K36  */  be_nested_str_weak(0x_X2502X),
+    /* K37  */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20_X28_X256i_X29_X20_X25s_X20rid_X3D_X25i_X20exch_X3D_X25i_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K38  */  be_nested_str_weak(exchange_id),
+    /* K39  */  be_const_int(2),
     /* K40  */  be_nested_str_weak(MTR_X3A_X20_X3Ercv_X20Ack_X20_X20_X20_X28_X256i_X29_X20rid_X3D_X25i_X20exch_X3D_X25i_X20ack_X3D_X25s_X20_X25sfrom_X20_X5B_X25s_X5D_X3A_X25i),
     /* K41  */  be_nested_str_weak(x_flag_r),
     /* K42  */  be_nested_str_weak(_X7Breliable_X7D_X20),
@@ -288,22 +288,21 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
     /* K63  */  be_nested_str_weak(_X20opcode_X3D),
     /* K64  */  be_nested_str_weak(_X20exchange_id_X3D),
     /* K65  */  be_nested_str_weak(MTR_X3A_X20_X3Ercv_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20_X5B_X2502X_X2F_X2502X_X5D_X20rid_X3D_X25i_X20exch_X3D_X25i_X20ack_X3D_X25s_X20_X25sfrom_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K66  */  be_nested_str_weak(MTR_X3A_X20PROTOCOL_ID_SECURE_CHANNEL_X20),
-    /* K67  */  be_nested_str_weak(im),
-    /* K68  */  be_nested_str_weak(process_incoming_ack),
-    /* K69  */  be_nested_str_weak(send_enqueued),
-    /* K70  */  be_nested_str_weak(MTR_X3A_X20ignoring_X20unhandled_X20protocol_id_X3A),
-    /* K71  */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20exception_X3A_X20),
-    /* K72  */  be_nested_str_weak(_X3B),
-    /* K73  */  be_nested_str_weak(debug),
-    /* K74  */  be_nested_str_weak(traceback),
+    /* K66  */  be_nested_str_weak(im),
+    /* K67  */  be_nested_str_weak(process_incoming_ack),
+    /* K68  */  be_nested_str_weak(send_enqueued),
+    /* K69  */  be_nested_str_weak(MTR_X3A_X20ignoring_X20unhandled_X20protocol_id_X3A),
+    /* K70  */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20exception_X3A_X20),
+    /* K71  */  be_nested_str_weak(_X3B),
+    /* K72  */  be_nested_str_weak(debug),
+    /* K73  */  be_nested_str_weak(traceback),
     }),
     be_str_weak(msg_received),
     &be_const_str_solidified,
-    ( &(const binstruction[396]) {  /* code */
+    ( &(const binstruction[388]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0x50140000,  //  0001  LDBOOL	R5	0	0
-      0xA8020172,  //  0002  EXBLK	0	#0176
+      0xA802016A,  //  0002  EXBLK	0	#016E
       0xB81A0200,  //  0003  GETNGBL	R6	K1
       0x8C180D02,  //  0004  GETMET	R6	R6	K2
       0x5C200000,  //  0005  MOVE	R8	R0
@@ -319,7 +318,7 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
       0xA8040001,  //  000F  EXBLK	1	1
       0x80041000,  //  0010  RET	1	R8
       0x88200D04,  //  0011  GETMBR	R8	R6	K4
-      0x78220021,  //  0012  JMPF	R8	#0035
+      0x78220022,  //  0012  JMPF	R8	#0036
       0xB8220A00,  //  0013  GETNGBL	R8	K5
       0x8C201106,  //  0014  GETMET	R8	R8	K6
       0xB82A0200,  //  0015  GETNGBL	R10	K1
@@ -327,376 +326,368 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
       0x5C300C00,  //  0017  MOVE	R12	R6
       0x7C280400,  //  0018  CALL	R10	2
       0x002A0E0A,  //  0019  ADD	R10	K7	R10
-      0x7C200400,  //  001A  CALL	R8	2
-      0x88200109,  //  001B  GETMBR	R8	R0	K9
-      0x8820110A,  //  001C  GETMBR	R8	R8	K10
-      0x8C20110B,  //  001D  GETMET	R8	R8	K11
-      0x88280D0C,  //  001E  GETMBR	R10	R6	K12
-      0x542E0059,  //  001F  LDINT	R11	90
-      0x7C200600,  //  0020  CALL	R8	3
-      0xB8260A00,  //  0021  GETNGBL	R9	K5
-      0x8C241306,  //  0022  GETMET	R9	R9	K6
-      0x602C0008,  //  0023  GETGBL	R11	G8
-      0x88300D0C,  //  0024  GETMBR	R12	R6	K12
-      0x7C2C0200,  //  0025  CALL	R11	1
-      0x002E1A0B,  //  0026  ADD	R11	K13	R11
-      0x002C170E,  //  0027  ADD	R11	R11	K14
-      0x60300008,  //  0028  GETGBL	R12	G8
-      0x8834110F,  //  0029  GETMBR	R13	R8	K15
-      0x7C300200,  //  002A  CALL	R12	1
-      0x002C160C,  //  002B  ADD	R11	R11	R12
-      0x58300010,  //  002C  LDCONST	R12	K16
-      0x7C240600,  //  002D  CALL	R9	3
-      0x88240111,  //  002E  GETMBR	R9	R0	K17
-      0x8C241312,  //  002F  GETMET	R9	R9	K18
-      0x5C2C0C00,  //  0030  MOVE	R11	R6
-      0x7C240400,  //  0031  CALL	R9	2
-      0xA8040001,  //  0032  EXBLK	1	1
-      0x80041200,  //  0033  RET	1	R9
-      0x7002013C,  //  0034  JMP		#0172
-      0x88200D0F,  //  0035  GETMBR	R8	R6	K15
-      0x1C201113,  //  0036  EQ	R8	R8	K19
-      0x7822007D,  //  0037  JMPF	R8	#00B6
-      0x88200D14,  //  0038  GETMBR	R8	R6	K20
-      0x1C201113,  //  0039  EQ	R8	R8	K19
-      0x7822007A,  //  003A  JMPF	R8	#00B6
-      0x88200109,  //  003B  GETMBR	R8	R0	K9
-      0x8820110A,  //  003C  GETMBR	R8	R8	K10
-      0x8C20110B,  //  003D  GETMET	R8	R8	K11
-      0x88280D0C,  //  003E  GETMBR	R10	R6	K12
-      0x542E0059,  //  003F  LDINT	R11	90
-      0x7C200600,  //  0040  CALL	R8	3
-      0xB8260A00,  //  0041  GETNGBL	R9	K5
-      0x8C241306,  //  0042  GETMET	R9	R9	K6
-      0x602C0008,  //  0043  GETGBL	R11	G8
-      0x88300D0C,  //  0044  GETMBR	R12	R6	K12
-      0x7C2C0200,  //  0045  CALL	R11	1
-      0x002E1A0B,  //  0046  ADD	R11	K13	R11
-      0x002C170E,  //  0047  ADD	R11	R11	K14
-      0x60300008,  //  0048  GETGBL	R12	G8
-      0x8834110F,  //  0049  GETMBR	R13	R8	K15
-      0x7C300200,  //  004A  CALL	R12	1
-      0x002C160C,  //  004B  ADD	R11	R11	R12
-      0x58300015,  //  004C  LDCONST	R12	K21
-      0x7C240600,  //  004D  CALL	R9	3
-      0x780A0000,  //  004E  JMPF	R2	#0050
-      0x90222C02,  //  004F  SETMBR	R8	K22	R2
-      0x780E0000,  //  0050  JMPF	R3	#0052
-      0x90222E03,  //  0051  SETMBR	R8	K23	R3
-      0x90223000,  //  0052  SETMBR	R8	K24	R0
-      0x901A3208,  //  0053  SETMBR	R6	K25	R8
-      0x8824111A,  //  0054  GETMBR	R9	R8	K26
-      0x8C24131B,  //  0055  GETMET	R9	R9	K27
-      0x882C0D1C,  //  0056  GETMBR	R11	R6	K28
-      0x50300000,  //  0057  LDBOOL	R12	0	0
-      0x7C240600,  //  0058  CALL	R9	3
-      0x74260011,  //  0059  JMPT	R9	#006C
-      0xB8260A00,  //  005A  GETNGBL	R9	K5
-      0x8C241306,  //  005B  GETMET	R9	R9	K6
-      0x8C2C091D,  //  005C  GETMET	R11	R4	K29
-      0x5834001E,  //  005D  LDCONST	R13	K30
-      0x88380D1C,  //  005E  GETMBR	R14	R6	K28
-      0x883C111A,  //  005F  GETMBR	R15	R8	K26
-      0x8C3C1F1F,  //  0060  GETMET	R15	R15	K31
-      0x7C3C0200,  //  0061  CALL	R15	1
-      0x7C2C0800,  //  0062  CALL	R11	4
-      0x58300015,  //  0063  LDCONST	R12	K21
-      0x7C240600,  //  0064  CALL	R9	3
-      0x8C240120,  //  0065  GETMET	R9	R0	K32
-      0x5C2C0C00,  //  0066  MOVE	R11	R6
-      0x50300000,  //  0067  LDBOOL	R12	0	0
-      0x7C240600,  //  0068  CALL	R9	3
-      0x50240000,  //  0069  LDBOOL	R9	0	0
-      0xA8040001,  //  006A  EXBLK	1	1
-      0x80041200,  //  006B  RET	1	R9
-      0x8C240D21,  //  006C  GETMET	R9	R6	K33
-      0x7C240200,  //  006D  CALL	R9	1
-      0x74260002,  //  006E  JMPT	R9	#0072
-      0x50240000,  //  006F  LDBOOL	R9	0	0
-      0xA8040001,  //  0070  EXBLK	1	1
-      0x80041200,  //  0071  RET	1	R9
-      0x88240109,  //  0072  GETMBR	R9	R0	K9
-      0x8C241322,  //  0073  GETMET	R9	R9	K34
-      0x5C2C0C00,  //  0074  MOVE	R11	R6
-      0x7C240400,  //  0075  CALL	R9	2
-      0x88240D23,  //  0076  GETMBR	R9	R6	K35
-      0x542A000F,  //  0077  LDINT	R10	16
-      0x2024120A,  //  0078  NE	R9	R9	R10
-      0x78260018,  //  0079  JMPF	R9	#0093
-      0xB8260200,  //  007A  GETNGBL	R9	K1
-      0x8C241324,  //  007B  GETMET	R9	R9	K36
-      0x882C0D23,  //  007C  GETMBR	R11	R6	K35
-      0x7C240400,  //  007D  CALL	R9	2
-      0x5C281200,  //  007E  MOVE	R10	R9
-      0x742A0004,  //  007F  JMPT	R10	#0085
-      0x8C28091D,  //  0080  GETMET	R10	R4	K29
-      0x58300025,  //  0081  LDCONST	R12	K37
-      0x88340D23,  //  0082  GETMBR	R13	R6	K35
-      0x7C280600,  //  0083  CALL	R10	3
-      0x5C241400,  //  0084  MOVE	R9	R10
-      0xB82A0A00,  //  0085  GETNGBL	R10	K5
-      0x8C281506,  //  0086  GETMET	R10	R10	K6
-      0x8C30091D,  //  0087  GETMET	R12	R4	K29
-      0x58380026,  //  0088  LDCONST	R14	K38
-      0x883C110F,  //  0089  GETMBR	R15	R8	K15
-      0x5C401200,  //  008A  MOVE	R16	R9
-      0x88440D1C,  //  008B  GETMBR	R17	R6	K28
-      0x88480D27,  //  008C  GETMBR	R18	R6	K39
-      0x5C4C0400,  //  008D  MOVE	R19	R2
-      0x5C500600,  //  008E  MOVE	R20	R3
-      0x7C301000,  //  008F  CALL	R12	8
-      0x58340010,  //  0090  LDCONST	R13	K16
-      0x7C280600,  //  0091  CALL	R10	3
-      0x70020013,  //  0092  JMP		#00A7
-      0xB8260A00,  //  0093  GETNGBL	R9	K5
-      0x8C241306,  //  0094  GETMET	R9	R9	K6
-      0x8C2C091D,  //  0095  GETMET	R11	R4	K29
-      0x58340028,  //  0096  LDCONST	R13	K40
-      0x8838110F,  //  0097  GETMBR	R14	R8	K15
-      0x883C0D1C,  //  0098  GETMBR	R15	R6	K28
-      0x88400D29,  //  0099  GETMBR	R16	R6	K41
-      0x78420001,  //  009A  JMPF	R16	#009D
-      0x5840002A,  //  009B  LDCONST	R16	K42
-      0x70020000,  //  009C  JMP		#009E
-      0x5840002B,  //  009D  LDCONST	R16	K43
-      0x88440D27,  //  009E  GETMBR	R17	R6	K39
-      0x60480008,  //  009F  GETGBL	R18	G8
-      0x884C0D2C,  //  00A0  GETMBR	R19	R6	K44
-      0x7C480200,  //  00A1  CALL	R18	1
-      0x5C4C0400,  //  00A2  MOVE	R19	R2
-      0x5C500600,  //  00A3  MOVE	R20	R3
-      0x7C2C1200,  //  00A4  CALL	R11	9
-      0x58300015,  //  00A5  LDCONST	R12	K21
-      0x7C240600,  //  00A6  CALL	R9	3
-      0x8824012D,  //  00A7  GETMBR	R9	R0	K45
-      0x8C24132E,  //  00A8  GETMET	R9	R9	K46
-      0x5C2C0C00,  //  00A9  MOVE	R11	R6
-      0x7C240400,  //  00AA  CALL	R9	2
-      0x5C141200,  //  00AB  MOVE	R5	R9
-      0x5C240A00,  //  00AC  MOVE	R9	R5
-      0x74260003,  //  00AD  JMPT	R9	#00B2
-      0x8C240120,  //  00AE  GETMET	R9	R0	K32
-      0x5C2C0C00,  //  00AF  MOVE	R11	R6
-      0x50300000,  //  00B0  LDBOOL	R12	0	0
-      0x7C240600,  //  00B1  CALL	R9	3
-      0x50240200,  //  00B2  LDBOOL	R9	1	0
-      0xA8040001,  //  00B3  EXBLK	1	1
-      0x80041200,  //  00B4  RET	1	R9
-      0x700200BB,  //  00B5  JMP		#0172
-      0xB8220A00,  //  00B6  GETNGBL	R8	K5
-      0x8C201106,  //  00B7  GETMET	R8	R8	K6
-      0x8C28091D,  //  00B8  GETMET	R10	R4	K29
-      0x5830002F,  //  00B9  LDCONST	R12	K47
-      0x88340D0F,  //  00BA  GETMBR	R13	R6	K15
-      0x88380D1C,  //  00BB  GETMBR	R14	R6	K28
-      0x7C280800,  //  00BC  CALL	R10	4
-      0x582C0015,  //  00BD  LDCONST	R11	K21
-      0x7C200600,  //  00BE  CALL	R8	3
-      0x88200109,  //  00BF  GETMBR	R8	R0	K9
-      0x8820110A,  //  00C0  GETMBR	R8	R8	K10
-      0x8C201130,  //  00C1  GETMET	R8	R8	K48
-      0x88280D0F,  //  00C2  GETMBR	R10	R6	K15
-      0x7C200400,  //  00C3  CALL	R8	2
-      0x4C240000,  //  00C4  LDNIL	R9
-      0x1C241009,  //  00C5  EQ	R9	R8	R9
-      0x7826000A,  //  00C6  JMPF	R9	#00D2
-      0xB8260A00,  //  00C7  GETNGBL	R9	K5
-      0x8C241306,  //  00C8  GETMET	R9	R9	K6
-      0x602C0008,  //  00C9  GETGBL	R11	G8
-      0x88300D0F,  //  00CA  GETMBR	R12	R6	K15
-      0x7C2C0200,  //  00CB  CALL	R11	1
-      0x002E620B,  //  00CC  ADD	R11	K49	R11
-      0x58300010,  //  00CD  LDCONST	R12	K16
-      0x7C240600,  //  00CE  CALL	R9	3
-      0x50240000,  //  00CF  LDBOOL	R9	0	0
-      0xA8040001,  //  00D0  EXBLK	1	1
-      0x80041200,  //  00D1  RET	1	R9
-      0x780A0000,  //  00D2  JMPF	R2	#00D4
-      0x90222C02,  //  00D3  SETMBR	R8	K22	R2
-      0x780E0000,  //  00D4  JMPF	R3	#00D6
-      0x90222E03,  //  00D5  SETMBR	R8	K23	R3
-      0x90223000,  //  00D6  SETMBR	R8	K24	R0
-      0x901A3208,  //  00D7  SETMBR	R6	K25	R8
-      0x8C241132,  //  00D8  GETMET	R9	R8	K50
-      0x882C0D1C,  //  00D9  GETMBR	R11	R6	K28
-      0x50300200,  //  00DA  LDBOOL	R12	1	0
-      0x7C240600,  //  00DB  CALL	R9	3
-      0x74260013,  //  00DC  JMPT	R9	#00F1
-      0xB8260A00,  //  00DD  GETNGBL	R9	K5
-      0x8C241306,  //  00DE  GETMET	R9	R9	K6
-      0x602C0008,  //  00DF  GETGBL	R11	G8
-      0x88300D1C,  //  00E0  GETMBR	R12	R6	K28
-      0x7C2C0200,  //  00E1  CALL	R11	1
-      0x002E660B,  //  00E2  ADD	R11	K51	R11
-      0x002C1734,  //  00E3  ADD	R11	R11	K52
-      0x60300008,  //  00E4  GETGBL	R12	G8
-      0x88341135,  //  00E5  GETMBR	R13	R8	K53
-      0x7C300200,  //  00E6  CALL	R12	1
-      0x002C160C,  //  00E7  ADD	R11	R11	R12
-      0x58300015,  //  00E8  LDCONST	R12	K21
-      0x7C240600,  //  00E9  CALL	R9	3
-      0x8C240136,  //  00EA  GETMET	R9	R0	K54
-      0x5C2C0C00,  //  00EB  MOVE	R11	R6
-      0x50300000,  //  00EC  LDBOOL	R12	0	0
-      0x7C240600,  //  00ED  CALL	R9	3
-      0x50240000,  //  00EE  LDBOOL	R9	0	0
-      0xA8040001,  //  00EF  EXBLK	1	1
-      0x80041200,  //  00F0  RET	1	R9
-      0x8C240D37,  //  00F1  GETMET	R9	R6	K55
-      0x7C240200,  //  00F2  CALL	R9	1
-      0x5C281200,  //  00F3  MOVE	R10	R9
-      0x742A0002,  //  00F4  JMPT	R10	#00F8
-      0x50280000,  //  00F5  LDBOOL	R10	0	0
-      0xA8040001,  //  00F6  EXBLK	1	1
-      0x80041400,  //  00F7  RET	1	R10
-      0x88280D39,  //  00F8  GETMBR	R10	R6	K57
-      0x0428153A,  //  00F9  SUB	R10	R10	K58
-      0x402A260A,  //  00FA  CONNECT	R10	K19	R10
-      0x882C0D38,  //  00FB  GETMBR	R11	R6	K56
-      0x9428160A,  //  00FC  GETIDX	R10	R11	R10
-      0x901A700A,  //  00FD  SETMBR	R6	K56	R10
-      0x88280D38,  //  00FE  GETMBR	R10	R6	K56
-      0x40281409,  //  00FF  CONNECT	R10	R10	R9
-      0xB82A0A00,  //  0100  GETNGBL	R10	K5
-      0x8C281506,  //  0101  GETMET	R10	R10	K6
-      0x8C30091D,  //  0102  GETMET	R12	R4	K29
-      0x5838003B,  //  0103  LDCONST	R14	K59
-      0x883C0D39,  //  0104  GETMBR	R15	R6	K57
-      0x88400D38,  //  0105  GETMBR	R16	R6	K56
-      0x8C40213C,  //  0106  GETMET	R16	R16	K60
-      0x7C400200,  //  0107  CALL	R16	1
-      0x7C300800,  //  0108  CALL	R12	4
-      0x54360003,  //  0109  LDINT	R13	4
-      0x7C280600,  //  010A  CALL	R10	3
-      0x8C280D21,  //  010B  GETMET	R10	R6	K33
-      0x7C280200,  //  010C  CALL	R10	1
-      0xB82A0A00,  //  010D  GETNGBL	R10	K5
-      0x8C281506,  //  010E  GETMET	R10	R10	K6
-      0x60300008,  //  010F  GETGBL	R12	G8
-      0x88340D3E,  //  0110  GETMBR	R13	R6	K62
-      0x7C300200,  //  0111  CALL	R12	1
-      0x00327A0C,  //  0112  ADD	R12	K61	R12
-      0x0030193F,  //  0113  ADD	R12	R12	K63
-      0x60340008,  //  0114  GETGBL	R13	G8
-      0x88380D23,  //  0115  GETMBR	R14	R6	K35
-      0x7C340200,  //  0116  CALL	R13	1
-      0x0030180D,  //  0117  ADD	R12	R12	R13
-      0x00301940,  //  0118  ADD	R12	R12	K64
-      0x60340008,  //  0119  GETGBL	R13	G8
-      0x88380D27,  //  011A  GETMBR	R14	R6	K39
-      0x543EFFFE,  //  011B  LDINT	R15	65535
-      0x2C381C0F,  //  011C  AND	R14	R14	R15
-      0x7C340200,  //  011D  CALL	R13	1
-      0x0030180D,  //  011E  ADD	R12	R12	R13
-      0x58340015,  //  011F  LDCONST	R13	K21
-      0x7C280600,  //  0120  CALL	R10	3
-      0xB82A0A00,  //  0121  GETNGBL	R10	K5
-      0x8C281506,  //  0122  GETMET	R10	R10	K6
-      0x8C30091D,  //  0123  GETMET	R12	R4	K29
-      0x58380041,  //  0124  LDCONST	R14	K65
-      0x883C110F,  //  0125  GETMBR	R15	R8	K15
-      0x88400D3E,  //  0126  GETMBR	R16	R6	K62
-      0x88440D23,  //  0127  GETMBR	R17	R6	K35
-      0x88480D1C,  //  0128  GETMBR	R18	R6	K28
-      0x884C0D27,  //  0129  GETMBR	R19	R6	K39
-      0x60500008,  //  012A  GETGBL	R20	G8
-      0x88540D2C,  //  012B  GETMBR	R21	R6	K44
-      0x7C500200,  //  012C  CALL	R20	1
-      0x88540D29,  //  012D  GETMBR	R21	R6	K41
-      0x78560001,  //  012E  JMPF	R21	#0131
-      0x5854002A,  //  012F  LDCONST	R21	K42
-      0x70020000,  //  0130  JMP		#0132
-      0x5854002B,  //  0131  LDCONST	R21	K43
-      0x5C580400,  //  0132  MOVE	R22	R2
-      0x5C5C0600,  //  0133  MOVE	R23	R3
-      0x7C301600,  //  0134  CALL	R12	11
-      0x58340015,  //  0135  LDCONST	R13	K21
-      0x7C280600,  //  0136  CALL	R10	3
-      0x88280109,  //  0137  GETMBR	R10	R0	K9
-      0x8C281522,  //  0138  GETMET	R10	R10	K34
-      0x5C300C00,  //  0139  MOVE	R12	R6
-      0x7C280400,  //  013A  CALL	R10	2
-      0x88280D3E,  //  013B  GETMBR	R10	R6	K62
-      0x1C2C1513,  //  013C  EQ	R11	R10	K19
-      0x782E0018,  //  013D  JMPF	R11	#0157
-      0xB82E0A00,  //  013E  GETNGBL	R11	K5
-      0x8C2C1706,  //  013F  GETMET	R11	R11	K6
-      0xB8360200,  //  0140  GETNGBL	R13	K1
-      0x8C341B08,  //  0141  GETMET	R13	R13	K8
-      0x5C3C0C00,  //  0142  MOVE	R15	R6
-      0x7C340400,  //  0143  CALL	R13	2
-      0x0036840D,  //  0144  ADD	R13	K66	R13
-      0x58380015,  //  0145  LDCONST	R14	K21
-      0x7C2C0600,  //  0146  CALL	R11	3
-      0x882C0D23,  //  0147  GETMBR	R11	R6	K35
-      0x5432000F,  //  0148  LDINT	R12	16
-      0x1C2C160C,  //  0149  EQ	R11	R11	R12
-      0x782E0009,  //  014A  JMPF	R11	#0155
-      0x882C0143,  //  014B  GETMBR	R11	R0	K67
-      0x8C2C1744,  //  014C  GETMET	R11	R11	K68
-      0x5C340C00,  //  014D  MOVE	R13	R6
-      0x7C2C0400,  //  014E  CALL	R11	2
-      0x5C141600,  //  014F  MOVE	R5	R11
-      0x78160003,  //  0150  JMPF	R5	#0155
-      0x882C0143,  //  0151  GETMBR	R11	R0	K67
-      0x8C2C1745,  //  0152  GETMET	R11	R11	K69
-      0x5C340000,  //  0153  MOVE	R13	R0
+      0x542E0003,  //  001A  LDINT	R11	4
+      0x7C200600,  //  001B  CALL	R8	3
+      0x88200109,  //  001C  GETMBR	R8	R0	K9
+      0x8820110A,  //  001D  GETMBR	R8	R8	K10
+      0x8C20110B,  //  001E  GETMET	R8	R8	K11
+      0x88280D0C,  //  001F  GETMBR	R10	R6	K12
+      0x542E0059,  //  0020  LDINT	R11	90
+      0x7C200600,  //  0021  CALL	R8	3
+      0xB8260A00,  //  0022  GETNGBL	R9	K5
+      0x8C241306,  //  0023  GETMET	R9	R9	K6
+      0x602C0008,  //  0024  GETGBL	R11	G8
+      0x88300D0C,  //  0025  GETMBR	R12	R6	K12
+      0x7C2C0200,  //  0026  CALL	R11	1
+      0x002E1A0B,  //  0027  ADD	R11	K13	R11
+      0x002C170E,  //  0028  ADD	R11	R11	K14
+      0x60300008,  //  0029  GETGBL	R12	G8
+      0x8834110F,  //  002A  GETMBR	R13	R8	K15
+      0x7C300200,  //  002B  CALL	R12	1
+      0x002C160C,  //  002C  ADD	R11	R11	R12
+      0x54320003,  //  002D  LDINT	R12	4
+      0x7C240600,  //  002E  CALL	R9	3
+      0x88240110,  //  002F  GETMBR	R9	R0	K16
+      0x8C241311,  //  0030  GETMET	R9	R9	K17
+      0x5C2C0C00,  //  0031  MOVE	R11	R6
+      0x7C240400,  //  0032  CALL	R9	2
+      0xA8040001,  //  0033  EXBLK	1	1
+      0x80041200,  //  0034  RET	1	R9
+      0x70020133,  //  0035  JMP		#016A
+      0x88200D0F,  //  0036  GETMBR	R8	R6	K15
+      0x1C201112,  //  0037  EQ	R8	R8	K18
+      0x7822007D,  //  0038  JMPF	R8	#00B7
+      0x88200D13,  //  0039  GETMBR	R8	R6	K19
+      0x1C201112,  //  003A  EQ	R8	R8	K18
+      0x7822007A,  //  003B  JMPF	R8	#00B7
+      0x88200109,  //  003C  GETMBR	R8	R0	K9
+      0x8820110A,  //  003D  GETMBR	R8	R8	K10
+      0x8C20110B,  //  003E  GETMET	R8	R8	K11
+      0x88280D0C,  //  003F  GETMBR	R10	R6	K12
+      0x542E0059,  //  0040  LDINT	R11	90
+      0x7C200600,  //  0041  CALL	R8	3
+      0xB8260A00,  //  0042  GETNGBL	R9	K5
+      0x8C241306,  //  0043  GETMET	R9	R9	K6
+      0x602C0008,  //  0044  GETGBL	R11	G8
+      0x88300D0C,  //  0045  GETMBR	R12	R6	K12
+      0x7C2C0200,  //  0046  CALL	R11	1
+      0x002E1A0B,  //  0047  ADD	R11	K13	R11
+      0x002C170E,  //  0048  ADD	R11	R11	K14
+      0x60300008,  //  0049  GETGBL	R12	G8
+      0x8834110F,  //  004A  GETMBR	R13	R8	K15
+      0x7C300200,  //  004B  CALL	R12	1
+      0x002C160C,  //  004C  ADD	R11	R11	R12
+      0x54320003,  //  004D  LDINT	R12	4
+      0x7C240600,  //  004E  CALL	R9	3
+      0x780A0000,  //  004F  JMPF	R2	#0051
+      0x90222802,  //  0050  SETMBR	R8	K20	R2
+      0x780E0000,  //  0051  JMPF	R3	#0053
+      0x90222A03,  //  0052  SETMBR	R8	K21	R3
+      0x90222C00,  //  0053  SETMBR	R8	K22	R0
+      0x901A2E08,  //  0054  SETMBR	R6	K23	R8
+      0x88241118,  //  0055  GETMBR	R9	R8	K24
+      0x8C241319,  //  0056  GETMET	R9	R9	K25
+      0x882C0D1A,  //  0057  GETMBR	R11	R6	K26
+      0x50300000,  //  0058  LDBOOL	R12	0	0
+      0x7C240600,  //  0059  CALL	R9	3
+      0x74260011,  //  005A  JMPT	R9	#006D
+      0xB8260A00,  //  005B  GETNGBL	R9	K5
+      0x8C241306,  //  005C  GETMET	R9	R9	K6
+      0x8C2C091B,  //  005D  GETMET	R11	R4	K27
+      0x5834001C,  //  005E  LDCONST	R13	K28
+      0x88380D1A,  //  005F  GETMBR	R14	R6	K26
+      0x883C1118,  //  0060  GETMBR	R15	R8	K24
+      0x8C3C1F1D,  //  0061  GETMET	R15	R15	K29
+      0x7C3C0200,  //  0062  CALL	R15	1
+      0x7C2C0800,  //  0063  CALL	R11	4
+      0x5830001E,  //  0064  LDCONST	R12	K30
+      0x7C240600,  //  0065  CALL	R9	3
+      0x8C24011F,  //  0066  GETMET	R9	R0	K31
+      0x5C2C0C00,  //  0067  MOVE	R11	R6
+      0x50300000,  //  0068  LDBOOL	R12	0	0
+      0x7C240600,  //  0069  CALL	R9	3
+      0x50240000,  //  006A  LDBOOL	R9	0	0
+      0xA8040001,  //  006B  EXBLK	1	1
+      0x80041200,  //  006C  RET	1	R9
+      0x8C240D20,  //  006D  GETMET	R9	R6	K32
+      0x7C240200,  //  006E  CALL	R9	1
+      0x74260002,  //  006F  JMPT	R9	#0073
+      0x50240000,  //  0070  LDBOOL	R9	0	0
+      0xA8040001,  //  0071  EXBLK	1	1
+      0x80041200,  //  0072  RET	1	R9
+      0x88240109,  //  0073  GETMBR	R9	R0	K9
+      0x8C241321,  //  0074  GETMET	R9	R9	K33
+      0x5C2C0C00,  //  0075  MOVE	R11	R6
+      0x7C240400,  //  0076  CALL	R9	2
+      0x88240D22,  //  0077  GETMBR	R9	R6	K34
+      0x542A000F,  //  0078  LDINT	R10	16
+      0x2024120A,  //  0079  NE	R9	R9	R10
+      0x78260018,  //  007A  JMPF	R9	#0094
+      0xB8260200,  //  007B  GETNGBL	R9	K1
+      0x8C241323,  //  007C  GETMET	R9	R9	K35
+      0x882C0D22,  //  007D  GETMBR	R11	R6	K34
+      0x7C240400,  //  007E  CALL	R9	2
+      0x5C281200,  //  007F  MOVE	R10	R9
+      0x742A0004,  //  0080  JMPT	R10	#0086
+      0x8C28091B,  //  0081  GETMET	R10	R4	K27
+      0x58300024,  //  0082  LDCONST	R12	K36
+      0x88340D22,  //  0083  GETMBR	R13	R6	K34
+      0x7C280600,  //  0084  CALL	R10	3
+      0x5C241400,  //  0085  MOVE	R9	R10
+      0xB82A0A00,  //  0086  GETNGBL	R10	K5
+      0x8C281506,  //  0087  GETMET	R10	R10	K6
+      0x8C30091B,  //  0088  GETMET	R12	R4	K27
+      0x58380025,  //  0089  LDCONST	R14	K37
+      0x883C110F,  //  008A  GETMBR	R15	R8	K15
+      0x5C401200,  //  008B  MOVE	R16	R9
+      0x88440D1A,  //  008C  GETMBR	R17	R6	K26
+      0x88480D26,  //  008D  GETMBR	R18	R6	K38
+      0x5C4C0400,  //  008E  MOVE	R19	R2
+      0x5C500600,  //  008F  MOVE	R20	R3
+      0x7C301000,  //  0090  CALL	R12	8
+      0x58340027,  //  0091  LDCONST	R13	K39
+      0x7C280600,  //  0092  CALL	R10	3
+      0x70020013,  //  0093  JMP		#00A8
+      0xB8260A00,  //  0094  GETNGBL	R9	K5
+      0x8C241306,  //  0095  GETMET	R9	R9	K6
+      0x8C2C091B,  //  0096  GETMET	R11	R4	K27
+      0x58340028,  //  0097  LDCONST	R13	K40
+      0x8838110F,  //  0098  GETMBR	R14	R8	K15
+      0x883C0D1A,  //  0099  GETMBR	R15	R6	K26
+      0x88400D29,  //  009A  GETMBR	R16	R6	K41
+      0x78420001,  //  009B  JMPF	R16	#009E
+      0x5840002A,  //  009C  LDCONST	R16	K42
+      0x70020000,  //  009D  JMP		#009F
+      0x5840002B,  //  009E  LDCONST	R16	K43
+      0x88440D26,  //  009F  GETMBR	R17	R6	K38
+      0x60480008,  //  00A0  GETGBL	R18	G8
+      0x884C0D2C,  //  00A1  GETMBR	R19	R6	K44
+      0x7C480200,  //  00A2  CALL	R18	1
+      0x5C4C0400,  //  00A3  MOVE	R19	R2
+      0x5C500600,  //  00A4  MOVE	R20	R3
+      0x7C2C1200,  //  00A5  CALL	R11	9
+      0x5830001E,  //  00A6  LDCONST	R12	K30
+      0x7C240600,  //  00A7  CALL	R9	3
+      0x8824012D,  //  00A8  GETMBR	R9	R0	K45
+      0x8C24132E,  //  00A9  GETMET	R9	R9	K46
+      0x5C2C0C00,  //  00AA  MOVE	R11	R6
+      0x7C240400,  //  00AB  CALL	R9	2
+      0x5C141200,  //  00AC  MOVE	R5	R9
+      0x5C240A00,  //  00AD  MOVE	R9	R5
+      0x74260003,  //  00AE  JMPT	R9	#00B3
+      0x8C24011F,  //  00AF  GETMET	R9	R0	K31
+      0x5C2C0C00,  //  00B0  MOVE	R11	R6
+      0x50300000,  //  00B1  LDBOOL	R12	0	0
+      0x7C240600,  //  00B2  CALL	R9	3
+      0x50240200,  //  00B3  LDBOOL	R9	1	0
+      0xA8040001,  //  00B4  EXBLK	1	1
+      0x80041200,  //  00B5  RET	1	R9
+      0x700200B2,  //  00B6  JMP		#016A
+      0xB8220A00,  //  00B7  GETNGBL	R8	K5
+      0x8C201106,  //  00B8  GETMET	R8	R8	K6
+      0x8C28091B,  //  00B9  GETMET	R10	R4	K27
+      0x5830002F,  //  00BA  LDCONST	R12	K47
+      0x88340D0F,  //  00BB  GETMBR	R13	R6	K15
+      0x88380D1A,  //  00BC  GETMBR	R14	R6	K26
+      0x7C280800,  //  00BD  CALL	R10	4
+      0x582C001E,  //  00BE  LDCONST	R11	K30
+      0x7C200600,  //  00BF  CALL	R8	3
+      0x88200109,  //  00C0  GETMBR	R8	R0	K9
+      0x8820110A,  //  00C1  GETMBR	R8	R8	K10
+      0x8C201130,  //  00C2  GETMET	R8	R8	K48
+      0x88280D0F,  //  00C3  GETMBR	R10	R6	K15
+      0x7C200400,  //  00C4  CALL	R8	2
+      0x4C240000,  //  00C5  LDNIL	R9
+      0x1C241009,  //  00C6  EQ	R9	R8	R9
+      0x7826000A,  //  00C7  JMPF	R9	#00D3
+      0xB8260A00,  //  00C8  GETNGBL	R9	K5
+      0x8C241306,  //  00C9  GETMET	R9	R9	K6
+      0x602C0008,  //  00CA  GETGBL	R11	G8
+      0x88300D0F,  //  00CB  GETMBR	R12	R6	K15
+      0x7C2C0200,  //  00CC  CALL	R11	1
+      0x002E620B,  //  00CD  ADD	R11	K49	R11
+      0x58300027,  //  00CE  LDCONST	R12	K39
+      0x7C240600,  //  00CF  CALL	R9	3
+      0x50240000,  //  00D0  LDBOOL	R9	0	0
+      0xA8040001,  //  00D1  EXBLK	1	1
+      0x80041200,  //  00D2  RET	1	R9
+      0x780A0000,  //  00D3  JMPF	R2	#00D5
+      0x90222802,  //  00D4  SETMBR	R8	K20	R2
+      0x780E0000,  //  00D5  JMPF	R3	#00D7
+      0x90222A03,  //  00D6  SETMBR	R8	K21	R3
+      0x90222C00,  //  00D7  SETMBR	R8	K22	R0
+      0x901A2E08,  //  00D8  SETMBR	R6	K23	R8
+      0x8C241132,  //  00D9  GETMET	R9	R8	K50
+      0x882C0D1A,  //  00DA  GETMBR	R11	R6	K26
+      0x50300200,  //  00DB  LDBOOL	R12	1	0
+      0x7C240600,  //  00DC  CALL	R9	3
+      0x74260013,  //  00DD  JMPT	R9	#00F2
+      0xB8260A00,  //  00DE  GETNGBL	R9	K5
+      0x8C241306,  //  00DF  GETMET	R9	R9	K6
+      0x602C0008,  //  00E0  GETGBL	R11	G8
+      0x88300D1A,  //  00E1  GETMBR	R12	R6	K26
+      0x7C2C0200,  //  00E2  CALL	R11	1
+      0x002E660B,  //  00E3  ADD	R11	K51	R11
+      0x002C1734,  //  00E4  ADD	R11	R11	K52
+      0x60300008,  //  00E5  GETGBL	R12	G8
+      0x88341135,  //  00E6  GETMBR	R13	R8	K53
+      0x7C300200,  //  00E7  CALL	R12	1
+      0x002C160C,  //  00E8  ADD	R11	R11	R12
+      0x5830001E,  //  00E9  LDCONST	R12	K30
+      0x7C240600,  //  00EA  CALL	R9	3
+      0x8C240136,  //  00EB  GETMET	R9	R0	K54
+      0x5C2C0C00,  //  00EC  MOVE	R11	R6
+      0x50300000,  //  00ED  LDBOOL	R12	0	0
+      0x7C240600,  //  00EE  CALL	R9	3
+      0x50240000,  //  00EF  LDBOOL	R9	0	0
+      0xA8040001,  //  00F0  EXBLK	1	1
+      0x80041200,  //  00F1  RET	1	R9
+      0x8C240D37,  //  00F2  GETMET	R9	R6	K55
+      0x7C240200,  //  00F3  CALL	R9	1
+      0x5C281200,  //  00F4  MOVE	R10	R9
+      0x742A0002,  //  00F5  JMPT	R10	#00F9
+      0x50280000,  //  00F6  LDBOOL	R10	0	0
+      0xA8040001,  //  00F7  EXBLK	1	1
+      0x80041400,  //  00F8  RET	1	R10
+      0x88280D39,  //  00F9  GETMBR	R10	R6	K57
+      0x0428153A,  //  00FA  SUB	R10	R10	K58
+      0x402A240A,  //  00FB  CONNECT	R10	K18	R10
+      0x882C0D38,  //  00FC  GETMBR	R11	R6	K56
+      0x9428160A,  //  00FD  GETIDX	R10	R11	R10
+      0x901A700A,  //  00FE  SETMBR	R6	K56	R10
+      0x88280D38,  //  00FF  GETMBR	R10	R6	K56
+      0x40281409,  //  0100  CONNECT	R10	R10	R9
+      0xB82A0A00,  //  0101  GETNGBL	R10	K5
+      0x8C281506,  //  0102  GETMET	R10	R10	K6
+      0x8C30091B,  //  0103  GETMET	R12	R4	K27
+      0x5838003B,  //  0104  LDCONST	R14	K59
+      0x883C0D39,  //  0105  GETMBR	R15	R6	K57
+      0x88400D38,  //  0106  GETMBR	R16	R6	K56
+      0x8C40213C,  //  0107  GETMET	R16	R16	K60
+      0x7C400200,  //  0108  CALL	R16	1
+      0x7C300800,  //  0109  CALL	R12	4
+      0x54360003,  //  010A  LDINT	R13	4
+      0x7C280600,  //  010B  CALL	R10	3
+      0x8C280D20,  //  010C  GETMET	R10	R6	K32
+      0x7C280200,  //  010D  CALL	R10	1
+      0xB82A0A00,  //  010E  GETNGBL	R10	K5
+      0x8C281506,  //  010F  GETMET	R10	R10	K6
+      0x60300008,  //  0110  GETGBL	R12	G8
+      0x88340D3E,  //  0111  GETMBR	R13	R6	K62
+      0x7C300200,  //  0112  CALL	R12	1
+      0x00327A0C,  //  0113  ADD	R12	K61	R12
+      0x0030193F,  //  0114  ADD	R12	R12	K63
+      0x60340008,  //  0115  GETGBL	R13	G8
+      0x88380D22,  //  0116  GETMBR	R14	R6	K34
+      0x7C340200,  //  0117  CALL	R13	1
+      0x0030180D,  //  0118  ADD	R12	R12	R13
+      0x00301940,  //  0119  ADD	R12	R12	K64
+      0x60340008,  //  011A  GETGBL	R13	G8
+      0x88380D26,  //  011B  GETMBR	R14	R6	K38
+      0x543EFFFE,  //  011C  LDINT	R15	65535
+      0x2C381C0F,  //  011D  AND	R14	R14	R15
+      0x7C340200,  //  011E  CALL	R13	1
+      0x0030180D,  //  011F  ADD	R12	R12	R13
+      0x5834001E,  //  0120  LDCONST	R13	K30
+      0x7C280600,  //  0121  CALL	R10	3
+      0xB82A0A00,  //  0122  GETNGBL	R10	K5
+      0x8C281506,  //  0123  GETMET	R10	R10	K6
+      0x8C30091B,  //  0124  GETMET	R12	R4	K27
+      0x58380041,  //  0125  LDCONST	R14	K65
+      0x883C110F,  //  0126  GETMBR	R15	R8	K15
+      0x88400D3E,  //  0127  GETMBR	R16	R6	K62
+      0x88440D22,  //  0128  GETMBR	R17	R6	K34
+      0x88480D1A,  //  0129  GETMBR	R18	R6	K26
+      0x884C0D26,  //  012A  GETMBR	R19	R6	K38
+      0x60500008,  //  012B  GETGBL	R20	G8
+      0x88540D2C,  //  012C  GETMBR	R21	R6	K44
+      0x7C500200,  //  012D  CALL	R20	1
+      0x88540D29,  //  012E  GETMBR	R21	R6	K41
+      0x78560001,  //  012F  JMPF	R21	#0132
+      0x5854002A,  //  0130  LDCONST	R21	K42
+      0x70020000,  //  0131  JMP		#0133
+      0x5854002B,  //  0132  LDCONST	R21	K43
+      0x5C580400,  //  0133  MOVE	R22	R2
+      0x5C5C0600,  //  0134  MOVE	R23	R3
+      0x7C301600,  //  0135  CALL	R12	11
+      0x5834001E,  //  0136  LDCONST	R13	K30
+      0x7C280600,  //  0137  CALL	R10	3
+      0x88280109,  //  0138  GETMBR	R10	R0	K9
+      0x8C281521,  //  0139  GETMET	R10	R10	K33
+      0x5C300C00,  //  013A  MOVE	R12	R6
+      0x7C280400,  //  013B  CALL	R10	2
+      0x88280D3E,  //  013C  GETMBR	R10	R6	K62
+      0x1C2C1512,  //  013D  EQ	R11	R10	K18
+      0x782E000F,  //  013E  JMPF	R11	#014F
+      0x882C0D22,  //  013F  GETMBR	R11	R6	K34
+      0x5432000F,  //  0140  LDINT	R12	16
+      0x1C2C160C,  //  0141  EQ	R11	R11	R12
+      0x782E0009,  //  0142  JMPF	R11	#014D
+      0x882C0142,  //  0143  GETMBR	R11	R0	K66
+      0x8C2C1743,  //  0144  GETMET	R11	R11	K67
+      0x5C340C00,  //  0145  MOVE	R13	R6
+      0x7C2C0400,  //  0146  CALL	R11	2
+      0x5C141600,  //  0147  MOVE	R5	R11
+      0x78160003,  //  0148  JMPF	R5	#014D
+      0x882C0142,  //  0149  GETMBR	R11	R0	K66
+      0x8C2C1744,  //  014A  GETMET	R11	R11	K68
+      0x5C340000,  //  014B  MOVE	R13	R0
+      0x7C2C0400,  //  014C  CALL	R11	2
+      0x50140200,  //  014D  LDBOOL	R5	1	0
+      0x7002001A,  //  014E  JMP		#016A
+      0x1C2C153A,  //  014F  EQ	R11	R10	K58
+      0x782E0010,  //  0150  JMPF	R11	#0162
+      0x882C0142,  //  0151  GETMBR	R11	R0	K66
+      0x8C2C172E,  //  0152  GETMET	R11	R11	K46
+      0x5C340C00,  //  0153  MOVE	R13	R6
       0x7C2C0400,  //  0154  CALL	R11	2
-      0x50140200,  //  0155  LDBOOL	R5	1	0
-      0x7002001A,  //  0156  JMP		#0172
-      0x1C2C153A,  //  0157  EQ	R11	R10	K58
-      0x782E0010,  //  0158  JMPF	R11	#016A
-      0x882C0143,  //  0159  GETMBR	R11	R0	K67
-      0x8C2C172E,  //  015A  GETMET	R11	R11	K46
-      0x5C340C00,  //  015B  MOVE	R13	R6
-      0x7C2C0400,  //  015C  CALL	R11	2
-      0x5C141600,  //  015D  MOVE	R5	R11
-      0x78160004,  //  015E  JMPF	R5	#0164
-      0x882C0143,  //  015F  GETMBR	R11	R0	K67
-      0x8C2C1745,  //  0160  GETMET	R11	R11	K69
-      0x5C340000,  //  0161  MOVE	R13	R0
-      0x7C2C0400,  //  0162  CALL	R11	2
-      0x70020003,  //  0163  JMP		#0168
-      0x8C2C0136,  //  0164  GETMET	R11	R0	K54
-      0x5C340C00,  //  0165  MOVE	R13	R6
-      0x50380200,  //  0166  LDBOOL	R14	1	0
-      0x7C2C0600,  //  0167  CALL	R11	3
-      0x50140200,  //  0168  LDBOOL	R5	1	0
-      0x70020007,  //  0169  JMP		#0172
-      0xB82E0A00,  //  016A  GETNGBL	R11	K5
-      0x8C2C1706,  //  016B  GETMET	R11	R11	K6
-      0x60340008,  //  016C  GETGBL	R13	G8
-      0x5C381400,  //  016D  MOVE	R14	R10
-      0x7C340200,  //  016E  CALL	R13	1
-      0x00368C0D,  //  016F  ADD	R13	K70	R13
-      0x58380015,  //  0170  LDCONST	R14	K21
-      0x7C2C0600,  //  0171  CALL	R11	3
-      0xA8040001,  //  0172  EXBLK	1	1
-      0x80040A00,  //  0173  RET	1	R5
-      0xA8040001,  //  0174  EXBLK	1	1
-      0x70020014,  //  0175  JMP		#018B
-      0xAC180002,  //  0176  CATCH	R6	0	2
-      0x70020011,  //  0177  JMP		#018A
-      0xB8220A00,  //  0178  GETNGBL	R8	K5
-      0x8C201106,  //  0179  GETMET	R8	R8	K6
-      0x60280008,  //  017A  GETGBL	R10	G8
-      0x5C2C0C00,  //  017B  MOVE	R11	R6
-      0x7C280200,  //  017C  CALL	R10	1
-      0x002A8E0A,  //  017D  ADD	R10	K71	R10
-      0x00281548,  //  017E  ADD	R10	R10	K72
-      0x602C0008,  //  017F  GETGBL	R11	G8
-      0x5C300E00,  //  0180  MOVE	R12	R7
-      0x7C2C0200,  //  0181  CALL	R11	1
-      0x0028140B,  //  0182  ADD	R10	R10	R11
-      0x7C200400,  //  0183  CALL	R8	2
-      0xA4229200,  //  0184  IMPORT	R8	K73
-      0x8C24114A,  //  0185  GETMET	R9	R8	K74
-      0x7C240200,  //  0186  CALL	R9	1
-      0x50240000,  //  0187  LDBOOL	R9	0	0
-      0x80041200,  //  0188  RET	1	R9
-      0x70020000,  //  0189  JMP		#018B
-      0xB0080000,  //  018A  RAISE	2	R0	R0
-      0x80000000,  //  018B  RET	0
+      0x5C141600,  //  0155  MOVE	R5	R11
+      0x78160004,  //  0156  JMPF	R5	#015C
+      0x882C0142,  //  0157  GETMBR	R11	R0	K66
+      0x8C2C1744,  //  0158  GETMET	R11	R11	K68
+      0x5C340000,  //  0159  MOVE	R13	R0
+      0x7C2C0400,  //  015A  CALL	R11	2
+      0x70020003,  //  015B  JMP		#0160
+      0x8C2C0136,  //  015C  GETMET	R11	R0	K54
+      0x5C340C00,  //  015D  MOVE	R13	R6
+      0x50380200,  //  015E  LDBOOL	R14	1	0
+      0x7C2C0600,  //  015F  CALL	R11	3
+      0x50140200,  //  0160  LDBOOL	R5	1	0
+      0x70020007,  //  0161  JMP		#016A
+      0xB82E0A00,  //  0162  GETNGBL	R11	K5
+      0x8C2C1706,  //  0163  GETMET	R11	R11	K6
+      0x60340008,  //  0164  GETGBL	R13	G8
+      0x5C381400,  //  0165  MOVE	R14	R10
+      0x7C340200,  //  0166  CALL	R13	1
+      0x00368A0D,  //  0167  ADD	R13	K69	R13
+      0x5838001E,  //  0168  LDCONST	R14	K30
+      0x7C2C0600,  //  0169  CALL	R11	3
+      0xA8040001,  //  016A  EXBLK	1	1
+      0x80040A00,  //  016B  RET	1	R5
+      0xA8040001,  //  016C  EXBLK	1	1
+      0x70020014,  //  016D  JMP		#0183
+      0xAC180002,  //  016E  CATCH	R6	0	2
+      0x70020011,  //  016F  JMP		#0182
+      0xB8220A00,  //  0170  GETNGBL	R8	K5
+      0x8C201106,  //  0171  GETMET	R8	R8	K6
+      0x60280008,  //  0172  GETGBL	R10	G8
+      0x5C2C0C00,  //  0173  MOVE	R11	R6
+      0x7C280200,  //  0174  CALL	R10	1
+      0x002A8C0A,  //  0175  ADD	R10	K70	R10
+      0x00281547,  //  0176  ADD	R10	R10	K71
+      0x602C0008,  //  0177  GETGBL	R11	G8
+      0x5C300E00,  //  0178  MOVE	R12	R7
+      0x7C2C0200,  //  0179  CALL	R11	1
+      0x0028140B,  //  017A  ADD	R10	R10	R11
+      0x7C200400,  //  017B  CALL	R8	2
+      0xA4229000,  //  017C  IMPORT	R8	K72
+      0x8C241149,  //  017D  GETMET	R9	R8	K73
+      0x7C240200,  //  017E  CALL	R9	1
+      0x50240000,  //  017F  LDBOOL	R9	0	0
+      0x80041200,  //  0180  RET	1	R9
+      0x70020000,  //  0181  JMP		#0183
+      0xB0080000,  //  0182  RAISE	2	R0	R0
+      0x80000000,  //  0183  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
@@ -124,7 +124,7 @@ be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name *
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
+    ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_const_int(0),
     /* K2   */  be_nested_str_weak(sessions),
@@ -133,14 +133,15 @@ be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name *
     /* K5   */  be_nested_str_weak(format),
     /* K6   */  be_nested_str_weak(MTR_X3A_X20session_X2Eresumption_id_X3D_X25s_X20vs_X20_X25s),
     /* K7   */  be_nested_str_weak(resumption_id),
-    /* K8   */  be_nested_str_weak(shared_secret),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20session_X2Eshared_secret_X3D_X25s),
-    /* K10  */  be_nested_str_weak(update),
-    /* K11  */  be_const_int(1),
+    /* K8   */  be_const_int(3),
+    /* K9   */  be_nested_str_weak(shared_secret),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20session_X2Eshared_secret_X3D_X25s),
+    /* K11  */  be_nested_str_weak(update),
+    /* K12  */  be_const_int(1),
     }),
     be_str_weak(find_session_by_resumption_id),
     &be_const_str_solidified,
-    ( &(const binstruction[47]) {  /* code */
+    ( &(const binstruction[49]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x740E0001,  //  0002  JMPT	R3	#0005
@@ -152,7 +153,7 @@ be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name *
       0x5C180800,  //  0008  MOVE	R6	R4
       0x7C140200,  //  0009  CALL	R5	1
       0x14140605,  //  000A  LT	R5	R3	R5
-      0x78160021,  //  000B  JMPF	R5	#002E
+      0x78160023,  //  000B  JMPF	R5	#0030
       0x94140803,  //  000C  GETIDX	R5	R4	R3
       0xB81A0600,  //  000D  GETNGBL	R6	K3
       0x8C180D04,  //  000E  GETMET	R6	R6	K4
@@ -165,29 +166,31 @@ be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name *
       0x5C340200,  //  0015  MOVE	R13	R1
       0x7C300200,  //  0016  CALL	R12	1
       0x7C200800,  //  0017  CALL	R8	4
-      0x7C180400,  //  0018  CALL	R6	2
-      0x88180B07,  //  0019  GETMBR	R6	R5	K7
-      0x1C180C01,  //  001A  EQ	R6	R6	R1
-      0x781A000F,  //  001B  JMPF	R6	#002C
-      0x88180B08,  //  001C  GETMBR	R6	R5	K8
-      0x4C1C0000,  //  001D  LDNIL	R7
-      0x20180C07,  //  001E  NE	R6	R6	R7
-      0x781A000B,  //  001F  JMPF	R6	#002C
-      0xB81A0600,  //  0020  GETNGBL	R6	K3
-      0x8C180D04,  //  0021  GETMET	R6	R6	K4
-      0x8C200505,  //  0022  GETMET	R8	R2	K5
-      0x58280009,  //  0023  LDCONST	R10	K9
-      0x602C0008,  //  0024  GETGBL	R11	G8
-      0x88300B08,  //  0025  GETMBR	R12	R5	K8
-      0x7C2C0200,  //  0026  CALL	R11	1
-      0x7C200600,  //  0027  CALL	R8	3
-      0x7C180400,  //  0028  CALL	R6	2
-      0x8C180B0A,  //  0029  GETMET	R6	R5	K10
-      0x7C180200,  //  002A  CALL	R6	1
-      0x80040A00,  //  002B  RET	1	R5
-      0x000C070B,  //  002C  ADD	R3	R3	K11
-      0x7001FFD8,  //  002D  JMP		#0007
-      0x80000000,  //  002E  RET	0
+      0x58240008,  //  0018  LDCONST	R9	K8
+      0x7C180600,  //  0019  CALL	R6	3
+      0x88180B07,  //  001A  GETMBR	R6	R5	K7
+      0x1C180C01,  //  001B  EQ	R6	R6	R1
+      0x781A0010,  //  001C  JMPF	R6	#002E
+      0x88180B09,  //  001D  GETMBR	R6	R5	K9
+      0x4C1C0000,  //  001E  LDNIL	R7
+      0x20180C07,  //  001F  NE	R6	R6	R7
+      0x781A000C,  //  0020  JMPF	R6	#002E
+      0xB81A0600,  //  0021  GETNGBL	R6	K3
+      0x8C180D04,  //  0022  GETMET	R6	R6	K4
+      0x8C200505,  //  0023  GETMET	R8	R2	K5
+      0x5828000A,  //  0024  LDCONST	R10	K10
+      0x602C0008,  //  0025  GETGBL	R11	G8
+      0x88300B09,  //  0026  GETMBR	R12	R5	K9
+      0x7C2C0200,  //  0027  CALL	R11	1
+      0x7C200600,  //  0028  CALL	R8	3
+      0x58240008,  //  0029  LDCONST	R9	K8
+      0x7C180600,  //  002A  CALL	R6	3
+      0x8C180B0B,  //  002B  GETMET	R6	R5	K11
+      0x7C180200,  //  002C  CALL	R6	1
+      0x80040A00,  //  002D  RET	1	R5
+      0x000C070C,  //  002E  ADD	R3	R3	K12
+      0x7001FFD6,  //  002F  JMP		#0007
+      0x80000000,  //  0030  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Reduce logging for Matter, which reduces pressure on the garbage collector and makes provisioning much faster (~35 seconds using AppleTV/iPhone).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
