### PR TITLE
Berry add global function `format` as a simpler syntax to `string.format`

### DIFF
--- a/lib/libesp32/berry/src/be_baselib.c
+++ b/lib/libesp32/berry/src/be_baselib.c
@@ -14,6 +14,7 @@
 #include "be_vector.h"
 #include "be_string.h"
 #include "be_map.h"
+#include "be_strlib.h"
 #include <string.h>
 
 #define READLINE_STEP       100
@@ -504,6 +505,7 @@ void be_load_baselib_next(bvm *vm)
 {
     be_regfunc(vm, "call", l_call);
     be_regfunc(vm, "bool", l_bool);
+    be_regfunc(vm, "format", be_str_format);
 }
 #else
 extern const bclass be_class_list;
@@ -537,6 +539,7 @@ vartab m_builtin (scope: local) {
     bytes, class(be_class_bytes)
     call, func(l_call)
     bool, func(l_bool)
+    format, func(be_str_format)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_m_builtin.h"

--- a/lib/libesp32/berry/src/be_strlib.c
+++ b/lib/libesp32/berry/src/be_strlib.c
@@ -599,7 +599,7 @@ static bbool convert_to_real(bvm *vm, int index, breal *val)
     return converted;
 }
 
-static int str_format(bvm *vm)
+int be_str_format(bvm *vm)
 {
     int top = be_top(vm);
     if (top > 0 && be_isstring(vm, 1)) {
@@ -940,7 +940,7 @@ static int str_escape(bvm *vm)
 
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(string) {
-    be_native_module_function("format", str_format),
+    be_native_module_function("format", be_str_format),
     be_native_module_function("count", str_count),
     be_native_module_function("split", str_split),
     be_native_module_function("find", str_find),
@@ -958,7 +958,7 @@ be_define_native_module(string, NULL);
 #else
 /* @const_object_info_begin
 module string (scope: global, depend: BE_USE_STRING_MODULE) {
-    format, func(str_format)
+    format, func(be_str_format)
     count, func(str_count)
     split, func(str_split)
     find, func(str_find)

--- a/lib/libesp32/berry/src/be_strlib.h
+++ b/lib/libesp32/berry/src/be_strlib.h
@@ -25,6 +25,7 @@ const char* be_splitpath(const char *path);
 const char* be_splitname(const char *path);
 const char* be_pushvfstr(bvm *vm, const char *format, va_list arg);
 bstring* be_strindex(bvm *vm, bstring *str, bvalue *idx);
+int be_str_format(bvm *vm);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description:

Berry: provide a global function `format()` as a simpler syntax for `import string [...] string.format()`. This remains backwards compatible.

As a side effect, performance should be slightly improved and code smaller.

Before:
```berry
def f(x)
    import string
    return string.format("x=%i", x)
end

# compiles to
  0000  IMPORT	R1	K0            # first lookup
  0001  GETMET	R2	R1	K1    # second lookup
  0002  LDCONST	R4	K2
  0003  MOVE	R5	R0
  0004  CALL	R2	3
  0005  RET	1	R2
```

After:
```berry
def f(x)
    return format("x=%i", x)
end

# compiles to
  0000  GETGBL	R1	G24            # no lookup, simple indexed access
  0001  LDCONST	R2	K0
  0002  MOVE	R3	R0
  0003  CALL	R1	2
  0004  RET	1	R1
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
