### PR TITLE
Matter add 0300/400A for CT

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light2.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light2.be
@@ -36,7 +36,7 @@ class Matter_Plugin_Bridge_Light2 : Matter_Plugin_Bridge_Light1
     # 0x0005: inherited                             # Scenes 1.4 p.30 - no writable
     # 0x0006: inherited                             # On/Off 1.5 p.48
     # 0x0008: inherited                             # Level Control 1.6 p.57
-    0x0300: [7,8,0xF,0x400B,0x400C,0xFFFC,0xFFFD],  # Color Control 3.2 p.111
+    0x0300: [7,8,0xF,0x400A,0x400B,0x400C,0xFFFC,0xFFFD],  # Color Control 3.2 p.111
   }
   static var TYPES = { 0x010C: 2, 0x0013: 1 }       # Dimmable Light
 
@@ -117,6 +117,8 @@ class Matter_Plugin_Bridge_Light2 : Matter_Plugin_Bridge_Light1
       elif attribute == 0x400C          #  ---------- ColorTempPhysicalMaxMireds / u2 ----------
         return TLV.create_TLV(TLV.U1, self.ct_max)
       
+      elif attribute == 0x400A          #  ---------- ColorCapabilities / map32 ----------
+        return TLV.create_TLV(TLV.U4, 0x10)    # CT
       elif attribute == 0xFFFC          #  ---------- FeatureMap / map32 ----------
         return TLV.create_TLV(TLV.U4, 0x10)    # CT
       elif attribute == 0xFFFD          #  ---------- ClusterRevision / u2 ----------

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light3.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light3.be
@@ -122,13 +122,13 @@ class Matter_Plugin_Bridge_Light3 : Matter_Plugin_Bridge_Light1
         return TLV.create_TLV(TLV.U1, 0)
       elif attribute == 0x4001          #  ---------- EnhancedColorMode / u1 ----------
         return TLV.create_TLV(TLV.U1, 0)
-      elif attribute == 0x400A          #  ---------- ColorCapabilities / map2 ----------
-        return TLV.create_TLV(TLV.U1, 0)
 
       # Defined Primaries Information Attribute Set
       elif attribute == 0x0010          #  ---------- NumberOfPrimaries / u1 ----------
         return TLV.create_TLV(TLV.U1, 0)
 
+      elif attribute == 0x400A          #  ---------- ColorCapabilities / map32 ----------
+        return TLV.create_TLV(TLV.U4, 0x01)
       elif attribute == 0xFFFC          #  ---------- FeatureMap / map32 ----------
         return TLV.create_TLV(TLV.U4, 0x01)    # HS
       elif attribute == 0xFFFD          #  ---------- ClusterRevision / u2 ----------

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light2.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light2.h
@@ -425,7 +425,7 @@ be_local_closure(Matter_Plugin_Bridge_Light2_read_attribute,   /* name */
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[92]) {  /* code */
+    ( &(const binstruction[101]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0xB8120200,  //  0001  GETNGBL	R4	K1
       0x88100902,  //  0002  GETMBR	R4	R4	K2
@@ -433,7 +433,7 @@ be_local_closure(Matter_Plugin_Bridge_Light2_read_attribute,   /* name */
       0x88180504,  //  0004  GETMBR	R6	R2	K4
       0x541E02FF,  //  0005  LDINT	R7	768
       0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E004A,  //  0007  JMPF	R7	#0053
+      0x781E0053,  //  0007  JMPF	R7	#005C
       0x8C1C0105,  //  0008  GETMET	R7	R0	K5
       0x7C1C0200,  //  0009  CALL	R7	1
       0x541E0006,  //  000A  LDINT	R7	7
@@ -454,7 +454,7 @@ be_local_closure(Matter_Plugin_Bridge_Light2_read_attribute,   /* name */
       0x4C280000,  //  0019  LDNIL	R10
       0x7C1C0600,  //  001A  CALL	R7	3
       0x80040E00,  //  001B  RET	1	R7
-      0x70020034,  //  001C  JMP		#0052
+      0x7002003D,  //  001C  JMP		#005B
       0x541E0007,  //  001D  LDINT	R7	8
       0x1C1C0C07,  //  001E  EQ	R7	R6	R7
       0x781E0005,  //  001F  JMPF	R7	#0026
@@ -463,7 +463,7 @@ be_local_closure(Matter_Plugin_Bridge_Light2_read_attribute,   /* name */
       0x5828000A,  //  0022  LDCONST	R10	K10
       0x7C1C0600,  //  0023  CALL	R7	3
       0x80040E00,  //  0024  RET	1	R7
-      0x7002002B,  //  0025  JMP		#0052
+      0x70020034,  //  0025  JMP		#005B
       0x541E000E,  //  0026  LDINT	R7	15
       0x1C1C0C07,  //  0027  EQ	R7	R6	R7
       0x781E0005,  //  0028  JMPF	R7	#002F
@@ -472,7 +472,7 @@ be_local_closure(Matter_Plugin_Bridge_Light2_read_attribute,   /* name */
       0x5828000B,  //  002B  LDCONST	R10	K11
       0x7C1C0600,  //  002C  CALL	R7	3
       0x80040E00,  //  002D  RET	1	R7
-      0x70020022,  //  002E  JMP		#0052
+      0x7002002B,  //  002E  JMP		#005B
       0x541E400A,  //  002F  LDINT	R7	16395
       0x1C1C0C07,  //  0030  EQ	R7	R6	R7
       0x781E0005,  //  0031  JMPF	R7	#0038
@@ -481,7 +481,7 @@ be_local_closure(Matter_Plugin_Bridge_Light2_read_attribute,   /* name */
       0x8828010C,  //  0034  GETMBR	R10	R0	K12
       0x7C1C0600,  //  0035  CALL	R7	3
       0x80040E00,  //  0036  RET	1	R7
-      0x70020019,  //  0037  JMP		#0052
+      0x70020022,  //  0037  JMP		#005B
       0x541E400B,  //  0038  LDINT	R7	16396
       0x1C1C0C07,  //  0039  EQ	R7	R6	R7
       0x781E0005,  //  003A  JMPF	R7	#0041
@@ -490,8 +490,8 @@ be_local_closure(Matter_Plugin_Bridge_Light2_read_attribute,   /* name */
       0x8828010D,  //  003D  GETMBR	R10	R0	K13
       0x7C1C0600,  //  003E  CALL	R7	3
       0x80040E00,  //  003F  RET	1	R7
-      0x70020010,  //  0040  JMP		#0052
-      0x541EFFFB,  //  0041  LDINT	R7	65532
+      0x70020019,  //  0040  JMP		#005B
+      0x541E4009,  //  0041  LDINT	R7	16394
       0x1C1C0C07,  //  0042  EQ	R7	R6	R7
       0x781E0005,  //  0043  JMPF	R7	#004A
       0x8C1C0907,  //  0044  GETMET	R7	R4	K7
@@ -499,25 +499,34 @@ be_local_closure(Matter_Plugin_Bridge_Light2_read_attribute,   /* name */
       0x542A000F,  //  0046  LDINT	R10	16
       0x7C1C0600,  //  0047  CALL	R7	3
       0x80040E00,  //  0048  RET	1	R7
-      0x70020007,  //  0049  JMP		#0052
-      0x541EFFFC,  //  004A  LDINT	R7	65533
+      0x70020010,  //  0049  JMP		#005B
+      0x541EFFFB,  //  004A  LDINT	R7	65532
       0x1C1C0C07,  //  004B  EQ	R7	R6	R7
-      0x781E0004,  //  004C  JMPF	R7	#0052
+      0x781E0005,  //  004C  JMPF	R7	#0053
       0x8C1C0907,  //  004D  GETMET	R7	R4	K7
       0x8824090E,  //  004E  GETMBR	R9	R4	K14
-      0x542A0004,  //  004F  LDINT	R10	5
+      0x542A000F,  //  004F  LDINT	R10	16
       0x7C1C0600,  //  0050  CALL	R7	3
       0x80040E00,  //  0051  RET	1	R7
       0x70020007,  //  0052  JMP		#005B
-      0x601C0003,  //  0053  GETGBL	R7	G3
-      0x5C200000,  //  0054  MOVE	R8	R0
-      0x7C1C0200,  //  0055  CALL	R7	1
-      0x8C1C0F0F,  //  0056  GETMET	R7	R7	K15
-      0x5C240200,  //  0057  MOVE	R9	R1
-      0x5C280400,  //  0058  MOVE	R10	R2
+      0x541EFFFC,  //  0053  LDINT	R7	65533
+      0x1C1C0C07,  //  0054  EQ	R7	R6	R7
+      0x781E0004,  //  0055  JMPF	R7	#005B
+      0x8C1C0907,  //  0056  GETMET	R7	R4	K7
+      0x8824090E,  //  0057  GETMBR	R9	R4	K14
+      0x542A0004,  //  0058  LDINT	R10	5
       0x7C1C0600,  //  0059  CALL	R7	3
       0x80040E00,  //  005A  RET	1	R7
-      0x80000000,  //  005B  RET	0
+      0x70020007,  //  005B  JMP		#0064
+      0x601C0003,  //  005C  GETGBL	R7	G3
+      0x5C200000,  //  005D  MOVE	R8	R0
+      0x7C1C0200,  //  005E  CALL	R7	1
+      0x8C1C0F0F,  //  005F  GETMET	R7	R7	K15
+      0x5C240200,  //  0060  MOVE	R9	R1
+      0x5C280400,  //  0061  MOVE	R10	R2
+      0x7C1C0600,  //  0062  CALL	R7	3
+      0x80040E00,  //  0063  RET	1	R7
+      0x80000000,  //  0064  RET	0
     })
   )
 );
@@ -541,11 +550,12 @@ be_local_class(Matter_Plugin_Bridge_Light2,
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(768, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(8,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(7),
         be_const_int(8),
         be_const_int(15),
+        be_const_int(16394),
         be_const_int(16395),
         be_const_int(16396),
         be_const_int(65532),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light3.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light3.h
@@ -561,7 +561,7 @@ be_local_closure(Matter_Plugin_Bridge_Light3_read_attribute,   /* name */
       0x7C1C0600,  //  004F  CALL	R7	3
       0x80040E00,  //  0050  RET	1	R7
       0x70020022,  //  0051  JMP		#0075
-      0x541E4009,  //  0052  LDINT	R7	16394
+      0x541E000F,  //  0052  LDINT	R7	16
       0x1C1C0C07,  //  0053  EQ	R7	R6	R7
       0x781E0005,  //  0054  JMPF	R7	#005B
       0x8C1C0908,  //  0055  GETMET	R7	R4	K8
@@ -570,12 +570,12 @@ be_local_closure(Matter_Plugin_Bridge_Light3_read_attribute,   /* name */
       0x7C1C0600,  //  0058  CALL	R7	3
       0x80040E00,  //  0059  RET	1	R7
       0x70020019,  //  005A  JMP		#0075
-      0x541E000F,  //  005B  LDINT	R7	16
+      0x541E4009,  //  005B  LDINT	R7	16394
       0x1C1C0C07,  //  005C  EQ	R7	R6	R7
       0x781E0005,  //  005D  JMPF	R7	#0064
       0x8C1C0908,  //  005E  GETMET	R7	R4	K8
-      0x88240909,  //  005F  GETMBR	R9	R4	K9
-      0x58280006,  //  0060  LDCONST	R10	K6
+      0x8824090D,  //  005F  GETMBR	R9	R4	K13
+      0x5828000B,  //  0060  LDCONST	R10	K11
       0x7C1C0600,  //  0061  CALL	R7	3
       0x80040E00,  //  0062  RET	1	R7
       0x70020010,  //  0063  JMP		#0075


### PR DESCRIPTION
## Description:

Matter, add support for attribute 0300/400A for CT lights.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
