### PR TITLE
Fix Berry hue_bridge

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_light_state_class.cpp
+++ b/lib/libesp32/berry_tasmota/src/be_light_state_class.cpp
@@ -44,9 +44,9 @@ extern void ls_set_reachable(class LightStateClass* l, int32_t pow); BE_FUNC_CTY
 
 extern void ls_signal_change(void) {} BE_FUNC_CTYPE_DECLARE(ls_signal_change, "", ".");
 
-extern int32_t ls_gamma8(int32_t val);      BE_FUNC_CTYPE_DECLARE(ls_gamma8, "i", "-i")
-extern int32_t ls_gamma10(int32_t val);     BE_FUNC_CTYPE_DECLARE(ls_gamma10, "i", "-i")
-extern int32_t ls_rev_gamma10(int32_t val); BE_FUNC_CTYPE_DECLARE(ls_rev_gamma10, "i", "-i")
+extern int32_t ls_gamma8(int32_t val);      BE_FUNC_CTYPE_DECLARE(ls_gamma8, "i", "i")
+extern int32_t ls_gamma10(int32_t val);     BE_FUNC_CTYPE_DECLARE(ls_gamma10, "i", "i")
+extern int32_t ls_rev_gamma10(int32_t val); BE_FUNC_CTYPE_DECLARE(ls_rev_gamma10, "i", "i")
 
 //  moved to constants array
 const be_const_member_t light_state_members[] = {
@@ -112,9 +112,9 @@ class be_class_light_state (scope: global, name: light_state) {
 
   signal_change, ctype_func(ls_signal_change)
 
-  gamma8, ctype_func(ls_gamma8)
-  gamma10, ctype_func(ls_gamma10)
-  reverse_gamma10, ctype_func(ls_rev_gamma10)
+  gamma8, static_ctype_func(ls_gamma8)
+  gamma10, static_ctype_func(ls_gamma10)
+  reverse_gamma10, static_ctype_func(ls_rev_gamma10)
 }
 @const_object_info_end */
 

--- a/lib/libesp32/berry_tasmota/src/embedded/hue_bridge.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/hue_bridge.be
@@ -23,7 +23,7 @@ hue_bridge.init = def (m)
       if !manuf     manuf = "Tasmota" end
 
       self.lights[id] = { 'light': light, 'name':name, 'model': str(model), 'manuf':str(manuf) }
-      light
+      return light
     end
 
     def remove_light(id)

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_hue_bridge.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_hue_bridge.h
@@ -171,7 +171,7 @@ be_local_closure(hue_bridge_monad_add_light,   /* name */
       0x7C200200,  //  0027  CALL	R8	1
       0x981E1A08,  //  0028  SETIDX	R7	K13	R8
       0x98180207,  //  0029  SETIDX	R6	R1	R7
-      0x80000000,  //  002A  RET	0
+      0x80040400,  //  002A  RET	1	R2
     })
   )
 );

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_axp192.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_axp192.h
@@ -72,7 +72,7 @@ be_local_closure(AXP192_get_bat_power,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read24),
-    /* K1   */  be_const_real_hex(0x3A102DE0),
+    /* K1   */  be_const_real_hex(0x3A102DE1),
     }),
     &be_const_str_get_bat_power,
     &be_const_str_solidified,

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_axp202.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_i2c_axp202.h
@@ -172,7 +172,7 @@ be_local_closure(AXP202_get_bat_power,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(read24),
-    /* K1   */  be_const_real_hex(0x3A102DE0),
+    /* K1   */  be_const_real_hex(0x3A102DE1),
     }),
     &be_const_str_get_bat_power,
     &be_const_str_solidified,

--- a/tasmota/berry/alexa/hue_test.be
+++ b/tasmota/berry/alexa/hue_test.be
@@ -17,13 +17,13 @@ assert(l.power == false)
 l.set_power(true)
 assert(l.power == true)
 
-import hue_ntv
-print(l._p)
-print(hue_ntv.light_state(l))
+# import hue_ntv
+# print(l._p)
+# print(hue_ntv.light_state(l))
 
-print(hue_ntv.full_state(3, l, "aaa", "bbb", "ccc"))
+# print(hue_ntv.full_state(3, l, "aaa", "bbb", "ccc"))
 
-
+import hue_bridge
 hue_bridge.add_light(10, l, "Synthetic Light", "V1", "DeadParrot")
 
 l1 = light_state(light_state.DIMMER)

--- a/tasmota/berry/alexa/light_state.be
+++ b/tasmota/berry/alexa/light_state.be
@@ -36,11 +36,6 @@ assert(l.ct == 400)
 
 assert(l.mode_ct)
 
-
-
-
-
-
 # assert(l.x == 0.215944)
 # assert(l.y == 0.700957)
 
@@ -69,7 +64,22 @@ c.set_xy(0.422, 0.548)
 l = light_state(light_state.RGBCT)
 
 l.set_rgb(30,40,90)
-assert(str(l.get()) == "{'mode_ct': false, 'hue': 230, 'rgb': '1E285A', 'bri': 90, 'channels': [30, 40, 90, 0, 0], 'mode_rgb': true, 'sat': 170}")
+assert(str(l.get()) == "{'rgb': '1E285A', 'hue': 230, 'type': 5, 'power': false, 'bri': 90, 'mode_rgb': true, 'sat': 170, 'mode_ct': false, 'channels': [30, 40, 90, 0, 0]}")
 
 l.set_ct(340)
-assert(str(l.get()) == "{'bri': 90, 'ct': 340, 'mode_ct': true, 'mode_rgb': false, 'channels': [0, 0, 0, 42, 48]}")
+assert(str(l.get()) == "{'mode_ct': true, 'ct': 340, 'channels': [0, 0, 0, 42, 48], 'bri': 90, 'type': 5, 'mode_rgb': false, 'power': false}")
+
+# gamma functions
+assert(light_state.gamma8(0) == 0)
+assert(light_state.gamma8(100) == 20)
+assert(light_state.gamma8(255) == 255)
+
+assert(light_state.gamma10(0) == 0)
+assert(light_state.gamma10(100) == 7)
+assert(light_state.gamma10(255) == 25)
+assert(light_state.gamma10(1023) == 1023)
+
+assert(light_state.reverse_gamma10(0) == 0)
+assert(light_state.reverse_gamma10(7) == 107)
+assert(light_state.reverse_gamma10(25) == 253)
+assert(light_state.reverse_gamma10(1023) == 1023)


### PR DESCRIPTION
## Description:

Small fixes to Berry hue_bridge:
- gamma and reverse gamma changed as static methods
- minor fix
- fixed tests

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
