### PR TITLE
Update be_matter_vendors.h - Adding Nabu Casa vendor id

### DIFF
--- a/lib/libesp32/berry_matter/generate/be_matter_vendors.h
+++ b/lib/libesp32/berry_matter/generate/be_matter_vendors.h
@@ -51,6 +51,7 @@ const matter_vendor_t matter_Vendors[] = {
   { 0x133F, "ASR"},
   { 0x1342, "Beken Corporation"},
   { 0x1344, "Eltako"},
+  { 0x134B, "Nabu Casa"},
   { 0x1345, "Meross"},
   { 0x1346, "Rafael"},
   { 0x1349, "Apple Home"},

--- a/lib/libesp32/berry_matter/generate/be_matter_vendors.h
+++ b/lib/libesp32/berry_matter/generate/be_matter_vendors.h
@@ -51,7 +51,6 @@ const matter_vendor_t matter_Vendors[] = {
   { 0x133F, "ASR"},
   { 0x1342, "Beken Corporation"},
   { 0x1344, "Eltako"},
-  { 0x134B, "Nabu Casa"},
   { 0x1345, "Meross"},
   { 0x1346, "Rafael"},
   { 0x1349, "Apple Home"},
@@ -88,6 +87,8 @@ const matter_vendor_t matter_Vendors[] = {
   { 0x142D, "QH"},
   { 0x142F, "QIACHIP"},
   { 0x6006, "Google LLC"},
+  
+  { 0x134B, "Nabu Casa"},
 
   { 0xFFFF, NULL },
 };


### PR DESCRIPTION
## Description:

Adding Nabu Casa vendor id to display the name instead of the ID.

### Behavior before the change
![image](https://github.com/arendst/Tasmota/assets/938089/2d417d72-4d50-460b-b9ac-bac893268195)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
