### PR TITLE
Berry `tasmota.wifi()` would wrongly report wifi as up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Shutter bootloop using more than 4 shutters (#18673)
 - AIThinker webcam issues (#18652)
+- Berry `tasmota.wifi()` would wrongly report wifi as up
 
 ### Removed
 

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -756,6 +756,7 @@ String IPForUrl(const IPAddress & ip)
 // IPv4 has always priority
 // Copy the value of the IP if pointer provided (optional)
 bool WifiGetIP(IPAddress *ip) {
+#ifdef ESP32
   wifi_mode_t mode = WiFi.getMode();
   if ((mode == WIFI_MODE_STA || mode == WIFI_MODE_APSTA) && (uint32_t)WiFi.localIP() != 0) {
     if (ip != nullptr) { *ip = WiFi.localIP(); }
@@ -765,6 +766,17 @@ bool WifiGetIP(IPAddress *ip) {
     if (ip != nullptr) { *ip = WiFi.softAPIP(); }
     return true;
   }
+#else
+  WiFiMode_t mode = WiFi.getMode();
+  if ((mode == WIFI_STA || mode == WIFI_AP_STA) && (uint32_t)WiFi.localIP() != 0) {
+    if (ip != nullptr) { *ip = WiFi.localIP(); }
+    return true;
+  }
+  if ((mode == WIFI_AP || mode == WIFI_AP_STA) && (uint32_t)WiFi.softAPIP() != 0) {
+    if (ip != nullptr) { *ip = WiFi.softAPIP(); }
+    return true;
+  }
+#endif
 #ifdef USE_IPV6
   IPAddress lip;
   if (WifiGetIPv6(&lip)) {

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -503,6 +503,7 @@ void WifiSetState(uint8_t state)
  * - DNS reporting actual values used (not the Settings):
  *    `DNSGetIP(n)`, `DNSGetIPStr(n)` with n=`0`/`1` (same dns for Wifi and Eth)
 \*****************************************************************************************************/
+bool WifiGetIP(IPAddress *ip, bool exclude_ap = false);
 // IPv4 for Wifi
 // Returns only IPv6 global address (no loopback and no link-local)
 bool WifiGetIPv4(IPAddress *ip)
@@ -755,14 +756,15 @@ String IPForUrl(const IPAddress & ip)
 // Check to see if we have any routable IP address
 // IPv4 has always priority
 // Copy the value of the IP if pointer provided (optional)
-bool WifiGetIP(IPAddress *ip) {
+// `exclude_ap` allows to exlude AP IP address and focus only on local STA
+bool WifiGetIP(IPAddress *ip, bool exclude_ap) {
 #ifdef ESP32
   wifi_mode_t mode = WiFi.getMode();
   if ((mode == WIFI_MODE_STA || mode == WIFI_MODE_APSTA) && (uint32_t)WiFi.localIP() != 0) {
     if (ip != nullptr) { *ip = WiFi.localIP(); }
     return true;
   }
-  if ((mode == WIFI_MODE_AP || mode == WIFI_MODE_APSTA) && (uint32_t)WiFi.softAPIP() != 0) {
+  if (!exclude_ap && (mode == WIFI_MODE_AP || mode == WIFI_MODE_APSTA) && (uint32_t)WiFi.softAPIP() != 0) {
     if (ip != nullptr) { *ip = WiFi.softAPIP(); }
     return true;
   }
@@ -772,7 +774,7 @@ bool WifiGetIP(IPAddress *ip) {
     if (ip != nullptr) { *ip = WiFi.localIP(); }
     return true;
   }
-  if ((mode == WIFI_AP || mode == WIFI_AP_STA) && (uint32_t)WiFi.softAPIP() != 0) {
+  if (!exclude_ap && (mode == WIFI_AP || mode == WIFI_AP_STA) && (uint32_t)WiFi.softAPIP() != 0) {
     if (ip != nullptr) { *ip = WiFi.softAPIP(); }
     return true;
   }

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -756,11 +756,12 @@ String IPForUrl(const IPAddress & ip)
 // IPv4 has always priority
 // Copy the value of the IP if pointer provided (optional)
 bool WifiGetIP(IPAddress *ip) {
-  if ((uint32_t)WiFi.localIP() != 0) {
+  wifi_mode_t mode = WiFi.getMode();
+  if ((mode == WIFI_MODE_STA || mode == WIFI_MODE_APSTA) && (uint32_t)WiFi.localIP() != 0) {
     if (ip != nullptr) { *ip = WiFi.localIP(); }
     return true;
   }
-  if ((uint32_t)WiFi.softAPIP() != 0) {
+  if ((mode == WIFI_MODE_AP || mode == WIFI_MODE_APSTA) && (uint32_t)WiFi.softAPIP() != 0) {
     if (ip != nullptr) { *ip = WiFi.softAPIP(); }
     return true;
   }

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -3701,8 +3701,8 @@ bool Xdrv01(uint32_t function)
       if (Wifi.wifi_test_counter) {
         Wifi.wifi_test_counter--;
         AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_WIFI D_TRYING_TO_CONNECT " %s"), SettingsText(SET_STASSID1));
-        IPAddress local_ip = WiFi.localIP();
-        if (IPIsValid(local_ip)) {            // Got IP - Connection Established (only IPv4 supported for )
+        IPAddress local_ip;
+        if (WifiGetIP(&local_ip, true)) {            // Got IP - Connection Established (exclude AP address)
           Wifi.wifi_test_AP_TIMEOUT = false;
           Wifi.wifi_test_counter = 0;
           Wifi.wifiTest = WIFI_TEST_FINISHED;

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -3701,11 +3701,12 @@ bool Xdrv01(uint32_t function)
       if (Wifi.wifi_test_counter) {
         Wifi.wifi_test_counter--;
         AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_WIFI D_TRYING_TO_CONNECT " %s"), SettingsText(SET_STASSID1));
-        if (WifiHasIP()) {            // Got IP - Connection Established
+        IPAddress local_ip = WiFi.localIP();
+        if (IPIsValid(local_ip)) {            // Got IP - Connection Established (only IPv4 supported for )
           Wifi.wifi_test_AP_TIMEOUT = false;
           Wifi.wifi_test_counter = 0;
           Wifi.wifiTest = WIFI_TEST_FINISHED;
-          AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_WIFI D_CMND_SSID " %s: " D_CONNECTED " - " D_IP_ADDRESS " %s"), SettingsText(Wifi.wifi_Test_Save_SSID2 ? SET_STASSID2 : SET_STASSID1), WiFi.localIP().toString().c_str());
+          AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_WIFI D_CMND_SSID " %s: " D_CONNECTED " - " D_IP_ADDRESS " %s"), SettingsText(Wifi.wifi_Test_Save_SSID2 ? SET_STASSID2 : SET_STASSID1), local_ip.toString().c_str());
 //          TasmotaGlobal.blinks = 255;                    // Signal wifi connection with blinks
           if (MAX_WIFI_OPTION != Wifi.old_wificonfig) {
             TasmotaGlobal.wifi_state_flag = Settings->sta_config = Wifi.old_wificonfig;


### PR DESCRIPTION
## Description:

Berry: `tasmota.wifi()` would wrongly report wifi as up, confusing with AP IP `192.168.4.1`.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
