### PR TITLE
Berry fix energy

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_energylib.c
+++ b/lib/libesp32/berry_tasmota/src/be_energylib.c
@@ -19,6 +19,7 @@ extern struct ENERGY Energy;
 module energy (scope: global) {
   init, closure(energy_init_closure)
   _ptr, comptr(&Energy)
+  _deref, closure(energy__deref_closure)
 
   read, closure(energy_read_closure)
   member, closure(energy_member_closure)

--- a/lib/libesp32/berry_tasmota/src/embedded/energy.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/energy.be
@@ -6,28 +6,48 @@ energy = module("energy")
 energy._ptr = nil
 
 def init(m)
-    import global
-    global._energy = energy_struct(m._ptr)
+    global._energy = nil
     return m
 end
 energy.init = init
 
+def _deref()            # dereference enery pointer
+    if global._energy == nil
+        import introspect
+        var p = bytes(energy._ptr, 4).get(0, 4)      # dereference pointer
+        if p != 0
+            global._energy = energy_struct(introspect.toptr(p))
+        end
+    end
+end
+energy._deref = _deref
+
 def read()
-    return _energy.tomap()
+    energy._deref()
+    if global._energy
+        return _energy.tomap()
+    end
 end
 energy.read = read
 
 def member(k)
-    return _energy.(k)
+    energy._deref()
+    if global._energy
+        return _energy.(k)
+    end
 end
 energy.member = member
 
 def setmember(k, v)
-    _energy.(k) = v
+    energy._deref()
+    if global._energy
+        _energy.(k) = v
+    end
 end
 energy.setmember = setmember
 
 #@ solidify:energy.init
+#@ solidify:energy._deref
 #@ solidify:energy.read
 #@ solidify:energy.member
 #@ solidify:energy.setmember

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_energy.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_energy.h
@@ -9,7 +9,7 @@
 ********************************************************************/
 be_local_closure(energy_init,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    3,                          /* nstack */
     1,                          /* argc */
     0,                          /* varg */
     0,                          /* has upvals */
@@ -17,21 +17,75 @@ be_local_closure(energy_init,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
+    ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(global),
     /* K1   */  be_nested_str(_energy),
-    /* K2   */  be_nested_str(energy_struct),
-    /* K3   */  be_nested_str(_ptr),
     }),
     &be_const_str_init,
     &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0400,  //  0001  GETNGBL	R2	K2
-      0x880C0103,  //  0002  GETMBR	R3	R0	K3
-      0x7C080200,  //  0003  CALL	R2	1
-      0x90060202,  //  0004  SETMBR	R1	K1	R2
-      0x80040000,  //  0005  RET	1	R0
+    ( &(const binstruction[ 4]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x90060202,  //  0002  SETMBR	R1	K1	R2
+      0x80040000,  //  0003  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _deref
+********************************************************************/
+be_local_closure(energy__deref,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    0,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str(global),
+    /* K1   */  be_nested_str(_energy),
+    /* K2   */  be_nested_str(introspect),
+    /* K3   */  be_nested_str(energy),
+    /* K4   */  be_nested_str(_ptr),
+    /* K5   */  be_nested_str(get),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str(energy_struct),
+    /* K8   */  be_nested_str(toptr),
+    }),
+    &be_const_str__deref,
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0xB8020000,  //  0000  GETNGBL	R0	K0
+      0x88000101,  //  0001  GETMBR	R0	R0	K1
+      0x4C040000,  //  0002  LDNIL	R1
+      0x1C000001,  //  0003  EQ	R0	R0	R1
+      0x78020012,  //  0004  JMPF	R0	#0018
+      0xA4020400,  //  0005  IMPORT	R0	K2
+      0x60040015,  //  0006  GETGBL	R1	G21
+      0xB80A0600,  //  0007  GETNGBL	R2	K3
+      0x88080504,  //  0008  GETMBR	R2	R2	K4
+      0x540E0003,  //  0009  LDINT	R3	4
+      0x7C040400,  //  000A  CALL	R1	2
+      0x8C040305,  //  000B  GETMET	R1	R1	K5
+      0x580C0006,  //  000C  LDCONST	R3	K6
+      0x54120003,  //  000D  LDINT	R4	4
+      0x7C040600,  //  000E  CALL	R1	3
+      0x20080306,  //  000F  NE	R2	R1	K6
+      0x780A0006,  //  0010  JMPF	R2	#0018
+      0xB80A0000,  //  0011  GETNGBL	R2	K0
+      0xB80E0E00,  //  0012  GETNGBL	R3	K7
+      0x8C100108,  //  0013  GETMET	R4	R0	K8
+      0x5C180200,  //  0014  MOVE	R6	R1
+      0x7C100400,  //  0015  CALL	R4	2
+      0x7C0C0200,  //  0016  CALL	R3	1
+      0x900A0203,  //  0017  SETMBR	R2	K1	R3
+      0x80000000,  //  0018  RET	0
     })
   )
 );
@@ -51,17 +105,27 @@ be_local_closure(energy_read,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(_energy),
-    /* K1   */  be_nested_str(tomap),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str(energy),
+    /* K1   */  be_nested_str(_deref),
+    /* K2   */  be_nested_str(global),
+    /* K3   */  be_nested_str(_energy),
+    /* K4   */  be_nested_str(tomap),
     }),
     &be_const_str_read,
     &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
+    ( &(const binstruction[11]) {  /* code */
       0xB8020000,  //  0000  GETNGBL	R0	K0
       0x8C000101,  //  0001  GETMET	R0	R0	K1
       0x7C000200,  //  0002  CALL	R0	1
-      0x80040000,  //  0003  RET	1	R0
+      0xB8020400,  //  0003  GETNGBL	R0	K2
+      0x88000103,  //  0004  GETMBR	R0	R0	K3
+      0x78020003,  //  0005  JMPF	R0	#000A
+      0xB8020600,  //  0006  GETNGBL	R0	K3
+      0x8C000104,  //  0007  GETMET	R0	R0	K4
+      0x7C000200,  //  0008  CALL	R0	1
+      0x80040000,  //  0009  RET	1	R0
+      0x80000000,  //  000A  RET	0
     })
   )
 );
@@ -73,7 +137,7 @@ be_local_closure(energy_read,   /* name */
 ********************************************************************/
 be_local_closure(energy_member,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
+    3,                          /* nstack */
     1,                          /* argc */
     0,                          /* varg */
     0,                          /* has upvals */
@@ -81,15 +145,25 @@ be_local_closure(energy_member,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(_energy),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str(energy),
+    /* K1   */  be_nested_str(_deref),
+    /* K2   */  be_nested_str(global),
+    /* K3   */  be_nested_str(_energy),
     }),
     &be_const_str_member,
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
+    ( &(const binstruction[10]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040200,  //  0001  GETMBR	R1	R1	R0
-      0x80040200,  //  0002  RET	1	R1
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0xB8060400,  //  0003  GETNGBL	R1	K2
+      0x88040303,  //  0004  GETMBR	R1	R1	K3
+      0x78060002,  //  0005  JMPF	R1	#0009
+      0xB8060600,  //  0006  GETNGBL	R1	K3
+      0x88040200,  //  0007  GETMBR	R1	R1	R0
+      0x80040200,  //  0008  RET	1	R1
+      0x80000000,  //  0009  RET	0
     })
   )
 );
@@ -101,7 +175,7 @@ be_local_closure(energy_member,   /* name */
 ********************************************************************/
 be_local_closure(energy_setmember,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
+    4,                          /* nstack */
     2,                          /* argc */
     0,                          /* varg */
     0,                          /* has upvals */
@@ -109,15 +183,24 @@ be_local_closure(energy_setmember,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(_energy),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str(energy),
+    /* K1   */  be_nested_str(_deref),
+    /* K2   */  be_nested_str(global),
+    /* K3   */  be_nested_str(_energy),
     }),
     &be_const_str_setmember,
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
+    ( &(const binstruction[ 9]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x90080001,  //  0001  SETMBR	R2	R0	R1
-      0x80000000,  //  0002  RET	0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0xB80A0400,  //  0003  GETNGBL	R2	K2
+      0x88080503,  //  0004  GETMBR	R2	R2	K3
+      0x780A0001,  //  0005  JMPF	R2	#0008
+      0xB80A0600,  //  0006  GETNGBL	R2	K3
+      0x90080001,  //  0007  SETMBR	R2	R0	R1
+      0x80000000,  //  0008  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Fix broken energy module. The global is now a pointer, not a static struct.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
