### PR TITLE
start modus tcp bridge automatically

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -801,6 +801,7 @@
 //  #define SERIAL_BRIDGE_BUFFER_SIZE 256          // Serial Bridge receive buffer size (Default ESP8266 = 256, ESP32 = 800)
 //#define USE_MODBUS_BRIDGE                        // Add support for software Modbus Bridge (+4.5k code)
 //#define USE_MODBUS_BRIDGE_TCP                    // Add support for software Modbus TCP Bridge (also enable Modbus TCP Bridge) (+2k code)
+//#define USE_MODBUS_BRIDGE_TCP_DEFAULT_PORT 502   // Add support for software Modbus TCP Bridge (start the TCP bridge automatically at PORT 502)
 //#define USE_TCP_BRIDGE                           //  Add support for Serial to TCP bridge (+1.3k code)
 //#define USE_MP3_PLAYER                           // Use of the DFPlayer Mini MP3 Player RB-DFR-562 commands: play, pause, stop, track, volume and reset
   #define MP3_VOLUME           30                // Set the startup volume on init, the range can be 0..100(max)

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -799,9 +799,9 @@
 //#define USE_DYP                                  // Add support for DYP ME-007 ultrasonic distance sensor, serial port version (+0k5 code)
 #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge (+2k code)
 //  #define SERIAL_BRIDGE_BUFFER_SIZE 256          // Serial Bridge receive buffer size (Default ESP8266 = 256, ESP32 = 800)
-//#define USE_MODBUS_BRIDGE                        // Add support for software Modbus Bridge (+4.5k code)
-//#define USE_MODBUS_BRIDGE_TCP                    // Add support for software Modbus TCP Bridge (also enable Modbus TCP Bridge) (+2k code)
-//#define USE_MODBUS_BRIDGE_TCP_DEFAULT_PORT 502   // Add support for software Modbus TCP Bridge (start the TCP bridge automatically at PORT 502)
+// #define USE_MODBUS_BRIDGE                        // Add support for software Modbus Bridge (+4.5k code)
+// #define USE_MODBUS_BRIDGE_TCP                    // Add support for software Modbus TCP Bridge (also enable Modbus TCP Bridge) (+2k code)
+// #define MODBUS_BRIDGE_TCP_DEFAULT_PORT 502       // Add support for software Modbus TCP Bridge (start the TCP bridge automatically at PORT 502)
 //#define USE_TCP_BRIDGE                           //  Add support for Serial to TCP bridge (+1.3k code)
 //#define USE_MP3_PLAYER                           // Use of the DFPlayer Mini MP3 Player RB-DFR-562 commands: play, pause, stop, track, volume and reset
   #define MP3_VOLUME           30                // Set the startup volume on init, the range can be 0..100(max)

--- a/tasmota/tasmota_xdrv_driver/xdrv_63_modbus_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_63_modbus_bridge.ino
@@ -574,7 +574,7 @@ void ModbusBridgeInit(void)
       ModbusBridgeAllocError(PSTR("TCP"));
       return;
     }
-#if defined(USE_MODBUS_BRIDGE_TCP_DEFAULT_PORT)
+#ifdef USE_MODBUS_BRIDGE_TCP_DEFAULT_PORT
     else 
     {
       AddLog(LOG_LEVEL_INFO, PSTR("MBS: MBRTCP Starting server on port %d"), USE_MODBUS_BRIDGE_TCP_DEFAULT_PORT);

--- a/tasmota/tasmota_xdrv_driver/xdrv_63_modbus_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_63_modbus_bridge.ino
@@ -574,6 +574,16 @@ void ModbusBridgeInit(void)
       ModbusBridgeAllocError(PSTR("TCP"));
       return;
     }
+#if defined(USE_MODBUS_BRIDGE_TCP_DEFAULT_PORT)
+    else 
+    {
+      AddLog(LOG_LEVEL_INFO, PSTR("MBS: MBRTCP Starting server on port %d"), USE_MODBUS_BRIDGE_TCP_DEFAULT_PORT);
+
+      modbusBridgeTCP.server_tcp = new WiFiServer(USE_MODBUS_BRIDGE_TCP_DEFAULT_PORT);
+      modbusBridgeTCP.server_tcp->begin(); // start TCP server
+      modbusBridgeTCP.server_tcp->setNoDelay(true);
+    }
+#endif
 #endif
   }
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_63_modbus_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_63_modbus_bridge.ino
@@ -574,12 +574,12 @@ void ModbusBridgeInit(void)
       ModbusBridgeAllocError(PSTR("TCP"));
       return;
     }
-#ifdef USE_MODBUS_BRIDGE_TCP_DEFAULT_PORT
+#ifdef MODBUS_BRIDGE_TCP_DEFAULT_PORT
     else 
     {
-      AddLog(LOG_LEVEL_INFO, PSTR("MBS: MBRTCP Starting server on port %d"), USE_MODBUS_BRIDGE_TCP_DEFAULT_PORT);
+      AddLog(LOG_LEVEL_INFO, PSTR("MBS: MBRTCP Starting server on port %d"), MODBUS_BRIDGE_TCP_DEFAULT_PORT);
 
-      modbusBridgeTCP.server_tcp = new WiFiServer(USE_MODBUS_BRIDGE_TCP_DEFAULT_PORT);
+      modbusBridgeTCP.server_tcp = new WiFiServer(MODBUS_BRIDGE_TCP_DEFAULT_PORT);
       modbusBridgeTCP.server_tcp->begin(); // start TCP server
       modbusBridgeTCP.server_tcp->setNoDelay(true);
     }


### PR DESCRIPTION
## Description:
This change adds the possiility to start the TCP modus bridge directly at system start with the default TCP port (502). No need to send the start command or to define a rule.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
