### PR TITLE
haas: sync shutter discovery and fix for more than 4 shutter

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_12_discovery.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_12_discovery.ino
@@ -109,22 +109,23 @@ void TasDiscoverMessage(void) {
 
   uint16_t Relay[MAX_RELAYS_SET] = { 0 };                      // Base array to store the relay type
   uint16_t Shutter[MAX_RELAYS_SET] = { 0 };                    // Array to store a temp list for shutters
-  for (uint32_t i = 0; i < MAX_RELAYS_SET; i++) {
-    if (i < TasmotaGlobal.devices_present) {
 
 #ifdef USE_SHUTTER
-      if (Settings->flag3.shutter_mode) {
-        for (uint32_t k = 0; k < TasmotaGlobal.shutters_present; k++) {
-          if (ShutterGetStartRelay(k) > 0) {
-            Shutter[ShutterGetStartRelay(k)-1] = Shutter[ShutterGetStartRelay(k)] = 1;
-          } else {
-            // terminate loop at first INVALID ShutterGetStartRelay(k).
-            break;
-          }
-        }
+  if (Settings->flag3.shutter_mode) {
+    for (uint32_t k = 0; k < TasmotaGlobal.shutters_present; k++) {
+      uint8_t sr = ShutterGetStartRelay(k);
+      if (sr > 0) {
+        Shutter[sr-1] = Shutter[sr] = 1;
+      } else {
+        // terminate loop at first INVALID ShutterGetStartRelay(k).
+        break;
       }
+    }
+  }
 #endif  // USE_SHUTTER
 
+  for (uint32_t i = 0; i < MAX_RELAYS_SET; i++) {
+    if (i < TasmotaGlobal.devices_present) {
       if (Shutter[i] != 0) {                                   // Check if there are shutters present
         Relay[i] = 3;                                          // Relay is a shutter
       } else {

--- a/tasmota/tasmota_xdrv_driver/xdrv_12_home_assistant.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_12_home_assistant.ino
@@ -393,7 +393,7 @@ void HassDiscoverMessage(void) {
                         light_controller_isCTRGBLinked,
                         light_subtype);
 
-  for (uint32_t i = 0; i < tmax(TasmotaGlobal.shutters_present, MAX_SHUTTERS); i++) {
+  for (uint32_t i = 0; i < tmin(TasmotaGlobal.shutters_present, MAX_SHUTTERS); i++) {
 #ifdef USE_SHUTTER
     ResponseAppend_P(PSTR("%s%d"), (i > 0 ? "," : ""), Settings->shutter_options[i]);
 #else
@@ -528,10 +528,11 @@ void HAssAnnounceRelayLight(void)
 
 #ifdef USE_SHUTTER
   if (Settings->flag3.shutter_mode) {
-    for (uint32_t i = 0; i < MAX_SHUTTERS; i++) {
-      if (Settings->shutter_startrelay[i] > 0 ) {
-        bitSet(shutter_mask, Settings->shutter_startrelay[i] -1);
-        bitSet(shutter_mask, Settings->shutter_startrelay[i]);
+    for (uint32_t i = 0; i < TasmotaGlobal.shutters_present; i++) {
+      uint8_t sr = ShutterGetStartRelay(i);
+      if (sr > 0) {
+        bitSet(shutter_mask, sr-1);
+        bitSet(shutter_mask, sr);
       } else {
         // terminate loop at first INVALID Settings->shutter_startrelay[i].
         break;
@@ -1064,7 +1065,7 @@ void HAssAnnounceShutters(void)
   char unique_id[30];
   uint8_t ShowTopic; // Used to hide/unhide a topic during Discovery to spare some cpu load
 
-  for (uint32_t i = 0; i < MAX_SHUTTERS; i++) {
+  for (uint32_t i = 0; i < TasmotaGlobal.shutters_present; i++) {
     ResponseClear();  // Clear retained message
     TasmotaGlobal.masterlog_level = ShowTopic = 4; // Hide topic on clean and remove use weblog 4 to see it
 
@@ -1072,7 +1073,7 @@ void HAssAnnounceShutters(void)
     snprintf_P(unique_id, sizeof(unique_id), PSTR("%06X_SHT_%d"), ESP_getChipId(), i + 1);
     snprintf_P(stopic, sizeof(stopic), PSTR(HOME_ASSISTANT_DISCOVERY_PREFIX "/cover/%s/config"), unique_id);
 
-    if (Settings->flag.hass_discovery && Settings->flag3.shutter_mode && Settings->shutter_startrelay[i] > 0) {
+    if (Settings->flag.hass_discovery && Settings->flag3.shutter_mode && ShutterGetStartRelay(i) > 0) {
        ShowTopic = 0; // Show the new generated topic
       if (i > MAX_FRIENDLYNAMES) {
         snprintf_P(stemp1, sizeof(stemp1), PSTR("%s Shutter %d"), SettingsText(SET_DEVICENAME), i + 1);
@@ -1091,9 +1092,9 @@ void HAssAnnounceShutters(void)
       GetTopic_P(stemp2, CMND, TasmotaGlobal.mqtt_topic, PSTR("ShutterPosition"));
       TryResponseAppend_P(HASS_DISCOVER_SHUTTER_POS, stemp1, i + 1, stemp2, i + 1);
 
-      if (Settings->shutter_tilt_config[3][i] != Settings->shutter_tilt_config[4][i]) {
+      if (ShutterGetTiltConfig(3,i) != ShutterGetTiltConfig(4,i)) {
         GetTopic_P(stemp1, CMND, TasmotaGlobal.mqtt_topic, PSTR("ShutterTilt"));
-        TryResponseAppend_P(HASS_DISCOVER_SHUTTER_TILT, stemp1, i + 1, Settings->shutter_tilt_config[3][i], Settings->shutter_tilt_config[4][i]);
+        TryResponseAppend_P(HASS_DISCOVER_SHUTTER_TILT, stemp1, i + 1, ShutterGetTiltConfig(3,i), ShutterGetTiltConfig(4,i));
       }
 
       TryResponseAppend_P(HASS_DISCOVER_DEVICE_INFO_SHORT, unique_id, ESP_getChipId());


### PR DESCRIPTION
## Description:

Discovered while testing `USE_SHUTTER_ESP32`. Also added a tiny optimization in `xdrv_12_discovery`, that is, avoiding unnecessary recomputation.

Thank you!

/cc @stefanbode 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
