### PR TITLE
Added define for HX711 sensor to adjust calibration precision.

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -991,6 +991,7 @@
 //  #define TM1638_MAX_LEDS        8               // Add support for 8 leds
 //#define USE_HX711                                // Add support for HX711 load cell (+1k5 code)
 //  #define USE_HX711_GUI                          // Add optional web GUI to HX711 as scale (+1k8 code)
+//  #define HX711_CAL_PRECISION     1              // When HX711 calibration is to course, raise this value
 
 //#define USE_DINGTIAN_RELAY                       // Add support for the Dingian board using 74'595 et 74'165 shift registers
 //  #define DINGTIAN_INPUTS_INVERTED               // Invert input states (Hi => OFF, Low => ON)

--- a/tasmota/tasmota_xsns_sensor/xsns_34_hx711.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_34_hx711.ino
@@ -43,6 +43,10 @@
 #ifndef HX_SCALE
 #define HX_SCALE             120     // Default result of measured weight / reference weight when scale is 1
 #endif
+#ifndef HX711_CAL_PRECISION
+#define HX711_CAL_PRECISION  1     // When calibration is to course, raise this value.
+#endif
+
 
 #define HX_TIMEOUT           120     // A reading at default 10Hz (pin RATE to Gnd on HX711) can take up to 100 milliseconds
 #define HX_SAMPLES           10      // Number of samples for average calculation
@@ -340,7 +344,7 @@ void HxEvery100mSecond(void) {
     for (uint32_t i = 2; i < HX_SAMPLES -2; i++) {
       sum_raw += Hx.reads[i];
     }
-    Hx.raw_absolute = sum_raw / (HX_SAMPLES -4);     // Uncalibrated value
+    Hx.raw_absolute = (sum_raw / (HX_SAMPLES -4)) * HX711_CAL_PRECISION;     // Uncalibrated value
     Hx.raw = Hx.raw_absolute / Hx.scale;             // grams
 
     if ((0 == Settings->weight_user_tare) && Hx.tare_flg) {  // Reset scale based on current load


### PR DESCRIPTION
## Description:
Calibration Precision can be adjusted by the define HX711_CAL_PRECISION
In this way, older calibrations in active devices are not affected.

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/issues/18608

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
