### PR TITLE
Repair SHUTTER Shelly 2.5 with manual relay change on switches

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
@@ -1128,14 +1128,14 @@ void ShutterRelayChanged(void)
           case SHT_COUNTER:
           case SHT_PWM_VALUE:
           case SHT_PWM_TIME:
+            ShutterPowerOff(i);			 
           case SHT_TIME: {
-            ShutterPowerOff(i);
             // powerstate_local == 0 => direction=0, stop
             // powerstate_local == 1 => direction=1, target=Shutter[i].open_max
             // powerstate_local == 2 => direction=-1, target=0 // only happen on SHT_TIME
             // powerstate_local == 3 => direction=-1, target=0 // only happen if NOT SHT_TIME
             int8_t direction = (powerstate_local == 0) ? 0 : (powerstate_local == 1) ? 1 : -1;
-            int8_t target =    (powerstate_local == 1) ? Shutter[i].open_max : 0;
+            int32_t target =    (powerstate_local == 1) ? Shutter[i].open_max : 0;
 
             if (direction != 0) {
               ShutterStartInit(i, direction, target);

--- a/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
@@ -893,14 +893,14 @@ void ShutterRelayChanged(void)
           case SHT_COUNTER:
           case SHT_PWM_VALUE:
           case SHT_PWM_TIME:
+	     ShutterPowerOff(i);
           case SHT_TIME: {
-            ShutterPowerOff(i);
             // powerstate_local == 0 => direction=0, stop
             // powerstate_local == 1 => direction=1, target=Shutter[i].open_max
             // powerstate_local == 2 => direction=-1, target=0 // only happen on SHT_TIME
             // powerstate_local == 3 => direction=-1, target=0 // only happen if NOT SHT_TIME
             int8_t direction = (powerstate_local == 0) ? 0 : (powerstate_local == 1) ? 1 : -1;
-            int8_t target =    (powerstate_local == 1) ? Shutter[i].open_max : 0;
+            int32_t target =    (powerstate_local == 1) ? Shutter[i].open_max : 0;
 
             if (direction != 0) {
               ShutterStartInit(i, direction, target);


### PR DESCRIPTION
## Description:
#18841 fix SWITCH issue with manual relay change
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
