### PR TITLE
fix factory file not removed

### DIFF
--- a/pio-tools/name-firmware.py
+++ b/pio-tools/name-firmware.py
@@ -13,6 +13,7 @@ def bin_map_copy(source, target, env):
     # get locations and file names based on variant
     map_file = tasmotapiolib.get_final_map_path(env)
     bin_file = tasmotapiolib.get_final_bin_path(env)
+    one_bin_file = bin_file
 
     if env["PIOPLATFORM"] == "espressif32":
         factory_tmp = pathlib.Path(firsttarget).with_suffix("")
@@ -21,7 +22,7 @@ def bin_map_copy(source, target, env):
         one_bin_file = one_bin_tmp.with_suffix(one_bin_tmp.suffix + ".factory.bin")
 
     # check if new target files exist and remove if necessary
-    for f in [map_file, bin_file]:
+    for f in [map_file, bin_file, one_bin_file]:
         if f.is_file():
             f.unlink()
 


### PR DESCRIPTION
## Description:

Actually an existing factory.bin file in folder `build/output/firmware` is not removed.  The first builded will be kept.
The PR removes the old existing when the same env is build again and the new one is copied to.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
