### PR TITLE
esp32_webcam: faster page load

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
@@ -974,14 +974,14 @@ uint32_t WcSetStreamserver(uint32_t flag) {
 
 void WcInterruptControl() {
   WcSetStreamserver(Settings->webcam_config.stream);
-  WcSetup(Settings->webcam_config.resolution);
+  if(Wc.up != 0) {WcSetup(Settings->webcam_config.resolution);}
 }
 
 /*********************************************************************************************/
 
 
 void WcLoop(void) {
-  if (4 == Wc.stream_active) { return; }
+  // if (4 == Wc.stream_active) { return; }
 
   if (Wc.CamServer) {
     Wc.CamServer->handleClient();
@@ -1042,11 +1042,10 @@ void WcShowStream(void) {
 //    if (!Wc.CamServer || !Wc.up) {
     if (!Wc.CamServer) {
       WcInterruptControl();
-      delay(50);   // Give the webcam webserver some time to prepare the stream
     }
-    if (Wc.CamServer && Wc.up) {
-      WSContentSend_P(PSTR("<p></p><center><img src='http://%_I:81/stream' alt='Webcam stream' style='width:99%%;'></center><p></p>"),
-        (uint32_t)WiFi.localIP());
+    if (Wc.CamServer && Wc.up!=0) {
+      // Give the webcam webserver some time to prepare the stream - catch error in JS
+      WSContentSend_P(PSTR("<p></p><center><img onerror='setTimeout(()=>{this.src=this.src;},1000)' src='http://%_I:81/stream' alt='Webcam stream' style='width:99%%;'></center><p></p>"),(uint32_t)WiFi.localIP());
     }
   }
 }
@@ -1383,6 +1382,7 @@ void CmndWebcamClock(void){
 }
 
 void CmndWebcamInit(void) {
+  Wc.up = 0;
   WcInterruptControl();
   ResponseCmndDone();
 }


### PR DESCRIPTION
## Description:

Faster web interface by avoiding re-initialisation calls of the hardware and removing a delay from the render section, instead adding error catching to the browser.

I did not see any negative side effects in multiple attempts, but this has to be tested on more devices.  
Works for me on Firefox and Chrome. Safari has issues with MJPEG for years and will probably show no picture after initial success and some page reloads/navigation actions.  
This will not solve any problems with failing hardware initialization, but performance in my setup is way more snappy now and as we had some recent reports about non-working ESP32-cams with newer Tasmota versions I can confirm, that the current driver is NOT fundamentally broken. Basically I had zero issues in extensive tests in the last 2 days since the last PR.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
