### PR TITLE
Berry strtab test case

### DIFF
--- a/lib/libesp32/berry/src/be_string.c
+++ b/lib/libesp32/berry/src/be_string.c
@@ -268,9 +268,13 @@ void be_gcstrtab(bvm *vm)
             }
         }
     }
+#if BE_USE_DEBUG_GC == 0
     if (tab->count < size >> 2 && size > 8) {
         resize(vm, size >> 1);
     }
+#else
+    resize(vm, tab->count + 4);
+#endif
 }
 
 uint32_t be_strhash(const bstring *s)


### PR DESCRIPTION
## Description:

Berry, sync with upstream https://github.com/berry-lang/berry/pull/337 to create a systematic strtab resize after each GC.

No change in Tasmota code because we don't enable GC debug mode (it's way too slow anyways)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
