### PR TITLE
Accelerate path.listdir()

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_port.cpp
+++ b/lib/libesp32/berry_tasmota/src/be_port.cpp
@@ -146,17 +146,19 @@ extern "C" {
                         // without this TAS fails to find stuff at boot...
                         File *dir = (File *)be_fopen(path, "r");
                         if (dir) {
+                            String fpath;
                             String fname;
                             switch (action){
                                 case MPATH_LISTDIR:
                                     dir->seekDir(0);
-                                    fname = dir->getNextFileName();
-                                    while (fname.length() != 0) {
+                                    fpath = dir->getNextFileName();
+                                    while (fpath.length() != 0) {
+                                        fname = fpath.substring(fpath.lastIndexOf("/") + 1);
                                         const char * fn = fname.c_str();
                                         be_pushstring(vm, fn);
                                         be_data_push(vm, -2);
                                         be_pop(vm, 1);
-                                        fname = dir->getNextFileName();
+                                        fpath = dir->getNextFileName();
                                     }
                                     break;
                                 case MPATH_ISDIR:

--- a/lib/libesp32/berry_tasmota/src/be_port.cpp
+++ b/lib/libesp32/berry_tasmota/src/be_port.cpp
@@ -140,27 +140,23 @@ extern "C" {
                         returnit = 1;
                     case MPATH_ISDIR:
                     case MPATH_MODIFIED: {
-                        // listdir and isdir both need to open the file.
+                        //isdir needs to open the file, listdir does not
 
                         // we use be_fopen because it pre-pends with '/'.
                         // without this TAS fails to find stuff at boot...
                         File *dir = (File *)be_fopen(path, "r");
                         if (dir) {
+                            String fname;
                             switch (action){
                                 case MPATH_LISTDIR:
-                                    // fill out the list object
-                                    dir->rewindDirectory();
-                                    while (1) {
-                                        File entry = dir->openNextFile();
-                                        if (!entry) {
-                                            break;
-                                        }
-                                        const char * fn = entry.name();
-                                        if (strcmp(fn, ".") && strcmp(fn, "..")) {
-                                            be_pushstring(vm, fn);
-                                            be_data_push(vm, -2);
-                                            be_pop(vm, 1);
-                                        }
+                                    dir->seekDir(0);
+                                    fname = dir->getNextFileName();
+                                    while (fname.length() != 0) {
+                                        const char * fn = fname.c_str();
+                                        be_pushstring(vm, fn);
+                                        be_data_push(vm, -2);
+                                        be_pop(vm, 1);
+                                        fname = dir->getNextFileName();
                                     }
                                     break;
                                 case MPATH_ISDIR:


### PR DESCRIPTION
## Description:

Related to https://github.com/arendst/Tasmota/pull/18906

@btsimonh I did not figure out the meaning of
```
                                        if (strcmp(fn, ".") && strcmp(fn, "..")) {
                                            be_pushstring(vm, fn);
                                            be_data_push(vm, -2);
                                            be_pop(vm, 1);
                                        }
```

Maybe the `ìf` is not needed with the newer API, maybe I have overlooked something.

Speed increase was by a factor of 7 for 200 files. List output in Berry was truncated and is another problem.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
