### PR TITLE
Berry add `searchall()` and `matchall()` to `re` module and pre-compiled patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Support for GDK101 gamma radiation sensor by Petr Novacek (#18390)
 - Matter support in now stabilized for Apple and Google (not tested with Alexa)
 - Berry `instrospect.name()` to get names of functions, modules and classes (#18422)
+- Berry add `searchall()` and `matchall()` to `re` module and pre-compiled patterns
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/default/be_re_lib.c
+++ b/lib/libesp32/berry/default/be_re_lib.c
@@ -175,6 +175,42 @@ int re_pattern_search(bvm *vm) {
   be_raise(vm, "type_error", NULL);
 }
 
+// Berry: `re_pattern.searchall(s:string) -> list(list(string))`
+int re_pattern_match_search_all(bvm *vm, bbool is_anchored) {
+  int32_t argc = be_top(vm); // Get the number of arguments
+  if (argc >= 2 && be_isstring(vm, 2)) {
+    const char * hay = be_tostring(vm, 2);
+    be_getmember(vm, 1, "_p");
+    ByteProg * code = (ByteProg*) be_tocomptr(vm, -1);
+    int limit = -1;
+    if (argc >= 3) {
+      limit = be_toint(vm, 3);
+    }
+
+    be_newobject(vm, "list");
+    for (int i = limit; i != 0 && hay != NULL; i--) {
+      hay = be_re_match_search_run(vm, code, hay, is_anchored);
+      if (hay != NULL) {
+        be_data_push(vm, -2);   // add sub list to list
+      }
+      be_pop(vm, 1);
+    }
+    be_pop(vm, 1);
+    be_return(vm);
+  }
+  be_raise(vm, "type_error", NULL);
+}
+
+// Berry: `re_pattern.searchall(s:string) -> list(list(string))`
+int re_pattern_search_all(bvm *vm) {
+  return re_pattern_match_search_all(vm, bfalse);
+}
+
+// Berry: `re_pattern.matchall(s:string) -> list(list(string))`
+int re_pattern_match_all(bvm *vm) {
+  return re_pattern_match_search_all(vm, btrue);
+}
+
 // Berry: `re_pattern.match(s:string) -> list(string)`
 int re_pattern_match(bvm *vm) {
   int32_t argc = be_top(vm); // Get the number of arguments
@@ -277,7 +313,9 @@ module re (scope: global) {
 class be_class_re_pattern (scope: global, name: re_pattern) {
   _p, var
   search, func(re_pattern_search)
+  searchall, func(re_pattern_search_all)
   match, func(re_pattern_match)
+  matchall, func(re_pattern_match_all)
   split, func(re_pattern_split)
 }
 @const_object_info_end */


### PR DESCRIPTION
## Description:

Berry add `matchall()` and `searchall()` to pre-compiled patterns:
- `<rr>.searchall(hay:string [, limit:string]) -> list(list(string))`: returns the list of searches. `limit` allows to limit the number of matches
- `<rr>.matchall(hay:string [, limit:string]) -> list(list(string))`: returns the list of matches. `limit` allows to limit the number of matches.
- `searchall`: pattern can match anywhere. `matchall`: pattern must match one after the other

```berry
import re
var rr = re.compile('<([a-zA-Z]+)>')

r = rr.searchall('<abc> yeah <xyz>')
# [['<abc>', 'abc'], ['<xyz>', 'xyz']]

r =  rr.matchall('<abc> yeah <xyz>')
# [['<abc>', 'abc']]

r =  rr.matchall('<abc><xyz>')
# [['<abc>', 'abc'], ['<xyz>', 'xyz']]
# there is no gap between each match
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
