### PR TITLE
Berry `webclient.url_encode()` is now a static class method, no change required to existing code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - InfluxDb resolves DNS name before request (#18015)
 - Shutter sliders in WEBGUI automatically appear and disappear during configuration and update during movement (#18701)
 - AdafruitFingerprint library from v2.0.4 to v2.1.0
+- Berry `webclient.url_encode()` is now a static class method, no change required to existing code
 
 ### Fixed
 - ESP32 InfluxDb initial connection delays using HTTPClient (#18015)

--- a/lib/libesp32/berry_tasmota/src/be_webclient_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webclient_lib.c
@@ -45,7 +45,7 @@ class be_class_webclient (scope: global, name: webclient) {
     .w, var
     init, func(wc_init)
     deinit, func(wc_deinit)
-    url_encode, func(wc_urlencode)
+    url_encode, static_func(wc_urlencode)
 
     begin, func(wc_begin)
     set_timeouts, func(wc_set_timeouts)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webclient.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webclient.ino
@@ -153,12 +153,12 @@ extern "C" {
     be_return_nil(vm);
   }
 
-  // wc.url_encode(string) -> string
+  // wc.url_encode(string) -> string  (static method)
   int32_t wc_urlencode(struct bvm *vm);
   int32_t wc_urlencode(struct bvm *vm) {
     int32_t argc = be_top(vm);
-    if (argc >= 2 && be_isstring(vm, 2)) {
-      const char * s = be_tostring(vm, 2);
+    if (argc >= 1 && be_isstring(vm, 1)) {
+      const char * s = be_tostring(vm, 1);
       String url = wc_UrlEncode(String(s));
       be_pushstring(vm, url.c_str());
       be_return(vm);  /* return self */


### PR DESCRIPTION
## Description:

Example:
```berry
webclient.url_encode("a ?b")
# returns 'a%20%3Fb'
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
