### PR TITLE
Make `USE_DISPLAY_MODES1TO5` in firmware `LVGL` possible

### DIFF
--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -24,7 +24,7 @@
 
 /*********************************************************************************************\
  * [tasmota32x-safeboot.bin]
- * Provide an image with useful supported sensors enabled
+ * Provide aan image with useful supported sensors enabled
  *
  * Is a copy of FIRMWARE_MINIMAL with some additional features enabled
 \*********************************************************************************************/
@@ -314,7 +314,7 @@
 #define USE_UNIVERSAL_DISPLAY
 #define USE_DISPLAY_LVGL_ONLY
 
-#undef USE_DISPLAY_MODES1TO5
+//#undef USE_DISPLAY_MODES1TO5
 #undef USE_DISPLAY_LCD
 #undef USE_DISPLAY_SSD1306
 #undef USE_DISPLAY_MATRIX

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -24,7 +24,7 @@
 
 /*********************************************************************************************\
  * [tasmota32x-safeboot.bin]
- * Provide aan image with useful supported sensors enabled
+ * Provide an image with useful supported sensors enabled
  *
  * Is a copy of FIRMWARE_MINIMAL with some additional features enabled
 \*********************************************************************************************/


### PR DESCRIPTION
## Description:

There is no reason for hard disabling in variant FIRMWARE_LVGL

## Checklist:
  - [x] The pull request is done against the latest development 
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
