### PR TITLE
[ZCDimmer] reboot bugfix

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_68_zerocrossDimmer.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_68_zerocrossDimmer.ino
@@ -24,6 +24,8 @@
 
 #define XDRV_68             68
 
+// #define ZCDIMMERSET_SHOW  // Show ZCDimmerSet-Value on Webpage if present
+
 static const uint8_t GATE_ENABLE_TIME = 100;
 static const uint8_t MIN_PERCENT = 5;
 static const uint8_t MAX_PERCENT = 99;
@@ -83,7 +85,7 @@ void IRAM_ATTR ACDimmerZeroCross(uint32_t time) {
 uint32_t IRAM_ATTR ACDimmerTimer_intr_ESP8266() {
   //ACDimmerTimer_intr();
   ACDimmerTimer_intr();
-  return 6000;
+  return 4000;
 }
 
 void ACDimmerInterruptDisable(bool disable)
@@ -92,14 +94,14 @@ void ACDimmerInterruptDisable(bool disable)
   ac_zero_cross_dimmer.timer_iterrupt_started = !disable;
   if (disable) {
     //stop the interrupt
-#ifdef ESP32   
+#ifdef ESP32
     if (dimmer_timer != nullptr) { 
      timerAlarmDisable(dimmer_timer);
     }
-#endif  
-#ifdef ESP8266  
+#endif
+#ifdef ESP8266
     //setTimer1Callback(NULL);
-#endif  
+#endif
   } else {
     for (uint8_t i = 0 ; i < MAX_PWMS; i++) {
       if (Pin(GPIO_PWM1, i) != -1) {
@@ -124,7 +126,7 @@ void ACDimmerInterruptDisable(bool disable)
     // Uses ESP8266 waveform (soft PWM) class
     // PWM and AcDimmer can even run at the same time this way
     //setTimer1Callback(&ACDimmerTimer_intr_ESP8266);
-#endif    
+#endif
   }
 }
 
@@ -157,6 +159,7 @@ void IRAM_ATTR ACDimmerTimer_intr() {
         break;    
       case 0:
       case 3:
+#ifdef ESP32
         if (time_since_zc + TRIGGER_PERIOD >= ac_zero_cross_dimmer.enable_time_us[i]){
           // Very close to the fire event. Loop the last µseconds to wait.
           while (time_since_zc < ac_zero_cross_dimmer.enable_time_us[i]) {
@@ -164,6 +167,7 @@ void IRAM_ATTR ACDimmerTimer_intr() {
             time_since_zc = now - ac_zero_cross_dimmer.crossed_zero_at;
           }
         }
+#endif
         if (time_since_zc >= ac_zero_cross_dimmer.enable_time_us[i]) {
           digitalWrite(Pin(GPIO_PWM1, i), HIGH);
           ac_zero_cross_dimmer.current_state_in_phase[i]++;
@@ -198,7 +202,7 @@ void ACDimmerControllTrigger(void) {
       //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("ZCD: Float2: %*_f"),0,&state);
       ac_zero_cross_dimmer.enable_time_us[i] = (uint32_t)state;
     }    
-#endif  
+#endif
     
     ac_zero_cross_dimmer.disable_time_us[i] = ac_zero_cross_dimmer.enable_time_us[i] + ac_zero_cross_dimmer.triggertime;
   }
@@ -210,12 +214,12 @@ void ACDimmerLogging(void)
     bool alarmEnabled = false;
     uint32_t timercounter = ac_zero_cross_dimmer.intr_counter;
 
-#ifdef ESP32    
+#ifdef ESP32
     if (dimmer_timer != nullptr) {
       alarmEnabled = timerAlarmEnabled(dimmer_timer);
       timercounter = (uint32_t)timerRead(dimmer_timer);
     }
-#endif    
+#endif
 
     AddLog(LOG_LEVEL_DEBUG, PSTR("ZCD: ZeroEnable %d -> %d, Alarm %d, intr: %ld, cycle time: %ld µs, missed zc %ld"),
       ac_zero_cross_dimmer.dimmer_in_use, ac_zero_cross_dimmer.timer_iterrupt_started, alarmEnabled, timercounter, 
@@ -231,6 +235,21 @@ void ACDimmerLogging(void)
     }
 } 
 
+#ifdef USE_WEBSERVER
+#ifdef ZCDIMMERSET_SHOW
+void ACDimmerShow(void)
+{
+  char c_ZCDimmerSetBuffer[8];
+  for (uint8_t i = 0; i < MAX_PWMS; i++){
+    if (Pin(GPIO_PWM1, i) == -1) continue;
+    if (ac_zero_cross_dimmer.detailpower[i]){
+      dtostrfd(ac_zero_cross_dimmer.detailpower[i]/100.0, 2, c_ZCDimmerSetBuffer);
+      WSContentSend_PD(PSTR("{s}ZCDimmer%d{m}%s %%{e}"), i+1, c_ZCDimmerSetBuffer);
+    }
+  }
+}
+#endif  // ZCDIMMERSET_SHOW
+#endif  // USE_WEBSERVER
 
 /*********************************************************************************************\
  * Commands
@@ -264,7 +283,7 @@ bool Xdrv68(uint32_t function)
   if (Settings->flag4.zerocross_dimmer) {
     switch (function) {
       case FUNC_INIT:
-#ifdef ESP32      
+#ifdef ESP32
         //ACDimmerInterruptDisable(false);
 #endif      
 #ifdef ESP8266
@@ -286,6 +305,13 @@ bool Xdrv68(uint32_t function)
       case FUNC_COMMAND:
         result = DecodeCommand(kZCDimmerCommands, ZCDimmerCommand);
         break; 
+#ifdef USE_WEBSERVER
+#ifdef ZCDIMMERSET_SHOW
+      case FUNC_WEB_SENSOR:
+        ACDimmerShow();
+        break;
+#endif  // ZCDIMMERSET_SHOW
+#endif  // USE_WEBSERVER
     }
   }
   return result;


### PR DESCRIPTION
## Description:

- Bugfix of reboots on ESP8266
- Display value of ``ZCDimmerSet`` on Webpage

See also discussion [#14978](https://github.com/arendst/Tasmota/discussions/14978)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).