### PR TITLE
refac firmware-metrics

### DIFF
--- a/pio-tools/gzip-firmware.py
+++ b/pio-tools/gzip-firmware.py
@@ -20,10 +20,6 @@ def map_gzip(source, target, env):
         with map_file.open("rb") as fp:
             with gzip.open(gzip_file, "wb", compresslevel=9) as f:
                 shutil.copyfileobj(fp, f)
-        if env["PIOPLATFORM"] == "espressif32":
-            # Print Metrics for firmware using "map" file
-            import tasmota_metrics
-            env.Execute("$PYTHONEXE -m tasmota_metrics " + str(map_file.resolve()))
 
         # remove map file
         if map_file.is_file():

--- a/pio-tools/metrics-firmware.py
+++ b/pio-tools/metrics-firmware.py
@@ -1,0 +1,12 @@
+Import("env")
+
+import tasmotapiolib
+
+if env["PIOPLATFORM"] == "espressif32":
+    def firm_metrics(source, target, env):
+        # Print Metrics for firmware using "map" file from ".pio/build/..."
+        import tasmota_metrics
+        print("$PYTHONEXE -m tasmota_metrics " + str(tasmotapiolib.get_source_map_path(env).resolve()))
+        env.Execute("$PYTHONEXE -m tasmota_metrics " + str(tasmotapiolib.get_source_map_path(env).resolve()))
+
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin",firm_metrics)

--- a/pio-tools/metrics-firmware.py
+++ b/pio-tools/metrics-firmware.py
@@ -1,10 +1,8 @@
 Import("env")
 
 import tasmotapiolib
-
-if env["PIOPLATFORM"] == "espressif32":
-    def firm_metrics(source, target, env):
-        # Print Metrics for firmware using "map" file from ".pio/build/..."
+def firm_metrics(source, target, env):
+    if env["PIOPLATFORM"] == "espressif32":
         import tasmota_metrics
         env.Execute("$PYTHONEXE -m tasmota_metrics " + str(tasmotapiolib.get_source_map_path(env).resolve()))
 

--- a/pio-tools/metrics-firmware.py
+++ b/pio-tools/metrics-firmware.py
@@ -6,7 +6,6 @@ if env["PIOPLATFORM"] == "espressif32":
     def firm_metrics(source, target, env):
         # Print Metrics for firmware using "map" file from ".pio/build/..."
         import tasmota_metrics
-        print("$PYTHONEXE -m tasmota_metrics " + str(tasmotapiolib.get_source_map_path(env).resolve()))
         env.Execute("$PYTHONEXE -m tasmota_metrics " + str(tasmotapiolib.get_source_map_path(env).resolve()))
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin",firm_metrics)

--- a/pio-tools/name-firmware.py
+++ b/pio-tools/name-firmware.py
@@ -25,7 +25,10 @@ def bin_map_copy(source, target, env):
 
     # copy firmware.bin and map to final destination
     shutil.copy(firsttarget, bin_file)
-    shutil.copy(tasmotapiolib.get_source_map_path(env), map_file)
     if env["PIOPLATFORM"] == "espressif32":
+        # the map file is needed later for fimrmware-metrics.py
+        shutil.copy(tasmotapiolib.get_source_map_path(env), map_file)
         shutil.copy(factory, one_bin_file)
+    else:
+        shutil.move(tasmotapiolib.get_source_map_path(env), map_file)
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", bin_map_copy)

--- a/pio-tools/name-firmware.py
+++ b/pio-tools/name-firmware.py
@@ -25,7 +25,7 @@ def bin_map_copy(source, target, env):
 
     # copy firmware.bin and map to final destination
     shutil.copy(firsttarget, bin_file)
-    shutil.move(tasmotapiolib.get_source_map_path(env), map_file)
+    shutil.copy(tasmotapiolib.get_source_map_path(env), map_file)
     if env["PIOPLATFORM"] == "espressif32":
         shutil.copy(factory, one_bin_file)
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", bin_map_copy)

--- a/platformio.ini
+++ b/platformio.ini
@@ -73,6 +73,7 @@ extra_scripts               = pre:pio-tools/pre_source_dir.py
 [esp_defaults]
 extra_scripts               = post:pio-tools/name-firmware.py
                               post:pio-tools/gzip-firmware.py
+                              post:pio-tools/metrics-firmware.py
                               post:pio-tools/custom_target.py
 ;                              post:pio-tools/obj-dump.py
                               ${scripts_defaults.extra_scripts}


### PR DESCRIPTION
## Description:

resolve dependencies from other scripts. firmware-metrics is now a standalone Platformio python script.
The map file from path `.pio/build/....` is used

@arendst Give it a try.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
