### PR TITLE
Berry fix rules for string comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - ESP8266 Energy Export Active no update regression from v12.3.1.3
 - NovaSDS GUI values (#18444)
+- Berry fix rules for string comparisons
 
 ### Removed
 

--- a/lib/libesp32/berry_tasmota/src/embedded/rule_matcher.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/rule_matcher.be
@@ -17,8 +17,8 @@ tasmota.Rule_Matcher.parse("AA#BB#CC")
 tasmota.Rule_Matcher.parse("AA")
 # [<Matcher key='AA'>]
 
-tasmota.Rule_Matcher.parse("AA#BB#CC=2")
-# [<Matcher key='AA'>, <Matcher key='BB'>, <Matcher key='CC'>, <Matcher op '=' val='2'>]
+tasmota.Rule_Matcher.parse("AA#BB#CC==2")
+# [<Matcher key='AA'>, <Matcher key='BB'>, <Matcher key='CC'>, <Matcher op '==' val='2'>]
 
 tasmota.Rule_Matcher.parse("AA#BB#CC>=3.5")
 # [<Matcher key='AA'>, <Matcher key='BB'>, <Matcher key='CC'>, <Matcher op '>=' val='3.5'>]
@@ -26,8 +26,8 @@ tasmota.Rule_Matcher.parse("AA#BB#CC>=3.5")
 tasmota.Rule_Matcher.parse("AA#BB#CC!3.5")
 # [<Matcher key='AA'>, <Matcher key='BB'>, <Matcher key='CC!3.5'>]
 
-tasmota.Rule_Matcher.parse("AA#BB#CC==3=5")
-# [<Matcher key='AA'>, <Matcher key='BB'>, <Matcher key='CC'>, <Matcher op '==' val='3=5'>]
+tasmota.Rule_Matcher.parse("AA#BB#CC=3=5")
+# [<Matcher key='AA'>, <Matcher key='BB'>, <Matcher key='CC'>, <Matcher op '=' val='3=5'>]
 
 tasmota.Rule_Matcher.parse("AA#BB#!CC!==3=5")
 # [<Matcher key='AA'>, <Matcher key='BB'>, <Matcher key='!CC'>, <Matcher op '!==' val='3=5'>]
@@ -39,16 +39,16 @@ tasmota.Rule_Matcher.parse("A#?#B")
 # [<Matcher key='A'>, <Matcher any>, <Matcher key='B'>]
 
 tasmota.Rule_Matcher.parse("A#?>50")
-# [<Matcher key='A'>, <Matcher any>, <Matcher op '>' val='50'>]
+# [<Matcher key='A'>, <Matcher any>, <Matcher op '>' val=50>]
 
 tasmota.Rule_Matcher.parse("A[1]")
-# [<instance: Rule_Matcher_Key()>, <Matcher [0]>]
+# [<Matcher key='A'>, <Matcher [1]>]
 
 tasmota.Rule_Matcher.parse("A[1]#B[2]>3")
-# [<instance: Rule_Matcher_Key()>, <Matcher [0]>, <instance: Rule_Matcher_Key()>, <Matcher [0]>, <Matcher op '>' val='3'>]
+# [<Matcher key='A'>, <Matcher [1]>, <Matcher key='B'>, <Matcher [2]>, <Matcher op '>' val=3>]
 
 tasmota.Rule_Matcher.parse("A#B[]>3")
-# [<instance: Rule_Matcher_Key()>, <instance: Rule_Matcher_Key()>, <Matcher [0]>, <Matcher op '>' val='3'>]
+# [<Matcher key='A'>, <Matcher key='B'>, <Matcher [0]>, <Matcher op '>' val=3>]
 
 #################################################################################
 
@@ -67,7 +67,13 @@ assert(m.match({'aa':{'bb':1}}) == nil)
 assert(m.match({'aa':{'bb':{'cc':1}}}) == nil)
 assert(m.match({'aa':{'bb':{'cc':2}}}) == 2)
 
-m = tasmota.Rule_Matcher.parse("AA#?#CC==2")
+m = tasmota.Rule_Matcher.parse("AA#BB#CC=Foo")
+assert(m.match({'aa':{'bb':{'cc':1}}}) == nil)
+assert(m.match({'aa':{'bb':{'cc':'Foo'}}}) == 'Foo')
+assert(m.match({'aa':{'bb':{'cc':'foo'}}}) == 'foo')
+assert(m.match({'aa':{'bb':{'cc':'foobar'}}}) == nil)
+
+m = tasmota.Rule_Matcher.parse("AA#?#CC=2")
 assert(m.match({'aa':1}) == nil)
 assert(m.match({'aa':{'bb':{'cc':2}}}) == 2)
 
@@ -251,7 +257,7 @@ class Rule_Matcher
         self.op_value = val_num
       end
     else
-      self.op_value = str(op)
+      self.op_value = str(op_value)
     end
 
   end

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_rule_matcher.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_rule_matcher.h
@@ -789,7 +789,7 @@ be_local_closure(Rule_Matcher_Operator_op_parse,   /* name */
       0x90022C13,  //  005A  SETMBR	R0	K22	R19
       0x70020003,  //  005B  JMP		#0060
       0x60480008,  //  005C  GETGBL	R18	G8
-      0x5C4C0200,  //  005D  MOVE	R19	R1
+      0x5C4C0400,  //  005D  MOVE	R19	R2
       0x7C480200,  //  005E  CALL	R18	1
       0x90022C12,  //  005F  SETMBR	R0	K22	R18
       0x80000000,  //  0060  RET	0


### PR DESCRIPTION
## Description:

Fix a major bug in Berry rule for string matching.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
