### PR TITLE
clang for berry binary compile

### DIFF
--- a/lib/libesp32/berry/Makefile
+++ b/lib/libesp32/berry/Makefile
@@ -3,7 +3,7 @@ DEBUG_FLAGS = -O0 -g -DBE_DEBUG
 TEST_FLAGS  = $(DEBUG_FLAGS) --coverage -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined
 LIBS        = -lm
 TARGET      = berry
-CC          = gcc
+CC          = clang # install clang!! gcc seems to produce a defect berry binary
 MKDIR       = mkdir
 LFLAGS      =
 


### PR DESCRIPTION
## Description:

Weird issues with gcc compiled berry binary. Solved with using "clang" compiler.
clang is available for Linux too. No Tasmota code changes!

fyi @s-hadinger 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
