### PR TITLE
Add HybridControllerPhase to json payload

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
@@ -2048,6 +2048,7 @@ const char HTTP_THERMOSTAT_HL[]          PROGMEM = "{s}<hr>{m}<hr>{e}";
 #endif  // USE_WEBSERVER
 
 #define D_THERMOSTAT_JSON_NAME_CONTROL_METHOD "ControlMethod"
+#define D_THERMOSTAT_JSON_NAME_HYBRID_CONTROLLER_PHASE "HybridControllerPhase"
 #define D_THERMOSTAT_JSON_NAME_EMERGENCY_STATE "EmergencyState"
 
 void ThermostatShow(uint8_t ctr_output, bool json)
@@ -2058,7 +2059,8 @@ void ThermostatShow(uint8_t ctr_output, bool json)
     ResponseAppend_P(PSTR("%s\"%s\":%i"), "", D_CMND_THERMOSTATMODESET, Thermostat[ctr_output].status.thermostat_mode);
     ResponseAppend_P(PSTR("%s\"%s\":%2_f"), ",", D_CMND_TEMPTARGETSET, &f_target_temp);
     ResponseAppend_P(PSTR("%s\"%s\":%i"), ",", D_CMND_CTRDUTYCYCLEREAD, ThermostatGetDutyCycle(ctr_output));
-    ResponseAppend_P(PSTR("%s\"%s\":%i"), ",", D_THERMOSTAT_JSON_NAME_CONTROL_METHOD, Thermostat[ctr_output].status.controller_mode == CTR_HYBRID ? Thermostat[ctr_output].status.phase_hybrid_ctr : Thermostat[ctr_output].status.controller_mode);
+    ResponseAppend_P(PSTR("%s\"%s\":%i"), ",", D_THERMOSTAT_JSON_NAME_CONTROL_METHOD, Thermostat[ctr_output].status.controller_mode);
+    ResponseAppend_P(PSTR("%s\"%s\":%i"), ",", D_THERMOSTAT_JSON_NAME_HYBRID_CONTROLLER_PHASE, Thermostat[ctr_output].status.phase_hybrid_ctr);
     ResponseAppend_P(PSTR("%s\"%s\":%i"), ",", D_THERMOSTAT_JSON_NAME_EMERGENCY_STATE, Thermostat[ctr_output].diag.state_emergency == EMERGENCY_ON);
     ResponseJsonEnd();
     return;


### PR DESCRIPTION
## Description:

This PR adds `HybridControllerPhase` to the JSON payload.

Previously, `ControlMethod` was thought sufficient but actually this was confusing because in Hybrid mode the controller phase determines whether it is using a Ramp Up or PI controller.

Now, when `ControlMethod==0` we know it is in Hybrid mode and can test
- `HybridControllerPhase==0` for Ramp Up
- `HybridControllerPhase==1` for PI
- `HybridControllerPhase==2` for Autotune

Otherwise we use

- `ControlMethod==1` for PI
- `ControlMethod==2` for Ramp Up
- `ControlMethod==3` for Autotune

**Related issue (if applicable):** N/A

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
