### PR TITLE
Add MFRC522 support for customizable SPI pins

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -773,6 +773,7 @@
 //    #define USE_DISPLAY_ST7789                   // [DisplayModel 12] Enable ST7789 module
 //    #define USE_DISPLAY_SSD1331                  // [DisplayModel 14] Enable SSD1331 module
 //  #define USE_RC522                              // Add support for MFRC522 13.56Mhz Rfid reader (+6k code)
+//    #define RC522_USE_CONFIGURED_SPI_PINS        // Use the SPI 1 interface as configured via the template for communication with RC522
 //    #define USE_RC522_DATA_FUNCTION              // Add support for reading data block content (+0k4 code)
 //    #define USE_RC522_TYPE_INFORMATION           // Add support for showing card type (+0k4 code)
 //  #define USE_MCP2515                            // Add support for can bus using MCP2515 (+7k code)

--- a/tasmota/tasmota_xsns_sensor/xsns_80_mfrc522.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_80_mfrc522.ino
@@ -100,7 +100,11 @@ void RC522ScanForTag(void) {
 void RC522Init(void) {
   if (PinUsed(GPIO_RC522_CS) && PinUsed(GPIO_RC522_RST) && TasmotaGlobal.spi_enabled) {
     Mfrc522 = new MFRC522(Pin(GPIO_RC522_CS), Pin(GPIO_RC522_RST));
+#ifdef RC522_USE_CONFIGURED_SPI_PINS
+    SPI.begin(Pin(GPIO_SPI_CLK), Pin(GPIO_SPI_MISO), Pin(GPIO_SPI_MOSI));
+#else
     SPI.begin();
+#endif
     Mfrc522->PCD_Init();
 //    if (Mfrc522->PCD_PerformSelfTest()) {  // Saves 0k5 code
       uint8_t v = Mfrc522->PCD_ReadRegister(Mfrc522->VersionReg);


### PR DESCRIPTION
## Description:
(MF)RC522 reader modules cannot be used with e.g. ESP32-cam modules, since the driver uses the default SPI interface.
This code change enables custom builds to use the SPI pins configured via a template (e.g. via web UI)

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.9 (Note: tested on ESP32-cam)
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

