### PR TITLE
Solved: ModbusBridge reading int16 returns uint16

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_63_modbus_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_63_modbus_bridge.ino
@@ -485,7 +485,7 @@ void ModbusBridgeHandle(void)
                 ((uint8_t *)&value)[0] = modbusBridge.buffer[dataOffset + 3 + (count * 4)];
               }
               if (modbusBridge.type == ModbusBridgeType::mb_int32)
-                snprintf(svalue, MBR_MAX_VALUE_LENGTH, "%d", value);
+                snprintf(svalue, MBR_MAX_VALUE_LENGTH, "%d", (int32_t)value);
               else
                 snprintf(svalue, MBR_MAX_VALUE_LENGTH, "%u", value);
             }
@@ -506,7 +506,7 @@ void ModbusBridgeHandle(void)
                 ((uint8_t *)&value)[0] = modbusBridge.buffer[dataOffset + 1 + (count * 2)];
               }
               if (modbusBridge.type == ModbusBridgeType::mb_int16)
-                snprintf(svalue, MBR_MAX_VALUE_LENGTH, "%d", value);
+                snprintf(svalue, MBR_MAX_VALUE_LENGTH, "%d", (int16_t)value);
               else
                 snprintf(svalue, MBR_MAX_VALUE_LENGTH, "%u", value);
             }
@@ -515,7 +515,7 @@ void ModbusBridgeHandle(void)
             {
               uint8_t value = modbusBridge.buffer[dataOffset + (count * 1)];
               if (modbusBridge.type == ModbusBridgeType::mb_int8)
-                snprintf(svalue, MBR_MAX_VALUE_LENGTH, "%d", value);
+                snprintf(svalue, MBR_MAX_VALUE_LENGTH, "%d", (int8_t)value);
               else
                 snprintf(svalue, MBR_MAX_VALUE_LENGTH, "%u", value);
             }


### PR DESCRIPTION
This PR fixed: https://github.com/arendst/Tasmota/issues/18522

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
