### PR TITLE
fix GT911 crash in LVGL firmware

### DIFF
--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -306,7 +306,7 @@
 #define SHOW_SPLASH
 #define USE_XPT2046
 #define USE_FT5206
-//#define USE_GT911                                // TODO Fix GT911 Touch driver with LVGL HASPMOTA
+#define USE_GT911
 #define USE_MPU_ACCEL
 #define USE_RTC_CHIPS                            // Enable RTC chip support and NTP server - Select only one
   #define USE_BM8563

--- a/tasmota/tasmota_support/support_esp.ino
+++ b/tasmota/tasmota_support/support_esp.ino
@@ -673,7 +673,7 @@ uint32_t ESP_getFreeHeap(void) {
 
 uint32_t ESP_getMaxAllocHeap(void) {
   // arduino returns IRAM but we want only DRAM
-#ifdef RGB_DISPLAY
+#ifdef USE_GT911 // GT911 IRQ crashes with heap_caps_get_largest_free_block
   return ESP_getFreeHeap();
 #endif
   uint32_t free_block_size = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -2466,7 +2466,11 @@ void HandleInformation(void)
   WSContentSend_P(PSTR("}1" D_PROGRAM_SIZE "}2%d KB"), ESP_getSketchSize() / 1024);
   WSContentSend_P(PSTR("}1" D_FREE_PROGRAM_SPACE "}2%d KB"), ESP_getFreeSketchSpace() / 1024);
 #ifdef ESP32
+#ifdef USE_GT911
+  WSContentSend_PD(PSTR("}1" D_FREE_MEMORY "}2%1_f KB"), &freemem);
+#else
   WSContentSend_PD(PSTR("}1" D_FREE_MEMORY "}2%1_f KB (" D_FRAGMENTATION " %d%%)"), &freemem, ESP_getHeapFragmentation());
+#endif // USE_GT911
   if (UsePSRAM()) {
     WSContentSend_P(PSTR("}1" D_PSR_MAX_MEMORY "}2%d KB"), ESP.getPsramSize() / 1024);
     WSContentSend_P(PSTR("}1" D_PSR_FREE_MEMORY "}2%d KB"), ESP.getFreePsram() / 1024);


### PR DESCRIPTION
## Description:

GT911 IRQ crashes with `heap_caps_get_largest_free_block`.
Solution: Disable and use `ESP_getFreeHeap()` only, in Information page when driver GT911 is enabled.

Thx @gemu2015  for his comment [here](https://github.com/arendst/Tasmota/pull/18631#issuecomment-1541815665) to solve

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
