### PR TITLE
Tasmota Core 208

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.7
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.8
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Breaking Changed
 
 ### Changed
+- ESP32 Framework (Core) from v2.0.7 to v2.0.8
 
 ### Fixed
 - ESP8266 Energy Export Active no update regression from v12.3.1.3

--- a/lib/libesp32/Zip-readonly-FS/src/ZipReadFS.cpp
+++ b/lib/libesp32/Zip-readonly-FS/src/ZipReadFS.cpp
@@ -37,7 +37,7 @@ enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_D
 time_t dos2unixtime(uint32_t dostime)
      /* Return the Unix time_t value (GMT/UTC time) for the DOS format (local)
       * time dostime, where dostime is a four byte value (date in most
-      * significant word, time in least significant word), see dostime() 
+      * significant word, time in least significant word), see dostime()
       * function.
       */
 {
@@ -174,8 +174,6 @@ public:
   bool setBufferSize(size_t size) {
     return true;
   }
-
-  #if ESP_ARDUINO_VERSION > ESP_ARDUINO_VERSION_VAL(2, 0, 5)
   bool seekDir(long position){
     if(!_f){
         return false;
@@ -189,7 +187,14 @@ public:
     }
     return _f.getNextFileName();
   }
-  #endif
+  String getNextFileName(bool *isDir)
+  {
+    if (!_f) {
+        return "";
+    }
+    return _f.getNextFileName(isDir);
+
+  }
 
 protected:
   File _f;
@@ -300,15 +305,12 @@ public:
   FileImplPtr openNextFile(const char* mode) {
     return nullptr;     // TODO
   }
-
-  #if ESP_ARDUINO_VERSION > ESP_ARDUINO_VERSION_VAL(2, 0, 5)
   bool seekDir(long position){
     if(!_f){
         return false;
     }
     return _f.seekDir(position);
   }
-
   String getNextFileName(void)
   {
     if (!_f) {
@@ -316,8 +318,14 @@ public:
     }
     return _f.getNextFileName();
   }
-  #endif
+    String getNextFileName(bool *isDir)
+  {
+    if (!_f) {
+        return "";
+    }
+    return _f.getNextFileName(isDir);
 
+  }
   void rewindDirectory(void) {
     // ignore
   }

--- a/platformio.ini
+++ b/platformio.ini
@@ -115,7 +115,7 @@ build_flags                 = ${esp_defaults.build_flags}
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
-platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2023.03.00/platform-espressif8266.zip
+platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2023.04.00/platform-espressif8266.zip
 platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -42,7 +42,7 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
                               ${esp_defaults.extra_scripts}
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.02.00/platform-espressif32.zip
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/pre2.0.8/framework-arduinoespressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.04.00/platform-espressif32.zip
+platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_6_flash_fs.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_6_flash_fs.ino
@@ -108,7 +108,6 @@ public:
   }
 
   #ifdef ESP32
-  #if ESP_ARDUINO_VERSION > ESP_ARDUINO_VERSION_VAL(2, 0, 5)
   bool seekDir(long position){
     return false;
     // ignore
@@ -118,7 +117,11 @@ public:
     return "";
     // ignore
   }
-  #endif
+  String getNextFileName(bool *isDir)
+  {
+    return "";
+    // ignore
+    }
   #endif // ESP32
 
   const char* name() const {


### PR DESCRIPTION
## Description:

based on released Espressif Arduino Core 2.0.8 and IDF 4.4.4 with changes for Tasmota
+ needed changes (add ons) in ZipReadFS.cpp and xdrv_23_zigbee_7_6_flash_fs.ino -> fix Linker errors

Tested with ESP32, ESP32-solo1, ESP32-S2, ESP32-S3 and ESP32-C3

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
