### PR TITLE
Add support for INMP441 MEMS microphone

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio.ino
@@ -37,6 +37,18 @@
 //#define USE_I2S_WEBRADIO                       // Add support for web radio
 //#define USE_I2S_SAY_TIME                       // Add support for english speaking clock
 //#define USE_I2S_RTTTL                          // Add support for Rtttl playback
+//#define USE_LSB                                // Add support for LSBJ chips, e.g. TM8211/PT8211
+// Microphone support
+//#define USE_I2S_MIC                            // Add support for I2S microphone
+  //#define MIC_CHANNELS 1                       // 1 = mono (I2S_CHANNEL_FMT_ONLY_RIGHT), 2 = stereo (I2S_CHANNEL_FMT_RIGHT_LEFT)
+  //#define MICSRATE 32000                       // Set sample rate
+  //#define USE_INMP441                          // Add support for INMP441 MEMS microphone
+  //#define MIC_PDM                              // Set microphone as PDM (only on ESP32)
+//#define USE_SHINE                              // Use MP3 encoding (only on ESP32 with PSRAM)
+//#define MP3_MIC_STREAM                         // Add support for streaming microphone via http (only on ESP32 with PSRAM)
+  //#define MP3_STREAM_PORT 81                   // Choose MP3 stream port (default = 81)
+//#define I2S_BRIDGE                             // Add support for UDP PCM audio bridge
+  //#define I2S_BRIDGE_PORT    6970              // Set bridge port (default = 6970)
 
 #include "AudioFileSourcePROGMEM.h"
 #include "AudioFileSourceID3.h"

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_1_i2s_mp3mic.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_1_i2s_mp3mic.ino
@@ -21,7 +21,6 @@
 #ifdef ESP32
 #if ( (defined(USE_I2S_AUDIO) && defined(USE_I2S_MIC)) || defined(USE_M5STACK_CORE2) || defined(ESP32S3_BOX) )
 
-
 uint32_t SpeakerMic(uint8_t spkr) {
 esp_err_t err = ESP_OK;
 
@@ -76,16 +75,26 @@ esp_err_t err = ESP_OK;
       .bits_per_chan          = I2S_BITS_PER_CHAN_16BIT
   };
 
+  if (audio_i2s.mic_channels == 1) {
+    i2s_config.channel_format = I2S_CHANNEL_FMT_ONLY_RIGHT;
+  } else {
+    i2s_config.channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT;
+  }
 
 #ifdef USE_I2S_MIC
-  // mic select to GND
-    #ifdef MIC_PDM 
+  // Mic L/R to GND
+  #ifdef USE_INMP441
+    i2s_config.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX );
+    i2s_config.communication_format = I2S_COMM_FORMAT_I2S;
+    i2s_config.channel_format = I2S_CHANNEL_FMT_ONLY_LEFT;
+  #elif MIC_PDM
     i2s_config.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM);
-    #else
+  #else
     i2s_config.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_TX);
     i2s_config.communication_format = I2S_COMM_FORMAT_STAND_I2S;
-    #endif
+  #endif
 #endif
+
 
 #ifdef ESP32S3_BOX
   i2s_config.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_TX);
@@ -96,11 +105,6 @@ esp_err_t err = ESP_OK;
   i2s_config.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM);
 #endif
 
-  if (audio_i2s.mic_channels == 1) {
-    i2s_config.channel_format = I2S_CHANNEL_FMT_ONLY_RIGHT;
-  } else {
-    i2s_config.channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT;
-  }
 
   err += i2s_driver_install(audio_i2s.mic_port, &i2s_config, 0, NULL);
 


### PR DESCRIPTION
## Description:

Adds support for INMP441 MEMS microphone as `#define USE_INMP441` under `#define USE_I2S_MIC`. 

Tested on this commonly available board:
![](https://images.squarespace-cdn.com/content/v1/59b037304c0dbfb092fbe894/1606077846852-DFLTBN8QXTZOFF3ENOAY/INMP441_drawing.png?format=2500w)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
