### PR TITLE
better way to support LSBJ

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio.ino
@@ -265,10 +265,6 @@ int32_t I2S_Init_0(void) {
     audio_i2s.out = new AudioOutputI2S();
 #endif
 
-#ifdef USE_I2S_LSB
-    audio_i2s.lsbJustified = true;
-#endif // Allow supporting LSBJ chips, e.g. TM8211/PT8211
-
     audio_i2s.bclk = DAC_IIS_BCK;
     audio_i2s.ws = DAC_IIS_WS;
     audio_i2s.dout = DAC_IIS_DOUT;
@@ -339,6 +335,11 @@ int32_t I2S_Init_0(void) {
   if (audio_i2s.mic_port != 0) {
     AddLog(LOG_LEVEL_INFO, PSTR("Init audio I2S mic: port=%d, bclk=%d, ws=%d, din=%d"), audio_i2s.mic_port, audio_i2s.mic_bclk, audio_i2s.mic_ws, audio_i2s.mic_din);
   }
+
+#ifdef USE_I2S_LSB
+  audio_i2s.out->SetLsbJustified(true);
+#endif // Allow supporting LSBJ chips, e.g. TM8211/PT8211
+
 #else
 
 #ifdef USE_I2S_NO_DAC


### PR DESCRIPTION
## Description:

Proper way to support LSBJ with a function placed at init time

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
