### PR TITLE
fix c3 exception at start when lvgl enabled

### DIFF
--- a/lib/libesp32/berry/default/berry_conf.h
+++ b/lib/libesp32/berry/default/berry_conf.h
@@ -226,7 +226,7 @@
   #define BE_USE_OS_MODULE                0
   #define BE_USE_GLOBAL_MODULE            1
   #define BE_USE_SYS_MODULE               1
-  #define BE_USE_DEBUG_MODULE             1
+  #define BE_USE_DEBUG_MODULE             0
   #define BE_USE_GC_MODULE                1
   #define BE_USE_SOLIDIFY_MODULE          0
   #define BE_USE_INTROSPECT_MODULE        1


### PR DESCRIPTION
## Description:

regression from [#18441 ](https://github.com/arendst/Tasmota/pull/18441)
fixed by reverting `#define BE_USE_DEBUG_MODULE 1` to `#define BE_USE_DEBUG_MODULE 0`

fyi @s-hadinger 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
