### PR TITLE
Fix log message for MTR HTTP sync/async request in Matter_HTTP_remote.be

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_remote.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_remote.be
@@ -43,7 +43,7 @@ class Matter_HTTP_remote : Matter_HTTP_async
   # returns nil if no network
   def begin(cmd)
     import string
-    tasmota.log(string.format("MTR: HTTP async request 'http://%s:%i/%s'", self.addr, self.port, cmd), 3)
+    tasmota.log(string.format("MTR: HTTP async request 'http://%s:%i%s'", self.addr, self.port, cmd), 3)
     return super(self).begin(cmd)
   end
 
@@ -56,7 +56,7 @@ class Matter_HTTP_remote : Matter_HTTP_async
   # returns the payload as string
   def begin_sync(cmd, timeout)
     import string
-    tasmota.log(string.format("MTR: HTTP sync request 'http://%s:%i/%s'", self.addr, self.port, cmd), 3)
+    tasmota.log(string.format("MTR: HTTP sync request 'http://%s:%i%s'", self.addr, self.port, cmd), 3)
     return super(self).begin_sync(cmd, timeout)
   end
 


### PR DESCRIPTION
Fix log message for MTR HTTP sync/async request in Matter_HTTP_remote.be
## Description:
I noticed a log issue in the logs:
Example:

Request should be request '[http://192.168.1.103:80/cm?cmnd=Status%2011](http://192.168.1.103/cm?cmnd=Status%2011)'
And not request '[http://192.168.1.103:80//cm?cmnd=Status%2011](http://192.168.1.103//cm?cmnd=Status%2011)'
```
22:27:54.927 MTR: HTTP async request 'http://192.168.1.103:80//cm?cmnd=Status%2011'
22:27:54.931 WIF: DNS resolved '192.168.1.103' (192.168.1.103) in 1 ms
22:27:55.643 MTR: HTTP timeout
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
