### PR TITLE
fix c3 map metrics

### DIFF
--- a/pio-tools/gzip-firmware.py
+++ b/pio-tools/gzip-firmware.py
@@ -20,6 +20,10 @@ def map_gzip(source, target, env):
         with map_file.open("rb") as fp:
             with gzip.open(gzip_file, "wb", compresslevel=9) as f:
                 shutil.copyfileobj(fp, f)
+        if env["PIOPLATFORM"] == "espressif32":
+            # Print Metrics for firmware using "map" file
+            import tasmota_metrics
+            env.Execute("$PYTHONEXE -m tasmota_metrics " + str(map_file.resolve()))
 
         # remove map file
         if map_file.is_file():

--- a/pio-tools/name-firmware.py
+++ b/pio-tools/name-firmware.py
@@ -28,11 +28,4 @@ def bin_map_copy(source, target, env):
     shutil.move(tasmotapiolib.get_source_map_path(env), map_file)
     if env["PIOPLATFORM"] == "espressif32":
         shutil.copy(factory, one_bin_file)
-        # Print Metrics for firmware using "map" file
-        import esp_idf_size
-        CYAN = '\033[96m'
-        ENDC = '\033[0m'
-        print(CYAN + "=============================================================================================" + ENDC)
-        env.Execute("$PYTHONEXE -m esp_idf_size " + str(map_file.resolve()))
-        print(CYAN + "=============================================================================================" + ENDC)
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", bin_map_copy)

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -42,7 +42,7 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
                               ${esp_defaults.extra_scripts}
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.04.00/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.04.01/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

C3 map metrics is now working too. Thx @Staars for the fix in `esp-idf-size`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
