### PR TITLE
add I2S audio LSB flag

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio.ino
@@ -36,6 +36,7 @@
 //#define USE_I2S_NO_DAC                         // Add support for transistor-based output without DAC
 //#define USE_I2S_WEBRADIO                       // Add support for web radio
 //#define USE_I2S_SAY_TIME                       // Add support for english speaking clock
+//#define USE_I2S_RTTTL                          // Add support for Rtttl playback
 
 #include "AudioFileSourcePROGMEM.h"
 #include "AudioFileSourceID3.h"
@@ -251,6 +252,11 @@ int32_t I2S_Init_0(void) {
 #else
     audio_i2s.out = new AudioOutputI2S();
 #endif
+
+#ifdef USE_I2S_LSB
+    audio_i2s.lsbJustified = true;
+#endif // Allow supporting LSBJ chips, e.g. TM8211/PT8211
+
     audio_i2s.bclk = DAC_IIS_BCK;
     audio_i2s.ws = DAC_IIS_WS;
     audio_i2s.dout = DAC_IIS_DOUT;


### PR DESCRIPTION
## Description:

Add a compile time flag to change I2S audio DAC to LSB or Japanese format. This format is used with low cost DAC chips like PT8211 or TM8211 which can be found in [Sonoff TX Ultimate](https://templates.blakadder.com/sonoff_T5-1C-86.html) switch

compile time flag `USE_I2S_LSB` will change the DAC to LSB

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
