### PR TITLE
Show Metrics for ESP32x firmware

### DIFF
--- a/pio-tools/name-firmware.py
+++ b/pio-tools/name-firmware.py
@@ -28,5 +28,11 @@ def bin_map_copy(source, target, env):
     shutil.move(tasmotapiolib.get_source_map_path(env), map_file)
     if env["PIOPLATFORM"] == "espressif32":
         shutil.copy(factory, one_bin_file)
-
+        # Print Metrics for firmware using "map" file
+        import esp_idf_size
+        CYAN = '\033[96m'
+        ENDC = '\033[0m'
+        print(CYAN + "=============================================================================================" + ENDC)
+        env.Execute("$PYTHONEXE -m esp_idf_size " + str(map_file.resolve()))
+        print(CYAN + "=============================================================================================" + ENDC)
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", bin_map_copy)


### PR DESCRIPTION
## Description:

Shows firmware metrics of ESP32x after successful compile. Example:

```
=============================================================================================
/Users/hans/.platformio/penv/bin/python -m esp_idf_size /Users/hans/Git/Tasmota/build_output/map/tasmota32.map
Total sizes:
Used static DRAM:   56284 bytes (  68296 remain, 45.2% used)
      .data size:   20900 bytes
      .bss  size:   35384 bytes
Used static IRAM:   87134 bytes (  43938 remain, 66.5% used)
      .text size:   86107 bytes
   .vectors size:    1027 bytes
Used Flash size : 1213872 bytes
           .text:  961099 bytes
         .rodata:  252517 bytes
Total image size: 1321906 bytes (.bin may be padded larger)
=============================================================================================
```


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
