### PR TITLE
Fix interaction of `SO92`, `VirtualCT`, and `RGBWWTable`

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -1911,19 +1911,12 @@ void LightAnimate(void)
         cur_col_10[i] = change8to10(Light.new_color[i]);
       }
 
-      bool rgbwwtable_applied_white = false;      // did we already applied RGBWWTable to white channels (ex: in white_blend_mode or virtual_ct)
       if (Light.pwm_multi_channels) {
         calcGammaMultiChannels(cur_col_10);
       } else {
         // AddLog(LOG_LEVEL_INFO, PSTR(">>> calcGammaBulbs In  %03X,%03X,%03X,%03X,%03X"), cur_col_10[0], cur_col_10[1], cur_col_10[2], cur_col_10[3], cur_col_10[4]);
-        rgbwwtable_applied_white = calcGammaBulbs(cur_col_10);     // true means that one PWM channel is used for CT
+        calcGammaBulbs(cur_col_10);
         // AddLog(LOG_LEVEL_INFO, PSTR(">>> calcGammaBulbs Out %03X,%03X,%03X,%03X,%03X"), cur_col_10[0], cur_col_10[1], cur_col_10[2], cur_col_10[3], cur_col_10[4]);
-      }
-
-      // Apply RGBWWTable only if not Settings->flag4.white_blend_mode
-      for (uint32_t i = 0; i < (rgbwwtable_applied_white ? 3 : Light.subtype); i++) {
-        uint32_t adjust = change8to10(Settings->rgbwwTable[i]);
-        cur_col_10[i] = changeUIntScale(cur_col_10[i], 0, 1023, 0, adjust);
       }
 
       // final adjusments for PMW ranges, post-gamma correction
@@ -2320,7 +2313,7 @@ void calcGammaBulb5Channels_8(uint8_t in8[LST_MAX], uint16_t col10[LST_MAX]) {
   calcGammaBulb5Channels(col10, nullptr, nullptr);
 }
 
-bool calcGammaBulbs(uint16_t cur_col_10[5]) {
+void calcGammaBulbs(uint16_t cur_col_10[5]) {
   bool rgbwwtable_applied_white = false;
   bool white_free_cw = false;         // true if White channels are uncorrelated. Happens when CW+WW>255, i.e. manually setting white channels to exceed to total power of a single channel (may harm the power supply)
   // Various values needed for accurate White calculation
@@ -2339,7 +2332,7 @@ bool calcGammaBulbs(uint16_t cur_col_10[5]) {
     calcGammaBulbCW(cur_col_10, &white_bri10, &white_free_cw);
   }
 
-  // Now see if we need to mix RGB and  White
+  // Now see if we need to mix RGB and White
   // Valid only for LST_RGBW, LST_RGBCW, SetOption105 1, and white is zero (see doc)
   if ((LST_RGBW <= Light.subtype) && (Settings->flag4.white_blend_mode) && (0 == cur_col_10[3]+cur_col_10[4])) {
     uint32_t min_rgb_10 = min3(cur_col_10[0], cur_col_10[1], cur_col_10[2]);
@@ -2404,6 +2397,12 @@ bool calcGammaBulbs(uint16_t cur_col_10[5]) {
     }
   }
 
+  // Apply RGBWWTable (RGB: always, CW: only if white_blend_mode is not engaged)
+  for (uint32_t i = 0; i < (rgbwwtable_applied_white ? 3 : Light.subtype); i++) {
+    uint32_t adjust = change8to10(Settings->rgbwwTable[i]);
+    cur_col_10[i] = changeUIntScale(cur_col_10[i], 0, 1023, 0, adjust);
+  }
+
   if ((LST_COLDWARM == Light.subtype) || (LST_RGBCW == Light.subtype)) {
 #ifdef ESP8266
     if ((PHILIPS == TasmotaGlobal.module_type) || (Settings->flag4.pwm_ct_mode)) {   // channel 1 is the color tone, mapped to cold channel (0..255)
@@ -2412,24 +2411,22 @@ bool calcGammaBulbs(uint16_t cur_col_10[5]) {
 #endif  // ESP8266
       // Xiaomi Philips bulbs follow a different scheme:
       // channel 0=intensity, channel1=temperature
+      // Need to compute white_bri10 and ct_10 from cur_col_10[] for compatibility with VirtualCT
       white_bri10 = cur_col_10[cw0] + cur_col_10[cw0+1];
       ct_10 = changeUIntScale(cur_col_10[cw0+1], 0, white_bri10, 0, 1023);
       if (white_free_cw || white_bri10 > 1023) {
-        // cannot represent free_ct_mode here.
-        // There is one edge case: In white_free_cw, the gamma correction
-        // is done for cw and ww separately, so their gamma-corrected sum might
-        // turn out to be smaller than 1023. For consistent behaviour we still set
-        // the brightness to 1023 in this case; otherwise, Color1 0000007979 is much brighter
-        // than Color1 0000008181
+        // Cannot represent white_free_cw in pwm_ct_mode because we can't set white_bri10 > 1023,
+        // so we set the maximum brightness instead. Note that in white_free_cw, the gamma correction
+        // is done for cw and ww separately, so their gamma-corrected sum may be smaller than 1023.
+        // For consistent behaviour we still set the white_bri10 to 1023 in this case; otherwise, 
+        // Color1 0000007979 is much brighter than Color1 0000008181.
         white_bri10 = 1023;
       }
+
       cur_col_10[cw0] = white_bri10;
       cur_col_10[cw0+1] = ct_10;
-      return false;     // avoid any interference
     }
   }
-
-  return rgbwwtable_applied_white;
 }
 
 #ifdef USE_DEVICE_GROUPS

--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -2409,12 +2409,9 @@ void calcGammaBulbs(uint16_t cur_col_10[5]) {
     // Need to compute white_bri10 and ct_10 from cur_col_10[] for compatibility with VirtualCT
     white_bri10 = cur_col_10[cw0] + cur_col_10[cw0+1];
     ct_10 = changeUIntScale(cur_col_10[cw0+1], 0, white_bri10, 0, 1023);
-    if (white_free_cw || white_bri10 > 1023) {
-      // Cannot represent white_free_cw in pwm_ct_mode because we can't set white_bri10 > 1023,
-      // so we set the maximum brightness instead. Note that in white_free_cw, the gamma correction
-      // is done for cw and ww separately, so their gamma-corrected sum may be smaller than 1023.
-      // We nevertheless set white_bri10=1023 in this case; if we did not do so,
-      // Color1 0000007979 would be much brighter than Color1 0000008181.
+    if (white_bri10 > 1023) {
+      // In white_free_cw mode, the combined brightness of cw and ww may be larger than 1023.
+      // This cannot be represented in pwm_ct_mode, so we set the maximum brightness instead.
       white_bri10 = 1023;
     }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -2322,7 +2322,6 @@ void calcGammaBulb5Channels_8(uint8_t in8[LST_MAX], uint16_t col10[LST_MAX]) {
 
 bool calcGammaBulbs(uint16_t cur_col_10[5]) {
   bool rgbwwtable_applied_white = false;
-  bool pwm_ct = false;
   bool white_free_cw = false;         // true if White channels are uncorrelated. Happens when CW+WW>255, i.e. manually setting white channels to exceed to total power of a single channel (may harm the power supply)
   // Various values needed for accurate White calculation
   // CT value streteched to 0..1023 (from within CT range, so not necessarily from 153 to 500). 0=Cold, 1023=Warm
@@ -2348,7 +2347,6 @@ bool calcGammaBulbs(uint16_t cur_col_10[5]) {
 #else
     if (Settings->flag4.pwm_ct_mode) {   // channel 1 is the color tone, mapped to cold channel (0..255)
 #endif  // ESP8266
-      pwm_ct = true;
       // Xiaomi Philips bulbs follow a different scheme:
       // channel 0=intensity, channel1=temperature
       cur_col_10[cw0] = white_bri10;


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #15337

Previously, when `SO92` (`pwm_ct_mode`) was enabled, `VirtualCT` would not work at all, and 5th entry of the `RGBWWTable` would affect the color temperature instead of the warm white intensity. With this patch, all options interact as intended. I did extensive testing with various modes to ensure that the code works as intended (`cw`, `rgb`, `rgbw`, `rgbww` with and without `SO92`, `SO105` in all applicable modes, `RGBWWTable`, all with `LEDTable` enabled and disabled).

Nothing changes for users who have `SO92` disabled.

For those that have `SO92` enabled but do not use `VirtualCT` or `RGBWWTable`, there are tiny changes to the color temperature when `LEDTable` is enabled, most notable at low brightness and `ct` values around 240 (25 %) and around 413 (75 %). If needed, I can provide an argument why I believe the new values to be more correct than the old ones.

This restructure rendered some variables unnecessary, which I hence removed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9 (tested on device)
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9 (tested in simulator)
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
