### PR TITLE
Fix for HX711 weight sensor module not sending changes to MQTT

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_34_hx711.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_34_hx711.ino
@@ -430,7 +430,7 @@ void HxEvery100mSecond(void) {
           Hx.weight_diff = Hx.weight;
           Hx.weight_changed = true;
         }
-        else if (Hx.weight_changed && (Hx.weight == Hx.weight_diff)) {
+        else if (Hx.weight_changed && (abs(Hx.weight - Hx.weight_diff) < Hx.weight_delta)) {
           ResponseClear();
           ResponseAppendTime();
           HxShow(true);


### PR DESCRIPTION
## Description:

The HX711 weight sensor module didn't report the weight correctly upon change to the mqtt server. This was because minor differences between each measurement (noise) prohibiting sending updates. When the measurement is now measured twice between the hysterese (instead of being exactly the same) the value is send to MQTT.

**Related issue (if applicable):** fixes(https://github.com/arendst/Tasmota/discussions/18592)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
