### PR TITLE
allow folders to be added to the filesystem

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -77,7 +77,10 @@ def esp32_build_filesystem(fs_size):
             else:
                 print("Failed to download: ",file)
             continue
-        shutil.copy(file, filesystem_dir)
+        if os.path.isdir(file):
+            shutil.copytree(file, filesystem_dir, dirs_exist_ok=True)
+        else:
+            shutil.copy(file, filesystem_dir)
     if not os.listdir(filesystem_dir):
         print("No files added -> will NOT create littlefs.bin and NOT overwrite fs partition!")
         return False


### PR DESCRIPTION
## Description:

Adding files to the filesystem in the build process did require adding single file paths line by line in the env: section.
Now it is possible to just add a directory like so:
```
custom_files_upload         = ${env:tasmota32_base.custom_files_upload}
                              /Users/user/Developer/_test/fs/
```  

There is no error catching and the idea is to prepare one folder with the contents of the filesystem, that will be flashed together with the firmware. This could be added later, but should not be necessary.

@Jason2866 Plz take a look.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
