### PR TITLE
Enable more esp32 libs by default

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -132,9 +132,9 @@ lib_extra_dirs           = ${library.lib_extra_dirs}
 ; *** comment the following line if you dont use LVGL in a Tasmota32 build. Reduces compile time
                           lib/libesp32_lvgl
 ; *** comment the following line if you dont use ESP32 Audio in a Tasmota32 build. Reduces compile time
-;                          lib/libesp32_audio
+                          lib/libesp32_audio
 ; *** uncomment the following line if you use Bluetooth or Apple Homekit in a Tasmota32 build. Reduces compile time
-;                          lib/libesp32_div
+                          lib/libesp32_div
 ; *** uncomment the following line if you use Epaper driver epidy in your Tasmota32 build. Reduces compile time
 ;                          lib/libesp32_eink
 


### PR DESCRIPTION
## Description:

in most cases no more the need to add `lib_extra_dirs` to individual custom [env]
An existing `platformio override.ini` is NOT changed. The changes needs to be edited!
Thx @blakadder for pointing at

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
