### PR TITLE
Berry `re` (regex) add `match2` and optional offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 `Shuttersetup` for "Shelly 2.5 pro" automatic calibration and setup (experimental)
 - Berry `tcpclientasync` class for non-blocking TCP client
 - Support for GM861 1D and 2D bar code reader (#18399)
+- Berry `re` (regex) add `match2` and optional offset
 
 ### Breaking Changed
 - Change command ``FileUpload`` index binary data detection from >199 to >299

--- a/lib/libesp32/berry/default/be_re_lib.c
+++ b/lib/libesp32/berry/default/be_re_lib.c
@@ -62,7 +62,7 @@ int be_re_compile(bvm *vm) {
 
 // pushes either a list if matched, else `nil`
 // return index of next offset, or -1 if not found
-const char *be_re_match_search_run(bvm *vm, ByteProg *code, const char *hay, bbool is_anchored) {
+const char *be_re_match_search_run(bvm *vm, ByteProg *code, const char *hay, bbool is_anchored, bbool size_only) {
   Subject subj = {hay, hay + strlen(hay)};
 
   int sub_els = (code->sub + 1) * 2;
@@ -80,7 +80,11 @@ const char *be_re_match_search_run(bvm *vm, ByteProg *code, const char *hay, bbo
     if (sub[i] == nil || sub[i+1] == nil) {
       be_pushnil(vm);
     } else {
-    be_pushnstring(vm, sub[i], sub[i+1] - sub[i]);
+      if (size_only && i==0) {
+        be_pushint(vm, sub[i+1] - sub[i]);
+      } else {
+        be_pushnstring(vm, sub[i], sub[i+1] - sub[i]);
+      }
     }
     be_data_push(vm, -2);
     be_pop(vm, 1);
@@ -89,11 +93,20 @@ const char *be_re_match_search_run(bvm *vm, ByteProg *code, const char *hay, bbo
   return sub[1];
 }
 
-int be_re_match_search(bvm *vm, bbool is_anchored) {
+int be_re_match_search(bvm *vm, bbool is_anchored, bbool size_only) {
   int32_t argc = be_top(vm); // Get the number of arguments
   if (argc >= 2 && be_isstring(vm, 1) && be_isstring(vm, 2)) {
     const char * regex_str = be_tostring(vm, 1);
     const char * hay = be_tostring(vm, 2);
+    int32_t offset = 0;
+    if (argc >= 3 && be_isint(vm, 3)) {
+      offset = be_toint(vm, 3);
+    }
+    int32_t hay_len = strlen(hay);
+    if (offset < 0) { offset = 0; }
+    if (offset >= hay_len) { be_return_nil(vm); }      // any match of empty string returns nil, this catches implicitly when hay_len == 0
+    hay += offset;                  // shift to offset
+
 	  int sz = re1_5_sizecode(regex_str);
   	if (sz < 0) {
       be_raise(vm, "internal_error", "error in regex");
@@ -104,7 +117,7 @@ int be_re_match_search(bvm *vm, bbool is_anchored) {
     if (ret != 0) {
       be_raise(vm, "internal_error", "error in regex");
     }
-    be_re_match_search_run(vm, code, hay, is_anchored);
+    be_re_match_search_run(vm, code, hay, is_anchored, size_only);
     be_return(vm);
   }
   be_raise(vm, "type_error", NULL);
@@ -132,7 +145,7 @@ int be_re_match_search_all(bvm *vm, bbool is_anchored) {
 
     be_newobject(vm, "list");
     for (int i = limit; i != 0 && hay != NULL; i--) {
-      hay = be_re_match_search_run(vm, code, hay, is_anchored);
+      hay = be_re_match_search_run(vm, code, hay, is_anchored, bfalse);
       if (hay != NULL) {
         be_data_push(vm, -2);   // add sub list to list
       }
@@ -144,13 +157,17 @@ int be_re_match_search_all(bvm *vm, bbool is_anchored) {
   be_raise(vm, "type_error", NULL);
 }
 
-// Berry: `re.match(value:int | s:string) -> nil`
+// Berry: `re.match(s:string [, offset:int]) -> nil`
 int be_re_match(bvm *vm) {
-  return be_re_match_search(vm, btrue);
+  return be_re_match_search(vm, btrue, bfalse);
 }
-// Berry: `re.search(value:int | s:string) -> nil`
+// Berry: `re.match2(s:string [, offset:int]) -> nil`
+int be_re_match2(bvm *vm) {
+  return be_re_match_search(vm, btrue, btrue);
+}
+// Berry: `re.search(s:string [, offset:int]) -> nil`
 int be_re_search(bvm *vm) {
-  return be_re_match_search(vm, bfalse);
+  return be_re_match_search(vm, bfalse, bfalse);
 }
 
 // Berry: `re.search_all`
@@ -162,14 +179,22 @@ int be_re_search_all(bvm *vm) {
   return be_re_match_search_all(vm, bfalse);
 }
 
-// Berry: `re_pattern.search(s:string) -> list(string)`
+// Berry: `re_pattern.search(s:string [, offset:int]) -> list(string)`
 int re_pattern_search(bvm *vm) {
   int32_t argc = be_top(vm); // Get the number of arguments
   if (argc >= 2 && be_isstring(vm, 2)) {
     const char * hay = be_tostring(vm, 2);
+    int32_t offset = 0;
+    if (argc >= 3 && be_isint(vm, 3)) {
+      offset = be_toint(vm, 3);
+    }
+    int32_t hay_len = strlen(hay);
+    if (offset < 0) { offset = 0; }
+    if (offset >= hay_len) { be_return_nil(vm); }      // any match of empty string returns nil, this catches implicitly when hay_len == 0
+    hay += offset;                  // shift to offset
     be_getmember(vm, 1, "_p");
     ByteProg * code = (ByteProg*) be_tocomptr(vm, -1);
-    be_re_match_search_run(vm, code, hay, bfalse);
+    be_re_match_search_run(vm, code, hay, bfalse, bfalse);
     be_return(vm);
   }
   be_raise(vm, "type_error", NULL);
@@ -189,7 +214,7 @@ int re_pattern_match_search_all(bvm *vm, bbool is_anchored) {
 
     be_newobject(vm, "list");
     for (int i = limit; i != 0 && hay != NULL; i--) {
-      hay = be_re_match_search_run(vm, code, hay, is_anchored);
+      hay = be_re_match_search_run(vm, code, hay, is_anchored, bfalse);
       if (hay != NULL) {
         be_data_push(vm, -2);   // add sub list to list
       }
@@ -211,19 +236,36 @@ int re_pattern_match_all(bvm *vm) {
   return re_pattern_match_search_all(vm, btrue);
 }
 
-// Berry: `re_pattern.match(s:string) -> list(string)`
-int re_pattern_match(bvm *vm) {
+// Berry: `re_pattern.match(s:string [, offset:int]) -> list(string)`
+int re_pattern_match_size(bvm *vm, bbool size_only) {
   int32_t argc = be_top(vm); // Get the number of arguments
   if (argc >= 2 && be_isstring(vm, 2)) {
     const char * hay = be_tostring(vm, 2);
+    int32_t offset = 0;
+    if (argc >= 3 && be_isint(vm, 3)) {
+      offset = be_toint(vm, 3);
+    }
+    int32_t hay_len = strlen(hay);
+    if (offset < 0) { offset = 0; }
+    if (offset >= hay_len) { be_return_nil(vm); }      // any match of empty string returns nil, this catches implicitly when hay_len == 0
+    hay += offset;                  // shift to offset
     be_getmember(vm, 1, "_p");
     ByteProg * code = (ByteProg*) be_tocomptr(vm, -1);
-    be_re_match_search_run(vm, code, hay, btrue);
+    be_re_match_search_run(vm, code, hay, btrue, size_only);
     be_return(vm);
   }
   be_raise(vm, "type_error", NULL);
 }
 
+// Berry: `re_pattern.match(s:string [, offset:int]) -> list(string)`
+int re_pattern_match(bvm *vm) {
+  return re_pattern_match_size(vm, bfalse);
+}
+
+// Berry: `re_pattern.match(s:string [, offset:int]) -> list(string)`
+int re_pattern_match2(bvm *vm) {
+  return re_pattern_match_size(vm, btrue);
+}
 
 int re_pattern_split_run(bvm *vm, ByteProg *code, const char *hay, int split_limit) {
   Subject subj = {hay, hay + strlen(hay)};
@@ -304,6 +346,7 @@ module re (scope: global) {
   search, func(be_re_search)
   searchall, func(be_re_search_all)
   match, func(be_re_match)
+  match2, func(be_re_match2)
   matchall, func(be_re_match_all)
   split, func(be_re_split)
 }
@@ -315,6 +358,7 @@ class be_class_re_pattern (scope: global, name: re_pattern) {
   search, func(re_pattern_search)
   searchall, func(re_pattern_search_all)
   match, func(re_pattern_match)
+  match2, func(re_pattern_match2)
   matchall, func(re_pattern_match_all)
   split, func(re_pattern_split)
 }


### PR DESCRIPTION
## Description:

Berry, add two extensions to `re` (regex) module to allow to parse a big chunk of text in a greedy way without copying large chunks of text. This will make it more frugal.

- `search(hay:string [, offset:int]) -> list or nil` and `match(hay:string [, offset:int]) -> list or nil`: take an optional second argument `offset` which indicates at which character to start the matching (default `0`).
- `match2(hay:string [, offset:int]) -> list or nil` is useful if you are only interested in the sub-groups and not the entire matched string. The first element of the returned list is just the length of the matched string, instead of a copy of it.

Example:
``` berry
# the example below shows how to parse HTTP headers
# input:
# Content-Type: application/json
# Server: Tasmota/12.5.0.1 (ESP32-D0WDQ6)
# Cache-Control: no-cache, no-store, must-revalidate
# Pragma: no-cache
# Expires: -1
# Accept-Ranges: none
# Transfer-Encoding: chunked
# Connection: close

var s = bytes("436F6E74656E742D547970653A206170706C69636174696F6E2F6A736F6E0D0A5365727665723A205461736D6F74612F31322E352E302E31202845535033322D443057445136290D0A43616368652D436F6E74726F6C3A206E6F2D63616368652C206E6F2D73746F72652C206D7573742D726576616C69646174650D0A507261676D613A206E6F2D63616368650D0A457870697265733A202D310D0A4163636570742D52616E6765733A206E6F6E650D0A5472616E736665722D456E636F64696E673A206368756E6B65640D0A436F6E6E656374696F6E3A20636C6F73650D0A").asstring()

import re
HTTP_HEADER_REGEX = "([A-Za-z0-9-]+): (.*?)\r\n"
var m_header = re.compile(HTTP_HEADER_REGEX)

# regular matcher
print(m_header.match(s))
# ['Content-Type: application/json\r\n', 'Content-Type', 'application/json']

# size only matcher
print(m_header.match2(s))
# [32, 'Content-Type', 'application/json']

# which makes it easy to iterate
print(m_header.match2(s, 32))
# [41, 'Server', 'Tasmota/12.5.0.1 (ESP32-D0WDQ6)']

# full iterator
offset = 0

while true
  var l_header = m_header.match2(s, offset)
  if l_header == nil break end
  offset += l_header[0]
  print(l_header)
end

# [32, 'Content-Type', 'application/json']
# [41, 'Server', 'Tasmota/12.5.0.1 (ESP32-D0WDQ6)']
# [52, 'Cache-Control', 'no-cache, no-store, must-revalidate']
# [18, 'Pragma', 'no-cache']
# [13, 'Expires', '-1']
# [21, 'Accept-Ranges', 'none']
# [28, 'Transfer-Encoding', 'chunked']
# [19, 'Connection', 'close']
```


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
