### PR TITLE
fix ESP32 webcam init for some cases

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
@@ -135,7 +135,7 @@ struct PICSTORE {
 #endif // ENABLE_RTSPSERVER
 
 struct {
-  uint8_t  up;
+  uint8_t  up = 0;
   uint16_t width;
   uint16_t height;
   uint8_t  stream_active;
@@ -1455,6 +1455,9 @@ bool Xdrv81(uint32_t function) {
       break;
     case FUNC_PRE_INIT:
       WcInit();
+      break;
+    case FUNC_INIT:
+      if(Wc.up == 0) WcSetup(Settings->webcam_config.resolution);
       break;
 
   }


### PR DESCRIPTION
## Description:

This is an attempt to reduce the number of init failures for the el cheapo ESP32 web cam by moving the first initialization of the camera hardware to an earlier boot stage.
My impression was, that all my (personally observed) init failures fell into the period, when the webserver started and the camera init tried to happen at the same time. In these cases it was always possible to init the cam with `wcinit` and reload the page after that.
Thus this fix can only work, if the failing pattern is the one from above. I know that there are more points of failure with this hardware.

In my tests I now have 100% init success after restart that was around 50% before, but I do not expect miracles for all configs.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
