### PR TITLE
Berry: add path.rmdir(path), path.mkdir(path)

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_path_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_path_tasmota_lib.c
@@ -18,7 +18,10 @@
 #include "be_sys.h"
 #include <time.h>
 
+// from be_port.c
 extern int m_path_listdir(bvm *vm);
+extern int m_path_mkdir(bvm *vm);
+extern int m_path_rmdir(bvm *vm);
 
 static int m_path_exists(bvm *vm)
 {
@@ -79,6 +82,8 @@ module path (scope: global, file: tasmota_path) {
     listdir, func(m_path_listdir)
     remove, func(m_path_remove)
     format, func(m_path_format)
+    mkdir, func(m_path_mkdir)
+    rmdir, func(m_path_rmdir)
 }
 @const_object_info_end */
 #include "be_fixed_tasmota_path.h"

--- a/lib/libesp32/berry_tasmota/src/be_port.cpp
+++ b/lib/libesp32/berry_tasmota/src/be_port.cpp
@@ -131,6 +131,36 @@ extern "C" {
 #endif // USE_UFILESYS
         be_return_nil(vm);
     }
+
+    static int _m_path_mkdir_rmdir(bvm *vm, int remove) {
+#ifdef USE_UFILESYS
+        const char *path = NULL;
+        if (be_top(vm) >= 1 && be_isstring(vm, 1)) {
+            path = be_tostring(vm, 1);
+            int res = 0;
+            if (path != nullptr) {
+                if (remove) 
+                    res = zip_ufsp.rmdir(path);
+                else
+                    res = zip_ufsp.mkdir(path);
+            }
+            be_pushbool(vm, res);
+        } else {
+            be_pushbool(vm, bfalse);
+        }
+        be_return(vm);
+#else // USE_UFILESYS
+        be_return_nil(vm);
+#endif // USE_UFILESYS
+    }
+
+    int m_path_mkdir(bvm *vm) {
+        return _m_path_mkdir_rmdir(vm, 0);
+    }
+    int m_path_rmdir(bvm *vm) {
+        return _m_path_mkdir_rmdir(vm, 1);
+    }
+
 }
 
 BERRY_API char* be_readstring(char *buffer, size_t size)
@@ -161,6 +191,7 @@ void* be_fopen(const char *filename, const char *modes)
     return nullptr;
     // return fopen(filename, modes);
 }
+
 #endif // USE_UFILESYS
 
 


### PR DESCRIPTION


## Description:
This is a very minimial change which allows the existing FS module mkdir and rmdir to be used via the tasmota path module in berry.
Use case is managing files on SD card, or organising berry modules in folders.

It's only applicable to Berry and hence ESP32 devices.

Berry test code:
```
import path

print(path.mkdir('/testdir'))
print(path.mkdir('/testdir/test'))
var f = open('/testdir/test/test.txt', 'w')
print(f)
f.write('test test')
f.close()

print(path.remove('/testdir/test/test.txt'))
print(path.rmdir('/testdir/test'))
print(path.rmdir('/testdir'))

print(path.listdir('/testdir/test'))

#will return false
print(path.rmdir('/testdir'))

```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
