### PR TITLE
Berry Allow comments in multi-line strings

### DIFF
--- a/lib/libesp32/berry/src/be_lexer.c
+++ b/lib/libesp32/berry/src/be_lexer.c
@@ -394,7 +394,9 @@ static int skip_delimiter(blexer *lexer) {
     int c = lgetc(lexer);
     int delimeter_present = 0;
     while (1) {
-        if (c == '\r' || c == '\n') {
+        if (c == '#') {
+            skip_comment(lexer);
+        } else if (c == '\r' || c == '\n') {
             skip_newline(lexer);
         } else if (c == ' ' || c == '\t' || c == '\f' || c ==  '\v') {
             next(lexer);

--- a/lib/libesp32/berry/tests/string.be
+++ b/lib/libesp32/berry/tests/string.be
@@ -88,3 +88,25 @@ assert(string.replace("hellollo", "aa", "xx") == "hellollo")
 assert(string.replace("hello", "ll", "") == "heo")
 assert(string.replace("hello", "", "xx") == "hello")
 assert(string.replace("hello", "", "") == "hello")
+
+# multi-line strings
+var s = "a" "b""c"
+assert(s == 'abc')
+
+s = 'a'"b"'''c'
+assert(s == 'abc')
+
+s = "a"
+'b'
+    ""
+    "c"
+assert(s == 'abc')
+
+s = "a" #- b -# "b"  #--# "c"
+assert(s == 'abc')
+
+s = "a"#
+    # "z"
+    "b"  # zz
+    "c"
+assert(s == 'abc')


### PR DESCRIPTION
## Description:

Berry apply from upstream https://github.com/berry-lang/berry/pull/341

Allow multi-line strings to have comments:

```berry
var s = "a"   # comment
        "b"  #- comment -# "c"

print(s)
#shows 'abc'
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
