### PR TITLE
Matter fix Illuminance for 0 lux

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Illuminance.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Illuminance.be
@@ -53,8 +53,11 @@ class Matter_Plugin_Bridge_Sensor_Illuminance : Matter_Plugin_Bridge_Sensor
     if val == nil   return nil    end
     import math
 
-    if val < 1  val = 1   end
-    return math.log10(val) * 10000 + 1
+    if val < 1
+      return 0
+    else
+      return math.log10(val) * 10000 + 1
+    end
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Illuminance.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Illuminance.be
@@ -43,8 +43,11 @@ class Matter_Plugin_Sensor_Illuminance : Matter_Plugin_Sensor
     if val == nil   return nil    end
     import math
 
-    if val < 1  val = 1   end
-    return math.log10(val) * 10000 + 1
+    if val < 1
+      return 0
+    else
+      return math.log10(val) * 10000 + 1
+    end
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Illuminance.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Illuminance.h
@@ -19,14 +19,15 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Illuminance_pre_value,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(math),
     /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(log10),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(log10),
     }),
     be_str_weak(pre_value),
     &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
+    ( &(const binstruction[18]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
       0x1C080202,  //  0001  EQ	R2	R1	R2
       0x780A0001,  //  0002  JMPF	R2	#0005
@@ -34,15 +35,17 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Illuminance_pre_value,   /* name */
       0x80040400,  //  0004  RET	1	R2
       0xA40A0000,  //  0005  IMPORT	R2	K0
       0x140C0301,  //  0006  LT	R3	R1	K1
-      0x780E0000,  //  0007  JMPF	R3	#0009
-      0x58040001,  //  0008  LDCONST	R1	K1
-      0x8C0C0502,  //  0009  GETMET	R3	R2	K2
-      0x5C140200,  //  000A  MOVE	R5	R1
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x5412270F,  //  000C  LDINT	R4	10000
-      0x080C0604,  //  000D  MUL	R3	R3	R4
-      0x000C0701,  //  000E  ADD	R3	R3	K1
-      0x80040600,  //  000F  RET	1	R3
+      0x780E0001,  //  0007  JMPF	R3	#000A
+      0x80060400,  //  0008  RET	1	K2
+      0x70020006,  //  0009  JMP		#0011
+      0x8C0C0503,  //  000A  GETMET	R3	R2	K3
+      0x5C140200,  //  000B  MOVE	R5	R1
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x5412270F,  //  000D  LDINT	R4	10000
+      0x080C0604,  //  000E  MUL	R3	R3	R4
+      0x000C0701,  //  000F  ADD	R3	R3	K1
+      0x80040600,  //  0010  RET	1	R3
+      0x80000000,  //  0011  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Illuminance.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Illuminance.h
@@ -129,14 +129,15 @@ be_local_closure(Matter_Plugin_Sensor_Illuminance_pre_value,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(math),
     /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(log10),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(log10),
     }),
     be_str_weak(pre_value),
     &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
+    ( &(const binstruction[18]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
       0x1C080202,  //  0001  EQ	R2	R1	R2
       0x780A0001,  //  0002  JMPF	R2	#0005
@@ -144,15 +145,17 @@ be_local_closure(Matter_Plugin_Sensor_Illuminance_pre_value,   /* name */
       0x80040400,  //  0004  RET	1	R2
       0xA40A0000,  //  0005  IMPORT	R2	K0
       0x140C0301,  //  0006  LT	R3	R1	K1
-      0x780E0000,  //  0007  JMPF	R3	#0009
-      0x58040001,  //  0008  LDCONST	R1	K1
-      0x8C0C0502,  //  0009  GETMET	R3	R2	K2
-      0x5C140200,  //  000A  MOVE	R5	R1
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x5412270F,  //  000C  LDINT	R4	10000
-      0x080C0604,  //  000D  MUL	R3	R3	R4
-      0x000C0701,  //  000E  ADD	R3	R3	K1
-      0x80040600,  //  000F  RET	1	R3
+      0x780E0001,  //  0007  JMPF	R3	#000A
+      0x80060400,  //  0008  RET	1	K2
+      0x70020006,  //  0009  JMP		#0011
+      0x8C0C0503,  //  000A  GETMET	R3	R2	K3
+      0x5C140200,  //  000B  MOVE	R5	R1
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x5412270F,  //  000D  LDINT	R4	10000
+      0x080C0604,  //  000E  MUL	R3	R3	R4
+      0x000C0701,  //  000F  ADD	R3	R3	K1
+      0x80040600,  //  0010  RET	1	R3
+      0x80000000,  //  0011  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Matter: return `0` for low illuminance

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
