### PR TITLE
Fix NeoPool NPFiltration switch result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Matter fix local Occupancy sensor
 - Zigbee fixed regression with SetOption101
 - Berry fixed parser error with upvals in closures
+- NeoPool fix NPFiltration switch result (#18871)
 
 ### Removed
 

--- a/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
@@ -2118,6 +2118,19 @@ void CmndNeopoolBit(void)
 }
 
 
+void CmndNeopoolFiltrationRes(uint16_t data)
+{
+  uint16_t speed = NeoPoolGetFiltrationSpeed();
+  if (speed) {
+    Response_P(PSTR("{\"%s\":\"%s\",\""  D_NEOPOOL_JSON_FILTRATION_SPEED  "\":\"%d\"}"),
+      XdrvMailbox.command,
+      GetStateText(data),
+      (speed < 3) ? speed : 3);
+  } else {
+    ResponseCmndStateText(data);
+  }
+}
+
 void CmndNeopoolFiltration(void)
 {
   uint16_t addr = MBF_PAR_FILT_MANUAL_STATE;
@@ -2165,6 +2178,8 @@ void CmndNeopoolFiltration(void)
         NeopoolResponseError();
         return;
       }
+      CmndNeopoolFiltrationRes(value[0]);
+      return;
     } else {
       NeopoolCmndError();
       return;
@@ -2174,15 +2189,7 @@ void CmndNeopoolFiltration(void)
     NeopoolResponseError();
     return;
   }
-  uint16_t speed = NeoPoolGetFiltrationSpeed();
-  if (speed) {
-    Response_P(PSTR("{\"%s\":\"%s\",\""  D_NEOPOOL_JSON_FILTRATION_SPEED  "\":\"%d\"}"),
-      XdrvMailbox.command,
-      GetStateText(data),
-      (speed < 3) ? speed : 3);
-  } else {
-    ResponseCmndStateText(data);
-  }
+  CmndNeopoolFiltrationRes(data);
 }
 
 


### PR DESCRIPTION
## Description:

Due to the slow processing on some devices NPFiltration with switch parameter now returns given parameter as result instead of the device register state. NPFiltration without switch parameter always returns the device register state.

**Related issue (if applicable):** fixes #18871

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
