### PR TITLE
Berry safeguard when freeing null pointer

### DIFF
--- a/lib/libesp32/berry/src/be_mem.c
+++ b/lib/libesp32/berry/src/be_mem.c
@@ -66,6 +66,7 @@ BERRY_API void* be_realloc(bvm *vm, void *ptr, size_t old_size, size_t new_size)
     
         /* Case 2: deallocate */
         else if (new_size == 0) {
+            if (ptr == NULL) { return NULL; }   /* safeguard */
 #if BE_USE_DEBUG_GC
             memset(ptr, 0xFF, old_size); /* fill the structure with invalid pointers */
 #endif


### PR DESCRIPTION
## Description:

Include patch from Berry upstream. Avoid crashing when be_free is passed a NULL pointer.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
