### PR TITLE
Disable crashing GT911 driver in LVGL build

### DIFF
--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -306,7 +306,7 @@
 #define SHOW_SPLASH
 #define USE_XPT2046
 #define USE_FT5206
-#define USE_GT911
+//#define USE_GT911                                // TODO Fix GT911 Touch driver with LVGL HASPMOTA
 #define USE_MPU_ACCEL
 #define USE_RTC_CHIPS                            // Enable RTC chip support and NTP server - Select only one
   #define USE_BM8563


### PR DESCRIPTION
## Description:

the PR [#18954](https://github.com/arendst/Tasmota/pull/18594) does not fix complete.
When calling the Tasmota Web Information Page, the device crashes.

```
Guru Meditation Error: Core  1 panic'ed (Interrupt wdt timeout on CPU1). 

Core  1 register dump:
PC      : 0x42134acd  PS      : 0x00060134  A0      : 0x82134dd7  A1      : 0x3fca90d0  
=> 0x42134acd: block_size at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_tlsf_block_functions.h:74
      (inlined by) block_is_last at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_tlsf_block_functions.h:85
      (inlined by) tlsf_walk_pool at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_tlsf.c:641
A2      : 0x3fcebea8  A3      : 0x42134e14  A4      : 0x3fca9134  A5      : 0x3fcebeb0  
=> 0x42134e14: multi_heap_get_info_tlsf at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/multi_heap.c:374
A6      : 0xfffffffc  A7      : 0x00000001  A8      : 0xffffffff  A9      : 0x3fca90b0  
A10     : 0x3fcebeb0  A11     : 0xfffffffc  A12     : 0x00000000  A13     : 0x3fca9134  
A14     : 0x00060123  A15     : 0x00060120  SAR     : 0x0000000e  EXCCAUSE: 0x00000006  
EXCVADDR: 0x00000000  LBEG    : 0x400570e8  LEND    : 0x400570f3  LCOUNT  : 0x00000000  
=> 0x400570e8: ?? ??:0
=> 0x400570f3: ?? ??:0


Backtrace: 0x42134aca:0x3fca90d0 0x42134dd4:0x3fca90f0 0x42134e61:0x3fca9110 0x420e07b2:0x3fca9130 0x420e07fd:0x3fca9170 0x420a94ac:0x3fca91b0 0x42076418:0x3fca91d0 0x420a46da:0x3fca92c0 0x42071a45:0x3fca92e0 0x42031b86:0x3fca9300 0x42036301:0x3fca9320 0x4203838c:0x3fca9350 0x420a1e41:0x3fca93c0 0x42075dad:0x3fca9420 0x420a82e6:0x3fca9440 0x420b371d:0x3fca9460 0x42027097:0x3fca94d0
=> 0x42134aca: tlsf_walk_pool at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_tlsf.c:641
=> 0x42134dd4: multi_heap_get_info_impl at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/multi_heap.c:400
=> 0x42134e61: multi_heap_get_info at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/multi_heap_poisoning.c:371
=> 0x420e07b2: heap_caps_get_info at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_caps.c:556
=> 0x420e07fd: heap_caps_get_largest_free_block at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_caps.c:544
=> 0x420a94ac: ESP_getHeapFragmentation() at ??:?
=> 0x42076418: _Z17HandleInformationv$part$552 at ??:?
=> 0x420a46da: HandleInformation() at :?
=> 0x42071a45: std::_Function_handler<void (), void (*)()>::_M_invoke(std::_Any_data const&) at ??:?
=> 0x42031b86: std::function<void ()>::operator()() const at ??:?
=> 0x42036301: FunctionRequestHandler::handle(WebServer&, http_method, String) at :?
=> 0x4203838c: WebServer::handleClient() at ??:?
=> 0x420a1e41: Xdrv01(unsigned int) at ??:?
=> 0x42075dad: XdrvCall(unsigned int) at ??:?
=> 0x420a82e6: XdrvXsnsCall(unsigned int) at ??:?
=> 0x420b371d: loop() at ??:?
=> 0x42027097: loopTask(void*) at :?


Core  0 register dump:
PC      : 0x4037e263  PS      : 0x00060734  A0      : 0x80382820  A1      : 0x3fcab520  
=> 0x4037e263: compare_and_set_native at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_hw_support/include/soc/compare_set.h:25
      (inlined by) spinlock_acquire at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_hw_support/include/soc/spinlock.h:103
      (inlined by) xPortEnterCriticalTimeout at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port/xtensa/port.c:301
A2      : 0x3fca35d0  A3      : 0xb33fffff  A4      : 0x0000abab  A5      : 0x0000cdcd  
A6      : 0x00060723  A7      : 0x00060720  A8      : 0x0000abab  A9      : 0xffffffff  
A10     : 0x00060d23  A11     : 0x00000000  A12     : 0x00060d20  A13     : 0xffffffff  
A14     : 0x00ffffff  A15     : 0x00060d23  SAR     : 0x0000001d  EXCCAUSE: 0x00000006  
EXCVADDR: 0x00000000  LBEG    : 0x40056fc5  LEND    : 0x40056fe7  LCOUNT  : 0xffffffff  
=> 0x40056fc5: ?? ??:0
=> 0x40056fe7: ?? ??:0


Backtrace: 0x4037e260:0x3fcab520 0x4038281d:0x3fcab560 0x4038296d:0x3fcab580 0x40378e62:0x3fcab5a0 0x40378eb4:0x3fcab5c0 0x40382d29:0x3fcab5e0 0x420d15d8:0x3fcab600 0x420d1fce:0x3fcab620 0x420de3d8:0x3fcab640 0x4212f411:0x3fcab660 0x420cdbc5:0x3fcab680 0x42131aed:0x3fcab6a0 0x42131ba5:0x3fcab6f0 0x4003f4bd:0x3fcab710 |<-CORRUPTED
=> 0x4037e260: esp_ptr_external_ram at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/soc/include/soc/soc_memory_types.h:97
      (inlined by) spinlock_acquire at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_hw_support/include/soc/spinlock.h:99
      (inlined by) xPortEnterCriticalTimeout at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port/xtensa/port.c:301
=> 0x4038281d: vPortEnterCritical at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port/xtensa/include/freertos/portmacro.h:578 (discriminator 1)
      (inlined by) multi_heap_internal_lock at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/multi_heap.c:142 (discriminator 1)
=> 0x4038296d: multi_heap_malloc at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/multi_heap_poisoning.c:233
      (inlined by) multi_heap_malloc at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/multi_heap_poisoning.c:223
=> 0x40378e62: heap_caps_malloc_base at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_caps.c:175
      (inlined by) heap_caps_malloc_base at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_caps.c:120
=> 0x40378eb4: heap_caps_malloc_default at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/heap/heap_caps.c:230
=> 0x40382d29: malloc at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/heap.c:24
=> 0x420d15d8: mem_malloc at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/lwip/src/core/mem.c:237
=> 0x420d1fce: pbuf_alloc at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/lwip/src/core/pbuf.c:288
=> 0x420de3d8: wlanif_input at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/port/esp32/netif/wlanif.c:188
=> 0x4212f411: esp_netif_receive at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_netif/lwip/esp_netif_lwip.c:886
=> 0x420cdbc5: wifi_sta_receive at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_wifi/src/wifi_netif.c:39
=> 0x42131aed: sta_input at ??:?
=> 0x42131ba5: sta_rx_cb at ??:?
=> 0x4003f4bd: ?? ??:0




ELF file SHA256: 0000000000000000

Rebooting...
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0xc (RTC_SW_CPU_RST),boot:0x8 (SPI_FAST_FLASH_BOOT)
Saved PC:0x420c3cd7
=> 0x420c3cd7: panic_handler at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/port/panic_handler.c:142 (discriminator 2)
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fce3808,len:0x128
load:0x403c9700,len:0xb9c
=> 0x403c9700: ?? ??:0
load:0x403cc700,len:0x2878
=> 0x403cc700: ?? ??:0
entry 0x403c98bc
=> 0x403c98bc: ?? ??:0

```

fyi @gemu2015 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
