### PR TITLE
Matter Bridge mode always on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Berry `webclient.url_encode()` is now a static class method, no change required to existing code (#18775)
+- Matter Bridge mode always on
 
 ### Fixed
 - Interaction of ``SetOption92``, ``VirtualCT``, and ``RGBWWTable`` (#18768)

--- a/lib/libesp32/berry_matter/src/be_matter_module.c
+++ b/lib/libesp32/berry_matter/src/be_matter_module.c
@@ -189,6 +189,7 @@ extern const bclass be_class_Matter_TLV;   // need to declare it upfront because
 #include "../generate/be_matter_certs.h"
 
 #include "solidify/solidified_Matter_Plugin_Root.h"
+#include "solidify/solidified_Matter_Plugin_Aggregator.h"
 #include "solidify/solidified_Matter_Plugin_Device.h"
 #include "solidify/solidified_Matter_Plugin_OnOff.h"
 #include "solidify/solidified_Matter_Plugin_Light0.h"
@@ -388,6 +389,7 @@ module matter (scope: global, strings: weak) {
 
   // Plugins
   Plugin_Root, class(be_class_Matter_Plugin_Root)       // Generic behavior common to all devices
+  Plugin_Aggregator, class(be_class_Matter_Plugin_Aggregator) // Aggregator
   Plugin_Device, class(be_class_Matter_Plugin_Device)   // Generic device (abstract)
   Plugin_OnOff, class(be_class_Matter_Plugin_OnOff)     // Relay/Light behavior (OnOff)
   Plugin_Light0, class(be_class_Matter_Plugin_Light0)     // OnOff Light

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin.be
@@ -36,6 +36,7 @@ class Matter_Plugin
   # Configuration of the plugin: clusters and type
   static var CLUSTERS = {
     0x001D: [0,1,2,3,0xFFFC,0xFFFD],                # Descriptor Cluster 9.5 p.453
+    0x0039: [0x11],                                 # Bridged Device Basic Information 9.13 p.485
   }
   var device                                # reference to the `device` global object
   var endpoint                              # current endpoint
@@ -180,6 +181,12 @@ class Matter_Plugin
         return TLV.create_TLV(TLV.U4, 1)    # "Initial Release"
       end
 
+    # ====================================================================================================
+    elif cluster == 0x0039              # ========== Bridged Device Basic Information 9.13 p.485 ==========
+
+      if   attribute == 0x0011          #  ---------- Reachable / bool ----------
+        return TLV.create_TLV(TLV.BOOL, 1)     # by default we are reachable
+      end
     else
       return nil
     end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Aggregator.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Aggregator.be
@@ -1,0 +1,71 @@
+#
+# Matter_Plugin_Aggregator.be - implements the Aggregator endpoint
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import matter
+
+# Matter plug-in for root behavior
+
+# dummy declaration for solidification
+class Matter_Plugin end
+
+#@ solidify:Matter_Plugin_Aggregator,weak
+
+class Matter_Plugin_Aggregator : Matter_Plugin
+  static var TYPE = "aggregator"      # name of the plug-in in json
+  static var NAME = "Aggregator"      # display name of the plug-in
+#   static var CLUSTERS  = {
+#     # 0x001D: inherited               # Descriptor Cluster 9.5 p.453
+#   }
+  static var TYPES = { 0x000E: 1 }    # Aggregator
+
+  #############################################################
+  # read an attribute
+  #
+  def read_attribute(session, ctx)
+    import string
+    var TLV = matter.TLV
+    var cluster = ctx.cluster
+    var attribute = ctx.attribute
+
+    if   cluster == 0x001D              # ========== Descriptor Cluster 9.5 p.453 ==========
+
+      # overwrite PartsList
+      if   attribute == 0x0003          # ---------- PartsList / list[endpoint-no]----------
+        var pl = TLV.Matter_TLV_array()
+        var eps = self.device.get_active_endpoints(true)
+        for ep: eps
+          if ep != 0xFF00
+            pl.add_TLV(nil, TLV.U2, ep)     # add each endpoint
+          end
+        end
+        return pl
+      else
+        return super(self).read_attribute(session, ctx)
+      end
+
+    else
+      return super(self).read_attribute(session, ctx)
+
+    end
+    # no match found, return that the attribute is unsupported
+  end
+
+end
+matter.Plugin_Aggregator = Matter_Plugin_Aggregator
+  

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_HTTP.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_HTTP.be
@@ -43,7 +43,7 @@ class Matter_Plugin_Bridge_HTTP : Matter_Plugin_Device
     # 0x0006: [0,0xFFFC,0xFFFD],                    # On/Off 1.5 p.48
 
     # 0x0028: [0,1,2,3,4,5,6,7,8,9,0x0A,0x0F,0x12,0x13],# Basic Information Cluster cluster 11.1 p.565
-    0x0039: [0x11]                                  # Bridged Device Basic Information 9.13 p.485
+    # 0x0039: [0x11]                                  # Bridged Device Basic Information 9.13 p.485
 
   }
   # static var TYPES = { 0x010A: 2 }       # On/Off Light
@@ -176,9 +176,7 @@ class Matter_Plugin_Bridge_HTTP : Matter_Plugin_Device
     # ====================================================================================================
     if   cluster == 0x0039              # ========== Bridged Device Basic Information 9.13 p.485 ==========
 
-      if   attribute == 0x0000          #  ---------- DataModelRevision / CommissioningWindowStatus ----------
-        # return TLV.create_TLV(TLV.U2, 1)
-      elif attribute == 0x0011          #  ---------- Reachable / bool ----------
+      if   attribute == 0x0011          #  ---------- Reachable / bool ----------
         # self.is_reachable_lazy_sync()   # Not needed anymore
         return TLV.create_TLV(TLV.BOOL, self.http_remote.reachable)     # TODO find a way to do a ping
       end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_OnOff.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_OnOff.be
@@ -1,0 +1,97 @@
+#
+# Matter_Plugin_Sensor_OnOff.be - implements the behavior for a Occupany Switch
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Matter plug-in for core behavior
+
+# dummy declaration for solidification
+class Matter_Plugin_Device end
+
+#@ solidify:Matter_Plugin_Sensor_OnOff,weak
+
+class Matter_Plugin_Sensor_OnOff : Matter_Plugin_Device
+  static var TYPE = "occupancy"                     # name of the plug-in in json
+  static var NAME = "OnOff"                         # display name of the plug-in
+  static var ARG  = "switch"                        # additional argument name (or empty if none)
+  static var ARG_TYPE = / x -> int(x)               # function to convert argument to the right type
+  static var UPDATE_TIME = 5000                     # update every 250ms
+  static var CLUSTERS  = {
+    0x0006: [0,0xFFFC,0xFFFD],                      # On/Off 1.5 p.48
+  }
+  static var TYPES = { 0x0850: 2 }                  # OnOff Sensor, rev 2
+
+  var tasmota_switch_index                          # Switch number in Tasmota (one based)
+  var shadow_onoff
+
+  #############################################################
+  # Constructor
+  def init(device, endpoint, arguments)
+    super(self).init(device, endpoint, arguments)
+    self.tasmota_switch_index = int(arguments.find(self.ARG #-'relay'-#, 1))
+    if self.tasmota_switch_index <= 0    self.tasmota_switch_index = 1    end
+  end
+
+  #############################################################
+  # Update shadow
+  #
+  def update_shadow()
+    super(self).update_shadow()
+
+    import json
+    var ret = tasmota.cmd("Status 8", true)
+    if ret != nil
+      var j = json.load(ret)
+      if j != nil
+        var state = false
+        state = (j.find("Switch" + str(self.tasmota_switch_index)) == "ON")
+
+        if self.shadow_onoff != nil && self.shadow_onoff != bool(state)
+          self.attribute_updated(0x0406, 0x0000)
+        end
+        self.shadow_onoff = state
+      end
+    end
+  end
+
+  #############################################################
+  # read an attribute
+  #
+  def read_attribute(session, ctx)
+    import string
+    var TLV = matter.TLV
+    var cluster = ctx.cluster
+    var attribute = ctx.attribute
+
+    # ====================================================================================================
+    if   cluster == 0x0006              # ========== On/Off 1.5 p.48 ==========
+      self.update_shadow_lazy()
+      if   attribute == 0x0000          #  ---------- OnOff / bool ----------
+        return TLV.create_TLV(TLV.BOOL, self.shadow_onoff)
+      elif attribute == 0xFFFC          #  ---------- FeatureMap / map32 ----------
+        return TLV.create_TLV(TLV.U4, 0)    # 0 = no Level Control for Lighting
+      elif attribute == 0xFFFD          #  ---------- ClusterRevision / u2 ----------
+        return TLV.create_TLV(TLV.U4, 4)    # 0 = no Level Control for Lighting
+      end
+
+    else
+      return super(self).read_attribute(session, ctx)
+    end
+  end
+
+end
+matter.Plugin_Sensor_OnOff = Matter_Plugin_Sensor_OnOff

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -32,7 +32,6 @@ import matter
 # WebUI for the partition manager
 #################################################################################
 class Matter_UI
-  static var _ROOT_TYPES    = "root"
   static var _CLASSES_TYPES = "|relay|light0|light1|light2|light3|shutter|shutter+tilt"
                               "|temperature|pressure|illuminance|humidity|occupancy"
   static var _CLASSES_TYPES2= "-http|http_relay|http_light0|http_light1|http_light2|http_light3"
@@ -164,6 +163,15 @@ class Matter_UI
     import string
 
     webserver.content_send("<fieldset><legend><b>&nbsp;Matter Passcode&nbsp;</b></legend><p></p>")
+    # button for open/close commissioning
+    webserver.content_send("<form action='/matterc' method='post'>")
+    if self.device.commissioning_open == nil
+      webserver.content_send(string.format("<p></p><button name='open_comm' class='button bgrn'>%s</button>", "Open Commissioning"))
+    else
+      webserver.content_send(string.format("<p></p><button name='clos_comm' class='button bgrn'>%s</button>", "Close Commissioning"))
+    end
+    webserver.content_send("</form></p>")
+    #
     webserver.content_send("<form action='/matterc' method='post' onsubmit='return confirm(\"This will cause a restart.\");'>")
     webserver.content_send("<p>Passcode:</p>")
     webserver.content_send(string.format("<input type='number' min='1' max='99999998' name='passcode' value='%i'>", self.device.root_passcode))
@@ -239,22 +247,16 @@ class Matter_UI
     var i = 0
   
     # special case for root node
-    if endpoints[0] == 0
-      var ep = endpoints[i]
-      var conf = self.device.plugins_config[str(ep)]
-      var typ = conf.find('type')
-      
-      webserver.content_send(string.format("<tr><td><input type='text' name='ep%03i' maxlength='4' size='3' value='0' readonly></td>", i))
-      webserver.content_send(string.format("<td><select name='pi%03i'>", i))
-      self.plugin_option(conf.find('type', ''), self._ROOT_TYPES)
-      webserver.content_send(string.format("</select></td>"))
-      webserver.content_send("<td><font size='-1'>&nbsp;</font></td>")
-
-      i += 1
-    end
+    # display a fake configuration item (disabled)
+    webserver.content_send("<tr><td><input type='text' name='ep000' maxlength='4' size='3' value='0' readonly disabled></td>")
+    webserver.content_send("<td><select name='pi000'>")
+    webserver.content_send("<option value='' selected disabled>Root node</option>")
+    webserver.content_send("</select></td>")
+    webserver.content_send("<td><font size='-1'>&nbsp;</font></td>")
 
     while i < size(endpoints)
       var ep = endpoints[i]
+      if ep == 0  i += 1  continue end          # skip endpoint 0 (leftover from previous versions)
       var conf = self.device.plugins_config[str(ep)]
       var typ = conf.find('type')
       if !typ   i += 1   continue    end
@@ -372,6 +374,16 @@ class Matter_UI
         webserver.redirect("/?rst=")
 
       #---------------------------------------------------------------------#
+      # Enable or Disable Commissioning
+      #---------------------------------------------------------------------#
+      elif webserver.has_arg("open_comm")
+        self.device.start_root_basic_commissioning()
+        webserver.redirect("/")
+      elif webserver.has_arg("clos_comm")
+        self.device.stop_basic_commissioning()
+        webserver.redirect("/")
+
+      #---------------------------------------------------------------------#
       # Enable Matter
       #---------------------------------------------------------------------#
       elif webserver.has_arg("enable")
@@ -421,71 +433,68 @@ class Matter_UI
       #---------------------------------------------------------------------#
       # Apply new configuration template
       #---------------------------------------------------------------------#
-    elif webserver.has_arg("config")
-      var config = {}
+      elif webserver.has_arg("config")
+        var config = {}
 
-      tasmota.log(string.format("MTR: /matterc received '%s' command", 'config'), 3)
-      # iterate by id
-      var idx = 0
-      var idx_str = string.format("%03i", idx)
-      while webserver.has_arg('ep'+idx_str)
+        tasmota.log(string.format("MTR: /matterc received '%s' command", 'config'), 3)
+        # iterate by id
+        var idx = 1
+        var idx_str = string.format("%03i", idx)
+        while webserver.has_arg('ep'+idx_str)
 
-        var ep = webserver.arg('ep'+idx_str)
-        var ep_int = int(ep)
-        var typ = webserver.arg('pi'+idx_str)
-        var arg = webserver.arg('arg'+idx_str)
-        tasmota.log(string.format("MTR: ep=%i type=%s arg=%s", ep, typ, arg), 3)
+          var ep = webserver.arg('ep'+idx_str)
+          var ep_int = int(ep)
+          var typ = webserver.arg('pi'+idx_str)
+          var arg = webserver.arg('arg'+idx_str)
+          tasmota.log(string.format("MTR: ep=%i type=%s arg=%s", ep, typ, arg), 3)
 
-        if ep != '' && typ != ''
-        
-          # check if type exists
-          var typ_class = self.device.plugins_classes.find(typ)
-          if typ_class != nil
-            var elt = {'type':typ}
-            typ_class.ui_string_to_conf(typ_class, elt, arg)
-            # var arg_name = typ_class.ARG
-            # var arg_type = typ_class.ARG_TYPE
-            # if arg && arg_name
-            #   elt[arg_name] = arg_type(arg)
-            # end
-            config[ep] = elt
+          if ep != '' && typ != '' && ep != '0'
+          
+            # check if type exists
+            var typ_class = self.device.plugins_classes.find(typ)
+            if typ_class != nil
+              var elt = {'type':typ}
+              typ_class.ui_string_to_conf(typ_class, elt, arg)
+              # var arg_name = typ_class.ARG
+              # var arg_type = typ_class.ARG_TYPE
+              # if arg && arg_name
+              #   elt[arg_name] = arg_type(arg)
+              # end
+              config[ep] = elt
+
+            else
+              tasmota.log(string.format("MTR: unknown type = %s", typ), 2)
+            end
 
           else
-            tasmota.log(string.format("MTR: unknown type = %s", typ), 2)
+            tasmota.log("MTR: skipping parameter", 2)
           end
 
-        else
-            tasmota.log("MTR: skipping parameter", 2)
+          idx += 1
+          idx_str = string.format("%03i", idx)
         end
 
-        idx += 1
-        idx_str = string.format("%03i", idx)
+        tasmota.log(string.format("MTR: config = %s", str(config)), 3)
+
+        if error
+          tasmota.log(string.format("MTR: config error = %s", error), 3)
+        else
+          self.device.plugins_config = config
+          self.device.plugins_persist = true
+          self.device.save_param()
+          #- and force restart -#
+          webserver.redirect("/?rst=")
+        end
+
       end
-
-      tasmota.log(string.format("MTR: config = %s", str(config)), 3)
-
-      # sanity check
-      if !config.contains("0")    error = "Missing endpoint 0"    end
 
       if error
-        tasmota.log(string.format("MTR: config error = %s", error), 3)
-      else
-        self.device.plugins_config = config
-        self.device.plugins_persist = true
-        self.device.save_param()
-        #- and force restart -#
-        webserver.redirect("/?rst=")
+        webserver.content_start("Parameter error")           #- title of the web page -#
+        webserver.content_send_style()                  #- send standard Tasmota styles -#
+        webserver.content_send(string.format("<p style='width:340px;'><b>Error:</b>%s</p>", webserver.html_escape(error)))
+        webserver.content_button(webserver.BUTTON_CONFIGURATION) #- button back to configuration page -#
+        webserver.content_stop()                        #- end of web page -#
       end
-
-    end
-
-    if error
-      webserver.content_start("Parameter error")           #- title of the web page -#
-      webserver.content_send_style()                  #- send standard Tasmota styles -#
-      webserver.content_send(string.format("<p style='width:340px;'><b>Error:</b>%s</p>", webserver.html_escape(error)))
-      webserver.content_button(webserver.BUTTON_CONFIGURATION) #- button back to configuration page -#
-      webserver.content_stop()                        #- end of web page -#
-    end
 
     except .. as e, m
       tasmota.log(string.format("BRY: Exception> '%s' - %s", e, m), 2)

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
@@ -2264,38 +2264,45 @@ be_local_closure(Matter_Device__load_plugins_config,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
+    ( &(const bvalue[34]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(k2l_num),
     /* K2   */  be_nested_str_weak(tasmota),
     /* K3   */  be_nested_str_weak(log),
     /* K4   */  be_nested_str_weak(MTR_X3A_X20endpoints_X20to_X20be_X20configured_X20),
     /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(format),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20endpoint_X20_X25i_X20config_X20_X25s),
-    /* K8   */  be_nested_str_weak(find),
-    /* K9   */  be_nested_str_weak(type),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
-    /* K11  */  be_nested_str_weak(plugins_classes),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-    /* K13  */  be_nested_str_weak(_X27_X20skipping),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_nested_str_weak(plugins),
-    /* K16  */  be_nested_str_weak(push),
-    /* K17  */  be_nested_str_weak(),
-    /* K18  */  be_nested_str_weak(k2l),
-    /* K19  */  be_nested_str_weak(_X20_X25s_X3A_X25s),
-    /* K20  */  be_nested_str_weak(stop_iteration),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20endpoint_X3A_X25i_X20type_X3A_X25s_X25s),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K23  */  be_nested_str_weak(_X7C),
-    /* K24  */  be_nested_str_weak(publish_result),
-    /* K25  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
-    /* K26  */  be_nested_str_weak(Matter),
+    /* K6   */  be_nested_str_weak(plugins),
+    /* K7   */  be_nested_str_weak(push),
+    /* K8   */  be_nested_str_weak(matter),
+    /* K9   */  be_nested_str_weak(Plugin_Root),
+    /* K10  */  be_const_int(0),
+    /* K11  */  be_nested_str_weak(format),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20endpoint_X3A_X25i_X20type_X3A_X25s_X25s),
+    /* K13  */  be_nested_str_weak(root),
+    /* K14  */  be_nested_str_weak(),
+    /* K15  */  be_const_int(2),
+    /* K16  */  be_nested_str_weak(Plugin_Aggregator),
+    /* K17  */  be_nested_str_weak(aggregator),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20endpoint_X20_X25i_X20config_X20_X25s),
+    /* K19  */  be_nested_str_weak(find),
+    /* K20  */  be_nested_str_weak(type),
+    /* K21  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20only_X20one_X20root_X20node_X20allowed),
+    /* K23  */  be_nested_str_weak(plugins_classes),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+    /* K25  */  be_nested_str_weak(_X27_X20skipping),
+    /* K26  */  be_nested_str_weak(k2l),
+    /* K27  */  be_nested_str_weak(_X20_X25s_X3A_X25s),
+    /* K28  */  be_nested_str_weak(stop_iteration),
+    /* K29  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K30  */  be_nested_str_weak(_X7C),
+    /* K31  */  be_nested_str_weak(publish_result),
+    /* K32  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
+    /* K33  */  be_nested_str_weak(Matter),
     }),
     be_str_weak(_load_plugins_config),
     &be_const_str_solidified,
-    ( &(const binstruction[133]) {  /* code */
+    ( &(const binstruction[185]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0x8C0C0101,  //  0001  GETMET	R3	R0	K1
       0x5C140200,  //  0002  MOVE	R5	R1
@@ -2308,127 +2315,179 @@ be_local_closure(Matter_Device__load_plugins_config,   /* name */
       0x001A0806,  //  0009  ADD	R6	K4	R6
       0x581C0005,  //  000A  LDCONST	R7	K5
       0x7C100600,  //  000B  CALL	R4	3
-      0x60100010,  //  000C  GETGBL	R4	G16
-      0x5C140600,  //  000D  MOVE	R5	R3
-      0x7C100200,  //  000E  CALL	R4	1
-      0xA802006B,  //  000F  EXBLK	0	#007C
-      0x5C140800,  //  0010  MOVE	R5	R4
-      0x7C140000,  //  0011  CALL	R5	0
-      0xA8020056,  //  0012  EXBLK	0	#006A
-      0x60180008,  //  0013  GETGBL	R6	G8
-      0x5C1C0A00,  //  0014  MOVE	R7	R5
-      0x7C180200,  //  0015  CALL	R6	1
-      0x94180206,  //  0016  GETIDX	R6	R1	R6
-      0xB81E0400,  //  0017  GETNGBL	R7	K2
-      0x8C1C0F03,  //  0018  GETMET	R7	R7	K3
-      0x8C240506,  //  0019  GETMET	R9	R2	K6
-      0x582C0007,  //  001A  LDCONST	R11	K7
-      0x5C300A00,  //  001B  MOVE	R12	R5
-      0x5C340C00,  //  001C  MOVE	R13	R6
-      0x7C240800,  //  001D  CALL	R9	4
-      0x58280005,  //  001E  LDCONST	R10	K5
-      0x7C1C0600,  //  001F  CALL	R7	3
-      0x8C1C0D08,  //  0020  GETMET	R7	R6	K8
-      0x58240009,  //  0021  LDCONST	R9	K9
-      0x7C1C0400,  //  0022  CALL	R7	2
-      0x4C200000,  //  0023  LDNIL	R8
-      0x1C200E08,  //  0024  EQ	R8	R7	R8
-      0x78220006,  //  0025  JMPF	R8	#002D
-      0xB8220400,  //  0026  GETNGBL	R8	K2
-      0x8C201103,  //  0027  GETMET	R8	R8	K3
-      0x5828000A,  //  0028  LDCONST	R10	K10
-      0x582C0005,  //  0029  LDCONST	R11	K5
-      0x7C200600,  //  002A  CALL	R8	3
-      0xA8040001,  //  002B  EXBLK	1	1
-      0x7001FFE2,  //  002C  JMP		#0010
-      0x8820010B,  //  002D  GETMBR	R8	R0	K11
-      0x8C201108,  //  002E  GETMET	R8	R8	K8
-      0x5C280E00,  //  002F  MOVE	R10	R7
-      0x7C200400,  //  0030  CALL	R8	2
-      0x4C240000,  //  0031  LDNIL	R9
-      0x1C241009,  //  0032  EQ	R9	R8	R9
-      0x7826000A,  //  0033  JMPF	R9	#003F
-      0xB8260400,  //  0034  GETNGBL	R9	K2
-      0x8C241303,  //  0035  GETMET	R9	R9	K3
-      0x602C0008,  //  0036  GETGBL	R11	G8
-      0x5C300E00,  //  0037  MOVE	R12	R7
-      0x7C2C0200,  //  0038  CALL	R11	1
-      0x002E180B,  //  0039  ADD	R11	K12	R11
-      0x002C170D,  //  003A  ADD	R11	R11	K13
-      0x5830000E,  //  003B  LDCONST	R12	K14
-      0x7C240600,  //  003C  CALL	R9	3
-      0xA8040001,  //  003D  EXBLK	1	1
-      0x7001FFD0,  //  003E  JMP		#0010
-      0x5C241000,  //  003F  MOVE	R9	R8
-      0x5C280000,  //  0040  MOVE	R10	R0
-      0x5C2C0A00,  //  0041  MOVE	R11	R5
-      0x5C300C00,  //  0042  MOVE	R12	R6
-      0x7C240600,  //  0043  CALL	R9	3
-      0x8828010F,  //  0044  GETMBR	R10	R0	K15
-      0x8C281510,  //  0045  GETMET	R10	R10	K16
-      0x5C301200,  //  0046  MOVE	R12	R9
-      0x7C280400,  //  0047  CALL	R10	2
-      0x58280011,  //  0048  LDCONST	R10	K17
-      0x602C0010,  //  0049  GETGBL	R11	G16
-      0x8C300112,  //  004A  GETMET	R12	R0	K18
-      0x5C380C00,  //  004B  MOVE	R14	R6
-      0x7C300400,  //  004C  CALL	R12	2
-      0x7C2C0200,  //  004D  CALL	R11	1
-      0xA802000B,  //  004E  EXBLK	0	#005B
-      0x5C301600,  //  004F  MOVE	R12	R11
-      0x7C300000,  //  0050  CALL	R12	0
-      0x1C341909,  //  0051  EQ	R13	R12	K9
-      0x78360000,  //  0052  JMPF	R13	#0054
-      0x7001FFFA,  //  0053  JMP		#004F
-      0x8C340506,  //  0054  GETMET	R13	R2	K6
-      0x583C0013,  //  0055  LDCONST	R15	K19
-      0x5C401800,  //  0056  MOVE	R16	R12
-      0x94440C0C,  //  0057  GETIDX	R17	R6	R12
-      0x7C340800,  //  0058  CALL	R13	4
-      0x0028140D,  //  0059  ADD	R10	R10	R13
-      0x7001FFF3,  //  005A  JMP		#004F
-      0x582C0014,  //  005B  LDCONST	R11	K20
-      0xAC2C0200,  //  005C  CATCH	R11	1	0
-      0xB0080000,  //  005D  RAISE	2	R0	R0
-      0xB82E0400,  //  005E  GETNGBL	R11	K2
-      0x8C2C1703,  //  005F  GETMET	R11	R11	K3
-      0x8C340506,  //  0060  GETMET	R13	R2	K6
-      0x583C0015,  //  0061  LDCONST	R15	K21
-      0x5C400A00,  //  0062  MOVE	R16	R5
-      0x5C440E00,  //  0063  MOVE	R17	R7
-      0x5C481400,  //  0064  MOVE	R18	R10
-      0x7C340A00,  //  0065  CALL	R13	5
-      0x5838000E,  //  0066  LDCONST	R14	K14
-      0x7C2C0600,  //  0067  CALL	R11	3
-      0xA8040001,  //  0068  EXBLK	1	1
-      0x70020010,  //  0069  JMP		#007B
-      0xAC180002,  //  006A  CATCH	R6	0	2
-      0x7002000D,  //  006B  JMP		#007A
-      0xB8220400,  //  006C  GETNGBL	R8	K2
-      0x8C201103,  //  006D  GETMET	R8	R8	K3
-      0x60280008,  //  006E  GETGBL	R10	G8
-      0x5C2C0C00,  //  006F  MOVE	R11	R6
-      0x7C280200,  //  0070  CALL	R10	1
-      0x002A2C0A,  //  0071  ADD	R10	K22	R10
-      0x00281517,  //  0072  ADD	R10	R10	K23
-      0x602C0008,  //  0073  GETGBL	R11	G8
-      0x5C300E00,  //  0074  MOVE	R12	R7
-      0x7C2C0200,  //  0075  CALL	R11	1
-      0x0028140B,  //  0076  ADD	R10	R10	R11
-      0x582C000E,  //  0077  LDCONST	R11	K14
-      0x7C200600,  //  0078  CALL	R8	3
-      0x70020000,  //  0079  JMP		#007B
-      0xB0080000,  //  007A  RAISE	2	R0	R0
-      0x7001FF93,  //  007B  JMP		#0010
-      0x58100014,  //  007C  LDCONST	R4	K20
-      0xAC100200,  //  007D  CATCH	R4	1	0
-      0xB0080000,  //  007E  RAISE	2	R0	R0
-      0xB8120400,  //  007F  GETNGBL	R4	K2
-      0x8C100918,  //  0080  GETMET	R4	R4	K24
-      0x58180019,  //  0081  LDCONST	R6	K25
-      0x581C001A,  //  0082  LDCONST	R7	K26
-      0x7C100600,  //  0083  CALL	R4	3
-      0x80000000,  //  0084  RET	0
+      0x88100106,  //  000C  GETMBR	R4	R0	K6
+      0x8C100907,  //  000D  GETMET	R4	R4	K7
+      0xB81A1000,  //  000E  GETNGBL	R6	K8
+      0x8C180D09,  //  000F  GETMET	R6	R6	K9
+      0x5C200000,  //  0010  MOVE	R8	R0
+      0x5824000A,  //  0011  LDCONST	R9	K10
+      0x60280013,  //  0012  GETGBL	R10	G19
+      0x7C280000,  //  0013  CALL	R10	0
+      0x7C180800,  //  0014  CALL	R6	4
+      0x7C100400,  //  0015  CALL	R4	2
+      0xB8120400,  //  0016  GETNGBL	R4	K2
+      0x8C100903,  //  0017  GETMET	R4	R4	K3
+      0x8C18050B,  //  0018  GETMET	R6	R2	K11
+      0x5820000C,  //  0019  LDCONST	R8	K12
+      0x5824000A,  //  001A  LDCONST	R9	K10
+      0x5828000D,  //  001B  LDCONST	R10	K13
+      0x582C000E,  //  001C  LDCONST	R11	K14
+      0x7C180A00,  //  001D  CALL	R6	5
+      0x581C000F,  //  001E  LDCONST	R7	K15
+      0x7C100600,  //  001F  CALL	R4	3
+      0x88100106,  //  0020  GETMBR	R4	R0	K6
+      0x8C100907,  //  0021  GETMET	R4	R4	K7
+      0xB81A1000,  //  0022  GETNGBL	R6	K8
+      0x8C180D10,  //  0023  GETMET	R6	R6	K16
+      0x5C200000,  //  0024  MOVE	R8	R0
+      0x5426FEFF,  //  0025  LDINT	R9	65280
+      0x60280013,  //  0026  GETGBL	R10	G19
+      0x7C280000,  //  0027  CALL	R10	0
+      0x7C180800,  //  0028  CALL	R6	4
+      0x7C100400,  //  0029  CALL	R4	2
+      0xB8120400,  //  002A  GETNGBL	R4	K2
+      0x8C100903,  //  002B  GETMET	R4	R4	K3
+      0x8C18050B,  //  002C  GETMET	R6	R2	K11
+      0x5820000C,  //  002D  LDCONST	R8	K12
+      0x5426FEFF,  //  002E  LDINT	R9	65280
+      0x58280011,  //  002F  LDCONST	R10	K17
+      0x582C000E,  //  0030  LDCONST	R11	K14
+      0x7C180A00,  //  0031  CALL	R6	5
+      0x581C000F,  //  0032  LDCONST	R7	K15
+      0x7C100600,  //  0033  CALL	R4	3
+      0x60100010,  //  0034  GETGBL	R4	G16
+      0x5C140600,  //  0035  MOVE	R5	R3
+      0x7C100200,  //  0036  CALL	R4	1
+      0xA8020077,  //  0037  EXBLK	0	#00B0
+      0x5C140800,  //  0038  MOVE	R5	R4
+      0x7C140000,  //  0039  CALL	R5	0
+      0x1C180B0A,  //  003A  EQ	R6	R5	K10
+      0x781A0000,  //  003B  JMPF	R6	#003D
+      0x7001FFFA,  //  003C  JMP		#0038
+      0xA802005F,  //  003D  EXBLK	0	#009E
+      0x60180008,  //  003E  GETGBL	R6	G8
+      0x5C1C0A00,  //  003F  MOVE	R7	R5
+      0x7C180200,  //  0040  CALL	R6	1
+      0x94180206,  //  0041  GETIDX	R6	R1	R6
+      0xB81E0400,  //  0042  GETNGBL	R7	K2
+      0x8C1C0F03,  //  0043  GETMET	R7	R7	K3
+      0x8C24050B,  //  0044  GETMET	R9	R2	K11
+      0x582C0012,  //  0045  LDCONST	R11	K18
+      0x5C300A00,  //  0046  MOVE	R12	R5
+      0x5C340C00,  //  0047  MOVE	R13	R6
+      0x7C240800,  //  0048  CALL	R9	4
+      0x58280005,  //  0049  LDCONST	R10	K5
+      0x7C1C0600,  //  004A  CALL	R7	3
+      0x8C1C0D13,  //  004B  GETMET	R7	R6	K19
+      0x58240014,  //  004C  LDCONST	R9	K20
+      0x7C1C0400,  //  004D  CALL	R7	2
+      0x4C200000,  //  004E  LDNIL	R8
+      0x1C200E08,  //  004F  EQ	R8	R7	R8
+      0x78220006,  //  0050  JMPF	R8	#0058
+      0xB8220400,  //  0051  GETNGBL	R8	K2
+      0x8C201103,  //  0052  GETMET	R8	R8	K3
+      0x58280015,  //  0053  LDCONST	R10	K21
+      0x582C0005,  //  0054  LDCONST	R11	K5
+      0x7C200600,  //  0055  CALL	R8	3
+      0xA8040001,  //  0056  EXBLK	1	1
+      0x7001FFDF,  //  0057  JMP		#0038
+      0x1C200F0D,  //  0058  EQ	R8	R7	K13
+      0x78220006,  //  0059  JMPF	R8	#0061
+      0xB8220400,  //  005A  GETNGBL	R8	K2
+      0x8C201103,  //  005B  GETMET	R8	R8	K3
+      0x58280016,  //  005C  LDCONST	R10	K22
+      0x582C0005,  //  005D  LDCONST	R11	K5
+      0x7C200600,  //  005E  CALL	R8	3
+      0xA8040001,  //  005F  EXBLK	1	1
+      0x7001FFD6,  //  0060  JMP		#0038
+      0x88200117,  //  0061  GETMBR	R8	R0	K23
+      0x8C201113,  //  0062  GETMET	R8	R8	K19
+      0x5C280E00,  //  0063  MOVE	R10	R7
+      0x7C200400,  //  0064  CALL	R8	2
+      0x4C240000,  //  0065  LDNIL	R9
+      0x1C241009,  //  0066  EQ	R9	R8	R9
+      0x7826000A,  //  0067  JMPF	R9	#0073
+      0xB8260400,  //  0068  GETNGBL	R9	K2
+      0x8C241303,  //  0069  GETMET	R9	R9	K3
+      0x602C0008,  //  006A  GETGBL	R11	G8
+      0x5C300E00,  //  006B  MOVE	R12	R7
+      0x7C2C0200,  //  006C  CALL	R11	1
+      0x002E300B,  //  006D  ADD	R11	K24	R11
+      0x002C1719,  //  006E  ADD	R11	R11	K25
+      0x5830000F,  //  006F  LDCONST	R12	K15
+      0x7C240600,  //  0070  CALL	R9	3
+      0xA8040001,  //  0071  EXBLK	1	1
+      0x7001FFC4,  //  0072  JMP		#0038
+      0x5C241000,  //  0073  MOVE	R9	R8
+      0x5C280000,  //  0074  MOVE	R10	R0
+      0x5C2C0A00,  //  0075  MOVE	R11	R5
+      0x5C300C00,  //  0076  MOVE	R12	R6
+      0x7C240600,  //  0077  CALL	R9	3
+      0x88280106,  //  0078  GETMBR	R10	R0	K6
+      0x8C281507,  //  0079  GETMET	R10	R10	K7
+      0x5C301200,  //  007A  MOVE	R12	R9
+      0x7C280400,  //  007B  CALL	R10	2
+      0x5828000E,  //  007C  LDCONST	R10	K14
+      0x602C0010,  //  007D  GETGBL	R11	G16
+      0x8C30011A,  //  007E  GETMET	R12	R0	K26
+      0x5C380C00,  //  007F  MOVE	R14	R6
+      0x7C300400,  //  0080  CALL	R12	2
+      0x7C2C0200,  //  0081  CALL	R11	1
+      0xA802000B,  //  0082  EXBLK	0	#008F
+      0x5C301600,  //  0083  MOVE	R12	R11
+      0x7C300000,  //  0084  CALL	R12	0
+      0x1C341914,  //  0085  EQ	R13	R12	K20
+      0x78360000,  //  0086  JMPF	R13	#0088
+      0x7001FFFA,  //  0087  JMP		#0083
+      0x8C34050B,  //  0088  GETMET	R13	R2	K11
+      0x583C001B,  //  0089  LDCONST	R15	K27
+      0x5C401800,  //  008A  MOVE	R16	R12
+      0x94440C0C,  //  008B  GETIDX	R17	R6	R12
+      0x7C340800,  //  008C  CALL	R13	4
+      0x0028140D,  //  008D  ADD	R10	R10	R13
+      0x7001FFF3,  //  008E  JMP		#0083
+      0x582C001C,  //  008F  LDCONST	R11	K28
+      0xAC2C0200,  //  0090  CATCH	R11	1	0
+      0xB0080000,  //  0091  RAISE	2	R0	R0
+      0xB82E0400,  //  0092  GETNGBL	R11	K2
+      0x8C2C1703,  //  0093  GETMET	R11	R11	K3
+      0x8C34050B,  //  0094  GETMET	R13	R2	K11
+      0x583C000C,  //  0095  LDCONST	R15	K12
+      0x5C400A00,  //  0096  MOVE	R16	R5
+      0x5C440E00,  //  0097  MOVE	R17	R7
+      0x5C481400,  //  0098  MOVE	R18	R10
+      0x7C340A00,  //  0099  CALL	R13	5
+      0x5838000F,  //  009A  LDCONST	R14	K15
+      0x7C2C0600,  //  009B  CALL	R11	3
+      0xA8040001,  //  009C  EXBLK	1	1
+      0x70020010,  //  009D  JMP		#00AF
+      0xAC180002,  //  009E  CATCH	R6	0	2
+      0x7002000D,  //  009F  JMP		#00AE
+      0xB8220400,  //  00A0  GETNGBL	R8	K2
+      0x8C201103,  //  00A1  GETMET	R8	R8	K3
+      0x60280008,  //  00A2  GETGBL	R10	G8
+      0x5C2C0C00,  //  00A3  MOVE	R11	R6
+      0x7C280200,  //  00A4  CALL	R10	1
+      0x002A3A0A,  //  00A5  ADD	R10	K29	R10
+      0x0028151E,  //  00A6  ADD	R10	R10	K30
+      0x602C0008,  //  00A7  GETGBL	R11	G8
+      0x5C300E00,  //  00A8  MOVE	R12	R7
+      0x7C2C0200,  //  00A9  CALL	R11	1
+      0x0028140B,  //  00AA  ADD	R10	R10	R11
+      0x582C000F,  //  00AB  LDCONST	R11	K15
+      0x7C200600,  //  00AC  CALL	R8	3
+      0x70020000,  //  00AD  JMP		#00AF
+      0xB0080000,  //  00AE  RAISE	2	R0	R0
+      0x7001FF87,  //  00AF  JMP		#0038
+      0x5810001C,  //  00B0  LDCONST	R4	K28
+      0xAC100200,  //  00B1  CATCH	R4	1	0
+      0xB0080000,  //  00B2  RAISE	2	R0	R0
+      0xB8120400,  //  00B3  GETNGBL	R4	K2
+      0x8C10091F,  //  00B4  GETMET	R4	R4	K31
+      0x58180020,  //  00B5  LDCONST	R6	K32
+      0x581C0021,  //  00B6  LDCONST	R7	K33
+      0x7C100600,  //  00B7  CALL	R4	3
+      0x80000000,  //  00B8  RET	0
     })
   )
 );
@@ -4034,406 +4093,400 @@ be_local_closure(Matter_Device_autoconf_device_map,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[53]) {     /* constants */
+    ( &(const bvalue[51]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(json),
-    /* K2   */  be_nested_str_weak(0),
-    /* K3   */  be_nested_str_weak(type),
-    /* K4   */  be_nested_str_weak(root),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(light),
-    /* K7   */  be_nested_str_weak(get),
-    /* K8   */  be_nested_str_weak(find),
-    /* K9   */  be_nested_str_weak(channels),
-    /* K10  */  be_nested_str_weak(),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(light1),
-    /* K13  */  be_const_int(2),
-    /* K14  */  be_nested_str_weak(light2),
-    /* K15  */  be_nested_str_weak(light3),
-    /* K16  */  be_nested_str_weak(tasmota),
-    /* K17  */  be_nested_str_weak(cmd),
-    /* K18  */  be_nested_str_weak(Status_X2013),
-    /* K19  */  be_nested_str_weak(log),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20Status_X2013_X20_X3D_X20),
-    /* K21  */  be_const_int(3),
-    /* K22  */  be_nested_str_weak(contains),
-    /* K23  */  be_nested_str_weak(StatusSHT),
-    /* K24  */  be_nested_str_weak(SHT),
-    /* K25  */  be_nested_str_weak(format),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20_X27_X25s_X27_X20_X3D_X20_X25s),
-    /* K27  */  be_nested_str_weak(Relay1),
-    /* K28  */  be_nested_str_weak(Relay2),
-    /* K29  */  be_nested_str_weak(push),
-    /* K30  */  be_nested_str_weak(MTR_X3A_X20relay1_X20_X3D_X20_X25s_X2C_X20relay2_X20_X3D_X20_X25s),
-    /* K31  */  be_nested_str_weak(TiltConfig),
-    /* K32  */  be_nested_str_weak(shutter_X2Btilt),
-    /* K33  */  be_nested_str_weak(shutter),
-    /* K34  */  be_nested_str_weak(get_power),
-    /* K35  */  be_nested_str_weak(relay),
-    /* K36  */  be_nested_str_weak(load),
-    /* K37  */  be_nested_str_weak(read_sensors),
-    /* K38  */  be_nested_str_weak(k2l),
-    /* K39  */  be_nested_str_weak(Temperature),
-    /* K40  */  be_nested_str_weak(_X23Temperature),
-    /* K41  */  be_nested_str_weak(temperature),
-    /* K42  */  be_nested_str_weak(filter),
-    /* K43  */  be_nested_str_weak(stop_iteration),
-    /* K44  */  be_nested_str_weak(Pressure),
-    /* K45  */  be_nested_str_weak(_X23Pressure),
-    /* K46  */  be_nested_str_weak(pressure),
-    /* K47  */  be_nested_str_weak(Illuminance),
-    /* K48  */  be_nested_str_weak(_X23Illuminance),
-    /* K49  */  be_nested_str_weak(illuminance),
-    /* K50  */  be_nested_str_weak(Humidity),
-    /* K51  */  be_nested_str_weak(_X23Humidity),
-    /* K52  */  be_nested_str_weak(humidity),
+    /* K2   */  be_const_int(1),
+    /* K3   */  be_nested_str_weak(light),
+    /* K4   */  be_nested_str_weak(get),
+    /* K5   */  be_nested_str_weak(find),
+    /* K6   */  be_nested_str_weak(channels),
+    /* K7   */  be_nested_str_weak(),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(type),
+    /* K10  */  be_nested_str_weak(light1),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_nested_str_weak(light2),
+    /* K13  */  be_nested_str_weak(light3),
+    /* K14  */  be_nested_str_weak(tasmota),
+    /* K15  */  be_nested_str_weak(cmd),
+    /* K16  */  be_nested_str_weak(Status_X2013),
+    /* K17  */  be_nested_str_weak(log),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20Status_X2013_X20_X3D_X20),
+    /* K19  */  be_const_int(3),
+    /* K20  */  be_nested_str_weak(contains),
+    /* K21  */  be_nested_str_weak(StatusSHT),
+    /* K22  */  be_nested_str_weak(SHT),
+    /* K23  */  be_nested_str_weak(format),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20_X27_X25s_X27_X20_X3D_X20_X25s),
+    /* K25  */  be_nested_str_weak(Relay1),
+    /* K26  */  be_nested_str_weak(Relay2),
+    /* K27  */  be_nested_str_weak(push),
+    /* K28  */  be_nested_str_weak(MTR_X3A_X20relay1_X20_X3D_X20_X25s_X2C_X20relay2_X20_X3D_X20_X25s),
+    /* K29  */  be_nested_str_weak(TiltConfig),
+    /* K30  */  be_nested_str_weak(shutter_X2Btilt),
+    /* K31  */  be_nested_str_weak(shutter),
+    /* K32  */  be_nested_str_weak(get_power),
+    /* K33  */  be_nested_str_weak(relay),
+    /* K34  */  be_nested_str_weak(load),
+    /* K35  */  be_nested_str_weak(read_sensors),
+    /* K36  */  be_nested_str_weak(k2l),
+    /* K37  */  be_nested_str_weak(Temperature),
+    /* K38  */  be_nested_str_weak(_X23Temperature),
+    /* K39  */  be_nested_str_weak(temperature),
+    /* K40  */  be_nested_str_weak(filter),
+    /* K41  */  be_nested_str_weak(stop_iteration),
+    /* K42  */  be_nested_str_weak(Pressure),
+    /* K43  */  be_nested_str_weak(_X23Pressure),
+    /* K44  */  be_nested_str_weak(pressure),
+    /* K45  */  be_nested_str_weak(Illuminance),
+    /* K46  */  be_nested_str_weak(_X23Illuminance),
+    /* K47  */  be_nested_str_weak(illuminance),
+    /* K48  */  be_nested_str_weak(Humidity),
+    /* K49  */  be_nested_str_weak(_X23Humidity),
+    /* K50  */  be_nested_str_weak(humidity),
     }),
     be_str_weak(autoconf_device_map),
     &be_const_str_solidified,
-    ( &(const binstruction[342]) {  /* code */
+    ( &(const binstruction[338]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xA40A0200,  //  0001  IMPORT	R2	K1
       0x600C0013,  //  0002  GETGBL	R3	G19
       0x7C0C0000,  //  0003  CALL	R3	0
-      0x60100013,  //  0004  GETGBL	R4	G19
-      0x7C100000,  //  0005  CALL	R4	0
-      0x98120704,  //  0006  SETIDX	R4	K3	K4
-      0x980E0404,  //  0007  SETIDX	R3	K2	R4
-      0x58100005,  //  0008  LDCONST	R4	K5
-      0x50140000,  //  0009  LDBOOL	R5	0	0
-      0xA41A0C00,  //  000A  IMPORT	R6	K6
-      0x8C1C0D07,  //  000B  GETMET	R7	R6	K7
-      0x7C1C0200,  //  000C  CALL	R7	1
-      0x4C200000,  //  000D  LDNIL	R8
-      0x20200E08,  //  000E  NE	R8	R7	R8
-      0x78220024,  //  000F  JMPF	R8	#0035
-      0x6020000C,  //  0010  GETGBL	R8	G12
-      0x8C240F08,  //  0011  GETMET	R9	R7	K8
-      0x582C0009,  //  0012  LDCONST	R11	K9
-      0x5830000A,  //  0013  LDCONST	R12	K10
-      0x7C240600,  //  0014  CALL	R9	3
-      0x7C200200,  //  0015  CALL	R8	1
-      0x2424110B,  //  0016  GT	R9	R8	K11
-      0x7826001C,  //  0017  JMPF	R9	#0035
-      0x1C241105,  //  0018  EQ	R9	R8	K5
-      0x78260007,  //  0019  JMPF	R9	#0022
-      0x60240008,  //  001A  GETGBL	R9	G8
-      0x5C280800,  //  001B  MOVE	R10	R4
-      0x7C240200,  //  001C  CALL	R9	1
-      0x60280013,  //  001D  GETGBL	R10	G19
-      0x7C280000,  //  001E  CALL	R10	0
-      0x982A070C,  //  001F  SETIDX	R10	K3	K12
-      0x980C120A,  //  0020  SETIDX	R3	R9	R10
-      0x70020010,  //  0021  JMP		#0033
-      0x1C24110D,  //  0022  EQ	R9	R8	K13
-      0x78260007,  //  0023  JMPF	R9	#002C
-      0x60240008,  //  0024  GETGBL	R9	G8
-      0x5C280800,  //  0025  MOVE	R10	R4
-      0x7C240200,  //  0026  CALL	R9	1
-      0x60280013,  //  0027  GETGBL	R10	G19
-      0x7C280000,  //  0028  CALL	R10	0
-      0x982A070E,  //  0029  SETIDX	R10	K3	K14
-      0x980C120A,  //  002A  SETIDX	R3	R9	R10
-      0x70020006,  //  002B  JMP		#0033
-      0x60240008,  //  002C  GETGBL	R9	G8
-      0x5C280800,  //  002D  MOVE	R10	R4
-      0x7C240200,  //  002E  CALL	R9	1
-      0x60280013,  //  002F  GETGBL	R10	G19
-      0x7C280000,  //  0030  CALL	R10	0
-      0x982A070F,  //  0031  SETIDX	R10	K3	K15
-      0x980C120A,  //  0032  SETIDX	R3	R9	R10
-      0x50140200,  //  0033  LDBOOL	R5	1	0
-      0x00100905,  //  0034  ADD	R4	R4	K5
-      0xB8222000,  //  0035  GETNGBL	R8	K16
-      0x8C201111,  //  0036  GETMET	R8	R8	K17
-      0x58280012,  //  0037  LDCONST	R10	K18
-      0x502C0200,  //  0038  LDBOOL	R11	1	0
-      0x7C200600,  //  0039  CALL	R8	3
-      0x60240012,  //  003A  GETGBL	R9	G18
-      0x7C240000,  //  003B  CALL	R9	0
-      0xB82A2000,  //  003C  GETNGBL	R10	K16
-      0x8C281513,  //  003D  GETMET	R10	R10	K19
-      0x60300008,  //  003E  GETGBL	R12	G8
-      0x5C341000,  //  003F  MOVE	R13	R8
-      0x7C300200,  //  0040  CALL	R12	1
-      0x0032280C,  //  0041  ADD	R12	K20	R12
-      0x58340015,  //  0042  LDCONST	R13	K21
-      0x7C280600,  //  0043  CALL	R10	3
-      0x4C280000,  //  0044  LDNIL	R10
-      0x2028100A,  //  0045  NE	R10	R8	R10
-      0x782A0051,  //  0046  JMPF	R10	#0099
-      0x8C281116,  //  0047  GETMET	R10	R8	K22
-      0x58300017,  //  0048  LDCONST	R12	K23
-      0x7C280400,  //  0049  CALL	R10	2
-      0x782A004D,  //  004A  JMPF	R10	#0099
-      0x94201117,  //  004B  GETIDX	R8	R8	K23
-      0x5828000B,  //  004C  LDCONST	R10	K11
-      0x502C0200,  //  004D  LDBOOL	R11	1	0
-      0x782E0049,  //  004E  JMPF	R11	#0099
-      0x602C0008,  //  004F  GETGBL	R11	G8
-      0x5C301400,  //  0050  MOVE	R12	R10
-      0x7C2C0200,  //  0051  CALL	R11	1
-      0x002E300B,  //  0052  ADD	R11	K24	R11
-      0x8C301116,  //  0053  GETMET	R12	R8	K22
-      0x5C381600,  //  0054  MOVE	R14	R11
-      0x7C300400,  //  0055  CALL	R12	2
-      0x74320000,  //  0056  JMPT	R12	#0058
-      0x70020040,  //  0057  JMP		#0099
-      0x9430100B,  //  0058  GETIDX	R12	R8	R11
-      0xB8362000,  //  0059  GETNGBL	R13	K16
-      0x8C341B13,  //  005A  GETMET	R13	R13	K19
-      0x8C3C0319,  //  005B  GETMET	R15	R1	K25
-      0x5844001A,  //  005C  LDCONST	R17	K26
-      0x5C481600,  //  005D  MOVE	R18	R11
-      0x604C0008,  //  005E  GETGBL	R19	G8
-      0x5C501800,  //  005F  MOVE	R20	R12
-      0x7C4C0200,  //  0060  CALL	R19	1
-      0x7C3C0800,  //  0061  CALL	R15	4
-      0x58400015,  //  0062  LDCONST	R16	K21
+      0x58100002,  //  0004  LDCONST	R4	K2
+      0x50140000,  //  0005  LDBOOL	R5	0	0
+      0xA41A0600,  //  0006  IMPORT	R6	K3
+      0x8C1C0D04,  //  0007  GETMET	R7	R6	K4
+      0x7C1C0200,  //  0008  CALL	R7	1
+      0x4C200000,  //  0009  LDNIL	R8
+      0x20200E08,  //  000A  NE	R8	R7	R8
+      0x78220024,  //  000B  JMPF	R8	#0031
+      0x6020000C,  //  000C  GETGBL	R8	G12
+      0x8C240F05,  //  000D  GETMET	R9	R7	K5
+      0x582C0006,  //  000E  LDCONST	R11	K6
+      0x58300007,  //  000F  LDCONST	R12	K7
+      0x7C240600,  //  0010  CALL	R9	3
+      0x7C200200,  //  0011  CALL	R8	1
+      0x24241108,  //  0012  GT	R9	R8	K8
+      0x7826001C,  //  0013  JMPF	R9	#0031
+      0x1C241102,  //  0014  EQ	R9	R8	K2
+      0x78260007,  //  0015  JMPF	R9	#001E
+      0x60240008,  //  0016  GETGBL	R9	G8
+      0x5C280800,  //  0017  MOVE	R10	R4
+      0x7C240200,  //  0018  CALL	R9	1
+      0x60280013,  //  0019  GETGBL	R10	G19
+      0x7C280000,  //  001A  CALL	R10	0
+      0x982A130A,  //  001B  SETIDX	R10	K9	K10
+      0x980C120A,  //  001C  SETIDX	R3	R9	R10
+      0x70020010,  //  001D  JMP		#002F
+      0x1C24110B,  //  001E  EQ	R9	R8	K11
+      0x78260007,  //  001F  JMPF	R9	#0028
+      0x60240008,  //  0020  GETGBL	R9	G8
+      0x5C280800,  //  0021  MOVE	R10	R4
+      0x7C240200,  //  0022  CALL	R9	1
+      0x60280013,  //  0023  GETGBL	R10	G19
+      0x7C280000,  //  0024  CALL	R10	0
+      0x982A130C,  //  0025  SETIDX	R10	K9	K12
+      0x980C120A,  //  0026  SETIDX	R3	R9	R10
+      0x70020006,  //  0027  JMP		#002F
+      0x60240008,  //  0028  GETGBL	R9	G8
+      0x5C280800,  //  0029  MOVE	R10	R4
+      0x7C240200,  //  002A  CALL	R9	1
+      0x60280013,  //  002B  GETGBL	R10	G19
+      0x7C280000,  //  002C  CALL	R10	0
+      0x982A130D,  //  002D  SETIDX	R10	K9	K13
+      0x980C120A,  //  002E  SETIDX	R3	R9	R10
+      0x50140200,  //  002F  LDBOOL	R5	1	0
+      0x00100902,  //  0030  ADD	R4	R4	K2
+      0xB8221C00,  //  0031  GETNGBL	R8	K14
+      0x8C20110F,  //  0032  GETMET	R8	R8	K15
+      0x58280010,  //  0033  LDCONST	R10	K16
+      0x502C0200,  //  0034  LDBOOL	R11	1	0
+      0x7C200600,  //  0035  CALL	R8	3
+      0x60240012,  //  0036  GETGBL	R9	G18
+      0x7C240000,  //  0037  CALL	R9	0
+      0xB82A1C00,  //  0038  GETNGBL	R10	K14
+      0x8C281511,  //  0039  GETMET	R10	R10	K17
+      0x60300008,  //  003A  GETGBL	R12	G8
+      0x5C341000,  //  003B  MOVE	R13	R8
+      0x7C300200,  //  003C  CALL	R12	1
+      0x0032240C,  //  003D  ADD	R12	K18	R12
+      0x58340013,  //  003E  LDCONST	R13	K19
+      0x7C280600,  //  003F  CALL	R10	3
+      0x4C280000,  //  0040  LDNIL	R10
+      0x2028100A,  //  0041  NE	R10	R8	R10
+      0x782A0051,  //  0042  JMPF	R10	#0095
+      0x8C281114,  //  0043  GETMET	R10	R8	K20
+      0x58300015,  //  0044  LDCONST	R12	K21
+      0x7C280400,  //  0045  CALL	R10	2
+      0x782A004D,  //  0046  JMPF	R10	#0095
+      0x94201115,  //  0047  GETIDX	R8	R8	K21
+      0x58280008,  //  0048  LDCONST	R10	K8
+      0x502C0200,  //  0049  LDBOOL	R11	1	0
+      0x782E0049,  //  004A  JMPF	R11	#0095
+      0x602C0008,  //  004B  GETGBL	R11	G8
+      0x5C301400,  //  004C  MOVE	R12	R10
+      0x7C2C0200,  //  004D  CALL	R11	1
+      0x002E2C0B,  //  004E  ADD	R11	K22	R11
+      0x8C301114,  //  004F  GETMET	R12	R8	K20
+      0x5C381600,  //  0050  MOVE	R14	R11
+      0x7C300400,  //  0051  CALL	R12	2
+      0x74320000,  //  0052  JMPT	R12	#0054
+      0x70020040,  //  0053  JMP		#0095
+      0x9430100B,  //  0054  GETIDX	R12	R8	R11
+      0xB8361C00,  //  0055  GETNGBL	R13	K14
+      0x8C341B11,  //  0056  GETMET	R13	R13	K17
+      0x8C3C0317,  //  0057  GETMET	R15	R1	K23
+      0x58440018,  //  0058  LDCONST	R17	K24
+      0x5C481600,  //  0059  MOVE	R18	R11
+      0x604C0008,  //  005A  GETGBL	R19	G8
+      0x5C501800,  //  005B  MOVE	R20	R12
+      0x7C4C0200,  //  005C  CALL	R19	1
+      0x7C3C0800,  //  005D  CALL	R15	4
+      0x58400013,  //  005E  LDCONST	R16	K19
+      0x7C340600,  //  005F  CALL	R13	3
+      0x8C341905,  //  0060  GETMET	R13	R12	K5
+      0x583C0019,  //  0061  LDCONST	R15	K25
+      0x58400008,  //  0062  LDCONST	R16	K8
       0x7C340600,  //  0063  CALL	R13	3
-      0x8C341908,  //  0064  GETMET	R13	R12	K8
-      0x583C001B,  //  0065  LDCONST	R15	K27
-      0x5840000B,  //  0066  LDCONST	R16	K11
-      0x7C340600,  //  0067  CALL	R13	3
-      0x04341B05,  //  0068  SUB	R13	R13	K5
-      0x8C381908,  //  0069  GETMET	R14	R12	K8
-      0x5840001C,  //  006A  LDCONST	R16	K28
-      0x5844000B,  //  006B  LDCONST	R17	K11
-      0x7C380600,  //  006C  CALL	R14	3
-      0x04381D05,  //  006D  SUB	R14	R14	K5
-      0x283C1B0B,  //  006E  GE	R15	R13	K11
-      0x783E0002,  //  006F  JMPF	R15	#0073
-      0x8C3C131D,  //  0070  GETMET	R15	R9	K29
-      0x5C441A00,  //  0071  MOVE	R17	R13
-      0x7C3C0400,  //  0072  CALL	R15	2
-      0x283C1D0B,  //  0073  GE	R15	R14	K11
-      0x783E0002,  //  0074  JMPF	R15	#0078
-      0x8C3C131D,  //  0075  GETMET	R15	R9	K29
-      0x5C441C00,  //  0076  MOVE	R17	R14
-      0x7C3C0400,  //  0077  CALL	R15	2
-      0xB83E2000,  //  0078  GETNGBL	R15	K16
-      0x8C3C1F13,  //  0079  GETMET	R15	R15	K19
-      0x8C440319,  //  007A  GETMET	R17	R1	K25
-      0x584C001E,  //  007B  LDCONST	R19	K30
-      0x5C501A00,  //  007C  MOVE	R20	R13
-      0x5C541C00,  //  007D  MOVE	R21	R14
-      0x7C440800,  //  007E  CALL	R17	4
-      0x58480015,  //  007F  LDCONST	R18	K21
-      0x7C3C0600,  //  0080  CALL	R15	3
-      0x8C3C1908,  //  0081  GETMET	R15	R12	K8
-      0x5844001F,  //  0082  LDCONST	R17	K31
-      0x7C3C0400,  //  0083  CALL	R15	2
-      0x783E0002,  //  0084  JMPF	R15	#0088
-      0x94401F0D,  //  0085  GETIDX	R16	R15	K13
-      0x2440210B,  //  0086  GT	R16	R16	K11
-      0x74420000,  //  0087  JMPT	R16	#0089
-      0x50400001,  //  0088  LDBOOL	R16	0	1
-      0x50400200,  //  0089  LDBOOL	R16	1	0
-      0x60440008,  //  008A  GETGBL	R17	G8
-      0x5C480800,  //  008B  MOVE	R18	R4
-      0x7C440200,  //  008C  CALL	R17	1
-      0x60480013,  //  008D  GETGBL	R18	G19
-      0x7C480000,  //  008E  CALL	R18	0
-      0x78420001,  //  008F  JMPF	R16	#0092
-      0x584C0020,  //  0090  LDCONST	R19	K32
-      0x70020000,  //  0091  JMP		#0093
-      0x584C0021,  //  0092  LDCONST	R19	K33
-      0x984A0613,  //  0093  SETIDX	R18	K3	R19
-      0x984A420A,  //  0094  SETIDX	R18	K33	R10
-      0x980C2212,  //  0095  SETIDX	R3	R17	R18
-      0x00100905,  //  0096  ADD	R4	R4	K5
-      0x00281505,  //  0097  ADD	R10	R10	K5
-      0x7001FFB3,  //  0098  JMP		#004D
-      0x6028000C,  //  0099  GETGBL	R10	G12
-      0xB82E2000,  //  009A  GETNGBL	R11	K16
-      0x8C2C1722,  //  009B  GETMET	R11	R11	K34
-      0x7C2C0200,  //  009C  CALL	R11	1
-      0x7C280200,  //  009D  CALL	R10	1
-      0x582C000B,  //  009E  LDCONST	R11	K11
-      0x78160000,  //  009F  JMPF	R5	#00A1
-      0x04281505,  //  00A0  SUB	R10	R10	K5
-      0x1430160A,  //  00A1  LT	R12	R11	R10
-      0x78320010,  //  00A2  JMPF	R12	#00B4
-      0x8C301308,  //  00A3  GETMET	R12	R9	K8
-      0x5C381600,  //  00A4  MOVE	R14	R11
-      0x7C300400,  //  00A5  CALL	R12	2
-      0x4C340000,  //  00A6  LDNIL	R13
-      0x1C30180D,  //  00A7  EQ	R12	R12	R13
-      0x78320008,  //  00A8  JMPF	R12	#00B2
-      0x60300008,  //  00A9  GETGBL	R12	G8
-      0x5C340800,  //  00AA  MOVE	R13	R4
-      0x7C300200,  //  00AB  CALL	R12	1
-      0x60340013,  //  00AC  GETGBL	R13	G19
-      0x7C340000,  //  00AD  CALL	R13	0
-      0x98360723,  //  00AE  SETIDX	R13	K3	K35
-      0x9836460B,  //  00AF  SETIDX	R13	K35	R11
-      0x980C180D,  //  00B0  SETIDX	R3	R12	R13
-      0x00100905,  //  00B1  ADD	R4	R4	K5
-      0x002C1705,  //  00B2  ADD	R11	R11	K5
-      0x7001FFEC,  //  00B3  JMP		#00A1
-      0x8C300524,  //  00B4  GETMET	R12	R2	K36
-      0xB83A2000,  //  00B5  GETNGBL	R14	K16
-      0x8C381D25,  //  00B6  GETMET	R14	R14	K37
-      0x7C380200,  //  00B7  CALL	R14	1
-      0x7C300400,  //  00B8  CALL	R12	2
-      0x5412001F,  //  00B9  LDINT	R4	32
-      0x60340010,  //  00BA  GETGBL	R13	G16
-      0x8C380126,  //  00BB  GETMET	R14	R0	K38
-      0x5C401800,  //  00BC  MOVE	R16	R12
-      0x7C380400,  //  00BD  CALL	R14	2
-      0x7C340200,  //  00BE  CALL	R13	1
-      0xA802001C,  //  00BF  EXBLK	0	#00DD
-      0x5C381A00,  //  00C0  MOVE	R14	R13
-      0x7C380000,  //  00C1  CALL	R14	0
-      0x943C180E,  //  00C2  GETIDX	R15	R12	R14
-      0x6040000F,  //  00C3  GETGBL	R16	G15
-      0x5C441E00,  //  00C4  MOVE	R17	R15
-      0x60480013,  //  00C5  GETGBL	R18	G19
+      0x04341B02,  //  0064  SUB	R13	R13	K2
+      0x8C381905,  //  0065  GETMET	R14	R12	K5
+      0x5840001A,  //  0066  LDCONST	R16	K26
+      0x58440008,  //  0067  LDCONST	R17	K8
+      0x7C380600,  //  0068  CALL	R14	3
+      0x04381D02,  //  0069  SUB	R14	R14	K2
+      0x283C1B08,  //  006A  GE	R15	R13	K8
+      0x783E0002,  //  006B  JMPF	R15	#006F
+      0x8C3C131B,  //  006C  GETMET	R15	R9	K27
+      0x5C441A00,  //  006D  MOVE	R17	R13
+      0x7C3C0400,  //  006E  CALL	R15	2
+      0x283C1D08,  //  006F  GE	R15	R14	K8
+      0x783E0002,  //  0070  JMPF	R15	#0074
+      0x8C3C131B,  //  0071  GETMET	R15	R9	K27
+      0x5C441C00,  //  0072  MOVE	R17	R14
+      0x7C3C0400,  //  0073  CALL	R15	2
+      0xB83E1C00,  //  0074  GETNGBL	R15	K14
+      0x8C3C1F11,  //  0075  GETMET	R15	R15	K17
+      0x8C440317,  //  0076  GETMET	R17	R1	K23
+      0x584C001C,  //  0077  LDCONST	R19	K28
+      0x5C501A00,  //  0078  MOVE	R20	R13
+      0x5C541C00,  //  0079  MOVE	R21	R14
+      0x7C440800,  //  007A  CALL	R17	4
+      0x58480013,  //  007B  LDCONST	R18	K19
+      0x7C3C0600,  //  007C  CALL	R15	3
+      0x8C3C1905,  //  007D  GETMET	R15	R12	K5
+      0x5844001D,  //  007E  LDCONST	R17	K29
+      0x7C3C0400,  //  007F  CALL	R15	2
+      0x783E0002,  //  0080  JMPF	R15	#0084
+      0x94401F0B,  //  0081  GETIDX	R16	R15	K11
+      0x24402108,  //  0082  GT	R16	R16	K8
+      0x74420000,  //  0083  JMPT	R16	#0085
+      0x50400001,  //  0084  LDBOOL	R16	0	1
+      0x50400200,  //  0085  LDBOOL	R16	1	0
+      0x60440008,  //  0086  GETGBL	R17	G8
+      0x5C480800,  //  0087  MOVE	R18	R4
+      0x7C440200,  //  0088  CALL	R17	1
+      0x60480013,  //  0089  GETGBL	R18	G19
+      0x7C480000,  //  008A  CALL	R18	0
+      0x78420001,  //  008B  JMPF	R16	#008E
+      0x584C001E,  //  008C  LDCONST	R19	K30
+      0x70020000,  //  008D  JMP		#008F
+      0x584C001F,  //  008E  LDCONST	R19	K31
+      0x984A1213,  //  008F  SETIDX	R18	K9	R19
+      0x984A3E0A,  //  0090  SETIDX	R18	K31	R10
+      0x980C2212,  //  0091  SETIDX	R3	R17	R18
+      0x00100902,  //  0092  ADD	R4	R4	K2
+      0x00281502,  //  0093  ADD	R10	R10	K2
+      0x7001FFB3,  //  0094  JMP		#0049
+      0x6028000C,  //  0095  GETGBL	R10	G12
+      0xB82E1C00,  //  0096  GETNGBL	R11	K14
+      0x8C2C1720,  //  0097  GETMET	R11	R11	K32
+      0x7C2C0200,  //  0098  CALL	R11	1
+      0x7C280200,  //  0099  CALL	R10	1
+      0x582C0008,  //  009A  LDCONST	R11	K8
+      0x78160000,  //  009B  JMPF	R5	#009D
+      0x04281502,  //  009C  SUB	R10	R10	K2
+      0x1430160A,  //  009D  LT	R12	R11	R10
+      0x78320010,  //  009E  JMPF	R12	#00B0
+      0x8C301305,  //  009F  GETMET	R12	R9	K5
+      0x5C381600,  //  00A0  MOVE	R14	R11
+      0x7C300400,  //  00A1  CALL	R12	2
+      0x4C340000,  //  00A2  LDNIL	R13
+      0x1C30180D,  //  00A3  EQ	R12	R12	R13
+      0x78320008,  //  00A4  JMPF	R12	#00AE
+      0x60300008,  //  00A5  GETGBL	R12	G8
+      0x5C340800,  //  00A6  MOVE	R13	R4
+      0x7C300200,  //  00A7  CALL	R12	1
+      0x60340013,  //  00A8  GETGBL	R13	G19
+      0x7C340000,  //  00A9  CALL	R13	0
+      0x98361321,  //  00AA  SETIDX	R13	K9	K33
+      0x9836420B,  //  00AB  SETIDX	R13	K33	R11
+      0x980C180D,  //  00AC  SETIDX	R3	R12	R13
+      0x00100902,  //  00AD  ADD	R4	R4	K2
+      0x002C1702,  //  00AE  ADD	R11	R11	K2
+      0x7001FFEC,  //  00AF  JMP		#009D
+      0x8C300522,  //  00B0  GETMET	R12	R2	K34
+      0xB83A1C00,  //  00B1  GETNGBL	R14	K14
+      0x8C381D23,  //  00B2  GETMET	R14	R14	K35
+      0x7C380200,  //  00B3  CALL	R14	1
+      0x7C300400,  //  00B4  CALL	R12	2
+      0x5412001F,  //  00B5  LDINT	R4	32
+      0x60340010,  //  00B6  GETGBL	R13	G16
+      0x8C380124,  //  00B7  GETMET	R14	R0	K36
+      0x5C401800,  //  00B8  MOVE	R16	R12
+      0x7C380400,  //  00B9  CALL	R14	2
+      0x7C340200,  //  00BA  CALL	R13	1
+      0xA802001C,  //  00BB  EXBLK	0	#00D9
+      0x5C381A00,  //  00BC  MOVE	R14	R13
+      0x7C380000,  //  00BD  CALL	R14	0
+      0x943C180E,  //  00BE  GETIDX	R15	R12	R14
+      0x6040000F,  //  00BF  GETGBL	R16	G15
+      0x5C441E00,  //  00C0  MOVE	R17	R15
+      0x60480013,  //  00C1  GETGBL	R18	G19
+      0x7C400400,  //  00C2  CALL	R16	2
+      0x7842000D,  //  00C3  JMPF	R16	#00D2
+      0x8C401F14,  //  00C4  GETMET	R16	R15	K20
+      0x58480025,  //  00C5  LDCONST	R18	K37
       0x7C400400,  //  00C6  CALL	R16	2
-      0x7842000D,  //  00C7  JMPF	R16	#00D6
-      0x8C401F16,  //  00C8  GETMET	R16	R15	K22
-      0x58480027,  //  00C9  LDCONST	R18	K39
-      0x7C400400,  //  00CA  CALL	R16	2
-      0x78420009,  //  00CB  JMPF	R16	#00D6
-      0x00401D28,  //  00CC  ADD	R16	R14	K40
-      0x60440008,  //  00CD  GETGBL	R17	G8
-      0x5C480800,  //  00CE  MOVE	R18	R4
-      0x7C440200,  //  00CF  CALL	R17	1
-      0x60480013,  //  00D0  GETGBL	R18	G19
-      0x7C480000,  //  00D1  CALL	R18	0
-      0x984A0729,  //  00D2  SETIDX	R18	K3	K41
-      0x984A5410,  //  00D3  SETIDX	R18	K42	R16
-      0x980C2212,  //  00D4  SETIDX	R3	R17	R18
-      0x00100905,  //  00D5  ADD	R4	R4	K5
-      0x54420027,  //  00D6  LDINT	R16	40
-      0x24400810,  //  00D7  GT	R16	R4	R16
-      0x78420000,  //  00D8  JMPF	R16	#00DA
-      0x70020000,  //  00D9  JMP		#00DB
-      0x7001FFE4,  //  00DA  JMP		#00C0
-      0xA8040001,  //  00DB  EXBLK	1	1
-      0x70020002,  //  00DC  JMP		#00E0
-      0x5834002B,  //  00DD  LDCONST	R13	K43
-      0xAC340200,  //  00DE  CATCH	R13	1	0
-      0xB0080000,  //  00DF  RAISE	2	R0	R0
-      0x54120027,  //  00E0  LDINT	R4	40
-      0x60340010,  //  00E1  GETGBL	R13	G16
-      0x8C380126,  //  00E2  GETMET	R14	R0	K38
-      0x5C401800,  //  00E3  MOVE	R16	R12
-      0x7C380400,  //  00E4  CALL	R14	2
-      0x7C340200,  //  00E5  CALL	R13	1
-      0xA802001C,  //  00E6  EXBLK	0	#0104
-      0x5C381A00,  //  00E7  MOVE	R14	R13
-      0x7C380000,  //  00E8  CALL	R14	0
-      0x943C180E,  //  00E9  GETIDX	R15	R12	R14
-      0x6040000F,  //  00EA  GETGBL	R16	G15
-      0x5C441E00,  //  00EB  MOVE	R17	R15
-      0x60480013,  //  00EC  GETGBL	R18	G19
+      0x78420009,  //  00C7  JMPF	R16	#00D2
+      0x00401D26,  //  00C8  ADD	R16	R14	K38
+      0x60440008,  //  00C9  GETGBL	R17	G8
+      0x5C480800,  //  00CA  MOVE	R18	R4
+      0x7C440200,  //  00CB  CALL	R17	1
+      0x60480013,  //  00CC  GETGBL	R18	G19
+      0x7C480000,  //  00CD  CALL	R18	0
+      0x984A1327,  //  00CE  SETIDX	R18	K9	K39
+      0x984A5010,  //  00CF  SETIDX	R18	K40	R16
+      0x980C2212,  //  00D0  SETIDX	R3	R17	R18
+      0x00100902,  //  00D1  ADD	R4	R4	K2
+      0x54420027,  //  00D2  LDINT	R16	40
+      0x24400810,  //  00D3  GT	R16	R4	R16
+      0x78420000,  //  00D4  JMPF	R16	#00D6
+      0x70020000,  //  00D5  JMP		#00D7
+      0x7001FFE4,  //  00D6  JMP		#00BC
+      0xA8040001,  //  00D7  EXBLK	1	1
+      0x70020002,  //  00D8  JMP		#00DC
+      0x58340029,  //  00D9  LDCONST	R13	K41
+      0xAC340200,  //  00DA  CATCH	R13	1	0
+      0xB0080000,  //  00DB  RAISE	2	R0	R0
+      0x54120027,  //  00DC  LDINT	R4	40
+      0x60340010,  //  00DD  GETGBL	R13	G16
+      0x8C380124,  //  00DE  GETMET	R14	R0	K36
+      0x5C401800,  //  00DF  MOVE	R16	R12
+      0x7C380400,  //  00E0  CALL	R14	2
+      0x7C340200,  //  00E1  CALL	R13	1
+      0xA802001C,  //  00E2  EXBLK	0	#0100
+      0x5C381A00,  //  00E3  MOVE	R14	R13
+      0x7C380000,  //  00E4  CALL	R14	0
+      0x943C180E,  //  00E5  GETIDX	R15	R12	R14
+      0x6040000F,  //  00E6  GETGBL	R16	G15
+      0x5C441E00,  //  00E7  MOVE	R17	R15
+      0x60480013,  //  00E8  GETGBL	R18	G19
+      0x7C400400,  //  00E9  CALL	R16	2
+      0x7842000D,  //  00EA  JMPF	R16	#00F9
+      0x8C401F14,  //  00EB  GETMET	R16	R15	K20
+      0x5848002A,  //  00EC  LDCONST	R18	K42
       0x7C400400,  //  00ED  CALL	R16	2
-      0x7842000D,  //  00EE  JMPF	R16	#00FD
-      0x8C401F16,  //  00EF  GETMET	R16	R15	K22
-      0x5848002C,  //  00F0  LDCONST	R18	K44
-      0x7C400400,  //  00F1  CALL	R16	2
-      0x78420009,  //  00F2  JMPF	R16	#00FD
-      0x00401D2D,  //  00F3  ADD	R16	R14	K45
-      0x60440008,  //  00F4  GETGBL	R17	G8
-      0x5C480800,  //  00F5  MOVE	R18	R4
-      0x7C440200,  //  00F6  CALL	R17	1
-      0x60480013,  //  00F7  GETGBL	R18	G19
-      0x7C480000,  //  00F8  CALL	R18	0
-      0x984A072E,  //  00F9  SETIDX	R18	K3	K46
-      0x984A5410,  //  00FA  SETIDX	R18	K42	R16
-      0x980C2212,  //  00FB  SETIDX	R3	R17	R18
-      0x00100905,  //  00FC  ADD	R4	R4	K5
-      0x5442002E,  //  00FD  LDINT	R16	47
-      0x24400810,  //  00FE  GT	R16	R4	R16
-      0x78420000,  //  00FF  JMPF	R16	#0101
-      0x70020000,  //  0100  JMP		#0102
-      0x7001FFE4,  //  0101  JMP		#00E7
-      0xA8040001,  //  0102  EXBLK	1	1
-      0x70020002,  //  0103  JMP		#0107
-      0x5834002B,  //  0104  LDCONST	R13	K43
-      0xAC340200,  //  0105  CATCH	R13	1	0
-      0xB0080000,  //  0106  RAISE	2	R0	R0
-      0x5412002F,  //  0107  LDINT	R4	48
-      0x60340010,  //  0108  GETGBL	R13	G16
-      0x8C380126,  //  0109  GETMET	R14	R0	K38
-      0x5C401800,  //  010A  MOVE	R16	R12
-      0x7C380400,  //  010B  CALL	R14	2
-      0x7C340200,  //  010C  CALL	R13	1
-      0xA802001C,  //  010D  EXBLK	0	#012B
-      0x5C381A00,  //  010E  MOVE	R14	R13
-      0x7C380000,  //  010F  CALL	R14	0
-      0x943C180E,  //  0110  GETIDX	R15	R12	R14
-      0x6040000F,  //  0111  GETGBL	R16	G15
-      0x5C441E00,  //  0112  MOVE	R17	R15
-      0x60480013,  //  0113  GETGBL	R18	G19
+      0x78420009,  //  00EE  JMPF	R16	#00F9
+      0x00401D2B,  //  00EF  ADD	R16	R14	K43
+      0x60440008,  //  00F0  GETGBL	R17	G8
+      0x5C480800,  //  00F1  MOVE	R18	R4
+      0x7C440200,  //  00F2  CALL	R17	1
+      0x60480013,  //  00F3  GETGBL	R18	G19
+      0x7C480000,  //  00F4  CALL	R18	0
+      0x984A132C,  //  00F5  SETIDX	R18	K9	K44
+      0x984A5010,  //  00F6  SETIDX	R18	K40	R16
+      0x980C2212,  //  00F7  SETIDX	R3	R17	R18
+      0x00100902,  //  00F8  ADD	R4	R4	K2
+      0x5442002E,  //  00F9  LDINT	R16	47
+      0x24400810,  //  00FA  GT	R16	R4	R16
+      0x78420000,  //  00FB  JMPF	R16	#00FD
+      0x70020000,  //  00FC  JMP		#00FE
+      0x7001FFE4,  //  00FD  JMP		#00E3
+      0xA8040001,  //  00FE  EXBLK	1	1
+      0x70020002,  //  00FF  JMP		#0103
+      0x58340029,  //  0100  LDCONST	R13	K41
+      0xAC340200,  //  0101  CATCH	R13	1	0
+      0xB0080000,  //  0102  RAISE	2	R0	R0
+      0x5412002F,  //  0103  LDINT	R4	48
+      0x60340010,  //  0104  GETGBL	R13	G16
+      0x8C380124,  //  0105  GETMET	R14	R0	K36
+      0x5C401800,  //  0106  MOVE	R16	R12
+      0x7C380400,  //  0107  CALL	R14	2
+      0x7C340200,  //  0108  CALL	R13	1
+      0xA802001C,  //  0109  EXBLK	0	#0127
+      0x5C381A00,  //  010A  MOVE	R14	R13
+      0x7C380000,  //  010B  CALL	R14	0
+      0x943C180E,  //  010C  GETIDX	R15	R12	R14
+      0x6040000F,  //  010D  GETGBL	R16	G15
+      0x5C441E00,  //  010E  MOVE	R17	R15
+      0x60480013,  //  010F  GETGBL	R18	G19
+      0x7C400400,  //  0110  CALL	R16	2
+      0x7842000D,  //  0111  JMPF	R16	#0120
+      0x8C401F14,  //  0112  GETMET	R16	R15	K20
+      0x5848002D,  //  0113  LDCONST	R18	K45
       0x7C400400,  //  0114  CALL	R16	2
-      0x7842000D,  //  0115  JMPF	R16	#0124
-      0x8C401F16,  //  0116  GETMET	R16	R15	K22
-      0x5848002F,  //  0117  LDCONST	R18	K47
-      0x7C400400,  //  0118  CALL	R16	2
-      0x78420009,  //  0119  JMPF	R16	#0124
-      0x00401D30,  //  011A  ADD	R16	R14	K48
-      0x60440008,  //  011B  GETGBL	R17	G8
-      0x5C480800,  //  011C  MOVE	R18	R4
-      0x7C440200,  //  011D  CALL	R17	1
-      0x60480013,  //  011E  GETGBL	R18	G19
-      0x7C480000,  //  011F  CALL	R18	0
-      0x984A0731,  //  0120  SETIDX	R18	K3	K49
-      0x984A5410,  //  0121  SETIDX	R18	K42	R16
-      0x980C2212,  //  0122  SETIDX	R3	R17	R18
-      0x00100905,  //  0123  ADD	R4	R4	K5
-      0x54420037,  //  0124  LDINT	R16	56
-      0x24400810,  //  0125  GT	R16	R4	R16
-      0x78420000,  //  0126  JMPF	R16	#0128
-      0x70020000,  //  0127  JMP		#0129
-      0x7001FFE4,  //  0128  JMP		#010E
-      0xA8040001,  //  0129  EXBLK	1	1
-      0x70020002,  //  012A  JMP		#012E
-      0x5834002B,  //  012B  LDCONST	R13	K43
-      0xAC340200,  //  012C  CATCH	R13	1	0
-      0xB0080000,  //  012D  RAISE	2	R0	R0
-      0x54120037,  //  012E  LDINT	R4	56
-      0x60340010,  //  012F  GETGBL	R13	G16
-      0x8C380126,  //  0130  GETMET	R14	R0	K38
-      0x5C401800,  //  0131  MOVE	R16	R12
-      0x7C380400,  //  0132  CALL	R14	2
-      0x7C340200,  //  0133  CALL	R13	1
-      0xA802001C,  //  0134  EXBLK	0	#0152
-      0x5C381A00,  //  0135  MOVE	R14	R13
-      0x7C380000,  //  0136  CALL	R14	0
-      0x943C180E,  //  0137  GETIDX	R15	R12	R14
-      0x6040000F,  //  0138  GETGBL	R16	G15
-      0x5C441E00,  //  0139  MOVE	R17	R15
-      0x60480013,  //  013A  GETGBL	R18	G19
+      0x78420009,  //  0115  JMPF	R16	#0120
+      0x00401D2E,  //  0116  ADD	R16	R14	K46
+      0x60440008,  //  0117  GETGBL	R17	G8
+      0x5C480800,  //  0118  MOVE	R18	R4
+      0x7C440200,  //  0119  CALL	R17	1
+      0x60480013,  //  011A  GETGBL	R18	G19
+      0x7C480000,  //  011B  CALL	R18	0
+      0x984A132F,  //  011C  SETIDX	R18	K9	K47
+      0x984A5010,  //  011D  SETIDX	R18	K40	R16
+      0x980C2212,  //  011E  SETIDX	R3	R17	R18
+      0x00100902,  //  011F  ADD	R4	R4	K2
+      0x54420037,  //  0120  LDINT	R16	56
+      0x24400810,  //  0121  GT	R16	R4	R16
+      0x78420000,  //  0122  JMPF	R16	#0124
+      0x70020000,  //  0123  JMP		#0125
+      0x7001FFE4,  //  0124  JMP		#010A
+      0xA8040001,  //  0125  EXBLK	1	1
+      0x70020002,  //  0126  JMP		#012A
+      0x58340029,  //  0127  LDCONST	R13	K41
+      0xAC340200,  //  0128  CATCH	R13	1	0
+      0xB0080000,  //  0129  RAISE	2	R0	R0
+      0x54120037,  //  012A  LDINT	R4	56
+      0x60340010,  //  012B  GETGBL	R13	G16
+      0x8C380124,  //  012C  GETMET	R14	R0	K36
+      0x5C401800,  //  012D  MOVE	R16	R12
+      0x7C380400,  //  012E  CALL	R14	2
+      0x7C340200,  //  012F  CALL	R13	1
+      0xA802001C,  //  0130  EXBLK	0	#014E
+      0x5C381A00,  //  0131  MOVE	R14	R13
+      0x7C380000,  //  0132  CALL	R14	0
+      0x943C180E,  //  0133  GETIDX	R15	R12	R14
+      0x6040000F,  //  0134  GETGBL	R16	G15
+      0x5C441E00,  //  0135  MOVE	R17	R15
+      0x60480013,  //  0136  GETGBL	R18	G19
+      0x7C400400,  //  0137  CALL	R16	2
+      0x7842000D,  //  0138  JMPF	R16	#0147
+      0x8C401F14,  //  0139  GETMET	R16	R15	K20
+      0x58480030,  //  013A  LDCONST	R18	K48
       0x7C400400,  //  013B  CALL	R16	2
-      0x7842000D,  //  013C  JMPF	R16	#014B
-      0x8C401F16,  //  013D  GETMET	R16	R15	K22
-      0x58480032,  //  013E  LDCONST	R18	K50
-      0x7C400400,  //  013F  CALL	R16	2
-      0x78420009,  //  0140  JMPF	R16	#014B
-      0x00401D33,  //  0141  ADD	R16	R14	K51
-      0x60440008,  //  0142  GETGBL	R17	G8
-      0x5C480800,  //  0143  MOVE	R18	R4
-      0x7C440200,  //  0144  CALL	R17	1
-      0x60480013,  //  0145  GETGBL	R18	G19
-      0x7C480000,  //  0146  CALL	R18	0
-      0x984A0734,  //  0147  SETIDX	R18	K3	K52
-      0x984A5410,  //  0148  SETIDX	R18	K42	R16
-      0x980C2212,  //  0149  SETIDX	R3	R17	R18
-      0x00100905,  //  014A  ADD	R4	R4	K5
-      0x5442003F,  //  014B  LDINT	R16	64
-      0x24400810,  //  014C  GT	R16	R4	R16
-      0x78420000,  //  014D  JMPF	R16	#014F
-      0x70020000,  //  014E  JMP		#0150
-      0x7001FFE4,  //  014F  JMP		#0135
-      0xA8040001,  //  0150  EXBLK	1	1
-      0x70020002,  //  0151  JMP		#0155
-      0x5834002B,  //  0152  LDCONST	R13	K43
-      0xAC340200,  //  0153  CATCH	R13	1	0
-      0xB0080000,  //  0154  RAISE	2	R0	R0
-      0x80040600,  //  0155  RET	1	R3
+      0x78420009,  //  013C  JMPF	R16	#0147
+      0x00401D31,  //  013D  ADD	R16	R14	K49
+      0x60440008,  //  013E  GETGBL	R17	G8
+      0x5C480800,  //  013F  MOVE	R18	R4
+      0x7C440200,  //  0140  CALL	R17	1
+      0x60480013,  //  0141  GETGBL	R18	G19
+      0x7C480000,  //  0142  CALL	R18	0
+      0x984A1332,  //  0143  SETIDX	R18	K9	K50
+      0x984A5010,  //  0144  SETIDX	R18	K40	R16
+      0x980C2212,  //  0145  SETIDX	R3	R17	R18
+      0x00100902,  //  0146  ADD	R4	R4	K2
+      0x5442003F,  //  0147  LDINT	R16	64
+      0x24400810,  //  0148  GT	R16	R4	R16
+      0x78420000,  //  0149  JMPF	R16	#014B
+      0x70020000,  //  014A  JMP		#014C
+      0x7001FFE4,  //  014B  JMP		#0131
+      0xA8040001,  //  014C  EXBLK	1	1
+      0x70020002,  //  014D  JMP		#0151
+      0x58340029,  //  014E  LDCONST	R13	K41
+      0xAC340200,  //  014F  CATCH	R13	1	0
+      0xB0080000,  //  0150  RAISE	2	R0	R0
+      0x80040600,  //  0151  RET	1	R3
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
@@ -486,7 +486,7 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
+    ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
@@ -505,10 +505,11 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
     /* K15  */  be_const_int(2),
     /* K16  */  be_const_int(3),
     /* K17  */  be_nested_str_weak(create_TLV),
+    /* K18  */  be_nested_str_weak(BOOL),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[92]) {  /* code */
+    ( &(const binstruction[104]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x880C0701,  //  0001  GETMBR	R3	R3	K1
       0x88100502,  //  0002  GETMBR	R4	R2	K2
@@ -597,10 +598,22 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
       0x5824000B,  //  0055  LDCONST	R9	K11
       0x7C180600,  //  0056  CALL	R6	3
       0x80040C00,  //  0057  RET	1	R6
-      0x70020001,  //  0058  JMP		#005B
-      0x4C180000,  //  0059  LDNIL	R6
-      0x80040C00,  //  005A  RET	1	R6
-      0x80000000,  //  005B  RET	0
+      0x7002000D,  //  0058  JMP		#0067
+      0x541A0038,  //  0059  LDINT	R6	57
+      0x1C180806,  //  005A  EQ	R6	R4	R6
+      0x781A0008,  //  005B  JMPF	R6	#0065
+      0x541A0010,  //  005C  LDINT	R6	17
+      0x1C180A06,  //  005D  EQ	R6	R5	R6
+      0x781A0004,  //  005E  JMPF	R6	#0064
+      0x8C180711,  //  005F  GETMET	R6	R3	K17
+      0x88200712,  //  0060  GETMBR	R8	R3	K18
+      0x5824000B,  //  0061  LDCONST	R9	K11
+      0x7C180600,  //  0062  CALL	R6	3
+      0x80040C00,  //  0063  RET	1	R6
+      0x70020001,  //  0064  JMP		#0067
+      0x4C180000,  //  0065  LDNIL	R6
+      0x80040C00,  //  0066  RET	1	R6
+      0x80000000,  //  0067  RET	0
     })
   )
 );
@@ -886,7 +899,7 @@ be_local_class(Matter_Plugin,
         { be_const_key_weak(ARG_TYPE, 4), be_const_static_closure(Matter_Plugin__X3Clambda_X3E_closure) },
         { be_const_key_weak(update_shadow_lazy, 28), be_const_closure(Matter_Plugin_update_shadow_lazy_closure) },
         { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
+        be_const_map( *     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(29, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(6,
@@ -897,6 +910,11 @@ be_local_class(Matter_Plugin,
         be_const_int(3),
         be_const_int(65532),
         be_const_int(65533),
+    }))    ) } )) },
+        { be_const_key_int(57, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(1,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(17),
     }))    ) } )) },
     }))    ) } )) },
         { be_const_key_weak(subscribe_event, -1), be_const_closure(Matter_Plugin_subscribe_event_closure) },

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Aggregator.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Aggregator.h
@@ -1,0 +1,128 @@
+/* Solidification of Matter_Plugin_Aggregator.h */
+/********************************************************************\
+* Generated code, don't edit                                         *
+\********************************************************************/
+#include "be_constobj.h"
+
+extern const bclass be_class_Matter_Plugin_Aggregator;
+
+/********************************************************************
+** Solidified function: read_attribute
+********************************************************************/
+be_local_closure(Matter_Plugin_Aggregator_read_attribute,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(Matter_TLV_array),
+    /* K7   */  be_nested_str_weak(device),
+    /* K8   */  be_nested_str_weak(get_active_endpoints),
+    /* K9   */  be_nested_str_weak(add_TLV),
+    /* K10  */  be_nested_str_weak(U2),
+    /* K11  */  be_nested_str_weak(stop_iteration),
+    /* K12  */  be_nested_str_weak(read_attribute),
+    }),
+    be_str_weak(read_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[54]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x88100902,  //  0002  GETMBR	R4	R4	K2
+      0x88140503,  //  0003  GETMBR	R5	R2	K3
+      0x88180504,  //  0004  GETMBR	R6	R2	K4
+      0x541E001C,  //  0005  LDINT	R7	29
+      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
+      0x781E0024,  //  0007  JMPF	R7	#002D
+      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
+      0x781E0019,  //  0009  JMPF	R7	#0024
+      0x8C1C0906,  //  000A  GETMET	R7	R4	K6
+      0x7C1C0200,  //  000B  CALL	R7	1
+      0x88200107,  //  000C  GETMBR	R8	R0	K7
+      0x8C201108,  //  000D  GETMET	R8	R8	K8
+      0x50280200,  //  000E  LDBOOL	R10	1	0
+      0x7C200400,  //  000F  CALL	R8	2
+      0x60240010,  //  0010  GETGBL	R9	G16
+      0x5C281000,  //  0011  MOVE	R10	R8
+      0x7C240200,  //  0012  CALL	R9	1
+      0xA802000A,  //  0013  EXBLK	0	#001F
+      0x5C281200,  //  0014  MOVE	R10	R9
+      0x7C280000,  //  0015  CALL	R10	0
+      0x542EFEFF,  //  0016  LDINT	R11	65280
+      0x202C140B,  //  0017  NE	R11	R10	R11
+      0x782E0004,  //  0018  JMPF	R11	#001E
+      0x8C2C0F09,  //  0019  GETMET	R11	R7	K9
+      0x4C340000,  //  001A  LDNIL	R13
+      0x8838090A,  //  001B  GETMBR	R14	R4	K10
+      0x5C3C1400,  //  001C  MOVE	R15	R10
+      0x7C2C0800,  //  001D  CALL	R11	4
+      0x7001FFF4,  //  001E  JMP		#0014
+      0x5824000B,  //  001F  LDCONST	R9	K11
+      0xAC240200,  //  0020  CATCH	R9	1	0
+      0xB0080000,  //  0021  RAISE	2	R0	R0
+      0x80040E00,  //  0022  RET	1	R7
+      0x70020007,  //  0023  JMP		#002C
+      0x601C0003,  //  0024  GETGBL	R7	G3
+      0x5C200000,  //  0025  MOVE	R8	R0
+      0x7C1C0200,  //  0026  CALL	R7	1
+      0x8C1C0F0C,  //  0027  GETMET	R7	R7	K12
+      0x5C240200,  //  0028  MOVE	R9	R1
+      0x5C280400,  //  0029  MOVE	R10	R2
+      0x7C1C0600,  //  002A  CALL	R7	3
+      0x80040E00,  //  002B  RET	1	R7
+      0x70020007,  //  002C  JMP		#0035
+      0x601C0003,  //  002D  GETGBL	R7	G3
+      0x5C200000,  //  002E  MOVE	R8	R0
+      0x7C1C0200,  //  002F  CALL	R7	1
+      0x8C1C0F0C,  //  0030  GETMET	R7	R7	K12
+      0x5C240200,  //  0031  MOVE	R9	R1
+      0x5C280400,  //  0032  MOVE	R10	R2
+      0x7C1C0600,  //  0033  CALL	R7	3
+      0x80040E00,  //  0034  RET	1	R7
+      0x80000000,  //  0035  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Matter_Plugin_Aggregator
+********************************************************************/
+extern const bclass be_class_Matter_Plugin;
+be_local_class(Matter_Plugin_Aggregator,
+    0,
+    &be_class_Matter_Plugin,
+    be_nested_map(4,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(NAME, 3), be_nested_str_weak(Aggregator) },
+        { be_const_key_weak(TYPE, -1), be_nested_str_weak(aggregator) },
+        { be_const_key_weak(TYPES, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(14, -1), be_const_int(1) },
+    }))    ) } )) },
+        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Aggregator_read_attribute_closure) },
+    })),
+    be_str_weak(Matter_Plugin_Aggregator)
+);
+/*******************************************************************/
+
+void be_load_Matter_Plugin_Aggregator_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_Matter_Plugin_Aggregator);
+    be_setglobal(vm, "Matter_Plugin_Aggregator");
+    be_pop(vm, 1);
+}
+/********************************************************************/
+/* End of solidification */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_HTTP.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_HTTP.h
@@ -459,50 +459,46 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(create_TLV),
-    /* K6   */  be_nested_str_weak(BOOL),
-    /* K7   */  be_nested_str_weak(http_remote),
-    /* K8   */  be_nested_str_weak(reachable),
-    /* K9   */  be_nested_str_weak(read_attribute),
+    /* K4   */  be_nested_str_weak(create_TLV),
+    /* K5   */  be_nested_str_weak(BOOL),
+    /* K6   */  be_nested_str_weak(http_remote),
+    /* K7   */  be_nested_str_weak(reachable),
+    /* K8   */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[29]) {  /* code */
+    ( &(const binstruction[26]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x880C0701,  //  0001  GETMBR	R3	R3	K1
       0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
       0x541A0038,  //  0004  LDINT	R6	57
       0x1C180806,  //  0005  EQ	R6	R4	R6
-      0x781A000C,  //  0006  JMPF	R6	#0014
-      0x1C180B04,  //  0007  EQ	R6	R5	K4
-      0x781A0000,  //  0008  JMPF	R6	#000A
-      0x70020008,  //  0009  JMP		#0013
-      0x541A0010,  //  000A  LDINT	R6	17
-      0x1C180A06,  //  000B  EQ	R6	R5	R6
-      0x781A0005,  //  000C  JMPF	R6	#0013
-      0x8C180705,  //  000D  GETMET	R6	R3	K5
-      0x88200706,  //  000E  GETMBR	R8	R3	K6
-      0x88240107,  //  000F  GETMBR	R9	R0	K7
-      0x88241308,  //  0010  GETMBR	R9	R9	K8
-      0x7C180600,  //  0011  CALL	R6	3
-      0x80040C00,  //  0012  RET	1	R6
-      0x70020007,  //  0013  JMP		#001C
-      0x60180003,  //  0014  GETGBL	R6	G3
-      0x5C1C0000,  //  0015  MOVE	R7	R0
-      0x7C180200,  //  0016  CALL	R6	1
-      0x8C180D09,  //  0017  GETMET	R6	R6	K9
-      0x5C200200,  //  0018  MOVE	R8	R1
-      0x5C240400,  //  0019  MOVE	R9	R2
-      0x7C180600,  //  001A  CALL	R6	3
-      0x80040C00,  //  001B  RET	1	R6
-      0x80000000,  //  001C  RET	0
+      0x781A0009,  //  0006  JMPF	R6	#0011
+      0x541A0010,  //  0007  LDINT	R6	17
+      0x1C180A06,  //  0008  EQ	R6	R5	R6
+      0x781A0005,  //  0009  JMPF	R6	#0010
+      0x8C180704,  //  000A  GETMET	R6	R3	K4
+      0x88200705,  //  000B  GETMBR	R8	R3	K5
+      0x88240106,  //  000C  GETMBR	R9	R0	K6
+      0x88241307,  //  000D  GETMBR	R9	R9	K7
+      0x7C180600,  //  000E  CALL	R6	3
+      0x80040C00,  //  000F  RET	1	R6
+      0x70020007,  //  0010  JMP		#0019
+      0x60180003,  //  0011  GETGBL	R6	G3
+      0x5C1C0000,  //  0012  MOVE	R7	R0
+      0x7C180200,  //  0013  CALL	R6	1
+      0x8C180D08,  //  0014  GETMET	R6	R6	K8
+      0x5C200200,  //  0015  MOVE	R8	R1
+      0x5C240400,  //  0016  MOVE	R9	R2
+      0x7C180600,  //  0017  CALL	R6	3
+      0x80040C00,  //  0018  RET	1	R6
+      0x80000000,  //  0019  RET	0
     })
   )
 );
@@ -628,13 +624,8 @@ be_local_class(Matter_Plugin_Bridge_HTTP,
         { be_const_key_weak(ui_conf_to_string, -1), be_const_static_closure(Matter_Plugin_Bridge_HTTP_ui_conf_to_string_closure) },
         { be_const_key_weak(http_remote, -1), be_const_var(0) },
         { be_const_key_weak(CLUSTERS, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
+        be_const_map( *     be_nested_map(0,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(1,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
-    }))    ) } )) },
     }))    ) } )) },
         { be_const_key_weak(ARG, -1), be_nested_str_weak() },
         { be_const_key_weak(UPDATE_CMD, -1), be_nested_str_weak(Status_X2011) },

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_OnOff.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_OnOff.h
@@ -1,0 +1,295 @@
+/* Solidification of Matter_Plugin_Sensor_OnOff.h */
+/********************************************************************\
+* Generated code, don't edit                                         *
+\********************************************************************/
+#include "be_constobj.h"
+
+extern const bclass be_class_Matter_Plugin_Sensor_OnOff;
+
+/********************************************************************
+** Solidified function: <lambda>
+********************************************************************/
+be_local_closure(Matter_Plugin_Sensor_OnOff__X3Clambda_X3E,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(_X3Clambda_X3E),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x60040009,  //  0000  GETGBL	R1	G9
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_attribute
+********************************************************************/
+be_local_closure(Matter_Plugin_Sensor_OnOff_read_attribute,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_nested_str_weak(update_shadow_lazy),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(create_TLV),
+    /* K8   */  be_nested_str_weak(BOOL),
+    /* K9   */  be_nested_str_weak(shadow_onoff),
+    /* K10  */  be_nested_str_weak(U4),
+    /* K11  */  be_nested_str_weak(read_attribute),
+    }),
+    be_str_weak(read_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[45]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x88100902,  //  0002  GETMBR	R4	R4	K2
+      0x88140503,  //  0003  GETMBR	R5	R2	K3
+      0x88180504,  //  0004  GETMBR	R6	R2	K4
+      0x541E0005,  //  0005  LDINT	R7	6
+      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
+      0x781E001B,  //  0007  JMPF	R7	#0024
+      0x8C1C0105,  //  0008  GETMET	R7	R0	K5
+      0x7C1C0200,  //  0009  CALL	R7	1
+      0x1C1C0D06,  //  000A  EQ	R7	R6	K6
+      0x781E0005,  //  000B  JMPF	R7	#0012
+      0x8C1C0907,  //  000C  GETMET	R7	R4	K7
+      0x88240908,  //  000D  GETMBR	R9	R4	K8
+      0x88280109,  //  000E  GETMBR	R10	R0	K9
+      0x7C1C0600,  //  000F  CALL	R7	3
+      0x80040E00,  //  0010  RET	1	R7
+      0x70020010,  //  0011  JMP		#0023
+      0x541EFFFB,  //  0012  LDINT	R7	65532
+      0x1C1C0C07,  //  0013  EQ	R7	R6	R7
+      0x781E0005,  //  0014  JMPF	R7	#001B
+      0x8C1C0907,  //  0015  GETMET	R7	R4	K7
+      0x8824090A,  //  0016  GETMBR	R9	R4	K10
+      0x58280006,  //  0017  LDCONST	R10	K6
+      0x7C1C0600,  //  0018  CALL	R7	3
+      0x80040E00,  //  0019  RET	1	R7
+      0x70020007,  //  001A  JMP		#0023
+      0x541EFFFC,  //  001B  LDINT	R7	65533
+      0x1C1C0C07,  //  001C  EQ	R7	R6	R7
+      0x781E0004,  //  001D  JMPF	R7	#0023
+      0x8C1C0907,  //  001E  GETMET	R7	R4	K7
+      0x8824090A,  //  001F  GETMBR	R9	R4	K10
+      0x542A0003,  //  0020  LDINT	R10	4
+      0x7C1C0600,  //  0021  CALL	R7	3
+      0x80040E00,  //  0022  RET	1	R7
+      0x70020007,  //  0023  JMP		#002C
+      0x601C0003,  //  0024  GETGBL	R7	G3
+      0x5C200000,  //  0025  MOVE	R8	R0
+      0x7C1C0200,  //  0026  CALL	R7	1
+      0x8C1C0F0B,  //  0027  GETMET	R7	R7	K11
+      0x5C240200,  //  0028  MOVE	R9	R1
+      0x5C280400,  //  0029  MOVE	R10	R2
+      0x7C1C0600,  //  002A  CALL	R7	3
+      0x80040E00,  //  002B  RET	1	R7
+      0x80000000,  //  002C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_shadow
+********************************************************************/
+be_local_closure(Matter_Plugin_Sensor_OnOff_update_shadow,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(update_shadow),
+    /* K1   */  be_nested_str_weak(json),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(cmd),
+    /* K4   */  be_nested_str_weak(Status_X208),
+    /* K5   */  be_nested_str_weak(load),
+    /* K6   */  be_nested_str_weak(find),
+    /* K7   */  be_nested_str_weak(Switch),
+    /* K8   */  be_nested_str_weak(tasmota_switch_index),
+    /* K9   */  be_nested_str_weak(ON),
+    /* K10  */  be_nested_str_weak(shadow_onoff),
+    /* K11  */  be_nested_str_weak(attribute_updated),
+    /* K12  */  be_const_int(0),
+    }),
+    be_str_weak(update_shadow),
+    &be_const_str_solidified,
+    ( &(const binstruction[45]) {  /* code */
+      0x60040003,  //  0000  GETGBL	R1	G3
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x8C040300,  //  0003  GETMET	R1	R1	K0
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA4060200,  //  0005  IMPORT	R1	K1
+      0xB80A0400,  //  0006  GETNGBL	R2	K2
+      0x8C080503,  //  0007  GETMET	R2	R2	K3
+      0x58100004,  //  0008  LDCONST	R4	K4
+      0x50140200,  //  0009  LDBOOL	R5	1	0
+      0x7C080600,  //  000A  CALL	R2	3
+      0x4C0C0000,  //  000B  LDNIL	R3
+      0x200C0403,  //  000C  NE	R3	R2	R3
+      0x780E001D,  //  000D  JMPF	R3	#002C
+      0x8C0C0305,  //  000E  GETMET	R3	R1	K5
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x4C100000,  //  0011  LDNIL	R4
+      0x20100604,  //  0012  NE	R4	R3	R4
+      0x78120017,  //  0013  JMPF	R4	#002C
+      0x50100000,  //  0014  LDBOOL	R4	0	0
+      0x8C140706,  //  0015  GETMET	R5	R3	K6
+      0x601C0008,  //  0016  GETGBL	R7	G8
+      0x88200108,  //  0017  GETMBR	R8	R0	K8
+      0x7C1C0200,  //  0018  CALL	R7	1
+      0x001E0E07,  //  0019  ADD	R7	K7	R7
+      0x7C140400,  //  001A  CALL	R5	2
+      0x1C140B09,  //  001B  EQ	R5	R5	K9
+      0x5C100A00,  //  001C  MOVE	R4	R5
+      0x8814010A,  //  001D  GETMBR	R5	R0	K10
+      0x4C180000,  //  001E  LDNIL	R6
+      0x20140A06,  //  001F  NE	R5	R5	R6
+      0x78160009,  //  0020  JMPF	R5	#002B
+      0x8814010A,  //  0021  GETMBR	R5	R0	K10
+      0x60180017,  //  0022  GETGBL	R6	G23
+      0x5C1C0800,  //  0023  MOVE	R7	R4
+      0x7C180200,  //  0024  CALL	R6	1
+      0x20140A06,  //  0025  NE	R5	R5	R6
+      0x78160003,  //  0026  JMPF	R5	#002B
+      0x8C14010B,  //  0027  GETMET	R5	R0	K11
+      0x541E0405,  //  0028  LDINT	R7	1030
+      0x5820000C,  //  0029  LDCONST	R8	K12
+      0x7C140600,  //  002A  CALL	R5	3
+      0x90021404,  //  002B  SETMBR	R0	K10	R4
+      0x80000000,  //  002C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Plugin_Sensor_OnOff_init,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(tasmota_switch_index),
+    /* K2   */  be_nested_str_weak(find),
+    /* K3   */  be_nested_str_weak(ARG),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_const_int(0),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0x60100003,  //  0000  GETGBL	R4	G3
+      0x5C140000,  //  0001  MOVE	R5	R0
+      0x7C100200,  //  0002  CALL	R4	1
+      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x5C200600,  //  0006  MOVE	R8	R3
+      0x7C100800,  //  0007  CALL	R4	4
+      0x60100009,  //  0008  GETGBL	R4	G9
+      0x8C140702,  //  0009  GETMET	R5	R3	K2
+      0x881C0103,  //  000A  GETMBR	R7	R0	K3
+      0x58200004,  //  000B  LDCONST	R8	K4
+      0x7C140600,  //  000C  CALL	R5	3
+      0x7C100200,  //  000D  CALL	R4	1
+      0x90020204,  //  000E  SETMBR	R0	K1	R4
+      0x88100101,  //  000F  GETMBR	R4	R0	K1
+      0x18100905,  //  0010  LE	R4	R4	K5
+      0x78120000,  //  0011  JMPF	R4	#0013
+      0x90020304,  //  0012  SETMBR	R0	K1	K4
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Matter_Plugin_Sensor_OnOff
+********************************************************************/
+extern const bclass be_class_Matter_Plugin_Device;
+be_local_class(Matter_Plugin_Sensor_OnOff,
+    2,
+    &be_class_Matter_Plugin_Device,
+    be_nested_map(12,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(5000) },
+        { be_const_key_weak(TYPE, 11), be_nested_str_weak(occupancy) },
+        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(2128, -1), be_const_int(2) },
+    }))    ) } )) },
+        { be_const_key_weak(ARG, 9), be_nested_str_weak(switch) },
+        { be_const_key_weak(ARG_TYPE, 8), be_const_static_closure(Matter_Plugin_Sensor_OnOff__X3Clambda_X3E_closure) },
+        { be_const_key_weak(NAME, -1), be_nested_str_weak(OnOff) },
+        { be_const_key_weak(read_attribute, 5), be_const_closure(Matter_Plugin_Sensor_OnOff_read_attribute_closure) },
+        { be_const_key_weak(tasmota_switch_index, -1), be_const_var(0) },
+        { be_const_key_weak(shadow_onoff, -1), be_const_var(1) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_Sensor_OnOff_init_closure) },
+        { be_const_key_weak(CLUSTERS, 7), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(6, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(3,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_Sensor_OnOff_update_shadow_closure) },
+    })),
+    be_str_weak(Matter_Plugin_Sensor_OnOff)
+);
+/*******************************************************************/
+
+void be_load_Matter_Plugin_Sensor_OnOff_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_Matter_Plugin_Sensor_OnOff);
+    be_setglobal(vm, "Matter_Plugin_Sensor_OnOff");
+    be_pop(vm, 1);
+}
+/********************************************************************/
+/* End of solidification */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
@@ -71,109 +71,11 @@ be_local_closure(Matter_UI_page_part_mgr,   /* name */
 
 
 /********************************************************************
-** Solidified function: plugin_option
+** Solidified function: show_commissioning_info
 ********************************************************************/
-be_local_closure(Matter_UI_plugin_option,   /* name */
+be_local_closure(Matter_UI_show_commissioning_info,   /* name */
   be_nested_proto(
-    17,                          /* nstack */
-    3,                          /* argc */
-    3,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(split),
-    /* K3   */  be_nested_str_weak(_X7C),
-    /* K4   */  be_nested_str_weak(stop_iteration),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(),
-    /* K7   */  be_nested_str_weak(content_send),
-    /* K8   */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X27_X3E_X3C_X2Foption_X3E),
-    /* K9   */  be_nested_str_weak(_X2Dhttp),
-    /* K10  */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X27_X20disabled_X3E_X2D_X2D_X2D_X20Tasmota_X20Remote_X20_X2D_X2D_X2D_X3C_X2Foption_X3E),
-    /* K11  */  be_nested_str_weak(device),
-    /* K12  */  be_nested_str_weak(get_plugin_class_displayname),
-    /* K13  */  be_nested_str_weak(format),
-    /* K14  */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X25s_X27_X25s_X3E_X25s_X3C_X2Foption_X3E),
-    /* K15  */  be_nested_str_weak(_X20selected),
-    /* K16  */  be_const_int(1),
-    }),
-    be_str_weak(plugin_option),
-    &be_const_str_solidified,
-    ( &(const binstruction[57]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xA4120200,  //  0001  IMPORT	R4	K1
-      0x60140012,  //  0002  GETGBL	R5	G18
-      0x7C140000,  //  0003  CALL	R5	0
-      0x60180010,  //  0004  GETGBL	R6	G16
-      0x5C1C0400,  //  0005  MOVE	R7	R2
-      0x7C180200,  //  0006  CALL	R6	1
-      0xA8020007,  //  0007  EXBLK	0	#0010
-      0x5C1C0C00,  //  0008  MOVE	R7	R6
-      0x7C1C0000,  //  0009  CALL	R7	0
-      0x8C200902,  //  000A  GETMET	R8	R4	K2
-      0x5C280E00,  //  000B  MOVE	R10	R7
-      0x582C0003,  //  000C  LDCONST	R11	K3
-      0x7C200600,  //  000D  CALL	R8	3
-      0x00140A08,  //  000E  ADD	R5	R5	R8
-      0x7001FFF7,  //  000F  JMP		#0008
-      0x58180004,  //  0010  LDCONST	R6	K4
-      0xAC180200,  //  0011  CATCH	R6	1	0
-      0xB0080000,  //  0012  RAISE	2	R0	R0
-      0x58180005,  //  0013  LDCONST	R6	K5
-      0x601C000C,  //  0014  GETGBL	R7	G12
-      0x5C200A00,  //  0015  MOVE	R8	R5
-      0x7C1C0200,  //  0016  CALL	R7	1
-      0x141C0C07,  //  0017  LT	R7	R6	R7
-      0x781E001E,  //  0018  JMPF	R7	#0038
-      0x941C0A06,  //  0019  GETIDX	R7	R5	R6
-      0x1C200F06,  //  001A  EQ	R8	R7	K6
-      0x78220003,  //  001B  JMPF	R8	#0020
-      0x8C200707,  //  001C  GETMET	R8	R3	K7
-      0x58280008,  //  001D  LDCONST	R10	K8
-      0x7C200400,  //  001E  CALL	R8	2
-      0x70020015,  //  001F  JMP		#0036
-      0x1C200F09,  //  0020  EQ	R8	R7	K9
-      0x78220003,  //  0021  JMPF	R8	#0026
-      0x8C200707,  //  0022  GETMET	R8	R3	K7
-      0x5828000A,  //  0023  LDCONST	R10	K10
-      0x7C200400,  //  0024  CALL	R8	2
-      0x7002000F,  //  0025  JMP		#0036
-      0x8820010B,  //  0026  GETMBR	R8	R0	K11
-      0x8C20110C,  //  0027  GETMET	R8	R8	K12
-      0x5C280E00,  //  0028  MOVE	R10	R7
-      0x7C200400,  //  0029  CALL	R8	2
-      0x8C240707,  //  002A  GETMET	R9	R3	K7
-      0x8C2C090D,  //  002B  GETMET	R11	R4	K13
-      0x5834000E,  //  002C  LDCONST	R13	K14
-      0x5C380E00,  //  002D  MOVE	R14	R7
-      0x1C3C0E01,  //  002E  EQ	R15	R7	R1
-      0x783E0001,  //  002F  JMPF	R15	#0032
-      0x583C000F,  //  0030  LDCONST	R15	K15
-      0x70020000,  //  0031  JMP		#0033
-      0x583C0006,  //  0032  LDCONST	R15	K6
-      0x5C401000,  //  0033  MOVE	R16	R8
-      0x7C2C0A00,  //  0034  CALL	R11	5
-      0x7C240400,  //  0035  CALL	R9	2
-      0x00180D10,  //  0036  ADD	R6	R6	K16
-      0x7001FFDB,  //  0037  JMP		#0014
-      0x80000000,  //  0038  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: show_bridge_status
-********************************************************************/
-be_local_closure(Matter_UI_show_bridge_status,   /* name */
-  be_nested_proto(
-    15,                          /* nstack */
+    14,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -181,139 +83,97 @@ be_local_closure(Matter_UI_show_bridge_status,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
+    ( &(const bvalue[20]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(device),
-    /* K4   */  be_nested_str_weak(plugins),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(Plugin_Bridge_HTTP),
-    /* K7   */  be_nested_str_weak(http_remote),
-    /* K8   */  be_nested_str_weak(addr),
-    /* K9   */  be_nested_str_weak(contains),
-    /* K10  */  be_nested_str_weak(push),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(content_send),
-    /* K13  */  be_nested_str_weak(_X3Chr_X3E),
-    /* K14  */  be_nested_str_weak(_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
-    /* K15  */  be_nested_str_weak(_STYLESHEET),
-    /* K16  */  be_nested_str_weak(keys),
-    /* K17  */  be_nested_str_weak(format),
-    /* K18  */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27ztdm_X20htrm_X27_X3E_X3Ctd_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Ftd_X3E),
-    /* K19  */  be_nested_str_weak(html_escape),
-    /* K20  */  be_nested_str_weak(web_last_seen),
-    /* K21  */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27htrm_X27_X3E_X3Ctd_X20colspan_X3D_X272_X27_X3E),
-    /* K22  */  be_nested_str_weak(web_values),
-    /* K23  */  be_nested_str_weak(_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-    /* K24  */  be_nested_str_weak(stop_iteration),
-    /* K25  */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Chr_X3E),
+    /* K2   */  be_nested_str_weak(device),
+    /* K3   */  be_nested_str_weak(commissioning_open),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(millis),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(content_send),
+    /* K8   */  be_nested_str_weak(format),
+    /* K9   */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BCommissioning_X20open_X20for_X20_X25i_X20min_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K10  */  be_nested_str_weak(compute_manual_pairing_code),
+    /* K11  */  be_nested_str_weak(_X3Cp_X3EManual_X20pairing_X20code_X3A_X3Cbr_X3E_X3Cb_X3E_X25s_X2D_X25s_X2D_X25s_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Chr_X3E),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_const_int(2147483647),
+    /* K14  */  be_nested_str_weak(_X3Cdiv_X3E_X3Ccenter_X3E),
+    /* K15  */  be_nested_str_weak(compute_qrcode_content),
+    /* K16  */  be_nested_str_weak(show_qrcode),
+    /* K17  */  be_nested_str_weak(_X3Cp_X3E_X20_X25s_X3C_X2Fp_X3E),
+    /* K18  */  be_nested_str_weak(_X3C_X2Fdiv_X3E),
+    /* K19  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
     }),
-    be_str_weak(show_bridge_status),
+    be_str_weak(show_commissioning_info),
     &be_const_str_solidified,
-    ( &(const binstruction[102]) {  /* code */
+    ( &(const binstruction[66]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x58100002,  //  0003  LDCONST	R4	K2
-      0x6014000C,  //  0004  GETGBL	R5	G12
-      0x88180103,  //  0005  GETMBR	R6	R0	K3
-      0x88180D04,  //  0006  GETMBR	R6	R6	K4
-      0x7C140200,  //  0007  CALL	R5	1
-      0x14140805,  //  0008  LT	R5	R4	R5
-      0x7816001D,  //  0009  JMPF	R5	#0028
-      0x88140103,  //  000A  GETMBR	R5	R0	K3
-      0x88140B04,  //  000B  GETMBR	R5	R5	K4
-      0x94140A04,  //  000C  GETIDX	R5	R5	R4
-      0x6018000F,  //  000D  GETGBL	R6	G15
-      0x5C1C0A00,  //  000E  MOVE	R7	R5
-      0xB8220A00,  //  000F  GETNGBL	R8	K5
-      0x88201106,  //  0010  GETMBR	R8	R8	K6
-      0x7C180400,  //  0011  CALL	R6	2
-      0x781A0012,  //  0012  JMPF	R6	#0026
-      0x4C180000,  //  0013  LDNIL	R6
-      0x1C180606,  //  0014  EQ	R6	R3	R6
-      0x781A0002,  //  0015  JMPF	R6	#0019
-      0x60180013,  //  0016  GETGBL	R6	G19
-      0x7C180000,  //  0017  CALL	R6	0
-      0x5C0C0C00,  //  0018  MOVE	R3	R6
-      0x88180B07,  //  0019  GETMBR	R6	R5	K7
-      0x88180D08,  //  001A  GETMBR	R6	R6	K8
-      0x8C1C0709,  //  001B  GETMET	R7	R3	K9
-      0x5C240C00,  //  001C  MOVE	R9	R6
-      0x7C1C0400,  //  001D  CALL	R7	2
-      0x741E0002,  //  001E  JMPT	R7	#0022
-      0x601C0012,  //  001F  GETGBL	R7	G18
-      0x7C1C0000,  //  0020  CALL	R7	0
-      0x980C0C07,  //  0021  SETIDX	R3	R6	R7
-      0x941C0606,  //  0022  GETIDX	R7	R3	R6
-      0x8C1C0F0A,  //  0023  GETMET	R7	R7	K10
-      0x5C240A00,  //  0024  MOVE	R9	R5
-      0x7C1C0400,  //  0025  CALL	R7	2
-      0x0010090B,  //  0026  ADD	R4	R4	K11
-      0x7001FFDB,  //  0027  JMP		#0004
-      0x4C140000,  //  0028  LDNIL	R5
-      0x1C140605,  //  0029  EQ	R5	R3	R5
-      0x78160000,  //  002A  JMPF	R5	#002C
-      0x80000A00,  //  002B  RET	0
-      0x8C14030C,  //  002C  GETMET	R5	R1	K12
-      0x581C000D,  //  002D  LDCONST	R7	K13
-      0x7C140400,  //  002E  CALL	R5	2
-      0x8C14030C,  //  002F  GETMET	R5	R1	K12
-      0x581C000E,  //  0030  LDCONST	R7	K14
-      0x7C140400,  //  0031  CALL	R5	2
-      0x8C14030C,  //  0032  GETMET	R5	R1	K12
-      0xB81E0A00,  //  0033  GETNGBL	R7	K5
-      0x881C0F0F,  //  0034  GETMBR	R7	R7	K15
-      0x7C140400,  //  0035  CALL	R5	2
-      0x60140010,  //  0036  GETGBL	R5	G16
-      0x8C180710,  //  0037  GETMET	R6	R3	K16
-      0x7C180200,  //  0038  CALL	R6	1
-      0x7C140200,  //  0039  CALL	R5	1
-      0xA8020023,  //  003A  EXBLK	0	#005F
-      0x5C180A00,  //  003B  MOVE	R6	R5
-      0x7C180000,  //  003C  CALL	R6	0
-      0x8C1C030C,  //  003D  GETMET	R7	R1	K12
-      0x8C240511,  //  003E  GETMET	R9	R2	K17
-      0x582C0012,  //  003F  LDCONST	R11	K18
-      0x8C300313,  //  0040  GETMET	R12	R1	K19
-      0x5C380C00,  //  0041  MOVE	R14	R6
-      0x7C300400,  //  0042  CALL	R12	2
-      0x7C240600,  //  0043  CALL	R9	3
-      0x7C1C0400,  //  0044  CALL	R7	2
-      0x941C0606,  //  0045  GETIDX	R7	R3	R6
-      0x941C0F02,  //  0046  GETIDX	R7	R7	K2
-      0x881C0F07,  //  0047  GETMBR	R7	R7	K7
-      0x8C20030C,  //  0048  GETMET	R8	R1	K12
-      0x8C280F14,  //  0049  GETMET	R10	R7	K20
-      0x7C280200,  //  004A  CALL	R10	1
-      0x7C200400,  //  004B  CALL	R8	2
-      0x60200010,  //  004C  GETGBL	R8	G16
-      0x94240606,  //  004D  GETIDX	R9	R3	R6
-      0x7C200200,  //  004E  CALL	R8	1
-      0xA802000A,  //  004F  EXBLK	0	#005B
-      0x5C241000,  //  0050  MOVE	R9	R8
-      0x7C240000,  //  0051  CALL	R9	0
-      0x8C28030C,  //  0052  GETMET	R10	R1	K12
-      0x58300015,  //  0053  LDCONST	R12	K21
-      0x7C280400,  //  0054  CALL	R10	2
-      0x8C281316,  //  0055  GETMET	R10	R9	K22
-      0x7C280200,  //  0056  CALL	R10	1
-      0x8C28030C,  //  0057  GETMET	R10	R1	K12
-      0x58300017,  //  0058  LDCONST	R12	K23
-      0x7C280400,  //  0059  CALL	R10	2
-      0x7001FFF4,  //  005A  JMP		#0050
-      0x58200018,  //  005B  LDCONST	R8	K24
-      0xAC200200,  //  005C  CATCH	R8	1	0
-      0xB0080000,  //  005D  RAISE	2	R0	R0
-      0x7001FFDB,  //  005E  JMP		#003B
-      0x58140018,  //  005F  LDCONST	R5	K24
-      0xAC140200,  //  0060  CATCH	R5	1	0
-      0xB0080000,  //  0061  RAISE	2	R0	R0
-      0x8C14030C,  //  0062  GETMET	R5	R1	K12
-      0x581C0019,  //  0063  LDCONST	R7	K25
-      0x7C140400,  //  0064  CALL	R5	2
-      0x80000000,  //  0065  RET	0
+      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0xB8120800,  //  0004  GETNGBL	R4	K4
+      0x8C100905,  //  0005  GETMET	R4	R4	K5
+      0x7C100200,  //  0006  CALL	R4	1
+      0x040C0604,  //  0007  SUB	R3	R3	R4
+      0x541203E7,  //  0008  LDINT	R4	1000
+      0x0C0C0604,  //  0009  DIV	R3	R3	R4
+      0x14100706,  //  000A  LT	R4	R3	K6
+      0x78120000,  //  000B  JMPF	R4	#000D
+      0x580C0006,  //  000C  LDCONST	R3	K6
+      0x5412001D,  //  000D  LDINT	R4	30
+      0x00100604,  //  000E  ADD	R4	R3	R4
+      0x5416003B,  //  000F  LDINT	R5	60
+      0x0C100805,  //  0010  DIV	R4	R4	R5
+      0x8C140307,  //  0011  GETMET	R5	R1	K7
+      0x8C1C0508,  //  0012  GETMET	R7	R2	K8
+      0x58240009,  //  0013  LDCONST	R9	K9
+      0x5C280800,  //  0014  MOVE	R10	R4
+      0x7C1C0600,  //  0015  CALL	R7	3
+      0x7C140400,  //  0016  CALL	R5	2
+      0x88140102,  //  0017  GETMBR	R5	R0	K2
+      0x8C140B0A,  //  0018  GETMET	R5	R5	K10
+      0x7C140200,  //  0019  CALL	R5	1
+      0x8C180307,  //  001A  GETMET	R6	R1	K7
+      0x8C200508,  //  001B  GETMET	R8	R2	K8
+      0x5828000B,  //  001C  LDCONST	R10	K11
+      0x402E0D0C,  //  001D  CONNECT	R11	K6	K12
+      0x942C0A0B,  //  001E  GETIDX	R11	R5	R11
+      0x54320003,  //  001F  LDINT	R12	4
+      0x54360005,  //  0020  LDINT	R13	6
+      0x4030180D,  //  0021  CONNECT	R12	R12	R13
+      0x94300A0C,  //  0022  GETIDX	R12	R5	R12
+      0x54360006,  //  0023  LDINT	R13	7
+      0x40341B0D,  //  0024  CONNECT	R13	R13	K13
+      0x94340A0D,  //  0025  GETIDX	R13	R5	R13
+      0x7C200A00,  //  0026  CALL	R8	5
+      0x7C180400,  //  0027  CALL	R6	2
+      0x8C180307,  //  0028  GETMET	R6	R1	K7
+      0x8C200508,  //  0029  GETMET	R8	R2	K8
+      0x5828000E,  //  002A  LDCONST	R10	K14
+      0x7C200400,  //  002B  CALL	R8	2
+      0x7C180400,  //  002C  CALL	R6	2
+      0x88180102,  //  002D  GETMBR	R6	R0	K2
+      0x8C180D0F,  //  002E  GETMET	R6	R6	K15
+      0x7C180200,  //  002F  CALL	R6	1
+      0x8C1C0110,  //  0030  GETMET	R7	R0	K16
+      0x5C240C00,  //  0031  MOVE	R9	R6
+      0x7C1C0400,  //  0032  CALL	R7	2
+      0x8C1C0307,  //  0033  GETMET	R7	R1	K7
+      0x8C240508,  //  0034  GETMET	R9	R2	K8
+      0x582C0011,  //  0035  LDCONST	R11	K17
+      0x5C300C00,  //  0036  MOVE	R12	R6
+      0x7C240600,  //  0037  CALL	R9	3
+      0x7C1C0400,  //  0038  CALL	R7	2
+      0x8C1C0307,  //  0039  GETMET	R7	R1	K7
+      0x8C240508,  //  003A  GETMET	R9	R2	K8
+      0x582C0012,  //  003B  LDCONST	R11	K18
+      0x7C240400,  //  003C  CALL	R9	2
+      0x7C1C0400,  //  003D  CALL	R7	2
+      0x8C1C0307,  //  003E  GETMET	R7	R1	K7
+      0x58240013,  //  003F  LDCONST	R9	K19
+      0x7C1C0400,  //  0040  CALL	R7	2
+      0x80000000,  //  0041  RET	0
     })
   )
 );
@@ -487,48 +347,6 @@ be_local_closure(Matter_UI_show_qrcode,   /* name */
 
 
 /********************************************************************
-** Solidified function: web_add_config_button
-********************************************************************/
-be_local_closure(Matter_UI_web_add_config_button,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(content_send),
-    /* K2   */  be_nested_str_weak(_X3Cp_X3E_X3Cform_X20id_X3Dac_X20action_X3D_X27matterc_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X3E),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(_LOGO),
-    /* K5   */  be_nested_str_weak(_X20Configure_X20Matter_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
-    }),
-    be_str_weak(web_add_config_button),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x7C080400,  //  0003  CALL	R2	2
-      0x8C080301,  //  0004  GETMET	R2	R1	K1
-      0xB8120600,  //  0005  GETNGBL	R4	K3
-      0x88100904,  //  0006  GETMBR	R4	R4	K4
-      0x7C080400,  //  0007  CALL	R2	2
-      0x8C080301,  //  0008  GETMET	R2	R1	K1
-      0x58100005,  //  0009  LDCONST	R4	K5
-      0x7C080400,  //  000A  CALL	R2	2
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: page_part_ctl
 ********************************************************************/
 be_local_closure(Matter_UI_page_part_ctl,   /* name */
@@ -541,7 +359,7 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[71]) {     /* constants */
+    ( &(const bvalue[74]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_nested_str_weak(check_privileged_access),
     /* K2   */  be_nested_str_weak(string),
@@ -565,58 +383,61 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
     /* K20  */  be_nested_str_weak(save_param),
     /* K21  */  be_nested_str_weak(redirect),
     /* K22  */  be_nested_str_weak(_X2F_X3Frst_X3D),
-    /* K23  */  be_nested_str_weak(enable),
-    /* K24  */  be_nested_str_weak(cmd),
-    /* K25  */  be_nested_str_weak(SetOption),
-    /* K26  */  be_nested_str_weak(matter),
-    /* K27  */  be_nested_str_weak(MATTER_OPTION),
-    /* K28  */  be_nested_str_weak(_X201),
-    /* K29  */  be_nested_str_weak(disable),
-    /* K30  */  be_nested_str_weak(_X200),
-    /* K31  */  be_nested_str_weak(del_fabric),
-    /* K32  */  be_const_int(0),
-    /* K33  */  be_nested_str_weak(sessions),
-    /* K34  */  be_nested_str_weak(fabrics),
-    /* K35  */  be_nested_str_weak(get_fabric_index),
-    /* K36  */  be_nested_str_weak(remove_fabric),
-    /* K37  */  be_const_int(1),
-    /* K38  */  be_nested_str_weak(_X2Fmatterc_X3F),
-    /* K39  */  be_nested_str_weak(auto),
-    /* K40  */  be_nested_str_weak(plugins_persist),
-    /* K41  */  be_nested_str_weak(config),
-    /* K42  */  be_nested_str_weak(_X2503i),
-    /* K43  */  be_nested_str_weak(ep),
-    /* K44  */  be_nested_str_weak(pi),
-    /* K45  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20type_X3D_X25s_X20arg_X3D_X25s),
-    /* K46  */  be_nested_str_weak(),
-    /* K47  */  be_nested_str_weak(plugins_classes),
-    /* K48  */  be_nested_str_weak(find),
-    /* K49  */  be_nested_str_weak(type),
-    /* K50  */  be_nested_str_weak(ui_string_to_conf),
-    /* K51  */  be_nested_str_weak(MTR_X3A_X20unknown_X20type_X20_X3D_X20_X25s),
-    /* K52  */  be_const_int(2),
-    /* K53  */  be_nested_str_weak(MTR_X3A_X20skipping_X20parameter),
-    /* K54  */  be_nested_str_weak(MTR_X3A_X20config_X20_X3D_X20_X25s),
-    /* K55  */  be_nested_str_weak(contains),
-    /* K56  */  be_nested_str_weak(0),
-    /* K57  */  be_nested_str_weak(Missing_X20endpoint_X200),
-    /* K58  */  be_nested_str_weak(MTR_X3A_X20config_X20error_X20_X3D_X20_X25s),
-    /* K59  */  be_nested_str_weak(plugins_config),
-    /* K60  */  be_nested_str_weak(content_start),
-    /* K61  */  be_nested_str_weak(Parameter_X20error),
-    /* K62  */  be_nested_str_weak(content_send_style),
-    /* K63  */  be_nested_str_weak(content_send),
-    /* K64  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EError_X3A_X3C_X2Fb_X3E_X25s_X3C_X2Fp_X3E),
-    /* K65  */  be_nested_str_weak(html_escape),
-    /* K66  */  be_nested_str_weak(content_button),
-    /* K67  */  be_nested_str_weak(BUTTON_CONFIGURATION),
-    /* K68  */  be_nested_str_weak(content_stop),
-    /* K69  */  be_nested_str_weak(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    /* K70  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E),
+    /* K23  */  be_nested_str_weak(open_comm),
+    /* K24  */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K25  */  be_nested_str_weak(_X2F),
+    /* K26  */  be_nested_str_weak(clos_comm),
+    /* K27  */  be_nested_str_weak(stop_basic_commissioning),
+    /* K28  */  be_nested_str_weak(enable),
+    /* K29  */  be_nested_str_weak(cmd),
+    /* K30  */  be_nested_str_weak(SetOption),
+    /* K31  */  be_nested_str_weak(matter),
+    /* K32  */  be_nested_str_weak(MATTER_OPTION),
+    /* K33  */  be_nested_str_weak(_X201),
+    /* K34  */  be_nested_str_weak(disable),
+    /* K35  */  be_nested_str_weak(_X200),
+    /* K36  */  be_nested_str_weak(del_fabric),
+    /* K37  */  be_const_int(0),
+    /* K38  */  be_nested_str_weak(sessions),
+    /* K39  */  be_nested_str_weak(fabrics),
+    /* K40  */  be_nested_str_weak(get_fabric_index),
+    /* K41  */  be_nested_str_weak(remove_fabric),
+    /* K42  */  be_const_int(1),
+    /* K43  */  be_nested_str_weak(_X2Fmatterc_X3F),
+    /* K44  */  be_nested_str_weak(auto),
+    /* K45  */  be_nested_str_weak(plugins_persist),
+    /* K46  */  be_nested_str_weak(config),
+    /* K47  */  be_nested_str_weak(_X2503i),
+    /* K48  */  be_nested_str_weak(ep),
+    /* K49  */  be_nested_str_weak(pi),
+    /* K50  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20type_X3D_X25s_X20arg_X3D_X25s),
+    /* K51  */  be_nested_str_weak(),
+    /* K52  */  be_nested_str_weak(0),
+    /* K53  */  be_nested_str_weak(plugins_classes),
+    /* K54  */  be_nested_str_weak(find),
+    /* K55  */  be_nested_str_weak(type),
+    /* K56  */  be_nested_str_weak(ui_string_to_conf),
+    /* K57  */  be_nested_str_weak(MTR_X3A_X20unknown_X20type_X20_X3D_X20_X25s),
+    /* K58  */  be_const_int(2),
+    /* K59  */  be_nested_str_weak(MTR_X3A_X20skipping_X20parameter),
+    /* K60  */  be_nested_str_weak(MTR_X3A_X20config_X20_X3D_X20_X25s),
+    /* K61  */  be_nested_str_weak(MTR_X3A_X20config_X20error_X20_X3D_X20_X25s),
+    /* K62  */  be_nested_str_weak(plugins_config),
+    /* K63  */  be_nested_str_weak(content_start),
+    /* K64  */  be_nested_str_weak(Parameter_X20error),
+    /* K65  */  be_nested_str_weak(content_send_style),
+    /* K66  */  be_nested_str_weak(content_send),
+    /* K67  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EError_X3A_X3C_X2Fb_X3E_X25s_X3C_X2Fp_X3E),
+    /* K68  */  be_nested_str_weak(html_escape),
+    /* K69  */  be_nested_str_weak(content_button),
+    /* K70  */  be_nested_str_weak(BUTTON_CONFIGURATION),
+    /* K71  */  be_nested_str_weak(content_stop),
+    /* K72  */  be_nested_str_weak(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+    /* K73  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E),
     }),
     be_str_weak(page_part_ctl),
     &be_const_str_solidified,
-    ( &(const binstruction[353]) {  /* code */
+    ( &(const binstruction[372]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x8C080301,  //  0001  GETMET	R2	R1	K1
       0x7C080200,  //  0002  CALL	R2	1
@@ -627,7 +448,7 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0xA40E0600,  //  0007  IMPORT	R3	K3
       0xA4120800,  //  0008  IMPORT	R4	K4
       0x4C140000,  //  0009  LDNIL	R5
-      0xA8020136,  //  000A  EXBLK	0	#0142
+      0xA8020149,  //  000A  EXBLK	0	#0155
       0x8C180305,  //  000B  GETMET	R6	R1	K5
       0x58200006,  //  000C  LDCONST	R8	K6
       0x7C180400,  //  000D  CALL	R6	2
@@ -678,564 +499,317 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x8C180315,  //  003A  GETMET	R6	R1	K21
       0x58200016,  //  003B  LDCONST	R8	K22
       0x7C180400,  //  003C  CALL	R6	2
-      0x700200EE,  //  003D  JMP		#012D
+      0x70020101,  //  003D  JMP		#0140
       0x8C180305,  //  003E  GETMET	R6	R1	K5
       0x58200017,  //  003F  LDCONST	R8	K23
       0x7C180400,  //  0040  CALL	R6	2
-      0x781A0014,  //  0041  JMPF	R6	#0057
-      0xB81A1000,  //  0042  GETNGBL	R6	K8
-      0x8C180D09,  //  0043  GETMET	R6	R6	K9
-      0x8C20050A,  //  0044  GETMET	R8	R2	K10
-      0x5828000B,  //  0045  LDCONST	R10	K11
-      0x582C0017,  //  0046  LDCONST	R11	K23
-      0x7C200600,  //  0047  CALL	R8	3
-      0x5824000C,  //  0048  LDCONST	R9	K12
-      0x7C180600,  //  0049  CALL	R6	3
-      0xB81A1000,  //  004A  GETNGBL	R6	K8
-      0x8C180D18,  //  004B  GETMET	R6	R6	K24
-      0x60200008,  //  004C  GETGBL	R8	G8
-      0xB8263400,  //  004D  GETNGBL	R9	K26
-      0x8824131B,  //  004E  GETMBR	R9	R9	K27
-      0x7C200200,  //  004F  CALL	R8	1
-      0x00223208,  //  0050  ADD	R8	K25	R8
-      0x0020111C,  //  0051  ADD	R8	R8	K28
+      0x781A0006,  //  0041  JMPF	R6	#0049
+      0x8818010D,  //  0042  GETMBR	R6	R0	K13
+      0x8C180D18,  //  0043  GETMET	R6	R6	K24
+      0x7C180200,  //  0044  CALL	R6	1
+      0x8C180315,  //  0045  GETMET	R6	R1	K21
+      0x58200019,  //  0046  LDCONST	R8	K25
+      0x7C180400,  //  0047  CALL	R6	2
+      0x700200F6,  //  0048  JMP		#0140
+      0x8C180305,  //  0049  GETMET	R6	R1	K5
+      0x5820001A,  //  004A  LDCONST	R8	K26
+      0x7C180400,  //  004B  CALL	R6	2
+      0x781A0006,  //  004C  JMPF	R6	#0054
+      0x8818010D,  //  004D  GETMBR	R6	R0	K13
+      0x8C180D1B,  //  004E  GETMET	R6	R6	K27
+      0x7C180200,  //  004F  CALL	R6	1
+      0x8C180315,  //  0050  GETMET	R6	R1	K21
+      0x58200019,  //  0051  LDCONST	R8	K25
       0x7C180400,  //  0052  CALL	R6	2
-      0x8C180315,  //  0053  GETMET	R6	R1	K21
-      0x58200016,  //  0054  LDCONST	R8	K22
-      0x7C180400,  //  0055  CALL	R6	2
-      0x700200D5,  //  0056  JMP		#012D
-      0x8C180305,  //  0057  GETMET	R6	R1	K5
-      0x5820001D,  //  0058  LDCONST	R8	K29
-      0x7C180400,  //  0059  CALL	R6	2
-      0x781A0014,  //  005A  JMPF	R6	#0070
-      0xB81A1000,  //  005B  GETNGBL	R6	K8
-      0x8C180D09,  //  005C  GETMET	R6	R6	K9
-      0x8C20050A,  //  005D  GETMET	R8	R2	K10
-      0x5828000B,  //  005E  LDCONST	R10	K11
-      0x582C001D,  //  005F  LDCONST	R11	K29
-      0x7C200600,  //  0060  CALL	R8	3
-      0x5824000C,  //  0061  LDCONST	R9	K12
-      0x7C180600,  //  0062  CALL	R6	3
-      0xB81A1000,  //  0063  GETNGBL	R6	K8
-      0x8C180D18,  //  0064  GETMET	R6	R6	K24
-      0x60200008,  //  0065  GETGBL	R8	G8
-      0xB8263400,  //  0066  GETNGBL	R9	K26
-      0x8824131B,  //  0067  GETMBR	R9	R9	K27
-      0x7C200200,  //  0068  CALL	R8	1
-      0x00223208,  //  0069  ADD	R8	K25	R8
-      0x0020111E,  //  006A  ADD	R8	R8	K30
+      0x700200EB,  //  0053  JMP		#0140
+      0x8C180305,  //  0054  GETMET	R6	R1	K5
+      0x5820001C,  //  0055  LDCONST	R8	K28
+      0x7C180400,  //  0056  CALL	R6	2
+      0x781A0014,  //  0057  JMPF	R6	#006D
+      0xB81A1000,  //  0058  GETNGBL	R6	K8
+      0x8C180D09,  //  0059  GETMET	R6	R6	K9
+      0x8C20050A,  //  005A  GETMET	R8	R2	K10
+      0x5828000B,  //  005B  LDCONST	R10	K11
+      0x582C001C,  //  005C  LDCONST	R11	K28
+      0x7C200600,  //  005D  CALL	R8	3
+      0x5824000C,  //  005E  LDCONST	R9	K12
+      0x7C180600,  //  005F  CALL	R6	3
+      0xB81A1000,  //  0060  GETNGBL	R6	K8
+      0x8C180D1D,  //  0061  GETMET	R6	R6	K29
+      0x60200008,  //  0062  GETGBL	R8	G8
+      0xB8263E00,  //  0063  GETNGBL	R9	K31
+      0x88241320,  //  0064  GETMBR	R9	R9	K32
+      0x7C200200,  //  0065  CALL	R8	1
+      0x00223C08,  //  0066  ADD	R8	K30	R8
+      0x00201121,  //  0067  ADD	R8	R8	K33
+      0x7C180400,  //  0068  CALL	R6	2
+      0x8C180315,  //  0069  GETMET	R6	R1	K21
+      0x58200016,  //  006A  LDCONST	R8	K22
       0x7C180400,  //  006B  CALL	R6	2
-      0x8C180315,  //  006C  GETMET	R6	R1	K21
-      0x58200016,  //  006D  LDCONST	R8	K22
-      0x7C180400,  //  006E  CALL	R6	2
-      0x700200BC,  //  006F  JMP		#012D
-      0x8C180305,  //  0070  GETMET	R6	R1	K5
-      0x5820001F,  //  0071  LDCONST	R8	K31
-      0x7C180400,  //  0072  CALL	R6	2
-      0x781A0026,  //  0073  JMPF	R6	#009B
-      0xB81A1000,  //  0074  GETNGBL	R6	K8
-      0x8C180D09,  //  0075  GETMET	R6	R6	K9
-      0x8C20050A,  //  0076  GETMET	R8	R2	K10
-      0x5828000B,  //  0077  LDCONST	R10	K11
-      0x582C001F,  //  0078  LDCONST	R11	K31
-      0x7C200600,  //  0079  CALL	R8	3
-      0x5824000C,  //  007A  LDCONST	R9	K12
-      0x7C180600,  //  007B  CALL	R6	3
-      0x60180009,  //  007C  GETGBL	R6	G9
-      0x8C1C030F,  //  007D  GETMET	R7	R1	K15
-      0x5824001F,  //  007E  LDCONST	R9	K31
-      0x7C1C0400,  //  007F  CALL	R7	2
-      0x7C180200,  //  0080  CALL	R6	1
-      0x581C0020,  //  0081  LDCONST	R7	K32
-      0x8820010D,  //  0082  GETMBR	R8	R0	K13
-      0x88201121,  //  0083  GETMBR	R8	R8	K33
-      0x88201122,  //  0084  GETMBR	R8	R8	K34
-      0x6024000C,  //  0085  GETGBL	R9	G12
-      0x5C281000,  //  0086  MOVE	R10	R8
-      0x7C240200,  //  0087  CALL	R9	1
-      0x14240E09,  //  0088  LT	R9	R7	R9
-      0x7826000C,  //  0089  JMPF	R9	#0097
-      0x94241007,  //  008A  GETIDX	R9	R8	R7
-      0x8C241323,  //  008B  GETMET	R9	R9	K35
-      0x7C240200,  //  008C  CALL	R9	1
-      0x1C241206,  //  008D  EQ	R9	R9	R6
-      0x78260005,  //  008E  JMPF	R9	#0095
-      0x8824010D,  //  008F  GETMBR	R9	R0	K13
-      0x8C241324,  //  0090  GETMET	R9	R9	K36
-      0x942C1007,  //  0091  GETIDX	R11	R8	R7
-      0x7C240400,  //  0092  CALL	R9	2
-      0x70020002,  //  0093  JMP		#0097
-      0x70020000,  //  0094  JMP		#0096
-      0x001C0F25,  //  0095  ADD	R7	R7	K37
-      0x7001FFED,  //  0096  JMP		#0085
-      0x8C240315,  //  0097  GETMET	R9	R1	K21
-      0x582C0026,  //  0098  LDCONST	R11	K38
-      0x7C240400,  //  0099  CALL	R9	2
-      0x70020091,  //  009A  JMP		#012D
-      0x8C180305,  //  009B  GETMET	R6	R1	K5
-      0x58200027,  //  009C  LDCONST	R8	K39
-      0x7C180400,  //  009D  CALL	R6	2
-      0x781A0011,  //  009E  JMPF	R6	#00B1
-      0xB81A1000,  //  009F  GETNGBL	R6	K8
-      0x8C180D09,  //  00A0  GETMET	R6	R6	K9
-      0x8C20050A,  //  00A1  GETMET	R8	R2	K10
-      0x5828000B,  //  00A2  LDCONST	R10	K11
-      0x582C0027,  //  00A3  LDCONST	R11	K39
-      0x7C200600,  //  00A4  CALL	R8	3
-      0x5824000C,  //  00A5  LDCONST	R9	K12
-      0x7C180600,  //  00A6  CALL	R6	3
-      0x8818010D,  //  00A7  GETMBR	R6	R0	K13
-      0x501C0000,  //  00A8  LDBOOL	R7	0	0
-      0x901A5007,  //  00A9  SETMBR	R6	K40	R7
-      0x8818010D,  //  00AA  GETMBR	R6	R0	K13
-      0x8C180D14,  //  00AB  GETMET	R6	R6	K20
-      0x7C180200,  //  00AC  CALL	R6	1
-      0x8C180315,  //  00AD  GETMET	R6	R1	K21
-      0x58200016,  //  00AE  LDCONST	R8	K22
-      0x7C180400,  //  00AF  CALL	R6	2
-      0x7002007B,  //  00B0  JMP		#012D
+      0x700200D2,  //  006C  JMP		#0140
+      0x8C180305,  //  006D  GETMET	R6	R1	K5
+      0x58200022,  //  006E  LDCONST	R8	K34
+      0x7C180400,  //  006F  CALL	R6	2
+      0x781A0014,  //  0070  JMPF	R6	#0086
+      0xB81A1000,  //  0071  GETNGBL	R6	K8
+      0x8C180D09,  //  0072  GETMET	R6	R6	K9
+      0x8C20050A,  //  0073  GETMET	R8	R2	K10
+      0x5828000B,  //  0074  LDCONST	R10	K11
+      0x582C0022,  //  0075  LDCONST	R11	K34
+      0x7C200600,  //  0076  CALL	R8	3
+      0x5824000C,  //  0077  LDCONST	R9	K12
+      0x7C180600,  //  0078  CALL	R6	3
+      0xB81A1000,  //  0079  GETNGBL	R6	K8
+      0x8C180D1D,  //  007A  GETMET	R6	R6	K29
+      0x60200008,  //  007B  GETGBL	R8	G8
+      0xB8263E00,  //  007C  GETNGBL	R9	K31
+      0x88241320,  //  007D  GETMBR	R9	R9	K32
+      0x7C200200,  //  007E  CALL	R8	1
+      0x00223C08,  //  007F  ADD	R8	K30	R8
+      0x00201123,  //  0080  ADD	R8	R8	K35
+      0x7C180400,  //  0081  CALL	R6	2
+      0x8C180315,  //  0082  GETMET	R6	R1	K21
+      0x58200016,  //  0083  LDCONST	R8	K22
+      0x7C180400,  //  0084  CALL	R6	2
+      0x700200B9,  //  0085  JMP		#0140
+      0x8C180305,  //  0086  GETMET	R6	R1	K5
+      0x58200024,  //  0087  LDCONST	R8	K36
+      0x7C180400,  //  0088  CALL	R6	2
+      0x781A0026,  //  0089  JMPF	R6	#00B1
+      0xB81A1000,  //  008A  GETNGBL	R6	K8
+      0x8C180D09,  //  008B  GETMET	R6	R6	K9
+      0x8C20050A,  //  008C  GETMET	R8	R2	K10
+      0x5828000B,  //  008D  LDCONST	R10	K11
+      0x582C0024,  //  008E  LDCONST	R11	K36
+      0x7C200600,  //  008F  CALL	R8	3
+      0x5824000C,  //  0090  LDCONST	R9	K12
+      0x7C180600,  //  0091  CALL	R6	3
+      0x60180009,  //  0092  GETGBL	R6	G9
+      0x8C1C030F,  //  0093  GETMET	R7	R1	K15
+      0x58240024,  //  0094  LDCONST	R9	K36
+      0x7C1C0400,  //  0095  CALL	R7	2
+      0x7C180200,  //  0096  CALL	R6	1
+      0x581C0025,  //  0097  LDCONST	R7	K37
+      0x8820010D,  //  0098  GETMBR	R8	R0	K13
+      0x88201126,  //  0099  GETMBR	R8	R8	K38
+      0x88201127,  //  009A  GETMBR	R8	R8	K39
+      0x6024000C,  //  009B  GETGBL	R9	G12
+      0x5C281000,  //  009C  MOVE	R10	R8
+      0x7C240200,  //  009D  CALL	R9	1
+      0x14240E09,  //  009E  LT	R9	R7	R9
+      0x7826000C,  //  009F  JMPF	R9	#00AD
+      0x94241007,  //  00A0  GETIDX	R9	R8	R7
+      0x8C241328,  //  00A1  GETMET	R9	R9	K40
+      0x7C240200,  //  00A2  CALL	R9	1
+      0x1C241206,  //  00A3  EQ	R9	R9	R6
+      0x78260005,  //  00A4  JMPF	R9	#00AB
+      0x8824010D,  //  00A5  GETMBR	R9	R0	K13
+      0x8C241329,  //  00A6  GETMET	R9	R9	K41
+      0x942C1007,  //  00A7  GETIDX	R11	R8	R7
+      0x7C240400,  //  00A8  CALL	R9	2
+      0x70020002,  //  00A9  JMP		#00AD
+      0x70020000,  //  00AA  JMP		#00AC
+      0x001C0F2A,  //  00AB  ADD	R7	R7	K42
+      0x7001FFED,  //  00AC  JMP		#009B
+      0x8C240315,  //  00AD  GETMET	R9	R1	K21
+      0x582C002B,  //  00AE  LDCONST	R11	K43
+      0x7C240400,  //  00AF  CALL	R9	2
+      0x7002008E,  //  00B0  JMP		#0140
       0x8C180305,  //  00B1  GETMET	R6	R1	K5
-      0x58200029,  //  00B2  LDCONST	R8	K41
+      0x5820002C,  //  00B2  LDCONST	R8	K44
       0x7C180400,  //  00B3  CALL	R6	2
-      0x781A0077,  //  00B4  JMPF	R6	#012D
-      0x60180013,  //  00B5  GETGBL	R6	G19
-      0x7C180000,  //  00B6  CALL	R6	0
-      0xB81E1000,  //  00B7  GETNGBL	R7	K8
-      0x8C1C0F09,  //  00B8  GETMET	R7	R7	K9
-      0x8C24050A,  //  00B9  GETMET	R9	R2	K10
-      0x582C000B,  //  00BA  LDCONST	R11	K11
-      0x58300029,  //  00BB  LDCONST	R12	K41
-      0x7C240600,  //  00BC  CALL	R9	3
-      0x5828000C,  //  00BD  LDCONST	R10	K12
-      0x7C1C0600,  //  00BE  CALL	R7	3
-      0x581C0020,  //  00BF  LDCONST	R7	K32
-      0x8C20050A,  //  00C0  GETMET	R8	R2	K10
-      0x5828002A,  //  00C1  LDCONST	R10	K42
-      0x5C2C0E00,  //  00C2  MOVE	R11	R7
-      0x7C200600,  //  00C3  CALL	R8	3
-      0x8C240305,  //  00C4  GETMET	R9	R1	K5
-      0x002E5608,  //  00C5  ADD	R11	K43	R8
-      0x7C240400,  //  00C6  CALL	R9	2
-      0x78260040,  //  00C7  JMPF	R9	#0109
-      0x8C24030F,  //  00C8  GETMET	R9	R1	K15
-      0x002E5608,  //  00C9  ADD	R11	K43	R8
-      0x7C240400,  //  00CA  CALL	R9	2
-      0x60280009,  //  00CB  GETGBL	R10	G9
-      0x5C2C1200,  //  00CC  MOVE	R11	R9
-      0x7C280200,  //  00CD  CALL	R10	1
-      0x8C2C030F,  //  00CE  GETMET	R11	R1	K15
-      0x00365808,  //  00CF  ADD	R13	K44	R8
-      0x7C2C0400,  //  00D0  CALL	R11	2
-      0x8C30030F,  //  00D1  GETMET	R12	R1	K15
-      0x003A1E08,  //  00D2  ADD	R14	K15	R8
-      0x7C300400,  //  00D3  CALL	R12	2
-      0xB8361000,  //  00D4  GETNGBL	R13	K8
-      0x8C341B09,  //  00D5  GETMET	R13	R13	K9
-      0x8C3C050A,  //  00D6  GETMET	R15	R2	K10
-      0x5844002D,  //  00D7  LDCONST	R17	K45
-      0x5C481200,  //  00D8  MOVE	R18	R9
-      0x5C4C1600,  //  00D9  MOVE	R19	R11
-      0x5C501800,  //  00DA  MOVE	R20	R12
-      0x7C3C0A00,  //  00DB  CALL	R15	5
-      0x5840000C,  //  00DC  LDCONST	R16	K12
-      0x7C340600,  //  00DD  CALL	R13	3
-      0x2034132E,  //  00DE  NE	R13	R9	K46
-      0x7836001C,  //  00DF  JMPF	R13	#00FD
-      0x2034172E,  //  00E0  NE	R13	R11	K46
-      0x7836001A,  //  00E1  JMPF	R13	#00FD
-      0x8834010D,  //  00E2  GETMBR	R13	R0	K13
-      0x88341B2F,  //  00E3  GETMBR	R13	R13	K47
-      0x8C341B30,  //  00E4  GETMET	R13	R13	K48
-      0x5C3C1600,  //  00E5  MOVE	R15	R11
-      0x7C340400,  //  00E6  CALL	R13	2
-      0x4C380000,  //  00E7  LDNIL	R14
-      0x20381A0E,  //  00E8  NE	R14	R13	R14
-      0x783A0009,  //  00E9  JMPF	R14	#00F4
-      0x60380013,  //  00EA  GETGBL	R14	G19
-      0x7C380000,  //  00EB  CALL	R14	0
-      0x983A620B,  //  00EC  SETIDX	R14	K49	R11
-      0x8C3C1B32,  //  00ED  GETMET	R15	R13	K50
-      0x5C441A00,  //  00EE  MOVE	R17	R13
-      0x5C481C00,  //  00EF  MOVE	R18	R14
-      0x5C4C1800,  //  00F0  MOVE	R19	R12
-      0x7C3C0800,  //  00F1  CALL	R15	4
-      0x9818120E,  //  00F2  SETIDX	R6	R9	R14
-      0x70020007,  //  00F3  JMP		#00FC
-      0xB83A1000,  //  00F4  GETNGBL	R14	K8
-      0x8C381D09,  //  00F5  GETMET	R14	R14	K9
-      0x8C40050A,  //  00F6  GETMET	R16	R2	K10
-      0x58480033,  //  00F7  LDCONST	R18	K51
-      0x5C4C1600,  //  00F8  MOVE	R19	R11
-      0x7C400600,  //  00F9  CALL	R16	3
-      0x58440034,  //  00FA  LDCONST	R17	K52
-      0x7C380600,  //  00FB  CALL	R14	3
-      0x70020004,  //  00FC  JMP		#0102
-      0xB8361000,  //  00FD  GETNGBL	R13	K8
-      0x8C341B09,  //  00FE  GETMET	R13	R13	K9
-      0x583C0035,  //  00FF  LDCONST	R15	K53
-      0x58400034,  //  0100  LDCONST	R16	K52
-      0x7C340600,  //  0101  CALL	R13	3
-      0x001C0F25,  //  0102  ADD	R7	R7	K37
-      0x8C34050A,  //  0103  GETMET	R13	R2	K10
-      0x583C002A,  //  0104  LDCONST	R15	K42
-      0x5C400E00,  //  0105  MOVE	R16	R7
-      0x7C340600,  //  0106  CALL	R13	3
-      0x5C201A00,  //  0107  MOVE	R8	R13
-      0x7001FFBA,  //  0108  JMP		#00C4
-      0xB8261000,  //  0109  GETNGBL	R9	K8
-      0x8C241309,  //  010A  GETMET	R9	R9	K9
-      0x8C2C050A,  //  010B  GETMET	R11	R2	K10
-      0x58340036,  //  010C  LDCONST	R13	K54
-      0x60380008,  //  010D  GETGBL	R14	G8
-      0x5C3C0C00,  //  010E  MOVE	R15	R6
-      0x7C380200,  //  010F  CALL	R14	1
-      0x7C2C0600,  //  0110  CALL	R11	3
-      0x5830000C,  //  0111  LDCONST	R12	K12
-      0x7C240600,  //  0112  CALL	R9	3
-      0x8C240D37,  //  0113  GETMET	R9	R6	K55
-      0x582C0038,  //  0114  LDCONST	R11	K56
-      0x7C240400,  //  0115  CALL	R9	2
-      0x74260000,  //  0116  JMPT	R9	#0118
-      0x58140039,  //  0117  LDCONST	R5	K57
-      0x78160008,  //  0118  JMPF	R5	#0122
-      0xB8261000,  //  0119  GETNGBL	R9	K8
-      0x8C241309,  //  011A  GETMET	R9	R9	K9
-      0x8C2C050A,  //  011B  GETMET	R11	R2	K10
-      0x5834003A,  //  011C  LDCONST	R13	K58
-      0x5C380A00,  //  011D  MOVE	R14	R5
-      0x7C2C0600,  //  011E  CALL	R11	3
-      0x5830000C,  //  011F  LDCONST	R12	K12
-      0x7C240600,  //  0120  CALL	R9	3
-      0x7002000A,  //  0121  JMP		#012D
-      0x8824010D,  //  0122  GETMBR	R9	R0	K13
-      0x90267606,  //  0123  SETMBR	R9	K59	R6
-      0x8824010D,  //  0124  GETMBR	R9	R0	K13
-      0x50280200,  //  0125  LDBOOL	R10	1	0
-      0x9026500A,  //  0126  SETMBR	R9	K40	R10
-      0x8824010D,  //  0127  GETMBR	R9	R0	K13
-      0x8C241314,  //  0128  GETMET	R9	R9	K20
-      0x7C240200,  //  0129  CALL	R9	1
-      0x8C240315,  //  012A  GETMET	R9	R1	K21
-      0x582C0016,  //  012B  LDCONST	R11	K22
-      0x7C240400,  //  012C  CALL	R9	2
-      0x78160011,  //  012D  JMPF	R5	#0140
-      0x8C18033C,  //  012E  GETMET	R6	R1	K60
-      0x5820003D,  //  012F  LDCONST	R8	K61
-      0x7C180400,  //  0130  CALL	R6	2
-      0x8C18033E,  //  0131  GETMET	R6	R1	K62
-      0x7C180200,  //  0132  CALL	R6	1
-      0x8C18033F,  //  0133  GETMET	R6	R1	K63
-      0x8C20050A,  //  0134  GETMET	R8	R2	K10
-      0x58280040,  //  0135  LDCONST	R10	K64
-      0x8C2C0341,  //  0136  GETMET	R11	R1	K65
-      0x5C340A00,  //  0137  MOVE	R13	R5
-      0x7C2C0400,  //  0138  CALL	R11	2
-      0x7C200600,  //  0139  CALL	R8	3
-      0x7C180400,  //  013A  CALL	R6	2
-      0x8C180342,  //  013B  GETMET	R6	R1	K66
-      0x88200343,  //  013C  GETMBR	R8	R1	K67
-      0x7C180400,  //  013D  CALL	R6	2
-      0x8C180344,  //  013E  GETMET	R6	R1	K68
-      0x7C180200,  //  013F  CALL	R6	1
-      0xA8040001,  //  0140  EXBLK	1	1
-      0x7002001D,  //  0141  JMP		#0160
-      0xAC180002,  //  0142  CATCH	R6	0	2
-      0x7002001A,  //  0143  JMP		#015F
-      0xB8221000,  //  0144  GETNGBL	R8	K8
-      0x8C201109,  //  0145  GETMET	R8	R8	K9
-      0x8C28050A,  //  0146  GETMET	R10	R2	K10
-      0x58300045,  //  0147  LDCONST	R12	K69
-      0x5C340C00,  //  0148  MOVE	R13	R6
-      0x5C380E00,  //  0149  MOVE	R14	R7
-      0x7C280800,  //  014A  CALL	R10	4
-      0x582C0034,  //  014B  LDCONST	R11	K52
+      0x781A0011,  //  00B4  JMPF	R6	#00C7
+      0xB81A1000,  //  00B5  GETNGBL	R6	K8
+      0x8C180D09,  //  00B6  GETMET	R6	R6	K9
+      0x8C20050A,  //  00B7  GETMET	R8	R2	K10
+      0x5828000B,  //  00B8  LDCONST	R10	K11
+      0x582C002C,  //  00B9  LDCONST	R11	K44
+      0x7C200600,  //  00BA  CALL	R8	3
+      0x5824000C,  //  00BB  LDCONST	R9	K12
+      0x7C180600,  //  00BC  CALL	R6	3
+      0x8818010D,  //  00BD  GETMBR	R6	R0	K13
+      0x501C0000,  //  00BE  LDBOOL	R7	0	0
+      0x901A5A07,  //  00BF  SETMBR	R6	K45	R7
+      0x8818010D,  //  00C0  GETMBR	R6	R0	K13
+      0x8C180D14,  //  00C1  GETMET	R6	R6	K20
+      0x7C180200,  //  00C2  CALL	R6	1
+      0x8C180315,  //  00C3  GETMET	R6	R1	K21
+      0x58200016,  //  00C4  LDCONST	R8	K22
+      0x7C180400,  //  00C5  CALL	R6	2
+      0x70020078,  //  00C6  JMP		#0140
+      0x8C180305,  //  00C7  GETMET	R6	R1	K5
+      0x5820002E,  //  00C8  LDCONST	R8	K46
+      0x7C180400,  //  00C9  CALL	R6	2
+      0x781A0074,  //  00CA  JMPF	R6	#0140
+      0x60180013,  //  00CB  GETGBL	R6	G19
+      0x7C180000,  //  00CC  CALL	R6	0
+      0xB81E1000,  //  00CD  GETNGBL	R7	K8
+      0x8C1C0F09,  //  00CE  GETMET	R7	R7	K9
+      0x8C24050A,  //  00CF  GETMET	R9	R2	K10
+      0x582C000B,  //  00D0  LDCONST	R11	K11
+      0x5830002E,  //  00D1  LDCONST	R12	K46
+      0x7C240600,  //  00D2  CALL	R9	3
+      0x5828000C,  //  00D3  LDCONST	R10	K12
+      0x7C1C0600,  //  00D4  CALL	R7	3
+      0x581C002A,  //  00D5  LDCONST	R7	K42
+      0x8C20050A,  //  00D6  GETMET	R8	R2	K10
+      0x5828002F,  //  00D7  LDCONST	R10	K47
+      0x5C2C0E00,  //  00D8  MOVE	R11	R7
+      0x7C200600,  //  00D9  CALL	R8	3
+      0x8C240305,  //  00DA  GETMET	R9	R1	K5
+      0x002E6008,  //  00DB  ADD	R11	K48	R8
+      0x7C240400,  //  00DC  CALL	R9	2
+      0x78260042,  //  00DD  JMPF	R9	#0121
+      0x8C24030F,  //  00DE  GETMET	R9	R1	K15
+      0x002E6008,  //  00DF  ADD	R11	K48	R8
+      0x7C240400,  //  00E0  CALL	R9	2
+      0x60280009,  //  00E1  GETGBL	R10	G9
+      0x5C2C1200,  //  00E2  MOVE	R11	R9
+      0x7C280200,  //  00E3  CALL	R10	1
+      0x8C2C030F,  //  00E4  GETMET	R11	R1	K15
+      0x00366208,  //  00E5  ADD	R13	K49	R8
+      0x7C2C0400,  //  00E6  CALL	R11	2
+      0x8C30030F,  //  00E7  GETMET	R12	R1	K15
+      0x003A1E08,  //  00E8  ADD	R14	K15	R8
+      0x7C300400,  //  00E9  CALL	R12	2
+      0xB8361000,  //  00EA  GETNGBL	R13	K8
+      0x8C341B09,  //  00EB  GETMET	R13	R13	K9
+      0x8C3C050A,  //  00EC  GETMET	R15	R2	K10
+      0x58440032,  //  00ED  LDCONST	R17	K50
+      0x5C481200,  //  00EE  MOVE	R18	R9
+      0x5C4C1600,  //  00EF  MOVE	R19	R11
+      0x5C501800,  //  00F0  MOVE	R20	R12
+      0x7C3C0A00,  //  00F1  CALL	R15	5
+      0x5840000C,  //  00F2  LDCONST	R16	K12
+      0x7C340600,  //  00F3  CALL	R13	3
+      0x20341333,  //  00F4  NE	R13	R9	K51
+      0x7836001E,  //  00F5  JMPF	R13	#0115
+      0x20341733,  //  00F6  NE	R13	R11	K51
+      0x7836001C,  //  00F7  JMPF	R13	#0115
+      0x20341334,  //  00F8  NE	R13	R9	K52
+      0x7836001A,  //  00F9  JMPF	R13	#0115
+      0x8834010D,  //  00FA  GETMBR	R13	R0	K13
+      0x88341B35,  //  00FB  GETMBR	R13	R13	K53
+      0x8C341B36,  //  00FC  GETMET	R13	R13	K54
+      0x5C3C1600,  //  00FD  MOVE	R15	R11
+      0x7C340400,  //  00FE  CALL	R13	2
+      0x4C380000,  //  00FF  LDNIL	R14
+      0x20381A0E,  //  0100  NE	R14	R13	R14
+      0x783A0009,  //  0101  JMPF	R14	#010C
+      0x60380013,  //  0102  GETGBL	R14	G19
+      0x7C380000,  //  0103  CALL	R14	0
+      0x983A6E0B,  //  0104  SETIDX	R14	K55	R11
+      0x8C3C1B38,  //  0105  GETMET	R15	R13	K56
+      0x5C441A00,  //  0106  MOVE	R17	R13
+      0x5C481C00,  //  0107  MOVE	R18	R14
+      0x5C4C1800,  //  0108  MOVE	R19	R12
+      0x7C3C0800,  //  0109  CALL	R15	4
+      0x9818120E,  //  010A  SETIDX	R6	R9	R14
+      0x70020007,  //  010B  JMP		#0114
+      0xB83A1000,  //  010C  GETNGBL	R14	K8
+      0x8C381D09,  //  010D  GETMET	R14	R14	K9
+      0x8C40050A,  //  010E  GETMET	R16	R2	K10
+      0x58480039,  //  010F  LDCONST	R18	K57
+      0x5C4C1600,  //  0110  MOVE	R19	R11
+      0x7C400600,  //  0111  CALL	R16	3
+      0x5844003A,  //  0112  LDCONST	R17	K58
+      0x7C380600,  //  0113  CALL	R14	3
+      0x70020004,  //  0114  JMP		#011A
+      0xB8361000,  //  0115  GETNGBL	R13	K8
+      0x8C341B09,  //  0116  GETMET	R13	R13	K9
+      0x583C003B,  //  0117  LDCONST	R15	K59
+      0x5840003A,  //  0118  LDCONST	R16	K58
+      0x7C340600,  //  0119  CALL	R13	3
+      0x001C0F2A,  //  011A  ADD	R7	R7	K42
+      0x8C34050A,  //  011B  GETMET	R13	R2	K10
+      0x583C002F,  //  011C  LDCONST	R15	K47
+      0x5C400E00,  //  011D  MOVE	R16	R7
+      0x7C340600,  //  011E  CALL	R13	3
+      0x5C201A00,  //  011F  MOVE	R8	R13
+      0x7001FFB8,  //  0120  JMP		#00DA
+      0xB8261000,  //  0121  GETNGBL	R9	K8
+      0x8C241309,  //  0122  GETMET	R9	R9	K9
+      0x8C2C050A,  //  0123  GETMET	R11	R2	K10
+      0x5834003C,  //  0124  LDCONST	R13	K60
+      0x60380008,  //  0125  GETGBL	R14	G8
+      0x5C3C0C00,  //  0126  MOVE	R15	R6
+      0x7C380200,  //  0127  CALL	R14	1
+      0x7C2C0600,  //  0128  CALL	R11	3
+      0x5830000C,  //  0129  LDCONST	R12	K12
+      0x7C240600,  //  012A  CALL	R9	3
+      0x78160008,  //  012B  JMPF	R5	#0135
+      0xB8261000,  //  012C  GETNGBL	R9	K8
+      0x8C241309,  //  012D  GETMET	R9	R9	K9
+      0x8C2C050A,  //  012E  GETMET	R11	R2	K10
+      0x5834003D,  //  012F  LDCONST	R13	K61
+      0x5C380A00,  //  0130  MOVE	R14	R5
+      0x7C2C0600,  //  0131  CALL	R11	3
+      0x5830000C,  //  0132  LDCONST	R12	K12
+      0x7C240600,  //  0133  CALL	R9	3
+      0x7002000A,  //  0134  JMP		#0140
+      0x8824010D,  //  0135  GETMBR	R9	R0	K13
+      0x90267C06,  //  0136  SETMBR	R9	K62	R6
+      0x8824010D,  //  0137  GETMBR	R9	R0	K13
+      0x50280200,  //  0138  LDBOOL	R10	1	0
+      0x90265A0A,  //  0139  SETMBR	R9	K45	R10
+      0x8824010D,  //  013A  GETMBR	R9	R0	K13
+      0x8C241314,  //  013B  GETMET	R9	R9	K20
+      0x7C240200,  //  013C  CALL	R9	1
+      0x8C240315,  //  013D  GETMET	R9	R1	K21
+      0x582C0016,  //  013E  LDCONST	R11	K22
+      0x7C240400,  //  013F  CALL	R9	2
+      0x78160011,  //  0140  JMPF	R5	#0153
+      0x8C18033F,  //  0141  GETMET	R6	R1	K63
+      0x58200040,  //  0142  LDCONST	R8	K64
+      0x7C180400,  //  0143  CALL	R6	2
+      0x8C180341,  //  0144  GETMET	R6	R1	K65
+      0x7C180200,  //  0145  CALL	R6	1
+      0x8C180342,  //  0146  GETMET	R6	R1	K66
+      0x8C20050A,  //  0147  GETMET	R8	R2	K10
+      0x58280043,  //  0148  LDCONST	R10	K67
+      0x8C2C0344,  //  0149  GETMET	R11	R1	K68
+      0x5C340A00,  //  014A  MOVE	R13	R5
+      0x7C2C0400,  //  014B  CALL	R11	2
       0x7C200600,  //  014C  CALL	R8	3
-      0x8C20033C,  //  014D  GETMET	R8	R1	K60
-      0x5828003D,  //  014E  LDCONST	R10	K61
-      0x7C200400,  //  014F  CALL	R8	2
-      0x8C20033E,  //  0150  GETMET	R8	R1	K62
-      0x7C200200,  //  0151  CALL	R8	1
-      0x8C20033F,  //  0152  GETMET	R8	R1	K63
-      0x8C28050A,  //  0153  GETMET	R10	R2	K10
-      0x58300046,  //  0154  LDCONST	R12	K70
-      0x5C340C00,  //  0155  MOVE	R13	R6
-      0x5C380E00,  //  0156  MOVE	R14	R7
-      0x7C280800,  //  0157  CALL	R10	4
-      0x7C200400,  //  0158  CALL	R8	2
-      0x8C200342,  //  0159  GETMET	R8	R1	K66
-      0x88280343,  //  015A  GETMBR	R10	R1	K67
-      0x7C200400,  //  015B  CALL	R8	2
-      0x8C200344,  //  015C  GETMET	R8	R1	K68
-      0x7C200200,  //  015D  CALL	R8	1
-      0x70020000,  //  015E  JMP		#0160
-      0xB0080000,  //  015F  RAISE	2	R0	R0
-      0x80000000,  //  0160  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: show_passcode_form
-********************************************************************/
-be_local_closure(Matter_UI_show_passcode_form,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20Passcode_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    /* K4   */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X20onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E),
-    /* K5   */  be_nested_str_weak(_X3Cp_X3EPasscode_X3A_X3C_X2Fp_X3E),
-    /* K6   */  be_nested_str_weak(format),
-    /* K7   */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27number_X27_X20min_X3D_X271_X27_X20max_X3D_X2799999998_X27_X20name_X3D_X27passcode_X27_X20value_X3D_X27_X25i_X27_X3E),
-    /* K8   */  be_nested_str_weak(device),
-    /* K9   */  be_nested_str_weak(root_passcode),
-    /* K10  */  be_nested_str_weak(_X3Cp_X3EDistinguish_X20id_X3A_X3C_X2Fp_X3E),
-    /* K11  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27number_X27_X20min_X3D_X270_X27_X20max_X3D_X274095_X27_X20name_X3D_X27discriminator_X27_X20value_X3D_X27_X25i_X27_X3E),
-    /* K12  */  be_nested_str_weak(root_discriminator),
-    /* K13  */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20type_X3D_X27checkbox_X27_X20name_X3D_X27ipv4_X27_X25s_X3EIPv4_X20only_X3C_X2Fp_X3E),
-    /* K14  */  be_nested_str_weak(ipv4only),
-    /* K15  */  be_nested_str_weak(_X20checked),
-    /* K16  */  be_nested_str_weak(),
-    /* K17  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27passcode_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
-    /* K18  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    }),
-    be_str_weak(show_passcode_form),
-    &be_const_str_solidified,
-    ( &(const binstruction[46]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
-      0x58140003,  //  0003  LDCONST	R5	K3
-      0x7C0C0400,  //  0004  CALL	R3	2
-      0x8C0C0302,  //  0005  GETMET	R3	R1	K2
-      0x58140004,  //  0006  LDCONST	R5	K4
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x8C0C0302,  //  0008  GETMET	R3	R1	K2
-      0x58140005,  //  0009  LDCONST	R5	K5
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x8C0C0302,  //  000B  GETMET	R3	R1	K2
-      0x8C140506,  //  000C  GETMET	R5	R2	K6
-      0x581C0007,  //  000D  LDCONST	R7	K7
-      0x88200108,  //  000E  GETMBR	R8	R0	K8
-      0x88201109,  //  000F  GETMBR	R8	R8	K9
-      0x7C140600,  //  0010  CALL	R5	3
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x8C0C0302,  //  0012  GETMET	R3	R1	K2
-      0x5814000A,  //  0013  LDCONST	R5	K10
-      0x7C0C0400,  //  0014  CALL	R3	2
-      0x8C0C0302,  //  0015  GETMET	R3	R1	K2
-      0x8C140506,  //  0016  GETMET	R5	R2	K6
-      0x581C000B,  //  0017  LDCONST	R7	K11
-      0x88200108,  //  0018  GETMBR	R8	R0	K8
-      0x8820110C,  //  0019  GETMBR	R8	R8	K12
-      0x7C140600,  //  001A  CALL	R5	3
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x8C0C0302,  //  001C  GETMET	R3	R1	K2
-      0x8C140506,  //  001D  GETMET	R5	R2	K6
-      0x581C000D,  //  001E  LDCONST	R7	K13
-      0x88200108,  //  001F  GETMBR	R8	R0	K8
-      0x8820110E,  //  0020  GETMBR	R8	R8	K14
-      0x78220001,  //  0021  JMPF	R8	#0024
-      0x5820000F,  //  0022  LDCONST	R8	K15
-      0x70020000,  //  0023  JMP		#0025
-      0x58200010,  //  0024  LDCONST	R8	K16
-      0x7C140600,  //  0025  CALL	R5	3
-      0x7C0C0400,  //  0026  CALL	R3	2
-      0x8C0C0302,  //  0027  GETMET	R3	R1	K2
-      0x58140011,  //  0028  LDCONST	R5	K17
-      0x7C0C0400,  //  0029  CALL	R3	2
-      0x8C0C0302,  //  002A  GETMET	R3	R1	K2
-      0x58140012,  //  002B  LDCONST	R5	K18
-      0x7C0C0400,  //  002C  CALL	R3	2
-      0x80000000,  //  002D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: web_add_handler
-********************************************************************/
-be_local_closure(Matter_UI_web_add_handler,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(page_part_mgr),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80040000,  //  0003  RET	1	R0
-        })
-      ),
-      be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(page_part_ctl),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80040000,  //  0003  RET	1	R0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(on),
-    /* K2   */  be_nested_str_weak(_X2Fmatterc),
-    /* K3   */  be_nested_str_weak(HTTP_GET),
-    /* K4   */  be_nested_str_weak(HTTP_POST),
-    }),
-    be_str_weak(web_add_handler),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x84140000,  //  0003  CLOSURE	R5	P0
-      0x88180303,  //  0004  GETMBR	R6	R1	K3
-      0x7C080800,  //  0005  CALL	R2	4
-      0x8C080301,  //  0006  GETMET	R2	R1	K1
-      0x58100002,  //  0007  LDCONST	R4	K2
-      0x84140001,  //  0008  CLOSURE	R5	P1
-      0x88180304,  //  0009  GETMBR	R6	R1	K4
-      0x7C080800,  //  000A  CALL	R2	4
-      0xA0000000,  //  000B  CLOSE	R0
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: show_enable
-********************************************************************/
-be_local_closure(Matter_UI_show_enable,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(get_option),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(MATTER_OPTION),
-    /* K6   */  be_nested_str_weak(content_send),
-    /* K7   */  be_nested_str_weak(format),
-    /* K8   */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20_X25s_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    /* K9   */  be_nested_str_weak(Enabled),
-    /* K10  */  be_nested_str_weak(Disabled),
-    /* K11  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A320px_X3B_X27_X3ECheck_X20the_X20_X3Ca_X20href_X3D_X27https_X3A_X2F_X2Ftasmota_X2Egithub_X2Eio_X2Fdocs_X2FMatter_X2F_X27_X20target_X3D_X27_blank_X27_X3EMatter_X20documentation_X3C_X2Fa_X3E_X2E_X3C_X2Fp_X3E),
-    /* K12  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X20onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E),
-    /* K13  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27_X25s_X27_X20class_X3D_X27button_X20bgrn_X27_X3E),
-    /* K14  */  be_nested_str_weak(disable),
-    /* K15  */  be_nested_str_weak(enable),
-    /* K16  */  be_nested_str_weak(Disable),
-    /* K17  */  be_nested_str_weak(Enable),
-    /* K18  */  be_nested_str_weak(_X20Matter_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
-    /* K19  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    }),
-    be_str_weak(show_enable),
-    &be_const_str_solidified,
-    ( &(const binstruction[44]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xB8120400,  //  0002  GETNGBL	R4	K2
-      0x8C100903,  //  0003  GETMET	R4	R4	K3
-      0xB81A0800,  //  0004  GETNGBL	R6	K4
-      0x88180D05,  //  0005  GETMBR	R6	R6	K5
-      0x7C100400,  //  0006  CALL	R4	2
-      0x8C140506,  //  0007  GETMET	R5	R2	K6
-      0x8C1C0707,  //  0008  GETMET	R7	R3	K7
-      0x58240008,  //  0009  LDCONST	R9	K8
-      0x78120001,  //  000A  JMPF	R4	#000D
-      0x58280009,  //  000B  LDCONST	R10	K9
-      0x70020000,  //  000C  JMP		#000E
-      0x5828000A,  //  000D  LDCONST	R10	K10
-      0x7C1C0600,  //  000E  CALL	R7	3
-      0x7C140400,  //  000F  CALL	R5	2
-      0x8C140506,  //  0010  GETMET	R5	R2	K6
-      0x581C000B,  //  0011  LDCONST	R7	K11
-      0x7C140400,  //  0012  CALL	R5	2
-      0x8C140506,  //  0013  GETMET	R5	R2	K6
-      0x581C000C,  //  0014  LDCONST	R7	K12
-      0x7C140400,  //  0015  CALL	R5	2
-      0x8C140506,  //  0016  GETMET	R5	R2	K6
-      0x8C1C0707,  //  0017  GETMET	R7	R3	K7
-      0x5824000D,  //  0018  LDCONST	R9	K13
-      0x78120001,  //  0019  JMPF	R4	#001C
-      0x5828000E,  //  001A  LDCONST	R10	K14
-      0x70020000,  //  001B  JMP		#001D
-      0x5828000F,  //  001C  LDCONST	R10	K15
-      0x7C1C0600,  //  001D  CALL	R7	3
-      0x7C140400,  //  001E  CALL	R5	2
-      0x8C140506,  //  001F  GETMET	R5	R2	K6
-      0x78120001,  //  0020  JMPF	R4	#0023
-      0x581C0010,  //  0021  LDCONST	R7	K16
-      0x70020000,  //  0022  JMP		#0024
-      0x581C0011,  //  0023  LDCONST	R7	K17
-      0x7C140400,  //  0024  CALL	R5	2
-      0x8C140506,  //  0025  GETMET	R5	R2	K6
-      0x581C0012,  //  0026  LDCONST	R7	K18
-      0x7C140400,  //  0027  CALL	R5	2
-      0x8C140506,  //  0028  GETMET	R5	R2	K6
-      0x581C0013,  //  0029  LDCONST	R7	K19
-      0x7C140400,  //  002A  CALL	R5	2
-      0x80040800,  //  002B  RET	1	R4
+      0x7C180400,  //  014D  CALL	R6	2
+      0x8C180345,  //  014E  GETMET	R6	R1	K69
+      0x88200346,  //  014F  GETMBR	R8	R1	K70
+      0x7C180400,  //  0150  CALL	R6	2
+      0x8C180347,  //  0151  GETMET	R6	R1	K71
+      0x7C180200,  //  0152  CALL	R6	1
+      0xA8040001,  //  0153  EXBLK	1	1
+      0x7002001D,  //  0154  JMP		#0173
+      0xAC180002,  //  0155  CATCH	R6	0	2
+      0x7002001A,  //  0156  JMP		#0172
+      0xB8221000,  //  0157  GETNGBL	R8	K8
+      0x8C201109,  //  0158  GETMET	R8	R8	K9
+      0x8C28050A,  //  0159  GETMET	R10	R2	K10
+      0x58300048,  //  015A  LDCONST	R12	K72
+      0x5C340C00,  //  015B  MOVE	R13	R6
+      0x5C380E00,  //  015C  MOVE	R14	R7
+      0x7C280800,  //  015D  CALL	R10	4
+      0x582C003A,  //  015E  LDCONST	R11	K58
+      0x7C200600,  //  015F  CALL	R8	3
+      0x8C20033F,  //  0160  GETMET	R8	R1	K63
+      0x58280040,  //  0161  LDCONST	R10	K64
+      0x7C200400,  //  0162  CALL	R8	2
+      0x8C200341,  //  0163  GETMET	R8	R1	K65
+      0x7C200200,  //  0164  CALL	R8	1
+      0x8C200342,  //  0165  GETMET	R8	R1	K66
+      0x8C28050A,  //  0166  GETMET	R10	R2	K10
+      0x58300049,  //  0167  LDCONST	R12	K73
+      0x5C340C00,  //  0168  MOVE	R13	R6
+      0x5C380E00,  //  0169  MOVE	R14	R7
+      0x7C280800,  //  016A  CALL	R10	4
+      0x7C200400,  //  016B  CALL	R8	2
+      0x8C200345,  //  016C  GETMET	R8	R1	K69
+      0x88280346,  //  016D  GETMBR	R10	R1	K70
+      0x7C200400,  //  016E  CALL	R8	2
+      0x8C200347,  //  016F  GETMET	R8	R1	K71
+      0x7C200200,  //  0170  CALL	R8	1
+      0x70020000,  //  0171  JMP		#0173
+      0xB0080000,  //  0172  RAISE	2	R0	R0
+      0x80000000,  //  0173  RET	0
     })
   )
 );
@@ -1284,6 +858,228 @@ be_local_closure(Matter_UI_web_get_arg,   /* name */
       0x8C080506,  //  000E  GETMET	R2	R2	K6
       0x7C080200,  //  000F  CALL	R2	1
       0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: show_plugins_configuration
+********************************************************************/
+be_local_closure(Matter_UI_show_plugins_configuration,   /* name */
+  be_nested_proto(
+    19,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[38]) {     /* constants */
+    /* K0   */  be_nested_str_weak(webserver),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BCurrent_X20Configuration_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K4   */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27),
+    /* K5   */  be_nested_str_weak(onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20RESET_X20the_X20configuration_X20to_X20the_X20default_X2E_X20You_X20will_X20need_X20to_X20associate_X20again_X2E_X22_X29_X3B_X27_X3E),
+    /* K6   */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27auto_X27_X20class_X3D_X27button_X20bred_X27_X3EReset_X20to_X20default_X3C_X2Fbutton_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Fform_X3E),
+    /* K7   */  be_nested_str_weak(onsubmit_X3D_X27return_X20confirm_X28_X22Changing_X20the_X20configuration_X20requires_X20to_X20associate_X20again_X2E_X22_X29_X3B_X27_X3E),
+    /* K8   */  be_nested_str_weak(_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
+    /* K9   */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X2735_X27_X3E_X3Cb_X3EEp_X2E_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3Ctd_X3E_X3Cb_X3EType_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3Ctd_X3E_X3Cb_X3EParam_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+    /* K10  */  be_nested_str_weak(device),
+    /* K11  */  be_nested_str_weak(k2l_num),
+    /* K12  */  be_nested_str_weak(plugins_config),
+    /* K13  */  be_const_int(0),
+    /* K14  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27ep000_X27_X20maxlength_X3D_X274_X27_X20size_X3D_X273_X27_X20value_X3D_X270_X27_X20readonly_X20disabled_X3E_X3C_X2Ftd_X3E),
+    /* K15  */  be_nested_str_weak(_X3Ctd_X3E_X3Cselect_X20name_X3D_X27pi000_X27_X3E),
+    /* K16  */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X27_X20selected_X20disabled_X3ERoot_X20node_X3C_X2Foption_X3E),
+    /* K17  */  be_nested_str_weak(_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E),
+    /* K18  */  be_nested_str_weak(_X3Ctd_X3E_X3Cfont_X20size_X3D_X27_X2D1_X27_X3E_X26nbsp_X3B_X3C_X2Ffont_X3E_X3C_X2Ftd_X3E),
+    /* K19  */  be_const_int(1),
+    /* K20  */  be_nested_str_weak(find),
+    /* K21  */  be_nested_str_weak(type),
+    /* K22  */  be_nested_str_weak(plugins_classes),
+    /* K23  */  be_nested_str_weak(),
+    /* K24  */  be_nested_str_weak(ui_conf_to_string),
+    /* K25  */  be_nested_str_weak(format),
+    /* K26  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27ep_X2503i_X27_X20maxlength_X3D_X274_X27_X20size_X3D_X273_X27_X20pattern_X3D_X27_X5B0_X2D9_X5D_X7B1_X2C4_X7D_X27_X20value_X3D_X27_X25i_X27_X3E_X3C_X2Ftd_X3E),
+    /* K27  */  be_nested_str_weak(_X3Ctd_X3E_X3Cselect_X20name_X3D_X27pi_X2503i_X27_X3E),
+    /* K28  */  be_nested_str_weak(plugin_option),
+    /* K29  */  be_nested_str_weak(_CLASSES_TYPES),
+    /* K30  */  be_nested_str_weak(_CLASSES_TYPES2),
+    /* K31  */  be_nested_str_weak(_X3Ctd_X3E_X3Cfont_X20size_X3D_X27_X2D1_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27arg_X2503i_X27_X20minlength_X3D_X270_X27_X20size_X3D_X278_X27_X20value_X3D_X27_X25s_X27_X3E_X3C_X2Ffont_X3E_X3C_X2Ftd_X3E),
+    /* K32  */  be_nested_str_weak(html_escape),
+    /* K33  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27ep_X2503i_X27_X20maxlength_X3D_X274_X27_X20size_X3D_X273_X27_X20pattern_X3D_X27_X5B0_X2D9_X5D_X7B1_X2C4_X7D_X27_X20value_X3D_X27_X27_X3E_X3C_X2Ftd_X3E),
+    /* K34  */  be_nested_str_weak(_X3Ctd_X3E_X3Cfont_X20size_X3D_X27_X2D1_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27arg_X2503i_X27_X20minlength_X3D_X270_X27_X20size_X3D_X278_X27_X20value_X3D_X27_X27_X3E_X3C_X2Ffont_X3E_X3C_X2Ftd_X3E),
+    /* K35  */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K36  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27config_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X20configuration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E),
+    /* K37  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    }),
+    be_str_weak(show_plugins_configuration),
+    &be_const_str_solidified,
+    ( &(const binstruction[160]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
+      0x58140003,  //  0003  LDCONST	R5	K3
+      0x7C0C0400,  //  0004  CALL	R3	2
+      0x8C0C0302,  //  0005  GETMET	R3	R1	K2
+      0x58140004,  //  0006  LDCONST	R5	K4
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x8C0C0302,  //  0008  GETMET	R3	R1	K2
+      0x58140005,  //  0009  LDCONST	R5	K5
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x8C0C0302,  //  000B  GETMET	R3	R1	K2
+      0x58140006,  //  000C  LDCONST	R5	K6
+      0x7C0C0400,  //  000D  CALL	R3	2
+      0x8C0C0302,  //  000E  GETMET	R3	R1	K2
+      0x58140004,  //  000F  LDCONST	R5	K4
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x8C0C0302,  //  0011  GETMET	R3	R1	K2
+      0x58140007,  //  0012  LDCONST	R5	K7
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x8C0C0302,  //  0014  GETMET	R3	R1	K2
+      0x58140008,  //  0015  LDCONST	R5	K8
+      0x7C0C0400,  //  0016  CALL	R3	2
+      0x8C0C0302,  //  0017  GETMET	R3	R1	K2
+      0x58140009,  //  0018  LDCONST	R5	K9
+      0x7C0C0400,  //  0019  CALL	R3	2
+      0x880C010A,  //  001A  GETMBR	R3	R0	K10
+      0x8C0C070B,  //  001B  GETMET	R3	R3	K11
+      0x8814010A,  //  001C  GETMBR	R5	R0	K10
+      0x88140B0C,  //  001D  GETMBR	R5	R5	K12
+      0x7C0C0400,  //  001E  CALL	R3	2
+      0x5810000D,  //  001F  LDCONST	R4	K13
+      0x8C140302,  //  0020  GETMET	R5	R1	K2
+      0x581C000E,  //  0021  LDCONST	R7	K14
+      0x7C140400,  //  0022  CALL	R5	2
+      0x8C140302,  //  0023  GETMET	R5	R1	K2
+      0x581C000F,  //  0024  LDCONST	R7	K15
+      0x7C140400,  //  0025  CALL	R5	2
+      0x8C140302,  //  0026  GETMET	R5	R1	K2
+      0x581C0010,  //  0027  LDCONST	R7	K16
+      0x7C140400,  //  0028  CALL	R5	2
+      0x8C140302,  //  0029  GETMET	R5	R1	K2
+      0x581C0011,  //  002A  LDCONST	R7	K17
+      0x7C140400,  //  002B  CALL	R5	2
+      0x8C140302,  //  002C  GETMET	R5	R1	K2
+      0x581C0012,  //  002D  LDCONST	R7	K18
+      0x7C140400,  //  002E  CALL	R5	2
+      0x6014000C,  //  002F  GETGBL	R5	G12
+      0x5C180600,  //  0030  MOVE	R6	R3
+      0x7C140200,  //  0031  CALL	R5	1
+      0x14140805,  //  0032  LT	R5	R4	R5
+      0x78160045,  //  0033  JMPF	R5	#007A
+      0x94140604,  //  0034  GETIDX	R5	R3	R4
+      0x1C180B0D,  //  0035  EQ	R6	R5	K13
+      0x781A0001,  //  0036  JMPF	R6	#0039
+      0x00100913,  //  0037  ADD	R4	R4	K19
+      0x7001FFF5,  //  0038  JMP		#002F
+      0x8818010A,  //  0039  GETMBR	R6	R0	K10
+      0x601C0008,  //  003A  GETGBL	R7	G8
+      0x5C200A00,  //  003B  MOVE	R8	R5
+      0x7C1C0200,  //  003C  CALL	R7	1
+      0x88180D0C,  //  003D  GETMBR	R6	R6	K12
+      0x94180C07,  //  003E  GETIDX	R6	R6	R7
+      0x8C200D14,  //  003F  GETMET	R8	R6	K20
+      0x58280015,  //  0040  LDCONST	R10	K21
+      0x7C200400,  //  0041  CALL	R8	2
+      0x5C1C1000,  //  0042  MOVE	R7	R8
+      0x5C200E00,  //  0043  MOVE	R8	R7
+      0x74220001,  //  0044  JMPT	R8	#0047
+      0x00100913,  //  0045  ADD	R4	R4	K19
+      0x7001FFE7,  //  0046  JMP		#002F
+      0x8820010A,  //  0047  GETMBR	R8	R0	K10
+      0x88201116,  //  0048  GETMBR	R8	R8	K22
+      0x8C201114,  //  0049  GETMET	R8	R8	K20
+      0x5C280E00,  //  004A  MOVE	R10	R7
+      0x7C200400,  //  004B  CALL	R8	2
+      0x58240017,  //  004C  LDCONST	R9	K23
+      0x4C280000,  //  004D  LDNIL	R10
+      0x2028100A,  //  004E  NE	R10	R8	R10
+      0x782A0004,  //  004F  JMPF	R10	#0055
+      0x8C281118,  //  0050  GETMET	R10	R8	K24
+      0x5C301000,  //  0051  MOVE	R12	R8
+      0x5C340C00,  //  0052  MOVE	R13	R6
+      0x7C280600,  //  0053  CALL	R10	3
+      0x5C241400,  //  0054  MOVE	R9	R10
+      0x8C280302,  //  0055  GETMET	R10	R1	K2
+      0x8C300519,  //  0056  GETMET	R12	R2	K25
+      0x5838001A,  //  0057  LDCONST	R14	K26
+      0x5C3C0800,  //  0058  MOVE	R15	R4
+      0x5C400A00,  //  0059  MOVE	R16	R5
+      0x7C300800,  //  005A  CALL	R12	4
+      0x7C280400,  //  005B  CALL	R10	2
+      0x8C280302,  //  005C  GETMET	R10	R1	K2
+      0x8C300519,  //  005D  GETMET	R12	R2	K25
+      0x5838001B,  //  005E  LDCONST	R14	K27
+      0x5C3C0800,  //  005F  MOVE	R15	R4
+      0x7C300600,  //  0060  CALL	R12	3
+      0x7C280400,  //  0061  CALL	R10	2
+      0x8C28011C,  //  0062  GETMET	R10	R0	K28
+      0x8C300D14,  //  0063  GETMET	R12	R6	K20
+      0x58380015,  //  0064  LDCONST	R14	K21
+      0x583C0017,  //  0065  LDCONST	R15	K23
+      0x7C300600,  //  0066  CALL	R12	3
+      0x8834011D,  //  0067  GETMBR	R13	R0	K29
+      0x8838011E,  //  0068  GETMBR	R14	R0	K30
+      0x7C280800,  //  0069  CALL	R10	4
+      0x8C280302,  //  006A  GETMET	R10	R1	K2
+      0x8C300519,  //  006B  GETMET	R12	R2	K25
+      0x58380011,  //  006C  LDCONST	R14	K17
+      0x7C300400,  //  006D  CALL	R12	2
+      0x7C280400,  //  006E  CALL	R10	2
+      0x8C280302,  //  006F  GETMET	R10	R1	K2
+      0x8C300519,  //  0070  GETMET	R12	R2	K25
+      0x5838001F,  //  0071  LDCONST	R14	K31
+      0x5C3C0800,  //  0072  MOVE	R15	R4
+      0x8C400320,  //  0073  GETMET	R16	R1	K32
+      0x5C481200,  //  0074  MOVE	R18	R9
+      0x7C400400,  //  0075  CALL	R16	2
+      0x7C300800,  //  0076  CALL	R12	4
+      0x7C280400,  //  0077  CALL	R10	2
+      0x00100913,  //  0078  ADD	R4	R4	K19
+      0x7001FFB4,  //  0079  JMP		#002F
+      0x8C140302,  //  007A  GETMET	R5	R1	K2
+      0x8C1C0519,  //  007B  GETMET	R7	R2	K25
+      0x58240021,  //  007C  LDCONST	R9	K33
+      0x5C280800,  //  007D  MOVE	R10	R4
+      0x7C1C0600,  //  007E  CALL	R7	3
+      0x7C140400,  //  007F  CALL	R5	2
+      0x8C140302,  //  0080  GETMET	R5	R1	K2
+      0x8C1C0519,  //  0081  GETMET	R7	R2	K25
+      0x5824001B,  //  0082  LDCONST	R9	K27
+      0x5C280800,  //  0083  MOVE	R10	R4
+      0x7C1C0600,  //  0084  CALL	R7	3
+      0x7C140400,  //  0085  CALL	R5	2
+      0x8C14011C,  //  0086  GETMET	R5	R0	K28
+      0x581C0017,  //  0087  LDCONST	R7	K23
+      0x8820011D,  //  0088  GETMBR	R8	R0	K29
+      0x8824011E,  //  0089  GETMBR	R9	R0	K30
+      0x7C140800,  //  008A  CALL	R5	4
+      0x8C140302,  //  008B  GETMET	R5	R1	K2
+      0x8C1C0519,  //  008C  GETMET	R7	R2	K25
+      0x58240011,  //  008D  LDCONST	R9	K17
+      0x7C1C0400,  //  008E  CALL	R7	2
+      0x7C140400,  //  008F  CALL	R5	2
+      0x8C140302,  //  0090  GETMET	R5	R1	K2
+      0x8C1C0519,  //  0091  GETMET	R7	R2	K25
+      0x58240022,  //  0092  LDCONST	R9	K34
+      0x5C280800,  //  0093  MOVE	R10	R4
+      0x7C1C0600,  //  0094  CALL	R7	3
+      0x7C140400,  //  0095  CALL	R5	2
+      0x8C140302,  //  0096  GETMET	R5	R1	K2
+      0x581C0023,  //  0097  LDCONST	R7	K35
+      0x7C140400,  //  0098  CALL	R5	2
+      0x8C140302,  //  0099  GETMET	R5	R1	K2
+      0x581C0024,  //  009A  LDCONST	R7	K36
+      0x7C140400,  //  009B  CALL	R5	2
+      0x8C140302,  //  009C  GETMET	R5	R1	K2
+      0x581C0025,  //  009D  LDCONST	R7	K37
+      0x7C140400,  //  009E  CALL	R5	2
+      0x80000000,  //  009F  RET	0
     })
   )
 );
@@ -1452,11 +1248,11 @@ be_local_closure(Matter_UI_web_sensor,   /* name */
 
 
 /********************************************************************
-** Solidified function: show_plugins_configuration
+** Solidified function: web_add_config_button
 ********************************************************************/
-be_local_closure(Matter_UI_show_plugins_configuration,   /* name */
+be_local_closure(Matter_UI_web_add_config_button,   /* name */
   be_nested_proto(
-    19,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1464,231 +1260,29 @@ be_local_closure(Matter_UI_show_plugins_configuration,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[37]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BCurrent_X20Configuration_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    /* K4   */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27),
-    /* K5   */  be_nested_str_weak(onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20RESET_X20the_X20configuration_X20to_X20the_X20default_X2E_X20You_X20will_X20need_X20to_X20associate_X20again_X2E_X22_X29_X3B_X27_X3E),
-    /* K6   */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27auto_X27_X20class_X3D_X27button_X20bred_X27_X3EReset_X20to_X20default_X3C_X2Fbutton_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Fform_X3E),
-    /* K7   */  be_nested_str_weak(onsubmit_X3D_X27return_X20confirm_X28_X22Changing_X20the_X20configuration_X20requires_X20to_X20associate_X20again_X2E_X22_X29_X3B_X27_X3E),
-    /* K8   */  be_nested_str_weak(_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
-    /* K9   */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X2735_X27_X3E_X3Cb_X3EEp_X2E_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3Ctd_X3E_X3Cb_X3EType_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3Ctd_X3E_X3Cb_X3EParam_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-    /* K10  */  be_nested_str_weak(device),
-    /* K11  */  be_nested_str_weak(k2l_num),
-    /* K12  */  be_nested_str_weak(plugins_config),
-    /* K13  */  be_const_int(0),
-    /* K14  */  be_nested_str_weak(find),
-    /* K15  */  be_nested_str_weak(type),
-    /* K16  */  be_nested_str_weak(format),
-    /* K17  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27ep_X2503i_X27_X20maxlength_X3D_X274_X27_X20size_X3D_X273_X27_X20value_X3D_X270_X27_X20readonly_X3E_X3C_X2Ftd_X3E),
-    /* K18  */  be_nested_str_weak(_X3Ctd_X3E_X3Cselect_X20name_X3D_X27pi_X2503i_X27_X3E),
-    /* K19  */  be_nested_str_weak(plugin_option),
-    /* K20  */  be_nested_str_weak(),
-    /* K21  */  be_nested_str_weak(_ROOT_TYPES),
-    /* K22  */  be_nested_str_weak(_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E),
-    /* K23  */  be_nested_str_weak(_X3Ctd_X3E_X3Cfont_X20size_X3D_X27_X2D1_X27_X3E_X26nbsp_X3B_X3C_X2Ffont_X3E_X3C_X2Ftd_X3E),
-    /* K24  */  be_const_int(1),
-    /* K25  */  be_nested_str_weak(plugins_classes),
-    /* K26  */  be_nested_str_weak(ui_conf_to_string),
-    /* K27  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27ep_X2503i_X27_X20maxlength_X3D_X274_X27_X20size_X3D_X273_X27_X20pattern_X3D_X27_X5B0_X2D9_X5D_X7B1_X2C4_X7D_X27_X20value_X3D_X27_X25i_X27_X3E_X3C_X2Ftd_X3E),
-    /* K28  */  be_nested_str_weak(_CLASSES_TYPES),
-    /* K29  */  be_nested_str_weak(_CLASSES_TYPES2),
-    /* K30  */  be_nested_str_weak(_X3Ctd_X3E_X3Cfont_X20size_X3D_X27_X2D1_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27arg_X2503i_X27_X20minlength_X3D_X270_X27_X20size_X3D_X278_X27_X20value_X3D_X27_X25s_X27_X3E_X3C_X2Ffont_X3E_X3C_X2Ftd_X3E),
-    /* K31  */  be_nested_str_weak(html_escape),
-    /* K32  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27ep_X2503i_X27_X20maxlength_X3D_X274_X27_X20size_X3D_X273_X27_X20pattern_X3D_X27_X5B0_X2D9_X5D_X7B1_X2C4_X7D_X27_X20value_X3D_X27_X27_X3E_X3C_X2Ftd_X3E),
-    /* K33  */  be_nested_str_weak(_X3Ctd_X3E_X3Cfont_X20size_X3D_X27_X2D1_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27arg_X2503i_X27_X20minlength_X3D_X270_X27_X20size_X3D_X278_X27_X20value_X3D_X27_X27_X3E_X3C_X2Ffont_X3E_X3C_X2Ftd_X3E),
-    /* K34  */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    /* K35  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27config_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X20configuration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E),
-    /* K36  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K1   */  be_nested_str_weak(content_send),
+    /* K2   */  be_nested_str_weak(_X3Cp_X3E_X3Cform_X20id_X3Dac_X20action_X3D_X27matterc_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X3E),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(_LOGO),
+    /* K5   */  be_nested_str_weak(_X20Configure_X20Matter_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
     }),
-    be_str_weak(show_plugins_configuration),
+    be_str_weak(web_add_config_button),
     &be_const_str_solidified,
-    ( &(const binstruction[183]) {  /* code */
+    ( &(const binstruction[12]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
-      0x58140003,  //  0003  LDCONST	R5	K3
-      0x7C0C0400,  //  0004  CALL	R3	2
-      0x8C0C0302,  //  0005  GETMET	R3	R1	K2
-      0x58140004,  //  0006  LDCONST	R5	K4
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x8C0C0302,  //  0008  GETMET	R3	R1	K2
-      0x58140005,  //  0009  LDCONST	R5	K5
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x8C0C0302,  //  000B  GETMET	R3	R1	K2
-      0x58140006,  //  000C  LDCONST	R5	K6
-      0x7C0C0400,  //  000D  CALL	R3	2
-      0x8C0C0302,  //  000E  GETMET	R3	R1	K2
-      0x58140004,  //  000F  LDCONST	R5	K4
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x8C0C0302,  //  0011  GETMET	R3	R1	K2
-      0x58140007,  //  0012  LDCONST	R5	K7
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x8C0C0302,  //  0014  GETMET	R3	R1	K2
-      0x58140008,  //  0015  LDCONST	R5	K8
-      0x7C0C0400,  //  0016  CALL	R3	2
-      0x8C0C0302,  //  0017  GETMET	R3	R1	K2
-      0x58140009,  //  0018  LDCONST	R5	K9
-      0x7C0C0400,  //  0019  CALL	R3	2
-      0x880C010A,  //  001A  GETMBR	R3	R0	K10
-      0x8C0C070B,  //  001B  GETMET	R3	R3	K11
-      0x8814010A,  //  001C  GETMBR	R5	R0	K10
-      0x88140B0C,  //  001D  GETMBR	R5	R5	K12
-      0x7C0C0400,  //  001E  CALL	R3	2
-      0x5810000D,  //  001F  LDCONST	R4	K13
-      0x9414070D,  //  0020  GETIDX	R5	R3	K13
-      0x1C140B0D,  //  0021  EQ	R5	R5	K13
-      0x78160026,  //  0022  JMPF	R5	#004A
-      0x94140604,  //  0023  GETIDX	R5	R3	R4
-      0x8818010A,  //  0024  GETMBR	R6	R0	K10
-      0x601C0008,  //  0025  GETGBL	R7	G8
-      0x5C200A00,  //  0026  MOVE	R8	R5
-      0x7C1C0200,  //  0027  CALL	R7	1
-      0x88180D0C,  //  0028  GETMBR	R6	R6	K12
-      0x94180C07,  //  0029  GETIDX	R6	R6	R7
-      0x8C200D0E,  //  002A  GETMET	R8	R6	K14
-      0x5828000F,  //  002B  LDCONST	R10	K15
-      0x7C200400,  //  002C  CALL	R8	2
-      0x5C1C1000,  //  002D  MOVE	R7	R8
-      0x8C200302,  //  002E  GETMET	R8	R1	K2
-      0x8C280510,  //  002F  GETMET	R10	R2	K16
-      0x58300011,  //  0030  LDCONST	R12	K17
-      0x5C340800,  //  0031  MOVE	R13	R4
-      0x7C280600,  //  0032  CALL	R10	3
-      0x7C200400,  //  0033  CALL	R8	2
-      0x8C200302,  //  0034  GETMET	R8	R1	K2
-      0x8C280510,  //  0035  GETMET	R10	R2	K16
-      0x58300012,  //  0036  LDCONST	R12	K18
-      0x5C340800,  //  0037  MOVE	R13	R4
-      0x7C280600,  //  0038  CALL	R10	3
-      0x7C200400,  //  0039  CALL	R8	2
-      0x8C200113,  //  003A  GETMET	R8	R0	K19
-      0x8C280D0E,  //  003B  GETMET	R10	R6	K14
-      0x5830000F,  //  003C  LDCONST	R12	K15
-      0x58340014,  //  003D  LDCONST	R13	K20
-      0x7C280600,  //  003E  CALL	R10	3
-      0x882C0115,  //  003F  GETMBR	R11	R0	K21
-      0x7C200600,  //  0040  CALL	R8	3
-      0x8C200302,  //  0041  GETMET	R8	R1	K2
-      0x8C280510,  //  0042  GETMET	R10	R2	K16
-      0x58300016,  //  0043  LDCONST	R12	K22
-      0x7C280400,  //  0044  CALL	R10	2
-      0x7C200400,  //  0045  CALL	R8	2
-      0x8C200302,  //  0046  GETMET	R8	R1	K2
-      0x58280017,  //  0047  LDCONST	R10	K23
-      0x7C200400,  //  0048  CALL	R8	2
-      0x00100918,  //  0049  ADD	R4	R4	K24
-      0x6014000C,  //  004A  GETGBL	R5	G12
-      0x5C180600,  //  004B  MOVE	R6	R3
-      0x7C140200,  //  004C  CALL	R5	1
-      0x14140805,  //  004D  LT	R5	R4	R5
-      0x78160041,  //  004E  JMPF	R5	#0091
-      0x94140604,  //  004F  GETIDX	R5	R3	R4
-      0x8818010A,  //  0050  GETMBR	R6	R0	K10
-      0x601C0008,  //  0051  GETGBL	R7	G8
-      0x5C200A00,  //  0052  MOVE	R8	R5
-      0x7C1C0200,  //  0053  CALL	R7	1
-      0x88180D0C,  //  0054  GETMBR	R6	R6	K12
-      0x94180C07,  //  0055  GETIDX	R6	R6	R7
-      0x8C200D0E,  //  0056  GETMET	R8	R6	K14
-      0x5828000F,  //  0057  LDCONST	R10	K15
-      0x7C200400,  //  0058  CALL	R8	2
-      0x5C1C1000,  //  0059  MOVE	R7	R8
-      0x5C200E00,  //  005A  MOVE	R8	R7
-      0x74220001,  //  005B  JMPT	R8	#005E
-      0x00100918,  //  005C  ADD	R4	R4	K24
-      0x7001FFEB,  //  005D  JMP		#004A
-      0x8820010A,  //  005E  GETMBR	R8	R0	K10
-      0x88201119,  //  005F  GETMBR	R8	R8	K25
-      0x8C20110E,  //  0060  GETMET	R8	R8	K14
-      0x5C280E00,  //  0061  MOVE	R10	R7
-      0x7C200400,  //  0062  CALL	R8	2
-      0x58240014,  //  0063  LDCONST	R9	K20
-      0x4C280000,  //  0064  LDNIL	R10
-      0x2028100A,  //  0065  NE	R10	R8	R10
-      0x782A0004,  //  0066  JMPF	R10	#006C
-      0x8C28111A,  //  0067  GETMET	R10	R8	K26
-      0x5C301000,  //  0068  MOVE	R12	R8
-      0x5C340C00,  //  0069  MOVE	R13	R6
-      0x7C280600,  //  006A  CALL	R10	3
-      0x5C241400,  //  006B  MOVE	R9	R10
-      0x8C280302,  //  006C  GETMET	R10	R1	K2
-      0x8C300510,  //  006D  GETMET	R12	R2	K16
-      0x5838001B,  //  006E  LDCONST	R14	K27
-      0x5C3C0800,  //  006F  MOVE	R15	R4
-      0x5C400A00,  //  0070  MOVE	R16	R5
-      0x7C300800,  //  0071  CALL	R12	4
-      0x7C280400,  //  0072  CALL	R10	2
-      0x8C280302,  //  0073  GETMET	R10	R1	K2
-      0x8C300510,  //  0074  GETMET	R12	R2	K16
-      0x58380012,  //  0075  LDCONST	R14	K18
-      0x5C3C0800,  //  0076  MOVE	R15	R4
-      0x7C300600,  //  0077  CALL	R12	3
-      0x7C280400,  //  0078  CALL	R10	2
-      0x8C280113,  //  0079  GETMET	R10	R0	K19
-      0x8C300D0E,  //  007A  GETMET	R12	R6	K14
-      0x5838000F,  //  007B  LDCONST	R14	K15
-      0x583C0014,  //  007C  LDCONST	R15	K20
-      0x7C300600,  //  007D  CALL	R12	3
-      0x8834011C,  //  007E  GETMBR	R13	R0	K28
-      0x8838011D,  //  007F  GETMBR	R14	R0	K29
-      0x7C280800,  //  0080  CALL	R10	4
-      0x8C280302,  //  0081  GETMET	R10	R1	K2
-      0x8C300510,  //  0082  GETMET	R12	R2	K16
-      0x58380016,  //  0083  LDCONST	R14	K22
-      0x7C300400,  //  0084  CALL	R12	2
-      0x7C280400,  //  0085  CALL	R10	2
-      0x8C280302,  //  0086  GETMET	R10	R1	K2
-      0x8C300510,  //  0087  GETMET	R12	R2	K16
-      0x5838001E,  //  0088  LDCONST	R14	K30
-      0x5C3C0800,  //  0089  MOVE	R15	R4
-      0x8C40031F,  //  008A  GETMET	R16	R1	K31
-      0x5C481200,  //  008B  MOVE	R18	R9
-      0x7C400400,  //  008C  CALL	R16	2
-      0x7C300800,  //  008D  CALL	R12	4
-      0x7C280400,  //  008E  CALL	R10	2
-      0x00100918,  //  008F  ADD	R4	R4	K24
-      0x7001FFB8,  //  0090  JMP		#004A
-      0x8C140302,  //  0091  GETMET	R5	R1	K2
-      0x8C1C0510,  //  0092  GETMET	R7	R2	K16
-      0x58240020,  //  0093  LDCONST	R9	K32
-      0x5C280800,  //  0094  MOVE	R10	R4
-      0x7C1C0600,  //  0095  CALL	R7	3
-      0x7C140400,  //  0096  CALL	R5	2
-      0x8C140302,  //  0097  GETMET	R5	R1	K2
-      0x8C1C0510,  //  0098  GETMET	R7	R2	K16
-      0x58240012,  //  0099  LDCONST	R9	K18
-      0x5C280800,  //  009A  MOVE	R10	R4
-      0x7C1C0600,  //  009B  CALL	R7	3
-      0x7C140400,  //  009C  CALL	R5	2
-      0x8C140113,  //  009D  GETMET	R5	R0	K19
-      0x581C0014,  //  009E  LDCONST	R7	K20
-      0x8820011C,  //  009F  GETMBR	R8	R0	K28
-      0x8824011D,  //  00A0  GETMBR	R9	R0	K29
-      0x7C140800,  //  00A1  CALL	R5	4
-      0x8C140302,  //  00A2  GETMET	R5	R1	K2
-      0x8C1C0510,  //  00A3  GETMET	R7	R2	K16
-      0x58240016,  //  00A4  LDCONST	R9	K22
-      0x7C1C0400,  //  00A5  CALL	R7	2
-      0x7C140400,  //  00A6  CALL	R5	2
-      0x8C140302,  //  00A7  GETMET	R5	R1	K2
-      0x8C1C0510,  //  00A8  GETMET	R7	R2	K16
-      0x58240021,  //  00A9  LDCONST	R9	K33
-      0x5C280800,  //  00AA  MOVE	R10	R4
-      0x7C1C0600,  //  00AB  CALL	R7	3
-      0x7C140400,  //  00AC  CALL	R5	2
-      0x8C140302,  //  00AD  GETMET	R5	R1	K2
-      0x581C0022,  //  00AE  LDCONST	R7	K34
-      0x7C140400,  //  00AF  CALL	R5	2
-      0x8C140302,  //  00B0  GETMET	R5	R1	K2
-      0x581C0023,  //  00B1  LDCONST	R7	K35
-      0x7C140400,  //  00B2  CALL	R5	2
-      0x8C140302,  //  00B3  GETMET	R5	R1	K2
-      0x581C0024,  //  00B4  LDCONST	R7	K36
-      0x7C140400,  //  00B5  CALL	R5	2
-      0x80000000,  //  00B6  RET	0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x7C080400,  //  0003  CALL	R2	2
+      0x8C080301,  //  0004  GETMET	R2	R1	K1
+      0xB8120600,  //  0005  GETNGBL	R4	K3
+      0x88100904,  //  0006  GETMBR	R4	R4	K4
+      0x7C080400,  //  0007  CALL	R2	2
+      0x8C080301,  //  0008  GETMET	R2	R1	K1
+      0x58100005,  //  0009  LDCONST	R4	K5
+      0x7C080400,  //  000A  CALL	R2	2
+      0x80000000,  //  000B  RET	0
     })
   )
 );
@@ -1696,12 +1290,110 @@ be_local_closure(Matter_UI_show_plugins_configuration,   /* name */
 
 
 /********************************************************************
-** Solidified function: show_commissioning_info
+** Solidified function: plugin_option
 ********************************************************************/
-be_local_closure(Matter_UI_show_commissioning_info,   /* name */
+be_local_closure(Matter_UI_plugin_option,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
-    1,                          /* argc */
+    17,                          /* nstack */
+    3,                          /* argc */
+    3,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[17]) {     /* constants */
+    /* K0   */  be_nested_str_weak(webserver),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(split),
+    /* K3   */  be_nested_str_weak(_X7C),
+    /* K4   */  be_nested_str_weak(stop_iteration),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(),
+    /* K7   */  be_nested_str_weak(content_send),
+    /* K8   */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X27_X3E_X3C_X2Foption_X3E),
+    /* K9   */  be_nested_str_weak(_X2Dhttp),
+    /* K10  */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X27_X20disabled_X3E_X2D_X2D_X2D_X20Tasmota_X20Remote_X20_X2D_X2D_X2D_X3C_X2Foption_X3E),
+    /* K11  */  be_nested_str_weak(device),
+    /* K12  */  be_nested_str_weak(get_plugin_class_displayname),
+    /* K13  */  be_nested_str_weak(format),
+    /* K14  */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X25s_X27_X25s_X3E_X25s_X3C_X2Foption_X3E),
+    /* K15  */  be_nested_str_weak(_X20selected),
+    /* K16  */  be_const_int(1),
+    }),
+    be_str_weak(plugin_option),
+    &be_const_str_solidified,
+    ( &(const binstruction[57]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xA4120200,  //  0001  IMPORT	R4	K1
+      0x60140012,  //  0002  GETGBL	R5	G18
+      0x7C140000,  //  0003  CALL	R5	0
+      0x60180010,  //  0004  GETGBL	R6	G16
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x7C180200,  //  0006  CALL	R6	1
+      0xA8020007,  //  0007  EXBLK	0	#0010
+      0x5C1C0C00,  //  0008  MOVE	R7	R6
+      0x7C1C0000,  //  0009  CALL	R7	0
+      0x8C200902,  //  000A  GETMET	R8	R4	K2
+      0x5C280E00,  //  000B  MOVE	R10	R7
+      0x582C0003,  //  000C  LDCONST	R11	K3
+      0x7C200600,  //  000D  CALL	R8	3
+      0x00140A08,  //  000E  ADD	R5	R5	R8
+      0x7001FFF7,  //  000F  JMP		#0008
+      0x58180004,  //  0010  LDCONST	R6	K4
+      0xAC180200,  //  0011  CATCH	R6	1	0
+      0xB0080000,  //  0012  RAISE	2	R0	R0
+      0x58180005,  //  0013  LDCONST	R6	K5
+      0x601C000C,  //  0014  GETGBL	R7	G12
+      0x5C200A00,  //  0015  MOVE	R8	R5
+      0x7C1C0200,  //  0016  CALL	R7	1
+      0x141C0C07,  //  0017  LT	R7	R6	R7
+      0x781E001E,  //  0018  JMPF	R7	#0038
+      0x941C0A06,  //  0019  GETIDX	R7	R5	R6
+      0x1C200F06,  //  001A  EQ	R8	R7	K6
+      0x78220003,  //  001B  JMPF	R8	#0020
+      0x8C200707,  //  001C  GETMET	R8	R3	K7
+      0x58280008,  //  001D  LDCONST	R10	K8
+      0x7C200400,  //  001E  CALL	R8	2
+      0x70020015,  //  001F  JMP		#0036
+      0x1C200F09,  //  0020  EQ	R8	R7	K9
+      0x78220003,  //  0021  JMPF	R8	#0026
+      0x8C200707,  //  0022  GETMET	R8	R3	K7
+      0x5828000A,  //  0023  LDCONST	R10	K10
+      0x7C200400,  //  0024  CALL	R8	2
+      0x7002000F,  //  0025  JMP		#0036
+      0x8820010B,  //  0026  GETMBR	R8	R0	K11
+      0x8C20110C,  //  0027  GETMET	R8	R8	K12
+      0x5C280E00,  //  0028  MOVE	R10	R7
+      0x7C200400,  //  0029  CALL	R8	2
+      0x8C240707,  //  002A  GETMET	R9	R3	K7
+      0x8C2C090D,  //  002B  GETMET	R11	R4	K13
+      0x5834000E,  //  002C  LDCONST	R13	K14
+      0x5C380E00,  //  002D  MOVE	R14	R7
+      0x1C3C0E01,  //  002E  EQ	R15	R7	R1
+      0x783E0001,  //  002F  JMPF	R15	#0032
+      0x583C000F,  //  0030  LDCONST	R15	K15
+      0x70020000,  //  0031  JMP		#0033
+      0x583C0006,  //  0032  LDCONST	R15	K6
+      0x5C401000,  //  0033  MOVE	R16	R8
+      0x7C2C0A00,  //  0034  CALL	R11	5
+      0x7C240400,  //  0035  CALL	R9	2
+      0x00180D10,  //  0036  ADD	R6	R6	K16
+      0x7001FFDB,  //  0037  JMP		#0014
+      0x80000000,  //  0038  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: show_enable
+********************************************************************/
+be_local_closure(Matter_UI_show_enable,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1711,94 +1403,72 @@ be_local_closure(Matter_UI_show_commissioning_info,   /* name */
     ( &(const bvalue[20]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(device),
-    /* K3   */  be_nested_str_weak(commissioning_open),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(millis),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(content_send),
-    /* K8   */  be_nested_str_weak(format),
-    /* K9   */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BCommissioning_X20open_X20for_X20_X25i_X20min_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    /* K10  */  be_nested_str_weak(compute_manual_pairing_code),
-    /* K11  */  be_nested_str_weak(_X3Cp_X3EManual_X20pairing_X20code_X3A_X3Cbr_X3E_X3Cb_X3E_X25s_X2D_X25s_X2D_X25s_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Chr_X3E),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_const_int(2147483647),
-    /* K14  */  be_nested_str_weak(_X3Cdiv_X3E_X3Ccenter_X3E),
-    /* K15  */  be_nested_str_weak(compute_qrcode_content),
-    /* K16  */  be_nested_str_weak(show_qrcode),
-    /* K17  */  be_nested_str_weak(_X3Cp_X3E_X20_X25s_X3C_X2Fp_X3E),
-    /* K18  */  be_nested_str_weak(_X3C_X2Fdiv_X3E),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(get_option),
+    /* K4   */  be_nested_str_weak(matter),
+    /* K5   */  be_nested_str_weak(MATTER_OPTION),
+    /* K6   */  be_nested_str_weak(content_send),
+    /* K7   */  be_nested_str_weak(format),
+    /* K8   */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20_X25s_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K9   */  be_nested_str_weak(Enabled),
+    /* K10  */  be_nested_str_weak(Disabled),
+    /* K11  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A320px_X3B_X27_X3ECheck_X20the_X20_X3Ca_X20href_X3D_X27https_X3A_X2F_X2Ftasmota_X2Egithub_X2Eio_X2Fdocs_X2FMatter_X2F_X27_X20target_X3D_X27_blank_X27_X3EMatter_X20documentation_X3C_X2Fa_X3E_X2E_X3C_X2Fp_X3E),
+    /* K12  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X20onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E),
+    /* K13  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27_X25s_X27_X20class_X3D_X27button_X20bgrn_X27_X3E),
+    /* K14  */  be_nested_str_weak(disable),
+    /* K15  */  be_nested_str_weak(enable),
+    /* K16  */  be_nested_str_weak(Disable),
+    /* K17  */  be_nested_str_weak(Enable),
+    /* K18  */  be_nested_str_weak(_X20Matter_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
     /* K19  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
     }),
-    be_str_weak(show_commissioning_info),
+    be_str_weak(show_enable),
     &be_const_str_solidified,
-    ( &(const binstruction[66]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
-      0xB8120800,  //  0004  GETNGBL	R4	K4
-      0x8C100905,  //  0005  GETMET	R4	R4	K5
-      0x7C100200,  //  0006  CALL	R4	1
-      0x040C0604,  //  0007  SUB	R3	R3	R4
-      0x541203E7,  //  0008  LDINT	R4	1000
-      0x0C0C0604,  //  0009  DIV	R3	R3	R4
-      0x14100706,  //  000A  LT	R4	R3	K6
-      0x78120000,  //  000B  JMPF	R4	#000D
-      0x580C0006,  //  000C  LDCONST	R3	K6
-      0x5412001D,  //  000D  LDINT	R4	30
-      0x00100604,  //  000E  ADD	R4	R3	R4
-      0x5416003B,  //  000F  LDINT	R5	60
-      0x0C100805,  //  0010  DIV	R4	R4	R5
-      0x8C140307,  //  0011  GETMET	R5	R1	K7
-      0x8C1C0508,  //  0012  GETMET	R7	R2	K8
-      0x58240009,  //  0013  LDCONST	R9	K9
-      0x5C280800,  //  0014  MOVE	R10	R4
-      0x7C1C0600,  //  0015  CALL	R7	3
-      0x7C140400,  //  0016  CALL	R5	2
-      0x88140102,  //  0017  GETMBR	R5	R0	K2
-      0x8C140B0A,  //  0018  GETMET	R5	R5	K10
-      0x7C140200,  //  0019  CALL	R5	1
-      0x8C180307,  //  001A  GETMET	R6	R1	K7
-      0x8C200508,  //  001B  GETMET	R8	R2	K8
-      0x5828000B,  //  001C  LDCONST	R10	K11
-      0x402E0D0C,  //  001D  CONNECT	R11	K6	K12
-      0x942C0A0B,  //  001E  GETIDX	R11	R5	R11
-      0x54320003,  //  001F  LDINT	R12	4
-      0x54360005,  //  0020  LDINT	R13	6
-      0x4030180D,  //  0021  CONNECT	R12	R12	R13
-      0x94300A0C,  //  0022  GETIDX	R12	R5	R12
-      0x54360006,  //  0023  LDINT	R13	7
-      0x40341B0D,  //  0024  CONNECT	R13	R13	K13
-      0x94340A0D,  //  0025  GETIDX	R13	R5	R13
-      0x7C200A00,  //  0026  CALL	R8	5
-      0x7C180400,  //  0027  CALL	R6	2
-      0x8C180307,  //  0028  GETMET	R6	R1	K7
-      0x8C200508,  //  0029  GETMET	R8	R2	K8
-      0x5828000E,  //  002A  LDCONST	R10	K14
-      0x7C200400,  //  002B  CALL	R8	2
-      0x7C180400,  //  002C  CALL	R6	2
-      0x88180102,  //  002D  GETMBR	R6	R0	K2
-      0x8C180D0F,  //  002E  GETMET	R6	R6	K15
-      0x7C180200,  //  002F  CALL	R6	1
-      0x8C1C0110,  //  0030  GETMET	R7	R0	K16
-      0x5C240C00,  //  0031  MOVE	R9	R6
-      0x7C1C0400,  //  0032  CALL	R7	2
-      0x8C1C0307,  //  0033  GETMET	R7	R1	K7
-      0x8C240508,  //  0034  GETMET	R9	R2	K8
-      0x582C0011,  //  0035  LDCONST	R11	K17
-      0x5C300C00,  //  0036  MOVE	R12	R6
-      0x7C240600,  //  0037  CALL	R9	3
-      0x7C1C0400,  //  0038  CALL	R7	2
-      0x8C1C0307,  //  0039  GETMET	R7	R1	K7
-      0x8C240508,  //  003A  GETMET	R9	R2	K8
-      0x582C0012,  //  003B  LDCONST	R11	K18
-      0x7C240400,  //  003C  CALL	R9	2
-      0x7C1C0400,  //  003D  CALL	R7	2
-      0x8C1C0307,  //  003E  GETMET	R7	R1	K7
-      0x58240013,  //  003F  LDCONST	R9	K19
-      0x7C1C0400,  //  0040  CALL	R7	2
-      0x80000000,  //  0041  RET	0
+    ( &(const binstruction[44]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xB8120400,  //  0002  GETNGBL	R4	K2
+      0x8C100903,  //  0003  GETMET	R4	R4	K3
+      0xB81A0800,  //  0004  GETNGBL	R6	K4
+      0x88180D05,  //  0005  GETMBR	R6	R6	K5
+      0x7C100400,  //  0006  CALL	R4	2
+      0x8C140506,  //  0007  GETMET	R5	R2	K6
+      0x8C1C0707,  //  0008  GETMET	R7	R3	K7
+      0x58240008,  //  0009  LDCONST	R9	K8
+      0x78120001,  //  000A  JMPF	R4	#000D
+      0x58280009,  //  000B  LDCONST	R10	K9
+      0x70020000,  //  000C  JMP		#000E
+      0x5828000A,  //  000D  LDCONST	R10	K10
+      0x7C1C0600,  //  000E  CALL	R7	3
+      0x7C140400,  //  000F  CALL	R5	2
+      0x8C140506,  //  0010  GETMET	R5	R2	K6
+      0x581C000B,  //  0011  LDCONST	R7	K11
+      0x7C140400,  //  0012  CALL	R5	2
+      0x8C140506,  //  0013  GETMET	R5	R2	K6
+      0x581C000C,  //  0014  LDCONST	R7	K12
+      0x7C140400,  //  0015  CALL	R5	2
+      0x8C140506,  //  0016  GETMET	R5	R2	K6
+      0x8C1C0707,  //  0017  GETMET	R7	R3	K7
+      0x5824000D,  //  0018  LDCONST	R9	K13
+      0x78120001,  //  0019  JMPF	R4	#001C
+      0x5828000E,  //  001A  LDCONST	R10	K14
+      0x70020000,  //  001B  JMP		#001D
+      0x5828000F,  //  001C  LDCONST	R10	K15
+      0x7C1C0600,  //  001D  CALL	R7	3
+      0x7C140400,  //  001E  CALL	R5	2
+      0x8C140506,  //  001F  GETMET	R5	R2	K6
+      0x78120001,  //  0020  JMPF	R4	#0023
+      0x581C0010,  //  0021  LDCONST	R7	K16
+      0x70020000,  //  0022  JMP		#0024
+      0x581C0011,  //  0023  LDCONST	R7	K17
+      0x7C140400,  //  0024  CALL	R5	2
+      0x8C140506,  //  0025  GETMET	R5	R2	K6
+      0x581C0012,  //  0026  LDCONST	R7	K18
+      0x7C140400,  //  0027  CALL	R5	2
+      0x8C140506,  //  0028  GETMET	R5	R2	K6
+      0x581C0013,  //  0029  LDCONST	R7	K19
+      0x7C140400,  //  002A  CALL	R5	2
+      0x80040800,  //  002B  RET	1	R4
     })
   )
 );
@@ -1962,32 +1632,392 @@ be_local_closure(Matter_UI_show_fabric_info,   /* name */
 
 
 /********************************************************************
+** Solidified function: web_add_handler
+********************************************************************/
+be_local_closure(Matter_UI_web_add_handler,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(page_part_mgr),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80040000,  //  0003  RET	1	R0
+        })
+      ),
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(page_part_ctl),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80040000,  //  0003  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(webserver),
+    /* K1   */  be_nested_str_weak(on),
+    /* K2   */  be_nested_str_weak(_X2Fmatterc),
+    /* K3   */  be_nested_str_weak(HTTP_GET),
+    /* K4   */  be_nested_str_weak(HTTP_POST),
+    }),
+    be_str_weak(web_add_handler),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x84140000,  //  0003  CLOSURE	R5	P0
+      0x88180303,  //  0004  GETMBR	R6	R1	K3
+      0x7C080800,  //  0005  CALL	R2	4
+      0x8C080301,  //  0006  GETMET	R2	R1	K1
+      0x58100002,  //  0007  LDCONST	R4	K2
+      0x84140001,  //  0008  CLOSURE	R5	P1
+      0x88180304,  //  0009  GETMBR	R6	R1	K4
+      0x7C080800,  //  000A  CALL	R2	4
+      0xA0000000,  //  000B  CLOSE	R0
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: show_passcode_form
+********************************************************************/
+be_local_closure(Matter_UI_show_passcode_form,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[26]) {     /* constants */
+    /* K0   */  be_nested_str_weak(webserver),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20Passcode_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K4   */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E),
+    /* K5   */  be_nested_str_weak(device),
+    /* K6   */  be_nested_str_weak(commissioning_open),
+    /* K7   */  be_nested_str_weak(format),
+    /* K8   */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27open_comm_X27_X20class_X3D_X27button_X20bgrn_X27_X3E_X25s_X3C_X2Fbutton_X3E),
+    /* K9   */  be_nested_str_weak(Open_X20Commissioning),
+    /* K10  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27clos_comm_X27_X20class_X3D_X27button_X20bgrn_X27_X3E_X25s_X3C_X2Fbutton_X3E),
+    /* K11  */  be_nested_str_weak(Close_X20Commissioning),
+    /* K12  */  be_nested_str_weak(_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
+    /* K13  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X20onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E),
+    /* K14  */  be_nested_str_weak(_X3Cp_X3EPasscode_X3A_X3C_X2Fp_X3E),
+    /* K15  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27number_X27_X20min_X3D_X271_X27_X20max_X3D_X2799999998_X27_X20name_X3D_X27passcode_X27_X20value_X3D_X27_X25i_X27_X3E),
+    /* K16  */  be_nested_str_weak(root_passcode),
+    /* K17  */  be_nested_str_weak(_X3Cp_X3EDistinguish_X20id_X3A_X3C_X2Fp_X3E),
+    /* K18  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27number_X27_X20min_X3D_X270_X27_X20max_X3D_X274095_X27_X20name_X3D_X27discriminator_X27_X20value_X3D_X27_X25i_X27_X3E),
+    /* K19  */  be_nested_str_weak(root_discriminator),
+    /* K20  */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20type_X3D_X27checkbox_X27_X20name_X3D_X27ipv4_X27_X25s_X3EIPv4_X20only_X3C_X2Fp_X3E),
+    /* K21  */  be_nested_str_weak(ipv4only),
+    /* K22  */  be_nested_str_weak(_X20checked),
+    /* K23  */  be_nested_str_weak(),
+    /* K24  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27passcode_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
+    /* K25  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    }),
+    be_str_weak(show_passcode_form),
+    &be_const_str_solidified,
+    ( &(const binstruction[70]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
+      0x58140003,  //  0003  LDCONST	R5	K3
+      0x7C0C0400,  //  0004  CALL	R3	2
+      0x8C0C0302,  //  0005  GETMET	R3	R1	K2
+      0x58140004,  //  0006  LDCONST	R5	K4
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x880C0105,  //  0008  GETMBR	R3	R0	K5
+      0x880C0706,  //  0009  GETMBR	R3	R3	K6
+      0x4C100000,  //  000A  LDNIL	R4
+      0x1C0C0604,  //  000B  EQ	R3	R3	R4
+      0x780E0006,  //  000C  JMPF	R3	#0014
+      0x8C0C0302,  //  000D  GETMET	R3	R1	K2
+      0x8C140507,  //  000E  GETMET	R5	R2	K7
+      0x581C0008,  //  000F  LDCONST	R7	K8
+      0x58200009,  //  0010  LDCONST	R8	K9
+      0x7C140600,  //  0011  CALL	R5	3
+      0x7C0C0400,  //  0012  CALL	R3	2
+      0x70020005,  //  0013  JMP		#001A
+      0x8C0C0302,  //  0014  GETMET	R3	R1	K2
+      0x8C140507,  //  0015  GETMET	R5	R2	K7
+      0x581C000A,  //  0016  LDCONST	R7	K10
+      0x5820000B,  //  0017  LDCONST	R8	K11
+      0x7C140600,  //  0018  CALL	R5	3
+      0x7C0C0400,  //  0019  CALL	R3	2
+      0x8C0C0302,  //  001A  GETMET	R3	R1	K2
+      0x5814000C,  //  001B  LDCONST	R5	K12
+      0x7C0C0400,  //  001C  CALL	R3	2
+      0x8C0C0302,  //  001D  GETMET	R3	R1	K2
+      0x5814000D,  //  001E  LDCONST	R5	K13
+      0x7C0C0400,  //  001F  CALL	R3	2
+      0x8C0C0302,  //  0020  GETMET	R3	R1	K2
+      0x5814000E,  //  0021  LDCONST	R5	K14
+      0x7C0C0400,  //  0022  CALL	R3	2
+      0x8C0C0302,  //  0023  GETMET	R3	R1	K2
+      0x8C140507,  //  0024  GETMET	R5	R2	K7
+      0x581C000F,  //  0025  LDCONST	R7	K15
+      0x88200105,  //  0026  GETMBR	R8	R0	K5
+      0x88201110,  //  0027  GETMBR	R8	R8	K16
+      0x7C140600,  //  0028  CALL	R5	3
+      0x7C0C0400,  //  0029  CALL	R3	2
+      0x8C0C0302,  //  002A  GETMET	R3	R1	K2
+      0x58140011,  //  002B  LDCONST	R5	K17
+      0x7C0C0400,  //  002C  CALL	R3	2
+      0x8C0C0302,  //  002D  GETMET	R3	R1	K2
+      0x8C140507,  //  002E  GETMET	R5	R2	K7
+      0x581C0012,  //  002F  LDCONST	R7	K18
+      0x88200105,  //  0030  GETMBR	R8	R0	K5
+      0x88201113,  //  0031  GETMBR	R8	R8	K19
+      0x7C140600,  //  0032  CALL	R5	3
+      0x7C0C0400,  //  0033  CALL	R3	2
+      0x8C0C0302,  //  0034  GETMET	R3	R1	K2
+      0x8C140507,  //  0035  GETMET	R5	R2	K7
+      0x581C0014,  //  0036  LDCONST	R7	K20
+      0x88200105,  //  0037  GETMBR	R8	R0	K5
+      0x88201115,  //  0038  GETMBR	R8	R8	K21
+      0x78220001,  //  0039  JMPF	R8	#003C
+      0x58200016,  //  003A  LDCONST	R8	K22
+      0x70020000,  //  003B  JMP		#003D
+      0x58200017,  //  003C  LDCONST	R8	K23
+      0x7C140600,  //  003D  CALL	R5	3
+      0x7C0C0400,  //  003E  CALL	R3	2
+      0x8C0C0302,  //  003F  GETMET	R3	R1	K2
+      0x58140018,  //  0040  LDCONST	R5	K24
+      0x7C0C0400,  //  0041  CALL	R3	2
+      0x8C0C0302,  //  0042  GETMET	R3	R1	K2
+      0x58140019,  //  0043  LDCONST	R5	K25
+      0x7C0C0400,  //  0044  CALL	R3	2
+      0x80000000,  //  0045  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: show_bridge_status
+********************************************************************/
+be_local_closure(Matter_UI_show_bridge_status,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[26]) {     /* constants */
+    /* K0   */  be_nested_str_weak(webserver),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(device),
+    /* K4   */  be_nested_str_weak(plugins),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(Plugin_Bridge_HTTP),
+    /* K7   */  be_nested_str_weak(http_remote),
+    /* K8   */  be_nested_str_weak(addr),
+    /* K9   */  be_nested_str_weak(contains),
+    /* K10  */  be_nested_str_weak(push),
+    /* K11  */  be_const_int(1),
+    /* K12  */  be_nested_str_weak(content_send),
+    /* K13  */  be_nested_str_weak(_X3Chr_X3E),
+    /* K14  */  be_nested_str_weak(_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
+    /* K15  */  be_nested_str_weak(_STYLESHEET),
+    /* K16  */  be_nested_str_weak(keys),
+    /* K17  */  be_nested_str_weak(format),
+    /* K18  */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27ztdm_X20htrm_X27_X3E_X3Ctd_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Ftd_X3E),
+    /* K19  */  be_nested_str_weak(html_escape),
+    /* K20  */  be_nested_str_weak(web_last_seen),
+    /* K21  */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27htrm_X27_X3E_X3Ctd_X20colspan_X3D_X272_X27_X3E),
+    /* K22  */  be_nested_str_weak(web_values),
+    /* K23  */  be_nested_str_weak(_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+    /* K24  */  be_nested_str_weak(stop_iteration),
+    /* K25  */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Chr_X3E),
+    }),
+    be_str_weak(show_bridge_status),
+    &be_const_str_solidified,
+    ( &(const binstruction[102]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x58100002,  //  0003  LDCONST	R4	K2
+      0x6014000C,  //  0004  GETGBL	R5	G12
+      0x88180103,  //  0005  GETMBR	R6	R0	K3
+      0x88180D04,  //  0006  GETMBR	R6	R6	K4
+      0x7C140200,  //  0007  CALL	R5	1
+      0x14140805,  //  0008  LT	R5	R4	R5
+      0x7816001D,  //  0009  JMPF	R5	#0028
+      0x88140103,  //  000A  GETMBR	R5	R0	K3
+      0x88140B04,  //  000B  GETMBR	R5	R5	K4
+      0x94140A04,  //  000C  GETIDX	R5	R5	R4
+      0x6018000F,  //  000D  GETGBL	R6	G15
+      0x5C1C0A00,  //  000E  MOVE	R7	R5
+      0xB8220A00,  //  000F  GETNGBL	R8	K5
+      0x88201106,  //  0010  GETMBR	R8	R8	K6
+      0x7C180400,  //  0011  CALL	R6	2
+      0x781A0012,  //  0012  JMPF	R6	#0026
+      0x4C180000,  //  0013  LDNIL	R6
+      0x1C180606,  //  0014  EQ	R6	R3	R6
+      0x781A0002,  //  0015  JMPF	R6	#0019
+      0x60180013,  //  0016  GETGBL	R6	G19
+      0x7C180000,  //  0017  CALL	R6	0
+      0x5C0C0C00,  //  0018  MOVE	R3	R6
+      0x88180B07,  //  0019  GETMBR	R6	R5	K7
+      0x88180D08,  //  001A  GETMBR	R6	R6	K8
+      0x8C1C0709,  //  001B  GETMET	R7	R3	K9
+      0x5C240C00,  //  001C  MOVE	R9	R6
+      0x7C1C0400,  //  001D  CALL	R7	2
+      0x741E0002,  //  001E  JMPT	R7	#0022
+      0x601C0012,  //  001F  GETGBL	R7	G18
+      0x7C1C0000,  //  0020  CALL	R7	0
+      0x980C0C07,  //  0021  SETIDX	R3	R6	R7
+      0x941C0606,  //  0022  GETIDX	R7	R3	R6
+      0x8C1C0F0A,  //  0023  GETMET	R7	R7	K10
+      0x5C240A00,  //  0024  MOVE	R9	R5
+      0x7C1C0400,  //  0025  CALL	R7	2
+      0x0010090B,  //  0026  ADD	R4	R4	K11
+      0x7001FFDB,  //  0027  JMP		#0004
+      0x4C140000,  //  0028  LDNIL	R5
+      0x1C140605,  //  0029  EQ	R5	R3	R5
+      0x78160000,  //  002A  JMPF	R5	#002C
+      0x80000A00,  //  002B  RET	0
+      0x8C14030C,  //  002C  GETMET	R5	R1	K12
+      0x581C000D,  //  002D  LDCONST	R7	K13
+      0x7C140400,  //  002E  CALL	R5	2
+      0x8C14030C,  //  002F  GETMET	R5	R1	K12
+      0x581C000E,  //  0030  LDCONST	R7	K14
+      0x7C140400,  //  0031  CALL	R5	2
+      0x8C14030C,  //  0032  GETMET	R5	R1	K12
+      0xB81E0A00,  //  0033  GETNGBL	R7	K5
+      0x881C0F0F,  //  0034  GETMBR	R7	R7	K15
+      0x7C140400,  //  0035  CALL	R5	2
+      0x60140010,  //  0036  GETGBL	R5	G16
+      0x8C180710,  //  0037  GETMET	R6	R3	K16
+      0x7C180200,  //  0038  CALL	R6	1
+      0x7C140200,  //  0039  CALL	R5	1
+      0xA8020023,  //  003A  EXBLK	0	#005F
+      0x5C180A00,  //  003B  MOVE	R6	R5
+      0x7C180000,  //  003C  CALL	R6	0
+      0x8C1C030C,  //  003D  GETMET	R7	R1	K12
+      0x8C240511,  //  003E  GETMET	R9	R2	K17
+      0x582C0012,  //  003F  LDCONST	R11	K18
+      0x8C300313,  //  0040  GETMET	R12	R1	K19
+      0x5C380C00,  //  0041  MOVE	R14	R6
+      0x7C300400,  //  0042  CALL	R12	2
+      0x7C240600,  //  0043  CALL	R9	3
+      0x7C1C0400,  //  0044  CALL	R7	2
+      0x941C0606,  //  0045  GETIDX	R7	R3	R6
+      0x941C0F02,  //  0046  GETIDX	R7	R7	K2
+      0x881C0F07,  //  0047  GETMBR	R7	R7	K7
+      0x8C20030C,  //  0048  GETMET	R8	R1	K12
+      0x8C280F14,  //  0049  GETMET	R10	R7	K20
+      0x7C280200,  //  004A  CALL	R10	1
+      0x7C200400,  //  004B  CALL	R8	2
+      0x60200010,  //  004C  GETGBL	R8	G16
+      0x94240606,  //  004D  GETIDX	R9	R3	R6
+      0x7C200200,  //  004E  CALL	R8	1
+      0xA802000A,  //  004F  EXBLK	0	#005B
+      0x5C241000,  //  0050  MOVE	R9	R8
+      0x7C240000,  //  0051  CALL	R9	0
+      0x8C28030C,  //  0052  GETMET	R10	R1	K12
+      0x58300015,  //  0053  LDCONST	R12	K21
+      0x7C280400,  //  0054  CALL	R10	2
+      0x8C281316,  //  0055  GETMET	R10	R9	K22
+      0x7C280200,  //  0056  CALL	R10	1
+      0x8C28030C,  //  0057  GETMET	R10	R1	K12
+      0x58300017,  //  0058  LDCONST	R12	K23
+      0x7C280400,  //  0059  CALL	R10	2
+      0x7001FFF4,  //  005A  JMP		#0050
+      0x58200018,  //  005B  LDCONST	R8	K24
+      0xAC200200,  //  005C  CATCH	R8	1	0
+      0xB0080000,  //  005D  RAISE	2	R0	R0
+      0x7001FFDB,  //  005E  JMP		#003B
+      0x58140018,  //  005F  LDCONST	R5	K24
+      0xAC140200,  //  0060  CATCH	R5	1	0
+      0xB0080000,  //  0061  RAISE	2	R0	R0
+      0x8C14030C,  //  0062  GETMET	R5	R1	K12
+      0x581C0019,  //  0063  LDCONST	R7	K25
+      0x7C140400,  //  0064  CALL	R5	2
+      0x80000000,  //  0065  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_UI
 ********************************************************************/
 be_local_class(Matter_UI,
     1,
     NULL,
-    be_nested_map(19,
+    be_nested_map(18,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(_CLASSES_TYPES, -1), be_nested_str_weak(_X7Crelay_X7Clight0_X7Clight1_X7Clight2_X7Clight3_X7Cshutter_X7Cshutter_X2Btilt_X7Ctemperature_X7Cpressure_X7Cilluminance_X7Chumidity_X7Coccupancy) },
-        { be_const_key_weak(device, -1), be_const_var(0) },
-        { be_const_key_weak(show_enable, -1), be_const_closure(Matter_UI_show_enable_closure) },
-        { be_const_key_weak(plugin_option, -1), be_const_closure(Matter_UI_plugin_option_closure) },
         { be_const_key_weak(show_bridge_status, -1), be_const_closure(Matter_UI_show_bridge_status_closure) },
-        { be_const_key_weak(show_qrcode, -1), be_const_closure(Matter_UI_show_qrcode_closure) },
-        { be_const_key_weak(web_get_arg, -1), be_const_closure(Matter_UI_web_get_arg_closure) },
-        { be_const_key_weak(show_plugins_configuration, 1), be_const_closure(Matter_UI_show_plugins_configuration_closure) },
-        { be_const_key_weak(web_sensor, -1), be_const_closure(Matter_UI_web_sensor_closure) },
-        { be_const_key_weak(show_passcode_form, 2), be_const_closure(Matter_UI_show_passcode_form_closure) },
-        { be_const_key_weak(web_add_handler, -1), be_const_closure(Matter_UI_web_add_handler_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_UI_init_closure) },
-        { be_const_key_weak(_ROOT_TYPES, 6), be_nested_str_weak(root) },
-        { be_const_key_weak(page_part_ctl, 11), be_const_closure(Matter_UI_page_part_ctl_closure) },
-        { be_const_key_weak(web_add_config_button, 8), be_const_closure(Matter_UI_web_add_config_button_closure) },
-        { be_const_key_weak(page_part_mgr, 7), be_const_closure(Matter_UI_page_part_mgr_closure) },
         { be_const_key_weak(show_commissioning_info, -1), be_const_closure(Matter_UI_show_commissioning_info_closure) },
-        { be_const_key_weak(_CLASSES_TYPES2, -1), be_nested_str_weak(_X2Dhttp_X7Chttp_relay_X7Chttp_light0_X7Chttp_light1_X7Chttp_light2_X7Chttp_light3_X7Chttp_temperature_X7Chttp_pressure_X7Chttp_illuminance_X7Chttp_humidity_X7Chttp_occupancy) },
+        { be_const_key_weak(show_passcode_form, 11), be_const_closure(Matter_UI_show_passcode_form_closure) },
+        { be_const_key_weak(device, -1), be_const_var(0) },
+        { be_const_key_weak(web_get_arg, -1), be_const_closure(Matter_UI_web_get_arg_closure) },
+        { be_const_key_weak(show_qrcode, 4), be_const_closure(Matter_UI_show_qrcode_closure) },
+        { be_const_key_weak(show_plugins_configuration, -1), be_const_closure(Matter_UI_show_plugins_configuration_closure) },
+        { be_const_key_weak(_CLASSES_TYPES, -1), be_nested_str_weak(_X7Crelay_X7Clight0_X7Clight1_X7Clight2_X7Clight3_X7Cshutter_X7Cshutter_X2Btilt_X7Ctemperature_X7Cpressure_X7Cilluminance_X7Chumidity_X7Coccupancy) },
+        { be_const_key_weak(web_sensor, -1), be_const_closure(Matter_UI_web_sensor_closure) },
+        { be_const_key_weak(web_add_config_button, -1), be_const_closure(Matter_UI_web_add_config_button_closure) },
+        { be_const_key_weak(_CLASSES_TYPES2, 7), be_nested_str_weak(_X2Dhttp_X7Chttp_relay_X7Chttp_light0_X7Chttp_light1_X7Chttp_light2_X7Chttp_light3_X7Chttp_temperature_X7Chttp_pressure_X7Chttp_illuminance_X7Chttp_humidity_X7Chttp_occupancy) },
+        { be_const_key_weak(plugin_option, -1), be_const_closure(Matter_UI_plugin_option_closure) },
+        { be_const_key_weak(show_enable, -1), be_const_closure(Matter_UI_show_enable_closure) },
         { be_const_key_weak(show_fabric_info, -1), be_const_closure(Matter_UI_show_fabric_info_closure) },
+        { be_const_key_weak(web_add_handler, -1), be_const_closure(Matter_UI_web_add_handler_closure) },
+        { be_const_key_weak(init, 3), be_const_closure(Matter_UI_init_closure) },
+        { be_const_key_weak(page_part_ctl, 2), be_const_closure(Matter_UI_page_part_ctl_closure) },
+        { be_const_key_weak(page_part_mgr, 0), be_const_closure(Matter_UI_page_part_mgr_closure) },
     })),
     be_str_weak(Matter_UI)
 );


### PR DESCRIPTION
## Description:

Changes:
- Tasmota is now always in Matter Bridge mode. This seems required by Apple, because they don't support hybrid local/bridge devices. Anyways this is probably a good approach because it will allow to dynamically change the configuration. This should not be a breaking change for already commissioned devices. It is not a problem for controller that do not support Bridge Mode, they just see endpoints as regular devices.
- Matter commisioning open/close button is added in the configuration page. This allows to re-open a commissioning when fabrics are already commissioned (in this case the button disappears from the main page)

Internal changes:
- Endpoint `0` is removed from the configuration file `_matter_device.json` since it's always present. It stills appears in the WebUI as non-editable
- Endpoint `0xFF00` is silently created as "aggregator". Controllers that do not support Bridge mode will ignore the Aggregator endpoint.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
