### PR TITLE
Berry fixed a rare condition when a GC causes a memory corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Partition_Manager.tapp fixed
+- Berry fixed a rare condition when a GC causes a memory corruption
 
 ### Removed
 

--- a/lib/libesp32/berry/src/be_string.c
+++ b/lib/libesp32/berry/src/be_string.c
@@ -195,6 +195,9 @@ static bstring* newshortstr(bvm *vm, const char *str, size_t len)
     }
     s = createstrobj(vm, len, 0);
     if (s) {
+        /* recompute size and list that may have changed due to a GC */
+        size = vm->strtab.size;
+        list = vm->strtab.table + (hash & (size - 1));
         memcpy(cast(char *, sstr(s)), str, len);
         s->extra = 0;
         s->next = cast(void*, *list);


### PR DESCRIPTION
## Description:

In rare case, a GC happening during a string allocation could cause the `strtab` structure to change. Pointers need to be recomputed after a potential GC.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
