### PR TITLE
core 2.0.10 (IDF 4.4.5.20230614)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.9
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.10
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -42,7 +42,7 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
                               ${esp_defaults.extra_scripts}
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.06.02/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.06.04/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

replaces #18872 and includes the changes done there.
The Arduino libs are compiled with latest [Tasmota IDF 4.4 version](https://github.com/tasmota/esp-idf/tree/v4.4.5.20230614)

Latest IDF 4.4 fixes the lwip DHCP timeout bug when Ethernet and wifi used together.
The workaround (used with previous cores) using a older lwip build is not needed anymore.

Tasmota IDF code base is now nearly identic to official one. Only some small changes.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
