### PR TITLE
Berry solidify for ubuntu 22.04

### DIFF
--- a/lib/libesp32/berry_matter/solidify_all.be
+++ b/lib/libesp32/berry_matter/solidify_all.be
@@ -1,8 +1,6 @@
-#! ../berry/berry -s -g
+#!/usr/bin/env -S ../berry/berry -s -g
 #
 # Berry solidify files
-#
-# `../berry/berry -s -g`
 
 import os
 import global

--- a/lib/libesp32/berry_tasmota/solidify_all.be
+++ b/lib/libesp32/berry_tasmota/solidify_all.be
@@ -1,8 +1,6 @@
-#! ../berry/berry -s -g
+#!/usr/bin/env -S ../berry/berry -s -g
 #
 # Berry solidify files
-#
-# `../berry/berry -s -g`
 
 import os
 import global

--- a/lib/libesp32_lvgl/lv_binding_berry/solidify_all.be
+++ b/lib/libesp32_lvgl/lv_binding_berry/solidify_all.be
@@ -1,8 +1,6 @@
-#! ../../libesp32/berry/berry -s -g
+#!/usr/bin/env -S ../../libesp32/berry/berry -s -g
 #
 # Berry solidify files
-#
-# `../berry/berry -s -g`
 
 import os
 import global


### PR DESCRIPTION
## Description:

Change `solidifyall.be` to be compatible with coreutils from Ubuntu 22.04

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
