### PR TITLE
Add wcclient.get_bytes() to Berry

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_webclient_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webclient_lib.c
@@ -30,6 +30,7 @@ extern int wc_getstring(bvm *vm);
 extern int wc_writefile(bvm *vm);
 extern int wc_writeflash(bvm *vm);
 extern int wc_getsize(bvm *vm);
+extern int wc_getbytes(bvm *vm);
 
 #include "be_fixed_be_class_webclient.h"
 
@@ -68,6 +69,7 @@ class be_class_webclient (scope: global, name: webclient) {
     write_file, func(wc_writefile)
     write_flash, func(wc_writeflash)
     get_size, func(wc_getsize)
+    get_bytes, func(wc_getbytes)
 }
 @const_object_info_end */
 


### PR DESCRIPTION
(cherry picked from commit 5903b21448a3f088b12bd47a04996ff84e467a3a)

## Description:

Add webclient.get_bytes() to Berry to allow binary files to be read from the web.

My first time modifying the Berry native code, so pls confirm I did it right?

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
