### PR TITLE
esp8266 iram metrics

### DIFF
--- a/pio-tools/metrics-firmware.py
+++ b/pio-tools/metrics-firmware.py
@@ -1,9 +1,25 @@
 Import("env")
 
+import os
 import tasmotapiolib
+from os.path import join
+
 def firm_metrics(source, target, env):
     if env["PIOPLATFORM"] == "espressif32":
         import tasmota_metrics
         env.Execute("$PYTHONEXE -m tasmota_metrics " + str(tasmotapiolib.get_source_map_path(env).resolve()))
+    elif env["PIOPLATFORM"] == "espressif8266":
+        map_file = join(env.subst("$BUILD_DIR")) + os.sep + "firmware.map"
+        with open(map_file,'r') as f:
+            phrase = "_text_end = ABSOLUTE (.)"
+            for line in f:
+                if  phrase in line:
+                    address = line.strip().split(" ")[0]
+                    if int(address, 16) < 0x40108000:
+                        used_bytes = int(address, 16) - 0x40100000
+                        remaining_bytes = 0x8000 - used_bytes
+                        percentage = round(used_bytes / 0x8000 * 100,1)
+                        print("Used static IRAM:",used_bytes,"bytes (",remaining_bytes,"remain,",percentage,"% used)")
+
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin",firm_metrics)

--- a/pio-tools/name-firmware.py
+++ b/pio-tools/name-firmware.py
@@ -1,8 +1,10 @@
 Import("env")
 
+import os
 import shutil
 import pathlib
 import tasmotapiolib
+from os.path import join
 
 
 def bin_map_copy(source, target, env):
@@ -30,5 +32,7 @@ def bin_map_copy(source, target, env):
         shutil.copy(tasmotapiolib.get_source_map_path(env), map_file)
         shutil.copy(factory, one_bin_file)
     else:
+        map_firm = join(env.subst("$BUILD_DIR")) + os.sep + "firmware.map"
+        shutil.copy(tasmotapiolib.get_source_map_path(env), map_firm)
         shutil.move(tasmotapiolib.get_source_map_path(env), map_file)
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", bin_map_copy)


### PR DESCRIPTION
## Description:

Show ESP8266 IRAM usage at the end of the Pio compile run.

@Staars Thx for the scanner logic part.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
