### PR TITLE
adjust neopixel busy time

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
@@ -134,10 +134,15 @@ extern "C" {
             if (s_sk6812_grbw)      s_sk6812_grbw->Begin();
             break;
           case 2: // # 02 : show         void -> void
-            if (s_ws2812_grb)       s_ws2812_grb->Show();
-            if (s_sk6812_grbw)      s_sk6812_grbw->Show();
+            {
+              uint32_t pixels_size;       // number of bytes to push
+            if (s_ws2812_grb)     { s_ws2812_grb->Show();   pixels_size = s_ws2812_grb->PixelsSize(); }
+            if (s_sk6812_grbw)    { s_sk6812_grbw->Show();  pixels_size = s_ws2812_grb->PixelsSize(); }
+
             // Wait for RMT/I2S to complete fixes distortion due to analogRead
-            SystemBusyDelay(8);  // Max 256 leds
+            // 1ms is needed for 96 bytes
+            SystemBusyDelay((pixels_size + 95) / 96);
+            }
             break;
           case 3: // # 03 : CanShow      void -> bool
             if (s_ws2812_grb)       be_pushbool(vm, s_ws2812_grb->CanShow());

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
@@ -137,8 +137,7 @@ extern "C" {
             if (s_ws2812_grb)       s_ws2812_grb->Show();
             if (s_sk6812_grbw)      s_sk6812_grbw->Show();
             // Wait for RMT/I2S to complete fixes distortion due to analogRead
-//            delay(5);
-            SystemBusyDelay(5);  // Max 256 leds
+            SystemBusyDelay(8);  // Max 256 leds
             break;
           case 3: // # 03 : CanShow      void -> bool
             if (s_ws2812_grb)       be_pushbool(vm, s_ws2812_grb->CanShow());

--- a/tasmota/tasmota_xlgt_light/xlgt_01_ws2812.ino
+++ b/tasmota/tasmota_xlgt_light/xlgt_01_ws2812.ino
@@ -218,7 +218,7 @@ void Ws2812LibStripShow(void) {
 #if defined(USE_WS2812_DMA) || defined(USE_WS2812_RMT) || defined(USE_WS2812_I2S)
   // Wait for DMA/RMT/I2S to complete fixes distortion due to analogRead
 //  delay((Settings->light_pixels >> 6) +1);  // 256 / 64 = 4 +1 = 5
-  SystemBusyDelay((Settings->light_pixels >> 6) +1);  // 256 / 64 = 4 +1 = 5
+  SystemBusyDelay( (Settings->light_pixels + 31) >> 5);  // (256 + 32) / 32 = 8
 #endif
 }
 


### PR DESCRIPTION
## Description:

I re-did the timing calculation. If I'm not mistaken it takes 1ms per 32 pixels (1.35 usec per bit * 24 * 32 = ~1000 usec).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
