### PR TITLE
Matter support for async HTTP for bridged devices

### DIFF
--- a/lib/libesp32/berry_mapping/src/be_class_wrapper.c
+++ b/lib/libesp32/berry_mapping/src/be_class_wrapper.c
@@ -486,7 +486,7 @@ int be_call_c_func(bvm *vm, const void * func, const char * return_type, const c
   } else { // class name
     be_find_global_or_module_member(vm, return_type);
     be_pushcomptr(vm, (void*) ret);         // stack = class, ptr
-    be_call(vm, 1);                 // instanciate with 2 arguments, stack = instance, ptr, -1
+    be_call(vm, 1);                 // instanciate with 1 argument (ptr)
     be_pop(vm, 1);                  // stack = instance
     be_return(vm);
   }

--- a/lib/libesp32/berry_matter/src/be_matter_module.c
+++ b/lib/libesp32/berry_matter/src/be_matter_module.c
@@ -133,6 +133,9 @@ extern const bclass be_class_Matter_TLV;   // need to declare it upfront because
 #include "solidify/solidified_Matter_TLV.h"
 #include "solidify/solidified_Matter_IM_Data.h"
 #include "solidify/solidified_Matter_UDPServer.h"
+#include "solidify/solidified_Matter_TCP_async.h"
+#include "solidify/solidified_Matter_HTTP_async.h"
+#include "solidify/solidified_Matter_HTTP_remote.h"
 #include "solidify/solidified_Matter_Expirable.h"
 #include "solidify/solidified_Matter_Fabric.h"
 #include "solidify/solidified_Matter_Session.h"
@@ -286,6 +289,9 @@ module matter (scope: global, strings: weak) {
   // UDP Server
   UDPPacket_sent, class(be_class_Matter_UDPPacket_sent)
   UDPServer, class(be_class_Matter_UDPServer)
+  TCP_async, class(be_class_Matter_TCP_async)
+  HTTP_async, class(be_class_Matter_HTTP_async)
+  HTTP_remote, class(be_class_Matter_HTTP_remote)
 
   // Expirable
   Expirable, class(be_class_Matter_Expirable)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_async.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_async.be
@@ -1,0 +1,406 @@
+#
+# Matter_HTTP_async.be - implements a generic async non-blocking TCP connection
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#@ solidify:Matter_HTTP_async,weak
+
+# dummy declaration for solidification
+class Matter_TCP_async end
+
+class Matter_HTTP_async : Matter_TCP_async
+  # var addr                                        # remote address
+  # var port                                        # remote port
+  # var timeout                                     # timeout in ms
+  # var tcp                                         # instance of tcpclientasync
+  # var time_start                                  # timestamp when starting connection
+  # var tcp_connected                               # is tcp connected, true/false/nil (nil is in-progress)
+  var cmd                                         # GET url command
+  var response                                    # aggrated response
+  var response_offset                             # offset to parse in response
+  var status_code                                 # status code looking for 200
+  var payload                                     # actual payload of the response (string)
+  # var status                                      # status, see above
+  var http_status                                 # status: 0/ in progress, 1/ finished ok, -1/ failed, -2/ timeout
+  # static var TIMEOUT = 1000                       # default timeout: 500ms
+  var phase                                       # parsing phase: 0/ status line, 1/ headers, 2/ payload chunked
+  var is_chunked                                  # true if the content is chunked
+  var chunk_size                                  # nil or int, size of the current chunk
+  static var HTTP_GET = "GET %s HTTP/1.1\r\nHost %s:%s\r\nConnection: close\r\n\r\n"    # see https://stackoverflow.com/questions/6686261/what-at-the-bare-minimum-is-required-for-an-http-request
+
+  static var HTTP_STATUS_REGEX = "HTTP/1\\.[1-2] (\\d+) .*?\r\n"    # extract stattus code from first line
+  static var HTTP_HEADER_REGEX = "([A-Za-z0-9-]+): (.*?)\r\n"       # extract a header with its 2 parts
+  static var HTTP_BODY_REGEX   = "\r\n"                             # end of headers
+  static var HTTP_CHUNK_REGEX   = "\r\n([A-Fa-f0-9]+)[ \t]*.*?\r\n"              # extract the length of a chunk
+  static var SPINLOCK = 5                         # delay in ms for spinlock
+
+  #############################################################
+  # init
+  def init(addr, port, timeout, fastloop)
+    super(self).init(addr, port, timeout, fastloop)
+    self.compile_re()
+  end
+
+  #############################################################
+  # compile once for all the regex
+  def compile_re()
+    import re
+    if !global.contains("_re_http_status")
+      global._re_http_status = re.compile(self.HTTP_STATUS_REGEX)
+      global._re_http_header = re.compile(self.HTTP_HEADER_REGEX)
+      global._re_http_body   = re.compile(self.HTTP_BODY_REGEX)
+      global._re_http_chunk  = re.compile(self.HTTP_CHUNK_REGEX)
+    end
+  end
+
+  #############################################################
+  # begin
+  #
+  # returns true if everything is ok, and connection started
+  # returns false if DNS failed
+  # returns nil if no network
+  def begin(cmd)
+    var ret = super(self).begin()
+    self.cmd = cmd
+    return ret
+  end
+
+  #############################################################
+  # begin_sync
+  #
+  # Synchronous (blocking version)
+  #
+  # returns nil if something went wrong
+  # returns the payload as string
+  def begin_sync(cmd, timeout)
+    var timeout_old = self.timeout
+    if timeout != nil   self.set_timeout(timeout)    end
+    var payload = nil
+    var spinlock = self.SPINLOCK
+
+    # try
+    var ret = self.begin(cmd)
+    if ret      # true just means that DNS was ok and that nothing went wrong
+      while self.http_status == 0
+        self.loop()
+        tasmota.delay(spinlock)
+      end
+    end
+
+    self.set_timeout(timeout_old)
+    return self.http_status > 0 ? self.payload : nil
+  end
+
+  def reset()
+    super(self).reset()
+    # free buffers
+    self.cmd = nil
+    self.response = nil
+    self.response_offset = 0
+    self.payload = ""
+    self.phase = 0
+    self.http_status = 0
+    self.is_chunked = false
+    self.chunk_size = nil
+  end
+
+  #############################################################
+  # parse_http_response
+  #
+  # Parse incoming HTTP response from self.response
+  def parse_http_response()
+    if self.phase == 0
+      self.parse_http_status_line()
+    elif self.phase == 1
+      self.parse_http_headers()
+    elif self.phase == 2
+      self.parse_http_payload()
+    end
+    # if phase == 3 (payload raw) we don't parse anything and work for tcp connection to be closed
+  end
+
+  #############################################################
+  # parse_http_status_line
+  #
+  # Parse incoming HTTP status line
+  def parse_http_status_line()
+    var m = global._re_http_status.match2(self.response, self.response_offset)
+    # Ex: [17, '200']
+    if m
+      self.response_offset = m[0]         # move to following bytes
+      self.status_code = int(m[1])
+      self.phase = 1                      # proceed to parsing headers
+      self.parse_http_headers()
+    elif size(self.response) > 100        # if no match and we still have 100 bytes, then it fails
+      self.close()
+      self.status = -4
+    end
+  end
+
+  #############################################################
+  # parse_http_status_line
+  #
+  # Parse incoming HTTP status line
+  def parse_http_headers()
+    while true
+      # print("parse_http_headers", "self.response_offset=", self.response_offset)
+      var m = global._re_http_header.match2(self.response, self.response_offset)
+      # print("m=", m)
+      # Ex: [32, 'Content-Type', 'application/json']
+      if m
+        self.event_http_header(m[1], m[2])
+        self.response_offset += m[0]
+      else  # no more headers
+        var m2 = global._re_http_body.match2(self.response, self.response_offset)
+        if m2
+          # end of headers
+          # we keep \r\n which is used by pattern
+          self.event_http_headers_end()     # no more headers
+          self.phase = 2
+          self.parse_http_payload()         # continue to parsing payload
+        end
+        if size(self.response) > 1024       # we don't accept a single header larger than 1KB
+          self.close()
+          self.status = -4
+          self.http_status = -1
+          self.event_http_failed()
+        end
+        return
+      end
+    end
+  end
+
+  #############################################################
+  # parse_http_status_line
+  #
+  # Parse incoming HTTP status line
+  def parse_http_payload()
+    if self.is_chunked
+      while true
+        # if no current chunk size
+        if self.chunk_size == nil
+          var m = global._re_http_chunk.match2(self.response, self.response_offset)
+          if m
+            self.response_offset += m[0]
+            self.chunk_size = int('0x'+m[1])
+            # if chunk size is zero, finished
+            if self.chunk_size == 0
+              self.close()
+              self.status = 2   # finished
+              self.response = ''    # free space
+              self.response_offset = 0
+              self.http_status = 1        # ok
+              self.event_http_finished()
+              return
+            end
+          end
+        end
+        # do we have a chunk size
+        if self.chunk_size != nil
+          # print("chunk_size", self.chunk_size, size(self.response) - self.response_offset)
+          if self.chunk_size <= size(self.response) - self.response_offset
+            # we have a complete chunk in the buffer
+            self.payload += self.response[self.response_offset .. self.response_offset + self.chunk_size - 1]
+            self.response = self.response[self.response_offset + self.chunk_size .. ]    # truncate to save space
+            self.response_offset = 0
+            self.chunk_size = nil
+            # print(bytes().fromstring(self.response).tohex())
+          else
+            return          # return until more data is received
+          end
+        else
+          return
+        end
+      end
+    else
+      # non-chunked
+      self.payload += self.response[self.response_offset..]
+      self.response = ""
+      self.response_offset = 0
+    end
+  end
+
+  #############################################################
+  # send_http
+  #
+  # Send http request
+  def send_http()
+    import string
+    # "GET %s HTTP/1.1\r\nHost %s:%s\r\nConnection: close\r\n\r\n"
+    self.response = ""
+
+    # special formatting for IPv6
+    var addr = self.addr
+    if string.find(addr, ':') >= 0
+      addr = "[" + addr + "]"       # IPv6 must be enclosed in brakets
+    end
+
+    var req = string.format(self.HTTP_GET, self.cmd, addr, self.port)
+    #print("sending ", req)
+    var ret = self.write(req)
+    if ret != size(req)
+      # print("Could not send","size=",size(req),"ret=",ret)
+      self.close()
+      self.status = -4
+      self.http_status = -1
+      self.event_http_failed()
+    end
+  end
+
+
+  #############################################################
+  # Events: method should be overriden
+  #############################################################
+  #   From TCP
+  # event_established:  connection was established
+  # event_dnsfailed:    dns resolution failed
+  # event_refused:      connection was refused by peer
+  # event_timeout:      connection timed out
+  # event_closed:       connection was normally closed (after being established)
+  # event_available:   incoming data is ready to be retrieved with `read()` or `readbytes()`
+  # event_listening:    outgoing buffer is empty, ready to send data with `write()`
+  #   From HTTP
+  # event_http_status_code: received HTTP status code (stored in `status_code`)
+  # event_http_header:      received HTTP header (not stored except `is_chunked`)
+  # event_http_headers_end: all HTTP headers received
+  #   Always finishes with one of:
+  # event_http_finished:    HTTP finished, result is in `payload`
+  # event_http_failed:      HTTP connection failed (not a timeout)
+  # event_http_timeout:     HTTP timeout
+
+  #############################################################
+  # event_established
+  #
+  # When connection is established, we send the GET request in
+  # a single write, and we don't need to send anything more
+  def event_established()
+    self.send_http()
+  end
+
+  #############################################################
+  # event_available
+  #
+  # Data received
+  def event_available()
+    self.receive()
+  end
+
+  #############################################################
+  # event_http_status_code
+  #
+  # Received status_code
+  def event_http_status_code(status_code, status_message)
+    self.status_code = status_code
+  end
+
+  #############################################################
+  # event_http_header
+  #
+  # Received header
+  def event_http_header(header_key, header_value)
+    import string
+    header_key = string.tolower(header_key)
+    header_value = string.tolower(header_value)
+    # print("header=", header_key, header_value)
+    if   header_key == 'transfer-encoding' && string.tolower(header_value) == 'chunked'
+      self.is_chunked = true
+    end
+  end
+
+  #############################################################
+  # event_http_headers_end
+  #
+  # All headers are received
+  def event_http_headers_end()
+    # print("event_http_headers_end")
+    # truncate to save space
+    if self.response_offset > 0
+      self.response = self.response[self.response_offset .. ]
+      self.response_offset = 0
+    end
+  end
+
+  #############################################################
+  # receive
+  #
+  # Receive and collate
+  def receive()
+    if self.tcp_connected != true     return    end      # not connected
+
+    if (tasmota.millis() - self.time_start) > self.timeout
+      # connection timeout
+      # print("Connected timeout in", tasmota.millis() - self.time_start, "ms")
+      self.status = -3
+      self.close()
+      self.http_status = -2
+      self.event_http_timeout()
+    else
+
+      var avail = self.tcp.available()
+      var new_data = 0
+      while avail > 0
+        var s = self.tcp.read()
+        # print("read size=", size(s), "avail=", avail, "in", tasmota.millis() - self.time_start, "ms")
+        self.response += s
+        new_data += size(s)
+        avail = self.tcp.available()
+      end
+
+      if new_data > 0
+        # print("read size=", new_data, "in", tasmota.millis() - self.time_start, "ms")
+        self.parse_http_response()          # try to parse response
+      end
+
+    end
+  end
+
+  #############################################################
+  # event_http_finished
+  #
+  # Transaction finished sucessfully, result in self.payload
+  def event_http_finished()   end
+
+  #############################################################
+  # event_http_failed
+  #
+  # Transaction finished sucessfully, result in self.payload
+  def event_http_failed()     end
+  def event_refused()         self.http_status = -1   self.event_http_failed()  end
+  #############################################################
+  # event_http_timeout
+  #
+  # Transaction finished sucessfully, result in self.payload
+  def event_http_timeout()    end
+  def event_timeout()         self.http_status = -2   self.event_http_timeout()  end
+
+end
+matter.HTTP_async = Matter_HTTP_async
+
+#-
+
+# Example
+
+tcp = matter.HTTP_async("192.168.2.200", 80, 1000)
+tcp.begin("/cm?cmnd=Status%208")
+tcp.begin("/")
+
+# Synchronous examples
+tcp = matter.HTTP_async("192.168.2.200", 80, 1000)
+print(tcp.begin_sync("/cm?cmnd=Status%208", 500))
+print(tcp.begin_sync("/", 500))
+
+-#

--- a/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_remote.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_remote.be
@@ -1,0 +1,87 @@
+#
+# Matter_HTTP_remote.be - implements an interface to query remotely Tasmota device via HTTP
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#@ solidify:Matter_HTTP_remote,weak
+
+# dummy declaration for solidification
+class Matter_HTTP_async end
+
+class Matter_HTTP_remote : Matter_HTTP_async
+  var cb                                            # call cb(http_status, payload)
+
+  #############################################################
+  # init
+  def init(addr, port, timeout, fastloop)
+    super(self).init(addr, port, timeout, fastloop)
+  end
+
+  def set_cb(cb)
+    self.cb = cb
+  end
+
+  #############################################################
+  # begin
+  #
+  # returns true if everything is ok, and connection started
+  # returns false if DNS failed
+  # returns nil if no network
+  def begin(cmd)
+    import string
+    tasmota.log(string.format("MTR: HTTP async request 'http://%s:%i/%s'", self.addr, self.port, cmd), 3)
+    return super(self).begin(cmd)
+  end
+
+  #############################################################
+  # begin_sync
+  #
+  # Synchronous (blocking version)
+  #
+  # returns nil if something went wrong
+  # returns the payload as string
+  def begin_sync(cmd, timeout)
+    import string
+    tasmota.log(string.format("MTR: HTTP sync request 'http://%s:%i/%s'", self.addr, self.port, cmd), 3)
+    return super(self).begin_sync(cmd, timeout)
+  end
+
+  def event_http_finished()
+    import string
+    var payload_short = (self.payload != nil) ? self.payload : 'nil'
+    if size(payload_short) > 30   payload_short = payload_short[0..29] + '...'   end
+    tasmota.log(string.format("MTR: HTTP response in %i ms: '%s'", tasmota.millis() - self.time_start, payload_short), 3)
+
+    if self.cb
+      self.cb(self.http_status, self.payload)
+    end
+  end
+  def event_http_failed()
+    tasmota.log("MTR: HTTP failed", 3)
+    if self.cb
+      self.cb(self.http_status, nil)
+    end
+  end
+  def event_http_timeout()
+    tasmota.log("MTR: HTTP timeout", 3)
+    if self.cb
+      self.cb(self.http_status, nil)
+    end
+  end
+
+end
+matter.HTTP_remote = Matter_HTTP_remote

--- a/lib/libesp32/berry_matter/src/embedded/Matter_TCP_async.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_TCP_async.be
@@ -1,0 +1,236 @@
+#
+# Matter_TCP_async.be - implements a generic async non-blocking TCP connection
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#@ solidify:Matter_TCP_async,weak
+
+# Status:
+# nil = uninitialized
+#   0 = starting    (tcp_connected == nil) - still on-going
+#   1 = connected   (tcp_connected == true)
+#   2 = finished    (tcp_connected == false and result in response)
+#  -1 = DNS failed  (tcp_connected == false)
+#  -2 = refused     (tcp_connecetd == false)
+#  -3 = timeout     (tcp_connecetd == false)
+#  -4 = error       communication error
+
+class Matter_TCP_async
+  var addr                                        # (string) remote address
+  var port                                        # (int) remote port
+  var timeout                                     # (int) timeout in ms
+  var tcp                                         # instance of tcpclientasync
+  var time_start                                  # (int) timestamp when starting connection
+  var tcp_connected                               # (bool or nil) is tcp connected, true/false/nil (nil is in-progress)
+  var status                                      # (int) status, see above
+  static var TIMEOUT = 1000                       # default timeout: 1000ms
+
+  var fast_loop                                   # (opt) either nil or a closure
+
+  #############################################################
+  # constructor
+  #
+  # fastloop: (opt) if 'true' uses fastloop instead of every_50ms
+  def init(addr, port, timeout, fastloop)
+    if timeout == nil   timeout = self.TIMEOUT  end
+    if port == nil      port = 80 end
+    self.addr = str(addr)
+    self.port = int(port)
+    self.timeout = timeout
+    self.tcp = tcpclientasync()
+    if fastloop
+      self.fast_loop = / -> self.loop()         # create a closure to use with fastloop
+    end
+  end
+
+  #############################################################
+  # begin
+  #
+  # returns true if everything is ok, and connection started
+  # returns false if DNS failed
+  # returns nil if no network
+  def begin()
+    self.reset()
+
+    if !tasmota.wifi()['up'] && !tasmota.eth()['up']    return nil    end       # no network
+    self.time_start = tasmota.millis()
+    self.status = 0
+
+    if (self.tcp.connect(self.addr, self.port))
+      if self.fast_loop
+        tasmota.remove_fast_loop(self.fast_loop)
+        tasmota.add_fast_loop(self.fast_loop)
+      else
+        tasmota.add_driver(self)
+      end
+      return true
+    else
+      import string
+      tasmota.log(string.format("BRY: failed to resolve [%s]:%i", self.addr, self.port), 3)
+      self.close()
+      self.status = -1
+      self.tcp_connected = false
+      self.event_dnsfailed()
+      return false
+    end
+  end
+
+  #############################################################
+  # Set a new timeout, or `nil` for default (1s)
+  def set_timeout(timeout)
+    if timeout == nil   timeout = self.TIMEOUT  end
+    self.timeout = timeout
+  end
+
+  #############################################################
+  # Reset the instance to send a open a new connection
+  # This allows to reuse the same object.
+  def reset()
+    self.tcp.close()
+    self.tcp_connected = nil
+  end
+
+  #############################################################
+  # send_http
+  def close()
+    self.tcp.close()
+    if self.fast_loop
+      tasmota.remove_fast_loop(self.fast_loop)
+    else
+      tasmota.remove_driver(self)
+    end
+    # if it was connected, send event
+    if self.tcp_connected == true
+      self.event_closed()
+    end
+    self.tcp_connected = false
+  end
+
+  def every_50ms()
+    self.loop()
+  end
+
+  #############################################################
+  # Main loop, check evolution and trigger events
+  #############################################################
+  def loop()
+    var prev_connected = self.tcp_connected
+    if self.status == nil   self.close()  return  end   # safeguard, this is invalid state
+
+    self.tcp_connected = self.tcp.connected()
+    # if not yet connected, check if we finally got a response
+    if prev_connected == nil                          # not yet connected
+      if self.tcp_connected == true
+        # we finally got connection
+        self.status = 1
+        self.event_established()
+        # and continue below
+      elif self.tcp_connected == false
+        # connection failed
+        self.status = -2
+        self.event_refused()
+        self.close()
+        return
+      elif (tasmota.millis() - self.time_start) > self.timeout
+        # connection timeout
+        self.status = -3
+        self.tcp_connected = false        # force to false
+        self.event_timeout()
+      end
+    end
+
+    if (tasmota.millis() - self.time_start) > self.timeout
+      self.close()
+      self.status = -3
+      self.event_timeout()
+      return
+    end
+
+    if self.tcp_connected == false
+      if prev_connected == true
+        self.event_closed()
+      end
+      self.close()                # close implicitly removes from loop
+      return
+    end
+
+    # reading has priority because we don't want to lose data
+    if self.tcp.available()
+      self.event_available()
+    end
+
+    # can we send data
+    if self.tcp.listening()
+      self.event_listening()
+    end
+  end
+
+  def write(content)
+    if self.tcp_connected
+      return self.tcp.write(content)
+    end
+    return 0
+  end
+
+  def read()
+    if self.tcp_connected
+      return self.tcp.read()
+    end
+    return nil
+  end
+
+  def readbytes()
+    if self.tcp_connected
+      return self.tcp.readbytes()
+    end
+    return nil
+  end
+
+  def available()
+    if self.tcp_connected
+      return self.tcp.available()
+    end
+    return 0
+  end
+
+  def listening()
+    if self.tcp_connected
+      return self.tcp.listening()
+    end
+    return false
+  end
+
+  #############################################################
+  # Events: method should be overriden
+  #############################################################
+  # event_established:  connection was established
+  # event_dnsfailed:    dns resolution failed
+  # event_refused:      connection was refused by peer
+  # event_timeout:      connection timed out
+  # event_closed:       connection was normally closed (after being established)
+  # event_available:   incoming data is ready to be retrieved with `read()` or `readbytes()`
+  # event_listening:    outgoing buffer is empty, ready to send data with `write()`
+  def event_established()     end
+  def event_dnsfailed()       end
+  def event_refused()         end
+  def event_timeout()         end
+  def event_closed()          end
+  def event_available()       end
+  def event_listening()       end
+
+end
+matter.TCP_async = Matter_TCP_async

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_async.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_async.h
@@ -1,0 +1,1114 @@
+/* Solidification of Matter_HTTP_async.h */
+/********************************************************************\
+* Generated code, don't edit                                         *
+\********************************************************************/
+#include "be_constobj.h"
+
+extern const bclass be_class_Matter_HTTP_async;
+
+/********************************************************************
+** Solidified function: event_available
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_available,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(receive),
+    }),
+    be_str_weak(event_available),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_established
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_established,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(send_http),
+    }),
+    be_str_weak(event_established),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_http_status_line
+********************************************************************/
+be_local_closure(Matter_HTTP_async_parse_http_status_line,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(global),
+    /* K1   */  be_nested_str_weak(_re_http_status),
+    /* K2   */  be_nested_str_weak(match2),
+    /* K3   */  be_nested_str_weak(response),
+    /* K4   */  be_nested_str_weak(response_offset),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(status_code),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(phase),
+    /* K9   */  be_nested_str_weak(parse_http_headers),
+    /* K10  */  be_nested_str_weak(close),
+    /* K11  */  be_nested_str_weak(status),
+    }),
+    be_str_weak(parse_http_status_line),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x8C040302,  //  0002  GETMET	R1	R1	K2
+      0x880C0103,  //  0003  GETMBR	R3	R0	K3
+      0x88100104,  //  0004  GETMBR	R4	R0	K4
+      0x7C040600,  //  0005  CALL	R1	3
+      0x78060009,  //  0006  JMPF	R1	#0011
+      0x94080305,  //  0007  GETIDX	R2	R1	K5
+      0x90020802,  //  0008  SETMBR	R0	K4	R2
+      0x60080009,  //  0009  GETGBL	R2	G9
+      0x940C0307,  //  000A  GETIDX	R3	R1	K7
+      0x7C080200,  //  000B  CALL	R2	1
+      0x90020C02,  //  000C  SETMBR	R0	K6	R2
+      0x90021107,  //  000D  SETMBR	R0	K8	K7
+      0x8C080109,  //  000E  GETMET	R2	R0	K9
+      0x7C080200,  //  000F  CALL	R2	1
+      0x70020009,  //  0010  JMP		#001B
+      0x6008000C,  //  0011  GETGBL	R2	G12
+      0x880C0103,  //  0012  GETMBR	R3	R0	K3
+      0x7C080200,  //  0013  CALL	R2	1
+      0x540E0063,  //  0014  LDINT	R3	100
+      0x24080403,  //  0015  GT	R2	R2	R3
+      0x780A0003,  //  0016  JMPF	R2	#001B
+      0x8C08010A,  //  0017  GETMET	R2	R0	K10
+      0x7C080200,  //  0018  CALL	R2	1
+      0x5409FFFB,  //  0019  LDINT	R2	-4
+      0x90021602,  //  001A  SETMBR	R0	K11	R2
+      0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_http_header
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_http_header,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tolower),
+    /* K2   */  be_nested_str_weak(transfer_X2Dencoding),
+    /* K3   */  be_nested_str_weak(chunked),
+    /* K4   */  be_nested_str_weak(is_chunked),
+    }),
+    be_str_weak(event_http_header),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0x8C100701,  //  0001  GETMET	R4	R3	K1
+      0x5C180200,  //  0002  MOVE	R6	R1
+      0x7C100400,  //  0003  CALL	R4	2
+      0x5C040800,  //  0004  MOVE	R1	R4
+      0x8C100701,  //  0005  GETMET	R4	R3	K1
+      0x5C180400,  //  0006  MOVE	R6	R2
+      0x7C100400,  //  0007  CALL	R4	2
+      0x5C080800,  //  0008  MOVE	R2	R4
+      0x1C100302,  //  0009  EQ	R4	R1	K2
+      0x78120006,  //  000A  JMPF	R4	#0012
+      0x8C100701,  //  000B  GETMET	R4	R3	K1
+      0x5C180400,  //  000C  MOVE	R6	R2
+      0x7C100400,  //  000D  CALL	R4	2
+      0x1C100903,  //  000E  EQ	R4	R4	K3
+      0x78120001,  //  000F  JMPF	R4	#0012
+      0x50100200,  //  0010  LDBOOL	R4	1	0
+      0x90020804,  //  0011  SETMBR	R0	K4	R4
+      0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_http_failed
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_http_failed,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(event_http_failed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_HTTP_async_init,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(compile_re),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x60140003,  //  0000  GETGBL	R5	G3
+      0x5C180000,  //  0001  MOVE	R6	R0
+      0x7C140200,  //  0002  CALL	R5	1
+      0x8C140B00,  //  0003  GETMET	R5	R5	K0
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x5C200400,  //  0005  MOVE	R8	R2
+      0x5C240600,  //  0006  MOVE	R9	R3
+      0x5C280800,  //  0007  MOVE	R10	R4
+      0x7C140A00,  //  0008  CALL	R5	5
+      0x8C140101,  //  0009  GETMET	R5	R0	K1
+      0x7C140200,  //  000A  CALL	R5	1
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: begin_sync
+********************************************************************/
+be_local_closure(Matter_HTTP_async_begin_sync,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(timeout),
+    /* K1   */  be_nested_str_weak(set_timeout),
+    /* K2   */  be_nested_str_weak(SPINLOCK),
+    /* K3   */  be_nested_str_weak(begin),
+    /* K4   */  be_nested_str_weak(http_status),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(loop),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(delay),
+    /* K9   */  be_nested_str_weak(payload),
+    }),
+    be_str_weak(begin_sync),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x4C100000,  //  0001  LDNIL	R4
+      0x20100404,  //  0002  NE	R4	R2	R4
+      0x78120002,  //  0003  JMPF	R4	#0007
+      0x8C100101,  //  0004  GETMET	R4	R0	K1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C100400,  //  0006  CALL	R4	2
+      0x4C100000,  //  0007  LDNIL	R4
+      0x88140102,  //  0008  GETMBR	R5	R0	K2
+      0x8C180103,  //  0009  GETMET	R6	R0	K3
+      0x5C200200,  //  000A  MOVE	R8	R1
+      0x7C180400,  //  000B  CALL	R6	2
+      0x781A0009,  //  000C  JMPF	R6	#0017
+      0x881C0104,  //  000D  GETMBR	R7	R0	K4
+      0x1C1C0F05,  //  000E  EQ	R7	R7	K5
+      0x781E0006,  //  000F  JMPF	R7	#0017
+      0x8C1C0106,  //  0010  GETMET	R7	R0	K6
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0xB81E0E00,  //  0012  GETNGBL	R7	K7
+      0x8C1C0F08,  //  0013  GETMET	R7	R7	K8
+      0x5C240A00,  //  0014  MOVE	R9	R5
+      0x7C1C0400,  //  0015  CALL	R7	2
+      0x7001FFF5,  //  0016  JMP		#000D
+      0x8C1C0101,  //  0017  GETMET	R7	R0	K1
+      0x5C240600,  //  0018  MOVE	R9	R3
+      0x7C1C0400,  //  0019  CALL	R7	2
+      0x881C0104,  //  001A  GETMBR	R7	R0	K4
+      0x241C0F05,  //  001B  GT	R7	R7	K5
+      0x781E0001,  //  001C  JMPF	R7	#001F
+      0x881C0109,  //  001D  GETMBR	R7	R0	K9
+      0x70020000,  //  001E  JMP		#0020
+      0x4C1C0000,  //  001F  LDNIL	R7
+      0x80040E00,  //  0020  RET	1	R7
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: reset
+********************************************************************/
+be_local_closure(Matter_HTTP_async_reset,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(reset),
+    /* K1   */  be_nested_str_weak(cmd),
+    /* K2   */  be_nested_str_weak(response),
+    /* K3   */  be_nested_str_weak(response_offset),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(payload),
+    /* K6   */  be_nested_str_weak(),
+    /* K7   */  be_nested_str_weak(phase),
+    /* K8   */  be_nested_str_weak(http_status),
+    /* K9   */  be_nested_str_weak(is_chunked),
+    /* K10  */  be_nested_str_weak(chunk_size),
+    }),
+    be_str_weak(reset),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x60040003,  //  0000  GETGBL	R1	G3
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x8C040300,  //  0003  GETMET	R1	R1	K0
+      0x7C040200,  //  0004  CALL	R1	1
+      0x4C040000,  //  0005  LDNIL	R1
+      0x90020201,  //  0006  SETMBR	R0	K1	R1
+      0x4C040000,  //  0007  LDNIL	R1
+      0x90020401,  //  0008  SETMBR	R0	K2	R1
+      0x90020704,  //  0009  SETMBR	R0	K3	K4
+      0x90020B06,  //  000A  SETMBR	R0	K5	K6
+      0x90020F04,  //  000B  SETMBR	R0	K7	K4
+      0x90021104,  //  000C  SETMBR	R0	K8	K4
+      0x50040000,  //  000D  LDBOOL	R1	0	0
+      0x90021201,  //  000E  SETMBR	R0	K9	R1
+      0x4C040000,  //  000F  LDNIL	R1
+      0x90021401,  //  0010  SETMBR	R0	K10	R1
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_http_status_code
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_http_status_code,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(status_code),
+    }),
+    be_str_weak(event_http_status_code),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_timeout
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_timeout,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(http_status),
+    /* K1   */  be_nested_str_weak(event_http_timeout),
+    }),
+    be_str_weak(event_timeout),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x5405FFFD,  //  0000  LDINT	R1	-2
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x7C040200,  //  0003  CALL	R1	1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: compile_re
+********************************************************************/
+be_local_closure(Matter_HTTP_async_compile_re,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(re),
+    /* K1   */  be_nested_str_weak(global),
+    /* K2   */  be_nested_str_weak(contains),
+    /* K3   */  be_nested_str_weak(_re_http_status),
+    /* K4   */  be_nested_str_weak(compile),
+    /* K5   */  be_nested_str_weak(HTTP_STATUS_REGEX),
+    /* K6   */  be_nested_str_weak(_re_http_header),
+    /* K7   */  be_nested_str_weak(HTTP_HEADER_REGEX),
+    /* K8   */  be_nested_str_weak(_re_http_body),
+    /* K9   */  be_nested_str_weak(HTTP_BODY_REGEX),
+    /* K10  */  be_nested_str_weak(_re_http_chunk),
+    /* K11  */  be_nested_str_weak(HTTP_CHUNK_REGEX),
+    }),
+    be_str_weak(compile_re),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x58100003,  //  0003  LDCONST	R4	K3
+      0x7C080400,  //  0004  CALL	R2	2
+      0x740A0013,  //  0005  JMPT	R2	#001A
+      0xB80A0200,  //  0006  GETNGBL	R2	K1
+      0x8C0C0304,  //  0007  GETMET	R3	R1	K4
+      0x88140105,  //  0008  GETMBR	R5	R0	K5
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x900A0603,  //  000A  SETMBR	R2	K3	R3
+      0xB80A0200,  //  000B  GETNGBL	R2	K1
+      0x8C0C0304,  //  000C  GETMET	R3	R1	K4
+      0x88140107,  //  000D  GETMBR	R5	R0	K7
+      0x7C0C0400,  //  000E  CALL	R3	2
+      0x900A0C03,  //  000F  SETMBR	R2	K6	R3
+      0xB80A0200,  //  0010  GETNGBL	R2	K1
+      0x8C0C0304,  //  0011  GETMET	R3	R1	K4
+      0x88140109,  //  0012  GETMBR	R5	R0	K9
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x900A1003,  //  0014  SETMBR	R2	K8	R3
+      0xB80A0200,  //  0015  GETNGBL	R2	K1
+      0x8C0C0304,  //  0016  GETMET	R3	R1	K4
+      0x8814010B,  //  0017  GETMBR	R5	R0	K11
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x900A1403,  //  0019  SETMBR	R2	K10	R3
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_http_payload
+********************************************************************/
+be_local_closure(Matter_HTTP_async_parse_http_payload,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(is_chunked),
+    /* K1   */  be_nested_str_weak(chunk_size),
+    /* K2   */  be_nested_str_weak(global),
+    /* K3   */  be_nested_str_weak(_re_http_chunk),
+    /* K4   */  be_nested_str_weak(match2),
+    /* K5   */  be_nested_str_weak(response),
+    /* K6   */  be_nested_str_weak(response_offset),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_nested_str_weak(0x),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(close),
+    /* K11  */  be_nested_str_weak(status),
+    /* K12  */  be_const_int(2),
+    /* K13  */  be_nested_str_weak(),
+    /* K14  */  be_nested_str_weak(http_status),
+    /* K15  */  be_nested_str_weak(event_http_finished),
+    /* K16  */  be_nested_str_weak(payload),
+    /* K17  */  be_const_int(2147483647),
+    }),
+    be_str_weak(parse_http_payload),
+    &be_const_str_solidified,
+    ( &(const binstruction[85]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060048,  //  0001  JMPF	R1	#004B
+      0x50040200,  //  0002  LDBOOL	R1	1	0
+      0x78060045,  //  0003  JMPF	R1	#004A
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x4C080000,  //  0005  LDNIL	R2
+      0x1C040202,  //  0006  EQ	R1	R1	R2
+      0x7806001B,  //  0007  JMPF	R1	#0024
+      0xB8060400,  //  0008  GETNGBL	R1	K2
+      0x88040303,  //  0009  GETMBR	R1	R1	K3
+      0x8C040304,  //  000A  GETMET	R1	R1	K4
+      0x880C0105,  //  000B  GETMBR	R3	R0	K5
+      0x88100106,  //  000C  GETMBR	R4	R0	K6
+      0x7C040600,  //  000D  CALL	R1	3
+      0x78060014,  //  000E  JMPF	R1	#0024
+      0x88080106,  //  000F  GETMBR	R2	R0	K6
+      0x940C0307,  //  0010  GETIDX	R3	R1	K7
+      0x00080403,  //  0011  ADD	R2	R2	R3
+      0x90020C02,  //  0012  SETMBR	R0	K6	R2
+      0x60080009,  //  0013  GETGBL	R2	G9
+      0x940C0309,  //  0014  GETIDX	R3	R1	K9
+      0x000E1003,  //  0015  ADD	R3	K8	R3
+      0x7C080200,  //  0016  CALL	R2	1
+      0x90020202,  //  0017  SETMBR	R0	K1	R2
+      0x88080101,  //  0018  GETMBR	R2	R0	K1
+      0x1C080507,  //  0019  EQ	R2	R2	K7
+      0x780A0008,  //  001A  JMPF	R2	#0024
+      0x8C08010A,  //  001B  GETMET	R2	R0	K10
+      0x7C080200,  //  001C  CALL	R2	1
+      0x9002170C,  //  001D  SETMBR	R0	K11	K12
+      0x90020B0D,  //  001E  SETMBR	R0	K5	K13
+      0x90020D07,  //  001F  SETMBR	R0	K6	K7
+      0x90021D09,  //  0020  SETMBR	R0	K14	K9
+      0x8C08010F,  //  0021  GETMET	R2	R0	K15
+      0x7C080200,  //  0022  CALL	R2	1
+      0x80000400,  //  0023  RET	0
+      0x88040101,  //  0024  GETMBR	R1	R0	K1
+      0x4C080000,  //  0025  LDNIL	R2
+      0x20040202,  //  0026  NE	R1	R1	R2
+      0x7806001F,  //  0027  JMPF	R1	#0048
+      0x88040101,  //  0028  GETMBR	R1	R0	K1
+      0x6008000C,  //  0029  GETGBL	R2	G12
+      0x880C0105,  //  002A  GETMBR	R3	R0	K5
+      0x7C080200,  //  002B  CALL	R2	1
+      0x880C0106,  //  002C  GETMBR	R3	R0	K6
+      0x04080403,  //  002D  SUB	R2	R2	R3
+      0x18040202,  //  002E  LE	R1	R1	R2
+      0x78060015,  //  002F  JMPF	R1	#0046
+      0x88080106,  //  0030  GETMBR	R2	R0	K6
+      0x880C0106,  //  0031  GETMBR	R3	R0	K6
+      0x88100101,  //  0032  GETMBR	R4	R0	K1
+      0x000C0604,  //  0033  ADD	R3	R3	R4
+      0x040C0709,  //  0034  SUB	R3	R3	K9
+      0x40080403,  //  0035  CONNECT	R2	R2	R3
+      0x880C0105,  //  0036  GETMBR	R3	R0	K5
+      0x88040110,  //  0037  GETMBR	R1	R0	K16
+      0x94080602,  //  0038  GETIDX	R2	R3	R2
+      0x00040202,  //  0039  ADD	R1	R1	R2
+      0x90022001,  //  003A  SETMBR	R0	K16	R1
+      0x88040106,  //  003B  GETMBR	R1	R0	K6
+      0x88080101,  //  003C  GETMBR	R2	R0	K1
+      0x00040202,  //  003D  ADD	R1	R1	R2
+      0x40040311,  //  003E  CONNECT	R1	R1	K17
+      0x88080105,  //  003F  GETMBR	R2	R0	K5
+      0x94040401,  //  0040  GETIDX	R1	R2	R1
+      0x90020A01,  //  0041  SETMBR	R0	K5	R1
+      0x90020D07,  //  0042  SETMBR	R0	K6	K7
+      0x4C040000,  //  0043  LDNIL	R1
+      0x90020201,  //  0044  SETMBR	R0	K1	R1
+      0x70020000,  //  0045  JMP		#0047
+      0x80000200,  //  0046  RET	0
+      0x70020000,  //  0047  JMP		#0049
+      0x80000200,  //  0048  RET	0
+      0x7001FFB7,  //  0049  JMP		#0002
+      0x70020008,  //  004A  JMP		#0054
+      0x88080106,  //  004B  GETMBR	R2	R0	K6
+      0x40080511,  //  004C  CONNECT	R2	R2	K17
+      0x880C0105,  //  004D  GETMBR	R3	R0	K5
+      0x88040110,  //  004E  GETMBR	R1	R0	K16
+      0x94080602,  //  004F  GETIDX	R2	R3	R2
+      0x00040202,  //  0050  ADD	R1	R1	R2
+      0x90022001,  //  0051  SETMBR	R0	K16	R1
+      0x90020B0D,  //  0052  SETMBR	R0	K5	K13
+      0x90020D07,  //  0053  SETMBR	R0	K6	K7
+      0x80000000,  //  0054  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: receive
+********************************************************************/
+be_local_closure(Matter_HTTP_async_receive,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tcp_connected),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(millis),
+    /* K3   */  be_nested_str_weak(time_start),
+    /* K4   */  be_nested_str_weak(timeout),
+    /* K5   */  be_nested_str_weak(status),
+    /* K6   */  be_nested_str_weak(close),
+    /* K7   */  be_nested_str_weak(http_status),
+    /* K8   */  be_nested_str_weak(event_http_timeout),
+    /* K9   */  be_nested_str_weak(tcp),
+    /* K10  */  be_nested_str_weak(available),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_weak(read),
+    /* K13  */  be_nested_str_weak(response),
+    /* K14  */  be_nested_str_weak(parse_http_response),
+    }),
+    be_str_weak(receive),
+    &be_const_str_solidified,
+    ( &(const binstruction[48]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x50080200,  //  0001  LDBOOL	R2	1	0
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060000,  //  0003  JMPF	R1	#0005
+      0x80000200,  //  0004  RET	0
+      0xB8060200,  //  0005  GETNGBL	R1	K1
+      0x8C040302,  //  0006  GETMET	R1	R1	K2
+      0x7C040200,  //  0007  CALL	R1	1
+      0x88080103,  //  0008  GETMBR	R2	R0	K3
+      0x04040202,  //  0009  SUB	R1	R1	R2
+      0x88080104,  //  000A  GETMBR	R2	R0	K4
+      0x24040202,  //  000B  GT	R1	R1	R2
+      0x78060008,  //  000C  JMPF	R1	#0016
+      0x5405FFFC,  //  000D  LDINT	R1	-3
+      0x90020A01,  //  000E  SETMBR	R0	K5	R1
+      0x8C040106,  //  000F  GETMET	R1	R0	K6
+      0x7C040200,  //  0010  CALL	R1	1
+      0x5405FFFD,  //  0011  LDINT	R1	-2
+      0x90020E01,  //  0012  SETMBR	R0	K7	R1
+      0x8C040108,  //  0013  GETMET	R1	R0	K8
+      0x7C040200,  //  0014  CALL	R1	1
+      0x70020018,  //  0015  JMP		#002F
+      0x88040109,  //  0016  GETMBR	R1	R0	K9
+      0x8C04030A,  //  0017  GETMET	R1	R1	K10
+      0x7C040200,  //  0018  CALL	R1	1
+      0x5808000B,  //  0019  LDCONST	R2	K11
+      0x240C030B,  //  001A  GT	R3	R1	K11
+      0x780E000E,  //  001B  JMPF	R3	#002B
+      0x880C0109,  //  001C  GETMBR	R3	R0	K9
+      0x8C0C070C,  //  001D  GETMET	R3	R3	K12
+      0x7C0C0200,  //  001E  CALL	R3	1
+      0x8810010D,  //  001F  GETMBR	R4	R0	K13
+      0x00100803,  //  0020  ADD	R4	R4	R3
+      0x90021A04,  //  0021  SETMBR	R0	K13	R4
+      0x6010000C,  //  0022  GETGBL	R4	G12
+      0x5C140600,  //  0023  MOVE	R5	R3
+      0x7C100200,  //  0024  CALL	R4	1
+      0x00080404,  //  0025  ADD	R2	R2	R4
+      0x88100109,  //  0026  GETMBR	R4	R0	K9
+      0x8C10090A,  //  0027  GETMET	R4	R4	K10
+      0x7C100200,  //  0028  CALL	R4	1
+      0x5C040800,  //  0029  MOVE	R1	R4
+      0x7001FFEE,  //  002A  JMP		#001A
+      0x240C050B,  //  002B  GT	R3	R2	K11
+      0x780E0001,  //  002C  JMPF	R3	#002F
+      0x8C0C010E,  //  002D  GETMET	R3	R0	K14
+      0x7C0C0200,  //  002E  CALL	R3	1
+      0x80000000,  //  002F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_http_finished
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_http_finished,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(event_http_finished),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_http_headers
+********************************************************************/
+be_local_closure(Matter_HTTP_async_parse_http_headers,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[17]) {     /* constants */
+    /* K0   */  be_nested_str_weak(global),
+    /* K1   */  be_nested_str_weak(_re_http_header),
+    /* K2   */  be_nested_str_weak(match2),
+    /* K3   */  be_nested_str_weak(response),
+    /* K4   */  be_nested_str_weak(response_offset),
+    /* K5   */  be_nested_str_weak(event_http_header),
+    /* K6   */  be_const_int(1),
+    /* K7   */  be_const_int(2),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(_re_http_body),
+    /* K10  */  be_nested_str_weak(event_http_headers_end),
+    /* K11  */  be_nested_str_weak(phase),
+    /* K12  */  be_nested_str_weak(parse_http_payload),
+    /* K13  */  be_nested_str_weak(close),
+    /* K14  */  be_nested_str_weak(status),
+    /* K15  */  be_nested_str_weak(http_status),
+    /* K16  */  be_nested_str_weak(event_http_failed),
+    }),
+    be_str_weak(parse_http_headers),
+    &be_const_str_solidified,
+    ( &(const binstruction[47]) {  /* code */
+      0x50040200,  //  0000  LDBOOL	R1	1	0
+      0x7806002B,  //  0001  JMPF	R1	#002E
+      0xB8060000,  //  0002  GETNGBL	R1	K0
+      0x88040301,  //  0003  GETMBR	R1	R1	K1
+      0x8C040302,  //  0004  GETMET	R1	R1	K2
+      0x880C0103,  //  0005  GETMBR	R3	R0	K3
+      0x88100104,  //  0006  GETMBR	R4	R0	K4
+      0x7C040600,  //  0007  CALL	R1	3
+      0x78060008,  //  0008  JMPF	R1	#0012
+      0x8C080105,  //  0009  GETMET	R2	R0	K5
+      0x94100306,  //  000A  GETIDX	R4	R1	K6
+      0x94140307,  //  000B  GETIDX	R5	R1	K7
+      0x7C080600,  //  000C  CALL	R2	3
+      0x88080104,  //  000D  GETMBR	R2	R0	K4
+      0x940C0308,  //  000E  GETIDX	R3	R1	K8
+      0x00080403,  //  000F  ADD	R2	R2	R3
+      0x90020802,  //  0010  SETMBR	R0	K4	R2
+      0x7002001A,  //  0011  JMP		#002D
+      0xB80A0000,  //  0012  GETNGBL	R2	K0
+      0x88080509,  //  0013  GETMBR	R2	R2	K9
+      0x8C080502,  //  0014  GETMET	R2	R2	K2
+      0x88100103,  //  0015  GETMBR	R4	R0	K3
+      0x88140104,  //  0016  GETMBR	R5	R0	K4
+      0x7C080600,  //  0017  CALL	R2	3
+      0x780A0004,  //  0018  JMPF	R2	#001E
+      0x8C0C010A,  //  0019  GETMET	R3	R0	K10
+      0x7C0C0200,  //  001A  CALL	R3	1
+      0x90021707,  //  001B  SETMBR	R0	K11	K7
+      0x8C0C010C,  //  001C  GETMET	R3	R0	K12
+      0x7C0C0200,  //  001D  CALL	R3	1
+      0x600C000C,  //  001E  GETGBL	R3	G12
+      0x88100103,  //  001F  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x541203FF,  //  0021  LDINT	R4	1024
+      0x240C0604,  //  0022  GT	R3	R3	R4
+      0x780E0007,  //  0023  JMPF	R3	#002C
+      0x8C0C010D,  //  0024  GETMET	R3	R0	K13
+      0x7C0C0200,  //  0025  CALL	R3	1
+      0x540DFFFB,  //  0026  LDINT	R3	-4
+      0x90021C03,  //  0027  SETMBR	R0	K14	R3
+      0x540DFFFE,  //  0028  LDINT	R3	-1
+      0x90021E03,  //  0029  SETMBR	R0	K15	R3
+      0x8C0C0110,  //  002A  GETMET	R3	R0	K16
+      0x7C0C0200,  //  002B  CALL	R3	1
+      0x80000600,  //  002C  RET	0
+      0x7001FFD1,  //  002D  JMP		#0000
+      0x80000000,  //  002E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_http_response
+********************************************************************/
+be_local_closure(Matter_HTTP_async_parse_http_response,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(phase),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(parse_http_status_line),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(parse_http_headers),
+    /* K5   */  be_const_int(2),
+    /* K6   */  be_nested_str_weak(parse_http_payload),
+    }),
+    be_str_weak(parse_http_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x1C040301,  //  0001  EQ	R1	R1	K1
+      0x78060002,  //  0002  JMPF	R1	#0006
+      0x8C040102,  //  0003  GETMET	R1	R0	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x7002000A,  //  0005  JMP		#0011
+      0x88040100,  //  0006  GETMBR	R1	R0	K0
+      0x1C040303,  //  0007  EQ	R1	R1	K3
+      0x78060002,  //  0008  JMPF	R1	#000C
+      0x8C040104,  //  0009  GETMET	R1	R0	K4
+      0x7C040200,  //  000A  CALL	R1	1
+      0x70020004,  //  000B  JMP		#0011
+      0x88040100,  //  000C  GETMBR	R1	R0	K0
+      0x1C040305,  //  000D  EQ	R1	R1	K5
+      0x78060001,  //  000E  JMPF	R1	#0011
+      0x8C040106,  //  000F  GETMET	R1	R0	K6
+      0x7C040200,  //  0010  CALL	R1	1
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: begin
+********************************************************************/
+be_local_closure(Matter_HTTP_async_begin,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(begin),
+    /* K1   */  be_nested_str_weak(cmd),
+    }),
+    be_str_weak(begin),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x7C080200,  //  0004  CALL	R2	1
+      0x90020201,  //  0005  SETMBR	R0	K1	R1
+      0x80040400,  //  0006  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_http_timeout
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_http_timeout,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(event_http_timeout),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_refused
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_refused,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(http_status),
+    /* K1   */  be_nested_str_weak(event_http_failed),
+    }),
+    be_str_weak(event_refused),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x5405FFFE,  //  0000  LDINT	R1	-1
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x7C040200,  //  0003  CALL	R1	1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_http
+********************************************************************/
+be_local_closure(Matter_HTTP_async_send_http,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(response),
+    /* K2   */  be_nested_str_weak(),
+    /* K3   */  be_nested_str_weak(addr),
+    /* K4   */  be_nested_str_weak(find),
+    /* K5   */  be_nested_str_weak(_X3A),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(_X5B),
+    /* K8   */  be_nested_str_weak(_X5D),
+    /* K9   */  be_nested_str_weak(format),
+    /* K10  */  be_nested_str_weak(HTTP_GET),
+    /* K11  */  be_nested_str_weak(cmd),
+    /* K12  */  be_nested_str_weak(port),
+    /* K13  */  be_nested_str_weak(write),
+    /* K14  */  be_nested_str_weak(close),
+    /* K15  */  be_nested_str_weak(status),
+    /* K16  */  be_nested_str_weak(http_status),
+    /* K17  */  be_nested_str_weak(event_http_failed),
+    }),
+    be_str_weak(send_http),
+    &be_const_str_solidified,
+    ( &(const binstruction[35]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x90020302,  //  0001  SETMBR	R0	K1	K2
+      0x88080103,  //  0002  GETMBR	R2	R0	K3
+      0x8C0C0304,  //  0003  GETMET	R3	R1	K4
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x58180005,  //  0005  LDCONST	R6	K5
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x280C0706,  //  0007  GE	R3	R3	K6
+      0x780E0002,  //  0008  JMPF	R3	#000C
+      0x000E0E02,  //  0009  ADD	R3	K7	R2
+      0x000C0708,  //  000A  ADD	R3	R3	K8
+      0x5C080600,  //  000B  MOVE	R2	R3
+      0x8C0C0309,  //  000C  GETMET	R3	R1	K9
+      0x8814010A,  //  000D  GETMBR	R5	R0	K10
+      0x8818010B,  //  000E  GETMBR	R6	R0	K11
+      0x5C1C0400,  //  000F  MOVE	R7	R2
+      0x8820010C,  //  0010  GETMBR	R8	R0	K12
+      0x7C0C0A00,  //  0011  CALL	R3	5
+      0x8C10010D,  //  0012  GETMET	R4	R0	K13
+      0x5C180600,  //  0013  MOVE	R6	R3
+      0x7C100400,  //  0014  CALL	R4	2
+      0x6014000C,  //  0015  GETGBL	R5	G12
+      0x5C180600,  //  0016  MOVE	R6	R3
+      0x7C140200,  //  0017  CALL	R5	1
+      0x20140805,  //  0018  NE	R5	R4	R5
+      0x78160007,  //  0019  JMPF	R5	#0022
+      0x8C14010E,  //  001A  GETMET	R5	R0	K14
+      0x7C140200,  //  001B  CALL	R5	1
+      0x5415FFFB,  //  001C  LDINT	R5	-4
+      0x90021E05,  //  001D  SETMBR	R0	K15	R5
+      0x5415FFFE,  //  001E  LDINT	R5	-1
+      0x90022005,  //  001F  SETMBR	R0	K16	R5
+      0x8C140111,  //  0020  GETMET	R5	R0	K17
+      0x7C140200,  //  0021  CALL	R5	1
+      0x80000000,  //  0022  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_http_headers_end
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_http_headers_end,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(response_offset),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(response),
+    /* K3   */  be_const_int(2147483647),
+    }),
+    be_str_weak(event_http_headers_end),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x24040301,  //  0001  GT	R1	R1	K1
+      0x78060005,  //  0002  JMPF	R1	#0009
+      0x88040100,  //  0003  GETMBR	R1	R0	K0
+      0x40040303,  //  0004  CONNECT	R1	R1	K3
+      0x88080102,  //  0005  GETMBR	R2	R0	K2
+      0x94040401,  //  0006  GETIDX	R1	R2	R1
+      0x90020401,  //  0007  SETMBR	R0	K2	R1
+      0x90020101,  //  0008  SETMBR	R0	K0	K1
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Matter_HTTP_async
+********************************************************************/
+extern const bclass be_class_Matter_TCP_async;
+be_local_class(Matter_HTTP_async,
+    9,
+    &be_class_Matter_TCP_async,
+    be_nested_map(36,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(phase, -1), be_const_var(6) },
+        { be_const_key_weak(event_http_headers_end, -1), be_const_closure(Matter_HTTP_async_event_http_headers_end_closure) },
+        { be_const_key_weak(HTTP_GET, -1), be_nested_str_weak(GET_X20_X25s_X20HTTP_X2F1_X2E1_X0D_X0AHost_X20_X25s_X3A_X25s_X0D_X0AConnection_X3A_X20close_X0D_X0A_X0D_X0A) },
+        { be_const_key_weak(send_http, 18), be_const_closure(Matter_HTTP_async_send_http_closure) },
+        { be_const_key_weak(event_refused, 17), be_const_closure(Matter_HTTP_async_event_refused_closure) },
+        { be_const_key_weak(payload, -1), be_const_var(4) },
+        { be_const_key_weak(response, 20), be_const_var(1) },
+        { be_const_key_weak(parse_http_status_line, -1), be_const_closure(Matter_HTTP_async_parse_http_status_line_closure) },
+        { be_const_key_weak(event_http_header, -1), be_const_closure(Matter_HTTP_async_event_http_header_closure) },
+        { be_const_key_weak(status_code, -1), be_const_var(3) },
+        { be_const_key_weak(event_http_timeout, -1), be_const_closure(Matter_HTTP_async_event_http_timeout_closure) },
+        { be_const_key_weak(cmd, -1), be_const_var(0) },
+        { be_const_key_weak(event_http_failed, 4), be_const_closure(Matter_HTTP_async_event_http_failed_closure) },
+        { be_const_key_weak(begin, -1), be_const_closure(Matter_HTTP_async_begin_closure) },
+        { be_const_key_weak(chunk_size, 24), be_const_var(8) },
+        { be_const_key_weak(init, 25), be_const_closure(Matter_HTTP_async_init_closure) },
+        { be_const_key_weak(begin_sync, -1), be_const_closure(Matter_HTTP_async_begin_sync_closure) },
+        { be_const_key_weak(reset, 33), be_const_closure(Matter_HTTP_async_reset_closure) },
+        { be_const_key_weak(parse_http_headers, 22), be_const_closure(Matter_HTTP_async_parse_http_headers_closure) },
+        { be_const_key_weak(event_http_finished, 23), be_const_closure(Matter_HTTP_async_event_http_finished_closure) },
+        { be_const_key_weak(HTTP_BODY_REGEX, 34), be_nested_str_weak(_X0D_X0A) },
+        { be_const_key_weak(event_http_status_code, -1), be_const_closure(Matter_HTTP_async_event_http_status_code_closure) },
+        { be_const_key_weak(parse_http_payload, -1), be_const_closure(Matter_HTTP_async_parse_http_payload_closure) },
+        { be_const_key_weak(HTTP_CHUNK_REGEX, -1), be_nested_str_weak(_X0D_X0A_X28_X5BA_X2DFa_X2Df0_X2D9_X5D_X2B_X29_X5B_X20_X09_X5D_X2A_X2E_X2A_X3F_X0D_X0A) },
+        { be_const_key_weak(compile_re, 31), be_const_closure(Matter_HTTP_async_compile_re_closure) },
+        { be_const_key_weak(event_timeout, 11), be_const_closure(Matter_HTTP_async_event_timeout_closure) },
+        { be_const_key_weak(receive, -1), be_const_closure(Matter_HTTP_async_receive_closure) },
+        { be_const_key_weak(HTTP_HEADER_REGEX, 19), be_nested_str_weak(_X28_X5BA_X2DZa_X2Dz0_X2D9_X2D_X5D_X2B_X29_X3A_X20_X28_X2E_X2A_X3F_X29_X0D_X0A) },
+        { be_const_key_weak(http_status, 3), be_const_var(5) },
+        { be_const_key_weak(parse_http_response, -1), be_const_closure(Matter_HTTP_async_parse_http_response_closure) },
+        { be_const_key_weak(is_chunked, 13), be_const_var(7) },
+        { be_const_key_weak(SPINLOCK, -1), be_const_int(5) },
+        { be_const_key_weak(response_offset, 10), be_const_var(2) },
+        { be_const_key_weak(HTTP_STATUS_REGEX, -1), be_nested_str_weak(HTTP_X2F1_X5C_X2E_X5B1_X2D2_X5D_X20_X28_X5Cd_X2B_X29_X20_X2E_X2A_X3F_X0D_X0A) },
+        { be_const_key_weak(event_established, -1), be_const_closure(Matter_HTTP_async_event_established_closure) },
+        { be_const_key_weak(event_available, 1), be_const_closure(Matter_HTTP_async_event_available_closure) },
+    })),
+    be_str_weak(Matter_HTTP_async)
+);
+/*******************************************************************/
+
+void be_load_Matter_HTTP_async_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_Matter_HTTP_async);
+    be_setglobal(vm, "Matter_HTTP_async");
+    be_pop(vm, 1);
+}
+/********************************************************************/
+/* End of solidification */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_remote.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_remote.h
@@ -1,0 +1,363 @@
+/* Solidification of Matter_HTTP_remote.h */
+/********************************************************************\
+* Generated code, don't edit                                         *
+\********************************************************************/
+#include "be_constobj.h"
+
+extern const bclass be_class_Matter_HTTP_remote;
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_init,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x60140003,  //  0000  GETGBL	R5	G3
+      0x5C180000,  //  0001  MOVE	R6	R0
+      0x7C140200,  //  0002  CALL	R5	1
+      0x8C140B00,  //  0003  GETMET	R5	R5	K0
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x5C200400,  //  0005  MOVE	R8	R2
+      0x5C240600,  //  0006  MOVE	R9	R3
+      0x5C280800,  //  0007  MOVE	R10	R4
+      0x7C140A00,  //  0008  CALL	R5	5
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: begin_sync
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_begin_sync,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20sync_X20request_X20_X27http_X3A_X2F_X2F_X25s_X3A_X25i_X2F_X25s_X27),
+    /* K5   */  be_nested_str_weak(addr),
+    /* K6   */  be_nested_str_weak(port),
+    /* K7   */  be_const_int(3),
+    /* K8   */  be_nested_str_weak(begin_sync),
+    }),
+    be_str_weak(begin_sync),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x8C180703,  //  0003  GETMET	R6	R3	K3
+      0x58200004,  //  0004  LDCONST	R8	K4
+      0x88240105,  //  0005  GETMBR	R9	R0	K5
+      0x88280106,  //  0006  GETMBR	R10	R0	K6
+      0x5C2C0200,  //  0007  MOVE	R11	R1
+      0x7C180A00,  //  0008  CALL	R6	5
+      0x581C0007,  //  0009  LDCONST	R7	K7
+      0x7C100600,  //  000A  CALL	R4	3
+      0x60100003,  //  000B  GETGBL	R4	G3
+      0x5C140000,  //  000C  MOVE	R5	R0
+      0x7C100200,  //  000D  CALL	R4	1
+      0x8C100908,  //  000E  GETMET	R4	R4	K8
+      0x5C180200,  //  000F  MOVE	R6	R1
+      0x5C1C0400,  //  0010  MOVE	R7	R2
+      0x7C100600,  //  0011  CALL	R4	3
+      0x80040800,  //  0012  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_http_finished
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_event_http_finished,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(payload),
+    /* K2   */  be_nested_str_weak(nil),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(_X2E_X2E_X2E),
+    /* K5   */  be_nested_str_weak(tasmota),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(format),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20response_X20in_X20_X25i_X20ms_X3A_X20_X27_X25s_X27),
+    /* K9   */  be_nested_str_weak(millis),
+    /* K10  */  be_nested_str_weak(time_start),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(cb),
+    /* K13  */  be_nested_str_weak(http_status),
+    }),
+    be_str_weak(event_http_finished),
+    &be_const_str_solidified,
+    ( &(const binstruction[39]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x20080403,  //  0003  NE	R2	R2	R3
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x88080101,  //  0005  GETMBR	R2	R0	K1
+      0x70020000,  //  0006  JMP		#0008
+      0x58080002,  //  0007  LDCONST	R2	K2
+      0x600C000C,  //  0008  GETGBL	R3	G12
+      0x5C100400,  //  0009  MOVE	R4	R2
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x5412001D,  //  000B  LDINT	R4	30
+      0x240C0604,  //  000C  GT	R3	R3	R4
+      0x780E0004,  //  000D  JMPF	R3	#0013
+      0x540E001C,  //  000E  LDINT	R3	29
+      0x400E0603,  //  000F  CONNECT	R3	K3	R3
+      0x940C0403,  //  0010  GETIDX	R3	R2	R3
+      0x000C0704,  //  0011  ADD	R3	R3	K4
+      0x5C080600,  //  0012  MOVE	R2	R3
+      0xB80E0A00,  //  0013  GETNGBL	R3	K5
+      0x8C0C0706,  //  0014  GETMET	R3	R3	K6
+      0x8C140307,  //  0015  GETMET	R5	R1	K7
+      0x581C0008,  //  0016  LDCONST	R7	K8
+      0xB8220A00,  //  0017  GETNGBL	R8	K5
+      0x8C201109,  //  0018  GETMET	R8	R8	K9
+      0x7C200200,  //  0019  CALL	R8	1
+      0x8824010A,  //  001A  GETMBR	R9	R0	K10
+      0x04201009,  //  001B  SUB	R8	R8	R9
+      0x5C240400,  //  001C  MOVE	R9	R2
+      0x7C140800,  //  001D  CALL	R5	4
+      0x5818000B,  //  001E  LDCONST	R6	K11
+      0x7C0C0600,  //  001F  CALL	R3	3
+      0x880C010C,  //  0020  GETMBR	R3	R0	K12
+      0x780E0003,  //  0021  JMPF	R3	#0026
+      0x8C0C010C,  //  0022  GETMET	R3	R0	K12
+      0x8814010D,  //  0023  GETMBR	R5	R0	K13
+      0x88180101,  //  0024  GETMBR	R6	R0	K1
+      0x7C0C0600,  //  0025  CALL	R3	3
+      0x80000000,  //  0026  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_http_failed
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_event_http_failed,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20failed),
+    /* K3   */  be_const_int(3),
+    /* K4   */  be_nested_str_weak(cb),
+    /* K5   */  be_nested_str_weak(http_status),
+    }),
+    be_str_weak(event_http_failed),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x580C0002,  //  0002  LDCONST	R3	K2
+      0x58100003,  //  0003  LDCONST	R4	K3
+      0x7C040600,  //  0004  CALL	R1	3
+      0x88040104,  //  0005  GETMBR	R1	R0	K4
+      0x78060003,  //  0006  JMPF	R1	#000B
+      0x8C040104,  //  0007  GETMET	R1	R0	K4
+      0x880C0105,  //  0008  GETMBR	R3	R0	K5
+      0x4C100000,  //  0009  LDNIL	R4
+      0x7C040600,  //  000A  CALL	R1	3
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_cb
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_set_cb,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(cb),
+    }),
+    be_str_weak(set_cb),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: begin
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_begin,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20async_X20request_X20_X27http_X3A_X2F_X2F_X25s_X3A_X25i_X2F_X25s_X27),
+    /* K5   */  be_nested_str_weak(addr),
+    /* K6   */  be_nested_str_weak(port),
+    /* K7   */  be_const_int(3),
+    /* K8   */  be_nested_str_weak(begin),
+    }),
+    be_str_weak(begin),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x8C140503,  //  0003  GETMET	R5	R2	K3
+      0x581C0004,  //  0004  LDCONST	R7	K4
+      0x88200105,  //  0005  GETMBR	R8	R0	K5
+      0x88240106,  //  0006  GETMBR	R9	R0	K6
+      0x5C280200,  //  0007  MOVE	R10	R1
+      0x7C140A00,  //  0008  CALL	R5	5
+      0x58180007,  //  0009  LDCONST	R6	K7
+      0x7C0C0600,  //  000A  CALL	R3	3
+      0x600C0003,  //  000B  GETGBL	R3	G3
+      0x5C100000,  //  000C  MOVE	R4	R0
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x8C0C0708,  //  000E  GETMET	R3	R3	K8
+      0x5C140200,  //  000F  MOVE	R5	R1
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x80040600,  //  0011  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_http_timeout
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_event_http_timeout,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20timeout),
+    /* K3   */  be_const_int(3),
+    /* K4   */  be_nested_str_weak(cb),
+    /* K5   */  be_nested_str_weak(http_status),
+    }),
+    be_str_weak(event_http_timeout),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x580C0002,  //  0002  LDCONST	R3	K2
+      0x58100003,  //  0003  LDCONST	R4	K3
+      0x7C040600,  //  0004  CALL	R1	3
+      0x88040104,  //  0005  GETMBR	R1	R0	K4
+      0x78060003,  //  0006  JMPF	R1	#000B
+      0x8C040104,  //  0007  GETMET	R1	R0	K4
+      0x880C0105,  //  0008  GETMBR	R3	R0	K5
+      0x4C100000,  //  0009  LDNIL	R4
+      0x7C040600,  //  000A  CALL	R1	3
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Matter_HTTP_remote
+********************************************************************/
+extern const bclass be_class_Matter_HTTP_async;
+be_local_class(Matter_HTTP_remote,
+    1,
+    &be_class_Matter_HTTP_async,
+    be_nested_map(8,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(cb, 1), be_const_var(0) },
+        { be_const_key_weak(event_http_timeout, -1), be_const_closure(Matter_HTTP_remote_event_http_timeout_closure) },
+        { be_const_key_weak(event_http_failed, -1), be_const_closure(Matter_HTTP_remote_event_http_failed_closure) },
+        { be_const_key_weak(init, 7), be_const_closure(Matter_HTTP_remote_init_closure) },
+        { be_const_key_weak(begin_sync, 2), be_const_closure(Matter_HTTP_remote_begin_sync_closure) },
+        { be_const_key_weak(set_cb, -1), be_const_closure(Matter_HTTP_remote_set_cb_closure) },
+        { be_const_key_weak(begin, -1), be_const_closure(Matter_HTTP_remote_begin_closure) },
+        { be_const_key_weak(event_http_finished, -1), be_const_closure(Matter_HTTP_remote_event_http_finished_closure) },
+    })),
+    be_str_weak(Matter_HTTP_remote)
+);
+/*******************************************************************/
+
+void be_load_Matter_HTTP_remote_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_Matter_HTTP_remote);
+    be_setglobal(vm, "Matter_HTTP_remote");
+    be_pop(vm, 1);
+}
+/********************************************************************/
+/* End of solidification */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
@@ -7,6 +7,127 @@
 extern const bclass be_class_Matter_Plugin;
 
 /********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(Matter_Plugin_every_250ms,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(update_next),
+    /* K1   */  be_nested_str_weak(crypto),
+    /* K2   */  be_nested_str_weak(random),
+    /* K3   */  be_nested_str_weak(get),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_const_int(2147483647),
+    /* K6   */  be_nested_str_weak(tasmota),
+    /* K7   */  be_nested_str_weak(millis),
+    /* K8   */  be_nested_str_weak(UPDATE_TIME),
+    /* K9   */  be_nested_str_weak(time_reached),
+    /* K10  */  be_nested_str_weak(tick),
+    /* K11  */  be_nested_str_weak(device),
+    /* K12  */  be_nested_str_weak(probe_shadow_async),
+    }),
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[38]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x7806000F,  //  0003  JMPF	R1	#0014
+      0xA4060200,  //  0004  IMPORT	R1	K1
+      0x8C080302,  //  0005  GETMET	R2	R1	K2
+      0x54120003,  //  0006  LDINT	R4	4
+      0x7C080400,  //  0007  CALL	R2	2
+      0x8C080503,  //  0008  GETMET	R2	R2	K3
+      0x58100004,  //  0009  LDCONST	R4	K4
+      0x54160003,  //  000A  LDINT	R5	4
+      0x7C080600,  //  000B  CALL	R2	3
+      0x2C080505,  //  000C  AND	R2	R2	K5
+      0xB80E0C00,  //  000D  GETNGBL	R3	K6
+      0x8C0C0707,  //  000E  GETMET	R3	R3	K7
+      0x88140108,  //  000F  GETMBR	R5	R0	K8
+      0x10140405,  //  0010  MOD	R5	R2	R5
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x90020003,  //  0012  SETMBR	R0	K0	R3
+      0x70020010,  //  0013  JMP		#0025
+      0xB8060C00,  //  0014  GETNGBL	R1	K6
+      0x8C040309,  //  0015  GETMET	R1	R1	K9
+      0x880C0100,  //  0016  GETMBR	R3	R0	K0
+      0x7C040400,  //  0017  CALL	R1	2
+      0x7806000B,  //  0018  JMPF	R1	#0025
+      0x8804010A,  //  0019  GETMBR	R1	R0	K10
+      0x8808010B,  //  001A  GETMBR	R2	R0	K11
+      0x8808050A,  //  001B  GETMBR	R2	R2	K10
+      0x20040202,  //  001C  NE	R1	R1	R2
+      0x78060001,  //  001D  JMPF	R1	#0020
+      0x8C04010C,  //  001E  GETMET	R1	R0	K12
+      0x7C040200,  //  001F  CALL	R1	1
+      0xB8060C00,  //  0020  GETNGBL	R1	K6
+      0x8C040307,  //  0021  GETMET	R1	R1	K7
+      0x880C0108,  //  0022  GETMBR	R3	R0	K8
+      0x7C040400,  //  0023  CALL	R1	2
+      0x90020001,  //  0024  SETMBR	R0	K0	R1
+      0x80000000,  //  0025  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_cluster_list
+********************************************************************/
+be_local_closure(Matter_Plugin_get_cluster_list,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(clusters),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(push),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(get_cluster_list),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x88100100,  //  0003  GETMBR	R4	R0	K0
+      0x8C100901,  //  0004  GETMET	R4	R4	K1
+      0x7C100200,  //  0005  CALL	R4	1
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0xA8020005,  //  0007  EXBLK	0	#000E
+      0x5C100600,  //  0008  MOVE	R4	R3
+      0x7C100000,  //  0009  CALL	R4	0
+      0x8C140502,  //  000A  GETMET	R5	R2	K2
+      0x5C1C0800,  //  000B  MOVE	R7	R4
+      0x7C140400,  //  000C  CALL	R5	2
+      0x7001FFF9,  //  000D  JMP		#0008
+      0x580C0003,  //  000E  LDCONST	R3	K3
+      0xAC0C0200,  //  000F  CATCH	R3	1	0
+      0xB0080000,  //  0010  RAISE	2	R0	R0
+      0x80040400,  //  0011  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: <lambda>
 ********************************************************************/
 be_local_closure(Matter_Plugin__X3Clambda_X3E,   /* name */
@@ -34,32 +155,24 @@ be_local_closure(Matter_Plugin__X3Clambda_X3E,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_attribute_list
+** Solidified function: write_attribute
 ********************************************************************/
-be_local_closure(Matter_Plugin_get_attribute_list,   /* name */
+be_local_closure(Matter_Plugin_write_attribute,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
+    5,                          /* nstack */
+    4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(clusters),
-    /* K1   */  be_nested_str_weak(find),
-    }),
-    be_str_weak(get_attribute_list),
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(write_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x5C140400,  //  0002  MOVE	R5	R2
-      0x60180012,  //  0003  GETGBL	R6	G18
-      0x7C180000,  //  0004  CALL	R6	0
-      0x7C0C0600,  //  0005  CALL	R3	3
-      0x80040600,  //  0006  RET	1	R3
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x80040800,  //  0001  RET	1	R4
     })
   )
 );
@@ -67,42 +180,48 @@ be_local_closure(Matter_Plugin_get_attribute_list,   /* name */
 
 
 /********************************************************************
-** Solidified function: has
+** Solidified function: parse_sensors
 ********************************************************************/
-be_local_closure(Matter_Plugin_has,   /* name */
+be_local_closure(Matter_Plugin_parse_sensors,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    3,                          /* argc */
+    2,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(clusters),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(endpoints),
-    /* K3   */  be_nested_str_weak(find),
-    }),
-    be_str_weak(has),
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(parse_sensors),
     &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x780E0006,  //  0004  JMPF	R3	#000C
-      0x880C0102,  //  0005  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
-      0x5C140400,  //  0007  MOVE	R5	R2
-      0x7C0C0400,  //  0008  CALL	R3	2
-      0x4C100000,  //  0009  LDNIL	R4
-      0x200C0604,  //  000A  NE	R3	R3	R4
-      0x740E0000,  //  000B  JMPT	R3	#000D
-      0x500C0001,  //  000C  LDBOOL	R3	0	1
-      0x500C0200,  //  000D  LDBOOL	R3	1	0
-      0x80040600,  //  000E  RET	1	R3
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Plugin_invoke_request,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x80040800,  //  0001  RET	1	R4
     })
   )
 );
@@ -213,118 +332,6 @@ be_local_closure(Matter_Plugin_consolidate_clusters,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_endpoint
-********************************************************************/
-be_local_closure(Matter_Plugin_get_endpoint,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(endpoint),
-    }),
-    be_str_weak(get_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: timed_request
-********************************************************************/
-be_local_closure(Matter_Plugin_timed_request,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(timed_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x80040800,  //  0001  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: subscribe_event
-********************************************************************/
-be_local_closure(Matter_Plugin_subscribe_event,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(subscribe_event),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_shadow_lazy
-********************************************************************/
-be_local_closure(Matter_Plugin_update_shadow_lazy,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tick),
-    /* K1   */  be_nested_str_weak(device),
-    /* K2   */  be_nested_str_weak(update_shadow),
-    }),
-    be_str_weak(update_shadow_lazy),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x88080500,  //  0002  GETMBR	R2	R2	K0
-      0x20040202,  //  0003  NE	R1	R1	R2
-      0x78060001,  //  0004  JMPF	R1	#0007
-      0x8C040102,  //  0005  GETMET	R1	R0	K2
-      0x7C040200,  //  0006  CALL	R1	1
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: attribute_updated
 ********************************************************************/
 be_local_closure(Matter_Plugin_attribute_updated,   /* name */
@@ -360,12 +367,12 @@ be_local_closure(Matter_Plugin_attribute_updated,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_cluster_list
+** Solidified function: has
 ********************************************************************/
-be_local_closure(Matter_Plugin_get_cluster_list,   /* name */
+be_local_closure(Matter_Plugin_has,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
+    6,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -374,31 +381,383 @@ be_local_closure(Matter_Plugin_get_cluster_list,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(clusters),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(push),
-    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K1   */  be_nested_str_weak(contains),
+    /* K2   */  be_nested_str_weak(endpoints),
+    /* K3   */  be_nested_str_weak(find),
     }),
-    be_str_weak(get_cluster_list),
+    be_str_weak(has),
     &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x88100100,  //  0003  GETMBR	R4	R0	K0
-      0x8C100901,  //  0004  GETMET	R4	R4	K1
-      0x7C100200,  //  0005  CALL	R4	1
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0xA8020005,  //  0007  EXBLK	0	#000E
-      0x5C100600,  //  0008  MOVE	R4	R3
-      0x7C100000,  //  0009  CALL	R4	0
-      0x8C140502,  //  000A  GETMET	R5	R2	K2
-      0x5C1C0800,  //  000B  MOVE	R7	R4
-      0x7C140400,  //  000C  CALL	R5	2
-      0x7001FFF9,  //  000D  JMP		#0008
-      0x580C0003,  //  000E  LDCONST	R3	K3
-      0xAC0C0200,  //  000F  CATCH	R3	1	0
-      0xB0080000,  //  0010  RAISE	2	R0	R0
-      0x80040400,  //  0011  RET	1	R2
+    ( &(const binstruction[15]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x780E0006,  //  0004  JMPF	R3	#000C
+      0x880C0102,  //  0005  GETMBR	R3	R0	K2
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x5C140400,  //  0007  MOVE	R5	R2
+      0x7C0C0400,  //  0008  CALL	R3	2
+      0x4C100000,  //  0009  LDNIL	R4
+      0x200C0604,  //  000A  NE	R3	R3	R4
+      0x740E0000,  //  000B  JMPT	R3	#000D
+      0x500C0001,  //  000C  LDBOOL	R3	0	1
+      0x500C0200,  //  000D  LDBOOL	R3	1	0
+      0x80040600,  //  000E  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_shadow_lazy
+********************************************************************/
+be_local_closure(Matter_Plugin_update_shadow_lazy,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tick),
+    /* K1   */  be_nested_str_weak(device),
+    /* K2   */  be_nested_str_weak(update_shadow),
+    }),
+    be_str_weak(update_shadow_lazy),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x88080500,  //  0002  GETMBR	R2	R2	K0
+      0x20040202,  //  0003  NE	R1	R1	R2
+      0x78060004,  //  0004  JMPF	R1	#000A
+      0x8C040102,  //  0005  GETMET	R1	R0	K2
+      0x7C040200,  //  0006  CALL	R1	1
+      0x88040101,  //  0007  GETMBR	R1	R0	K1
+      0x88040300,  //  0008  GETMBR	R1	R1	K0
+      0x90020001,  //  0009  SETMBR	R0	K0	R1
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_endpoint
+********************************************************************/
+be_local_closure(Matter_Plugin_get_endpoint,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(endpoint),
+    }),
+    be_str_weak(get_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_update
+********************************************************************/
+be_local_closure(Matter_Plugin_parse_update,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(parse_update),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Plugin_init,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(endpoint),
+    /* K2   */  be_nested_str_weak(clusters),
+    /* K3   */  be_nested_str_weak(consolidate_clusters),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x8C100103,  //  0002  GETMET	R4	R0	K3
+      0x7C100200,  //  0003  CALL	R4	1
+      0x90020404,  //  0004  SETMBR	R0	K2	R4
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_event
+********************************************************************/
+be_local_closure(Matter_Plugin_read_event,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(read_event),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x80040A00,  //  0001  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: subscribe_attribute
+********************************************************************/
+be_local_closure(Matter_Plugin_subscribe_attribute,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(subscribe_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x80040A00,  //  0001  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: ui_string_to_conf
+********************************************************************/
+be_local_closure(Matter_Plugin_ui_string_to_conf,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Plugin),
+    /* K1   */  be_nested_str_weak(ARG),
+    /* K2   */  be_nested_str_weak(ARG_TYPE),
+    }),
+    be_str_weak(ui_string_to_conf),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x580C0000,  //  0000  LDCONST	R3	K0
+      0x88100101,  //  0001  GETMBR	R4	R0	K1
+      0x88140102,  //  0002  GETMBR	R5	R0	K2
+      0x780A0004,  //  0003  JMPF	R2	#0009
+      0x78120003,  //  0004  JMPF	R4	#0009
+      0x5C180A00,  //  0005  MOVE	R6	R5
+      0x5C1C0400,  //  0006  MOVE	R7	R2
+      0x7C180200,  //  0007  CALL	R6	1
+      0x98040806,  //  0008  SETIDX	R1	R4	R6
+      0x80040200,  //  0009  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: subscribe_event
+********************************************************************/
+be_local_closure(Matter_Plugin_subscribe_event,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(subscribe_event),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x80040A00,  //  0001  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_attribute_list
+********************************************************************/
+be_local_closure(Matter_Plugin_get_attribute_list,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(clusters),
+    /* K1   */  be_nested_str_weak(find),
+    }),
+    be_str_weak(get_attribute_list),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140400,  //  0002  MOVE	R5	R2
+      0x60180012,  //  0003  GETGBL	R6	G18
+      0x7C180000,  //  0004  CALL	R6	0
+      0x7C0C0600,  //  0005  CALL	R3	3
+      0x80040600,  //  0006  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: timed_request
+********************************************************************/
+be_local_closure(Matter_Plugin_timed_request,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(timed_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x80040800,  //  0001  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_shadow
+********************************************************************/
+be_local_closure(Matter_Plugin_update_shadow,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tick),
+    /* K1   */  be_nested_str_weak(device),
+    /* K2   */  be_nested_str_weak(parse_update),
+    }),
+    be_str_weak(update_shadow),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x88040300,  //  0001  GETMBR	R1	R1	K0
+      0x90020001,  //  0002  SETMBR	R0	K0	R1
+      0x8C040102,  //  0003  GETMET	R1	R0	K2
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x7C040400,  //  0005  CALL	R1	2
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: probe_shadow_async
+********************************************************************/
+be_local_closure(Matter_Plugin_probe_shadow_async,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(update_shadow),
+    }),
+    be_str_weak(probe_shadow_async),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
     })
   )
 );
@@ -541,326 +900,6 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
 
 
 /********************************************************************
-** Solidified function: write_attribute
-********************************************************************/
-be_local_closure(Matter_Plugin_write_attribute,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(write_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x80040800,  //  0001  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: subscribe_attribute
-********************************************************************/
-be_local_closure(Matter_Plugin_subscribe_attribute,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(subscribe_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_shadow
-********************************************************************/
-be_local_closure(Matter_Plugin_update_shadow,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tick),
-    /* K1   */  be_nested_str_weak(device),
-    }),
-    be_str_weak(update_shadow),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x88040300,  //  0001  GETMBR	R1	R1	K0
-      0x90020001,  //  0002  SETMBR	R0	K0	R1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Plugin_init,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(clusters),
-    /* K3   */  be_nested_str_weak(consolidate_clusters),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x8C100103,  //  0002  GETMET	R4	R0	K3
-      0x7C100200,  //  0003  CALL	R4	1
-      0x90020404,  //  0004  SETMBR	R0	K2	R4
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: read_event
-********************************************************************/
-be_local_closure(Matter_Plugin_read_event,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(read_event),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_types
-********************************************************************/
-be_local_closure(Matter_Plugin_get_types,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(TYPES),
-    }),
-    be_str_weak(get_types),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: ui_string_to_conf
-********************************************************************/
-be_local_closure(Matter_Plugin_ui_string_to_conf,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Plugin),
-    /* K1   */  be_nested_str_weak(ARG),
-    /* K2   */  be_nested_str_weak(ARG_TYPE),
-    }),
-    be_str_weak(ui_string_to_conf),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x580C0000,  //  0000  LDCONST	R3	K0
-      0x88100101,  //  0001  GETMBR	R4	R0	K1
-      0x88140102,  //  0002  GETMBR	R5	R0	K2
-      0x780A0004,  //  0003  JMPF	R2	#0009
-      0x78120003,  //  0004  JMPF	R4	#0009
-      0x5C180A00,  //  0005  MOVE	R6	R5
-      0x5C1C0400,  //  0006  MOVE	R7	R2
-      0x7C180200,  //  0007  CALL	R6	1
-      0x98040806,  //  0008  SETIDX	R1	R4	R6
-      0x80040200,  //  0009  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(Matter_Plugin_invoke_request,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x80040800,  //  0001  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_sensors
-********************************************************************/
-be_local_closure(Matter_Plugin_parse_sensors,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(parse_sensors),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_250ms
-********************************************************************/
-be_local_closure(Matter_Plugin_every_250ms,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(update_next),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(random),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_const_int(2147483647),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(millis),
-    /* K8   */  be_nested_str_weak(UPDATE_TIME),
-    /* K9   */  be_nested_str_weak(time_reached),
-    /* K10  */  be_nested_str_weak(update_shadow_lazy),
-    }),
-    be_str_weak(every_250ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x7806000F,  //  0003  JMPF	R1	#0014
-      0xA4060200,  //  0004  IMPORT	R1	K1
-      0x8C080302,  //  0005  GETMET	R2	R1	K2
-      0x54120003,  //  0006  LDINT	R4	4
-      0x7C080400,  //  0007  CALL	R2	2
-      0x8C080503,  //  0008  GETMET	R2	R2	K3
-      0x58100004,  //  0009  LDCONST	R4	K4
-      0x54160003,  //  000A  LDINT	R5	4
-      0x7C080600,  //  000B  CALL	R2	3
-      0x2C080505,  //  000C  AND	R2	R2	K5
-      0xB80E0C00,  //  000D  GETNGBL	R3	K6
-      0x8C0C0707,  //  000E  GETMET	R3	R3	K7
-      0x88140108,  //  000F  GETMBR	R5	R0	K8
-      0x10140405,  //  0010  MOD	R5	R2	R5
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x90020003,  //  0012  SETMBR	R0	K0	R3
-      0x7002000B,  //  0013  JMP		#0020
-      0xB8060C00,  //  0014  GETNGBL	R1	K6
-      0x8C040309,  //  0015  GETMET	R1	R1	K9
-      0x880C0100,  //  0016  GETMBR	R3	R0	K0
-      0x7C040400,  //  0017  CALL	R1	2
-      0x78060006,  //  0018  JMPF	R1	#0020
-      0x8C04010A,  //  0019  GETMET	R1	R0	K10
-      0x7C040200,  //  001A  CALL	R1	1
-      0xB8060C00,  //  001B  GETNGBL	R1	K6
-      0x8C040307,  //  001C  GETMET	R1	R1	K7
-      0x880C0108,  //  001D  GETMBR	R3	R0	K8
-      0x7C040400,  //  001E  CALL	R1	2
-      0x90020001,  //  001F  SETMBR	R0	K0	R1
-      0x80000000,  //  0020  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: ui_conf_to_string
 ********************************************************************/
 be_local_closure(Matter_Plugin_ui_conf_to_string,   /* name */
@@ -901,37 +940,66 @@ be_local_closure(Matter_Plugin_ui_conf_to_string,   /* name */
 
 
 /********************************************************************
+** Solidified function: get_types
+********************************************************************/
+be_local_closure(Matter_Plugin_get_types,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(TYPES),
+    }),
+    be_str_weak(get_types),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_Plugin
 ********************************************************************/
 be_local_class(Matter_Plugin,
     5,
     NULL,
-    be_nested_map(32,
+    be_nested_map(34,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(ARG_TYPE, 5), be_const_static_closure(Matter_Plugin__X3Clambda_X3E_closure) },
-        { be_const_key_weak(get_attribute_list, -1), be_const_closure(Matter_Plugin_get_attribute_list_closure) },
-        { be_const_key_weak(ui_conf_to_string, 11), be_const_static_closure(Matter_Plugin_ui_conf_to_string_closure) },
-        { be_const_key_weak(has, -1), be_const_closure(Matter_Plugin_has_closure) },
-        { be_const_key_weak(tick, -1), be_const_var(4) },
-        { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_Plugin_every_250ms_closure) },
+        { be_const_key_weak(every_250ms, 11), be_const_closure(Matter_Plugin_every_250ms_closure) },
+        { be_const_key_weak(get_cluster_list, 24), be_const_closure(Matter_Plugin_get_cluster_list_closure) },
         { be_const_key_weak(NAME, -1), be_nested_str_weak() },
-        { be_const_key_weak(ARG, 16), be_nested_str_weak() },
-        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(5000) },
-        { be_const_key_weak(get_endpoint, -1), be_const_closure(Matter_Plugin_get_endpoint_closure) },
-        { be_const_key_weak(timed_request, -1), be_const_closure(Matter_Plugin_timed_request_closure) },
-        { be_const_key_weak(clusters, 17), be_const_var(3) },
-        { be_const_key_weak(subscribe_event, 30), be_const_closure(Matter_Plugin_subscribe_event_closure) },
-        { be_const_key_weak(TYPE, -1), be_nested_str_weak() },
+        { be_const_key_weak(consolidate_clusters, -1), be_const_closure(Matter_Plugin_consolidate_clusters_closure) },
+        { be_const_key_weak(tick, -1), be_const_var(4) },
+        { be_const_key_weak(write_attribute, -1), be_const_closure(Matter_Plugin_write_attribute_closure) },
+        { be_const_key_weak(has, -1), be_const_closure(Matter_Plugin_has_closure) },
+        { be_const_key_weak(invoke_request, 6), be_const_closure(Matter_Plugin_invoke_request_closure) },
         { be_const_key_weak(parse_sensors, 29), be_const_closure(Matter_Plugin_parse_sensors_closure) },
         { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Plugin_attribute_updated_closure) },
-        { be_const_key_weak(get_cluster_list, -1), be_const_closure(Matter_Plugin_get_cluster_list_closure) },
-        { be_const_key_weak(ui_string_to_conf, 22), be_const_static_closure(Matter_Plugin_ui_string_to_conf_closure) },
-        { be_const_key_weak(device, -1), be_const_var(1) },
-        { be_const_key_weak(write_attribute, 23), be_const_closure(Matter_Plugin_write_attribute_closure) },
-        { be_const_key_weak(subscribe_attribute, -1), be_const_closure(Matter_Plugin_subscribe_attribute_closure) },
+        { be_const_key_weak(parse_update, -1), be_const_closure(Matter_Plugin_parse_update_closure) },
+        { be_const_key_weak(update_next, -1), be_const_var(0) },
+        { be_const_key_weak(update_shadow_lazy, -1), be_const_closure(Matter_Plugin_update_shadow_lazy_closure) },
+        { be_const_key_weak(get_endpoint, -1), be_const_closure(Matter_Plugin_get_endpoint_closure) },
+        { be_const_key_weak(clusters, 10), be_const_var(3) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_init_closure) },
+        { be_const_key_weak(read_event, 18), be_const_closure(Matter_Plugin_read_event_closure) },
+        { be_const_key_weak(read_attribute, 19), be_const_closure(Matter_Plugin_read_attribute_closure) },
+        { be_const_key_weak(ui_string_to_conf, -1), be_const_static_closure(Matter_Plugin_ui_string_to_conf_closure) },
+        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(5000) },
+        { be_const_key_weak(subscribe_event, -1), be_const_closure(Matter_Plugin_subscribe_event_closure) },
+        { be_const_key_weak(get_attribute_list, -1), be_const_closure(Matter_Plugin_get_attribute_list_closure) },
+        { be_const_key_weak(timed_request, -1), be_const_closure(Matter_Plugin_timed_request_closure) },
         { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_update_shadow_closure) },
-        { be_const_key_weak(read_event, 24), be_const_closure(Matter_Plugin_read_event_closure) },
-        { be_const_key_weak(init, 18), be_const_closure(Matter_Plugin_init_closure) },
+        { be_const_key_weak(device, -1), be_const_var(1) },
+        { be_const_key_weak(ARG, -1), be_nested_str_weak() },
         { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
@@ -946,13 +1014,13 @@ be_local_class(Matter_Plugin,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
+        { be_const_key_weak(probe_shadow_async, -1), be_const_closure(Matter_Plugin_probe_shadow_async_closure) },
+        { be_const_key_weak(ARG_TYPE, 17), be_const_static_closure(Matter_Plugin__X3Clambda_X3E_closure) },
+        { be_const_key_weak(subscribe_attribute, 3), be_const_closure(Matter_Plugin_subscribe_attribute_closure) },
+        { be_const_key_weak(ui_conf_to_string, -1), be_const_static_closure(Matter_Plugin_ui_conf_to_string_closure) },
+        { be_const_key_weak(TYPE, -1), be_nested_str_weak() },
+        { be_const_key_weak(endpoint, 4), be_const_var(2) },
         { be_const_key_weak(get_types, -1), be_const_closure(Matter_Plugin_get_types_closure) },
-        { be_const_key_weak(read_attribute, 2), be_const_closure(Matter_Plugin_read_attribute_closure) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_invoke_request_closure) },
-        { be_const_key_weak(update_next, 14), be_const_var(0) },
-        { be_const_key_weak(endpoint, 31), be_const_var(2) },
-        { be_const_key_weak(update_shadow_lazy, -1), be_const_closure(Matter_Plugin_update_shadow_lazy_closure) },
-        { be_const_key_weak(consolidate_clusters, -1), be_const_closure(Matter_Plugin_consolidate_clusters_closure) },
     })),
     be_str_weak(Matter_Plugin)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_HTTP.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_HTTP.h
@@ -7,6 +7,280 @@
 extern const bclass be_class_Matter_Plugin_Bridge_HTTP;
 
 /********************************************************************
+** Solidified function: ui_conf_to_string
+********************************************************************/
+be_local_closure(Matter_Plugin_Bridge_HTTP_ui_conf_to_string,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Plugin_Bridge_HTTP),
+    /* K1   */  be_nested_str_weak(ui_conf_to_string),
+    /* K2   */  be_nested_str_weak(find),
+    /* K3   */  be_nested_str_weak(ARG_HTTP),
+    /* K4   */  be_nested_str_weak(),
+    /* K5   */  be_nested_str_weak(_X2C),
+    }),
+    be_str_weak(ui_conf_to_string),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C0003,  //  0001  GETGBL	R3	G3
+      0x5C100400,  //  0002  MOVE	R4	R2
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x8C0C0701,  //  0004  GETMET	R3	R3	K1
+      0x5C140000,  //  0005  MOVE	R5	R0
+      0x5C180200,  //  0006  MOVE	R6	R1
+      0x7C0C0600,  //  0007  CALL	R3	3
+      0x60100008,  //  0008  GETGBL	R4	G8
+      0x8C140302,  //  0009  GETMET	R5	R1	K2
+      0x881C0503,  //  000A  GETMBR	R7	R2	K3
+      0x58200004,  //  000B  LDCONST	R8	K4
+      0x7C140600,  //  000C  CALL	R5	3
+      0x7C100200,  //  000D  CALL	R4	1
+      0x00140705,  //  000E  ADD	R5	R3	K5
+      0x00140A04,  //  000F  ADD	R5	R5	R4
+      0x80040A00,  //  0010  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Plugin_Bridge_HTTP_init,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        6,                          /* nstack */
+        2,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(parse_http_response),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 6]) {  /* code */
+          0x68080000,  //  0000  GETUPV	R2	U0
+          0x8C080500,  //  0001  GETMET	R2	R2	K0
+          0x5C100000,  //  0002  MOVE	R4	R0
+          0x5C140200,  //  0003  MOVE	R5	R1
+          0x7C080600,  //  0004  CALL	R2	3
+          0x80040400,  //  0005  RET	1	R2
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(init),
+    /* K2   */  be_nested_str_weak(find),
+    /* K3   */  be_nested_str_weak(ARG_HTTP),
+    /* K4   */  be_nested_str_weak(http_shadow_map),
+    /* K5   */  be_nested_str_weak(reachable),
+    /* K6   */  be_nested_str_weak(next_probe_timestamp),
+    /* K7   */  be_nested_str_weak(http_remote),
+    /* K8   */  be_nested_str_weak(matter),
+    /* K9   */  be_nested_str_weak(HTTP_remote),
+    /* K10  */  be_nested_str_weak(PROBE_TIMEOUT),
+    /* K11  */  be_nested_str_weak(set_cb),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[32]) {  /* code */
+      0xA4120000,  //  0000  IMPORT	R4	K0
+      0x60140003,  //  0001  GETGBL	R5	G3
+      0x5C180000,  //  0002  MOVE	R6	R0
+      0x7C140200,  //  0003  CALL	R5	1
+      0x8C140B01,  //  0004  GETMET	R5	R5	K1
+      0x5C1C0200,  //  0005  MOVE	R7	R1
+      0x5C200400,  //  0006  MOVE	R8	R2
+      0x5C240600,  //  0007  MOVE	R9	R3
+      0x7C140800,  //  0008  CALL	R5	4
+      0x8C140702,  //  0009  GETMET	R5	R3	K2
+      0x881C0103,  //  000A  GETMBR	R7	R0	K3
+      0x7C140400,  //  000B  CALL	R5	2
+      0x60180013,  //  000C  GETGBL	R6	G19
+      0x7C180000,  //  000D  CALL	R6	0
+      0x90020806,  //  000E  SETMBR	R0	K4	R6
+      0x50180000,  //  000F  LDBOOL	R6	0	0
+      0x90020A06,  //  0010  SETMBR	R0	K5	R6
+      0x4C180000,  //  0011  LDNIL	R6
+      0x90020C06,  //  0012  SETMBR	R0	K6	R6
+      0xB81A1000,  //  0013  GETNGBL	R6	K8
+      0x8C180D09,  //  0014  GETMET	R6	R6	K9
+      0x5C200A00,  //  0015  MOVE	R8	R5
+      0x5426004F,  //  0016  LDINT	R9	80
+      0x8828010A,  //  0017  GETMBR	R10	R0	K10
+      0x7C180800,  //  0018  CALL	R6	4
+      0x90020E06,  //  0019  SETMBR	R0	K7	R6
+      0x88180107,  //  001A  GETMBR	R6	R0	K7
+      0x8C180D0B,  //  001B  GETMET	R6	R6	K11
+      0x84200000,  //  001C  CLOSURE	R8	P0
+      0x7C180400,  //  001D  CALL	R6	2
+      0xA0000000,  //  001E  CLOSE	R0
+      0x80000000,  //  001F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_remote_status_lazy
+********************************************************************/
+be_local_closure(Matter_Plugin_Bridge_HTTP_get_remote_status_lazy,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(tick),
+    /* K2   */  be_nested_str_weak(http_shadow_map),
+    /* K3   */  be_nested_str_weak(find),
+    /* K4   */  be_nested_str_weak(_tick),
+    /* K5   */  be_nested_str_weak(call_remote_sync),
+    /* K6   */  be_nested_str_weak(Status),
+    }),
+    be_str_weak(get_remote_status_lazy),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x8C100903,  //  0003  GETMET	R4	R4	K3
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x7C100400,  //  0005  CALL	R4	2
+      0x78120005,  //  0006  JMPF	R4	#000D
+      0x8C140903,  //  0007  GETMET	R5	R4	K3
+      0x581C0004,  //  0008  LDCONST	R7	K4
+      0x7C140400,  //  0009  CALL	R5	2
+      0x1C140A03,  //  000A  EQ	R5	R5	R3
+      0x78160000,  //  000B  JMPF	R5	#000D
+      0x80040800,  //  000C  RET	1	R4
+      0x8C140105,  //  000D  GETMET	R5	R0	K5
+      0x581C0006,  //  000E  LDCONST	R7	K6
+      0x60200008,  //  000F  GETGBL	R8	G8
+      0x5C240200,  //  0010  MOVE	R9	R1
+      0x7C200200,  //  0011  CALL	R8	1
+      0x7C140600,  //  0012  CALL	R5	3
+      0x80040A00,  //  0013  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_http_response
+********************************************************************/
+be_local_closure(Matter_Plugin_Bridge_HTTP_parse_http_response,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(reachable),
+    /* K2   */  be_nested_str_weak(device),
+    /* K3   */  be_nested_str_weak(tick),
+    /* K4   */  be_nested_str_weak(reachable_tick),
+    /* K5   */  be_nested_str_weak(json),
+    /* K6   */  be_nested_str_weak(load),
+    /* K7   */  be_nested_str_weak(contains),
+    /* K8   */  be_nested_str_weak(StatusSNS),
+    /* K9   */  be_nested_str_weak(StatusSTS),
+    /* K10  */  be_nested_str_weak(StatusSHT),
+    /* K11  */  be_nested_str_weak(_tick),
+    /* K12  */  be_nested_str_weak(http_shadow_map),
+    /* K13  */  be_nested_str_weak(parse_update),
+    }),
+    be_str_weak(parse_http_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[44]) {  /* code */
+      0x240C0300,  //  0000  GT	R3	R1	K0
+      0x780E0028,  //  0001  JMPF	R3	#002B
+      0x500C0200,  //  0002  LDBOOL	R3	1	0
+      0x90020203,  //  0003  SETMBR	R0	K1	R3
+      0x880C0102,  //  0004  GETMBR	R3	R0	K2
+      0x880C0703,  //  0005  GETMBR	R3	R3	K3
+      0x90020803,  //  0006  SETMBR	R0	K4	R3
+      0xA4120A00,  //  0007  IMPORT	R4	K5
+      0x8C140906,  //  0008  GETMET	R5	R4	K6
+      0x5C1C0400,  //  0009  MOVE	R7	R2
+      0x7C140400,  //  000A  CALL	R5	2
+      0x4C180000,  //  000B  LDNIL	R6
+      0x7816001D,  //  000C  JMPF	R5	#002B
+      0x8C1C0B07,  //  000D  GETMET	R7	R5	K7
+      0x58240008,  //  000E  LDCONST	R9	K8
+      0x7C1C0400,  //  000F  CALL	R7	2
+      0x781E0002,  //  0010  JMPF	R7	#0014
+      0x94140B08,  //  0011  GETIDX	R5	R5	K8
+      0x541A0007,  //  0012  LDINT	R6	8
+      0x7002000C,  //  0013  JMP		#0021
+      0x8C1C0B07,  //  0014  GETMET	R7	R5	K7
+      0x58240009,  //  0015  LDCONST	R9	K9
+      0x7C1C0400,  //  0016  CALL	R7	2
+      0x781E0002,  //  0017  JMPF	R7	#001B
+      0x94140B09,  //  0018  GETIDX	R5	R5	K9
+      0x541A000A,  //  0019  LDINT	R6	11
+      0x70020005,  //  001A  JMP		#0021
+      0x8C1C0B07,  //  001B  GETMET	R7	R5	K7
+      0x5824000A,  //  001C  LDCONST	R9	K10
+      0x7C1C0400,  //  001D  CALL	R7	2
+      0x781E0001,  //  001E  JMPF	R7	#0021
+      0x94140B09,  //  001F  GETIDX	R5	R5	K9
+      0x541A000C,  //  0020  LDINT	R6	13
+      0x4C1C0000,  //  0021  LDNIL	R7
+      0x201C0C07,  //  0022  NE	R7	R6	R7
+      0x781E0002,  //  0023  JMPF	R7	#0027
+      0x98161603,  //  0024  SETIDX	R5	K11	R3
+      0x881C010C,  //  0025  GETMBR	R7	R0	K12
+      0x981C0C05,  //  0026  SETIDX	R7	R6	R5
+      0x8C1C010D,  //  0027  GETMET	R7	R0	K13
+      0x5C240A00,  //  0028  MOVE	R9	R5
+      0x5C280C00,  //  0029  MOVE	R10	R6
+      0x7C1C0600,  //  002A  CALL	R7	3
+      0x80000000,  //  002B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: get_types
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_HTTP_get_types,   /* name */
@@ -55,169 +329,6 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_get_types,   /* name */
 
 
 /********************************************************************
-** Solidified function: is_reachable
-********************************************************************/
-be_local_closure(Matter_Plugin_Bridge_HTTP_is_reachable,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(tick),
-    /* K2   */  be_nested_str_weak(reachable_tick),
-    /* K3   */  be_nested_str_weak(call_remote),
-    /* K4   */  be_nested_str_weak(),
-    /* K5   */  be_nested_str_weak(reachable),
-    }),
-    be_str_weak(is_reachable),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x88080102,  //  0002  GETMBR	R2	R0	K2
-      0x20040202,  //  0003  NE	R1	R1	R2
-      0x78060006,  //  0004  JMPF	R1	#000C
-      0x8C040103,  //  0005  GETMET	R1	R0	K3
-      0x580C0004,  //  0006  LDCONST	R3	K4
-      0x58100004,  //  0007  LDCONST	R4	K4
-      0x7C040600,  //  0008  CALL	R1	3
-      0x4C080000,  //  0009  LDNIL	R2
-      0x20080202,  //  000A  NE	R2	R1	R2
-      0x90020A02,  //  000B  SETMBR	R0	K5	R2
-      0x88040105,  //  000C  GETMBR	R1	R0	K5
-      0x80040200,  //  000D  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: read_attribute
-********************************************************************/
-be_local_closure(Matter_Plugin_Bridge_HTTP_read_attribute,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(TLV),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(create_TLV),
-    /* K6   */  be_nested_str_weak(BOOL),
-    /* K7   */  be_nested_str_weak(read_attribute),
-    }),
-    be_str_weak(read_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0xB80E0000,  //  0000  GETNGBL	R3	K0
-      0x880C0701,  //  0001  GETMBR	R3	R3	K1
-      0x88100502,  //  0002  GETMBR	R4	R2	K2
-      0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x541A0038,  //  0004  LDINT	R6	57
-      0x1C180806,  //  0005  EQ	R6	R4	R6
-      0x781A000B,  //  0006  JMPF	R6	#0013
-      0x1C180B04,  //  0007  EQ	R6	R5	K4
-      0x781A0000,  //  0008  JMPF	R6	#000A
-      0x70020007,  //  0009  JMP		#0012
-      0x541A0010,  //  000A  LDINT	R6	17
-      0x1C180A06,  //  000B  EQ	R6	R5	R6
-      0x781A0004,  //  000C  JMPF	R6	#0012
-      0x8C180705,  //  000D  GETMET	R6	R3	K5
-      0x88200706,  //  000E  GETMBR	R8	R3	K6
-      0x50240200,  //  000F  LDBOOL	R9	1	0
-      0x7C180600,  //  0010  CALL	R6	3
-      0x80040C00,  //  0011  RET	1	R6
-      0x70020007,  //  0012  JMP		#001B
-      0x60180003,  //  0013  GETGBL	R6	G3
-      0x5C1C0000,  //  0014  MOVE	R7	R0
-      0x7C180200,  //  0015  CALL	R6	1
-      0x8C180D07,  //  0016  GETMET	R6	R6	K7
-      0x5C200200,  //  0017  MOVE	R8	R1
-      0x5C240400,  //  0018  MOVE	R9	R2
-      0x7C180600,  //  0019  CALL	R6	3
-      0x80040C00,  //  001A  RET	1	R6
-      0x80000000,  //  001B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_status_11
-********************************************************************/
-be_local_closure(Matter_Plugin_Bridge_HTTP_get_status_11,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(tick),
-    /* K2   */  be_nested_str_weak(tasmota_status_11),
-    /* K3   */  be_nested_str_weak(find),
-    /* K4   */  be_nested_str_weak(_tick),
-    /* K5   */  be_nested_str_weak(call_remote),
-    /* K6   */  be_nested_str_weak(Status),
-    /* K7   */  be_nested_str_weak(11),
-    }),
-    be_str_weak(get_status_11),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x88080102,  //  0002  GETMBR	R2	R0	K2
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C080403,  //  0004  EQ	R2	R2	R3
-      0x740A0005,  //  0005  JMPT	R2	#000C
-      0x88080102,  //  0006  GETMBR	R2	R0	K2
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
-      0x58100004,  //  0008  LDCONST	R4	K4
-      0x7C080400,  //  0009  CALL	R2	2
-      0x20080401,  //  000A  NE	R2	R2	R1
-      0x780A000B,  //  000B  JMPF	R2	#0018
-      0x8C080105,  //  000C  GETMET	R2	R0	K5
-      0x58100006,  //  000D  LDCONST	R4	K6
-      0x58140007,  //  000E  LDCONST	R5	K7
-      0x7C080600,  //  000F  CALL	R2	3
-      0x780A0003,  //  0010  JMPF	R2	#0015
-      0x980A0801,  //  0011  SETIDX	R2	K4	R1
-      0x90020402,  //  0012  SETMBR	R0	K2	R2
-      0x80040400,  //  0013  RET	1	R2
-      0x70020001,  //  0014  JMP		#0017
-      0x4C0C0000,  //  0015  LDNIL	R3
-      0x80040600,  //  0016  RET	1	R3
-      0x70020001,  //  0017  JMP		#001A
-      0x88080102,  //  0018  GETMBR	R2	R0	K2
-      0x80040400,  //  0019  RET	1	R2
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: ui_string_to_conf
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_HTTP_ui_string_to_conf,   /* name */
@@ -243,7 +354,7 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_ui_string_to_conf,   /* name */
     }),
     be_str_weak(ui_string_to_conf),
     &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
+    ( &(const binstruction[19]) {  /* code */
       0x580C0000,  //  0000  LDCONST	R3	K0
       0xA4120200,  //  0001  IMPORT	R4	K1
       0x8C140902,  //  0002  GETMET	R5	R4	K2
@@ -262,12 +373,7 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_ui_string_to_conf,   /* name */
       0x5C240200,  //  000F  MOVE	R9	R1
       0x94280B08,  //  0010  GETIDX	R10	R5	K8
       0x7C180800,  //  0011  CALL	R6	4
-      0x60180001,  //  0012  GETGBL	R6	G1
-      0x581C0007,  //  0013  LDCONST	R7	K7
-      0x5C200200,  //  0014  MOVE	R8	R1
-      0x5C240400,  //  0015  MOVE	R9	R2
-      0x7C180600,  //  0016  CALL	R6	3
-      0x80040200,  //  0017  RET	1	R1
+      0x80040200,  //  0012  RET	1	R1
     })
   )
 );
@@ -275,11 +381,35 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_ui_string_to_conf,   /* name */
 
 
 /********************************************************************
-** Solidified function: call_remote
+** Solidified function: probe_shadow_async
 ********************************************************************/
-be_local_closure(Matter_Plugin_Bridge_HTTP_call_remote,   /* name */
+be_local_closure(Matter_Plugin_Bridge_HTTP_probe_shadow_async,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(probe_shadow_async),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_attribute
+********************************************************************/
+be_local_closure(Matter_Plugin_Bridge_HTTP_read_attribute,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -287,133 +417,48 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_call_remote,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[31]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota_http),
-    /* K1   */  be_nested_str_weak(json),
-    /* K2   */  be_nested_str_weak(string),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(wifi),
-    /* K5   */  be_nested_str_weak(up),
-    /* K6   */  be_nested_str_weak(eth),
-    /* K7   */  be_const_int(2),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(webclient),
-    /* K10  */  be_nested_str_weak(set_timeouts),
-    /* K11  */  be_nested_str_weak(set_follow_redirects),
-    /* K12  */  be_nested_str_weak(format),
-    /* K13  */  be_nested_str_weak(_X25scm_X3Fcmnd_X3D_X25s_X25_X2520_X25s),
-    /* K14  */  be_nested_str_weak(),
-    /* K15  */  be_nested_str_weak(log),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20GET_X20),
-    /* K17  */  be_const_int(3),
-    /* K18  */  be_nested_str_weak(begin),
-    /* K19  */  be_nested_str_weak(GET),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20GET_X20code_X3D),
-    /* K21  */  be_nested_str_weak(get_string),
-    /* K22  */  be_nested_str_weak(close),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20GET_X20payload_X3D),
-    /* K24  */  be_nested_str_weak(load),
-    /* K25  */  be_nested_str_weak(reachable),
-    /* K26  */  be_nested_str_weak(reachable_tick),
-    /* K27  */  be_nested_str_weak(device),
-    /* K28  */  be_nested_str_weak(tick),
-    /* K29  */  be_const_int(1),
-    /* K30  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20GET_X20retrying),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(create_TLV),
+    /* K6   */  be_nested_str_weak(BOOL),
+    /* K7   */  be_nested_str_weak(reachable),
+    /* K8   */  be_nested_str_weak(read_attribute),
     }),
-    be_str_weak(call_remote),
+    be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[91]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x740E0001,  //  0001  JMPT	R3	#0004
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x80040600,  //  0003  RET	1	R3
-      0xA40E0200,  //  0004  IMPORT	R3	K1
-      0xA4120400,  //  0005  IMPORT	R4	K2
-      0xB8160600,  //  0006  GETNGBL	R5	K3
-      0x8C140B04,  //  0007  GETMET	R5	R5	K4
-      0x7C140200,  //  0008  CALL	R5	1
-      0x94140B05,  //  0009  GETIDX	R5	R5	K5
-      0x74160006,  //  000A  JMPT	R5	#0012
-      0xB8160600,  //  000B  GETNGBL	R5	K3
-      0x8C140B06,  //  000C  GETMET	R5	R5	K6
-      0x7C140200,  //  000D  CALL	R5	1
-      0x94140B05,  //  000E  GETIDX	R5	R5	K5
-      0x74160001,  //  000F  JMPT	R5	#0012
-      0x4C140000,  //  0010  LDNIL	R5
-      0x80040A00,  //  0011  RET	1	R5
-      0x58140007,  //  0012  LDCONST	R5	K7
-      0x24180B08,  //  0013  GT	R6	R5	K8
-      0x781A0041,  //  0014  JMPF	R6	#0057
-      0xB81A1200,  //  0015  GETNGBL	R6	K9
-      0x7C180000,  //  0016  CALL	R6	0
-      0x8C1C0D0A,  //  0017  GETMET	R7	R6	K10
-      0x542603E7,  //  0018  LDINT	R9	1000
-      0x542A03E7,  //  0019  LDINT	R10	1000
-      0x7C1C0600,  //  001A  CALL	R7	3
-      0x8C1C0D0B,  //  001B  GETMET	R7	R6	K11
-      0x50240000,  //  001C  LDBOOL	R9	0	0
-      0x7C1C0400,  //  001D  CALL	R7	2
-      0x8C1C090C,  //  001E  GETMET	R7	R4	K12
-      0x5824000D,  //  001F  LDCONST	R9	K13
-      0x88280100,  //  0020  GETMBR	R10	R0	K0
-      0x5C2C0200,  //  0021  MOVE	R11	R1
-      0x780A0001,  //  0022  JMPF	R2	#0025
-      0x5C300400,  //  0023  MOVE	R12	R2
-      0x70020000,  //  0024  JMP		#0026
-      0x5830000E,  //  0025  LDCONST	R12	K14
-      0x7C1C0A00,  //  0026  CALL	R7	5
-      0xB8220600,  //  0027  GETNGBL	R8	K3
-      0x8C20110F,  //  0028  GETMET	R8	R8	K15
-      0x002A2007,  //  0029  ADD	R10	K16	R7
-      0x582C0011,  //  002A  LDCONST	R11	K17
-      0x7C200600,  //  002B  CALL	R8	3
-      0x8C200D12,  //  002C  GETMET	R8	R6	K18
-      0x5C280E00,  //  002D  MOVE	R10	R7
-      0x7C200400,  //  002E  CALL	R8	2
-      0x8C200D13,  //  002F  GETMET	R8	R6	K19
-      0x7C200200,  //  0030  CALL	R8	1
-      0xB8260600,  //  0031  GETNGBL	R9	K3
-      0x8C24130F,  //  0032  GETMET	R9	R9	K15
-      0x602C0008,  //  0033  GETGBL	R11	G8
-      0x5C301000,  //  0034  MOVE	R12	R8
-      0x7C2C0200,  //  0035  CALL	R11	1
-      0x002E280B,  //  0036  ADD	R11	K20	R11
-      0x58300011,  //  0037  LDCONST	R12	K17
-      0x7C240600,  //  0038  CALL	R9	3
-      0x542600C7,  //  0039  LDINT	R9	200
-      0x1C241009,  //  003A  EQ	R9	R8	R9
-      0x78260011,  //  003B  JMPF	R9	#004E
-      0x8C240D15,  //  003C  GETMET	R9	R6	K21
-      0x7C240200,  //  003D  CALL	R9	1
-      0x8C280D16,  //  003E  GETMET	R10	R6	K22
-      0x7C280200,  //  003F  CALL	R10	1
-      0xB82A0600,  //  0040  GETNGBL	R10	K3
-      0x8C28150F,  //  0041  GETMET	R10	R10	K15
-      0x00322E09,  //  0042  ADD	R12	K23	R9
-      0x58340011,  //  0043  LDCONST	R13	K17
-      0x7C280600,  //  0044  CALL	R10	3
-      0x8C280718,  //  0045  GETMET	R10	R3	K24
-      0x5C301200,  //  0046  MOVE	R12	R9
-      0x7C280400,  //  0047  CALL	R10	2
-      0x502C0200,  //  0048  LDBOOL	R11	1	0
-      0x9002320B,  //  0049  SETMBR	R0	K25	R11
-      0x882C011B,  //  004A  GETMBR	R11	R0	K27
-      0x882C171C,  //  004B  GETMBR	R11	R11	K28
-      0x9002340B,  //  004C  SETMBR	R0	K26	R11
-      0x80041400,  //  004D  RET	1	R10
-      0x8C240D16,  //  004E  GETMET	R9	R6	K22
-      0x7C240200,  //  004F  CALL	R9	1
-      0x04140B1D,  //  0050  SUB	R5	R5	K29
-      0xB8260600,  //  0051  GETNGBL	R9	K3
-      0x8C24130F,  //  0052  GETMET	R9	R9	K15
-      0x582C001E,  //  0053  LDCONST	R11	K30
-      0x58300011,  //  0054  LDCONST	R12	K17
-      0x7C240600,  //  0055  CALL	R9	3
-      0x7001FFBB,  //  0056  JMP		#0013
-      0x50180000,  //  0057  LDBOOL	R6	0	0
-      0x90023206,  //  0058  SETMBR	R0	K25	R6
-      0x4C180000,  //  0059  LDNIL	R6
-      0x80040C00,  //  005A  RET	1	R6
+    ( &(const binstruction[28]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
+      0x88140503,  //  0003  GETMBR	R5	R2	K3
+      0x541A0038,  //  0004  LDINT	R6	57
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A000B,  //  0006  JMPF	R6	#0013
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A0000,  //  0008  JMPF	R6	#000A
+      0x70020007,  //  0009  JMP		#0012
+      0x541A0010,  //  000A  LDINT	R6	17
+      0x1C180A06,  //  000B  EQ	R6	R5	R6
+      0x781A0004,  //  000C  JMPF	R6	#0012
+      0x8C180705,  //  000D  GETMET	R6	R3	K5
+      0x88200706,  //  000E  GETMBR	R8	R3	K6
+      0x88240107,  //  000F  GETMBR	R9	R0	K7
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80040C00,  //  0011  RET	1	R6
+      0x70020007,  //  0012  JMP		#001B
+      0x60180003,  //  0013  GETGBL	R6	G3
+      0x5C1C0000,  //  0014  MOVE	R7	R0
+      0x7C180200,  //  0015  CALL	R6	1
+      0x8C180D08,  //  0016  GETMET	R6	R6	K8
+      0x5C200200,  //  0017  MOVE	R8	R1
+      0x5C240400,  //  0018  MOVE	R9	R2
+      0x7C180600,  //  0019  CALL	R6	3
+      0x80040C00,  //  001A  RET	1	R6
+      0x80000000,  //  001B  RET	0
     })
   )
 );
@@ -421,11 +466,11 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_call_remote,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_status_8
+** Solidified function: is_reachable_sync
 ********************************************************************/
-be_local_closure(Matter_Plugin_Bridge_HTTP_get_status_8,   /* name */
+be_local_closure(Matter_Plugin_Bridge_HTTP_is_reachable_sync,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -433,46 +478,31 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_get_status_8,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
     /* K1   */  be_nested_str_weak(tick),
-    /* K2   */  be_nested_str_weak(tasmota_status_8),
-    /* K3   */  be_nested_str_weak(find),
-    /* K4   */  be_nested_str_weak(_tick),
-    /* K5   */  be_nested_str_weak(call_remote),
-    /* K6   */  be_nested_str_weak(Status),
-    /* K7   */  be_nested_str_weak(8),
+    /* K2   */  be_nested_str_weak(reachable_tick),
+    /* K3   */  be_nested_str_weak(call_remote_sync),
+    /* K4   */  be_nested_str_weak(),
+    /* K5   */  be_nested_str_weak(reachable),
     }),
-    be_str_weak(get_status_8),
+    be_str_weak(is_reachable_sync),
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
+    ( &(const binstruction[14]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x88040301,  //  0001  GETMBR	R1	R1	K1
       0x88080102,  //  0002  GETMBR	R2	R0	K2
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C080403,  //  0004  EQ	R2	R2	R3
-      0x740A0005,  //  0005  JMPT	R2	#000C
-      0x88080102,  //  0006  GETMBR	R2	R0	K2
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
-      0x58100004,  //  0008  LDCONST	R4	K4
-      0x7C080400,  //  0009  CALL	R2	2
-      0x20080401,  //  000A  NE	R2	R2	R1
-      0x780A000B,  //  000B  JMPF	R2	#0018
-      0x8C080105,  //  000C  GETMET	R2	R0	K5
-      0x58100006,  //  000D  LDCONST	R4	K6
-      0x58140007,  //  000E  LDCONST	R5	K7
-      0x7C080600,  //  000F  CALL	R2	3
-      0x780A0003,  //  0010  JMPF	R2	#0015
-      0x980A0801,  //  0011  SETIDX	R2	K4	R1
-      0x90020402,  //  0012  SETMBR	R0	K2	R2
-      0x80040400,  //  0013  RET	1	R2
-      0x70020001,  //  0014  JMP		#0017
-      0x4C0C0000,  //  0015  LDNIL	R3
-      0x80040600,  //  0016  RET	1	R3
-      0x70020001,  //  0017  JMP		#001A
-      0x88080102,  //  0018  GETMBR	R2	R0	K2
-      0x80040400,  //  0019  RET	1	R2
-      0x80000000,  //  001A  RET	0
+      0x20040202,  //  0003  NE	R1	R1	R2
+      0x78060006,  //  0004  JMPF	R1	#000C
+      0x8C040103,  //  0005  GETMET	R1	R0	K3
+      0x580C0004,  //  0006  LDCONST	R3	K4
+      0x58100004,  //  0007  LDCONST	R4	K4
+      0x7C040600,  //  0008  CALL	R1	3
+      0x4C080000,  //  0009  LDNIL	R2
+      0x20080202,  //  000A  NE	R2	R1	R2
+      0x90020A02,  //  000B  SETMBR	R0	K5	R2
+      0x88040105,  //  000C  GETMBR	R1	R0	K5
+      0x80040200,  //  000D  RET	1	R1
     })
   )
 );
@@ -480,133 +510,155 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_get_status_8,   /* name */
 
 
 /********************************************************************
-** Solidified function: ui_conf_to_string
+** Solidified function: call_remote_sync
 ********************************************************************/
-be_local_closure(Matter_Plugin_Bridge_HTTP_ui_conf_to_string,   /* name */
+be_local_closure(Matter_Plugin_Bridge_HTTP_call_remote_sync,   /* name */
   be_nested_proto(
     11,                          /* nstack */
-    2,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Plugin_Bridge_HTTP),
-    /* K1   */  be_nested_str_weak(ui_conf_to_string),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(ARG_HTTP),
-    /* K4   */  be_nested_str_weak(),
-    /* K5   */  be_nested_str_weak(_X2C),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20ui_conf_to_string),
-    }),
-    be_str_weak(ui_conf_to_string),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C0003,  //  0001  GETGBL	R3	G3
-      0x5C100400,  //  0002  MOVE	R4	R2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0701,  //  0004  GETMET	R3	R3	K1
-      0x5C140000,  //  0005  MOVE	R5	R0
-      0x5C180200,  //  0006  MOVE	R6	R1
-      0x7C0C0600,  //  0007  CALL	R3	3
-      0x60100008,  //  0008  GETGBL	R4	G8
-      0x8C140302,  //  0009  GETMET	R5	R1	K2
-      0x881C0503,  //  000A  GETMBR	R7	R2	K3
-      0x58200004,  //  000B  LDCONST	R8	K4
-      0x7C140600,  //  000C  CALL	R5	3
-      0x7C100200,  //  000D  CALL	R4	1
-      0x00140705,  //  000E  ADD	R5	R3	K5
-      0x00140A04,  //  000F  ADD	R5	R5	R4
-      0x60180001,  //  0010  GETGBL	R6	G1
-      0x581C0006,  //  0011  LDCONST	R7	K6
-      0x5C200200,  //  0012  MOVE	R8	R1
-      0x5C240000,  //  0013  MOVE	R9	R0
-      0x5C280A00,  //  0014  MOVE	R10	R5
-      0x7C180800,  //  0015  CALL	R6	4
-      0x80040A00,  //  0016  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Plugin_Bridge_HTTP_init,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
+    ( &(const bvalue[21]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(init),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(ARG_HTTP),
-    /* K4   */  be_nested_str_weak(_X3A_X2F_X2F),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(http_X3A_X2F_X2F),
-    /* K7   */  be_nested_str_weak(_X2F),
-    /* K8   */  be_nested_str_weak(tasmota_http),
-    /* K9   */  be_nested_str_weak(tasmota),
-    /* K10  */  be_nested_str_weak(log),
-    /* K11  */  be_nested_str_weak(format),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20ERROR_X3A_X20_X27url_X27_X20is_X20not_X20configured_X20for_X20endpoint_X20_X25i),
-    /* K13  */  be_const_int(2),
-    /* K14  */  be_nested_str_weak(tasmota_status_8),
-    /* K15  */  be_nested_str_weak(tasmota_status_11),
-    /* K16  */  be_nested_str_weak(reachable),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(wifi),
+    /* K3   */  be_nested_str_weak(up),
+    /* K4   */  be_nested_str_weak(eth),
+    /* K5   */  be_const_int(2),
+    /* K6   */  be_nested_str_weak(format),
+    /* K7   */  be_nested_str_weak(_X2Fcm_X3Fcmnd_X3D_X25s_X25_X2520_X25s),
+    /* K8   */  be_nested_str_weak(),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_nested_str_weak(http_remote),
+    /* K11  */  be_nested_str_weak(begin_sync),
+    /* K12  */  be_nested_str_weak(SYNC_TIMEOUT),
+    /* K13  */  be_nested_str_weak(reachable),
+    /* K14  */  be_nested_str_weak(reachable_tick),
+    /* K15  */  be_nested_str_weak(device),
+    /* K16  */  be_nested_str_weak(tick),
+    /* K17  */  be_const_int(1),
+    /* K18  */  be_nested_str_weak(log),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20GET_X20retrying),
+    /* K20  */  be_const_int(3),
     }),
-    be_str_weak(init),
+    be_str_weak(call_remote_sync),
     &be_const_str_solidified,
-    ( &(const binstruction[39]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0x60140003,  //  0001  GETGBL	R5	G3
-      0x5C180000,  //  0002  MOVE	R6	R0
-      0x7C140200,  //  0003  CALL	R5	1
-      0x8C140B01,  //  0004  GETMET	R5	R5	K1
-      0x5C1C0200,  //  0005  MOVE	R7	R1
-      0x5C200400,  //  0006  MOVE	R8	R2
-      0x5C240600,  //  0007  MOVE	R9	R3
-      0x7C140800,  //  0008  CALL	R5	4
-      0x8C140702,  //  0009  GETMET	R5	R3	K2
-      0x881C0103,  //  000A  GETMBR	R7	R0	K3
-      0x7C140400,  //  000B  CALL	R5	2
-      0x7816000A,  //  000C  JMPF	R5	#0018
-      0x8C180902,  //  000D  GETMET	R6	R4	K2
-      0x5C200A00,  //  000E  MOVE	R8	R5
-      0x58240004,  //  000F  LDCONST	R9	K4
-      0x7C180600,  //  0010  CALL	R6	3
-      0x14180D05,  //  0011  LT	R6	R6	K5
-      0x781A0002,  //  0012  JMPF	R6	#0016
-      0x001A0C05,  //  0013  ADD	R6	K6	R5
-      0x00180D07,  //  0014  ADD	R6	R6	K7
-      0x5C140C00,  //  0015  MOVE	R5	R6
-      0x90021005,  //  0016  SETMBR	R0	K8	R5
-      0x70020007,  //  0017  JMP		#0020
-      0xB81A1200,  //  0018  GETNGBL	R6	K9
-      0x8C180D0A,  //  0019  GETMET	R6	R6	K10
-      0x8C20090B,  //  001A  GETMET	R8	R4	K11
-      0x5828000C,  //  001B  LDCONST	R10	K12
-      0x5C2C0400,  //  001C  MOVE	R11	R2
-      0x7C200600,  //  001D  CALL	R8	3
-      0x5824000D,  //  001E  LDCONST	R9	K13
-      0x7C180600,  //  001F  CALL	R6	3
-      0x4C180000,  //  0020  LDNIL	R6
-      0x90021C06,  //  0021  SETMBR	R0	K14	R6
-      0x4C180000,  //  0022  LDNIL	R6
-      0x90021E06,  //  0023  SETMBR	R0	K15	R6
-      0x50180000,  //  0024  LDBOOL	R6	0	0
-      0x90022006,  //  0025  SETMBR	R0	K16	R6
-      0x80000000,  //  0026  RET	0
+    ( &(const binstruction[49]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x94100903,  //  0004  GETIDX	R4	R4	K3
+      0x74120006,  //  0005  JMPT	R4	#000D
+      0xB8120200,  //  0006  GETNGBL	R4	K1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x94100903,  //  0009  GETIDX	R4	R4	K3
+      0x74120001,  //  000A  JMPT	R4	#000D
+      0x4C100000,  //  000B  LDNIL	R4
+      0x80040800,  //  000C  RET	1	R4
+      0x58100005,  //  000D  LDCONST	R4	K5
+      0x8C140706,  //  000E  GETMET	R5	R3	K6
+      0x581C0007,  //  000F  LDCONST	R7	K7
+      0x5C200200,  //  0010  MOVE	R8	R1
+      0x780A0001,  //  0011  JMPF	R2	#0014
+      0x5C240400,  //  0012  MOVE	R9	R2
+      0x70020000,  //  0013  JMP		#0015
+      0x58240008,  //  0014  LDCONST	R9	K8
+      0x7C140800,  //  0015  CALL	R5	4
+      0x24180909,  //  0016  GT	R6	R4	K9
+      0x781A0014,  //  0017  JMPF	R6	#002D
+      0x8818010A,  //  0018  GETMBR	R6	R0	K10
+      0x8C180D0B,  //  0019  GETMET	R6	R6	K11
+      0x5C200A00,  //  001A  MOVE	R8	R5
+      0x8824010C,  //  001B  GETMBR	R9	R0	K12
+      0x7C180600,  //  001C  CALL	R6	3
+      0x4C1C0000,  //  001D  LDNIL	R7
+      0x201C0C07,  //  001E  NE	R7	R6	R7
+      0x781E0005,  //  001F  JMPF	R7	#0026
+      0x501C0200,  //  0020  LDBOOL	R7	1	0
+      0x90021A07,  //  0021  SETMBR	R0	K13	R7
+      0x881C010F,  //  0022  GETMBR	R7	R0	K15
+      0x881C0F10,  //  0023  GETMBR	R7	R7	K16
+      0x90021C07,  //  0024  SETMBR	R0	K14	R7
+      0x80040C00,  //  0025  RET	1	R6
+      0x04100911,  //  0026  SUB	R4	R4	K17
+      0xB81E0200,  //  0027  GETNGBL	R7	K1
+      0x8C1C0F12,  //  0028  GETMET	R7	R7	K18
+      0x58240013,  //  0029  LDCONST	R9	K19
+      0x58280014,  //  002A  LDCONST	R10	K20
+      0x7C1C0600,  //  002B  CALL	R7	3
+      0x7001FFE8,  //  002C  JMP		#0016
+      0x50180000,  //  002D  LDBOOL	R6	0	0
+      0x90021A06,  //  002E  SETMBR	R0	K13	R6
+      0x4C180000,  //  002F  LDNIL	R6
+      0x80040C00,  //  0030  RET	1	R6
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: call_remote_async
+********************************************************************/
+be_local_closure(Matter_Plugin_Bridge_HTTP_call_remote_async,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(wifi),
+    /* K3   */  be_nested_str_weak(up),
+    /* K4   */  be_nested_str_weak(eth),
+    /* K5   */  be_nested_str_weak(format),
+    /* K6   */  be_nested_str_weak(_X2Fcm_X3Fcmnd_X3D_X25s_X25_X2520_X25s),
+    /* K7   */  be_nested_str_weak(),
+    /* K8   */  be_nested_str_weak(http_remote),
+    /* K9   */  be_nested_str_weak(begin),
+    /* K10  */  be_nested_str_weak(PROBE_TIMEOUT),
+    }),
+    be_str_weak(call_remote_async),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x94100903,  //  0004  GETIDX	R4	R4	K3
+      0x74120006,  //  0005  JMPT	R4	#000D
+      0xB8120200,  //  0006  GETNGBL	R4	K1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x94100903,  //  0009  GETIDX	R4	R4	K3
+      0x74120001,  //  000A  JMPT	R4	#000D
+      0x4C100000,  //  000B  LDNIL	R4
+      0x80040800,  //  000C  RET	1	R4
+      0x8C100705,  //  000D  GETMET	R4	R3	K5
+      0x58180006,  //  000E  LDCONST	R6	K6
+      0x5C1C0200,  //  000F  MOVE	R7	R1
+      0x780A0001,  //  0010  JMPF	R2	#0013
+      0x5C200400,  //  0011  MOVE	R8	R2
+      0x70020000,  //  0012  JMP		#0014
+      0x58200007,  //  0013  LDCONST	R8	K7
+      0x7C100800,  //  0014  CALL	R4	4
+      0x88140108,  //  0015  GETMBR	R5	R0	K8
+      0x8C140B09,  //  0016  GETMET	R5	R5	K9
+      0x5C1C0800,  //  0017  MOVE	R7	R4
+      0x8820010A,  //  0018  GETMBR	R8	R0	K10
+      0x7C140600,  //  0019  CALL	R5	3
+      0x80000000,  //  001A  RET	0
     })
   )
 );
@@ -620,16 +672,25 @@ extern const bclass be_class_Matter_Plugin_Device;
 be_local_class(Matter_Plugin_Bridge_HTTP,
     5,
     &be_class_Matter_Plugin_Device,
-    be_nested_map(21,
+    be_nested_map(24,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(get_types, 20), be_const_closure(Matter_Plugin_Bridge_HTTP_get_types_closure) },
-        { be_const_key_weak(is_reachable, -1), be_const_closure(Matter_Plugin_Bridge_HTTP_is_reachable_closure) },
-        { be_const_key_weak(tasmota_http, -1), be_const_var(0) },
+        { be_const_key_weak(ARG_HTTP, 1), be_nested_str_weak(url) },
+        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(3000) },
+        { be_const_key_weak(SYNC_TIMEOUT, -1), be_const_int(500) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Bridge_HTTP_init_closure) },
-        { be_const_key_weak(reachable_tick, -1), be_const_var(4) },
-        { be_const_key_weak(get_status_8, 6), be_const_closure(Matter_Plugin_Bridge_HTTP_get_status_8_closure) },
-        { be_const_key_weak(tasmota_status_11, -1), be_const_var(2) },
-        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(get_remote_status_lazy, 19), be_const_closure(Matter_Plugin_Bridge_HTTP_get_remote_status_lazy_closure) },
+        { be_const_key_weak(parse_http_response, -1), be_const_closure(Matter_Plugin_Bridge_HTTP_parse_http_response_closure) },
+        { be_const_key_weak(NAME, -1), be_nested_str_weak() },
+        { be_const_key_weak(call_remote_sync, 16), be_const_closure(Matter_Plugin_Bridge_HTTP_call_remote_sync_closure) },
+        { be_const_key_weak(reachable, -1), be_const_var(0) },
+        { be_const_key_weak(get_types, 12), be_const_closure(Matter_Plugin_Bridge_HTTP_get_types_closure) },
+        { be_const_key_weak(ui_conf_to_string, 7), be_const_static_closure(Matter_Plugin_Bridge_HTTP_ui_conf_to_string_closure) },
+        { be_const_key_weak(http_shadow_map, -1), be_const_var(2) },
+        { be_const_key_weak(probe_shadow_async, -1), be_const_closure(Matter_Plugin_Bridge_HTTP_probe_shadow_async_closure) },
+        { be_const_key_weak(TYPE, 14), be_nested_str_weak() },
+        { be_const_key_weak(PROBE_TIMEOUT, -1), be_const_int(700) },
+        { be_const_key_weak(ARG, -1), be_nested_str_weak() },
+        { be_const_key_weak(CLUSTERS, 22), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
@@ -638,19 +699,13 @@ be_local_class(Matter_Plugin_Bridge_HTTP,
         be_const_int(17),
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(NAME, -1), be_nested_str_weak() },
-        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(3000) },
-        { be_const_key_weak(TYPE, -1), be_nested_str_weak() },
-        { be_const_key_weak(reachable, -1), be_const_var(3) },
-        { be_const_key_weak(ARG_HTTP, 3), be_nested_str_weak(url) },
-        { be_const_key_weak(ui_string_to_conf, -1), be_const_static_closure(Matter_Plugin_Bridge_HTTP_ui_string_to_conf_closure) },
-        { be_const_key_weak(tasmota_status_8, 18), be_const_var(1) },
-        { be_const_key_weak(ARG, 8), be_nested_str_weak() },
-        { be_const_key_weak(call_remote, -1), be_const_closure(Matter_Plugin_Bridge_HTTP_call_remote_closure) },
-        { be_const_key_weak(get_status_11, 5), be_const_closure(Matter_Plugin_Bridge_HTTP_get_status_11_closure) },
-        { be_const_key_weak(HTTP_TIMEOUT, 4), be_const_int(300) },
-        { be_const_key_weak(ui_conf_to_string, -1), be_const_static_closure(Matter_Plugin_Bridge_HTTP_ui_conf_to_string_closure) },
         { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Bridge_HTTP_read_attribute_closure) },
+        { be_const_key_weak(next_probe_timestamp, 17), be_const_var(4) },
+        { be_const_key_weak(http_remote, -1), be_const_var(3) },
+        { be_const_key_weak(reachable_tick, -1), be_const_var(1) },
+        { be_const_key_weak(is_reachable_sync, -1), be_const_closure(Matter_Plugin_Bridge_HTTP_is_reachable_sync_closure) },
+        { be_const_key_weak(ui_string_to_conf, -1), be_const_static_closure(Matter_Plugin_Bridge_HTTP_ui_string_to_conf_closure) },
+        { be_const_key_weak(call_remote_async, -1), be_const_closure(Matter_Plugin_Bridge_HTTP_call_remote_async_closure) },
     })),
     be_str_weak(Matter_Plugin_Bridge_HTTP)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_OnOff.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_OnOff.h
@@ -7,33 +7,6 @@
 extern const bclass be_class_Matter_Plugin_Bridge_OnOff;
 
 /********************************************************************
-** Solidified function: <lambda>
-********************************************************************/
-be_local_closure(Matter_Plugin_Bridge_OnOff__X3Clambda_X3E,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(_X3Clambda_X3E),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x60040009,  //  0000  GETGBL	R1	G9
-      0x5C080000,  //  0001  MOVE	R2	R0
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: init
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_OnOff_init,   /* name */
@@ -86,38 +59,52 @@ be_local_closure(Matter_Plugin_Bridge_OnOff_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_onoff
+** Solidified function: parse_update
 ********************************************************************/
-be_local_closure(Matter_Plugin_Bridge_OnOff_set_onoff,   /* name */
+be_local_closure(Matter_Plugin_Bridge_OnOff_parse_update,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
+    8,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(call_remote),
-    /* K1   */  be_nested_str_weak(Power),
-    /* K2   */  be_nested_str_weak(1),
-    /* K3   */  be_nested_str_weak(0),
-    /* K4   */  be_nested_str_weak(update_shadow),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(find),
+    /* K1   */  be_nested_str_weak(POWER),
+    /* K2   */  be_nested_str_weak(ON),
+    /* K3   */  be_nested_str_weak(shadow_onoff),
+    /* K4   */  be_nested_str_weak(attribute_updated),
+    /* K5   */  be_const_int(0),
     }),
-    be_str_weak(set_onoff),
+    be_str_weak(parse_update),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x58100001,  //  0001  LDCONST	R4	K1
-      0x78060001,  //  0002  JMPF	R1	#0005
-      0x58140002,  //  0003  LDCONST	R5	K2
-      0x70020000,  //  0004  JMP		#0006
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x7C080600,  //  0006  CALL	R2	3
-      0x8C080104,  //  0007  GETMET	R2	R0	K4
-      0x7C080200,  //  0008  CALL	R2	1
-      0x80000000,  //  0009  RET	0
+    ( &(const binstruction[23]) {  /* code */
+      0x540E000A,  //  0000  LDINT	R3	11
+      0x1C0C0403,  //  0001  EQ	R3	R2	R3
+      0x780E0012,  //  0002  JMPF	R3	#0016
+      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
+      0x58140001,  //  0004  LDCONST	R5	K1
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x1C0C0702,  //  0006  EQ	R3	R3	K2
+      0x88100103,  //  0007  GETMBR	R4	R0	K3
+      0x4C140000,  //  0008  LDNIL	R5
+      0x20100805,  //  0009  NE	R4	R4	R5
+      0x78120009,  //  000A  JMPF	R4	#0015
+      0x88100103,  //  000B  GETMBR	R4	R0	K3
+      0x60140017,  //  000C  GETGBL	R5	G23
+      0x5C180600,  //  000D  MOVE	R6	R3
+      0x7C140200,  //  000E  CALL	R5	1
+      0x20100805,  //  000F  NE	R4	R4	R5
+      0x78120003,  //  0010  JMPF	R4	#0015
+      0x8C100104,  //  0011  GETMET	R4	R0	K4
+      0x541A0005,  //  0012  LDINT	R6	6
+      0x581C0005,  //  0013  LDCONST	R7	K5
+      0x7C100600,  //  0014  CALL	R4	3
+      0x90020603,  //  0015  SETMBR	R0	K3	R3
+      0x80000000,  //  0016  RET	0
     })
   )
 );
@@ -195,6 +182,104 @@ be_local_closure(Matter_Plugin_Bridge_OnOff_invoke_request,   /* name */
       0x501C0200,  //  0027  LDBOOL	R7	1	0
       0x80040E00,  //  0028  RET	1	R7
       0x80000000,  //  0029  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_onoff
+********************************************************************/
+be_local_closure(Matter_Plugin_Bridge_OnOff_set_onoff,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(call_remote_sync),
+    /* K1   */  be_nested_str_weak(Power),
+    /* K2   */  be_nested_str_weak(1),
+    /* K3   */  be_nested_str_weak(0),
+    /* K4   */  be_nested_str_weak(update_shadow),
+    }),
+    be_str_weak(set_onoff),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x58100001,  //  0001  LDCONST	R4	K1
+      0x78060001,  //  0002  JMPF	R1	#0005
+      0x58140002,  //  0003  LDCONST	R5	K2
+      0x70020000,  //  0004  JMP		#0006
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x7C080600,  //  0006  CALL	R2	3
+      0x8C080104,  //  0007  GETMET	R2	R0	K4
+      0x7C080200,  //  0008  CALL	R2	1
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: <lambda>
+********************************************************************/
+be_local_closure(Matter_Plugin_Bridge_OnOff__X3Clambda_X3E,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(_X3Clambda_X3E),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x60040009,  //  0000  GETGBL	R1	G9
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: probe_shadow_async
+********************************************************************/
+be_local_closure(Matter_Plugin_Bridge_OnOff_probe_shadow_async,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(call_remote_async),
+    /* K1   */  be_nested_str_weak(Status),
+    /* K2   */  be_nested_str_weak(11),
+    }),
+    be_str_weak(probe_shadow_async),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x580C0001,  //  0001  LDCONST	R3	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x7C040600,  //  0003  CALL	R1	3
+      0x80000000,  //  0004  RET	0
     })
   )
 );
@@ -287,7 +372,7 @@ be_local_closure(Matter_Plugin_Bridge_OnOff_read_attribute,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_OnOff_update_shadow,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -295,54 +380,25 @@ be_local_closure(Matter_Plugin_Bridge_OnOff_update_shadow,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_status_11),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(StatusSTS),
-    /* K3   */  be_nested_str_weak(POWER),
-    /* K4   */  be_nested_str_weak(ON),
-    /* K5   */  be_nested_str_weak(shadow_onoff),
-    /* K6   */  be_nested_str_weak(attribute_updated),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(update_shadow),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(call_remote_sync),
+    /* K1   */  be_nested_str_weak(Status),
+    /* K2   */  be_nested_str_weak(11),
+    /* K3   */  be_nested_str_weak(update_shadow),
     }),
     be_str_weak(update_shadow),
     &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
+    ( &(const binstruction[10]) {  /* code */
       0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x78060018,  //  0002  JMPF	R1	#001C
-      0x8C080301,  //  0003  GETMET	R2	R1	K1
-      0x58100002,  //  0004  LDCONST	R4	K2
-      0x60140013,  //  0005  GETGBL	R5	G19
-      0x7C140000,  //  0006  CALL	R5	0
-      0x7C080600,  //  0007  CALL	R2	3
-      0x5C040400,  //  0008  MOVE	R1	R2
-      0x8C080301,  //  0009  GETMET	R2	R1	K1
-      0x58100003,  //  000A  LDCONST	R4	K3
-      0x7C080400,  //  000B  CALL	R2	2
-      0x1C080504,  //  000C  EQ	R2	R2	K4
-      0x880C0105,  //  000D  GETMBR	R3	R0	K5
-      0x4C100000,  //  000E  LDNIL	R4
-      0x200C0604,  //  000F  NE	R3	R3	R4
-      0x780E0009,  //  0010  JMPF	R3	#001B
-      0x880C0105,  //  0011  GETMBR	R3	R0	K5
-      0x60100017,  //  0012  GETGBL	R4	G23
-      0x5C140400,  //  0013  MOVE	R5	R2
-      0x7C100200,  //  0014  CALL	R4	1
-      0x200C0604,  //  0015  NE	R3	R3	R4
-      0x780E0003,  //  0016  JMPF	R3	#001B
-      0x8C0C0106,  //  0017  GETMET	R3	R0	K6
-      0x54160005,  //  0018  LDINT	R5	6
-      0x58180007,  //  0019  LDCONST	R6	K7
-      0x7C0C0600,  //  001A  CALL	R3	3
-      0x90020A02,  //  001B  SETMBR	R0	K5	R2
-      0x60080003,  //  001C  GETGBL	R2	G3
-      0x5C0C0000,  //  001D  MOVE	R3	R0
-      0x7C080200,  //  001E  CALL	R2	1
-      0x8C080508,  //  001F  GETMET	R2	R2	K8
-      0x7C080200,  //  0020  CALL	R2	1
-      0x80000000,  //  0021  RET	0
+      0x580C0001,  //  0001  LDCONST	R3	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x7C040600,  //  0003  CALL	R1	3
+      0x60080003,  //  0004  GETGBL	R2	G3
+      0x5C0C0000,  //  0005  MOVE	R3	R0
+      0x7C080200,  //  0006  CALL	R2	1
+      0x8C080503,  //  0007  GETMET	R2	R2	K3
+      0x7C080200,  //  0008  CALL	R2	1
+      0x80000000,  //  0009  RET	0
     })
   )
 );
@@ -354,11 +410,29 @@ be_local_closure(Matter_Plugin_Bridge_OnOff_update_shadow,   /* name */
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Bridge_HTTP;
 be_local_class(Matter_Plugin_Bridge_OnOff,
-    3,
+    2,
     &be_class_Matter_Plugin_Bridge_HTTP,
-    be_nested_map(14,
+    be_nested_map(15,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(CLUSTERS, 11), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Bridge_OnOff_init_closure) },
+        { be_const_key_weak(parse_update, -1), be_const_closure(Matter_Plugin_Bridge_OnOff_parse_update_closure) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_Bridge_OnOff_invoke_request_closure) },
+        { be_const_key_weak(set_onoff, -1), be_const_closure(Matter_Plugin_Bridge_OnOff_set_onoff_closure) },
+        { be_const_key_weak(ARG_TYPE, 7), be_const_static_closure(Matter_Plugin_Bridge_OnOff__X3Clambda_X3E_closure) },
+        { be_const_key_weak(tasmota_relay_index, 11), be_const_var(0) },
+        { be_const_key_weak(probe_shadow_async, -1), be_const_closure(Matter_Plugin_Bridge_OnOff_probe_shadow_async_closure) },
+        { be_const_key_weak(update_shadow, 10), be_const_closure(Matter_Plugin_Bridge_OnOff_update_shadow_closure) },
+        { be_const_key_weak(NAME, -1), be_nested_str_weak(_X26_X23x1F517_X3B_X20Relay) },
+        { be_const_key_weak(ARG, 8), be_nested_str_weak(relay) },
+        { be_const_key_weak(TYPE, 14), be_nested_str_weak(http_relay) },
+        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(266, -1), be_const_int(2) },
+    }))    ) } )) },
+        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Bridge_OnOff_read_attribute_closure) },
+        { be_const_key_weak(shadow_onoff, -1), be_const_var(1) },
+        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(6, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
@@ -369,23 +443,6 @@ be_local_class(Matter_Plugin_Bridge_OnOff,
         be_const_int(65533),
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(ARG, -1), be_nested_str_weak(relay) },
-        { be_const_key_weak(ARG_TYPE, -1), be_const_static_closure(Matter_Plugin_Bridge_OnOff__X3Clambda_X3E_closure) },
-        { be_const_key_weak(TYPE, -1), be_nested_str_weak(http_relay) },
-        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_Bridge_OnOff_update_shadow_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Bridge_OnOff_init_closure) },
-        { be_const_key_weak(shadow_onoff, 13), be_const_var(2) },
-        { be_const_key_weak(invoke_request, 4), be_const_closure(Matter_Plugin_Bridge_OnOff_invoke_request_closure) },
-        { be_const_key_weak(NAME, -1), be_nested_str_weak(_X26_X23x1F517_X3B_X20Relay) },
-        { be_const_key_weak(tasmota_http, 12), be_const_var(0) },
-        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_int(266, -1), be_const_int(2) },
-    }))    ) } )) },
-        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Bridge_OnOff_read_attribute_closure) },
-        { be_const_key_weak(tasmota_relay_index, -1), be_const_var(1) },
-        { be_const_key_weak(set_onoff, -1), be_const_closure(Matter_Plugin_Bridge_OnOff_set_onoff_closure) },
     })),
     be_str_weak(Matter_Plugin_Bridge_OnOff)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TCP_async.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TCP_async.h
@@ -1,0 +1,872 @@
+/* Solidification of Matter_TCP_async.h */
+/********************************************************************\
+* Generated code, don't edit                                         *
+\********************************************************************/
+#include "be_constobj.h"
+
+extern const bclass be_class_Matter_TCP_async;
+
+/********************************************************************
+** Solidified function: write
+********************************************************************/
+be_local_closure(Matter_TCP_async_write,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tcp_connected),
+    /* K1   */  be_nested_str_weak(tcp),
+    /* K2   */  be_nested_str_weak(write),
+    /* K3   */  be_const_int(0),
+    }),
+    be_str_weak(write),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0004,  //  0001  JMPF	R2	#0007
+      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x8C080502,  //  0003  GETMET	R2	R2	K2
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x80040400,  //  0006  RET	1	R2
+      0x80060600,  //  0007  RET	1	K3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: readbytes
+********************************************************************/
+be_local_closure(Matter_TCP_async_readbytes,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tcp_connected),
+    /* K1   */  be_nested_str_weak(tcp),
+    /* K2   */  be_nested_str_weak(readbytes),
+    }),
+    be_str_weak(readbytes),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060003,  //  0001  JMPF	R1	#0006
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80040200,  //  0005  RET	1	R1
+      0x4C040000,  //  0006  LDNIL	R1
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_50ms
+********************************************************************/
+be_local_closure(Matter_TCP_async_every_50ms,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(loop),
+    }),
+    be_str_weak(every_50ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: listening
+********************************************************************/
+be_local_closure(Matter_TCP_async_listening,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tcp_connected),
+    /* K1   */  be_nested_str_weak(tcp),
+    /* K2   */  be_nested_str_weak(listening),
+    }),
+    be_str_weak(listening),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060003,  //  0001  JMPF	R1	#0006
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80040200,  //  0005  RET	1	R1
+      0x50040000,  //  0006  LDBOOL	R1	0	0
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: loop
+********************************************************************/
+be_local_closure(Matter_TCP_async_loop,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tcp_connected),
+    /* K1   */  be_nested_str_weak(status),
+    /* K2   */  be_nested_str_weak(close),
+    /* K3   */  be_nested_str_weak(tcp),
+    /* K4   */  be_nested_str_weak(connected),
+    /* K5   */  be_const_int(1),
+    /* K6   */  be_nested_str_weak(event_established),
+    /* K7   */  be_nested_str_weak(event_refused),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(millis),
+    /* K10  */  be_nested_str_weak(time_start),
+    /* K11  */  be_nested_str_weak(timeout),
+    /* K12  */  be_nested_str_weak(event_timeout),
+    /* K13  */  be_nested_str_weak(event_closed),
+    /* K14  */  be_nested_str_weak(available),
+    /* K15  */  be_nested_str_weak(event_available),
+    /* K16  */  be_nested_str_weak(listening),
+    /* K17  */  be_nested_str_weak(event_listening),
+    }),
+    be_str_weak(loop),
+    &be_const_str_solidified,
+    ( &(const binstruction[89]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x1C080403,  //  0003  EQ	R2	R2	R3
+      0x780A0002,  //  0004  JMPF	R2	#0008
+      0x8C080102,  //  0005  GETMET	R2	R0	K2
+      0x7C080200,  //  0006  CALL	R2	1
+      0x80000400,  //  0007  RET	0
+      0x88080103,  //  0008  GETMBR	R2	R0	K3
+      0x8C080504,  //  0009  GETMET	R2	R2	K4
+      0x7C080200,  //  000A  CALL	R2	1
+      0x90020002,  //  000B  SETMBR	R0	K0	R2
+      0x4C080000,  //  000C  LDNIL	R2
+      0x1C080202,  //  000D  EQ	R2	R1	R2
+      0x780A0021,  //  000E  JMPF	R2	#0031
+      0x88080100,  //  000F  GETMBR	R2	R0	K0
+      0x500C0200,  //  0010  LDBOOL	R3	1	0
+      0x1C080403,  //  0011  EQ	R2	R2	R3
+      0x780A0003,  //  0012  JMPF	R2	#0017
+      0x90020305,  //  0013  SETMBR	R0	K1	K5
+      0x8C080106,  //  0014  GETMET	R2	R0	K6
+      0x7C080200,  //  0015  CALL	R2	1
+      0x70020019,  //  0016  JMP		#0031
+      0x88080100,  //  0017  GETMBR	R2	R0	K0
+      0x500C0000,  //  0018  LDBOOL	R3	0	0
+      0x1C080403,  //  0019  EQ	R2	R2	R3
+      0x780A0007,  //  001A  JMPF	R2	#0023
+      0x5409FFFD,  //  001B  LDINT	R2	-2
+      0x90020202,  //  001C  SETMBR	R0	K1	R2
+      0x8C080107,  //  001D  GETMET	R2	R0	K7
+      0x7C080200,  //  001E  CALL	R2	1
+      0x8C080102,  //  001F  GETMET	R2	R0	K2
+      0x7C080200,  //  0020  CALL	R2	1
+      0x80000400,  //  0021  RET	0
+      0x7002000D,  //  0022  JMP		#0031
+      0xB80A1000,  //  0023  GETNGBL	R2	K8
+      0x8C080509,  //  0024  GETMET	R2	R2	K9
+      0x7C080200,  //  0025  CALL	R2	1
+      0x880C010A,  //  0026  GETMBR	R3	R0	K10
+      0x04080403,  //  0027  SUB	R2	R2	R3
+      0x880C010B,  //  0028  GETMBR	R3	R0	K11
+      0x24080403,  //  0029  GT	R2	R2	R3
+      0x780A0005,  //  002A  JMPF	R2	#0031
+      0x5409FFFC,  //  002B  LDINT	R2	-3
+      0x90020202,  //  002C  SETMBR	R0	K1	R2
+      0x50080000,  //  002D  LDBOOL	R2	0	0
+      0x90020002,  //  002E  SETMBR	R0	K0	R2
+      0x8C08010C,  //  002F  GETMET	R2	R0	K12
+      0x7C080200,  //  0030  CALL	R2	1
+      0xB80A1000,  //  0031  GETNGBL	R2	K8
+      0x8C080509,  //  0032  GETMET	R2	R2	K9
+      0x7C080200,  //  0033  CALL	R2	1
+      0x880C010A,  //  0034  GETMBR	R3	R0	K10
+      0x04080403,  //  0035  SUB	R2	R2	R3
+      0x880C010B,  //  0036  GETMBR	R3	R0	K11
+      0x24080403,  //  0037  GT	R2	R2	R3
+      0x780A0006,  //  0038  JMPF	R2	#0040
+      0x8C080102,  //  0039  GETMET	R2	R0	K2
+      0x7C080200,  //  003A  CALL	R2	1
+      0x5409FFFC,  //  003B  LDINT	R2	-3
+      0x90020202,  //  003C  SETMBR	R0	K1	R2
+      0x8C08010C,  //  003D  GETMET	R2	R0	K12
+      0x7C080200,  //  003E  CALL	R2	1
+      0x80000400,  //  003F  RET	0
+      0x88080100,  //  0040  GETMBR	R2	R0	K0
+      0x500C0000,  //  0041  LDBOOL	R3	0	0
+      0x1C080403,  //  0042  EQ	R2	R2	R3
+      0x780A0007,  //  0043  JMPF	R2	#004C
+      0x50080200,  //  0044  LDBOOL	R2	1	0
+      0x1C080202,  //  0045  EQ	R2	R1	R2
+      0x780A0001,  //  0046  JMPF	R2	#0049
+      0x8C08010D,  //  0047  GETMET	R2	R0	K13
+      0x7C080200,  //  0048  CALL	R2	1
+      0x8C080102,  //  0049  GETMET	R2	R0	K2
+      0x7C080200,  //  004A  CALL	R2	1
+      0x80000400,  //  004B  RET	0
+      0x88080103,  //  004C  GETMBR	R2	R0	K3
+      0x8C08050E,  //  004D  GETMET	R2	R2	K14
+      0x7C080200,  //  004E  CALL	R2	1
+      0x780A0001,  //  004F  JMPF	R2	#0052
+      0x8C08010F,  //  0050  GETMET	R2	R0	K15
+      0x7C080200,  //  0051  CALL	R2	1
+      0x88080103,  //  0052  GETMBR	R2	R0	K3
+      0x8C080510,  //  0053  GETMET	R2	R2	K16
+      0x7C080200,  //  0054  CALL	R2	1
+      0x780A0001,  //  0055  JMPF	R2	#0058
+      0x8C080111,  //  0056  GETMET	R2	R0	K17
+      0x7C080200,  //  0057  CALL	R2	1
+      0x80000000,  //  0058  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_established
+********************************************************************/
+be_local_closure(Matter_TCP_async_event_established,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(event_established),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: reset
+********************************************************************/
+be_local_closure(Matter_TCP_async_reset,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tcp),
+    /* K1   */  be_nested_str_weak(close),
+    /* K2   */  be_nested_str_weak(tcp_connected),
+    }),
+    be_str_weak(reset),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x4C040000,  //  0003  LDNIL	R1
+      0x90020401,  //  0004  SETMBR	R0	K2	R1
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_listening
+********************************************************************/
+be_local_closure(Matter_TCP_async_event_listening,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(event_listening),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_TCP_async_init,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(loop),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80040000,  //  0003  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(TIMEOUT),
+    /* K1   */  be_nested_str_weak(addr),
+    /* K2   */  be_nested_str_weak(port),
+    /* K3   */  be_nested_str_weak(timeout),
+    /* K4   */  be_nested_str_weak(tcp),
+    /* K5   */  be_nested_str_weak(tcpclientasync),
+    /* K6   */  be_nested_str_weak(fast_loop),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140605,  //  0001  EQ	R5	R3	R5
+      0x78160000,  //  0002  JMPF	R5	#0004
+      0x880C0100,  //  0003  GETMBR	R3	R0	K0
+      0x4C140000,  //  0004  LDNIL	R5
+      0x1C140405,  //  0005  EQ	R5	R2	R5
+      0x78160000,  //  0006  JMPF	R5	#0008
+      0x540A004F,  //  0007  LDINT	R2	80
+      0x60140008,  //  0008  GETGBL	R5	G8
+      0x5C180200,  //  0009  MOVE	R6	R1
+      0x7C140200,  //  000A  CALL	R5	1
+      0x90020205,  //  000B  SETMBR	R0	K1	R5
+      0x60140009,  //  000C  GETGBL	R5	G9
+      0x5C180400,  //  000D  MOVE	R6	R2
+      0x7C140200,  //  000E  CALL	R5	1
+      0x90020405,  //  000F  SETMBR	R0	K2	R5
+      0x90020603,  //  0010  SETMBR	R0	K3	R3
+      0xB8160A00,  //  0011  GETNGBL	R5	K5
+      0x7C140000,  //  0012  CALL	R5	0
+      0x90020805,  //  0013  SETMBR	R0	K4	R5
+      0x78120001,  //  0014  JMPF	R4	#0017
+      0x84140000,  //  0015  CLOSURE	R5	P0
+      0x90020C05,  //  0016  SETMBR	R0	K6	R5
+      0xA0000000,  //  0017  CLOSE	R0
+      0x80000000,  //  0018  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_closed
+********************************************************************/
+be_local_closure(Matter_TCP_async_event_closed,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(event_closed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read
+********************************************************************/
+be_local_closure(Matter_TCP_async_read,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tcp_connected),
+    /* K1   */  be_nested_str_weak(tcp),
+    /* K2   */  be_nested_str_weak(read),
+    }),
+    be_str_weak(read),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060003,  //  0001  JMPF	R1	#0006
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80040200,  //  0005  RET	1	R1
+      0x4C040000,  //  0006  LDNIL	R1
+      0x80040200,  //  0007  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: begin
+********************************************************************/
+be_local_closure(Matter_TCP_async_begin,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[25]) {     /* constants */
+    /* K0   */  be_nested_str_weak(reset),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(wifi),
+    /* K3   */  be_nested_str_weak(up),
+    /* K4   */  be_nested_str_weak(eth),
+    /* K5   */  be_nested_str_weak(time_start),
+    /* K6   */  be_nested_str_weak(millis),
+    /* K7   */  be_nested_str_weak(status),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(tcp),
+    /* K10  */  be_nested_str_weak(connect),
+    /* K11  */  be_nested_str_weak(addr),
+    /* K12  */  be_nested_str_weak(port),
+    /* K13  */  be_nested_str_weak(fast_loop),
+    /* K14  */  be_nested_str_weak(remove_fast_loop),
+    /* K15  */  be_nested_str_weak(add_fast_loop),
+    /* K16  */  be_nested_str_weak(add_driver),
+    /* K17  */  be_nested_str_weak(string),
+    /* K18  */  be_nested_str_weak(log),
+    /* K19  */  be_nested_str_weak(format),
+    /* K20  */  be_nested_str_weak(BRY_X3A_X20failed_X20to_X20resolve_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K21  */  be_const_int(3),
+    /* K22  */  be_nested_str_weak(close),
+    /* K23  */  be_nested_str_weak(tcp_connected),
+    /* K24  */  be_nested_str_weak(event_dnsfailed),
+    }),
+    be_str_weak(begin),
+    &be_const_str_solidified,
+    ( &(const binstruction[64]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0xB8060200,  //  0002  GETNGBL	R1	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x94040303,  //  0005  GETIDX	R1	R1	K3
+      0x74060006,  //  0006  JMPT	R1	#000E
+      0xB8060200,  //  0007  GETNGBL	R1	K1
+      0x8C040304,  //  0008  GETMET	R1	R1	K4
+      0x7C040200,  //  0009  CALL	R1	1
+      0x94040303,  //  000A  GETIDX	R1	R1	K3
+      0x74060001,  //  000B  JMPT	R1	#000E
+      0x4C040000,  //  000C  LDNIL	R1
+      0x80040200,  //  000D  RET	1	R1
+      0xB8060200,  //  000E  GETNGBL	R1	K1
+      0x8C040306,  //  000F  GETMET	R1	R1	K6
+      0x7C040200,  //  0010  CALL	R1	1
+      0x90020A01,  //  0011  SETMBR	R0	K5	R1
+      0x90020F08,  //  0012  SETMBR	R0	K7	K8
+      0x88040109,  //  0013  GETMBR	R1	R0	K9
+      0x8C04030A,  //  0014  GETMET	R1	R1	K10
+      0x880C010B,  //  0015  GETMBR	R3	R0	K11
+      0x8810010C,  //  0016  GETMBR	R4	R0	K12
+      0x7C040600,  //  0017  CALL	R1	3
+      0x78060011,  //  0018  JMPF	R1	#002B
+      0x8804010D,  //  0019  GETMBR	R1	R0	K13
+      0x78060008,  //  001A  JMPF	R1	#0024
+      0xB8060200,  //  001B  GETNGBL	R1	K1
+      0x8C04030E,  //  001C  GETMET	R1	R1	K14
+      0x880C010D,  //  001D  GETMBR	R3	R0	K13
+      0x7C040400,  //  001E  CALL	R1	2
+      0xB8060200,  //  001F  GETNGBL	R1	K1
+      0x8C04030F,  //  0020  GETMET	R1	R1	K15
+      0x880C010D,  //  0021  GETMBR	R3	R0	K13
+      0x7C040400,  //  0022  CALL	R1	2
+      0x70020003,  //  0023  JMP		#0028
+      0xB8060200,  //  0024  GETNGBL	R1	K1
+      0x8C040310,  //  0025  GETMET	R1	R1	K16
+      0x5C0C0000,  //  0026  MOVE	R3	R0
+      0x7C040400,  //  0027  CALL	R1	2
+      0x50040200,  //  0028  LDBOOL	R1	1	0
+      0x80040200,  //  0029  RET	1	R1
+      0x70020013,  //  002A  JMP		#003F
+      0xA4062200,  //  002B  IMPORT	R1	K17
+      0xB80A0200,  //  002C  GETNGBL	R2	K1
+      0x8C080512,  //  002D  GETMET	R2	R2	K18
+      0x8C100313,  //  002E  GETMET	R4	R1	K19
+      0x58180014,  //  002F  LDCONST	R6	K20
+      0x881C010B,  //  0030  GETMBR	R7	R0	K11
+      0x8820010C,  //  0031  GETMBR	R8	R0	K12
+      0x7C100800,  //  0032  CALL	R4	4
+      0x58140015,  //  0033  LDCONST	R5	K21
+      0x7C080600,  //  0034  CALL	R2	3
+      0x8C080116,  //  0035  GETMET	R2	R0	K22
+      0x7C080200,  //  0036  CALL	R2	1
+      0x5409FFFE,  //  0037  LDINT	R2	-1
+      0x90020E02,  //  0038  SETMBR	R0	K7	R2
+      0x50080000,  //  0039  LDBOOL	R2	0	0
+      0x90022E02,  //  003A  SETMBR	R0	K23	R2
+      0x8C080118,  //  003B  GETMET	R2	R0	K24
+      0x7C080200,  //  003C  CALL	R2	1
+      0x50080000,  //  003D  LDBOOL	R2	0	0
+      0x80040400,  //  003E  RET	1	R2
+      0x80000000,  //  003F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_timeout
+********************************************************************/
+be_local_closure(Matter_TCP_async_event_timeout,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(event_timeout),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: available
+********************************************************************/
+be_local_closure(Matter_TCP_async_available,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tcp_connected),
+    /* K1   */  be_nested_str_weak(tcp),
+    /* K2   */  be_nested_str_weak(available),
+    /* K3   */  be_const_int(0),
+    }),
+    be_str_weak(available),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060003,  //  0001  JMPF	R1	#0006
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80040200,  //  0005  RET	1	R1
+      0x80060600,  //  0006  RET	1	K3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_refused
+********************************************************************/
+be_local_closure(Matter_TCP_async_event_refused,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(event_refused),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_dnsfailed
+********************************************************************/
+be_local_closure(Matter_TCP_async_event_dnsfailed,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(event_dnsfailed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_available
+********************************************************************/
+be_local_closure(Matter_TCP_async_event_available,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(event_available),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: close
+********************************************************************/
+be_local_closure(Matter_TCP_async_close,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tcp),
+    /* K1   */  be_nested_str_weak(close),
+    /* K2   */  be_nested_str_weak(fast_loop),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(remove_fast_loop),
+    /* K5   */  be_nested_str_weak(remove_driver),
+    /* K6   */  be_nested_str_weak(tcp_connected),
+    /* K7   */  be_nested_str_weak(event_closed),
+    }),
+    be_str_weak(close),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040102,  //  0003  GETMBR	R1	R0	K2
+      0x78060004,  //  0004  JMPF	R1	#000A
+      0xB8060600,  //  0005  GETNGBL	R1	K3
+      0x8C040304,  //  0006  GETMET	R1	R1	K4
+      0x880C0102,  //  0007  GETMBR	R3	R0	K2
+      0x7C040400,  //  0008  CALL	R1	2
+      0x70020003,  //  0009  JMP		#000E
+      0xB8060600,  //  000A  GETNGBL	R1	K3
+      0x8C040305,  //  000B  GETMET	R1	R1	K5
+      0x5C0C0000,  //  000C  MOVE	R3	R0
+      0x7C040400,  //  000D  CALL	R1	2
+      0x88040106,  //  000E  GETMBR	R1	R0	K6
+      0x50080200,  //  000F  LDBOOL	R2	1	0
+      0x1C040202,  //  0010  EQ	R1	R1	R2
+      0x78060001,  //  0011  JMPF	R1	#0014
+      0x8C040107,  //  0012  GETMET	R1	R0	K7
+      0x7C040200,  //  0013  CALL	R1	1
+      0x50040000,  //  0014  LDBOOL	R1	0	0
+      0x90020C01,  //  0015  SETMBR	R0	K6	R1
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_timeout
+********************************************************************/
+be_local_closure(Matter_TCP_async_set_timeout,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(TIMEOUT),
+    /* K1   */  be_nested_str_weak(timeout),
+    }),
+    be_str_weak(set_timeout),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x88040100,  //  0003  GETMBR	R1	R0	K0
+      0x90020201,  //  0004  SETMBR	R0	K1	R1
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Matter_TCP_async
+********************************************************************/
+be_local_class(Matter_TCP_async,
+    8,
+    NULL,
+    be_nested_map(28,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(write, -1), be_const_closure(Matter_TCP_async_write_closure) },
+        { be_const_key_weak(timeout, -1), be_const_var(2) },
+        { be_const_key_weak(port, -1), be_const_var(1) },
+        { be_const_key_weak(close, 7), be_const_closure(Matter_TCP_async_close_closure) },
+        { be_const_key_weak(tcp, -1), be_const_var(3) },
+        { be_const_key_weak(tcp_connected, -1), be_const_var(5) },
+        { be_const_key_weak(listening, -1), be_const_closure(Matter_TCP_async_listening_closure) },
+        { be_const_key_weak(event_available, -1), be_const_closure(Matter_TCP_async_event_available_closure) },
+        { be_const_key_weak(readbytes, 1), be_const_closure(Matter_TCP_async_readbytes_closure) },
+        { be_const_key_weak(event_dnsfailed, -1), be_const_closure(Matter_TCP_async_event_dnsfailed_closure) },
+        { be_const_key_weak(event_established, -1), be_const_closure(Matter_TCP_async_event_established_closure) },
+        { be_const_key_weak(event_refused, 21), be_const_closure(Matter_TCP_async_event_refused_closure) },
+        { be_const_key_weak(reset, -1), be_const_closure(Matter_TCP_async_reset_closure) },
+        { be_const_key_weak(event_listening, -1), be_const_closure(Matter_TCP_async_event_listening_closure) },
+        { be_const_key_weak(event_timeout, -1), be_const_closure(Matter_TCP_async_event_timeout_closure) },
+        { be_const_key_weak(status, 25), be_const_var(6) },
+        { be_const_key_weak(every_50ms, 11), be_const_closure(Matter_TCP_async_every_50ms_closure) },
+        { be_const_key_weak(read, -1), be_const_closure(Matter_TCP_async_read_closure) },
+        { be_const_key_weak(begin, -1), be_const_closure(Matter_TCP_async_begin_closure) },
+        { be_const_key_weak(init, 14), be_const_closure(Matter_TCP_async_init_closure) },
+        { be_const_key_weak(available, -1), be_const_closure(Matter_TCP_async_available_closure) },
+        { be_const_key_weak(event_closed, -1), be_const_closure(Matter_TCP_async_event_closed_closure) },
+        { be_const_key_weak(addr, 9), be_const_var(0) },
+        { be_const_key_weak(loop, 3), be_const_closure(Matter_TCP_async_loop_closure) },
+        { be_const_key_weak(TIMEOUT, 5), be_const_int(1000) },
+        { be_const_key_weak(time_start, -1), be_const_var(4) },
+        { be_const_key_weak(fast_loop, 2), be_const_var(7) },
+        { be_const_key_weak(set_timeout, -1), be_const_closure(Matter_TCP_async_set_timeout_closure) },
+    })),
+    be_str_weak(Matter_TCP_async)
+);
+/*******************************************************************/
+
+void be_load_Matter_TCP_async_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_Matter_TCP_async);
+    be_setglobal(vm, "Matter_TCP_async");
+    be_pop(vm, 1);
+}
+/********************************************************************/
+/* End of solidification */


### PR DESCRIPTION
## Description:

Matter, improved support for bridged devices on Matter. Currently only Relay (On-Off) is supported.

This PR brings async (non-blocking) HTTP support for remote ESP8266 devices, and unlocks to a theoretical limit of 16 sub-devices (for now).

As a side effect, the configuration should be a domain-name only (not containing "http://").

Example:
<img width="390" alt="image" src="https://github.com/arendst/Tasmota/assets/49731213/7cbb5f0b-471d-482e-8087-dcc8f6daee25">


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
