### PR TITLE
Added support for Dingtian Relay Board v3.6.10

### DIFF
--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -467,8 +467,8 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_MCP23XXX_INT "|" D_SENSOR_MCP23SXX_CS "|"
   D_SENSOR_PCF8574_INT "|"
   D_SENSOR_LOX_O2_RX "|"
-  D_SENSOR_GM861_TX "|" D_SENSOR_GM861_RX "|"  
-  D_GPIO_DINGTIAN_OE "|" 
+  D_SENSOR_GM861_TX "|" D_SENSOR_GM861_RX "|"
+  D_GPIO_DINGTIAN_OE "|"
   ;
 
 const char kSensorNamesFixed[] PROGMEM =

--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -210,6 +210,7 @@ enum UserSelectablePins {
   GPIO_PCF8574_INT,                     // PCF8574 interrupt
   GPIO_LOX_O2_RX,                       // LOX-O2 RX
   GPIO_GM861_TX, GPIO_GM861_RX,         // GM861 Serial interface
+  GPIO_DINGTIAN_OE,                     // New version of Dingtian relay board where PL is not shared with OE
   GPIO_SENSOR_END };
 
 // Error as warning to rethink GPIO usage with max 2045
@@ -466,7 +467,8 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_MCP23XXX_INT "|" D_SENSOR_MCP23SXX_CS "|"
   D_SENSOR_PCF8574_INT "|"
   D_SENSOR_LOX_O2_RX "|"
-  D_SENSOR_GM861_TX "|" D_SENSOR_GM861_RX "|"
+  D_SENSOR_GM861_TX "|" D_SENSOR_GM861_RX "|"  
+  D_GPIO_DINGTIAN_OE "|" 
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -1121,6 +1123,7 @@ const uint16_t kGpioNiceList[] PROGMEM = {
   AGPIO(GPIO_DINGTIAN_SDI),
   AGPIO(GPIO_DINGTIAN_Q7),
   AGPIO(GPIO_DINGTIAN_PL),
+  AGPIO(GPIO_DINGTIAN_OE),
   AGPIO(GPIO_DINGTIAN_RCK),
 #endif
 

--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/ca_AD.h
+++ b/tasmota/language/ca_AD.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCk"
 #define D_SENSOR_CM11_TX       "CM110x Tx"
 #define D_SENSOR_CM11_RX       "CM110x Rx"

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI             "Dingtian - SDI"
 #define D_GPIO_DINGTIAN_Q7              "Dingtian - Q7"
 #define D_GPIO_DINGTIAN_PL              "Dingtian - PL"
+#define D_GPIO_DINGTIAN_OE              "Dingtian - OE"
 #define D_GPIO_DINGTIAN_RCK             "Dingtian - RCK"
 #define D_SENSOR_CM11_TX                "CM110x - TX"
 #define D_SENSOR_CM11_RX                "CM110x - RX"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -919,6 +919,7 @@
 #define D_GPIO_DINGTIAN_SDI    "Dingtian SDI"
 #define D_GPIO_DINGTIAN_Q7     "Dingtian Q7"
 #define D_GPIO_DINGTIAN_PL     "Dingtian PL"
+#define D_GPIO_DINGTIAN_OE     "Dingtian OE"
 #define D_GPIO_DINGTIAN_RCK    "Dingtian RCK"
 #define D_SENSOR_CM11_TX       "CM110x TX"
 #define D_SENSOR_CM11_RX       "CM110x RX"

--- a/tasmota/tasmota_xdrv_driver/xdrv_90_esp32_dingtian_relay.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_90_esp32_dingtian_relay.ino
@@ -41,7 +41,7 @@ struct DINGTIAN_DATA {
   uint8_t     first;            // index of 1st Tasmota relay assigned to 1st Dingtian relays
   int8_t      key_offset;       // index of virtual key
   // pins
-  uint8_t     pin_clk, pin_sdi, pin_q7, pin_pl, pin_rck;
+  uint8_t     pin_clk, pin_sdi, pin_q7, pin_pl, pin_oe, pin_rck;
 } *Dingtian = nullptr;
 
 
@@ -56,7 +56,7 @@ uint32_t DingtianReadWrite(uint32_t outputs)
 
   // setup
   digitalWrite(Dingtian->pin_rck, 0);    // rclk and clkinh to 0
-  digitalWrite(Dingtian->pin_pl, 1);      // load inputs in '165, ready for shift-in (side effect '595 in tri-state)
+  if (PinUsed(GPIO_DINGTIAN_PL)) digitalWrite(Dingtian->pin_pl, 1);      // load inputs in '165, ready for shift-in (side effect '595 in tri-state)
   for ( int i = Dingtian->count ; i > 0 ; i-- ) {
     // relay out to '595
     digitalWrite(Dingtian->pin_sdi, outputs & 1);
@@ -70,7 +70,8 @@ uint32_t DingtianReadWrite(uint32_t outputs)
   }
   // ending
   digitalWrite(Dingtian->pin_rck, 1);    // rclk pulse to load '595 into output registers
-  digitalWrite(Dingtian->pin_pl, 0);      // re-enable '595 ouputs
+  if (PinUsed(GPIO_DINGTIAN_PL)) digitalWrite(Dingtian->pin_pl, 0);      // re-enable '595 ouputs (old board version)
+  if (PinUsed(GPIO_DINGTIAN_OE))digitalWrite(Dingtian->pin_oe, 0);      // enable '595 ouputs (new board version)
 
 #ifdef DINGTIAN_INPUTS_INVERTED
   return ~inputs;
@@ -88,26 +89,28 @@ uint32_t DingtianReadWrite(uint32_t outputs)
 
 void DingtianInit(void) {
   if (PinUsed(GPIO_DINGTIAN_CLK, GPIO_ANY) && PinUsed(GPIO_DINGTIAN_SDI) && PinUsed(GPIO_DINGTIAN_Q7)
-   && PinUsed(GPIO_DINGTIAN_PL) && PinUsed(GPIO_DINGTIAN_RCK)) {
+   && (PinUsed(GPIO_DINGTIAN_PL) || PinUsed(GPIO_DINGTIAN_OE)) && PinUsed(GPIO_DINGTIAN_RCK)) {
     // allocate Dingtian data structure
     Dingtian = (struct DINGTIAN_DATA*)calloc(1, sizeof(struct DINGTIAN_DATA));
     if (Dingtian) {
       // get pins
-      Dingtian->pin_clk = Pin(GPIO_DINGTIAN_CLK, GPIO_ANY);   // shift clock  : 595's SCLK & 165's CLK
-      Dingtian->pin_sdi = Pin(GPIO_DINGTIAN_SDI);             // Serial out   : 595's SER
-      Dingtian->pin_q7  = Pin(GPIO_DINGTIAN_Q7);              // Serial in    : 165's Q7
-      Dingtian->pin_pl  = Pin(GPIO_DINGTIAN_PL);              // Input load   : 595's nOE  & 165's PL (or SH/LD on some datasheet)
-      Dingtian->pin_rck = Pin(GPIO_DINGTIAN_RCK);             // Output load  : 595's RCLK & 165's CLKINH
+      Dingtian->pin_clk = Pin(GPIO_DINGTIAN_CLK, GPIO_ANY);                     // shift clock   : 595's SCLK & 165's CLK
+      Dingtian->pin_sdi = Pin(GPIO_DINGTIAN_SDI);                               // Serial out    : 595's SER
+      Dingtian->pin_q7  = Pin(GPIO_DINGTIAN_Q7);                                // Serial in     : 165's Q7
+      if (PinUsed(GPIO_DINGTIAN_PL)) Dingtian->pin_pl  = Pin(GPIO_DINGTIAN_PL); // Input load    : 595's nOE  & 165's PL (or SH/LD on some datasheet)
+      if (PinUsed(GPIO_DINGTIAN_OE)) Dingtian->pin_oe  = Pin(GPIO_DINGTIAN_OE); // Output enable : 595's nOE (v3.6.10)
+      Dingtian->pin_rck = Pin(GPIO_DINGTIAN_RCK);                               // Output load   : 595's RCLK & 165's CLKINH
       // number of shift registers is the CLK index
       Dingtian->count   = ((GetPin(Dingtian->pin_clk) - AGPIO(GPIO_DINGTIAN_CLK)) + 1) * 8;
 
-      AddLog(LOG_LEVEL_DEBUG, PSTR("DNGT: clk:%d, sdi:%d, q7:%d, pl:%d, rck:%d, count:%d"),
-        Dingtian->pin_clk, Dingtian->pin_sdi, Dingtian->pin_q7, Dingtian->pin_pl, Dingtian->pin_rck, Dingtian->count);
+      AddLog(LOG_LEVEL_DEBUG, PSTR("DNGT: clk:%d, sdi:%d, q7:%d, pl:%d, oe:%d, rck:%d, count:%d"),
+        Dingtian->pin_clk, Dingtian->pin_sdi, Dingtian->pin_q7, Dingtian->pin_pl, Dingtian->pin_oe, Dingtian->pin_rck, Dingtian->count);
 
       DINGTIAN_SET_OUTPUT(Dingtian->pin_clk, 0);
       DINGTIAN_SET_OUTPUT(Dingtian->pin_sdi, 0);
       DINGTIAN_SET_INPUT( Dingtian->pin_q7);
       DINGTIAN_SET_OUTPUT(Dingtian->pin_pl, 0);
+      //Do not initialize Dingtian->pin_oe so the relays will not toggle while restarting
       DINGTIAN_SET_OUTPUT(Dingtian->pin_rck, 0);
 
       Dingtian->first = TasmotaGlobal.devices_present;

--- a/tasmota/tasmota_xdrv_driver/xdrv_90_esp32_dingtian_relay.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_90_esp32_dingtian_relay.ino
@@ -30,6 +30,9 @@
 #error DINGTIAN - Only one of DINGTIAN_USE_AS_BUTTON or DINGTIAN_USE_AS_SWITCH should be defined
 #endif
 
+#define DINGTIAN_SET_OUTPUT(pin,value)  { pinMode((pin), OUTPUT); digitalWrite((pin), (value)); }
+#define DINGTIAN_SET_INPUT(pin)         { pinMode((pin), INPUT); }
+
 /********************************************************************************************************
  * Global private data
  */
@@ -71,7 +74,11 @@ uint32_t DingtianReadWrite(uint32_t outputs)
   // ending
   digitalWrite(Dingtian->pin_rck, 1);    // rclk pulse to load '595 into output registers
   if (PinUsed(GPIO_DINGTIAN_PL)) digitalWrite(Dingtian->pin_pl, 0);      // re-enable '595 ouputs (old board version)
-  if (PinUsed(GPIO_DINGTIAN_OE))digitalWrite(Dingtian->pin_oe, 0);      // enable '595 ouputs (new board version)
+  if (PinUsed(GPIO_DINGTIAN_OE))
+  {
+    digitalWrite(Dingtian->pin_oe, 0);      // enable '595 ouputs (new board version)
+    DINGTIAN_SET_OUTPUT(Dingtian->pin_oe, 0);
+  }
 
 #ifdef DINGTIAN_INPUTS_INVERTED
   return ~inputs;
@@ -83,9 +90,6 @@ uint32_t DingtianReadWrite(uint32_t outputs)
 /********************************************************************************************************
  * Driver initialisation
  */
-
-#define DINGTIAN_SET_OUTPUT(pin,value)  { pinMode((pin), OUTPUT); digitalWrite((pin), (value)); }
-#define DINGTIAN_SET_INPUT(pin)         { pinMode((pin), INPUT); }
 
 void DingtianInit(void) {
   if (PinUsed(GPIO_DINGTIAN_CLK, GPIO_ANY) && PinUsed(GPIO_DINGTIAN_SDI) && PinUsed(GPIO_DINGTIAN_Q7)
@@ -111,6 +115,7 @@ void DingtianInit(void) {
       DINGTIAN_SET_INPUT( Dingtian->pin_q7);
       DINGTIAN_SET_OUTPUT(Dingtian->pin_pl, 0);
       //Do not initialize Dingtian->pin_oe so the relays will not toggle while restarting
+      DINGTIAN_SET_OUTPUT(Dingtian->pin_pl, 0);
       DINGTIAN_SET_OUTPUT(Dingtian->pin_rck, 0);
 
       Dingtian->first = TasmotaGlobal.devices_present;


### PR DESCRIPTION
## Description:
Dingtian has done a hardware revision (v3.6.10) because the relays where toggling at power on and buzzing when relay was activated.

The PL pin from the input register is now disconnected from the ESP32 GPIO32.
The OE pin from the output register is still connected to the ESP32 GPIO32, and has to be pulled low after the output shift register is initialized.

I want to create documentation next week.

**Related issue (if applicable):** https://github.com/arendst/Tasmota/pull/17032

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
