### PR TITLE
Zigbee support for air sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Support for GM861 1D and 2D bar code reader (#18399)
 - Berry `re` (regex) add `match2` and optional offset
 - Support for PCA9557 8-bit I/O expander (#18632)
+- Zigbee support for air sensors
 
 ### Breaking Changed
 - Change command ``FileUpload`` index binary data detection from >199 to >299

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_1z_libs.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_1z_libs.ino
@@ -111,10 +111,10 @@ public:
                                   // Bit #9 is `0` command is cluster specific, or `1` general_command
   uint8_t       key_suffix;       // append a suffix to key (default is 1, explicitly output if >1)
   uint8_t       attr_type;        // [opt] type of the attribute, default to Zunk (0xFF)
-  uint16_t      attr_multiplier;  // [opt] multiplier for attribute, defaults to 0x01 (no change)
-  uint16_t      attr_divider;     // [opt] divider
-  int16_t       attr_base;        // [opt] base for conversion
   uint16_t      manuf;            // manufacturer id (0 if none)
+  uint32_t      attr_multiplier;  // [opt] multiplier for attribute, defaults to 0x01 (no change)
+  uint32_t      attr_divider;     // [opt] divider
+  int32_t       attr_base;        // [opt] base for conversion
 
   // Constructor with all defaults
   Z_attribute():

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
@@ -318,9 +318,9 @@ public:
   }
 
   uint8_t       type;             // zigbee type, Zunk by default
-  uint16_t      multiplier;       // multiply by x (ignore if 0 or 1)
-  uint16_t      divider;          // divide by x (ignore if 0 or 1)
-  int16_t       base;             // add x (ignore if 0)
+  uint32_t      multiplier;       // multiply by x (ignore if 0 or 1)
+  uint32_t      divider;          // divide by x (ignore if 0 or 1)
+  int32_t       base;             // add x (ignore if 0)
   uint16_t      cluster;          // cluster number
   uint16_t      attribute;        // attribute number
   uint16_t      manuf;            // manufacturer code, 0 if none
@@ -338,7 +338,7 @@ public:
     {};
   
   void set(uint16_t cluster, uint16_t attribute, uint16_t new_cluster, uint16_t new_attribute,
-          int8_t multiplier = 1, int8_t divider = 1, int16_t base = 0) {
+          uint32_t multiplier = 1, uint32_t divider = 1, int32_t base = 0) {
     this->cluster = cluster;
     this->attribute = attribute;
     this->new_cluster = new_cluster;
@@ -354,9 +354,9 @@ public:
   uint16_t      attribute;        // attribute to match
   uint16_t      new_cluster;      // replace with this cluster
   uint16_t      new_attribute;    // replace with this attribute
-  uint16_t      multiplier;       // multiply by x (ignore if 0 or 1)
-  uint16_t      divider;          // divide by x (ignore if 0 or 1)
-  int16_t       base;           // add x (ignore if 0)
+  uint32_t      multiplier;       // multiply by x (ignore if 0 or 1)
+  uint32_t      divider;          // divide by x (ignore if 0 or 1)
+  int32_t       base;           // add x (ignore if 0)
 };
 
 //
@@ -530,9 +530,9 @@ public:
   uint16_t cluster = 0xFFFF;
   uint16_t attribute = 0xFFFF;
   const char * name = nullptr;
-  uint16_t multiplier = 1;
-  uint16_t divider = 1;
-  int16_t  base = 0;
+  uint32_t multiplier = 1;
+  uint32_t divider = 1;
+  int32_t  base = 0;
   uint8_t zigbee_type = Znodata;
   uint8_t map_offset = 0;
   Z_Data_Type map_type = Z_Data_Type::Z_Unknown;

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -1000,9 +1000,9 @@ void ZCLFrame::parseReadConfigAttributes(uint16_t shortaddr, Z_attribute_list& a
     }
 
     // find the multiplier
-    uint16_t multiplier = 1;
-    uint16_t divider = 1;
-    int16_t base = 0;
+    uint32_t multiplier = 1;
+    uint32_t divider = 1;
+    int32_t base = 0;
     Z_attribute_match matched_attr = Z_findAttributeMatcherById(shortaddr, cluster, attrid, false);
     if (matched_attr.found()) {
       attr_2.addAttribute(matched_attr.name, true).setBool(true);

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_7_plugin.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_7_plugin.ino
@@ -214,9 +214,9 @@ bool ZbLoad_inner(const char *filename, File &fp) {
         uint16_t attr_id = 0xFFFF;
         uint16_t cluster_id = 0xFFFF;
         uint8_t  type_id = Zunk;
-        uint16_t multiplier = 1;
-        uint16_t divider = 1;
-        int16_t  base = 0;
+        uint32_t multiplier = 1;
+        uint32_t divider = 1;
+        int32_t  base = 0;
         char *   name = nullptr;
         uint16_t manuf = 0;
 
@@ -281,9 +281,9 @@ bool ZbLoad_inner(const char *filename, File &fp) {
         char * delimiter_slash2 = strchr(tok2, '/');
         uint16_t new_cluster_id = strtoul(tok2, &delimiter_slash2, 16);
         uint16_t new_attr_id = strtoul(delimiter_slash2+1, nullptr, 16);
-        uint16_t multiplier = 1;
-        uint16_t divider = 1;
-        int16_t  base = 0;
+        uint32_t multiplier = 1;
+        uint32_t divider = 1;
+        int32_t  base = 0;
 
         // ADDITIONAL ELEMENTS?
         while (token = strtok_r(rest, ",", &rest)) {
@@ -386,7 +386,7 @@ bool ZbUnload(const char *filename_raw) {
 }
 
 // append modifiers like mul/div/manuf
-void Z_AppendModifiers(char * buf, size_t buf_len, uint16_t multiplier, uint16_t divider, int16_t base, uint16_t manuf) {
+void Z_AppendModifiers(char * buf, size_t buf_len, uint32_t multiplier, uint32_t divider, int32_t base, uint16_t manuf) {
   if (multiplier != 0 && multiplier != 1) {
     ext_snprintf_P(buf, buf_len, "%s,%s%i", buf, Z_MUL, multiplier);
   }

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
@@ -232,7 +232,7 @@ void zigbeeZCLSendCmd(class ZCLFrame &zcl) {
 // I.e. multipliers and dividers are inversed
 // multiplier == 0: ignore
 // multiplier == 1: ignore
-void ZbApplyMultiplierForWrites(double &val_d, uint16_t multiplier, uint16_t divider, int16_t base) {
+void ZbApplyMultiplierForWrites(double &val_d, uint32_t multiplier, uint32_t divider, int32_t base) {
   if (0 != base) {
     val_d = val_d - base;
   }

--- a/tasmota/zigbee/air_quality.zb
+++ b/tasmota/zigbee/air_quality.zb
@@ -1,0 +1,7 @@
+#Z2Tv1
+# Extension for Air Quality - clusters from Concentration Measurement
+:                                   # apply to all devices
+040D/0000,CO2,mul:1000000
+040D/0001,CO2Min,mul:1000000
+040D/0002,CO2Max,mul:1000000
+040D/0003,CO2Tolerance,mul:1000000

--- a/tasmota/zigbee/air_quality.zb
+++ b/tasmota/zigbee/air_quality.zb
@@ -1,7 +1,7 @@
 #Z2Tv1
 # Extension for Air Quality - clusters from Concentration Measurement
 :                                   # apply to all devices
-040D/0000,CO2,mul:1000000
+040D/0000,CO2,mul:1000000                   # concentration in ppm
 040D/0001,CO2Min,mul:1000000
 040D/0002,CO2Max,mul:1000000
 040D/0003,CO2Tolerance,mul:1000000


### PR DESCRIPTION
## Description:

Zigbee extend multiplier, divider and base from 16 bits to 32 bits to make it compatible with air sensors.

Added a plugin for generic CO2 sensor.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
