### PR TITLE
Berry `instrospect.name()` to get names of functions, modules and classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Berry `webserver.html_escape()` reusing the internal HTML escaping function
 - Support for GDK101 gamma radiation sensor by Petr Novacek (#18390)
 - Matter support in now stabilized for Apple and Google (not tested with Alexa)
+- Berry `instrospect.name()` to get names of functions, modules and classes
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_introspectlib.c
+++ b/lib/libesp32/berry/src/be_introspectlib.c
@@ -188,6 +188,31 @@ static int m_ismethod(bvm *vm)
     be_return_nil(vm);
 }
 
+static int m_name(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1) {
+        bvalue *v = be_indexof(vm, 1);
+        const char* name = NULL;
+        switch (var_type(v)) {
+            case BE_CLOSURE:
+                name = str(((bclosure*) var_toobj(v))->proto->name);
+                break;
+            case BE_CLASS:
+                name = str(((bclass*) var_toobj(v))->name);
+                break;
+            case BE_MODULE:
+                name = be_module_name(var_toobj(v));
+                break;
+        }
+        if (name) {
+            be_pushstring(vm, name);
+            be_return(vm);
+        }
+    }
+    be_return_nil(vm);
+}
+
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(introspect) {
     be_native_module_function("members", m_attrlist),
@@ -200,6 +225,8 @@ be_native_module_attr_table(introspect) {
 
     be_native_module_function("toptr", m_toptr),
     be_native_module_function("fromptr", m_fromptr),
+
+    be_native_module_function("name", m_name),
 
     be_native_module_function("ismethod", m_ismethod),
 };
@@ -218,6 +245,8 @@ module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
 
     toptr, func(m_toptr)
     fromptr, func(m_fromptr)
+
+    name, func(m_name)
 
     ismethod, func(m_ismethod)
 }


### PR DESCRIPTION
## Description:

Berry, add `introspect.name(any) -> string or nil`

It works only for berry functions (non-native), modules and classes. If a function is anonymous or a type is unsupported, it return `nil`

```berry
import string
import introspect

introspect.name(string)
# 'string'

def foo() end
introspect.name(foo)
# 'foo'

class A def a() end static def b() end end
introspect.name(A)
# 'A'
introspect.name(A.a)
# 'a'
introspect.name(A.b)
# 'b'
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
