### PR TITLE
fix #18817 http response for status with retain

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -3051,9 +3051,6 @@ void HandleHttpCommand(void)
   String svalue = Webserver->arg(F("cmnd"));
   if (svalue.length() && (svalue.length() < MQTT_MAX_PACKET_SIZE)) {
     uint32_t curridx = TasmotaGlobal.log_buffer_pointer;
-    int offset = 3;
-    if (0 == strncasecmp((char*)svalue.c_str(), "status", 6) && Settings->flag5.mqtt_status_retain)
-      offset += 11;
     TasmotaGlobal.templog_level = LOG_LEVEL_INFO;
     ExecuteWebCommand((char*)svalue.c_str(), SRC_WEBCOMMAND);
     WSContentSend_P(PSTR("{"));
@@ -3066,8 +3063,9 @@ void HandleHttpCommand(void)
       char* JSON = (char*)memchr(line, '{', len);
       if (JSON) {  // Is it a JSON message (and not only [15:26:08 MQT: stat/wemos5/POWER = O])
         if (cflg) { WSContentSend_P(PSTR(",")); }
-        uint32_t JSONlen = len - (JSON - line) -offset;
-        WSContentSend(JSON +1, JSONlen);
+        uint32_t JSONlen = len - (JSON - line) -3;
+        for( ++JSON ; JSON[JSONlen] != '}' ; JSONlen-- );
+        WSContentSend(JSON, JSONlen);
         cflg = true;
       }
     }

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -3064,7 +3064,7 @@ void HandleHttpCommand(void)
       if (JSON) {  // Is it a JSON message (and not only [15:26:08 MQT: stat/wemos5/POWER = O])
         if (cflg) { WSContentSend_P(PSTR(",")); }
         uint32_t JSONlen = len - (JSON - line) -3;
-        for( ++JSON ; JSON[JSONlen] != '}' ; JSONlen-- );
+        for( ++JSON ; JSONlen && JSON[JSONlen] != '}' ; JSONlen-- );
         WSContentSend(JSON, JSONlen);
         cflg = true;
       }

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -3051,6 +3051,9 @@ void HandleHttpCommand(void)
   String svalue = Webserver->arg(F("cmnd"));
   if (svalue.length() && (svalue.length() < MQTT_MAX_PACKET_SIZE)) {
     uint32_t curridx = TasmotaGlobal.log_buffer_pointer;
+    int offset = 3;
+    if (0 == strncasecmp((char*)svalue.c_str(), "status", 6) && Settings->flag5.mqtt_status_retain)
+      offset += 11;
     TasmotaGlobal.templog_level = LOG_LEVEL_INFO;
     ExecuteWebCommand((char*)svalue.c_str(), SRC_WEBCOMMAND);
     WSContentSend_P(PSTR("{"));
@@ -3063,7 +3066,7 @@ void HandleHttpCommand(void)
       char* JSON = (char*)memchr(line, '{', len);
       if (JSON) {  // Is it a JSON message (and not only [15:26:08 MQT: stat/wemos5/POWER = O])
         if (cflg) { WSContentSend_P(PSTR(",")); }
-        uint32_t JSONlen = len - (JSON - line) -3;
+        uint32_t JSONlen = len - (JSON - line) -offset;
         WSContentSend(JSON +1, JSONlen);
         cflg = true;
       }


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #18817

Fixes the HTTP reponse for Status command when StatusRetain is ON

Edited : 2nd version -  Should work in every cases.
test against various variants of Status command as well as as other commands with both StatusRetain On and Off

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
