### PR TITLE
Berry: add BLE server/advertiser

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
@@ -44,11 +44,16 @@ module MI32 (scope: global) {
  * To use: `import BLE`
  *******************************************************************/
 
+extern int be_BLE_init(bvm *vm);
+
 extern void be_BLE_reg_conn_cb(void* function, uint8_t *buffer);
 BE_FUNC_CTYPE_DECLARE(be_BLE_reg_conn_cb, "", "cc");
 
 extern void be_BLE_reg_adv_cb(void* function, uint8_t *buffer);
 BE_FUNC_CTYPE_DECLARE(be_BLE_reg_adv_cb, "", "c[c]");
+
+extern void be_BLE_reg_server_cb(void* function, uint8_t *buffer);
+BE_FUNC_CTYPE_DECLARE(be_BLE_reg_server_cb, "", "c[c]");
 
 extern void be_BLE_set_MAC(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type);
 BE_FUNC_CTYPE_DECLARE(be_BLE_set_MAC, "", "@(bytes)~[i]");
@@ -73,6 +78,7 @@ BE_FUNC_CTYPE_DECLARE(be_BLE_adv_block, "", "@(bytes)~[i]");
 
 /* @const_object_info_begin
 module BLE (scope: global) {
+  init,       func(be_BLE_init)
   conn_cb,    ctype_func(be_BLE_reg_conn_cb)
   set_svc,    ctype_func(be_BLE_set_service)
   run,        ctype_func(be_BLE_run)
@@ -81,6 +87,7 @@ module BLE (scope: global) {
   set_MAC,    ctype_func(be_BLE_set_MAC)
   adv_watch,  ctype_func(be_BLE_adv_watch)
   adv_block,  ctype_func(be_BLE_adv_block)
+  serv_cb,    ctype_func(be_BLE_reg_server_cb)
 }
 @const_object_info_end */
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
@@ -74,9 +74,11 @@ extern "C" {
 
 /********************************************************************
 **  BLE - generic BLE functions
-********************************************************************/ 
+********************************************************************/
+  extern bool MI32checkBLEinitialization();
   extern void MI32setBerryAdvCB(void* function, uint8_t *buffer);
   extern void MI32setBerryConnCB(void* function, uint8_t *buffer);
+  extern void MI32setBerryServerCB(void* function, uint8_t *buffer);
   extern bool MI32runBerryConnection(uint8_t operation, bbool response);
   extern bool MI32setBerryCtxSvc(const char *Svc, bbool discoverAttributes);
   extern bool MI32setBerryCtxChr(const char *Chr);
@@ -84,10 +86,23 @@ extern "C" {
   extern bool MI32addMACtoBlockList(uint8_t *MAC, uint8_t type);
   extern bool MI32addMACtoWatchList(uint8_t *MAC, uint8_t type);
 
+  int be_BLE_init(bvm *vm);
+  int be_BLE_init(bvm *vm) {
+    if (MI32checkBLEinitialization() == true){
+      be_return(vm);
+    }
+    be_raise(vm, "ble_error", "BLE: device not initialized");
+    be_return_nil(vm);
+  }
 
   void be_BLE_reg_conn_cb(void* function, uint8_t *buffer);
   void be_BLE_reg_conn_cb(void* function, uint8_t *buffer){    
     MI32setBerryConnCB(function,buffer);
+  }
+
+  void be_BLE_reg_server_cb(void* function, uint8_t *buffer);
+  void be_BLE_reg_server_cb(void* function, uint8_t *buffer){    
+    MI32setBerryServerCB(function,buffer);
   }
 
   void be_BLE_reg_adv_cb(void* function, uint8_t *buffer);
@@ -193,7 +208,9 @@ BLE.set_chr
 
 BLE.set_MAC
 BLE.run(op, optional: bool response)
+
 be_BLE_op:
+# client
 1 read
 2 write
 3 subscribe
@@ -205,8 +222,28 @@ be_BLE_op:
 13 subscribe once, then disconnect
 14 unsubscribe once, then disconnect - maybe later
 
+#server
+__commands
+201 add/set advertisement
+202 add/set scan response
+
+211 add/set characteristic 
+
+__response
+221 onRead
+222 onWrite
+223 unsubscribed
+224 subscribed to notifications
+225 subscribed to indications
+226 subscribed to notifications and indications
+227 onConnect
+228 onDisconnect
+229 onStatus
+
+
 BLE.conn_cb(cb,buffer)
 BLE.adv_cb(cb,buffer)
+BLE.serv_cb(cb,buffer)
 BLE.adv_watch(MAC)
 BLE.adv_block(MAC)
 


### PR DESCRIPTION
## Description:

Exposes more functions of NimBLE-Arduino.
This is a very simplistic approach and not a full fledged implementation. It only adds one function to the BLE module of Berry and the API and works as a session (in a Free-RTOS task) with basically no boilerplate code.
Working examples are support for:
- sending iBeacons
- sending sensor data in the BTHome standard - https://bthome.io
- commissioning WiFi credentials via https://www.improv-wifi.com/
- building a custom BLE interface to control Tasmota with console commands

Example code in the comments ...

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
