### PR TITLE
Berry fixed parser error with upvals in closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Fixed HASPmota event when value is non-integer (fixes #18229)
 - Matter fix local Occupancy sensor
 - Zigbee fixed regression with SetOption101
+- Berry fixed parser error with upvals in closures
 
 ### Removed
 

--- a/lib/libesp32/berry/src/be_parser.c
+++ b/lib/libesp32/berry/src/be_parser.c
@@ -964,9 +964,10 @@ static void suffix_alloc_reg(bparser *parser, bexpdesc *l)
     bbool is_suffix = l->type == ETINDEX || l->type == ETMEMBER;   /* is suffix */
     bbool is_suffix_reg = l->v.ss.tt == ETREG || l->v.ss.tt == ETLOCAL || l->v.ss.tt == ETGLOBAL || l->v.ss.tt == ETNGLOBAL;   /* if suffix, does it need a register */
     bbool is_global = l->type == ETGLOBAL || l->type == ETNGLOBAL;
+    bbool is_upval = l->type == ETUPVAL;
     /* in the suffix expression, if the object is a temporary
      * variable (l->v.ss.tt == ETREG), it needs to be cached. */
-    if (is_global || (is_suffix && is_suffix_reg)) {
+    if (is_global || is_upval || (is_suffix && is_suffix_reg)) {
         be_code_allocregs(finfo, 1);
     }
 }

--- a/lib/libesp32/berry/tests/closure.be
+++ b/lib/libesp32/berry/tests/closure.be
@@ -11,3 +11,6 @@ tick()
 assert(l[0]() == [1, 100])
 assert(l[1]() == [2, 100])
 assert(l[2]() == [3, 100])
+
+# the following failed to compile #344
+def test() var nv = 1 var f = def() nv += 2*1 print(nv) end end


### PR DESCRIPTION
## Description:

Fix Berry compiler error found by @sfromis in https://github.com/berry-lang/berry/issues/344

This is a rare case of wrong calculation of registers for upvals in closures.

I tested re-solidifying all Tasmota code, no changes.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
