### PR TITLE
Matter fix autoconf_device_map

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
@@ -1032,7 +1032,7 @@ class Matter_Device
     var relays_reserved = []                        # list of relays that are used for non-relay (shutters)
     tasmota.log("MTR: Status 13 = "+str(r_st13), 3)
 
-    if r_st13.contains('StatusSHT')
+    if r_st13 != nil && r_st13.contains('StatusSHT')
       r_st13 = r_st13['StatusSHT']        # skip root
       # Shutter is enabled, iterate
       var idx = 0


### PR DESCRIPTION
## Description:

Fix exception when Status 13 is empty

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
