### PR TITLE
Matter reduce memory usage

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
@@ -216,6 +216,7 @@ class Matter_IM
     # should return true if answered, false if passing to next handler
     def read_single_attribute(ret, pi, ctx, direct)
       import string
+      var TLV = matter.TLV
       var attr_name = matter.get_attribute_name(ctx.cluster, ctx.attribute)
       attr_name = attr_name ? " (" + attr_name + ")" : ""
       # Special case to report unsupported item, if pi==nil
@@ -230,7 +231,12 @@ class Matter_IM
         a1.attribute_data.path.attribute = ctx.attribute
         a1.attribute_data.data = res
 
-        ret.attribute_reports.push(a1)
+        var a1_tlv = a1.to_TLV()
+        var a1_len = a1_tlv.encode_len()
+        var a1_bytes = bytes(a1_len)
+        var a2 = TLV.create_TLV(TLV.RAW, a1_tlv.tlv2raw(a1_bytes))
+
+        ret.attribute_reports.push(a2)
         if !no_log
           tasmota.log(string.format("MTR: >Read_Attr (%6i) %s%s - %s", session.local_session_id, str(ctx), attr_name, str(res)), 2)
         end
@@ -246,7 +252,12 @@ class Matter_IM
           a1.attribute_status.path.attribute = ctx.attribute
           a1.attribute_status.status.status = ctx.status
 
-          ret.attribute_reports.push(a1)
+          var a1_tlv = a1.to_TLV()
+          var a1_len = a1_tlv.encode_len()
+          var a1_bytes = bytes(a1_len)
+          var a2 = TLV.create_TLV(TLV.RAW, a1_tlv.tlv2raw(a1_bytes))
+  
+          ret.attribute_reports.push(a2)
           tasmota.log(string.format("MTR: >Read_Attr (%6i) %s%s - STATUS: 0x%02X %s", session.local_session_id, str(ctx), attr_name, ctx.status, ctx.status == matter.UNSUPPORTED_ATTRIBUTE ? "UNSUPPORTED_ATTRIBUTE" : ""), 2)
           return true
         end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_TLV.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_TLV.be
@@ -86,6 +86,7 @@ class Matter_TLV
   static var ARRAY  = 0x16
   static var LIST   = 0x17
   static var EOC    = 0x18
+  static var RAW    = 0xFF  # encodes an anonymous raw value (already encoded in TLV to save memory)
 
   #################################################################################
   # Matter_TLV_item class
@@ -224,6 +225,8 @@ class Matter_TLV
       var TLV = self.TLV
       if b == nil   b = bytes() end     # start new buffer if none passed
 
+      if self.typ == TLV.RAW  b..self.val return b   end
+
       # special case for bool
       # we need to change the type according to the value
       if self.typ == TLV.BFALSE || self.typ == TLV.BTRUE
@@ -319,6 +322,8 @@ class Matter_TLV
     def encode_len()
       var TLV = self.TLV
       var len = 0
+
+      if self.typ == TLV.RAW  return size(self.val)   end
 
       # special case for bool
       # we need to change the type according to the value

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -1371,7 +1371,7 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
     1,                          /* has sup protos */
     ( &(const struct bproto*[ 2]) {
       be_nested_proto(
-        19,                          /* nstack */
+        23,                          /* nstack */
         4,                          /* argc */
         0,                          /* varg */
         1,                          /* has upvals */
@@ -1382,204 +1382,225 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
-        ( &(const bvalue[33]) {     /* constants */
+        ( &(const bvalue[39]) {     /* constants */
         /* K0   */  be_nested_str_weak(string),
         /* K1   */  be_nested_str_weak(matter),
-        /* K2   */  be_nested_str_weak(get_attribute_name),
-        /* K3   */  be_nested_str_weak(cluster),
-        /* K4   */  be_nested_str_weak(attribute),
-        /* K5   */  be_nested_str_weak(_X20_X28),
-        /* K6   */  be_nested_str_weak(_X29),
-        /* K7   */  be_nested_str_weak(),
-        /* K8   */  be_nested_str_weak(read_attribute),
-        /* K9   */  be_nested_str_weak(AttributeReportIB),
-        /* K10  */  be_nested_str_weak(attribute_data),
-        /* K11  */  be_nested_str_weak(AttributeDataIB),
-        /* K12  */  be_nested_str_weak(data_version),
-        /* K13  */  be_const_int(1),
-        /* K14  */  be_nested_str_weak(path),
-        /* K15  */  be_nested_str_weak(AttributePathIB),
-        /* K16  */  be_nested_str_weak(endpoint),
-        /* K17  */  be_nested_str_weak(data),
-        /* K18  */  be_nested_str_weak(attribute_reports),
-        /* K19  */  be_nested_str_weak(push),
-        /* K20  */  be_nested_str_weak(tasmota),
-        /* K21  */  be_nested_str_weak(log),
-        /* K22  */  be_nested_str_weak(format),
-        /* K23  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
-        /* K24  */  be_nested_str_weak(local_session_id),
-        /* K25  */  be_const_int(2),
-        /* K26  */  be_nested_str_weak(status),
-        /* K27  */  be_nested_str_weak(attribute_status),
-        /* K28  */  be_nested_str_weak(AttributeStatusIB),
-        /* K29  */  be_nested_str_weak(StatusIB),
-        /* K30  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
-        /* K31  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-        /* K32  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20IGNORED),
+        /* K2   */  be_nested_str_weak(TLV),
+        /* K3   */  be_nested_str_weak(get_attribute_name),
+        /* K4   */  be_nested_str_weak(cluster),
+        /* K5   */  be_nested_str_weak(attribute),
+        /* K6   */  be_nested_str_weak(_X20_X28),
+        /* K7   */  be_nested_str_weak(_X29),
+        /* K8   */  be_nested_str_weak(),
+        /* K9   */  be_nested_str_weak(read_attribute),
+        /* K10  */  be_nested_str_weak(AttributeReportIB),
+        /* K11  */  be_nested_str_weak(attribute_data),
+        /* K12  */  be_nested_str_weak(AttributeDataIB),
+        /* K13  */  be_nested_str_weak(data_version),
+        /* K14  */  be_const_int(1),
+        /* K15  */  be_nested_str_weak(path),
+        /* K16  */  be_nested_str_weak(AttributePathIB),
+        /* K17  */  be_nested_str_weak(endpoint),
+        /* K18  */  be_nested_str_weak(data),
+        /* K19  */  be_nested_str_weak(to_TLV),
+        /* K20  */  be_nested_str_weak(encode_len),
+        /* K21  */  be_nested_str_weak(create_TLV),
+        /* K22  */  be_nested_str_weak(RAW),
+        /* K23  */  be_nested_str_weak(tlv2raw),
+        /* K24  */  be_nested_str_weak(attribute_reports),
+        /* K25  */  be_nested_str_weak(push),
+        /* K26  */  be_nested_str_weak(tasmota),
+        /* K27  */  be_nested_str_weak(log),
+        /* K28  */  be_nested_str_weak(format),
+        /* K29  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
+        /* K30  */  be_nested_str_weak(local_session_id),
+        /* K31  */  be_const_int(2),
+        /* K32  */  be_nested_str_weak(status),
+        /* K33  */  be_nested_str_weak(attribute_status),
+        /* K34  */  be_nested_str_weak(AttributeStatusIB),
+        /* K35  */  be_nested_str_weak(StatusIB),
+        /* K36  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
+        /* K37  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+        /* K38  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20IGNORED),
         }),
         be_str_weak(read_single_attribute),
         &be_const_str_solidified,
-        ( &(const binstruction[160]) {  /* code */
+        ( &(const binstruction[175]) {  /* code */
           0xA4120000,  //  0000  IMPORT	R4	K0
           0xB8160200,  //  0001  GETNGBL	R5	K1
-          0x8C140B02,  //  0002  GETMET	R5	R5	K2
-          0x881C0503,  //  0003  GETMBR	R7	R2	K3
-          0x88200504,  //  0004  GETMBR	R8	R2	K4
-          0x7C140600,  //  0005  CALL	R5	3
-          0x78160002,  //  0006  JMPF	R5	#000A
-          0x001A0A05,  //  0007  ADD	R6	K5	R5
-          0x00180D06,  //  0008  ADD	R6	R6	K6
-          0x70020000,  //  0009  JMP		#000B
-          0x58180007,  //  000A  LDCONST	R6	K7
-          0x5C140C00,  //  000B  MOVE	R5	R6
-          0x4C180000,  //  000C  LDNIL	R6
-          0x20180206,  //  000D  NE	R6	R1	R6
-          0x781A0004,  //  000E  JMPF	R6	#0014
-          0x8C180308,  //  000F  GETMET	R6	R1	K8
-          0x68200000,  //  0010  GETUPV	R8	U0
-          0x5C240400,  //  0011  MOVE	R9	R2
-          0x7C180600,  //  0012  CALL	R6	3
-          0x70020000,  //  0013  JMP		#0015
-          0x4C180000,  //  0014  LDNIL	R6
-          0x4C1C0000,  //  0015  LDNIL	R7
-          0x201C0C07,  //  0016  NE	R7	R6	R7
-          0x781E0034,  //  0017  JMPF	R7	#004D
-          0xB81E0200,  //  0018  GETNGBL	R7	K1
-          0x8C1C0F09,  //  0019  GETMET	R7	R7	K9
-          0x7C1C0200,  //  001A  CALL	R7	1
-          0xB8220200,  //  001B  GETNGBL	R8	K1
-          0x8C20110B,  //  001C  GETMET	R8	R8	K11
-          0x7C200200,  //  001D  CALL	R8	1
-          0x901E1408,  //  001E  SETMBR	R7	K10	R8
-          0x88200F0A,  //  001F  GETMBR	R8	R7	K10
-          0x9022190D,  //  0020  SETMBR	R8	K12	K13
-          0x88200F0A,  //  0021  GETMBR	R8	R7	K10
-          0xB8260200,  //  0022  GETNGBL	R9	K1
-          0x8C24130F,  //  0023  GETMET	R9	R9	K15
-          0x7C240200,  //  0024  CALL	R9	1
-          0x90221C09,  //  0025  SETMBR	R8	K14	R9
-          0x88200F0A,  //  0026  GETMBR	R8	R7	K10
-          0x8820110E,  //  0027  GETMBR	R8	R8	K14
-          0x88240510,  //  0028  GETMBR	R9	R2	K16
-          0x90222009,  //  0029  SETMBR	R8	K16	R9
-          0x88200F0A,  //  002A  GETMBR	R8	R7	K10
-          0x8820110E,  //  002B  GETMBR	R8	R8	K14
-          0x88240503,  //  002C  GETMBR	R9	R2	K3
-          0x90220609,  //  002D  SETMBR	R8	K3	R9
-          0x88200F0A,  //  002E  GETMBR	R8	R7	K10
-          0x8820110E,  //  002F  GETMBR	R8	R8	K14
-          0x88240504,  //  0030  GETMBR	R9	R2	K4
-          0x90220809,  //  0031  SETMBR	R8	K4	R9
-          0x88200F0A,  //  0032  GETMBR	R8	R7	K10
-          0x90222206,  //  0033  SETMBR	R8	K17	R6
-          0x88200112,  //  0034  GETMBR	R8	R0	K18
-          0x8C201113,  //  0035  GETMET	R8	R8	K19
-          0x5C280E00,  //  0036  MOVE	R10	R7
-          0x7C200400,  //  0037  CALL	R8	2
-          0x68200001,  //  0038  GETUPV	R8	U1
-          0x7422000F,  //  0039  JMPT	R8	#004A
-          0xB8222800,  //  003A  GETNGBL	R8	K20
-          0x8C201115,  //  003B  GETMET	R8	R8	K21
-          0x8C280916,  //  003C  GETMET	R10	R4	K22
-          0x58300017,  //  003D  LDCONST	R12	K23
-          0x68340000,  //  003E  GETUPV	R13	U0
-          0x88341B18,  //  003F  GETMBR	R13	R13	K24
-          0x60380008,  //  0040  GETGBL	R14	G8
-          0x5C3C0400,  //  0041  MOVE	R15	R2
-          0x7C380200,  //  0042  CALL	R14	1
-          0x5C3C0A00,  //  0043  MOVE	R15	R5
-          0x60400008,  //  0044  GETGBL	R16	G8
-          0x5C440C00,  //  0045  MOVE	R17	R6
-          0x7C400200,  //  0046  CALL	R16	1
-          0x7C280C00,  //  0047  CALL	R10	6
-          0x582C0019,  //  0048  LDCONST	R11	K25
-          0x7C200600,  //  0049  CALL	R8	3
-          0x50200200,  //  004A  LDBOOL	R8	1	0
-          0x80041000,  //  004B  RET	1	R8
-          0x70020051,  //  004C  JMP		#009F
-          0x881C051A,  //  004D  GETMBR	R7	R2	K26
-          0x4C200000,  //  004E  LDNIL	R8
-          0x201C0E08,  //  004F  NE	R7	R7	R8
-          0x781E003E,  //  0050  JMPF	R7	#0090
-          0x780E003C,  //  0051  JMPF	R3	#008F
-          0xB81E0200,  //  0052  GETNGBL	R7	K1
-          0x8C1C0F09,  //  0053  GETMET	R7	R7	K9
-          0x7C1C0200,  //  0054  CALL	R7	1
-          0xB8220200,  //  0055  GETNGBL	R8	K1
-          0x8C20111C,  //  0056  GETMET	R8	R8	K28
-          0x7C200200,  //  0057  CALL	R8	1
-          0x901E3608,  //  0058  SETMBR	R7	K27	R8
-          0x88200F1B,  //  0059  GETMBR	R8	R7	K27
-          0xB8260200,  //  005A  GETNGBL	R9	K1
-          0x8C24130F,  //  005B  GETMET	R9	R9	K15
-          0x7C240200,  //  005C  CALL	R9	1
-          0x90221C09,  //  005D  SETMBR	R8	K14	R9
-          0x88200F1B,  //  005E  GETMBR	R8	R7	K27
-          0xB8260200,  //  005F  GETNGBL	R9	K1
-          0x8C24131D,  //  0060  GETMET	R9	R9	K29
-          0x7C240200,  //  0061  CALL	R9	1
-          0x90223409,  //  0062  SETMBR	R8	K26	R9
-          0x88200F1B,  //  0063  GETMBR	R8	R7	K27
-          0x8820110E,  //  0064  GETMBR	R8	R8	K14
-          0x88240510,  //  0065  GETMBR	R9	R2	K16
-          0x90222009,  //  0066  SETMBR	R8	K16	R9
-          0x88200F1B,  //  0067  GETMBR	R8	R7	K27
-          0x8820110E,  //  0068  GETMBR	R8	R8	K14
-          0x88240503,  //  0069  GETMBR	R9	R2	K3
-          0x90220609,  //  006A  SETMBR	R8	K3	R9
-          0x88200F1B,  //  006B  GETMBR	R8	R7	K27
-          0x8820110E,  //  006C  GETMBR	R8	R8	K14
-          0x88240504,  //  006D  GETMBR	R9	R2	K4
-          0x90220809,  //  006E  SETMBR	R8	K4	R9
-          0x88200F1B,  //  006F  GETMBR	R8	R7	K27
-          0x8820111A,  //  0070  GETMBR	R8	R8	K26
-          0x8824051A,  //  0071  GETMBR	R9	R2	K26
-          0x90223409,  //  0072  SETMBR	R8	K26	R9
-          0x88200112,  //  0073  GETMBR	R8	R0	K18
-          0x8C201113,  //  0074  GETMET	R8	R8	K19
-          0x5C280E00,  //  0075  MOVE	R10	R7
-          0x7C200400,  //  0076  CALL	R8	2
-          0xB8222800,  //  0077  GETNGBL	R8	K20
-          0x8C201115,  //  0078  GETMET	R8	R8	K21
-          0x8C280916,  //  0079  GETMET	R10	R4	K22
-          0x5830001E,  //  007A  LDCONST	R12	K30
-          0x68340000,  //  007B  GETUPV	R13	U0
-          0x88341B18,  //  007C  GETMBR	R13	R13	K24
-          0x60380008,  //  007D  GETGBL	R14	G8
-          0x5C3C0400,  //  007E  MOVE	R15	R2
-          0x7C380200,  //  007F  CALL	R14	1
-          0x5C3C0A00,  //  0080  MOVE	R15	R5
-          0x8840051A,  //  0081  GETMBR	R16	R2	K26
-          0x8844051A,  //  0082  GETMBR	R17	R2	K26
-          0xB84A0200,  //  0083  GETNGBL	R18	K1
-          0x8848251F,  //  0084  GETMBR	R18	R18	K31
-          0x1C442212,  //  0085  EQ	R17	R17	R18
-          0x78460001,  //  0086  JMPF	R17	#0089
-          0x5844001F,  //  0087  LDCONST	R17	K31
-          0x70020000,  //  0088  JMP		#008A
-          0x58440007,  //  0089  LDCONST	R17	K7
-          0x7C280E00,  //  008A  CALL	R10	7
-          0x582C0019,  //  008B  LDCONST	R11	K25
-          0x7C200600,  //  008C  CALL	R8	3
-          0x50200200,  //  008D  LDBOOL	R8	1	0
-          0x80041000,  //  008E  RET	1	R8
-          0x7002000E,  //  008F  JMP		#009F
-          0xB81E2800,  //  0090  GETNGBL	R7	K20
-          0x8C1C0F15,  //  0091  GETMET	R7	R7	K21
-          0x8C240916,  //  0092  GETMET	R9	R4	K22
-          0x582C0020,  //  0093  LDCONST	R11	K32
-          0x68300000,  //  0094  GETUPV	R12	U0
-          0x88301918,  //  0095  GETMBR	R12	R12	K24
-          0x60340008,  //  0096  GETGBL	R13	G8
-          0x5C380400,  //  0097  MOVE	R14	R2
-          0x7C340200,  //  0098  CALL	R13	1
-          0x5C380A00,  //  0099  MOVE	R14	R5
-          0x7C240A00,  //  009A  CALL	R9	5
-          0x58280019,  //  009B  LDCONST	R10	K25
-          0x7C1C0600,  //  009C  CALL	R7	3
-          0x501C0000,  //  009D  LDBOOL	R7	0	0
-          0x80040E00,  //  009E  RET	1	R7
-          0x80000000,  //  009F  RET	0
+          0x88140B02,  //  0002  GETMBR	R5	R5	K2
+          0xB81A0200,  //  0003  GETNGBL	R6	K1
+          0x8C180D03,  //  0004  GETMET	R6	R6	K3
+          0x88200504,  //  0005  GETMBR	R8	R2	K4
+          0x88240505,  //  0006  GETMBR	R9	R2	K5
+          0x7C180600,  //  0007  CALL	R6	3
+          0x781A0002,  //  0008  JMPF	R6	#000C
+          0x001E0C06,  //  0009  ADD	R7	K6	R6
+          0x001C0F07,  //  000A  ADD	R7	R7	K7
+          0x70020000,  //  000B  JMP		#000D
+          0x581C0008,  //  000C  LDCONST	R7	K8
+          0x5C180E00,  //  000D  MOVE	R6	R7
+          0x4C1C0000,  //  000E  LDNIL	R7
+          0x201C0207,  //  000F  NE	R7	R1	R7
+          0x781E0004,  //  0010  JMPF	R7	#0016
+          0x8C1C0309,  //  0011  GETMET	R7	R1	K9
+          0x68240000,  //  0012  GETUPV	R9	U0
+          0x5C280400,  //  0013  MOVE	R10	R2
+          0x7C1C0600,  //  0014  CALL	R7	3
+          0x70020000,  //  0015  JMP		#0017
+          0x4C1C0000,  //  0016  LDNIL	R7
+          0x4C200000,  //  0017  LDNIL	R8
+          0x20200E08,  //  0018  NE	R8	R7	R8
+          0x78220041,  //  0019  JMPF	R8	#005C
+          0xB8220200,  //  001A  GETNGBL	R8	K1
+          0x8C20110A,  //  001B  GETMET	R8	R8	K10
+          0x7C200200,  //  001C  CALL	R8	1
+          0xB8260200,  //  001D  GETNGBL	R9	K1
+          0x8C24130C,  //  001E  GETMET	R9	R9	K12
+          0x7C240200,  //  001F  CALL	R9	1
+          0x90221609,  //  0020  SETMBR	R8	K11	R9
+          0x8824110B,  //  0021  GETMBR	R9	R8	K11
+          0x90261B0E,  //  0022  SETMBR	R9	K13	K14
+          0x8824110B,  //  0023  GETMBR	R9	R8	K11
+          0xB82A0200,  //  0024  GETNGBL	R10	K1
+          0x8C281510,  //  0025  GETMET	R10	R10	K16
+          0x7C280200,  //  0026  CALL	R10	1
+          0x90261E0A,  //  0027  SETMBR	R9	K15	R10
+          0x8824110B,  //  0028  GETMBR	R9	R8	K11
+          0x8824130F,  //  0029  GETMBR	R9	R9	K15
+          0x88280511,  //  002A  GETMBR	R10	R2	K17
+          0x9026220A,  //  002B  SETMBR	R9	K17	R10
+          0x8824110B,  //  002C  GETMBR	R9	R8	K11
+          0x8824130F,  //  002D  GETMBR	R9	R9	K15
+          0x88280504,  //  002E  GETMBR	R10	R2	K4
+          0x9026080A,  //  002F  SETMBR	R9	K4	R10
+          0x8824110B,  //  0030  GETMBR	R9	R8	K11
+          0x8824130F,  //  0031  GETMBR	R9	R9	K15
+          0x88280505,  //  0032  GETMBR	R10	R2	K5
+          0x90260A0A,  //  0033  SETMBR	R9	K5	R10
+          0x8824110B,  //  0034  GETMBR	R9	R8	K11
+          0x90262407,  //  0035  SETMBR	R9	K18	R7
+          0x8C241113,  //  0036  GETMET	R9	R8	K19
+          0x7C240200,  //  0037  CALL	R9	1
+          0x8C281314,  //  0038  GETMET	R10	R9	K20
+          0x7C280200,  //  0039  CALL	R10	1
+          0x602C0015,  //  003A  GETGBL	R11	G21
+          0x5C301400,  //  003B  MOVE	R12	R10
+          0x7C2C0200,  //  003C  CALL	R11	1
+          0x8C300B15,  //  003D  GETMET	R12	R5	K21
+          0x88380B16,  //  003E  GETMBR	R14	R5	K22
+          0x8C3C1317,  //  003F  GETMET	R15	R9	K23
+          0x5C441600,  //  0040  MOVE	R17	R11
+          0x7C3C0400,  //  0041  CALL	R15	2
+          0x7C300600,  //  0042  CALL	R12	3
+          0x88340118,  //  0043  GETMBR	R13	R0	K24
+          0x8C341B19,  //  0044  GETMET	R13	R13	K25
+          0x5C3C1800,  //  0045  MOVE	R15	R12
+          0x7C340400,  //  0046  CALL	R13	2
+          0x68340001,  //  0047  GETUPV	R13	U1
+          0x7436000F,  //  0048  JMPT	R13	#0059
+          0xB8363400,  //  0049  GETNGBL	R13	K26
+          0x8C341B1B,  //  004A  GETMET	R13	R13	K27
+          0x8C3C091C,  //  004B  GETMET	R15	R4	K28
+          0x5844001D,  //  004C  LDCONST	R17	K29
+          0x68480000,  //  004D  GETUPV	R18	U0
+          0x8848251E,  //  004E  GETMBR	R18	R18	K30
+          0x604C0008,  //  004F  GETGBL	R19	G8
+          0x5C500400,  //  0050  MOVE	R20	R2
+          0x7C4C0200,  //  0051  CALL	R19	1
+          0x5C500C00,  //  0052  MOVE	R20	R6
+          0x60540008,  //  0053  GETGBL	R21	G8
+          0x5C580E00,  //  0054  MOVE	R22	R7
+          0x7C540200,  //  0055  CALL	R21	1
+          0x7C3C0C00,  //  0056  CALL	R15	6
+          0x5840001F,  //  0057  LDCONST	R16	K31
+          0x7C340600,  //  0058  CALL	R13	3
+          0x50340200,  //  0059  LDBOOL	R13	1	0
+          0x80041A00,  //  005A  RET	1	R13
+          0x70020051,  //  005B  JMP		#00AE
+          0x88200520,  //  005C  GETMBR	R8	R2	K32
+          0x4C240000,  //  005D  LDNIL	R9
+          0x20201009,  //  005E  NE	R8	R8	R9
+          0x7822003E,  //  005F  JMPF	R8	#009F
+          0x780E003C,  //  0060  JMPF	R3	#009E
+          0xB8220200,  //  0061  GETNGBL	R8	K1
+          0x8C20110A,  //  0062  GETMET	R8	R8	K10
+          0x7C200200,  //  0063  CALL	R8	1
+          0xB8260200,  //  0064  GETNGBL	R9	K1
+          0x8C241322,  //  0065  GETMET	R9	R9	K34
+          0x7C240200,  //  0066  CALL	R9	1
+          0x90224209,  //  0067  SETMBR	R8	K33	R9
+          0x88241121,  //  0068  GETMBR	R9	R8	K33
+          0xB82A0200,  //  0069  GETNGBL	R10	K1
+          0x8C281510,  //  006A  GETMET	R10	R10	K16
+          0x7C280200,  //  006B  CALL	R10	1
+          0x90261E0A,  //  006C  SETMBR	R9	K15	R10
+          0x88241121,  //  006D  GETMBR	R9	R8	K33
+          0xB82A0200,  //  006E  GETNGBL	R10	K1
+          0x8C281523,  //  006F  GETMET	R10	R10	K35
+          0x7C280200,  //  0070  CALL	R10	1
+          0x9026400A,  //  0071  SETMBR	R9	K32	R10
+          0x88241121,  //  0072  GETMBR	R9	R8	K33
+          0x8824130F,  //  0073  GETMBR	R9	R9	K15
+          0x88280511,  //  0074  GETMBR	R10	R2	K17
+          0x9026220A,  //  0075  SETMBR	R9	K17	R10
+          0x88241121,  //  0076  GETMBR	R9	R8	K33
+          0x8824130F,  //  0077  GETMBR	R9	R9	K15
+          0x88280504,  //  0078  GETMBR	R10	R2	K4
+          0x9026080A,  //  0079  SETMBR	R9	K4	R10
+          0x88241121,  //  007A  GETMBR	R9	R8	K33
+          0x8824130F,  //  007B  GETMBR	R9	R9	K15
+          0x88280505,  //  007C  GETMBR	R10	R2	K5
+          0x90260A0A,  //  007D  SETMBR	R9	K5	R10
+          0x88241121,  //  007E  GETMBR	R9	R8	K33
+          0x88241320,  //  007F  GETMBR	R9	R9	K32
+          0x88280520,  //  0080  GETMBR	R10	R2	K32
+          0x9026400A,  //  0081  SETMBR	R9	K32	R10
+          0x88240118,  //  0082  GETMBR	R9	R0	K24
+          0x8C241319,  //  0083  GETMET	R9	R9	K25
+          0x5C2C1000,  //  0084  MOVE	R11	R8
+          0x7C240400,  //  0085  CALL	R9	2
+          0xB8263400,  //  0086  GETNGBL	R9	K26
+          0x8C24131B,  //  0087  GETMET	R9	R9	K27
+          0x8C2C091C,  //  0088  GETMET	R11	R4	K28
+          0x58340024,  //  0089  LDCONST	R13	K36
+          0x68380000,  //  008A  GETUPV	R14	U0
+          0x88381D1E,  //  008B  GETMBR	R14	R14	K30
+          0x603C0008,  //  008C  GETGBL	R15	G8
+          0x5C400400,  //  008D  MOVE	R16	R2
+          0x7C3C0200,  //  008E  CALL	R15	1
+          0x5C400C00,  //  008F  MOVE	R16	R6
+          0x88440520,  //  0090  GETMBR	R17	R2	K32
+          0x88480520,  //  0091  GETMBR	R18	R2	K32
+          0xB84E0200,  //  0092  GETNGBL	R19	K1
+          0x884C2725,  //  0093  GETMBR	R19	R19	K37
+          0x1C482413,  //  0094  EQ	R18	R18	R19
+          0x784A0001,  //  0095  JMPF	R18	#0098
+          0x58480025,  //  0096  LDCONST	R18	K37
+          0x70020000,  //  0097  JMP		#0099
+          0x58480008,  //  0098  LDCONST	R18	K8
+          0x7C2C0E00,  //  0099  CALL	R11	7
+          0x5830001F,  //  009A  LDCONST	R12	K31
+          0x7C240600,  //  009B  CALL	R9	3
+          0x50240200,  //  009C  LDBOOL	R9	1	0
+          0x80041200,  //  009D  RET	1	R9
+          0x7002000E,  //  009E  JMP		#00AE
+          0xB8223400,  //  009F  GETNGBL	R8	K26
+          0x8C20111B,  //  00A0  GETMET	R8	R8	K27
+          0x8C28091C,  //  00A1  GETMET	R10	R4	K28
+          0x58300026,  //  00A2  LDCONST	R12	K38
+          0x68340000,  //  00A3  GETUPV	R13	U0
+          0x88341B1E,  //  00A4  GETMBR	R13	R13	K30
+          0x60380008,  //  00A5  GETGBL	R14	G8
+          0x5C3C0400,  //  00A6  MOVE	R15	R2
+          0x7C380200,  //  00A7  CALL	R14	1
+          0x5C3C0C00,  //  00A8  MOVE	R15	R6
+          0x7C280A00,  //  00A9  CALL	R10	5
+          0x582C001F,  //  00AA  LDCONST	R11	K31
+          0x7C200600,  //  00AB  CALL	R8	3
+          0x50200000,  //  00AC  LDBOOL	R8	0	0
+          0x80041000,  //  00AD  RET	1	R8
+          0x80000000,  //  00AE  RET	0
         })
       ),
       be_nested_proto(

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
@@ -413,292 +413,301 @@ be_local_closure(Matter_TLV_item_encode_len,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[31]) {     /* constants */
+    ( &(const bvalue[32]) {     /* constants */
     /* K0   */  be_nested_str_weak(TLV),
     /* K1   */  be_const_int(0),
     /* K2   */  be_nested_str_weak(typ),
-    /* K3   */  be_nested_str_weak(BFALSE),
-    /* K4   */  be_nested_str_weak(BTRUE),
-    /* K5   */  be_nested_str_weak(val),
-    /* K6   */  be_nested_str_weak(I2),
-    /* K7   */  be_nested_str_weak(I4),
-    /* K8   */  be_nested_str_weak(I1),
-    /* K9   */  be_nested_str_weak(U2),
-    /* K10  */  be_nested_str_weak(U4),
-    /* K11  */  be_nested_str_weak(U1),
-    /* K12  */  be_nested_str_weak(B1),
-    /* K13  */  be_nested_str_weak(B8),
-    /* K14  */  be_nested_str_weak(B2),
-    /* K15  */  be_nested_str_weak(B4),
-    /* K16  */  be_nested_str_weak(UTF1),
-    /* K17  */  be_nested_str_weak(UTF8),
-    /* K18  */  be_nested_str_weak(UTF2),
-    /* K19  */  be_nested_str_weak(UTF4),
-    /* K20  */  be_nested_str_weak(_encode_tag_len),
-    /* K21  */  be_const_int(1),
-    /* K22  */  be_const_int(2),
-    /* K23  */  be_nested_str_weak(I8),
-    /* K24  */  be_nested_str_weak(U8),
-    /* K25  */  be_nested_str_weak(FLOAT),
-    /* K26  */  be_nested_str_weak(DOUBLE),
-    /* K27  */  be_nested_str_weak(value_error),
-    /* K28  */  be_nested_str_weak(Unsupported_X20type_X20TLV_X2EDOUBLE),
-    /* K29  */  be_nested_str_weak(NULL),
-    /* K30  */  be_nested_str_weak(unsupported_X20type_X20),
+    /* K3   */  be_nested_str_weak(RAW),
+    /* K4   */  be_nested_str_weak(val),
+    /* K5   */  be_nested_str_weak(BFALSE),
+    /* K6   */  be_nested_str_weak(BTRUE),
+    /* K7   */  be_nested_str_weak(I2),
+    /* K8   */  be_nested_str_weak(I4),
+    /* K9   */  be_nested_str_weak(I1),
+    /* K10  */  be_nested_str_weak(U2),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_nested_str_weak(U1),
+    /* K13  */  be_nested_str_weak(B1),
+    /* K14  */  be_nested_str_weak(B8),
+    /* K15  */  be_nested_str_weak(B2),
+    /* K16  */  be_nested_str_weak(B4),
+    /* K17  */  be_nested_str_weak(UTF1),
+    /* K18  */  be_nested_str_weak(UTF8),
+    /* K19  */  be_nested_str_weak(UTF2),
+    /* K20  */  be_nested_str_weak(UTF4),
+    /* K21  */  be_nested_str_weak(_encode_tag_len),
+    /* K22  */  be_const_int(1),
+    /* K23  */  be_const_int(2),
+    /* K24  */  be_nested_str_weak(I8),
+    /* K25  */  be_nested_str_weak(U8),
+    /* K26  */  be_nested_str_weak(FLOAT),
+    /* K27  */  be_nested_str_weak(DOUBLE),
+    /* K28  */  be_nested_str_weak(value_error),
+    /* K29  */  be_nested_str_weak(Unsupported_X20type_X20TLV_X2EDOUBLE),
+    /* K30  */  be_nested_str_weak(NULL),
+    /* K31  */  be_nested_str_weak(unsupported_X20type_X20),
     }),
     be_str_weak(encode_len),
     &be_const_str_solidified,
-    ( &(const binstruction[250]) {  /* code */
+    ( &(const binstruction[258]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x58080001,  //  0001  LDCONST	R2	K1
       0x880C0102,  //  0002  GETMBR	R3	R0	K2
       0x88100303,  //  0003  GETMBR	R4	R1	K3
       0x1C0C0604,  //  0004  EQ	R3	R3	R4
-      0x740E0003,  //  0005  JMPT	R3	#000A
-      0x880C0102,  //  0006  GETMBR	R3	R0	K2
-      0x88100304,  //  0007  GETMBR	R4	R1	K4
-      0x1C0C0604,  //  0008  EQ	R3	R3	R4
-      0x780E0008,  //  0009  JMPF	R3	#0013
-      0x600C0017,  //  000A  GETGBL	R3	G23
-      0x88100105,  //  000B  GETMBR	R4	R0	K5
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x780E0001,  //  000D  JMPF	R3	#0010
-      0x880C0304,  //  000E  GETMBR	R3	R1	K4
-      0x70020000,  //  000F  JMP		#0011
-      0x880C0303,  //  0010  GETMBR	R3	R1	K3
-      0x90020403,  //  0011  SETMBR	R0	K2	R3
-      0x70020070,  //  0012  JMP		#0084
-      0x880C0102,  //  0013  GETMBR	R3	R0	K2
-      0x88100306,  //  0014  GETMBR	R4	R1	K6
-      0x280C0604,  //  0015  GE	R3	R3	R4
-      0x780E0018,  //  0016  JMPF	R3	#0030
-      0x880C0102,  //  0017  GETMBR	R3	R0	K2
-      0x88100307,  //  0018  GETMBR	R4	R1	K7
-      0x180C0604,  //  0019  LE	R3	R3	R4
-      0x780E0014,  //  001A  JMPF	R3	#0030
-      0x600C0009,  //  001B  GETGBL	R3	G9
-      0x88100105,  //  001C  GETMBR	R4	R0	K5
-      0x7C0C0200,  //  001D  CALL	R3	1
-      0x5412007E,  //  001E  LDINT	R4	127
-      0x18100604,  //  001F  LE	R4	R3	R4
-      0x78120005,  //  0020  JMPF	R4	#0027
-      0x5411FF7F,  //  0021  LDINT	R4	-128
-      0x28100604,  //  0022  GE	R4	R3	R4
-      0x78120002,  //  0023  JMPF	R4	#0027
-      0x88100308,  //  0024  GETMBR	R4	R1	K8
-      0x90020404,  //  0025  SETMBR	R0	K2	R4
-      0x70020007,  //  0026  JMP		#002F
-      0x54127FFE,  //  0027  LDINT	R4	32767
-      0x18100604,  //  0028  LE	R4	R3	R4
-      0x78120004,  //  0029  JMPF	R4	#002F
-      0x54117FFF,  //  002A  LDINT	R4	-32768
-      0x28100604,  //  002B  GE	R4	R3	R4
-      0x78120001,  //  002C  JMPF	R4	#002F
-      0x88100306,  //  002D  GETMBR	R4	R1	K6
-      0x90020404,  //  002E  SETMBR	R0	K2	R4
-      0x70020053,  //  002F  JMP		#0084
-      0x880C0102,  //  0030  GETMBR	R3	R0	K2
-      0x88100309,  //  0031  GETMBR	R4	R1	K9
-      0x280C0604,  //  0032  GE	R3	R3	R4
-      0x780E0016,  //  0033  JMPF	R3	#004B
-      0x880C0102,  //  0034  GETMBR	R3	R0	K2
-      0x8810030A,  //  0035  GETMBR	R4	R1	K10
-      0x180C0604,  //  0036  LE	R3	R3	R4
-      0x780E0012,  //  0037  JMPF	R3	#004B
-      0x600C0009,  //  0038  GETGBL	R3	G9
-      0x88100105,  //  0039  GETMBR	R4	R0	K5
-      0x7C0C0200,  //  003A  CALL	R3	1
-      0x541200FE,  //  003B  LDINT	R4	255
-      0x18100604,  //  003C  LE	R4	R3	R4
-      0x78120004,  //  003D  JMPF	R4	#0043
-      0x28100701,  //  003E  GE	R4	R3	K1
-      0x78120002,  //  003F  JMPF	R4	#0043
-      0x8810030B,  //  0040  GETMBR	R4	R1	K11
-      0x90020404,  //  0041  SETMBR	R0	K2	R4
-      0x70020006,  //  0042  JMP		#004A
-      0x5412FFFE,  //  0043  LDINT	R4	65535
+      0x780E0003,  //  0005  JMPF	R3	#000A
+      0x600C000C,  //  0006  GETGBL	R3	G12
+      0x88100104,  //  0007  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x80040600,  //  0009  RET	1	R3
+      0x880C0102,  //  000A  GETMBR	R3	R0	K2
+      0x88100305,  //  000B  GETMBR	R4	R1	K5
+      0x1C0C0604,  //  000C  EQ	R3	R3	R4
+      0x740E0003,  //  000D  JMPT	R3	#0012
+      0x880C0102,  //  000E  GETMBR	R3	R0	K2
+      0x88100306,  //  000F  GETMBR	R4	R1	K6
+      0x1C0C0604,  //  0010  EQ	R3	R3	R4
+      0x780E0008,  //  0011  JMPF	R3	#001B
+      0x600C0017,  //  0012  GETGBL	R3	G23
+      0x88100104,  //  0013  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  0014  CALL	R3	1
+      0x780E0001,  //  0015  JMPF	R3	#0018
+      0x880C0306,  //  0016  GETMBR	R3	R1	K6
+      0x70020000,  //  0017  JMP		#0019
+      0x880C0305,  //  0018  GETMBR	R3	R1	K5
+      0x90020403,  //  0019  SETMBR	R0	K2	R3
+      0x70020070,  //  001A  JMP		#008C
+      0x880C0102,  //  001B  GETMBR	R3	R0	K2
+      0x88100307,  //  001C  GETMBR	R4	R1	K7
+      0x280C0604,  //  001D  GE	R3	R3	R4
+      0x780E0018,  //  001E  JMPF	R3	#0038
+      0x880C0102,  //  001F  GETMBR	R3	R0	K2
+      0x88100308,  //  0020  GETMBR	R4	R1	K8
+      0x180C0604,  //  0021  LE	R3	R3	R4
+      0x780E0014,  //  0022  JMPF	R3	#0038
+      0x600C0009,  //  0023  GETGBL	R3	G9
+      0x88100104,  //  0024  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  0025  CALL	R3	1
+      0x5412007E,  //  0026  LDINT	R4	127
+      0x18100604,  //  0027  LE	R4	R3	R4
+      0x78120005,  //  0028  JMPF	R4	#002F
+      0x5411FF7F,  //  0029  LDINT	R4	-128
+      0x28100604,  //  002A  GE	R4	R3	R4
+      0x78120002,  //  002B  JMPF	R4	#002F
+      0x88100309,  //  002C  GETMBR	R4	R1	K9
+      0x90020404,  //  002D  SETMBR	R0	K2	R4
+      0x70020007,  //  002E  JMP		#0037
+      0x54127FFE,  //  002F  LDINT	R4	32767
+      0x18100604,  //  0030  LE	R4	R3	R4
+      0x78120004,  //  0031  JMPF	R4	#0037
+      0x54117FFF,  //  0032  LDINT	R4	-32768
+      0x28100604,  //  0033  GE	R4	R3	R4
+      0x78120001,  //  0034  JMPF	R4	#0037
+      0x88100307,  //  0035  GETMBR	R4	R1	K7
+      0x90020404,  //  0036  SETMBR	R0	K2	R4
+      0x70020053,  //  0037  JMP		#008C
+      0x880C0102,  //  0038  GETMBR	R3	R0	K2
+      0x8810030A,  //  0039  GETMBR	R4	R1	K10
+      0x280C0604,  //  003A  GE	R3	R3	R4
+      0x780E0016,  //  003B  JMPF	R3	#0053
+      0x880C0102,  //  003C  GETMBR	R3	R0	K2
+      0x8810030B,  //  003D  GETMBR	R4	R1	K11
+      0x180C0604,  //  003E  LE	R3	R3	R4
+      0x780E0012,  //  003F  JMPF	R3	#0053
+      0x600C0009,  //  0040  GETGBL	R3	G9
+      0x88100104,  //  0041  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  0042  CALL	R3	1
+      0x541200FE,  //  0043  LDINT	R4	255
       0x18100604,  //  0044  LE	R4	R3	R4
-      0x78120003,  //  0045  JMPF	R4	#004A
+      0x78120004,  //  0045  JMPF	R4	#004B
       0x28100701,  //  0046  GE	R4	R3	K1
-      0x78120001,  //  0047  JMPF	R4	#004A
-      0x88100309,  //  0048  GETMBR	R4	R1	K9
+      0x78120002,  //  0047  JMPF	R4	#004B
+      0x8810030C,  //  0048  GETMBR	R4	R1	K12
       0x90020404,  //  0049  SETMBR	R0	K2	R4
-      0x70020038,  //  004A  JMP		#0084
-      0x880C0102,  //  004B  GETMBR	R3	R0	K2
-      0x8810030C,  //  004C  GETMBR	R4	R1	K12
-      0x280C0604,  //  004D  GE	R3	R3	R4
-      0x780E0018,  //  004E  JMPF	R3	#0068
-      0x880C0102,  //  004F  GETMBR	R3	R0	K2
-      0x8810030D,  //  0050  GETMBR	R4	R1	K13
-      0x180C0604,  //  0051  LE	R3	R3	R4
-      0x780E0014,  //  0052  JMPF	R3	#0068
-      0x600C000C,  //  0053  GETGBL	R3	G12
-      0x88100105,  //  0054  GETMBR	R4	R0	K5
-      0x7C0C0200,  //  0055  CALL	R3	1
-      0x541200FE,  //  0056  LDINT	R4	255
-      0x180C0604,  //  0057  LE	R3	R3	R4
-      0x780E0002,  //  0058  JMPF	R3	#005C
-      0x880C030C,  //  0059  GETMBR	R3	R1	K12
-      0x90020403,  //  005A  SETMBR	R0	K2	R3
-      0x7002000A,  //  005B  JMP		#0067
-      0x600C000C,  //  005C  GETGBL	R3	G12
-      0x88100105,  //  005D  GETMBR	R4	R0	K5
-      0x7C0C0200,  //  005E  CALL	R3	1
-      0x5412FFFE,  //  005F  LDINT	R4	65535
-      0x180C0604,  //  0060  LE	R3	R3	R4
-      0x780E0002,  //  0061  JMPF	R3	#0065
-      0x880C030E,  //  0062  GETMBR	R3	R1	K14
-      0x90020403,  //  0063  SETMBR	R0	K2	R3
-      0x70020001,  //  0064  JMP		#0067
-      0x880C030F,  //  0065  GETMBR	R3	R1	K15
-      0x90020403,  //  0066  SETMBR	R0	K2	R3
-      0x7002001B,  //  0067  JMP		#0084
-      0x880C0102,  //  0068  GETMBR	R3	R0	K2
-      0x88100310,  //  0069  GETMBR	R4	R1	K16
-      0x280C0604,  //  006A  GE	R3	R3	R4
-      0x780E0017,  //  006B  JMPF	R3	#0084
-      0x880C0102,  //  006C  GETMBR	R3	R0	K2
-      0x88100311,  //  006D  GETMBR	R4	R1	K17
-      0x180C0604,  //  006E  LE	R3	R3	R4
-      0x780E0013,  //  006F  JMPF	R3	#0084
-      0x600C000C,  //  0070  GETGBL	R3	G12
-      0x88100105,  //  0071  GETMBR	R4	R0	K5
-      0x7C0C0200,  //  0072  CALL	R3	1
-      0x541200FE,  //  0073  LDINT	R4	255
-      0x180C0604,  //  0074  LE	R3	R3	R4
-      0x780E0002,  //  0075  JMPF	R3	#0079
-      0x880C0310,  //  0076  GETMBR	R3	R1	K16
-      0x90020403,  //  0077  SETMBR	R0	K2	R3
-      0x7002000A,  //  0078  JMP		#0084
-      0x600C000C,  //  0079  GETGBL	R3	G12
-      0x88100105,  //  007A  GETMBR	R4	R0	K5
-      0x7C0C0200,  //  007B  CALL	R3	1
-      0x5412FFFE,  //  007C  LDINT	R4	65535
-      0x180C0604,  //  007D  LE	R3	R3	R4
-      0x780E0002,  //  007E  JMPF	R3	#0082
-      0x880C0312,  //  007F  GETMBR	R3	R1	K18
-      0x90020403,  //  0080  SETMBR	R0	K2	R3
-      0x70020001,  //  0081  JMP		#0084
-      0x880C0313,  //  0082  GETMBR	R3	R1	K19
-      0x90020403,  //  0083  SETMBR	R0	K2	R3
-      0x8C0C0114,  //  0084  GETMET	R3	R0	K20
-      0x7C0C0200,  //  0085  CALL	R3	1
-      0x00080403,  //  0086  ADD	R2	R2	R3
-      0x880C0102,  //  0087  GETMBR	R3	R0	K2
-      0x88100308,  //  0088  GETMBR	R4	R1	K8
-      0x1C0C0604,  //  0089  EQ	R3	R3	R4
-      0x740E0003,  //  008A  JMPT	R3	#008F
-      0x880C0102,  //  008B  GETMBR	R3	R0	K2
-      0x8810030B,  //  008C  GETMBR	R4	R1	K11
-      0x1C0C0604,  //  008D  EQ	R3	R3	R4
-      0x780E0001,  //  008E  JMPF	R3	#0091
-      0x00080515,  //  008F  ADD	R2	R2	K21
-      0x70020067,  //  0090  JMP		#00F9
-      0x880C0102,  //  0091  GETMBR	R3	R0	K2
-      0x88100306,  //  0092  GETMBR	R4	R1	K6
-      0x1C0C0604,  //  0093  EQ	R3	R3	R4
-      0x740E0003,  //  0094  JMPT	R3	#0099
-      0x880C0102,  //  0095  GETMBR	R3	R0	K2
-      0x88100309,  //  0096  GETMBR	R4	R1	K9
-      0x1C0C0604,  //  0097  EQ	R3	R3	R4
-      0x780E0001,  //  0098  JMPF	R3	#009B
-      0x00080516,  //  0099  ADD	R2	R2	K22
-      0x7002005D,  //  009A  JMP		#00F9
-      0x880C0102,  //  009B  GETMBR	R3	R0	K2
-      0x88100307,  //  009C  GETMBR	R4	R1	K7
-      0x1C0C0604,  //  009D  EQ	R3	R3	R4
-      0x740E0003,  //  009E  JMPT	R3	#00A3
-      0x880C0102,  //  009F  GETMBR	R3	R0	K2
-      0x8810030A,  //  00A0  GETMBR	R4	R1	K10
-      0x1C0C0604,  //  00A1  EQ	R3	R3	R4
-      0x780E0002,  //  00A2  JMPF	R3	#00A6
-      0x540E0003,  //  00A3  LDINT	R3	4
-      0x00080403,  //  00A4  ADD	R2	R2	R3
-      0x70020052,  //  00A5  JMP		#00F9
-      0x880C0102,  //  00A6  GETMBR	R3	R0	K2
-      0x88100317,  //  00A7  GETMBR	R4	R1	K23
-      0x1C0C0604,  //  00A8  EQ	R3	R3	R4
-      0x740E0003,  //  00A9  JMPT	R3	#00AE
-      0x880C0102,  //  00AA  GETMBR	R3	R0	K2
-      0x88100318,  //  00AB  GETMBR	R4	R1	K24
-      0x1C0C0604,  //  00AC  EQ	R3	R3	R4
-      0x780E0002,  //  00AD  JMPF	R3	#00B1
-      0x540E0007,  //  00AE  LDINT	R3	8
-      0x00080403,  //  00AF  ADD	R2	R2	R3
-      0x70020047,  //  00B0  JMP		#00F9
-      0x880C0102,  //  00B1  GETMBR	R3	R0	K2
-      0x88100303,  //  00B2  GETMBR	R4	R1	K3
-      0x1C0C0604,  //  00B3  EQ	R3	R3	R4
-      0x740E0003,  //  00B4  JMPT	R3	#00B9
-      0x880C0102,  //  00B5  GETMBR	R3	R0	K2
-      0x88100304,  //  00B6  GETMBR	R4	R1	K4
-      0x1C0C0604,  //  00B7  EQ	R3	R3	R4
-      0x780E0000,  //  00B8  JMPF	R3	#00BA
-      0x7002003E,  //  00B9  JMP		#00F9
-      0x880C0102,  //  00BA  GETMBR	R3	R0	K2
-      0x88100319,  //  00BB  GETMBR	R4	R1	K25
-      0x1C0C0604,  //  00BC  EQ	R3	R3	R4
-      0x780E0002,  //  00BD  JMPF	R3	#00C1
-      0x540E0003,  //  00BE  LDINT	R3	4
-      0x00080403,  //  00BF  ADD	R2	R2	R3
-      0x70020037,  //  00C0  JMP		#00F9
-      0x880C0102,  //  00C1  GETMBR	R3	R0	K2
-      0x8810031A,  //  00C2  GETMBR	R4	R1	K26
-      0x1C0C0604,  //  00C3  EQ	R3	R3	R4
-      0x780E0001,  //  00C4  JMPF	R3	#00C7
-      0xB006371C,  //  00C5  RAISE	1	K27	K28
-      0x70020031,  //  00C6  JMP		#00F9
-      0x880C0102,  //  00C7  GETMBR	R3	R0	K2
-      0x88100310,  //  00C8  GETMBR	R4	R1	K16
-      0x1C0C0604,  //  00C9  EQ	R3	R3	R4
-      0x780E0005,  //  00CA  JMPF	R3	#00D1
-      0x600C000C,  //  00CB  GETGBL	R3	G12
-      0x88100105,  //  00CC  GETMBR	R4	R0	K5
-      0x7C0C0200,  //  00CD  CALL	R3	1
-      0x000E2A03,  //  00CE  ADD	R3	K21	R3
-      0x00080403,  //  00CF  ADD	R2	R2	R3
-      0x70020027,  //  00D0  JMP		#00F9
-      0x880C0102,  //  00D1  GETMBR	R3	R0	K2
-      0x88100312,  //  00D2  GETMBR	R4	R1	K18
-      0x1C0C0604,  //  00D3  EQ	R3	R3	R4
-      0x780E0005,  //  00D4  JMPF	R3	#00DB
-      0x600C000C,  //  00D5  GETGBL	R3	G12
-      0x88100105,  //  00D6  GETMBR	R4	R0	K5
-      0x7C0C0200,  //  00D7  CALL	R3	1
-      0x000E2C03,  //  00D8  ADD	R3	K22	R3
-      0x00080403,  //  00D9  ADD	R2	R2	R3
-      0x7002001D,  //  00DA  JMP		#00F9
-      0x880C0102,  //  00DB  GETMBR	R3	R0	K2
-      0x8810030C,  //  00DC  GETMBR	R4	R1	K12
-      0x1C0C0604,  //  00DD  EQ	R3	R3	R4
-      0x780E0005,  //  00DE  JMPF	R3	#00E5
-      0x600C000C,  //  00DF  GETGBL	R3	G12
-      0x88100105,  //  00E0  GETMBR	R4	R0	K5
-      0x7C0C0200,  //  00E1  CALL	R3	1
-      0x000E2A03,  //  00E2  ADD	R3	K21	R3
-      0x00080403,  //  00E3  ADD	R2	R2	R3
-      0x70020013,  //  00E4  JMP		#00F9
-      0x880C0102,  //  00E5  GETMBR	R3	R0	K2
-      0x8810030E,  //  00E6  GETMBR	R4	R1	K14
-      0x1C0C0604,  //  00E7  EQ	R3	R3	R4
-      0x780E0005,  //  00E8  JMPF	R3	#00EF
-      0x600C000C,  //  00E9  GETGBL	R3	G12
-      0x88100105,  //  00EA  GETMBR	R4	R0	K5
-      0x7C0C0200,  //  00EB  CALL	R3	1
-      0x000E2C03,  //  00EC  ADD	R3	K22	R3
-      0x00080403,  //  00ED  ADD	R2	R2	R3
-      0x70020009,  //  00EE  JMP		#00F9
-      0x880C0102,  //  00EF  GETMBR	R3	R0	K2
-      0x8810031D,  //  00F0  GETMBR	R4	R1	K29
-      0x1C0C0604,  //  00F1  EQ	R3	R3	R4
-      0x780E0000,  //  00F2  JMPF	R3	#00F4
-      0x70020004,  //  00F3  JMP		#00F9
-      0x600C0008,  //  00F4  GETGBL	R3	G8
-      0x88100102,  //  00F5  GETMBR	R4	R0	K2
-      0x7C0C0200,  //  00F6  CALL	R3	1
-      0x000E3C03,  //  00F7  ADD	R3	K30	R3
-      0xB0063603,  //  00F8  RAISE	1	K27	R3
-      0x80040400,  //  00F9  RET	1	R2
+      0x70020006,  //  004A  JMP		#0052
+      0x5412FFFE,  //  004B  LDINT	R4	65535
+      0x18100604,  //  004C  LE	R4	R3	R4
+      0x78120003,  //  004D  JMPF	R4	#0052
+      0x28100701,  //  004E  GE	R4	R3	K1
+      0x78120001,  //  004F  JMPF	R4	#0052
+      0x8810030A,  //  0050  GETMBR	R4	R1	K10
+      0x90020404,  //  0051  SETMBR	R0	K2	R4
+      0x70020038,  //  0052  JMP		#008C
+      0x880C0102,  //  0053  GETMBR	R3	R0	K2
+      0x8810030D,  //  0054  GETMBR	R4	R1	K13
+      0x280C0604,  //  0055  GE	R3	R3	R4
+      0x780E0018,  //  0056  JMPF	R3	#0070
+      0x880C0102,  //  0057  GETMBR	R3	R0	K2
+      0x8810030E,  //  0058  GETMBR	R4	R1	K14
+      0x180C0604,  //  0059  LE	R3	R3	R4
+      0x780E0014,  //  005A  JMPF	R3	#0070
+      0x600C000C,  //  005B  GETGBL	R3	G12
+      0x88100104,  //  005C  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  005D  CALL	R3	1
+      0x541200FE,  //  005E  LDINT	R4	255
+      0x180C0604,  //  005F  LE	R3	R3	R4
+      0x780E0002,  //  0060  JMPF	R3	#0064
+      0x880C030D,  //  0061  GETMBR	R3	R1	K13
+      0x90020403,  //  0062  SETMBR	R0	K2	R3
+      0x7002000A,  //  0063  JMP		#006F
+      0x600C000C,  //  0064  GETGBL	R3	G12
+      0x88100104,  //  0065  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  0066  CALL	R3	1
+      0x5412FFFE,  //  0067  LDINT	R4	65535
+      0x180C0604,  //  0068  LE	R3	R3	R4
+      0x780E0002,  //  0069  JMPF	R3	#006D
+      0x880C030F,  //  006A  GETMBR	R3	R1	K15
+      0x90020403,  //  006B  SETMBR	R0	K2	R3
+      0x70020001,  //  006C  JMP		#006F
+      0x880C0310,  //  006D  GETMBR	R3	R1	K16
+      0x90020403,  //  006E  SETMBR	R0	K2	R3
+      0x7002001B,  //  006F  JMP		#008C
+      0x880C0102,  //  0070  GETMBR	R3	R0	K2
+      0x88100311,  //  0071  GETMBR	R4	R1	K17
+      0x280C0604,  //  0072  GE	R3	R3	R4
+      0x780E0017,  //  0073  JMPF	R3	#008C
+      0x880C0102,  //  0074  GETMBR	R3	R0	K2
+      0x88100312,  //  0075  GETMBR	R4	R1	K18
+      0x180C0604,  //  0076  LE	R3	R3	R4
+      0x780E0013,  //  0077  JMPF	R3	#008C
+      0x600C000C,  //  0078  GETGBL	R3	G12
+      0x88100104,  //  0079  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  007A  CALL	R3	1
+      0x541200FE,  //  007B  LDINT	R4	255
+      0x180C0604,  //  007C  LE	R3	R3	R4
+      0x780E0002,  //  007D  JMPF	R3	#0081
+      0x880C0311,  //  007E  GETMBR	R3	R1	K17
+      0x90020403,  //  007F  SETMBR	R0	K2	R3
+      0x7002000A,  //  0080  JMP		#008C
+      0x600C000C,  //  0081  GETGBL	R3	G12
+      0x88100104,  //  0082  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  0083  CALL	R3	1
+      0x5412FFFE,  //  0084  LDINT	R4	65535
+      0x180C0604,  //  0085  LE	R3	R3	R4
+      0x780E0002,  //  0086  JMPF	R3	#008A
+      0x880C0313,  //  0087  GETMBR	R3	R1	K19
+      0x90020403,  //  0088  SETMBR	R0	K2	R3
+      0x70020001,  //  0089  JMP		#008C
+      0x880C0314,  //  008A  GETMBR	R3	R1	K20
+      0x90020403,  //  008B  SETMBR	R0	K2	R3
+      0x8C0C0115,  //  008C  GETMET	R3	R0	K21
+      0x7C0C0200,  //  008D  CALL	R3	1
+      0x00080403,  //  008E  ADD	R2	R2	R3
+      0x880C0102,  //  008F  GETMBR	R3	R0	K2
+      0x88100309,  //  0090  GETMBR	R4	R1	K9
+      0x1C0C0604,  //  0091  EQ	R3	R3	R4
+      0x740E0003,  //  0092  JMPT	R3	#0097
+      0x880C0102,  //  0093  GETMBR	R3	R0	K2
+      0x8810030C,  //  0094  GETMBR	R4	R1	K12
+      0x1C0C0604,  //  0095  EQ	R3	R3	R4
+      0x780E0001,  //  0096  JMPF	R3	#0099
+      0x00080516,  //  0097  ADD	R2	R2	K22
+      0x70020067,  //  0098  JMP		#0101
+      0x880C0102,  //  0099  GETMBR	R3	R0	K2
+      0x88100307,  //  009A  GETMBR	R4	R1	K7
+      0x1C0C0604,  //  009B  EQ	R3	R3	R4
+      0x740E0003,  //  009C  JMPT	R3	#00A1
+      0x880C0102,  //  009D  GETMBR	R3	R0	K2
+      0x8810030A,  //  009E  GETMBR	R4	R1	K10
+      0x1C0C0604,  //  009F  EQ	R3	R3	R4
+      0x780E0001,  //  00A0  JMPF	R3	#00A3
+      0x00080517,  //  00A1  ADD	R2	R2	K23
+      0x7002005D,  //  00A2  JMP		#0101
+      0x880C0102,  //  00A3  GETMBR	R3	R0	K2
+      0x88100308,  //  00A4  GETMBR	R4	R1	K8
+      0x1C0C0604,  //  00A5  EQ	R3	R3	R4
+      0x740E0003,  //  00A6  JMPT	R3	#00AB
+      0x880C0102,  //  00A7  GETMBR	R3	R0	K2
+      0x8810030B,  //  00A8  GETMBR	R4	R1	K11
+      0x1C0C0604,  //  00A9  EQ	R3	R3	R4
+      0x780E0002,  //  00AA  JMPF	R3	#00AE
+      0x540E0003,  //  00AB  LDINT	R3	4
+      0x00080403,  //  00AC  ADD	R2	R2	R3
+      0x70020052,  //  00AD  JMP		#0101
+      0x880C0102,  //  00AE  GETMBR	R3	R0	K2
+      0x88100318,  //  00AF  GETMBR	R4	R1	K24
+      0x1C0C0604,  //  00B0  EQ	R3	R3	R4
+      0x740E0003,  //  00B1  JMPT	R3	#00B6
+      0x880C0102,  //  00B2  GETMBR	R3	R0	K2
+      0x88100319,  //  00B3  GETMBR	R4	R1	K25
+      0x1C0C0604,  //  00B4  EQ	R3	R3	R4
+      0x780E0002,  //  00B5  JMPF	R3	#00B9
+      0x540E0007,  //  00B6  LDINT	R3	8
+      0x00080403,  //  00B7  ADD	R2	R2	R3
+      0x70020047,  //  00B8  JMP		#0101
+      0x880C0102,  //  00B9  GETMBR	R3	R0	K2
+      0x88100305,  //  00BA  GETMBR	R4	R1	K5
+      0x1C0C0604,  //  00BB  EQ	R3	R3	R4
+      0x740E0003,  //  00BC  JMPT	R3	#00C1
+      0x880C0102,  //  00BD  GETMBR	R3	R0	K2
+      0x88100306,  //  00BE  GETMBR	R4	R1	K6
+      0x1C0C0604,  //  00BF  EQ	R3	R3	R4
+      0x780E0000,  //  00C0  JMPF	R3	#00C2
+      0x7002003E,  //  00C1  JMP		#0101
+      0x880C0102,  //  00C2  GETMBR	R3	R0	K2
+      0x8810031A,  //  00C3  GETMBR	R4	R1	K26
+      0x1C0C0604,  //  00C4  EQ	R3	R3	R4
+      0x780E0002,  //  00C5  JMPF	R3	#00C9
+      0x540E0003,  //  00C6  LDINT	R3	4
+      0x00080403,  //  00C7  ADD	R2	R2	R3
+      0x70020037,  //  00C8  JMP		#0101
+      0x880C0102,  //  00C9  GETMBR	R3	R0	K2
+      0x8810031B,  //  00CA  GETMBR	R4	R1	K27
+      0x1C0C0604,  //  00CB  EQ	R3	R3	R4
+      0x780E0001,  //  00CC  JMPF	R3	#00CF
+      0xB006391D,  //  00CD  RAISE	1	K28	K29
+      0x70020031,  //  00CE  JMP		#0101
+      0x880C0102,  //  00CF  GETMBR	R3	R0	K2
+      0x88100311,  //  00D0  GETMBR	R4	R1	K17
+      0x1C0C0604,  //  00D1  EQ	R3	R3	R4
+      0x780E0005,  //  00D2  JMPF	R3	#00D9
+      0x600C000C,  //  00D3  GETGBL	R3	G12
+      0x88100104,  //  00D4  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  00D5  CALL	R3	1
+      0x000E2C03,  //  00D6  ADD	R3	K22	R3
+      0x00080403,  //  00D7  ADD	R2	R2	R3
+      0x70020027,  //  00D8  JMP		#0101
+      0x880C0102,  //  00D9  GETMBR	R3	R0	K2
+      0x88100313,  //  00DA  GETMBR	R4	R1	K19
+      0x1C0C0604,  //  00DB  EQ	R3	R3	R4
+      0x780E0005,  //  00DC  JMPF	R3	#00E3
+      0x600C000C,  //  00DD  GETGBL	R3	G12
+      0x88100104,  //  00DE  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  00DF  CALL	R3	1
+      0x000E2E03,  //  00E0  ADD	R3	K23	R3
+      0x00080403,  //  00E1  ADD	R2	R2	R3
+      0x7002001D,  //  00E2  JMP		#0101
+      0x880C0102,  //  00E3  GETMBR	R3	R0	K2
+      0x8810030D,  //  00E4  GETMBR	R4	R1	K13
+      0x1C0C0604,  //  00E5  EQ	R3	R3	R4
+      0x780E0005,  //  00E6  JMPF	R3	#00ED
+      0x600C000C,  //  00E7  GETGBL	R3	G12
+      0x88100104,  //  00E8  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  00E9  CALL	R3	1
+      0x000E2C03,  //  00EA  ADD	R3	K22	R3
+      0x00080403,  //  00EB  ADD	R2	R2	R3
+      0x70020013,  //  00EC  JMP		#0101
+      0x880C0102,  //  00ED  GETMBR	R3	R0	K2
+      0x8810030F,  //  00EE  GETMBR	R4	R1	K15
+      0x1C0C0604,  //  00EF  EQ	R3	R3	R4
+      0x780E0005,  //  00F0  JMPF	R3	#00F7
+      0x600C000C,  //  00F1  GETGBL	R3	G12
+      0x88100104,  //  00F2  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  00F3  CALL	R3	1
+      0x000E2E03,  //  00F4  ADD	R3	K23	R3
+      0x00080403,  //  00F5  ADD	R2	R2	R3
+      0x70020009,  //  00F6  JMP		#0101
+      0x880C0102,  //  00F7  GETMBR	R3	R0	K2
+      0x8810031E,  //  00F8  GETMBR	R4	R1	K30
+      0x1C0C0604,  //  00F9  EQ	R3	R3	R4
+      0x780E0000,  //  00FA  JMPF	R3	#00FC
+      0x70020004,  //  00FB  JMP		#0101
+      0x600C0008,  //  00FC  GETGBL	R3	G8
+      0x88100102,  //  00FD  GETMBR	R4	R0	K2
+      0x7C0C0200,  //  00FE  CALL	R3	1
+      0x000E3E03,  //  00FF  ADD	R3	K31	R3
+      0xB0063803,  //  0100  RAISE	1	K28	R3
+      0x80040400,  //  0101  RET	1	R2
     })
   )
 );
@@ -1045,52 +1054,53 @@ be_local_closure(Matter_TLV_item_tlv2raw,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[41]) {     /* constants */
+    ( &(const bvalue[42]) {     /* constants */
     /* K0   */  be_nested_str_weak(TLV),
     /* K1   */  be_nested_str_weak(typ),
-    /* K2   */  be_nested_str_weak(BFALSE),
-    /* K3   */  be_nested_str_weak(BTRUE),
-    /* K4   */  be_nested_str_weak(val),
-    /* K5   */  be_nested_str_weak(I2),
-    /* K6   */  be_nested_str_weak(I4),
-    /* K7   */  be_nested_str_weak(I1),
-    /* K8   */  be_nested_str_weak(U2),
-    /* K9   */  be_nested_str_weak(U4),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(U1),
-    /* K12  */  be_nested_str_weak(B1),
-    /* K13  */  be_nested_str_weak(B8),
-    /* K14  */  be_nested_str_weak(B2),
-    /* K15  */  be_nested_str_weak(B4),
-    /* K16  */  be_nested_str_weak(UTF1),
-    /* K17  */  be_nested_str_weak(UTF8),
-    /* K18  */  be_nested_str_weak(UTF2),
-    /* K19  */  be_nested_str_weak(UTF4),
-    /* K20  */  be_nested_str_weak(_encode_tag),
-    /* K21  */  be_nested_str_weak(add),
-    /* K22  */  be_const_int(1),
-    /* K23  */  be_const_int(2),
-    /* K24  */  be_nested_str_weak(I8),
-    /* K25  */  be_nested_str_weak(U8),
-    /* K26  */  be_nested_str_weak(copy),
-    /* K27  */  be_nested_str_weak(resize),
-    /* K28  */  be_nested_str_weak(int64),
-    /* K29  */  be_nested_str_weak(tobytes),
-    /* K30  */  be_nested_str_weak(FLOAT),
-    /* K31  */  be_nested_str_weak(setfloat),
-    /* K32  */  be_nested_str_weak(DOUBLE),
-    /* K33  */  be_nested_str_weak(value_error),
-    /* K34  */  be_nested_str_weak(Unsupported_X20type_X20TLV_X2EDOUBLE),
-    /* K35  */  be_nested_str_weak(string_X20too_X20big),
-    /* K36  */  be_nested_str_weak(fromstring),
-    /* K37  */  be_nested_str_weak(frostring),
-    /* K38  */  be_nested_str_weak(bytes_X20too_X20big),
-    /* K39  */  be_nested_str_weak(NULL),
-    /* K40  */  be_nested_str_weak(unsupported_X20type_X20),
+    /* K2   */  be_nested_str_weak(RAW),
+    /* K3   */  be_nested_str_weak(val),
+    /* K4   */  be_nested_str_weak(BFALSE),
+    /* K5   */  be_nested_str_weak(BTRUE),
+    /* K6   */  be_nested_str_weak(I2),
+    /* K7   */  be_nested_str_weak(I4),
+    /* K8   */  be_nested_str_weak(I1),
+    /* K9   */  be_nested_str_weak(U2),
+    /* K10  */  be_nested_str_weak(U4),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_weak(U1),
+    /* K13  */  be_nested_str_weak(B1),
+    /* K14  */  be_nested_str_weak(B8),
+    /* K15  */  be_nested_str_weak(B2),
+    /* K16  */  be_nested_str_weak(B4),
+    /* K17  */  be_nested_str_weak(UTF1),
+    /* K18  */  be_nested_str_weak(UTF8),
+    /* K19  */  be_nested_str_weak(UTF2),
+    /* K20  */  be_nested_str_weak(UTF4),
+    /* K21  */  be_nested_str_weak(_encode_tag),
+    /* K22  */  be_nested_str_weak(add),
+    /* K23  */  be_const_int(1),
+    /* K24  */  be_const_int(2),
+    /* K25  */  be_nested_str_weak(I8),
+    /* K26  */  be_nested_str_weak(U8),
+    /* K27  */  be_nested_str_weak(copy),
+    /* K28  */  be_nested_str_weak(resize),
+    /* K29  */  be_nested_str_weak(int64),
+    /* K30  */  be_nested_str_weak(tobytes),
+    /* K31  */  be_nested_str_weak(FLOAT),
+    /* K32  */  be_nested_str_weak(setfloat),
+    /* K33  */  be_nested_str_weak(DOUBLE),
+    /* K34  */  be_nested_str_weak(value_error),
+    /* K35  */  be_nested_str_weak(Unsupported_X20type_X20TLV_X2EDOUBLE),
+    /* K36  */  be_nested_str_weak(string_X20too_X20big),
+    /* K37  */  be_nested_str_weak(fromstring),
+    /* K38  */  be_nested_str_weak(frostring),
+    /* K39  */  be_nested_str_weak(bytes_X20too_X20big),
+    /* K40  */  be_nested_str_weak(NULL),
+    /* K41  */  be_nested_str_weak(unsupported_X20type_X20),
     }),
     be_str_weak(tlv2raw),
     &be_const_str_solidified,
-    ( &(const binstruction[361]) {  /* code */
+    ( &(const binstruction[368]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x4C0C0000,  //  0001  LDNIL	R3
       0x1C0C0203,  //  0002  EQ	R3	R1	R3
@@ -1101,357 +1111,364 @@ be_local_closure(Matter_TLV_item_tlv2raw,   /* name */
       0x880C0101,  //  0007  GETMBR	R3	R0	K1
       0x88100502,  //  0008  GETMBR	R4	R2	K2
       0x1C0C0604,  //  0009  EQ	R3	R3	R4
-      0x740E0003,  //  000A  JMPT	R3	#000F
-      0x880C0101,  //  000B  GETMBR	R3	R0	K1
-      0x88100503,  //  000C  GETMBR	R4	R2	K3
-      0x1C0C0604,  //  000D  EQ	R3	R3	R4
-      0x780E0008,  //  000E  JMPF	R3	#0018
-      0x600C0017,  //  000F  GETGBL	R3	G23
-      0x88100104,  //  0010  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  0011  CALL	R3	1
-      0x780E0001,  //  0012  JMPF	R3	#0015
-      0x880C0503,  //  0013  GETMBR	R3	R2	K3
-      0x70020000,  //  0014  JMP		#0016
-      0x880C0502,  //  0015  GETMBR	R3	R2	K2
-      0x90020203,  //  0016  SETMBR	R0	K1	R3
-      0x70020070,  //  0017  JMP		#0089
-      0x880C0101,  //  0018  GETMBR	R3	R0	K1
-      0x88100505,  //  0019  GETMBR	R4	R2	K5
-      0x280C0604,  //  001A  GE	R3	R3	R4
-      0x780E0018,  //  001B  JMPF	R3	#0035
-      0x880C0101,  //  001C  GETMBR	R3	R0	K1
-      0x88100506,  //  001D  GETMBR	R4	R2	K6
-      0x180C0604,  //  001E  LE	R3	R3	R4
-      0x780E0014,  //  001F  JMPF	R3	#0035
-      0x600C0009,  //  0020  GETGBL	R3	G9
-      0x88100104,  //  0021  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  0022  CALL	R3	1
-      0x5412007E,  //  0023  LDINT	R4	127
-      0x18100604,  //  0024  LE	R4	R3	R4
-      0x78120005,  //  0025  JMPF	R4	#002C
-      0x5411FF7F,  //  0026  LDINT	R4	-128
-      0x28100604,  //  0027  GE	R4	R3	R4
-      0x78120002,  //  0028  JMPF	R4	#002C
-      0x88100507,  //  0029  GETMBR	R4	R2	K7
-      0x90020204,  //  002A  SETMBR	R0	K1	R4
-      0x70020007,  //  002B  JMP		#0034
-      0x54127FFE,  //  002C  LDINT	R4	32767
-      0x18100604,  //  002D  LE	R4	R3	R4
-      0x78120004,  //  002E  JMPF	R4	#0034
-      0x54117FFF,  //  002F  LDINT	R4	-32768
-      0x28100604,  //  0030  GE	R4	R3	R4
-      0x78120001,  //  0031  JMPF	R4	#0034
-      0x88100505,  //  0032  GETMBR	R4	R2	K5
-      0x90020204,  //  0033  SETMBR	R0	K1	R4
-      0x70020053,  //  0034  JMP		#0089
-      0x880C0101,  //  0035  GETMBR	R3	R0	K1
-      0x88100508,  //  0036  GETMBR	R4	R2	K8
-      0x280C0604,  //  0037  GE	R3	R3	R4
-      0x780E0016,  //  0038  JMPF	R3	#0050
-      0x880C0101,  //  0039  GETMBR	R3	R0	K1
-      0x88100509,  //  003A  GETMBR	R4	R2	K9
-      0x180C0604,  //  003B  LE	R3	R3	R4
-      0x780E0012,  //  003C  JMPF	R3	#0050
-      0x600C0009,  //  003D  GETGBL	R3	G9
-      0x88100104,  //  003E  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  003F  CALL	R3	1
-      0x541200FE,  //  0040  LDINT	R4	255
-      0x18100604,  //  0041  LE	R4	R3	R4
-      0x78120004,  //  0042  JMPF	R4	#0048
-      0x2810070A,  //  0043  GE	R4	R3	K10
-      0x78120002,  //  0044  JMPF	R4	#0048
-      0x8810050B,  //  0045  GETMBR	R4	R2	K11
-      0x90020204,  //  0046  SETMBR	R0	K1	R4
-      0x70020006,  //  0047  JMP		#004F
-      0x5412FFFE,  //  0048  LDINT	R4	65535
-      0x18100604,  //  0049  LE	R4	R3	R4
-      0x78120003,  //  004A  JMPF	R4	#004F
-      0x2810070A,  //  004B  GE	R4	R3	K10
-      0x78120001,  //  004C  JMPF	R4	#004F
-      0x88100508,  //  004D  GETMBR	R4	R2	K8
-      0x90020204,  //  004E  SETMBR	R0	K1	R4
-      0x70020038,  //  004F  JMP		#0089
-      0x880C0101,  //  0050  GETMBR	R3	R0	K1
-      0x8810050C,  //  0051  GETMBR	R4	R2	K12
-      0x280C0604,  //  0052  GE	R3	R3	R4
-      0x780E0018,  //  0053  JMPF	R3	#006D
-      0x880C0101,  //  0054  GETMBR	R3	R0	K1
-      0x8810050D,  //  0055  GETMBR	R4	R2	K13
-      0x180C0604,  //  0056  LE	R3	R3	R4
-      0x780E0014,  //  0057  JMPF	R3	#006D
-      0x600C000C,  //  0058  GETGBL	R3	G12
-      0x88100104,  //  0059  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  005A  CALL	R3	1
-      0x541200FE,  //  005B  LDINT	R4	255
-      0x180C0604,  //  005C  LE	R3	R3	R4
-      0x780E0002,  //  005D  JMPF	R3	#0061
-      0x880C050C,  //  005E  GETMBR	R3	R2	K12
-      0x90020203,  //  005F  SETMBR	R0	K1	R3
-      0x7002000A,  //  0060  JMP		#006C
-      0x600C000C,  //  0061  GETGBL	R3	G12
-      0x88100104,  //  0062  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  0063  CALL	R3	1
-      0x5412FFFE,  //  0064  LDINT	R4	65535
-      0x180C0604,  //  0065  LE	R3	R3	R4
-      0x780E0002,  //  0066  JMPF	R3	#006A
-      0x880C050E,  //  0067  GETMBR	R3	R2	K14
-      0x90020203,  //  0068  SETMBR	R0	K1	R3
-      0x70020001,  //  0069  JMP		#006C
-      0x880C050F,  //  006A  GETMBR	R3	R2	K15
-      0x90020203,  //  006B  SETMBR	R0	K1	R3
-      0x7002001B,  //  006C  JMP		#0089
-      0x880C0101,  //  006D  GETMBR	R3	R0	K1
-      0x88100510,  //  006E  GETMBR	R4	R2	K16
-      0x280C0604,  //  006F  GE	R3	R3	R4
-      0x780E0017,  //  0070  JMPF	R3	#0089
-      0x880C0101,  //  0071  GETMBR	R3	R0	K1
-      0x88100511,  //  0072  GETMBR	R4	R2	K17
-      0x180C0604,  //  0073  LE	R3	R3	R4
-      0x780E0013,  //  0074  JMPF	R3	#0089
-      0x600C000C,  //  0075  GETGBL	R3	G12
-      0x88100104,  //  0076  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  0077  CALL	R3	1
-      0x541200FE,  //  0078  LDINT	R4	255
-      0x180C0604,  //  0079  LE	R3	R3	R4
-      0x780E0002,  //  007A  JMPF	R3	#007E
-      0x880C0510,  //  007B  GETMBR	R3	R2	K16
-      0x90020203,  //  007C  SETMBR	R0	K1	R3
-      0x7002000A,  //  007D  JMP		#0089
-      0x600C000C,  //  007E  GETGBL	R3	G12
-      0x88100104,  //  007F  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  0080  CALL	R3	1
-      0x5412FFFE,  //  0081  LDINT	R4	65535
-      0x180C0604,  //  0082  LE	R3	R3	R4
-      0x780E0002,  //  0083  JMPF	R3	#0087
-      0x880C0512,  //  0084  GETMBR	R3	R2	K18
-      0x90020203,  //  0085  SETMBR	R0	K1	R3
-      0x70020001,  //  0086  JMP		#0089
-      0x880C0513,  //  0087  GETMBR	R3	R2	K19
-      0x90020203,  //  0088  SETMBR	R0	K1	R3
-      0x8C0C0114,  //  0089  GETMET	R3	R0	K20
-      0x5C140200,  //  008A  MOVE	R5	R1
-      0x7C0C0400,  //  008B  CALL	R3	2
-      0x880C0101,  //  008C  GETMBR	R3	R0	K1
-      0x88100507,  //  008D  GETMBR	R4	R2	K7
-      0x1C0C0604,  //  008E  EQ	R3	R3	R4
-      0x740E0003,  //  008F  JMPT	R3	#0094
-      0x880C0101,  //  0090  GETMBR	R3	R0	K1
-      0x8810050B,  //  0091  GETMBR	R4	R2	K11
-      0x1C0C0604,  //  0092  EQ	R3	R3	R4
-      0x780E0006,  //  0093  JMPF	R3	#009B
-      0x8C0C0315,  //  0094  GETMET	R3	R1	K21
-      0x60140009,  //  0095  GETGBL	R5	G9
-      0x88180104,  //  0096  GETMBR	R6	R0	K4
-      0x7C140200,  //  0097  CALL	R5	1
-      0x58180016,  //  0098  LDCONST	R6	K22
-      0x7C0C0600,  //  0099  CALL	R3	3
-      0x700200CC,  //  009A  JMP		#0168
-      0x880C0101,  //  009B  GETMBR	R3	R0	K1
-      0x88100505,  //  009C  GETMBR	R4	R2	K5
-      0x1C0C0604,  //  009D  EQ	R3	R3	R4
-      0x740E0003,  //  009E  JMPT	R3	#00A3
-      0x880C0101,  //  009F  GETMBR	R3	R0	K1
-      0x88100508,  //  00A0  GETMBR	R4	R2	K8
-      0x1C0C0604,  //  00A1  EQ	R3	R3	R4
-      0x780E0006,  //  00A2  JMPF	R3	#00AA
-      0x8C0C0315,  //  00A3  GETMET	R3	R1	K21
-      0x60140009,  //  00A4  GETGBL	R5	G9
-      0x88180104,  //  00A5  GETMBR	R6	R0	K4
-      0x7C140200,  //  00A6  CALL	R5	1
-      0x58180017,  //  00A7  LDCONST	R6	K23
-      0x7C0C0600,  //  00A8  CALL	R3	3
-      0x700200BD,  //  00A9  JMP		#0168
-      0x880C0101,  //  00AA  GETMBR	R3	R0	K1
-      0x88100506,  //  00AB  GETMBR	R4	R2	K6
-      0x1C0C0604,  //  00AC  EQ	R3	R3	R4
-      0x740E0003,  //  00AD  JMPT	R3	#00B2
-      0x880C0101,  //  00AE  GETMBR	R3	R0	K1
-      0x88100509,  //  00AF  GETMBR	R4	R2	K9
-      0x1C0C0604,  //  00B0  EQ	R3	R3	R4
-      0x780E0006,  //  00B1  JMPF	R3	#00B9
-      0x8C0C0315,  //  00B2  GETMET	R3	R1	K21
-      0x60140009,  //  00B3  GETGBL	R5	G9
-      0x88180104,  //  00B4  GETMBR	R6	R0	K4
-      0x7C140200,  //  00B5  CALL	R5	1
-      0x541A0003,  //  00B6  LDINT	R6	4
-      0x7C0C0600,  //  00B7  CALL	R3	3
-      0x700200AE,  //  00B8  JMP		#0168
-      0x880C0101,  //  00B9  GETMBR	R3	R0	K1
-      0x88100518,  //  00BA  GETMBR	R4	R2	K24
-      0x1C0C0604,  //  00BB  EQ	R3	R3	R4
-      0x740E0003,  //  00BC  JMPT	R3	#00C1
-      0x880C0101,  //  00BD  GETMBR	R3	R0	K1
-      0x88100519,  //  00BE  GETMBR	R4	R2	K25
-      0x1C0C0604,  //  00BF  EQ	R3	R3	R4
-      0x780E001F,  //  00C0  JMPF	R3	#00E1
-      0x880C0104,  //  00C1  GETMBR	R3	R0	K4
-      0x6010000F,  //  00C2  GETGBL	R4	G15
-      0x5C140600,  //  00C3  MOVE	R5	R3
-      0x60180015,  //  00C4  GETGBL	R6	G21
-      0x7C100400,  //  00C5  CALL	R4	2
-      0x78120006,  //  00C6  JMPF	R4	#00CE
-      0x8C10071A,  //  00C7  GETMET	R4	R3	K26
-      0x7C100200,  //  00C8  CALL	R4	1
-      0x8C10091B,  //  00C9  GETMET	R4	R4	K27
-      0x541A0007,  //  00CA  LDINT	R6	8
-      0x7C100400,  //  00CB  CALL	R4	2
-      0x5C0C0800,  //  00CC  MOVE	R3	R4
-      0x70020010,  //  00CD  JMP		#00DF
-      0x6010000F,  //  00CE  GETGBL	R4	G15
-      0x5C140600,  //  00CF  MOVE	R5	R3
-      0xB81A3800,  //  00D0  GETNGBL	R6	K28
-      0x7C100400,  //  00D1  CALL	R4	2
-      0x78120003,  //  00D2  JMPF	R4	#00D7
-      0x8C10071D,  //  00D3  GETMET	R4	R3	K29
-      0x7C100200,  //  00D4  CALL	R4	1
-      0x5C0C0800,  //  00D5  MOVE	R3	R4
-      0x70020007,  //  00D6  JMP		#00DF
-      0xB8123800,  //  00D7  GETNGBL	R4	K28
-      0x60140009,  //  00D8  GETGBL	R5	G9
-      0x5C180600,  //  00D9  MOVE	R6	R3
-      0x7C140200,  //  00DA  CALL	R5	1
+      0x780E0002,  //  000A  JMPF	R3	#000E
+      0x880C0103,  //  000B  GETMBR	R3	R0	K3
+      0x400C0203,  //  000C  CONNECT	R3	R1	R3
+      0x80040200,  //  000D  RET	1	R1
+      0x880C0101,  //  000E  GETMBR	R3	R0	K1
+      0x88100504,  //  000F  GETMBR	R4	R2	K4
+      0x1C0C0604,  //  0010  EQ	R3	R3	R4
+      0x740E0003,  //  0011  JMPT	R3	#0016
+      0x880C0101,  //  0012  GETMBR	R3	R0	K1
+      0x88100505,  //  0013  GETMBR	R4	R2	K5
+      0x1C0C0604,  //  0014  EQ	R3	R3	R4
+      0x780E0008,  //  0015  JMPF	R3	#001F
+      0x600C0017,  //  0016  GETGBL	R3	G23
+      0x88100103,  //  0017  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0018  CALL	R3	1
+      0x780E0001,  //  0019  JMPF	R3	#001C
+      0x880C0505,  //  001A  GETMBR	R3	R2	K5
+      0x70020000,  //  001B  JMP		#001D
+      0x880C0504,  //  001C  GETMBR	R3	R2	K4
+      0x90020203,  //  001D  SETMBR	R0	K1	R3
+      0x70020070,  //  001E  JMP		#0090
+      0x880C0101,  //  001F  GETMBR	R3	R0	K1
+      0x88100506,  //  0020  GETMBR	R4	R2	K6
+      0x280C0604,  //  0021  GE	R3	R3	R4
+      0x780E0018,  //  0022  JMPF	R3	#003C
+      0x880C0101,  //  0023  GETMBR	R3	R0	K1
+      0x88100507,  //  0024  GETMBR	R4	R2	K7
+      0x180C0604,  //  0025  LE	R3	R3	R4
+      0x780E0014,  //  0026  JMPF	R3	#003C
+      0x600C0009,  //  0027  GETGBL	R3	G9
+      0x88100103,  //  0028  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0029  CALL	R3	1
+      0x5412007E,  //  002A  LDINT	R4	127
+      0x18100604,  //  002B  LE	R4	R3	R4
+      0x78120005,  //  002C  JMPF	R4	#0033
+      0x5411FF7F,  //  002D  LDINT	R4	-128
+      0x28100604,  //  002E  GE	R4	R3	R4
+      0x78120002,  //  002F  JMPF	R4	#0033
+      0x88100508,  //  0030  GETMBR	R4	R2	K8
+      0x90020204,  //  0031  SETMBR	R0	K1	R4
+      0x70020007,  //  0032  JMP		#003B
+      0x54127FFE,  //  0033  LDINT	R4	32767
+      0x18100604,  //  0034  LE	R4	R3	R4
+      0x78120004,  //  0035  JMPF	R4	#003B
+      0x54117FFF,  //  0036  LDINT	R4	-32768
+      0x28100604,  //  0037  GE	R4	R3	R4
+      0x78120001,  //  0038  JMPF	R4	#003B
+      0x88100506,  //  0039  GETMBR	R4	R2	K6
+      0x90020204,  //  003A  SETMBR	R0	K1	R4
+      0x70020053,  //  003B  JMP		#0090
+      0x880C0101,  //  003C  GETMBR	R3	R0	K1
+      0x88100509,  //  003D  GETMBR	R4	R2	K9
+      0x280C0604,  //  003E  GE	R3	R3	R4
+      0x780E0016,  //  003F  JMPF	R3	#0057
+      0x880C0101,  //  0040  GETMBR	R3	R0	K1
+      0x8810050A,  //  0041  GETMBR	R4	R2	K10
+      0x180C0604,  //  0042  LE	R3	R3	R4
+      0x780E0012,  //  0043  JMPF	R3	#0057
+      0x600C0009,  //  0044  GETGBL	R3	G9
+      0x88100103,  //  0045  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0046  CALL	R3	1
+      0x541200FE,  //  0047  LDINT	R4	255
+      0x18100604,  //  0048  LE	R4	R3	R4
+      0x78120004,  //  0049  JMPF	R4	#004F
+      0x2810070B,  //  004A  GE	R4	R3	K11
+      0x78120002,  //  004B  JMPF	R4	#004F
+      0x8810050C,  //  004C  GETMBR	R4	R2	K12
+      0x90020204,  //  004D  SETMBR	R0	K1	R4
+      0x70020006,  //  004E  JMP		#0056
+      0x5412FFFE,  //  004F  LDINT	R4	65535
+      0x18100604,  //  0050  LE	R4	R3	R4
+      0x78120003,  //  0051  JMPF	R4	#0056
+      0x2810070B,  //  0052  GE	R4	R3	K11
+      0x78120001,  //  0053  JMPF	R4	#0056
+      0x88100509,  //  0054  GETMBR	R4	R2	K9
+      0x90020204,  //  0055  SETMBR	R0	K1	R4
+      0x70020038,  //  0056  JMP		#0090
+      0x880C0101,  //  0057  GETMBR	R3	R0	K1
+      0x8810050D,  //  0058  GETMBR	R4	R2	K13
+      0x280C0604,  //  0059  GE	R3	R3	R4
+      0x780E0018,  //  005A  JMPF	R3	#0074
+      0x880C0101,  //  005B  GETMBR	R3	R0	K1
+      0x8810050E,  //  005C  GETMBR	R4	R2	K14
+      0x180C0604,  //  005D  LE	R3	R3	R4
+      0x780E0014,  //  005E  JMPF	R3	#0074
+      0x600C000C,  //  005F  GETGBL	R3	G12
+      0x88100103,  //  0060  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0061  CALL	R3	1
+      0x541200FE,  //  0062  LDINT	R4	255
+      0x180C0604,  //  0063  LE	R3	R3	R4
+      0x780E0002,  //  0064  JMPF	R3	#0068
+      0x880C050D,  //  0065  GETMBR	R3	R2	K13
+      0x90020203,  //  0066  SETMBR	R0	K1	R3
+      0x7002000A,  //  0067  JMP		#0073
+      0x600C000C,  //  0068  GETGBL	R3	G12
+      0x88100103,  //  0069  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  006A  CALL	R3	1
+      0x5412FFFE,  //  006B  LDINT	R4	65535
+      0x180C0604,  //  006C  LE	R3	R3	R4
+      0x780E0002,  //  006D  JMPF	R3	#0071
+      0x880C050F,  //  006E  GETMBR	R3	R2	K15
+      0x90020203,  //  006F  SETMBR	R0	K1	R3
+      0x70020001,  //  0070  JMP		#0073
+      0x880C0510,  //  0071  GETMBR	R3	R2	K16
+      0x90020203,  //  0072  SETMBR	R0	K1	R3
+      0x7002001B,  //  0073  JMP		#0090
+      0x880C0101,  //  0074  GETMBR	R3	R0	K1
+      0x88100511,  //  0075  GETMBR	R4	R2	K17
+      0x280C0604,  //  0076  GE	R3	R3	R4
+      0x780E0017,  //  0077  JMPF	R3	#0090
+      0x880C0101,  //  0078  GETMBR	R3	R0	K1
+      0x88100512,  //  0079  GETMBR	R4	R2	K18
+      0x180C0604,  //  007A  LE	R3	R3	R4
+      0x780E0013,  //  007B  JMPF	R3	#0090
+      0x600C000C,  //  007C  GETGBL	R3	G12
+      0x88100103,  //  007D  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  007E  CALL	R3	1
+      0x541200FE,  //  007F  LDINT	R4	255
+      0x180C0604,  //  0080  LE	R3	R3	R4
+      0x780E0002,  //  0081  JMPF	R3	#0085
+      0x880C0511,  //  0082  GETMBR	R3	R2	K17
+      0x90020203,  //  0083  SETMBR	R0	K1	R3
+      0x7002000A,  //  0084  JMP		#0090
+      0x600C000C,  //  0085  GETGBL	R3	G12
+      0x88100103,  //  0086  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0087  CALL	R3	1
+      0x5412FFFE,  //  0088  LDINT	R4	65535
+      0x180C0604,  //  0089  LE	R3	R3	R4
+      0x780E0002,  //  008A  JMPF	R3	#008E
+      0x880C0513,  //  008B  GETMBR	R3	R2	K19
+      0x90020203,  //  008C  SETMBR	R0	K1	R3
+      0x70020001,  //  008D  JMP		#0090
+      0x880C0514,  //  008E  GETMBR	R3	R2	K20
+      0x90020203,  //  008F  SETMBR	R0	K1	R3
+      0x8C0C0115,  //  0090  GETMET	R3	R0	K21
+      0x5C140200,  //  0091  MOVE	R5	R1
+      0x7C0C0400,  //  0092  CALL	R3	2
+      0x880C0101,  //  0093  GETMBR	R3	R0	K1
+      0x88100508,  //  0094  GETMBR	R4	R2	K8
+      0x1C0C0604,  //  0095  EQ	R3	R3	R4
+      0x740E0003,  //  0096  JMPT	R3	#009B
+      0x880C0101,  //  0097  GETMBR	R3	R0	K1
+      0x8810050C,  //  0098  GETMBR	R4	R2	K12
+      0x1C0C0604,  //  0099  EQ	R3	R3	R4
+      0x780E0006,  //  009A  JMPF	R3	#00A2
+      0x8C0C0316,  //  009B  GETMET	R3	R1	K22
+      0x60140009,  //  009C  GETGBL	R5	G9
+      0x88180103,  //  009D  GETMBR	R6	R0	K3
+      0x7C140200,  //  009E  CALL	R5	1
+      0x58180017,  //  009F  LDCONST	R6	K23
+      0x7C0C0600,  //  00A0  CALL	R3	3
+      0x700200CC,  //  00A1  JMP		#016F
+      0x880C0101,  //  00A2  GETMBR	R3	R0	K1
+      0x88100506,  //  00A3  GETMBR	R4	R2	K6
+      0x1C0C0604,  //  00A4  EQ	R3	R3	R4
+      0x740E0003,  //  00A5  JMPT	R3	#00AA
+      0x880C0101,  //  00A6  GETMBR	R3	R0	K1
+      0x88100509,  //  00A7  GETMBR	R4	R2	K9
+      0x1C0C0604,  //  00A8  EQ	R3	R3	R4
+      0x780E0006,  //  00A9  JMPF	R3	#00B1
+      0x8C0C0316,  //  00AA  GETMET	R3	R1	K22
+      0x60140009,  //  00AB  GETGBL	R5	G9
+      0x88180103,  //  00AC  GETMBR	R6	R0	K3
+      0x7C140200,  //  00AD  CALL	R5	1
+      0x58180018,  //  00AE  LDCONST	R6	K24
+      0x7C0C0600,  //  00AF  CALL	R3	3
+      0x700200BD,  //  00B0  JMP		#016F
+      0x880C0101,  //  00B1  GETMBR	R3	R0	K1
+      0x88100507,  //  00B2  GETMBR	R4	R2	K7
+      0x1C0C0604,  //  00B3  EQ	R3	R3	R4
+      0x740E0003,  //  00B4  JMPT	R3	#00B9
+      0x880C0101,  //  00B5  GETMBR	R3	R0	K1
+      0x8810050A,  //  00B6  GETMBR	R4	R2	K10
+      0x1C0C0604,  //  00B7  EQ	R3	R3	R4
+      0x780E0006,  //  00B8  JMPF	R3	#00C0
+      0x8C0C0316,  //  00B9  GETMET	R3	R1	K22
+      0x60140009,  //  00BA  GETGBL	R5	G9
+      0x88180103,  //  00BB  GETMBR	R6	R0	K3
+      0x7C140200,  //  00BC  CALL	R5	1
+      0x541A0003,  //  00BD  LDINT	R6	4
+      0x7C0C0600,  //  00BE  CALL	R3	3
+      0x700200AE,  //  00BF  JMP		#016F
+      0x880C0101,  //  00C0  GETMBR	R3	R0	K1
+      0x88100519,  //  00C1  GETMBR	R4	R2	K25
+      0x1C0C0604,  //  00C2  EQ	R3	R3	R4
+      0x740E0003,  //  00C3  JMPT	R3	#00C8
+      0x880C0101,  //  00C4  GETMBR	R3	R0	K1
+      0x8810051A,  //  00C5  GETMBR	R4	R2	K26
+      0x1C0C0604,  //  00C6  EQ	R3	R3	R4
+      0x780E001F,  //  00C7  JMPF	R3	#00E8
+      0x880C0103,  //  00C8  GETMBR	R3	R0	K3
+      0x6010000F,  //  00C9  GETGBL	R4	G15
+      0x5C140600,  //  00CA  MOVE	R5	R3
+      0x60180015,  //  00CB  GETGBL	R6	G21
+      0x7C100400,  //  00CC  CALL	R4	2
+      0x78120006,  //  00CD  JMPF	R4	#00D5
+      0x8C10071B,  //  00CE  GETMET	R4	R3	K27
+      0x7C100200,  //  00CF  CALL	R4	1
+      0x8C10091C,  //  00D0  GETMET	R4	R4	K28
+      0x541A0007,  //  00D1  LDINT	R6	8
+      0x7C100400,  //  00D2  CALL	R4	2
+      0x5C0C0800,  //  00D3  MOVE	R3	R4
+      0x70020010,  //  00D4  JMP		#00E6
+      0x6010000F,  //  00D5  GETGBL	R4	G15
+      0x5C140600,  //  00D6  MOVE	R5	R3
+      0xB81A3A00,  //  00D7  GETNGBL	R6	K29
+      0x7C100400,  //  00D8  CALL	R4	2
+      0x78120003,  //  00D9  JMPF	R4	#00DE
+      0x8C10071E,  //  00DA  GETMET	R4	R3	K30
       0x7C100200,  //  00DB  CALL	R4	1
-      0x8C10091D,  //  00DC  GETMET	R4	R4	K29
-      0x7C100200,  //  00DD  CALL	R4	1
-      0x5C0C0800,  //  00DE  MOVE	R3	R4
-      0x40100203,  //  00DF  CONNECT	R4	R1	R3
-      0x70020086,  //  00E0  JMP		#0168
-      0x880C0101,  //  00E1  GETMBR	R3	R0	K1
-      0x88100502,  //  00E2  GETMBR	R4	R2	K2
-      0x1C0C0604,  //  00E3  EQ	R3	R3	R4
-      0x740E0003,  //  00E4  JMPT	R3	#00E9
-      0x880C0101,  //  00E5  GETMBR	R3	R0	K1
-      0x88100503,  //  00E6  GETMBR	R4	R2	K3
-      0x1C0C0604,  //  00E7  EQ	R3	R3	R4
-      0x780E0000,  //  00E8  JMPF	R3	#00EA
-      0x7002007D,  //  00E9  JMP		#0168
-      0x880C0101,  //  00EA  GETMBR	R3	R0	K1
-      0x8810051E,  //  00EB  GETMBR	R4	R2	K30
-      0x1C0C0604,  //  00EC  EQ	R3	R3	R4
-      0x780E000D,  //  00ED  JMPF	R3	#00FC
-      0x600C000C,  //  00EE  GETGBL	R3	G12
-      0x5C100200,  //  00EF  MOVE	R4	R1
-      0x7C0C0200,  //  00F0  CALL	R3	1
-      0x8C100315,  //  00F1  GETMET	R4	R1	K21
-      0x5818000A,  //  00F2  LDCONST	R6	K10
-      0x541E0003,  //  00F3  LDINT	R7	4
-      0x7C100600,  //  00F4  CALL	R4	3
-      0x8C10031F,  //  00F5  GETMET	R4	R1	K31
-      0x5C180600,  //  00F6  MOVE	R6	R3
-      0x601C000A,  //  00F7  GETGBL	R7	G10
-      0x88200104,  //  00F8  GETMBR	R8	R0	K4
-      0x7C1C0200,  //  00F9  CALL	R7	1
-      0x7C100600,  //  00FA  CALL	R4	3
-      0x7002006B,  //  00FB  JMP		#0168
-      0x880C0101,  //  00FC  GETMBR	R3	R0	K1
-      0x88100520,  //  00FD  GETMBR	R4	R2	K32
-      0x1C0C0604,  //  00FE  EQ	R3	R3	R4
-      0x780E0001,  //  00FF  JMPF	R3	#0102
-      0xB0064322,  //  0100  RAISE	1	K33	K34
-      0x70020065,  //  0101  JMP		#0168
-      0x880C0101,  //  0102  GETMBR	R3	R0	K1
-      0x88100510,  //  0103  GETMBR	R4	R2	K16
-      0x1C0C0604,  //  0104  EQ	R3	R3	R4
-      0x780E0015,  //  0105  JMPF	R3	#011C
-      0x600C000C,  //  0106  GETGBL	R3	G12
-      0x88100104,  //  0107  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  0108  CALL	R3	1
-      0x541200FE,  //  0109  LDINT	R4	255
-      0x240C0604,  //  010A  GT	R3	R3	R4
-      0x780E0000,  //  010B  JMPF	R3	#010D
-      0xB0064323,  //  010C  RAISE	1	K33	K35
-      0x8C0C0315,  //  010D  GETMET	R3	R1	K21
-      0x6014000C,  //  010E  GETGBL	R5	G12
-      0x88180104,  //  010F  GETMBR	R6	R0	K4
-      0x7C140200,  //  0110  CALL	R5	1
-      0x58180016,  //  0111  LDCONST	R6	K22
-      0x7C0C0600,  //  0112  CALL	R3	3
-      0x600C0015,  //  0113  GETGBL	R3	G21
-      0x7C0C0000,  //  0114  CALL	R3	0
-      0x8C0C0724,  //  0115  GETMET	R3	R3	K36
-      0x60140008,  //  0116  GETGBL	R5	G8
-      0x88180104,  //  0117  GETMBR	R6	R0	K4
-      0x7C140200,  //  0118  CALL	R5	1
-      0x7C0C0400,  //  0119  CALL	R3	2
-      0x400C0203,  //  011A  CONNECT	R3	R1	R3
-      0x7002004B,  //  011B  JMP		#0168
-      0x880C0101,  //  011C  GETMBR	R3	R0	K1
-      0x88100512,  //  011D  GETMBR	R4	R2	K18
-      0x1C0C0604,  //  011E  EQ	R3	R3	R4
-      0x780E0015,  //  011F  JMPF	R3	#0136
-      0x600C000C,  //  0120  GETGBL	R3	G12
-      0x88100104,  //  0121  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  0122  CALL	R3	1
-      0x5412FFFE,  //  0123  LDINT	R4	65535
-      0x240C0604,  //  0124  GT	R3	R3	R4
-      0x780E0000,  //  0125  JMPF	R3	#0127
-      0xB0064323,  //  0126  RAISE	1	K33	K35
-      0x8C0C0315,  //  0127  GETMET	R3	R1	K21
-      0x6014000C,  //  0128  GETGBL	R5	G12
-      0x88180104,  //  0129  GETMBR	R6	R0	K4
-      0x7C140200,  //  012A  CALL	R5	1
-      0x58180017,  //  012B  LDCONST	R6	K23
-      0x7C0C0600,  //  012C  CALL	R3	3
-      0x600C0015,  //  012D  GETGBL	R3	G21
-      0x7C0C0000,  //  012E  CALL	R3	0
-      0x8C0C0725,  //  012F  GETMET	R3	R3	K37
-      0x60140008,  //  0130  GETGBL	R5	G8
-      0x88180104,  //  0131  GETMBR	R6	R0	K4
-      0x7C140200,  //  0132  CALL	R5	1
-      0x7C0C0400,  //  0133  CALL	R3	2
-      0x400C0203,  //  0134  CONNECT	R3	R1	R3
-      0x70020031,  //  0135  JMP		#0168
-      0x880C0101,  //  0136  GETMBR	R3	R0	K1
-      0x8810050C,  //  0137  GETMBR	R4	R2	K12
-      0x1C0C0604,  //  0138  EQ	R3	R3	R4
-      0x780E000F,  //  0139  JMPF	R3	#014A
-      0x600C000C,  //  013A  GETGBL	R3	G12
-      0x88100104,  //  013B  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  013C  CALL	R3	1
-      0x541200FE,  //  013D  LDINT	R4	255
-      0x240C0604,  //  013E  GT	R3	R3	R4
-      0x780E0000,  //  013F  JMPF	R3	#0141
-      0xB0064326,  //  0140  RAISE	1	K33	K38
-      0x8C0C0315,  //  0141  GETMET	R3	R1	K21
-      0x6014000C,  //  0142  GETGBL	R5	G12
-      0x88180104,  //  0143  GETMBR	R6	R0	K4
-      0x7C140200,  //  0144  CALL	R5	1
-      0x58180016,  //  0145  LDCONST	R6	K22
-      0x7C0C0600,  //  0146  CALL	R3	3
-      0x880C0104,  //  0147  GETMBR	R3	R0	K4
-      0x400C0203,  //  0148  CONNECT	R3	R1	R3
-      0x7002001D,  //  0149  JMP		#0168
-      0x880C0101,  //  014A  GETMBR	R3	R0	K1
-      0x8810050E,  //  014B  GETMBR	R4	R2	K14
-      0x1C0C0604,  //  014C  EQ	R3	R3	R4
-      0x780E000F,  //  014D  JMPF	R3	#015E
-      0x600C000C,  //  014E  GETGBL	R3	G12
-      0x88100104,  //  014F  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  0150  CALL	R3	1
-      0x5412FFFE,  //  0151  LDINT	R4	65535
-      0x240C0604,  //  0152  GT	R3	R3	R4
-      0x780E0000,  //  0153  JMPF	R3	#0155
-      0xB0064326,  //  0154  RAISE	1	K33	K38
-      0x8C0C0315,  //  0155  GETMET	R3	R1	K21
-      0x6014000C,  //  0156  GETGBL	R5	G12
-      0x88180104,  //  0157  GETMBR	R6	R0	K4
-      0x7C140200,  //  0158  CALL	R5	1
-      0x58180017,  //  0159  LDCONST	R6	K23
-      0x7C0C0600,  //  015A  CALL	R3	3
-      0x880C0104,  //  015B  GETMBR	R3	R0	K4
-      0x400C0203,  //  015C  CONNECT	R3	R1	R3
-      0x70020009,  //  015D  JMP		#0168
-      0x880C0101,  //  015E  GETMBR	R3	R0	K1
-      0x88100527,  //  015F  GETMBR	R4	R2	K39
-      0x1C0C0604,  //  0160  EQ	R3	R3	R4
-      0x780E0000,  //  0161  JMPF	R3	#0163
-      0x70020004,  //  0162  JMP		#0168
-      0x600C0008,  //  0163  GETGBL	R3	G8
-      0x88100101,  //  0164  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0165  CALL	R3	1
-      0x000E5003,  //  0166  ADD	R3	K40	R3
-      0xB0064203,  //  0167  RAISE	1	K33	R3
-      0x80040200,  //  0168  RET	1	R1
+      0x5C0C0800,  //  00DC  MOVE	R3	R4
+      0x70020007,  //  00DD  JMP		#00E6
+      0xB8123A00,  //  00DE  GETNGBL	R4	K29
+      0x60140009,  //  00DF  GETGBL	R5	G9
+      0x5C180600,  //  00E0  MOVE	R6	R3
+      0x7C140200,  //  00E1  CALL	R5	1
+      0x7C100200,  //  00E2  CALL	R4	1
+      0x8C10091E,  //  00E3  GETMET	R4	R4	K30
+      0x7C100200,  //  00E4  CALL	R4	1
+      0x5C0C0800,  //  00E5  MOVE	R3	R4
+      0x40100203,  //  00E6  CONNECT	R4	R1	R3
+      0x70020086,  //  00E7  JMP		#016F
+      0x880C0101,  //  00E8  GETMBR	R3	R0	K1
+      0x88100504,  //  00E9  GETMBR	R4	R2	K4
+      0x1C0C0604,  //  00EA  EQ	R3	R3	R4
+      0x740E0003,  //  00EB  JMPT	R3	#00F0
+      0x880C0101,  //  00EC  GETMBR	R3	R0	K1
+      0x88100505,  //  00ED  GETMBR	R4	R2	K5
+      0x1C0C0604,  //  00EE  EQ	R3	R3	R4
+      0x780E0000,  //  00EF  JMPF	R3	#00F1
+      0x7002007D,  //  00F0  JMP		#016F
+      0x880C0101,  //  00F1  GETMBR	R3	R0	K1
+      0x8810051F,  //  00F2  GETMBR	R4	R2	K31
+      0x1C0C0604,  //  00F3  EQ	R3	R3	R4
+      0x780E000D,  //  00F4  JMPF	R3	#0103
+      0x600C000C,  //  00F5  GETGBL	R3	G12
+      0x5C100200,  //  00F6  MOVE	R4	R1
+      0x7C0C0200,  //  00F7  CALL	R3	1
+      0x8C100316,  //  00F8  GETMET	R4	R1	K22
+      0x5818000B,  //  00F9  LDCONST	R6	K11
+      0x541E0003,  //  00FA  LDINT	R7	4
+      0x7C100600,  //  00FB  CALL	R4	3
+      0x8C100320,  //  00FC  GETMET	R4	R1	K32
+      0x5C180600,  //  00FD  MOVE	R6	R3
+      0x601C000A,  //  00FE  GETGBL	R7	G10
+      0x88200103,  //  00FF  GETMBR	R8	R0	K3
+      0x7C1C0200,  //  0100  CALL	R7	1
+      0x7C100600,  //  0101  CALL	R4	3
+      0x7002006B,  //  0102  JMP		#016F
+      0x880C0101,  //  0103  GETMBR	R3	R0	K1
+      0x88100521,  //  0104  GETMBR	R4	R2	K33
+      0x1C0C0604,  //  0105  EQ	R3	R3	R4
+      0x780E0001,  //  0106  JMPF	R3	#0109
+      0xB0064523,  //  0107  RAISE	1	K34	K35
+      0x70020065,  //  0108  JMP		#016F
+      0x880C0101,  //  0109  GETMBR	R3	R0	K1
+      0x88100511,  //  010A  GETMBR	R4	R2	K17
+      0x1C0C0604,  //  010B  EQ	R3	R3	R4
+      0x780E0015,  //  010C  JMPF	R3	#0123
+      0x600C000C,  //  010D  GETGBL	R3	G12
+      0x88100103,  //  010E  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  010F  CALL	R3	1
+      0x541200FE,  //  0110  LDINT	R4	255
+      0x240C0604,  //  0111  GT	R3	R3	R4
+      0x780E0000,  //  0112  JMPF	R3	#0114
+      0xB0064524,  //  0113  RAISE	1	K34	K36
+      0x8C0C0316,  //  0114  GETMET	R3	R1	K22
+      0x6014000C,  //  0115  GETGBL	R5	G12
+      0x88180103,  //  0116  GETMBR	R6	R0	K3
+      0x7C140200,  //  0117  CALL	R5	1
+      0x58180017,  //  0118  LDCONST	R6	K23
+      0x7C0C0600,  //  0119  CALL	R3	3
+      0x600C0015,  //  011A  GETGBL	R3	G21
+      0x7C0C0000,  //  011B  CALL	R3	0
+      0x8C0C0725,  //  011C  GETMET	R3	R3	K37
+      0x60140008,  //  011D  GETGBL	R5	G8
+      0x88180103,  //  011E  GETMBR	R6	R0	K3
+      0x7C140200,  //  011F  CALL	R5	1
+      0x7C0C0400,  //  0120  CALL	R3	2
+      0x400C0203,  //  0121  CONNECT	R3	R1	R3
+      0x7002004B,  //  0122  JMP		#016F
+      0x880C0101,  //  0123  GETMBR	R3	R0	K1
+      0x88100513,  //  0124  GETMBR	R4	R2	K19
+      0x1C0C0604,  //  0125  EQ	R3	R3	R4
+      0x780E0015,  //  0126  JMPF	R3	#013D
+      0x600C000C,  //  0127  GETGBL	R3	G12
+      0x88100103,  //  0128  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0129  CALL	R3	1
+      0x5412FFFE,  //  012A  LDINT	R4	65535
+      0x240C0604,  //  012B  GT	R3	R3	R4
+      0x780E0000,  //  012C  JMPF	R3	#012E
+      0xB0064524,  //  012D  RAISE	1	K34	K36
+      0x8C0C0316,  //  012E  GETMET	R3	R1	K22
+      0x6014000C,  //  012F  GETGBL	R5	G12
+      0x88180103,  //  0130  GETMBR	R6	R0	K3
+      0x7C140200,  //  0131  CALL	R5	1
+      0x58180018,  //  0132  LDCONST	R6	K24
+      0x7C0C0600,  //  0133  CALL	R3	3
+      0x600C0015,  //  0134  GETGBL	R3	G21
+      0x7C0C0000,  //  0135  CALL	R3	0
+      0x8C0C0726,  //  0136  GETMET	R3	R3	K38
+      0x60140008,  //  0137  GETGBL	R5	G8
+      0x88180103,  //  0138  GETMBR	R6	R0	K3
+      0x7C140200,  //  0139  CALL	R5	1
+      0x7C0C0400,  //  013A  CALL	R3	2
+      0x400C0203,  //  013B  CONNECT	R3	R1	R3
+      0x70020031,  //  013C  JMP		#016F
+      0x880C0101,  //  013D  GETMBR	R3	R0	K1
+      0x8810050D,  //  013E  GETMBR	R4	R2	K13
+      0x1C0C0604,  //  013F  EQ	R3	R3	R4
+      0x780E000F,  //  0140  JMPF	R3	#0151
+      0x600C000C,  //  0141  GETGBL	R3	G12
+      0x88100103,  //  0142  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0143  CALL	R3	1
+      0x541200FE,  //  0144  LDINT	R4	255
+      0x240C0604,  //  0145  GT	R3	R3	R4
+      0x780E0000,  //  0146  JMPF	R3	#0148
+      0xB0064527,  //  0147  RAISE	1	K34	K39
+      0x8C0C0316,  //  0148  GETMET	R3	R1	K22
+      0x6014000C,  //  0149  GETGBL	R5	G12
+      0x88180103,  //  014A  GETMBR	R6	R0	K3
+      0x7C140200,  //  014B  CALL	R5	1
+      0x58180017,  //  014C  LDCONST	R6	K23
+      0x7C0C0600,  //  014D  CALL	R3	3
+      0x880C0103,  //  014E  GETMBR	R3	R0	K3
+      0x400C0203,  //  014F  CONNECT	R3	R1	R3
+      0x7002001D,  //  0150  JMP		#016F
+      0x880C0101,  //  0151  GETMBR	R3	R0	K1
+      0x8810050F,  //  0152  GETMBR	R4	R2	K15
+      0x1C0C0604,  //  0153  EQ	R3	R3	R4
+      0x780E000F,  //  0154  JMPF	R3	#0165
+      0x600C000C,  //  0155  GETGBL	R3	G12
+      0x88100103,  //  0156  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0157  CALL	R3	1
+      0x5412FFFE,  //  0158  LDINT	R4	65535
+      0x240C0604,  //  0159  GT	R3	R3	R4
+      0x780E0000,  //  015A  JMPF	R3	#015C
+      0xB0064527,  //  015B  RAISE	1	K34	K39
+      0x8C0C0316,  //  015C  GETMET	R3	R1	K22
+      0x6014000C,  //  015D  GETGBL	R5	G12
+      0x88180103,  //  015E  GETMBR	R6	R0	K3
+      0x7C140200,  //  015F  CALL	R5	1
+      0x58180018,  //  0160  LDCONST	R6	K24
+      0x7C0C0600,  //  0161  CALL	R3	3
+      0x880C0103,  //  0162  GETMBR	R3	R0	K3
+      0x400C0203,  //  0163  CONNECT	R3	R1	R3
+      0x70020009,  //  0164  JMP		#016F
+      0x880C0101,  //  0165  GETMBR	R3	R0	K1
+      0x88100528,  //  0166  GETMBR	R4	R2	K40
+      0x1C0C0604,  //  0167  EQ	R3	R3	R4
+      0x780E0000,  //  0168  JMPF	R3	#016A
+      0x70020004,  //  0169  JMP		#016F
+      0x600C0008,  //  016A  GETGBL	R3	G8
+      0x88100101,  //  016B  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  016C  CALL	R3	1
+      0x000E5203,  //  016D  ADD	R3	K41	R3
+      0xB0064403,  //  016E  RAISE	1	K34	R3
+      0x80040200,  //  016F  RET	1	R1
     })
   )
 );
@@ -3214,21 +3231,25 @@ be_local_closure(Matter_TLV_parse,   /* name */
 be_local_class(Matter_TLV,
     0,
     NULL,
-    be_nested_map(34,
+    be_nested_map(35,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(Matter_TLV_array, -1), be_const_class(be_class_Matter_TLV_array) },
-        { be_const_key_weak(BTRUE, -1), be_const_int(9) },
-        { be_const_key_weak(create_TLV, 11), be_const_static_closure(Matter_TLV_create_TLV_closure) },
-        { be_const_key_weak(UTF1, -1), be_const_int(12) },
-        { be_const_key_weak(STRUCT, 23), be_const_int(21) },
-        { be_const_key_weak(Matter_TLV_item, 24), be_const_class(be_class_Matter_TLV_item) },
-        { be_const_key_weak(UTF4, 20), be_const_int(14) },
-        { be_const_key_weak(FLOAT, -1), be_const_int(10) },
-        { be_const_key_weak(I2, -1), be_const_int(1) },
-        { be_const_key_weak(BOOL, 16), be_const_int(8) },
-        { be_const_key_weak(B1, -1), be_const_int(16) },
-        { be_const_key_weak(Matter_TLV_list, 28), be_const_class(be_class_Matter_TLV_list) },
-        { be_const_key_weak(I8, -1), be_const_int(3) },
+        { be_const_key_weak(BFALSE, -1), be_const_int(8) },
+        { be_const_key_weak(create_TLV, -1), be_const_static_closure(Matter_TLV_create_TLV_closure) },
+        { be_const_key_weak(Matter_TLV_list, -1), be_const_class(be_class_Matter_TLV_list) },
+        { be_const_key_weak(I4, 33), be_const_int(2) },
+        { be_const_key_weak(U2, -1), be_const_int(5) },
+        { be_const_key_weak(UTF4, -1), be_const_int(14) },
+        { be_const_key_weak(DOUBLE, 3), be_const_int(11) },
+        { be_const_key_weak(U4, 28), be_const_int(6) },
+        { be_const_key_weak(UTF2, 14), be_const_int(13) },
+        { be_const_key_weak(Matter_TLV_struct, 2), be_const_class(be_class_Matter_TLV_struct) },
+        { be_const_key_weak(BOOL, -1), be_const_int(8) },
+        { be_const_key_weak(RAW, -1), be_const_int(255) },
+        { be_const_key_weak(parse, -1), be_const_static_closure(Matter_TLV_parse_closure) },
+        { be_const_key_weak(U8, -1), be_const_int(7) },
+        { be_const_key_weak(LIST, -1), be_const_int(23) },
+        { be_const_key_weak(I2, 27), be_const_int(1) },
+        { be_const_key_weak(B2, -1), be_const_int(17) },
         { be_const_key_weak(_len, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(25,
     ( (struct bvalue*) &(const bvalue[]) {
@@ -3258,7 +3279,12 @@ be_local_class(Matter_TLV,
         be_const_int(4294967197),
         be_const_int(0),
     }))    ) } )) },
-        { be_const_key_weak(_type, 19), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        { be_const_key_weak(EOC, -1), be_const_int(24) },
+        { be_const_key_weak(Matter_TLV_array, -1), be_const_class(be_class_Matter_TLV_array) },
+        { be_const_key_weak(U1, 32), be_const_int(4) },
+        { be_const_key_weak(STRUCT, -1), be_const_int(21) },
+        { be_const_key_weak(Matter_TLV_item, 19), be_const_class(be_class_Matter_TLV_item) },
+        { be_const_key_weak(_type, 21), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(25,
     ( (struct bvalue*) &(const bvalue[]) {
         be_nested_str_weak(i1),
@@ -3287,25 +3313,17 @@ be_local_class(Matter_TLV,
         be_nested_str_weak(list),
         be_nested_str_weak(end),
     }))    ) } )) },
-        { be_const_key_weak(B2, -1), be_const_int(17) },
-        { be_const_key_weak(LIST, -1), be_const_int(23) },
-        { be_const_key_weak(U1, -1), be_const_int(4) },
-        { be_const_key_weak(NULL, 12), be_const_int(20) },
-        { be_const_key_weak(EOC, 27), be_const_int(24) },
-        { be_const_key_weak(U8, -1), be_const_int(7) },
-        { be_const_key_weak(U4, -1), be_const_int(6) },
-        { be_const_key_weak(UTF8, 21), be_const_int(15) },
-        { be_const_key_weak(UTF2, -1), be_const_int(13) },
+        { be_const_key_weak(I8, 26), be_const_int(3) },
+        { be_const_key_weak(B8, 11), be_const_int(19) },
+        { be_const_key_weak(FLOAT, -1), be_const_int(10) },
+        { be_const_key_weak(ARRAY, -1), be_const_int(22) },
         { be_const_key_weak(B4, -1), be_const_int(18) },
-        { be_const_key_weak(B8, -1), be_const_int(19) },
-        { be_const_key_weak(DOUBLE, -1), be_const_int(11) },
-        { be_const_key_weak(ARRAY, 31), be_const_int(22) },
-        { be_const_key_weak(parse, -1), be_const_static_closure(Matter_TLV_parse_closure) },
+        { be_const_key_weak(B1, -1), be_const_int(16) },
+        { be_const_key_weak(UTF1, -1), be_const_int(12) },
         { be_const_key_weak(I1, -1), be_const_int(0) },
-        { be_const_key_weak(U2, -1), be_const_int(5) },
-        { be_const_key_weak(BFALSE, -1), be_const_int(8) },
-        { be_const_key_weak(I4, 4), be_const_int(2) },
-        { be_const_key_weak(Matter_TLV_struct, 0), be_const_class(be_class_Matter_TLV_struct) },
+        { be_const_key_weak(BTRUE, -1), be_const_int(9) },
+        { be_const_key_weak(NULL, -1), be_const_int(20) },
+        { be_const_key_weak(UTF8, -1), be_const_int(15) },
     })),
     be_str_weak(Matter_TLV)
 );


### PR DESCRIPTION
## Description:

Matter: reduce memory usage when reading attributes. Internally TLV structures are early encoded as a single binary raw buffer. More optimization to come.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
