### PR TITLE
Matter persist plugins config

### DIFF
--- a/lib/libesp32/berry_matter/src/be_matter_module.c
+++ b/lib/libesp32/berry_matter/src/be_matter_module.c
@@ -162,7 +162,7 @@ extern const bclass be_class_Matter_TLV;   // need to declare it upfront because
 #include "solidify/solidified_Matter_Plugin_Sensor.h"
 #include "solidify/solidified_Matter_Plugin_Sensor_Pressure.h"
 #include "solidify/solidified_Matter_Plugin_Sensor_Temp.h"
-#include "solidify/solidified_Matter_Plugin_Sensor_Light.h"
+#include "solidify/solidified_Matter_Plugin_Sensor_Illuminance.h"
 #include "solidify/solidified_Matter_Plugin_Sensor_Humidity.h"
 
 /*********************************************************************************************\
@@ -340,7 +340,7 @@ module matter (scope: global, strings: weak) {
   Plugin_Sensor, class(be_class_Matter_Plugin_Sensor)     // Generic Sensor
   Plugin_Sensor_Pressure, class(be_class_Matter_Plugin_Sensor_Pressure)   // Pressure Sensor
   Plugin_Sensor_Temp, class(be_class_Matter_Plugin_Sensor_Temp)           // Temperature Sensor
-  Plugin_Sensor_Light, class(be_class_Matter_Plugin_Sensor_Light)         // Light Sensor
+  Plugin_Sensor_Illuminance, class(be_class_Matter_Plugin_Sensor_Illuminance) // Illuminance Sensor
   Plugin_Sensor_Humidity, class(be_class_Matter_Plugin_Sensor_Humidity)   // Humidity Sensor
 }
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin.be
@@ -23,6 +23,7 @@
 #@ solidify:Matter_Plugin,weak
 
 class Matter_Plugin
+  static var NAME = "generic" # name of the plug-in in json
   static var CLUSTERS = {
     0x001D: [0,1,2,3,0xFFFC,0xFFFD],                # Descriptor Cluster 9.5 p.453
   }
@@ -39,7 +40,10 @@ class Matter_Plugin
   #############################################################
   # Constructor
   #
-  def init(device, endpoint)
+  # device: contains the root device object so the plugin can "call home"
+  # endpoint: (int) the endpoint number (16 bits)
+  # arguments: (map) the map for all complementary arguments that are plugin specific
+  def init(device, endpoint, arguments)
     self.device = device
     self.endpoint = endpoint
     self.clusters = self.consolidate_clusters()
@@ -215,6 +219,31 @@ class Matter_Plugin
   def every_second()
     self.update_shadow()                    # force reading value and sending subscriptions
   end
+
+  #############################################################
+  # to_json
+  #
+  # generate the json string for parameter of the plug-in
+  # this function calls a method to be overriden with custom parameters
+  def to_json()
+    import string
+    var s = string.format('{"type":"%s"', self.NAME)
+    s = self.to_json_parameters(s)
+    s += '}'
+    return s
+  end
+
+  #############################################################
+  # to_json_parameters
+  #
+  # To be overriden.
+  # returns a json sub-string to add after endpoint and type name
+  def to_json_parameters(s)
+    # s += ',"my_param":"my_value"'
+    return s
+  end
+
+
 end
 
 matter.Plugin = Matter_Plugin

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Device.be
@@ -32,9 +32,9 @@ class Matter_Plugin_Device : Matter_Plugin
 
   #############################################################
   # Constructor
-  def init(device, endpoint, tasmota_relay_index)
-    super(self).init(device, endpoint)
-  end
+  # def init(device, endpoint, arguments)
+  #   super(self).init(device, endpoint, arguments)
+  # end
 
   #############################################################
   # read an attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light0.be
@@ -25,6 +25,7 @@ class Matter_Plugin end
 #@ solidify:Matter_Plugin_Light0,weak
 
 class Matter_Plugin_Light0 : Matter_Plugin
+  static var NAME = "light0"                        # name of the plug-in in json
   static var CLUSTERS  = {
     # 0x001D: inherited                             # Descriptor Cluster 9.5 p.453
     0x0003: [0,1,0xFFFC,0xFFFD],                    # Identify 1.2 p.16
@@ -38,8 +39,8 @@ class Matter_Plugin_Light0 : Matter_Plugin
 
   #############################################################
   # Constructor
-  def init(device, endpoint)
-    super(self).init(device, endpoint)
+  def init(device, endpoint, arguments)
+    super(self).init(device, endpoint, arguments)
     self.shadow_onoff = false
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light1.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light1.be
@@ -25,6 +25,7 @@ class Matter_Plugin_Light0 end
 #@ solidify:Matter_Plugin_Light1,weak
 
 class Matter_Plugin_Light1 : Matter_Plugin_Light0
+  static var NAME = "light1"                        # name of the plug-in in json
   static var CLUSTERS  = {
     # 0x001D: inherited                                     # Descriptor Cluster 9.5 p.453
     # 0x0003: inherited                                     # Identify 1.2 p.16
@@ -40,8 +41,8 @@ class Matter_Plugin_Light1 : Matter_Plugin_Light0
 
   #############################################################
   # Constructor
-  def init(device, endpoint)
-    super(self).init(device, endpoint)
+  def init(device, endpoint, arguments)
+    super(self).init(device, endpoint, arguments)
     self.shadow_bri = 0
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light2.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light2.be
@@ -25,6 +25,7 @@ class Matter_Plugin_Light1 end
 #@ solidify:Matter_Plugin_Light2,weak
 
 class Matter_Plugin_Light2 : Matter_Plugin_Light1
+  static var NAME = "light2"                        # name of the plug-in in json
   static var CLUSTERS  = {
     # 0x001D: inherited                                     # Descriptor Cluster 9.5 p.453
     # 0x0003: inherited                                     # Identify 1.2 p.16
@@ -41,8 +42,8 @@ class Matter_Plugin_Light2 : Matter_Plugin_Light1
 
   #############################################################
   # Constructor
-  def init(device, endpoint)
-    super(self).init(device, endpoint)
+  def init(device, endpoint, arguments)
+    super(self).init(device, endpoint, arguments)
     self.shadow_ct = 325
     self.update_ct_minmax()
   end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light3.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light3.be
@@ -25,6 +25,7 @@ class Matter_Plugin_Light1 end
 #@ solidify:Matter_Plugin_Light3,weak
 
 class Matter_Plugin_Light3 : Matter_Plugin_Light1
+  static var NAME = "light3"                        # name of the plug-in in json
   static var CLUSTERS  = {
     # 0x001D: inherited                                     # Descriptor Cluster 9.5 p.453
     # 0x0003: inherited                                     # Identify 1.2 p.16
@@ -40,8 +41,8 @@ class Matter_Plugin_Light3 : Matter_Plugin_Light1
 
   #############################################################
   # Constructor
-  def init(device, endpoint)
-    super(self).init(device, endpoint)
+  def init(device, endpoint, arguments)
+    super(self).init(device, endpoint, arguments)
     self.shadow_hue = 0
     self.shadow_sat = 0
   end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_OnOff.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_OnOff.be
@@ -25,6 +25,7 @@ class Matter_Plugin end
 #@ solidify:Matter_Plugin_OnOff,weak
 
 class Matter_Plugin_OnOff : Matter_Plugin
+  static var NAME = "relay"                         # name of the plug-in in json
   static var CLUSTERS  = {
     # 0x001D: inherited                             # Descriptor Cluster 9.5 p.453
     0x0003: [0,1,0xFFFC,0xFFFD],                    # Identify 1.2 p.16
@@ -40,11 +41,11 @@ class Matter_Plugin_OnOff : Matter_Plugin
 
   #############################################################
   # Constructor
-  def init(device, endpoint, tasmota_relay_index)
-    super(self).init(device, endpoint)
+  def init(device, endpoint, arguments)
+    super(self).init(device, endpoint, arguments)
     self.get_onoff()                        # read actual value
-    if tasmota_relay_index == nil     tasmota_relay_index = 0   end
-    self.tasmota_relay_index = tasmota_relay_index
+    self.tasmota_relay_index = arguments.find('relay')
+    if self.tasmota_relay_index == nil     self.tasmota_relay_index = 0   end
   end
 
   #############################################################
@@ -212,6 +213,17 @@ class Matter_Plugin_OnOff : Matter_Plugin
   # Signal that onoff attribute changed
   def onoff_changed()
     self.attribute_updated(nil, 0x0006, 0x0000)   # send to all endpoints
+  end
+
+  #############################################################
+  # to_json_parameters
+  #
+  # To be overriden.
+  # returns a json sub-string to add after endpoint and type name
+  def to_json_parameters(s)
+    import string
+    s += string.format(',"relay":%i', self.tasmota_relay_index)
+    return s
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
@@ -25,6 +25,7 @@ class Matter_Plugin end
 #@ solidify:Matter_Plugin_Root,weak
 
 class Matter_Plugin_Root : Matter_Plugin
+  static var NAME = "root"            # name of the plug-in in json
   static var CLUSTERS  = {
     # 0x001D: inherited               # Descriptor Cluster 9.5 p.453
     0x001F: [0,2,3,4],                # Access Control Cluster, p.461
@@ -46,8 +47,8 @@ class Matter_Plugin_Root : Matter_Plugin
 
   #############################################################
   # Constructor
-  def init(device, endpoint)
-    super(self).init(device, endpoint)
+  def init(device, endpoint, arguments)
+    super(self).init(device, endpoint, arguments)
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor.be
@@ -31,10 +31,12 @@ class Matter_Plugin_Sensor : Matter_Plugin_Device
 
   #############################################################
   # Constructor
-  def init(device, endpoint, sensor_filter)
-    super(self).init(device, endpoint)
-    self.tasmota_sensor_filter = sensor_filter
-    self.tasmota_sensor_matcher = tasmota.Rule_Matcher.parse(sensor_filter)
+  def init(device, endpoint, arguments)
+    super(self).init(device, endpoint, arguments)
+    self.tasmota_sensor_filter = arguments.find('filter')
+    if self.tasmota_sensor_filter
+      self.tasmota_sensor_matcher = tasmota.Rule_Matcher.parse(self.tasmota_sensor_filter)
+    end
   end
 
   #############################################################
@@ -70,6 +72,17 @@ class Matter_Plugin_Sensor : Matter_Plugin_Device
   # This allows to convert the raw sensor value to the target one, typically int
   def pre_value(val)
     return val
+  end
+
+  #############################################################
+  # to_json_parameters
+  #
+  # To be overriden.
+  # returns a json sub-string to add after endpoint and type name
+  def to_json_parameters(s)
+    import string
+    s += string.format(',"filter":"%s"', self.tasmota_sensor_filter)
+    return s
   end
 
 end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Humidity.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Humidity.be
@@ -25,6 +25,7 @@ class Matter_Plugin_Sensor end
 #@ solidify:Matter_Plugin_Sensor_Humidity,weak
 
 class Matter_Plugin_Sensor_Humidity : Matter_Plugin_Sensor
+  static var NAME = "humidity"                      # name of the plug-in in json
   static var CLUSTERS  = {
     0x0405: [0,1,2,0xFFFC,0xFFFD],                  # Humidity Measurement p.102 - no writable
   }

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Illuminance.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Illuminance.be
@@ -22,9 +22,10 @@
 # dummy declaration for solidification
 class Matter_Plugin_Sensor end
 
-#@ solidify:Matter_Plugin_Sensor_Light,weak
+#@ solidify:Matter_Plugin_Sensor_Illuminance,weak
 
-class Matter_Plugin_Sensor_Light : Matter_Plugin_Sensor
+class Matter_Plugin_Sensor_Illuminance : Matter_Plugin_Sensor
+  static var NAME = "illuminance"                   # name of the plug-in in json
   static var CLUSTERS  = {
     0x0400: [0,1,2,0xFFFC,0xFFFD],                  # Illuminance Measurement p.95 - no writable
   }
@@ -81,4 +82,4 @@ class Matter_Plugin_Sensor_Light : Matter_Plugin_Sensor
   end
 
 end
-matter.Plugin_Sensor_Pressure = Matter_Plugin_Sensor_Pressure
+matter.Plugin_Sensor_Illuminance = Matter_Plugin_Sensor_Illuminance

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Pressure.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Pressure.be
@@ -25,6 +25,7 @@ class Matter_Plugin_Sensor end
 #@ solidify:Matter_Plugin_Sensor_Pressure,weak
 
 class Matter_Plugin_Sensor_Pressure : Matter_Plugin_Sensor
+  static var NAME = "pressure"                      # name of the plug-in in json
   static var CLUSTERS  = {
     0x0403: [0,1,2,0xFFFC,0xFFFD],                  # Temperature Measurement p.97 - no writable
   }

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Temp.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Temp.be
@@ -25,8 +25,9 @@ class Matter_Plugin_Sensor end
 #@ solidify:Matter_Plugin_Sensor_Temp,weak
 
 class Matter_Plugin_Sensor_Temp : Matter_Plugin_Sensor
+  static var NAME = "temperature"                   # name of the plug-in in json
   static var CLUSTERS  = {
-    0x0402: [0,1,2],                                # Temperature Measurement p.97 - no writable
+    0x0402: [0,1,2,0xFFFC,0xFFFD],                  # Temperature Measurement p.97 - no writable
   }
   static var TYPES = { 0x0302: 2 }                  # Temperature Sensor, rev 2
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
@@ -32,12 +32,14 @@ class Matter_Expirable end
 #################################################################################
 #################################################################################
 class Matter_Session_Store
+  var device                      # device root object
   var sessions
   var fabrics                     # list of provisioned fabrics
   static var _FABRICS  = "_matter_fabrics.json"
 
   #############################################################
-  def init()
+  def init(device)
+    self.device = device
     self.sessions = matter.Expirable_list()
     self.fabrics = matter.Expirable_list()
   end
@@ -327,6 +329,7 @@ class Matter_Session_Store
       f.write(fabs)
       f.close()
       tasmota.log(string.format("MTR: =Saved     %i fabric(s) and %i session(s)", fabs_size, sessions_saved), 2)
+      self.device.event_fabrics_saved()     # signal event
     except .. as e, m
       tasmota.log("MTR: Session_Store::save Exception:" + str(e) + "|" + str(m), 2)
     end

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
@@ -7,781 +7,103 @@
 extern const bclass be_class_Matter_Device;
 
 /********************************************************************
-** Solidified function: start_operational_discovery
+** Solidified function: register_plugin_class
 ********************************************************************/
-be_local_closure(Matter_Device_start_operational_discovery,   /* name */
+be_local_closure(Matter_Device_register_plugin_class,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
+    4,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_classes),
+    }),
+    be_str_weak(register_plugin_class),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x980C0202,  //  0001  SETIDX	R3	R1	R2
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _compute_pbkdf
+********************************************************************/
+be_local_closure(Matter_Device__compute_pbkdf,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(mdns),
-    /* K2   */  be_nested_str_weak(string),
-    /* K3   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K4   */  be_nested_str_weak(root_w0),
-    /* K5   */  be_nested_str_weak(root_L),
-    /* K6   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K7   */  be_nested_str_weak(mdns_announce_op_discovery),
-    /* K8   */  be_nested_str_weak(get_fabric),
-    }),
-    be_str_weak(start_operational_discovery),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA4120400,  //  0002  IMPORT	R4	K2
-      0x8C140103,  //  0003  GETMET	R5	R0	K3
-      0x7C140200,  //  0004  CALL	R5	1
-      0x4C140000,  //  0005  LDNIL	R5
-      0x90020805,  //  0006  SETMBR	R0	K4	R5
-      0x4C140000,  //  0007  LDNIL	R5
-      0x90020A05,  //  0008  SETMBR	R0	K5	R5
-      0x8C140306,  //  0009  GETMET	R5	R1	K6
-      0x541E003B,  //  000A  LDINT	R7	60
-      0x7C140400,  //  000B  CALL	R5	2
-      0x8C140107,  //  000C  GETMET	R5	R0	K7
-      0x8C1C0308,  //  000D  GETMET	R7	R1	K8
-      0x7C1C0200,  //  000E  CALL	R7	1
-      0x7C140400,  //  000F  CALL	R5	2
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start
-********************************************************************/
-be_local_closure(Matter_Device_start,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_trigger_read_sensors),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80000000,  //  0003  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(started),
-    /* K1   */  be_nested_str_weak(plugins),
-    /* K2   */  be_nested_str_weak(push),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Plugin_Root),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(autoconf_device),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(add_cron),
-    /* K9   */  be_nested_str_weak(_X2A_X2F30_X20_X2A_X20_X2A_X20_X2A_X20_X2A_X20_X2A),
-    /* K10  */  be_nested_str_weak(matter_sensors_30s),
-    /* K11  */  be_nested_str_weak(_start_udp),
-    /* K12  */  be_nested_str_weak(UDP_PORT),
-    /* K13  */  be_nested_str_weak(start_mdns_announce_hostnames),
-    }),
-    be_str_weak(start),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060000,  //  0001  JMPF	R1	#0003
-      0x80000200,  //  0002  RET	0
-      0x88040101,  //  0003  GETMBR	R1	R0	K1
-      0x8C040302,  //  0004  GETMET	R1	R1	K2
-      0xB80E0600,  //  0005  GETNGBL	R3	K3
-      0x8C0C0704,  //  0006  GETMET	R3	R3	K4
-      0x5C140000,  //  0007  MOVE	R5	R0
-      0x58180005,  //  0008  LDCONST	R6	K5
-      0x7C0C0600,  //  0009  CALL	R3	3
-      0x7C040400,  //  000A  CALL	R1	2
-      0x8C040106,  //  000B  GETMET	R1	R0	K6
-      0x7C040200,  //  000C  CALL	R1	1
-      0xB8060E00,  //  000D  GETNGBL	R1	K7
-      0x8C040308,  //  000E  GETMET	R1	R1	K8
-      0x580C0009,  //  000F  LDCONST	R3	K9
-      0x84100000,  //  0010  CLOSURE	R4	P0
-      0x5814000A,  //  0011  LDCONST	R5	K10
-      0x7C040800,  //  0012  CALL	R1	4
-      0x8C04010B,  //  0013  GETMET	R1	R0	K11
-      0x880C010C,  //  0014  GETMBR	R3	R0	K12
-      0x7C040400,  //  0015  CALL	R1	2
-      0x8C04010D,  //  0016  GETMET	R1	R0	K13
-      0x7C040200,  //  0017  CALL	R1	1
-      0x50040200,  //  0018  LDBOOL	R1	1	0
-      0x90020001,  //  0019  SETMBR	R0	K0	R1
-      0xA0000000,  //  001A  CLOSE	R0
-      0x80000000,  //  001B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_remove_PASE
-********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
     /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(mdns_pase_eth),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eremove_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
-    /* K7   */  be_nested_str_weak(_matterc),
-    /* K8   */  be_nested_str_weak(_udp),
-    /* K9   */  be_nested_str_weak(commissioning_instance_eth),
-    /* K10  */  be_nested_str_weak(hostname_eth),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
-    /* K13  */  be_nested_str_weak(eth),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_nested_str_weak(remove_service),
-    /* K16  */  be_nested_str_weak(mdns_pase_wifi),
-    /* K17  */  be_nested_str_weak(commissioning_instance_wifi),
-    /* K18  */  be_nested_str_weak(hostname_wifi),
-    /* K19  */  be_nested_str_weak(wifi),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K21  */  be_nested_str_weak(_X7C),
+    /* K2   */  be_nested_str_weak(add),
+    /* K3   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
+    /* K4   */  be_nested_str_weak(derive),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(root_w0),
+    /* K7   */  be_nested_str_weak(EC_P256),
+    /* K8   */  be_nested_str_weak(mod),
+    /* K9   */  be_nested_str_weak(root_L),
+    /* K10  */  be_nested_str_weak(public_key),
     }),
-    be_str_weak(mdns_remove_PASE),
+    be_str_weak(_compute_pbkdf),
     &be_const_str_solidified,
-    ( &(const binstruction[83]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xA802003D,  //  0002  EXBLK	0	#0041
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
-      0x780E001B,  //  0004  JMPF	R3	#0021
-      0xB80E0600,  //  0005  GETNGBL	R3	K3
-      0x8C0C0704,  //  0006  GETMET	R3	R3	K4
-      0x8C140505,  //  0007  GETMET	R5	R2	K5
-      0x581C0006,  //  0008  LDCONST	R7	K6
-      0x58200007,  //  0009  LDCONST	R8	K7
-      0x58240008,  //  000A  LDCONST	R9	K8
-      0x88280109,  //  000B  GETMBR	R10	R0	K9
-      0x882C010A,  //  000C  GETMBR	R11	R0	K10
-      0x7C140C00,  //  000D  CALL	R5	6
-      0x5818000B,  //  000E  LDCONST	R6	K11
-      0x7C0C0600,  //  000F  CALL	R3	3
-      0xB80E0600,  //  0010  GETNGBL	R3	K3
-      0x8C0C0704,  //  0011  GETMET	R3	R3	K4
-      0x8C140505,  //  0012  GETMET	R5	R2	K5
-      0x581C000C,  //  0013  LDCONST	R7	K12
-      0x5820000D,  //  0014  LDCONST	R8	K13
-      0x88240109,  //  0015  GETMBR	R9	R0	K9
-      0x7C140800,  //  0016  CALL	R5	4
-      0x5818000E,  //  0017  LDCONST	R6	K14
-      0x7C0C0600,  //  0018  CALL	R3	3
-      0x500C0000,  //  0019  LDBOOL	R3	0	0
-      0x90020403,  //  001A  SETMBR	R0	K2	R3
-      0x8C0C030F,  //  001B  GETMET	R3	R1	K15
-      0x58140007,  //  001C  LDCONST	R5	K7
-      0x58180008,  //  001D  LDCONST	R6	K8
-      0x881C0109,  //  001E  GETMBR	R7	R0	K9
-      0x8820010A,  //  001F  GETMBR	R8	R0	K10
-      0x7C0C0A00,  //  0020  CALL	R3	5
-      0x880C0110,  //  0021  GETMBR	R3	R0	K16
-      0x780E001B,  //  0022  JMPF	R3	#003F
-      0xB80E0600,  //  0023  GETNGBL	R3	K3
-      0x8C0C0704,  //  0024  GETMET	R3	R3	K4
-      0x8C140505,  //  0025  GETMET	R5	R2	K5
-      0x581C0006,  //  0026  LDCONST	R7	K6
-      0x58200007,  //  0027  LDCONST	R8	K7
-      0x58240008,  //  0028  LDCONST	R9	K8
-      0x88280111,  //  0029  GETMBR	R10	R0	K17
-      0x882C0112,  //  002A  GETMBR	R11	R0	K18
-      0x7C140C00,  //  002B  CALL	R5	6
-      0x5818000B,  //  002C  LDCONST	R6	K11
-      0x7C0C0600,  //  002D  CALL	R3	3
-      0xB80E0600,  //  002E  GETNGBL	R3	K3
-      0x8C0C0704,  //  002F  GETMET	R3	R3	K4
-      0x8C140505,  //  0030  GETMET	R5	R2	K5
-      0x581C000C,  //  0031  LDCONST	R7	K12
-      0x58200013,  //  0032  LDCONST	R8	K19
-      0x88240111,  //  0033  GETMBR	R9	R0	K17
-      0x7C140800,  //  0034  CALL	R5	4
-      0x5818000E,  //  0035  LDCONST	R6	K14
-      0x7C0C0600,  //  0036  CALL	R3	3
-      0x500C0000,  //  0037  LDBOOL	R3	0	0
-      0x90022003,  //  0038  SETMBR	R0	K16	R3
-      0x8C0C030F,  //  0039  GETMET	R3	R1	K15
-      0x58140007,  //  003A  LDCONST	R5	K7
-      0x58180008,  //  003B  LDCONST	R6	K8
-      0x881C0111,  //  003C  GETMBR	R7	R0	K17
-      0x88200112,  //  003D  GETMBR	R8	R0	K18
-      0x7C0C0A00,  //  003E  CALL	R3	5
-      0xA8040001,  //  003F  EXBLK	1	1
-      0x70020010,  //  0040  JMP		#0052
-      0xAC0C0002,  //  0041  CATCH	R3	0	2
-      0x7002000D,  //  0042  JMP		#0051
-      0xB8160600,  //  0043  GETNGBL	R5	K3
-      0x8C140B04,  //  0044  GETMET	R5	R5	K4
-      0x601C0008,  //  0045  GETGBL	R7	G8
-      0x5C200600,  //  0046  MOVE	R8	R3
-      0x7C1C0200,  //  0047  CALL	R7	1
-      0x001E2807,  //  0048  ADD	R7	K20	R7
-      0x001C0F15,  //  0049  ADD	R7	R7	K21
-      0x60200008,  //  004A  GETGBL	R8	G8
-      0x5C240800,  //  004B  MOVE	R9	R4
-      0x7C200200,  //  004C  CALL	R8	1
-      0x001C0E08,  //  004D  ADD	R7	R7	R8
-      0x5820000E,  //  004E  LDCONST	R8	K14
-      0x7C140600,  //  004F  CALL	R5	3
-      0x70020000,  //  0050  JMP		#0052
-      0xB0080000,  //  0051  RAISE	2	R0	R0
-      0x80000000,  //  0052  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_commissioning_complete_deferred
-********************************************************************/
-be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        3,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 2]) {  /* upvals */
-          be_local_const_upval(1, 0),
-          be_local_const_upval(1, 1),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_commissioning_complete),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080001,  //  0002  GETUPV	R2	U1
-          0x7C000400,  //  0003  CALL	R0	2
-          0x80040000,  //  0004  RET	1	R0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(set_timer),
-    /* K2   */  be_const_int(0),
-    }),
-    be_str_weak(start_commissioning_complete_deferred),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x84140000,  //  0003  CLOSURE	R5	P0
-      0x7C080600,  //  0004  CALL	R2	3
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_before_restart
-********************************************************************/
-be_local_closure(Matter_Device_save_before_restart,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K1   */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
-    }),
-    be_str_weak(save_before_restart),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
-      0x7C040200,  //  0003  CALL	R1	1
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _start_udp
-********************************************************************/
-be_local_closure(Matter_Device__start_udp,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        8,                          /* nstack */
-        3,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(msg_received),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 7]) {  /* code */
-          0x680C0000,  //  0000  GETUPV	R3	U0
-          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
-          0x5C140000,  //  0002  MOVE	R5	R0
-          0x5C180200,  //  0003  MOVE	R6	R1
-          0x5C1C0400,  //  0004  MOVE	R7	R2
-          0x7C0C0800,  //  0005  CALL	R3	4
-          0x80040600,  //  0006  RET	1	R3
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20starting_X20UDP_X20server_X20on_X20port_X3A_X20),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(UDPServer),
-    /* K7   */  be_nested_str_weak(),
-    /* K8   */  be_nested_str_weak(start),
-    }),
-    be_str_weak(_start_udp),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80000400,  //  0002  RET	0
-      0x4C080000,  //  0003  LDNIL	R2
-      0x1C080202,  //  0004  EQ	R2	R1	R2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x540615A3,  //  0006  LDINT	R1	5540
-      0xB80A0200,  //  0007  GETNGBL	R2	K1
-      0x8C080502,  //  0008  GETMET	R2	R2	K2
-      0x60100008,  //  0009  GETGBL	R4	G8
-      0x5C140200,  //  000A  MOVE	R5	R1
-      0x7C100200,  //  000B  CALL	R4	1
-      0x00120604,  //  000C  ADD	R4	K3	R4
-      0x58140004,  //  000D  LDCONST	R5	K4
-      0x7C080600,  //  000E  CALL	R2	3
-      0xB80A0A00,  //  000F  GETNGBL	R2	K5
-      0x8C080506,  //  0010  GETMET	R2	R2	K6
-      0x58100007,  //  0011  LDCONST	R4	K7
-      0x5C140200,  //  0012  MOVE	R5	R1
-      0x7C080600,  //  0013  CALL	R2	3
-      0x90020002,  //  0014  SETMBR	R0	K0	R2
-      0x88080100,  //  0015  GETMBR	R2	R0	K0
-      0x8C080508,  //  0016  GETMET	R2	R2	K8
-      0x84100000,  //  0017  CLOSURE	R4	P0
-      0x7C080400,  //  0018  CALL	R2	2
-      0xA0000000,  //  0019  CLOSE	R0
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_commands
-********************************************************************/
-be_local_closure(Matter_Device_register_commands,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        10,                          /* nstack */
-        4,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(MtrJoin),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 8]) {  /* code */
-          0x68100000,  //  0000  GETUPV	R4	U0
-          0x8C100900,  //  0001  GETMET	R4	R4	K0
-          0x5C180000,  //  0002  MOVE	R6	R0
-          0x5C1C0200,  //  0003  MOVE	R7	R1
-          0x5C200400,  //  0004  MOVE	R8	R2
-          0x5C240600,  //  0005  MOVE	R9	R3
-          0x7C100A00,  //  0006  CALL	R4	5
-          0x80040800,  //  0007  RET	1	R4
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(add_cmd),
-    /* K2   */  be_nested_str_weak(MtrJoin),
-    }),
-    be_str_weak(register_commands),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x580C0002,  //  0002  LDCONST	R3	K2
-      0x84100000,  //  0003  CLOSURE	R4	P0
-      0x7C040600,  //  0004  CALL	R1	3
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    8,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
-        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
-        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(commissioning_iterations),
-    /* K4   */  be_nested_str_weak(commissioning_discriminator),
-    /* K5   */  be_nested_str_weak(commissioning_salt),
-    /* K6   */  be_nested_str_weak(commissioning_w0),
-    /* K7   */  be_nested_str_weak(commissioning_L),
-    /* K8   */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K9   */  be_nested_str_weak(wifi),
-    /* K10  */  be_nested_str_weak(up),
-    /* K11  */  be_nested_str_weak(eth),
-    /* K12  */  be_nested_str_weak(mdns_announce_PASE),
-    /* K13  */  be_nested_str_weak(add_rule),
-    /* K14  */  be_nested_str_weak(Wifi_X23Connected),
-    /* K15  */  be_nested_str_weak(Eth_X23Connected),
-    }),
-    be_str_weak(start_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0xB8220200,  //  0000  GETNGBL	R8	K1
-      0x8C201102,  //  0001  GETMET	R8	R8	K2
-      0x7C200200,  //  0002  CALL	R8	1
-      0x542603E7,  //  0003  LDINT	R9	1000
-      0x08240209,  //  0004  MUL	R9	R1	R9
-      0x00201009,  //  0005  ADD	R8	R8	R9
-      0x90020008,  //  0006  SETMBR	R0	K0	R8
-      0x90020602,  //  0007  SETMBR	R0	K3	R2
-      0x90020803,  //  0008  SETMBR	R0	K4	R3
-      0x90020A04,  //  0009  SETMBR	R0	K5	R4
-      0x90020C05,  //  000A  SETMBR	R0	K6	R5
-      0x90020E06,  //  000B  SETMBR	R0	K7	R6
-      0x90021007,  //  000C  SETMBR	R0	K8	R7
-      0xB8220200,  //  000D  GETNGBL	R8	K1
-      0x8C201109,  //  000E  GETMET	R8	R8	K9
-      0x7C200200,  //  000F  CALL	R8	1
-      0x9420110A,  //  0010  GETIDX	R8	R8	K10
-      0x74220004,  //  0011  JMPT	R8	#0017
-      0xB8220200,  //  0012  GETNGBL	R8	K1
-      0x8C20110B,  //  0013  GETMET	R8	R8	K11
-      0x7C200200,  //  0014  CALL	R8	1
-      0x9420110A,  //  0015  GETIDX	R8	R8	K10
-      0x78220002,  //  0016  JMPF	R8	#001A
-      0x8C20010C,  //  0017  GETMET	R8	R0	K12
-      0x7C200200,  //  0018  CALL	R8	1
-      0x7002000B,  //  0019  JMP		#0026
-      0xB8220200,  //  001A  GETNGBL	R8	K1
-      0x8C20110D,  //  001B  GETMET	R8	R8	K13
-      0x5828000E,  //  001C  LDCONST	R10	K14
-      0x842C0000,  //  001D  CLOSURE	R11	P0
-      0x5830000C,  //  001E  LDCONST	R12	K12
-      0x7C200800,  //  001F  CALL	R8	4
-      0xB8220200,  //  0020  GETNGBL	R8	K1
-      0x8C20110D,  //  0021  GETMET	R8	R8	K13
-      0x5828000F,  //  0022  LDCONST	R10	K15
-      0x842C0001,  //  0023  CLOSURE	R11	P1
-      0x5830000C,  //  0024  LDCONST	R12	K12
-      0x7C200800,  //  0025  CALL	R8	4
-      0xA0000000,  //  0026  CLOSE	R0
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_fabric
-********************************************************************/
-be_local_closure(Matter_Device_remove_fabric,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(find_children_fabrics),
-    /* K2   */  be_nested_str_weak(get_fabric_index),
-    /* K3   */  be_nested_str_weak(find_fabric_by_index),
-    /* K4   */  be_nested_str_weak(message_handler),
-    /* K5   */  be_nested_str_weak(im),
-    /* K6   */  be_nested_str_weak(subs_shop),
-    /* K7   */  be_nested_str_weak(remove_by_fabric),
-    /* K8   */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K9   */  be_nested_str_weak(remove_fabric),
-    /* K10  */  be_nested_str_weak(stop_iteration),
-    /* K11  */  be_nested_str_weak(save_fabrics),
-    }),
-    be_str_weak(remove_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[43]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x8C100302,  //  0002  GETMET	R4	R1	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x7C080400,  //  0004  CALL	R2	2
-      0x4C0C0000,  //  0005  LDNIL	R3
-      0x1C0C0403,  //  0006  EQ	R3	R2	R3
-      0x780E0000,  //  0007  JMPF	R3	#0009
-      0x80000600,  //  0008  RET	0
-      0x600C0010,  //  0009  GETGBL	R3	G16
-      0x5C100400,  //  000A  MOVE	R4	R2
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0xA8020016,  //  000C  EXBLK	0	#0024
-      0x5C100600,  //  000D  MOVE	R4	R3
-      0x7C100000,  //  000E  CALL	R4	0
-      0x88140100,  //  000F  GETMBR	R5	R0	K0
-      0x8C140B03,  //  0010  GETMET	R5	R5	K3
-      0x5C1C0800,  //  0011  MOVE	R7	R4
-      0x7C140400,  //  0012  CALL	R5	2
-      0x4C180000,  //  0013  LDNIL	R6
-      0x20180A06,  //  0014  NE	R6	R5	R6
-      0x781A000C,  //  0015  JMPF	R6	#0023
-      0x88180104,  //  0016  GETMBR	R6	R0	K4
-      0x88180D05,  //  0017  GETMBR	R6	R6	K5
-      0x88180D06,  //  0018  GETMBR	R6	R6	K6
-      0x8C180D07,  //  0019  GETMET	R6	R6	K7
-      0x5C200A00,  //  001A  MOVE	R8	R5
-      0x7C180400,  //  001B  CALL	R6	2
-      0x8C180108,  //  001C  GETMET	R6	R0	K8
-      0x5C200A00,  //  001D  MOVE	R8	R5
-      0x7C180400,  //  001E  CALL	R6	2
-      0x88180100,  //  001F  GETMBR	R6	R0	K0
-      0x8C180D09,  //  0020  GETMET	R6	R6	K9
-      0x5C200A00,  //  0021  MOVE	R8	R5
-      0x7C180400,  //  0022  CALL	R6	2
-      0x7001FFE8,  //  0023  JMP		#000D
-      0x580C000A,  //  0024  LDCONST	R3	K10
-      0xAC0C0200,  //  0025  CATCH	R3	1	0
-      0xB0080000,  //  0026  RAISE	2	R0	R0
-      0x880C0100,  //  0027  GETMBR	R3	R0	K0
-      0x8C0C070B,  //  0028  GETMET	R3	R3	K11
-      0x7C0C0200,  //  0029  CALL	R3	1
-      0x80000000,  //  002A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: attribute_updated
-********************************************************************/
-be_local_closure(Matter_Device_attribute_updated,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Path),
-    /* K2   */  be_nested_str_weak(endpoint),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(message_handler),
-    /* K6   */  be_nested_str_weak(im),
-    /* K7   */  be_nested_str_weak(subs_shop),
-    /* K8   */  be_nested_str_weak(attribute_updated_ctx),
-    }),
-    be_str_weak(attribute_updated),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x1C140805,  //  0001  EQ	R5	R4	R5
-      0x78160000,  //  0002  JMPF	R5	#0004
-      0x50100000,  //  0003  LDBOOL	R4	0	0
-      0xB8160000,  //  0004  GETNGBL	R5	K0
-      0x8C140B01,  //  0005  GETMET	R5	R5	K1
-      0x7C140200,  //  0006  CALL	R5	1
-      0x90160401,  //  0007  SETMBR	R5	K2	R1
-      0x90160602,  //  0008  SETMBR	R5	K3	R2
-      0x90160803,  //  0009  SETMBR	R5	K4	R3
-      0x88180105,  //  000A  GETMBR	R6	R0	K5
-      0x88180D06,  //  000B  GETMBR	R6	R6	K6
-      0x88180D07,  //  000C  GETMBR	R6	R6	K7
-      0x8C180D08,  //  000D  GETMET	R6	R6	K8
-      0x5C200A00,  //  000E  MOVE	R8	R5
-      0x5C240800,  //  000F  MOVE	R9	R4
-      0x7C180600,  //  0010  CALL	R6	3
-      0x80000000,  //  0011  RET	0
+    ( &(const binstruction[41]) {  /* code */
+      0xA4120000,  //  0000  IMPORT	R4	K0
+      0xA4160200,  //  0001  IMPORT	R5	K1
+      0x60180015,  //  0002  GETGBL	R6	G21
+      0x7C180000,  //  0003  CALL	R6	0
+      0x8C180D02,  //  0004  GETMET	R6	R6	K2
+      0x5C200200,  //  0005  MOVE	R8	R1
+      0x54260003,  //  0006  LDINT	R9	4
+      0x7C180600,  //  0007  CALL	R6	3
+      0x8C1C0903,  //  0008  GETMET	R7	R4	K3
+      0x7C1C0200,  //  0009  CALL	R7	1
+      0x8C1C0F04,  //  000A  GETMET	R7	R7	K4
+      0x5C240C00,  //  000B  MOVE	R9	R6
+      0x5C280600,  //  000C  MOVE	R10	R3
+      0x5C2C0400,  //  000D  MOVE	R11	R2
+      0x5432004F,  //  000E  LDINT	R12	80
+      0x7C1C0A00,  //  000F  CALL	R7	5
+      0x54220026,  //  0010  LDINT	R8	39
+      0x40220A08,  //  0011  CONNECT	R8	K5	R8
+      0x94200E08,  //  0012  GETIDX	R8	R7	R8
+      0x54260027,  //  0013  LDINT	R9	40
+      0x542A004E,  //  0014  LDINT	R10	79
+      0x4024120A,  //  0015  CONNECT	R9	R9	R10
+      0x94240E09,  //  0016  GETIDX	R9	R7	R9
+      0x8C280907,  //  0017  GETMET	R10	R4	K7
+      0x7C280200,  //  0018  CALL	R10	1
+      0x8C281508,  //  0019  GETMET	R10	R10	K8
+      0x5C301000,  //  001A  MOVE	R12	R8
+      0x7C280400,  //  001B  CALL	R10	2
+      0x90020C0A,  //  001C  SETMBR	R0	K6	R10
+      0x8C280907,  //  001D  GETMET	R10	R4	K7
+      0x7C280200,  //  001E  CALL	R10	1
+      0x8C281508,  //  001F  GETMET	R10	R10	K8
+      0x5C301200,  //  0020  MOVE	R12	R9
+      0x7C280400,  //  0021  CALL	R10	2
+      0x8C2C0907,  //  0022  GETMET	R11	R4	K7
+      0x7C2C0200,  //  0023  CALL	R11	1
+      0x8C2C170A,  //  0024  GETMET	R11	R11	K10
+      0x5C341400,  //  0025  MOVE	R13	R10
+      0x7C2C0400,  //  0026  CALL	R11	2
+      0x9002120B,  //  0027  SETMBR	R0	K9	R11
+      0x80000000,  //  0028  RET	0
     })
   )
 );
@@ -1013,545 +335,174 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
 
 
 /********************************************************************
-** Solidified function: autoconf_device
+** Solidified function: mdns_announce_op_discovery
 ********************************************************************/
-be_local_closure(Matter_Device_autoconf_device,   /* name */
+be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
   be_nested_proto(
-    21,                          /* nstack */
-    1,                          /* argc */
+    15,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[49]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(json),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(light),
-    /* K4   */  be_nested_str_weak(get),
-    /* K5   */  be_nested_str_weak(find),
-    /* K6   */  be_nested_str_weak(channels),
-    /* K7   */  be_nested_str_weak(),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(plugins),
-    /* K10  */  be_nested_str_weak(push),
-    /* K11  */  be_nested_str_weak(matter),
-    /* K12  */  be_nested_str_weak(Plugin_Light1),
-    /* K13  */  be_nested_str_weak(tasmota),
-    /* K14  */  be_nested_str_weak(log),
+    ( &(const bvalue[29]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(copy),
+    /* K4   */  be_nested_str_weak(reverse),
+    /* K5   */  be_nested_str_weak(get_fabric_compressed),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_nested_str_weak(_X2D),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(log),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_nested_str_weak(eth),
+    /* K13  */  be_nested_str_weak(find),
+    /* K14  */  be_nested_str_weak(up),
     /* K15  */  be_nested_str_weak(format),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20Endpoint_X3A_X25i_X20Light_Dimmer),
-    /* K17  */  be_const_int(2),
-    /* K18  */  be_nested_str_weak(Plugin_Light2),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20Endpoint_X3A_X25i_X20Light_CT),
-    /* K20  */  be_nested_str_weak(Plugin_Light3),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20Endpoint_X3A_X25i_X20Light_RGB),
-    /* K22  */  be_nested_str_weak(get_power),
-    /* K23  */  be_nested_str_weak(Plugin_OnOff),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20Endpoint_X3A_X25i_X20Relay__X25i),
-    /* K25  */  be_nested_str_weak(load),
-    /* K26  */  be_nested_str_weak(read_sensors),
-    /* K27  */  be_nested_str_weak(k2l),
-    /* K28  */  be_nested_str_weak(contains),
-    /* K29  */  be_nested_str_weak(Temperature),
-    /* K30  */  be_nested_str_weak(_X23Temperature),
-    /* K31  */  be_nested_str_weak(Plugin_Sensor_Temp),
-    /* K32  */  be_nested_str_weak(MTR_X3A_X20Endpoint_X3A_X25i_X20Temperature_X20_X28_X25s_X29),
-    /* K33  */  be_nested_str_weak(stop_iteration),
-    /* K34  */  be_nested_str_weak(Pressure),
-    /* K35  */  be_nested_str_weak(_X23Pressure),
-    /* K36  */  be_nested_str_weak(Plugin_Sensor_Pressure),
-    /* K37  */  be_nested_str_weak(MTR_X3A_X20Endpoint_X3A_X25i_X20Pressure_X20_X28_X25s_X29),
-    /* K38  */  be_nested_str_weak(Illuminance),
-    /* K39  */  be_nested_str_weak(_X23Illuminance),
-    /* K40  */  be_nested_str_weak(Plugin_Sensor_Light),
-    /* K41  */  be_nested_str_weak(MTR_X3A_X20Endpoint_X3A_X25i_X20Light_X20_X28_X25s_X29),
-    /* K42  */  be_nested_str_weak(Humidity),
-    /* K43  */  be_nested_str_weak(_X23Humidity),
-    /* K44  */  be_nested_str_weak(Plugin_Sensor_Humidity),
-    /* K45  */  be_nested_str_weak(MTR_X3A_X20Endpoint_X3A_X25i_X20Humidity_X20_X28_X25s_X29),
-    /* K46  */  be_nested_str_weak(publish_result),
-    /* K47  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
-    /* K48  */  be_nested_str_weak(Matter),
+    /* K16  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K17  */  be_nested_str_weak(hostname_eth),
+    /* K18  */  be_const_int(3),
+    /* K19  */  be_nested_str_weak(add_service),
+    /* K20  */  be_nested_str_weak(_matter),
+    /* K21  */  be_nested_str_weak(_tcp),
+    /* K22  */  be_nested_str_weak(_I),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
+    /* K24  */  be_nested_str_weak(add_subtype),
+    /* K25  */  be_nested_str_weak(wifi),
+    /* K26  */  be_nested_str_weak(hostname_wifi),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K28  */  be_nested_str_weak(_X7C),
     }),
-    be_str_weak(autoconf_device),
+    be_str_weak(mdns_announce_op_discovery),
     &be_const_str_solidified,
-    ( &(const binstruction[312]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x580C0002,  //  0002  LDCONST	R3	K2
-      0x50100000,  //  0003  LDBOOL	R4	0	0
-      0xA4160600,  //  0004  IMPORT	R5	K3
-      0x8C180B04,  //  0005  GETMET	R6	R5	K4
-      0x7C180200,  //  0006  CALL	R6	1
-      0x4C1C0000,  //  0007  LDNIL	R7
-      0x201C0C07,  //  0008  NE	R7	R6	R7
-      0x781E003F,  //  0009  JMPF	R7	#004A
-      0x601C000C,  //  000A  GETGBL	R7	G12
-      0x8C200D05,  //  000B  GETMET	R8	R6	K5
-      0x58280006,  //  000C  LDCONST	R10	K6
-      0x582C0007,  //  000D  LDCONST	R11	K7
-      0x7C200600,  //  000E  CALL	R8	3
+    ( &(const binstruction[122]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xA8020064,  //  0002  EXBLK	0	#0068
+      0x8C100302,  //  0003  GETMET	R4	R1	K2
+      0x7C100200,  //  0004  CALL	R4	1
+      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C140305,  //  0009  GETMET	R5	R1	K5
+      0x7C140200,  //  000A  CALL	R5	1
+      0x8C180B06,  //  000B  GETMET	R6	R5	K6
+      0x7C180200,  //  000C  CALL	R6	1
+      0x00180D07,  //  000D  ADD	R6	R6	K7
+      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
       0x7C1C0200,  //  000F  CALL	R7	1
-      0x24200F08,  //  0010  GT	R8	R7	K8
-      0x78220037,  //  0011  JMPF	R8	#004A
-      0x1C200F02,  //  0012  EQ	R8	R7	K2
-      0x78220010,  //  0013  JMPF	R8	#0025
-      0x88200109,  //  0014  GETMBR	R8	R0	K9
-      0x8C20110A,  //  0015  GETMET	R8	R8	K10
-      0xB82A1600,  //  0016  GETNGBL	R10	K11
-      0x8C28150C,  //  0017  GETMET	R10	R10	K12
-      0x5C300000,  //  0018  MOVE	R12	R0
-      0x5C340600,  //  0019  MOVE	R13	R3
-      0x7C280600,  //  001A  CALL	R10	3
-      0x7C200400,  //  001B  CALL	R8	2
-      0xB8221A00,  //  001C  GETNGBL	R8	K13
-      0x8C20110E,  //  001D  GETMET	R8	R8	K14
-      0x8C28030F,  //  001E  GETMET	R10	R1	K15
-      0x58300010,  //  001F  LDCONST	R12	K16
-      0x5C340600,  //  0020  MOVE	R13	R3
-      0x7C280600,  //  0021  CALL	R10	3
-      0x582C0011,  //  0022  LDCONST	R11	K17
-      0x7C200600,  //  0023  CALL	R8	3
-      0x70020022,  //  0024  JMP		#0048
-      0x1C200F11,  //  0025  EQ	R8	R7	K17
-      0x78220010,  //  0026  JMPF	R8	#0038
-      0x88200109,  //  0027  GETMBR	R8	R0	K9
-      0x8C20110A,  //  0028  GETMET	R8	R8	K10
-      0xB82A1600,  //  0029  GETNGBL	R10	K11
-      0x8C281512,  //  002A  GETMET	R10	R10	K18
-      0x5C300000,  //  002B  MOVE	R12	R0
-      0x5C340600,  //  002C  MOVE	R13	R3
-      0x7C280600,  //  002D  CALL	R10	3
-      0x7C200400,  //  002E  CALL	R8	2
-      0xB8221A00,  //  002F  GETNGBL	R8	K13
-      0x8C20110E,  //  0030  GETMET	R8	R8	K14
-      0x8C28030F,  //  0031  GETMET	R10	R1	K15
-      0x58300013,  //  0032  LDCONST	R12	K19
-      0x5C340600,  //  0033  MOVE	R13	R3
-      0x7C280600,  //  0034  CALL	R10	3
-      0x582C0011,  //  0035  LDCONST	R11	K17
+      0x00180C07,  //  0010  ADD	R6	R6	R7
+      0xB81E1000,  //  0011  GETNGBL	R7	K8
+      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
+      0x00261406,  //  0013  ADD	R9	K10	R6
+      0x5828000B,  //  0014  LDCONST	R10	K11
+      0x7C1C0600,  //  0015  CALL	R7	3
+      0xB81E1000,  //  0016  GETNGBL	R7	K8
+      0x8C1C0F0C,  //  0017  GETMET	R7	R7	K12
+      0x7C1C0200,  //  0018  CALL	R7	1
+      0x8C1C0F0D,  //  0019  GETMET	R7	R7	K13
+      0x5824000E,  //  001A  LDCONST	R9	K14
+      0x7C1C0400,  //  001B  CALL	R7	2
+      0x781E0020,  //  001C  JMPF	R7	#003E
+      0xB81E1000,  //  001D  GETNGBL	R7	K8
+      0x8C1C0F09,  //  001E  GETMET	R7	R7	K9
+      0x8C24070F,  //  001F  GETMET	R9	R3	K15
+      0x582C0010,  //  0020  LDCONST	R11	K16
+      0x5830000C,  //  0021  LDCONST	R12	K12
+      0x5C340C00,  //  0022  MOVE	R13	R6
+      0x88380111,  //  0023  GETMBR	R14	R0	K17
+      0x7C240A00,  //  0024  CALL	R9	5
+      0x58280012,  //  0025  LDCONST	R10	K18
+      0x7C1C0600,  //  0026  CALL	R7	3
+      0x8C1C0513,  //  0027  GETMET	R7	R2	K19
+      0x58240014,  //  0028  LDCONST	R9	K20
+      0x58280015,  //  0029  LDCONST	R10	K21
+      0x542E15A3,  //  002A  LDINT	R11	5540
+      0x4C300000,  //  002B  LDNIL	R12
+      0x5C340C00,  //  002C  MOVE	R13	R6
+      0x88380111,  //  002D  GETMBR	R14	R0	K17
+      0x7C1C0E00,  //  002E  CALL	R7	7
+      0x8C1C0B06,  //  002F  GETMET	R7	R5	K6
+      0x7C1C0200,  //  0030  CALL	R7	1
+      0x001E2C07,  //  0031  ADD	R7	K22	R7
+      0xB8221000,  //  0032  GETNGBL	R8	K8
+      0x8C201109,  //  0033  GETMET	R8	R8	K9
+      0x002A2E07,  //  0034  ADD	R10	K23	R7
+      0x582C0012,  //  0035  LDCONST	R11	K18
       0x7C200600,  //  0036  CALL	R8	3
-      0x7002000F,  //  0037  JMP		#0048
-      0x88200109,  //  0038  GETMBR	R8	R0	K9
-      0x8C20110A,  //  0039  GETMET	R8	R8	K10
-      0xB82A1600,  //  003A  GETNGBL	R10	K11
-      0x8C281514,  //  003B  GETMET	R10	R10	K20
-      0x5C300000,  //  003C  MOVE	R12	R0
-      0x5C340600,  //  003D  MOVE	R13	R3
-      0x7C280600,  //  003E  CALL	R10	3
-      0x7C200400,  //  003F  CALL	R8	2
-      0xB8221A00,  //  0040  GETNGBL	R8	K13
-      0x8C20110E,  //  0041  GETMET	R8	R8	K14
-      0x8C28030F,  //  0042  GETMET	R10	R1	K15
-      0x58300015,  //  0043  LDCONST	R12	K21
-      0x5C340600,  //  0044  MOVE	R13	R3
-      0x7C280600,  //  0045  CALL	R10	3
-      0x582C0011,  //  0046  LDCONST	R11	K17
-      0x7C200600,  //  0047  CALL	R8	3
-      0x50100200,  //  0048  LDBOOL	R4	1	0
-      0x000C0702,  //  0049  ADD	R3	R3	K2
-      0x601C000C,  //  004A  GETGBL	R7	G12
-      0xB8221A00,  //  004B  GETNGBL	R8	K13
-      0x8C201116,  //  004C  GETMET	R8	R8	K22
-      0x7C200200,  //  004D  CALL	R8	1
-      0x7C1C0200,  //  004E  CALL	R7	1
-      0x58200008,  //  004F  LDCONST	R8	K8
-      0x78120000,  //  0050  JMPF	R4	#0052
-      0x041C0F02,  //  0051  SUB	R7	R7	K2
-      0x14241007,  //  0052  LT	R9	R8	R7
-      0x78260014,  //  0053  JMPF	R9	#0069
-      0x88240109,  //  0054  GETMBR	R9	R0	K9
-      0x8C24130A,  //  0055  GETMET	R9	R9	K10
-      0xB82E1600,  //  0056  GETNGBL	R11	K11
-      0x8C2C1717,  //  0057  GETMET	R11	R11	K23
-      0x5C340000,  //  0058  MOVE	R13	R0
-      0x5C380600,  //  0059  MOVE	R14	R3
-      0x5C3C1000,  //  005A  MOVE	R15	R8
-      0x7C2C0800,  //  005B  CALL	R11	4
-      0x7C240400,  //  005C  CALL	R9	2
-      0xB8261A00,  //  005D  GETNGBL	R9	K13
-      0x8C24130E,  //  005E  GETMET	R9	R9	K14
-      0x8C2C030F,  //  005F  GETMET	R11	R1	K15
-      0x58340018,  //  0060  LDCONST	R13	K24
-      0x5C380600,  //  0061  MOVE	R14	R3
-      0x003C1102,  //  0062  ADD	R15	R8	K2
-      0x7C2C0800,  //  0063  CALL	R11	4
-      0x58300011,  //  0064  LDCONST	R12	K17
-      0x7C240600,  //  0065  CALL	R9	3
-      0x00201102,  //  0066  ADD	R8	R8	K2
-      0x000C0702,  //  0067  ADD	R3	R3	K2
-      0x7001FFE8,  //  0068  JMP		#0052
-      0x8C240519,  //  0069  GETMET	R9	R2	K25
-      0xB82E1A00,  //  006A  GETNGBL	R11	K13
-      0x8C2C171A,  //  006B  GETMET	R11	R11	K26
-      0x7C2C0200,  //  006C  CALL	R11	1
-      0x7C240400,  //  006D  CALL	R9	2
-      0x540E001F,  //  006E  LDINT	R3	32
-      0x60280010,  //  006F  GETGBL	R10	G16
-      0x8C2C011B,  //  0070  GETMET	R11	R0	K27
-      0x5C341200,  //  0071  MOVE	R13	R9
-      0x7C2C0400,  //  0072  CALL	R11	2
-      0x7C280200,  //  0073  CALL	R10	1
-      0xA8020026,  //  0074  EXBLK	0	#009C
-      0x5C2C1400,  //  0075  MOVE	R11	R10
-      0x7C2C0000,  //  0076  CALL	R11	0
-      0x9430120B,  //  0077  GETIDX	R12	R9	R11
-      0x6034000F,  //  0078  GETGBL	R13	G15
-      0x5C381800,  //  0079  MOVE	R14	R12
-      0x603C0013,  //  007A  GETGBL	R15	G19
-      0x7C340400,  //  007B  CALL	R13	2
-      0x78360017,  //  007C  JMPF	R13	#0095
-      0x8C34191C,  //  007D  GETMET	R13	R12	K28
-      0x583C001D,  //  007E  LDCONST	R15	K29
-      0x7C340400,  //  007F  CALL	R13	2
-      0x78360013,  //  0080  JMPF	R13	#0095
-      0x0034171E,  //  0081  ADD	R13	R11	K30
-      0x88380109,  //  0082  GETMBR	R14	R0	K9
-      0x8C381D0A,  //  0083  GETMET	R14	R14	K10
-      0xB8421600,  //  0084  GETNGBL	R16	K11
-      0x8C40211F,  //  0085  GETMET	R16	R16	K31
-      0x5C480000,  //  0086  MOVE	R18	R0
-      0x5C4C0600,  //  0087  MOVE	R19	R3
-      0x5C501A00,  //  0088  MOVE	R20	R13
-      0x7C400800,  //  0089  CALL	R16	4
-      0x7C380400,  //  008A  CALL	R14	2
-      0xB83A1A00,  //  008B  GETNGBL	R14	K13
-      0x8C381D0E,  //  008C  GETMET	R14	R14	K14
-      0x8C40030F,  //  008D  GETMET	R16	R1	K15
-      0x58480020,  //  008E  LDCONST	R18	K32
-      0x5C4C0600,  //  008F  MOVE	R19	R3
-      0x5C501A00,  //  0090  MOVE	R20	R13
-      0x7C400800,  //  0091  CALL	R16	4
-      0x58440011,  //  0092  LDCONST	R17	K17
-      0x7C380600,  //  0093  CALL	R14	3
-      0x000C0702,  //  0094  ADD	R3	R3	K2
-      0x54360027,  //  0095  LDINT	R13	40
-      0x2434060D,  //  0096  GT	R13	R3	R13
-      0x78360000,  //  0097  JMPF	R13	#0099
-      0x70020000,  //  0098  JMP		#009A
-      0x7001FFDA,  //  0099  JMP		#0075
-      0xA8040001,  //  009A  EXBLK	1	1
-      0x70020002,  //  009B  JMP		#009F
-      0x58280021,  //  009C  LDCONST	R10	K33
-      0xAC280200,  //  009D  CATCH	R10	1	0
-      0xB0080000,  //  009E  RAISE	2	R0	R0
-      0x540E0027,  //  009F  LDINT	R3	40
-      0x60280010,  //  00A0  GETGBL	R10	G16
-      0x8C2C011B,  //  00A1  GETMET	R11	R0	K27
-      0x5C341200,  //  00A2  MOVE	R13	R9
-      0x7C2C0400,  //  00A3  CALL	R11	2
-      0x7C280200,  //  00A4  CALL	R10	1
-      0xA8020026,  //  00A5  EXBLK	0	#00CD
-      0x5C2C1400,  //  00A6  MOVE	R11	R10
-      0x7C2C0000,  //  00A7  CALL	R11	0
-      0x9430120B,  //  00A8  GETIDX	R12	R9	R11
-      0x6034000F,  //  00A9  GETGBL	R13	G15
-      0x5C381800,  //  00AA  MOVE	R14	R12
-      0x603C0013,  //  00AB  GETGBL	R15	G19
-      0x7C340400,  //  00AC  CALL	R13	2
-      0x78360017,  //  00AD  JMPF	R13	#00C6
-      0x8C34191C,  //  00AE  GETMET	R13	R12	K28
-      0x583C0022,  //  00AF  LDCONST	R15	K34
-      0x7C340400,  //  00B0  CALL	R13	2
-      0x78360013,  //  00B1  JMPF	R13	#00C6
-      0x00341723,  //  00B2  ADD	R13	R11	K35
-      0x88380109,  //  00B3  GETMBR	R14	R0	K9
-      0x8C381D0A,  //  00B4  GETMET	R14	R14	K10
-      0xB8421600,  //  00B5  GETNGBL	R16	K11
-      0x8C402124,  //  00B6  GETMET	R16	R16	K36
-      0x5C480000,  //  00B7  MOVE	R18	R0
-      0x5C4C0600,  //  00B8  MOVE	R19	R3
-      0x5C501A00,  //  00B9  MOVE	R20	R13
-      0x7C400800,  //  00BA  CALL	R16	4
-      0x7C380400,  //  00BB  CALL	R14	2
-      0xB83A1A00,  //  00BC  GETNGBL	R14	K13
-      0x8C381D0E,  //  00BD  GETMET	R14	R14	K14
-      0x8C40030F,  //  00BE  GETMET	R16	R1	K15
-      0x58480025,  //  00BF  LDCONST	R18	K37
-      0x5C4C0600,  //  00C0  MOVE	R19	R3
-      0x5C501A00,  //  00C1  MOVE	R20	R13
-      0x7C400800,  //  00C2  CALL	R16	4
-      0x58440011,  //  00C3  LDCONST	R17	K17
-      0x7C380600,  //  00C4  CALL	R14	3
-      0x000C0702,  //  00C5  ADD	R3	R3	K2
-      0x5436002E,  //  00C6  LDINT	R13	47
-      0x2434060D,  //  00C7  GT	R13	R3	R13
-      0x78360000,  //  00C8  JMPF	R13	#00CA
-      0x70020000,  //  00C9  JMP		#00CB
-      0x7001FFDA,  //  00CA  JMP		#00A6
-      0xA8040001,  //  00CB  EXBLK	1	1
-      0x70020002,  //  00CC  JMP		#00D0
-      0x58280021,  //  00CD  LDCONST	R10	K33
-      0xAC280200,  //  00CE  CATCH	R10	1	0
-      0xB0080000,  //  00CF  RAISE	2	R0	R0
-      0x540E002F,  //  00D0  LDINT	R3	48
-      0x60280010,  //  00D1  GETGBL	R10	G16
-      0x8C2C011B,  //  00D2  GETMET	R11	R0	K27
-      0x5C341200,  //  00D3  MOVE	R13	R9
-      0x7C2C0400,  //  00D4  CALL	R11	2
-      0x7C280200,  //  00D5  CALL	R10	1
-      0xA8020026,  //  00D6  EXBLK	0	#00FE
-      0x5C2C1400,  //  00D7  MOVE	R11	R10
-      0x7C2C0000,  //  00D8  CALL	R11	0
-      0x9430120B,  //  00D9  GETIDX	R12	R9	R11
-      0x6034000F,  //  00DA  GETGBL	R13	G15
-      0x5C381800,  //  00DB  MOVE	R14	R12
-      0x603C0013,  //  00DC  GETGBL	R15	G19
-      0x7C340400,  //  00DD  CALL	R13	2
-      0x78360017,  //  00DE  JMPF	R13	#00F7
-      0x8C34191C,  //  00DF  GETMET	R13	R12	K28
-      0x583C0026,  //  00E0  LDCONST	R15	K38
-      0x7C340400,  //  00E1  CALL	R13	2
-      0x78360013,  //  00E2  JMPF	R13	#00F7
-      0x00341727,  //  00E3  ADD	R13	R11	K39
-      0x88380109,  //  00E4  GETMBR	R14	R0	K9
-      0x8C381D0A,  //  00E5  GETMET	R14	R14	K10
-      0xB8421600,  //  00E6  GETNGBL	R16	K11
-      0x8C402128,  //  00E7  GETMET	R16	R16	K40
-      0x5C480000,  //  00E8  MOVE	R18	R0
-      0x5C4C0600,  //  00E9  MOVE	R19	R3
-      0x5C501A00,  //  00EA  MOVE	R20	R13
-      0x7C400800,  //  00EB  CALL	R16	4
-      0x7C380400,  //  00EC  CALL	R14	2
-      0xB83A1A00,  //  00ED  GETNGBL	R14	K13
-      0x8C381D0E,  //  00EE  GETMET	R14	R14	K14
-      0x8C40030F,  //  00EF  GETMET	R16	R1	K15
-      0x58480029,  //  00F0  LDCONST	R18	K41
-      0x5C4C0600,  //  00F1  MOVE	R19	R3
-      0x5C501A00,  //  00F2  MOVE	R20	R13
-      0x7C400800,  //  00F3  CALL	R16	4
-      0x58440011,  //  00F4  LDCONST	R17	K17
-      0x7C380600,  //  00F5  CALL	R14	3
-      0x000C0702,  //  00F6  ADD	R3	R3	K2
-      0x54360037,  //  00F7  LDINT	R13	56
-      0x2434060D,  //  00F8  GT	R13	R3	R13
-      0x78360000,  //  00F9  JMPF	R13	#00FB
-      0x70020000,  //  00FA  JMP		#00FC
-      0x7001FFDA,  //  00FB  JMP		#00D7
-      0xA8040001,  //  00FC  EXBLK	1	1
-      0x70020002,  //  00FD  JMP		#0101
-      0x58280021,  //  00FE  LDCONST	R10	K33
-      0xAC280200,  //  00FF  CATCH	R10	1	0
-      0xB0080000,  //  0100  RAISE	2	R0	R0
-      0x540E0037,  //  0101  LDINT	R3	56
-      0x60280010,  //  0102  GETGBL	R10	G16
-      0x8C2C011B,  //  0103  GETMET	R11	R0	K27
-      0x5C341200,  //  0104  MOVE	R13	R9
-      0x7C2C0400,  //  0105  CALL	R11	2
-      0x7C280200,  //  0106  CALL	R10	1
-      0xA8020026,  //  0107  EXBLK	0	#012F
-      0x5C2C1400,  //  0108  MOVE	R11	R10
-      0x7C2C0000,  //  0109  CALL	R11	0
-      0x9430120B,  //  010A  GETIDX	R12	R9	R11
-      0x6034000F,  //  010B  GETGBL	R13	G15
-      0x5C381800,  //  010C  MOVE	R14	R12
-      0x603C0013,  //  010D  GETGBL	R15	G19
-      0x7C340400,  //  010E  CALL	R13	2
-      0x78360017,  //  010F  JMPF	R13	#0128
-      0x8C34191C,  //  0110  GETMET	R13	R12	K28
-      0x583C002A,  //  0111  LDCONST	R15	K42
-      0x7C340400,  //  0112  CALL	R13	2
-      0x78360013,  //  0113  JMPF	R13	#0128
-      0x0034172B,  //  0114  ADD	R13	R11	K43
-      0x88380109,  //  0115  GETMBR	R14	R0	K9
-      0x8C381D0A,  //  0116  GETMET	R14	R14	K10
-      0xB8421600,  //  0117  GETNGBL	R16	K11
-      0x8C40212C,  //  0118  GETMET	R16	R16	K44
-      0x5C480000,  //  0119  MOVE	R18	R0
-      0x5C4C0600,  //  011A  MOVE	R19	R3
-      0x5C501A00,  //  011B  MOVE	R20	R13
-      0x7C400800,  //  011C  CALL	R16	4
-      0x7C380400,  //  011D  CALL	R14	2
-      0xB83A1A00,  //  011E  GETNGBL	R14	K13
-      0x8C381D0E,  //  011F  GETMET	R14	R14	K14
-      0x8C40030F,  //  0120  GETMET	R16	R1	K15
-      0x5848002D,  //  0121  LDCONST	R18	K45
-      0x5C4C0600,  //  0122  MOVE	R19	R3
-      0x5C501A00,  //  0123  MOVE	R20	R13
-      0x7C400800,  //  0124  CALL	R16	4
-      0x58440011,  //  0125  LDCONST	R17	K17
-      0x7C380600,  //  0126  CALL	R14	3
-      0x000C0702,  //  0127  ADD	R3	R3	K2
-      0x5436003F,  //  0128  LDINT	R13	64
-      0x2434060D,  //  0129  GT	R13	R3	R13
-      0x78360000,  //  012A  JMPF	R13	#012C
-      0x70020000,  //  012B  JMP		#012D
-      0x7001FFDA,  //  012C  JMP		#0108
-      0xA8040001,  //  012D  EXBLK	1	1
-      0x70020002,  //  012E  JMP		#0132
-      0x58280021,  //  012F  LDCONST	R10	K33
-      0xAC280200,  //  0130  CATCH	R10	1	0
-      0xB0080000,  //  0131  RAISE	2	R0	R0
-      0xB82A1A00,  //  0132  GETNGBL	R10	K13
-      0x8C28152E,  //  0133  GETMET	R10	R10	K46
-      0x5830002F,  //  0134  LDCONST	R12	K47
-      0x58340030,  //  0135  LDCONST	R13	K48
-      0x7C280600,  //  0136  CALL	R10	3
-      0x80000000,  //  0137  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _trigger_read_sensors
-********************************************************************/
-be_local_closure(Matter_Device__trigger_read_sensors,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(read_sensors),
-    /* K3   */  be_nested_str_weak(load),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(plugins),
-    /* K6   */  be_nested_str_weak(parse_sensors),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
-    /* K10  */  be_const_int(3),
-    }),
-    be_str_weak(_trigger_read_sensors),
-    &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x1C0C0403,  //  0005  EQ	R3	R2	R3
-      0x780E0000,  //  0006  JMPF	R3	#0008
-      0x80000600,  //  0007  RET	0
-      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
-      0x5C140400,  //  0009  MOVE	R5	R2
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x4C100000,  //  000B  LDNIL	R4
-      0x20100604,  //  000C  NE	R4	R3	R4
-      0x7812000D,  //  000D  JMPF	R4	#001C
-      0x58100004,  //  000E  LDCONST	R4	K4
-      0x6014000C,  //  000F  GETGBL	R5	G12
-      0x88180105,  //  0010  GETMBR	R6	R0	K5
-      0x7C140200,  //  0011  CALL	R5	1
-      0x14140805,  //  0012  LT	R5	R4	R5
-      0x78160006,  //  0013  JMPF	R5	#001B
-      0x88140105,  //  0014  GETMBR	R5	R0	K5
-      0x94140A04,  //  0015  GETIDX	R5	R5	R4
-      0x8C140B06,  //  0016  GETMET	R5	R5	K6
-      0x5C1C0600,  //  0017  MOVE	R7	R3
-      0x7C140400,  //  0018  CALL	R5	2
-      0x00100907,  //  0019  ADD	R4	R4	K7
-      0x7001FFF3,  //  001A  JMP		#000F
-      0x70020007,  //  001B  JMP		#0024
-      0xB8120200,  //  001C  GETNGBL	R4	K1
-      0x8C100908,  //  001D  GETMET	R4	R4	K8
-      0x60180008,  //  001E  GETGBL	R6	G8
-      0x5C1C0400,  //  001F  MOVE	R7	R2
-      0x7C180200,  //  0020  CALL	R6	1
-      0x001A1206,  //  0021  ADD	R6	K9	R6
-      0x581C000A,  //  0022  LDCONST	R7	K10
-      0x7C100600,  //  0023  CALL	R4	3
-      0x80000000,  //  0024  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_active_endpoints
-********************************************************************/
-be_local_closure(Matter_Device_get_active_endpoints,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins),
-    /* K1   */  be_nested_str_weak(get_endpoint),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(find),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(get_active_endpoints),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x88100100,  //  0003  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0xA8020011,  //  0005  EXBLK	0	#0018
-      0x5C100600,  //  0006  MOVE	R4	R3
-      0x7C100000,  //  0007  CALL	R4	0
-      0x8C140901,  //  0008  GETMET	R5	R4	K1
-      0x7C140200,  //  0009  CALL	R5	1
-      0x78060002,  //  000A  JMPF	R1	#000E
-      0x1C180B02,  //  000B  EQ	R6	R5	K2
-      0x781A0000,  //  000C  JMPF	R6	#000E
-      0x7001FFF7,  //  000D  JMP		#0006
-      0x8C180503,  //  000E  GETMET	R6	R2	K3
-      0x5C200A00,  //  000F  MOVE	R8	R5
-      0x7C180400,  //  0010  CALL	R6	2
-      0x4C1C0000,  //  0011  LDNIL	R7
-      0x1C180C07,  //  0012  EQ	R6	R6	R7
-      0x781A0002,  //  0013  JMPF	R6	#0017
-      0x8C180504,  //  0014  GETMET	R6	R2	K4
-      0x5C200A00,  //  0015  MOVE	R8	R5
-      0x7C180400,  //  0016  CALL	R6	2
-      0x7001FFED,  //  0017  JMP		#0006
-      0x580C0005,  //  0018  LDCONST	R3	K5
-      0xAC0C0200,  //  0019  CATCH	R3	1	0
-      0xB0080000,  //  001A  RAISE	2	R0	R0
-      0x80040400,  //  001B  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: msg_send
-********************************************************************/
-be_local_closure(Matter_Device_msg_send,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(send_UDP),
-    }),
-    be_str_weak(msg_send),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
+      0x8C200518,  //  0037  GETMET	R8	R2	K24
+      0x58280014,  //  0038  LDCONST	R10	K20
+      0x582C0015,  //  0039  LDCONST	R11	K21
+      0x5C300C00,  //  003A  MOVE	R12	R6
+      0x88340111,  //  003B  GETMBR	R13	R0	K17
+      0x5C380E00,  //  003C  MOVE	R14	R7
+      0x7C200C00,  //  003D  CALL	R8	6
+      0xB81E1000,  //  003E  GETNGBL	R7	K8
+      0x8C1C0F19,  //  003F  GETMET	R7	R7	K25
+      0x7C1C0200,  //  0040  CALL	R7	1
+      0x8C1C0F0D,  //  0041  GETMET	R7	R7	K13
+      0x5824000E,  //  0042  LDCONST	R9	K14
+      0x7C1C0400,  //  0043  CALL	R7	2
+      0x781E0020,  //  0044  JMPF	R7	#0066
+      0xB81E1000,  //  0045  GETNGBL	R7	K8
+      0x8C1C0F09,  //  0046  GETMET	R7	R7	K9
+      0x8C24070F,  //  0047  GETMET	R9	R3	K15
+      0x582C0010,  //  0048  LDCONST	R11	K16
+      0x58300019,  //  0049  LDCONST	R12	K25
+      0x5C340C00,  //  004A  MOVE	R13	R6
+      0x8838011A,  //  004B  GETMBR	R14	R0	K26
+      0x7C240A00,  //  004C  CALL	R9	5
+      0x58280012,  //  004D  LDCONST	R10	K18
+      0x7C1C0600,  //  004E  CALL	R7	3
+      0x8C1C0513,  //  004F  GETMET	R7	R2	K19
+      0x58240014,  //  0050  LDCONST	R9	K20
+      0x58280015,  //  0051  LDCONST	R10	K21
+      0x542E15A3,  //  0052  LDINT	R11	5540
+      0x4C300000,  //  0053  LDNIL	R12
+      0x5C340C00,  //  0054  MOVE	R13	R6
+      0x8838011A,  //  0055  GETMBR	R14	R0	K26
+      0x7C1C0E00,  //  0056  CALL	R7	7
+      0x8C1C0B06,  //  0057  GETMET	R7	R5	K6
+      0x7C1C0200,  //  0058  CALL	R7	1
+      0x001E2C07,  //  0059  ADD	R7	K22	R7
+      0xB8221000,  //  005A  GETNGBL	R8	K8
+      0x8C201109,  //  005B  GETMET	R8	R8	K9
+      0x002A2E07,  //  005C  ADD	R10	K23	R7
+      0x582C0012,  //  005D  LDCONST	R11	K18
+      0x7C200600,  //  005E  CALL	R8	3
+      0x8C200518,  //  005F  GETMET	R8	R2	K24
+      0x58280014,  //  0060  LDCONST	R10	K20
+      0x582C0015,  //  0061  LDCONST	R11	K21
+      0x5C300C00,  //  0062  MOVE	R12	R6
+      0x8834011A,  //  0063  GETMBR	R13	R0	K26
+      0x5C380E00,  //  0064  MOVE	R14	R7
+      0x7C200C00,  //  0065  CALL	R8	6
+      0xA8040001,  //  0066  EXBLK	1	1
+      0x70020010,  //  0067  JMP		#0079
+      0xAC100002,  //  0068  CATCH	R4	0	2
+      0x7002000D,  //  0069  JMP		#0078
+      0xB81A1000,  //  006A  GETNGBL	R6	K8
+      0x8C180D09,  //  006B  GETMET	R6	R6	K9
+      0x60200008,  //  006C  GETGBL	R8	G8
+      0x5C240800,  //  006D  MOVE	R9	R4
+      0x7C200200,  //  006E  CALL	R8	1
+      0x00223608,  //  006F  ADD	R8	K27	R8
+      0x0020111C,  //  0070  ADD	R8	R8	K28
+      0x60240008,  //  0071  GETGBL	R9	G8
+      0x5C280A00,  //  0072  MOVE	R10	R5
+      0x7C240200,  //  0073  CALL	R9	1
+      0x00201009,  //  0074  ADD	R8	R8	R9
+      0x5824000B,  //  0075  LDCONST	R9	K11
+      0x7C180600,  //  0076  CALL	R6	3
+      0x70020000,  //  0077  JMP		#0079
+      0xB0080000,  //  0078  RAISE	2	R0	R0
+      0x80000000,  //  0079  RET	0
     })
   )
 );
@@ -1597,12 +548,74 @@ be_local_closure(Matter_Device_stop,   /* name */
 
 
 /********************************************************************
-** Solidified function: msg_received
+** Solidified function: register_commands
 ********************************************************************/
-be_local_closure(Matter_Device_msg_received,   /* name */
+be_local_closure(Matter_Device_register_commands,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        10,                          /* nstack */
+        4,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(MtrJoin),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 8]) {  /* code */
+          0x68100000,  //  0000  GETUPV	R4	U0
+          0x8C100900,  //  0001  GETMET	R4	R4	K0
+          0x5C180000,  //  0002  MOVE	R6	R0
+          0x5C1C0200,  //  0003  MOVE	R7	R1
+          0x5C200400,  //  0004  MOVE	R8	R2
+          0x5C240600,  //  0005  MOVE	R9	R3
+          0x7C100A00,  //  0006  CALL	R4	5
+          0x80040800,  //  0007  RET	1	R4
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(add_cmd),
+    /* K2   */  be_nested_str_weak(MtrJoin),
+    }),
+    be_str_weak(register_commands),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x580C0002,  //  0002  LDCONST	R3	K2
+      0x84100000,  //  0003  CLOSURE	R4	P0
+      0x7C040600,  //  0004  CALL	R1	3
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: msg_send
+********************************************************************/
+be_local_closure(Matter_Device_msg_send,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1610,19 +623,180 @@ be_local_closure(Matter_Device_msg_received,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(msg_received),
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(send_UDP),
     }),
-    be_str_weak(msg_received),
+    be_str_weak(msg_send),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
-      0x8C100901,  //  0001  GETMET	R4	R4	K1
-      0x5C180200,  //  0002  MOVE	R6	R1
-      0x5C1C0400,  //  0003  MOVE	R7	R2
-      0x5C200600,  //  0004  MOVE	R8	R3
-      0x7C100800,  //  0005  CALL	R4	4
-      0x80040800,  //  0006  RET	1	R4
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_param
+********************************************************************/
+be_local_closure(Matter_Device_save_param,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[24]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(format),
+    /* K2   */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s),
+    /* K3   */  be_nested_str_weak(root_discriminator),
+    /* K4   */  be_nested_str_weak(root_passcode),
+    /* K5   */  be_nested_str_weak(ipv4only),
+    /* K6   */  be_nested_str_weak(true),
+    /* K7   */  be_nested_str_weak(false),
+    /* K8   */  be_nested_str_weak(plugins_persist),
+    /* K9   */  be_nested_str_weak(_X2C_X22config_X22_X3A),
+    /* K10  */  be_nested_str_weak(plugins_to_json),
+    /* K11  */  be_nested_str_weak(_X7D),
+    /* K12  */  be_nested_str_weak(FILENAME),
+    /* K13  */  be_nested_str_weak(w),
+    /* K14  */  be_nested_str_weak(write),
+    /* K15  */  be_nested_str_weak(close),
+    /* K16  */  be_nested_str_weak(tasmota),
+    /* K17  */  be_nested_str_weak(log),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
+    /* K19  */  be_nested_str_weak(_X20and_X20condiguration),
+    /* K20  */  be_nested_str_weak(),
+    /* K21  */  be_const_int(2),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+    /* K23  */  be_nested_str_weak(_X7C),
+    }),
+    be_str_weak(save_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[63]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x88140103,  //  0003  GETMBR	R5	R0	K3
+      0x88180104,  //  0004  GETMBR	R6	R0	K4
+      0x881C0105,  //  0005  GETMBR	R7	R0	K5
+      0x781E0001,  //  0006  JMPF	R7	#0009
+      0x581C0006,  //  0007  LDCONST	R7	K6
+      0x70020000,  //  0008  JMP		#000A
+      0x581C0007,  //  0009  LDCONST	R7	K7
+      0x7C080A00,  //  000A  CALL	R2	5
+      0x880C0108,  //  000B  GETMBR	R3	R0	K8
+      0x780E0003,  //  000C  JMPF	R3	#0011
+      0x00080509,  //  000D  ADD	R2	R2	K9
+      0x8C0C010A,  //  000E  GETMET	R3	R0	K10
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0x00080403,  //  0010  ADD	R2	R2	R3
+      0x0008050B,  //  0011  ADD	R2	R2	K11
+      0xA8020018,  //  0012  EXBLK	0	#002C
+      0x600C0011,  //  0013  GETGBL	R3	G17
+      0x8810010C,  //  0014  GETMBR	R4	R0	K12
+      0x5814000D,  //  0015  LDCONST	R5	K13
+      0x7C0C0400,  //  0016  CALL	R3	2
+      0x8C10070E,  //  0017  GETMET	R4	R3	K14
+      0x5C180400,  //  0018  MOVE	R6	R2
+      0x7C100400,  //  0019  CALL	R4	2
+      0x8C10070F,  //  001A  GETMET	R4	R3	K15
+      0x7C100200,  //  001B  CALL	R4	1
+      0xB8122000,  //  001C  GETNGBL	R4	K16
+      0x8C100911,  //  001D  GETMET	R4	R4	K17
+      0x8C180301,  //  001E  GETMET	R6	R1	K1
+      0x58200012,  //  001F  LDCONST	R8	K18
+      0x88240108,  //  0020  GETMBR	R9	R0	K8
+      0x78260001,  //  0021  JMPF	R9	#0024
+      0x58240013,  //  0022  LDCONST	R9	K19
+      0x70020000,  //  0023  JMP		#0025
+      0x58240014,  //  0024  LDCONST	R9	K20
+      0x7C180600,  //  0025  CALL	R6	3
+      0x581C0015,  //  0026  LDCONST	R7	K21
+      0x7C100600,  //  0027  CALL	R4	3
+      0xA8040001,  //  0028  EXBLK	1	1
+      0x80040400,  //  0029  RET	1	R2
+      0xA8040001,  //  002A  EXBLK	1	1
+      0x70020011,  //  002B  JMP		#003E
+      0xAC0C0002,  //  002C  CATCH	R3	0	2
+      0x7002000E,  //  002D  JMP		#003D
+      0xB8162000,  //  002E  GETNGBL	R5	K16
+      0x8C140B11,  //  002F  GETMET	R5	R5	K17
+      0x601C0008,  //  0030  GETGBL	R7	G8
+      0x5C200600,  //  0031  MOVE	R8	R3
+      0x7C1C0200,  //  0032  CALL	R7	1
+      0x001E2C07,  //  0033  ADD	R7	K22	R7
+      0x001C0F17,  //  0034  ADD	R7	R7	K23
+      0x60200008,  //  0035  GETGBL	R8	G8
+      0x5C240800,  //  0036  MOVE	R9	R4
+      0x7C200200,  //  0037  CALL	R8	1
+      0x001C0E08,  //  0038  ADD	R7	R7	R8
+      0x58200015,  //  0039  LDCONST	R8	K21
+      0x7C140600,  //  003A  CALL	R5	3
+      0x80040400,  //  003B  RET	1	R2
+      0x70020000,  //  003C  JMP		#003E
+      0xB0080000,  //  003D  RAISE	2	R0	R0
+      0x80000000,  //  003E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_announce_op_discovery_all_fabrics
+********************************************************************/
+be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(active_fabrics),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(mdns_announce_op_discovery),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(mdns_announce_op_discovery_all_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000B,  //  0005  EXBLK	0	#0012
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x780E0005,  //  000A  JMPF	R3	#0011
+      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x780E0002,  //  000D  JMPF	R3	#0011
+      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x7001FFF3,  //  0011  JMP		#0006
+      0x58040005,  //  0012  LDCONST	R1	K5
+      0xAC040200,  //  0013  CATCH	R1	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x80000000,  //  0015  RET	0
     })
   )
 );
@@ -1683,6 +857,43 @@ be_local_closure(Matter_Device_start_operational_discovery_deferred,   /* name *
       0x7C080600,  //  0004  CALL	R2	3
       0xA0000000,  //  0005  CLOSE	R0
       0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_commissioning_complete
+********************************************************************/
+be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X20Commissioning_X20complete_X20_X2A_X2A_X2A),
+    /* K3   */  be_const_int(2),
+    /* K4   */  be_nested_str_weak(stop_basic_commissioning),
+    }),
+    be_str_weak(start_commissioning_complete),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x58140003,  //  0003  LDCONST	R5	K3
+      0x7C080600,  //  0004  CALL	R2	3
+      0x8C080104,  //  0005  GETMET	R2	R0	K4
+      0x7C080200,  //  0006  CALL	R2	1
+      0x80000000,  //  0007  RET	0
     })
   )
 );
@@ -1766,11 +977,74 @@ be_local_closure(Matter_Device_compute_qrcode_content,   /* name */
 
 
 /********************************************************************
-** Solidified function: sort_distinct
+** Solidified function: compute_manual_pairing_code
 ********************************************************************/
-be_local_closure(Matter_Device_sort_distinct,   /* name */
+be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    11,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(root_discriminator),
+    /* K2   */  be_nested_str_weak(root_passcode),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(_X251i_X2505i_X2504i),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(Verhoeff),
+    /* K7   */  be_nested_str_weak(checksum),
+    }),
+    be_str_weak(compute_manual_pairing_code),
+    &be_const_str_solidified,
+    ( &(const binstruction[31]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x540E0FFE,  //  0002  LDINT	R3	4095
+      0x2C080403,  //  0003  AND	R2	R2	R3
+      0x540E0009,  //  0004  LDINT	R3	10
+      0x3C080403,  //  0005  SHR	R2	R2	R3
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x541202FF,  //  0007  LDINT	R4	768
+      0x2C0C0604,  //  0008  AND	R3	R3	R4
+      0x54120005,  //  0009  LDINT	R4	6
+      0x380C0604,  //  000A  SHL	R3	R3	R4
+      0x88100102,  //  000B  GETMBR	R4	R0	K2
+      0x54163FFE,  //  000C  LDINT	R5	16383
+      0x2C100805,  //  000D  AND	R4	R4	R5
+      0x300C0604,  //  000E  OR	R3	R3	R4
+      0x88100102,  //  000F  GETMBR	R4	R0	K2
+      0x5416000D,  //  0010  LDINT	R5	14
+      0x3C100805,  //  0011  SHR	R4	R4	R5
+      0x8C140303,  //  0012  GETMET	R5	R1	K3
+      0x581C0004,  //  0013  LDCONST	R7	K4
+      0x5C200400,  //  0014  MOVE	R8	R2
+      0x5C240600,  //  0015  MOVE	R9	R3
+      0x5C280800,  //  0016  MOVE	R10	R4
+      0x7C140A00,  //  0017  CALL	R5	5
+      0xB81A0A00,  //  0018  GETNGBL	R6	K5
+      0x88180D06,  //  0019  GETMBR	R6	R6	K6
+      0x8C180D07,  //  001A  GETMET	R6	R6	K7
+      0x5C200A00,  //  001B  MOVE	R8	R5
+      0x7C180400,  //  001C  CALL	R6	2
+      0x00140A06,  //  001D  ADD	R5	R5	R6
+      0x80040A00,  //  001E  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: k2l
+********************************************************************/
+be_local_closure(Matter_Device_k2l,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
     1,                          /* argc */
     4,                          /* varg */
     0,                          /* has upvals */
@@ -1778,69 +1052,67 @@ be_local_closure(Matter_Device_sort_distinct,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(push),
     /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_nested_str_weak(remove),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_const_int(0),
     }),
-    be_str_weak(sort_distinct),
+    be_str_weak(k2l),
     &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
+    ( &(const binstruction[50]) {  /* code */
       0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080010,  //  0001  GETGBL	R2	G16
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x040C0701,  //  0005  SUB	R3	R3	K1
-      0x400E0203,  //  0006  CONNECT	R3	K1	R3
-      0x7C080200,  //  0007  CALL	R2	1
-      0xA8020010,  //  0008  EXBLK	0	#001A
-      0x5C0C0400,  //  0009  MOVE	R3	R2
-      0x7C0C0000,  //  000A  CALL	R3	0
-      0x94100003,  //  000B  GETIDX	R4	R0	R3
-      0x5C140600,  //  000C  MOVE	R5	R3
-      0x24180B02,  //  000D  GT	R6	R5	K2
-      0x781A0008,  //  000E  JMPF	R6	#0018
-      0x04180B01,  //  000F  SUB	R6	R5	K1
-      0x94180006,  //  0010  GETIDX	R6	R0	R6
-      0x24180C04,  //  0011  GT	R6	R6	R4
-      0x781A0004,  //  0012  JMPF	R6	#0018
-      0x04180B01,  //  0013  SUB	R6	R5	K1
-      0x94180006,  //  0014  GETIDX	R6	R0	R6
-      0x98000A06,  //  0015  SETIDX	R0	R5	R6
-      0x04140B01,  //  0016  SUB	R5	R5	K1
-      0x7001FFF4,  //  0017  JMP		#000D
-      0x98000A04,  //  0018  SETIDX	R0	R5	R4
-      0x7001FFEE,  //  0019  JMP		#0009
-      0x58080003,  //  001A  LDCONST	R2	K3
-      0xAC080200,  //  001B  CATCH	R2	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x58080001,  //  001D  LDCONST	R2	K1
-      0x600C000C,  //  001E  GETGBL	R3	G12
-      0x5C100000,  //  001F  MOVE	R4	R0
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x180C0701,  //  0021  LE	R3	R3	K1
-      0x780E0000,  //  0022  JMPF	R3	#0024
-      0x80040000,  //  0023  RET	1	R0
-      0x940C0102,  //  0024  GETIDX	R3	R0	K2
-      0x6010000C,  //  0025  GETGBL	R4	G12
-      0x5C140000,  //  0026  MOVE	R5	R0
-      0x7C100200,  //  0027  CALL	R4	1
-      0x14100404,  //  0028  LT	R4	R2	R4
-      0x78120009,  //  0029  JMPF	R4	#0034
-      0x94100002,  //  002A  GETIDX	R4	R0	R2
-      0x1C100803,  //  002B  EQ	R4	R4	R3
-      0x78120003,  //  002C  JMPF	R4	#0031
-      0x8C100104,  //  002D  GETMET	R4	R0	K4
-      0x5C180400,  //  002E  MOVE	R6	R2
-      0x7C100400,  //  002F  CALL	R4	2
-      0x70020001,  //  0030  JMP		#0033
-      0x940C0002,  //  0031  GETIDX	R3	R0	R2
-      0x00080501,  //  0032  ADD	R2	R2	K1
-      0x7001FFF0,  //  0033  JMP		#0025
-      0x80040000,  //  0034  RET	1	R0
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0003,  //  0004  EQ	R3	R0	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80040400,  //  0006  RET	1	R2
+      0x600C0010,  //  0007  GETGBL	R3	G16
+      0x8C100101,  //  0008  GETMET	R4	R0	K1
+      0x7C100200,  //  0009  CALL	R4	1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0xA8020005,  //  000B  EXBLK	0	#0012
+      0x5C100600,  //  000C  MOVE	R4	R3
+      0x7C100000,  //  000D  CALL	R4	0
+      0x8C140502,  //  000E  GETMET	R5	R2	K2
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x7C140400,  //  0010  CALL	R5	2
+      0x7001FFF9,  //  0011  JMP		#000C
+      0x580C0003,  //  0012  LDCONST	R3	K3
+      0xAC0C0200,  //  0013  CATCH	R3	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x600C0010,  //  0015  GETGBL	R3	G16
+      0x6010000C,  //  0016  GETGBL	R4	G12
+      0x5C140400,  //  0017  MOVE	R5	R2
+      0x7C100200,  //  0018  CALL	R4	1
+      0x04100904,  //  0019  SUB	R4	R4	K4
+      0x40120804,  //  001A  CONNECT	R4	K4	R4
+      0x7C0C0200,  //  001B  CALL	R3	1
+      0xA8020010,  //  001C  EXBLK	0	#002E
+      0x5C100600,  //  001D  MOVE	R4	R3
+      0x7C100000,  //  001E  CALL	R4	0
+      0x94140404,  //  001F  GETIDX	R5	R2	R4
+      0x5C180800,  //  0020  MOVE	R6	R4
+      0x241C0D05,  //  0021  GT	R7	R6	K5
+      0x781E0008,  //  0022  JMPF	R7	#002C
+      0x041C0D04,  //  0023  SUB	R7	R6	K4
+      0x941C0407,  //  0024  GETIDX	R7	R2	R7
+      0x241C0E05,  //  0025  GT	R7	R7	R5
+      0x781E0004,  //  0026  JMPF	R7	#002C
+      0x041C0D04,  //  0027  SUB	R7	R6	K4
+      0x941C0407,  //  0028  GETIDX	R7	R2	R7
+      0x98080C07,  //  0029  SETIDX	R2	R6	R7
+      0x04180D04,  //  002A  SUB	R6	R6	K4
+      0x7001FFF4,  //  002B  JMP		#0021
+      0x98080C05,  //  002C  SETIDX	R2	R6	R5
+      0x7001FFEE,  //  002D  JMP		#001D
+      0x580C0003,  //  002E  LDCONST	R3	K3
+      0xAC0C0200,  //  002F  CATCH	R3	1	0
+      0xB0080000,  //  0030  RAISE	2	R0	R0
+      0x80040400,  //  0031  RET	1	R2
     })
   )
 );
@@ -1980,171 +1252,12 @@ be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
 
 
 /********************************************************************
-** Solidified function: every_second
+** Solidified function: MtrJoin
 ********************************************************************/
-be_local_closure(Matter_Device_every_second,   /* name */
+be_local_closure(Matter_Device_MtrJoin,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(every_second),
-    /* K2   */  be_nested_str_weak(message_handler),
-    /* K3   */  be_nested_str_weak(commissioning_open),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(time_reached),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(plugins),
-    /* K8   */  be_const_int(1),
-    }),
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040102,  //  0003  GETMBR	R1	R0	K2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
-      0x7C040200,  //  0005  CALL	R1	1
-      0x88040103,  //  0006  GETMBR	R1	R0	K3
-      0x4C080000,  //  0007  LDNIL	R2
-      0x20040202,  //  0008  NE	R1	R1	R2
-      0x78060006,  //  0009  JMPF	R1	#0011
-      0xB8060800,  //  000A  GETNGBL	R1	K4
-      0x8C040305,  //  000B  GETMET	R1	R1	K5
-      0x880C0103,  //  000C  GETMBR	R3	R0	K3
-      0x7C040400,  //  000D  CALL	R1	2
-      0x78060001,  //  000E  JMPF	R1	#0011
-      0x4C040000,  //  000F  LDNIL	R1
-      0x90020601,  //  0010  SETMBR	R0	K3	R1
-      0x58040006,  //  0011  LDCONST	R1	K6
-      0x6008000C,  //  0012  GETGBL	R2	G12
-      0x880C0107,  //  0013  GETMBR	R3	R0	K7
-      0x7C080200,  //  0014  CALL	R2	1
-      0x14080202,  //  0015  LT	R2	R1	R2
-      0x780A0005,  //  0016  JMPF	R2	#001D
-      0x88080107,  //  0017  GETMBR	R2	R0	K7
-      0x94080401,  //  0018  GETIDX	R2	R2	R1
-      0x8C080501,  //  0019  GETMET	R2	R2	K1
-      0x7C080200,  //  001A  CALL	R2	1
-      0x00040308,  //  001B  ADD	R1	R1	K8
-      0x7001FFF4,  //  001C  JMP		#0012
-      0x80000000,  //  001D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_root_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(PASE_TIMEOUT),
-    /* K2   */  be_nested_str_weak(compute_manual_pairing_code),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s_X2D_X25s_X2D_X25s),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_const_int(2147483647),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(compute_qrcode_content),
-    /* K12  */  be_nested_str_weak(publish_result),
-    /* K13  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A1_X2C_X22PairingCode_X22_X3A_X22_X25s_X22_X2C_X22QRCode_X22_X3A_X22_X25s_X22_X7D_X7D),
-    /* K14  */  be_nested_str_weak(Matter),
-    /* K15  */  be_nested_str_weak(_compute_pbkdf),
-    /* K16  */  be_nested_str_weak(root_passcode),
-    /* K17  */  be_nested_str_weak(root_iterations),
-    /* K18  */  be_nested_str_weak(root_salt),
-    /* K19  */  be_nested_str_weak(start_basic_commissioning),
-    /* K20  */  be_nested_str_weak(root_discriminator),
-    /* K21  */  be_nested_str_weak(root_w0),
-    /* K22  */  be_nested_str_weak(root_L),
-    }),
-    be_str_weak(start_root_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[49]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x1C0C0203,  //  0002  EQ	R3	R1	R3
-      0x780E0000,  //  0003  JMPF	R3	#0005
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C0C0102,  //  0005  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0xB8120600,  //  0007  GETNGBL	R4	K3
-      0x8C100904,  //  0008  GETMET	R4	R4	K4
-      0x8C180505,  //  0009  GETMET	R6	R2	K5
-      0x58200006,  //  000A  LDCONST	R8	K6
-      0x40260F08,  //  000B  CONNECT	R9	K7	K8
-      0x94240609,  //  000C  GETIDX	R9	R3	R9
-      0x542A0003,  //  000D  LDINT	R10	4
-      0x542E0005,  //  000E  LDINT	R11	6
-      0x4028140B,  //  000F  CONNECT	R10	R10	R11
-      0x9428060A,  //  0010  GETIDX	R10	R3	R10
-      0x542E0006,  //  0011  LDINT	R11	7
-      0x402C1709,  //  0012  CONNECT	R11	R11	K9
-      0x942C060B,  //  0013  GETIDX	R11	R3	R11
-      0x7C180A00,  //  0014  CALL	R6	5
-      0x581C000A,  //  0015  LDCONST	R7	K10
-      0x7C100600,  //  0016  CALL	R4	3
-      0x8C10010B,  //  0017  GETMET	R4	R0	K11
-      0x7C100200,  //  0018  CALL	R4	1
-      0xB8160600,  //  0019  GETNGBL	R5	K3
-      0x8C140B0C,  //  001A  GETMET	R5	R5	K12
-      0x8C1C0505,  //  001B  GETMET	R7	R2	K5
-      0x5824000D,  //  001C  LDCONST	R9	K13
-      0x5C280600,  //  001D  MOVE	R10	R3
-      0x5C2C0800,  //  001E  MOVE	R11	R4
-      0x7C1C0800,  //  001F  CALL	R7	4
-      0x5820000E,  //  0020  LDCONST	R8	K14
-      0x7C140600,  //  0021  CALL	R5	3
-      0x8C14010F,  //  0022  GETMET	R5	R0	K15
-      0x881C0110,  //  0023  GETMBR	R7	R0	K16
-      0x88200111,  //  0024  GETMBR	R8	R0	K17
-      0x88240112,  //  0025  GETMBR	R9	R0	K18
-      0x7C140800,  //  0026  CALL	R5	4
-      0x8C140113,  //  0027  GETMET	R5	R0	K19
-      0x5C1C0200,  //  0028  MOVE	R7	R1
-      0x88200111,  //  0029  GETMBR	R8	R0	K17
-      0x88240114,  //  002A  GETMBR	R9	R0	K20
-      0x88280112,  //  002B  GETMBR	R10	R0	K18
-      0x882C0115,  //  002C  GETMBR	R11	R0	K21
-      0x88300116,  //  002D  GETMBR	R12	R0	K22
-      0x4C340000,  //  002E  LDNIL	R13
-      0x7C141000,  //  002F  CALL	R5	8
-      0x80000000,  //  0030  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _init_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device__init_basic_commissioning,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
+    8,                          /* nstack */
+    5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -2152,346 +1265,27 @@ be_local_closure(Matter_Device__init_basic_commissioning,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(count_active_fabrics),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(start_root_basic_commissioning),
-    }),
-    be_str_weak(_init_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x1C040302,  //  0003  EQ	R1	R1	K2
-      0x78060001,  //  0004  JMPF	R1	#0007
-      0x8C040103,  //  0005  GETMET	R1	R0	K3
-      0x7C040200,  //  0006  CALL	R1	1
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Device_init,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_start),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0004,  //  0006  LDCONST	R3	K4
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_start),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0004,  //  0006  LDCONST	R3	K4
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[36]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(string),
+    /* K0   */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K1   */  be_nested_str_weak(stop_basic_commissioning),
     /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(get_option),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(MATTER_OPTION),
-    /* K6   */  be_nested_str_weak(UI),
-    /* K7   */  be_nested_str_weak(started),
-    /* K8   */  be_nested_str_weak(plugins),
-    /* K9   */  be_nested_str_weak(vendorid),
-    /* K10  */  be_nested_str_weak(VENDOR_ID),
-    /* K11  */  be_nested_str_weak(productid),
-    /* K12  */  be_nested_str_weak(PRODUCT_ID),
-    /* K13  */  be_nested_str_weak(root_iterations),
-    /* K14  */  be_nested_str_weak(PBKDF_ITERATIONS),
-    /* K15  */  be_nested_str_weak(root_salt),
-    /* K16  */  be_nested_str_weak(random),
-    /* K17  */  be_nested_str_weak(ipv4only),
-    /* K18  */  be_nested_str_weak(load_param),
-    /* K19  */  be_nested_str_weak(sessions),
-    /* K20  */  be_nested_str_weak(Session_Store),
-    /* K21  */  be_nested_str_weak(load_fabrics),
-    /* K22  */  be_nested_str_weak(message_handler),
-    /* K23  */  be_nested_str_weak(MessageHandler),
-    /* K24  */  be_nested_str_weak(ui),
-    /* K25  */  be_nested_str_weak(wifi),
-    /* K26  */  be_nested_str_weak(up),
-    /* K27  */  be_nested_str_weak(eth),
-    /* K28  */  be_nested_str_weak(start),
-    /* K29  */  be_nested_str_weak(add_rule),
-    /* K30  */  be_nested_str_weak(Wifi_X23Connected),
-    /* K31  */  be_nested_str_weak(matter_start),
-    /* K32  */  be_nested_str_weak(Eth_X23Connected),
-    /* K33  */  be_nested_str_weak(_init_basic_commissioning),
-    /* K34  */  be_nested_str_weak(add_driver),
-    /* K35  */  be_nested_str_weak(register_commands),
+    /* K3   */  be_nested_str_weak(resp_cmnd_done),
     }),
-    be_str_weak(init),
+    be_str_weak(MtrJoin),
     &be_const_str_solidified,
-    ( &(const binstruction[93]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x8C0C0703,  //  0003  GETMET	R3	R3	K3
-      0xB8160800,  //  0004  GETNGBL	R5	K4
-      0x88140B05,  //  0005  GETMBR	R5	R5	K5
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x740E0004,  //  0007  JMPT	R3	#000D
-      0xB80E0800,  //  0008  GETNGBL	R3	K4
-      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
-      0x5C140000,  //  000A  MOVE	R5	R0
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x80000600,  //  000C  RET	0
-      0x500C0000,  //  000D  LDBOOL	R3	0	0
-      0x90020E03,  //  000E  SETMBR	R0	K7	R3
-      0x600C0012,  //  000F  GETGBL	R3	G18
-      0x7C0C0000,  //  0010  CALL	R3	0
-      0x90021003,  //  0011  SETMBR	R0	K8	R3
-      0x880C010A,  //  0012  GETMBR	R3	R0	K10
-      0x90021203,  //  0013  SETMBR	R0	K9	R3
-      0x880C010C,  //  0014  GETMBR	R3	R0	K12
-      0x90021603,  //  0015  SETMBR	R0	K11	R3
-      0x880C010E,  //  0016  GETMBR	R3	R0	K14
-      0x90021A03,  //  0017  SETMBR	R0	K13	R3
-      0x8C0C0310,  //  0018  GETMET	R3	R1	K16
-      0x5416000F,  //  0019  LDINT	R5	16
-      0x7C0C0400,  //  001A  CALL	R3	2
-      0x90021E03,  //  001B  SETMBR	R0	K15	R3
-      0x500C0000,  //  001C  LDBOOL	R3	0	0
-      0x90022203,  //  001D  SETMBR	R0	K17	R3
-      0x8C0C0112,  //  001E  GETMET	R3	R0	K18
-      0x7C0C0200,  //  001F  CALL	R3	1
-      0xB80E0800,  //  0020  GETNGBL	R3	K4
-      0x8C0C0714,  //  0021  GETMET	R3	R3	K20
-      0x7C0C0200,  //  0022  CALL	R3	1
-      0x90022603,  //  0023  SETMBR	R0	K19	R3
-      0x880C0113,  //  0024  GETMBR	R3	R0	K19
-      0x8C0C0715,  //  0025  GETMET	R3	R3	K21
-      0x7C0C0200,  //  0026  CALL	R3	1
-      0xB80E0800,  //  0027  GETNGBL	R3	K4
-      0x8C0C0717,  //  0028  GETMET	R3	R3	K23
-      0x5C140000,  //  0029  MOVE	R5	R0
-      0x7C0C0400,  //  002A  CALL	R3	2
-      0x90022C03,  //  002B  SETMBR	R0	K22	R3
-      0xB80E0800,  //  002C  GETNGBL	R3	K4
-      0x8C0C0706,  //  002D  GETMET	R3	R3	K6
-      0x5C140000,  //  002E  MOVE	R5	R0
-      0x7C0C0400,  //  002F  CALL	R3	2
-      0x90023003,  //  0030  SETMBR	R0	K24	R3
-      0xB80E0400,  //  0031  GETNGBL	R3	K2
-      0x8C0C0719,  //  0032  GETMET	R3	R3	K25
-      0x7C0C0200,  //  0033  CALL	R3	1
-      0x940C071A,  //  0034  GETIDX	R3	R3	K26
-      0x740E0004,  //  0035  JMPT	R3	#003B
-      0xB80E0400,  //  0036  GETNGBL	R3	K2
-      0x8C0C071B,  //  0037  GETMET	R3	R3	K27
-      0x7C0C0200,  //  0038  CALL	R3	1
-      0x940C071A,  //  0039  GETIDX	R3	R3	K26
-      0x780E0001,  //  003A  JMPF	R3	#003D
-      0x8C0C011C,  //  003B  GETMET	R3	R0	K28
-      0x7C0C0200,  //  003C  CALL	R3	1
-      0xB80E0400,  //  003D  GETNGBL	R3	K2
-      0x8C0C0719,  //  003E  GETMET	R3	R3	K25
-      0x7C0C0200,  //  003F  CALL	R3	1
-      0x940C071A,  //  0040  GETIDX	R3	R3	K26
-      0x740E0005,  //  0041  JMPT	R3	#0048
-      0xB80E0400,  //  0042  GETNGBL	R3	K2
-      0x8C0C071D,  //  0043  GETMET	R3	R3	K29
-      0x5814001E,  //  0044  LDCONST	R5	K30
-      0x84180000,  //  0045  CLOSURE	R6	P0
-      0x581C001F,  //  0046  LDCONST	R7	K31
-      0x7C0C0800,  //  0047  CALL	R3	4
-      0xB80E0400,  //  0048  GETNGBL	R3	K2
-      0x8C0C071B,  //  0049  GETMET	R3	R3	K27
-      0x7C0C0200,  //  004A  CALL	R3	1
-      0x940C071A,  //  004B  GETIDX	R3	R3	K26
-      0x740E0005,  //  004C  JMPT	R3	#0053
-      0xB80E0400,  //  004D  GETNGBL	R3	K2
-      0x8C0C071D,  //  004E  GETMET	R3	R3	K29
-      0x58140020,  //  004F  LDCONST	R5	K32
-      0x84180001,  //  0050  CLOSURE	R6	P1
-      0x581C001F,  //  0051  LDCONST	R7	K31
-      0x7C0C0800,  //  0052  CALL	R3	4
-      0x8C0C0121,  //  0053  GETMET	R3	R0	K33
-      0x7C0C0200,  //  0054  CALL	R3	1
-      0xB80E0400,  //  0055  GETNGBL	R3	K2
-      0x8C0C0722,  //  0056  GETMET	R3	R3	K34
-      0x5C140000,  //  0057  MOVE	R5	R0
-      0x7C0C0400,  //  0058  CALL	R3	2
-      0x8C0C0123,  //  0059  GETMET	R3	R0	K35
-      0x7C0C0200,  //  005A  CALL	R3	1
-      0xA0000000,  //  005B  CLOSE	R0
-      0x80000000,  //  005C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _compute_pbkdf
-********************************************************************/
-be_local_closure(Matter_Device__compute_pbkdf,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(add),
-    /* K3   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
-    /* K4   */  be_nested_str_weak(derive),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(root_w0),
-    /* K7   */  be_nested_str_weak(EC_P256),
-    /* K8   */  be_nested_str_weak(mod),
-    /* K9   */  be_nested_str_weak(root_L),
-    /* K10  */  be_nested_str_weak(public_key),
-    }),
-    be_str_weak(_compute_pbkdf),
-    &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0xA4160200,  //  0001  IMPORT	R5	K1
-      0x60180015,  //  0002  GETGBL	R6	G21
-      0x7C180000,  //  0003  CALL	R6	0
-      0x8C180D02,  //  0004  GETMET	R6	R6	K2
-      0x5C200200,  //  0005  MOVE	R8	R1
-      0x54260003,  //  0006  LDINT	R9	4
-      0x7C180600,  //  0007  CALL	R6	3
-      0x8C1C0903,  //  0008  GETMET	R7	R4	K3
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x8C1C0F04,  //  000A  GETMET	R7	R7	K4
-      0x5C240C00,  //  000B  MOVE	R9	R6
-      0x5C280600,  //  000C  MOVE	R10	R3
-      0x5C2C0400,  //  000D  MOVE	R11	R2
-      0x5432004F,  //  000E  LDINT	R12	80
-      0x7C1C0A00,  //  000F  CALL	R7	5
-      0x54220026,  //  0010  LDINT	R8	39
-      0x40220A08,  //  0011  CONNECT	R8	K5	R8
-      0x94200E08,  //  0012  GETIDX	R8	R7	R8
-      0x54260027,  //  0013  LDINT	R9	40
-      0x542A004E,  //  0014  LDINT	R10	79
-      0x4024120A,  //  0015  CONNECT	R9	R9	R10
-      0x94240E09,  //  0016  GETIDX	R9	R7	R9
-      0x8C280907,  //  0017  GETMET	R10	R4	K7
-      0x7C280200,  //  0018  CALL	R10	1
-      0x8C281508,  //  0019  GETMET	R10	R10	K8
-      0x5C301000,  //  001A  MOVE	R12	R8
-      0x7C280400,  //  001B  CALL	R10	2
-      0x90020C0A,  //  001C  SETMBR	R0	K6	R10
-      0x8C280907,  //  001D  GETMET	R10	R4	K7
-      0x7C280200,  //  001E  CALL	R10	1
-      0x8C281508,  //  001F  GETMET	R10	R10	K8
-      0x5C301200,  //  0020  MOVE	R12	R9
-      0x7C280400,  //  0021  CALL	R10	2
-      0x8C2C0907,  //  0022  GETMET	R11	R4	K7
-      0x7C2C0200,  //  0023  CALL	R11	1
-      0x8C2C170A,  //  0024  GETMET	R11	R11	K10
-      0x5C341400,  //  0025  MOVE	R13	R10
-      0x7C2C0400,  //  0026  CALL	R11	2
-      0x9002120B,  //  0027  SETMBR	R0	K9	R11
-      0x80000000,  //  0028  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_250ms
-********************************************************************/
-be_local_closure(Matter_Device_every_250ms,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(every_250ms),
-    }),
-    be_str_weak(every_250ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80000000,  //  0003  RET	0
+    ( &(const binstruction[13]) {  /* code */
+      0x60140009,  //  0000  GETGBL	R5	G9
+      0x5C180600,  //  0001  MOVE	R6	R3
+      0x7C140200,  //  0002  CALL	R5	1
+      0x78160002,  //  0003  JMPF	R5	#0007
+      0x8C180100,  //  0004  GETMET	R6	R0	K0
+      0x7C180200,  //  0005  CALL	R6	1
+      0x70020001,  //  0006  JMP		#0009
+      0x8C180101,  //  0007  GETMET	R6	R0	K1
+      0x7C180200,  //  0008  CALL	R6	1
+      0xB81A0400,  //  0009  GETNGBL	R6	K2
+      0x8C180D03,  //  000A  GETMET	R6	R6	K3
+      0x7C180200,  //  000B  CALL	R6	1
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -2821,6 +1615,2340 @@ be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
       0x50400200,  //  00D5  LDBOOL	R16	1	0
       0x7C340600,  //  00D6  CALL	R13	3
       0x80000000,  //  00D7  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: received_ack
+********************************************************************/
+be_local_closure(Matter_Device_received_ack,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(received_ack),
+    }),
+    be_str_weak(received_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _trigger_read_sensors
+********************************************************************/
+be_local_closure(Matter_Device__trigger_read_sensors,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(read_sensors),
+    /* K3   */  be_nested_str_weak(load),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(plugins),
+    /* K6   */  be_nested_str_weak(parse_sensors),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
+    /* K10  */  be_const_int(3),
+    }),
+    be_str_weak(_trigger_read_sensors),
+    &be_const_str_solidified,
+    ( &(const binstruction[37]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x7C080200,  //  0003  CALL	R2	1
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x1C0C0403,  //  0005  EQ	R3	R2	R3
+      0x780E0000,  //  0006  JMPF	R3	#0008
+      0x80000600,  //  0007  RET	0
+      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
+      0x5C140400,  //  0009  MOVE	R5	R2
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x4C100000,  //  000B  LDNIL	R4
+      0x20100604,  //  000C  NE	R4	R3	R4
+      0x7812000D,  //  000D  JMPF	R4	#001C
+      0x58100004,  //  000E  LDCONST	R4	K4
+      0x6014000C,  //  000F  GETGBL	R5	G12
+      0x88180105,  //  0010  GETMBR	R6	R0	K5
+      0x7C140200,  //  0011  CALL	R5	1
+      0x14140805,  //  0012  LT	R5	R4	R5
+      0x78160006,  //  0013  JMPF	R5	#001B
+      0x88140105,  //  0014  GETMBR	R5	R0	K5
+      0x94140A04,  //  0015  GETIDX	R5	R5	R4
+      0x8C140B06,  //  0016  GETMET	R5	R5	K6
+      0x5C1C0600,  //  0017  MOVE	R7	R3
+      0x7C140400,  //  0018  CALL	R5	2
+      0x00100907,  //  0019  ADD	R4	R4	K7
+      0x7001FFF3,  //  001A  JMP		#000F
+      0x70020007,  //  001B  JMP		#0024
+      0xB8120200,  //  001C  GETNGBL	R4	K1
+      0x8C100908,  //  001D  GETMET	R4	R4	K8
+      0x60180008,  //  001E  GETGBL	R6	G8
+      0x5C1C0400,  //  001F  MOVE	R7	R2
+      0x7C180200,  //  0020  CALL	R6	1
+      0x001A1206,  //  0021  ADD	R6	K9	R6
+      0x581C000A,  //  0022  LDCONST	R7	K10
+      0x7C100600,  //  0023  CALL	R4	3
+      0x80000000,  //  0024  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_root_commissioning_open
+********************************************************************/
+be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    /* K1   */  be_nested_str_weak(commissioning_admin_fabric),
+    }),
+    be_str_weak(is_root_commissioning_open),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060003,  //  0003  JMPF	R1	#0008
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x4C080000,  //  0005  LDNIL	R2
+      0x1C040202,  //  0006  EQ	R1	R1	R2
+      0x74060000,  //  0007  JMPT	R1	#0009
+      0x50040001,  //  0008  LDBOOL	R1	0	1
+      0x50040200,  //  0009  LDBOOL	R1	1	0
+      0x80040200,  //  000A  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_commissioning_open
+********************************************************************/
+be_local_closure(Matter_Device_is_commissioning_open,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    }),
+    be_str_weak(is_commissioning_open),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(is_root_commissioning_open),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(publish_result),
+    /* K3   */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A0_X7D_X7D),
+    /* K4   */  be_nested_str_weak(Matter),
+    /* K5   */  be_nested_str_weak(commissioning_open),
+    /* K6   */  be_nested_str_weak(mdns_remove_PASE),
+    /* K7   */  be_nested_str_weak(commissioning_iterations),
+    /* K8   */  be_nested_str_weak(commissioning_discriminator),
+    /* K9   */  be_nested_str_weak(commissioning_salt),
+    /* K10  */  be_nested_str_weak(commissioning_w0),
+    /* K11  */  be_nested_str_weak(commissioning_L),
+    /* K12  */  be_nested_str_weak(commissioning_admin_fabric),
+    }),
+    be_str_weak(stop_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x78060004,  //  0002  JMPF	R1	#0008
+      0xB8060200,  //  0003  GETNGBL	R1	K1
+      0x8C040302,  //  0004  GETMET	R1	R1	K2
+      0x580C0003,  //  0005  LDCONST	R3	K3
+      0x58100004,  //  0006  LDCONST	R4	K4
+      0x7C040600,  //  0007  CALL	R1	3
+      0x4C040000,  //  0008  LDNIL	R1
+      0x90020A01,  //  0009  SETMBR	R0	K5	R1
+      0x8C040106,  //  000A  GETMET	R1	R0	K6
+      0x7C040200,  //  000B  CALL	R1	1
+      0x4C040000,  //  000C  LDNIL	R1
+      0x90020E01,  //  000D  SETMBR	R0	K7	R1
+      0x4C040000,  //  000E  LDNIL	R1
+      0x90021001,  //  000F  SETMBR	R0	K8	R1
+      0x4C040000,  //  0010  LDNIL	R1
+      0x90021201,  //  0011  SETMBR	R0	K9	R1
+      0x4C040000,  //  0012  LDNIL	R1
+      0x90021401,  //  0013  SETMBR	R0	K10	R1
+      0x4C040000,  //  0014  LDNIL	R1
+      0x90021601,  //  0015  SETMBR	R0	K11	R1
+      0x4C040000,  //  0016  LDNIL	R1
+      0x90021801,  //  0017  SETMBR	R0	K12	R1
+      0x80000000,  //  0018  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_root_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[23]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(PASE_TIMEOUT),
+    /* K2   */  be_nested_str_weak(compute_manual_pairing_code),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(format),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s_X2D_X25s_X2D_X25s),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_const_int(3),
+    /* K9   */  be_const_int(2147483647),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(compute_qrcode_content),
+    /* K12  */  be_nested_str_weak(publish_result),
+    /* K13  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A1_X2C_X22PairingCode_X22_X3A_X22_X25s_X22_X2C_X22QRCode_X22_X3A_X22_X25s_X22_X7D_X7D),
+    /* K14  */  be_nested_str_weak(Matter),
+    /* K15  */  be_nested_str_weak(_compute_pbkdf),
+    /* K16  */  be_nested_str_weak(root_passcode),
+    /* K17  */  be_nested_str_weak(root_iterations),
+    /* K18  */  be_nested_str_weak(root_salt),
+    /* K19  */  be_nested_str_weak(start_basic_commissioning),
+    /* K20  */  be_nested_str_weak(root_discriminator),
+    /* K21  */  be_nested_str_weak(root_w0),
+    /* K22  */  be_nested_str_weak(root_L),
+    }),
+    be_str_weak(start_root_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[49]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x1C0C0203,  //  0002  EQ	R3	R1	R3
+      0x780E0000,  //  0003  JMPF	R3	#0005
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x8C0C0102,  //  0005  GETMET	R3	R0	K2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0xB8120600,  //  0007  GETNGBL	R4	K3
+      0x8C100904,  //  0008  GETMET	R4	R4	K4
+      0x8C180505,  //  0009  GETMET	R6	R2	K5
+      0x58200006,  //  000A  LDCONST	R8	K6
+      0x40260F08,  //  000B  CONNECT	R9	K7	K8
+      0x94240609,  //  000C  GETIDX	R9	R3	R9
+      0x542A0003,  //  000D  LDINT	R10	4
+      0x542E0005,  //  000E  LDINT	R11	6
+      0x4028140B,  //  000F  CONNECT	R10	R10	R11
+      0x9428060A,  //  0010  GETIDX	R10	R3	R10
+      0x542E0006,  //  0011  LDINT	R11	7
+      0x402C1709,  //  0012  CONNECT	R11	R11	K9
+      0x942C060B,  //  0013  GETIDX	R11	R3	R11
+      0x7C180A00,  //  0014  CALL	R6	5
+      0x581C000A,  //  0015  LDCONST	R7	K10
+      0x7C100600,  //  0016  CALL	R4	3
+      0x8C10010B,  //  0017  GETMET	R4	R0	K11
+      0x7C100200,  //  0018  CALL	R4	1
+      0xB8160600,  //  0019  GETNGBL	R5	K3
+      0x8C140B0C,  //  001A  GETMET	R5	R5	K12
+      0x8C1C0505,  //  001B  GETMET	R7	R2	K5
+      0x5824000D,  //  001C  LDCONST	R9	K13
+      0x5C280600,  //  001D  MOVE	R10	R3
+      0x5C2C0800,  //  001E  MOVE	R11	R4
+      0x7C1C0800,  //  001F  CALL	R7	4
+      0x5820000E,  //  0020  LDCONST	R8	K14
+      0x7C140600,  //  0021  CALL	R5	3
+      0x8C14010F,  //  0022  GETMET	R5	R0	K15
+      0x881C0110,  //  0023  GETMBR	R7	R0	K16
+      0x88200111,  //  0024  GETMBR	R8	R0	K17
+      0x88240112,  //  0025  GETMBR	R9	R0	K18
+      0x7C140800,  //  0026  CALL	R5	4
+      0x8C140113,  //  0027  GETMET	R5	R0	K19
+      0x5C1C0200,  //  0028  MOVE	R7	R1
+      0x88200111,  //  0029  GETMBR	R8	R0	K17
+      0x88240114,  //  002A  GETMBR	R9	R0	K20
+      0x88280112,  //  002B  GETMBR	R10	R0	K18
+      0x882C0115,  //  002C  GETMBR	R11	R0	K21
+      0x88300116,  //  002D  GETMBR	R12	R0	K22
+      0x4C340000,  //  002E  LDNIL	R13
+      0x7C141000,  //  002F  CALL	R5	8
+      0x80000000,  //  0030  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: attribute_updated
+********************************************************************/
+be_local_closure(Matter_Device_attribute_updated,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Path),
+    /* K2   */  be_nested_str_weak(endpoint),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_nested_str_weak(message_handler),
+    /* K6   */  be_nested_str_weak(im),
+    /* K7   */  be_nested_str_weak(subs_shop),
+    /* K8   */  be_nested_str_weak(attribute_updated_ctx),
+    }),
+    be_str_weak(attribute_updated),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140805,  //  0001  EQ	R5	R4	R5
+      0x78160000,  //  0002  JMPF	R5	#0004
+      0x50100000,  //  0003  LDBOOL	R4	0	0
+      0xB8160000,  //  0004  GETNGBL	R5	K0
+      0x8C140B01,  //  0005  GETMET	R5	R5	K1
+      0x7C140200,  //  0006  CALL	R5	1
+      0x90160401,  //  0007  SETMBR	R5	K2	R1
+      0x90160602,  //  0008  SETMBR	R5	K3	R2
+      0x90160803,  //  0009  SETMBR	R5	K4	R3
+      0x88180105,  //  000A  GETMBR	R6	R0	K5
+      0x88180D06,  //  000B  GETMBR	R6	R6	K6
+      0x88180D07,  //  000C  GETMBR	R6	R6	K7
+      0x8C180D08,  //  000D  GETMET	R6	R6	K8
+      0x5C200A00,  //  000E  MOVE	R8	R5
+      0x5C240800,  //  000F  MOVE	R9	R4
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: autoconf_device
+********************************************************************/
+be_local_closure(Matter_Device_autoconf_device,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(json),
+    /* K2   */  be_nested_str_weak(plugins),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(autoconf_device_map),
+    /* K5   */  be_nested_str_weak(tasmota),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
+    /* K8   */  be_const_int(3),
+    /* K9   */  be_nested_str_weak(_load_plugins_config),
+    }),
+    be_str_weak(autoconf_device),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x88100102,  //  0003  GETMBR	R4	R0	K2
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x240C0703,  //  0005  GT	R3	R3	K3
+      0x780E0000,  //  0006  JMPF	R3	#0008
+      0x80000600,  //  0007  RET	0
+      0x8C0C0104,  //  0008  GETMET	R3	R0	K4
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0xB8120A00,  //  000A  GETNGBL	R4	K5
+      0x8C100906,  //  000B  GETMET	R4	R4	K6
+      0x60180008,  //  000C  GETGBL	R6	G8
+      0x5C1C0600,  //  000D  MOVE	R7	R3
+      0x7C180200,  //  000E  CALL	R6	1
+      0x001A0E06,  //  000F  ADD	R6	K7	R6
+      0x581C0008,  //  0010  LDCONST	R7	K8
+      0x7C100600,  //  0011  CALL	R4	3
+      0x8C100109,  //  0012  GETMET	R4	R0	K9
+      0x5C180600,  //  0013  MOVE	R6	R3
+      0x7C100400,  //  0014  CALL	R4	2
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(Matter_Device_every_250ms,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(every_250ms),
+    }),
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_remove_op_discovery_all_fabrics
+********************************************************************/
+be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(active_fabrics),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(mdns_remove_op_discovery_all_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000B,  //  0005  EXBLK	0	#0012
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x780E0005,  //  000A  JMPF	R3	#0011
+      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x780E0002,  //  000D  JMPF	R3	#0011
+      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x7001FFF3,  //  0011  JMP		#0006
+      0x58040005,  //  0012  LDCONST	R1	K5
+      0xAC040200,  //  0013  CATCH	R1	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_commissioning_complete_deferred
+********************************************************************/
+be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        3,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 2]) {  /* upvals */
+          be_local_const_upval(1, 0),
+          be_local_const_upval(1, 1),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start_commissioning_complete),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x68080001,  //  0002  GETUPV	R2	U1
+          0x7C000400,  //  0003  CALL	R0	2
+          0x80040000,  //  0004  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(set_timer),
+    /* K2   */  be_const_int(0),
+    }),
+    be_str_weak(start_commissioning_complete_deferred),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x84140000,  //  0003  CLOSURE	R5	P0
+      0x7C080600,  //  0004  CALL	R2	3
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Device_init,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_start),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0004,  //  0006  LDCONST	R3	K4
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Eth_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_start),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0004,  //  0006  LDCONST	R3	K4
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[41]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(get_option),
+    /* K4   */  be_nested_str_weak(matter),
+    /* K5   */  be_nested_str_weak(MATTER_OPTION),
+    /* K6   */  be_nested_str_weak(UI),
+    /* K7   */  be_nested_str_weak(started),
+    /* K8   */  be_nested_str_weak(plugins),
+    /* K9   */  be_nested_str_weak(plugins_persist),
+    /* K10  */  be_nested_str_weak(plugins_classes),
+    /* K11  */  be_nested_str_weak(register_native_classes),
+    /* K12  */  be_nested_str_weak(vendorid),
+    /* K13  */  be_nested_str_weak(VENDOR_ID),
+    /* K14  */  be_nested_str_weak(productid),
+    /* K15  */  be_nested_str_weak(PRODUCT_ID),
+    /* K16  */  be_nested_str_weak(root_iterations),
+    /* K17  */  be_nested_str_weak(PBKDF_ITERATIONS),
+    /* K18  */  be_nested_str_weak(root_salt),
+    /* K19  */  be_nested_str_weak(random),
+    /* K20  */  be_nested_str_weak(ipv4only),
+    /* K21  */  be_nested_str_weak(load_param),
+    /* K22  */  be_nested_str_weak(sessions),
+    /* K23  */  be_nested_str_weak(Session_Store),
+    /* K24  */  be_nested_str_weak(load_fabrics),
+    /* K25  */  be_nested_str_weak(message_handler),
+    /* K26  */  be_nested_str_weak(MessageHandler),
+    /* K27  */  be_nested_str_weak(ui),
+    /* K28  */  be_nested_str_weak(wifi),
+    /* K29  */  be_nested_str_weak(up),
+    /* K30  */  be_nested_str_weak(eth),
+    /* K31  */  be_nested_str_weak(start),
+    /* K32  */  be_nested_str_weak(add_rule),
+    /* K33  */  be_nested_str_weak(Wifi_X23Connected),
+    /* K34  */  be_nested_str_weak(matter_start),
+    /* K35  */  be_nested_str_weak(Eth_X23Connected),
+    /* K36  */  be_nested_str_weak(_init_basic_commissioning),
+    /* K37  */  be_nested_str_weak(add_driver),
+    /* K38  */  be_nested_str_weak(register_commands),
+    /* K39  */  be_nested_str_weak(count_active_fabrics),
+    /* K40  */  be_const_int(0),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[108]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xB80E0400,  //  0002  GETNGBL	R3	K2
+      0x8C0C0703,  //  0003  GETMET	R3	R3	K3
+      0xB8160800,  //  0004  GETNGBL	R5	K4
+      0x88140B05,  //  0005  GETMBR	R5	R5	K5
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x740E0004,  //  0007  JMPT	R3	#000D
+      0xB80E0800,  //  0008  GETNGBL	R3	K4
+      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
+      0x5C140000,  //  000A  MOVE	R5	R0
+      0x7C0C0400,  //  000B  CALL	R3	2
+      0x80000600,  //  000C  RET	0
+      0x500C0000,  //  000D  LDBOOL	R3	0	0
+      0x90020E03,  //  000E  SETMBR	R0	K7	R3
+      0x600C0012,  //  000F  GETGBL	R3	G18
+      0x7C0C0000,  //  0010  CALL	R3	0
+      0x90021003,  //  0011  SETMBR	R0	K8	R3
+      0x500C0000,  //  0012  LDBOOL	R3	0	0
+      0x90021203,  //  0013  SETMBR	R0	K9	R3
+      0x600C0013,  //  0014  GETGBL	R3	G19
+      0x7C0C0000,  //  0015  CALL	R3	0
+      0x90021403,  //  0016  SETMBR	R0	K10	R3
+      0x8C0C010B,  //  0017  GETMET	R3	R0	K11
+      0x7C0C0200,  //  0018  CALL	R3	1
+      0x880C010D,  //  0019  GETMBR	R3	R0	K13
+      0x90021803,  //  001A  SETMBR	R0	K12	R3
+      0x880C010F,  //  001B  GETMBR	R3	R0	K15
+      0x90021C03,  //  001C  SETMBR	R0	K14	R3
+      0x880C0111,  //  001D  GETMBR	R3	R0	K17
+      0x90022003,  //  001E  SETMBR	R0	K16	R3
+      0x8C0C0313,  //  001F  GETMET	R3	R1	K19
+      0x5416000F,  //  0020  LDINT	R5	16
+      0x7C0C0400,  //  0021  CALL	R3	2
+      0x90022403,  //  0022  SETMBR	R0	K18	R3
+      0x500C0000,  //  0023  LDBOOL	R3	0	0
+      0x90022803,  //  0024  SETMBR	R0	K20	R3
+      0x8C0C0115,  //  0025  GETMET	R3	R0	K21
+      0x7C0C0200,  //  0026  CALL	R3	1
+      0xB80E0800,  //  0027  GETNGBL	R3	K4
+      0x8C0C0717,  //  0028  GETMET	R3	R3	K23
+      0x5C140000,  //  0029  MOVE	R5	R0
+      0x7C0C0400,  //  002A  CALL	R3	2
+      0x90022C03,  //  002B  SETMBR	R0	K22	R3
+      0x880C0116,  //  002C  GETMBR	R3	R0	K22
+      0x8C0C0718,  //  002D  GETMET	R3	R3	K24
+      0x7C0C0200,  //  002E  CALL	R3	1
+      0xB80E0800,  //  002F  GETNGBL	R3	K4
+      0x8C0C071A,  //  0030  GETMET	R3	R3	K26
+      0x5C140000,  //  0031  MOVE	R5	R0
+      0x7C0C0400,  //  0032  CALL	R3	2
+      0x90023203,  //  0033  SETMBR	R0	K25	R3
+      0xB80E0800,  //  0034  GETNGBL	R3	K4
+      0x8C0C0706,  //  0035  GETMET	R3	R3	K6
+      0x5C140000,  //  0036  MOVE	R5	R0
+      0x7C0C0400,  //  0037  CALL	R3	2
+      0x90023603,  //  0038  SETMBR	R0	K27	R3
+      0xB80E0400,  //  0039  GETNGBL	R3	K2
+      0x8C0C071C,  //  003A  GETMET	R3	R3	K28
+      0x7C0C0200,  //  003B  CALL	R3	1
+      0x940C071D,  //  003C  GETIDX	R3	R3	K29
+      0x740E0004,  //  003D  JMPT	R3	#0043
+      0xB80E0400,  //  003E  GETNGBL	R3	K2
+      0x8C0C071E,  //  003F  GETMET	R3	R3	K30
+      0x7C0C0200,  //  0040  CALL	R3	1
+      0x940C071D,  //  0041  GETIDX	R3	R3	K29
+      0x780E0001,  //  0042  JMPF	R3	#0045
+      0x8C0C011F,  //  0043  GETMET	R3	R0	K31
+      0x7C0C0200,  //  0044  CALL	R3	1
+      0xB80E0400,  //  0045  GETNGBL	R3	K2
+      0x8C0C071C,  //  0046  GETMET	R3	R3	K28
+      0x7C0C0200,  //  0047  CALL	R3	1
+      0x940C071D,  //  0048  GETIDX	R3	R3	K29
+      0x740E0005,  //  0049  JMPT	R3	#0050
+      0xB80E0400,  //  004A  GETNGBL	R3	K2
+      0x8C0C0720,  //  004B  GETMET	R3	R3	K32
+      0x58140021,  //  004C  LDCONST	R5	K33
+      0x84180000,  //  004D  CLOSURE	R6	P0
+      0x581C0022,  //  004E  LDCONST	R7	K34
+      0x7C0C0800,  //  004F  CALL	R3	4
+      0xB80E0400,  //  0050  GETNGBL	R3	K2
+      0x8C0C071E,  //  0051  GETMET	R3	R3	K30
+      0x7C0C0200,  //  0052  CALL	R3	1
+      0x940C071D,  //  0053  GETIDX	R3	R3	K29
+      0x740E0005,  //  0054  JMPT	R3	#005B
+      0xB80E0400,  //  0055  GETNGBL	R3	K2
+      0x8C0C0720,  //  0056  GETMET	R3	R3	K32
+      0x58140023,  //  0057  LDCONST	R5	K35
+      0x84180001,  //  0058  CLOSURE	R6	P1
+      0x581C0022,  //  0059  LDCONST	R7	K34
+      0x7C0C0800,  //  005A  CALL	R3	4
+      0x8C0C0124,  //  005B  GETMET	R3	R0	K36
+      0x7C0C0200,  //  005C  CALL	R3	1
+      0xB80E0400,  //  005D  GETNGBL	R3	K2
+      0x8C0C0725,  //  005E  GETMET	R3	R3	K37
+      0x5C140000,  //  005F  MOVE	R5	R0
+      0x7C0C0400,  //  0060  CALL	R3	2
+      0x8C0C0126,  //  0061  GETMET	R3	R0	K38
+      0x7C0C0200,  //  0062  CALL	R3	1
+      0x880C0116,  //  0063  GETMBR	R3	R0	K22
+      0x8C0C0727,  //  0064  GETMET	R3	R3	K39
+      0x7C0C0200,  //  0065  CALL	R3	1
+      0x240C0728,  //  0066  GT	R3	R3	K40
+      0x780E0001,  //  0067  JMPF	R3	#006A
+      0x500C0200,  //  0068  LDBOOL	R3	1	0
+      0x90021203,  //  0069  SETMBR	R0	K9	R3
+      0xA0000000,  //  006A  CLOSE	R0
+      0x80000000,  //  006B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _init_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device__init_basic_commissioning,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(count_active_fabrics),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(start_root_basic_commissioning),
+    }),
+    be_str_weak(_init_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x1C040302,  //  0003  EQ	R1	R1	K2
+      0x78060001,  //  0004  JMPF	R1	#0007
+      0x8C040103,  //  0005  GETMET	R1	R0	K3
+      0x7C040200,  //  0006  CALL	R1	1
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_before_restart
+********************************************************************/
+be_local_closure(Matter_Device_save_before_restart,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K1   */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
+    }),
+    be_str_weak(save_before_restart),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x7C040200,  //  0003  CALL	R1	1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_operational_discovery
+********************************************************************/
+be_local_closure(Matter_Device_start_operational_discovery,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(mdns),
+    /* K2   */  be_nested_str_weak(string),
+    /* K3   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K4   */  be_nested_str_weak(root_w0),
+    /* K5   */  be_nested_str_weak(root_L),
+    /* K6   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K7   */  be_nested_str_weak(mdns_announce_op_discovery),
+    /* K8   */  be_nested_str_weak(get_fabric),
+    }),
+    be_str_weak(start_operational_discovery),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xA4120400,  //  0002  IMPORT	R4	K2
+      0x8C140103,  //  0003  GETMET	R5	R0	K3
+      0x7C140200,  //  0004  CALL	R5	1
+      0x4C140000,  //  0005  LDNIL	R5
+      0x90020805,  //  0006  SETMBR	R0	K4	R5
+      0x4C140000,  //  0007  LDNIL	R5
+      0x90020A05,  //  0008  SETMBR	R0	K5	R5
+      0x8C140306,  //  0009  GETMET	R5	R1	K6
+      0x541E003B,  //  000A  LDINT	R7	60
+      0x7C140400,  //  000B  CALL	R5	2
+      0x8C140107,  //  000C  GETMET	R5	R0	K7
+      0x8C1C0308,  //  000D  GETMET	R7	R1	K8
+      0x7C1C0200,  //  000E  CALL	R7	1
+      0x7C140400,  //  000F  CALL	R5	2
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    8,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 4]) {     /* constants */
+        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0000,  //  0006  LDCONST	R3	K0
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 4]) {     /* constants */
+        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Eth_X23Connected),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0000,  //  0006  LDCONST	R3	K0
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(millis),
+    /* K3   */  be_nested_str_weak(commissioning_iterations),
+    /* K4   */  be_nested_str_weak(commissioning_discriminator),
+    /* K5   */  be_nested_str_weak(commissioning_salt),
+    /* K6   */  be_nested_str_weak(commissioning_w0),
+    /* K7   */  be_nested_str_weak(commissioning_L),
+    /* K8   */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K9   */  be_nested_str_weak(wifi),
+    /* K10  */  be_nested_str_weak(up),
+    /* K11  */  be_nested_str_weak(eth),
+    /* K12  */  be_nested_str_weak(mdns_announce_PASE),
+    /* K13  */  be_nested_str_weak(add_rule),
+    /* K14  */  be_nested_str_weak(Wifi_X23Connected),
+    /* K15  */  be_nested_str_weak(Eth_X23Connected),
+    }),
+    be_str_weak(start_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0xB8220200,  //  0000  GETNGBL	R8	K1
+      0x8C201102,  //  0001  GETMET	R8	R8	K2
+      0x7C200200,  //  0002  CALL	R8	1
+      0x542603E7,  //  0003  LDINT	R9	1000
+      0x08240209,  //  0004  MUL	R9	R1	R9
+      0x00201009,  //  0005  ADD	R8	R8	R9
+      0x90020008,  //  0006  SETMBR	R0	K0	R8
+      0x90020602,  //  0007  SETMBR	R0	K3	R2
+      0x90020803,  //  0008  SETMBR	R0	K4	R3
+      0x90020A04,  //  0009  SETMBR	R0	K5	R4
+      0x90020C05,  //  000A  SETMBR	R0	K6	R5
+      0x90020E06,  //  000B  SETMBR	R0	K7	R6
+      0x90021007,  //  000C  SETMBR	R0	K8	R7
+      0xB8220200,  //  000D  GETNGBL	R8	K1
+      0x8C201109,  //  000E  GETMET	R8	R8	K9
+      0x7C200200,  //  000F  CALL	R8	1
+      0x9420110A,  //  0010  GETIDX	R8	R8	K10
+      0x74220004,  //  0011  JMPT	R8	#0017
+      0xB8220200,  //  0012  GETNGBL	R8	K1
+      0x8C20110B,  //  0013  GETMET	R8	R8	K11
+      0x7C200200,  //  0014  CALL	R8	1
+      0x9420110A,  //  0015  GETIDX	R8	R8	K10
+      0x78220002,  //  0016  JMPF	R8	#001A
+      0x8C20010C,  //  0017  GETMET	R8	R0	K12
+      0x7C200200,  //  0018  CALL	R8	1
+      0x7002000B,  //  0019  JMP		#0026
+      0xB8220200,  //  001A  GETNGBL	R8	K1
+      0x8C20110D,  //  001B  GETMET	R8	R8	K13
+      0x5828000E,  //  001C  LDCONST	R10	K14
+      0x842C0000,  //  001D  CLOSURE	R11	P0
+      0x5830000C,  //  001E  LDCONST	R12	K12
+      0x7C200800,  //  001F  CALL	R8	4
+      0xB8220200,  //  0020  GETNGBL	R8	K1
+      0x8C20110D,  //  0021  GETMET	R8	R8	K13
+      0x5828000F,  //  0022  LDCONST	R10	K15
+      0x842C0001,  //  0023  CLOSURE	R11	P1
+      0x5830000C,  //  0024  LDCONST	R12	K12
+      0x7C200800,  //  0025  CALL	R8	4
+      0xA0000000,  //  0026  CLOSE	R0
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: msg_received
+********************************************************************/
+be_local_closure(Matter_Device_msg_received,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(msg_received),
+    }),
+    be_str_weak(msg_received),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x8C100901,  //  0001  GETMET	R4	R4	K1
+      0x5C180200,  //  0002  MOVE	R6	R1
+      0x5C1C0400,  //  0003  MOVE	R7	R2
+      0x5C200600,  //  0004  MOVE	R8	R3
+      0x7C100800,  //  0005  CALL	R4	4
+      0x80040800,  //  0006  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _start_udp
+********************************************************************/
+be_local_closure(Matter_Device__start_udp,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(msg_received),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20starting_X20UDP_X20server_X20on_X20port_X3A_X20),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(UDPServer),
+    /* K7   */  be_nested_str_weak(),
+    /* K8   */  be_nested_str_weak(start),
+    }),
+    be_str_weak(_start_udp),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80000400,  //  0002  RET	0
+      0x4C080000,  //  0003  LDNIL	R2
+      0x1C080202,  //  0004  EQ	R2	R1	R2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x540615A3,  //  0006  LDINT	R1	5540
+      0xB80A0200,  //  0007  GETNGBL	R2	K1
+      0x8C080502,  //  0008  GETMET	R2	R2	K2
+      0x60100008,  //  0009  GETGBL	R4	G8
+      0x5C140200,  //  000A  MOVE	R5	R1
+      0x7C100200,  //  000B  CALL	R4	1
+      0x00120604,  //  000C  ADD	R4	K3	R4
+      0x58140004,  //  000D  LDCONST	R5	K4
+      0x7C080600,  //  000E  CALL	R2	3
+      0xB80A0A00,  //  000F  GETNGBL	R2	K5
+      0x8C080506,  //  0010  GETMET	R2	R2	K6
+      0x58100007,  //  0011  LDCONST	R4	K7
+      0x5C140200,  //  0012  MOVE	R5	R1
+      0x7C080600,  //  0013  CALL	R2	3
+      0x90020002,  //  0014  SETMBR	R0	K0	R2
+      0x88080100,  //  0015  GETMBR	R2	R0	K0
+      0x8C080508,  //  0016  GETMET	R2	R2	K8
+      0x84100000,  //  0017  CLOSURE	R4	P0
+      0x7C080400,  //  0018  CALL	R2	2
+      0xA0000000,  //  0019  CLOSE	R0
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_remove_op_discovery
+********************************************************************/
+be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[24]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(copy),
+    /* K4   */  be_nested_str_weak(reverse),
+    /* K5   */  be_nested_str_weak(get_fabric_compressed),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_nested_str_weak(_X2D),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(eth),
+    /* K10  */  be_nested_str_weak(find),
+    /* K11  */  be_nested_str_weak(up),
+    /* K12  */  be_nested_str_weak(log),
+    /* K13  */  be_nested_str_weak(format),
+    /* K14  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
+    /* K15  */  be_const_int(2),
+    /* K16  */  be_nested_str_weak(remove_service),
+    /* K17  */  be_nested_str_weak(_matter),
+    /* K18  */  be_nested_str_weak(_tcp),
+    /* K19  */  be_nested_str_weak(hostname_eth),
+    /* K20  */  be_nested_str_weak(wifi),
+    /* K21  */  be_nested_str_weak(hostname_wifi),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K23  */  be_nested_str_weak(_X7C),
+    }),
+    be_str_weak(mdns_remove_op_discovery),
+    &be_const_str_solidified,
+    ( &(const binstruction[81]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xA802003B,  //  0002  EXBLK	0	#003F
+      0x8C100302,  //  0003  GETMET	R4	R1	K2
+      0x7C100200,  //  0004  CALL	R4	1
+      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C140305,  //  0009  GETMET	R5	R1	K5
+      0x7C140200,  //  000A  CALL	R5	1
+      0x8C180B06,  //  000B  GETMET	R6	R5	K6
+      0x7C180200,  //  000C  CALL	R6	1
+      0x00180D07,  //  000D  ADD	R6	R6	K7
+      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
+      0x7C1C0200,  //  000F  CALL	R7	1
+      0x00180C07,  //  0010  ADD	R6	R6	R7
+      0xB81E1000,  //  0011  GETNGBL	R7	K8
+      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
+      0x7C1C0200,  //  0013  CALL	R7	1
+      0x8C1C0F0A,  //  0014  GETMET	R7	R7	K10
+      0x5824000B,  //  0015  LDCONST	R9	K11
+      0x7C1C0400,  //  0016  CALL	R7	2
+      0x781E000E,  //  0017  JMPF	R7	#0027
+      0xB81E1000,  //  0018  GETNGBL	R7	K8
+      0x8C1C0F0C,  //  0019  GETMET	R7	R7	K12
+      0x8C24070D,  //  001A  GETMET	R9	R3	K13
+      0x582C000E,  //  001B  LDCONST	R11	K14
+      0x58300009,  //  001C  LDCONST	R12	K9
+      0x5C340C00,  //  001D  MOVE	R13	R6
+      0x7C240800,  //  001E  CALL	R9	4
+      0x5828000F,  //  001F  LDCONST	R10	K15
+      0x7C1C0600,  //  0020  CALL	R7	3
+      0x8C1C0510,  //  0021  GETMET	R7	R2	K16
+      0x58240011,  //  0022  LDCONST	R9	K17
+      0x58280012,  //  0023  LDCONST	R10	K18
+      0x5C2C0C00,  //  0024  MOVE	R11	R6
+      0x88300113,  //  0025  GETMBR	R12	R0	K19
+      0x7C1C0A00,  //  0026  CALL	R7	5
+      0xB81E1000,  //  0027  GETNGBL	R7	K8
+      0x8C1C0F14,  //  0028  GETMET	R7	R7	K20
+      0x7C1C0200,  //  0029  CALL	R7	1
+      0x8C1C0F0A,  //  002A  GETMET	R7	R7	K10
+      0x5824000B,  //  002B  LDCONST	R9	K11
+      0x7C1C0400,  //  002C  CALL	R7	2
+      0x781E000E,  //  002D  JMPF	R7	#003D
+      0xB81E1000,  //  002E  GETNGBL	R7	K8
+      0x8C1C0F0C,  //  002F  GETMET	R7	R7	K12
+      0x8C24070D,  //  0030  GETMET	R9	R3	K13
+      0x582C000E,  //  0031  LDCONST	R11	K14
+      0x58300014,  //  0032  LDCONST	R12	K20
+      0x5C340C00,  //  0033  MOVE	R13	R6
+      0x7C240800,  //  0034  CALL	R9	4
+      0x5828000F,  //  0035  LDCONST	R10	K15
+      0x7C1C0600,  //  0036  CALL	R7	3
+      0x8C1C0510,  //  0037  GETMET	R7	R2	K16
+      0x58240011,  //  0038  LDCONST	R9	K17
+      0x58280012,  //  0039  LDCONST	R10	K18
+      0x5C2C0C00,  //  003A  MOVE	R11	R6
+      0x88300115,  //  003B  GETMBR	R12	R0	K21
+      0x7C1C0A00,  //  003C  CALL	R7	5
+      0xA8040001,  //  003D  EXBLK	1	1
+      0x70020010,  //  003E  JMP		#0050
+      0xAC100002,  //  003F  CATCH	R4	0	2
+      0x7002000D,  //  0040  JMP		#004F
+      0xB81A1000,  //  0041  GETNGBL	R6	K8
+      0x8C180D0C,  //  0042  GETMET	R6	R6	K12
+      0x60200008,  //  0043  GETGBL	R8	G8
+      0x5C240800,  //  0044  MOVE	R9	R4
+      0x7C200200,  //  0045  CALL	R8	1
+      0x00222C08,  //  0046  ADD	R8	K22	R8
+      0x00201117,  //  0047  ADD	R8	R8	K23
+      0x60240008,  //  0048  GETGBL	R9	G8
+      0x5C280A00,  //  0049  MOVE	R10	R5
+      0x7C240200,  //  004A  CALL	R9	1
+      0x00201009,  //  004B  ADD	R8	R8	R9
+      0x5824000F,  //  004C  LDCONST	R9	K15
+      0x7C180600,  //  004D  CALL	R6	3
+      0x70020000,  //  004E  JMP		#0050
+      0xB0080000,  //  004F  RAISE	2	R0	R0
+      0x80000000,  //  0050  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: load_param
+********************************************************************/
+be_local_closure(Matter_Device_load_param,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[27]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(crypto),
+    /* K2   */  be_nested_str_weak(FILENAME),
+    /* K3   */  be_nested_str_weak(read),
+    /* K4   */  be_nested_str_weak(close),
+    /* K5   */  be_nested_str_weak(json),
+    /* K6   */  be_nested_str_weak(load),
+    /* K7   */  be_nested_str_weak(root_discriminator),
+    /* K8   */  be_nested_str_weak(find),
+    /* K9   */  be_nested_str_weak(distinguish),
+    /* K10  */  be_nested_str_weak(root_passcode),
+    /* K11  */  be_nested_str_weak(passcode),
+    /* K12  */  be_nested_str_weak(ipv4only),
+    /* K13  */  be_nested_str_weak(config),
+    /* K14  */  be_nested_str_weak(_load_plugins_config),
+    /* K15  */  be_nested_str_weak(plugins_persist),
+    /* K16  */  be_nested_str_weak(io_error),
+    /* K17  */  be_nested_str_weak(tasmota),
+    /* K18  */  be_nested_str_weak(log),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
+    /* K20  */  be_nested_str_weak(_X7C),
+    /* K21  */  be_const_int(2),
+    /* K22  */  be_nested_str_weak(random),
+    /* K23  */  be_nested_str_weak(get),
+    /* K24  */  be_const_int(0),
+    /* K25  */  be_nested_str_weak(PASSCODE_DEFAULT),
+    /* K26  */  be_nested_str_weak(save_param),
+    }),
+    be_str_weak(load_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[88]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xA8020026,  //  0002  EXBLK	0	#002A
+      0x600C0011,  //  0003  GETGBL	R3	G17
+      0x88100102,  //  0004  GETMBR	R4	R0	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C100703,  //  0006  GETMET	R4	R3	K3
+      0x7C100200,  //  0007  CALL	R4	1
+      0x8C140704,  //  0008  GETMET	R5	R3	K4
+      0x7C140200,  //  0009  CALL	R5	1
+      0xA4160A00,  //  000A  IMPORT	R5	K5
+      0x8C180B06,  //  000B  GETMET	R6	R5	K6
+      0x5C200800,  //  000C  MOVE	R8	R4
+      0x7C180400,  //  000D  CALL	R6	2
+      0x8C1C0D08,  //  000E  GETMET	R7	R6	K8
+      0x58240009,  //  000F  LDCONST	R9	K9
+      0x88280107,  //  0010  GETMBR	R10	R0	K7
+      0x7C1C0600,  //  0011  CALL	R7	3
+      0x90020E07,  //  0012  SETMBR	R0	K7	R7
+      0x8C1C0D08,  //  0013  GETMET	R7	R6	K8
+      0x5824000B,  //  0014  LDCONST	R9	K11
+      0x8828010A,  //  0015  GETMBR	R10	R0	K10
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x90021407,  //  0017  SETMBR	R0	K10	R7
+      0x601C0017,  //  0018  GETGBL	R7	G23
+      0x8C200D08,  //  0019  GETMET	R8	R6	K8
+      0x5828000C,  //  001A  LDCONST	R10	K12
+      0x502C0000,  //  001B  LDBOOL	R11	0	0
+      0x7C200600,  //  001C  CALL	R8	3
+      0x7C1C0200,  //  001D  CALL	R7	1
+      0x90021807,  //  001E  SETMBR	R0	K12	R7
+      0x8C1C0D08,  //  001F  GETMET	R7	R6	K8
+      0x5824000D,  //  0020  LDCONST	R9	K13
+      0x7C1C0400,  //  0021  CALL	R7	2
+      0x781E0004,  //  0022  JMPF	R7	#0028
+      0x8C20010E,  //  0023  GETMET	R8	R0	K14
+      0x5C280E00,  //  0024  MOVE	R10	R7
+      0x7C200400,  //  0025  CALL	R8	2
+      0x50200200,  //  0026  LDBOOL	R8	1	0
+      0x90021E08,  //  0027  SETMBR	R0	K15	R8
+      0xA8040001,  //  0028  EXBLK	1	1
+      0x70020012,  //  0029  JMP		#003D
+      0xAC0C0002,  //  002A  CATCH	R3	0	2
+      0x7002000F,  //  002B  JMP		#003C
+      0x20140710,  //  002C  NE	R5	R3	K16
+      0x7816000C,  //  002D  JMPF	R5	#003B
+      0xB8162200,  //  002E  GETNGBL	R5	K17
+      0x8C140B12,  //  002F  GETMET	R5	R5	K18
+      0x601C0008,  //  0030  GETGBL	R7	G8
+      0x5C200600,  //  0031  MOVE	R8	R3
+      0x7C1C0200,  //  0032  CALL	R7	1
+      0x001E2607,  //  0033  ADD	R7	K19	R7
+      0x001C0F14,  //  0034  ADD	R7	R7	K20
+      0x60200008,  //  0035  GETGBL	R8	G8
+      0x5C240800,  //  0036  MOVE	R9	R4
+      0x7C200200,  //  0037  CALL	R8	1
+      0x001C0E08,  //  0038  ADD	R7	R7	R8
+      0x58200015,  //  0039  LDCONST	R8	K21
+      0x7C140600,  //  003A  CALL	R5	3
+      0x70020000,  //  003B  JMP		#003D
+      0xB0080000,  //  003C  RAISE	2	R0	R0
+      0x500C0000,  //  003D  LDBOOL	R3	0	0
+      0x88100107,  //  003E  GETMBR	R4	R0	K7
+      0x4C140000,  //  003F  LDNIL	R5
+      0x1C100805,  //  0040  EQ	R4	R4	R5
+      0x7812000A,  //  0041  JMPF	R4	#004D
+      0x8C100516,  //  0042  GETMET	R4	R2	K22
+      0x58180015,  //  0043  LDCONST	R6	K21
+      0x7C100400,  //  0044  CALL	R4	2
+      0x8C100917,  //  0045  GETMET	R4	R4	K23
+      0x58180018,  //  0046  LDCONST	R6	K24
+      0x581C0015,  //  0047  LDCONST	R7	K21
+      0x7C100600,  //  0048  CALL	R4	3
+      0x54160FFE,  //  0049  LDINT	R5	4095
+      0x2C100805,  //  004A  AND	R4	R4	R5
+      0x90020E04,  //  004B  SETMBR	R0	K7	R4
+      0x500C0200,  //  004C  LDBOOL	R3	1	0
+      0x8810010A,  //  004D  GETMBR	R4	R0	K10
+      0x4C140000,  //  004E  LDNIL	R5
+      0x1C100805,  //  004F  EQ	R4	R4	R5
+      0x78120002,  //  0050  JMPF	R4	#0054
+      0x88100119,  //  0051  GETMBR	R4	R0	K25
+      0x90021404,  //  0052  SETMBR	R0	K10	R4
+      0x500C0200,  //  0053  LDBOOL	R3	1	0
+      0x780E0001,  //  0054  JMPF	R3	#0057
+      0x8C10011A,  //  0055  GETMET	R4	R0	K26
+      0x7C100200,  //  0056  CALL	R4	1
+      0x80000000,  //  0057  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _load_plugins_config
+********************************************************************/
+be_local_closure(Matter_Device__load_plugins_config,   /* name */
+  be_nested_proto(
+    19,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[27]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(k2l_num),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20endpoints_X20to_X20be_X20configured_X20),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(format),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20endpoint_X20_X25i_X20config_X20_X25s),
+    /* K8   */  be_nested_str_weak(find),
+    /* K9   */  be_nested_str_weak(type),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
+    /* K11  */  be_nested_str_weak(plugins_classes),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+    /* K13  */  be_nested_str_weak(_X27_X20skipping),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(plugins),
+    /* K16  */  be_nested_str_weak(push),
+    /* K17  */  be_nested_str_weak(),
+    /* K18  */  be_nested_str_weak(k2l),
+    /* K19  */  be_nested_str_weak(_X20_X25s_X3A_X25s),
+    /* K20  */  be_nested_str_weak(stop_iteration),
+    /* K21  */  be_nested_str_weak(MTR_X3A_X20endpoint_X3A_X25i_X20type_X3A_X25s_X25s),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K23  */  be_nested_str_weak(_X7C),
+    /* K24  */  be_nested_str_weak(publish_result),
+    /* K25  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
+    /* K26  */  be_nested_str_weak(Matter),
+    }),
+    be_str_weak(_load_plugins_config),
+    &be_const_str_solidified,
+    ( &(const binstruction[133]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x8C0C0101,  //  0001  GETMET	R3	R0	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0xB8120400,  //  0004  GETNGBL	R4	K2
+      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x60180008,  //  0006  GETGBL	R6	G8
+      0x5C1C0600,  //  0007  MOVE	R7	R3
+      0x7C180200,  //  0008  CALL	R6	1
+      0x001A0806,  //  0009  ADD	R6	K4	R6
+      0x581C0005,  //  000A  LDCONST	R7	K5
+      0x7C100600,  //  000B  CALL	R4	3
+      0x60100010,  //  000C  GETGBL	R4	G16
+      0x5C140600,  //  000D  MOVE	R5	R3
+      0x7C100200,  //  000E  CALL	R4	1
+      0xA802006B,  //  000F  EXBLK	0	#007C
+      0x5C140800,  //  0010  MOVE	R5	R4
+      0x7C140000,  //  0011  CALL	R5	0
+      0xA8020056,  //  0012  EXBLK	0	#006A
+      0x60180008,  //  0013  GETGBL	R6	G8
+      0x5C1C0A00,  //  0014  MOVE	R7	R5
+      0x7C180200,  //  0015  CALL	R6	1
+      0x94180206,  //  0016  GETIDX	R6	R1	R6
+      0xB81E0400,  //  0017  GETNGBL	R7	K2
+      0x8C1C0F03,  //  0018  GETMET	R7	R7	K3
+      0x8C240506,  //  0019  GETMET	R9	R2	K6
+      0x582C0007,  //  001A  LDCONST	R11	K7
+      0x5C300A00,  //  001B  MOVE	R12	R5
+      0x5C340C00,  //  001C  MOVE	R13	R6
+      0x7C240800,  //  001D  CALL	R9	4
+      0x58280005,  //  001E  LDCONST	R10	K5
+      0x7C1C0600,  //  001F  CALL	R7	3
+      0x8C1C0D08,  //  0020  GETMET	R7	R6	K8
+      0x58240009,  //  0021  LDCONST	R9	K9
+      0x7C1C0400,  //  0022  CALL	R7	2
+      0x4C200000,  //  0023  LDNIL	R8
+      0x1C200E08,  //  0024  EQ	R8	R7	R8
+      0x78220006,  //  0025  JMPF	R8	#002D
+      0xB8220400,  //  0026  GETNGBL	R8	K2
+      0x8C201103,  //  0027  GETMET	R8	R8	K3
+      0x5828000A,  //  0028  LDCONST	R10	K10
+      0x582C0005,  //  0029  LDCONST	R11	K5
+      0x7C200600,  //  002A  CALL	R8	3
+      0xA8040001,  //  002B  EXBLK	1	1
+      0x7001FFE2,  //  002C  JMP		#0010
+      0x8820010B,  //  002D  GETMBR	R8	R0	K11
+      0x8C201108,  //  002E  GETMET	R8	R8	K8
+      0x5C280E00,  //  002F  MOVE	R10	R7
+      0x7C200400,  //  0030  CALL	R8	2
+      0x4C240000,  //  0031  LDNIL	R9
+      0x1C241009,  //  0032  EQ	R9	R8	R9
+      0x7826000A,  //  0033  JMPF	R9	#003F
+      0xB8260400,  //  0034  GETNGBL	R9	K2
+      0x8C241303,  //  0035  GETMET	R9	R9	K3
+      0x602C0008,  //  0036  GETGBL	R11	G8
+      0x5C300E00,  //  0037  MOVE	R12	R7
+      0x7C2C0200,  //  0038  CALL	R11	1
+      0x002E180B,  //  0039  ADD	R11	K12	R11
+      0x002C170D,  //  003A  ADD	R11	R11	K13
+      0x5830000E,  //  003B  LDCONST	R12	K14
+      0x7C240600,  //  003C  CALL	R9	3
+      0xA8040001,  //  003D  EXBLK	1	1
+      0x7001FFD0,  //  003E  JMP		#0010
+      0x5C241000,  //  003F  MOVE	R9	R8
+      0x5C280000,  //  0040  MOVE	R10	R0
+      0x5C2C0A00,  //  0041  MOVE	R11	R5
+      0x5C300C00,  //  0042  MOVE	R12	R6
+      0x7C240600,  //  0043  CALL	R9	3
+      0x8828010F,  //  0044  GETMBR	R10	R0	K15
+      0x8C281510,  //  0045  GETMET	R10	R10	K16
+      0x5C301200,  //  0046  MOVE	R12	R9
+      0x7C280400,  //  0047  CALL	R10	2
+      0x58280011,  //  0048  LDCONST	R10	K17
+      0x602C0010,  //  0049  GETGBL	R11	G16
+      0x8C300112,  //  004A  GETMET	R12	R0	K18
+      0x5C380C00,  //  004B  MOVE	R14	R6
+      0x7C300400,  //  004C  CALL	R12	2
+      0x7C2C0200,  //  004D  CALL	R11	1
+      0xA802000B,  //  004E  EXBLK	0	#005B
+      0x5C301600,  //  004F  MOVE	R12	R11
+      0x7C300000,  //  0050  CALL	R12	0
+      0x1C341909,  //  0051  EQ	R13	R12	K9
+      0x78360000,  //  0052  JMPF	R13	#0054
+      0x7001FFFA,  //  0053  JMP		#004F
+      0x8C340506,  //  0054  GETMET	R13	R2	K6
+      0x583C0013,  //  0055  LDCONST	R15	K19
+      0x5C401800,  //  0056  MOVE	R16	R12
+      0x94440C0C,  //  0057  GETIDX	R17	R6	R12
+      0x7C340800,  //  0058  CALL	R13	4
+      0x0028140D,  //  0059  ADD	R10	R10	R13
+      0x7001FFF3,  //  005A  JMP		#004F
+      0x582C0014,  //  005B  LDCONST	R11	K20
+      0xAC2C0200,  //  005C  CATCH	R11	1	0
+      0xB0080000,  //  005D  RAISE	2	R0	R0
+      0xB82E0400,  //  005E  GETNGBL	R11	K2
+      0x8C2C1703,  //  005F  GETMET	R11	R11	K3
+      0x8C340506,  //  0060  GETMET	R13	R2	K6
+      0x583C0015,  //  0061  LDCONST	R15	K21
+      0x5C400A00,  //  0062  MOVE	R16	R5
+      0x5C440E00,  //  0063  MOVE	R17	R7
+      0x5C481400,  //  0064  MOVE	R18	R10
+      0x7C340A00,  //  0065  CALL	R13	5
+      0x5838000E,  //  0066  LDCONST	R14	K14
+      0x7C2C0600,  //  0067  CALL	R11	3
+      0xA8040001,  //  0068  EXBLK	1	1
+      0x70020010,  //  0069  JMP		#007B
+      0xAC180002,  //  006A  CATCH	R6	0	2
+      0x7002000D,  //  006B  JMP		#007A
+      0xB8220400,  //  006C  GETNGBL	R8	K2
+      0x8C201103,  //  006D  GETMET	R8	R8	K3
+      0x60280008,  //  006E  GETGBL	R10	G8
+      0x5C2C0C00,  //  006F  MOVE	R11	R6
+      0x7C280200,  //  0070  CALL	R10	1
+      0x002A2C0A,  //  0071  ADD	R10	K22	R10
+      0x00281517,  //  0072  ADD	R10	R10	K23
+      0x602C0008,  //  0073  GETGBL	R11	G8
+      0x5C300E00,  //  0074  MOVE	R12	R7
+      0x7C2C0200,  //  0075  CALL	R11	1
+      0x0028140B,  //  0076  ADD	R10	R10	R11
+      0x582C000E,  //  0077  LDCONST	R11	K14
+      0x7C200600,  //  0078  CALL	R8	3
+      0x70020000,  //  0079  JMP		#007B
+      0xB0080000,  //  007A  RAISE	2	R0	R0
+      0x7001FF93,  //  007B  JMP		#0010
+      0x58100014,  //  007C  LDCONST	R4	K20
+      0xAC100200,  //  007D  CATCH	R4	1	0
+      0xB0080000,  //  007E  RAISE	2	R0	R0
+      0xB8120400,  //  007F  GETNGBL	R4	K2
+      0x8C100918,  //  0080  GETMET	R4	R4	K24
+      0x58180019,  //  0081  LDCONST	R6	K25
+      0x581C001A,  //  0082  LDCONST	R7	K26
+      0x7C100600,  //  0083  CALL	R4	3
+      0x80000000,  //  0084  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: autoconf_device_map
+********************************************************************/
+be_local_closure(Matter_Device_autoconf_device_map,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[36]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(0),
+    /* K2   */  be_nested_str_weak(type),
+    /* K3   */  be_nested_str_weak(root),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(light),
+    /* K6   */  be_nested_str_weak(get),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_nested_str_weak(channels),
+    /* K9   */  be_nested_str_weak(),
+    /* K10  */  be_const_int(0),
+    /* K11  */  be_nested_str_weak(light1),
+    /* K12  */  be_const_int(2),
+    /* K13  */  be_nested_str_weak(light2),
+    /* K14  */  be_nested_str_weak(light3),
+    /* K15  */  be_nested_str_weak(tasmota),
+    /* K16  */  be_nested_str_weak(get_power),
+    /* K17  */  be_nested_str_weak(relay),
+    /* K18  */  be_nested_str_weak(load),
+    /* K19  */  be_nested_str_weak(read_sensors),
+    /* K20  */  be_nested_str_weak(k2l),
+    /* K21  */  be_nested_str_weak(contains),
+    /* K22  */  be_nested_str_weak(Temperature),
+    /* K23  */  be_nested_str_weak(_X23Temperature),
+    /* K24  */  be_nested_str_weak(temperature),
+    /* K25  */  be_nested_str_weak(filter),
+    /* K26  */  be_nested_str_weak(stop_iteration),
+    /* K27  */  be_nested_str_weak(Pressure),
+    /* K28  */  be_nested_str_weak(_X23Pressure),
+    /* K29  */  be_nested_str_weak(pressure),
+    /* K30  */  be_nested_str_weak(Illuminance),
+    /* K31  */  be_nested_str_weak(_X23Illuminance),
+    /* K32  */  be_nested_str_weak(illuminance),
+    /* K33  */  be_nested_str_weak(Humidity),
+    /* K34  */  be_nested_str_weak(_X23Humidity),
+    /* K35  */  be_nested_str_weak(humidity),
+    }),
+    be_str_weak(autoconf_device_map),
+    &be_const_str_solidified,
+    ( &(const binstruction[235]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x60080013,  //  0001  GETGBL	R2	G19
+      0x7C080000,  //  0002  CALL	R2	0
+      0x600C0013,  //  0003  GETGBL	R3	G19
+      0x7C0C0000,  //  0004  CALL	R3	0
+      0x980E0503,  //  0005  SETIDX	R3	K2	K3
+      0x980A0203,  //  0006  SETIDX	R2	K1	R3
+      0x580C0004,  //  0007  LDCONST	R3	K4
+      0x50100000,  //  0008  LDBOOL	R4	0	0
+      0xA4160A00,  //  0009  IMPORT	R5	K5
+      0x8C180B06,  //  000A  GETMET	R6	R5	K6
+      0x7C180200,  //  000B  CALL	R6	1
+      0x4C1C0000,  //  000C  LDNIL	R7
+      0x201C0C07,  //  000D  NE	R7	R6	R7
+      0x781E0024,  //  000E  JMPF	R7	#0034
+      0x601C000C,  //  000F  GETGBL	R7	G12
+      0x8C200D07,  //  0010  GETMET	R8	R6	K7
+      0x58280008,  //  0011  LDCONST	R10	K8
+      0x582C0009,  //  0012  LDCONST	R11	K9
+      0x7C200600,  //  0013  CALL	R8	3
+      0x7C1C0200,  //  0014  CALL	R7	1
+      0x24200F0A,  //  0015  GT	R8	R7	K10
+      0x7822001C,  //  0016  JMPF	R8	#0034
+      0x1C200F04,  //  0017  EQ	R8	R7	K4
+      0x78220007,  //  0018  JMPF	R8	#0021
+      0x60200008,  //  0019  GETGBL	R8	G8
+      0x5C240600,  //  001A  MOVE	R9	R3
+      0x7C200200,  //  001B  CALL	R8	1
+      0x60240013,  //  001C  GETGBL	R9	G19
+      0x7C240000,  //  001D  CALL	R9	0
+      0x9826050B,  //  001E  SETIDX	R9	K2	K11
+      0x98081009,  //  001F  SETIDX	R2	R8	R9
+      0x70020010,  //  0020  JMP		#0032
+      0x1C200F0C,  //  0021  EQ	R8	R7	K12
+      0x78220007,  //  0022  JMPF	R8	#002B
+      0x60200008,  //  0023  GETGBL	R8	G8
+      0x5C240600,  //  0024  MOVE	R9	R3
+      0x7C200200,  //  0025  CALL	R8	1
+      0x60240013,  //  0026  GETGBL	R9	G19
+      0x7C240000,  //  0027  CALL	R9	0
+      0x9826050D,  //  0028  SETIDX	R9	K2	K13
+      0x98081009,  //  0029  SETIDX	R2	R8	R9
+      0x70020006,  //  002A  JMP		#0032
+      0x60200008,  //  002B  GETGBL	R8	G8
+      0x5C240600,  //  002C  MOVE	R9	R3
+      0x7C200200,  //  002D  CALL	R8	1
+      0x60240013,  //  002E  GETGBL	R9	G19
+      0x7C240000,  //  002F  CALL	R9	0
+      0x9826050E,  //  0030  SETIDX	R9	K2	K14
+      0x98081009,  //  0031  SETIDX	R2	R8	R9
+      0x50100200,  //  0032  LDBOOL	R4	1	0
+      0x000C0704,  //  0033  ADD	R3	R3	K4
+      0x601C000C,  //  0034  GETGBL	R7	G12
+      0xB8221E00,  //  0035  GETNGBL	R8	K15
+      0x8C201110,  //  0036  GETMET	R8	R8	K16
+      0x7C200200,  //  0037  CALL	R8	1
+      0x7C1C0200,  //  0038  CALL	R7	1
+      0x5820000A,  //  0039  LDCONST	R8	K10
+      0x78120000,  //  003A  JMPF	R4	#003C
+      0x041C0F04,  //  003B  SUB	R7	R7	K4
+      0x14241007,  //  003C  LT	R9	R8	R7
+      0x7826000A,  //  003D  JMPF	R9	#0049
+      0x60240008,  //  003E  GETGBL	R9	G8
+      0x5C280600,  //  003F  MOVE	R10	R3
+      0x7C240200,  //  0040  CALL	R9	1
+      0x60280013,  //  0041  GETGBL	R10	G19
+      0x7C280000,  //  0042  CALL	R10	0
+      0x982A0511,  //  0043  SETIDX	R10	K2	K17
+      0x982A2208,  //  0044  SETIDX	R10	K17	R8
+      0x9808120A,  //  0045  SETIDX	R2	R9	R10
+      0x00201104,  //  0046  ADD	R8	R8	K4
+      0x000C0704,  //  0047  ADD	R3	R3	K4
+      0x7001FFF2,  //  0048  JMP		#003C
+      0x8C240312,  //  0049  GETMET	R9	R1	K18
+      0xB82E1E00,  //  004A  GETNGBL	R11	K15
+      0x8C2C1713,  //  004B  GETMET	R11	R11	K19
+      0x7C2C0200,  //  004C  CALL	R11	1
+      0x7C240400,  //  004D  CALL	R9	2
+      0x540E001F,  //  004E  LDINT	R3	32
+      0x60280010,  //  004F  GETGBL	R10	G16
+      0x8C2C0114,  //  0050  GETMET	R11	R0	K20
+      0x5C341200,  //  0051  MOVE	R13	R9
+      0x7C2C0400,  //  0052  CALL	R11	2
+      0x7C280200,  //  0053  CALL	R10	1
+      0xA802001C,  //  0054  EXBLK	0	#0072
+      0x5C2C1400,  //  0055  MOVE	R11	R10
+      0x7C2C0000,  //  0056  CALL	R11	0
+      0x9430120B,  //  0057  GETIDX	R12	R9	R11
+      0x6034000F,  //  0058  GETGBL	R13	G15
+      0x5C381800,  //  0059  MOVE	R14	R12
+      0x603C0013,  //  005A  GETGBL	R15	G19
+      0x7C340400,  //  005B  CALL	R13	2
+      0x7836000D,  //  005C  JMPF	R13	#006B
+      0x8C341915,  //  005D  GETMET	R13	R12	K21
+      0x583C0016,  //  005E  LDCONST	R15	K22
+      0x7C340400,  //  005F  CALL	R13	2
+      0x78360009,  //  0060  JMPF	R13	#006B
+      0x00341717,  //  0061  ADD	R13	R11	K23
+      0x60380008,  //  0062  GETGBL	R14	G8
+      0x5C3C0600,  //  0063  MOVE	R15	R3
+      0x7C380200,  //  0064  CALL	R14	1
+      0x603C0013,  //  0065  GETGBL	R15	G19
+      0x7C3C0000,  //  0066  CALL	R15	0
+      0x983E0518,  //  0067  SETIDX	R15	K2	K24
+      0x983E320D,  //  0068  SETIDX	R15	K25	R13
+      0x98081C0F,  //  0069  SETIDX	R2	R14	R15
+      0x000C0704,  //  006A  ADD	R3	R3	K4
+      0x54360027,  //  006B  LDINT	R13	40
+      0x2434060D,  //  006C  GT	R13	R3	R13
+      0x78360000,  //  006D  JMPF	R13	#006F
+      0x70020000,  //  006E  JMP		#0070
+      0x7001FFE4,  //  006F  JMP		#0055
+      0xA8040001,  //  0070  EXBLK	1	1
+      0x70020002,  //  0071  JMP		#0075
+      0x5828001A,  //  0072  LDCONST	R10	K26
+      0xAC280200,  //  0073  CATCH	R10	1	0
+      0xB0080000,  //  0074  RAISE	2	R0	R0
+      0x540E0027,  //  0075  LDINT	R3	40
+      0x60280010,  //  0076  GETGBL	R10	G16
+      0x8C2C0114,  //  0077  GETMET	R11	R0	K20
+      0x5C341200,  //  0078  MOVE	R13	R9
+      0x7C2C0400,  //  0079  CALL	R11	2
+      0x7C280200,  //  007A  CALL	R10	1
+      0xA802001C,  //  007B  EXBLK	0	#0099
+      0x5C2C1400,  //  007C  MOVE	R11	R10
+      0x7C2C0000,  //  007D  CALL	R11	0
+      0x9430120B,  //  007E  GETIDX	R12	R9	R11
+      0x6034000F,  //  007F  GETGBL	R13	G15
+      0x5C381800,  //  0080  MOVE	R14	R12
+      0x603C0013,  //  0081  GETGBL	R15	G19
+      0x7C340400,  //  0082  CALL	R13	2
+      0x7836000D,  //  0083  JMPF	R13	#0092
+      0x8C341915,  //  0084  GETMET	R13	R12	K21
+      0x583C001B,  //  0085  LDCONST	R15	K27
+      0x7C340400,  //  0086  CALL	R13	2
+      0x78360009,  //  0087  JMPF	R13	#0092
+      0x0034171C,  //  0088  ADD	R13	R11	K28
+      0x60380008,  //  0089  GETGBL	R14	G8
+      0x5C3C0600,  //  008A  MOVE	R15	R3
+      0x7C380200,  //  008B  CALL	R14	1
+      0x603C0013,  //  008C  GETGBL	R15	G19
+      0x7C3C0000,  //  008D  CALL	R15	0
+      0x983E051D,  //  008E  SETIDX	R15	K2	K29
+      0x983E320D,  //  008F  SETIDX	R15	K25	R13
+      0x98081C0F,  //  0090  SETIDX	R2	R14	R15
+      0x000C0704,  //  0091  ADD	R3	R3	K4
+      0x5436002E,  //  0092  LDINT	R13	47
+      0x2434060D,  //  0093  GT	R13	R3	R13
+      0x78360000,  //  0094  JMPF	R13	#0096
+      0x70020000,  //  0095  JMP		#0097
+      0x7001FFE4,  //  0096  JMP		#007C
+      0xA8040001,  //  0097  EXBLK	1	1
+      0x70020002,  //  0098  JMP		#009C
+      0x5828001A,  //  0099  LDCONST	R10	K26
+      0xAC280200,  //  009A  CATCH	R10	1	0
+      0xB0080000,  //  009B  RAISE	2	R0	R0
+      0x540E002F,  //  009C  LDINT	R3	48
+      0x60280010,  //  009D  GETGBL	R10	G16
+      0x8C2C0114,  //  009E  GETMET	R11	R0	K20
+      0x5C341200,  //  009F  MOVE	R13	R9
+      0x7C2C0400,  //  00A0  CALL	R11	2
+      0x7C280200,  //  00A1  CALL	R10	1
+      0xA802001C,  //  00A2  EXBLK	0	#00C0
+      0x5C2C1400,  //  00A3  MOVE	R11	R10
+      0x7C2C0000,  //  00A4  CALL	R11	0
+      0x9430120B,  //  00A5  GETIDX	R12	R9	R11
+      0x6034000F,  //  00A6  GETGBL	R13	G15
+      0x5C381800,  //  00A7  MOVE	R14	R12
+      0x603C0013,  //  00A8  GETGBL	R15	G19
+      0x7C340400,  //  00A9  CALL	R13	2
+      0x7836000D,  //  00AA  JMPF	R13	#00B9
+      0x8C341915,  //  00AB  GETMET	R13	R12	K21
+      0x583C001E,  //  00AC  LDCONST	R15	K30
+      0x7C340400,  //  00AD  CALL	R13	2
+      0x78360009,  //  00AE  JMPF	R13	#00B9
+      0x0034171F,  //  00AF  ADD	R13	R11	K31
+      0x60380008,  //  00B0  GETGBL	R14	G8
+      0x5C3C0600,  //  00B1  MOVE	R15	R3
+      0x7C380200,  //  00B2  CALL	R14	1
+      0x603C0013,  //  00B3  GETGBL	R15	G19
+      0x7C3C0000,  //  00B4  CALL	R15	0
+      0x983E0520,  //  00B5  SETIDX	R15	K2	K32
+      0x983E320D,  //  00B6  SETIDX	R15	K25	R13
+      0x98081C0F,  //  00B7  SETIDX	R2	R14	R15
+      0x000C0704,  //  00B8  ADD	R3	R3	K4
+      0x54360037,  //  00B9  LDINT	R13	56
+      0x2434060D,  //  00BA  GT	R13	R3	R13
+      0x78360000,  //  00BB  JMPF	R13	#00BD
+      0x70020000,  //  00BC  JMP		#00BE
+      0x7001FFE4,  //  00BD  JMP		#00A3
+      0xA8040001,  //  00BE  EXBLK	1	1
+      0x70020002,  //  00BF  JMP		#00C3
+      0x5828001A,  //  00C0  LDCONST	R10	K26
+      0xAC280200,  //  00C1  CATCH	R10	1	0
+      0xB0080000,  //  00C2  RAISE	2	R0	R0
+      0x540E0037,  //  00C3  LDINT	R3	56
+      0x60280010,  //  00C4  GETGBL	R10	G16
+      0x8C2C0114,  //  00C5  GETMET	R11	R0	K20
+      0x5C341200,  //  00C6  MOVE	R13	R9
+      0x7C2C0400,  //  00C7  CALL	R11	2
+      0x7C280200,  //  00C8  CALL	R10	1
+      0xA802001C,  //  00C9  EXBLK	0	#00E7
+      0x5C2C1400,  //  00CA  MOVE	R11	R10
+      0x7C2C0000,  //  00CB  CALL	R11	0
+      0x9430120B,  //  00CC  GETIDX	R12	R9	R11
+      0x6034000F,  //  00CD  GETGBL	R13	G15
+      0x5C381800,  //  00CE  MOVE	R14	R12
+      0x603C0013,  //  00CF  GETGBL	R15	G19
+      0x7C340400,  //  00D0  CALL	R13	2
+      0x7836000D,  //  00D1  JMPF	R13	#00E0
+      0x8C341915,  //  00D2  GETMET	R13	R12	K21
+      0x583C0021,  //  00D3  LDCONST	R15	K33
+      0x7C340400,  //  00D4  CALL	R13	2
+      0x78360009,  //  00D5  JMPF	R13	#00E0
+      0x00341722,  //  00D6  ADD	R13	R11	K34
+      0x60380008,  //  00D7  GETGBL	R14	G8
+      0x5C3C0600,  //  00D8  MOVE	R15	R3
+      0x7C380200,  //  00D9  CALL	R14	1
+      0x603C0013,  //  00DA  GETGBL	R15	G19
+      0x7C3C0000,  //  00DB  CALL	R15	0
+      0x983E0523,  //  00DC  SETIDX	R15	K2	K35
+      0x983E320D,  //  00DD  SETIDX	R15	K25	R13
+      0x98081C0F,  //  00DE  SETIDX	R2	R14	R15
+      0x000C0704,  //  00DF  ADD	R3	R3	K4
+      0x5436003F,  //  00E0  LDINT	R13	64
+      0x2434060D,  //  00E1  GT	R13	R3	R13
+      0x78360000,  //  00E2  JMPF	R13	#00E4
+      0x70020000,  //  00E3  JMP		#00E5
+      0x7001FFE4,  //  00E4  JMP		#00CA
+      0xA8040001,  //  00E5  EXBLK	1	1
+      0x70020002,  //  00E6  JMP		#00EA
+      0x5828001A,  //  00E7  LDCONST	R10	K26
+      0xAC280200,  //  00E8  CATCH	R10	1	0
+      0xB0080000,  //  00E9  RAISE	2	R0	R0
+      0x80040400,  //  00EA  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_fabric
+********************************************************************/
+be_local_closure(Matter_Device_remove_fabric,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(find_children_fabrics),
+    /* K2   */  be_nested_str_weak(get_fabric_index),
+    /* K3   */  be_nested_str_weak(find_fabric_by_index),
+    /* K4   */  be_nested_str_weak(message_handler),
+    /* K5   */  be_nested_str_weak(im),
+    /* K6   */  be_nested_str_weak(subs_shop),
+    /* K7   */  be_nested_str_weak(remove_by_fabric),
+    /* K8   */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K9   */  be_nested_str_weak(remove_fabric),
+    /* K10  */  be_nested_str_weak(stop_iteration),
+    /* K11  */  be_nested_str_weak(save_fabrics),
+    }),
+    be_str_weak(remove_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[43]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8C100302,  //  0002  GETMET	R4	R1	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x7C080400,  //  0004  CALL	R2	2
+      0x4C0C0000,  //  0005  LDNIL	R3
+      0x1C0C0403,  //  0006  EQ	R3	R2	R3
+      0x780E0000,  //  0007  JMPF	R3	#0009
+      0x80000600,  //  0008  RET	0
+      0x600C0010,  //  0009  GETGBL	R3	G16
+      0x5C100400,  //  000A  MOVE	R4	R2
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0xA8020016,  //  000C  EXBLK	0	#0024
+      0x5C100600,  //  000D  MOVE	R4	R3
+      0x7C100000,  //  000E  CALL	R4	0
+      0x88140100,  //  000F  GETMBR	R5	R0	K0
+      0x8C140B03,  //  0010  GETMET	R5	R5	K3
+      0x5C1C0800,  //  0011  MOVE	R7	R4
+      0x7C140400,  //  0012  CALL	R5	2
+      0x4C180000,  //  0013  LDNIL	R6
+      0x20180A06,  //  0014  NE	R6	R5	R6
+      0x781A000C,  //  0015  JMPF	R6	#0023
+      0x88180104,  //  0016  GETMBR	R6	R0	K4
+      0x88180D05,  //  0017  GETMBR	R6	R6	K5
+      0x88180D06,  //  0018  GETMBR	R6	R6	K6
+      0x8C180D07,  //  0019  GETMET	R6	R6	K7
+      0x5C200A00,  //  001A  MOVE	R8	R5
+      0x7C180400,  //  001B  CALL	R6	2
+      0x8C180108,  //  001C  GETMET	R6	R0	K8
+      0x5C200A00,  //  001D  MOVE	R8	R5
+      0x7C180400,  //  001E  CALL	R6	2
+      0x88180100,  //  001F  GETMBR	R6	R0	K0
+      0x8C180D09,  //  0020  GETMET	R6	R6	K9
+      0x5C200A00,  //  0021  MOVE	R8	R5
+      0x7C180400,  //  0022  CALL	R6	2
+      0x7001FFE8,  //  0023  JMP		#000D
+      0x580C000A,  //  0024  LDCONST	R3	K10
+      0xAC0C0200,  //  0025  CATCH	R3	1	0
+      0xB0080000,  //  0026  RAISE	2	R0	R0
+      0x880C0100,  //  0027  GETMBR	R3	R0	K0
+      0x8C0C070B,  //  0028  GETMET	R3	R3	K11
+      0x7C0C0200,  //  0029  CALL	R3	1
+      0x80000000,  //  002A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Device_every_second,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(every_second),
+    /* K2   */  be_nested_str_weak(message_handler),
+    /* K3   */  be_nested_str_weak(commissioning_open),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(time_reached),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(plugins),
+    /* K8   */  be_const_int(1),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040102,  //  0003  GETMBR	R1	R0	K2
+      0x8C040301,  //  0004  GETMET	R1	R1	K1
+      0x7C040200,  //  0005  CALL	R1	1
+      0x88040103,  //  0006  GETMBR	R1	R0	K3
+      0x4C080000,  //  0007  LDNIL	R2
+      0x20040202,  //  0008  NE	R1	R1	R2
+      0x78060006,  //  0009  JMPF	R1	#0011
+      0xB8060800,  //  000A  GETNGBL	R1	K4
+      0x8C040305,  //  000B  GETMET	R1	R1	K5
+      0x880C0103,  //  000C  GETMBR	R3	R0	K3
+      0x7C040400,  //  000D  CALL	R1	2
+      0x78060001,  //  000E  JMPF	R1	#0011
+      0x4C040000,  //  000F  LDNIL	R1
+      0x90020601,  //  0010  SETMBR	R0	K3	R1
+      0x58040006,  //  0011  LDCONST	R1	K6
+      0x6008000C,  //  0012  GETGBL	R2	G12
+      0x880C0107,  //  0013  GETMBR	R3	R0	K7
+      0x7C080200,  //  0014  CALL	R2	1
+      0x14080202,  //  0015  LT	R2	R1	R2
+      0x780A0005,  //  0016  JMPF	R2	#001D
+      0x88080107,  //  0017  GETMBR	R2	R0	K7
+      0x94080401,  //  0018  GETIDX	R2	R2	R1
+      0x8C080501,  //  0019  GETMET	R2	R2	K1
+      0x7C080200,  //  001A  CALL	R2	1
+      0x00040308,  //  001B  ADD	R1	R1	K8
+      0x7001FFF4,  //  001C  JMP		#0012
+      0x80000000,  //  001D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_active_endpoints
+********************************************************************/
+be_local_closure(Matter_Device_get_active_endpoints,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins),
+    /* K1   */  be_nested_str_weak(get_endpoint),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(find),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(get_active_endpoints),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x88100100,  //  0003  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0xA8020011,  //  0005  EXBLK	0	#0018
+      0x5C100600,  //  0006  MOVE	R4	R3
+      0x7C100000,  //  0007  CALL	R4	0
+      0x8C140901,  //  0008  GETMET	R5	R4	K1
+      0x7C140200,  //  0009  CALL	R5	1
+      0x78060002,  //  000A  JMPF	R1	#000E
+      0x1C180B02,  //  000B  EQ	R6	R5	K2
+      0x781A0000,  //  000C  JMPF	R6	#000E
+      0x7001FFF7,  //  000D  JMP		#0006
+      0x8C180503,  //  000E  GETMET	R6	R2	K3
+      0x5C200A00,  //  000F  MOVE	R8	R5
+      0x7C180400,  //  0010  CALL	R6	2
+      0x4C1C0000,  //  0011  LDNIL	R7
+      0x1C180C07,  //  0012  EQ	R6	R6	R7
+      0x781A0002,  //  0013  JMPF	R6	#0017
+      0x8C180504,  //  0014  GETMET	R6	R2	K4
+      0x5C200A00,  //  0015  MOVE	R8	R5
+      0x7C180400,  //  0016  CALL	R6	2
+      0x7001FFED,  //  0017  JMP		#0006
+      0x580C0005,  //  0018  LDCONST	R3	K5
+      0xAC0C0200,  //  0019  CATCH	R3	1	0
+      0xB0080000,  //  001A  RAISE	2	R0	R0
+      0x80040400,  //  001B  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Device_invoke_request,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(endpoint),
+    /* K2   */  be_nested_str_weak(plugins),
+    /* K3   */  be_nested_str_weak(invoke_request),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(status),
+    /* K6   */  be_nested_str_weak(matter),
+    /* K7   */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+    }),
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58100000,  //  0000  LDCONST	R4	K0
+      0x88140701,  //  0001  GETMBR	R5	R3	K1
+      0x6018000C,  //  0002  GETGBL	R6	G12
+      0x881C0102,  //  0003  GETMBR	R7	R0	K2
+      0x7C180200,  //  0004  CALL	R6	1
+      0x14180806,  //  0005  LT	R6	R4	R6
+      0x781A000C,  //  0006  JMPF	R6	#0014
+      0x88180102,  //  0007  GETMBR	R6	R0	K2
+      0x94180C04,  //  0008  GETIDX	R6	R6	R4
+      0x881C0D01,  //  0009  GETMBR	R7	R6	K1
+      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
+      0x781E0005,  //  000B  JMPF	R7	#0012
+      0x8C1C0D03,  //  000C  GETMET	R7	R6	K3
+      0x5C240200,  //  000D  MOVE	R9	R1
+      0x5C280400,  //  000E  MOVE	R10	R2
+      0x5C2C0600,  //  000F  MOVE	R11	R3
+      0x7C1C0800,  //  0010  CALL	R7	4
+      0x80040E00,  //  0011  RET	1	R7
+      0x00100904,  //  0012  ADD	R4	R4	K4
+      0x7001FFED,  //  0013  JMP		#0002
+      0xB81A0C00,  //  0014  GETNGBL	R6	K6
+      0x88180D07,  //  0015  GETMBR	R6	R6	K7
+      0x900E0A06,  //  0016  SETMBR	R3	K5	R6
+      0x80000000,  //  0017  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(Matter_Device_start,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_trigger_read_sensors),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80000000,  //  0003  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(started),
+    /* K1   */  be_nested_str_weak(autoconf_device),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(add_cron),
+    /* K4   */  be_nested_str_weak(_X2A_X2F30_X20_X2A_X20_X2A_X20_X2A_X20_X2A_X20_X2A),
+    /* K5   */  be_nested_str_weak(matter_sensors_30s),
+    /* K6   */  be_nested_str_weak(_start_udp),
+    /* K7   */  be_nested_str_weak(UDP_PORT),
+    /* K8   */  be_nested_str_weak(start_mdns_announce_hostnames),
+    }),
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060000,  //  0001  JMPF	R1	#0003
+      0x80000200,  //  0002  RET	0
+      0x8C040101,  //  0003  GETMET	R1	R0	K1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xB8060400,  //  0005  GETNGBL	R1	K2
+      0x8C040303,  //  0006  GETMET	R1	R1	K3
+      0x580C0004,  //  0007  LDCONST	R3	K4
+      0x84100000,  //  0008  CLOSURE	R4	P0
+      0x58140005,  //  0009  LDCONST	R5	K5
+      0x7C040800,  //  000A  CALL	R1	4
+      0x8C040106,  //  000B  GETMET	R1	R0	K6
+      0x880C0107,  //  000C  GETMBR	R3	R0	K7
+      0x7C040400,  //  000D  CALL	R1	2
+      0x8C040108,  //  000E  GETMET	R1	R0	K8
+      0x7C040200,  //  000F  CALL	R1	1
+      0x50040200,  //  0010  LDBOOL	R1	1	0
+      0x90020001,  //  0011  SETMBR	R0	K0	R1
+      0xA0000000,  //  0012  CLOSE	R0
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: plugins_to_json
+********************************************************************/
+be_local_closure(Matter_Device_plugins_to_json,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(_X7B),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(plugins),
+    /* K4   */  be_nested_str_weak(_X2C),
+    /* K5   */  be_nested_str_weak(format),
+    /* K6   */  be_nested_str_weak(_X22_X25i_X22_X3A_X25s),
+    /* K7   */  be_nested_str_weak(get_endpoint),
+    /* K8   */  be_nested_str_weak(to_json),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(_X7D),
+    }),
+    be_str_weak(plugins_to_json),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x58080001,  //  0001  LDCONST	R2	K1
+      0x580C0002,  //  0002  LDCONST	R3	K2
+      0x6010000C,  //  0003  GETGBL	R4	G12
+      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x7C100200,  //  0005  CALL	R4	1
+      0x14100604,  //  0006  LT	R4	R3	R4
+      0x7812000E,  //  0007  JMPF	R4	#0017
+      0x88100103,  //  0008  GETMBR	R4	R0	K3
+      0x94100803,  //  0009  GETIDX	R4	R4	R3
+      0x24140702,  //  000A  GT	R5	R3	K2
+      0x78160000,  //  000B  JMPF	R5	#000D
+      0x00080504,  //  000C  ADD	R2	R2	K4
+      0x8C140305,  //  000D  GETMET	R5	R1	K5
+      0x581C0006,  //  000E  LDCONST	R7	K6
+      0x8C200907,  //  000F  GETMET	R8	R4	K7
+      0x7C200200,  //  0010  CALL	R8	1
+      0x8C240908,  //  0011  GETMET	R9	R4	K8
+      0x7C240200,  //  0012  CALL	R9	1
+      0x7C140800,  //  0013  CALL	R5	4
+      0x00080405,  //  0014  ADD	R2	R2	R5
+      0x000C0709,  //  0015  ADD	R3	R3	K9
+      0x7001FFEB,  //  0016  JMP		#0003
+      0x0008050A,  //  0017  ADD	R2	R2	K10
+      0x80040400,  //  0018  RET	1	R2
     })
   )
 );
@@ -3163,61 +4291,112 @@ be_local_closure(Matter_Device_mdns_announce_PASE,   /* name */
 
 
 /********************************************************************
-** Solidified function: stop_basic_commissioning
+** Solidified function: register_native_classes
 ********************************************************************/
-be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
+be_local_closure(Matter_Device_register_native_classes,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
+    9,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(is_root_commissioning_open),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(publish_result),
-    /* K3   */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A0_X7D_X7D),
-    /* K4   */  be_nested_str_weak(Matter),
-    /* K5   */  be_nested_str_weak(commissioning_open),
-    /* K6   */  be_nested_str_weak(mdns_remove_PASE),
-    /* K7   */  be_nested_str_weak(commissioning_iterations),
-    /* K8   */  be_nested_str_weak(commissioning_discriminator),
-    /* K9   */  be_nested_str_weak(commissioning_salt),
-    /* K10  */  be_nested_str_weak(commissioning_w0),
-    /* K11  */  be_nested_str_weak(commissioning_L),
-    /* K12  */  be_nested_str_weak(commissioning_admin_fabric),
+    ( &(const bvalue[28]) {     /* constants */
+    /* K0   */  be_nested_str_weak(register_plugin_class),
+    /* K1   */  be_nested_str_weak(root),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(Plugin_Root),
+    /* K4   */  be_nested_str_weak(light0),
+    /* K5   */  be_nested_str_weak(Plugin_Light0),
+    /* K6   */  be_nested_str_weak(light1),
+    /* K7   */  be_nested_str_weak(Plugin_Light1),
+    /* K8   */  be_nested_str_weak(light2),
+    /* K9   */  be_nested_str_weak(Plugin_Light2),
+    /* K10  */  be_nested_str_weak(light3),
+    /* K11  */  be_nested_str_weak(Plugin_Light3),
+    /* K12  */  be_nested_str_weak(relay),
+    /* K13  */  be_nested_str_weak(Plugin_OnOff),
+    /* K14  */  be_nested_str_weak(temperature),
+    /* K15  */  be_nested_str_weak(Plugin_Sensor_Temp),
+    /* K16  */  be_nested_str_weak(humidity),
+    /* K17  */  be_nested_str_weak(Plugin_Sensor_Humidity),
+    /* K18  */  be_nested_str_weak(illuminance),
+    /* K19  */  be_nested_str_weak(Plugin_Sensor_Illuminance),
+    /* K20  */  be_nested_str_weak(pressure),
+    /* K21  */  be_nested_str_weak(Plugin_Sensor_Pressure),
+    /* K22  */  be_nested_str_weak(tasmota),
+    /* K23  */  be_nested_str_weak(log),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20registered_X20classes_X20),
+    /* K25  */  be_nested_str_weak(k2l),
+    /* K26  */  be_nested_str_weak(plugins_classes),
+    /* K27  */  be_const_int(3),
     }),
-    be_str_weak(stop_basic_commissioning),
+    be_str_weak(register_native_classes),
     &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x78060004,  //  0002  JMPF	R1	#0008
-      0xB8060200,  //  0003  GETNGBL	R1	K1
-      0x8C040302,  //  0004  GETMET	R1	R1	K2
-      0x580C0003,  //  0005  LDCONST	R3	K3
-      0x58100004,  //  0006  LDCONST	R4	K4
-      0x7C040600,  //  0007  CALL	R1	3
-      0x4C040000,  //  0008  LDNIL	R1
-      0x90020A01,  //  0009  SETMBR	R0	K5	R1
-      0x8C040106,  //  000A  GETMET	R1	R0	K6
-      0x7C040200,  //  000B  CALL	R1	1
-      0x4C040000,  //  000C  LDNIL	R1
-      0x90020E01,  //  000D  SETMBR	R0	K7	R1
-      0x4C040000,  //  000E  LDNIL	R1
-      0x90021001,  //  000F  SETMBR	R0	K8	R1
-      0x4C040000,  //  0010  LDNIL	R1
-      0x90021201,  //  0011  SETMBR	R0	K9	R1
-      0x4C040000,  //  0012  LDNIL	R1
-      0x90021401,  //  0013  SETMBR	R0	K10	R1
-      0x4C040000,  //  0014  LDNIL	R1
-      0x90021601,  //  0015  SETMBR	R0	K11	R1
-      0x4C040000,  //  0016  LDNIL	R1
-      0x90021801,  //  0017  SETMBR	R0	K12	R1
-      0x80000000,  //  0018  RET	0
+    ( &(const binstruction[61]) {  /* code */
+      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x58140001,  //  0001  LDCONST	R5	K1
+      0xB81A0400,  //  0002  GETNGBL	R6	K2
+      0x88180D03,  //  0003  GETMBR	R6	R6	K3
+      0x7C0C0600,  //  0004  CALL	R3	3
+      0x8C0C0100,  //  0005  GETMET	R3	R0	K0
+      0x58140004,  //  0006  LDCONST	R5	K4
+      0xB81A0400,  //  0007  GETNGBL	R6	K2
+      0x88180D05,  //  0008  GETMBR	R6	R6	K5
+      0x7C0C0600,  //  0009  CALL	R3	3
+      0x8C0C0100,  //  000A  GETMET	R3	R0	K0
+      0x58140006,  //  000B  LDCONST	R5	K6
+      0xB81A0400,  //  000C  GETNGBL	R6	K2
+      0x88180D07,  //  000D  GETMBR	R6	R6	K7
+      0x7C0C0600,  //  000E  CALL	R3	3
+      0x8C0C0100,  //  000F  GETMET	R3	R0	K0
+      0x58140008,  //  0010  LDCONST	R5	K8
+      0xB81A0400,  //  0011  GETNGBL	R6	K2
+      0x88180D09,  //  0012  GETMBR	R6	R6	K9
+      0x7C0C0600,  //  0013  CALL	R3	3
+      0x8C0C0100,  //  0014  GETMET	R3	R0	K0
+      0x5814000A,  //  0015  LDCONST	R5	K10
+      0xB81A0400,  //  0016  GETNGBL	R6	K2
+      0x88180D0B,  //  0017  GETMBR	R6	R6	K11
+      0x7C0C0600,  //  0018  CALL	R3	3
+      0x8C0C0100,  //  0019  GETMET	R3	R0	K0
+      0x5814000C,  //  001A  LDCONST	R5	K12
+      0xB81A0400,  //  001B  GETNGBL	R6	K2
+      0x88180D0D,  //  001C  GETMBR	R6	R6	K13
+      0x7C0C0600,  //  001D  CALL	R3	3
+      0x8C0C0100,  //  001E  GETMET	R3	R0	K0
+      0x5814000E,  //  001F  LDCONST	R5	K14
+      0xB81A0400,  //  0020  GETNGBL	R6	K2
+      0x88180D0F,  //  0021  GETMBR	R6	R6	K15
+      0x7C0C0600,  //  0022  CALL	R3	3
+      0x8C0C0100,  //  0023  GETMET	R3	R0	K0
+      0x58140010,  //  0024  LDCONST	R5	K16
+      0xB81A0400,  //  0025  GETNGBL	R6	K2
+      0x88180D11,  //  0026  GETMBR	R6	R6	K17
+      0x7C0C0600,  //  0027  CALL	R3	3
+      0x8C0C0100,  //  0028  GETMET	R3	R0	K0
+      0x58140012,  //  0029  LDCONST	R5	K18
+      0xB81A0400,  //  002A  GETNGBL	R6	K2
+      0x88180D13,  //  002B  GETMBR	R6	R6	K19
+      0x7C0C0600,  //  002C  CALL	R3	3
+      0x8C0C0100,  //  002D  GETMET	R3	R0	K0
+      0x58140014,  //  002E  LDCONST	R5	K20
+      0xB81A0400,  //  002F  GETNGBL	R6	K2
+      0x88180D15,  //  0030  GETMBR	R6	R6	K21
+      0x7C0C0600,  //  0031  CALL	R3	3
+      0xB80E2C00,  //  0032  GETNGBL	R3	K22
+      0x8C0C0717,  //  0033  GETMET	R3	R3	K23
+      0x60140008,  //  0034  GETGBL	R5	G8
+      0x8C180119,  //  0035  GETMET	R6	R0	K25
+      0x8820011A,  //  0036  GETMBR	R8	R0	K26
+      0x7C180400,  //  0037  CALL	R6	2
+      0x7C140200,  //  0038  CALL	R5	1
+      0x00163005,  //  0039  ADD	R5	K24	R5
+      0x5818001B,  //  003A  LDCONST	R6	K27
+      0x7C0C0600,  //  003B  CALL	R3	3
+      0x80000000,  //  003C  RET	0
     })
   )
 );
@@ -3225,503 +4404,12 @@ be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
 
 
 /********************************************************************
-** Solidified function: received_ack
+** Solidified function: event_fabrics_saved
 ********************************************************************/
-be_local_closure(Matter_Device_received_ack,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(received_ack),
-    }),
-    be_str_weak(received_ack),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: load_param
-********************************************************************/
-be_local_closure(Matter_Device_load_param,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(FILENAME),
-    /* K3   */  be_nested_str_weak(read),
-    /* K4   */  be_nested_str_weak(close),
-    /* K5   */  be_nested_str_weak(json),
-    /* K6   */  be_nested_str_weak(load),
-    /* K7   */  be_nested_str_weak(root_discriminator),
-    /* K8   */  be_nested_str_weak(find),
-    /* K9   */  be_nested_str_weak(distinguish),
-    /* K10  */  be_nested_str_weak(root_passcode),
-    /* K11  */  be_nested_str_weak(passcode),
-    /* K12  */  be_nested_str_weak(ipv4only),
-    /* K13  */  be_nested_str_weak(io_error),
-    /* K14  */  be_nested_str_weak(tasmota),
-    /* K15  */  be_nested_str_weak(log),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
-    /* K17  */  be_nested_str_weak(_X7C),
-    /* K18  */  be_const_int(2),
-    /* K19  */  be_nested_str_weak(random),
-    /* K20  */  be_nested_str_weak(get),
-    /* K21  */  be_const_int(0),
-    /* K22  */  be_nested_str_weak(PASSCODE_DEFAULT),
-    /* K23  */  be_nested_str_weak(save_param),
-    }),
-    be_str_weak(load_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[79]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xA802001D,  //  0002  EXBLK	0	#0021
-      0x600C0011,  //  0003  GETGBL	R3	G17
-      0x88100102,  //  0004  GETMBR	R4	R0	K2
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C100703,  //  0006  GETMET	R4	R3	K3
-      0x7C100200,  //  0007  CALL	R4	1
-      0x8C140704,  //  0008  GETMET	R5	R3	K4
-      0x7C140200,  //  0009  CALL	R5	1
-      0xA4160A00,  //  000A  IMPORT	R5	K5
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
-      0x5C200800,  //  000C  MOVE	R8	R4
-      0x7C180400,  //  000D  CALL	R6	2
-      0x8C1C0D08,  //  000E  GETMET	R7	R6	K8
-      0x58240009,  //  000F  LDCONST	R9	K9
-      0x88280107,  //  0010  GETMBR	R10	R0	K7
-      0x7C1C0600,  //  0011  CALL	R7	3
-      0x90020E07,  //  0012  SETMBR	R0	K7	R7
-      0x8C1C0D08,  //  0013  GETMET	R7	R6	K8
-      0x5824000B,  //  0014  LDCONST	R9	K11
-      0x8828010A,  //  0015  GETMBR	R10	R0	K10
-      0x7C1C0600,  //  0016  CALL	R7	3
-      0x90021407,  //  0017  SETMBR	R0	K10	R7
-      0x601C0017,  //  0018  GETGBL	R7	G23
-      0x8C200D08,  //  0019  GETMET	R8	R6	K8
-      0x5828000C,  //  001A  LDCONST	R10	K12
-      0x502C0000,  //  001B  LDBOOL	R11	0	0
-      0x7C200600,  //  001C  CALL	R8	3
-      0x7C1C0200,  //  001D  CALL	R7	1
-      0x90021807,  //  001E  SETMBR	R0	K12	R7
-      0xA8040001,  //  001F  EXBLK	1	1
-      0x70020012,  //  0020  JMP		#0034
-      0xAC0C0002,  //  0021  CATCH	R3	0	2
-      0x7002000F,  //  0022  JMP		#0033
-      0x2014070D,  //  0023  NE	R5	R3	K13
-      0x7816000C,  //  0024  JMPF	R5	#0032
-      0xB8161C00,  //  0025  GETNGBL	R5	K14
-      0x8C140B0F,  //  0026  GETMET	R5	R5	K15
-      0x601C0008,  //  0027  GETGBL	R7	G8
-      0x5C200600,  //  0028  MOVE	R8	R3
-      0x7C1C0200,  //  0029  CALL	R7	1
-      0x001E2007,  //  002A  ADD	R7	K16	R7
-      0x001C0F11,  //  002B  ADD	R7	R7	K17
-      0x60200008,  //  002C  GETGBL	R8	G8
-      0x5C240800,  //  002D  MOVE	R9	R4
-      0x7C200200,  //  002E  CALL	R8	1
-      0x001C0E08,  //  002F  ADD	R7	R7	R8
-      0x58200012,  //  0030  LDCONST	R8	K18
-      0x7C140600,  //  0031  CALL	R5	3
-      0x70020000,  //  0032  JMP		#0034
-      0xB0080000,  //  0033  RAISE	2	R0	R0
-      0x500C0000,  //  0034  LDBOOL	R3	0	0
-      0x88100107,  //  0035  GETMBR	R4	R0	K7
-      0x4C140000,  //  0036  LDNIL	R5
-      0x1C100805,  //  0037  EQ	R4	R4	R5
-      0x7812000A,  //  0038  JMPF	R4	#0044
-      0x8C100513,  //  0039  GETMET	R4	R2	K19
-      0x58180012,  //  003A  LDCONST	R6	K18
-      0x7C100400,  //  003B  CALL	R4	2
-      0x8C100914,  //  003C  GETMET	R4	R4	K20
-      0x58180015,  //  003D  LDCONST	R6	K21
-      0x581C0012,  //  003E  LDCONST	R7	K18
-      0x7C100600,  //  003F  CALL	R4	3
-      0x54160FFE,  //  0040  LDINT	R5	4095
-      0x2C100805,  //  0041  AND	R4	R4	R5
-      0x90020E04,  //  0042  SETMBR	R0	K7	R4
-      0x500C0200,  //  0043  LDBOOL	R3	1	0
-      0x8810010A,  //  0044  GETMBR	R4	R0	K10
-      0x4C140000,  //  0045  LDNIL	R5
-      0x1C100805,  //  0046  EQ	R4	R4	R5
-      0x78120002,  //  0047  JMPF	R4	#004B
-      0x88100116,  //  0048  GETMBR	R4	R0	K22
-      0x90021404,  //  0049  SETMBR	R0	K10	R4
-      0x500C0200,  //  004A  LDBOOL	R3	1	0
-      0x780E0001,  //  004B  JMPF	R3	#004E
-      0x8C100117,  //  004C  GETMET	R4	R0	K23
-      0x7C100200,  //  004D  CALL	R4	1
-      0x80000000,  //  004E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_remove_op_discovery_all_fabrics
-********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(active_fabrics),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(mdns_remove_op_discovery_all_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000B,  //  0005  EXBLK	0	#0012
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x780E0005,  //  000A  JMPF	R3	#0011
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x780E0002,  //  000D  JMPF	R3	#0011
-      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x7001FFF3,  //  0011  JMP		#0006
-      0x58040005,  //  0012  LDCONST	R1	K5
-      0xAC040200,  //  0013  CATCH	R1	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_param
-********************************************************************/
-be_local_closure(Matter_Device_save_param,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(dump),
-    /* K2   */  be_nested_str_weak(distinguish),
-    /* K3   */  be_nested_str_weak(root_discriminator),
-    /* K4   */  be_nested_str_weak(passcode),
-    /* K5   */  be_nested_str_weak(root_passcode),
-    /* K6   */  be_nested_str_weak(ipv4only),
-    /* K7   */  be_nested_str_weak(string),
-    /* K8   */  be_nested_str_weak(FILENAME),
-    /* K9   */  be_nested_str_weak(w),
-    /* K10  */  be_nested_str_weak(write),
-    /* K11  */  be_nested_str_weak(close),
-    /* K12  */  be_nested_str_weak(tasmota),
-    /* K13  */  be_nested_str_weak(log),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K15  */  be_nested_str_weak(_X7C),
-    /* K16  */  be_const_int(2),
-    }),
-    be_str_weak(save_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x60100013,  //  0002  GETGBL	R4	G19
-      0x7C100000,  //  0003  CALL	R4	0
-      0x88140103,  //  0004  GETMBR	R5	R0	K3
-      0x98120405,  //  0005  SETIDX	R4	K2	R5
-      0x88140105,  //  0006  GETMBR	R5	R0	K5
-      0x98120805,  //  0007  SETIDX	R4	K4	R5
-      0x88140106,  //  0008  GETMBR	R5	R0	K6
-      0x98120C05,  //  0009  SETIDX	R4	K6	R5
-      0x7C080400,  //  000A  CALL	R2	2
-      0xA802000D,  //  000B  EXBLK	0	#001A
-      0xA40E0E00,  //  000C  IMPORT	R3	K7
-      0x60100011,  //  000D  GETGBL	R4	G17
-      0x88140108,  //  000E  GETMBR	R5	R0	K8
-      0x58180009,  //  000F  LDCONST	R6	K9
-      0x7C100400,  //  0010  CALL	R4	2
-      0x8C14090A,  //  0011  GETMET	R5	R4	K10
-      0x5C1C0400,  //  0012  MOVE	R7	R2
-      0x7C140400,  //  0013  CALL	R5	2
-      0x8C14090B,  //  0014  GETMET	R5	R4	K11
-      0x7C140200,  //  0015  CALL	R5	1
-      0xA8040001,  //  0016  EXBLK	1	1
-      0x80040400,  //  0017  RET	1	R2
-      0xA8040001,  //  0018  EXBLK	1	1
-      0x70020011,  //  0019  JMP		#002C
-      0xAC0C0002,  //  001A  CATCH	R3	0	2
-      0x7002000E,  //  001B  JMP		#002B
-      0xB8161800,  //  001C  GETNGBL	R5	K12
-      0x8C140B0D,  //  001D  GETMET	R5	R5	K13
-      0x601C0008,  //  001E  GETGBL	R7	G8
-      0x5C200600,  //  001F  MOVE	R8	R3
-      0x7C1C0200,  //  0020  CALL	R7	1
-      0x001E1C07,  //  0021  ADD	R7	K14	R7
-      0x001C0F0F,  //  0022  ADD	R7	R7	K15
-      0x60200008,  //  0023  GETGBL	R8	G8
-      0x5C240800,  //  0024  MOVE	R9	R4
-      0x7C200200,  //  0025  CALL	R8	1
-      0x001C0E08,  //  0026  ADD	R7	R7	R8
-      0x58200010,  //  0027  LDCONST	R8	K16
-      0x7C140600,  //  0028  CALL	R5	3
-      0x80040400,  //  0029  RET	1	R2
-      0x70020000,  //  002A  JMP		#002C
-      0xB0080000,  //  002B  RAISE	2	R0	R0
-      0x80000000,  //  002C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_remove_op_discovery
-********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(reverse),
-    /* K5   */  be_nested_str_weak(get_fabric_compressed),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_nested_str_weak(_X2D),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(eth),
-    /* K10  */  be_nested_str_weak(find),
-    /* K11  */  be_nested_str_weak(up),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(format),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_nested_str_weak(remove_service),
-    /* K17  */  be_nested_str_weak(_matter),
-    /* K18  */  be_nested_str_weak(_tcp),
-    /* K19  */  be_nested_str_weak(hostname_eth),
-    /* K20  */  be_nested_str_weak(wifi),
-    /* K21  */  be_nested_str_weak(hostname_wifi),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K23  */  be_nested_str_weak(_X7C),
-    }),
-    be_str_weak(mdns_remove_op_discovery),
-    &be_const_str_solidified,
-    ( &(const binstruction[81]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA802003B,  //  0002  EXBLK	0	#003F
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x7C100200,  //  0004  CALL	R4	1
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C140305,  //  0009  GETMET	R5	R1	K5
-      0x7C140200,  //  000A  CALL	R5	1
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
-      0x7C180200,  //  000C  CALL	R6	1
-      0x00180D07,  //  000D  ADD	R6	R6	K7
-      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
-      0x7C1C0200,  //  000F  CALL	R7	1
-      0x00180C07,  //  0010  ADD	R6	R6	R7
-      0xB81E1000,  //  0011  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
-      0x7C1C0200,  //  0013  CALL	R7	1
-      0x8C1C0F0A,  //  0014  GETMET	R7	R7	K10
-      0x5824000B,  //  0015  LDCONST	R9	K11
-      0x7C1C0400,  //  0016  CALL	R7	2
-      0x781E000E,  //  0017  JMPF	R7	#0027
-      0xB81E1000,  //  0018  GETNGBL	R7	K8
-      0x8C1C0F0C,  //  0019  GETMET	R7	R7	K12
-      0x8C24070D,  //  001A  GETMET	R9	R3	K13
-      0x582C000E,  //  001B  LDCONST	R11	K14
-      0x58300009,  //  001C  LDCONST	R12	K9
-      0x5C340C00,  //  001D  MOVE	R13	R6
-      0x7C240800,  //  001E  CALL	R9	4
-      0x5828000F,  //  001F  LDCONST	R10	K15
-      0x7C1C0600,  //  0020  CALL	R7	3
-      0x8C1C0510,  //  0021  GETMET	R7	R2	K16
-      0x58240011,  //  0022  LDCONST	R9	K17
-      0x58280012,  //  0023  LDCONST	R10	K18
-      0x5C2C0C00,  //  0024  MOVE	R11	R6
-      0x88300113,  //  0025  GETMBR	R12	R0	K19
-      0x7C1C0A00,  //  0026  CALL	R7	5
-      0xB81E1000,  //  0027  GETNGBL	R7	K8
-      0x8C1C0F14,  //  0028  GETMET	R7	R7	K20
-      0x7C1C0200,  //  0029  CALL	R7	1
-      0x8C1C0F0A,  //  002A  GETMET	R7	R7	K10
-      0x5824000B,  //  002B  LDCONST	R9	K11
-      0x7C1C0400,  //  002C  CALL	R7	2
-      0x781E000E,  //  002D  JMPF	R7	#003D
-      0xB81E1000,  //  002E  GETNGBL	R7	K8
-      0x8C1C0F0C,  //  002F  GETMET	R7	R7	K12
-      0x8C24070D,  //  0030  GETMET	R9	R3	K13
-      0x582C000E,  //  0031  LDCONST	R11	K14
-      0x58300014,  //  0032  LDCONST	R12	K20
-      0x5C340C00,  //  0033  MOVE	R13	R6
-      0x7C240800,  //  0034  CALL	R9	4
-      0x5828000F,  //  0035  LDCONST	R10	K15
-      0x7C1C0600,  //  0036  CALL	R7	3
-      0x8C1C0510,  //  0037  GETMET	R7	R2	K16
-      0x58240011,  //  0038  LDCONST	R9	K17
-      0x58280012,  //  0039  LDCONST	R10	K18
-      0x5C2C0C00,  //  003A  MOVE	R11	R6
-      0x88300115,  //  003B  GETMBR	R12	R0	K21
-      0x7C1C0A00,  //  003C  CALL	R7	5
-      0xA8040001,  //  003D  EXBLK	1	1
-      0x70020010,  //  003E  JMP		#0050
-      0xAC100002,  //  003F  CATCH	R4	0	2
-      0x7002000D,  //  0040  JMP		#004F
-      0xB81A1000,  //  0041  GETNGBL	R6	K8
-      0x8C180D0C,  //  0042  GETMET	R6	R6	K12
-      0x60200008,  //  0043  GETGBL	R8	G8
-      0x5C240800,  //  0044  MOVE	R9	R4
-      0x7C200200,  //  0045  CALL	R8	1
-      0x00222C08,  //  0046  ADD	R8	K22	R8
-      0x00201117,  //  0047  ADD	R8	R8	K23
-      0x60240008,  //  0048  GETGBL	R9	G8
-      0x5C280A00,  //  0049  MOVE	R10	R5
-      0x7C240200,  //  004A  CALL	R9	1
-      0x00201009,  //  004B  ADD	R8	R8	R9
-      0x5824000F,  //  004C  LDCONST	R9	K15
-      0x7C180600,  //  004D  CALL	R6	3
-      0x70020000,  //  004E  JMP		#0050
-      0xB0080000,  //  004F  RAISE	2	R0	R0
-      0x80000000,  //  0050  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_root_commissioning_open
-********************************************************************/
-be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
+be_local_closure(Matter_Device_event_fabrics_saved,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(commissioning_admin_fabric),
-    }),
-    be_str_weak(is_root_commissioning_open),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060003,  //  0003  JMPF	R1	#0008
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x4C080000,  //  0005  LDNIL	R2
-      0x1C040202,  //  0006  EQ	R1	R1	R2
-      0x74060000,  //  0007  JMPT	R1	#0009
-      0x50040001,  //  0008  LDBOOL	R1	0	1
-      0x50040200,  //  0009  LDBOOL	R1	1	0
-      0x80040200,  //  000A  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_commissioning_open
-********************************************************************/
-be_local_closure(Matter_Device_is_commissioning_open,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    }),
-    be_str_weak(is_commissioning_open),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_commissioning_complete
-********************************************************************/
-be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -3729,75 +4417,27 @@ be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X20Commissioning_X20complete_X20_X2A_X2A_X2A),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_nested_str_weak(stop_basic_commissioning),
-    }),
-    be_str_weak(start_commissioning_complete),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x58140003,  //  0003  LDCONST	R5	K3
-      0x7C080600,  //  0004  CALL	R2	3
-      0x8C080104,  //  0005  GETMET	R2	R0	K4
-      0x7C080200,  //  0006  CALL	R2	1
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_announce_op_discovery_all_fabrics
-********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(active_fabrics),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(mdns_announce_op_discovery),
-    /* K5   */  be_nested_str_weak(stop_iteration),
+    /* K1   */  be_nested_str_weak(count_active_fabrics),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(plugins_persist),
+    /* K4   */  be_nested_str_weak(save_param),
     }),
-    be_str_weak(mdns_announce_op_discovery_all_fabrics),
+    be_str_weak(event_fabrics_saved),
     &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000B,  //  0005  EXBLK	0	#0012
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x780E0005,  //  000A  JMPF	R3	#0011
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x780E0002,  //  000D  JMPF	R3	#0011
-      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x7001FFF3,  //  0011  JMP		#0006
-      0x58040005,  //  0012  LDCONST	R1	K5
-      0xAC040200,  //  0013  CATCH	R1	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x80000000,  //  0015  RET	0
+    ( &(const binstruction[12]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x24040302,  //  0003  GT	R1	R1	K2
+      0x78060005,  //  0004  JMPF	R1	#000B
+      0x88040103,  //  0005  GETMBR	R1	R0	K3
+      0x74060003,  //  0006  JMPT	R1	#000B
+      0x50040200,  //  0007  LDBOOL	R1	1	0
+      0x90020601,  //  0008  SETMBR	R0	K3	R1
+      0x8C040104,  //  0009  GETMET	R1	R0	K4
+      0x7C040200,  //  000A  CALL	R1	1
+      0x80000000,  //  000B  RET	0
     })
   )
 );
@@ -3805,346 +4445,11 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name
 
 
 /********************************************************************
-** Solidified function: MtrJoin
+** Solidified function: k2l_num
 ********************************************************************/
-be_local_closure(Matter_Device_MtrJoin,   /* name */
+be_local_closure(Matter_Device_k2l_num,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K1   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(resp_cmnd_done),
-    }),
-    be_str_weak(MtrJoin),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x60140009,  //  0000  GETGBL	R5	G9
-      0x5C180600,  //  0001  MOVE	R6	R3
-      0x7C140200,  //  0002  CALL	R5	1
-      0x78160002,  //  0003  JMPF	R5	#0007
-      0x8C180100,  //  0004  GETMET	R6	R0	K0
-      0x7C180200,  //  0005  CALL	R6	1
-      0x70020001,  //  0006  JMP		#0009
-      0x8C180101,  //  0007  GETMET	R6	R0	K1
-      0x7C180200,  //  0008  CALL	R6	1
-      0xB81A0400,  //  0009  GETNGBL	R6	K2
-      0x8C180D03,  //  000A  GETMET	R6	R6	K3
-      0x7C180200,  //  000B  CALL	R6	1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(Matter_Device_invoke_request,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(plugins),
-    /* K3   */  be_nested_str_weak(invoke_request),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(status),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
-    }),
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58100000,  //  0000  LDCONST	R4	K0
-      0x88140701,  //  0001  GETMBR	R5	R3	K1
-      0x6018000C,  //  0002  GETGBL	R6	G12
-      0x881C0102,  //  0003  GETMBR	R7	R0	K2
-      0x7C180200,  //  0004  CALL	R6	1
-      0x14180806,  //  0005  LT	R6	R4	R6
-      0x781A000C,  //  0006  JMPF	R6	#0014
-      0x88180102,  //  0007  GETMBR	R6	R0	K2
-      0x94180C04,  //  0008  GETIDX	R6	R6	R4
-      0x881C0D01,  //  0009  GETMBR	R7	R6	K1
-      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0D03,  //  000C  GETMET	R7	R6	K3
-      0x5C240200,  //  000D  MOVE	R9	R1
-      0x5C280400,  //  000E  MOVE	R10	R2
-      0x5C2C0600,  //  000F  MOVE	R11	R3
-      0x7C1C0800,  //  0010  CALL	R7	4
-      0x80040E00,  //  0011  RET	1	R7
-      0x00100904,  //  0012  ADD	R4	R4	K4
-      0x7001FFED,  //  0013  JMP		#0002
-      0xB81A0C00,  //  0014  GETNGBL	R6	K6
-      0x88180D07,  //  0015  GETMBR	R6	R6	K7
-      0x900E0A06,  //  0016  SETMBR	R3	K5	R6
-      0x80000000,  //  0017  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: compute_manual_pairing_code
-********************************************************************/
-be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(root_discriminator),
-    /* K2   */  be_nested_str_weak(root_passcode),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(_X251i_X2505i_X2504i),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(Verhoeff),
-    /* K7   */  be_nested_str_weak(checksum),
-    }),
-    be_str_weak(compute_manual_pairing_code),
-    &be_const_str_solidified,
-    ( &(const binstruction[31]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x540E0FFE,  //  0002  LDINT	R3	4095
-      0x2C080403,  //  0003  AND	R2	R2	R3
-      0x540E0009,  //  0004  LDINT	R3	10
-      0x3C080403,  //  0005  SHR	R2	R2	R3
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x541202FF,  //  0007  LDINT	R4	768
-      0x2C0C0604,  //  0008  AND	R3	R3	R4
-      0x54120005,  //  0009  LDINT	R4	6
-      0x380C0604,  //  000A  SHL	R3	R3	R4
-      0x88100102,  //  000B  GETMBR	R4	R0	K2
-      0x54163FFE,  //  000C  LDINT	R5	16383
-      0x2C100805,  //  000D  AND	R4	R4	R5
-      0x300C0604,  //  000E  OR	R3	R3	R4
-      0x88100102,  //  000F  GETMBR	R4	R0	K2
-      0x5416000D,  //  0010  LDINT	R5	14
-      0x3C100805,  //  0011  SHR	R4	R4	R5
-      0x8C140303,  //  0012  GETMET	R5	R1	K3
-      0x581C0004,  //  0013  LDCONST	R7	K4
-      0x5C200400,  //  0014  MOVE	R8	R2
-      0x5C240600,  //  0015  MOVE	R9	R3
-      0x5C280800,  //  0016  MOVE	R10	R4
-      0x7C140A00,  //  0017  CALL	R5	5
-      0xB81A0A00,  //  0018  GETNGBL	R6	K5
-      0x88180D06,  //  0019  GETMBR	R6	R6	K6
-      0x8C180D07,  //  001A  GETMET	R6	R6	K7
-      0x5C200A00,  //  001B  MOVE	R8	R5
-      0x7C180400,  //  001C  CALL	R6	2
-      0x00140A06,  //  001D  ADD	R5	R5	R6
-      0x80040A00,  //  001E  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_announce_op_discovery
-********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
-  be_nested_proto(
-    15,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(reverse),
-    /* K5   */  be_nested_str_weak(get_fabric_compressed),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_nested_str_weak(_X2D),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(eth),
-    /* K13  */  be_nested_str_weak(find),
-    /* K14  */  be_nested_str_weak(up),
-    /* K15  */  be_nested_str_weak(format),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K17  */  be_nested_str_weak(hostname_eth),
-    /* K18  */  be_const_int(3),
-    /* K19  */  be_nested_str_weak(add_service),
-    /* K20  */  be_nested_str_weak(_matter),
-    /* K21  */  be_nested_str_weak(_tcp),
-    /* K22  */  be_nested_str_weak(_I),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
-    /* K24  */  be_nested_str_weak(add_subtype),
-    /* K25  */  be_nested_str_weak(wifi),
-    /* K26  */  be_nested_str_weak(hostname_wifi),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K28  */  be_nested_str_weak(_X7C),
-    }),
-    be_str_weak(mdns_announce_op_discovery),
-    &be_const_str_solidified,
-    ( &(const binstruction[122]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA8020064,  //  0002  EXBLK	0	#0068
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x7C100200,  //  0004  CALL	R4	1
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C140305,  //  0009  GETMET	R5	R1	K5
-      0x7C140200,  //  000A  CALL	R5	1
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
-      0x7C180200,  //  000C  CALL	R6	1
-      0x00180D07,  //  000D  ADD	R6	R6	K7
-      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
-      0x7C1C0200,  //  000F  CALL	R7	1
-      0x00180C07,  //  0010  ADD	R6	R6	R7
-      0xB81E1000,  //  0011  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
-      0x00261406,  //  0013  ADD	R9	K10	R6
-      0x5828000B,  //  0014  LDCONST	R10	K11
-      0x7C1C0600,  //  0015  CALL	R7	3
-      0xB81E1000,  //  0016  GETNGBL	R7	K8
-      0x8C1C0F0C,  //  0017  GETMET	R7	R7	K12
-      0x7C1C0200,  //  0018  CALL	R7	1
-      0x8C1C0F0D,  //  0019  GETMET	R7	R7	K13
-      0x5824000E,  //  001A  LDCONST	R9	K14
-      0x7C1C0400,  //  001B  CALL	R7	2
-      0x781E0020,  //  001C  JMPF	R7	#003E
-      0xB81E1000,  //  001D  GETNGBL	R7	K8
-      0x8C1C0F09,  //  001E  GETMET	R7	R7	K9
-      0x8C24070F,  //  001F  GETMET	R9	R3	K15
-      0x582C0010,  //  0020  LDCONST	R11	K16
-      0x5830000C,  //  0021  LDCONST	R12	K12
-      0x5C340C00,  //  0022  MOVE	R13	R6
-      0x88380111,  //  0023  GETMBR	R14	R0	K17
-      0x7C240A00,  //  0024  CALL	R9	5
-      0x58280012,  //  0025  LDCONST	R10	K18
-      0x7C1C0600,  //  0026  CALL	R7	3
-      0x8C1C0513,  //  0027  GETMET	R7	R2	K19
-      0x58240014,  //  0028  LDCONST	R9	K20
-      0x58280015,  //  0029  LDCONST	R10	K21
-      0x542E15A3,  //  002A  LDINT	R11	5540
-      0x4C300000,  //  002B  LDNIL	R12
-      0x5C340C00,  //  002C  MOVE	R13	R6
-      0x88380111,  //  002D  GETMBR	R14	R0	K17
-      0x7C1C0E00,  //  002E  CALL	R7	7
-      0x8C1C0B06,  //  002F  GETMET	R7	R5	K6
-      0x7C1C0200,  //  0030  CALL	R7	1
-      0x001E2C07,  //  0031  ADD	R7	K22	R7
-      0xB8221000,  //  0032  GETNGBL	R8	K8
-      0x8C201109,  //  0033  GETMET	R8	R8	K9
-      0x002A2E07,  //  0034  ADD	R10	K23	R7
-      0x582C0012,  //  0035  LDCONST	R11	K18
-      0x7C200600,  //  0036  CALL	R8	3
-      0x8C200518,  //  0037  GETMET	R8	R2	K24
-      0x58280014,  //  0038  LDCONST	R10	K20
-      0x582C0015,  //  0039  LDCONST	R11	K21
-      0x5C300C00,  //  003A  MOVE	R12	R6
-      0x88340111,  //  003B  GETMBR	R13	R0	K17
-      0x5C380E00,  //  003C  MOVE	R14	R7
-      0x7C200C00,  //  003D  CALL	R8	6
-      0xB81E1000,  //  003E  GETNGBL	R7	K8
-      0x8C1C0F19,  //  003F  GETMET	R7	R7	K25
-      0x7C1C0200,  //  0040  CALL	R7	1
-      0x8C1C0F0D,  //  0041  GETMET	R7	R7	K13
-      0x5824000E,  //  0042  LDCONST	R9	K14
-      0x7C1C0400,  //  0043  CALL	R7	2
-      0x781E0020,  //  0044  JMPF	R7	#0066
-      0xB81E1000,  //  0045  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0046  GETMET	R7	R7	K9
-      0x8C24070F,  //  0047  GETMET	R9	R3	K15
-      0x582C0010,  //  0048  LDCONST	R11	K16
-      0x58300019,  //  0049  LDCONST	R12	K25
-      0x5C340C00,  //  004A  MOVE	R13	R6
-      0x8838011A,  //  004B  GETMBR	R14	R0	K26
-      0x7C240A00,  //  004C  CALL	R9	5
-      0x58280012,  //  004D  LDCONST	R10	K18
-      0x7C1C0600,  //  004E  CALL	R7	3
-      0x8C1C0513,  //  004F  GETMET	R7	R2	K19
-      0x58240014,  //  0050  LDCONST	R9	K20
-      0x58280015,  //  0051  LDCONST	R10	K21
-      0x542E15A3,  //  0052  LDINT	R11	5540
-      0x4C300000,  //  0053  LDNIL	R12
-      0x5C340C00,  //  0054  MOVE	R13	R6
-      0x8838011A,  //  0055  GETMBR	R14	R0	K26
-      0x7C1C0E00,  //  0056  CALL	R7	7
-      0x8C1C0B06,  //  0057  GETMET	R7	R5	K6
-      0x7C1C0200,  //  0058  CALL	R7	1
-      0x001E2C07,  //  0059  ADD	R7	K22	R7
-      0xB8221000,  //  005A  GETNGBL	R8	K8
-      0x8C201109,  //  005B  GETMET	R8	R8	K9
-      0x002A2E07,  //  005C  ADD	R10	K23	R7
-      0x582C0012,  //  005D  LDCONST	R11	K18
-      0x7C200600,  //  005E  CALL	R8	3
-      0x8C200518,  //  005F  GETMET	R8	R2	K24
-      0x58280014,  //  0060  LDCONST	R10	K20
-      0x582C0015,  //  0061  LDCONST	R11	K21
-      0x5C300C00,  //  0062  MOVE	R12	R6
-      0x8834011A,  //  0063  GETMBR	R13	R0	K26
-      0x5C380E00,  //  0064  MOVE	R14	R7
-      0x7C200C00,  //  0065  CALL	R8	6
-      0xA8040001,  //  0066  EXBLK	1	1
-      0x70020010,  //  0067  JMP		#0079
-      0xAC100002,  //  0068  CATCH	R4	0	2
-      0x7002000D,  //  0069  JMP		#0078
-      0xB81A1000,  //  006A  GETNGBL	R6	K8
-      0x8C180D09,  //  006B  GETMET	R6	R6	K9
-      0x60200008,  //  006C  GETGBL	R8	G8
-      0x5C240800,  //  006D  MOVE	R9	R4
-      0x7C200200,  //  006E  CALL	R8	1
-      0x00223608,  //  006F  ADD	R8	K27	R8
-      0x0020111C,  //  0070  ADD	R8	R8	K28
-      0x60240008,  //  0071  GETGBL	R9	G8
-      0x5C280A00,  //  0072  MOVE	R10	R5
-      0x7C240200,  //  0073  CALL	R9	1
-      0x00201009,  //  0074  ADD	R8	R8	R9
-      0x5824000B,  //  0075  LDCONST	R9	K11
-      0x7C180600,  //  0076  CALL	R6	3
-      0x70020000,  //  0077  JMP		#0079
-      0xB0080000,  //  0078  RAISE	2	R0	R0
-      0x80000000,  //  0079  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: k2l
-********************************************************************/
-be_local_closure(Matter_Device_k2l,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
+    9,                          /* nstack */
     1,                          /* argc */
     4,                          /* varg */
     0,                          /* has upvals */
@@ -4160,9 +4465,9 @@ be_local_closure(Matter_Device_k2l,   /* name */
     /* K4   */  be_const_int(1),
     /* K5   */  be_const_int(0),
     }),
-    be_str_weak(k2l),
+    be_str_weak(k2l_num),
     &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
+    ( &(const binstruction[52]) {  /* code */
       0x58040000,  //  0000  LDCONST	R1	K0
       0x60080012,  //  0001  GETGBL	R2	G18
       0x7C080000,  //  0002  CALL	R2	0
@@ -4174,45 +4479,258 @@ be_local_closure(Matter_Device_k2l,   /* name */
       0x8C100101,  //  0008  GETMET	R4	R0	K1
       0x7C100200,  //  0009  CALL	R4	1
       0x7C0C0200,  //  000A  CALL	R3	1
-      0xA8020005,  //  000B  EXBLK	0	#0012
+      0xA8020007,  //  000B  EXBLK	0	#0014
       0x5C100600,  //  000C  MOVE	R4	R3
       0x7C100000,  //  000D  CALL	R4	0
       0x8C140502,  //  000E  GETMET	R5	R2	K2
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x7C140400,  //  0010  CALL	R5	2
-      0x7001FFF9,  //  0011  JMP		#000C
-      0x580C0003,  //  0012  LDCONST	R3	K3
-      0xAC0C0200,  //  0013  CATCH	R3	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x600C0010,  //  0015  GETGBL	R3	G16
-      0x6010000C,  //  0016  GETGBL	R4	G12
-      0x5C140400,  //  0017  MOVE	R5	R2
-      0x7C100200,  //  0018  CALL	R4	1
-      0x04100904,  //  0019  SUB	R4	R4	K4
-      0x40120804,  //  001A  CONNECT	R4	K4	R4
-      0x7C0C0200,  //  001B  CALL	R3	1
-      0xA8020010,  //  001C  EXBLK	0	#002E
-      0x5C100600,  //  001D  MOVE	R4	R3
-      0x7C100000,  //  001E  CALL	R4	0
-      0x94140404,  //  001F  GETIDX	R5	R2	R4
-      0x5C180800,  //  0020  MOVE	R6	R4
-      0x241C0D05,  //  0021  GT	R7	R6	K5
-      0x781E0008,  //  0022  JMPF	R7	#002C
-      0x041C0D04,  //  0023  SUB	R7	R6	K4
-      0x941C0407,  //  0024  GETIDX	R7	R2	R7
-      0x241C0E05,  //  0025  GT	R7	R7	R5
-      0x781E0004,  //  0026  JMPF	R7	#002C
-      0x041C0D04,  //  0027  SUB	R7	R6	K4
-      0x941C0407,  //  0028  GETIDX	R7	R2	R7
-      0x98080C07,  //  0029  SETIDX	R2	R6	R7
-      0x04180D04,  //  002A  SUB	R6	R6	K4
-      0x7001FFF4,  //  002B  JMP		#0021
-      0x98080C05,  //  002C  SETIDX	R2	R6	R5
-      0x7001FFEE,  //  002D  JMP		#001D
-      0x580C0003,  //  002E  LDCONST	R3	K3
-      0xAC0C0200,  //  002F  CATCH	R3	1	0
-      0xB0080000,  //  0030  RAISE	2	R0	R0
-      0x80040400,  //  0031  RET	1	R2
+      0x601C0009,  //  000F  GETGBL	R7	G9
+      0x5C200800,  //  0010  MOVE	R8	R4
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x7C140400,  //  0012  CALL	R5	2
+      0x7001FFF7,  //  0013  JMP		#000C
+      0x580C0003,  //  0014  LDCONST	R3	K3
+      0xAC0C0200,  //  0015  CATCH	R3	1	0
+      0xB0080000,  //  0016  RAISE	2	R0	R0
+      0x600C0010,  //  0017  GETGBL	R3	G16
+      0x6010000C,  //  0018  GETGBL	R4	G12
+      0x5C140400,  //  0019  MOVE	R5	R2
+      0x7C100200,  //  001A  CALL	R4	1
+      0x04100904,  //  001B  SUB	R4	R4	K4
+      0x40120804,  //  001C  CONNECT	R4	K4	R4
+      0x7C0C0200,  //  001D  CALL	R3	1
+      0xA8020010,  //  001E  EXBLK	0	#0030
+      0x5C100600,  //  001F  MOVE	R4	R3
+      0x7C100000,  //  0020  CALL	R4	0
+      0x94140404,  //  0021  GETIDX	R5	R2	R4
+      0x5C180800,  //  0022  MOVE	R6	R4
+      0x241C0D05,  //  0023  GT	R7	R6	K5
+      0x781E0008,  //  0024  JMPF	R7	#002E
+      0x041C0D04,  //  0025  SUB	R7	R6	K4
+      0x941C0407,  //  0026  GETIDX	R7	R2	R7
+      0x241C0E05,  //  0027  GT	R7	R7	R5
+      0x781E0004,  //  0028  JMPF	R7	#002E
+      0x041C0D04,  //  0029  SUB	R7	R6	K4
+      0x941C0407,  //  002A  GETIDX	R7	R2	R7
+      0x98080C07,  //  002B  SETIDX	R2	R6	R7
+      0x04180D04,  //  002C  SUB	R6	R6	K4
+      0x7001FFF4,  //  002D  JMP		#0023
+      0x98080C05,  //  002E  SETIDX	R2	R6	R5
+      0x7001FFEE,  //  002F  JMP		#001F
+      0x580C0003,  //  0030  LDCONST	R3	K3
+      0xAC0C0200,  //  0031  CATCH	R3	1	0
+      0xB0080000,  //  0032  RAISE	2	R0	R0
+      0x80040400,  //  0033  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_remove_PASE
+********************************************************************/
+be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[22]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(mdns_pase_eth),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(format),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eremove_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
+    /* K7   */  be_nested_str_weak(_matterc),
+    /* K8   */  be_nested_str_weak(_udp),
+    /* K9   */  be_nested_str_weak(commissioning_instance_eth),
+    /* K10  */  be_nested_str_weak(hostname_eth),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
+    /* K13  */  be_nested_str_weak(eth),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(remove_service),
+    /* K16  */  be_nested_str_weak(mdns_pase_wifi),
+    /* K17  */  be_nested_str_weak(commissioning_instance_wifi),
+    /* K18  */  be_nested_str_weak(hostname_wifi),
+    /* K19  */  be_nested_str_weak(wifi),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K21  */  be_nested_str_weak(_X7C),
+    }),
+    be_str_weak(mdns_remove_PASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[83]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xA802003D,  //  0002  EXBLK	0	#0041
+      0x880C0102,  //  0003  GETMBR	R3	R0	K2
+      0x780E001B,  //  0004  JMPF	R3	#0021
+      0xB80E0600,  //  0005  GETNGBL	R3	K3
+      0x8C0C0704,  //  0006  GETMET	R3	R3	K4
+      0x8C140505,  //  0007  GETMET	R5	R2	K5
+      0x581C0006,  //  0008  LDCONST	R7	K6
+      0x58200007,  //  0009  LDCONST	R8	K7
+      0x58240008,  //  000A  LDCONST	R9	K8
+      0x88280109,  //  000B  GETMBR	R10	R0	K9
+      0x882C010A,  //  000C  GETMBR	R11	R0	K10
+      0x7C140C00,  //  000D  CALL	R5	6
+      0x5818000B,  //  000E  LDCONST	R6	K11
+      0x7C0C0600,  //  000F  CALL	R3	3
+      0xB80E0600,  //  0010  GETNGBL	R3	K3
+      0x8C0C0704,  //  0011  GETMET	R3	R3	K4
+      0x8C140505,  //  0012  GETMET	R5	R2	K5
+      0x581C000C,  //  0013  LDCONST	R7	K12
+      0x5820000D,  //  0014  LDCONST	R8	K13
+      0x88240109,  //  0015  GETMBR	R9	R0	K9
+      0x7C140800,  //  0016  CALL	R5	4
+      0x5818000E,  //  0017  LDCONST	R6	K14
+      0x7C0C0600,  //  0018  CALL	R3	3
+      0x500C0000,  //  0019  LDBOOL	R3	0	0
+      0x90020403,  //  001A  SETMBR	R0	K2	R3
+      0x8C0C030F,  //  001B  GETMET	R3	R1	K15
+      0x58140007,  //  001C  LDCONST	R5	K7
+      0x58180008,  //  001D  LDCONST	R6	K8
+      0x881C0109,  //  001E  GETMBR	R7	R0	K9
+      0x8820010A,  //  001F  GETMBR	R8	R0	K10
+      0x7C0C0A00,  //  0020  CALL	R3	5
+      0x880C0110,  //  0021  GETMBR	R3	R0	K16
+      0x780E001B,  //  0022  JMPF	R3	#003F
+      0xB80E0600,  //  0023  GETNGBL	R3	K3
+      0x8C0C0704,  //  0024  GETMET	R3	R3	K4
+      0x8C140505,  //  0025  GETMET	R5	R2	K5
+      0x581C0006,  //  0026  LDCONST	R7	K6
+      0x58200007,  //  0027  LDCONST	R8	K7
+      0x58240008,  //  0028  LDCONST	R9	K8
+      0x88280111,  //  0029  GETMBR	R10	R0	K17
+      0x882C0112,  //  002A  GETMBR	R11	R0	K18
+      0x7C140C00,  //  002B  CALL	R5	6
+      0x5818000B,  //  002C  LDCONST	R6	K11
+      0x7C0C0600,  //  002D  CALL	R3	3
+      0xB80E0600,  //  002E  GETNGBL	R3	K3
+      0x8C0C0704,  //  002F  GETMET	R3	R3	K4
+      0x8C140505,  //  0030  GETMET	R5	R2	K5
+      0x581C000C,  //  0031  LDCONST	R7	K12
+      0x58200013,  //  0032  LDCONST	R8	K19
+      0x88240111,  //  0033  GETMBR	R9	R0	K17
+      0x7C140800,  //  0034  CALL	R5	4
+      0x5818000E,  //  0035  LDCONST	R6	K14
+      0x7C0C0600,  //  0036  CALL	R3	3
+      0x500C0000,  //  0037  LDBOOL	R3	0	0
+      0x90022003,  //  0038  SETMBR	R0	K16	R3
+      0x8C0C030F,  //  0039  GETMET	R3	R1	K15
+      0x58140007,  //  003A  LDCONST	R5	K7
+      0x58180008,  //  003B  LDCONST	R6	K8
+      0x881C0111,  //  003C  GETMBR	R7	R0	K17
+      0x88200112,  //  003D  GETMBR	R8	R0	K18
+      0x7C0C0A00,  //  003E  CALL	R3	5
+      0xA8040001,  //  003F  EXBLK	1	1
+      0x70020010,  //  0040  JMP		#0052
+      0xAC0C0002,  //  0041  CATCH	R3	0	2
+      0x7002000D,  //  0042  JMP		#0051
+      0xB8160600,  //  0043  GETNGBL	R5	K3
+      0x8C140B04,  //  0044  GETMET	R5	R5	K4
+      0x601C0008,  //  0045  GETGBL	R7	G8
+      0x5C200600,  //  0046  MOVE	R8	R3
+      0x7C1C0200,  //  0047  CALL	R7	1
+      0x001E2807,  //  0048  ADD	R7	K20	R7
+      0x001C0F15,  //  0049  ADD	R7	R7	K21
+      0x60200008,  //  004A  GETGBL	R8	G8
+      0x5C240800,  //  004B  MOVE	R9	R4
+      0x7C200200,  //  004C  CALL	R8	1
+      0x001C0E08,  //  004D  ADD	R7	R7	R8
+      0x5820000E,  //  004E  LDCONST	R8	K14
+      0x7C140600,  //  004F  CALL	R5	3
+      0x70020000,  //  0050  JMP		#0052
+      0xB0080000,  //  0051  RAISE	2	R0	R0
+      0x80000000,  //  0052  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sort_distinct
+********************************************************************/
+be_local_closure(Matter_Device_sort_distinct,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Device),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_nested_str_weak(remove),
+    }),
+    be_str_weak(sort_distinct),
+    &be_const_str_solidified,
+    ( &(const binstruction[53]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x60080010,  //  0001  GETGBL	R2	G16
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x040C0701,  //  0005  SUB	R3	R3	K1
+      0x400E0203,  //  0006  CONNECT	R3	K1	R3
+      0x7C080200,  //  0007  CALL	R2	1
+      0xA8020010,  //  0008  EXBLK	0	#001A
+      0x5C0C0400,  //  0009  MOVE	R3	R2
+      0x7C0C0000,  //  000A  CALL	R3	0
+      0x94100003,  //  000B  GETIDX	R4	R0	R3
+      0x5C140600,  //  000C  MOVE	R5	R3
+      0x24180B02,  //  000D  GT	R6	R5	K2
+      0x781A0008,  //  000E  JMPF	R6	#0018
+      0x04180B01,  //  000F  SUB	R6	R5	K1
+      0x94180006,  //  0010  GETIDX	R6	R0	R6
+      0x24180C04,  //  0011  GT	R6	R6	R4
+      0x781A0004,  //  0012  JMPF	R6	#0018
+      0x04180B01,  //  0013  SUB	R6	R5	K1
+      0x94180006,  //  0014  GETIDX	R6	R0	R6
+      0x98000A06,  //  0015  SETIDX	R0	R5	R6
+      0x04140B01,  //  0016  SUB	R5	R5	K1
+      0x7001FFF4,  //  0017  JMP		#000D
+      0x98000A04,  //  0018  SETIDX	R0	R5	R4
+      0x7001FFEE,  //  0019  JMP		#0009
+      0x58080003,  //  001A  LDCONST	R2	K3
+      0xAC080200,  //  001B  CATCH	R2	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x58080001,  //  001D  LDCONST	R2	K1
+      0x600C000C,  //  001E  GETGBL	R3	G12
+      0x5C100000,  //  001F  MOVE	R4	R0
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x180C0701,  //  0021  LE	R3	R3	K1
+      0x780E0000,  //  0022  JMPF	R3	#0024
+      0x80040000,  //  0023  RET	1	R0
+      0x940C0102,  //  0024  GETIDX	R3	R0	K2
+      0x6010000C,  //  0025  GETGBL	R4	G12
+      0x5C140000,  //  0026  MOVE	R5	R0
+      0x7C100200,  //  0027  CALL	R4	1
+      0x14100404,  //  0028  LT	R4	R2	R4
+      0x78120009,  //  0029  JMPF	R4	#0034
+      0x94100002,  //  002A  GETIDX	R4	R0	R2
+      0x1C100803,  //  002B  EQ	R4	R4	R3
+      0x78120003,  //  002C  JMPF	R4	#0031
+      0x8C100104,  //  002D  GETMET	R4	R0	K4
+      0x5C180400,  //  002E  MOVE	R6	R2
+      0x7C100400,  //  002F  CALL	R4	2
+      0x70020001,  //  0030  JMP		#0033
+      0x940C0002,  //  0031  GETIDX	R3	R0	R2
+      0x00080501,  //  0032  ADD	R2	R2	K1
+      0x7001FFF0,  //  0033  JMP		#0025
+      0x80040000,  //  0034  RET	1	R0
     })
   )
 );
@@ -4223,89 +4741,98 @@ be_local_closure(Matter_Device_k2l,   /* name */
 ** Solidified class: Matter_Device
 ********************************************************************/
 be_local_class(Matter_Device,
-    28,
+    30,
     NULL,
-    be_nested_map(79,
+    be_nested_map(88,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(commissioning_w0, 50), be_const_var(10) },
-        { be_const_key_weak(start_operational_discovery, 13), be_const_closure(Matter_Device_start_operational_discovery_closure) },
-        { be_const_key_weak(plugins, -1), be_const_var(1) },
-        { be_const_key_weak(k2l, -1), be_const_static_closure(Matter_Device_k2l_closure) },
-        { be_const_key_weak(mdns_remove_PASE, 72), be_const_closure(Matter_Device_mdns_remove_PASE_closure) },
-        { be_const_key_weak(message_handler, -1), be_const_var(3) },
-        { be_const_key_weak(mdns_announce_op_discovery, 43), be_const_closure(Matter_Device_mdns_announce_op_discovery_closure) },
-        { be_const_key_weak(save_before_restart, -1), be_const_closure(Matter_Device_save_before_restart_closure) },
-        { be_const_key_weak(_start_udp, -1), be_const_closure(Matter_Device__start_udp_closure) },
-        { be_const_key_weak(commissioning_open, -1), be_const_var(6) },
-        { be_const_key_weak(root_L, 45), be_const_var(27) },
-        { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
-        { be_const_key_weak(root_passcode, -1), be_const_var(22) },
-        { be_const_key_weak(compute_manual_pairing_code, 77), be_const_closure(Matter_Device_compute_manual_pairing_code_closure) },
-        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
-        { be_const_key_weak(start_basic_commissioning, -1), be_const_closure(Matter_Device_start_basic_commissioning_closure) },
-        { be_const_key_weak(remove_fabric, -1), be_const_closure(Matter_Device_remove_fabric_closure) },
-        { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Device_attribute_updated_closure) },
-        { be_const_key_weak(_mdns_announce_hostname, 31), be_const_closure(Matter_Device__mdns_announce_hostname_closure) },
-        { be_const_key_weak(autoconf_device, -1), be_const_closure(Matter_Device_autoconf_device_closure) },
-        { be_const_key_weak(_trigger_read_sensors, -1), be_const_closure(Matter_Device__trigger_read_sensors_closure) },
-        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(Matter_Device_get_active_endpoints_closure) },
-        { be_const_key_weak(commissioning_admin_fabric, -1), be_const_var(12) },
-        { be_const_key_weak(msg_send, -1), be_const_closure(Matter_Device_msg_send_closure) },
-        { be_const_key_weak(hostname_wifi, 32), be_const_var(15) },
-        { be_const_key_weak(productid, -1), be_const_var(18) },
-        { be_const_key_weak(msg_received, -1), be_const_closure(Matter_Device_msg_received_closure) },
-        { be_const_key_weak(commissioning_discriminator, -1), be_const_var(8) },
-        { be_const_key_weak(FILENAME, 46), be_nested_str_weak(_matter_device_X2Ejson) },
-        { be_const_key_weak(commissioning_instance_eth, 53), be_const_var(14) },
-        { be_const_key_weak(start, 75), be_const_closure(Matter_Device_start_closure) },
-        { be_const_key_weak(compute_qrcode_content, -1), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
-        { be_const_key_weak(MtrJoin, 33), be_const_closure(Matter_Device_MtrJoin_closure) },
-        { be_const_key_weak(stop, -1), be_const_closure(Matter_Device_stop_closure) },
-        { be_const_key_weak(root_w0, -1), be_const_var(26) },
-        { be_const_key_weak(ui, -1), be_const_var(5) },
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Device_every_second_closure) },
-        { be_const_key_weak(start_root_basic_commissioning, -1), be_const_closure(Matter_Device_start_root_basic_commissioning_closure) },
-        { be_const_key_weak(start_mdns_announce_hostnames, -1), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Device_init_closure) },
+        { be_const_key_weak(root_L, -1), be_const_var(29) },
         { be_const_key_weak(_compute_pbkdf, -1), be_const_closure(Matter_Device__compute_pbkdf_closure) },
+        { be_const_key_weak(_mdns_announce_hostname, -1), be_const_closure(Matter_Device__mdns_announce_hostname_closure) },
+        { be_const_key_weak(compute_qrcode_content, -1), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
+        { be_const_key_weak(mdns_remove_PASE, 51), be_const_closure(Matter_Device_mdns_remove_PASE_closure) },
+        { be_const_key_weak(stop, 56), be_const_closure(Matter_Device_stop_closure) },
+        { be_const_key_weak(udp_server, 0), be_const_var(4) },
+        { be_const_key_weak(MtrJoin, -1), be_const_closure(Matter_Device_MtrJoin_closure) },
+        { be_const_key_weak(commissioning_discriminator, -1), be_const_var(10) },
+        { be_const_key_weak(msg_send, 26), be_const_closure(Matter_Device_msg_send_closure) },
+        { be_const_key_weak(save_param, 4), be_const_closure(Matter_Device_save_param_closure) },
+        { be_const_key_weak(mdns_pase_eth, -1), be_const_var(21) },
+        { be_const_key_weak(hostname_eth, -1), be_const_var(18) },
+        { be_const_key_weak(productid, -1), be_const_var(20) },
+        { be_const_key_weak(vendorid, 69), be_const_var(19) },
+        { be_const_key_weak(start_commissioning_complete, 3), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
+        { be_const_key_weak(commissioning_salt, -1), be_const_var(11) },
+        { be_const_key_weak(commissioning_open, -1), be_const_var(8) },
+        { be_const_key_weak(compute_manual_pairing_code, -1), be_const_closure(Matter_Device_compute_manual_pairing_code_closure) },
+        { be_const_key_weak(commissioning_L, -1), be_const_var(13) },
+        { be_const_key_weak(hostname_wifi, 85), be_const_var(17) },
+        { be_const_key_weak(start_mdns_announce_hostnames, -1), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
+        { be_const_key_weak(root_passcode, 7), be_const_var(24) },
         { be_const_key_weak(process_attribute_expansion, -1), be_const_closure(Matter_Device_process_attribute_expansion_closure) },
-        { be_const_key_weak(PASE_TIMEOUT, 36), be_const_int(600) },
-        { be_const_key_weak(mdns_announce_PASE, 40), be_const_closure(Matter_Device_mdns_announce_PASE_closure) },
-        { be_const_key_weak(mdns_remove_op_discovery, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_closure) },
-        { be_const_key_weak(commissioning_salt, 39), be_const_var(9) },
-        { be_const_key_weak(stop_basic_commissioning, -1), be_const_closure(Matter_Device_stop_basic_commissioning_closure) },
-        { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_Device_every_250ms_closure) },
-        { be_const_key_weak(root_salt, 41), be_const_var(25) },
-        { be_const_key_weak(commissioning_iterations, 6), be_const_var(7) },
-        { be_const_key_weak(received_ack, -1), be_const_closure(Matter_Device_received_ack_closure) },
-        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
-        { be_const_key_weak(commissioning_L, -1), be_const_var(11) },
-        { be_const_key_weak(root_discriminator, -1), be_const_var(21) },
-        { be_const_key_weak(ipv4only, -1), be_const_var(23) },
-        { be_const_key_weak(load_param, 37), be_const_closure(Matter_Device_load_param_closure) },
-        { be_const_key_weak(start_operational_discovery_deferred, 55), be_const_closure(Matter_Device_start_operational_discovery_deferred_closure) },
-        { be_const_key_weak(sessions, -1), be_const_var(4) },
-        { be_const_key_weak(mdns_remove_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics_closure) },
-        { be_const_key_weak(register_commands, 52), be_const_closure(Matter_Device_register_commands_closure) },
-        { be_const_key_weak(commissioning_instance_wifi, -1), be_const_var(13) },
-        { be_const_key_weak(save_param, -1), be_const_closure(Matter_Device_save_param_closure) },
-        { be_const_key_weak(PBKDF_ITERATIONS, -1), be_const_int(1000) },
-        { be_const_key_weak(_init_basic_commissioning, 44), be_const_closure(Matter_Device__init_basic_commissioning_closure) },
+        { be_const_key_weak(received_ack, 12), be_const_closure(Matter_Device_received_ack_closure) },
+        { be_const_key_weak(event_fabrics_saved, -1), be_const_closure(Matter_Device_event_fabrics_saved_closure) },
+        { be_const_key_weak(start_root_basic_commissioning, 16), be_const_closure(Matter_Device_start_root_basic_commissioning_closure) },
+        { be_const_key_weak(ui, -1), be_const_var(7) },
+        { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
+        { be_const_key_weak(commissioning_iterations, -1), be_const_var(9) },
+        { be_const_key_weak(mdns_announce_op_discovery, 22), be_const_closure(Matter_Device_mdns_announce_op_discovery_closure) },
         { be_const_key_weak(is_root_commissioning_open, -1), be_const_closure(Matter_Device_is_root_commissioning_open_closure) },
-        { be_const_key_weak(root_iterations, -1), be_const_var(24) },
-        { be_const_key_weak(is_commissioning_open, -1), be_const_closure(Matter_Device_is_commissioning_open_closure) },
-        { be_const_key_weak(udp_server, -1), be_const_var(2) },
-        { be_const_key_weak(start_commissioning_complete, -1), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
-        { be_const_key_weak(mdns_announce_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics_closure) },
-        { be_const_key_weak(sort_distinct, 34), be_const_static_closure(Matter_Device_sort_distinct_closure) },
+        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
+        { be_const_key_weak(mdns_announce_PASE, 35), be_const_closure(Matter_Device_mdns_announce_PASE_closure) },
+        { be_const_key_weak(is_commissioning_open, 44), be_const_closure(Matter_Device_is_commissioning_open_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Device_init_closure) },
+        { be_const_key_weak(stop_basic_commissioning, -1), be_const_closure(Matter_Device_stop_basic_commissioning_closure) },
+        { be_const_key_weak(save_before_restart, -1), be_const_closure(Matter_Device_save_before_restart_closure) },
+        { be_const_key_weak(plugins_to_json, -1), be_const_closure(Matter_Device_plugins_to_json_closure) },
+        { be_const_key_weak(_trigger_read_sensors, 53), be_const_closure(Matter_Device__trigger_read_sensors_closure) },
+        { be_const_key_weak(every_250ms, 61), be_const_closure(Matter_Device_every_250ms_closure) },
+        { be_const_key_weak(root_w0, -1), be_const_var(28) },
+        { be_const_key_weak(mdns_remove_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics_closure) },
+        { be_const_key_weak(start_commissioning_complete_deferred, 48), be_const_closure(Matter_Device_start_commissioning_complete_deferred_closure) },
+        { be_const_key_weak(commissioning_instance_wifi, -1), be_const_var(15) },
+        { be_const_key_weak(_init_basic_commissioning, -1), be_const_closure(Matter_Device__init_basic_commissioning_closure) },
         { be_const_key_weak(started, -1), be_const_var(0) },
-        { be_const_key_weak(hostname_eth, -1), be_const_var(16) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Device_invoke_request_closure) },
-        { be_const_key_weak(mdns_pase_eth, 14), be_const_var(19) },
-        { be_const_key_weak(mdns_pase_wifi, -1), be_const_var(20) },
-        { be_const_key_weak(PASSCODE_DEFAULT, 11), be_const_int(20202021) },
-        { be_const_key_weak(start_commissioning_complete_deferred, -1), be_const_closure(Matter_Device_start_commissioning_complete_deferred_closure) },
-        { be_const_key_weak(vendorid, 3), be_const_var(17) },
+        { be_const_key_weak(autoconf_device, -1), be_const_closure(Matter_Device_autoconf_device_closure) },
+        { be_const_key_weak(invoke_request, 68), be_const_closure(Matter_Device_invoke_request_closure) },
+        { be_const_key_weak(start_operational_discovery, -1), be_const_closure(Matter_Device_start_operational_discovery_closure) },
+        { be_const_key_weak(PASE_TIMEOUT, 66), be_const_int(600) },
+        { be_const_key_weak(root_salt, 37), be_const_var(27) },
+        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(Matter_Device_get_active_endpoints_closure) },
+        { be_const_key_weak(message_handler, 47), be_const_var(5) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Device_every_second_closure) },
+        { be_const_key_weak(mdns_remove_op_discovery, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_closure) },
+        { be_const_key_weak(mdns_pase_wifi, -1), be_const_var(22) },
+        { be_const_key_weak(remove_fabric, -1), be_const_closure(Matter_Device_remove_fabric_closure) },
+        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
+        { be_const_key_weak(load_param, -1), be_const_closure(Matter_Device_load_param_closure) },
+        { be_const_key_weak(_load_plugins_config, -1), be_const_closure(Matter_Device__load_plugins_config_closure) },
+        { be_const_key_weak(plugins_classes, -1), be_const_var(3) },
+        { be_const_key_weak(autoconf_device_map, -1), be_const_closure(Matter_Device_autoconf_device_map_closure) },
+        { be_const_key_weak(attribute_updated, 57), be_const_closure(Matter_Device_attribute_updated_closure) },
+        { be_const_key_weak(commissioning_admin_fabric, -1), be_const_var(14) },
+        { be_const_key_weak(register_plugin_class, 54), be_const_closure(Matter_Device_register_plugin_class_closure) },
+        { be_const_key_weak(commissioning_instance_eth, 70), be_const_var(16) },
+        { be_const_key_weak(plugins, 52), be_const_var(1) },
+        { be_const_key_weak(PASSCODE_DEFAULT, -1), be_const_int(20202021) },
+        { be_const_key_weak(_start_udp, -1), be_const_closure(Matter_Device__start_udp_closure) },
+        { be_const_key_weak(start_basic_commissioning, -1), be_const_closure(Matter_Device_start_basic_commissioning_closure) },
+        { be_const_key_weak(start, -1), be_const_closure(Matter_Device_start_closure) },
+        { be_const_key_weak(msg_received, 38), be_const_closure(Matter_Device_msg_received_closure) },
+        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
+        { be_const_key_weak(commissioning_w0, -1), be_const_var(12) },
+        { be_const_key_weak(mdns_announce_op_discovery_all_fabrics, 33), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics_closure) },
+        { be_const_key_weak(plugins_persist, 28), be_const_var(2) },
+        { be_const_key_weak(register_native_classes, -1), be_const_closure(Matter_Device_register_native_classes_closure) },
+        { be_const_key_weak(root_discriminator, 25), be_const_var(23) },
+        { be_const_key_weak(k2l_num, -1), be_const_static_closure(Matter_Device_k2l_num_closure) },
+        { be_const_key_weak(ipv4only, -1), be_const_var(25) },
+        { be_const_key_weak(start_operational_discovery_deferred, 13), be_const_closure(Matter_Device_start_operational_discovery_deferred_closure) },
+        { be_const_key_weak(root_iterations, -1), be_const_var(26) },
+        { be_const_key_weak(register_commands, 8), be_const_closure(Matter_Device_register_commands_closure) },
+        { be_const_key_weak(sessions, -1), be_const_var(6) },
+        { be_const_key_weak(k2l, -1), be_const_static_closure(Matter_Device_k2l_closure) },
+        { be_const_key_weak(sort_distinct, -1), be_const_static_closure(Matter_Device_sort_distinct_closure) },
+        { be_const_key_weak(PBKDF_ITERATIONS, -1), be_const_int(1000) },
     })),
     be_str_weak(Matter_Device)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
@@ -7,6 +7,372 @@
 extern const bclass be_class_Matter_Plugin;
 
 /********************************************************************
+** Solidified function: get_endpoint
+********************************************************************/
+be_local_closure(Matter_Plugin_get_endpoint,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(endpoint),
+    }),
+    be_str_weak(get_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: timed_request
+********************************************************************/
+be_local_closure(Matter_Plugin_timed_request,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(timed_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x80040800,  //  0001  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: to_json_parameters
+********************************************************************/
+be_local_closure(Matter_Plugin_to_json_parameters,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(to_json_parameters),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80040200,  //  0000  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_event
+********************************************************************/
+be_local_closure(Matter_Plugin_read_event,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(read_event),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x80040A00,  //  0001  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: to_json
+********************************************************************/
+be_local_closure(Matter_Plugin_to_json,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(format),
+    /* K2   */  be_nested_str_weak(_X7B_X22type_X22_X3A_X22_X25s_X22),
+    /* K3   */  be_nested_str_weak(NAME),
+    /* K4   */  be_nested_str_weak(to_json_parameters),
+    /* K5   */  be_nested_str_weak(_X7D),
+    }),
+    be_str_weak(to_json),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x88140103,  //  0003  GETMBR	R5	R0	K3
+      0x7C080600,  //  0004  CALL	R2	3
+      0x8C0C0104,  //  0005  GETMET	R3	R0	K4
+      0x5C140400,  //  0006  MOVE	R5	R2
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x5C080600,  //  0008  MOVE	R2	R3
+      0x00080505,  //  0009  ADD	R2	R2	K5
+      0x80040400,  //  000A  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: subscribe_event
+********************************************************************/
+be_local_closure(Matter_Plugin_subscribe_event,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(subscribe_event),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x80040A00,  //  0001  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Plugin_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(update_shadow),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Plugin_invoke_request,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x80040800,  //  0001  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_sensors
+********************************************************************/
+be_local_closure(Matter_Plugin_parse_sensors,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(parse_sensors),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_shadow
+********************************************************************/
+be_local_closure(Matter_Plugin_update_shadow,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(update_shadow),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: write_attribute
+********************************************************************/
+be_local_closure(Matter_Plugin_write_attribute,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(write_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x80040800,  //  0001  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Plugin_init,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(endpoint),
+    /* K2   */  be_nested_str_weak(clusters),
+    /* K3   */  be_nested_str_weak(consolidate_clusters),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x8C100103,  //  0002  GETMET	R4	R0	K3
+      0x7C100200,  //  0003  CALL	R4	1
+      0x90020404,  //  0004  SETMBR	R0	K2	R4
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: attribute_updated
+********************************************************************/
+be_local_closure(Matter_Plugin_attribute_updated,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(endpoint),
+    /* K1   */  be_nested_str_weak(device),
+    /* K2   */  be_nested_str_weak(attribute_updated),
+    }),
+    be_str_weak(attribute_updated),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140205,  //  0001  EQ	R5	R1	R5
+      0x78160000,  //  0002  JMPF	R5	#0004
+      0x88040100,  //  0003  GETMBR	R1	R0	K0
+      0x88140101,  //  0004  GETMBR	R5	R0	K1
+      0x8C140B02,  //  0005  GETMET	R5	R5	K2
+      0x5C1C0200,  //  0006  MOVE	R7	R1
+      0x5C200400,  //  0007  MOVE	R8	R2
+      0x5C240600,  //  0008  MOVE	R9	R3
+      0x5C280800,  //  0009  MOVE	R10	R4
+      0x7C140A00,  //  000A  CALL	R5	5
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
 be_local_closure(Matter_Plugin_read_attribute,   /* name */
@@ -288,244 +654,6 @@ be_local_closure(Matter_Plugin_consolidate_clusters,   /* name */
 
 
 /********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(Matter_Plugin_every_second,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(update_shadow),
-    }),
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: subscribe_attribute
-********************************************************************/
-be_local_closure(Matter_Plugin_subscribe_attribute,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(subscribe_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: subscribe_event
-********************************************************************/
-be_local_closure(Matter_Plugin_subscribe_event,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(subscribe_event),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_shadow
-********************************************************************/
-be_local_closure(Matter_Plugin_update_shadow,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(update_shadow),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: read_event
-********************************************************************/
-be_local_closure(Matter_Plugin_read_event,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(read_event),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_endpoint
-********************************************************************/
-be_local_closure(Matter_Plugin_get_endpoint,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(endpoint),
-    }),
-    be_str_weak(get_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: write_attribute
-********************************************************************/
-be_local_closure(Matter_Plugin_write_attribute,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(write_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x80040800,  //  0001  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Plugin_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(clusters),
-    /* K3   */  be_nested_str_weak(consolidate_clusters),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x8C0C0103,  //  0002  GETMET	R3	R0	K3
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x90020403,  //  0004  SETMBR	R0	K2	R3
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: timed_request
-********************************************************************/
-be_local_closure(Matter_Plugin_timed_request,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(timed_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x80040800,  //  0001  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: get_attribute_list
 ********************************************************************/
 be_local_closure(Matter_Plugin_get_attribute_list,   /* name */
@@ -605,87 +733,24 @@ be_local_closure(Matter_Plugin_get_cluster_list,   /* name */
 
 
 /********************************************************************
-** Solidified function: parse_sensors
+** Solidified function: subscribe_attribute
 ********************************************************************/
-be_local_closure(Matter_Plugin_parse_sensors,   /* name */
+be_local_closure(Matter_Plugin_subscribe_attribute,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(parse_sensors),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(Matter_Plugin_invoke_request,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x80040800,  //  0001  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: attribute_updated
-********************************************************************/
-be_local_closure(Matter_Plugin_attribute_updated,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
+    6,                          /* nstack */
     5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(endpoint),
-    /* K1   */  be_nested_str_weak(device),
-    /* K2   */  be_nested_str_weak(attribute_updated),
-    }),
-    be_str_weak(attribute_updated),
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(subscribe_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
+    ( &(const binstruction[ 2]) {  /* code */
       0x4C140000,  //  0000  LDNIL	R5
-      0x1C140205,  //  0001  EQ	R5	R1	R5
-      0x78160000,  //  0002  JMPF	R5	#0004
-      0x88040100,  //  0003  GETMBR	R1	R0	K0
-      0x88140101,  //  0004  GETMBR	R5	R0	K1
-      0x8C140B02,  //  0005  GETMET	R5	R5	K2
-      0x5C1C0200,  //  0006  MOVE	R7	R1
-      0x5C200400,  //  0007  MOVE	R8	R2
-      0x5C240600,  //  0008  MOVE	R9	R3
-      0x5C280800,  //  0009  MOVE	R10	R4
-      0x7C140A00,  //  000A  CALL	R5	5
-      0x80000000,  //  000B  RET	0
+      0x80040A00,  //  0001  RET	1	R5
     })
   )
 );
@@ -698,26 +763,31 @@ be_local_closure(Matter_Plugin_attribute_updated,   /* name */
 be_local_class(Matter_Plugin,
     3,
     NULL,
-    be_nested_map(21,
+    be_nested_map(24,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_read_attribute_closure) },
-        { be_const_key_weak(attribute_updated, 18), be_const_closure(Matter_Plugin_attribute_updated_closure) },
-        { be_const_key_weak(consolidate_clusters, -1), be_const_closure(Matter_Plugin_consolidate_clusters_closure) },
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Plugin_every_second_closure) },
-        { be_const_key_weak(subscribe_attribute, 1), be_const_closure(Matter_Plugin_subscribe_attribute_closure) },
-        { be_const_key_weak(subscribe_event, -1), be_const_closure(Matter_Plugin_subscribe_event_closure) },
-        { be_const_key_weak(device, -1), be_const_var(0) },
-        { be_const_key_weak(update_shadow, 17), be_const_closure(Matter_Plugin_update_shadow_closure) },
+        { be_const_key_weak(subscribe_attribute, 23), be_const_closure(Matter_Plugin_subscribe_attribute_closure) },
         { be_const_key_weak(get_endpoint, -1), be_const_closure(Matter_Plugin_get_endpoint_closure) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_invoke_request_closure) },
-        { be_const_key_weak(has, 8), be_const_closure(Matter_Plugin_has_closure) },
-        { be_const_key_weak(parse_sensors, 13), be_const_closure(Matter_Plugin_parse_sensors_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_init_closure) },
+        { be_const_key_weak(timed_request, -1), be_const_closure(Matter_Plugin_timed_request_closure) },
+        { be_const_key_weak(device, 21), be_const_var(0) },
+        { be_const_key_weak(endpoint, 0), be_const_var(1) },
+        { be_const_key_weak(get_cluster_list, 17), be_const_closure(Matter_Plugin_get_cluster_list_closure) },
+        { be_const_key_weak(NAME, -1), be_nested_str_weak(generic) },
+        { be_const_key_weak(to_json, 5), be_const_closure(Matter_Plugin_to_json_closure) },
         { be_const_key_weak(get_attribute_list, -1), be_const_closure(Matter_Plugin_get_attribute_list_closure) },
-        { be_const_key_weak(timed_request, 9), be_const_closure(Matter_Plugin_timed_request_closure) },
-        { be_const_key_weak(read_event, 11), be_const_closure(Matter_Plugin_read_event_closure) },
-        { be_const_key_weak(get_cluster_list, -1), be_const_closure(Matter_Plugin_get_cluster_list_closure) },
-        { be_const_key_weak(CLUSTERS, 20), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(every_second, 8), be_const_closure(Matter_Plugin_every_second_closure) },
+        { be_const_key_weak(clusters, 22), be_const_var(2) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_invoke_request_closure) },
+        { be_const_key_weak(parse_sensors, -1), be_const_closure(Matter_Plugin_parse_sensors_closure) },
+        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_update_shadow_closure) },
+        { be_const_key_weak(consolidate_clusters, -1), be_const_closure(Matter_Plugin_consolidate_clusters_closure) },
+        { be_const_key_weak(has, -1), be_const_closure(Matter_Plugin_has_closure) },
+        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_read_attribute_closure) },
+        { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Plugin_attribute_updated_closure) },
+        { be_const_key_weak(read_event, 16), be_const_closure(Matter_Plugin_read_event_closure) },
+        { be_const_key_weak(write_attribute, 15), be_const_closure(Matter_Plugin_write_attribute_closure) },
+        { be_const_key_weak(subscribe_event, 14), be_const_closure(Matter_Plugin_subscribe_event_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_init_closure) },
+        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(29, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
@@ -731,9 +801,7 @@ be_local_class(Matter_Plugin,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(write_attribute, -1), be_const_closure(Matter_Plugin_write_attribute_closure) },
-        { be_const_key_weak(clusters, -1), be_const_var(2) },
-        { be_const_key_weak(endpoint, -1), be_const_var(1) },
+        { be_const_key_weak(to_json_parameters, -1), be_const_closure(Matter_Plugin_to_json_parameters_closure) },
     })),
     be_str_weak(Matter_Plugin)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Device.h
@@ -7,86 +7,6 @@
 extern const bclass be_class_Matter_Plugin_Device;
 
 /********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(Matter_Plugin_Device_invoke_request,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(command),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K8   */  be_nested_str_weak(add_TLV),
-    /* K9   */  be_nested_str_weak(U2),
-    /* K10  */  be_nested_str_weak(invoke_request),
-    }),
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0xB8120000,  //  0000  GETNGBL	R4	K0
-      0x88100901,  //  0001  GETMBR	R4	R4	K1
-      0x88140702,  //  0002  GETMBR	R5	R3	K2
-      0x88180703,  //  0003  GETMBR	R6	R3	K3
-      0x1C1C0B04,  //  0004  EQ	R7	R5	K4
-      0x781E0016,  //  0005  JMPF	R7	#001D
-      0x1C1C0D05,  //  0006  EQ	R7	R6	K5
-      0x781E0002,  //  0007  JMPF	R7	#000B
-      0x501C0200,  //  0008  LDBOOL	R7	1	0
-      0x80040E00,  //  0009  RET	1	R7
-      0x70020010,  //  000A  JMP		#001C
-      0x1C1C0D06,  //  000B  EQ	R7	R6	K6
-      0x781E0009,  //  000C  JMPF	R7	#0017
-      0x8C1C0907,  //  000D  GETMET	R7	R4	K7
-      0x7C1C0200,  //  000E  CALL	R7	1
-      0x8C200F08,  //  000F  GETMET	R8	R7	K8
-      0x58280005,  //  0010  LDCONST	R10	K5
-      0x882C0909,  //  0011  GETMBR	R11	R4	K9
-      0x58300005,  //  0012  LDCONST	R12	K5
-      0x7C200800,  //  0013  CALL	R8	4
-      0x900E0705,  //  0014  SETMBR	R3	K3	K5
-      0x80040E00,  //  0015  RET	1	R7
-      0x70020004,  //  0016  JMP		#001C
-      0x541E003F,  //  0017  LDINT	R7	64
-      0x1C1C0C07,  //  0018  EQ	R7	R6	R7
-      0x781E0001,  //  0019  JMPF	R7	#001C
-      0x501C0200,  //  001A  LDBOOL	R7	1	0
-      0x80040E00,  //  001B  RET	1	R7
-      0x7002000E,  //  001C  JMP		#002C
-      0x541E0003,  //  001D  LDINT	R7	4
-      0x1C1C0A07,  //  001E  EQ	R7	R5	R7
-      0x781E0002,  //  001F  JMPF	R7	#0023
-      0x501C0200,  //  0020  LDBOOL	R7	1	0
-      0x80040E00,  //  0021  RET	1	R7
-      0x70020008,  //  0022  JMP		#002C
-      0x601C0003,  //  0023  GETGBL	R7	G3
-      0x5C200000,  //  0024  MOVE	R8	R0
-      0x7C1C0200,  //  0025  CALL	R7	1
-      0x8C1C0F0A,  //  0026  GETMET	R7	R7	K10
-      0x5C240200,  //  0027  MOVE	R9	R1
-      0x5C280400,  //  0028  MOVE	R10	R2
-      0x5C2C0600,  //  0029  MOVE	R11	R3
-      0x7C1C0800,  //  002A  CALL	R7	4
-      0x80040E00,  //  002B  RET	1	R7
-      0x80000000,  //  002C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
 be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
@@ -200,11 +120,11 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
 
 
 /********************************************************************
-** Solidified function: init
+** Solidified function: invoke_request
 ********************************************************************/
-be_local_closure(Matter_Plugin_Device_init,   /* name */
+be_local_closure(Matter_Plugin_Device_invoke_request,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    13,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -212,20 +132,67 @@ be_local_closure(Matter_Plugin_Device_init,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(command),
+    /* K4   */  be_const_int(3),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_const_int(1),
+    /* K7   */  be_nested_str_weak(Matter_TLV_struct),
+    /* K8   */  be_nested_str_weak(add_TLV),
+    /* K9   */  be_nested_str_weak(U2),
+    /* K10  */  be_nested_str_weak(invoke_request),
     }),
-    be_str_weak(init),
+    be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x60100003,  //  0000  GETGBL	R4	G3
-      0x5C140000,  //  0001  MOVE	R5	R0
-      0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x5C1C0400,  //  0005  MOVE	R7	R2
-      0x7C100600,  //  0006  CALL	R4	3
-      0x80000000,  //  0007  RET	0
+    ( &(const binstruction[45]) {  /* code */
+      0xB8120000,  //  0000  GETNGBL	R4	K0
+      0x88100901,  //  0001  GETMBR	R4	R4	K1
+      0x88140702,  //  0002  GETMBR	R5	R3	K2
+      0x88180703,  //  0003  GETMBR	R6	R3	K3
+      0x1C1C0B04,  //  0004  EQ	R7	R5	K4
+      0x781E0016,  //  0005  JMPF	R7	#001D
+      0x1C1C0D05,  //  0006  EQ	R7	R6	K5
+      0x781E0002,  //  0007  JMPF	R7	#000B
+      0x501C0200,  //  0008  LDBOOL	R7	1	0
+      0x80040E00,  //  0009  RET	1	R7
+      0x70020010,  //  000A  JMP		#001C
+      0x1C1C0D06,  //  000B  EQ	R7	R6	K6
+      0x781E0009,  //  000C  JMPF	R7	#0017
+      0x8C1C0907,  //  000D  GETMET	R7	R4	K7
+      0x7C1C0200,  //  000E  CALL	R7	1
+      0x8C200F08,  //  000F  GETMET	R8	R7	K8
+      0x58280005,  //  0010  LDCONST	R10	K5
+      0x882C0909,  //  0011  GETMBR	R11	R4	K9
+      0x58300005,  //  0012  LDCONST	R12	K5
+      0x7C200800,  //  0013  CALL	R8	4
+      0x900E0705,  //  0014  SETMBR	R3	K3	K5
+      0x80040E00,  //  0015  RET	1	R7
+      0x70020004,  //  0016  JMP		#001C
+      0x541E003F,  //  0017  LDINT	R7	64
+      0x1C1C0C07,  //  0018  EQ	R7	R6	R7
+      0x781E0001,  //  0019  JMPF	R7	#001C
+      0x501C0200,  //  001A  LDBOOL	R7	1	0
+      0x80040E00,  //  001B  RET	1	R7
+      0x7002000E,  //  001C  JMP		#002C
+      0x541E0003,  //  001D  LDINT	R7	4
+      0x1C1C0A07,  //  001E  EQ	R7	R5	R7
+      0x781E0002,  //  001F  JMPF	R7	#0023
+      0x501C0200,  //  0020  LDBOOL	R7	1	0
+      0x80040E00,  //  0021  RET	1	R7
+      0x70020008,  //  0022  JMP		#002C
+      0x601C0003,  //  0023  GETGBL	R7	G3
+      0x5C200000,  //  0024  MOVE	R8	R0
+      0x7C1C0200,  //  0025  CALL	R7	1
+      0x8C1C0F0A,  //  0026  GETMET	R7	R7	K10
+      0x5C240200,  //  0027  MOVE	R9	R1
+      0x5C280400,  //  0028  MOVE	R10	R2
+      0x5C2C0600,  //  0029  MOVE	R11	R3
+      0x7C1C0800,  //  002A  CALL	R7	4
+      0x80040E00,  //  002B  RET	1	R7
+      0x80000000,  //  002C  RET	0
     })
   )
 );
@@ -239,16 +206,8 @@ extern const bclass be_class_Matter_Plugin;
 be_local_class(Matter_Plugin_Device,
     0,
     &be_class_Matter_Plugin,
-    be_nested_map(5,
+    be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(TYPES, 3), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_int(0, -1), be_const_int(0) },
-    }))    ) } )) },
-        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Device_read_attribute_closure) },
-        { be_const_key_weak(invoke_request, 1), be_const_closure(Matter_Plugin_Device_invoke_request_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Device_init_closure) },
         { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
@@ -268,6 +227,13 @@ be_local_class(Matter_Plugin_Device,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
+        { be_const_key_weak(TYPES, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(0, -1), be_const_int(0) },
+    }))    ) } )) },
+        { be_const_key_weak(read_attribute, 1), be_const_closure(Matter_Plugin_Device_read_attribute_closure) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_Device_invoke_request_closure) },
     })),
     be_str_weak(Matter_Plugin_Device)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light0.h
@@ -7,6 +7,133 @@
 extern const bclass be_class_Matter_Plugin_Light0;
 
 /********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Plugin_Light0_invoke_request,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(light),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(command),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(Matter_TLV_struct),
+    /* K9   */  be_nested_str_weak(add_TLV),
+    /* K10  */  be_nested_str_weak(U2),
+    /* K11  */  be_nested_str_weak(set),
+    /* K12  */  be_nested_str_weak(power),
+    /* K13  */  be_nested_str_weak(update_shadow),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(shadow_onoff),
+    }),
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[87]) {  /* code */
+      0xA4120000,  //  0000  IMPORT	R4	K0
+      0xB8160200,  //  0001  GETNGBL	R5	K1
+      0x88140B02,  //  0002  GETMBR	R5	R5	K2
+      0x88180703,  //  0003  GETMBR	R6	R3	K3
+      0x881C0704,  //  0004  GETMBR	R7	R3	K4
+      0x1C200D05,  //  0005  EQ	R8	R6	K5
+      0x78220016,  //  0006  JMPF	R8	#001E
+      0x1C200F06,  //  0007  EQ	R8	R7	K6
+      0x78220002,  //  0008  JMPF	R8	#000C
+      0x50200200,  //  0009  LDBOOL	R8	1	0
+      0x80041000,  //  000A  RET	1	R8
+      0x70020010,  //  000B  JMP		#001D
+      0x1C200F07,  //  000C  EQ	R8	R7	K7
+      0x78220009,  //  000D  JMPF	R8	#0018
+      0x8C200B08,  //  000E  GETMET	R8	R5	K8
+      0x7C200200,  //  000F  CALL	R8	1
+      0x8C241109,  //  0010  GETMET	R9	R8	K9
+      0x582C0006,  //  0011  LDCONST	R11	K6
+      0x88300B0A,  //  0012  GETMBR	R12	R5	K10
+      0x58340006,  //  0013  LDCONST	R13	K6
+      0x7C240800,  //  0014  CALL	R9	4
+      0x900E0906,  //  0015  SETMBR	R3	K4	K6
+      0x80041000,  //  0016  RET	1	R8
+      0x70020004,  //  0017  JMP		#001D
+      0x5422003F,  //  0018  LDINT	R8	64
+      0x1C200E08,  //  0019  EQ	R8	R7	R8
+      0x78220001,  //  001A  JMPF	R8	#001D
+      0x50200200,  //  001B  LDBOOL	R8	1	0
+      0x80041000,  //  001C  RET	1	R8
+      0x70020037,  //  001D  JMP		#0056
+      0x54220003,  //  001E  LDINT	R8	4
+      0x1C200C08,  //  001F  EQ	R8	R6	R8
+      0x78220002,  //  0020  JMPF	R8	#0024
+      0x50200200,  //  0021  LDBOOL	R8	1	0
+      0x80041000,  //  0022  RET	1	R8
+      0x70020031,  //  0023  JMP		#0056
+      0x54220004,  //  0024  LDINT	R8	5
+      0x1C200C08,  //  0025  EQ	R8	R6	R8
+      0x78220002,  //  0026  JMPF	R8	#002A
+      0x50200200,  //  0027  LDBOOL	R8	1	0
+      0x80041000,  //  0028  RET	1	R8
+      0x7002002B,  //  0029  JMP		#0056
+      0x54220005,  //  002A  LDINT	R8	6
+      0x1C200C08,  //  002B  EQ	R8	R6	R8
+      0x78220028,  //  002C  JMPF	R8	#0056
+      0x1C200F06,  //  002D  EQ	R8	R7	K6
+      0x7822000A,  //  002E  JMPF	R8	#003A
+      0x8C20090B,  //  002F  GETMET	R8	R4	K11
+      0x60280013,  //  0030  GETGBL	R10	G19
+      0x7C280000,  //  0031  CALL	R10	0
+      0x502C0000,  //  0032  LDBOOL	R11	0	0
+      0x982A180B,  //  0033  SETIDX	R10	K12	R11
+      0x7C200400,  //  0034  CALL	R8	2
+      0x8C20010D,  //  0035  GETMET	R8	R0	K13
+      0x7C200200,  //  0036  CALL	R8	1
+      0x50200200,  //  0037  LDBOOL	R8	1	0
+      0x80041000,  //  0038  RET	1	R8
+      0x7002001B,  //  0039  JMP		#0056
+      0x1C200F07,  //  003A  EQ	R8	R7	K7
+      0x7822000A,  //  003B  JMPF	R8	#0047
+      0x8C20090B,  //  003C  GETMET	R8	R4	K11
+      0x60280013,  //  003D  GETGBL	R10	G19
+      0x7C280000,  //  003E  CALL	R10	0
+      0x502C0200,  //  003F  LDBOOL	R11	1	0
+      0x982A180B,  //  0040  SETIDX	R10	K12	R11
+      0x7C200400,  //  0041  CALL	R8	2
+      0x8C20010D,  //  0042  GETMET	R8	R0	K13
+      0x7C200200,  //  0043  CALL	R8	1
+      0x50200200,  //  0044  LDBOOL	R8	1	0
+      0x80041000,  //  0045  RET	1	R8
+      0x7002000E,  //  0046  JMP		#0056
+      0x1C200F0E,  //  0047  EQ	R8	R7	K14
+      0x7822000C,  //  0048  JMPF	R8	#0056
+      0x8C20090B,  //  0049  GETMET	R8	R4	K11
+      0x60280013,  //  004A  GETGBL	R10	G19
+      0x7C280000,  //  004B  CALL	R10	0
+      0x882C010F,  //  004C  GETMBR	R11	R0	K15
+      0x782E0000,  //  004D  JMPF	R11	#004F
+      0x502C0001,  //  004E  LDBOOL	R11	0	1
+      0x502C0200,  //  004F  LDBOOL	R11	1	0
+      0x982A180B,  //  0050  SETIDX	R10	K12	R11
+      0x7C200400,  //  0051  CALL	R8	2
+      0x8C20010D,  //  0052  GETMET	R8	R0	K13
+      0x7C200200,  //  0053  CALL	R8	1
+      0x50200200,  //  0054  LDBOOL	R8	1	0
+      0x80041000,  //  0055  RET	1	R8
+      0x80000000,  //  0056  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
 be_local_closure(Matter_Plugin_Light0_read_attribute,   /* name */
@@ -220,139 +347,12 @@ be_local_closure(Matter_Plugin_Light0_update_shadow,   /* name */
 
 
 /********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(Matter_Plugin_Light0_invoke_request,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(light),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(command),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K9   */  be_nested_str_weak(add_TLV),
-    /* K10  */  be_nested_str_weak(U2),
-    /* K11  */  be_nested_str_weak(set),
-    /* K12  */  be_nested_str_weak(power),
-    /* K13  */  be_nested_str_weak(update_shadow),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_nested_str_weak(shadow_onoff),
-    }),
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[87]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0xB8160200,  //  0001  GETNGBL	R5	K1
-      0x88140B02,  //  0002  GETMBR	R5	R5	K2
-      0x88180703,  //  0003  GETMBR	R6	R3	K3
-      0x881C0704,  //  0004  GETMBR	R7	R3	K4
-      0x1C200D05,  //  0005  EQ	R8	R6	K5
-      0x78220016,  //  0006  JMPF	R8	#001E
-      0x1C200F06,  //  0007  EQ	R8	R7	K6
-      0x78220002,  //  0008  JMPF	R8	#000C
-      0x50200200,  //  0009  LDBOOL	R8	1	0
-      0x80041000,  //  000A  RET	1	R8
-      0x70020010,  //  000B  JMP		#001D
-      0x1C200F07,  //  000C  EQ	R8	R7	K7
-      0x78220009,  //  000D  JMPF	R8	#0018
-      0x8C200B08,  //  000E  GETMET	R8	R5	K8
-      0x7C200200,  //  000F  CALL	R8	1
-      0x8C241109,  //  0010  GETMET	R9	R8	K9
-      0x582C0006,  //  0011  LDCONST	R11	K6
-      0x88300B0A,  //  0012  GETMBR	R12	R5	K10
-      0x58340006,  //  0013  LDCONST	R13	K6
-      0x7C240800,  //  0014  CALL	R9	4
-      0x900E0906,  //  0015  SETMBR	R3	K4	K6
-      0x80041000,  //  0016  RET	1	R8
-      0x70020004,  //  0017  JMP		#001D
-      0x5422003F,  //  0018  LDINT	R8	64
-      0x1C200E08,  //  0019  EQ	R8	R7	R8
-      0x78220001,  //  001A  JMPF	R8	#001D
-      0x50200200,  //  001B  LDBOOL	R8	1	0
-      0x80041000,  //  001C  RET	1	R8
-      0x70020037,  //  001D  JMP		#0056
-      0x54220003,  //  001E  LDINT	R8	4
-      0x1C200C08,  //  001F  EQ	R8	R6	R8
-      0x78220002,  //  0020  JMPF	R8	#0024
-      0x50200200,  //  0021  LDBOOL	R8	1	0
-      0x80041000,  //  0022  RET	1	R8
-      0x70020031,  //  0023  JMP		#0056
-      0x54220004,  //  0024  LDINT	R8	5
-      0x1C200C08,  //  0025  EQ	R8	R6	R8
-      0x78220002,  //  0026  JMPF	R8	#002A
-      0x50200200,  //  0027  LDBOOL	R8	1	0
-      0x80041000,  //  0028  RET	1	R8
-      0x7002002B,  //  0029  JMP		#0056
-      0x54220005,  //  002A  LDINT	R8	6
-      0x1C200C08,  //  002B  EQ	R8	R6	R8
-      0x78220028,  //  002C  JMPF	R8	#0056
-      0x1C200F06,  //  002D  EQ	R8	R7	K6
-      0x7822000A,  //  002E  JMPF	R8	#003A
-      0x8C20090B,  //  002F  GETMET	R8	R4	K11
-      0x60280013,  //  0030  GETGBL	R10	G19
-      0x7C280000,  //  0031  CALL	R10	0
-      0x502C0000,  //  0032  LDBOOL	R11	0	0
-      0x982A180B,  //  0033  SETIDX	R10	K12	R11
-      0x7C200400,  //  0034  CALL	R8	2
-      0x8C20010D,  //  0035  GETMET	R8	R0	K13
-      0x7C200200,  //  0036  CALL	R8	1
-      0x50200200,  //  0037  LDBOOL	R8	1	0
-      0x80041000,  //  0038  RET	1	R8
-      0x7002001B,  //  0039  JMP		#0056
-      0x1C200F07,  //  003A  EQ	R8	R7	K7
-      0x7822000A,  //  003B  JMPF	R8	#0047
-      0x8C20090B,  //  003C  GETMET	R8	R4	K11
-      0x60280013,  //  003D  GETGBL	R10	G19
-      0x7C280000,  //  003E  CALL	R10	0
-      0x502C0200,  //  003F  LDBOOL	R11	1	0
-      0x982A180B,  //  0040  SETIDX	R10	K12	R11
-      0x7C200400,  //  0041  CALL	R8	2
-      0x8C20010D,  //  0042  GETMET	R8	R0	K13
-      0x7C200200,  //  0043  CALL	R8	1
-      0x50200200,  //  0044  LDBOOL	R8	1	0
-      0x80041000,  //  0045  RET	1	R8
-      0x7002000E,  //  0046  JMP		#0056
-      0x1C200F0E,  //  0047  EQ	R8	R7	K14
-      0x7822000C,  //  0048  JMPF	R8	#0056
-      0x8C20090B,  //  0049  GETMET	R8	R4	K11
-      0x60280013,  //  004A  GETGBL	R10	G19
-      0x7C280000,  //  004B  CALL	R10	0
-      0x882C010F,  //  004C  GETMBR	R11	R0	K15
-      0x782E0000,  //  004D  JMPF	R11	#004F
-      0x502C0001,  //  004E  LDBOOL	R11	0	1
-      0x502C0200,  //  004F  LDBOOL	R11	1	0
-      0x982A180B,  //  0050  SETIDX	R10	K12	R11
-      0x7C200400,  //  0051  CALL	R8	2
-      0x8C20010D,  //  0052  GETMET	R8	R0	K13
-      0x7C200200,  //  0053  CALL	R8	1
-      0x50200200,  //  0054  LDBOOL	R8	1	0
-      0x80041000,  //  0055  RET	1	R8
-      0x80000000,  //  0056  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: init
 ********************************************************************/
 be_local_closure(Matter_Plugin_Light0_init,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
+    9,                          /* nstack */
+    4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -365,17 +365,18 @@ be_local_closure(Matter_Plugin_Light0_init,   /* name */
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x600C0003,  //  0000  GETGBL	R3	G3
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x500C0000,  //  0007  LDBOOL	R3	0	0
-      0x90020203,  //  0008  SETMBR	R0	K1	R3
-      0x80000000,  //  0009  RET	0
+    ( &(const binstruction[11]) {  /* code */
+      0x60100003,  //  0000  GETGBL	R4	G3
+      0x5C140000,  //  0001  MOVE	R5	R0
+      0x7C100200,  //  0002  CALL	R4	1
+      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x5C200600,  //  0006  MOVE	R8	R3
+      0x7C100800,  //  0007  CALL	R4	4
+      0x50100000,  //  0008  LDBOOL	R4	0	0
+      0x90020204,  //  0009  SETMBR	R0	K1	R4
+      0x80000000,  //  000A  RET	0
     })
   )
 );
@@ -389,11 +390,11 @@ extern const bclass be_class_Matter_Plugin;
 be_local_class(Matter_Plugin_Light0,
     1,
     &be_class_Matter_Plugin,
-    be_nested_map(7,
+    be_nested_map(8,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(read_attribute, 4), be_const_closure(Matter_Plugin_Light0_read_attribute_closure) },
-        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_Light0_update_shadow_closure) },
-        { be_const_key_weak(CLUSTERS, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(shadow_onoff, -1), be_const_var(0) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Light0_init_closure) },
+        { be_const_key_weak(CLUSTERS, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(4, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
@@ -431,14 +432,15 @@ be_local_class(Matter_Plugin_Light0,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
+        { be_const_key_weak(invoke_request, 1), be_const_closure(Matter_Plugin_Light0_invoke_request_closure) },
+        { be_const_key_weak(read_attribute, 7), be_const_closure(Matter_Plugin_Light0_read_attribute_closure) },
+        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_Light0_update_shadow_closure) },
+        { be_const_key_weak(NAME, -1), be_nested_str_weak(light0) },
         { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(256, -1), be_const_int(2) },
     }))    ) } )) },
-        { be_const_key_weak(invoke_request, 2), be_const_closure(Matter_Plugin_Light0_invoke_request_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Light0_init_closure) },
-        { be_const_key_weak(shadow_onoff, -1), be_const_var(0) },
     })),
     be_str_weak(Matter_Plugin_Light0)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light1.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light1.h
@@ -7,6 +7,158 @@
 extern const bclass be_class_Matter_Plugin_Light1;
 
 /********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Plugin_Light1_init,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(shadow_bri),
+    /* K2   */  be_const_int(0),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x60100003,  //  0000  GETGBL	R4	G3
+      0x5C140000,  //  0001  MOVE	R5	R0
+      0x7C100200,  //  0002  CALL	R4	1
+      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x5C200600,  //  0006  MOVE	R8	R3
+      0x7C100800,  //  0007  CALL	R4	4
+      0x90020302,  //  0008  SETMBR	R0	K1	K2
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_attribute
+********************************************************************/
+be_local_closure(Matter_Plugin_Light1_read_attribute,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(U1),
+    /* K8   */  be_nested_str_weak(shadow_bri),
+    /* K9   */  be_const_int(2),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_const_int(1),
+    /* K13  */  be_nested_str_weak(read_attribute),
+    }),
+    be_str_weak(read_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[77]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x88100902,  //  0002  GETMBR	R4	R4	K2
+      0x88140503,  //  0003  GETMBR	R5	R2	K3
+      0x88180504,  //  0004  GETMBR	R6	R2	K4
+      0x541E0007,  //  0005  LDINT	R7	8
+      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
+      0x781E003B,  //  0007  JMPF	R7	#0044
+      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
+      0x781E0005,  //  0009  JMPF	R7	#0010
+      0x8C1C0906,  //  000A  GETMET	R7	R4	K6
+      0x88240907,  //  000B  GETMBR	R9	R4	K7
+      0x88280108,  //  000C  GETMBR	R10	R0	K8
+      0x7C1C0600,  //  000D  CALL	R7	3
+      0x80040E00,  //  000E  RET	1	R7
+      0x70020032,  //  000F  JMP		#0043
+      0x1C1C0D09,  //  0010  EQ	R7	R6	K9
+      0x781E0005,  //  0011  JMPF	R7	#0018
+      0x8C1C0906,  //  0012  GETMET	R7	R4	K6
+      0x88240907,  //  0013  GETMBR	R9	R4	K7
+      0x58280005,  //  0014  LDCONST	R10	K5
+      0x7C1C0600,  //  0015  CALL	R7	3
+      0x80040E00,  //  0016  RET	1	R7
+      0x7002002A,  //  0017  JMP		#0043
+      0x1C1C0D0A,  //  0018  EQ	R7	R6	K10
+      0x781E0005,  //  0019  JMPF	R7	#0020
+      0x8C1C0906,  //  001A  GETMET	R7	R4	K6
+      0x88240907,  //  001B  GETMBR	R9	R4	K7
+      0x542A00FD,  //  001C  LDINT	R10	254
+      0x7C1C0600,  //  001D  CALL	R7	3
+      0x80040E00,  //  001E  RET	1	R7
+      0x70020022,  //  001F  JMP		#0043
+      0x541E000E,  //  0020  LDINT	R7	15
+      0x1C1C0C07,  //  0021  EQ	R7	R6	R7
+      0x781E0005,  //  0022  JMPF	R7	#0029
+      0x8C1C0906,  //  0023  GETMET	R7	R4	K6
+      0x88240907,  //  0024  GETMBR	R9	R4	K7
+      0x58280005,  //  0025  LDCONST	R10	K5
+      0x7C1C0600,  //  0026  CALL	R7	3
+      0x80040E00,  //  0027  RET	1	R7
+      0x70020019,  //  0028  JMP		#0043
+      0x541E0010,  //  0029  LDINT	R7	17
+      0x1C1C0C07,  //  002A  EQ	R7	R6	R7
+      0x781E0005,  //  002B  JMPF	R7	#0032
+      0x8C1C0906,  //  002C  GETMET	R7	R4	K6
+      0x88240907,  //  002D  GETMBR	R9	R4	K7
+      0x88280108,  //  002E  GETMBR	R10	R0	K8
+      0x7C1C0600,  //  002F  CALL	R7	3
+      0x80040E00,  //  0030  RET	1	R7
+      0x70020010,  //  0031  JMP		#0043
+      0x541EFFFB,  //  0032  LDINT	R7	65532
+      0x1C1C0C07,  //  0033  EQ	R7	R6	R7
+      0x781E0005,  //  0034  JMPF	R7	#003B
+      0x8C1C0906,  //  0035  GETMET	R7	R4	K6
+      0x8824090B,  //  0036  GETMBR	R9	R4	K11
+      0x5828000C,  //  0037  LDCONST	R10	K12
+      0x7C1C0600,  //  0038  CALL	R7	3
+      0x80040E00,  //  0039  RET	1	R7
+      0x70020007,  //  003A  JMP		#0043
+      0x541EFFFC,  //  003B  LDINT	R7	65533
+      0x1C1C0C07,  //  003C  EQ	R7	R6	R7
+      0x781E0004,  //  003D  JMPF	R7	#0043
+      0x8C1C0906,  //  003E  GETMET	R7	R4	K6
+      0x8824090B,  //  003F  GETMBR	R9	R4	K11
+      0x542A0004,  //  0040  LDINT	R10	5
+      0x7C1C0600,  //  0041  CALL	R7	3
+      0x80040E00,  //  0042  RET	1	R7
+      0x70020007,  //  0043  JMP		#004C
+      0x601C0003,  //  0044  GETGBL	R7	G3
+      0x5C200000,  //  0045  MOVE	R8	R0
+      0x7C1C0200,  //  0046  CALL	R7	1
+      0x8C1C0F0D,  //  0047  GETMET	R7	R7	K13
+      0x5C240200,  //  0048  MOVE	R9	R1
+      0x5C280400,  //  0049  MOVE	R10	R2
+      0x7C1C0600,  //  004A  CALL	R7	3
+      0x80040E00,  //  004B  RET	1	R7
+      0x80000000,  //  004C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
 be_local_closure(Matter_Plugin_Light1_invoke_request,   /* name */
@@ -230,176 +382,21 @@ be_local_closure(Matter_Plugin_Light1_update_shadow,   /* name */
 
 
 /********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Plugin_Light1_init,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(shadow_bri),
-    /* K2   */  be_const_int(0),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x600C0003,  //  0000  GETGBL	R3	G3
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x90020302,  //  0007  SETMBR	R0	K1	K2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: read_attribute
-********************************************************************/
-be_local_closure(Matter_Plugin_Light1_read_attribute,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(create_TLV),
-    /* K7   */  be_nested_str_weak(U1),
-    /* K8   */  be_nested_str_weak(shadow_bri),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(U4),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_nested_str_weak(read_attribute),
-    }),
-    be_str_weak(read_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[77]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
-      0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0007,  //  0005  LDINT	R7	8
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E003B,  //  0007  JMPF	R7	#0044
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E0005,  //  0009  JMPF	R7	#0010
-      0x8C1C0906,  //  000A  GETMET	R7	R4	K6
-      0x88240907,  //  000B  GETMBR	R9	R4	K7
-      0x88280108,  //  000C  GETMBR	R10	R0	K8
-      0x7C1C0600,  //  000D  CALL	R7	3
-      0x80040E00,  //  000E  RET	1	R7
-      0x70020032,  //  000F  JMP		#0043
-      0x1C1C0D09,  //  0010  EQ	R7	R6	K9
-      0x781E0005,  //  0011  JMPF	R7	#0018
-      0x8C1C0906,  //  0012  GETMET	R7	R4	K6
-      0x88240907,  //  0013  GETMBR	R9	R4	K7
-      0x58280005,  //  0014  LDCONST	R10	K5
-      0x7C1C0600,  //  0015  CALL	R7	3
-      0x80040E00,  //  0016  RET	1	R7
-      0x7002002A,  //  0017  JMP		#0043
-      0x1C1C0D0A,  //  0018  EQ	R7	R6	K10
-      0x781E0005,  //  0019  JMPF	R7	#0020
-      0x8C1C0906,  //  001A  GETMET	R7	R4	K6
-      0x88240907,  //  001B  GETMBR	R9	R4	K7
-      0x542A00FD,  //  001C  LDINT	R10	254
-      0x7C1C0600,  //  001D  CALL	R7	3
-      0x80040E00,  //  001E  RET	1	R7
-      0x70020022,  //  001F  JMP		#0043
-      0x541E000E,  //  0020  LDINT	R7	15
-      0x1C1C0C07,  //  0021  EQ	R7	R6	R7
-      0x781E0005,  //  0022  JMPF	R7	#0029
-      0x8C1C0906,  //  0023  GETMET	R7	R4	K6
-      0x88240907,  //  0024  GETMBR	R9	R4	K7
-      0x58280005,  //  0025  LDCONST	R10	K5
-      0x7C1C0600,  //  0026  CALL	R7	3
-      0x80040E00,  //  0027  RET	1	R7
-      0x70020019,  //  0028  JMP		#0043
-      0x541E0010,  //  0029  LDINT	R7	17
-      0x1C1C0C07,  //  002A  EQ	R7	R6	R7
-      0x781E0005,  //  002B  JMPF	R7	#0032
-      0x8C1C0906,  //  002C  GETMET	R7	R4	K6
-      0x88240907,  //  002D  GETMBR	R9	R4	K7
-      0x88280108,  //  002E  GETMBR	R10	R0	K8
-      0x7C1C0600,  //  002F  CALL	R7	3
-      0x80040E00,  //  0030  RET	1	R7
-      0x70020010,  //  0031  JMP		#0043
-      0x541EFFFB,  //  0032  LDINT	R7	65532
-      0x1C1C0C07,  //  0033  EQ	R7	R6	R7
-      0x781E0005,  //  0034  JMPF	R7	#003B
-      0x8C1C0906,  //  0035  GETMET	R7	R4	K6
-      0x8824090B,  //  0036  GETMBR	R9	R4	K11
-      0x5828000C,  //  0037  LDCONST	R10	K12
-      0x7C1C0600,  //  0038  CALL	R7	3
-      0x80040E00,  //  0039  RET	1	R7
-      0x70020007,  //  003A  JMP		#0043
-      0x541EFFFC,  //  003B  LDINT	R7	65533
-      0x1C1C0C07,  //  003C  EQ	R7	R6	R7
-      0x781E0004,  //  003D  JMPF	R7	#0043
-      0x8C1C0906,  //  003E  GETMET	R7	R4	K6
-      0x8824090B,  //  003F  GETMBR	R9	R4	K11
-      0x542A0004,  //  0040  LDINT	R10	5
-      0x7C1C0600,  //  0041  CALL	R7	3
-      0x80040E00,  //  0042  RET	1	R7
-      0x70020007,  //  0043  JMP		#004C
-      0x601C0003,  //  0044  GETGBL	R7	G3
-      0x5C200000,  //  0045  MOVE	R8	R0
-      0x7C1C0200,  //  0046  CALL	R7	1
-      0x8C1C0F0D,  //  0047  GETMET	R7	R7	K13
-      0x5C240200,  //  0048  MOVE	R9	R1
-      0x5C280400,  //  0049  MOVE	R10	R2
-      0x7C1C0600,  //  004A  CALL	R7	3
-      0x80040E00,  //  004B  RET	1	R7
-      0x80000000,  //  004C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_Plugin_Light1
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light0;
 be_local_class(Matter_Plugin_Light1,
     1,
     &be_class_Matter_Plugin_Light0,
-    be_nested_map(7,
+    be_nested_map(8,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(invoke_request, 1), be_const_closure(Matter_Plugin_Light1_invoke_request_closure) },
-        { be_const_key_weak(read_attribute, 4), be_const_closure(Matter_Plugin_Light1_read_attribute_closure) },
-        { be_const_key_weak(shadow_bri, -1), be_const_var(0) },
-        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(TYPES, 7), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(257, -1), be_const_int(2) },
     }))    ) } )) },
-        { be_const_key_weak(update_shadow, 6), be_const_closure(Matter_Plugin_Light1_update_shadow_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Light1_init_closure) },
-        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_Light1_invoke_request_closure) },
+        { be_const_key_weak(CLUSTERS, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(8, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
@@ -414,6 +411,11 @@ be_local_class(Matter_Plugin_Light1,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
+        { be_const_key_weak(init, 1), be_const_closure(Matter_Plugin_Light1_init_closure) },
+        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_Light1_update_shadow_closure) },
+        { be_const_key_weak(shadow_bri, 4), be_const_var(0) },
+        { be_const_key_weak(NAME, -1), be_nested_str_weak(light1) },
+        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Light1_read_attribute_closure) },
     })),
     be_str_weak(Matter_Plugin_Light1)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light2.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light2.h
@@ -7,206 +7,6 @@
 extern const bclass be_class_Matter_Plugin_Light2;
 
 /********************************************************************
-** Solidified function: read_attribute
-********************************************************************/
-be_local_closure(Matter_Plugin_Light2_read_attribute,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(create_TLV),
-    /* K6   */  be_nested_str_weak(U1),
-    /* K7   */  be_nested_str_weak(shadow_ct),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(ct_min),
-    /* K11  */  be_nested_str_weak(ct_max),
-    /* K12  */  be_nested_str_weak(U4),
-    /* K13  */  be_nested_str_weak(read_attribute),
-    }),
-    be_str_weak(read_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[80]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
-      0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E02FF,  //  0005  LDINT	R7	768
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E003E,  //  0007  JMPF	R7	#0047
-      0x541E0006,  //  0008  LDINT	R7	7
-      0x1C1C0C07,  //  0009  EQ	R7	R6	R7
-      0x781E0005,  //  000A  JMPF	R7	#0011
-      0x8C1C0905,  //  000B  GETMET	R7	R4	K5
-      0x88240906,  //  000C  GETMBR	R9	R4	K6
-      0x88280107,  //  000D  GETMBR	R10	R0	K7
-      0x7C1C0600,  //  000E  CALL	R7	3
-      0x80040E00,  //  000F  RET	1	R7
-      0x70020034,  //  0010  JMP		#0046
-      0x541E0007,  //  0011  LDINT	R7	8
-      0x1C1C0C07,  //  0012  EQ	R7	R6	R7
-      0x781E0005,  //  0013  JMPF	R7	#001A
-      0x8C1C0905,  //  0014  GETMET	R7	R4	K5
-      0x88240906,  //  0015  GETMBR	R9	R4	K6
-      0x58280008,  //  0016  LDCONST	R10	K8
-      0x7C1C0600,  //  0017  CALL	R7	3
-      0x80040E00,  //  0018  RET	1	R7
-      0x7002002B,  //  0019  JMP		#0046
-      0x541E000E,  //  001A  LDINT	R7	15
-      0x1C1C0C07,  //  001B  EQ	R7	R6	R7
-      0x781E0005,  //  001C  JMPF	R7	#0023
-      0x8C1C0905,  //  001D  GETMET	R7	R4	K5
-      0x88240906,  //  001E  GETMBR	R9	R4	K6
-      0x58280009,  //  001F  LDCONST	R10	K9
-      0x7C1C0600,  //  0020  CALL	R7	3
-      0x80040E00,  //  0021  RET	1	R7
-      0x70020022,  //  0022  JMP		#0046
-      0x541E400A,  //  0023  LDINT	R7	16395
-      0x1C1C0C07,  //  0024  EQ	R7	R6	R7
-      0x781E0005,  //  0025  JMPF	R7	#002C
-      0x8C1C0905,  //  0026  GETMET	R7	R4	K5
-      0x88240906,  //  0027  GETMBR	R9	R4	K6
-      0x8828010A,  //  0028  GETMBR	R10	R0	K10
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x80040E00,  //  002A  RET	1	R7
-      0x70020019,  //  002B  JMP		#0046
-      0x541E400B,  //  002C  LDINT	R7	16396
-      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
-      0x781E0005,  //  002E  JMPF	R7	#0035
-      0x8C1C0905,  //  002F  GETMET	R7	R4	K5
-      0x88240906,  //  0030  GETMBR	R9	R4	K6
-      0x8828010B,  //  0031  GETMBR	R10	R0	K11
-      0x7C1C0600,  //  0032  CALL	R7	3
-      0x80040E00,  //  0033  RET	1	R7
-      0x70020010,  //  0034  JMP		#0046
-      0x541EFFFB,  //  0035  LDINT	R7	65532
-      0x1C1C0C07,  //  0036  EQ	R7	R6	R7
-      0x781E0005,  //  0037  JMPF	R7	#003E
-      0x8C1C0905,  //  0038  GETMET	R7	R4	K5
-      0x8824090C,  //  0039  GETMBR	R9	R4	K12
-      0x542A000F,  //  003A  LDINT	R10	16
-      0x7C1C0600,  //  003B  CALL	R7	3
-      0x80040E00,  //  003C  RET	1	R7
-      0x70020007,  //  003D  JMP		#0046
-      0x541EFFFC,  //  003E  LDINT	R7	65533
-      0x1C1C0C07,  //  003F  EQ	R7	R6	R7
-      0x781E0004,  //  0040  JMPF	R7	#0046
-      0x8C1C0905,  //  0041  GETMET	R7	R4	K5
-      0x8824090C,  //  0042  GETMBR	R9	R4	K12
-      0x542A0004,  //  0043  LDINT	R10	5
-      0x7C1C0600,  //  0044  CALL	R7	3
-      0x80040E00,  //  0045  RET	1	R7
-      0x70020007,  //  0046  JMP		#004F
-      0x601C0003,  //  0047  GETGBL	R7	G3
-      0x5C200000,  //  0048  MOVE	R8	R0
-      0x7C1C0200,  //  0049  CALL	R7	1
-      0x8C1C0F0D,  //  004A  GETMET	R7	R7	K13
-      0x5C240200,  //  004B  MOVE	R9	R1
-      0x5C280400,  //  004C  MOVE	R10	R2
-      0x7C1C0600,  //  004D  CALL	R7	3
-      0x80040E00,  //  004E  RET	1	R7
-      0x80000000,  //  004F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Plugin_Light2_init,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(shadow_ct),
-    /* K2   */  be_nested_str_weak(update_ct_minmax),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x600C0003,  //  0000  GETGBL	R3	G3
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x540E0144,  //  0007  LDINT	R3	325
-      0x90020203,  //  0008  SETMBR	R0	K1	R3
-      0x8C0C0102,  //  0009  GETMET	R3	R0	K2
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_ct_minmax
-********************************************************************/
-be_local_closure(Matter_Plugin_Light2_update_ct_minmax,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(get_option),
-    /* K2   */  be_nested_str_weak(ct_min),
-    /* K3   */  be_nested_str_weak(ct_max),
-    }),
-    be_str_weak(update_ct_minmax),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x540E0051,  //  0002  LDINT	R3	82
-      0x7C040400,  //  0003  CALL	R1	2
-      0x78060001,  //  0004  JMPF	R1	#0007
-      0x540A00C7,  //  0005  LDINT	R2	200
-      0x70020000,  //  0006  JMP		#0008
-      0x540A0098,  //  0007  LDINT	R2	153
-      0x90020402,  //  0008  SETMBR	R0	K2	R2
-      0x78060001,  //  0009  JMPF	R1	#000C
-      0x540A017B,  //  000A  LDINT	R2	380
-      0x70020000,  //  000B  JMP		#000D
-      0x540A01F3,  //  000C  LDINT	R2	500
-      0x90020602,  //  000D  SETMBR	R0	K3	R2
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
 be_local_closure(Matter_Plugin_Light2_invoke_request,   /* name */
@@ -371,23 +171,226 @@ be_local_closure(Matter_Plugin_Light2_update_shadow,   /* name */
 
 
 /********************************************************************
+** Solidified function: read_attribute
+********************************************************************/
+be_local_closure(Matter_Plugin_Light2_read_attribute,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_nested_str_weak(create_TLV),
+    /* K6   */  be_nested_str_weak(U1),
+    /* K7   */  be_nested_str_weak(shadow_ct),
+    /* K8   */  be_const_int(2),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_nested_str_weak(ct_min),
+    /* K11  */  be_nested_str_weak(ct_max),
+    /* K12  */  be_nested_str_weak(U4),
+    /* K13  */  be_nested_str_weak(read_attribute),
+    }),
+    be_str_weak(read_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[80]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x88100902,  //  0002  GETMBR	R4	R4	K2
+      0x88140503,  //  0003  GETMBR	R5	R2	K3
+      0x88180504,  //  0004  GETMBR	R6	R2	K4
+      0x541E02FF,  //  0005  LDINT	R7	768
+      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
+      0x781E003E,  //  0007  JMPF	R7	#0047
+      0x541E0006,  //  0008  LDINT	R7	7
+      0x1C1C0C07,  //  0009  EQ	R7	R6	R7
+      0x781E0005,  //  000A  JMPF	R7	#0011
+      0x8C1C0905,  //  000B  GETMET	R7	R4	K5
+      0x88240906,  //  000C  GETMBR	R9	R4	K6
+      0x88280107,  //  000D  GETMBR	R10	R0	K7
+      0x7C1C0600,  //  000E  CALL	R7	3
+      0x80040E00,  //  000F  RET	1	R7
+      0x70020034,  //  0010  JMP		#0046
+      0x541E0007,  //  0011  LDINT	R7	8
+      0x1C1C0C07,  //  0012  EQ	R7	R6	R7
+      0x781E0005,  //  0013  JMPF	R7	#001A
+      0x8C1C0905,  //  0014  GETMET	R7	R4	K5
+      0x88240906,  //  0015  GETMBR	R9	R4	K6
+      0x58280008,  //  0016  LDCONST	R10	K8
+      0x7C1C0600,  //  0017  CALL	R7	3
+      0x80040E00,  //  0018  RET	1	R7
+      0x7002002B,  //  0019  JMP		#0046
+      0x541E000E,  //  001A  LDINT	R7	15
+      0x1C1C0C07,  //  001B  EQ	R7	R6	R7
+      0x781E0005,  //  001C  JMPF	R7	#0023
+      0x8C1C0905,  //  001D  GETMET	R7	R4	K5
+      0x88240906,  //  001E  GETMBR	R9	R4	K6
+      0x58280009,  //  001F  LDCONST	R10	K9
+      0x7C1C0600,  //  0020  CALL	R7	3
+      0x80040E00,  //  0021  RET	1	R7
+      0x70020022,  //  0022  JMP		#0046
+      0x541E400A,  //  0023  LDINT	R7	16395
+      0x1C1C0C07,  //  0024  EQ	R7	R6	R7
+      0x781E0005,  //  0025  JMPF	R7	#002C
+      0x8C1C0905,  //  0026  GETMET	R7	R4	K5
+      0x88240906,  //  0027  GETMBR	R9	R4	K6
+      0x8828010A,  //  0028  GETMBR	R10	R0	K10
+      0x7C1C0600,  //  0029  CALL	R7	3
+      0x80040E00,  //  002A  RET	1	R7
+      0x70020019,  //  002B  JMP		#0046
+      0x541E400B,  //  002C  LDINT	R7	16396
+      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
+      0x781E0005,  //  002E  JMPF	R7	#0035
+      0x8C1C0905,  //  002F  GETMET	R7	R4	K5
+      0x88240906,  //  0030  GETMBR	R9	R4	K6
+      0x8828010B,  //  0031  GETMBR	R10	R0	K11
+      0x7C1C0600,  //  0032  CALL	R7	3
+      0x80040E00,  //  0033  RET	1	R7
+      0x70020010,  //  0034  JMP		#0046
+      0x541EFFFB,  //  0035  LDINT	R7	65532
+      0x1C1C0C07,  //  0036  EQ	R7	R6	R7
+      0x781E0005,  //  0037  JMPF	R7	#003E
+      0x8C1C0905,  //  0038  GETMET	R7	R4	K5
+      0x8824090C,  //  0039  GETMBR	R9	R4	K12
+      0x542A000F,  //  003A  LDINT	R10	16
+      0x7C1C0600,  //  003B  CALL	R7	3
+      0x80040E00,  //  003C  RET	1	R7
+      0x70020007,  //  003D  JMP		#0046
+      0x541EFFFC,  //  003E  LDINT	R7	65533
+      0x1C1C0C07,  //  003F  EQ	R7	R6	R7
+      0x781E0004,  //  0040  JMPF	R7	#0046
+      0x8C1C0905,  //  0041  GETMET	R7	R4	K5
+      0x8824090C,  //  0042  GETMBR	R9	R4	K12
+      0x542A0004,  //  0043  LDINT	R10	5
+      0x7C1C0600,  //  0044  CALL	R7	3
+      0x80040E00,  //  0045  RET	1	R7
+      0x70020007,  //  0046  JMP		#004F
+      0x601C0003,  //  0047  GETGBL	R7	G3
+      0x5C200000,  //  0048  MOVE	R8	R0
+      0x7C1C0200,  //  0049  CALL	R7	1
+      0x8C1C0F0D,  //  004A  GETMET	R7	R7	K13
+      0x5C240200,  //  004B  MOVE	R9	R1
+      0x5C280400,  //  004C  MOVE	R10	R2
+      0x7C1C0600,  //  004D  CALL	R7	3
+      0x80040E00,  //  004E  RET	1	R7
+      0x80000000,  //  004F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Plugin_Light2_init,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(shadow_ct),
+    /* K2   */  be_nested_str_weak(update_ct_minmax),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x60100003,  //  0000  GETGBL	R4	G3
+      0x5C140000,  //  0001  MOVE	R5	R0
+      0x7C100200,  //  0002  CALL	R4	1
+      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x5C200600,  //  0006  MOVE	R8	R3
+      0x7C100800,  //  0007  CALL	R4	4
+      0x54120144,  //  0008  LDINT	R4	325
+      0x90020204,  //  0009  SETMBR	R0	K1	R4
+      0x8C100102,  //  000A  GETMET	R4	R0	K2
+      0x7C100200,  //  000B  CALL	R4	1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_ct_minmax
+********************************************************************/
+be_local_closure(Matter_Plugin_Light2_update_ct_minmax,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(get_option),
+    /* K2   */  be_nested_str_weak(ct_min),
+    /* K3   */  be_nested_str_weak(ct_max),
+    }),
+    be_str_weak(update_ct_minmax),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x540E0051,  //  0002  LDINT	R3	82
+      0x7C040400,  //  0003  CALL	R1	2
+      0x78060001,  //  0004  JMPF	R1	#0007
+      0x540A00C7,  //  0005  LDINT	R2	200
+      0x70020000,  //  0006  JMP		#0008
+      0x540A0098,  //  0007  LDINT	R2	153
+      0x90020402,  //  0008  SETMBR	R0	K2	R2
+      0x78060001,  //  0009  JMPF	R1	#000C
+      0x540A017B,  //  000A  LDINT	R2	380
+      0x70020000,  //  000B  JMP		#000D
+      0x540A01F3,  //  000C  LDINT	R2	500
+      0x90020602,  //  000D  SETMBR	R0	K3	R2
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_Plugin_Light2
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light1;
 be_local_class(Matter_Plugin_Light2,
     3,
     &be_class_Matter_Plugin_Light1,
-    be_nested_map(10,
+    be_nested_map(11,
     ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(update_ct_minmax, -1), be_const_closure(Matter_Plugin_Light2_update_ct_minmax_closure) },
+        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_Light2_update_shadow_closure) },
+        { be_const_key_weak(NAME, 5), be_nested_str_weak(light2) },
+        { be_const_key_weak(read_attribute, 8), be_const_closure(Matter_Plugin_Light2_read_attribute_closure) },
         { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(268, -1), be_const_int(2) },
     }))    ) } )) },
-        { be_const_key_weak(shadow_ct, -1), be_const_var(0) },
-        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Light2_read_attribute_closure) },
-        { be_const_key_weak(ct_min, 8), be_const_var(1) },
-        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(ct_min, 1), be_const_var(1) },
+        { be_const_key_weak(CLUSTERS, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(768, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
@@ -402,11 +405,10 @@ be_local_class(Matter_Plugin_Light2,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Light2_init_closure) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_Light2_invoke_request_closure) },
-        { be_const_key_weak(update_ct_minmax, 6), be_const_closure(Matter_Plugin_Light2_update_ct_minmax_closure) },
+        { be_const_key_weak(shadow_ct, -1), be_const_var(0) },
         { be_const_key_weak(ct_max, -1), be_const_var(2) },
-        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_Light2_update_shadow_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Light2_init_closure) },
+        { be_const_key_weak(invoke_request, 0), be_const_closure(Matter_Plugin_Light2_invoke_request_closure) },
     })),
     be_str_weak(Matter_Plugin_Light2)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light3.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light3.h
@@ -7,186 +7,6 @@
 extern const bclass be_class_Matter_Plugin_Light3;
 
 /********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Plugin_Light3_init,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(shadow_hue),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(shadow_sat),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x600C0003,  //  0000  GETGBL	R3	G3
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x90020302,  //  0007  SETMBR	R0	K1	K2
-      0x90020702,  //  0008  SETMBR	R0	K3	K2
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: read_attribute
-********************************************************************/
-be_local_closure(Matter_Plugin_Light3_read_attribute,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(create_TLV),
-    /* K7   */  be_nested_str_weak(U1),
-    /* K8   */  be_nested_str_weak(shadow_hue),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(shadow_sat),
-    /* K11  */  be_nested_str_weak(U4),
-    /* K12  */  be_nested_str_weak(read_attribute),
-    }),
-    be_str_weak(read_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[105]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
-      0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E02FF,  //  0005  LDINT	R7	768
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0057,  //  0007  JMPF	R7	#0060
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E0005,  //  0009  JMPF	R7	#0010
-      0x8C1C0906,  //  000A  GETMET	R7	R4	K6
-      0x88240907,  //  000B  GETMBR	R9	R4	K7
-      0x88280108,  //  000C  GETMBR	R10	R0	K8
-      0x7C1C0600,  //  000D  CALL	R7	3
-      0x80040E00,  //  000E  RET	1	R7
-      0x7002004E,  //  000F  JMP		#005F
-      0x1C1C0D09,  //  0010  EQ	R7	R6	K9
-      0x781E0005,  //  0011  JMPF	R7	#0018
-      0x8C1C0906,  //  0012  GETMET	R7	R4	K6
-      0x88240907,  //  0013  GETMBR	R9	R4	K7
-      0x8828010A,  //  0014  GETMBR	R10	R0	K10
-      0x7C1C0600,  //  0015  CALL	R7	3
-      0x80040E00,  //  0016  RET	1	R7
-      0x70020046,  //  0017  JMP		#005F
-      0x541E0006,  //  0018  LDINT	R7	7
-      0x1C1C0C07,  //  0019  EQ	R7	R6	R7
-      0x781E0005,  //  001A  JMPF	R7	#0021
-      0x8C1C0906,  //  001B  GETMET	R7	R4	K6
-      0x88240907,  //  001C  GETMBR	R9	R4	K7
-      0x58280005,  //  001D  LDCONST	R10	K5
-      0x7C1C0600,  //  001E  CALL	R7	3
-      0x80040E00,  //  001F  RET	1	R7
-      0x7002003D,  //  0020  JMP		#005F
-      0x541E0007,  //  0021  LDINT	R7	8
-      0x1C1C0C07,  //  0022  EQ	R7	R6	R7
-      0x781E0005,  //  0023  JMPF	R7	#002A
-      0x8C1C0906,  //  0024  GETMET	R7	R4	K6
-      0x88240907,  //  0025  GETMBR	R9	R4	K7
-      0x58280005,  //  0026  LDCONST	R10	K5
-      0x7C1C0600,  //  0027  CALL	R7	3
-      0x80040E00,  //  0028  RET	1	R7
-      0x70020034,  //  0029  JMP		#005F
-      0x541E000E,  //  002A  LDINT	R7	15
-      0x1C1C0C07,  //  002B  EQ	R7	R6	R7
-      0x781E0005,  //  002C  JMPF	R7	#0033
-      0x8C1C0906,  //  002D  GETMET	R7	R4	K6
-      0x88240907,  //  002E  GETMBR	R9	R4	K7
-      0x58280005,  //  002F  LDCONST	R10	K5
-      0x7C1C0600,  //  0030  CALL	R7	3
-      0x80040E00,  //  0031  RET	1	R7
-      0x7002002B,  //  0032  JMP		#005F
-      0x541E4000,  //  0033  LDINT	R7	16385
-      0x1C1C0C07,  //  0034  EQ	R7	R6	R7
-      0x781E0005,  //  0035  JMPF	R7	#003C
-      0x8C1C0906,  //  0036  GETMET	R7	R4	K6
-      0x88240907,  //  0037  GETMBR	R9	R4	K7
-      0x58280005,  //  0038  LDCONST	R10	K5
-      0x7C1C0600,  //  0039  CALL	R7	3
-      0x80040E00,  //  003A  RET	1	R7
-      0x70020022,  //  003B  JMP		#005F
-      0x541E4009,  //  003C  LDINT	R7	16394
-      0x1C1C0C07,  //  003D  EQ	R7	R6	R7
-      0x781E0005,  //  003E  JMPF	R7	#0045
-      0x8C1C0906,  //  003F  GETMET	R7	R4	K6
-      0x88240907,  //  0040  GETMBR	R9	R4	K7
-      0x58280005,  //  0041  LDCONST	R10	K5
-      0x7C1C0600,  //  0042  CALL	R7	3
-      0x80040E00,  //  0043  RET	1	R7
-      0x70020019,  //  0044  JMP		#005F
-      0x541E000F,  //  0045  LDINT	R7	16
-      0x1C1C0C07,  //  0046  EQ	R7	R6	R7
-      0x781E0005,  //  0047  JMPF	R7	#004E
-      0x8C1C0906,  //  0048  GETMET	R7	R4	K6
-      0x88240907,  //  0049  GETMBR	R9	R4	K7
-      0x58280005,  //  004A  LDCONST	R10	K5
-      0x7C1C0600,  //  004B  CALL	R7	3
-      0x80040E00,  //  004C  RET	1	R7
-      0x70020010,  //  004D  JMP		#005F
-      0x541EFFFB,  //  004E  LDINT	R7	65532
-      0x1C1C0C07,  //  004F  EQ	R7	R6	R7
-      0x781E0005,  //  0050  JMPF	R7	#0057
-      0x8C1C0906,  //  0051  GETMET	R7	R4	K6
-      0x8824090B,  //  0052  GETMBR	R9	R4	K11
-      0x58280009,  //  0053  LDCONST	R10	K9
-      0x7C1C0600,  //  0054  CALL	R7	3
-      0x80040E00,  //  0055  RET	1	R7
-      0x70020007,  //  0056  JMP		#005F
-      0x541EFFFC,  //  0057  LDINT	R7	65533
-      0x1C1C0C07,  //  0058  EQ	R7	R6	R7
-      0x781E0004,  //  0059  JMPF	R7	#005F
-      0x8C1C0906,  //  005A  GETMET	R7	R4	K6
-      0x8824090B,  //  005B  GETMBR	R9	R4	K11
-      0x542A0004,  //  005C  LDINT	R10	5
-      0x7C1C0600,  //  005D  CALL	R7	3
-      0x80040E00,  //  005E  RET	1	R7
-      0x70020007,  //  005F  JMP		#0068
-      0x601C0003,  //  0060  GETGBL	R7	G3
-      0x5C200000,  //  0061  MOVE	R8	R0
-      0x7C1C0200,  //  0062  CALL	R7	1
-      0x8C1C0F0C,  //  0063  GETMET	R7	R7	K12
-      0x5C240200,  //  0064  MOVE	R9	R1
-      0x5C280400,  //  0065  MOVE	R10	R2
-      0x7C1C0600,  //  0066  CALL	R7	3
-      0x80040E00,  //  0067  RET	1	R7
-      0x80000000,  //  0068  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
 be_local_closure(Matter_Plugin_Light3_invoke_request,   /* name */
@@ -380,6 +200,148 @@ be_local_closure(Matter_Plugin_Light3_invoke_request,   /* name */
 
 
 /********************************************************************
+** Solidified function: read_attribute
+********************************************************************/
+be_local_closure(Matter_Plugin_Light3_read_attribute,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(U1),
+    /* K8   */  be_nested_str_weak(shadow_hue),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(shadow_sat),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_nested_str_weak(read_attribute),
+    }),
+    be_str_weak(read_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[105]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x88100902,  //  0002  GETMBR	R4	R4	K2
+      0x88140503,  //  0003  GETMBR	R5	R2	K3
+      0x88180504,  //  0004  GETMBR	R6	R2	K4
+      0x541E02FF,  //  0005  LDINT	R7	768
+      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
+      0x781E0057,  //  0007  JMPF	R7	#0060
+      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
+      0x781E0005,  //  0009  JMPF	R7	#0010
+      0x8C1C0906,  //  000A  GETMET	R7	R4	K6
+      0x88240907,  //  000B  GETMBR	R9	R4	K7
+      0x88280108,  //  000C  GETMBR	R10	R0	K8
+      0x7C1C0600,  //  000D  CALL	R7	3
+      0x80040E00,  //  000E  RET	1	R7
+      0x7002004E,  //  000F  JMP		#005F
+      0x1C1C0D09,  //  0010  EQ	R7	R6	K9
+      0x781E0005,  //  0011  JMPF	R7	#0018
+      0x8C1C0906,  //  0012  GETMET	R7	R4	K6
+      0x88240907,  //  0013  GETMBR	R9	R4	K7
+      0x8828010A,  //  0014  GETMBR	R10	R0	K10
+      0x7C1C0600,  //  0015  CALL	R7	3
+      0x80040E00,  //  0016  RET	1	R7
+      0x70020046,  //  0017  JMP		#005F
+      0x541E0006,  //  0018  LDINT	R7	7
+      0x1C1C0C07,  //  0019  EQ	R7	R6	R7
+      0x781E0005,  //  001A  JMPF	R7	#0021
+      0x8C1C0906,  //  001B  GETMET	R7	R4	K6
+      0x88240907,  //  001C  GETMBR	R9	R4	K7
+      0x58280005,  //  001D  LDCONST	R10	K5
+      0x7C1C0600,  //  001E  CALL	R7	3
+      0x80040E00,  //  001F  RET	1	R7
+      0x7002003D,  //  0020  JMP		#005F
+      0x541E0007,  //  0021  LDINT	R7	8
+      0x1C1C0C07,  //  0022  EQ	R7	R6	R7
+      0x781E0005,  //  0023  JMPF	R7	#002A
+      0x8C1C0906,  //  0024  GETMET	R7	R4	K6
+      0x88240907,  //  0025  GETMBR	R9	R4	K7
+      0x58280005,  //  0026  LDCONST	R10	K5
+      0x7C1C0600,  //  0027  CALL	R7	3
+      0x80040E00,  //  0028  RET	1	R7
+      0x70020034,  //  0029  JMP		#005F
+      0x541E000E,  //  002A  LDINT	R7	15
+      0x1C1C0C07,  //  002B  EQ	R7	R6	R7
+      0x781E0005,  //  002C  JMPF	R7	#0033
+      0x8C1C0906,  //  002D  GETMET	R7	R4	K6
+      0x88240907,  //  002E  GETMBR	R9	R4	K7
+      0x58280005,  //  002F  LDCONST	R10	K5
+      0x7C1C0600,  //  0030  CALL	R7	3
+      0x80040E00,  //  0031  RET	1	R7
+      0x7002002B,  //  0032  JMP		#005F
+      0x541E4000,  //  0033  LDINT	R7	16385
+      0x1C1C0C07,  //  0034  EQ	R7	R6	R7
+      0x781E0005,  //  0035  JMPF	R7	#003C
+      0x8C1C0906,  //  0036  GETMET	R7	R4	K6
+      0x88240907,  //  0037  GETMBR	R9	R4	K7
+      0x58280005,  //  0038  LDCONST	R10	K5
+      0x7C1C0600,  //  0039  CALL	R7	3
+      0x80040E00,  //  003A  RET	1	R7
+      0x70020022,  //  003B  JMP		#005F
+      0x541E4009,  //  003C  LDINT	R7	16394
+      0x1C1C0C07,  //  003D  EQ	R7	R6	R7
+      0x781E0005,  //  003E  JMPF	R7	#0045
+      0x8C1C0906,  //  003F  GETMET	R7	R4	K6
+      0x88240907,  //  0040  GETMBR	R9	R4	K7
+      0x58280005,  //  0041  LDCONST	R10	K5
+      0x7C1C0600,  //  0042  CALL	R7	3
+      0x80040E00,  //  0043  RET	1	R7
+      0x70020019,  //  0044  JMP		#005F
+      0x541E000F,  //  0045  LDINT	R7	16
+      0x1C1C0C07,  //  0046  EQ	R7	R6	R7
+      0x781E0005,  //  0047  JMPF	R7	#004E
+      0x8C1C0906,  //  0048  GETMET	R7	R4	K6
+      0x88240907,  //  0049  GETMBR	R9	R4	K7
+      0x58280005,  //  004A  LDCONST	R10	K5
+      0x7C1C0600,  //  004B  CALL	R7	3
+      0x80040E00,  //  004C  RET	1	R7
+      0x70020010,  //  004D  JMP		#005F
+      0x541EFFFB,  //  004E  LDINT	R7	65532
+      0x1C1C0C07,  //  004F  EQ	R7	R6	R7
+      0x781E0005,  //  0050  JMPF	R7	#0057
+      0x8C1C0906,  //  0051  GETMET	R7	R4	K6
+      0x8824090B,  //  0052  GETMBR	R9	R4	K11
+      0x58280009,  //  0053  LDCONST	R10	K9
+      0x7C1C0600,  //  0054  CALL	R7	3
+      0x80040E00,  //  0055  RET	1	R7
+      0x70020007,  //  0056  JMP		#005F
+      0x541EFFFC,  //  0057  LDINT	R7	65533
+      0x1C1C0C07,  //  0058  EQ	R7	R6	R7
+      0x781E0004,  //  0059  JMPF	R7	#005F
+      0x8C1C0906,  //  005A  GETMET	R7	R4	K6
+      0x8824090B,  //  005B  GETMBR	R9	R4	K11
+      0x542A0004,  //  005C  LDINT	R10	5
+      0x7C1C0600,  //  005D  CALL	R7	3
+      0x80040E00,  //  005E  RET	1	R7
+      0x70020007,  //  005F  JMP		#0068
+      0x601C0003,  //  0060  GETGBL	R7	G3
+      0x5C200000,  //  0061  MOVE	R8	R0
+      0x7C1C0200,  //  0062  CALL	R7	1
+      0x8C1C0F0C,  //  0063  GETMET	R7	R7	K12
+      0x5C240200,  //  0064  MOVE	R9	R1
+      0x5C280400,  //  0065  MOVE	R10	R2
+      0x7C1C0600,  //  0066  CALL	R7	3
+      0x80040E00,  //  0067  RET	1	R7
+      0x80000000,  //  0068  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: update_shadow
 ********************************************************************/
 be_local_closure(Matter_Plugin_Light3_update_shadow,   /* name */
@@ -480,15 +442,66 @@ be_local_closure(Matter_Plugin_Light3_update_shadow,   /* name */
 
 
 /********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Plugin_Light3_init,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(shadow_hue),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(shadow_sat),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x60100003,  //  0000  GETGBL	R4	G3
+      0x5C140000,  //  0001  MOVE	R5	R0
+      0x7C100200,  //  0002  CALL	R4	1
+      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x5C200600,  //  0006  MOVE	R8	R3
+      0x7C100800,  //  0007  CALL	R4	4
+      0x90020302,  //  0008  SETMBR	R0	K1	K2
+      0x90020702,  //  0009  SETMBR	R0	K3	K2
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_Plugin_Light3
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Light1;
 be_local_class(Matter_Plugin_Light3,
     2,
     &be_class_Matter_Plugin_Light1,
-    be_nested_map(8,
+    be_nested_map(9,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(CLUSTERS, 7), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Light3_init_closure) },
+        { be_const_key_weak(shadow_sat, -1), be_const_var(1) },
+        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(269, -1), be_const_int(2) },
+    }))    ) } )) },
+        { be_const_key_weak(NAME, -1), be_nested_str_weak(light3) },
+        { be_const_key_weak(shadow_hue, 8), be_const_var(0) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_Light3_invoke_request_closure) },
+        { be_const_key_weak(read_attribute, 0), be_const_closure(Matter_Plugin_Light3_read_attribute_closure) },
+        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_Light3_update_shadow_closure) },
+        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(768, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
@@ -505,17 +518,6 @@ be_local_class(Matter_Plugin_Light3,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_Light3_invoke_request_closure) },
-        { be_const_key_weak(TYPES, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_int(269, -1), be_const_int(2) },
-    }))    ) } )) },
-        { be_const_key_weak(init, 1), be_const_closure(Matter_Plugin_Light3_init_closure) },
-        { be_const_key_weak(shadow_hue, -1), be_const_var(0) },
-        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_Light3_update_shadow_closure) },
-        { be_const_key_weak(shadow_sat, -1), be_const_var(1) },
-        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Light3_read_attribute_closure) },
     })),
     be_str_weak(Matter_Plugin_Light3)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_OnOff.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_OnOff.h
@@ -7,6 +7,101 @@
 extern const bclass be_class_Matter_Plugin_OnOff;
 
 /********************************************************************
+** Solidified function: get_onoff
+********************************************************************/
+be_local_closure(Matter_Plugin_OnOff_get_onoff,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(get_power),
+    /* K2   */  be_nested_str_weak(tasmota_relay_index),
+    /* K3   */  be_nested_str_weak(shadow_onoff),
+    /* K4   */  be_nested_str_weak(onoff_changed),
+    }),
+    be_str_weak(get_onoff),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x7C040400,  //  0003  CALL	R1	2
+      0x4C080000,  //  0004  LDNIL	R2
+      0x20080202,  //  0005  NE	R2	R1	R2
+      0x780A000C,  //  0006  JMPF	R2	#0014
+      0x88080103,  //  0007  GETMBR	R2	R0	K3
+      0x4C0C0000,  //  0008  LDNIL	R3
+      0x20080403,  //  0009  NE	R2	R2	R3
+      0x780A0007,  //  000A  JMPF	R2	#0013
+      0x88080103,  //  000B  GETMBR	R2	R0	K3
+      0x600C0017,  //  000C  GETGBL	R3	G23
+      0x5C100200,  //  000D  MOVE	R4	R1
+      0x7C0C0200,  //  000E  CALL	R3	1
+      0x20080403,  //  000F  NE	R2	R2	R3
+      0x780A0001,  //  0010  JMPF	R2	#0013
+      0x8C080104,  //  0011  GETMET	R2	R0	K4
+      0x7C080200,  //  0012  CALL	R2	1
+      0x90020601,  //  0013  SETMBR	R0	K3	R1
+      0x88080103,  //  0014  GETMBR	R2	R0	K3
+      0x4C0C0000,  //  0015  LDNIL	R3
+      0x1C080403,  //  0016  EQ	R2	R2	R3
+      0x780A0001,  //  0017  JMPF	R2	#001A
+      0x50080000,  //  0018  LDBOOL	R2	0	0
+      0x90020602,  //  0019  SETMBR	R0	K3	R2
+      0x88080103,  //  001A  GETMBR	R2	R0	K3
+      0x80040400,  //  001B  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_onoff
+********************************************************************/
+be_local_closure(Matter_Plugin_OnOff_set_onoff,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(set_power),
+    /* K2   */  be_nested_str_weak(tasmota_relay_index),
+    /* K3   */  be_nested_str_weak(get_onoff),
+    }),
+    be_str_weak(set_onoff),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x60140017,  //  0003  GETGBL	R5	G23
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x7C140200,  //  0005  CALL	R5	1
+      0x7C080600,  //  0006  CALL	R2	3
+      0x8C080103,  //  0007  GETMET	R2	R0	K3
+      0x7C080200,  //  0008  CALL	R2	1
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
 be_local_closure(Matter_Plugin_OnOff_invoke_request,   /* name */
@@ -163,56 +258,49 @@ be_local_closure(Matter_Plugin_OnOff_invoke_request,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_onoff
+** Solidified function: init
 ********************************************************************/
-be_local_closure(Matter_Plugin_OnOff_get_onoff,   /* name */
+be_local_closure(Matter_Plugin_OnOff_init,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
+    9,                          /* nstack */
+    4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(get_power),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(get_onoff),
     /* K2   */  be_nested_str_weak(tasmota_relay_index),
-    /* K3   */  be_nested_str_weak(shadow_onoff),
-    /* K4   */  be_nested_str_weak(onoff_changed),
+    /* K3   */  be_nested_str_weak(find),
+    /* K4   */  be_nested_str_weak(relay),
+    /* K5   */  be_const_int(0),
     }),
-    be_str_weak(get_onoff),
+    be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x7C040400,  //  0003  CALL	R1	2
-      0x4C080000,  //  0004  LDNIL	R2
-      0x20080202,  //  0005  NE	R2	R1	R2
-      0x780A000C,  //  0006  JMPF	R2	#0014
-      0x88080103,  //  0007  GETMBR	R2	R0	K3
-      0x4C0C0000,  //  0008  LDNIL	R3
-      0x20080403,  //  0009  NE	R2	R2	R3
-      0x780A0007,  //  000A  JMPF	R2	#0013
-      0x88080103,  //  000B  GETMBR	R2	R0	K3
-      0x600C0017,  //  000C  GETGBL	R3	G23
-      0x5C100200,  //  000D  MOVE	R4	R1
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0x20080403,  //  000F  NE	R2	R2	R3
-      0x780A0001,  //  0010  JMPF	R2	#0013
-      0x8C080104,  //  0011  GETMET	R2	R0	K4
-      0x7C080200,  //  0012  CALL	R2	1
-      0x90020601,  //  0013  SETMBR	R0	K3	R1
-      0x88080103,  //  0014  GETMBR	R2	R0	K3
-      0x4C0C0000,  //  0015  LDNIL	R3
-      0x1C080403,  //  0016  EQ	R2	R2	R3
-      0x780A0001,  //  0017  JMPF	R2	#001A
-      0x50080000,  //  0018  LDBOOL	R2	0	0
-      0x90020602,  //  0019  SETMBR	R0	K3	R2
-      0x88080103,  //  001A  GETMBR	R2	R0	K3
-      0x80040400,  //  001B  RET	1	R2
+    ( &(const binstruction[20]) {  /* code */
+      0x60100003,  //  0000  GETGBL	R4	G3
+      0x5C140000,  //  0001  MOVE	R5	R0
+      0x7C100200,  //  0002  CALL	R4	1
+      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x5C200600,  //  0006  MOVE	R8	R3
+      0x7C100800,  //  0007  CALL	R4	4
+      0x8C100101,  //  0008  GETMET	R4	R0	K1
+      0x7C100200,  //  0009  CALL	R4	1
+      0x8C100703,  //  000A  GETMET	R4	R3	K3
+      0x58180004,  //  000B  LDCONST	R6	K4
+      0x7C100400,  //  000C  CALL	R4	2
+      0x90020404,  //  000D  SETMBR	R0	K2	R4
+      0x88100102,  //  000E  GETMBR	R4	R0	K2
+      0x4C140000,  //  000F  LDNIL	R5
+      0x1C100805,  //  0010  EQ	R4	R4	R5
+      0x78120000,  //  0011  JMPF	R4	#0013
+      0x90020505,  //  0012  SETMBR	R0	K2	K5
+      0x80000000,  //  0013  RET	0
     })
   )
 );
@@ -252,9 +340,9 @@ be_local_closure(Matter_Plugin_OnOff_onoff_changed,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_onoff
+** Solidified function: to_json_parameters
 ********************************************************************/
-be_local_closure(Matter_Plugin_OnOff_set_onoff,   /* name */
+be_local_closure(Matter_Plugin_OnOff_to_json_parameters,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
@@ -265,24 +353,49 @@ be_local_closure(Matter_Plugin_OnOff_set_onoff,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(set_power),
-    /* K2   */  be_nested_str_weak(tasmota_relay_index),
-    /* K3   */  be_nested_str_weak(get_onoff),
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(format),
+    /* K2   */  be_nested_str_weak(_X2C_X22relay_X22_X3A_X25i),
+    /* K3   */  be_nested_str_weak(tasmota_relay_index),
     }),
-    be_str_weak(set_onoff),
+    be_str_weak(to_json_parameters),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
-      0x60140017,  //  0003  GETGBL	R5	G23
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x7C140200,  //  0005  CALL	R5	1
-      0x7C080600,  //  0006  CALL	R2	3
-      0x8C080103,  //  0007  GETMET	R2	R0	K3
-      0x7C080200,  //  0008  CALL	R2	1
-      0x80000000,  //  0009  RET	0
+    ( &(const binstruction[ 7]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0x58140002,  //  0002  LDCONST	R5	K2
+      0x88180103,  //  0003  GETMBR	R6	R0	K3
+      0x7C0C0600,  //  0004  CALL	R3	3
+      0x00040203,  //  0005  ADD	R1	R1	R3
+      0x80040200,  //  0006  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Plugin_OnOff_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_onoff),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
     })
   )
 );
@@ -503,95 +616,24 @@ be_local_closure(Matter_Plugin_OnOff_read_attribute,   /* name */
 
 
 /********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Plugin_OnOff_init,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(get_onoff),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(tasmota_relay_index),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x60100003,  //  0000  GETGBL	R4	G3
-      0x5C140000,  //  0001  MOVE	R5	R0
-      0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x5C1C0400,  //  0005  MOVE	R7	R2
-      0x7C100600,  //  0006  CALL	R4	3
-      0x8C100101,  //  0007  GETMET	R4	R0	K1
-      0x7C100200,  //  0008  CALL	R4	1
-      0x4C100000,  //  0009  LDNIL	R4
-      0x1C100604,  //  000A  EQ	R4	R3	R4
-      0x78120000,  //  000B  JMPF	R4	#000D
-      0x580C0002,  //  000C  LDCONST	R3	K2
-      0x90020603,  //  000D  SETMBR	R0	K3	R3
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(Matter_Plugin_OnOff_every_second,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_onoff),
-    }),
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_Plugin_OnOff
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin;
 be_local_class(Matter_Plugin_OnOff,
     2,
     &be_class_Matter_Plugin,
-    be_nested_map(11,
+    be_nested_map(13,
     ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(shadow_onoff, -1), be_const_var(1) },
+        { be_const_key_weak(tasmota_relay_index, -1), be_const_var(0) },
+        { be_const_key_weak(get_onoff, -1), be_const_closure(Matter_Plugin_OnOff_get_onoff_closure) },
         { be_const_key_weak(every_second, -1), be_const_closure(Matter_Plugin_OnOff_every_second_closure) },
-        { be_const_key_weak(get_onoff, 8), be_const_closure(Matter_Plugin_OnOff_get_onoff_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_OnOff_init_closure) },
-        { be_const_key_weak(shadow_onoff, 5), be_const_var(1) },
-        { be_const_key_weak(TYPES, 7), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_int(266, -1), be_const_int(2) },
-    }))    ) } )) },
         { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_OnOff_read_attribute_closure) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_OnOff_invoke_request_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_OnOff_init_closure) },
+        { be_const_key_weak(onoff_changed, -1), be_const_closure(Matter_Plugin_OnOff_onoff_changed_closure) },
+        { be_const_key_weak(to_json_parameters, -1), be_const_closure(Matter_Plugin_OnOff_to_json_parameters_closure) },
+        { be_const_key_weak(NAME, 3), be_nested_str_weak(relay) },
         { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
@@ -630,10 +672,12 @@ be_local_class(Matter_Plugin_OnOff,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(set_onoff, -1), be_const_closure(Matter_Plugin_OnOff_set_onoff_closure) },
-        { be_const_key_weak(onoff_changed, -1), be_const_closure(Matter_Plugin_OnOff_onoff_changed_closure) },
-        { be_const_key_weak(tasmota_relay_index, 2), be_const_var(0) },
-        { be_const_key_weak(invoke_request, 0), be_const_closure(Matter_Plugin_OnOff_invoke_request_closure) },
+        { be_const_key_weak(set_onoff, 4), be_const_closure(Matter_Plugin_OnOff_set_onoff_closure) },
+        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(266, -1), be_const_int(2) },
+    }))    ) } )) },
     })),
     be_str_weak(Matter_Plugin_OnOff)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
@@ -1151,8 +1151,8 @@ be_local_closure(Matter_Plugin_Root_write_attribute,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Root_init,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
+    9,                          /* nstack */
+    4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1164,15 +1164,16 @@ be_local_closure(Matter_Plugin_Root_init,   /* name */
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x600C0003,  //  0000  GETGBL	R3	G3
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x80000000,  //  0007  RET	0
+    ( &(const binstruction[ 9]) {  /* code */
+      0x60100003,  //  0000  GETGBL	R4	G3
+      0x5C140000,  //  0001  MOVE	R5	R0
+      0x7C100200,  //  0002  CALL	R4	1
+      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x5C200600,  //  0006  MOVE	R8	R3
+      0x7C100800,  //  0007  CALL	R4	4
+      0x80000000,  //  0008  RET	0
     })
   )
 );
@@ -2073,15 +2074,17 @@ extern const bclass be_class_Matter_Plugin;
 be_local_class(Matter_Plugin_Root,
     0,
     &be_class_Matter_Plugin,
-    be_nested_map(6,
+    be_nested_map(7,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Root_read_attribute_closure) },
-        { be_const_key_weak(write_attribute, -1), be_const_closure(Matter_Plugin_Root_write_attribute_closure) },
+        { be_const_key_weak(read_attribute, 2), be_const_closure(Matter_Plugin_Root_read_attribute_closure) },
+        { be_const_key_weak(NAME, -1), be_nested_str_weak(root) },
+        { be_const_key_weak(invoke_request, 6), be_const_closure(Matter_Plugin_Root_invoke_request_closure) },
         { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(22, -1), be_const_int(1) },
     }))    ) } )) },
+        { be_const_key_weak(write_attribute, -1), be_const_closure(Matter_Plugin_Root_write_attribute_closure) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Root_init_closure) },
         { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(13,
@@ -2186,7 +2189,6 @@ be_local_class(Matter_Plugin_Root,
         be_const_int(8),
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_Root_invoke_request_closure) },
     })),
     be_str_weak(Matter_Plugin_Root)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor.h
@@ -31,6 +31,118 @@ be_local_closure(Matter_Plugin_Sensor_pre_value,   /* name */
 
 
 /********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Plugin_Sensor_init,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(tasmota_sensor_filter),
+    /* K2   */  be_nested_str_weak(find),
+    /* K3   */  be_nested_str_weak(filter),
+    /* K4   */  be_nested_str_weak(tasmota_sensor_matcher),
+    /* K5   */  be_nested_str_weak(tasmota),
+    /* K6   */  be_nested_str_weak(Rule_Matcher),
+    /* K7   */  be_nested_str_weak(parse),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x60100003,  //  0000  GETGBL	R4	G3
+      0x5C140000,  //  0001  MOVE	R5	R0
+      0x7C100200,  //  0002  CALL	R4	1
+      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x5C200600,  //  0006  MOVE	R8	R3
+      0x7C100800,  //  0007  CALL	R4	4
+      0x8C100702,  //  0008  GETMET	R4	R3	K2
+      0x58180003,  //  0009  LDCONST	R6	K3
+      0x7C100400,  //  000A  CALL	R4	2
+      0x90020204,  //  000B  SETMBR	R0	K1	R4
+      0x88100101,  //  000C  GETMBR	R4	R0	K1
+      0x78120005,  //  000D  JMPF	R4	#0014
+      0xB8120A00,  //  000E  GETNGBL	R4	K5
+      0x88100906,  //  000F  GETMBR	R4	R4	K6
+      0x8C100907,  //  0010  GETMET	R4	R4	K7
+      0x88180101,  //  0011  GETMBR	R6	R0	K1
+      0x7C100400,  //  0012  CALL	R4	2
+      0x90020804,  //  0013  SETMBR	R0	K4	R4
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: to_json_parameters
+********************************************************************/
+be_local_closure(Matter_Plugin_Sensor_to_json_parameters,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(format),
+    /* K2   */  be_nested_str_weak(_X2C_X22filter_X22_X3A_X22_X25s_X22),
+    /* K3   */  be_nested_str_weak(tasmota_sensor_filter),
+    }),
+    be_str_weak(to_json_parameters),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0x58140002,  //  0002  LDCONST	R5	K2
+      0x88180103,  //  0003  GETMBR	R6	R0	K3
+      0x7C0C0600,  //  0004  CALL	R3	3
+      0x00040203,  //  0005  ADD	R1	R1	R3
+      0x80040200,  //  0006  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: valued_changed
+********************************************************************/
+be_local_closure(Matter_Plugin_Sensor_valued_changed,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(valued_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: parse_sensors
 ********************************************************************/
 be_local_closure(Matter_Plugin_Sensor_parse_sensors,   /* name */
@@ -81,90 +193,22 @@ be_local_closure(Matter_Plugin_Sensor_parse_sensors,   /* name */
 
 
 /********************************************************************
-** Solidified function: valued_changed
-********************************************************************/
-be_local_closure(Matter_Plugin_Sensor_valued_changed,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(valued_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Plugin_Sensor_init,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(tasmota_sensor_filter),
-    /* K2   */  be_nested_str_weak(tasmota_sensor_matcher),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(Rule_Matcher),
-    /* K5   */  be_nested_str_weak(parse),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x60100003,  //  0000  GETGBL	R4	G3
-      0x5C140000,  //  0001  MOVE	R5	R0
-      0x7C100200,  //  0002  CALL	R4	1
-      0x8C100900,  //  0003  GETMET	R4	R4	K0
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x5C1C0400,  //  0005  MOVE	R7	R2
-      0x7C100600,  //  0006  CALL	R4	3
-      0x90020203,  //  0007  SETMBR	R0	K1	R3
-      0xB8120600,  //  0008  GETNGBL	R4	K3
-      0x88100904,  //  0009  GETMBR	R4	R4	K4
-      0x8C100905,  //  000A  GETMET	R4	R4	K5
-      0x5C180600,  //  000B  MOVE	R6	R3
-      0x7C100400,  //  000C  CALL	R4	2
-      0x90020404,  //  000D  SETMBR	R0	K2	R4
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_Plugin_Sensor
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Device;
 be_local_class(Matter_Plugin_Sensor,
     3,
     &be_class_Matter_Plugin_Device,
-    be_nested_map(7,
+    be_nested_map(8,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(tasmota_sensor_matcher, -1), be_const_var(1) },
-        { be_const_key_weak(pre_value, 2), be_const_closure(Matter_Plugin_Sensor_pre_value_closure) },
+        { be_const_key_weak(pre_value, -1), be_const_closure(Matter_Plugin_Sensor_pre_value_closure) },
         { be_const_key_weak(parse_sensors, -1), be_const_closure(Matter_Plugin_Sensor_parse_sensors_closure) },
+        { be_const_key_weak(tasmota_sensor_filter, 7), be_const_var(0) },
+        { be_const_key_weak(init, 6), be_const_closure(Matter_Plugin_Sensor_init_closure) },
+        { be_const_key_weak(to_json_parameters, 1), be_const_closure(Matter_Plugin_Sensor_to_json_parameters_closure) },
+        { be_const_key_weak(valued_changed, -1), be_const_closure(Matter_Plugin_Sensor_valued_changed_closure) },
         { be_const_key_weak(shadow_value, -1), be_const_var(2) },
-        { be_const_key_weak(tasmota_sensor_filter, 3), be_const_var(0) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Sensor_init_closure) },
-        { be_const_key_weak(valued_changed, 0), be_const_closure(Matter_Plugin_Sensor_valued_changed_closure) },
+        { be_const_key_weak(tasmota_sensor_matcher, -1), be_const_var(1) },
     })),
     be_str_weak(Matter_Plugin_Sensor)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Humidity.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Humidity.h
@@ -7,6 +7,34 @@
 extern const bclass be_class_Matter_Plugin_Sensor_Humidity;
 
 /********************************************************************
+** Solidified function: pre_value
+********************************************************************/
+be_local_closure(Matter_Plugin_Sensor_Humidity_pre_value,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(pre_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x60080009,  //  0000  GETGBL	R2	G9
+      0x540E0063,  //  0001  LDINT	R3	100
+      0x080C0203,  //  0002  MUL	R3	R1	R3
+      0x7C080200,  //  0003  CALL	R2	1
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: valued_changed
 ********************************************************************/
 be_local_closure(Matter_Plugin_Sensor_Humidity_valued_changed,   /* name */
@@ -32,34 +60,6 @@ be_local_closure(Matter_Plugin_Sensor_Humidity_valued_changed,   /* name */
       0x58180001,  //  0003  LDCONST	R6	K1
       0x7C080800,  //  0004  CALL	R2	4
       0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pre_value
-********************************************************************/
-be_local_closure(Matter_Plugin_Sensor_Humidity_pre_value,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(pre_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x60080009,  //  0000  GETGBL	R2	G9
-      0x540E0063,  //  0001  LDINT	R3	100
-      0x080C0203,  //  0002  MUL	R3	R1	R3
-      0x7C080200,  //  0003  CALL	R2	1
-      0x80040400,  //  0004  RET	1	R2
     })
   )
 );
@@ -183,16 +183,16 @@ extern const bclass be_class_Matter_Plugin_Sensor;
 be_local_class(Matter_Plugin_Sensor_Humidity,
     0,
     &be_class_Matter_Plugin_Sensor,
-    be_nested_map(5,
+    be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(valued_changed, 3), be_const_closure(Matter_Plugin_Sensor_Humidity_valued_changed_closure) },
-        { be_const_key_weak(pre_value, -1), be_const_closure(Matter_Plugin_Sensor_Humidity_pre_value_closure) },
+        { be_const_key_weak(NAME, 1), be_nested_str_weak(humidity) },
         { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Sensor_Humidity_read_attribute_closure) },
-        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(TYPES, 5), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(775, -1), be_const_int(2) },
     }))    ) } )) },
+        { be_const_key_weak(valued_changed, -1), be_const_closure(Matter_Plugin_Sensor_Humidity_valued_changed_closure) },
         { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
@@ -206,6 +206,7 @@ be_local_class(Matter_Plugin_Sensor_Humidity,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
+        { be_const_key_weak(pre_value, -1), be_const_closure(Matter_Plugin_Sensor_Humidity_pre_value_closure) },
     })),
     be_str_weak(Matter_Plugin_Sensor_Humidity)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Illuminance.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Illuminance.h
@@ -1,15 +1,42 @@
-/* Solidification of Matter_Plugin_Sensor_Light.h */
+/* Solidification of Matter_Plugin_Sensor_Illuminance.h */
 /********************************************************************\
 * Generated code, don't edit                                         *
 \********************************************************************/
 #include "be_constobj.h"
 
-extern const bclass be_class_Matter_Plugin_Sensor_Light;
+extern const bclass be_class_Matter_Plugin_Sensor_Illuminance;
+
+/********************************************************************
+** Solidified function: pre_value
+********************************************************************/
+be_local_closure(Matter_Plugin_Sensor_Illuminance_pre_value,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(pre_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x60080009,  //  0000  GETGBL	R2	G9
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x80040400,  //  0003  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
 
 /********************************************************************
 ** Solidified function: valued_changed
 ********************************************************************/
-be_local_closure(Matter_Plugin_Sensor_Light_valued_changed,   /* name */
+be_local_closure(Matter_Plugin_Sensor_Illuminance_valued_changed,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
@@ -39,36 +66,9 @@ be_local_closure(Matter_Plugin_Sensor_Light_valued_changed,   /* name */
 
 
 /********************************************************************
-** Solidified function: pre_value
-********************************************************************/
-be_local_closure(Matter_Plugin_Sensor_Light_pre_value,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(pre_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x60080009,  //  0000  GETGBL	R2	G9
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x80040400,  //  0003  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
-be_local_closure(Matter_Plugin_Sensor_Light_read_attribute,   /* name */
+be_local_closure(Matter_Plugin_Sensor_Illuminance_read_attribute,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     3,                          /* argc */
@@ -176,22 +176,22 @@ be_local_closure(Matter_Plugin_Sensor_Light_read_attribute,   /* name */
 
 
 /********************************************************************
-** Solidified class: Matter_Plugin_Sensor_Light
+** Solidified class: Matter_Plugin_Sensor_Illuminance
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Sensor;
-be_local_class(Matter_Plugin_Sensor_Light,
+be_local_class(Matter_Plugin_Sensor_Illuminance,
     0,
     &be_class_Matter_Plugin_Sensor,
-    be_nested_map(5,
+    be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(valued_changed, 3), be_const_closure(Matter_Plugin_Sensor_Light_valued_changed_closure) },
-        { be_const_key_weak(pre_value, -1), be_const_closure(Matter_Plugin_Sensor_Light_pre_value_closure) },
-        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Sensor_Light_read_attribute_closure) },
-        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(NAME, 1), be_nested_str_weak(illuminance) },
+        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Sensor_Illuminance_read_attribute_closure) },
+        { be_const_key_weak(TYPES, 5), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(262, -1), be_const_int(2) },
     }))    ) } )) },
+        { be_const_key_weak(valued_changed, -1), be_const_closure(Matter_Plugin_Sensor_Illuminance_valued_changed_closure) },
         { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
@@ -205,14 +205,15 @@ be_local_class(Matter_Plugin_Sensor_Light,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
+        { be_const_key_weak(pre_value, -1), be_const_closure(Matter_Plugin_Sensor_Illuminance_pre_value_closure) },
     })),
-    be_str_weak(Matter_Plugin_Sensor_Light)
+    be_str_weak(Matter_Plugin_Sensor_Illuminance)
 );
 /*******************************************************************/
 
-void be_load_Matter_Plugin_Sensor_Light_class(bvm *vm) {
-    be_pushntvclass(vm, &be_class_Matter_Plugin_Sensor_Light);
-    be_setglobal(vm, "Matter_Plugin_Sensor_Light");
+void be_load_Matter_Plugin_Sensor_Illuminance_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_Matter_Plugin_Sensor_Illuminance);
+    be_setglobal(vm, "Matter_Plugin_Sensor_Illuminance");
     be_pop(vm, 1);
 }
 /********************************************************************/

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Pressure.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Pressure.h
@@ -7,6 +7,33 @@
 extern const bclass be_class_Matter_Plugin_Sensor_Pressure;
 
 /********************************************************************
+** Solidified function: pre_value
+********************************************************************/
+be_local_closure(Matter_Plugin_Sensor_Pressure_pre_value,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(pre_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x60080009,  //  0000  GETGBL	R2	G9
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x80040400,  //  0003  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: valued_changed
 ********************************************************************/
 be_local_closure(Matter_Plugin_Sensor_Pressure_valued_changed,   /* name */
@@ -32,33 +59,6 @@ be_local_closure(Matter_Plugin_Sensor_Pressure_valued_changed,   /* name */
       0x58180001,  //  0003  LDCONST	R6	K1
       0x7C080800,  //  0004  CALL	R2	4
       0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pre_value
-********************************************************************/
-be_local_closure(Matter_Plugin_Sensor_Pressure_pre_value,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(pre_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x60080009,  //  0000  GETGBL	R2	G9
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x80040400,  //  0003  RET	1	R2
     })
   )
 );
@@ -182,16 +182,16 @@ extern const bclass be_class_Matter_Plugin_Sensor;
 be_local_class(Matter_Plugin_Sensor_Pressure,
     0,
     &be_class_Matter_Plugin_Sensor,
-    be_nested_map(5,
+    be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(valued_changed, 3), be_const_closure(Matter_Plugin_Sensor_Pressure_valued_changed_closure) },
-        { be_const_key_weak(pre_value, -1), be_const_closure(Matter_Plugin_Sensor_Pressure_pre_value_closure) },
+        { be_const_key_weak(NAME, 1), be_nested_str_weak(pressure) },
         { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Sensor_Pressure_read_attribute_closure) },
-        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(TYPES, 5), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(773, -1), be_const_int(2) },
     }))    ) } )) },
+        { be_const_key_weak(valued_changed, -1), be_const_closure(Matter_Plugin_Sensor_Pressure_valued_changed_closure) },
         { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
@@ -205,6 +205,7 @@ be_local_class(Matter_Plugin_Sensor_Pressure,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
+        { be_const_key_weak(pre_value, -1), be_const_closure(Matter_Plugin_Sensor_Pressure_pre_value_closure) },
     })),
     be_str_weak(Matter_Plugin_Sensor_Pressure)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Temp.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Temp.h
@@ -7,6 +7,34 @@
 extern const bclass be_class_Matter_Plugin_Sensor_Temp;
 
 /********************************************************************
+** Solidified function: pre_value
+********************************************************************/
+be_local_closure(Matter_Plugin_Sensor_Temp_pre_value,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(pre_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x60080009,  //  0000  GETGBL	R2	G9
+      0x540E0063,  //  0001  LDINT	R3	100
+      0x080C0203,  //  0002  MUL	R3	R1	R3
+      0x7C080200,  //  0003  CALL	R2	1
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: valued_changed
 ********************************************************************/
 be_local_closure(Matter_Plugin_Sensor_Temp_valued_changed,   /* name */
@@ -32,34 +60,6 @@ be_local_closure(Matter_Plugin_Sensor_Temp_valued_changed,   /* name */
       0x58180001,  //  0003  LDCONST	R6	K1
       0x7C080800,  //  0004  CALL	R2	4
       0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pre_value
-********************************************************************/
-be_local_closure(Matter_Plugin_Sensor_Temp_pre_value,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(pre_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x60080009,  //  0000  GETGBL	R2	G9
-      0x540E0063,  //  0001  LDINT	R3	100
-      0x080C0203,  //  0002  MUL	R3	R1	R3
-      0x7C080200,  //  0003  CALL	R2	1
-      0x80040400,  //  0004  RET	1	R2
     })
   )
 );
@@ -180,27 +180,30 @@ extern const bclass be_class_Matter_Plugin_Sensor;
 be_local_class(Matter_Plugin_Sensor_Temp,
     0,
     &be_class_Matter_Plugin_Sensor,
-    be_nested_map(5,
+    be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(valued_changed, 3), be_const_closure(Matter_Plugin_Sensor_Temp_valued_changed_closure) },
-        { be_const_key_weak(pre_value, -1), be_const_closure(Matter_Plugin_Sensor_Temp_pre_value_closure) },
+        { be_const_key_weak(NAME, 1), be_nested_str_weak(temperature) },
         { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Sensor_Temp_read_attribute_closure) },
-        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(TYPES, 5), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(770, -1), be_const_int(2) },
     }))    ) } )) },
+        { be_const_key_weak(valued_changed, -1), be_const_closure(Matter_Plugin_Sensor_Temp_valued_changed_closure) },
         { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(1026, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(3,
+        be_const_list( *     be_nested_list(5,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(0),
         be_const_int(1),
         be_const_int(2),
+        be_const_int(65532),
+        be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
+        { be_const_key_weak(pre_value, -1), be_const_closure(Matter_Plugin_Sensor_Temp_pre_value_closure) },
     })),
     be_str_weak(Matter_Plugin_Sensor_Temp)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
@@ -7,11 +7,11 @@
 extern const bclass be_class_Matter_Session_Store;
 
 /********************************************************************
-** Solidified function: gen_local_session_id
+** Solidified function: create_fabric
 ********************************************************************/
-be_local_closure(Matter_Session_Store_gen_local_session_id,   /* name */
+be_local_closure(Matter_Session_Store_create_fabric,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,36 +19,69 @@ be_local_closure(Matter_Session_Store_gen_local_session_id,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(random),
-    /* K2   */  be_const_int(2),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(get_session_by_local_session_id),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Fabric),
     }),
-    be_str_weak(gen_local_session_id),
+    be_str_weak(create_fabric),
     &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x50080200,  //  0001  LDBOOL	R2	1	0
-      0x780A000E,  //  0002  JMPF	R2	#0012
-      0x8C080301,  //  0003  GETMET	R2	R1	K1
-      0x58100002,  //  0004  LDCONST	R4	K2
-      0x7C080400,  //  0005  CALL	R2	2
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
-      0x58100004,  //  0007  LDCONST	R4	K4
-      0x58140002,  //  0008  LDCONST	R5	K2
-      0x7C080600,  //  0009  CALL	R2	3
-      0x8C0C0105,  //  000A  GETMET	R3	R0	K5
-      0x5C140400,  //  000B  MOVE	R5	R2
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x4C100000,  //  000D  LDNIL	R4
-      0x1C0C0604,  //  000E  EQ	R3	R3	R4
-      0x780E0000,  //  000F  JMPF	R3	#0011
-      0x80040400,  //  0010  RET	1	R2
-      0x7001FFEE,  //  0011  JMP		#0001
-      0x80000000,  //  0012  RET	0
+    ( &(const binstruction[ 5]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x80040200,  //  0004  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_session_by_source_node_id
+********************************************************************/
+be_local_closure(Matter_Session_Store_get_session_by_source_node_id,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(_source_node_id),
+    /* K3   */  be_nested_str_weak(update),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(get_session_by_source_node_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0001,  //  0002  JMPF	R2	#0005
+      0x4C080000,  //  0003  LDNIL	R2
+      0x80040400,  //  0004  RET	1	R2
+      0x6008000C,  //  0005  GETGBL	R2	G12
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x7C080200,  //  0007  CALL	R2	1
+      0x580C0001,  //  0008  LDCONST	R3	K1
+      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0x14140602,  //  000A  LT	R5	R3	R2
+      0x78160008,  //  000B  JMPF	R5	#0015
+      0x94140803,  //  000C  GETIDX	R5	R4	R3
+      0x88180B02,  //  000D  GETMBR	R6	R5	K2
+      0x1C180C01,  //  000E  EQ	R6	R6	R1
+      0x781A0002,  //  000F  JMPF	R6	#0013
+      0x8C180B03,  //  0010  GETMET	R6	R5	K3
+      0x7C180200,  //  0011  CALL	R6	1
+      0x80040A00,  //  0012  RET	1	R5
+      0x000C0704,  //  0013  ADD	R3	R3	K4
+      0x7001FFF4,  //  0014  JMP		#000A
+      0x80000000,  //  0015  RET	0
     })
   )
 );
@@ -112,298 +145,9 @@ be_local_closure(Matter_Session_Store_remove_redundant_fabric,   /* name */
 
 
 /********************************************************************
-** Solidified function: find_session_by_resumption_id
+** Solidified function: active_fabrics
 ********************************************************************/
-be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(sessions),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20session_X2Eresumption_id_X3D_X25s_X20vs_X20_X25s),
-    /* K7   */  be_nested_str_weak(resumption_id),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str_weak(shared_secret),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20session_X2Eshared_secret_X3D_X25s),
-    /* K11  */  be_nested_str_weak(update),
-    /* K12  */  be_const_int(1),
-    }),
-    be_str_weak(find_session_by_resumption_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[49]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x740E0001,  //  0002  JMPT	R3	#0005
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x80040600,  //  0004  RET	1	R3
-      0x580C0001,  //  0005  LDCONST	R3	K1
-      0x88100102,  //  0006  GETMBR	R4	R0	K2
-      0x6014000C,  //  0007  GETGBL	R5	G12
-      0x5C180800,  //  0008  MOVE	R6	R4
-      0x7C140200,  //  0009  CALL	R5	1
-      0x14140605,  //  000A  LT	R5	R3	R5
-      0x78160023,  //  000B  JMPF	R5	#0030
-      0x94140803,  //  000C  GETIDX	R5	R4	R3
-      0xB81A0600,  //  000D  GETNGBL	R6	K3
-      0x8C180D04,  //  000E  GETMET	R6	R6	K4
-      0x8C200505,  //  000F  GETMET	R8	R2	K5
-      0x58280006,  //  0010  LDCONST	R10	K6
-      0x602C0008,  //  0011  GETGBL	R11	G8
-      0x88300B07,  //  0012  GETMBR	R12	R5	K7
-      0x7C2C0200,  //  0013  CALL	R11	1
-      0x60300008,  //  0014  GETGBL	R12	G8
-      0x5C340200,  //  0015  MOVE	R13	R1
-      0x7C300200,  //  0016  CALL	R12	1
-      0x7C200800,  //  0017  CALL	R8	4
-      0x58240008,  //  0018  LDCONST	R9	K8
-      0x7C180600,  //  0019  CALL	R6	3
-      0x88180B07,  //  001A  GETMBR	R6	R5	K7
-      0x1C180C01,  //  001B  EQ	R6	R6	R1
-      0x781A0010,  //  001C  JMPF	R6	#002E
-      0x88180B09,  //  001D  GETMBR	R6	R5	K9
-      0x4C1C0000,  //  001E  LDNIL	R7
-      0x20180C07,  //  001F  NE	R6	R6	R7
-      0x781A000C,  //  0020  JMPF	R6	#002E
-      0xB81A0600,  //  0021  GETNGBL	R6	K3
-      0x8C180D04,  //  0022  GETMET	R6	R6	K4
-      0x8C200505,  //  0023  GETMET	R8	R2	K5
-      0x5828000A,  //  0024  LDCONST	R10	K10
-      0x602C0008,  //  0025  GETGBL	R11	G8
-      0x88300B09,  //  0026  GETMBR	R12	R5	K9
-      0x7C2C0200,  //  0027  CALL	R11	1
-      0x7C200600,  //  0028  CALL	R8	3
-      0x58240008,  //  0029  LDCONST	R9	K8
-      0x7C180600,  //  002A  CALL	R6	3
-      0x8C180B0B,  //  002B  GETMET	R6	R5	K11
-      0x7C180200,  //  002C  CALL	R6	1
-      0x80040A00,  //  002D  RET	1	R5
-      0x000C070C,  //  002E  ADD	R3	R3	K12
-      0x7001FFD6,  //  002F  JMP		#0007
-      0x80000000,  //  0030  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_fabric
-********************************************************************/
-be_local_closure(Matter_Session_Store_remove_fabric,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(_fabric),
-    /* K3   */  be_nested_str_weak(remove),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(fabrics),
-    /* K6   */  be_nested_str_weak(find),
-    }),
-    be_str_weak(remove_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E000B,  //  0005  JMPF	R3	#0012
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x880C0702,  //  0008  GETMBR	R3	R3	K2
-      0x1C0C0601,  //  0009  EQ	R3	R3	R1
-      0x780E0004,  //  000A  JMPF	R3	#0010
-      0x880C0101,  //  000B  GETMBR	R3	R0	K1
-      0x8C0C0703,  //  000C  GETMET	R3	R3	K3
-      0x5C140400,  //  000D  MOVE	R5	R2
-      0x7C0C0400,  //  000E  CALL	R3	2
-      0x70020000,  //  000F  JMP		#0011
-      0x00080504,  //  0010  ADD	R2	R2	K4
-      0x7001FFEE,  //  0011  JMP		#0001
-      0x880C0105,  //  0012  GETMBR	R3	R0	K5
-      0x8C0C0703,  //  0013  GETMET	R3	R3	K3
-      0x88140105,  //  0014  GETMBR	R5	R0	K5
-      0x8C140B06,  //  0015  GETMET	R5	R5	K6
-      0x5C1C0200,  //  0016  MOVE	R7	R1
-      0x7C140400,  //  0017  CALL	R5	2
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x80000000,  //  0019  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_session_source_id_unsecure
-********************************************************************/
-be_local_closure(Matter_Session_Store_find_session_source_id_unsecure,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_session_by_source_node_id),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(Session),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(_source_node_id),
-    /* K5   */  be_nested_str_weak(sessions),
-    /* K6   */  be_nested_str_weak(push),
-    /* K7   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K8   */  be_nested_str_weak(update),
-    }),
-    be_str_weak(find_session_source_id_unsecure),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
-      0x5C140200,  //  0001  MOVE	R5	R1
-      0x7C0C0400,  //  0002  CALL	R3	2
-      0x4C100000,  //  0003  LDNIL	R4
-      0x1C100604,  //  0004  EQ	R4	R3	R4
-      0x7812000E,  //  0005  JMPF	R4	#0015
-      0xB8120200,  //  0006  GETNGBL	R4	K1
-      0x8C100902,  //  0007  GETMET	R4	R4	K2
-      0x5C180000,  //  0008  MOVE	R6	R0
-      0x581C0003,  //  0009  LDCONST	R7	K3
-      0x58200003,  //  000A  LDCONST	R8	K3
-      0x7C100800,  //  000B  CALL	R4	4
-      0x5C0C0800,  //  000C  MOVE	R3	R4
-      0x900E0801,  //  000D  SETMBR	R3	K4	R1
-      0x88100105,  //  000E  GETMBR	R4	R0	K5
-      0x8C100906,  //  000F  GETMET	R4	R4	K6
-      0x5C180600,  //  0010  MOVE	R6	R3
-      0x7C100400,  //  0011  CALL	R4	2
-      0x8C100707,  //  0012  GETMET	R4	R3	K7
-      0x5C180400,  //  0013  MOVE	R6	R2
-      0x7C100400,  //  0014  CALL	R4	2
-      0x8C100708,  //  0015  GETMET	R4	R3	K8
-      0x7C100200,  //  0016  CALL	R4	1
-      0x80040600,  //  0017  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_session_by_source_node_id
-********************************************************************/
-be_local_closure(Matter_Session_Store_get_session_by_source_node_id,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(_source_node_id),
-    /* K3   */  be_nested_str_weak(update),
-    /* K4   */  be_const_int(1),
-    }),
-    be_str_weak(get_session_by_source_node_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x6008000C,  //  0005  GETGBL	R2	G12
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x7C080200,  //  0007  CALL	R2	1
-      0x580C0001,  //  0008  LDCONST	R3	K1
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
-      0x14140602,  //  000A  LT	R5	R3	R2
-      0x78160008,  //  000B  JMPF	R5	#0015
-      0x94140803,  //  000C  GETIDX	R5	R4	R3
-      0x88180B02,  //  000D  GETMBR	R6	R5	K2
-      0x1C180C01,  //  000E  EQ	R6	R6	R1
-      0x781A0002,  //  000F  JMPF	R6	#0013
-      0x8C180B03,  //  0010  GETMET	R6	R5	K3
-      0x7C180200,  //  0011  CALL	R6	1
-      0x80040A00,  //  0012  RET	1	R5
-      0x000C0704,  //  0013  ADD	R3	R3	K4
-      0x7001FFF4,  //  0014  JMP		#000A
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_session
-********************************************************************/
-be_local_closure(Matter_Session_Store_add_session,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(push),
-    }),
-    be_str_weak(add_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x200C0403,  //  0001  NE	R3	R2	R3
-      0x780E0002,  //  0002  JMPF	R3	#0006
-      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
-      0x5C140200,  //  0008  MOVE	R5	R1
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x80000000,  //  000A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: count_active_fabrics
-********************************************************************/
-be_local_closure(Matter_Session_Store_count_active_fabrics,   /* name */
+be_local_closure(Matter_Session_Store_active_fabrics,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -416,9 +160,9 @@ be_local_closure(Matter_Session_Store_count_active_fabrics,   /* name */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(remove_expired),
     /* K1   */  be_nested_str_weak(fabrics),
-    /* K2   */  be_nested_str_weak(count_persistables),
+    /* K2   */  be_nested_str_weak(persistables),
     }),
-    be_str_weak(count_active_fabrics),
+    be_str_weak(active_fabrics),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
       0x8C040100,  //  0000  GETMET	R1	R0	K0
@@ -427,40 +171,6 @@ be_local_closure(Matter_Session_Store_count_active_fabrics,   /* name */
       0x8C040302,  //  0003  GETMET	R1	R1	K2
       0x7C040200,  //  0004  CALL	R1	1
       0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_expired
-********************************************************************/
-be_local_closure(Matter_Session_Store_remove_expired,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(every_second),
-    /* K2   */  be_nested_str_weak(fabrics),
-    }),
-    be_str_weak(remove_expired),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040102,  //  0003  GETMBR	R1	R0	K2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -563,52 +273,6 @@ be_local_closure(Matter_Session_Store_find_children_fabrics,   /* name */
 
 
 /********************************************************************
-** Solidified function: find_fabric_by_index
-********************************************************************/
-be_local_closure(Matter_Session_Store_find_fabric_by_index,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(active_fabrics),
-    /* K1   */  be_nested_str_weak(get_fabric_index),
-    /* K2   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(find_fabric_by_index),
-    &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0x60080010,  //  0000  GETGBL	R2	G16
-      0x8C0C0100,  //  0001  GETMET	R3	R0	K0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x7C080200,  //  0003  CALL	R2	1
-      0xA8020008,  //  0004  EXBLK	0	#000E
-      0x5C0C0400,  //  0005  MOVE	R3	R2
-      0x7C0C0000,  //  0006  CALL	R3	0
-      0x8C100701,  //  0007  GETMET	R4	R3	K1
-      0x7C100200,  //  0008  CALL	R4	1
-      0x1C100801,  //  0009  EQ	R4	R4	R1
-      0x78120001,  //  000A  JMPF	R4	#000D
-      0xA8040001,  //  000B  EXBLK	1	1
-      0x80040600,  //  000C  RET	1	R3
-      0x7001FFF6,  //  000D  JMP		#0005
-      0x58080002,  //  000E  LDCONST	R2	K2
-      0xAC080200,  //  000F  CATCH	R2	1	0
-      0xB0080000,  //  0010  RAISE	2	R0	R0
-      0x4C080000,  //  0011  LDNIL	R2
-      0x80040400,  //  0012  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: next_fabric_idx
 ********************************************************************/
 be_local_closure(Matter_Session_Store_next_fabric_idx,   /* name */
@@ -657,385 +321,6 @@ be_local_closure(Matter_Session_Store_next_fabric_idx,   /* name */
       0xAC080200,  //  0016  CATCH	R2	1	0
       0xB0080000,  //  0017  RAISE	2	R0	R0
       0x80040200,  //  0018  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_session_by_local_session_id
-********************************************************************/
-be_local_closure(Matter_Session_Store_get_session_by_local_session_id,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(local_session_id),
-    /* K3   */  be_nested_str_weak(update),
-    /* K4   */  be_const_int(1),
-    }),
-    be_str_weak(get_session_by_local_session_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x6008000C,  //  0005  GETGBL	R2	G12
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x7C080200,  //  0007  CALL	R2	1
-      0x580C0001,  //  0008  LDCONST	R3	K1
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
-      0x14140602,  //  000A  LT	R5	R3	R2
-      0x78160008,  //  000B  JMPF	R5	#0015
-      0x94140803,  //  000C  GETIDX	R5	R4	R3
-      0x88180B02,  //  000D  GETMBR	R6	R5	K2
-      0x1C180C01,  //  000E  EQ	R6	R6	R1
-      0x781A0002,  //  000F  JMPF	R6	#0013
-      0x8C180B03,  //  0010  GETMET	R6	R5	K3
-      0x7C180200,  //  0011  CALL	R6	1
-      0x80040A00,  //  0012  RET	1	R5
-      0x000C0704,  //  0013  ADD	R3	R3	K4
-      0x7001FFF4,  //  0014  JMP		#000A
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: active_fabrics
-********************************************************************/
-be_local_closure(Matter_Session_Store_active_fabrics,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    /* K1   */  be_nested_str_weak(fabrics),
-    /* K2   */  be_nested_str_weak(persistables),
-    }),
-    be_str_weak(active_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(Matter_Session_Store_every_second,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    }),
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_session
-********************************************************************/
-be_local_closure(Matter_Session_Store_remove_session,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(remove),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(remove_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x6010000C,  //  0002  GETGBL	R4	G12
-      0x88140101,  //  0003  GETMBR	R5	R0	K1
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100404,  //  0005  LT	R4	R2	R4
-      0x78120008,  //  0006  JMPF	R4	#0010
-      0x94100602,  //  0007  GETIDX	R4	R3	R2
-      0x1C100801,  //  0008  EQ	R4	R4	R1
-      0x78120003,  //  0009  JMPF	R4	#000E
-      0x8C100702,  //  000A  GETMET	R4	R3	K2
-      0x5C180400,  //  000B  MOVE	R6	R2
-      0x7C100400,  //  000C  CALL	R4	2
-      0x70020000,  //  000D  JMP		#000F
-      0x00080503,  //  000E  ADD	R2	R2	K3
-      0x7001FFF1,  //  000F  JMP		#0002
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Session_Store_init,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(Expirable_list),
-    /* K3   */  be_nested_str_weak(fabrics),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x8C040302,  //  0001  GETMET	R1	R1	K2
-      0x7C040200,  //  0002  CALL	R1	1
-      0x90020001,  //  0003  SETMBR	R0	K0	R1
-      0xB8060200,  //  0004  GETNGBL	R1	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x7C040200,  //  0006  CALL	R1	1
-      0x90020601,  //  0007  SETMBR	R0	K3	R1
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: create_session
-********************************************************************/
-be_local_closure(Matter_Session_Store_create_session,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_session_by_local_session_id),
-    /* K1   */  be_nested_str_weak(remove_session),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Session),
-    /* K4   */  be_nested_str_weak(sessions),
-    /* K5   */  be_nested_str_weak(push),
-    }),
-    be_str_weak(create_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
-      0x5C140200,  //  0001  MOVE	R5	R1
-      0x7C0C0400,  //  0002  CALL	R3	2
-      0x4C100000,  //  0003  LDNIL	R4
-      0x20100604,  //  0004  NE	R4	R3	R4
-      0x78120002,  //  0005  JMPF	R4	#0009
-      0x8C100101,  //  0006  GETMET	R4	R0	K1
-      0x5C180600,  //  0007  MOVE	R6	R3
-      0x7C100400,  //  0008  CALL	R4	2
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x8C100903,  //  000A  GETMET	R4	R4	K3
-      0x5C180000,  //  000B  MOVE	R6	R0
-      0x5C1C0200,  //  000C  MOVE	R7	R1
-      0x5C200400,  //  000D  MOVE	R8	R2
-      0x7C100800,  //  000E  CALL	R4	4
-      0x5C0C0800,  //  000F  MOVE	R3	R4
-      0x88100104,  //  0010  GETMBR	R4	R0	K4
-      0x8C100905,  //  0011  GETMET	R4	R4	K5
-      0x5C180600,  //  0012  MOVE	R6	R3
-      0x7C100400,  //  0013  CALL	R4	2
-      0x80040600,  //  0014  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_fabrics
-********************************************************************/
-be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(remove_expired),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(fabrics),
-    /* K4   */  be_nested_str_weak(persistables),
-    /* K5   */  be_nested_str_weak(_sessions),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(stop_iteration),
-    /* K8   */  be_nested_str_weak(push),
-    /* K9   */  be_nested_str_weak(tojson),
-    /* K10  */  be_nested_str_weak(_X5B),
-    /* K11  */  be_nested_str_weak(concat),
-    /* K12  */  be_nested_str_weak(_X2C),
-    /* K13  */  be_nested_str_weak(_X5D),
-    /* K14  */  be_nested_str_weak(string),
-    /* K15  */  be_nested_str_weak(_FABRICS),
-    /* K16  */  be_nested_str_weak(w),
-    /* K17  */  be_nested_str_weak(write),
-    /* K18  */  be_nested_str_weak(close),
-    /* K19  */  be_nested_str_weak(tasmota),
-    /* K20  */  be_nested_str_weak(log),
-    /* K21  */  be_nested_str_weak(format),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20_X25i_X20fabric_X28s_X29_X20and_X20_X25i_X20session_X28s_X29),
-    /* K23  */  be_const_int(2),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K25  */  be_nested_str_weak(_X7C),
-    }),
-    be_str_weak(save_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[84]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x58080002,  //  0003  LDCONST	R2	K2
-      0x600C0012,  //  0004  GETGBL	R3	G18
-      0x7C0C0000,  //  0005  CALL	R3	0
-      0x60100010,  //  0006  GETGBL	R4	G16
-      0x88140103,  //  0007  GETMBR	R5	R0	K3
-      0x8C140B04,  //  0008  GETMET	R5	R5	K4
-      0x7C140200,  //  0009  CALL	R5	1
-      0x7C100200,  //  000A  CALL	R4	1
-      0xA8020013,  //  000B  EXBLK	0	#0020
-      0x5C140800,  //  000C  MOVE	R5	R4
-      0x7C140000,  //  000D  CALL	R5	0
-      0x60180010,  //  000E  GETGBL	R6	G16
-      0x881C0B05,  //  000F  GETMBR	R7	R5	K5
-      0x8C1C0F04,  //  0010  GETMET	R7	R7	K4
-      0x7C1C0200,  //  0011  CALL	R7	1
-      0x7C180200,  //  0012  CALL	R6	1
-      0xA8020003,  //  0013  EXBLK	0	#0018
-      0x5C1C0C00,  //  0014  MOVE	R7	R6
-      0x7C1C0000,  //  0015  CALL	R7	0
-      0x00080506,  //  0016  ADD	R2	R2	K6
-      0x7001FFFB,  //  0017  JMP		#0014
-      0x58180007,  //  0018  LDCONST	R6	K7
-      0xAC180200,  //  0019  CATCH	R6	1	0
-      0xB0080000,  //  001A  RAISE	2	R0	R0
-      0x8C180708,  //  001B  GETMET	R6	R3	K8
-      0x8C200B09,  //  001C  GETMET	R8	R5	K9
-      0x7C200200,  //  001D  CALL	R8	1
-      0x7C180400,  //  001E  CALL	R6	2
-      0x7001FFEB,  //  001F  JMP		#000C
-      0x58100007,  //  0020  LDCONST	R4	K7
-      0xAC100200,  //  0021  CATCH	R4	1	0
-      0xB0080000,  //  0022  RAISE	2	R0	R0
-      0x6010000C,  //  0023  GETGBL	R4	G12
-      0x5C140600,  //  0024  MOVE	R5	R3
-      0x7C100200,  //  0025  CALL	R4	1
-      0x8C14070B,  //  0026  GETMET	R5	R3	K11
-      0x581C000C,  //  0027  LDCONST	R7	K12
-      0x7C140400,  //  0028  CALL	R5	2
-      0x00161405,  //  0029  ADD	R5	K10	R5
-      0x00140B0D,  //  002A  ADD	R5	R5	K13
-      0x5C0C0A00,  //  002B  MOVE	R3	R5
-      0xA8020014,  //  002C  EXBLK	0	#0042
-      0xA4161C00,  //  002D  IMPORT	R5	K14
-      0x60180011,  //  002E  GETGBL	R6	G17
-      0x881C010F,  //  002F  GETMBR	R7	R0	K15
-      0x58200010,  //  0030  LDCONST	R8	K16
-      0x7C180400,  //  0031  CALL	R6	2
-      0x8C1C0D11,  //  0032  GETMET	R7	R6	K17
-      0x5C240600,  //  0033  MOVE	R9	R3
-      0x7C1C0400,  //  0034  CALL	R7	2
-      0x8C1C0D12,  //  0035  GETMET	R7	R6	K18
-      0x7C1C0200,  //  0036  CALL	R7	1
-      0xB81E2600,  //  0037  GETNGBL	R7	K19
-      0x8C1C0F14,  //  0038  GETMET	R7	R7	K20
-      0x8C240B15,  //  0039  GETMET	R9	R5	K21
-      0x582C0016,  //  003A  LDCONST	R11	K22
-      0x5C300800,  //  003B  MOVE	R12	R4
-      0x5C340400,  //  003C  MOVE	R13	R2
-      0x7C240800,  //  003D  CALL	R9	4
-      0x58280017,  //  003E  LDCONST	R10	K23
-      0x7C1C0600,  //  003F  CALL	R7	3
-      0xA8040001,  //  0040  EXBLK	1	1
-      0x70020010,  //  0041  JMP		#0053
-      0xAC140002,  //  0042  CATCH	R5	0	2
-      0x7002000D,  //  0043  JMP		#0052
-      0xB81E2600,  //  0044  GETNGBL	R7	K19
-      0x8C1C0F14,  //  0045  GETMET	R7	R7	K20
-      0x60240008,  //  0046  GETGBL	R9	G8
-      0x5C280A00,  //  0047  MOVE	R10	R5
-      0x7C240200,  //  0048  CALL	R9	1
-      0x00263009,  //  0049  ADD	R9	K24	R9
-      0x00241319,  //  004A  ADD	R9	R9	K25
-      0x60280008,  //  004B  GETGBL	R10	G8
-      0x5C2C0C00,  //  004C  MOVE	R11	R6
-      0x7C280200,  //  004D  CALL	R10	1
-      0x0024120A,  //  004E  ADD	R9	R9	R10
-      0x58280017,  //  004F  LDCONST	R10	K23
-      0x7C1C0600,  //  0050  CALL	R7	3
-      0x70020000,  //  0051  JMP		#0053
-      0xB0080000,  //  0052  RAISE	2	R0	R0
-      0x80000000,  //  0053  RET	0
     })
   )
 );
@@ -1214,11 +499,11 @@ be_local_closure(Matter_Session_Store_load_fabrics,   /* name */
 
 
 /********************************************************************
-** Solidified function: sessions_active
+** Solidified function: count_active_fabrics
 ********************************************************************/
-be_local_closure(Matter_Session_Store_sessions_active,   /* name */
+be_local_closure(Matter_Session_Store_count_active_fabrics,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    3,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1226,39 +511,20 @@ be_local_closure(Matter_Session_Store_sessions_active,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_const_int(1),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_expired),
+    /* K1   */  be_nested_str_weak(fabrics),
+    /* K2   */  be_nested_str_weak(count_persistables),
     }),
-    be_str_weak(sessions_active),
+    be_str_weak(count_active_fabrics),
     &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60040012,  //  0000  GETGBL	R1	G18
-      0x7C040000,  //  0001  CALL	R1	0
-      0x58080000,  //  0002  LDCONST	R2	K0
-      0x600C000C,  //  0003  GETGBL	R3	G12
-      0x88100101,  //  0004  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x140C0403,  //  0006  LT	R3	R2	R3
-      0x780E000C,  //  0007  JMPF	R3	#0015
-      0x880C0101,  //  0008  GETMBR	R3	R0	K1
-      0x940C0602,  //  0009  GETIDX	R3	R3	R2
-      0x8C100702,  //  000A  GETMET	R4	R3	K2
-      0x7C100200,  //  000B  CALL	R4	1
-      0x78120005,  //  000C  JMPF	R4	#0013
-      0x8C100703,  //  000D  GETMET	R4	R3	K3
-      0x7C100200,  //  000E  CALL	R4	1
-      0x78120002,  //  000F  JMPF	R4	#0013
-      0x8C100304,  //  0010  GETMET	R4	R1	K4
-      0x5C180600,  //  0011  MOVE	R6	R3
-      0x7C100400,  //  0012  CALL	R4	2
-      0x00080505,  //  0013  ADD	R2	R2	K5
-      0x7001FFED,  //  0014  JMP		#0003
-      0x80040200,  //  0015  RET	1	R1
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80040200,  //  0005  RET	1	R1
     })
   )
 );
@@ -1266,30 +532,101 @@ be_local_closure(Matter_Session_Store_sessions_active,   /* name */
 
 
 /********************************************************************
-** Solidified function: create_fabric
+** Solidified function: remove_fabric
 ********************************************************************/
-be_local_closure(Matter_Session_Store_create_fabric,   /* name */
+be_local_closure(Matter_Session_Store_remove_fabric,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
+    8,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Fabric),
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(_fabric),
+    /* K3   */  be_nested_str_weak(remove),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(fabrics),
+    /* K6   */  be_nested_str_weak(find),
     }),
-    be_str_weak(create_fabric),
+    be_str_weak(remove_fabric),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x80040200,  //  0004  RET	1	R1
+    ( &(const binstruction[26]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E000B,  //  0005  JMPF	R3	#0012
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x880C0702,  //  0008  GETMBR	R3	R3	K2
+      0x1C0C0601,  //  0009  EQ	R3	R3	R1
+      0x780E0004,  //  000A  JMPF	R3	#0010
+      0x880C0101,  //  000B  GETMBR	R3	R0	K1
+      0x8C0C0703,  //  000C  GETMET	R3	R3	K3
+      0x5C140400,  //  000D  MOVE	R5	R2
+      0x7C0C0400,  //  000E  CALL	R3	2
+      0x70020000,  //  000F  JMP		#0011
+      0x00080504,  //  0010  ADD	R2	R2	K4
+      0x7001FFEE,  //  0011  JMP		#0001
+      0x880C0105,  //  0012  GETMBR	R3	R0	K5
+      0x8C0C0703,  //  0013  GETMET	R3	R3	K3
+      0x88140105,  //  0014  GETMBR	R5	R0	K5
+      0x8C140B06,  //  0015  GETMET	R5	R5	K6
+      0x5C1C0200,  //  0016  MOVE	R7	R1
+      0x7C140400,  //  0017  CALL	R5	2
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x80000000,  //  0019  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_session
+********************************************************************/
+be_local_closure(Matter_Session_Store_remove_session,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(remove),
+    /* K3   */  be_const_int(1),
+    }),
+    be_str_weak(remove_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x6010000C,  //  0002  GETGBL	R4	G12
+      0x88140101,  //  0003  GETMBR	R5	R0	K1
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100404,  //  0005  LT	R4	R2	R4
+      0x78120008,  //  0006  JMPF	R4	#0010
+      0x94100602,  //  0007  GETIDX	R4	R3	R2
+      0x1C100801,  //  0008  EQ	R4	R4	R1
+      0x78120003,  //  0009  JMPF	R4	#000E
+      0x8C100702,  //  000A  GETMET	R4	R3	K2
+      0x5C180400,  //  000B  MOVE	R6	R2
+      0x7C100400,  //  000C  CALL	R4	2
+      0x70020000,  //  000D  JMP		#000F
+      0x00080503,  //  000E  ADD	R2	R2	K3
+      0x7001FFF1,  //  000F  JMP		#0002
+      0x80000000,  //  0010  RET	0
     })
   )
 );
@@ -1351,39 +688,710 @@ be_local_closure(Matter_Session_Store_add_fabric,   /* name */
 
 
 /********************************************************************
+** Solidified function: find_fabric_by_index
+********************************************************************/
+be_local_closure(Matter_Session_Store_find_fabric_by_index,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(active_fabrics),
+    /* K1   */  be_nested_str_weak(get_fabric_index),
+    /* K2   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(find_fabric_by_index),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0x60080010,  //  0000  GETGBL	R2	G16
+      0x8C0C0100,  //  0001  GETMET	R3	R0	K0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x7C080200,  //  0003  CALL	R2	1
+      0xA8020008,  //  0004  EXBLK	0	#000E
+      0x5C0C0400,  //  0005  MOVE	R3	R2
+      0x7C0C0000,  //  0006  CALL	R3	0
+      0x8C100701,  //  0007  GETMET	R4	R3	K1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x1C100801,  //  0009  EQ	R4	R4	R1
+      0x78120001,  //  000A  JMPF	R4	#000D
+      0xA8040001,  //  000B  EXBLK	1	1
+      0x80040600,  //  000C  RET	1	R3
+      0x7001FFF6,  //  000D  JMP		#0005
+      0x58080002,  //  000E  LDCONST	R2	K2
+      0xAC080200,  //  000F  CATCH	R2	1	0
+      0xB0080000,  //  0010  RAISE	2	R0	R0
+      0x4C080000,  //  0011  LDNIL	R2
+      0x80040400,  //  0012  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_expired
+********************************************************************/
+be_local_closure(Matter_Session_Store_remove_expired,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(every_second),
+    /* K2   */  be_nested_str_weak(fabrics),
+    }),
+    be_str_weak(remove_expired),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040102,  //  0003  GETMBR	R1	R0	K2
+      0x8C040301,  //  0004  GETMET	R1	R1	K1
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_session
+********************************************************************/
+be_local_closure(Matter_Session_Store_add_session,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(add_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x200C0403,  //  0001  NE	R3	R2	R3
+      0x780E0002,  //  0002  JMPF	R3	#0006
+      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
+      0x5C140200,  //  0008  MOVE	R5	R1
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: create_session
+********************************************************************/
+be_local_closure(Matter_Session_Store_create_session,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_session_by_local_session_id),
+    /* K1   */  be_nested_str_weak(remove_session),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(Session),
+    /* K4   */  be_nested_str_weak(sessions),
+    /* K5   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(create_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x5C140200,  //  0001  MOVE	R5	R1
+      0x7C0C0400,  //  0002  CALL	R3	2
+      0x4C100000,  //  0003  LDNIL	R4
+      0x20100604,  //  0004  NE	R4	R3	R4
+      0x78120002,  //  0005  JMPF	R4	#0009
+      0x8C100101,  //  0006  GETMET	R4	R0	K1
+      0x5C180600,  //  0007  MOVE	R6	R3
+      0x7C100400,  //  0008  CALL	R4	2
+      0xB8120400,  //  0009  GETNGBL	R4	K2
+      0x8C100903,  //  000A  GETMET	R4	R4	K3
+      0x5C180000,  //  000B  MOVE	R6	R0
+      0x5C1C0200,  //  000C  MOVE	R7	R1
+      0x5C200400,  //  000D  MOVE	R8	R2
+      0x7C100800,  //  000E  CALL	R4	4
+      0x5C0C0800,  //  000F  MOVE	R3	R4
+      0x88100104,  //  0010  GETMBR	R4	R0	K4
+      0x8C100905,  //  0011  GETMET	R4	R4	K5
+      0x5C180600,  //  0012  MOVE	R6	R3
+      0x7C100400,  //  0013  CALL	R4	2
+      0x80040600,  //  0014  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Session_Store_init,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(Expirable_list),
+    /* K4   */  be_nested_str_weak(fabrics),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0xB80A0400,  //  0001  GETNGBL	R2	K2
+      0x8C080503,  //  0002  GETMET	R2	R2	K3
+      0x7C080200,  //  0003  CALL	R2	1
+      0x90020202,  //  0004  SETMBR	R0	K1	R2
+      0xB80A0400,  //  0005  GETNGBL	R2	K2
+      0x8C080503,  //  0006  GETMET	R2	R2	K3
+      0x7C080200,  //  0007  CALL	R2	1
+      0x90020802,  //  0008  SETMBR	R0	K4	R2
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_session_by_local_session_id
+********************************************************************/
+be_local_closure(Matter_Session_Store_get_session_by_local_session_id,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(local_session_id),
+    /* K3   */  be_nested_str_weak(update),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(get_session_by_local_session_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0001,  //  0002  JMPF	R2	#0005
+      0x4C080000,  //  0003  LDNIL	R2
+      0x80040400,  //  0004  RET	1	R2
+      0x6008000C,  //  0005  GETGBL	R2	G12
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x7C080200,  //  0007  CALL	R2	1
+      0x580C0001,  //  0008  LDCONST	R3	K1
+      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0x14140602,  //  000A  LT	R5	R3	R2
+      0x78160008,  //  000B  JMPF	R5	#0015
+      0x94140803,  //  000C  GETIDX	R5	R4	R3
+      0x88180B02,  //  000D  GETMBR	R6	R5	K2
+      0x1C180C01,  //  000E  EQ	R6	R6	R1
+      0x781A0002,  //  000F  JMPF	R6	#0013
+      0x8C180B03,  //  0010  GETMET	R6	R5	K3
+      0x7C180200,  //  0011  CALL	R6	1
+      0x80040A00,  //  0012  RET	1	R5
+      0x000C0704,  //  0013  ADD	R3	R3	K4
+      0x7001FFF4,  //  0014  JMP		#000A
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Session_Store_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_expired),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_session_source_id_unsecure
+********************************************************************/
+be_local_closure(Matter_Session_Store_find_session_source_id_unsecure,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_session_by_source_node_id),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(Session),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(_source_node_id),
+    /* K5   */  be_nested_str_weak(sessions),
+    /* K6   */  be_nested_str_weak(push),
+    /* K7   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K8   */  be_nested_str_weak(update),
+    }),
+    be_str_weak(find_session_source_id_unsecure),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x5C140200,  //  0001  MOVE	R5	R1
+      0x7C0C0400,  //  0002  CALL	R3	2
+      0x4C100000,  //  0003  LDNIL	R4
+      0x1C100604,  //  0004  EQ	R4	R3	R4
+      0x7812000E,  //  0005  JMPF	R4	#0015
+      0xB8120200,  //  0006  GETNGBL	R4	K1
+      0x8C100902,  //  0007  GETMET	R4	R4	K2
+      0x5C180000,  //  0008  MOVE	R6	R0
+      0x581C0003,  //  0009  LDCONST	R7	K3
+      0x58200003,  //  000A  LDCONST	R8	K3
+      0x7C100800,  //  000B  CALL	R4	4
+      0x5C0C0800,  //  000C  MOVE	R3	R4
+      0x900E0801,  //  000D  SETMBR	R3	K4	R1
+      0x88100105,  //  000E  GETMBR	R4	R0	K5
+      0x8C100906,  //  000F  GETMET	R4	R4	K6
+      0x5C180600,  //  0010  MOVE	R6	R3
+      0x7C100400,  //  0011  CALL	R4	2
+      0x8C100707,  //  0012  GETMET	R4	R3	K7
+      0x5C180400,  //  0013  MOVE	R6	R2
+      0x7C100400,  //  0014  CALL	R4	2
+      0x8C100708,  //  0015  GETMET	R4	R3	K8
+      0x7C100200,  //  0016  CALL	R4	1
+      0x80040600,  //  0017  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sessions_active
+********************************************************************/
+be_local_closure(Matter_Session_Store_sessions_active,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_const_int(1),
+    }),
+    be_str_weak(sessions_active),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x60040012,  //  0000  GETGBL	R1	G18
+      0x7C040000,  //  0001  CALL	R1	0
+      0x58080000,  //  0002  LDCONST	R2	K0
+      0x600C000C,  //  0003  GETGBL	R3	G12
+      0x88100101,  //  0004  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x140C0403,  //  0006  LT	R3	R2	R3
+      0x780E000C,  //  0007  JMPF	R3	#0015
+      0x880C0101,  //  0008  GETMBR	R3	R0	K1
+      0x940C0602,  //  0009  GETIDX	R3	R3	R2
+      0x8C100702,  //  000A  GETMET	R4	R3	K2
+      0x7C100200,  //  000B  CALL	R4	1
+      0x78120005,  //  000C  JMPF	R4	#0013
+      0x8C100703,  //  000D  GETMET	R4	R3	K3
+      0x7C100200,  //  000E  CALL	R4	1
+      0x78120002,  //  000F  JMPF	R4	#0013
+      0x8C100304,  //  0010  GETMET	R4	R1	K4
+      0x5C180600,  //  0011  MOVE	R6	R3
+      0x7C100400,  //  0012  CALL	R4	2
+      0x00080505,  //  0013  ADD	R2	R2	K5
+      0x7001FFED,  //  0014  JMP		#0003
+      0x80040200,  //  0015  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_session_by_resumption_id
+********************************************************************/
+be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(sessions),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(format),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20session_X2Eresumption_id_X3D_X25s_X20vs_X20_X25s),
+    /* K7   */  be_nested_str_weak(resumption_id),
+    /* K8   */  be_const_int(3),
+    /* K9   */  be_nested_str_weak(shared_secret),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20session_X2Eshared_secret_X3D_X25s),
+    /* K11  */  be_nested_str_weak(update),
+    /* K12  */  be_const_int(1),
+    }),
+    be_str_weak(find_session_by_resumption_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[49]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x740E0001,  //  0002  JMPT	R3	#0005
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x80040600,  //  0004  RET	1	R3
+      0x580C0001,  //  0005  LDCONST	R3	K1
+      0x88100102,  //  0006  GETMBR	R4	R0	K2
+      0x6014000C,  //  0007  GETGBL	R5	G12
+      0x5C180800,  //  0008  MOVE	R6	R4
+      0x7C140200,  //  0009  CALL	R5	1
+      0x14140605,  //  000A  LT	R5	R3	R5
+      0x78160023,  //  000B  JMPF	R5	#0030
+      0x94140803,  //  000C  GETIDX	R5	R4	R3
+      0xB81A0600,  //  000D  GETNGBL	R6	K3
+      0x8C180D04,  //  000E  GETMET	R6	R6	K4
+      0x8C200505,  //  000F  GETMET	R8	R2	K5
+      0x58280006,  //  0010  LDCONST	R10	K6
+      0x602C0008,  //  0011  GETGBL	R11	G8
+      0x88300B07,  //  0012  GETMBR	R12	R5	K7
+      0x7C2C0200,  //  0013  CALL	R11	1
+      0x60300008,  //  0014  GETGBL	R12	G8
+      0x5C340200,  //  0015  MOVE	R13	R1
+      0x7C300200,  //  0016  CALL	R12	1
+      0x7C200800,  //  0017  CALL	R8	4
+      0x58240008,  //  0018  LDCONST	R9	K8
+      0x7C180600,  //  0019  CALL	R6	3
+      0x88180B07,  //  001A  GETMBR	R6	R5	K7
+      0x1C180C01,  //  001B  EQ	R6	R6	R1
+      0x781A0010,  //  001C  JMPF	R6	#002E
+      0x88180B09,  //  001D  GETMBR	R6	R5	K9
+      0x4C1C0000,  //  001E  LDNIL	R7
+      0x20180C07,  //  001F  NE	R6	R6	R7
+      0x781A000C,  //  0020  JMPF	R6	#002E
+      0xB81A0600,  //  0021  GETNGBL	R6	K3
+      0x8C180D04,  //  0022  GETMET	R6	R6	K4
+      0x8C200505,  //  0023  GETMET	R8	R2	K5
+      0x5828000A,  //  0024  LDCONST	R10	K10
+      0x602C0008,  //  0025  GETGBL	R11	G8
+      0x88300B09,  //  0026  GETMBR	R12	R5	K9
+      0x7C2C0200,  //  0027  CALL	R11	1
+      0x7C200600,  //  0028  CALL	R8	3
+      0x58240008,  //  0029  LDCONST	R9	K8
+      0x7C180600,  //  002A  CALL	R6	3
+      0x8C180B0B,  //  002B  GETMET	R6	R5	K11
+      0x7C180200,  //  002C  CALL	R6	1
+      0x80040A00,  //  002D  RET	1	R5
+      0x000C070C,  //  002E  ADD	R3	R3	K12
+      0x7001FFD6,  //  002F  JMP		#0007
+      0x80000000,  //  0030  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_fabrics
+********************************************************************/
+be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[28]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(remove_expired),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(fabrics),
+    /* K4   */  be_nested_str_weak(persistables),
+    /* K5   */  be_nested_str_weak(_sessions),
+    /* K6   */  be_const_int(1),
+    /* K7   */  be_nested_str_weak(stop_iteration),
+    /* K8   */  be_nested_str_weak(push),
+    /* K9   */  be_nested_str_weak(tojson),
+    /* K10  */  be_nested_str_weak(_X5B),
+    /* K11  */  be_nested_str_weak(concat),
+    /* K12  */  be_nested_str_weak(_X2C),
+    /* K13  */  be_nested_str_weak(_X5D),
+    /* K14  */  be_nested_str_weak(string),
+    /* K15  */  be_nested_str_weak(_FABRICS),
+    /* K16  */  be_nested_str_weak(w),
+    /* K17  */  be_nested_str_weak(write),
+    /* K18  */  be_nested_str_weak(close),
+    /* K19  */  be_nested_str_weak(tasmota),
+    /* K20  */  be_nested_str_weak(log),
+    /* K21  */  be_nested_str_weak(format),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20_X25i_X20fabric_X28s_X29_X20and_X20_X25i_X20session_X28s_X29),
+    /* K23  */  be_const_int(2),
+    /* K24  */  be_nested_str_weak(device),
+    /* K25  */  be_nested_str_weak(event_fabrics_saved),
+    /* K26  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+    /* K27  */  be_nested_str_weak(_X7C),
+    }),
+    be_str_weak(save_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[87]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x58080002,  //  0003  LDCONST	R2	K2
+      0x600C0012,  //  0004  GETGBL	R3	G18
+      0x7C0C0000,  //  0005  CALL	R3	0
+      0x60100010,  //  0006  GETGBL	R4	G16
+      0x88140103,  //  0007  GETMBR	R5	R0	K3
+      0x8C140B04,  //  0008  GETMET	R5	R5	K4
+      0x7C140200,  //  0009  CALL	R5	1
+      0x7C100200,  //  000A  CALL	R4	1
+      0xA8020013,  //  000B  EXBLK	0	#0020
+      0x5C140800,  //  000C  MOVE	R5	R4
+      0x7C140000,  //  000D  CALL	R5	0
+      0x60180010,  //  000E  GETGBL	R6	G16
+      0x881C0B05,  //  000F  GETMBR	R7	R5	K5
+      0x8C1C0F04,  //  0010  GETMET	R7	R7	K4
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x7C180200,  //  0012  CALL	R6	1
+      0xA8020003,  //  0013  EXBLK	0	#0018
+      0x5C1C0C00,  //  0014  MOVE	R7	R6
+      0x7C1C0000,  //  0015  CALL	R7	0
+      0x00080506,  //  0016  ADD	R2	R2	K6
+      0x7001FFFB,  //  0017  JMP		#0014
+      0x58180007,  //  0018  LDCONST	R6	K7
+      0xAC180200,  //  0019  CATCH	R6	1	0
+      0xB0080000,  //  001A  RAISE	2	R0	R0
+      0x8C180708,  //  001B  GETMET	R6	R3	K8
+      0x8C200B09,  //  001C  GETMET	R8	R5	K9
+      0x7C200200,  //  001D  CALL	R8	1
+      0x7C180400,  //  001E  CALL	R6	2
+      0x7001FFEB,  //  001F  JMP		#000C
+      0x58100007,  //  0020  LDCONST	R4	K7
+      0xAC100200,  //  0021  CATCH	R4	1	0
+      0xB0080000,  //  0022  RAISE	2	R0	R0
+      0x6010000C,  //  0023  GETGBL	R4	G12
+      0x5C140600,  //  0024  MOVE	R5	R3
+      0x7C100200,  //  0025  CALL	R4	1
+      0x8C14070B,  //  0026  GETMET	R5	R3	K11
+      0x581C000C,  //  0027  LDCONST	R7	K12
+      0x7C140400,  //  0028  CALL	R5	2
+      0x00161405,  //  0029  ADD	R5	K10	R5
+      0x00140B0D,  //  002A  ADD	R5	R5	K13
+      0x5C0C0A00,  //  002B  MOVE	R3	R5
+      0xA8020017,  //  002C  EXBLK	0	#0045
+      0xA4161C00,  //  002D  IMPORT	R5	K14
+      0x60180011,  //  002E  GETGBL	R6	G17
+      0x881C010F,  //  002F  GETMBR	R7	R0	K15
+      0x58200010,  //  0030  LDCONST	R8	K16
+      0x7C180400,  //  0031  CALL	R6	2
+      0x8C1C0D11,  //  0032  GETMET	R7	R6	K17
+      0x5C240600,  //  0033  MOVE	R9	R3
+      0x7C1C0400,  //  0034  CALL	R7	2
+      0x8C1C0D12,  //  0035  GETMET	R7	R6	K18
+      0x7C1C0200,  //  0036  CALL	R7	1
+      0xB81E2600,  //  0037  GETNGBL	R7	K19
+      0x8C1C0F14,  //  0038  GETMET	R7	R7	K20
+      0x8C240B15,  //  0039  GETMET	R9	R5	K21
+      0x582C0016,  //  003A  LDCONST	R11	K22
+      0x5C300800,  //  003B  MOVE	R12	R4
+      0x5C340400,  //  003C  MOVE	R13	R2
+      0x7C240800,  //  003D  CALL	R9	4
+      0x58280017,  //  003E  LDCONST	R10	K23
+      0x7C1C0600,  //  003F  CALL	R7	3
+      0x881C0118,  //  0040  GETMBR	R7	R0	K24
+      0x8C1C0F19,  //  0041  GETMET	R7	R7	K25
+      0x7C1C0200,  //  0042  CALL	R7	1
+      0xA8040001,  //  0043  EXBLK	1	1
+      0x70020010,  //  0044  JMP		#0056
+      0xAC140002,  //  0045  CATCH	R5	0	2
+      0x7002000D,  //  0046  JMP		#0055
+      0xB81E2600,  //  0047  GETNGBL	R7	K19
+      0x8C1C0F14,  //  0048  GETMET	R7	R7	K20
+      0x60240008,  //  0049  GETGBL	R9	G8
+      0x5C280A00,  //  004A  MOVE	R10	R5
+      0x7C240200,  //  004B  CALL	R9	1
+      0x00263409,  //  004C  ADD	R9	K26	R9
+      0x0024131B,  //  004D  ADD	R9	R9	K27
+      0x60280008,  //  004E  GETGBL	R10	G8
+      0x5C2C0C00,  //  004F  MOVE	R11	R6
+      0x7C280200,  //  0050  CALL	R10	1
+      0x0024120A,  //  0051  ADD	R9	R9	R10
+      0x58280017,  //  0052  LDCONST	R10	K23
+      0x7C1C0600,  //  0053  CALL	R7	3
+      0x70020000,  //  0054  JMP		#0056
+      0xB0080000,  //  0055  RAISE	2	R0	R0
+      0x80000000,  //  0056  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: gen_local_session_id
+********************************************************************/
+be_local_closure(Matter_Session_Store_gen_local_session_id,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(random),
+    /* K2   */  be_const_int(2),
+    /* K3   */  be_nested_str_weak(get),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(get_session_by_local_session_id),
+    }),
+    be_str_weak(gen_local_session_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x50080200,  //  0001  LDBOOL	R2	1	0
+      0x780A000E,  //  0002  JMPF	R2	#0012
+      0x8C080301,  //  0003  GETMET	R2	R1	K1
+      0x58100002,  //  0004  LDCONST	R4	K2
+      0x7C080400,  //  0005  CALL	R2	2
+      0x8C080503,  //  0006  GETMET	R2	R2	K3
+      0x58100004,  //  0007  LDCONST	R4	K4
+      0x58140002,  //  0008  LDCONST	R5	K2
+      0x7C080600,  //  0009  CALL	R2	3
+      0x8C0C0105,  //  000A  GETMET	R3	R0	K5
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x4C100000,  //  000D  LDNIL	R4
+      0x1C0C0604,  //  000E  EQ	R3	R3	R4
+      0x780E0000,  //  000F  JMPF	R3	#0011
+      0x80040400,  //  0010  RET	1	R2
+      0x7001FFEE,  //  0011  JMP		#0001
+      0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_Session_Store
 ********************************************************************/
 be_local_class(Matter_Session_Store,
-    2,
+    3,
     NULL,
-    be_nested_map(26,
+    be_nested_map(27,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(gen_local_session_id, 25), be_const_closure(Matter_Session_Store_gen_local_session_id_closure) },
-        { be_const_key_weak(remove_redundant_fabric, 15), be_const_closure(Matter_Session_Store_remove_redundant_fabric_closure) },
-        { be_const_key_weak(find_session_by_resumption_id, -1), be_const_closure(Matter_Session_Store_find_session_by_resumption_id_closure) },
-        { be_const_key_weak(fabrics, 5), be_const_var(1) },
-        { be_const_key_weak(add_fabric, -1), be_const_closure(Matter_Session_Store_add_fabric_closure) },
+        { be_const_key_weak(gen_local_session_id, -1), be_const_closure(Matter_Session_Store_gen_local_session_id_closure) },
         { be_const_key_weak(create_fabric, -1), be_const_closure(Matter_Session_Store_create_fabric_closure) },
-        { be_const_key_weak(sessions_active, -1), be_const_closure(Matter_Session_Store_sessions_active_closure) },
-        { be_const_key_weak(add_session, -1), be_const_closure(Matter_Session_Store_add_session_closure) },
-        { be_const_key_weak(count_active_fabrics, -1), be_const_closure(Matter_Session_Store_count_active_fabrics_closure) },
-        { be_const_key_weak(remove_expired, 17), be_const_closure(Matter_Session_Store_remove_expired_closure) },
-        { be_const_key_weak(_FABRICS, -1), be_nested_str_weak(_matter_fabrics_X2Ejson) },
-        { be_const_key_weak(find_fabric_by_index, -1), be_const_closure(Matter_Session_Store_find_fabric_by_index_closure) },
-        { be_const_key_weak(sessions, 4), be_const_var(0) },
-        { be_const_key_weak(get_session_by_source_node_id, 11), be_const_closure(Matter_Session_Store_get_session_by_source_node_id_closure) },
-        { be_const_key_weak(next_fabric_idx, -1), be_const_closure(Matter_Session_Store_next_fabric_idx_closure) },
-        { be_const_key_weak(get_session_by_local_session_id, 24), be_const_closure(Matter_Session_Store_get_session_by_local_session_id_closure) },
-        { be_const_key_weak(active_fabrics, -1), be_const_closure(Matter_Session_Store_active_fabrics_closure) },
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Session_Store_every_second_closure) },
-        { be_const_key_weak(remove_session, -1), be_const_closure(Matter_Session_Store_remove_session_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Session_Store_init_closure) },
-        { be_const_key_weak(create_session, -1), be_const_closure(Matter_Session_Store_create_session_closure) },
+        { be_const_key_weak(get_session_by_source_node_id, -1), be_const_closure(Matter_Session_Store_get_session_by_source_node_id_closure) },
         { be_const_key_weak(save_fabrics, -1), be_const_closure(Matter_Session_Store_save_fabrics_closure) },
-        { be_const_key_weak(load_fabrics, -1), be_const_closure(Matter_Session_Store_load_fabrics_closure) },
-        { be_const_key_weak(remove_fabric, 6), be_const_closure(Matter_Session_Store_remove_fabric_closure) },
-        { be_const_key_weak(find_children_fabrics, -1), be_const_closure(Matter_Session_Store_find_children_fabrics_closure) },
-        { be_const_key_weak(find_session_source_id_unsecure, -1), be_const_closure(Matter_Session_Store_find_session_source_id_unsecure_closure) },
+        { be_const_key_weak(active_fabrics, 10), be_const_closure(Matter_Session_Store_active_fabrics_closure) },
+        { be_const_key_weak(find_session_by_resumption_id, 20), be_const_closure(Matter_Session_Store_find_session_by_resumption_id_closure) },
+        { be_const_key_weak(sessions_active, -1), be_const_closure(Matter_Session_Store_sessions_active_closure) },
+        { be_const_key_weak(sessions, -1), be_const_var(1) },
+        { be_const_key_weak(fabrics, -1), be_const_var(2) },
+        { be_const_key_weak(load_fabrics, 6), be_const_closure(Matter_Session_Store_load_fabrics_closure) },
+        { be_const_key_weak(find_session_source_id_unsecure, 23), be_const_closure(Matter_Session_Store_find_session_source_id_unsecure_closure) },
+        { be_const_key_weak(_FABRICS, -1), be_nested_str_weak(_matter_fabrics_X2Ejson) },
+        { be_const_key_weak(remove_session, -1), be_const_closure(Matter_Session_Store_remove_session_closure) },
+        { be_const_key_weak(remove_fabric, 22), be_const_closure(Matter_Session_Store_remove_fabric_closure) },
+        { be_const_key_weak(find_fabric_by_index, 19), be_const_closure(Matter_Session_Store_find_fabric_by_index_closure) },
+        { be_const_key_weak(remove_expired, -1), be_const_closure(Matter_Session_Store_remove_expired_closure) },
+        { be_const_key_weak(add_session, -1), be_const_closure(Matter_Session_Store_add_session_closure) },
+        { be_const_key_weak(remove_redundant_fabric, 11), be_const_closure(Matter_Session_Store_remove_redundant_fabric_closure) },
+        { be_const_key_weak(create_session, -1), be_const_closure(Matter_Session_Store_create_session_closure) },
+        { be_const_key_weak(get_session_by_local_session_id, -1), be_const_closure(Matter_Session_Store_get_session_by_local_session_id_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Session_Store_init_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Session_Store_every_second_closure) },
+        { be_const_key_weak(add_fabric, -1), be_const_closure(Matter_Session_Store_add_fabric_closure) },
+        { be_const_key_weak(count_active_fabrics, -1), be_const_closure(Matter_Session_Store_count_active_fabrics_closure) },
+        { be_const_key_weak(device, 5), be_const_var(0) },
+        { be_const_key_weak(next_fabric_idx, 3), be_const_closure(Matter_Session_Store_next_fabric_idx_closure) },
+        { be_const_key_weak(find_children_fabrics, 0), be_const_closure(Matter_Session_Store_find_children_fabrics_closure) },
     })),
     be_str_weak(Matter_Session_Store)
 );


### PR DESCRIPTION
## Description:

Matter, persist plugins and endpoint configuration in `_matter_device.json`. The configuration is computed automatically from the template and sensors, but once the first fabric is associated, the configuration is frozen and persisted in json to avoid conflicts with associated devices.

A WebUI will follow.

Example: (pretty printed)

```json
{
	"distinguish": 1,
	"passcode": 20202022,
	"ipv4only": false,
	"config": {
		"0": {
			"type": "root"
		},
		"1": {
			"type": "relay",
			"relay": 0
		},
		"32": {
			"type": "temperature",
			"filter": "AXP192#Temperature"
		},
		"33": {
			"type": "temperature",
			"filter": "BMP280#Temperature"
		},
		"34": {
			"type": "temperature",
			"filter": "SHT3X#Temperature"
		},
		"40": {
			"type": "pressure",
			"filter": "BMP280#Pressure"
		},
		"56": {
			"type": "humidity",
			"filter": "SHT3X#Humidity"
		}
	}
}
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
