### PR TITLE
Increase solidify buffer

### DIFF
--- a/lib/libesp32/berry/src/be_solidifylib.c
+++ b/lib/libesp32/berry/src/be_solidifylib.c
@@ -31,7 +31,7 @@ extern const bclass be_class_map;
     be_vector_count(&(vm)->gbldesc.builtin.vlist)
 
 #ifndef INST_BUF_SIZE
-#define INST_BUF_SIZE   288
+#define INST_BUF_SIZE   768
 #endif
 
 #define logfmt(...)                                     \


### PR DESCRIPTION
## Description:

Increase Berry solidify buffer to allow long strings

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
