### PR TITLE
Zigbee fixed regression with SetOption101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Interaction of ``SetOption92``, ``VirtualCT``, and ``RGBWWTable`` (#18768)
 - Fixed HASPmota event when value is non-integer (fixes #18229)
 - Matter fix local Occupancy sensor
+- Zigbee fixed regression with SetOption101
 
 ### Removed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_6_0_commands.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_6_0_commands.ino
@@ -509,18 +509,10 @@ void convertClusterSpecific(class Z_attribute_list &attr_list, uint16_t cluster,
         break;
       }
     } else {  // general case
-      // do we send command with endpoint suffix
-      char command_suffix[4] = { 0x00 };  // empty string by default
-      // if SO101 and multiple endpoints, append endpoint number
-      if (Settings->flag4.zb_index_ep) {
-        if (zigbee_devices.getShortAddr(shortaddr).countEndpoints() > 0) {
-          snprintf_P(command_suffix, sizeof(command_suffix), PSTR("%d"), srcendpoint);
-        }
-      }
       if (0 == xyz.x_type) {
-        attr_list.addAttribute(command_name, command_suffix).setBool(true);
+        attr_list.addAttribute(command_name).setBool(true);
       } else if (0 == xyz.y_type) {
-        attr_list.addAttribute(command_name, command_suffix).setUInt(xyz.x);
+        attr_list.addAttribute(command_name).setUInt(xyz.x);
       } else {
         // multiple answers, create an array
         JsonGeneratorArray arr;
@@ -529,7 +521,7 @@ void convertClusterSpecific(class Z_attribute_list &attr_list, uint16_t cluster,
         if (xyz.z_type) {
           arr.add(xyz.z);
         }
-        attr_list.addAttribute(command_name, command_suffix).setStrRaw(arr.toString().c_str());
+        attr_list.addAttribute(command_name).setStrRaw(arr.toString().c_str());
       }
     }
   }


### PR DESCRIPTION
## Description:

Zigbee, fixed regression when `SetOption101 1` is enabled, suffix is duplicated:

```
21:54:17.118 MQT: stat/zbbridge/SETOPTION = {"SetOption101":"ON"}
21:54:20.464 MQT: tele/zbbridge/remote4b/ZbReceived = {"Device":"0xDC2E","Name":"remote4b","0006!FD":"00","LidlPower1":0,"Endpoint":1,"LinkQuality":45}
21:54:23.219 MQT: tele/zbbridge/remote4b/ZbReceived = {"Device":"0xDC2E","Name":"remote4b","0006!FD":"00","LidlPower22":0,"Endpoint":2,"LinkQuality":40}
21:54:26.316 MQT: tele/zbbridge/remote4b/ZbReceived = {"Device":"0xDC2E","Name":"remote4b","0006!FD":"00","LidlPower33":0,"Endpoint":3,"LinkQuality":48}
21:54:28.017 MQT: tele/zbbridge/remote4b/ZbReceived = {"Device":"0xDC2E","Name":"remote4b","0006!FD":"00","LidlPower44":0,"Endpoint":4,"LinkQuality":40}
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
