### PR TITLE
Fix for aligment at displayfloat command

### DIFF
--- a/tasmota/tasmota_xdsp_display/xdsp_15_tm1637.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_15_tm1637.ino
@@ -83,14 +83,14 @@
 
 
 
-  DisplayFloat          num [,position {0-(Settings->display_width-1)} [,precision {0-Settings->display_width} [,length {1 to Settings->display_width}]]]
+  DisplayFloat          num [,position {0-(Settings->display_width-1)} [,precision {0-Settings->display_width} [,length {1 to Settings->display_width} [,alignment {0=left 1=right}]]]]
 
                                Clears and then displays float (with decimal point)  command e.g., "DisplayFloat 12.34"
                                See function description below for more details.
 
 
 
-  DisplayFloatNC        num [,position {0-(Settings->display_width-1)} [,precision {0-Settings->display_width} [,length {1 to Settings->display_width}]]]
+  DisplayFloatNC        num [,position {0-(Settings->display_width-1)} [,precision {0-Settings->display_width} [,length {1 to Settings->display_width} [,alignment {0=left 1=right}]]]]
 
                                Displays float (with decimal point) as above, but without clearing first. command e.g., "DisplayFloatNC 12.34"
                                See function description below for more details.
@@ -434,7 +434,6 @@ bool CmndTM1637Float(bool clear)
   uint8_t length = 0;
   uint8_t precision = Settings->display_width;
   uint8_t position = 0;
-
   float fnum = 0.0f;
 
   switch (ArgC())
@@ -468,6 +467,14 @@ bool CmndTM1637Float(bool clear)
     length = strlen(txt);
   if ((length <= 0) || (length > Settings->display_width))
     length = Settings->display_width;
+
+  // Add leading spaces before value if txt is shorter than length
+  if (strlen(txt) < length + 1) 
+  {
+    char tmptxt[30];
+    ext_snprintf_P(tmptxt, sizeof(tmptxt), "%*s%s", strlen(txt)-(length+1), "", txt);
+    strcpy (txt, tmptxt);
+  }
 
   AddLog(LOG_LEVEL_DEBUG, PSTR("TM7: num %4_f, prec %d, len %d"), &fnum, precision, length);
 

--- a/tasmota/tasmota_xdsp_display/xdsp_15_tm1637.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_15_tm1637.ino
@@ -431,13 +431,18 @@ bool CmndTM1637Float(bool clear)
   char sPrecision[CMD_MAX_LEN];
   char sPosition[CMD_MAX_LEN];
   char sLength[CMD_MAX_LEN];
+  char sAlignment[CMD_MAX_LEN];
   uint8_t length = 0;
   uint8_t precision = Settings->display_width;
   uint8_t position = 0;
+  uint8_t alignment = 0;
   float fnum = 0.0f;
 
   switch (ArgC())
   {
+  case 5:
+    subStr(sAlignment, XdrvMailbox.data, ",", 5);
+    alignment = atoi(sAlignment);
   case 4:
     subStr(sLength, XdrvMailbox.data, ",", 4);
     length = atoi(sLength);
@@ -469,7 +474,7 @@ bool CmndTM1637Float(bool clear)
     length = Settings->display_width;
 
   // Add leading spaces before value if txt is shorter than length
-  if (strlen(txt) < length + 1) 
+  if ((alignment == 1) && (strlen(txt) < length + 1))
   {
     char tmptxt[30];
     ext_snprintf_P(tmptxt, sizeof(tmptxt), "%*s%s", strlen(txt)-(length+1), "", txt);


### PR DESCRIPTION
## Description: The displayfloat command always aligned to the left while the displaynumber command aligns to the right. Now displayfloat also aligns to the right when align parameter is 1.

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/discussions/18591

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
