### PR TITLE
Matter remove superfluous `import.string`

### DIFF
--- a/lib/libesp32/berry/src/be_lexer.c
+++ b/lib/libesp32/berry/src/be_lexer.c
@@ -467,6 +467,14 @@ static void scan_f_string(blexer *lexer)
                 if ((i+1 < buf_unparsed_fstr.len) && (buf_unparsed_fstr.s[i+1] == '}')) { i++; }      /* if '}}' replace with '}' */
                 save_char(lexer, '}');
                 break;
+            case '\n':
+                save_char(lexer, '\\');
+                save_char(lexer, 'n');
+                break;
+            case '\r':
+                save_char(lexer, '\\');
+                save_char(lexer, 'r');
+                break;
             default:        /* copy any other character */
                 save_char(lexer, ch);
                 break;

--- a/lib/libesp32/berry_matter/generate/Matter_generate_c.be
+++ b/lib/libesp32/berry_matter/generate/Matter_generate_c.be
@@ -82,7 +82,7 @@ fprint("  const matter_command_t* commands;")
 fprint("} matter_cluster_t;")
 fprint()
 for cl:cl_ids
-  fprint(string.format("const matter_attribute_t matter_Attributes_%04X[] = {", cl))
+  fprint(f"const matter_attribute_t matter_Attributes_{cl:04X}[] = {")
   var attributes = c[cl_id_name[cl]]['attributes']
   var attr_id_name = {}
   for attr:attributes
@@ -94,13 +94,13 @@ for cl:cl_ids
     var reportable = attributes[attr_id].find('reportable', false)
     var writable = attributes[attr_id].find('writable', false)
     var flags = (writable ? 0x01 : 0x00) | (reportable ? 0x02 : 0x00)
-    fprint(string.format('  { 0x%04X, %i, 0x%02X, "%s" },', attr_id, 0, flags, attributes[attr_id]['attributeName']))
+    fprint(format('  { 0x%04X, %i, 0x%02X, "%s" },', attr_id, 0, flags, attributes[attr_id]['attributeName']))
   end
   fprint('  { 0xFFFF, 0, 0x00, NULL },')
   fprint("};")
   fprint()
   # commands
-  fprint(string.format("const matter_command_t matter_Commands_%04X[] = {", cl))
+  fprint(f"const matter_command_t matter_Commands_{cl:04X}[] = {")
   var commands = c[cl_id_name[cl]]['commands']
   var cmd_id_name = {}
   for cmd:commands
@@ -109,7 +109,7 @@ for cl:cl_ids
   var cmd_ids_local = k2l(cmd_id_name)
 
   for cmd_id:cmd_ids_local
-    fprint(string.format('  { 0x%04X, "%s" },', cmd_id, commands[cmd_id]['commandName']))
+    fprint(format('  { 0x%04X, "%s" },', cmd_id, commands[cmd_id]['commandName']))
   end
   fprint('  { 0xFFFF, NULL },')
   fprint("};")
@@ -118,7 +118,7 @@ end
 
 fprint("const matter_cluster_t matterAllClusters[] = {")
 for cl:cl_ids
-  fprint(string.format('  { 0x%04X, "%s", matter_Attributes_%04X, matter_Commands_%04X },', cl, cl_id_name[cl], cl, cl))
+  fprint(format('  { 0x%04X, "%s", matter_Attributes_%04X, matter_Commands_%04X },', cl, cl_id_name[cl], cl, cl))
 end
   fprint('  { 0xFFFF, NULL, NULL },')
 fprint("};")

--- a/lib/libesp32/berry_matter/solidify_all.be
+++ b/lib/libesp32/berry_matter/solidify_all.be
@@ -5,7 +5,7 @@
 import os
 import global
 import solidify
-import string
+import string as string2
 import re
 
 import sys
@@ -18,7 +18,7 @@ var globs = "path,ctypes_bytes_dyn,tasmota,ccronexpr,gpio,light,webclient,load,M
             "_lvgl,"
             "int64"
 
-for g:string.split(globs, ",")
+for g:string2.split(globs, ",")
   global.(g) = nil
 end
 
@@ -44,9 +44,9 @@ def parse_file(fname, prefix_out)
   var compiled = compile(src)
   compiled()      # run the compile code to instanciate the classes and modules
   # output solidified
-  var fname_h = string.split(fname, '.be')[0] + '.h'  # take whatever is before the first '.be'
+  var fname_h = string2.split(fname, '.be')[0] + '.h'  # take whatever is before the first '.be'
   var fout = open(prefix_out + "solidified_" + fname_h, "w")
-  fout.write(string.format("/* Solidification of %s */\n", fname_h))
+  fout.write(f"/* Solidification of {fname_h} */\n")
   fout.write("/********************************************************************\\\n")
   fout.write("* Generated code, don't edit                                         *\n")
   fout.write("\\********************************************************************/\n")
@@ -56,13 +56,13 @@ def parse_file(fname, prefix_out)
   # print(directives)
 
   for directive : directives
-    var object_list = string.split(directive[1], ',')
+    var object_list = string2.split(directive[1], ',')
     var object_name = object_list[0]
     var weak = (object_list.find('weak') != nil)          # do we solidify with weak strings?
     var o = global
     var cl_name = nil
     var obj_name = nil
-    for subname : string.split(object_name, '.')
+    for subname : string2.split(object_name, '.')
       o = o.(subname)
       cl_name = obj_name
       obj_name = subname

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Base38.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Base38.be
@@ -26,7 +26,6 @@ class Matter_Base38
   static def encode(raw)
     # encodes b38 (mutates `b`)
     def b38_enc(v, l)
-      import string
       var ENCODE = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-."
       var i = 0
       var ret = ""

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning.be
@@ -44,9 +44,8 @@ class Matter_Commisioning_Context
 
   #############################################################
   def add_session(local_session_id, initiator_session_id, i2r, r2i, ac)
-    import string
     # create session object
-    tasmota.log(string.format("MTR: add_session local_session_id=%i initiator_session_id=%i", local_session_id, initiator_session_id), 4)
+    tasmota.log(format("MTR: add_session local_session_id=%i initiator_session_id=%i", local_session_id, initiator_session_id), 4)
     
     var session = self.device.sessions.create_session(local_session_id, initiator_session_id)
     session.set_keys(i2r, r2i, ac)
@@ -75,8 +74,7 @@ class Matter_Commisioning_Context
     elif msg.opcode == 0x40
       return self.parse_StatusReport(msg)
     else
-      import string
-      tasmota.log(string.format("MTR: >????????? Unknown OpCode (secure channel) %02X", msg.opcode), 2)
+      tasmota.log(format("MTR: >????????? Unknown OpCode (secure channel) %02X", msg.opcode), 2)
       return false
     end
 
@@ -108,7 +106,6 @@ class Matter_Commisioning_Context
 
   def parse_PBKDFParamRequest(msg)
     import crypto
-    import string
     var session = msg.session
     # sanity checks
     if msg.opcode != 0x20 || msg.local_session_id != 0 || msg.protocol_id != 0
@@ -133,7 +130,7 @@ class Matter_Commisioning_Context
     # record the initiator_session_id
     session.__future_initiator_session_id = pbkdfparamreq.initiator_session_id
     session.__future_local_session_id = self.device.sessions.gen_local_session_id()
-    tasmota.log(string.format("MTR: New_Session(%6i) from '[%s]:%i'", session.__future_local_session_id, msg.remote_ip, msg.remote_port), 3)
+    tasmota.log(format("MTR: New_Session(%6i) from '[%s]:%i'", session.__future_local_session_id, msg.remote_ip, msg.remote_port), 3)
 
     # prepare response
     var pbkdfparamresp = matter.PBKDFParamResponse()
@@ -159,7 +156,6 @@ class Matter_Commisioning_Context
 
   def parse_Pake1(msg)
     import crypto
-    import string
 
     var session = msg.session
     # sanity checks
@@ -239,7 +235,7 @@ class Matter_Commisioning_Context
     var raw = resp.encode_frame(pake2_raw)
 
     # log the fact that a new commissioning is starting
-    tasmota.log(string.format("MTR: New Commissioning (PASE id=%i) from [%s]:%i", session.__future_local_session_id, session._ip, session._port))
+    tasmota.log(format("MTR: New Commissioning (PASE id=%i) from [%s]:%i", session.__future_local_session_id, session._ip, session._port))
 
     self.responder.send_response_frame(resp)
     return true
@@ -319,7 +315,6 @@ class Matter_Commisioning_Context
 
   def parse_Sigma1(msg)
     import crypto
-    import string
     var session = msg.session
     # sanity checks
     if msg.opcode != 0x30 || msg.local_session_id != 0 || msg.protocol_id != 0
@@ -329,13 +324,13 @@ class Matter_Commisioning_Context
       return false
     end
     var sigma1 = matter.Sigma1().parse(msg.raw, msg.app_payload_idx)
-    # tasmota.log(string.format("MTR: sigma1=%s", matter.inspect(sigma1)), 4)
+    # tasmota.log(format("MTR: sigma1=%s", matter.inspect(sigma1)), 4)
 
     session.__initiator_pub = sigma1.initiatorEphPubKey
 
     # find session
     var is_resumption = (sigma1.resumptionID != nil && sigma1.initiatorResumeMIC != nil)
-    # tasmota.log(string.format("MTR: is_resumption=%i", is_resumption ? 1 : 0), 4)
+    # tasmota.log(format("MTR: is_resumption=%i", is_resumption ? 1 : 0), 4)
     # TODO disable resumption until fixed
     is_resumption = false
 
@@ -343,7 +338,7 @@ class Matter_Commisioning_Context
     var session_resumption
     if is_resumption
       session_resumption = self.device.sessions.find_session_by_resumption_id(sigma1.resumptionID)
-      # tasmota.log(string.format("MTR: session_resumption found session=%s session_resumption=%s", matter.inspect(session), matter.inspect(session_resumption)), 4)
+      # tasmota.log(format("MTR: session_resumption found session=%s session_resumption=%s", matter.inspect(session), matter.inspect(session_resumption)), 4)
       if session_resumption == nil || session_resumption._fabric == nil
         is_resumption = false
       end
@@ -375,7 +370,7 @@ class Matter_Commisioning_Context
         session.set_mode_CASE()
         session.__future_initiator_session_id = sigma1.initiator_session_id    # update initiator_session_id
         session.__future_local_session_id = self.device.sessions.gen_local_session_id()
-        tasmota.log(string.format("MTR: New_Session(%6i) from '[%s]:%i'", session.__future_local_session_id, msg.remote_ip, msg.remote_port), 3)
+        tasmota.log(format("MTR: New_Session(%6i) from '[%s]:%i'", session.__future_local_session_id, msg.remote_ip, msg.remote_port), 3)
 
         # Generate and Send Sigma2_Resume
         session.shared_secret = session_resumption.shared_secret
@@ -463,7 +458,7 @@ class Matter_Commisioning_Context
   
       session.__future_initiator_session_id = sigma1.initiator_session_id    # update initiator_session_id
       session.__future_local_session_id = self.device.sessions.gen_local_session_id()
-      tasmota.log(string.format("MTR: New_Session(%6i) from '[%s]:%i'", session.__future_local_session_id, msg.remote_ip, msg.remote_port), 3)
+      tasmota.log(format("MTR: New_Session(%6i) from '[%s]:%i'", session.__future_local_session_id, msg.remote_ip, msg.remote_port), 3)
 
       # tasmota.log("MTR: fabric="+matter.inspect(session._fabric), 4)
       # tasmota.log("MTR: no_private_key="+session.get_pk().tohex(), 4)
@@ -543,7 +538,7 @@ class Matter_Commisioning_Context
       var raw = resp.encode_frame(sigma2_raw)
   
       # log the fact that a new connection is starting
-      tasmota.log(string.format("MTR: New Connection (CASE id=%i) from [%s]:%i", session.__future_local_session_id, session._ip, session._port))
+      tasmota.log(format("MTR: New Connection (CASE id=%i) from [%s]:%i", session.__future_local_session_id, session._ip, session._port))
       
       self.responder.send_response_frame(resp)
       return true

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Control_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Control_Message.be
@@ -45,8 +45,7 @@ class Matter_Control_Message
     elif msg.opcode == 0x01
       return self.parse_MsgCounterSyncRsp(msg)
     else
-      import string
-      tasmota.log(string.format("MTR: >????????? Unknown OpCode (control message) %02X", msg.opcode), 2)
+      tasmota.log(format("MTR: >????????? Unknown OpCode (control message) %02X", msg.opcode), 2)
       return false
     end
 
@@ -58,9 +57,8 @@ class Matter_Control_Message
   #
   # Not yet implemented
   def parse_MsgCounterSyncReq(msg)
-    import string
     var session = msg.session
-    tasmota.log(string.format("MTR: >MCSyncReq * Not implemented %s", msg.raw[msg.app_payload_idx..].tohex()), 2)
+    tasmota.log(format("MTR: >MCSyncReq * Not implemented %s", msg.raw[msg.app_payload_idx..].tohex()), 2)
     return false      # we don't explicitly ack the message
   end
 
@@ -69,9 +67,8 @@ class Matter_Control_Message
   #
   # Not yet implemented
   def parse_MsgCounterSyncRsp(msg)
-    import string
     var session = msg.session
-    tasmota.log(string.format("MTR: >MCSyncRsp * Not implemented %s", msg.raw[msg.app_payload_idx..].tohex()), 2)
+    tasmota.log(format("MTR: >MCSyncRsp * Not implemented %s", msg.raw[msg.app_payload_idx..].tohex()), 2)
     return false      # we don't explicitly ack the message
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Fabric.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Fabric.be
@@ -102,8 +102,7 @@ class Matter_Fabric : Matter_Expirable
     if name != nil
       return name
     else
-      import string
-      return string.format("0x%04X", vnd)
+      return f"0x{vnd:04X}"
     end
   end
 
@@ -184,9 +183,8 @@ class Matter_Fabric : Matter_Expirable
   # Provide the next counter value, and update the last know persisted if needed
   #
   def counter_group_data_snd_next()
-    import string
     var next = self._counter_group_data_snd_impl.next()
-    tasmota.log(string.format("MTR: .          Counter_group_data_snd=%i", next), 3)
+    tasmota.log(f"MTR: .          Counter_group_data_snd={next:i}", 3)
     if matter.Counter.is_greater(next, self.counter_group_data_snd)
       self.counter_group_data_snd = next + self._GROUP_SND_INCR
       if self.does_persist()
@@ -200,9 +198,8 @@ class Matter_Fabric : Matter_Expirable
   # Provide the next counter value, and update the last know persisted if needed
   #
   def counter_group_ctrl_snd_next()
-    import string
     var next = self._counter_group_ctrl_snd_impl.next()
-    tasmota.log(string.format("MTR: .          Counter_group_ctrl_snd=%i", next), 3)
+    tasmota.log(f"MTR: .          Counter_group_ctrl_snd={next:i}", 3)
     if matter.Counter.is_greater(next, self.counter_group_ctrl_snd)
       self.counter_group_ctrl_snd = next + self._GROUP_SND_INCR
       if self.does_persist()
@@ -216,15 +213,13 @@ class Matter_Fabric : Matter_Expirable
   #############################################################
   # Called before removal
   def log_new_fabric()
-    import string
-    tasmota.log(string.format("MTR: +Fabric    fab='%s' vendorid=%s", self.get_fabric_id().copy().reverse().tohex(), self.get_admin_vendor_name()), 3)
+    tasmota.log(format("MTR: +Fabric    fab='%s' vendorid=%s", self.get_fabric_id().copy().reverse().tohex(), self.get_admin_vendor_name()), 3)
   end
 
   #############################################################
   # Called before removal
   def before_remove()
-    import string
-    tasmota.log(string.format("MTR: -Fabric    fab='%s' (removed)", self.get_fabric_id().copy().reverse().tohex()), 3)
+    tasmota.log(format("MTR: -Fabric    fab='%s' (removed)", self.get_fabric_id().copy().reverse().tohex()), 3)
   end
 
   #############################################################
@@ -287,7 +282,6 @@ class Matter_Fabric : Matter_Expirable
   #############################################################
   def tojson()
     import json
-    import string
     import introspect
 
     self.persist_pre()
@@ -303,7 +297,7 @@ class Matter_Fabric : Matter_Expirable
       var v = introspect.get(self, k)
       if v == nil     continue end
       if  isinstance(v, bytes)      v = "$$" + v.tob64() end    # bytes
-      r.push(string.format("%s:%s", json.dump(str(k)), json.dump(v)))
+      r.push(format("%s:%s", json.dump(str(k)), json.dump(v)))
     end
 
     # add sessions

--- a/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_async.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_async.be
@@ -251,7 +251,7 @@ class Matter_HTTP_async : Matter_TCP_async
       addr = "[" + addr + "]"       # IPv6 must be enclosed in brakets
     end
 
-    var req = string.format(self.HTTP_GET, self.cmd, addr, self.port)
+    var req = format(self.HTTP_GET, self.cmd, addr, self.port)
     var ret = self.write(req)
     if ret != size(req)
       # print("Could not send","size=",size(req),"ret=",ret)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_remote.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_remote.be
@@ -123,7 +123,7 @@ class Matter_HTTP_remote : Matter_HTTP_async
 
     self.current_cmd = cmd
     var cmd_url = "/cm?cmnd=" + string.tr(cmd, ' ', '+')
-    tasmota.log(string.format("MTR: HTTP async request 'http://%s:%i%s'", self.addr, self.port, cmd_url), 3)
+    tasmota.log(format("MTR: HTTP async request 'http://%s:%i%s'", self.addr, self.port, cmd_url), 3)
     var ret = self.begin(cmd_url)
   end
 
@@ -142,20 +142,19 @@ class Matter_HTTP_remote : Matter_HTTP_async
 
     self.current_cmd = nil
     var cmd_url = "/cm?cmnd=" + string.tr(cmd, ' ', '+')
-    tasmota.log(string.format("MTR: HTTP sync request 'http://%s:%i%s'", self.addr, self.port, cmd_url), 3)
+    tasmota.log(format("MTR: HTTP sync request 'http://%s:%i%s'", self.addr, self.port, cmd_url), 3)
     var ret = super(self).begin_sync(cmd_url, timeout)
     var payload_short = (ret) ? ret : 'nil'
     if size(payload_short) > 30   payload_short = payload_short[0..29] + '...'   end
-    tasmota.log(string.format("MTR: HTTP sync-resp  in %i ms from %s: [%i] '%s'", tasmota.millis() - self.time_start, self.addr, size(self.payload), payload_short), 3)
+    tasmota.log(format("MTR: HTTP sync-resp  in %i ms from %s: [%i] '%s'", tasmota.millis() - self.time_start, self.addr, size(self.payload), payload_short), 3)
     return ret
   end
 
   def event_http_finished()
     if self.current_cmd == nil    return  end       # do nothing if sync request
-    import string
     var payload_short = (self.payload != nil) ? self.payload : 'nil'
     if size(payload_short) > 30   payload_short = payload_short[0..29] + '...'   end
-    tasmota.log(string.format("MTR: HTTP async-resp in %i ms from %s: [%i] '%s'", tasmota.millis() - self.time_start, self.addr, size(self.payload), payload_short), 3)
+    tasmota.log(format("MTR: HTTP async-resp in %i ms from %s: [%i] '%s'", tasmota.millis() - self.time_start, self.addr, size(self.payload), payload_short), 3)
     self.dispatch_cb(self.http_status, self.payload)
   end
   def event_http_failed()
@@ -164,9 +163,8 @@ class Matter_HTTP_remote : Matter_HTTP_async
     self.dispatch_cb(self.http_status, nil)
   end
   def event_http_timeout()
-    import string
     if self.current_cmd == nil    return  end       # do nothing if sync request
-    tasmota.log(string.format("MTR: HTTP timeout http_status=%i phase=%i tcp_status=%i size_payload=%i", self.http_status, self.phase, self.status, size(self.payload)), 3)
+    tasmota.log(format("MTR: HTTP timeout http_status=%i phase=%i tcp_status=%i size_payload=%i", self.http_status, self.phase, self.status, size(self.payload)), 3)
     self.dispatch_cb(self.http_status, nil)
   end
 
@@ -212,7 +210,6 @@ class Matter_HTTP_remote : Matter_HTTP_async
   # Show when the device was last seen
   def web_last_seen()
     import webserver
-    import string
 
     var seconds = -1                      # default if no known value
     if self.reachable_utc != nil

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
@@ -83,10 +83,9 @@ class Matter_IM
   #
   # return `true` if handled
   def process_incoming_ack(msg)
-    import string
     # check if there is an exchange_id interested in receiving this
     var message = self.find_sendqueue_by_exchangeid(msg.exchange_id)
-    # tasmota.log(string.format("MTR: process_incoming_ack exch=%i message=%i", msg.exchange_id, message != nil ? 1 : 0), 4)
+    # tasmota.log(format("MTR: process_incoming_ack exch=%i message=%i", msg.exchange_id, message != nil ? 1 : 0), 4)
     if message
       return message.ack_received(msg)                # dispatch to IM_Message
     end
@@ -179,18 +178,17 @@ class Matter_IM
   # or raises an exception
   # return true if we handled the response and ack, false instead
   def process_status_response(msg, val)
-    import string
     var status = val.findsubval(0, 0xFF)
     var message = self.find_sendqueue_by_exchangeid(msg.exchange_id)
     if status == matter.SUCCESS
       if message
         return message.status_ok_received(msg)         # re-arm the sending of next packets for the same exchange
       else
-        tasmota.log(string.format("MTR: >OK        (%6i) exch=%i not found", msg.session.local_session_id, msg.exchange_id), 3)      # don't show 'SUCCESS' to not overflow logs with non-information
+        tasmota.log(format("MTR: >OK        (%6i) exch=%i not found", msg.session.local_session_id, msg.exchange_id), 3)      # don't show 'SUCCESS' to not overflow logs with non-information
       end
     else
       # error
-      tasmota.log(string.format("MTR: >Status    ERROR = 0x%02X", status), 3)
+      tasmota.log(format("MTR: >Status    ERROR = 0x%02X", status), 3)
       if message
         message.status_error_received(msg)
         self.remove_sendqueue_by_exchangeid(msg.exchange_id)
@@ -204,7 +202,6 @@ class Matter_IM
   #
   # query: `ReadRequestMessage` or `SubscribeRequestMessage`
   def _inner_process_read_request(session, query, no_log)
-    import string
 
     ### Inner function to be iterated upon
     # ret is the ReportDataMessage list to send back
@@ -215,7 +212,6 @@ class Matter_IM
     #
     # should return true if answered, false if passing to next handler
     def read_single_attribute(ret, pi, ctx, direct)
-      import string
       var TLV = matter.TLV
       var attr_name = matter.get_attribute_name(ctx.cluster, ctx.attribute)
       attr_name = attr_name ? " (" + attr_name + ")" : ""
@@ -239,10 +235,10 @@ class Matter_IM
         var a1_len = a1_tlv.encode_len()
         var a1_bytes = bytes(a1_len)        # pre-size bytes() to the actual size
         a1_raw = a1_tlv.tlv2raw(a1_bytes)
-        # tasmota.log(string.format("MTR: guessed len=%i actual=%i '%s'", a1_len, size(a1_raw), a1_raw.tohex()), 2)
+        # tasmota.log(format("MTR: guessed len=%i actual=%i '%s'", a1_len, size(a1_raw), a1_raw.tohex()), 2)
 
         if !no_log
-          tasmota.log(string.format("MTR: >Read_Attr (%6i) %s%s - %s", session.local_session_id, str(ctx), attr_name, res_str), 3)
+          tasmota.log(format("MTR: >Read_Attr (%6i) %s%s - %s", session.local_session_id, str(ctx), attr_name, res_str), 3)
         end          
       elif ctx.status != nil
         if direct                           # we report an error only if a concrete direct read, not with wildcards
@@ -260,10 +256,10 @@ class Matter_IM
           var a1_bytes = bytes(a1_len)        # pre-size bytes() to the actual size
           a1_raw = a1_tlv.tlv2raw(a1_bytes)
 
-          tasmota.log(string.format("MTR: >Read_Attr (%6i) %s%s - STATUS: 0x%02X %s", session.local_session_id, str(ctx), attr_name, ctx.status, ctx.status == matter.UNSUPPORTED_ATTRIBUTE ? "UNSUPPORTED_ATTRIBUTE" : ""), 3)
+          tasmota.log(format("MTR: >Read_Attr (%6i) %s%s - STATUS: 0x%02X %s", session.local_session_id, str(ctx), attr_name, ctx.status, ctx.status == matter.UNSUPPORTED_ATTRIBUTE ? "UNSUPPORTED_ATTRIBUTE" : ""), 3)
         end
       else
-        tasmota.log(string.format("MTR: >Read_Attr (%6i) %s%s - IGNORED", session.local_session_id, str(ctx), attr_name), 3)
+        tasmota.log(format("MTR: >Read_Attr (%6i) %s%s - IGNORED", session.local_session_id, str(ctx), attr_name), 3)
         # ignore if content is nil and status is undefined
         found = false
       end
@@ -307,9 +303,9 @@ class Matter_IM
         # we need expansion, log first
         if ctx.cluster != nil && ctx.attribute != nil
           var attr_name = matter.get_attribute_name(ctx.cluster, ctx.attribute)
-          tasmota.log(string.format("MTR: >Read_Attr (%6i) %s", session.local_session_id, str(ctx) + (attr_name ? " (" + attr_name + ")" : "")), 3)
+          tasmota.log(format("MTR: >Read_Attr (%6i) %s", session.local_session_id, str(ctx) + (attr_name ? " (" + attr_name + ")" : "")), 3)
         else
-          tasmota.log(string.format("MTR: >Read_Attr (%6i) %s", session.local_session_id, str(ctx)), 3)
+          tasmota.log(format("MTR: >Read_Attr (%6i) %s", session.local_session_id, str(ctx)), 3)
         end
         
       end
@@ -346,7 +342,6 @@ class Matter_IM
   # process IM 0x03 Subscribe Request
   #
   def subscribe_request(msg, val)
-    import string
     var query = matter.SubscribeRequestMessage().from_TLV(val)
 
     if !query.keep_subscriptions
@@ -366,7 +361,7 @@ class Matter_IM
       ctx.attribute = q.attribute
       attr_req.push(str(ctx))
     end
-    tasmota.log(string.format("MTR: >Subscribe (%6i) %s (min=%i, max=%i, keep=%i) sub=%i",
+    tasmota.log(format("MTR: >Subscribe (%6i) %s (min=%i, max=%i, keep=%i) sub=%i",
                               msg.session.local_session_id, attr_req.concat(" "), sub.min_interval, sub.max_interval, query.keep_subscriptions ? 1 : 0, sub.subscription_id), 3)
 
     var ret = self._inner_process_read_request(msg.session, query, true #-no_log-#)
@@ -383,7 +378,6 @@ class Matter_IM
   # returns `true` if processed, `false` if silently ignored,
   # or raises an exception
   def process_invoke_request(msg, val)
-    import string
     # structure is `ReadRequestMessage` 10.6.2 p.558
     # tasmota.log("MTR: IM:invoke_request processing start", 4)
     var ctx = matter.Path()
@@ -405,7 +399,7 @@ class Matter_IM
         var ctx_str = str(ctx)                    # keep string before invoking, it is modified by response
         var res = self.device.invoke_request(msg.session, q.command_fields, ctx)
         var params_log = (ctx.log != nil) ? "(" + str(ctx.log) + ") " : ""
-        tasmota.log(string.format("MTR: >Command   (%6i) %s %s %s", msg.session.local_session_id, ctx_str, cmd_name ? cmd_name : "", params_log), ctx.endpoint != 0 ? 2 : 3 #- don't log for endpoint 0 -# )
+        tasmota.log(format("MTR: >Command   (%6i) %s %s %s", msg.session.local_session_id, ctx_str, cmd_name ? cmd_name : "", params_log), ctx.endpoint != 0 ? 2 : 3 #- don't log for endpoint 0 -# )
         ctx.log = nil
         var a1 = matter.InvokeResponseIB()
         if res == true || ctx.status == matter.SUCCESS      # special case, just respond ok
@@ -417,7 +411,7 @@ class Matter_IM
           a1.status.status = matter.StatusIB()
           a1.status.status.status = matter.SUCCESS
           ret.invoke_responses.push(a1)
-          tasmota.log(string.format("MTR: <Replied   (%6i) OK exch=%i", msg.session.local_session_id, msg.exchange_id), 3)
+          tasmota.log(format("MTR: <Replied   (%6i) OK exch=%i", msg.session.local_session_id, msg.exchange_id), 3)
         elif res != nil
           a1.command = matter.CommandDataIB()
           a1.command.command_path = matter.CommandPathIB()
@@ -428,7 +422,7 @@ class Matter_IM
           ret.invoke_responses.push(a1)
 
           cmd_name = matter.get_command_name(ctx.cluster, ctx.command)
-          tasmota.log(string.format("MTR: <Replied   (%6i) %s %s", msg.session.local_session_id, str(ctx), cmd_name ? cmd_name : ""), 3)
+          tasmota.log(format("MTR: <Replied   (%6i) %s %s", msg.session.local_session_id, str(ctx), cmd_name ? cmd_name : ""), 3)
         elif ctx.status != nil
           a1.status = matter.CommandStatusIB()
           a1.status.command_path = matter.CommandPathIB()
@@ -438,9 +432,9 @@ class Matter_IM
           a1.status.status = matter.StatusIB()
           a1.status.status.status = ctx.status
           ret.invoke_responses.push(a1)
-          tasmota.log(string.format("MTR: <Replied   (%6i) Status=0x%02X exch=%i", msg.session.local_session_id, ctx.status, msg.exchange_id), 3)
+          tasmota.log(format("MTR: <Replied   (%6i) Status=0x%02X exch=%i", msg.session.local_session_id, ctx.status, msg.exchange_id), 3)
         else
-          tasmota.log(string.format("MTR: _Ignore    (%6i) exch=%i", msg.session.local_session_id, msg.exchange_id), 3)
+          tasmota.log(format("MTR: _Ignore    (%6i) exch=%i", msg.session.local_session_id, msg.exchange_id), 3)
           # ignore if content is nil and status is undefined
         end
       end
@@ -462,7 +456,6 @@ class Matter_IM
   # process IM 0x04 Subscribe Response
   #
   def subscribe_response(msg, val)
-    import string
     var query = matter.SubscribeResponseMessage().from_TLV(val)
     # tasmota.log("MTR: received SubscribeResponsetMessage=" + str(query), 4)
     return false
@@ -472,7 +465,6 @@ class Matter_IM
   # process IM 0x05 ReportData
   #
   def report_data(msg, val)
-    import string
     var query = matter.ReportDataMessage().from_TLV(val)
     # tasmota.log("MTR: received ReportDataMessage=" + str(query), 4)
     return false
@@ -482,7 +474,6 @@ class Matter_IM
   # process IM 0x06 Write Request
   #
   def process_write_request(msg, val)
-    import string
     var query = matter.WriteRequestMessage().from_TLV(val)
     # tasmota.log("MTR: received WriteRequestMessage=" + str(query), 3)
 
@@ -502,10 +493,9 @@ class Matter_IM
     #
     # should return true if answered, false if failed
     def write_single_attribute(ret, pi, ctx, write_data, direct)
-      import string
       var attr_name = matter.get_attribute_name(ctx.cluster, ctx.attribute)
       attr_name = attr_name ? " (" + attr_name + ")" : ""
-      # tasmota.log(string.format("MTR: Read Attribute " + str(ctx) + (attr_name ? " (" + attr_name + ")" : ""), 2)
+      # tasmota.log(format("MTR: Read Attribute " + str(ctx) + (attr_name ? " (" + attr_name + ")" : ""), 2)
       # Special case to report unsupported item, if pi==nil
       ctx.status = matter.UNSUPPORTED_WRITE
       var res = (pi != nil) ? pi.write_attribute(msg.session, ctx, write_data) : nil
@@ -521,11 +511,11 @@ class Matter_IM
           a1.status.status = ctx.status
 
           ret.write_responses.push(a1)
-          tasmota.log(string.format("MTR: Write_Attr %s%s - STATUS: 0x%02X %s", str(ctx), attr_name, ctx.status, ctx.status == matter.SUCCESS ? "SUCCESS" : ""), (ctx.endpoint != 0) ? 2 : 3)
+          tasmota.log(format("MTR: Write_Attr %s%s - STATUS: 0x%02X %s", str(ctx), attr_name, ctx.status, ctx.status == matter.SUCCESS ? "SUCCESS" : ""), (ctx.endpoint != 0) ? 2 : 3)
           return true
         end
       else
-        tasmota.log(string.format("MTR: Write_Attr %s%s - IGNORED", str(ctx), attr_name), 3)
+        tasmota.log(format("MTR: Write_Attr %s%s - IGNORED", str(ctx), attr_name), 3)
         # ignore if content is nil and status is undefined
       end
     end
@@ -585,7 +575,6 @@ class Matter_IM
   # process IM 0x07 Write Response
   #
   def process_write_response(msg, val)
-    import string
     var query = matter.WriteResponseMessage().from_TLV(val)
     # tasmota.log("MTR: received WriteResponseMessage=" + str(query), 4)
     return false
@@ -595,7 +584,6 @@ class Matter_IM
   # process IM 0x09 Invoke Response
   #
   def process_invoke_response(msg, val)
-    import string
     var query = matter.InvokeResponseMessage().from_TLV(val)
     # tasmota.log("MTR: received InvokeResponseMessage=" + str(query), 4)
     return false
@@ -605,11 +593,10 @@ class Matter_IM
   # process IM 0x0A Timed Request
   #
   def process_timed_request(msg, val)
-    import string
     var query = matter.TimedRequestMessage().from_TLV(val)
     # tasmota.log("MTR: received TimedRequestMessage=" + str(query), 3)
 
-    tasmota.log(string.format("MTR: >Command   (%6i) TimedRequest=%i", msg.session.local_session_id, query.timeout), 3)
+    tasmota.log(format("MTR: >Command   (%6i) TimedRequest=%i", msg.session.local_session_id, query.timeout), 3)
     
     # Send success status report
     self.send_status(msg, matter.SUCCESS)
@@ -621,7 +608,6 @@ class Matter_IM
   # send regular update for data subscribed
   #
   def send_subscribe_update(sub)
-    import string
     var session = sub.session
 
     # create a fake read request to feed to the ReportData
@@ -637,7 +623,7 @@ class Matter_IM
       fake_read.attributes_requests.push(p1)
     end
 
-    tasmota.log(string.format("MTR: <Sub_Data  (%6i) sub=%i", session.local_session_id, sub.subscription_id), 3)
+    tasmota.log(format("MTR: <Sub_Data  (%6i) sub=%i", session.local_session_id, sub.subscription_id), 3)
     sub.is_keep_alive = false             # sending an actual data update
 
     var ret = self._inner_process_read_request(session, fake_read)
@@ -653,10 +639,9 @@ class Matter_IM
   # send regular update for data subscribed
   #
   def send_subscribe_heartbeat(sub)
-    import string
     var session = sub.session
     
-    tasmota.log(string.format("MTR: <Sub_Alive (%6i) sub=%i", session.local_session_id, sub.subscription_id), 3)
+    tasmota.log(format("MTR: <Sub_Alive (%6i) sub=%i", session.local_session_id, sub.subscription_id), 3)
     sub.is_keep_alive = true              # sending keep-alive
 
     # prepare the response

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM_Data.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM_Data.be
@@ -96,12 +96,11 @@ class Matter_AttributePathIB : Matter_IM_base
 
   def tostring()
     try
-      import string
       var s = ""
-      if self.node    s += string.format("node=%s ", self.node) end
-      s += (self.endpoint != nil ? string.format("[%02X]", self.endpoint) : "[**]")
-      s += (self.cluster != nil ? string.format("%04X/", self.cluster) : "****/")
-      s += (self.attribute != nil ? string.format("%04X", self.attribute) : "****")
+      if self.node    s += format("node=%s ", self.node) end
+      s += (self.endpoint != nil ? format("[%02X]", self.endpoint) : "[**]")
+      s += (self.cluster != nil ? format("%04X/", self.cluster) : "****/")
+      s += (self.attribute != nil ? format("%04X", self.attribute) : "****")
       return s
     except .. as e, m
       return "Exception> " + str(e) + ", " + str(m)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
@@ -66,8 +66,7 @@ class Matter_IM_Message
   # Status Report OK received for previous message, proceed to next (if any)
   # return true if we manage the ack ourselves, false if it needs to be done upper
   def status_ok_received(msg)
-    import string
-    # tasmota.log(string.format("MTR: IM_Message status_ok_received exch=%i", self.resp.exchange_id), 3)
+    # tasmota.log(format("MTR: IM_Message status_ok_received exch=%i", self.resp.exchange_id), 3)
     self.expiration = tasmota.millis() + self.MSG_TIMEOUT     # give more time
     if msg
       self.resp = msg.build_response(self.resp.opcode, self.resp.x_flag_r, self.resp)   # update packet
@@ -87,13 +86,12 @@ class Matter_IM_Message
 
   # default responder for data
   def send_im(responder)
-    import string
-    # tasmota.log(string.format("MTR: IM_Message send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    # tasmota.log(format("MTR: IM_Message send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
     if !self.ready   return false  end
     var resp = self.resp
     resp.encode_frame(self.data.to_TLV().tlv2raw())    # payload in cleartext
     resp.encrypt()
-    tasmota.log(string.format("MTR: <snd       (%6i) id=%i exch=%i rack=%s", resp.session.local_session_id, resp.message_counter, resp.exchange_id, resp.ack_message_counter), 4)
+    tasmota.log(format("MTR: <snd       (%6i) id=%i exch=%i rack=%s", resp.session.local_session_id, resp.message_counter, resp.exchange_id, resp.ack_message_counter), 4)
     responder.send_response_frame(resp)
     self.last_counter = resp.message_counter
     self.finish = true              # by default we remove the packet after it is sent
@@ -164,8 +162,7 @@ class Matter_IM_ReportData : Matter_IM_Message
 
   # default responder for data
   def send_im(responder)
-    import string
-    # tasmota.log(string.format("MTR: IM_ReportData send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    # tasmota.log(format("MTR: IM_ReportData send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
     if !self.ready   return false  end
     var resp = self.resp                          # response frame object
     var data = self.data                          # TLV data of the response (if any)
@@ -174,7 +171,7 @@ class Matter_IM_ReportData : Matter_IM_Message
     # the message were grouped by right-sized binaries upfront, we just need to send one block at time
     var elements = 1                # number of elements added
 
-    # tasmota.log(string.format("MTR: exch=%i elements=%i msg_sz=%i total=%i", self.get_exchangeid(), elements, msg_sz, sz_attribute_reports), 3)
+    # tasmota.log(format("MTR: exch=%i elements=%i msg_sz=%i total=%i", self.get_exchangeid(), elements, msg_sz, sz_attribute_reports), 3)
     var next_elemnts
     if data.attribute_reports != nil
       next_elemnts = data.attribute_reports[elements .. ]
@@ -185,11 +182,11 @@ class Matter_IM_ReportData : Matter_IM_Message
     end
 
     if was_chunked
-      # tasmota.log(string.format("MTR: .Read_Attr next_chunk exch=%i", self.get_exchangeid()), 4)
+      # tasmota.log(format("MTR: .Read_Attr next_chunk exch=%i", self.get_exchangeid()), 4)
     end
     if data.more_chunked_messages
       if !was_chunked
-        # tasmota.log(string.format("MTR: .Read_Attr first_chunk exch=%i", self.get_exchangeid()), 4)
+        # tasmota.log(format("MTR: .Read_Attr first_chunk exch=%i", self.get_exchangeid()), 4)
       end
       # tasmota.log("MTR: sending TLV" + str(data), 4)
     end
@@ -203,13 +200,13 @@ class Matter_IM_ReportData : Matter_IM_Message
     # print(">>>>> send elements after encode")
     resp.encrypt()
     # print(">>>>> send elements after encrypt")
-    # tasmota.log(string.format("MTR: <snd       (%6i) id=%i exch=%i rack=%s", resp.session.local_session_id, resp.message_counter, resp.exchange_id, resp.ack_message_counter), 4)
+    # tasmota.log(format("MTR: <snd       (%6i) id=%i exch=%i rack=%s", resp.session.local_session_id, resp.message_counter, resp.exchange_id, resp.ack_message_counter), 4)
     responder.send_response_frame(resp)
     self.last_counter = resp.message_counter
 
     if next_elemnts != nil && size(next_elemnts) > 0
       data.attribute_reports = next_elemnts
-      # tasmota.log(string.format("MTR: to_be_sent_later size=%i exch=%i", size(data.attribute_reports), resp.exchange_id), 4)
+      # tasmota.log(format("MTR: to_be_sent_later size=%i exch=%i", size(data.attribute_reports), resp.exchange_id), 4)
       self.ready = false    # wait for Status Report before continuing sending
       # keep alive
     else
@@ -246,8 +243,7 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
 
   # ack received, confirm the heartbeat
   def ack_received(msg)
-    # import string
-    # tasmota.log(string.format("MTR: IM_ReportDataSubscribed ack_received sub=%i", self.sub.subscription_id), 3)
+    # tasmota.log(format("MTR: IM_ReportDataSubscribed ack_received sub=%i", self.sub.subscription_id), 3)
     super(self).ack_received(msg)
     if !self.report_data_phase
       # if ack is received while all data is sent, means that it finished without error
@@ -262,16 +258,14 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
 
   # we received an ACK error, remove subscription
   def status_error_received(msg)
-    # import string
-    # tasmota.log(string.format("MTR: IM_ReportDataSubscribed status_error_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
+    # tasmota.log(format("MTR: IM_ReportDataSubscribed status_error_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     self.sub.remove_self()
   end
 
   # ack received for previous message, proceed to next (if any)
   # return true if we manage the ack ourselves, false if it needs to be done upper
   def status_ok_received(msg)
-    # import string
-    # tasmota.log(string.format("MTR: IM_ReportDataSubscribed status_ok_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
+    # tasmota.log(format("MTR: IM_ReportDataSubscribed status_ok_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     if self.report_data_phase
       return super(self).status_ok_received(msg)
     else
@@ -284,14 +278,13 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
   # returns true if transaction is complete (remove object from queue)
   # default responder for data
   def send_im(responder)
-    import string
-    # tasmota.log(string.format("MTR: IM_ReportDataSubscribed send sub=%i exch=%i ready=%i", self.sub.subscription_id, self.resp.exchange_id, self.ready ? 1 : 0), 3)
-    # tasmota.log(string.format("MTR: ReportDataSubscribed::send_im size(self.data.attribute_reports)=%i ready=%s report_data_phase=%s", size(self.data.attribute_reports), str(self.ready), str(self.report_data_phase)), 3)
+    # tasmota.log(format("MTR: IM_ReportDataSubscribed send sub=%i exch=%i ready=%i", self.sub.subscription_id, self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    # tasmota.log(format("MTR: ReportDataSubscribed::send_im size(self.data.attribute_reports)=%i ready=%s report_data_phase=%s", size(self.data.attribute_reports), str(self.ready), str(self.report_data_phase)), 3)
     if !self.ready   return false  end
     if size(self.data.attribute_reports) > 0      # do we have still attributes to send
       if self.report_data_phase
         super(self).send_im(responder)
-        # tasmota.log(string.format("MTR: ReportDataSubscribed::send_im called super finish=%i", self.finish), 3)
+        # tasmota.log(format("MTR: ReportDataSubscribed::send_im called super finish=%i", self.finish), 3)
         if !self.finish return end              # ReportData needs to continue
         # ReportData is finished
         self.report_data_phase = false
@@ -302,7 +295,7 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
         var resp = self.resp.build_standalone_ack(false)
         resp.encode_frame()
         resp.encrypt()
-        tasmota.log(string.format("MTR: <Ack       (%6i) ack=%i id=%i", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter), 4)
+        tasmota.log(format("MTR: <Ack       (%6i) ack=%i id=%i", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter), 4)
         responder.send_response_frame(resp)
         self.last_counter = resp.message_counter
         self.finish = true
@@ -346,8 +339,7 @@ class Matter_IM_SubscribedHeartbeat : Matter_IM_ReportData
 
   # ack received, confirm the heartbeat
   def ack_received(msg)
-    # import string
-    # tasmota.log(string.format("MTR: Matter_IM_SubscribedHeartbeat ack_received sub=%i", self.sub.subscription_id), 3)
+    # tasmota.log(format("MTR: Matter_IM_SubscribedHeartbeat ack_received sub=%i", self.sub.subscription_id), 3)
     super(self).ack_received(msg)
     self.finish = true
     return true                       # proceed to calling send() which removes the message
@@ -355,8 +347,7 @@ class Matter_IM_SubscribedHeartbeat : Matter_IM_ReportData
 
   # we received an ACK error, remove subscription
   def status_error_received(msg)
-    # import string
-    # tasmota.log(string.format("MTR: Matter_IM_SubscribedHeartbeat status_error_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
+    # tasmota.log(format("MTR: Matter_IM_SubscribedHeartbeat status_error_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     self.sub.remove_self()
     return false                            # let the caller to the ack
   end
@@ -364,15 +355,13 @@ class Matter_IM_SubscribedHeartbeat : Matter_IM_ReportData
   # ack received for previous message, proceed to next (if any)
   # return true if we manage the ack ourselves, false if it needs to be done upper
   def status_ok_received(msg)
-    # import string
-    # tasmota.log(string.format("MTR: Matter_IM_SubscribedHeartbeat status_ok_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
+    # tasmota.log(format("MTR: Matter_IM_SubscribedHeartbeat status_ok_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     return false                            # let the caller to the ack
   end
 
   # default responder for data
   def send_im(responder)
-    # import string
-    # tasmota.log(string.format("MTR: Matter_IM_SubscribedHeartbeat send sub=%i exch=%i ready=%i", self.sub.subscription_id, self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    # tasmota.log(format("MTR: Matter_IM_SubscribedHeartbeat send sub=%i exch=%i ready=%i", self.sub.subscription_id, self.resp.exchange_id, self.ready ? 1 : 0), 3)
     if !self.ready   return false  end
 
     super(self).send_im(responder)
@@ -398,8 +387,7 @@ class Matter_IM_SubscribeResponse : Matter_IM_ReportData
 
   # default responder for data
   def send_im(responder)
-    # import string
-    # tasmota.log(string.format("MTR: Matter_IM_SubscribeResponse send sub=%i ready=%i", self.sub.subscription_id, self.ready ? 1 : 0), 3)
+    # tasmota.log(format("MTR: Matter_IM_SubscribeResponse send sub=%i ready=%i", self.sub.subscription_id, self.ready ? 1 : 0), 3)
     if !self.ready   return false  end
     if self.report_data_phase
       super(self).send_im(responder)
@@ -422,7 +410,7 @@ class Matter_IM_SubscribeResponse : Matter_IM_ReportData
       resp.encrypt()
       responder.send_response_frame(resp)
       self.last_counter = resp.message_counter
-      # tasmota.log(string.format("MTR: Send SubscribeResponseMessage sub=%i id=%i", self.sub.subscription_id, resp.message_counter), 3)
+      # tasmota.log(format("MTR: Send SubscribeResponseMessage sub=%i id=%i", self.sub.subscription_id, resp.message_counter), 3)
       self.sub.re_arm()
       self.finish = true          # remove exchange
     end
@@ -430,10 +418,9 @@ class Matter_IM_SubscribeResponse : Matter_IM_ReportData
 
   # Status ok received
   def status_ok_received(msg)
-    import string
-    # tasmota.log(string.format("MTR: IM_SubscribeResponse status_ok_received sub=%i exch=%i ack=%i last_counter=%i", self.sub.subscription_id, self.resp.exchange_id, msg.ack_message_counter ? msg.ack_message_counter : 0 , self.last_counter), 3)
+    # tasmota.log(format("MTR: IM_SubscribeResponse status_ok_received sub=%i exch=%i ack=%i last_counter=%i", self.sub.subscription_id, self.resp.exchange_id, msg.ack_message_counter ? msg.ack_message_counter : 0 , self.last_counter), 3)
     # once we receive ack, open flow for subscriptions
-    tasmota.log(string.format("MTR: >Sub_OK    (%6i) sub=%i", msg.session.local_session_id, self.sub.subscription_id), 3)
+    tasmota.log(format("MTR: >Sub_OK    (%6i) sub=%i", msg.session.local_session_id, self.sub.subscription_id), 3)
     return super(self).status_ok_received(msg)
   end
     

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM_Subscription.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM_Subscription.be
@@ -98,13 +98,12 @@ class Matter_IM_Subscription
 
   # we received a complete ack for previous message, rearm
   def re_arm()
-    import string
     self.wait_status = false
     var now = tasmota.millis()
     self.expiration = now + (self.max_interval - self.MAX_INTERVAL_MARGIN) * 1000
     self.not_before = now + self.min_interval * 1000 - 1
     if !self.is_keep_alive
-      tasmota.log(string.format("MTR: .Sub_Done  (      ) sub=%i", self.subscription_id), 3)
+      tasmota.log(format("MTR: .Sub_Done  (      ) sub=%i", self.subscription_id), 3)
     end
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Message.be
@@ -229,7 +229,6 @@ class Matter_Frame
   # Generate a Standalone Acknowledgment
   # Uses `PROTOCOL_ID_SECURE_CHANNEL` no ecnryption required
   def build_standalone_ack(reliable)
-    import string
     # send back response
     var resp = classof(self)(self.message_handler)
 
@@ -263,7 +262,6 @@ class Matter_Frame
   #
   # if 'resp' is not nil, update frame
   def build_response(opcode, reliable, resp)
-    import string
     # send back response
     if resp == nil
       resp = classof(self)(self.message_handler)
@@ -301,8 +299,8 @@ class Matter_Frame
 
     if resp.local_session_id == 0
       var op_name = matter.get_opcode_name(resp.opcode)
-      if !op_name   op_name = string.format("0x%02X", resp.opcode) end
-      tasmota.log(string.format("MTR: <Replied   (%6i) %s", resp.session.local_session_id, op_name), 3)
+      if !op_name   op_name = format("0x%02X", resp.opcode) end
+      tasmota.log(format("MTR: <Replied   (%6i) %s", resp.session.local_session_id, op_name), 3)
     end
     return resp
   end
@@ -312,7 +310,6 @@ class Matter_Frame
  #
   # if 'resp' is not nil, update frame
   static def initiate_response(message_handler, session, opcode, reliable, resp)
-    import string
     # send back response
     if resp == nil
       resp = matter.Frame(message_handler)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_MessageHandler.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_MessageHandler.be
@@ -44,11 +44,10 @@ class Matter_MessageHandler
   # reliable: do we send as reliable message
   #
   def send_simple_ack(frame, reliable)
-    import string
     if frame.x_flag_r                   # nothing to respond, check if we need a standalone ack
       var resp = frame.build_standalone_ack(reliable)
       resp.encode_frame()
-      tasmota.log(string.format("MTR: <Ack       (%6i) ack=%i id=%i %s", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter, reliable ? '{reliable}' : ''), 4)
+      tasmota.log(format("MTR: <Ack       (%6i) ack=%i id=%i %s", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter, reliable ? '{reliable}' : ''), 4)
       self.send_response_frame(resp)
     end
   end
@@ -59,12 +58,11 @@ class Matter_MessageHandler
   # reliable: do we send as reliable message
   #
   def send_encrypted_ack(frame, reliable)
-    import string
     if frame.x_flag_r                   # nothing to respond, check if we need a standalone ack
       var resp = frame.build_standalone_ack(reliable)
       resp.encode_frame()
       resp.encrypt()
-      tasmota.log(string.format("MTR: <Ack*      (%6i) ack=%i id=%i %s", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter, reliable ? '{reliable}' : ''), 4)
+      tasmota.log(format("MTR: <Ack*      (%6i) ack=%i id=%i %s", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter, reliable ? '{reliable}' : ''), 4)
       self.send_response_frame(resp)
     end
   end
@@ -76,7 +74,6 @@ class Matter_MessageHandler
   # and dispacth to appropriate handler
   #
   def msg_received(raw, addr, port)
-    import string
     var ret = false
 
     try
@@ -105,7 +102,7 @@ class Matter_MessageHandler
         
         # check if it's a duplicate
         if !session._counter_insecure_rcv.validate(frame.message_counter, false)
-          tasmota.log(string.format("MTR: .          Duplicate unencrypted message = %i ref = %i", frame.message_counter, session._counter_insecure_rcv.val()), 4)
+          tasmota.log(format("MTR: .          Duplicate unencrypted message = %i ref = %i", frame.message_counter, session._counter_insecure_rcv.val()), 4)
           self.send_simple_ack(frame, false #-not reliable-#)
           return false
         end
@@ -114,10 +111,10 @@ class Matter_MessageHandler
         self.device.received_ack(frame)                         # remove acknowledge packet from sending list
         if frame.opcode != 0x10                                 # don't show `MRP_Standalone_Acknowledgement`
           var op_name = matter.get_opcode_name(frame.opcode)
-          if !op_name   op_name = string.format("0x%02X", frame.opcode) end
-          tasmota.log(string.format("MTR: >Received  (%6i) %s rid=%i exch=%i from [%s]:%i", session.local_session_id, op_name, frame.message_counter, frame.exchange_id, addr, port), 3)
+          if !op_name   op_name = format("0x%02X", frame.opcode) end
+          tasmota.log(format("MTR: >Received  (%6i) %s rid=%i exch=%i from [%s]:%i", session.local_session_id, op_name, frame.message_counter, frame.exchange_id, addr, port), 3)
         else
-          tasmota.log(string.format("MTR: >rcv Ack   (%6i) rid=%i exch=%i ack=%s %sfrom [%s]:%i", session.local_session_id, frame.message_counter, frame.x_flag_r ? "{reliable} " : "", frame.exchange_id, str(frame.ack_message_counter), addr, port), 4)
+          tasmota.log(format("MTR: >rcv Ack   (%6i) rid=%i exch=%i ack=%s %sfrom [%s]:%i", session.local_session_id, frame.message_counter, frame.x_flag_r ? "{reliable} " : "", frame.exchange_id, str(frame.ack_message_counter), addr, port), 4)
         end
         ret = self.commissioning.process_incoming(frame)
         # if ret is false, the implicit Ack was not sent
@@ -126,7 +123,7 @@ class Matter_MessageHandler
       else
         #############################################################
         # encrypted message
-        tasmota.log(string.format("MTR: decode header: local_session_id=%i message_counter=%i", frame.local_session_id, frame.message_counter), 4)
+        tasmota.log(format("MTR: decode header: local_session_id=%i message_counter=%i", frame.local_session_id, frame.message_counter), 4)
 
         var session = self.device.sessions.get_session_by_local_session_id(frame.local_session_id)
         if session == nil
@@ -154,11 +151,11 @@ class Matter_MessageHandler
         frame.raw .. cleartext                          # add cleartext
 
         # continue decoding
-        # tasmota.log(string.format("MTR: idx=%i clear=%s", frame.payload_idx, frame.raw.tohex()), 4)
+        # tasmota.log(format("MTR: idx=%i clear=%s", frame.payload_idx, frame.raw.tohex()), 4)
         frame.decode_payload()
         tasmota.log("MTR: >          Decrypted message: protocol_id:"+str(frame.protocol_id)+" opcode="+str(frame.opcode)+" exchange_id="+str(frame.exchange_id & 0xFFFF), 4)
 
-        # tasmota.log(string.format("MTR: >rcv       (%6i) [%02X/%02X] rid=%i exch=%i ack=%s %sfrom [%s]:%i", session.local_session_id, frame.protocol_id, frame.opcode, frame.message_counter, frame.exchange_id, str(frame.ack_message_counter), frame.x_flag_r ? "{reliable} " : "", addr, port), 3)
+        # tasmota.log(format("MTR: >rcv       (%6i) [%02X/%02X] rid=%i exch=%i ack=%s %sfrom [%s]:%i", session.local_session_id, frame.protocol_id, frame.opcode, frame.message_counter, frame.exchange_id, str(frame.ack_message_counter), frame.x_flag_r ? "{reliable} " : "", addr, port), 3)
 
         self.device.received_ack(frame)                     # remove acknowledge packet from sending list
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Path.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Path.be
@@ -36,12 +36,11 @@ class Matter_Path
 
   def tostring()
     try
-      import string
       var s = ""
-      s += (self.endpoint  != nil ? string.format("[%02X]", self.endpoint) : "[**]")
-      s += (self.cluster   != nil ? string.format("%04X/", self.cluster) : "****/")
-      s += (self.attribute != nil ? string.format("%04X", self.attribute) : "")
-      s += (self.command   != nil ? string.format("%04X", self.command) : "")
+      s += (self.endpoint  != nil ? format("[%02X]", self.endpoint) : "[**]")
+      s += (self.cluster   != nil ? format("%04X/", self.cluster) : "****/")
+      s += (self.attribute != nil ? format("%04X", self.attribute) : "")
+      s += (self.command   != nil ? format("%04X", self.command) : "")
       if self.attribute == nil && self.command == nil     s += "****" end
       return s
     except .. as e, m

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Aggregator.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Aggregator.be
@@ -38,7 +38,6 @@ class Matter_Plugin_Aggregator : Matter_Plugin
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_HTTP.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_HTTP.be
@@ -53,7 +53,6 @@ class Matter_Plugin_Bridge_HTTP : Matter_Plugin_Device
   #############################################################
   # Constructor
   def init(device, endpoint, arguments)
-    import string
     super(self).init(device, endpoint, arguments)
 
     var addr = arguments.find(self.ARG_HTTP)
@@ -107,7 +106,6 @@ class Matter_Plugin_Bridge_HTTP : Matter_Plugin_Device
   # arg can be nil, in this case `cmd` has it all
   def call_remote_sync(cmd, arg)
     # if !self.http_remote  return nil  end
-    import string
     import json
 
     var retry = 2         # try 2 times if first failed
@@ -213,7 +211,6 @@ class Matter_Plugin_Bridge_HTTP : Matter_Plugin_Device
   static var PREFIX = "| <i>%s</i> "
   def web_values()
     import webserver
-    import string
     self.web_values_prefix()
     webserver.content_send("&lt;-- (" + self.NAME + ") --&gt;")
   end
@@ -221,9 +218,8 @@ class Matter_Plugin_Bridge_HTTP : Matter_Plugin_Device
   # Show prefix before web value
   def web_values_prefix()
     import webserver
-    import string
     var name = self.get_name()
-    webserver.content_send(string.format(self.PREFIX, name ? webserver.html_escape(name) : ""))
+    webserver.content_send(format(self.PREFIX, name ? webserver.html_escape(name) : ""))
   end
 
   # Show on/off value as html

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light0.be
@@ -90,7 +90,6 @@ class Matter_Plugin_Bridge_Light0 : Matter_Plugin_Bridge_HTTP
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute
@@ -144,20 +143,18 @@ class Matter_Plugin_Bridge_Light0 : Matter_Plugin_Bridge_HTTP
   # Show values of the remote device as HTML
   def web_values()
     import webserver
-    import string
     self.web_values_prefix()        # display '| ' and name if present
-    webserver.content_send(string.format("%s", self.web_value_onoff(self.shadow_onoff)))
+    webserver.content_send(format("%s", self.web_value_onoff(self.shadow_onoff)))
   end
 
   # Show prefix before web value
   def web_values_prefix()
     import webserver
-    import string
     var name = self.get_name()
     if !name
       name = "Power" + str(self.tasmota_relay_index)
     end
-    webserver.content_send(string.format(self.PREFIX, name ? webserver.html_escape(name) : ""))
+    webserver.content_send(format(self.PREFIX, name ? webserver.html_escape(name) : ""))
   end
 
 end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light1.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light1.be
@@ -79,7 +79,6 @@ class Matter_Plugin_Bridge_Light1 : Matter_Plugin_Bridge_Light0
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute
@@ -172,18 +171,16 @@ class Matter_Plugin_Bridge_Light1 : Matter_Plugin_Bridge_Light0
   # Show values of the remote device as HTML
   def web_values()
     import webserver
-    import string
     self.web_values_prefix()        # display '| ' and name if present
-    webserver.content_send(string.format("%s %s", self.web_value_onoff(self.shadow_onoff), self.web_value_dimmer()))
+    webserver.content_send(format("%s %s", self.web_value_onoff(self.shadow_onoff), self.web_value_dimmer()))
   end
 
   # Show on/off value as html
   def web_value_dimmer()
-    import string
     var bri_html = ""
     if self.shadow_bri != nil
       var bri = tasmota.scale_uint(self.shadow_bri, 0, 254, 0, 100)
-      bri_html = string.format("%i%%", bri)
+      bri_html = format("%i%%", bri)
     end
     return  "&#128261; " + bri_html;
   end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light2.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light2.be
@@ -96,7 +96,6 @@ class Matter_Plugin_Bridge_Light2 : Matter_Plugin_Bridge_Light1
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute
@@ -174,20 +173,18 @@ class Matter_Plugin_Bridge_Light2 : Matter_Plugin_Bridge_Light1
   # Show values of the remote device as HTML
   def web_values()
     import webserver
-    import string
     self.web_values_prefix()        # display '| ' and name if present
-    webserver.content_send(string.format("%s %s %s",
+    webserver.content_send(format("%s %s %s",
                               self.web_value_onoff(self.shadow_onoff), self.web_value_dimmer(),
                               self.web_value_ct()))
   end
 
   # Show on/off value as html
   def web_value_ct()
-    import string
     var ct_html = ""
     if self.shadow_ct != nil
       var ct_k = (((1000000 / self.shadow_ct) + 25) / 50) * 50      # convert in Kelvin
-      ct_html = string.format("%iK", ct_k)
+      ct_html = format("%iK", ct_k)
     end
     return  "&#9898; " + ct_html;
   end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light3.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light3.be
@@ -96,7 +96,6 @@ class Matter_Plugin_Bridge_Light3 : Matter_Plugin_Bridge_Light1
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute
@@ -200,22 +199,20 @@ class Matter_Plugin_Bridge_Light3 : Matter_Plugin_Bridge_Light1
   # Show values of the remote device as HTML
   def web_values()
     import webserver
-    import string
     self.web_values_prefix()        # display '| ' and name if present
-    webserver.content_send(string.format("%s %s %s",
+    webserver.content_send(format("%s %s %s",
                               self.web_value_onoff(self.shadow_onoff), self.web_value_dimmer(),
                               self.web_value_RGB()))
   end
 
   # Show on/off value as html
   def web_value_RGB()
-    import string
     if self.shadow_hue != nil && self.shadow_sat != nil
       var l = light_state(3)      # RGB virtual light state object
       l.set_bri(255)              # set full brightness to get full range RGB
       l.set_huesat(tasmota.scale_uint(self.shadow_hue, 0, 254, 0, 360), tasmota.scale_uint(self.shadow_sat, 0, 254, 0, 255))
-      var rgb_hex = string.format("#%02X%02X%02X", l.r, l.g, l.b)
-      var rgb_html = string.format('<i class="bxm" style="--cl:%s"></i>%s', rgb_hex, rgb_hex)
+      var rgb_hex = format("#%02X%02X%02X", l.r, l.g, l.b)
+      var rgb_html = format('<i class="bxm" style="--cl:%s"></i>%s', rgb_hex, rgb_hex)
       return rgb_html
     end
     return ""

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_OnOff.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_OnOff.be
@@ -38,9 +38,8 @@ class Matter_Plugin_Bridge_OnOff : Matter_Plugin_Bridge_Light0
   # Show values of the remote device as HTML
   def web_values()
     import webserver
-    import string
     self.web_values_prefix()        # display '| ' and name if present
-    webserver.content_send(string.format("Relay %i %s", self.tasmota_relay_index, self.web_value_onoff(self.shadow_onoff)))
+    webserver.content_send(format("Relay %i %s", self.tasmota_relay_index, self.web_value_onoff(self.shadow_onoff)))
   end
 
 end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor.be
@@ -101,10 +101,9 @@ class Matter_Plugin_Bridge_Sensor : Matter_Plugin_Bridge_HTTP
   # Show prefix before web value
   def web_values_prefix()
     import webserver
-    import string
     var name = self.get_name()
     if (!name)    name = self.filter_name_html()    end
-    webserver.content_send(string.format(self.PREFIX, name ? webserver.html_escape(name) : ""))
+    webserver.content_send(format(self.PREFIX, name ? webserver.html_escape(name) : ""))
   end
 
 end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Contact.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Contact.be
@@ -72,7 +72,6 @@ class Matter_Plugin_Bridge_Sensor_Contact : Matter_Plugin_Bridge_HTTP
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute
@@ -102,20 +101,18 @@ class Matter_Plugin_Bridge_Sensor_Contact : Matter_Plugin_Bridge_HTTP
   # Show values of the remote device as HTML
   def web_values()
     import webserver
-    import string
     self.web_values_prefix()        # display '| ' and name if present
-    webserver.content_send(string.format("Contact%i %s", self.tasmota_switch_index, self.web_value_onoff(self.shadow_contact)))
+    webserver.content_send(format("Contact%i %s", self.tasmota_switch_index, self.web_value_onoff(self.shadow_contact)))
   end
 
   # Show prefix before web value
   def web_values_prefix()
     import webserver
-    import string
     var name = self.get_name()
     if !name
       name = "Switch" + str(self.tasmota_switch_index)
     end
-    webserver.content_send(string.format(self.PREFIX, name ? webserver.html_escape(name) : ""))
+    webserver.content_send(format(self.PREFIX, name ? webserver.html_escape(name) : ""))
   end
 end
 matter.Plugin_Bridge_Sensor_Contact = Matter_Plugin_Bridge_Sensor_Contact

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Humidity.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Humidity.be
@@ -57,7 +57,6 @@ class Matter_Plugin_Bridge_Sensor_Humidity : Matter_Plugin_Bridge_Sensor
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute
@@ -91,9 +90,8 @@ class Matter_Plugin_Bridge_Sensor_Humidity : Matter_Plugin_Bridge_Sensor
   # Show values of the remote device as HTML
   def web_values()
     import webserver
-    import string
     self.web_values_prefix()        # display '| ' and name if present
-    webserver.content_send(string.format("&#x1F4A7; %2.0f%%",
+    webserver.content_send(format("&#x1F4A7; %2.0f%%",
                                          self.shadow_value != nil ? real(self.shadow_value) / 100 : nil))
   end
   

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Illuminance.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Illuminance.be
@@ -64,7 +64,6 @@ class Matter_Plugin_Bridge_Sensor_Illuminance : Matter_Plugin_Bridge_Sensor
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute
@@ -98,9 +97,8 @@ class Matter_Plugin_Bridge_Sensor_Illuminance : Matter_Plugin_Bridge_Sensor
   # Show values of the remote device as HTML
   def web_values()
     import webserver
-    import string
     self.web_values_prefix()        # display '| ' and name if present
-    webserver.content_send(string.format("&#128261; %ilux",
+    webserver.content_send(format("&#128261; %ilux",
                                          int(self.shadow_value)))
   end
   

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Occupancy.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Occupancy.be
@@ -72,7 +72,6 @@ class Matter_Plugin_Bridge_Sensor_Occupancy : Matter_Plugin_Bridge_HTTP
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute
@@ -106,20 +105,18 @@ class Matter_Plugin_Bridge_Sensor_Occupancy : Matter_Plugin_Bridge_HTTP
   # Show values of the remote device as HTML
   def web_values()
     import webserver
-    import string
     self.web_values_prefix()        # display '| ' and name if present
-    webserver.content_send(string.format("Occupancy%i %s", self.tasmota_switch_index, self.web_value_onoff(self.shadow_occupancy)))
+    webserver.content_send(format("Occupancy%i %s", self.tasmota_switch_index, self.web_value_onoff(self.shadow_occupancy)))
   end
 
   # Show prefix before web value
   def web_values_prefix()
     import webserver
-    import string
     var name = self.get_name()
     if !name
       name = "Switch" + str(self.tasmota_switch_index)
     end
-    webserver.content_send(string.format(self.PREFIX, name ? webserver.html_escape(name) : ""))
+    webserver.content_send(format(self.PREFIX, name ? webserver.html_escape(name) : ""))
   end
 end
 matter.Plugin_Bridge_Sensor_Occupancy = Matter_Plugin_Bridge_Sensor_Occupancy

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Pressure.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Pressure.be
@@ -57,7 +57,6 @@ class Matter_Plugin_Bridge_Sensor_Pressure : Matter_Plugin_Bridge_Sensor
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute
@@ -91,9 +90,8 @@ class Matter_Plugin_Bridge_Sensor_Pressure : Matter_Plugin_Bridge_Sensor
   # Show values of the remote device as HTML
   def web_values()
     import webserver
-    import string
     self.web_values_prefix()        # display '| ' and name if present
-    webserver.content_send(string.format("&#x26C5; %i hPa",
+    webserver.content_send(format("&#x26C5; %i hPa",
                                          int(self.shadow_value)))
   end
   

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Temp.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Temp.be
@@ -57,7 +57,6 @@ class Matter_Plugin_Bridge_Sensor_Temp : Matter_Plugin_Bridge_Sensor
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute
@@ -91,9 +90,8 @@ class Matter_Plugin_Bridge_Sensor_Temp : Matter_Plugin_Bridge_Sensor
   # Show values of the remote device as HTML
   def web_values()
     import webserver
-    import string
     self.web_values_prefix()        # display '| ' and name if present
-    webserver.content_send(string.format("&#x2600;&#xFE0F; %.1f °C",
+    webserver.content_send(format("&#x2600;&#xFE0F; %.1f °C",
                                          self.shadow_value != nil ? real(self.shadow_value) / 100 : nil))
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Device.be
@@ -56,7 +56,6 @@ class Matter_Plugin_Device : Matter_Plugin
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light0.be
@@ -65,7 +65,6 @@ class Matter_Plugin_Light0 : Matter_Plugin_Device
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light1.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light1.be
@@ -72,7 +72,6 @@ class Matter_Plugin_Light1 : Matter_Plugin_Light0
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light2.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light2.be
@@ -79,7 +79,6 @@ class Matter_Plugin_Light2 : Matter_Plugin_Light1
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light3.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Light3.be
@@ -71,7 +71,6 @@ class Matter_Plugin_Light3 : Matter_Plugin_Light1
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_OnOff.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_OnOff.be
@@ -87,7 +87,6 @@ class Matter_Plugin_OnOff : Matter_Plugin_Device
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
@@ -326,7 +326,6 @@ class Matter_Plugin_Root : Matter_Plugin
   #   or an `int` to indicate a status
   def invoke_request(session, val, ctx)
     import crypto
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var command = ctx.command
@@ -433,7 +432,7 @@ class Matter_Plugin_Root : Matter_Plugin
         var CSRNonce = val.findsubval(0)     # octstr 32
         if size(CSRNonce) != 32   return nil end    # check size on nonce
         var IsForUpdateNOC = val.findsubval(1, false)     # bool
-        # tasmota.log(string.format("MTR: CSRRequest CSRNonce=%s IsForUpdateNOC=%s", str(CSRNonce), str(IsForUpdateNOC)), 4)
+        # tasmota.log(format("MTR: CSRRequest CSRNonce=%s IsForUpdateNOC=%s", str(CSRNonce), str(IsForUpdateNOC)), 4)
 
         var csr = session.gen_CSR()
 
@@ -550,7 +549,7 @@ class Matter_Plugin_Root : Matter_Plugin
       elif command == 0x0009            # ---------- UpdateFabricLabel ----------
         var label = val.findsubval(0)     # Label string max 32
         session.set_fabric_label(label)
-        tasmota.log(string.format("MTR: .          Update fabric '%s' label='%s'", session._fabric.get_fabric_id().copy().reverse().tohex(), str(label)), 3)
+        tasmota.log(format("MTR: .          Update fabric '%s' label='%s'", session._fabric.get_fabric_id().copy().reverse().tohex(), str(label)), 3)
         ctx.status = matter.SUCCESS                  # OK
         return nil                      # trigger a standalone ack
 
@@ -582,7 +581,7 @@ class Matter_Plugin_Root : Matter_Plugin
         var iterations = val.findsubval(3)          # Iterations u4
         var salt = val.findsubval(4)                # Salt octstr
 
-        tasmota.log(string.format("MTR: OpenCommissioningWindow(timeout=%i, passcode=%s, discriminator=%i, iterations=%i, salt=%s)",
+        tasmota.log(format("MTR: OpenCommissioningWindow(timeout=%i, passcode=%s, discriminator=%i, iterations=%i, salt=%s)",
                                   timeout, passcode_verifier.tohex(), discriminator, iterations, salt.tohex()), 4)
 
         # check values
@@ -630,7 +629,6 @@ class Matter_Plugin_Root : Matter_Plugin
   # write an attribute
   #
   def write_attribute(session, ctx, write_data)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Contact.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Contact.be
@@ -76,7 +76,6 @@ class Matter_Plugin_Sensor_Contact : Matter_Plugin_Device
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Humidity.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Humidity.be
@@ -56,7 +56,6 @@ class Matter_Plugin_Sensor_Humidity : Matter_Plugin_Sensor
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Illuminance.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Illuminance.be
@@ -63,7 +63,6 @@ class Matter_Plugin_Sensor_Illuminance : Matter_Plugin_Sensor
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Occupancy.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Occupancy.be
@@ -73,7 +73,6 @@ class Matter_Plugin_Sensor_Occupancy : Matter_Plugin_Device
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_OnOff.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_OnOff.be
@@ -71,7 +71,6 @@ class Matter_Plugin_Sensor_OnOff : Matter_Plugin_Device
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Pressure.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Pressure.be
@@ -56,7 +56,6 @@ class Matter_Plugin_Sensor_Pressure : Matter_Plugin_Sensor
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Temp.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Temp.be
@@ -56,7 +56,6 @@ class Matter_Plugin_Sensor_Temp : Matter_Plugin_Sensor
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Shutter.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Shutter.be
@@ -94,7 +94,6 @@ class Matter_Plugin_Shutter : Matter_Plugin_Device
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute
@@ -197,11 +196,10 @@ class Matter_Plugin_Shutter : Matter_Plugin_Device
   # parse the output from `ShutterPosition`
   # Ex: `{"Shutter1":{"Position":50,"Direction":0,"Target":50,"Tilt":30}}`
   def parse_sensors(payload)
-    import string
     var k = "Shutter" + str(self.tasmota_shutter_index + 1)
     if payload.contains(k)
       var v = payload[k]
-      # tasmota.log(string.format("MTR: getting shutter values(%i): %s", self.endpoint, str(v)), 2)
+      # tasmota.log(format("MTR: getting shutter values(%i): %s", self.endpoint, str(v)), 2)
       # Position
       var val_pos = v.find("Position")
       if val_pos != nil

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_ShutterTilt.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_ShutterTilt.be
@@ -60,7 +60,6 @@ class Matter_Plugin_ShutterTilt : Matter_Plugin_Shutter
   # parse the output from `ShutterPosition`
   # Ex: `{"Shutter1":{"Position":50,"Direction":0,"Target":50,"Tilt":30}}`
   def parse_sensors(payload)
-    import string
     var k = "Shutter" + str(self.tasmota_shutter_index + 1)
     if payload.contains(k)
       var v = payload[k]
@@ -98,7 +97,6 @@ class Matter_Plugin_ShutterTilt : Matter_Plugin_Shutter
   # read an attribute
   #
   def read_attribute(session, ctx)
-    import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var attribute = ctx.attribute

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Session.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Session.be
@@ -118,8 +118,7 @@ class Matter_Session : Matter_Expirable
   #############################################################
   # Called before removal
   def before_remove()
-    import string
-    tasmota.log(string.format("MTR: -Session   (%6i) (removed)", self.local_session_id), 3)
+    tasmota.log(format("MTR: -Session   (%6i) (removed)", self.local_session_id), 3)
   end
 
   #############################################################
@@ -128,9 +127,8 @@ class Matter_Session : Matter_Expirable
   # Provide the next counter value, and update the last know persisted if needed
   #
   def counter_snd_next()
-    import string
     var next = self._counter_snd_impl.next()
-    # tasmota.log(string.format("MTR: .          Counter_snd=%i", next), 4)
+    # tasmota.log(format("MTR: .          Counter_snd=%i", next), 4)
     if matter.Counter.is_greater(next, self.counter_snd)
       self.counter_snd = next + self._COUNTER_SND_INCR
       if self.does_persist()
@@ -294,7 +292,6 @@ class Matter_Session : Matter_Expirable
   #############################################################
   def tojson()
     import json
-    import string
     import introspect
 
     self.persist_pre()
@@ -314,7 +311,7 @@ class Matter_Session : Matter_Expirable
       elif type(v) == 'instance'    continue                    # skip any other instance
       end
       
-      r.push(string.format("%s:%s", json.dump(str(k)), json.dump(v)))
+      r.push(format("%s:%s", json.dump(str(k)), json.dump(v)))
     end
     self.persist_post()
     return "{" + r.concat(",") + "}"

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
@@ -275,15 +275,14 @@ class Matter_Session_Store
   #############################################################
   # find session by resumption id
   def find_session_by_resumption_id(resumption_id)
-    import string
     if !resumption_id  return nil end
     var i = 0
     var sessions = self.sessions
     while i < size(sessions)
       var session = sessions[i]
-      tasmota.log(string.format("MTR: session.resumption_id=%s vs %s", str(session.resumption_id), str(resumption_id)), 4)
+      tasmota.log(format("MTR: session.resumption_id=%s vs %s", str(session.resumption_id), str(resumption_id)), 4)
       if session.resumption_id == resumption_id && session.shared_secret != nil
-        # tasmota.log(string.format("MTR: session.shared_secret=%s", str(session.shared_secret)), 4)
+        # tasmota.log(format("MTR: session.shared_secret=%s", str(session.shared_secret)), 4)
         session.update()
         return session
       end
@@ -323,12 +322,10 @@ class Matter_Session_Store
     fabs = "[" + fabs.concat(",") + "]"
 
     try
-      import string
-
       var f = open(self._FABRICS, "w")
       f.write(fabs)
       f.close()
-      tasmota.log(string.format("MTR: =Saved     %i fabric(s) and %i session(s)", fabs_size, sessions_saved), 3)
+      tasmota.log(format("MTR: =Saved     %i fabric(s) and %i session(s)", fabs_size, sessions_saved), 3)
       self.device.event_fabrics_saved()     # signal event
     except .. as e, m
       tasmota.log("MTR: Session_Store::save Exception:" + str(e) + "|" + str(m), 2)
@@ -338,7 +335,6 @@ class Matter_Session_Store
   #############################################################
   # load fabrics and associated sessions
   def load_fabrics()
-    import string
     try
       self.sessions = matter.Expirable_list()        # remove any left-over
       self.fabrics = matter.Expirable_list()         # remove any left-over
@@ -373,7 +369,7 @@ class Matter_Session_Store
         self.fabrics.push(fabric)
       end
 
-      tasmota.log(string.format("MTR: Loaded %i fabric(s)", size(self.fabrics)), 2)
+      tasmota.log(format("MTR: Loaded %i fabric(s)", size(self.fabrics)), 2)
     except .. as e, m
       if e != "io_error"
         tasmota.log("MTR: Session_Store::load Exception:" + str(e) + "|" + str(m), 2)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_TCP_async.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_TCP_async.be
@@ -81,8 +81,7 @@ class Matter_TCP_async
       end
       return true
     else
-      import string
-      tasmota.log(string.format("BRY: failed to resolve [%s]:%i", self.addr, self.port), 3)
+      tasmota.log(format("BRY: failed to resolve [%s]:%i", self.addr, self.port), 3)
       self.close()
       self.status = -1
       self.tcp_connected = false

--- a/lib/libesp32/berry_matter/src/embedded/Matter_TLV.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_TLV.be
@@ -136,34 +136,33 @@ class Matter_TLV
     # We are trying to follow the official Matter way of printing TLV
     # Ex: '42U' or '1 = 42U' or '0xFFF1::0xDEED:0xAA55FEED = 42U'
     def tostring()
-      import string
       # var s = "<instance: Matter_TLV_item("
       var s = ""
       try       # any exception raised in `tostring()` causes a crash, so better catch it here
 
         if self.tag_profile == -1
           s += "Matter::"
-          if self.tag_number != nil   s += string.format("0x%08X ", self.tag_number) end
+          if self.tag_number != nil   s += format("0x%08X ", self.tag_number) end
         else
-          if self.tag_vendor != nil   s += string.format("0x%04X::", self.tag_vendor) end
-          if self.tag_profile != nil   s += string.format("0x%04X:", self.tag_profile) end
-          if self.tag_number != nil   s += string.format("0x%08X ", self.tag_number) end
-          if self.tag_sub != nil   s += string.format("%i ", self.tag_sub) end
+          if self.tag_vendor != nil   s += format("0x%04X::", self.tag_vendor) end
+          if self.tag_profile != nil   s += format("0x%04X:", self.tag_profile) end
+          if self.tag_number != nil   s += format("0x%08X ", self.tag_number) end
+          if self.tag_sub != nil   s += format("%i ", self.tag_sub) end
         end
 
         if size(s) > 0    s += "= " end
 
         # print value
-        if type(self.val) == 'int'        s += string.format("%i", self.val)
+        if type(self.val) == 'int'        s += format("%i", self.val)
           if self.typ >= self.TLV.U1 && self.typ <= self.TLV.U8   s += "U" end
         elif type(self.val) == 'bool'     s += self.val ? "true" : "false"
         elif self.val == nil              s += "null"
-        elif type(self.val) == 'real'     s += string.format("%g", self.val)
-        elif type(self.val) == 'string'   s += string.format('"%s"', self.val)
+        elif type(self.val) == 'real'     s += format("%g", self.val)
+        elif type(self.val) == 'string'   s += format('"%s"', self.val)
         elif isinstance(self.val, int64)  s += self.val.tostring()
           if self.typ >= self.TLV.U1 && self.typ <= self.TLV.U8   s += "U" end
         elif type(self.val) == 'instance'
-          s += string.format("%s", self.val.tohex())
+          s += format("%s", self.val.tohex())
         end
         
       except .. as e, m
@@ -572,18 +571,17 @@ class Matter_TLV
     end
 
     def tostring_inner(sorted, pre, post)
-      import string
       var s = ""
       try
 
         if self.tag_profile == -1
           s += "Matter::"
-          if self.tag_number != nil   s += string.format("0x%08X ", self.tag_number) end
+          if self.tag_number != nil   s += format("0x%08X ", self.tag_number) end
         else
-          if self.tag_vendor != nil   s += string.format("0x%04X::", self.tag_vendor) end
-          if self.tag_profile != nil   s += string.format("0x%04X:", self.tag_profile) end
-          if self.tag_number != nil   s += string.format("0x%08X ", self.tag_number) end
-          if self.tag_sub != nil   s += string.format("%i ", self.tag_sub) end
+          if self.tag_vendor != nil   s += format("0x%04X::", self.tag_vendor) end
+          if self.tag_profile != nil   s += format("0x%04X:", self.tag_profile) end
+          if self.tag_number != nil   s += format("0x%08X ", self.tag_number) end
+          if self.tag_sub != nil   s += format("%i ", self.tag_sub) end
         end
 
         if size(s) > 0    s += "= " end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UDPServer.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UDPServer.be
@@ -116,7 +116,6 @@ class Matter_UDPServer
   # avoid any starvation.
   # Then resend queued outgoing packets.
   def every_50ms()
-    import string
     var packet_read = 0
     if self.udp_socket == nil  return end
     var packet = self.udp_socket.read()
@@ -125,7 +124,7 @@ class Matter_UDPServer
       packet_read += 1
       var from_addr = self.udp_socket.remote_ip
       var from_port = self.udp_socket.remote_port
-      tasmota.log(string.format("MTR: UDP received from [%s]:%i", from_addr, from_port), 4)
+      tasmota.log(format("MTR: UDP received from [%s]:%i", from_addr, from_port), 4)
       if self.dispatch_cb
         self.dispatch_cb(packet, from_addr, from_port)
       end
@@ -144,12 +143,11 @@ class Matter_UDPServer
   #
   # Returns `true` if packet was successfully sent.
   def send(packet)
-    import string
     var ok = self.udp_socket.send(packet.addr ? packet.addr : self.udp_socket.remote_ip, packet.port ? packet.port : self.udp_socket.remote_port, packet.raw)
     if ok
-      tasmota.log(string.format("MTR: sending packet to '[%s]:%i'", packet.addr, packet.port), 4)
+      tasmota.log(format("MTR: sending packet to '[%s]:%i'", packet.addr, packet.port), 4)
     else
-      tasmota.log(string.format("MTR: error sending packet to '[%s]:%i'", packet.addr, packet.port), 3)
+      tasmota.log(format("MTR: error sending packet to '[%s]:%i'", packet.addr, packet.port), 3)
     end
     return ok
   end
@@ -175,9 +173,8 @@ class Matter_UDPServer
           packet.retries += 1
           idx += 1
         else
-          import string
           self.packets_sent.remove(idx)
-          tasmota.log(string.format("MTR: .          (%6i) Unacked packet '[%s]:%i' msg_id=%i", packet.session_id, packet.addr, packet.port, packet.msg_id), 3)
+          tasmota.log(format("MTR: .          (%6i) Unacked packet '[%s]:%i' msg_id=%i", packet.session_id, packet.addr, packet.port, packet.msg_id), 3)
         end
       else
         idx += 1

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -207,7 +207,6 @@ class Matter_UI
   #- ---------------------------------------------------------------------- -#
   def show_fabric_info()
     import webserver
-    import string
 
     webserver.content_send("<fieldset><legend><b>&nbsp;Fabrics&nbsp;</b></legend><p></p>"
                            "<p>Associated fabrics:</p>")
@@ -498,7 +497,7 @@ class Matter_UI
         webserver.content_send("<option value='' disabled>--- Tasmota Remote ---</option>")
       else
         var nam = self.device.get_plugin_class_displayname(typ)
-        webserver.content_send(string.format("<option value='%s'%s>%s</option>", typ, (typ == cur) ? " selected" : "", nam))
+        webserver.content_send(format("<option value='%s'%s>%s</option>", typ, (typ == cur) ? " selected" : "", nam))
       end
       i += 1
     end
@@ -510,7 +509,6 @@ class Matter_UI
   #######################################################################
   def page_part_mgr_adv()
     import webserver
-    import string
 
     if !webserver.check_privileged_access() return nil end
 
@@ -531,7 +529,6 @@ class Matter_UI
   #######################################################################
   def page_part_mgr()
     import webserver
-    import string
 
     if !webserver.check_privileged_access() return nil end
 
@@ -616,7 +613,6 @@ class Matter_UI
   #- ---------------------------------------------------------------------- -#
   def show_remote_autoconf(url)
     import webserver
-    import string
     import json
 
     if url == ''  return end
@@ -635,7 +631,7 @@ class Matter_UI
     end
     
     if status8 != nil && status11 != nil
-      tasmota.log(string.format("MTR: probed '%s' status8=%s satus11=%s", url, str(status8), str(status11)), 3)
+      tasmota.log(format("MTR: probed '%s' status8=%s satus11=%s", url, str(status8), str(status11)), 3)
 
       var config_list = self.generate_config_from_status(status8, status11)
 
@@ -644,7 +640,7 @@ class Matter_UI
       webserver.content_send("<fieldset><legend><b>&nbsp;Matter Remote Device&nbsp;</b></legend><p></p>"
                              "<p><b>Add Remote sensor or device</b></p>")
 
-      webserver.content_send(string.format("<p>&#x1F517; <a target='_blank' href=\"http://%s/?\">%s</a></p>", webserver.html_escape(url), webserver.html_escape(url)))
+      webserver.content_send(format("<p>&#x1F517; <a target='_blank' href=\"http://%s/?\">%s</a></p>", webserver.html_escape(url), webserver.html_escape(url)))
 
       # Add new endpoint section
       webserver.content_send("<form action='/matterc' method='post'>"
@@ -655,7 +651,7 @@ class Matter_UI
                              "<td style='font-size:smaller;'>Parameter</td>"
                              "</tr>")
 
-      webserver.content_send(string.format("<input name='url' type='hidden' value='%s'>", webserver.html_escape(url)))
+      webserver.content_send(format("<input name='url' type='hidden' value='%s'>", webserver.html_escape(url)))
 
       var i = 0
       while i < size(config_list)
@@ -669,23 +665,23 @@ class Matter_UI
           arg = cl.ui_conf_to_string(cl, config)
         end
 
-        webserver.content_send(string.format("<tr><td style='font-size:smaller;'><input type='text' name='nam%i' size='1' value='' placeholder='(optional)'></td>", i))
-        webserver.content_send(string.format("<td style='font-size:smaller;'><select name='pi%i' onchange='otm(\"arg%i\",this.value)'>", i, i))
+        webserver.content_send(format("<tr><td style='font-size:smaller;'><input type='text' name='nam%i' size='1' value='' placeholder='(optional)'></td>", i))
+        webserver.content_send(format("<td style='font-size:smaller;'><select name='pi%i' onchange='otm(\"arg%i\",this.value)'>", i, i))
         self.plugin_option(typ, self._CLASSES_TYPES2)
         webserver.content_send("</select></td>"
                                "<td style='font-size:smaller;'>")
-        webserver.content_send(string.format("<input type='text' id='arg%i' name='arg%i' size='1' value='%s' placeholder='%s'>",
+        webserver.content_send(format("<input type='text' id='arg%i' name='arg%i' size='1' value='%s' placeholder='%s'>",
                                i, i, webserver.html_escape(arg), cl ? webserver.html_escape(cl.ARG_HINT) : ''))
         webserver.content_send("</td></tr>")
         i += 1
       end
       # empty line for new endpoint
-      webserver.content_send(string.format("<tr><td style='font-size:smaller;'><input type='text' name='nam%i' size='1' value='' placeholder='(optional)'></td>", i))
-      webserver.content_send(string.format("<td style='font-size:smaller;'><select name='pi%i' onchange='otm(\"arg%i\",this.value)'>", i, i))
+      webserver.content_send(format("<tr><td style='font-size:smaller;'><input type='text' name='nam%i' size='1' value='' placeholder='(optional)'></td>", i))
+      webserver.content_send(format("<td style='font-size:smaller;'><select name='pi%i' onchange='otm(\"arg%i\",this.value)'>", i, i))
       self.plugin_option('', self._CLASSES_TYPES2)
       webserver.content_send("</select></td>"
                              "<td style='font-size:smaller;'>")
-      webserver.content_send(string.format("<input type='text' id='arg%i' name='arg%i' size='1' value='%s'>",
+      webserver.content_send(format("<input type='text' id='arg%i' name='arg%i' size='1' value='%s'>",
                              i, i, ''))
       webserver.content_send("</td></tr>")
 
@@ -699,7 +695,7 @@ class Matter_UI
       webserver.content_send("</form></fieldset>")
 
     else
-      webserver.content_send(string.format("<p><b>Unable to connect to '%s'</b></p>", webserver.html_escape(url)))
+      webserver.content_send(format("<p><b>Unable to connect to '%s'</b></p>", webserver.html_escape(url)))
     end
 
 
@@ -710,7 +706,6 @@ class Matter_UI
   #######################################################################
   def page_part_mgr_add()
     import webserver
-    import string
 
     if !webserver.check_privileged_access() return nil end
 
@@ -743,14 +738,14 @@ class Matter_UI
 
       # debug information about parameters
       for i:0..webserver.arg_size()-1
-        tasmota.log(string.format("MTR: Arg%i '%s' = '%s'", i, webserver.arg_name(i), webserver.arg(i)))
+        tasmota.log(format("MTR: Arg%i '%s' = '%s'", i, webserver.arg_name(i), webserver.arg(i)))
       end
 
       #---------------------------------------------------------------------#
       # Change Passcode and/or Passcode
       #---------------------------------------------------------------------#
       if webserver.has_arg("passcode") || webserver.has_arg("discriminator")
-        tasmota.log(string.format("MTR: /matterc received '%s' command", 'passcode'), 3)
+        tasmota.log(format("MTR: /matterc received '%s' command", 'passcode'), 3)
         if webserver.has_arg("passcode")
           self.device.root_passcode = int(webserver.arg("passcode"))
         end
@@ -769,10 +764,10 @@ class Matter_UI
 
         if matter_enabled_requested != self.matter_enabled()
           if matter_enabled_requested
-            tasmota.log(string.format("MTR: /matterc received '%s' command", 'enable'), 3)
+            tasmota.log(format("MTR: /matterc received '%s' command", 'enable'), 3)
             tasmota.cmd("SetOption" + str(matter.MATTER_OPTION) + " 1")
           else
-            tasmota.log(string.format("MTR: /matterc received '%s' command", 'disable'), 3)
+            tasmota.log(format("MTR: /matterc received '%s' command", 'disable'), 3)
             tasmota.cmd("SetOption" + str(matter.MATTER_OPTION) + " 0")
           end
           #- and force restart -#
@@ -794,7 +789,7 @@ class Matter_UI
       # Delete Fabric
       #---------------------------------------------------------------------#
       elif webserver.has_arg("del_fabric")
-        tasmota.log(string.format("MTR: /matterc received '%s' command", 'del_fabric'), 3)
+        tasmota.log(format("MTR: /matterc received '%s' command", 'del_fabric'), 3)
         var del_fabric = int(webserver.arg("del_fabric"))
         var idx = 0
         var fabrics = self.device.sessions.fabrics
@@ -813,7 +808,7 @@ class Matter_UI
       # Reset to default auto-configuration
       #---------------------------------------------------------------------#
       elif webserver.has_arg("auto")
-        tasmota.log(string.format("MTR: /matterc received '%s' command", 'auto'), 3)
+        tasmota.log(format("MTR: /matterc received '%s' command", 'auto'), 3)
         self.device.plugins_persist = false
         self.device.save_param()
         #- and force restart -#
@@ -823,7 +818,7 @@ class Matter_UI
       # Apply new configuration template
       #---------------------------------------------------------------------#
       elif webserver.has_arg("config")
-        tasmota.log(string.format("MTR: /matterc received '%s' command", 'config'), 3)
+        tasmota.log(format("MTR: /matterc received '%s' command", 'config'), 3)
         var needs_saving = false
         # iterate by endpoint number
         for i:0..webserver.arg_size()-1
@@ -837,25 +832,25 @@ class Matter_UI
             if conf_ep != nil     # found
               var typ_class = self.device.plugins_classes.find(conf_ep.find('type', ''))
               if typ_class != nil
-                tasmota.log(string.format("MTR: ep=%i arg=%s", arg_ep, arg), 3)
+                tasmota.log(format("MTR: ep=%i arg=%s", arg_ep, arg), 3)
                 # compute the actual value
                 var prev_arg = typ_class.ui_conf_to_string(typ_class, conf_ep)
                 var changed = (prev_arg != arg)
-                tasmota.log(string.format("MTR: ep=%i prev_arg='%s' arg='%s' %s", arg_ep, prev_arg, arg, prev_arg != arg ? "changed" : ""), 3)
+                tasmota.log(format("MTR: ep=%i prev_arg='%s' arg='%s' %s", arg_ep, prev_arg, arg, prev_arg != arg ? "changed" : ""), 3)
 
                 if changed
                   needs_saving = true
                   typ_class.ui_string_to_conf(typ_class, conf_ep, arg)
                   var pl = self.device.find_plugin_by_endpoint(arg_ep)
                   if pl
-                    tasmota.log(string.format("MTR: apply conf '%s' (%i) to %s", conf_ep, arg_ep, pl), 3)
+                    tasmota.log(format("MTR: apply conf '%s' (%i) to %s", conf_ep, arg_ep, pl), 3)
                     pl.parse_configuration(conf_ep)
                   end
                 end
 
               end
             else            
-              tasmota.log(string.format("MTR: ep=%i not found", arg_ep), 3)
+              tasmota.log(format("MTR: ep=%i not found", arg_ep), 3)
             end
           elif string.find(arg_name, "nam") == 0    # 'nam<i>' with i being the endpoint
             var nam_ep = int(arg_name[3..])         # target endpoint as int
@@ -877,7 +872,7 @@ class Matter_UI
                   else
                     conf_ep.remove('name')
                   end
-                  tasmota.log(string.format("MTR: apply name '%s' (%i) to %s", conf_ep, nam_ep, pl), 3)
+                  tasmota.log(format("MTR: apply name '%s' (%i) to %s", conf_ep, nam_ep, pl), 3)
                   pl.parse_configuration(conf_ep)
                 end
               end
@@ -885,10 +880,10 @@ class Matter_UI
           end
         end
 
-        tasmota.log(string.format("MTR: config = %s", str(self.device.plugins_config)), 3)
+        tasmota.log(format("MTR: config = %s", str(self.device.plugins_config)), 3)
 
         if error
-          tasmota.log(string.format("MTR: config error = %s", error), 3)
+          tasmota.log(format("MTR: config error = %s", error), 3)
         else
           if needs_saving || !self.device.plugins_persist
             self.device.plugins_persist = true
@@ -904,7 +899,7 @@ class Matter_UI
         var typ = webserver.arg('pi')
         var arg = webserver.arg('arg')
         var nam = webserver.arg('nam')
-        tasmota.log(string.format("MTR: add endpoint typ='%s' arg='%s'", typ, arg), 3)
+        tasmota.log(format("MTR: add endpoint typ='%s' arg='%s'", typ, arg), 3)
 
         # check if type exists
         var typ_class = self.device.plugins_classes.find(typ)
@@ -944,12 +939,12 @@ class Matter_UI
               # check if configuration is already present
               var duplicate = false
               for c: self.device.plugins_config   # iterate on values, not on keys()
-                # tasmota.log(string.format("MTR: map_compare '%s' ?= '%s' -> %s", str(c), str(config), str(self.equal_map(c,config))), 3)
+                # tasmota.log(format("MTR: map_compare '%s' ?= '%s' -> %s", str(c), str(config), str(self.equal_map(c,config))), 3)
                 if self.equal_map(c,config)   duplicate = true  break   end
               end
               # not a duplicate, add it
               if !duplicate
-                tasmota.log(string.format("MTR: remote add url='%s' type='%s' arg='%s'", url, typ, arg), 3)
+                tasmota.log(format("MTR: remote add url='%s' type='%s' arg='%s'", url, typ, arg), 3)
                 self.device.bridge_add_endpoint(typ, config)
               end
             end
@@ -984,18 +979,18 @@ class Matter_UI
       if error
         webserver.content_start("Parameter error")           #- title of the web page -#
         webserver.content_send_style()                  #- send standard Tasmota styles -#
-        webserver.content_send(string.format("<p style='width:340px;'><b>Error:</b>%s</p>", webserver.html_escape(error)))
+        webserver.content_send(format("<p style='width:340px;'><b>Error:</b>%s</p>", webserver.html_escape(error)))
         webserver.content_button(webserver.BUTTON_CONFIGURATION) #- button back to configuration page -#
         webserver.content_stop()                        #- end of web page -#
       end
 
     except .. as e, m
-      tasmota.log(string.format("BRY: Exception> '%s' - %s", e, m), 2)
+      tasmota.log(format("BRY: Exception> '%s' - %s", e, m), 2)
       #- display error page -#
       webserver.content_start("Parameter error")           #- title of the web page -#
       webserver.content_send_style()                  #- send standard Tasmota styles -#
 
-      webserver.content_send(string.format("<p style='width:340px;'><b>Exception:</b><br>'%s'<br>%s</p>", e, m))
+      webserver.content_send(format("<p style='width:340px;'><b>Exception:</b><br>'%s'<br>%s</p>", e, m))
 
       webserver.content_button(webserver.BUTTON_CONFIGURATION) #- button back to configuration page -#
       webserver.content_stop()                        #- end of web page -#
@@ -1007,7 +1002,6 @@ class Matter_UI
   #######################################################################
   def show_bridge_status()
     import webserver
-    import string
     var bridge_plugin_by_host
     
     var idx = 0
@@ -1034,7 +1028,7 @@ class Matter_UI
 
     for host: self.device.k2l(bridge_plugin_by_host)
       var host_html = webserver.html_escape(host)
-      webserver.content_send(string.format("<tr class='ztdm htrm'><td>&#x1F517; <a target='_blank' title='http://%s/' href=\"http://%s/?\"'>%s</a></td>", host_html, host_html, host_html))
+      webserver.content_send(format("<tr class='ztdm htrm'><td>&#x1F517; <a target='_blank' title='http://%s/' href=\"http://%s/?\"'>%s</a></td>", host_html, host_html, host_html))
       var http_remote = bridge_plugin_by_host[host][0].http_remote    # get the http_remote object from the first in list
       webserver.content_send(http_remote.web_last_seen())
 
@@ -1053,17 +1047,16 @@ class Matter_UI
   #- display sensor value in the web UI -#
   def web_sensor()
     import webserver
-    import string
 
     if self.matter_enabled()
 
       # mtc0 = close, mtc1 = open commissioning
       var fabrics_count = self.device.sessions.count_active_fabrics()
       if fabrics_count == 0
-        webserver.content_send(string.format("<div style='text-align:right;font-size:11px;color:#aaa;padding:0px;'>%s</div>", "Matter: No active association"))
+        webserver.content_send(format("<div style='text-align:right;font-size:11px;color:#aaa;padding:0px;'>%s</div>", "Matter: No active association"))
       else
         var plural = fabrics_count > 1
-        webserver.content_send(string.format("<div style='text-align:right;font-size:11px;color:#aaa;padding:0px;'>%s</div>", "Matter: " + str(fabrics_count) + " active association" + (plural ? "s" : "")))
+        webserver.content_send(format("<div style='text-align:right;font-size:11px;color:#aaa;padding:0px;'>%s</div>", "Matter: " + str(fabrics_count) + " active association" + (plural ? "s" : "")))
       end
 
       self.show_bridge_status()

--- a/lib/libesp32/berry_matter/src/embedded/Matter_inspect.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_inspect.be
@@ -52,7 +52,6 @@ matter.jitter = jitter
 # debug function
 def inspect(p)
   try
-    import string
     import introspect
 
     var keys = []
@@ -66,7 +65,7 @@ def inspect(p)
     for k : keys
       var v = introspect.get(p, k)
       # if type(v) == 'string'    v = string.escape(v, true) end
-      r.push(string.format("'%s': %s", str(k), str(v)))
+      r.push(format("'%s': %s", str(k), str(v)))
     end
 
     return "{" + r.concat(", ") + "}"

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Base38.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Base38.h
@@ -19,7 +19,7 @@ be_local_closure(Matter_Base38_encode,   /* name */
     1,                          /* has sup protos */
     ( &(const struct bproto*[ 1]) {
       be_nested_proto(
-        7,                          /* nstack */
+        6,                          /* nstack */
         2,                          /* argc */
         0,                          /* varg */
         0,                          /* has upvals */
@@ -27,31 +27,29 @@ be_local_closure(Matter_Base38_encode,   /* name */
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(string),
-        /* K1   */  be_nested_str_weak(0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_X2D_X2E),
-        /* K2   */  be_const_int(0),
-        /* K3   */  be_nested_str_weak(),
-        /* K4   */  be_const_int(1),
+        ( &(const bvalue[ 4]) {     /* constants */
+        /* K0   */  be_nested_str_weak(0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_X2D_X2E),
+        /* K1   */  be_const_int(0),
+        /* K2   */  be_nested_str_weak(),
+        /* K3   */  be_const_int(1),
         }),
         be_str_weak(b38_enc),
         &be_const_str_solidified,
-        ( &(const binstruction[15]) {  /* code */
-          0xA40A0000,  //  0000  IMPORT	R2	K0
+        ( &(const binstruction[14]) {  /* code */
+          0x58080000,  //  0000  LDCONST	R2	K0
           0x580C0001,  //  0001  LDCONST	R3	K1
           0x58100002,  //  0002  LDCONST	R4	K2
-          0x58140003,  //  0003  LDCONST	R5	K3
-          0x14180801,  //  0004  LT	R6	R4	R1
-          0x781A0007,  //  0005  JMPF	R6	#000E
-          0x541A0025,  //  0006  LDINT	R6	38
-          0x10180006,  //  0007  MOD	R6	R0	R6
-          0x94180606,  //  0008  GETIDX	R6	R3	R6
-          0x00140A06,  //  0009  ADD	R5	R5	R6
-          0x541A0025,  //  000A  LDINT	R6	38
-          0x0C000006,  //  000B  DIV	R0	R0	R6
-          0x00100904,  //  000C  ADD	R4	R4	K4
-          0x7001FFF5,  //  000D  JMP		#0004
-          0x80040A00,  //  000E  RET	1	R5
+          0x14140601,  //  0003  LT	R5	R3	R1
+          0x78160007,  //  0004  JMPF	R5	#000D
+          0x54160025,  //  0005  LDINT	R5	38
+          0x10140005,  //  0006  MOD	R5	R0	R5
+          0x94140405,  //  0007  GETIDX	R5	R2	R5
+          0x00100805,  //  0008  ADD	R4	R4	R5
+          0x54160025,  //  0009  LDINT	R5	38
+          0x0C000005,  //  000A  DIV	R0	R0	R5
+          0x000C0703,  //  000B  ADD	R3	R3	K3
+          0x7001FFF5,  //  000C  JMP		#0003
+          0x80040800,  //  000D  RET	1	R4
         })
       ),
     }),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
@@ -195,7 +195,7 @@ be_local_closure(Matter_Commisioning_Context_every_second,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Commisioning_Context_add_session,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    12,                          /* nstack */
     6,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -203,42 +203,39 @@ be_local_closure(Matter_Commisioning_Context_add_session,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20add_session_X20local_session_id_X3D_X25i_X20initiator_session_id_X3D_X25i),
-    /* K5   */  be_nested_str_weak(device),
-    /* K6   */  be_nested_str_weak(sessions),
-    /* K7   */  be_nested_str_weak(create_session),
-    /* K8   */  be_nested_str_weak(set_keys),
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20add_session_X20local_session_id_X3D_X25i_X20initiator_session_id_X3D_X25i),
+    /* K3   */  be_nested_str_weak(device),
+    /* K4   */  be_nested_str_weak(sessions),
+    /* K5   */  be_nested_str_weak(create_session),
+    /* K6   */  be_nested_str_weak(set_keys),
     }),
     be_str_weak(add_session),
     &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0xA41A0000,  //  0000  IMPORT	R6	K0
-      0xB81E0200,  //  0001  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0002  GETMET	R7	R7	K2
-      0x8C240D03,  //  0003  GETMET	R9	R6	K3
-      0x582C0004,  //  0004  LDCONST	R11	K4
-      0x5C300200,  //  0005  MOVE	R12	R1
-      0x5C340400,  //  0006  MOVE	R13	R2
-      0x7C240800,  //  0007  CALL	R9	4
-      0x542A0003,  //  0008  LDINT	R10	4
-      0x7C1C0600,  //  0009  CALL	R7	3
-      0x881C0105,  //  000A  GETMBR	R7	R0	K5
-      0x881C0F06,  //  000B  GETMBR	R7	R7	K6
-      0x8C1C0F07,  //  000C  GETMET	R7	R7	K7
-      0x5C240200,  //  000D  MOVE	R9	R1
-      0x5C280400,  //  000E  MOVE	R10	R2
-      0x7C1C0600,  //  000F  CALL	R7	3
-      0x8C200F08,  //  0010  GETMET	R8	R7	K8
-      0x5C280600,  //  0011  MOVE	R10	R3
-      0x5C2C0800,  //  0012  MOVE	R11	R4
-      0x5C300A00,  //  0013  MOVE	R12	R5
-      0x7C200800,  //  0014  CALL	R8	4
-      0x80000000,  //  0015  RET	0
+    ( &(const binstruction[21]) {  /* code */
+      0xB81A0000,  //  0000  GETNGBL	R6	K0
+      0x8C180D01,  //  0001  GETMET	R6	R6	K1
+      0x60200018,  //  0002  GETGBL	R8	G24
+      0x58240002,  //  0003  LDCONST	R9	K2
+      0x5C280200,  //  0004  MOVE	R10	R1
+      0x5C2C0400,  //  0005  MOVE	R11	R2
+      0x7C200600,  //  0006  CALL	R8	3
+      0x54260003,  //  0007  LDINT	R9	4
+      0x7C180600,  //  0008  CALL	R6	3
+      0x88180103,  //  0009  GETMBR	R6	R0	K3
+      0x88180D04,  //  000A  GETMBR	R6	R6	K4
+      0x8C180D05,  //  000B  GETMET	R6	R6	K5
+      0x5C200200,  //  000C  MOVE	R8	R1
+      0x5C240400,  //  000D  MOVE	R9	R2
+      0x7C180600,  //  000E  CALL	R6	3
+      0x8C1C0D06,  //  000F  GETMET	R7	R6	K6
+      0x5C240600,  //  0010  MOVE	R9	R3
+      0x5C280800,  //  0011  MOVE	R10	R4
+      0x5C2C0A00,  //  0012  MOVE	R11	R5
+      0x7C1C0800,  //  0013  CALL	R7	4
+      0x80000000,  //  0014  RET	0
     })
   )
 );
@@ -250,7 +247,7 @@ be_local_closure(Matter_Commisioning_Context_add_session,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Commisioning_Context_parse_PBKDFParamRequest,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    12,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -258,180 +255,177 @@ be_local_closure(Matter_Commisioning_Context_parse_PBKDFParamRequest,   /* name 
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[50]) {     /* constants */
+    ( &(const bvalue[48]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(session),
-    /* K3   */  be_nested_str_weak(opcode),
-    /* K4   */  be_nested_str_weak(local_session_id),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(protocol_id),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20invalid_X20PBKDFParamRequest_X20message),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(send_status_report),
-    /* K14  */  be_const_int(1),
-    /* K15  */  be_nested_str_weak(matter),
-    /* K16  */  be_nested_str_weak(PBKDFParamRequest),
-    /* K17  */  be_nested_str_weak(parse),
-    /* K18  */  be_nested_str_weak(raw),
-    /* K19  */  be_nested_str_weak(app_payload_idx),
-    /* K20  */  be_nested_str_weak(set_mode_PASE),
-    /* K21  */  be_nested_str_weak(__Msg1),
-    /* K22  */  be_const_int(2147483647),
-    /* K23  */  be_nested_str_weak(passcodeId),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20non_X2Dzero_X20passcode_X20id),
-    /* K25  */  be_nested_str_weak(__future_initiator_session_id),
-    /* K26  */  be_nested_str_weak(initiator_session_id),
-    /* K27  */  be_nested_str_weak(__future_local_session_id),
-    /* K28  */  be_nested_str_weak(device),
-    /* K29  */  be_nested_str_weak(sessions),
-    /* K30  */  be_nested_str_weak(gen_local_session_id),
-    /* K31  */  be_nested_str_weak(format),
-    /* K32  */  be_nested_str_weak(MTR_X3A_X20New_Session_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-    /* K33  */  be_nested_str_weak(remote_ip),
-    /* K34  */  be_nested_str_weak(remote_port),
-    /* K35  */  be_nested_str_weak(PBKDFParamResponse),
-    /* K36  */  be_nested_str_weak(initiatorRandom),
-    /* K37  */  be_nested_str_weak(responderRandom),
-    /* K38  */  be_nested_str_weak(random),
-    /* K39  */  be_nested_str_weak(responderSessionId),
-    /* K40  */  be_nested_str_weak(pbkdf_parameters_salt),
-    /* K41  */  be_nested_str_weak(commissioning_salt),
-    /* K42  */  be_nested_str_weak(pbkdf_parameters_iterations),
-    /* K43  */  be_nested_str_weak(commissioning_iterations),
-    /* K44  */  be_nested_str_weak(tlv2raw),
-    /* K45  */  be_nested_str_weak(__Msg2),
-    /* K46  */  be_nested_str_weak(build_response),
-    /* K47  */  be_nested_str_weak(encode_frame),
-    /* K48  */  be_nested_str_weak(responder),
-    /* K49  */  be_nested_str_weak(send_response_frame),
+    /* K1   */  be_nested_str_weak(session),
+    /* K2   */  be_nested_str_weak(opcode),
+    /* K3   */  be_nested_str_weak(local_session_id),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(protocol_id),
+    /* K6   */  be_nested_str_weak(tasmota),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20invalid_X20PBKDFParamRequest_X20message),
+    /* K9   */  be_const_int(2),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(send_status_report),
+    /* K13  */  be_const_int(1),
+    /* K14  */  be_nested_str_weak(matter),
+    /* K15  */  be_nested_str_weak(PBKDFParamRequest),
+    /* K16  */  be_nested_str_weak(parse),
+    /* K17  */  be_nested_str_weak(raw),
+    /* K18  */  be_nested_str_weak(app_payload_idx),
+    /* K19  */  be_nested_str_weak(set_mode_PASE),
+    /* K20  */  be_nested_str_weak(__Msg1),
+    /* K21  */  be_const_int(2147483647),
+    /* K22  */  be_nested_str_weak(passcodeId),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20non_X2Dzero_X20passcode_X20id),
+    /* K24  */  be_nested_str_weak(__future_initiator_session_id),
+    /* K25  */  be_nested_str_weak(initiator_session_id),
+    /* K26  */  be_nested_str_weak(__future_local_session_id),
+    /* K27  */  be_nested_str_weak(device),
+    /* K28  */  be_nested_str_weak(sessions),
+    /* K29  */  be_nested_str_weak(gen_local_session_id),
+    /* K30  */  be_nested_str_weak(MTR_X3A_X20New_Session_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+    /* K31  */  be_nested_str_weak(remote_ip),
+    /* K32  */  be_nested_str_weak(remote_port),
+    /* K33  */  be_nested_str_weak(PBKDFParamResponse),
+    /* K34  */  be_nested_str_weak(initiatorRandom),
+    /* K35  */  be_nested_str_weak(responderRandom),
+    /* K36  */  be_nested_str_weak(random),
+    /* K37  */  be_nested_str_weak(responderSessionId),
+    /* K38  */  be_nested_str_weak(pbkdf_parameters_salt),
+    /* K39  */  be_nested_str_weak(commissioning_salt),
+    /* K40  */  be_nested_str_weak(pbkdf_parameters_iterations),
+    /* K41  */  be_nested_str_weak(commissioning_iterations),
+    /* K42  */  be_nested_str_weak(tlv2raw),
+    /* K43  */  be_nested_str_weak(__Msg2),
+    /* K44  */  be_nested_str_weak(build_response),
+    /* K45  */  be_nested_str_weak(encode_frame),
+    /* K46  */  be_nested_str_weak(responder),
+    /* K47  */  be_nested_str_weak(send_response_frame),
     }),
     be_str_weak(parse_PBKDFParamRequest),
     &be_const_str_solidified,
-    ( &(const binstruction[119]) {  /* code */
+    ( &(const binstruction[118]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0x880C0301,  //  0001  GETMBR	R3	R1	K1
       0x88100302,  //  0002  GETMBR	R4	R1	K2
-      0x88140303,  //  0003  GETMBR	R5	R1	K3
-      0x541A001F,  //  0004  LDINT	R6	32
-      0x20140A06,  //  0005  NE	R5	R5	R6
-      0x74160005,  //  0006  JMPT	R5	#000D
-      0x88140304,  //  0007  GETMBR	R5	R1	K4
-      0x20140B05,  //  0008  NE	R5	R5	K5
-      0x74160002,  //  0009  JMPT	R5	#000D
-      0x88140306,  //  000A  GETMBR	R5	R1	K6
-      0x20140B05,  //  000B  NE	R5	R5	K5
-      0x78160012,  //  000C  JMPF	R5	#0020
-      0xB8160E00,  //  000D  GETNGBL	R5	K7
-      0x8C140B08,  //  000E  GETMET	R5	R5	K8
+      0x5416001F,  //  0003  LDINT	R5	32
+      0x20100805,  //  0004  NE	R4	R4	R5
+      0x74120005,  //  0005  JMPT	R4	#000C
+      0x88100303,  //  0006  GETMBR	R4	R1	K3
+      0x20100904,  //  0007  NE	R4	R4	K4
+      0x74120002,  //  0008  JMPT	R4	#000C
+      0x88100305,  //  0009  GETMBR	R4	R1	K5
+      0x20100904,  //  000A  NE	R4	R4	K4
+      0x78120012,  //  000B  JMPF	R4	#001F
+      0xB8120C00,  //  000C  GETNGBL	R4	K6
+      0x8C100907,  //  000D  GETMET	R4	R4	K7
+      0x58180008,  //  000E  LDCONST	R6	K8
       0x581C0009,  //  000F  LDCONST	R7	K9
-      0x5820000A,  //  0010  LDCONST	R8	K10
-      0x7C140600,  //  0011  CALL	R5	3
-      0xB8160E00,  //  0012  GETNGBL	R5	K7
-      0x8C140B08,  //  0013  GETMET	R5	R5	K8
+      0x7C100600,  //  0010  CALL	R4	3
+      0xB8120C00,  //  0011  GETNGBL	R4	K6
+      0x8C100907,  //  0012  GETMET	R4	R4	K7
+      0x5818000A,  //  0013  LDCONST	R6	K10
       0x581C000B,  //  0014  LDCONST	R7	K11
-      0x5820000C,  //  0015  LDCONST	R8	K12
-      0x7C140600,  //  0016  CALL	R5	3
-      0x8C14010D,  //  0017  GETMET	R5	R0	K13
-      0x5C1C0200,  //  0018  MOVE	R7	R1
-      0x5820000E,  //  0019  LDCONST	R8	K14
-      0x58240005,  //  001A  LDCONST	R9	K5
-      0x5828000A,  //  001B  LDCONST	R10	K10
-      0x502C0000,  //  001C  LDBOOL	R11	0	0
-      0x7C140C00,  //  001D  CALL	R5	6
-      0x50140000,  //  001E  LDBOOL	R5	0	0
-      0x80040A00,  //  001F  RET	1	R5
-      0xB8161E00,  //  0020  GETNGBL	R5	K15
-      0x8C140B10,  //  0021  GETMET	R5	R5	K16
-      0x7C140200,  //  0022  CALL	R5	1
-      0x8C140B11,  //  0023  GETMET	R5	R5	K17
+      0x7C100600,  //  0015  CALL	R4	3
+      0x8C10010C,  //  0016  GETMET	R4	R0	K12
+      0x5C180200,  //  0017  MOVE	R6	R1
+      0x581C000D,  //  0018  LDCONST	R7	K13
+      0x58200004,  //  0019  LDCONST	R8	K4
+      0x58240009,  //  001A  LDCONST	R9	K9
+      0x50280000,  //  001B  LDBOOL	R10	0	0
+      0x7C100C00,  //  001C  CALL	R4	6
+      0x50100000,  //  001D  LDBOOL	R4	0	0
+      0x80040800,  //  001E  RET	1	R4
+      0xB8121C00,  //  001F  GETNGBL	R4	K14
+      0x8C10090F,  //  0020  GETMET	R4	R4	K15
+      0x7C100200,  //  0021  CALL	R4	1
+      0x8C100910,  //  0022  GETMET	R4	R4	K16
+      0x88180311,  //  0023  GETMBR	R6	R1	K17
       0x881C0312,  //  0024  GETMBR	R7	R1	K18
-      0x88200313,  //  0025  GETMBR	R8	R1	K19
-      0x7C140600,  //  0026  CALL	R5	3
-      0x88180302,  //  0027  GETMBR	R6	R1	K2
-      0x8C180D14,  //  0028  GETMET	R6	R6	K20
-      0x7C180200,  //  0029  CALL	R6	1
-      0x88180313,  //  002A  GETMBR	R6	R1	K19
-      0x40180D16,  //  002B  CONNECT	R6	R6	K22
-      0x881C0312,  //  002C  GETMBR	R7	R1	K18
-      0x94180E06,  //  002D  GETIDX	R6	R7	R6
-      0x90122A06,  //  002E  SETMBR	R4	K21	R6
-      0x88180B17,  //  002F  GETMBR	R6	R5	K23
-      0x20180D05,  //  0030  NE	R6	R6	K5
-      0x781A0012,  //  0031  JMPF	R6	#0045
-      0xB81A0E00,  //  0032  GETNGBL	R6	K7
-      0x8C180D08,  //  0033  GETMET	R6	R6	K8
-      0x58200018,  //  0034  LDCONST	R8	K24
-      0x5824000A,  //  0035  LDCONST	R9	K10
-      0x7C180600,  //  0036  CALL	R6	3
-      0xB81A0E00,  //  0037  GETNGBL	R6	K7
-      0x8C180D08,  //  0038  GETMET	R6	R6	K8
+      0x7C100600,  //  0025  CALL	R4	3
+      0x88140301,  //  0026  GETMBR	R5	R1	K1
+      0x8C140B13,  //  0027  GETMET	R5	R5	K19
+      0x7C140200,  //  0028  CALL	R5	1
+      0x88140312,  //  0029  GETMBR	R5	R1	K18
+      0x40140B15,  //  002A  CONNECT	R5	R5	K21
+      0x88180311,  //  002B  GETMBR	R6	R1	K17
+      0x94140C05,  //  002C  GETIDX	R5	R6	R5
+      0x900E2805,  //  002D  SETMBR	R3	K20	R5
+      0x88140916,  //  002E  GETMBR	R5	R4	K22
+      0x20140B04,  //  002F  NE	R5	R5	K4
+      0x78160012,  //  0030  JMPF	R5	#0044
+      0xB8160C00,  //  0031  GETNGBL	R5	K6
+      0x8C140B07,  //  0032  GETMET	R5	R5	K7
+      0x581C0017,  //  0033  LDCONST	R7	K23
+      0x58200009,  //  0034  LDCONST	R8	K9
+      0x7C140600,  //  0035  CALL	R5	3
+      0xB8160C00,  //  0036  GETNGBL	R5	K6
+      0x8C140B07,  //  0037  GETMET	R5	R5	K7
+      0x581C000A,  //  0038  LDCONST	R7	K10
       0x5820000B,  //  0039  LDCONST	R8	K11
-      0x5824000C,  //  003A  LDCONST	R9	K12
-      0x7C180600,  //  003B  CALL	R6	3
-      0x8C18010D,  //  003C  GETMET	R6	R0	K13
-      0x5C200200,  //  003D  MOVE	R8	R1
-      0x5824000E,  //  003E  LDCONST	R9	K14
-      0x58280005,  //  003F  LDCONST	R10	K5
-      0x582C000A,  //  0040  LDCONST	R11	K10
-      0x50300000,  //  0041  LDBOOL	R12	0	0
-      0x7C180C00,  //  0042  CALL	R6	6
-      0x50180000,  //  0043  LDBOOL	R6	0	0
-      0x80040C00,  //  0044  RET	1	R6
-      0x88180B1A,  //  0045  GETMBR	R6	R5	K26
-      0x90123206,  //  0046  SETMBR	R4	K25	R6
-      0x8818011C,  //  0047  GETMBR	R6	R0	K28
-      0x88180D1D,  //  0048  GETMBR	R6	R6	K29
-      0x8C180D1E,  //  0049  GETMET	R6	R6	K30
-      0x7C180200,  //  004A  CALL	R6	1
-      0x90123606,  //  004B  SETMBR	R4	K27	R6
-      0xB81A0E00,  //  004C  GETNGBL	R6	K7
-      0x8C180D08,  //  004D  GETMET	R6	R6	K8
-      0x8C20071F,  //  004E  GETMET	R8	R3	K31
-      0x58280020,  //  004F  LDCONST	R10	K32
-      0x882C091B,  //  0050  GETMBR	R11	R4	K27
-      0x88300321,  //  0051  GETMBR	R12	R1	K33
-      0x88340322,  //  0052  GETMBR	R13	R1	K34
-      0x7C200A00,  //  0053  CALL	R8	5
-      0x5824000C,  //  0054  LDCONST	R9	K12
-      0x7C180600,  //  0055  CALL	R6	3
-      0xB81A1E00,  //  0056  GETNGBL	R6	K15
-      0x8C180D23,  //  0057  GETMET	R6	R6	K35
-      0x7C180200,  //  0058  CALL	R6	1
-      0x881C0B24,  //  0059  GETMBR	R7	R5	K36
-      0x901A4807,  //  005A  SETMBR	R6	K36	R7
-      0x8C1C0526,  //  005B  GETMET	R7	R2	K38
-      0x5426001F,  //  005C  LDINT	R9	32
-      0x7C1C0400,  //  005D  CALL	R7	2
-      0x901A4A07,  //  005E  SETMBR	R6	K37	R7
-      0x881C091B,  //  005F  GETMBR	R7	R4	K27
-      0x901A4E07,  //  0060  SETMBR	R6	K39	R7
-      0x881C011C,  //  0061  GETMBR	R7	R0	K28
-      0x881C0F29,  //  0062  GETMBR	R7	R7	K41
-      0x901A5007,  //  0063  SETMBR	R6	K40	R7
-      0x881C011C,  //  0064  GETMBR	R7	R0	K28
-      0x881C0F2B,  //  0065  GETMBR	R7	R7	K43
-      0x901A5407,  //  0066  SETMBR	R6	K42	R7
-      0x8C1C0D2C,  //  0067  GETMET	R7	R6	K44
-      0x7C1C0200,  //  0068  CALL	R7	1
-      0x90125A07,  //  0069  SETMBR	R4	K45	R7
-      0x8C20032E,  //  006A  GETMET	R8	R1	K46
-      0x542A0020,  //  006B  LDINT	R10	33
-      0x502C0200,  //  006C  LDBOOL	R11	1	0
-      0x7C200600,  //  006D  CALL	R8	3
-      0x8C24112F,  //  006E  GETMET	R9	R8	K47
-      0x5C2C0E00,  //  006F  MOVE	R11	R7
-      0x7C240400,  //  0070  CALL	R9	2
-      0x88280130,  //  0071  GETMBR	R10	R0	K48
-      0x8C281531,  //  0072  GETMET	R10	R10	K49
-      0x5C301000,  //  0073  MOVE	R12	R8
-      0x7C280400,  //  0074  CALL	R10	2
-      0x50280200,  //  0075  LDBOOL	R10	1	0
-      0x80041400,  //  0076  RET	1	R10
+      0x7C140600,  //  003A  CALL	R5	3
+      0x8C14010C,  //  003B  GETMET	R5	R0	K12
+      0x5C1C0200,  //  003C  MOVE	R7	R1
+      0x5820000D,  //  003D  LDCONST	R8	K13
+      0x58240004,  //  003E  LDCONST	R9	K4
+      0x58280009,  //  003F  LDCONST	R10	K9
+      0x502C0000,  //  0040  LDBOOL	R11	0	0
+      0x7C140C00,  //  0041  CALL	R5	6
+      0x50140000,  //  0042  LDBOOL	R5	0	0
+      0x80040A00,  //  0043  RET	1	R5
+      0x88140919,  //  0044  GETMBR	R5	R4	K25
+      0x900E3005,  //  0045  SETMBR	R3	K24	R5
+      0x8814011B,  //  0046  GETMBR	R5	R0	K27
+      0x88140B1C,  //  0047  GETMBR	R5	R5	K28
+      0x8C140B1D,  //  0048  GETMET	R5	R5	K29
+      0x7C140200,  //  0049  CALL	R5	1
+      0x900E3405,  //  004A  SETMBR	R3	K26	R5
+      0xB8160C00,  //  004B  GETNGBL	R5	K6
+      0x8C140B07,  //  004C  GETMET	R5	R5	K7
+      0x601C0018,  //  004D  GETGBL	R7	G24
+      0x5820001E,  //  004E  LDCONST	R8	K30
+      0x8824071A,  //  004F  GETMBR	R9	R3	K26
+      0x8828031F,  //  0050  GETMBR	R10	R1	K31
+      0x882C0320,  //  0051  GETMBR	R11	R1	K32
+      0x7C1C0800,  //  0052  CALL	R7	4
+      0x5820000B,  //  0053  LDCONST	R8	K11
+      0x7C140600,  //  0054  CALL	R5	3
+      0xB8161C00,  //  0055  GETNGBL	R5	K14
+      0x8C140B21,  //  0056  GETMET	R5	R5	K33
+      0x7C140200,  //  0057  CALL	R5	1
+      0x88180922,  //  0058  GETMBR	R6	R4	K34
+      0x90164406,  //  0059  SETMBR	R5	K34	R6
+      0x8C180524,  //  005A  GETMET	R6	R2	K36
+      0x5422001F,  //  005B  LDINT	R8	32
+      0x7C180400,  //  005C  CALL	R6	2
+      0x90164606,  //  005D  SETMBR	R5	K35	R6
+      0x8818071A,  //  005E  GETMBR	R6	R3	K26
+      0x90164A06,  //  005F  SETMBR	R5	K37	R6
+      0x8818011B,  //  0060  GETMBR	R6	R0	K27
+      0x88180D27,  //  0061  GETMBR	R6	R6	K39
+      0x90164C06,  //  0062  SETMBR	R5	K38	R6
+      0x8818011B,  //  0063  GETMBR	R6	R0	K27
+      0x88180D29,  //  0064  GETMBR	R6	R6	K41
+      0x90165006,  //  0065  SETMBR	R5	K40	R6
+      0x8C180B2A,  //  0066  GETMET	R6	R5	K42
+      0x7C180200,  //  0067  CALL	R6	1
+      0x900E5606,  //  0068  SETMBR	R3	K43	R6
+      0x8C1C032C,  //  0069  GETMET	R7	R1	K44
+      0x54260020,  //  006A  LDINT	R9	33
+      0x50280200,  //  006B  LDBOOL	R10	1	0
+      0x7C1C0600,  //  006C  CALL	R7	3
+      0x8C200F2D,  //  006D  GETMET	R8	R7	K45
+      0x5C280C00,  //  006E  MOVE	R10	R6
+      0x7C200400,  //  006F  CALL	R8	2
+      0x8824012E,  //  0070  GETMBR	R9	R0	K46
+      0x8C24132F,  //  0071  GETMET	R9	R9	K47
+      0x5C2C0E00,  //  0072  MOVE	R11	R7
+      0x7C240400,  //  0073  CALL	R9	2
+      0x50240200,  //  0074  LDBOOL	R9	1	0
+      0x80041200,  //  0075  RET	1	R9
     })
   )
 );
@@ -499,7 +493,7 @@ be_local_closure(Matter_Commisioning_Context_send_status_report,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Commisioning_Context_parse_Pake1,   /* name */
   be_nested_proto(
-    23,                          /* nstack */
+    21,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -507,180 +501,177 @@ be_local_closure(Matter_Commisioning_Context_parse_Pake1,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[54]) {     /* constants */
+    ( &(const bvalue[52]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(session),
-    /* K3   */  be_nested_str_weak(opcode),
-    /* K4   */  be_nested_str_weak(local_session_id),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(protocol_id),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20invalid_X20Pake1_X20message),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K12  */  be_nested_str_weak(send_status_report),
-    /* K13  */  be_const_int(1),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_nested_str_weak(matter),
-    /* K16  */  be_nested_str_weak(Pake1),
-    /* K17  */  be_nested_str_weak(parse),
-    /* K18  */  be_nested_str_weak(raw),
-    /* K19  */  be_nested_str_weak(app_payload_idx),
-    /* K20  */  be_nested_str_weak(pA),
-    /* K21  */  be_nested_str_weak(SPAKE2P_Matter),
-    /* K22  */  be_nested_str_weak(device),
-    /* K23  */  be_nested_str_weak(commissioning_w0),
-    /* K24  */  be_nested_str_weak(commissioning_L),
-    /* K25  */  be_nested_str_weak(random),
-    /* K26  */  be_nested_str_weak(compute_pB),
-    /* K27  */  be_nested_str_weak(compute_ZV_verifier),
-    /* K28  */  be_nested_str_weak(SHA256),
-    /* K29  */  be_nested_str_weak(update),
-    /* K30  */  be_nested_str_weak(fromstring),
-    /* K31  */  be_nested_str_weak(Matter_Context_Prefix),
-    /* K32  */  be_nested_str_weak(__Msg1),
-    /* K33  */  be_nested_str_weak(__Msg2),
-    /* K34  */  be_nested_str_weak(out),
-    /* K35  */  be_nested_str_weak(set_context),
-    /* K36  */  be_nested_str_weak(compute_TT_hash),
-    /* K37  */  be_nested_str_weak(Pake2),
-    /* K38  */  be_nested_str_weak(pB),
-    /* K39  */  be_nested_str_weak(cB),
-    /* K40  */  be_nested_str_weak(tlv2raw),
-    /* K41  */  be_nested_str_weak(__spake_cA),
-    /* K42  */  be_nested_str_weak(cA),
-    /* K43  */  be_nested_str_weak(__spake_Ke),
-    /* K44  */  be_nested_str_weak(Ke),
-    /* K45  */  be_nested_str_weak(build_response),
-    /* K46  */  be_nested_str_weak(encode_frame),
-    /* K47  */  be_nested_str_weak(format),
-    /* K48  */  be_nested_str_weak(MTR_X3A_X20New_X20Commissioning_X20_X28PASE_X20id_X3D_X25i_X29_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K49  */  be_nested_str_weak(__future_local_session_id),
-    /* K50  */  be_nested_str_weak(_ip),
-    /* K51  */  be_nested_str_weak(_port),
-    /* K52  */  be_nested_str_weak(responder),
-    /* K53  */  be_nested_str_weak(send_response_frame),
+    /* K1   */  be_nested_str_weak(session),
+    /* K2   */  be_nested_str_weak(opcode),
+    /* K3   */  be_nested_str_weak(local_session_id),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(protocol_id),
+    /* K6   */  be_nested_str_weak(tasmota),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20invalid_X20Pake1_X20message),
+    /* K9   */  be_const_int(3),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
+    /* K11  */  be_nested_str_weak(send_status_report),
+    /* K12  */  be_const_int(1),
+    /* K13  */  be_const_int(2),
+    /* K14  */  be_nested_str_weak(matter),
+    /* K15  */  be_nested_str_weak(Pake1),
+    /* K16  */  be_nested_str_weak(parse),
+    /* K17  */  be_nested_str_weak(raw),
+    /* K18  */  be_nested_str_weak(app_payload_idx),
+    /* K19  */  be_nested_str_weak(pA),
+    /* K20  */  be_nested_str_weak(SPAKE2P_Matter),
+    /* K21  */  be_nested_str_weak(device),
+    /* K22  */  be_nested_str_weak(commissioning_w0),
+    /* K23  */  be_nested_str_weak(commissioning_L),
+    /* K24  */  be_nested_str_weak(random),
+    /* K25  */  be_nested_str_weak(compute_pB),
+    /* K26  */  be_nested_str_weak(compute_ZV_verifier),
+    /* K27  */  be_nested_str_weak(SHA256),
+    /* K28  */  be_nested_str_weak(update),
+    /* K29  */  be_nested_str_weak(fromstring),
+    /* K30  */  be_nested_str_weak(Matter_Context_Prefix),
+    /* K31  */  be_nested_str_weak(__Msg1),
+    /* K32  */  be_nested_str_weak(__Msg2),
+    /* K33  */  be_nested_str_weak(out),
+    /* K34  */  be_nested_str_weak(set_context),
+    /* K35  */  be_nested_str_weak(compute_TT_hash),
+    /* K36  */  be_nested_str_weak(Pake2),
+    /* K37  */  be_nested_str_weak(pB),
+    /* K38  */  be_nested_str_weak(cB),
+    /* K39  */  be_nested_str_weak(tlv2raw),
+    /* K40  */  be_nested_str_weak(__spake_cA),
+    /* K41  */  be_nested_str_weak(cA),
+    /* K42  */  be_nested_str_weak(__spake_Ke),
+    /* K43  */  be_nested_str_weak(Ke),
+    /* K44  */  be_nested_str_weak(build_response),
+    /* K45  */  be_nested_str_weak(encode_frame),
+    /* K46  */  be_nested_str_weak(MTR_X3A_X20New_X20Commissioning_X20_X28PASE_X20id_X3D_X25i_X29_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K47  */  be_nested_str_weak(__future_local_session_id),
+    /* K48  */  be_nested_str_weak(_ip),
+    /* K49  */  be_nested_str_weak(_port),
+    /* K50  */  be_nested_str_weak(responder),
+    /* K51  */  be_nested_str_weak(send_response_frame),
     }),
     be_str_weak(parse_Pake1),
     &be_const_str_solidified,
-    ( &(const binstruction[115]) {  /* code */
+    ( &(const binstruction[114]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0x880C0301,  //  0001  GETMBR	R3	R1	K1
       0x88100302,  //  0002  GETMBR	R4	R1	K2
-      0x88140303,  //  0003  GETMBR	R5	R1	K3
-      0x541A0021,  //  0004  LDINT	R6	34
-      0x20140A06,  //  0005  NE	R5	R5	R6
-      0x74160005,  //  0006  JMPT	R5	#000D
-      0x88140304,  //  0007  GETMBR	R5	R1	K4
-      0x20140B05,  //  0008  NE	R5	R5	K5
-      0x74160002,  //  0009  JMPT	R5	#000D
-      0x88140306,  //  000A  GETMBR	R5	R1	K6
-      0x20140B05,  //  000B  NE	R5	R5	K5
-      0x78160012,  //  000C  JMPF	R5	#0020
-      0xB8160E00,  //  000D  GETNGBL	R5	K7
-      0x8C140B08,  //  000E  GETMET	R5	R5	K8
+      0x54160021,  //  0003  LDINT	R5	34
+      0x20100805,  //  0004  NE	R4	R4	R5
+      0x74120005,  //  0005  JMPT	R4	#000C
+      0x88100303,  //  0006  GETMBR	R4	R1	K3
+      0x20100904,  //  0007  NE	R4	R4	K4
+      0x74120002,  //  0008  JMPT	R4	#000C
+      0x88100305,  //  0009  GETMBR	R4	R1	K5
+      0x20100904,  //  000A  NE	R4	R4	K4
+      0x78120012,  //  000B  JMPF	R4	#001F
+      0xB8120C00,  //  000C  GETNGBL	R4	K6
+      0x8C100907,  //  000D  GETMET	R4	R4	K7
+      0x58180008,  //  000E  LDCONST	R6	K8
       0x581C0009,  //  000F  LDCONST	R7	K9
-      0x5820000A,  //  0010  LDCONST	R8	K10
-      0x7C140600,  //  0011  CALL	R5	3
-      0xB8160E00,  //  0012  GETNGBL	R5	K7
-      0x8C140B08,  //  0013  GETMET	R5	R5	K8
-      0x581C000B,  //  0014  LDCONST	R7	K11
-      0x5820000A,  //  0015  LDCONST	R8	K10
-      0x7C140600,  //  0016  CALL	R5	3
-      0x8C14010C,  //  0017  GETMET	R5	R0	K12
-      0x5C1C0200,  //  0018  MOVE	R7	R1
-      0x5820000D,  //  0019  LDCONST	R8	K13
-      0x58240005,  //  001A  LDCONST	R9	K5
-      0x5828000E,  //  001B  LDCONST	R10	K14
-      0x502C0000,  //  001C  LDBOOL	R11	0	0
-      0x7C140C00,  //  001D  CALL	R5	6
-      0x50140000,  //  001E  LDBOOL	R5	0	0
-      0x80040A00,  //  001F  RET	1	R5
-      0xB8161E00,  //  0020  GETNGBL	R5	K15
-      0x8C140B10,  //  0021  GETMET	R5	R5	K16
-      0x7C140200,  //  0022  CALL	R5	1
-      0x8C140B11,  //  0023  GETMET	R5	R5	K17
+      0x7C100600,  //  0010  CALL	R4	3
+      0xB8120C00,  //  0011  GETNGBL	R4	K6
+      0x8C100907,  //  0012  GETMET	R4	R4	K7
+      0x5818000A,  //  0013  LDCONST	R6	K10
+      0x581C0009,  //  0014  LDCONST	R7	K9
+      0x7C100600,  //  0015  CALL	R4	3
+      0x8C10010B,  //  0016  GETMET	R4	R0	K11
+      0x5C180200,  //  0017  MOVE	R6	R1
+      0x581C000C,  //  0018  LDCONST	R7	K12
+      0x58200004,  //  0019  LDCONST	R8	K4
+      0x5824000D,  //  001A  LDCONST	R9	K13
+      0x50280000,  //  001B  LDBOOL	R10	0	0
+      0x7C100C00,  //  001C  CALL	R4	6
+      0x50100000,  //  001D  LDBOOL	R4	0	0
+      0x80040800,  //  001E  RET	1	R4
+      0xB8121C00,  //  001F  GETNGBL	R4	K14
+      0x8C10090F,  //  0020  GETMET	R4	R4	K15
+      0x7C100200,  //  0021  CALL	R4	1
+      0x8C100910,  //  0022  GETMET	R4	R4	K16
+      0x88180311,  //  0023  GETMBR	R6	R1	K17
       0x881C0312,  //  0024  GETMBR	R7	R1	K18
-      0x88200313,  //  0025  GETMBR	R8	R1	K19
-      0x7C140600,  //  0026  CALL	R5	3
-      0x88180B14,  //  0027  GETMBR	R6	R5	K20
-      0x8C1C0515,  //  0028  GETMET	R7	R2	K21
-      0x88240116,  //  0029  GETMBR	R9	R0	K22
-      0x88241317,  //  002A  GETMBR	R9	R9	K23
-      0x4C280000,  //  002B  LDNIL	R10
-      0x882C0116,  //  002C  GETMBR	R11	R0	K22
-      0x882C1718,  //  002D  GETMBR	R11	R11	K24
-      0x7C1C0800,  //  002E  CALL	R7	4
-      0x8C200519,  //  002F  GETMET	R8	R2	K25
-      0x542A001F,  //  0030  LDINT	R10	32
-      0x7C200400,  //  0031  CALL	R8	2
-      0x8C240F1A,  //  0032  GETMET	R9	R7	K26
-      0x5C2C1000,  //  0033  MOVE	R11	R8
-      0x7C240400,  //  0034  CALL	R9	2
-      0x8C240F1B,  //  0035  GETMET	R9	R7	K27
-      0x5C2C0C00,  //  0036  MOVE	R11	R6
-      0x7C240400,  //  0037  CALL	R9	2
-      0x8C24051C,  //  0038  GETMET	R9	R2	K28
-      0x7C240200,  //  0039  CALL	R9	1
-      0x8C28131D,  //  003A  GETMET	R10	R9	K29
-      0x60300015,  //  003B  GETGBL	R12	G21
-      0x7C300000,  //  003C  CALL	R12	0
-      0x8C30191E,  //  003D  GETMET	R12	R12	K30
-      0x8838011F,  //  003E  GETMBR	R14	R0	K31
-      0x7C300400,  //  003F  CALL	R12	2
-      0x7C280400,  //  0040  CALL	R10	2
-      0x8C28131D,  //  0041  GETMET	R10	R9	K29
-      0x88300920,  //  0042  GETMBR	R12	R4	K32
-      0x7C280400,  //  0043  CALL	R10	2
-      0x8C28131D,  //  0044  GETMET	R10	R9	K29
-      0x88300921,  //  0045  GETMBR	R12	R4	K33
-      0x7C280400,  //  0046  CALL	R10	2
-      0x8C281322,  //  0047  GETMET	R10	R9	K34
-      0x7C280200,  //  0048  CALL	R10	1
-      0x901E2806,  //  0049  SETMBR	R7	K20	R6
-      0x8C2C0F23,  //  004A  GETMET	R11	R7	K35
-      0x5C341400,  //  004B  MOVE	R13	R10
-      0x7C2C0400,  //  004C  CALL	R11	2
-      0x8C2C0F24,  //  004D  GETMET	R11	R7	K36
-      0x50340200,  //  004E  LDBOOL	R13	1	0
-      0x7C2C0400,  //  004F  CALL	R11	2
-      0xB82E1E00,  //  0050  GETNGBL	R11	K15
-      0x8C2C1725,  //  0051  GETMET	R11	R11	K37
-      0x7C2C0200,  //  0052  CALL	R11	1
-      0x88300F26,  //  0053  GETMBR	R12	R7	K38
-      0x902E4C0C,  //  0054  SETMBR	R11	K38	R12
-      0x88300F27,  //  0055  GETMBR	R12	R7	K39
-      0x902E4E0C,  //  0056  SETMBR	R11	K39	R12
-      0x8C301728,  //  0057  GETMET	R12	R11	K40
-      0x7C300200,  //  0058  CALL	R12	1
-      0x88340F2A,  //  0059  GETMBR	R13	R7	K42
-      0x9012520D,  //  005A  SETMBR	R4	K41	R13
-      0x88340F2C,  //  005B  GETMBR	R13	R7	K44
-      0x9012560D,  //  005C  SETMBR	R4	K43	R13
-      0x8C34032D,  //  005D  GETMET	R13	R1	K45
-      0x543E0022,  //  005E  LDINT	R15	35
-      0x50400200,  //  005F  LDBOOL	R16	1	0
-      0x7C340600,  //  0060  CALL	R13	3
-      0x8C381B2E,  //  0061  GETMET	R14	R13	K46
-      0x5C401800,  //  0062  MOVE	R16	R12
-      0x7C380400,  //  0063  CALL	R14	2
-      0xB83E0E00,  //  0064  GETNGBL	R15	K7
-      0x8C3C1F08,  //  0065  GETMET	R15	R15	K8
-      0x8C44072F,  //  0066  GETMET	R17	R3	K47
-      0x584C0030,  //  0067  LDCONST	R19	K48
-      0x88500931,  //  0068  GETMBR	R20	R4	K49
-      0x88540932,  //  0069  GETMBR	R21	R4	K50
-      0x88580933,  //  006A  GETMBR	R22	R4	K51
-      0x7C440A00,  //  006B  CALL	R17	5
-      0x7C3C0400,  //  006C  CALL	R15	2
-      0x883C0134,  //  006D  GETMBR	R15	R0	K52
-      0x8C3C1F35,  //  006E  GETMET	R15	R15	K53
-      0x5C441A00,  //  006F  MOVE	R17	R13
-      0x7C3C0400,  //  0070  CALL	R15	2
-      0x503C0200,  //  0071  LDBOOL	R15	1	0
-      0x80041E00,  //  0072  RET	1	R15
+      0x7C100600,  //  0025  CALL	R4	3
+      0x88140913,  //  0026  GETMBR	R5	R4	K19
+      0x8C180514,  //  0027  GETMET	R6	R2	K20
+      0x88200115,  //  0028  GETMBR	R8	R0	K21
+      0x88201116,  //  0029  GETMBR	R8	R8	K22
+      0x4C240000,  //  002A  LDNIL	R9
+      0x88280115,  //  002B  GETMBR	R10	R0	K21
+      0x88281517,  //  002C  GETMBR	R10	R10	K23
+      0x7C180800,  //  002D  CALL	R6	4
+      0x8C1C0518,  //  002E  GETMET	R7	R2	K24
+      0x5426001F,  //  002F  LDINT	R9	32
+      0x7C1C0400,  //  0030  CALL	R7	2
+      0x8C200D19,  //  0031  GETMET	R8	R6	K25
+      0x5C280E00,  //  0032  MOVE	R10	R7
+      0x7C200400,  //  0033  CALL	R8	2
+      0x8C200D1A,  //  0034  GETMET	R8	R6	K26
+      0x5C280A00,  //  0035  MOVE	R10	R5
+      0x7C200400,  //  0036  CALL	R8	2
+      0x8C20051B,  //  0037  GETMET	R8	R2	K27
+      0x7C200200,  //  0038  CALL	R8	1
+      0x8C24111C,  //  0039  GETMET	R9	R8	K28
+      0x602C0015,  //  003A  GETGBL	R11	G21
+      0x7C2C0000,  //  003B  CALL	R11	0
+      0x8C2C171D,  //  003C  GETMET	R11	R11	K29
+      0x8834011E,  //  003D  GETMBR	R13	R0	K30
+      0x7C2C0400,  //  003E  CALL	R11	2
+      0x7C240400,  //  003F  CALL	R9	2
+      0x8C24111C,  //  0040  GETMET	R9	R8	K28
+      0x882C071F,  //  0041  GETMBR	R11	R3	K31
+      0x7C240400,  //  0042  CALL	R9	2
+      0x8C24111C,  //  0043  GETMET	R9	R8	K28
+      0x882C0720,  //  0044  GETMBR	R11	R3	K32
+      0x7C240400,  //  0045  CALL	R9	2
+      0x8C241121,  //  0046  GETMET	R9	R8	K33
+      0x7C240200,  //  0047  CALL	R9	1
+      0x901A2605,  //  0048  SETMBR	R6	K19	R5
+      0x8C280D22,  //  0049  GETMET	R10	R6	K34
+      0x5C301200,  //  004A  MOVE	R12	R9
+      0x7C280400,  //  004B  CALL	R10	2
+      0x8C280D23,  //  004C  GETMET	R10	R6	K35
+      0x50300200,  //  004D  LDBOOL	R12	1	0
+      0x7C280400,  //  004E  CALL	R10	2
+      0xB82A1C00,  //  004F  GETNGBL	R10	K14
+      0x8C281524,  //  0050  GETMET	R10	R10	K36
+      0x7C280200,  //  0051  CALL	R10	1
+      0x882C0D25,  //  0052  GETMBR	R11	R6	K37
+      0x902A4A0B,  //  0053  SETMBR	R10	K37	R11
+      0x882C0D26,  //  0054  GETMBR	R11	R6	K38
+      0x902A4C0B,  //  0055  SETMBR	R10	K38	R11
+      0x8C2C1527,  //  0056  GETMET	R11	R10	K39
+      0x7C2C0200,  //  0057  CALL	R11	1
+      0x88300D29,  //  0058  GETMBR	R12	R6	K41
+      0x900E500C,  //  0059  SETMBR	R3	K40	R12
+      0x88300D2B,  //  005A  GETMBR	R12	R6	K43
+      0x900E540C,  //  005B  SETMBR	R3	K42	R12
+      0x8C30032C,  //  005C  GETMET	R12	R1	K44
+      0x543A0022,  //  005D  LDINT	R14	35
+      0x503C0200,  //  005E  LDBOOL	R15	1	0
+      0x7C300600,  //  005F  CALL	R12	3
+      0x8C34192D,  //  0060  GETMET	R13	R12	K45
+      0x5C3C1600,  //  0061  MOVE	R15	R11
+      0x7C340400,  //  0062  CALL	R13	2
+      0xB83A0C00,  //  0063  GETNGBL	R14	K6
+      0x8C381D07,  //  0064  GETMET	R14	R14	K7
+      0x60400018,  //  0065  GETGBL	R16	G24
+      0x5844002E,  //  0066  LDCONST	R17	K46
+      0x8848072F,  //  0067  GETMBR	R18	R3	K47
+      0x884C0730,  //  0068  GETMBR	R19	R3	K48
+      0x88500731,  //  0069  GETMBR	R20	R3	K49
+      0x7C400800,  //  006A  CALL	R16	4
+      0x7C380400,  //  006B  CALL	R14	2
+      0x88380132,  //  006C  GETMBR	R14	R0	K50
+      0x8C381D33,  //  006D  GETMET	R14	R14	K51
+      0x5C401800,  //  006E  MOVE	R16	R12
+      0x7C380400,  //  006F  CALL	R14	2
+      0x50380200,  //  0070  LDBOOL	R14	1	0
+      0x80041C00,  //  0071  RET	1	R14
     })
   )
 );
@@ -1264,7 +1255,7 @@ be_local_closure(Matter_Commisioning_Context_parse_Sigma3,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    7,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1272,7 +1263,7 @@ be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
+    ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
     /* K1   */  be_nested_str_weak(is_commissioning_open),
     /* K2   */  be_nested_str_weak(opcode),
@@ -1286,13 +1277,11 @@ be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
     /* K10  */  be_nested_str_weak(parse_Sigma1),
     /* K11  */  be_nested_str_weak(parse_Sigma3),
     /* K12  */  be_nested_str_weak(parse_StatusReport),
-    /* K13  */  be_nested_str_weak(string),
-    /* K14  */  be_nested_str_weak(format),
-    /* K15  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28secure_X20channel_X29_X20_X2502X),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28secure_X20channel_X29_X20_X2502X),
     }),
     be_str_weak(process_incoming),
     &be_const_str_solidified,
-    ( &(const binstruction[91]) {  /* code */
+    ( &(const binstruction[90]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x7C080200,  //  0002  CALL	R2	1
@@ -1316,7 +1305,7 @@ be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
       0x540E000F,  //  0014  LDINT	R3	16
       0x1C080403,  //  0015  EQ	R2	R2	R3
       0x780A0000,  //  0016  JMPF	R2	#0018
-      0x70020040,  //  0017  JMP		#0059
+      0x7002003F,  //  0017  JMP		#0058
       0x88080302,  //  0018  GETMBR	R2	R1	K2
       0x540E001F,  //  0019  LDINT	R3	32
       0x1C080403,  //  001A  EQ	R2	R2	R3
@@ -1325,7 +1314,7 @@ be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
       0x5C100200,  //  001D  MOVE	R4	R1
       0x7C080400,  //  001E  CALL	R2	2
       0x80040400,  //  001F  RET	1	R2
-      0x70020037,  //  0020  JMP		#0059
+      0x70020036,  //  0020  JMP		#0058
       0x88080302,  //  0021  GETMBR	R2	R1	K2
       0x540E0021,  //  0022  LDINT	R3	34
       0x1C080403,  //  0023  EQ	R2	R2	R3
@@ -1334,7 +1323,7 @@ be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
       0x5C100200,  //  0026  MOVE	R4	R1
       0x7C080400,  //  0027  CALL	R2	2
       0x80040400,  //  0028  RET	1	R2
-      0x7002002E,  //  0029  JMP		#0059
+      0x7002002D,  //  0029  JMP		#0058
       0x88080302,  //  002A  GETMBR	R2	R1	K2
       0x540E0023,  //  002B  LDINT	R3	36
       0x1C080403,  //  002C  EQ	R2	R2	R3
@@ -1343,7 +1332,7 @@ be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
       0x5C100200,  //  002F  MOVE	R4	R1
       0x7C080400,  //  0030  CALL	R2	2
       0x80040400,  //  0031  RET	1	R2
-      0x70020025,  //  0032  JMP		#0059
+      0x70020024,  //  0032  JMP		#0058
       0x88080302,  //  0033  GETMBR	R2	R1	K2
       0x540E002F,  //  0034  LDINT	R3	48
       0x1C080403,  //  0035  EQ	R2	R2	R3
@@ -1352,7 +1341,7 @@ be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
       0x5C100200,  //  0038  MOVE	R4	R1
       0x7C080400,  //  0039  CALL	R2	2
       0x80040400,  //  003A  RET	1	R2
-      0x7002001C,  //  003B  JMP		#0059
+      0x7002001B,  //  003B  JMP		#0058
       0x88080302,  //  003C  GETMBR	R2	R1	K2
       0x540E0031,  //  003D  LDINT	R3	50
       0x1C080403,  //  003E  EQ	R2	R2	R3
@@ -1361,7 +1350,7 @@ be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
       0x5C100200,  //  0041  MOVE	R4	R1
       0x7C080400,  //  0042  CALL	R2	2
       0x80040400,  //  0043  RET	1	R2
-      0x70020013,  //  0044  JMP		#0059
+      0x70020012,  //  0044  JMP		#0058
       0x88080302,  //  0045  GETMBR	R2	R1	K2
       0x540E003F,  //  0046  LDINT	R3	64
       0x1C080403,  //  0047  EQ	R2	R2	R3
@@ -1370,20 +1359,19 @@ be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
       0x5C100200,  //  004A  MOVE	R4	R1
       0x7C080400,  //  004B  CALL	R2	2
       0x80040400,  //  004C  RET	1	R2
-      0x7002000A,  //  004D  JMP		#0059
-      0xA40A1A00,  //  004E  IMPORT	R2	K13
-      0xB80E0600,  //  004F  GETNGBL	R3	K3
-      0x8C0C0704,  //  0050  GETMET	R3	R3	K4
-      0x8C14050E,  //  0051  GETMET	R5	R2	K14
-      0x581C000F,  //  0052  LDCONST	R7	K15
-      0x88200302,  //  0053  GETMBR	R8	R1	K2
-      0x7C140600,  //  0054  CALL	R5	3
-      0x58180006,  //  0055  LDCONST	R6	K6
-      0x7C0C0600,  //  0056  CALL	R3	3
-      0x500C0000,  //  0057  LDBOOL	R3	0	0
-      0x80040600,  //  0058  RET	1	R3
-      0x50080000,  //  0059  LDBOOL	R2	0	0
-      0x80040400,  //  005A  RET	1	R2
+      0x70020009,  //  004D  JMP		#0058
+      0xB80A0600,  //  004E  GETNGBL	R2	K3
+      0x8C080504,  //  004F  GETMET	R2	R2	K4
+      0x60100018,  //  0050  GETGBL	R4	G24
+      0x5814000D,  //  0051  LDCONST	R5	K13
+      0x88180302,  //  0052  GETMBR	R6	R1	K2
+      0x7C100400,  //  0053  CALL	R4	2
+      0x58140006,  //  0054  LDCONST	R5	K6
+      0x7C080600,  //  0055  CALL	R2	3
+      0x50080000,  //  0056  LDBOOL	R2	0	0
+      0x80040400,  //  0057  RET	1	R2
+      0x50080000,  //  0058  LDBOOL	R2	0	0
+      0x80040400,  //  0059  RET	1	R2
     })
   )
 );
@@ -1395,7 +1383,7 @@ be_local_closure(Matter_Commisioning_Context_process_incoming,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Commisioning_Context_parse_Sigma1,   /* name */
   be_nested_proto(
-    37,                          /* nstack */
+    36,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1403,599 +1391,596 @@ be_local_closure(Matter_Commisioning_Context_parse_Sigma1,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[106]) {     /* constants */
+    ( &(const bvalue[104]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(session),
-    /* K3   */  be_nested_str_weak(opcode),
-    /* K4   */  be_nested_str_weak(local_session_id),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(protocol_id),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(send_status_report),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_const_int(2),
-    /* K14  */  be_nested_str_weak(matter),
-    /* K15  */  be_nested_str_weak(Sigma1),
-    /* K16  */  be_nested_str_weak(parse),
-    /* K17  */  be_nested_str_weak(raw),
-    /* K18  */  be_nested_str_weak(app_payload_idx),
-    /* K19  */  be_nested_str_weak(__initiator_pub),
-    /* K20  */  be_nested_str_weak(initiatorEphPubKey),
-    /* K21  */  be_nested_str_weak(resumptionID),
-    /* K22  */  be_nested_str_weak(initiatorResumeMIC),
-    /* K23  */  be_nested_str_weak(device),
-    /* K24  */  be_nested_str_weak(sessions),
-    /* K25  */  be_nested_str_weak(find_session_by_resumption_id),
-    /* K26  */  be_nested_str_weak(_fabric),
-    /* K27  */  be_nested_str_weak(initiatorRandom),
-    /* K28  */  be_nested_str_weak(fromstring),
-    /* K29  */  be_nested_str_weak(Sigma1_Resume),
-    /* K30  */  be_nested_str_weak(HKDF_SHA256),
-    /* K31  */  be_nested_str_weak(derive),
-    /* K32  */  be_nested_str_weak(shared_secret),
-    /* K33  */  be_nested_str_weak(NCASE_SigmaS1),
-    /* K34  */  be_const_int(2147483647),
-    /* K35  */  be_nested_str_weak(AES_CCM),
-    /* K36  */  be_nested_str_weak(decrypt),
-    /* K37  */  be_nested_str_weak(tag),
-    /* K38  */  be_nested_str_weak(_source_node_id),
-    /* K39  */  be_nested_str_weak(source_node_id),
-    /* K40  */  be_nested_str_weak(set_mode_CASE),
-    /* K41  */  be_nested_str_weak(__future_initiator_session_id),
-    /* K42  */  be_nested_str_weak(initiator_session_id),
-    /* K43  */  be_nested_str_weak(__future_local_session_id),
-    /* K44  */  be_nested_str_weak(gen_local_session_id),
-    /* K45  */  be_nested_str_weak(format),
-    /* K46  */  be_nested_str_weak(MTR_X3A_X20New_Session_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-    /* K47  */  be_nested_str_weak(remote_ip),
-    /* K48  */  be_nested_str_weak(remote_port),
-    /* K49  */  be_nested_str_weak(resumption_id),
-    /* K50  */  be_nested_str_weak(random),
-    /* K51  */  be_nested_str_weak(Sigma2_Resume),
-    /* K52  */  be_nested_str_weak(NCASE_SigmaS2),
-    /* K53  */  be_nested_str_weak(Sigma2Resume),
-    /* K54  */  be_nested_str_weak(responderSessionID),
-    /* K55  */  be_nested_str_weak(sigma2ResumeMIC),
-    /* K56  */  be_nested_str_weak(SessionResumptionKeys),
-    /* K57  */  be_nested_str_weak(rtc),
-    /* K58  */  be_nested_str_weak(utc),
-    /* K59  */  be_nested_str_weak(tlv2raw),
-    /* K60  */  be_nested_str_weak(__Msg1),
-    /* K61  */  be_nested_str_weak(build_response),
-    /* K62  */  be_nested_str_weak(encode_frame),
-    /* K63  */  be_nested_str_weak(responder),
-    /* K64  */  be_nested_str_weak(send_response_frame),
-    /* K65  */  be_nested_str_weak(close),
-    /* K66  */  be_nested_str_weak(set_keys),
-    /* K67  */  be_nested_str_weak(_breadcrumb),
-    /* K68  */  be_nested_str_weak(counter_snd_next),
-    /* K69  */  be_nested_str_weak(set_persist),
-    /* K70  */  be_nested_str_weak(set_no_expiration),
-    /* K71  */  be_nested_str_weak(persist_to_fabric),
-    /* K72  */  be_nested_str_weak(save),
-    /* K73  */  be_nested_str_weak(find_fabric_by_destination_id),
-    /* K74  */  be_nested_str_weak(destinationId),
-    /* K75  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28GeneralCode_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20NO_SHARED_TRUST_ROOTS_X29),
-    /* K76  */  be_nested_str_weak(__responder_priv),
-    /* K77  */  be_nested_str_weak(__responder_pub),
-    /* K78  */  be_nested_str_weak(EC_P256),
-    /* K79  */  be_nested_str_weak(public_key),
-    /* K80  */  be_nested_str_weak(shared_key),
-    /* K81  */  be_nested_str_weak(TLV),
-    /* K82  */  be_nested_str_weak(Matter_TLV_struct),
-    /* K83  */  be_nested_str_weak(add_TLV),
-    /* K84  */  be_nested_str_weak(B2),
-    /* K85  */  be_nested_str_weak(get_noc),
-    /* K86  */  be_nested_str_weak(get_icac),
-    /* K87  */  be_nested_str_weak(ecdsa_sign_sha256),
-    /* K88  */  be_nested_str_weak(get_pk),
-    /* K89  */  be_nested_str_weak(Msg1),
-    /* K90  */  be_nested_str_weak(SHA256),
-    /* K91  */  be_nested_str_weak(update),
-    /* K92  */  be_nested_str_weak(out),
-    /* K93  */  be_nested_str_weak(S2K_Info),
-    /* K94  */  be_nested_str_weak(get_ipk_group_key),
-    /* K95  */  be_nested_str_weak(TBEData2_Nonce),
-    /* K96  */  be_nested_str_weak(encrypt),
-    /* K97  */  be_nested_str_weak(Sigma2),
-    /* K98  */  be_nested_str_weak(responderRandom),
-    /* K99  */  be_nested_str_weak(responderSessionId),
-    /* K100 */  be_nested_str_weak(responderEphPubKey),
-    /* K101 */  be_nested_str_weak(encrypted2),
-    /* K102 */  be_nested_str_weak(__Msg2),
-    /* K103 */  be_nested_str_weak(MTR_X3A_X20New_X20Connection_X20_X28CASE_X20id_X3D_X25i_X29_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K104 */  be_nested_str_weak(_ip),
-    /* K105 */  be_nested_str_weak(_port),
+    /* K1   */  be_nested_str_weak(session),
+    /* K2   */  be_nested_str_weak(opcode),
+    /* K3   */  be_nested_str_weak(local_session_id),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(protocol_id),
+    /* K6   */  be_nested_str_weak(tasmota),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
+    /* K9   */  be_const_int(3),
+    /* K10  */  be_nested_str_weak(send_status_report),
+    /* K11  */  be_const_int(1),
+    /* K12  */  be_const_int(2),
+    /* K13  */  be_nested_str_weak(matter),
+    /* K14  */  be_nested_str_weak(Sigma1),
+    /* K15  */  be_nested_str_weak(parse),
+    /* K16  */  be_nested_str_weak(raw),
+    /* K17  */  be_nested_str_weak(app_payload_idx),
+    /* K18  */  be_nested_str_weak(__initiator_pub),
+    /* K19  */  be_nested_str_weak(initiatorEphPubKey),
+    /* K20  */  be_nested_str_weak(resumptionID),
+    /* K21  */  be_nested_str_weak(initiatorResumeMIC),
+    /* K22  */  be_nested_str_weak(device),
+    /* K23  */  be_nested_str_weak(sessions),
+    /* K24  */  be_nested_str_weak(find_session_by_resumption_id),
+    /* K25  */  be_nested_str_weak(_fabric),
+    /* K26  */  be_nested_str_weak(initiatorRandom),
+    /* K27  */  be_nested_str_weak(fromstring),
+    /* K28  */  be_nested_str_weak(Sigma1_Resume),
+    /* K29  */  be_nested_str_weak(HKDF_SHA256),
+    /* K30  */  be_nested_str_weak(derive),
+    /* K31  */  be_nested_str_weak(shared_secret),
+    /* K32  */  be_nested_str_weak(NCASE_SigmaS1),
+    /* K33  */  be_const_int(2147483647),
+    /* K34  */  be_nested_str_weak(AES_CCM),
+    /* K35  */  be_nested_str_weak(decrypt),
+    /* K36  */  be_nested_str_weak(tag),
+    /* K37  */  be_nested_str_weak(_source_node_id),
+    /* K38  */  be_nested_str_weak(source_node_id),
+    /* K39  */  be_nested_str_weak(set_mode_CASE),
+    /* K40  */  be_nested_str_weak(__future_initiator_session_id),
+    /* K41  */  be_nested_str_weak(initiator_session_id),
+    /* K42  */  be_nested_str_weak(__future_local_session_id),
+    /* K43  */  be_nested_str_weak(gen_local_session_id),
+    /* K44  */  be_nested_str_weak(MTR_X3A_X20New_Session_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+    /* K45  */  be_nested_str_weak(remote_ip),
+    /* K46  */  be_nested_str_weak(remote_port),
+    /* K47  */  be_nested_str_weak(resumption_id),
+    /* K48  */  be_nested_str_weak(random),
+    /* K49  */  be_nested_str_weak(Sigma2_Resume),
+    /* K50  */  be_nested_str_weak(NCASE_SigmaS2),
+    /* K51  */  be_nested_str_weak(Sigma2Resume),
+    /* K52  */  be_nested_str_weak(responderSessionID),
+    /* K53  */  be_nested_str_weak(sigma2ResumeMIC),
+    /* K54  */  be_nested_str_weak(SessionResumptionKeys),
+    /* K55  */  be_nested_str_weak(rtc),
+    /* K56  */  be_nested_str_weak(utc),
+    /* K57  */  be_nested_str_weak(tlv2raw),
+    /* K58  */  be_nested_str_weak(__Msg1),
+    /* K59  */  be_nested_str_weak(build_response),
+    /* K60  */  be_nested_str_weak(encode_frame),
+    /* K61  */  be_nested_str_weak(responder),
+    /* K62  */  be_nested_str_weak(send_response_frame),
+    /* K63  */  be_nested_str_weak(close),
+    /* K64  */  be_nested_str_weak(set_keys),
+    /* K65  */  be_nested_str_weak(_breadcrumb),
+    /* K66  */  be_nested_str_weak(counter_snd_next),
+    /* K67  */  be_nested_str_weak(set_persist),
+    /* K68  */  be_nested_str_weak(set_no_expiration),
+    /* K69  */  be_nested_str_weak(persist_to_fabric),
+    /* K70  */  be_nested_str_weak(save),
+    /* K71  */  be_nested_str_weak(find_fabric_by_destination_id),
+    /* K72  */  be_nested_str_weak(destinationId),
+    /* K73  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28GeneralCode_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20NO_SHARED_TRUST_ROOTS_X29),
+    /* K74  */  be_nested_str_weak(__responder_priv),
+    /* K75  */  be_nested_str_weak(__responder_pub),
+    /* K76  */  be_nested_str_weak(EC_P256),
+    /* K77  */  be_nested_str_weak(public_key),
+    /* K78  */  be_nested_str_weak(shared_key),
+    /* K79  */  be_nested_str_weak(TLV),
+    /* K80  */  be_nested_str_weak(Matter_TLV_struct),
+    /* K81  */  be_nested_str_weak(add_TLV),
+    /* K82  */  be_nested_str_weak(B2),
+    /* K83  */  be_nested_str_weak(get_noc),
+    /* K84  */  be_nested_str_weak(get_icac),
+    /* K85  */  be_nested_str_weak(ecdsa_sign_sha256),
+    /* K86  */  be_nested_str_weak(get_pk),
+    /* K87  */  be_nested_str_weak(Msg1),
+    /* K88  */  be_nested_str_weak(SHA256),
+    /* K89  */  be_nested_str_weak(update),
+    /* K90  */  be_nested_str_weak(out),
+    /* K91  */  be_nested_str_weak(S2K_Info),
+    /* K92  */  be_nested_str_weak(get_ipk_group_key),
+    /* K93  */  be_nested_str_weak(TBEData2_Nonce),
+    /* K94  */  be_nested_str_weak(encrypt),
+    /* K95  */  be_nested_str_weak(Sigma2),
+    /* K96  */  be_nested_str_weak(responderRandom),
+    /* K97  */  be_nested_str_weak(responderSessionId),
+    /* K98  */  be_nested_str_weak(responderEphPubKey),
+    /* K99  */  be_nested_str_weak(encrypted2),
+    /* K100 */  be_nested_str_weak(__Msg2),
+    /* K101 */  be_nested_str_weak(MTR_X3A_X20New_X20Connection_X20_X28CASE_X20id_X3D_X25i_X29_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K102 */  be_nested_str_weak(_ip),
+    /* K103 */  be_nested_str_weak(_port),
     }),
     be_str_weak(parse_Sigma1),
     &be_const_str_solidified,
-    ( &(const binstruction[482]) {  /* code */
+    ( &(const binstruction[481]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0x880C0301,  //  0001  GETMBR	R3	R1	K1
       0x88100302,  //  0002  GETMBR	R4	R1	K2
-      0x88140303,  //  0003  GETMBR	R5	R1	K3
-      0x541A002F,  //  0004  LDINT	R6	48
-      0x20140A06,  //  0005  NE	R5	R5	R6
-      0x74160005,  //  0006  JMPT	R5	#000D
-      0x88140304,  //  0007  GETMBR	R5	R1	K4
-      0x20140B05,  //  0008  NE	R5	R5	K5
-      0x74160002,  //  0009  JMPT	R5	#000D
-      0x88140306,  //  000A  GETMBR	R5	R1	K6
-      0x20140B05,  //  000B  NE	R5	R5	K5
-      0x7816000D,  //  000C  JMPF	R5	#001B
-      0xB8160E00,  //  000D  GETNGBL	R5	K7
-      0x8C140B08,  //  000E  GETMET	R5	R5	K8
+      0x5416002F,  //  0003  LDINT	R5	48
+      0x20100805,  //  0004  NE	R4	R4	R5
+      0x74120005,  //  0005  JMPT	R4	#000C
+      0x88100303,  //  0006  GETMBR	R4	R1	K3
+      0x20100904,  //  0007  NE	R4	R4	K4
+      0x74120002,  //  0008  JMPT	R4	#000C
+      0x88100305,  //  0009  GETMBR	R4	R1	K5
+      0x20100904,  //  000A  NE	R4	R4	K4
+      0x7812000D,  //  000B  JMPF	R4	#001A
+      0xB8120C00,  //  000C  GETNGBL	R4	K6
+      0x8C100907,  //  000D  GETMET	R4	R4	K7
+      0x58180008,  //  000E  LDCONST	R6	K8
       0x581C0009,  //  000F  LDCONST	R7	K9
-      0x5820000A,  //  0010  LDCONST	R8	K10
-      0x7C140600,  //  0011  CALL	R5	3
-      0x8C14010B,  //  0012  GETMET	R5	R0	K11
-      0x5C1C0200,  //  0013  MOVE	R7	R1
-      0x5820000C,  //  0014  LDCONST	R8	K12
-      0x58240005,  //  0015  LDCONST	R9	K5
-      0x5828000D,  //  0016  LDCONST	R10	K13
-      0x502C0000,  //  0017  LDBOOL	R11	0	0
-      0x7C140C00,  //  0018  CALL	R5	6
-      0x50140000,  //  0019  LDBOOL	R5	0	0
-      0x80040A00,  //  001A  RET	1	R5
-      0xB8161C00,  //  001B  GETNGBL	R5	K14
-      0x8C140B0F,  //  001C  GETMET	R5	R5	K15
-      0x7C140200,  //  001D  CALL	R5	1
-      0x8C140B10,  //  001E  GETMET	R5	R5	K16
+      0x7C100600,  //  0010  CALL	R4	3
+      0x8C10010A,  //  0011  GETMET	R4	R0	K10
+      0x5C180200,  //  0012  MOVE	R6	R1
+      0x581C000B,  //  0013  LDCONST	R7	K11
+      0x58200004,  //  0014  LDCONST	R8	K4
+      0x5824000C,  //  0015  LDCONST	R9	K12
+      0x50280000,  //  0016  LDBOOL	R10	0	0
+      0x7C100C00,  //  0017  CALL	R4	6
+      0x50100000,  //  0018  LDBOOL	R4	0	0
+      0x80040800,  //  0019  RET	1	R4
+      0xB8121A00,  //  001A  GETNGBL	R4	K13
+      0x8C10090E,  //  001B  GETMET	R4	R4	K14
+      0x7C100200,  //  001C  CALL	R4	1
+      0x8C10090F,  //  001D  GETMET	R4	R4	K15
+      0x88180310,  //  001E  GETMBR	R6	R1	K16
       0x881C0311,  //  001F  GETMBR	R7	R1	K17
-      0x88200312,  //  0020  GETMBR	R8	R1	K18
-      0x7C140600,  //  0021  CALL	R5	3
-      0x88180B14,  //  0022  GETMBR	R6	R5	K20
-      0x90122606,  //  0023  SETMBR	R4	K19	R6
-      0x88180B15,  //  0024  GETMBR	R6	R5	K21
-      0x4C1C0000,  //  0025  LDNIL	R7
-      0x20180C07,  //  0026  NE	R6	R6	R7
-      0x781A0003,  //  0027  JMPF	R6	#002C
-      0x88180B16,  //  0028  GETMBR	R6	R5	K22
-      0x4C1C0000,  //  0029  LDNIL	R7
-      0x20180C07,  //  002A  NE	R6	R6	R7
-      0x741A0000,  //  002B  JMPT	R6	#002D
-      0x50180001,  //  002C  LDBOOL	R6	0	1
-      0x50180200,  //  002D  LDBOOL	R6	1	0
-      0x50180000,  //  002E  LDBOOL	R6	0	0
-      0x4C1C0000,  //  002F  LDNIL	R7
-      0x781A000D,  //  0030  JMPF	R6	#003F
-      0x88200117,  //  0031  GETMBR	R8	R0	K23
-      0x88201118,  //  0032  GETMBR	R8	R8	K24
-      0x8C201119,  //  0033  GETMET	R8	R8	K25
-      0x88280B15,  //  0034  GETMBR	R10	R5	K21
-      0x7C200400,  //  0035  CALL	R8	2
-      0x5C1C1000,  //  0036  MOVE	R7	R8
-      0x4C200000,  //  0037  LDNIL	R8
-      0x1C200E08,  //  0038  EQ	R8	R7	R8
-      0x74220003,  //  0039  JMPT	R8	#003E
-      0x88200F1A,  //  003A  GETMBR	R8	R7	K26
-      0x4C240000,  //  003B  LDNIL	R9
-      0x1C201009,  //  003C  EQ	R8	R8	R9
-      0x78220000,  //  003D  JMPF	R8	#003F
-      0x50180000,  //  003E  LDBOOL	R6	0	0
-      0x781A00B6,  //  003F  JMPF	R6	#00F7
-      0x88200B1B,  //  0040  GETMBR	R8	R5	K27
-      0x88240B15,  //  0041  GETMBR	R9	R5	K21
-      0x00201009,  //  0042  ADD	R8	R8	R9
-      0x60240015,  //  0043  GETGBL	R9	G21
-      0x7C240000,  //  0044  CALL	R9	0
-      0x8C24131C,  //  0045  GETMET	R9	R9	K28
-      0x582C001D,  //  0046  LDCONST	R11	K29
-      0x7C240400,  //  0047  CALL	R9	2
-      0x8C28051E,  //  0048  GETMET	R10	R2	K30
-      0x7C280200,  //  0049  CALL	R10	1
-      0x8C28151F,  //  004A  GETMET	R10	R10	K31
-      0x88300F20,  //  004B  GETMBR	R12	R7	K32
+      0x7C100600,  //  0020  CALL	R4	3
+      0x88140913,  //  0021  GETMBR	R5	R4	K19
+      0x900E2405,  //  0022  SETMBR	R3	K18	R5
+      0x88140914,  //  0023  GETMBR	R5	R4	K20
+      0x4C180000,  //  0024  LDNIL	R6
+      0x20140A06,  //  0025  NE	R5	R5	R6
+      0x78160003,  //  0026  JMPF	R5	#002B
+      0x88140915,  //  0027  GETMBR	R5	R4	K21
+      0x4C180000,  //  0028  LDNIL	R6
+      0x20140A06,  //  0029  NE	R5	R5	R6
+      0x74160000,  //  002A  JMPT	R5	#002C
+      0x50140001,  //  002B  LDBOOL	R5	0	1
+      0x50140200,  //  002C  LDBOOL	R5	1	0
+      0x50140000,  //  002D  LDBOOL	R5	0	0
+      0x4C180000,  //  002E  LDNIL	R6
+      0x7816000D,  //  002F  JMPF	R5	#003E
+      0x881C0116,  //  0030  GETMBR	R7	R0	K22
+      0x881C0F17,  //  0031  GETMBR	R7	R7	K23
+      0x8C1C0F18,  //  0032  GETMET	R7	R7	K24
+      0x88240914,  //  0033  GETMBR	R9	R4	K20
+      0x7C1C0400,  //  0034  CALL	R7	2
+      0x5C180E00,  //  0035  MOVE	R6	R7
+      0x4C1C0000,  //  0036  LDNIL	R7
+      0x1C1C0C07,  //  0037  EQ	R7	R6	R7
+      0x741E0003,  //  0038  JMPT	R7	#003D
+      0x881C0D19,  //  0039  GETMBR	R7	R6	K25
+      0x4C200000,  //  003A  LDNIL	R8
+      0x1C1C0E08,  //  003B  EQ	R7	R7	R8
+      0x781E0000,  //  003C  JMPF	R7	#003E
+      0x50140000,  //  003D  LDBOOL	R5	0	0
+      0x781600B6,  //  003E  JMPF	R5	#00F6
+      0x881C091A,  //  003F  GETMBR	R7	R4	K26
+      0x88200914,  //  0040  GETMBR	R8	R4	K20
+      0x001C0E08,  //  0041  ADD	R7	R7	R8
+      0x60200015,  //  0042  GETGBL	R8	G21
+      0x7C200000,  //  0043  CALL	R8	0
+      0x8C20111B,  //  0044  GETMET	R8	R8	K27
+      0x5828001C,  //  0045  LDCONST	R10	K28
+      0x7C200400,  //  0046  CALL	R8	2
+      0x8C24051D,  //  0047  GETMET	R9	R2	K29
+      0x7C240200,  //  0048  CALL	R9	1
+      0x8C24131E,  //  0049  GETMET	R9	R9	K30
+      0x882C0D1F,  //  004A  GETMBR	R11	R6	K31
+      0x5C300E00,  //  004B  MOVE	R12	R7
       0x5C341000,  //  004C  MOVE	R13	R8
-      0x5C381200,  //  004D  MOVE	R14	R9
-      0x543E000F,  //  004E  LDINT	R15	16
-      0x7C280A00,  //  004F  CALL	R10	5
-      0x602C0015,  //  0050  GETGBL	R11	G21
-      0x7C2C0000,  //  0051  CALL	R11	0
-      0x8C2C171C,  //  0052  GETMET	R11	R11	K28
-      0x58340021,  //  0053  LDCONST	R13	K33
-      0x7C2C0400,  //  0054  CALL	R11	2
-      0x5431FFEE,  //  0055  LDINT	R12	-17
-      0x40320A0C,  //  0056  CONNECT	R12	K5	R12
-      0x88340B16,  //  0057  GETMBR	R13	R5	K22
-      0x94301A0C,  //  0058  GETIDX	R12	R13	R12
-      0x5439FFEF,  //  0059  LDINT	R14	-16
-      0x40381D22,  //  005A  CONNECT	R14	R14	K34
-      0x883C0B16,  //  005B  GETMBR	R15	R5	K22
-      0x94341E0E,  //  005C  GETIDX	R13	R15	R14
-      0x8C400523,  //  005D  GETMET	R16	R2	K35
+      0x543A000F,  //  004D  LDINT	R14	16
+      0x7C240A00,  //  004E  CALL	R9	5
+      0x60280015,  //  004F  GETGBL	R10	G21
+      0x7C280000,  //  0050  CALL	R10	0
+      0x8C28151B,  //  0051  GETMET	R10	R10	K27
+      0x58300020,  //  0052  LDCONST	R12	K32
+      0x7C280400,  //  0053  CALL	R10	2
+      0x542DFFEE,  //  0054  LDINT	R11	-17
+      0x402E080B,  //  0055  CONNECT	R11	K4	R11
+      0x88300915,  //  0056  GETMBR	R12	R4	K21
+      0x942C180B,  //  0057  GETIDX	R11	R12	R11
+      0x5435FFEF,  //  0058  LDINT	R13	-16
+      0x40341B21,  //  0059  CONNECT	R13	R13	K33
+      0x88380915,  //  005A  GETMBR	R14	R4	K21
+      0x94301C0D,  //  005B  GETIDX	R12	R14	R13
+      0x8C3C0522,  //  005C  GETMET	R15	R2	K34
+      0x5C441200,  //  005D  MOVE	R17	R9
       0x5C481400,  //  005E  MOVE	R18	R10
-      0x5C4C1600,  //  005F  MOVE	R19	R11
-      0x60500015,  //  0060  GETGBL	R20	G21
-      0x7C500000,  //  0061  CALL	R20	0
-      0x6054000C,  //  0062  GETGBL	R21	G12
-      0x5C581800,  //  0063  MOVE	R22	R12
-      0x7C540200,  //  0064  CALL	R21	1
-      0x545A000F,  //  0065  LDINT	R22	16
-      0x7C400C00,  //  0066  CALL	R16	6
-      0x5C382000,  //  0067  MOVE	R14	R16
-      0x8C401D24,  //  0068  GETMET	R16	R14	K36
-      0x5C481800,  //  0069  MOVE	R18	R12
-      0x7C400400,  //  006A  CALL	R16	2
-      0x5C3C2000,  //  006B  MOVE	R15	R16
-      0x8C401D25,  //  006C  GETMET	R16	R14	K37
-      0x7C400200,  //  006D  CALL	R16	1
-      0x1C441A10,  //  006E  EQ	R17	R13	R16
-      0x78460085,  //  006F  JMPF	R17	#00F6
-      0x88440F1A,  //  0070  GETMBR	R17	R7	K26
-      0x90123411,  //  0071  SETMBR	R4	K26	R17
-      0x88440327,  //  0072  GETMBR	R17	R1	K39
-      0x90124C11,  //  0073  SETMBR	R4	K38	R17
-      0x8C440928,  //  0074  GETMET	R17	R4	K40
-      0x7C440200,  //  0075  CALL	R17	1
-      0x88440B2A,  //  0076  GETMBR	R17	R5	K42
-      0x90125211,  //  0077  SETMBR	R4	K41	R17
-      0x88440117,  //  0078  GETMBR	R17	R0	K23
-      0x88442318,  //  0079  GETMBR	R17	R17	K24
-      0x8C44232C,  //  007A  GETMET	R17	R17	K44
-      0x7C440200,  //  007B  CALL	R17	1
-      0x90125611,  //  007C  SETMBR	R4	K43	R17
-      0xB8460E00,  //  007D  GETNGBL	R17	K7
-      0x8C442308,  //  007E  GETMET	R17	R17	K8
-      0x8C4C072D,  //  007F  GETMET	R19	R3	K45
-      0x5854002E,  //  0080  LDCONST	R21	K46
-      0x8858092B,  //  0081  GETMBR	R22	R4	K43
-      0x885C032F,  //  0082  GETMBR	R23	R1	K47
-      0x88600330,  //  0083  GETMBR	R24	R1	K48
-      0x7C4C0A00,  //  0084  CALL	R19	5
-      0x5850000A,  //  0085  LDCONST	R20	K10
-      0x7C440600,  //  0086  CALL	R17	3
-      0x88440F20,  //  0087  GETMBR	R17	R7	K32
-      0x90124011,  //  0088  SETMBR	R4	K32	R17
-      0x8C440532,  //  0089  GETMET	R17	R2	K50
-      0x544E000F,  //  008A  LDINT	R19	16
-      0x7C440400,  //  008B  CALL	R17	2
-      0x90126211,  //  008C  SETMBR	R4	K49	R17
-      0x60440015,  //  008D  GETGBL	R17	G21
-      0x7C440000,  //  008E  CALL	R17	0
-      0x8C44231C,  //  008F  GETMET	R17	R17	K28
-      0x584C0033,  //  0090  LDCONST	R19	K51
-      0x7C440400,  //  0091  CALL	R17	2
-      0x88480B1B,  //  0092  GETMBR	R18	R5	K27
-      0x884C0931,  //  0093  GETMBR	R19	R4	K49
-      0x00482413,  //  0094  ADD	R18	R18	R19
-      0x8C4C051E,  //  0095  GETMET	R19	R2	K30
-      0x7C4C0200,  //  0096  CALL	R19	1
-      0x8C4C271F,  //  0097  GETMET	R19	R19	K31
-      0x88540920,  //  0098  GETMBR	R21	R4	K32
-      0x5C582400,  //  0099  MOVE	R22	R18
-      0x5C5C2200,  //  009A  MOVE	R23	R17
-      0x5462000F,  //  009B  LDINT	R24	16
-      0x7C4C0A00,  //  009C  CALL	R19	5
-      0x8C500523,  //  009D  GETMET	R20	R2	K35
-      0x5C582600,  //  009E  MOVE	R22	R19
-      0x605C0015,  //  009F  GETGBL	R23	G21
-      0x7C5C0000,  //  00A0  CALL	R23	0
-      0x8C5C2F1C,  //  00A1  GETMET	R23	R23	K28
-      0x58640034,  //  00A2  LDCONST	R25	K52
-      0x7C5C0400,  //  00A3  CALL	R23	2
-      0x60600015,  //  00A4  GETGBL	R24	G21
-      0x7C600000,  //  00A5  CALL	R24	0
-      0x58640005,  //  00A6  LDCONST	R25	K5
-      0x546A000F,  //  00A7  LDINT	R26	16
-      0x7C500C00,  //  00A8  CALL	R20	6
-      0x8C542925,  //  00A9  GETMET	R21	R20	K37
-      0x7C540200,  //  00AA  CALL	R21	1
-      0xB85A1C00,  //  00AB  GETNGBL	R22	K14
-      0x8C582D35,  //  00AC  GETMET	R22	R22	K53
-      0x7C580200,  //  00AD  CALL	R22	1
-      0x885C0931,  //  00AE  GETMBR	R23	R4	K49
-      0x905A2A17,  //  00AF  SETMBR	R22	K21	R23
-      0x885C092B,  //  00B0  GETMBR	R23	R4	K43
-      0x905A6C17,  //  00B1  SETMBR	R22	K54	R23
-      0x905A6E15,  //  00B2  SETMBR	R22	K55	R21
-      0x8C5C051E,  //  00B3  GETMET	R23	R2	K30
-      0x7C5C0200,  //  00B4  CALL	R23	1
-      0x8C5C2F1F,  //  00B5  GETMET	R23	R23	K31
-      0x88640920,  //  00B6  GETMBR	R25	R4	K32
-      0x88680B1B,  //  00B7  GETMBR	R26	R5	K27
-      0x886C0931,  //  00B8  GETMBR	R27	R4	K49
-      0x0068341B,  //  00B9  ADD	R26	R26	R27
-      0x606C0015,  //  00BA  GETGBL	R27	G21
-      0x7C6C0000,  //  00BB  CALL	R27	0
-      0x8C6C371C,  //  00BC  GETMET	R27	R27	K28
-      0x58740038,  //  00BD  LDCONST	R29	K56
-      0x7C6C0400,  //  00BE  CALL	R27	2
-      0x5472002F,  //  00BF  LDINT	R28	48
-      0x7C5C0A00,  //  00C0  CALL	R23	5
-      0x5462000E,  //  00C1  LDINT	R24	15
-      0x40620A18,  //  00C2  CONNECT	R24	K5	R24
-      0x94602E18,  //  00C3  GETIDX	R24	R23	R24
-      0x5466000F,  //  00C4  LDINT	R25	16
-      0x546A001E,  //  00C5  LDINT	R26	31
-      0x4064321A,  //  00C6  CONNECT	R25	R25	R26
-      0x94642E19,  //  00C7  GETIDX	R25	R23	R25
-      0x546A001F,  //  00C8  LDINT	R26	32
-      0x546E002E,  //  00C9  LDINT	R27	47
-      0x4068341B,  //  00CA  CONNECT	R26	R26	R27
-      0x94682E1A,  //  00CB  GETIDX	R26	R23	R26
-      0xB86E0E00,  //  00CC  GETNGBL	R27	K7
-      0x8C6C3739,  //  00CD  GETMET	R27	R27	K57
-      0x7C6C0200,  //  00CE  CALL	R27	1
-      0x946C373A,  //  00CF  GETIDX	R27	R27	K58
-      0x8C702D3B,  //  00D0  GETMET	R28	R22	K59
-      0x7C700200,  //  00D1  CALL	R28	1
-      0x4C740000,  //  00D2  LDNIL	R29
-      0x9012781D,  //  00D3  SETMBR	R4	K60	R29
-      0x8C74033D,  //  00D4  GETMET	R29	R1	K61
-      0x547E0032,  //  00D5  LDINT	R31	51
-      0x50800200,  //  00D6  LDBOOL	R32	1	0
-      0x7C740600,  //  00D7  CALL	R29	3
-      0x8C783B3E,  //  00D8  GETMET	R30	R29	K62
-      0x5C803800,  //  00D9  MOVE	R32	R28
-      0x7C780400,  //  00DA  CALL	R30	2
-      0x887C013F,  //  00DB  GETMBR	R31	R0	K63
-      0x8C7C3F40,  //  00DC  GETMET	R31	R31	K64
-      0x5C843A00,  //  00DD  MOVE	R33	R29
-      0x7C7C0400,  //  00DE  CALL	R31	2
-      0x8C7C0941,  //  00DF  GETMET	R31	R4	K65
-      0x7C7C0200,  //  00E0  CALL	R31	1
-      0x8C7C0942,  //  00E1  GETMET	R31	R4	K66
+      0x604C0015,  //  005F  GETGBL	R19	G21
+      0x7C4C0000,  //  0060  CALL	R19	0
+      0x6050000C,  //  0061  GETGBL	R20	G12
+      0x5C541600,  //  0062  MOVE	R21	R11
+      0x7C500200,  //  0063  CALL	R20	1
+      0x5456000F,  //  0064  LDINT	R21	16
+      0x7C3C0C00,  //  0065  CALL	R15	6
+      0x5C341E00,  //  0066  MOVE	R13	R15
+      0x8C3C1B23,  //  0067  GETMET	R15	R13	K35
+      0x5C441600,  //  0068  MOVE	R17	R11
+      0x7C3C0400,  //  0069  CALL	R15	2
+      0x5C381E00,  //  006A  MOVE	R14	R15
+      0x8C3C1B24,  //  006B  GETMET	R15	R13	K36
+      0x7C3C0200,  //  006C  CALL	R15	1
+      0x1C40180F,  //  006D  EQ	R16	R12	R15
+      0x78420085,  //  006E  JMPF	R16	#00F5
+      0x88400D19,  //  006F  GETMBR	R16	R6	K25
+      0x900E3210,  //  0070  SETMBR	R3	K25	R16
+      0x88400326,  //  0071  GETMBR	R16	R1	K38
+      0x900E4A10,  //  0072  SETMBR	R3	K37	R16
+      0x8C400727,  //  0073  GETMET	R16	R3	K39
+      0x7C400200,  //  0074  CALL	R16	1
+      0x88400929,  //  0075  GETMBR	R16	R4	K41
+      0x900E5010,  //  0076  SETMBR	R3	K40	R16
+      0x88400116,  //  0077  GETMBR	R16	R0	K22
+      0x88402117,  //  0078  GETMBR	R16	R16	K23
+      0x8C40212B,  //  0079  GETMET	R16	R16	K43
+      0x7C400200,  //  007A  CALL	R16	1
+      0x900E5410,  //  007B  SETMBR	R3	K42	R16
+      0xB8420C00,  //  007C  GETNGBL	R16	K6
+      0x8C402107,  //  007D  GETMET	R16	R16	K7
+      0x60480018,  //  007E  GETGBL	R18	G24
+      0x584C002C,  //  007F  LDCONST	R19	K44
+      0x8850072A,  //  0080  GETMBR	R20	R3	K42
+      0x8854032D,  //  0081  GETMBR	R21	R1	K45
+      0x8858032E,  //  0082  GETMBR	R22	R1	K46
+      0x7C480800,  //  0083  CALL	R18	4
+      0x584C0009,  //  0084  LDCONST	R19	K9
+      0x7C400600,  //  0085  CALL	R16	3
+      0x88400D1F,  //  0086  GETMBR	R16	R6	K31
+      0x900E3E10,  //  0087  SETMBR	R3	K31	R16
+      0x8C400530,  //  0088  GETMET	R16	R2	K48
+      0x544A000F,  //  0089  LDINT	R18	16
+      0x7C400400,  //  008A  CALL	R16	2
+      0x900E5E10,  //  008B  SETMBR	R3	K47	R16
+      0x60400015,  //  008C  GETGBL	R16	G21
+      0x7C400000,  //  008D  CALL	R16	0
+      0x8C40211B,  //  008E  GETMET	R16	R16	K27
+      0x58480031,  //  008F  LDCONST	R18	K49
+      0x7C400400,  //  0090  CALL	R16	2
+      0x8844091A,  //  0091  GETMBR	R17	R4	K26
+      0x8848072F,  //  0092  GETMBR	R18	R3	K47
+      0x00442212,  //  0093  ADD	R17	R17	R18
+      0x8C48051D,  //  0094  GETMET	R18	R2	K29
+      0x7C480200,  //  0095  CALL	R18	1
+      0x8C48251E,  //  0096  GETMET	R18	R18	K30
+      0x8850071F,  //  0097  GETMBR	R20	R3	K31
+      0x5C542200,  //  0098  MOVE	R21	R17
+      0x5C582000,  //  0099  MOVE	R22	R16
+      0x545E000F,  //  009A  LDINT	R23	16
+      0x7C480A00,  //  009B  CALL	R18	5
+      0x8C4C0522,  //  009C  GETMET	R19	R2	K34
+      0x5C542400,  //  009D  MOVE	R21	R18
+      0x60580015,  //  009E  GETGBL	R22	G21
+      0x7C580000,  //  009F  CALL	R22	0
+      0x8C582D1B,  //  00A0  GETMET	R22	R22	K27
+      0x58600032,  //  00A1  LDCONST	R24	K50
+      0x7C580400,  //  00A2  CALL	R22	2
+      0x605C0015,  //  00A3  GETGBL	R23	G21
+      0x7C5C0000,  //  00A4  CALL	R23	0
+      0x58600004,  //  00A5  LDCONST	R24	K4
+      0x5466000F,  //  00A6  LDINT	R25	16
+      0x7C4C0C00,  //  00A7  CALL	R19	6
+      0x8C502724,  //  00A8  GETMET	R20	R19	K36
+      0x7C500200,  //  00A9  CALL	R20	1
+      0xB8561A00,  //  00AA  GETNGBL	R21	K13
+      0x8C542B33,  //  00AB  GETMET	R21	R21	K51
+      0x7C540200,  //  00AC  CALL	R21	1
+      0x8858072F,  //  00AD  GETMBR	R22	R3	K47
+      0x90562816,  //  00AE  SETMBR	R21	K20	R22
+      0x8858072A,  //  00AF  GETMBR	R22	R3	K42
+      0x90566816,  //  00B0  SETMBR	R21	K52	R22
+      0x90566A14,  //  00B1  SETMBR	R21	K53	R20
+      0x8C58051D,  //  00B2  GETMET	R22	R2	K29
+      0x7C580200,  //  00B3  CALL	R22	1
+      0x8C582D1E,  //  00B4  GETMET	R22	R22	K30
+      0x8860071F,  //  00B5  GETMBR	R24	R3	K31
+      0x8864091A,  //  00B6  GETMBR	R25	R4	K26
+      0x8868072F,  //  00B7  GETMBR	R26	R3	K47
+      0x0064321A,  //  00B8  ADD	R25	R25	R26
+      0x60680015,  //  00B9  GETGBL	R26	G21
+      0x7C680000,  //  00BA  CALL	R26	0
+      0x8C68351B,  //  00BB  GETMET	R26	R26	K27
+      0x58700036,  //  00BC  LDCONST	R28	K54
+      0x7C680400,  //  00BD  CALL	R26	2
+      0x546E002F,  //  00BE  LDINT	R27	48
+      0x7C580A00,  //  00BF  CALL	R22	5
+      0x545E000E,  //  00C0  LDINT	R23	15
+      0x405E0817,  //  00C1  CONNECT	R23	K4	R23
+      0x945C2C17,  //  00C2  GETIDX	R23	R22	R23
+      0x5462000F,  //  00C3  LDINT	R24	16
+      0x5466001E,  //  00C4  LDINT	R25	31
+      0x40603019,  //  00C5  CONNECT	R24	R24	R25
+      0x94602C18,  //  00C6  GETIDX	R24	R22	R24
+      0x5466001F,  //  00C7  LDINT	R25	32
+      0x546A002E,  //  00C8  LDINT	R26	47
+      0x4064321A,  //  00C9  CONNECT	R25	R25	R26
+      0x94642C19,  //  00CA  GETIDX	R25	R22	R25
+      0xB86A0C00,  //  00CB  GETNGBL	R26	K6
+      0x8C683537,  //  00CC  GETMET	R26	R26	K55
+      0x7C680200,  //  00CD  CALL	R26	1
+      0x94683538,  //  00CE  GETIDX	R26	R26	K56
+      0x8C6C2B39,  //  00CF  GETMET	R27	R21	K57
+      0x7C6C0200,  //  00D0  CALL	R27	1
+      0x4C700000,  //  00D1  LDNIL	R28
+      0x900E741C,  //  00D2  SETMBR	R3	K58	R28
+      0x8C70033B,  //  00D3  GETMET	R28	R1	K59
+      0x547A0032,  //  00D4  LDINT	R30	51
+      0x507C0200,  //  00D5  LDBOOL	R31	1	0
+      0x7C700600,  //  00D6  CALL	R28	3
+      0x8C74393C,  //  00D7  GETMET	R29	R28	K60
+      0x5C7C3600,  //  00D8  MOVE	R31	R27
+      0x7C740400,  //  00D9  CALL	R29	2
+      0x8878013D,  //  00DA  GETMBR	R30	R0	K61
+      0x8C783D3E,  //  00DB  GETMET	R30	R30	K62
+      0x5C803800,  //  00DC  MOVE	R32	R28
+      0x7C780400,  //  00DD  CALL	R30	2
+      0x8C78073F,  //  00DE  GETMET	R30	R3	K63
+      0x7C780200,  //  00DF  CALL	R30	1
+      0x8C780740,  //  00E0  GETMET	R30	R3	K64
+      0x5C802E00,  //  00E1  MOVE	R32	R23
       0x5C843000,  //  00E2  MOVE	R33	R24
       0x5C883200,  //  00E3  MOVE	R34	R25
       0x5C8C3400,  //  00E4  MOVE	R35	R26
-      0x5C903600,  //  00E5  MOVE	R36	R27
-      0x7C7C0A00,  //  00E6  CALL	R31	5
-      0x90128705,  //  00E7  SETMBR	R4	K67	K5
-      0x8C7C0944,  //  00E8  GETMET	R31	R4	K68
-      0x7C7C0200,  //  00E9  CALL	R31	1
-      0x8C7C0945,  //  00EA  GETMET	R31	R4	K69
-      0x50840200,  //  00EB  LDBOOL	R33	1	0
-      0x7C7C0400,  //  00EC  CALL	R31	2
-      0x8C7C0946,  //  00ED  GETMET	R31	R4	K70
-      0x7C7C0200,  //  00EE  CALL	R31	1
-      0x8C7C0947,  //  00EF  GETMET	R31	R4	K71
-      0x7C7C0200,  //  00F0  CALL	R31	1
-      0x8C7C0948,  //  00F1  GETMET	R31	R4	K72
-      0x7C7C0200,  //  00F2  CALL	R31	1
-      0x507C0200,  //  00F3  LDBOOL	R31	1	0
-      0x80043E00,  //  00F4  RET	1	R31
-      0x70020000,  //  00F5  JMP		#00F7
-      0x50180000,  //  00F6  LDBOOL	R6	0	0
-      0x5C200C00,  //  00F7  MOVE	R8	R6
-      0x742200E6,  //  00F8  JMPT	R8	#01E0
-      0x8C200149,  //  00F9  GETMET	R8	R0	K73
-      0x88280B4A,  //  00FA  GETMBR	R10	R5	K74
-      0x882C0B1B,  //  00FB  GETMBR	R11	R5	K27
-      0x7C200600,  //  00FC  CALL	R8	3
-      0x90123408,  //  00FD  SETMBR	R4	K26	R8
-      0x4C240000,  //  00FE  LDNIL	R9
-      0x1C240809,  //  00FF  EQ	R9	R4	R9
-      0x74260003,  //  0100  JMPT	R9	#0105
-      0x8824091A,  //  0101  GETMBR	R9	R4	K26
-      0x4C280000,  //  0102  LDNIL	R10
-      0x1C24120A,  //  0103  EQ	R9	R9	R10
-      0x7826000D,  //  0104  JMPF	R9	#0113
-      0xB8260E00,  //  0105  GETNGBL	R9	K7
-      0x8C241308,  //  0106  GETMET	R9	R9	K8
-      0x582C004B,  //  0107  LDCONST	R11	K75
-      0x5830000A,  //  0108  LDCONST	R12	K10
-      0x7C240600,  //  0109  CALL	R9	3
-      0x8C24010B,  //  010A  GETMET	R9	R0	K11
-      0x5C2C0200,  //  010B  MOVE	R11	R1
-      0x5830000C,  //  010C  LDCONST	R12	K12
-      0x58340005,  //  010D  LDCONST	R13	K5
-      0x5838000C,  //  010E  LDCONST	R14	K12
-      0x503C0000,  //  010F  LDBOOL	R15	0	0
-      0x7C240C00,  //  0110  CALL	R9	6
-      0x50240000,  //  0111  LDBOOL	R9	0	0
-      0x80041200,  //  0112  RET	1	R9
-      0x88240327,  //  0113  GETMBR	R9	R1	K39
-      0x90124C09,  //  0114  SETMBR	R4	K38	R9
-      0x8C240928,  //  0115  GETMET	R9	R4	K40
-      0x7C240200,  //  0116  CALL	R9	1
-      0x88240B2A,  //  0117  GETMBR	R9	R5	K42
-      0x90125209,  //  0118  SETMBR	R4	K41	R9
-      0x88240117,  //  0119  GETMBR	R9	R0	K23
-      0x88241318,  //  011A  GETMBR	R9	R9	K24
-      0x8C24132C,  //  011B  GETMET	R9	R9	K44
-      0x7C240200,  //  011C  CALL	R9	1
-      0x90125609,  //  011D  SETMBR	R4	K43	R9
-      0xB8260E00,  //  011E  GETNGBL	R9	K7
-      0x8C241308,  //  011F  GETMET	R9	R9	K8
-      0x8C2C072D,  //  0120  GETMET	R11	R3	K45
-      0x5834002E,  //  0121  LDCONST	R13	K46
-      0x8838092B,  //  0122  GETMBR	R14	R4	K43
-      0x883C032F,  //  0123  GETMBR	R15	R1	K47
-      0x88400330,  //  0124  GETMBR	R16	R1	K48
-      0x7C2C0A00,  //  0125  CALL	R11	5
-      0x5830000A,  //  0126  LDCONST	R12	K10
-      0x7C240600,  //  0127  CALL	R9	3
-      0x8C240532,  //  0128  GETMET	R9	R2	K50
-      0x542E000F,  //  0129  LDINT	R11	16
-      0x7C240400,  //  012A  CALL	R9	2
-      0x90126209,  //  012B  SETMBR	R4	K49	R9
-      0x8C240532,  //  012C  GETMET	R9	R2	K50
-      0x542E001F,  //  012D  LDINT	R11	32
-      0x7C240400,  //  012E  CALL	R9	2
-      0x90129809,  //  012F  SETMBR	R4	K76	R9
-      0x8C24054E,  //  0130  GETMET	R9	R2	K78
-      0x7C240200,  //  0131  CALL	R9	1
-      0x8C24134F,  //  0132  GETMET	R9	R9	K79
-      0x882C094C,  //  0133  GETMBR	R11	R4	K76
-      0x7C240400,  //  0134  CALL	R9	2
-      0x90129A09,  //  0135  SETMBR	R4	K77	R9
-      0x8C240532,  //  0136  GETMET	R9	R2	K50
-      0x542E001F,  //  0137  LDINT	R11	32
-      0x7C240400,  //  0138  CALL	R9	2
-      0x8C28054E,  //  0139  GETMET	R10	R2	K78
-      0x7C280200,  //  013A  CALL	R10	1
-      0x8C281550,  //  013B  GETMET	R10	R10	K80
-      0x8830094C,  //  013C  GETMBR	R12	R4	K76
-      0x88340B14,  //  013D  GETMBR	R13	R5	K20
-      0x7C280600,  //  013E  CALL	R10	3
-      0x9012400A,  //  013F  SETMBR	R4	K32	R10
-      0xB82A1C00,  //  0140  GETNGBL	R10	K14
-      0x88281551,  //  0141  GETMBR	R10	R10	K81
-      0x8C281552,  //  0142  GETMET	R10	R10	K82
-      0x7C280200,  //  0143  CALL	R10	1
-      0x8C2C1553,  //  0144  GETMET	R11	R10	K83
-      0x5834000C,  //  0145  LDCONST	R13	K12
-      0xB83A1C00,  //  0146  GETNGBL	R14	K14
-      0x88381D51,  //  0147  GETMBR	R14	R14	K81
-      0x88381D54,  //  0148  GETMBR	R14	R14	K84
-      0x8C3C1155,  //  0149  GETMET	R15	R8	K85
-      0x7C3C0200,  //  014A  CALL	R15	1
-      0x7C2C0800,  //  014B  CALL	R11	4
-      0x8C2C1553,  //  014C  GETMET	R11	R10	K83
-      0x5834000D,  //  014D  LDCONST	R13	K13
-      0xB83A1C00,  //  014E  GETNGBL	R14	K14
-      0x88381D51,  //  014F  GETMBR	R14	R14	K81
-      0x88381D54,  //  0150  GETMBR	R14	R14	K84
-      0x8C3C1156,  //  0151  GETMET	R15	R8	K86
-      0x7C3C0200,  //  0152  CALL	R15	1
-      0x7C2C0800,  //  0153  CALL	R11	4
-      0x8C2C1553,  //  0154  GETMET	R11	R10	K83
-      0x5834000A,  //  0155  LDCONST	R13	K10
-      0xB83A1C00,  //  0156  GETNGBL	R14	K14
-      0x88381D51,  //  0157  GETMBR	R14	R14	K81
-      0x88381D54,  //  0158  GETMBR	R14	R14	K84
-      0x883C094D,  //  0159  GETMBR	R15	R4	K77
-      0x7C2C0800,  //  015A  CALL	R11	4
-      0x8C2C1553,  //  015B  GETMET	R11	R10	K83
-      0x54360003,  //  015C  LDINT	R13	4
-      0xB83A1C00,  //  015D  GETNGBL	R14	K14
-      0x88381D51,  //  015E  GETMBR	R14	R14	K81
-      0x88381D54,  //  015F  GETMBR	R14	R14	K84
-      0x883C0B14,  //  0160  GETMBR	R15	R5	K20
-      0x7C2C0800,  //  0161  CALL	R11	4
-      0x8C2C054E,  //  0162  GETMET	R11	R2	K78
-      0x7C2C0200,  //  0163  CALL	R11	1
-      0x8C2C1757,  //  0164  GETMET	R11	R11	K87
-      0x8C341158,  //  0165  GETMET	R13	R8	K88
-      0x7C340200,  //  0166  CALL	R13	1
-      0x8C38153B,  //  0167  GETMET	R14	R10	K59
-      0x7C380200,  //  0168  CALL	R14	1
-      0x7C2C0600,  //  0169  CALL	R11	3
-      0xB8321C00,  //  016A  GETNGBL	R12	K14
-      0x88301951,  //  016B  GETMBR	R12	R12	K81
-      0x8C301952,  //  016C  GETMET	R12	R12	K82
-      0x7C300200,  //  016D  CALL	R12	1
-      0x8C341953,  //  016E  GETMET	R13	R12	K83
-      0x583C000C,  //  016F  LDCONST	R15	K12
-      0xB8421C00,  //  0170  GETNGBL	R16	K14
-      0x88402151,  //  0171  GETMBR	R16	R16	K81
-      0x88402154,  //  0172  GETMBR	R16	R16	K84
-      0x8C441155,  //  0173  GETMET	R17	R8	K85
-      0x7C440200,  //  0174  CALL	R17	1
-      0x7C340800,  //  0175  CALL	R13	4
-      0x8C341953,  //  0176  GETMET	R13	R12	K83
-      0x583C000D,  //  0177  LDCONST	R15	K13
-      0xB8421C00,  //  0178  GETNGBL	R16	K14
-      0x88402151,  //  0179  GETMBR	R16	R16	K81
-      0x88402154,  //  017A  GETMBR	R16	R16	K84
-      0x8C441156,  //  017B  GETMET	R17	R8	K86
-      0x7C440200,  //  017C  CALL	R17	1
-      0x7C340800,  //  017D  CALL	R13	4
-      0x8C341953,  //  017E  GETMET	R13	R12	K83
-      0x583C000A,  //  017F  LDCONST	R15	K10
-      0xB8421C00,  //  0180  GETNGBL	R16	K14
-      0x88402151,  //  0181  GETMBR	R16	R16	K81
-      0x88402154,  //  0182  GETMBR	R16	R16	K84
-      0x5C441600,  //  0183  MOVE	R17	R11
-      0x7C340800,  //  0184  CALL	R13	4
-      0x8C341953,  //  0185  GETMET	R13	R12	K83
-      0x543E0003,  //  0186  LDINT	R15	4
-      0xB8421C00,  //  0187  GETNGBL	R16	K14
-      0x88402151,  //  0188  GETMBR	R16	R16	K81
-      0x88402154,  //  0189  GETMBR	R16	R16	K84
-      0x88440931,  //  018A  GETMBR	R17	R4	K49
-      0x7C340800,  //  018B  CALL	R13	4
-      0x88340B59,  //  018C  GETMBR	R13	R5	K89
-      0x9012780D,  //  018D  SETMBR	R4	K60	R13
-      0x8C34055A,  //  018E  GETMET	R13	R2	K90
-      0x7C340200,  //  018F  CALL	R13	1
-      0x8C341B5B,  //  0190  GETMET	R13	R13	K91
-      0x883C093C,  //  0191  GETMBR	R15	R4	K60
-      0x7C340400,  //  0192  CALL	R13	2
-      0x8C341B5C,  //  0193  GETMET	R13	R13	K92
-      0x7C340200,  //  0194  CALL	R13	1
-      0x60380015,  //  0195  GETGBL	R14	G21
-      0x7C380000,  //  0196  CALL	R14	0
-      0x8C381D1C,  //  0197  GETMET	R14	R14	K28
-      0x8840015D,  //  0198  GETMBR	R16	R0	K93
-      0x7C380400,  //  0199  CALL	R14	2
-      0x8C3C115E,  //  019A  GETMET	R15	R8	K94
-      0x7C3C0200,  //  019B  CALL	R15	1
-      0x003C1E09,  //  019C  ADD	R15	R15	R9
-      0x8840094D,  //  019D  GETMBR	R16	R4	K77
-      0x003C1E10,  //  019E  ADD	R15	R15	R16
-      0x003C1E0D,  //  019F  ADD	R15	R15	R13
-      0x8C40051E,  //  01A0  GETMET	R16	R2	K30
-      0x7C400200,  //  01A1  CALL	R16	1
-      0x8C40211F,  //  01A2  GETMET	R16	R16	K31
-      0x88480920,  //  01A3  GETMBR	R18	R4	K32
-      0x5C4C1E00,  //  01A4  MOVE	R19	R15
-      0x5C501C00,  //  01A5  MOVE	R20	R14
-      0x5456000F,  //  01A6  LDINT	R21	16
-      0x7C400A00,  //  01A7  CALL	R16	5
-      0x8C44193B,  //  01A8  GETMET	R17	R12	K59
-      0x7C440200,  //  01A9  CALL	R17	1
-      0x8C480523,  //  01AA  GETMET	R18	R2	K35
-      0x5C502000,  //  01AB  MOVE	R20	R16
-      0x60540015,  //  01AC  GETGBL	R21	G21
-      0x7C540000,  //  01AD  CALL	R21	0
-      0x8C542B1C,  //  01AE  GETMET	R21	R21	K28
-      0x885C015F,  //  01AF  GETMBR	R23	R0	K95
-      0x7C540400,  //  01B0  CALL	R21	2
-      0x60580015,  //  01B1  GETGBL	R22	G21
-      0x7C580000,  //  01B2  CALL	R22	0
-      0x605C000C,  //  01B3  GETGBL	R23	G12
-      0x5C602200,  //  01B4  MOVE	R24	R17
-      0x7C5C0200,  //  01B5  CALL	R23	1
-      0x5462000F,  //  01B6  LDINT	R24	16
-      0x7C480C00,  //  01B7  CALL	R18	6
-      0x8C4C2560,  //  01B8  GETMET	R19	R18	K96
-      0x5C542200,  //  01B9  MOVE	R21	R17
-      0x7C4C0400,  //  01BA  CALL	R19	2
-      0x8C502525,  //  01BB  GETMET	R20	R18	K37
-      0x7C500200,  //  01BC  CALL	R20	1
-      0x004C2614,  //  01BD  ADD	R19	R19	R20
-      0xB8521C00,  //  01BE  GETNGBL	R20	K14
-      0x8C502961,  //  01BF  GETMET	R20	R20	K97
-      0x7C500200,  //  01C0  CALL	R20	1
-      0x9052C409,  //  01C1  SETMBR	R20	K98	R9
-      0x8854092B,  //  01C2  GETMBR	R21	R4	K43
-      0x9052C615,  //  01C3  SETMBR	R20	K99	R21
-      0x8854094D,  //  01C4  GETMBR	R21	R4	K77
-      0x9052C815,  //  01C5  SETMBR	R20	K100	R21
-      0x9052CA13,  //  01C6  SETMBR	R20	K101	R19
-      0x8C54293B,  //  01C7  GETMET	R21	R20	K59
-      0x7C540200,  //  01C8  CALL	R21	1
-      0x9012CC15,  //  01C9  SETMBR	R4	K102	R21
-      0x8C58033D,  //  01CA  GETMET	R22	R1	K61
-      0x54620030,  //  01CB  LDINT	R24	49
-      0x50640200,  //  01CC  LDBOOL	R25	1	0
-      0x7C580600,  //  01CD  CALL	R22	3
-      0x8C5C2D3E,  //  01CE  GETMET	R23	R22	K62
-      0x5C642A00,  //  01CF  MOVE	R25	R21
-      0x7C5C0400,  //  01D0  CALL	R23	2
-      0xB8620E00,  //  01D1  GETNGBL	R24	K7
-      0x8C603108,  //  01D2  GETMET	R24	R24	K8
-      0x8C68072D,  //  01D3  GETMET	R26	R3	K45
-      0x58700067,  //  01D4  LDCONST	R28	K103
-      0x8874092B,  //  01D5  GETMBR	R29	R4	K43
-      0x88780968,  //  01D6  GETMBR	R30	R4	K104
-      0x887C0969,  //  01D7  GETMBR	R31	R4	K105
-      0x7C680A00,  //  01D8  CALL	R26	5
-      0x7C600400,  //  01D9  CALL	R24	2
-      0x8860013F,  //  01DA  GETMBR	R24	R0	K63
-      0x8C603140,  //  01DB  GETMET	R24	R24	K64
-      0x5C682C00,  //  01DC  MOVE	R26	R22
-      0x7C600400,  //  01DD  CALL	R24	2
-      0x50600200,  //  01DE  LDBOOL	R24	1	0
-      0x80043000,  //  01DF  RET	1	R24
-      0x50200200,  //  01E0  LDBOOL	R8	1	0
-      0x80041000,  //  01E1  RET	1	R8
+      0x7C780A00,  //  00E5  CALL	R30	5
+      0x900E8304,  //  00E6  SETMBR	R3	K65	K4
+      0x8C780742,  //  00E7  GETMET	R30	R3	K66
+      0x7C780200,  //  00E8  CALL	R30	1
+      0x8C780743,  //  00E9  GETMET	R30	R3	K67
+      0x50800200,  //  00EA  LDBOOL	R32	1	0
+      0x7C780400,  //  00EB  CALL	R30	2
+      0x8C780744,  //  00EC  GETMET	R30	R3	K68
+      0x7C780200,  //  00ED  CALL	R30	1
+      0x8C780745,  //  00EE  GETMET	R30	R3	K69
+      0x7C780200,  //  00EF  CALL	R30	1
+      0x8C780746,  //  00F0  GETMET	R30	R3	K70
+      0x7C780200,  //  00F1  CALL	R30	1
+      0x50780200,  //  00F2  LDBOOL	R30	1	0
+      0x80043C00,  //  00F3  RET	1	R30
+      0x70020000,  //  00F4  JMP		#00F6
+      0x50140000,  //  00F5  LDBOOL	R5	0	0
+      0x5C1C0A00,  //  00F6  MOVE	R7	R5
+      0x741E00E6,  //  00F7  JMPT	R7	#01DF
+      0x8C1C0147,  //  00F8  GETMET	R7	R0	K71
+      0x88240948,  //  00F9  GETMBR	R9	R4	K72
+      0x8828091A,  //  00FA  GETMBR	R10	R4	K26
+      0x7C1C0600,  //  00FB  CALL	R7	3
+      0x900E3207,  //  00FC  SETMBR	R3	K25	R7
+      0x4C200000,  //  00FD  LDNIL	R8
+      0x1C200608,  //  00FE  EQ	R8	R3	R8
+      0x74220003,  //  00FF  JMPT	R8	#0104
+      0x88200719,  //  0100  GETMBR	R8	R3	K25
+      0x4C240000,  //  0101  LDNIL	R9
+      0x1C201009,  //  0102  EQ	R8	R8	R9
+      0x7822000D,  //  0103  JMPF	R8	#0112
+      0xB8220C00,  //  0104  GETNGBL	R8	K6
+      0x8C201107,  //  0105  GETMET	R8	R8	K7
+      0x58280049,  //  0106  LDCONST	R10	K73
+      0x582C0009,  //  0107  LDCONST	R11	K9
+      0x7C200600,  //  0108  CALL	R8	3
+      0x8C20010A,  //  0109  GETMET	R8	R0	K10
+      0x5C280200,  //  010A  MOVE	R10	R1
+      0x582C000B,  //  010B  LDCONST	R11	K11
+      0x58300004,  //  010C  LDCONST	R12	K4
+      0x5834000B,  //  010D  LDCONST	R13	K11
+      0x50380000,  //  010E  LDBOOL	R14	0	0
+      0x7C200C00,  //  010F  CALL	R8	6
+      0x50200000,  //  0110  LDBOOL	R8	0	0
+      0x80041000,  //  0111  RET	1	R8
+      0x88200326,  //  0112  GETMBR	R8	R1	K38
+      0x900E4A08,  //  0113  SETMBR	R3	K37	R8
+      0x8C200727,  //  0114  GETMET	R8	R3	K39
+      0x7C200200,  //  0115  CALL	R8	1
+      0x88200929,  //  0116  GETMBR	R8	R4	K41
+      0x900E5008,  //  0117  SETMBR	R3	K40	R8
+      0x88200116,  //  0118  GETMBR	R8	R0	K22
+      0x88201117,  //  0119  GETMBR	R8	R8	K23
+      0x8C20112B,  //  011A  GETMET	R8	R8	K43
+      0x7C200200,  //  011B  CALL	R8	1
+      0x900E5408,  //  011C  SETMBR	R3	K42	R8
+      0xB8220C00,  //  011D  GETNGBL	R8	K6
+      0x8C201107,  //  011E  GETMET	R8	R8	K7
+      0x60280018,  //  011F  GETGBL	R10	G24
+      0x582C002C,  //  0120  LDCONST	R11	K44
+      0x8830072A,  //  0121  GETMBR	R12	R3	K42
+      0x8834032D,  //  0122  GETMBR	R13	R1	K45
+      0x8838032E,  //  0123  GETMBR	R14	R1	K46
+      0x7C280800,  //  0124  CALL	R10	4
+      0x582C0009,  //  0125  LDCONST	R11	K9
+      0x7C200600,  //  0126  CALL	R8	3
+      0x8C200530,  //  0127  GETMET	R8	R2	K48
+      0x542A000F,  //  0128  LDINT	R10	16
+      0x7C200400,  //  0129  CALL	R8	2
+      0x900E5E08,  //  012A  SETMBR	R3	K47	R8
+      0x8C200530,  //  012B  GETMET	R8	R2	K48
+      0x542A001F,  //  012C  LDINT	R10	32
+      0x7C200400,  //  012D  CALL	R8	2
+      0x900E9408,  //  012E  SETMBR	R3	K74	R8
+      0x8C20054C,  //  012F  GETMET	R8	R2	K76
+      0x7C200200,  //  0130  CALL	R8	1
+      0x8C20114D,  //  0131  GETMET	R8	R8	K77
+      0x8828074A,  //  0132  GETMBR	R10	R3	K74
+      0x7C200400,  //  0133  CALL	R8	2
+      0x900E9608,  //  0134  SETMBR	R3	K75	R8
+      0x8C200530,  //  0135  GETMET	R8	R2	K48
+      0x542A001F,  //  0136  LDINT	R10	32
+      0x7C200400,  //  0137  CALL	R8	2
+      0x8C24054C,  //  0138  GETMET	R9	R2	K76
+      0x7C240200,  //  0139  CALL	R9	1
+      0x8C24134E,  //  013A  GETMET	R9	R9	K78
+      0x882C074A,  //  013B  GETMBR	R11	R3	K74
+      0x88300913,  //  013C  GETMBR	R12	R4	K19
+      0x7C240600,  //  013D  CALL	R9	3
+      0x900E3E09,  //  013E  SETMBR	R3	K31	R9
+      0xB8261A00,  //  013F  GETNGBL	R9	K13
+      0x8824134F,  //  0140  GETMBR	R9	R9	K79
+      0x8C241350,  //  0141  GETMET	R9	R9	K80
+      0x7C240200,  //  0142  CALL	R9	1
+      0x8C281351,  //  0143  GETMET	R10	R9	K81
+      0x5830000B,  //  0144  LDCONST	R12	K11
+      0xB8361A00,  //  0145  GETNGBL	R13	K13
+      0x88341B4F,  //  0146  GETMBR	R13	R13	K79
+      0x88341B52,  //  0147  GETMBR	R13	R13	K82
+      0x8C380F53,  //  0148  GETMET	R14	R7	K83
+      0x7C380200,  //  0149  CALL	R14	1
+      0x7C280800,  //  014A  CALL	R10	4
+      0x8C281351,  //  014B  GETMET	R10	R9	K81
+      0x5830000C,  //  014C  LDCONST	R12	K12
+      0xB8361A00,  //  014D  GETNGBL	R13	K13
+      0x88341B4F,  //  014E  GETMBR	R13	R13	K79
+      0x88341B52,  //  014F  GETMBR	R13	R13	K82
+      0x8C380F54,  //  0150  GETMET	R14	R7	K84
+      0x7C380200,  //  0151  CALL	R14	1
+      0x7C280800,  //  0152  CALL	R10	4
+      0x8C281351,  //  0153  GETMET	R10	R9	K81
+      0x58300009,  //  0154  LDCONST	R12	K9
+      0xB8361A00,  //  0155  GETNGBL	R13	K13
+      0x88341B4F,  //  0156  GETMBR	R13	R13	K79
+      0x88341B52,  //  0157  GETMBR	R13	R13	K82
+      0x8838074B,  //  0158  GETMBR	R14	R3	K75
+      0x7C280800,  //  0159  CALL	R10	4
+      0x8C281351,  //  015A  GETMET	R10	R9	K81
+      0x54320003,  //  015B  LDINT	R12	4
+      0xB8361A00,  //  015C  GETNGBL	R13	K13
+      0x88341B4F,  //  015D  GETMBR	R13	R13	K79
+      0x88341B52,  //  015E  GETMBR	R13	R13	K82
+      0x88380913,  //  015F  GETMBR	R14	R4	K19
+      0x7C280800,  //  0160  CALL	R10	4
+      0x8C28054C,  //  0161  GETMET	R10	R2	K76
+      0x7C280200,  //  0162  CALL	R10	1
+      0x8C281555,  //  0163  GETMET	R10	R10	K85
+      0x8C300F56,  //  0164  GETMET	R12	R7	K86
+      0x7C300200,  //  0165  CALL	R12	1
+      0x8C341339,  //  0166  GETMET	R13	R9	K57
+      0x7C340200,  //  0167  CALL	R13	1
+      0x7C280600,  //  0168  CALL	R10	3
+      0xB82E1A00,  //  0169  GETNGBL	R11	K13
+      0x882C174F,  //  016A  GETMBR	R11	R11	K79
+      0x8C2C1750,  //  016B  GETMET	R11	R11	K80
+      0x7C2C0200,  //  016C  CALL	R11	1
+      0x8C301751,  //  016D  GETMET	R12	R11	K81
+      0x5838000B,  //  016E  LDCONST	R14	K11
+      0xB83E1A00,  //  016F  GETNGBL	R15	K13
+      0x883C1F4F,  //  0170  GETMBR	R15	R15	K79
+      0x883C1F52,  //  0171  GETMBR	R15	R15	K82
+      0x8C400F53,  //  0172  GETMET	R16	R7	K83
+      0x7C400200,  //  0173  CALL	R16	1
+      0x7C300800,  //  0174  CALL	R12	4
+      0x8C301751,  //  0175  GETMET	R12	R11	K81
+      0x5838000C,  //  0176  LDCONST	R14	K12
+      0xB83E1A00,  //  0177  GETNGBL	R15	K13
+      0x883C1F4F,  //  0178  GETMBR	R15	R15	K79
+      0x883C1F52,  //  0179  GETMBR	R15	R15	K82
+      0x8C400F54,  //  017A  GETMET	R16	R7	K84
+      0x7C400200,  //  017B  CALL	R16	1
+      0x7C300800,  //  017C  CALL	R12	4
+      0x8C301751,  //  017D  GETMET	R12	R11	K81
+      0x58380009,  //  017E  LDCONST	R14	K9
+      0xB83E1A00,  //  017F  GETNGBL	R15	K13
+      0x883C1F4F,  //  0180  GETMBR	R15	R15	K79
+      0x883C1F52,  //  0181  GETMBR	R15	R15	K82
+      0x5C401400,  //  0182  MOVE	R16	R10
+      0x7C300800,  //  0183  CALL	R12	4
+      0x8C301751,  //  0184  GETMET	R12	R11	K81
+      0x543A0003,  //  0185  LDINT	R14	4
+      0xB83E1A00,  //  0186  GETNGBL	R15	K13
+      0x883C1F4F,  //  0187  GETMBR	R15	R15	K79
+      0x883C1F52,  //  0188  GETMBR	R15	R15	K82
+      0x8840072F,  //  0189  GETMBR	R16	R3	K47
+      0x7C300800,  //  018A  CALL	R12	4
+      0x88300957,  //  018B  GETMBR	R12	R4	K87
+      0x900E740C,  //  018C  SETMBR	R3	K58	R12
+      0x8C300558,  //  018D  GETMET	R12	R2	K88
+      0x7C300200,  //  018E  CALL	R12	1
+      0x8C301959,  //  018F  GETMET	R12	R12	K89
+      0x8838073A,  //  0190  GETMBR	R14	R3	K58
+      0x7C300400,  //  0191  CALL	R12	2
+      0x8C30195A,  //  0192  GETMET	R12	R12	K90
+      0x7C300200,  //  0193  CALL	R12	1
+      0x60340015,  //  0194  GETGBL	R13	G21
+      0x7C340000,  //  0195  CALL	R13	0
+      0x8C341B1B,  //  0196  GETMET	R13	R13	K27
+      0x883C015B,  //  0197  GETMBR	R15	R0	K91
+      0x7C340400,  //  0198  CALL	R13	2
+      0x8C380F5C,  //  0199  GETMET	R14	R7	K92
+      0x7C380200,  //  019A  CALL	R14	1
+      0x00381C08,  //  019B  ADD	R14	R14	R8
+      0x883C074B,  //  019C  GETMBR	R15	R3	K75
+      0x00381C0F,  //  019D  ADD	R14	R14	R15
+      0x00381C0C,  //  019E  ADD	R14	R14	R12
+      0x8C3C051D,  //  019F  GETMET	R15	R2	K29
+      0x7C3C0200,  //  01A0  CALL	R15	1
+      0x8C3C1F1E,  //  01A1  GETMET	R15	R15	K30
+      0x8844071F,  //  01A2  GETMBR	R17	R3	K31
+      0x5C481C00,  //  01A3  MOVE	R18	R14
+      0x5C4C1A00,  //  01A4  MOVE	R19	R13
+      0x5452000F,  //  01A5  LDINT	R20	16
+      0x7C3C0A00,  //  01A6  CALL	R15	5
+      0x8C401739,  //  01A7  GETMET	R16	R11	K57
+      0x7C400200,  //  01A8  CALL	R16	1
+      0x8C440522,  //  01A9  GETMET	R17	R2	K34
+      0x5C4C1E00,  //  01AA  MOVE	R19	R15
+      0x60500015,  //  01AB  GETGBL	R20	G21
+      0x7C500000,  //  01AC  CALL	R20	0
+      0x8C50291B,  //  01AD  GETMET	R20	R20	K27
+      0x8858015D,  //  01AE  GETMBR	R22	R0	K93
+      0x7C500400,  //  01AF  CALL	R20	2
+      0x60540015,  //  01B0  GETGBL	R21	G21
+      0x7C540000,  //  01B1  CALL	R21	0
+      0x6058000C,  //  01B2  GETGBL	R22	G12
+      0x5C5C2000,  //  01B3  MOVE	R23	R16
+      0x7C580200,  //  01B4  CALL	R22	1
+      0x545E000F,  //  01B5  LDINT	R23	16
+      0x7C440C00,  //  01B6  CALL	R17	6
+      0x8C48235E,  //  01B7  GETMET	R18	R17	K94
+      0x5C502000,  //  01B8  MOVE	R20	R16
+      0x7C480400,  //  01B9  CALL	R18	2
+      0x8C4C2324,  //  01BA  GETMET	R19	R17	K36
+      0x7C4C0200,  //  01BB  CALL	R19	1
+      0x00482413,  //  01BC  ADD	R18	R18	R19
+      0xB84E1A00,  //  01BD  GETNGBL	R19	K13
+      0x8C4C275F,  //  01BE  GETMET	R19	R19	K95
+      0x7C4C0200,  //  01BF  CALL	R19	1
+      0x904EC008,  //  01C0  SETMBR	R19	K96	R8
+      0x8850072A,  //  01C1  GETMBR	R20	R3	K42
+      0x904EC214,  //  01C2  SETMBR	R19	K97	R20
+      0x8850074B,  //  01C3  GETMBR	R20	R3	K75
+      0x904EC414,  //  01C4  SETMBR	R19	K98	R20
+      0x904EC612,  //  01C5  SETMBR	R19	K99	R18
+      0x8C502739,  //  01C6  GETMET	R20	R19	K57
+      0x7C500200,  //  01C7  CALL	R20	1
+      0x900EC814,  //  01C8  SETMBR	R3	K100	R20
+      0x8C54033B,  //  01C9  GETMET	R21	R1	K59
+      0x545E0030,  //  01CA  LDINT	R23	49
+      0x50600200,  //  01CB  LDBOOL	R24	1	0
+      0x7C540600,  //  01CC  CALL	R21	3
+      0x8C582B3C,  //  01CD  GETMET	R22	R21	K60
+      0x5C602800,  //  01CE  MOVE	R24	R20
+      0x7C580400,  //  01CF  CALL	R22	2
+      0xB85E0C00,  //  01D0  GETNGBL	R23	K6
+      0x8C5C2F07,  //  01D1  GETMET	R23	R23	K7
+      0x60640018,  //  01D2  GETGBL	R25	G24
+      0x58680065,  //  01D3  LDCONST	R26	K101
+      0x886C072A,  //  01D4  GETMBR	R27	R3	K42
+      0x88700766,  //  01D5  GETMBR	R28	R3	K102
+      0x88740767,  //  01D6  GETMBR	R29	R3	K103
+      0x7C640800,  //  01D7  CALL	R25	4
+      0x7C5C0400,  //  01D8  CALL	R23	2
+      0x885C013D,  //  01D9  GETMBR	R23	R0	K61
+      0x8C5C2F3E,  //  01DA  GETMET	R23	R23	K62
+      0x5C642A00,  //  01DB  MOVE	R25	R21
+      0x7C5C0400,  //  01DC  CALL	R23	2
+      0x505C0200,  //  01DD  LDBOOL	R23	1	0
+      0x80042E00,  //  01DE  RET	1	R23
+      0x501C0200,  //  01DF  LDBOOL	R7	1	0
+      0x80040E00,  //  01E0  RET	1	R7
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Control_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Control_Message.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Control_Message;
 ********************************************************************/
 be_local_closure(Matter_Control_Message_parse_MsgCounterSyncRsp,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    9,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,39 +19,36 @@ be_local_closure(Matter_Control_Message_parse_MsgCounterSyncRsp,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(session),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20_X3EMCSyncRsp_X20_X2A_X20Not_X20implemented_X20_X25s),
-    /* K6   */  be_nested_str_weak(raw),
-    /* K7   */  be_nested_str_weak(app_payload_idx),
-    /* K8   */  be_const_int(2147483647),
-    /* K9   */  be_nested_str_weak(tohex),
-    /* K10  */  be_const_int(2),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(session),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20_X3EMCSyncRsp_X20_X2A_X20Not_X20implemented_X20_X25s),
+    /* K4   */  be_nested_str_weak(raw),
+    /* K5   */  be_nested_str_weak(app_payload_idx),
+    /* K6   */  be_const_int(2147483647),
+    /* K7   */  be_nested_str_weak(tohex),
+    /* K8   */  be_const_int(2),
     }),
     be_str_weak(parse_MsgCounterSyncRsp),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
-      0xB8120400,  //  0002  GETNGBL	R4	K2
-      0x8C100903,  //  0003  GETMET	R4	R4	K3
-      0x8C180504,  //  0004  GETMET	R6	R2	K4
-      0x58200005,  //  0005  LDCONST	R8	K5
-      0x88240307,  //  0006  GETMBR	R9	R1	K7
-      0x40241308,  //  0007  CONNECT	R9	R9	K8
-      0x88280306,  //  0008  GETMBR	R10	R1	K6
-      0x94241409,  //  0009  GETIDX	R9	R10	R9
-      0x8C241309,  //  000A  GETMET	R9	R9	K9
-      0x7C240200,  //  000B  CALL	R9	1
-      0x7C180600,  //  000C  CALL	R6	3
-      0x581C000A,  //  000D  LDCONST	R7	K10
-      0x7C100600,  //  000E  CALL	R4	3
-      0x50100000,  //  000F  LDBOOL	R4	0	0
-      0x80040800,  //  0010  RET	1	R4
+    ( &(const binstruction[16]) {  /* code */
+      0x88080300,  //  0000  GETMBR	R2	R1	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x60140018,  //  0003  GETGBL	R5	G24
+      0x58180003,  //  0004  LDCONST	R6	K3
+      0x881C0305,  //  0005  GETMBR	R7	R1	K5
+      0x401C0F06,  //  0006  CONNECT	R7	R7	K6
+      0x88200304,  //  0007  GETMBR	R8	R1	K4
+      0x941C1007,  //  0008  GETIDX	R7	R8	R7
+      0x8C1C0F07,  //  0009  GETMET	R7	R7	K7
+      0x7C1C0200,  //  000A  CALL	R7	1
+      0x7C140400,  //  000B  CALL	R5	2
+      0x58180008,  //  000C  LDCONST	R6	K8
+      0x7C0C0600,  //  000D  CALL	R3	3
+      0x500C0000,  //  000E  LDBOOL	R3	0	0
+      0x80040600,  //  000F  RET	1	R3
     })
   )
 );
@@ -63,7 +60,7 @@ be_local_closure(Matter_Control_Message_parse_MsgCounterSyncRsp,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Control_Message_parse_MsgCounterSyncReq,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    9,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -71,39 +68,36 @@ be_local_closure(Matter_Control_Message_parse_MsgCounterSyncReq,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(session),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20_X3EMCSyncReq_X20_X2A_X20Not_X20implemented_X20_X25s),
-    /* K6   */  be_nested_str_weak(raw),
-    /* K7   */  be_nested_str_weak(app_payload_idx),
-    /* K8   */  be_const_int(2147483647),
-    /* K9   */  be_nested_str_weak(tohex),
-    /* K10  */  be_const_int(2),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(session),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20_X3EMCSyncReq_X20_X2A_X20Not_X20implemented_X20_X25s),
+    /* K4   */  be_nested_str_weak(raw),
+    /* K5   */  be_nested_str_weak(app_payload_idx),
+    /* K6   */  be_const_int(2147483647),
+    /* K7   */  be_nested_str_weak(tohex),
+    /* K8   */  be_const_int(2),
     }),
     be_str_weak(parse_MsgCounterSyncReq),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
-      0xB8120400,  //  0002  GETNGBL	R4	K2
-      0x8C100903,  //  0003  GETMET	R4	R4	K3
-      0x8C180504,  //  0004  GETMET	R6	R2	K4
-      0x58200005,  //  0005  LDCONST	R8	K5
-      0x88240307,  //  0006  GETMBR	R9	R1	K7
-      0x40241308,  //  0007  CONNECT	R9	R9	K8
-      0x88280306,  //  0008  GETMBR	R10	R1	K6
-      0x94241409,  //  0009  GETIDX	R9	R10	R9
-      0x8C241309,  //  000A  GETMET	R9	R9	K9
-      0x7C240200,  //  000B  CALL	R9	1
-      0x7C180600,  //  000C  CALL	R6	3
-      0x581C000A,  //  000D  LDCONST	R7	K10
-      0x7C100600,  //  000E  CALL	R4	3
-      0x50100000,  //  000F  LDBOOL	R4	0	0
-      0x80040800,  //  0010  RET	1	R4
+    ( &(const binstruction[16]) {  /* code */
+      0x88080300,  //  0000  GETMBR	R2	R1	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x60140018,  //  0003  GETGBL	R5	G24
+      0x58180003,  //  0004  LDCONST	R6	K3
+      0x881C0305,  //  0005  GETMBR	R7	R1	K5
+      0x401C0F06,  //  0006  CONNECT	R7	R7	K6
+      0x88200304,  //  0007  GETMBR	R8	R1	K4
+      0x941C1007,  //  0008  GETIDX	R7	R8	R7
+      0x8C1C0F07,  //  0009  GETMET	R7	R7	K7
+      0x7C1C0200,  //  000A  CALL	R7	1
+      0x7C140400,  //  000B  CALL	R5	2
+      0x58180008,  //  000C  LDCONST	R6	K8
+      0x7C0C0600,  //  000D  CALL	R3	3
+      0x500C0000,  //  000E  LDBOOL	R3	0	0
+      0x80040600,  //  000F  RET	1	R3
     })
   )
 );
@@ -147,7 +141,7 @@ be_local_closure(Matter_Control_Message_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Control_Message_process_incoming_control_message,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    7,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -155,7 +149,7 @@ be_local_closure(Matter_Control_Message_process_incoming_control_message,   /* n
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
+    ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
     /* K1   */  be_nested_str_weak(log),
     /* K2   */  be_nested_str_weak(MTR_X3A_X20received_X20control_X20message_X20),
@@ -167,14 +161,12 @@ be_local_closure(Matter_Control_Message_process_incoming_control_message,   /* n
     /* K8   */  be_nested_str_weak(parse_MsgCounterSyncReq),
     /* K9   */  be_const_int(1),
     /* K10  */  be_nested_str_weak(parse_MsgCounterSyncRsp),
-    /* K11  */  be_nested_str_weak(string),
-    /* K12  */  be_nested_str_weak(format),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28control_X20message_X29_X20_X2502X),
-    /* K14  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28control_X20message_X29_X20_X2502X),
+    /* K12  */  be_const_int(2),
     }),
     be_str_weak(process_incoming_control_message),
     &be_const_str_solidified,
-    ( &(const binstruction[38]) {  /* code */
+    ( &(const binstruction[37]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
       0x8C080501,  //  0001  GETMET	R2	R2	K1
       0xB8120600,  //  0002  GETNGBL	R4	K3
@@ -191,7 +183,7 @@ be_local_closure(Matter_Control_Message_process_incoming_control_message,   /* n
       0x5C100200,  //  000D  MOVE	R4	R1
       0x7C080400,  //  000E  CALL	R2	2
       0x80040400,  //  000F  RET	1	R2
-      0x70020012,  //  0010  JMP		#0024
+      0x70020011,  //  0010  JMP		#0023
       0x88080306,  //  0011  GETMBR	R2	R1	K6
       0x1C080509,  //  0012  EQ	R2	R2	K9
       0x780A0004,  //  0013  JMPF	R2	#0019
@@ -199,20 +191,19 @@ be_local_closure(Matter_Control_Message_process_incoming_control_message,   /* n
       0x5C100200,  //  0015  MOVE	R4	R1
       0x7C080400,  //  0016  CALL	R2	2
       0x80040400,  //  0017  RET	1	R2
-      0x7002000A,  //  0018  JMP		#0024
-      0xA40A1600,  //  0019  IMPORT	R2	K11
-      0xB80E0000,  //  001A  GETNGBL	R3	K0
-      0x8C0C0701,  //  001B  GETMET	R3	R3	K1
-      0x8C14050C,  //  001C  GETMET	R5	R2	K12
-      0x581C000D,  //  001D  LDCONST	R7	K13
-      0x88200306,  //  001E  GETMBR	R8	R1	K6
-      0x7C140600,  //  001F  CALL	R5	3
-      0x5818000E,  //  0020  LDCONST	R6	K14
-      0x7C0C0600,  //  0021  CALL	R3	3
-      0x500C0000,  //  0022  LDBOOL	R3	0	0
-      0x80040600,  //  0023  RET	1	R3
-      0x50080000,  //  0024  LDBOOL	R2	0	0
-      0x80040400,  //  0025  RET	1	R2
+      0x70020009,  //  0018  JMP		#0023
+      0xB80A0000,  //  0019  GETNGBL	R2	K0
+      0x8C080501,  //  001A  GETMET	R2	R2	K1
+      0x60100018,  //  001B  GETGBL	R4	G24
+      0x5814000B,  //  001C  LDCONST	R5	K11
+      0x88180306,  //  001D  GETMBR	R6	R1	K6
+      0x7C100400,  //  001E  CALL	R4	2
+      0x5814000C,  //  001F  LDCONST	R5	K12
+      0x7C080600,  //  0020  CALL	R2	3
+      0x50080000,  //  0021  LDBOOL	R2	0	0
+      0x80040400,  //  0022  RET	1	R2
+      0x50080000,  //  0023  LDBOOL	R2	0	0
+      0x80040400,  //  0024  RET	1	R2
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
@@ -40,7 +40,7 @@ be_local_closure(Matter_Device_is_commissioning_open,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
   be_nested_proto(
-    15,                          /* nstack */
+    14,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -48,7 +48,7 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
+    ( &(const bvalue[26]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
     /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(start),
@@ -66,16 +66,15 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
     /* K14  */  be_nested_str_weak(ip),
     /* K15  */  be_nested_str_weak(ip6),
     /* K16  */  be_nested_str_weak(log),
-    /* K17  */  be_nested_str_weak(format),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eadd_hostname_X28_X25s_X2C_X20_X25s_X29),
-    /* K19  */  be_const_int(3),
-    /* K20  */  be_nested_str_weak(wifi),
-    /* K21  */  be_nested_str_weak(hostname_wifi),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20start_X20mDNS_X20on_X20_X25s_X20host_X20_X27_X25s_X2Elocal_X27),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K24  */  be_nested_str_weak(_X7C),
-    /* K25  */  be_const_int(2),
-    /* K26  */  be_nested_str_weak(mdns_announce_op_discovery_all_fabrics),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eadd_hostname_X28_X25s_X2C_X20_X25s_X29),
+    /* K18  */  be_const_int(3),
+    /* K19  */  be_nested_str_weak(wifi),
+    /* K20  */  be_nested_str_weak(hostname_wifi),
+    /* K21  */  be_nested_str_weak(MTR_X3A_X20start_X20mDNS_X20on_X20_X25s_X20host_X20_X27_X25s_X2Elocal_X27),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K23  */  be_nested_str_weak(_X7C),
+    /* K24  */  be_const_int(2),
+    /* K25  */  be_nested_str_weak(mdns_announce_op_discovery_all_fabrics),
     }),
     be_str_weak(_mdns_announce_hostname),
     &be_const_str_solidified,
@@ -117,15 +116,15 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
       0x70020012,  //  0022  JMP		#0036
       0xB8160600,  //  0023  GETNGBL	R5	K3
       0x8C140B10,  //  0024  GETMET	R5	R5	K16
-      0x8C1C0711,  //  0025  GETMET	R7	R3	K17
-      0x58240012,  //  0026  LDCONST	R9	K18
-      0x88280105,  //  0027  GETMBR	R10	R0	K5
-      0x8C2C0907,  //  0028  GETMET	R11	R4	K7
-      0x5834000E,  //  0029  LDCONST	R13	K14
-      0x5838000A,  //  002A  LDCONST	R14	K10
-      0x7C2C0600,  //  002B  CALL	R11	3
-      0x7C1C0800,  //  002C  CALL	R7	4
-      0x58200013,  //  002D  LDCONST	R8	K19
+      0x601C0018,  //  0025  GETGBL	R7	G24
+      0x58200011,  //  0026  LDCONST	R8	K17
+      0x88240105,  //  0027  GETMBR	R9	R0	K5
+      0x8C280907,  //  0028  GETMET	R10	R4	K7
+      0x5830000E,  //  0029  LDCONST	R12	K14
+      0x5834000A,  //  002A  LDCONST	R13	K10
+      0x7C280600,  //  002B  CALL	R10	3
+      0x7C1C0600,  //  002C  CALL	R7	3
+      0x58200012,  //  002D  LDCONST	R8	K18
       0x7C140600,  //  002E  CALL	R5	3
       0x8C14050C,  //  002F  GETMET	R5	R2	K12
       0x881C0105,  //  0030  GETMBR	R7	R0	K5
@@ -136,7 +135,7 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
       0x7C140600,  //  0035  CALL	R5	3
       0x7002002F,  //  0036  JMP		#0067
       0xB8120600,  //  0037  GETNGBL	R4	K3
-      0x8C100914,  //  0038  GETMET	R4	R4	K20
+      0x8C100913,  //  0038  GETMET	R4	R4	K19
       0x7C100200,  //  0039  CALL	R4	1
       0x8C140706,  //  003A  GETMET	R5	R3	K6
       0x8C1C0907,  //  003B  GETMET	R7	R4	K7
@@ -145,11 +144,11 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
       0x58200009,  //  003E  LDCONST	R8	K9
       0x5824000A,  //  003F  LDCONST	R9	K10
       0x7C140800,  //  0040  CALL	R5	4
-      0x90022A05,  //  0041  SETMBR	R0	K21	R5
+      0x90022805,  //  0041  SETMBR	R0	K20	R5
       0x8814010B,  //  0042  GETMBR	R5	R0	K11
       0x7416000F,  //  0043  JMPT	R5	#0054
       0x8C14050C,  //  0044  GETMET	R5	R2	K12
-      0x881C0115,  //  0045  GETMBR	R7	R0	K21
+      0x881C0114,  //  0045  GETMBR	R7	R0	K20
       0x8C200907,  //  0046  GETMET	R8	R4	K7
       0x5828000D,  //  0047  LDCONST	R10	K13
       0x582C000A,  //  0048  LDCONST	R11	K10
@@ -166,18 +165,18 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
       0x70020012,  //  0053  JMP		#0067
       0xB8160600,  //  0054  GETNGBL	R5	K3
       0x8C140B10,  //  0055  GETMET	R5	R5	K16
-      0x8C1C0711,  //  0056  GETMET	R7	R3	K17
-      0x58240012,  //  0057  LDCONST	R9	K18
-      0x88280105,  //  0058  GETMBR	R10	R0	K5
-      0x8C2C0907,  //  0059  GETMET	R11	R4	K7
-      0x5834000E,  //  005A  LDCONST	R13	K14
-      0x5838000A,  //  005B  LDCONST	R14	K10
-      0x7C2C0600,  //  005C  CALL	R11	3
-      0x7C1C0800,  //  005D  CALL	R7	4
-      0x58200013,  //  005E  LDCONST	R8	K19
+      0x601C0018,  //  0056  GETGBL	R7	G24
+      0x58200011,  //  0057  LDCONST	R8	K17
+      0x88240105,  //  0058  GETMBR	R9	R0	K5
+      0x8C280907,  //  0059  GETMET	R10	R4	K7
+      0x5830000E,  //  005A  LDCONST	R12	K14
+      0x5834000A,  //  005B  LDCONST	R13	K10
+      0x7C280600,  //  005C  CALL	R10	3
+      0x7C1C0600,  //  005D  CALL	R7	3
+      0x58200012,  //  005E  LDCONST	R8	K18
       0x7C140600,  //  005F  CALL	R5	3
       0x8C14050C,  //  0060  GETMET	R5	R2	K12
-      0x881C0115,  //  0061  GETMBR	R7	R0	K21
+      0x881C0114,  //  0061  GETMBR	R7	R0	K20
       0x8C200907,  //  0062  GETMET	R8	R4	K7
       0x5828000E,  //  0063  LDCONST	R10	K14
       0x582C000A,  //  0064  LDCONST	R11	K10
@@ -185,18 +184,18 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
       0x7C140600,  //  0066  CALL	R5	3
       0xB8120600,  //  0067  GETNGBL	R4	K3
       0x8C100910,  //  0068  GETMET	R4	R4	K16
-      0x8C180711,  //  0069  GETMET	R6	R3	K17
-      0x58200016,  //  006A  LDCONST	R8	K22
+      0x60180018,  //  0069  GETGBL	R6	G24
+      0x581C0015,  //  006A  LDCONST	R7	K21
       0x78060001,  //  006B  JMPF	R1	#006E
-      0x58240004,  //  006C  LDCONST	R9	K4
+      0x58200004,  //  006C  LDCONST	R8	K4
       0x70020000,  //  006D  JMP		#006F
-      0x58240014,  //  006E  LDCONST	R9	K20
+      0x58200013,  //  006E  LDCONST	R8	K19
       0x78060001,  //  006F  JMPF	R1	#0072
-      0x88280105,  //  0070  GETMBR	R10	R0	K5
+      0x88240105,  //  0070  GETMBR	R9	R0	K5
       0x70020000,  //  0071  JMP		#0073
-      0x88280115,  //  0072  GETMBR	R10	R0	K21
-      0x7C180800,  //  0073  CALL	R6	4
-      0x581C0013,  //  0074  LDCONST	R7	K19
+      0x88240114,  //  0072  GETMBR	R9	R0	K20
+      0x7C180600,  //  0073  CALL	R6	3
+      0x581C0012,  //  0074  LDCONST	R7	K18
       0x7C100600,  //  0075  CALL	R4	3
       0xA8040001,  //  0076  EXBLK	1	1
       0x70020010,  //  0077  JMP		#0089
@@ -207,17 +206,17 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
       0x60200008,  //  007C  GETGBL	R8	G8
       0x5C240800,  //  007D  MOVE	R9	R4
       0x7C200200,  //  007E  CALL	R8	1
-      0x00222E08,  //  007F  ADD	R8	K23	R8
-      0x00201118,  //  0080  ADD	R8	R8	K24
+      0x00222C08,  //  007F  ADD	R8	K22	R8
+      0x00201117,  //  0080  ADD	R8	R8	K23
       0x60240008,  //  0081  GETGBL	R9	G8
       0x5C280A00,  //  0082  MOVE	R10	R5
       0x7C240200,  //  0083  CALL	R9	1
       0x00201009,  //  0084  ADD	R8	R8	R9
-      0x58240019,  //  0085  LDCONST	R9	K25
+      0x58240018,  //  0085  LDCONST	R9	K24
       0x7C180600,  //  0086  CALL	R6	3
       0x70020000,  //  0087  JMP		#0089
       0xB0080000,  //  0088  RAISE	2	R0	R0
-      0x8C10011A,  //  0089  GETMET	R4	R0	K26
+      0x8C100119,  //  0089  GETMET	R4	R0	K25
       0x7C100200,  //  008A  CALL	R4	1
       0x80000000,  //  008B  RET	0
     })
@@ -262,7 +261,7 @@ be_local_closure(Matter_Device_save_before_restart,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    12,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -270,117 +269,114 @@ be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
+    ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(reverse),
-    /* K5   */  be_nested_str_weak(get_fabric_compressed),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_nested_str_weak(_X2D),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(eth),
-    /* K10  */  be_nested_str_weak(find),
-    /* K11  */  be_nested_str_weak(up),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(format),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
-    /* K15  */  be_const_int(3),
-    /* K16  */  be_nested_str_weak(remove_service),
-    /* K17  */  be_nested_str_weak(_matter),
-    /* K18  */  be_nested_str_weak(_tcp),
-    /* K19  */  be_nested_str_weak(hostname_eth),
-    /* K20  */  be_nested_str_weak(wifi),
-    /* K21  */  be_nested_str_weak(hostname_wifi),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K23  */  be_nested_str_weak(_X7C),
-    /* K24  */  be_const_int(2),
+    /* K1   */  be_nested_str_weak(get_device_id),
+    /* K2   */  be_nested_str_weak(copy),
+    /* K3   */  be_nested_str_weak(reverse),
+    /* K4   */  be_nested_str_weak(get_fabric_compressed),
+    /* K5   */  be_nested_str_weak(tohex),
+    /* K6   */  be_nested_str_weak(_X2D),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(eth),
+    /* K9   */  be_nested_str_weak(find),
+    /* K10  */  be_nested_str_weak(up),
+    /* K11  */  be_nested_str_weak(log),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
+    /* K13  */  be_const_int(3),
+    /* K14  */  be_nested_str_weak(remove_service),
+    /* K15  */  be_nested_str_weak(_matter),
+    /* K16  */  be_nested_str_weak(_tcp),
+    /* K17  */  be_nested_str_weak(hostname_eth),
+    /* K18  */  be_nested_str_weak(wifi),
+    /* K19  */  be_nested_str_weak(hostname_wifi),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K21  */  be_nested_str_weak(_X7C),
+    /* K22  */  be_const_int(2),
     }),
     be_str_weak(mdns_remove_op_discovery),
     &be_const_str_solidified,
-    ( &(const binstruction[81]) {  /* code */
+    ( &(const binstruction[80]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA802003B,  //  0002  EXBLK	0	#003F
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x7C100200,  //  0004  CALL	R4	1
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C140305,  //  0009  GETMET	R5	R1	K5
-      0x7C140200,  //  000A  CALL	R5	1
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
-      0x7C180200,  //  000C  CALL	R6	1
-      0x00180D07,  //  000D  ADD	R6	R6	K7
-      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
-      0x7C1C0200,  //  000F  CALL	R7	1
-      0x00180C07,  //  0010  ADD	R6	R6	R7
-      0xB81E1000,  //  0011  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
-      0x7C1C0200,  //  0013  CALL	R7	1
-      0x8C1C0F0A,  //  0014  GETMET	R7	R7	K10
-      0x5824000B,  //  0015  LDCONST	R9	K11
-      0x7C1C0400,  //  0016  CALL	R7	2
-      0x781E000E,  //  0017  JMPF	R7	#0027
-      0xB81E1000,  //  0018  GETNGBL	R7	K8
-      0x8C1C0F0C,  //  0019  GETMET	R7	R7	K12
-      0x8C24070D,  //  001A  GETMET	R9	R3	K13
-      0x582C000E,  //  001B  LDCONST	R11	K14
-      0x58300009,  //  001C  LDCONST	R12	K9
-      0x5C340C00,  //  001D  MOVE	R13	R6
-      0x7C240800,  //  001E  CALL	R9	4
-      0x5828000F,  //  001F  LDCONST	R10	K15
-      0x7C1C0600,  //  0020  CALL	R7	3
-      0x8C1C0510,  //  0021  GETMET	R7	R2	K16
-      0x58240011,  //  0022  LDCONST	R9	K17
-      0x58280012,  //  0023  LDCONST	R10	K18
-      0x5C2C0C00,  //  0024  MOVE	R11	R6
-      0x88300113,  //  0025  GETMBR	R12	R0	K19
-      0x7C1C0A00,  //  0026  CALL	R7	5
-      0xB81E1000,  //  0027  GETNGBL	R7	K8
-      0x8C1C0F14,  //  0028  GETMET	R7	R7	K20
-      0x7C1C0200,  //  0029  CALL	R7	1
-      0x8C1C0F0A,  //  002A  GETMET	R7	R7	K10
-      0x5824000B,  //  002B  LDCONST	R9	K11
-      0x7C1C0400,  //  002C  CALL	R7	2
-      0x781E000E,  //  002D  JMPF	R7	#003D
-      0xB81E1000,  //  002E  GETNGBL	R7	K8
-      0x8C1C0F0C,  //  002F  GETMET	R7	R7	K12
-      0x8C24070D,  //  0030  GETMET	R9	R3	K13
-      0x582C000E,  //  0031  LDCONST	R11	K14
-      0x58300014,  //  0032  LDCONST	R12	K20
-      0x5C340C00,  //  0033  MOVE	R13	R6
-      0x7C240800,  //  0034  CALL	R9	4
-      0x5828000F,  //  0035  LDCONST	R10	K15
-      0x7C1C0600,  //  0036  CALL	R7	3
-      0x8C1C0510,  //  0037  GETMET	R7	R2	K16
-      0x58240011,  //  0038  LDCONST	R9	K17
-      0x58280012,  //  0039  LDCONST	R10	K18
-      0x5C2C0C00,  //  003A  MOVE	R11	R6
-      0x88300115,  //  003B  GETMBR	R12	R0	K21
-      0x7C1C0A00,  //  003C  CALL	R7	5
-      0xA8040001,  //  003D  EXBLK	1	1
-      0x70020010,  //  003E  JMP		#0050
-      0xAC100002,  //  003F  CATCH	R4	0	2
-      0x7002000D,  //  0040  JMP		#004F
-      0xB81A1000,  //  0041  GETNGBL	R6	K8
-      0x8C180D0C,  //  0042  GETMET	R6	R6	K12
-      0x60200008,  //  0043  GETGBL	R8	G8
-      0x5C240800,  //  0044  MOVE	R9	R4
-      0x7C200200,  //  0045  CALL	R8	1
-      0x00222C08,  //  0046  ADD	R8	K22	R8
-      0x00201117,  //  0047  ADD	R8	R8	K23
-      0x60240008,  //  0048  GETGBL	R9	G8
-      0x5C280A00,  //  0049  MOVE	R10	R5
-      0x7C240200,  //  004A  CALL	R9	1
-      0x00201009,  //  004B  ADD	R8	R8	R9
-      0x58240018,  //  004C  LDCONST	R9	K24
-      0x7C180600,  //  004D  CALL	R6	3
-      0x70020000,  //  004E  JMP		#0050
-      0xB0080000,  //  004F  RAISE	2	R0	R0
-      0x80000000,  //  0050  RET	0
+      0xA802003B,  //  0001  EXBLK	0	#003E
+      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x8C100304,  //  0008  GETMET	R4	R1	K4
+      0x7C100200,  //  0009  CALL	R4	1
+      0x8C140905,  //  000A  GETMET	R5	R4	K5
+      0x7C140200,  //  000B  CALL	R5	1
+      0x00140B06,  //  000C  ADD	R5	R5	K6
+      0x8C180705,  //  000D  GETMET	R6	R3	K5
+      0x7C180200,  //  000E  CALL	R6	1
+      0x00140A06,  //  000F  ADD	R5	R5	R6
+      0xB81A0E00,  //  0010  GETNGBL	R6	K7
+      0x8C180D08,  //  0011  GETMET	R6	R6	K8
+      0x7C180200,  //  0012  CALL	R6	1
+      0x8C180D09,  //  0013  GETMET	R6	R6	K9
+      0x5820000A,  //  0014  LDCONST	R8	K10
+      0x7C180400,  //  0015  CALL	R6	2
+      0x781A000E,  //  0016  JMPF	R6	#0026
+      0xB81A0E00,  //  0017  GETNGBL	R6	K7
+      0x8C180D0B,  //  0018  GETMET	R6	R6	K11
+      0x60200018,  //  0019  GETGBL	R8	G24
+      0x5824000C,  //  001A  LDCONST	R9	K12
+      0x58280008,  //  001B  LDCONST	R10	K8
+      0x5C2C0A00,  //  001C  MOVE	R11	R5
+      0x7C200600,  //  001D  CALL	R8	3
+      0x5824000D,  //  001E  LDCONST	R9	K13
+      0x7C180600,  //  001F  CALL	R6	3
+      0x8C18050E,  //  0020  GETMET	R6	R2	K14
+      0x5820000F,  //  0021  LDCONST	R8	K15
+      0x58240010,  //  0022  LDCONST	R9	K16
+      0x5C280A00,  //  0023  MOVE	R10	R5
+      0x882C0111,  //  0024  GETMBR	R11	R0	K17
+      0x7C180A00,  //  0025  CALL	R6	5
+      0xB81A0E00,  //  0026  GETNGBL	R6	K7
+      0x8C180D12,  //  0027  GETMET	R6	R6	K18
+      0x7C180200,  //  0028  CALL	R6	1
+      0x8C180D09,  //  0029  GETMET	R6	R6	K9
+      0x5820000A,  //  002A  LDCONST	R8	K10
+      0x7C180400,  //  002B  CALL	R6	2
+      0x781A000E,  //  002C  JMPF	R6	#003C
+      0xB81A0E00,  //  002D  GETNGBL	R6	K7
+      0x8C180D0B,  //  002E  GETMET	R6	R6	K11
+      0x60200018,  //  002F  GETGBL	R8	G24
+      0x5824000C,  //  0030  LDCONST	R9	K12
+      0x58280012,  //  0031  LDCONST	R10	K18
+      0x5C2C0A00,  //  0032  MOVE	R11	R5
+      0x7C200600,  //  0033  CALL	R8	3
+      0x5824000D,  //  0034  LDCONST	R9	K13
+      0x7C180600,  //  0035  CALL	R6	3
+      0x8C18050E,  //  0036  GETMET	R6	R2	K14
+      0x5820000F,  //  0037  LDCONST	R8	K15
+      0x58240010,  //  0038  LDCONST	R9	K16
+      0x5C280A00,  //  0039  MOVE	R10	R5
+      0x882C0113,  //  003A  GETMBR	R11	R0	K19
+      0x7C180A00,  //  003B  CALL	R6	5
+      0xA8040001,  //  003C  EXBLK	1	1
+      0x70020010,  //  003D  JMP		#004F
+      0xAC0C0002,  //  003E  CATCH	R3	0	2
+      0x7002000D,  //  003F  JMP		#004E
+      0xB8160E00,  //  0040  GETNGBL	R5	K7
+      0x8C140B0B,  //  0041  GETMET	R5	R5	K11
+      0x601C0008,  //  0042  GETGBL	R7	G8
+      0x5C200600,  //  0043  MOVE	R8	R3
+      0x7C1C0200,  //  0044  CALL	R7	1
+      0x001E2807,  //  0045  ADD	R7	K20	R7
+      0x001C0F15,  //  0046  ADD	R7	R7	K21
+      0x60200008,  //  0047  GETGBL	R8	G8
+      0x5C240800,  //  0048  MOVE	R9	R4
+      0x7C200200,  //  0049  CALL	R8	1
+      0x001C0E08,  //  004A  ADD	R7	R7	R8
+      0x58200016,  //  004B  LDCONST	R8	K22
+      0x7C140600,  //  004C  CALL	R5	3
+      0x70020000,  //  004D  JMP		#004F
+      0xB0080000,  //  004E  RAISE	2	R0	R0
+      0x80000000,  //  004F  RET	0
     })
   )
 );
@@ -698,7 +694,7 @@ be_local_closure(Matter_Device_every_250ms,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
   be_nested_proto(
-    25,                          /* nstack */
+    24,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -773,234 +769,232 @@ be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(cluster),
-    /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(plugins),
-    /* K5   */  be_nested_str_weak(get_endpoint),
-    /* K6   */  be_nested_str_weak(contains),
-    /* K7   */  be_nested_str_weak(get_cluster_list),
-    /* K8   */  be_nested_str_weak(get_attribute_list),
-    /* K9   */  be_nested_str_weak(push),
-    /* K10  */  be_nested_str_weak(stop_iteration),
-    /* K11  */  be_nested_str_weak(status),
-    /* K12  */  be_nested_str_weak(matter),
-    /* K13  */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
-    /* K14  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
-    /* K15  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    /* K16  */  be_nested_str_weak(UNREPORTABLE_ATTRIBUTE),
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(endpoint),
+    /* K1   */  be_nested_str_weak(cluster),
+    /* K2   */  be_nested_str_weak(attribute),
+    /* K3   */  be_nested_str_weak(plugins),
+    /* K4   */  be_nested_str_weak(get_endpoint),
+    /* K5   */  be_nested_str_weak(contains),
+    /* K6   */  be_nested_str_weak(get_cluster_list),
+    /* K7   */  be_nested_str_weak(get_attribute_list),
+    /* K8   */  be_nested_str_weak(push),
+    /* K9   */  be_nested_str_weak(stop_iteration),
+    /* K10  */  be_nested_str_weak(status),
+    /* K11  */  be_nested_str_weak(matter),
+    /* K12  */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+    /* K13  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
+    /* K14  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+    /* K15  */  be_nested_str_weak(UNREPORTABLE_ATTRIBUTE),
     }),
     be_str_weak(process_attribute_expansion),
     &be_const_str_solidified,
-    ( &(const binstruction[206]) {  /* code */
+    ( &(const binstruction[205]) {  /* code */
       0x840C0000,  //  0000  CLOSURE	R3	P0
-      0xA4120000,  //  0001  IMPORT	R4	K0
-      0x88140301,  //  0002  GETMBR	R5	R1	K1
-      0x50180000,  //  0003  LDBOOL	R6	0	0
-      0x881C0302,  //  0004  GETMBR	R7	R1	K2
-      0x50200000,  //  0005  LDBOOL	R8	0	0
-      0x88240303,  //  0006  GETMBR	R9	R1	K3
-      0x50280000,  //  0007  LDBOOL	R10	0	0
-      0x882C0301,  //  0008  GETMBR	R11	R1	K1
-      0x4C300000,  //  0009  LDNIL	R12
-      0x202C160C,  //  000A  NE	R11	R11	R12
-      0x782E0007,  //  000B  JMPF	R11	#0014
-      0x882C0302,  //  000C  GETMBR	R11	R1	K2
-      0x4C300000,  //  000D  LDNIL	R12
-      0x202C160C,  //  000E  NE	R11	R11	R12
-      0x782E0003,  //  000F  JMPF	R11	#0014
-      0x882C0303,  //  0010  GETMBR	R11	R1	K3
-      0x4C300000,  //  0011  LDNIL	R12
-      0x202C160C,  //  0012  NE	R11	R11	R12
-      0x742E0000,  //  0013  JMPT	R11	#0015
-      0x502C0001,  //  0014  LDBOOL	R11	0	1
-      0x502C0200,  //  0015  LDBOOL	R11	1	0
-      0x60300013,  //  0016  GETGBL	R12	G19
-      0x7C300000,  //  0017  CALL	R12	0
-      0x60340010,  //  0018  GETGBL	R13	G16
-      0x88380104,  //  0019  GETMBR	R14	R0	K4
-      0x7C340200,  //  001A  CALL	R13	1
-      0xA8020055,  //  001B  EXBLK	0	#0072
-      0x5C381A00,  //  001C  MOVE	R14	R13
-      0x7C380000,  //  001D  CALL	R14	0
-      0x8C3C1D05,  //  001E  GETMET	R15	R14	K5
-      0x7C3C0200,  //  001F  CALL	R15	1
-      0x4C400000,  //  0020  LDNIL	R16
-      0x20400A10,  //  0021  NE	R16	R5	R16
-      0x78420002,  //  0022  JMPF	R16	#0026
-      0x20401E05,  //  0023  NE	R16	R15	R5
-      0x78420000,  //  0024  JMPF	R16	#0026
-      0x7001FFF5,  //  0025  JMP		#001C
-      0x8C401906,  //  0026  GETMET	R16	R12	K6
-      0x5C481E00,  //  0027  MOVE	R18	R15
-      0x7C400400,  //  0028  CALL	R16	2
-      0x74420002,  //  0029  JMPT	R16	#002D
-      0x60400013,  //  002A  GETGBL	R16	G19
-      0x7C400000,  //  002B  CALL	R16	0
-      0x98301E10,  //  002C  SETIDX	R12	R15	R16
-      0x50180200,  //  002D  LDBOOL	R6	1	0
-      0x8C401D07,  //  002E  GETMET	R16	R14	K7
-      0x5C481E00,  //  002F  MOVE	R18	R15
-      0x7C400400,  //  0030  CALL	R16	2
-      0x60440010,  //  0031  GETGBL	R17	G16
-      0x5C482000,  //  0032  MOVE	R18	R16
-      0x7C440200,  //  0033  CALL	R17	1
-      0xA8020038,  //  0034  EXBLK	0	#006E
-      0x5C482200,  //  0035  MOVE	R18	R17
-      0x7C480000,  //  0036  CALL	R18	0
-      0x4C4C0000,  //  0037  LDNIL	R19
-      0x204C0E13,  //  0038  NE	R19	R7	R19
-      0x784E0002,  //  0039  JMPF	R19	#003D
-      0x204C2407,  //  003A  NE	R19	R18	R7
-      0x784E0000,  //  003B  JMPF	R19	#003D
-      0x7001FFF7,  //  003C  JMP		#0035
-      0x944C180F,  //  003D  GETIDX	R19	R12	R15
-      0x8C4C2706,  //  003E  GETMET	R19	R19	K6
-      0x5C542400,  //  003F  MOVE	R21	R18
-      0x7C4C0400,  //  0040  CALL	R19	2
-      0x744E0003,  //  0041  JMPT	R19	#0046
-      0x944C180F,  //  0042  GETIDX	R19	R12	R15
-      0x60500013,  //  0043  GETGBL	R20	G19
-      0x7C500000,  //  0044  CALL	R20	0
-      0x984C2414,  //  0045  SETIDX	R19	R18	R20
-      0x50200200,  //  0046  LDBOOL	R8	1	0
-      0x8C4C1D08,  //  0047  GETMET	R19	R14	K8
-      0x5C541E00,  //  0048  MOVE	R21	R15
-      0x5C582400,  //  0049  MOVE	R22	R18
-      0x7C4C0600,  //  004A  CALL	R19	3
-      0x60500010,  //  004B  GETGBL	R20	G16
-      0x5C542600,  //  004C  MOVE	R21	R19
-      0x7C500200,  //  004D  CALL	R20	1
-      0xA802001A,  //  004E  EXBLK	0	#006A
-      0x5C542800,  //  004F  MOVE	R21	R20
-      0x7C540000,  //  0050  CALL	R21	0
-      0x4C580000,  //  0051  LDNIL	R22
-      0x20581216,  //  0052  NE	R22	R9	R22
-      0x785A0002,  //  0053  JMPF	R22	#0057
-      0x20582A09,  //  0054  NE	R22	R21	R9
-      0x785A0000,  //  0055  JMPF	R22	#0057
-      0x7001FFF7,  //  0056  JMP		#004F
-      0x9458180F,  //  0057  GETIDX	R22	R12	R15
-      0x94582C12,  //  0058  GETIDX	R22	R22	R18
-      0x8C582D06,  //  0059  GETMET	R22	R22	K6
-      0x5C602A00,  //  005A  MOVE	R24	R21
-      0x7C580400,  //  005B  CALL	R22	2
-      0x745A0004,  //  005C  JMPT	R22	#0062
-      0x9458180F,  //  005D  GETIDX	R22	R12	R15
-      0x94582C12,  //  005E  GETIDX	R22	R22	R18
-      0x605C0012,  //  005F  GETGBL	R23	G18
-      0x7C5C0000,  //  0060  CALL	R23	0
-      0x98582A17,  //  0061  SETIDX	R22	R21	R23
-      0x50280200,  //  0062  LDBOOL	R10	1	0
-      0x9458180F,  //  0063  GETIDX	R22	R12	R15
-      0x94582C12,  //  0064  GETIDX	R22	R22	R18
-      0x94582C15,  //  0065  GETIDX	R22	R22	R21
-      0x8C582D09,  //  0066  GETMET	R22	R22	K9
-      0x5C601C00,  //  0067  MOVE	R24	R14
-      0x7C580400,  //  0068  CALL	R22	2
-      0x7001FFE4,  //  0069  JMP		#004F
-      0x5850000A,  //  006A  LDCONST	R20	K10
-      0xAC500200,  //  006B  CATCH	R20	1	0
-      0xB0080000,  //  006C  RAISE	2	R0	R0
-      0x7001FFC6,  //  006D  JMP		#0035
-      0x5844000A,  //  006E  LDCONST	R17	K10
-      0xAC440200,  //  006F  CATCH	R17	1	0
-      0xB0080000,  //  0070  RAISE	2	R0	R0
-      0x7001FFA9,  //  0071  JMP		#001C
-      0x5834000A,  //  0072  LDCONST	R13	K10
-      0xAC340200,  //  0073  CATCH	R13	1	0
-      0xB0080000,  //  0074  RAISE	2	R0	R0
-      0x60340010,  //  0075  GETGBL	R13	G16
-      0x5C380600,  //  0076  MOVE	R14	R3
-      0x5C3C1800,  //  0077  MOVE	R15	R12
-      0x7C380200,  //  0078  CALL	R14	1
-      0x7C340200,  //  0079  CALL	R13	1
-      0xA8020033,  //  007A  EXBLK	0	#00AF
-      0x5C381A00,  //  007B  MOVE	R14	R13
-      0x7C380000,  //  007C  CALL	R14	0
-      0x603C0010,  //  007D  GETGBL	R15	G16
-      0x5C400600,  //  007E  MOVE	R16	R3
-      0x9444180E,  //  007F  GETIDX	R17	R12	R14
-      0x7C400200,  //  0080  CALL	R16	1
-      0x7C3C0200,  //  0081  CALL	R15	1
-      0xA8020027,  //  0082  EXBLK	0	#00AB
-      0x5C401E00,  //  0083  MOVE	R16	R15
-      0x7C400000,  //  0084  CALL	R16	0
-      0x60440010,  //  0085  GETGBL	R17	G16
-      0x5C480600,  //  0086  MOVE	R18	R3
-      0x944C180E,  //  0087  GETIDX	R19	R12	R14
-      0x944C2610,  //  0088  GETIDX	R19	R19	R16
-      0x7C480200,  //  0089  CALL	R18	1
-      0x7C440200,  //  008A  CALL	R17	1
-      0xA802001A,  //  008B  EXBLK	0	#00A7
-      0x5C482200,  //  008C  MOVE	R18	R17
-      0x7C480000,  //  008D  CALL	R18	0
-      0x604C0010,  //  008E  GETGBL	R19	G16
-      0x9450180E,  //  008F  GETIDX	R20	R12	R14
-      0x94502810,  //  0090  GETIDX	R20	R20	R16
-      0x94502812,  //  0091  GETIDX	R20	R20	R18
-      0x7C4C0200,  //  0092  CALL	R19	1
-      0xA802000E,  //  0093  EXBLK	0	#00A3
-      0x5C502600,  //  0094  MOVE	R20	R19
-      0x7C500000,  //  0095  CALL	R20	0
-      0x9006020E,  //  0096  SETMBR	R1	K1	R14
-      0x90060410,  //  0097  SETMBR	R1	K2	R16
-      0x90060612,  //  0098  SETMBR	R1	K3	R18
-      0x5C540400,  //  0099  MOVE	R21	R2
-      0x5C582800,  //  009A  MOVE	R22	R20
-      0x5C5C0200,  //  009B  MOVE	R23	R1
-      0x5C601600,  //  009C  MOVE	R24	R11
-      0x7C540600,  //  009D  CALL	R21	3
-      0x782E0002,  //  009E  JMPF	R11	#00A2
-      0x78560001,  //  009F  JMPF	R21	#00A2
-      0xA8040004,  //  00A0  EXBLK	1	4
-      0x80002C00,  //  00A1  RET	0
-      0x7001FFF0,  //  00A2  JMP		#0094
-      0x584C000A,  //  00A3  LDCONST	R19	K10
-      0xAC4C0200,  //  00A4  CATCH	R19	1	0
-      0xB0080000,  //  00A5  RAISE	2	R0	R0
-      0x7001FFE4,  //  00A6  JMP		#008C
-      0x5844000A,  //  00A7  LDCONST	R17	K10
-      0xAC440200,  //  00A8  CATCH	R17	1	0
-      0xB0080000,  //  00A9  RAISE	2	R0	R0
-      0x7001FFD7,  //  00AA  JMP		#0083
-      0x583C000A,  //  00AB  LDCONST	R15	K10
-      0xAC3C0200,  //  00AC  CATCH	R15	1	0
-      0xB0080000,  //  00AD  RAISE	2	R0	R0
-      0x7001FFCB,  //  00AE  JMP		#007B
-      0x5834000A,  //  00AF  LDCONST	R13	K10
-      0xAC340200,  //  00B0  CATCH	R13	1	0
-      0xB0080000,  //  00B1  RAISE	2	R0	R0
-      0x782E0019,  //  00B2  JMPF	R11	#00CD
-      0x5C340C00,  //  00B3  MOVE	R13	R6
-      0x74360003,  //  00B4  JMPT	R13	#00B9
-      0xB8361800,  //  00B5  GETNGBL	R13	K12
-      0x88341B0D,  //  00B6  GETMBR	R13	R13	K13
-      0x9006160D,  //  00B7  SETMBR	R1	K11	R13
-      0x7002000E,  //  00B8  JMP		#00C8
-      0x5C341000,  //  00B9  MOVE	R13	R8
-      0x74360003,  //  00BA  JMPT	R13	#00BF
-      0xB8361800,  //  00BB  GETNGBL	R13	K12
-      0x88341B0E,  //  00BC  GETMBR	R13	R13	K14
-      0x9006160D,  //  00BD  SETMBR	R1	K11	R13
-      0x70020008,  //  00BE  JMP		#00C8
-      0x5C341400,  //  00BF  MOVE	R13	R10
-      0x74360003,  //  00C0  JMPT	R13	#00C5
-      0xB8361800,  //  00C1  GETNGBL	R13	K12
-      0x88341B0F,  //  00C2  GETMBR	R13	R13	K15
-      0x9006160D,  //  00C3  SETMBR	R1	K11	R13
-      0x70020002,  //  00C4  JMP		#00C8
-      0xB8361800,  //  00C5  GETNGBL	R13	K12
-      0x88341B10,  //  00C6  GETMBR	R13	R13	K16
-      0x9006160D,  //  00C7  SETMBR	R1	K11	R13
-      0x5C340400,  //  00C8  MOVE	R13	R2
-      0x4C380000,  //  00C9  LDNIL	R14
-      0x5C3C0200,  //  00CA  MOVE	R15	R1
-      0x50400200,  //  00CB  LDBOOL	R16	1	0
-      0x7C340600,  //  00CC  CALL	R13	3
-      0x80000000,  //  00CD  RET	0
+      0x88100300,  //  0001  GETMBR	R4	R1	K0
+      0x50140000,  //  0002  LDBOOL	R5	0	0
+      0x88180301,  //  0003  GETMBR	R6	R1	K1
+      0x501C0000,  //  0004  LDBOOL	R7	0	0
+      0x88200302,  //  0005  GETMBR	R8	R1	K2
+      0x50240000,  //  0006  LDBOOL	R9	0	0
+      0x88280300,  //  0007  GETMBR	R10	R1	K0
+      0x4C2C0000,  //  0008  LDNIL	R11
+      0x2028140B,  //  0009  NE	R10	R10	R11
+      0x782A0007,  //  000A  JMPF	R10	#0013
+      0x88280301,  //  000B  GETMBR	R10	R1	K1
+      0x4C2C0000,  //  000C  LDNIL	R11
+      0x2028140B,  //  000D  NE	R10	R10	R11
+      0x782A0003,  //  000E  JMPF	R10	#0013
+      0x88280302,  //  000F  GETMBR	R10	R1	K2
+      0x4C2C0000,  //  0010  LDNIL	R11
+      0x2028140B,  //  0011  NE	R10	R10	R11
+      0x742A0000,  //  0012  JMPT	R10	#0014
+      0x50280001,  //  0013  LDBOOL	R10	0	1
+      0x50280200,  //  0014  LDBOOL	R10	1	0
+      0x602C0013,  //  0015  GETGBL	R11	G19
+      0x7C2C0000,  //  0016  CALL	R11	0
+      0x60300010,  //  0017  GETGBL	R12	G16
+      0x88340103,  //  0018  GETMBR	R13	R0	K3
+      0x7C300200,  //  0019  CALL	R12	1
+      0xA8020055,  //  001A  EXBLK	0	#0071
+      0x5C341800,  //  001B  MOVE	R13	R12
+      0x7C340000,  //  001C  CALL	R13	0
+      0x8C381B04,  //  001D  GETMET	R14	R13	K4
+      0x7C380200,  //  001E  CALL	R14	1
+      0x4C3C0000,  //  001F  LDNIL	R15
+      0x203C080F,  //  0020  NE	R15	R4	R15
+      0x783E0002,  //  0021  JMPF	R15	#0025
+      0x203C1C04,  //  0022  NE	R15	R14	R4
+      0x783E0000,  //  0023  JMPF	R15	#0025
+      0x7001FFF5,  //  0024  JMP		#001B
+      0x8C3C1705,  //  0025  GETMET	R15	R11	K5
+      0x5C441C00,  //  0026  MOVE	R17	R14
+      0x7C3C0400,  //  0027  CALL	R15	2
+      0x743E0002,  //  0028  JMPT	R15	#002C
+      0x603C0013,  //  0029  GETGBL	R15	G19
+      0x7C3C0000,  //  002A  CALL	R15	0
+      0x982C1C0F,  //  002B  SETIDX	R11	R14	R15
+      0x50140200,  //  002C  LDBOOL	R5	1	0
+      0x8C3C1B06,  //  002D  GETMET	R15	R13	K6
+      0x5C441C00,  //  002E  MOVE	R17	R14
+      0x7C3C0400,  //  002F  CALL	R15	2
+      0x60400010,  //  0030  GETGBL	R16	G16
+      0x5C441E00,  //  0031  MOVE	R17	R15
+      0x7C400200,  //  0032  CALL	R16	1
+      0xA8020038,  //  0033  EXBLK	0	#006D
+      0x5C442000,  //  0034  MOVE	R17	R16
+      0x7C440000,  //  0035  CALL	R17	0
+      0x4C480000,  //  0036  LDNIL	R18
+      0x20480C12,  //  0037  NE	R18	R6	R18
+      0x784A0002,  //  0038  JMPF	R18	#003C
+      0x20482206,  //  0039  NE	R18	R17	R6
+      0x784A0000,  //  003A  JMPF	R18	#003C
+      0x7001FFF7,  //  003B  JMP		#0034
+      0x9448160E,  //  003C  GETIDX	R18	R11	R14
+      0x8C482505,  //  003D  GETMET	R18	R18	K5
+      0x5C502200,  //  003E  MOVE	R20	R17
+      0x7C480400,  //  003F  CALL	R18	2
+      0x744A0003,  //  0040  JMPT	R18	#0045
+      0x9448160E,  //  0041  GETIDX	R18	R11	R14
+      0x604C0013,  //  0042  GETGBL	R19	G19
+      0x7C4C0000,  //  0043  CALL	R19	0
+      0x98482213,  //  0044  SETIDX	R18	R17	R19
+      0x501C0200,  //  0045  LDBOOL	R7	1	0
+      0x8C481B07,  //  0046  GETMET	R18	R13	K7
+      0x5C501C00,  //  0047  MOVE	R20	R14
+      0x5C542200,  //  0048  MOVE	R21	R17
+      0x7C480600,  //  0049  CALL	R18	3
+      0x604C0010,  //  004A  GETGBL	R19	G16
+      0x5C502400,  //  004B  MOVE	R20	R18
+      0x7C4C0200,  //  004C  CALL	R19	1
+      0xA802001A,  //  004D  EXBLK	0	#0069
+      0x5C502600,  //  004E  MOVE	R20	R19
+      0x7C500000,  //  004F  CALL	R20	0
+      0x4C540000,  //  0050  LDNIL	R21
+      0x20541015,  //  0051  NE	R21	R8	R21
+      0x78560002,  //  0052  JMPF	R21	#0056
+      0x20542808,  //  0053  NE	R21	R20	R8
+      0x78560000,  //  0054  JMPF	R21	#0056
+      0x7001FFF7,  //  0055  JMP		#004E
+      0x9454160E,  //  0056  GETIDX	R21	R11	R14
+      0x94542A11,  //  0057  GETIDX	R21	R21	R17
+      0x8C542B05,  //  0058  GETMET	R21	R21	K5
+      0x5C5C2800,  //  0059  MOVE	R23	R20
+      0x7C540400,  //  005A  CALL	R21	2
+      0x74560004,  //  005B  JMPT	R21	#0061
+      0x9454160E,  //  005C  GETIDX	R21	R11	R14
+      0x94542A11,  //  005D  GETIDX	R21	R21	R17
+      0x60580012,  //  005E  GETGBL	R22	G18
+      0x7C580000,  //  005F  CALL	R22	0
+      0x98542816,  //  0060  SETIDX	R21	R20	R22
+      0x50240200,  //  0061  LDBOOL	R9	1	0
+      0x9454160E,  //  0062  GETIDX	R21	R11	R14
+      0x94542A11,  //  0063  GETIDX	R21	R21	R17
+      0x94542A14,  //  0064  GETIDX	R21	R21	R20
+      0x8C542B08,  //  0065  GETMET	R21	R21	K8
+      0x5C5C1A00,  //  0066  MOVE	R23	R13
+      0x7C540400,  //  0067  CALL	R21	2
+      0x7001FFE4,  //  0068  JMP		#004E
+      0x584C0009,  //  0069  LDCONST	R19	K9
+      0xAC4C0200,  //  006A  CATCH	R19	1	0
+      0xB0080000,  //  006B  RAISE	2	R0	R0
+      0x7001FFC6,  //  006C  JMP		#0034
+      0x58400009,  //  006D  LDCONST	R16	K9
+      0xAC400200,  //  006E  CATCH	R16	1	0
+      0xB0080000,  //  006F  RAISE	2	R0	R0
+      0x7001FFA9,  //  0070  JMP		#001B
+      0x58300009,  //  0071  LDCONST	R12	K9
+      0xAC300200,  //  0072  CATCH	R12	1	0
+      0xB0080000,  //  0073  RAISE	2	R0	R0
+      0x60300010,  //  0074  GETGBL	R12	G16
+      0x5C340600,  //  0075  MOVE	R13	R3
+      0x5C381600,  //  0076  MOVE	R14	R11
+      0x7C340200,  //  0077  CALL	R13	1
+      0x7C300200,  //  0078  CALL	R12	1
+      0xA8020033,  //  0079  EXBLK	0	#00AE
+      0x5C341800,  //  007A  MOVE	R13	R12
+      0x7C340000,  //  007B  CALL	R13	0
+      0x60380010,  //  007C  GETGBL	R14	G16
+      0x5C3C0600,  //  007D  MOVE	R15	R3
+      0x9440160D,  //  007E  GETIDX	R16	R11	R13
+      0x7C3C0200,  //  007F  CALL	R15	1
+      0x7C380200,  //  0080  CALL	R14	1
+      0xA8020027,  //  0081  EXBLK	0	#00AA
+      0x5C3C1C00,  //  0082  MOVE	R15	R14
+      0x7C3C0000,  //  0083  CALL	R15	0
+      0x60400010,  //  0084  GETGBL	R16	G16
+      0x5C440600,  //  0085  MOVE	R17	R3
+      0x9448160D,  //  0086  GETIDX	R18	R11	R13
+      0x9448240F,  //  0087  GETIDX	R18	R18	R15
+      0x7C440200,  //  0088  CALL	R17	1
+      0x7C400200,  //  0089  CALL	R16	1
+      0xA802001A,  //  008A  EXBLK	0	#00A6
+      0x5C442000,  //  008B  MOVE	R17	R16
+      0x7C440000,  //  008C  CALL	R17	0
+      0x60480010,  //  008D  GETGBL	R18	G16
+      0x944C160D,  //  008E  GETIDX	R19	R11	R13
+      0x944C260F,  //  008F  GETIDX	R19	R19	R15
+      0x944C2611,  //  0090  GETIDX	R19	R19	R17
+      0x7C480200,  //  0091  CALL	R18	1
+      0xA802000E,  //  0092  EXBLK	0	#00A2
+      0x5C4C2400,  //  0093  MOVE	R19	R18
+      0x7C4C0000,  //  0094  CALL	R19	0
+      0x9006000D,  //  0095  SETMBR	R1	K0	R13
+      0x9006020F,  //  0096  SETMBR	R1	K1	R15
+      0x90060411,  //  0097  SETMBR	R1	K2	R17
+      0x5C500400,  //  0098  MOVE	R20	R2
+      0x5C542600,  //  0099  MOVE	R21	R19
+      0x5C580200,  //  009A  MOVE	R22	R1
+      0x5C5C1400,  //  009B  MOVE	R23	R10
+      0x7C500600,  //  009C  CALL	R20	3
+      0x782A0002,  //  009D  JMPF	R10	#00A1
+      0x78520001,  //  009E  JMPF	R20	#00A1
+      0xA8040004,  //  009F  EXBLK	1	4
+      0x80002A00,  //  00A0  RET	0
+      0x7001FFF0,  //  00A1  JMP		#0093
+      0x58480009,  //  00A2  LDCONST	R18	K9
+      0xAC480200,  //  00A3  CATCH	R18	1	0
+      0xB0080000,  //  00A4  RAISE	2	R0	R0
+      0x7001FFE4,  //  00A5  JMP		#008B
+      0x58400009,  //  00A6  LDCONST	R16	K9
+      0xAC400200,  //  00A7  CATCH	R16	1	0
+      0xB0080000,  //  00A8  RAISE	2	R0	R0
+      0x7001FFD7,  //  00A9  JMP		#0082
+      0x58380009,  //  00AA  LDCONST	R14	K9
+      0xAC380200,  //  00AB  CATCH	R14	1	0
+      0xB0080000,  //  00AC  RAISE	2	R0	R0
+      0x7001FFCB,  //  00AD  JMP		#007A
+      0x58300009,  //  00AE  LDCONST	R12	K9
+      0xAC300200,  //  00AF  CATCH	R12	1	0
+      0xB0080000,  //  00B0  RAISE	2	R0	R0
+      0x782A0019,  //  00B1  JMPF	R10	#00CC
+      0x5C300A00,  //  00B2  MOVE	R12	R5
+      0x74320003,  //  00B3  JMPT	R12	#00B8
+      0xB8321600,  //  00B4  GETNGBL	R12	K11
+      0x8830190C,  //  00B5  GETMBR	R12	R12	K12
+      0x9006140C,  //  00B6  SETMBR	R1	K10	R12
+      0x7002000E,  //  00B7  JMP		#00C7
+      0x5C300E00,  //  00B8  MOVE	R12	R7
+      0x74320003,  //  00B9  JMPT	R12	#00BE
+      0xB8321600,  //  00BA  GETNGBL	R12	K11
+      0x8830190D,  //  00BB  GETMBR	R12	R12	K13
+      0x9006140C,  //  00BC  SETMBR	R1	K10	R12
+      0x70020008,  //  00BD  JMP		#00C7
+      0x5C301200,  //  00BE  MOVE	R12	R9
+      0x74320003,  //  00BF  JMPT	R12	#00C4
+      0xB8321600,  //  00C0  GETNGBL	R12	K11
+      0x8830190E,  //  00C1  GETMBR	R12	R12	K14
+      0x9006140C,  //  00C2  SETMBR	R1	K10	R12
+      0x70020002,  //  00C3  JMP		#00C7
+      0xB8321600,  //  00C4  GETNGBL	R12	K11
+      0x8830190F,  //  00C5  GETMBR	R12	R12	K15
+      0x9006140C,  //  00C6  SETMBR	R1	K10	R12
+      0x5C300400,  //  00C7  MOVE	R12	R2
+      0x4C340000,  //  00C8  LDNIL	R13
+      0x5C380200,  //  00C9  MOVE	R14	R1
+      0x503C0200,  //  00CA  LDBOOL	R15	1	0
+      0x7C300600,  //  00CB  CALL	R12	3
+      0x80000000,  //  00CC  RET	0
     })
   )
 );
@@ -1012,7 +1006,7 @@ be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device__compute_pbkdf,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    13,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1020,63 +1014,61 @@ be_local_closure(Matter_Device__compute_pbkdf,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
+    ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(add),
-    /* K3   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
-    /* K4   */  be_nested_str_weak(derive),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(root_w0),
-    /* K7   */  be_nested_str_weak(EC_P256),
-    /* K8   */  be_nested_str_weak(mod),
-    /* K9   */  be_nested_str_weak(root_L),
-    /* K10  */  be_nested_str_weak(public_key),
+    /* K1   */  be_nested_str_weak(add),
+    /* K2   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
+    /* K3   */  be_nested_str_weak(derive),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(root_w0),
+    /* K6   */  be_nested_str_weak(EC_P256),
+    /* K7   */  be_nested_str_weak(mod),
+    /* K8   */  be_nested_str_weak(root_L),
+    /* K9   */  be_nested_str_weak(public_key),
     }),
     be_str_weak(_compute_pbkdf),
     &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
+    ( &(const binstruction[40]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
-      0xA4160200,  //  0001  IMPORT	R5	K1
-      0x60180015,  //  0002  GETGBL	R6	G21
-      0x7C180000,  //  0003  CALL	R6	0
-      0x8C180D02,  //  0004  GETMET	R6	R6	K2
-      0x5C200200,  //  0005  MOVE	R8	R1
-      0x54260003,  //  0006  LDINT	R9	4
-      0x7C180600,  //  0007  CALL	R6	3
-      0x8C1C0903,  //  0008  GETMET	R7	R4	K3
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x8C1C0F04,  //  000A  GETMET	R7	R7	K4
-      0x5C240C00,  //  000B  MOVE	R9	R6
-      0x5C280600,  //  000C  MOVE	R10	R3
-      0x5C2C0400,  //  000D  MOVE	R11	R2
-      0x5432004F,  //  000E  LDINT	R12	80
-      0x7C1C0A00,  //  000F  CALL	R7	5
-      0x54220026,  //  0010  LDINT	R8	39
-      0x40220A08,  //  0011  CONNECT	R8	K5	R8
-      0x94200E08,  //  0012  GETIDX	R8	R7	R8
-      0x54260027,  //  0013  LDINT	R9	40
-      0x542A004E,  //  0014  LDINT	R10	79
-      0x4024120A,  //  0015  CONNECT	R9	R9	R10
-      0x94240E09,  //  0016  GETIDX	R9	R7	R9
-      0x8C280907,  //  0017  GETMET	R10	R4	K7
-      0x7C280200,  //  0018  CALL	R10	1
-      0x8C281508,  //  0019  GETMET	R10	R10	K8
-      0x5C301000,  //  001A  MOVE	R12	R8
-      0x7C280400,  //  001B  CALL	R10	2
-      0x90020C0A,  //  001C  SETMBR	R0	K6	R10
-      0x8C280907,  //  001D  GETMET	R10	R4	K7
-      0x7C280200,  //  001E  CALL	R10	1
-      0x8C281508,  //  001F  GETMET	R10	R10	K8
-      0x5C301200,  //  0020  MOVE	R12	R9
-      0x7C280400,  //  0021  CALL	R10	2
-      0x8C2C0907,  //  0022  GETMET	R11	R4	K7
-      0x7C2C0200,  //  0023  CALL	R11	1
-      0x8C2C170A,  //  0024  GETMET	R11	R11	K10
-      0x5C341400,  //  0025  MOVE	R13	R10
-      0x7C2C0400,  //  0026  CALL	R11	2
-      0x9002120B,  //  0027  SETMBR	R0	K9	R11
-      0x80000000,  //  0028  RET	0
+      0x60140015,  //  0001  GETGBL	R5	G21
+      0x7C140000,  //  0002  CALL	R5	0
+      0x8C140B01,  //  0003  GETMET	R5	R5	K1
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x54220003,  //  0005  LDINT	R8	4
+      0x7C140600,  //  0006  CALL	R5	3
+      0x8C180902,  //  0007  GETMET	R6	R4	K2
+      0x7C180200,  //  0008  CALL	R6	1
+      0x8C180D03,  //  0009  GETMET	R6	R6	K3
+      0x5C200A00,  //  000A  MOVE	R8	R5
+      0x5C240600,  //  000B  MOVE	R9	R3
+      0x5C280400,  //  000C  MOVE	R10	R2
+      0x542E004F,  //  000D  LDINT	R11	80
+      0x7C180A00,  //  000E  CALL	R6	5
+      0x541E0026,  //  000F  LDINT	R7	39
+      0x401E0807,  //  0010  CONNECT	R7	K4	R7
+      0x941C0C07,  //  0011  GETIDX	R7	R6	R7
+      0x54220027,  //  0012  LDINT	R8	40
+      0x5426004E,  //  0013  LDINT	R9	79
+      0x40201009,  //  0014  CONNECT	R8	R8	R9
+      0x94200C08,  //  0015  GETIDX	R8	R6	R8
+      0x8C240906,  //  0016  GETMET	R9	R4	K6
+      0x7C240200,  //  0017  CALL	R9	1
+      0x8C241307,  //  0018  GETMET	R9	R9	K7
+      0x5C2C0E00,  //  0019  MOVE	R11	R7
+      0x7C240400,  //  001A  CALL	R9	2
+      0x90020A09,  //  001B  SETMBR	R0	K5	R9
+      0x8C240906,  //  001C  GETMET	R9	R4	K6
+      0x7C240200,  //  001D  CALL	R9	1
+      0x8C241307,  //  001E  GETMET	R9	R9	K7
+      0x5C2C1000,  //  001F  MOVE	R11	R8
+      0x7C240400,  //  0020  CALL	R9	2
+      0x8C280906,  //  0021  GETMET	R10	R4	K6
+      0x7C280200,  //  0022  CALL	R10	1
+      0x8C281509,  //  0023  GETMET	R10	R10	K9
+      0x5C301200,  //  0024  MOVE	R12	R9
+      0x7C280400,  //  0025  CALL	R10	2
+      0x9002100A,  //  0026  SETMBR	R0	K8	R10
+      0x80000000,  //  0027  RET	0
     })
   )
 );
@@ -1088,7 +1080,7 @@ be_local_closure(Matter_Device__compute_pbkdf,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_bridge_remove_endpoint,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    11,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1096,92 +1088,89 @@ be_local_closure(Matter_Device_bridge_remove_endpoint,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(json),
-    /* K2   */  be_nested_str_weak(plugins_config),
-    /* K3   */  be_nested_str_weak(contains),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(format),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(remove),
-    /* K12  */  be_nested_str_weak(plugins_persist),
-    /* K13  */  be_nested_str_weak(save_param),
-    /* K14  */  be_nested_str_weak(signal_endpoints_changed),
-    /* K15  */  be_const_int(0),
-    /* K16  */  be_nested_str_weak(plugins),
-    /* K17  */  be_nested_str_weak(get_endpoint),
-    /* K18  */  be_const_int(1),
-    /* K19  */  be_nested_str_weak(clean_remotes),
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(plugins_config),
+    /* K2   */  be_nested_str_weak(contains),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
+    /* K6   */  be_const_int(3),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
+    /* K8   */  be_const_int(2),
+    /* K9   */  be_nested_str_weak(remove),
+    /* K10  */  be_nested_str_weak(plugins_persist),
+    /* K11  */  be_nested_str_weak(save_param),
+    /* K12  */  be_nested_str_weak(signal_endpoints_changed),
+    /* K13  */  be_const_int(0),
+    /* K14  */  be_nested_str_weak(plugins),
+    /* K15  */  be_nested_str_weak(get_endpoint),
+    /* K16  */  be_const_int(1),
+    /* K17  */  be_nested_str_weak(clean_remotes),
     }),
     be_str_weak(bridge_remove_endpoint),
     &be_const_str_solidified,
-    ( &(const binstruction[61]) {  /* code */
+    ( &(const binstruction[60]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0x60100008,  //  0002  GETGBL	R4	G8
-      0x5C140200,  //  0003  MOVE	R5	R1
-      0x7C100200,  //  0004  CALL	R4	1
+      0x600C0008,  //  0001  GETGBL	R3	G8
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x4C100000,  //  0004  LDNIL	R4
       0x4C140000,  //  0005  LDNIL	R5
-      0x4C180000,  //  0006  LDNIL	R6
-      0x881C0102,  //  0007  GETMBR	R7	R0	K2
-      0x8C1C0F03,  //  0008  GETMET	R7	R7	K3
-      0x5C240800,  //  0009  MOVE	R9	R4
-      0x7C1C0400,  //  000A  CALL	R7	2
-      0x741E0005,  //  000B  JMPT	R7	#0012
-      0xB81E0800,  //  000C  GETNGBL	R7	K4
-      0x8C1C0F05,  //  000D  GETMET	R7	R7	K5
-      0x00260C04,  //  000E  ADD	R9	K6	R4
-      0x58280007,  //  000F  LDCONST	R10	K7
-      0x7C1C0600,  //  0010  CALL	R7	3
-      0x80000E00,  //  0011  RET	0
-      0xB81E0800,  //  0012  GETNGBL	R7	K4
-      0x8C1C0F05,  //  0013  GETMET	R7	R7	K5
-      0x8C240508,  //  0014  GETMET	R9	R2	K8
-      0x582C0009,  //  0015  LDCONST	R11	K9
-      0x5C300200,  //  0016  MOVE	R12	R1
-      0x7C240600,  //  0017  CALL	R9	3
-      0x5828000A,  //  0018  LDCONST	R10	K10
-      0x7C1C0600,  //  0019  CALL	R7	3
-      0x881C0102,  //  001A  GETMBR	R7	R0	K2
-      0x8C1C0F0B,  //  001B  GETMET	R7	R7	K11
-      0x5C240800,  //  001C  MOVE	R9	R4
-      0x7C1C0400,  //  001D  CALL	R7	2
-      0x501C0200,  //  001E  LDBOOL	R7	1	0
-      0x90021807,  //  001F  SETMBR	R0	K12	R7
-      0x8C1C010D,  //  0020  GETMET	R7	R0	K13
-      0x7C1C0200,  //  0021  CALL	R7	1
-      0x8C1C010E,  //  0022  GETMET	R7	R0	K14
-      0x7C1C0200,  //  0023  CALL	R7	1
-      0x581C000F,  //  0024  LDCONST	R7	K15
-      0x6020000C,  //  0025  GETGBL	R8	G12
-      0x88240110,  //  0026  GETMBR	R9	R0	K16
-      0x7C200200,  //  0027  CALL	R8	1
-      0x14200E08,  //  0028  LT	R8	R7	R8
-      0x7822000F,  //  0029  JMPF	R8	#003A
-      0x88200110,  //  002A  GETMBR	R8	R0	K16
-      0x94201007,  //  002B  GETIDX	R8	R8	R7
-      0x8C201111,  //  002C  GETMET	R8	R8	K17
-      0x7C200200,  //  002D  CALL	R8	1
-      0x1C200208,  //  002E  EQ	R8	R1	R8
-      0x78220007,  //  002F  JMPF	R8	#0038
-      0x88200110,  //  0030  GETMBR	R8	R0	K16
-      0x8C20110B,  //  0031  GETMET	R8	R8	K11
-      0x5C280E00,  //  0032  MOVE	R10	R7
-      0x7C200400,  //  0033  CALL	R8	2
-      0x8C20010E,  //  0034  GETMET	R8	R0	K14
-      0x7C200200,  //  0035  CALL	R8	1
-      0x70020002,  //  0036  JMP		#003A
-      0x70020000,  //  0037  JMP		#0039
-      0x001C0F12,  //  0038  ADD	R7	R7	K18
-      0x7001FFEA,  //  0039  JMP		#0025
-      0x8C200113,  //  003A  GETMET	R8	R0	K19
-      0x7C200200,  //  003B  CALL	R8	1
-      0x80000000,  //  003C  RET	0
+      0x88180101,  //  0006  GETMBR	R6	R0	K1
+      0x8C180D02,  //  0007  GETMET	R6	R6	K2
+      0x5C200600,  //  0008  MOVE	R8	R3
+      0x7C180400,  //  0009  CALL	R6	2
+      0x741A0005,  //  000A  JMPT	R6	#0011
+      0xB81A0600,  //  000B  GETNGBL	R6	K3
+      0x8C180D04,  //  000C  GETMET	R6	R6	K4
+      0x00220A03,  //  000D  ADD	R8	K5	R3
+      0x58240006,  //  000E  LDCONST	R9	K6
+      0x7C180600,  //  000F  CALL	R6	3
+      0x80000C00,  //  0010  RET	0
+      0xB81A0600,  //  0011  GETNGBL	R6	K3
+      0x8C180D04,  //  0012  GETMET	R6	R6	K4
+      0x60200018,  //  0013  GETGBL	R8	G24
+      0x58240007,  //  0014  LDCONST	R9	K7
+      0x5C280200,  //  0015  MOVE	R10	R1
+      0x7C200400,  //  0016  CALL	R8	2
+      0x58240008,  //  0017  LDCONST	R9	K8
+      0x7C180600,  //  0018  CALL	R6	3
+      0x88180101,  //  0019  GETMBR	R6	R0	K1
+      0x8C180D09,  //  001A  GETMET	R6	R6	K9
+      0x5C200600,  //  001B  MOVE	R8	R3
+      0x7C180400,  //  001C  CALL	R6	2
+      0x50180200,  //  001D  LDBOOL	R6	1	0
+      0x90021406,  //  001E  SETMBR	R0	K10	R6
+      0x8C18010B,  //  001F  GETMET	R6	R0	K11
+      0x7C180200,  //  0020  CALL	R6	1
+      0x8C18010C,  //  0021  GETMET	R6	R0	K12
+      0x7C180200,  //  0022  CALL	R6	1
+      0x5818000D,  //  0023  LDCONST	R6	K13
+      0x601C000C,  //  0024  GETGBL	R7	G12
+      0x8820010E,  //  0025  GETMBR	R8	R0	K14
+      0x7C1C0200,  //  0026  CALL	R7	1
+      0x141C0C07,  //  0027  LT	R7	R6	R7
+      0x781E000F,  //  0028  JMPF	R7	#0039
+      0x881C010E,  //  0029  GETMBR	R7	R0	K14
+      0x941C0E06,  //  002A  GETIDX	R7	R7	R6
+      0x8C1C0F0F,  //  002B  GETMET	R7	R7	K15
+      0x7C1C0200,  //  002C  CALL	R7	1
+      0x1C1C0207,  //  002D  EQ	R7	R1	R7
+      0x781E0007,  //  002E  JMPF	R7	#0037
+      0x881C010E,  //  002F  GETMBR	R7	R0	K14
+      0x8C1C0F09,  //  0030  GETMET	R7	R7	K9
+      0x5C240C00,  //  0031  MOVE	R9	R6
+      0x7C1C0400,  //  0032  CALL	R7	2
+      0x8C1C010C,  //  0033  GETMET	R7	R0	K12
+      0x7C1C0200,  //  0034  CALL	R7	1
+      0x70020002,  //  0035  JMP		#0039
+      0x70020000,  //  0036  JMP		#0038
+      0x00180D10,  //  0037  ADD	R6	R6	K16
+      0x7001FFEA,  //  0038  JMP		#0024
+      0x8C1C0111,  //  0039  GETMET	R7	R0	K17
+      0x7C1C0200,  //  003A  CALL	R7	1
+      0x80000000,  //  003B  RET	0
     })
   )
 );
@@ -1355,7 +1344,7 @@ be_local_closure(Matter_Device_remove_fabric,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_save_param,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1363,105 +1352,102 @@ be_local_closure(Matter_Device_save_param,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[28]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(json),
-    /* K2   */  be_nested_str_weak(format),
-    /* K3   */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
-    /* K4   */  be_nested_str_weak(root_discriminator),
-    /* K5   */  be_nested_str_weak(root_passcode),
-    /* K6   */  be_nested_str_weak(ipv4only),
-    /* K7   */  be_nested_str_weak(true),
-    /* K8   */  be_nested_str_weak(false),
-    /* K9   */  be_nested_str_weak(next_ep),
-    /* K10  */  be_nested_str_weak(plugins_persist),
-    /* K11  */  be_nested_str_weak(_X2C_X22config_X22_X3A),
-    /* K12  */  be_nested_str_weak(dump),
-    /* K13  */  be_nested_str_weak(plugins_config),
-    /* K14  */  be_nested_str_weak(_X7D),
-    /* K15  */  be_nested_str_weak(FILENAME),
-    /* K16  */  be_nested_str_weak(w),
-    /* K17  */  be_nested_str_weak(write),
-    /* K18  */  be_nested_str_weak(close),
-    /* K19  */  be_nested_str_weak(tasmota),
-    /* K20  */  be_nested_str_weak(log),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
-    /* K22  */  be_nested_str_weak(_X20and_X20configuration),
-    /* K23  */  be_nested_str_weak(),
-    /* K24  */  be_const_int(3),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K26  */  be_nested_str_weak(_X7C),
-    /* K27  */  be_const_int(2),
+    ( &(const bvalue[26]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
+    /* K2   */  be_nested_str_weak(root_discriminator),
+    /* K3   */  be_nested_str_weak(root_passcode),
+    /* K4   */  be_nested_str_weak(ipv4only),
+    /* K5   */  be_nested_str_weak(true),
+    /* K6   */  be_nested_str_weak(false),
+    /* K7   */  be_nested_str_weak(next_ep),
+    /* K8   */  be_nested_str_weak(plugins_persist),
+    /* K9   */  be_nested_str_weak(_X2C_X22config_X22_X3A),
+    /* K10  */  be_nested_str_weak(dump),
+    /* K11  */  be_nested_str_weak(plugins_config),
+    /* K12  */  be_nested_str_weak(_X7D),
+    /* K13  */  be_nested_str_weak(FILENAME),
+    /* K14  */  be_nested_str_weak(w),
+    /* K15  */  be_nested_str_weak(write),
+    /* K16  */  be_nested_str_weak(close),
+    /* K17  */  be_nested_str_weak(tasmota),
+    /* K18  */  be_nested_str_weak(log),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
+    /* K20  */  be_nested_str_weak(_X20and_X20configuration),
+    /* K21  */  be_nested_str_weak(),
+    /* K22  */  be_const_int(3),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+    /* K24  */  be_nested_str_weak(_X7C),
+    /* K25  */  be_const_int(2),
     }),
     be_str_weak(save_param),
     &be_const_str_solidified,
-    ( &(const binstruction[66]) {  /* code */
+    ( &(const binstruction[65]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
-      0x58140003,  //  0003  LDCONST	R5	K3
-      0x88180104,  //  0004  GETMBR	R6	R0	K4
-      0x881C0105,  //  0005  GETMBR	R7	R0	K5
-      0x88200106,  //  0006  GETMBR	R8	R0	K6
-      0x78220001,  //  0007  JMPF	R8	#000A
-      0x58200007,  //  0008  LDCONST	R8	K7
-      0x70020000,  //  0009  JMP		#000B
-      0x58200008,  //  000A  LDCONST	R8	K8
-      0x88240109,  //  000B  GETMBR	R9	R0	K9
-      0x7C0C0C00,  //  000C  CALL	R3	6
-      0x8810010A,  //  000D  GETMBR	R4	R0	K10
-      0x78120004,  //  000E  JMPF	R4	#0014
-      0x000C070B,  //  000F  ADD	R3	R3	K11
-      0x8C10050C,  //  0010  GETMET	R4	R2	K12
-      0x8818010D,  //  0011  GETMBR	R6	R0	K13
-      0x7C100400,  //  0012  CALL	R4	2
-      0x000C0604,  //  0013  ADD	R3	R3	R4
-      0x000C070E,  //  0014  ADD	R3	R3	K14
-      0xA8020018,  //  0015  EXBLK	0	#002F
-      0x60100011,  //  0016  GETGBL	R4	G17
-      0x8814010F,  //  0017  GETMBR	R5	R0	K15
-      0x58180010,  //  0018  LDCONST	R6	K16
-      0x7C100400,  //  0019  CALL	R4	2
-      0x8C140911,  //  001A  GETMET	R5	R4	K17
-      0x5C1C0600,  //  001B  MOVE	R7	R3
-      0x7C140400,  //  001C  CALL	R5	2
-      0x8C140912,  //  001D  GETMET	R5	R4	K18
-      0x7C140200,  //  001E  CALL	R5	1
-      0xB8162600,  //  001F  GETNGBL	R5	K19
-      0x8C140B14,  //  0020  GETMET	R5	R5	K20
-      0x8C1C0302,  //  0021  GETMET	R7	R1	K2
-      0x58240015,  //  0022  LDCONST	R9	K21
-      0x8828010A,  //  0023  GETMBR	R10	R0	K10
-      0x782A0001,  //  0024  JMPF	R10	#0027
-      0x58280016,  //  0025  LDCONST	R10	K22
-      0x70020000,  //  0026  JMP		#0028
-      0x58280017,  //  0027  LDCONST	R10	K23
-      0x7C1C0600,  //  0028  CALL	R7	3
-      0x58200018,  //  0029  LDCONST	R8	K24
-      0x7C140600,  //  002A  CALL	R5	3
-      0xA8040001,  //  002B  EXBLK	1	1
-      0x80040600,  //  002C  RET	1	R3
-      0xA8040001,  //  002D  EXBLK	1	1
-      0x70020011,  //  002E  JMP		#0041
-      0xAC100002,  //  002F  CATCH	R4	0	2
-      0x7002000E,  //  0030  JMP		#0040
-      0xB81A2600,  //  0031  GETNGBL	R6	K19
-      0x8C180D14,  //  0032  GETMET	R6	R6	K20
-      0x60200008,  //  0033  GETGBL	R8	G8
-      0x5C240800,  //  0034  MOVE	R9	R4
-      0x7C200200,  //  0035  CALL	R8	1
-      0x00223208,  //  0036  ADD	R8	K25	R8
-      0x0020111A,  //  0037  ADD	R8	R8	K26
-      0x60240008,  //  0038  GETGBL	R9	G8
-      0x5C280A00,  //  0039  MOVE	R10	R5
-      0x7C240200,  //  003A  CALL	R9	1
-      0x00201009,  //  003B  ADD	R8	R8	R9
-      0x5824001B,  //  003C  LDCONST	R9	K27
-      0x7C180600,  //  003D  CALL	R6	3
-      0x80040600,  //  003E  RET	1	R3
-      0x70020000,  //  003F  JMP		#0041
-      0xB0080000,  //  0040  RAISE	2	R0	R0
-      0x80000000,  //  0041  RET	0
+      0x60080018,  //  0001  GETGBL	R2	G24
+      0x580C0001,  //  0002  LDCONST	R3	K1
+      0x88100102,  //  0003  GETMBR	R4	R0	K2
+      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x88180104,  //  0005  GETMBR	R6	R0	K4
+      0x781A0001,  //  0006  JMPF	R6	#0009
+      0x58180005,  //  0007  LDCONST	R6	K5
+      0x70020000,  //  0008  JMP		#000A
+      0x58180006,  //  0009  LDCONST	R6	K6
+      0x881C0107,  //  000A  GETMBR	R7	R0	K7
+      0x7C080A00,  //  000B  CALL	R2	5
+      0x880C0108,  //  000C  GETMBR	R3	R0	K8
+      0x780E0004,  //  000D  JMPF	R3	#0013
+      0x00080509,  //  000E  ADD	R2	R2	K9
+      0x8C0C030A,  //  000F  GETMET	R3	R1	K10
+      0x8814010B,  //  0010  GETMBR	R5	R0	K11
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x00080403,  //  0012  ADD	R2	R2	R3
+      0x0008050C,  //  0013  ADD	R2	R2	K12
+      0xA8020018,  //  0014  EXBLK	0	#002E
+      0x600C0011,  //  0015  GETGBL	R3	G17
+      0x8810010D,  //  0016  GETMBR	R4	R0	K13
+      0x5814000E,  //  0017  LDCONST	R5	K14
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x8C10070F,  //  0019  GETMET	R4	R3	K15
+      0x5C180400,  //  001A  MOVE	R6	R2
+      0x7C100400,  //  001B  CALL	R4	2
+      0x8C100710,  //  001C  GETMET	R4	R3	K16
+      0x7C100200,  //  001D  CALL	R4	1
+      0xB8122200,  //  001E  GETNGBL	R4	K17
+      0x8C100912,  //  001F  GETMET	R4	R4	K18
+      0x60180018,  //  0020  GETGBL	R6	G24
+      0x581C0013,  //  0021  LDCONST	R7	K19
+      0x88200108,  //  0022  GETMBR	R8	R0	K8
+      0x78220001,  //  0023  JMPF	R8	#0026
+      0x58200014,  //  0024  LDCONST	R8	K20
+      0x70020000,  //  0025  JMP		#0027
+      0x58200015,  //  0026  LDCONST	R8	K21
+      0x7C180400,  //  0027  CALL	R6	2
+      0x581C0016,  //  0028  LDCONST	R7	K22
+      0x7C100600,  //  0029  CALL	R4	3
+      0xA8040001,  //  002A  EXBLK	1	1
+      0x80040400,  //  002B  RET	1	R2
+      0xA8040001,  //  002C  EXBLK	1	1
+      0x70020011,  //  002D  JMP		#0040
+      0xAC0C0002,  //  002E  CATCH	R3	0	2
+      0x7002000E,  //  002F  JMP		#003F
+      0xB8162200,  //  0030  GETNGBL	R5	K17
+      0x8C140B12,  //  0031  GETMET	R5	R5	K18
+      0x601C0008,  //  0032  GETGBL	R7	G8
+      0x5C200600,  //  0033  MOVE	R8	R3
+      0x7C1C0200,  //  0034  CALL	R7	1
+      0x001E2E07,  //  0035  ADD	R7	K23	R7
+      0x001C0F18,  //  0036  ADD	R7	R7	K24
+      0x60200008,  //  0037  GETGBL	R8	G8
+      0x5C240800,  //  0038  MOVE	R9	R4
+      0x7C200200,  //  0039  CALL	R8	1
+      0x001C0E08,  //  003A  ADD	R7	R7	R8
+      0x58200019,  //  003B  LDCONST	R8	K25
+      0x7C140600,  //  003C  CALL	R5	3
+      0x80040400,  //  003D  RET	1	R2
+      0x70020000,  //  003E  JMP		#0040
+      0xB0080000,  //  003F  RAISE	2	R0	R0
+      0x80000000,  //  0040  RET	0
     })
   )
 );
@@ -1510,7 +1496,7 @@ be_local_closure(Matter_Device_get_plugin_class_arg,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1518,116 +1504,113 @@ be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
+    ( &(const bvalue[20]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(mdns_pase_eth),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eremove_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
-    /* K7   */  be_nested_str_weak(_matterc),
-    /* K8   */  be_nested_str_weak(_udp),
-    /* K9   */  be_nested_str_weak(commissioning_instance_eth),
-    /* K10  */  be_nested_str_weak(hostname_eth),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
-    /* K13  */  be_nested_str_weak(eth),
-    /* K14  */  be_nested_str_weak(remove_service),
-    /* K15  */  be_nested_str_weak(mdns_pase_wifi),
-    /* K16  */  be_nested_str_weak(commissioning_instance_wifi),
-    /* K17  */  be_nested_str_weak(hostname_wifi),
-    /* K18  */  be_nested_str_weak(wifi),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K20  */  be_nested_str_weak(_X7C),
-    /* K21  */  be_const_int(2),
+    /* K1   */  be_nested_str_weak(mdns_pase_eth),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eremove_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
+    /* K5   */  be_nested_str_weak(_matterc),
+    /* K6   */  be_nested_str_weak(_udp),
+    /* K7   */  be_nested_str_weak(commissioning_instance_eth),
+    /* K8   */  be_nested_str_weak(hostname_eth),
+    /* K9   */  be_const_int(3),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
+    /* K11  */  be_nested_str_weak(eth),
+    /* K12  */  be_nested_str_weak(remove_service),
+    /* K13  */  be_nested_str_weak(mdns_pase_wifi),
+    /* K14  */  be_nested_str_weak(commissioning_instance_wifi),
+    /* K15  */  be_nested_str_weak(hostname_wifi),
+    /* K16  */  be_nested_str_weak(wifi),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K18  */  be_nested_str_weak(_X7C),
+    /* K19  */  be_const_int(2),
     }),
     be_str_weak(mdns_remove_PASE),
     &be_const_str_solidified,
-    ( &(const binstruction[83]) {  /* code */
+    ( &(const binstruction[82]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xA802003D,  //  0002  EXBLK	0	#0041
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
-      0x780E001B,  //  0004  JMPF	R3	#0021
-      0xB80E0600,  //  0005  GETNGBL	R3	K3
-      0x8C0C0704,  //  0006  GETMET	R3	R3	K4
-      0x8C140505,  //  0007  GETMET	R5	R2	K5
-      0x581C0006,  //  0008  LDCONST	R7	K6
-      0x58200007,  //  0009  LDCONST	R8	K7
-      0x58240008,  //  000A  LDCONST	R9	K8
-      0x88280109,  //  000B  GETMBR	R10	R0	K9
-      0x882C010A,  //  000C  GETMBR	R11	R0	K10
-      0x7C140C00,  //  000D  CALL	R5	6
-      0x5818000B,  //  000E  LDCONST	R6	K11
-      0x7C0C0600,  //  000F  CALL	R3	3
-      0xB80E0600,  //  0010  GETNGBL	R3	K3
-      0x8C0C0704,  //  0011  GETMET	R3	R3	K4
-      0x8C140505,  //  0012  GETMET	R5	R2	K5
-      0x581C000C,  //  0013  LDCONST	R7	K12
-      0x5820000D,  //  0014  LDCONST	R8	K13
-      0x88240109,  //  0015  GETMBR	R9	R0	K9
-      0x7C140800,  //  0016  CALL	R5	4
-      0x5818000B,  //  0017  LDCONST	R6	K11
-      0x7C0C0600,  //  0018  CALL	R3	3
-      0x500C0000,  //  0019  LDBOOL	R3	0	0
-      0x90020403,  //  001A  SETMBR	R0	K2	R3
-      0x8C0C030E,  //  001B  GETMET	R3	R1	K14
-      0x58140007,  //  001C  LDCONST	R5	K7
-      0x58180008,  //  001D  LDCONST	R6	K8
-      0x881C0109,  //  001E  GETMBR	R7	R0	K9
-      0x8820010A,  //  001F  GETMBR	R8	R0	K10
-      0x7C0C0A00,  //  0020  CALL	R3	5
-      0x880C010F,  //  0021  GETMBR	R3	R0	K15
-      0x780E001B,  //  0022  JMPF	R3	#003F
-      0xB80E0600,  //  0023  GETNGBL	R3	K3
-      0x8C0C0704,  //  0024  GETMET	R3	R3	K4
-      0x8C140505,  //  0025  GETMET	R5	R2	K5
-      0x581C0006,  //  0026  LDCONST	R7	K6
-      0x58200007,  //  0027  LDCONST	R8	K7
-      0x58240008,  //  0028  LDCONST	R9	K8
-      0x88280110,  //  0029  GETMBR	R10	R0	K16
-      0x882C0111,  //  002A  GETMBR	R11	R0	K17
-      0x7C140C00,  //  002B  CALL	R5	6
-      0x5818000B,  //  002C  LDCONST	R6	K11
-      0x7C0C0600,  //  002D  CALL	R3	3
-      0xB80E0600,  //  002E  GETNGBL	R3	K3
-      0x8C0C0704,  //  002F  GETMET	R3	R3	K4
-      0x8C140505,  //  0030  GETMET	R5	R2	K5
-      0x581C000C,  //  0031  LDCONST	R7	K12
-      0x58200012,  //  0032  LDCONST	R8	K18
-      0x88240110,  //  0033  GETMBR	R9	R0	K16
-      0x7C140800,  //  0034  CALL	R5	4
-      0x5818000B,  //  0035  LDCONST	R6	K11
-      0x7C0C0600,  //  0036  CALL	R3	3
-      0x500C0000,  //  0037  LDBOOL	R3	0	0
-      0x90021E03,  //  0038  SETMBR	R0	K15	R3
-      0x8C0C030E,  //  0039  GETMET	R3	R1	K14
-      0x58140007,  //  003A  LDCONST	R5	K7
-      0x58180008,  //  003B  LDCONST	R6	K8
-      0x881C0110,  //  003C  GETMBR	R7	R0	K16
-      0x88200111,  //  003D  GETMBR	R8	R0	K17
-      0x7C0C0A00,  //  003E  CALL	R3	5
-      0xA8040001,  //  003F  EXBLK	1	1
-      0x70020010,  //  0040  JMP		#0052
-      0xAC0C0002,  //  0041  CATCH	R3	0	2
-      0x7002000D,  //  0042  JMP		#0051
-      0xB8160600,  //  0043  GETNGBL	R5	K3
-      0x8C140B04,  //  0044  GETMET	R5	R5	K4
-      0x601C0008,  //  0045  GETGBL	R7	G8
-      0x5C200600,  //  0046  MOVE	R8	R3
-      0x7C1C0200,  //  0047  CALL	R7	1
-      0x001E2607,  //  0048  ADD	R7	K19	R7
-      0x001C0F14,  //  0049  ADD	R7	R7	K20
-      0x60200008,  //  004A  GETGBL	R8	G8
-      0x5C240800,  //  004B  MOVE	R9	R4
-      0x7C200200,  //  004C  CALL	R8	1
-      0x001C0E08,  //  004D  ADD	R7	R7	R8
-      0x58200015,  //  004E  LDCONST	R8	K21
-      0x7C140600,  //  004F  CALL	R5	3
-      0x70020000,  //  0050  JMP		#0052
-      0xB0080000,  //  0051  RAISE	2	R0	R0
-      0x80000000,  //  0052  RET	0
+      0xA802003D,  //  0001  EXBLK	0	#0040
+      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x780A001B,  //  0003  JMPF	R2	#0020
+      0xB80A0400,  //  0004  GETNGBL	R2	K2
+      0x8C080503,  //  0005  GETMET	R2	R2	K3
+      0x60100018,  //  0006  GETGBL	R4	G24
+      0x58140004,  //  0007  LDCONST	R5	K4
+      0x58180005,  //  0008  LDCONST	R6	K5
+      0x581C0006,  //  0009  LDCONST	R7	K6
+      0x88200107,  //  000A  GETMBR	R8	R0	K7
+      0x88240108,  //  000B  GETMBR	R9	R0	K8
+      0x7C100A00,  //  000C  CALL	R4	5
+      0x58140009,  //  000D  LDCONST	R5	K9
+      0x7C080600,  //  000E  CALL	R2	3
+      0xB80A0400,  //  000F  GETNGBL	R2	K2
+      0x8C080503,  //  0010  GETMET	R2	R2	K3
+      0x60100018,  //  0011  GETGBL	R4	G24
+      0x5814000A,  //  0012  LDCONST	R5	K10
+      0x5818000B,  //  0013  LDCONST	R6	K11
+      0x881C0107,  //  0014  GETMBR	R7	R0	K7
+      0x7C100600,  //  0015  CALL	R4	3
+      0x58140009,  //  0016  LDCONST	R5	K9
+      0x7C080600,  //  0017  CALL	R2	3
+      0x50080000,  //  0018  LDBOOL	R2	0	0
+      0x90020202,  //  0019  SETMBR	R0	K1	R2
+      0x8C08030C,  //  001A  GETMET	R2	R1	K12
+      0x58100005,  //  001B  LDCONST	R4	K5
+      0x58140006,  //  001C  LDCONST	R5	K6
+      0x88180107,  //  001D  GETMBR	R6	R0	K7
+      0x881C0108,  //  001E  GETMBR	R7	R0	K8
+      0x7C080A00,  //  001F  CALL	R2	5
+      0x8808010D,  //  0020  GETMBR	R2	R0	K13
+      0x780A001B,  //  0021  JMPF	R2	#003E
+      0xB80A0400,  //  0022  GETNGBL	R2	K2
+      0x8C080503,  //  0023  GETMET	R2	R2	K3
+      0x60100018,  //  0024  GETGBL	R4	G24
+      0x58140004,  //  0025  LDCONST	R5	K4
+      0x58180005,  //  0026  LDCONST	R6	K5
+      0x581C0006,  //  0027  LDCONST	R7	K6
+      0x8820010E,  //  0028  GETMBR	R8	R0	K14
+      0x8824010F,  //  0029  GETMBR	R9	R0	K15
+      0x7C100A00,  //  002A  CALL	R4	5
+      0x58140009,  //  002B  LDCONST	R5	K9
+      0x7C080600,  //  002C  CALL	R2	3
+      0xB80A0400,  //  002D  GETNGBL	R2	K2
+      0x8C080503,  //  002E  GETMET	R2	R2	K3
+      0x60100018,  //  002F  GETGBL	R4	G24
+      0x5814000A,  //  0030  LDCONST	R5	K10
+      0x58180010,  //  0031  LDCONST	R6	K16
+      0x881C010E,  //  0032  GETMBR	R7	R0	K14
+      0x7C100600,  //  0033  CALL	R4	3
+      0x58140009,  //  0034  LDCONST	R5	K9
+      0x7C080600,  //  0035  CALL	R2	3
+      0x50080000,  //  0036  LDBOOL	R2	0	0
+      0x90021A02,  //  0037  SETMBR	R0	K13	R2
+      0x8C08030C,  //  0038  GETMET	R2	R1	K12
+      0x58100005,  //  0039  LDCONST	R4	K5
+      0x58140006,  //  003A  LDCONST	R5	K6
+      0x8818010E,  //  003B  GETMBR	R6	R0	K14
+      0x881C010F,  //  003C  GETMBR	R7	R0	K15
+      0x7C080A00,  //  003D  CALL	R2	5
+      0xA8040001,  //  003E  EXBLK	1	1
+      0x70020010,  //  003F  JMP		#0051
+      0xAC080002,  //  0040  CATCH	R2	0	2
+      0x7002000D,  //  0041  JMP		#0050
+      0xB8120400,  //  0042  GETNGBL	R4	K2
+      0x8C100903,  //  0043  GETMET	R4	R4	K3
+      0x60180008,  //  0044  GETGBL	R6	G8
+      0x5C1C0400,  //  0045  MOVE	R7	R2
+      0x7C180200,  //  0046  CALL	R6	1
+      0x001A2206,  //  0047  ADD	R6	K17	R6
+      0x00180D12,  //  0048  ADD	R6	R6	K18
+      0x601C0008,  //  0049  GETGBL	R7	G8
+      0x5C200600,  //  004A  MOVE	R8	R3
+      0x7C1C0200,  //  004B  CALL	R7	1
+      0x00180C07,  //  004C  ADD	R6	R6	R7
+      0x581C0013,  //  004D  LDCONST	R7	K19
+      0x7C100600,  //  004E  CALL	R4	3
+      0x70020000,  //  004F  JMP		#0051
+      0xB0080000,  //  0050  RAISE	2	R0	R0
+      0x80000000,  //  0051  RET	0
     })
   )
 );
@@ -1680,7 +1663,7 @@ be_local_closure(Matter_Device_event_fabrics_saved,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    11,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1688,49 +1671,46 @@ be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(get_fabric),
-    /* K2   */  be_nested_str_weak(get_fabric_id),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(reverse),
-    /* K5   */  be_nested_str_weak(tohex),
-    /* K6   */  be_nested_str_weak(get_admin_vendor_name),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(format),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X2D_X2D_X2D_X20Commissioning_X20complete_X20for_X20Fabric_X20_X27_X25s_X27_X20_X28Vendor_X20_X25s_X29_X20_X2D_X2D_X2D),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(stop_basic_commissioning),
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_fabric),
+    /* K1   */  be_nested_str_weak(get_fabric_id),
+    /* K2   */  be_nested_str_weak(copy),
+    /* K3   */  be_nested_str_weak(reverse),
+    /* K4   */  be_nested_str_weak(tohex),
+    /* K5   */  be_nested_str_weak(get_admin_vendor_name),
+    /* K6   */  be_nested_str_weak(tasmota),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X2D_X2D_X2D_X20Commissioning_X20complete_X20for_X20Fabric_X20_X27_X25s_X27_X20_X28Vendor_X20_X25s_X29_X20_X2D_X2D_X2D),
+    /* K9   */  be_const_int(2),
+    /* K10  */  be_nested_str_weak(stop_basic_commissioning),
     }),
     be_str_weak(start_commissioning_complete),
     &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0301,  //  0001  GETMET	R3	R1	K1
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C100702,  //  0003  GETMET	R4	R3	K2
-      0x7C100200,  //  0004  CALL	R4	1
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C100905,  //  0009  GETMET	R4	R4	K5
-      0x7C100200,  //  000A  CALL	R4	1
-      0x8C140706,  //  000B  GETMET	R5	R3	K6
-      0x7C140200,  //  000C  CALL	R5	1
-      0xB81A0E00,  //  000D  GETNGBL	R6	K7
-      0x8C180D08,  //  000E  GETMET	R6	R6	K8
-      0x8C200509,  //  000F  GETMET	R8	R2	K9
-      0x5828000A,  //  0010  LDCONST	R10	K10
-      0x5C2C0800,  //  0011  MOVE	R11	R4
-      0x5C300A00,  //  0012  MOVE	R12	R5
-      0x7C200800,  //  0013  CALL	R8	4
-      0x5824000B,  //  0014  LDCONST	R9	K11
-      0x7C180600,  //  0015  CALL	R6	3
-      0x8C18010C,  //  0016  GETMET	R6	R0	K12
-      0x7C180200,  //  0017  CALL	R6	1
-      0x80000000,  //  0018  RET	0
+    ( &(const binstruction[24]) {  /* code */
+      0x8C080300,  //  0000  GETMET	R2	R1	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x8C0C0501,  //  0002  GETMET	R3	R2	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x8C0C0704,  //  0008  GETMET	R3	R3	K4
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x8C100505,  //  000A  GETMET	R4	R2	K5
+      0x7C100200,  //  000B  CALL	R4	1
+      0xB8160C00,  //  000C  GETNGBL	R5	K6
+      0x8C140B07,  //  000D  GETMET	R5	R5	K7
+      0x601C0018,  //  000E  GETGBL	R7	G24
+      0x58200008,  //  000F  LDCONST	R8	K8
+      0x5C240600,  //  0010  MOVE	R9	R3
+      0x5C280800,  //  0011  MOVE	R10	R4
+      0x7C1C0600,  //  0012  CALL	R7	3
+      0x58200009,  //  0013  LDCONST	R8	K9
+      0x7C140600,  //  0014  CALL	R5	3
+      0x8C14010A,  //  0015  GETMET	R5	R0	K10
+      0x7C140200,  //  0016  CALL	R5	1
+      0x80000000,  //  0017  RET	0
     })
   )
 );
@@ -1775,7 +1755,7 @@ be_local_closure(Matter_Device_msg_received,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device__instantiate_plugins_from_config,   /* name */
   be_nested_proto(
-    20,                          /* nstack */
+    18,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1783,196 +1763,193 @@ be_local_closure(Matter_Device__instantiate_plugins_from_config,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[32]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(k2l_num),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20Configuring_X20endpoints),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_nested_str_weak(plugins),
-    /* K7   */  be_nested_str_weak(push),
-    /* K8   */  be_nested_str_weak(matter),
-    /* K9   */  be_nested_str_weak(Plugin_Root),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(format),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20_X20_X20endpoint_X20_X3D_X20_X255i_X20type_X3A_X25s_X25s),
-    /* K13  */  be_nested_str_weak(root),
-    /* K14  */  be_nested_str_weak(),
-    /* K15  */  be_nested_str_weak(Plugin_Aggregator),
-    /* K16  */  be_nested_str_weak(find),
-    /* K17  */  be_nested_str_weak(type),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
-    /* K19  */  be_const_int(3),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20only_X20one_X20root_X20node_X20allowed),
-    /* K21  */  be_nested_str_weak(plugins_classes),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-    /* K23  */  be_nested_str_weak(_X27_X20skipping),
-    /* K24  */  be_nested_str_weak(conf_to_log),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K26  */  be_nested_str_weak(_X7C),
-    /* K27  */  be_nested_str_weak(stop_iteration),
-    /* K28  */  be_nested_str_weak(aggregator),
-    /* K29  */  be_nested_str_weak(publish_result),
-    /* K30  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
-    /* K31  */  be_nested_str_weak(Matter),
+    ( &(const bvalue[30]) {     /* constants */
+    /* K0   */  be_nested_str_weak(k2l_num),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20Configuring_X20endpoints),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_nested_str_weak(plugins),
+    /* K6   */  be_nested_str_weak(push),
+    /* K7   */  be_nested_str_weak(matter),
+    /* K8   */  be_nested_str_weak(Plugin_Root),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X20_X20endpoint_X20_X3D_X20_X255i_X20type_X3A_X25s_X25s),
+    /* K11  */  be_nested_str_weak(root),
+    /* K12  */  be_nested_str_weak(),
+    /* K13  */  be_nested_str_weak(Plugin_Aggregator),
+    /* K14  */  be_nested_str_weak(find),
+    /* K15  */  be_nested_str_weak(type),
+    /* K16  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
+    /* K17  */  be_const_int(3),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20only_X20one_X20root_X20node_X20allowed),
+    /* K19  */  be_nested_str_weak(plugins_classes),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+    /* K21  */  be_nested_str_weak(_X27_X20skipping),
+    /* K22  */  be_nested_str_weak(conf_to_log),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K24  */  be_nested_str_weak(_X7C),
+    /* K25  */  be_nested_str_weak(stop_iteration),
+    /* K26  */  be_nested_str_weak(aggregator),
+    /* K27  */  be_nested_str_weak(publish_result),
+    /* K28  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
+    /* K29  */  be_nested_str_weak(Matter),
     }),
     be_str_weak(_instantiate_plugins_from_config),
     &be_const_str_solidified,
-    ( &(const binstruction[153]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0101,  //  0001  GETMET	R3	R0	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0xB8120400,  //  0004  GETNGBL	R4	K2
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
+    ( &(const binstruction[152]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0xB80E0200,  //  0003  GETNGBL	R3	K1
+      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x58140003,  //  0005  LDCONST	R5	K3
       0x58180004,  //  0006  LDCONST	R6	K4
-      0x581C0005,  //  0007  LDCONST	R7	K5
-      0x7C100600,  //  0008  CALL	R4	3
-      0x88100106,  //  0009  GETMBR	R4	R0	K6
-      0x8C100907,  //  000A  GETMET	R4	R4	K7
-      0xB81A1000,  //  000B  GETNGBL	R6	K8
-      0x8C180D09,  //  000C  GETMET	R6	R6	K9
-      0x5C200000,  //  000D  MOVE	R8	R0
-      0x5824000A,  //  000E  LDCONST	R9	K10
-      0x60280013,  //  000F  GETGBL	R10	G19
-      0x7C280000,  //  0010  CALL	R10	0
-      0x7C180800,  //  0011  CALL	R6	4
-      0x7C100400,  //  0012  CALL	R4	2
-      0xB8120400,  //  0013  GETNGBL	R4	K2
-      0x8C100903,  //  0014  GETMET	R4	R4	K3
-      0x8C18050B,  //  0015  GETMET	R6	R2	K11
-      0x5820000C,  //  0016  LDCONST	R8	K12
-      0x5824000A,  //  0017  LDCONST	R9	K10
-      0x5828000D,  //  0018  LDCONST	R10	K13
-      0x582C000E,  //  0019  LDCONST	R11	K14
-      0x7C180A00,  //  001A  CALL	R6	5
-      0x581C0005,  //  001B  LDCONST	R7	K5
-      0x7C100600,  //  001C  CALL	R4	3
-      0x88100106,  //  001D  GETMBR	R4	R0	K6
-      0x8C100907,  //  001E  GETMET	R4	R4	K7
-      0xB81A1000,  //  001F  GETNGBL	R6	K8
-      0x8C180D0F,  //  0020  GETMET	R6	R6	K15
-      0x5C200000,  //  0021  MOVE	R8	R0
-      0x5426FEFF,  //  0022  LDINT	R9	65280
-      0x60280013,  //  0023  GETGBL	R10	G19
-      0x7C280000,  //  0024  CALL	R10	0
-      0x7C180800,  //  0025  CALL	R6	4
-      0x7C100400,  //  0026  CALL	R4	2
-      0x60100010,  //  0027  GETGBL	R4	G16
-      0x5C140600,  //  0028  MOVE	R5	R3
-      0x7C100200,  //  0029  CALL	R4	1
-      0xA802005A,  //  002A  EXBLK	0	#0086
-      0x5C140800,  //  002B  MOVE	R5	R4
-      0x7C140000,  //  002C  CALL	R5	0
-      0x1C180B0A,  //  002D  EQ	R6	R5	K10
-      0x781A0000,  //  002E  JMPF	R6	#0030
-      0x7001FFFA,  //  002F  JMP		#002B
-      0xA8020042,  //  0030  EXBLK	0	#0074
-      0x60180008,  //  0031  GETGBL	R6	G8
-      0x5C1C0A00,  //  0032  MOVE	R7	R5
-      0x7C180200,  //  0033  CALL	R6	1
-      0x94180206,  //  0034  GETIDX	R6	R1	R6
-      0x8C1C0D10,  //  0035  GETMET	R7	R6	K16
-      0x58240011,  //  0036  LDCONST	R9	K17
-      0x7C1C0400,  //  0037  CALL	R7	2
-      0x4C200000,  //  0038  LDNIL	R8
-      0x1C200E08,  //  0039  EQ	R8	R7	R8
-      0x78220006,  //  003A  JMPF	R8	#0042
-      0xB8220400,  //  003B  GETNGBL	R8	K2
-      0x8C201103,  //  003C  GETMET	R8	R8	K3
-      0x58280012,  //  003D  LDCONST	R10	K18
-      0x582C0013,  //  003E  LDCONST	R11	K19
-      0x7C200600,  //  003F  CALL	R8	3
-      0xA8040001,  //  0040  EXBLK	1	1
-      0x7001FFE8,  //  0041  JMP		#002B
-      0x1C200F0D,  //  0042  EQ	R8	R7	K13
-      0x78220006,  //  0043  JMPF	R8	#004B
-      0xB8220400,  //  0044  GETNGBL	R8	K2
-      0x8C201103,  //  0045  GETMET	R8	R8	K3
-      0x58280014,  //  0046  LDCONST	R10	K20
-      0x582C0013,  //  0047  LDCONST	R11	K19
-      0x7C200600,  //  0048  CALL	R8	3
-      0xA8040001,  //  0049  EXBLK	1	1
-      0x7001FFDF,  //  004A  JMP		#002B
-      0x88200115,  //  004B  GETMBR	R8	R0	K21
-      0x8C201110,  //  004C  GETMET	R8	R8	K16
-      0x5C280E00,  //  004D  MOVE	R10	R7
-      0x7C200400,  //  004E  CALL	R8	2
-      0x4C240000,  //  004F  LDNIL	R9
-      0x1C241009,  //  0050  EQ	R9	R8	R9
-      0x7826000A,  //  0051  JMPF	R9	#005D
-      0xB8260400,  //  0052  GETNGBL	R9	K2
-      0x8C241303,  //  0053  GETMET	R9	R9	K3
-      0x602C0008,  //  0054  GETGBL	R11	G8
-      0x5C300E00,  //  0055  MOVE	R12	R7
-      0x7C2C0200,  //  0056  CALL	R11	1
-      0x002E2C0B,  //  0057  ADD	R11	K22	R11
-      0x002C1717,  //  0058  ADD	R11	R11	K23
-      0x58300005,  //  0059  LDCONST	R12	K5
-      0x7C240600,  //  005A  CALL	R9	3
-      0xA8040001,  //  005B  EXBLK	1	1
-      0x7001FFCD,  //  005C  JMP		#002B
-      0x5C241000,  //  005D  MOVE	R9	R8
-      0x5C280000,  //  005E  MOVE	R10	R0
+      0x7C0C0600,  //  0007  CALL	R3	3
+      0x880C0105,  //  0008  GETMBR	R3	R0	K5
+      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
+      0xB8160E00,  //  000A  GETNGBL	R5	K7
+      0x8C140B08,  //  000B  GETMET	R5	R5	K8
+      0x5C1C0000,  //  000C  MOVE	R7	R0
+      0x58200009,  //  000D  LDCONST	R8	K9
+      0x60240013,  //  000E  GETGBL	R9	G19
+      0x7C240000,  //  000F  CALL	R9	0
+      0x7C140800,  //  0010  CALL	R5	4
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0xB80E0200,  //  0012  GETNGBL	R3	K1
+      0x8C0C0702,  //  0013  GETMET	R3	R3	K2
+      0x60140018,  //  0014  GETGBL	R5	G24
+      0x5818000A,  //  0015  LDCONST	R6	K10
+      0x581C0009,  //  0016  LDCONST	R7	K9
+      0x5820000B,  //  0017  LDCONST	R8	K11
+      0x5824000C,  //  0018  LDCONST	R9	K12
+      0x7C140800,  //  0019  CALL	R5	4
+      0x58180004,  //  001A  LDCONST	R6	K4
+      0x7C0C0600,  //  001B  CALL	R3	3
+      0x880C0105,  //  001C  GETMBR	R3	R0	K5
+      0x8C0C0706,  //  001D  GETMET	R3	R3	K6
+      0xB8160E00,  //  001E  GETNGBL	R5	K7
+      0x8C140B0D,  //  001F  GETMET	R5	R5	K13
+      0x5C1C0000,  //  0020  MOVE	R7	R0
+      0x5422FEFF,  //  0021  LDINT	R8	65280
+      0x60240013,  //  0022  GETGBL	R9	G19
+      0x7C240000,  //  0023  CALL	R9	0
+      0x7C140800,  //  0024  CALL	R5	4
+      0x7C0C0400,  //  0025  CALL	R3	2
+      0x600C0010,  //  0026  GETGBL	R3	G16
+      0x5C100400,  //  0027  MOVE	R4	R2
+      0x7C0C0200,  //  0028  CALL	R3	1
+      0xA802005A,  //  0029  EXBLK	0	#0085
+      0x5C100600,  //  002A  MOVE	R4	R3
+      0x7C100000,  //  002B  CALL	R4	0
+      0x1C140909,  //  002C  EQ	R5	R4	K9
+      0x78160000,  //  002D  JMPF	R5	#002F
+      0x7001FFFA,  //  002E  JMP		#002A
+      0xA8020042,  //  002F  EXBLK	0	#0073
+      0x60140008,  //  0030  GETGBL	R5	G8
+      0x5C180800,  //  0031  MOVE	R6	R4
+      0x7C140200,  //  0032  CALL	R5	1
+      0x94140205,  //  0033  GETIDX	R5	R1	R5
+      0x8C180B0E,  //  0034  GETMET	R6	R5	K14
+      0x5820000F,  //  0035  LDCONST	R8	K15
+      0x7C180400,  //  0036  CALL	R6	2
+      0x4C1C0000,  //  0037  LDNIL	R7
+      0x1C1C0C07,  //  0038  EQ	R7	R6	R7
+      0x781E0006,  //  0039  JMPF	R7	#0041
+      0xB81E0200,  //  003A  GETNGBL	R7	K1
+      0x8C1C0F02,  //  003B  GETMET	R7	R7	K2
+      0x58240010,  //  003C  LDCONST	R9	K16
+      0x58280011,  //  003D  LDCONST	R10	K17
+      0x7C1C0600,  //  003E  CALL	R7	3
+      0xA8040001,  //  003F  EXBLK	1	1
+      0x7001FFE8,  //  0040  JMP		#002A
+      0x1C1C0D0B,  //  0041  EQ	R7	R6	K11
+      0x781E0006,  //  0042  JMPF	R7	#004A
+      0xB81E0200,  //  0043  GETNGBL	R7	K1
+      0x8C1C0F02,  //  0044  GETMET	R7	R7	K2
+      0x58240012,  //  0045  LDCONST	R9	K18
+      0x58280011,  //  0046  LDCONST	R10	K17
+      0x7C1C0600,  //  0047  CALL	R7	3
+      0xA8040001,  //  0048  EXBLK	1	1
+      0x7001FFDF,  //  0049  JMP		#002A
+      0x881C0113,  //  004A  GETMBR	R7	R0	K19
+      0x8C1C0F0E,  //  004B  GETMET	R7	R7	K14
+      0x5C240C00,  //  004C  MOVE	R9	R6
+      0x7C1C0400,  //  004D  CALL	R7	2
+      0x4C200000,  //  004E  LDNIL	R8
+      0x1C200E08,  //  004F  EQ	R8	R7	R8
+      0x7822000A,  //  0050  JMPF	R8	#005C
+      0xB8220200,  //  0051  GETNGBL	R8	K1
+      0x8C201102,  //  0052  GETMET	R8	R8	K2
+      0x60280008,  //  0053  GETGBL	R10	G8
+      0x5C2C0C00,  //  0054  MOVE	R11	R6
+      0x7C280200,  //  0055  CALL	R10	1
+      0x002A280A,  //  0056  ADD	R10	K20	R10
+      0x00281515,  //  0057  ADD	R10	R10	K21
+      0x582C0004,  //  0058  LDCONST	R11	K4
+      0x7C200600,  //  0059  CALL	R8	3
+      0xA8040001,  //  005A  EXBLK	1	1
+      0x7001FFCD,  //  005B  JMP		#002A
+      0x5C200E00,  //  005C  MOVE	R8	R7
+      0x5C240000,  //  005D  MOVE	R9	R0
+      0x5C280800,  //  005E  MOVE	R10	R4
       0x5C2C0A00,  //  005F  MOVE	R11	R5
-      0x5C300C00,  //  0060  MOVE	R12	R6
-      0x7C240600,  //  0061  CALL	R9	3
-      0x88280106,  //  0062  GETMBR	R10	R0	K6
-      0x8C281507,  //  0063  GETMET	R10	R10	K7
-      0x5C301200,  //  0064  MOVE	R12	R9
-      0x7C280400,  //  0065  CALL	R10	2
-      0xB82A0400,  //  0066  GETNGBL	R10	K2
-      0x8C281503,  //  0067  GETMET	R10	R10	K3
-      0x8C30050B,  //  0068  GETMET	R12	R2	K11
-      0x5838000C,  //  0069  LDCONST	R14	K12
-      0x5C3C0A00,  //  006A  MOVE	R15	R5
-      0x5C400E00,  //  006B  MOVE	R16	R7
-      0x8C440118,  //  006C  GETMET	R17	R0	K24
-      0x5C4C0C00,  //  006D  MOVE	R19	R6
-      0x7C440400,  //  006E  CALL	R17	2
-      0x7C300A00,  //  006F  CALL	R12	5
-      0x58340005,  //  0070  LDCONST	R13	K5
-      0x7C280600,  //  0071  CALL	R10	3
-      0xA8040001,  //  0072  EXBLK	1	1
-      0x70020010,  //  0073  JMP		#0085
-      0xAC180002,  //  0074  CATCH	R6	0	2
-      0x7002000D,  //  0075  JMP		#0084
-      0xB8220400,  //  0076  GETNGBL	R8	K2
-      0x8C201103,  //  0077  GETMET	R8	R8	K3
-      0x60280008,  //  0078  GETGBL	R10	G8
-      0x5C2C0C00,  //  0079  MOVE	R11	R6
-      0x7C280200,  //  007A  CALL	R10	1
-      0x002A320A,  //  007B  ADD	R10	K25	R10
-      0x0028151A,  //  007C  ADD	R10	R10	K26
-      0x602C0008,  //  007D  GETGBL	R11	G8
-      0x5C300E00,  //  007E  MOVE	R12	R7
-      0x7C2C0200,  //  007F  CALL	R11	1
-      0x0028140B,  //  0080  ADD	R10	R10	R11
-      0x582C0005,  //  0081  LDCONST	R11	K5
-      0x7C200600,  //  0082  CALL	R8	3
-      0x70020000,  //  0083  JMP		#0085
-      0xB0080000,  //  0084  RAISE	2	R0	R0
-      0x7001FFA4,  //  0085  JMP		#002B
-      0x5810001B,  //  0086  LDCONST	R4	K27
-      0xAC100200,  //  0087  CATCH	R4	1	0
-      0xB0080000,  //  0088  RAISE	2	R0	R0
-      0xB8120400,  //  0089  GETNGBL	R4	K2
-      0x8C100903,  //  008A  GETMET	R4	R4	K3
-      0x8C18050B,  //  008B  GETMET	R6	R2	K11
-      0x5820000C,  //  008C  LDCONST	R8	K12
-      0x5426FEFF,  //  008D  LDINT	R9	65280
-      0x5828001C,  //  008E  LDCONST	R10	K28
-      0x582C000E,  //  008F  LDCONST	R11	K14
-      0x7C180A00,  //  0090  CALL	R6	5
-      0x581C0005,  //  0091  LDCONST	R7	K5
-      0x7C100600,  //  0092  CALL	R4	3
-      0xB8120400,  //  0093  GETNGBL	R4	K2
-      0x8C10091D,  //  0094  GETMET	R4	R4	K29
-      0x5818001E,  //  0095  LDCONST	R6	K30
-      0x581C001F,  //  0096  LDCONST	R7	K31
-      0x7C100600,  //  0097  CALL	R4	3
-      0x80000000,  //  0098  RET	0
+      0x7C200600,  //  0060  CALL	R8	3
+      0x88240105,  //  0061  GETMBR	R9	R0	K5
+      0x8C241306,  //  0062  GETMET	R9	R9	K6
+      0x5C2C1000,  //  0063  MOVE	R11	R8
+      0x7C240400,  //  0064  CALL	R9	2
+      0xB8260200,  //  0065  GETNGBL	R9	K1
+      0x8C241302,  //  0066  GETMET	R9	R9	K2
+      0x602C0018,  //  0067  GETGBL	R11	G24
+      0x5830000A,  //  0068  LDCONST	R12	K10
+      0x5C340800,  //  0069  MOVE	R13	R4
+      0x5C380C00,  //  006A  MOVE	R14	R6
+      0x8C3C0116,  //  006B  GETMET	R15	R0	K22
+      0x5C440A00,  //  006C  MOVE	R17	R5
+      0x7C3C0400,  //  006D  CALL	R15	2
+      0x7C2C0800,  //  006E  CALL	R11	4
+      0x58300004,  //  006F  LDCONST	R12	K4
+      0x7C240600,  //  0070  CALL	R9	3
+      0xA8040001,  //  0071  EXBLK	1	1
+      0x70020010,  //  0072  JMP		#0084
+      0xAC140002,  //  0073  CATCH	R5	0	2
+      0x7002000D,  //  0074  JMP		#0083
+      0xB81E0200,  //  0075  GETNGBL	R7	K1
+      0x8C1C0F02,  //  0076  GETMET	R7	R7	K2
+      0x60240008,  //  0077  GETGBL	R9	G8
+      0x5C280A00,  //  0078  MOVE	R10	R5
+      0x7C240200,  //  0079  CALL	R9	1
+      0x00262E09,  //  007A  ADD	R9	K23	R9
+      0x00241318,  //  007B  ADD	R9	R9	K24
+      0x60280008,  //  007C  GETGBL	R10	G8
+      0x5C2C0C00,  //  007D  MOVE	R11	R6
+      0x7C280200,  //  007E  CALL	R10	1
+      0x0024120A,  //  007F  ADD	R9	R9	R10
+      0x58280004,  //  0080  LDCONST	R10	K4
+      0x7C1C0600,  //  0081  CALL	R7	3
+      0x70020000,  //  0082  JMP		#0084
+      0xB0080000,  //  0083  RAISE	2	R0	R0
+      0x7001FFA4,  //  0084  JMP		#002A
+      0x580C0019,  //  0085  LDCONST	R3	K25
+      0xAC0C0200,  //  0086  CATCH	R3	1	0
+      0xB0080000,  //  0087  RAISE	2	R0	R0
+      0xB80E0200,  //  0088  GETNGBL	R3	K1
+      0x8C0C0702,  //  0089  GETMET	R3	R3	K2
+      0x60140018,  //  008A  GETGBL	R5	G24
+      0x5818000A,  //  008B  LDCONST	R6	K10
+      0x541EFEFF,  //  008C  LDINT	R7	65280
+      0x5820001A,  //  008D  LDCONST	R8	K26
+      0x5824000C,  //  008E  LDCONST	R9	K12
+      0x7C140800,  //  008F  CALL	R5	4
+      0x58180004,  //  0090  LDCONST	R6	K4
+      0x7C0C0600,  //  0091  CALL	R3	3
+      0xB80E0200,  //  0092  GETNGBL	R3	K1
+      0x8C0C071B,  //  0093  GETMET	R3	R3	K27
+      0x5814001C,  //  0094  LDCONST	R5	K28
+      0x5818001D,  //  0095  LDCONST	R6	K29
+      0x7C0C0600,  //  0096  CALL	R3	3
+      0x80000000,  //  0097  RET	0
     })
   )
 );
@@ -2166,7 +2143,7 @@ be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    13,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2174,72 +2151,69 @@ be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(PASE_TIMEOUT),
-    /* K2   */  be_nested_str_weak(compute_manual_pairing_code),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s),
-    /* K7   */  be_const_int(2),
-    /* K8   */  be_nested_str_weak(compute_qrcode_content),
-    /* K9   */  be_nested_str_weak(publish_result),
-    /* K10  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A1_X2C_X22PairingCode_X22_X3A_X22_X25s_X22_X2C_X22QRCode_X22_X3A_X22_X25s_X22_X7D_X7D),
-    /* K11  */  be_nested_str_weak(Matter),
-    /* K12  */  be_nested_str_weak(_compute_pbkdf),
-    /* K13  */  be_nested_str_weak(root_passcode),
-    /* K14  */  be_nested_str_weak(root_iterations),
-    /* K15  */  be_nested_str_weak(root_salt),
-    /* K16  */  be_nested_str_weak(start_basic_commissioning),
-    /* K17  */  be_nested_str_weak(root_discriminator),
-    /* K18  */  be_nested_str_weak(root_w0),
-    /* K19  */  be_nested_str_weak(root_L),
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(PASE_TIMEOUT),
+    /* K1   */  be_nested_str_weak(compute_manual_pairing_code),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s),
+    /* K5   */  be_const_int(2),
+    /* K6   */  be_nested_str_weak(compute_qrcode_content),
+    /* K7   */  be_nested_str_weak(publish_result),
+    /* K8   */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A1_X2C_X22PairingCode_X22_X3A_X22_X25s_X22_X2C_X22QRCode_X22_X3A_X22_X25s_X22_X7D_X7D),
+    /* K9   */  be_nested_str_weak(Matter),
+    /* K10  */  be_nested_str_weak(_compute_pbkdf),
+    /* K11  */  be_nested_str_weak(root_passcode),
+    /* K12  */  be_nested_str_weak(root_iterations),
+    /* K13  */  be_nested_str_weak(root_salt),
+    /* K14  */  be_nested_str_weak(start_basic_commissioning),
+    /* K15  */  be_nested_str_weak(root_discriminator),
+    /* K16  */  be_nested_str_weak(root_w0),
+    /* K17  */  be_nested_str_weak(root_L),
     }),
     be_str_weak(start_root_basic_commissioning),
     &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x1C0C0203,  //  0002  EQ	R3	R1	R3
-      0x780E0000,  //  0003  JMPF	R3	#0005
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C0C0102,  //  0005  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0xB8120600,  //  0007  GETNGBL	R4	K3
-      0x8C100904,  //  0008  GETMET	R4	R4	K4
-      0x8C180505,  //  0009  GETMET	R6	R2	K5
-      0x58200006,  //  000A  LDCONST	R8	K6
-      0x5C240600,  //  000B  MOVE	R9	R3
-      0x7C180600,  //  000C  CALL	R6	3
-      0x581C0007,  //  000D  LDCONST	R7	K7
-      0x7C100600,  //  000E  CALL	R4	3
-      0x8C100108,  //  000F  GETMET	R4	R0	K8
-      0x7C100200,  //  0010  CALL	R4	1
-      0xB8160600,  //  0011  GETNGBL	R5	K3
-      0x8C140B09,  //  0012  GETMET	R5	R5	K9
-      0x8C1C0505,  //  0013  GETMET	R7	R2	K5
-      0x5824000A,  //  0014  LDCONST	R9	K10
-      0x5C280600,  //  0015  MOVE	R10	R3
-      0x5C2C0800,  //  0016  MOVE	R11	R4
-      0x7C1C0800,  //  0017  CALL	R7	4
-      0x5820000B,  //  0018  LDCONST	R8	K11
-      0x7C140600,  //  0019  CALL	R5	3
-      0x8C14010C,  //  001A  GETMET	R5	R0	K12
-      0x881C010D,  //  001B  GETMBR	R7	R0	K13
-      0x8820010E,  //  001C  GETMBR	R8	R0	K14
-      0x8824010F,  //  001D  GETMBR	R9	R0	K15
-      0x7C140800,  //  001E  CALL	R5	4
-      0x8C140110,  //  001F  GETMET	R5	R0	K16
-      0x5C1C0200,  //  0020  MOVE	R7	R1
-      0x8820010E,  //  0021  GETMBR	R8	R0	K14
-      0x88240111,  //  0022  GETMBR	R9	R0	K17
-      0x8828010F,  //  0023  GETMBR	R10	R0	K15
-      0x882C0112,  //  0024  GETMBR	R11	R0	K18
-      0x88300113,  //  0025  GETMBR	R12	R0	K19
-      0x4C340000,  //  0026  LDNIL	R13
-      0x7C141000,  //  0027  CALL	R5	8
-      0x80000000,  //  0028  RET	0
+    ( &(const binstruction[40]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x88040100,  //  0003  GETMBR	R1	R0	K0
+      0x8C080101,  //  0004  GETMET	R2	R0	K1
+      0x7C080200,  //  0005  CALL	R2	1
+      0xB80E0400,  //  0006  GETNGBL	R3	K2
+      0x8C0C0703,  //  0007  GETMET	R3	R3	K3
+      0x60140018,  //  0008  GETGBL	R5	G24
+      0x58180004,  //  0009  LDCONST	R6	K4
+      0x5C1C0400,  //  000A  MOVE	R7	R2
+      0x7C140400,  //  000B  CALL	R5	2
+      0x58180005,  //  000C  LDCONST	R6	K5
+      0x7C0C0600,  //  000D  CALL	R3	3
+      0x8C0C0106,  //  000E  GETMET	R3	R0	K6
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0xB8120400,  //  0010  GETNGBL	R4	K2
+      0x8C100907,  //  0011  GETMET	R4	R4	K7
+      0x60180018,  //  0012  GETGBL	R6	G24
+      0x581C0008,  //  0013  LDCONST	R7	K8
+      0x5C200400,  //  0014  MOVE	R8	R2
+      0x5C240600,  //  0015  MOVE	R9	R3
+      0x7C180600,  //  0016  CALL	R6	3
+      0x581C0009,  //  0017  LDCONST	R7	K9
+      0x7C100600,  //  0018  CALL	R4	3
+      0x8C10010A,  //  0019  GETMET	R4	R0	K10
+      0x8818010B,  //  001A  GETMBR	R6	R0	K11
+      0x881C010C,  //  001B  GETMBR	R7	R0	K12
+      0x8820010D,  //  001C  GETMBR	R8	R0	K13
+      0x7C100800,  //  001D  CALL	R4	4
+      0x8C10010E,  //  001E  GETMET	R4	R0	K14
+      0x5C180200,  //  001F  MOVE	R6	R1
+      0x881C010C,  //  0020  GETMBR	R7	R0	K12
+      0x8820010F,  //  0021  GETMBR	R8	R0	K15
+      0x8824010D,  //  0022  GETMBR	R9	R0	K13
+      0x88280110,  //  0023  GETMBR	R10	R0	K16
+      0x882C0111,  //  0024  GETMBR	R11	R0	K17
+      0x4C300000,  //  0025  LDNIL	R12
+      0x7C101000,  //  0026  CALL	R4	8
+      0x80000000,  //  0027  RET	0
     })
   )
 );
@@ -2429,7 +2403,7 @@ be_local_closure(Matter_Device_start,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_conf_to_log,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    9,                          /* nstack */
     1,                          /* argc */
     4,                          /* varg */
     0,                          /* has upvals */
@@ -2437,44 +2411,41 @@ be_local_closure(Matter_Device_conf_to_log,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(),
-    /* K3   */  be_nested_str_weak(k2l),
-    /* K4   */  be_nested_str_weak(type),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(_X20_X25s_X3A_X25s),
-    /* K7   */  be_nested_str_weak(stop_iteration),
+    /* K1   */  be_nested_str_weak(),
+    /* K2   */  be_nested_str_weak(k2l),
+    /* K3   */  be_nested_str_weak(type),
+    /* K4   */  be_nested_str_weak(_X20_X25s_X3A_X25s),
+    /* K5   */  be_nested_str_weak(stop_iteration),
     }),
     be_str_weak(conf_to_log),
     &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
+    ( &(const binstruction[24]) {  /* code */
       0x58040000,  //  0000  LDCONST	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x580C0002,  //  0002  LDCONST	R3	K2
-      0x60100010,  //  0003  GETGBL	R4	G16
-      0x8C140303,  //  0004  GETMET	R5	R1	K3
-      0x5C1C0000,  //  0005  MOVE	R7	R0
-      0x7C140400,  //  0006  CALL	R5	2
-      0x7C100200,  //  0007  CALL	R4	1
-      0xA802000B,  //  0008  EXBLK	0	#0015
-      0x5C140800,  //  0009  MOVE	R5	R4
-      0x7C140000,  //  000A  CALL	R5	0
-      0x1C180B04,  //  000B  EQ	R6	R5	K4
-      0x781A0000,  //  000C  JMPF	R6	#000E
-      0x7001FFFA,  //  000D  JMP		#0009
-      0x8C180505,  //  000E  GETMET	R6	R2	K5
-      0x58200006,  //  000F  LDCONST	R8	K6
-      0x5C240A00,  //  0010  MOVE	R9	R5
-      0x94280005,  //  0011  GETIDX	R10	R0	R5
-      0x7C180800,  //  0012  CALL	R6	4
-      0x000C0606,  //  0013  ADD	R3	R3	R6
-      0x7001FFF3,  //  0014  JMP		#0009
-      0x58100007,  //  0015  LDCONST	R4	K7
-      0xAC100200,  //  0016  CATCH	R4	1	0
-      0xB0080000,  //  0017  RAISE	2	R0	R0
-      0x80040600,  //  0018  RET	1	R3
+      0x58080001,  //  0001  LDCONST	R2	K1
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x8C100302,  //  0003  GETMET	R4	R1	K2
+      0x5C180000,  //  0004  MOVE	R6	R0
+      0x7C100400,  //  0005  CALL	R4	2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0xA802000B,  //  0007  EXBLK	0	#0014
+      0x5C100600,  //  0008  MOVE	R4	R3
+      0x7C100000,  //  0009  CALL	R4	0
+      0x1C140903,  //  000A  EQ	R5	R4	K3
+      0x78160000,  //  000B  JMPF	R5	#000D
+      0x7001FFFA,  //  000C  JMP		#0008
+      0x60140018,  //  000D  GETGBL	R5	G24
+      0x58180004,  //  000E  LDCONST	R6	K4
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x94200004,  //  0010  GETIDX	R8	R0	R4
+      0x7C140600,  //  0011  CALL	R5	3
+      0x00080405,  //  0012  ADD	R2	R2	R5
+      0x7001FFF3,  //  0013  JMP		#0008
+      0x580C0005,  //  0014  LDCONST	R3	K5
+      0xAC0C0200,  //  0015  CATCH	R3	1	0
+      0xB0080000,  //  0016  RAISE	2	R0	R0
+      0x80040400,  //  0017  RET	1	R2
     })
   )
 );
@@ -2573,7 +2544,7 @@ be_local_closure(Matter_Device__init_basic_commissioning,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_init,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    7,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2646,157 +2617,155 @@ be_local_closure(Matter_Device_init,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[43]) {     /* constants */
+    ( &(const bvalue[42]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(get_option),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(MATTER_OPTION),
-    /* K6   */  be_nested_str_weak(UI),
-    /* K7   */  be_nested_str_weak(started),
-    /* K8   */  be_nested_str_weak(tick),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(plugins),
-    /* K11  */  be_nested_str_weak(plugins_persist),
-    /* K12  */  be_nested_str_weak(plugins_classes),
-    /* K13  */  be_nested_str_weak(register_native_classes),
-    /* K14  */  be_nested_str_weak(vendorid),
-    /* K15  */  be_nested_str_weak(VENDOR_ID),
-    /* K16  */  be_nested_str_weak(productid),
-    /* K17  */  be_nested_str_weak(PRODUCT_ID),
-    /* K18  */  be_nested_str_weak(root_iterations),
-    /* K19  */  be_nested_str_weak(PBKDF_ITERATIONS),
-    /* K20  */  be_nested_str_weak(next_ep),
-    /* K21  */  be_const_int(1),
-    /* K22  */  be_nested_str_weak(root_salt),
-    /* K23  */  be_nested_str_weak(random),
-    /* K24  */  be_nested_str_weak(ipv4only),
-    /* K25  */  be_nested_str_weak(load_param),
-    /* K26  */  be_nested_str_weak(sessions),
-    /* K27  */  be_nested_str_weak(Session_Store),
-    /* K28  */  be_nested_str_weak(load_fabrics),
-    /* K29  */  be_nested_str_weak(message_handler),
-    /* K30  */  be_nested_str_weak(MessageHandler),
-    /* K31  */  be_nested_str_weak(ui),
-    /* K32  */  be_nested_str_weak(wifi),
-    /* K33  */  be_nested_str_weak(up),
-    /* K34  */  be_nested_str_weak(eth),
-    /* K35  */  be_nested_str_weak(start),
-    /* K36  */  be_nested_str_weak(add_rule),
-    /* K37  */  be_nested_str_weak(Wifi_X23Connected),
-    /* K38  */  be_nested_str_weak(matter_start),
-    /* K39  */  be_nested_str_weak(Eth_X23Connected),
-    /* K40  */  be_nested_str_weak(_init_basic_commissioning),
-    /* K41  */  be_nested_str_weak(add_driver),
-    /* K42  */  be_nested_str_weak(register_commands),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(get_option),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(MATTER_OPTION),
+    /* K5   */  be_nested_str_weak(UI),
+    /* K6   */  be_nested_str_weak(started),
+    /* K7   */  be_nested_str_weak(tick),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(plugins),
+    /* K10  */  be_nested_str_weak(plugins_persist),
+    /* K11  */  be_nested_str_weak(plugins_classes),
+    /* K12  */  be_nested_str_weak(register_native_classes),
+    /* K13  */  be_nested_str_weak(vendorid),
+    /* K14  */  be_nested_str_weak(VENDOR_ID),
+    /* K15  */  be_nested_str_weak(productid),
+    /* K16  */  be_nested_str_weak(PRODUCT_ID),
+    /* K17  */  be_nested_str_weak(root_iterations),
+    /* K18  */  be_nested_str_weak(PBKDF_ITERATIONS),
+    /* K19  */  be_nested_str_weak(next_ep),
+    /* K20  */  be_const_int(1),
+    /* K21  */  be_nested_str_weak(root_salt),
+    /* K22  */  be_nested_str_weak(random),
+    /* K23  */  be_nested_str_weak(ipv4only),
+    /* K24  */  be_nested_str_weak(load_param),
+    /* K25  */  be_nested_str_weak(sessions),
+    /* K26  */  be_nested_str_weak(Session_Store),
+    /* K27  */  be_nested_str_weak(load_fabrics),
+    /* K28  */  be_nested_str_weak(message_handler),
+    /* K29  */  be_nested_str_weak(MessageHandler),
+    /* K30  */  be_nested_str_weak(ui),
+    /* K31  */  be_nested_str_weak(wifi),
+    /* K32  */  be_nested_str_weak(up),
+    /* K33  */  be_nested_str_weak(eth),
+    /* K34  */  be_nested_str_weak(start),
+    /* K35  */  be_nested_str_weak(add_rule),
+    /* K36  */  be_nested_str_weak(Wifi_X23Connected),
+    /* K37  */  be_nested_str_weak(matter_start),
+    /* K38  */  be_nested_str_weak(Eth_X23Connected),
+    /* K39  */  be_nested_str_weak(_init_basic_commissioning),
+    /* K40  */  be_nested_str_weak(add_driver),
+    /* K41  */  be_nested_str_weak(register_commands),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[103]) {  /* code */
+    ( &(const binstruction[102]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x8C0C0703,  //  0003  GETMET	R3	R3	K3
-      0xB8160800,  //  0004  GETNGBL	R5	K4
-      0x88140B05,  //  0005  GETMBR	R5	R5	K5
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x740E0004,  //  0007  JMPT	R3	#000D
-      0xB80E0800,  //  0008  GETNGBL	R3	K4
-      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
-      0x5C140000,  //  000A  MOVE	R5	R0
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x80000600,  //  000C  RET	0
-      0x500C0000,  //  000D  LDBOOL	R3	0	0
-      0x90020E03,  //  000E  SETMBR	R0	K7	R3
-      0x90021109,  //  000F  SETMBR	R0	K8	K9
-      0x600C0012,  //  0010  GETGBL	R3	G18
-      0x7C0C0000,  //  0011  CALL	R3	0
-      0x90021403,  //  0012  SETMBR	R0	K10	R3
-      0x500C0000,  //  0013  LDBOOL	R3	0	0
-      0x90021603,  //  0014  SETMBR	R0	K11	R3
-      0x600C0013,  //  0015  GETGBL	R3	G19
-      0x7C0C0000,  //  0016  CALL	R3	0
-      0x90021803,  //  0017  SETMBR	R0	K12	R3
-      0x8C0C010D,  //  0018  GETMET	R3	R0	K13
-      0x7C0C0200,  //  0019  CALL	R3	1
-      0x880C010F,  //  001A  GETMBR	R3	R0	K15
-      0x90021C03,  //  001B  SETMBR	R0	K14	R3
-      0x880C0111,  //  001C  GETMBR	R3	R0	K17
-      0x90022003,  //  001D  SETMBR	R0	K16	R3
-      0x880C0113,  //  001E  GETMBR	R3	R0	K19
-      0x90022403,  //  001F  SETMBR	R0	K18	R3
-      0x90022915,  //  0020  SETMBR	R0	K20	K21
-      0x8C0C0317,  //  0021  GETMET	R3	R1	K23
-      0x5416000F,  //  0022  LDINT	R5	16
-      0x7C0C0400,  //  0023  CALL	R3	2
-      0x90022C03,  //  0024  SETMBR	R0	K22	R3
-      0x500C0000,  //  0025  LDBOOL	R3	0	0
-      0x90023003,  //  0026  SETMBR	R0	K24	R3
-      0x8C0C0119,  //  0027  GETMET	R3	R0	K25
-      0x7C0C0200,  //  0028  CALL	R3	1
-      0xB80E0800,  //  0029  GETNGBL	R3	K4
-      0x8C0C071B,  //  002A  GETMET	R3	R3	K27
-      0x5C140000,  //  002B  MOVE	R5	R0
-      0x7C0C0400,  //  002C  CALL	R3	2
-      0x90023403,  //  002D  SETMBR	R0	K26	R3
-      0x880C011A,  //  002E  GETMBR	R3	R0	K26
-      0x8C0C071C,  //  002F  GETMET	R3	R3	K28
-      0x7C0C0200,  //  0030  CALL	R3	1
-      0xB80E0800,  //  0031  GETNGBL	R3	K4
-      0x8C0C071E,  //  0032  GETMET	R3	R3	K30
-      0x5C140000,  //  0033  MOVE	R5	R0
-      0x7C0C0400,  //  0034  CALL	R3	2
-      0x90023A03,  //  0035  SETMBR	R0	K29	R3
-      0xB80E0800,  //  0036  GETNGBL	R3	K4
-      0x8C0C0706,  //  0037  GETMET	R3	R3	K6
-      0x5C140000,  //  0038  MOVE	R5	R0
-      0x7C0C0400,  //  0039  CALL	R3	2
-      0x90023E03,  //  003A  SETMBR	R0	K31	R3
-      0xB80E0400,  //  003B  GETNGBL	R3	K2
-      0x8C0C0720,  //  003C  GETMET	R3	R3	K32
-      0x7C0C0200,  //  003D  CALL	R3	1
-      0x940C0721,  //  003E  GETIDX	R3	R3	K33
-      0x740E0004,  //  003F  JMPT	R3	#0045
-      0xB80E0400,  //  0040  GETNGBL	R3	K2
-      0x8C0C0722,  //  0041  GETMET	R3	R3	K34
-      0x7C0C0200,  //  0042  CALL	R3	1
-      0x940C0721,  //  0043  GETIDX	R3	R3	K33
-      0x780E0001,  //  0044  JMPF	R3	#0047
-      0x8C0C0123,  //  0045  GETMET	R3	R0	K35
-      0x7C0C0200,  //  0046  CALL	R3	1
-      0xB80E0400,  //  0047  GETNGBL	R3	K2
-      0x8C0C0720,  //  0048  GETMET	R3	R3	K32
-      0x7C0C0200,  //  0049  CALL	R3	1
-      0x940C0721,  //  004A  GETIDX	R3	R3	K33
-      0x740E0005,  //  004B  JMPT	R3	#0052
-      0xB80E0400,  //  004C  GETNGBL	R3	K2
-      0x8C0C0724,  //  004D  GETMET	R3	R3	K36
-      0x58140025,  //  004E  LDCONST	R5	K37
-      0x84180000,  //  004F  CLOSURE	R6	P0
-      0x581C0026,  //  0050  LDCONST	R7	K38
-      0x7C0C0800,  //  0051  CALL	R3	4
-      0xB80E0400,  //  0052  GETNGBL	R3	K2
-      0x8C0C0722,  //  0053  GETMET	R3	R3	K34
-      0x7C0C0200,  //  0054  CALL	R3	1
-      0x940C0721,  //  0055  GETIDX	R3	R3	K33
-      0x740E0005,  //  0056  JMPT	R3	#005D
-      0xB80E0400,  //  0057  GETNGBL	R3	K2
-      0x8C0C0724,  //  0058  GETMET	R3	R3	K36
-      0x58140027,  //  0059  LDCONST	R5	K39
-      0x84180001,  //  005A  CLOSURE	R6	P1
-      0x581C0026,  //  005B  LDCONST	R7	K38
-      0x7C0C0800,  //  005C  CALL	R3	4
-      0x8C0C0128,  //  005D  GETMET	R3	R0	K40
-      0x7C0C0200,  //  005E  CALL	R3	1
-      0xB80E0400,  //  005F  GETNGBL	R3	K2
-      0x8C0C0729,  //  0060  GETMET	R3	R3	K41
-      0x5C140000,  //  0061  MOVE	R5	R0
-      0x7C0C0400,  //  0062  CALL	R3	2
-      0x8C0C012A,  //  0063  GETMET	R3	R0	K42
-      0x7C0C0200,  //  0064  CALL	R3	1
-      0xA0000000,  //  0065  CLOSE	R0
-      0x80000000,  //  0066  RET	0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0xB8120600,  //  0003  GETNGBL	R4	K3
+      0x88100904,  //  0004  GETMBR	R4	R4	K4
+      0x7C080400,  //  0005  CALL	R2	2
+      0x740A0004,  //  0006  JMPT	R2	#000C
+      0xB80A0600,  //  0007  GETNGBL	R2	K3
+      0x8C080505,  //  0008  GETMET	R2	R2	K5
+      0x5C100000,  //  0009  MOVE	R4	R0
+      0x7C080400,  //  000A  CALL	R2	2
+      0x80000400,  //  000B  RET	0
+      0x50080000,  //  000C  LDBOOL	R2	0	0
+      0x90020C02,  //  000D  SETMBR	R0	K6	R2
+      0x90020F08,  //  000E  SETMBR	R0	K7	K8
+      0x60080012,  //  000F  GETGBL	R2	G18
+      0x7C080000,  //  0010  CALL	R2	0
+      0x90021202,  //  0011  SETMBR	R0	K9	R2
+      0x50080000,  //  0012  LDBOOL	R2	0	0
+      0x90021402,  //  0013  SETMBR	R0	K10	R2
+      0x60080013,  //  0014  GETGBL	R2	G19
+      0x7C080000,  //  0015  CALL	R2	0
+      0x90021602,  //  0016  SETMBR	R0	K11	R2
+      0x8C08010C,  //  0017  GETMET	R2	R0	K12
+      0x7C080200,  //  0018  CALL	R2	1
+      0x8808010E,  //  0019  GETMBR	R2	R0	K14
+      0x90021A02,  //  001A  SETMBR	R0	K13	R2
+      0x88080110,  //  001B  GETMBR	R2	R0	K16
+      0x90021E02,  //  001C  SETMBR	R0	K15	R2
+      0x88080112,  //  001D  GETMBR	R2	R0	K18
+      0x90022202,  //  001E  SETMBR	R0	K17	R2
+      0x90022714,  //  001F  SETMBR	R0	K19	K20
+      0x8C080316,  //  0020  GETMET	R2	R1	K22
+      0x5412000F,  //  0021  LDINT	R4	16
+      0x7C080400,  //  0022  CALL	R2	2
+      0x90022A02,  //  0023  SETMBR	R0	K21	R2
+      0x50080000,  //  0024  LDBOOL	R2	0	0
+      0x90022E02,  //  0025  SETMBR	R0	K23	R2
+      0x8C080118,  //  0026  GETMET	R2	R0	K24
+      0x7C080200,  //  0027  CALL	R2	1
+      0xB80A0600,  //  0028  GETNGBL	R2	K3
+      0x8C08051A,  //  0029  GETMET	R2	R2	K26
+      0x5C100000,  //  002A  MOVE	R4	R0
+      0x7C080400,  //  002B  CALL	R2	2
+      0x90023202,  //  002C  SETMBR	R0	K25	R2
+      0x88080119,  //  002D  GETMBR	R2	R0	K25
+      0x8C08051B,  //  002E  GETMET	R2	R2	K27
+      0x7C080200,  //  002F  CALL	R2	1
+      0xB80A0600,  //  0030  GETNGBL	R2	K3
+      0x8C08051D,  //  0031  GETMET	R2	R2	K29
+      0x5C100000,  //  0032  MOVE	R4	R0
+      0x7C080400,  //  0033  CALL	R2	2
+      0x90023802,  //  0034  SETMBR	R0	K28	R2
+      0xB80A0600,  //  0035  GETNGBL	R2	K3
+      0x8C080505,  //  0036  GETMET	R2	R2	K5
+      0x5C100000,  //  0037  MOVE	R4	R0
+      0x7C080400,  //  0038  CALL	R2	2
+      0x90023C02,  //  0039  SETMBR	R0	K30	R2
+      0xB80A0200,  //  003A  GETNGBL	R2	K1
+      0x8C08051F,  //  003B  GETMET	R2	R2	K31
+      0x7C080200,  //  003C  CALL	R2	1
+      0x94080520,  //  003D  GETIDX	R2	R2	K32
+      0x740A0004,  //  003E  JMPT	R2	#0044
+      0xB80A0200,  //  003F  GETNGBL	R2	K1
+      0x8C080521,  //  0040  GETMET	R2	R2	K33
+      0x7C080200,  //  0041  CALL	R2	1
+      0x94080520,  //  0042  GETIDX	R2	R2	K32
+      0x780A0001,  //  0043  JMPF	R2	#0046
+      0x8C080122,  //  0044  GETMET	R2	R0	K34
+      0x7C080200,  //  0045  CALL	R2	1
+      0xB80A0200,  //  0046  GETNGBL	R2	K1
+      0x8C08051F,  //  0047  GETMET	R2	R2	K31
+      0x7C080200,  //  0048  CALL	R2	1
+      0x94080520,  //  0049  GETIDX	R2	R2	K32
+      0x740A0005,  //  004A  JMPT	R2	#0051
+      0xB80A0200,  //  004B  GETNGBL	R2	K1
+      0x8C080523,  //  004C  GETMET	R2	R2	K35
+      0x58100024,  //  004D  LDCONST	R4	K36
+      0x84140000,  //  004E  CLOSURE	R5	P0
+      0x58180025,  //  004F  LDCONST	R6	K37
+      0x7C080800,  //  0050  CALL	R2	4
+      0xB80A0200,  //  0051  GETNGBL	R2	K1
+      0x8C080521,  //  0052  GETMET	R2	R2	K33
+      0x7C080200,  //  0053  CALL	R2	1
+      0x94080520,  //  0054  GETIDX	R2	R2	K32
+      0x740A0005,  //  0055  JMPT	R2	#005C
+      0xB80A0200,  //  0056  GETNGBL	R2	K1
+      0x8C080523,  //  0057  GETMET	R2	R2	K35
+      0x58100026,  //  0058  LDCONST	R4	K38
+      0x84140001,  //  0059  CLOSURE	R5	P1
+      0x58180025,  //  005A  LDCONST	R6	K37
+      0x7C080800,  //  005B  CALL	R2	4
+      0x8C080127,  //  005C  GETMET	R2	R0	K39
+      0x7C080200,  //  005D  CALL	R2	1
+      0xB80A0200,  //  005E  GETNGBL	R2	K1
+      0x8C080528,  //  005F  GETMET	R2	R2	K40
+      0x5C100000,  //  0060  MOVE	R4	R0
+      0x7C080400,  //  0061  CALL	R2	2
+      0x8C080129,  //  0062  GETMET	R2	R0	K41
+      0x7C080200,  //  0063  CALL	R2	1
+      0xA0000000,  //  0064  CLOSE	R0
+      0x80000000,  //  0065  RET	0
     })
   )
 );
@@ -2975,7 +2944,7 @@ be_local_closure(Matter_Device_get_plugin_class_displayname,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
   be_nested_proto(
-    15,                          /* nstack */
+    14,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2983,162 +2952,159 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
+    ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(reverse),
-    /* K5   */  be_nested_str_weak(get_fabric_compressed),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_nested_str_weak(_X2D),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(eth),
-    /* K13  */  be_nested_str_weak(find),
-    /* K14  */  be_nested_str_weak(up),
-    /* K15  */  be_nested_str_weak(format),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K17  */  be_nested_str_weak(hostname_eth),
-    /* K18  */  be_nested_str_weak(add_service),
-    /* K19  */  be_nested_str_weak(_matter),
-    /* K20  */  be_nested_str_weak(_tcp),
-    /* K21  */  be_nested_str_weak(_I),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
-    /* K23  */  be_nested_str_weak(add_subtype),
-    /* K24  */  be_nested_str_weak(wifi),
-    /* K25  */  be_nested_str_weak(hostname_wifi),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K27  */  be_nested_str_weak(_X7C),
-    /* K28  */  be_const_int(2),
+    /* K1   */  be_nested_str_weak(get_device_id),
+    /* K2   */  be_nested_str_weak(copy),
+    /* K3   */  be_nested_str_weak(reverse),
+    /* K4   */  be_nested_str_weak(get_fabric_compressed),
+    /* K5   */  be_nested_str_weak(tohex),
+    /* K6   */  be_nested_str_weak(_X2D),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(eth),
+    /* K12  */  be_nested_str_weak(find),
+    /* K13  */  be_nested_str_weak(up),
+    /* K14  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K15  */  be_nested_str_weak(hostname_eth),
+    /* K16  */  be_nested_str_weak(add_service),
+    /* K17  */  be_nested_str_weak(_matter),
+    /* K18  */  be_nested_str_weak(_tcp),
+    /* K19  */  be_nested_str_weak(_I),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
+    /* K21  */  be_nested_str_weak(add_subtype),
+    /* K22  */  be_nested_str_weak(wifi),
+    /* K23  */  be_nested_str_weak(hostname_wifi),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K25  */  be_nested_str_weak(_X7C),
+    /* K26  */  be_const_int(2),
     }),
     be_str_weak(mdns_announce_op_discovery),
     &be_const_str_solidified,
-    ( &(const binstruction[122]) {  /* code */
+    ( &(const binstruction[121]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA8020064,  //  0002  EXBLK	0	#0068
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x7C100200,  //  0004  CALL	R4	1
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C140305,  //  0009  GETMET	R5	R1	K5
-      0x7C140200,  //  000A  CALL	R5	1
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
-      0x7C180200,  //  000C  CALL	R6	1
-      0x00180D07,  //  000D  ADD	R6	R6	K7
-      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
-      0x7C1C0200,  //  000F  CALL	R7	1
-      0x00180C07,  //  0010  ADD	R6	R6	R7
-      0xB81E1000,  //  0011  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
-      0x00261406,  //  0013  ADD	R9	K10	R6
-      0x5828000B,  //  0014  LDCONST	R10	K11
-      0x7C1C0600,  //  0015  CALL	R7	3
-      0xB81E1000,  //  0016  GETNGBL	R7	K8
-      0x8C1C0F0C,  //  0017  GETMET	R7	R7	K12
-      0x7C1C0200,  //  0018  CALL	R7	1
-      0x8C1C0F0D,  //  0019  GETMET	R7	R7	K13
-      0x5824000E,  //  001A  LDCONST	R9	K14
-      0x7C1C0400,  //  001B  CALL	R7	2
-      0x781E0020,  //  001C  JMPF	R7	#003E
-      0xB81E1000,  //  001D  GETNGBL	R7	K8
-      0x8C1C0F09,  //  001E  GETMET	R7	R7	K9
-      0x8C24070F,  //  001F  GETMET	R9	R3	K15
-      0x582C0010,  //  0020  LDCONST	R11	K16
-      0x5830000C,  //  0021  LDCONST	R12	K12
-      0x5C340C00,  //  0022  MOVE	R13	R6
-      0x88380111,  //  0023  GETMBR	R14	R0	K17
-      0x7C240A00,  //  0024  CALL	R9	5
-      0x5828000B,  //  0025  LDCONST	R10	K11
-      0x7C1C0600,  //  0026  CALL	R7	3
-      0x8C1C0512,  //  0027  GETMET	R7	R2	K18
-      0x58240013,  //  0028  LDCONST	R9	K19
-      0x58280014,  //  0029  LDCONST	R10	K20
-      0x542E15A3,  //  002A  LDINT	R11	5540
-      0x4C300000,  //  002B  LDNIL	R12
-      0x5C340C00,  //  002C  MOVE	R13	R6
-      0x88380111,  //  002D  GETMBR	R14	R0	K17
-      0x7C1C0E00,  //  002E  CALL	R7	7
-      0x8C1C0B06,  //  002F  GETMET	R7	R5	K6
-      0x7C1C0200,  //  0030  CALL	R7	1
-      0x001E2A07,  //  0031  ADD	R7	K21	R7
-      0xB8221000,  //  0032  GETNGBL	R8	K8
-      0x8C201109,  //  0033  GETMET	R8	R8	K9
-      0x002A2C07,  //  0034  ADD	R10	K22	R7
-      0x582C000B,  //  0035  LDCONST	R11	K11
-      0x7C200600,  //  0036  CALL	R8	3
-      0x8C200517,  //  0037  GETMET	R8	R2	K23
-      0x58280013,  //  0038  LDCONST	R10	K19
-      0x582C0014,  //  0039  LDCONST	R11	K20
-      0x5C300C00,  //  003A  MOVE	R12	R6
-      0x88340111,  //  003B  GETMBR	R13	R0	K17
-      0x5C380E00,  //  003C  MOVE	R14	R7
-      0x7C200C00,  //  003D  CALL	R8	6
-      0xB81E1000,  //  003E  GETNGBL	R7	K8
-      0x8C1C0F18,  //  003F  GETMET	R7	R7	K24
-      0x7C1C0200,  //  0040  CALL	R7	1
-      0x8C1C0F0D,  //  0041  GETMET	R7	R7	K13
-      0x5824000E,  //  0042  LDCONST	R9	K14
-      0x7C1C0400,  //  0043  CALL	R7	2
-      0x781E0020,  //  0044  JMPF	R7	#0066
-      0xB81E1000,  //  0045  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0046  GETMET	R7	R7	K9
-      0x8C24070F,  //  0047  GETMET	R9	R3	K15
-      0x582C0010,  //  0048  LDCONST	R11	K16
-      0x58300018,  //  0049  LDCONST	R12	K24
-      0x5C340C00,  //  004A  MOVE	R13	R6
-      0x88380119,  //  004B  GETMBR	R14	R0	K25
-      0x7C240A00,  //  004C  CALL	R9	5
-      0x5828000B,  //  004D  LDCONST	R10	K11
-      0x7C1C0600,  //  004E  CALL	R7	3
-      0x8C1C0512,  //  004F  GETMET	R7	R2	K18
-      0x58240013,  //  0050  LDCONST	R9	K19
-      0x58280014,  //  0051  LDCONST	R10	K20
-      0x542E15A3,  //  0052  LDINT	R11	5540
-      0x4C300000,  //  0053  LDNIL	R12
-      0x5C340C00,  //  0054  MOVE	R13	R6
-      0x88380119,  //  0055  GETMBR	R14	R0	K25
-      0x7C1C0E00,  //  0056  CALL	R7	7
-      0x8C1C0B06,  //  0057  GETMET	R7	R5	K6
-      0x7C1C0200,  //  0058  CALL	R7	1
-      0x001E2A07,  //  0059  ADD	R7	K21	R7
-      0xB8221000,  //  005A  GETNGBL	R8	K8
-      0x8C201109,  //  005B  GETMET	R8	R8	K9
-      0x002A2C07,  //  005C  ADD	R10	K22	R7
-      0x582C000B,  //  005D  LDCONST	R11	K11
-      0x7C200600,  //  005E  CALL	R8	3
-      0x8C200517,  //  005F  GETMET	R8	R2	K23
-      0x58280013,  //  0060  LDCONST	R10	K19
-      0x582C0014,  //  0061  LDCONST	R11	K20
-      0x5C300C00,  //  0062  MOVE	R12	R6
-      0x88340119,  //  0063  GETMBR	R13	R0	K25
-      0x5C380E00,  //  0064  MOVE	R14	R7
-      0x7C200C00,  //  0065  CALL	R8	6
-      0xA8040001,  //  0066  EXBLK	1	1
-      0x70020010,  //  0067  JMP		#0079
-      0xAC100002,  //  0068  CATCH	R4	0	2
-      0x7002000D,  //  0069  JMP		#0078
-      0xB81A1000,  //  006A  GETNGBL	R6	K8
-      0x8C180D09,  //  006B  GETMET	R6	R6	K9
-      0x60200008,  //  006C  GETGBL	R8	G8
-      0x5C240800,  //  006D  MOVE	R9	R4
-      0x7C200200,  //  006E  CALL	R8	1
-      0x00223408,  //  006F  ADD	R8	K26	R8
-      0x0020111B,  //  0070  ADD	R8	R8	K27
-      0x60240008,  //  0071  GETGBL	R9	G8
-      0x5C280A00,  //  0072  MOVE	R10	R5
-      0x7C240200,  //  0073  CALL	R9	1
-      0x00201009,  //  0074  ADD	R8	R8	R9
-      0x5824001C,  //  0075  LDCONST	R9	K28
-      0x7C180600,  //  0076  CALL	R6	3
-      0x70020000,  //  0077  JMP		#0079
-      0xB0080000,  //  0078  RAISE	2	R0	R0
-      0x80000000,  //  0079  RET	0
+      0xA8020064,  //  0001  EXBLK	0	#0067
+      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x8C100304,  //  0008  GETMET	R4	R1	K4
+      0x7C100200,  //  0009  CALL	R4	1
+      0x8C140905,  //  000A  GETMET	R5	R4	K5
+      0x7C140200,  //  000B  CALL	R5	1
+      0x00140B06,  //  000C  ADD	R5	R5	K6
+      0x8C180705,  //  000D  GETMET	R6	R3	K5
+      0x7C180200,  //  000E  CALL	R6	1
+      0x00140A06,  //  000F  ADD	R5	R5	R6
+      0xB81A0E00,  //  0010  GETNGBL	R6	K7
+      0x8C180D08,  //  0011  GETMET	R6	R6	K8
+      0x00221205,  //  0012  ADD	R8	K9	R5
+      0x5824000A,  //  0013  LDCONST	R9	K10
+      0x7C180600,  //  0014  CALL	R6	3
+      0xB81A0E00,  //  0015  GETNGBL	R6	K7
+      0x8C180D0B,  //  0016  GETMET	R6	R6	K11
+      0x7C180200,  //  0017  CALL	R6	1
+      0x8C180D0C,  //  0018  GETMET	R6	R6	K12
+      0x5820000D,  //  0019  LDCONST	R8	K13
+      0x7C180400,  //  001A  CALL	R6	2
+      0x781A0020,  //  001B  JMPF	R6	#003D
+      0xB81A0E00,  //  001C  GETNGBL	R6	K7
+      0x8C180D08,  //  001D  GETMET	R6	R6	K8
+      0x60200018,  //  001E  GETGBL	R8	G24
+      0x5824000E,  //  001F  LDCONST	R9	K14
+      0x5828000B,  //  0020  LDCONST	R10	K11
+      0x5C2C0A00,  //  0021  MOVE	R11	R5
+      0x8830010F,  //  0022  GETMBR	R12	R0	K15
+      0x7C200800,  //  0023  CALL	R8	4
+      0x5824000A,  //  0024  LDCONST	R9	K10
+      0x7C180600,  //  0025  CALL	R6	3
+      0x8C180510,  //  0026  GETMET	R6	R2	K16
+      0x58200011,  //  0027  LDCONST	R8	K17
+      0x58240012,  //  0028  LDCONST	R9	K18
+      0x542A15A3,  //  0029  LDINT	R10	5540
+      0x4C2C0000,  //  002A  LDNIL	R11
+      0x5C300A00,  //  002B  MOVE	R12	R5
+      0x8834010F,  //  002C  GETMBR	R13	R0	K15
+      0x7C180E00,  //  002D  CALL	R6	7
+      0x8C180905,  //  002E  GETMET	R6	R4	K5
+      0x7C180200,  //  002F  CALL	R6	1
+      0x001A2606,  //  0030  ADD	R6	K19	R6
+      0xB81E0E00,  //  0031  GETNGBL	R7	K7
+      0x8C1C0F08,  //  0032  GETMET	R7	R7	K8
+      0x00262806,  //  0033  ADD	R9	K20	R6
+      0x5828000A,  //  0034  LDCONST	R10	K10
+      0x7C1C0600,  //  0035  CALL	R7	3
+      0x8C1C0515,  //  0036  GETMET	R7	R2	K21
+      0x58240011,  //  0037  LDCONST	R9	K17
+      0x58280012,  //  0038  LDCONST	R10	K18
+      0x5C2C0A00,  //  0039  MOVE	R11	R5
+      0x8830010F,  //  003A  GETMBR	R12	R0	K15
+      0x5C340C00,  //  003B  MOVE	R13	R6
+      0x7C1C0C00,  //  003C  CALL	R7	6
+      0xB81A0E00,  //  003D  GETNGBL	R6	K7
+      0x8C180D16,  //  003E  GETMET	R6	R6	K22
+      0x7C180200,  //  003F  CALL	R6	1
+      0x8C180D0C,  //  0040  GETMET	R6	R6	K12
+      0x5820000D,  //  0041  LDCONST	R8	K13
+      0x7C180400,  //  0042  CALL	R6	2
+      0x781A0020,  //  0043  JMPF	R6	#0065
+      0xB81A0E00,  //  0044  GETNGBL	R6	K7
+      0x8C180D08,  //  0045  GETMET	R6	R6	K8
+      0x60200018,  //  0046  GETGBL	R8	G24
+      0x5824000E,  //  0047  LDCONST	R9	K14
+      0x58280016,  //  0048  LDCONST	R10	K22
+      0x5C2C0A00,  //  0049  MOVE	R11	R5
+      0x88300117,  //  004A  GETMBR	R12	R0	K23
+      0x7C200800,  //  004B  CALL	R8	4
+      0x5824000A,  //  004C  LDCONST	R9	K10
+      0x7C180600,  //  004D  CALL	R6	3
+      0x8C180510,  //  004E  GETMET	R6	R2	K16
+      0x58200011,  //  004F  LDCONST	R8	K17
+      0x58240012,  //  0050  LDCONST	R9	K18
+      0x542A15A3,  //  0051  LDINT	R10	5540
+      0x4C2C0000,  //  0052  LDNIL	R11
+      0x5C300A00,  //  0053  MOVE	R12	R5
+      0x88340117,  //  0054  GETMBR	R13	R0	K23
+      0x7C180E00,  //  0055  CALL	R6	7
+      0x8C180905,  //  0056  GETMET	R6	R4	K5
+      0x7C180200,  //  0057  CALL	R6	1
+      0x001A2606,  //  0058  ADD	R6	K19	R6
+      0xB81E0E00,  //  0059  GETNGBL	R7	K7
+      0x8C1C0F08,  //  005A  GETMET	R7	R7	K8
+      0x00262806,  //  005B  ADD	R9	K20	R6
+      0x5828000A,  //  005C  LDCONST	R10	K10
+      0x7C1C0600,  //  005D  CALL	R7	3
+      0x8C1C0515,  //  005E  GETMET	R7	R2	K21
+      0x58240011,  //  005F  LDCONST	R9	K17
+      0x58280012,  //  0060  LDCONST	R10	K18
+      0x5C2C0A00,  //  0061  MOVE	R11	R5
+      0x88300117,  //  0062  GETMBR	R12	R0	K23
+      0x5C340C00,  //  0063  MOVE	R13	R6
+      0x7C1C0C00,  //  0064  CALL	R7	6
+      0xA8040001,  //  0065  EXBLK	1	1
+      0x70020010,  //  0066  JMP		#0078
+      0xAC0C0002,  //  0067  CATCH	R3	0	2
+      0x7002000D,  //  0068  JMP		#0077
+      0xB8160E00,  //  0069  GETNGBL	R5	K7
+      0x8C140B08,  //  006A  GETMET	R5	R5	K8
+      0x601C0008,  //  006B  GETGBL	R7	G8
+      0x5C200600,  //  006C  MOVE	R8	R3
+      0x7C1C0200,  //  006D  CALL	R7	1
+      0x001E3007,  //  006E  ADD	R7	K24	R7
+      0x001C0F19,  //  006F  ADD	R7	R7	K25
+      0x60200008,  //  0070  GETGBL	R8	G8
+      0x5C240800,  //  0071  MOVE	R9	R4
+      0x7C200200,  //  0072  CALL	R8	1
+      0x001C0E08,  //  0073  ADD	R7	R7	R8
+      0x5820001A,  //  0074  LDCONST	R8	K26
+      0x7C140600,  //  0075  CALL	R5	3
+      0x70020000,  //  0076  JMP		#0078
+      0xB0080000,  //  0077  RAISE	2	R0	R0
+      0x80000000,  //  0078  RET	0
     })
   )
 );
@@ -3150,7 +3116,7 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_clean_remotes,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3158,96 +3124,94 @@ be_local_closure(Matter_Device_clean_remotes,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
+    ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(http_remotes),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(stop_iteration),
-    /* K5   */  be_nested_str_weak(plugins),
-    /* K6   */  be_nested_str_weak(get),
-    /* K7   */  be_nested_str_weak(http_remote),
-    /* K8   */  be_nested_str_weak(find),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(keys),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
-    /* K14  */  be_nested_str_weak(addr),
-    /* K15  */  be_const_int(3),
-    /* K16  */  be_nested_str_weak(close),
-    /* K17  */  be_nested_str_weak(remove),
+    /* K1   */  be_nested_str_weak(http_remotes),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_nested_str_weak(plugins),
+    /* K5   */  be_nested_str_weak(get),
+    /* K6   */  be_nested_str_weak(http_remote),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(keys),
+    /* K10  */  be_nested_str_weak(tasmota),
+    /* K11  */  be_nested_str_weak(log),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
+    /* K13  */  be_nested_str_weak(addr),
+    /* K14  */  be_const_int(3),
+    /* K15  */  be_nested_str_weak(close),
+    /* K16  */  be_nested_str_weak(remove),
     }),
     be_str_weak(clean_remotes),
     &be_const_str_solidified,
-    ( &(const binstruction[67]) {  /* code */
+    ( &(const binstruction[66]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x780E003D,  //  0003  JMPF	R3	#0042
-      0x600C0013,  //  0004  GETGBL	R3	G19
-      0x7C0C0000,  //  0005  CALL	R3	0
-      0x60100010,  //  0006  GETGBL	R4	G16
-      0x88140102,  //  0007  GETMBR	R5	R0	K2
-      0x7C100200,  //  0008  CALL	R4	1
-      0xA8020003,  //  0009  EXBLK	0	#000E
-      0x5C140800,  //  000A  MOVE	R5	R4
-      0x7C140000,  //  000B  CALL	R5	0
-      0x980C0B03,  //  000C  SETIDX	R3	R5	K3
-      0x7001FFFB,  //  000D  JMP		#000A
-      0x58100004,  //  000E  LDCONST	R4	K4
-      0xAC100200,  //  000F  CATCH	R4	1	0
-      0xB0080000,  //  0010  RAISE	2	R0	R0
-      0x60100010,  //  0011  GETGBL	R4	G16
-      0x88140105,  //  0012  GETMBR	R5	R0	K5
-      0x7C100200,  //  0013  CALL	R4	1
-      0xA802000F,  //  0014  EXBLK	0	#0025
-      0x5C140800,  //  0015  MOVE	R5	R4
-      0x7C140000,  //  0016  CALL	R5	0
-      0x8C180306,  //  0017  GETMET	R6	R1	K6
-      0x5C200A00,  //  0018  MOVE	R8	R5
-      0x58240007,  //  0019  LDCONST	R9	K7
-      0x7C180600,  //  001A  CALL	R6	3
-      0x4C1C0000,  //  001B  LDNIL	R7
-      0x201C0C07,  //  001C  NE	R7	R6	R7
-      0x781E0005,  //  001D  JMPF	R7	#0024
-      0x8C1C0708,  //  001E  GETMET	R7	R3	K8
-      0x5C240C00,  //  001F  MOVE	R9	R6
-      0x58280003,  //  0020  LDCONST	R10	K3
-      0x7C1C0600,  //  0021  CALL	R7	3
-      0x001C0F09,  //  0022  ADD	R7	R7	K9
-      0x980C0C07,  //  0023  SETIDX	R3	R6	R7
-      0x7001FFEF,  //  0024  JMP		#0015
-      0x58100004,  //  0025  LDCONST	R4	K4
-      0xAC100200,  //  0026  CATCH	R4	1	0
-      0xB0080000,  //  0027  RAISE	2	R0	R0
-      0x60100010,  //  0028  GETGBL	R4	G16
-      0x8C14070A,  //  0029  GETMET	R5	R3	K10
-      0x7C140200,  //  002A  CALL	R5	1
-      0x7C100200,  //  002B  CALL	R4	1
-      0xA8020011,  //  002C  EXBLK	0	#003F
-      0x5C140800,  //  002D  MOVE	R5	R4
-      0x7C140000,  //  002E  CALL	R5	0
-      0x94180605,  //  002F  GETIDX	R6	R3	R5
-      0x1C180D03,  //  0030  EQ	R6	R6	K3
-      0x781A000B,  //  0031  JMPF	R6	#003E
-      0xB81A1600,  //  0032  GETNGBL	R6	K11
-      0x8C180D0C,  //  0033  GETMET	R6	R6	K12
-      0x88200B0E,  //  0034  GETMBR	R8	R5	K14
-      0x00221A08,  //  0035  ADD	R8	K13	R8
-      0x5824000F,  //  0036  LDCONST	R9	K15
-      0x7C180600,  //  0037  CALL	R6	3
-      0x8C180B10,  //  0038  GETMET	R6	R5	K16
-      0x7C180200,  //  0039  CALL	R6	1
-      0x88180102,  //  003A  GETMBR	R6	R0	K2
-      0x8C180D11,  //  003B  GETMET	R6	R6	K17
-      0x5C200A00,  //  003C  MOVE	R8	R5
-      0x7C180400,  //  003D  CALL	R6	2
-      0x7001FFED,  //  003E  JMP		#002D
-      0x58100004,  //  003F  LDCONST	R4	K4
-      0xAC100200,  //  0040  CATCH	R4	1	0
-      0xB0080000,  //  0041  RAISE	2	R0	R0
-      0x80000000,  //  0042  RET	0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x780A003D,  //  0002  JMPF	R2	#0041
+      0x60080013,  //  0003  GETGBL	R2	G19
+      0x7C080000,  //  0004  CALL	R2	0
+      0x600C0010,  //  0005  GETGBL	R3	G16
+      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0xA8020003,  //  0008  EXBLK	0	#000D
+      0x5C100600,  //  0009  MOVE	R4	R3
+      0x7C100000,  //  000A  CALL	R4	0
+      0x98080902,  //  000B  SETIDX	R2	R4	K2
+      0x7001FFFB,  //  000C  JMP		#0009
+      0x580C0003,  //  000D  LDCONST	R3	K3
+      0xAC0C0200,  //  000E  CATCH	R3	1	0
+      0xB0080000,  //  000F  RAISE	2	R0	R0
+      0x600C0010,  //  0010  GETGBL	R3	G16
+      0x88100104,  //  0011  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  0012  CALL	R3	1
+      0xA802000F,  //  0013  EXBLK	0	#0024
+      0x5C100600,  //  0014  MOVE	R4	R3
+      0x7C100000,  //  0015  CALL	R4	0
+      0x8C140305,  //  0016  GETMET	R5	R1	K5
+      0x5C1C0800,  //  0017  MOVE	R7	R4
+      0x58200006,  //  0018  LDCONST	R8	K6
+      0x7C140600,  //  0019  CALL	R5	3
+      0x4C180000,  //  001A  LDNIL	R6
+      0x20180A06,  //  001B  NE	R6	R5	R6
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C180507,  //  001D  GETMET	R6	R2	K7
+      0x5C200A00,  //  001E  MOVE	R8	R5
+      0x58240002,  //  001F  LDCONST	R9	K2
+      0x7C180600,  //  0020  CALL	R6	3
+      0x00180D08,  //  0021  ADD	R6	R6	K8
+      0x98080A06,  //  0022  SETIDX	R2	R5	R6
+      0x7001FFEF,  //  0023  JMP		#0014
+      0x580C0003,  //  0024  LDCONST	R3	K3
+      0xAC0C0200,  //  0025  CATCH	R3	1	0
+      0xB0080000,  //  0026  RAISE	2	R0	R0
+      0x600C0010,  //  0027  GETGBL	R3	G16
+      0x8C100509,  //  0028  GETMET	R4	R2	K9
+      0x7C100200,  //  0029  CALL	R4	1
+      0x7C0C0200,  //  002A  CALL	R3	1
+      0xA8020011,  //  002B  EXBLK	0	#003E
+      0x5C100600,  //  002C  MOVE	R4	R3
+      0x7C100000,  //  002D  CALL	R4	0
+      0x94140404,  //  002E  GETIDX	R5	R2	R4
+      0x1C140B02,  //  002F  EQ	R5	R5	K2
+      0x7816000B,  //  0030  JMPF	R5	#003D
+      0xB8161400,  //  0031  GETNGBL	R5	K10
+      0x8C140B0B,  //  0032  GETMET	R5	R5	K11
+      0x881C090D,  //  0033  GETMBR	R7	R4	K13
+      0x001E1807,  //  0034  ADD	R7	K12	R7
+      0x5820000E,  //  0035  LDCONST	R8	K14
+      0x7C140600,  //  0036  CALL	R5	3
+      0x8C14090F,  //  0037  GETMET	R5	R4	K15
+      0x7C140200,  //  0038  CALL	R5	1
+      0x88140101,  //  0039  GETMBR	R5	R0	K1
+      0x8C140B10,  //  003A  GETMET	R5	R5	K16
+      0x5C1C0800,  //  003B  MOVE	R7	R4
+      0x7C140400,  //  003C  CALL	R5	2
+      0x7001FFED,  //  003D  JMP		#002C
+      0x580C0003,  //  003E  LDCONST	R3	K3
+      0xAC0C0200,  //  003F  CATCH	R3	1	0
+      0xB0080000,  //  0040  RAISE	2	R0	R0
+      0x80000000,  //  0041  RET	0
     })
   )
 );
@@ -3661,7 +3625,7 @@ be_local_closure(Matter_Device_compute_qrcode_content,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_start_operational_discovery,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    7,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3669,31 +3633,29 @@ be_local_closure(Matter_Device_start_operational_discovery,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(mdns),
-    /* K2   */  be_nested_str_weak(string),
-    /* K3   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K4   */  be_nested_str_weak(root_w0),
-    /* K5   */  be_nested_str_weak(root_L),
-    /* K6   */  be_nested_str_weak(mdns_announce_op_discovery),
+    /* K2   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K3   */  be_nested_str_weak(root_w0),
+    /* K4   */  be_nested_str_weak(root_L),
+    /* K5   */  be_nested_str_weak(mdns_announce_op_discovery),
     }),
     be_str_weak(start_operational_discovery),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
+    ( &(const binstruction[12]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA4120400,  //  0002  IMPORT	R4	K2
-      0x8C140103,  //  0003  GETMET	R5	R0	K3
-      0x7C140200,  //  0004  CALL	R5	1
-      0x4C140000,  //  0005  LDNIL	R5
-      0x90020805,  //  0006  SETMBR	R0	K4	R5
-      0x4C140000,  //  0007  LDNIL	R5
-      0x90020A05,  //  0008  SETMBR	R0	K5	R5
-      0x8C140106,  //  0009  GETMET	R5	R0	K6
-      0x5C1C0200,  //  000A  MOVE	R7	R1
-      0x7C140400,  //  000B  CALL	R5	2
-      0x80000000,  //  000C  RET	0
+      0x8C100102,  //  0002  GETMET	R4	R0	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x4C100000,  //  0004  LDNIL	R4
+      0x90020604,  //  0005  SETMBR	R0	K3	R4
+      0x4C100000,  //  0006  LDNIL	R4
+      0x90020804,  //  0007  SETMBR	R0	K4	R4
+      0x8C100105,  //  0008  GETMET	R4	R0	K5
+      0x5C180200,  //  0009  MOVE	R6	R1
+      0x7C100400,  //  000A  CALL	R4	2
+      0x80000000,  //  000B  RET	0
     })
   )
 );
@@ -3814,7 +3776,7 @@ be_local_closure(Matter_Device__trigger_read_sensors,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_bridge_add_endpoint,   /* name */
   be_nested_proto(
-    19,                          /* nstack */
+    17,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3822,105 +3784,102 @@ be_local_closure(Matter_Device_bridge_add_endpoint,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(plugins_classes),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-    /* K6   */  be_nested_str_weak(_X27_X20skipping),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(next_ep),
-    /* K9   */  be_nested_str_weak(plugins),
-    /* K10  */  be_nested_str_weak(push),
-    /* K11  */  be_nested_str_weak(type),
-    /* K12  */  be_nested_str_weak(keys),
-    /* K13  */  be_nested_str_weak(stop_iteration),
-    /* K14  */  be_nested_str_weak(format),
-    /* K15  */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
-    /* K16  */  be_nested_str_weak(conf_to_log),
-    /* K17  */  be_const_int(2),
-    /* K18  */  be_nested_str_weak(plugins_config),
-    /* K19  */  be_nested_str_weak(plugins_persist),
-    /* K20  */  be_const_int(1),
-    /* K21  */  be_nested_str_weak(save_param),
-    /* K22  */  be_nested_str_weak(signal_endpoints_changed),
+    ( &(const bvalue[21]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_classes),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+    /* K5   */  be_nested_str_weak(_X27_X20skipping),
+    /* K6   */  be_const_int(3),
+    /* K7   */  be_nested_str_weak(next_ep),
+    /* K8   */  be_nested_str_weak(plugins),
+    /* K9   */  be_nested_str_weak(push),
+    /* K10  */  be_nested_str_weak(type),
+    /* K11  */  be_nested_str_weak(keys),
+    /* K12  */  be_nested_str_weak(stop_iteration),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
+    /* K14  */  be_nested_str_weak(conf_to_log),
+    /* K15  */  be_const_int(2),
+    /* K16  */  be_nested_str_weak(plugins_config),
+    /* K17  */  be_nested_str_weak(plugins_persist),
+    /* K18  */  be_const_int(1),
+    /* K19  */  be_nested_str_weak(save_param),
+    /* K20  */  be_nested_str_weak(signal_endpoints_changed),
     }),
     be_str_weak(bridge_add_endpoint),
     &be_const_str_solidified,
-    ( &(const binstruction[71]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x88100101,  //  0001  GETMBR	R4	R0	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x5C180200,  //  0003  MOVE	R6	R1
-      0x7C100400,  //  0004  CALL	R4	2
-      0x4C140000,  //  0005  LDNIL	R5
-      0x1C140805,  //  0006  EQ	R5	R4	R5
-      0x78160009,  //  0007  JMPF	R5	#0012
-      0xB8160600,  //  0008  GETNGBL	R5	K3
-      0x8C140B04,  //  0009  GETMET	R5	R5	K4
-      0x601C0008,  //  000A  GETGBL	R7	G8
-      0x5C200200,  //  000B  MOVE	R8	R1
-      0x7C1C0200,  //  000C  CALL	R7	1
-      0x001E0A07,  //  000D  ADD	R7	K5	R7
-      0x001C0F06,  //  000E  ADD	R7	R7	K6
-      0x58200007,  //  000F  LDCONST	R8	K7
-      0x7C140600,  //  0010  CALL	R5	3
-      0x80000A00,  //  0011  RET	0
-      0x88140108,  //  0012  GETMBR	R5	R0	K8
-      0x60180008,  //  0013  GETGBL	R6	G8
-      0x5C1C0A00,  //  0014  MOVE	R7	R5
-      0x7C180200,  //  0015  CALL	R6	1
-      0x5C1C0800,  //  0016  MOVE	R7	R4
-      0x5C200000,  //  0017  MOVE	R8	R0
-      0x5C240A00,  //  0018  MOVE	R9	R5
-      0x5C280400,  //  0019  MOVE	R10	R2
-      0x7C1C0600,  //  001A  CALL	R7	3
-      0x88200109,  //  001B  GETMBR	R8	R0	K9
-      0x8C20110A,  //  001C  GETMET	R8	R8	K10
-      0x5C280E00,  //  001D  MOVE	R10	R7
-      0x7C200400,  //  001E  CALL	R8	2
-      0x60200013,  //  001F  GETGBL	R8	G19
-      0x7C200000,  //  0020  CALL	R8	0
-      0x98221601,  //  0021  SETIDX	R8	K11	R1
-      0x60240010,  //  0022  GETGBL	R9	G16
-      0x8C28050C,  //  0023  GETMET	R10	R2	K12
-      0x7C280200,  //  0024  CALL	R10	1
-      0x7C240200,  //  0025  CALL	R9	1
-      0xA8020004,  //  0026  EXBLK	0	#002C
-      0x5C281200,  //  0027  MOVE	R10	R9
-      0x7C280000,  //  0028  CALL	R10	0
-      0x942C040A,  //  0029  GETIDX	R11	R2	R10
-      0x9820140B,  //  002A  SETIDX	R8	R10	R11
-      0x7001FFFA,  //  002B  JMP		#0027
-      0x5824000D,  //  002C  LDCONST	R9	K13
-      0xAC240200,  //  002D  CATCH	R9	1	0
-      0xB0080000,  //  002E  RAISE	2	R0	R0
-      0xB8260600,  //  002F  GETNGBL	R9	K3
-      0x8C241304,  //  0030  GETMET	R9	R9	K4
-      0x8C2C070E,  //  0031  GETMET	R11	R3	K14
-      0x5834000F,  //  0032  LDCONST	R13	K15
-      0x5C380A00,  //  0033  MOVE	R14	R5
-      0x5C3C0200,  //  0034  MOVE	R15	R1
-      0x8C400110,  //  0035  GETMET	R16	R0	K16
-      0x5C480400,  //  0036  MOVE	R18	R2
-      0x7C400400,  //  0037  CALL	R16	2
-      0x7C2C0A00,  //  0038  CALL	R11	5
-      0x58300011,  //  0039  LDCONST	R12	K17
-      0x7C240600,  //  003A  CALL	R9	3
-      0x88240112,  //  003B  GETMBR	R9	R0	K18
-      0x98240C08,  //  003C  SETIDX	R9	R6	R8
-      0x50240200,  //  003D  LDBOOL	R9	1	0
-      0x90022609,  //  003E  SETMBR	R0	K19	R9
-      0x88240108,  //  003F  GETMBR	R9	R0	K8
-      0x00241314,  //  0040  ADD	R9	R9	K20
-      0x90021009,  //  0041  SETMBR	R0	K8	R9
-      0x8C240115,  //  0042  GETMET	R9	R0	K21
-      0x7C240200,  //  0043  CALL	R9	1
-      0x8C240116,  //  0044  GETMET	R9	R0	K22
-      0x7C240200,  //  0045  CALL	R9	1
-      0x80040A00,  //  0046  RET	1	R5
+    ( &(const binstruction[70]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x4C100000,  //  0004  LDNIL	R4
+      0x1C100604,  //  0005  EQ	R4	R3	R4
+      0x78120009,  //  0006  JMPF	R4	#0011
+      0xB8120400,  //  0007  GETNGBL	R4	K2
+      0x8C100903,  //  0008  GETMET	R4	R4	K3
+      0x60180008,  //  0009  GETGBL	R6	G8
+      0x5C1C0200,  //  000A  MOVE	R7	R1
+      0x7C180200,  //  000B  CALL	R6	1
+      0x001A0806,  //  000C  ADD	R6	K4	R6
+      0x00180D05,  //  000D  ADD	R6	R6	K5
+      0x581C0006,  //  000E  LDCONST	R7	K6
+      0x7C100600,  //  000F  CALL	R4	3
+      0x80000800,  //  0010  RET	0
+      0x88100107,  //  0011  GETMBR	R4	R0	K7
+      0x60140008,  //  0012  GETGBL	R5	G8
+      0x5C180800,  //  0013  MOVE	R6	R4
+      0x7C140200,  //  0014  CALL	R5	1
+      0x5C180600,  //  0015  MOVE	R6	R3
+      0x5C1C0000,  //  0016  MOVE	R7	R0
+      0x5C200800,  //  0017  MOVE	R8	R4
+      0x5C240400,  //  0018  MOVE	R9	R2
+      0x7C180600,  //  0019  CALL	R6	3
+      0x881C0108,  //  001A  GETMBR	R7	R0	K8
+      0x8C1C0F09,  //  001B  GETMET	R7	R7	K9
+      0x5C240C00,  //  001C  MOVE	R9	R6
+      0x7C1C0400,  //  001D  CALL	R7	2
+      0x601C0013,  //  001E  GETGBL	R7	G19
+      0x7C1C0000,  //  001F  CALL	R7	0
+      0x981E1401,  //  0020  SETIDX	R7	K10	R1
+      0x60200010,  //  0021  GETGBL	R8	G16
+      0x8C24050B,  //  0022  GETMET	R9	R2	K11
+      0x7C240200,  //  0023  CALL	R9	1
+      0x7C200200,  //  0024  CALL	R8	1
+      0xA8020004,  //  0025  EXBLK	0	#002B
+      0x5C241000,  //  0026  MOVE	R9	R8
+      0x7C240000,  //  0027  CALL	R9	0
+      0x94280409,  //  0028  GETIDX	R10	R2	R9
+      0x981C120A,  //  0029  SETIDX	R7	R9	R10
+      0x7001FFFA,  //  002A  JMP		#0026
+      0x5820000C,  //  002B  LDCONST	R8	K12
+      0xAC200200,  //  002C  CATCH	R8	1	0
+      0xB0080000,  //  002D  RAISE	2	R0	R0
+      0xB8220400,  //  002E  GETNGBL	R8	K2
+      0x8C201103,  //  002F  GETMET	R8	R8	K3
+      0x60280018,  //  0030  GETGBL	R10	G24
+      0x582C000D,  //  0031  LDCONST	R11	K13
+      0x5C300800,  //  0032  MOVE	R12	R4
+      0x5C340200,  //  0033  MOVE	R13	R1
+      0x8C38010E,  //  0034  GETMET	R14	R0	K14
+      0x5C400400,  //  0035  MOVE	R16	R2
+      0x7C380400,  //  0036  CALL	R14	2
+      0x7C280800,  //  0037  CALL	R10	4
+      0x582C000F,  //  0038  LDCONST	R11	K15
+      0x7C200600,  //  0039  CALL	R8	3
+      0x88200110,  //  003A  GETMBR	R8	R0	K16
+      0x98200A07,  //  003B  SETIDX	R8	R5	R7
+      0x50200200,  //  003C  LDBOOL	R8	1	0
+      0x90022208,  //  003D  SETMBR	R0	K17	R8
+      0x88200107,  //  003E  GETMBR	R8	R0	K7
+      0x00201112,  //  003F  ADD	R8	R8	K18
+      0x90020E08,  //  0040  SETMBR	R0	K7	R8
+      0x8C200113,  //  0041  GETMET	R8	R0	K19
+      0x7C200200,  //  0042  CALL	R8	1
+      0x8C200114,  //  0043  GETMET	R8	R0	K20
+      0x7C200200,  //  0044  CALL	R8	1
+      0x80040800,  //  0045  RET	1	R4
     })
   )
 );
@@ -3932,7 +3891,7 @@ be_local_closure(Matter_Device_bridge_add_endpoint,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_load_param,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3940,148 +3899,146 @@ be_local_closure(Matter_Device_load_param,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[32]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(FILENAME),
-    /* K3   */  be_nested_str_weak(read),
-    /* K4   */  be_nested_str_weak(close),
-    /* K5   */  be_nested_str_weak(json),
-    /* K6   */  be_nested_str_weak(load),
-    /* K7   */  be_nested_str_weak(root_discriminator),
-    /* K8   */  be_nested_str_weak(find),
-    /* K9   */  be_nested_str_weak(distinguish),
-    /* K10  */  be_nested_str_weak(root_passcode),
-    /* K11  */  be_nested_str_weak(passcode),
-    /* K12  */  be_nested_str_weak(ipv4only),
-    /* K13  */  be_nested_str_weak(next_ep),
-    /* K14  */  be_nested_str_weak(nextep),
-    /* K15  */  be_nested_str_weak(plugins_config),
-    /* K16  */  be_nested_str_weak(config),
-    /* K17  */  be_nested_str_weak(tasmota),
-    /* K18  */  be_nested_str_weak(log),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20load_config_X20_X3D_X20),
-    /* K20  */  be_const_int(3),
-    /* K21  */  be_nested_str_weak(adjust_next_ep),
-    /* K22  */  be_nested_str_weak(plugins_persist),
-    /* K23  */  be_nested_str_weak(io_error),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
-    /* K25  */  be_nested_str_weak(_X7C),
-    /* K26  */  be_const_int(2),
-    /* K27  */  be_nested_str_weak(random),
-    /* K28  */  be_nested_str_weak(get),
-    /* K29  */  be_const_int(0),
-    /* K30  */  be_nested_str_weak(generate_random_passcode),
-    /* K31  */  be_nested_str_weak(save_param),
+    ( &(const bvalue[31]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(FILENAME),
+    /* K2   */  be_nested_str_weak(read),
+    /* K3   */  be_nested_str_weak(close),
+    /* K4   */  be_nested_str_weak(json),
+    /* K5   */  be_nested_str_weak(load),
+    /* K6   */  be_nested_str_weak(root_discriminator),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_nested_str_weak(distinguish),
+    /* K9   */  be_nested_str_weak(root_passcode),
+    /* K10  */  be_nested_str_weak(passcode),
+    /* K11  */  be_nested_str_weak(ipv4only),
+    /* K12  */  be_nested_str_weak(next_ep),
+    /* K13  */  be_nested_str_weak(nextep),
+    /* K14  */  be_nested_str_weak(plugins_config),
+    /* K15  */  be_nested_str_weak(config),
+    /* K16  */  be_nested_str_weak(tasmota),
+    /* K17  */  be_nested_str_weak(log),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20load_config_X20_X3D_X20),
+    /* K19  */  be_const_int(3),
+    /* K20  */  be_nested_str_weak(adjust_next_ep),
+    /* K21  */  be_nested_str_weak(plugins_persist),
+    /* K22  */  be_nested_str_weak(io_error),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
+    /* K24  */  be_nested_str_weak(_X7C),
+    /* K25  */  be_const_int(2),
+    /* K26  */  be_nested_str_weak(random),
+    /* K27  */  be_nested_str_weak(get),
+    /* K28  */  be_const_int(0),
+    /* K29  */  be_nested_str_weak(generate_random_passcode),
+    /* K30  */  be_nested_str_weak(save_param),
     }),
     be_str_weak(load_param),
     &be_const_str_solidified,
-    ( &(const binstruction[105]) {  /* code */
+    ( &(const binstruction[104]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xA8020036,  //  0002  EXBLK	0	#003A
-      0x600C0011,  //  0003  GETGBL	R3	G17
-      0x88100102,  //  0004  GETMBR	R4	R0	K2
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C100703,  //  0006  GETMET	R4	R3	K3
-      0x7C100200,  //  0007  CALL	R4	1
-      0x8C140704,  //  0008  GETMET	R5	R3	K4
-      0x7C140200,  //  0009  CALL	R5	1
-      0xA4160A00,  //  000A  IMPORT	R5	K5
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
-      0x5C200800,  //  000C  MOVE	R8	R4
-      0x7C180400,  //  000D  CALL	R6	2
-      0x8C1C0D08,  //  000E  GETMET	R7	R6	K8
-      0x58240009,  //  000F  LDCONST	R9	K9
-      0x88280107,  //  0010  GETMBR	R10	R0	K7
-      0x7C1C0600,  //  0011  CALL	R7	3
-      0x90020E07,  //  0012  SETMBR	R0	K7	R7
-      0x8C1C0D08,  //  0013  GETMET	R7	R6	K8
-      0x5824000B,  //  0014  LDCONST	R9	K11
-      0x8828010A,  //  0015  GETMBR	R10	R0	K10
-      0x7C1C0600,  //  0016  CALL	R7	3
-      0x90021407,  //  0017  SETMBR	R0	K10	R7
-      0x601C0017,  //  0018  GETGBL	R7	G23
-      0x8C200D08,  //  0019  GETMET	R8	R6	K8
-      0x5828000C,  //  001A  LDCONST	R10	K12
-      0x502C0000,  //  001B  LDBOOL	R11	0	0
-      0x7C200600,  //  001C  CALL	R8	3
-      0x7C1C0200,  //  001D  CALL	R7	1
-      0x90021807,  //  001E  SETMBR	R0	K12	R7
-      0x8C1C0D08,  //  001F  GETMET	R7	R6	K8
-      0x5824000E,  //  0020  LDCONST	R9	K14
-      0x8828010D,  //  0021  GETMBR	R10	R0	K13
-      0x7C1C0600,  //  0022  CALL	R7	3
-      0x90021A07,  //  0023  SETMBR	R0	K13	R7
-      0x8C1C0D08,  //  0024  GETMET	R7	R6	K8
-      0x58240010,  //  0025  LDCONST	R9	K16
-      0x7C1C0400,  //  0026  CALL	R7	2
-      0x90021E07,  //  0027  SETMBR	R0	K15	R7
-      0x881C010F,  //  0028  GETMBR	R7	R0	K15
-      0x4C200000,  //  0029  LDNIL	R8
-      0x201C0E08,  //  002A  NE	R7	R7	R8
-      0x781E000B,  //  002B  JMPF	R7	#0038
-      0xB81E2200,  //  002C  GETNGBL	R7	K17
-      0x8C1C0F12,  //  002D  GETMET	R7	R7	K18
-      0x60240008,  //  002E  GETGBL	R9	G8
-      0x8828010F,  //  002F  GETMBR	R10	R0	K15
-      0x7C240200,  //  0030  CALL	R9	1
-      0x00262609,  //  0031  ADD	R9	K19	R9
-      0x58280014,  //  0032  LDCONST	R10	K20
-      0x7C1C0600,  //  0033  CALL	R7	3
-      0x8C1C0115,  //  0034  GETMET	R7	R0	K21
-      0x7C1C0200,  //  0035  CALL	R7	1
-      0x501C0200,  //  0036  LDBOOL	R7	1	0
-      0x90022C07,  //  0037  SETMBR	R0	K22	R7
-      0xA8040001,  //  0038  EXBLK	1	1
-      0x70020012,  //  0039  JMP		#004D
-      0xAC0C0002,  //  003A  CATCH	R3	0	2
-      0x7002000F,  //  003B  JMP		#004C
-      0x20140717,  //  003C  NE	R5	R3	K23
-      0x7816000C,  //  003D  JMPF	R5	#004B
-      0xB8162200,  //  003E  GETNGBL	R5	K17
-      0x8C140B12,  //  003F  GETMET	R5	R5	K18
-      0x601C0008,  //  0040  GETGBL	R7	G8
-      0x5C200600,  //  0041  MOVE	R8	R3
-      0x7C1C0200,  //  0042  CALL	R7	1
-      0x001E3007,  //  0043  ADD	R7	K24	R7
-      0x001C0F19,  //  0044  ADD	R7	R7	K25
-      0x60200008,  //  0045  GETGBL	R8	G8
-      0x5C240800,  //  0046  MOVE	R9	R4
-      0x7C200200,  //  0047  CALL	R8	1
-      0x001C0E08,  //  0048  ADD	R7	R7	R8
-      0x5820001A,  //  0049  LDCONST	R8	K26
-      0x7C140600,  //  004A  CALL	R5	3
-      0x70020000,  //  004B  JMP		#004D
-      0xB0080000,  //  004C  RAISE	2	R0	R0
-      0x500C0000,  //  004D  LDBOOL	R3	0	0
-      0x88100107,  //  004E  GETMBR	R4	R0	K7
-      0x4C140000,  //  004F  LDNIL	R5
-      0x1C100805,  //  0050  EQ	R4	R4	R5
-      0x7812000A,  //  0051  JMPF	R4	#005D
-      0x8C10051B,  //  0052  GETMET	R4	R2	K27
-      0x5818001A,  //  0053  LDCONST	R6	K26
-      0x7C100400,  //  0054  CALL	R4	2
-      0x8C10091C,  //  0055  GETMET	R4	R4	K28
-      0x5818001D,  //  0056  LDCONST	R6	K29
-      0x581C001A,  //  0057  LDCONST	R7	K26
-      0x7C100600,  //  0058  CALL	R4	3
-      0x54160FFE,  //  0059  LDINT	R5	4095
-      0x2C100805,  //  005A  AND	R4	R4	R5
-      0x90020E04,  //  005B  SETMBR	R0	K7	R4
-      0x500C0200,  //  005C  LDBOOL	R3	1	0
-      0x8810010A,  //  005D  GETMBR	R4	R0	K10
-      0x4C140000,  //  005E  LDNIL	R5
-      0x1C100805,  //  005F  EQ	R4	R4	R5
-      0x78120003,  //  0060  JMPF	R4	#0065
-      0x8C10011E,  //  0061  GETMET	R4	R0	K30
-      0x7C100200,  //  0062  CALL	R4	1
-      0x90021404,  //  0063  SETMBR	R0	K10	R4
-      0x500C0200,  //  0064  LDBOOL	R3	1	0
-      0x780E0001,  //  0065  JMPF	R3	#0068
-      0x8C10011F,  //  0066  GETMET	R4	R0	K31
-      0x7C100200,  //  0067  CALL	R4	1
-      0x80000000,  //  0068  RET	0
+      0xA8020036,  //  0001  EXBLK	0	#0039
+      0x60080011,  //  0002  GETGBL	R2	G17
+      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x7C080200,  //  0004  CALL	R2	1
+      0x8C0C0502,  //  0005  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0x8C100503,  //  0007  GETMET	R4	R2	K3
+      0x7C100200,  //  0008  CALL	R4	1
+      0xA4120800,  //  0009  IMPORT	R4	K4
+      0x8C140905,  //  000A  GETMET	R5	R4	K5
+      0x5C1C0600,  //  000B  MOVE	R7	R3
+      0x7C140400,  //  000C  CALL	R5	2
+      0x8C180B07,  //  000D  GETMET	R6	R5	K7
+      0x58200008,  //  000E  LDCONST	R8	K8
+      0x88240106,  //  000F  GETMBR	R9	R0	K6
+      0x7C180600,  //  0010  CALL	R6	3
+      0x90020C06,  //  0011  SETMBR	R0	K6	R6
+      0x8C180B07,  //  0012  GETMET	R6	R5	K7
+      0x5820000A,  //  0013  LDCONST	R8	K10
+      0x88240109,  //  0014  GETMBR	R9	R0	K9
+      0x7C180600,  //  0015  CALL	R6	3
+      0x90021206,  //  0016  SETMBR	R0	K9	R6
+      0x60180017,  //  0017  GETGBL	R6	G23
+      0x8C1C0B07,  //  0018  GETMET	R7	R5	K7
+      0x5824000B,  //  0019  LDCONST	R9	K11
+      0x50280000,  //  001A  LDBOOL	R10	0	0
+      0x7C1C0600,  //  001B  CALL	R7	3
+      0x7C180200,  //  001C  CALL	R6	1
+      0x90021606,  //  001D  SETMBR	R0	K11	R6
+      0x8C180B07,  //  001E  GETMET	R6	R5	K7
+      0x5820000D,  //  001F  LDCONST	R8	K13
+      0x8824010C,  //  0020  GETMBR	R9	R0	K12
+      0x7C180600,  //  0021  CALL	R6	3
+      0x90021806,  //  0022  SETMBR	R0	K12	R6
+      0x8C180B07,  //  0023  GETMET	R6	R5	K7
+      0x5820000F,  //  0024  LDCONST	R8	K15
+      0x7C180400,  //  0025  CALL	R6	2
+      0x90021C06,  //  0026  SETMBR	R0	K14	R6
+      0x8818010E,  //  0027  GETMBR	R6	R0	K14
+      0x4C1C0000,  //  0028  LDNIL	R7
+      0x20180C07,  //  0029  NE	R6	R6	R7
+      0x781A000B,  //  002A  JMPF	R6	#0037
+      0xB81A2000,  //  002B  GETNGBL	R6	K16
+      0x8C180D11,  //  002C  GETMET	R6	R6	K17
+      0x60200008,  //  002D  GETGBL	R8	G8
+      0x8824010E,  //  002E  GETMBR	R9	R0	K14
+      0x7C200200,  //  002F  CALL	R8	1
+      0x00222408,  //  0030  ADD	R8	K18	R8
+      0x58240013,  //  0031  LDCONST	R9	K19
+      0x7C180600,  //  0032  CALL	R6	3
+      0x8C180114,  //  0033  GETMET	R6	R0	K20
+      0x7C180200,  //  0034  CALL	R6	1
+      0x50180200,  //  0035  LDBOOL	R6	1	0
+      0x90022A06,  //  0036  SETMBR	R0	K21	R6
+      0xA8040001,  //  0037  EXBLK	1	1
+      0x70020012,  //  0038  JMP		#004C
+      0xAC080002,  //  0039  CATCH	R2	0	2
+      0x7002000F,  //  003A  JMP		#004B
+      0x20100516,  //  003B  NE	R4	R2	K22
+      0x7812000C,  //  003C  JMPF	R4	#004A
+      0xB8122000,  //  003D  GETNGBL	R4	K16
+      0x8C100911,  //  003E  GETMET	R4	R4	K17
+      0x60180008,  //  003F  GETGBL	R6	G8
+      0x5C1C0400,  //  0040  MOVE	R7	R2
+      0x7C180200,  //  0041  CALL	R6	1
+      0x001A2E06,  //  0042  ADD	R6	K23	R6
+      0x00180D18,  //  0043  ADD	R6	R6	K24
+      0x601C0008,  //  0044  GETGBL	R7	G8
+      0x5C200600,  //  0045  MOVE	R8	R3
+      0x7C1C0200,  //  0046  CALL	R7	1
+      0x00180C07,  //  0047  ADD	R6	R6	R7
+      0x581C0019,  //  0048  LDCONST	R7	K25
+      0x7C100600,  //  0049  CALL	R4	3
+      0x70020000,  //  004A  JMP		#004C
+      0xB0080000,  //  004B  RAISE	2	R0	R0
+      0x50080000,  //  004C  LDBOOL	R2	0	0
+      0x880C0106,  //  004D  GETMBR	R3	R0	K6
+      0x4C100000,  //  004E  LDNIL	R4
+      0x1C0C0604,  //  004F  EQ	R3	R3	R4
+      0x780E000A,  //  0050  JMPF	R3	#005C
+      0x8C0C031A,  //  0051  GETMET	R3	R1	K26
+      0x58140019,  //  0052  LDCONST	R5	K25
+      0x7C0C0400,  //  0053  CALL	R3	2
+      0x8C0C071B,  //  0054  GETMET	R3	R3	K27
+      0x5814001C,  //  0055  LDCONST	R5	K28
+      0x58180019,  //  0056  LDCONST	R6	K25
+      0x7C0C0600,  //  0057  CALL	R3	3
+      0x54120FFE,  //  0058  LDINT	R4	4095
+      0x2C0C0604,  //  0059  AND	R3	R3	R4
+      0x90020C03,  //  005A  SETMBR	R0	K6	R3
+      0x50080200,  //  005B  LDBOOL	R2	1	0
+      0x880C0109,  //  005C  GETMBR	R3	R0	K9
+      0x4C100000,  //  005D  LDNIL	R4
+      0x1C0C0604,  //  005E  EQ	R3	R3	R4
+      0x780E0003,  //  005F  JMPF	R3	#0064
+      0x8C0C011D,  //  0060  GETMET	R3	R0	K29
+      0x7C0C0200,  //  0061  CALL	R3	1
+      0x90021203,  //  0062  SETMBR	R0	K9	R3
+      0x50080200,  //  0063  LDBOOL	R2	1	0
+      0x780A0001,  //  0064  JMPF	R2	#0067
+      0x8C0C011E,  //  0065  GETMET	R3	R0	K30
+      0x7C0C0200,  //  0066  CALL	R3	1
+      0x80000000,  //  0067  RET	0
     })
   )
 );
@@ -4093,7 +4050,7 @@ be_local_closure(Matter_Device_load_param,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    9,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -4101,50 +4058,47 @@ be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(root_discriminator),
-    /* K2   */  be_nested_str_weak(root_passcode),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(_X251i_X2505i_X2504i),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(Verhoeff),
-    /* K7   */  be_nested_str_weak(checksum),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(root_discriminator),
+    /* K1   */  be_nested_str_weak(root_passcode),
+    /* K2   */  be_nested_str_weak(_X251i_X2505i_X2504i),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(Verhoeff),
+    /* K5   */  be_nested_str_weak(checksum),
     }),
     be_str_weak(compute_manual_pairing_code),
     &be_const_str_solidified,
-    ( &(const binstruction[31]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x540E0FFE,  //  0002  LDINT	R3	4095
-      0x2C080403,  //  0003  AND	R2	R2	R3
-      0x540E0009,  //  0004  LDINT	R3	10
-      0x3C080403,  //  0005  SHR	R2	R2	R3
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x541202FF,  //  0007  LDINT	R4	768
-      0x2C0C0604,  //  0008  AND	R3	R3	R4
-      0x54120005,  //  0009  LDINT	R4	6
-      0x380C0604,  //  000A  SHL	R3	R3	R4
-      0x88100102,  //  000B  GETMBR	R4	R0	K2
-      0x54163FFE,  //  000C  LDINT	R5	16383
-      0x2C100805,  //  000D  AND	R4	R4	R5
-      0x300C0604,  //  000E  OR	R3	R3	R4
-      0x88100102,  //  000F  GETMBR	R4	R0	K2
-      0x5416000D,  //  0010  LDINT	R5	14
-      0x3C100805,  //  0011  SHR	R4	R4	R5
-      0x8C140303,  //  0012  GETMET	R5	R1	K3
-      0x581C0004,  //  0013  LDCONST	R7	K4
-      0x5C200400,  //  0014  MOVE	R8	R2
-      0x5C240600,  //  0015  MOVE	R9	R3
-      0x5C280800,  //  0016  MOVE	R10	R4
-      0x7C140A00,  //  0017  CALL	R5	5
-      0xB81A0A00,  //  0018  GETNGBL	R6	K5
-      0x88180D06,  //  0019  GETMBR	R6	R6	K6
-      0x8C180D07,  //  001A  GETMET	R6	R6	K7
-      0x5C200A00,  //  001B  MOVE	R8	R5
-      0x7C180400,  //  001C  CALL	R6	2
-      0x00140A06,  //  001D  ADD	R5	R5	R6
-      0x80040A00,  //  001E  RET	1	R5
+    ( &(const binstruction[30]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x540A0FFE,  //  0001  LDINT	R2	4095
+      0x2C040202,  //  0002  AND	R1	R1	R2
+      0x540A0009,  //  0003  LDINT	R2	10
+      0x3C040202,  //  0004  SHR	R1	R1	R2
+      0x88080100,  //  0005  GETMBR	R2	R0	K0
+      0x540E02FF,  //  0006  LDINT	R3	768
+      0x2C080403,  //  0007  AND	R2	R2	R3
+      0x540E0005,  //  0008  LDINT	R3	6
+      0x38080403,  //  0009  SHL	R2	R2	R3
+      0x880C0101,  //  000A  GETMBR	R3	R0	K1
+      0x54123FFE,  //  000B  LDINT	R4	16383
+      0x2C0C0604,  //  000C  AND	R3	R3	R4
+      0x30080403,  //  000D  OR	R2	R2	R3
+      0x880C0101,  //  000E  GETMBR	R3	R0	K1
+      0x5412000D,  //  000F  LDINT	R4	14
+      0x3C0C0604,  //  0010  SHR	R3	R3	R4
+      0x60100018,  //  0011  GETGBL	R4	G24
+      0x58140002,  //  0012  LDCONST	R5	K2
+      0x5C180200,  //  0013  MOVE	R6	R1
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x5C200600,  //  0015  MOVE	R8	R3
+      0x7C100800,  //  0016  CALL	R4	4
+      0xB8160600,  //  0017  GETNGBL	R5	K3
+      0x88140B04,  //  0018  GETMBR	R5	R5	K4
+      0x8C140B05,  //  0019  GETMET	R5	R5	K5
+      0x5C1C0800,  //  001A  MOVE	R7	R4
+      0x7C140400,  //  001B  CALL	R5	2
+      0x00100805,  //  001C  ADD	R4	R4	R5
+      0x80040800,  //  001D  RET	1	R4
     })
   )
 );
@@ -4272,7 +4226,7 @@ be_local_closure(Matter_Device_start_operational_discovery_deferred,   /* name *
 ********************************************************************/
 be_local_closure(Matter_Device_autoconf_device_map,   /* name */
   be_nested_proto(
-    22,                          /* nstack */
+    20,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -4280,249 +4234,246 @@ be_local_closure(Matter_Device_autoconf_device_map,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[38]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(json),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(light),
-    /* K4   */  be_nested_str_weak(get),
-    /* K5   */  be_nested_str_weak(find),
-    /* K6   */  be_nested_str_weak(channels),
-    /* K7   */  be_nested_str_weak(),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(type),
-    /* K10  */  be_nested_str_weak(light1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(light2),
-    /* K13  */  be_nested_str_weak(light3),
-    /* K14  */  be_nested_str_weak(tasmota),
-    /* K15  */  be_nested_str_weak(cmd),
-    /* K16  */  be_nested_str_weak(Status_X2013),
-    /* K17  */  be_nested_str_weak(log),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20Status_X2013_X20_X3D_X20),
-    /* K19  */  be_const_int(3),
-    /* K20  */  be_nested_str_weak(contains),
-    /* K21  */  be_nested_str_weak(StatusSHT),
-    /* K22  */  be_nested_str_weak(SHT),
-    /* K23  */  be_nested_str_weak(format),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20_X27_X25s_X27_X20_X3D_X20_X25s),
-    /* K25  */  be_nested_str_weak(Relay1),
-    /* K26  */  be_nested_str_weak(Relay2),
-    /* K27  */  be_nested_str_weak(push),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20relay1_X20_X3D_X20_X25s_X2C_X20relay2_X20_X3D_X20_X25s),
-    /* K29  */  be_nested_str_weak(TiltConfig),
-    /* K30  */  be_nested_str_weak(shutter_X2Btilt),
-    /* K31  */  be_nested_str_weak(shutter),
-    /* K32  */  be_nested_str_weak(get_power),
-    /* K33  */  be_nested_str_weak(relay),
-    /* K34  */  be_nested_str_weak(load),
-    /* K35  */  be_nested_str_weak(read_sensors),
-    /* K36  */  be_nested_str_weak(autoconf_sensors_list),
-    /* K37  */  be_nested_str_weak(stop_iteration),
+    ( &(const bvalue[36]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_nested_str_weak(light),
+    /* K3   */  be_nested_str_weak(get),
+    /* K4   */  be_nested_str_weak(find),
+    /* K5   */  be_nested_str_weak(channels),
+    /* K6   */  be_nested_str_weak(),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_nested_str_weak(type),
+    /* K9   */  be_nested_str_weak(light1),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(light2),
+    /* K12  */  be_nested_str_weak(light3),
+    /* K13  */  be_nested_str_weak(tasmota),
+    /* K14  */  be_nested_str_weak(cmd),
+    /* K15  */  be_nested_str_weak(Status_X2013),
+    /* K16  */  be_nested_str_weak(log),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20Status_X2013_X20_X3D_X20),
+    /* K18  */  be_const_int(3),
+    /* K19  */  be_nested_str_weak(contains),
+    /* K20  */  be_nested_str_weak(StatusSHT),
+    /* K21  */  be_nested_str_weak(SHT),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20_X27_X25s_X27_X20_X3D_X20_X25s),
+    /* K23  */  be_nested_str_weak(Relay1),
+    /* K24  */  be_nested_str_weak(Relay2),
+    /* K25  */  be_nested_str_weak(push),
+    /* K26  */  be_nested_str_weak(MTR_X3A_X20relay1_X20_X3D_X20_X25s_X2C_X20relay2_X20_X3D_X20_X25s),
+    /* K27  */  be_nested_str_weak(TiltConfig),
+    /* K28  */  be_nested_str_weak(shutter_X2Btilt),
+    /* K29  */  be_nested_str_weak(shutter),
+    /* K30  */  be_nested_str_weak(get_power),
+    /* K31  */  be_nested_str_weak(relay),
+    /* K32  */  be_nested_str_weak(load),
+    /* K33  */  be_nested_str_weak(read_sensors),
+    /* K34  */  be_nested_str_weak(autoconf_sensors_list),
+    /* K35  */  be_nested_str_weak(stop_iteration),
     }),
     be_str_weak(autoconf_device_map),
     &be_const_str_solidified,
-    ( &(const binstruction[200]) {  /* code */
+    ( &(const binstruction[199]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x600C0013,  //  0002  GETGBL	R3	G19
-      0x7C0C0000,  //  0003  CALL	R3	0
-      0x58100002,  //  0004  LDCONST	R4	K2
-      0x50140000,  //  0005  LDBOOL	R5	0	0
-      0xA41A0600,  //  0006  IMPORT	R6	K3
-      0x8C1C0D04,  //  0007  GETMET	R7	R6	K4
-      0x7C1C0200,  //  0008  CALL	R7	1
-      0x4C200000,  //  0009  LDNIL	R8
-      0x20200E08,  //  000A  NE	R8	R7	R8
-      0x78220024,  //  000B  JMPF	R8	#0031
-      0x6020000C,  //  000C  GETGBL	R8	G12
-      0x8C240F05,  //  000D  GETMET	R9	R7	K5
+      0x60080013,  //  0001  GETGBL	R2	G19
+      0x7C080000,  //  0002  CALL	R2	0
+      0x580C0001,  //  0003  LDCONST	R3	K1
+      0x50100000,  //  0004  LDBOOL	R4	0	0
+      0xA4160400,  //  0005  IMPORT	R5	K2
+      0x8C180B03,  //  0006  GETMET	R6	R5	K3
+      0x7C180200,  //  0007  CALL	R6	1
+      0x4C1C0000,  //  0008  LDNIL	R7
+      0x201C0C07,  //  0009  NE	R7	R6	R7
+      0x781E0024,  //  000A  JMPF	R7	#0030
+      0x601C000C,  //  000B  GETGBL	R7	G12
+      0x8C200D04,  //  000C  GETMET	R8	R6	K4
+      0x58280005,  //  000D  LDCONST	R10	K5
       0x582C0006,  //  000E  LDCONST	R11	K6
-      0x58300007,  //  000F  LDCONST	R12	K7
-      0x7C240600,  //  0010  CALL	R9	3
-      0x7C200200,  //  0011  CALL	R8	1
-      0x24241108,  //  0012  GT	R9	R8	K8
-      0x7826001C,  //  0013  JMPF	R9	#0031
-      0x1C241102,  //  0014  EQ	R9	R8	K2
-      0x78260007,  //  0015  JMPF	R9	#001E
-      0x60240008,  //  0016  GETGBL	R9	G8
-      0x5C280800,  //  0017  MOVE	R10	R4
-      0x7C240200,  //  0018  CALL	R9	1
-      0x60280013,  //  0019  GETGBL	R10	G19
-      0x7C280000,  //  001A  CALL	R10	0
-      0x982A130A,  //  001B  SETIDX	R10	K9	K10
-      0x980C120A,  //  001C  SETIDX	R3	R9	R10
-      0x70020010,  //  001D  JMP		#002F
-      0x1C24110B,  //  001E  EQ	R9	R8	K11
-      0x78260007,  //  001F  JMPF	R9	#0028
-      0x60240008,  //  0020  GETGBL	R9	G8
-      0x5C280800,  //  0021  MOVE	R10	R4
-      0x7C240200,  //  0022  CALL	R9	1
-      0x60280013,  //  0023  GETGBL	R10	G19
-      0x7C280000,  //  0024  CALL	R10	0
-      0x982A130C,  //  0025  SETIDX	R10	K9	K12
-      0x980C120A,  //  0026  SETIDX	R3	R9	R10
-      0x70020006,  //  0027  JMP		#002F
-      0x60240008,  //  0028  GETGBL	R9	G8
-      0x5C280800,  //  0029  MOVE	R10	R4
-      0x7C240200,  //  002A  CALL	R9	1
-      0x60280013,  //  002B  GETGBL	R10	G19
-      0x7C280000,  //  002C  CALL	R10	0
-      0x982A130D,  //  002D  SETIDX	R10	K9	K13
-      0x980C120A,  //  002E  SETIDX	R3	R9	R10
-      0x50140200,  //  002F  LDBOOL	R5	1	0
-      0x00100902,  //  0030  ADD	R4	R4	K2
-      0xB8221C00,  //  0031  GETNGBL	R8	K14
-      0x8C20110F,  //  0032  GETMET	R8	R8	K15
-      0x58280010,  //  0033  LDCONST	R10	K16
-      0x502C0200,  //  0034  LDBOOL	R11	1	0
-      0x7C200600,  //  0035  CALL	R8	3
-      0x60240012,  //  0036  GETGBL	R9	G18
-      0x7C240000,  //  0037  CALL	R9	0
-      0xB82A1C00,  //  0038  GETNGBL	R10	K14
-      0x8C281511,  //  0039  GETMET	R10	R10	K17
-      0x60300008,  //  003A  GETGBL	R12	G8
-      0x5C341000,  //  003B  MOVE	R13	R8
-      0x7C300200,  //  003C  CALL	R12	1
-      0x0032240C,  //  003D  ADD	R12	K18	R12
-      0x58340013,  //  003E  LDCONST	R13	K19
-      0x7C280600,  //  003F  CALL	R10	3
-      0x4C280000,  //  0040  LDNIL	R10
-      0x2028100A,  //  0041  NE	R10	R8	R10
-      0x782A0051,  //  0042  JMPF	R10	#0095
-      0x8C281114,  //  0043  GETMET	R10	R8	K20
-      0x58300015,  //  0044  LDCONST	R12	K21
-      0x7C280400,  //  0045  CALL	R10	2
-      0x782A004D,  //  0046  JMPF	R10	#0095
-      0x94201115,  //  0047  GETIDX	R8	R8	K21
-      0x58280008,  //  0048  LDCONST	R10	K8
-      0x502C0200,  //  0049  LDBOOL	R11	1	0
-      0x782E0049,  //  004A  JMPF	R11	#0095
-      0x602C0008,  //  004B  GETGBL	R11	G8
-      0x5C301400,  //  004C  MOVE	R12	R10
-      0x7C2C0200,  //  004D  CALL	R11	1
-      0x002E2C0B,  //  004E  ADD	R11	K22	R11
-      0x8C301114,  //  004F  GETMET	R12	R8	K20
-      0x5C381600,  //  0050  MOVE	R14	R11
-      0x7C300400,  //  0051  CALL	R12	2
-      0x74320000,  //  0052  JMPT	R12	#0054
-      0x70020040,  //  0053  JMP		#0095
-      0x9430100B,  //  0054  GETIDX	R12	R8	R11
-      0xB8361C00,  //  0055  GETNGBL	R13	K14
-      0x8C341B11,  //  0056  GETMET	R13	R13	K17
-      0x8C3C0317,  //  0057  GETMET	R15	R1	K23
-      0x58440018,  //  0058  LDCONST	R17	K24
-      0x5C481600,  //  0059  MOVE	R18	R11
-      0x604C0008,  //  005A  GETGBL	R19	G8
-      0x5C501800,  //  005B  MOVE	R20	R12
-      0x7C4C0200,  //  005C  CALL	R19	1
-      0x7C3C0800,  //  005D  CALL	R15	4
-      0x58400013,  //  005E  LDCONST	R16	K19
-      0x7C340600,  //  005F  CALL	R13	3
-      0x8C341905,  //  0060  GETMET	R13	R12	K5
-      0x583C0019,  //  0061  LDCONST	R15	K25
-      0x58400008,  //  0062  LDCONST	R16	K8
-      0x7C340600,  //  0063  CALL	R13	3
-      0x04341B02,  //  0064  SUB	R13	R13	K2
-      0x8C381905,  //  0065  GETMET	R14	R12	K5
-      0x5840001A,  //  0066  LDCONST	R16	K26
-      0x58440008,  //  0067  LDCONST	R17	K8
-      0x7C380600,  //  0068  CALL	R14	3
-      0x04381D02,  //  0069  SUB	R14	R14	K2
-      0x283C1B08,  //  006A  GE	R15	R13	K8
-      0x783E0002,  //  006B  JMPF	R15	#006F
-      0x8C3C131B,  //  006C  GETMET	R15	R9	K27
-      0x5C441A00,  //  006D  MOVE	R17	R13
-      0x7C3C0400,  //  006E  CALL	R15	2
-      0x283C1D08,  //  006F  GE	R15	R14	K8
-      0x783E0002,  //  0070  JMPF	R15	#0074
-      0x8C3C131B,  //  0071  GETMET	R15	R9	K27
-      0x5C441C00,  //  0072  MOVE	R17	R14
-      0x7C3C0400,  //  0073  CALL	R15	2
-      0xB83E1C00,  //  0074  GETNGBL	R15	K14
-      0x8C3C1F11,  //  0075  GETMET	R15	R15	K17
-      0x8C440317,  //  0076  GETMET	R17	R1	K23
-      0x584C001C,  //  0077  LDCONST	R19	K28
-      0x5C501A00,  //  0078  MOVE	R20	R13
-      0x5C541C00,  //  0079  MOVE	R21	R14
-      0x7C440800,  //  007A  CALL	R17	4
-      0x58480013,  //  007B  LDCONST	R18	K19
-      0x7C3C0600,  //  007C  CALL	R15	3
-      0x8C3C1905,  //  007D  GETMET	R15	R12	K5
-      0x5844001D,  //  007E  LDCONST	R17	K29
-      0x7C3C0400,  //  007F  CALL	R15	2
-      0x783E0002,  //  0080  JMPF	R15	#0084
-      0x94401F0B,  //  0081  GETIDX	R16	R15	K11
-      0x24402108,  //  0082  GT	R16	R16	K8
-      0x74420000,  //  0083  JMPT	R16	#0085
-      0x50400001,  //  0084  LDBOOL	R16	0	1
-      0x50400200,  //  0085  LDBOOL	R16	1	0
-      0x60440008,  //  0086  GETGBL	R17	G8
-      0x5C480800,  //  0087  MOVE	R18	R4
-      0x7C440200,  //  0088  CALL	R17	1
-      0x60480013,  //  0089  GETGBL	R18	G19
-      0x7C480000,  //  008A  CALL	R18	0
-      0x78420001,  //  008B  JMPF	R16	#008E
-      0x584C001E,  //  008C  LDCONST	R19	K30
-      0x70020000,  //  008D  JMP		#008F
-      0x584C001F,  //  008E  LDCONST	R19	K31
-      0x984A1213,  //  008F  SETIDX	R18	K9	R19
-      0x984A3E0A,  //  0090  SETIDX	R18	K31	R10
-      0x980C2212,  //  0091  SETIDX	R3	R17	R18
-      0x00100902,  //  0092  ADD	R4	R4	K2
-      0x00281502,  //  0093  ADD	R10	R10	K2
-      0x7001FFB3,  //  0094  JMP		#0049
-      0x6028000C,  //  0095  GETGBL	R10	G12
-      0xB82E1C00,  //  0096  GETNGBL	R11	K14
-      0x8C2C1720,  //  0097  GETMET	R11	R11	K32
-      0x7C2C0200,  //  0098  CALL	R11	1
-      0x7C280200,  //  0099  CALL	R10	1
-      0x582C0008,  //  009A  LDCONST	R11	K8
-      0x78160000,  //  009B  JMPF	R5	#009D
-      0x04281502,  //  009C  SUB	R10	R10	K2
-      0x1430160A,  //  009D  LT	R12	R11	R10
-      0x78320010,  //  009E  JMPF	R12	#00B0
-      0x8C301305,  //  009F  GETMET	R12	R9	K5
-      0x5C381600,  //  00A0  MOVE	R14	R11
-      0x7C300400,  //  00A1  CALL	R12	2
-      0x4C340000,  //  00A2  LDNIL	R13
-      0x1C30180D,  //  00A3  EQ	R12	R12	R13
-      0x78320008,  //  00A4  JMPF	R12	#00AE
-      0x60300008,  //  00A5  GETGBL	R12	G8
-      0x5C340800,  //  00A6  MOVE	R13	R4
-      0x7C300200,  //  00A7  CALL	R12	1
-      0x60340013,  //  00A8  GETGBL	R13	G19
-      0x7C340000,  //  00A9  CALL	R13	0
-      0x98361321,  //  00AA  SETIDX	R13	K9	K33
-      0x9836420B,  //  00AB  SETIDX	R13	K33	R11
-      0x980C180D,  //  00AC  SETIDX	R3	R12	R13
-      0x00100902,  //  00AD  ADD	R4	R4	K2
-      0x002C1702,  //  00AE  ADD	R11	R11	K2
-      0x7001FFEC,  //  00AF  JMP		#009D
-      0x8C300522,  //  00B0  GETMET	R12	R2	K34
-      0xB83A1C00,  //  00B1  GETNGBL	R14	K14
-      0x8C381D23,  //  00B2  GETMET	R14	R14	K35
-      0x7C380200,  //  00B3  CALL	R14	1
-      0x7C300400,  //  00B4  CALL	R12	2
-      0x8C340124,  //  00B5  GETMET	R13	R0	K36
-      0x5C3C1800,  //  00B6  MOVE	R15	R12
-      0x7C340400,  //  00B7  CALL	R13	2
-      0x60380010,  //  00B8  GETGBL	R14	G16
-      0x5C3C1A00,  //  00B9  MOVE	R15	R13
-      0x7C380200,  //  00BA  CALL	R14	1
-      0xA8020007,  //  00BB  EXBLK	0	#00C4
-      0x5C3C1C00,  //  00BC  MOVE	R15	R14
-      0x7C3C0000,  //  00BD  CALL	R15	0
-      0x60400008,  //  00BE  GETGBL	R16	G8
-      0x5C440800,  //  00BF  MOVE	R17	R4
-      0x7C400200,  //  00C0  CALL	R16	1
-      0x980C200F,  //  00C1  SETIDX	R3	R16	R15
-      0x00100902,  //  00C2  ADD	R4	R4	K2
-      0x7001FFF7,  //  00C3  JMP		#00BC
-      0x58380025,  //  00C4  LDCONST	R14	K37
-      0xAC380200,  //  00C5  CATCH	R14	1	0
-      0xB0080000,  //  00C6  RAISE	2	R0	R0
-      0x80040600,  //  00C7  RET	1	R3
+      0x7C200600,  //  000F  CALL	R8	3
+      0x7C1C0200,  //  0010  CALL	R7	1
+      0x24200F07,  //  0011  GT	R8	R7	K7
+      0x7822001C,  //  0012  JMPF	R8	#0030
+      0x1C200F01,  //  0013  EQ	R8	R7	K1
+      0x78220007,  //  0014  JMPF	R8	#001D
+      0x60200008,  //  0015  GETGBL	R8	G8
+      0x5C240600,  //  0016  MOVE	R9	R3
+      0x7C200200,  //  0017  CALL	R8	1
+      0x60240013,  //  0018  GETGBL	R9	G19
+      0x7C240000,  //  0019  CALL	R9	0
+      0x98261109,  //  001A  SETIDX	R9	K8	K9
+      0x98081009,  //  001B  SETIDX	R2	R8	R9
+      0x70020010,  //  001C  JMP		#002E
+      0x1C200F0A,  //  001D  EQ	R8	R7	K10
+      0x78220007,  //  001E  JMPF	R8	#0027
+      0x60200008,  //  001F  GETGBL	R8	G8
+      0x5C240600,  //  0020  MOVE	R9	R3
+      0x7C200200,  //  0021  CALL	R8	1
+      0x60240013,  //  0022  GETGBL	R9	G19
+      0x7C240000,  //  0023  CALL	R9	0
+      0x9826110B,  //  0024  SETIDX	R9	K8	K11
+      0x98081009,  //  0025  SETIDX	R2	R8	R9
+      0x70020006,  //  0026  JMP		#002E
+      0x60200008,  //  0027  GETGBL	R8	G8
+      0x5C240600,  //  0028  MOVE	R9	R3
+      0x7C200200,  //  0029  CALL	R8	1
+      0x60240013,  //  002A  GETGBL	R9	G19
+      0x7C240000,  //  002B  CALL	R9	0
+      0x9826110C,  //  002C  SETIDX	R9	K8	K12
+      0x98081009,  //  002D  SETIDX	R2	R8	R9
+      0x50100200,  //  002E  LDBOOL	R4	1	0
+      0x000C0701,  //  002F  ADD	R3	R3	K1
+      0xB81E1A00,  //  0030  GETNGBL	R7	K13
+      0x8C1C0F0E,  //  0031  GETMET	R7	R7	K14
+      0x5824000F,  //  0032  LDCONST	R9	K15
+      0x50280200,  //  0033  LDBOOL	R10	1	0
+      0x7C1C0600,  //  0034  CALL	R7	3
+      0x60200012,  //  0035  GETGBL	R8	G18
+      0x7C200000,  //  0036  CALL	R8	0
+      0xB8261A00,  //  0037  GETNGBL	R9	K13
+      0x8C241310,  //  0038  GETMET	R9	R9	K16
+      0x602C0008,  //  0039  GETGBL	R11	G8
+      0x5C300E00,  //  003A  MOVE	R12	R7
+      0x7C2C0200,  //  003B  CALL	R11	1
+      0x002E220B,  //  003C  ADD	R11	K17	R11
+      0x58300012,  //  003D  LDCONST	R12	K18
+      0x7C240600,  //  003E  CALL	R9	3
+      0x4C240000,  //  003F  LDNIL	R9
+      0x20240E09,  //  0040  NE	R9	R7	R9
+      0x78260051,  //  0041  JMPF	R9	#0094
+      0x8C240F13,  //  0042  GETMET	R9	R7	K19
+      0x582C0014,  //  0043  LDCONST	R11	K20
+      0x7C240400,  //  0044  CALL	R9	2
+      0x7826004D,  //  0045  JMPF	R9	#0094
+      0x941C0F14,  //  0046  GETIDX	R7	R7	K20
+      0x58240007,  //  0047  LDCONST	R9	K7
+      0x50280200,  //  0048  LDBOOL	R10	1	0
+      0x782A0049,  //  0049  JMPF	R10	#0094
+      0x60280008,  //  004A  GETGBL	R10	G8
+      0x5C2C1200,  //  004B  MOVE	R11	R9
+      0x7C280200,  //  004C  CALL	R10	1
+      0x002A2A0A,  //  004D  ADD	R10	K21	R10
+      0x8C2C0F13,  //  004E  GETMET	R11	R7	K19
+      0x5C341400,  //  004F  MOVE	R13	R10
+      0x7C2C0400,  //  0050  CALL	R11	2
+      0x742E0000,  //  0051  JMPT	R11	#0053
+      0x70020040,  //  0052  JMP		#0094
+      0x942C0E0A,  //  0053  GETIDX	R11	R7	R10
+      0xB8321A00,  //  0054  GETNGBL	R12	K13
+      0x8C301910,  //  0055  GETMET	R12	R12	K16
+      0x60380018,  //  0056  GETGBL	R14	G24
+      0x583C0016,  //  0057  LDCONST	R15	K22
+      0x5C401400,  //  0058  MOVE	R16	R10
+      0x60440008,  //  0059  GETGBL	R17	G8
+      0x5C481600,  //  005A  MOVE	R18	R11
+      0x7C440200,  //  005B  CALL	R17	1
+      0x7C380600,  //  005C  CALL	R14	3
+      0x583C0012,  //  005D  LDCONST	R15	K18
+      0x7C300600,  //  005E  CALL	R12	3
+      0x8C301704,  //  005F  GETMET	R12	R11	K4
+      0x58380017,  //  0060  LDCONST	R14	K23
+      0x583C0007,  //  0061  LDCONST	R15	K7
+      0x7C300600,  //  0062  CALL	R12	3
+      0x04301901,  //  0063  SUB	R12	R12	K1
+      0x8C341704,  //  0064  GETMET	R13	R11	K4
+      0x583C0018,  //  0065  LDCONST	R15	K24
+      0x58400007,  //  0066  LDCONST	R16	K7
+      0x7C340600,  //  0067  CALL	R13	3
+      0x04341B01,  //  0068  SUB	R13	R13	K1
+      0x28381907,  //  0069  GE	R14	R12	K7
+      0x783A0002,  //  006A  JMPF	R14	#006E
+      0x8C381119,  //  006B  GETMET	R14	R8	K25
+      0x5C401800,  //  006C  MOVE	R16	R12
+      0x7C380400,  //  006D  CALL	R14	2
+      0x28381B07,  //  006E  GE	R14	R13	K7
+      0x783A0002,  //  006F  JMPF	R14	#0073
+      0x8C381119,  //  0070  GETMET	R14	R8	K25
+      0x5C401A00,  //  0071  MOVE	R16	R13
+      0x7C380400,  //  0072  CALL	R14	2
+      0xB83A1A00,  //  0073  GETNGBL	R14	K13
+      0x8C381D10,  //  0074  GETMET	R14	R14	K16
+      0x60400018,  //  0075  GETGBL	R16	G24
+      0x5844001A,  //  0076  LDCONST	R17	K26
+      0x5C481800,  //  0077  MOVE	R18	R12
+      0x5C4C1A00,  //  0078  MOVE	R19	R13
+      0x7C400600,  //  0079  CALL	R16	3
+      0x58440012,  //  007A  LDCONST	R17	K18
+      0x7C380600,  //  007B  CALL	R14	3
+      0x8C381704,  //  007C  GETMET	R14	R11	K4
+      0x5840001B,  //  007D  LDCONST	R16	K27
+      0x7C380400,  //  007E  CALL	R14	2
+      0x783A0002,  //  007F  JMPF	R14	#0083
+      0x943C1D0A,  //  0080  GETIDX	R15	R14	K10
+      0x243C1F07,  //  0081  GT	R15	R15	K7
+      0x743E0000,  //  0082  JMPT	R15	#0084
+      0x503C0001,  //  0083  LDBOOL	R15	0	1
+      0x503C0200,  //  0084  LDBOOL	R15	1	0
+      0x60400008,  //  0085  GETGBL	R16	G8
+      0x5C440600,  //  0086  MOVE	R17	R3
+      0x7C400200,  //  0087  CALL	R16	1
+      0x60440013,  //  0088  GETGBL	R17	G19
+      0x7C440000,  //  0089  CALL	R17	0
+      0x783E0001,  //  008A  JMPF	R15	#008D
+      0x5848001C,  //  008B  LDCONST	R18	K28
+      0x70020000,  //  008C  JMP		#008E
+      0x5848001D,  //  008D  LDCONST	R18	K29
+      0x98461012,  //  008E  SETIDX	R17	K8	R18
+      0x98463A09,  //  008F  SETIDX	R17	K29	R9
+      0x98082011,  //  0090  SETIDX	R2	R16	R17
+      0x000C0701,  //  0091  ADD	R3	R3	K1
+      0x00241301,  //  0092  ADD	R9	R9	K1
+      0x7001FFB3,  //  0093  JMP		#0048
+      0x6024000C,  //  0094  GETGBL	R9	G12
+      0xB82A1A00,  //  0095  GETNGBL	R10	K13
+      0x8C28151E,  //  0096  GETMET	R10	R10	K30
+      0x7C280200,  //  0097  CALL	R10	1
+      0x7C240200,  //  0098  CALL	R9	1
+      0x58280007,  //  0099  LDCONST	R10	K7
+      0x78120000,  //  009A  JMPF	R4	#009C
+      0x04241301,  //  009B  SUB	R9	R9	K1
+      0x142C1409,  //  009C  LT	R11	R10	R9
+      0x782E0010,  //  009D  JMPF	R11	#00AF
+      0x8C2C1104,  //  009E  GETMET	R11	R8	K4
+      0x5C341400,  //  009F  MOVE	R13	R10
+      0x7C2C0400,  //  00A0  CALL	R11	2
+      0x4C300000,  //  00A1  LDNIL	R12
+      0x1C2C160C,  //  00A2  EQ	R11	R11	R12
+      0x782E0008,  //  00A3  JMPF	R11	#00AD
+      0x602C0008,  //  00A4  GETGBL	R11	G8
+      0x5C300600,  //  00A5  MOVE	R12	R3
+      0x7C2C0200,  //  00A6  CALL	R11	1
+      0x60300013,  //  00A7  GETGBL	R12	G19
+      0x7C300000,  //  00A8  CALL	R12	0
+      0x9832111F,  //  00A9  SETIDX	R12	K8	K31
+      0x98323E0A,  //  00AA  SETIDX	R12	K31	R10
+      0x9808160C,  //  00AB  SETIDX	R2	R11	R12
+      0x000C0701,  //  00AC  ADD	R3	R3	K1
+      0x00281501,  //  00AD  ADD	R10	R10	K1
+      0x7001FFEC,  //  00AE  JMP		#009C
+      0x8C2C0320,  //  00AF  GETMET	R11	R1	K32
+      0xB8361A00,  //  00B0  GETNGBL	R13	K13
+      0x8C341B21,  //  00B1  GETMET	R13	R13	K33
+      0x7C340200,  //  00B2  CALL	R13	1
+      0x7C2C0400,  //  00B3  CALL	R11	2
+      0x8C300122,  //  00B4  GETMET	R12	R0	K34
+      0x5C381600,  //  00B5  MOVE	R14	R11
+      0x7C300400,  //  00B6  CALL	R12	2
+      0x60340010,  //  00B7  GETGBL	R13	G16
+      0x5C381800,  //  00B8  MOVE	R14	R12
+      0x7C340200,  //  00B9  CALL	R13	1
+      0xA8020007,  //  00BA  EXBLK	0	#00C3
+      0x5C381A00,  //  00BB  MOVE	R14	R13
+      0x7C380000,  //  00BC  CALL	R14	0
+      0x603C0008,  //  00BD  GETGBL	R15	G8
+      0x5C400600,  //  00BE  MOVE	R16	R3
+      0x7C3C0200,  //  00BF  CALL	R15	1
+      0x98081E0E,  //  00C0  SETIDX	R2	R15	R14
+      0x000C0701,  //  00C1  ADD	R3	R3	K1
+      0x7001FFF7,  //  00C2  JMP		#00BB
+      0x58340023,  //  00C3  LDCONST	R13	K35
+      0xAC340200,  //  00C4  CATCH	R13	1	0
+      0xB0080000,  //  00C5  RAISE	2	R0	R0
+      0x80040400,  //  00C6  RET	1	R2
     })
   )
 );
@@ -4534,7 +4485,7 @@ be_local_closure(Matter_Device_autoconf_device_map,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_autoconf_device,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -4542,65 +4493,63 @@ be_local_closure(Matter_Device_autoconf_device,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(json),
-    /* K2   */  be_nested_str_weak(plugins),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(plugins_persist),
-    /* K5   */  be_nested_str_weak(plugins_config),
-    /* K6   */  be_nested_str_weak(autoconf_device_map),
-    /* K7   */  be_nested_str_weak(adjust_next_ep),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(_instantiate_plugins_from_config),
-    /* K13  */  be_nested_str_weak(sessions),
-    /* K14  */  be_nested_str_weak(count_active_fabrics),
-    /* K15  */  be_nested_str_weak(save_param),
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(plugins),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(plugins_persist),
+    /* K4   */  be_nested_str_weak(plugins_config),
+    /* K5   */  be_nested_str_weak(autoconf_device_map),
+    /* K6   */  be_nested_str_weak(adjust_next_ep),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(_instantiate_plugins_from_config),
+    /* K12  */  be_nested_str_weak(sessions),
+    /* K13  */  be_nested_str_weak(count_active_fabrics),
+    /* K14  */  be_nested_str_weak(save_param),
     }),
     be_str_weak(autoconf_device),
     &be_const_str_solidified,
-    ( &(const binstruction[38]) {  /* code */
+    ( &(const binstruction[37]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x88100102,  //  0003  GETMBR	R4	R0	K2
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x240C0703,  //  0005  GT	R3	R3	K3
-      0x780E0000,  //  0006  JMPF	R3	#0008
-      0x80000600,  //  0007  RET	0
-      0x880C0104,  //  0008  GETMBR	R3	R0	K4
-      0x740E000C,  //  0009  JMPT	R3	#0017
-      0x8C0C0106,  //  000A  GETMET	R3	R0	K6
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x90020A03,  //  000C  SETMBR	R0	K5	R3
-      0x8C0C0107,  //  000D  GETMET	R3	R0	K7
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0xB80E1000,  //  000F  GETNGBL	R3	K8
-      0x8C0C0709,  //  0010  GETMET	R3	R3	K9
-      0x60140008,  //  0011  GETGBL	R5	G8
-      0x88180105,  //  0012  GETMBR	R6	R0	K5
-      0x7C140200,  //  0013  CALL	R5	1
-      0x00161405,  //  0014  ADD	R5	K10	R5
-      0x5818000B,  //  0015  LDCONST	R6	K11
-      0x7C0C0600,  //  0016  CALL	R3	3
-      0x8C0C010C,  //  0017  GETMET	R3	R0	K12
-      0x88140105,  //  0018  GETMBR	R5	R0	K5
-      0x7C0C0400,  //  0019  CALL	R3	2
-      0x880C0104,  //  001A  GETMBR	R3	R0	K4
-      0x740E0008,  //  001B  JMPT	R3	#0025
-      0x880C010D,  //  001C  GETMBR	R3	R0	K13
-      0x8C0C070E,  //  001D  GETMET	R3	R3	K14
-      0x7C0C0200,  //  001E  CALL	R3	1
-      0x240C0703,  //  001F  GT	R3	R3	K3
-      0x780E0003,  //  0020  JMPF	R3	#0025
-      0x500C0200,  //  0021  LDBOOL	R3	1	0
-      0x90020803,  //  0022  SETMBR	R0	K4	R3
-      0x8C0C010F,  //  0023  GETMET	R3	R0	K15
-      0x7C0C0200,  //  0024  CALL	R3	1
-      0x80000000,  //  0025  RET	0
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x24080502,  //  0004  GT	R2	R2	K2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x80000400,  //  0006  RET	0
+      0x88080103,  //  0007  GETMBR	R2	R0	K3
+      0x740A000C,  //  0008  JMPT	R2	#0016
+      0x8C080105,  //  0009  GETMET	R2	R0	K5
+      0x7C080200,  //  000A  CALL	R2	1
+      0x90020802,  //  000B  SETMBR	R0	K4	R2
+      0x8C080106,  //  000C  GETMET	R2	R0	K6
+      0x7C080200,  //  000D  CALL	R2	1
+      0xB80A0E00,  //  000E  GETNGBL	R2	K7
+      0x8C080508,  //  000F  GETMET	R2	R2	K8
+      0x60100008,  //  0010  GETGBL	R4	G8
+      0x88140104,  //  0011  GETMBR	R5	R0	K4
+      0x7C100200,  //  0012  CALL	R4	1
+      0x00121204,  //  0013  ADD	R4	K9	R4
+      0x5814000A,  //  0014  LDCONST	R5	K10
+      0x7C080600,  //  0015  CALL	R2	3
+      0x8C08010B,  //  0016  GETMET	R2	R0	K11
+      0x88100104,  //  0017  GETMBR	R4	R0	K4
+      0x7C080400,  //  0018  CALL	R2	2
+      0x88080103,  //  0019  GETMBR	R2	R0	K3
+      0x740A0008,  //  001A  JMPT	R2	#0024
+      0x8808010C,  //  001B  GETMBR	R2	R0	K12
+      0x8C08050D,  //  001C  GETMET	R2	R2	K13
+      0x7C080200,  //  001D  CALL	R2	1
+      0x24080502,  //  001E  GT	R2	R2	K2
+      0x780A0003,  //  001F  JMPF	R2	#0024
+      0x50080200,  //  0020  LDBOOL	R2	1	0
+      0x90020602,  //  0021  SETMBR	R0	K3	R2
+      0x8C08010E,  //  0022  GETMET	R2	R0	K14
+      0x7C080200,  //  0023  CALL	R2	1
+      0x80000000,  //  0024  RET	0
     })
   )
 );
@@ -4994,7 +4943,7 @@ be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_mdns_announce_PASE,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    12,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -5002,291 +4951,288 @@ be_local_closure(Matter_Device_mdns_announce_PASE,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[43]) {     /* constants */
+    ( &(const bvalue[41]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(crypto),
-    /* K3   */  be_nested_str_weak(VP),
-    /* K4   */  be_nested_str_weak(vendorid),
-    /* K5   */  be_nested_str_weak(_X2B),
-    /* K6   */  be_nested_str_weak(productid),
-    /* K7   */  be_nested_str_weak(D),
-    /* K8   */  be_nested_str_weak(commissioning_discriminator),
-    /* K9   */  be_nested_str_weak(CM),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_nested_str_weak(T),
-    /* K12  */  be_const_int(0),
-    /* K13  */  be_nested_str_weak(SII),
-    /* K14  */  be_nested_str_weak(SAI),
-    /* K15  */  be_nested_str_weak(commissioning_instance_wifi),
-    /* K16  */  be_nested_str_weak(random),
-    /* K17  */  be_nested_str_weak(tohex),
-    /* K18  */  be_nested_str_weak(commissioning_instance_eth),
-    /* K19  */  be_nested_str_weak(hostname_eth),
-    /* K20  */  be_nested_str_weak(add_service),
-    /* K21  */  be_nested_str_weak(_matterc),
-    /* K22  */  be_nested_str_weak(_udp),
-    /* K23  */  be_nested_str_weak(mdns_pase_eth),
-    /* K24  */  be_nested_str_weak(tasmota),
-    /* K25  */  be_nested_str_weak(log),
-    /* K26  */  be_nested_str_weak(format),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20announce_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K28  */  be_nested_str_weak(eth),
-    /* K29  */  be_const_int(2),
-    /* K30  */  be_nested_str_weak(_L),
-    /* K31  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
-    /* K32  */  be_const_int(3),
-    /* K33  */  be_nested_str_weak(add_subtype),
-    /* K34  */  be_nested_str_weak(_S),
-    /* K35  */  be_nested_str_weak(_V),
-    /* K36  */  be_nested_str_weak(_CM1),
-    /* K37  */  be_nested_str_weak(hostname_wifi),
-    /* K38  */  be_nested_str_weak(mdns_pase_wifi),
-    /* K39  */  be_nested_str_weak(MTR_X3A_X20starting_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K40  */  be_nested_str_weak(wifi),
-    /* K41  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K42  */  be_nested_str_weak(_X7C),
+    /* K1   */  be_nested_str_weak(crypto),
+    /* K2   */  be_nested_str_weak(VP),
+    /* K3   */  be_nested_str_weak(vendorid),
+    /* K4   */  be_nested_str_weak(_X2B),
+    /* K5   */  be_nested_str_weak(productid),
+    /* K6   */  be_nested_str_weak(D),
+    /* K7   */  be_nested_str_weak(commissioning_discriminator),
+    /* K8   */  be_nested_str_weak(CM),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(T),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_weak(SII),
+    /* K13  */  be_nested_str_weak(SAI),
+    /* K14  */  be_nested_str_weak(commissioning_instance_wifi),
+    /* K15  */  be_nested_str_weak(random),
+    /* K16  */  be_nested_str_weak(tohex),
+    /* K17  */  be_nested_str_weak(commissioning_instance_eth),
+    /* K18  */  be_nested_str_weak(hostname_eth),
+    /* K19  */  be_nested_str_weak(add_service),
+    /* K20  */  be_nested_str_weak(_matterc),
+    /* K21  */  be_nested_str_weak(_udp),
+    /* K22  */  be_nested_str_weak(mdns_pase_eth),
+    /* K23  */  be_nested_str_weak(tasmota),
+    /* K24  */  be_nested_str_weak(log),
+    /* K25  */  be_nested_str_weak(MTR_X3A_X20announce_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K26  */  be_nested_str_weak(eth),
+    /* K27  */  be_const_int(2),
+    /* K28  */  be_nested_str_weak(_L),
+    /* K29  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
+    /* K30  */  be_const_int(3),
+    /* K31  */  be_nested_str_weak(add_subtype),
+    /* K32  */  be_nested_str_weak(_S),
+    /* K33  */  be_nested_str_weak(_V),
+    /* K34  */  be_nested_str_weak(_CM1),
+    /* K35  */  be_nested_str_weak(hostname_wifi),
+    /* K36  */  be_nested_str_weak(mdns_pase_wifi),
+    /* K37  */  be_nested_str_weak(MTR_X3A_X20starting_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K38  */  be_nested_str_weak(wifi),
+    /* K39  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K40  */  be_nested_str_weak(_X7C),
     }),
     be_str_weak(mdns_announce_PASE),
     &be_const_str_solidified,
-    ( &(const binstruction[237]) {  /* code */
+    ( &(const binstruction[236]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xA40E0400,  //  0002  IMPORT	R3	K2
-      0x60100013,  //  0003  GETGBL	R4	G19
-      0x7C100000,  //  0004  CALL	R4	0
-      0x60140008,  //  0005  GETGBL	R5	G8
-      0x88180104,  //  0006  GETMBR	R6	R0	K4
-      0x7C140200,  //  0007  CALL	R5	1
-      0x00140B05,  //  0008  ADD	R5	R5	K5
-      0x60180008,  //  0009  GETGBL	R6	G8
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x7C180200,  //  000B  CALL	R6	1
-      0x00140A06,  //  000C  ADD	R5	R5	R6
-      0x98120605,  //  000D  SETIDX	R4	K3	R5
-      0x88140108,  //  000E  GETMBR	R5	R0	K8
-      0x98120E05,  //  000F  SETIDX	R4	K7	R5
-      0x9812130A,  //  0010  SETIDX	R4	K9	K10
-      0x9812170C,  //  0011  SETIDX	R4	K11	K12
-      0x54161387,  //  0012  LDINT	R5	5000
-      0x98121A05,  //  0013  SETIDX	R4	K13	R5
-      0x5416012B,  //  0014  LDINT	R5	300
-      0x98121C05,  //  0015  SETIDX	R4	K14	R5
-      0x8C140710,  //  0016  GETMET	R5	R3	K16
-      0x541E0007,  //  0017  LDINT	R7	8
-      0x7C140400,  //  0018  CALL	R5	2
-      0x8C140B11,  //  0019  GETMET	R5	R5	K17
-      0x7C140200,  //  001A  CALL	R5	1
-      0x90021E05,  //  001B  SETMBR	R0	K15	R5
-      0x8C140710,  //  001C  GETMET	R5	R3	K16
-      0x541E0007,  //  001D  LDINT	R7	8
-      0x7C140400,  //  001E  CALL	R5	2
-      0x8C140B11,  //  001F  GETMET	R5	R5	K17
-      0x7C140200,  //  0020  CALL	R5	1
-      0x90022405,  //  0021  SETMBR	R0	K18	R5
-      0xA80200B7,  //  0022  EXBLK	0	#00DB
-      0x88140113,  //  0023  GETMBR	R5	R0	K19
-      0x78160058,  //  0024  JMPF	R5	#007E
-      0x8C140314,  //  0025  GETMET	R5	R1	K20
+      0x600C0013,  //  0002  GETGBL	R3	G19
+      0x7C0C0000,  //  0003  CALL	R3	0
+      0x60100008,  //  0004  GETGBL	R4	G8
+      0x88140103,  //  0005  GETMBR	R5	R0	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x00100904,  //  0007  ADD	R4	R4	K4
+      0x60140008,  //  0008  GETGBL	R5	G8
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x7C140200,  //  000A  CALL	R5	1
+      0x00100805,  //  000B  ADD	R4	R4	R5
+      0x980E0404,  //  000C  SETIDX	R3	K2	R4
+      0x88100107,  //  000D  GETMBR	R4	R0	K7
+      0x980E0C04,  //  000E  SETIDX	R3	K6	R4
+      0x980E1109,  //  000F  SETIDX	R3	K8	K9
+      0x980E150B,  //  0010  SETIDX	R3	K10	K11
+      0x54121387,  //  0011  LDINT	R4	5000
+      0x980E1804,  //  0012  SETIDX	R3	K12	R4
+      0x5412012B,  //  0013  LDINT	R4	300
+      0x980E1A04,  //  0014  SETIDX	R3	K13	R4
+      0x8C10050F,  //  0015  GETMET	R4	R2	K15
+      0x541A0007,  //  0016  LDINT	R6	8
+      0x7C100400,  //  0017  CALL	R4	2
+      0x8C100910,  //  0018  GETMET	R4	R4	K16
+      0x7C100200,  //  0019  CALL	R4	1
+      0x90021C04,  //  001A  SETMBR	R0	K14	R4
+      0x8C10050F,  //  001B  GETMET	R4	R2	K15
+      0x541A0007,  //  001C  LDINT	R6	8
+      0x7C100400,  //  001D  CALL	R4	2
+      0x8C100910,  //  001E  GETMET	R4	R4	K16
+      0x7C100200,  //  001F  CALL	R4	1
+      0x90022204,  //  0020  SETMBR	R0	K17	R4
+      0xA80200B7,  //  0021  EXBLK	0	#00DA
+      0x88100112,  //  0022  GETMBR	R4	R0	K18
+      0x78120058,  //  0023  JMPF	R4	#007D
+      0x8C100313,  //  0024  GETMET	R4	R1	K19
+      0x58180014,  //  0025  LDCONST	R6	K20
       0x581C0015,  //  0026  LDCONST	R7	K21
-      0x58200016,  //  0027  LDCONST	R8	K22
-      0x542615A3,  //  0028  LDINT	R9	5540
-      0x5C280800,  //  0029  MOVE	R10	R4
+      0x542215A3,  //  0027  LDINT	R8	5540
+      0x5C240600,  //  0028  MOVE	R9	R3
+      0x88280111,  //  0029  GETMBR	R10	R0	K17
       0x882C0112,  //  002A  GETMBR	R11	R0	K18
-      0x88300113,  //  002B  GETMBR	R12	R0	K19
-      0x7C140E00,  //  002C  CALL	R5	7
-      0x50140200,  //  002D  LDBOOL	R5	1	0
-      0x90022E05,  //  002E  SETMBR	R0	K23	R5
-      0xB8163000,  //  002F  GETNGBL	R5	K24
-      0x8C140B19,  //  0030  GETMET	R5	R5	K25
-      0x8C1C051A,  //  0031  GETMET	R7	R2	K26
-      0x5824001B,  //  0032  LDCONST	R9	K27
-      0x5828001C,  //  0033  LDCONST	R10	K28
-      0x882C0112,  //  0034  GETMBR	R11	R0	K18
-      0x88300113,  //  0035  GETMBR	R12	R0	K19
-      0x7C1C0A00,  //  0036  CALL	R7	5
-      0x5820001D,  //  0037  LDCONST	R8	K29
-      0x7C140600,  //  0038  CALL	R5	3
-      0x60140008,  //  0039  GETGBL	R5	G8
-      0x88180108,  //  003A  GETMBR	R6	R0	K8
-      0x541E0FFE,  //  003B  LDINT	R7	4095
-      0x2C180C07,  //  003C  AND	R6	R6	R7
-      0x7C140200,  //  003D  CALL	R5	1
-      0x00163C05,  //  003E  ADD	R5	K30	R5
-      0xB81A3000,  //  003F  GETNGBL	R6	K24
-      0x8C180D19,  //  0040  GETMET	R6	R6	K25
-      0x00223E05,  //  0041  ADD	R8	K31	R5
-      0x58240020,  //  0042  LDCONST	R9	K32
-      0x7C180600,  //  0043  CALL	R6	3
-      0x8C180321,  //  0044  GETMET	R6	R1	K33
+      0x7C100E00,  //  002B  CALL	R4	7
+      0x50100200,  //  002C  LDBOOL	R4	1	0
+      0x90022C04,  //  002D  SETMBR	R0	K22	R4
+      0xB8122E00,  //  002E  GETNGBL	R4	K23
+      0x8C100918,  //  002F  GETMET	R4	R4	K24
+      0x60180018,  //  0030  GETGBL	R6	G24
+      0x581C0019,  //  0031  LDCONST	R7	K25
+      0x5820001A,  //  0032  LDCONST	R8	K26
+      0x88240111,  //  0033  GETMBR	R9	R0	K17
+      0x88280112,  //  0034  GETMBR	R10	R0	K18
+      0x7C180800,  //  0035  CALL	R6	4
+      0x581C001B,  //  0036  LDCONST	R7	K27
+      0x7C100600,  //  0037  CALL	R4	3
+      0x60100008,  //  0038  GETGBL	R4	G8
+      0x88140107,  //  0039  GETMBR	R5	R0	K7
+      0x541A0FFE,  //  003A  LDINT	R6	4095
+      0x2C140A06,  //  003B  AND	R5	R5	R6
+      0x7C100200,  //  003C  CALL	R4	1
+      0x00123804,  //  003D  ADD	R4	K28	R4
+      0xB8162E00,  //  003E  GETNGBL	R5	K23
+      0x8C140B18,  //  003F  GETMET	R5	R5	K24
+      0x001E3A04,  //  0040  ADD	R7	K29	R4
+      0x5820001E,  //  0041  LDCONST	R8	K30
+      0x7C140600,  //  0042  CALL	R5	3
+      0x8C14031F,  //  0043  GETMET	R5	R1	K31
+      0x581C0014,  //  0044  LDCONST	R7	K20
       0x58200015,  //  0045  LDCONST	R8	K21
-      0x58240016,  //  0046  LDCONST	R9	K22
+      0x88240111,  //  0046  GETMBR	R9	R0	K17
       0x88280112,  //  0047  GETMBR	R10	R0	K18
-      0x882C0113,  //  0048  GETMBR	R11	R0	K19
-      0x5C300A00,  //  0049  MOVE	R12	R5
-      0x7C180C00,  //  004A  CALL	R6	6
-      0x60180008,  //  004B  GETGBL	R6	G8
-      0x881C0108,  //  004C  GETMBR	R7	R0	K8
-      0x54220EFF,  //  004D  LDINT	R8	3840
-      0x2C1C0E08,  //  004E  AND	R7	R7	R8
-      0x54220007,  //  004F  LDINT	R8	8
-      0x3C1C0E08,  //  0050  SHR	R7	R7	R8
-      0x7C180200,  //  0051  CALL	R6	1
-      0x001A4406,  //  0052  ADD	R6	K34	R6
-      0x5C140C00,  //  0053  MOVE	R5	R6
-      0xB81A3000,  //  0054  GETNGBL	R6	K24
-      0x8C180D19,  //  0055  GETMET	R6	R6	K25
-      0x00223E05,  //  0056  ADD	R8	K31	R5
-      0x58240020,  //  0057  LDCONST	R9	K32
-      0x7C180600,  //  0058  CALL	R6	3
-      0x8C180321,  //  0059  GETMET	R6	R1	K33
+      0x5C2C0800,  //  0048  MOVE	R11	R4
+      0x7C140C00,  //  0049  CALL	R5	6
+      0x60140008,  //  004A  GETGBL	R5	G8
+      0x88180107,  //  004B  GETMBR	R6	R0	K7
+      0x541E0EFF,  //  004C  LDINT	R7	3840
+      0x2C180C07,  //  004D  AND	R6	R6	R7
+      0x541E0007,  //  004E  LDINT	R7	8
+      0x3C180C07,  //  004F  SHR	R6	R6	R7
+      0x7C140200,  //  0050  CALL	R5	1
+      0x00164005,  //  0051  ADD	R5	K32	R5
+      0x5C100A00,  //  0052  MOVE	R4	R5
+      0xB8162E00,  //  0053  GETNGBL	R5	K23
+      0x8C140B18,  //  0054  GETMET	R5	R5	K24
+      0x001E3A04,  //  0055  ADD	R7	K29	R4
+      0x5820001E,  //  0056  LDCONST	R8	K30
+      0x7C140600,  //  0057  CALL	R5	3
+      0x8C14031F,  //  0058  GETMET	R5	R1	K31
+      0x581C0014,  //  0059  LDCONST	R7	K20
       0x58200015,  //  005A  LDCONST	R8	K21
-      0x58240016,  //  005B  LDCONST	R9	K22
+      0x88240111,  //  005B  GETMBR	R9	R0	K17
       0x88280112,  //  005C  GETMBR	R10	R0	K18
-      0x882C0113,  //  005D  GETMBR	R11	R0	K19
-      0x5C300A00,  //  005E  MOVE	R12	R5
-      0x7C180C00,  //  005F  CALL	R6	6
-      0x60180008,  //  0060  GETGBL	R6	G8
-      0x881C0104,  //  0061  GETMBR	R7	R0	K4
-      0x7C180200,  //  0062  CALL	R6	1
-      0x001A4606,  //  0063  ADD	R6	K35	R6
-      0x5C140C00,  //  0064  MOVE	R5	R6
-      0xB81A3000,  //  0065  GETNGBL	R6	K24
-      0x8C180D19,  //  0066  GETMET	R6	R6	K25
-      0x00223E05,  //  0067  ADD	R8	K31	R5
-      0x58240020,  //  0068  LDCONST	R9	K32
-      0x7C180600,  //  0069  CALL	R6	3
-      0x8C180321,  //  006A  GETMET	R6	R1	K33
+      0x5C2C0800,  //  005D  MOVE	R11	R4
+      0x7C140C00,  //  005E  CALL	R5	6
+      0x60140008,  //  005F  GETGBL	R5	G8
+      0x88180103,  //  0060  GETMBR	R6	R0	K3
+      0x7C140200,  //  0061  CALL	R5	1
+      0x00164205,  //  0062  ADD	R5	K33	R5
+      0x5C100A00,  //  0063  MOVE	R4	R5
+      0xB8162E00,  //  0064  GETNGBL	R5	K23
+      0x8C140B18,  //  0065  GETMET	R5	R5	K24
+      0x001E3A04,  //  0066  ADD	R7	K29	R4
+      0x5820001E,  //  0067  LDCONST	R8	K30
+      0x7C140600,  //  0068  CALL	R5	3
+      0x8C14031F,  //  0069  GETMET	R5	R1	K31
+      0x581C0014,  //  006A  LDCONST	R7	K20
       0x58200015,  //  006B  LDCONST	R8	K21
-      0x58240016,  //  006C  LDCONST	R9	K22
+      0x88240111,  //  006C  GETMBR	R9	R0	K17
       0x88280112,  //  006D  GETMBR	R10	R0	K18
-      0x882C0113,  //  006E  GETMBR	R11	R0	K19
-      0x5C300A00,  //  006F  MOVE	R12	R5
-      0x7C180C00,  //  0070  CALL	R6	6
-      0x58140024,  //  0071  LDCONST	R5	K36
-      0xB81A3000,  //  0072  GETNGBL	R6	K24
-      0x8C180D19,  //  0073  GETMET	R6	R6	K25
-      0x00223E05,  //  0074  ADD	R8	K31	R5
-      0x58240020,  //  0075  LDCONST	R9	K32
-      0x7C180600,  //  0076  CALL	R6	3
-      0x8C180321,  //  0077  GETMET	R6	R1	K33
+      0x5C2C0800,  //  006E  MOVE	R11	R4
+      0x7C140C00,  //  006F  CALL	R5	6
+      0x58100022,  //  0070  LDCONST	R4	K34
+      0xB8162E00,  //  0071  GETNGBL	R5	K23
+      0x8C140B18,  //  0072  GETMET	R5	R5	K24
+      0x001E3A04,  //  0073  ADD	R7	K29	R4
+      0x5820001E,  //  0074  LDCONST	R8	K30
+      0x7C140600,  //  0075  CALL	R5	3
+      0x8C14031F,  //  0076  GETMET	R5	R1	K31
+      0x581C0014,  //  0077  LDCONST	R7	K20
       0x58200015,  //  0078  LDCONST	R8	K21
-      0x58240016,  //  0079  LDCONST	R9	K22
+      0x88240111,  //  0079  GETMBR	R9	R0	K17
       0x88280112,  //  007A  GETMBR	R10	R0	K18
-      0x882C0113,  //  007B  GETMBR	R11	R0	K19
-      0x5C300A00,  //  007C  MOVE	R12	R5
-      0x7C180C00,  //  007D  CALL	R6	6
-      0x88140125,  //  007E  GETMBR	R5	R0	K37
-      0x78160058,  //  007F  JMPF	R5	#00D9
-      0x8C140314,  //  0080  GETMET	R5	R1	K20
+      0x5C2C0800,  //  007B  MOVE	R11	R4
+      0x7C140C00,  //  007C  CALL	R5	6
+      0x88100123,  //  007D  GETMBR	R4	R0	K35
+      0x78120058,  //  007E  JMPF	R4	#00D8
+      0x8C100313,  //  007F  GETMET	R4	R1	K19
+      0x58180014,  //  0080  LDCONST	R6	K20
       0x581C0015,  //  0081  LDCONST	R7	K21
-      0x58200016,  //  0082  LDCONST	R8	K22
-      0x542615A3,  //  0083  LDINT	R9	5540
-      0x5C280800,  //  0084  MOVE	R10	R4
-      0x882C010F,  //  0085  GETMBR	R11	R0	K15
-      0x88300125,  //  0086  GETMBR	R12	R0	K37
-      0x7C140E00,  //  0087  CALL	R5	7
-      0x50140200,  //  0088  LDBOOL	R5	1	0
-      0x90024C05,  //  0089  SETMBR	R0	K38	R5
-      0xB8163000,  //  008A  GETNGBL	R5	K24
-      0x8C140B19,  //  008B  GETMET	R5	R5	K25
-      0x8C1C051A,  //  008C  GETMET	R7	R2	K26
-      0x58240027,  //  008D  LDCONST	R9	K39
-      0x58280028,  //  008E  LDCONST	R10	K40
-      0x882C010F,  //  008F  GETMBR	R11	R0	K15
-      0x88300125,  //  0090  GETMBR	R12	R0	K37
-      0x7C1C0A00,  //  0091  CALL	R7	5
-      0x58200020,  //  0092  LDCONST	R8	K32
-      0x7C140600,  //  0093  CALL	R5	3
-      0x60140008,  //  0094  GETGBL	R5	G8
-      0x88180108,  //  0095  GETMBR	R6	R0	K8
-      0x541E0FFE,  //  0096  LDINT	R7	4095
-      0x2C180C07,  //  0097  AND	R6	R6	R7
-      0x7C140200,  //  0098  CALL	R5	1
-      0x00163C05,  //  0099  ADD	R5	K30	R5
-      0xB81A3000,  //  009A  GETNGBL	R6	K24
-      0x8C180D19,  //  009B  GETMET	R6	R6	K25
-      0x00223E05,  //  009C  ADD	R8	K31	R5
-      0x58240020,  //  009D  LDCONST	R9	K32
-      0x7C180600,  //  009E  CALL	R6	3
-      0x8C180321,  //  009F  GETMET	R6	R1	K33
+      0x542215A3,  //  0082  LDINT	R8	5540
+      0x5C240600,  //  0083  MOVE	R9	R3
+      0x8828010E,  //  0084  GETMBR	R10	R0	K14
+      0x882C0123,  //  0085  GETMBR	R11	R0	K35
+      0x7C100E00,  //  0086  CALL	R4	7
+      0x50100200,  //  0087  LDBOOL	R4	1	0
+      0x90024804,  //  0088  SETMBR	R0	K36	R4
+      0xB8122E00,  //  0089  GETNGBL	R4	K23
+      0x8C100918,  //  008A  GETMET	R4	R4	K24
+      0x60180018,  //  008B  GETGBL	R6	G24
+      0x581C0025,  //  008C  LDCONST	R7	K37
+      0x58200026,  //  008D  LDCONST	R8	K38
+      0x8824010E,  //  008E  GETMBR	R9	R0	K14
+      0x88280123,  //  008F  GETMBR	R10	R0	K35
+      0x7C180800,  //  0090  CALL	R6	4
+      0x581C001E,  //  0091  LDCONST	R7	K30
+      0x7C100600,  //  0092  CALL	R4	3
+      0x60100008,  //  0093  GETGBL	R4	G8
+      0x88140107,  //  0094  GETMBR	R5	R0	K7
+      0x541A0FFE,  //  0095  LDINT	R6	4095
+      0x2C140A06,  //  0096  AND	R5	R5	R6
+      0x7C100200,  //  0097  CALL	R4	1
+      0x00123804,  //  0098  ADD	R4	K28	R4
+      0xB8162E00,  //  0099  GETNGBL	R5	K23
+      0x8C140B18,  //  009A  GETMET	R5	R5	K24
+      0x001E3A04,  //  009B  ADD	R7	K29	R4
+      0x5820001E,  //  009C  LDCONST	R8	K30
+      0x7C140600,  //  009D  CALL	R5	3
+      0x8C14031F,  //  009E  GETMET	R5	R1	K31
+      0x581C0014,  //  009F  LDCONST	R7	K20
       0x58200015,  //  00A0  LDCONST	R8	K21
-      0x58240016,  //  00A1  LDCONST	R9	K22
-      0x8828010F,  //  00A2  GETMBR	R10	R0	K15
-      0x882C0125,  //  00A3  GETMBR	R11	R0	K37
-      0x5C300A00,  //  00A4  MOVE	R12	R5
-      0x7C180C00,  //  00A5  CALL	R6	6
-      0x60180008,  //  00A6  GETGBL	R6	G8
-      0x881C0108,  //  00A7  GETMBR	R7	R0	K8
-      0x54220EFF,  //  00A8  LDINT	R8	3840
-      0x2C1C0E08,  //  00A9  AND	R7	R7	R8
-      0x54220007,  //  00AA  LDINT	R8	8
-      0x3C1C0E08,  //  00AB  SHR	R7	R7	R8
-      0x7C180200,  //  00AC  CALL	R6	1
-      0x001A4406,  //  00AD  ADD	R6	K34	R6
-      0x5C140C00,  //  00AE  MOVE	R5	R6
-      0xB81A3000,  //  00AF  GETNGBL	R6	K24
-      0x8C180D19,  //  00B0  GETMET	R6	R6	K25
-      0x00223E05,  //  00B1  ADD	R8	K31	R5
-      0x58240020,  //  00B2  LDCONST	R9	K32
-      0x7C180600,  //  00B3  CALL	R6	3
-      0x8C180321,  //  00B4  GETMET	R6	R1	K33
+      0x8824010E,  //  00A1  GETMBR	R9	R0	K14
+      0x88280123,  //  00A2  GETMBR	R10	R0	K35
+      0x5C2C0800,  //  00A3  MOVE	R11	R4
+      0x7C140C00,  //  00A4  CALL	R5	6
+      0x60140008,  //  00A5  GETGBL	R5	G8
+      0x88180107,  //  00A6  GETMBR	R6	R0	K7
+      0x541E0EFF,  //  00A7  LDINT	R7	3840
+      0x2C180C07,  //  00A8  AND	R6	R6	R7
+      0x541E0007,  //  00A9  LDINT	R7	8
+      0x3C180C07,  //  00AA  SHR	R6	R6	R7
+      0x7C140200,  //  00AB  CALL	R5	1
+      0x00164005,  //  00AC  ADD	R5	K32	R5
+      0x5C100A00,  //  00AD  MOVE	R4	R5
+      0xB8162E00,  //  00AE  GETNGBL	R5	K23
+      0x8C140B18,  //  00AF  GETMET	R5	R5	K24
+      0x001E3A04,  //  00B0  ADD	R7	K29	R4
+      0x5820001E,  //  00B1  LDCONST	R8	K30
+      0x7C140600,  //  00B2  CALL	R5	3
+      0x8C14031F,  //  00B3  GETMET	R5	R1	K31
+      0x581C0014,  //  00B4  LDCONST	R7	K20
       0x58200015,  //  00B5  LDCONST	R8	K21
-      0x58240016,  //  00B6  LDCONST	R9	K22
-      0x8828010F,  //  00B7  GETMBR	R10	R0	K15
-      0x882C0125,  //  00B8  GETMBR	R11	R0	K37
-      0x5C300A00,  //  00B9  MOVE	R12	R5
-      0x7C180C00,  //  00BA  CALL	R6	6
-      0x60180008,  //  00BB  GETGBL	R6	G8
-      0x881C0104,  //  00BC  GETMBR	R7	R0	K4
-      0x7C180200,  //  00BD  CALL	R6	1
-      0x001A4606,  //  00BE  ADD	R6	K35	R6
-      0x5C140C00,  //  00BF  MOVE	R5	R6
-      0xB81A3000,  //  00C0  GETNGBL	R6	K24
-      0x8C180D19,  //  00C1  GETMET	R6	R6	K25
-      0x00223E05,  //  00C2  ADD	R8	K31	R5
-      0x58240020,  //  00C3  LDCONST	R9	K32
-      0x7C180600,  //  00C4  CALL	R6	3
-      0x8C180321,  //  00C5  GETMET	R6	R1	K33
+      0x8824010E,  //  00B6  GETMBR	R9	R0	K14
+      0x88280123,  //  00B7  GETMBR	R10	R0	K35
+      0x5C2C0800,  //  00B8  MOVE	R11	R4
+      0x7C140C00,  //  00B9  CALL	R5	6
+      0x60140008,  //  00BA  GETGBL	R5	G8
+      0x88180103,  //  00BB  GETMBR	R6	R0	K3
+      0x7C140200,  //  00BC  CALL	R5	1
+      0x00164205,  //  00BD  ADD	R5	K33	R5
+      0x5C100A00,  //  00BE  MOVE	R4	R5
+      0xB8162E00,  //  00BF  GETNGBL	R5	K23
+      0x8C140B18,  //  00C0  GETMET	R5	R5	K24
+      0x001E3A04,  //  00C1  ADD	R7	K29	R4
+      0x5820001E,  //  00C2  LDCONST	R8	K30
+      0x7C140600,  //  00C3  CALL	R5	3
+      0x8C14031F,  //  00C4  GETMET	R5	R1	K31
+      0x581C0014,  //  00C5  LDCONST	R7	K20
       0x58200015,  //  00C6  LDCONST	R8	K21
-      0x58240016,  //  00C7  LDCONST	R9	K22
-      0x8828010F,  //  00C8  GETMBR	R10	R0	K15
-      0x882C0125,  //  00C9  GETMBR	R11	R0	K37
-      0x5C300A00,  //  00CA  MOVE	R12	R5
-      0x7C180C00,  //  00CB  CALL	R6	6
-      0x58140024,  //  00CC  LDCONST	R5	K36
-      0xB81A3000,  //  00CD  GETNGBL	R6	K24
-      0x8C180D19,  //  00CE  GETMET	R6	R6	K25
-      0x00223E05,  //  00CF  ADD	R8	K31	R5
-      0x58240020,  //  00D0  LDCONST	R9	K32
-      0x7C180600,  //  00D1  CALL	R6	3
-      0x8C180321,  //  00D2  GETMET	R6	R1	K33
+      0x8824010E,  //  00C7  GETMBR	R9	R0	K14
+      0x88280123,  //  00C8  GETMBR	R10	R0	K35
+      0x5C2C0800,  //  00C9  MOVE	R11	R4
+      0x7C140C00,  //  00CA  CALL	R5	6
+      0x58100022,  //  00CB  LDCONST	R4	K34
+      0xB8162E00,  //  00CC  GETNGBL	R5	K23
+      0x8C140B18,  //  00CD  GETMET	R5	R5	K24
+      0x001E3A04,  //  00CE  ADD	R7	K29	R4
+      0x5820001E,  //  00CF  LDCONST	R8	K30
+      0x7C140600,  //  00D0  CALL	R5	3
+      0x8C14031F,  //  00D1  GETMET	R5	R1	K31
+      0x581C0014,  //  00D2  LDCONST	R7	K20
       0x58200015,  //  00D3  LDCONST	R8	K21
-      0x58240016,  //  00D4  LDCONST	R9	K22
-      0x8828010F,  //  00D5  GETMBR	R10	R0	K15
-      0x882C0125,  //  00D6  GETMBR	R11	R0	K37
-      0x5C300A00,  //  00D7  MOVE	R12	R5
-      0x7C180C00,  //  00D8  CALL	R6	6
-      0xA8040001,  //  00D9  EXBLK	1	1
-      0x70020010,  //  00DA  JMP		#00EC
-      0xAC140002,  //  00DB  CATCH	R5	0	2
-      0x7002000D,  //  00DC  JMP		#00EB
-      0xB81E3000,  //  00DD  GETNGBL	R7	K24
-      0x8C1C0F19,  //  00DE  GETMET	R7	R7	K25
-      0x60240008,  //  00DF  GETGBL	R9	G8
-      0x5C280A00,  //  00E0  MOVE	R10	R5
-      0x7C240200,  //  00E1  CALL	R9	1
-      0x00265209,  //  00E2  ADD	R9	K41	R9
-      0x0024132A,  //  00E3  ADD	R9	R9	K42
-      0x60280008,  //  00E4  GETGBL	R10	G8
-      0x5C2C0C00,  //  00E5  MOVE	R11	R6
-      0x7C280200,  //  00E6  CALL	R10	1
-      0x0024120A,  //  00E7  ADD	R9	R9	R10
-      0x5828001D,  //  00E8  LDCONST	R10	K29
-      0x7C1C0600,  //  00E9  CALL	R7	3
-      0x70020000,  //  00EA  JMP		#00EC
-      0xB0080000,  //  00EB  RAISE	2	R0	R0
-      0x80000000,  //  00EC  RET	0
+      0x8824010E,  //  00D4  GETMBR	R9	R0	K14
+      0x88280123,  //  00D5  GETMBR	R10	R0	K35
+      0x5C2C0800,  //  00D6  MOVE	R11	R4
+      0x7C140C00,  //  00D7  CALL	R5	6
+      0xA8040001,  //  00D8  EXBLK	1	1
+      0x70020010,  //  00D9  JMP		#00EB
+      0xAC100002,  //  00DA  CATCH	R4	0	2
+      0x7002000D,  //  00DB  JMP		#00EA
+      0xB81A2E00,  //  00DC  GETNGBL	R6	K23
+      0x8C180D18,  //  00DD  GETMET	R6	R6	K24
+      0x60200008,  //  00DE  GETGBL	R8	G8
+      0x5C240800,  //  00DF  MOVE	R9	R4
+      0x7C200200,  //  00E0  CALL	R8	1
+      0x00224E08,  //  00E1  ADD	R8	K39	R8
+      0x00201128,  //  00E2  ADD	R8	R8	K40
+      0x60240008,  //  00E3  GETGBL	R9	G8
+      0x5C280A00,  //  00E4  MOVE	R10	R5
+      0x7C240200,  //  00E5  CALL	R9	1
+      0x00201009,  //  00E6  ADD	R8	R8	R9
+      0x5824001B,  //  00E7  LDCONST	R9	K27
+      0x7C180600,  //  00E8  CALL	R6	3
+      0x70020000,  //  00E9  JMP		#00EB
+      0xB0080000,  //  00EA  RAISE	2	R0	R0
+      0x80000000,  //  00EB  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Fabric.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Fabric.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Fabric;
 ********************************************************************/
 be_local_closure(Matter_Fabric_counter_group_data_snd_next,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    7,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,54 +19,51 @@ be_local_closure(Matter_Fabric_counter_group_data_snd_next,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(_counter_group_data_snd_impl),
-    /* K2   */  be_nested_str_weak(next),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_data_snd_X3D_X25i),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(matter),
-    /* K9   */  be_nested_str_weak(Counter),
-    /* K10  */  be_nested_str_weak(is_greater),
-    /* K11  */  be_nested_str_weak(counter_group_data_snd),
-    /* K12  */  be_nested_str_weak(_GROUP_SND_INCR),
-    /* K13  */  be_nested_str_weak(does_persist),
-    /* K14  */  be_nested_str_weak(save),
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_counter_group_data_snd_impl),
+    /* K1   */  be_nested_str_weak(next),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_data_snd_X3D_X25i),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(matter),
+    /* K7   */  be_nested_str_weak(Counter),
+    /* K8   */  be_nested_str_weak(is_greater),
+    /* K9   */  be_nested_str_weak(counter_group_data_snd),
+    /* K10  */  be_nested_str_weak(_GROUP_SND_INCR),
+    /* K11  */  be_nested_str_weak(does_persist),
+    /* K12  */  be_nested_str_weak(save),
     }),
     be_str_weak(counter_group_data_snd_next),
     &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0xB80E0600,  //  0004  GETNGBL	R3	K3
-      0x8C0C0704,  //  0005  GETMET	R3	R3	K4
-      0x8C140305,  //  0006  GETMET	R5	R1	K5
-      0x581C0006,  //  0007  LDCONST	R7	K6
-      0x5C200400,  //  0008  MOVE	R8	R2
-      0x7C140600,  //  0009  CALL	R5	3
-      0x58180007,  //  000A  LDCONST	R6	K7
-      0x7C0C0600,  //  000B  CALL	R3	3
-      0xB80E1000,  //  000C  GETNGBL	R3	K8
-      0x880C0709,  //  000D  GETMBR	R3	R3	K9
-      0x8C0C070A,  //  000E  GETMET	R3	R3	K10
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x8818010B,  //  0010  GETMBR	R6	R0	K11
-      0x7C0C0600,  //  0011  CALL	R3	3
-      0x780E0007,  //  0012  JMPF	R3	#001B
-      0x880C010C,  //  0013  GETMBR	R3	R0	K12
-      0x000C0403,  //  0014  ADD	R3	R2	R3
-      0x90021603,  //  0015  SETMBR	R0	K11	R3
-      0x8C0C010D,  //  0016  GETMET	R3	R0	K13
-      0x7C0C0200,  //  0017  CALL	R3	1
-      0x780E0001,  //  0018  JMPF	R3	#001B
-      0x8C0C010E,  //  0019  GETMET	R3	R0	K14
-      0x7C0C0200,  //  001A  CALL	R3	1
-      0x80040400,  //  001B  RET	1	R2
+    ( &(const binstruction[27]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0xB80A0400,  //  0003  GETNGBL	R2	K2
+      0x8C080503,  //  0004  GETMET	R2	R2	K3
+      0x60100018,  //  0005  GETGBL	R4	G24
+      0x58140004,  //  0006  LDCONST	R5	K4
+      0x5C180200,  //  0007  MOVE	R6	R1
+      0x7C100400,  //  0008  CALL	R4	2
+      0x58140005,  //  0009  LDCONST	R5	K5
+      0x7C080600,  //  000A  CALL	R2	3
+      0xB80A0C00,  //  000B  GETNGBL	R2	K6
+      0x88080507,  //  000C  GETMBR	R2	R2	K7
+      0x8C080508,  //  000D  GETMET	R2	R2	K8
+      0x5C100200,  //  000E  MOVE	R4	R1
+      0x88140109,  //  000F  GETMBR	R5	R0	K9
+      0x7C080600,  //  0010  CALL	R2	3
+      0x780A0007,  //  0011  JMPF	R2	#001A
+      0x8808010A,  //  0012  GETMBR	R2	R0	K10
+      0x00080202,  //  0013  ADD	R2	R1	R2
+      0x90021202,  //  0014  SETMBR	R0	K9	R2
+      0x8C08010B,  //  0015  GETMET	R2	R0	K11
+      0x7C080200,  //  0016  CALL	R2	1
+      0x780A0001,  //  0017  JMPF	R2	#001A
+      0x8C08010C,  //  0018  GETMET	R2	R0	K12
+      0x7C080200,  //  0019  CALL	R2	1
+      0x80040200,  //  001A  RET	1	R1
     })
   )
 );
@@ -493,7 +490,7 @@ be_local_closure(Matter_Fabric_fabric_completed,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Fabric_counter_group_ctrl_snd_next,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    7,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -501,54 +498,51 @@ be_local_closure(Matter_Fabric_counter_group_ctrl_snd_next,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(_counter_group_ctrl_snd_impl),
-    /* K2   */  be_nested_str_weak(next),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_ctrl_snd_X3D_X25i),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(matter),
-    /* K9   */  be_nested_str_weak(Counter),
-    /* K10  */  be_nested_str_weak(is_greater),
-    /* K11  */  be_nested_str_weak(counter_group_ctrl_snd),
-    /* K12  */  be_nested_str_weak(_GROUP_SND_INCR),
-    /* K13  */  be_nested_str_weak(does_persist),
-    /* K14  */  be_nested_str_weak(save),
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_counter_group_ctrl_snd_impl),
+    /* K1   */  be_nested_str_weak(next),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_ctrl_snd_X3D_X25i),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(matter),
+    /* K7   */  be_nested_str_weak(Counter),
+    /* K8   */  be_nested_str_weak(is_greater),
+    /* K9   */  be_nested_str_weak(counter_group_ctrl_snd),
+    /* K10  */  be_nested_str_weak(_GROUP_SND_INCR),
+    /* K11  */  be_nested_str_weak(does_persist),
+    /* K12  */  be_nested_str_weak(save),
     }),
     be_str_weak(counter_group_ctrl_snd_next),
     &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0xB80E0600,  //  0004  GETNGBL	R3	K3
-      0x8C0C0704,  //  0005  GETMET	R3	R3	K4
-      0x8C140305,  //  0006  GETMET	R5	R1	K5
-      0x581C0006,  //  0007  LDCONST	R7	K6
-      0x5C200400,  //  0008  MOVE	R8	R2
-      0x7C140600,  //  0009  CALL	R5	3
-      0x58180007,  //  000A  LDCONST	R6	K7
-      0x7C0C0600,  //  000B  CALL	R3	3
-      0xB80E1000,  //  000C  GETNGBL	R3	K8
-      0x880C0709,  //  000D  GETMBR	R3	R3	K9
-      0x8C0C070A,  //  000E  GETMET	R3	R3	K10
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x8818010B,  //  0010  GETMBR	R6	R0	K11
-      0x7C0C0600,  //  0011  CALL	R3	3
-      0x780E0007,  //  0012  JMPF	R3	#001B
-      0x880C010C,  //  0013  GETMBR	R3	R0	K12
-      0x000C0403,  //  0014  ADD	R3	R2	R3
-      0x90021603,  //  0015  SETMBR	R0	K11	R3
-      0x8C0C010D,  //  0016  GETMET	R3	R0	K13
-      0x7C0C0200,  //  0017  CALL	R3	1
-      0x780E0001,  //  0018  JMPF	R3	#001B
-      0x8C0C010E,  //  0019  GETMET	R3	R0	K14
-      0x7C0C0200,  //  001A  CALL	R3	1
-      0x80040400,  //  001B  RET	1	R2
+    ( &(const binstruction[27]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0xB80A0400,  //  0003  GETNGBL	R2	K2
+      0x8C080503,  //  0004  GETMET	R2	R2	K3
+      0x60100018,  //  0005  GETGBL	R4	G24
+      0x58140004,  //  0006  LDCONST	R5	K4
+      0x5C180200,  //  0007  MOVE	R6	R1
+      0x7C100400,  //  0008  CALL	R4	2
+      0x58140005,  //  0009  LDCONST	R5	K5
+      0x7C080600,  //  000A  CALL	R2	3
+      0xB80A0C00,  //  000B  GETNGBL	R2	K6
+      0x88080507,  //  000C  GETMBR	R2	R2	K7
+      0x8C080508,  //  000D  GETMET	R2	R2	K8
+      0x5C100200,  //  000E  MOVE	R4	R1
+      0x88140109,  //  000F  GETMBR	R5	R0	K9
+      0x7C080600,  //  0010  CALL	R2	3
+      0x780A0007,  //  0011  JMPF	R2	#001A
+      0x8808010A,  //  0012  GETMBR	R2	R0	K10
+      0x00080202,  //  0013  ADD	R2	R1	R2
+      0x90021202,  //  0014  SETMBR	R0	K9	R2
+      0x8C08010B,  //  0015  GETMET	R2	R0	K11
+      0x7C080200,  //  0016  CALL	R2	1
+      0x780A0001,  //  0017  JMPF	R2	#001A
+      0x8C08010C,  //  0018  GETMET	R2	R0	K12
+      0x7C080200,  //  0019  CALL	R2	1
+      0x80040200,  //  001A  RET	1	R1
     })
   )
 );
@@ -587,7 +581,7 @@ be_local_closure(Matter_Fabric_get_ipk_epoch_key,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Fabric_tojson,   /* name */
   be_nested_proto(
-    18,                          /* nstack */
+    16,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -595,160 +589,157 @@ be_local_closure(Matter_Fabric_tojson,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
+    ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(introspect),
-    /* K3   */  be_nested_str_weak(persist_pre),
-    /* K4   */  be_nested_str_weak(members),
-    /* K5   */  be_nested_str_weak(get),
-    /* K6   */  be_nested_str_weak(function),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(_),
-    /* K9   */  be_nested_str_weak(push),
-    /* K10  */  be_nested_str_weak(stop_iteration),
-    /* K11  */  be_nested_str_weak(matter),
-    /* K12  */  be_nested_str_weak(sort),
-    /* K13  */  be_nested_str_weak(_X24_X24),
-    /* K14  */  be_nested_str_weak(tob64),
-    /* K15  */  be_nested_str_weak(format),
-    /* K16  */  be_nested_str_weak(_X25s_X3A_X25s),
-    /* K17  */  be_nested_str_weak(dump),
-    /* K18  */  be_nested_str_weak(_sessions),
-    /* K19  */  be_nested_str_weak(persistables),
-    /* K20  */  be_nested_str_weak(tojson),
-    /* K21  */  be_nested_str_weak(_X5B),
-    /* K22  */  be_nested_str_weak(concat),
-    /* K23  */  be_nested_str_weak(_X2C),
-    /* K24  */  be_nested_str_weak(_X5D),
-    /* K25  */  be_nested_str_weak(_X22_sessions_X22_X3A),
-    /* K26  */  be_nested_str_weak(persist_post),
-    /* K27  */  be_nested_str_weak(_X7B),
-    /* K28  */  be_nested_str_weak(_X7D),
+    /* K1   */  be_nested_str_weak(introspect),
+    /* K2   */  be_nested_str_weak(persist_pre),
+    /* K3   */  be_nested_str_weak(members),
+    /* K4   */  be_nested_str_weak(get),
+    /* K5   */  be_nested_str_weak(function),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(_),
+    /* K8   */  be_nested_str_weak(push),
+    /* K9   */  be_nested_str_weak(stop_iteration),
+    /* K10  */  be_nested_str_weak(matter),
+    /* K11  */  be_nested_str_weak(sort),
+    /* K12  */  be_nested_str_weak(_X24_X24),
+    /* K13  */  be_nested_str_weak(tob64),
+    /* K14  */  be_nested_str_weak(_X25s_X3A_X25s),
+    /* K15  */  be_nested_str_weak(dump),
+    /* K16  */  be_nested_str_weak(_sessions),
+    /* K17  */  be_nested_str_weak(persistables),
+    /* K18  */  be_nested_str_weak(tojson),
+    /* K19  */  be_nested_str_weak(_X5B),
+    /* K20  */  be_nested_str_weak(concat),
+    /* K21  */  be_nested_str_weak(_X2C),
+    /* K22  */  be_nested_str_weak(_X5D),
+    /* K23  */  be_nested_str_weak(_X22_sessions_X22_X3A),
+    /* K24  */  be_nested_str_weak(persist_post),
+    /* K25  */  be_nested_str_weak(_X7B),
+    /* K26  */  be_nested_str_weak(_X7D),
     }),
     be_str_weak(tojson),
     &be_const_str_solidified,
-    ( &(const binstruction[120]) {  /* code */
+    ( &(const binstruction[119]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xA40E0400,  //  0002  IMPORT	R3	K2
-      0x8C100103,  //  0003  GETMET	R4	R0	K3
-      0x7C100200,  //  0004  CALL	R4	1
-      0x60100012,  //  0005  GETGBL	R4	G18
-      0x7C100000,  //  0006  CALL	R4	0
-      0x60140010,  //  0007  GETGBL	R5	G16
-      0x8C180704,  //  0008  GETMET	R6	R3	K4
-      0x5C200000,  //  0009  MOVE	R8	R0
-      0x7C180400,  //  000A  CALL	R6	2
-      0x7C140200,  //  000B  CALL	R5	1
-      0xA8020011,  //  000C  EXBLK	0	#001F
-      0x5C180A00,  //  000D  MOVE	R6	R5
-      0x7C180000,  //  000E  CALL	R6	0
-      0x8C1C0705,  //  000F  GETMET	R7	R3	K5
-      0x5C240000,  //  0010  MOVE	R9	R0
-      0x5C280C00,  //  0011  MOVE	R10	R6
-      0x7C1C0600,  //  0012  CALL	R7	3
-      0x60200004,  //  0013  GETGBL	R8	G4
-      0x5C240E00,  //  0014  MOVE	R9	R7
-      0x7C200200,  //  0015  CALL	R8	1
-      0x20201106,  //  0016  NE	R8	R8	K6
-      0x78220005,  //  0017  JMPF	R8	#001E
-      0x94200D07,  //  0018  GETIDX	R8	R6	K7
-      0x20201108,  //  0019  NE	R8	R8	K8
-      0x78220002,  //  001A  JMPF	R8	#001E
-      0x8C200909,  //  001B  GETMET	R8	R4	K9
-      0x5C280C00,  //  001C  MOVE	R10	R6
-      0x7C200400,  //  001D  CALL	R8	2
-      0x7001FFED,  //  001E  JMP		#000D
-      0x5814000A,  //  001F  LDCONST	R5	K10
-      0xAC140200,  //  0020  CATCH	R5	1	0
-      0xB0080000,  //  0021  RAISE	2	R0	R0
-      0xB8161600,  //  0022  GETNGBL	R5	K11
-      0x8C140B0C,  //  0023  GETMET	R5	R5	K12
-      0x5C1C0800,  //  0024  MOVE	R7	R4
-      0x7C140400,  //  0025  CALL	R5	2
-      0x5C100A00,  //  0026  MOVE	R4	R5
-      0x60140012,  //  0027  GETGBL	R5	G18
-      0x7C140000,  //  0028  CALL	R5	0
-      0x60180010,  //  0029  GETGBL	R6	G16
-      0x5C1C0800,  //  002A  MOVE	R7	R4
-      0x7C180200,  //  002B  CALL	R6	1
-      0xA8020020,  //  002C  EXBLK	0	#004E
-      0x5C1C0C00,  //  002D  MOVE	R7	R6
-      0x7C1C0000,  //  002E  CALL	R7	0
-      0x8C200705,  //  002F  GETMET	R8	R3	K5
-      0x5C280000,  //  0030  MOVE	R10	R0
-      0x5C2C0E00,  //  0031  MOVE	R11	R7
-      0x7C200600,  //  0032  CALL	R8	3
-      0x4C240000,  //  0033  LDNIL	R9
-      0x1C241009,  //  0034  EQ	R9	R8	R9
-      0x78260000,  //  0035  JMPF	R9	#0037
-      0x7001FFF5,  //  0036  JMP		#002D
-      0x6024000F,  //  0037  GETGBL	R9	G15
-      0x5C281000,  //  0038  MOVE	R10	R8
-      0x602C0015,  //  0039  GETGBL	R11	G21
-      0x7C240400,  //  003A  CALL	R9	2
-      0x78260003,  //  003B  JMPF	R9	#0040
-      0x8C24110E,  //  003C  GETMET	R9	R8	K14
-      0x7C240200,  //  003D  CALL	R9	1
-      0x00261A09,  //  003E  ADD	R9	K13	R9
-      0x5C201200,  //  003F  MOVE	R8	R9
-      0x8C240B09,  //  0040  GETMET	R9	R5	K9
-      0x8C2C050F,  //  0041  GETMET	R11	R2	K15
-      0x58340010,  //  0042  LDCONST	R13	K16
-      0x8C380311,  //  0043  GETMET	R14	R1	K17
-      0x60400008,  //  0044  GETGBL	R16	G8
-      0x5C440E00,  //  0045  MOVE	R17	R7
-      0x7C400200,  //  0046  CALL	R16	1
-      0x7C380400,  //  0047  CALL	R14	2
-      0x8C3C0311,  //  0048  GETMET	R15	R1	K17
-      0x5C441000,  //  0049  MOVE	R17	R8
-      0x7C3C0400,  //  004A  CALL	R15	2
-      0x7C2C0800,  //  004B  CALL	R11	4
-      0x7C240400,  //  004C  CALL	R9	2
-      0x7001FFDE,  //  004D  JMP		#002D
-      0x5818000A,  //  004E  LDCONST	R6	K10
-      0xAC180200,  //  004F  CATCH	R6	1	0
-      0xB0080000,  //  0050  RAISE	2	R0	R0
-      0x60180012,  //  0051  GETGBL	R6	G18
-      0x7C180000,  //  0052  CALL	R6	0
-      0x601C0010,  //  0053  GETGBL	R7	G16
-      0x88200112,  //  0054  GETMBR	R8	R0	K18
-      0x8C201113,  //  0055  GETMET	R8	R8	K19
-      0x7C200200,  //  0056  CALL	R8	1
-      0x7C1C0200,  //  0057  CALL	R7	1
-      0xA8020006,  //  0058  EXBLK	0	#0060
-      0x5C200E00,  //  0059  MOVE	R8	R7
-      0x7C200000,  //  005A  CALL	R8	0
-      0x8C240D09,  //  005B  GETMET	R9	R6	K9
-      0x8C2C1114,  //  005C  GETMET	R11	R8	K20
-      0x7C2C0200,  //  005D  CALL	R11	1
-      0x7C240400,  //  005E  CALL	R9	2
-      0x7001FFF8,  //  005F  JMP		#0059
-      0x581C000A,  //  0060  LDCONST	R7	K10
-      0xAC1C0200,  //  0061  CATCH	R7	1	0
-      0xB0080000,  //  0062  RAISE	2	R0	R0
-      0x601C000C,  //  0063  GETGBL	R7	G12
-      0x5C200C00,  //  0064  MOVE	R8	R6
-      0x7C1C0200,  //  0065  CALL	R7	1
-      0x241C0F07,  //  0066  GT	R7	R7	K7
-      0x781E0007,  //  0067  JMPF	R7	#0070
-      0x8C1C0D16,  //  0068  GETMET	R7	R6	K22
-      0x58240017,  //  0069  LDCONST	R9	K23
-      0x7C1C0400,  //  006A  CALL	R7	2
-      0x001E2A07,  //  006B  ADD	R7	K21	R7
-      0x001C0F18,  //  006C  ADD	R7	R7	K24
-      0x8C200B09,  //  006D  GETMET	R8	R5	K9
-      0x002A3207,  //  006E  ADD	R10	K25	R7
-      0x7C200400,  //  006F  CALL	R8	2
-      0x8C1C011A,  //  0070  GETMET	R7	R0	K26
-      0x7C1C0200,  //  0071  CALL	R7	1
-      0x8C1C0B16,  //  0072  GETMET	R7	R5	K22
-      0x58240017,  //  0073  LDCONST	R9	K23
-      0x7C1C0400,  //  0074  CALL	R7	2
-      0x001E3607,  //  0075  ADD	R7	K27	R7
-      0x001C0F1C,  //  0076  ADD	R7	R7	K28
-      0x80040E00,  //  0077  RET	1	R7
+      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x600C0012,  //  0004  GETGBL	R3	G18
+      0x7C0C0000,  //  0005  CALL	R3	0
+      0x60100010,  //  0006  GETGBL	R4	G16
+      0x8C140503,  //  0007  GETMET	R5	R2	K3
+      0x5C1C0000,  //  0008  MOVE	R7	R0
+      0x7C140400,  //  0009  CALL	R5	2
+      0x7C100200,  //  000A  CALL	R4	1
+      0xA8020011,  //  000B  EXBLK	0	#001E
+      0x5C140800,  //  000C  MOVE	R5	R4
+      0x7C140000,  //  000D  CALL	R5	0
+      0x8C180504,  //  000E  GETMET	R6	R2	K4
+      0x5C200000,  //  000F  MOVE	R8	R0
+      0x5C240A00,  //  0010  MOVE	R9	R5
+      0x7C180600,  //  0011  CALL	R6	3
+      0x601C0004,  //  0012  GETGBL	R7	G4
+      0x5C200C00,  //  0013  MOVE	R8	R6
+      0x7C1C0200,  //  0014  CALL	R7	1
+      0x201C0F05,  //  0015  NE	R7	R7	K5
+      0x781E0005,  //  0016  JMPF	R7	#001D
+      0x941C0B06,  //  0017  GETIDX	R7	R5	K6
+      0x201C0F07,  //  0018  NE	R7	R7	K7
+      0x781E0002,  //  0019  JMPF	R7	#001D
+      0x8C1C0708,  //  001A  GETMET	R7	R3	K8
+      0x5C240A00,  //  001B  MOVE	R9	R5
+      0x7C1C0400,  //  001C  CALL	R7	2
+      0x7001FFED,  //  001D  JMP		#000C
+      0x58100009,  //  001E  LDCONST	R4	K9
+      0xAC100200,  //  001F  CATCH	R4	1	0
+      0xB0080000,  //  0020  RAISE	2	R0	R0
+      0xB8121400,  //  0021  GETNGBL	R4	K10
+      0x8C10090B,  //  0022  GETMET	R4	R4	K11
+      0x5C180600,  //  0023  MOVE	R6	R3
+      0x7C100400,  //  0024  CALL	R4	2
+      0x5C0C0800,  //  0025  MOVE	R3	R4
+      0x60100012,  //  0026  GETGBL	R4	G18
+      0x7C100000,  //  0027  CALL	R4	0
+      0x60140010,  //  0028  GETGBL	R5	G16
+      0x5C180600,  //  0029  MOVE	R6	R3
+      0x7C140200,  //  002A  CALL	R5	1
+      0xA8020020,  //  002B  EXBLK	0	#004D
+      0x5C180A00,  //  002C  MOVE	R6	R5
+      0x7C180000,  //  002D  CALL	R6	0
+      0x8C1C0504,  //  002E  GETMET	R7	R2	K4
+      0x5C240000,  //  002F  MOVE	R9	R0
+      0x5C280C00,  //  0030  MOVE	R10	R6
+      0x7C1C0600,  //  0031  CALL	R7	3
+      0x4C200000,  //  0032  LDNIL	R8
+      0x1C200E08,  //  0033  EQ	R8	R7	R8
+      0x78220000,  //  0034  JMPF	R8	#0036
+      0x7001FFF5,  //  0035  JMP		#002C
+      0x6020000F,  //  0036  GETGBL	R8	G15
+      0x5C240E00,  //  0037  MOVE	R9	R7
+      0x60280015,  //  0038  GETGBL	R10	G21
+      0x7C200400,  //  0039  CALL	R8	2
+      0x78220003,  //  003A  JMPF	R8	#003F
+      0x8C200F0D,  //  003B  GETMET	R8	R7	K13
+      0x7C200200,  //  003C  CALL	R8	1
+      0x00221808,  //  003D  ADD	R8	K12	R8
+      0x5C1C1000,  //  003E  MOVE	R7	R8
+      0x8C200908,  //  003F  GETMET	R8	R4	K8
+      0x60280018,  //  0040  GETGBL	R10	G24
+      0x582C000E,  //  0041  LDCONST	R11	K14
+      0x8C30030F,  //  0042  GETMET	R12	R1	K15
+      0x60380008,  //  0043  GETGBL	R14	G8
+      0x5C3C0C00,  //  0044  MOVE	R15	R6
+      0x7C380200,  //  0045  CALL	R14	1
+      0x7C300400,  //  0046  CALL	R12	2
+      0x8C34030F,  //  0047  GETMET	R13	R1	K15
+      0x5C3C0E00,  //  0048  MOVE	R15	R7
+      0x7C340400,  //  0049  CALL	R13	2
+      0x7C280600,  //  004A  CALL	R10	3
+      0x7C200400,  //  004B  CALL	R8	2
+      0x7001FFDE,  //  004C  JMP		#002C
+      0x58140009,  //  004D  LDCONST	R5	K9
+      0xAC140200,  //  004E  CATCH	R5	1	0
+      0xB0080000,  //  004F  RAISE	2	R0	R0
+      0x60140012,  //  0050  GETGBL	R5	G18
+      0x7C140000,  //  0051  CALL	R5	0
+      0x60180010,  //  0052  GETGBL	R6	G16
+      0x881C0110,  //  0053  GETMBR	R7	R0	K16
+      0x8C1C0F11,  //  0054  GETMET	R7	R7	K17
+      0x7C1C0200,  //  0055  CALL	R7	1
+      0x7C180200,  //  0056  CALL	R6	1
+      0xA8020006,  //  0057  EXBLK	0	#005F
+      0x5C1C0C00,  //  0058  MOVE	R7	R6
+      0x7C1C0000,  //  0059  CALL	R7	0
+      0x8C200B08,  //  005A  GETMET	R8	R5	K8
+      0x8C280F12,  //  005B  GETMET	R10	R7	K18
+      0x7C280200,  //  005C  CALL	R10	1
+      0x7C200400,  //  005D  CALL	R8	2
+      0x7001FFF8,  //  005E  JMP		#0058
+      0x58180009,  //  005F  LDCONST	R6	K9
+      0xAC180200,  //  0060  CATCH	R6	1	0
+      0xB0080000,  //  0061  RAISE	2	R0	R0
+      0x6018000C,  //  0062  GETGBL	R6	G12
+      0x5C1C0A00,  //  0063  MOVE	R7	R5
+      0x7C180200,  //  0064  CALL	R6	1
+      0x24180D06,  //  0065  GT	R6	R6	K6
+      0x781A0007,  //  0066  JMPF	R6	#006F
+      0x8C180B14,  //  0067  GETMET	R6	R5	K20
+      0x58200015,  //  0068  LDCONST	R8	K21
+      0x7C180400,  //  0069  CALL	R6	2
+      0x001A2606,  //  006A  ADD	R6	K19	R6
+      0x00180D16,  //  006B  ADD	R6	R6	K22
+      0x8C1C0908,  //  006C  GETMET	R7	R4	K8
+      0x00262E06,  //  006D  ADD	R9	K23	R6
+      0x7C1C0400,  //  006E  CALL	R7	2
+      0x8C180118,  //  006F  GETMET	R6	R0	K24
+      0x7C180200,  //  0070  CALL	R6	1
+      0x8C180914,  //  0071  GETMET	R6	R4	K20
+      0x58200015,  //  0072  LDCONST	R8	K21
+      0x7C180400,  //  0073  CALL	R6	2
+      0x001A3206,  //  0074  ADD	R6	K25	R6
+      0x00180D1A,  //  0075  ADD	R6	R6	K26
+      0x80040C00,  //  0076  RET	1	R6
     })
   )
 );
@@ -976,7 +967,7 @@ be_local_closure(Matter_Fabric_get_newest_session,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Fabric_before_remove,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    7,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -984,38 +975,35 @@ be_local_closure(Matter_Fabric_before_remove,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2DFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20_X28removed_X29),
-    /* K5   */  be_nested_str_weak(get_fabric_id),
-    /* K6   */  be_nested_str_weak(copy),
-    /* K7   */  be_nested_str_weak(reverse),
-    /* K8   */  be_nested_str_weak(tohex),
-    /* K9   */  be_const_int(3),
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2DFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20_X28removed_X29),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(copy),
+    /* K5   */  be_nested_str_weak(reverse),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_const_int(3),
     }),
     be_str_weak(before_remove),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x8C100303,  //  0003  GETMET	R4	R1	K3
-      0x58180004,  //  0004  LDCONST	R6	K4
-      0x8C1C0105,  //  0005  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0006  CALL	R7	1
-      0x8C1C0F06,  //  0007  GETMET	R7	R7	K6
-      0x7C1C0200,  //  0008  CALL	R7	1
-      0x8C1C0F07,  //  0009  GETMET	R7	R7	K7
-      0x7C1C0200,  //  000A  CALL	R7	1
-      0x8C1C0F08,  //  000B  GETMET	R7	R7	K8
-      0x7C1C0200,  //  000C  CALL	R7	1
-      0x7C100600,  //  000D  CALL	R4	3
-      0x58140009,  //  000E  LDCONST	R5	K9
-      0x7C080600,  //  000F  CALL	R2	3
-      0x80000000,  //  0010  RET	0
+    ( &(const binstruction[16]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x600C0018,  //  0002  GETGBL	R3	G24
+      0x58100002,  //  0003  LDCONST	R4	K2
+      0x8C140103,  //  0004  GETMET	R5	R0	K3
+      0x7C140200,  //  0005  CALL	R5	1
+      0x8C140B04,  //  0006  GETMET	R5	R5	K4
+      0x7C140200,  //  0007  CALL	R5	1
+      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0x7C140200,  //  0009  CALL	R5	1
+      0x8C140B06,  //  000A  GETMET	R5	R5	K6
+      0x7C140200,  //  000B  CALL	R5	1
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x58100007,  //  000D  LDCONST	R4	K7
+      0x7C040600,  //  000E  CALL	R1	3
+      0x80000000,  //  000F  RET	0
     })
   )
 );
@@ -1198,7 +1186,7 @@ be_local_closure(Matter_Fabric_hydrate_post,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Fabric_get_admin_vendor_name,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1206,18 +1194,16 @@ be_local_closure(Matter_Fabric_get_admin_vendor_name,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
+    ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(admin_vendor),
     /* K1   */  be_nested_str_weak(),
     /* K2   */  be_nested_str_weak(matter),
     /* K3   */  be_nested_str_weak(get_vendor_name),
-    /* K4   */  be_nested_str_weak(string),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(0x_X2504X),
+    /* K4   */  be_nested_str_weak(0x_X2504X),
     }),
     be_str_weak(get_admin_vendor_name),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
+    ( &(const binstruction[20]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x4C080000,  //  0001  LDNIL	R2
       0x1C080202,  //  0002  EQ	R2	R1	R2
@@ -1231,14 +1217,13 @@ be_local_closure(Matter_Fabric_get_admin_vendor_name,   /* name */
       0x200C0403,  //  000A  NE	R3	R2	R3
       0x780E0001,  //  000B  JMPF	R3	#000E
       0x80040400,  //  000C  RET	1	R2
-      0x70020005,  //  000D  JMP		#0014
-      0xA40E0800,  //  000E  IMPORT	R3	K4
-      0x8C100705,  //  000F  GETMET	R4	R3	K5
-      0x58180006,  //  0010  LDCONST	R6	K6
-      0x5C1C0200,  //  0011  MOVE	R7	R1
-      0x7C100600,  //  0012  CALL	R4	3
-      0x80040800,  //  0013  RET	1	R4
-      0x80000000,  //  0014  RET	0
+      0x70020004,  //  000D  JMP		#0013
+      0x600C0018,  //  000E  GETGBL	R3	G24
+      0x58100004,  //  000F  LDCONST	R4	K4
+      0x5C140200,  //  0010  MOVE	R5	R1
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x80040600,  //  0012  RET	1	R3
+      0x80000000,  //  0013  RET	0
     })
   )
 );
@@ -1333,7 +1318,7 @@ be_local_closure(Matter_Fabric_set_admin_subject_vendor,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Fabric_log_new_fabric,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    8,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1341,41 +1326,38 @@ be_local_closure(Matter_Fabric_log_new_fabric,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2BFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20vendorid_X3D_X25s),
-    /* K5   */  be_nested_str_weak(get_fabric_id),
-    /* K6   */  be_nested_str_weak(copy),
-    /* K7   */  be_nested_str_weak(reverse),
-    /* K8   */  be_nested_str_weak(tohex),
-    /* K9   */  be_nested_str_weak(get_admin_vendor_name),
-    /* K10  */  be_const_int(3),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2BFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20vendorid_X3D_X25s),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(copy),
+    /* K5   */  be_nested_str_weak(reverse),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_nested_str_weak(get_admin_vendor_name),
+    /* K8   */  be_const_int(3),
     }),
     be_str_weak(log_new_fabric),
     &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x8C100303,  //  0003  GETMET	R4	R1	K3
-      0x58180004,  //  0004  LDCONST	R6	K4
-      0x8C1C0105,  //  0005  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0006  CALL	R7	1
-      0x8C1C0F06,  //  0007  GETMET	R7	R7	K6
-      0x7C1C0200,  //  0008  CALL	R7	1
-      0x8C1C0F07,  //  0009  GETMET	R7	R7	K7
-      0x7C1C0200,  //  000A  CALL	R7	1
-      0x8C1C0F08,  //  000B  GETMET	R7	R7	K8
-      0x7C1C0200,  //  000C  CALL	R7	1
-      0x8C200109,  //  000D  GETMET	R8	R0	K9
-      0x7C200200,  //  000E  CALL	R8	1
-      0x7C100800,  //  000F  CALL	R4	4
-      0x5814000A,  //  0010  LDCONST	R5	K10
-      0x7C080600,  //  0011  CALL	R2	3
-      0x80000000,  //  0012  RET	0
+    ( &(const binstruction[18]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x600C0018,  //  0002  GETGBL	R3	G24
+      0x58100002,  //  0003  LDCONST	R4	K2
+      0x8C140103,  //  0004  GETMET	R5	R0	K3
+      0x7C140200,  //  0005  CALL	R5	1
+      0x8C140B04,  //  0006  GETMET	R5	R5	K4
+      0x7C140200,  //  0007  CALL	R5	1
+      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0x7C140200,  //  0009  CALL	R5	1
+      0x8C140B06,  //  000A  GETMET	R5	R5	K6
+      0x7C140200,  //  000B  CALL	R5	1
+      0x8C180107,  //  000C  GETMET	R6	R0	K7
+      0x7C180200,  //  000D  CALL	R6	1
+      0x7C0C0600,  //  000E  CALL	R3	3
+      0x58100008,  //  000F  LDCONST	R4	K8
+      0x7C040600,  //  0010  CALL	R1	3
+      0x80000000,  //  0011  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_async.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_async.h
@@ -507,7 +507,7 @@ be_local_closure(Matter_HTTP_async_parse_http_payload,   /* name */
 ********************************************************************/
 be_local_closure(Matter_HTTP_async_send_http,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    8,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -515,7 +515,7 @@ be_local_closure(Matter_HTTP_async_send_http,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
+    ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(response),
     /* K2   */  be_nested_str_weak(),
@@ -525,15 +525,14 @@ be_local_closure(Matter_HTTP_async_send_http,   /* name */
     /* K6   */  be_const_int(0),
     /* K7   */  be_nested_str_weak(_X5B),
     /* K8   */  be_nested_str_weak(_X5D),
-    /* K9   */  be_nested_str_weak(format),
-    /* K10  */  be_nested_str_weak(HTTP_GET),
-    /* K11  */  be_nested_str_weak(cmd),
-    /* K12  */  be_nested_str_weak(port),
-    /* K13  */  be_nested_str_weak(write),
-    /* K14  */  be_nested_str_weak(close),
-    /* K15  */  be_nested_str_weak(status),
-    /* K16  */  be_nested_str_weak(http_status),
-    /* K17  */  be_nested_str_weak(event_http_failed),
+    /* K9   */  be_nested_str_weak(HTTP_GET),
+    /* K10  */  be_nested_str_weak(cmd),
+    /* K11  */  be_nested_str_weak(port),
+    /* K12  */  be_nested_str_weak(write),
+    /* K13  */  be_nested_str_weak(close),
+    /* K14  */  be_nested_str_weak(status),
+    /* K15  */  be_nested_str_weak(http_status),
+    /* K16  */  be_nested_str_weak(event_http_failed),
     }),
     be_str_weak(send_http),
     &be_const_str_solidified,
@@ -550,13 +549,13 @@ be_local_closure(Matter_HTTP_async_send_http,   /* name */
       0x000E0E02,  //  0009  ADD	R3	K7	R2
       0x000C0708,  //  000A  ADD	R3	R3	K8
       0x5C080600,  //  000B  MOVE	R2	R3
-      0x8C0C0309,  //  000C  GETMET	R3	R1	K9
-      0x8814010A,  //  000D  GETMBR	R5	R0	K10
-      0x8818010B,  //  000E  GETMBR	R6	R0	K11
-      0x5C1C0400,  //  000F  MOVE	R7	R2
-      0x8820010C,  //  0010  GETMBR	R8	R0	K12
-      0x7C0C0A00,  //  0011  CALL	R3	5
-      0x8C10010D,  //  0012  GETMET	R4	R0	K13
+      0x600C0018,  //  000C  GETGBL	R3	G24
+      0x88100109,  //  000D  GETMBR	R4	R0	K9
+      0x8814010A,  //  000E  GETMBR	R5	R0	K10
+      0x5C180400,  //  000F  MOVE	R6	R2
+      0x881C010B,  //  0010  GETMBR	R7	R0	K11
+      0x7C0C0800,  //  0011  CALL	R3	4
+      0x8C10010C,  //  0012  GETMET	R4	R0	K12
       0x5C180600,  //  0013  MOVE	R6	R3
       0x7C100400,  //  0014  CALL	R4	2
       0x6014000C,  //  0015  GETGBL	R5	G12
@@ -564,13 +563,13 @@ be_local_closure(Matter_HTTP_async_send_http,   /* name */
       0x7C140200,  //  0017  CALL	R5	1
       0x20140805,  //  0018  NE	R5	R4	R5
       0x78160007,  //  0019  JMPF	R5	#0022
-      0x8C14010E,  //  001A  GETMET	R5	R0	K14
+      0x8C14010D,  //  001A  GETMET	R5	R0	K13
       0x7C140200,  //  001B  CALL	R5	1
       0x5415FFFB,  //  001C  LDINT	R5	-4
-      0x90021E05,  //  001D  SETMBR	R0	K15	R5
+      0x90021C05,  //  001D  SETMBR	R0	K14	R5
       0x5415FFFE,  //  001E  LDINT	R5	-1
-      0x90022005,  //  001F  SETMBR	R0	K16	R5
-      0x8C140111,  //  0020  GETMET	R5	R0	K17
+      0x90021E05,  //  001F  SETMBR	R0	K15	R5
+      0x8C140110,  //  0020  GETMET	R5	R0	K16
       0x7C140200,  //  0021  CALL	R5	1
       0x80000000,  //  0022  RET	0
     })

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_remote.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_remote.h
@@ -52,7 +52,7 @@ be_local_closure(Matter_HTTP_remote_device_is_alive,   /* name */
 ********************************************************************/
 be_local_closure(Matter_HTTP_remote_call_sync,   /* name */
   be_nested_proto(
-    17,                          /* nstack */
+    16,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -60,7 +60,7 @@ be_local_closure(Matter_HTTP_remote_call_sync,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
+    ( &(const bvalue[24]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(webserver),
     /* K2   */  be_nested_str_weak(tasmota),
@@ -73,19 +73,18 @@ be_local_closure(Matter_HTTP_remote_call_sync,   /* name */
     /* K9   */  be_nested_str_weak(_X20),
     /* K10  */  be_nested_str_weak(_X2B),
     /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(format),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20sync_X20request_X20_X27http_X3A_X2F_X2F_X25s_X3A_X25i_X25s_X27),
-    /* K14  */  be_nested_str_weak(addr),
-    /* K15  */  be_nested_str_weak(port),
-    /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(begin_sync),
-    /* K18  */  be_nested_str_weak(nil),
-    /* K19  */  be_const_int(0),
-    /* K20  */  be_nested_str_weak(_X2E_X2E_X2E),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20sync_X2Dresp_X20_X20in_X20_X25i_X20ms_X20from_X20_X25s_X3A_X20_X5B_X25i_X5D_X20_X27_X25s_X27),
-    /* K22  */  be_nested_str_weak(millis),
-    /* K23  */  be_nested_str_weak(time_start),
-    /* K24  */  be_nested_str_weak(payload),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20sync_X20request_X20_X27http_X3A_X2F_X2F_X25s_X3A_X25i_X25s_X27),
+    /* K13  */  be_nested_str_weak(addr),
+    /* K14  */  be_nested_str_weak(port),
+    /* K15  */  be_const_int(3),
+    /* K16  */  be_nested_str_weak(begin_sync),
+    /* K17  */  be_nested_str_weak(nil),
+    /* K18  */  be_const_int(0),
+    /* K19  */  be_nested_str_weak(_X2E_X2E_X2E),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20sync_X2Dresp_X20_X20in_X20_X25i_X20ms_X20from_X20_X25s_X3A_X20_X5B_X25i_X5D_X20_X27_X25s_X27),
+    /* K21  */  be_nested_str_weak(millis),
+    /* K22  */  be_nested_str_weak(time_start),
+    /* K23  */  be_nested_str_weak(payload),
     }),
     be_str_weak(call_sync),
     &be_const_str_solidified,
@@ -114,25 +113,25 @@ be_local_closure(Matter_HTTP_remote_call_sync,   /* name */
       0x00160E05,  //  0015  ADD	R5	K7	R5
       0xB81A0400,  //  0016  GETNGBL	R6	K2
       0x8C180D0B,  //  0017  GETMET	R6	R6	K11
-      0x8C20070C,  //  0018  GETMET	R8	R3	K12
-      0x5828000D,  //  0019  LDCONST	R10	K13
-      0x882C010E,  //  001A  GETMBR	R11	R0	K14
-      0x8830010F,  //  001B  GETMBR	R12	R0	K15
-      0x5C340A00,  //  001C  MOVE	R13	R5
-      0x7C200A00,  //  001D  CALL	R8	5
-      0x58240010,  //  001E  LDCONST	R9	K16
+      0x60200018,  //  0018  GETGBL	R8	G24
+      0x5824000C,  //  0019  LDCONST	R9	K12
+      0x8828010D,  //  001A  GETMBR	R10	R0	K13
+      0x882C010E,  //  001B  GETMBR	R11	R0	K14
+      0x5C300A00,  //  001C  MOVE	R12	R5
+      0x7C200800,  //  001D  CALL	R8	4
+      0x5824000F,  //  001E  LDCONST	R9	K15
       0x7C180600,  //  001F  CALL	R6	3
       0x60180003,  //  0020  GETGBL	R6	G3
       0x5C1C0000,  //  0021  MOVE	R7	R0
       0x7C180200,  //  0022  CALL	R6	1
-      0x8C180D11,  //  0023  GETMET	R6	R6	K17
+      0x8C180D10,  //  0023  GETMET	R6	R6	K16
       0x5C200A00,  //  0024  MOVE	R8	R5
       0x5C240400,  //  0025  MOVE	R9	R2
       0x7C180600,  //  0026  CALL	R6	3
       0x781A0001,  //  0027  JMPF	R6	#002A
       0x5C1C0C00,  //  0028  MOVE	R7	R6
       0x70020000,  //  0029  JMP		#002B
-      0x581C0012,  //  002A  LDCONST	R7	K18
+      0x581C0011,  //  002A  LDCONST	R7	K17
       0x6020000C,  //  002B  GETGBL	R8	G12
       0x5C240E00,  //  002C  MOVE	R9	R7
       0x7C200200,  //  002D  CALL	R8	1
@@ -140,26 +139,26 @@ be_local_closure(Matter_HTTP_remote_call_sync,   /* name */
       0x24201009,  //  002F  GT	R8	R8	R9
       0x78220004,  //  0030  JMPF	R8	#0036
       0x5422001C,  //  0031  LDINT	R8	29
-      0x40222608,  //  0032  CONNECT	R8	K19	R8
+      0x40222408,  //  0032  CONNECT	R8	K18	R8
       0x94200E08,  //  0033  GETIDX	R8	R7	R8
-      0x00201114,  //  0034  ADD	R8	R8	K20
+      0x00201113,  //  0034  ADD	R8	R8	K19
       0x5C1C1000,  //  0035  MOVE	R7	R8
       0xB8220400,  //  0036  GETNGBL	R8	K2
       0x8C20110B,  //  0037  GETMET	R8	R8	K11
-      0x8C28070C,  //  0038  GETMET	R10	R3	K12
-      0x58300015,  //  0039  LDCONST	R12	K21
-      0xB8360400,  //  003A  GETNGBL	R13	K2
-      0x8C341B16,  //  003B  GETMET	R13	R13	K22
-      0x7C340200,  //  003C  CALL	R13	1
-      0x88380117,  //  003D  GETMBR	R14	R0	K23
-      0x04341A0E,  //  003E  SUB	R13	R13	R14
-      0x8838010E,  //  003F  GETMBR	R14	R0	K14
-      0x603C000C,  //  0040  GETGBL	R15	G12
-      0x88400118,  //  0041  GETMBR	R16	R0	K24
-      0x7C3C0200,  //  0042  CALL	R15	1
-      0x5C400E00,  //  0043  MOVE	R16	R7
-      0x7C280C00,  //  0044  CALL	R10	6
-      0x582C0010,  //  0045  LDCONST	R11	K16
+      0x60280018,  //  0038  GETGBL	R10	G24
+      0x582C0014,  //  0039  LDCONST	R11	K20
+      0xB8320400,  //  003A  GETNGBL	R12	K2
+      0x8C301915,  //  003B  GETMET	R12	R12	K21
+      0x7C300200,  //  003C  CALL	R12	1
+      0x88340116,  //  003D  GETMBR	R13	R0	K22
+      0x0430180D,  //  003E  SUB	R12	R12	R13
+      0x8834010D,  //  003F  GETMBR	R13	R0	K13
+      0x6038000C,  //  0040  GETGBL	R14	G12
+      0x883C0117,  //  0041  GETMBR	R15	R0	K23
+      0x7C380200,  //  0042  CALL	R14	1
+      0x5C3C0E00,  //  0043  MOVE	R15	R7
+      0x7C280A00,  //  0044  CALL	R10	5
+      0x582C000F,  //  0045  LDCONST	R11	K15
       0x7C200600,  //  0046  CALL	R8	3
       0x80040C00,  //  0047  RET	1	R6
     })
@@ -173,7 +172,7 @@ be_local_closure(Matter_HTTP_remote_call_sync,   /* name */
 ********************************************************************/
 be_local_closure(Matter_HTTP_remote_web_last_seen,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -181,38 +180,36 @@ be_local_closure(Matter_HTTP_remote_web_last_seen,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
+    ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(reachable_utc),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(rtc),
-    /* K5   */  be_nested_str_weak(utc),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(seconds_to_dhm),
+    /* K1   */  be_nested_str_weak(reachable_utc),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(rtc),
+    /* K4   */  be_nested_str_weak(utc),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(seconds_to_dhm),
     }),
     be_str_weak(web_last_seen),
     &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
+    ( &(const binstruction[18]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x540DFFFE,  //  0002  LDINT	R3	-1
-      0x88100102,  //  0003  GETMBR	R4	R0	K2
-      0x4C140000,  //  0004  LDNIL	R5
-      0x20100805,  //  0005  NE	R4	R4	R5
-      0x78120006,  //  0006  JMPF	R4	#000E
-      0xB8120600,  //  0007  GETNGBL	R4	K3
-      0x8C100904,  //  0008  GETMET	R4	R4	K4
-      0x7C100200,  //  0009  CALL	R4	1
-      0x94100905,  //  000A  GETIDX	R4	R4	K5
-      0x88140102,  //  000B  GETMBR	R5	R0	K2
-      0x04100805,  //  000C  SUB	R4	R4	R5
-      0x5C0C0800,  //  000D  MOVE	R3	R4
-      0xB8120C00,  //  000E  GETNGBL	R4	K6
-      0x8C100907,  //  000F  GETMET	R4	R4	K7
-      0x5C180600,  //  0010  MOVE	R6	R3
-      0x7C100400,  //  0011  CALL	R4	2
-      0x80040800,  //  0012  RET	1	R4
+      0x5409FFFE,  //  0001  LDINT	R2	-1
+      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x4C100000,  //  0003  LDNIL	R4
+      0x200C0604,  //  0004  NE	R3	R3	R4
+      0x780E0006,  //  0005  JMPF	R3	#000D
+      0xB80E0400,  //  0006  GETNGBL	R3	K2
+      0x8C0C0703,  //  0007  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x940C0704,  //  0009  GETIDX	R3	R3	K4
+      0x88100101,  //  000A  GETMBR	R4	R0	K1
+      0x040C0604,  //  000B  SUB	R3	R3	R4
+      0x5C080600,  //  000C  MOVE	R2	R3
+      0xB80E0A00,  //  000D  GETNGBL	R3	K5
+      0x8C0C0706,  //  000E  GETMET	R3	R3	K6
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x80040600,  //  0011  RET	1	R3
     })
   )
 );
@@ -380,7 +377,7 @@ be_local_closure(Matter_HTTP_remote_scheduler,   /* name */
 ********************************************************************/
 be_local_closure(Matter_HTTP_remote_event_http_finished,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -388,73 +385,70 @@ be_local_closure(Matter_HTTP_remote_event_http_finished,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
+    ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(current_cmd),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(payload),
-    /* K3   */  be_nested_str_weak(nil),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(_X2E_X2E_X2E),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(format),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20async_X2Dresp_X20in_X20_X25i_X20ms_X20from_X20_X25s_X3A_X20_X5B_X25i_X5D_X20_X27_X25s_X27),
-    /* K10  */  be_nested_str_weak(millis),
-    /* K11  */  be_nested_str_weak(time_start),
-    /* K12  */  be_nested_str_weak(addr),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(dispatch_cb),
-    /* K15  */  be_nested_str_weak(http_status),
+    /* K1   */  be_nested_str_weak(payload),
+    /* K2   */  be_nested_str_weak(nil),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(_X2E_X2E_X2E),
+    /* K5   */  be_nested_str_weak(tasmota),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20async_X2Dresp_X20in_X20_X25i_X20ms_X20from_X20_X25s_X3A_X20_X5B_X25i_X5D_X20_X27_X25s_X27),
+    /* K8   */  be_nested_str_weak(millis),
+    /* K9   */  be_nested_str_weak(time_start),
+    /* K10  */  be_nested_str_weak(addr),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(dispatch_cb),
+    /* K13  */  be_nested_str_weak(http_status),
     }),
     be_str_weak(event_http_finished),
     &be_const_str_solidified,
-    ( &(const binstruction[46]) {  /* code */
+    ( &(const binstruction[45]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060000,  //  0003  JMPF	R1	#0005
       0x80000200,  //  0004  RET	0
-      0xA4060200,  //  0005  IMPORT	R1	K1
-      0x88080102,  //  0006  GETMBR	R2	R0	K2
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x20080403,  //  0008  NE	R2	R2	R3
-      0x780A0001,  //  0009  JMPF	R2	#000C
-      0x88080102,  //  000A  GETMBR	R2	R0	K2
-      0x70020000,  //  000B  JMP		#000D
-      0x58080003,  //  000C  LDCONST	R2	K3
-      0x600C000C,  //  000D  GETGBL	R3	G12
-      0x5C100400,  //  000E  MOVE	R4	R2
-      0x7C0C0200,  //  000F  CALL	R3	1
-      0x5412001D,  //  0010  LDINT	R4	30
-      0x240C0604,  //  0011  GT	R3	R3	R4
-      0x780E0004,  //  0012  JMPF	R3	#0018
-      0x540E001C,  //  0013  LDINT	R3	29
-      0x400E0803,  //  0014  CONNECT	R3	K4	R3
-      0x940C0403,  //  0015  GETIDX	R3	R2	R3
-      0x000C0705,  //  0016  ADD	R3	R3	K5
-      0x5C080600,  //  0017  MOVE	R2	R3
-      0xB80E0C00,  //  0018  GETNGBL	R3	K6
-      0x8C0C0707,  //  0019  GETMET	R3	R3	K7
-      0x8C140308,  //  001A  GETMET	R5	R1	K8
-      0x581C0009,  //  001B  LDCONST	R7	K9
-      0xB8220C00,  //  001C  GETNGBL	R8	K6
-      0x8C20110A,  //  001D  GETMET	R8	R8	K10
-      0x7C200200,  //  001E  CALL	R8	1
-      0x8824010B,  //  001F  GETMBR	R9	R0	K11
-      0x04201009,  //  0020  SUB	R8	R8	R9
-      0x8824010C,  //  0021  GETMBR	R9	R0	K12
-      0x6028000C,  //  0022  GETGBL	R10	G12
-      0x882C0102,  //  0023  GETMBR	R11	R0	K2
-      0x7C280200,  //  0024  CALL	R10	1
-      0x5C2C0400,  //  0025  MOVE	R11	R2
-      0x7C140C00,  //  0026  CALL	R5	6
-      0x5818000D,  //  0027  LDCONST	R6	K13
-      0x7C0C0600,  //  0028  CALL	R3	3
-      0x8C0C010E,  //  0029  GETMET	R3	R0	K14
-      0x8814010F,  //  002A  GETMBR	R5	R0	K15
-      0x88180102,  //  002B  GETMBR	R6	R0	K2
-      0x7C0C0600,  //  002C  CALL	R3	3
-      0x80000000,  //  002D  RET	0
+      0x88040101,  //  0005  GETMBR	R1	R0	K1
+      0x4C080000,  //  0006  LDNIL	R2
+      0x20040202,  //  0007  NE	R1	R1	R2
+      0x78060001,  //  0008  JMPF	R1	#000B
+      0x88040101,  //  0009  GETMBR	R1	R0	K1
+      0x70020000,  //  000A  JMP		#000C
+      0x58040002,  //  000B  LDCONST	R1	K2
+      0x6008000C,  //  000C  GETGBL	R2	G12
+      0x5C0C0200,  //  000D  MOVE	R3	R1
+      0x7C080200,  //  000E  CALL	R2	1
+      0x540E001D,  //  000F  LDINT	R3	30
+      0x24080403,  //  0010  GT	R2	R2	R3
+      0x780A0004,  //  0011  JMPF	R2	#0017
+      0x540A001C,  //  0012  LDINT	R2	29
+      0x400A0602,  //  0013  CONNECT	R2	K3	R2
+      0x94080202,  //  0014  GETIDX	R2	R1	R2
+      0x00080504,  //  0015  ADD	R2	R2	K4
+      0x5C040400,  //  0016  MOVE	R1	R2
+      0xB80A0A00,  //  0017  GETNGBL	R2	K5
+      0x8C080506,  //  0018  GETMET	R2	R2	K6
+      0x60100018,  //  0019  GETGBL	R4	G24
+      0x58140007,  //  001A  LDCONST	R5	K7
+      0xB81A0A00,  //  001B  GETNGBL	R6	K5
+      0x8C180D08,  //  001C  GETMET	R6	R6	K8
+      0x7C180200,  //  001D  CALL	R6	1
+      0x881C0109,  //  001E  GETMBR	R7	R0	K9
+      0x04180C07,  //  001F  SUB	R6	R6	R7
+      0x881C010A,  //  0020  GETMBR	R7	R0	K10
+      0x6020000C,  //  0021  GETGBL	R8	G12
+      0x88240101,  //  0022  GETMBR	R9	R0	K1
+      0x7C200200,  //  0023  CALL	R8	1
+      0x5C240200,  //  0024  MOVE	R9	R1
+      0x7C100A00,  //  0025  CALL	R4	5
+      0x5814000B,  //  0026  LDCONST	R5	K11
+      0x7C080600,  //  0027  CALL	R2	3
+      0x8C08010C,  //  0028  GETMET	R2	R0	K12
+      0x8810010D,  //  0029  GETMBR	R4	R0	K13
+      0x88140101,  //  002A  GETMBR	R5	R0	K1
+      0x7C080600,  //  002B  CALL	R2	3
+      0x80000000,  //  002C  RET	0
     })
   )
 );
@@ -466,7 +460,7 @@ be_local_closure(Matter_HTTP_remote_event_http_finished,   /* name */
 ********************************************************************/
 be_local_closure(Matter_HTTP_remote_probe_async,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    12,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -474,7 +468,7 @@ be_local_closure(Matter_HTTP_remote_probe_async,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
+    ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(webserver),
     /* K2   */  be_nested_str_weak(tasmota),
@@ -487,12 +481,11 @@ be_local_closure(Matter_HTTP_remote_probe_async,   /* name */
     /* K9   */  be_nested_str_weak(_X20),
     /* K10  */  be_nested_str_weak(_X2B),
     /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(format),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20async_X20request_X20_X27http_X3A_X2F_X2F_X25s_X3A_X25i_X25s_X27),
-    /* K14  */  be_nested_str_weak(addr),
-    /* K15  */  be_nested_str_weak(port),
-    /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(begin),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20async_X20request_X20_X27http_X3A_X2F_X2F_X25s_X3A_X25i_X25s_X27),
+    /* K13  */  be_nested_str_weak(addr),
+    /* K14  */  be_nested_str_weak(port),
+    /* K15  */  be_const_int(3),
+    /* K16  */  be_nested_str_weak(begin),
     }),
     be_str_weak(probe_async),
     &be_const_str_solidified,
@@ -520,15 +513,15 @@ be_local_closure(Matter_HTTP_remote_probe_async,   /* name */
       0x00120E04,  //  0014  ADD	R4	K7	R4
       0xB8160400,  //  0015  GETNGBL	R5	K2
       0x8C140B0B,  //  0016  GETMET	R5	R5	K11
-      0x8C1C050C,  //  0017  GETMET	R7	R2	K12
-      0x5824000D,  //  0018  LDCONST	R9	K13
-      0x8828010E,  //  0019  GETMBR	R10	R0	K14
-      0x882C010F,  //  001A  GETMBR	R11	R0	K15
-      0x5C300800,  //  001B  MOVE	R12	R4
-      0x7C1C0A00,  //  001C  CALL	R7	5
-      0x58200010,  //  001D  LDCONST	R8	K16
+      0x601C0018,  //  0017  GETGBL	R7	G24
+      0x5820000C,  //  0018  LDCONST	R8	K12
+      0x8824010D,  //  0019  GETMBR	R9	R0	K13
+      0x8828010E,  //  001A  GETMBR	R10	R0	K14
+      0x5C2C0800,  //  001B  MOVE	R11	R4
+      0x7C1C0800,  //  001C  CALL	R7	4
+      0x5820000F,  //  001D  LDCONST	R8	K15
       0x7C140600,  //  001E  CALL	R5	3
-      0x8C140111,  //  001F  GETMET	R5	R0	K17
+      0x8C140110,  //  001F  GETMET	R5	R0	K16
       0x5C1C0800,  //  0020  MOVE	R7	R4
       0x7C140400,  //  0021  CALL	R5	2
       0x80000000,  //  0022  RET	0
@@ -642,7 +635,7 @@ be_local_closure(Matter_HTTP_remote_event_http_failed,   /* name */
 ********************************************************************/
 be_local_closure(Matter_HTTP_remote_event_http_timeout,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -650,47 +643,44 @@ be_local_closure(Matter_HTTP_remote_event_http_timeout,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(current_cmd),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20timeout_X20http_status_X3D_X25i_X20phase_X3D_X25i_X20tcp_status_X3D_X25i_X20size_payload_X3D_X25i),
-    /* K6   */  be_nested_str_weak(http_status),
-    /* K7   */  be_nested_str_weak(phase),
-    /* K8   */  be_nested_str_weak(status),
-    /* K9   */  be_nested_str_weak(payload),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(dispatch_cb),
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(current_cmd),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20timeout_X20http_status_X3D_X25i_X20phase_X3D_X25i_X20tcp_status_X3D_X25i_X20size_payload_X3D_X25i),
+    /* K4   */  be_nested_str_weak(http_status),
+    /* K5   */  be_nested_str_weak(phase),
+    /* K6   */  be_nested_str_weak(status),
+    /* K7   */  be_nested_str_weak(payload),
+    /* K8   */  be_const_int(3),
+    /* K9   */  be_nested_str_weak(dispatch_cb),
     }),
     be_str_weak(event_http_timeout),
     &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x1C080403,  //  0003  EQ	R2	R2	R3
-      0x780A0000,  //  0004  JMPF	R2	#0006
-      0x80000400,  //  0005  RET	0
-      0xB80A0400,  //  0006  GETNGBL	R2	K2
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
-      0x8C100304,  //  0008  GETMET	R4	R1	K4
-      0x58180005,  //  0009  LDCONST	R6	K5
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x88200107,  //  000B  GETMBR	R8	R0	K7
-      0x88240108,  //  000C  GETMBR	R9	R0	K8
-      0x6028000C,  //  000D  GETGBL	R10	G12
-      0x882C0109,  //  000E  GETMBR	R11	R0	K9
-      0x7C280200,  //  000F  CALL	R10	1
-      0x7C100C00,  //  0010  CALL	R4	6
-      0x5814000A,  //  0011  LDCONST	R5	K10
-      0x7C080600,  //  0012  CALL	R2	3
-      0x8C08010B,  //  0013  GETMET	R2	R0	K11
-      0x88100106,  //  0014  GETMBR	R4	R0	K6
-      0x4C140000,  //  0015  LDNIL	R5
-      0x7C080600,  //  0016  CALL	R2	3
-      0x80000000,  //  0017  RET	0
+    ( &(const binstruction[23]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060000,  //  0003  JMPF	R1	#0005
+      0x80000200,  //  0004  RET	0
+      0xB8060200,  //  0005  GETNGBL	R1	K1
+      0x8C040302,  //  0006  GETMET	R1	R1	K2
+      0x600C0018,  //  0007  GETGBL	R3	G24
+      0x58100003,  //  0008  LDCONST	R4	K3
+      0x88140104,  //  0009  GETMBR	R5	R0	K4
+      0x88180105,  //  000A  GETMBR	R6	R0	K5
+      0x881C0106,  //  000B  GETMBR	R7	R0	K6
+      0x6020000C,  //  000C  GETGBL	R8	G12
+      0x88240107,  //  000D  GETMBR	R9	R0	K7
+      0x7C200200,  //  000E  CALL	R8	1
+      0x7C0C0A00,  //  000F  CALL	R3	5
+      0x58100008,  //  0010  LDCONST	R4	K8
+      0x7C040600,  //  0011  CALL	R1	3
+      0x8C040109,  //  0012  GETMET	R1	R0	K9
+      0x880C0104,  //  0013  GETMBR	R3	R0	K4
+      0x4C100000,  //  0014  LDNIL	R4
+      0x7C040600,  //  0015  CALL	R1	3
+      0x80000000,  //  0016  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -67,7 +67,7 @@ be_local_closure(Matter_IM_expire_sendqueue,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_process_invoke_request,   /* name */
   be_nested_proto(
-    22,                          /* nstack */
+    20,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -75,332 +75,329 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[45]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(Path),
-    /* K3   */  be_nested_str_weak(InvokeRequestMessage),
-    /* K4   */  be_nested_str_weak(from_TLV),
-    /* K5   */  be_nested_str_weak(invoke_requests),
-    /* K6   */  be_nested_str_weak(InvokeResponseMessage),
-    /* K7   */  be_nested_str_weak(suppress_response),
-    /* K8   */  be_nested_str_weak(invoke_responses),
-    /* K9   */  be_nested_str_weak(endpoint),
-    /* K10  */  be_nested_str_weak(command_path),
-    /* K11  */  be_nested_str_weak(cluster),
-    /* K12  */  be_nested_str_weak(command),
-    /* K13  */  be_nested_str_weak(status),
-    /* K14  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
-    /* K15  */  be_nested_str_weak(get_command_name),
-    /* K16  */  be_nested_str_weak(device),
-    /* K17  */  be_nested_str_weak(invoke_request),
-    /* K18  */  be_nested_str_weak(session),
-    /* K19  */  be_nested_str_weak(command_fields),
-    /* K20  */  be_nested_str_weak(log),
-    /* K21  */  be_nested_str_weak(_X28),
-    /* K22  */  be_nested_str_weak(_X29_X20),
-    /* K23  */  be_nested_str_weak(),
-    /* K24  */  be_nested_str_weak(tasmota),
-    /* K25  */  be_nested_str_weak(format),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20_X25s),
-    /* K27  */  be_nested_str_weak(local_session_id),
-    /* K28  */  be_const_int(0),
-    /* K29  */  be_const_int(2),
-    /* K30  */  be_const_int(3),
-    /* K31  */  be_nested_str_weak(InvokeResponseIB),
-    /* K32  */  be_nested_str_weak(SUCCESS),
-    /* K33  */  be_nested_str_weak(CommandStatusIB),
-    /* K34  */  be_nested_str_weak(CommandPathIB),
-    /* K35  */  be_nested_str_weak(StatusIB),
-    /* K36  */  be_nested_str_weak(push),
-    /* K37  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20OK_X20exch_X3D_X25i),
-    /* K38  */  be_nested_str_weak(exchange_id),
-    /* K39  */  be_nested_str_weak(CommandDataIB),
-    /* K40  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s),
-    /* K41  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20Status_X3D0x_X2502X_X20exch_X3D_X25i),
-    /* K42  */  be_nested_str_weak(MTR_X3A_X20_Ignore_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i),
-    /* K43  */  be_nested_str_weak(stop_iteration),
-    /* K44  */  be_nested_str_weak(send_invoke_response),
+    ( &(const bvalue[43]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Path),
+    /* K2   */  be_nested_str_weak(InvokeRequestMessage),
+    /* K3   */  be_nested_str_weak(from_TLV),
+    /* K4   */  be_nested_str_weak(invoke_requests),
+    /* K5   */  be_nested_str_weak(InvokeResponseMessage),
+    /* K6   */  be_nested_str_weak(suppress_response),
+    /* K7   */  be_nested_str_weak(invoke_responses),
+    /* K8   */  be_nested_str_weak(endpoint),
+    /* K9   */  be_nested_str_weak(command_path),
+    /* K10  */  be_nested_str_weak(cluster),
+    /* K11  */  be_nested_str_weak(command),
+    /* K12  */  be_nested_str_weak(status),
+    /* K13  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
+    /* K14  */  be_nested_str_weak(get_command_name),
+    /* K15  */  be_nested_str_weak(device),
+    /* K16  */  be_nested_str_weak(invoke_request),
+    /* K17  */  be_nested_str_weak(session),
+    /* K18  */  be_nested_str_weak(command_fields),
+    /* K19  */  be_nested_str_weak(log),
+    /* K20  */  be_nested_str_weak(_X28),
+    /* K21  */  be_nested_str_weak(_X29_X20),
+    /* K22  */  be_nested_str_weak(),
+    /* K23  */  be_nested_str_weak(tasmota),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20_X25s),
+    /* K25  */  be_nested_str_weak(local_session_id),
+    /* K26  */  be_const_int(0),
+    /* K27  */  be_const_int(2),
+    /* K28  */  be_const_int(3),
+    /* K29  */  be_nested_str_weak(InvokeResponseIB),
+    /* K30  */  be_nested_str_weak(SUCCESS),
+    /* K31  */  be_nested_str_weak(CommandStatusIB),
+    /* K32  */  be_nested_str_weak(CommandPathIB),
+    /* K33  */  be_nested_str_weak(StatusIB),
+    /* K34  */  be_nested_str_weak(push),
+    /* K35  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20OK_X20exch_X3D_X25i),
+    /* K36  */  be_nested_str_weak(exchange_id),
+    /* K37  */  be_nested_str_weak(CommandDataIB),
+    /* K38  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s),
+    /* K39  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20Status_X3D0x_X2502X_X20exch_X3D_X25i),
+    /* K40  */  be_nested_str_weak(MTR_X3A_X20_Ignore_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i),
+    /* K41  */  be_nested_str_weak(stop_iteration),
+    /* K42  */  be_nested_str_weak(send_invoke_response),
     }),
     be_str_weak(process_invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[276]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0xB8160200,  //  0004  GETNGBL	R5	K1
-      0x8C140B03,  //  0005  GETMET	R5	R5	K3
-      0x7C140200,  //  0006  CALL	R5	1
-      0x8C140B04,  //  0007  GETMET	R5	R5	K4
-      0x5C1C0400,  //  0008  MOVE	R7	R2
-      0x7C140400,  //  0009  CALL	R5	2
-      0x88180B05,  //  000A  GETMBR	R6	R5	K5
-      0x4C1C0000,  //  000B  LDNIL	R7
-      0x20180C07,  //  000C  NE	R6	R6	R7
-      0x781A0104,  //  000D  JMPF	R6	#0113
-      0xB81A0200,  //  000E  GETNGBL	R6	K1
-      0x8C180D06,  //  000F  GETMET	R6	R6	K6
-      0x7C180200,  //  0010  CALL	R6	1
-      0x501C0000,  //  0011  LDBOOL	R7	0	0
-      0x901A0E07,  //  0012  SETMBR	R6	K7	R7
-      0x601C0012,  //  0013  GETGBL	R7	G18
-      0x7C1C0000,  //  0014  CALL	R7	0
-      0x901A1007,  //  0015  SETMBR	R6	K8	R7
-      0x601C0010,  //  0016  GETGBL	R7	G16
-      0x88200B05,  //  0017  GETMBR	R8	R5	K5
-      0x7C1C0200,  //  0018  CALL	R7	1
-      0xA80200E7,  //  0019  EXBLK	0	#0102
-      0x5C200E00,  //  001A  MOVE	R8	R7
-      0x7C200000,  //  001B  CALL	R8	0
-      0x8824110A,  //  001C  GETMBR	R9	R8	K10
-      0x88241309,  //  001D  GETMBR	R9	R9	K9
-      0x90121209,  //  001E  SETMBR	R4	K9	R9
-      0x8824110A,  //  001F  GETMBR	R9	R8	K10
-      0x8824130B,  //  0020  GETMBR	R9	R9	K11
-      0x90121609,  //  0021  SETMBR	R4	K11	R9
-      0x8824110A,  //  0022  GETMBR	R9	R8	K10
-      0x8824130C,  //  0023  GETMBR	R9	R9	K12
-      0x90121809,  //  0024  SETMBR	R4	K12	R9
-      0xB8260200,  //  0025  GETNGBL	R9	K1
-      0x8824130E,  //  0026  GETMBR	R9	R9	K14
-      0x90121A09,  //  0027  SETMBR	R4	K13	R9
-      0xB8260200,  //  0028  GETNGBL	R9	K1
-      0x8C24130F,  //  0029  GETMET	R9	R9	K15
-      0x882C090B,  //  002A  GETMBR	R11	R4	K11
-      0x8830090C,  //  002B  GETMBR	R12	R4	K12
-      0x7C240600,  //  002C  CALL	R9	3
-      0x60280008,  //  002D  GETGBL	R10	G8
-      0x5C2C0800,  //  002E  MOVE	R11	R4
-      0x7C280200,  //  002F  CALL	R10	1
-      0x882C0110,  //  0030  GETMBR	R11	R0	K16
-      0x8C2C1711,  //  0031  GETMET	R11	R11	K17
-      0x88340312,  //  0032  GETMBR	R13	R1	K18
-      0x88381113,  //  0033  GETMBR	R14	R8	K19
-      0x5C3C0800,  //  0034  MOVE	R15	R4
-      0x7C2C0800,  //  0035  CALL	R11	4
-      0x88300914,  //  0036  GETMBR	R12	R4	K20
-      0x4C340000,  //  0037  LDNIL	R13
-      0x2030180D,  //  0038  NE	R12	R12	R13
-      0x78320005,  //  0039  JMPF	R12	#0040
-      0x60300008,  //  003A  GETGBL	R12	G8
-      0x88340914,  //  003B  GETMBR	R13	R4	K20
-      0x7C300200,  //  003C  CALL	R12	1
-      0x00322A0C,  //  003D  ADD	R12	K21	R12
-      0x00301916,  //  003E  ADD	R12	R12	K22
-      0x70020000,  //  003F  JMP		#0041
-      0x58300017,  //  0040  LDCONST	R12	K23
-      0xB8363000,  //  0041  GETNGBL	R13	K24
-      0x8C341B14,  //  0042  GETMET	R13	R13	K20
-      0x8C3C0719,  //  0043  GETMET	R15	R3	K25
-      0x5844001A,  //  0044  LDCONST	R17	K26
-      0x88480312,  //  0045  GETMBR	R18	R1	K18
-      0x8848251B,  //  0046  GETMBR	R18	R18	K27
-      0x5C4C1400,  //  0047  MOVE	R19	R10
-      0x78260001,  //  0048  JMPF	R9	#004B
-      0x5C501200,  //  0049  MOVE	R20	R9
-      0x70020000,  //  004A  JMP		#004C
-      0x58500017,  //  004B  LDCONST	R20	K23
-      0x5C541800,  //  004C  MOVE	R21	R12
-      0x7C3C0C00,  //  004D  CALL	R15	6
-      0x88400909,  //  004E  GETMBR	R16	R4	K9
-      0x2040211C,  //  004F  NE	R16	R16	K28
-      0x78420001,  //  0050  JMPF	R16	#0053
-      0x5840001D,  //  0051  LDCONST	R16	K29
-      0x70020000,  //  0052  JMP		#0054
-      0x5840001E,  //  0053  LDCONST	R16	K30
-      0x7C340600,  //  0054  CALL	R13	3
-      0x4C340000,  //  0055  LDNIL	R13
-      0x9012280D,  //  0056  SETMBR	R4	K20	R13
-      0xB8360200,  //  0057  GETNGBL	R13	K1
-      0x8C341B1F,  //  0058  GETMET	R13	R13	K31
-      0x7C340200,  //  0059  CALL	R13	1
-      0x50380200,  //  005A  LDBOOL	R14	1	0
-      0x1C38160E,  //  005B  EQ	R14	R11	R14
-      0x743A0004,  //  005C  JMPT	R14	#0062
-      0x8838090D,  //  005D  GETMBR	R14	R4	K13
-      0xB83E0200,  //  005E  GETNGBL	R15	K1
-      0x883C1F20,  //  005F  GETMBR	R15	R15	K32
-      0x1C381C0F,  //  0060  EQ	R14	R14	R15
-      0x783A002D,  //  0061  JMPF	R14	#0090
-      0xB83A0200,  //  0062  GETNGBL	R14	K1
-      0x8C381D21,  //  0063  GETMET	R14	R14	K33
-      0x7C380200,  //  0064  CALL	R14	1
-      0x90361A0E,  //  0065  SETMBR	R13	K13	R14
-      0x88381B0D,  //  0066  GETMBR	R14	R13	K13
-      0xB83E0200,  //  0067  GETNGBL	R15	K1
-      0x8C3C1F22,  //  0068  GETMET	R15	R15	K34
-      0x7C3C0200,  //  0069  CALL	R15	1
-      0x903A140F,  //  006A  SETMBR	R14	K10	R15
-      0x88381B0D,  //  006B  GETMBR	R14	R13	K13
-      0x88381D0A,  //  006C  GETMBR	R14	R14	K10
-      0x883C0909,  //  006D  GETMBR	R15	R4	K9
-      0x903A120F,  //  006E  SETMBR	R14	K9	R15
-      0x88381B0D,  //  006F  GETMBR	R14	R13	K13
-      0x88381D0A,  //  0070  GETMBR	R14	R14	K10
-      0x883C090B,  //  0071  GETMBR	R15	R4	K11
-      0x903A160F,  //  0072  SETMBR	R14	K11	R15
-      0x88381B0D,  //  0073  GETMBR	R14	R13	K13
-      0x88381D0A,  //  0074  GETMBR	R14	R14	K10
-      0x883C090C,  //  0075  GETMBR	R15	R4	K12
-      0x903A180F,  //  0076  SETMBR	R14	K12	R15
-      0x88381B0D,  //  0077  GETMBR	R14	R13	K13
-      0xB83E0200,  //  0078  GETNGBL	R15	K1
-      0x8C3C1F23,  //  0079  GETMET	R15	R15	K35
-      0x7C3C0200,  //  007A  CALL	R15	1
-      0x903A1A0F,  //  007B  SETMBR	R14	K13	R15
-      0x88381B0D,  //  007C  GETMBR	R14	R13	K13
-      0x88381D0D,  //  007D  GETMBR	R14	R14	K13
-      0xB83E0200,  //  007E  GETNGBL	R15	K1
-      0x883C1F20,  //  007F  GETMBR	R15	R15	K32
-      0x903A1A0F,  //  0080  SETMBR	R14	K13	R15
-      0x88380D08,  //  0081  GETMBR	R14	R6	K8
-      0x8C381D24,  //  0082  GETMET	R14	R14	K36
-      0x5C401A00,  //  0083  MOVE	R16	R13
-      0x7C380400,  //  0084  CALL	R14	2
-      0xB83A3000,  //  0085  GETNGBL	R14	K24
-      0x8C381D14,  //  0086  GETMET	R14	R14	K20
-      0x8C400719,  //  0087  GETMET	R16	R3	K25
-      0x58480025,  //  0088  LDCONST	R18	K37
-      0x884C0312,  //  0089  GETMBR	R19	R1	K18
-      0x884C271B,  //  008A  GETMBR	R19	R19	K27
-      0x88500326,  //  008B  GETMBR	R20	R1	K38
-      0x7C400800,  //  008C  CALL	R16	4
-      0x5844001E,  //  008D  LDCONST	R17	K30
-      0x7C380600,  //  008E  CALL	R14	3
-      0x70020070,  //  008F  JMP		#0101
-      0x4C380000,  //  0090  LDNIL	R14
-      0x2038160E,  //  0091  NE	R14	R11	R14
-      0x783A0031,  //  0092  JMPF	R14	#00C5
-      0xB83A0200,  //  0093  GETNGBL	R14	K1
-      0x8C381D27,  //  0094  GETMET	R14	R14	K39
-      0x7C380200,  //  0095  CALL	R14	1
-      0x9036180E,  //  0096  SETMBR	R13	K12	R14
-      0x88381B0C,  //  0097  GETMBR	R14	R13	K12
-      0xB83E0200,  //  0098  GETNGBL	R15	K1
-      0x8C3C1F22,  //  0099  GETMET	R15	R15	K34
-      0x7C3C0200,  //  009A  CALL	R15	1
-      0x903A140F,  //  009B  SETMBR	R14	K10	R15
-      0x88381B0C,  //  009C  GETMBR	R14	R13	K12
-      0x88381D0A,  //  009D  GETMBR	R14	R14	K10
-      0x883C0909,  //  009E  GETMBR	R15	R4	K9
-      0x903A120F,  //  009F  SETMBR	R14	K9	R15
-      0x88381B0C,  //  00A0  GETMBR	R14	R13	K12
-      0x88381D0A,  //  00A1  GETMBR	R14	R14	K10
-      0x883C090B,  //  00A2  GETMBR	R15	R4	K11
-      0x903A160F,  //  00A3  SETMBR	R14	K11	R15
-      0x88381B0C,  //  00A4  GETMBR	R14	R13	K12
-      0x88381D0A,  //  00A5  GETMBR	R14	R14	K10
-      0x883C090C,  //  00A6  GETMBR	R15	R4	K12
-      0x903A180F,  //  00A7  SETMBR	R14	K12	R15
-      0x88381B0C,  //  00A8  GETMBR	R14	R13	K12
-      0x903A260B,  //  00A9  SETMBR	R14	K19	R11
-      0x88380D08,  //  00AA  GETMBR	R14	R6	K8
-      0x8C381D24,  //  00AB  GETMET	R14	R14	K36
-      0x5C401A00,  //  00AC  MOVE	R16	R13
-      0x7C380400,  //  00AD  CALL	R14	2
-      0xB83A0200,  //  00AE  GETNGBL	R14	K1
-      0x8C381D0F,  //  00AF  GETMET	R14	R14	K15
-      0x8840090B,  //  00B0  GETMBR	R16	R4	K11
-      0x8844090C,  //  00B1  GETMBR	R17	R4	K12
-      0x7C380600,  //  00B2  CALL	R14	3
-      0x5C241C00,  //  00B3  MOVE	R9	R14
-      0xB83A3000,  //  00B4  GETNGBL	R14	K24
-      0x8C381D14,  //  00B5  GETMET	R14	R14	K20
-      0x8C400719,  //  00B6  GETMET	R16	R3	K25
-      0x58480028,  //  00B7  LDCONST	R18	K40
-      0x884C0312,  //  00B8  GETMBR	R19	R1	K18
-      0x884C271B,  //  00B9  GETMBR	R19	R19	K27
-      0x60500008,  //  00BA  GETGBL	R20	G8
-      0x5C540800,  //  00BB  MOVE	R21	R4
-      0x7C500200,  //  00BC  CALL	R20	1
-      0x78260001,  //  00BD  JMPF	R9	#00C0
-      0x5C541200,  //  00BE  MOVE	R21	R9
-      0x70020000,  //  00BF  JMP		#00C1
-      0x58540017,  //  00C0  LDCONST	R21	K23
-      0x7C400A00,  //  00C1  CALL	R16	5
-      0x5844001E,  //  00C2  LDCONST	R17	K30
-      0x7C380600,  //  00C3  CALL	R14	3
-      0x7002003B,  //  00C4  JMP		#0101
-      0x8838090D,  //  00C5  GETMBR	R14	R4	K13
-      0x4C3C0000,  //  00C6  LDNIL	R15
-      0x20381C0F,  //  00C7  NE	R14	R14	R15
-      0x783A002D,  //  00C8  JMPF	R14	#00F7
-      0xB83A0200,  //  00C9  GETNGBL	R14	K1
-      0x8C381D21,  //  00CA  GETMET	R14	R14	K33
-      0x7C380200,  //  00CB  CALL	R14	1
-      0x90361A0E,  //  00CC  SETMBR	R13	K13	R14
-      0x88381B0D,  //  00CD  GETMBR	R14	R13	K13
-      0xB83E0200,  //  00CE  GETNGBL	R15	K1
-      0x8C3C1F22,  //  00CF  GETMET	R15	R15	K34
-      0x7C3C0200,  //  00D0  CALL	R15	1
-      0x903A140F,  //  00D1  SETMBR	R14	K10	R15
-      0x88381B0D,  //  00D2  GETMBR	R14	R13	K13
-      0x88381D0A,  //  00D3  GETMBR	R14	R14	K10
-      0x883C0909,  //  00D4  GETMBR	R15	R4	K9
-      0x903A120F,  //  00D5  SETMBR	R14	K9	R15
-      0x88381B0D,  //  00D6  GETMBR	R14	R13	K13
-      0x88381D0A,  //  00D7  GETMBR	R14	R14	K10
-      0x883C090B,  //  00D8  GETMBR	R15	R4	K11
-      0x903A160F,  //  00D9  SETMBR	R14	K11	R15
-      0x88381B0D,  //  00DA  GETMBR	R14	R13	K13
-      0x88381D0A,  //  00DB  GETMBR	R14	R14	K10
-      0x883C090C,  //  00DC  GETMBR	R15	R4	K12
-      0x903A180F,  //  00DD  SETMBR	R14	K12	R15
-      0x88381B0D,  //  00DE  GETMBR	R14	R13	K13
-      0xB83E0200,  //  00DF  GETNGBL	R15	K1
-      0x8C3C1F23,  //  00E0  GETMET	R15	R15	K35
-      0x7C3C0200,  //  00E1  CALL	R15	1
-      0x903A1A0F,  //  00E2  SETMBR	R14	K13	R15
-      0x88381B0D,  //  00E3  GETMBR	R14	R13	K13
-      0x88381D0D,  //  00E4  GETMBR	R14	R14	K13
-      0x883C090D,  //  00E5  GETMBR	R15	R4	K13
-      0x903A1A0F,  //  00E6  SETMBR	R14	K13	R15
-      0x88380D08,  //  00E7  GETMBR	R14	R6	K8
-      0x8C381D24,  //  00E8  GETMET	R14	R14	K36
-      0x5C401A00,  //  00E9  MOVE	R16	R13
-      0x7C380400,  //  00EA  CALL	R14	2
-      0xB83A3000,  //  00EB  GETNGBL	R14	K24
-      0x8C381D14,  //  00EC  GETMET	R14	R14	K20
-      0x8C400719,  //  00ED  GETMET	R16	R3	K25
-      0x58480029,  //  00EE  LDCONST	R18	K41
-      0x884C0312,  //  00EF  GETMBR	R19	R1	K18
-      0x884C271B,  //  00F0  GETMBR	R19	R19	K27
-      0x8850090D,  //  00F1  GETMBR	R20	R4	K13
-      0x88540326,  //  00F2  GETMBR	R21	R1	K38
-      0x7C400A00,  //  00F3  CALL	R16	5
-      0x5844001E,  //  00F4  LDCONST	R17	K30
-      0x7C380600,  //  00F5  CALL	R14	3
-      0x70020009,  //  00F6  JMP		#0101
-      0xB83A3000,  //  00F7  GETNGBL	R14	K24
-      0x8C381D14,  //  00F8  GETMET	R14	R14	K20
-      0x8C400719,  //  00F9  GETMET	R16	R3	K25
-      0x5848002A,  //  00FA  LDCONST	R18	K42
-      0x884C0312,  //  00FB  GETMBR	R19	R1	K18
-      0x884C271B,  //  00FC  GETMBR	R19	R19	K27
-      0x88500326,  //  00FD  GETMBR	R20	R1	K38
-      0x7C400800,  //  00FE  CALL	R16	4
-      0x5844001E,  //  00FF  LDCONST	R17	K30
-      0x7C380600,  //  0100  CALL	R14	3
-      0x7001FF17,  //  0101  JMP		#001A
-      0x581C002B,  //  0102  LDCONST	R7	K43
-      0xAC1C0200,  //  0103  CATCH	R7	1	0
-      0xB0080000,  //  0104  RAISE	2	R0	R0
-      0x601C000C,  //  0105  GETGBL	R7	G12
-      0x88200D08,  //  0106  GETMBR	R8	R6	K8
-      0x7C1C0200,  //  0107  CALL	R7	1
-      0x241C0F1C,  //  0108  GT	R7	R7	K28
-      0x781E0004,  //  0109  JMPF	R7	#010F
-      0x8C1C012C,  //  010A  GETMET	R7	R0	K44
-      0x5C240200,  //  010B  MOVE	R9	R1
-      0x5C280C00,  //  010C  MOVE	R10	R6
-      0x7C1C0600,  //  010D  CALL	R7	3
-      0x70020001,  //  010E  JMP		#0111
-      0x501C0000,  //  010F  LDBOOL	R7	0	0
-      0x80040E00,  //  0110  RET	1	R7
-      0x501C0200,  //  0111  LDBOOL	R7	1	0
-      0x80040E00,  //  0112  RET	1	R7
-      0x80000000,  //  0113  RET	0
+    ( &(const binstruction[275]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0xB8120000,  //  0003  GETNGBL	R4	K0
+      0x8C100902,  //  0004  GETMET	R4	R4	K2
+      0x7C100200,  //  0005  CALL	R4	1
+      0x8C100903,  //  0006  GETMET	R4	R4	K3
+      0x5C180400,  //  0007  MOVE	R6	R2
+      0x7C100400,  //  0008  CALL	R4	2
+      0x88140904,  //  0009  GETMBR	R5	R4	K4
+      0x4C180000,  //  000A  LDNIL	R6
+      0x20140A06,  //  000B  NE	R5	R5	R6
+      0x78160104,  //  000C  JMPF	R5	#0112
+      0xB8160000,  //  000D  GETNGBL	R5	K0
+      0x8C140B05,  //  000E  GETMET	R5	R5	K5
+      0x7C140200,  //  000F  CALL	R5	1
+      0x50180000,  //  0010  LDBOOL	R6	0	0
+      0x90160C06,  //  0011  SETMBR	R5	K6	R6
+      0x60180012,  //  0012  GETGBL	R6	G18
+      0x7C180000,  //  0013  CALL	R6	0
+      0x90160E06,  //  0014  SETMBR	R5	K7	R6
+      0x60180010,  //  0015  GETGBL	R6	G16
+      0x881C0904,  //  0016  GETMBR	R7	R4	K4
+      0x7C180200,  //  0017  CALL	R6	1
+      0xA80200E7,  //  0018  EXBLK	0	#0101
+      0x5C1C0C00,  //  0019  MOVE	R7	R6
+      0x7C1C0000,  //  001A  CALL	R7	0
+      0x88200F09,  //  001B  GETMBR	R8	R7	K9
+      0x88201108,  //  001C  GETMBR	R8	R8	K8
+      0x900E1008,  //  001D  SETMBR	R3	K8	R8
+      0x88200F09,  //  001E  GETMBR	R8	R7	K9
+      0x8820110A,  //  001F  GETMBR	R8	R8	K10
+      0x900E1408,  //  0020  SETMBR	R3	K10	R8
+      0x88200F09,  //  0021  GETMBR	R8	R7	K9
+      0x8820110B,  //  0022  GETMBR	R8	R8	K11
+      0x900E1608,  //  0023  SETMBR	R3	K11	R8
+      0xB8220000,  //  0024  GETNGBL	R8	K0
+      0x8820110D,  //  0025  GETMBR	R8	R8	K13
+      0x900E1808,  //  0026  SETMBR	R3	K12	R8
+      0xB8220000,  //  0027  GETNGBL	R8	K0
+      0x8C20110E,  //  0028  GETMET	R8	R8	K14
+      0x8828070A,  //  0029  GETMBR	R10	R3	K10
+      0x882C070B,  //  002A  GETMBR	R11	R3	K11
+      0x7C200600,  //  002B  CALL	R8	3
+      0x60240008,  //  002C  GETGBL	R9	G8
+      0x5C280600,  //  002D  MOVE	R10	R3
+      0x7C240200,  //  002E  CALL	R9	1
+      0x8828010F,  //  002F  GETMBR	R10	R0	K15
+      0x8C281510,  //  0030  GETMET	R10	R10	K16
+      0x88300311,  //  0031  GETMBR	R12	R1	K17
+      0x88340F12,  //  0032  GETMBR	R13	R7	K18
+      0x5C380600,  //  0033  MOVE	R14	R3
+      0x7C280800,  //  0034  CALL	R10	4
+      0x882C0713,  //  0035  GETMBR	R11	R3	K19
+      0x4C300000,  //  0036  LDNIL	R12
+      0x202C160C,  //  0037  NE	R11	R11	R12
+      0x782E0005,  //  0038  JMPF	R11	#003F
+      0x602C0008,  //  0039  GETGBL	R11	G8
+      0x88300713,  //  003A  GETMBR	R12	R3	K19
+      0x7C2C0200,  //  003B  CALL	R11	1
+      0x002E280B,  //  003C  ADD	R11	K20	R11
+      0x002C1715,  //  003D  ADD	R11	R11	K21
+      0x70020000,  //  003E  JMP		#0040
+      0x582C0016,  //  003F  LDCONST	R11	K22
+      0xB8322E00,  //  0040  GETNGBL	R12	K23
+      0x8C301913,  //  0041  GETMET	R12	R12	K19
+      0x60380018,  //  0042  GETGBL	R14	G24
+      0x583C0018,  //  0043  LDCONST	R15	K24
+      0x88400311,  //  0044  GETMBR	R16	R1	K17
+      0x88402119,  //  0045  GETMBR	R16	R16	K25
+      0x5C441200,  //  0046  MOVE	R17	R9
+      0x78220001,  //  0047  JMPF	R8	#004A
+      0x5C481000,  //  0048  MOVE	R18	R8
+      0x70020000,  //  0049  JMP		#004B
+      0x58480016,  //  004A  LDCONST	R18	K22
+      0x5C4C1600,  //  004B  MOVE	R19	R11
+      0x7C380A00,  //  004C  CALL	R14	5
+      0x883C0708,  //  004D  GETMBR	R15	R3	K8
+      0x203C1F1A,  //  004E  NE	R15	R15	K26
+      0x783E0001,  //  004F  JMPF	R15	#0052
+      0x583C001B,  //  0050  LDCONST	R15	K27
+      0x70020000,  //  0051  JMP		#0053
+      0x583C001C,  //  0052  LDCONST	R15	K28
+      0x7C300600,  //  0053  CALL	R12	3
+      0x4C300000,  //  0054  LDNIL	R12
+      0x900E260C,  //  0055  SETMBR	R3	K19	R12
+      0xB8320000,  //  0056  GETNGBL	R12	K0
+      0x8C30191D,  //  0057  GETMET	R12	R12	K29
+      0x7C300200,  //  0058  CALL	R12	1
+      0x50340200,  //  0059  LDBOOL	R13	1	0
+      0x1C34140D,  //  005A  EQ	R13	R10	R13
+      0x74360004,  //  005B  JMPT	R13	#0061
+      0x8834070C,  //  005C  GETMBR	R13	R3	K12
+      0xB83A0000,  //  005D  GETNGBL	R14	K0
+      0x88381D1E,  //  005E  GETMBR	R14	R14	K30
+      0x1C341A0E,  //  005F  EQ	R13	R13	R14
+      0x7836002D,  //  0060  JMPF	R13	#008F
+      0xB8360000,  //  0061  GETNGBL	R13	K0
+      0x8C341B1F,  //  0062  GETMET	R13	R13	K31
+      0x7C340200,  //  0063  CALL	R13	1
+      0x9032180D,  //  0064  SETMBR	R12	K12	R13
+      0x8834190C,  //  0065  GETMBR	R13	R12	K12
+      0xB83A0000,  //  0066  GETNGBL	R14	K0
+      0x8C381D20,  //  0067  GETMET	R14	R14	K32
+      0x7C380200,  //  0068  CALL	R14	1
+      0x9036120E,  //  0069  SETMBR	R13	K9	R14
+      0x8834190C,  //  006A  GETMBR	R13	R12	K12
+      0x88341B09,  //  006B  GETMBR	R13	R13	K9
+      0x88380708,  //  006C  GETMBR	R14	R3	K8
+      0x9036100E,  //  006D  SETMBR	R13	K8	R14
+      0x8834190C,  //  006E  GETMBR	R13	R12	K12
+      0x88341B09,  //  006F  GETMBR	R13	R13	K9
+      0x8838070A,  //  0070  GETMBR	R14	R3	K10
+      0x9036140E,  //  0071  SETMBR	R13	K10	R14
+      0x8834190C,  //  0072  GETMBR	R13	R12	K12
+      0x88341B09,  //  0073  GETMBR	R13	R13	K9
+      0x8838070B,  //  0074  GETMBR	R14	R3	K11
+      0x9036160E,  //  0075  SETMBR	R13	K11	R14
+      0x8834190C,  //  0076  GETMBR	R13	R12	K12
+      0xB83A0000,  //  0077  GETNGBL	R14	K0
+      0x8C381D21,  //  0078  GETMET	R14	R14	K33
+      0x7C380200,  //  0079  CALL	R14	1
+      0x9036180E,  //  007A  SETMBR	R13	K12	R14
+      0x8834190C,  //  007B  GETMBR	R13	R12	K12
+      0x88341B0C,  //  007C  GETMBR	R13	R13	K12
+      0xB83A0000,  //  007D  GETNGBL	R14	K0
+      0x88381D1E,  //  007E  GETMBR	R14	R14	K30
+      0x9036180E,  //  007F  SETMBR	R13	K12	R14
+      0x88340B07,  //  0080  GETMBR	R13	R5	K7
+      0x8C341B22,  //  0081  GETMET	R13	R13	K34
+      0x5C3C1800,  //  0082  MOVE	R15	R12
+      0x7C340400,  //  0083  CALL	R13	2
+      0xB8362E00,  //  0084  GETNGBL	R13	K23
+      0x8C341B13,  //  0085  GETMET	R13	R13	K19
+      0x603C0018,  //  0086  GETGBL	R15	G24
+      0x58400023,  //  0087  LDCONST	R16	K35
+      0x88440311,  //  0088  GETMBR	R17	R1	K17
+      0x88442319,  //  0089  GETMBR	R17	R17	K25
+      0x88480324,  //  008A  GETMBR	R18	R1	K36
+      0x7C3C0600,  //  008B  CALL	R15	3
+      0x5840001C,  //  008C  LDCONST	R16	K28
+      0x7C340600,  //  008D  CALL	R13	3
+      0x70020070,  //  008E  JMP		#0100
+      0x4C340000,  //  008F  LDNIL	R13
+      0x2034140D,  //  0090  NE	R13	R10	R13
+      0x78360031,  //  0091  JMPF	R13	#00C4
+      0xB8360000,  //  0092  GETNGBL	R13	K0
+      0x8C341B25,  //  0093  GETMET	R13	R13	K37
+      0x7C340200,  //  0094  CALL	R13	1
+      0x9032160D,  //  0095  SETMBR	R12	K11	R13
+      0x8834190B,  //  0096  GETMBR	R13	R12	K11
+      0xB83A0000,  //  0097  GETNGBL	R14	K0
+      0x8C381D20,  //  0098  GETMET	R14	R14	K32
+      0x7C380200,  //  0099  CALL	R14	1
+      0x9036120E,  //  009A  SETMBR	R13	K9	R14
+      0x8834190B,  //  009B  GETMBR	R13	R12	K11
+      0x88341B09,  //  009C  GETMBR	R13	R13	K9
+      0x88380708,  //  009D  GETMBR	R14	R3	K8
+      0x9036100E,  //  009E  SETMBR	R13	K8	R14
+      0x8834190B,  //  009F  GETMBR	R13	R12	K11
+      0x88341B09,  //  00A0  GETMBR	R13	R13	K9
+      0x8838070A,  //  00A1  GETMBR	R14	R3	K10
+      0x9036140E,  //  00A2  SETMBR	R13	K10	R14
+      0x8834190B,  //  00A3  GETMBR	R13	R12	K11
+      0x88341B09,  //  00A4  GETMBR	R13	R13	K9
+      0x8838070B,  //  00A5  GETMBR	R14	R3	K11
+      0x9036160E,  //  00A6  SETMBR	R13	K11	R14
+      0x8834190B,  //  00A7  GETMBR	R13	R12	K11
+      0x9036240A,  //  00A8  SETMBR	R13	K18	R10
+      0x88340B07,  //  00A9  GETMBR	R13	R5	K7
+      0x8C341B22,  //  00AA  GETMET	R13	R13	K34
+      0x5C3C1800,  //  00AB  MOVE	R15	R12
+      0x7C340400,  //  00AC  CALL	R13	2
+      0xB8360000,  //  00AD  GETNGBL	R13	K0
+      0x8C341B0E,  //  00AE  GETMET	R13	R13	K14
+      0x883C070A,  //  00AF  GETMBR	R15	R3	K10
+      0x8840070B,  //  00B0  GETMBR	R16	R3	K11
+      0x7C340600,  //  00B1  CALL	R13	3
+      0x5C201A00,  //  00B2  MOVE	R8	R13
+      0xB8362E00,  //  00B3  GETNGBL	R13	K23
+      0x8C341B13,  //  00B4  GETMET	R13	R13	K19
+      0x603C0018,  //  00B5  GETGBL	R15	G24
+      0x58400026,  //  00B6  LDCONST	R16	K38
+      0x88440311,  //  00B7  GETMBR	R17	R1	K17
+      0x88442319,  //  00B8  GETMBR	R17	R17	K25
+      0x60480008,  //  00B9  GETGBL	R18	G8
+      0x5C4C0600,  //  00BA  MOVE	R19	R3
+      0x7C480200,  //  00BB  CALL	R18	1
+      0x78220001,  //  00BC  JMPF	R8	#00BF
+      0x5C4C1000,  //  00BD  MOVE	R19	R8
+      0x70020000,  //  00BE  JMP		#00C0
+      0x584C0016,  //  00BF  LDCONST	R19	K22
+      0x7C3C0800,  //  00C0  CALL	R15	4
+      0x5840001C,  //  00C1  LDCONST	R16	K28
+      0x7C340600,  //  00C2  CALL	R13	3
+      0x7002003B,  //  00C3  JMP		#0100
+      0x8834070C,  //  00C4  GETMBR	R13	R3	K12
+      0x4C380000,  //  00C5  LDNIL	R14
+      0x20341A0E,  //  00C6  NE	R13	R13	R14
+      0x7836002D,  //  00C7  JMPF	R13	#00F6
+      0xB8360000,  //  00C8  GETNGBL	R13	K0
+      0x8C341B1F,  //  00C9  GETMET	R13	R13	K31
+      0x7C340200,  //  00CA  CALL	R13	1
+      0x9032180D,  //  00CB  SETMBR	R12	K12	R13
+      0x8834190C,  //  00CC  GETMBR	R13	R12	K12
+      0xB83A0000,  //  00CD  GETNGBL	R14	K0
+      0x8C381D20,  //  00CE  GETMET	R14	R14	K32
+      0x7C380200,  //  00CF  CALL	R14	1
+      0x9036120E,  //  00D0  SETMBR	R13	K9	R14
+      0x8834190C,  //  00D1  GETMBR	R13	R12	K12
+      0x88341B09,  //  00D2  GETMBR	R13	R13	K9
+      0x88380708,  //  00D3  GETMBR	R14	R3	K8
+      0x9036100E,  //  00D4  SETMBR	R13	K8	R14
+      0x8834190C,  //  00D5  GETMBR	R13	R12	K12
+      0x88341B09,  //  00D6  GETMBR	R13	R13	K9
+      0x8838070A,  //  00D7  GETMBR	R14	R3	K10
+      0x9036140E,  //  00D8  SETMBR	R13	K10	R14
+      0x8834190C,  //  00D9  GETMBR	R13	R12	K12
+      0x88341B09,  //  00DA  GETMBR	R13	R13	K9
+      0x8838070B,  //  00DB  GETMBR	R14	R3	K11
+      0x9036160E,  //  00DC  SETMBR	R13	K11	R14
+      0x8834190C,  //  00DD  GETMBR	R13	R12	K12
+      0xB83A0000,  //  00DE  GETNGBL	R14	K0
+      0x8C381D21,  //  00DF  GETMET	R14	R14	K33
+      0x7C380200,  //  00E0  CALL	R14	1
+      0x9036180E,  //  00E1  SETMBR	R13	K12	R14
+      0x8834190C,  //  00E2  GETMBR	R13	R12	K12
+      0x88341B0C,  //  00E3  GETMBR	R13	R13	K12
+      0x8838070C,  //  00E4  GETMBR	R14	R3	K12
+      0x9036180E,  //  00E5  SETMBR	R13	K12	R14
+      0x88340B07,  //  00E6  GETMBR	R13	R5	K7
+      0x8C341B22,  //  00E7  GETMET	R13	R13	K34
+      0x5C3C1800,  //  00E8  MOVE	R15	R12
+      0x7C340400,  //  00E9  CALL	R13	2
+      0xB8362E00,  //  00EA  GETNGBL	R13	K23
+      0x8C341B13,  //  00EB  GETMET	R13	R13	K19
+      0x603C0018,  //  00EC  GETGBL	R15	G24
+      0x58400027,  //  00ED  LDCONST	R16	K39
+      0x88440311,  //  00EE  GETMBR	R17	R1	K17
+      0x88442319,  //  00EF  GETMBR	R17	R17	K25
+      0x8848070C,  //  00F0  GETMBR	R18	R3	K12
+      0x884C0324,  //  00F1  GETMBR	R19	R1	K36
+      0x7C3C0800,  //  00F2  CALL	R15	4
+      0x5840001C,  //  00F3  LDCONST	R16	K28
+      0x7C340600,  //  00F4  CALL	R13	3
+      0x70020009,  //  00F5  JMP		#0100
+      0xB8362E00,  //  00F6  GETNGBL	R13	K23
+      0x8C341B13,  //  00F7  GETMET	R13	R13	K19
+      0x603C0018,  //  00F8  GETGBL	R15	G24
+      0x58400028,  //  00F9  LDCONST	R16	K40
+      0x88440311,  //  00FA  GETMBR	R17	R1	K17
+      0x88442319,  //  00FB  GETMBR	R17	R17	K25
+      0x88480324,  //  00FC  GETMBR	R18	R1	K36
+      0x7C3C0600,  //  00FD  CALL	R15	3
+      0x5840001C,  //  00FE  LDCONST	R16	K28
+      0x7C340600,  //  00FF  CALL	R13	3
+      0x7001FF17,  //  0100  JMP		#0019
+      0x58180029,  //  0101  LDCONST	R6	K41
+      0xAC180200,  //  0102  CATCH	R6	1	0
+      0xB0080000,  //  0103  RAISE	2	R0	R0
+      0x6018000C,  //  0104  GETGBL	R6	G12
+      0x881C0B07,  //  0105  GETMBR	R7	R5	K7
+      0x7C180200,  //  0106  CALL	R6	1
+      0x24180D1A,  //  0107  GT	R6	R6	K26
+      0x781A0004,  //  0108  JMPF	R6	#010E
+      0x8C18012A,  //  0109  GETMET	R6	R0	K42
+      0x5C200200,  //  010A  MOVE	R8	R1
+      0x5C240A00,  //  010B  MOVE	R9	R5
+      0x7C180600,  //  010C  CALL	R6	3
+      0x70020001,  //  010D  JMP		#0110
+      0x50180000,  //  010E  LDBOOL	R6	0	0
+      0x80040C00,  //  010F  RET	1	R6
+      0x50180200,  //  0110  LDBOOL	R6	1	0
+      0x80040C00,  //  0111  RET	1	R6
+      0x80000000,  //  0112  RET	0
     })
   )
 );
@@ -412,7 +409,7 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_subscribe_request,   /* name */
   be_nested_proto(
-    19,                          /* nstack */
+    17,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -420,120 +417,117 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[31]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(SubscribeRequestMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(keep_subscriptions),
-    /* K5   */  be_nested_str_weak(subs_shop),
-    /* K6   */  be_nested_str_weak(remove_by_session),
-    /* K7   */  be_nested_str_weak(session),
-    /* K8   */  be_nested_str_weak(new_subscription),
-    /* K9   */  be_nested_str_weak(Path),
-    /* K10  */  be_nested_str_weak(attributes_requests),
-    /* K11  */  be_nested_str_weak(endpoint),
-    /* K12  */  be_nested_str_weak(cluster),
-    /* K13  */  be_nested_str_weak(attribute),
-    /* K14  */  be_nested_str_weak(push),
-    /* K15  */  be_nested_str_weak(stop_iteration),
-    /* K16  */  be_nested_str_weak(tasmota),
-    /* K17  */  be_nested_str_weak(log),
-    /* K18  */  be_nested_str_weak(format),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X2C_X20keep_X3D_X25i_X29_X20sub_X3D_X25i),
-    /* K20  */  be_nested_str_weak(local_session_id),
-    /* K21  */  be_nested_str_weak(concat),
-    /* K22  */  be_nested_str_weak(_X20),
-    /* K23  */  be_nested_str_weak(min_interval),
-    /* K24  */  be_nested_str_weak(max_interval),
-    /* K25  */  be_const_int(1),
-    /* K26  */  be_const_int(0),
-    /* K27  */  be_nested_str_weak(subscription_id),
-    /* K28  */  be_const_int(3),
-    /* K29  */  be_nested_str_weak(_inner_process_read_request),
-    /* K30  */  be_nested_str_weak(send_subscribe_response),
+    ( &(const bvalue[29]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(SubscribeRequestMessage),
+    /* K2   */  be_nested_str_weak(from_TLV),
+    /* K3   */  be_nested_str_weak(keep_subscriptions),
+    /* K4   */  be_nested_str_weak(subs_shop),
+    /* K5   */  be_nested_str_weak(remove_by_session),
+    /* K6   */  be_nested_str_weak(session),
+    /* K7   */  be_nested_str_weak(new_subscription),
+    /* K8   */  be_nested_str_weak(Path),
+    /* K9   */  be_nested_str_weak(attributes_requests),
+    /* K10  */  be_nested_str_weak(endpoint),
+    /* K11  */  be_nested_str_weak(cluster),
+    /* K12  */  be_nested_str_weak(attribute),
+    /* K13  */  be_nested_str_weak(push),
+    /* K14  */  be_nested_str_weak(stop_iteration),
+    /* K15  */  be_nested_str_weak(tasmota),
+    /* K16  */  be_nested_str_weak(log),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X2C_X20keep_X3D_X25i_X29_X20sub_X3D_X25i),
+    /* K18  */  be_nested_str_weak(local_session_id),
+    /* K19  */  be_nested_str_weak(concat),
+    /* K20  */  be_nested_str_weak(_X20),
+    /* K21  */  be_nested_str_weak(min_interval),
+    /* K22  */  be_nested_str_weak(max_interval),
+    /* K23  */  be_const_int(1),
+    /* K24  */  be_const_int(0),
+    /* K25  */  be_nested_str_weak(subscription_id),
+    /* K26  */  be_const_int(3),
+    /* K27  */  be_nested_str_weak(_inner_process_read_request),
+    /* K28  */  be_nested_str_weak(send_subscribe_response),
     }),
     be_str_weak(subscribe_request),
     &be_const_str_solidified,
-    ( &(const binstruction[78]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0x88140904,  //  0007  GETMBR	R5	R4	K4
-      0x74160003,  //  0008  JMPT	R5	#000D
-      0x88140105,  //  0009  GETMBR	R5	R0	K5
-      0x8C140B06,  //  000A  GETMET	R5	R5	K6
-      0x881C0307,  //  000B  GETMBR	R7	R1	K7
-      0x7C140400,  //  000C  CALL	R5	2
-      0x88140105,  //  000D  GETMBR	R5	R0	K5
-      0x8C140B08,  //  000E  GETMET	R5	R5	K8
-      0x881C0307,  //  000F  GETMBR	R7	R1	K7
-      0x5C200800,  //  0010  MOVE	R8	R4
-      0x7C140600,  //  0011  CALL	R5	3
-      0x60180012,  //  0012  GETGBL	R6	G18
-      0x7C180000,  //  0013  CALL	R6	0
-      0xB81E0200,  //  0014  GETNGBL	R7	K1
-      0x8C1C0F09,  //  0015  GETMET	R7	R7	K9
-      0x7C1C0200,  //  0016  CALL	R7	1
-      0x60200010,  //  0017  GETGBL	R8	G16
-      0x8824090A,  //  0018  GETMBR	R9	R4	K10
-      0x7C200200,  //  0019  CALL	R8	1
-      0xA802000D,  //  001A  EXBLK	0	#0029
-      0x5C241000,  //  001B  MOVE	R9	R8
-      0x7C240000,  //  001C  CALL	R9	0
-      0x8828130B,  //  001D  GETMBR	R10	R9	K11
-      0x901E160A,  //  001E  SETMBR	R7	K11	R10
-      0x8828130C,  //  001F  GETMBR	R10	R9	K12
-      0x901E180A,  //  0020  SETMBR	R7	K12	R10
-      0x8828130D,  //  0021  GETMBR	R10	R9	K13
-      0x901E1A0A,  //  0022  SETMBR	R7	K13	R10
-      0x8C280D0E,  //  0023  GETMET	R10	R6	K14
-      0x60300008,  //  0024  GETGBL	R12	G8
-      0x5C340E00,  //  0025  MOVE	R13	R7
-      0x7C300200,  //  0026  CALL	R12	1
-      0x7C280400,  //  0027  CALL	R10	2
-      0x7001FFF1,  //  0028  JMP		#001B
-      0x5820000F,  //  0029  LDCONST	R8	K15
-      0xAC200200,  //  002A  CATCH	R8	1	0
-      0xB0080000,  //  002B  RAISE	2	R0	R0
-      0xB8222000,  //  002C  GETNGBL	R8	K16
-      0x8C201111,  //  002D  GETMET	R8	R8	K17
-      0x8C280712,  //  002E  GETMET	R10	R3	K18
-      0x58300013,  //  002F  LDCONST	R12	K19
-      0x88340307,  //  0030  GETMBR	R13	R1	K7
-      0x88341B14,  //  0031  GETMBR	R13	R13	K20
-      0x8C380D15,  //  0032  GETMET	R14	R6	K21
-      0x58400016,  //  0033  LDCONST	R16	K22
-      0x7C380400,  //  0034  CALL	R14	2
-      0x883C0B17,  //  0035  GETMBR	R15	R5	K23
-      0x88400B18,  //  0036  GETMBR	R16	R5	K24
-      0x88440904,  //  0037  GETMBR	R17	R4	K4
-      0x78460001,  //  0038  JMPF	R17	#003B
-      0x58440019,  //  0039  LDCONST	R17	K25
-      0x70020000,  //  003A  JMP		#003C
-      0x5844001A,  //  003B  LDCONST	R17	K26
-      0x88480B1B,  //  003C  GETMBR	R18	R5	K27
-      0x7C281000,  //  003D  CALL	R10	8
-      0x582C001C,  //  003E  LDCONST	R11	K28
-      0x7C200600,  //  003F  CALL	R8	3
-      0x8C20011D,  //  0040  GETMET	R8	R0	K29
-      0x88280307,  //  0041  GETMBR	R10	R1	K7
-      0x5C2C0800,  //  0042  MOVE	R11	R4
-      0x50300200,  //  0043  LDBOOL	R12	1	0
-      0x7C200800,  //  0044  CALL	R8	4
-      0x88240B1B,  //  0045  GETMBR	R9	R5	K27
-      0x90223609,  //  0046  SETMBR	R8	K27	R9
-      0x8C24011E,  //  0047  GETMET	R9	R0	K30
-      0x5C2C0200,  //  0048  MOVE	R11	R1
-      0x5C301000,  //  0049  MOVE	R12	R8
-      0x5C340A00,  //  004A  MOVE	R13	R5
-      0x7C240800,  //  004B  CALL	R9	4
-      0x50240200,  //  004C  LDBOOL	R9	1	0
-      0x80041200,  //  004D  RET	1	R9
+    ( &(const binstruction[77]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x88100703,  //  0006  GETMBR	R4	R3	K3
+      0x74120003,  //  0007  JMPT	R4	#000C
+      0x88100104,  //  0008  GETMBR	R4	R0	K4
+      0x8C100905,  //  0009  GETMET	R4	R4	K5
+      0x88180306,  //  000A  GETMBR	R6	R1	K6
+      0x7C100400,  //  000B  CALL	R4	2
+      0x88100104,  //  000C  GETMBR	R4	R0	K4
+      0x8C100907,  //  000D  GETMET	R4	R4	K7
+      0x88180306,  //  000E  GETMBR	R6	R1	K6
+      0x5C1C0600,  //  000F  MOVE	R7	R3
+      0x7C100600,  //  0010  CALL	R4	3
+      0x60140012,  //  0011  GETGBL	R5	G18
+      0x7C140000,  //  0012  CALL	R5	0
+      0xB81A0000,  //  0013  GETNGBL	R6	K0
+      0x8C180D08,  //  0014  GETMET	R6	R6	K8
+      0x7C180200,  //  0015  CALL	R6	1
+      0x601C0010,  //  0016  GETGBL	R7	G16
+      0x88200709,  //  0017  GETMBR	R8	R3	K9
+      0x7C1C0200,  //  0018  CALL	R7	1
+      0xA802000D,  //  0019  EXBLK	0	#0028
+      0x5C200E00,  //  001A  MOVE	R8	R7
+      0x7C200000,  //  001B  CALL	R8	0
+      0x8824110A,  //  001C  GETMBR	R9	R8	K10
+      0x901A1409,  //  001D  SETMBR	R6	K10	R9
+      0x8824110B,  //  001E  GETMBR	R9	R8	K11
+      0x901A1609,  //  001F  SETMBR	R6	K11	R9
+      0x8824110C,  //  0020  GETMBR	R9	R8	K12
+      0x901A1809,  //  0021  SETMBR	R6	K12	R9
+      0x8C240B0D,  //  0022  GETMET	R9	R5	K13
+      0x602C0008,  //  0023  GETGBL	R11	G8
+      0x5C300C00,  //  0024  MOVE	R12	R6
+      0x7C2C0200,  //  0025  CALL	R11	1
+      0x7C240400,  //  0026  CALL	R9	2
+      0x7001FFF1,  //  0027  JMP		#001A
+      0x581C000E,  //  0028  LDCONST	R7	K14
+      0xAC1C0200,  //  0029  CATCH	R7	1	0
+      0xB0080000,  //  002A  RAISE	2	R0	R0
+      0xB81E1E00,  //  002B  GETNGBL	R7	K15
+      0x8C1C0F10,  //  002C  GETMET	R7	R7	K16
+      0x60240018,  //  002D  GETGBL	R9	G24
+      0x58280011,  //  002E  LDCONST	R10	K17
+      0x882C0306,  //  002F  GETMBR	R11	R1	K6
+      0x882C1712,  //  0030  GETMBR	R11	R11	K18
+      0x8C300B13,  //  0031  GETMET	R12	R5	K19
+      0x58380014,  //  0032  LDCONST	R14	K20
+      0x7C300400,  //  0033  CALL	R12	2
+      0x88340915,  //  0034  GETMBR	R13	R4	K21
+      0x88380916,  //  0035  GETMBR	R14	R4	K22
+      0x883C0703,  //  0036  GETMBR	R15	R3	K3
+      0x783E0001,  //  0037  JMPF	R15	#003A
+      0x583C0017,  //  0038  LDCONST	R15	K23
+      0x70020000,  //  0039  JMP		#003B
+      0x583C0018,  //  003A  LDCONST	R15	K24
+      0x88400919,  //  003B  GETMBR	R16	R4	K25
+      0x7C240E00,  //  003C  CALL	R9	7
+      0x5828001A,  //  003D  LDCONST	R10	K26
+      0x7C1C0600,  //  003E  CALL	R7	3
+      0x8C1C011B,  //  003F  GETMET	R7	R0	K27
+      0x88240306,  //  0040  GETMBR	R9	R1	K6
+      0x5C280600,  //  0041  MOVE	R10	R3
+      0x502C0200,  //  0042  LDBOOL	R11	1	0
+      0x7C1C0800,  //  0043  CALL	R7	4
+      0x88200919,  //  0044  GETMBR	R8	R4	K25
+      0x901E3208,  //  0045  SETMBR	R7	K25	R8
+      0x8C20011C,  //  0046  GETMET	R8	R0	K28
+      0x5C280200,  //  0047  MOVE	R10	R1
+      0x5C2C0E00,  //  0048  MOVE	R11	R7
+      0x5C300800,  //  0049  MOVE	R12	R4
+      0x7C200800,  //  004A  CALL	R8	4
+      0x50200200,  //  004B  LDBOOL	R8	1	0
+      0x80041000,  //  004C  RET	1	R8
     })
   )
 );
@@ -545,7 +539,7 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_process_write_request,   /* name */
   be_nested_proto(
-    20,                          /* nstack */
+    19,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -553,7 +547,7 @@ be_local_closure(Matter_IM_process_write_request,   /* name */
     1,                          /* has sup protos */
     ( &(const struct bproto*[ 2]) {
       be_nested_proto(
-        19,                          /* nstack */
+        17,                          /* nstack */
         5,                          /* argc */
         0,                          /* varg */
         1,                          /* has upvals */
@@ -563,141 +557,138 @@ be_local_closure(Matter_IM_process_write_request,   /* name */
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
-        ( &(const bvalue[28]) {     /* constants */
-        /* K0   */  be_nested_str_weak(string),
-        /* K1   */  be_nested_str_weak(matter),
-        /* K2   */  be_nested_str_weak(get_attribute_name),
-        /* K3   */  be_nested_str_weak(cluster),
-        /* K4   */  be_nested_str_weak(attribute),
-        /* K5   */  be_nested_str_weak(_X20_X28),
-        /* K6   */  be_nested_str_weak(_X29),
-        /* K7   */  be_nested_str_weak(),
-        /* K8   */  be_nested_str_weak(status),
-        /* K9   */  be_nested_str_weak(UNSUPPORTED_WRITE),
-        /* K10  */  be_nested_str_weak(write_attribute),
-        /* K11  */  be_nested_str_weak(session),
-        /* K12  */  be_nested_str_weak(SUCCESS),
-        /* K13  */  be_nested_str_weak(AttributeStatusIB),
-        /* K14  */  be_nested_str_weak(path),
-        /* K15  */  be_nested_str_weak(AttributePathIB),
-        /* K16  */  be_nested_str_weak(StatusIB),
-        /* K17  */  be_nested_str_weak(endpoint),
-        /* K18  */  be_nested_str_weak(write_responses),
-        /* K19  */  be_nested_str_weak(push),
-        /* K20  */  be_nested_str_weak(tasmota),
-        /* K21  */  be_nested_str_weak(log),
-        /* K22  */  be_nested_str_weak(format),
-        /* K23  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
-        /* K24  */  be_const_int(0),
-        /* K25  */  be_const_int(2),
-        /* K26  */  be_const_int(3),
-        /* K27  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20_X25s_X25s_X20_X2D_X20IGNORED),
+        ( &(const bvalue[26]) {     /* constants */
+        /* K0   */  be_nested_str_weak(matter),
+        /* K1   */  be_nested_str_weak(get_attribute_name),
+        /* K2   */  be_nested_str_weak(cluster),
+        /* K3   */  be_nested_str_weak(attribute),
+        /* K4   */  be_nested_str_weak(_X20_X28),
+        /* K5   */  be_nested_str_weak(_X29),
+        /* K6   */  be_nested_str_weak(),
+        /* K7   */  be_nested_str_weak(status),
+        /* K8   */  be_nested_str_weak(UNSUPPORTED_WRITE),
+        /* K9   */  be_nested_str_weak(write_attribute),
+        /* K10  */  be_nested_str_weak(session),
+        /* K11  */  be_nested_str_weak(SUCCESS),
+        /* K12  */  be_nested_str_weak(AttributeStatusIB),
+        /* K13  */  be_nested_str_weak(path),
+        /* K14  */  be_nested_str_weak(AttributePathIB),
+        /* K15  */  be_nested_str_weak(StatusIB),
+        /* K16  */  be_nested_str_weak(endpoint),
+        /* K17  */  be_nested_str_weak(write_responses),
+        /* K18  */  be_nested_str_weak(push),
+        /* K19  */  be_nested_str_weak(tasmota),
+        /* K20  */  be_nested_str_weak(log),
+        /* K21  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
+        /* K22  */  be_const_int(0),
+        /* K23  */  be_const_int(2),
+        /* K24  */  be_const_int(3),
+        /* K25  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20_X25s_X25s_X20_X2D_X20IGNORED),
         }),
         be_str_weak(write_single_attribute),
         &be_const_str_solidified,
-        ( &(const binstruction[102]) {  /* code */
-          0xA4160000,  //  0000  IMPORT	R5	K0
-          0xB81A0200,  //  0001  GETNGBL	R6	K1
-          0x8C180D02,  //  0002  GETMET	R6	R6	K2
+        ( &(const binstruction[101]) {  /* code */
+          0xB8160000,  //  0000  GETNGBL	R5	K0
+          0x8C140B01,  //  0001  GETMET	R5	R5	K1
+          0x881C0502,  //  0002  GETMBR	R7	R2	K2
           0x88200503,  //  0003  GETMBR	R8	R2	K3
-          0x88240504,  //  0004  GETMBR	R9	R2	K4
-          0x7C180600,  //  0005  CALL	R6	3
-          0x781A0002,  //  0006  JMPF	R6	#000A
-          0x001E0A06,  //  0007  ADD	R7	K5	R6
-          0x001C0F06,  //  0008  ADD	R7	R7	K6
-          0x70020000,  //  0009  JMP		#000B
-          0x581C0007,  //  000A  LDCONST	R7	K7
-          0x5C180E00,  //  000B  MOVE	R6	R7
-          0xB81E0200,  //  000C  GETNGBL	R7	K1
-          0x881C0F09,  //  000D  GETMBR	R7	R7	K9
-          0x900A1007,  //  000E  SETMBR	R2	K8	R7
-          0x4C1C0000,  //  000F  LDNIL	R7
-          0x201C0207,  //  0010  NE	R7	R1	R7
-          0x781E0006,  //  0011  JMPF	R7	#0019
-          0x8C1C030A,  //  0012  GETMET	R7	R1	K10
-          0x68240000,  //  0013  GETUPV	R9	U0
-          0x8824130B,  //  0014  GETMBR	R9	R9	K11
-          0x5C280400,  //  0015  MOVE	R10	R2
-          0x5C2C0600,  //  0016  MOVE	R11	R3
-          0x7C1C0800,  //  0017  CALL	R7	4
-          0x70020000,  //  0018  JMP		#001A
-          0x4C1C0000,  //  0019  LDNIL	R7
-          0x781E0002,  //  001A  JMPF	R7	#001E
-          0xB8220200,  //  001B  GETNGBL	R8	K1
-          0x8820110C,  //  001C  GETMBR	R8	R8	K12
-          0x900A1008,  //  001D  SETMBR	R2	K8	R8
-          0x88200508,  //  001E  GETMBR	R8	R2	K8
-          0x4C240000,  //  001F  LDNIL	R9
-          0x20201009,  //  0020  NE	R8	R8	R9
-          0x78220037,  //  0021  JMPF	R8	#005A
-          0x78120035,  //  0022  JMPF	R4	#0059
-          0xB8220200,  //  0023  GETNGBL	R8	K1
-          0x8C20110D,  //  0024  GETMET	R8	R8	K13
-          0x7C200200,  //  0025  CALL	R8	1
-          0xB8260200,  //  0026  GETNGBL	R9	K1
-          0x8C24130F,  //  0027  GETMET	R9	R9	K15
-          0x7C240200,  //  0028  CALL	R9	1
-          0x90221C09,  //  0029  SETMBR	R8	K14	R9
-          0xB8260200,  //  002A  GETNGBL	R9	K1
-          0x8C241310,  //  002B  GETMET	R9	R9	K16
-          0x7C240200,  //  002C  CALL	R9	1
-          0x90221009,  //  002D  SETMBR	R8	K8	R9
-          0x8824110E,  //  002E  GETMBR	R9	R8	K14
-          0x88280511,  //  002F  GETMBR	R10	R2	K17
-          0x9026220A,  //  0030  SETMBR	R9	K17	R10
-          0x8824110E,  //  0031  GETMBR	R9	R8	K14
-          0x88280503,  //  0032  GETMBR	R10	R2	K3
-          0x9026060A,  //  0033  SETMBR	R9	K3	R10
-          0x8824110E,  //  0034  GETMBR	R9	R8	K14
-          0x88280504,  //  0035  GETMBR	R10	R2	K4
-          0x9026080A,  //  0036  SETMBR	R9	K4	R10
-          0x88241108,  //  0037  GETMBR	R9	R8	K8
-          0x88280508,  //  0038  GETMBR	R10	R2	K8
-          0x9026100A,  //  0039  SETMBR	R9	K8	R10
-          0x88240112,  //  003A  GETMBR	R9	R0	K18
-          0x8C241313,  //  003B  GETMET	R9	R9	K19
-          0x5C2C1000,  //  003C  MOVE	R11	R8
-          0x7C240400,  //  003D  CALL	R9	2
-          0xB8262800,  //  003E  GETNGBL	R9	K20
-          0x8C241315,  //  003F  GETMET	R9	R9	K21
-          0x8C2C0B16,  //  0040  GETMET	R11	R5	K22
-          0x58340017,  //  0041  LDCONST	R13	K23
-          0x60380008,  //  0042  GETGBL	R14	G8
-          0x5C3C0400,  //  0043  MOVE	R15	R2
-          0x7C380200,  //  0044  CALL	R14	1
-          0x5C3C0C00,  //  0045  MOVE	R15	R6
-          0x88400508,  //  0046  GETMBR	R16	R2	K8
-          0x88440508,  //  0047  GETMBR	R17	R2	K8
-          0xB84A0200,  //  0048  GETNGBL	R18	K1
-          0x8848250C,  //  0049  GETMBR	R18	R18	K12
-          0x1C442212,  //  004A  EQ	R17	R17	R18
-          0x78460001,  //  004B  JMPF	R17	#004E
-          0x5844000C,  //  004C  LDCONST	R17	K12
-          0x70020000,  //  004D  JMP		#004F
-          0x58440007,  //  004E  LDCONST	R17	K7
-          0x7C2C0C00,  //  004F  CALL	R11	6
-          0x88300511,  //  0050  GETMBR	R12	R2	K17
-          0x20301918,  //  0051  NE	R12	R12	K24
-          0x78320001,  //  0052  JMPF	R12	#0055
-          0x58300019,  //  0053  LDCONST	R12	K25
-          0x70020000,  //  0054  JMP		#0056
-          0x5830001A,  //  0055  LDCONST	R12	K26
-          0x7C240600,  //  0056  CALL	R9	3
-          0x50240200,  //  0057  LDBOOL	R9	1	0
-          0x80041200,  //  0058  RET	1	R9
-          0x7002000A,  //  0059  JMP		#0065
-          0xB8222800,  //  005A  GETNGBL	R8	K20
-          0x8C201115,  //  005B  GETMET	R8	R8	K21
-          0x8C280B16,  //  005C  GETMET	R10	R5	K22
-          0x5830001B,  //  005D  LDCONST	R12	K27
-          0x60340008,  //  005E  GETGBL	R13	G8
-          0x5C380400,  //  005F  MOVE	R14	R2
-          0x7C340200,  //  0060  CALL	R13	1
-          0x5C380C00,  //  0061  MOVE	R14	R6
-          0x7C280800,  //  0062  CALL	R10	4
-          0x582C001A,  //  0063  LDCONST	R11	K26
-          0x7C200600,  //  0064  CALL	R8	3
-          0x80000000,  //  0065  RET	0
+          0x7C140600,  //  0004  CALL	R5	3
+          0x78160002,  //  0005  JMPF	R5	#0009
+          0x001A0805,  //  0006  ADD	R6	K4	R5
+          0x00180D05,  //  0007  ADD	R6	R6	K5
+          0x70020000,  //  0008  JMP		#000A
+          0x58180006,  //  0009  LDCONST	R6	K6
+          0x5C140C00,  //  000A  MOVE	R5	R6
+          0xB81A0000,  //  000B  GETNGBL	R6	K0
+          0x88180D08,  //  000C  GETMBR	R6	R6	K8
+          0x900A0E06,  //  000D  SETMBR	R2	K7	R6
+          0x4C180000,  //  000E  LDNIL	R6
+          0x20180206,  //  000F  NE	R6	R1	R6
+          0x781A0006,  //  0010  JMPF	R6	#0018
+          0x8C180309,  //  0011  GETMET	R6	R1	K9
+          0x68200000,  //  0012  GETUPV	R8	U0
+          0x8820110A,  //  0013  GETMBR	R8	R8	K10
+          0x5C240400,  //  0014  MOVE	R9	R2
+          0x5C280600,  //  0015  MOVE	R10	R3
+          0x7C180800,  //  0016  CALL	R6	4
+          0x70020000,  //  0017  JMP		#0019
+          0x4C180000,  //  0018  LDNIL	R6
+          0x781A0002,  //  0019  JMPF	R6	#001D
+          0xB81E0000,  //  001A  GETNGBL	R7	K0
+          0x881C0F0B,  //  001B  GETMBR	R7	R7	K11
+          0x900A0E07,  //  001C  SETMBR	R2	K7	R7
+          0x881C0507,  //  001D  GETMBR	R7	R2	K7
+          0x4C200000,  //  001E  LDNIL	R8
+          0x201C0E08,  //  001F  NE	R7	R7	R8
+          0x781E0037,  //  0020  JMPF	R7	#0059
+          0x78120035,  //  0021  JMPF	R4	#0058
+          0xB81E0000,  //  0022  GETNGBL	R7	K0
+          0x8C1C0F0C,  //  0023  GETMET	R7	R7	K12
+          0x7C1C0200,  //  0024  CALL	R7	1
+          0xB8220000,  //  0025  GETNGBL	R8	K0
+          0x8C20110E,  //  0026  GETMET	R8	R8	K14
+          0x7C200200,  //  0027  CALL	R8	1
+          0x901E1A08,  //  0028  SETMBR	R7	K13	R8
+          0xB8220000,  //  0029  GETNGBL	R8	K0
+          0x8C20110F,  //  002A  GETMET	R8	R8	K15
+          0x7C200200,  //  002B  CALL	R8	1
+          0x901E0E08,  //  002C  SETMBR	R7	K7	R8
+          0x88200F0D,  //  002D  GETMBR	R8	R7	K13
+          0x88240510,  //  002E  GETMBR	R9	R2	K16
+          0x90222009,  //  002F  SETMBR	R8	K16	R9
+          0x88200F0D,  //  0030  GETMBR	R8	R7	K13
+          0x88240502,  //  0031  GETMBR	R9	R2	K2
+          0x90220409,  //  0032  SETMBR	R8	K2	R9
+          0x88200F0D,  //  0033  GETMBR	R8	R7	K13
+          0x88240503,  //  0034  GETMBR	R9	R2	K3
+          0x90220609,  //  0035  SETMBR	R8	K3	R9
+          0x88200F07,  //  0036  GETMBR	R8	R7	K7
+          0x88240507,  //  0037  GETMBR	R9	R2	K7
+          0x90220E09,  //  0038  SETMBR	R8	K7	R9
+          0x88200111,  //  0039  GETMBR	R8	R0	K17
+          0x8C201112,  //  003A  GETMET	R8	R8	K18
+          0x5C280E00,  //  003B  MOVE	R10	R7
+          0x7C200400,  //  003C  CALL	R8	2
+          0xB8222600,  //  003D  GETNGBL	R8	K19
+          0x8C201114,  //  003E  GETMET	R8	R8	K20
+          0x60280018,  //  003F  GETGBL	R10	G24
+          0x582C0015,  //  0040  LDCONST	R11	K21
+          0x60300008,  //  0041  GETGBL	R12	G8
+          0x5C340400,  //  0042  MOVE	R13	R2
+          0x7C300200,  //  0043  CALL	R12	1
+          0x5C340A00,  //  0044  MOVE	R13	R5
+          0x88380507,  //  0045  GETMBR	R14	R2	K7
+          0x883C0507,  //  0046  GETMBR	R15	R2	K7
+          0xB8420000,  //  0047  GETNGBL	R16	K0
+          0x8840210B,  //  0048  GETMBR	R16	R16	K11
+          0x1C3C1E10,  //  0049  EQ	R15	R15	R16
+          0x783E0001,  //  004A  JMPF	R15	#004D
+          0x583C000B,  //  004B  LDCONST	R15	K11
+          0x70020000,  //  004C  JMP		#004E
+          0x583C0006,  //  004D  LDCONST	R15	K6
+          0x7C280A00,  //  004E  CALL	R10	5
+          0x882C0510,  //  004F  GETMBR	R11	R2	K16
+          0x202C1716,  //  0050  NE	R11	R11	K22
+          0x782E0001,  //  0051  JMPF	R11	#0054
+          0x582C0017,  //  0052  LDCONST	R11	K23
+          0x70020000,  //  0053  JMP		#0055
+          0x582C0018,  //  0054  LDCONST	R11	K24
+          0x7C200600,  //  0055  CALL	R8	3
+          0x50200200,  //  0056  LDBOOL	R8	1	0
+          0x80041000,  //  0057  RET	1	R8
+          0x7002000A,  //  0058  JMP		#0064
+          0xB81E2600,  //  0059  GETNGBL	R7	K19
+          0x8C1C0F14,  //  005A  GETMET	R7	R7	K20
+          0x60240018,  //  005B  GETGBL	R9	G24
+          0x58280019,  //  005C  LDCONST	R10	K25
+          0x602C0008,  //  005D  GETGBL	R11	G8
+          0x5C300400,  //  005E  MOVE	R12	R2
+          0x7C2C0200,  //  005F  CALL	R11	1
+          0x5C300A00,  //  0060  MOVE	R12	R5
+          0x7C240600,  //  0061  CALL	R9	3
+          0x58280018,  //  0062  LDCONST	R10	K24
+          0x7C1C0600,  //  0063  CALL	R7	3
+          0x80000000,  //  0064  RET	0
         })
       ),
       be_nested_proto(
@@ -706,9 +697,9 @@ be_local_closure(Matter_IM_process_write_request,   /* name */
         0,                          /* varg */
         1,                          /* has upvals */
         ( &(const bupvaldesc[ 3]) {  /* upvals */
-          be_local_const_upval(1, 7),
-          be_local_const_upval(1, 9),
-          be_local_const_upval(1, 13),
+          be_local_const_upval(1, 6),
+          be_local_const_upval(1, 8),
+          be_local_const_upval(1, 12),
         }),
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
@@ -729,145 +720,143 @@ be_local_closure(Matter_IM_process_write_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(WriteRequestMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(suppress_response),
-    /* K5   */  be_nested_str_weak(device),
-    /* K6   */  be_nested_str_weak(get_active_endpoints),
-    /* K7   */  be_nested_str_weak(Path),
-    /* K8   */  be_nested_str_weak(write_requests),
-    /* K9   */  be_nested_str_weak(WriteResponseMessage),
-    /* K10  */  be_nested_str_weak(write_responses),
-    /* K11  */  be_nested_str_weak(path),
-    /* K12  */  be_nested_str_weak(data),
-    /* K13  */  be_nested_str_weak(endpoint),
-    /* K14  */  be_nested_str_weak(cluster),
-    /* K15  */  be_nested_str_weak(attribute),
-    /* K16  */  be_nested_str_weak(status),
-    /* K17  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    /* K18  */  be_nested_str_weak(INVALID_ACTION),
-    /* K19  */  be_nested_str_weak(get_attribute_name),
-    /* K20  */  be_nested_str_weak(tasmota),
-    /* K21  */  be_nested_str_weak(log),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
-    /* K23  */  be_nested_str_weak(_X20_X28),
-    /* K24  */  be_nested_str_weak(_X29),
-    /* K25  */  be_nested_str_weak(),
-    /* K26  */  be_const_int(3),
-    /* K27  */  be_nested_str_weak(process_attribute_expansion),
-    /* K28  */  be_nested_str_weak(stop_iteration),
-    /* K29  */  be_nested_str_weak(send_write_response),
+    ( &(const bvalue[29]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(WriteRequestMessage),
+    /* K2   */  be_nested_str_weak(from_TLV),
+    /* K3   */  be_nested_str_weak(suppress_response),
+    /* K4   */  be_nested_str_weak(device),
+    /* K5   */  be_nested_str_weak(get_active_endpoints),
+    /* K6   */  be_nested_str_weak(Path),
+    /* K7   */  be_nested_str_weak(write_requests),
+    /* K8   */  be_nested_str_weak(WriteResponseMessage),
+    /* K9   */  be_nested_str_weak(write_responses),
+    /* K10  */  be_nested_str_weak(path),
+    /* K11  */  be_nested_str_weak(data),
+    /* K12  */  be_nested_str_weak(endpoint),
+    /* K13  */  be_nested_str_weak(cluster),
+    /* K14  */  be_nested_str_weak(attribute),
+    /* K15  */  be_nested_str_weak(status),
+    /* K16  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+    /* K17  */  be_nested_str_weak(INVALID_ACTION),
+    /* K18  */  be_nested_str_weak(get_attribute_name),
+    /* K19  */  be_nested_str_weak(tasmota),
+    /* K20  */  be_nested_str_weak(log),
+    /* K21  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
+    /* K22  */  be_nested_str_weak(_X20_X28),
+    /* K23  */  be_nested_str_weak(_X29),
+    /* K24  */  be_nested_str_weak(),
+    /* K25  */  be_const_int(3),
+    /* K26  */  be_nested_str_weak(process_attribute_expansion),
+    /* K27  */  be_nested_str_weak(stop_iteration),
+    /* K28  */  be_nested_str_weak(send_write_response),
     }),
     be_str_weak(process_write_request),
     &be_const_str_solidified,
-    ( &(const binstruction[104]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0x88140904,  //  0007  GETMBR	R5	R4	K4
-      0x88180105,  //  0008  GETMBR	R6	R0	K5
-      0x8C180D06,  //  0009  GETMET	R6	R6	K6
-      0x7C180200,  //  000A  CALL	R6	1
-      0x841C0000,  //  000B  CLOSURE	R7	P0
-      0xB8220200,  //  000C  GETNGBL	R8	K1
-      0x8C201107,  //  000D  GETMET	R8	R8	K7
-      0x7C200200,  //  000E  CALL	R8	1
-      0x88240908,  //  000F  GETMBR	R9	R4	K8
-      0x4C280000,  //  0010  LDNIL	R10
-      0x2024120A,  //  0011  NE	R9	R9	R10
-      0x78260051,  //  0012  JMPF	R9	#0065
-      0xB8260200,  //  0013  GETNGBL	R9	K1
-      0x8C241309,  //  0014  GETMET	R9	R9	K9
-      0x7C240200,  //  0015  CALL	R9	1
-      0x60280012,  //  0016  GETGBL	R10	G18
-      0x7C280000,  //  0017  CALL	R10	0
-      0x9026140A,  //  0018  SETMBR	R9	K10	R10
-      0x60280010,  //  0019  GETGBL	R10	G16
-      0x882C0908,  //  001A  GETMBR	R11	R4	K8
-      0x7C280200,  //  001B  CALL	R10	1
-      0xA802003D,  //  001C  EXBLK	0	#005B
-      0x5C2C1400,  //  001D  MOVE	R11	R10
-      0x7C2C0000,  //  001E  CALL	R11	0
-      0x8830170B,  //  001F  GETMBR	R12	R11	K11
+    ( &(const binstruction[103]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x88100703,  //  0006  GETMBR	R4	R3	K3
+      0x88140104,  //  0007  GETMBR	R5	R0	K4
+      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0x7C140200,  //  0009  CALL	R5	1
+      0x84180000,  //  000A  CLOSURE	R6	P0
+      0xB81E0000,  //  000B  GETNGBL	R7	K0
+      0x8C1C0F06,  //  000C  GETMET	R7	R7	K6
+      0x7C1C0200,  //  000D  CALL	R7	1
+      0x88200707,  //  000E  GETMBR	R8	R3	K7
+      0x4C240000,  //  000F  LDNIL	R9
+      0x20201009,  //  0010  NE	R8	R8	R9
+      0x78220051,  //  0011  JMPF	R8	#0064
+      0xB8220000,  //  0012  GETNGBL	R8	K0
+      0x8C201108,  //  0013  GETMET	R8	R8	K8
+      0x7C200200,  //  0014  CALL	R8	1
+      0x60240012,  //  0015  GETGBL	R9	G18
+      0x7C240000,  //  0016  CALL	R9	0
+      0x90221209,  //  0017  SETMBR	R8	K9	R9
+      0x60240010,  //  0018  GETGBL	R9	G16
+      0x88280707,  //  0019  GETMBR	R10	R3	K7
+      0x7C240200,  //  001A  CALL	R9	1
+      0xA802003D,  //  001B  EXBLK	0	#005A
+      0x5C281200,  //  001C  MOVE	R10	R9
+      0x7C280000,  //  001D  CALL	R10	0
+      0x882C150A,  //  001E  GETMBR	R11	R10	K10
+      0x8830150B,  //  001F  GETMBR	R12	R10	K11
       0x8834170C,  //  0020  GETMBR	R13	R11	K12
-      0x8838190D,  //  0021  GETMBR	R14	R12	K13
-      0x90221A0E,  //  0022  SETMBR	R8	K13	R14
-      0x8838190E,  //  0023  GETMBR	R14	R12	K14
-      0x90221C0E,  //  0024  SETMBR	R8	K14	R14
-      0x8838190F,  //  0025  GETMBR	R14	R12	K15
-      0x90221E0E,  //  0026  SETMBR	R8	K15	R14
-      0xB83A0200,  //  0027  GETNGBL	R14	K1
-      0x88381D11,  //  0028  GETMBR	R14	R14	K17
-      0x9022200E,  //  0029  SETMBR	R8	K16	R14
-      0x8838110E,  //  002A  GETMBR	R14	R8	K14
-      0x4C3C0000,  //  002B  LDNIL	R15
-      0x1C381C0F,  //  002C  EQ	R14	R14	R15
-      0x743A0003,  //  002D  JMPT	R14	#0032
-      0x8838110F,  //  002E  GETMBR	R14	R8	K15
-      0x4C3C0000,  //  002F  LDNIL	R15
-      0x1C381C0F,  //  0030  EQ	R14	R14	R15
-      0x783A000A,  //  0031  JMPF	R14	#003D
-      0xB83A0200,  //  0032  GETNGBL	R14	K1
-      0x88381D12,  //  0033  GETMBR	R14	R14	K18
-      0x9022200E,  //  0034  SETMBR	R8	K16	R14
-      0x5C380E00,  //  0035  MOVE	R14	R7
-      0x5C3C1200,  //  0036  MOVE	R15	R9
-      0x4C400000,  //  0037  LDNIL	R16
-      0x5C441000,  //  0038  MOVE	R17	R8
-      0x4C480000,  //  0039  LDNIL	R18
-      0x504C0200,  //  003A  LDBOOL	R19	1	0
-      0x7C380A00,  //  003B  CALL	R14	5
-      0x7001FFDF,  //  003C  JMP		#001D
-      0x8838110D,  //  003D  GETMBR	R14	R8	K13
-      0x4C3C0000,  //  003E  LDNIL	R15
-      0x1C381C0F,  //  003F  EQ	R14	R14	R15
-      0x783A0012,  //  0040  JMPF	R14	#0054
-      0xB83A0200,  //  0041  GETNGBL	R14	K1
-      0x8C381D13,  //  0042  GETMET	R14	R14	K19
-      0x8840110E,  //  0043  GETMBR	R16	R8	K14
-      0x8844110F,  //  0044  GETMBR	R17	R8	K15
-      0x7C380600,  //  0045  CALL	R14	3
-      0xB83E2800,  //  0046  GETNGBL	R15	K20
-      0x8C3C1F15,  //  0047  GETMET	R15	R15	K21
-      0x60440008,  //  0048  GETGBL	R17	G8
-      0x5C481000,  //  0049  MOVE	R18	R8
-      0x7C440200,  //  004A  CALL	R17	1
-      0x00462C11,  //  004B  ADD	R17	K22	R17
-      0x783A0002,  //  004C  JMPF	R14	#0050
-      0x004A2E0E,  //  004D  ADD	R18	K23	R14
-      0x00482518,  //  004E  ADD	R18	R18	K24
-      0x70020000,  //  004F  JMP		#0051
-      0x58480019,  //  0050  LDCONST	R18	K25
-      0x00442212,  //  0051  ADD	R17	R17	R18
-      0x5848001A,  //  0052  LDCONST	R18	K26
-      0x7C3C0600,  //  0053  CALL	R15	3
-      0x88380105,  //  0054  GETMBR	R14	R0	K5
-      0x8C381D1B,  //  0055  GETMET	R14	R14	K27
-      0x5C401000,  //  0056  MOVE	R16	R8
-      0x84440001,  //  0057  CLOSURE	R17	P1
-      0x7C380600,  //  0058  CALL	R14	3
-      0xA0280000,  //  0059  CLOSE	R10
-      0x7001FFC1,  //  005A  JMP		#001D
-      0x5828001C,  //  005B  LDCONST	R10	K28
-      0xAC280200,  //  005C  CATCH	R10	1	0
-      0xB0080000,  //  005D  RAISE	2	R0	R0
-      0x5C280A00,  //  005E  MOVE	R10	R5
-      0x742A0003,  //  005F  JMPT	R10	#0064
-      0x8C28011D,  //  0060  GETMET	R10	R0	K29
-      0x5C300200,  //  0061  MOVE	R12	R1
-      0x5C341200,  //  0062  MOVE	R13	R9
-      0x7C280600,  //  0063  CALL	R10	3
-      0xA0240000,  //  0064  CLOSE	R9
-      0x50240200,  //  0065  LDBOOL	R9	1	0
-      0xA0000000,  //  0066  CLOSE	R0
-      0x80041200,  //  0067  RET	1	R9
+      0x901E180D,  //  0021  SETMBR	R7	K12	R13
+      0x8834170D,  //  0022  GETMBR	R13	R11	K13
+      0x901E1A0D,  //  0023  SETMBR	R7	K13	R13
+      0x8834170E,  //  0024  GETMBR	R13	R11	K14
+      0x901E1C0D,  //  0025  SETMBR	R7	K14	R13
+      0xB8360000,  //  0026  GETNGBL	R13	K0
+      0x88341B10,  //  0027  GETMBR	R13	R13	K16
+      0x901E1E0D,  //  0028  SETMBR	R7	K15	R13
+      0x88340F0D,  //  0029  GETMBR	R13	R7	K13
+      0x4C380000,  //  002A  LDNIL	R14
+      0x1C341A0E,  //  002B  EQ	R13	R13	R14
+      0x74360003,  //  002C  JMPT	R13	#0031
+      0x88340F0E,  //  002D  GETMBR	R13	R7	K14
+      0x4C380000,  //  002E  LDNIL	R14
+      0x1C341A0E,  //  002F  EQ	R13	R13	R14
+      0x7836000A,  //  0030  JMPF	R13	#003C
+      0xB8360000,  //  0031  GETNGBL	R13	K0
+      0x88341B11,  //  0032  GETMBR	R13	R13	K17
+      0x901E1E0D,  //  0033  SETMBR	R7	K15	R13
+      0x5C340C00,  //  0034  MOVE	R13	R6
+      0x5C381000,  //  0035  MOVE	R14	R8
+      0x4C3C0000,  //  0036  LDNIL	R15
+      0x5C400E00,  //  0037  MOVE	R16	R7
+      0x4C440000,  //  0038  LDNIL	R17
+      0x50480200,  //  0039  LDBOOL	R18	1	0
+      0x7C340A00,  //  003A  CALL	R13	5
+      0x7001FFDF,  //  003B  JMP		#001C
+      0x88340F0C,  //  003C  GETMBR	R13	R7	K12
+      0x4C380000,  //  003D  LDNIL	R14
+      0x1C341A0E,  //  003E  EQ	R13	R13	R14
+      0x78360012,  //  003F  JMPF	R13	#0053
+      0xB8360000,  //  0040  GETNGBL	R13	K0
+      0x8C341B12,  //  0041  GETMET	R13	R13	K18
+      0x883C0F0D,  //  0042  GETMBR	R15	R7	K13
+      0x88400F0E,  //  0043  GETMBR	R16	R7	K14
+      0x7C340600,  //  0044  CALL	R13	3
+      0xB83A2600,  //  0045  GETNGBL	R14	K19
+      0x8C381D14,  //  0046  GETMET	R14	R14	K20
+      0x60400008,  //  0047  GETGBL	R16	G8
+      0x5C440E00,  //  0048  MOVE	R17	R7
+      0x7C400200,  //  0049  CALL	R16	1
+      0x00422A10,  //  004A  ADD	R16	K21	R16
+      0x78360002,  //  004B  JMPF	R13	#004F
+      0x00462C0D,  //  004C  ADD	R17	K22	R13
+      0x00442317,  //  004D  ADD	R17	R17	K23
+      0x70020000,  //  004E  JMP		#0050
+      0x58440018,  //  004F  LDCONST	R17	K24
+      0x00402011,  //  0050  ADD	R16	R16	R17
+      0x58440019,  //  0051  LDCONST	R17	K25
+      0x7C380600,  //  0052  CALL	R14	3
+      0x88340104,  //  0053  GETMBR	R13	R0	K4
+      0x8C341B1A,  //  0054  GETMET	R13	R13	K26
+      0x5C3C0E00,  //  0055  MOVE	R15	R7
+      0x84400001,  //  0056  CLOSURE	R16	P1
+      0x7C340600,  //  0057  CALL	R13	3
+      0xA0240000,  //  0058  CLOSE	R9
+      0x7001FFC1,  //  0059  JMP		#001C
+      0x5824001B,  //  005A  LDCONST	R9	K27
+      0xAC240200,  //  005B  CATCH	R9	1	0
+      0xB0080000,  //  005C  RAISE	2	R0	R0
+      0x5C240800,  //  005D  MOVE	R9	R4
+      0x74260003,  //  005E  JMPT	R9	#0063
+      0x8C24011C,  //  005F  GETMET	R9	R0	K28
+      0x5C2C0200,  //  0060  MOVE	R11	R1
+      0x5C301000,  //  0061  MOVE	R12	R8
+      0x7C240600,  //  0062  CALL	R9	3
+      0xA0200000,  //  0063  CLOSE	R8
+      0x50200200,  //  0064  LDBOOL	R8	1	0
+      0xA0000000,  //  0065  CLOSE	R0
+      0x80041000,  //  0066  RET	1	R8
     })
   )
 );
@@ -1173,7 +1162,7 @@ be_local_closure(Matter_IM_send_status,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_subscribe_response,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1181,24 +1170,22 @@ be_local_closure(Matter_IM_subscribe_response,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(SubscribeResponseMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(SubscribeResponseMessage),
+    /* K2   */  be_nested_str_weak(from_TLV),
     }),
     be_str_weak(subscribe_response),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0x50140000,  //  0007  LDBOOL	R5	0	0
-      0x80040A00,  //  0008  RET	1	R5
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x50100000,  //  0006  LDBOOL	R4	0	0
+      0x80040800,  //  0007  RET	1	R4
     })
   )
 );
@@ -1365,7 +1352,7 @@ be_local_closure(Matter_IM_process_incoming,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM__inner_process_read_request,   /* name */
   be_nested_proto(
-    20,                          /* nstack */
+    18,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1373,7 +1360,7 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
     1,                          /* has sup protos */
     ( &(const struct bproto*[ 2]) {
       be_nested_proto(
-        25,                          /* nstack */
+        23,                          /* nstack */
         4,                          /* argc */
         0,                          /* varg */
         1,                          /* has upvals */
@@ -1384,257 +1371,254 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
-        ( &(const bvalue[40]) {     /* constants */
-        /* K0   */  be_nested_str_weak(string),
-        /* K1   */  be_nested_str_weak(matter),
-        /* K2   */  be_nested_str_weak(TLV),
-        /* K3   */  be_nested_str_weak(get_attribute_name),
-        /* K4   */  be_nested_str_weak(cluster),
-        /* K5   */  be_nested_str_weak(attribute),
-        /* K6   */  be_nested_str_weak(_X20_X28),
-        /* K7   */  be_nested_str_weak(_X29),
-        /* K8   */  be_nested_str_weak(),
-        /* K9   */  be_nested_str_weak(read_attribute),
-        /* K10  */  be_nested_str_weak(AttributeReportIB),
-        /* K11  */  be_nested_str_weak(attribute_data),
-        /* K12  */  be_nested_str_weak(AttributeDataIB),
-        /* K13  */  be_nested_str_weak(data_version),
-        /* K14  */  be_const_int(1),
-        /* K15  */  be_nested_str_weak(path),
-        /* K16  */  be_nested_str_weak(AttributePathIB),
-        /* K17  */  be_nested_str_weak(endpoint),
-        /* K18  */  be_nested_str_weak(data),
-        /* K19  */  be_nested_str_weak(to_TLV),
-        /* K20  */  be_nested_str_weak(encode_len),
-        /* K21  */  be_nested_str_weak(tlv2raw),
-        /* K22  */  be_nested_str_weak(tasmota),
-        /* K23  */  be_nested_str_weak(log),
-        /* K24  */  be_nested_str_weak(format),
-        /* K25  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
-        /* K26  */  be_nested_str_weak(local_session_id),
-        /* K27  */  be_const_int(3),
-        /* K28  */  be_nested_str_weak(status),
-        /* K29  */  be_nested_str_weak(attribute_status),
-        /* K30  */  be_nested_str_weak(AttributeStatusIB),
-        /* K31  */  be_nested_str_weak(StatusIB),
-        /* K32  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
-        /* K33  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-        /* K34  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20IGNORED),
-        /* K35  */  be_nested_str_weak(attribute_reports),
-        /* K36  */  be_const_int(0),
-        /* K37  */  be_nested_str_weak(push),
-        /* K38  */  be_nested_str_weak(IM_ReportData),
-        /* K39  */  be_nested_str_weak(MAX_MESSAGE),
+        ( &(const bvalue[38]) {     /* constants */
+        /* K0   */  be_nested_str_weak(matter),
+        /* K1   */  be_nested_str_weak(TLV),
+        /* K2   */  be_nested_str_weak(get_attribute_name),
+        /* K3   */  be_nested_str_weak(cluster),
+        /* K4   */  be_nested_str_weak(attribute),
+        /* K5   */  be_nested_str_weak(_X20_X28),
+        /* K6   */  be_nested_str_weak(_X29),
+        /* K7   */  be_nested_str_weak(),
+        /* K8   */  be_nested_str_weak(read_attribute),
+        /* K9   */  be_nested_str_weak(AttributeReportIB),
+        /* K10  */  be_nested_str_weak(attribute_data),
+        /* K11  */  be_nested_str_weak(AttributeDataIB),
+        /* K12  */  be_nested_str_weak(data_version),
+        /* K13  */  be_const_int(1),
+        /* K14  */  be_nested_str_weak(path),
+        /* K15  */  be_nested_str_weak(AttributePathIB),
+        /* K16  */  be_nested_str_weak(endpoint),
+        /* K17  */  be_nested_str_weak(data),
+        /* K18  */  be_nested_str_weak(to_TLV),
+        /* K19  */  be_nested_str_weak(encode_len),
+        /* K20  */  be_nested_str_weak(tlv2raw),
+        /* K21  */  be_nested_str_weak(tasmota),
+        /* K22  */  be_nested_str_weak(log),
+        /* K23  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
+        /* K24  */  be_nested_str_weak(local_session_id),
+        /* K25  */  be_const_int(3),
+        /* K26  */  be_nested_str_weak(status),
+        /* K27  */  be_nested_str_weak(attribute_status),
+        /* K28  */  be_nested_str_weak(AttributeStatusIB),
+        /* K29  */  be_nested_str_weak(StatusIB),
+        /* K30  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
+        /* K31  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+        /* K32  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20IGNORED),
+        /* K33  */  be_nested_str_weak(attribute_reports),
+        /* K34  */  be_const_int(0),
+        /* K35  */  be_nested_str_weak(push),
+        /* K36  */  be_nested_str_weak(IM_ReportData),
+        /* K37  */  be_nested_str_weak(MAX_MESSAGE),
         }),
         be_str_weak(read_single_attribute),
         &be_const_str_solidified,
-        ( &(const binstruction[206]) {  /* code */
-          0xA4120000,  //  0000  IMPORT	R4	K0
-          0xB8160200,  //  0001  GETNGBL	R5	K1
-          0x88140B02,  //  0002  GETMBR	R5	R5	K2
-          0xB81A0200,  //  0003  GETNGBL	R6	K1
-          0x8C180D03,  //  0004  GETMET	R6	R6	K3
+        ( &(const binstruction[205]) {  /* code */
+          0xB8120000,  //  0000  GETNGBL	R4	K0
+          0x88100901,  //  0001  GETMBR	R4	R4	K1
+          0xB8160000,  //  0002  GETNGBL	R5	K0
+          0x8C140B02,  //  0003  GETMET	R5	R5	K2
+          0x881C0503,  //  0004  GETMBR	R7	R2	K3
           0x88200504,  //  0005  GETMBR	R8	R2	K4
-          0x88240505,  //  0006  GETMBR	R9	R2	K5
-          0x7C180600,  //  0007  CALL	R6	3
-          0x781A0002,  //  0008  JMPF	R6	#000C
-          0x001E0C06,  //  0009  ADD	R7	K6	R6
-          0x001C0F07,  //  000A  ADD	R7	R7	K7
-          0x70020000,  //  000B  JMP		#000D
-          0x581C0008,  //  000C  LDCONST	R7	K8
-          0x5C180E00,  //  000D  MOVE	R6	R7
-          0x4C1C0000,  //  000E  LDNIL	R7
-          0x201C0207,  //  000F  NE	R7	R1	R7
-          0x781E0004,  //  0010  JMPF	R7	#0016
-          0x8C1C0309,  //  0011  GETMET	R7	R1	K9
-          0x68240000,  //  0012  GETUPV	R9	U0
-          0x5C280400,  //  0013  MOVE	R10	R2
-          0x7C1C0600,  //  0014  CALL	R7	3
-          0x70020000,  //  0015  JMP		#0017
-          0x4C1C0000,  //  0016  LDNIL	R7
-          0x50200200,  //  0017  LDBOOL	R8	1	0
+          0x7C140600,  //  0006  CALL	R5	3
+          0x78160002,  //  0007  JMPF	R5	#000B
+          0x001A0A05,  //  0008  ADD	R6	K5	R5
+          0x00180D06,  //  0009  ADD	R6	R6	K6
+          0x70020000,  //  000A  JMP		#000C
+          0x58180007,  //  000B  LDCONST	R6	K7
+          0x5C140C00,  //  000C  MOVE	R5	R6
+          0x4C180000,  //  000D  LDNIL	R6
+          0x20180206,  //  000E  NE	R6	R1	R6
+          0x781A0004,  //  000F  JMPF	R6	#0015
+          0x8C180308,  //  0010  GETMET	R6	R1	K8
+          0x68200000,  //  0011  GETUPV	R8	U0
+          0x5C240400,  //  0012  MOVE	R9	R2
+          0x7C180600,  //  0013  CALL	R6	3
+          0x70020000,  //  0014  JMP		#0016
+          0x4C180000,  //  0015  LDNIL	R6
+          0x501C0200,  //  0016  LDBOOL	R7	1	0
+          0x4C200000,  //  0017  LDNIL	R8
           0x4C240000,  //  0018  LDNIL	R9
-          0x4C280000,  //  0019  LDNIL	R10
-          0x20280E0A,  //  001A  NE	R10	R7	R10
-          0x782A003A,  //  001B  JMPF	R10	#0057
-          0x60280008,  //  001C  GETGBL	R10	G8
-          0x5C2C0E00,  //  001D  MOVE	R11	R7
-          0x7C280200,  //  001E  CALL	R10	1
-          0xB82E0200,  //  001F  GETNGBL	R11	K1
-          0x8C2C170A,  //  0020  GETMET	R11	R11	K10
-          0x7C2C0200,  //  0021  CALL	R11	1
-          0xB8320200,  //  0022  GETNGBL	R12	K1
-          0x8C30190C,  //  0023  GETMET	R12	R12	K12
-          0x7C300200,  //  0024  CALL	R12	1
-          0x902E160C,  //  0025  SETMBR	R11	K11	R12
-          0x8830170B,  //  0026  GETMBR	R12	R11	K11
-          0x90321B0E,  //  0027  SETMBR	R12	K13	K14
-          0x8830170B,  //  0028  GETMBR	R12	R11	K11
-          0xB8360200,  //  0029  GETNGBL	R13	K1
-          0x8C341B10,  //  002A  GETMET	R13	R13	K16
-          0x7C340200,  //  002B  CALL	R13	1
-          0x90321E0D,  //  002C  SETMBR	R12	K15	R13
-          0x8830170B,  //  002D  GETMBR	R12	R11	K11
-          0x8830190F,  //  002E  GETMBR	R12	R12	K15
-          0x88340511,  //  002F  GETMBR	R13	R2	K17
-          0x9032220D,  //  0030  SETMBR	R12	K17	R13
-          0x8830170B,  //  0031  GETMBR	R12	R11	K11
-          0x8830190F,  //  0032  GETMBR	R12	R12	K15
-          0x88340504,  //  0033  GETMBR	R13	R2	K4
-          0x9032080D,  //  0034  SETMBR	R12	K4	R13
-          0x8830170B,  //  0035  GETMBR	R12	R11	K11
-          0x8830190F,  //  0036  GETMBR	R12	R12	K15
-          0x88340505,  //  0037  GETMBR	R13	R2	K5
-          0x90320A0D,  //  0038  SETMBR	R12	K5	R13
-          0x8830170B,  //  0039  GETMBR	R12	R11	K11
-          0x90322407,  //  003A  SETMBR	R12	K18	R7
-          0x8C301713,  //  003B  GETMET	R12	R11	K19
-          0x7C300200,  //  003C  CALL	R12	1
-          0x8C341914,  //  003D  GETMET	R13	R12	K20
-          0x7C340200,  //  003E  CALL	R13	1
-          0x60380015,  //  003F  GETGBL	R14	G21
-          0x5C3C1A00,  //  0040  MOVE	R15	R13
-          0x7C380200,  //  0041  CALL	R14	1
-          0x8C3C1915,  //  0042  GETMET	R15	R12	K21
-          0x5C441C00,  //  0043  MOVE	R17	R14
-          0x7C3C0400,  //  0044  CALL	R15	2
-          0x5C241E00,  //  0045  MOVE	R9	R15
-          0x683C0001,  //  0046  GETUPV	R15	U1
-          0x743E000D,  //  0047  JMPT	R15	#0056
-          0xB83E2C00,  //  0048  GETNGBL	R15	K22
-          0x8C3C1F17,  //  0049  GETMET	R15	R15	K23
-          0x8C440918,  //  004A  GETMET	R17	R4	K24
-          0x584C0019,  //  004B  LDCONST	R19	K25
-          0x68500000,  //  004C  GETUPV	R20	U0
-          0x8850291A,  //  004D  GETMBR	R20	R20	K26
-          0x60540008,  //  004E  GETGBL	R21	G8
-          0x5C580400,  //  004F  MOVE	R22	R2
-          0x7C540200,  //  0050  CALL	R21	1
-          0x5C580C00,  //  0051  MOVE	R22	R6
-          0x5C5C1400,  //  0052  MOVE	R23	R10
-          0x7C440C00,  //  0053  CALL	R17	6
-          0x5848001B,  //  0054  LDCONST	R18	K27
-          0x7C3C0600,  //  0055  CALL	R15	3
-          0x70020055,  //  0056  JMP		#00AD
-          0x8828051C,  //  0057  GETMBR	R10	R2	K28
-          0x4C2C0000,  //  0058  LDNIL	R11
-          0x2028140B,  //  0059  NE	R10	R10	R11
-          0x782A0043,  //  005A  JMPF	R10	#009F
-          0x780E0041,  //  005B  JMPF	R3	#009E
-          0xB82A0200,  //  005C  GETNGBL	R10	K1
-          0x8C28150A,  //  005D  GETMET	R10	R10	K10
-          0x7C280200,  //  005E  CALL	R10	1
-          0xB82E0200,  //  005F  GETNGBL	R11	K1
-          0x8C2C171E,  //  0060  GETMET	R11	R11	K30
-          0x7C2C0200,  //  0061  CALL	R11	1
-          0x902A3A0B,  //  0062  SETMBR	R10	K29	R11
-          0x882C151D,  //  0063  GETMBR	R11	R10	K29
-          0xB8320200,  //  0064  GETNGBL	R12	K1
-          0x8C301910,  //  0065  GETMET	R12	R12	K16
-          0x7C300200,  //  0066  CALL	R12	1
-          0x902E1E0C,  //  0067  SETMBR	R11	K15	R12
-          0x882C151D,  //  0068  GETMBR	R11	R10	K29
-          0xB8320200,  //  0069  GETNGBL	R12	K1
-          0x8C30191F,  //  006A  GETMET	R12	R12	K31
-          0x7C300200,  //  006B  CALL	R12	1
-          0x902E380C,  //  006C  SETMBR	R11	K28	R12
-          0x882C151D,  //  006D  GETMBR	R11	R10	K29
-          0x882C170F,  //  006E  GETMBR	R11	R11	K15
-          0x88300511,  //  006F  GETMBR	R12	R2	K17
-          0x902E220C,  //  0070  SETMBR	R11	K17	R12
-          0x882C151D,  //  0071  GETMBR	R11	R10	K29
-          0x882C170F,  //  0072  GETMBR	R11	R11	K15
-          0x88300504,  //  0073  GETMBR	R12	R2	K4
-          0x902E080C,  //  0074  SETMBR	R11	K4	R12
-          0x882C151D,  //  0075  GETMBR	R11	R10	K29
-          0x882C170F,  //  0076  GETMBR	R11	R11	K15
-          0x88300505,  //  0077  GETMBR	R12	R2	K5
-          0x902E0A0C,  //  0078  SETMBR	R11	K5	R12
-          0x882C151D,  //  0079  GETMBR	R11	R10	K29
-          0x882C171C,  //  007A  GETMBR	R11	R11	K28
-          0x8830051C,  //  007B  GETMBR	R12	R2	K28
-          0x902E380C,  //  007C  SETMBR	R11	K28	R12
-          0x8C2C1513,  //  007D  GETMET	R11	R10	K19
-          0x7C2C0200,  //  007E  CALL	R11	1
-          0x8C301714,  //  007F  GETMET	R12	R11	K20
-          0x7C300200,  //  0080  CALL	R12	1
-          0x60340015,  //  0081  GETGBL	R13	G21
-          0x5C381800,  //  0082  MOVE	R14	R12
-          0x7C340200,  //  0083  CALL	R13	1
-          0x8C381715,  //  0084  GETMET	R14	R11	K21
-          0x5C401A00,  //  0085  MOVE	R16	R13
-          0x7C380400,  //  0086  CALL	R14	2
-          0x5C241C00,  //  0087  MOVE	R9	R14
-          0xB83A2C00,  //  0088  GETNGBL	R14	K22
-          0x8C381D17,  //  0089  GETMET	R14	R14	K23
-          0x8C400918,  //  008A  GETMET	R16	R4	K24
-          0x58480020,  //  008B  LDCONST	R18	K32
-          0x684C0000,  //  008C  GETUPV	R19	U0
-          0x884C271A,  //  008D  GETMBR	R19	R19	K26
-          0x60500008,  //  008E  GETGBL	R20	G8
-          0x5C540400,  //  008F  MOVE	R21	R2
-          0x7C500200,  //  0090  CALL	R20	1
-          0x5C540C00,  //  0091  MOVE	R21	R6
-          0x8858051C,  //  0092  GETMBR	R22	R2	K28
-          0x885C051C,  //  0093  GETMBR	R23	R2	K28
-          0xB8620200,  //  0094  GETNGBL	R24	K1
-          0x88603121,  //  0095  GETMBR	R24	R24	K33
-          0x1C5C2E18,  //  0096  EQ	R23	R23	R24
-          0x785E0001,  //  0097  JMPF	R23	#009A
-          0x585C0021,  //  0098  LDCONST	R23	K33
-          0x70020000,  //  0099  JMP		#009B
-          0x585C0008,  //  009A  LDCONST	R23	K8
-          0x7C400E00,  //  009B  CALL	R16	7
-          0x5844001B,  //  009C  LDCONST	R17	K27
-          0x7C380600,  //  009D  CALL	R14	3
-          0x7002000D,  //  009E  JMP		#00AD
-          0xB82A2C00,  //  009F  GETNGBL	R10	K22
-          0x8C281517,  //  00A0  GETMET	R10	R10	K23
-          0x8C300918,  //  00A1  GETMET	R12	R4	K24
-          0x58380022,  //  00A2  LDCONST	R14	K34
-          0x683C0000,  //  00A3  GETUPV	R15	U0
-          0x883C1F1A,  //  00A4  GETMBR	R15	R15	K26
-          0x60400008,  //  00A5  GETGBL	R16	G8
-          0x5C440400,  //  00A6  MOVE	R17	R2
-          0x7C400200,  //  00A7  CALL	R16	1
-          0x5C440C00,  //  00A8  MOVE	R17	R6
-          0x7C300A00,  //  00A9  CALL	R12	5
-          0x5834001B,  //  00AA  LDCONST	R13	K27
-          0x7C280600,  //  00AB  CALL	R10	3
-          0x50200000,  //  00AC  LDBOOL	R8	0	0
-          0x7826001E,  //  00AD  JMPF	R9	#00CD
-          0x6028000C,  //  00AE  GETGBL	R10	G12
-          0x882C0123,  //  00AF  GETMBR	R11	R0	K35
-          0x7C280200,  //  00B0  CALL	R10	1
-          0x1C281524,  //  00B1  EQ	R10	R10	K36
-          0x782A0004,  //  00B2  JMPF	R10	#00B8
-          0x88280123,  //  00B3  GETMBR	R10	R0	K35
-          0x8C281525,  //  00B4  GETMET	R10	R10	K37
-          0x5C301200,  //  00B5  MOVE	R12	R9
-          0x7C280400,  //  00B6  CALL	R10	2
-          0x70020014,  //  00B7  JMP		#00CD
-          0x5429FFFE,  //  00B8  LDINT	R10	-1
-          0x882C0123,  //  00B9  GETMBR	R11	R0	K35
-          0x9428160A,  //  00BA  GETIDX	R10	R11	R10
-          0x6030000C,  //  00BB  GETGBL	R12	G12
-          0x5C341400,  //  00BC  MOVE	R13	R10
-          0x7C300200,  //  00BD  CALL	R12	1
-          0x6034000C,  //  00BE  GETGBL	R13	G12
-          0x5C381200,  //  00BF  MOVE	R14	R9
-          0x7C340200,  //  00C0  CALL	R13	1
-          0x0030180D,  //  00C1  ADD	R12	R12	R13
-          0xB8360200,  //  00C2  GETNGBL	R13	K1
-          0x88341B26,  //  00C3  GETMBR	R13	R13	K38
-          0x88341B27,  //  00C4  GETMBR	R13	R13	K39
-          0x1830180D,  //  00C5  LE	R12	R12	R13
-          0x78320001,  //  00C6  JMPF	R12	#00C9
-          0x40301409,  //  00C7  CONNECT	R12	R10	R9
-          0x70020003,  //  00C8  JMP		#00CD
-          0x882C0123,  //  00C9  GETMBR	R11	R0	K35
-          0x8C2C1725,  //  00CA  GETMET	R11	R11	K37
-          0x5C341200,  //  00CB  MOVE	R13	R9
-          0x7C2C0400,  //  00CC  CALL	R11	2
-          0x80041000,  //  00CD  RET	1	R8
+          0x20240C09,  //  0019  NE	R9	R6	R9
+          0x7826003A,  //  001A  JMPF	R9	#0056
+          0x60240008,  //  001B  GETGBL	R9	G8
+          0x5C280C00,  //  001C  MOVE	R10	R6
+          0x7C240200,  //  001D  CALL	R9	1
+          0xB82A0000,  //  001E  GETNGBL	R10	K0
+          0x8C281509,  //  001F  GETMET	R10	R10	K9
+          0x7C280200,  //  0020  CALL	R10	1
+          0xB82E0000,  //  0021  GETNGBL	R11	K0
+          0x8C2C170B,  //  0022  GETMET	R11	R11	K11
+          0x7C2C0200,  //  0023  CALL	R11	1
+          0x902A140B,  //  0024  SETMBR	R10	K10	R11
+          0x882C150A,  //  0025  GETMBR	R11	R10	K10
+          0x902E190D,  //  0026  SETMBR	R11	K12	K13
+          0x882C150A,  //  0027  GETMBR	R11	R10	K10
+          0xB8320000,  //  0028  GETNGBL	R12	K0
+          0x8C30190F,  //  0029  GETMET	R12	R12	K15
+          0x7C300200,  //  002A  CALL	R12	1
+          0x902E1C0C,  //  002B  SETMBR	R11	K14	R12
+          0x882C150A,  //  002C  GETMBR	R11	R10	K10
+          0x882C170E,  //  002D  GETMBR	R11	R11	K14
+          0x88300510,  //  002E  GETMBR	R12	R2	K16
+          0x902E200C,  //  002F  SETMBR	R11	K16	R12
+          0x882C150A,  //  0030  GETMBR	R11	R10	K10
+          0x882C170E,  //  0031  GETMBR	R11	R11	K14
+          0x88300503,  //  0032  GETMBR	R12	R2	K3
+          0x902E060C,  //  0033  SETMBR	R11	K3	R12
+          0x882C150A,  //  0034  GETMBR	R11	R10	K10
+          0x882C170E,  //  0035  GETMBR	R11	R11	K14
+          0x88300504,  //  0036  GETMBR	R12	R2	K4
+          0x902E080C,  //  0037  SETMBR	R11	K4	R12
+          0x882C150A,  //  0038  GETMBR	R11	R10	K10
+          0x902E2206,  //  0039  SETMBR	R11	K17	R6
+          0x8C2C1512,  //  003A  GETMET	R11	R10	K18
+          0x7C2C0200,  //  003B  CALL	R11	1
+          0x8C301713,  //  003C  GETMET	R12	R11	K19
+          0x7C300200,  //  003D  CALL	R12	1
+          0x60340015,  //  003E  GETGBL	R13	G21
+          0x5C381800,  //  003F  MOVE	R14	R12
+          0x7C340200,  //  0040  CALL	R13	1
+          0x8C381714,  //  0041  GETMET	R14	R11	K20
+          0x5C401A00,  //  0042  MOVE	R16	R13
+          0x7C380400,  //  0043  CALL	R14	2
+          0x5C201C00,  //  0044  MOVE	R8	R14
+          0x68380001,  //  0045  GETUPV	R14	U1
+          0x743A000D,  //  0046  JMPT	R14	#0055
+          0xB83A2A00,  //  0047  GETNGBL	R14	K21
+          0x8C381D16,  //  0048  GETMET	R14	R14	K22
+          0x60400018,  //  0049  GETGBL	R16	G24
+          0x58440017,  //  004A  LDCONST	R17	K23
+          0x68480000,  //  004B  GETUPV	R18	U0
+          0x88482518,  //  004C  GETMBR	R18	R18	K24
+          0x604C0008,  //  004D  GETGBL	R19	G8
+          0x5C500400,  //  004E  MOVE	R20	R2
+          0x7C4C0200,  //  004F  CALL	R19	1
+          0x5C500A00,  //  0050  MOVE	R20	R5
+          0x5C541200,  //  0051  MOVE	R21	R9
+          0x7C400A00,  //  0052  CALL	R16	5
+          0x58440019,  //  0053  LDCONST	R17	K25
+          0x7C380600,  //  0054  CALL	R14	3
+          0x70020055,  //  0055  JMP		#00AC
+          0x8824051A,  //  0056  GETMBR	R9	R2	K26
+          0x4C280000,  //  0057  LDNIL	R10
+          0x2024120A,  //  0058  NE	R9	R9	R10
+          0x78260043,  //  0059  JMPF	R9	#009E
+          0x780E0041,  //  005A  JMPF	R3	#009D
+          0xB8260000,  //  005B  GETNGBL	R9	K0
+          0x8C241309,  //  005C  GETMET	R9	R9	K9
+          0x7C240200,  //  005D  CALL	R9	1
+          0xB82A0000,  //  005E  GETNGBL	R10	K0
+          0x8C28151C,  //  005F  GETMET	R10	R10	K28
+          0x7C280200,  //  0060  CALL	R10	1
+          0x9026360A,  //  0061  SETMBR	R9	K27	R10
+          0x8828131B,  //  0062  GETMBR	R10	R9	K27
+          0xB82E0000,  //  0063  GETNGBL	R11	K0
+          0x8C2C170F,  //  0064  GETMET	R11	R11	K15
+          0x7C2C0200,  //  0065  CALL	R11	1
+          0x902A1C0B,  //  0066  SETMBR	R10	K14	R11
+          0x8828131B,  //  0067  GETMBR	R10	R9	K27
+          0xB82E0000,  //  0068  GETNGBL	R11	K0
+          0x8C2C171D,  //  0069  GETMET	R11	R11	K29
+          0x7C2C0200,  //  006A  CALL	R11	1
+          0x902A340B,  //  006B  SETMBR	R10	K26	R11
+          0x8828131B,  //  006C  GETMBR	R10	R9	K27
+          0x8828150E,  //  006D  GETMBR	R10	R10	K14
+          0x882C0510,  //  006E  GETMBR	R11	R2	K16
+          0x902A200B,  //  006F  SETMBR	R10	K16	R11
+          0x8828131B,  //  0070  GETMBR	R10	R9	K27
+          0x8828150E,  //  0071  GETMBR	R10	R10	K14
+          0x882C0503,  //  0072  GETMBR	R11	R2	K3
+          0x902A060B,  //  0073  SETMBR	R10	K3	R11
+          0x8828131B,  //  0074  GETMBR	R10	R9	K27
+          0x8828150E,  //  0075  GETMBR	R10	R10	K14
+          0x882C0504,  //  0076  GETMBR	R11	R2	K4
+          0x902A080B,  //  0077  SETMBR	R10	K4	R11
+          0x8828131B,  //  0078  GETMBR	R10	R9	K27
+          0x8828151A,  //  0079  GETMBR	R10	R10	K26
+          0x882C051A,  //  007A  GETMBR	R11	R2	K26
+          0x902A340B,  //  007B  SETMBR	R10	K26	R11
+          0x8C281312,  //  007C  GETMET	R10	R9	K18
+          0x7C280200,  //  007D  CALL	R10	1
+          0x8C2C1513,  //  007E  GETMET	R11	R10	K19
+          0x7C2C0200,  //  007F  CALL	R11	1
+          0x60300015,  //  0080  GETGBL	R12	G21
+          0x5C341600,  //  0081  MOVE	R13	R11
+          0x7C300200,  //  0082  CALL	R12	1
+          0x8C341514,  //  0083  GETMET	R13	R10	K20
+          0x5C3C1800,  //  0084  MOVE	R15	R12
+          0x7C340400,  //  0085  CALL	R13	2
+          0x5C201A00,  //  0086  MOVE	R8	R13
+          0xB8362A00,  //  0087  GETNGBL	R13	K21
+          0x8C341B16,  //  0088  GETMET	R13	R13	K22
+          0x603C0018,  //  0089  GETGBL	R15	G24
+          0x5840001E,  //  008A  LDCONST	R16	K30
+          0x68440000,  //  008B  GETUPV	R17	U0
+          0x88442318,  //  008C  GETMBR	R17	R17	K24
+          0x60480008,  //  008D  GETGBL	R18	G8
+          0x5C4C0400,  //  008E  MOVE	R19	R2
+          0x7C480200,  //  008F  CALL	R18	1
+          0x5C4C0A00,  //  0090  MOVE	R19	R5
+          0x8850051A,  //  0091  GETMBR	R20	R2	K26
+          0x8854051A,  //  0092  GETMBR	R21	R2	K26
+          0xB85A0000,  //  0093  GETNGBL	R22	K0
+          0x88582D1F,  //  0094  GETMBR	R22	R22	K31
+          0x1C542A16,  //  0095  EQ	R21	R21	R22
+          0x78560001,  //  0096  JMPF	R21	#0099
+          0x5854001F,  //  0097  LDCONST	R21	K31
+          0x70020000,  //  0098  JMP		#009A
+          0x58540007,  //  0099  LDCONST	R21	K7
+          0x7C3C0C00,  //  009A  CALL	R15	6
+          0x58400019,  //  009B  LDCONST	R16	K25
+          0x7C340600,  //  009C  CALL	R13	3
+          0x7002000D,  //  009D  JMP		#00AC
+          0xB8262A00,  //  009E  GETNGBL	R9	K21
+          0x8C241316,  //  009F  GETMET	R9	R9	K22
+          0x602C0018,  //  00A0  GETGBL	R11	G24
+          0x58300020,  //  00A1  LDCONST	R12	K32
+          0x68340000,  //  00A2  GETUPV	R13	U0
+          0x88341B18,  //  00A3  GETMBR	R13	R13	K24
+          0x60380008,  //  00A4  GETGBL	R14	G8
+          0x5C3C0400,  //  00A5  MOVE	R15	R2
+          0x7C380200,  //  00A6  CALL	R14	1
+          0x5C3C0A00,  //  00A7  MOVE	R15	R5
+          0x7C2C0800,  //  00A8  CALL	R11	4
+          0x58300019,  //  00A9  LDCONST	R12	K25
+          0x7C240600,  //  00AA  CALL	R9	3
+          0x501C0000,  //  00AB  LDBOOL	R7	0	0
+          0x7822001E,  //  00AC  JMPF	R8	#00CC
+          0x6024000C,  //  00AD  GETGBL	R9	G12
+          0x88280121,  //  00AE  GETMBR	R10	R0	K33
+          0x7C240200,  //  00AF  CALL	R9	1
+          0x1C241322,  //  00B0  EQ	R9	R9	K34
+          0x78260004,  //  00B1  JMPF	R9	#00B7
+          0x88240121,  //  00B2  GETMBR	R9	R0	K33
+          0x8C241323,  //  00B3  GETMET	R9	R9	K35
+          0x5C2C1000,  //  00B4  MOVE	R11	R8
+          0x7C240400,  //  00B5  CALL	R9	2
+          0x70020014,  //  00B6  JMP		#00CC
+          0x5425FFFE,  //  00B7  LDINT	R9	-1
+          0x88280121,  //  00B8  GETMBR	R10	R0	K33
+          0x94241409,  //  00B9  GETIDX	R9	R10	R9
+          0x602C000C,  //  00BA  GETGBL	R11	G12
+          0x5C301200,  //  00BB  MOVE	R12	R9
+          0x7C2C0200,  //  00BC  CALL	R11	1
+          0x6030000C,  //  00BD  GETGBL	R12	G12
+          0x5C341000,  //  00BE  MOVE	R13	R8
+          0x7C300200,  //  00BF  CALL	R12	1
+          0x002C160C,  //  00C0  ADD	R11	R11	R12
+          0xB8320000,  //  00C1  GETNGBL	R12	K0
+          0x88301924,  //  00C2  GETMBR	R12	R12	K36
+          0x88301925,  //  00C3  GETMBR	R12	R12	K37
+          0x182C160C,  //  00C4  LE	R11	R11	R12
+          0x782E0001,  //  00C5  JMPF	R11	#00C8
+          0x402C1208,  //  00C6  CONNECT	R11	R9	R8
+          0x70020003,  //  00C7  JMP		#00CC
+          0x88280121,  //  00C8  GETMBR	R10	R0	K33
+          0x8C281523,  //  00C9  GETMET	R10	R10	K35
+          0x5C301000,  //  00CA  MOVE	R12	R8
+          0x7C280400,  //  00CB  CALL	R10	2
+          0x80040E00,  //  00CC  RET	1	R7
         })
       ),
       be_nested_proto(
@@ -1643,8 +1627,8 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
         0,                          /* varg */
         1,                          /* has upvals */
         ( &(const bupvaldesc[ 2]) {  /* upvals */
-          be_local_const_upval(1, 5),
-          be_local_const_upval(1, 8),
+          be_local_const_upval(1, 4),
+          be_local_const_upval(1, 7),
         }),
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
@@ -1664,130 +1648,127 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(device),
-    /* K2   */  be_nested_str_weak(get_active_endpoints),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Path),
-    /* K5   */  be_nested_str_weak(ReportDataMessage),
-    /* K6   */  be_nested_str_weak(attribute_reports),
-    /* K7   */  be_nested_str_weak(attributes_requests),
-    /* K8   */  be_nested_str_weak(endpoint),
-    /* K9   */  be_nested_str_weak(cluster),
-    /* K10  */  be_nested_str_weak(attribute),
-    /* K11  */  be_nested_str_weak(status),
-    /* K12  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    /* K13  */  be_nested_str_weak(get_attribute_name),
-    /* K14  */  be_nested_str_weak(tasmota),
-    /* K15  */  be_nested_str_weak(log),
-    /* K16  */  be_nested_str_weak(format),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s),
-    /* K18  */  be_nested_str_weak(local_session_id),
-    /* K19  */  be_nested_str_weak(_X20_X28),
-    /* K20  */  be_nested_str_weak(_X29),
-    /* K21  */  be_nested_str_weak(),
-    /* K22  */  be_const_int(3),
-    /* K23  */  be_nested_str_weak(process_attribute_expansion),
-    /* K24  */  be_nested_str_weak(stop_iteration),
+    ( &(const bvalue[23]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(get_active_endpoints),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(Path),
+    /* K4   */  be_nested_str_weak(ReportDataMessage),
+    /* K5   */  be_nested_str_weak(attribute_reports),
+    /* K6   */  be_nested_str_weak(attributes_requests),
+    /* K7   */  be_nested_str_weak(endpoint),
+    /* K8   */  be_nested_str_weak(cluster),
+    /* K9   */  be_nested_str_weak(attribute),
+    /* K10  */  be_nested_str_weak(status),
+    /* K11  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+    /* K12  */  be_nested_str_weak(get_attribute_name),
+    /* K13  */  be_nested_str_weak(tasmota),
+    /* K14  */  be_nested_str_weak(log),
+    /* K15  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s),
+    /* K16  */  be_nested_str_weak(local_session_id),
+    /* K17  */  be_nested_str_weak(_X20_X28),
+    /* K18  */  be_nested_str_weak(_X29),
+    /* K19  */  be_nested_str_weak(),
+    /* K20  */  be_const_int(3),
+    /* K21  */  be_nested_str_weak(process_attribute_expansion),
+    /* K22  */  be_nested_str_weak(stop_iteration),
     }),
     be_str_weak(_inner_process_read_request),
     &be_const_str_solidified,
-    ( &(const binstruction[94]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0x84140000,  //  0001  CLOSURE	R5	P0
-      0x88180101,  //  0002  GETMBR	R6	R0	K1
-      0x8C180D02,  //  0003  GETMET	R6	R6	K2
-      0x7C180200,  //  0004  CALL	R6	1
-      0xB81E0600,  //  0005  GETNGBL	R7	K3
-      0x8C1C0F04,  //  0006  GETMET	R7	R7	K4
-      0x7C1C0200,  //  0007  CALL	R7	1
-      0xB8220600,  //  0008  GETNGBL	R8	K3
-      0x8C201105,  //  0009  GETMET	R8	R8	K5
-      0x7C200200,  //  000A  CALL	R8	1
-      0x60240012,  //  000B  GETGBL	R9	G18
-      0x7C240000,  //  000C  CALL	R9	0
-      0x90220C09,  //  000D  SETMBR	R8	K6	R9
-      0x60240010,  //  000E  GETGBL	R9	G16
-      0x88280507,  //  000F  GETMBR	R10	R2	K7
-      0x7C240200,  //  0010  CALL	R9	1
-      0xA8020046,  //  0011  EXBLK	0	#0059
-      0x5C281200,  //  0012  MOVE	R10	R9
-      0x7C280000,  //  0013  CALL	R10	0
-      0x882C1508,  //  0014  GETMBR	R11	R10	K8
-      0x901E100B,  //  0015  SETMBR	R7	K8	R11
-      0x882C1509,  //  0016  GETMBR	R11	R10	K9
-      0x901E120B,  //  0017  SETMBR	R7	K9	R11
-      0x882C150A,  //  0018  GETMBR	R11	R10	K10
-      0x901E140B,  //  0019  SETMBR	R7	K10	R11
-      0xB82E0600,  //  001A  GETNGBL	R11	K3
-      0x882C170C,  //  001B  GETMBR	R11	R11	K12
-      0x901E160B,  //  001C  SETMBR	R7	K11	R11
-      0x882C0F08,  //  001D  GETMBR	R11	R7	K8
-      0x4C300000,  //  001E  LDNIL	R12
-      0x1C2C160C,  //  001F  EQ	R11	R11	R12
-      0x742E0007,  //  0020  JMPT	R11	#0029
-      0x882C0F09,  //  0021  GETMBR	R11	R7	K9
-      0x4C300000,  //  0022  LDNIL	R12
-      0x1C2C160C,  //  0023  EQ	R11	R11	R12
-      0x742E0003,  //  0024  JMPT	R11	#0029
-      0x882C0F0A,  //  0025  GETMBR	R11	R7	K10
-      0x4C300000,  //  0026  LDNIL	R12
-      0x1C2C160C,  //  0027  EQ	R11	R11	R12
-      0x782E0029,  //  0028  JMPF	R11	#0053
-      0x882C0F09,  //  0029  GETMBR	R11	R7	K9
-      0x4C300000,  //  002A  LDNIL	R12
-      0x202C160C,  //  002B  NE	R11	R11	R12
-      0x782E001A,  //  002C  JMPF	R11	#0048
-      0x882C0F0A,  //  002D  GETMBR	R11	R7	K10
-      0x4C300000,  //  002E  LDNIL	R12
-      0x202C160C,  //  002F  NE	R11	R11	R12
-      0x782E0016,  //  0030  JMPF	R11	#0048
-      0xB82E0600,  //  0031  GETNGBL	R11	K3
-      0x8C2C170D,  //  0032  GETMET	R11	R11	K13
-      0x88340F09,  //  0033  GETMBR	R13	R7	K9
-      0x88380F0A,  //  0034  GETMBR	R14	R7	K10
-      0x7C2C0600,  //  0035  CALL	R11	3
-      0xB8321C00,  //  0036  GETNGBL	R12	K14
-      0x8C30190F,  //  0037  GETMET	R12	R12	K15
-      0x8C380910,  //  0038  GETMET	R14	R4	K16
-      0x58400011,  //  0039  LDCONST	R16	K17
-      0x88440312,  //  003A  GETMBR	R17	R1	K18
-      0x60480008,  //  003B  GETGBL	R18	G8
-      0x5C4C0E00,  //  003C  MOVE	R19	R7
-      0x7C480200,  //  003D  CALL	R18	1
-      0x782E0002,  //  003E  JMPF	R11	#0042
-      0x004E260B,  //  003F  ADD	R19	K19	R11
-      0x004C2714,  //  0040  ADD	R19	R19	K20
-      0x70020000,  //  0041  JMP		#0043
-      0x584C0015,  //  0042  LDCONST	R19	K21
-      0x00482413,  //  0043  ADD	R18	R18	R19
-      0x7C380800,  //  0044  CALL	R14	4
-      0x583C0016,  //  0045  LDCONST	R15	K22
-      0x7C300600,  //  0046  CALL	R12	3
-      0x7002000A,  //  0047  JMP		#0053
-      0xB82E1C00,  //  0048  GETNGBL	R11	K14
-      0x8C2C170F,  //  0049  GETMET	R11	R11	K15
-      0x8C340910,  //  004A  GETMET	R13	R4	K16
-      0x583C0011,  //  004B  LDCONST	R15	K17
-      0x88400312,  //  004C  GETMBR	R16	R1	K18
-      0x60440008,  //  004D  GETGBL	R17	G8
-      0x5C480E00,  //  004E  MOVE	R18	R7
-      0x7C440200,  //  004F  CALL	R17	1
-      0x7C340800,  //  0050  CALL	R13	4
-      0x58380016,  //  0051  LDCONST	R14	K22
-      0x7C2C0600,  //  0052  CALL	R11	3
-      0x882C0101,  //  0053  GETMBR	R11	R0	K1
-      0x8C2C1717,  //  0054  GETMET	R11	R11	K23
-      0x5C340E00,  //  0055  MOVE	R13	R7
-      0x84380001,  //  0056  CLOSURE	R14	P1
-      0x7C2C0600,  //  0057  CALL	R11	3
-      0x7001FFB8,  //  0058  JMP		#0012
-      0x58240018,  //  0059  LDCONST	R9	K24
-      0xAC240200,  //  005A  CATCH	R9	1	0
-      0xB0080000,  //  005B  RAISE	2	R0	R0
-      0xA0000000,  //  005C  CLOSE	R0
-      0x80041000,  //  005D  RET	1	R8
+    ( &(const binstruction[93]) {  /* code */
+      0x84100000,  //  0000  CLOSURE	R4	P0
+      0x88140100,  //  0001  GETMBR	R5	R0	K0
+      0x8C140B01,  //  0002  GETMET	R5	R5	K1
+      0x7C140200,  //  0003  CALL	R5	1
+      0xB81A0400,  //  0004  GETNGBL	R6	K2
+      0x8C180D03,  //  0005  GETMET	R6	R6	K3
+      0x7C180200,  //  0006  CALL	R6	1
+      0xB81E0400,  //  0007  GETNGBL	R7	K2
+      0x8C1C0F04,  //  0008  GETMET	R7	R7	K4
+      0x7C1C0200,  //  0009  CALL	R7	1
+      0x60200012,  //  000A  GETGBL	R8	G18
+      0x7C200000,  //  000B  CALL	R8	0
+      0x901E0A08,  //  000C  SETMBR	R7	K5	R8
+      0x60200010,  //  000D  GETGBL	R8	G16
+      0x88240506,  //  000E  GETMBR	R9	R2	K6
+      0x7C200200,  //  000F  CALL	R8	1
+      0xA8020046,  //  0010  EXBLK	0	#0058
+      0x5C241000,  //  0011  MOVE	R9	R8
+      0x7C240000,  //  0012  CALL	R9	0
+      0x88281307,  //  0013  GETMBR	R10	R9	K7
+      0x901A0E0A,  //  0014  SETMBR	R6	K7	R10
+      0x88281308,  //  0015  GETMBR	R10	R9	K8
+      0x901A100A,  //  0016  SETMBR	R6	K8	R10
+      0x88281309,  //  0017  GETMBR	R10	R9	K9
+      0x901A120A,  //  0018  SETMBR	R6	K9	R10
+      0xB82A0400,  //  0019  GETNGBL	R10	K2
+      0x8828150B,  //  001A  GETMBR	R10	R10	K11
+      0x901A140A,  //  001B  SETMBR	R6	K10	R10
+      0x88280D07,  //  001C  GETMBR	R10	R6	K7
+      0x4C2C0000,  //  001D  LDNIL	R11
+      0x1C28140B,  //  001E  EQ	R10	R10	R11
+      0x742A0007,  //  001F  JMPT	R10	#0028
+      0x88280D08,  //  0020  GETMBR	R10	R6	K8
+      0x4C2C0000,  //  0021  LDNIL	R11
+      0x1C28140B,  //  0022  EQ	R10	R10	R11
+      0x742A0003,  //  0023  JMPT	R10	#0028
+      0x88280D09,  //  0024  GETMBR	R10	R6	K9
+      0x4C2C0000,  //  0025  LDNIL	R11
+      0x1C28140B,  //  0026  EQ	R10	R10	R11
+      0x782A0029,  //  0027  JMPF	R10	#0052
+      0x88280D08,  //  0028  GETMBR	R10	R6	K8
+      0x4C2C0000,  //  0029  LDNIL	R11
+      0x2028140B,  //  002A  NE	R10	R10	R11
+      0x782A001A,  //  002B  JMPF	R10	#0047
+      0x88280D09,  //  002C  GETMBR	R10	R6	K9
+      0x4C2C0000,  //  002D  LDNIL	R11
+      0x2028140B,  //  002E  NE	R10	R10	R11
+      0x782A0016,  //  002F  JMPF	R10	#0047
+      0xB82A0400,  //  0030  GETNGBL	R10	K2
+      0x8C28150C,  //  0031  GETMET	R10	R10	K12
+      0x88300D08,  //  0032  GETMBR	R12	R6	K8
+      0x88340D09,  //  0033  GETMBR	R13	R6	K9
+      0x7C280600,  //  0034  CALL	R10	3
+      0xB82E1A00,  //  0035  GETNGBL	R11	K13
+      0x8C2C170E,  //  0036  GETMET	R11	R11	K14
+      0x60340018,  //  0037  GETGBL	R13	G24
+      0x5838000F,  //  0038  LDCONST	R14	K15
+      0x883C0310,  //  0039  GETMBR	R15	R1	K16
+      0x60400008,  //  003A  GETGBL	R16	G8
+      0x5C440C00,  //  003B  MOVE	R17	R6
+      0x7C400200,  //  003C  CALL	R16	1
+      0x782A0002,  //  003D  JMPF	R10	#0041
+      0x0046220A,  //  003E  ADD	R17	K17	R10
+      0x00442312,  //  003F  ADD	R17	R17	K18
+      0x70020000,  //  0040  JMP		#0042
+      0x58440013,  //  0041  LDCONST	R17	K19
+      0x00402011,  //  0042  ADD	R16	R16	R17
+      0x7C340600,  //  0043  CALL	R13	3
+      0x58380014,  //  0044  LDCONST	R14	K20
+      0x7C2C0600,  //  0045  CALL	R11	3
+      0x7002000A,  //  0046  JMP		#0052
+      0xB82A1A00,  //  0047  GETNGBL	R10	K13
+      0x8C28150E,  //  0048  GETMET	R10	R10	K14
+      0x60300018,  //  0049  GETGBL	R12	G24
+      0x5834000F,  //  004A  LDCONST	R13	K15
+      0x88380310,  //  004B  GETMBR	R14	R1	K16
+      0x603C0008,  //  004C  GETGBL	R15	G8
+      0x5C400C00,  //  004D  MOVE	R16	R6
+      0x7C3C0200,  //  004E  CALL	R15	1
+      0x7C300600,  //  004F  CALL	R12	3
+      0x58340014,  //  0050  LDCONST	R13	K20
+      0x7C280600,  //  0051  CALL	R10	3
+      0x88280100,  //  0052  GETMBR	R10	R0	K0
+      0x8C281515,  //  0053  GETMET	R10	R10	K21
+      0x5C300C00,  //  0054  MOVE	R12	R6
+      0x84340001,  //  0055  CLOSURE	R13	P1
+      0x7C280600,  //  0056  CALL	R10	3
+      0x7001FFB8,  //  0057  JMP		#0011
+      0x58200016,  //  0058  LDCONST	R8	K22
+      0xAC200200,  //  0059  CATCH	R8	1	0
+      0xB0080000,  //  005A  RAISE	2	R0	R0
+      0xA0000000,  //  005B  CLOSE	R0
+      0x80040E00,  //  005C  RET	1	R7
     })
   )
 );
@@ -1849,7 +1830,7 @@ be_local_closure(Matter_IM_find_sendqueue_by_exchangeid,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_process_incoming_ack,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1857,26 +1838,24 @@ be_local_closure(Matter_IM_process_incoming_ack,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
-    /* K2   */  be_nested_str_weak(exchange_id),
-    /* K3   */  be_nested_str_weak(ack_received),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
+    /* K1   */  be_nested_str_weak(exchange_id),
+    /* K2   */  be_nested_str_weak(ack_received),
     }),
     be_str_weak(process_incoming_ack),
     &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0101,  //  0001  GETMET	R3	R0	K1
-      0x88140302,  //  0002  GETMBR	R5	R1	K2
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x780E0003,  //  0004  JMPF	R3	#0009
-      0x8C100703,  //  0005  GETMET	R4	R3	K3
-      0x5C180200,  //  0006  MOVE	R6	R1
-      0x7C100400,  //  0007  CALL	R4	2
-      0x80040800,  //  0008  RET	1	R4
-      0x50100000,  //  0009  LDBOOL	R4	0	0
-      0x80040800,  //  000A  RET	1	R4
+    ( &(const binstruction[10]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x88100301,  //  0001  GETMBR	R4	R1	K1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x780A0003,  //  0003  JMPF	R2	#0008
+      0x8C0C0502,  //  0004  GETMET	R3	R2	K2
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x80040600,  //  0007  RET	1	R3
+      0x500C0000,  //  0008  LDBOOL	R3	0	0
+      0x80040600,  //  0009  RET	1	R3
     })
   )
 );
@@ -1976,7 +1955,7 @@ be_local_closure(Matter_IM_send_report_data,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_process_status_response,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    11,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1984,75 +1963,72 @@ be_local_closure(Matter_IM_process_status_response,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
-    /* K4   */  be_nested_str_weak(exchange_id),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(SUCCESS),
-    /* K7   */  be_nested_str_weak(status_ok_received),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(format),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20_X3EOK_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i_X20not_X20found),
-    /* K12  */  be_nested_str_weak(session),
-    /* K13  */  be_nested_str_weak(local_session_id),
-    /* K14  */  be_const_int(3),
-    /* K15  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
-    /* K16  */  be_nested_str_weak(status_error_received),
-    /* K17  */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(findsubval),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
+    /* K3   */  be_nested_str_weak(exchange_id),
+    /* K4   */  be_nested_str_weak(matter),
+    /* K5   */  be_nested_str_weak(SUCCESS),
+    /* K6   */  be_nested_str_weak(status_ok_received),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3EOK_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i_X20not_X20found),
+    /* K10  */  be_nested_str_weak(session),
+    /* K11  */  be_nested_str_weak(local_session_id),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
+    /* K14  */  be_nested_str_weak(status_error_received),
+    /* K15  */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
     }),
     be_str_weak(process_status_response),
     &be_const_str_solidified,
-    ( &(const binstruction[46]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x8C100501,  //  0001  GETMET	R4	R2	K1
-      0x58180002,  //  0002  LDCONST	R6	K2
-      0x541E00FE,  //  0003  LDINT	R7	255
-      0x7C100600,  //  0004  CALL	R4	3
-      0x8C140103,  //  0005  GETMET	R5	R0	K3
-      0x881C0304,  //  0006  GETMBR	R7	R1	K4
-      0x7C140400,  //  0007  CALL	R5	2
-      0xB81A0A00,  //  0008  GETNGBL	R6	K5
-      0x88180D06,  //  0009  GETMBR	R6	R6	K6
-      0x1C180806,  //  000A  EQ	R6	R4	R6
-      0x781A0010,  //  000B  JMPF	R6	#001D
-      0x78160004,  //  000C  JMPF	R5	#0012
-      0x8C180B07,  //  000D  GETMET	R6	R5	K7
-      0x5C200200,  //  000E  MOVE	R8	R1
-      0x7C180400,  //  000F  CALL	R6	2
-      0x80040C00,  //  0010  RET	1	R6
-      0x70020009,  //  0011  JMP		#001C
-      0xB81A1000,  //  0012  GETNGBL	R6	K8
-      0x8C180D09,  //  0013  GETMET	R6	R6	K9
-      0x8C20070A,  //  0014  GETMET	R8	R3	K10
-      0x5828000B,  //  0015  LDCONST	R10	K11
-      0x882C030C,  //  0016  GETMBR	R11	R1	K12
-      0x882C170D,  //  0017  GETMBR	R11	R11	K13
-      0x88300304,  //  0018  GETMBR	R12	R1	K4
-      0x7C200800,  //  0019  CALL	R8	4
-      0x5824000E,  //  001A  LDCONST	R9	K14
-      0x7C180600,  //  001B  CALL	R6	3
-      0x7002000E,  //  001C  JMP		#002C
-      0xB81A1000,  //  001D  GETNGBL	R6	K8
-      0x8C180D09,  //  001E  GETMET	R6	R6	K9
-      0x8C20070A,  //  001F  GETMET	R8	R3	K10
-      0x5828000F,  //  0020  LDCONST	R10	K15
-      0x5C2C0800,  //  0021  MOVE	R11	R4
-      0x7C200600,  //  0022  CALL	R8	3
-      0x5824000E,  //  0023  LDCONST	R9	K14
-      0x7C180600,  //  0024  CALL	R6	3
-      0x78160005,  //  0025  JMPF	R5	#002C
-      0x8C180B10,  //  0026  GETMET	R6	R5	K16
-      0x5C200200,  //  0027  MOVE	R8	R1
-      0x7C180400,  //  0028  CALL	R6	2
-      0x8C180111,  //  0029  GETMET	R6	R0	K17
-      0x88200304,  //  002A  GETMBR	R8	R1	K4
-      0x7C180400,  //  002B  CALL	R6	2
-      0x50180000,  //  002C  LDBOOL	R6	0	0
-      0x80040C00,  //  002D  RET	1	R6
+    ( &(const binstruction[45]) {  /* code */
+      0x8C0C0500,  //  0000  GETMET	R3	R2	K0
+      0x58140001,  //  0001  LDCONST	R5	K1
+      0x541A00FE,  //  0002  LDINT	R6	255
+      0x7C0C0600,  //  0003  CALL	R3	3
+      0x8C100102,  //  0004  GETMET	R4	R0	K2
+      0x88180303,  //  0005  GETMBR	R6	R1	K3
+      0x7C100400,  //  0006  CALL	R4	2
+      0xB8160800,  //  0007  GETNGBL	R5	K4
+      0x88140B05,  //  0008  GETMBR	R5	R5	K5
+      0x1C140605,  //  0009  EQ	R5	R3	R5
+      0x78160010,  //  000A  JMPF	R5	#001C
+      0x78120004,  //  000B  JMPF	R4	#0011
+      0x8C140906,  //  000C  GETMET	R5	R4	K6
+      0x5C1C0200,  //  000D  MOVE	R7	R1
+      0x7C140400,  //  000E  CALL	R5	2
+      0x80040A00,  //  000F  RET	1	R5
+      0x70020009,  //  0010  JMP		#001B
+      0xB8160E00,  //  0011  GETNGBL	R5	K7
+      0x8C140B08,  //  0012  GETMET	R5	R5	K8
+      0x601C0018,  //  0013  GETGBL	R7	G24
+      0x58200009,  //  0014  LDCONST	R8	K9
+      0x8824030A,  //  0015  GETMBR	R9	R1	K10
+      0x8824130B,  //  0016  GETMBR	R9	R9	K11
+      0x88280303,  //  0017  GETMBR	R10	R1	K3
+      0x7C1C0600,  //  0018  CALL	R7	3
+      0x5820000C,  //  0019  LDCONST	R8	K12
+      0x7C140600,  //  001A  CALL	R5	3
+      0x7002000E,  //  001B  JMP		#002B
+      0xB8160E00,  //  001C  GETNGBL	R5	K7
+      0x8C140B08,  //  001D  GETMET	R5	R5	K8
+      0x601C0018,  //  001E  GETGBL	R7	G24
+      0x5820000D,  //  001F  LDCONST	R8	K13
+      0x5C240600,  //  0020  MOVE	R9	R3
+      0x7C1C0400,  //  0021  CALL	R7	2
+      0x5820000C,  //  0022  LDCONST	R8	K12
+      0x7C140600,  //  0023  CALL	R5	3
+      0x78120005,  //  0024  JMPF	R4	#002B
+      0x8C14090E,  //  0025  GETMET	R5	R4	K14
+      0x5C1C0200,  //  0026  MOVE	R7	R1
+      0x7C140400,  //  0027  CALL	R5	2
+      0x8C14010F,  //  0028  GETMET	R5	R0	K15
+      0x881C0303,  //  0029  GETMBR	R7	R1	K3
+      0x7C140400,  //  002A  CALL	R5	2
+      0x50140000,  //  002B  LDBOOL	R5	0	0
+      0x80040A00,  //  002C  RET	1	R5
     })
   )
 );
@@ -2064,7 +2040,7 @@ be_local_closure(Matter_IM_process_status_response,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_process_write_response,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2072,24 +2048,22 @@ be_local_closure(Matter_IM_process_write_response,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(WriteResponseMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(WriteResponseMessage),
+    /* K2   */  be_nested_str_weak(from_TLV),
     }),
     be_str_weak(process_write_response),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0x50140000,  //  0007  LDBOOL	R5	0	0
-      0x80040A00,  //  0008  RET	1	R5
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x50100000,  //  0006  LDBOOL	R4	0	0
+      0x80040800,  //  0007  RET	1	R4
     })
   )
 );
@@ -2101,7 +2075,7 @@ be_local_closure(Matter_IM_process_write_response,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_send_subscribe_update,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2109,105 +2083,102 @@ be_local_closure(Matter_IM_send_subscribe_update,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(session),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(ReadRequestMessage),
-    /* K4   */  be_nested_str_weak(fabric_filtered),
-    /* K5   */  be_nested_str_weak(attributes_requests),
-    /* K6   */  be_nested_str_weak(updates),
-    /* K7   */  be_nested_str_weak(AttributePathIB),
-    /* K8   */  be_nested_str_weak(endpoint),
-    /* K9   */  be_nested_str_weak(cluster),
-    /* K10  */  be_nested_str_weak(attribute),
-    /* K11  */  be_nested_str_weak(push),
-    /* K12  */  be_nested_str_weak(stop_iteration),
-    /* K13  */  be_nested_str_weak(tasmota),
-    /* K14  */  be_nested_str_weak(log),
-    /* K15  */  be_nested_str_weak(format),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Data_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
-    /* K17  */  be_nested_str_weak(local_session_id),
-    /* K18  */  be_nested_str_weak(subscription_id),
-    /* K19  */  be_const_int(3),
-    /* K20  */  be_nested_str_weak(is_keep_alive),
-    /* K21  */  be_nested_str_weak(_inner_process_read_request),
-    /* K22  */  be_nested_str_weak(suppress_response),
-    /* K23  */  be_nested_str_weak(IM_ReportDataSubscribed),
-    /* K24  */  be_nested_str_weak(_message_handler),
-    /* K25  */  be_nested_str_weak(send_queue),
-    /* K26  */  be_nested_str_weak(send_enqueued),
+    ( &(const bvalue[25]) {     /* constants */
+    /* K0   */  be_nested_str_weak(session),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(ReadRequestMessage),
+    /* K3   */  be_nested_str_weak(fabric_filtered),
+    /* K4   */  be_nested_str_weak(attributes_requests),
+    /* K5   */  be_nested_str_weak(updates),
+    /* K6   */  be_nested_str_weak(AttributePathIB),
+    /* K7   */  be_nested_str_weak(endpoint),
+    /* K8   */  be_nested_str_weak(cluster),
+    /* K9   */  be_nested_str_weak(attribute),
+    /* K10  */  be_nested_str_weak(push),
+    /* K11  */  be_nested_str_weak(stop_iteration),
+    /* K12  */  be_nested_str_weak(tasmota),
+    /* K13  */  be_nested_str_weak(log),
+    /* K14  */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Data_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
+    /* K15  */  be_nested_str_weak(local_session_id),
+    /* K16  */  be_nested_str_weak(subscription_id),
+    /* K17  */  be_const_int(3),
+    /* K18  */  be_nested_str_weak(is_keep_alive),
+    /* K19  */  be_nested_str_weak(_inner_process_read_request),
+    /* K20  */  be_nested_str_weak(suppress_response),
+    /* K21  */  be_nested_str_weak(IM_ReportDataSubscribed),
+    /* K22  */  be_nested_str_weak(_message_handler),
+    /* K23  */  be_nested_str_weak(send_queue),
+    /* K24  */  be_nested_str_weak(send_enqueued),
     }),
     be_str_weak(send_subscribe_update),
     &be_const_str_solidified,
-    ( &(const binstruction[67]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
-      0xB8120400,  //  0002  GETNGBL	R4	K2
-      0x8C100903,  //  0003  GETMET	R4	R4	K3
-      0x7C100200,  //  0004  CALL	R4	1
-      0x50140000,  //  0005  LDBOOL	R5	0	0
-      0x90120805,  //  0006  SETMBR	R4	K4	R5
-      0x60140012,  //  0007  GETGBL	R5	G18
-      0x7C140000,  //  0008  CALL	R5	0
-      0x90120A05,  //  0009  SETMBR	R4	K5	R5
-      0x60140010,  //  000A  GETGBL	R5	G16
-      0x88180306,  //  000B  GETMBR	R6	R1	K6
-      0x7C140200,  //  000C  CALL	R5	1
-      0xA802000F,  //  000D  EXBLK	0	#001E
-      0x5C180A00,  //  000E  MOVE	R6	R5
-      0x7C180000,  //  000F  CALL	R6	0
-      0xB81E0400,  //  0010  GETNGBL	R7	K2
-      0x8C1C0F07,  //  0011  GETMET	R7	R7	K7
-      0x7C1C0200,  //  0012  CALL	R7	1
-      0x88200D08,  //  0013  GETMBR	R8	R6	K8
-      0x901E1008,  //  0014  SETMBR	R7	K8	R8
-      0x88200D09,  //  0015  GETMBR	R8	R6	K9
-      0x901E1208,  //  0016  SETMBR	R7	K9	R8
-      0x88200D0A,  //  0017  GETMBR	R8	R6	K10
-      0x901E1408,  //  0018  SETMBR	R7	K10	R8
-      0x88200905,  //  0019  GETMBR	R8	R4	K5
-      0x8C20110B,  //  001A  GETMET	R8	R8	K11
-      0x5C280E00,  //  001B  MOVE	R10	R7
-      0x7C200400,  //  001C  CALL	R8	2
-      0x7001FFEF,  //  001D  JMP		#000E
-      0x5814000C,  //  001E  LDCONST	R5	K12
-      0xAC140200,  //  001F  CATCH	R5	1	0
-      0xB0080000,  //  0020  RAISE	2	R0	R0
-      0xB8161A00,  //  0021  GETNGBL	R5	K13
-      0x8C140B0E,  //  0022  GETMET	R5	R5	K14
-      0x8C1C050F,  //  0023  GETMET	R7	R2	K15
-      0x58240010,  //  0024  LDCONST	R9	K16
-      0x88280711,  //  0025  GETMBR	R10	R3	K17
-      0x882C0312,  //  0026  GETMBR	R11	R1	K18
-      0x7C1C0800,  //  0027  CALL	R7	4
-      0x58200013,  //  0028  LDCONST	R8	K19
-      0x7C140600,  //  0029  CALL	R5	3
-      0x50140000,  //  002A  LDBOOL	R5	0	0
-      0x90062805,  //  002B  SETMBR	R1	K20	R5
-      0x8C140115,  //  002C  GETMET	R5	R0	K21
+    ( &(const binstruction[66]) {  /* code */
+      0x88080300,  //  0000  GETMBR	R2	R1	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x50100000,  //  0004  LDBOOL	R4	0	0
+      0x900E0604,  //  0005  SETMBR	R3	K3	R4
+      0x60100012,  //  0006  GETGBL	R4	G18
+      0x7C100000,  //  0007  CALL	R4	0
+      0x900E0804,  //  0008  SETMBR	R3	K4	R4
+      0x60100010,  //  0009  GETGBL	R4	G16
+      0x88140305,  //  000A  GETMBR	R5	R1	K5
+      0x7C100200,  //  000B  CALL	R4	1
+      0xA802000F,  //  000C  EXBLK	0	#001D
+      0x5C140800,  //  000D  MOVE	R5	R4
+      0x7C140000,  //  000E  CALL	R5	0
+      0xB81A0200,  //  000F  GETNGBL	R6	K1
+      0x8C180D06,  //  0010  GETMET	R6	R6	K6
+      0x7C180200,  //  0011  CALL	R6	1
+      0x881C0B07,  //  0012  GETMBR	R7	R5	K7
+      0x901A0E07,  //  0013  SETMBR	R6	K7	R7
+      0x881C0B08,  //  0014  GETMBR	R7	R5	K8
+      0x901A1007,  //  0015  SETMBR	R6	K8	R7
+      0x881C0B09,  //  0016  GETMBR	R7	R5	K9
+      0x901A1207,  //  0017  SETMBR	R6	K9	R7
+      0x881C0704,  //  0018  GETMBR	R7	R3	K4
+      0x8C1C0F0A,  //  0019  GETMET	R7	R7	K10
+      0x5C240C00,  //  001A  MOVE	R9	R6
+      0x7C1C0400,  //  001B  CALL	R7	2
+      0x7001FFEF,  //  001C  JMP		#000D
+      0x5810000B,  //  001D  LDCONST	R4	K11
+      0xAC100200,  //  001E  CATCH	R4	1	0
+      0xB0080000,  //  001F  RAISE	2	R0	R0
+      0xB8121800,  //  0020  GETNGBL	R4	K12
+      0x8C10090D,  //  0021  GETMET	R4	R4	K13
+      0x60180018,  //  0022  GETGBL	R6	G24
+      0x581C000E,  //  0023  LDCONST	R7	K14
+      0x8820050F,  //  0024  GETMBR	R8	R2	K15
+      0x88240310,  //  0025  GETMBR	R9	R1	K16
+      0x7C180600,  //  0026  CALL	R6	3
+      0x581C0011,  //  0027  LDCONST	R7	K17
+      0x7C100600,  //  0028  CALL	R4	3
+      0x50100000,  //  0029  LDBOOL	R4	0	0
+      0x90062404,  //  002A  SETMBR	R1	K18	R4
+      0x8C100113,  //  002B  GETMET	R4	R0	K19
+      0x5C180400,  //  002C  MOVE	R6	R2
       0x5C1C0600,  //  002D  MOVE	R7	R3
-      0x5C200800,  //  002E  MOVE	R8	R4
-      0x7C140600,  //  002F  CALL	R5	3
-      0x50180000,  //  0030  LDBOOL	R6	0	0
-      0x90162C06,  //  0031  SETMBR	R5	K22	R6
-      0x88180312,  //  0032  GETMBR	R6	R1	K18
-      0x90162406,  //  0033  SETMBR	R5	K18	R6
-      0xB81A0400,  //  0034  GETNGBL	R6	K2
-      0x8C180D17,  //  0035  GETMET	R6	R6	K23
-      0x88200718,  //  0036  GETMBR	R8	R3	K24
-      0x5C240600,  //  0037  MOVE	R9	R3
-      0x5C280A00,  //  0038  MOVE	R10	R5
-      0x5C2C0200,  //  0039  MOVE	R11	R1
-      0x7C180A00,  //  003A  CALL	R6	5
-      0x881C0119,  //  003B  GETMBR	R7	R0	K25
-      0x8C1C0F0B,  //  003C  GETMET	R7	R7	K11
-      0x5C240C00,  //  003D  MOVE	R9	R6
-      0x7C1C0400,  //  003E  CALL	R7	2
-      0x8C1C011A,  //  003F  GETMET	R7	R0	K26
-      0x88240718,  //  0040  GETMBR	R9	R3	K24
-      0x7C1C0400,  //  0041  CALL	R7	2
-      0x80000000,  //  0042  RET	0
+      0x7C100600,  //  002E  CALL	R4	3
+      0x50140000,  //  002F  LDBOOL	R5	0	0
+      0x90122805,  //  0030  SETMBR	R4	K20	R5
+      0x88140310,  //  0031  GETMBR	R5	R1	K16
+      0x90122005,  //  0032  SETMBR	R4	K16	R5
+      0xB8160200,  //  0033  GETNGBL	R5	K1
+      0x8C140B15,  //  0034  GETMET	R5	R5	K21
+      0x881C0516,  //  0035  GETMBR	R7	R2	K22
+      0x5C200400,  //  0036  MOVE	R8	R2
+      0x5C240800,  //  0037  MOVE	R9	R4
+      0x5C280200,  //  0038  MOVE	R10	R1
+      0x7C140A00,  //  0039  CALL	R5	5
+      0x88180117,  //  003A  GETMBR	R6	R0	K23
+      0x8C180D0A,  //  003B  GETMET	R6	R6	K10
+      0x5C200A00,  //  003C  MOVE	R8	R5
+      0x7C180400,  //  003D  CALL	R6	2
+      0x8C180118,  //  003E  GETMET	R6	R0	K24
+      0x88200516,  //  003F  GETMBR	R8	R2	K22
+      0x7C180400,  //  0040  CALL	R6	2
+      0x80000000,  //  0041  RET	0
     })
   )
 );
@@ -2289,7 +2260,7 @@ be_local_closure(Matter_IM_send_enqueued,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_process_timed_request,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2297,49 +2268,46 @@ be_local_closure(Matter_IM_process_timed_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TimedRequestMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(format),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20TimedRequest_X3D_X25i),
-    /* K8   */  be_nested_str_weak(session),
-    /* K9   */  be_nested_str_weak(local_session_id),
-    /* K10  */  be_nested_str_weak(timeout),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(send_status),
-    /* K13  */  be_nested_str_weak(SUCCESS),
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TimedRequestMessage),
+    /* K2   */  be_nested_str_weak(from_TLV),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20TimedRequest_X3D_X25i),
+    /* K6   */  be_nested_str_weak(session),
+    /* K7   */  be_nested_str_weak(local_session_id),
+    /* K8   */  be_nested_str_weak(timeout),
+    /* K9   */  be_const_int(3),
+    /* K10  */  be_nested_str_weak(send_status),
+    /* K11  */  be_nested_str_weak(SUCCESS),
     }),
     be_str_weak(process_timed_request),
     &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0xB8160800,  //  0007  GETNGBL	R5	K4
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x8C1C0706,  //  0009  GETMET	R7	R3	K6
-      0x58240007,  //  000A  LDCONST	R9	K7
-      0x88280308,  //  000B  GETMBR	R10	R1	K8
-      0x88281509,  //  000C  GETMBR	R10	R10	K9
-      0x882C090A,  //  000D  GETMBR	R11	R4	K10
-      0x7C1C0800,  //  000E  CALL	R7	4
-      0x5820000B,  //  000F  LDCONST	R8	K11
-      0x7C140600,  //  0010  CALL	R5	3
-      0x8C14010C,  //  0011  GETMET	R5	R0	K12
-      0x5C1C0200,  //  0012  MOVE	R7	R1
-      0xB8220200,  //  0013  GETNGBL	R8	K1
-      0x8820110D,  //  0014  GETMBR	R8	R8	K13
-      0x7C140600,  //  0015  CALL	R5	3
-      0x50140200,  //  0016  LDBOOL	R5	1	0
-      0x80040A00,  //  0017  RET	1	R5
+    ( &(const binstruction[23]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0xB8120600,  //  0006  GETNGBL	R4	K3
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x60180018,  //  0008  GETGBL	R6	G24
+      0x581C0005,  //  0009  LDCONST	R7	K5
+      0x88200306,  //  000A  GETMBR	R8	R1	K6
+      0x88201107,  //  000B  GETMBR	R8	R8	K7
+      0x88240708,  //  000C  GETMBR	R9	R3	K8
+      0x7C180600,  //  000D  CALL	R6	3
+      0x581C0009,  //  000E  LDCONST	R7	K9
+      0x7C100600,  //  000F  CALL	R4	3
+      0x8C10010A,  //  0010  GETMET	R4	R0	K10
+      0x5C180200,  //  0011  MOVE	R6	R1
+      0xB81E0000,  //  0012  GETNGBL	R7	K0
+      0x881C0F0B,  //  0013  GETMBR	R7	R7	K11
+      0x7C100600,  //  0014  CALL	R4	3
+      0x50100200,  //  0015  LDBOOL	R4	1	0
+      0x80040800,  //  0016  RET	1	R4
     })
   )
 );
@@ -2351,7 +2319,7 @@ be_local_closure(Matter_IM_process_timed_request,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_report_data,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2359,24 +2327,22 @@ be_local_closure(Matter_IM_report_data,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(ReportDataMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(ReportDataMessage),
+    /* K2   */  be_nested_str_weak(from_TLV),
     }),
     be_str_weak(report_data),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0x50140000,  //  0007  LDBOOL	R5	0	0
-      0x80040A00,  //  0008  RET	1	R5
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x50100000,  //  0006  LDBOOL	R4	0	0
+      0x80040800,  //  0007  RET	1	R4
     })
   )
 );
@@ -2388,7 +2354,7 @@ be_local_closure(Matter_IM_report_data,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_process_invoke_response,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2396,24 +2362,22 @@ be_local_closure(Matter_IM_process_invoke_response,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(InvokeResponseMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(InvokeResponseMessage),
+    /* K2   */  be_nested_str_weak(from_TLV),
     }),
     be_str_weak(process_invoke_response),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0x50140000,  //  0007  LDBOOL	R5	0	0
-      0x80040A00,  //  0008  RET	1	R5
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x50100000,  //  0006  LDBOOL	R4	0	0
+      0x80040800,  //  0007  RET	1	R4
     })
   )
 );
@@ -2464,7 +2428,7 @@ be_local_closure(Matter_IM_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_send_subscribe_heartbeat,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2472,64 +2436,61 @@ be_local_closure(Matter_IM_send_subscribe_heartbeat,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(session),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Alive_X20_X28_X256i_X29_X20sub_X3D_X25i),
-    /* K6   */  be_nested_str_weak(local_session_id),
-    /* K7   */  be_nested_str_weak(subscription_id),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str_weak(is_keep_alive),
-    /* K10  */  be_nested_str_weak(matter),
-    /* K11  */  be_nested_str_weak(ReportDataMessage),
-    /* K12  */  be_nested_str_weak(suppress_response),
-    /* K13  */  be_nested_str_weak(IM_SubscribedHeartbeat),
-    /* K14  */  be_nested_str_weak(_message_handler),
-    /* K15  */  be_nested_str_weak(send_queue),
-    /* K16  */  be_nested_str_weak(push),
-    /* K17  */  be_nested_str_weak(send_enqueued),
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(session),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Alive_X20_X28_X256i_X29_X20sub_X3D_X25i),
+    /* K4   */  be_nested_str_weak(local_session_id),
+    /* K5   */  be_nested_str_weak(subscription_id),
+    /* K6   */  be_const_int(3),
+    /* K7   */  be_nested_str_weak(is_keep_alive),
+    /* K8   */  be_nested_str_weak(matter),
+    /* K9   */  be_nested_str_weak(ReportDataMessage),
+    /* K10  */  be_nested_str_weak(suppress_response),
+    /* K11  */  be_nested_str_weak(IM_SubscribedHeartbeat),
+    /* K12  */  be_nested_str_weak(_message_handler),
+    /* K13  */  be_nested_str_weak(send_queue),
+    /* K14  */  be_nested_str_weak(push),
+    /* K15  */  be_nested_str_weak(send_enqueued),
     }),
     be_str_weak(send_subscribe_heartbeat),
     &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
-      0xB8120400,  //  0002  GETNGBL	R4	K2
-      0x8C100903,  //  0003  GETMET	R4	R4	K3
-      0x8C180504,  //  0004  GETMET	R6	R2	K4
-      0x58200005,  //  0005  LDCONST	R8	K5
-      0x88240706,  //  0006  GETMBR	R9	R3	K6
-      0x88280307,  //  0007  GETMBR	R10	R1	K7
-      0x7C180800,  //  0008  CALL	R6	4
-      0x581C0008,  //  0009  LDCONST	R7	K8
-      0x7C100600,  //  000A  CALL	R4	3
-      0x50100200,  //  000B  LDBOOL	R4	1	0
-      0x90061204,  //  000C  SETMBR	R1	K9	R4
-      0xB8121400,  //  000D  GETNGBL	R4	K10
-      0x8C10090B,  //  000E  GETMET	R4	R4	K11
-      0x7C100200,  //  000F  CALL	R4	1
-      0x50140200,  //  0010  LDBOOL	R5	1	0
-      0x90121805,  //  0011  SETMBR	R4	K12	R5
-      0x88140307,  //  0012  GETMBR	R5	R1	K7
-      0x90120E05,  //  0013  SETMBR	R4	K7	R5
-      0xB8161400,  //  0014  GETNGBL	R5	K10
-      0x8C140B0D,  //  0015  GETMET	R5	R5	K13
-      0x881C070E,  //  0016  GETMBR	R7	R3	K14
+    ( &(const binstruction[34]) {  /* code */
+      0x88080300,  //  0000  GETMBR	R2	R1	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x60140018,  //  0003  GETGBL	R5	G24
+      0x58180003,  //  0004  LDCONST	R6	K3
+      0x881C0504,  //  0005  GETMBR	R7	R2	K4
+      0x88200305,  //  0006  GETMBR	R8	R1	K5
+      0x7C140600,  //  0007  CALL	R5	3
+      0x58180006,  //  0008  LDCONST	R6	K6
+      0x7C0C0600,  //  0009  CALL	R3	3
+      0x500C0200,  //  000A  LDBOOL	R3	1	0
+      0x90060E03,  //  000B  SETMBR	R1	K7	R3
+      0xB80E1000,  //  000C  GETNGBL	R3	K8
+      0x8C0C0709,  //  000D  GETMET	R3	R3	K9
+      0x7C0C0200,  //  000E  CALL	R3	1
+      0x50100200,  //  000F  LDBOOL	R4	1	0
+      0x900E1404,  //  0010  SETMBR	R3	K10	R4
+      0x88100305,  //  0011  GETMBR	R4	R1	K5
+      0x900E0A04,  //  0012  SETMBR	R3	K5	R4
+      0xB8121000,  //  0013  GETNGBL	R4	K8
+      0x8C10090B,  //  0014  GETMET	R4	R4	K11
+      0x8818050C,  //  0015  GETMBR	R6	R2	K12
+      0x5C1C0400,  //  0016  MOVE	R7	R2
       0x5C200600,  //  0017  MOVE	R8	R3
-      0x5C240800,  //  0018  MOVE	R9	R4
-      0x5C280200,  //  0019  MOVE	R10	R1
-      0x7C140A00,  //  001A  CALL	R5	5
-      0x8818010F,  //  001B  GETMBR	R6	R0	K15
-      0x8C180D10,  //  001C  GETMET	R6	R6	K16
-      0x5C200A00,  //  001D  MOVE	R8	R5
-      0x7C180400,  //  001E  CALL	R6	2
-      0x8C180111,  //  001F  GETMET	R6	R0	K17
-      0x8820070E,  //  0020  GETMBR	R8	R3	K14
-      0x7C180400,  //  0021  CALL	R6	2
-      0x80000000,  //  0022  RET	0
+      0x5C240200,  //  0018  MOVE	R9	R1
+      0x7C100A00,  //  0019  CALL	R4	5
+      0x8814010D,  //  001A  GETMBR	R5	R0	K13
+      0x8C140B0E,  //  001B  GETMET	R5	R5	K14
+      0x5C1C0800,  //  001C  MOVE	R7	R4
+      0x7C140400,  //  001D  CALL	R5	2
+      0x8C14010F,  //  001E  GETMET	R5	R0	K15
+      0x881C050C,  //  001F  GETMBR	R7	R2	K12
+      0x7C140400,  //  0020  CALL	R5	2
+      0x80000000,  //  0021  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Data.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Data.h
@@ -307,7 +307,7 @@ be_local_closure(Matter_AttributePathIB_to_TLV,   /* name */
 ********************************************************************/
 be_local_closure(Matter_AttributePathIB_tostring,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -315,89 +315,86 @@ be_local_closure(Matter_AttributePathIB_tostring,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(),
-    /* K2   */  be_nested_str_weak(node),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(node_X3D_X25s_X20),
-    /* K5   */  be_nested_str_weak(endpoint),
-    /* K6   */  be_nested_str_weak(_X5B_X2502X_X5D),
-    /* K7   */  be_nested_str_weak(_X5B_X2A_X2A_X5D),
-    /* K8   */  be_nested_str_weak(cluster),
-    /* K9   */  be_nested_str_weak(_X2504X_X2F),
-    /* K10  */  be_nested_str_weak(_X2A_X2A_X2A_X2A_X2F),
-    /* K11  */  be_nested_str_weak(attribute),
-    /* K12  */  be_nested_str_weak(_X2504X),
-    /* K13  */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
-    /* K14  */  be_nested_str_weak(Exception_X3E_X20),
-    /* K15  */  be_nested_str_weak(_X2C_X20),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(),
+    /* K1   */  be_nested_str_weak(node),
+    /* K2   */  be_nested_str_weak(node_X3D_X25s_X20),
+    /* K3   */  be_nested_str_weak(endpoint),
+    /* K4   */  be_nested_str_weak(_X5B_X2502X_X5D),
+    /* K5   */  be_nested_str_weak(_X5B_X2A_X2A_X5D),
+    /* K6   */  be_nested_str_weak(cluster),
+    /* K7   */  be_nested_str_weak(_X2504X_X2F),
+    /* K8   */  be_nested_str_weak(_X2A_X2A_X2A_X2A_X2F),
+    /* K9   */  be_nested_str_weak(attribute),
+    /* K10  */  be_nested_str_weak(_X2504X),
+    /* K11  */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
+    /* K12  */  be_nested_str_weak(Exception_X3E_X20),
+    /* K13  */  be_nested_str_weak(_X2C_X20),
     }),
     be_str_weak(tostring),
     &be_const_str_solidified,
-    ( &(const binstruction[62]) {  /* code */
-      0xA802002D,  //  0000  EXBLK	0	#002F
-      0xA4060000,  //  0001  IMPORT	R1	K0
-      0x58080001,  //  0002  LDCONST	R2	K1
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
-      0x780E0004,  //  0004  JMPF	R3	#000A
-      0x8C0C0303,  //  0005  GETMET	R3	R1	K3
-      0x58140004,  //  0006  LDCONST	R5	K4
-      0x88180102,  //  0007  GETMBR	R6	R0	K2
-      0x7C0C0600,  //  0008  CALL	R3	3
-      0x00080403,  //  0009  ADD	R2	R2	R3
-      0x880C0105,  //  000A  GETMBR	R3	R0	K5
-      0x4C100000,  //  000B  LDNIL	R4
-      0x200C0604,  //  000C  NE	R3	R3	R4
-      0x780E0004,  //  000D  JMPF	R3	#0013
-      0x8C0C0303,  //  000E  GETMET	R3	R1	K3
-      0x58140006,  //  000F  LDCONST	R5	K6
-      0x88180105,  //  0010  GETMBR	R6	R0	K5
-      0x7C0C0600,  //  0011  CALL	R3	3
-      0x70020000,  //  0012  JMP		#0014
-      0x580C0007,  //  0013  LDCONST	R3	K7
-      0x00080403,  //  0014  ADD	R2	R2	R3
-      0x880C0108,  //  0015  GETMBR	R3	R0	K8
-      0x4C100000,  //  0016  LDNIL	R4
-      0x200C0604,  //  0017  NE	R3	R3	R4
-      0x780E0004,  //  0018  JMPF	R3	#001E
-      0x8C0C0303,  //  0019  GETMET	R3	R1	K3
-      0x58140009,  //  001A  LDCONST	R5	K9
-      0x88180108,  //  001B  GETMBR	R6	R0	K8
-      0x7C0C0600,  //  001C  CALL	R3	3
-      0x70020000,  //  001D  JMP		#001F
-      0x580C000A,  //  001E  LDCONST	R3	K10
-      0x00080403,  //  001F  ADD	R2	R2	R3
-      0x880C010B,  //  0020  GETMBR	R3	R0	K11
-      0x4C100000,  //  0021  LDNIL	R4
-      0x200C0604,  //  0022  NE	R3	R3	R4
-      0x780E0004,  //  0023  JMPF	R3	#0029
-      0x8C0C0303,  //  0024  GETMET	R3	R1	K3
-      0x5814000C,  //  0025  LDCONST	R5	K12
-      0x8818010B,  //  0026  GETMBR	R6	R0	K11
-      0x7C0C0600,  //  0027  CALL	R3	3
-      0x70020000,  //  0028  JMP		#002A
-      0x580C000D,  //  0029  LDCONST	R3	K13
-      0x00080403,  //  002A  ADD	R2	R2	R3
-      0xA8040001,  //  002B  EXBLK	1	1
-      0x80040400,  //  002C  RET	1	R2
-      0xA8040001,  //  002D  EXBLK	1	1
-      0x7002000D,  //  002E  JMP		#003D
-      0xAC040002,  //  002F  CATCH	R1	0	2
-      0x7002000A,  //  0030  JMP		#003C
-      0x600C0008,  //  0031  GETGBL	R3	G8
-      0x5C100200,  //  0032  MOVE	R4	R1
-      0x7C0C0200,  //  0033  CALL	R3	1
-      0x000E1C03,  //  0034  ADD	R3	K14	R3
-      0x000C070F,  //  0035  ADD	R3	R3	K15
-      0x60100008,  //  0036  GETGBL	R4	G8
-      0x5C140400,  //  0037  MOVE	R5	R2
-      0x7C100200,  //  0038  CALL	R4	1
-      0x000C0604,  //  0039  ADD	R3	R3	R4
-      0x80040600,  //  003A  RET	1	R3
-      0x70020000,  //  003B  JMP		#003D
-      0xB0080000,  //  003C  RAISE	2	R0	R0
-      0x80000000,  //  003D  RET	0
+    ( &(const binstruction[61]) {  /* code */
+      0xA802002C,  //  0000  EXBLK	0	#002E
+      0x58040000,  //  0001  LDCONST	R1	K0
+      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x780A0004,  //  0003  JMPF	R2	#0009
+      0x60080018,  //  0004  GETGBL	R2	G24
+      0x580C0002,  //  0005  LDCONST	R3	K2
+      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x00040202,  //  0008  ADD	R1	R1	R2
+      0x88080103,  //  0009  GETMBR	R2	R0	K3
+      0x4C0C0000,  //  000A  LDNIL	R3
+      0x20080403,  //  000B  NE	R2	R2	R3
+      0x780A0004,  //  000C  JMPF	R2	#0012
+      0x60080018,  //  000D  GETGBL	R2	G24
+      0x580C0004,  //  000E  LDCONST	R3	K4
+      0x88100103,  //  000F  GETMBR	R4	R0	K3
+      0x7C080400,  //  0010  CALL	R2	2
+      0x70020000,  //  0011  JMP		#0013
+      0x58080005,  //  0012  LDCONST	R2	K5
+      0x00040202,  //  0013  ADD	R1	R1	R2
+      0x88080106,  //  0014  GETMBR	R2	R0	K6
+      0x4C0C0000,  //  0015  LDNIL	R3
+      0x20080403,  //  0016  NE	R2	R2	R3
+      0x780A0004,  //  0017  JMPF	R2	#001D
+      0x60080018,  //  0018  GETGBL	R2	G24
+      0x580C0007,  //  0019  LDCONST	R3	K7
+      0x88100106,  //  001A  GETMBR	R4	R0	K6
+      0x7C080400,  //  001B  CALL	R2	2
+      0x70020000,  //  001C  JMP		#001E
+      0x58080008,  //  001D  LDCONST	R2	K8
+      0x00040202,  //  001E  ADD	R1	R1	R2
+      0x88080109,  //  001F  GETMBR	R2	R0	K9
+      0x4C0C0000,  //  0020  LDNIL	R3
+      0x20080403,  //  0021  NE	R2	R2	R3
+      0x780A0004,  //  0022  JMPF	R2	#0028
+      0x60080018,  //  0023  GETGBL	R2	G24
+      0x580C000A,  //  0024  LDCONST	R3	K10
+      0x88100109,  //  0025  GETMBR	R4	R0	K9
+      0x7C080400,  //  0026  CALL	R2	2
+      0x70020000,  //  0027  JMP		#0029
+      0x5808000B,  //  0028  LDCONST	R2	K11
+      0x00040202,  //  0029  ADD	R1	R1	R2
+      0xA8040001,  //  002A  EXBLK	1	1
+      0x80040200,  //  002B  RET	1	R1
+      0xA8040001,  //  002C  EXBLK	1	1
+      0x7002000D,  //  002D  JMP		#003C
+      0xAC040002,  //  002E  CATCH	R1	0	2
+      0x7002000A,  //  002F  JMP		#003B
+      0x600C0008,  //  0030  GETGBL	R3	G8
+      0x5C100200,  //  0031  MOVE	R4	R1
+      0x7C0C0200,  //  0032  CALL	R3	1
+      0x000E1803,  //  0033  ADD	R3	K12	R3
+      0x000C070D,  //  0034  ADD	R3	R3	K13
+      0x60100008,  //  0035  GETGBL	R4	G8
+      0x5C140400,  //  0036  MOVE	R5	R2
+      0x7C100200,  //  0037  CALL	R4	1
+      0x000C0604,  //  0038  ADD	R3	R3	R4
+      0x80040600,  //  0039  RET	1	R3
+      0x70020000,  //  003A  JMP		#003C
+      0xB0080000,  //  003B  RAISE	2	R0	R0
+      0x80000000,  //  003C  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
@@ -35,7 +35,7 @@ be_local_closure(Matter_IM_Message_status_error_received,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_Message_send_im,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    11,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -43,66 +43,63 @@ be_local_closure(Matter_IM_Message_send_im,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(ready),
-    /* K2   */  be_nested_str_weak(resp),
-    /* K3   */  be_nested_str_weak(encode_frame),
-    /* K4   */  be_nested_str_weak(data),
-    /* K5   */  be_nested_str_weak(to_TLV),
-    /* K6   */  be_nested_str_weak(tlv2raw),
-    /* K7   */  be_nested_str_weak(encrypt),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(format),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25i_X20exch_X3D_X25i_X20rack_X3D_X25s),
-    /* K12  */  be_nested_str_weak(session),
-    /* K13  */  be_nested_str_weak(local_session_id),
-    /* K14  */  be_nested_str_weak(message_counter),
-    /* K15  */  be_nested_str_weak(exchange_id),
-    /* K16  */  be_nested_str_weak(ack_message_counter),
-    /* K17  */  be_nested_str_weak(send_response_frame),
-    /* K18  */  be_nested_str_weak(last_counter),
-    /* K19  */  be_nested_str_weak(finish),
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ready),
+    /* K1   */  be_nested_str_weak(resp),
+    /* K2   */  be_nested_str_weak(encode_frame),
+    /* K3   */  be_nested_str_weak(data),
+    /* K4   */  be_nested_str_weak(to_TLV),
+    /* K5   */  be_nested_str_weak(tlv2raw),
+    /* K6   */  be_nested_str_weak(encrypt),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25i_X20exch_X3D_X25i_X20rack_X3D_X25s),
+    /* K10  */  be_nested_str_weak(session),
+    /* K11  */  be_nested_str_weak(local_session_id),
+    /* K12  */  be_nested_str_weak(message_counter),
+    /* K13  */  be_nested_str_weak(exchange_id),
+    /* K14  */  be_nested_str_weak(ack_message_counter),
+    /* K15  */  be_nested_str_weak(send_response_frame),
+    /* K16  */  be_nested_str_weak(last_counter),
+    /* K17  */  be_nested_str_weak(finish),
     }),
     be_str_weak(send_im),
     &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x740E0001,  //  0002  JMPT	R3	#0005
-      0x500C0000,  //  0003  LDBOOL	R3	0	0
-      0x80040600,  //  0004  RET	1	R3
-      0x880C0102,  //  0005  GETMBR	R3	R0	K2
-      0x8C100703,  //  0006  GETMET	R4	R3	K3
-      0x88180104,  //  0007  GETMBR	R6	R0	K4
-      0x8C180D05,  //  0008  GETMET	R6	R6	K5
-      0x7C180200,  //  0009  CALL	R6	1
-      0x8C180D06,  //  000A  GETMET	R6	R6	K6
-      0x7C180200,  //  000B  CALL	R6	1
-      0x7C100400,  //  000C  CALL	R4	2
-      0x8C100707,  //  000D  GETMET	R4	R3	K7
-      0x7C100200,  //  000E  CALL	R4	1
-      0xB8121000,  //  000F  GETNGBL	R4	K8
-      0x8C100909,  //  0010  GETMET	R4	R4	K9
-      0x8C18050A,  //  0011  GETMET	R6	R2	K10
-      0x5820000B,  //  0012  LDCONST	R8	K11
-      0x8824070C,  //  0013  GETMBR	R9	R3	K12
-      0x8824130D,  //  0014  GETMBR	R9	R9	K13
-      0x8828070E,  //  0015  GETMBR	R10	R3	K14
-      0x882C070F,  //  0016  GETMBR	R11	R3	K15
-      0x88300710,  //  0017  GETMBR	R12	R3	K16
-      0x7C180C00,  //  0018  CALL	R6	6
-      0x541E0003,  //  0019  LDINT	R7	4
-      0x7C100600,  //  001A  CALL	R4	3
-      0x8C100311,  //  001B  GETMET	R4	R1	K17
-      0x5C180600,  //  001C  MOVE	R6	R3
-      0x7C100400,  //  001D  CALL	R4	2
-      0x8810070E,  //  001E  GETMBR	R4	R3	K14
-      0x90022404,  //  001F  SETMBR	R0	K18	R4
-      0x50100200,  //  0020  LDBOOL	R4	1	0
-      0x90022604,  //  0021  SETMBR	R0	K19	R4
-      0x80000000,  //  0022  RET	0
+    ( &(const binstruction[34]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x740A0001,  //  0001  JMPT	R2	#0004
+      0x50080000,  //  0002  LDBOOL	R2	0	0
+      0x80040400,  //  0003  RET	1	R2
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C0C0502,  //  0005  GETMET	R3	R2	K2
+      0x88140103,  //  0006  GETMBR	R5	R0	K3
+      0x8C140B04,  //  0007  GETMET	R5	R5	K4
+      0x7C140200,  //  0008  CALL	R5	1
+      0x8C140B05,  //  0009  GETMET	R5	R5	K5
+      0x7C140200,  //  000A  CALL	R5	1
+      0x7C0C0400,  //  000B  CALL	R3	2
+      0x8C0C0506,  //  000C  GETMET	R3	R2	K6
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0xB80E0E00,  //  000E  GETNGBL	R3	K7
+      0x8C0C0708,  //  000F  GETMET	R3	R3	K8
+      0x60140018,  //  0010  GETGBL	R5	G24
+      0x58180009,  //  0011  LDCONST	R6	K9
+      0x881C050A,  //  0012  GETMBR	R7	R2	K10
+      0x881C0F0B,  //  0013  GETMBR	R7	R7	K11
+      0x8820050C,  //  0014  GETMBR	R8	R2	K12
+      0x8824050D,  //  0015  GETMBR	R9	R2	K13
+      0x8828050E,  //  0016  GETMBR	R10	R2	K14
+      0x7C140A00,  //  0017  CALL	R5	5
+      0x541A0003,  //  0018  LDINT	R6	4
+      0x7C0C0600,  //  0019  CALL	R3	3
+      0x8C0C030F,  //  001A  GETMET	R3	R1	K15
+      0x5C140400,  //  001B  MOVE	R5	R2
+      0x7C0C0400,  //  001C  CALL	R3	2
+      0x880C050C,  //  001D  GETMBR	R3	R2	K12
+      0x90022003,  //  001E  SETMBR	R0	K16	R3
+      0x500C0200,  //  001F  LDBOOL	R3	1	0
+      0x90022203,  //  0020  SETMBR	R0	K17	R3
+      0x80000000,  //  0021  RET	0
     })
   )
 );
@@ -254,7 +251,7 @@ be_local_closure(Matter_IM_Message_reached_timeout,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_Message_status_ok_received,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    7,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -262,41 +259,39 @@ be_local_closure(Matter_IM_Message_status_ok_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(expiration),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(millis),
-    /* K4   */  be_nested_str_weak(MSG_TIMEOUT),
-    /* K5   */  be_nested_str_weak(resp),
-    /* K6   */  be_nested_str_weak(build_response),
-    /* K7   */  be_nested_str_weak(opcode),
-    /* K8   */  be_nested_str_weak(x_flag_r),
-    /* K9   */  be_nested_str_weak(ready),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(expiration),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(millis),
+    /* K3   */  be_nested_str_weak(MSG_TIMEOUT),
+    /* K4   */  be_nested_str_weak(resp),
+    /* K5   */  be_nested_str_weak(build_response),
+    /* K6   */  be_nested_str_weak(opcode),
+    /* K7   */  be_nested_str_weak(x_flag_r),
+    /* K8   */  be_nested_str_weak(ready),
     }),
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0400,  //  0001  GETNGBL	R3	K2
-      0x8C0C0703,  //  0002  GETMET	R3	R3	K3
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x88100104,  //  0004  GETMBR	R4	R0	K4
-      0x000C0604,  //  0005  ADD	R3	R3	R4
-      0x90020203,  //  0006  SETMBR	R0	K1	R3
-      0x78060007,  //  0007  JMPF	R1	#0010
-      0x8C0C0306,  //  0008  GETMET	R3	R1	K6
-      0x88140105,  //  0009  GETMBR	R5	R0	K5
-      0x88140B07,  //  000A  GETMBR	R5	R5	K7
-      0x88180105,  //  000B  GETMBR	R6	R0	K5
-      0x88180D08,  //  000C  GETMBR	R6	R6	K8
-      0x881C0105,  //  000D  GETMBR	R7	R0	K5
-      0x7C0C0800,  //  000E  CALL	R3	4
-      0x90020A03,  //  000F  SETMBR	R0	K5	R3
-      0x500C0200,  //  0010  LDBOOL	R3	1	0
-      0x90021203,  //  0011  SETMBR	R0	K9	R3
-      0x500C0200,  //  0012  LDBOOL	R3	1	0
-      0x80040600,  //  0013  RET	1	R3
+    ( &(const binstruction[19]) {  /* code */
+      0xB80A0200,  //  0000  GETNGBL	R2	K1
+      0x8C080502,  //  0001  GETMET	R2	R2	K2
+      0x7C080200,  //  0002  CALL	R2	1
+      0x880C0103,  //  0003  GETMBR	R3	R0	K3
+      0x00080403,  //  0004  ADD	R2	R2	R3
+      0x90020002,  //  0005  SETMBR	R0	K0	R2
+      0x78060007,  //  0006  JMPF	R1	#000F
+      0x8C080305,  //  0007  GETMET	R2	R1	K5
+      0x88100104,  //  0008  GETMBR	R4	R0	K4
+      0x88100906,  //  0009  GETMBR	R4	R4	K6
+      0x88140104,  //  000A  GETMBR	R5	R0	K4
+      0x88140B07,  //  000B  GETMBR	R5	R5	K7
+      0x88180104,  //  000C  GETMBR	R6	R0	K4
+      0x7C080800,  //  000D  CALL	R2	4
+      0x90020802,  //  000E  SETMBR	R0	K4	R2
+      0x50080200,  //  000F  LDBOOL	R2	1	0
+      0x90021002,  //  0010  SETMBR	R0	K8	R2
+      0x50080200,  //  0011  LDBOOL	R2	1	0
+      0x80040400,  //  0012  RET	1	R2
     })
   )
 );
@@ -528,7 +523,7 @@ extern const bclass be_class_Matter_IM_ReportData;
 ********************************************************************/
 be_local_closure(Matter_IM_ReportData_send_im,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    12,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -536,97 +531,95 @@ be_local_closure(Matter_IM_ReportData_send_im,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(ready),
-    /* K2   */  be_nested_str_weak(resp),
-    /* K3   */  be_nested_str_weak(data),
-    /* K4   */  be_nested_str_weak(more_chunked_messages),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(attribute_reports),
-    /* K7   */  be_const_int(2147483647),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(to_TLV),
-    /* K10  */  be_nested_str_weak(tlv2raw),
-    /* K11  */  be_nested_str_weak(MAX_MESSAGE),
-    /* K12  */  be_nested_str_weak(encode_frame),
-    /* K13  */  be_nested_str_weak(encrypt),
-    /* K14  */  be_nested_str_weak(send_response_frame),
-    /* K15  */  be_nested_str_weak(last_counter),
-    /* K16  */  be_nested_str_weak(message_counter),
-    /* K17  */  be_nested_str_weak(finish),
+    ( &(const bvalue[17]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ready),
+    /* K1   */  be_nested_str_weak(resp),
+    /* K2   */  be_nested_str_weak(data),
+    /* K3   */  be_nested_str_weak(more_chunked_messages),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(attribute_reports),
+    /* K6   */  be_const_int(2147483647),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_nested_str_weak(to_TLV),
+    /* K9   */  be_nested_str_weak(tlv2raw),
+    /* K10  */  be_nested_str_weak(MAX_MESSAGE),
+    /* K11  */  be_nested_str_weak(encode_frame),
+    /* K12  */  be_nested_str_weak(encrypt),
+    /* K13  */  be_nested_str_weak(send_response_frame),
+    /* K14  */  be_nested_str_weak(last_counter),
+    /* K15  */  be_nested_str_weak(message_counter),
+    /* K16  */  be_nested_str_weak(finish),
     }),
     be_str_weak(send_im),
     &be_const_str_solidified,
-    ( &(const binstruction[68]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x740E0001,  //  0002  JMPT	R3	#0005
-      0x500C0000,  //  0003  LDBOOL	R3	0	0
-      0x80040600,  //  0004  RET	1	R3
+    ( &(const binstruction[67]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x740A0001,  //  0001  JMPT	R2	#0004
+      0x50080000,  //  0002  LDBOOL	R2	0	0
+      0x80040400,  //  0003  RET	1	R2
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
       0x880C0102,  //  0005  GETMBR	R3	R0	K2
-      0x88100103,  //  0006  GETMBR	R4	R0	K3
-      0x88140904,  //  0007  GETMBR	R5	R4	K4
-      0x58180005,  //  0008  LDCONST	R6	K5
-      0x4C1C0000,  //  0009  LDNIL	R7
-      0x88200906,  //  000A  GETMBR	R8	R4	K6
-      0x4C240000,  //  000B  LDNIL	R9
-      0x20201009,  //  000C  NE	R8	R8	R9
-      0x7822000D,  //  000D  JMPF	R8	#001C
-      0x40200D07,  //  000E  CONNECT	R8	R6	K7
-      0x88240906,  //  000F  GETMBR	R9	R4	K6
-      0x941C1208,  //  0010  GETIDX	R7	R9	R8
-      0x04280D05,  //  0011  SUB	R10	R6	K5
-      0x402A100A,  //  0012  CONNECT	R10	K8	R10
-      0x882C0906,  //  0013  GETMBR	R11	R4	K6
-      0x9428160A,  //  0014  GETIDX	R10	R11	R10
-      0x90120C0A,  //  0015  SETMBR	R4	K6	R10
-      0x6028000C,  //  0016  GETGBL	R10	G12
-      0x5C2C0E00,  //  0017  MOVE	R11	R7
-      0x7C280200,  //  0018  CALL	R10	1
-      0x24281508,  //  0019  GT	R10	R10	K8
-      0x9012080A,  //  001A  SETMBR	R4	K4	R10
-      0x70020001,  //  001B  JMP		#001E
-      0x50200000,  //  001C  LDBOOL	R8	0	0
-      0x90120808,  //  001D  SETMBR	R4	K4	R8
-      0x7815FFFF,  //  001E  JMPF	R5	#001F
-      0x88200904,  //  001F  GETMBR	R8	R4	K4
-      0x78220001,  //  0020  JMPF	R8	#0023
-      0x5C200A00,  //  0021  MOVE	R8	R5
-      0x7421FFFF,  //  0022  JMPT	R8	#0023
-      0x88200103,  //  0023  GETMBR	R8	R0	K3
-      0x8C201109,  //  0024  GETMET	R8	R8	K9
-      0x7C200200,  //  0025  CALL	R8	1
-      0x8C24110A,  //  0026  GETMET	R9	R8	K10
-      0x602C0015,  //  0027  GETGBL	R11	G21
-      0x8830010B,  //  0028  GETMBR	R12	R0	K11
-      0x7C2C0200,  //  0029  CALL	R11	1
-      0x7C240400,  //  002A  CALL	R9	2
-      0x8C28070C,  //  002B  GETMET	R10	R3	K12
-      0x5C301200,  //  002C  MOVE	R12	R9
-      0x7C280400,  //  002D  CALL	R10	2
-      0x8C28070D,  //  002E  GETMET	R10	R3	K13
-      0x7C280200,  //  002F  CALL	R10	1
-      0x8C28030E,  //  0030  GETMET	R10	R1	K14
-      0x5C300600,  //  0031  MOVE	R12	R3
-      0x7C280400,  //  0032  CALL	R10	2
-      0x88280710,  //  0033  GETMBR	R10	R3	K16
-      0x90021E0A,  //  0034  SETMBR	R0	K15	R10
-      0x4C280000,  //  0035  LDNIL	R10
-      0x20280E0A,  //  0036  NE	R10	R7	R10
-      0x782A0008,  //  0037  JMPF	R10	#0041
-      0x6028000C,  //  0038  GETGBL	R10	G12
-      0x5C2C0E00,  //  0039  MOVE	R11	R7
-      0x7C280200,  //  003A  CALL	R10	1
-      0x24281508,  //  003B  GT	R10	R10	K8
-      0x782A0003,  //  003C  JMPF	R10	#0041
-      0x90120C07,  //  003D  SETMBR	R4	K6	R7
-      0x50280000,  //  003E  LDBOOL	R10	0	0
-      0x9002020A,  //  003F  SETMBR	R0	K1	R10
-      0x70020001,  //  0040  JMP		#0043
-      0x50280200,  //  0041  LDBOOL	R10	1	0
-      0x9002220A,  //  0042  SETMBR	R0	K17	R10
-      0x80000000,  //  0043  RET	0
+      0x88100703,  //  0006  GETMBR	R4	R3	K3
+      0x58140004,  //  0007  LDCONST	R5	K4
+      0x4C180000,  //  0008  LDNIL	R6
+      0x881C0705,  //  0009  GETMBR	R7	R3	K5
+      0x4C200000,  //  000A  LDNIL	R8
+      0x201C0E08,  //  000B  NE	R7	R7	R8
+      0x781E000D,  //  000C  JMPF	R7	#001B
+      0x401C0B06,  //  000D  CONNECT	R7	R5	K6
+      0x88200705,  //  000E  GETMBR	R8	R3	K5
+      0x94181007,  //  000F  GETIDX	R6	R8	R7
+      0x04240B04,  //  0010  SUB	R9	R5	K4
+      0x40260E09,  //  0011  CONNECT	R9	K7	R9
+      0x88280705,  //  0012  GETMBR	R10	R3	K5
+      0x94241409,  //  0013  GETIDX	R9	R10	R9
+      0x900E0A09,  //  0014  SETMBR	R3	K5	R9
+      0x6024000C,  //  0015  GETGBL	R9	G12
+      0x5C280C00,  //  0016  MOVE	R10	R6
+      0x7C240200,  //  0017  CALL	R9	1
+      0x24241307,  //  0018  GT	R9	R9	K7
+      0x900E0609,  //  0019  SETMBR	R3	K3	R9
+      0x70020001,  //  001A  JMP		#001D
+      0x501C0000,  //  001B  LDBOOL	R7	0	0
+      0x900E0607,  //  001C  SETMBR	R3	K3	R7
+      0x7811FFFF,  //  001D  JMPF	R4	#001E
+      0x881C0703,  //  001E  GETMBR	R7	R3	K3
+      0x781E0001,  //  001F  JMPF	R7	#0022
+      0x5C1C0800,  //  0020  MOVE	R7	R4
+      0x741DFFFF,  //  0021  JMPT	R7	#0022
+      0x881C0102,  //  0022  GETMBR	R7	R0	K2
+      0x8C1C0F08,  //  0023  GETMET	R7	R7	K8
+      0x7C1C0200,  //  0024  CALL	R7	1
+      0x8C200F09,  //  0025  GETMET	R8	R7	K9
+      0x60280015,  //  0026  GETGBL	R10	G21
+      0x882C010A,  //  0027  GETMBR	R11	R0	K10
+      0x7C280200,  //  0028  CALL	R10	1
+      0x7C200400,  //  0029  CALL	R8	2
+      0x8C24050B,  //  002A  GETMET	R9	R2	K11
+      0x5C2C1000,  //  002B  MOVE	R11	R8
+      0x7C240400,  //  002C  CALL	R9	2
+      0x8C24050C,  //  002D  GETMET	R9	R2	K12
+      0x7C240200,  //  002E  CALL	R9	1
+      0x8C24030D,  //  002F  GETMET	R9	R1	K13
+      0x5C2C0400,  //  0030  MOVE	R11	R2
+      0x7C240400,  //  0031  CALL	R9	2
+      0x8824050F,  //  0032  GETMBR	R9	R2	K15
+      0x90021C09,  //  0033  SETMBR	R0	K14	R9
+      0x4C240000,  //  0034  LDNIL	R9
+      0x20240C09,  //  0035  NE	R9	R6	R9
+      0x78260008,  //  0036  JMPF	R9	#0040
+      0x6024000C,  //  0037  GETGBL	R9	G12
+      0x5C280C00,  //  0038  MOVE	R10	R6
+      0x7C240200,  //  0039  CALL	R9	1
+      0x24241307,  //  003A  GT	R9	R9	K7
+      0x78260003,  //  003B  JMPF	R9	#0040
+      0x900E0A06,  //  003C  SETMBR	R3	K5	R6
+      0x50240000,  //  003D  LDBOOL	R9	0	0
+      0x90020009,  //  003E  SETMBR	R0	K0	R9
+      0x70020001,  //  003F  JMP		#0042
+      0x50240200,  //  0040  LDBOOL	R9	1	0
+      0x90022009,  //  0041  SETMBR	R0	K16	R9
+      0x80000000,  //  0042  RET	0
     })
   )
 );
@@ -748,7 +741,7 @@ be_local_closure(Matter_IM_ReportDataSubscribed_ack_received,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_ReportDataSubscribed_send_im,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -756,103 +749,100 @@ be_local_closure(Matter_IM_ReportDataSubscribed_send_im,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(ready),
-    /* K2   */  be_nested_str_weak(data),
-    /* K3   */  be_nested_str_weak(attribute_reports),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(report_data_phase),
-    /* K6   */  be_nested_str_weak(send_im),
-    /* K7   */  be_nested_str_weak(finish),
-    /* K8   */  be_nested_str_weak(resp),
-    /* K9   */  be_nested_str_weak(build_standalone_ack),
-    /* K10  */  be_nested_str_weak(encode_frame),
-    /* K11  */  be_nested_str_weak(encrypt),
-    /* K12  */  be_nested_str_weak(tasmota),
-    /* K13  */  be_nested_str_weak(log),
-    /* K14  */  be_nested_str_weak(format),
-    /* K15  */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i),
-    /* K16  */  be_nested_str_weak(session),
-    /* K17  */  be_nested_str_weak(local_session_id),
-    /* K18  */  be_nested_str_weak(ack_message_counter),
-    /* K19  */  be_nested_str_weak(message_counter),
-    /* K20  */  be_nested_str_weak(send_response_frame),
-    /* K21  */  be_nested_str_weak(last_counter),
+    ( &(const bvalue[20]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ready),
+    /* K1   */  be_nested_str_weak(data),
+    /* K2   */  be_nested_str_weak(attribute_reports),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(report_data_phase),
+    /* K5   */  be_nested_str_weak(send_im),
+    /* K6   */  be_nested_str_weak(finish),
+    /* K7   */  be_nested_str_weak(resp),
+    /* K8   */  be_nested_str_weak(build_standalone_ack),
+    /* K9   */  be_nested_str_weak(encode_frame),
+    /* K10  */  be_nested_str_weak(encrypt),
+    /* K11  */  be_nested_str_weak(tasmota),
+    /* K12  */  be_nested_str_weak(log),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i),
+    /* K14  */  be_nested_str_weak(session),
+    /* K15  */  be_nested_str_weak(local_session_id),
+    /* K16  */  be_nested_str_weak(ack_message_counter),
+    /* K17  */  be_nested_str_weak(message_counter),
+    /* K18  */  be_nested_str_weak(send_response_frame),
+    /* K19  */  be_nested_str_weak(last_counter),
     }),
     be_str_weak(send_im),
     &be_const_str_solidified,
-    ( &(const binstruction[70]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x740E0001,  //  0002  JMPT	R3	#0005
-      0x500C0000,  //  0003  LDBOOL	R3	0	0
-      0x80040600,  //  0004  RET	1	R3
-      0x600C000C,  //  0005  GETGBL	R3	G12
-      0x88100102,  //  0006  GETMBR	R4	R0	K2
-      0x88100903,  //  0007  GETMBR	R4	R4	K3
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0x240C0704,  //  0009  GT	R3	R3	K4
-      0x780E002C,  //  000A  JMPF	R3	#0038
-      0x880C0105,  //  000B  GETMBR	R3	R0	K5
-      0x780E000F,  //  000C  JMPF	R3	#001D
-      0x600C0003,  //  000D  GETGBL	R3	G3
-      0x5C100000,  //  000E  MOVE	R4	R0
-      0x7C0C0200,  //  000F  CALL	R3	1
-      0x8C0C0706,  //  0010  GETMET	R3	R3	K6
-      0x5C140200,  //  0011  MOVE	R5	R1
-      0x7C0C0400,  //  0012  CALL	R3	2
-      0x880C0107,  //  0013  GETMBR	R3	R0	K7
-      0x740E0000,  //  0014  JMPT	R3	#0016
-      0x80000600,  //  0015  RET	0
-      0x500C0000,  //  0016  LDBOOL	R3	0	0
-      0x90020A03,  //  0017  SETMBR	R0	K5	R3
-      0x500C0000,  //  0018  LDBOOL	R3	0	0
-      0x90020203,  //  0019  SETMBR	R0	K1	R3
-      0x500C0000,  //  001A  LDBOOL	R3	0	0
-      0x90020E03,  //  001B  SETMBR	R0	K7	R3
-      0x70020019,  //  001C  JMP		#0037
-      0x880C0108,  //  001D  GETMBR	R3	R0	K8
-      0x8C0C0709,  //  001E  GETMET	R3	R3	K9
-      0x50140000,  //  001F  LDBOOL	R5	0	0
-      0x7C0C0400,  //  0020  CALL	R3	2
-      0x8C10070A,  //  0021  GETMET	R4	R3	K10
-      0x7C100200,  //  0022  CALL	R4	1
-      0x8C10070B,  //  0023  GETMET	R4	R3	K11
-      0x7C100200,  //  0024  CALL	R4	1
-      0xB8121800,  //  0025  GETNGBL	R4	K12
-      0x8C10090D,  //  0026  GETMET	R4	R4	K13
-      0x8C18050E,  //  0027  GETMET	R6	R2	K14
-      0x5820000F,  //  0028  LDCONST	R8	K15
-      0x88240710,  //  0029  GETMBR	R9	R3	K16
-      0x88241311,  //  002A  GETMBR	R9	R9	K17
-      0x88280712,  //  002B  GETMBR	R10	R3	K18
-      0x882C0713,  //  002C  GETMBR	R11	R3	K19
-      0x7C180A00,  //  002D  CALL	R6	5
-      0x541E0003,  //  002E  LDINT	R7	4
-      0x7C100600,  //  002F  CALL	R4	3
-      0x8C100314,  //  0030  GETMET	R4	R1	K20
-      0x5C180600,  //  0031  MOVE	R6	R3
-      0x7C100400,  //  0032  CALL	R4	2
-      0x88100713,  //  0033  GETMBR	R4	R3	K19
-      0x90022A04,  //  0034  SETMBR	R0	K21	R4
-      0x50100200,  //  0035  LDBOOL	R4	1	0
-      0x90020E04,  //  0036  SETMBR	R0	K7	R4
-      0x7002000C,  //  0037  JMP		#0045
-      0x880C0105,  //  0038  GETMBR	R3	R0	K5
-      0x780E0008,  //  0039  JMPF	R3	#0043
-      0x600C0003,  //  003A  GETGBL	R3	G3
-      0x5C100000,  //  003B  MOVE	R4	R0
-      0x7C0C0200,  //  003C  CALL	R3	1
-      0x8C0C0706,  //  003D  GETMET	R3	R3	K6
-      0x5C140200,  //  003E  MOVE	R5	R1
-      0x7C0C0400,  //  003F  CALL	R3	2
-      0x500C0000,  //  0040  LDBOOL	R3	0	0
-      0x90020A03,  //  0041  SETMBR	R0	K5	R3
-      0x70020001,  //  0042  JMP		#0045
-      0x500C0200,  //  0043  LDBOOL	R3	1	0
-      0x90020E03,  //  0044  SETMBR	R0	K7	R3
-      0x80000000,  //  0045  RET	0
+    ( &(const binstruction[69]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x740A0001,  //  0001  JMPT	R2	#0004
+      0x50080000,  //  0002  LDBOOL	R2	0	0
+      0x80040400,  //  0003  RET	1	R2
+      0x6008000C,  //  0004  GETGBL	R2	G12
+      0x880C0101,  //  0005  GETMBR	R3	R0	K1
+      0x880C0702,  //  0006  GETMBR	R3	R3	K2
+      0x7C080200,  //  0007  CALL	R2	1
+      0x24080503,  //  0008  GT	R2	R2	K3
+      0x780A002C,  //  0009  JMPF	R2	#0037
+      0x88080104,  //  000A  GETMBR	R2	R0	K4
+      0x780A000F,  //  000B  JMPF	R2	#001C
+      0x60080003,  //  000C  GETGBL	R2	G3
+      0x5C0C0000,  //  000D  MOVE	R3	R0
+      0x7C080200,  //  000E  CALL	R2	1
+      0x8C080505,  //  000F  GETMET	R2	R2	K5
+      0x5C100200,  //  0010  MOVE	R4	R1
+      0x7C080400,  //  0011  CALL	R2	2
+      0x88080106,  //  0012  GETMBR	R2	R0	K6
+      0x740A0000,  //  0013  JMPT	R2	#0015
+      0x80000400,  //  0014  RET	0
+      0x50080000,  //  0015  LDBOOL	R2	0	0
+      0x90020802,  //  0016  SETMBR	R0	K4	R2
+      0x50080000,  //  0017  LDBOOL	R2	0	0
+      0x90020002,  //  0018  SETMBR	R0	K0	R2
+      0x50080000,  //  0019  LDBOOL	R2	0	0
+      0x90020C02,  //  001A  SETMBR	R0	K6	R2
+      0x70020019,  //  001B  JMP		#0036
+      0x88080107,  //  001C  GETMBR	R2	R0	K7
+      0x8C080508,  //  001D  GETMET	R2	R2	K8
+      0x50100000,  //  001E  LDBOOL	R4	0	0
+      0x7C080400,  //  001F  CALL	R2	2
+      0x8C0C0509,  //  0020  GETMET	R3	R2	K9
+      0x7C0C0200,  //  0021  CALL	R3	1
+      0x8C0C050A,  //  0022  GETMET	R3	R2	K10
+      0x7C0C0200,  //  0023  CALL	R3	1
+      0xB80E1600,  //  0024  GETNGBL	R3	K11
+      0x8C0C070C,  //  0025  GETMET	R3	R3	K12
+      0x60140018,  //  0026  GETGBL	R5	G24
+      0x5818000D,  //  0027  LDCONST	R6	K13
+      0x881C050E,  //  0028  GETMBR	R7	R2	K14
+      0x881C0F0F,  //  0029  GETMBR	R7	R7	K15
+      0x88200510,  //  002A  GETMBR	R8	R2	K16
+      0x88240511,  //  002B  GETMBR	R9	R2	K17
+      0x7C140800,  //  002C  CALL	R5	4
+      0x541A0003,  //  002D  LDINT	R6	4
+      0x7C0C0600,  //  002E  CALL	R3	3
+      0x8C0C0312,  //  002F  GETMET	R3	R1	K18
+      0x5C140400,  //  0030  MOVE	R5	R2
+      0x7C0C0400,  //  0031  CALL	R3	2
+      0x880C0511,  //  0032  GETMBR	R3	R2	K17
+      0x90022603,  //  0033  SETMBR	R0	K19	R3
+      0x500C0200,  //  0034  LDBOOL	R3	1	0
+      0x90020C03,  //  0035  SETMBR	R0	K6	R3
+      0x7002000C,  //  0036  JMP		#0044
+      0x88080104,  //  0037  GETMBR	R2	R0	K4
+      0x780A0008,  //  0038  JMPF	R2	#0042
+      0x60080003,  //  0039  GETGBL	R2	G3
+      0x5C0C0000,  //  003A  MOVE	R3	R0
+      0x7C080200,  //  003B  CALL	R2	1
+      0x8C080505,  //  003C  GETMET	R2	R2	K5
+      0x5C100200,  //  003D  MOVE	R4	R1
+      0x7C080400,  //  003E  CALL	R2	2
+      0x50080000,  //  003F  LDBOOL	R2	0	0
+      0x90020802,  //  0040  SETMBR	R0	K4	R2
+      0x70020001,  //  0041  JMP		#0044
+      0x50080200,  //  0042  LDBOOL	R2	1	0
+      0x90020C02,  //  0043  SETMBR	R0	K6	R2
+      0x80000000,  //  0044  RET	0
     })
   )
 );
@@ -1345,7 +1335,7 @@ be_local_closure(Matter_IM_SubscribeResponse_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_SubscribeResponse_status_ok_received,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    8,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1353,41 +1343,38 @@ be_local_closure(Matter_IM_SubscribeResponse_status_ok_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X3ESub_OK_X20_X20_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
-    /* K5   */  be_nested_str_weak(session),
-    /* K6   */  be_nested_str_weak(local_session_id),
-    /* K7   */  be_nested_str_weak(sub),
-    /* K8   */  be_nested_str_weak(subscription_id),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_nested_str_weak(status_ok_received),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X3ESub_OK_X20_X20_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
+    /* K3   */  be_nested_str_weak(session),
+    /* K4   */  be_nested_str_weak(local_session_id),
+    /* K5   */  be_nested_str_weak(sub),
+    /* K6   */  be_nested_str_weak(subscription_id),
+    /* K7   */  be_const_int(3),
+    /* K8   */  be_nested_str_weak(status_ok_received),
     }),
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x581C0004,  //  0004  LDCONST	R7	K4
-      0x88200305,  //  0005  GETMBR	R8	R1	K5
-      0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x88240107,  //  0007  GETMBR	R9	R0	K7
-      0x88241308,  //  0008  GETMBR	R9	R9	K8
-      0x7C140800,  //  0009  CALL	R5	4
-      0x58180009,  //  000A  LDCONST	R6	K9
-      0x7C0C0600,  //  000B  CALL	R3	3
-      0x600C0003,  //  000C  GETGBL	R3	G3
-      0x5C100000,  //  000D  MOVE	R4	R0
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0x8C0C070A,  //  000F  GETMET	R3	R3	K10
-      0x5C140200,  //  0010  MOVE	R5	R1
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x80040600,  //  0012  RET	1	R3
+    ( &(const binstruction[18]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x60100018,  //  0002  GETGBL	R4	G24
+      0x58140002,  //  0003  LDCONST	R5	K2
+      0x88180303,  //  0004  GETMBR	R6	R1	K3
+      0x88180D04,  //  0005  GETMBR	R6	R6	K4
+      0x881C0105,  //  0006  GETMBR	R7	R0	K5
+      0x881C0F06,  //  0007  GETMBR	R7	R7	K6
+      0x7C100600,  //  0008  CALL	R4	3
+      0x58140007,  //  0009  LDCONST	R5	K7
+      0x7C080600,  //  000A  CALL	R2	3
+      0x60080003,  //  000B  GETGBL	R2	G3
+      0x5C0C0000,  //  000C  MOVE	R3	R0
+      0x7C080200,  //  000D  CALL	R2	1
+      0x8C080508,  //  000E  GETMET	R2	R2	K8
+      0x5C100200,  //  000F  MOVE	R4	R1
+      0x7C080400,  //  0010  CALL	R2	2
+      0x80040400,  //  0011  RET	1	R2
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Subscription.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Subscription.h
@@ -323,7 +323,7 @@ be_local_closure(Matter_IM_Subscription_attribute_updated_ctx,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_Subscription_re_arm,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    7,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -331,57 +331,54 @@ be_local_closure(Matter_IM_Subscription_re_arm,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(wait_status),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(millis),
-    /* K4   */  be_nested_str_weak(expiration),
-    /* K5   */  be_nested_str_weak(max_interval),
-    /* K6   */  be_nested_str_weak(MAX_INTERVAL_MARGIN),
-    /* K7   */  be_nested_str_weak(not_before),
-    /* K8   */  be_nested_str_weak(min_interval),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(is_keep_alive),
-    /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(format),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X2ESub_Done_X20_X20_X28_X20_X20_X20_X20_X20_X20_X29_X20sub_X3D_X25i),
-    /* K14  */  be_nested_str_weak(subscription_id),
-    /* K15  */  be_const_int(3),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(wait_status),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(millis),
+    /* K3   */  be_nested_str_weak(expiration),
+    /* K4   */  be_nested_str_weak(max_interval),
+    /* K5   */  be_nested_str_weak(MAX_INTERVAL_MARGIN),
+    /* K6   */  be_nested_str_weak(not_before),
+    /* K7   */  be_nested_str_weak(min_interval),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(is_keep_alive),
+    /* K10  */  be_nested_str_weak(log),
+    /* K11  */  be_nested_str_weak(MTR_X3A_X20_X2ESub_Done_X20_X20_X28_X20_X20_X20_X20_X20_X20_X29_X20sub_X3D_X25i),
+    /* K12  */  be_nested_str_weak(subscription_id),
+    /* K13  */  be_const_int(3),
     }),
     be_str_weak(re_arm),
     &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x50080000,  //  0001  LDBOOL	R2	0	0
-      0x90020202,  //  0002  SETMBR	R0	K1	R2
-      0xB80A0400,  //  0003  GETNGBL	R2	K2
-      0x8C080503,  //  0004  GETMET	R2	R2	K3
-      0x7C080200,  //  0005  CALL	R2	1
+    ( &(const binstruction[29]) {  /* code */
+      0x50040000,  //  0000  LDBOOL	R1	0	0
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0xB8060200,  //  0002  GETNGBL	R1	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x88080104,  //  0005  GETMBR	R2	R0	K4
       0x880C0105,  //  0006  GETMBR	R3	R0	K5
-      0x88100106,  //  0007  GETMBR	R4	R0	K6
-      0x040C0604,  //  0008  SUB	R3	R3	R4
-      0x541203E7,  //  0009  LDINT	R4	1000
-      0x080C0604,  //  000A  MUL	R3	R3	R4
-      0x000C0403,  //  000B  ADD	R3	R2	R3
-      0x90020803,  //  000C  SETMBR	R0	K4	R3
-      0x880C0108,  //  000D  GETMBR	R3	R0	K8
-      0x541203E7,  //  000E  LDINT	R4	1000
-      0x080C0604,  //  000F  MUL	R3	R3	R4
-      0x000C0403,  //  0010  ADD	R3	R2	R3
-      0x040C0709,  //  0011  SUB	R3	R3	K9
-      0x90020E03,  //  0012  SETMBR	R0	K7	R3
-      0x880C010A,  //  0013  GETMBR	R3	R0	K10
-      0x740E0007,  //  0014  JMPT	R3	#001D
-      0xB80E0400,  //  0015  GETNGBL	R3	K2
-      0x8C0C070B,  //  0016  GETMET	R3	R3	K11
-      0x8C14030C,  //  0017  GETMET	R5	R1	K12
-      0x581C000D,  //  0018  LDCONST	R7	K13
-      0x8820010E,  //  0019  GETMBR	R8	R0	K14
-      0x7C140600,  //  001A  CALL	R5	3
-      0x5818000F,  //  001B  LDCONST	R6	K15
-      0x7C0C0600,  //  001C  CALL	R3	3
-      0x80000000,  //  001D  RET	0
+      0x04080403,  //  0007  SUB	R2	R2	R3
+      0x540E03E7,  //  0008  LDINT	R3	1000
+      0x08080403,  //  0009  MUL	R2	R2	R3
+      0x00080202,  //  000A  ADD	R2	R1	R2
+      0x90020602,  //  000B  SETMBR	R0	K3	R2
+      0x88080107,  //  000C  GETMBR	R2	R0	K7
+      0x540E03E7,  //  000D  LDINT	R3	1000
+      0x08080403,  //  000E  MUL	R2	R2	R3
+      0x00080202,  //  000F  ADD	R2	R1	R2
+      0x04080508,  //  0010  SUB	R2	R2	K8
+      0x90020C02,  //  0011  SETMBR	R0	K6	R2
+      0x88080109,  //  0012  GETMBR	R2	R0	K9
+      0x740A0007,  //  0013  JMPT	R2	#001C
+      0xB80A0200,  //  0014  GETNGBL	R2	K1
+      0x8C08050A,  //  0015  GETMET	R2	R2	K10
+      0x60100018,  //  0016  GETGBL	R4	G24
+      0x5814000B,  //  0017  LDCONST	R5	K11
+      0x8818010C,  //  0018  GETMBR	R6	R0	K12
+      0x7C100400,  //  0019  CALL	R4	2
+      0x5814000D,  //  001A  LDCONST	R5	K13
+      0x7C080600,  //  001B  CALL	R2	3
+      0x80000000,  //  001C  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
@@ -348,7 +348,7 @@ be_local_closure(Matter_Frame_debug,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Frame_build_standalone_ack,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -356,79 +356,77 @@ be_local_closure(Matter_Frame_build_standalone_ack,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(message_handler),
-    /* K2   */  be_nested_str_weak(remote_ip),
-    /* K3   */  be_nested_str_weak(remote_port),
-    /* K4   */  be_nested_str_weak(flag_s),
-    /* K5   */  be_nested_str_weak(flag_dsiz),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(dest_node_id_8),
-    /* K8   */  be_nested_str_weak(source_node_id),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(session),
-    /* K11  */  be_nested_str_weak(message_counter),
-    /* K12  */  be_nested_str_weak(counter_snd_next),
-    /* K13  */  be_nested_str_weak(local_session_id),
-    /* K14  */  be_nested_str_weak(initiator_session_id),
-    /* K15  */  be_nested_str_weak(x_flag_i),
-    /* K16  */  be_nested_str_weak(opcode),
-    /* K17  */  be_nested_str_weak(exchange_id),
-    /* K18  */  be_nested_str_weak(protocol_id),
-    /* K19  */  be_nested_str_weak(x_flag_a),
-    /* K20  */  be_nested_str_weak(ack_message_counter),
-    /* K21  */  be_nested_str_weak(x_flag_r),
+    ( &(const bvalue[21]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(remote_ip),
+    /* K2   */  be_nested_str_weak(remote_port),
+    /* K3   */  be_nested_str_weak(flag_s),
+    /* K4   */  be_nested_str_weak(flag_dsiz),
+    /* K5   */  be_const_int(1),
+    /* K6   */  be_nested_str_weak(dest_node_id_8),
+    /* K7   */  be_nested_str_weak(source_node_id),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(session),
+    /* K10  */  be_nested_str_weak(message_counter),
+    /* K11  */  be_nested_str_weak(counter_snd_next),
+    /* K12  */  be_nested_str_weak(local_session_id),
+    /* K13  */  be_nested_str_weak(initiator_session_id),
+    /* K14  */  be_nested_str_weak(x_flag_i),
+    /* K15  */  be_nested_str_weak(opcode),
+    /* K16  */  be_nested_str_weak(exchange_id),
+    /* K17  */  be_nested_str_weak(protocol_id),
+    /* K18  */  be_nested_str_weak(x_flag_a),
+    /* K19  */  be_nested_str_weak(ack_message_counter),
+    /* K20  */  be_nested_str_weak(x_flag_r),
     }),
     be_str_weak(build_standalone_ack),
     &be_const_str_solidified,
-    ( &(const binstruction[46]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x600C0006,  //  0001  GETGBL	R3	G6
-      0x5C100000,  //  0002  MOVE	R4	R0
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x88100101,  //  0004  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x88100102,  //  0006  GETMBR	R4	R0	K2
-      0x900E0404,  //  0007  SETMBR	R3	K2	R4
-      0x88100103,  //  0008  GETMBR	R4	R0	K3
-      0x900E0604,  //  0009  SETMBR	R3	K3	R4
-      0x88100104,  //  000A  GETMBR	R4	R0	K4
-      0x78120003,  //  000B  JMPF	R4	#0010
-      0x900E0B06,  //  000C  SETMBR	R3	K5	K6
-      0x88100108,  //  000D  GETMBR	R4	R0	K8
-      0x900E0E04,  //  000E  SETMBR	R3	K7	R4
-      0x70020000,  //  000F  JMP		#0011
-      0x900E0B09,  //  0010  SETMBR	R3	K5	K9
-      0x8810010A,  //  0011  GETMBR	R4	R0	K10
-      0x900E1404,  //  0012  SETMBR	R3	K10	R4
-      0x8810010A,  //  0013  GETMBR	R4	R0	K10
-      0x8C10090C,  //  0014  GETMET	R4	R4	K12
-      0x7C100200,  //  0015  CALL	R4	1
-      0x900E1604,  //  0016  SETMBR	R3	K11	R4
-      0x8810010A,  //  0017  GETMBR	R4	R0	K10
-      0x8810090E,  //  0018  GETMBR	R4	R4	K14
-      0x900E1A04,  //  0019  SETMBR	R3	K13	R4
-      0x8810010F,  //  001A  GETMBR	R4	R0	K15
-      0x78120001,  //  001B  JMPF	R4	#001E
-      0x58100009,  //  001C  LDCONST	R4	K9
-      0x70020000,  //  001D  JMP		#001F
-      0x58100006,  //  001E  LDCONST	R4	K6
-      0x900E1E04,  //  001F  SETMBR	R3	K15	R4
-      0x5412000F,  //  0020  LDINT	R4	16
-      0x900E2004,  //  0021  SETMBR	R3	K16	R4
-      0x88100111,  //  0022  GETMBR	R4	R0	K17
-      0x900E2204,  //  0023  SETMBR	R3	K17	R4
-      0x900E2509,  //  0024  SETMBR	R3	K18	K9
-      0x900E2706,  //  0025  SETMBR	R3	K19	K6
-      0x8810010B,  //  0026  GETMBR	R4	R0	K11
-      0x900E2804,  //  0027  SETMBR	R3	K20	R4
-      0x78060001,  //  0028  JMPF	R1	#002B
-      0x58100006,  //  0029  LDCONST	R4	K6
-      0x70020000,  //  002A  JMP		#002C
-      0x58100009,  //  002B  LDCONST	R4	K9
-      0x900E2A04,  //  002C  SETMBR	R3	K21	R4
-      0x80040600,  //  002D  RET	1	R3
+    ( &(const binstruction[45]) {  /* code */
+      0x60080006,  //  0000  GETGBL	R2	G6
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x880C0100,  //  0003  GETMBR	R3	R0	K0
+      0x7C080200,  //  0004  CALL	R2	1
+      0x880C0101,  //  0005  GETMBR	R3	R0	K1
+      0x900A0203,  //  0006  SETMBR	R2	K1	R3
+      0x880C0102,  //  0007  GETMBR	R3	R0	K2
+      0x900A0403,  //  0008  SETMBR	R2	K2	R3
+      0x880C0103,  //  0009  GETMBR	R3	R0	K3
+      0x780E0003,  //  000A  JMPF	R3	#000F
+      0x900A0905,  //  000B  SETMBR	R2	K4	K5
+      0x880C0107,  //  000C  GETMBR	R3	R0	K7
+      0x900A0C03,  //  000D  SETMBR	R2	K6	R3
+      0x70020000,  //  000E  JMP		#0010
+      0x900A0908,  //  000F  SETMBR	R2	K4	K8
+      0x880C0109,  //  0010  GETMBR	R3	R0	K9
+      0x900A1203,  //  0011  SETMBR	R2	K9	R3
+      0x880C0109,  //  0012  GETMBR	R3	R0	K9
+      0x8C0C070B,  //  0013  GETMET	R3	R3	K11
+      0x7C0C0200,  //  0014  CALL	R3	1
+      0x900A1403,  //  0015  SETMBR	R2	K10	R3
+      0x880C0109,  //  0016  GETMBR	R3	R0	K9
+      0x880C070D,  //  0017  GETMBR	R3	R3	K13
+      0x900A1803,  //  0018  SETMBR	R2	K12	R3
+      0x880C010E,  //  0019  GETMBR	R3	R0	K14
+      0x780E0001,  //  001A  JMPF	R3	#001D
+      0x580C0008,  //  001B  LDCONST	R3	K8
+      0x70020000,  //  001C  JMP		#001E
+      0x580C0005,  //  001D  LDCONST	R3	K5
+      0x900A1C03,  //  001E  SETMBR	R2	K14	R3
+      0x540E000F,  //  001F  LDINT	R3	16
+      0x900A1E03,  //  0020  SETMBR	R2	K15	R3
+      0x880C0110,  //  0021  GETMBR	R3	R0	K16
+      0x900A2003,  //  0022  SETMBR	R2	K16	R3
+      0x900A2308,  //  0023  SETMBR	R2	K17	K8
+      0x900A2505,  //  0024  SETMBR	R2	K18	K5
+      0x880C010A,  //  0025  GETMBR	R3	R0	K10
+      0x900A2603,  //  0026  SETMBR	R2	K19	R3
+      0x78060001,  //  0027  JMPF	R1	#002A
+      0x580C0005,  //  0028  LDCONST	R3	K5
+      0x70020000,  //  0029  JMP		#002B
+      0x580C0008,  //  002A  LDCONST	R3	K8
+      0x900A2803,  //  002B  SETMBR	R2	K20	R3
+      0x80040400,  //  002C  RET	1	R2
     })
   )
 );
@@ -440,7 +438,7 @@ be_local_closure(Matter_Frame_build_standalone_ack,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Frame_build_response,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    11,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -448,135 +446,132 @@ be_local_closure(Matter_Frame_build_response,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[32]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(message_handler),
-    /* K2   */  be_nested_str_weak(remote_ip),
-    /* K3   */  be_nested_str_weak(remote_port),
-    /* K4   */  be_nested_str_weak(flag_s),
-    /* K5   */  be_nested_str_weak(flag_dsiz),
-    /* K6   */  be_const_int(1),
-    /* K7   */  be_nested_str_weak(dest_node_id_8),
-    /* K8   */  be_nested_str_weak(source_node_id),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(session),
-    /* K11  */  be_nested_str_weak(local_session_id),
-    /* K12  */  be_nested_str_weak(initiator_session_id),
-    /* K13  */  be_nested_str_weak(message_counter),
-    /* K14  */  be_nested_str_weak(counter_snd_next),
-    /* K15  */  be_nested_str_weak(_counter_insecure_snd),
-    /* K16  */  be_nested_str_weak(next),
-    /* K17  */  be_nested_str_weak(x_flag_i),
-    /* K18  */  be_nested_str_weak(opcode),
-    /* K19  */  be_nested_str_weak(exchange_id),
-    /* K20  */  be_nested_str_weak(protocol_id),
-    /* K21  */  be_nested_str_weak(x_flag_r),
-    /* K22  */  be_nested_str_weak(x_flag_a),
-    /* K23  */  be_nested_str_weak(ack_message_counter),
-    /* K24  */  be_nested_str_weak(matter),
-    /* K25  */  be_nested_str_weak(get_opcode_name),
-    /* K26  */  be_nested_str_weak(format),
-    /* K27  */  be_nested_str_weak(0x_X2502X),
-    /* K28  */  be_nested_str_weak(tasmota),
-    /* K29  */  be_nested_str_weak(log),
-    /* K30  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s),
-    /* K31  */  be_const_int(3),
+    ( &(const bvalue[30]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(remote_ip),
+    /* K2   */  be_nested_str_weak(remote_port),
+    /* K3   */  be_nested_str_weak(flag_s),
+    /* K4   */  be_nested_str_weak(flag_dsiz),
+    /* K5   */  be_const_int(1),
+    /* K6   */  be_nested_str_weak(dest_node_id_8),
+    /* K7   */  be_nested_str_weak(source_node_id),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(session),
+    /* K10  */  be_nested_str_weak(local_session_id),
+    /* K11  */  be_nested_str_weak(initiator_session_id),
+    /* K12  */  be_nested_str_weak(message_counter),
+    /* K13  */  be_nested_str_weak(counter_snd_next),
+    /* K14  */  be_nested_str_weak(_counter_insecure_snd),
+    /* K15  */  be_nested_str_weak(next),
+    /* K16  */  be_nested_str_weak(x_flag_i),
+    /* K17  */  be_nested_str_weak(opcode),
+    /* K18  */  be_nested_str_weak(exchange_id),
+    /* K19  */  be_nested_str_weak(protocol_id),
+    /* K20  */  be_nested_str_weak(x_flag_r),
+    /* K21  */  be_nested_str_weak(x_flag_a),
+    /* K22  */  be_nested_str_weak(ack_message_counter),
+    /* K23  */  be_nested_str_weak(matter),
+    /* K24  */  be_nested_str_weak(get_opcode_name),
+    /* K25  */  be_nested_str_weak(0x_X2502X),
+    /* K26  */  be_nested_str_weak(tasmota),
+    /* K27  */  be_nested_str_weak(log),
+    /* K28  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s),
+    /* K29  */  be_const_int(3),
     }),
     be_str_weak(build_response),
     &be_const_str_solidified,
-    ( &(const binstruction[92]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0x4C140000,  //  0001  LDNIL	R5
-      0x1C140605,  //  0002  EQ	R5	R3	R5
-      0x78160005,  //  0003  JMPF	R5	#000A
-      0x60140006,  //  0004  GETGBL	R5	G6
-      0x5C180000,  //  0005  MOVE	R6	R0
-      0x7C140200,  //  0006  CALL	R5	1
-      0x88180101,  //  0007  GETMBR	R6	R0	K1
-      0x7C140200,  //  0008  CALL	R5	1
-      0x5C0C0A00,  //  0009  MOVE	R3	R5
-      0x88140102,  //  000A  GETMBR	R5	R0	K2
-      0x900E0405,  //  000B  SETMBR	R3	K2	R5
-      0x88140103,  //  000C  GETMBR	R5	R0	K3
-      0x900E0605,  //  000D  SETMBR	R3	K3	R5
-      0x88140104,  //  000E  GETMBR	R5	R0	K4
-      0x78160003,  //  000F  JMPF	R5	#0014
-      0x900E0B06,  //  0010  SETMBR	R3	K5	K6
-      0x88140108,  //  0011  GETMBR	R5	R0	K8
-      0x900E0E05,  //  0012  SETMBR	R3	K7	R5
-      0x70020000,  //  0013  JMP		#0015
-      0x900E0B09,  //  0014  SETMBR	R3	K5	K9
-      0x8814010A,  //  0015  GETMBR	R5	R0	K10
-      0x900E1405,  //  0016  SETMBR	R3	K10	R5
-      0x8814010B,  //  0017  GETMBR	R5	R0	K11
-      0x20140B09,  //  0018  NE	R5	R5	K9
-      0x7816000D,  //  0019  JMPF	R5	#0028
-      0x8814010A,  //  001A  GETMBR	R5	R0	K10
-      0x7816000B,  //  001B  JMPF	R5	#0028
-      0x8814010A,  //  001C  GETMBR	R5	R0	K10
-      0x88140B0C,  //  001D  GETMBR	R5	R5	K12
-      0x20140B09,  //  001E  NE	R5	R5	K9
-      0x78160007,  //  001F  JMPF	R5	#0028
-      0x8814010A,  //  0020  GETMBR	R5	R0	K10
-      0x8C140B0E,  //  0021  GETMET	R5	R5	K14
-      0x7C140200,  //  0022  CALL	R5	1
-      0x900E1A05,  //  0023  SETMBR	R3	K13	R5
-      0x8814010A,  //  0024  GETMBR	R5	R0	K10
-      0x88140B0C,  //  0025  GETMBR	R5	R5	K12
-      0x900E1605,  //  0026  SETMBR	R3	K11	R5
-      0x70020005,  //  0027  JMP		#002E
-      0x8814010A,  //  0028  GETMBR	R5	R0	K10
-      0x88140B0F,  //  0029  GETMBR	R5	R5	K15
-      0x8C140B10,  //  002A  GETMET	R5	R5	K16
-      0x7C140200,  //  002B  CALL	R5	1
-      0x900E1A05,  //  002C  SETMBR	R3	K13	R5
-      0x900E1709,  //  002D  SETMBR	R3	K11	K9
-      0x88140111,  //  002E  GETMBR	R5	R0	K17
-      0x78160001,  //  002F  JMPF	R5	#0032
-      0x58140009,  //  0030  LDCONST	R5	K9
-      0x70020000,  //  0031  JMP		#0033
-      0x58140006,  //  0032  LDCONST	R5	K6
-      0x900E2205,  //  0033  SETMBR	R3	K17	R5
-      0x900E2401,  //  0034  SETMBR	R3	K18	R1
-      0x88140113,  //  0035  GETMBR	R5	R0	K19
-      0x900E2605,  //  0036  SETMBR	R3	K19	R5
-      0x88140114,  //  0037  GETMBR	R5	R0	K20
-      0x900E2805,  //  0038  SETMBR	R3	K20	R5
-      0x88140115,  //  0039  GETMBR	R5	R0	K21
-      0x78160002,  //  003A  JMPF	R5	#003E
-      0x900E2D06,  //  003B  SETMBR	R3	K22	K6
-      0x8814010D,  //  003C  GETMBR	R5	R0	K13
-      0x900E2E05,  //  003D  SETMBR	R3	K23	R5
-      0x780A0001,  //  003E  JMPF	R2	#0041
-      0x58140006,  //  003F  LDCONST	R5	K6
-      0x70020000,  //  0040  JMP		#0042
-      0x58140009,  //  0041  LDCONST	R5	K9
-      0x900E2A05,  //  0042  SETMBR	R3	K21	R5
-      0x8814070B,  //  0043  GETMBR	R5	R3	K11
-      0x1C140B09,  //  0044  EQ	R5	R5	K9
-      0x78160014,  //  0045  JMPF	R5	#005B
-      0xB8163000,  //  0046  GETNGBL	R5	K24
-      0x8C140B19,  //  0047  GETMET	R5	R5	K25
-      0x881C0712,  //  0048  GETMBR	R7	R3	K18
-      0x7C140400,  //  0049  CALL	R5	2
-      0x5C180A00,  //  004A  MOVE	R6	R5
-      0x741A0004,  //  004B  JMPT	R6	#0051
-      0x8C18091A,  //  004C  GETMET	R6	R4	K26
-      0x5820001B,  //  004D  LDCONST	R8	K27
-      0x88240712,  //  004E  GETMBR	R9	R3	K18
-      0x7C180600,  //  004F  CALL	R6	3
-      0x5C140C00,  //  0050  MOVE	R5	R6
-      0xB81A3800,  //  0051  GETNGBL	R6	K28
-      0x8C180D1D,  //  0052  GETMET	R6	R6	K29
-      0x8C20091A,  //  0053  GETMET	R8	R4	K26
-      0x5828001E,  //  0054  LDCONST	R10	K30
-      0x882C070A,  //  0055  GETMBR	R11	R3	K10
-      0x882C170B,  //  0056  GETMBR	R11	R11	K11
-      0x5C300A00,  //  0057  MOVE	R12	R5
-      0x7C200800,  //  0058  CALL	R8	4
-      0x5824001F,  //  0059  LDCONST	R9	K31
-      0x7C180600,  //  005A  CALL	R6	3
-      0x80040600,  //  005B  RET	1	R3
+    ( &(const binstruction[91]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x1C100604,  //  0001  EQ	R4	R3	R4
+      0x78120005,  //  0002  JMPF	R4	#0009
+      0x60100006,  //  0003  GETGBL	R4	G6
+      0x5C140000,  //  0004  MOVE	R5	R0
+      0x7C100200,  //  0005  CALL	R4	1
+      0x88140100,  //  0006  GETMBR	R5	R0	K0
+      0x7C100200,  //  0007  CALL	R4	1
+      0x5C0C0800,  //  0008  MOVE	R3	R4
+      0x88100101,  //  0009  GETMBR	R4	R0	K1
+      0x900E0204,  //  000A  SETMBR	R3	K1	R4
+      0x88100102,  //  000B  GETMBR	R4	R0	K2
+      0x900E0404,  //  000C  SETMBR	R3	K2	R4
+      0x88100103,  //  000D  GETMBR	R4	R0	K3
+      0x78120003,  //  000E  JMPF	R4	#0013
+      0x900E0905,  //  000F  SETMBR	R3	K4	K5
+      0x88100107,  //  0010  GETMBR	R4	R0	K7
+      0x900E0C04,  //  0011  SETMBR	R3	K6	R4
+      0x70020000,  //  0012  JMP		#0014
+      0x900E0908,  //  0013  SETMBR	R3	K4	K8
+      0x88100109,  //  0014  GETMBR	R4	R0	K9
+      0x900E1204,  //  0015  SETMBR	R3	K9	R4
+      0x8810010A,  //  0016  GETMBR	R4	R0	K10
+      0x20100908,  //  0017  NE	R4	R4	K8
+      0x7812000D,  //  0018  JMPF	R4	#0027
+      0x88100109,  //  0019  GETMBR	R4	R0	K9
+      0x7812000B,  //  001A  JMPF	R4	#0027
+      0x88100109,  //  001B  GETMBR	R4	R0	K9
+      0x8810090B,  //  001C  GETMBR	R4	R4	K11
+      0x20100908,  //  001D  NE	R4	R4	K8
+      0x78120007,  //  001E  JMPF	R4	#0027
+      0x88100109,  //  001F  GETMBR	R4	R0	K9
+      0x8C10090D,  //  0020  GETMET	R4	R4	K13
+      0x7C100200,  //  0021  CALL	R4	1
+      0x900E1804,  //  0022  SETMBR	R3	K12	R4
+      0x88100109,  //  0023  GETMBR	R4	R0	K9
+      0x8810090B,  //  0024  GETMBR	R4	R4	K11
+      0x900E1404,  //  0025  SETMBR	R3	K10	R4
+      0x70020005,  //  0026  JMP		#002D
+      0x88100109,  //  0027  GETMBR	R4	R0	K9
+      0x8810090E,  //  0028  GETMBR	R4	R4	K14
+      0x8C10090F,  //  0029  GETMET	R4	R4	K15
+      0x7C100200,  //  002A  CALL	R4	1
+      0x900E1804,  //  002B  SETMBR	R3	K12	R4
+      0x900E1508,  //  002C  SETMBR	R3	K10	K8
+      0x88100110,  //  002D  GETMBR	R4	R0	K16
+      0x78120001,  //  002E  JMPF	R4	#0031
+      0x58100008,  //  002F  LDCONST	R4	K8
+      0x70020000,  //  0030  JMP		#0032
+      0x58100005,  //  0031  LDCONST	R4	K5
+      0x900E2004,  //  0032  SETMBR	R3	K16	R4
+      0x900E2201,  //  0033  SETMBR	R3	K17	R1
+      0x88100112,  //  0034  GETMBR	R4	R0	K18
+      0x900E2404,  //  0035  SETMBR	R3	K18	R4
+      0x88100113,  //  0036  GETMBR	R4	R0	K19
+      0x900E2604,  //  0037  SETMBR	R3	K19	R4
+      0x88100114,  //  0038  GETMBR	R4	R0	K20
+      0x78120002,  //  0039  JMPF	R4	#003D
+      0x900E2B05,  //  003A  SETMBR	R3	K21	K5
+      0x8810010C,  //  003B  GETMBR	R4	R0	K12
+      0x900E2C04,  //  003C  SETMBR	R3	K22	R4
+      0x780A0001,  //  003D  JMPF	R2	#0040
+      0x58100005,  //  003E  LDCONST	R4	K5
+      0x70020000,  //  003F  JMP		#0041
+      0x58100008,  //  0040  LDCONST	R4	K8
+      0x900E2804,  //  0041  SETMBR	R3	K20	R4
+      0x8810070A,  //  0042  GETMBR	R4	R3	K10
+      0x1C100908,  //  0043  EQ	R4	R4	K8
+      0x78120014,  //  0044  JMPF	R4	#005A
+      0xB8122E00,  //  0045  GETNGBL	R4	K23
+      0x8C100918,  //  0046  GETMET	R4	R4	K24
+      0x88180711,  //  0047  GETMBR	R6	R3	K17
+      0x7C100400,  //  0048  CALL	R4	2
+      0x5C140800,  //  0049  MOVE	R5	R4
+      0x74160004,  //  004A  JMPT	R5	#0050
+      0x60140018,  //  004B  GETGBL	R5	G24
+      0x58180019,  //  004C  LDCONST	R6	K25
+      0x881C0711,  //  004D  GETMBR	R7	R3	K17
+      0x7C140400,  //  004E  CALL	R5	2
+      0x5C100A00,  //  004F  MOVE	R4	R5
+      0xB8163400,  //  0050  GETNGBL	R5	K26
+      0x8C140B1B,  //  0051  GETMET	R5	R5	K27
+      0x601C0018,  //  0052  GETGBL	R7	G24
+      0x5820001C,  //  0053  LDCONST	R8	K28
+      0x88240709,  //  0054  GETMBR	R9	R3	K9
+      0x8824130A,  //  0055  GETMBR	R9	R9	K10
+      0x5C280800,  //  0056  MOVE	R10	R4
+      0x7C1C0600,  //  0057  CALL	R7	3
+      0x5820001D,  //  0058  LDCONST	R8	K29
+      0x7C140600,  //  0059  CALL	R5	3
+      0x80040600,  //  005A  RET	1	R3
     })
   )
 );
@@ -588,7 +583,7 @@ be_local_closure(Matter_Frame_build_response,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Frame_initiate_response,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     5,                          /* argc */
     4,                          /* varg */
     0,                          /* has upvals */
@@ -596,82 +591,80 @@ be_local_closure(Matter_Frame_initiate_response,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
+    ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_Frame),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Frame),
-    /* K4   */  be_nested_str_weak(remote_ip),
-    /* K5   */  be_nested_str_weak(_ip),
-    /* K6   */  be_nested_str_weak(remote_port),
-    /* K7   */  be_nested_str_weak(_port),
-    /* K8   */  be_nested_str_weak(flag_dsiz),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(session),
-    /* K11  */  be_nested_str_weak(initiator_session_id),
-    /* K12  */  be_nested_str_weak(message_counter),
-    /* K13  */  be_nested_str_weak(counter_snd_next),
-    /* K14  */  be_nested_str_weak(local_session_id),
-    /* K15  */  be_nested_str_weak(_counter_insecure_snd),
-    /* K16  */  be_nested_str_weak(next),
-    /* K17  */  be_nested_str_weak(x_flag_i),
-    /* K18  */  be_const_int(1),
-    /* K19  */  be_nested_str_weak(opcode),
-    /* K20  */  be_nested_str_weak(_exchange_id),
-    /* K21  */  be_nested_str_weak(exchange_id),
-    /* K22  */  be_nested_str_weak(protocol_id),
-    /* K23  */  be_nested_str_weak(x_flag_r),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(Frame),
+    /* K3   */  be_nested_str_weak(remote_ip),
+    /* K4   */  be_nested_str_weak(_ip),
+    /* K5   */  be_nested_str_weak(remote_port),
+    /* K6   */  be_nested_str_weak(_port),
+    /* K7   */  be_nested_str_weak(flag_dsiz),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(session),
+    /* K10  */  be_nested_str_weak(initiator_session_id),
+    /* K11  */  be_nested_str_weak(message_counter),
+    /* K12  */  be_nested_str_weak(counter_snd_next),
+    /* K13  */  be_nested_str_weak(local_session_id),
+    /* K14  */  be_nested_str_weak(_counter_insecure_snd),
+    /* K15  */  be_nested_str_weak(next),
+    /* K16  */  be_nested_str_weak(x_flag_i),
+    /* K17  */  be_const_int(1),
+    /* K18  */  be_nested_str_weak(opcode),
+    /* K19  */  be_nested_str_weak(_exchange_id),
+    /* K20  */  be_nested_str_weak(exchange_id),
+    /* K21  */  be_nested_str_weak(protocol_id),
+    /* K22  */  be_nested_str_weak(x_flag_r),
     }),
     be_str_weak(initiate_response),
     &be_const_str_solidified,
-    ( &(const binstruction[47]) {  /* code */
+    ( &(const binstruction[46]) {  /* code */
       0x58140000,  //  0000  LDCONST	R5	K0
-      0xA41A0200,  //  0001  IMPORT	R6	K1
-      0x4C1C0000,  //  0002  LDNIL	R7
-      0x1C1C0807,  //  0003  EQ	R7	R4	R7
-      0x781E0004,  //  0004  JMPF	R7	#000A
-      0xB81E0400,  //  0005  GETNGBL	R7	K2
-      0x8C1C0F03,  //  0006  GETMET	R7	R7	K3
-      0x5C240000,  //  0007  MOVE	R9	R0
-      0x7C1C0400,  //  0008  CALL	R7	2
-      0x5C100E00,  //  0009  MOVE	R4	R7
-      0x881C0305,  //  000A  GETMBR	R7	R1	K5
-      0x90120807,  //  000B  SETMBR	R4	K4	R7
-      0x881C0307,  //  000C  GETMBR	R7	R1	K7
-      0x90120C07,  //  000D  SETMBR	R4	K6	R7
-      0x90121109,  //  000E  SETMBR	R4	K8	K9
-      0x90121401,  //  000F  SETMBR	R4	K10	R1
-      0x78060008,  //  0010  JMPF	R1	#001A
-      0x881C030B,  //  0011  GETMBR	R7	R1	K11
-      0x201C0F09,  //  0012  NE	R7	R7	K9
-      0x781E0005,  //  0013  JMPF	R7	#001A
-      0x8C1C030D,  //  0014  GETMET	R7	R1	K13
-      0x7C1C0200,  //  0015  CALL	R7	1
-      0x90121807,  //  0016  SETMBR	R4	K12	R7
-      0x881C030B,  //  0017  GETMBR	R7	R1	K11
-      0x90121C07,  //  0018  SETMBR	R4	K14	R7
-      0x70020004,  //  0019  JMP		#001F
-      0x881C030F,  //  001A  GETMBR	R7	R1	K15
-      0x8C1C0F10,  //  001B  GETMET	R7	R7	K16
-      0x7C1C0200,  //  001C  CALL	R7	1
-      0x90121807,  //  001D  SETMBR	R4	K12	R7
-      0x90121D09,  //  001E  SETMBR	R4	K14	K9
-      0x90122312,  //  001F  SETMBR	R4	K17	K18
-      0x90122602,  //  0020  SETMBR	R4	K19	R2
-      0x881C0314,  //  0021  GETMBR	R7	R1	K20
-      0x001C0F12,  //  0022  ADD	R7	R7	K18
-      0x90062807,  //  0023  SETMBR	R1	K20	R7
-      0x881C0314,  //  0024  GETMBR	R7	R1	K20
-      0x5422FFFF,  //  0025  LDINT	R8	65536
-      0x301C0E08,  //  0026  OR	R7	R7	R8
-      0x90122A07,  //  0027  SETMBR	R4	K21	R7
-      0x90122D12,  //  0028  SETMBR	R4	K22	K18
-      0x780E0001,  //  0029  JMPF	R3	#002C
-      0x581C0012,  //  002A  LDCONST	R7	K18
-      0x70020000,  //  002B  JMP		#002D
-      0x581C0009,  //  002C  LDCONST	R7	K9
-      0x90122E07,  //  002D  SETMBR	R4	K23	R7
-      0x80040800,  //  002E  RET	1	R4
+      0x4C180000,  //  0001  LDNIL	R6
+      0x1C180806,  //  0002  EQ	R6	R4	R6
+      0x781A0004,  //  0003  JMPF	R6	#0009
+      0xB81A0200,  //  0004  GETNGBL	R6	K1
+      0x8C180D02,  //  0005  GETMET	R6	R6	K2
+      0x5C200000,  //  0006  MOVE	R8	R0
+      0x7C180400,  //  0007  CALL	R6	2
+      0x5C100C00,  //  0008  MOVE	R4	R6
+      0x88180304,  //  0009  GETMBR	R6	R1	K4
+      0x90120606,  //  000A  SETMBR	R4	K3	R6
+      0x88180306,  //  000B  GETMBR	R6	R1	K6
+      0x90120A06,  //  000C  SETMBR	R4	K5	R6
+      0x90120F08,  //  000D  SETMBR	R4	K7	K8
+      0x90121201,  //  000E  SETMBR	R4	K9	R1
+      0x78060008,  //  000F  JMPF	R1	#0019
+      0x8818030A,  //  0010  GETMBR	R6	R1	K10
+      0x20180D08,  //  0011  NE	R6	R6	K8
+      0x781A0005,  //  0012  JMPF	R6	#0019
+      0x8C18030C,  //  0013  GETMET	R6	R1	K12
+      0x7C180200,  //  0014  CALL	R6	1
+      0x90121606,  //  0015  SETMBR	R4	K11	R6
+      0x8818030A,  //  0016  GETMBR	R6	R1	K10
+      0x90121A06,  //  0017  SETMBR	R4	K13	R6
+      0x70020004,  //  0018  JMP		#001E
+      0x8818030E,  //  0019  GETMBR	R6	R1	K14
+      0x8C180D0F,  //  001A  GETMET	R6	R6	K15
+      0x7C180200,  //  001B  CALL	R6	1
+      0x90121606,  //  001C  SETMBR	R4	K11	R6
+      0x90121B08,  //  001D  SETMBR	R4	K13	K8
+      0x90122111,  //  001E  SETMBR	R4	K16	K17
+      0x90122402,  //  001F  SETMBR	R4	K18	R2
+      0x88180313,  //  0020  GETMBR	R6	R1	K19
+      0x00180D11,  //  0021  ADD	R6	R6	K17
+      0x90062606,  //  0022  SETMBR	R1	K19	R6
+      0x88180313,  //  0023  GETMBR	R6	R1	K19
+      0x541EFFFF,  //  0024  LDINT	R7	65536
+      0x30180C07,  //  0025  OR	R6	R6	R7
+      0x90122806,  //  0026  SETMBR	R4	K20	R6
+      0x90122B11,  //  0027  SETMBR	R4	K21	K17
+      0x780E0001,  //  0028  JMPF	R3	#002B
+      0x58180011,  //  0029  LDCONST	R6	K17
+      0x70020000,  //  002A  JMP		#002C
+      0x58180008,  //  002B  LDCONST	R6	K8
+      0x90122C06,  //  002C  SETMBR	R4	K22	R6
+      0x80040800,  //  002D  RET	1	R4
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
@@ -42,7 +42,7 @@ be_local_closure(Matter_MessageHandler_send_response_frame,   /* name */
 ********************************************************************/
 be_local_closure(Matter_MessageHandler_send_encrypted_ack,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    12,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -50,56 +50,53 @@ be_local_closure(Matter_MessageHandler_send_encrypted_ack,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(x_flag_r),
-    /* K2   */  be_nested_str_weak(build_standalone_ack),
-    /* K3   */  be_nested_str_weak(encode_frame),
-    /* K4   */  be_nested_str_weak(encrypt),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(format),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X2A_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i_X20_X25s),
-    /* K9   */  be_nested_str_weak(session),
-    /* K10  */  be_nested_str_weak(local_session_id),
-    /* K11  */  be_nested_str_weak(ack_message_counter),
-    /* K12  */  be_nested_str_weak(message_counter),
-    /* K13  */  be_nested_str_weak(_X7Breliable_X7D),
-    /* K14  */  be_nested_str_weak(),
-    /* K15  */  be_nested_str_weak(send_response_frame),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(x_flag_r),
+    /* K1   */  be_nested_str_weak(build_standalone_ack),
+    /* K2   */  be_nested_str_weak(encode_frame),
+    /* K3   */  be_nested_str_weak(encrypt),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X2A_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i_X20_X25s),
+    /* K7   */  be_nested_str_weak(session),
+    /* K8   */  be_nested_str_weak(local_session_id),
+    /* K9   */  be_nested_str_weak(ack_message_counter),
+    /* K10  */  be_nested_str_weak(message_counter),
+    /* K11  */  be_nested_str_weak(_X7Breliable_X7D),
+    /* K12  */  be_nested_str_weak(),
+    /* K13  */  be_nested_str_weak(send_response_frame),
     }),
     be_str_weak(send_encrypted_ack),
     &be_const_str_solidified,
-    ( &(const binstruction[29]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x88100301,  //  0001  GETMBR	R4	R1	K1
-      0x78120018,  //  0002  JMPF	R4	#001C
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x5C180400,  //  0004  MOVE	R6	R2
-      0x7C100400,  //  0005  CALL	R4	2
-      0x8C140903,  //  0006  GETMET	R5	R4	K3
-      0x7C140200,  //  0007  CALL	R5	1
-      0x8C140904,  //  0008  GETMET	R5	R4	K4
-      0x7C140200,  //  0009  CALL	R5	1
-      0xB8160A00,  //  000A  GETNGBL	R5	K5
-      0x8C140B06,  //  000B  GETMET	R5	R5	K6
-      0x8C1C0707,  //  000C  GETMET	R7	R3	K7
-      0x58240008,  //  000D  LDCONST	R9	K8
-      0x88280909,  //  000E  GETMBR	R10	R4	K9
-      0x8828150A,  //  000F  GETMBR	R10	R10	K10
-      0x882C090B,  //  0010  GETMBR	R11	R4	K11
-      0x8830090C,  //  0011  GETMBR	R12	R4	K12
-      0x780A0001,  //  0012  JMPF	R2	#0015
-      0x5834000D,  //  0013  LDCONST	R13	K13
-      0x70020000,  //  0014  JMP		#0016
-      0x5834000E,  //  0015  LDCONST	R13	K14
-      0x7C1C0C00,  //  0016  CALL	R7	6
-      0x54220003,  //  0017  LDINT	R8	4
-      0x7C140600,  //  0018  CALL	R5	3
-      0x8C14010F,  //  0019  GETMET	R5	R0	K15
-      0x5C1C0800,  //  001A  MOVE	R7	R4
-      0x7C140400,  //  001B  CALL	R5	2
-      0x80000000,  //  001C  RET	0
+    ( &(const binstruction[28]) {  /* code */
+      0x880C0300,  //  0000  GETMBR	R3	R1	K0
+      0x780E0018,  //  0001  JMPF	R3	#001B
+      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
+      0x5C140400,  //  0003  MOVE	R5	R2
+      0x7C0C0400,  //  0004  CALL	R3	2
+      0x8C100702,  //  0005  GETMET	R4	R3	K2
+      0x7C100200,  //  0006  CALL	R4	1
+      0x8C100703,  //  0007  GETMET	R4	R3	K3
+      0x7C100200,  //  0008  CALL	R4	1
+      0xB8120800,  //  0009  GETNGBL	R4	K4
+      0x8C100905,  //  000A  GETMET	R4	R4	K5
+      0x60180018,  //  000B  GETGBL	R6	G24
+      0x581C0006,  //  000C  LDCONST	R7	K6
+      0x88200707,  //  000D  GETMBR	R8	R3	K7
+      0x88201108,  //  000E  GETMBR	R8	R8	K8
+      0x88240709,  //  000F  GETMBR	R9	R3	K9
+      0x8828070A,  //  0010  GETMBR	R10	R3	K10
+      0x780A0001,  //  0011  JMPF	R2	#0014
+      0x582C000B,  //  0012  LDCONST	R11	K11
+      0x70020000,  //  0013  JMP		#0015
+      0x582C000C,  //  0014  LDCONST	R11	K12
+      0x7C180A00,  //  0015  CALL	R6	5
+      0x541E0003,  //  0016  LDINT	R7	4
+      0x7C100600,  //  0017  CALL	R4	3
+      0x8C10010D,  //  0018  GETMET	R4	R0	K13
+      0x5C180600,  //  0019  MOVE	R6	R3
+      0x7C100400,  //  001A  CALL	R4	2
+      0x80000000,  //  001B  RET	0
     })
   )
 );
@@ -145,7 +142,7 @@ be_local_closure(Matter_MessageHandler_every_second,   /* name */
 ********************************************************************/
 be_local_closure(Matter_MessageHandler_send_simple_ack,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    12,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -153,53 +150,50 @@ be_local_closure(Matter_MessageHandler_send_simple_ack,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(x_flag_r),
-    /* K2   */  be_nested_str_weak(build_standalone_ack),
-    /* K3   */  be_nested_str_weak(encode_frame),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(format),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i_X20_X25s),
-    /* K8   */  be_nested_str_weak(session),
-    /* K9   */  be_nested_str_weak(local_session_id),
-    /* K10  */  be_nested_str_weak(ack_message_counter),
-    /* K11  */  be_nested_str_weak(message_counter),
-    /* K12  */  be_nested_str_weak(_X7Breliable_X7D),
-    /* K13  */  be_nested_str_weak(),
-    /* K14  */  be_nested_str_weak(send_response_frame),
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(x_flag_r),
+    /* K1   */  be_nested_str_weak(build_standalone_ack),
+    /* K2   */  be_nested_str_weak(encode_frame),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i_X20_X25s),
+    /* K6   */  be_nested_str_weak(session),
+    /* K7   */  be_nested_str_weak(local_session_id),
+    /* K8   */  be_nested_str_weak(ack_message_counter),
+    /* K9   */  be_nested_str_weak(message_counter),
+    /* K10  */  be_nested_str_weak(_X7Breliable_X7D),
+    /* K11  */  be_nested_str_weak(),
+    /* K12  */  be_nested_str_weak(send_response_frame),
     }),
     be_str_weak(send_simple_ack),
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x88100301,  //  0001  GETMBR	R4	R1	K1
-      0x78120016,  //  0002  JMPF	R4	#001A
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x5C180400,  //  0004  MOVE	R6	R2
-      0x7C100400,  //  0005  CALL	R4	2
-      0x8C140903,  //  0006  GETMET	R5	R4	K3
-      0x7C140200,  //  0007  CALL	R5	1
-      0xB8160800,  //  0008  GETNGBL	R5	K4
-      0x8C140B05,  //  0009  GETMET	R5	R5	K5
-      0x8C1C0706,  //  000A  GETMET	R7	R3	K6
-      0x58240007,  //  000B  LDCONST	R9	K7
-      0x88280908,  //  000C  GETMBR	R10	R4	K8
-      0x88281509,  //  000D  GETMBR	R10	R10	K9
-      0x882C090A,  //  000E  GETMBR	R11	R4	K10
-      0x8830090B,  //  000F  GETMBR	R12	R4	K11
-      0x780A0001,  //  0010  JMPF	R2	#0013
-      0x5834000C,  //  0011  LDCONST	R13	K12
-      0x70020000,  //  0012  JMP		#0014
-      0x5834000D,  //  0013  LDCONST	R13	K13
-      0x7C1C0C00,  //  0014  CALL	R7	6
-      0x54220003,  //  0015  LDINT	R8	4
-      0x7C140600,  //  0016  CALL	R5	3
-      0x8C14010E,  //  0017  GETMET	R5	R0	K14
-      0x5C1C0800,  //  0018  MOVE	R7	R4
-      0x7C140400,  //  0019  CALL	R5	2
-      0x80000000,  //  001A  RET	0
+    ( &(const binstruction[26]) {  /* code */
+      0x880C0300,  //  0000  GETMBR	R3	R1	K0
+      0x780E0016,  //  0001  JMPF	R3	#0019
+      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
+      0x5C140400,  //  0003  MOVE	R5	R2
+      0x7C0C0400,  //  0004  CALL	R3	2
+      0x8C100702,  //  0005  GETMET	R4	R3	K2
+      0x7C100200,  //  0006  CALL	R4	1
+      0xB8120600,  //  0007  GETNGBL	R4	K3
+      0x8C100904,  //  0008  GETMET	R4	R4	K4
+      0x60180018,  //  0009  GETGBL	R6	G24
+      0x581C0005,  //  000A  LDCONST	R7	K5
+      0x88200706,  //  000B  GETMBR	R8	R3	K6
+      0x88201107,  //  000C  GETMBR	R8	R8	K7
+      0x88240708,  //  000D  GETMBR	R9	R3	K8
+      0x88280709,  //  000E  GETMBR	R10	R3	K9
+      0x780A0001,  //  000F  JMPF	R2	#0012
+      0x582C000A,  //  0010  LDCONST	R11	K10
+      0x70020000,  //  0011  JMP		#0013
+      0x582C000B,  //  0012  LDCONST	R11	K11
+      0x7C180A00,  //  0013  CALL	R6	5
+      0x541E0003,  //  0014  LDINT	R7	4
+      0x7C100600,  //  0015  CALL	R4	3
+      0x8C10010C,  //  0016  GETMET	R4	R0	K12
+      0x5C180600,  //  0017  MOVE	R6	R3
+      0x7C100400,  //  0018  CALL	R4	2
+      0x80000000,  //  0019  RET	0
     })
   )
 );
@@ -211,7 +205,7 @@ be_local_closure(Matter_MessageHandler_send_simple_ack,   /* name */
 ********************************************************************/
 be_local_closure(Matter_MessageHandler_msg_received,   /* name */
   be_nested_proto(
-    21,                          /* nstack */
+    19,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -219,403 +213,400 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[68]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(Frame),
-    /* K3   */  be_nested_str_weak(decode_header),
-    /* K4   */  be_nested_str_weak(sec_p),
-    /* K5   */  be_nested_str_weak(device),
-    /* K6   */  be_nested_str_weak(sessions),
-    /* K7   */  be_nested_str_weak(find_session_source_id_unsecure),
-    /* K8   */  be_nested_str_weak(source_node_id),
-    /* K9   */  be_nested_str_weak(control_message),
-    /* K10  */  be_nested_str_weak(process_incoming_control_message),
-    /* K11  */  be_nested_str_weak(local_session_id),
-    /* K12  */  be_const_int(0),
-    /* K13  */  be_nested_str_weak(sec_sesstype),
-    /* K14  */  be_nested_str_weak(_ip),
-    /* K15  */  be_nested_str_weak(_port),
-    /* K16  */  be_nested_str_weak(_message_handler),
-    /* K17  */  be_nested_str_weak(session),
-    /* K18  */  be_nested_str_weak(_counter_insecure_rcv),
-    /* K19  */  be_nested_str_weak(validate),
-    /* K20  */  be_nested_str_weak(message_counter),
-    /* K21  */  be_nested_str_weak(tasmota),
-    /* K22  */  be_nested_str_weak(log),
-    /* K23  */  be_nested_str_weak(format),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Duplicate_X20unencrypted_X20message_X20_X3D_X20_X25i_X20ref_X20_X3D_X20_X25i),
-    /* K25  */  be_nested_str_weak(val),
-    /* K26  */  be_nested_str_weak(send_simple_ack),
-    /* K27  */  be_nested_str_weak(decode_payload),
-    /* K28  */  be_nested_str_weak(received_ack),
-    /* K29  */  be_nested_str_weak(opcode),
-    /* K30  */  be_nested_str_weak(get_opcode_name),
-    /* K31  */  be_nested_str_weak(0x_X2502X),
-    /* K32  */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20_X28_X256i_X29_X20_X25s_X20rid_X3D_X25i_X20exch_X3D_X25i_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K33  */  be_nested_str_weak(exchange_id),
-    /* K34  */  be_const_int(3),
-    /* K35  */  be_nested_str_weak(MTR_X3A_X20_X3Ercv_X20Ack_X20_X20_X20_X28_X256i_X29_X20rid_X3D_X25i_X20exch_X3D_X25i_X20ack_X3D_X25s_X20_X25sfrom_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K36  */  be_nested_str_weak(x_flag_r),
-    /* K37  */  be_nested_str_weak(_X7Breliable_X7D_X20),
-    /* K38  */  be_nested_str_weak(),
-    /* K39  */  be_nested_str_weak(ack_message_counter),
-    /* K40  */  be_nested_str_weak(commissioning),
-    /* K41  */  be_nested_str_weak(process_incoming),
-    /* K42  */  be_nested_str_weak(MTR_X3A_X20decode_X20header_X3A_X20local_session_id_X3D_X25i_X20message_counter_X3D_X25i),
-    /* K43  */  be_nested_str_weak(get_session_by_local_session_id),
-    /* K44  */  be_nested_str_weak(MTR_X3A_X20unknown_X20local_session_id_X3D),
-    /* K45  */  be_nested_str_weak(counter_rcv_validate),
-    /* K46  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Duplicate_X20encrypted_X20message_X20_X3D_X20),
-    /* K47  */  be_nested_str_weak(_X20counter_X3D),
-    /* K48  */  be_nested_str_weak(counter_rcv),
-    /* K49  */  be_nested_str_weak(send_encrypted_ack),
-    /* K50  */  be_nested_str_weak(decrypt),
-    /* K51  */  be_nested_str_weak(raw),
-    /* K52  */  be_nested_str_weak(payload_idx),
-    /* K53  */  be_const_int(1),
-    /* K54  */  be_nested_str_weak(MTR_X3A_X20_X3E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Decrypted_X20message_X3A_X20protocol_id_X3A),
-    /* K55  */  be_nested_str_weak(protocol_id),
-    /* K56  */  be_nested_str_weak(_X20opcode_X3D),
-    /* K57  */  be_nested_str_weak(_X20exchange_id_X3D),
-    /* K58  */  be_nested_str_weak(im),
-    /* K59  */  be_nested_str_weak(process_incoming_ack),
-    /* K60  */  be_nested_str_weak(send_enqueued),
-    /* K61  */  be_nested_str_weak(MTR_X3A_X20ignoring_X20unhandled_X20protocol_id_X3A),
-    /* K62  */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20exception_X3A_X20),
-    /* K63  */  be_nested_str_weak(_X3B),
-    /* K64  */  be_const_int(2),
-    /* K65  */  be_nested_str_weak(_debug_present),
-    /* K66  */  be_nested_str_weak(debug),
-    /* K67  */  be_nested_str_weak(traceback),
+    ( &(const bvalue[66]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Frame),
+    /* K2   */  be_nested_str_weak(decode_header),
+    /* K3   */  be_nested_str_weak(sec_p),
+    /* K4   */  be_nested_str_weak(device),
+    /* K5   */  be_nested_str_weak(sessions),
+    /* K6   */  be_nested_str_weak(find_session_source_id_unsecure),
+    /* K7   */  be_nested_str_weak(source_node_id),
+    /* K8   */  be_nested_str_weak(control_message),
+    /* K9   */  be_nested_str_weak(process_incoming_control_message),
+    /* K10  */  be_nested_str_weak(local_session_id),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_weak(sec_sesstype),
+    /* K13  */  be_nested_str_weak(_ip),
+    /* K14  */  be_nested_str_weak(_port),
+    /* K15  */  be_nested_str_weak(_message_handler),
+    /* K16  */  be_nested_str_weak(session),
+    /* K17  */  be_nested_str_weak(_counter_insecure_rcv),
+    /* K18  */  be_nested_str_weak(validate),
+    /* K19  */  be_nested_str_weak(message_counter),
+    /* K20  */  be_nested_str_weak(tasmota),
+    /* K21  */  be_nested_str_weak(log),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Duplicate_X20unencrypted_X20message_X20_X3D_X20_X25i_X20ref_X20_X3D_X20_X25i),
+    /* K23  */  be_nested_str_weak(val),
+    /* K24  */  be_nested_str_weak(send_simple_ack),
+    /* K25  */  be_nested_str_weak(decode_payload),
+    /* K26  */  be_nested_str_weak(received_ack),
+    /* K27  */  be_nested_str_weak(opcode),
+    /* K28  */  be_nested_str_weak(get_opcode_name),
+    /* K29  */  be_nested_str_weak(0x_X2502X),
+    /* K30  */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20_X28_X256i_X29_X20_X25s_X20rid_X3D_X25i_X20exch_X3D_X25i_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K31  */  be_nested_str_weak(exchange_id),
+    /* K32  */  be_const_int(3),
+    /* K33  */  be_nested_str_weak(MTR_X3A_X20_X3Ercv_X20Ack_X20_X20_X20_X28_X256i_X29_X20rid_X3D_X25i_X20exch_X3D_X25i_X20ack_X3D_X25s_X20_X25sfrom_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K34  */  be_nested_str_weak(x_flag_r),
+    /* K35  */  be_nested_str_weak(_X7Breliable_X7D_X20),
+    /* K36  */  be_nested_str_weak(),
+    /* K37  */  be_nested_str_weak(ack_message_counter),
+    /* K38  */  be_nested_str_weak(commissioning),
+    /* K39  */  be_nested_str_weak(process_incoming),
+    /* K40  */  be_nested_str_weak(MTR_X3A_X20decode_X20header_X3A_X20local_session_id_X3D_X25i_X20message_counter_X3D_X25i),
+    /* K41  */  be_nested_str_weak(get_session_by_local_session_id),
+    /* K42  */  be_nested_str_weak(MTR_X3A_X20unknown_X20local_session_id_X3D),
+    /* K43  */  be_nested_str_weak(counter_rcv_validate),
+    /* K44  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Duplicate_X20encrypted_X20message_X20_X3D_X20),
+    /* K45  */  be_nested_str_weak(_X20counter_X3D),
+    /* K46  */  be_nested_str_weak(counter_rcv),
+    /* K47  */  be_nested_str_weak(send_encrypted_ack),
+    /* K48  */  be_nested_str_weak(decrypt),
+    /* K49  */  be_nested_str_weak(raw),
+    /* K50  */  be_nested_str_weak(payload_idx),
+    /* K51  */  be_const_int(1),
+    /* K52  */  be_nested_str_weak(MTR_X3A_X20_X3E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Decrypted_X20message_X3A_X20protocol_id_X3A),
+    /* K53  */  be_nested_str_weak(protocol_id),
+    /* K54  */  be_nested_str_weak(_X20opcode_X3D),
+    /* K55  */  be_nested_str_weak(_X20exchange_id_X3D),
+    /* K56  */  be_nested_str_weak(im),
+    /* K57  */  be_nested_str_weak(process_incoming_ack),
+    /* K58  */  be_nested_str_weak(send_enqueued),
+    /* K59  */  be_nested_str_weak(MTR_X3A_X20ignoring_X20unhandled_X20protocol_id_X3A),
+    /* K60  */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20exception_X3A_X20),
+    /* K61  */  be_nested_str_weak(_X3B),
+    /* K62  */  be_const_int(2),
+    /* K63  */  be_nested_str_weak(_debug_present),
+    /* K64  */  be_nested_str_weak(debug),
+    /* K65  */  be_nested_str_weak(traceback),
     }),
     be_str_weak(msg_received),
     &be_const_str_solidified,
-    ( &(const binstruction[324]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0x50140000,  //  0001  LDBOOL	R5	0	0
-      0xA8020126,  //  0002  EXBLK	0	#012A
-      0xB81A0200,  //  0003  GETNGBL	R6	K1
-      0x8C180D02,  //  0004  GETMET	R6	R6	K2
-      0x5C200000,  //  0005  MOVE	R8	R0
-      0x5C240200,  //  0006  MOVE	R9	R1
-      0x5C280400,  //  0007  MOVE	R10	R2
-      0x5C2C0600,  //  0008  MOVE	R11	R3
-      0x7C180A00,  //  0009  CALL	R6	5
-      0x8C1C0D03,  //  000A  GETMET	R7	R6	K3
-      0x7C1C0200,  //  000B  CALL	R7	1
-      0x5C200E00,  //  000C  MOVE	R8	R7
-      0x74220002,  //  000D  JMPT	R8	#0011
-      0x50200000,  //  000E  LDBOOL	R8	0	0
-      0xA8040001,  //  000F  EXBLK	1	1
-      0x80041000,  //  0010  RET	1	R8
-      0x88200D04,  //  0011  GETMBR	R8	R6	K4
-      0x7822000C,  //  0012  JMPF	R8	#0020
-      0x88200105,  //  0013  GETMBR	R8	R0	K5
-      0x88201106,  //  0014  GETMBR	R8	R8	K6
-      0x8C201107,  //  0015  GETMET	R8	R8	K7
-      0x88280D08,  //  0016  GETMBR	R10	R6	K8
-      0x542E0059,  //  0017  LDINT	R11	90
-      0x7C200600,  //  0018  CALL	R8	3
-      0x88240109,  //  0019  GETMBR	R9	R0	K9
-      0x8C24130A,  //  001A  GETMET	R9	R9	K10
-      0x5C2C0C00,  //  001B  MOVE	R11	R6
-      0x7C240400,  //  001C  CALL	R9	2
-      0xA8040001,  //  001D  EXBLK	1	1
-      0x80041200,  //  001E  RET	1	R9
-      0x70020105,  //  001F  JMP		#0126
-      0x88200D0B,  //  0020  GETMBR	R8	R6	K11
-      0x1C20110C,  //  0021  EQ	R8	R8	K12
-      0x78220070,  //  0022  JMPF	R8	#0094
-      0x88200D0D,  //  0023  GETMBR	R8	R6	K13
-      0x1C20110C,  //  0024  EQ	R8	R8	K12
-      0x7822006D,  //  0025  JMPF	R8	#0094
-      0x88200105,  //  0026  GETMBR	R8	R0	K5
-      0x88201106,  //  0027  GETMBR	R8	R8	K6
-      0x8C201107,  //  0028  GETMET	R8	R8	K7
-      0x88280D08,  //  0029  GETMBR	R10	R6	K8
-      0x542E0059,  //  002A  LDINT	R11	90
-      0x7C200600,  //  002B  CALL	R8	3
-      0x780A0000,  //  002C  JMPF	R2	#002E
-      0x90221C02,  //  002D  SETMBR	R8	K14	R2
-      0x780E0000,  //  002E  JMPF	R3	#0030
-      0x90221E03,  //  002F  SETMBR	R8	K15	R3
-      0x90222000,  //  0030  SETMBR	R8	K16	R0
-      0x901A2208,  //  0031  SETMBR	R6	K17	R8
-      0x88241112,  //  0032  GETMBR	R9	R8	K18
-      0x8C241313,  //  0033  GETMET	R9	R9	K19
-      0x882C0D14,  //  0034  GETMBR	R11	R6	K20
-      0x50300000,  //  0035  LDBOOL	R12	0	0
-      0x7C240600,  //  0036  CALL	R9	3
-      0x74260011,  //  0037  JMPT	R9	#004A
-      0xB8262A00,  //  0038  GETNGBL	R9	K21
-      0x8C241316,  //  0039  GETMET	R9	R9	K22
-      0x8C2C0917,  //  003A  GETMET	R11	R4	K23
-      0x58340018,  //  003B  LDCONST	R13	K24
-      0x88380D14,  //  003C  GETMBR	R14	R6	K20
-      0x883C1112,  //  003D  GETMBR	R15	R8	K18
-      0x8C3C1F19,  //  003E  GETMET	R15	R15	K25
-      0x7C3C0200,  //  003F  CALL	R15	1
-      0x7C2C0800,  //  0040  CALL	R11	4
-      0x54320003,  //  0041  LDINT	R12	4
-      0x7C240600,  //  0042  CALL	R9	3
-      0x8C24011A,  //  0043  GETMET	R9	R0	K26
-      0x5C2C0C00,  //  0044  MOVE	R11	R6
-      0x50300000,  //  0045  LDBOOL	R12	0	0
-      0x7C240600,  //  0046  CALL	R9	3
-      0x50240000,  //  0047  LDBOOL	R9	0	0
-      0xA8040001,  //  0048  EXBLK	1	1
-      0x80041200,  //  0049  RET	1	R9
-      0x8C240D1B,  //  004A  GETMET	R9	R6	K27
-      0x7C240200,  //  004B  CALL	R9	1
-      0x74260002,  //  004C  JMPT	R9	#0050
-      0x50240000,  //  004D  LDBOOL	R9	0	0
-      0xA8040001,  //  004E  EXBLK	1	1
-      0x80041200,  //  004F  RET	1	R9
-      0x88240105,  //  0050  GETMBR	R9	R0	K5
-      0x8C24131C,  //  0051  GETMET	R9	R9	K28
-      0x5C2C0C00,  //  0052  MOVE	R11	R6
-      0x7C240400,  //  0053  CALL	R9	2
-      0x88240D1D,  //  0054  GETMBR	R9	R6	K29
-      0x542A000F,  //  0055  LDINT	R10	16
-      0x2024120A,  //  0056  NE	R9	R9	R10
-      0x78260018,  //  0057  JMPF	R9	#0071
-      0xB8260200,  //  0058  GETNGBL	R9	K1
-      0x8C24131E,  //  0059  GETMET	R9	R9	K30
-      0x882C0D1D,  //  005A  GETMBR	R11	R6	K29
-      0x7C240400,  //  005B  CALL	R9	2
-      0x5C281200,  //  005C  MOVE	R10	R9
-      0x742A0004,  //  005D  JMPT	R10	#0063
-      0x8C280917,  //  005E  GETMET	R10	R4	K23
-      0x5830001F,  //  005F  LDCONST	R12	K31
-      0x88340D1D,  //  0060  GETMBR	R13	R6	K29
-      0x7C280600,  //  0061  CALL	R10	3
-      0x5C241400,  //  0062  MOVE	R9	R10
-      0xB82A2A00,  //  0063  GETNGBL	R10	K21
-      0x8C281516,  //  0064  GETMET	R10	R10	K22
-      0x8C300917,  //  0065  GETMET	R12	R4	K23
-      0x58380020,  //  0066  LDCONST	R14	K32
-      0x883C110B,  //  0067  GETMBR	R15	R8	K11
-      0x5C401200,  //  0068  MOVE	R16	R9
-      0x88440D14,  //  0069  GETMBR	R17	R6	K20
-      0x88480D21,  //  006A  GETMBR	R18	R6	K33
-      0x5C4C0400,  //  006B  MOVE	R19	R2
-      0x5C500600,  //  006C  MOVE	R20	R3
-      0x7C301000,  //  006D  CALL	R12	8
-      0x58340022,  //  006E  LDCONST	R13	K34
-      0x7C280600,  //  006F  CALL	R10	3
-      0x70020013,  //  0070  JMP		#0085
-      0xB8262A00,  //  0071  GETNGBL	R9	K21
-      0x8C241316,  //  0072  GETMET	R9	R9	K22
-      0x8C2C0917,  //  0073  GETMET	R11	R4	K23
-      0x58340023,  //  0074  LDCONST	R13	K35
-      0x8838110B,  //  0075  GETMBR	R14	R8	K11
-      0x883C0D14,  //  0076  GETMBR	R15	R6	K20
-      0x88400D24,  //  0077  GETMBR	R16	R6	K36
-      0x78420001,  //  0078  JMPF	R16	#007B
-      0x58400025,  //  0079  LDCONST	R16	K37
-      0x70020000,  //  007A  JMP		#007C
-      0x58400026,  //  007B  LDCONST	R16	K38
-      0x88440D21,  //  007C  GETMBR	R17	R6	K33
-      0x60480008,  //  007D  GETGBL	R18	G8
-      0x884C0D27,  //  007E  GETMBR	R19	R6	K39
-      0x7C480200,  //  007F  CALL	R18	1
-      0x5C4C0400,  //  0080  MOVE	R19	R2
-      0x5C500600,  //  0081  MOVE	R20	R3
-      0x7C2C1200,  //  0082  CALL	R11	9
-      0x54320003,  //  0083  LDINT	R12	4
-      0x7C240600,  //  0084  CALL	R9	3
-      0x88240128,  //  0085  GETMBR	R9	R0	K40
-      0x8C241329,  //  0086  GETMET	R9	R9	K41
-      0x5C2C0C00,  //  0087  MOVE	R11	R6
-      0x7C240400,  //  0088  CALL	R9	2
-      0x5C141200,  //  0089  MOVE	R5	R9
-      0x5C240A00,  //  008A  MOVE	R9	R5
-      0x74260003,  //  008B  JMPT	R9	#0090
-      0x8C24011A,  //  008C  GETMET	R9	R0	K26
-      0x5C2C0C00,  //  008D  MOVE	R11	R6
-      0x50300000,  //  008E  LDBOOL	R12	0	0
-      0x7C240600,  //  008F  CALL	R9	3
-      0x50240200,  //  0090  LDBOOL	R9	1	0
-      0xA8040001,  //  0091  EXBLK	1	1
-      0x80041200,  //  0092  RET	1	R9
-      0x70020091,  //  0093  JMP		#0126
-      0xB8222A00,  //  0094  GETNGBL	R8	K21
-      0x8C201116,  //  0095  GETMET	R8	R8	K22
-      0x8C280917,  //  0096  GETMET	R10	R4	K23
-      0x5830002A,  //  0097  LDCONST	R12	K42
-      0x88340D0B,  //  0098  GETMBR	R13	R6	K11
-      0x88380D14,  //  0099  GETMBR	R14	R6	K20
-      0x7C280800,  //  009A  CALL	R10	4
-      0x542E0003,  //  009B  LDINT	R11	4
-      0x7C200600,  //  009C  CALL	R8	3
-      0x88200105,  //  009D  GETMBR	R8	R0	K5
-      0x88201106,  //  009E  GETMBR	R8	R8	K6
-      0x8C20112B,  //  009F  GETMET	R8	R8	K43
-      0x88280D0B,  //  00A0  GETMBR	R10	R6	K11
-      0x7C200400,  //  00A1  CALL	R8	2
-      0x4C240000,  //  00A2  LDNIL	R9
-      0x1C241009,  //  00A3  EQ	R9	R8	R9
-      0x7826000A,  //  00A4  JMPF	R9	#00B0
-      0xB8262A00,  //  00A5  GETNGBL	R9	K21
-      0x8C241316,  //  00A6  GETMET	R9	R9	K22
-      0x602C0008,  //  00A7  GETGBL	R11	G8
-      0x88300D0B,  //  00A8  GETMBR	R12	R6	K11
-      0x7C2C0200,  //  00A9  CALL	R11	1
-      0x002E580B,  //  00AA  ADD	R11	K44	R11
-      0x58300022,  //  00AB  LDCONST	R12	K34
-      0x7C240600,  //  00AC  CALL	R9	3
-      0x50240000,  //  00AD  LDBOOL	R9	0	0
-      0xA8040001,  //  00AE  EXBLK	1	1
-      0x80041200,  //  00AF  RET	1	R9
-      0x780A0000,  //  00B0  JMPF	R2	#00B2
-      0x90221C02,  //  00B1  SETMBR	R8	K14	R2
-      0x780E0000,  //  00B2  JMPF	R3	#00B4
-      0x90221E03,  //  00B3  SETMBR	R8	K15	R3
-      0x90222000,  //  00B4  SETMBR	R8	K16	R0
-      0x901A2208,  //  00B5  SETMBR	R6	K17	R8
-      0x8C24112D,  //  00B6  GETMET	R9	R8	K45
-      0x882C0D14,  //  00B7  GETMBR	R11	R6	K20
-      0x50300200,  //  00B8  LDBOOL	R12	1	0
-      0x7C240600,  //  00B9  CALL	R9	3
-      0x74260013,  //  00BA  JMPT	R9	#00CF
-      0xB8262A00,  //  00BB  GETNGBL	R9	K21
-      0x8C241316,  //  00BC  GETMET	R9	R9	K22
-      0x602C0008,  //  00BD  GETGBL	R11	G8
-      0x88300D14,  //  00BE  GETMBR	R12	R6	K20
-      0x7C2C0200,  //  00BF  CALL	R11	1
-      0x002E5C0B,  //  00C0  ADD	R11	K46	R11
-      0x002C172F,  //  00C1  ADD	R11	R11	K47
-      0x60300008,  //  00C2  GETGBL	R12	G8
-      0x88341130,  //  00C3  GETMBR	R13	R8	K48
-      0x7C300200,  //  00C4  CALL	R12	1
-      0x002C160C,  //  00C5  ADD	R11	R11	R12
-      0x54320003,  //  00C6  LDINT	R12	4
-      0x7C240600,  //  00C7  CALL	R9	3
-      0x8C240131,  //  00C8  GETMET	R9	R0	K49
-      0x5C2C0C00,  //  00C9  MOVE	R11	R6
-      0x50300000,  //  00CA  LDBOOL	R12	0	0
-      0x7C240600,  //  00CB  CALL	R9	3
-      0x50240000,  //  00CC  LDBOOL	R9	0	0
-      0xA8040001,  //  00CD  EXBLK	1	1
-      0x80041200,  //  00CE  RET	1	R9
-      0x8C240D32,  //  00CF  GETMET	R9	R6	K50
-      0x7C240200,  //  00D0  CALL	R9	1
-      0x5C281200,  //  00D1  MOVE	R10	R9
-      0x742A0002,  //  00D2  JMPT	R10	#00D6
-      0x50280000,  //  00D3  LDBOOL	R10	0	0
-      0xA8040001,  //  00D4  EXBLK	1	1
-      0x80041400,  //  00D5  RET	1	R10
-      0x88280D34,  //  00D6  GETMBR	R10	R6	K52
-      0x04281535,  //  00D7  SUB	R10	R10	K53
-      0x402A180A,  //  00D8  CONNECT	R10	K12	R10
-      0x882C0D33,  //  00D9  GETMBR	R11	R6	K51
-      0x9428160A,  //  00DA  GETIDX	R10	R11	R10
-      0x901A660A,  //  00DB  SETMBR	R6	K51	R10
-      0x88280D33,  //  00DC  GETMBR	R10	R6	K51
-      0x40281409,  //  00DD  CONNECT	R10	R10	R9
-      0x8C280D1B,  //  00DE  GETMET	R10	R6	K27
-      0x7C280200,  //  00DF  CALL	R10	1
-      0xB82A2A00,  //  00E0  GETNGBL	R10	K21
-      0x8C281516,  //  00E1  GETMET	R10	R10	K22
-      0x60300008,  //  00E2  GETGBL	R12	G8
-      0x88340D37,  //  00E3  GETMBR	R13	R6	K55
-      0x7C300200,  //  00E4  CALL	R12	1
-      0x00326C0C,  //  00E5  ADD	R12	K54	R12
-      0x00301938,  //  00E6  ADD	R12	R12	K56
-      0x60340008,  //  00E7  GETGBL	R13	G8
-      0x88380D1D,  //  00E8  GETMBR	R14	R6	K29
-      0x7C340200,  //  00E9  CALL	R13	1
-      0x0030180D,  //  00EA  ADD	R12	R12	R13
-      0x00301939,  //  00EB  ADD	R12	R12	K57
-      0x60340008,  //  00EC  GETGBL	R13	G8
-      0x88380D21,  //  00ED  GETMBR	R14	R6	K33
-      0x543EFFFE,  //  00EE  LDINT	R15	65535
-      0x2C381C0F,  //  00EF  AND	R14	R14	R15
-      0x7C340200,  //  00F0  CALL	R13	1
-      0x0030180D,  //  00F1  ADD	R12	R12	R13
-      0x54360003,  //  00F2  LDINT	R13	4
-      0x7C280600,  //  00F3  CALL	R10	3
-      0x88280105,  //  00F4  GETMBR	R10	R0	K5
-      0x8C28151C,  //  00F5  GETMET	R10	R10	K28
-      0x5C300C00,  //  00F6  MOVE	R12	R6
-      0x7C280400,  //  00F7  CALL	R10	2
-      0x88280D37,  //  00F8  GETMBR	R10	R6	K55
-      0x1C2C150C,  //  00F9  EQ	R11	R10	K12
-      0x782E000F,  //  00FA  JMPF	R11	#010B
-      0x882C0D1D,  //  00FB  GETMBR	R11	R6	K29
-      0x5432000F,  //  00FC  LDINT	R12	16
-      0x1C2C160C,  //  00FD  EQ	R11	R11	R12
-      0x782E0009,  //  00FE  JMPF	R11	#0109
-      0x882C013A,  //  00FF  GETMBR	R11	R0	K58
-      0x8C2C173B,  //  0100  GETMET	R11	R11	K59
-      0x5C340C00,  //  0101  MOVE	R13	R6
-      0x7C2C0400,  //  0102  CALL	R11	2
-      0x5C141600,  //  0103  MOVE	R5	R11
-      0x78160003,  //  0104  JMPF	R5	#0109
-      0x882C013A,  //  0105  GETMBR	R11	R0	K58
-      0x8C2C173C,  //  0106  GETMET	R11	R11	K60
-      0x5C340000,  //  0107  MOVE	R13	R0
-      0x7C2C0400,  //  0108  CALL	R11	2
-      0x50140200,  //  0109  LDBOOL	R5	1	0
-      0x7002001A,  //  010A  JMP		#0126
-      0x1C2C1535,  //  010B  EQ	R11	R10	K53
-      0x782E0010,  //  010C  JMPF	R11	#011E
-      0x882C013A,  //  010D  GETMBR	R11	R0	K58
-      0x8C2C1729,  //  010E  GETMET	R11	R11	K41
-      0x5C340C00,  //  010F  MOVE	R13	R6
-      0x7C2C0400,  //  0110  CALL	R11	2
-      0x5C141600,  //  0111  MOVE	R5	R11
-      0x78160004,  //  0112  JMPF	R5	#0118
-      0x882C013A,  //  0113  GETMBR	R11	R0	K58
-      0x8C2C173C,  //  0114  GETMET	R11	R11	K60
-      0x5C340000,  //  0115  MOVE	R13	R0
-      0x7C2C0400,  //  0116  CALL	R11	2
-      0x70020003,  //  0117  JMP		#011C
-      0x8C2C0131,  //  0118  GETMET	R11	R0	K49
-      0x5C340C00,  //  0119  MOVE	R13	R6
-      0x50380200,  //  011A  LDBOOL	R14	1	0
-      0x7C2C0600,  //  011B  CALL	R11	3
-      0x50140200,  //  011C  LDBOOL	R5	1	0
-      0x70020007,  //  011D  JMP		#0126
-      0xB82E2A00,  //  011E  GETNGBL	R11	K21
-      0x8C2C1716,  //  011F  GETMET	R11	R11	K22
-      0x60340008,  //  0120  GETGBL	R13	G8
-      0x5C381400,  //  0121  MOVE	R14	R10
-      0x7C340200,  //  0122  CALL	R13	1
-      0x00367A0D,  //  0123  ADD	R13	K61	R13
-      0x58380022,  //  0124  LDCONST	R14	K34
-      0x7C2C0600,  //  0125  CALL	R11	3
-      0xA8040001,  //  0126  EXBLK	1	1
-      0x80040A00,  //  0127  RET	1	R5
-      0xA8040001,  //  0128  EXBLK	1	1
-      0x70020018,  //  0129  JMP		#0143
-      0xAC180002,  //  012A  CATCH	R6	0	2
-      0x70020015,  //  012B  JMP		#0142
-      0xB8222A00,  //  012C  GETNGBL	R8	K21
-      0x8C201116,  //  012D  GETMET	R8	R8	K22
-      0x60280008,  //  012E  GETGBL	R10	G8
-      0x5C2C0C00,  //  012F  MOVE	R11	R6
-      0x7C280200,  //  0130  CALL	R10	1
-      0x002A7C0A,  //  0131  ADD	R10	K62	R10
-      0x0028153F,  //  0132  ADD	R10	R10	K63
-      0x602C0008,  //  0133  GETGBL	R11	G8
-      0x5C300E00,  //  0134  MOVE	R12	R7
-      0x7C2C0200,  //  0135  CALL	R11	1
-      0x0028140B,  //  0136  ADD	R10	R10	R11
-      0x582C0040,  //  0137  LDCONST	R11	K64
-      0x7C200600,  //  0138  CALL	R8	3
-      0xB8222A00,  //  0139  GETNGBL	R8	K21
-      0x88201141,  //  013A  GETMBR	R8	R8	K65
-      0x78220002,  //  013B  JMPF	R8	#013F
-      0xA4228400,  //  013C  IMPORT	R8	K66
-      0x8C241143,  //  013D  GETMET	R9	R8	K67
-      0x7C240200,  //  013E  CALL	R9	1
-      0x50200000,  //  013F  LDBOOL	R8	0	0
-      0x80041000,  //  0140  RET	1	R8
-      0x70020000,  //  0141  JMP		#0143
-      0xB0080000,  //  0142  RAISE	2	R0	R0
-      0x80000000,  //  0143  RET	0
+    ( &(const binstruction[323]) {  /* code */
+      0x50100000,  //  0000  LDBOOL	R4	0	0
+      0xA8020126,  //  0001  EXBLK	0	#0129
+      0xB8160000,  //  0002  GETNGBL	R5	K0
+      0x8C140B01,  //  0003  GETMET	R5	R5	K1
+      0x5C1C0000,  //  0004  MOVE	R7	R0
+      0x5C200200,  //  0005  MOVE	R8	R1
+      0x5C240400,  //  0006  MOVE	R9	R2
+      0x5C280600,  //  0007  MOVE	R10	R3
+      0x7C140A00,  //  0008  CALL	R5	5
+      0x8C180B02,  //  0009  GETMET	R6	R5	K2
+      0x7C180200,  //  000A  CALL	R6	1
+      0x5C1C0C00,  //  000B  MOVE	R7	R6
+      0x741E0002,  //  000C  JMPT	R7	#0010
+      0x501C0000,  //  000D  LDBOOL	R7	0	0
+      0xA8040001,  //  000E  EXBLK	1	1
+      0x80040E00,  //  000F  RET	1	R7
+      0x881C0B03,  //  0010  GETMBR	R7	R5	K3
+      0x781E000C,  //  0011  JMPF	R7	#001F
+      0x881C0104,  //  0012  GETMBR	R7	R0	K4
+      0x881C0F05,  //  0013  GETMBR	R7	R7	K5
+      0x8C1C0F06,  //  0014  GETMET	R7	R7	K6
+      0x88240B07,  //  0015  GETMBR	R9	R5	K7
+      0x542A0059,  //  0016  LDINT	R10	90
+      0x7C1C0600,  //  0017  CALL	R7	3
+      0x88200108,  //  0018  GETMBR	R8	R0	K8
+      0x8C201109,  //  0019  GETMET	R8	R8	K9
+      0x5C280A00,  //  001A  MOVE	R10	R5
+      0x7C200400,  //  001B  CALL	R8	2
+      0xA8040001,  //  001C  EXBLK	1	1
+      0x80041000,  //  001D  RET	1	R8
+      0x70020105,  //  001E  JMP		#0125
+      0x881C0B0A,  //  001F  GETMBR	R7	R5	K10
+      0x1C1C0F0B,  //  0020  EQ	R7	R7	K11
+      0x781E0070,  //  0021  JMPF	R7	#0093
+      0x881C0B0C,  //  0022  GETMBR	R7	R5	K12
+      0x1C1C0F0B,  //  0023  EQ	R7	R7	K11
+      0x781E006D,  //  0024  JMPF	R7	#0093
+      0x881C0104,  //  0025  GETMBR	R7	R0	K4
+      0x881C0F05,  //  0026  GETMBR	R7	R7	K5
+      0x8C1C0F06,  //  0027  GETMET	R7	R7	K6
+      0x88240B07,  //  0028  GETMBR	R9	R5	K7
+      0x542A0059,  //  0029  LDINT	R10	90
+      0x7C1C0600,  //  002A  CALL	R7	3
+      0x780A0000,  //  002B  JMPF	R2	#002D
+      0x901E1A02,  //  002C  SETMBR	R7	K13	R2
+      0x780E0000,  //  002D  JMPF	R3	#002F
+      0x901E1C03,  //  002E  SETMBR	R7	K14	R3
+      0x901E1E00,  //  002F  SETMBR	R7	K15	R0
+      0x90162007,  //  0030  SETMBR	R5	K16	R7
+      0x88200F11,  //  0031  GETMBR	R8	R7	K17
+      0x8C201112,  //  0032  GETMET	R8	R8	K18
+      0x88280B13,  //  0033  GETMBR	R10	R5	K19
+      0x502C0000,  //  0034  LDBOOL	R11	0	0
+      0x7C200600,  //  0035  CALL	R8	3
+      0x74220011,  //  0036  JMPT	R8	#0049
+      0xB8222800,  //  0037  GETNGBL	R8	K20
+      0x8C201115,  //  0038  GETMET	R8	R8	K21
+      0x60280018,  //  0039  GETGBL	R10	G24
+      0x582C0016,  //  003A  LDCONST	R11	K22
+      0x88300B13,  //  003B  GETMBR	R12	R5	K19
+      0x88340F11,  //  003C  GETMBR	R13	R7	K17
+      0x8C341B17,  //  003D  GETMET	R13	R13	K23
+      0x7C340200,  //  003E  CALL	R13	1
+      0x7C280600,  //  003F  CALL	R10	3
+      0x542E0003,  //  0040  LDINT	R11	4
+      0x7C200600,  //  0041  CALL	R8	3
+      0x8C200118,  //  0042  GETMET	R8	R0	K24
+      0x5C280A00,  //  0043  MOVE	R10	R5
+      0x502C0000,  //  0044  LDBOOL	R11	0	0
+      0x7C200600,  //  0045  CALL	R8	3
+      0x50200000,  //  0046  LDBOOL	R8	0	0
+      0xA8040001,  //  0047  EXBLK	1	1
+      0x80041000,  //  0048  RET	1	R8
+      0x8C200B19,  //  0049  GETMET	R8	R5	K25
+      0x7C200200,  //  004A  CALL	R8	1
+      0x74220002,  //  004B  JMPT	R8	#004F
+      0x50200000,  //  004C  LDBOOL	R8	0	0
+      0xA8040001,  //  004D  EXBLK	1	1
+      0x80041000,  //  004E  RET	1	R8
+      0x88200104,  //  004F  GETMBR	R8	R0	K4
+      0x8C20111A,  //  0050  GETMET	R8	R8	K26
+      0x5C280A00,  //  0051  MOVE	R10	R5
+      0x7C200400,  //  0052  CALL	R8	2
+      0x88200B1B,  //  0053  GETMBR	R8	R5	K27
+      0x5426000F,  //  0054  LDINT	R9	16
+      0x20201009,  //  0055  NE	R8	R8	R9
+      0x78220018,  //  0056  JMPF	R8	#0070
+      0xB8220000,  //  0057  GETNGBL	R8	K0
+      0x8C20111C,  //  0058  GETMET	R8	R8	K28
+      0x88280B1B,  //  0059  GETMBR	R10	R5	K27
+      0x7C200400,  //  005A  CALL	R8	2
+      0x5C241000,  //  005B  MOVE	R9	R8
+      0x74260004,  //  005C  JMPT	R9	#0062
+      0x60240018,  //  005D  GETGBL	R9	G24
+      0x5828001D,  //  005E  LDCONST	R10	K29
+      0x882C0B1B,  //  005F  GETMBR	R11	R5	K27
+      0x7C240400,  //  0060  CALL	R9	2
+      0x5C201200,  //  0061  MOVE	R8	R9
+      0xB8262800,  //  0062  GETNGBL	R9	K20
+      0x8C241315,  //  0063  GETMET	R9	R9	K21
+      0x602C0018,  //  0064  GETGBL	R11	G24
+      0x5830001E,  //  0065  LDCONST	R12	K30
+      0x88340F0A,  //  0066  GETMBR	R13	R7	K10
+      0x5C381000,  //  0067  MOVE	R14	R8
+      0x883C0B13,  //  0068  GETMBR	R15	R5	K19
+      0x88400B1F,  //  0069  GETMBR	R16	R5	K31
+      0x5C440400,  //  006A  MOVE	R17	R2
+      0x5C480600,  //  006B  MOVE	R18	R3
+      0x7C2C0E00,  //  006C  CALL	R11	7
+      0x58300020,  //  006D  LDCONST	R12	K32
+      0x7C240600,  //  006E  CALL	R9	3
+      0x70020013,  //  006F  JMP		#0084
+      0xB8222800,  //  0070  GETNGBL	R8	K20
+      0x8C201115,  //  0071  GETMET	R8	R8	K21
+      0x60280018,  //  0072  GETGBL	R10	G24
+      0x582C0021,  //  0073  LDCONST	R11	K33
+      0x88300F0A,  //  0074  GETMBR	R12	R7	K10
+      0x88340B13,  //  0075  GETMBR	R13	R5	K19
+      0x88380B22,  //  0076  GETMBR	R14	R5	K34
+      0x783A0001,  //  0077  JMPF	R14	#007A
+      0x58380023,  //  0078  LDCONST	R14	K35
+      0x70020000,  //  0079  JMP		#007B
+      0x58380024,  //  007A  LDCONST	R14	K36
+      0x883C0B1F,  //  007B  GETMBR	R15	R5	K31
+      0x60400008,  //  007C  GETGBL	R16	G8
+      0x88440B25,  //  007D  GETMBR	R17	R5	K37
+      0x7C400200,  //  007E  CALL	R16	1
+      0x5C440400,  //  007F  MOVE	R17	R2
+      0x5C480600,  //  0080  MOVE	R18	R3
+      0x7C281000,  //  0081  CALL	R10	8
+      0x542E0003,  //  0082  LDINT	R11	4
+      0x7C200600,  //  0083  CALL	R8	3
+      0x88200126,  //  0084  GETMBR	R8	R0	K38
+      0x8C201127,  //  0085  GETMET	R8	R8	K39
+      0x5C280A00,  //  0086  MOVE	R10	R5
+      0x7C200400,  //  0087  CALL	R8	2
+      0x5C101000,  //  0088  MOVE	R4	R8
+      0x5C200800,  //  0089  MOVE	R8	R4
+      0x74220003,  //  008A  JMPT	R8	#008F
+      0x8C200118,  //  008B  GETMET	R8	R0	K24
+      0x5C280A00,  //  008C  MOVE	R10	R5
+      0x502C0000,  //  008D  LDBOOL	R11	0	0
+      0x7C200600,  //  008E  CALL	R8	3
+      0x50200200,  //  008F  LDBOOL	R8	1	0
+      0xA8040001,  //  0090  EXBLK	1	1
+      0x80041000,  //  0091  RET	1	R8
+      0x70020091,  //  0092  JMP		#0125
+      0xB81E2800,  //  0093  GETNGBL	R7	K20
+      0x8C1C0F15,  //  0094  GETMET	R7	R7	K21
+      0x60240018,  //  0095  GETGBL	R9	G24
+      0x58280028,  //  0096  LDCONST	R10	K40
+      0x882C0B0A,  //  0097  GETMBR	R11	R5	K10
+      0x88300B13,  //  0098  GETMBR	R12	R5	K19
+      0x7C240600,  //  0099  CALL	R9	3
+      0x542A0003,  //  009A  LDINT	R10	4
+      0x7C1C0600,  //  009B  CALL	R7	3
+      0x881C0104,  //  009C  GETMBR	R7	R0	K4
+      0x881C0F05,  //  009D  GETMBR	R7	R7	K5
+      0x8C1C0F29,  //  009E  GETMET	R7	R7	K41
+      0x88240B0A,  //  009F  GETMBR	R9	R5	K10
+      0x7C1C0400,  //  00A0  CALL	R7	2
+      0x4C200000,  //  00A1  LDNIL	R8
+      0x1C200E08,  //  00A2  EQ	R8	R7	R8
+      0x7822000A,  //  00A3  JMPF	R8	#00AF
+      0xB8222800,  //  00A4  GETNGBL	R8	K20
+      0x8C201115,  //  00A5  GETMET	R8	R8	K21
+      0x60280008,  //  00A6  GETGBL	R10	G8
+      0x882C0B0A,  //  00A7  GETMBR	R11	R5	K10
+      0x7C280200,  //  00A8  CALL	R10	1
+      0x002A540A,  //  00A9  ADD	R10	K42	R10
+      0x582C0020,  //  00AA  LDCONST	R11	K32
+      0x7C200600,  //  00AB  CALL	R8	3
+      0x50200000,  //  00AC  LDBOOL	R8	0	0
+      0xA8040001,  //  00AD  EXBLK	1	1
+      0x80041000,  //  00AE  RET	1	R8
+      0x780A0000,  //  00AF  JMPF	R2	#00B1
+      0x901E1A02,  //  00B0  SETMBR	R7	K13	R2
+      0x780E0000,  //  00B1  JMPF	R3	#00B3
+      0x901E1C03,  //  00B2  SETMBR	R7	K14	R3
+      0x901E1E00,  //  00B3  SETMBR	R7	K15	R0
+      0x90162007,  //  00B4  SETMBR	R5	K16	R7
+      0x8C200F2B,  //  00B5  GETMET	R8	R7	K43
+      0x88280B13,  //  00B6  GETMBR	R10	R5	K19
+      0x502C0200,  //  00B7  LDBOOL	R11	1	0
+      0x7C200600,  //  00B8  CALL	R8	3
+      0x74220013,  //  00B9  JMPT	R8	#00CE
+      0xB8222800,  //  00BA  GETNGBL	R8	K20
+      0x8C201115,  //  00BB  GETMET	R8	R8	K21
+      0x60280008,  //  00BC  GETGBL	R10	G8
+      0x882C0B13,  //  00BD  GETMBR	R11	R5	K19
+      0x7C280200,  //  00BE  CALL	R10	1
+      0x002A580A,  //  00BF  ADD	R10	K44	R10
+      0x0028152D,  //  00C0  ADD	R10	R10	K45
+      0x602C0008,  //  00C1  GETGBL	R11	G8
+      0x88300F2E,  //  00C2  GETMBR	R12	R7	K46
+      0x7C2C0200,  //  00C3  CALL	R11	1
+      0x0028140B,  //  00C4  ADD	R10	R10	R11
+      0x542E0003,  //  00C5  LDINT	R11	4
+      0x7C200600,  //  00C6  CALL	R8	3
+      0x8C20012F,  //  00C7  GETMET	R8	R0	K47
+      0x5C280A00,  //  00C8  MOVE	R10	R5
+      0x502C0000,  //  00C9  LDBOOL	R11	0	0
+      0x7C200600,  //  00CA  CALL	R8	3
+      0x50200000,  //  00CB  LDBOOL	R8	0	0
+      0xA8040001,  //  00CC  EXBLK	1	1
+      0x80041000,  //  00CD  RET	1	R8
+      0x8C200B30,  //  00CE  GETMET	R8	R5	K48
+      0x7C200200,  //  00CF  CALL	R8	1
+      0x5C241000,  //  00D0  MOVE	R9	R8
+      0x74260002,  //  00D1  JMPT	R9	#00D5
+      0x50240000,  //  00D2  LDBOOL	R9	0	0
+      0xA8040001,  //  00D3  EXBLK	1	1
+      0x80041200,  //  00D4  RET	1	R9
+      0x88240B32,  //  00D5  GETMBR	R9	R5	K50
+      0x04241333,  //  00D6  SUB	R9	R9	K51
+      0x40261609,  //  00D7  CONNECT	R9	K11	R9
+      0x88280B31,  //  00D8  GETMBR	R10	R5	K49
+      0x94241409,  //  00D9  GETIDX	R9	R10	R9
+      0x90166209,  //  00DA  SETMBR	R5	K49	R9
+      0x88240B31,  //  00DB  GETMBR	R9	R5	K49
+      0x40241208,  //  00DC  CONNECT	R9	R9	R8
+      0x8C240B19,  //  00DD  GETMET	R9	R5	K25
+      0x7C240200,  //  00DE  CALL	R9	1
+      0xB8262800,  //  00DF  GETNGBL	R9	K20
+      0x8C241315,  //  00E0  GETMET	R9	R9	K21
+      0x602C0008,  //  00E1  GETGBL	R11	G8
+      0x88300B35,  //  00E2  GETMBR	R12	R5	K53
+      0x7C2C0200,  //  00E3  CALL	R11	1
+      0x002E680B,  //  00E4  ADD	R11	K52	R11
+      0x002C1736,  //  00E5  ADD	R11	R11	K54
+      0x60300008,  //  00E6  GETGBL	R12	G8
+      0x88340B1B,  //  00E7  GETMBR	R13	R5	K27
+      0x7C300200,  //  00E8  CALL	R12	1
+      0x002C160C,  //  00E9  ADD	R11	R11	R12
+      0x002C1737,  //  00EA  ADD	R11	R11	K55
+      0x60300008,  //  00EB  GETGBL	R12	G8
+      0x88340B1F,  //  00EC  GETMBR	R13	R5	K31
+      0x543AFFFE,  //  00ED  LDINT	R14	65535
+      0x2C341A0E,  //  00EE  AND	R13	R13	R14
+      0x7C300200,  //  00EF  CALL	R12	1
+      0x002C160C,  //  00F0  ADD	R11	R11	R12
+      0x54320003,  //  00F1  LDINT	R12	4
+      0x7C240600,  //  00F2  CALL	R9	3
+      0x88240104,  //  00F3  GETMBR	R9	R0	K4
+      0x8C24131A,  //  00F4  GETMET	R9	R9	K26
+      0x5C2C0A00,  //  00F5  MOVE	R11	R5
+      0x7C240400,  //  00F6  CALL	R9	2
+      0x88240B35,  //  00F7  GETMBR	R9	R5	K53
+      0x1C28130B,  //  00F8  EQ	R10	R9	K11
+      0x782A000F,  //  00F9  JMPF	R10	#010A
+      0x88280B1B,  //  00FA  GETMBR	R10	R5	K27
+      0x542E000F,  //  00FB  LDINT	R11	16
+      0x1C28140B,  //  00FC  EQ	R10	R10	R11
+      0x782A0009,  //  00FD  JMPF	R10	#0108
+      0x88280138,  //  00FE  GETMBR	R10	R0	K56
+      0x8C281539,  //  00FF  GETMET	R10	R10	K57
+      0x5C300A00,  //  0100  MOVE	R12	R5
+      0x7C280400,  //  0101  CALL	R10	2
+      0x5C101400,  //  0102  MOVE	R4	R10
+      0x78120003,  //  0103  JMPF	R4	#0108
+      0x88280138,  //  0104  GETMBR	R10	R0	K56
+      0x8C28153A,  //  0105  GETMET	R10	R10	K58
+      0x5C300000,  //  0106  MOVE	R12	R0
+      0x7C280400,  //  0107  CALL	R10	2
+      0x50100200,  //  0108  LDBOOL	R4	1	0
+      0x7002001A,  //  0109  JMP		#0125
+      0x1C281333,  //  010A  EQ	R10	R9	K51
+      0x782A0010,  //  010B  JMPF	R10	#011D
+      0x88280138,  //  010C  GETMBR	R10	R0	K56
+      0x8C281527,  //  010D  GETMET	R10	R10	K39
+      0x5C300A00,  //  010E  MOVE	R12	R5
+      0x7C280400,  //  010F  CALL	R10	2
+      0x5C101400,  //  0110  MOVE	R4	R10
+      0x78120004,  //  0111  JMPF	R4	#0117
+      0x88280138,  //  0112  GETMBR	R10	R0	K56
+      0x8C28153A,  //  0113  GETMET	R10	R10	K58
+      0x5C300000,  //  0114  MOVE	R12	R0
+      0x7C280400,  //  0115  CALL	R10	2
+      0x70020003,  //  0116  JMP		#011B
+      0x8C28012F,  //  0117  GETMET	R10	R0	K47
+      0x5C300A00,  //  0118  MOVE	R12	R5
+      0x50340200,  //  0119  LDBOOL	R13	1	0
+      0x7C280600,  //  011A  CALL	R10	3
+      0x50100200,  //  011B  LDBOOL	R4	1	0
+      0x70020007,  //  011C  JMP		#0125
+      0xB82A2800,  //  011D  GETNGBL	R10	K20
+      0x8C281515,  //  011E  GETMET	R10	R10	K21
+      0x60300008,  //  011F  GETGBL	R12	G8
+      0x5C341200,  //  0120  MOVE	R13	R9
+      0x7C300200,  //  0121  CALL	R12	1
+      0x0032760C,  //  0122  ADD	R12	K59	R12
+      0x58340020,  //  0123  LDCONST	R13	K32
+      0x7C280600,  //  0124  CALL	R10	3
+      0xA8040001,  //  0125  EXBLK	1	1
+      0x80040800,  //  0126  RET	1	R4
+      0xA8040001,  //  0127  EXBLK	1	1
+      0x70020018,  //  0128  JMP		#0142
+      0xAC140002,  //  0129  CATCH	R5	0	2
+      0x70020015,  //  012A  JMP		#0141
+      0xB81E2800,  //  012B  GETNGBL	R7	K20
+      0x8C1C0F15,  //  012C  GETMET	R7	R7	K21
+      0x60240008,  //  012D  GETGBL	R9	G8
+      0x5C280A00,  //  012E  MOVE	R10	R5
+      0x7C240200,  //  012F  CALL	R9	1
+      0x00267809,  //  0130  ADD	R9	K60	R9
+      0x0024133D,  //  0131  ADD	R9	R9	K61
+      0x60280008,  //  0132  GETGBL	R10	G8
+      0x5C2C0C00,  //  0133  MOVE	R11	R6
+      0x7C280200,  //  0134  CALL	R10	1
+      0x0024120A,  //  0135  ADD	R9	R9	R10
+      0x5828003E,  //  0136  LDCONST	R10	K62
+      0x7C1C0600,  //  0137  CALL	R7	3
+      0xB81E2800,  //  0138  GETNGBL	R7	K20
+      0x881C0F3F,  //  0139  GETMBR	R7	R7	K63
+      0x781E0002,  //  013A  JMPF	R7	#013E
+      0xA41E8000,  //  013B  IMPORT	R7	K64
+      0x8C200F41,  //  013C  GETMET	R8	R7	K65
+      0x7C200200,  //  013D  CALL	R8	1
+      0x501C0000,  //  013E  LDBOOL	R7	0	0
+      0x80040E00,  //  013F  RET	1	R7
+      0x70020000,  //  0140  JMP		#0142
+      0xB0080000,  //  0141  RAISE	2	R0	R0
+      0x80000000,  //  0142  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Path;
 ********************************************************************/
 be_local_closure(Matter_Path_tostring,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,101 +19,98 @@ be_local_closure(Matter_Path_tostring,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(),
-    /* K2   */  be_nested_str_weak(endpoint),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(_X5B_X2502X_X5D),
-    /* K5   */  be_nested_str_weak(_X5B_X2A_X2A_X5D),
-    /* K6   */  be_nested_str_weak(cluster),
-    /* K7   */  be_nested_str_weak(_X2504X_X2F),
-    /* K8   */  be_nested_str_weak(_X2A_X2A_X2A_X2A_X2F),
-    /* K9   */  be_nested_str_weak(attribute),
-    /* K10  */  be_nested_str_weak(_X2504X),
-    /* K11  */  be_nested_str_weak(command),
-    /* K12  */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
-    /* K13  */  be_nested_str_weak(Exception_X3E_X20),
-    /* K14  */  be_nested_str_weak(_X2C_X20),
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(),
+    /* K1   */  be_nested_str_weak(endpoint),
+    /* K2   */  be_nested_str_weak(_X5B_X2502X_X5D),
+    /* K3   */  be_nested_str_weak(_X5B_X2A_X2A_X5D),
+    /* K4   */  be_nested_str_weak(cluster),
+    /* K5   */  be_nested_str_weak(_X2504X_X2F),
+    /* K6   */  be_nested_str_weak(_X2A_X2A_X2A_X2A_X2F),
+    /* K7   */  be_nested_str_weak(attribute),
+    /* K8   */  be_nested_str_weak(_X2504X),
+    /* K9   */  be_nested_str_weak(command),
+    /* K10  */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
+    /* K11  */  be_nested_str_weak(Exception_X3E_X20),
+    /* K12  */  be_nested_str_weak(_X2C_X20),
     }),
     be_str_weak(tostring),
     &be_const_str_solidified,
-    ( &(const binstruction[75]) {  /* code */
-      0xA802003A,  //  0000  EXBLK	0	#003C
-      0xA4060000,  //  0001  IMPORT	R1	K0
-      0x58080001,  //  0002  LDCONST	R2	K1
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
-      0x4C100000,  //  0004  LDNIL	R4
-      0x200C0604,  //  0005  NE	R3	R3	R4
-      0x780E0004,  //  0006  JMPF	R3	#000C
-      0x8C0C0303,  //  0007  GETMET	R3	R1	K3
-      0x58140004,  //  0008  LDCONST	R5	K4
-      0x88180102,  //  0009  GETMBR	R6	R0	K2
-      0x7C0C0600,  //  000A  CALL	R3	3
-      0x70020000,  //  000B  JMP		#000D
-      0x580C0005,  //  000C  LDCONST	R3	K5
-      0x00080403,  //  000D  ADD	R2	R2	R3
-      0x880C0106,  //  000E  GETMBR	R3	R0	K6
-      0x4C100000,  //  000F  LDNIL	R4
-      0x200C0604,  //  0010  NE	R3	R3	R4
-      0x780E0004,  //  0011  JMPF	R3	#0017
-      0x8C0C0303,  //  0012  GETMET	R3	R1	K3
-      0x58140007,  //  0013  LDCONST	R5	K7
-      0x88180106,  //  0014  GETMBR	R6	R0	K6
-      0x7C0C0600,  //  0015  CALL	R3	3
-      0x70020000,  //  0016  JMP		#0018
-      0x580C0008,  //  0017  LDCONST	R3	K8
-      0x00080403,  //  0018  ADD	R2	R2	R3
-      0x880C0109,  //  0019  GETMBR	R3	R0	K9
-      0x4C100000,  //  001A  LDNIL	R4
-      0x200C0604,  //  001B  NE	R3	R3	R4
-      0x780E0004,  //  001C  JMPF	R3	#0022
-      0x8C0C0303,  //  001D  GETMET	R3	R1	K3
-      0x5814000A,  //  001E  LDCONST	R5	K10
-      0x88180109,  //  001F  GETMBR	R6	R0	K9
-      0x7C0C0600,  //  0020  CALL	R3	3
-      0x70020000,  //  0021  JMP		#0023
-      0x580C0001,  //  0022  LDCONST	R3	K1
-      0x00080403,  //  0023  ADD	R2	R2	R3
-      0x880C010B,  //  0024  GETMBR	R3	R0	K11
-      0x4C100000,  //  0025  LDNIL	R4
-      0x200C0604,  //  0026  NE	R3	R3	R4
-      0x780E0004,  //  0027  JMPF	R3	#002D
-      0x8C0C0303,  //  0028  GETMET	R3	R1	K3
-      0x5814000A,  //  0029  LDCONST	R5	K10
-      0x8818010B,  //  002A  GETMBR	R6	R0	K11
-      0x7C0C0600,  //  002B  CALL	R3	3
-      0x70020000,  //  002C  JMP		#002E
-      0x580C0001,  //  002D  LDCONST	R3	K1
-      0x00080403,  //  002E  ADD	R2	R2	R3
-      0x880C0109,  //  002F  GETMBR	R3	R0	K9
-      0x4C100000,  //  0030  LDNIL	R4
-      0x1C0C0604,  //  0031  EQ	R3	R3	R4
-      0x780E0004,  //  0032  JMPF	R3	#0038
-      0x880C010B,  //  0033  GETMBR	R3	R0	K11
-      0x4C100000,  //  0034  LDNIL	R4
-      0x1C0C0604,  //  0035  EQ	R3	R3	R4
-      0x780E0000,  //  0036  JMPF	R3	#0038
-      0x0008050C,  //  0037  ADD	R2	R2	K12
-      0xA8040001,  //  0038  EXBLK	1	1
-      0x80040400,  //  0039  RET	1	R2
-      0xA8040001,  //  003A  EXBLK	1	1
-      0x7002000D,  //  003B  JMP		#004A
-      0xAC040002,  //  003C  CATCH	R1	0	2
-      0x7002000A,  //  003D  JMP		#0049
-      0x600C0008,  //  003E  GETGBL	R3	G8
-      0x5C100200,  //  003F  MOVE	R4	R1
-      0x7C0C0200,  //  0040  CALL	R3	1
-      0x000E1A03,  //  0041  ADD	R3	K13	R3
-      0x000C070E,  //  0042  ADD	R3	R3	K14
-      0x60100008,  //  0043  GETGBL	R4	G8
-      0x5C140400,  //  0044  MOVE	R5	R2
-      0x7C100200,  //  0045  CALL	R4	1
-      0x000C0604,  //  0046  ADD	R3	R3	R4
-      0x80040600,  //  0047  RET	1	R3
-      0x70020000,  //  0048  JMP		#004A
-      0xB0080000,  //  0049  RAISE	2	R0	R0
-      0x80000000,  //  004A  RET	0
+    ( &(const binstruction[74]) {  /* code */
+      0xA8020039,  //  0000  EXBLK	0	#003B
+      0x58040000,  //  0001  LDCONST	R1	K0
+      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x20080403,  //  0004  NE	R2	R2	R3
+      0x780A0004,  //  0005  JMPF	R2	#000B
+      0x60080018,  //  0006  GETGBL	R2	G24
+      0x580C0002,  //  0007  LDCONST	R3	K2
+      0x88100101,  //  0008  GETMBR	R4	R0	K1
+      0x7C080400,  //  0009  CALL	R2	2
+      0x70020000,  //  000A  JMP		#000C
+      0x58080003,  //  000B  LDCONST	R2	K3
+      0x00040202,  //  000C  ADD	R1	R1	R2
+      0x88080104,  //  000D  GETMBR	R2	R0	K4
+      0x4C0C0000,  //  000E  LDNIL	R3
+      0x20080403,  //  000F  NE	R2	R2	R3
+      0x780A0004,  //  0010  JMPF	R2	#0016
+      0x60080018,  //  0011  GETGBL	R2	G24
+      0x580C0005,  //  0012  LDCONST	R3	K5
+      0x88100104,  //  0013  GETMBR	R4	R0	K4
+      0x7C080400,  //  0014  CALL	R2	2
+      0x70020000,  //  0015  JMP		#0017
+      0x58080006,  //  0016  LDCONST	R2	K6
+      0x00040202,  //  0017  ADD	R1	R1	R2
+      0x88080107,  //  0018  GETMBR	R2	R0	K7
+      0x4C0C0000,  //  0019  LDNIL	R3
+      0x20080403,  //  001A  NE	R2	R2	R3
+      0x780A0004,  //  001B  JMPF	R2	#0021
+      0x60080018,  //  001C  GETGBL	R2	G24
+      0x580C0008,  //  001D  LDCONST	R3	K8
+      0x88100107,  //  001E  GETMBR	R4	R0	K7
+      0x7C080400,  //  001F  CALL	R2	2
+      0x70020000,  //  0020  JMP		#0022
+      0x58080000,  //  0021  LDCONST	R2	K0
+      0x00040202,  //  0022  ADD	R1	R1	R2
+      0x88080109,  //  0023  GETMBR	R2	R0	K9
+      0x4C0C0000,  //  0024  LDNIL	R3
+      0x20080403,  //  0025  NE	R2	R2	R3
+      0x780A0004,  //  0026  JMPF	R2	#002C
+      0x60080018,  //  0027  GETGBL	R2	G24
+      0x580C0008,  //  0028  LDCONST	R3	K8
+      0x88100109,  //  0029  GETMBR	R4	R0	K9
+      0x7C080400,  //  002A  CALL	R2	2
+      0x70020000,  //  002B  JMP		#002D
+      0x58080000,  //  002C  LDCONST	R2	K0
+      0x00040202,  //  002D  ADD	R1	R1	R2
+      0x88080107,  //  002E  GETMBR	R2	R0	K7
+      0x4C0C0000,  //  002F  LDNIL	R3
+      0x1C080403,  //  0030  EQ	R2	R2	R3
+      0x780A0004,  //  0031  JMPF	R2	#0037
+      0x88080109,  //  0032  GETMBR	R2	R0	K9
+      0x4C0C0000,  //  0033  LDNIL	R3
+      0x1C080403,  //  0034  EQ	R2	R2	R3
+      0x780A0000,  //  0035  JMPF	R2	#0037
+      0x0004030A,  //  0036  ADD	R1	R1	K10
+      0xA8040001,  //  0037  EXBLK	1	1
+      0x80040200,  //  0038  RET	1	R1
+      0xA8040001,  //  0039  EXBLK	1	1
+      0x7002000D,  //  003A  JMP		#0049
+      0xAC040002,  //  003B  CATCH	R1	0	2
+      0x7002000A,  //  003C  JMP		#0048
+      0x600C0008,  //  003D  GETGBL	R3	G8
+      0x5C100200,  //  003E  MOVE	R4	R1
+      0x7C0C0200,  //  003F  CALL	R3	1
+      0x000E1603,  //  0040  ADD	R3	K11	R3
+      0x000C070C,  //  0041  ADD	R3	R3	K12
+      0x60100008,  //  0042  GETGBL	R4	G8
+      0x5C140400,  //  0043  MOVE	R5	R2
+      0x7C100200,  //  0044  CALL	R4	1
+      0x000C0604,  //  0045  ADD	R3	R3	R4
+      0x80040600,  //  0046  RET	1	R3
+      0x70020000,  //  0047  JMP		#0049
+      0xB0080000,  //  0048  RAISE	2	R0	R0
+      0x80000000,  //  0049  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Aggregator.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Aggregator.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Plugin_Aggregator;
 ********************************************************************/
 be_local_closure(Matter_Plugin_Aggregator_read_attribute,   /* name */
   be_nested_proto(
-    16,                          /* nstack */
+    15,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,78 +19,76 @@ be_local_closure(Matter_Plugin_Aggregator_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(Matter_TLV_array),
-    /* K7   */  be_nested_str_weak(device),
-    /* K8   */  be_nested_str_weak(get_active_endpoints),
-    /* K9   */  be_nested_str_weak(add_TLV),
-    /* K10  */  be_nested_str_weak(U2),
-    /* K11  */  be_nested_str_weak(stop_iteration),
-    /* K12  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(3),
+    /* K5   */  be_nested_str_weak(Matter_TLV_array),
+    /* K6   */  be_nested_str_weak(device),
+    /* K7   */  be_nested_str_weak(get_active_endpoints),
+    /* K8   */  be_nested_str_weak(add_TLV),
+    /* K9   */  be_nested_str_weak(U2),
+    /* K10  */  be_nested_str_weak(stop_iteration),
+    /* K11  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[54]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[53]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E001C,  //  0005  LDINT	R7	29
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0024,  //  0007  JMPF	R7	#002D
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E0019,  //  0009  JMPF	R7	#0024
-      0x8C1C0906,  //  000A  GETMET	R7	R4	K6
-      0x7C1C0200,  //  000B  CALL	R7	1
-      0x88200107,  //  000C  GETMBR	R8	R0	K7
-      0x8C201108,  //  000D  GETMET	R8	R8	K8
-      0x50280200,  //  000E  LDBOOL	R10	1	0
-      0x7C200400,  //  000F  CALL	R8	2
-      0x60240010,  //  0010  GETGBL	R9	G16
-      0x5C281000,  //  0011  MOVE	R10	R8
-      0x7C240200,  //  0012  CALL	R9	1
-      0xA802000A,  //  0013  EXBLK	0	#001F
-      0x5C281200,  //  0014  MOVE	R10	R9
-      0x7C280000,  //  0015  CALL	R10	0
-      0x542EFEFF,  //  0016  LDINT	R11	65280
-      0x142C140B,  //  0017  LT	R11	R10	R11
-      0x782E0004,  //  0018  JMPF	R11	#001E
-      0x8C2C0F09,  //  0019  GETMET	R11	R7	K9
-      0x4C340000,  //  001A  LDNIL	R13
-      0x8838090A,  //  001B  GETMBR	R14	R4	K10
-      0x5C3C1400,  //  001C  MOVE	R15	R10
-      0x7C2C0800,  //  001D  CALL	R11	4
-      0x7001FFF4,  //  001E  JMP		#0014
-      0x5824000B,  //  001F  LDCONST	R9	K11
-      0xAC240200,  //  0020  CATCH	R9	1	0
-      0xB0080000,  //  0021  RAISE	2	R0	R0
-      0x80040E00,  //  0022  RET	1	R7
-      0x70020007,  //  0023  JMP		#002C
-      0x601C0003,  //  0024  GETGBL	R7	G3
-      0x5C200000,  //  0025  MOVE	R8	R0
-      0x7C1C0200,  //  0026  CALL	R7	1
-      0x8C1C0F0C,  //  0027  GETMET	R7	R7	K12
-      0x5C240200,  //  0028  MOVE	R9	R1
-      0x5C280400,  //  0029  MOVE	R10	R2
-      0x7C1C0600,  //  002A  CALL	R7	3
-      0x80040E00,  //  002B  RET	1	R7
-      0x70020007,  //  002C  JMP		#0035
-      0x601C0003,  //  002D  GETGBL	R7	G3
-      0x5C200000,  //  002E  MOVE	R8	R0
-      0x7C1C0200,  //  002F  CALL	R7	1
-      0x8C1C0F0C,  //  0030  GETMET	R7	R7	K12
-      0x5C240200,  //  0031  MOVE	R9	R1
-      0x5C280400,  //  0032  MOVE	R10	R2
-      0x7C1C0600,  //  0033  CALL	R7	3
-      0x80040E00,  //  0034  RET	1	R7
-      0x80000000,  //  0035  RET	0
+      0x541A001C,  //  0004  LDINT	R6	29
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0024,  //  0006  JMPF	R6	#002C
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A0019,  //  0008  JMPF	R6	#0023
+      0x8C180705,  //  0009  GETMET	R6	R3	K5
+      0x7C180200,  //  000A  CALL	R6	1
+      0x881C0106,  //  000B  GETMBR	R7	R0	K6
+      0x8C1C0F07,  //  000C  GETMET	R7	R7	K7
+      0x50240200,  //  000D  LDBOOL	R9	1	0
+      0x7C1C0400,  //  000E  CALL	R7	2
+      0x60200010,  //  000F  GETGBL	R8	G16
+      0x5C240E00,  //  0010  MOVE	R9	R7
+      0x7C200200,  //  0011  CALL	R8	1
+      0xA802000A,  //  0012  EXBLK	0	#001E
+      0x5C241000,  //  0013  MOVE	R9	R8
+      0x7C240000,  //  0014  CALL	R9	0
+      0x542AFEFF,  //  0015  LDINT	R10	65280
+      0x1428120A,  //  0016  LT	R10	R9	R10
+      0x782A0004,  //  0017  JMPF	R10	#001D
+      0x8C280D08,  //  0018  GETMET	R10	R6	K8
+      0x4C300000,  //  0019  LDNIL	R12
+      0x88340709,  //  001A  GETMBR	R13	R3	K9
+      0x5C381200,  //  001B  MOVE	R14	R9
+      0x7C280800,  //  001C  CALL	R10	4
+      0x7001FFF4,  //  001D  JMP		#0013
+      0x5820000A,  //  001E  LDCONST	R8	K10
+      0xAC200200,  //  001F  CATCH	R8	1	0
+      0xB0080000,  //  0020  RAISE	2	R0	R0
+      0x80040C00,  //  0021  RET	1	R6
+      0x70020007,  //  0022  JMP		#002B
+      0x60180003,  //  0023  GETGBL	R6	G3
+      0x5C1C0000,  //  0024  MOVE	R7	R0
+      0x7C180200,  //  0025  CALL	R6	1
+      0x8C180D0B,  //  0026  GETMET	R6	R6	K11
+      0x5C200200,  //  0027  MOVE	R8	R1
+      0x5C240400,  //  0028  MOVE	R9	R2
+      0x7C180600,  //  0029  CALL	R6	3
+      0x80040C00,  //  002A  RET	1	R6
+      0x70020007,  //  002B  JMP		#0034
+      0x60180003,  //  002C  GETGBL	R6	G3
+      0x5C1C0000,  //  002D  MOVE	R7	R0
+      0x7C180200,  //  002E  CALL	R6	1
+      0x8C180D0B,  //  002F  GETMET	R6	R6	K11
+      0x5C200200,  //  0030  MOVE	R8	R1
+      0x5C240400,  //  0031  MOVE	R9	R2
+      0x7C180600,  //  0032  CALL	R6	3
+      0x80040C00,  //  0033  RET	1	R6
+      0x80000000,  //  0034  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_HTTP.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_HTTP.h
@@ -231,7 +231,7 @@ extern const bclass be_class_Matter_Plugin_Bridge_HTTP;
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_HTTP_init,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -239,41 +239,39 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_init,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(init),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(ARG_HTTP),
-    /* K4   */  be_nested_str_weak(http_remote),
-    /* K5   */  be_nested_str_weak(device),
-    /* K6   */  be_nested_str_weak(register_http_remote),
-    /* K7   */  be_nested_str_weak(PROBE_TIMEOUT),
-    /* K8   */  be_nested_str_weak(register_cmd_cb),
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(ARG_HTTP),
+    /* K3   */  be_nested_str_weak(http_remote),
+    /* K4   */  be_nested_str_weak(device),
+    /* K5   */  be_nested_str_weak(register_http_remote),
+    /* K6   */  be_nested_str_weak(PROBE_TIMEOUT),
+    /* K7   */  be_nested_str_weak(register_cmd_cb),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0x60140003,  //  0001  GETGBL	R5	G3
-      0x5C180000,  //  0002  MOVE	R6	R0
-      0x7C140200,  //  0003  CALL	R5	1
-      0x8C140B01,  //  0004  GETMET	R5	R5	K1
-      0x5C1C0200,  //  0005  MOVE	R7	R1
-      0x5C200400,  //  0006  MOVE	R8	R2
-      0x5C240600,  //  0007  MOVE	R9	R3
-      0x7C140800,  //  0008  CALL	R5	4
-      0x8C140702,  //  0009  GETMET	R5	R3	K2
-      0x881C0103,  //  000A  GETMBR	R7	R0	K3
-      0x7C140400,  //  000B  CALL	R5	2
-      0x88180105,  //  000C  GETMBR	R6	R0	K5
-      0x8C180D06,  //  000D  GETMET	R6	R6	K6
-      0x5C200A00,  //  000E  MOVE	R8	R5
-      0x88240107,  //  000F  GETMBR	R9	R0	K7
-      0x7C180600,  //  0010  CALL	R6	3
-      0x90020806,  //  0011  SETMBR	R0	K4	R6
-      0x8C180108,  //  0012  GETMET	R6	R0	K8
-      0x7C180200,  //  0013  CALL	R6	1
-      0x80000000,  //  0014  RET	0
+    ( &(const binstruction[20]) {  /* code */
+      0x60100003,  //  0000  GETGBL	R4	G3
+      0x5C140000,  //  0001  MOVE	R5	R0
+      0x7C100200,  //  0002  CALL	R4	1
+      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x5C200600,  //  0006  MOVE	R8	R3
+      0x7C100800,  //  0007  CALL	R4	4
+      0x8C100701,  //  0008  GETMET	R4	R3	K1
+      0x88180102,  //  0009  GETMBR	R6	R0	K2
+      0x7C100400,  //  000A  CALL	R4	2
+      0x88140104,  //  000B  GETMBR	R5	R0	K4
+      0x8C140B05,  //  000C  GETMET	R5	R5	K5
+      0x5C1C0800,  //  000D  MOVE	R7	R4
+      0x88200106,  //  000E  GETMBR	R8	R0	K6
+      0x7C140600,  //  000F  CALL	R5	3
+      0x90020605,  //  0010  SETMBR	R0	K3	R5
+      0x8C140107,  //  0011  GETMET	R5	R0	K7
+      0x7C140200,  //  0012  CALL	R5	1
+      0x80000000,  //  0013  RET	0
     })
   )
 );
@@ -352,7 +350,7 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_web_value_onoff,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_HTTP_call_remote_sync,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -360,69 +358,67 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_call_remote_sync,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(json),
-    /* K2   */  be_const_int(2),
-    /* K3   */  be_nested_str_weak(_X20),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(http_remote),
-    /* K6   */  be_nested_str_weak(call_sync),
-    /* K7   */  be_nested_str_weak(SYNC_TIMEOUT),
-    /* K8   */  be_nested_str_weak(device_is_alive),
-    /* K9   */  be_nested_str_weak(load),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20GET_X20retrying),
-    /* K14  */  be_const_int(3),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_const_int(2),
+    /* K2   */  be_nested_str_weak(_X20),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(http_remote),
+    /* K5   */  be_nested_str_weak(call_sync),
+    /* K6   */  be_nested_str_weak(SYNC_TIMEOUT),
+    /* K7   */  be_nested_str_weak(device_is_alive),
+    /* K8   */  be_nested_str_weak(load),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(tasmota),
+    /* K11  */  be_nested_str_weak(log),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20GET_X20retrying),
+    /* K13  */  be_const_int(3),
     }),
     be_str_weak(call_remote_sync),
     &be_const_str_solidified,
-    ( &(const binstruction[43]) {  /* code */
+    ( &(const binstruction[42]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xA4120200,  //  0001  IMPORT	R4	K1
-      0x58140002,  //  0002  LDCONST	R5	K2
-      0x4C180000,  //  0003  LDNIL	R6
-      0x20180406,  //  0004  NE	R6	R2	R6
-      0x781A0005,  //  0005  JMPF	R6	#000C
-      0x00180303,  //  0006  ADD	R6	R1	K3
-      0x601C0008,  //  0007  GETGBL	R7	G8
-      0x5C200400,  //  0008  MOVE	R8	R2
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x00180C07,  //  000A  ADD	R6	R6	R7
-      0x5C040C00,  //  000B  MOVE	R1	R6
-      0x24180B04,  //  000C  GT	R6	R5	K4
-      0x781A0016,  //  000D  JMPF	R6	#0025
-      0x88180105,  //  000E  GETMBR	R6	R0	K5
-      0x8C180D06,  //  000F  GETMET	R6	R6	K6
-      0x5C200200,  //  0010  MOVE	R8	R1
-      0x88240107,  //  0011  GETMBR	R9	R0	K7
-      0x7C180600,  //  0012  CALL	R6	3
-      0x4C1C0000,  //  0013  LDNIL	R7
-      0x201C0C07,  //  0014  NE	R7	R6	R7
-      0x781E0007,  //  0015  JMPF	R7	#001E
-      0x881C0105,  //  0016  GETMBR	R7	R0	K5
-      0x8C1C0F08,  //  0017  GETMET	R7	R7	K8
-      0x50240200,  //  0018  LDBOOL	R9	1	0
-      0x7C1C0400,  //  0019  CALL	R7	2
-      0x8C1C0909,  //  001A  GETMET	R7	R4	K9
-      0x5C240C00,  //  001B  MOVE	R9	R6
-      0x7C1C0400,  //  001C  CALL	R7	2
-      0x80040E00,  //  001D  RET	1	R7
-      0x04140B0A,  //  001E  SUB	R5	R5	K10
-      0xB81E1600,  //  001F  GETNGBL	R7	K11
-      0x8C1C0F0C,  //  0020  GETMET	R7	R7	K12
+      0x58100001,  //  0001  LDCONST	R4	K1
+      0x4C140000,  //  0002  LDNIL	R5
+      0x20140405,  //  0003  NE	R5	R2	R5
+      0x78160005,  //  0004  JMPF	R5	#000B
+      0x00140302,  //  0005  ADD	R5	R1	K2
+      0x60180008,  //  0006  GETGBL	R6	G8
+      0x5C1C0400,  //  0007  MOVE	R7	R2
+      0x7C180200,  //  0008  CALL	R6	1
+      0x00140A06,  //  0009  ADD	R5	R5	R6
+      0x5C040A00,  //  000A  MOVE	R1	R5
+      0x24140903,  //  000B  GT	R5	R4	K3
+      0x78160016,  //  000C  JMPF	R5	#0024
+      0x88140104,  //  000D  GETMBR	R5	R0	K4
+      0x8C140B05,  //  000E  GETMET	R5	R5	K5
+      0x5C1C0200,  //  000F  MOVE	R7	R1
+      0x88200106,  //  0010  GETMBR	R8	R0	K6
+      0x7C140600,  //  0011  CALL	R5	3
+      0x4C180000,  //  0012  LDNIL	R6
+      0x20180A06,  //  0013  NE	R6	R5	R6
+      0x781A0007,  //  0014  JMPF	R6	#001D
+      0x88180104,  //  0015  GETMBR	R6	R0	K4
+      0x8C180D07,  //  0016  GETMET	R6	R6	K7
+      0x50200200,  //  0017  LDBOOL	R8	1	0
+      0x7C180400,  //  0018  CALL	R6	2
+      0x8C180708,  //  0019  GETMET	R6	R3	K8
+      0x5C200A00,  //  001A  MOVE	R8	R5
+      0x7C180400,  //  001B  CALL	R6	2
+      0x80040C00,  //  001C  RET	1	R6
+      0x04100909,  //  001D  SUB	R4	R4	K9
+      0xB81A1400,  //  001E  GETNGBL	R6	K10
+      0x8C180D0B,  //  001F  GETMET	R6	R6	K11
+      0x5820000C,  //  0020  LDCONST	R8	K12
       0x5824000D,  //  0021  LDCONST	R9	K13
-      0x5828000E,  //  0022  LDCONST	R10	K14
-      0x7C1C0600,  //  0023  CALL	R7	3
-      0x7001FFE6,  //  0024  JMP		#000C
-      0x88180105,  //  0025  GETMBR	R6	R0	K5
-      0x8C180D08,  //  0026  GETMET	R6	R6	K8
-      0x50200000,  //  0027  LDBOOL	R8	0	0
-      0x7C180400,  //  0028  CALL	R6	2
-      0x4C180000,  //  0029  LDNIL	R6
-      0x80040C00,  //  002A  RET	1	R6
+      0x7C180600,  //  0022  CALL	R6	3
+      0x7001FFE6,  //  0023  JMP		#000B
+      0x88140104,  //  0024  GETMBR	R5	R0	K4
+      0x8C140B07,  //  0025  GETMET	R5	R5	K7
+      0x501C0000,  //  0026  LDBOOL	R7	0	0
+      0x7C140400,  //  0027  CALL	R5	2
+      0x4C140000,  //  0028  LDNIL	R5
+      0x80040A00,  //  0029  RET	1	R5
     })
   )
 );
@@ -526,7 +522,7 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_parse_update,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_HTTP_web_values_prefix,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -534,35 +530,32 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_web_values_prefix,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(get_name),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(PREFIX),
-    /* K6   */  be_nested_str_weak(html_escape),
-    /* K7   */  be_nested_str_weak(),
+    /* K1   */  be_nested_str_weak(get_name),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(PREFIX),
+    /* K4   */  be_nested_str_weak(html_escape),
+    /* K5   */  be_nested_str_weak(),
     }),
     be_str_weak(web_values_prefix),
     &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
+    ( &(const binstruction[15]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C100303,  //  0004  GETMET	R4	R1	K3
-      0x8C180504,  //  0005  GETMET	R6	R2	K4
-      0x88200105,  //  0006  GETMBR	R8	R0	K5
-      0x780E0003,  //  0007  JMPF	R3	#000C
-      0x8C240306,  //  0008  GETMET	R9	R1	K6
-      0x5C2C0600,  //  0009  MOVE	R11	R3
-      0x7C240400,  //  000A  CALL	R9	2
-      0x70020000,  //  000B  JMP		#000D
-      0x58240007,  //  000C  LDCONST	R9	K7
-      0x7C180600,  //  000D  CALL	R6	3
-      0x7C100400,  //  000E  CALL	R4	2
-      0x80000000,  //  000F  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C0C0302,  //  0003  GETMET	R3	R1	K2
+      0x60140018,  //  0004  GETGBL	R5	G24
+      0x88180103,  //  0005  GETMBR	R6	R0	K3
+      0x780A0003,  //  0006  JMPF	R2	#000B
+      0x8C1C0304,  //  0007  GETMET	R7	R1	K4
+      0x5C240400,  //  0008  MOVE	R9	R2
+      0x7C1C0400,  //  0009  CALL	R7	2
+      0x70020000,  //  000A  JMP		#000C
+      0x581C0005,  //  000B  LDCONST	R7	K5
+      0x7C140400,  //  000C  CALL	R5	2
+      0x7C0C0400,  //  000D  CALL	R3	2
+      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -642,7 +635,7 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_read_attribute,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_HTTP_web_values,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -650,28 +643,26 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_web_values,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(web_values_prefix),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(_X26lt_X3B_X2D_X2D_X20_X28),
-    /* K5   */  be_nested_str_weak(NAME),
-    /* K6   */  be_nested_str_weak(_X29_X20_X2D_X2D_X26gt_X3B),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(_X26lt_X3B_X2D_X2D_X20_X28),
+    /* K4   */  be_nested_str_weak(NAME),
+    /* K5   */  be_nested_str_weak(_X29_X20_X2D_X2D_X26gt_X3B),
     }),
     be_str_weak(web_values),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
+    ( &(const binstruction[ 9]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0303,  //  0004  GETMET	R3	R1	K3
-      0x88140105,  //  0005  GETMBR	R5	R0	K5
-      0x00160805,  //  0006  ADD	R5	K4	R5
-      0x00140B06,  //  0007  ADD	R5	R5	K6
-      0x7C0C0400,  //  0008  CALL	R3	2
-      0x80000000,  //  0009  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x88100104,  //  0004  GETMBR	R4	R0	K4
+      0x00120604,  //  0005  ADD	R4	K3	R4
+      0x00100905,  //  0006  ADD	R4	R4	K5
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80000000,  //  0008  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light0.h
@@ -139,7 +139,7 @@ be_local_closure(Matter_Plugin_Bridge_Light0_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Light0_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -147,68 +147,66 @@ be_local_closure(Matter_Plugin_Bridge_Light0_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(BOOL),
-    /* K9   */  be_nested_str_weak(shadow_onoff),
-    /* K10  */  be_nested_str_weak(U4),
-    /* K11  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(BOOL),
+    /* K8   */  be_nested_str_weak(shadow_onoff),
+    /* K9   */  be_nested_str_weak(U4),
+    /* K10  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[44]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0005,  //  0005  LDINT	R7	6
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E001B,  //  0007  JMPF	R7	#0024
-      0x8C1C0105,  //  0008  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x1C1C0D06,  //  000A  EQ	R7	R6	K6
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0907,  //  000C  GETMET	R7	R4	K7
-      0x88240908,  //  000D  GETMBR	R9	R4	K8
-      0x88280109,  //  000E  GETMBR	R10	R0	K9
-      0x7C1C0600,  //  000F  CALL	R7	3
-      0x80040E00,  //  0010  RET	1	R7
-      0x70020010,  //  0011  JMP		#0023
-      0x541EFFFB,  //  0012  LDINT	R7	65532
-      0x1C1C0C07,  //  0013  EQ	R7	R6	R7
-      0x781E0005,  //  0014  JMPF	R7	#001B
-      0x8C1C0907,  //  0015  GETMET	R7	R4	K7
-      0x8824090A,  //  0016  GETMBR	R9	R4	K10
-      0x58280006,  //  0017  LDCONST	R10	K6
-      0x7C1C0600,  //  0018  CALL	R7	3
-      0x80040E00,  //  0019  RET	1	R7
-      0x70020007,  //  001A  JMP		#0023
-      0x541EFFFC,  //  001B  LDINT	R7	65533
-      0x1C1C0C07,  //  001C  EQ	R7	R6	R7
-      0x781E0004,  //  001D  JMPF	R7	#0023
-      0x8C1C0907,  //  001E  GETMET	R7	R4	K7
-      0x8824090A,  //  001F  GETMBR	R9	R4	K10
-      0x542A0003,  //  0020  LDINT	R10	4
-      0x7C1C0600,  //  0021  CALL	R7	3
-      0x80040E00,  //  0022  RET	1	R7
-      0x70020007,  //  0023  JMP		#002C
-      0x601C0003,  //  0024  GETGBL	R7	G3
-      0x5C200000,  //  0025  MOVE	R8	R0
-      0x7C1C0200,  //  0026  CALL	R7	1
-      0x8C1C0F0B,  //  0027  GETMET	R7	R7	K11
-      0x5C240200,  //  0028  MOVE	R9	R1
-      0x5C280400,  //  0029  MOVE	R10	R2
-      0x7C1C0600,  //  002A  CALL	R7	3
-      0x80040E00,  //  002B  RET	1	R7
-      0x80000000,  //  002C  RET	0
+      0x541A0005,  //  0004  LDINT	R6	6
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A001B,  //  0006  JMPF	R6	#0023
+      0x8C180104,  //  0007  GETMET	R6	R0	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x1C180B05,  //  0009  EQ	R6	R5	K5
+      0x781A0005,  //  000A  JMPF	R6	#0011
+      0x8C180706,  //  000B  GETMET	R6	R3	K6
+      0x88200707,  //  000C  GETMBR	R8	R3	K7
+      0x88240108,  //  000D  GETMBR	R9	R0	K8
+      0x7C180600,  //  000E  CALL	R6	3
+      0x80040C00,  //  000F  RET	1	R6
+      0x70020010,  //  0010  JMP		#0022
+      0x541AFFFB,  //  0011  LDINT	R6	65532
+      0x1C180A06,  //  0012  EQ	R6	R5	R6
+      0x781A0005,  //  0013  JMPF	R6	#001A
+      0x8C180706,  //  0014  GETMET	R6	R3	K6
+      0x88200709,  //  0015  GETMBR	R8	R3	K9
+      0x58240005,  //  0016  LDCONST	R9	K5
+      0x7C180600,  //  0017  CALL	R6	3
+      0x80040C00,  //  0018  RET	1	R6
+      0x70020007,  //  0019  JMP		#0022
+      0x541AFFFC,  //  001A  LDINT	R6	65533
+      0x1C180A06,  //  001B  EQ	R6	R5	R6
+      0x781A0004,  //  001C  JMPF	R6	#0022
+      0x8C180706,  //  001D  GETMET	R6	R3	K6
+      0x88200709,  //  001E  GETMBR	R8	R3	K9
+      0x54260003,  //  001F  LDINT	R9	4
+      0x7C180600,  //  0020  CALL	R6	3
+      0x80040C00,  //  0021  RET	1	R6
+      0x70020007,  //  0022  JMP		#002B
+      0x60180003,  //  0023  GETGBL	R6	G3
+      0x5C1C0000,  //  0024  MOVE	R7	R0
+      0x7C180200,  //  0025  CALL	R6	1
+      0x8C180D0A,  //  0026  GETMET	R6	R6	K10
+      0x5C200200,  //  0027  MOVE	R8	R1
+      0x5C240400,  //  0028  MOVE	R9	R2
+      0x7C180600,  //  0029  CALL	R6	3
+      0x80040C00,  //  002A  RET	1	R6
+      0x80000000,  //  002B  RET	0
     })
   )
 );
@@ -364,7 +362,7 @@ be_local_closure(Matter_Plugin_Bridge_Light0_invoke_request,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Light0_web_values,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    9,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -372,32 +370,29 @@ be_local_closure(Matter_Plugin_Bridge_Light0_web_values,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(web_values_prefix),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(_X25s),
-    /* K6   */  be_nested_str_weak(web_value_onoff),
-    /* K7   */  be_nested_str_weak(shadow_onoff),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(_X25s),
+    /* K4   */  be_nested_str_weak(web_value_onoff),
+    /* K5   */  be_nested_str_weak(shadow_onoff),
     }),
     be_str_weak(web_values),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
+    ( &(const binstruction[12]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0303,  //  0004  GETMET	R3	R1	K3
-      0x8C140504,  //  0005  GETMET	R5	R2	K4
-      0x581C0005,  //  0006  LDCONST	R7	K5
-      0x8C200106,  //  0007  GETMET	R8	R0	K6
-      0x88280107,  //  0008  GETMBR	R10	R0	K7
-      0x7C200400,  //  0009  CALL	R8	2
-      0x7C140600,  //  000A  CALL	R5	3
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x80000000,  //  000C  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x60100018,  //  0004  GETGBL	R4	G24
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x8C180104,  //  0006  GETMET	R6	R0	K4
+      0x88200105,  //  0007  GETMBR	R8	R0	K5
+      0x7C180400,  //  0008  CALL	R6	2
+      0x7C100400,  //  0009  CALL	R4	2
+      0x7C080400,  //  000A  CALL	R2	2
+      0x80000000,  //  000B  RET	0
     })
   )
 );
@@ -409,7 +404,7 @@ be_local_closure(Matter_Plugin_Bridge_Light0_web_values,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Light0_web_values_prefix,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -417,44 +412,41 @@ be_local_closure(Matter_Plugin_Bridge_Light0_web_values_prefix,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(get_name),
-    /* K3   */  be_nested_str_weak(Power),
-    /* K4   */  be_nested_str_weak(tasmota_relay_index),
-    /* K5   */  be_nested_str_weak(content_send),
-    /* K6   */  be_nested_str_weak(format),
-    /* K7   */  be_nested_str_weak(PREFIX),
-    /* K8   */  be_nested_str_weak(html_escape),
-    /* K9   */  be_nested_str_weak(),
+    /* K1   */  be_nested_str_weak(get_name),
+    /* K2   */  be_nested_str_weak(Power),
+    /* K3   */  be_nested_str_weak(tasmota_relay_index),
+    /* K4   */  be_nested_str_weak(content_send),
+    /* K5   */  be_nested_str_weak(PREFIX),
+    /* K6   */  be_nested_str_weak(html_escape),
+    /* K7   */  be_nested_str_weak(),
     }),
     be_str_weak(web_values_prefix),
     &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
+    ( &(const binstruction[22]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x5C100600,  //  0004  MOVE	R4	R3
-      0x74120004,  //  0005  JMPT	R4	#000B
-      0x60100008,  //  0006  GETGBL	R4	G8
-      0x88140104,  //  0007  GETMBR	R5	R0	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x00120604,  //  0009  ADD	R4	K3	R4
-      0x5C0C0800,  //  000A  MOVE	R3	R4
-      0x8C100305,  //  000B  GETMET	R4	R1	K5
-      0x8C180506,  //  000C  GETMET	R6	R2	K6
-      0x88200107,  //  000D  GETMBR	R8	R0	K7
-      0x780E0003,  //  000E  JMPF	R3	#0013
-      0x8C240308,  //  000F  GETMET	R9	R1	K8
-      0x5C2C0600,  //  0010  MOVE	R11	R3
-      0x7C240400,  //  0011  CALL	R9	2
-      0x70020000,  //  0012  JMP		#0014
-      0x58240009,  //  0013  LDCONST	R9	K9
-      0x7C180600,  //  0014  CALL	R6	3
-      0x7C100400,  //  0015  CALL	R4	2
-      0x80000000,  //  0016  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x5C0C0400,  //  0003  MOVE	R3	R2
+      0x740E0004,  //  0004  JMPT	R3	#000A
+      0x600C0008,  //  0005  GETGBL	R3	G8
+      0x88100103,  //  0006  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x000E0403,  //  0008  ADD	R3	K2	R3
+      0x5C080600,  //  0009  MOVE	R2	R3
+      0x8C0C0304,  //  000A  GETMET	R3	R1	K4
+      0x60140018,  //  000B  GETGBL	R5	G24
+      0x88180105,  //  000C  GETMBR	R6	R0	K5
+      0x780A0003,  //  000D  JMPF	R2	#0012
+      0x8C1C0306,  //  000E  GETMET	R7	R1	K6
+      0x5C240400,  //  000F  MOVE	R9	R2
+      0x7C1C0400,  //  0010  CALL	R7	2
+      0x70020000,  //  0011  JMP		#0013
+      0x581C0007,  //  0012  LDCONST	R7	K7
+      0x7C140400,  //  0013  CALL	R5	2
+      0x7C0C0400,  //  0014  CALL	R3	2
+      0x80000000,  //  0015  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light1.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light1.h
@@ -139,7 +139,7 @@ be_local_closure(Matter_Plugin_Bridge_Light1_invoke_request,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Light1_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -147,126 +147,124 @@ be_local_closure(Matter_Plugin_Bridge_Light1_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(shadow_bri),
-    /* K8   */  be_nested_str_weak(create_TLV),
-    /* K9   */  be_nested_str_weak(U1),
-    /* K10  */  be_nested_str_weak(NULL),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(U4),
-    /* K14  */  be_const_int(1),
-    /* K15  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(shadow_bri),
+    /* K7   */  be_nested_str_weak(create_TLV),
+    /* K8   */  be_nested_str_weak(U1),
+    /* K9   */  be_nested_str_weak(NULL),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(U4),
+    /* K13  */  be_const_int(1),
+    /* K14  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[99]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[98]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0007,  //  0005  LDINT	R7	8
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0051,  //  0007  JMPF	R7	#005A
-      0x8C1C0105,  //  0008  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x1C1C0D06,  //  000A  EQ	R7	R6	K6
-      0x781E000F,  //  000B  JMPF	R7	#001C
-      0x881C0107,  //  000C  GETMBR	R7	R0	K7
-      0x4C200000,  //  000D  LDNIL	R8
-      0x201C0E08,  //  000E  NE	R7	R7	R8
-      0x781E0005,  //  000F  JMPF	R7	#0016
-      0x8C1C0908,  //  0010  GETMET	R7	R4	K8
-      0x88240909,  //  0011  GETMBR	R9	R4	K9
-      0x88280107,  //  0012  GETMBR	R10	R0	K7
-      0x7C1C0600,  //  0013  CALL	R7	3
-      0x80040E00,  //  0014  RET	1	R7
-      0x70020004,  //  0015  JMP		#001B
-      0x8C1C0908,  //  0016  GETMET	R7	R4	K8
-      0x8824090A,  //  0017  GETMBR	R9	R4	K10
-      0x4C280000,  //  0018  LDNIL	R10
-      0x7C1C0600,  //  0019  CALL	R7	3
-      0x80040E00,  //  001A  RET	1	R7
-      0x7002003C,  //  001B  JMP		#0059
-      0x1C1C0D0B,  //  001C  EQ	R7	R6	K11
-      0x781E0005,  //  001D  JMPF	R7	#0024
-      0x8C1C0908,  //  001E  GETMET	R7	R4	K8
-      0x88240909,  //  001F  GETMBR	R9	R4	K9
-      0x58280006,  //  0020  LDCONST	R10	K6
-      0x7C1C0600,  //  0021  CALL	R7	3
-      0x80040E00,  //  0022  RET	1	R7
-      0x70020034,  //  0023  JMP		#0059
-      0x1C1C0D0C,  //  0024  EQ	R7	R6	K12
-      0x781E0005,  //  0025  JMPF	R7	#002C
-      0x8C1C0908,  //  0026  GETMET	R7	R4	K8
-      0x88240909,  //  0027  GETMBR	R9	R4	K9
-      0x542A00FD,  //  0028  LDINT	R10	254
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x80040E00,  //  002A  RET	1	R7
-      0x7002002C,  //  002B  JMP		#0059
-      0x541E000E,  //  002C  LDINT	R7	15
-      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
-      0x781E0005,  //  002E  JMPF	R7	#0035
-      0x8C1C0908,  //  002F  GETMET	R7	R4	K8
-      0x88240909,  //  0030  GETMBR	R9	R4	K9
-      0x58280006,  //  0031  LDCONST	R10	K6
-      0x7C1C0600,  //  0032  CALL	R7	3
-      0x80040E00,  //  0033  RET	1	R7
-      0x70020023,  //  0034  JMP		#0059
-      0x541E0010,  //  0035  LDINT	R7	17
-      0x1C1C0C07,  //  0036  EQ	R7	R6	R7
-      0x781E000F,  //  0037  JMPF	R7	#0048
-      0x881C0107,  //  0038  GETMBR	R7	R0	K7
-      0x4C200000,  //  0039  LDNIL	R8
-      0x201C0E08,  //  003A  NE	R7	R7	R8
-      0x781E0005,  //  003B  JMPF	R7	#0042
-      0x8C1C0908,  //  003C  GETMET	R7	R4	K8
-      0x88240909,  //  003D  GETMBR	R9	R4	K9
-      0x88280107,  //  003E  GETMBR	R10	R0	K7
-      0x7C1C0600,  //  003F  CALL	R7	3
-      0x80040E00,  //  0040  RET	1	R7
-      0x70020004,  //  0041  JMP		#0047
-      0x8C1C0908,  //  0042  GETMET	R7	R4	K8
-      0x8824090A,  //  0043  GETMBR	R9	R4	K10
-      0x4C280000,  //  0044  LDNIL	R10
-      0x7C1C0600,  //  0045  CALL	R7	3
-      0x80040E00,  //  0046  RET	1	R7
-      0x70020010,  //  0047  JMP		#0059
-      0x541EFFFB,  //  0048  LDINT	R7	65532
-      0x1C1C0C07,  //  0049  EQ	R7	R6	R7
-      0x781E0005,  //  004A  JMPF	R7	#0051
-      0x8C1C0908,  //  004B  GETMET	R7	R4	K8
-      0x8824090D,  //  004C  GETMBR	R9	R4	K13
-      0x5828000E,  //  004D  LDCONST	R10	K14
-      0x7C1C0600,  //  004E  CALL	R7	3
-      0x80040E00,  //  004F  RET	1	R7
-      0x70020007,  //  0050  JMP		#0059
-      0x541EFFFC,  //  0051  LDINT	R7	65533
-      0x1C1C0C07,  //  0052  EQ	R7	R6	R7
-      0x781E0004,  //  0053  JMPF	R7	#0059
-      0x8C1C0908,  //  0054  GETMET	R7	R4	K8
-      0x8824090D,  //  0055  GETMBR	R9	R4	K13
-      0x542A0004,  //  0056  LDINT	R10	5
-      0x7C1C0600,  //  0057  CALL	R7	3
-      0x80040E00,  //  0058  RET	1	R7
-      0x70020007,  //  0059  JMP		#0062
-      0x601C0003,  //  005A  GETGBL	R7	G3
-      0x5C200000,  //  005B  MOVE	R8	R0
-      0x7C1C0200,  //  005C  CALL	R7	1
-      0x8C1C0F0F,  //  005D  GETMET	R7	R7	K15
-      0x5C240200,  //  005E  MOVE	R9	R1
-      0x5C280400,  //  005F  MOVE	R10	R2
-      0x7C1C0600,  //  0060  CALL	R7	3
-      0x80040E00,  //  0061  RET	1	R7
-      0x80000000,  //  0062  RET	0
+      0x541A0007,  //  0004  LDINT	R6	8
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0051,  //  0006  JMPF	R6	#0059
+      0x8C180104,  //  0007  GETMET	R6	R0	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x1C180B05,  //  0009  EQ	R6	R5	K5
+      0x781A000F,  //  000A  JMPF	R6	#001B
+      0x88180106,  //  000B  GETMBR	R6	R0	K6
+      0x4C1C0000,  //  000C  LDNIL	R7
+      0x20180C07,  //  000D  NE	R6	R6	R7
+      0x781A0005,  //  000E  JMPF	R6	#0015
+      0x8C180707,  //  000F  GETMET	R6	R3	K7
+      0x88200708,  //  0010  GETMBR	R8	R3	K8
+      0x88240106,  //  0011  GETMBR	R9	R0	K6
+      0x7C180600,  //  0012  CALL	R6	3
+      0x80040C00,  //  0013  RET	1	R6
+      0x70020004,  //  0014  JMP		#001A
+      0x8C180707,  //  0015  GETMET	R6	R3	K7
+      0x88200709,  //  0016  GETMBR	R8	R3	K9
+      0x4C240000,  //  0017  LDNIL	R9
+      0x7C180600,  //  0018  CALL	R6	3
+      0x80040C00,  //  0019  RET	1	R6
+      0x7002003C,  //  001A  JMP		#0058
+      0x1C180B0A,  //  001B  EQ	R6	R5	K10
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C180707,  //  001D  GETMET	R6	R3	K7
+      0x88200708,  //  001E  GETMBR	R8	R3	K8
+      0x58240005,  //  001F  LDCONST	R9	K5
+      0x7C180600,  //  0020  CALL	R6	3
+      0x80040C00,  //  0021  RET	1	R6
+      0x70020034,  //  0022  JMP		#0058
+      0x1C180B0B,  //  0023  EQ	R6	R5	K11
+      0x781A0005,  //  0024  JMPF	R6	#002B
+      0x8C180707,  //  0025  GETMET	R6	R3	K7
+      0x88200708,  //  0026  GETMBR	R8	R3	K8
+      0x542600FD,  //  0027  LDINT	R9	254
+      0x7C180600,  //  0028  CALL	R6	3
+      0x80040C00,  //  0029  RET	1	R6
+      0x7002002C,  //  002A  JMP		#0058
+      0x541A000E,  //  002B  LDINT	R6	15
+      0x1C180A06,  //  002C  EQ	R6	R5	R6
+      0x781A0005,  //  002D  JMPF	R6	#0034
+      0x8C180707,  //  002E  GETMET	R6	R3	K7
+      0x88200708,  //  002F  GETMBR	R8	R3	K8
+      0x58240005,  //  0030  LDCONST	R9	K5
+      0x7C180600,  //  0031  CALL	R6	3
+      0x80040C00,  //  0032  RET	1	R6
+      0x70020023,  //  0033  JMP		#0058
+      0x541A0010,  //  0034  LDINT	R6	17
+      0x1C180A06,  //  0035  EQ	R6	R5	R6
+      0x781A000F,  //  0036  JMPF	R6	#0047
+      0x88180106,  //  0037  GETMBR	R6	R0	K6
+      0x4C1C0000,  //  0038  LDNIL	R7
+      0x20180C07,  //  0039  NE	R6	R6	R7
+      0x781A0005,  //  003A  JMPF	R6	#0041
+      0x8C180707,  //  003B  GETMET	R6	R3	K7
+      0x88200708,  //  003C  GETMBR	R8	R3	K8
+      0x88240106,  //  003D  GETMBR	R9	R0	K6
+      0x7C180600,  //  003E  CALL	R6	3
+      0x80040C00,  //  003F  RET	1	R6
+      0x70020004,  //  0040  JMP		#0046
+      0x8C180707,  //  0041  GETMET	R6	R3	K7
+      0x88200709,  //  0042  GETMBR	R8	R3	K9
+      0x4C240000,  //  0043  LDNIL	R9
+      0x7C180600,  //  0044  CALL	R6	3
+      0x80040C00,  //  0045  RET	1	R6
+      0x70020010,  //  0046  JMP		#0058
+      0x541AFFFB,  //  0047  LDINT	R6	65532
+      0x1C180A06,  //  0048  EQ	R6	R5	R6
+      0x781A0005,  //  0049  JMPF	R6	#0050
+      0x8C180707,  //  004A  GETMET	R6	R3	K7
+      0x8820070C,  //  004B  GETMBR	R8	R3	K12
+      0x5824000D,  //  004C  LDCONST	R9	K13
+      0x7C180600,  //  004D  CALL	R6	3
+      0x80040C00,  //  004E  RET	1	R6
+      0x70020007,  //  004F  JMP		#0058
+      0x541AFFFC,  //  0050  LDINT	R6	65533
+      0x1C180A06,  //  0051  EQ	R6	R5	R6
+      0x781A0004,  //  0052  JMPF	R6	#0058
+      0x8C180707,  //  0053  GETMET	R6	R3	K7
+      0x8820070C,  //  0054  GETMBR	R8	R3	K12
+      0x54260004,  //  0055  LDINT	R9	5
+      0x7C180600,  //  0056  CALL	R6	3
+      0x80040C00,  //  0057  RET	1	R6
+      0x70020007,  //  0058  JMP		#0061
+      0x60180003,  //  0059  GETGBL	R6	G3
+      0x5C1C0000,  //  005A  MOVE	R7	R0
+      0x7C180200,  //  005B  CALL	R6	1
+      0x8C180D0E,  //  005C  GETMET	R6	R6	K14
+      0x5C200200,  //  005D  MOVE	R8	R1
+      0x5C240400,  //  005E  MOVE	R9	R2
+      0x7C180600,  //  005F  CALL	R6	3
+      0x80040C00,  //  0060  RET	1	R6
+      0x80000000,  //  0061  RET	0
     })
   )
 );
@@ -278,7 +276,7 @@ be_local_closure(Matter_Plugin_Bridge_Light1_read_attribute,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Light1_web_values,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    9,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -286,35 +284,32 @@ be_local_closure(Matter_Plugin_Bridge_Light1_web_values,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(web_values_prefix),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(_X25s_X20_X25s),
-    /* K6   */  be_nested_str_weak(web_value_onoff),
-    /* K7   */  be_nested_str_weak(shadow_onoff),
-    /* K8   */  be_nested_str_weak(web_value_dimmer),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(_X25s_X20_X25s),
+    /* K4   */  be_nested_str_weak(web_value_onoff),
+    /* K5   */  be_nested_str_weak(shadow_onoff),
+    /* K6   */  be_nested_str_weak(web_value_dimmer),
     }),
     be_str_weak(web_values),
     &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
+    ( &(const binstruction[14]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0303,  //  0004  GETMET	R3	R1	K3
-      0x8C140504,  //  0005  GETMET	R5	R2	K4
-      0x581C0005,  //  0006  LDCONST	R7	K5
-      0x8C200106,  //  0007  GETMET	R8	R0	K6
-      0x88280107,  //  0008  GETMBR	R10	R0	K7
-      0x7C200400,  //  0009  CALL	R8	2
-      0x8C240108,  //  000A  GETMET	R9	R0	K8
-      0x7C240200,  //  000B  CALL	R9	1
-      0x7C140800,  //  000C  CALL	R5	4
-      0x7C0C0400,  //  000D  CALL	R3	2
-      0x80000000,  //  000E  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x60100018,  //  0004  GETGBL	R4	G24
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x8C180104,  //  0006  GETMET	R6	R0	K4
+      0x88200105,  //  0007  GETMBR	R8	R0	K5
+      0x7C180400,  //  0008  CALL	R6	2
+      0x8C1C0106,  //  0009  GETMET	R7	R0	K6
+      0x7C1C0200,  //  000A  CALL	R7	1
+      0x7C100600,  //  000B  CALL	R4	3
+      0x7C080400,  //  000C  CALL	R2	2
+      0x80000000,  //  000D  RET	0
     })
   )
 );
@@ -445,7 +440,7 @@ be_local_closure(Matter_Plugin_Bridge_Light1_parse_update,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Light1_web_value_dimmer,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -453,41 +448,38 @@ be_local_closure(Matter_Plugin_Bridge_Light1_web_value_dimmer,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(),
-    /* K2   */  be_nested_str_weak(shadow_bri),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(scale_uint),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(format),
-    /* K7   */  be_nested_str_weak(_X25i_X25_X25),
-    /* K8   */  be_nested_str_weak(_X26_X23128261_X3B_X20),
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(),
+    /* K1   */  be_nested_str_weak(shadow_bri),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(scale_uint),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(_X25i_X25_X25),
+    /* K6   */  be_nested_str_weak(_X26_X23128261_X3B_X20),
     }),
     be_str_weak(web_value_dimmer),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x58080001,  //  0001  LDCONST	R2	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x4C100000,  //  0003  LDNIL	R4
-      0x200C0604,  //  0004  NE	R3	R3	R4
-      0x780E000C,  //  0005  JMPF	R3	#0013
-      0xB80E0600,  //  0006  GETNGBL	R3	K3
-      0x8C0C0704,  //  0007  GETMET	R3	R3	K4
-      0x88140102,  //  0008  GETMBR	R5	R0	K2
-      0x58180005,  //  0009  LDCONST	R6	K5
-      0x541E00FD,  //  000A  LDINT	R7	254
-      0x58200005,  //  000B  LDCONST	R8	K5
-      0x54260063,  //  000C  LDINT	R9	100
-      0x7C0C0C00,  //  000D  CALL	R3	6
-      0x8C100306,  //  000E  GETMET	R4	R1	K6
-      0x58180007,  //  000F  LDCONST	R6	K7
-      0x5C1C0600,  //  0010  MOVE	R7	R3
-      0x7C100600,  //  0011  CALL	R4	3
-      0x5C080800,  //  0012  MOVE	R2	R4
-      0x000E1002,  //  0013  ADD	R3	K8	R2
-      0x80040600,  //  0014  RET	1	R3
+    ( &(const binstruction[20]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x20080403,  //  0003  NE	R2	R2	R3
+      0x780A000C,  //  0004  JMPF	R2	#0012
+      0xB80A0400,  //  0005  GETNGBL	R2	K2
+      0x8C080503,  //  0006  GETMET	R2	R2	K3
+      0x88100101,  //  0007  GETMBR	R4	R0	K1
+      0x58140004,  //  0008  LDCONST	R5	K4
+      0x541A00FD,  //  0009  LDINT	R6	254
+      0x581C0004,  //  000A  LDCONST	R7	K4
+      0x54220063,  //  000B  LDINT	R8	100
+      0x7C080C00,  //  000C  CALL	R2	6
+      0x600C0018,  //  000D  GETGBL	R3	G24
+      0x58100005,  //  000E  LDCONST	R4	K5
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x5C040600,  //  0011  MOVE	R1	R3
+      0x000A0C01,  //  0012  ADD	R2	K6	R1
+      0x80040400,  //  0013  RET	1	R2
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light2.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light2.h
@@ -114,7 +114,7 @@ be_local_closure(Matter_Plugin_Bridge_Light2_parse_update,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Light2_web_values,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -122,38 +122,35 @@ be_local_closure(Matter_Plugin_Bridge_Light2_web_values,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(web_values_prefix),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(_X25s_X20_X25s_X20_X25s),
-    /* K6   */  be_nested_str_weak(web_value_onoff),
-    /* K7   */  be_nested_str_weak(shadow_onoff),
-    /* K8   */  be_nested_str_weak(web_value_dimmer),
-    /* K9   */  be_nested_str_weak(web_value_ct),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(_X25s_X20_X25s_X20_X25s),
+    /* K4   */  be_nested_str_weak(web_value_onoff),
+    /* K5   */  be_nested_str_weak(shadow_onoff),
+    /* K6   */  be_nested_str_weak(web_value_dimmer),
+    /* K7   */  be_nested_str_weak(web_value_ct),
     }),
     be_str_weak(web_values),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
+    ( &(const binstruction[16]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0303,  //  0004  GETMET	R3	R1	K3
-      0x8C140504,  //  0005  GETMET	R5	R2	K4
-      0x581C0005,  //  0006  LDCONST	R7	K5
-      0x8C200106,  //  0007  GETMET	R8	R0	K6
-      0x88280107,  //  0008  GETMBR	R10	R0	K7
-      0x7C200400,  //  0009  CALL	R8	2
-      0x8C240108,  //  000A  GETMET	R9	R0	K8
-      0x7C240200,  //  000B  CALL	R9	1
-      0x8C280109,  //  000C  GETMET	R10	R0	K9
-      0x7C280200,  //  000D  CALL	R10	1
-      0x7C140A00,  //  000E  CALL	R5	5
-      0x7C0C0400,  //  000F  CALL	R3	2
-      0x80000000,  //  0010  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x60100018,  //  0004  GETGBL	R4	G24
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x8C180104,  //  0006  GETMET	R6	R0	K4
+      0x88200105,  //  0007  GETMBR	R8	R0	K5
+      0x7C180400,  //  0008  CALL	R6	2
+      0x8C1C0106,  //  0009  GETMET	R7	R0	K6
+      0x7C1C0200,  //  000A  CALL	R7	1
+      0x8C200107,  //  000B  GETMET	R8	R0	K7
+      0x7C200200,  //  000C  CALL	R8	1
+      0x7C100800,  //  000D  CALL	R4	4
+      0x7C080400,  //  000E  CALL	R2	2
+      0x80000000,  //  000F  RET	0
     })
   )
 );
@@ -165,7 +162,7 @@ be_local_closure(Matter_Plugin_Bridge_Light2_web_values,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Light2_web_value_ct,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -173,39 +170,36 @@ be_local_closure(Matter_Plugin_Bridge_Light2_web_value_ct,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(),
-    /* K2   */  be_nested_str_weak(shadow_ct),
-    /* K3   */  be_const_int(1000000),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(_X25iK),
-    /* K6   */  be_nested_str_weak(_X26_X239898_X3B_X20),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(),
+    /* K1   */  be_nested_str_weak(shadow_ct),
+    /* K2   */  be_const_int(1000000),
+    /* K3   */  be_nested_str_weak(_X25iK),
+    /* K4   */  be_nested_str_weak(_X26_X239898_X3B_X20),
     }),
     be_str_weak(web_value_ct),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x58080001,  //  0001  LDCONST	R2	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x4C100000,  //  0003  LDNIL	R4
-      0x200C0604,  //  0004  NE	R3	R3	R4
-      0x780E000C,  //  0005  JMPF	R3	#0013
-      0x880C0102,  //  0006  GETMBR	R3	R0	K2
-      0x0C0E0603,  //  0007  DIV	R3	K3	R3
-      0x54120018,  //  0008  LDINT	R4	25
-      0x000C0604,  //  0009  ADD	R3	R3	R4
-      0x54120031,  //  000A  LDINT	R4	50
-      0x0C0C0604,  //  000B  DIV	R3	R3	R4
-      0x54120031,  //  000C  LDINT	R4	50
-      0x080C0604,  //  000D  MUL	R3	R3	R4
-      0x8C100304,  //  000E  GETMET	R4	R1	K4
-      0x58180005,  //  000F  LDCONST	R6	K5
-      0x5C1C0600,  //  0010  MOVE	R7	R3
-      0x7C100600,  //  0011  CALL	R4	3
-      0x5C080800,  //  0012  MOVE	R2	R4
-      0x000E0C02,  //  0013  ADD	R3	K6	R2
-      0x80040600,  //  0014  RET	1	R3
+    ( &(const binstruction[20]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x20080403,  //  0003  NE	R2	R2	R3
+      0x780A000C,  //  0004  JMPF	R2	#0012
+      0x88080101,  //  0005  GETMBR	R2	R0	K1
+      0x0C0A0402,  //  0006  DIV	R2	K2	R2
+      0x540E0018,  //  0007  LDINT	R3	25
+      0x00080403,  //  0008  ADD	R2	R2	R3
+      0x540E0031,  //  0009  LDINT	R3	50
+      0x0C080403,  //  000A  DIV	R2	R2	R3
+      0x540E0031,  //  000B  LDINT	R3	50
+      0x08080403,  //  000C  MUL	R2	R2	R3
+      0x600C0018,  //  000D  GETGBL	R3	G24
+      0x58100003,  //  000E  LDCONST	R4	K3
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x5C040600,  //  0011  MOVE	R1	R3
+      0x000A0801,  //  0012  ADD	R2	K4	R1
+      0x80040400,  //  0013  RET	1	R2
     })
   )
 );
@@ -400,7 +394,7 @@ be_local_closure(Matter_Plugin_Bridge_Light2_update_ct_minmax,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Light2_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -408,128 +402,126 @@ be_local_closure(Matter_Plugin_Bridge_Light2_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_nested_str_weak(shadow_ct),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(U1),
-    /* K9   */  be_nested_str_weak(NULL),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(ct_min),
-    /* K13  */  be_nested_str_weak(ct_max),
-    /* K14  */  be_nested_str_weak(U4),
-    /* K15  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_nested_str_weak(shadow_ct),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(U1),
+    /* K8   */  be_nested_str_weak(NULL),
+    /* K9   */  be_const_int(2),
+    /* K10  */  be_const_int(0),
+    /* K11  */  be_nested_str_weak(ct_min),
+    /* K12  */  be_nested_str_weak(ct_max),
+    /* K13  */  be_nested_str_weak(U4),
+    /* K14  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[101]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[100]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E02FF,  //  0005  LDINT	R7	768
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0053,  //  0007  JMPF	R7	#005C
-      0x8C1C0105,  //  0008  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x541E0006,  //  000A  LDINT	R7	7
-      0x1C1C0C07,  //  000B  EQ	R7	R6	R7
-      0x781E000F,  //  000C  JMPF	R7	#001D
-      0x881C0106,  //  000D  GETMBR	R7	R0	K6
-      0x4C200000,  //  000E  LDNIL	R8
-      0x201C0E08,  //  000F  NE	R7	R7	R8
-      0x781E0005,  //  0010  JMPF	R7	#0017
-      0x8C1C0907,  //  0011  GETMET	R7	R4	K7
-      0x88240908,  //  0012  GETMBR	R9	R4	K8
-      0x88280106,  //  0013  GETMBR	R10	R0	K6
-      0x7C1C0600,  //  0014  CALL	R7	3
-      0x80040E00,  //  0015  RET	1	R7
-      0x70020004,  //  0016  JMP		#001C
-      0x8C1C0907,  //  0017  GETMET	R7	R4	K7
-      0x88240909,  //  0018  GETMBR	R9	R4	K9
-      0x4C280000,  //  0019  LDNIL	R10
-      0x7C1C0600,  //  001A  CALL	R7	3
-      0x80040E00,  //  001B  RET	1	R7
-      0x7002003D,  //  001C  JMP		#005B
-      0x541E0007,  //  001D  LDINT	R7	8
-      0x1C1C0C07,  //  001E  EQ	R7	R6	R7
-      0x781E0005,  //  001F  JMPF	R7	#0026
-      0x8C1C0907,  //  0020  GETMET	R7	R4	K7
-      0x88240908,  //  0021  GETMBR	R9	R4	K8
-      0x5828000A,  //  0022  LDCONST	R10	K10
-      0x7C1C0600,  //  0023  CALL	R7	3
-      0x80040E00,  //  0024  RET	1	R7
-      0x70020034,  //  0025  JMP		#005B
-      0x541E000E,  //  0026  LDINT	R7	15
-      0x1C1C0C07,  //  0027  EQ	R7	R6	R7
-      0x781E0005,  //  0028  JMPF	R7	#002F
-      0x8C1C0907,  //  0029  GETMET	R7	R4	K7
-      0x88240908,  //  002A  GETMBR	R9	R4	K8
-      0x5828000B,  //  002B  LDCONST	R10	K11
-      0x7C1C0600,  //  002C  CALL	R7	3
-      0x80040E00,  //  002D  RET	1	R7
-      0x7002002B,  //  002E  JMP		#005B
-      0x541E400A,  //  002F  LDINT	R7	16395
-      0x1C1C0C07,  //  0030  EQ	R7	R6	R7
-      0x781E0005,  //  0031  JMPF	R7	#0038
-      0x8C1C0907,  //  0032  GETMET	R7	R4	K7
-      0x88240908,  //  0033  GETMBR	R9	R4	K8
-      0x8828010C,  //  0034  GETMBR	R10	R0	K12
-      0x7C1C0600,  //  0035  CALL	R7	3
-      0x80040E00,  //  0036  RET	1	R7
-      0x70020022,  //  0037  JMP		#005B
-      0x541E400B,  //  0038  LDINT	R7	16396
-      0x1C1C0C07,  //  0039  EQ	R7	R6	R7
-      0x781E0005,  //  003A  JMPF	R7	#0041
-      0x8C1C0907,  //  003B  GETMET	R7	R4	K7
-      0x88240908,  //  003C  GETMBR	R9	R4	K8
-      0x8828010D,  //  003D  GETMBR	R10	R0	K13
-      0x7C1C0600,  //  003E  CALL	R7	3
-      0x80040E00,  //  003F  RET	1	R7
-      0x70020019,  //  0040  JMP		#005B
-      0x541E4009,  //  0041  LDINT	R7	16394
-      0x1C1C0C07,  //  0042  EQ	R7	R6	R7
-      0x781E0005,  //  0043  JMPF	R7	#004A
-      0x8C1C0907,  //  0044  GETMET	R7	R4	K7
-      0x8824090E,  //  0045  GETMBR	R9	R4	K14
-      0x542A000F,  //  0046  LDINT	R10	16
-      0x7C1C0600,  //  0047  CALL	R7	3
-      0x80040E00,  //  0048  RET	1	R7
-      0x70020010,  //  0049  JMP		#005B
-      0x541EFFFB,  //  004A  LDINT	R7	65532
-      0x1C1C0C07,  //  004B  EQ	R7	R6	R7
-      0x781E0005,  //  004C  JMPF	R7	#0053
-      0x8C1C0907,  //  004D  GETMET	R7	R4	K7
-      0x8824090E,  //  004E  GETMBR	R9	R4	K14
-      0x542A000F,  //  004F  LDINT	R10	16
-      0x7C1C0600,  //  0050  CALL	R7	3
-      0x80040E00,  //  0051  RET	1	R7
-      0x70020007,  //  0052  JMP		#005B
-      0x541EFFFC,  //  0053  LDINT	R7	65533
-      0x1C1C0C07,  //  0054  EQ	R7	R6	R7
-      0x781E0004,  //  0055  JMPF	R7	#005B
-      0x8C1C0907,  //  0056  GETMET	R7	R4	K7
-      0x8824090E,  //  0057  GETMBR	R9	R4	K14
-      0x542A0004,  //  0058  LDINT	R10	5
-      0x7C1C0600,  //  0059  CALL	R7	3
-      0x80040E00,  //  005A  RET	1	R7
-      0x70020007,  //  005B  JMP		#0064
-      0x601C0003,  //  005C  GETGBL	R7	G3
-      0x5C200000,  //  005D  MOVE	R8	R0
-      0x7C1C0200,  //  005E  CALL	R7	1
-      0x8C1C0F0F,  //  005F  GETMET	R7	R7	K15
-      0x5C240200,  //  0060  MOVE	R9	R1
-      0x5C280400,  //  0061  MOVE	R10	R2
-      0x7C1C0600,  //  0062  CALL	R7	3
-      0x80040E00,  //  0063  RET	1	R7
-      0x80000000,  //  0064  RET	0
+      0x541A02FF,  //  0004  LDINT	R6	768
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0053,  //  0006  JMPF	R6	#005B
+      0x8C180104,  //  0007  GETMET	R6	R0	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x541A0006,  //  0009  LDINT	R6	7
+      0x1C180A06,  //  000A  EQ	R6	R5	R6
+      0x781A000F,  //  000B  JMPF	R6	#001C
+      0x88180105,  //  000C  GETMBR	R6	R0	K5
+      0x4C1C0000,  //  000D  LDNIL	R7
+      0x20180C07,  //  000E  NE	R6	R6	R7
+      0x781A0005,  //  000F  JMPF	R6	#0016
+      0x8C180706,  //  0010  GETMET	R6	R3	K6
+      0x88200707,  //  0011  GETMBR	R8	R3	K7
+      0x88240105,  //  0012  GETMBR	R9	R0	K5
+      0x7C180600,  //  0013  CALL	R6	3
+      0x80040C00,  //  0014  RET	1	R6
+      0x70020004,  //  0015  JMP		#001B
+      0x8C180706,  //  0016  GETMET	R6	R3	K6
+      0x88200708,  //  0017  GETMBR	R8	R3	K8
+      0x4C240000,  //  0018  LDNIL	R9
+      0x7C180600,  //  0019  CALL	R6	3
+      0x80040C00,  //  001A  RET	1	R6
+      0x7002003D,  //  001B  JMP		#005A
+      0x541A0007,  //  001C  LDINT	R6	8
+      0x1C180A06,  //  001D  EQ	R6	R5	R6
+      0x781A0005,  //  001E  JMPF	R6	#0025
+      0x8C180706,  //  001F  GETMET	R6	R3	K6
+      0x88200707,  //  0020  GETMBR	R8	R3	K7
+      0x58240009,  //  0021  LDCONST	R9	K9
+      0x7C180600,  //  0022  CALL	R6	3
+      0x80040C00,  //  0023  RET	1	R6
+      0x70020034,  //  0024  JMP		#005A
+      0x541A000E,  //  0025  LDINT	R6	15
+      0x1C180A06,  //  0026  EQ	R6	R5	R6
+      0x781A0005,  //  0027  JMPF	R6	#002E
+      0x8C180706,  //  0028  GETMET	R6	R3	K6
+      0x88200707,  //  0029  GETMBR	R8	R3	K7
+      0x5824000A,  //  002A  LDCONST	R9	K10
+      0x7C180600,  //  002B  CALL	R6	3
+      0x80040C00,  //  002C  RET	1	R6
+      0x7002002B,  //  002D  JMP		#005A
+      0x541A400A,  //  002E  LDINT	R6	16395
+      0x1C180A06,  //  002F  EQ	R6	R5	R6
+      0x781A0005,  //  0030  JMPF	R6	#0037
+      0x8C180706,  //  0031  GETMET	R6	R3	K6
+      0x88200707,  //  0032  GETMBR	R8	R3	K7
+      0x8824010B,  //  0033  GETMBR	R9	R0	K11
+      0x7C180600,  //  0034  CALL	R6	3
+      0x80040C00,  //  0035  RET	1	R6
+      0x70020022,  //  0036  JMP		#005A
+      0x541A400B,  //  0037  LDINT	R6	16396
+      0x1C180A06,  //  0038  EQ	R6	R5	R6
+      0x781A0005,  //  0039  JMPF	R6	#0040
+      0x8C180706,  //  003A  GETMET	R6	R3	K6
+      0x88200707,  //  003B  GETMBR	R8	R3	K7
+      0x8824010C,  //  003C  GETMBR	R9	R0	K12
+      0x7C180600,  //  003D  CALL	R6	3
+      0x80040C00,  //  003E  RET	1	R6
+      0x70020019,  //  003F  JMP		#005A
+      0x541A4009,  //  0040  LDINT	R6	16394
+      0x1C180A06,  //  0041  EQ	R6	R5	R6
+      0x781A0005,  //  0042  JMPF	R6	#0049
+      0x8C180706,  //  0043  GETMET	R6	R3	K6
+      0x8820070D,  //  0044  GETMBR	R8	R3	K13
+      0x5426000F,  //  0045  LDINT	R9	16
+      0x7C180600,  //  0046  CALL	R6	3
+      0x80040C00,  //  0047  RET	1	R6
+      0x70020010,  //  0048  JMP		#005A
+      0x541AFFFB,  //  0049  LDINT	R6	65532
+      0x1C180A06,  //  004A  EQ	R6	R5	R6
+      0x781A0005,  //  004B  JMPF	R6	#0052
+      0x8C180706,  //  004C  GETMET	R6	R3	K6
+      0x8820070D,  //  004D  GETMBR	R8	R3	K13
+      0x5426000F,  //  004E  LDINT	R9	16
+      0x7C180600,  //  004F  CALL	R6	3
+      0x80040C00,  //  0050  RET	1	R6
+      0x70020007,  //  0051  JMP		#005A
+      0x541AFFFC,  //  0052  LDINT	R6	65533
+      0x1C180A06,  //  0053  EQ	R6	R5	R6
+      0x781A0004,  //  0054  JMPF	R6	#005A
+      0x8C180706,  //  0055  GETMET	R6	R3	K6
+      0x8820070D,  //  0056  GETMBR	R8	R3	K13
+      0x54260004,  //  0057  LDINT	R9	5
+      0x7C180600,  //  0058  CALL	R6	3
+      0x80040C00,  //  0059  RET	1	R6
+      0x70020007,  //  005A  JMP		#0063
+      0x60180003,  //  005B  GETGBL	R6	G3
+      0x5C1C0000,  //  005C  MOVE	R7	R0
+      0x7C180200,  //  005D  CALL	R6	1
+      0x8C180D0E,  //  005E  GETMET	R6	R6	K14
+      0x5C200200,  //  005F  MOVE	R8	R1
+      0x5C240400,  //  0060  MOVE	R9	R2
+      0x7C180600,  //  0061  CALL	R6	3
+      0x80040C00,  //  0062  RET	1	R6
+      0x80000000,  //  0063  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light3.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light3.h
@@ -168,7 +168,7 @@ be_local_closure(Matter_Plugin_Bridge_Light3_parse_update,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Light3_web_values,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -176,38 +176,35 @@ be_local_closure(Matter_Plugin_Bridge_Light3_web_values,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(web_values_prefix),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(_X25s_X20_X25s_X20_X25s),
-    /* K6   */  be_nested_str_weak(web_value_onoff),
-    /* K7   */  be_nested_str_weak(shadow_onoff),
-    /* K8   */  be_nested_str_weak(web_value_dimmer),
-    /* K9   */  be_nested_str_weak(web_value_RGB),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(_X25s_X20_X25s_X20_X25s),
+    /* K4   */  be_nested_str_weak(web_value_onoff),
+    /* K5   */  be_nested_str_weak(shadow_onoff),
+    /* K6   */  be_nested_str_weak(web_value_dimmer),
+    /* K7   */  be_nested_str_weak(web_value_RGB),
     }),
     be_str_weak(web_values),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
+    ( &(const binstruction[16]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0303,  //  0004  GETMET	R3	R1	K3
-      0x8C140504,  //  0005  GETMET	R5	R2	K4
-      0x581C0005,  //  0006  LDCONST	R7	K5
-      0x8C200106,  //  0007  GETMET	R8	R0	K6
-      0x88280107,  //  0008  GETMBR	R10	R0	K7
-      0x7C200400,  //  0009  CALL	R8	2
-      0x8C240108,  //  000A  GETMET	R9	R0	K8
-      0x7C240200,  //  000B  CALL	R9	1
-      0x8C280109,  //  000C  GETMET	R10	R0	K9
-      0x7C280200,  //  000D  CALL	R10	1
-      0x7C140A00,  //  000E  CALL	R5	5
-      0x7C0C0400,  //  000F  CALL	R3	2
-      0x80000000,  //  0010  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x60100018,  //  0004  GETGBL	R4	G24
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x8C180104,  //  0006  GETMET	R6	R0	K4
+      0x88200105,  //  0007  GETMBR	R8	R0	K5
+      0x7C180400,  //  0008  CALL	R6	2
+      0x8C1C0106,  //  0009  GETMET	R7	R0	K6
+      0x7C1C0200,  //  000A  CALL	R7	1
+      0x8C200107,  //  000B  GETMET	R8	R0	K7
+      0x7C200200,  //  000C  CALL	R8	1
+      0x7C100800,  //  000D  CALL	R4	4
+      0x7C080400,  //  000E  CALL	R2	2
+      0x80000000,  //  000F  RET	0
     })
   )
 );
@@ -219,7 +216,7 @@ be_local_closure(Matter_Plugin_Bridge_Light3_web_values,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Light3_web_value_RGB,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    12,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -227,74 +224,71 @@ be_local_closure(Matter_Plugin_Bridge_Light3_web_value_RGB,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(shadow_hue),
-    /* K2   */  be_nested_str_weak(shadow_sat),
-    /* K3   */  be_nested_str_weak(light_state),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(set_bri),
-    /* K6   */  be_nested_str_weak(set_huesat),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(scale_uint),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(format),
-    /* K11  */  be_nested_str_weak(_X23_X2502X_X2502X_X2502X),
-    /* K12  */  be_nested_str_weak(r),
-    /* K13  */  be_nested_str_weak(g),
-    /* K14  */  be_nested_str_weak(b),
-    /* K15  */  be_nested_str_weak(_X3Ci_X20class_X3D_X22bxm_X22_X20style_X3D_X22_X2D_X2Dcl_X3A_X25s_X22_X3E_X3C_X2Fi_X3E_X25s),
-    /* K16  */  be_nested_str_weak(),
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(shadow_hue),
+    /* K1   */  be_nested_str_weak(shadow_sat),
+    /* K2   */  be_nested_str_weak(light_state),
+    /* K3   */  be_const_int(3),
+    /* K4   */  be_nested_str_weak(set_bri),
+    /* K5   */  be_nested_str_weak(set_huesat),
+    /* K6   */  be_nested_str_weak(tasmota),
+    /* K7   */  be_nested_str_weak(scale_uint),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(_X23_X2502X_X2502X_X2502X),
+    /* K10  */  be_nested_str_weak(r),
+    /* K11  */  be_nested_str_weak(g),
+    /* K12  */  be_nested_str_weak(b),
+    /* K13  */  be_nested_str_weak(_X3Ci_X20class_X3D_X22bxm_X22_X20style_X3D_X22_X2D_X2Dcl_X3A_X25s_X22_X3E_X3C_X2Fi_X3E_X25s),
+    /* K14  */  be_nested_str_weak(),
     }),
     be_str_weak(web_value_RGB),
     &be_const_str_solidified,
-    ( &(const binstruction[46]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x20080403,  //  0003  NE	R2	R2	R3
-      0x780A0027,  //  0004  JMPF	R2	#002D
-      0x88080102,  //  0005  GETMBR	R2	R0	K2
-      0x4C0C0000,  //  0006  LDNIL	R3
-      0x20080403,  //  0007  NE	R2	R2	R3
-      0x780A0023,  //  0008  JMPF	R2	#002D
-      0xB80A0600,  //  0009  GETNGBL	R2	K3
-      0x580C0004,  //  000A  LDCONST	R3	K4
-      0x7C080200,  //  000B  CALL	R2	1
-      0x8C0C0505,  //  000C  GETMET	R3	R2	K5
-      0x541600FE,  //  000D  LDINT	R5	255
-      0x7C0C0400,  //  000E  CALL	R3	2
-      0x8C0C0506,  //  000F  GETMET	R3	R2	K6
-      0xB8160E00,  //  0010  GETNGBL	R5	K7
-      0x8C140B08,  //  0011  GETMET	R5	R5	K8
-      0x881C0101,  //  0012  GETMBR	R7	R0	K1
-      0x58200009,  //  0013  LDCONST	R8	K9
-      0x542600FD,  //  0014  LDINT	R9	254
-      0x58280009,  //  0015  LDCONST	R10	K9
-      0x542E0167,  //  0016  LDINT	R11	360
-      0x7C140C00,  //  0017  CALL	R5	6
-      0xB81A0E00,  //  0018  GETNGBL	R6	K7
-      0x8C180D08,  //  0019  GETMET	R6	R6	K8
-      0x88200102,  //  001A  GETMBR	R8	R0	K2
-      0x58240009,  //  001B  LDCONST	R9	K9
-      0x542A00FD,  //  001C  LDINT	R10	254
-      0x582C0009,  //  001D  LDCONST	R11	K9
-      0x543200FE,  //  001E  LDINT	R12	255
-      0x7C180C00,  //  001F  CALL	R6	6
-      0x7C0C0600,  //  0020  CALL	R3	3
-      0x8C0C030A,  //  0021  GETMET	R3	R1	K10
-      0x5814000B,  //  0022  LDCONST	R5	K11
-      0x8818050C,  //  0023  GETMBR	R6	R2	K12
-      0x881C050D,  //  0024  GETMBR	R7	R2	K13
-      0x8820050E,  //  0025  GETMBR	R8	R2	K14
-      0x7C0C0A00,  //  0026  CALL	R3	5
-      0x8C10030A,  //  0027  GETMET	R4	R1	K10
-      0x5818000F,  //  0028  LDCONST	R6	K15
-      0x5C1C0600,  //  0029  MOVE	R7	R3
-      0x5C200600,  //  002A  MOVE	R8	R3
-      0x7C100800,  //  002B  CALL	R4	4
-      0x80040800,  //  002C  RET	1	R4
-      0x80062000,  //  002D  RET	1	K16
+    ( &(const binstruction[45]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060027,  //  0003  JMPF	R1	#002C
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x4C080000,  //  0005  LDNIL	R2
+      0x20040202,  //  0006  NE	R1	R1	R2
+      0x78060023,  //  0007  JMPF	R1	#002C
+      0xB8060400,  //  0008  GETNGBL	R1	K2
+      0x58080003,  //  0009  LDCONST	R2	K3
+      0x7C040200,  //  000A  CALL	R1	1
+      0x8C080304,  //  000B  GETMET	R2	R1	K4
+      0x541200FE,  //  000C  LDINT	R4	255
+      0x7C080400,  //  000D  CALL	R2	2
+      0x8C080305,  //  000E  GETMET	R2	R1	K5
+      0xB8120C00,  //  000F  GETNGBL	R4	K6
+      0x8C100907,  //  0010  GETMET	R4	R4	K7
+      0x88180100,  //  0011  GETMBR	R6	R0	K0
+      0x581C0008,  //  0012  LDCONST	R7	K8
+      0x542200FD,  //  0013  LDINT	R8	254
+      0x58240008,  //  0014  LDCONST	R9	K8
+      0x542A0167,  //  0015  LDINT	R10	360
+      0x7C100C00,  //  0016  CALL	R4	6
+      0xB8160C00,  //  0017  GETNGBL	R5	K6
+      0x8C140B07,  //  0018  GETMET	R5	R5	K7
+      0x881C0101,  //  0019  GETMBR	R7	R0	K1
+      0x58200008,  //  001A  LDCONST	R8	K8
+      0x542600FD,  //  001B  LDINT	R9	254
+      0x58280008,  //  001C  LDCONST	R10	K8
+      0x542E00FE,  //  001D  LDINT	R11	255
+      0x7C140C00,  //  001E  CALL	R5	6
+      0x7C080600,  //  001F  CALL	R2	3
+      0x60080018,  //  0020  GETGBL	R2	G24
+      0x580C0009,  //  0021  LDCONST	R3	K9
+      0x8810030A,  //  0022  GETMBR	R4	R1	K10
+      0x8814030B,  //  0023  GETMBR	R5	R1	K11
+      0x8818030C,  //  0024  GETMBR	R6	R1	K12
+      0x7C080800,  //  0025  CALL	R2	4
+      0x600C0018,  //  0026  GETGBL	R3	G24
+      0x5810000D,  //  0027  LDCONST	R4	K13
+      0x5C140400,  //  0028  MOVE	R5	R2
+      0x5C180400,  //  0029  MOVE	R6	R2
+      0x7C0C0600,  //  002A  CALL	R3	3
+      0x80040600,  //  002B  RET	1	R3
+      0x80061C00,  //  002C  RET	1	K14
     })
   )
 );
@@ -454,7 +448,7 @@ be_local_closure(Matter_Plugin_Bridge_Light3_invoke_request,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Light3_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -462,153 +456,151 @@ be_local_closure(Matter_Plugin_Bridge_Light3_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(shadow_hue),
-    /* K8   */  be_nested_str_weak(create_TLV),
-    /* K9   */  be_nested_str_weak(U1),
-    /* K10  */  be_nested_str_weak(NULL),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(shadow_sat),
-    /* K13  */  be_nested_str_weak(U4),
-    /* K14  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(shadow_hue),
+    /* K7   */  be_nested_str_weak(create_TLV),
+    /* K8   */  be_nested_str_weak(U1),
+    /* K9   */  be_nested_str_weak(NULL),
+    /* K10  */  be_const_int(1),
+    /* K11  */  be_nested_str_weak(shadow_sat),
+    /* K12  */  be_nested_str_weak(U4),
+    /* K13  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[127]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[126]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E02FF,  //  0005  LDINT	R7	768
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E006D,  //  0007  JMPF	R7	#0076
-      0x8C1C0105,  //  0008  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x1C1C0D06,  //  000A  EQ	R7	R6	K6
-      0x781E000F,  //  000B  JMPF	R7	#001C
-      0x881C0107,  //  000C  GETMBR	R7	R0	K7
-      0x4C200000,  //  000D  LDNIL	R8
-      0x201C0E08,  //  000E  NE	R7	R7	R8
-      0x781E0005,  //  000F  JMPF	R7	#0016
-      0x8C1C0908,  //  0010  GETMET	R7	R4	K8
-      0x88240909,  //  0011  GETMBR	R9	R4	K9
-      0x88280107,  //  0012  GETMBR	R10	R0	K7
-      0x7C1C0600,  //  0013  CALL	R7	3
-      0x80040E00,  //  0014  RET	1	R7
-      0x70020004,  //  0015  JMP		#001B
-      0x8C1C0908,  //  0016  GETMET	R7	R4	K8
-      0x8824090A,  //  0017  GETMBR	R9	R4	K10
-      0x4C280000,  //  0018  LDNIL	R10
-      0x7C1C0600,  //  0019  CALL	R7	3
-      0x80040E00,  //  001A  RET	1	R7
-      0x70020058,  //  001B  JMP		#0075
-      0x1C1C0D0B,  //  001C  EQ	R7	R6	K11
-      0x781E000F,  //  001D  JMPF	R7	#002E
-      0x881C010C,  //  001E  GETMBR	R7	R0	K12
-      0x4C200000,  //  001F  LDNIL	R8
-      0x201C0E08,  //  0020  NE	R7	R7	R8
-      0x781E0005,  //  0021  JMPF	R7	#0028
-      0x8C1C0908,  //  0022  GETMET	R7	R4	K8
-      0x88240909,  //  0023  GETMBR	R9	R4	K9
-      0x8828010C,  //  0024  GETMBR	R10	R0	K12
-      0x7C1C0600,  //  0025  CALL	R7	3
-      0x80040E00,  //  0026  RET	1	R7
-      0x70020004,  //  0027  JMP		#002D
-      0x8C1C0908,  //  0028  GETMET	R7	R4	K8
-      0x8824090A,  //  0029  GETMBR	R9	R4	K10
-      0x4C280000,  //  002A  LDNIL	R10
-      0x7C1C0600,  //  002B  CALL	R7	3
-      0x80040E00,  //  002C  RET	1	R7
-      0x70020046,  //  002D  JMP		#0075
-      0x541E0006,  //  002E  LDINT	R7	7
-      0x1C1C0C07,  //  002F  EQ	R7	R6	R7
-      0x781E0005,  //  0030  JMPF	R7	#0037
-      0x8C1C0908,  //  0031  GETMET	R7	R4	K8
-      0x88240909,  //  0032  GETMBR	R9	R4	K9
-      0x58280006,  //  0033  LDCONST	R10	K6
-      0x7C1C0600,  //  0034  CALL	R7	3
-      0x80040E00,  //  0035  RET	1	R7
-      0x7002003D,  //  0036  JMP		#0075
-      0x541E0007,  //  0037  LDINT	R7	8
-      0x1C1C0C07,  //  0038  EQ	R7	R6	R7
-      0x781E0005,  //  0039  JMPF	R7	#0040
-      0x8C1C0908,  //  003A  GETMET	R7	R4	K8
-      0x88240909,  //  003B  GETMBR	R9	R4	K9
-      0x58280006,  //  003C  LDCONST	R10	K6
-      0x7C1C0600,  //  003D  CALL	R7	3
-      0x80040E00,  //  003E  RET	1	R7
-      0x70020034,  //  003F  JMP		#0075
-      0x541E000E,  //  0040  LDINT	R7	15
-      0x1C1C0C07,  //  0041  EQ	R7	R6	R7
-      0x781E0005,  //  0042  JMPF	R7	#0049
-      0x8C1C0908,  //  0043  GETMET	R7	R4	K8
-      0x88240909,  //  0044  GETMBR	R9	R4	K9
-      0x58280006,  //  0045  LDCONST	R10	K6
-      0x7C1C0600,  //  0046  CALL	R7	3
-      0x80040E00,  //  0047  RET	1	R7
-      0x7002002B,  //  0048  JMP		#0075
-      0x541E4000,  //  0049  LDINT	R7	16385
-      0x1C1C0C07,  //  004A  EQ	R7	R6	R7
-      0x781E0005,  //  004B  JMPF	R7	#0052
-      0x8C1C0908,  //  004C  GETMET	R7	R4	K8
-      0x88240909,  //  004D  GETMBR	R9	R4	K9
-      0x58280006,  //  004E  LDCONST	R10	K6
-      0x7C1C0600,  //  004F  CALL	R7	3
-      0x80040E00,  //  0050  RET	1	R7
-      0x70020022,  //  0051  JMP		#0075
-      0x541E4009,  //  0052  LDINT	R7	16394
-      0x1C1C0C07,  //  0053  EQ	R7	R6	R7
-      0x781E0005,  //  0054  JMPF	R7	#005B
-      0x8C1C0908,  //  0055  GETMET	R7	R4	K8
-      0x8824090D,  //  0056  GETMBR	R9	R4	K13
-      0x5828000B,  //  0057  LDCONST	R10	K11
-      0x7C1C0600,  //  0058  CALL	R7	3
-      0x80040E00,  //  0059  RET	1	R7
-      0x70020019,  //  005A  JMP		#0075
-      0x541E000F,  //  005B  LDINT	R7	16
-      0x1C1C0C07,  //  005C  EQ	R7	R6	R7
-      0x781E0005,  //  005D  JMPF	R7	#0064
-      0x8C1C0908,  //  005E  GETMET	R7	R4	K8
-      0x88240909,  //  005F  GETMBR	R9	R4	K9
-      0x58280006,  //  0060  LDCONST	R10	K6
-      0x7C1C0600,  //  0061  CALL	R7	3
-      0x80040E00,  //  0062  RET	1	R7
-      0x70020010,  //  0063  JMP		#0075
-      0x541EFFFB,  //  0064  LDINT	R7	65532
-      0x1C1C0C07,  //  0065  EQ	R7	R6	R7
-      0x781E0005,  //  0066  JMPF	R7	#006D
-      0x8C1C0908,  //  0067  GETMET	R7	R4	K8
-      0x8824090D,  //  0068  GETMBR	R9	R4	K13
-      0x5828000B,  //  0069  LDCONST	R10	K11
-      0x7C1C0600,  //  006A  CALL	R7	3
-      0x80040E00,  //  006B  RET	1	R7
-      0x70020007,  //  006C  JMP		#0075
-      0x541EFFFC,  //  006D  LDINT	R7	65533
-      0x1C1C0C07,  //  006E  EQ	R7	R6	R7
-      0x781E0004,  //  006F  JMPF	R7	#0075
-      0x8C1C0908,  //  0070  GETMET	R7	R4	K8
-      0x8824090D,  //  0071  GETMBR	R9	R4	K13
-      0x542A0004,  //  0072  LDINT	R10	5
-      0x7C1C0600,  //  0073  CALL	R7	3
-      0x80040E00,  //  0074  RET	1	R7
-      0x70020007,  //  0075  JMP		#007E
-      0x601C0003,  //  0076  GETGBL	R7	G3
-      0x5C200000,  //  0077  MOVE	R8	R0
-      0x7C1C0200,  //  0078  CALL	R7	1
-      0x8C1C0F0E,  //  0079  GETMET	R7	R7	K14
-      0x5C240200,  //  007A  MOVE	R9	R1
-      0x5C280400,  //  007B  MOVE	R10	R2
-      0x7C1C0600,  //  007C  CALL	R7	3
-      0x80040E00,  //  007D  RET	1	R7
-      0x80000000,  //  007E  RET	0
+      0x541A02FF,  //  0004  LDINT	R6	768
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A006D,  //  0006  JMPF	R6	#0075
+      0x8C180104,  //  0007  GETMET	R6	R0	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x1C180B05,  //  0009  EQ	R6	R5	K5
+      0x781A000F,  //  000A  JMPF	R6	#001B
+      0x88180106,  //  000B  GETMBR	R6	R0	K6
+      0x4C1C0000,  //  000C  LDNIL	R7
+      0x20180C07,  //  000D  NE	R6	R6	R7
+      0x781A0005,  //  000E  JMPF	R6	#0015
+      0x8C180707,  //  000F  GETMET	R6	R3	K7
+      0x88200708,  //  0010  GETMBR	R8	R3	K8
+      0x88240106,  //  0011  GETMBR	R9	R0	K6
+      0x7C180600,  //  0012  CALL	R6	3
+      0x80040C00,  //  0013  RET	1	R6
+      0x70020004,  //  0014  JMP		#001A
+      0x8C180707,  //  0015  GETMET	R6	R3	K7
+      0x88200709,  //  0016  GETMBR	R8	R3	K9
+      0x4C240000,  //  0017  LDNIL	R9
+      0x7C180600,  //  0018  CALL	R6	3
+      0x80040C00,  //  0019  RET	1	R6
+      0x70020058,  //  001A  JMP		#0074
+      0x1C180B0A,  //  001B  EQ	R6	R5	K10
+      0x781A000F,  //  001C  JMPF	R6	#002D
+      0x8818010B,  //  001D  GETMBR	R6	R0	K11
+      0x4C1C0000,  //  001E  LDNIL	R7
+      0x20180C07,  //  001F  NE	R6	R6	R7
+      0x781A0005,  //  0020  JMPF	R6	#0027
+      0x8C180707,  //  0021  GETMET	R6	R3	K7
+      0x88200708,  //  0022  GETMBR	R8	R3	K8
+      0x8824010B,  //  0023  GETMBR	R9	R0	K11
+      0x7C180600,  //  0024  CALL	R6	3
+      0x80040C00,  //  0025  RET	1	R6
+      0x70020004,  //  0026  JMP		#002C
+      0x8C180707,  //  0027  GETMET	R6	R3	K7
+      0x88200709,  //  0028  GETMBR	R8	R3	K9
+      0x4C240000,  //  0029  LDNIL	R9
+      0x7C180600,  //  002A  CALL	R6	3
+      0x80040C00,  //  002B  RET	1	R6
+      0x70020046,  //  002C  JMP		#0074
+      0x541A0006,  //  002D  LDINT	R6	7
+      0x1C180A06,  //  002E  EQ	R6	R5	R6
+      0x781A0005,  //  002F  JMPF	R6	#0036
+      0x8C180707,  //  0030  GETMET	R6	R3	K7
+      0x88200708,  //  0031  GETMBR	R8	R3	K8
+      0x58240005,  //  0032  LDCONST	R9	K5
+      0x7C180600,  //  0033  CALL	R6	3
+      0x80040C00,  //  0034  RET	1	R6
+      0x7002003D,  //  0035  JMP		#0074
+      0x541A0007,  //  0036  LDINT	R6	8
+      0x1C180A06,  //  0037  EQ	R6	R5	R6
+      0x781A0005,  //  0038  JMPF	R6	#003F
+      0x8C180707,  //  0039  GETMET	R6	R3	K7
+      0x88200708,  //  003A  GETMBR	R8	R3	K8
+      0x58240005,  //  003B  LDCONST	R9	K5
+      0x7C180600,  //  003C  CALL	R6	3
+      0x80040C00,  //  003D  RET	1	R6
+      0x70020034,  //  003E  JMP		#0074
+      0x541A000E,  //  003F  LDINT	R6	15
+      0x1C180A06,  //  0040  EQ	R6	R5	R6
+      0x781A0005,  //  0041  JMPF	R6	#0048
+      0x8C180707,  //  0042  GETMET	R6	R3	K7
+      0x88200708,  //  0043  GETMBR	R8	R3	K8
+      0x58240005,  //  0044  LDCONST	R9	K5
+      0x7C180600,  //  0045  CALL	R6	3
+      0x80040C00,  //  0046  RET	1	R6
+      0x7002002B,  //  0047  JMP		#0074
+      0x541A4000,  //  0048  LDINT	R6	16385
+      0x1C180A06,  //  0049  EQ	R6	R5	R6
+      0x781A0005,  //  004A  JMPF	R6	#0051
+      0x8C180707,  //  004B  GETMET	R6	R3	K7
+      0x88200708,  //  004C  GETMBR	R8	R3	K8
+      0x58240005,  //  004D  LDCONST	R9	K5
+      0x7C180600,  //  004E  CALL	R6	3
+      0x80040C00,  //  004F  RET	1	R6
+      0x70020022,  //  0050  JMP		#0074
+      0x541A4009,  //  0051  LDINT	R6	16394
+      0x1C180A06,  //  0052  EQ	R6	R5	R6
+      0x781A0005,  //  0053  JMPF	R6	#005A
+      0x8C180707,  //  0054  GETMET	R6	R3	K7
+      0x8820070C,  //  0055  GETMBR	R8	R3	K12
+      0x5824000A,  //  0056  LDCONST	R9	K10
+      0x7C180600,  //  0057  CALL	R6	3
+      0x80040C00,  //  0058  RET	1	R6
+      0x70020019,  //  0059  JMP		#0074
+      0x541A000F,  //  005A  LDINT	R6	16
+      0x1C180A06,  //  005B  EQ	R6	R5	R6
+      0x781A0005,  //  005C  JMPF	R6	#0063
+      0x8C180707,  //  005D  GETMET	R6	R3	K7
+      0x88200708,  //  005E  GETMBR	R8	R3	K8
+      0x58240005,  //  005F  LDCONST	R9	K5
+      0x7C180600,  //  0060  CALL	R6	3
+      0x80040C00,  //  0061  RET	1	R6
+      0x70020010,  //  0062  JMP		#0074
+      0x541AFFFB,  //  0063  LDINT	R6	65532
+      0x1C180A06,  //  0064  EQ	R6	R5	R6
+      0x781A0005,  //  0065  JMPF	R6	#006C
+      0x8C180707,  //  0066  GETMET	R6	R3	K7
+      0x8820070C,  //  0067  GETMBR	R8	R3	K12
+      0x5824000A,  //  0068  LDCONST	R9	K10
+      0x7C180600,  //  0069  CALL	R6	3
+      0x80040C00,  //  006A  RET	1	R6
+      0x70020007,  //  006B  JMP		#0074
+      0x541AFFFC,  //  006C  LDINT	R6	65533
+      0x1C180A06,  //  006D  EQ	R6	R5	R6
+      0x781A0004,  //  006E  JMPF	R6	#0074
+      0x8C180707,  //  006F  GETMET	R6	R3	K7
+      0x8820070C,  //  0070  GETMBR	R8	R3	K12
+      0x54260004,  //  0071  LDINT	R9	5
+      0x7C180600,  //  0072  CALL	R6	3
+      0x80040C00,  //  0073  RET	1	R6
+      0x70020007,  //  0074  JMP		#007D
+      0x60180003,  //  0075  GETGBL	R6	G3
+      0x5C1C0000,  //  0076  MOVE	R7	R0
+      0x7C180200,  //  0077  CALL	R6	1
+      0x8C180D0D,  //  0078  GETMET	R6	R6	K13
+      0x5C200200,  //  0079  MOVE	R8	R1
+      0x5C240400,  //  007A  MOVE	R9	R2
+      0x7C180600,  //  007B  CALL	R6	3
+      0x80040C00,  //  007C  RET	1	R6
+      0x80000000,  //  007D  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_OnOff.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_OnOff.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Plugin_Bridge_OnOff;
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_OnOff_web_values,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,34 +19,31 @@ be_local_closure(Matter_Plugin_Bridge_OnOff_web_values,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(web_values_prefix),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(Relay_X20_X25i_X20_X25s),
-    /* K6   */  be_nested_str_weak(tasmota_relay_index),
-    /* K7   */  be_nested_str_weak(web_value_onoff),
-    /* K8   */  be_nested_str_weak(shadow_onoff),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(Relay_X20_X25i_X20_X25s),
+    /* K4   */  be_nested_str_weak(tasmota_relay_index),
+    /* K5   */  be_nested_str_weak(web_value_onoff),
+    /* K6   */  be_nested_str_weak(shadow_onoff),
     }),
     be_str_weak(web_values),
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
+    ( &(const binstruction[13]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0303,  //  0004  GETMET	R3	R1	K3
-      0x8C140504,  //  0005  GETMET	R5	R2	K4
-      0x581C0005,  //  0006  LDCONST	R7	K5
-      0x88200106,  //  0007  GETMBR	R8	R0	K6
-      0x8C240107,  //  0008  GETMET	R9	R0	K7
-      0x882C0108,  //  0009  GETMBR	R11	R0	K8
-      0x7C240400,  //  000A  CALL	R9	2
-      0x7C140800,  //  000B  CALL	R5	4
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x80000000,  //  000D  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x60100018,  //  0004  GETGBL	R4	G24
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x88180104,  //  0006  GETMBR	R6	R0	K4
+      0x8C1C0105,  //  0007  GETMET	R7	R0	K5
+      0x88240106,  //  0008  GETMBR	R9	R0	K6
+      0x7C1C0400,  //  0009  CALL	R7	2
+      0x7C100600,  //  000A  CALL	R4	3
+      0x7C080400,  //  000B  CALL	R2	2
+      0x80000000,  //  000C  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Plugin_Bridge_Sensor;
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_web_values_prefix,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,41 +19,38 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_web_values_prefix,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(get_name),
-    /* K3   */  be_nested_str_weak(filter_name_html),
-    /* K4   */  be_nested_str_weak(content_send),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(PREFIX),
-    /* K7   */  be_nested_str_weak(html_escape),
-    /* K8   */  be_nested_str_weak(),
+    /* K1   */  be_nested_str_weak(get_name),
+    /* K2   */  be_nested_str_weak(filter_name_html),
+    /* K3   */  be_nested_str_weak(content_send),
+    /* K4   */  be_nested_str_weak(PREFIX),
+    /* K5   */  be_nested_str_weak(html_escape),
+    /* K6   */  be_nested_str_weak(),
     }),
     be_str_weak(web_values_prefix),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
+    ( &(const binstruction[20]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x5C100600,  //  0004  MOVE	R4	R3
-      0x74120002,  //  0005  JMPT	R4	#0009
-      0x8C100103,  //  0006  GETMET	R4	R0	K3
-      0x7C100200,  //  0007  CALL	R4	1
-      0x5C0C0800,  //  0008  MOVE	R3	R4
-      0x8C100304,  //  0009  GETMET	R4	R1	K4
-      0x8C180505,  //  000A  GETMET	R6	R2	K5
-      0x88200106,  //  000B  GETMBR	R8	R0	K6
-      0x780E0003,  //  000C  JMPF	R3	#0011
-      0x8C240307,  //  000D  GETMET	R9	R1	K7
-      0x5C2C0600,  //  000E  MOVE	R11	R3
-      0x7C240400,  //  000F  CALL	R9	2
-      0x70020000,  //  0010  JMP		#0012
-      0x58240008,  //  0011  LDCONST	R9	K8
-      0x7C180600,  //  0012  CALL	R6	3
-      0x7C100400,  //  0013  CALL	R4	2
-      0x80000000,  //  0014  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x5C0C0400,  //  0003  MOVE	R3	R2
+      0x740E0002,  //  0004  JMPT	R3	#0008
+      0x8C0C0102,  //  0005  GETMET	R3	R0	K2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0x5C080600,  //  0007  MOVE	R2	R3
+      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
+      0x60140018,  //  0009  GETGBL	R5	G24
+      0x88180104,  //  000A  GETMBR	R6	R0	K4
+      0x780A0003,  //  000B  JMPF	R2	#0010
+      0x8C1C0305,  //  000C  GETMET	R7	R1	K5
+      0x5C240400,  //  000D  MOVE	R9	R2
+      0x7C1C0400,  //  000E  CALL	R7	2
+      0x70020000,  //  000F  JMP		#0011
+      0x581C0006,  //  0010  LDCONST	R7	K6
+      0x7C140400,  //  0011  CALL	R5	2
+      0x7C0C0400,  //  0012  CALL	R3	2
+      0x80000000,  //  0013  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Contact.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Contact.h
@@ -88,7 +88,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Contact_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Contact_web_values_prefix,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -96,44 +96,41 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Contact_web_values_prefix,   /* nam
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(get_name),
-    /* K3   */  be_nested_str_weak(Switch),
-    /* K4   */  be_nested_str_weak(tasmota_switch_index),
-    /* K5   */  be_nested_str_weak(content_send),
-    /* K6   */  be_nested_str_weak(format),
-    /* K7   */  be_nested_str_weak(PREFIX),
-    /* K8   */  be_nested_str_weak(html_escape),
-    /* K9   */  be_nested_str_weak(),
+    /* K1   */  be_nested_str_weak(get_name),
+    /* K2   */  be_nested_str_weak(Switch),
+    /* K3   */  be_nested_str_weak(tasmota_switch_index),
+    /* K4   */  be_nested_str_weak(content_send),
+    /* K5   */  be_nested_str_weak(PREFIX),
+    /* K6   */  be_nested_str_weak(html_escape),
+    /* K7   */  be_nested_str_weak(),
     }),
     be_str_weak(web_values_prefix),
     &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
+    ( &(const binstruction[22]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x5C100600,  //  0004  MOVE	R4	R3
-      0x74120004,  //  0005  JMPT	R4	#000B
-      0x60100008,  //  0006  GETGBL	R4	G8
-      0x88140104,  //  0007  GETMBR	R5	R0	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x00120604,  //  0009  ADD	R4	K3	R4
-      0x5C0C0800,  //  000A  MOVE	R3	R4
-      0x8C100305,  //  000B  GETMET	R4	R1	K5
-      0x8C180506,  //  000C  GETMET	R6	R2	K6
-      0x88200107,  //  000D  GETMBR	R8	R0	K7
-      0x780E0003,  //  000E  JMPF	R3	#0013
-      0x8C240308,  //  000F  GETMET	R9	R1	K8
-      0x5C2C0600,  //  0010  MOVE	R11	R3
-      0x7C240400,  //  0011  CALL	R9	2
-      0x70020000,  //  0012  JMP		#0014
-      0x58240009,  //  0013  LDCONST	R9	K9
-      0x7C180600,  //  0014  CALL	R6	3
-      0x7C100400,  //  0015  CALL	R4	2
-      0x80000000,  //  0016  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x5C0C0400,  //  0003  MOVE	R3	R2
+      0x740E0004,  //  0004  JMPT	R3	#000A
+      0x600C0008,  //  0005  GETGBL	R3	G8
+      0x88100103,  //  0006  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x000E0403,  //  0008  ADD	R3	K2	R3
+      0x5C080600,  //  0009  MOVE	R2	R3
+      0x8C0C0304,  //  000A  GETMET	R3	R1	K4
+      0x60140018,  //  000B  GETGBL	R5	G24
+      0x88180105,  //  000C  GETMBR	R6	R0	K5
+      0x780A0003,  //  000D  JMPF	R2	#0012
+      0x8C1C0306,  //  000E  GETMET	R7	R1	K6
+      0x5C240400,  //  000F  MOVE	R9	R2
+      0x7C1C0400,  //  0010  CALL	R7	2
+      0x70020000,  //  0011  JMP		#0013
+      0x581C0007,  //  0012  LDCONST	R7	K7
+      0x7C140400,  //  0013  CALL	R5	2
+      0x7C0C0400,  //  0014  CALL	R3	2
+      0x80000000,  //  0015  RET	0
     })
   )
 );
@@ -204,7 +201,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Contact_parse_update,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Contact_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -212,77 +209,75 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Contact_read_attribute,   /* name *
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_contact),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(BOOL),
-    /* K9   */  be_nested_str_weak(NULL),
-    /* K10  */  be_nested_str_weak(U4),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(shadow_contact),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(BOOL),
+    /* K8   */  be_nested_str_weak(NULL),
+    /* K9   */  be_nested_str_weak(U4),
+    /* K10  */  be_const_int(1),
+    /* K11  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[52]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0044,  //  0005  LDINT	R7	69
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0023,  //  0007  JMPF	R7	#002C
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E000F,  //  0009  JMPF	R7	#001A
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x4C200000,  //  000B  LDNIL	R8
-      0x201C0E08,  //  000C  NE	R7	R7	R8
-      0x781E0005,  //  000D  JMPF	R7	#0014
-      0x8C1C0907,  //  000E  GETMET	R7	R4	K7
-      0x88240908,  //  000F  GETMBR	R9	R4	K8
-      0x88280106,  //  0010  GETMBR	R10	R0	K6
-      0x7C1C0600,  //  0011  CALL	R7	3
-      0x80040E00,  //  0012  RET	1	R7
-      0x70020004,  //  0013  JMP		#0019
-      0x8C1C0907,  //  0014  GETMET	R7	R4	K7
-      0x88240909,  //  0015  GETMBR	R9	R4	K9
-      0x4C280000,  //  0016  LDNIL	R10
-      0x7C1C0600,  //  0017  CALL	R7	3
-      0x80040E00,  //  0018  RET	1	R7
-      0x70020010,  //  0019  JMP		#002B
-      0x541EFFFB,  //  001A  LDINT	R7	65532
-      0x1C1C0C07,  //  001B  EQ	R7	R6	R7
-      0x781E0005,  //  001C  JMPF	R7	#0023
-      0x8C1C0907,  //  001D  GETMET	R7	R4	K7
-      0x8824090A,  //  001E  GETMBR	R9	R4	K10
-      0x58280005,  //  001F  LDCONST	R10	K5
-      0x7C1C0600,  //  0020  CALL	R7	3
-      0x80040E00,  //  0021  RET	1	R7
-      0x70020007,  //  0022  JMP		#002B
-      0x541EFFFC,  //  0023  LDINT	R7	65533
-      0x1C1C0C07,  //  0024  EQ	R7	R6	R7
-      0x781E0004,  //  0025  JMPF	R7	#002B
-      0x8C1C0907,  //  0026  GETMET	R7	R4	K7
-      0x8824090A,  //  0027  GETMBR	R9	R4	K10
-      0x5828000B,  //  0028  LDCONST	R10	K11
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x80040E00,  //  002A  RET	1	R7
-      0x70020007,  //  002B  JMP		#0034
-      0x601C0003,  //  002C  GETGBL	R7	G3
-      0x5C200000,  //  002D  MOVE	R8	R0
-      0x7C1C0200,  //  002E  CALL	R7	1
-      0x8C1C0F0C,  //  002F  GETMET	R7	R7	K12
-      0x5C240200,  //  0030  MOVE	R9	R1
-      0x5C280400,  //  0031  MOVE	R10	R2
-      0x7C1C0600,  //  0032  CALL	R7	3
-      0x80040E00,  //  0033  RET	1	R7
-      0x80000000,  //  0034  RET	0
+      0x541A0044,  //  0004  LDINT	R6	69
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0023,  //  0006  JMPF	R6	#002B
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A000F,  //  0008  JMPF	R6	#0019
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x20180C07,  //  000B  NE	R6	R6	R7
+      0x781A0005,  //  000C  JMPF	R6	#0013
+      0x8C180706,  //  000D  GETMET	R6	R3	K6
+      0x88200707,  //  000E  GETMBR	R8	R3	K7
+      0x88240105,  //  000F  GETMBR	R9	R0	K5
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80040C00,  //  0011  RET	1	R6
+      0x70020004,  //  0012  JMP		#0018
+      0x8C180706,  //  0013  GETMET	R6	R3	K6
+      0x88200708,  //  0014  GETMBR	R8	R3	K8
+      0x4C240000,  //  0015  LDNIL	R9
+      0x7C180600,  //  0016  CALL	R6	3
+      0x80040C00,  //  0017  RET	1	R6
+      0x70020010,  //  0018  JMP		#002A
+      0x541AFFFB,  //  0019  LDINT	R6	65532
+      0x1C180A06,  //  001A  EQ	R6	R5	R6
+      0x781A0005,  //  001B  JMPF	R6	#0022
+      0x8C180706,  //  001C  GETMET	R6	R3	K6
+      0x88200709,  //  001D  GETMBR	R8	R3	K9
+      0x58240004,  //  001E  LDCONST	R9	K4
+      0x7C180600,  //  001F  CALL	R6	3
+      0x80040C00,  //  0020  RET	1	R6
+      0x70020007,  //  0021  JMP		#002A
+      0x541AFFFC,  //  0022  LDINT	R6	65533
+      0x1C180A06,  //  0023  EQ	R6	R5	R6
+      0x781A0004,  //  0024  JMPF	R6	#002A
+      0x8C180706,  //  0025  GETMET	R6	R3	K6
+      0x88200709,  //  0026  GETMBR	R8	R3	K9
+      0x5824000A,  //  0027  LDCONST	R9	K10
+      0x7C180600,  //  0028  CALL	R6	3
+      0x80040C00,  //  0029  RET	1	R6
+      0x70020007,  //  002A  JMP		#0033
+      0x60180003,  //  002B  GETGBL	R6	G3
+      0x5C1C0000,  //  002C  MOVE	R7	R0
+      0x7C180200,  //  002D  CALL	R6	1
+      0x8C180D0B,  //  002E  GETMET	R6	R6	K11
+      0x5C200200,  //  002F  MOVE	R8	R1
+      0x5C240400,  //  0030  MOVE	R9	R2
+      0x7C180600,  //  0031  CALL	R6	3
+      0x80040C00,  //  0032  RET	1	R6
+      0x80000000,  //  0033  RET	0
     })
   )
 );
@@ -294,7 +289,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Contact_read_attribute,   /* name *
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Contact_web_values,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -302,34 +297,31 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Contact_web_values,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(web_values_prefix),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(Contact_X25i_X20_X25s),
-    /* K6   */  be_nested_str_weak(tasmota_switch_index),
-    /* K7   */  be_nested_str_weak(web_value_onoff),
-    /* K8   */  be_nested_str_weak(shadow_contact),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(Contact_X25i_X20_X25s),
+    /* K4   */  be_nested_str_weak(tasmota_switch_index),
+    /* K5   */  be_nested_str_weak(web_value_onoff),
+    /* K6   */  be_nested_str_weak(shadow_contact),
     }),
     be_str_weak(web_values),
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
+    ( &(const binstruction[13]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0303,  //  0004  GETMET	R3	R1	K3
-      0x8C140504,  //  0005  GETMET	R5	R2	K4
-      0x581C0005,  //  0006  LDCONST	R7	K5
-      0x88200106,  //  0007  GETMBR	R8	R0	K6
-      0x8C240107,  //  0008  GETMET	R9	R0	K7
-      0x882C0108,  //  0009  GETMBR	R11	R0	K8
-      0x7C240400,  //  000A  CALL	R9	2
-      0x7C140800,  //  000B  CALL	R5	4
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x80000000,  //  000D  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x60100018,  //  0004  GETGBL	R4	G24
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x88180104,  //  0006  GETMBR	R6	R0	K4
+      0x8C1C0105,  //  0007  GETMET	R7	R0	K5
+      0x88240106,  //  0008  GETMBR	R9	R0	K6
+      0x7C1C0400,  //  0009  CALL	R7	2
+      0x7C100600,  //  000A  CALL	R4	3
+      0x7C080400,  //  000B  CALL	R2	2
+      0x80000000,  //  000C  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Humidity.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Humidity.h
@@ -44,7 +44,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Humidity_pre_value,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Humidity_read_attribute,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -52,97 +52,95 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Humidity_read_attribute,   /* name 
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_value),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(U2),
-    /* K9   */  be_nested_str_weak(NULL),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(U4),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(shadow_value),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(U2),
+    /* K8   */  be_nested_str_weak(NULL),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[71]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[70]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0404,  //  0005  LDINT	R7	1029
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0035,  //  0007  JMPF	R7	#003E
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E0011,  //  0009  JMPF	R7	#001C
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x4C200000,  //  000B  LDNIL	R8
-      0x201C0E08,  //  000C  NE	R7	R7	R8
-      0x781E0007,  //  000D  JMPF	R7	#0016
-      0x8C1C0907,  //  000E  GETMET	R7	R4	K7
-      0x88240908,  //  000F  GETMBR	R9	R4	K8
-      0x60280009,  //  0010  GETGBL	R10	G9
-      0x882C0106,  //  0011  GETMBR	R11	R0	K6
-      0x7C280200,  //  0012  CALL	R10	1
-      0x7C1C0600,  //  0013  CALL	R7	3
-      0x80040E00,  //  0014  RET	1	R7
-      0x70020004,  //  0015  JMP		#001B
-      0x8C1C0907,  //  0016  GETMET	R7	R4	K7
-      0x88240909,  //  0017  GETMBR	R9	R4	K9
-      0x4C280000,  //  0018  LDNIL	R10
-      0x7C1C0600,  //  0019  CALL	R7	3
-      0x80040E00,  //  001A  RET	1	R7
-      0x70020020,  //  001B  JMP		#003D
-      0x1C1C0D0A,  //  001C  EQ	R7	R6	K10
-      0x781E0005,  //  001D  JMPF	R7	#0024
-      0x8C1C0907,  //  001E  GETMET	R7	R4	K7
-      0x88240908,  //  001F  GETMBR	R9	R4	K8
-      0x542A01F3,  //  0020  LDINT	R10	500
-      0x7C1C0600,  //  0021  CALL	R7	3
-      0x80040E00,  //  0022  RET	1	R7
-      0x70020018,  //  0023  JMP		#003D
-      0x1C1C0D0B,  //  0024  EQ	R7	R6	K11
-      0x781E0005,  //  0025  JMPF	R7	#002C
-      0x8C1C0907,  //  0026  GETMET	R7	R4	K7
-      0x88240908,  //  0027  GETMBR	R9	R4	K8
-      0x542A270F,  //  0028  LDINT	R10	10000
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x80040E00,  //  002A  RET	1	R7
-      0x70020010,  //  002B  JMP		#003D
-      0x541EFFFB,  //  002C  LDINT	R7	65532
-      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
-      0x781E0005,  //  002E  JMPF	R7	#0035
-      0x8C1C0907,  //  002F  GETMET	R7	R4	K7
-      0x8824090C,  //  0030  GETMBR	R9	R4	K12
-      0x58280005,  //  0031  LDCONST	R10	K5
-      0x7C1C0600,  //  0032  CALL	R7	3
-      0x80040E00,  //  0033  RET	1	R7
-      0x70020007,  //  0034  JMP		#003D
-      0x541EFFFC,  //  0035  LDINT	R7	65533
-      0x1C1C0C07,  //  0036  EQ	R7	R6	R7
-      0x781E0004,  //  0037  JMPF	R7	#003D
-      0x8C1C0907,  //  0038  GETMET	R7	R4	K7
-      0x8824090C,  //  0039  GETMBR	R9	R4	K12
-      0x5828000D,  //  003A  LDCONST	R10	K13
-      0x7C1C0600,  //  003B  CALL	R7	3
-      0x80040E00,  //  003C  RET	1	R7
-      0x70020007,  //  003D  JMP		#0046
-      0x601C0003,  //  003E  GETGBL	R7	G3
-      0x5C200000,  //  003F  MOVE	R8	R0
-      0x7C1C0200,  //  0040  CALL	R7	1
-      0x8C1C0F0E,  //  0041  GETMET	R7	R7	K14
-      0x5C240200,  //  0042  MOVE	R9	R1
-      0x5C280400,  //  0043  MOVE	R10	R2
-      0x7C1C0600,  //  0044  CALL	R7	3
-      0x80040E00,  //  0045  RET	1	R7
-      0x80000000,  //  0046  RET	0
+      0x541A0404,  //  0004  LDINT	R6	1029
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0035,  //  0006  JMPF	R6	#003D
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A0011,  //  0008  JMPF	R6	#001B
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x20180C07,  //  000B  NE	R6	R6	R7
+      0x781A0007,  //  000C  JMPF	R6	#0015
+      0x8C180706,  //  000D  GETMET	R6	R3	K6
+      0x88200707,  //  000E  GETMBR	R8	R3	K7
+      0x60240009,  //  000F  GETGBL	R9	G9
+      0x88280105,  //  0010  GETMBR	R10	R0	K5
+      0x7C240200,  //  0011  CALL	R9	1
+      0x7C180600,  //  0012  CALL	R6	3
+      0x80040C00,  //  0013  RET	1	R6
+      0x70020004,  //  0014  JMP		#001A
+      0x8C180706,  //  0015  GETMET	R6	R3	K6
+      0x88200708,  //  0016  GETMBR	R8	R3	K8
+      0x4C240000,  //  0017  LDNIL	R9
+      0x7C180600,  //  0018  CALL	R6	3
+      0x80040C00,  //  0019  RET	1	R6
+      0x70020020,  //  001A  JMP		#003C
+      0x1C180B09,  //  001B  EQ	R6	R5	K9
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C180706,  //  001D  GETMET	R6	R3	K6
+      0x88200707,  //  001E  GETMBR	R8	R3	K7
+      0x542601F3,  //  001F  LDINT	R9	500
+      0x7C180600,  //  0020  CALL	R6	3
+      0x80040C00,  //  0021  RET	1	R6
+      0x70020018,  //  0022  JMP		#003C
+      0x1C180B0A,  //  0023  EQ	R6	R5	K10
+      0x781A0005,  //  0024  JMPF	R6	#002B
+      0x8C180706,  //  0025  GETMET	R6	R3	K6
+      0x88200707,  //  0026  GETMBR	R8	R3	K7
+      0x5426270F,  //  0027  LDINT	R9	10000
+      0x7C180600,  //  0028  CALL	R6	3
+      0x80040C00,  //  0029  RET	1	R6
+      0x70020010,  //  002A  JMP		#003C
+      0x541AFFFB,  //  002B  LDINT	R6	65532
+      0x1C180A06,  //  002C  EQ	R6	R5	R6
+      0x781A0005,  //  002D  JMPF	R6	#0034
+      0x8C180706,  //  002E  GETMET	R6	R3	K6
+      0x8820070B,  //  002F  GETMBR	R8	R3	K11
+      0x58240004,  //  0030  LDCONST	R9	K4
+      0x7C180600,  //  0031  CALL	R6	3
+      0x80040C00,  //  0032  RET	1	R6
+      0x70020007,  //  0033  JMP		#003C
+      0x541AFFFC,  //  0034  LDINT	R6	65533
+      0x1C180A06,  //  0035  EQ	R6	R5	R6
+      0x781A0004,  //  0036  JMPF	R6	#003C
+      0x8C180706,  //  0037  GETMET	R6	R3	K6
+      0x8820070B,  //  0038  GETMBR	R8	R3	K11
+      0x5824000C,  //  0039  LDCONST	R9	K12
+      0x7C180600,  //  003A  CALL	R6	3
+      0x80040C00,  //  003B  RET	1	R6
+      0x70020007,  //  003C  JMP		#0045
+      0x60180003,  //  003D  GETGBL	R6	G3
+      0x5C1C0000,  //  003E  MOVE	R7	R0
+      0x7C180200,  //  003F  CALL	R6	1
+      0x8C180D0D,  //  0040  GETMET	R6	R6	K13
+      0x5C200200,  //  0041  MOVE	R8	R1
+      0x5C240400,  //  0042  MOVE	R9	R2
+      0x7C180600,  //  0043  CALL	R6	3
+      0x80040C00,  //  0044  RET	1	R6
+      0x80000000,  //  0045  RET	0
     })
   )
 );
@@ -185,7 +183,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Humidity_value_changed,   /* name *
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Humidity_web_values,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    8,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -193,39 +191,36 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Humidity_web_values,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
+    ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(web_values_prefix),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(_X26_X23x1F4A7_X3B_X20_X252_X2E0f_X25_X25),
-    /* K6   */  be_nested_str_weak(shadow_value),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(_X26_X23x1F4A7_X3B_X20_X252_X2E0f_X25_X25),
+    /* K4   */  be_nested_str_weak(shadow_value),
     }),
     be_str_weak(web_values),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
+    ( &(const binstruction[20]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0303,  //  0004  GETMET	R3	R1	K3
-      0x8C140504,  //  0005  GETMET	R5	R2	K4
-      0x581C0005,  //  0006  LDCONST	R7	K5
-      0x88200106,  //  0007  GETMBR	R8	R0	K6
-      0x4C240000,  //  0008  LDNIL	R9
-      0x20201009,  //  0009  NE	R8	R8	R9
-      0x78220005,  //  000A  JMPF	R8	#0011
-      0x6020000A,  //  000B  GETGBL	R8	G10
-      0x88240106,  //  000C  GETMBR	R9	R0	K6
-      0x7C200200,  //  000D  CALL	R8	1
-      0x54260063,  //  000E  LDINT	R9	100
-      0x0C201009,  //  000F  DIV	R8	R8	R9
-      0x70020000,  //  0010  JMP		#0012
-      0x4C200000,  //  0011  LDNIL	R8
-      0x7C140600,  //  0012  CALL	R5	3
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x80000000,  //  0014  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x60100018,  //  0004  GETGBL	R4	G24
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x88180104,  //  0006  GETMBR	R6	R0	K4
+      0x4C1C0000,  //  0007  LDNIL	R7
+      0x20180C07,  //  0008  NE	R6	R6	R7
+      0x781A0005,  //  0009  JMPF	R6	#0010
+      0x6018000A,  //  000A  GETGBL	R6	G10
+      0x881C0104,  //  000B  GETMBR	R7	R0	K4
+      0x7C180200,  //  000C  CALL	R6	1
+      0x541E0063,  //  000D  LDINT	R7	100
+      0x0C180C07,  //  000E  DIV	R6	R6	R7
+      0x70020000,  //  000F  JMP		#0011
+      0x4C180000,  //  0010  LDNIL	R6
+      0x7C100400,  //  0011  CALL	R4	2
+      0x7C080400,  //  0012  CALL	R2	2
+      0x80000000,  //  0013  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Illuminance.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Illuminance.h
@@ -56,7 +56,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Illuminance_pre_value,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Illuminance_read_attribute,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -64,97 +64,95 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Illuminance_read_attribute,   /* na
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_value),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(U2),
-    /* K9   */  be_nested_str_weak(NULL),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(U4),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(shadow_value),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(U2),
+    /* K8   */  be_nested_str_weak(NULL),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[71]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[70]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E03FF,  //  0005  LDINT	R7	1024
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0035,  //  0007  JMPF	R7	#003E
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E0011,  //  0009  JMPF	R7	#001C
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x4C200000,  //  000B  LDNIL	R8
-      0x201C0E08,  //  000C  NE	R7	R7	R8
-      0x781E0007,  //  000D  JMPF	R7	#0016
-      0x8C1C0907,  //  000E  GETMET	R7	R4	K7
-      0x88240908,  //  000F  GETMBR	R9	R4	K8
-      0x60280009,  //  0010  GETGBL	R10	G9
-      0x882C0106,  //  0011  GETMBR	R11	R0	K6
-      0x7C280200,  //  0012  CALL	R10	1
-      0x7C1C0600,  //  0013  CALL	R7	3
-      0x80040E00,  //  0014  RET	1	R7
-      0x70020004,  //  0015  JMP		#001B
-      0x8C1C0907,  //  0016  GETMET	R7	R4	K7
-      0x88240909,  //  0017  GETMBR	R9	R4	K9
-      0x4C280000,  //  0018  LDNIL	R10
-      0x7C1C0600,  //  0019  CALL	R7	3
-      0x80040E00,  //  001A  RET	1	R7
-      0x70020020,  //  001B  JMP		#003D
-      0x1C1C0D0A,  //  001C  EQ	R7	R6	K10
-      0x781E0005,  //  001D  JMPF	R7	#0024
-      0x8C1C0907,  //  001E  GETMET	R7	R4	K7
-      0x88240908,  //  001F  GETMBR	R9	R4	K8
-      0x5828000A,  //  0020  LDCONST	R10	K10
-      0x7C1C0600,  //  0021  CALL	R7	3
-      0x80040E00,  //  0022  RET	1	R7
-      0x70020018,  //  0023  JMP		#003D
-      0x1C1C0D0B,  //  0024  EQ	R7	R6	K11
-      0x781E0005,  //  0025  JMPF	R7	#002C
-      0x8C1C0907,  //  0026  GETMET	R7	R4	K7
-      0x88240908,  //  0027  GETMBR	R9	R4	K8
-      0x542AFFFD,  //  0028  LDINT	R10	65534
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x80040E00,  //  002A  RET	1	R7
-      0x70020010,  //  002B  JMP		#003D
-      0x541EFFFB,  //  002C  LDINT	R7	65532
-      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
-      0x781E0005,  //  002E  JMPF	R7	#0035
-      0x8C1C0907,  //  002F  GETMET	R7	R4	K7
-      0x8824090C,  //  0030  GETMBR	R9	R4	K12
-      0x58280005,  //  0031  LDCONST	R10	K5
-      0x7C1C0600,  //  0032  CALL	R7	3
-      0x80040E00,  //  0033  RET	1	R7
-      0x70020007,  //  0034  JMP		#003D
-      0x541EFFFC,  //  0035  LDINT	R7	65533
-      0x1C1C0C07,  //  0036  EQ	R7	R6	R7
-      0x781E0004,  //  0037  JMPF	R7	#003D
-      0x8C1C0907,  //  0038  GETMET	R7	R4	K7
-      0x8824090C,  //  0039  GETMBR	R9	R4	K12
-      0x5828000D,  //  003A  LDCONST	R10	K13
-      0x7C1C0600,  //  003B  CALL	R7	3
-      0x80040E00,  //  003C  RET	1	R7
-      0x70020007,  //  003D  JMP		#0046
-      0x601C0003,  //  003E  GETGBL	R7	G3
-      0x5C200000,  //  003F  MOVE	R8	R0
-      0x7C1C0200,  //  0040  CALL	R7	1
-      0x8C1C0F0E,  //  0041  GETMET	R7	R7	K14
-      0x5C240200,  //  0042  MOVE	R9	R1
-      0x5C280400,  //  0043  MOVE	R10	R2
-      0x7C1C0600,  //  0044  CALL	R7	3
-      0x80040E00,  //  0045  RET	1	R7
-      0x80000000,  //  0046  RET	0
+      0x541A03FF,  //  0004  LDINT	R6	1024
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0035,  //  0006  JMPF	R6	#003D
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A0011,  //  0008  JMPF	R6	#001B
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x20180C07,  //  000B  NE	R6	R6	R7
+      0x781A0007,  //  000C  JMPF	R6	#0015
+      0x8C180706,  //  000D  GETMET	R6	R3	K6
+      0x88200707,  //  000E  GETMBR	R8	R3	K7
+      0x60240009,  //  000F  GETGBL	R9	G9
+      0x88280105,  //  0010  GETMBR	R10	R0	K5
+      0x7C240200,  //  0011  CALL	R9	1
+      0x7C180600,  //  0012  CALL	R6	3
+      0x80040C00,  //  0013  RET	1	R6
+      0x70020004,  //  0014  JMP		#001A
+      0x8C180706,  //  0015  GETMET	R6	R3	K6
+      0x88200708,  //  0016  GETMBR	R8	R3	K8
+      0x4C240000,  //  0017  LDNIL	R9
+      0x7C180600,  //  0018  CALL	R6	3
+      0x80040C00,  //  0019  RET	1	R6
+      0x70020020,  //  001A  JMP		#003C
+      0x1C180B09,  //  001B  EQ	R6	R5	K9
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C180706,  //  001D  GETMET	R6	R3	K6
+      0x88200707,  //  001E  GETMBR	R8	R3	K7
+      0x58240009,  //  001F  LDCONST	R9	K9
+      0x7C180600,  //  0020  CALL	R6	3
+      0x80040C00,  //  0021  RET	1	R6
+      0x70020018,  //  0022  JMP		#003C
+      0x1C180B0A,  //  0023  EQ	R6	R5	K10
+      0x781A0005,  //  0024  JMPF	R6	#002B
+      0x8C180706,  //  0025  GETMET	R6	R3	K6
+      0x88200707,  //  0026  GETMBR	R8	R3	K7
+      0x5426FFFD,  //  0027  LDINT	R9	65534
+      0x7C180600,  //  0028  CALL	R6	3
+      0x80040C00,  //  0029  RET	1	R6
+      0x70020010,  //  002A  JMP		#003C
+      0x541AFFFB,  //  002B  LDINT	R6	65532
+      0x1C180A06,  //  002C  EQ	R6	R5	R6
+      0x781A0005,  //  002D  JMPF	R6	#0034
+      0x8C180706,  //  002E  GETMET	R6	R3	K6
+      0x8820070B,  //  002F  GETMBR	R8	R3	K11
+      0x58240004,  //  0030  LDCONST	R9	K4
+      0x7C180600,  //  0031  CALL	R6	3
+      0x80040C00,  //  0032  RET	1	R6
+      0x70020007,  //  0033  JMP		#003C
+      0x541AFFFC,  //  0034  LDINT	R6	65533
+      0x1C180A06,  //  0035  EQ	R6	R5	R6
+      0x781A0004,  //  0036  JMPF	R6	#003C
+      0x8C180706,  //  0037  GETMET	R6	R3	K6
+      0x8820070B,  //  0038  GETMBR	R8	R3	K11
+      0x5824000C,  //  0039  LDCONST	R9	K12
+      0x7C180600,  //  003A  CALL	R6	3
+      0x80040C00,  //  003B  RET	1	R6
+      0x70020007,  //  003C  JMP		#0045
+      0x60180003,  //  003D  GETGBL	R6	G3
+      0x5C1C0000,  //  003E  MOVE	R7	R0
+      0x7C180200,  //  003F  CALL	R6	1
+      0x8C180D0D,  //  0040  GETMET	R6	R6	K13
+      0x5C200200,  //  0041  MOVE	R8	R1
+      0x5C240400,  //  0042  MOVE	R9	R2
+      0x7C180600,  //  0043  CALL	R6	3
+      0x80040C00,  //  0044  RET	1	R6
+      0x80000000,  //  0045  RET	0
     })
   )
 );
@@ -197,7 +195,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Illuminance_value_changed,   /* nam
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Illuminance_web_values,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    8,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -205,31 +203,28 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Illuminance_web_values,   /* name *
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
+    ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(web_values_prefix),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(_X26_X23128261_X3B_X20_X25ilux),
-    /* K6   */  be_nested_str_weak(shadow_value),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(_X26_X23128261_X3B_X20_X25ilux),
+    /* K4   */  be_nested_str_weak(shadow_value),
     }),
     be_str_weak(web_values),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
+    ( &(const binstruction[12]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0303,  //  0004  GETMET	R3	R1	K3
-      0x8C140504,  //  0005  GETMET	R5	R2	K4
-      0x581C0005,  //  0006  LDCONST	R7	K5
-      0x60200009,  //  0007  GETGBL	R8	G9
-      0x88240106,  //  0008  GETMBR	R9	R0	K6
-      0x7C200200,  //  0009  CALL	R8	1
-      0x7C140600,  //  000A  CALL	R5	3
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x80000000,  //  000C  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x60100018,  //  0004  GETGBL	R4	G24
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x60180009,  //  0006  GETGBL	R6	G9
+      0x881C0104,  //  0007  GETMBR	R7	R0	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x7C100400,  //  0009  CALL	R4	2
+      0x7C080400,  //  000A  CALL	R2	2
+      0x80000000,  //  000B  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Occupancy.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Occupancy.h
@@ -147,7 +147,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Occupancy_parse_update,   /* name *
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Occupancy_web_values_prefix,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -155,44 +155,41 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Occupancy_web_values_prefix,   /* n
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(get_name),
-    /* K3   */  be_nested_str_weak(Switch),
-    /* K4   */  be_nested_str_weak(tasmota_switch_index),
-    /* K5   */  be_nested_str_weak(content_send),
-    /* K6   */  be_nested_str_weak(format),
-    /* K7   */  be_nested_str_weak(PREFIX),
-    /* K8   */  be_nested_str_weak(html_escape),
-    /* K9   */  be_nested_str_weak(),
+    /* K1   */  be_nested_str_weak(get_name),
+    /* K2   */  be_nested_str_weak(Switch),
+    /* K3   */  be_nested_str_weak(tasmota_switch_index),
+    /* K4   */  be_nested_str_weak(content_send),
+    /* K5   */  be_nested_str_weak(PREFIX),
+    /* K6   */  be_nested_str_weak(html_escape),
+    /* K7   */  be_nested_str_weak(),
     }),
     be_str_weak(web_values_prefix),
     &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
+    ( &(const binstruction[22]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x5C100600,  //  0004  MOVE	R4	R3
-      0x74120004,  //  0005  JMPT	R4	#000B
-      0x60100008,  //  0006  GETGBL	R4	G8
-      0x88140104,  //  0007  GETMBR	R5	R0	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x00120604,  //  0009  ADD	R4	K3	R4
-      0x5C0C0800,  //  000A  MOVE	R3	R4
-      0x8C100305,  //  000B  GETMET	R4	R1	K5
-      0x8C180506,  //  000C  GETMET	R6	R2	K6
-      0x88200107,  //  000D  GETMBR	R8	R0	K7
-      0x780E0003,  //  000E  JMPF	R3	#0013
-      0x8C240308,  //  000F  GETMET	R9	R1	K8
-      0x5C2C0600,  //  0010  MOVE	R11	R3
-      0x7C240400,  //  0011  CALL	R9	2
-      0x70020000,  //  0012  JMP		#0014
-      0x58240009,  //  0013  LDCONST	R9	K9
-      0x7C180600,  //  0014  CALL	R6	3
-      0x7C100400,  //  0015  CALL	R4	2
-      0x80000000,  //  0016  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x5C0C0400,  //  0003  MOVE	R3	R2
+      0x740E0004,  //  0004  JMPT	R3	#000A
+      0x600C0008,  //  0005  GETGBL	R3	G8
+      0x88100103,  //  0006  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x000E0403,  //  0008  ADD	R3	K2	R3
+      0x5C080600,  //  0009  MOVE	R2	R3
+      0x8C0C0304,  //  000A  GETMET	R3	R1	K4
+      0x60140018,  //  000B  GETGBL	R5	G24
+      0x88180105,  //  000C  GETMBR	R6	R0	K5
+      0x780A0003,  //  000D  JMPF	R2	#0012
+      0x8C1C0306,  //  000E  GETMET	R7	R1	K6
+      0x5C240400,  //  000F  MOVE	R9	R2
+      0x7C1C0400,  //  0010  CALL	R7	2
+      0x70020000,  //  0011  JMP		#0013
+      0x581C0007,  //  0012  LDCONST	R7	K7
+      0x7C140400,  //  0013  CALL	R5	2
+      0x7C0C0400,  //  0014  CALL	R3	2
+      0x80000000,  //  0015  RET	0
     })
   )
 );
@@ -204,7 +201,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Occupancy_web_values_prefix,   /* n
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Occupancy_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -212,95 +209,93 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Occupancy_read_attribute,   /* name
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_occupancy),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(U1),
-    /* K9   */  be_nested_str_weak(NULL),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_const_int(2),
-    /* K13  */  be_nested_str_weak(U4),
-    /* K14  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(shadow_occupancy),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(U1),
+    /* K8   */  be_nested_str_weak(NULL),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_nested_str_weak(U4),
+    /* K13  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[69]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[68]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0405,  //  0005  LDINT	R7	1030
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0033,  //  0007  JMPF	R7	#003C
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E000F,  //  0009  JMPF	R7	#001A
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x4C200000,  //  000B  LDNIL	R8
-      0x201C0E08,  //  000C  NE	R7	R7	R8
-      0x781E0005,  //  000D  JMPF	R7	#0014
-      0x8C1C0907,  //  000E  GETMET	R7	R4	K7
-      0x88240908,  //  000F  GETMBR	R9	R4	K8
-      0x88280106,  //  0010  GETMBR	R10	R0	K6
-      0x7C1C0600,  //  0011  CALL	R7	3
-      0x80040E00,  //  0012  RET	1	R7
-      0x70020004,  //  0013  JMP		#0019
-      0x8C1C0907,  //  0014  GETMET	R7	R4	K7
-      0x88240909,  //  0015  GETMBR	R9	R4	K9
-      0x4C280000,  //  0016  LDNIL	R10
-      0x7C1C0600,  //  0017  CALL	R7	3
-      0x80040E00,  //  0018  RET	1	R7
-      0x70020020,  //  0019  JMP		#003B
-      0x1C1C0D0A,  //  001A  EQ	R7	R6	K10
-      0x781E0005,  //  001B  JMPF	R7	#0022
-      0x8C1C0907,  //  001C  GETMET	R7	R4	K7
-      0x88240908,  //  001D  GETMBR	R9	R4	K8
-      0x5828000B,  //  001E  LDCONST	R10	K11
-      0x7C1C0600,  //  001F  CALL	R7	3
-      0x80040E00,  //  0020  RET	1	R7
-      0x70020018,  //  0021  JMP		#003B
-      0x1C1C0D0C,  //  0022  EQ	R7	R6	K12
-      0x781E0005,  //  0023  JMPF	R7	#002A
-      0x8C1C0907,  //  0024  GETMET	R7	R4	K7
-      0x88240908,  //  0025  GETMBR	R9	R4	K8
-      0x58280005,  //  0026  LDCONST	R10	K5
-      0x7C1C0600,  //  0027  CALL	R7	3
-      0x80040E00,  //  0028  RET	1	R7
-      0x70020010,  //  0029  JMP		#003B
-      0x541EFFFB,  //  002A  LDINT	R7	65532
-      0x1C1C0C07,  //  002B  EQ	R7	R6	R7
-      0x781E0005,  //  002C  JMPF	R7	#0033
-      0x8C1C0907,  //  002D  GETMET	R7	R4	K7
-      0x8824090D,  //  002E  GETMBR	R9	R4	K13
-      0x58280005,  //  002F  LDCONST	R10	K5
-      0x7C1C0600,  //  0030  CALL	R7	3
-      0x80040E00,  //  0031  RET	1	R7
-      0x70020007,  //  0032  JMP		#003B
-      0x541EFFFC,  //  0033  LDINT	R7	65533
-      0x1C1C0C07,  //  0034  EQ	R7	R6	R7
-      0x781E0004,  //  0035  JMPF	R7	#003B
-      0x8C1C0907,  //  0036  GETMET	R7	R4	K7
-      0x8824090D,  //  0037  GETMBR	R9	R4	K13
-      0x5828000B,  //  0038  LDCONST	R10	K11
-      0x7C1C0600,  //  0039  CALL	R7	3
-      0x80040E00,  //  003A  RET	1	R7
-      0x70020007,  //  003B  JMP		#0044
-      0x601C0003,  //  003C  GETGBL	R7	G3
-      0x5C200000,  //  003D  MOVE	R8	R0
-      0x7C1C0200,  //  003E  CALL	R7	1
-      0x8C1C0F0E,  //  003F  GETMET	R7	R7	K14
-      0x5C240200,  //  0040  MOVE	R9	R1
-      0x5C280400,  //  0041  MOVE	R10	R2
-      0x7C1C0600,  //  0042  CALL	R7	3
-      0x80040E00,  //  0043  RET	1	R7
-      0x80000000,  //  0044  RET	0
+      0x541A0405,  //  0004  LDINT	R6	1030
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0033,  //  0006  JMPF	R6	#003B
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A000F,  //  0008  JMPF	R6	#0019
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x20180C07,  //  000B  NE	R6	R6	R7
+      0x781A0005,  //  000C  JMPF	R6	#0013
+      0x8C180706,  //  000D  GETMET	R6	R3	K6
+      0x88200707,  //  000E  GETMBR	R8	R3	K7
+      0x88240105,  //  000F  GETMBR	R9	R0	K5
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80040C00,  //  0011  RET	1	R6
+      0x70020004,  //  0012  JMP		#0018
+      0x8C180706,  //  0013  GETMET	R6	R3	K6
+      0x88200708,  //  0014  GETMBR	R8	R3	K8
+      0x4C240000,  //  0015  LDNIL	R9
+      0x7C180600,  //  0016  CALL	R6	3
+      0x80040C00,  //  0017  RET	1	R6
+      0x70020020,  //  0018  JMP		#003A
+      0x1C180B09,  //  0019  EQ	R6	R5	K9
+      0x781A0005,  //  001A  JMPF	R6	#0021
+      0x8C180706,  //  001B  GETMET	R6	R3	K6
+      0x88200707,  //  001C  GETMBR	R8	R3	K7
+      0x5824000A,  //  001D  LDCONST	R9	K10
+      0x7C180600,  //  001E  CALL	R6	3
+      0x80040C00,  //  001F  RET	1	R6
+      0x70020018,  //  0020  JMP		#003A
+      0x1C180B0B,  //  0021  EQ	R6	R5	K11
+      0x781A0005,  //  0022  JMPF	R6	#0029
+      0x8C180706,  //  0023  GETMET	R6	R3	K6
+      0x88200707,  //  0024  GETMBR	R8	R3	K7
+      0x58240004,  //  0025  LDCONST	R9	K4
+      0x7C180600,  //  0026  CALL	R6	3
+      0x80040C00,  //  0027  RET	1	R6
+      0x70020010,  //  0028  JMP		#003A
+      0x541AFFFB,  //  0029  LDINT	R6	65532
+      0x1C180A06,  //  002A  EQ	R6	R5	R6
+      0x781A0005,  //  002B  JMPF	R6	#0032
+      0x8C180706,  //  002C  GETMET	R6	R3	K6
+      0x8820070C,  //  002D  GETMBR	R8	R3	K12
+      0x58240004,  //  002E  LDCONST	R9	K4
+      0x7C180600,  //  002F  CALL	R6	3
+      0x80040C00,  //  0030  RET	1	R6
+      0x70020007,  //  0031  JMP		#003A
+      0x541AFFFC,  //  0032  LDINT	R6	65533
+      0x1C180A06,  //  0033  EQ	R6	R5	R6
+      0x781A0004,  //  0034  JMPF	R6	#003A
+      0x8C180706,  //  0035  GETMET	R6	R3	K6
+      0x8820070C,  //  0036  GETMBR	R8	R3	K12
+      0x5824000A,  //  0037  LDCONST	R9	K10
+      0x7C180600,  //  0038  CALL	R6	3
+      0x80040C00,  //  0039  RET	1	R6
+      0x70020007,  //  003A  JMP		#0043
+      0x60180003,  //  003B  GETGBL	R6	G3
+      0x5C1C0000,  //  003C  MOVE	R7	R0
+      0x7C180200,  //  003D  CALL	R6	1
+      0x8C180D0D,  //  003E  GETMET	R6	R6	K13
+      0x5C200200,  //  003F  MOVE	R8	R1
+      0x5C240400,  //  0040  MOVE	R9	R2
+      0x7C180600,  //  0041  CALL	R6	3
+      0x80040C00,  //  0042  RET	1	R6
+      0x80000000,  //  0043  RET	0
     })
   )
 );
@@ -312,7 +307,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Occupancy_read_attribute,   /* name
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Occupancy_web_values,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -320,34 +315,31 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Occupancy_web_values,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(web_values_prefix),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(Occupancy_X25i_X20_X25s),
-    /* K6   */  be_nested_str_weak(tasmota_switch_index),
-    /* K7   */  be_nested_str_weak(web_value_onoff),
-    /* K8   */  be_nested_str_weak(shadow_occupancy),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(Occupancy_X25i_X20_X25s),
+    /* K4   */  be_nested_str_weak(tasmota_switch_index),
+    /* K5   */  be_nested_str_weak(web_value_onoff),
+    /* K6   */  be_nested_str_weak(shadow_occupancy),
     }),
     be_str_weak(web_values),
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
+    ( &(const binstruction[13]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0303,  //  0004  GETMET	R3	R1	K3
-      0x8C140504,  //  0005  GETMET	R5	R2	K4
-      0x581C0005,  //  0006  LDCONST	R7	K5
-      0x88200106,  //  0007  GETMBR	R8	R0	K6
-      0x8C240107,  //  0008  GETMET	R9	R0	K7
-      0x882C0108,  //  0009  GETMBR	R11	R0	K8
-      0x7C240400,  //  000A  CALL	R9	2
-      0x7C140800,  //  000B  CALL	R5	4
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x80000000,  //  000D  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x60100018,  //  0004  GETGBL	R4	G24
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x88180104,  //  0006  GETMBR	R6	R0	K4
+      0x8C1C0105,  //  0007  GETMET	R7	R0	K5
+      0x88240106,  //  0008  GETMBR	R9	R0	K6
+      0x7C1C0400,  //  0009  CALL	R7	2
+      0x7C100600,  //  000A  CALL	R4	3
+      0x7C080400,  //  000B  CALL	R2	2
+      0x80000000,  //  000C  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Pressure.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Pressure.h
@@ -43,7 +43,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Pressure_pre_value,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Pressure_read_attribute,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -51,97 +51,95 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Pressure_read_attribute,   /* name 
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_value),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(I2),
-    /* K9   */  be_nested_str_weak(NULL),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(U4),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(shadow_value),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(I2),
+    /* K8   */  be_nested_str_weak(NULL),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[71]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[70]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0402,  //  0005  LDINT	R7	1027
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0035,  //  0007  JMPF	R7	#003E
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E0011,  //  0009  JMPF	R7	#001C
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x4C200000,  //  000B  LDNIL	R8
-      0x201C0E08,  //  000C  NE	R7	R7	R8
-      0x781E0007,  //  000D  JMPF	R7	#0016
-      0x8C1C0907,  //  000E  GETMET	R7	R4	K7
-      0x88240908,  //  000F  GETMBR	R9	R4	K8
-      0x60280009,  //  0010  GETGBL	R10	G9
-      0x882C0106,  //  0011  GETMBR	R11	R0	K6
-      0x7C280200,  //  0012  CALL	R10	1
-      0x7C1C0600,  //  0013  CALL	R7	3
-      0x80040E00,  //  0014  RET	1	R7
-      0x70020004,  //  0015  JMP		#001B
-      0x8C1C0907,  //  0016  GETMET	R7	R4	K7
-      0x88240909,  //  0017  GETMBR	R9	R4	K9
-      0x4C280000,  //  0018  LDNIL	R10
-      0x7C1C0600,  //  0019  CALL	R7	3
-      0x80040E00,  //  001A  RET	1	R7
-      0x70020020,  //  001B  JMP		#003D
-      0x1C1C0D0A,  //  001C  EQ	R7	R6	K10
-      0x781E0005,  //  001D  JMPF	R7	#0024
-      0x8C1C0907,  //  001E  GETMET	R7	R4	K7
-      0x88240908,  //  001F  GETMBR	R9	R4	K8
-      0x542A01F3,  //  0020  LDINT	R10	500
-      0x7C1C0600,  //  0021  CALL	R7	3
-      0x80040E00,  //  0022  RET	1	R7
-      0x70020018,  //  0023  JMP		#003D
-      0x1C1C0D0B,  //  0024  EQ	R7	R6	K11
-      0x781E0005,  //  0025  JMPF	R7	#002C
-      0x8C1C0907,  //  0026  GETMET	R7	R4	K7
-      0x88240908,  //  0027  GETMBR	R9	R4	K8
-      0x542A05DB,  //  0028  LDINT	R10	1500
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x80040E00,  //  002A  RET	1	R7
-      0x70020010,  //  002B  JMP		#003D
-      0x541EFFFB,  //  002C  LDINT	R7	65532
-      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
-      0x781E0005,  //  002E  JMPF	R7	#0035
-      0x8C1C0907,  //  002F  GETMET	R7	R4	K7
-      0x8824090C,  //  0030  GETMBR	R9	R4	K12
-      0x58280005,  //  0031  LDCONST	R10	K5
-      0x7C1C0600,  //  0032  CALL	R7	3
-      0x80040E00,  //  0033  RET	1	R7
-      0x70020007,  //  0034  JMP		#003D
-      0x541EFFFC,  //  0035  LDINT	R7	65533
-      0x1C1C0C07,  //  0036  EQ	R7	R6	R7
-      0x781E0004,  //  0037  JMPF	R7	#003D
-      0x8C1C0907,  //  0038  GETMET	R7	R4	K7
-      0x8824090C,  //  0039  GETMBR	R9	R4	K12
-      0x5828000D,  //  003A  LDCONST	R10	K13
-      0x7C1C0600,  //  003B  CALL	R7	3
-      0x80040E00,  //  003C  RET	1	R7
-      0x70020007,  //  003D  JMP		#0046
-      0x601C0003,  //  003E  GETGBL	R7	G3
-      0x5C200000,  //  003F  MOVE	R8	R0
-      0x7C1C0200,  //  0040  CALL	R7	1
-      0x8C1C0F0E,  //  0041  GETMET	R7	R7	K14
-      0x5C240200,  //  0042  MOVE	R9	R1
-      0x5C280400,  //  0043  MOVE	R10	R2
-      0x7C1C0600,  //  0044  CALL	R7	3
-      0x80040E00,  //  0045  RET	1	R7
-      0x80000000,  //  0046  RET	0
+      0x541A0402,  //  0004  LDINT	R6	1027
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0035,  //  0006  JMPF	R6	#003D
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A0011,  //  0008  JMPF	R6	#001B
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x20180C07,  //  000B  NE	R6	R6	R7
+      0x781A0007,  //  000C  JMPF	R6	#0015
+      0x8C180706,  //  000D  GETMET	R6	R3	K6
+      0x88200707,  //  000E  GETMBR	R8	R3	K7
+      0x60240009,  //  000F  GETGBL	R9	G9
+      0x88280105,  //  0010  GETMBR	R10	R0	K5
+      0x7C240200,  //  0011  CALL	R9	1
+      0x7C180600,  //  0012  CALL	R6	3
+      0x80040C00,  //  0013  RET	1	R6
+      0x70020004,  //  0014  JMP		#001A
+      0x8C180706,  //  0015  GETMET	R6	R3	K6
+      0x88200708,  //  0016  GETMBR	R8	R3	K8
+      0x4C240000,  //  0017  LDNIL	R9
+      0x7C180600,  //  0018  CALL	R6	3
+      0x80040C00,  //  0019  RET	1	R6
+      0x70020020,  //  001A  JMP		#003C
+      0x1C180B09,  //  001B  EQ	R6	R5	K9
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C180706,  //  001D  GETMET	R6	R3	K6
+      0x88200707,  //  001E  GETMBR	R8	R3	K7
+      0x542601F3,  //  001F  LDINT	R9	500
+      0x7C180600,  //  0020  CALL	R6	3
+      0x80040C00,  //  0021  RET	1	R6
+      0x70020018,  //  0022  JMP		#003C
+      0x1C180B0A,  //  0023  EQ	R6	R5	K10
+      0x781A0005,  //  0024  JMPF	R6	#002B
+      0x8C180706,  //  0025  GETMET	R6	R3	K6
+      0x88200707,  //  0026  GETMBR	R8	R3	K7
+      0x542605DB,  //  0027  LDINT	R9	1500
+      0x7C180600,  //  0028  CALL	R6	3
+      0x80040C00,  //  0029  RET	1	R6
+      0x70020010,  //  002A  JMP		#003C
+      0x541AFFFB,  //  002B  LDINT	R6	65532
+      0x1C180A06,  //  002C  EQ	R6	R5	R6
+      0x781A0005,  //  002D  JMPF	R6	#0034
+      0x8C180706,  //  002E  GETMET	R6	R3	K6
+      0x8820070B,  //  002F  GETMBR	R8	R3	K11
+      0x58240004,  //  0030  LDCONST	R9	K4
+      0x7C180600,  //  0031  CALL	R6	3
+      0x80040C00,  //  0032  RET	1	R6
+      0x70020007,  //  0033  JMP		#003C
+      0x541AFFFC,  //  0034  LDINT	R6	65533
+      0x1C180A06,  //  0035  EQ	R6	R5	R6
+      0x781A0004,  //  0036  JMPF	R6	#003C
+      0x8C180706,  //  0037  GETMET	R6	R3	K6
+      0x8820070B,  //  0038  GETMBR	R8	R3	K11
+      0x5824000C,  //  0039  LDCONST	R9	K12
+      0x7C180600,  //  003A  CALL	R6	3
+      0x80040C00,  //  003B  RET	1	R6
+      0x70020007,  //  003C  JMP		#0045
+      0x60180003,  //  003D  GETGBL	R6	G3
+      0x5C1C0000,  //  003E  MOVE	R7	R0
+      0x7C180200,  //  003F  CALL	R6	1
+      0x8C180D0D,  //  0040  GETMET	R6	R6	K13
+      0x5C200200,  //  0041  MOVE	R8	R1
+      0x5C240400,  //  0042  MOVE	R9	R2
+      0x7C180600,  //  0043  CALL	R6	3
+      0x80040C00,  //  0044  RET	1	R6
+      0x80000000,  //  0045  RET	0
     })
   )
 );
@@ -184,7 +182,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Pressure_value_changed,   /* name *
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Pressure_web_values,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    8,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -192,31 +190,28 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Pressure_web_values,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
+    ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(web_values_prefix),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(_X26_X23x26C5_X3B_X20_X25i_X20hPa),
-    /* K6   */  be_nested_str_weak(shadow_value),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(_X26_X23x26C5_X3B_X20_X25i_X20hPa),
+    /* K4   */  be_nested_str_weak(shadow_value),
     }),
     be_str_weak(web_values),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
+    ( &(const binstruction[12]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0303,  //  0004  GETMET	R3	R1	K3
-      0x8C140504,  //  0005  GETMET	R5	R2	K4
-      0x581C0005,  //  0006  LDCONST	R7	K5
-      0x60200009,  //  0007  GETGBL	R8	G9
-      0x88240106,  //  0008  GETMBR	R9	R0	K6
-      0x7C200200,  //  0009  CALL	R8	1
-      0x7C140600,  //  000A  CALL	R5	3
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x80000000,  //  000C  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x60100018,  //  0004  GETGBL	R4	G24
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x60180009,  //  0006  GETGBL	R6	G9
+      0x881C0104,  //  0007  GETMBR	R7	R0	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x7C100400,  //  0009  CALL	R4	2
+      0x7C080400,  //  000A  CALL	R2	2
+      0x80000000,  //  000B  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Temp.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Temp.h
@@ -44,7 +44,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Temp_pre_value,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Temp_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -52,94 +52,92 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Temp_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_value),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(I2),
-    /* K9   */  be_nested_str_weak(NULL),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(U4),
-    /* K13  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(shadow_value),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(I2),
+    /* K8   */  be_nested_str_weak(NULL),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[69]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[68]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0401,  //  0005  LDINT	R7	1026
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0033,  //  0007  JMPF	R7	#003C
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E000F,  //  0009  JMPF	R7	#001A
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x4C200000,  //  000B  LDNIL	R8
-      0x201C0E08,  //  000C  NE	R7	R7	R8
-      0x781E0005,  //  000D  JMPF	R7	#0014
-      0x8C1C0907,  //  000E  GETMET	R7	R4	K7
-      0x88240908,  //  000F  GETMBR	R9	R4	K8
-      0x88280106,  //  0010  GETMBR	R10	R0	K6
-      0x7C1C0600,  //  0011  CALL	R7	3
-      0x80040E00,  //  0012  RET	1	R7
-      0x70020004,  //  0013  JMP		#0019
-      0x8C1C0907,  //  0014  GETMET	R7	R4	K7
-      0x88240909,  //  0015  GETMBR	R9	R4	K9
-      0x4C280000,  //  0016  LDNIL	R10
-      0x7C1C0600,  //  0017  CALL	R7	3
-      0x80040E00,  //  0018  RET	1	R7
-      0x70020020,  //  0019  JMP		#003B
-      0x1C1C0D0A,  //  001A  EQ	R7	R6	K10
-      0x781E0005,  //  001B  JMPF	R7	#0022
-      0x8C1C0907,  //  001C  GETMET	R7	R4	K7
-      0x88240908,  //  001D  GETMBR	R9	R4	K8
-      0x5429EC77,  //  001E  LDINT	R10	-5000
-      0x7C1C0600,  //  001F  CALL	R7	3
-      0x80040E00,  //  0020  RET	1	R7
-      0x70020018,  //  0021  JMP		#003B
-      0x1C1C0D0B,  //  0022  EQ	R7	R6	K11
-      0x781E0005,  //  0023  JMPF	R7	#002A
-      0x8C1C0907,  //  0024  GETMET	R7	R4	K7
-      0x88240908,  //  0025  GETMBR	R9	R4	K8
-      0x542A3A97,  //  0026  LDINT	R10	15000
-      0x7C1C0600,  //  0027  CALL	R7	3
-      0x80040E00,  //  0028  RET	1	R7
-      0x70020010,  //  0029  JMP		#003B
-      0x541EFFFB,  //  002A  LDINT	R7	65532
-      0x1C1C0C07,  //  002B  EQ	R7	R6	R7
-      0x781E0005,  //  002C  JMPF	R7	#0033
-      0x8C1C0907,  //  002D  GETMET	R7	R4	K7
-      0x8824090C,  //  002E  GETMBR	R9	R4	K12
-      0x58280005,  //  002F  LDCONST	R10	K5
-      0x7C1C0600,  //  0030  CALL	R7	3
-      0x80040E00,  //  0031  RET	1	R7
-      0x70020007,  //  0032  JMP		#003B
-      0x541EFFFC,  //  0033  LDINT	R7	65533
-      0x1C1C0C07,  //  0034  EQ	R7	R6	R7
-      0x781E0004,  //  0035  JMPF	R7	#003B
-      0x8C1C0907,  //  0036  GETMET	R7	R4	K7
-      0x8824090C,  //  0037  GETMBR	R9	R4	K12
-      0x542A0003,  //  0038  LDINT	R10	4
-      0x7C1C0600,  //  0039  CALL	R7	3
-      0x80040E00,  //  003A  RET	1	R7
-      0x70020007,  //  003B  JMP		#0044
-      0x601C0003,  //  003C  GETGBL	R7	G3
-      0x5C200000,  //  003D  MOVE	R8	R0
-      0x7C1C0200,  //  003E  CALL	R7	1
-      0x8C1C0F0D,  //  003F  GETMET	R7	R7	K13
-      0x5C240200,  //  0040  MOVE	R9	R1
-      0x5C280400,  //  0041  MOVE	R10	R2
-      0x7C1C0600,  //  0042  CALL	R7	3
-      0x80040E00,  //  0043  RET	1	R7
-      0x80000000,  //  0044  RET	0
+      0x541A0401,  //  0004  LDINT	R6	1026
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0033,  //  0006  JMPF	R6	#003B
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A000F,  //  0008  JMPF	R6	#0019
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x20180C07,  //  000B  NE	R6	R6	R7
+      0x781A0005,  //  000C  JMPF	R6	#0013
+      0x8C180706,  //  000D  GETMET	R6	R3	K6
+      0x88200707,  //  000E  GETMBR	R8	R3	K7
+      0x88240105,  //  000F  GETMBR	R9	R0	K5
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80040C00,  //  0011  RET	1	R6
+      0x70020004,  //  0012  JMP		#0018
+      0x8C180706,  //  0013  GETMET	R6	R3	K6
+      0x88200708,  //  0014  GETMBR	R8	R3	K8
+      0x4C240000,  //  0015  LDNIL	R9
+      0x7C180600,  //  0016  CALL	R6	3
+      0x80040C00,  //  0017  RET	1	R6
+      0x70020020,  //  0018  JMP		#003A
+      0x1C180B09,  //  0019  EQ	R6	R5	K9
+      0x781A0005,  //  001A  JMPF	R6	#0021
+      0x8C180706,  //  001B  GETMET	R6	R3	K6
+      0x88200707,  //  001C  GETMBR	R8	R3	K7
+      0x5425EC77,  //  001D  LDINT	R9	-5000
+      0x7C180600,  //  001E  CALL	R6	3
+      0x80040C00,  //  001F  RET	1	R6
+      0x70020018,  //  0020  JMP		#003A
+      0x1C180B0A,  //  0021  EQ	R6	R5	K10
+      0x781A0005,  //  0022  JMPF	R6	#0029
+      0x8C180706,  //  0023  GETMET	R6	R3	K6
+      0x88200707,  //  0024  GETMBR	R8	R3	K7
+      0x54263A97,  //  0025  LDINT	R9	15000
+      0x7C180600,  //  0026  CALL	R6	3
+      0x80040C00,  //  0027  RET	1	R6
+      0x70020010,  //  0028  JMP		#003A
+      0x541AFFFB,  //  0029  LDINT	R6	65532
+      0x1C180A06,  //  002A  EQ	R6	R5	R6
+      0x781A0005,  //  002B  JMPF	R6	#0032
+      0x8C180706,  //  002C  GETMET	R6	R3	K6
+      0x8820070B,  //  002D  GETMBR	R8	R3	K11
+      0x58240004,  //  002E  LDCONST	R9	K4
+      0x7C180600,  //  002F  CALL	R6	3
+      0x80040C00,  //  0030  RET	1	R6
+      0x70020007,  //  0031  JMP		#003A
+      0x541AFFFC,  //  0032  LDINT	R6	65533
+      0x1C180A06,  //  0033  EQ	R6	R5	R6
+      0x781A0004,  //  0034  JMPF	R6	#003A
+      0x8C180706,  //  0035  GETMET	R6	R3	K6
+      0x8820070B,  //  0036  GETMBR	R8	R3	K11
+      0x54260003,  //  0037  LDINT	R9	4
+      0x7C180600,  //  0038  CALL	R6	3
+      0x80040C00,  //  0039  RET	1	R6
+      0x70020007,  //  003A  JMP		#0043
+      0x60180003,  //  003B  GETGBL	R6	G3
+      0x5C1C0000,  //  003C  MOVE	R7	R0
+      0x7C180200,  //  003D  CALL	R6	1
+      0x8C180D0C,  //  003E  GETMET	R6	R6	K12
+      0x5C200200,  //  003F  MOVE	R8	R1
+      0x5C240400,  //  0040  MOVE	R9	R2
+      0x7C180600,  //  0041  CALL	R6	3
+      0x80040C00,  //  0042  RET	1	R6
+      0x80000000,  //  0043  RET	0
     })
   )
 );
@@ -182,7 +180,7 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Temp_value_changed,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_Temp_web_values,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    8,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -190,39 +188,36 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Temp_web_values,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
+    ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(web_values_prefix),
-    /* K3   */  be_nested_str_weak(content_send),
-    /* K4   */  be_nested_str_weak(format),
-    /* K5   */  be_nested_str_weak(_X26_X23x2600_X3B_X26_X23xFE0F_X3B_X20_X25_X2E1f_X20_XC2_XB0C),
-    /* K6   */  be_nested_str_weak(shadow_value),
+    /* K1   */  be_nested_str_weak(web_values_prefix),
+    /* K2   */  be_nested_str_weak(content_send),
+    /* K3   */  be_nested_str_weak(_X26_X23x2600_X3B_X26_X23xFE0F_X3B_X20_X25_X2E1f_X20_XC2_XB0C),
+    /* K4   */  be_nested_str_weak(shadow_value),
     }),
     be_str_weak(web_values),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
+    ( &(const binstruction[20]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0303,  //  0004  GETMET	R3	R1	K3
-      0x8C140504,  //  0005  GETMET	R5	R2	K4
-      0x581C0005,  //  0006  LDCONST	R7	K5
-      0x88200106,  //  0007  GETMBR	R8	R0	K6
-      0x4C240000,  //  0008  LDNIL	R9
-      0x20201009,  //  0009  NE	R8	R8	R9
-      0x78220005,  //  000A  JMPF	R8	#0011
-      0x6020000A,  //  000B  GETGBL	R8	G10
-      0x88240106,  //  000C  GETMBR	R9	R0	K6
-      0x7C200200,  //  000D  CALL	R8	1
-      0x54260063,  //  000E  LDINT	R9	100
-      0x0C201009,  //  000F  DIV	R8	R8	R9
-      0x70020000,  //  0010  JMP		#0012
-      0x4C200000,  //  0011  LDNIL	R8
-      0x7C140600,  //  0012  CALL	R5	3
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x80000000,  //  0014  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x60100018,  //  0004  GETGBL	R4	G24
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x88180104,  //  0006  GETMBR	R6	R0	K4
+      0x4C1C0000,  //  0007  LDNIL	R7
+      0x20180C07,  //  0008  NE	R6	R6	R7
+      0x781A0005,  //  0009  JMPF	R6	#0010
+      0x6018000A,  //  000A  GETGBL	R6	G10
+      0x881C0104,  //  000B  GETMBR	R7	R0	K4
+      0x7C180200,  //  000C  CALL	R6	1
+      0x541E0063,  //  000D  LDINT	R7	100
+      0x0C180C07,  //  000E  DIV	R6	R6	R7
+      0x70020000,  //  000F  JMP		#0011
+      0x4C180000,  //  0010  LDNIL	R6
+      0x7C100400,  //  0011  CALL	R4	2
+      0x7C080400,  //  0012  CALL	R2	2
+      0x80000000,  //  0013  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Device.h
@@ -202,7 +202,7 @@ be_local_closure(Matter_Plugin_Device_invoke_request,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
   be_nested_proto(
-    17,                          /* nstack */
+    16,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -210,216 +210,214 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(U2),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(U1),
-    /* K11  */  be_nested_str_weak(U4),
-    /* K12  */  be_nested_str_weak(Matter_TLV_array),
-    /* K13  */  be_nested_str_weak(TYPES),
-    /* K14  */  be_nested_str_weak(keys),
-    /* K15  */  be_nested_str_weak(add_struct),
-    /* K16  */  be_nested_str_weak(add_TLV),
-    /* K17  */  be_nested_str_weak(stop_iteration),
-    /* K18  */  be_nested_str_weak(NON_BRIDGE_VENDOR),
-    /* K19  */  be_nested_str_weak(find),
-    /* K20  */  be_nested_str_weak(get_admin_vendor),
-    /* K21  */  be_nested_str_weak(read_attribute),
-    /* K22  */  be_nested_str_weak(UTF1),
-    /* K23  */  be_nested_str_weak(get_name),
+    ( &(const bvalue[23]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(3),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(U2),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(U1),
+    /* K10  */  be_nested_str_weak(U4),
+    /* K11  */  be_nested_str_weak(Matter_TLV_array),
+    /* K12  */  be_nested_str_weak(TYPES),
+    /* K13  */  be_nested_str_weak(keys),
+    /* K14  */  be_nested_str_weak(add_struct),
+    /* K15  */  be_nested_str_weak(add_TLV),
+    /* K16  */  be_nested_str_weak(stop_iteration),
+    /* K17  */  be_nested_str_weak(NON_BRIDGE_VENDOR),
+    /* K18  */  be_nested_str_weak(find),
+    /* K19  */  be_nested_str_weak(get_admin_vendor),
+    /* K20  */  be_nested_str_weak(read_attribute),
+    /* K21  */  be_nested_str_weak(UTF1),
+    /* K22  */  be_nested_str_weak(get_name),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[181]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[180]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x1C1C0B05,  //  0005  EQ	R7	R5	K5
-      0x781E0021,  //  0006  JMPF	R7	#0029
-      0x1C1C0D06,  //  0007  EQ	R7	R6	K6
-      0x781E0005,  //  0008  JMPF	R7	#000F
-      0x8C1C0907,  //  0009  GETMET	R7	R4	K7
-      0x88240908,  //  000A  GETMBR	R9	R4	K8
-      0x58280006,  //  000B  LDCONST	R10	K6
-      0x7C1C0600,  //  000C  CALL	R7	3
-      0x80040E00,  //  000D  RET	1	R7
-      0x70020018,  //  000E  JMP		#0028
-      0x1C1C0D09,  //  000F  EQ	R7	R6	K9
-      0x781E0005,  //  0010  JMPF	R7	#0017
-      0x8C1C0907,  //  0011  GETMET	R7	R4	K7
-      0x8824090A,  //  0012  GETMBR	R9	R4	K10
-      0x58280006,  //  0013  LDCONST	R10	K6
-      0x7C1C0600,  //  0014  CALL	R7	3
-      0x80040E00,  //  0015  RET	1	R7
-      0x70020010,  //  0016  JMP		#0028
-      0x541EFFFB,  //  0017  LDINT	R7	65532
-      0x1C1C0C07,  //  0018  EQ	R7	R6	R7
-      0x781E0005,  //  0019  JMPF	R7	#0020
-      0x8C1C0907,  //  001A  GETMET	R7	R4	K7
-      0x8824090B,  //  001B  GETMBR	R9	R4	K11
-      0x58280006,  //  001C  LDCONST	R10	K6
-      0x7C1C0600,  //  001D  CALL	R7	3
-      0x80040E00,  //  001E  RET	1	R7
-      0x70020007,  //  001F  JMP		#0028
-      0x541EFFFC,  //  0020  LDINT	R7	65533
-      0x1C1C0C07,  //  0021  EQ	R7	R6	R7
-      0x781E0004,  //  0022  JMPF	R7	#0028
-      0x8C1C0907,  //  0023  GETMET	R7	R4	K7
-      0x8824090B,  //  0024  GETMBR	R9	R4	K11
-      0x542A0003,  //  0025  LDINT	R10	4
-      0x7C1C0600,  //  0026  CALL	R7	3
-      0x80040E00,  //  0027  RET	1	R7
-      0x7002008A,  //  0028  JMP		#00B4
-      0x541E0003,  //  0029  LDINT	R7	4
-      0x1C1C0A07,  //  002A  EQ	R7	R5	R7
-      0x781E0016,  //  002B  JMPF	R7	#0043
-      0x1C1C0D06,  //  002C  EQ	R7	R6	K6
-      0x781E0002,  //  002D  JMPF	R7	#0031
-      0x4C1C0000,  //  002E  LDNIL	R7
-      0x80040E00,  //  002F  RET	1	R7
-      0x70020010,  //  0030  JMP		#0042
-      0x541EFFFB,  //  0031  LDINT	R7	65532
-      0x1C1C0C07,  //  0032  EQ	R7	R6	R7
-      0x781E0005,  //  0033  JMPF	R7	#003A
-      0x8C1C0907,  //  0034  GETMET	R7	R4	K7
-      0x8824090B,  //  0035  GETMBR	R9	R4	K11
-      0x58280006,  //  0036  LDCONST	R10	K6
-      0x7C1C0600,  //  0037  CALL	R7	3
-      0x80040E00,  //  0038  RET	1	R7
-      0x70020007,  //  0039  JMP		#0042
-      0x541EFFFC,  //  003A  LDINT	R7	65533
-      0x1C1C0C07,  //  003B  EQ	R7	R6	R7
-      0x781E0004,  //  003C  JMPF	R7	#0042
-      0x8C1C0907,  //  003D  GETMET	R7	R4	K7
-      0x8824090B,  //  003E  GETMBR	R9	R4	K11
-      0x542A0003,  //  003F  LDINT	R10	4
-      0x7C1C0600,  //  0040  CALL	R7	3
-      0x80040E00,  //  0041  RET	1	R7
-      0x70020070,  //  0042  JMP		#00B4
-      0x541E0004,  //  0043  LDINT	R7	5
-      0x1C1C0A07,  //  0044  EQ	R7	R5	R7
-      0x781E0011,  //  0045  JMPF	R7	#0058
-      0x541EFFFB,  //  0046  LDINT	R7	65532
-      0x1C1C0C07,  //  0047  EQ	R7	R6	R7
-      0x781E0005,  //  0048  JMPF	R7	#004F
-      0x8C1C0907,  //  0049  GETMET	R7	R4	K7
-      0x8824090B,  //  004A  GETMBR	R9	R4	K11
-      0x58280006,  //  004B  LDCONST	R10	K6
-      0x7C1C0600,  //  004C  CALL	R7	3
-      0x80040E00,  //  004D  RET	1	R7
-      0x70020007,  //  004E  JMP		#0057
-      0x541EFFFC,  //  004F  LDINT	R7	65533
-      0x1C1C0C07,  //  0050  EQ	R7	R6	R7
-      0x781E0004,  //  0051  JMPF	R7	#0057
-      0x8C1C0907,  //  0052  GETMET	R7	R4	K7
-      0x8824090B,  //  0053  GETMBR	R9	R4	K11
-      0x542A0003,  //  0054  LDINT	R10	4
-      0x7C1C0600,  //  0055  CALL	R7	3
-      0x80040E00,  //  0056  RET	1	R7
-      0x7002005B,  //  0057  JMP		#00B4
-      0x541E001C,  //  0058  LDINT	R7	29
-      0x1C1C0A07,  //  0059  EQ	R7	R5	R7
-      0x781E003A,  //  005A  JMPF	R7	#0096
-      0x1C1C0D06,  //  005B  EQ	R7	R6	K6
-      0x781E002F,  //  005C  JMPF	R7	#008D
-      0x8C1C090C,  //  005D  GETMET	R7	R4	K12
-      0x7C1C0200,  //  005E  CALL	R7	1
-      0x8820010D,  //  005F  GETMBR	R8	R0	K13
-      0x60240010,  //  0060  GETGBL	R9	G16
-      0x8C28110E,  //  0061  GETMET	R10	R8	K14
-      0x7C280200,  //  0062  CALL	R10	1
-      0x7C240200,  //  0063  CALL	R9	1
-      0xA802000E,  //  0064  EXBLK	0	#0074
-      0x5C281200,  //  0065  MOVE	R10	R9
-      0x7C280000,  //  0066  CALL	R10	0
-      0x8C2C0F0F,  //  0067  GETMET	R11	R7	K15
-      0x7C2C0200,  //  0068  CALL	R11	1
-      0x8C301710,  //  0069  GETMET	R12	R11	K16
-      0x58380006,  //  006A  LDCONST	R14	K6
-      0x883C0908,  //  006B  GETMBR	R15	R4	K8
-      0x5C401400,  //  006C  MOVE	R16	R10
-      0x7C300800,  //  006D  CALL	R12	4
-      0x8C301710,  //  006E  GETMET	R12	R11	K16
-      0x58380009,  //  006F  LDCONST	R14	K9
-      0x883C0908,  //  0070  GETMBR	R15	R4	K8
-      0x9440100A,  //  0071  GETIDX	R16	R8	R10
-      0x7C300800,  //  0072  CALL	R12	4
-      0x7001FFF0,  //  0073  JMP		#0065
-      0x58240011,  //  0074  LDCONST	R9	K17
-      0xAC240200,  //  0075  CATCH	R9	1	0
-      0xB0080000,  //  0076  RAISE	2	R0	R0
-      0x88240112,  //  0077  GETMBR	R9	R0	K18
-      0x8C241313,  //  0078  GETMET	R9	R9	K19
-      0x8C2C0314,  //  0079  GETMET	R11	R1	K20
-      0x7C2C0200,  //  007A  CALL	R11	1
-      0x7C240400,  //  007B  CALL	R9	2
-      0x4C280000,  //  007C  LDNIL	R10
-      0x1C24120A,  //  007D  EQ	R9	R9	R10
-      0x7826000B,  //  007E  JMPF	R9	#008B
-      0x8C240F0F,  //  007F  GETMET	R9	R7	K15
-      0x7C240200,  //  0080  CALL	R9	1
-      0x8C281310,  //  0081  GETMET	R10	R9	K16
-      0x58300006,  //  0082  LDCONST	R12	K6
-      0x88340908,  //  0083  GETMBR	R13	R4	K8
-      0x543A0012,  //  0084  LDINT	R14	19
-      0x7C280800,  //  0085  CALL	R10	4
-      0x8C281310,  //  0086  GETMET	R10	R9	K16
-      0x58300009,  //  0087  LDCONST	R12	K9
-      0x88340908,  //  0088  GETMBR	R13	R4	K8
-      0x58380009,  //  0089  LDCONST	R14	K9
-      0x7C280800,  //  008A  CALL	R10	4
-      0x80040E00,  //  008B  RET	1	R7
-      0x70020007,  //  008C  JMP		#0095
-      0x601C0003,  //  008D  GETGBL	R7	G3
-      0x5C200000,  //  008E  MOVE	R8	R0
-      0x7C1C0200,  //  008F  CALL	R7	1
-      0x8C1C0F15,  //  0090  GETMET	R7	R7	K21
-      0x5C240200,  //  0091  MOVE	R9	R1
-      0x5C280400,  //  0092  MOVE	R10	R2
-      0x7C1C0600,  //  0093  CALL	R7	3
-      0x80040E00,  //  0094  RET	1	R7
-      0x7002001D,  //  0095  JMP		#00B4
-      0x541E0038,  //  0096  LDINT	R7	57
-      0x1C1C0A07,  //  0097  EQ	R7	R5	R7
-      0x781E0012,  //  0098  JMPF	R7	#00AC
-      0x541E0004,  //  0099  LDINT	R7	5
-      0x1C1C0C07,  //  009A  EQ	R7	R6	R7
-      0x781E0006,  //  009B  JMPF	R7	#00A3
-      0x8C1C0907,  //  009C  GETMET	R7	R4	K7
-      0x88240916,  //  009D  GETMBR	R9	R4	K22
-      0x8C280117,  //  009E  GETMET	R10	R0	K23
-      0x7C280200,  //  009F  CALL	R10	1
-      0x7C1C0600,  //  00A0  CALL	R7	3
-      0x80040E00,  //  00A1  RET	1	R7
-      0x70020007,  //  00A2  JMP		#00AB
-      0x601C0003,  //  00A3  GETGBL	R7	G3
-      0x5C200000,  //  00A4  MOVE	R8	R0
-      0x7C1C0200,  //  00A5  CALL	R7	1
-      0x8C1C0F15,  //  00A6  GETMET	R7	R7	K21
-      0x5C240200,  //  00A7  MOVE	R9	R1
-      0x5C280400,  //  00A8  MOVE	R10	R2
-      0x7C1C0600,  //  00A9  CALL	R7	3
-      0x80040E00,  //  00AA  RET	1	R7
-      0x70020007,  //  00AB  JMP		#00B4
-      0x601C0003,  //  00AC  GETGBL	R7	G3
-      0x5C200000,  //  00AD  MOVE	R8	R0
-      0x7C1C0200,  //  00AE  CALL	R7	1
-      0x8C1C0F15,  //  00AF  GETMET	R7	R7	K21
-      0x5C240200,  //  00B0  MOVE	R9	R1
-      0x5C280400,  //  00B1  MOVE	R10	R2
-      0x7C1C0600,  //  00B2  CALL	R7	3
-      0x80040E00,  //  00B3  RET	1	R7
-      0x80000000,  //  00B4  RET	0
+      0x1C180904,  //  0004  EQ	R6	R4	K4
+      0x781A0021,  //  0005  JMPF	R6	#0028
+      0x1C180B05,  //  0006  EQ	R6	R5	K5
+      0x781A0005,  //  0007  JMPF	R6	#000E
+      0x8C180706,  //  0008  GETMET	R6	R3	K6
+      0x88200707,  //  0009  GETMBR	R8	R3	K7
+      0x58240005,  //  000A  LDCONST	R9	K5
+      0x7C180600,  //  000B  CALL	R6	3
+      0x80040C00,  //  000C  RET	1	R6
+      0x70020018,  //  000D  JMP		#0027
+      0x1C180B08,  //  000E  EQ	R6	R5	K8
+      0x781A0005,  //  000F  JMPF	R6	#0016
+      0x8C180706,  //  0010  GETMET	R6	R3	K6
+      0x88200709,  //  0011  GETMBR	R8	R3	K9
+      0x58240005,  //  0012  LDCONST	R9	K5
+      0x7C180600,  //  0013  CALL	R6	3
+      0x80040C00,  //  0014  RET	1	R6
+      0x70020010,  //  0015  JMP		#0027
+      0x541AFFFB,  //  0016  LDINT	R6	65532
+      0x1C180A06,  //  0017  EQ	R6	R5	R6
+      0x781A0005,  //  0018  JMPF	R6	#001F
+      0x8C180706,  //  0019  GETMET	R6	R3	K6
+      0x8820070A,  //  001A  GETMBR	R8	R3	K10
+      0x58240005,  //  001B  LDCONST	R9	K5
+      0x7C180600,  //  001C  CALL	R6	3
+      0x80040C00,  //  001D  RET	1	R6
+      0x70020007,  //  001E  JMP		#0027
+      0x541AFFFC,  //  001F  LDINT	R6	65533
+      0x1C180A06,  //  0020  EQ	R6	R5	R6
+      0x781A0004,  //  0021  JMPF	R6	#0027
+      0x8C180706,  //  0022  GETMET	R6	R3	K6
+      0x8820070A,  //  0023  GETMBR	R8	R3	K10
+      0x54260003,  //  0024  LDINT	R9	4
+      0x7C180600,  //  0025  CALL	R6	3
+      0x80040C00,  //  0026  RET	1	R6
+      0x7002008A,  //  0027  JMP		#00B3
+      0x541A0003,  //  0028  LDINT	R6	4
+      0x1C180806,  //  0029  EQ	R6	R4	R6
+      0x781A0016,  //  002A  JMPF	R6	#0042
+      0x1C180B05,  //  002B  EQ	R6	R5	K5
+      0x781A0002,  //  002C  JMPF	R6	#0030
+      0x4C180000,  //  002D  LDNIL	R6
+      0x80040C00,  //  002E  RET	1	R6
+      0x70020010,  //  002F  JMP		#0041
+      0x541AFFFB,  //  0030  LDINT	R6	65532
+      0x1C180A06,  //  0031  EQ	R6	R5	R6
+      0x781A0005,  //  0032  JMPF	R6	#0039
+      0x8C180706,  //  0033  GETMET	R6	R3	K6
+      0x8820070A,  //  0034  GETMBR	R8	R3	K10
+      0x58240005,  //  0035  LDCONST	R9	K5
+      0x7C180600,  //  0036  CALL	R6	3
+      0x80040C00,  //  0037  RET	1	R6
+      0x70020007,  //  0038  JMP		#0041
+      0x541AFFFC,  //  0039  LDINT	R6	65533
+      0x1C180A06,  //  003A  EQ	R6	R5	R6
+      0x781A0004,  //  003B  JMPF	R6	#0041
+      0x8C180706,  //  003C  GETMET	R6	R3	K6
+      0x8820070A,  //  003D  GETMBR	R8	R3	K10
+      0x54260003,  //  003E  LDINT	R9	4
+      0x7C180600,  //  003F  CALL	R6	3
+      0x80040C00,  //  0040  RET	1	R6
+      0x70020070,  //  0041  JMP		#00B3
+      0x541A0004,  //  0042  LDINT	R6	5
+      0x1C180806,  //  0043  EQ	R6	R4	R6
+      0x781A0011,  //  0044  JMPF	R6	#0057
+      0x541AFFFB,  //  0045  LDINT	R6	65532
+      0x1C180A06,  //  0046  EQ	R6	R5	R6
+      0x781A0005,  //  0047  JMPF	R6	#004E
+      0x8C180706,  //  0048  GETMET	R6	R3	K6
+      0x8820070A,  //  0049  GETMBR	R8	R3	K10
+      0x58240005,  //  004A  LDCONST	R9	K5
+      0x7C180600,  //  004B  CALL	R6	3
+      0x80040C00,  //  004C  RET	1	R6
+      0x70020007,  //  004D  JMP		#0056
+      0x541AFFFC,  //  004E  LDINT	R6	65533
+      0x1C180A06,  //  004F  EQ	R6	R5	R6
+      0x781A0004,  //  0050  JMPF	R6	#0056
+      0x8C180706,  //  0051  GETMET	R6	R3	K6
+      0x8820070A,  //  0052  GETMBR	R8	R3	K10
+      0x54260003,  //  0053  LDINT	R9	4
+      0x7C180600,  //  0054  CALL	R6	3
+      0x80040C00,  //  0055  RET	1	R6
+      0x7002005B,  //  0056  JMP		#00B3
+      0x541A001C,  //  0057  LDINT	R6	29
+      0x1C180806,  //  0058  EQ	R6	R4	R6
+      0x781A003A,  //  0059  JMPF	R6	#0095
+      0x1C180B05,  //  005A  EQ	R6	R5	K5
+      0x781A002F,  //  005B  JMPF	R6	#008C
+      0x8C18070B,  //  005C  GETMET	R6	R3	K11
+      0x7C180200,  //  005D  CALL	R6	1
+      0x881C010C,  //  005E  GETMBR	R7	R0	K12
+      0x60200010,  //  005F  GETGBL	R8	G16
+      0x8C240F0D,  //  0060  GETMET	R9	R7	K13
+      0x7C240200,  //  0061  CALL	R9	1
+      0x7C200200,  //  0062  CALL	R8	1
+      0xA802000E,  //  0063  EXBLK	0	#0073
+      0x5C241000,  //  0064  MOVE	R9	R8
+      0x7C240000,  //  0065  CALL	R9	0
+      0x8C280D0E,  //  0066  GETMET	R10	R6	K14
+      0x7C280200,  //  0067  CALL	R10	1
+      0x8C2C150F,  //  0068  GETMET	R11	R10	K15
+      0x58340005,  //  0069  LDCONST	R13	K5
+      0x88380707,  //  006A  GETMBR	R14	R3	K7
+      0x5C3C1200,  //  006B  MOVE	R15	R9
+      0x7C2C0800,  //  006C  CALL	R11	4
+      0x8C2C150F,  //  006D  GETMET	R11	R10	K15
+      0x58340008,  //  006E  LDCONST	R13	K8
+      0x88380707,  //  006F  GETMBR	R14	R3	K7
+      0x943C0E09,  //  0070  GETIDX	R15	R7	R9
+      0x7C2C0800,  //  0071  CALL	R11	4
+      0x7001FFF0,  //  0072  JMP		#0064
+      0x58200010,  //  0073  LDCONST	R8	K16
+      0xAC200200,  //  0074  CATCH	R8	1	0
+      0xB0080000,  //  0075  RAISE	2	R0	R0
+      0x88200111,  //  0076  GETMBR	R8	R0	K17
+      0x8C201112,  //  0077  GETMET	R8	R8	K18
+      0x8C280313,  //  0078  GETMET	R10	R1	K19
+      0x7C280200,  //  0079  CALL	R10	1
+      0x7C200400,  //  007A  CALL	R8	2
+      0x4C240000,  //  007B  LDNIL	R9
+      0x1C201009,  //  007C  EQ	R8	R8	R9
+      0x7822000B,  //  007D  JMPF	R8	#008A
+      0x8C200D0E,  //  007E  GETMET	R8	R6	K14
+      0x7C200200,  //  007F  CALL	R8	1
+      0x8C24110F,  //  0080  GETMET	R9	R8	K15
+      0x582C0005,  //  0081  LDCONST	R11	K5
+      0x88300707,  //  0082  GETMBR	R12	R3	K7
+      0x54360012,  //  0083  LDINT	R13	19
+      0x7C240800,  //  0084  CALL	R9	4
+      0x8C24110F,  //  0085  GETMET	R9	R8	K15
+      0x582C0008,  //  0086  LDCONST	R11	K8
+      0x88300707,  //  0087  GETMBR	R12	R3	K7
+      0x58340008,  //  0088  LDCONST	R13	K8
+      0x7C240800,  //  0089  CALL	R9	4
+      0x80040C00,  //  008A  RET	1	R6
+      0x70020007,  //  008B  JMP		#0094
+      0x60180003,  //  008C  GETGBL	R6	G3
+      0x5C1C0000,  //  008D  MOVE	R7	R0
+      0x7C180200,  //  008E  CALL	R6	1
+      0x8C180D14,  //  008F  GETMET	R6	R6	K20
+      0x5C200200,  //  0090  MOVE	R8	R1
+      0x5C240400,  //  0091  MOVE	R9	R2
+      0x7C180600,  //  0092  CALL	R6	3
+      0x80040C00,  //  0093  RET	1	R6
+      0x7002001D,  //  0094  JMP		#00B3
+      0x541A0038,  //  0095  LDINT	R6	57
+      0x1C180806,  //  0096  EQ	R6	R4	R6
+      0x781A0012,  //  0097  JMPF	R6	#00AB
+      0x541A0004,  //  0098  LDINT	R6	5
+      0x1C180A06,  //  0099  EQ	R6	R5	R6
+      0x781A0006,  //  009A  JMPF	R6	#00A2
+      0x8C180706,  //  009B  GETMET	R6	R3	K6
+      0x88200715,  //  009C  GETMBR	R8	R3	K21
+      0x8C240116,  //  009D  GETMET	R9	R0	K22
+      0x7C240200,  //  009E  CALL	R9	1
+      0x7C180600,  //  009F  CALL	R6	3
+      0x80040C00,  //  00A0  RET	1	R6
+      0x70020007,  //  00A1  JMP		#00AA
+      0x60180003,  //  00A2  GETGBL	R6	G3
+      0x5C1C0000,  //  00A3  MOVE	R7	R0
+      0x7C180200,  //  00A4  CALL	R6	1
+      0x8C180D14,  //  00A5  GETMET	R6	R6	K20
+      0x5C200200,  //  00A6  MOVE	R8	R1
+      0x5C240400,  //  00A7  MOVE	R9	R2
+      0x7C180600,  //  00A8  CALL	R6	3
+      0x80040C00,  //  00A9  RET	1	R6
+      0x70020007,  //  00AA  JMP		#00B3
+      0x60180003,  //  00AB  GETGBL	R6	G3
+      0x5C1C0000,  //  00AC  MOVE	R7	R0
+      0x7C180200,  //  00AD  CALL	R6	1
+      0x8C180D14,  //  00AE  GETMET	R6	R6	K20
+      0x5C200200,  //  00AF  MOVE	R8	R1
+      0x5C240400,  //  00B0  MOVE	R9	R2
+      0x7C180600,  //  00B1  CALL	R6	3
+      0x80040C00,  //  00B2  RET	1	R6
+      0x80000000,  //  00B3  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light0.h
@@ -67,7 +67,7 @@ be_local_closure(Matter_Plugin_Light0_update_shadow,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Light0_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -75,68 +75,66 @@ be_local_closure(Matter_Plugin_Light0_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(BOOL),
-    /* K9   */  be_nested_str_weak(shadow_onoff),
-    /* K10  */  be_nested_str_weak(U4),
-    /* K11  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(BOOL),
+    /* K8   */  be_nested_str_weak(shadow_onoff),
+    /* K9   */  be_nested_str_weak(U4),
+    /* K10  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[44]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0005,  //  0005  LDINT	R7	6
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E001B,  //  0007  JMPF	R7	#0024
-      0x8C1C0105,  //  0008  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x1C1C0D06,  //  000A  EQ	R7	R6	K6
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0907,  //  000C  GETMET	R7	R4	K7
-      0x88240908,  //  000D  GETMBR	R9	R4	K8
-      0x88280109,  //  000E  GETMBR	R10	R0	K9
-      0x7C1C0600,  //  000F  CALL	R7	3
-      0x80040E00,  //  0010  RET	1	R7
-      0x70020010,  //  0011  JMP		#0023
-      0x541EFFFB,  //  0012  LDINT	R7	65532
-      0x1C1C0C07,  //  0013  EQ	R7	R6	R7
-      0x781E0005,  //  0014  JMPF	R7	#001B
-      0x8C1C0907,  //  0015  GETMET	R7	R4	K7
-      0x8824090A,  //  0016  GETMBR	R9	R4	K10
-      0x58280006,  //  0017  LDCONST	R10	K6
-      0x7C1C0600,  //  0018  CALL	R7	3
-      0x80040E00,  //  0019  RET	1	R7
-      0x70020007,  //  001A  JMP		#0023
-      0x541EFFFC,  //  001B  LDINT	R7	65533
-      0x1C1C0C07,  //  001C  EQ	R7	R6	R7
-      0x781E0004,  //  001D  JMPF	R7	#0023
-      0x8C1C0907,  //  001E  GETMET	R7	R4	K7
-      0x8824090A,  //  001F  GETMBR	R9	R4	K10
-      0x542A0003,  //  0020  LDINT	R10	4
-      0x7C1C0600,  //  0021  CALL	R7	3
-      0x80040E00,  //  0022  RET	1	R7
-      0x70020007,  //  0023  JMP		#002C
-      0x601C0003,  //  0024  GETGBL	R7	G3
-      0x5C200000,  //  0025  MOVE	R8	R0
-      0x7C1C0200,  //  0026  CALL	R7	1
-      0x8C1C0F0B,  //  0027  GETMET	R7	R7	K11
-      0x5C240200,  //  0028  MOVE	R9	R1
-      0x5C280400,  //  0029  MOVE	R10	R2
-      0x7C1C0600,  //  002A  CALL	R7	3
-      0x80040E00,  //  002B  RET	1	R7
-      0x80000000,  //  002C  RET	0
+      0x541A0005,  //  0004  LDINT	R6	6
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A001B,  //  0006  JMPF	R6	#0023
+      0x8C180104,  //  0007  GETMET	R6	R0	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x1C180B05,  //  0009  EQ	R6	R5	K5
+      0x781A0005,  //  000A  JMPF	R6	#0011
+      0x8C180706,  //  000B  GETMET	R6	R3	K6
+      0x88200707,  //  000C  GETMBR	R8	R3	K7
+      0x88240108,  //  000D  GETMBR	R9	R0	K8
+      0x7C180600,  //  000E  CALL	R6	3
+      0x80040C00,  //  000F  RET	1	R6
+      0x70020010,  //  0010  JMP		#0022
+      0x541AFFFB,  //  0011  LDINT	R6	65532
+      0x1C180A06,  //  0012  EQ	R6	R5	R6
+      0x781A0005,  //  0013  JMPF	R6	#001A
+      0x8C180706,  //  0014  GETMET	R6	R3	K6
+      0x88200709,  //  0015  GETMBR	R8	R3	K9
+      0x58240005,  //  0016  LDCONST	R9	K5
+      0x7C180600,  //  0017  CALL	R6	3
+      0x80040C00,  //  0018  RET	1	R6
+      0x70020007,  //  0019  JMP		#0022
+      0x541AFFFC,  //  001A  LDINT	R6	65533
+      0x1C180A06,  //  001B  EQ	R6	R5	R6
+      0x781A0004,  //  001C  JMPF	R6	#0022
+      0x8C180706,  //  001D  GETMET	R6	R3	K6
+      0x88200709,  //  001E  GETMBR	R8	R3	K9
+      0x54260003,  //  001F  LDINT	R9	4
+      0x7C180600,  //  0020  CALL	R6	3
+      0x80040C00,  //  0021  RET	1	R6
+      0x70020007,  //  0022  JMP		#002B
+      0x60180003,  //  0023  GETGBL	R6	G3
+      0x5C1C0000,  //  0024  MOVE	R7	R0
+      0x7C180200,  //  0025  CALL	R6	1
+      0x8C180D0A,  //  0026  GETMET	R6	R6	K10
+      0x5C200200,  //  0027  MOVE	R8	R1
+      0x5C240400,  //  0028  MOVE	R9	R2
+      0x7C180600,  //  0029  CALL	R6	3
+      0x80040C00,  //  002A  RET	1	R6
+      0x80000000,  //  002B  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light1.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light1.h
@@ -237,7 +237,7 @@ be_local_closure(Matter_Plugin_Light1_invoke_request,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Light1_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -245,105 +245,103 @@ be_local_closure(Matter_Plugin_Light1_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(U1),
-    /* K9   */  be_nested_str_weak(shadow_bri),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(U4),
-    /* K13  */  be_const_int(1),
-    /* K14  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(U1),
+    /* K8   */  be_nested_str_weak(shadow_bri),
+    /* K9   */  be_const_int(2),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_const_int(1),
+    /* K13  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[79]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[78]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0007,  //  0005  LDINT	R7	8
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E003D,  //  0007  JMPF	R7	#0046
-      0x8C1C0105,  //  0008  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x1C1C0D06,  //  000A  EQ	R7	R6	K6
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0907,  //  000C  GETMET	R7	R4	K7
-      0x88240908,  //  000D  GETMBR	R9	R4	K8
-      0x88280109,  //  000E  GETMBR	R10	R0	K9
-      0x7C1C0600,  //  000F  CALL	R7	3
-      0x80040E00,  //  0010  RET	1	R7
-      0x70020032,  //  0011  JMP		#0045
-      0x1C1C0D0A,  //  0012  EQ	R7	R6	K10
-      0x781E0005,  //  0013  JMPF	R7	#001A
-      0x8C1C0907,  //  0014  GETMET	R7	R4	K7
-      0x88240908,  //  0015  GETMBR	R9	R4	K8
-      0x58280006,  //  0016  LDCONST	R10	K6
-      0x7C1C0600,  //  0017  CALL	R7	3
-      0x80040E00,  //  0018  RET	1	R7
-      0x7002002A,  //  0019  JMP		#0045
-      0x1C1C0D0B,  //  001A  EQ	R7	R6	K11
-      0x781E0005,  //  001B  JMPF	R7	#0022
-      0x8C1C0907,  //  001C  GETMET	R7	R4	K7
-      0x88240908,  //  001D  GETMBR	R9	R4	K8
-      0x542A00FD,  //  001E  LDINT	R10	254
-      0x7C1C0600,  //  001F  CALL	R7	3
-      0x80040E00,  //  0020  RET	1	R7
-      0x70020022,  //  0021  JMP		#0045
-      0x541E000E,  //  0022  LDINT	R7	15
-      0x1C1C0C07,  //  0023  EQ	R7	R6	R7
-      0x781E0005,  //  0024  JMPF	R7	#002B
-      0x8C1C0907,  //  0025  GETMET	R7	R4	K7
-      0x88240908,  //  0026  GETMBR	R9	R4	K8
-      0x58280006,  //  0027  LDCONST	R10	K6
-      0x7C1C0600,  //  0028  CALL	R7	3
-      0x80040E00,  //  0029  RET	1	R7
-      0x70020019,  //  002A  JMP		#0045
-      0x541E0010,  //  002B  LDINT	R7	17
-      0x1C1C0C07,  //  002C  EQ	R7	R6	R7
-      0x781E0005,  //  002D  JMPF	R7	#0034
-      0x8C1C0907,  //  002E  GETMET	R7	R4	K7
-      0x88240908,  //  002F  GETMBR	R9	R4	K8
-      0x88280109,  //  0030  GETMBR	R10	R0	K9
-      0x7C1C0600,  //  0031  CALL	R7	3
-      0x80040E00,  //  0032  RET	1	R7
-      0x70020010,  //  0033  JMP		#0045
-      0x541EFFFB,  //  0034  LDINT	R7	65532
-      0x1C1C0C07,  //  0035  EQ	R7	R6	R7
-      0x781E0005,  //  0036  JMPF	R7	#003D
-      0x8C1C0907,  //  0037  GETMET	R7	R4	K7
-      0x8824090C,  //  0038  GETMBR	R9	R4	K12
-      0x5828000D,  //  0039  LDCONST	R10	K13
-      0x7C1C0600,  //  003A  CALL	R7	3
-      0x80040E00,  //  003B  RET	1	R7
-      0x70020007,  //  003C  JMP		#0045
-      0x541EFFFC,  //  003D  LDINT	R7	65533
-      0x1C1C0C07,  //  003E  EQ	R7	R6	R7
-      0x781E0004,  //  003F  JMPF	R7	#0045
-      0x8C1C0907,  //  0040  GETMET	R7	R4	K7
-      0x8824090C,  //  0041  GETMBR	R9	R4	K12
-      0x542A0004,  //  0042  LDINT	R10	5
-      0x7C1C0600,  //  0043  CALL	R7	3
-      0x80040E00,  //  0044  RET	1	R7
-      0x70020007,  //  0045  JMP		#004E
-      0x601C0003,  //  0046  GETGBL	R7	G3
-      0x5C200000,  //  0047  MOVE	R8	R0
-      0x7C1C0200,  //  0048  CALL	R7	1
-      0x8C1C0F0E,  //  0049  GETMET	R7	R7	K14
-      0x5C240200,  //  004A  MOVE	R9	R1
-      0x5C280400,  //  004B  MOVE	R10	R2
-      0x7C1C0600,  //  004C  CALL	R7	3
-      0x80040E00,  //  004D  RET	1	R7
-      0x80000000,  //  004E  RET	0
+      0x541A0007,  //  0004  LDINT	R6	8
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A003D,  //  0006  JMPF	R6	#0045
+      0x8C180104,  //  0007  GETMET	R6	R0	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x1C180B05,  //  0009  EQ	R6	R5	K5
+      0x781A0005,  //  000A  JMPF	R6	#0011
+      0x8C180706,  //  000B  GETMET	R6	R3	K6
+      0x88200707,  //  000C  GETMBR	R8	R3	K7
+      0x88240108,  //  000D  GETMBR	R9	R0	K8
+      0x7C180600,  //  000E  CALL	R6	3
+      0x80040C00,  //  000F  RET	1	R6
+      0x70020032,  //  0010  JMP		#0044
+      0x1C180B09,  //  0011  EQ	R6	R5	K9
+      0x781A0005,  //  0012  JMPF	R6	#0019
+      0x8C180706,  //  0013  GETMET	R6	R3	K6
+      0x88200707,  //  0014  GETMBR	R8	R3	K7
+      0x58240005,  //  0015  LDCONST	R9	K5
+      0x7C180600,  //  0016  CALL	R6	3
+      0x80040C00,  //  0017  RET	1	R6
+      0x7002002A,  //  0018  JMP		#0044
+      0x1C180B0A,  //  0019  EQ	R6	R5	K10
+      0x781A0005,  //  001A  JMPF	R6	#0021
+      0x8C180706,  //  001B  GETMET	R6	R3	K6
+      0x88200707,  //  001C  GETMBR	R8	R3	K7
+      0x542600FD,  //  001D  LDINT	R9	254
+      0x7C180600,  //  001E  CALL	R6	3
+      0x80040C00,  //  001F  RET	1	R6
+      0x70020022,  //  0020  JMP		#0044
+      0x541A000E,  //  0021  LDINT	R6	15
+      0x1C180A06,  //  0022  EQ	R6	R5	R6
+      0x781A0005,  //  0023  JMPF	R6	#002A
+      0x8C180706,  //  0024  GETMET	R6	R3	K6
+      0x88200707,  //  0025  GETMBR	R8	R3	K7
+      0x58240005,  //  0026  LDCONST	R9	K5
+      0x7C180600,  //  0027  CALL	R6	3
+      0x80040C00,  //  0028  RET	1	R6
+      0x70020019,  //  0029  JMP		#0044
+      0x541A0010,  //  002A  LDINT	R6	17
+      0x1C180A06,  //  002B  EQ	R6	R5	R6
+      0x781A0005,  //  002C  JMPF	R6	#0033
+      0x8C180706,  //  002D  GETMET	R6	R3	K6
+      0x88200707,  //  002E  GETMBR	R8	R3	K7
+      0x88240108,  //  002F  GETMBR	R9	R0	K8
+      0x7C180600,  //  0030  CALL	R6	3
+      0x80040C00,  //  0031  RET	1	R6
+      0x70020010,  //  0032  JMP		#0044
+      0x541AFFFB,  //  0033  LDINT	R6	65532
+      0x1C180A06,  //  0034  EQ	R6	R5	R6
+      0x781A0005,  //  0035  JMPF	R6	#003C
+      0x8C180706,  //  0036  GETMET	R6	R3	K6
+      0x8820070B,  //  0037  GETMBR	R8	R3	K11
+      0x5824000C,  //  0038  LDCONST	R9	K12
+      0x7C180600,  //  0039  CALL	R6	3
+      0x80040C00,  //  003A  RET	1	R6
+      0x70020007,  //  003B  JMP		#0044
+      0x541AFFFC,  //  003C  LDINT	R6	65533
+      0x1C180A06,  //  003D  EQ	R6	R5	R6
+      0x781A0004,  //  003E  JMPF	R6	#0044
+      0x8C180706,  //  003F  GETMET	R6	R3	K6
+      0x8820070B,  //  0040  GETMBR	R8	R3	K11
+      0x54260004,  //  0041  LDINT	R9	5
+      0x7C180600,  //  0042  CALL	R6	3
+      0x80040C00,  //  0043  RET	1	R6
+      0x70020007,  //  0044  JMP		#004D
+      0x60180003,  //  0045  GETGBL	R6	G3
+      0x5C1C0000,  //  0046  MOVE	R7	R0
+      0x7C180200,  //  0047  CALL	R6	1
+      0x8C180D0D,  //  0048  GETMET	R6	R6	K13
+      0x5C200200,  //  0049  MOVE	R8	R1
+      0x5C240400,  //  004A  MOVE	R9	R2
+      0x7C180600,  //  004B  CALL	R6	3
+      0x80040C00,  //  004C  RET	1	R6
+      0x80000000,  //  004D  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light2.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light2.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Plugin_Light2;
 ********************************************************************/
 be_local_closure(Matter_Plugin_Light2_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,108 +19,106 @@ be_local_closure(Matter_Plugin_Light2_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_nested_str_weak(create_TLV),
-    /* K7   */  be_nested_str_weak(U1),
-    /* K8   */  be_nested_str_weak(shadow_ct),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(ct_min),
-    /* K12  */  be_nested_str_weak(ct_max),
-    /* K13  */  be_nested_str_weak(U4),
-    /* K14  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_nested_str_weak(create_TLV),
+    /* K6   */  be_nested_str_weak(U1),
+    /* K7   */  be_nested_str_weak(shadow_ct),
+    /* K8   */  be_const_int(2),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_nested_str_weak(ct_min),
+    /* K11  */  be_nested_str_weak(ct_max),
+    /* K12  */  be_nested_str_weak(U4),
+    /* K13  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[82]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[81]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E02FF,  //  0005  LDINT	R7	768
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0040,  //  0007  JMPF	R7	#0049
-      0x8C1C0105,  //  0008  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x541E0006,  //  000A  LDINT	R7	7
-      0x1C1C0C07,  //  000B  EQ	R7	R6	R7
-      0x781E0005,  //  000C  JMPF	R7	#0013
-      0x8C1C0906,  //  000D  GETMET	R7	R4	K6
-      0x88240907,  //  000E  GETMBR	R9	R4	K7
-      0x88280108,  //  000F  GETMBR	R10	R0	K8
-      0x7C1C0600,  //  0010  CALL	R7	3
-      0x80040E00,  //  0011  RET	1	R7
-      0x70020034,  //  0012  JMP		#0048
-      0x541E0007,  //  0013  LDINT	R7	8
-      0x1C1C0C07,  //  0014  EQ	R7	R6	R7
-      0x781E0005,  //  0015  JMPF	R7	#001C
-      0x8C1C0906,  //  0016  GETMET	R7	R4	K6
-      0x88240907,  //  0017  GETMBR	R9	R4	K7
-      0x58280009,  //  0018  LDCONST	R10	K9
-      0x7C1C0600,  //  0019  CALL	R7	3
-      0x80040E00,  //  001A  RET	1	R7
-      0x7002002B,  //  001B  JMP		#0048
-      0x541E000E,  //  001C  LDINT	R7	15
-      0x1C1C0C07,  //  001D  EQ	R7	R6	R7
-      0x781E0005,  //  001E  JMPF	R7	#0025
-      0x8C1C0906,  //  001F  GETMET	R7	R4	K6
-      0x88240907,  //  0020  GETMBR	R9	R4	K7
-      0x5828000A,  //  0021  LDCONST	R10	K10
-      0x7C1C0600,  //  0022  CALL	R7	3
-      0x80040E00,  //  0023  RET	1	R7
-      0x70020022,  //  0024  JMP		#0048
-      0x541E400A,  //  0025  LDINT	R7	16395
-      0x1C1C0C07,  //  0026  EQ	R7	R6	R7
-      0x781E0005,  //  0027  JMPF	R7	#002E
-      0x8C1C0906,  //  0028  GETMET	R7	R4	K6
-      0x88240907,  //  0029  GETMBR	R9	R4	K7
-      0x8828010B,  //  002A  GETMBR	R10	R0	K11
-      0x7C1C0600,  //  002B  CALL	R7	3
-      0x80040E00,  //  002C  RET	1	R7
-      0x70020019,  //  002D  JMP		#0048
-      0x541E400B,  //  002E  LDINT	R7	16396
-      0x1C1C0C07,  //  002F  EQ	R7	R6	R7
-      0x781E0005,  //  0030  JMPF	R7	#0037
-      0x8C1C0906,  //  0031  GETMET	R7	R4	K6
-      0x88240907,  //  0032  GETMBR	R9	R4	K7
-      0x8828010C,  //  0033  GETMBR	R10	R0	K12
-      0x7C1C0600,  //  0034  CALL	R7	3
-      0x80040E00,  //  0035  RET	1	R7
-      0x70020010,  //  0036  JMP		#0048
-      0x541EFFFB,  //  0037  LDINT	R7	65532
-      0x1C1C0C07,  //  0038  EQ	R7	R6	R7
-      0x781E0005,  //  0039  JMPF	R7	#0040
-      0x8C1C0906,  //  003A  GETMET	R7	R4	K6
-      0x8824090D,  //  003B  GETMBR	R9	R4	K13
-      0x542A000F,  //  003C  LDINT	R10	16
-      0x7C1C0600,  //  003D  CALL	R7	3
-      0x80040E00,  //  003E  RET	1	R7
-      0x70020007,  //  003F  JMP		#0048
-      0x541EFFFC,  //  0040  LDINT	R7	65533
-      0x1C1C0C07,  //  0041  EQ	R7	R6	R7
-      0x781E0004,  //  0042  JMPF	R7	#0048
-      0x8C1C0906,  //  0043  GETMET	R7	R4	K6
-      0x8824090D,  //  0044  GETMBR	R9	R4	K13
-      0x542A0004,  //  0045  LDINT	R10	5
-      0x7C1C0600,  //  0046  CALL	R7	3
-      0x80040E00,  //  0047  RET	1	R7
-      0x70020007,  //  0048  JMP		#0051
-      0x601C0003,  //  0049  GETGBL	R7	G3
-      0x5C200000,  //  004A  MOVE	R8	R0
-      0x7C1C0200,  //  004B  CALL	R7	1
-      0x8C1C0F0E,  //  004C  GETMET	R7	R7	K14
-      0x5C240200,  //  004D  MOVE	R9	R1
-      0x5C280400,  //  004E  MOVE	R10	R2
-      0x7C1C0600,  //  004F  CALL	R7	3
-      0x80040E00,  //  0050  RET	1	R7
-      0x80000000,  //  0051  RET	0
+      0x541A02FF,  //  0004  LDINT	R6	768
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0040,  //  0006  JMPF	R6	#0048
+      0x8C180104,  //  0007  GETMET	R6	R0	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x541A0006,  //  0009  LDINT	R6	7
+      0x1C180A06,  //  000A  EQ	R6	R5	R6
+      0x781A0005,  //  000B  JMPF	R6	#0012
+      0x8C180705,  //  000C  GETMET	R6	R3	K5
+      0x88200706,  //  000D  GETMBR	R8	R3	K6
+      0x88240107,  //  000E  GETMBR	R9	R0	K7
+      0x7C180600,  //  000F  CALL	R6	3
+      0x80040C00,  //  0010  RET	1	R6
+      0x70020034,  //  0011  JMP		#0047
+      0x541A0007,  //  0012  LDINT	R6	8
+      0x1C180A06,  //  0013  EQ	R6	R5	R6
+      0x781A0005,  //  0014  JMPF	R6	#001B
+      0x8C180705,  //  0015  GETMET	R6	R3	K5
+      0x88200706,  //  0016  GETMBR	R8	R3	K6
+      0x58240008,  //  0017  LDCONST	R9	K8
+      0x7C180600,  //  0018  CALL	R6	3
+      0x80040C00,  //  0019  RET	1	R6
+      0x7002002B,  //  001A  JMP		#0047
+      0x541A000E,  //  001B  LDINT	R6	15
+      0x1C180A06,  //  001C  EQ	R6	R5	R6
+      0x781A0005,  //  001D  JMPF	R6	#0024
+      0x8C180705,  //  001E  GETMET	R6	R3	K5
+      0x88200706,  //  001F  GETMBR	R8	R3	K6
+      0x58240009,  //  0020  LDCONST	R9	K9
+      0x7C180600,  //  0021  CALL	R6	3
+      0x80040C00,  //  0022  RET	1	R6
+      0x70020022,  //  0023  JMP		#0047
+      0x541A400A,  //  0024  LDINT	R6	16395
+      0x1C180A06,  //  0025  EQ	R6	R5	R6
+      0x781A0005,  //  0026  JMPF	R6	#002D
+      0x8C180705,  //  0027  GETMET	R6	R3	K5
+      0x88200706,  //  0028  GETMBR	R8	R3	K6
+      0x8824010A,  //  0029  GETMBR	R9	R0	K10
+      0x7C180600,  //  002A  CALL	R6	3
+      0x80040C00,  //  002B  RET	1	R6
+      0x70020019,  //  002C  JMP		#0047
+      0x541A400B,  //  002D  LDINT	R6	16396
+      0x1C180A06,  //  002E  EQ	R6	R5	R6
+      0x781A0005,  //  002F  JMPF	R6	#0036
+      0x8C180705,  //  0030  GETMET	R6	R3	K5
+      0x88200706,  //  0031  GETMBR	R8	R3	K6
+      0x8824010B,  //  0032  GETMBR	R9	R0	K11
+      0x7C180600,  //  0033  CALL	R6	3
+      0x80040C00,  //  0034  RET	1	R6
+      0x70020010,  //  0035  JMP		#0047
+      0x541AFFFB,  //  0036  LDINT	R6	65532
+      0x1C180A06,  //  0037  EQ	R6	R5	R6
+      0x781A0005,  //  0038  JMPF	R6	#003F
+      0x8C180705,  //  0039  GETMET	R6	R3	K5
+      0x8820070C,  //  003A  GETMBR	R8	R3	K12
+      0x5426000F,  //  003B  LDINT	R9	16
+      0x7C180600,  //  003C  CALL	R6	3
+      0x80040C00,  //  003D  RET	1	R6
+      0x70020007,  //  003E  JMP		#0047
+      0x541AFFFC,  //  003F  LDINT	R6	65533
+      0x1C180A06,  //  0040  EQ	R6	R5	R6
+      0x781A0004,  //  0041  JMPF	R6	#0047
+      0x8C180705,  //  0042  GETMET	R6	R3	K5
+      0x8820070C,  //  0043  GETMBR	R8	R3	K12
+      0x54260004,  //  0044  LDINT	R9	5
+      0x7C180600,  //  0045  CALL	R6	3
+      0x80040C00,  //  0046  RET	1	R6
+      0x70020007,  //  0047  JMP		#0050
+      0x60180003,  //  0048  GETGBL	R6	G3
+      0x5C1C0000,  //  0049  MOVE	R7	R0
+      0x7C180200,  //  004A  CALL	R6	1
+      0x8C180D0D,  //  004B  GETMET	R6	R6	K13
+      0x5C200200,  //  004C  MOVE	R8	R1
+      0x5C240400,  //  004D  MOVE	R9	R2
+      0x7C180600,  //  004E  CALL	R6	3
+      0x80040C00,  //  004F  RET	1	R6
+      0x80000000,  //  0050  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light3.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Light3.h
@@ -112,7 +112,7 @@ be_local_closure(Matter_Plugin_Light3_update_shadow,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Light3_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -120,132 +120,130 @@ be_local_closure(Matter_Plugin_Light3_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(U1),
-    /* K9   */  be_nested_str_weak(shadow_hue),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_nested_str_weak(shadow_sat),
-    /* K12  */  be_nested_str_weak(U4),
-    /* K13  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(U1),
+    /* K8   */  be_nested_str_weak(shadow_hue),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(shadow_sat),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[107]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[106]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E02FF,  //  0005  LDINT	R7	768
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0059,  //  0007  JMPF	R7	#0062
-      0x8C1C0105,  //  0008  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x1C1C0D06,  //  000A  EQ	R7	R6	K6
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0907,  //  000C  GETMET	R7	R4	K7
-      0x88240908,  //  000D  GETMBR	R9	R4	K8
-      0x88280109,  //  000E  GETMBR	R10	R0	K9
-      0x7C1C0600,  //  000F  CALL	R7	3
-      0x80040E00,  //  0010  RET	1	R7
-      0x7002004E,  //  0011  JMP		#0061
-      0x1C1C0D0A,  //  0012  EQ	R7	R6	K10
-      0x781E0005,  //  0013  JMPF	R7	#001A
-      0x8C1C0907,  //  0014  GETMET	R7	R4	K7
-      0x88240908,  //  0015  GETMBR	R9	R4	K8
-      0x8828010B,  //  0016  GETMBR	R10	R0	K11
-      0x7C1C0600,  //  0017  CALL	R7	3
-      0x80040E00,  //  0018  RET	1	R7
-      0x70020046,  //  0019  JMP		#0061
-      0x541E0006,  //  001A  LDINT	R7	7
-      0x1C1C0C07,  //  001B  EQ	R7	R6	R7
-      0x781E0005,  //  001C  JMPF	R7	#0023
-      0x8C1C0907,  //  001D  GETMET	R7	R4	K7
-      0x88240908,  //  001E  GETMBR	R9	R4	K8
-      0x58280006,  //  001F  LDCONST	R10	K6
-      0x7C1C0600,  //  0020  CALL	R7	3
-      0x80040E00,  //  0021  RET	1	R7
-      0x7002003D,  //  0022  JMP		#0061
-      0x541E0007,  //  0023  LDINT	R7	8
-      0x1C1C0C07,  //  0024  EQ	R7	R6	R7
-      0x781E0005,  //  0025  JMPF	R7	#002C
-      0x8C1C0907,  //  0026  GETMET	R7	R4	K7
-      0x88240908,  //  0027  GETMBR	R9	R4	K8
-      0x58280006,  //  0028  LDCONST	R10	K6
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x80040E00,  //  002A  RET	1	R7
-      0x70020034,  //  002B  JMP		#0061
-      0x541E000E,  //  002C  LDINT	R7	15
-      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
-      0x781E0005,  //  002E  JMPF	R7	#0035
-      0x8C1C0907,  //  002F  GETMET	R7	R4	K7
-      0x88240908,  //  0030  GETMBR	R9	R4	K8
-      0x58280006,  //  0031  LDCONST	R10	K6
-      0x7C1C0600,  //  0032  CALL	R7	3
-      0x80040E00,  //  0033  RET	1	R7
-      0x7002002B,  //  0034  JMP		#0061
-      0x541E4000,  //  0035  LDINT	R7	16385
-      0x1C1C0C07,  //  0036  EQ	R7	R6	R7
-      0x781E0005,  //  0037  JMPF	R7	#003E
-      0x8C1C0907,  //  0038  GETMET	R7	R4	K7
-      0x88240908,  //  0039  GETMBR	R9	R4	K8
-      0x58280006,  //  003A  LDCONST	R10	K6
-      0x7C1C0600,  //  003B  CALL	R7	3
-      0x80040E00,  //  003C  RET	1	R7
-      0x70020022,  //  003D  JMP		#0061
-      0x541E4009,  //  003E  LDINT	R7	16394
-      0x1C1C0C07,  //  003F  EQ	R7	R6	R7
-      0x781E0005,  //  0040  JMPF	R7	#0047
-      0x8C1C0907,  //  0041  GETMET	R7	R4	K7
-      0x88240908,  //  0042  GETMBR	R9	R4	K8
-      0x5828000A,  //  0043  LDCONST	R10	K10
-      0x7C1C0600,  //  0044  CALL	R7	3
-      0x80040E00,  //  0045  RET	1	R7
-      0x70020019,  //  0046  JMP		#0061
-      0x541E000F,  //  0047  LDINT	R7	16
-      0x1C1C0C07,  //  0048  EQ	R7	R6	R7
-      0x781E0005,  //  0049  JMPF	R7	#0050
-      0x8C1C0907,  //  004A  GETMET	R7	R4	K7
-      0x88240908,  //  004B  GETMBR	R9	R4	K8
-      0x58280006,  //  004C  LDCONST	R10	K6
-      0x7C1C0600,  //  004D  CALL	R7	3
-      0x80040E00,  //  004E  RET	1	R7
-      0x70020010,  //  004F  JMP		#0061
-      0x541EFFFB,  //  0050  LDINT	R7	65532
-      0x1C1C0C07,  //  0051  EQ	R7	R6	R7
-      0x781E0005,  //  0052  JMPF	R7	#0059
-      0x8C1C0907,  //  0053  GETMET	R7	R4	K7
-      0x8824090C,  //  0054  GETMBR	R9	R4	K12
-      0x5828000A,  //  0055  LDCONST	R10	K10
-      0x7C1C0600,  //  0056  CALL	R7	3
-      0x80040E00,  //  0057  RET	1	R7
-      0x70020007,  //  0058  JMP		#0061
-      0x541EFFFC,  //  0059  LDINT	R7	65533
-      0x1C1C0C07,  //  005A  EQ	R7	R6	R7
-      0x781E0004,  //  005B  JMPF	R7	#0061
-      0x8C1C0907,  //  005C  GETMET	R7	R4	K7
-      0x8824090C,  //  005D  GETMBR	R9	R4	K12
-      0x542A0004,  //  005E  LDINT	R10	5
-      0x7C1C0600,  //  005F  CALL	R7	3
-      0x80040E00,  //  0060  RET	1	R7
-      0x70020007,  //  0061  JMP		#006A
-      0x601C0003,  //  0062  GETGBL	R7	G3
-      0x5C200000,  //  0063  MOVE	R8	R0
-      0x7C1C0200,  //  0064  CALL	R7	1
-      0x8C1C0F0D,  //  0065  GETMET	R7	R7	K13
-      0x5C240200,  //  0066  MOVE	R9	R1
-      0x5C280400,  //  0067  MOVE	R10	R2
-      0x7C1C0600,  //  0068  CALL	R7	3
-      0x80040E00,  //  0069  RET	1	R7
-      0x80000000,  //  006A  RET	0
+      0x541A02FF,  //  0004  LDINT	R6	768
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0059,  //  0006  JMPF	R6	#0061
+      0x8C180104,  //  0007  GETMET	R6	R0	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x1C180B05,  //  0009  EQ	R6	R5	K5
+      0x781A0005,  //  000A  JMPF	R6	#0011
+      0x8C180706,  //  000B  GETMET	R6	R3	K6
+      0x88200707,  //  000C  GETMBR	R8	R3	K7
+      0x88240108,  //  000D  GETMBR	R9	R0	K8
+      0x7C180600,  //  000E  CALL	R6	3
+      0x80040C00,  //  000F  RET	1	R6
+      0x7002004E,  //  0010  JMP		#0060
+      0x1C180B09,  //  0011  EQ	R6	R5	K9
+      0x781A0005,  //  0012  JMPF	R6	#0019
+      0x8C180706,  //  0013  GETMET	R6	R3	K6
+      0x88200707,  //  0014  GETMBR	R8	R3	K7
+      0x8824010A,  //  0015  GETMBR	R9	R0	K10
+      0x7C180600,  //  0016  CALL	R6	3
+      0x80040C00,  //  0017  RET	1	R6
+      0x70020046,  //  0018  JMP		#0060
+      0x541A0006,  //  0019  LDINT	R6	7
+      0x1C180A06,  //  001A  EQ	R6	R5	R6
+      0x781A0005,  //  001B  JMPF	R6	#0022
+      0x8C180706,  //  001C  GETMET	R6	R3	K6
+      0x88200707,  //  001D  GETMBR	R8	R3	K7
+      0x58240005,  //  001E  LDCONST	R9	K5
+      0x7C180600,  //  001F  CALL	R6	3
+      0x80040C00,  //  0020  RET	1	R6
+      0x7002003D,  //  0021  JMP		#0060
+      0x541A0007,  //  0022  LDINT	R6	8
+      0x1C180A06,  //  0023  EQ	R6	R5	R6
+      0x781A0005,  //  0024  JMPF	R6	#002B
+      0x8C180706,  //  0025  GETMET	R6	R3	K6
+      0x88200707,  //  0026  GETMBR	R8	R3	K7
+      0x58240005,  //  0027  LDCONST	R9	K5
+      0x7C180600,  //  0028  CALL	R6	3
+      0x80040C00,  //  0029  RET	1	R6
+      0x70020034,  //  002A  JMP		#0060
+      0x541A000E,  //  002B  LDINT	R6	15
+      0x1C180A06,  //  002C  EQ	R6	R5	R6
+      0x781A0005,  //  002D  JMPF	R6	#0034
+      0x8C180706,  //  002E  GETMET	R6	R3	K6
+      0x88200707,  //  002F  GETMBR	R8	R3	K7
+      0x58240005,  //  0030  LDCONST	R9	K5
+      0x7C180600,  //  0031  CALL	R6	3
+      0x80040C00,  //  0032  RET	1	R6
+      0x7002002B,  //  0033  JMP		#0060
+      0x541A4000,  //  0034  LDINT	R6	16385
+      0x1C180A06,  //  0035  EQ	R6	R5	R6
+      0x781A0005,  //  0036  JMPF	R6	#003D
+      0x8C180706,  //  0037  GETMET	R6	R3	K6
+      0x88200707,  //  0038  GETMBR	R8	R3	K7
+      0x58240005,  //  0039  LDCONST	R9	K5
+      0x7C180600,  //  003A  CALL	R6	3
+      0x80040C00,  //  003B  RET	1	R6
+      0x70020022,  //  003C  JMP		#0060
+      0x541A4009,  //  003D  LDINT	R6	16394
+      0x1C180A06,  //  003E  EQ	R6	R5	R6
+      0x781A0005,  //  003F  JMPF	R6	#0046
+      0x8C180706,  //  0040  GETMET	R6	R3	K6
+      0x88200707,  //  0041  GETMBR	R8	R3	K7
+      0x58240009,  //  0042  LDCONST	R9	K9
+      0x7C180600,  //  0043  CALL	R6	3
+      0x80040C00,  //  0044  RET	1	R6
+      0x70020019,  //  0045  JMP		#0060
+      0x541A000F,  //  0046  LDINT	R6	16
+      0x1C180A06,  //  0047  EQ	R6	R5	R6
+      0x781A0005,  //  0048  JMPF	R6	#004F
+      0x8C180706,  //  0049  GETMET	R6	R3	K6
+      0x88200707,  //  004A  GETMBR	R8	R3	K7
+      0x58240005,  //  004B  LDCONST	R9	K5
+      0x7C180600,  //  004C  CALL	R6	3
+      0x80040C00,  //  004D  RET	1	R6
+      0x70020010,  //  004E  JMP		#0060
+      0x541AFFFB,  //  004F  LDINT	R6	65532
+      0x1C180A06,  //  0050  EQ	R6	R5	R6
+      0x781A0005,  //  0051  JMPF	R6	#0058
+      0x8C180706,  //  0052  GETMET	R6	R3	K6
+      0x8820070B,  //  0053  GETMBR	R8	R3	K11
+      0x58240009,  //  0054  LDCONST	R9	K9
+      0x7C180600,  //  0055  CALL	R6	3
+      0x80040C00,  //  0056  RET	1	R6
+      0x70020007,  //  0057  JMP		#0060
+      0x541AFFFC,  //  0058  LDINT	R6	65533
+      0x1C180A06,  //  0059  EQ	R6	R5	R6
+      0x781A0004,  //  005A  JMPF	R6	#0060
+      0x8C180706,  //  005B  GETMET	R6	R3	K6
+      0x8820070B,  //  005C  GETMBR	R8	R3	K11
+      0x54260004,  //  005D  LDINT	R9	5
+      0x7C180600,  //  005E  CALL	R6	3
+      0x80040C00,  //  005F  RET	1	R6
+      0x70020007,  //  0060  JMP		#0069
+      0x60180003,  //  0061  GETGBL	R6	G3
+      0x5C1C0000,  //  0062  MOVE	R7	R0
+      0x7C180200,  //  0063  CALL	R6	1
+      0x8C180D0C,  //  0064  GETMET	R6	R6	K12
+      0x5C200200,  //  0065  MOVE	R8	R1
+      0x5C240400,  //  0066  MOVE	R9	R2
+      0x7C180600,  //  0067  CALL	R6	3
+      0x80040C00,  //  0068  RET	1	R6
+      0x80000000,  //  0069  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_OnOff.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_OnOff.h
@@ -190,7 +190,7 @@ be_local_closure(Matter_Plugin_OnOff_parse_configuration,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_OnOff_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -198,68 +198,66 @@ be_local_closure(Matter_Plugin_OnOff_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(BOOL),
-    /* K9   */  be_nested_str_weak(shadow_onoff),
-    /* K10  */  be_nested_str_weak(U4),
-    /* K11  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(BOOL),
+    /* K8   */  be_nested_str_weak(shadow_onoff),
+    /* K9   */  be_nested_str_weak(U4),
+    /* K10  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[44]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0005,  //  0005  LDINT	R7	6
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E001B,  //  0007  JMPF	R7	#0024
-      0x8C1C0105,  //  0008  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x1C1C0D06,  //  000A  EQ	R7	R6	K6
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0907,  //  000C  GETMET	R7	R4	K7
-      0x88240908,  //  000D  GETMBR	R9	R4	K8
-      0x88280109,  //  000E  GETMBR	R10	R0	K9
-      0x7C1C0600,  //  000F  CALL	R7	3
-      0x80040E00,  //  0010  RET	1	R7
-      0x70020010,  //  0011  JMP		#0023
-      0x541EFFFB,  //  0012  LDINT	R7	65532
-      0x1C1C0C07,  //  0013  EQ	R7	R6	R7
-      0x781E0005,  //  0014  JMPF	R7	#001B
-      0x8C1C0907,  //  0015  GETMET	R7	R4	K7
-      0x8824090A,  //  0016  GETMBR	R9	R4	K10
-      0x58280006,  //  0017  LDCONST	R10	K6
-      0x7C1C0600,  //  0018  CALL	R7	3
-      0x80040E00,  //  0019  RET	1	R7
-      0x70020007,  //  001A  JMP		#0023
-      0x541EFFFC,  //  001B  LDINT	R7	65533
-      0x1C1C0C07,  //  001C  EQ	R7	R6	R7
-      0x781E0004,  //  001D  JMPF	R7	#0023
-      0x8C1C0907,  //  001E  GETMET	R7	R4	K7
-      0x8824090A,  //  001F  GETMBR	R9	R4	K10
-      0x542A0003,  //  0020  LDINT	R10	4
-      0x7C1C0600,  //  0021  CALL	R7	3
-      0x80040E00,  //  0022  RET	1	R7
-      0x70020007,  //  0023  JMP		#002C
-      0x601C0003,  //  0024  GETGBL	R7	G3
-      0x5C200000,  //  0025  MOVE	R8	R0
-      0x7C1C0200,  //  0026  CALL	R7	1
-      0x8C1C0F0B,  //  0027  GETMET	R7	R7	K11
-      0x5C240200,  //  0028  MOVE	R9	R1
-      0x5C280400,  //  0029  MOVE	R10	R2
-      0x7C1C0600,  //  002A  CALL	R7	3
-      0x80040E00,  //  002B  RET	1	R7
-      0x80000000,  //  002C  RET	0
+      0x541A0005,  //  0004  LDINT	R6	6
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A001B,  //  0006  JMPF	R6	#0023
+      0x8C180104,  //  0007  GETMET	R6	R0	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x1C180B05,  //  0009  EQ	R6	R5	K5
+      0x781A0005,  //  000A  JMPF	R6	#0011
+      0x8C180706,  //  000B  GETMET	R6	R3	K6
+      0x88200707,  //  000C  GETMBR	R8	R3	K7
+      0x88240108,  //  000D  GETMBR	R9	R0	K8
+      0x7C180600,  //  000E  CALL	R6	3
+      0x80040C00,  //  000F  RET	1	R6
+      0x70020010,  //  0010  JMP		#0022
+      0x541AFFFB,  //  0011  LDINT	R6	65532
+      0x1C180A06,  //  0012  EQ	R6	R5	R6
+      0x781A0005,  //  0013  JMPF	R6	#001A
+      0x8C180706,  //  0014  GETMET	R6	R3	K6
+      0x88200709,  //  0015  GETMBR	R8	R3	K9
+      0x58240005,  //  0016  LDCONST	R9	K5
+      0x7C180600,  //  0017  CALL	R6	3
+      0x80040C00,  //  0018  RET	1	R6
+      0x70020007,  //  0019  JMP		#0022
+      0x541AFFFC,  //  001A  LDINT	R6	65533
+      0x1C180A06,  //  001B  EQ	R6	R5	R6
+      0x781A0004,  //  001C  JMPF	R6	#0022
+      0x8C180706,  //  001D  GETMET	R6	R3	K6
+      0x88200709,  //  001E  GETMBR	R8	R3	K9
+      0x54260003,  //  001F  LDINT	R9	4
+      0x7C180600,  //  0020  CALL	R6	3
+      0x80040C00,  //  0021  RET	1	R6
+      0x70020007,  //  0022  JMP		#002B
+      0x60180003,  //  0023  GETGBL	R6	G3
+      0x5C1C0000,  //  0024  MOVE	R7	R0
+      0x7C180200,  //  0025  CALL	R6	1
+      0x8C180D0A,  //  0026  GETMET	R6	R6	K10
+      0x5C200200,  //  0027  MOVE	R8	R1
+      0x5C240400,  //  0028  MOVE	R9	R2
+      0x7C180600,  //  0029  CALL	R6	3
+      0x80040C00,  //  002A  RET	1	R6
+      0x80000000,  //  002B  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Plugin_Root;
 ********************************************************************/
 be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
   be_nested_proto(
-    31,                          /* nstack */
+    30,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -25,7 +25,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
         1,                          /* has upvals */
         ( &(const bupvaldesc[ 2]) {  /* upvals */
           be_local_const_upval(1, 0),
-          be_local_const_upval(1, 11),
+          be_local_const_upval(1, 10),
         }),
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
@@ -47,822 +47,819 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[102]) {     /* constants */
+    ( &(const bvalue[100]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(TLV),
-    /* K4   */  be_nested_str_weak(cluster),
-    /* K5   */  be_nested_str_weak(command),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(findsubval),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(_breadcrumb),
-    /* K10  */  be_nested_str_weak(Matter_TLV_struct),
-    /* K11  */  be_nested_str_weak(add_TLV),
-    /* K12  */  be_nested_str_weak(U1),
-    /* K13  */  be_nested_str_weak(UTF1),
-    /* K14  */  be_nested_str_weak(),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_nested_str_weak(XX),
-    /* K17  */  be_const_int(3),
-    /* K18  */  be_nested_str_weak(_fabric),
-    /* K19  */  be_nested_str_weak(fabric_completed),
-    /* K20  */  be_nested_str_weak(set_no_expiration),
-    /* K21  */  be_nested_str_weak(save),
-    /* K22  */  be_nested_str_weak(device),
-    /* K23  */  be_nested_str_weak(start_commissioning_complete_deferred),
-    /* K24  */  be_nested_str_weak(context_error),
-    /* K25  */  be_nested_str_weak(CommissioningComplete_X3A_X20no_X20fabric_X20attached),
-    /* K26  */  be_nested_str_weak(status),
-    /* K27  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
-    /* K28  */  be_nested_str_weak(B2),
-    /* K29  */  be_nested_str_weak(DAC_Cert_FFF1_8000),
-    /* K30  */  be_nested_str_weak(PAI_Cert_FFF1),
-    /* K31  */  be_nested_str_weak(CD_FFF1_8000),
-    /* K32  */  be_nested_str_weak(B1),
-    /* K33  */  be_nested_str_weak(U4),
-    /* K34  */  be_nested_str_weak(tasmota),
-    /* K35  */  be_nested_str_weak(rtc),
-    /* K36  */  be_nested_str_weak(utc),
-    /* K37  */  be_nested_str_weak(tlv2raw),
-    /* K38  */  be_nested_str_weak(get_ac),
-    /* K39  */  be_nested_str_weak(EC_P256),
-    /* K40  */  be_nested_str_weak(ecdsa_sign_sha256),
-    /* K41  */  be_nested_str_weak(DAC_Priv_FFF1_8000),
-    /* K42  */  be_nested_str_weak(gen_CSR),
-    /* K43  */  be_nested_str_weak(set_temp_ca),
-    /* K44  */  be_nested_str_weak(SUCCESS),
-    /* K45  */  be_nested_str_weak(log),
-    /* K46  */  be_nested_str_weak(MTR_X3A_X20AddNoc_X20Args_X3D),
-    /* K47  */  be_nested_str_weak(get_temp_ca),
-    /* K48  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20AdNOC_X20without_X20CA),
-    /* K49  */  be_nested_str_weak(sessions),
-    /* K50  */  be_nested_str_weak(create_fabric),
-    /* K51  */  be_nested_str_weak(set_ca),
-    /* K52  */  be_nested_str_weak(set_noc_icac),
-    /* K53  */  be_nested_str_weak(set_ipk_epoch_key),
-    /* K54  */  be_nested_str_weak(set_admin_subject_vendor),
-    /* K55  */  be_nested_str_weak(set_pk),
-    /* K56  */  be_nested_str_weak(get_pk),
-    /* K57  */  be_nested_str_weak(parse),
-    /* K58  */  be_nested_str_weak(findsub),
-    /* K59  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20no_X20fabricid_X20nor_X20deviceid_X20in_X20NOC_X20certificate),
-    /* K60  */  be_nested_str_weak(int),
-    /* K61  */  be_nested_str_weak(int64),
-    /* K62  */  be_nested_str_weak(fromu32),
-    /* K63  */  be_nested_str_weak(tobytes),
-    /* K64  */  be_nested_str_weak(get_temp_ca_pub),
-    /* K65  */  be_const_int(2147483647),
-    /* K66  */  be_nested_str_weak(fromstring),
-    /* K67  */  be_nested_str_weak(CompressedFabric),
-    /* K68  */  be_nested_str_weak(HKDF_SHA256),
-    /* K69  */  be_nested_str_weak(copy),
-    /* K70  */  be_nested_str_weak(reverse),
-    /* K71  */  be_nested_str_weak(derive),
-    /* K72  */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K73  */  be_nested_str_weak(set_fabric_device),
-    /* K74  */  be_nested_str_weak(fabric_candidate),
-    /* K75  */  be_nested_str_weak(start_operational_discovery_deferred),
-    /* K76  */  be_nested_str_weak(is_PASE),
-    /* K77  */  be_nested_str_weak(set_expire_in_seconds),
-    /* K78  */  be_nested_str_weak(log_new_fabric),
-    /* K79  */  be_nested_str_weak(set_fabric_label),
-    /* K80  */  be_nested_str_weak(format),
-    /* K81  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Update_X20fabric_X20_X27_X25s_X27_X20label_X3D_X27_X25s_X27),
-    /* K82  */  be_nested_str_weak(get_fabric_id),
-    /* K83  */  be_nested_str_weak(tohex),
-    /* K84  */  be_nested_str_weak(fabric_index_X3A),
-    /* K85  */  be_nested_str_weak(active_fabrics),
-    /* K86  */  be_nested_str_weak(get_fabric_index),
-    /* K87  */  be_nested_str_weak(set_timer),
-    /* K88  */  be_nested_str_weak(stop_iteration),
-    /* K89  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
-    /* K90  */  be_nested_str_weak(_X29_X20not_X20found),
-    /* K91  */  be_nested_str_weak(INVALID_ACTION),
-    /* K92  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
-    /* K93  */  be_nested_str_weak(INVALID_DATA_TYPE),
-    /* K94  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
-    /* K95  */  be_nested_str_weak(CONSTRAINT_ERROR),
-    /* K96  */  be_nested_str_weak(start_basic_commissioning),
-    /* K97  */  be_nested_str_weak(get_fabric),
-    /* K98  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
-    /* K99  */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K100 */  be_nested_str_weak(stop_basic_commissioning),
-    /* K101 */  be_nested_str_weak(invoke_request),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(command),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(findsubval),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(_breadcrumb),
+    /* K9   */  be_nested_str_weak(Matter_TLV_struct),
+    /* K10  */  be_nested_str_weak(add_TLV),
+    /* K11  */  be_nested_str_weak(U1),
+    /* K12  */  be_nested_str_weak(UTF1),
+    /* K13  */  be_nested_str_weak(),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(XX),
+    /* K16  */  be_const_int(3),
+    /* K17  */  be_nested_str_weak(_fabric),
+    /* K18  */  be_nested_str_weak(fabric_completed),
+    /* K19  */  be_nested_str_weak(set_no_expiration),
+    /* K20  */  be_nested_str_weak(save),
+    /* K21  */  be_nested_str_weak(device),
+    /* K22  */  be_nested_str_weak(start_commissioning_complete_deferred),
+    /* K23  */  be_nested_str_weak(context_error),
+    /* K24  */  be_nested_str_weak(CommissioningComplete_X3A_X20no_X20fabric_X20attached),
+    /* K25  */  be_nested_str_weak(status),
+    /* K26  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
+    /* K27  */  be_nested_str_weak(B2),
+    /* K28  */  be_nested_str_weak(DAC_Cert_FFF1_8000),
+    /* K29  */  be_nested_str_weak(PAI_Cert_FFF1),
+    /* K30  */  be_nested_str_weak(CD_FFF1_8000),
+    /* K31  */  be_nested_str_weak(B1),
+    /* K32  */  be_nested_str_weak(U4),
+    /* K33  */  be_nested_str_weak(tasmota),
+    /* K34  */  be_nested_str_weak(rtc),
+    /* K35  */  be_nested_str_weak(utc),
+    /* K36  */  be_nested_str_weak(tlv2raw),
+    /* K37  */  be_nested_str_weak(get_ac),
+    /* K38  */  be_nested_str_weak(EC_P256),
+    /* K39  */  be_nested_str_weak(ecdsa_sign_sha256),
+    /* K40  */  be_nested_str_weak(DAC_Priv_FFF1_8000),
+    /* K41  */  be_nested_str_weak(gen_CSR),
+    /* K42  */  be_nested_str_weak(set_temp_ca),
+    /* K43  */  be_nested_str_weak(SUCCESS),
+    /* K44  */  be_nested_str_weak(log),
+    /* K45  */  be_nested_str_weak(MTR_X3A_X20AddNoc_X20Args_X3D),
+    /* K46  */  be_nested_str_weak(get_temp_ca),
+    /* K47  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20AdNOC_X20without_X20CA),
+    /* K48  */  be_nested_str_weak(sessions),
+    /* K49  */  be_nested_str_weak(create_fabric),
+    /* K50  */  be_nested_str_weak(set_ca),
+    /* K51  */  be_nested_str_weak(set_noc_icac),
+    /* K52  */  be_nested_str_weak(set_ipk_epoch_key),
+    /* K53  */  be_nested_str_weak(set_admin_subject_vendor),
+    /* K54  */  be_nested_str_weak(set_pk),
+    /* K55  */  be_nested_str_weak(get_pk),
+    /* K56  */  be_nested_str_weak(parse),
+    /* K57  */  be_nested_str_weak(findsub),
+    /* K58  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20no_X20fabricid_X20nor_X20deviceid_X20in_X20NOC_X20certificate),
+    /* K59  */  be_nested_str_weak(int),
+    /* K60  */  be_nested_str_weak(int64),
+    /* K61  */  be_nested_str_weak(fromu32),
+    /* K62  */  be_nested_str_weak(tobytes),
+    /* K63  */  be_nested_str_weak(get_temp_ca_pub),
+    /* K64  */  be_const_int(2147483647),
+    /* K65  */  be_nested_str_weak(fromstring),
+    /* K66  */  be_nested_str_weak(CompressedFabric),
+    /* K67  */  be_nested_str_weak(HKDF_SHA256),
+    /* K68  */  be_nested_str_weak(copy),
+    /* K69  */  be_nested_str_weak(reverse),
+    /* K70  */  be_nested_str_weak(derive),
+    /* K71  */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K72  */  be_nested_str_weak(set_fabric_device),
+    /* K73  */  be_nested_str_weak(fabric_candidate),
+    /* K74  */  be_nested_str_weak(start_operational_discovery_deferred),
+    /* K75  */  be_nested_str_weak(is_PASE),
+    /* K76  */  be_nested_str_weak(set_expire_in_seconds),
+    /* K77  */  be_nested_str_weak(log_new_fabric),
+    /* K78  */  be_nested_str_weak(set_fabric_label),
+    /* K79  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Update_X20fabric_X20_X27_X25s_X27_X20label_X3D_X27_X25s_X27),
+    /* K80  */  be_nested_str_weak(get_fabric_id),
+    /* K81  */  be_nested_str_weak(tohex),
+    /* K82  */  be_nested_str_weak(fabric_index_X3A),
+    /* K83  */  be_nested_str_weak(active_fabrics),
+    /* K84  */  be_nested_str_weak(get_fabric_index),
+    /* K85  */  be_nested_str_weak(set_timer),
+    /* K86  */  be_nested_str_weak(stop_iteration),
+    /* K87  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
+    /* K88  */  be_nested_str_weak(_X29_X20not_X20found),
+    /* K89  */  be_nested_str_weak(INVALID_ACTION),
+    /* K90  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
+    /* K91  */  be_nested_str_weak(INVALID_DATA_TYPE),
+    /* K92  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
+    /* K93  */  be_nested_str_weak(CONSTRAINT_ERROR),
+    /* K94  */  be_nested_str_weak(start_basic_commissioning),
+    /* K95  */  be_nested_str_weak(get_fabric),
+    /* K96  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
+    /* K97  */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K98  */  be_nested_str_weak(stop_basic_commissioning),
+    /* K99  */  be_nested_str_weak(invoke_request),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[709]) {  /* code */
+    ( &(const binstruction[708]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
-      0xA4160200,  //  0001  IMPORT	R5	K1
-      0xB81A0400,  //  0002  GETNGBL	R6	K2
-      0x88180D03,  //  0003  GETMBR	R6	R6	K3
+      0xB8160200,  //  0001  GETNGBL	R5	K1
+      0x88140B02,  //  0002  GETMBR	R5	R5	K2
+      0x88180703,  //  0003  GETMBR	R6	R3	K3
       0x881C0704,  //  0004  GETMBR	R7	R3	K4
-      0x88200705,  //  0005  GETMBR	R8	R3	K5
-      0x5426002F,  //  0006  LDINT	R9	48
-      0x1C240E09,  //  0007  EQ	R9	R7	R9
-      0x78260059,  //  0008  JMPF	R9	#0063
-      0x1C241106,  //  0009  EQ	R9	R8	K6
-      0x78260017,  //  000A  JMPF	R9	#0023
-      0x8C240507,  //  000B  GETMET	R9	R2	K7
-      0x582C0006,  //  000C  LDCONST	R11	K6
-      0x54320383,  //  000D  LDINT	R12	900
-      0x7C240600,  //  000E  CALL	R9	3
-      0x8C280507,  //  000F  GETMET	R10	R2	K7
-      0x58300008,  //  0010  LDCONST	R12	K8
-      0x58340006,  //  0011  LDCONST	R13	K6
-      0x7C280600,  //  0012  CALL	R10	3
-      0x9006120A,  //  0013  SETMBR	R1	K9	R10
-      0x8C2C0D0A,  //  0014  GETMET	R11	R6	K10
-      0x7C2C0200,  //  0015  CALL	R11	1
-      0x8C30170B,  //  0016  GETMET	R12	R11	K11
-      0x58380006,  //  0017  LDCONST	R14	K6
-      0x883C0D0C,  //  0018  GETMBR	R15	R6	K12
-      0x58400006,  //  0019  LDCONST	R16	K6
-      0x7C300800,  //  001A  CALL	R12	4
-      0x8C30170B,  //  001B  GETMET	R12	R11	K11
-      0x58380008,  //  001C  LDCONST	R14	K8
-      0x883C0D0D,  //  001D  GETMBR	R15	R6	K13
-      0x5840000E,  //  001E  LDCONST	R16	K14
-      0x7C300800,  //  001F  CALL	R12	4
-      0x900E0B08,  //  0020  SETMBR	R3	K5	K8
-      0x80041600,  //  0021  RET	1	R11
-      0x7002003E,  //  0022  JMP		#0062
-      0x1C24110F,  //  0023  EQ	R9	R8	K15
-      0x7826001A,  //  0024  JMPF	R9	#0040
-      0x8C240507,  //  0025  GETMET	R9	R2	K7
-      0x582C0006,  //  0026  LDCONST	R11	K6
-      0x7C240400,  //  0027  CALL	R9	2
-      0x8C280507,  //  0028  GETMET	R10	R2	K7
-      0x58300008,  //  0029  LDCONST	R12	K8
-      0x58340010,  //  002A  LDCONST	R13	K16
-      0x7C280600,  //  002B  CALL	R10	3
-      0x8C2C0507,  //  002C  GETMET	R11	R2	K7
-      0x5834000F,  //  002D  LDCONST	R13	K15
-      0x58380006,  //  002E  LDCONST	R14	K6
-      0x7C2C0600,  //  002F  CALL	R11	3
-      0x9006120B,  //  0030  SETMBR	R1	K9	R11
-      0x8C300D0A,  //  0031  GETMET	R12	R6	K10
-      0x7C300200,  //  0032  CALL	R12	1
-      0x8C34190B,  //  0033  GETMET	R13	R12	K11
-      0x583C0006,  //  0034  LDCONST	R15	K6
-      0x88400D0C,  //  0035  GETMBR	R16	R6	K12
-      0x58440006,  //  0036  LDCONST	R17	K6
-      0x7C340800,  //  0037  CALL	R13	4
-      0x8C34190B,  //  0038  GETMET	R13	R12	K11
-      0x583C0008,  //  0039  LDCONST	R15	K8
-      0x88400D0D,  //  003A  GETMBR	R16	R6	K13
-      0x5844000E,  //  003B  LDCONST	R17	K14
-      0x7C340800,  //  003C  CALL	R13	4
-      0x900E0B11,  //  003D  SETMBR	R3	K5	K17
-      0x80041800,  //  003E  RET	1	R12
-      0x70020021,  //  003F  JMP		#0062
-      0x54260003,  //  0040  LDINT	R9	4
-      0x1C241009,  //  0041  EQ	R9	R8	R9
-      0x7826001E,  //  0042  JMPF	R9	#0062
-      0x88240312,  //  0043  GETMBR	R9	R1	K18
-      0x7826001B,  //  0044  JMPF	R9	#0061
-      0x90061306,  //  0045  SETMBR	R1	K9	K6
-      0x88240312,  //  0046  GETMBR	R9	R1	K18
-      0x8C241313,  //  0047  GETMET	R9	R9	K19
-      0x7C240200,  //  0048  CALL	R9	1
-      0x8C240314,  //  0049  GETMET	R9	R1	K20
-      0x7C240200,  //  004A  CALL	R9	1
-      0x8C240315,  //  004B  GETMET	R9	R1	K21
-      0x7C240200,  //  004C  CALL	R9	1
-      0x8C240D0A,  //  004D  GETMET	R9	R6	K10
-      0x7C240200,  //  004E  CALL	R9	1
-      0x8C28130B,  //  004F  GETMET	R10	R9	K11
-      0x58300006,  //  0050  LDCONST	R12	K6
-      0x88340D0C,  //  0051  GETMBR	R13	R6	K12
-      0x58380006,  //  0052  LDCONST	R14	K6
-      0x7C280800,  //  0053  CALL	R10	4
-      0x8C28130B,  //  0054  GETMET	R10	R9	K11
-      0x58300008,  //  0055  LDCONST	R12	K8
-      0x88340D0D,  //  0056  GETMBR	R13	R6	K13
-      0x5838000E,  //  0057  LDCONST	R14	K14
-      0x7C280800,  //  0058  CALL	R10	4
-      0x542A0004,  //  0059  LDINT	R10	5
-      0x900E0A0A,  //  005A  SETMBR	R3	K5	R10
-      0x88280116,  //  005B  GETMBR	R10	R0	K22
-      0x8C281517,  //  005C  GETMET	R10	R10	K23
-      0x5C300200,  //  005D  MOVE	R12	R1
-      0x7C280400,  //  005E  CALL	R10	2
-      0x80041200,  //  005F  RET	1	R9
-      0x70020000,  //  0060  JMP		#0062
-      0xB0063119,  //  0061  RAISE	1	K24	K25
-      0x7002025F,  //  0062  JMP		#02C3
-      0x5426003D,  //  0063  LDINT	R9	62
-      0x1C240E09,  //  0064  EQ	R9	R7	R9
-      0x782601C0,  //  0065  JMPF	R9	#0227
-      0x1C24110F,  //  0066  EQ	R9	R8	K15
-      0x7826001D,  //  0067  JMPF	R9	#0086
-      0x8C240507,  //  0068  GETMET	R9	R2	K7
-      0x582C0006,  //  0069  LDCONST	R11	K6
-      0x7C240400,  //  006A  CALL	R9	2
-      0x20281308,  //  006B  NE	R10	R9	K8
-      0x782A0006,  //  006C  JMPF	R10	#0074
-      0x2028130F,  //  006D  NE	R10	R9	K15
-      0x782A0004,  //  006E  JMPF	R10	#0074
-      0xB82A0400,  //  006F  GETNGBL	R10	K2
-      0x8828151B,  //  0070  GETMBR	R10	R10	K27
-      0x900E340A,  //  0071  SETMBR	R3	K26	R10
-      0x4C280000,  //  0072  LDNIL	R10
-      0x80041400,  //  0073  RET	1	R10
-      0x8C280D0A,  //  0074  GETMET	R10	R6	K10
-      0x7C280200,  //  0075  CALL	R10	1
-      0x8C2C150B,  //  0076  GETMET	R11	R10	K11
-      0x58340006,  //  0077  LDCONST	R13	K6
-      0x88380D1C,  //  0078  GETMBR	R14	R6	K28
-      0x1C3C1308,  //  0079  EQ	R15	R9	K8
-      0x783E0003,  //  007A  JMPF	R15	#007F
-      0xB83E0400,  //  007B  GETNGBL	R15	K2
-      0x8C3C1F1D,  //  007C  GETMET	R15	R15	K29
-      0x7C3C0200,  //  007D  CALL	R15	1
-      0x70020002,  //  007E  JMP		#0082
-      0xB83E0400,  //  007F  GETNGBL	R15	K2
-      0x8C3C1F1E,  //  0080  GETMET	R15	R15	K30
-      0x7C3C0200,  //  0081  CALL	R15	1
-      0x7C2C0800,  //  0082  CALL	R11	4
-      0x900E0B11,  //  0083  SETMBR	R3	K5	K17
-      0x80041400,  //  0084  RET	1	R10
-      0x7002019F,  //  0085  JMP		#0226
-      0x1C241106,  //  0086  EQ	R9	R8	K6
-      0x7826003D,  //  0087  JMPF	R9	#00C6
-      0x8C240507,  //  0088  GETMET	R9	R2	K7
-      0x582C0006,  //  0089  LDCONST	R11	K6
-      0x7C240400,  //  008A  CALL	R9	2
-      0x6028000C,  //  008B  GETGBL	R10	G12
-      0x5C2C1200,  //  008C  MOVE	R11	R9
-      0x7C280200,  //  008D  CALL	R10	1
-      0x542E001F,  //  008E  LDINT	R11	32
-      0x2028140B,  //  008F  NE	R10	R10	R11
-      0x782A0001,  //  0090  JMPF	R10	#0093
-      0x4C280000,  //  0091  LDNIL	R10
-      0x80041400,  //  0092  RET	1	R10
-      0x900E0B08,  //  0093  SETMBR	R3	K5	K8
-      0x8C280D0A,  //  0094  GETMET	R10	R6	K10
-      0x7C280200,  //  0095  CALL	R10	1
-      0x8C2C150B,  //  0096  GETMET	R11	R10	K11
-      0x58340008,  //  0097  LDCONST	R13	K8
-      0x88380D1C,  //  0098  GETMBR	R14	R6	K28
-      0xB83E0400,  //  0099  GETNGBL	R15	K2
-      0x8C3C1F1F,  //  009A  GETMET	R15	R15	K31
-      0x7C3C0200,  //  009B  CALL	R15	1
-      0x7C2C0800,  //  009C  CALL	R11	4
-      0x8C2C150B,  //  009D  GETMET	R11	R10	K11
-      0x5834000F,  //  009E  LDCONST	R13	K15
-      0x88380D20,  //  009F  GETMBR	R14	R6	K32
-      0x5C3C1200,  //  00A0  MOVE	R15	R9
-      0x7C2C0800,  //  00A1  CALL	R11	4
-      0x8C2C150B,  //  00A2  GETMET	R11	R10	K11
-      0x58340011,  //  00A3  LDCONST	R13	K17
-      0x88380D21,  //  00A4  GETMBR	R14	R6	K33
-      0xB83E4400,  //  00A5  GETNGBL	R15	K34
-      0x8C3C1F23,  //  00A6  GETMET	R15	R15	K35
-      0x7C3C0200,  //  00A7  CALL	R15	1
-      0x943C1F24,  //  00A8  GETIDX	R15	R15	K36
-      0x7C2C0800,  //  00A9  CALL	R11	4
-      0x8C2C1525,  //  00AA  GETMET	R11	R10	K37
-      0x7C2C0200,  //  00AB  CALL	R11	1
-      0x8C300326,  //  00AC  GETMET	R12	R1	K38
-      0x7C300200,  //  00AD  CALL	R12	1
-      0x0034160C,  //  00AE  ADD	R13	R11	R12
-      0x8C380927,  //  00AF  GETMET	R14	R4	K39
-      0x7C380200,  //  00B0  CALL	R14	1
-      0x8C381D28,  //  00B1  GETMET	R14	R14	K40
-      0xB8420400,  //  00B2  GETNGBL	R16	K2
-      0x8C402129,  //  00B3  GETMET	R16	R16	K41
-      0x7C400200,  //  00B4  CALL	R16	1
-      0x5C441A00,  //  00B5  MOVE	R17	R13
-      0x7C380600,  //  00B6  CALL	R14	3
-      0x8C3C0D0A,  //  00B7  GETMET	R15	R6	K10
-      0x7C3C0200,  //  00B8  CALL	R15	1
-      0x8C401F0B,  //  00B9  GETMET	R16	R15	K11
-      0x58480006,  //  00BA  LDCONST	R18	K6
-      0x884C0D1C,  //  00BB  GETMBR	R19	R6	K28
-      0x5C501600,  //  00BC  MOVE	R20	R11
-      0x7C400800,  //  00BD  CALL	R16	4
-      0x8C401F0B,  //  00BE  GETMET	R16	R15	K11
-      0x58480008,  //  00BF  LDCONST	R18	K8
-      0x884C0D20,  //  00C0  GETMBR	R19	R6	K32
-      0x5C501C00,  //  00C1  MOVE	R20	R14
-      0x7C400800,  //  00C2  CALL	R16	4
-      0x900E0B08,  //  00C3  SETMBR	R3	K5	K8
-      0x80041E00,  //  00C4  RET	1	R15
-      0x7002015F,  //  00C5  JMP		#0226
-      0x54260003,  //  00C6  LDINT	R9	4
-      0x1C241009,  //  00C7  EQ	R9	R8	R9
-      0x78260039,  //  00C8  JMPF	R9	#0103
-      0x8C240507,  //  00C9  GETMET	R9	R2	K7
-      0x582C0006,  //  00CA  LDCONST	R11	K6
-      0x7C240400,  //  00CB  CALL	R9	2
-      0x6028000C,  //  00CC  GETGBL	R10	G12
-      0x5C2C1200,  //  00CD  MOVE	R11	R9
-      0x7C280200,  //  00CE  CALL	R10	1
-      0x542E001F,  //  00CF  LDINT	R11	32
-      0x2028140B,  //  00D0  NE	R10	R10	R11
-      0x782A0001,  //  00D1  JMPF	R10	#00D4
-      0x4C280000,  //  00D2  LDNIL	R10
-      0x80041400,  //  00D3  RET	1	R10
-      0x8C280507,  //  00D4  GETMET	R10	R2	K7
-      0x58300008,  //  00D5  LDCONST	R12	K8
-      0x50340000,  //  00D6  LDBOOL	R13	0	0
-      0x7C280600,  //  00D7  CALL	R10	3
-      0x8C2C032A,  //  00D8  GETMET	R11	R1	K42
-      0x7C2C0200,  //  00D9  CALL	R11	1
-      0x8C300D0A,  //  00DA  GETMET	R12	R6	K10
-      0x7C300200,  //  00DB  CALL	R12	1
-      0x8C34190B,  //  00DC  GETMET	R13	R12	K11
-      0x583C0008,  //  00DD  LDCONST	R15	K8
-      0x88400D1C,  //  00DE  GETMBR	R16	R6	K28
-      0x5C441600,  //  00DF  MOVE	R17	R11
-      0x7C340800,  //  00E0  CALL	R13	4
-      0x8C34190B,  //  00E1  GETMET	R13	R12	K11
-      0x583C000F,  //  00E2  LDCONST	R15	K15
-      0x88400D20,  //  00E3  GETMBR	R16	R6	K32
-      0x5C441200,  //  00E4  MOVE	R17	R9
-      0x7C340800,  //  00E5  CALL	R13	4
-      0x8C341925,  //  00E6  GETMET	R13	R12	K37
-      0x7C340200,  //  00E7  CALL	R13	1
-      0x8C380326,  //  00E8  GETMET	R14	R1	K38
-      0x7C380200,  //  00E9  CALL	R14	1
-      0x00381A0E,  //  00EA  ADD	R14	R13	R14
-      0x8C3C0927,  //  00EB  GETMET	R15	R4	K39
-      0x7C3C0200,  //  00EC  CALL	R15	1
-      0x8C3C1F28,  //  00ED  GETMET	R15	R15	K40
-      0xB8460400,  //  00EE  GETNGBL	R17	K2
-      0x8C442329,  //  00EF  GETMET	R17	R17	K41
-      0x7C440200,  //  00F0  CALL	R17	1
-      0x5C481C00,  //  00F1  MOVE	R18	R14
-      0x7C3C0600,  //  00F2  CALL	R15	3
-      0x8C400D0A,  //  00F3  GETMET	R16	R6	K10
-      0x7C400200,  //  00F4  CALL	R16	1
-      0x8C44210B,  //  00F5  GETMET	R17	R16	K11
-      0x584C0006,  //  00F6  LDCONST	R19	K6
-      0x88500D1C,  //  00F7  GETMBR	R20	R6	K28
-      0x5C541A00,  //  00F8  MOVE	R21	R13
-      0x7C440800,  //  00F9  CALL	R17	4
-      0x8C44210B,  //  00FA  GETMET	R17	R16	K11
-      0x584C0008,  //  00FB  LDCONST	R19	K8
-      0x88500D20,  //  00FC  GETMBR	R20	R6	K32
-      0x5C541E00,  //  00FD  MOVE	R21	R15
-      0x7C440800,  //  00FE  CALL	R17	4
-      0x54460004,  //  00FF  LDINT	R17	5
-      0x900E0A11,  //  0100  SETMBR	R3	K5	R17
-      0x80042000,  //  0101  RET	1	R16
-      0x70020122,  //  0102  JMP		#0226
-      0x5426000A,  //  0103  LDINT	R9	11
-      0x1C241009,  //  0104  EQ	R9	R8	R9
-      0x7826000B,  //  0105  JMPF	R9	#0112
-      0x8C240507,  //  0106  GETMET	R9	R2	K7
-      0x582C0006,  //  0107  LDCONST	R11	K6
-      0x7C240400,  //  0108  CALL	R9	2
-      0x8C28032B,  //  0109  GETMET	R10	R1	K43
-      0x5C301200,  //  010A  MOVE	R12	R9
-      0x7C280400,  //  010B  CALL	R10	2
-      0xB82A0400,  //  010C  GETNGBL	R10	K2
-      0x8828152C,  //  010D  GETMBR	R10	R10	K44
-      0x900E340A,  //  010E  SETMBR	R3	K26	R10
-      0x4C280000,  //  010F  LDNIL	R10
-      0x80041400,  //  0110  RET	1	R10
-      0x70020113,  //  0111  JMP		#0226
-      0x54260005,  //  0112  LDINT	R9	6
-      0x1C241009,  //  0113  EQ	R9	R8	R9
-      0x782600B9,  //  0114  JMPF	R9	#01CF
-      0xB8264400,  //  0115  GETNGBL	R9	K34
-      0x8C24132D,  //  0116  GETMET	R9	R9	K45
-      0x602C0008,  //  0117  GETGBL	R11	G8
-      0x5C300400,  //  0118  MOVE	R12	R2
-      0x7C2C0200,  //  0119  CALL	R11	1
-      0x002E5C0B,  //  011A  ADD	R11	K46	R11
-      0x54320003,  //  011B  LDINT	R12	4
-      0x7C240600,  //  011C  CALL	R9	3
-      0x8C240507,  //  011D  GETMET	R9	R2	K7
-      0x582C0006,  //  011E  LDCONST	R11	K6
-      0x7C240400,  //  011F  CALL	R9	2
-      0x8C280507,  //  0120  GETMET	R10	R2	K7
-      0x58300008,  //  0121  LDCONST	R12	K8
-      0x7C280400,  //  0122  CALL	R10	2
-      0x602C000C,  //  0123  GETGBL	R11	G12
-      0x5C301400,  //  0124  MOVE	R12	R10
-      0x7C2C0200,  //  0125  CALL	R11	1
-      0x1C2C1706,  //  0126  EQ	R11	R11	K6
-      0x782E0000,  //  0127  JMPF	R11	#0129
-      0x4C280000,  //  0128  LDNIL	R10
-      0x8C2C0507,  //  0129  GETMET	R11	R2	K7
-      0x5834000F,  //  012A  LDCONST	R13	K15
-      0x7C2C0400,  //  012B  CALL	R11	2
-      0x8C300507,  //  012C  GETMET	R12	R2	K7
-      0x58380011,  //  012D  LDCONST	R14	K17
-      0x7C300400,  //  012E  CALL	R12	2
-      0x8C340507,  //  012F  GETMET	R13	R2	K7
-      0x543E0003,  //  0130  LDINT	R15	4
-      0x7C340400,  //  0131  CALL	R13	2
-      0x8C38032F,  //  0132  GETMET	R14	R1	K47
-      0x7C380200,  //  0133  CALL	R14	1
-      0x4C3C0000,  //  0134  LDNIL	R15
-      0x1C381C0F,  //  0135  EQ	R14	R14	R15
-      0x783A0006,  //  0136  JMPF	R14	#013E
-      0xB83A4400,  //  0137  GETNGBL	R14	K34
-      0x8C381D2D,  //  0138  GETMET	R14	R14	K45
-      0x58400030,  //  0139  LDCONST	R16	K48
-      0x5844000F,  //  013A  LDCONST	R17	K15
-      0x7C380600,  //  013B  CALL	R14	3
-      0x4C380000,  //  013C  LDNIL	R14
-      0x80041C00,  //  013D  RET	1	R14
-      0x88380116,  //  013E  GETMBR	R14	R0	K22
-      0x88381D31,  //  013F  GETMBR	R14	R14	K49
-      0x8C381D32,  //  0140  GETMET	R14	R14	K50
-      0x7C380200,  //  0141  CALL	R14	1
-      0x8C3C1D33,  //  0142  GETMET	R15	R14	K51
-      0x8C44032F,  //  0143  GETMET	R17	R1	K47
-      0x7C440200,  //  0144  CALL	R17	1
-      0x7C3C0400,  //  0145  CALL	R15	2
-      0x8C3C1D34,  //  0146  GETMET	R15	R14	K52
+      0x5422002F,  //  0005  LDINT	R8	48
+      0x1C200C08,  //  0006  EQ	R8	R6	R8
+      0x78220059,  //  0007  JMPF	R8	#0062
+      0x1C200F05,  //  0008  EQ	R8	R7	K5
+      0x78220017,  //  0009  JMPF	R8	#0022
+      0x8C200506,  //  000A  GETMET	R8	R2	K6
+      0x58280005,  //  000B  LDCONST	R10	K5
+      0x542E0383,  //  000C  LDINT	R11	900
+      0x7C200600,  //  000D  CALL	R8	3
+      0x8C240506,  //  000E  GETMET	R9	R2	K6
+      0x582C0007,  //  000F  LDCONST	R11	K7
+      0x58300005,  //  0010  LDCONST	R12	K5
+      0x7C240600,  //  0011  CALL	R9	3
+      0x90061009,  //  0012  SETMBR	R1	K8	R9
+      0x8C280B09,  //  0013  GETMET	R10	R5	K9
+      0x7C280200,  //  0014  CALL	R10	1
+      0x8C2C150A,  //  0015  GETMET	R11	R10	K10
+      0x58340005,  //  0016  LDCONST	R13	K5
+      0x88380B0B,  //  0017  GETMBR	R14	R5	K11
+      0x583C0005,  //  0018  LDCONST	R15	K5
+      0x7C2C0800,  //  0019  CALL	R11	4
+      0x8C2C150A,  //  001A  GETMET	R11	R10	K10
+      0x58340007,  //  001B  LDCONST	R13	K7
+      0x88380B0C,  //  001C  GETMBR	R14	R5	K12
+      0x583C000D,  //  001D  LDCONST	R15	K13
+      0x7C2C0800,  //  001E  CALL	R11	4
+      0x900E0907,  //  001F  SETMBR	R3	K4	K7
+      0x80041400,  //  0020  RET	1	R10
+      0x7002003E,  //  0021  JMP		#0061
+      0x1C200F0E,  //  0022  EQ	R8	R7	K14
+      0x7822001A,  //  0023  JMPF	R8	#003F
+      0x8C200506,  //  0024  GETMET	R8	R2	K6
+      0x58280005,  //  0025  LDCONST	R10	K5
+      0x7C200400,  //  0026  CALL	R8	2
+      0x8C240506,  //  0027  GETMET	R9	R2	K6
+      0x582C0007,  //  0028  LDCONST	R11	K7
+      0x5830000F,  //  0029  LDCONST	R12	K15
+      0x7C240600,  //  002A  CALL	R9	3
+      0x8C280506,  //  002B  GETMET	R10	R2	K6
+      0x5830000E,  //  002C  LDCONST	R12	K14
+      0x58340005,  //  002D  LDCONST	R13	K5
+      0x7C280600,  //  002E  CALL	R10	3
+      0x9006100A,  //  002F  SETMBR	R1	K8	R10
+      0x8C2C0B09,  //  0030  GETMET	R11	R5	K9
+      0x7C2C0200,  //  0031  CALL	R11	1
+      0x8C30170A,  //  0032  GETMET	R12	R11	K10
+      0x58380005,  //  0033  LDCONST	R14	K5
+      0x883C0B0B,  //  0034  GETMBR	R15	R5	K11
+      0x58400005,  //  0035  LDCONST	R16	K5
+      0x7C300800,  //  0036  CALL	R12	4
+      0x8C30170A,  //  0037  GETMET	R12	R11	K10
+      0x58380007,  //  0038  LDCONST	R14	K7
+      0x883C0B0C,  //  0039  GETMBR	R15	R5	K12
+      0x5840000D,  //  003A  LDCONST	R16	K13
+      0x7C300800,  //  003B  CALL	R12	4
+      0x900E0910,  //  003C  SETMBR	R3	K4	K16
+      0x80041600,  //  003D  RET	1	R11
+      0x70020021,  //  003E  JMP		#0061
+      0x54220003,  //  003F  LDINT	R8	4
+      0x1C200E08,  //  0040  EQ	R8	R7	R8
+      0x7822001E,  //  0041  JMPF	R8	#0061
+      0x88200311,  //  0042  GETMBR	R8	R1	K17
+      0x7822001B,  //  0043  JMPF	R8	#0060
+      0x90061105,  //  0044  SETMBR	R1	K8	K5
+      0x88200311,  //  0045  GETMBR	R8	R1	K17
+      0x8C201112,  //  0046  GETMET	R8	R8	K18
+      0x7C200200,  //  0047  CALL	R8	1
+      0x8C200313,  //  0048  GETMET	R8	R1	K19
+      0x7C200200,  //  0049  CALL	R8	1
+      0x8C200314,  //  004A  GETMET	R8	R1	K20
+      0x7C200200,  //  004B  CALL	R8	1
+      0x8C200B09,  //  004C  GETMET	R8	R5	K9
+      0x7C200200,  //  004D  CALL	R8	1
+      0x8C24110A,  //  004E  GETMET	R9	R8	K10
+      0x582C0005,  //  004F  LDCONST	R11	K5
+      0x88300B0B,  //  0050  GETMBR	R12	R5	K11
+      0x58340005,  //  0051  LDCONST	R13	K5
+      0x7C240800,  //  0052  CALL	R9	4
+      0x8C24110A,  //  0053  GETMET	R9	R8	K10
+      0x582C0007,  //  0054  LDCONST	R11	K7
+      0x88300B0C,  //  0055  GETMBR	R12	R5	K12
+      0x5834000D,  //  0056  LDCONST	R13	K13
+      0x7C240800,  //  0057  CALL	R9	4
+      0x54260004,  //  0058  LDINT	R9	5
+      0x900E0809,  //  0059  SETMBR	R3	K4	R9
+      0x88240115,  //  005A  GETMBR	R9	R0	K21
+      0x8C241316,  //  005B  GETMET	R9	R9	K22
+      0x5C2C0200,  //  005C  MOVE	R11	R1
+      0x7C240400,  //  005D  CALL	R9	2
+      0x80041000,  //  005E  RET	1	R8
+      0x70020000,  //  005F  JMP		#0061
+      0xB0062F18,  //  0060  RAISE	1	K23	K24
+      0x7002025F,  //  0061  JMP		#02C2
+      0x5422003D,  //  0062  LDINT	R8	62
+      0x1C200C08,  //  0063  EQ	R8	R6	R8
+      0x782201C0,  //  0064  JMPF	R8	#0226
+      0x1C200F0E,  //  0065  EQ	R8	R7	K14
+      0x7822001D,  //  0066  JMPF	R8	#0085
+      0x8C200506,  //  0067  GETMET	R8	R2	K6
+      0x58280005,  //  0068  LDCONST	R10	K5
+      0x7C200400,  //  0069  CALL	R8	2
+      0x20241107,  //  006A  NE	R9	R8	K7
+      0x78260006,  //  006B  JMPF	R9	#0073
+      0x2024110E,  //  006C  NE	R9	R8	K14
+      0x78260004,  //  006D  JMPF	R9	#0073
+      0xB8260200,  //  006E  GETNGBL	R9	K1
+      0x8824131A,  //  006F  GETMBR	R9	R9	K26
+      0x900E3209,  //  0070  SETMBR	R3	K25	R9
+      0x4C240000,  //  0071  LDNIL	R9
+      0x80041200,  //  0072  RET	1	R9
+      0x8C240B09,  //  0073  GETMET	R9	R5	K9
+      0x7C240200,  //  0074  CALL	R9	1
+      0x8C28130A,  //  0075  GETMET	R10	R9	K10
+      0x58300005,  //  0076  LDCONST	R12	K5
+      0x88340B1B,  //  0077  GETMBR	R13	R5	K27
+      0x1C381107,  //  0078  EQ	R14	R8	K7
+      0x783A0003,  //  0079  JMPF	R14	#007E
+      0xB83A0200,  //  007A  GETNGBL	R14	K1
+      0x8C381D1C,  //  007B  GETMET	R14	R14	K28
+      0x7C380200,  //  007C  CALL	R14	1
+      0x70020002,  //  007D  JMP		#0081
+      0xB83A0200,  //  007E  GETNGBL	R14	K1
+      0x8C381D1D,  //  007F  GETMET	R14	R14	K29
+      0x7C380200,  //  0080  CALL	R14	1
+      0x7C280800,  //  0081  CALL	R10	4
+      0x900E0910,  //  0082  SETMBR	R3	K4	K16
+      0x80041200,  //  0083  RET	1	R9
+      0x7002019F,  //  0084  JMP		#0225
+      0x1C200F05,  //  0085  EQ	R8	R7	K5
+      0x7822003D,  //  0086  JMPF	R8	#00C5
+      0x8C200506,  //  0087  GETMET	R8	R2	K6
+      0x58280005,  //  0088  LDCONST	R10	K5
+      0x7C200400,  //  0089  CALL	R8	2
+      0x6024000C,  //  008A  GETGBL	R9	G12
+      0x5C281000,  //  008B  MOVE	R10	R8
+      0x7C240200,  //  008C  CALL	R9	1
+      0x542A001F,  //  008D  LDINT	R10	32
+      0x2024120A,  //  008E  NE	R9	R9	R10
+      0x78260001,  //  008F  JMPF	R9	#0092
+      0x4C240000,  //  0090  LDNIL	R9
+      0x80041200,  //  0091  RET	1	R9
+      0x900E0907,  //  0092  SETMBR	R3	K4	K7
+      0x8C240B09,  //  0093  GETMET	R9	R5	K9
+      0x7C240200,  //  0094  CALL	R9	1
+      0x8C28130A,  //  0095  GETMET	R10	R9	K10
+      0x58300007,  //  0096  LDCONST	R12	K7
+      0x88340B1B,  //  0097  GETMBR	R13	R5	K27
+      0xB83A0200,  //  0098  GETNGBL	R14	K1
+      0x8C381D1E,  //  0099  GETMET	R14	R14	K30
+      0x7C380200,  //  009A  CALL	R14	1
+      0x7C280800,  //  009B  CALL	R10	4
+      0x8C28130A,  //  009C  GETMET	R10	R9	K10
+      0x5830000E,  //  009D  LDCONST	R12	K14
+      0x88340B1F,  //  009E  GETMBR	R13	R5	K31
+      0x5C381000,  //  009F  MOVE	R14	R8
+      0x7C280800,  //  00A0  CALL	R10	4
+      0x8C28130A,  //  00A1  GETMET	R10	R9	K10
+      0x58300010,  //  00A2  LDCONST	R12	K16
+      0x88340B20,  //  00A3  GETMBR	R13	R5	K32
+      0xB83A4200,  //  00A4  GETNGBL	R14	K33
+      0x8C381D22,  //  00A5  GETMET	R14	R14	K34
+      0x7C380200,  //  00A6  CALL	R14	1
+      0x94381D23,  //  00A7  GETIDX	R14	R14	K35
+      0x7C280800,  //  00A8  CALL	R10	4
+      0x8C281324,  //  00A9  GETMET	R10	R9	K36
+      0x7C280200,  //  00AA  CALL	R10	1
+      0x8C2C0325,  //  00AB  GETMET	R11	R1	K37
+      0x7C2C0200,  //  00AC  CALL	R11	1
+      0x0030140B,  //  00AD  ADD	R12	R10	R11
+      0x8C340926,  //  00AE  GETMET	R13	R4	K38
+      0x7C340200,  //  00AF  CALL	R13	1
+      0x8C341B27,  //  00B0  GETMET	R13	R13	K39
+      0xB83E0200,  //  00B1  GETNGBL	R15	K1
+      0x8C3C1F28,  //  00B2  GETMET	R15	R15	K40
+      0x7C3C0200,  //  00B3  CALL	R15	1
+      0x5C401800,  //  00B4  MOVE	R16	R12
+      0x7C340600,  //  00B5  CALL	R13	3
+      0x8C380B09,  //  00B6  GETMET	R14	R5	K9
+      0x7C380200,  //  00B7  CALL	R14	1
+      0x8C3C1D0A,  //  00B8  GETMET	R15	R14	K10
+      0x58440005,  //  00B9  LDCONST	R17	K5
+      0x88480B1B,  //  00BA  GETMBR	R18	R5	K27
+      0x5C4C1400,  //  00BB  MOVE	R19	R10
+      0x7C3C0800,  //  00BC  CALL	R15	4
+      0x8C3C1D0A,  //  00BD  GETMET	R15	R14	K10
+      0x58440007,  //  00BE  LDCONST	R17	K7
+      0x88480B1F,  //  00BF  GETMBR	R18	R5	K31
+      0x5C4C1A00,  //  00C0  MOVE	R19	R13
+      0x7C3C0800,  //  00C1  CALL	R15	4
+      0x900E0907,  //  00C2  SETMBR	R3	K4	K7
+      0x80041C00,  //  00C3  RET	1	R14
+      0x7002015F,  //  00C4  JMP		#0225
+      0x54220003,  //  00C5  LDINT	R8	4
+      0x1C200E08,  //  00C6  EQ	R8	R7	R8
+      0x78220039,  //  00C7  JMPF	R8	#0102
+      0x8C200506,  //  00C8  GETMET	R8	R2	K6
+      0x58280005,  //  00C9  LDCONST	R10	K5
+      0x7C200400,  //  00CA  CALL	R8	2
+      0x6024000C,  //  00CB  GETGBL	R9	G12
+      0x5C281000,  //  00CC  MOVE	R10	R8
+      0x7C240200,  //  00CD  CALL	R9	1
+      0x542A001F,  //  00CE  LDINT	R10	32
+      0x2024120A,  //  00CF  NE	R9	R9	R10
+      0x78260001,  //  00D0  JMPF	R9	#00D3
+      0x4C240000,  //  00D1  LDNIL	R9
+      0x80041200,  //  00D2  RET	1	R9
+      0x8C240506,  //  00D3  GETMET	R9	R2	K6
+      0x582C0007,  //  00D4  LDCONST	R11	K7
+      0x50300000,  //  00D5  LDBOOL	R12	0	0
+      0x7C240600,  //  00D6  CALL	R9	3
+      0x8C280329,  //  00D7  GETMET	R10	R1	K41
+      0x7C280200,  //  00D8  CALL	R10	1
+      0x8C2C0B09,  //  00D9  GETMET	R11	R5	K9
+      0x7C2C0200,  //  00DA  CALL	R11	1
+      0x8C30170A,  //  00DB  GETMET	R12	R11	K10
+      0x58380007,  //  00DC  LDCONST	R14	K7
+      0x883C0B1B,  //  00DD  GETMBR	R15	R5	K27
+      0x5C401400,  //  00DE  MOVE	R16	R10
+      0x7C300800,  //  00DF  CALL	R12	4
+      0x8C30170A,  //  00E0  GETMET	R12	R11	K10
+      0x5838000E,  //  00E1  LDCONST	R14	K14
+      0x883C0B1F,  //  00E2  GETMBR	R15	R5	K31
+      0x5C401000,  //  00E3  MOVE	R16	R8
+      0x7C300800,  //  00E4  CALL	R12	4
+      0x8C301724,  //  00E5  GETMET	R12	R11	K36
+      0x7C300200,  //  00E6  CALL	R12	1
+      0x8C340325,  //  00E7  GETMET	R13	R1	K37
+      0x7C340200,  //  00E8  CALL	R13	1
+      0x0034180D,  //  00E9  ADD	R13	R12	R13
+      0x8C380926,  //  00EA  GETMET	R14	R4	K38
+      0x7C380200,  //  00EB  CALL	R14	1
+      0x8C381D27,  //  00EC  GETMET	R14	R14	K39
+      0xB8420200,  //  00ED  GETNGBL	R16	K1
+      0x8C402128,  //  00EE  GETMET	R16	R16	K40
+      0x7C400200,  //  00EF  CALL	R16	1
+      0x5C441A00,  //  00F0  MOVE	R17	R13
+      0x7C380600,  //  00F1  CALL	R14	3
+      0x8C3C0B09,  //  00F2  GETMET	R15	R5	K9
+      0x7C3C0200,  //  00F3  CALL	R15	1
+      0x8C401F0A,  //  00F4  GETMET	R16	R15	K10
+      0x58480005,  //  00F5  LDCONST	R18	K5
+      0x884C0B1B,  //  00F6  GETMBR	R19	R5	K27
+      0x5C501800,  //  00F7  MOVE	R20	R12
+      0x7C400800,  //  00F8  CALL	R16	4
+      0x8C401F0A,  //  00F9  GETMET	R16	R15	K10
+      0x58480007,  //  00FA  LDCONST	R18	K7
+      0x884C0B1F,  //  00FB  GETMBR	R19	R5	K31
+      0x5C501C00,  //  00FC  MOVE	R20	R14
+      0x7C400800,  //  00FD  CALL	R16	4
+      0x54420004,  //  00FE  LDINT	R16	5
+      0x900E0810,  //  00FF  SETMBR	R3	K4	R16
+      0x80041E00,  //  0100  RET	1	R15
+      0x70020122,  //  0101  JMP		#0225
+      0x5422000A,  //  0102  LDINT	R8	11
+      0x1C200E08,  //  0103  EQ	R8	R7	R8
+      0x7822000B,  //  0104  JMPF	R8	#0111
+      0x8C200506,  //  0105  GETMET	R8	R2	K6
+      0x58280005,  //  0106  LDCONST	R10	K5
+      0x7C200400,  //  0107  CALL	R8	2
+      0x8C24032A,  //  0108  GETMET	R9	R1	K42
+      0x5C2C1000,  //  0109  MOVE	R11	R8
+      0x7C240400,  //  010A  CALL	R9	2
+      0xB8260200,  //  010B  GETNGBL	R9	K1
+      0x8824132B,  //  010C  GETMBR	R9	R9	K43
+      0x900E3209,  //  010D  SETMBR	R3	K25	R9
+      0x4C240000,  //  010E  LDNIL	R9
+      0x80041200,  //  010F  RET	1	R9
+      0x70020113,  //  0110  JMP		#0225
+      0x54220005,  //  0111  LDINT	R8	6
+      0x1C200E08,  //  0112  EQ	R8	R7	R8
+      0x782200B9,  //  0113  JMPF	R8	#01CE
+      0xB8224200,  //  0114  GETNGBL	R8	K33
+      0x8C20112C,  //  0115  GETMET	R8	R8	K44
+      0x60280008,  //  0116  GETGBL	R10	G8
+      0x5C2C0400,  //  0117  MOVE	R11	R2
+      0x7C280200,  //  0118  CALL	R10	1
+      0x002A5A0A,  //  0119  ADD	R10	K45	R10
+      0x542E0003,  //  011A  LDINT	R11	4
+      0x7C200600,  //  011B  CALL	R8	3
+      0x8C200506,  //  011C  GETMET	R8	R2	K6
+      0x58280005,  //  011D  LDCONST	R10	K5
+      0x7C200400,  //  011E  CALL	R8	2
+      0x8C240506,  //  011F  GETMET	R9	R2	K6
+      0x582C0007,  //  0120  LDCONST	R11	K7
+      0x7C240400,  //  0121  CALL	R9	2
+      0x6028000C,  //  0122  GETGBL	R10	G12
+      0x5C2C1200,  //  0123  MOVE	R11	R9
+      0x7C280200,  //  0124  CALL	R10	1
+      0x1C281505,  //  0125  EQ	R10	R10	K5
+      0x782A0000,  //  0126  JMPF	R10	#0128
+      0x4C240000,  //  0127  LDNIL	R9
+      0x8C280506,  //  0128  GETMET	R10	R2	K6
+      0x5830000E,  //  0129  LDCONST	R12	K14
+      0x7C280400,  //  012A  CALL	R10	2
+      0x8C2C0506,  //  012B  GETMET	R11	R2	K6
+      0x58340010,  //  012C  LDCONST	R13	K16
+      0x7C2C0400,  //  012D  CALL	R11	2
+      0x8C300506,  //  012E  GETMET	R12	R2	K6
+      0x543A0003,  //  012F  LDINT	R14	4
+      0x7C300400,  //  0130  CALL	R12	2
+      0x8C34032E,  //  0131  GETMET	R13	R1	K46
+      0x7C340200,  //  0132  CALL	R13	1
+      0x4C380000,  //  0133  LDNIL	R14
+      0x1C341A0E,  //  0134  EQ	R13	R13	R14
+      0x78360006,  //  0135  JMPF	R13	#013D
+      0xB8364200,  //  0136  GETNGBL	R13	K33
+      0x8C341B2C,  //  0137  GETMET	R13	R13	K44
+      0x583C002F,  //  0138  LDCONST	R15	K47
+      0x5840000E,  //  0139  LDCONST	R16	K14
+      0x7C340600,  //  013A  CALL	R13	3
+      0x4C340000,  //  013B  LDNIL	R13
+      0x80041A00,  //  013C  RET	1	R13
+      0x88340115,  //  013D  GETMBR	R13	R0	K21
+      0x88341B30,  //  013E  GETMBR	R13	R13	K48
+      0x8C341B31,  //  013F  GETMET	R13	R13	K49
+      0x7C340200,  //  0140  CALL	R13	1
+      0x8C381B32,  //  0141  GETMET	R14	R13	K50
+      0x8C40032E,  //  0142  GETMET	R16	R1	K46
+      0x7C400200,  //  0143  CALL	R16	1
+      0x7C380400,  //  0144  CALL	R14	2
+      0x8C381B33,  //  0145  GETMET	R14	R13	K51
+      0x5C401000,  //  0146  MOVE	R16	R8
       0x5C441200,  //  0147  MOVE	R17	R9
-      0x5C481400,  //  0148  MOVE	R18	R10
-      0x7C3C0600,  //  0149  CALL	R15	3
-      0x8C3C1D35,  //  014A  GETMET	R15	R14	K53
-      0x5C441600,  //  014B  MOVE	R17	R11
-      0x7C3C0400,  //  014C  CALL	R15	2
-      0x8C3C1D36,  //  014D  GETMET	R15	R14	K54
+      0x7C380600,  //  0148  CALL	R14	3
+      0x8C381B34,  //  0149  GETMET	R14	R13	K52
+      0x5C401400,  //  014A  MOVE	R16	R10
+      0x7C380400,  //  014B  CALL	R14	2
+      0x8C381B35,  //  014C  GETMET	R14	R13	K53
+      0x5C401600,  //  014D  MOVE	R16	R11
       0x5C441800,  //  014E  MOVE	R17	R12
-      0x5C481A00,  //  014F  MOVE	R18	R13
-      0x7C3C0600,  //  0150  CALL	R15	3
-      0x8C3C1D37,  //  0151  GETMET	R15	R14	K55
-      0x8C440338,  //  0152  GETMET	R17	R1	K56
-      0x7C440200,  //  0153  CALL	R17	1
-      0x7C3C0400,  //  0154  CALL	R15	2
-      0xB83E0400,  //  0155  GETNGBL	R15	K2
-      0x883C1F03,  //  0156  GETMBR	R15	R15	K3
-      0x8C3C1F39,  //  0157  GETMET	R15	R15	K57
-      0x5C441200,  //  0158  MOVE	R17	R9
-      0x7C3C0400,  //  0159  CALL	R15	2
-      0x8C401F3A,  //  015A  GETMET	R16	R15	K58
-      0x544A0005,  //  015B  LDINT	R18	6
-      0x7C400400,  //  015C  CALL	R16	2
-      0x8C442107,  //  015D  GETMET	R17	R16	K7
-      0x544E0014,  //  015E  LDINT	R19	21
-      0x7C440400,  //  015F  CALL	R17	2
-      0x8C482107,  //  0160  GETMET	R18	R16	K7
-      0x54520010,  //  0161  LDINT	R20	17
-      0x7C480400,  //  0162  CALL	R18	2
-      0x5C4C2200,  //  0163  MOVE	R19	R17
-      0x784E0001,  //  0164  JMPF	R19	#0167
-      0x5C4C2400,  //  0165  MOVE	R19	R18
-      0x744E0006,  //  0166  JMPT	R19	#016E
-      0xB84E4400,  //  0167  GETNGBL	R19	K34
-      0x8C4C272D,  //  0168  GETMET	R19	R19	K45
-      0x5854003B,  //  0169  LDCONST	R21	K59
-      0x5858000F,  //  016A  LDCONST	R22	K15
-      0x7C4C0600,  //  016B  CALL	R19	3
-      0x504C0000,  //  016C  LDBOOL	R19	0	0
-      0x80042600,  //  016D  RET	1	R19
-      0x604C0004,  //  016E  GETGBL	R19	G4
-      0x5C502200,  //  016F  MOVE	R20	R17
-      0x7C4C0200,  //  0170  CALL	R19	1
-      0x1C4C273C,  //  0171  EQ	R19	R19	K60
-      0x784E0007,  //  0172  JMPF	R19	#017B
-      0xB84E7A00,  //  0173  GETNGBL	R19	K61
-      0x8C4C273E,  //  0174  GETMET	R19	R19	K62
-      0x5C542200,  //  0175  MOVE	R21	R17
-      0x7C4C0400,  //  0176  CALL	R19	2
-      0x8C4C273F,  //  0177  GETMET	R19	R19	K63
-      0x7C4C0200,  //  0178  CALL	R19	1
-      0x5C442600,  //  0179  MOVE	R17	R19
-      0x70020002,  //  017A  JMP		#017E
-      0x8C4C233F,  //  017B  GETMET	R19	R17	K63
-      0x7C4C0200,  //  017C  CALL	R19	1
-      0x5C442600,  //  017D  MOVE	R17	R19
-      0x604C0004,  //  017E  GETGBL	R19	G4
-      0x5C502400,  //  017F  MOVE	R20	R18
-      0x7C4C0200,  //  0180  CALL	R19	1
-      0x1C4C273C,  //  0181  EQ	R19	R19	K60
-      0x784E0007,  //  0182  JMPF	R19	#018B
-      0xB84E7A00,  //  0183  GETNGBL	R19	K61
-      0x8C4C273E,  //  0184  GETMET	R19	R19	K62
-      0x5C542400,  //  0185  MOVE	R21	R18
-      0x7C4C0400,  //  0186  CALL	R19	2
-      0x8C4C273F,  //  0187  GETMET	R19	R19	K63
-      0x7C4C0200,  //  0188  CALL	R19	1
-      0x5C482600,  //  0189  MOVE	R18	R19
-      0x70020002,  //  018A  JMP		#018E
-      0x8C4C253F,  //  018B  GETMET	R19	R18	K63
-      0x7C4C0200,  //  018C  CALL	R19	1
-      0x5C482600,  //  018D  MOVE	R18	R19
-      0x8C4C0340,  //  018E  GETMET	R19	R1	K64
-      0x7C4C0200,  //  018F  CALL	R19	1
-      0x40521141,  //  0190  CONNECT	R20	K8	K65
-      0x944C2614,  //  0191  GETIDX	R19	R19	R20
-      0x60540015,  //  0192  GETGBL	R21	G21
-      0x7C540000,  //  0193  CALL	R21	0
-      0x8C542B42,  //  0194  GETMET	R21	R21	K66
-      0x585C0043,  //  0195  LDCONST	R23	K67
-      0x7C540400,  //  0196  CALL	R21	2
-      0x5C502A00,  //  0197  MOVE	R20	R21
-      0x8C540944,  //  0198  GETMET	R21	R4	K68
-      0x7C540200,  //  0199  CALL	R21	1
-      0x8C582345,  //  019A  GETMET	R22	R17	K69
-      0x7C580200,  //  019B  CALL	R22	1
-      0x8C582D46,  //  019C  GETMET	R22	R22	K70
-      0x7C580200,  //  019D  CALL	R22	1
-      0x8C5C2B47,  //  019E  GETMET	R23	R21	K71
-      0x5C642600,  //  019F  MOVE	R25	R19
-      0x5C682C00,  //  01A0  MOVE	R26	R22
-      0x5C6C2800,  //  01A1  MOVE	R27	R20
-      0x54720007,  //  01A2  LDINT	R28	8
-      0x7C5C0A00,  //  01A3  CALL	R23	5
-      0x88600312,  //  01A4  GETMBR	R24	R1	K18
-      0x78620001,  //  01A5  JMPF	R24	#01A8
-      0x88600312,  //  01A6  GETMBR	R24	R1	K18
-      0x70020001,  //  01A7  JMP		#01AA
-      0x88600116,  //  01A8  GETMBR	R24	R0	K22
-      0x88603148,  //  01A9  GETMBR	R24	R24	K72
-      0x8C641D49,  //  01AA  GETMET	R25	R14	K73
+      0x7C380600,  //  014F  CALL	R14	3
+      0x8C381B36,  //  0150  GETMET	R14	R13	K54
+      0x8C400337,  //  0151  GETMET	R16	R1	K55
+      0x7C400200,  //  0152  CALL	R16	1
+      0x7C380400,  //  0153  CALL	R14	2
+      0xB83A0200,  //  0154  GETNGBL	R14	K1
+      0x88381D02,  //  0155  GETMBR	R14	R14	K2
+      0x8C381D38,  //  0156  GETMET	R14	R14	K56
+      0x5C401000,  //  0157  MOVE	R16	R8
+      0x7C380400,  //  0158  CALL	R14	2
+      0x8C3C1D39,  //  0159  GETMET	R15	R14	K57
+      0x54460005,  //  015A  LDINT	R17	6
+      0x7C3C0400,  //  015B  CALL	R15	2
+      0x8C401F06,  //  015C  GETMET	R16	R15	K6
+      0x544A0014,  //  015D  LDINT	R18	21
+      0x7C400400,  //  015E  CALL	R16	2
+      0x8C441F06,  //  015F  GETMET	R17	R15	K6
+      0x544E0010,  //  0160  LDINT	R19	17
+      0x7C440400,  //  0161  CALL	R17	2
+      0x5C482000,  //  0162  MOVE	R18	R16
+      0x784A0001,  //  0163  JMPF	R18	#0166
+      0x5C482200,  //  0164  MOVE	R18	R17
+      0x744A0006,  //  0165  JMPT	R18	#016D
+      0xB84A4200,  //  0166  GETNGBL	R18	K33
+      0x8C48252C,  //  0167  GETMET	R18	R18	K44
+      0x5850003A,  //  0168  LDCONST	R20	K58
+      0x5854000E,  //  0169  LDCONST	R21	K14
+      0x7C480600,  //  016A  CALL	R18	3
+      0x50480000,  //  016B  LDBOOL	R18	0	0
+      0x80042400,  //  016C  RET	1	R18
+      0x60480004,  //  016D  GETGBL	R18	G4
+      0x5C4C2000,  //  016E  MOVE	R19	R16
+      0x7C480200,  //  016F  CALL	R18	1
+      0x1C48253B,  //  0170  EQ	R18	R18	K59
+      0x784A0007,  //  0171  JMPF	R18	#017A
+      0xB84A7800,  //  0172  GETNGBL	R18	K60
+      0x8C48253D,  //  0173  GETMET	R18	R18	K61
+      0x5C502000,  //  0174  MOVE	R20	R16
+      0x7C480400,  //  0175  CALL	R18	2
+      0x8C48253E,  //  0176  GETMET	R18	R18	K62
+      0x7C480200,  //  0177  CALL	R18	1
+      0x5C402400,  //  0178  MOVE	R16	R18
+      0x70020002,  //  0179  JMP		#017D
+      0x8C48213E,  //  017A  GETMET	R18	R16	K62
+      0x7C480200,  //  017B  CALL	R18	1
+      0x5C402400,  //  017C  MOVE	R16	R18
+      0x60480004,  //  017D  GETGBL	R18	G4
+      0x5C4C2200,  //  017E  MOVE	R19	R17
+      0x7C480200,  //  017F  CALL	R18	1
+      0x1C48253B,  //  0180  EQ	R18	R18	K59
+      0x784A0007,  //  0181  JMPF	R18	#018A
+      0xB84A7800,  //  0182  GETNGBL	R18	K60
+      0x8C48253D,  //  0183  GETMET	R18	R18	K61
+      0x5C502200,  //  0184  MOVE	R20	R17
+      0x7C480400,  //  0185  CALL	R18	2
+      0x8C48253E,  //  0186  GETMET	R18	R18	K62
+      0x7C480200,  //  0187  CALL	R18	1
+      0x5C442400,  //  0188  MOVE	R17	R18
+      0x70020002,  //  0189  JMP		#018D
+      0x8C48233E,  //  018A  GETMET	R18	R17	K62
+      0x7C480200,  //  018B  CALL	R18	1
+      0x5C442400,  //  018C  MOVE	R17	R18
+      0x8C48033F,  //  018D  GETMET	R18	R1	K63
+      0x7C480200,  //  018E  CALL	R18	1
+      0x404E0F40,  //  018F  CONNECT	R19	K7	K64
+      0x94482413,  //  0190  GETIDX	R18	R18	R19
+      0x60500015,  //  0191  GETGBL	R20	G21
+      0x7C500000,  //  0192  CALL	R20	0
+      0x8C502941,  //  0193  GETMET	R20	R20	K65
+      0x58580042,  //  0194  LDCONST	R22	K66
+      0x7C500400,  //  0195  CALL	R20	2
+      0x5C4C2800,  //  0196  MOVE	R19	R20
+      0x8C500943,  //  0197  GETMET	R20	R4	K67
+      0x7C500200,  //  0198  CALL	R20	1
+      0x8C542144,  //  0199  GETMET	R21	R16	K68
+      0x7C540200,  //  019A  CALL	R21	1
+      0x8C542B45,  //  019B  GETMET	R21	R21	K69
+      0x7C540200,  //  019C  CALL	R21	1
+      0x8C582946,  //  019D  GETMET	R22	R20	K70
+      0x5C602400,  //  019E  MOVE	R24	R18
+      0x5C642A00,  //  019F  MOVE	R25	R21
+      0x5C682600,  //  01A0  MOVE	R26	R19
+      0x546E0007,  //  01A1  LDINT	R27	8
+      0x7C580A00,  //  01A2  CALL	R22	5
+      0x885C0311,  //  01A3  GETMBR	R23	R1	K17
+      0x785E0001,  //  01A4  JMPF	R23	#01A7
+      0x885C0311,  //  01A5  GETMBR	R23	R1	K17
+      0x70020001,  //  01A6  JMP		#01A9
+      0x885C0115,  //  01A7  GETMBR	R23	R0	K21
+      0x885C2F47,  //  01A8  GETMBR	R23	R23	K71
+      0x8C601B48,  //  01A9  GETMET	R24	R13	K72
+      0x5C682000,  //  01AA  MOVE	R26	R16
       0x5C6C2200,  //  01AB  MOVE	R27	R17
-      0x5C702400,  //  01AC  MOVE	R28	R18
+      0x5C702C00,  //  01AC  MOVE	R28	R22
       0x5C742E00,  //  01AD  MOVE	R29	R23
-      0x5C783000,  //  01AE  MOVE	R30	R24
-      0x7C640A00,  //  01AF  CALL	R25	5
-      0x8C641D4A,  //  01B0  GETMET	R25	R14	K74
-      0x7C640200,  //  01B1  CALL	R25	1
-      0x88640116,  //  01B2  GETMBR	R25	R0	K22
-      0x8C64334B,  //  01B3  GETMET	R25	R25	K75
-      0x5C6C1C00,  //  01B4  MOVE	R27	R14
-      0x7C640400,  //  01B5  CALL	R25	2
-      0x8C64034C,  //  01B6  GETMET	R25	R1	K76
-      0x7C640200,  //  01B7  CALL	R25	1
-      0x78660002,  //  01B8  JMPF	R25	#01BC
-      0x8C64034D,  //  01B9  GETMET	R25	R1	K77
-      0x546E003B,  //  01BA  LDINT	R27	60
-      0x7C640400,  //  01BB  CALL	R25	2
-      0x8C641D4E,  //  01BC  GETMET	R25	R14	K78
-      0x7C640200,  //  01BD  CALL	R25	1
-      0x8C640D0A,  //  01BE  GETMET	R25	R6	K10
-      0x7C640200,  //  01BF  CALL	R25	1
-      0x8C68330B,  //  01C0  GETMET	R26	R25	K11
-      0x58700006,  //  01C1  LDCONST	R28	K6
-      0x88740D0C,  //  01C2  GETMBR	R29	R6	K12
-      0xB87A0400,  //  01C3  GETNGBL	R30	K2
-      0x88783D2C,  //  01C4  GETMBR	R30	R30	K44
-      0x7C680800,  //  01C5  CALL	R26	4
-      0x8C68330B,  //  01C6  GETMET	R26	R25	K11
-      0x58700008,  //  01C7  LDCONST	R28	K8
-      0x88740D0C,  //  01C8  GETMBR	R29	R6	K12
-      0x58780008,  //  01C9  LDCONST	R30	K8
-      0x7C680800,  //  01CA  CALL	R26	4
-      0x546A0007,  //  01CB  LDINT	R26	8
-      0x900E0A1A,  //  01CC  SETMBR	R3	K5	R26
-      0x80043200,  //  01CD  RET	1	R25
-      0x70020056,  //  01CE  JMP		#0226
-      0x54260008,  //  01CF  LDINT	R9	9
-      0x1C241009,  //  01D0  EQ	R9	R8	R9
-      0x7826001E,  //  01D1  JMPF	R9	#01F1
-      0x8C240507,  //  01D2  GETMET	R9	R2	K7
-      0x582C0006,  //  01D3  LDCONST	R11	K6
-      0x7C240400,  //  01D4  CALL	R9	2
-      0x8C28034F,  //  01D5  GETMET	R10	R1	K79
-      0x5C301200,  //  01D6  MOVE	R12	R9
-      0x7C280400,  //  01D7  CALL	R10	2
-      0xB82A4400,  //  01D8  GETNGBL	R10	K34
-      0x8C28152D,  //  01D9  GETMET	R10	R10	K45
-      0x8C300B50,  //  01DA  GETMET	R12	R5	K80
-      0x58380051,  //  01DB  LDCONST	R14	K81
-      0x883C0312,  //  01DC  GETMBR	R15	R1	K18
-      0x8C3C1F52,  //  01DD  GETMET	R15	R15	K82
-      0x7C3C0200,  //  01DE  CALL	R15	1
-      0x8C3C1F45,  //  01DF  GETMET	R15	R15	K69
-      0x7C3C0200,  //  01E0  CALL	R15	1
-      0x8C3C1F46,  //  01E1  GETMET	R15	R15	K70
-      0x7C3C0200,  //  01E2  CALL	R15	1
-      0x8C3C1F53,  //  01E3  GETMET	R15	R15	K83
-      0x7C3C0200,  //  01E4  CALL	R15	1
-      0x60400008,  //  01E5  GETGBL	R16	G8
-      0x5C441200,  //  01E6  MOVE	R17	R9
-      0x7C400200,  //  01E7  CALL	R16	1
-      0x7C300800,  //  01E8  CALL	R12	4
-      0x58340011,  //  01E9  LDCONST	R13	K17
-      0x7C280600,  //  01EA  CALL	R10	3
-      0xB82A0400,  //  01EB  GETNGBL	R10	K2
-      0x8828152C,  //  01EC  GETMBR	R10	R10	K44
-      0x900E340A,  //  01ED  SETMBR	R3	K26	R10
-      0x4C280000,  //  01EE  LDNIL	R10
-      0x80041400,  //  01EF  RET	1	R10
-      0x70020034,  //  01F0  JMP		#0226
-      0x54260009,  //  01F1  LDINT	R9	10
-      0x1C241009,  //  01F2  EQ	R9	R8	R9
-      0x78260031,  //  01F3  JMPF	R9	#0226
-      0x8C240507,  //  01F4  GETMET	R9	R2	K7
-      0x582C0006,  //  01F5  LDCONST	R11	K6
-      0x7C240400,  //  01F6  CALL	R9	2
-      0x60280008,  //  01F7  GETGBL	R10	G8
-      0x5C2C1200,  //  01F8  MOVE	R11	R9
-      0x7C280200,  //  01F9  CALL	R10	1
-      0x002AA80A,  //  01FA  ADD	R10	K84	R10
-      0x900E5A0A,  //  01FB  SETMBR	R3	K45	R10
-      0x60280010,  //  01FC  GETGBL	R10	G16
-      0x882C0116,  //  01FD  GETMBR	R11	R0	K22
-      0x882C1731,  //  01FE  GETMBR	R11	R11	K49
-      0x8C2C1755,  //  01FF  GETMET	R11	R11	K85
-      0x7C2C0200,  //  0200  CALL	R11	1
-      0x7C280200,  //  0201  CALL	R10	1
-      0xA8020010,  //  0202  EXBLK	0	#0214
-      0x5C2C1400,  //  0203  MOVE	R11	R10
-      0x7C2C0000,  //  0204  CALL	R11	0
-      0x8C301756,  //  0205  GETMET	R12	R11	K86
-      0x7C300200,  //  0206  CALL	R12	1
-      0x1C301809,  //  0207  EQ	R12	R12	R9
-      0x78320008,  //  0208  JMPF	R12	#0212
-      0xB8324400,  //  0209  GETNGBL	R12	K34
-      0x8C301957,  //  020A  GETMET	R12	R12	K87
-      0x543A07CF,  //  020B  LDINT	R14	2000
-      0x843C0000,  //  020C  CLOSURE	R15	P0
-      0x7C300600,  //  020D  CALL	R12	3
-      0x50300200,  //  020E  LDBOOL	R12	1	0
-      0xA0000000,  //  020F  CLOSE	R0
-      0xA8040001,  //  0210  EXBLK	1	1
-      0x80041800,  //  0211  RET	1	R12
-      0xA0280000,  //  0212  CLOSE	R10
-      0x7001FFEE,  //  0213  JMP		#0203
-      0x58280058,  //  0214  LDCONST	R10	K88
-      0xAC280200,  //  0215  CATCH	R10	1	0
-      0xB0080000,  //  0216  RAISE	2	R0	R0
-      0xB82A4400,  //  0217  GETNGBL	R10	K34
-      0x8C28152D,  //  0218  GETMET	R10	R10	K45
-      0x60300008,  //  0219  GETGBL	R12	G8
-      0x5C341200,  //  021A  MOVE	R13	R9
-      0x7C300200,  //  021B  CALL	R12	1
-      0x0032B20C,  //  021C  ADD	R12	K89	R12
-      0x0030195A,  //  021D  ADD	R12	R12	K90
-      0x5834000F,  //  021E  LDCONST	R13	K15
-      0x7C280600,  //  021F  CALL	R10	3
-      0xB82A0400,  //  0220  GETNGBL	R10	K2
-      0x8828155B,  //  0221  GETMBR	R10	R10	K91
-      0x900E340A,  //  0222  SETMBR	R3	K26	R10
-      0x4C280000,  //  0223  LDNIL	R10
-      0xA0000000,  //  0224  CLOSE	R0
-      0x80041400,  //  0225  RET	1	R10
-      0x7002009B,  //  0226  JMP		#02C3
-      0x5426003B,  //  0227  LDINT	R9	60
-      0x1C240E09,  //  0228  EQ	R9	R7	R9
-      0x78260085,  //  0229  JMPF	R9	#02B0
-      0x1C241106,  //  022A  EQ	R9	R8	K6
-      0x78260065,  //  022B  JMPF	R9	#0292
-      0x8C240507,  //  022C  GETMET	R9	R2	K7
-      0x582C0006,  //  022D  LDCONST	R11	K6
-      0x7C240400,  //  022E  CALL	R9	2
-      0x8C280507,  //  022F  GETMET	R10	R2	K7
-      0x58300008,  //  0230  LDCONST	R12	K8
-      0x7C280400,  //  0231  CALL	R10	2
-      0x8C2C0507,  //  0232  GETMET	R11	R2	K7
-      0x5834000F,  //  0233  LDCONST	R13	K15
-      0x7C2C0400,  //  0234  CALL	R11	2
-      0x8C300507,  //  0235  GETMET	R12	R2	K7
-      0x58380011,  //  0236  LDCONST	R14	K17
-      0x7C300400,  //  0237  CALL	R12	2
-      0x8C340507,  //  0238  GETMET	R13	R2	K7
-      0x543E0003,  //  0239  LDINT	R15	4
-      0x7C340400,  //  023A  CALL	R13	2
-      0xB83A4400,  //  023B  GETNGBL	R14	K34
-      0x8C381D2D,  //  023C  GETMET	R14	R14	K45
-      0x8C400B50,  //  023D  GETMET	R16	R5	K80
-      0x5848005C,  //  023E  LDCONST	R18	K92
-      0x5C4C1200,  //  023F  MOVE	R19	R9
-      0x8C501553,  //  0240  GETMET	R20	R10	K83
-      0x7C500200,  //  0241  CALL	R20	1
-      0x5C541600,  //  0242  MOVE	R21	R11
-      0x5C581800,  //  0243  MOVE	R22	R12
-      0x8C5C1B53,  //  0244  GETMET	R23	R13	K83
-      0x7C5C0200,  //  0245  CALL	R23	1
-      0x7C400E00,  //  0246  CALL	R16	7
-      0x54460003,  //  0247  LDINT	R17	4
-      0x7C380600,  //  0248  CALL	R14	3
-      0x4C380000,  //  0249  LDNIL	R14
-      0x1C38120E,  //  024A  EQ	R14	R9	R14
-      0x743A000B,  //  024B  JMPT	R14	#0258
-      0x4C380000,  //  024C  LDNIL	R14
-      0x1C38140E,  //  024D  EQ	R14	R10	R14
-      0x743A0008,  //  024E  JMPT	R14	#0258
-      0x4C380000,  //  024F  LDNIL	R14
-      0x1C38160E,  //  0250  EQ	R14	R11	R14
-      0x743A0005,  //  0251  JMPT	R14	#0258
-      0x4C380000,  //  0252  LDNIL	R14
-      0x1C38180E,  //  0253  EQ	R14	R12	R14
-      0x743A0002,  //  0254  JMPT	R14	#0258
-      0x4C380000,  //  0255  LDNIL	R14
-      0x1C381A0E,  //  0256  EQ	R14	R13	R14
-      0x783A0005,  //  0257  JMPF	R14	#025E
-      0xB83A0400,  //  0258  GETNGBL	R14	K2
-      0x88381D5D,  //  0259  GETMBR	R14	R14	K93
-      0x900E340E,  //  025A  SETMBR	R3	K26	R14
-      0x4C380000,  //  025B  LDNIL	R14
-      0xA0000000,  //  025C  CLOSE	R0
-      0x80041C00,  //  025D  RET	1	R14
-      0x6038000C,  //  025E  GETGBL	R14	G12
-      0x5C3C1400,  //  025F  MOVE	R15	R10
-      0x7C380200,  //  0260  CALL	R14	1
-      0x543E001F,  //  0261  LDINT	R15	32
-      0x54420040,  //  0262  LDINT	R16	65
-      0x003C1E10,  //  0263  ADD	R15	R15	R16
-      0x20381C0F,  //  0264  NE	R14	R14	R15
-      0x743A000B,  //  0265  JMPT	R14	#0272
-      0x6038000C,  //  0266  GETGBL	R14	G12
-      0x5C3C1A00,  //  0267  MOVE	R15	R13
-      0x7C380200,  //  0268  CALL	R14	1
-      0x543E000F,  //  0269  LDINT	R15	16
-      0x14381C0F,  //  026A  LT	R14	R14	R15
-      0x743A0005,  //  026B  JMPT	R14	#0272
-      0x6038000C,  //  026C  GETGBL	R14	G12
-      0x5C3C1A00,  //  026D  MOVE	R15	R13
-      0x7C380200,  //  026E  CALL	R14	1
-      0x543E001F,  //  026F  LDINT	R15	32
-      0x24381C0F,  //  0270  GT	R14	R14	R15
-      0x783A000A,  //  0271  JMPF	R14	#027D
-      0xB83A4400,  //  0272  GETNGBL	R14	K34
-      0x8C381D2D,  //  0273  GETMET	R14	R14	K45
-      0x5840005E,  //  0274  LDCONST	R16	K94
-      0x5844000F,  //  0275  LDCONST	R17	K15
-      0x7C380600,  //  0276  CALL	R14	3
-      0xB83A0400,  //  0277  GETNGBL	R14	K2
-      0x88381D5F,  //  0278  GETMBR	R14	R14	K95
-      0x900E340E,  //  0279  SETMBR	R3	K26	R14
-      0x4C380000,  //  027A  LDNIL	R14
-      0xA0000000,  //  027B  CLOSE	R0
-      0x80041C00,  //  027C  RET	1	R14
-      0x543A001E,  //  027D  LDINT	R14	31
-      0x403A0C0E,  //  027E  CONNECT	R14	K6	R14
-      0x9438140E,  //  027F  GETIDX	R14	R10	R14
-      0x543E001F,  //  0280  LDINT	R15	32
-      0x403C1F41,  //  0281  CONNECT	R15	R15	K65
-      0x943C140F,  //  0282  GETIDX	R15	R10	R15
-      0x88400116,  //  0283  GETMBR	R16	R0	K22
-      0x8C402160,  //  0284  GETMET	R16	R16	K96
-      0x5C481200,  //  0285  MOVE	R18	R9
-      0x5C4C1800,  //  0286  MOVE	R19	R12
-      0x5C501600,  //  0287  MOVE	R20	R11
+      0x7C600A00,  //  01AE  CALL	R24	5
+      0x8C601B49,  //  01AF  GETMET	R24	R13	K73
+      0x7C600200,  //  01B0  CALL	R24	1
+      0x88600115,  //  01B1  GETMBR	R24	R0	K21
+      0x8C60314A,  //  01B2  GETMET	R24	R24	K74
+      0x5C681A00,  //  01B3  MOVE	R26	R13
+      0x7C600400,  //  01B4  CALL	R24	2
+      0x8C60034B,  //  01B5  GETMET	R24	R1	K75
+      0x7C600200,  //  01B6  CALL	R24	1
+      0x78620002,  //  01B7  JMPF	R24	#01BB
+      0x8C60034C,  //  01B8  GETMET	R24	R1	K76
+      0x546A003B,  //  01B9  LDINT	R26	60
+      0x7C600400,  //  01BA  CALL	R24	2
+      0x8C601B4D,  //  01BB  GETMET	R24	R13	K77
+      0x7C600200,  //  01BC  CALL	R24	1
+      0x8C600B09,  //  01BD  GETMET	R24	R5	K9
+      0x7C600200,  //  01BE  CALL	R24	1
+      0x8C64310A,  //  01BF  GETMET	R25	R24	K10
+      0x586C0005,  //  01C0  LDCONST	R27	K5
+      0x88700B0B,  //  01C1  GETMBR	R28	R5	K11
+      0xB8760200,  //  01C2  GETNGBL	R29	K1
+      0x88743B2B,  //  01C3  GETMBR	R29	R29	K43
+      0x7C640800,  //  01C4  CALL	R25	4
+      0x8C64310A,  //  01C5  GETMET	R25	R24	K10
+      0x586C0007,  //  01C6  LDCONST	R27	K7
+      0x88700B0B,  //  01C7  GETMBR	R28	R5	K11
+      0x58740007,  //  01C8  LDCONST	R29	K7
+      0x7C640800,  //  01C9  CALL	R25	4
+      0x54660007,  //  01CA  LDINT	R25	8
+      0x900E0819,  //  01CB  SETMBR	R3	K4	R25
+      0x80043000,  //  01CC  RET	1	R24
+      0x70020056,  //  01CD  JMP		#0225
+      0x54220008,  //  01CE  LDINT	R8	9
+      0x1C200E08,  //  01CF  EQ	R8	R7	R8
+      0x7822001E,  //  01D0  JMPF	R8	#01F0
+      0x8C200506,  //  01D1  GETMET	R8	R2	K6
+      0x58280005,  //  01D2  LDCONST	R10	K5
+      0x7C200400,  //  01D3  CALL	R8	2
+      0x8C24034E,  //  01D4  GETMET	R9	R1	K78
+      0x5C2C1000,  //  01D5  MOVE	R11	R8
+      0x7C240400,  //  01D6  CALL	R9	2
+      0xB8264200,  //  01D7  GETNGBL	R9	K33
+      0x8C24132C,  //  01D8  GETMET	R9	R9	K44
+      0x602C0018,  //  01D9  GETGBL	R11	G24
+      0x5830004F,  //  01DA  LDCONST	R12	K79
+      0x88340311,  //  01DB  GETMBR	R13	R1	K17
+      0x8C341B50,  //  01DC  GETMET	R13	R13	K80
+      0x7C340200,  //  01DD  CALL	R13	1
+      0x8C341B44,  //  01DE  GETMET	R13	R13	K68
+      0x7C340200,  //  01DF  CALL	R13	1
+      0x8C341B45,  //  01E0  GETMET	R13	R13	K69
+      0x7C340200,  //  01E1  CALL	R13	1
+      0x8C341B51,  //  01E2  GETMET	R13	R13	K81
+      0x7C340200,  //  01E3  CALL	R13	1
+      0x60380008,  //  01E4  GETGBL	R14	G8
+      0x5C3C1000,  //  01E5  MOVE	R15	R8
+      0x7C380200,  //  01E6  CALL	R14	1
+      0x7C2C0600,  //  01E7  CALL	R11	3
+      0x58300010,  //  01E8  LDCONST	R12	K16
+      0x7C240600,  //  01E9  CALL	R9	3
+      0xB8260200,  //  01EA  GETNGBL	R9	K1
+      0x8824132B,  //  01EB  GETMBR	R9	R9	K43
+      0x900E3209,  //  01EC  SETMBR	R3	K25	R9
+      0x4C240000,  //  01ED  LDNIL	R9
+      0x80041200,  //  01EE  RET	1	R9
+      0x70020034,  //  01EF  JMP		#0225
+      0x54220009,  //  01F0  LDINT	R8	10
+      0x1C200E08,  //  01F1  EQ	R8	R7	R8
+      0x78220031,  //  01F2  JMPF	R8	#0225
+      0x8C200506,  //  01F3  GETMET	R8	R2	K6
+      0x58280005,  //  01F4  LDCONST	R10	K5
+      0x7C200400,  //  01F5  CALL	R8	2
+      0x60240008,  //  01F6  GETGBL	R9	G8
+      0x5C281000,  //  01F7  MOVE	R10	R8
+      0x7C240200,  //  01F8  CALL	R9	1
+      0x0026A409,  //  01F9  ADD	R9	K82	R9
+      0x900E5809,  //  01FA  SETMBR	R3	K44	R9
+      0x60240010,  //  01FB  GETGBL	R9	G16
+      0x88280115,  //  01FC  GETMBR	R10	R0	K21
+      0x88281530,  //  01FD  GETMBR	R10	R10	K48
+      0x8C281553,  //  01FE  GETMET	R10	R10	K83
+      0x7C280200,  //  01FF  CALL	R10	1
+      0x7C240200,  //  0200  CALL	R9	1
+      0xA8020010,  //  0201  EXBLK	0	#0213
+      0x5C281200,  //  0202  MOVE	R10	R9
+      0x7C280000,  //  0203  CALL	R10	0
+      0x8C2C1554,  //  0204  GETMET	R11	R10	K84
+      0x7C2C0200,  //  0205  CALL	R11	1
+      0x1C2C1608,  //  0206  EQ	R11	R11	R8
+      0x782E0008,  //  0207  JMPF	R11	#0211
+      0xB82E4200,  //  0208  GETNGBL	R11	K33
+      0x8C2C1755,  //  0209  GETMET	R11	R11	K85
+      0x543607CF,  //  020A  LDINT	R13	2000
+      0x84380000,  //  020B  CLOSURE	R14	P0
+      0x7C2C0600,  //  020C  CALL	R11	3
+      0x502C0200,  //  020D  LDBOOL	R11	1	0
+      0xA0000000,  //  020E  CLOSE	R0
+      0xA8040001,  //  020F  EXBLK	1	1
+      0x80041600,  //  0210  RET	1	R11
+      0xA0240000,  //  0211  CLOSE	R9
+      0x7001FFEE,  //  0212  JMP		#0202
+      0x58240056,  //  0213  LDCONST	R9	K86
+      0xAC240200,  //  0214  CATCH	R9	1	0
+      0xB0080000,  //  0215  RAISE	2	R0	R0
+      0xB8264200,  //  0216  GETNGBL	R9	K33
+      0x8C24132C,  //  0217  GETMET	R9	R9	K44
+      0x602C0008,  //  0218  GETGBL	R11	G8
+      0x5C301000,  //  0219  MOVE	R12	R8
+      0x7C2C0200,  //  021A  CALL	R11	1
+      0x002EAE0B,  //  021B  ADD	R11	K87	R11
+      0x002C1758,  //  021C  ADD	R11	R11	K88
+      0x5830000E,  //  021D  LDCONST	R12	K14
+      0x7C240600,  //  021E  CALL	R9	3
+      0xB8260200,  //  021F  GETNGBL	R9	K1
+      0x88241359,  //  0220  GETMBR	R9	R9	K89
+      0x900E3209,  //  0221  SETMBR	R3	K25	R9
+      0x4C240000,  //  0222  LDNIL	R9
+      0xA0000000,  //  0223  CLOSE	R0
+      0x80041200,  //  0224  RET	1	R9
+      0x7002009B,  //  0225  JMP		#02C2
+      0x5422003B,  //  0226  LDINT	R8	60
+      0x1C200C08,  //  0227  EQ	R8	R6	R8
+      0x78220085,  //  0228  JMPF	R8	#02AF
+      0x1C200F05,  //  0229  EQ	R8	R7	K5
+      0x78220065,  //  022A  JMPF	R8	#0291
+      0x8C200506,  //  022B  GETMET	R8	R2	K6
+      0x58280005,  //  022C  LDCONST	R10	K5
+      0x7C200400,  //  022D  CALL	R8	2
+      0x8C240506,  //  022E  GETMET	R9	R2	K6
+      0x582C0007,  //  022F  LDCONST	R11	K7
+      0x7C240400,  //  0230  CALL	R9	2
+      0x8C280506,  //  0231  GETMET	R10	R2	K6
+      0x5830000E,  //  0232  LDCONST	R12	K14
+      0x7C280400,  //  0233  CALL	R10	2
+      0x8C2C0506,  //  0234  GETMET	R11	R2	K6
+      0x58340010,  //  0235  LDCONST	R13	K16
+      0x7C2C0400,  //  0236  CALL	R11	2
+      0x8C300506,  //  0237  GETMET	R12	R2	K6
+      0x543A0003,  //  0238  LDINT	R14	4
+      0x7C300400,  //  0239  CALL	R12	2
+      0xB8364200,  //  023A  GETNGBL	R13	K33
+      0x8C341B2C,  //  023B  GETMET	R13	R13	K44
+      0x603C0018,  //  023C  GETGBL	R15	G24
+      0x5840005A,  //  023D  LDCONST	R16	K90
+      0x5C441000,  //  023E  MOVE	R17	R8
+      0x8C481351,  //  023F  GETMET	R18	R9	K81
+      0x7C480200,  //  0240  CALL	R18	1
+      0x5C4C1400,  //  0241  MOVE	R19	R10
+      0x5C501600,  //  0242  MOVE	R20	R11
+      0x8C541951,  //  0243  GETMET	R21	R12	K81
+      0x7C540200,  //  0244  CALL	R21	1
+      0x7C3C0C00,  //  0245  CALL	R15	6
+      0x54420003,  //  0246  LDINT	R16	4
+      0x7C340600,  //  0247  CALL	R13	3
+      0x4C340000,  //  0248  LDNIL	R13
+      0x1C34100D,  //  0249  EQ	R13	R8	R13
+      0x7436000B,  //  024A  JMPT	R13	#0257
+      0x4C340000,  //  024B  LDNIL	R13
+      0x1C34120D,  //  024C  EQ	R13	R9	R13
+      0x74360008,  //  024D  JMPT	R13	#0257
+      0x4C340000,  //  024E  LDNIL	R13
+      0x1C34140D,  //  024F  EQ	R13	R10	R13
+      0x74360005,  //  0250  JMPT	R13	#0257
+      0x4C340000,  //  0251  LDNIL	R13
+      0x1C34160D,  //  0252  EQ	R13	R11	R13
+      0x74360002,  //  0253  JMPT	R13	#0257
+      0x4C340000,  //  0254  LDNIL	R13
+      0x1C34180D,  //  0255  EQ	R13	R12	R13
+      0x78360005,  //  0256  JMPF	R13	#025D
+      0xB8360200,  //  0257  GETNGBL	R13	K1
+      0x88341B5B,  //  0258  GETMBR	R13	R13	K91
+      0x900E320D,  //  0259  SETMBR	R3	K25	R13
+      0x4C340000,  //  025A  LDNIL	R13
+      0xA0000000,  //  025B  CLOSE	R0
+      0x80041A00,  //  025C  RET	1	R13
+      0x6034000C,  //  025D  GETGBL	R13	G12
+      0x5C381200,  //  025E  MOVE	R14	R9
+      0x7C340200,  //  025F  CALL	R13	1
+      0x543A001F,  //  0260  LDINT	R14	32
+      0x543E0040,  //  0261  LDINT	R15	65
+      0x00381C0F,  //  0262  ADD	R14	R14	R15
+      0x20341A0E,  //  0263  NE	R13	R13	R14
+      0x7436000B,  //  0264  JMPT	R13	#0271
+      0x6034000C,  //  0265  GETGBL	R13	G12
+      0x5C381800,  //  0266  MOVE	R14	R12
+      0x7C340200,  //  0267  CALL	R13	1
+      0x543A000F,  //  0268  LDINT	R14	16
+      0x14341A0E,  //  0269  LT	R13	R13	R14
+      0x74360005,  //  026A  JMPT	R13	#0271
+      0x6034000C,  //  026B  GETGBL	R13	G12
+      0x5C381800,  //  026C  MOVE	R14	R12
+      0x7C340200,  //  026D  CALL	R13	1
+      0x543A001F,  //  026E  LDINT	R14	32
+      0x24341A0E,  //  026F  GT	R13	R13	R14
+      0x7836000A,  //  0270  JMPF	R13	#027C
+      0xB8364200,  //  0271  GETNGBL	R13	K33
+      0x8C341B2C,  //  0272  GETMET	R13	R13	K44
+      0x583C005C,  //  0273  LDCONST	R15	K92
+      0x5840000E,  //  0274  LDCONST	R16	K14
+      0x7C340600,  //  0275  CALL	R13	3
+      0xB8360200,  //  0276  GETNGBL	R13	K1
+      0x88341B5D,  //  0277  GETMBR	R13	R13	K93
+      0x900E320D,  //  0278  SETMBR	R3	K25	R13
+      0x4C340000,  //  0279  LDNIL	R13
+      0xA0000000,  //  027A  CLOSE	R0
+      0x80041A00,  //  027B  RET	1	R13
+      0x5436001E,  //  027C  LDINT	R13	31
+      0x40360A0D,  //  027D  CONNECT	R13	K5	R13
+      0x9434120D,  //  027E  GETIDX	R13	R9	R13
+      0x543A001F,  //  027F  LDINT	R14	32
+      0x40381D40,  //  0280  CONNECT	R14	R14	K64
+      0x9438120E,  //  0281  GETIDX	R14	R9	R14
+      0x883C0115,  //  0282  GETMBR	R15	R0	K21
+      0x8C3C1F5E,  //  0283  GETMET	R15	R15	K94
+      0x5C441000,  //  0284  MOVE	R17	R8
+      0x5C481600,  //  0285  MOVE	R18	R11
+      0x5C4C1400,  //  0286  MOVE	R19	R10
+      0x5C501800,  //  0287  MOVE	R20	R12
       0x5C541A00,  //  0288  MOVE	R21	R13
       0x5C581C00,  //  0289  MOVE	R22	R14
-      0x5C5C1E00,  //  028A  MOVE	R23	R15
-      0x8C600361,  //  028B  GETMET	R24	R1	K97
-      0x7C600200,  //  028C  CALL	R24	1
-      0x7C401000,  //  028D  CALL	R16	8
-      0x50400200,  //  028E  LDBOOL	R16	1	0
-      0xA0000000,  //  028F  CLOSE	R0
-      0x80042000,  //  0290  RET	1	R16
-      0x7002001C,  //  0291  JMP		#02AF
-      0x1C241108,  //  0292  EQ	R9	R8	K8
-      0x78260012,  //  0293  JMPF	R9	#02A7
-      0x8C240507,  //  0294  GETMET	R9	R2	K7
-      0x582C0006,  //  0295  LDCONST	R11	K6
-      0x7C240400,  //  0296  CALL	R9	2
-      0xB82A4400,  //  0297  GETNGBL	R10	K34
-      0x8C28152D,  //  0298  GETMET	R10	R10	K45
-      0x60300008,  //  0299  GETGBL	R12	G8
-      0x5C341200,  //  029A  MOVE	R13	R9
-      0x7C300200,  //  029B  CALL	R12	1
-      0x0032C40C,  //  029C  ADD	R12	K98	R12
-      0x58340011,  //  029D  LDCONST	R13	K17
-      0x7C280600,  //  029E  CALL	R10	3
-      0x88280116,  //  029F  GETMBR	R10	R0	K22
-      0x8C281563,  //  02A0  GETMET	R10	R10	K99
-      0x5C301200,  //  02A1  MOVE	R12	R9
-      0x7C280400,  //  02A2  CALL	R10	2
-      0x50280200,  //  02A3  LDBOOL	R10	1	0
-      0xA0000000,  //  02A4  CLOSE	R0
-      0x80041400,  //  02A5  RET	1	R10
-      0x70020007,  //  02A6  JMP		#02AF
-      0x1C24110F,  //  02A7  EQ	R9	R8	K15
-      0x78260005,  //  02A8  JMPF	R9	#02AF
-      0x88240116,  //  02A9  GETMBR	R9	R0	K22
-      0x8C241364,  //  02AA  GETMET	R9	R9	K100
-      0x7C240200,  //  02AB  CALL	R9	1
-      0x50240200,  //  02AC  LDBOOL	R9	1	0
-      0xA0000000,  //  02AD  CLOSE	R0
-      0x80041200,  //  02AE  RET	1	R9
-      0x70020012,  //  02AF  JMP		#02C3
-      0x54260029,  //  02B0  LDINT	R9	42
-      0x1C240E09,  //  02B1  EQ	R9	R7	R9
-      0x78260005,  //  02B2  JMPF	R9	#02B9
-      0x1C241106,  //  02B3  EQ	R9	R8	K6
-      0x78260002,  //  02B4  JMPF	R9	#02B8
-      0x50240200,  //  02B5  LDBOOL	R9	1	0
-      0xA0000000,  //  02B6  CLOSE	R0
-      0x80041200,  //  02B7  RET	1	R9
-      0x70020009,  //  02B8  JMP		#02C3
-      0x60240003,  //  02B9  GETGBL	R9	G3
-      0x5C280000,  //  02BA  MOVE	R10	R0
-      0x7C240200,  //  02BB  CALL	R9	1
-      0x8C241365,  //  02BC  GETMET	R9	R9	K101
-      0x5C2C0200,  //  02BD  MOVE	R11	R1
-      0x5C300400,  //  02BE  MOVE	R12	R2
-      0x5C340600,  //  02BF  MOVE	R13	R3
-      0x7C240800,  //  02C0  CALL	R9	4
-      0xA0000000,  //  02C1  CLOSE	R0
-      0x80041200,  //  02C2  RET	1	R9
-      0xA0000000,  //  02C3  CLOSE	R0
-      0x80000000,  //  02C4  RET	0
+      0x8C5C035F,  //  028A  GETMET	R23	R1	K95
+      0x7C5C0200,  //  028B  CALL	R23	1
+      0x7C3C1000,  //  028C  CALL	R15	8
+      0x503C0200,  //  028D  LDBOOL	R15	1	0
+      0xA0000000,  //  028E  CLOSE	R0
+      0x80041E00,  //  028F  RET	1	R15
+      0x7002001C,  //  0290  JMP		#02AE
+      0x1C200F07,  //  0291  EQ	R8	R7	K7
+      0x78220012,  //  0292  JMPF	R8	#02A6
+      0x8C200506,  //  0293  GETMET	R8	R2	K6
+      0x58280005,  //  0294  LDCONST	R10	K5
+      0x7C200400,  //  0295  CALL	R8	2
+      0xB8264200,  //  0296  GETNGBL	R9	K33
+      0x8C24132C,  //  0297  GETMET	R9	R9	K44
+      0x602C0008,  //  0298  GETGBL	R11	G8
+      0x5C301000,  //  0299  MOVE	R12	R8
+      0x7C2C0200,  //  029A  CALL	R11	1
+      0x002EC00B,  //  029B  ADD	R11	K96	R11
+      0x58300010,  //  029C  LDCONST	R12	K16
+      0x7C240600,  //  029D  CALL	R9	3
+      0x88240115,  //  029E  GETMBR	R9	R0	K21
+      0x8C241361,  //  029F  GETMET	R9	R9	K97
+      0x5C2C1000,  //  02A0  MOVE	R11	R8
+      0x7C240400,  //  02A1  CALL	R9	2
+      0x50240200,  //  02A2  LDBOOL	R9	1	0
+      0xA0000000,  //  02A3  CLOSE	R0
+      0x80041200,  //  02A4  RET	1	R9
+      0x70020007,  //  02A5  JMP		#02AE
+      0x1C200F0E,  //  02A6  EQ	R8	R7	K14
+      0x78220005,  //  02A7  JMPF	R8	#02AE
+      0x88200115,  //  02A8  GETMBR	R8	R0	K21
+      0x8C201162,  //  02A9  GETMET	R8	R8	K98
+      0x7C200200,  //  02AA  CALL	R8	1
+      0x50200200,  //  02AB  LDBOOL	R8	1	0
+      0xA0000000,  //  02AC  CLOSE	R0
+      0x80041000,  //  02AD  RET	1	R8
+      0x70020012,  //  02AE  JMP		#02C2
+      0x54220029,  //  02AF  LDINT	R8	42
+      0x1C200C08,  //  02B0  EQ	R8	R6	R8
+      0x78220005,  //  02B1  JMPF	R8	#02B8
+      0x1C200F05,  //  02B2  EQ	R8	R7	K5
+      0x78220002,  //  02B3  JMPF	R8	#02B7
+      0x50200200,  //  02B4  LDBOOL	R8	1	0
+      0xA0000000,  //  02B5  CLOSE	R0
+      0x80041000,  //  02B6  RET	1	R8
+      0x70020009,  //  02B7  JMP		#02C2
+      0x60200003,  //  02B8  GETGBL	R8	G3
+      0x5C240000,  //  02B9  MOVE	R9	R0
+      0x7C200200,  //  02BA  CALL	R8	1
+      0x8C201163,  //  02BB  GETMET	R8	R8	K99
+      0x5C280200,  //  02BC  MOVE	R10	R1
+      0x5C2C0400,  //  02BD  MOVE	R11	R2
+      0x5C300600,  //  02BE  MOVE	R12	R3
+      0x7C200800,  //  02BF  CALL	R8	4
+      0xA0000000,  //  02C0  CLOSE	R0
+      0x80041000,  //  02C1  RET	1	R8
+      0xA0000000,  //  02C2  CLOSE	R0
+      0x80000000,  //  02C3  RET	0
     })
   )
 );
@@ -1873,7 +1870,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Root_write_attribute,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1881,126 +1878,124 @@ be_local_closure(Matter_Plugin_Root_write_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(int),
-    /* K7   */  be_nested_str_weak(int64),
-    /* K8   */  be_nested_str_weak(_breadcrumb),
-    /* K9   */  be_nested_str_weak(attribute_updated),
-    /* K10  */  be_nested_str_weak(status),
-    /* K11  */  be_nested_str_weak(CONSTRAINT_ERROR),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_nested_str_weak(INVALID_ACTION),
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(int),
+    /* K6   */  be_nested_str_weak(int64),
+    /* K7   */  be_nested_str_weak(_breadcrumb),
+    /* K8   */  be_nested_str_weak(attribute_updated),
+    /* K9   */  be_nested_str_weak(status),
+    /* K10  */  be_nested_str_weak(CONSTRAINT_ERROR),
+    /* K11  */  be_const_int(1),
+    /* K12  */  be_nested_str_weak(INVALID_ACTION),
     }),
     be_str_weak(write_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[101]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0xB8160200,  //  0001  GETNGBL	R5	K1
-      0x88140B02,  //  0002  GETMBR	R5	R5	K2
+    ( &(const binstruction[100]) {  /* code */
+      0xB8120000,  //  0000  GETNGBL	R4	K0
+      0x88100901,  //  0001  GETMBR	R4	R4	K1
+      0x88140502,  //  0002  GETMBR	R5	R2	K2
       0x88180503,  //  0003  GETMBR	R6	R2	K3
-      0x881C0504,  //  0004  GETMBR	R7	R2	K4
-      0x5422002F,  //  0005  LDINT	R8	48
-      0x1C200C08,  //  0006  EQ	R8	R6	R8
-      0x78220019,  //  0007  JMPF	R8	#0022
-      0x1C200F05,  //  0008  EQ	R8	R7	K5
-      0x78220016,  //  0009  JMPF	R8	#0021
-      0x60200004,  //  000A  GETGBL	R8	G4
-      0x5C240600,  //  000B  MOVE	R9	R3
-      0x7C200200,  //  000C  CALL	R8	1
-      0x1C201106,  //  000D  EQ	R8	R8	K6
-      0x74220004,  //  000E  JMPT	R8	#0014
-      0x6020000F,  //  000F  GETGBL	R8	G15
-      0x5C240600,  //  0010  MOVE	R9	R3
-      0xB82A0E00,  //  0011  GETNGBL	R10	K7
-      0x7C200400,  //  0012  CALL	R8	2
-      0x78220007,  //  0013  JMPF	R8	#001C
-      0x90061003,  //  0014  SETMBR	R1	K8	R3
-      0x8C200109,  //  0015  GETMET	R8	R0	K9
+      0x541E002F,  //  0004  LDINT	R7	48
+      0x1C1C0A07,  //  0005  EQ	R7	R5	R7
+      0x781E0019,  //  0006  JMPF	R7	#0021
+      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x781E0016,  //  0008  JMPF	R7	#0020
+      0x601C0004,  //  0009  GETGBL	R7	G4
+      0x5C200600,  //  000A  MOVE	R8	R3
+      0x7C1C0200,  //  000B  CALL	R7	1
+      0x1C1C0F05,  //  000C  EQ	R7	R7	K5
+      0x741E0004,  //  000D  JMPT	R7	#0013
+      0x601C000F,  //  000E  GETGBL	R7	G15
+      0x5C200600,  //  000F  MOVE	R8	R3
+      0xB8260C00,  //  0010  GETNGBL	R9	K6
+      0x7C1C0400,  //  0011  CALL	R7	2
+      0x781E0007,  //  0012  JMPF	R7	#001B
+      0x90060E03,  //  0013  SETMBR	R1	K7	R3
+      0x8C1C0108,  //  0014  GETMET	R7	R0	K8
+      0x88240502,  //  0015  GETMBR	R9	R2	K2
       0x88280503,  //  0016  GETMBR	R10	R2	K3
-      0x882C0504,  //  0017  GETMBR	R11	R2	K4
-      0x7C200600,  //  0018  CALL	R8	3
-      0x50200200,  //  0019  LDBOOL	R8	1	0
-      0x80041000,  //  001A  RET	1	R8
-      0x70020004,  //  001B  JMP		#0021
-      0xB8220200,  //  001C  GETNGBL	R8	K1
-      0x8820110B,  //  001D  GETMBR	R8	R8	K11
-      0x900A1408,  //  001E  SETMBR	R2	K10	R8
-      0x50200000,  //  001F  LDBOOL	R8	0	0
-      0x80041000,  //  0020  RET	1	R8
-      0x70020041,  //  0021  JMP		#0064
-      0x5422001E,  //  0022  LDINT	R8	31
-      0x1C200C08,  //  0023  EQ	R8	R6	R8
-      0x78220004,  //  0024  JMPF	R8	#002A
-      0x1C200F05,  //  0025  EQ	R8	R7	K5
-      0x78220001,  //  0026  JMPF	R8	#0029
-      0x50200200,  //  0027  LDBOOL	R8	1	0
-      0x80041000,  //  0028  RET	1	R8
-      0x70020039,  //  0029  JMP		#0064
-      0x54220027,  //  002A  LDINT	R8	40
-      0x1C200C08,  //  002B  EQ	R8	R6	R8
-      0x7822000B,  //  002C  JMPF	R8	#0039
-      0x54220004,  //  002D  LDINT	R8	5
-      0x1C200E08,  //  002E  EQ	R8	R7	R8
-      0x78220002,  //  002F  JMPF	R8	#0033
-      0x50200200,  //  0030  LDBOOL	R8	1	0
-      0x80041000,  //  0031  RET	1	R8
-      0x70020004,  //  0032  JMP		#0038
-      0x54220005,  //  0033  LDINT	R8	6
-      0x1C200E08,  //  0034  EQ	R8	R7	R8
-      0x78220001,  //  0035  JMPF	R8	#0038
-      0x50200200,  //  0036  LDBOOL	R8	1	0
-      0x80041000,  //  0037  RET	1	R8
-      0x7002002A,  //  0038  JMP		#0064
-      0x54220029,  //  0039  LDINT	R8	42
-      0x1C200C08,  //  003A  EQ	R8	R6	R8
-      0x78220004,  //  003B  JMPF	R8	#0041
-      0x1C200F05,  //  003C  EQ	R8	R7	K5
-      0x78220001,  //  003D  JMPF	R8	#0040
-      0x50200200,  //  003E  LDBOOL	R8	1	0
-      0x80041000,  //  003F  RET	1	R8
-      0x70020022,  //  0040  JMP		#0064
-      0x5422002A,  //  0041  LDINT	R8	43
-      0x1C200C08,  //  0042  EQ	R8	R6	R8
-      0x78220007,  //  0043  JMPF	R8	#004C
-      0x1C200F05,  //  0044  EQ	R8	R7	K5
-      0x78220004,  //  0045  JMPF	R8	#004B
-      0xB8220200,  //  0046  GETNGBL	R8	K1
-      0x8820110B,  //  0047  GETMBR	R8	R8	K11
-      0x900A1408,  //  0048  SETMBR	R2	K10	R8
-      0x50200000,  //  0049  LDBOOL	R8	0	0
-      0x80041000,  //  004A  RET	1	R8
-      0x70020017,  //  004B  JMP		#0064
-      0x5422002B,  //  004C  LDINT	R8	44
-      0x1C200C08,  //  004D  EQ	R8	R6	R8
-      0x78220009,  //  004E  JMPF	R8	#0059
-      0x1C200F05,  //  004F  EQ	R8	R7	K5
-      0x78220002,  //  0050  JMPF	R8	#0054
-      0x50200200,  //  0051  LDBOOL	R8	1	0
-      0x80041000,  //  0052  RET	1	R8
-      0x70020003,  //  0053  JMP		#0058
-      0x1C200F0C,  //  0054  EQ	R8	R7	K12
-      0x78220001,  //  0055  JMPF	R8	#0058
-      0x50200200,  //  0056  LDBOOL	R8	1	0
-      0x80041000,  //  0057  RET	1	R8
-      0x7002000A,  //  0058  JMP		#0064
-      0x54220030,  //  0059  LDINT	R8	49
-      0x1C200C08,  //  005A  EQ	R8	R6	R8
-      0x78220007,  //  005B  JMPF	R8	#0064
-      0x54220003,  //  005C  LDINT	R8	4
-      0x1C200E08,  //  005D  EQ	R8	R7	R8
-      0x78220004,  //  005E  JMPF	R8	#0064
-      0xB8220200,  //  005F  GETNGBL	R8	K1
-      0x8820110D,  //  0060  GETMBR	R8	R8	K13
-      0x900A1408,  //  0061  SETMBR	R2	K10	R8
-      0x50200000,  //  0062  LDBOOL	R8	0	0
-      0x80041000,  //  0063  RET	1	R8
-      0x80000000,  //  0064  RET	0
+      0x7C1C0600,  //  0017  CALL	R7	3
+      0x501C0200,  //  0018  LDBOOL	R7	1	0
+      0x80040E00,  //  0019  RET	1	R7
+      0x70020004,  //  001A  JMP		#0020
+      0xB81E0000,  //  001B  GETNGBL	R7	K0
+      0x881C0F0A,  //  001C  GETMBR	R7	R7	K10
+      0x900A1207,  //  001D  SETMBR	R2	K9	R7
+      0x501C0000,  //  001E  LDBOOL	R7	0	0
+      0x80040E00,  //  001F  RET	1	R7
+      0x70020041,  //  0020  JMP		#0063
+      0x541E001E,  //  0021  LDINT	R7	31
+      0x1C1C0A07,  //  0022  EQ	R7	R5	R7
+      0x781E0004,  //  0023  JMPF	R7	#0029
+      0x1C1C0D04,  //  0024  EQ	R7	R6	K4
+      0x781E0001,  //  0025  JMPF	R7	#0028
+      0x501C0200,  //  0026  LDBOOL	R7	1	0
+      0x80040E00,  //  0027  RET	1	R7
+      0x70020039,  //  0028  JMP		#0063
+      0x541E0027,  //  0029  LDINT	R7	40
+      0x1C1C0A07,  //  002A  EQ	R7	R5	R7
+      0x781E000B,  //  002B  JMPF	R7	#0038
+      0x541E0004,  //  002C  LDINT	R7	5
+      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
+      0x781E0002,  //  002E  JMPF	R7	#0032
+      0x501C0200,  //  002F  LDBOOL	R7	1	0
+      0x80040E00,  //  0030  RET	1	R7
+      0x70020004,  //  0031  JMP		#0037
+      0x541E0005,  //  0032  LDINT	R7	6
+      0x1C1C0C07,  //  0033  EQ	R7	R6	R7
+      0x781E0001,  //  0034  JMPF	R7	#0037
+      0x501C0200,  //  0035  LDBOOL	R7	1	0
+      0x80040E00,  //  0036  RET	1	R7
+      0x7002002A,  //  0037  JMP		#0063
+      0x541E0029,  //  0038  LDINT	R7	42
+      0x1C1C0A07,  //  0039  EQ	R7	R5	R7
+      0x781E0004,  //  003A  JMPF	R7	#0040
+      0x1C1C0D04,  //  003B  EQ	R7	R6	K4
+      0x781E0001,  //  003C  JMPF	R7	#003F
+      0x501C0200,  //  003D  LDBOOL	R7	1	0
+      0x80040E00,  //  003E  RET	1	R7
+      0x70020022,  //  003F  JMP		#0063
+      0x541E002A,  //  0040  LDINT	R7	43
+      0x1C1C0A07,  //  0041  EQ	R7	R5	R7
+      0x781E0007,  //  0042  JMPF	R7	#004B
+      0x1C1C0D04,  //  0043  EQ	R7	R6	K4
+      0x781E0004,  //  0044  JMPF	R7	#004A
+      0xB81E0000,  //  0045  GETNGBL	R7	K0
+      0x881C0F0A,  //  0046  GETMBR	R7	R7	K10
+      0x900A1207,  //  0047  SETMBR	R2	K9	R7
+      0x501C0000,  //  0048  LDBOOL	R7	0	0
+      0x80040E00,  //  0049  RET	1	R7
+      0x70020017,  //  004A  JMP		#0063
+      0x541E002B,  //  004B  LDINT	R7	44
+      0x1C1C0A07,  //  004C  EQ	R7	R5	R7
+      0x781E0009,  //  004D  JMPF	R7	#0058
+      0x1C1C0D04,  //  004E  EQ	R7	R6	K4
+      0x781E0002,  //  004F  JMPF	R7	#0053
+      0x501C0200,  //  0050  LDBOOL	R7	1	0
+      0x80040E00,  //  0051  RET	1	R7
+      0x70020003,  //  0052  JMP		#0057
+      0x1C1C0D0B,  //  0053  EQ	R7	R6	K11
+      0x781E0001,  //  0054  JMPF	R7	#0057
+      0x501C0200,  //  0055  LDBOOL	R7	1	0
+      0x80040E00,  //  0056  RET	1	R7
+      0x7002000A,  //  0057  JMP		#0063
+      0x541E0030,  //  0058  LDINT	R7	49
+      0x1C1C0A07,  //  0059  EQ	R7	R5	R7
+      0x781E0007,  //  005A  JMPF	R7	#0063
+      0x541E0003,  //  005B  LDINT	R7	4
+      0x1C1C0C07,  //  005C  EQ	R7	R6	R7
+      0x781E0004,  //  005D  JMPF	R7	#0063
+      0xB81E0000,  //  005E  GETNGBL	R7	K0
+      0x881C0F0C,  //  005F  GETMBR	R7	R7	K12
+      0x900A1207,  //  0060  SETMBR	R2	K9	R7
+      0x501C0000,  //  0061  LDBOOL	R7	0	0
+      0x80040E00,  //  0062  RET	1	R7
+      0x80000000,  //  0063  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Contact.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Contact.h
@@ -79,7 +79,7 @@ be_local_closure(Matter_Plugin_Sensor_Contact_parse_configuration,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Sensor_Contact_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -87,77 +87,75 @@ be_local_closure(Matter_Plugin_Sensor_Contact_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_contact),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(BOOL),
-    /* K9   */  be_nested_str_weak(NULL),
-    /* K10  */  be_nested_str_weak(U4),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(shadow_contact),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(BOOL),
+    /* K8   */  be_nested_str_weak(NULL),
+    /* K9   */  be_nested_str_weak(U4),
+    /* K10  */  be_const_int(1),
+    /* K11  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[52]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0044,  //  0005  LDINT	R7	69
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0023,  //  0007  JMPF	R7	#002C
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E000F,  //  0009  JMPF	R7	#001A
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x4C200000,  //  000B  LDNIL	R8
-      0x201C0E08,  //  000C  NE	R7	R7	R8
-      0x781E0005,  //  000D  JMPF	R7	#0014
-      0x8C1C0907,  //  000E  GETMET	R7	R4	K7
-      0x88240908,  //  000F  GETMBR	R9	R4	K8
-      0x88280106,  //  0010  GETMBR	R10	R0	K6
-      0x7C1C0600,  //  0011  CALL	R7	3
-      0x80040E00,  //  0012  RET	1	R7
-      0x70020004,  //  0013  JMP		#0019
-      0x8C1C0907,  //  0014  GETMET	R7	R4	K7
-      0x88240909,  //  0015  GETMBR	R9	R4	K9
-      0x4C280000,  //  0016  LDNIL	R10
-      0x7C1C0600,  //  0017  CALL	R7	3
-      0x80040E00,  //  0018  RET	1	R7
-      0x70020010,  //  0019  JMP		#002B
-      0x541EFFFB,  //  001A  LDINT	R7	65532
-      0x1C1C0C07,  //  001B  EQ	R7	R6	R7
-      0x781E0005,  //  001C  JMPF	R7	#0023
-      0x8C1C0907,  //  001D  GETMET	R7	R4	K7
-      0x8824090A,  //  001E  GETMBR	R9	R4	K10
-      0x58280005,  //  001F  LDCONST	R10	K5
-      0x7C1C0600,  //  0020  CALL	R7	3
-      0x80040E00,  //  0021  RET	1	R7
-      0x70020007,  //  0022  JMP		#002B
-      0x541EFFFC,  //  0023  LDINT	R7	65533
-      0x1C1C0C07,  //  0024  EQ	R7	R6	R7
-      0x781E0004,  //  0025  JMPF	R7	#002B
-      0x8C1C0907,  //  0026  GETMET	R7	R4	K7
-      0x8824090A,  //  0027  GETMBR	R9	R4	K10
-      0x5828000B,  //  0028  LDCONST	R10	K11
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x80040E00,  //  002A  RET	1	R7
-      0x70020007,  //  002B  JMP		#0034
-      0x601C0003,  //  002C  GETGBL	R7	G3
-      0x5C200000,  //  002D  MOVE	R8	R0
-      0x7C1C0200,  //  002E  CALL	R7	1
-      0x8C1C0F0C,  //  002F  GETMET	R7	R7	K12
-      0x5C240200,  //  0030  MOVE	R9	R1
-      0x5C280400,  //  0031  MOVE	R10	R2
-      0x7C1C0600,  //  0032  CALL	R7	3
-      0x80040E00,  //  0033  RET	1	R7
-      0x80000000,  //  0034  RET	0
+      0x541A0044,  //  0004  LDINT	R6	69
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0023,  //  0006  JMPF	R6	#002B
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A000F,  //  0008  JMPF	R6	#0019
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x20180C07,  //  000B  NE	R6	R6	R7
+      0x781A0005,  //  000C  JMPF	R6	#0013
+      0x8C180706,  //  000D  GETMET	R6	R3	K6
+      0x88200707,  //  000E  GETMBR	R8	R3	K7
+      0x88240105,  //  000F  GETMBR	R9	R0	K5
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80040C00,  //  0011  RET	1	R6
+      0x70020004,  //  0012  JMP		#0018
+      0x8C180706,  //  0013  GETMET	R6	R3	K6
+      0x88200708,  //  0014  GETMBR	R8	R3	K8
+      0x4C240000,  //  0015  LDNIL	R9
+      0x7C180600,  //  0016  CALL	R6	3
+      0x80040C00,  //  0017  RET	1	R6
+      0x70020010,  //  0018  JMP		#002A
+      0x541AFFFB,  //  0019  LDINT	R6	65532
+      0x1C180A06,  //  001A  EQ	R6	R5	R6
+      0x781A0005,  //  001B  JMPF	R6	#0022
+      0x8C180706,  //  001C  GETMET	R6	R3	K6
+      0x88200709,  //  001D  GETMBR	R8	R3	K9
+      0x58240004,  //  001E  LDCONST	R9	K4
+      0x7C180600,  //  001F  CALL	R6	3
+      0x80040C00,  //  0020  RET	1	R6
+      0x70020007,  //  0021  JMP		#002A
+      0x541AFFFC,  //  0022  LDINT	R6	65533
+      0x1C180A06,  //  0023  EQ	R6	R5	R6
+      0x781A0004,  //  0024  JMPF	R6	#002A
+      0x8C180706,  //  0025  GETMET	R6	R3	K6
+      0x88200709,  //  0026  GETMBR	R8	R3	K9
+      0x5824000A,  //  0027  LDCONST	R9	K10
+      0x7C180600,  //  0028  CALL	R6	3
+      0x80040C00,  //  0029  RET	1	R6
+      0x70020007,  //  002A  JMP		#0033
+      0x60180003,  //  002B  GETGBL	R6	G3
+      0x5C1C0000,  //  002C  MOVE	R7	R0
+      0x7C180200,  //  002D  CALL	R6	1
+      0x8C180D0B,  //  002E  GETMET	R6	R6	K11
+      0x5C200200,  //  002F  MOVE	R8	R1
+      0x5C240400,  //  0030  MOVE	R9	R2
+      0x7C180600,  //  0031  CALL	R6	3
+      0x80040C00,  //  0032  RET	1	R6
+      0x80000000,  //  0033  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Humidity.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Humidity.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Plugin_Sensor_Humidity;
 ********************************************************************/
 be_local_closure(Matter_Plugin_Sensor_Humidity_read_attribute,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,97 +19,95 @@ be_local_closure(Matter_Plugin_Sensor_Humidity_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_value),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(U2),
-    /* K9   */  be_nested_str_weak(NULL),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(U4),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(shadow_value),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(U2),
+    /* K8   */  be_nested_str_weak(NULL),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[71]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[70]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0404,  //  0005  LDINT	R7	1029
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0035,  //  0007  JMPF	R7	#003E
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E0011,  //  0009  JMPF	R7	#001C
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x4C200000,  //  000B  LDNIL	R8
-      0x201C0E08,  //  000C  NE	R7	R7	R8
-      0x781E0007,  //  000D  JMPF	R7	#0016
-      0x8C1C0907,  //  000E  GETMET	R7	R4	K7
-      0x88240908,  //  000F  GETMBR	R9	R4	K8
-      0x60280009,  //  0010  GETGBL	R10	G9
-      0x882C0106,  //  0011  GETMBR	R11	R0	K6
-      0x7C280200,  //  0012  CALL	R10	1
-      0x7C1C0600,  //  0013  CALL	R7	3
-      0x80040E00,  //  0014  RET	1	R7
-      0x70020004,  //  0015  JMP		#001B
-      0x8C1C0907,  //  0016  GETMET	R7	R4	K7
-      0x88240909,  //  0017  GETMBR	R9	R4	K9
-      0x4C280000,  //  0018  LDNIL	R10
-      0x7C1C0600,  //  0019  CALL	R7	3
-      0x80040E00,  //  001A  RET	1	R7
-      0x70020020,  //  001B  JMP		#003D
-      0x1C1C0D0A,  //  001C  EQ	R7	R6	K10
-      0x781E0005,  //  001D  JMPF	R7	#0024
-      0x8C1C0907,  //  001E  GETMET	R7	R4	K7
-      0x88240908,  //  001F  GETMBR	R9	R4	K8
-      0x542A01F3,  //  0020  LDINT	R10	500
-      0x7C1C0600,  //  0021  CALL	R7	3
-      0x80040E00,  //  0022  RET	1	R7
-      0x70020018,  //  0023  JMP		#003D
-      0x1C1C0D0B,  //  0024  EQ	R7	R6	K11
-      0x781E0005,  //  0025  JMPF	R7	#002C
-      0x8C1C0907,  //  0026  GETMET	R7	R4	K7
-      0x88240908,  //  0027  GETMBR	R9	R4	K8
-      0x542A270F,  //  0028  LDINT	R10	10000
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x80040E00,  //  002A  RET	1	R7
-      0x70020010,  //  002B  JMP		#003D
-      0x541EFFFB,  //  002C  LDINT	R7	65532
-      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
-      0x781E0005,  //  002E  JMPF	R7	#0035
-      0x8C1C0907,  //  002F  GETMET	R7	R4	K7
-      0x8824090C,  //  0030  GETMBR	R9	R4	K12
-      0x58280005,  //  0031  LDCONST	R10	K5
-      0x7C1C0600,  //  0032  CALL	R7	3
-      0x80040E00,  //  0033  RET	1	R7
-      0x70020007,  //  0034  JMP		#003D
-      0x541EFFFC,  //  0035  LDINT	R7	65533
-      0x1C1C0C07,  //  0036  EQ	R7	R6	R7
-      0x781E0004,  //  0037  JMPF	R7	#003D
-      0x8C1C0907,  //  0038  GETMET	R7	R4	K7
-      0x8824090C,  //  0039  GETMBR	R9	R4	K12
-      0x5828000D,  //  003A  LDCONST	R10	K13
-      0x7C1C0600,  //  003B  CALL	R7	3
-      0x80040E00,  //  003C  RET	1	R7
-      0x70020007,  //  003D  JMP		#0046
-      0x601C0003,  //  003E  GETGBL	R7	G3
-      0x5C200000,  //  003F  MOVE	R8	R0
-      0x7C1C0200,  //  0040  CALL	R7	1
-      0x8C1C0F0E,  //  0041  GETMET	R7	R7	K14
-      0x5C240200,  //  0042  MOVE	R9	R1
-      0x5C280400,  //  0043  MOVE	R10	R2
-      0x7C1C0600,  //  0044  CALL	R7	3
-      0x80040E00,  //  0045  RET	1	R7
-      0x80000000,  //  0046  RET	0
+      0x541A0404,  //  0004  LDINT	R6	1029
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0035,  //  0006  JMPF	R6	#003D
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A0011,  //  0008  JMPF	R6	#001B
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x20180C07,  //  000B  NE	R6	R6	R7
+      0x781A0007,  //  000C  JMPF	R6	#0015
+      0x8C180706,  //  000D  GETMET	R6	R3	K6
+      0x88200707,  //  000E  GETMBR	R8	R3	K7
+      0x60240009,  //  000F  GETGBL	R9	G9
+      0x88280105,  //  0010  GETMBR	R10	R0	K5
+      0x7C240200,  //  0011  CALL	R9	1
+      0x7C180600,  //  0012  CALL	R6	3
+      0x80040C00,  //  0013  RET	1	R6
+      0x70020004,  //  0014  JMP		#001A
+      0x8C180706,  //  0015  GETMET	R6	R3	K6
+      0x88200708,  //  0016  GETMBR	R8	R3	K8
+      0x4C240000,  //  0017  LDNIL	R9
+      0x7C180600,  //  0018  CALL	R6	3
+      0x80040C00,  //  0019  RET	1	R6
+      0x70020020,  //  001A  JMP		#003C
+      0x1C180B09,  //  001B  EQ	R6	R5	K9
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C180706,  //  001D  GETMET	R6	R3	K6
+      0x88200707,  //  001E  GETMBR	R8	R3	K7
+      0x542601F3,  //  001F  LDINT	R9	500
+      0x7C180600,  //  0020  CALL	R6	3
+      0x80040C00,  //  0021  RET	1	R6
+      0x70020018,  //  0022  JMP		#003C
+      0x1C180B0A,  //  0023  EQ	R6	R5	K10
+      0x781A0005,  //  0024  JMPF	R6	#002B
+      0x8C180706,  //  0025  GETMET	R6	R3	K6
+      0x88200707,  //  0026  GETMBR	R8	R3	K7
+      0x5426270F,  //  0027  LDINT	R9	10000
+      0x7C180600,  //  0028  CALL	R6	3
+      0x80040C00,  //  0029  RET	1	R6
+      0x70020010,  //  002A  JMP		#003C
+      0x541AFFFB,  //  002B  LDINT	R6	65532
+      0x1C180A06,  //  002C  EQ	R6	R5	R6
+      0x781A0005,  //  002D  JMPF	R6	#0034
+      0x8C180706,  //  002E  GETMET	R6	R3	K6
+      0x8820070B,  //  002F  GETMBR	R8	R3	K11
+      0x58240004,  //  0030  LDCONST	R9	K4
+      0x7C180600,  //  0031  CALL	R6	3
+      0x80040C00,  //  0032  RET	1	R6
+      0x70020007,  //  0033  JMP		#003C
+      0x541AFFFC,  //  0034  LDINT	R6	65533
+      0x1C180A06,  //  0035  EQ	R6	R5	R6
+      0x781A0004,  //  0036  JMPF	R6	#003C
+      0x8C180706,  //  0037  GETMET	R6	R3	K6
+      0x8820070B,  //  0038  GETMBR	R8	R3	K11
+      0x5824000C,  //  0039  LDCONST	R9	K12
+      0x7C180600,  //  003A  CALL	R6	3
+      0x80040C00,  //  003B  RET	1	R6
+      0x70020007,  //  003C  JMP		#0045
+      0x60180003,  //  003D  GETGBL	R6	G3
+      0x5C1C0000,  //  003E  MOVE	R7	R0
+      0x7C180200,  //  003F  CALL	R6	1
+      0x8C180D0D,  //  0040  GETMET	R6	R6	K13
+      0x5C200200,  //  0041  MOVE	R8	R1
+      0x5C240400,  //  0042  MOVE	R9	R2
+      0x7C180600,  //  0043  CALL	R6	3
+      0x80040C00,  //  0044  RET	1	R6
+      0x80000000,  //  0045  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Illuminance.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Illuminance.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Plugin_Sensor_Illuminance;
 ********************************************************************/
 be_local_closure(Matter_Plugin_Sensor_Illuminance_read_attribute,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,97 +19,95 @@ be_local_closure(Matter_Plugin_Sensor_Illuminance_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_value),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(U2),
-    /* K9   */  be_nested_str_weak(NULL),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(U4),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(shadow_value),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(U2),
+    /* K8   */  be_nested_str_weak(NULL),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[71]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[70]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E03FF,  //  0005  LDINT	R7	1024
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0035,  //  0007  JMPF	R7	#003E
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E0011,  //  0009  JMPF	R7	#001C
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x4C200000,  //  000B  LDNIL	R8
-      0x201C0E08,  //  000C  NE	R7	R7	R8
-      0x781E0007,  //  000D  JMPF	R7	#0016
-      0x8C1C0907,  //  000E  GETMET	R7	R4	K7
-      0x88240908,  //  000F  GETMBR	R9	R4	K8
-      0x60280009,  //  0010  GETGBL	R10	G9
-      0x882C0106,  //  0011  GETMBR	R11	R0	K6
-      0x7C280200,  //  0012  CALL	R10	1
-      0x7C1C0600,  //  0013  CALL	R7	3
-      0x80040E00,  //  0014  RET	1	R7
-      0x70020004,  //  0015  JMP		#001B
-      0x8C1C0907,  //  0016  GETMET	R7	R4	K7
-      0x88240909,  //  0017  GETMBR	R9	R4	K9
-      0x4C280000,  //  0018  LDNIL	R10
-      0x7C1C0600,  //  0019  CALL	R7	3
-      0x80040E00,  //  001A  RET	1	R7
-      0x70020020,  //  001B  JMP		#003D
-      0x1C1C0D0A,  //  001C  EQ	R7	R6	K10
-      0x781E0005,  //  001D  JMPF	R7	#0024
-      0x8C1C0907,  //  001E  GETMET	R7	R4	K7
-      0x88240908,  //  001F  GETMBR	R9	R4	K8
-      0x5828000A,  //  0020  LDCONST	R10	K10
-      0x7C1C0600,  //  0021  CALL	R7	3
-      0x80040E00,  //  0022  RET	1	R7
-      0x70020018,  //  0023  JMP		#003D
-      0x1C1C0D0B,  //  0024  EQ	R7	R6	K11
-      0x781E0005,  //  0025  JMPF	R7	#002C
-      0x8C1C0907,  //  0026  GETMET	R7	R4	K7
-      0x88240908,  //  0027  GETMBR	R9	R4	K8
-      0x542AFFFD,  //  0028  LDINT	R10	65534
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x80040E00,  //  002A  RET	1	R7
-      0x70020010,  //  002B  JMP		#003D
-      0x541EFFFB,  //  002C  LDINT	R7	65532
-      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
-      0x781E0005,  //  002E  JMPF	R7	#0035
-      0x8C1C0907,  //  002F  GETMET	R7	R4	K7
-      0x8824090C,  //  0030  GETMBR	R9	R4	K12
-      0x58280005,  //  0031  LDCONST	R10	K5
-      0x7C1C0600,  //  0032  CALL	R7	3
-      0x80040E00,  //  0033  RET	1	R7
-      0x70020007,  //  0034  JMP		#003D
-      0x541EFFFC,  //  0035  LDINT	R7	65533
-      0x1C1C0C07,  //  0036  EQ	R7	R6	R7
-      0x781E0004,  //  0037  JMPF	R7	#003D
-      0x8C1C0907,  //  0038  GETMET	R7	R4	K7
-      0x8824090C,  //  0039  GETMBR	R9	R4	K12
-      0x5828000D,  //  003A  LDCONST	R10	K13
-      0x7C1C0600,  //  003B  CALL	R7	3
-      0x80040E00,  //  003C  RET	1	R7
-      0x70020007,  //  003D  JMP		#0046
-      0x601C0003,  //  003E  GETGBL	R7	G3
-      0x5C200000,  //  003F  MOVE	R8	R0
-      0x7C1C0200,  //  0040  CALL	R7	1
-      0x8C1C0F0E,  //  0041  GETMET	R7	R7	K14
-      0x5C240200,  //  0042  MOVE	R9	R1
-      0x5C280400,  //  0043  MOVE	R10	R2
-      0x7C1C0600,  //  0044  CALL	R7	3
-      0x80040E00,  //  0045  RET	1	R7
-      0x80000000,  //  0046  RET	0
+      0x541A03FF,  //  0004  LDINT	R6	1024
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0035,  //  0006  JMPF	R6	#003D
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A0011,  //  0008  JMPF	R6	#001B
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x20180C07,  //  000B  NE	R6	R6	R7
+      0x781A0007,  //  000C  JMPF	R6	#0015
+      0x8C180706,  //  000D  GETMET	R6	R3	K6
+      0x88200707,  //  000E  GETMBR	R8	R3	K7
+      0x60240009,  //  000F  GETGBL	R9	G9
+      0x88280105,  //  0010  GETMBR	R10	R0	K5
+      0x7C240200,  //  0011  CALL	R9	1
+      0x7C180600,  //  0012  CALL	R6	3
+      0x80040C00,  //  0013  RET	1	R6
+      0x70020004,  //  0014  JMP		#001A
+      0x8C180706,  //  0015  GETMET	R6	R3	K6
+      0x88200708,  //  0016  GETMBR	R8	R3	K8
+      0x4C240000,  //  0017  LDNIL	R9
+      0x7C180600,  //  0018  CALL	R6	3
+      0x80040C00,  //  0019  RET	1	R6
+      0x70020020,  //  001A  JMP		#003C
+      0x1C180B09,  //  001B  EQ	R6	R5	K9
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C180706,  //  001D  GETMET	R6	R3	K6
+      0x88200707,  //  001E  GETMBR	R8	R3	K7
+      0x58240009,  //  001F  LDCONST	R9	K9
+      0x7C180600,  //  0020  CALL	R6	3
+      0x80040C00,  //  0021  RET	1	R6
+      0x70020018,  //  0022  JMP		#003C
+      0x1C180B0A,  //  0023  EQ	R6	R5	K10
+      0x781A0005,  //  0024  JMPF	R6	#002B
+      0x8C180706,  //  0025  GETMET	R6	R3	K6
+      0x88200707,  //  0026  GETMBR	R8	R3	K7
+      0x5426FFFD,  //  0027  LDINT	R9	65534
+      0x7C180600,  //  0028  CALL	R6	3
+      0x80040C00,  //  0029  RET	1	R6
+      0x70020010,  //  002A  JMP		#003C
+      0x541AFFFB,  //  002B  LDINT	R6	65532
+      0x1C180A06,  //  002C  EQ	R6	R5	R6
+      0x781A0005,  //  002D  JMPF	R6	#0034
+      0x8C180706,  //  002E  GETMET	R6	R3	K6
+      0x8820070B,  //  002F  GETMBR	R8	R3	K11
+      0x58240004,  //  0030  LDCONST	R9	K4
+      0x7C180600,  //  0031  CALL	R6	3
+      0x80040C00,  //  0032  RET	1	R6
+      0x70020007,  //  0033  JMP		#003C
+      0x541AFFFC,  //  0034  LDINT	R6	65533
+      0x1C180A06,  //  0035  EQ	R6	R5	R6
+      0x781A0004,  //  0036  JMPF	R6	#003C
+      0x8C180706,  //  0037  GETMET	R6	R3	K6
+      0x8820070B,  //  0038  GETMBR	R8	R3	K11
+      0x5824000C,  //  0039  LDCONST	R9	K12
+      0x7C180600,  //  003A  CALL	R6	3
+      0x80040C00,  //  003B  RET	1	R6
+      0x70020007,  //  003C  JMP		#0045
+      0x60180003,  //  003D  GETGBL	R6	G3
+      0x5C1C0000,  //  003E  MOVE	R7	R0
+      0x7C180200,  //  003F  CALL	R6	1
+      0x8C180D0D,  //  0040  GETMET	R6	R6	K13
+      0x5C200200,  //  0041  MOVE	R8	R1
+      0x5C240400,  //  0042  MOVE	R9	R2
+      0x7C180600,  //  0043  CALL	R6	3
+      0x80040C00,  //  0044  RET	1	R6
+      0x80000000,  //  0045  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Occupancy.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Occupancy.h
@@ -79,7 +79,7 @@ be_local_closure(Matter_Plugin_Sensor_Occupancy_parse_configuration,   /* name *
 ********************************************************************/
 be_local_closure(Matter_Plugin_Sensor_Occupancy_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -87,95 +87,93 @@ be_local_closure(Matter_Plugin_Sensor_Occupancy_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_occupancy),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(U1),
-    /* K9   */  be_nested_str_weak(NULL),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_const_int(2),
-    /* K13  */  be_nested_str_weak(U4),
-    /* K14  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(shadow_occupancy),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(U1),
+    /* K8   */  be_nested_str_weak(NULL),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_nested_str_weak(U4),
+    /* K13  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[69]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[68]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0405,  //  0005  LDINT	R7	1030
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0033,  //  0007  JMPF	R7	#003C
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E000F,  //  0009  JMPF	R7	#001A
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x4C200000,  //  000B  LDNIL	R8
-      0x201C0E08,  //  000C  NE	R7	R7	R8
-      0x781E0005,  //  000D  JMPF	R7	#0014
-      0x8C1C0907,  //  000E  GETMET	R7	R4	K7
-      0x88240908,  //  000F  GETMBR	R9	R4	K8
-      0x88280106,  //  0010  GETMBR	R10	R0	K6
-      0x7C1C0600,  //  0011  CALL	R7	3
-      0x80040E00,  //  0012  RET	1	R7
-      0x70020004,  //  0013  JMP		#0019
-      0x8C1C0907,  //  0014  GETMET	R7	R4	K7
-      0x88240909,  //  0015  GETMBR	R9	R4	K9
-      0x4C280000,  //  0016  LDNIL	R10
-      0x7C1C0600,  //  0017  CALL	R7	3
-      0x80040E00,  //  0018  RET	1	R7
-      0x70020020,  //  0019  JMP		#003B
-      0x1C1C0D0A,  //  001A  EQ	R7	R6	K10
-      0x781E0005,  //  001B  JMPF	R7	#0022
-      0x8C1C0907,  //  001C  GETMET	R7	R4	K7
-      0x88240908,  //  001D  GETMBR	R9	R4	K8
-      0x5828000B,  //  001E  LDCONST	R10	K11
-      0x7C1C0600,  //  001F  CALL	R7	3
-      0x80040E00,  //  0020  RET	1	R7
-      0x70020018,  //  0021  JMP		#003B
-      0x1C1C0D0C,  //  0022  EQ	R7	R6	K12
-      0x781E0005,  //  0023  JMPF	R7	#002A
-      0x8C1C0907,  //  0024  GETMET	R7	R4	K7
-      0x88240908,  //  0025  GETMBR	R9	R4	K8
-      0x58280005,  //  0026  LDCONST	R10	K5
-      0x7C1C0600,  //  0027  CALL	R7	3
-      0x80040E00,  //  0028  RET	1	R7
-      0x70020010,  //  0029  JMP		#003B
-      0x541EFFFB,  //  002A  LDINT	R7	65532
-      0x1C1C0C07,  //  002B  EQ	R7	R6	R7
-      0x781E0005,  //  002C  JMPF	R7	#0033
-      0x8C1C0907,  //  002D  GETMET	R7	R4	K7
-      0x8824090D,  //  002E  GETMBR	R9	R4	K13
-      0x58280005,  //  002F  LDCONST	R10	K5
-      0x7C1C0600,  //  0030  CALL	R7	3
-      0x80040E00,  //  0031  RET	1	R7
-      0x70020007,  //  0032  JMP		#003B
-      0x541EFFFC,  //  0033  LDINT	R7	65533
-      0x1C1C0C07,  //  0034  EQ	R7	R6	R7
-      0x781E0004,  //  0035  JMPF	R7	#003B
-      0x8C1C0907,  //  0036  GETMET	R7	R4	K7
-      0x8824090D,  //  0037  GETMBR	R9	R4	K13
-      0x5828000B,  //  0038  LDCONST	R10	K11
-      0x7C1C0600,  //  0039  CALL	R7	3
-      0x80040E00,  //  003A  RET	1	R7
-      0x70020007,  //  003B  JMP		#0044
-      0x601C0003,  //  003C  GETGBL	R7	G3
-      0x5C200000,  //  003D  MOVE	R8	R0
-      0x7C1C0200,  //  003E  CALL	R7	1
-      0x8C1C0F0E,  //  003F  GETMET	R7	R7	K14
-      0x5C240200,  //  0040  MOVE	R9	R1
-      0x5C280400,  //  0041  MOVE	R10	R2
-      0x7C1C0600,  //  0042  CALL	R7	3
-      0x80040E00,  //  0043  RET	1	R7
-      0x80000000,  //  0044  RET	0
+      0x541A0405,  //  0004  LDINT	R6	1030
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0033,  //  0006  JMPF	R6	#003B
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A000F,  //  0008  JMPF	R6	#0019
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x20180C07,  //  000B  NE	R6	R6	R7
+      0x781A0005,  //  000C  JMPF	R6	#0013
+      0x8C180706,  //  000D  GETMET	R6	R3	K6
+      0x88200707,  //  000E  GETMBR	R8	R3	K7
+      0x88240105,  //  000F  GETMBR	R9	R0	K5
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80040C00,  //  0011  RET	1	R6
+      0x70020004,  //  0012  JMP		#0018
+      0x8C180706,  //  0013  GETMET	R6	R3	K6
+      0x88200708,  //  0014  GETMBR	R8	R3	K8
+      0x4C240000,  //  0015  LDNIL	R9
+      0x7C180600,  //  0016  CALL	R6	3
+      0x80040C00,  //  0017  RET	1	R6
+      0x70020020,  //  0018  JMP		#003A
+      0x1C180B09,  //  0019  EQ	R6	R5	K9
+      0x781A0005,  //  001A  JMPF	R6	#0021
+      0x8C180706,  //  001B  GETMET	R6	R3	K6
+      0x88200707,  //  001C  GETMBR	R8	R3	K7
+      0x5824000A,  //  001D  LDCONST	R9	K10
+      0x7C180600,  //  001E  CALL	R6	3
+      0x80040C00,  //  001F  RET	1	R6
+      0x70020018,  //  0020  JMP		#003A
+      0x1C180B0B,  //  0021  EQ	R6	R5	K11
+      0x781A0005,  //  0022  JMPF	R6	#0029
+      0x8C180706,  //  0023  GETMET	R6	R3	K6
+      0x88200707,  //  0024  GETMBR	R8	R3	K7
+      0x58240004,  //  0025  LDCONST	R9	K4
+      0x7C180600,  //  0026  CALL	R6	3
+      0x80040C00,  //  0027  RET	1	R6
+      0x70020010,  //  0028  JMP		#003A
+      0x541AFFFB,  //  0029  LDINT	R6	65532
+      0x1C180A06,  //  002A  EQ	R6	R5	R6
+      0x781A0005,  //  002B  JMPF	R6	#0032
+      0x8C180706,  //  002C  GETMET	R6	R3	K6
+      0x8820070C,  //  002D  GETMBR	R8	R3	K12
+      0x58240004,  //  002E  LDCONST	R9	K4
+      0x7C180600,  //  002F  CALL	R6	3
+      0x80040C00,  //  0030  RET	1	R6
+      0x70020007,  //  0031  JMP		#003A
+      0x541AFFFC,  //  0032  LDINT	R6	65533
+      0x1C180A06,  //  0033  EQ	R6	R5	R6
+      0x781A0004,  //  0034  JMPF	R6	#003A
+      0x8C180706,  //  0035  GETMET	R6	R3	K6
+      0x8820070C,  //  0036  GETMBR	R8	R3	K12
+      0x5824000A,  //  0037  LDCONST	R9	K10
+      0x7C180600,  //  0038  CALL	R6	3
+      0x80040C00,  //  0039  RET	1	R6
+      0x70020007,  //  003A  JMP		#0043
+      0x60180003,  //  003B  GETGBL	R6	G3
+      0x5C1C0000,  //  003C  MOVE	R7	R0
+      0x7C180200,  //  003D  CALL	R6	1
+      0x8C180D0D,  //  003E  GETMET	R6	R6	K13
+      0x5C200200,  //  003F  MOVE	R8	R1
+      0x5C240400,  //  0040  MOVE	R9	R2
+      0x7C180600,  //  0041  CALL	R6	3
+      0x80040C00,  //  0042  RET	1	R6
+      0x80000000,  //  0043  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_OnOff.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_OnOff.h
@@ -79,7 +79,7 @@ be_local_closure(Matter_Plugin_Sensor_OnOff_parse_configuration,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Sensor_OnOff_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -87,68 +87,66 @@ be_local_closure(Matter_Plugin_Sensor_OnOff_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(BOOL),
-    /* K9   */  be_nested_str_weak(shadow_onoff),
-    /* K10  */  be_nested_str_weak(U4),
-    /* K11  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(BOOL),
+    /* K8   */  be_nested_str_weak(shadow_onoff),
+    /* K9   */  be_nested_str_weak(U4),
+    /* K10  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[44]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0005,  //  0005  LDINT	R7	6
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E001B,  //  0007  JMPF	R7	#0024
-      0x8C1C0105,  //  0008  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x1C1C0D06,  //  000A  EQ	R7	R6	K6
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0907,  //  000C  GETMET	R7	R4	K7
-      0x88240908,  //  000D  GETMBR	R9	R4	K8
-      0x88280109,  //  000E  GETMBR	R10	R0	K9
-      0x7C1C0600,  //  000F  CALL	R7	3
-      0x80040E00,  //  0010  RET	1	R7
-      0x70020010,  //  0011  JMP		#0023
-      0x541EFFFB,  //  0012  LDINT	R7	65532
-      0x1C1C0C07,  //  0013  EQ	R7	R6	R7
-      0x781E0005,  //  0014  JMPF	R7	#001B
-      0x8C1C0907,  //  0015  GETMET	R7	R4	K7
-      0x8824090A,  //  0016  GETMBR	R9	R4	K10
-      0x58280006,  //  0017  LDCONST	R10	K6
-      0x7C1C0600,  //  0018  CALL	R7	3
-      0x80040E00,  //  0019  RET	1	R7
-      0x70020007,  //  001A  JMP		#0023
-      0x541EFFFC,  //  001B  LDINT	R7	65533
-      0x1C1C0C07,  //  001C  EQ	R7	R6	R7
-      0x781E0004,  //  001D  JMPF	R7	#0023
-      0x8C1C0907,  //  001E  GETMET	R7	R4	K7
-      0x8824090A,  //  001F  GETMBR	R9	R4	K10
-      0x542A0003,  //  0020  LDINT	R10	4
-      0x7C1C0600,  //  0021  CALL	R7	3
-      0x80040E00,  //  0022  RET	1	R7
-      0x70020007,  //  0023  JMP		#002C
-      0x601C0003,  //  0024  GETGBL	R7	G3
-      0x5C200000,  //  0025  MOVE	R8	R0
-      0x7C1C0200,  //  0026  CALL	R7	1
-      0x8C1C0F0B,  //  0027  GETMET	R7	R7	K11
-      0x5C240200,  //  0028  MOVE	R9	R1
-      0x5C280400,  //  0029  MOVE	R10	R2
-      0x7C1C0600,  //  002A  CALL	R7	3
-      0x80040E00,  //  002B  RET	1	R7
-      0x80000000,  //  002C  RET	0
+      0x541A0005,  //  0004  LDINT	R6	6
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A001B,  //  0006  JMPF	R6	#0023
+      0x8C180104,  //  0007  GETMET	R6	R0	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x1C180B05,  //  0009  EQ	R6	R5	K5
+      0x781A0005,  //  000A  JMPF	R6	#0011
+      0x8C180706,  //  000B  GETMET	R6	R3	K6
+      0x88200707,  //  000C  GETMBR	R8	R3	K7
+      0x88240108,  //  000D  GETMBR	R9	R0	K8
+      0x7C180600,  //  000E  CALL	R6	3
+      0x80040C00,  //  000F  RET	1	R6
+      0x70020010,  //  0010  JMP		#0022
+      0x541AFFFB,  //  0011  LDINT	R6	65532
+      0x1C180A06,  //  0012  EQ	R6	R5	R6
+      0x781A0005,  //  0013  JMPF	R6	#001A
+      0x8C180706,  //  0014  GETMET	R6	R3	K6
+      0x88200709,  //  0015  GETMBR	R8	R3	K9
+      0x58240005,  //  0016  LDCONST	R9	K5
+      0x7C180600,  //  0017  CALL	R6	3
+      0x80040C00,  //  0018  RET	1	R6
+      0x70020007,  //  0019  JMP		#0022
+      0x541AFFFC,  //  001A  LDINT	R6	65533
+      0x1C180A06,  //  001B  EQ	R6	R5	R6
+      0x781A0004,  //  001C  JMPF	R6	#0022
+      0x8C180706,  //  001D  GETMET	R6	R3	K6
+      0x88200709,  //  001E  GETMBR	R8	R3	K9
+      0x54260003,  //  001F  LDINT	R9	4
+      0x7C180600,  //  0020  CALL	R6	3
+      0x80040C00,  //  0021  RET	1	R6
+      0x70020007,  //  0022  JMP		#002B
+      0x60180003,  //  0023  GETGBL	R6	G3
+      0x5C1C0000,  //  0024  MOVE	R7	R0
+      0x7C180200,  //  0025  CALL	R6	1
+      0x8C180D0A,  //  0026  GETMET	R6	R6	K10
+      0x5C200200,  //  0027  MOVE	R8	R1
+      0x5C240400,  //  0028  MOVE	R9	R2
+      0x7C180600,  //  0029  CALL	R6	3
+      0x80040C00,  //  002A  RET	1	R6
+      0x80000000,  //  002B  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Pressure.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Pressure.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Plugin_Sensor_Pressure;
 ********************************************************************/
 be_local_closure(Matter_Plugin_Sensor_Pressure_read_attribute,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,97 +19,95 @@ be_local_closure(Matter_Plugin_Sensor_Pressure_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_value),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(I2),
-    /* K9   */  be_nested_str_weak(NULL),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(U4),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(shadow_value),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(I2),
+    /* K8   */  be_nested_str_weak(NULL),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[71]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[70]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0402,  //  0005  LDINT	R7	1027
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0035,  //  0007  JMPF	R7	#003E
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E0011,  //  0009  JMPF	R7	#001C
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x4C200000,  //  000B  LDNIL	R8
-      0x201C0E08,  //  000C  NE	R7	R7	R8
-      0x781E0007,  //  000D  JMPF	R7	#0016
-      0x8C1C0907,  //  000E  GETMET	R7	R4	K7
-      0x88240908,  //  000F  GETMBR	R9	R4	K8
-      0x60280009,  //  0010  GETGBL	R10	G9
-      0x882C0106,  //  0011  GETMBR	R11	R0	K6
-      0x7C280200,  //  0012  CALL	R10	1
-      0x7C1C0600,  //  0013  CALL	R7	3
-      0x80040E00,  //  0014  RET	1	R7
-      0x70020004,  //  0015  JMP		#001B
-      0x8C1C0907,  //  0016  GETMET	R7	R4	K7
-      0x88240909,  //  0017  GETMBR	R9	R4	K9
-      0x4C280000,  //  0018  LDNIL	R10
-      0x7C1C0600,  //  0019  CALL	R7	3
-      0x80040E00,  //  001A  RET	1	R7
-      0x70020020,  //  001B  JMP		#003D
-      0x1C1C0D0A,  //  001C  EQ	R7	R6	K10
-      0x781E0005,  //  001D  JMPF	R7	#0024
-      0x8C1C0907,  //  001E  GETMET	R7	R4	K7
-      0x88240908,  //  001F  GETMBR	R9	R4	K8
-      0x542A01F3,  //  0020  LDINT	R10	500
-      0x7C1C0600,  //  0021  CALL	R7	3
-      0x80040E00,  //  0022  RET	1	R7
-      0x70020018,  //  0023  JMP		#003D
-      0x1C1C0D0B,  //  0024  EQ	R7	R6	K11
-      0x781E0005,  //  0025  JMPF	R7	#002C
-      0x8C1C0907,  //  0026  GETMET	R7	R4	K7
-      0x88240908,  //  0027  GETMBR	R9	R4	K8
-      0x542A05DB,  //  0028  LDINT	R10	1500
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x80040E00,  //  002A  RET	1	R7
-      0x70020010,  //  002B  JMP		#003D
-      0x541EFFFB,  //  002C  LDINT	R7	65532
-      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
-      0x781E0005,  //  002E  JMPF	R7	#0035
-      0x8C1C0907,  //  002F  GETMET	R7	R4	K7
-      0x8824090C,  //  0030  GETMBR	R9	R4	K12
-      0x58280005,  //  0031  LDCONST	R10	K5
-      0x7C1C0600,  //  0032  CALL	R7	3
-      0x80040E00,  //  0033  RET	1	R7
-      0x70020007,  //  0034  JMP		#003D
-      0x541EFFFC,  //  0035  LDINT	R7	65533
-      0x1C1C0C07,  //  0036  EQ	R7	R6	R7
-      0x781E0004,  //  0037  JMPF	R7	#003D
-      0x8C1C0907,  //  0038  GETMET	R7	R4	K7
-      0x8824090C,  //  0039  GETMBR	R9	R4	K12
-      0x5828000D,  //  003A  LDCONST	R10	K13
-      0x7C1C0600,  //  003B  CALL	R7	3
-      0x80040E00,  //  003C  RET	1	R7
-      0x70020007,  //  003D  JMP		#0046
-      0x601C0003,  //  003E  GETGBL	R7	G3
-      0x5C200000,  //  003F  MOVE	R8	R0
-      0x7C1C0200,  //  0040  CALL	R7	1
-      0x8C1C0F0E,  //  0041  GETMET	R7	R7	K14
-      0x5C240200,  //  0042  MOVE	R9	R1
-      0x5C280400,  //  0043  MOVE	R10	R2
-      0x7C1C0600,  //  0044  CALL	R7	3
-      0x80040E00,  //  0045  RET	1	R7
-      0x80000000,  //  0046  RET	0
+      0x541A0402,  //  0004  LDINT	R6	1027
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0035,  //  0006  JMPF	R6	#003D
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A0011,  //  0008  JMPF	R6	#001B
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x20180C07,  //  000B  NE	R6	R6	R7
+      0x781A0007,  //  000C  JMPF	R6	#0015
+      0x8C180706,  //  000D  GETMET	R6	R3	K6
+      0x88200707,  //  000E  GETMBR	R8	R3	K7
+      0x60240009,  //  000F  GETGBL	R9	G9
+      0x88280105,  //  0010  GETMBR	R10	R0	K5
+      0x7C240200,  //  0011  CALL	R9	1
+      0x7C180600,  //  0012  CALL	R6	3
+      0x80040C00,  //  0013  RET	1	R6
+      0x70020004,  //  0014  JMP		#001A
+      0x8C180706,  //  0015  GETMET	R6	R3	K6
+      0x88200708,  //  0016  GETMBR	R8	R3	K8
+      0x4C240000,  //  0017  LDNIL	R9
+      0x7C180600,  //  0018  CALL	R6	3
+      0x80040C00,  //  0019  RET	1	R6
+      0x70020020,  //  001A  JMP		#003C
+      0x1C180B09,  //  001B  EQ	R6	R5	K9
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C180706,  //  001D  GETMET	R6	R3	K6
+      0x88200707,  //  001E  GETMBR	R8	R3	K7
+      0x542601F3,  //  001F  LDINT	R9	500
+      0x7C180600,  //  0020  CALL	R6	3
+      0x80040C00,  //  0021  RET	1	R6
+      0x70020018,  //  0022  JMP		#003C
+      0x1C180B0A,  //  0023  EQ	R6	R5	K10
+      0x781A0005,  //  0024  JMPF	R6	#002B
+      0x8C180706,  //  0025  GETMET	R6	R3	K6
+      0x88200707,  //  0026  GETMBR	R8	R3	K7
+      0x542605DB,  //  0027  LDINT	R9	1500
+      0x7C180600,  //  0028  CALL	R6	3
+      0x80040C00,  //  0029  RET	1	R6
+      0x70020010,  //  002A  JMP		#003C
+      0x541AFFFB,  //  002B  LDINT	R6	65532
+      0x1C180A06,  //  002C  EQ	R6	R5	R6
+      0x781A0005,  //  002D  JMPF	R6	#0034
+      0x8C180706,  //  002E  GETMET	R6	R3	K6
+      0x8820070B,  //  002F  GETMBR	R8	R3	K11
+      0x58240004,  //  0030  LDCONST	R9	K4
+      0x7C180600,  //  0031  CALL	R6	3
+      0x80040C00,  //  0032  RET	1	R6
+      0x70020007,  //  0033  JMP		#003C
+      0x541AFFFC,  //  0034  LDINT	R6	65533
+      0x1C180A06,  //  0035  EQ	R6	R5	R6
+      0x781A0004,  //  0036  JMPF	R6	#003C
+      0x8C180706,  //  0037  GETMET	R6	R3	K6
+      0x8820070B,  //  0038  GETMBR	R8	R3	K11
+      0x5824000C,  //  0039  LDCONST	R9	K12
+      0x7C180600,  //  003A  CALL	R6	3
+      0x80040C00,  //  003B  RET	1	R6
+      0x70020007,  //  003C  JMP		#0045
+      0x60180003,  //  003D  GETGBL	R6	G3
+      0x5C1C0000,  //  003E  MOVE	R7	R0
+      0x7C180200,  //  003F  CALL	R6	1
+      0x8C180D0D,  //  0040  GETMET	R6	R6	K13
+      0x5C200200,  //  0041  MOVE	R8	R1
+      0x5C240400,  //  0042  MOVE	R9	R2
+      0x7C180600,  //  0043  CALL	R6	3
+      0x80040C00,  //  0044  RET	1	R6
+      0x80000000,  //  0045  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Temp.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Temp.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Plugin_Sensor_Temp;
 ********************************************************************/
 be_local_closure(Matter_Plugin_Sensor_Temp_read_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,94 +19,92 @@ be_local_closure(Matter_Plugin_Sensor_Temp_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(shadow_value),
-    /* K7   */  be_nested_str_weak(create_TLV),
-    /* K8   */  be_nested_str_weak(I2),
-    /* K9   */  be_nested_str_weak(NULL),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(U4),
-    /* K13  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(shadow_value),
+    /* K6   */  be_nested_str_weak(create_TLV),
+    /* K7   */  be_nested_str_weak(I2),
+    /* K8   */  be_nested_str_weak(NULL),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(U4),
+    /* K12  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[69]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[68]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0401,  //  0005  LDINT	R7	1026
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0033,  //  0007  JMPF	R7	#003C
-      0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E000F,  //  0009  JMPF	R7	#001A
-      0x881C0106,  //  000A  GETMBR	R7	R0	K6
-      0x4C200000,  //  000B  LDNIL	R8
-      0x201C0E08,  //  000C  NE	R7	R7	R8
-      0x781E0005,  //  000D  JMPF	R7	#0014
-      0x8C1C0907,  //  000E  GETMET	R7	R4	K7
-      0x88240908,  //  000F  GETMBR	R9	R4	K8
-      0x88280106,  //  0010  GETMBR	R10	R0	K6
-      0x7C1C0600,  //  0011  CALL	R7	3
-      0x80040E00,  //  0012  RET	1	R7
-      0x70020004,  //  0013  JMP		#0019
-      0x8C1C0907,  //  0014  GETMET	R7	R4	K7
-      0x88240909,  //  0015  GETMBR	R9	R4	K9
-      0x4C280000,  //  0016  LDNIL	R10
-      0x7C1C0600,  //  0017  CALL	R7	3
-      0x80040E00,  //  0018  RET	1	R7
-      0x70020020,  //  0019  JMP		#003B
-      0x1C1C0D0A,  //  001A  EQ	R7	R6	K10
-      0x781E0005,  //  001B  JMPF	R7	#0022
-      0x8C1C0907,  //  001C  GETMET	R7	R4	K7
-      0x88240908,  //  001D  GETMBR	R9	R4	K8
-      0x5429EC77,  //  001E  LDINT	R10	-5000
-      0x7C1C0600,  //  001F  CALL	R7	3
-      0x80040E00,  //  0020  RET	1	R7
-      0x70020018,  //  0021  JMP		#003B
-      0x1C1C0D0B,  //  0022  EQ	R7	R6	K11
-      0x781E0005,  //  0023  JMPF	R7	#002A
-      0x8C1C0907,  //  0024  GETMET	R7	R4	K7
-      0x88240908,  //  0025  GETMBR	R9	R4	K8
-      0x542A3A97,  //  0026  LDINT	R10	15000
-      0x7C1C0600,  //  0027  CALL	R7	3
-      0x80040E00,  //  0028  RET	1	R7
-      0x70020010,  //  0029  JMP		#003B
-      0x541EFFFB,  //  002A  LDINT	R7	65532
-      0x1C1C0C07,  //  002B  EQ	R7	R6	R7
-      0x781E0005,  //  002C  JMPF	R7	#0033
-      0x8C1C0907,  //  002D  GETMET	R7	R4	K7
-      0x8824090C,  //  002E  GETMBR	R9	R4	K12
-      0x58280005,  //  002F  LDCONST	R10	K5
-      0x7C1C0600,  //  0030  CALL	R7	3
-      0x80040E00,  //  0031  RET	1	R7
-      0x70020007,  //  0032  JMP		#003B
-      0x541EFFFC,  //  0033  LDINT	R7	65533
-      0x1C1C0C07,  //  0034  EQ	R7	R6	R7
-      0x781E0004,  //  0035  JMPF	R7	#003B
-      0x8C1C0907,  //  0036  GETMET	R7	R4	K7
-      0x8824090C,  //  0037  GETMBR	R9	R4	K12
-      0x542A0003,  //  0038  LDINT	R10	4
-      0x7C1C0600,  //  0039  CALL	R7	3
-      0x80040E00,  //  003A  RET	1	R7
-      0x70020007,  //  003B  JMP		#0044
-      0x601C0003,  //  003C  GETGBL	R7	G3
-      0x5C200000,  //  003D  MOVE	R8	R0
-      0x7C1C0200,  //  003E  CALL	R7	1
-      0x8C1C0F0D,  //  003F  GETMET	R7	R7	K13
-      0x5C240200,  //  0040  MOVE	R9	R1
-      0x5C280400,  //  0041  MOVE	R10	R2
-      0x7C1C0600,  //  0042  CALL	R7	3
-      0x80040E00,  //  0043  RET	1	R7
-      0x80000000,  //  0044  RET	0
+      0x541A0401,  //  0004  LDINT	R6	1026
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0033,  //  0006  JMPF	R6	#003B
+      0x1C180B04,  //  0007  EQ	R6	R5	K4
+      0x781A000F,  //  0008  JMPF	R6	#0019
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x20180C07,  //  000B  NE	R6	R6	R7
+      0x781A0005,  //  000C  JMPF	R6	#0013
+      0x8C180706,  //  000D  GETMET	R6	R3	K6
+      0x88200707,  //  000E  GETMBR	R8	R3	K7
+      0x88240105,  //  000F  GETMBR	R9	R0	K5
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80040C00,  //  0011  RET	1	R6
+      0x70020004,  //  0012  JMP		#0018
+      0x8C180706,  //  0013  GETMET	R6	R3	K6
+      0x88200708,  //  0014  GETMBR	R8	R3	K8
+      0x4C240000,  //  0015  LDNIL	R9
+      0x7C180600,  //  0016  CALL	R6	3
+      0x80040C00,  //  0017  RET	1	R6
+      0x70020020,  //  0018  JMP		#003A
+      0x1C180B09,  //  0019  EQ	R6	R5	K9
+      0x781A0005,  //  001A  JMPF	R6	#0021
+      0x8C180706,  //  001B  GETMET	R6	R3	K6
+      0x88200707,  //  001C  GETMBR	R8	R3	K7
+      0x5425EC77,  //  001D  LDINT	R9	-5000
+      0x7C180600,  //  001E  CALL	R6	3
+      0x80040C00,  //  001F  RET	1	R6
+      0x70020018,  //  0020  JMP		#003A
+      0x1C180B0A,  //  0021  EQ	R6	R5	K10
+      0x781A0005,  //  0022  JMPF	R6	#0029
+      0x8C180706,  //  0023  GETMET	R6	R3	K6
+      0x88200707,  //  0024  GETMBR	R8	R3	K7
+      0x54263A97,  //  0025  LDINT	R9	15000
+      0x7C180600,  //  0026  CALL	R6	3
+      0x80040C00,  //  0027  RET	1	R6
+      0x70020010,  //  0028  JMP		#003A
+      0x541AFFFB,  //  0029  LDINT	R6	65532
+      0x1C180A06,  //  002A  EQ	R6	R5	R6
+      0x781A0005,  //  002B  JMPF	R6	#0032
+      0x8C180706,  //  002C  GETMET	R6	R3	K6
+      0x8820070B,  //  002D  GETMBR	R8	R3	K11
+      0x58240004,  //  002E  LDCONST	R9	K4
+      0x7C180600,  //  002F  CALL	R6	3
+      0x80040C00,  //  0030  RET	1	R6
+      0x70020007,  //  0031  JMP		#003A
+      0x541AFFFC,  //  0032  LDINT	R6	65533
+      0x1C180A06,  //  0033  EQ	R6	R5	R6
+      0x781A0004,  //  0034  JMPF	R6	#003A
+      0x8C180706,  //  0035  GETMET	R6	R3	K6
+      0x8820070B,  //  0036  GETMBR	R8	R3	K11
+      0x54260003,  //  0037  LDINT	R9	4
+      0x7C180600,  //  0038  CALL	R6	3
+      0x80040C00,  //  0039  RET	1	R6
+      0x70020007,  //  003A  JMP		#0043
+      0x60180003,  //  003B  GETGBL	R6	G3
+      0x5C1C0000,  //  003C  MOVE	R7	R0
+      0x7C180200,  //  003D  CALL	R6	1
+      0x8C180D0C,  //  003E  GETMET	R6	R6	K12
+      0x5C200200,  //  003F  MOVE	R8	R1
+      0x5C240400,  //  0040  MOVE	R9	R2
+      0x7C180600,  //  0041  CALL	R6	3
+      0x80040C00,  //  0042  RET	1	R6
+      0x80000000,  //  0043  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Shutter.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Shutter.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Plugin_Shutter;
 ********************************************************************/
 be_local_closure(Matter_Plugin_Shutter_read_attribute,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    12,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,182 +19,180 @@ be_local_closure(Matter_Plugin_Shutter_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_nested_str_weak(update_inverted),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(create_TLV),
-    /* K9   */  be_nested_str_weak(U1),
-    /* K10  */  be_nested_str_weak(U2),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(shadow_shutter_inverted),
-    /* K13  */  be_nested_str_weak(shadow_shutter_pos),
-    /* K14  */  be_nested_str_weak(shadow_shutter_direction),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_nested_str_weak(shadow_shutter_target),
-    /* K17  */  be_nested_str_weak(U4),
-    /* K18  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_nested_str_weak(update_inverted),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(create_TLV),
+    /* K8   */  be_nested_str_weak(U1),
+    /* K9   */  be_nested_str_weak(U2),
+    /* K10  */  be_const_int(1),
+    /* K11  */  be_nested_str_weak(shadow_shutter_inverted),
+    /* K12  */  be_nested_str_weak(shadow_shutter_pos),
+    /* K13  */  be_nested_str_weak(shadow_shutter_direction),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(shadow_shutter_target),
+    /* K16  */  be_nested_str_weak(U4),
+    /* K17  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[152]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[151]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x4C1C0000,  //  0005  LDNIL	R7
-      0x54220101,  //  0006  LDINT	R8	258
-      0x1C200A08,  //  0007  EQ	R8	R5	R8
-      0x78220085,  //  0008  JMPF	R8	#008F
-      0x8C200105,  //  0009  GETMET	R8	R0	K5
-      0x7C200200,  //  000A  CALL	R8	1
-      0x8C200106,  //  000B  GETMET	R8	R0	K6
-      0x7C200200,  //  000C  CALL	R8	1
-      0x1C200D07,  //  000D  EQ	R8	R6	K7
-      0x78220005,  //  000E  JMPF	R8	#0015
-      0x8C200908,  //  000F  GETMET	R8	R4	K8
-      0x88280909,  //  0010  GETMBR	R10	R4	K9
-      0x542E00FE,  //  0011  LDINT	R11	255
-      0x7C200600,  //  0012  CALL	R8	3
-      0x80041000,  //  0013  RET	1	R8
-      0x70020078,  //  0014  JMP		#008E
-      0x54220004,  //  0015  LDINT	R8	5
-      0x1C200C08,  //  0016  EQ	R8	R6	R8
-      0x78220005,  //  0017  JMPF	R8	#001E
-      0x8C200908,  //  0018  GETMET	R8	R4	K8
-      0x8828090A,  //  0019  GETMBR	R10	R4	K10
-      0x582C0007,  //  001A  LDCONST	R11	K7
-      0x7C200600,  //  001B  CALL	R8	3
-      0x80041000,  //  001C  RET	1	R8
-      0x7002006F,  //  001D  JMP		#008E
-      0x54220006,  //  001E  LDINT	R8	7
-      0x1C200C08,  //  001F  EQ	R8	R6	R8
-      0x78220006,  //  0020  JMPF	R8	#0028
-      0x8C200908,  //  0021  GETMET	R8	R4	K8
-      0x88280909,  //  0022  GETMBR	R10	R4	K9
-      0x542E0007,  //  0023  LDINT	R11	8
-      0x002E160B,  //  0024  ADD	R11	K11	R11
-      0x7C200600,  //  0025  CALL	R8	3
-      0x80041000,  //  0026  RET	1	R8
-      0x70020065,  //  0027  JMP		#008E
-      0x5422000C,  //  0028  LDINT	R8	13
-      0x1C200C08,  //  0029  EQ	R8	R6	R8
-      0x78220005,  //  002A  JMPF	R8	#0031
-      0x8C200908,  //  002B  GETMET	R8	R4	K8
-      0x88280909,  //  002C  GETMBR	R10	R4	K9
-      0x542E00FE,  //  002D  LDINT	R11	255
-      0x7C200600,  //  002E  CALL	R8	3
-      0x80041000,  //  002F  RET	1	R8
-      0x7002005C,  //  0030  JMP		#008E
-      0x5422000D,  //  0031  LDINT	R8	14
-      0x1C200C08,  //  0032  EQ	R8	R6	R8
-      0x78220013,  //  0033  JMPF	R8	#0048
-      0x8820010C,  //  0034  GETMBR	R8	R0	K12
-      0x1C201107,  //  0035  EQ	R8	R8	K7
-      0x78220006,  //  0036  JMPF	R8	#003E
-      0x54220063,  //  0037  LDINT	R8	100
-      0x8824010D,  //  0038  GETMBR	R9	R0	K13
-      0x04201009,  //  0039  SUB	R8	R8	R9
-      0x54260063,  //  003A  LDINT	R9	100
-      0x08201009,  //  003B  MUL	R8	R8	R9
-      0x5C1C1000,  //  003C  MOVE	R7	R8
-      0x70020003,  //  003D  JMP		#0042
-      0x8820010D,  //  003E  GETMBR	R8	R0	K13
-      0x54260063,  //  003F  LDINT	R9	100
-      0x08201009,  //  0040  MUL	R8	R8	R9
-      0x5C1C1000,  //  0041  MOVE	R7	R8
-      0x8C200908,  //  0042  GETMET	R8	R4	K8
-      0x8828090A,  //  0043  GETMBR	R10	R4	K10
-      0x5C2C0E00,  //  0044  MOVE	R11	R7
-      0x7C200600,  //  0045  CALL	R8	3
-      0x80041000,  //  0046  RET	1	R8
-      0x70020045,  //  0047  JMP		#008E
-      0x54220009,  //  0048  LDINT	R8	10
-      0x1C200C08,  //  0049  EQ	R8	R6	R8
-      0x78220010,  //  004A  JMPF	R8	#005C
-      0x8820010E,  //  004B  GETMBR	R8	R0	K14
-      0x1C201107,  //  004C  EQ	R8	R8	K7
-      0x78220001,  //  004D  JMPF	R8	#0050
-      0x58200007,  //  004E  LDCONST	R8	K7
-      0x70020005,  //  004F  JMP		#0056
-      0x8820010E,  //  0050  GETMBR	R8	R0	K14
-      0x24201107,  //  0051  GT	R8	R8	K7
-      0x78220001,  //  0052  JMPF	R8	#0055
-      0x5820000B,  //  0053  LDCONST	R8	K11
-      0x70020000,  //  0054  JMP		#0056
-      0x5820000F,  //  0055  LDCONST	R8	K15
-      0x8C240908,  //  0056  GETMET	R9	R4	K8
-      0x882C0909,  //  0057  GETMBR	R11	R4	K9
-      0x5C301000,  //  0058  MOVE	R12	R8
-      0x7C240600,  //  0059  CALL	R9	3
-      0x80041200,  //  005A  RET	1	R9
-      0x70020031,  //  005B  JMP		#008E
-      0x5422000A,  //  005C  LDINT	R8	11
-      0x1C200C08,  //  005D  EQ	R8	R6	R8
-      0x78220013,  //  005E  JMPF	R8	#0073
-      0x8820010C,  //  005F  GETMBR	R8	R0	K12
-      0x1C201107,  //  0060  EQ	R8	R8	K7
-      0x78220006,  //  0061  JMPF	R8	#0069
-      0x54220063,  //  0062  LDINT	R8	100
-      0x88240110,  //  0063  GETMBR	R9	R0	K16
-      0x04201009,  //  0064  SUB	R8	R8	R9
-      0x54260063,  //  0065  LDINT	R9	100
-      0x08201009,  //  0066  MUL	R8	R8	R9
-      0x5C1C1000,  //  0067  MOVE	R7	R8
-      0x70020003,  //  0068  JMP		#006D
-      0x88200110,  //  0069  GETMBR	R8	R0	K16
-      0x54260063,  //  006A  LDINT	R9	100
-      0x08201009,  //  006B  MUL	R8	R8	R9
-      0x5C1C1000,  //  006C  MOVE	R7	R8
-      0x8C200908,  //  006D  GETMET	R8	R4	K8
-      0x8828090A,  //  006E  GETMBR	R10	R4	K10
-      0x5C2C0E00,  //  006F  MOVE	R11	R7
-      0x7C200600,  //  0070  CALL	R8	3
-      0x80041000,  //  0071  RET	1	R8
-      0x7002001A,  //  0072  JMP		#008E
-      0x54220016,  //  0073  LDINT	R8	23
-      0x1C200C08,  //  0074  EQ	R8	R6	R8
-      0x78220005,  //  0075  JMPF	R8	#007C
-      0x8C200908,  //  0076  GETMET	R8	R4	K8
-      0x88280909,  //  0077  GETMBR	R10	R4	K9
-      0x582C0007,  //  0078  LDCONST	R11	K7
-      0x7C200600,  //  0079  CALL	R8	3
-      0x80041000,  //  007A  RET	1	R8
-      0x70020011,  //  007B  JMP		#008E
-      0x5422FFFB,  //  007C  LDINT	R8	65532
-      0x1C200C08,  //  007D  EQ	R8	R6	R8
-      0x78220006,  //  007E  JMPF	R8	#0086
-      0x8C200908,  //  007F  GETMET	R8	R4	K8
-      0x88280911,  //  0080  GETMBR	R10	R4	K17
-      0x542E0003,  //  0081  LDINT	R11	4
-      0x002E160B,  //  0082  ADD	R11	K11	R11
-      0x7C200600,  //  0083  CALL	R8	3
-      0x80041000,  //  0084  RET	1	R8
-      0x70020007,  //  0085  JMP		#008E
-      0x5422FFFC,  //  0086  LDINT	R8	65533
-      0x1C200C08,  //  0087  EQ	R8	R6	R8
-      0x78220004,  //  0088  JMPF	R8	#008E
-      0x8C200908,  //  0089  GETMET	R8	R4	K8
-      0x88280911,  //  008A  GETMBR	R10	R4	K17
-      0x542E0004,  //  008B  LDINT	R11	5
-      0x7C200600,  //  008C  CALL	R8	3
-      0x80041000,  //  008D  RET	1	R8
-      0x70020007,  //  008E  JMP		#0097
-      0x60200003,  //  008F  GETGBL	R8	G3
-      0x5C240000,  //  0090  MOVE	R9	R0
-      0x7C200200,  //  0091  CALL	R8	1
-      0x8C201112,  //  0092  GETMET	R8	R8	K18
-      0x5C280200,  //  0093  MOVE	R10	R1
-      0x5C2C0400,  //  0094  MOVE	R11	R2
-      0x7C200600,  //  0095  CALL	R8	3
-      0x80041000,  //  0096  RET	1	R8
-      0x80000000,  //  0097  RET	0
+      0x4C180000,  //  0004  LDNIL	R6
+      0x541E0101,  //  0005  LDINT	R7	258
+      0x1C1C0807,  //  0006  EQ	R7	R4	R7
+      0x781E0085,  //  0007  JMPF	R7	#008E
+      0x8C1C0104,  //  0008  GETMET	R7	R0	K4
+      0x7C1C0200,  //  0009  CALL	R7	1
+      0x8C1C0105,  //  000A  GETMET	R7	R0	K5
+      0x7C1C0200,  //  000B  CALL	R7	1
+      0x1C1C0B06,  //  000C  EQ	R7	R5	K6
+      0x781E0005,  //  000D  JMPF	R7	#0014
+      0x8C1C0707,  //  000E  GETMET	R7	R3	K7
+      0x88240708,  //  000F  GETMBR	R9	R3	K8
+      0x542A00FE,  //  0010  LDINT	R10	255
+      0x7C1C0600,  //  0011  CALL	R7	3
+      0x80040E00,  //  0012  RET	1	R7
+      0x70020078,  //  0013  JMP		#008D
+      0x541E0004,  //  0014  LDINT	R7	5
+      0x1C1C0A07,  //  0015  EQ	R7	R5	R7
+      0x781E0005,  //  0016  JMPF	R7	#001D
+      0x8C1C0707,  //  0017  GETMET	R7	R3	K7
+      0x88240709,  //  0018  GETMBR	R9	R3	K9
+      0x58280006,  //  0019  LDCONST	R10	K6
+      0x7C1C0600,  //  001A  CALL	R7	3
+      0x80040E00,  //  001B  RET	1	R7
+      0x7002006F,  //  001C  JMP		#008D
+      0x541E0006,  //  001D  LDINT	R7	7
+      0x1C1C0A07,  //  001E  EQ	R7	R5	R7
+      0x781E0006,  //  001F  JMPF	R7	#0027
+      0x8C1C0707,  //  0020  GETMET	R7	R3	K7
+      0x88240708,  //  0021  GETMBR	R9	R3	K8
+      0x542A0007,  //  0022  LDINT	R10	8
+      0x002A140A,  //  0023  ADD	R10	K10	R10
+      0x7C1C0600,  //  0024  CALL	R7	3
+      0x80040E00,  //  0025  RET	1	R7
+      0x70020065,  //  0026  JMP		#008D
+      0x541E000C,  //  0027  LDINT	R7	13
+      0x1C1C0A07,  //  0028  EQ	R7	R5	R7
+      0x781E0005,  //  0029  JMPF	R7	#0030
+      0x8C1C0707,  //  002A  GETMET	R7	R3	K7
+      0x88240708,  //  002B  GETMBR	R9	R3	K8
+      0x542A00FE,  //  002C  LDINT	R10	255
+      0x7C1C0600,  //  002D  CALL	R7	3
+      0x80040E00,  //  002E  RET	1	R7
+      0x7002005C,  //  002F  JMP		#008D
+      0x541E000D,  //  0030  LDINT	R7	14
+      0x1C1C0A07,  //  0031  EQ	R7	R5	R7
+      0x781E0013,  //  0032  JMPF	R7	#0047
+      0x881C010B,  //  0033  GETMBR	R7	R0	K11
+      0x1C1C0F06,  //  0034  EQ	R7	R7	K6
+      0x781E0006,  //  0035  JMPF	R7	#003D
+      0x541E0063,  //  0036  LDINT	R7	100
+      0x8820010C,  //  0037  GETMBR	R8	R0	K12
+      0x041C0E08,  //  0038  SUB	R7	R7	R8
+      0x54220063,  //  0039  LDINT	R8	100
+      0x081C0E08,  //  003A  MUL	R7	R7	R8
+      0x5C180E00,  //  003B  MOVE	R6	R7
+      0x70020003,  //  003C  JMP		#0041
+      0x881C010C,  //  003D  GETMBR	R7	R0	K12
+      0x54220063,  //  003E  LDINT	R8	100
+      0x081C0E08,  //  003F  MUL	R7	R7	R8
+      0x5C180E00,  //  0040  MOVE	R6	R7
+      0x8C1C0707,  //  0041  GETMET	R7	R3	K7
+      0x88240709,  //  0042  GETMBR	R9	R3	K9
+      0x5C280C00,  //  0043  MOVE	R10	R6
+      0x7C1C0600,  //  0044  CALL	R7	3
+      0x80040E00,  //  0045  RET	1	R7
+      0x70020045,  //  0046  JMP		#008D
+      0x541E0009,  //  0047  LDINT	R7	10
+      0x1C1C0A07,  //  0048  EQ	R7	R5	R7
+      0x781E0010,  //  0049  JMPF	R7	#005B
+      0x881C010D,  //  004A  GETMBR	R7	R0	K13
+      0x1C1C0F06,  //  004B  EQ	R7	R7	K6
+      0x781E0001,  //  004C  JMPF	R7	#004F
+      0x581C0006,  //  004D  LDCONST	R7	K6
+      0x70020005,  //  004E  JMP		#0055
+      0x881C010D,  //  004F  GETMBR	R7	R0	K13
+      0x241C0F06,  //  0050  GT	R7	R7	K6
+      0x781E0001,  //  0051  JMPF	R7	#0054
+      0x581C000A,  //  0052  LDCONST	R7	K10
+      0x70020000,  //  0053  JMP		#0055
+      0x581C000E,  //  0054  LDCONST	R7	K14
+      0x8C200707,  //  0055  GETMET	R8	R3	K7
+      0x88280708,  //  0056  GETMBR	R10	R3	K8
+      0x5C2C0E00,  //  0057  MOVE	R11	R7
+      0x7C200600,  //  0058  CALL	R8	3
+      0x80041000,  //  0059  RET	1	R8
+      0x70020031,  //  005A  JMP		#008D
+      0x541E000A,  //  005B  LDINT	R7	11
+      0x1C1C0A07,  //  005C  EQ	R7	R5	R7
+      0x781E0013,  //  005D  JMPF	R7	#0072
+      0x881C010B,  //  005E  GETMBR	R7	R0	K11
+      0x1C1C0F06,  //  005F  EQ	R7	R7	K6
+      0x781E0006,  //  0060  JMPF	R7	#0068
+      0x541E0063,  //  0061  LDINT	R7	100
+      0x8820010F,  //  0062  GETMBR	R8	R0	K15
+      0x041C0E08,  //  0063  SUB	R7	R7	R8
+      0x54220063,  //  0064  LDINT	R8	100
+      0x081C0E08,  //  0065  MUL	R7	R7	R8
+      0x5C180E00,  //  0066  MOVE	R6	R7
+      0x70020003,  //  0067  JMP		#006C
+      0x881C010F,  //  0068  GETMBR	R7	R0	K15
+      0x54220063,  //  0069  LDINT	R8	100
+      0x081C0E08,  //  006A  MUL	R7	R7	R8
+      0x5C180E00,  //  006B  MOVE	R6	R7
+      0x8C1C0707,  //  006C  GETMET	R7	R3	K7
+      0x88240709,  //  006D  GETMBR	R9	R3	K9
+      0x5C280C00,  //  006E  MOVE	R10	R6
+      0x7C1C0600,  //  006F  CALL	R7	3
+      0x80040E00,  //  0070  RET	1	R7
+      0x7002001A,  //  0071  JMP		#008D
+      0x541E0016,  //  0072  LDINT	R7	23
+      0x1C1C0A07,  //  0073  EQ	R7	R5	R7
+      0x781E0005,  //  0074  JMPF	R7	#007B
+      0x8C1C0707,  //  0075  GETMET	R7	R3	K7
+      0x88240708,  //  0076  GETMBR	R9	R3	K8
+      0x58280006,  //  0077  LDCONST	R10	K6
+      0x7C1C0600,  //  0078  CALL	R7	3
+      0x80040E00,  //  0079  RET	1	R7
+      0x70020011,  //  007A  JMP		#008D
+      0x541EFFFB,  //  007B  LDINT	R7	65532
+      0x1C1C0A07,  //  007C  EQ	R7	R5	R7
+      0x781E0006,  //  007D  JMPF	R7	#0085
+      0x8C1C0707,  //  007E  GETMET	R7	R3	K7
+      0x88240710,  //  007F  GETMBR	R9	R3	K16
+      0x542A0003,  //  0080  LDINT	R10	4
+      0x002A140A,  //  0081  ADD	R10	K10	R10
+      0x7C1C0600,  //  0082  CALL	R7	3
+      0x80040E00,  //  0083  RET	1	R7
+      0x70020007,  //  0084  JMP		#008D
+      0x541EFFFC,  //  0085  LDINT	R7	65533
+      0x1C1C0A07,  //  0086  EQ	R7	R5	R7
+      0x781E0004,  //  0087  JMPF	R7	#008D
+      0x8C1C0707,  //  0088  GETMET	R7	R3	K7
+      0x88240710,  //  0089  GETMBR	R9	R3	K16
+      0x542A0004,  //  008A  LDINT	R10	5
+      0x7C1C0600,  //  008B  CALL	R7	3
+      0x80040E00,  //  008C  RET	1	R7
+      0x70020007,  //  008D  JMP		#0096
+      0x601C0003,  //  008E  GETGBL	R7	G3
+      0x5C200000,  //  008F  MOVE	R8	R0
+      0x7C1C0200,  //  0090  CALL	R7	1
+      0x8C1C0F11,  //  0091  GETMET	R7	R7	K17
+      0x5C240200,  //  0092  MOVE	R9	R1
+      0x5C280400,  //  0093  MOVE	R10	R2
+      0x7C1C0600,  //  0094  CALL	R7	3
+      0x80040E00,  //  0095  RET	1	R7
+      0x80000000,  //  0096  RET	0
     })
   )
 );
@@ -206,7 +204,7 @@ be_local_closure(Matter_Plugin_Shutter_read_attribute,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Shutter_parse_sensors,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -214,78 +212,76 @@ be_local_closure(Matter_Plugin_Shutter_parse_sensors,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(Shutter),
-    /* K2   */  be_nested_str_weak(tasmota_shutter_index),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(contains),
-    /* K5   */  be_nested_str_weak(find),
-    /* K6   */  be_nested_str_weak(Position),
-    /* K7   */  be_nested_str_weak(shadow_shutter_pos),
-    /* K8   */  be_nested_str_weak(attribute_updated),
-    /* K9   */  be_nested_str_weak(Direction),
-    /* K10  */  be_nested_str_weak(shadow_shutter_direction),
-    /* K11  */  be_nested_str_weak(Target),
-    /* K12  */  be_nested_str_weak(shadow_shutter_target),
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(Shutter),
+    /* K1   */  be_nested_str_weak(tasmota_shutter_index),
+    /* K2   */  be_const_int(1),
+    /* K3   */  be_nested_str_weak(contains),
+    /* K4   */  be_nested_str_weak(find),
+    /* K5   */  be_nested_str_weak(Position),
+    /* K6   */  be_nested_str_weak(shadow_shutter_pos),
+    /* K7   */  be_nested_str_weak(attribute_updated),
+    /* K8   */  be_nested_str_weak(Direction),
+    /* K9   */  be_nested_str_weak(shadow_shutter_direction),
+    /* K10  */  be_nested_str_weak(Target),
+    /* K11  */  be_nested_str_weak(shadow_shutter_target),
     }),
     be_str_weak(parse_sensors),
     &be_const_str_solidified,
-    ( &(const binstruction[54]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x600C0008,  //  0001  GETGBL	R3	G8
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
-      0x00100903,  //  0003  ADD	R4	R4	K3
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x000E0203,  //  0005  ADD	R3	K1	R3
-      0x8C100304,  //  0006  GETMET	R4	R1	K4
-      0x5C180600,  //  0007  MOVE	R6	R3
-      0x7C100400,  //  0008  CALL	R4	2
-      0x7812002A,  //  0009  JMPF	R4	#0035
-      0x94100203,  //  000A  GETIDX	R4	R1	R3
-      0x8C140905,  //  000B  GETMET	R5	R4	K5
-      0x581C0006,  //  000C  LDCONST	R7	K6
-      0x7C140400,  //  000D  CALL	R5	2
-      0x4C180000,  //  000E  LDNIL	R6
-      0x20180A06,  //  000F  NE	R6	R5	R6
-      0x781A0007,  //  0010  JMPF	R6	#0019
-      0x88180107,  //  0011  GETMBR	R6	R0	K7
-      0x20180A06,  //  0012  NE	R6	R5	R6
-      0x781A0003,  //  0013  JMPF	R6	#0018
-      0x8C180108,  //  0014  GETMET	R6	R0	K8
-      0x54220101,  //  0015  LDINT	R8	258
-      0x5426000D,  //  0016  LDINT	R9	14
-      0x7C180600,  //  0017  CALL	R6	3
-      0x90020E05,  //  0018  SETMBR	R0	K7	R5
-      0x8C180905,  //  0019  GETMET	R6	R4	K5
-      0x58200009,  //  001A  LDCONST	R8	K9
-      0x7C180400,  //  001B  CALL	R6	2
-      0x4C1C0000,  //  001C  LDNIL	R7
-      0x201C0C07,  //  001D  NE	R7	R6	R7
-      0x781E0007,  //  001E  JMPF	R7	#0027
-      0x881C010A,  //  001F  GETMBR	R7	R0	K10
-      0x201C0C07,  //  0020  NE	R7	R6	R7
-      0x781E0003,  //  0021  JMPF	R7	#0026
-      0x8C1C0108,  //  0022  GETMET	R7	R0	K8
-      0x54260101,  //  0023  LDINT	R9	258
-      0x542A0009,  //  0024  LDINT	R10	10
-      0x7C1C0600,  //  0025  CALL	R7	3
-      0x90021406,  //  0026  SETMBR	R0	K10	R6
-      0x8C1C0905,  //  0027  GETMET	R7	R4	K5
-      0x5824000B,  //  0028  LDCONST	R9	K11
-      0x7C1C0400,  //  0029  CALL	R7	2
-      0x4C200000,  //  002A  LDNIL	R8
-      0x20200E08,  //  002B  NE	R8	R7	R8
-      0x78220007,  //  002C  JMPF	R8	#0035
-      0x8820010C,  //  002D  GETMBR	R8	R0	K12
-      0x20200E08,  //  002E  NE	R8	R7	R8
-      0x78220003,  //  002F  JMPF	R8	#0034
-      0x8C200108,  //  0030  GETMET	R8	R0	K8
-      0x542A0101,  //  0031  LDINT	R10	258
-      0x542E000A,  //  0032  LDINT	R11	11
-      0x7C200600,  //  0033  CALL	R8	3
-      0x90021807,  //  0034  SETMBR	R0	K12	R7
-      0x80000000,  //  0035  RET	0
+    ( &(const binstruction[53]) {  /* code */
+      0x60080008,  //  0000  GETGBL	R2	G8
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x000C0702,  //  0002  ADD	R3	R3	K2
+      0x7C080200,  //  0003  CALL	R2	1
+      0x000A0002,  //  0004  ADD	R2	K0	R2
+      0x8C0C0303,  //  0005  GETMET	R3	R1	K3
+      0x5C140400,  //  0006  MOVE	R5	R2
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x780E002A,  //  0008  JMPF	R3	#0034
+      0x940C0202,  //  0009  GETIDX	R3	R1	R2
+      0x8C100704,  //  000A  GETMET	R4	R3	K4
+      0x58180005,  //  000B  LDCONST	R6	K5
+      0x7C100400,  //  000C  CALL	R4	2
+      0x4C140000,  //  000D  LDNIL	R5
+      0x20140805,  //  000E  NE	R5	R4	R5
+      0x78160007,  //  000F  JMPF	R5	#0018
+      0x88140106,  //  0010  GETMBR	R5	R0	K6
+      0x20140805,  //  0011  NE	R5	R4	R5
+      0x78160003,  //  0012  JMPF	R5	#0017
+      0x8C140107,  //  0013  GETMET	R5	R0	K7
+      0x541E0101,  //  0014  LDINT	R7	258
+      0x5422000D,  //  0015  LDINT	R8	14
+      0x7C140600,  //  0016  CALL	R5	3
+      0x90020C04,  //  0017  SETMBR	R0	K6	R4
+      0x8C140704,  //  0018  GETMET	R5	R3	K4
+      0x581C0008,  //  0019  LDCONST	R7	K8
+      0x7C140400,  //  001A  CALL	R5	2
+      0x4C180000,  //  001B  LDNIL	R6
+      0x20180A06,  //  001C  NE	R6	R5	R6
+      0x781A0007,  //  001D  JMPF	R6	#0026
+      0x88180109,  //  001E  GETMBR	R6	R0	K9
+      0x20180A06,  //  001F  NE	R6	R5	R6
+      0x781A0003,  //  0020  JMPF	R6	#0025
+      0x8C180107,  //  0021  GETMET	R6	R0	K7
+      0x54220101,  //  0022  LDINT	R8	258
+      0x54260009,  //  0023  LDINT	R9	10
+      0x7C180600,  //  0024  CALL	R6	3
+      0x90021205,  //  0025  SETMBR	R0	K9	R5
+      0x8C180704,  //  0026  GETMET	R6	R3	K4
+      0x5820000A,  //  0027  LDCONST	R8	K10
+      0x7C180400,  //  0028  CALL	R6	2
+      0x4C1C0000,  //  0029  LDNIL	R7
+      0x201C0C07,  //  002A  NE	R7	R6	R7
+      0x781E0007,  //  002B  JMPF	R7	#0034
+      0x881C010B,  //  002C  GETMBR	R7	R0	K11
+      0x201C0C07,  //  002D  NE	R7	R6	R7
+      0x781E0003,  //  002E  JMPF	R7	#0033
+      0x8C1C0107,  //  002F  GETMET	R7	R0	K7
+      0x54260101,  //  0030  LDINT	R9	258
+      0x542A000A,  //  0031  LDINT	R10	11
+      0x7C1C0600,  //  0032  CALL	R7	3
+      0x90021606,  //  0033  SETMBR	R0	K11	R6
+      0x80000000,  //  0034  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_ShutterTilt.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_ShutterTilt.h
@@ -207,7 +207,7 @@ be_local_closure(Matter_Plugin_ShutterTilt_invoke_request,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_ShutterTilt_read_attribute,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    13,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -215,145 +215,143 @@ be_local_closure(Matter_Plugin_ShutterTilt_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(update_shadow_lazy),
-    /* K6   */  be_nested_str_weak(create_TLV),
-    /* K7   */  be_nested_str_weak(U1),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(update_tilt_min_max),
-    /* K10  */  be_nested_str_weak(tilt_min),
-    /* K11  */  be_nested_str_weak(tilt_max),
-    /* K12  */  be_nested_str_weak(tasmota),
-    /* K13  */  be_nested_str_weak(scale_uint),
-    /* K14  */  be_nested_str_weak(shadow_shutter_tilt),
-    /* K15  */  be_const_int(0),
-    /* K16  */  be_nested_str_weak(U2),
-    /* K17  */  be_nested_str_weak(NULL),
-    /* K18  */  be_nested_str_weak(U4),
-    /* K19  */  be_const_int(3),
-    /* K20  */  be_nested_str_weak(read_attribute),
+    ( &(const bvalue[20]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(update_shadow_lazy),
+    /* K5   */  be_nested_str_weak(create_TLV),
+    /* K6   */  be_nested_str_weak(U1),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(update_tilt_min_max),
+    /* K9   */  be_nested_str_weak(tilt_min),
+    /* K10  */  be_nested_str_weak(tilt_max),
+    /* K11  */  be_nested_str_weak(tasmota),
+    /* K12  */  be_nested_str_weak(scale_uint),
+    /* K13  */  be_nested_str_weak(shadow_shutter_tilt),
+    /* K14  */  be_const_int(0),
+    /* K15  */  be_nested_str_weak(U2),
+    /* K16  */  be_nested_str_weak(NULL),
+    /* K17  */  be_nested_str_weak(U4),
+    /* K18  */  be_const_int(3),
+    /* K19  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[113]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
+    ( &(const binstruction[112]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
-      0x88180504,  //  0004  GETMBR	R6	R2	K4
-      0x541E0101,  //  0005  LDINT	R7	258
-      0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0060,  //  0007  JMPF	R7	#0069
-      0x8C1C0105,  //  0008  GETMET	R7	R0	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x541E0006,  //  000A  LDINT	R7	7
-      0x1C1C0C07,  //  000B  EQ	R7	R6	R7
-      0x781E0008,  //  000C  JMPF	R7	#0016
-      0x8C1C0906,  //  000D  GETMET	R7	R4	K6
-      0x88240907,  //  000E  GETMBR	R9	R4	K7
-      0x542A0007,  //  000F  LDINT	R10	8
-      0x002A100A,  //  0010  ADD	R10	K8	R10
-      0x542E000F,  //  0011  LDINT	R11	16
-      0x0028140B,  //  0012  ADD	R10	R10	R11
-      0x7C1C0600,  //  0013  CALL	R7	3
-      0x80040E00,  //  0014  RET	1	R7
-      0x70020052,  //  0015  JMP		#0069
-      0x541E000E,  //  0016  LDINT	R7	15
-      0x1C1C0C07,  //  0017  EQ	R7	R6	R7
-      0x781E0021,  //  0018  JMPF	R7	#003B
-      0x8C1C0109,  //  0019  GETMET	R7	R0	K9
-      0x7C1C0200,  //  001A  CALL	R7	1
-      0x881C010A,  //  001B  GETMBR	R7	R0	K10
-      0x4C200000,  //  001C  LDNIL	R8
-      0x201C0E08,  //  001D  NE	R7	R7	R8
-      0x781E0015,  //  001E  JMPF	R7	#0035
-      0x881C010B,  //  001F  GETMBR	R7	R0	K11
-      0x4C200000,  //  0020  LDNIL	R8
-      0x201C0E08,  //  0021  NE	R7	R7	R8
-      0x781E0011,  //  0022  JMPF	R7	#0035
-      0xB81E1800,  //  0023  GETNGBL	R7	K12
-      0x8C1C0F0D,  //  0024  GETMET	R7	R7	K13
-      0x8824010E,  //  0025  GETMBR	R9	R0	K14
-      0x8828010A,  //  0026  GETMBR	R10	R0	K10
-      0x0424120A,  //  0027  SUB	R9	R9	R10
-      0x5828000F,  //  0028  LDCONST	R10	K15
-      0x882C010B,  //  0029  GETMBR	R11	R0	K11
-      0x8830010A,  //  002A  GETMBR	R12	R0	K10
-      0x042C160C,  //  002B  SUB	R11	R11	R12
-      0x5830000F,  //  002C  LDCONST	R12	K15
-      0x5436270F,  //  002D  LDINT	R13	10000
-      0x7C1C0C00,  //  002E  CALL	R7	6
-      0x8C200906,  //  002F  GETMET	R8	R4	K6
-      0x88280910,  //  0030  GETMBR	R10	R4	K16
-      0x5C2C0E00,  //  0031  MOVE	R11	R7
-      0x7C200600,  //  0032  CALL	R8	3
-      0x80041000,  //  0033  RET	1	R8
-      0x70020004,  //  0034  JMP		#003A
-      0x8C1C0906,  //  0035  GETMET	R7	R4	K6
-      0x88240911,  //  0036  GETMBR	R9	R4	K17
-      0x4C280000,  //  0037  LDNIL	R10
-      0x7C1C0600,  //  0038  CALL	R7	3
-      0x80040E00,  //  0039  RET	1	R7
-      0x7002002D,  //  003A  JMP		#0069
-      0x541E000B,  //  003B  LDINT	R7	12
-      0x1C1C0C07,  //  003C  EQ	R7	R6	R7
-      0x781E001F,  //  003D  JMPF	R7	#005E
-      0x881C010A,  //  003E  GETMBR	R7	R0	K10
-      0x4C200000,  //  003F  LDNIL	R8
-      0x201C0E08,  //  0040  NE	R7	R7	R8
-      0x781E0015,  //  0041  JMPF	R7	#0058
-      0x881C010B,  //  0042  GETMBR	R7	R0	K11
-      0x4C200000,  //  0043  LDNIL	R8
-      0x201C0E08,  //  0044  NE	R7	R7	R8
-      0x781E0011,  //  0045  JMPF	R7	#0058
-      0xB81E1800,  //  0046  GETNGBL	R7	K12
-      0x8C1C0F0D,  //  0047  GETMET	R7	R7	K13
-      0x8824010E,  //  0048  GETMBR	R9	R0	K14
-      0x8828010A,  //  0049  GETMBR	R10	R0	K10
-      0x0424120A,  //  004A  SUB	R9	R9	R10
-      0x5828000F,  //  004B  LDCONST	R10	K15
-      0x882C010B,  //  004C  GETMBR	R11	R0	K11
-      0x8830010A,  //  004D  GETMBR	R12	R0	K10
-      0x042C160C,  //  004E  SUB	R11	R11	R12
-      0x5830000F,  //  004F  LDCONST	R12	K15
-      0x5436270F,  //  0050  LDINT	R13	10000
-      0x7C1C0C00,  //  0051  CALL	R7	6
-      0x8C200906,  //  0052  GETMET	R8	R4	K6
-      0x88280910,  //  0053  GETMBR	R10	R4	K16
-      0x5C2C0E00,  //  0054  MOVE	R11	R7
-      0x7C200600,  //  0055  CALL	R8	3
-      0x80041000,  //  0056  RET	1	R8
-      0x70020004,  //  0057  JMP		#005D
-      0x8C1C0906,  //  0058  GETMET	R7	R4	K6
-      0x88240911,  //  0059  GETMBR	R9	R4	K17
-      0x4C280000,  //  005A  LDNIL	R10
-      0x7C1C0600,  //  005B  CALL	R7	3
-      0x80040E00,  //  005C  RET	1	R7
-      0x7002000A,  //  005D  JMP		#0069
-      0x541EFFFB,  //  005E  LDINT	R7	65532
-      0x1C1C0C07,  //  005F  EQ	R7	R6	R7
-      0x781E0007,  //  0060  JMPF	R7	#0069
-      0x8C1C0906,  //  0061  GETMET	R7	R4	K6
-      0x88240912,  //  0062  GETMBR	R9	R4	K18
-      0x542A0003,  //  0063  LDINT	R10	4
-      0x002A260A,  //  0064  ADD	R10	K19	R10
-      0x542E000F,  //  0065  LDINT	R11	16
-      0x0028140B,  //  0066  ADD	R10	R10	R11
-      0x7C1C0600,  //  0067  CALL	R7	3
-      0x80040E00,  //  0068  RET	1	R7
-      0x601C0003,  //  0069  GETGBL	R7	G3
-      0x5C200000,  //  006A  MOVE	R8	R0
-      0x7C1C0200,  //  006B  CALL	R7	1
-      0x8C1C0F14,  //  006C  GETMET	R7	R7	K20
-      0x5C240200,  //  006D  MOVE	R9	R1
-      0x5C280400,  //  006E  MOVE	R10	R2
-      0x7C1C0600,  //  006F  CALL	R7	3
-      0x80040E00,  //  0070  RET	1	R7
+      0x541A0101,  //  0004  LDINT	R6	258
+      0x1C180806,  //  0005  EQ	R6	R4	R6
+      0x781A0060,  //  0006  JMPF	R6	#0068
+      0x8C180104,  //  0007  GETMET	R6	R0	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x541A0006,  //  0009  LDINT	R6	7
+      0x1C180A06,  //  000A  EQ	R6	R5	R6
+      0x781A0008,  //  000B  JMPF	R6	#0015
+      0x8C180705,  //  000C  GETMET	R6	R3	K5
+      0x88200706,  //  000D  GETMBR	R8	R3	K6
+      0x54260007,  //  000E  LDINT	R9	8
+      0x00260E09,  //  000F  ADD	R9	K7	R9
+      0x542A000F,  //  0010  LDINT	R10	16
+      0x0024120A,  //  0011  ADD	R9	R9	R10
+      0x7C180600,  //  0012  CALL	R6	3
+      0x80040C00,  //  0013  RET	1	R6
+      0x70020052,  //  0014  JMP		#0068
+      0x541A000E,  //  0015  LDINT	R6	15
+      0x1C180A06,  //  0016  EQ	R6	R5	R6
+      0x781A0021,  //  0017  JMPF	R6	#003A
+      0x8C180108,  //  0018  GETMET	R6	R0	K8
+      0x7C180200,  //  0019  CALL	R6	1
+      0x88180109,  //  001A  GETMBR	R6	R0	K9
+      0x4C1C0000,  //  001B  LDNIL	R7
+      0x20180C07,  //  001C  NE	R6	R6	R7
+      0x781A0015,  //  001D  JMPF	R6	#0034
+      0x8818010A,  //  001E  GETMBR	R6	R0	K10
+      0x4C1C0000,  //  001F  LDNIL	R7
+      0x20180C07,  //  0020  NE	R6	R6	R7
+      0x781A0011,  //  0021  JMPF	R6	#0034
+      0xB81A1600,  //  0022  GETNGBL	R6	K11
+      0x8C180D0C,  //  0023  GETMET	R6	R6	K12
+      0x8820010D,  //  0024  GETMBR	R8	R0	K13
+      0x88240109,  //  0025  GETMBR	R9	R0	K9
+      0x04201009,  //  0026  SUB	R8	R8	R9
+      0x5824000E,  //  0027  LDCONST	R9	K14
+      0x8828010A,  //  0028  GETMBR	R10	R0	K10
+      0x882C0109,  //  0029  GETMBR	R11	R0	K9
+      0x0428140B,  //  002A  SUB	R10	R10	R11
+      0x582C000E,  //  002B  LDCONST	R11	K14
+      0x5432270F,  //  002C  LDINT	R12	10000
+      0x7C180C00,  //  002D  CALL	R6	6
+      0x8C1C0705,  //  002E  GETMET	R7	R3	K5
+      0x8824070F,  //  002F  GETMBR	R9	R3	K15
+      0x5C280C00,  //  0030  MOVE	R10	R6
+      0x7C1C0600,  //  0031  CALL	R7	3
+      0x80040E00,  //  0032  RET	1	R7
+      0x70020004,  //  0033  JMP		#0039
+      0x8C180705,  //  0034  GETMET	R6	R3	K5
+      0x88200710,  //  0035  GETMBR	R8	R3	K16
+      0x4C240000,  //  0036  LDNIL	R9
+      0x7C180600,  //  0037  CALL	R6	3
+      0x80040C00,  //  0038  RET	1	R6
+      0x7002002D,  //  0039  JMP		#0068
+      0x541A000B,  //  003A  LDINT	R6	12
+      0x1C180A06,  //  003B  EQ	R6	R5	R6
+      0x781A001F,  //  003C  JMPF	R6	#005D
+      0x88180109,  //  003D  GETMBR	R6	R0	K9
+      0x4C1C0000,  //  003E  LDNIL	R7
+      0x20180C07,  //  003F  NE	R6	R6	R7
+      0x781A0015,  //  0040  JMPF	R6	#0057
+      0x8818010A,  //  0041  GETMBR	R6	R0	K10
+      0x4C1C0000,  //  0042  LDNIL	R7
+      0x20180C07,  //  0043  NE	R6	R6	R7
+      0x781A0011,  //  0044  JMPF	R6	#0057
+      0xB81A1600,  //  0045  GETNGBL	R6	K11
+      0x8C180D0C,  //  0046  GETMET	R6	R6	K12
+      0x8820010D,  //  0047  GETMBR	R8	R0	K13
+      0x88240109,  //  0048  GETMBR	R9	R0	K9
+      0x04201009,  //  0049  SUB	R8	R8	R9
+      0x5824000E,  //  004A  LDCONST	R9	K14
+      0x8828010A,  //  004B  GETMBR	R10	R0	K10
+      0x882C0109,  //  004C  GETMBR	R11	R0	K9
+      0x0428140B,  //  004D  SUB	R10	R10	R11
+      0x582C000E,  //  004E  LDCONST	R11	K14
+      0x5432270F,  //  004F  LDINT	R12	10000
+      0x7C180C00,  //  0050  CALL	R6	6
+      0x8C1C0705,  //  0051  GETMET	R7	R3	K5
+      0x8824070F,  //  0052  GETMBR	R9	R3	K15
+      0x5C280C00,  //  0053  MOVE	R10	R6
+      0x7C1C0600,  //  0054  CALL	R7	3
+      0x80040E00,  //  0055  RET	1	R7
+      0x70020004,  //  0056  JMP		#005C
+      0x8C180705,  //  0057  GETMET	R6	R3	K5
+      0x88200710,  //  0058  GETMBR	R8	R3	K16
+      0x4C240000,  //  0059  LDNIL	R9
+      0x7C180600,  //  005A  CALL	R6	3
+      0x80040C00,  //  005B  RET	1	R6
+      0x7002000A,  //  005C  JMP		#0068
+      0x541AFFFB,  //  005D  LDINT	R6	65532
+      0x1C180A06,  //  005E  EQ	R6	R5	R6
+      0x781A0007,  //  005F  JMPF	R6	#0068
+      0x8C180705,  //  0060  GETMET	R6	R3	K5
+      0x88200711,  //  0061  GETMBR	R8	R3	K17
+      0x54260003,  //  0062  LDINT	R9	4
+      0x00262409,  //  0063  ADD	R9	K18	R9
+      0x542A000F,  //  0064  LDINT	R10	16
+      0x0024120A,  //  0065  ADD	R9	R9	R10
+      0x7C180600,  //  0066  CALL	R6	3
+      0x80040C00,  //  0067  RET	1	R6
+      0x60180003,  //  0068  GETGBL	R6	G3
+      0x5C1C0000,  //  0069  MOVE	R7	R0
+      0x7C180200,  //  006A  CALL	R6	1
+      0x8C180D13,  //  006B  GETMET	R6	R6	K19
+      0x5C200200,  //  006C  MOVE	R8	R1
+      0x5C240400,  //  006D  MOVE	R9	R2
+      0x7C180600,  //  006E  CALL	R6	3
+      0x80040C00,  //  006F  RET	1	R6
     })
   )
 );
@@ -365,7 +363,7 @@ be_local_closure(Matter_Plugin_ShutterTilt_read_attribute,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_ShutterTilt_parse_sensors,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -373,53 +371,51 @@ be_local_closure(Matter_Plugin_ShutterTilt_parse_sensors,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(Shutter),
-    /* K2   */  be_nested_str_weak(tasmota_shutter_index),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(contains),
-    /* K5   */  be_nested_str_weak(find),
-    /* K6   */  be_nested_str_weak(Tilt),
-    /* K7   */  be_nested_str_weak(shadow_shutter_tilt),
-    /* K8   */  be_nested_str_weak(attribute_updated),
-    /* K9   */  be_nested_str_weak(parse_sensors),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(Shutter),
+    /* K1   */  be_nested_str_weak(tasmota_shutter_index),
+    /* K2   */  be_const_int(1),
+    /* K3   */  be_nested_str_weak(contains),
+    /* K4   */  be_nested_str_weak(find),
+    /* K5   */  be_nested_str_weak(Tilt),
+    /* K6   */  be_nested_str_weak(shadow_shutter_tilt),
+    /* K7   */  be_nested_str_weak(attribute_updated),
+    /* K8   */  be_nested_str_weak(parse_sensors),
     }),
     be_str_weak(parse_sensors),
     &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x600C0008,  //  0001  GETGBL	R3	G8
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
-      0x00100903,  //  0003  ADD	R4	R4	K3
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x000E0203,  //  0005  ADD	R3	K1	R3
-      0x8C100304,  //  0006  GETMET	R4	R1	K4
-      0x5C180600,  //  0007  MOVE	R6	R3
-      0x7C100400,  //  0008  CALL	R4	2
-      0x7812000E,  //  0009  JMPF	R4	#0019
-      0x94100203,  //  000A  GETIDX	R4	R1	R3
-      0x8C140905,  //  000B  GETMET	R5	R4	K5
-      0x581C0006,  //  000C  LDCONST	R7	K6
-      0x7C140400,  //  000D  CALL	R5	2
-      0x4C180000,  //  000E  LDNIL	R6
-      0x20180A06,  //  000F  NE	R6	R5	R6
-      0x781A0007,  //  0010  JMPF	R6	#0019
-      0x88180107,  //  0011  GETMBR	R6	R0	K7
-      0x20180A06,  //  0012  NE	R6	R5	R6
-      0x781A0003,  //  0013  JMPF	R6	#0018
-      0x8C180108,  //  0014  GETMET	R6	R0	K8
-      0x54220101,  //  0015  LDINT	R8	258
-      0x5426000E,  //  0016  LDINT	R9	15
-      0x7C180600,  //  0017  CALL	R6	3
-      0x90020E05,  //  0018  SETMBR	R0	K7	R5
-      0x60100003,  //  0019  GETGBL	R4	G3
-      0x5C140000,  //  001A  MOVE	R5	R0
-      0x7C100200,  //  001B  CALL	R4	1
-      0x8C100909,  //  001C  GETMET	R4	R4	K9
-      0x5C180200,  //  001D  MOVE	R6	R1
-      0x7C100400,  //  001E  CALL	R4	2
-      0x80000000,  //  001F  RET	0
+    ( &(const binstruction[31]) {  /* code */
+      0x60080008,  //  0000  GETGBL	R2	G8
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x000C0702,  //  0002  ADD	R3	R3	K2
+      0x7C080200,  //  0003  CALL	R2	1
+      0x000A0002,  //  0004  ADD	R2	K0	R2
+      0x8C0C0303,  //  0005  GETMET	R3	R1	K3
+      0x5C140400,  //  0006  MOVE	R5	R2
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x780E000E,  //  0008  JMPF	R3	#0018
+      0x940C0202,  //  0009  GETIDX	R3	R1	R2
+      0x8C100704,  //  000A  GETMET	R4	R3	K4
+      0x58180005,  //  000B  LDCONST	R6	K5
+      0x7C100400,  //  000C  CALL	R4	2
+      0x4C140000,  //  000D  LDNIL	R5
+      0x20140805,  //  000E  NE	R5	R4	R5
+      0x78160007,  //  000F  JMPF	R5	#0018
+      0x88140106,  //  0010  GETMBR	R5	R0	K6
+      0x20140805,  //  0011  NE	R5	R4	R5
+      0x78160003,  //  0012  JMPF	R5	#0017
+      0x8C140107,  //  0013  GETMET	R5	R0	K7
+      0x541E0101,  //  0014  LDINT	R7	258
+      0x5422000E,  //  0015  LDINT	R8	15
+      0x7C140600,  //  0016  CALL	R5	3
+      0x90020C04,  //  0017  SETMBR	R0	K6	R4
+      0x600C0003,  //  0018  GETGBL	R3	G3
+      0x5C100000,  //  0019  MOVE	R4	R0
+      0x7C0C0200,  //  001A  CALL	R3	1
+      0x8C0C0708,  //  001B  GETMET	R3	R3	K8
+      0x5C140200,  //  001C  MOVE	R5	R1
+      0x7C0C0400,  //  001D  CALL	R3	2
+      0x80000000,  //  001E  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_Session;
 ********************************************************************/
 be_local_closure(Matter_Session_before_remove,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,28 +19,25 @@ be_local_closure(Matter_Session_before_remove,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2DSession_X20_X20_X20_X28_X256i_X29_X20_X28removed_X29),
-    /* K5   */  be_nested_str_weak(local_session_id),
-    /* K6   */  be_const_int(3),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2DSession_X20_X20_X20_X28_X256i_X29_X20_X28removed_X29),
+    /* K3   */  be_nested_str_weak(local_session_id),
+    /* K4   */  be_const_int(3),
     }),
     be_str_weak(before_remove),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x8C100303,  //  0003  GETMET	R4	R1	K3
-      0x58180004,  //  0004  LDCONST	R6	K4
-      0x881C0105,  //  0005  GETMBR	R7	R0	K5
-      0x7C100600,  //  0006  CALL	R4	3
-      0x58140006,  //  0007  LDCONST	R5	K6
-      0x7C080600,  //  0008  CALL	R2	3
-      0x80000000,  //  0009  RET	0
+    ( &(const binstruction[ 9]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x600C0018,  //  0002  GETGBL	R3	G24
+      0x58100002,  //  0003  LDCONST	R4	K2
+      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x58100004,  //  0006  LDCONST	R4	K4
+      0x7C040600,  //  0007  CALL	R1	3
+      0x80000000,  //  0008  RET	0
     })
   )
 );
@@ -406,7 +403,7 @@ be_local_closure(Matter_Session_get_r2i,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Session_tojson,   /* name */
   be_nested_proto(
-    18,                          /* nstack */
+    16,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -414,131 +411,128 @@ be_local_closure(Matter_Session_tojson,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
+    ( &(const bvalue[22]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(introspect),
-    /* K3   */  be_nested_str_weak(persist_pre),
-    /* K4   */  be_nested_str_weak(members),
-    /* K5   */  be_nested_str_weak(get),
-    /* K6   */  be_nested_str_weak(function),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(_),
-    /* K9   */  be_nested_str_weak(push),
-    /* K10  */  be_nested_str_weak(stop_iteration),
-    /* K11  */  be_nested_str_weak(matter),
-    /* K12  */  be_nested_str_weak(sort),
-    /* K13  */  be_nested_str_weak(_X24_X24),
-    /* K14  */  be_nested_str_weak(tob64),
-    /* K15  */  be_nested_str_weak(instance),
-    /* K16  */  be_nested_str_weak(format),
-    /* K17  */  be_nested_str_weak(_X25s_X3A_X25s),
-    /* K18  */  be_nested_str_weak(dump),
-    /* K19  */  be_nested_str_weak(persist_post),
-    /* K20  */  be_nested_str_weak(_X7B),
-    /* K21  */  be_nested_str_weak(concat),
-    /* K22  */  be_nested_str_weak(_X2C),
-    /* K23  */  be_nested_str_weak(_X7D),
+    /* K1   */  be_nested_str_weak(introspect),
+    /* K2   */  be_nested_str_weak(persist_pre),
+    /* K3   */  be_nested_str_weak(members),
+    /* K4   */  be_nested_str_weak(get),
+    /* K5   */  be_nested_str_weak(function),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(_),
+    /* K8   */  be_nested_str_weak(push),
+    /* K9   */  be_nested_str_weak(stop_iteration),
+    /* K10  */  be_nested_str_weak(matter),
+    /* K11  */  be_nested_str_weak(sort),
+    /* K12  */  be_nested_str_weak(_X24_X24),
+    /* K13  */  be_nested_str_weak(tob64),
+    /* K14  */  be_nested_str_weak(instance),
+    /* K15  */  be_nested_str_weak(_X25s_X3A_X25s),
+    /* K16  */  be_nested_str_weak(dump),
+    /* K17  */  be_nested_str_weak(persist_post),
+    /* K18  */  be_nested_str_weak(_X7B),
+    /* K19  */  be_nested_str_weak(concat),
+    /* K20  */  be_nested_str_weak(_X2C),
+    /* K21  */  be_nested_str_weak(_X7D),
     }),
     be_str_weak(tojson),
     &be_const_str_solidified,
-    ( &(const binstruction[96]) {  /* code */
+    ( &(const binstruction[95]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xA40E0400,  //  0002  IMPORT	R3	K2
-      0x8C100103,  //  0003  GETMET	R4	R0	K3
-      0x7C100200,  //  0004  CALL	R4	1
-      0x60100012,  //  0005  GETGBL	R4	G18
-      0x7C100000,  //  0006  CALL	R4	0
-      0x60140010,  //  0007  GETGBL	R5	G16
-      0x8C180704,  //  0008  GETMET	R6	R3	K4
-      0x5C200000,  //  0009  MOVE	R8	R0
-      0x7C180400,  //  000A  CALL	R6	2
-      0x7C140200,  //  000B  CALL	R5	1
-      0xA8020011,  //  000C  EXBLK	0	#001F
-      0x5C180A00,  //  000D  MOVE	R6	R5
-      0x7C180000,  //  000E  CALL	R6	0
-      0x8C1C0705,  //  000F  GETMET	R7	R3	K5
-      0x5C240000,  //  0010  MOVE	R9	R0
-      0x5C280C00,  //  0011  MOVE	R10	R6
-      0x7C1C0600,  //  0012  CALL	R7	3
-      0x60200004,  //  0013  GETGBL	R8	G4
-      0x5C240E00,  //  0014  MOVE	R9	R7
-      0x7C200200,  //  0015  CALL	R8	1
-      0x20201106,  //  0016  NE	R8	R8	K6
-      0x78220005,  //  0017  JMPF	R8	#001E
-      0x94200D07,  //  0018  GETIDX	R8	R6	K7
-      0x20201108,  //  0019  NE	R8	R8	K8
-      0x78220002,  //  001A  JMPF	R8	#001E
-      0x8C200909,  //  001B  GETMET	R8	R4	K9
-      0x5C280C00,  //  001C  MOVE	R10	R6
-      0x7C200400,  //  001D  CALL	R8	2
-      0x7001FFED,  //  001E  JMP		#000D
-      0x5814000A,  //  001F  LDCONST	R5	K10
-      0xAC140200,  //  0020  CATCH	R5	1	0
-      0xB0080000,  //  0021  RAISE	2	R0	R0
-      0xB8161600,  //  0022  GETNGBL	R5	K11
-      0x8C140B0C,  //  0023  GETMET	R5	R5	K12
-      0x5C1C0800,  //  0024  MOVE	R7	R4
-      0x7C140400,  //  0025  CALL	R5	2
-      0x5C100A00,  //  0026  MOVE	R4	R5
-      0x60140012,  //  0027  GETGBL	R5	G18
-      0x7C140000,  //  0028  CALL	R5	0
-      0x60180010,  //  0029  GETGBL	R6	G16
-      0x5C1C0800,  //  002A  MOVE	R7	R4
-      0x7C180200,  //  002B  CALL	R6	1
-      0xA8020027,  //  002C  EXBLK	0	#0055
-      0x5C1C0C00,  //  002D  MOVE	R7	R6
-      0x7C1C0000,  //  002E  CALL	R7	0
-      0x8C200705,  //  002F  GETMET	R8	R3	K5
-      0x5C280000,  //  0030  MOVE	R10	R0
-      0x5C2C0E00,  //  0031  MOVE	R11	R7
-      0x7C200600,  //  0032  CALL	R8	3
-      0x4C240000,  //  0033  LDNIL	R9
-      0x1C241009,  //  0034  EQ	R9	R8	R9
-      0x78260000,  //  0035  JMPF	R9	#0037
-      0x7001FFF5,  //  0036  JMP		#002D
-      0x6024000F,  //  0037  GETGBL	R9	G15
-      0x5C281000,  //  0038  MOVE	R10	R8
-      0x602C0015,  //  0039  GETGBL	R11	G21
-      0x7C240400,  //  003A  CALL	R9	2
-      0x78260004,  //  003B  JMPF	R9	#0041
-      0x8C24110E,  //  003C  GETMET	R9	R8	K14
-      0x7C240200,  //  003D  CALL	R9	1
-      0x00261A09,  //  003E  ADD	R9	K13	R9
-      0x5C201200,  //  003F  MOVE	R8	R9
-      0x70020005,  //  0040  JMP		#0047
-      0x60240004,  //  0041  GETGBL	R9	G4
-      0x5C281000,  //  0042  MOVE	R10	R8
-      0x7C240200,  //  0043  CALL	R9	1
-      0x1C24130F,  //  0044  EQ	R9	R9	K15
-      0x78260000,  //  0045  JMPF	R9	#0047
-      0x7001FFE5,  //  0046  JMP		#002D
-      0x8C240B09,  //  0047  GETMET	R9	R5	K9
-      0x8C2C0510,  //  0048  GETMET	R11	R2	K16
-      0x58340011,  //  0049  LDCONST	R13	K17
-      0x8C380312,  //  004A  GETMET	R14	R1	K18
-      0x60400008,  //  004B  GETGBL	R16	G8
-      0x5C440E00,  //  004C  MOVE	R17	R7
-      0x7C400200,  //  004D  CALL	R16	1
-      0x7C380400,  //  004E  CALL	R14	2
-      0x8C3C0312,  //  004F  GETMET	R15	R1	K18
-      0x5C441000,  //  0050  MOVE	R17	R8
-      0x7C3C0400,  //  0051  CALL	R15	2
-      0x7C2C0800,  //  0052  CALL	R11	4
-      0x7C240400,  //  0053  CALL	R9	2
-      0x7001FFD7,  //  0054  JMP		#002D
-      0x5818000A,  //  0055  LDCONST	R6	K10
-      0xAC180200,  //  0056  CATCH	R6	1	0
-      0xB0080000,  //  0057  RAISE	2	R0	R0
-      0x8C180113,  //  0058  GETMET	R6	R0	K19
-      0x7C180200,  //  0059  CALL	R6	1
-      0x8C180B15,  //  005A  GETMET	R6	R5	K21
-      0x58200016,  //  005B  LDCONST	R8	K22
-      0x7C180400,  //  005C  CALL	R6	2
-      0x001A2806,  //  005D  ADD	R6	K20	R6
-      0x00180D17,  //  005E  ADD	R6	R6	K23
-      0x80040C00,  //  005F  RET	1	R6
+      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x600C0012,  //  0004  GETGBL	R3	G18
+      0x7C0C0000,  //  0005  CALL	R3	0
+      0x60100010,  //  0006  GETGBL	R4	G16
+      0x8C140503,  //  0007  GETMET	R5	R2	K3
+      0x5C1C0000,  //  0008  MOVE	R7	R0
+      0x7C140400,  //  0009  CALL	R5	2
+      0x7C100200,  //  000A  CALL	R4	1
+      0xA8020011,  //  000B  EXBLK	0	#001E
+      0x5C140800,  //  000C  MOVE	R5	R4
+      0x7C140000,  //  000D  CALL	R5	0
+      0x8C180504,  //  000E  GETMET	R6	R2	K4
+      0x5C200000,  //  000F  MOVE	R8	R0
+      0x5C240A00,  //  0010  MOVE	R9	R5
+      0x7C180600,  //  0011  CALL	R6	3
+      0x601C0004,  //  0012  GETGBL	R7	G4
+      0x5C200C00,  //  0013  MOVE	R8	R6
+      0x7C1C0200,  //  0014  CALL	R7	1
+      0x201C0F05,  //  0015  NE	R7	R7	K5
+      0x781E0005,  //  0016  JMPF	R7	#001D
+      0x941C0B06,  //  0017  GETIDX	R7	R5	K6
+      0x201C0F07,  //  0018  NE	R7	R7	K7
+      0x781E0002,  //  0019  JMPF	R7	#001D
+      0x8C1C0708,  //  001A  GETMET	R7	R3	K8
+      0x5C240A00,  //  001B  MOVE	R9	R5
+      0x7C1C0400,  //  001C  CALL	R7	2
+      0x7001FFED,  //  001D  JMP		#000C
+      0x58100009,  //  001E  LDCONST	R4	K9
+      0xAC100200,  //  001F  CATCH	R4	1	0
+      0xB0080000,  //  0020  RAISE	2	R0	R0
+      0xB8121400,  //  0021  GETNGBL	R4	K10
+      0x8C10090B,  //  0022  GETMET	R4	R4	K11
+      0x5C180600,  //  0023  MOVE	R6	R3
+      0x7C100400,  //  0024  CALL	R4	2
+      0x5C0C0800,  //  0025  MOVE	R3	R4
+      0x60100012,  //  0026  GETGBL	R4	G18
+      0x7C100000,  //  0027  CALL	R4	0
+      0x60140010,  //  0028  GETGBL	R5	G16
+      0x5C180600,  //  0029  MOVE	R6	R3
+      0x7C140200,  //  002A  CALL	R5	1
+      0xA8020027,  //  002B  EXBLK	0	#0054
+      0x5C180A00,  //  002C  MOVE	R6	R5
+      0x7C180000,  //  002D  CALL	R6	0
+      0x8C1C0504,  //  002E  GETMET	R7	R2	K4
+      0x5C240000,  //  002F  MOVE	R9	R0
+      0x5C280C00,  //  0030  MOVE	R10	R6
+      0x7C1C0600,  //  0031  CALL	R7	3
+      0x4C200000,  //  0032  LDNIL	R8
+      0x1C200E08,  //  0033  EQ	R8	R7	R8
+      0x78220000,  //  0034  JMPF	R8	#0036
+      0x7001FFF5,  //  0035  JMP		#002C
+      0x6020000F,  //  0036  GETGBL	R8	G15
+      0x5C240E00,  //  0037  MOVE	R9	R7
+      0x60280015,  //  0038  GETGBL	R10	G21
+      0x7C200400,  //  0039  CALL	R8	2
+      0x78220004,  //  003A  JMPF	R8	#0040
+      0x8C200F0D,  //  003B  GETMET	R8	R7	K13
+      0x7C200200,  //  003C  CALL	R8	1
+      0x00221808,  //  003D  ADD	R8	K12	R8
+      0x5C1C1000,  //  003E  MOVE	R7	R8
+      0x70020005,  //  003F  JMP		#0046
+      0x60200004,  //  0040  GETGBL	R8	G4
+      0x5C240E00,  //  0041  MOVE	R9	R7
+      0x7C200200,  //  0042  CALL	R8	1
+      0x1C20110E,  //  0043  EQ	R8	R8	K14
+      0x78220000,  //  0044  JMPF	R8	#0046
+      0x7001FFE5,  //  0045  JMP		#002C
+      0x8C200908,  //  0046  GETMET	R8	R4	K8
+      0x60280018,  //  0047  GETGBL	R10	G24
+      0x582C000F,  //  0048  LDCONST	R11	K15
+      0x8C300310,  //  0049  GETMET	R12	R1	K16
+      0x60380008,  //  004A  GETGBL	R14	G8
+      0x5C3C0C00,  //  004B  MOVE	R15	R6
+      0x7C380200,  //  004C  CALL	R14	1
+      0x7C300400,  //  004D  CALL	R12	2
+      0x8C340310,  //  004E  GETMET	R13	R1	K16
+      0x5C3C0E00,  //  004F  MOVE	R15	R7
+      0x7C340400,  //  0050  CALL	R13	2
+      0x7C280600,  //  0051  CALL	R10	3
+      0x7C200400,  //  0052  CALL	R8	2
+      0x7001FFD7,  //  0053  JMP		#002C
+      0x58140009,  //  0054  LDCONST	R5	K9
+      0xAC140200,  //  0055  CATCH	R5	1	0
+      0xB0080000,  //  0056  RAISE	2	R0	R0
+      0x8C140111,  //  0057  GETMET	R5	R0	K17
+      0x7C140200,  //  0058  CALL	R5	1
+      0x8C140913,  //  0059  GETMET	R5	R4	K19
+      0x581C0014,  //  005A  LDCONST	R7	K20
+      0x7C140400,  //  005B  CALL	R5	2
+      0x00162405,  //  005C  ADD	R5	K18	R5
+      0x00140B15,  //  005D  ADD	R5	R5	K21
+      0x80040A00,  //  005E  RET	1	R5
     })
   )
 );
@@ -1535,7 +1529,7 @@ be_local_closure(Matter_Session_get_ac,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Session_counter_snd_next,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1543,41 +1537,39 @@ be_local_closure(Matter_Session_counter_snd_next,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(_counter_snd_impl),
-    /* K2   */  be_nested_str_weak(next),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Counter),
-    /* K5   */  be_nested_str_weak(is_greater),
-    /* K6   */  be_nested_str_weak(counter_snd),
-    /* K7   */  be_nested_str_weak(_COUNTER_SND_INCR),
-    /* K8   */  be_nested_str_weak(does_persist),
-    /* K9   */  be_nested_str_weak(save),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_counter_snd_impl),
+    /* K1   */  be_nested_str_weak(next),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(Counter),
+    /* K4   */  be_nested_str_weak(is_greater),
+    /* K5   */  be_nested_str_weak(counter_snd),
+    /* K6   */  be_nested_str_weak(_COUNTER_SND_INCR),
+    /* K7   */  be_nested_str_weak(does_persist),
+    /* K8   */  be_nested_str_weak(save),
     }),
     be_str_weak(counter_snd_next),
     &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0xB80E0600,  //  0004  GETNGBL	R3	K3
-      0x880C0704,  //  0005  GETMBR	R3	R3	K4
-      0x8C0C0705,  //  0006  GETMET	R3	R3	K5
-      0x5C140400,  //  0007  MOVE	R5	R2
-      0x88180106,  //  0008  GETMBR	R6	R0	K6
-      0x7C0C0600,  //  0009  CALL	R3	3
-      0x780E0007,  //  000A  JMPF	R3	#0013
-      0x880C0107,  //  000B  GETMBR	R3	R0	K7
-      0x000C0403,  //  000C  ADD	R3	R2	R3
-      0x90020C03,  //  000D  SETMBR	R0	K6	R3
-      0x8C0C0108,  //  000E  GETMET	R3	R0	K8
-      0x7C0C0200,  //  000F  CALL	R3	1
-      0x780E0001,  //  0010  JMPF	R3	#0013
-      0x8C0C0109,  //  0011  GETMET	R3	R0	K9
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0x80040400,  //  0013  RET	1	R2
+    ( &(const binstruction[19]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0xB80A0400,  //  0003  GETNGBL	R2	K2
+      0x88080503,  //  0004  GETMBR	R2	R2	K3
+      0x8C080504,  //  0005  GETMET	R2	R2	K4
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x88140105,  //  0007  GETMBR	R5	R0	K5
+      0x7C080600,  //  0008  CALL	R2	3
+      0x780A0007,  //  0009  JMPF	R2	#0012
+      0x88080106,  //  000A  GETMBR	R2	R0	K6
+      0x00080202,  //  000B  ADD	R2	R1	R2
+      0x90020A02,  //  000C  SETMBR	R0	K5	R2
+      0x8C080107,  //  000D  GETMET	R2	R0	K7
+      0x7C080200,  //  000E  CALL	R2	1
+      0x780A0001,  //  000F  JMPF	R2	#0012
+      0x8C080108,  //  0010  GETMET	R2	R0	K8
+      0x7C080200,  //  0011  CALL	R2	1
+      0x80040200,  //  0012  RET	1	R1
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
@@ -332,7 +332,7 @@ be_local_closure(Matter_Session_Store_next_fabric_idx,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Session_Store_load_fabrics,   /* name */
   be_nested_proto(
-    17,                          /* nstack */
+    16,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -340,158 +340,155 @@ be_local_closure(Matter_Session_Store_load_fabrics,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Expirable_list),
-    /* K4   */  be_nested_str_weak(fabrics),
-    /* K5   */  be_nested_str_weak(_FABRICS),
-    /* K6   */  be_nested_str_weak(read),
-    /* K7   */  be_nested_str_weak(close),
-    /* K8   */  be_nested_str_weak(json),
-    /* K9   */  be_nested_str_weak(load),
-    /* K10  */  be_nested_str_weak(tasmota),
-    /* K11  */  be_nested_str_weak(gc),
-    /* K12  */  be_nested_str_weak(Fabric),
-    /* K13  */  be_nested_str_weak(fromjson),
-    /* K14  */  be_nested_str_weak(set_no_expiration),
-    /* K15  */  be_nested_str_weak(set_persist),
-    /* K16  */  be_nested_str_weak(find),
-    /* K17  */  be_nested_str_weak(_sessions),
-    /* K18  */  be_nested_str_weak(Session),
-    /* K19  */  be_nested_str_weak(add_session),
-    /* K20  */  be_nested_str_weak(stop_iteration),
-    /* K21  */  be_nested_str_weak(push),
-    /* K22  */  be_nested_str_weak(log),
-    /* K23  */  be_nested_str_weak(format),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20Loaded_X20_X25i_X20fabric_X28s_X29),
-    /* K25  */  be_const_int(2),
-    /* K26  */  be_nested_str_weak(io_error),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
-    /* K28  */  be_nested_str_weak(_X7C),
+    ( &(const bvalue[27]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(Expirable_list),
+    /* K3   */  be_nested_str_weak(fabrics),
+    /* K4   */  be_nested_str_weak(_FABRICS),
+    /* K5   */  be_nested_str_weak(read),
+    /* K6   */  be_nested_str_weak(close),
+    /* K7   */  be_nested_str_weak(json),
+    /* K8   */  be_nested_str_weak(load),
+    /* K9   */  be_nested_str_weak(tasmota),
+    /* K10  */  be_nested_str_weak(gc),
+    /* K11  */  be_nested_str_weak(Fabric),
+    /* K12  */  be_nested_str_weak(fromjson),
+    /* K13  */  be_nested_str_weak(set_no_expiration),
+    /* K14  */  be_nested_str_weak(set_persist),
+    /* K15  */  be_nested_str_weak(find),
+    /* K16  */  be_nested_str_weak(_sessions),
+    /* K17  */  be_nested_str_weak(Session),
+    /* K18  */  be_nested_str_weak(add_session),
+    /* K19  */  be_nested_str_weak(stop_iteration),
+    /* K20  */  be_nested_str_weak(push),
+    /* K21  */  be_nested_str_weak(log),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20Loaded_X20_X25i_X20fabric_X28s_X29),
+    /* K23  */  be_const_int(2),
+    /* K24  */  be_nested_str_weak(io_error),
+    /* K25  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
+    /* K26  */  be_nested_str_weak(_X7C),
     }),
     be_str_weak(load_fabrics),
     &be_const_str_solidified,
-    ( &(const binstruction[118]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA802005F,  //  0001  EXBLK	0	#0062
-      0xB80A0400,  //  0002  GETNGBL	R2	K2
-      0x8C080503,  //  0003  GETMET	R2	R2	K3
-      0x7C080200,  //  0004  CALL	R2	1
-      0x90020202,  //  0005  SETMBR	R0	K1	R2
-      0xB80A0400,  //  0006  GETNGBL	R2	K2
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
-      0x7C080200,  //  0008  CALL	R2	1
-      0x90020802,  //  0009  SETMBR	R0	K4	R2
-      0x60080011,  //  000A  GETGBL	R2	G17
-      0x880C0105,  //  000B  GETMBR	R3	R0	K5
-      0x7C080200,  //  000C  CALL	R2	1
-      0x8C0C0506,  //  000D  GETMET	R3	R2	K6
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0x8C100507,  //  000F  GETMET	R4	R2	K7
-      0x7C100200,  //  0010  CALL	R4	1
-      0xA4121000,  //  0011  IMPORT	R4	K8
-      0x8C140909,  //  0012  GETMET	R5	R4	K9
-      0x5C1C0600,  //  0013  MOVE	R7	R3
-      0x7C140400,  //  0014  CALL	R5	2
-      0x4C0C0000,  //  0015  LDNIL	R3
-      0xB81A1400,  //  0016  GETNGBL	R6	K10
-      0x8C180D0B,  //  0017  GETMET	R6	R6	K11
-      0x7C180200,  //  0018  CALL	R6	1
-      0x60180010,  //  0019  GETGBL	R6	G16
-      0x5C1C0A00,  //  001A  MOVE	R7	R5
-      0x7C180200,  //  001B  CALL	R6	1
-      0xA8020035,  //  001C  EXBLK	0	#0053
-      0x5C1C0C00,  //  001D  MOVE	R7	R6
-      0x7C1C0000,  //  001E  CALL	R7	0
-      0xB8220400,  //  001F  GETNGBL	R8	K2
-      0x8820110C,  //  0020  GETMBR	R8	R8	K12
-      0x8C20110D,  //  0021  GETMET	R8	R8	K13
-      0x5C280000,  //  0022  MOVE	R10	R0
-      0x5C2C0E00,  //  0023  MOVE	R11	R7
-      0x7C200600,  //  0024  CALL	R8	3
-      0x8C24110E,  //  0025  GETMET	R9	R8	K14
-      0x7C240200,  //  0026  CALL	R9	1
-      0x8C24110F,  //  0027  GETMET	R9	R8	K15
-      0x502C0200,  //  0028  LDBOOL	R11	1	0
-      0x7C240400,  //  0029  CALL	R9	2
-      0x8C240F10,  //  002A  GETMET	R9	R7	K16
-      0x582C0011,  //  002B  LDCONST	R11	K17
-      0x60300012,  //  002C  GETGBL	R12	G18
-      0x7C300000,  //  002D  CALL	R12	0
-      0x7C240600,  //  002E  CALL	R9	3
-      0x60280010,  //  002F  GETGBL	R10	G16
-      0x5C2C1200,  //  0030  MOVE	R11	R9
-      0x7C280200,  //  0031  CALL	R10	1
-      0xA8020017,  //  0032  EXBLK	0	#004B
-      0x5C2C1400,  //  0033  MOVE	R11	R10
-      0x7C2C0000,  //  0034  CALL	R11	0
-      0xB8320400,  //  0035  GETNGBL	R12	K2
-      0x88301912,  //  0036  GETMBR	R12	R12	K18
-      0x8C30190D,  //  0037  GETMET	R12	R12	K13
-      0x5C380000,  //  0038  MOVE	R14	R0
-      0x5C3C1600,  //  0039  MOVE	R15	R11
-      0x5C401000,  //  003A  MOVE	R16	R8
-      0x7C300800,  //  003B  CALL	R12	4
-      0x4C340000,  //  003C  LDNIL	R13
-      0x2034180D,  //  003D  NE	R13	R12	R13
-      0x7836000A,  //  003E  JMPF	R13	#004A
-      0x8C34190E,  //  003F  GETMET	R13	R12	K14
-      0x7C340200,  //  0040  CALL	R13	1
-      0x8C34190F,  //  0041  GETMET	R13	R12	K15
-      0x503C0200,  //  0042  LDBOOL	R15	1	0
-      0x7C340400,  //  0043  CALL	R13	2
-      0x8C340113,  //  0044  GETMET	R13	R0	K19
-      0x5C3C1800,  //  0045  MOVE	R15	R12
-      0x7C340400,  //  0046  CALL	R13	2
-      0x8C341113,  //  0047  GETMET	R13	R8	K19
-      0x5C3C1800,  //  0048  MOVE	R15	R12
-      0x7C340400,  //  0049  CALL	R13	2
-      0x7001FFE7,  //  004A  JMP		#0033
-      0x58280014,  //  004B  LDCONST	R10	K20
-      0xAC280200,  //  004C  CATCH	R10	1	0
-      0xB0080000,  //  004D  RAISE	2	R0	R0
-      0x88280104,  //  004E  GETMBR	R10	R0	K4
-      0x8C281515,  //  004F  GETMET	R10	R10	K21
-      0x5C301000,  //  0050  MOVE	R12	R8
-      0x7C280400,  //  0051  CALL	R10	2
-      0x7001FFC9,  //  0052  JMP		#001D
-      0x58180014,  //  0053  LDCONST	R6	K20
-      0xAC180200,  //  0054  CATCH	R6	1	0
-      0xB0080000,  //  0055  RAISE	2	R0	R0
-      0xB81A1400,  //  0056  GETNGBL	R6	K10
-      0x8C180D16,  //  0057  GETMET	R6	R6	K22
-      0x8C200317,  //  0058  GETMET	R8	R1	K23
-      0x58280018,  //  0059  LDCONST	R10	K24
-      0x602C000C,  //  005A  GETGBL	R11	G12
-      0x88300104,  //  005B  GETMBR	R12	R0	K4
-      0x7C2C0200,  //  005C  CALL	R11	1
-      0x7C200600,  //  005D  CALL	R8	3
-      0x58240019,  //  005E  LDCONST	R9	K25
-      0x7C180600,  //  005F  CALL	R6	3
-      0xA8040001,  //  0060  EXBLK	1	1
-      0x70020012,  //  0061  JMP		#0075
-      0xAC080002,  //  0062  CATCH	R2	0	2
-      0x7002000F,  //  0063  JMP		#0074
-      0x2010051A,  //  0064  NE	R4	R2	K26
-      0x7812000C,  //  0065  JMPF	R4	#0073
-      0xB8121400,  //  0066  GETNGBL	R4	K10
-      0x8C100916,  //  0067  GETMET	R4	R4	K22
-      0x60180008,  //  0068  GETGBL	R6	G8
-      0x5C1C0400,  //  0069  MOVE	R7	R2
-      0x7C180200,  //  006A  CALL	R6	1
-      0x001A3606,  //  006B  ADD	R6	K27	R6
-      0x00180D1C,  //  006C  ADD	R6	R6	K28
-      0x601C0008,  //  006D  GETGBL	R7	G8
-      0x5C200600,  //  006E  MOVE	R8	R3
-      0x7C1C0200,  //  006F  CALL	R7	1
-      0x00180C07,  //  0070  ADD	R6	R6	R7
-      0x581C0019,  //  0071  LDCONST	R7	K25
-      0x7C100600,  //  0072  CALL	R4	3
-      0x70020000,  //  0073  JMP		#0075
-      0xB0080000,  //  0074  RAISE	2	R0	R0
-      0x80000000,  //  0075  RET	0
+    ( &(const binstruction[117]) {  /* code */
+      0xA802005F,  //  0000  EXBLK	0	#0061
+      0xB8060200,  //  0001  GETNGBL	R1	K1
+      0x8C040302,  //  0002  GETMET	R1	R1	K2
+      0x7C040200,  //  0003  CALL	R1	1
+      0x90020001,  //  0004  SETMBR	R0	K0	R1
+      0xB8060200,  //  0005  GETNGBL	R1	K1
+      0x8C040302,  //  0006  GETMET	R1	R1	K2
+      0x7C040200,  //  0007  CALL	R1	1
+      0x90020601,  //  0008  SETMBR	R0	K3	R1
+      0x60040011,  //  0009  GETGBL	R1	G17
+      0x88080104,  //  000A  GETMBR	R2	R0	K4
+      0x7C040200,  //  000B  CALL	R1	1
+      0x8C080305,  //  000C  GETMET	R2	R1	K5
+      0x7C080200,  //  000D  CALL	R2	1
+      0x8C0C0306,  //  000E  GETMET	R3	R1	K6
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0xA40E0E00,  //  0010  IMPORT	R3	K7
+      0x8C100708,  //  0011  GETMET	R4	R3	K8
+      0x5C180400,  //  0012  MOVE	R6	R2
+      0x7C100400,  //  0013  CALL	R4	2
+      0x4C080000,  //  0014  LDNIL	R2
+      0xB8161200,  //  0015  GETNGBL	R5	K9
+      0x8C140B0A,  //  0016  GETMET	R5	R5	K10
+      0x7C140200,  //  0017  CALL	R5	1
+      0x60140010,  //  0018  GETGBL	R5	G16
+      0x5C180800,  //  0019  MOVE	R6	R4
+      0x7C140200,  //  001A  CALL	R5	1
+      0xA8020035,  //  001B  EXBLK	0	#0052
+      0x5C180A00,  //  001C  MOVE	R6	R5
+      0x7C180000,  //  001D  CALL	R6	0
+      0xB81E0200,  //  001E  GETNGBL	R7	K1
+      0x881C0F0B,  //  001F  GETMBR	R7	R7	K11
+      0x8C1C0F0C,  //  0020  GETMET	R7	R7	K12
+      0x5C240000,  //  0021  MOVE	R9	R0
+      0x5C280C00,  //  0022  MOVE	R10	R6
+      0x7C1C0600,  //  0023  CALL	R7	3
+      0x8C200F0D,  //  0024  GETMET	R8	R7	K13
+      0x7C200200,  //  0025  CALL	R8	1
+      0x8C200F0E,  //  0026  GETMET	R8	R7	K14
+      0x50280200,  //  0027  LDBOOL	R10	1	0
+      0x7C200400,  //  0028  CALL	R8	2
+      0x8C200D0F,  //  0029  GETMET	R8	R6	K15
+      0x58280010,  //  002A  LDCONST	R10	K16
+      0x602C0012,  //  002B  GETGBL	R11	G18
+      0x7C2C0000,  //  002C  CALL	R11	0
+      0x7C200600,  //  002D  CALL	R8	3
+      0x60240010,  //  002E  GETGBL	R9	G16
+      0x5C281000,  //  002F  MOVE	R10	R8
+      0x7C240200,  //  0030  CALL	R9	1
+      0xA8020017,  //  0031  EXBLK	0	#004A
+      0x5C281200,  //  0032  MOVE	R10	R9
+      0x7C280000,  //  0033  CALL	R10	0
+      0xB82E0200,  //  0034  GETNGBL	R11	K1
+      0x882C1711,  //  0035  GETMBR	R11	R11	K17
+      0x8C2C170C,  //  0036  GETMET	R11	R11	K12
+      0x5C340000,  //  0037  MOVE	R13	R0
+      0x5C381400,  //  0038  MOVE	R14	R10
+      0x5C3C0E00,  //  0039  MOVE	R15	R7
+      0x7C2C0800,  //  003A  CALL	R11	4
+      0x4C300000,  //  003B  LDNIL	R12
+      0x2030160C,  //  003C  NE	R12	R11	R12
+      0x7832000A,  //  003D  JMPF	R12	#0049
+      0x8C30170D,  //  003E  GETMET	R12	R11	K13
+      0x7C300200,  //  003F  CALL	R12	1
+      0x8C30170E,  //  0040  GETMET	R12	R11	K14
+      0x50380200,  //  0041  LDBOOL	R14	1	0
+      0x7C300400,  //  0042  CALL	R12	2
+      0x8C300112,  //  0043  GETMET	R12	R0	K18
+      0x5C381600,  //  0044  MOVE	R14	R11
+      0x7C300400,  //  0045  CALL	R12	2
+      0x8C300F12,  //  0046  GETMET	R12	R7	K18
+      0x5C381600,  //  0047  MOVE	R14	R11
+      0x7C300400,  //  0048  CALL	R12	2
+      0x7001FFE7,  //  0049  JMP		#0032
+      0x58240013,  //  004A  LDCONST	R9	K19
+      0xAC240200,  //  004B  CATCH	R9	1	0
+      0xB0080000,  //  004C  RAISE	2	R0	R0
+      0x88240103,  //  004D  GETMBR	R9	R0	K3
+      0x8C241314,  //  004E  GETMET	R9	R9	K20
+      0x5C2C0E00,  //  004F  MOVE	R11	R7
+      0x7C240400,  //  0050  CALL	R9	2
+      0x7001FFC9,  //  0051  JMP		#001C
+      0x58140013,  //  0052  LDCONST	R5	K19
+      0xAC140200,  //  0053  CATCH	R5	1	0
+      0xB0080000,  //  0054  RAISE	2	R0	R0
+      0xB8161200,  //  0055  GETNGBL	R5	K9
+      0x8C140B15,  //  0056  GETMET	R5	R5	K21
+      0x601C0018,  //  0057  GETGBL	R7	G24
+      0x58200016,  //  0058  LDCONST	R8	K22
+      0x6024000C,  //  0059  GETGBL	R9	G12
+      0x88280103,  //  005A  GETMBR	R10	R0	K3
+      0x7C240200,  //  005B  CALL	R9	1
+      0x7C1C0400,  //  005C  CALL	R7	2
+      0x58200017,  //  005D  LDCONST	R8	K23
+      0x7C140600,  //  005E  CALL	R5	3
+      0xA8040001,  //  005F  EXBLK	1	1
+      0x70020012,  //  0060  JMP		#0074
+      0xAC040002,  //  0061  CATCH	R1	0	2
+      0x7002000F,  //  0062  JMP		#0073
+      0x200C0318,  //  0063  NE	R3	R1	K24
+      0x780E000C,  //  0064  JMPF	R3	#0072
+      0xB80E1200,  //  0065  GETNGBL	R3	K9
+      0x8C0C0715,  //  0066  GETMET	R3	R3	K21
+      0x60140008,  //  0067  GETGBL	R5	G8
+      0x5C180200,  //  0068  MOVE	R6	R1
+      0x7C140200,  //  0069  CALL	R5	1
+      0x00163205,  //  006A  ADD	R5	K25	R5
+      0x00140B1A,  //  006B  ADD	R5	R5	K26
+      0x60180008,  //  006C  GETGBL	R6	G8
+      0x5C1C0400,  //  006D  MOVE	R7	R2
+      0x7C180200,  //  006E  CALL	R6	1
+      0x00140A06,  //  006F  ADD	R5	R5	R6
+      0x58180017,  //  0070  LDCONST	R6	K23
+      0x7C0C0600,  //  0071  CALL	R3	3
+      0x70020000,  //  0072  JMP		#0074
+      0xB0080000,  //  0073  RAISE	2	R0	R0
+      0x80000000,  //  0074  RET	0
     })
   )
 );
@@ -1088,7 +1085,7 @@ be_local_closure(Matter_Session_Store_sessions_active,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    12,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1096,61 +1093,58 @@ be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name *
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(sessions),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20session_X2Eresumption_id_X3D_X25s_X20vs_X20_X25s),
-    /* K7   */  be_nested_str_weak(resumption_id),
-    /* K8   */  be_nested_str_weak(shared_secret),
-    /* K9   */  be_nested_str_weak(update),
-    /* K10  */  be_const_int(1),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20session_X2Eresumption_id_X3D_X25s_X20vs_X20_X25s),
+    /* K5   */  be_nested_str_weak(resumption_id),
+    /* K6   */  be_nested_str_weak(shared_secret),
+    /* K7   */  be_nested_str_weak(update),
+    /* K8   */  be_const_int(1),
     }),
     be_str_weak(find_session_by_resumption_id),
     &be_const_str_solidified,
-    ( &(const binstruction[39]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x740E0001,  //  0002  JMPT	R3	#0005
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x80040600,  //  0004  RET	1	R3
-      0x580C0001,  //  0005  LDCONST	R3	K1
-      0x88100102,  //  0006  GETMBR	R4	R0	K2
-      0x6014000C,  //  0007  GETGBL	R5	G12
-      0x5C180800,  //  0008  MOVE	R6	R4
-      0x7C140200,  //  0009  CALL	R5	1
-      0x14140605,  //  000A  LT	R5	R3	R5
-      0x78160019,  //  000B  JMPF	R5	#0026
-      0x94140803,  //  000C  GETIDX	R5	R4	R3
-      0xB81A0600,  //  000D  GETNGBL	R6	K3
-      0x8C180D04,  //  000E  GETMET	R6	R6	K4
-      0x8C200505,  //  000F  GETMET	R8	R2	K5
-      0x58280006,  //  0010  LDCONST	R10	K6
-      0x602C0008,  //  0011  GETGBL	R11	G8
-      0x88300B07,  //  0012  GETMBR	R12	R5	K7
-      0x7C2C0200,  //  0013  CALL	R11	1
-      0x60300008,  //  0014  GETGBL	R12	G8
-      0x5C340200,  //  0015  MOVE	R13	R1
-      0x7C300200,  //  0016  CALL	R12	1
-      0x7C200800,  //  0017  CALL	R8	4
-      0x54260003,  //  0018  LDINT	R9	4
-      0x7C180600,  //  0019  CALL	R6	3
-      0x88180B07,  //  001A  GETMBR	R6	R5	K7
-      0x1C180C01,  //  001B  EQ	R6	R6	R1
-      0x781A0006,  //  001C  JMPF	R6	#0024
-      0x88180B08,  //  001D  GETMBR	R6	R5	K8
-      0x4C1C0000,  //  001E  LDNIL	R7
-      0x20180C07,  //  001F  NE	R6	R6	R7
-      0x781A0002,  //  0020  JMPF	R6	#0024
-      0x8C180B09,  //  0021  GETMET	R6	R5	K9
-      0x7C180200,  //  0022  CALL	R6	1
-      0x80040A00,  //  0023  RET	1	R5
-      0x000C070A,  //  0024  ADD	R3	R3	K10
-      0x7001FFE0,  //  0025  JMP		#0007
-      0x80000000,  //  0026  RET	0
+    ( &(const binstruction[38]) {  /* code */
+      0x5C080200,  //  0000  MOVE	R2	R1
+      0x740A0001,  //  0001  JMPT	R2	#0004
+      0x4C080000,  //  0002  LDNIL	R2
+      0x80040400,  //  0003  RET	1	R2
+      0x58080000,  //  0004  LDCONST	R2	K0
+      0x880C0101,  //  0005  GETMBR	R3	R0	K1
+      0x6010000C,  //  0006  GETGBL	R4	G12
+      0x5C140600,  //  0007  MOVE	R5	R3
+      0x7C100200,  //  0008  CALL	R4	1
+      0x14100404,  //  0009  LT	R4	R2	R4
+      0x78120019,  //  000A  JMPF	R4	#0025
+      0x94100602,  //  000B  GETIDX	R4	R3	R2
+      0xB8160400,  //  000C  GETNGBL	R5	K2
+      0x8C140B03,  //  000D  GETMET	R5	R5	K3
+      0x601C0018,  //  000E  GETGBL	R7	G24
+      0x58200004,  //  000F  LDCONST	R8	K4
+      0x60240008,  //  0010  GETGBL	R9	G8
+      0x88280905,  //  0011  GETMBR	R10	R4	K5
+      0x7C240200,  //  0012  CALL	R9	1
+      0x60280008,  //  0013  GETGBL	R10	G8
+      0x5C2C0200,  //  0014  MOVE	R11	R1
+      0x7C280200,  //  0015  CALL	R10	1
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x54220003,  //  0017  LDINT	R8	4
+      0x7C140600,  //  0018  CALL	R5	3
+      0x88140905,  //  0019  GETMBR	R5	R4	K5
+      0x1C140A01,  //  001A  EQ	R5	R5	R1
+      0x78160006,  //  001B  JMPF	R5	#0023
+      0x88140906,  //  001C  GETMBR	R5	R4	K6
+      0x4C180000,  //  001D  LDNIL	R6
+      0x20140A06,  //  001E  NE	R5	R5	R6
+      0x78160002,  //  001F  JMPF	R5	#0023
+      0x8C140907,  //  0020  GETMET	R5	R4	K7
+      0x7C140200,  //  0021  CALL	R5	1
+      0x80040800,  //  0022  RET	1	R4
+      0x00080508,  //  0023  ADD	R2	R2	K8
+      0x7001FFE0,  //  0024  JMP		#0006
+      0x80000000,  //  0025  RET	0
     })
   )
 );
@@ -1162,7 +1156,7 @@ be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name *
 ********************************************************************/
 be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    12,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1170,7 +1164,7 @@ be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
+    ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
     /* K1   */  be_nested_str_weak(remove_expired),
     /* K2   */  be_const_int(0),
@@ -1185,25 +1179,23 @@ be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
     /* K11  */  be_nested_str_weak(concat),
     /* K12  */  be_nested_str_weak(_X2C),
     /* K13  */  be_nested_str_weak(_X5D),
-    /* K14  */  be_nested_str_weak(string),
-    /* K15  */  be_nested_str_weak(_FABRICS),
-    /* K16  */  be_nested_str_weak(w),
-    /* K17  */  be_nested_str_weak(write),
-    /* K18  */  be_nested_str_weak(close),
-    /* K19  */  be_nested_str_weak(tasmota),
-    /* K20  */  be_nested_str_weak(log),
-    /* K21  */  be_nested_str_weak(format),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20_X25i_X20fabric_X28s_X29_X20and_X20_X25i_X20session_X28s_X29),
-    /* K23  */  be_const_int(3),
-    /* K24  */  be_nested_str_weak(device),
-    /* K25  */  be_nested_str_weak(event_fabrics_saved),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K27  */  be_nested_str_weak(_X7C),
-    /* K28  */  be_const_int(2),
+    /* K14  */  be_nested_str_weak(_FABRICS),
+    /* K15  */  be_nested_str_weak(w),
+    /* K16  */  be_nested_str_weak(write),
+    /* K17  */  be_nested_str_weak(close),
+    /* K18  */  be_nested_str_weak(tasmota),
+    /* K19  */  be_nested_str_weak(log),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20_X25i_X20fabric_X28s_X29_X20and_X20_X25i_X20session_X28s_X29),
+    /* K21  */  be_const_int(3),
+    /* K22  */  be_nested_str_weak(device),
+    /* K23  */  be_nested_str_weak(event_fabrics_saved),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+    /* K25  */  be_nested_str_weak(_X7C),
+    /* K26  */  be_const_int(2),
     }),
     be_str_weak(save_fabrics),
     &be_const_str_solidified,
-    ( &(const binstruction[87]) {  /* code */
+    ( &(const binstruction[86]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x8C080101,  //  0001  GETMET	R2	R0	K1
       0x7C080200,  //  0002  CALL	R2	1
@@ -1248,49 +1240,48 @@ be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
       0x00161405,  //  0029  ADD	R5	K10	R5
       0x00140B0D,  //  002A  ADD	R5	R5	K13
       0x5C0C0A00,  //  002B  MOVE	R3	R5
-      0xA8020017,  //  002C  EXBLK	0	#0045
-      0xA4161C00,  //  002D  IMPORT	R5	K14
-      0x60180011,  //  002E  GETGBL	R6	G17
-      0x881C010F,  //  002F  GETMBR	R7	R0	K15
-      0x58200010,  //  0030  LDCONST	R8	K16
-      0x7C180400,  //  0031  CALL	R6	2
-      0x8C1C0D11,  //  0032  GETMET	R7	R6	K17
-      0x5C240600,  //  0033  MOVE	R9	R3
-      0x7C1C0400,  //  0034  CALL	R7	2
-      0x8C1C0D12,  //  0035  GETMET	R7	R6	K18
-      0x7C1C0200,  //  0036  CALL	R7	1
-      0xB81E2600,  //  0037  GETNGBL	R7	K19
-      0x8C1C0F14,  //  0038  GETMET	R7	R7	K20
-      0x8C240B15,  //  0039  GETMET	R9	R5	K21
-      0x582C0016,  //  003A  LDCONST	R11	K22
-      0x5C300800,  //  003B  MOVE	R12	R4
-      0x5C340400,  //  003C  MOVE	R13	R2
-      0x7C240800,  //  003D  CALL	R9	4
-      0x58280017,  //  003E  LDCONST	R10	K23
-      0x7C1C0600,  //  003F  CALL	R7	3
-      0x881C0118,  //  0040  GETMBR	R7	R0	K24
-      0x8C1C0F19,  //  0041  GETMET	R7	R7	K25
-      0x7C1C0200,  //  0042  CALL	R7	1
-      0xA8040001,  //  0043  EXBLK	1	1
-      0x70020010,  //  0044  JMP		#0056
-      0xAC140002,  //  0045  CATCH	R5	0	2
-      0x7002000D,  //  0046  JMP		#0055
-      0xB81E2600,  //  0047  GETNGBL	R7	K19
-      0x8C1C0F14,  //  0048  GETMET	R7	R7	K20
-      0x60240008,  //  0049  GETGBL	R9	G8
-      0x5C280A00,  //  004A  MOVE	R10	R5
-      0x7C240200,  //  004B  CALL	R9	1
-      0x00263409,  //  004C  ADD	R9	K26	R9
-      0x0024131B,  //  004D  ADD	R9	R9	K27
-      0x60280008,  //  004E  GETGBL	R10	G8
-      0x5C2C0C00,  //  004F  MOVE	R11	R6
-      0x7C280200,  //  0050  CALL	R10	1
-      0x0024120A,  //  0051  ADD	R9	R9	R10
-      0x5828001C,  //  0052  LDCONST	R10	K28
-      0x7C1C0600,  //  0053  CALL	R7	3
-      0x70020000,  //  0054  JMP		#0056
-      0xB0080000,  //  0055  RAISE	2	R0	R0
-      0x80000000,  //  0056  RET	0
+      0xA8020016,  //  002C  EXBLK	0	#0044
+      0x60140011,  //  002D  GETGBL	R5	G17
+      0x8818010E,  //  002E  GETMBR	R6	R0	K14
+      0x581C000F,  //  002F  LDCONST	R7	K15
+      0x7C140400,  //  0030  CALL	R5	2
+      0x8C180B10,  //  0031  GETMET	R6	R5	K16
+      0x5C200600,  //  0032  MOVE	R8	R3
+      0x7C180400,  //  0033  CALL	R6	2
+      0x8C180B11,  //  0034  GETMET	R6	R5	K17
+      0x7C180200,  //  0035  CALL	R6	1
+      0xB81A2400,  //  0036  GETNGBL	R6	K18
+      0x8C180D13,  //  0037  GETMET	R6	R6	K19
+      0x60200018,  //  0038  GETGBL	R8	G24
+      0x58240014,  //  0039  LDCONST	R9	K20
+      0x5C280800,  //  003A  MOVE	R10	R4
+      0x5C2C0400,  //  003B  MOVE	R11	R2
+      0x7C200600,  //  003C  CALL	R8	3
+      0x58240015,  //  003D  LDCONST	R9	K21
+      0x7C180600,  //  003E  CALL	R6	3
+      0x88180116,  //  003F  GETMBR	R6	R0	K22
+      0x8C180D17,  //  0040  GETMET	R6	R6	K23
+      0x7C180200,  //  0041  CALL	R6	1
+      0xA8040001,  //  0042  EXBLK	1	1
+      0x70020010,  //  0043  JMP		#0055
+      0xAC140002,  //  0044  CATCH	R5	0	2
+      0x7002000D,  //  0045  JMP		#0054
+      0xB81E2400,  //  0046  GETNGBL	R7	K18
+      0x8C1C0F13,  //  0047  GETMET	R7	R7	K19
+      0x60240008,  //  0048  GETGBL	R9	G8
+      0x5C280A00,  //  0049  MOVE	R10	R5
+      0x7C240200,  //  004A  CALL	R9	1
+      0x00263009,  //  004B  ADD	R9	K24	R9
+      0x00241319,  //  004C  ADD	R9	R9	K25
+      0x60280008,  //  004D  GETGBL	R10	G8
+      0x5C2C0C00,  //  004E  MOVE	R11	R6
+      0x7C280200,  //  004F  CALL	R10	1
+      0x0024120A,  //  0050  ADD	R9	R9	R10
+      0x5828001A,  //  0051  LDCONST	R10	K26
+      0x7C1C0600,  //  0052  CALL	R7	3
+      0x70020000,  //  0053  JMP		#0055
+      0xB0080000,  //  0054  RAISE	2	R0	R0
+      0x80000000,  //  0055  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TCP_async.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TCP_async.h
@@ -46,7 +46,7 @@ be_local_closure(Matter_TCP_async_read,   /* name */
 ********************************************************************/
 be_local_closure(Matter_TCP_async_begin,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    7,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -54,7 +54,7 @@ be_local_closure(Matter_TCP_async_begin,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
+    ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_nested_str_weak(reset),
     /* K1   */  be_nested_str_weak(tasmota),
     /* K2   */  be_nested_str_weak(wifi),
@@ -72,18 +72,16 @@ be_local_closure(Matter_TCP_async_begin,   /* name */
     /* K14  */  be_nested_str_weak(remove_fast_loop),
     /* K15  */  be_nested_str_weak(add_fast_loop),
     /* K16  */  be_nested_str_weak(add_driver),
-    /* K17  */  be_nested_str_weak(string),
-    /* K18  */  be_nested_str_weak(log),
-    /* K19  */  be_nested_str_weak(format),
-    /* K20  */  be_nested_str_weak(BRY_X3A_X20failed_X20to_X20resolve_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K21  */  be_const_int(3),
-    /* K22  */  be_nested_str_weak(close),
-    /* K23  */  be_nested_str_weak(tcp_connected),
-    /* K24  */  be_nested_str_weak(event_dnsfailed),
+    /* K17  */  be_nested_str_weak(log),
+    /* K18  */  be_nested_str_weak(BRY_X3A_X20failed_X20to_X20resolve_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K19  */  be_const_int(3),
+    /* K20  */  be_nested_str_weak(close),
+    /* K21  */  be_nested_str_weak(tcp_connected),
+    /* K22  */  be_nested_str_weak(event_dnsfailed),
     }),
     be_str_weak(begin),
     &be_const_str_solidified,
-    ( &(const binstruction[64]) {  /* code */
+    ( &(const binstruction[63]) {  /* code */
       0x8C040100,  //  0000  GETMET	R1	R0	K0
       0x7C040200,  //  0001  CALL	R1	1
       0xB8060200,  //  0002  GETNGBL	R1	K1
@@ -126,28 +124,27 @@ be_local_closure(Matter_TCP_async_begin,   /* name */
       0x7C040400,  //  0027  CALL	R1	2
       0x50040200,  //  0028  LDBOOL	R1	1	0
       0x80040200,  //  0029  RET	1	R1
-      0x70020013,  //  002A  JMP		#003F
-      0xA4062200,  //  002B  IMPORT	R1	K17
-      0xB80A0200,  //  002C  GETNGBL	R2	K1
-      0x8C080512,  //  002D  GETMET	R2	R2	K18
-      0x8C100313,  //  002E  GETMET	R4	R1	K19
-      0x58180014,  //  002F  LDCONST	R6	K20
-      0x881C010B,  //  0030  GETMBR	R7	R0	K11
-      0x8820010C,  //  0031  GETMBR	R8	R0	K12
-      0x7C100800,  //  0032  CALL	R4	4
-      0x58140015,  //  0033  LDCONST	R5	K21
-      0x7C080600,  //  0034  CALL	R2	3
-      0x8C080116,  //  0035  GETMET	R2	R0	K22
-      0x7C080200,  //  0036  CALL	R2	1
-      0x5409FFFE,  //  0037  LDINT	R2	-1
-      0x90020E02,  //  0038  SETMBR	R0	K7	R2
-      0x50080000,  //  0039  LDBOOL	R2	0	0
-      0x90022E02,  //  003A  SETMBR	R0	K23	R2
-      0x8C080118,  //  003B  GETMET	R2	R0	K24
-      0x7C080200,  //  003C  CALL	R2	1
-      0x50080000,  //  003D  LDBOOL	R2	0	0
-      0x80040400,  //  003E  RET	1	R2
-      0x80000000,  //  003F  RET	0
+      0x70020012,  //  002A  JMP		#003E
+      0xB8060200,  //  002B  GETNGBL	R1	K1
+      0x8C040311,  //  002C  GETMET	R1	R1	K17
+      0x600C0018,  //  002D  GETGBL	R3	G24
+      0x58100012,  //  002E  LDCONST	R4	K18
+      0x8814010B,  //  002F  GETMBR	R5	R0	K11
+      0x8818010C,  //  0030  GETMBR	R6	R0	K12
+      0x7C0C0600,  //  0031  CALL	R3	3
+      0x58100013,  //  0032  LDCONST	R4	K19
+      0x7C040600,  //  0033  CALL	R1	3
+      0x8C040114,  //  0034  GETMET	R1	R0	K20
+      0x7C040200,  //  0035  CALL	R1	1
+      0x5405FFFE,  //  0036  LDINT	R1	-1
+      0x90020E01,  //  0037  SETMBR	R0	K7	R1
+      0x50040000,  //  0038  LDBOOL	R1	0	0
+      0x90022A01,  //  0039  SETMBR	R0	K21	R1
+      0x8C040116,  //  003A  GETMET	R1	R0	K22
+      0x7C040200,  //  003B  CALL	R1	1
+      0x50040000,  //  003C  LDBOOL	R1	0	0
+      0x80040200,  //  003D  RET	1	R1
+      0x80000000,  //  003E  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
@@ -795,7 +795,7 @@ be_local_closure(Matter_TLV_item_set_fulltag,   /* name */
 ********************************************************************/
 be_local_closure(Matter_TLV_item_tostring,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -803,211 +803,209 @@ be_local_closure(Matter_TLV_item_tostring,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[35]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(),
-    /* K2   */  be_nested_str_weak(tag_profile),
-    /* K3   */  be_nested_str_weak(Matter_X3A_X3A),
-    /* K4   */  be_nested_str_weak(tag_number),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(0x_X2508X_X20),
-    /* K7   */  be_nested_str_weak(tag_vendor),
-    /* K8   */  be_nested_str_weak(0x_X2504X_X3A_X3A),
-    /* K9   */  be_nested_str_weak(0x_X2504X_X3A),
-    /* K10  */  be_nested_str_weak(tag_sub),
-    /* K11  */  be_nested_str_weak(_X25i_X20),
-    /* K12  */  be_const_int(0),
-    /* K13  */  be_nested_str_weak(_X3D_X20),
-    /* K14  */  be_nested_str_weak(val),
-    /* K15  */  be_nested_str_weak(int),
-    /* K16  */  be_nested_str_weak(_X25i),
-    /* K17  */  be_nested_str_weak(typ),
-    /* K18  */  be_nested_str_weak(TLV),
-    /* K19  */  be_nested_str_weak(U1),
-    /* K20  */  be_nested_str_weak(U8),
-    /* K21  */  be_nested_str_weak(U),
-    /* K22  */  be_nested_str_weak(bool),
-    /* K23  */  be_nested_str_weak(true),
-    /* K24  */  be_nested_str_weak(false),
-    /* K25  */  be_nested_str_weak(null),
-    /* K26  */  be_nested_str_weak(real),
-    /* K27  */  be_nested_str_weak(_X25g),
-    /* K28  */  be_nested_str_weak(_X22_X25s_X22),
-    /* K29  */  be_nested_str_weak(int64),
-    /* K30  */  be_nested_str_weak(tostring),
-    /* K31  */  be_nested_str_weak(instance),
-    /* K32  */  be_nested_str_weak(_X25s),
-    /* K33  */  be_nested_str_weak(tohex),
-    /* K34  */  be_nested_str_weak(_X20),
+    ( &(const bvalue[34]) {     /* constants */
+    /* K0   */  be_nested_str_weak(),
+    /* K1   */  be_nested_str_weak(tag_profile),
+    /* K2   */  be_nested_str_weak(Matter_X3A_X3A),
+    /* K3   */  be_nested_str_weak(tag_number),
+    /* K4   */  be_nested_str_weak(0x_X2508X_X20),
+    /* K5   */  be_nested_str_weak(tag_vendor),
+    /* K6   */  be_nested_str_weak(0x_X2504X_X3A_X3A),
+    /* K7   */  be_nested_str_weak(0x_X2504X_X3A),
+    /* K8   */  be_nested_str_weak(tag_sub),
+    /* K9   */  be_nested_str_weak(_X25i_X20),
+    /* K10  */  be_const_int(0),
+    /* K11  */  be_nested_str_weak(_X3D_X20),
+    /* K12  */  be_nested_str_weak(val),
+    /* K13  */  be_nested_str_weak(int),
+    /* K14  */  be_nested_str_weak(_X25i),
+    /* K15  */  be_nested_str_weak(typ),
+    /* K16  */  be_nested_str_weak(TLV),
+    /* K17  */  be_nested_str_weak(U1),
+    /* K18  */  be_nested_str_weak(U8),
+    /* K19  */  be_nested_str_weak(U),
+    /* K20  */  be_nested_str_weak(bool),
+    /* K21  */  be_nested_str_weak(true),
+    /* K22  */  be_nested_str_weak(false),
+    /* K23  */  be_nested_str_weak(null),
+    /* K24  */  be_nested_str_weak(real),
+    /* K25  */  be_nested_str_weak(_X25g),
+    /* K26  */  be_nested_str_weak(string),
+    /* K27  */  be_nested_str_weak(_X22_X25s_X22),
+    /* K28  */  be_nested_str_weak(int64),
+    /* K29  */  be_nested_str_weak(tostring),
+    /* K30  */  be_nested_str_weak(instance),
+    /* K31  */  be_nested_str_weak(_X25s),
+    /* K32  */  be_nested_str_weak(tohex),
+    /* K33  */  be_nested_str_weak(_X20),
     }),
     be_str_weak(tostring),
     &be_const_str_solidified,
-    ( &(const binstruction[165]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x58080001,  //  0001  LDCONST	R2	K1
-      0xA8020099,  //  0002  EXBLK	0	#009D
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
-      0x5411FFFE,  //  0004  LDINT	R4	-1
-      0x1C0C0604,  //  0005  EQ	R3	R3	R4
-      0x780E000A,  //  0006  JMPF	R3	#0012
-      0x00080503,  //  0007  ADD	R2	R2	K3
-      0x880C0104,  //  0008  GETMBR	R3	R0	K4
-      0x4C100000,  //  0009  LDNIL	R4
-      0x200C0604,  //  000A  NE	R3	R3	R4
-      0x780E0004,  //  000B  JMPF	R3	#0011
-      0x8C0C0305,  //  000C  GETMET	R3	R1	K5
-      0x58140006,  //  000D  LDCONST	R5	K6
-      0x88180104,  //  000E  GETMBR	R6	R0	K4
-      0x7C0C0600,  //  000F  CALL	R3	3
-      0x00080403,  //  0010  ADD	R2	R2	R3
-      0x70020023,  //  0011  JMP		#0036
-      0x880C0107,  //  0012  GETMBR	R3	R0	K7
-      0x4C100000,  //  0013  LDNIL	R4
-      0x200C0604,  //  0014  NE	R3	R3	R4
-      0x780E0004,  //  0015  JMPF	R3	#001B
-      0x8C0C0305,  //  0016  GETMET	R3	R1	K5
-      0x58140008,  //  0017  LDCONST	R5	K8
-      0x88180107,  //  0018  GETMBR	R6	R0	K7
-      0x7C0C0600,  //  0019  CALL	R3	3
-      0x00080403,  //  001A  ADD	R2	R2	R3
-      0x880C0102,  //  001B  GETMBR	R3	R0	K2
-      0x4C100000,  //  001C  LDNIL	R4
-      0x200C0604,  //  001D  NE	R3	R3	R4
-      0x780E0004,  //  001E  JMPF	R3	#0024
-      0x8C0C0305,  //  001F  GETMET	R3	R1	K5
-      0x58140009,  //  0020  LDCONST	R5	K9
-      0x88180102,  //  0021  GETMBR	R6	R0	K2
-      0x7C0C0600,  //  0022  CALL	R3	3
-      0x00080403,  //  0023  ADD	R2	R2	R3
-      0x880C0104,  //  0024  GETMBR	R3	R0	K4
-      0x4C100000,  //  0025  LDNIL	R4
-      0x200C0604,  //  0026  NE	R3	R3	R4
-      0x780E0004,  //  0027  JMPF	R3	#002D
-      0x8C0C0305,  //  0028  GETMET	R3	R1	K5
-      0x58140006,  //  0029  LDCONST	R5	K6
-      0x88180104,  //  002A  GETMBR	R6	R0	K4
-      0x7C0C0600,  //  002B  CALL	R3	3
-      0x00080403,  //  002C  ADD	R2	R2	R3
-      0x880C010A,  //  002D  GETMBR	R3	R0	K10
-      0x4C100000,  //  002E  LDNIL	R4
-      0x200C0604,  //  002F  NE	R3	R3	R4
-      0x780E0004,  //  0030  JMPF	R3	#0036
-      0x8C0C0305,  //  0031  GETMET	R3	R1	K5
-      0x5814000B,  //  0032  LDCONST	R5	K11
-      0x8818010A,  //  0033  GETMBR	R6	R0	K10
-      0x7C0C0600,  //  0034  CALL	R3	3
-      0x00080403,  //  0035  ADD	R2	R2	R3
-      0x600C000C,  //  0036  GETGBL	R3	G12
-      0x5C100400,  //  0037  MOVE	R4	R2
-      0x7C0C0200,  //  0038  CALL	R3	1
-      0x240C070C,  //  0039  GT	R3	R3	K12
-      0x780E0000,  //  003A  JMPF	R3	#003C
-      0x0008050D,  //  003B  ADD	R2	R2	K13
-      0x600C0004,  //  003C  GETGBL	R3	G4
-      0x8810010E,  //  003D  GETMBR	R4	R0	K14
-      0x7C0C0200,  //  003E  CALL	R3	1
-      0x1C0C070F,  //  003F  EQ	R3	R3	K15
-      0x780E0010,  //  0040  JMPF	R3	#0052
-      0x8C0C0305,  //  0041  GETMET	R3	R1	K5
-      0x58140010,  //  0042  LDCONST	R5	K16
-      0x8818010E,  //  0043  GETMBR	R6	R0	K14
-      0x7C0C0600,  //  0044  CALL	R3	3
-      0x00080403,  //  0045  ADD	R2	R2	R3
-      0x880C0111,  //  0046  GETMBR	R3	R0	K17
-      0x88100112,  //  0047  GETMBR	R4	R0	K18
-      0x88100913,  //  0048  GETMBR	R4	R4	K19
-      0x280C0604,  //  0049  GE	R3	R3	R4
-      0x780E0005,  //  004A  JMPF	R3	#0051
-      0x880C0111,  //  004B  GETMBR	R3	R0	K17
-      0x88100112,  //  004C  GETMBR	R4	R0	K18
-      0x88100914,  //  004D  GETMBR	R4	R4	K20
-      0x180C0604,  //  004E  LE	R3	R3	R4
-      0x780E0000,  //  004F  JMPF	R3	#0051
-      0x00080515,  //  0050  ADD	R2	R2	K21
-      0x70020048,  //  0051  JMP		#009B
-      0x600C0004,  //  0052  GETGBL	R3	G4
-      0x8810010E,  //  0053  GETMBR	R4	R0	K14
-      0x7C0C0200,  //  0054  CALL	R3	1
-      0x1C0C0716,  //  0055  EQ	R3	R3	K22
-      0x780E0006,  //  0056  JMPF	R3	#005E
-      0x880C010E,  //  0057  GETMBR	R3	R0	K14
-      0x780E0001,  //  0058  JMPF	R3	#005B
-      0x580C0017,  //  0059  LDCONST	R3	K23
-      0x70020000,  //  005A  JMP		#005C
-      0x580C0018,  //  005B  LDCONST	R3	K24
-      0x00080403,  //  005C  ADD	R2	R2	R3
-      0x7002003C,  //  005D  JMP		#009B
-      0x880C010E,  //  005E  GETMBR	R3	R0	K14
-      0x4C100000,  //  005F  LDNIL	R4
-      0x1C0C0604,  //  0060  EQ	R3	R3	R4
-      0x780E0001,  //  0061  JMPF	R3	#0064
-      0x00080519,  //  0062  ADD	R2	R2	K25
-      0x70020036,  //  0063  JMP		#009B
-      0x600C0004,  //  0064  GETGBL	R3	G4
-      0x8810010E,  //  0065  GETMBR	R4	R0	K14
-      0x7C0C0200,  //  0066  CALL	R3	1
-      0x1C0C071A,  //  0067  EQ	R3	R3	K26
-      0x780E0005,  //  0068  JMPF	R3	#006F
-      0x8C0C0305,  //  0069  GETMET	R3	R1	K5
-      0x5814001B,  //  006A  LDCONST	R5	K27
-      0x8818010E,  //  006B  GETMBR	R6	R0	K14
-      0x7C0C0600,  //  006C  CALL	R3	3
-      0x00080403,  //  006D  ADD	R2	R2	R3
-      0x7002002B,  //  006E  JMP		#009B
-      0x600C0004,  //  006F  GETGBL	R3	G4
-      0x8810010E,  //  0070  GETMBR	R4	R0	K14
-      0x7C0C0200,  //  0071  CALL	R3	1
-      0x1C0C0700,  //  0072  EQ	R3	R3	K0
-      0x780E0005,  //  0073  JMPF	R3	#007A
-      0x8C0C0305,  //  0074  GETMET	R3	R1	K5
-      0x5814001C,  //  0075  LDCONST	R5	K28
-      0x8818010E,  //  0076  GETMBR	R6	R0	K14
-      0x7C0C0600,  //  0077  CALL	R3	3
-      0x00080403,  //  0078  ADD	R2	R2	R3
-      0x70020020,  //  0079  JMP		#009B
-      0x600C000F,  //  007A  GETGBL	R3	G15
-      0x8810010E,  //  007B  GETMBR	R4	R0	K14
-      0xB8163A00,  //  007C  GETNGBL	R5	K29
-      0x7C0C0400,  //  007D  CALL	R3	2
-      0x780E000F,  //  007E  JMPF	R3	#008F
-      0x880C010E,  //  007F  GETMBR	R3	R0	K14
-      0x8C0C071E,  //  0080  GETMET	R3	R3	K30
-      0x7C0C0200,  //  0081  CALL	R3	1
-      0x00080403,  //  0082  ADD	R2	R2	R3
-      0x880C0111,  //  0083  GETMBR	R3	R0	K17
-      0x88100112,  //  0084  GETMBR	R4	R0	K18
-      0x88100913,  //  0085  GETMBR	R4	R4	K19
-      0x280C0604,  //  0086  GE	R3	R3	R4
-      0x780E0005,  //  0087  JMPF	R3	#008E
-      0x880C0111,  //  0088  GETMBR	R3	R0	K17
-      0x88100112,  //  0089  GETMBR	R4	R0	K18
-      0x88100914,  //  008A  GETMBR	R4	R4	K20
-      0x180C0604,  //  008B  LE	R3	R3	R4
-      0x780E0000,  //  008C  JMPF	R3	#008E
-      0x00080515,  //  008D  ADD	R2	R2	K21
-      0x7002000B,  //  008E  JMP		#009B
-      0x600C0004,  //  008F  GETGBL	R3	G4
-      0x8810010E,  //  0090  GETMBR	R4	R0	K14
-      0x7C0C0200,  //  0091  CALL	R3	1
-      0x1C0C071F,  //  0092  EQ	R3	R3	K31
-      0x780E0006,  //  0093  JMPF	R3	#009B
-      0x8C0C0305,  //  0094  GETMET	R3	R1	K5
-      0x58140020,  //  0095  LDCONST	R5	K32
-      0x8818010E,  //  0096  GETMBR	R6	R0	K14
-      0x8C180D21,  //  0097  GETMET	R6	R6	K33
-      0x7C180200,  //  0098  CALL	R6	1
-      0x7C0C0600,  //  0099  CALL	R3	3
-      0x00080403,  //  009A  ADD	R2	R2	R3
-      0xA8040001,  //  009B  EXBLK	1	1
-      0x70020006,  //  009C  JMP		#00A4
-      0xAC0C0002,  //  009D  CATCH	R3	0	2
-      0x70020003,  //  009E  JMP		#00A3
-      0x00140722,  //  009F  ADD	R5	R3	K34
-      0x00140A04,  //  00A0  ADD	R5	R5	R4
-      0x80040A00,  //  00A1  RET	1	R5
-      0x70020000,  //  00A2  JMP		#00A4
-      0xB0080000,  //  00A3  RAISE	2	R0	R0
-      0x80040400,  //  00A4  RET	1	R2
+    ( &(const binstruction[164]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0xA8020099,  //  0001  EXBLK	0	#009C
+      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x540DFFFE,  //  0003  LDINT	R3	-1
+      0x1C080403,  //  0004  EQ	R2	R2	R3
+      0x780A000A,  //  0005  JMPF	R2	#0011
+      0x00040302,  //  0006  ADD	R1	R1	K2
+      0x88080103,  //  0007  GETMBR	R2	R0	K3
+      0x4C0C0000,  //  0008  LDNIL	R3
+      0x20080403,  //  0009  NE	R2	R2	R3
+      0x780A0004,  //  000A  JMPF	R2	#0010
+      0x60080018,  //  000B  GETGBL	R2	G24
+      0x580C0004,  //  000C  LDCONST	R3	K4
+      0x88100103,  //  000D  GETMBR	R4	R0	K3
+      0x7C080400,  //  000E  CALL	R2	2
+      0x00040202,  //  000F  ADD	R1	R1	R2
+      0x70020023,  //  0010  JMP		#0035
+      0x88080105,  //  0011  GETMBR	R2	R0	K5
+      0x4C0C0000,  //  0012  LDNIL	R3
+      0x20080403,  //  0013  NE	R2	R2	R3
+      0x780A0004,  //  0014  JMPF	R2	#001A
+      0x60080018,  //  0015  GETGBL	R2	G24
+      0x580C0006,  //  0016  LDCONST	R3	K6
+      0x88100105,  //  0017  GETMBR	R4	R0	K5
+      0x7C080400,  //  0018  CALL	R2	2
+      0x00040202,  //  0019  ADD	R1	R1	R2
+      0x88080101,  //  001A  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  001B  LDNIL	R3
+      0x20080403,  //  001C  NE	R2	R2	R3
+      0x780A0004,  //  001D  JMPF	R2	#0023
+      0x60080018,  //  001E  GETGBL	R2	G24
+      0x580C0007,  //  001F  LDCONST	R3	K7
+      0x88100101,  //  0020  GETMBR	R4	R0	K1
+      0x7C080400,  //  0021  CALL	R2	2
+      0x00040202,  //  0022  ADD	R1	R1	R2
+      0x88080103,  //  0023  GETMBR	R2	R0	K3
+      0x4C0C0000,  //  0024  LDNIL	R3
+      0x20080403,  //  0025  NE	R2	R2	R3
+      0x780A0004,  //  0026  JMPF	R2	#002C
+      0x60080018,  //  0027  GETGBL	R2	G24
+      0x580C0004,  //  0028  LDCONST	R3	K4
+      0x88100103,  //  0029  GETMBR	R4	R0	K3
+      0x7C080400,  //  002A  CALL	R2	2
+      0x00040202,  //  002B  ADD	R1	R1	R2
+      0x88080108,  //  002C  GETMBR	R2	R0	K8
+      0x4C0C0000,  //  002D  LDNIL	R3
+      0x20080403,  //  002E  NE	R2	R2	R3
+      0x780A0004,  //  002F  JMPF	R2	#0035
+      0x60080018,  //  0030  GETGBL	R2	G24
+      0x580C0009,  //  0031  LDCONST	R3	K9
+      0x88100108,  //  0032  GETMBR	R4	R0	K8
+      0x7C080400,  //  0033  CALL	R2	2
+      0x00040202,  //  0034  ADD	R1	R1	R2
+      0x6008000C,  //  0035  GETGBL	R2	G12
+      0x5C0C0200,  //  0036  MOVE	R3	R1
+      0x7C080200,  //  0037  CALL	R2	1
+      0x2408050A,  //  0038  GT	R2	R2	K10
+      0x780A0000,  //  0039  JMPF	R2	#003B
+      0x0004030B,  //  003A  ADD	R1	R1	K11
+      0x60080004,  //  003B  GETGBL	R2	G4
+      0x880C010C,  //  003C  GETMBR	R3	R0	K12
+      0x7C080200,  //  003D  CALL	R2	1
+      0x1C08050D,  //  003E  EQ	R2	R2	K13
+      0x780A0010,  //  003F  JMPF	R2	#0051
+      0x60080018,  //  0040  GETGBL	R2	G24
+      0x580C000E,  //  0041  LDCONST	R3	K14
+      0x8810010C,  //  0042  GETMBR	R4	R0	K12
+      0x7C080400,  //  0043  CALL	R2	2
+      0x00040202,  //  0044  ADD	R1	R1	R2
+      0x8808010F,  //  0045  GETMBR	R2	R0	K15
+      0x880C0110,  //  0046  GETMBR	R3	R0	K16
+      0x880C0711,  //  0047  GETMBR	R3	R3	K17
+      0x28080403,  //  0048  GE	R2	R2	R3
+      0x780A0005,  //  0049  JMPF	R2	#0050
+      0x8808010F,  //  004A  GETMBR	R2	R0	K15
+      0x880C0110,  //  004B  GETMBR	R3	R0	K16
+      0x880C0712,  //  004C  GETMBR	R3	R3	K18
+      0x18080403,  //  004D  LE	R2	R2	R3
+      0x780A0000,  //  004E  JMPF	R2	#0050
+      0x00040313,  //  004F  ADD	R1	R1	K19
+      0x70020048,  //  0050  JMP		#009A
+      0x60080004,  //  0051  GETGBL	R2	G4
+      0x880C010C,  //  0052  GETMBR	R3	R0	K12
+      0x7C080200,  //  0053  CALL	R2	1
+      0x1C080514,  //  0054  EQ	R2	R2	K20
+      0x780A0006,  //  0055  JMPF	R2	#005D
+      0x8808010C,  //  0056  GETMBR	R2	R0	K12
+      0x780A0001,  //  0057  JMPF	R2	#005A
+      0x58080015,  //  0058  LDCONST	R2	K21
+      0x70020000,  //  0059  JMP		#005B
+      0x58080016,  //  005A  LDCONST	R2	K22
+      0x00040202,  //  005B  ADD	R1	R1	R2
+      0x7002003C,  //  005C  JMP		#009A
+      0x8808010C,  //  005D  GETMBR	R2	R0	K12
+      0x4C0C0000,  //  005E  LDNIL	R3
+      0x1C080403,  //  005F  EQ	R2	R2	R3
+      0x780A0001,  //  0060  JMPF	R2	#0063
+      0x00040317,  //  0061  ADD	R1	R1	K23
+      0x70020036,  //  0062  JMP		#009A
+      0x60080004,  //  0063  GETGBL	R2	G4
+      0x880C010C,  //  0064  GETMBR	R3	R0	K12
+      0x7C080200,  //  0065  CALL	R2	1
+      0x1C080518,  //  0066  EQ	R2	R2	K24
+      0x780A0005,  //  0067  JMPF	R2	#006E
+      0x60080018,  //  0068  GETGBL	R2	G24
+      0x580C0019,  //  0069  LDCONST	R3	K25
+      0x8810010C,  //  006A  GETMBR	R4	R0	K12
+      0x7C080400,  //  006B  CALL	R2	2
+      0x00040202,  //  006C  ADD	R1	R1	R2
+      0x7002002B,  //  006D  JMP		#009A
+      0x60080004,  //  006E  GETGBL	R2	G4
+      0x880C010C,  //  006F  GETMBR	R3	R0	K12
+      0x7C080200,  //  0070  CALL	R2	1
+      0x1C08051A,  //  0071  EQ	R2	R2	K26
+      0x780A0005,  //  0072  JMPF	R2	#0079
+      0x60080018,  //  0073  GETGBL	R2	G24
+      0x580C001B,  //  0074  LDCONST	R3	K27
+      0x8810010C,  //  0075  GETMBR	R4	R0	K12
+      0x7C080400,  //  0076  CALL	R2	2
+      0x00040202,  //  0077  ADD	R1	R1	R2
+      0x70020020,  //  0078  JMP		#009A
+      0x6008000F,  //  0079  GETGBL	R2	G15
+      0x880C010C,  //  007A  GETMBR	R3	R0	K12
+      0xB8123800,  //  007B  GETNGBL	R4	K28
+      0x7C080400,  //  007C  CALL	R2	2
+      0x780A000F,  //  007D  JMPF	R2	#008E
+      0x8808010C,  //  007E  GETMBR	R2	R0	K12
+      0x8C08051D,  //  007F  GETMET	R2	R2	K29
+      0x7C080200,  //  0080  CALL	R2	1
+      0x00040202,  //  0081  ADD	R1	R1	R2
+      0x8808010F,  //  0082  GETMBR	R2	R0	K15
+      0x880C0110,  //  0083  GETMBR	R3	R0	K16
+      0x880C0711,  //  0084  GETMBR	R3	R3	K17
+      0x28080403,  //  0085  GE	R2	R2	R3
+      0x780A0005,  //  0086  JMPF	R2	#008D
+      0x8808010F,  //  0087  GETMBR	R2	R0	K15
+      0x880C0110,  //  0088  GETMBR	R3	R0	K16
+      0x880C0712,  //  0089  GETMBR	R3	R3	K18
+      0x18080403,  //  008A  LE	R2	R2	R3
+      0x780A0000,  //  008B  JMPF	R2	#008D
+      0x00040313,  //  008C  ADD	R1	R1	K19
+      0x7002000B,  //  008D  JMP		#009A
+      0x60080004,  //  008E  GETGBL	R2	G4
+      0x880C010C,  //  008F  GETMBR	R3	R0	K12
+      0x7C080200,  //  0090  CALL	R2	1
+      0x1C08051E,  //  0091  EQ	R2	R2	K30
+      0x780A0006,  //  0092  JMPF	R2	#009A
+      0x60080018,  //  0093  GETGBL	R2	G24
+      0x580C001F,  //  0094  LDCONST	R3	K31
+      0x8810010C,  //  0095  GETMBR	R4	R0	K12
+      0x8C100920,  //  0096  GETMET	R4	R4	K32
+      0x7C100200,  //  0097  CALL	R4	1
+      0x7C080400,  //  0098  CALL	R2	2
+      0x00040202,  //  0099  ADD	R1	R1	R2
+      0xA8040001,  //  009A  EXBLK	1	1
+      0x70020006,  //  009B  JMP		#00A3
+      0xAC080002,  //  009C  CATCH	R2	0	2
+      0x70020003,  //  009D  JMP		#00A2
+      0x00100521,  //  009E  ADD	R4	R2	K33
+      0x00100803,  //  009F  ADD	R4	R4	R3
+      0x80040800,  //  00A0  RET	1	R4
+      0x70020000,  //  00A1  JMP		#00A3
+      0xB0080000,  //  00A2  RAISE	2	R0	R0
+      0x80040200,  //  00A3  RET	1	R1
     })
   )
 );
@@ -2162,7 +2160,7 @@ be_local_closure(Matter_TLV_list_add_list,   /* name */
 ********************************************************************/
 be_local_closure(Matter_TLV_list_tostring_inner,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2170,114 +2168,111 @@ be_local_closure(Matter_TLV_list_tostring_inner,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(),
-    /* K2   */  be_nested_str_weak(tag_profile),
-    /* K3   */  be_nested_str_weak(Matter_X3A_X3A),
-    /* K4   */  be_nested_str_weak(tag_number),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(0x_X2508X_X20),
-    /* K7   */  be_nested_str_weak(tag_vendor),
-    /* K8   */  be_nested_str_weak(0x_X2504X_X3A_X3A),
-    /* K9   */  be_nested_str_weak(0x_X2504X_X3A),
-    /* K10  */  be_nested_str_weak(tag_sub),
-    /* K11  */  be_nested_str_weak(_X25i_X20),
-    /* K12  */  be_const_int(0),
-    /* K13  */  be_nested_str_weak(_X3D_X20),
-    /* K14  */  be_nested_str_weak(val),
-    /* K15  */  be_nested_str_weak(copy),
-    /* K16  */  be_nested_str_weak(sort),
-    /* K17  */  be_nested_str_weak(concat),
-    /* K18  */  be_nested_str_weak(_X2C_X20),
-    /* K19  */  be_nested_str_weak(_X20),
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(),
+    /* K1   */  be_nested_str_weak(tag_profile),
+    /* K2   */  be_nested_str_weak(Matter_X3A_X3A),
+    /* K3   */  be_nested_str_weak(tag_number),
+    /* K4   */  be_nested_str_weak(0x_X2508X_X20),
+    /* K5   */  be_nested_str_weak(tag_vendor),
+    /* K6   */  be_nested_str_weak(0x_X2504X_X3A_X3A),
+    /* K7   */  be_nested_str_weak(0x_X2504X_X3A),
+    /* K8   */  be_nested_str_weak(tag_sub),
+    /* K9   */  be_nested_str_weak(_X25i_X20),
+    /* K10  */  be_const_int(0),
+    /* K11  */  be_nested_str_weak(_X3D_X20),
+    /* K12  */  be_nested_str_weak(val),
+    /* K13  */  be_nested_str_weak(copy),
+    /* K14  */  be_nested_str_weak(sort),
+    /* K15  */  be_nested_str_weak(concat),
+    /* K16  */  be_nested_str_weak(_X2C_X20),
+    /* K17  */  be_nested_str_weak(_X20),
     }),
     be_str_weak(tostring_inner),
     &be_const_str_solidified,
-    ( &(const binstruction[83]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0x58140001,  //  0001  LDCONST	R5	K1
-      0xA8020047,  //  0002  EXBLK	0	#004B
-      0x88180102,  //  0003  GETMBR	R6	R0	K2
-      0x541DFFFE,  //  0004  LDINT	R7	-1
-      0x1C180C07,  //  0005  EQ	R6	R6	R7
-      0x781A000A,  //  0006  JMPF	R6	#0012
-      0x00140B03,  //  0007  ADD	R5	R5	K3
-      0x88180104,  //  0008  GETMBR	R6	R0	K4
-      0x4C1C0000,  //  0009  LDNIL	R7
-      0x20180C07,  //  000A  NE	R6	R6	R7
-      0x781A0004,  //  000B  JMPF	R6	#0011
-      0x8C180905,  //  000C  GETMET	R6	R4	K5
-      0x58200006,  //  000D  LDCONST	R8	K6
-      0x88240104,  //  000E  GETMBR	R9	R0	K4
-      0x7C180600,  //  000F  CALL	R6	3
-      0x00140A06,  //  0010  ADD	R5	R5	R6
-      0x70020023,  //  0011  JMP		#0036
-      0x88180107,  //  0012  GETMBR	R6	R0	K7
-      0x4C1C0000,  //  0013  LDNIL	R7
-      0x20180C07,  //  0014  NE	R6	R6	R7
-      0x781A0004,  //  0015  JMPF	R6	#001B
-      0x8C180905,  //  0016  GETMET	R6	R4	K5
-      0x58200008,  //  0017  LDCONST	R8	K8
-      0x88240107,  //  0018  GETMBR	R9	R0	K7
-      0x7C180600,  //  0019  CALL	R6	3
-      0x00140A06,  //  001A  ADD	R5	R5	R6
-      0x88180102,  //  001B  GETMBR	R6	R0	K2
-      0x4C1C0000,  //  001C  LDNIL	R7
-      0x20180C07,  //  001D  NE	R6	R6	R7
-      0x781A0004,  //  001E  JMPF	R6	#0024
-      0x8C180905,  //  001F  GETMET	R6	R4	K5
-      0x58200009,  //  0020  LDCONST	R8	K9
-      0x88240102,  //  0021  GETMBR	R9	R0	K2
-      0x7C180600,  //  0022  CALL	R6	3
-      0x00140A06,  //  0023  ADD	R5	R5	R6
-      0x88180104,  //  0024  GETMBR	R6	R0	K4
-      0x4C1C0000,  //  0025  LDNIL	R7
-      0x20180C07,  //  0026  NE	R6	R6	R7
-      0x781A0004,  //  0027  JMPF	R6	#002D
-      0x8C180905,  //  0028  GETMET	R6	R4	K5
-      0x58200006,  //  0029  LDCONST	R8	K6
-      0x88240104,  //  002A  GETMBR	R9	R0	K4
-      0x7C180600,  //  002B  CALL	R6	3
-      0x00140A06,  //  002C  ADD	R5	R5	R6
-      0x8818010A,  //  002D  GETMBR	R6	R0	K10
-      0x4C1C0000,  //  002E  LDNIL	R7
-      0x20180C07,  //  002F  NE	R6	R6	R7
-      0x781A0004,  //  0030  JMPF	R6	#0036
-      0x8C180905,  //  0031  GETMET	R6	R4	K5
-      0x5820000B,  //  0032  LDCONST	R8	K11
-      0x8824010A,  //  0033  GETMBR	R9	R0	K10
-      0x7C180600,  //  0034  CALL	R6	3
-      0x00140A06,  //  0035  ADD	R5	R5	R6
-      0x6018000C,  //  0036  GETGBL	R6	G12
-      0x5C1C0A00,  //  0037  MOVE	R7	R5
-      0x7C180200,  //  0038  CALL	R6	1
-      0x24180D0C,  //  0039  GT	R6	R6	K12
-      0x781A0000,  //  003A  JMPF	R6	#003C
-      0x00140B0D,  //  003B  ADD	R5	R5	K13
-      0x00140A02,  //  003C  ADD	R5	R5	R2
-      0x8818010E,  //  003D  GETMBR	R6	R0	K14
-      0x8C180D0F,  //  003E  GETMET	R6	R6	K15
-      0x7C180200,  //  003F  CALL	R6	1
-      0x78060002,  //  0040  JMPF	R1	#0044
-      0x8C1C0110,  //  0041  GETMET	R7	R0	K16
-      0x5C240C00,  //  0042  MOVE	R9	R6
-      0x7C1C0400,  //  0043  CALL	R7	2
-      0x8C1C0D11,  //  0044  GETMET	R7	R6	K17
-      0x58240012,  //  0045  LDCONST	R9	K18
-      0x7C1C0400,  //  0046  CALL	R7	2
-      0x00140A07,  //  0047  ADD	R5	R5	R7
-      0x00140A03,  //  0048  ADD	R5	R5	R3
-      0xA8040001,  //  0049  EXBLK	1	1
-      0x70020006,  //  004A  JMP		#0052
-      0xAC180002,  //  004B  CATCH	R6	0	2
-      0x70020003,  //  004C  JMP		#0051
-      0x00200D13,  //  004D  ADD	R8	R6	K19
-      0x00201007,  //  004E  ADD	R8	R8	R7
-      0x80041000,  //  004F  RET	1	R8
-      0x70020000,  //  0050  JMP		#0052
-      0xB0080000,  //  0051  RAISE	2	R0	R0
-      0x80040A00,  //  0052  RET	1	R5
+    ( &(const binstruction[82]) {  /* code */
+      0x58100000,  //  0000  LDCONST	R4	K0
+      0xA8020047,  //  0001  EXBLK	0	#004A
+      0x88140101,  //  0002  GETMBR	R5	R0	K1
+      0x5419FFFE,  //  0003  LDINT	R6	-1
+      0x1C140A06,  //  0004  EQ	R5	R5	R6
+      0x7816000A,  //  0005  JMPF	R5	#0011
+      0x00100902,  //  0006  ADD	R4	R4	K2
+      0x88140103,  //  0007  GETMBR	R5	R0	K3
+      0x4C180000,  //  0008  LDNIL	R6
+      0x20140A06,  //  0009  NE	R5	R5	R6
+      0x78160004,  //  000A  JMPF	R5	#0010
+      0x60140018,  //  000B  GETGBL	R5	G24
+      0x58180004,  //  000C  LDCONST	R6	K4
+      0x881C0103,  //  000D  GETMBR	R7	R0	K3
+      0x7C140400,  //  000E  CALL	R5	2
+      0x00100805,  //  000F  ADD	R4	R4	R5
+      0x70020023,  //  0010  JMP		#0035
+      0x88140105,  //  0011  GETMBR	R5	R0	K5
+      0x4C180000,  //  0012  LDNIL	R6
+      0x20140A06,  //  0013  NE	R5	R5	R6
+      0x78160004,  //  0014  JMPF	R5	#001A
+      0x60140018,  //  0015  GETGBL	R5	G24
+      0x58180006,  //  0016  LDCONST	R6	K6
+      0x881C0105,  //  0017  GETMBR	R7	R0	K5
+      0x7C140400,  //  0018  CALL	R5	2
+      0x00100805,  //  0019  ADD	R4	R4	R5
+      0x88140101,  //  001A  GETMBR	R5	R0	K1
+      0x4C180000,  //  001B  LDNIL	R6
+      0x20140A06,  //  001C  NE	R5	R5	R6
+      0x78160004,  //  001D  JMPF	R5	#0023
+      0x60140018,  //  001E  GETGBL	R5	G24
+      0x58180007,  //  001F  LDCONST	R6	K7
+      0x881C0101,  //  0020  GETMBR	R7	R0	K1
+      0x7C140400,  //  0021  CALL	R5	2
+      0x00100805,  //  0022  ADD	R4	R4	R5
+      0x88140103,  //  0023  GETMBR	R5	R0	K3
+      0x4C180000,  //  0024  LDNIL	R6
+      0x20140A06,  //  0025  NE	R5	R5	R6
+      0x78160004,  //  0026  JMPF	R5	#002C
+      0x60140018,  //  0027  GETGBL	R5	G24
+      0x58180004,  //  0028  LDCONST	R6	K4
+      0x881C0103,  //  0029  GETMBR	R7	R0	K3
+      0x7C140400,  //  002A  CALL	R5	2
+      0x00100805,  //  002B  ADD	R4	R4	R5
+      0x88140108,  //  002C  GETMBR	R5	R0	K8
+      0x4C180000,  //  002D  LDNIL	R6
+      0x20140A06,  //  002E  NE	R5	R5	R6
+      0x78160004,  //  002F  JMPF	R5	#0035
+      0x60140018,  //  0030  GETGBL	R5	G24
+      0x58180009,  //  0031  LDCONST	R6	K9
+      0x881C0108,  //  0032  GETMBR	R7	R0	K8
+      0x7C140400,  //  0033  CALL	R5	2
+      0x00100805,  //  0034  ADD	R4	R4	R5
+      0x6014000C,  //  0035  GETGBL	R5	G12
+      0x5C180800,  //  0036  MOVE	R6	R4
+      0x7C140200,  //  0037  CALL	R5	1
+      0x24140B0A,  //  0038  GT	R5	R5	K10
+      0x78160000,  //  0039  JMPF	R5	#003B
+      0x0010090B,  //  003A  ADD	R4	R4	K11
+      0x00100802,  //  003B  ADD	R4	R4	R2
+      0x8814010C,  //  003C  GETMBR	R5	R0	K12
+      0x8C140B0D,  //  003D  GETMET	R5	R5	K13
+      0x7C140200,  //  003E  CALL	R5	1
+      0x78060002,  //  003F  JMPF	R1	#0043
+      0x8C18010E,  //  0040  GETMET	R6	R0	K14
+      0x5C200A00,  //  0041  MOVE	R8	R5
+      0x7C180400,  //  0042  CALL	R6	2
+      0x8C180B0F,  //  0043  GETMET	R6	R5	K15
+      0x58200010,  //  0044  LDCONST	R8	K16
+      0x7C180400,  //  0045  CALL	R6	2
+      0x00100806,  //  0046  ADD	R4	R4	R6
+      0x00100803,  //  0047  ADD	R4	R4	R3
+      0xA8040001,  //  0048  EXBLK	1	1
+      0x70020006,  //  0049  JMP		#0051
+      0xAC140002,  //  004A  CATCH	R5	0	2
+      0x70020003,  //  004B  JMP		#0050
+      0x001C0B11,  //  004C  ADD	R7	R5	K17
+      0x001C0E06,  //  004D  ADD	R7	R7	R6
+      0x80040E00,  //  004E  RET	1	R7
+      0x70020000,  //  004F  JMP		#0051
+      0xB0080000,  //  0050  RAISE	2	R0	R0
+      0x80040800,  //  0051  RET	1	R4
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
@@ -211,7 +211,7 @@ be_local_closure(Matter_UDPServer__backoff_time,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UDPServer__resend_packets,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    11,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -219,7 +219,7 @@ be_local_closure(Matter_UDPServer__resend_packets,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
+    ( &(const bvalue[20]) {     /* constants */
     /* K0   */  be_const_int(0),
     /* K1   */  be_nested_str_weak(packets_sent),
     /* K2   */  be_nested_str_weak(tasmota),
@@ -234,31 +234,29 @@ be_local_closure(Matter_UDPServer__resend_packets,   /* name */
     /* K11  */  be_nested_str_weak(millis),
     /* K12  */  be_nested_str_weak(_backoff_time),
     /* K13  */  be_const_int(1),
-    /* K14  */  be_nested_str_weak(string),
-    /* K15  */  be_nested_str_weak(remove),
-    /* K16  */  be_nested_str_weak(format),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20Unacked_X20packet_X20_X27_X5B_X25s_X5D_X3A_X25i_X27_X20msg_id_X3D_X25i),
-    /* K18  */  be_nested_str_weak(session_id),
-    /* K19  */  be_nested_str_weak(addr),
-    /* K20  */  be_nested_str_weak(port),
-    /* K21  */  be_const_int(3),
+    /* K14  */  be_nested_str_weak(remove),
+    /* K15  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20Unacked_X20packet_X20_X27_X5B_X25s_X5D_X3A_X25i_X27_X20msg_id_X3D_X25i),
+    /* K16  */  be_nested_str_weak(session_id),
+    /* K17  */  be_nested_str_weak(addr),
+    /* K18  */  be_nested_str_weak(port),
+    /* K19  */  be_const_int(3),
     }),
     be_str_weak(_resend_packets),
     &be_const_str_solidified,
-    ( &(const binstruction[61]) {  /* code */
+    ( &(const binstruction[60]) {  /* code */
       0x58040000,  //  0000  LDCONST	R1	K0
       0x6008000C,  //  0001  GETGBL	R2	G12
       0x880C0101,  //  0002  GETMBR	R3	R0	K1
       0x7C080200,  //  0003  CALL	R2	1
       0x14080202,  //  0004  LT	R2	R1	R2
-      0x780A0035,  //  0005  JMPF	R2	#003C
+      0x780A0034,  //  0005  JMPF	R2	#003B
       0x88080101,  //  0006  GETMBR	R2	R0	K1
       0x94080401,  //  0007  GETIDX	R2	R2	R1
       0xB80E0400,  //  0008  GETNGBL	R3	K2
       0x8C0C0703,  //  0009  GETMET	R3	R3	K3
       0x88140504,  //  000A  GETMBR	R5	R2	K4
       0x7C0C0400,  //  000B  CALL	R3	2
-      0x780E002C,  //  000C  JMPF	R3	#003A
+      0x780E002B,  //  000C  JMPF	R3	#0039
       0x880C0505,  //  000D  GETMBR	R3	R2	K5
       0x88100106,  //  000E  GETMBR	R4	R0	K6
       0x180C0604,  //  000F  LE	R3	R3	R4
@@ -286,27 +284,26 @@ be_local_closure(Matter_UDPServer__resend_packets,   /* name */
       0x000C070D,  //  0025  ADD	R3	R3	K13
       0x900A0A03,  //  0026  SETMBR	R2	K5	R3
       0x0004030D,  //  0027  ADD	R1	R1	K13
-      0x7002000F,  //  0028  JMP		#0039
-      0xA40E1C00,  //  0029  IMPORT	R3	K14
-      0x88100101,  //  002A  GETMBR	R4	R0	K1
-      0x8C10090F,  //  002B  GETMET	R4	R4	K15
-      0x5C180200,  //  002C  MOVE	R6	R1
-      0x7C100400,  //  002D  CALL	R4	2
-      0xB8120400,  //  002E  GETNGBL	R4	K2
-      0x8C100907,  //  002F  GETMET	R4	R4	K7
-      0x8C180710,  //  0030  GETMET	R6	R3	K16
-      0x58200011,  //  0031  LDCONST	R8	K17
-      0x88240512,  //  0032  GETMBR	R9	R2	K18
-      0x88280513,  //  0033  GETMBR	R10	R2	K19
-      0x882C0514,  //  0034  GETMBR	R11	R2	K20
-      0x88300509,  //  0035  GETMBR	R12	R2	K9
-      0x7C180C00,  //  0036  CALL	R6	6
-      0x581C0015,  //  0037  LDCONST	R7	K21
-      0x7C100600,  //  0038  CALL	R4	3
-      0x70020000,  //  0039  JMP		#003B
-      0x0004030D,  //  003A  ADD	R1	R1	K13
-      0x7001FFC4,  //  003B  JMP		#0001
-      0x80000000,  //  003C  RET	0
+      0x7002000E,  //  0028  JMP		#0038
+      0x880C0101,  //  0029  GETMBR	R3	R0	K1
+      0x8C0C070E,  //  002A  GETMET	R3	R3	K14
+      0x5C140200,  //  002B  MOVE	R5	R1
+      0x7C0C0400,  //  002C  CALL	R3	2
+      0xB80E0400,  //  002D  GETNGBL	R3	K2
+      0x8C0C0707,  //  002E  GETMET	R3	R3	K7
+      0x60140018,  //  002F  GETGBL	R5	G24
+      0x5818000F,  //  0030  LDCONST	R6	K15
+      0x881C0510,  //  0031  GETMBR	R7	R2	K16
+      0x88200511,  //  0032  GETMBR	R8	R2	K17
+      0x88240512,  //  0033  GETMBR	R9	R2	K18
+      0x88280509,  //  0034  GETMBR	R10	R2	K9
+      0x7C140A00,  //  0035  CALL	R5	5
+      0x58180013,  //  0036  LDCONST	R6	K19
+      0x7C0C0600,  //  0037  CALL	R3	3
+      0x70020000,  //  0038  JMP		#003A
+      0x0004030D,  //  0039  ADD	R1	R1	K13
+      0x7001FFC5,  //  003A  JMP		#0001
+      0x80000000,  //  003B  RET	0
     })
   )
 );
@@ -386,7 +383,7 @@ be_local_closure(Matter_UDPServer_send_UDP,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UDPServer_every_50ms,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    11,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -394,72 +391,69 @@ be_local_closure(Matter_UDPServer_every_50ms,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(udp_socket),
-    /* K3   */  be_nested_str_weak(read),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(remote_ip),
-    /* K6   */  be_nested_str_weak(remote_port),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(format),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20UDP_X20received_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K11  */  be_nested_str_weak(dispatch_cb),
-    /* K12  */  be_nested_str_weak(MAX_PACKETS_READ),
-    /* K13  */  be_nested_str_weak(_resend_packets),
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(udp_socket),
+    /* K2   */  be_nested_str_weak(read),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(remote_ip),
+    /* K5   */  be_nested_str_weak(remote_port),
+    /* K6   */  be_nested_str_weak(tasmota),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20UDP_X20received_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K9   */  be_nested_str_weak(dispatch_cb),
+    /* K10  */  be_nested_str_weak(MAX_PACKETS_READ),
+    /* K11  */  be_nested_str_weak(_resend_packets),
     }),
     be_str_weak(every_50ms),
     &be_const_str_solidified,
-    ( &(const binstruction[47]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x58080001,  //  0001  LDCONST	R2	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x4C100000,  //  0003  LDNIL	R4
-      0x1C0C0604,  //  0004  EQ	R3	R3	R4
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80000600,  //  0006  RET	0
-      0x880C0102,  //  0007  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0008  GETMET	R3	R3	K3
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x4C100000,  //  000A  LDNIL	R4
-      0x20100604,  //  000B  NE	R4	R3	R4
-      0x7812001E,  //  000C  JMPF	R4	#002C
-      0x00080504,  //  000D  ADD	R2	R2	K4
-      0x88100102,  //  000E  GETMBR	R4	R0	K2
-      0x88100905,  //  000F  GETMBR	R4	R4	K5
-      0x88140102,  //  0010  GETMBR	R5	R0	K2
-      0x88140B06,  //  0011  GETMBR	R5	R5	K6
-      0xB81A0E00,  //  0012  GETNGBL	R6	K7
-      0x8C180D08,  //  0013  GETMET	R6	R6	K8
-      0x8C200309,  //  0014  GETMET	R8	R1	K9
-      0x5828000A,  //  0015  LDCONST	R10	K10
-      0x5C2C0800,  //  0016  MOVE	R11	R4
-      0x5C300A00,  //  0017  MOVE	R12	R5
-      0x7C200800,  //  0018  CALL	R8	4
-      0x54260003,  //  0019  LDINT	R9	4
-      0x7C180600,  //  001A  CALL	R6	3
-      0x8818010B,  //  001B  GETMBR	R6	R0	K11
-      0x781A0004,  //  001C  JMPF	R6	#0022
-      0x8C18010B,  //  001D  GETMET	R6	R0	K11
+    ( &(const binstruction[46]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x1C080403,  //  0003  EQ	R2	R2	R3
+      0x780A0000,  //  0004  JMPF	R2	#0006
+      0x80000400,  //  0005  RET	0
+      0x88080101,  //  0006  GETMBR	R2	R0	K1
+      0x8C080502,  //  0007  GETMET	R2	R2	K2
+      0x7C080200,  //  0008  CALL	R2	1
+      0x4C0C0000,  //  0009  LDNIL	R3
+      0x200C0403,  //  000A  NE	R3	R2	R3
+      0x780E001E,  //  000B  JMPF	R3	#002B
+      0x00040303,  //  000C  ADD	R1	R1	K3
+      0x880C0101,  //  000D  GETMBR	R3	R0	K1
+      0x880C0704,  //  000E  GETMBR	R3	R3	K4
+      0x88100101,  //  000F  GETMBR	R4	R0	K1
+      0x88100905,  //  0010  GETMBR	R4	R4	K5
+      0xB8160C00,  //  0011  GETNGBL	R5	K6
+      0x8C140B07,  //  0012  GETMET	R5	R5	K7
+      0x601C0018,  //  0013  GETGBL	R7	G24
+      0x58200008,  //  0014  LDCONST	R8	K8
+      0x5C240600,  //  0015  MOVE	R9	R3
+      0x5C280800,  //  0016  MOVE	R10	R4
+      0x7C1C0600,  //  0017  CALL	R7	3
+      0x54220003,  //  0018  LDINT	R8	4
+      0x7C140600,  //  0019  CALL	R5	3
+      0x88140109,  //  001A  GETMBR	R5	R0	K9
+      0x78160004,  //  001B  JMPF	R5	#0021
+      0x8C140109,  //  001C  GETMET	R5	R0	K9
+      0x5C1C0400,  //  001D  MOVE	R7	R2
       0x5C200600,  //  001E  MOVE	R8	R3
       0x5C240800,  //  001F  MOVE	R9	R4
-      0x5C280A00,  //  0020  MOVE	R10	R5
-      0x7C180800,  //  0021  CALL	R6	4
-      0x8818010C,  //  0022  GETMBR	R6	R0	K12
-      0x14180406,  //  0023  LT	R6	R2	R6
-      0x781A0004,  //  0024  JMPF	R6	#002A
-      0x88180102,  //  0025  GETMBR	R6	R0	K2
-      0x8C180D03,  //  0026  GETMET	R6	R6	K3
-      0x7C180200,  //  0027  CALL	R6	1
-      0x5C0C0C00,  //  0028  MOVE	R3	R6
-      0x70020000,  //  0029  JMP		#002B
-      0x4C0C0000,  //  002A  LDNIL	R3
-      0x7001FFDD,  //  002B  JMP		#000A
-      0x8C10010D,  //  002C  GETMET	R4	R0	K13
-      0x7C100200,  //  002D  CALL	R4	1
-      0x80000000,  //  002E  RET	0
+      0x7C140800,  //  0020  CALL	R5	4
+      0x8814010A,  //  0021  GETMBR	R5	R0	K10
+      0x14140205,  //  0022  LT	R5	R1	R5
+      0x78160004,  //  0023  JMPF	R5	#0029
+      0x88140101,  //  0024  GETMBR	R5	R0	K1
+      0x8C140B02,  //  0025  GETMET	R5	R5	K2
+      0x7C140200,  //  0026  CALL	R5	1
+      0x5C080A00,  //  0027  MOVE	R2	R5
+      0x70020000,  //  0028  JMP		#002A
+      0x4C080000,  //  0029  LDNIL	R2
+      0x7001FFDD,  //  002A  JMP		#0009
+      0x8C0C010B,  //  002B  GETMET	R3	R0	K11
+      0x7C0C0200,  //  002C  CALL	R3	1
+      0x80000000,  //  002D  RET	0
     })
   )
 );
@@ -683,7 +677,7 @@ be_local_closure(Matter_UDPServer_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UDPServer_send,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    9,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -691,63 +685,60 @@ be_local_closure(Matter_UDPServer_send,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(udp_socket),
-    /* K2   */  be_nested_str_weak(send),
-    /* K3   */  be_nested_str_weak(addr),
-    /* K4   */  be_nested_str_weak(remote_ip),
-    /* K5   */  be_nested_str_weak(port),
-    /* K6   */  be_nested_str_weak(remote_port),
-    /* K7   */  be_nested_str_weak(raw),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(format),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20sending_X20packet_X20to_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20error_X20sending_X20packet_X20to_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-    /* K13  */  be_const_int(3),
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_socket),
+    /* K1   */  be_nested_str_weak(send),
+    /* K2   */  be_nested_str_weak(addr),
+    /* K3   */  be_nested_str_weak(remote_ip),
+    /* K4   */  be_nested_str_weak(port),
+    /* K5   */  be_nested_str_weak(remote_port),
+    /* K6   */  be_nested_str_weak(raw),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20sending_X20packet_X20to_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20error_X20sending_X20packet_X20to_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+    /* K11  */  be_const_int(3),
     }),
     be_str_weak(send),
     &be_const_str_solidified,
-    ( &(const binstruction[38]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x88140303,  //  0003  GETMBR	R5	R1	K3
-      0x78160001,  //  0004  JMPF	R5	#0007
-      0x88140303,  //  0005  GETMBR	R5	R1	K3
-      0x70020001,  //  0006  JMP		#0009
-      0x88140101,  //  0007  GETMBR	R5	R0	K1
-      0x88140B04,  //  0008  GETMBR	R5	R5	K4
-      0x88180305,  //  0009  GETMBR	R6	R1	K5
-      0x781A0001,  //  000A  JMPF	R6	#000D
-      0x88180305,  //  000B  GETMBR	R6	R1	K5
-      0x70020001,  //  000C  JMP		#000F
-      0x88180101,  //  000D  GETMBR	R6	R0	K1
-      0x88180D06,  //  000E  GETMBR	R6	R6	K6
-      0x881C0307,  //  000F  GETMBR	R7	R1	K7
-      0x7C0C0800,  //  0010  CALL	R3	4
-      0x780E0009,  //  0011  JMPF	R3	#001C
-      0xB8121000,  //  0012  GETNGBL	R4	K8
-      0x8C100909,  //  0013  GETMET	R4	R4	K9
-      0x8C18050A,  //  0014  GETMET	R6	R2	K10
-      0x5820000B,  //  0015  LDCONST	R8	K11
-      0x88240303,  //  0016  GETMBR	R9	R1	K3
-      0x88280305,  //  0017  GETMBR	R10	R1	K5
-      0x7C180800,  //  0018  CALL	R6	4
-      0x541E0003,  //  0019  LDINT	R7	4
-      0x7C100600,  //  001A  CALL	R4	3
-      0x70020008,  //  001B  JMP		#0025
-      0xB8121000,  //  001C  GETNGBL	R4	K8
-      0x8C100909,  //  001D  GETMET	R4	R4	K9
-      0x8C18050A,  //  001E  GETMET	R6	R2	K10
-      0x5820000C,  //  001F  LDCONST	R8	K12
-      0x88240303,  //  0020  GETMBR	R9	R1	K3
-      0x88280305,  //  0021  GETMBR	R10	R1	K5
-      0x7C180800,  //  0022  CALL	R6	4
-      0x581C000D,  //  0023  LDCONST	R7	K13
-      0x7C100600,  //  0024  CALL	R4	3
-      0x80040600,  //  0025  RET	1	R3
+    ( &(const binstruction[37]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88100302,  //  0002  GETMBR	R4	R1	K2
+      0x78120001,  //  0003  JMPF	R4	#0006
+      0x88100302,  //  0004  GETMBR	R4	R1	K2
+      0x70020001,  //  0005  JMP		#0008
+      0x88100100,  //  0006  GETMBR	R4	R0	K0
+      0x88100903,  //  0007  GETMBR	R4	R4	K3
+      0x88140304,  //  0008  GETMBR	R5	R1	K4
+      0x78160001,  //  0009  JMPF	R5	#000C
+      0x88140304,  //  000A  GETMBR	R5	R1	K4
+      0x70020001,  //  000B  JMP		#000E
+      0x88140100,  //  000C  GETMBR	R5	R0	K0
+      0x88140B05,  //  000D  GETMBR	R5	R5	K5
+      0x88180306,  //  000E  GETMBR	R6	R1	K6
+      0x7C080800,  //  000F  CALL	R2	4
+      0x780A0009,  //  0010  JMPF	R2	#001B
+      0xB80E0E00,  //  0011  GETNGBL	R3	K7
+      0x8C0C0708,  //  0012  GETMET	R3	R3	K8
+      0x60140018,  //  0013  GETGBL	R5	G24
+      0x58180009,  //  0014  LDCONST	R6	K9
+      0x881C0302,  //  0015  GETMBR	R7	R1	K2
+      0x88200304,  //  0016  GETMBR	R8	R1	K4
+      0x7C140600,  //  0017  CALL	R5	3
+      0x541A0003,  //  0018  LDINT	R6	4
+      0x7C0C0600,  //  0019  CALL	R3	3
+      0x70020008,  //  001A  JMP		#0024
+      0xB80E0E00,  //  001B  GETNGBL	R3	K7
+      0x8C0C0708,  //  001C  GETMET	R3	R3	K8
+      0x60140018,  //  001D  GETGBL	R5	G24
+      0x5818000A,  //  001E  LDCONST	R6	K10
+      0x881C0302,  //  001F  GETMBR	R7	R1	K2
+      0x88200304,  //  0020  GETMBR	R8	R1	K4
+      0x7C140600,  //  0021  CALL	R5	3
+      0x5818000B,  //  0022  LDCONST	R6	K11
+      0x7C0C0600,  //  0023  CALL	R3	3
+      0x80040400,  //  0024  RET	1	R2
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
@@ -92,7 +92,7 @@ be_local_closure(Matter_UI_equal_map,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_page_part_mgr_adv,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -100,48 +100,46 @@ be_local_closure(Matter_UI_page_part_mgr_adv,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
+    ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(check_privileged_access),
-    /* K3   */  be_nested_str_weak(content_start),
-    /* K4   */  be_nested_str_weak(Matter_X20Advanced_X20Configuration),
-    /* K5   */  be_nested_str_weak(content_send_style),
-    /* K6   */  be_nested_str_weak(matter_enabled),
-    /* K7   */  be_nested_str_weak(show_passcode_form),
-    /* K8   */  be_nested_str_weak(show_fabric_info),
-    /* K9   */  be_nested_str_weak(content_button),
-    /* K10  */  be_nested_str_weak(BUTTON_CONFIGURATION),
-    /* K11  */  be_nested_str_weak(content_stop),
+    /* K1   */  be_nested_str_weak(check_privileged_access),
+    /* K2   */  be_nested_str_weak(content_start),
+    /* K3   */  be_nested_str_weak(Matter_X20Advanced_X20Configuration),
+    /* K4   */  be_nested_str_weak(content_send_style),
+    /* K5   */  be_nested_str_weak(matter_enabled),
+    /* K6   */  be_nested_str_weak(show_passcode_form),
+    /* K7   */  be_nested_str_weak(show_fabric_info),
+    /* K8   */  be_nested_str_weak(content_button),
+    /* K9   */  be_nested_str_weak(BUTTON_CONFIGURATION),
+    /* K10  */  be_nested_str_weak(content_stop),
     }),
     be_str_weak(page_part_mgr_adv),
     &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
+    ( &(const binstruction[24]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x740E0001,  //  0004  JMPT	R3	#0007
-      0x4C0C0000,  //  0005  LDNIL	R3
-      0x80040600,  //  0006  RET	1	R3
-      0x8C0C0303,  //  0007  GETMET	R3	R1	K3
-      0x58140004,  //  0008  LDCONST	R5	K4
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x8C0C0305,  //  000A  GETMET	R3	R1	K5
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x8C0C0106,  //  000C  GETMET	R3	R0	K6
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x780E0003,  //  000E  JMPF	R3	#0013
-      0x8C0C0107,  //  000F  GETMET	R3	R0	K7
-      0x7C0C0200,  //  0010  CALL	R3	1
-      0x8C0C0108,  //  0011  GETMET	R3	R0	K8
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0x8C0C0309,  //  0013  GETMET	R3	R1	K9
-      0x8814030A,  //  0014  GETMBR	R5	R1	K10
-      0x7C0C0400,  //  0015  CALL	R3	2
-      0x8C0C030B,  //  0016  GETMET	R3	R1	K11
-      0x7C0C0200,  //  0017  CALL	R3	1
-      0x80000000,  //  0018  RET	0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x740A0001,  //  0003  JMPT	R2	#0006
+      0x4C080000,  //  0004  LDNIL	R2
+      0x80040400,  //  0005  RET	1	R2
+      0x8C080302,  //  0006  GETMET	R2	R1	K2
+      0x58100003,  //  0007  LDCONST	R4	K3
+      0x7C080400,  //  0008  CALL	R2	2
+      0x8C080304,  //  0009  GETMET	R2	R1	K4
+      0x7C080200,  //  000A  CALL	R2	1
+      0x8C080105,  //  000B  GETMET	R2	R0	K5
+      0x7C080200,  //  000C  CALL	R2	1
+      0x780A0003,  //  000D  JMPF	R2	#0012
+      0x8C080106,  //  000E  GETMET	R2	R0	K6
+      0x7C080200,  //  000F  CALL	R2	1
+      0x8C080107,  //  0010  GETMET	R2	R0	K7
+      0x7C080200,  //  0011  CALL	R2	1
+      0x8C080308,  //  0012  GETMET	R2	R1	K8
+      0x88100309,  //  0013  GETMBR	R4	R1	K9
+      0x7C080400,  //  0014  CALL	R2	2
+      0x8C08030A,  //  0015  GETMET	R2	R1	K10
+      0x7C080200,  //  0016  CALL	R2	1
+      0x80000000,  //  0017  RET	0
     })
   )
 );
@@ -153,7 +151,7 @@ be_local_closure(Matter_UI_page_part_mgr_adv,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_page_part_mgr,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -161,57 +159,55 @@ be_local_closure(Matter_UI_page_part_mgr,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
+    ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(check_privileged_access),
-    /* K3   */  be_nested_str_weak(content_start),
-    /* K4   */  be_nested_str_weak(Matter),
-    /* K5   */  be_nested_str_weak(content_send_style),
-    /* K6   */  be_nested_str_weak(show_enable),
-    /* K7   */  be_nested_str_weak(matter_enabled),
-    /* K8   */  be_nested_str_weak(show_plugins_configuration),
-    /* K9   */  be_nested_str_weak(content_send),
-    /* K10  */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E),
-    /* K11  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cform_X20id_X3D_X27butmat_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27mattera_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X20name_X3D_X27_X27_X3EAdvanced_X20Configuration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E),
-    /* K12  */  be_nested_str_weak(content_button),
-    /* K13  */  be_nested_str_weak(BUTTON_CONFIGURATION),
-    /* K14  */  be_nested_str_weak(content_stop),
+    /* K1   */  be_nested_str_weak(check_privileged_access),
+    /* K2   */  be_nested_str_weak(content_start),
+    /* K3   */  be_nested_str_weak(Matter),
+    /* K4   */  be_nested_str_weak(content_send_style),
+    /* K5   */  be_nested_str_weak(show_enable),
+    /* K6   */  be_nested_str_weak(matter_enabled),
+    /* K7   */  be_nested_str_weak(show_plugins_configuration),
+    /* K8   */  be_nested_str_weak(content_send),
+    /* K9   */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E),
+    /* K10  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cform_X20id_X3D_X27butmat_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27mattera_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X20name_X3D_X27_X27_X3EAdvanced_X20Configuration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E),
+    /* K11  */  be_nested_str_weak(content_button),
+    /* K12  */  be_nested_str_weak(BUTTON_CONFIGURATION),
+    /* K13  */  be_nested_str_weak(content_stop),
     }),
     be_str_weak(page_part_mgr),
     &be_const_str_solidified,
-    ( &(const binstruction[31]) {  /* code */
+    ( &(const binstruction[30]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x740E0001,  //  0004  JMPT	R3	#0007
-      0x4C0C0000,  //  0005  LDNIL	R3
-      0x80040600,  //  0006  RET	1	R3
-      0x8C0C0303,  //  0007  GETMET	R3	R1	K3
-      0x58140004,  //  0008  LDCONST	R5	K4
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x8C0C0305,  //  000A  GETMET	R3	R1	K5
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x8C0C0106,  //  000C  GETMET	R3	R0	K6
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x8C0C0107,  //  000E  GETMET	R3	R0	K7
-      0x7C0C0200,  //  000F  CALL	R3	1
-      0x780E0001,  //  0010  JMPF	R3	#0013
-      0x8C0C0108,  //  0011  GETMET	R3	R0	K8
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0x8C0C0309,  //  0013  GETMET	R3	R1	K9
-      0x5814000A,  //  0014  LDCONST	R5	K10
-      0x7C0C0400,  //  0015  CALL	R3	2
-      0x8C0C0309,  //  0016  GETMET	R3	R1	K9
-      0x5814000B,  //  0017  LDCONST	R5	K11
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x8C0C030C,  //  0019  GETMET	R3	R1	K12
-      0x8814030D,  //  001A  GETMBR	R5	R1	K13
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x8C0C030E,  //  001C  GETMET	R3	R1	K14
-      0x7C0C0200,  //  001D  CALL	R3	1
-      0x80000000,  //  001E  RET	0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x740A0001,  //  0003  JMPT	R2	#0006
+      0x4C080000,  //  0004  LDNIL	R2
+      0x80040400,  //  0005  RET	1	R2
+      0x8C080302,  //  0006  GETMET	R2	R1	K2
+      0x58100003,  //  0007  LDCONST	R4	K3
+      0x7C080400,  //  0008  CALL	R2	2
+      0x8C080304,  //  0009  GETMET	R2	R1	K4
+      0x7C080200,  //  000A  CALL	R2	1
+      0x8C080105,  //  000B  GETMET	R2	R0	K5
+      0x7C080200,  //  000C  CALL	R2	1
+      0x8C080106,  //  000D  GETMET	R2	R0	K6
+      0x7C080200,  //  000E  CALL	R2	1
+      0x780A0001,  //  000F  JMPF	R2	#0012
+      0x8C080107,  //  0010  GETMET	R2	R0	K7
+      0x7C080200,  //  0011  CALL	R2	1
+      0x8C080308,  //  0012  GETMET	R2	R1	K8
+      0x58100009,  //  0013  LDCONST	R4	K9
+      0x7C080400,  //  0014  CALL	R2	2
+      0x8C080308,  //  0015  GETMET	R2	R1	K8
+      0x5810000A,  //  0016  LDCONST	R4	K10
+      0x7C080400,  //  0017  CALL	R2	2
+      0x8C08030B,  //  0018  GETMET	R2	R1	K11
+      0x8810030C,  //  0019  GETMBR	R4	R1	K12
+      0x7C080400,  //  001A  CALL	R2	2
+      0x8C08030D,  //  001B  GETMET	R2	R1	K13
+      0x7C080200,  //  001C  CALL	R2	1
+      0x80000000,  //  001D  RET	0
     })
   )
 );
@@ -431,7 +427,7 @@ be_local_closure(Matter_UI_generate_config_from_status,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_web_sensor,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -439,73 +435,70 @@ be_local_closure(Matter_UI_web_sensor,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
+    ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(matter_enabled),
-    /* K3   */  be_nested_str_weak(device),
-    /* K4   */  be_nested_str_weak(sessions),
-    /* K5   */  be_nested_str_weak(count_active_fabrics),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(content_send),
-    /* K8   */  be_nested_str_weak(format),
-    /* K9   */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27text_X2Dalign_X3Aright_X3Bfont_X2Dsize_X3A11px_X3Bcolor_X3A_X23aaa_X3Bpadding_X3A0px_X3B_X27_X3E_X25s_X3C_X2Fdiv_X3E),
-    /* K10  */  be_nested_str_weak(Matter_X3A_X20No_X20active_X20association),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(Matter_X3A_X20),
-    /* K13  */  be_nested_str_weak(_X20active_X20association),
-    /* K14  */  be_nested_str_weak(s),
-    /* K15  */  be_nested_str_weak(),
-    /* K16  */  be_nested_str_weak(show_bridge_status),
-    /* K17  */  be_nested_str_weak(is_root_commissioning_open),
-    /* K18  */  be_nested_str_weak(show_commissioning_info),
+    /* K1   */  be_nested_str_weak(matter_enabled),
+    /* K2   */  be_nested_str_weak(device),
+    /* K3   */  be_nested_str_weak(sessions),
+    /* K4   */  be_nested_str_weak(count_active_fabrics),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(content_send),
+    /* K7   */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27text_X2Dalign_X3Aright_X3Bfont_X2Dsize_X3A11px_X3Bcolor_X3A_X23aaa_X3Bpadding_X3A0px_X3B_X27_X3E_X25s_X3C_X2Fdiv_X3E),
+    /* K8   */  be_nested_str_weak(Matter_X3A_X20No_X20active_X20association),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(Matter_X3A_X20),
+    /* K11  */  be_nested_str_weak(_X20active_X20association),
+    /* K12  */  be_nested_str_weak(s),
+    /* K13  */  be_nested_str_weak(),
+    /* K14  */  be_nested_str_weak(show_bridge_status),
+    /* K15  */  be_nested_str_weak(is_root_commissioning_open),
+    /* K16  */  be_nested_str_weak(show_commissioning_info),
     }),
     be_str_weak(web_sensor),
     &be_const_str_solidified,
-    ( &(const binstruction[43]) {  /* code */
+    ( &(const binstruction[42]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0102,  //  0002  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x780E0024,  //  0004  JMPF	R3	#002A
-      0x880C0103,  //  0005  GETMBR	R3	R0	K3
-      0x880C0704,  //  0006  GETMBR	R3	R3	K4
-      0x8C0C0705,  //  0007  GETMET	R3	R3	K5
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0x1C100706,  //  0009  EQ	R4	R3	K6
-      0x78120006,  //  000A  JMPF	R4	#0012
-      0x8C100307,  //  000B  GETMET	R4	R1	K7
-      0x8C180508,  //  000C  GETMET	R6	R2	K8
-      0x58200009,  //  000D  LDCONST	R8	K9
-      0x5824000A,  //  000E  LDCONST	R9	K10
-      0x7C180600,  //  000F  CALL	R6	3
-      0x7C100400,  //  0010  CALL	R4	2
-      0x7002000F,  //  0011  JMP		#0022
-      0x2410070B,  //  0012  GT	R4	R3	K11
-      0x8C140307,  //  0013  GETMET	R5	R1	K7
-      0x8C1C0508,  //  0014  GETMET	R7	R2	K8
-      0x58240009,  //  0015  LDCONST	R9	K9
-      0x60280008,  //  0016  GETGBL	R10	G8
-      0x5C2C0600,  //  0017  MOVE	R11	R3
-      0x7C280200,  //  0018  CALL	R10	1
-      0x002A180A,  //  0019  ADD	R10	K12	R10
-      0x0028150D,  //  001A  ADD	R10	R10	K13
-      0x78120001,  //  001B  JMPF	R4	#001E
-      0x582C000E,  //  001C  LDCONST	R11	K14
-      0x70020000,  //  001D  JMP		#001F
-      0x582C000F,  //  001E  LDCONST	R11	K15
-      0x0028140B,  //  001F  ADD	R10	R10	R11
-      0x7C1C0600,  //  0020  CALL	R7	3
-      0x7C140400,  //  0021  CALL	R5	2
-      0x8C100110,  //  0022  GETMET	R4	R0	K16
-      0x7C100200,  //  0023  CALL	R4	1
-      0x88100103,  //  0024  GETMBR	R4	R0	K3
-      0x8C100911,  //  0025  GETMET	R4	R4	K17
-      0x7C100200,  //  0026  CALL	R4	1
-      0x78120001,  //  0027  JMPF	R4	#002A
-      0x8C100112,  //  0028  GETMET	R4	R0	K18
-      0x7C100200,  //  0029  CALL	R4	1
-      0x80000000,  //  002A  RET	0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x780A0024,  //  0003  JMPF	R2	#0029
+      0x88080102,  //  0004  GETMBR	R2	R0	K2
+      0x88080503,  //  0005  GETMBR	R2	R2	K3
+      0x8C080504,  //  0006  GETMET	R2	R2	K4
+      0x7C080200,  //  0007  CALL	R2	1
+      0x1C0C0505,  //  0008  EQ	R3	R2	K5
+      0x780E0006,  //  0009  JMPF	R3	#0011
+      0x8C0C0306,  //  000A  GETMET	R3	R1	K6
+      0x60140018,  //  000B  GETGBL	R5	G24
+      0x58180007,  //  000C  LDCONST	R6	K7
+      0x581C0008,  //  000D  LDCONST	R7	K8
+      0x7C140400,  //  000E  CALL	R5	2
+      0x7C0C0400,  //  000F  CALL	R3	2
+      0x7002000F,  //  0010  JMP		#0021
+      0x240C0509,  //  0011  GT	R3	R2	K9
+      0x8C100306,  //  0012  GETMET	R4	R1	K6
+      0x60180018,  //  0013  GETGBL	R6	G24
+      0x581C0007,  //  0014  LDCONST	R7	K7
+      0x60200008,  //  0015  GETGBL	R8	G8
+      0x5C240400,  //  0016  MOVE	R9	R2
+      0x7C200200,  //  0017  CALL	R8	1
+      0x00221408,  //  0018  ADD	R8	K10	R8
+      0x0020110B,  //  0019  ADD	R8	R8	K11
+      0x780E0001,  //  001A  JMPF	R3	#001D
+      0x5824000C,  //  001B  LDCONST	R9	K12
+      0x70020000,  //  001C  JMP		#001E
+      0x5824000D,  //  001D  LDCONST	R9	K13
+      0x00201009,  //  001E  ADD	R8	R8	R9
+      0x7C180400,  //  001F  CALL	R6	2
+      0x7C100400,  //  0020  CALL	R4	2
+      0x8C0C010E,  //  0021  GETMET	R3	R0	K14
+      0x7C0C0200,  //  0022  CALL	R3	1
+      0x880C0102,  //  0023  GETMBR	R3	R0	K2
+      0x8C0C070F,  //  0024  GETMET	R3	R3	K15
+      0x7C0C0200,  //  0025  CALL	R3	1
+      0x780E0001,  //  0026  JMPF	R3	#0029
+      0x8C0C0110,  //  0027  GETMET	R3	R0	K16
+      0x7C0C0200,  //  0028  CALL	R3	1
+      0x80000000,  //  0029  RET	0
     })
   )
 );
@@ -517,7 +510,7 @@ be_local_closure(Matter_UI_web_sensor,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_page_part_mgr_add,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -525,51 +518,49 @@ be_local_closure(Matter_UI_page_part_mgr_add,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
+    ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(check_privileged_access),
-    /* K3   */  be_nested_str_weak(content_start),
-    /* K4   */  be_nested_str_weak(Matter_X20Create_X20new_X20endpoint),
-    /* K5   */  be_nested_str_weak(content_send_style),
-    /* K6   */  be_nested_str_weak(arg),
-    /* K7   */  be_nested_str_weak(url),
-    /* K8   */  be_nested_str_weak(matter_enabled),
-    /* K9   */  be_nested_str_weak(show_remote_autoconf),
-    /* K10  */  be_nested_str_weak(content_button),
-    /* K11  */  be_nested_str_weak(BUTTON_CONFIGURATION),
-    /* K12  */  be_nested_str_weak(content_stop),
+    /* K1   */  be_nested_str_weak(check_privileged_access),
+    /* K2   */  be_nested_str_weak(content_start),
+    /* K3   */  be_nested_str_weak(Matter_X20Create_X20new_X20endpoint),
+    /* K4   */  be_nested_str_weak(content_send_style),
+    /* K5   */  be_nested_str_weak(arg),
+    /* K6   */  be_nested_str_weak(url),
+    /* K7   */  be_nested_str_weak(matter_enabled),
+    /* K8   */  be_nested_str_weak(show_remote_autoconf),
+    /* K9   */  be_nested_str_weak(content_button),
+    /* K10  */  be_nested_str_weak(BUTTON_CONFIGURATION),
+    /* K11  */  be_nested_str_weak(content_stop),
     }),
     be_str_weak(page_part_mgr_add),
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
+    ( &(const binstruction[26]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x740E0001,  //  0004  JMPT	R3	#0007
-      0x4C0C0000,  //  0005  LDNIL	R3
-      0x80040600,  //  0006  RET	1	R3
-      0x8C0C0303,  //  0007  GETMET	R3	R1	K3
-      0x58140004,  //  0008  LDCONST	R5	K4
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x8C0C0305,  //  000A  GETMET	R3	R1	K5
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x8C0C0306,  //  000C  GETMET	R3	R1	K6
-      0x58140007,  //  000D  LDCONST	R5	K7
-      0x7C0C0400,  //  000E  CALL	R3	2
-      0x8C100108,  //  000F  GETMET	R4	R0	K8
-      0x7C100200,  //  0010  CALL	R4	1
-      0x78120002,  //  0011  JMPF	R4	#0015
-      0x8C100109,  //  0012  GETMET	R4	R0	K9
-      0x5C180600,  //  0013  MOVE	R6	R3
-      0x7C100400,  //  0014  CALL	R4	2
-      0x8C10030A,  //  0015  GETMET	R4	R1	K10
-      0x8818030B,  //  0016  GETMBR	R6	R1	K11
-      0x7C100400,  //  0017  CALL	R4	2
-      0x8C10030C,  //  0018  GETMET	R4	R1	K12
-      0x7C100200,  //  0019  CALL	R4	1
-      0x80000000,  //  001A  RET	0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x740A0001,  //  0003  JMPT	R2	#0006
+      0x4C080000,  //  0004  LDNIL	R2
+      0x80040400,  //  0005  RET	1	R2
+      0x8C080302,  //  0006  GETMET	R2	R1	K2
+      0x58100003,  //  0007  LDCONST	R4	K3
+      0x7C080400,  //  0008  CALL	R2	2
+      0x8C080304,  //  0009  GETMET	R2	R1	K4
+      0x7C080200,  //  000A  CALL	R2	1
+      0x8C080305,  //  000B  GETMET	R2	R1	K5
+      0x58100006,  //  000C  LDCONST	R4	K6
+      0x7C080400,  //  000D  CALL	R2	2
+      0x8C0C0107,  //  000E  GETMET	R3	R0	K7
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0x780E0002,  //  0010  JMPF	R3	#0014
+      0x8C0C0108,  //  0011  GETMET	R3	R0	K8
+      0x5C140400,  //  0012  MOVE	R5	R2
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x8C0C0309,  //  0014  GETMET	R3	R1	K9
+      0x8814030A,  //  0015  GETMBR	R5	R1	K10
+      0x7C0C0400,  //  0016  CALL	R3	2
+      0x8C0C030B,  //  0017  GETMET	R3	R1	K11
+      0x7C0C0200,  //  0018  CALL	R3	1
+      0x80000000,  //  0019  RET	0
     })
   )
 );
@@ -1107,7 +1098,7 @@ be_local_closure(Matter_UI_show_commissioning_info,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_show_remote_autoconf,   /* name */
   be_nested_proto(
-    26,                          /* nstack */
+    24,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1115,289 +1106,286 @@ be_local_closure(Matter_UI_show_remote_autoconf,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[49]) {     /* constants */
+    ( &(const bvalue[47]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(json),
-    /* K3   */  be_nested_str_weak(),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(Plugin_Bridge_HTTP),
-    /* K6   */  be_nested_str_weak(PROBE_TIMEOUT),
-    /* K7   */  be_nested_str_weak(HTTP_remote),
-    /* K8   */  be_nested_str_weak(call_sync),
-    /* K9   */  be_nested_str_weak(Status_X208),
-    /* K10  */  be_nested_str_weak(load),
-    /* K11  */  be_nested_str_weak(find),
-    /* K12  */  be_nested_str_weak(StatusSNS),
-    /* K13  */  be_nested_str_weak(Status_X2011),
-    /* K14  */  be_nested_str_weak(StatusSTS),
-    /* K15  */  be_nested_str_weak(tasmota),
-    /* K16  */  be_nested_str_weak(log),
-    /* K17  */  be_nested_str_weak(format),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20probed_X20_X27_X25s_X27_X20status8_X3D_X25s_X20satus11_X3D_X25s),
-    /* K19  */  be_const_int(3),
-    /* K20  */  be_nested_str_weak(generate_config_from_status),
-    /* K21  */  be_nested_str_weak(show_plugins_hints_js),
-    /* K22  */  be_nested_str_weak(_CLASSES_TYPES2),
-    /* K23  */  be_nested_str_weak(content_send),
-    /* K24  */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20Remote_X20Device_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3EAdd_X20Remote_X20sensor_X20or_X20device_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
-    /* K25  */  be_nested_str_weak(_X3Cp_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Fp_X3E),
-    /* K26  */  be_nested_str_weak(html_escape),
-    /* K27  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E_X3Ctr_X3E_X3Ctd_X20width_X3D_X27100_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EName_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EType_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EParameter_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-    /* K28  */  be_nested_str_weak(_X3Cinput_X20name_X3D_X27url_X27_X20type_X3D_X27hidden_X27_X20value_X3D_X27_X25s_X27_X3E),
-    /* K29  */  be_const_int(0),
-    /* K30  */  be_nested_str_weak(type),
-    /* K31  */  be_nested_str_weak(http_),
-    /* K32  */  be_nested_str_weak(device),
-    /* K33  */  be_nested_str_weak(plugins_classes),
-    /* K34  */  be_nested_str_weak(ui_conf_to_string),
-    /* K35  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X3E_X3C_X2Ftd_X3E),
-    /* K36  */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cselect_X20name_X3D_X27pi_X25i_X27_X20onchange_X3D_X27otm_X28_X22arg_X25i_X22_X2Cthis_X2Evalue_X29_X27_X3E),
-    /* K37  */  be_nested_str_weak(plugin_option),
-    /* K38  */  be_nested_str_weak(_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E),
-    /* K39  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X25i_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X20placeholder_X3D_X27_X25s_X27_X3E),
-    /* K40  */  be_nested_str_weak(ARG_HINT),
-    /* K41  */  be_nested_str_weak(_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-    /* K42  */  be_const_int(1),
-    /* K43  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X25i_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X3E),
-    /* K44  */  be_nested_str_weak(_X3C_X2Ftable_X3E),
-    /* K45  */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E),
-    /* K46  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27addrem_X27_X20class_X3D_X27button_X20bgrn_X27_X3EAdd_X20endpoints_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E),
-    /* K47  */  be_nested_str_weak(_X3C_X2Fform_X3E_X3C_X2Ffieldset_X3E),
-    /* K48  */  be_nested_str_weak(_X3Cp_X3E_X3Cb_X3EUnable_X20to_X20connect_X20to_X20_X27_X25s_X27_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
+    /* K1   */  be_nested_str_weak(json),
+    /* K2   */  be_nested_str_weak(),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(Plugin_Bridge_HTTP),
+    /* K5   */  be_nested_str_weak(PROBE_TIMEOUT),
+    /* K6   */  be_nested_str_weak(HTTP_remote),
+    /* K7   */  be_nested_str_weak(call_sync),
+    /* K8   */  be_nested_str_weak(Status_X208),
+    /* K9   */  be_nested_str_weak(load),
+    /* K10  */  be_nested_str_weak(find),
+    /* K11  */  be_nested_str_weak(StatusSNS),
+    /* K12  */  be_nested_str_weak(Status_X2011),
+    /* K13  */  be_nested_str_weak(StatusSTS),
+    /* K14  */  be_nested_str_weak(tasmota),
+    /* K15  */  be_nested_str_weak(log),
+    /* K16  */  be_nested_str_weak(MTR_X3A_X20probed_X20_X27_X25s_X27_X20status8_X3D_X25s_X20satus11_X3D_X25s),
+    /* K17  */  be_const_int(3),
+    /* K18  */  be_nested_str_weak(generate_config_from_status),
+    /* K19  */  be_nested_str_weak(show_plugins_hints_js),
+    /* K20  */  be_nested_str_weak(_CLASSES_TYPES2),
+    /* K21  */  be_nested_str_weak(content_send),
+    /* K22  */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20Remote_X20Device_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3EAdd_X20Remote_X20sensor_X20or_X20device_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
+    /* K23  */  be_nested_str_weak(_X3Cp_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Fp_X3E),
+    /* K24  */  be_nested_str_weak(html_escape),
+    /* K25  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E_X3Ctr_X3E_X3Ctd_X20width_X3D_X27100_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EName_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EType_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EParameter_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+    /* K26  */  be_nested_str_weak(_X3Cinput_X20name_X3D_X27url_X27_X20type_X3D_X27hidden_X27_X20value_X3D_X27_X25s_X27_X3E),
+    /* K27  */  be_const_int(0),
+    /* K28  */  be_nested_str_weak(type),
+    /* K29  */  be_nested_str_weak(http_),
+    /* K30  */  be_nested_str_weak(device),
+    /* K31  */  be_nested_str_weak(plugins_classes),
+    /* K32  */  be_nested_str_weak(ui_conf_to_string),
+    /* K33  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X3E_X3C_X2Ftd_X3E),
+    /* K34  */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cselect_X20name_X3D_X27pi_X25i_X27_X20onchange_X3D_X27otm_X28_X22arg_X25i_X22_X2Cthis_X2Evalue_X29_X27_X3E),
+    /* K35  */  be_nested_str_weak(plugin_option),
+    /* K36  */  be_nested_str_weak(_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E),
+    /* K37  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X25i_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X20placeholder_X3D_X27_X25s_X27_X3E),
+    /* K38  */  be_nested_str_weak(ARG_HINT),
+    /* K39  */  be_nested_str_weak(_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+    /* K40  */  be_const_int(1),
+    /* K41  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X25i_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X3E),
+    /* K42  */  be_nested_str_weak(_X3C_X2Ftable_X3E),
+    /* K43  */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E),
+    /* K44  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27addrem_X27_X20class_X3D_X27button_X20bgrn_X27_X3EAdd_X20endpoints_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E),
+    /* K45  */  be_nested_str_weak(_X3C_X2Fform_X3E_X3C_X2Ffieldset_X3E),
+    /* K46  */  be_nested_str_weak(_X3Cp_X3E_X3Cb_X3EUnable_X20to_X20connect_X20to_X20_X27_X25s_X27_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
     }),
     be_str_weak(show_remote_autoconf),
     &be_const_str_solidified,
-    ( &(const binstruction[229]) {  /* code */
+    ( &(const binstruction[228]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA4120400,  //  0002  IMPORT	R4	K2
-      0x1C140303,  //  0003  EQ	R5	R1	K3
-      0x78160000,  //  0004  JMPF	R5	#0006
-      0x80000A00,  //  0005  RET	0
-      0xB8160800,  //  0006  GETNGBL	R5	K4
-      0x88140B05,  //  0007  GETMBR	R5	R5	K5
-      0x88140B06,  //  0008  GETMBR	R5	R5	K6
-      0xB81A0800,  //  0009  GETNGBL	R6	K4
-      0x8C180D07,  //  000A  GETMET	R6	R6	K7
-      0x5C200200,  //  000B  MOVE	R8	R1
-      0x5C240A00,  //  000C  MOVE	R9	R5
-      0x7C180600,  //  000D  CALL	R6	3
-      0x8C1C0D08,  //  000E  GETMET	R7	R6	K8
-      0x58240009,  //  000F  LDCONST	R9	K9
-      0x5C280A00,  //  0010  MOVE	R10	R5
-      0x7C1C0600,  //  0011  CALL	R7	3
-      0x4C200000,  //  0012  LDNIL	R8
-      0x20200E08,  //  0013  NE	R8	R7	R8
-      0x78220003,  //  0014  JMPF	R8	#0019
-      0x8C20090A,  //  0015  GETMET	R8	R4	K10
-      0x5C280E00,  //  0016  MOVE	R10	R7
-      0x7C200400,  //  0017  CALL	R8	2
-      0x5C1C1000,  //  0018  MOVE	R7	R8
-      0x4C200000,  //  0019  LDNIL	R8
-      0x20200E08,  //  001A  NE	R8	R7	R8
-      0x78220003,  //  001B  JMPF	R8	#0020
-      0x8C200F0B,  //  001C  GETMET	R8	R7	K11
-      0x5828000C,  //  001D  LDCONST	R10	K12
-      0x7C200400,  //  001E  CALL	R8	2
-      0x5C1C1000,  //  001F  MOVE	R7	R8
+      0x1C100302,  //  0002  EQ	R4	R1	K2
+      0x78120000,  //  0003  JMPF	R4	#0005
+      0x80000800,  //  0004  RET	0
+      0xB8120600,  //  0005  GETNGBL	R4	K3
+      0x88100904,  //  0006  GETMBR	R4	R4	K4
+      0x88100905,  //  0007  GETMBR	R4	R4	K5
+      0xB8160600,  //  0008  GETNGBL	R5	K3
+      0x8C140B06,  //  0009  GETMET	R5	R5	K6
+      0x5C1C0200,  //  000A  MOVE	R7	R1
+      0x5C200800,  //  000B  MOVE	R8	R4
+      0x7C140600,  //  000C  CALL	R5	3
+      0x8C180B07,  //  000D  GETMET	R6	R5	K7
+      0x58200008,  //  000E  LDCONST	R8	K8
+      0x5C240800,  //  000F  MOVE	R9	R4
+      0x7C180600,  //  0010  CALL	R6	3
+      0x4C1C0000,  //  0011  LDNIL	R7
+      0x201C0C07,  //  0012  NE	R7	R6	R7
+      0x781E0003,  //  0013  JMPF	R7	#0018
+      0x8C1C0709,  //  0014  GETMET	R7	R3	K9
+      0x5C240C00,  //  0015  MOVE	R9	R6
+      0x7C1C0400,  //  0016  CALL	R7	2
+      0x5C180E00,  //  0017  MOVE	R6	R7
+      0x4C1C0000,  //  0018  LDNIL	R7
+      0x201C0C07,  //  0019  NE	R7	R6	R7
+      0x781E0003,  //  001A  JMPF	R7	#001F
+      0x8C1C0D0A,  //  001B  GETMET	R7	R6	K10
+      0x5824000B,  //  001C  LDCONST	R9	K11
+      0x7C1C0400,  //  001D  CALL	R7	2
+      0x5C180E00,  //  001E  MOVE	R6	R7
+      0x4C1C0000,  //  001F  LDNIL	R7
       0x4C200000,  //  0020  LDNIL	R8
-      0x4C240000,  //  0021  LDNIL	R9
-      0x20240E09,  //  0022  NE	R9	R7	R9
-      0x78260012,  //  0023  JMPF	R9	#0037
-      0x8C240D08,  //  0024  GETMET	R9	R6	K8
-      0x582C000D,  //  0025  LDCONST	R11	K13
-      0x5C300A00,  //  0026  MOVE	R12	R5
-      0x7C240600,  //  0027  CALL	R9	3
-      0x5C201200,  //  0028  MOVE	R8	R9
-      0x4C240000,  //  0029  LDNIL	R9
-      0x20241009,  //  002A  NE	R9	R8	R9
-      0x78260003,  //  002B  JMPF	R9	#0030
-      0x8C24090A,  //  002C  GETMET	R9	R4	K10
-      0x5C2C1000,  //  002D  MOVE	R11	R8
-      0x7C240400,  //  002E  CALL	R9	2
-      0x5C201200,  //  002F  MOVE	R8	R9
-      0x4C240000,  //  0030  LDNIL	R9
-      0x20241009,  //  0031  NE	R9	R8	R9
-      0x78260003,  //  0032  JMPF	R9	#0037
-      0x8C24110B,  //  0033  GETMET	R9	R8	K11
-      0x582C000E,  //  0034  LDCONST	R11	K14
-      0x7C240400,  //  0035  CALL	R9	2
-      0x5C201200,  //  0036  MOVE	R8	R9
-      0x4C240000,  //  0037  LDNIL	R9
-      0x20240E09,  //  0038  NE	R9	R7	R9
-      0x782600A1,  //  0039  JMPF	R9	#00DC
-      0x4C240000,  //  003A  LDNIL	R9
-      0x20241009,  //  003B  NE	R9	R8	R9
-      0x7826009E,  //  003C  JMPF	R9	#00DC
-      0xB8261E00,  //  003D  GETNGBL	R9	K15
-      0x8C241310,  //  003E  GETMET	R9	R9	K16
-      0x8C2C0711,  //  003F  GETMET	R11	R3	K17
-      0x58340012,  //  0040  LDCONST	R13	K18
-      0x5C380200,  //  0041  MOVE	R14	R1
-      0x603C0008,  //  0042  GETGBL	R15	G8
-      0x5C400E00,  //  0043  MOVE	R16	R7
-      0x7C3C0200,  //  0044  CALL	R15	1
-      0x60400008,  //  0045  GETGBL	R16	G8
-      0x5C441000,  //  0046  MOVE	R17	R8
-      0x7C400200,  //  0047  CALL	R16	1
-      0x7C2C0A00,  //  0048  CALL	R11	5
-      0x58300013,  //  0049  LDCONST	R12	K19
-      0x7C240600,  //  004A  CALL	R9	3
-      0x8C240114,  //  004B  GETMET	R9	R0	K20
+      0x20200C08,  //  0021  NE	R8	R6	R8
+      0x78220012,  //  0022  JMPF	R8	#0036
+      0x8C200B07,  //  0023  GETMET	R8	R5	K7
+      0x5828000C,  //  0024  LDCONST	R10	K12
+      0x5C2C0800,  //  0025  MOVE	R11	R4
+      0x7C200600,  //  0026  CALL	R8	3
+      0x5C1C1000,  //  0027  MOVE	R7	R8
+      0x4C200000,  //  0028  LDNIL	R8
+      0x20200E08,  //  0029  NE	R8	R7	R8
+      0x78220003,  //  002A  JMPF	R8	#002F
+      0x8C200709,  //  002B  GETMET	R8	R3	K9
+      0x5C280E00,  //  002C  MOVE	R10	R7
+      0x7C200400,  //  002D  CALL	R8	2
+      0x5C1C1000,  //  002E  MOVE	R7	R8
+      0x4C200000,  //  002F  LDNIL	R8
+      0x20200E08,  //  0030  NE	R8	R7	R8
+      0x78220003,  //  0031  JMPF	R8	#0036
+      0x8C200F0A,  //  0032  GETMET	R8	R7	K10
+      0x5828000D,  //  0033  LDCONST	R10	K13
+      0x7C200400,  //  0034  CALL	R8	2
+      0x5C1C1000,  //  0035  MOVE	R7	R8
+      0x4C200000,  //  0036  LDNIL	R8
+      0x20200C08,  //  0037  NE	R8	R6	R8
+      0x782200A1,  //  0038  JMPF	R8	#00DB
+      0x4C200000,  //  0039  LDNIL	R8
+      0x20200E08,  //  003A  NE	R8	R7	R8
+      0x7822009E,  //  003B  JMPF	R8	#00DB
+      0xB8221C00,  //  003C  GETNGBL	R8	K14
+      0x8C20110F,  //  003D  GETMET	R8	R8	K15
+      0x60280018,  //  003E  GETGBL	R10	G24
+      0x582C0010,  //  003F  LDCONST	R11	K16
+      0x5C300200,  //  0040  MOVE	R12	R1
+      0x60340008,  //  0041  GETGBL	R13	G8
+      0x5C380C00,  //  0042  MOVE	R14	R6
+      0x7C340200,  //  0043  CALL	R13	1
+      0x60380008,  //  0044  GETGBL	R14	G8
+      0x5C3C0E00,  //  0045  MOVE	R15	R7
+      0x7C380200,  //  0046  CALL	R14	1
+      0x7C280800,  //  0047  CALL	R10	4
+      0x582C0011,  //  0048  LDCONST	R11	K17
+      0x7C200600,  //  0049  CALL	R8	3
+      0x8C200112,  //  004A  GETMET	R8	R0	K18
+      0x5C280C00,  //  004B  MOVE	R10	R6
       0x5C2C0E00,  //  004C  MOVE	R11	R7
-      0x5C301000,  //  004D  MOVE	R12	R8
-      0x7C240600,  //  004E  CALL	R9	3
-      0x8C280115,  //  004F  GETMET	R10	R0	K21
-      0x88300116,  //  0050  GETMBR	R12	R0	K22
-      0x7C280400,  //  0051  CALL	R10	2
-      0x8C280517,  //  0052  GETMET	R10	R2	K23
-      0x58300018,  //  0053  LDCONST	R12	K24
-      0x7C280400,  //  0054  CALL	R10	2
-      0x8C280517,  //  0055  GETMET	R10	R2	K23
-      0x8C300711,  //  0056  GETMET	R12	R3	K17
-      0x58380019,  //  0057  LDCONST	R14	K25
-      0x8C3C051A,  //  0058  GETMET	R15	R2	K26
-      0x5C440200,  //  0059  MOVE	R17	R1
-      0x7C3C0400,  //  005A  CALL	R15	2
-      0x8C40051A,  //  005B  GETMET	R16	R2	K26
-      0x5C480200,  //  005C  MOVE	R18	R1
-      0x7C400400,  //  005D  CALL	R16	2
-      0x7C300800,  //  005E  CALL	R12	4
-      0x7C280400,  //  005F  CALL	R10	2
-      0x8C280517,  //  0060  GETMET	R10	R2	K23
-      0x5830001B,  //  0061  LDCONST	R12	K27
-      0x7C280400,  //  0062  CALL	R10	2
-      0x8C280517,  //  0063  GETMET	R10	R2	K23
-      0x8C300711,  //  0064  GETMET	R12	R3	K17
-      0x5838001C,  //  0065  LDCONST	R14	K28
-      0x8C3C051A,  //  0066  GETMET	R15	R2	K26
-      0x5C440200,  //  0067  MOVE	R17	R1
-      0x7C3C0400,  //  0068  CALL	R15	2
-      0x7C300600,  //  0069  CALL	R12	3
-      0x7C280400,  //  006A  CALL	R10	2
-      0x5828001D,  //  006B  LDCONST	R10	K29
-      0x602C000C,  //  006C  GETGBL	R11	G12
-      0x5C301200,  //  006D  MOVE	R12	R9
-      0x7C2C0200,  //  006E  CALL	R11	1
-      0x142C140B,  //  006F  LT	R11	R10	R11
-      0x782E003E,  //  0070  JMPF	R11	#00B0
-      0x942C120A,  //  0071  GETIDX	R11	R9	R10
-      0x8C30170B,  //  0072  GETMET	R12	R11	K11
-      0x5838001E,  //  0073  LDCONST	R14	K30
-      0x583C0003,  //  0074  LDCONST	R15	K3
-      0x7C300600,  //  0075  CALL	R12	3
-      0x20341903,  //  0076  NE	R13	R12	K3
-      0x78360000,  //  0077  JMPF	R13	#0079
-      0x00323E0C,  //  0078  ADD	R12	K31	R12
-      0x88340120,  //  0079  GETMBR	R13	R0	K32
-      0x88341B21,  //  007A  GETMBR	R13	R13	K33
-      0x8C341B0B,  //  007B  GETMET	R13	R13	K11
-      0x5C3C1800,  //  007C  MOVE	R15	R12
-      0x7C340400,  //  007D  CALL	R13	2
-      0x58380003,  //  007E  LDCONST	R14	K3
-      0x4C3C0000,  //  007F  LDNIL	R15
-      0x203C1A0F,  //  0080  NE	R15	R13	R15
-      0x783E0004,  //  0081  JMPF	R15	#0087
-      0x8C3C1B22,  //  0082  GETMET	R15	R13	K34
-      0x5C441A00,  //  0083  MOVE	R17	R13
-      0x5C481600,  //  0084  MOVE	R18	R11
-      0x7C3C0600,  //  0085  CALL	R15	3
-      0x5C381E00,  //  0086  MOVE	R14	R15
-      0x8C3C0517,  //  0087  GETMET	R15	R2	K23
-      0x8C440711,  //  0088  GETMET	R17	R3	K17
-      0x584C0023,  //  0089  LDCONST	R19	K35
-      0x5C501400,  //  008A  MOVE	R20	R10
-      0x7C440600,  //  008B  CALL	R17	3
-      0x7C3C0400,  //  008C  CALL	R15	2
-      0x8C3C0517,  //  008D  GETMET	R15	R2	K23
-      0x8C440711,  //  008E  GETMET	R17	R3	K17
-      0x584C0024,  //  008F  LDCONST	R19	K36
-      0x5C501400,  //  0090  MOVE	R20	R10
-      0x5C541400,  //  0091  MOVE	R21	R10
-      0x7C440800,  //  0092  CALL	R17	4
-      0x7C3C0400,  //  0093  CALL	R15	2
-      0x8C3C0125,  //  0094  GETMET	R15	R0	K37
-      0x5C441800,  //  0095  MOVE	R17	R12
-      0x88480116,  //  0096  GETMBR	R18	R0	K22
-      0x7C3C0600,  //  0097  CALL	R15	3
-      0x8C3C0517,  //  0098  GETMET	R15	R2	K23
-      0x58440026,  //  0099  LDCONST	R17	K38
-      0x7C3C0400,  //  009A  CALL	R15	2
-      0x8C3C0517,  //  009B  GETMET	R15	R2	K23
-      0x8C440711,  //  009C  GETMET	R17	R3	K17
-      0x584C0027,  //  009D  LDCONST	R19	K39
-      0x5C501400,  //  009E  MOVE	R20	R10
-      0x5C541400,  //  009F  MOVE	R21	R10
-      0x8C58051A,  //  00A0  GETMET	R22	R2	K26
-      0x5C601C00,  //  00A1  MOVE	R24	R14
-      0x7C580400,  //  00A2  CALL	R22	2
-      0x78360003,  //  00A3  JMPF	R13	#00A8
-      0x8C5C051A,  //  00A4  GETMET	R23	R2	K26
-      0x88641B28,  //  00A5  GETMBR	R25	R13	K40
-      0x7C5C0400,  //  00A6  CALL	R23	2
-      0x70020000,  //  00A7  JMP		#00A9
-      0x585C0003,  //  00A8  LDCONST	R23	K3
-      0x7C440C00,  //  00A9  CALL	R17	6
-      0x7C3C0400,  //  00AA  CALL	R15	2
-      0x8C3C0517,  //  00AB  GETMET	R15	R2	K23
-      0x58440029,  //  00AC  LDCONST	R17	K41
-      0x7C3C0400,  //  00AD  CALL	R15	2
-      0x0028152A,  //  00AE  ADD	R10	R10	K42
-      0x7001FFBB,  //  00AF  JMP		#006C
-      0x8C2C0517,  //  00B0  GETMET	R11	R2	K23
-      0x8C340711,  //  00B1  GETMET	R13	R3	K17
-      0x583C0023,  //  00B2  LDCONST	R15	K35
-      0x5C401400,  //  00B3  MOVE	R16	R10
-      0x7C340600,  //  00B4  CALL	R13	3
-      0x7C2C0400,  //  00B5  CALL	R11	2
-      0x8C2C0517,  //  00B6  GETMET	R11	R2	K23
-      0x8C340711,  //  00B7  GETMET	R13	R3	K17
-      0x583C0024,  //  00B8  LDCONST	R15	K36
-      0x5C401400,  //  00B9  MOVE	R16	R10
-      0x5C441400,  //  00BA  MOVE	R17	R10
-      0x7C340800,  //  00BB  CALL	R13	4
-      0x7C2C0400,  //  00BC  CALL	R11	2
-      0x8C2C0125,  //  00BD  GETMET	R11	R0	K37
-      0x58340003,  //  00BE  LDCONST	R13	K3
-      0x88380116,  //  00BF  GETMBR	R14	R0	K22
-      0x7C2C0600,  //  00C0  CALL	R11	3
-      0x8C2C0517,  //  00C1  GETMET	R11	R2	K23
-      0x58340026,  //  00C2  LDCONST	R13	K38
-      0x7C2C0400,  //  00C3  CALL	R11	2
-      0x8C2C0517,  //  00C4  GETMET	R11	R2	K23
-      0x8C340711,  //  00C5  GETMET	R13	R3	K17
-      0x583C002B,  //  00C6  LDCONST	R15	K43
-      0x5C401400,  //  00C7  MOVE	R16	R10
-      0x5C441400,  //  00C8  MOVE	R17	R10
-      0x58480003,  //  00C9  LDCONST	R18	K3
-      0x7C340A00,  //  00CA  CALL	R13	5
-      0x7C2C0400,  //  00CB  CALL	R11	2
-      0x8C2C0517,  //  00CC  GETMET	R11	R2	K23
-      0x58340029,  //  00CD  LDCONST	R13	K41
-      0x7C2C0400,  //  00CE  CALL	R11	2
-      0x8C2C0517,  //  00CF  GETMET	R11	R2	K23
-      0x5834002C,  //  00D0  LDCONST	R13	K44
-      0x7C2C0400,  //  00D1  CALL	R11	2
-      0x8C2C0517,  //  00D2  GETMET	R11	R2	K23
-      0x5834002D,  //  00D3  LDCONST	R13	K45
-      0x7C2C0400,  //  00D4  CALL	R11	2
-      0x8C2C0517,  //  00D5  GETMET	R11	R2	K23
-      0x5834002E,  //  00D6  LDCONST	R13	K46
-      0x7C2C0400,  //  00D7  CALL	R11	2
-      0x8C2C0517,  //  00D8  GETMET	R11	R2	K23
-      0x5834002F,  //  00D9  LDCONST	R13	K47
-      0x7C2C0400,  //  00DA  CALL	R11	2
-      0x70020007,  //  00DB  JMP		#00E4
-      0x8C240517,  //  00DC  GETMET	R9	R2	K23
-      0x8C2C0711,  //  00DD  GETMET	R11	R3	K17
-      0x58340030,  //  00DE  LDCONST	R13	K48
-      0x8C38051A,  //  00DF  GETMET	R14	R2	K26
-      0x5C400200,  //  00E0  MOVE	R16	R1
-      0x7C380400,  //  00E1  CALL	R14	2
-      0x7C2C0600,  //  00E2  CALL	R11	3
-      0x7C240400,  //  00E3  CALL	R9	2
-      0x80000000,  //  00E4  RET	0
+      0x7C200600,  //  004D  CALL	R8	3
+      0x8C240113,  //  004E  GETMET	R9	R0	K19
+      0x882C0114,  //  004F  GETMBR	R11	R0	K20
+      0x7C240400,  //  0050  CALL	R9	2
+      0x8C240515,  //  0051  GETMET	R9	R2	K21
+      0x582C0016,  //  0052  LDCONST	R11	K22
+      0x7C240400,  //  0053  CALL	R9	2
+      0x8C240515,  //  0054  GETMET	R9	R2	K21
+      0x602C0018,  //  0055  GETGBL	R11	G24
+      0x58300017,  //  0056  LDCONST	R12	K23
+      0x8C340518,  //  0057  GETMET	R13	R2	K24
+      0x5C3C0200,  //  0058  MOVE	R15	R1
+      0x7C340400,  //  0059  CALL	R13	2
+      0x8C380518,  //  005A  GETMET	R14	R2	K24
+      0x5C400200,  //  005B  MOVE	R16	R1
+      0x7C380400,  //  005C  CALL	R14	2
+      0x7C2C0600,  //  005D  CALL	R11	3
+      0x7C240400,  //  005E  CALL	R9	2
+      0x8C240515,  //  005F  GETMET	R9	R2	K21
+      0x582C0019,  //  0060  LDCONST	R11	K25
+      0x7C240400,  //  0061  CALL	R9	2
+      0x8C240515,  //  0062  GETMET	R9	R2	K21
+      0x602C0018,  //  0063  GETGBL	R11	G24
+      0x5830001A,  //  0064  LDCONST	R12	K26
+      0x8C340518,  //  0065  GETMET	R13	R2	K24
+      0x5C3C0200,  //  0066  MOVE	R15	R1
+      0x7C340400,  //  0067  CALL	R13	2
+      0x7C2C0400,  //  0068  CALL	R11	2
+      0x7C240400,  //  0069  CALL	R9	2
+      0x5824001B,  //  006A  LDCONST	R9	K27
+      0x6028000C,  //  006B  GETGBL	R10	G12
+      0x5C2C1000,  //  006C  MOVE	R11	R8
+      0x7C280200,  //  006D  CALL	R10	1
+      0x1428120A,  //  006E  LT	R10	R9	R10
+      0x782A003E,  //  006F  JMPF	R10	#00AF
+      0x94281009,  //  0070  GETIDX	R10	R8	R9
+      0x8C2C150A,  //  0071  GETMET	R11	R10	K10
+      0x5834001C,  //  0072  LDCONST	R13	K28
+      0x58380002,  //  0073  LDCONST	R14	K2
+      0x7C2C0600,  //  0074  CALL	R11	3
+      0x20301702,  //  0075  NE	R12	R11	K2
+      0x78320000,  //  0076  JMPF	R12	#0078
+      0x002E3A0B,  //  0077  ADD	R11	K29	R11
+      0x8830011E,  //  0078  GETMBR	R12	R0	K30
+      0x8830191F,  //  0079  GETMBR	R12	R12	K31
+      0x8C30190A,  //  007A  GETMET	R12	R12	K10
+      0x5C381600,  //  007B  MOVE	R14	R11
+      0x7C300400,  //  007C  CALL	R12	2
+      0x58340002,  //  007D  LDCONST	R13	K2
+      0x4C380000,  //  007E  LDNIL	R14
+      0x2038180E,  //  007F  NE	R14	R12	R14
+      0x783A0004,  //  0080  JMPF	R14	#0086
+      0x8C381920,  //  0081  GETMET	R14	R12	K32
+      0x5C401800,  //  0082  MOVE	R16	R12
+      0x5C441400,  //  0083  MOVE	R17	R10
+      0x7C380600,  //  0084  CALL	R14	3
+      0x5C341C00,  //  0085  MOVE	R13	R14
+      0x8C380515,  //  0086  GETMET	R14	R2	K21
+      0x60400018,  //  0087  GETGBL	R16	G24
+      0x58440021,  //  0088  LDCONST	R17	K33
+      0x5C481200,  //  0089  MOVE	R18	R9
+      0x7C400400,  //  008A  CALL	R16	2
+      0x7C380400,  //  008B  CALL	R14	2
+      0x8C380515,  //  008C  GETMET	R14	R2	K21
+      0x60400018,  //  008D  GETGBL	R16	G24
+      0x58440022,  //  008E  LDCONST	R17	K34
+      0x5C481200,  //  008F  MOVE	R18	R9
+      0x5C4C1200,  //  0090  MOVE	R19	R9
+      0x7C400600,  //  0091  CALL	R16	3
+      0x7C380400,  //  0092  CALL	R14	2
+      0x8C380123,  //  0093  GETMET	R14	R0	K35
+      0x5C401600,  //  0094  MOVE	R16	R11
+      0x88440114,  //  0095  GETMBR	R17	R0	K20
+      0x7C380600,  //  0096  CALL	R14	3
+      0x8C380515,  //  0097  GETMET	R14	R2	K21
+      0x58400024,  //  0098  LDCONST	R16	K36
+      0x7C380400,  //  0099  CALL	R14	2
+      0x8C380515,  //  009A  GETMET	R14	R2	K21
+      0x60400018,  //  009B  GETGBL	R16	G24
+      0x58440025,  //  009C  LDCONST	R17	K37
+      0x5C481200,  //  009D  MOVE	R18	R9
+      0x5C4C1200,  //  009E  MOVE	R19	R9
+      0x8C500518,  //  009F  GETMET	R20	R2	K24
+      0x5C581A00,  //  00A0  MOVE	R22	R13
+      0x7C500400,  //  00A1  CALL	R20	2
+      0x78320003,  //  00A2  JMPF	R12	#00A7
+      0x8C540518,  //  00A3  GETMET	R21	R2	K24
+      0x885C1926,  //  00A4  GETMBR	R23	R12	K38
+      0x7C540400,  //  00A5  CALL	R21	2
+      0x70020000,  //  00A6  JMP		#00A8
+      0x58540002,  //  00A7  LDCONST	R21	K2
+      0x7C400A00,  //  00A8  CALL	R16	5
+      0x7C380400,  //  00A9  CALL	R14	2
+      0x8C380515,  //  00AA  GETMET	R14	R2	K21
+      0x58400027,  //  00AB  LDCONST	R16	K39
+      0x7C380400,  //  00AC  CALL	R14	2
+      0x00241328,  //  00AD  ADD	R9	R9	K40
+      0x7001FFBB,  //  00AE  JMP		#006B
+      0x8C280515,  //  00AF  GETMET	R10	R2	K21
+      0x60300018,  //  00B0  GETGBL	R12	G24
+      0x58340021,  //  00B1  LDCONST	R13	K33
+      0x5C381200,  //  00B2  MOVE	R14	R9
+      0x7C300400,  //  00B3  CALL	R12	2
+      0x7C280400,  //  00B4  CALL	R10	2
+      0x8C280515,  //  00B5  GETMET	R10	R2	K21
+      0x60300018,  //  00B6  GETGBL	R12	G24
+      0x58340022,  //  00B7  LDCONST	R13	K34
+      0x5C381200,  //  00B8  MOVE	R14	R9
+      0x5C3C1200,  //  00B9  MOVE	R15	R9
+      0x7C300600,  //  00BA  CALL	R12	3
+      0x7C280400,  //  00BB  CALL	R10	2
+      0x8C280123,  //  00BC  GETMET	R10	R0	K35
+      0x58300002,  //  00BD  LDCONST	R12	K2
+      0x88340114,  //  00BE  GETMBR	R13	R0	K20
+      0x7C280600,  //  00BF  CALL	R10	3
+      0x8C280515,  //  00C0  GETMET	R10	R2	K21
+      0x58300024,  //  00C1  LDCONST	R12	K36
+      0x7C280400,  //  00C2  CALL	R10	2
+      0x8C280515,  //  00C3  GETMET	R10	R2	K21
+      0x60300018,  //  00C4  GETGBL	R12	G24
+      0x58340029,  //  00C5  LDCONST	R13	K41
+      0x5C381200,  //  00C6  MOVE	R14	R9
+      0x5C3C1200,  //  00C7  MOVE	R15	R9
+      0x58400002,  //  00C8  LDCONST	R16	K2
+      0x7C300800,  //  00C9  CALL	R12	4
+      0x7C280400,  //  00CA  CALL	R10	2
+      0x8C280515,  //  00CB  GETMET	R10	R2	K21
+      0x58300027,  //  00CC  LDCONST	R12	K39
+      0x7C280400,  //  00CD  CALL	R10	2
+      0x8C280515,  //  00CE  GETMET	R10	R2	K21
+      0x5830002A,  //  00CF  LDCONST	R12	K42
+      0x7C280400,  //  00D0  CALL	R10	2
+      0x8C280515,  //  00D1  GETMET	R10	R2	K21
+      0x5830002B,  //  00D2  LDCONST	R12	K43
+      0x7C280400,  //  00D3  CALL	R10	2
+      0x8C280515,  //  00D4  GETMET	R10	R2	K21
+      0x5830002C,  //  00D5  LDCONST	R12	K44
+      0x7C280400,  //  00D6  CALL	R10	2
+      0x8C280515,  //  00D7  GETMET	R10	R2	K21
+      0x5830002D,  //  00D8  LDCONST	R12	K45
+      0x7C280400,  //  00D9  CALL	R10	2
+      0x70020007,  //  00DA  JMP		#00E3
+      0x8C200515,  //  00DB  GETMET	R8	R2	K21
+      0x60280018,  //  00DC  GETGBL	R10	G24
+      0x582C002E,  //  00DD  LDCONST	R11	K46
+      0x8C300518,  //  00DE  GETMET	R12	R2	K24
+      0x5C380200,  //  00DF  MOVE	R14	R1
+      0x7C300400,  //  00E0  CALL	R12	2
+      0x7C280400,  //  00E1  CALL	R10	2
+      0x7C200400,  //  00E2  CALL	R8	2
+      0x80000000,  //  00E3  RET	0
     })
   )
 );
@@ -1409,7 +1397,7 @@ be_local_closure(Matter_UI_show_remote_autoconf,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_show_fabric_info,   /* name */
   be_nested_proto(
-    15,                          /* nstack */
+    14,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1417,141 +1405,139 @@ be_local_closure(Matter_UI_show_fabric_info,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
+    ( &(const bvalue[28]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(content_send),
-    /* K3   */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BFabrics_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cp_X3EAssociated_X20fabrics_X3A_X3C_X2Fp_X3E),
-    /* K4   */  be_nested_str_weak(device),
-    /* K5   */  be_nested_str_weak(sessions),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(_X3Cp_X3E_X3Cb_X3ENone_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
-    /* K8   */  be_nested_str_weak(fabrics),
-    /* K9   */  be_nested_str_weak(persistables),
-    /* K10  */  be_nested_str_weak(_X3Chr_X3E),
-    /* K11  */  be_nested_str_weak(fabric_label),
-    /* K12  */  be_nested_str_weak(_X3CNo_X20label_X3E),
-    /* K13  */  be_nested_str_weak(html_escape),
-    /* K14  */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3B_X23_X25i_X20_X25s_X3C_X2Fb_X3E_X20_X28_X25s_X29_X26nbsp_X3B_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    /* K15  */  be_nested_str_weak(get_fabric_index),
-    /* K16  */  be_nested_str_weak(get_admin_vendor_name),
-    /* K17  */  be_nested_str_weak(get_fabric_id),
-    /* K18  */  be_nested_str_weak(copy),
-    /* K19  */  be_nested_str_weak(reverse),
-    /* K20  */  be_nested_str_weak(get_device_id),
-    /* K21  */  be_nested_str_weak(Fabric_X3A_X20_X25s_X3Cbr_X3E),
-    /* K22  */  be_nested_str_weak(tohex),
-    /* K23  */  be_nested_str_weak(Device_X3A_X20_X25s_X3Cbr_X3E_X26nbsp_X3B),
-    /* K24  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X20onsubmit_X3D_X27return_X20confirm_X28_X22Are_X20you_X20sure_X3F_X22_X29_X3B_X27_X3E),
-    /* K25  */  be_nested_str_weak(_X3Cinput_X20name_X3D_X27del_fabric_X27_X20type_X3D_X27hidden_X27_X20value_X3D_X27_X25i_X27_X3E),
-    /* K26  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27del_X27_X20class_X3D_X27button_X20bgrn_X27_X3EDelete_X20Fabric_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
-    /* K27  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    /* K28  */  be_nested_str_weak(stop_iteration),
+    /* K1   */  be_nested_str_weak(content_send),
+    /* K2   */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BFabrics_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cp_X3EAssociated_X20fabrics_X3A_X3C_X2Fp_X3E),
+    /* K3   */  be_nested_str_weak(device),
+    /* K4   */  be_nested_str_weak(sessions),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(_X3Cp_X3E_X3Cb_X3ENone_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
+    /* K7   */  be_nested_str_weak(fabrics),
+    /* K8   */  be_nested_str_weak(persistables),
+    /* K9   */  be_nested_str_weak(_X3Chr_X3E),
+    /* K10  */  be_nested_str_weak(fabric_label),
+    /* K11  */  be_nested_str_weak(_X3CNo_X20label_X3E),
+    /* K12  */  be_nested_str_weak(html_escape),
+    /* K13  */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3B_X23_X25i_X20_X25s_X3C_X2Fb_X3E_X20_X28_X25s_X29_X26nbsp_X3B_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K14  */  be_nested_str_weak(get_fabric_index),
+    /* K15  */  be_nested_str_weak(get_admin_vendor_name),
+    /* K16  */  be_nested_str_weak(get_fabric_id),
+    /* K17  */  be_nested_str_weak(copy),
+    /* K18  */  be_nested_str_weak(reverse),
+    /* K19  */  be_nested_str_weak(get_device_id),
+    /* K20  */  be_nested_str_weak(Fabric_X3A_X20_X25s_X3Cbr_X3E),
+    /* K21  */  be_nested_str_weak(tohex),
+    /* K22  */  be_nested_str_weak(Device_X3A_X20_X25s_X3Cbr_X3E_X26nbsp_X3B),
+    /* K23  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X20onsubmit_X3D_X27return_X20confirm_X28_X22Are_X20you_X20sure_X3F_X22_X29_X3B_X27_X3E),
+    /* K24  */  be_nested_str_weak(_X3Cinput_X20name_X3D_X27del_fabric_X27_X20type_X3D_X27hidden_X27_X20value_X3D_X27_X25i_X27_X3E),
+    /* K25  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27del_X27_X20class_X3D_X27button_X20bgrn_X27_X3EDelete_X20Fabric_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
+    /* K26  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K27  */  be_nested_str_weak(stop_iteration),
     }),
     be_str_weak(show_fabric_info),
     &be_const_str_solidified,
-    ( &(const binstruction[101]) {  /* code */
+    ( &(const binstruction[100]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x8C0C0302,  //  0002  GETMET	R3	R1	K2
-      0x58140003,  //  0003  LDCONST	R5	K3
-      0x7C0C0400,  //  0004  CALL	R3	2
-      0x600C000C,  //  0005  GETGBL	R3	G12
-      0x88100104,  //  0006  GETMBR	R4	R0	K4
-      0x88100905,  //  0007  GETMBR	R4	R4	K5
-      0x88100905,  //  0008  GETMBR	R4	R4	K5
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x1C0C0706,  //  000A  EQ	R3	R3	K6
-      0x780E0003,  //  000B  JMPF	R3	#0010
-      0x8C0C0302,  //  000C  GETMET	R3	R1	K2
-      0x58140007,  //  000D  LDCONST	R5	K7
-      0x7C0C0400,  //  000E  CALL	R3	2
-      0x70020050,  //  000F  JMP		#0061
-      0x500C0200,  //  0010  LDBOOL	R3	1	0
-      0x60100010,  //  0011  GETGBL	R4	G16
-      0x88140104,  //  0012  GETMBR	R5	R0	K4
-      0x88140B05,  //  0013  GETMBR	R5	R5	K5
-      0x88140B08,  //  0014  GETMBR	R5	R5	K8
-      0x8C140B09,  //  0015  GETMET	R5	R5	K9
-      0x7C140200,  //  0016  CALL	R5	1
-      0x7C100200,  //  0017  CALL	R4	1
-      0xA8020044,  //  0018  EXBLK	0	#005E
-      0x5C140800,  //  0019  MOVE	R5	R4
-      0x7C140000,  //  001A  CALL	R5	0
-      0x5C180600,  //  001B  MOVE	R6	R3
-      0x741A0002,  //  001C  JMPT	R6	#0020
-      0x8C180302,  //  001D  GETMET	R6	R1	K2
-      0x5820000A,  //  001E  LDCONST	R8	K10
-      0x7C180400,  //  001F  CALL	R6	2
-      0x500C0000,  //  0020  LDBOOL	R3	0	0
-      0x88180B0B,  //  0021  GETMBR	R6	R5	K11
-      0x5C1C0C00,  //  0022  MOVE	R7	R6
-      0x741E0000,  //  0023  JMPT	R7	#0025
-      0x5818000C,  //  0024  LDCONST	R6	K12
-      0x8C1C030D,  //  0025  GETMET	R7	R1	K13
-      0x5C240C00,  //  0026  MOVE	R9	R6
-      0x7C1C0400,  //  0027  CALL	R7	2
-      0x5C180E00,  //  0028  MOVE	R6	R7
-      0x8C1C0302,  //  0029  GETMET	R7	R1	K2
-      0x60240018,  //  002A  GETGBL	R9	G24
-      0x5828000E,  //  002B  LDCONST	R10	K14
-      0x8C2C0B0F,  //  002C  GETMET	R11	R5	K15
-      0x7C2C0200,  //  002D  CALL	R11	1
-      0x5C300C00,  //  002E  MOVE	R12	R6
-      0x8C340B10,  //  002F  GETMET	R13	R5	K16
-      0x7C340200,  //  0030  CALL	R13	1
-      0x7C240800,  //  0031  CALL	R9	4
-      0x7C1C0400,  //  0032  CALL	R7	2
-      0x8C1C0B11,  //  0033  GETMET	R7	R5	K17
-      0x7C1C0200,  //  0034  CALL	R7	1
-      0x8C1C0F12,  //  0035  GETMET	R7	R7	K18
-      0x7C1C0200,  //  0036  CALL	R7	1
-      0x8C1C0F13,  //  0037  GETMET	R7	R7	K19
-      0x7C1C0200,  //  0038  CALL	R7	1
-      0x8C200B14,  //  0039  GETMET	R8	R5	K20
-      0x7C200200,  //  003A  CALL	R8	1
-      0x8C201112,  //  003B  GETMET	R8	R8	K18
-      0x7C200200,  //  003C  CALL	R8	1
-      0x8C201113,  //  003D  GETMET	R8	R8	K19
-      0x7C200200,  //  003E  CALL	R8	1
-      0x8C240302,  //  003F  GETMET	R9	R1	K2
-      0x602C0018,  //  0040  GETGBL	R11	G24
-      0x58300015,  //  0041  LDCONST	R12	K21
-      0x8C340F16,  //  0042  GETMET	R13	R7	K22
-      0x7C340200,  //  0043  CALL	R13	1
-      0x7C2C0400,  //  0044  CALL	R11	2
-      0x7C240400,  //  0045  CALL	R9	2
-      0x8C240302,  //  0046  GETMET	R9	R1	K2
-      0x602C0018,  //  0047  GETGBL	R11	G24
-      0x58300017,  //  0048  LDCONST	R12	K23
-      0x8C341116,  //  0049  GETMET	R13	R8	K22
-      0x7C340200,  //  004A  CALL	R13	1
-      0x7C2C0400,  //  004B  CALL	R11	2
-      0x7C240400,  //  004C  CALL	R9	2
-      0x8C240302,  //  004D  GETMET	R9	R1	K2
-      0x582C0018,  //  004E  LDCONST	R11	K24
-      0x7C240400,  //  004F  CALL	R9	2
-      0x8C240302,  //  0050  GETMET	R9	R1	K2
-      0x602C0018,  //  0051  GETGBL	R11	G24
-      0x58300019,  //  0052  LDCONST	R12	K25
-      0x8C340B0F,  //  0053  GETMET	R13	R5	K15
-      0x7C340200,  //  0054  CALL	R13	1
-      0x7C2C0400,  //  0055  CALL	R11	2
-      0x7C240400,  //  0056  CALL	R9	2
-      0x8C240302,  //  0057  GETMET	R9	R1	K2
-      0x582C001A,  //  0058  LDCONST	R11	K26
-      0x7C240400,  //  0059  CALL	R9	2
-      0x8C240302,  //  005A  GETMET	R9	R1	K2
-      0x582C001B,  //  005B  LDCONST	R11	K27
-      0x7C240400,  //  005C  CALL	R9	2
-      0x7001FFBA,  //  005D  JMP		#0019
-      0x5810001C,  //  005E  LDCONST	R4	K28
-      0xAC100200,  //  005F  CATCH	R4	1	0
-      0xB0080000,  //  0060  RAISE	2	R0	R0
-      0x8C0C0302,  //  0061  GETMET	R3	R1	K2
-      0x5814001B,  //  0062  LDCONST	R5	K27
-      0x7C0C0400,  //  0063  CALL	R3	2
-      0x80000000,  //  0064  RET	0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x7C080400,  //  0003  CALL	R2	2
+      0x6008000C,  //  0004  GETGBL	R2	G12
+      0x880C0103,  //  0005  GETMBR	R3	R0	K3
+      0x880C0704,  //  0006  GETMBR	R3	R3	K4
+      0x880C0704,  //  0007  GETMBR	R3	R3	K4
+      0x7C080200,  //  0008  CALL	R2	1
+      0x1C080505,  //  0009  EQ	R2	R2	K5
+      0x780A0003,  //  000A  JMPF	R2	#000F
+      0x8C080301,  //  000B  GETMET	R2	R1	K1
+      0x58100006,  //  000C  LDCONST	R4	K6
+      0x7C080400,  //  000D  CALL	R2	2
+      0x70020050,  //  000E  JMP		#0060
+      0x50080200,  //  000F  LDBOOL	R2	1	0
+      0x600C0010,  //  0010  GETGBL	R3	G16
+      0x88100103,  //  0011  GETMBR	R4	R0	K3
+      0x88100904,  //  0012  GETMBR	R4	R4	K4
+      0x88100907,  //  0013  GETMBR	R4	R4	K7
+      0x8C100908,  //  0014  GETMET	R4	R4	K8
+      0x7C100200,  //  0015  CALL	R4	1
+      0x7C0C0200,  //  0016  CALL	R3	1
+      0xA8020044,  //  0017  EXBLK	0	#005D
+      0x5C100600,  //  0018  MOVE	R4	R3
+      0x7C100000,  //  0019  CALL	R4	0
+      0x5C140400,  //  001A  MOVE	R5	R2
+      0x74160002,  //  001B  JMPT	R5	#001F
+      0x8C140301,  //  001C  GETMET	R5	R1	K1
+      0x581C0009,  //  001D  LDCONST	R7	K9
+      0x7C140400,  //  001E  CALL	R5	2
+      0x50080000,  //  001F  LDBOOL	R2	0	0
+      0x8814090A,  //  0020  GETMBR	R5	R4	K10
+      0x5C180A00,  //  0021  MOVE	R6	R5
+      0x741A0000,  //  0022  JMPT	R6	#0024
+      0x5814000B,  //  0023  LDCONST	R5	K11
+      0x8C18030C,  //  0024  GETMET	R6	R1	K12
+      0x5C200A00,  //  0025  MOVE	R8	R5
+      0x7C180400,  //  0026  CALL	R6	2
+      0x5C140C00,  //  0027  MOVE	R5	R6
+      0x8C180301,  //  0028  GETMET	R6	R1	K1
+      0x60200018,  //  0029  GETGBL	R8	G24
+      0x5824000D,  //  002A  LDCONST	R9	K13
+      0x8C28090E,  //  002B  GETMET	R10	R4	K14
+      0x7C280200,  //  002C  CALL	R10	1
+      0x5C2C0A00,  //  002D  MOVE	R11	R5
+      0x8C30090F,  //  002E  GETMET	R12	R4	K15
+      0x7C300200,  //  002F  CALL	R12	1
+      0x7C200800,  //  0030  CALL	R8	4
+      0x7C180400,  //  0031  CALL	R6	2
+      0x8C180910,  //  0032  GETMET	R6	R4	K16
+      0x7C180200,  //  0033  CALL	R6	1
+      0x8C180D11,  //  0034  GETMET	R6	R6	K17
+      0x7C180200,  //  0035  CALL	R6	1
+      0x8C180D12,  //  0036  GETMET	R6	R6	K18
+      0x7C180200,  //  0037  CALL	R6	1
+      0x8C1C0913,  //  0038  GETMET	R7	R4	K19
+      0x7C1C0200,  //  0039  CALL	R7	1
+      0x8C1C0F11,  //  003A  GETMET	R7	R7	K17
+      0x7C1C0200,  //  003B  CALL	R7	1
+      0x8C1C0F12,  //  003C  GETMET	R7	R7	K18
+      0x7C1C0200,  //  003D  CALL	R7	1
+      0x8C200301,  //  003E  GETMET	R8	R1	K1
+      0x60280018,  //  003F  GETGBL	R10	G24
+      0x582C0014,  //  0040  LDCONST	R11	K20
+      0x8C300D15,  //  0041  GETMET	R12	R6	K21
+      0x7C300200,  //  0042  CALL	R12	1
+      0x7C280400,  //  0043  CALL	R10	2
+      0x7C200400,  //  0044  CALL	R8	2
+      0x8C200301,  //  0045  GETMET	R8	R1	K1
+      0x60280018,  //  0046  GETGBL	R10	G24
+      0x582C0016,  //  0047  LDCONST	R11	K22
+      0x8C300F15,  //  0048  GETMET	R12	R7	K21
+      0x7C300200,  //  0049  CALL	R12	1
+      0x7C280400,  //  004A  CALL	R10	2
+      0x7C200400,  //  004B  CALL	R8	2
+      0x8C200301,  //  004C  GETMET	R8	R1	K1
+      0x58280017,  //  004D  LDCONST	R10	K23
+      0x7C200400,  //  004E  CALL	R8	2
+      0x8C200301,  //  004F  GETMET	R8	R1	K1
+      0x60280018,  //  0050  GETGBL	R10	G24
+      0x582C0018,  //  0051  LDCONST	R11	K24
+      0x8C30090E,  //  0052  GETMET	R12	R4	K14
+      0x7C300200,  //  0053  CALL	R12	1
+      0x7C280400,  //  0054  CALL	R10	2
+      0x7C200400,  //  0055  CALL	R8	2
+      0x8C200301,  //  0056  GETMET	R8	R1	K1
+      0x58280019,  //  0057  LDCONST	R10	K25
+      0x7C200400,  //  0058  CALL	R8	2
+      0x8C200301,  //  0059  GETMET	R8	R1	K1
+      0x5828001A,  //  005A  LDCONST	R10	K26
+      0x7C200400,  //  005B  CALL	R8	2
+      0x7001FFBA,  //  005C  JMP		#0018
+      0x580C001B,  //  005D  LDCONST	R3	K27
+      0xAC0C0200,  //  005E  CATCH	R3	1	0
+      0xB0080000,  //  005F  RAISE	2	R0	R0
+      0x8C080301,  //  0060  GETMET	R2	R1	K1
+      0x5810001A,  //  0061  LDCONST	R4	K26
+      0x7C080400,  //  0062  CALL	R2	2
+      0x80000000,  //  0063  RET	0
     })
   )
 );
@@ -1611,7 +1597,7 @@ be_local_closure(Matter_UI_web_get_arg,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_plugin_option,   /* name */
   be_nested_proto(
-    17,                          /* nstack */
+    16,                          /* nstack */
     3,                          /* argc */
     3,                          /* varg */
     0,                          /* has upvals */
@@ -1619,7 +1605,7 @@ be_local_closure(Matter_UI_plugin_option,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
+    ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(split),
@@ -1633,10 +1619,9 @@ be_local_closure(Matter_UI_plugin_option,   /* name */
     /* K10  */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X27_X20disabled_X3E_X2D_X2D_X2D_X20Tasmota_X20Remote_X20_X2D_X2D_X2D_X3C_X2Foption_X3E),
     /* K11  */  be_nested_str_weak(device),
     /* K12  */  be_nested_str_weak(get_plugin_class_displayname),
-    /* K13  */  be_nested_str_weak(format),
-    /* K14  */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X25s_X27_X25s_X3E_X25s_X3C_X2Foption_X3E),
-    /* K15  */  be_nested_str_weak(_X20selected),
-    /* K16  */  be_const_int(1),
+    /* K13  */  be_nested_str_weak(_X3Coption_X20value_X3D_X27_X25s_X27_X25s_X3E_X25s_X3C_X2Foption_X3E),
+    /* K14  */  be_nested_str_weak(_X20selected),
+    /* K15  */  be_const_int(1),
     }),
     be_str_weak(plugin_option),
     &be_const_str_solidified,
@@ -1684,18 +1669,18 @@ be_local_closure(Matter_UI_plugin_option,   /* name */
       0x5C280E00,  //  0028  MOVE	R10	R7
       0x7C200400,  //  0029  CALL	R8	2
       0x8C240707,  //  002A  GETMET	R9	R3	K7
-      0x8C2C090D,  //  002B  GETMET	R11	R4	K13
-      0x5834000E,  //  002C  LDCONST	R13	K14
-      0x5C380E00,  //  002D  MOVE	R14	R7
-      0x1C3C0E01,  //  002E  EQ	R15	R7	R1
-      0x783E0001,  //  002F  JMPF	R15	#0032
-      0x583C000F,  //  0030  LDCONST	R15	K15
+      0x602C0018,  //  002B  GETGBL	R11	G24
+      0x5830000D,  //  002C  LDCONST	R12	K13
+      0x5C340E00,  //  002D  MOVE	R13	R7
+      0x1C380E01,  //  002E  EQ	R14	R7	R1
+      0x783A0001,  //  002F  JMPF	R14	#0032
+      0x5838000E,  //  0030  LDCONST	R14	K14
       0x70020000,  //  0031  JMP		#0033
-      0x583C0006,  //  0032  LDCONST	R15	K6
-      0x5C401000,  //  0033  MOVE	R16	R8
-      0x7C2C0A00,  //  0034  CALL	R11	5
+      0x58380006,  //  0032  LDCONST	R14	K6
+      0x5C3C1000,  //  0033  MOVE	R15	R8
+      0x7C2C0800,  //  0034  CALL	R11	4
       0x7C240400,  //  0035  CALL	R9	2
-      0x00180D10,  //  0036  ADD	R6	R6	K16
+      0x00180D0F,  //  0036  ADD	R6	R6	K15
       0x7001FFDB,  //  0037  JMP		#0014
       0x80000000,  //  0038  RET	0
     })
@@ -1784,7 +1769,7 @@ be_local_closure(Matter_UI_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_show_bridge_status,   /* name */
   be_nested_proto(
-    16,                          /* nstack */
+    14,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1792,144 +1777,141 @@ be_local_closure(Matter_UI_show_bridge_status,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
+    ( &(const bvalue[24]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(device),
-    /* K4   */  be_nested_str_weak(plugins),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(Plugin_Bridge_HTTP),
-    /* K7   */  be_nested_str_weak(http_remote),
-    /* K8   */  be_nested_str_weak(addr),
-    /* K9   */  be_nested_str_weak(contains),
-    /* K10  */  be_nested_str_weak(push),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(content_send),
-    /* K13  */  be_nested_str_weak(_X3Chr_X3E),
-    /* K14  */  be_nested_str_weak(_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
-    /* K15  */  be_nested_str_weak(_STYLESHEET),
-    /* K16  */  be_nested_str_weak(k2l),
-    /* K17  */  be_nested_str_weak(html_escape),
-    /* K18  */  be_nested_str_weak(format),
-    /* K19  */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27ztdm_X20htrm_X27_X3E_X3Ctd_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20title_X3D_X27http_X3A_X2F_X2F_X25s_X2F_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X27_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Ftd_X3E),
-    /* K20  */  be_nested_str_weak(web_last_seen),
-    /* K21  */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27htrm_X27_X3E_X3Ctd_X20colspan_X3D_X272_X27_X3E),
-    /* K22  */  be_nested_str_weak(web_values),
-    /* K23  */  be_nested_str_weak(_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-    /* K24  */  be_nested_str_weak(stop_iteration),
-    /* K25  */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Chr_X3E),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(device),
+    /* K3   */  be_nested_str_weak(plugins),
+    /* K4   */  be_nested_str_weak(matter),
+    /* K5   */  be_nested_str_weak(Plugin_Bridge_HTTP),
+    /* K6   */  be_nested_str_weak(http_remote),
+    /* K7   */  be_nested_str_weak(addr),
+    /* K8   */  be_nested_str_weak(contains),
+    /* K9   */  be_nested_str_weak(push),
+    /* K10  */  be_const_int(1),
+    /* K11  */  be_nested_str_weak(content_send),
+    /* K12  */  be_nested_str_weak(_X3Chr_X3E),
+    /* K13  */  be_nested_str_weak(_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
+    /* K14  */  be_nested_str_weak(_STYLESHEET),
+    /* K15  */  be_nested_str_weak(k2l),
+    /* K16  */  be_nested_str_weak(html_escape),
+    /* K17  */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27ztdm_X20htrm_X27_X3E_X3Ctd_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20title_X3D_X27http_X3A_X2F_X2F_X25s_X2F_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X27_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Ftd_X3E),
+    /* K18  */  be_nested_str_weak(web_last_seen),
+    /* K19  */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27htrm_X27_X3E_X3Ctd_X20colspan_X3D_X272_X27_X3E),
+    /* K20  */  be_nested_str_weak(web_values),
+    /* K21  */  be_nested_str_weak(_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+    /* K22  */  be_nested_str_weak(stop_iteration),
+    /* K23  */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Chr_X3E),
     }),
     be_str_weak(show_bridge_status),
     &be_const_str_solidified,
-    ( &(const binstruction[107]) {  /* code */
+    ( &(const binstruction[106]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x58100002,  //  0003  LDCONST	R4	K2
-      0x6014000C,  //  0004  GETGBL	R5	G12
-      0x88180103,  //  0005  GETMBR	R6	R0	K3
-      0x88180D04,  //  0006  GETMBR	R6	R6	K4
-      0x7C140200,  //  0007  CALL	R5	1
-      0x14140805,  //  0008  LT	R5	R4	R5
-      0x7816001D,  //  0009  JMPF	R5	#0028
-      0x88140103,  //  000A  GETMBR	R5	R0	K3
-      0x88140B04,  //  000B  GETMBR	R5	R5	K4
-      0x94140A04,  //  000C  GETIDX	R5	R5	R4
-      0x6018000F,  //  000D  GETGBL	R6	G15
-      0x5C1C0A00,  //  000E  MOVE	R7	R5
-      0xB8220A00,  //  000F  GETNGBL	R8	K5
-      0x88201106,  //  0010  GETMBR	R8	R8	K6
-      0x7C180400,  //  0011  CALL	R6	2
-      0x781A0012,  //  0012  JMPF	R6	#0026
-      0x4C180000,  //  0013  LDNIL	R6
-      0x1C180606,  //  0014  EQ	R6	R3	R6
-      0x781A0002,  //  0015  JMPF	R6	#0019
-      0x60180013,  //  0016  GETGBL	R6	G19
-      0x7C180000,  //  0017  CALL	R6	0
-      0x5C0C0C00,  //  0018  MOVE	R3	R6
-      0x88180B07,  //  0019  GETMBR	R6	R5	K7
-      0x88180D08,  //  001A  GETMBR	R6	R6	K8
-      0x8C1C0709,  //  001B  GETMET	R7	R3	K9
-      0x5C240C00,  //  001C  MOVE	R9	R6
-      0x7C1C0400,  //  001D  CALL	R7	2
-      0x741E0002,  //  001E  JMPT	R7	#0022
-      0x601C0012,  //  001F  GETGBL	R7	G18
-      0x7C1C0000,  //  0020  CALL	R7	0
-      0x980C0C07,  //  0021  SETIDX	R3	R6	R7
-      0x941C0606,  //  0022  GETIDX	R7	R3	R6
-      0x8C1C0F0A,  //  0023  GETMET	R7	R7	K10
-      0x5C240A00,  //  0024  MOVE	R9	R5
-      0x7C1C0400,  //  0025  CALL	R7	2
-      0x0010090B,  //  0026  ADD	R4	R4	K11
-      0x7001FFDB,  //  0027  JMP		#0004
-      0x4C140000,  //  0028  LDNIL	R5
-      0x1C140605,  //  0029  EQ	R5	R3	R5
-      0x78160000,  //  002A  JMPF	R5	#002C
-      0x80000A00,  //  002B  RET	0
-      0x8C14030C,  //  002C  GETMET	R5	R1	K12
-      0x581C000D,  //  002D  LDCONST	R7	K13
-      0x7C140400,  //  002E  CALL	R5	2
-      0x8C14030C,  //  002F  GETMET	R5	R1	K12
-      0x581C000E,  //  0030  LDCONST	R7	K14
-      0x7C140400,  //  0031  CALL	R5	2
-      0x8C14030C,  //  0032  GETMET	R5	R1	K12
-      0xB81E0A00,  //  0033  GETNGBL	R7	K5
-      0x881C0F0F,  //  0034  GETMBR	R7	R7	K15
-      0x7C140400,  //  0035  CALL	R5	2
-      0x60140010,  //  0036  GETGBL	R5	G16
-      0x88180103,  //  0037  GETMBR	R6	R0	K3
-      0x8C180D10,  //  0038  GETMET	R6	R6	K16
-      0x5C200600,  //  0039  MOVE	R8	R3
-      0x7C180400,  //  003A  CALL	R6	2
-      0x7C140200,  //  003B  CALL	R5	1
-      0xA8020026,  //  003C  EXBLK	0	#0064
-      0x5C180A00,  //  003D  MOVE	R6	R5
-      0x7C180000,  //  003E  CALL	R6	0
-      0x8C1C0311,  //  003F  GETMET	R7	R1	K17
-      0x5C240C00,  //  0040  MOVE	R9	R6
-      0x7C1C0400,  //  0041  CALL	R7	2
-      0x8C20030C,  //  0042  GETMET	R8	R1	K12
-      0x8C280512,  //  0043  GETMET	R10	R2	K18
-      0x58300013,  //  0044  LDCONST	R12	K19
-      0x5C340E00,  //  0045  MOVE	R13	R7
-      0x5C380E00,  //  0046  MOVE	R14	R7
-      0x5C3C0E00,  //  0047  MOVE	R15	R7
-      0x7C280A00,  //  0048  CALL	R10	5
-      0x7C200400,  //  0049  CALL	R8	2
-      0x94200606,  //  004A  GETIDX	R8	R3	R6
-      0x94201102,  //  004B  GETIDX	R8	R8	K2
-      0x88201107,  //  004C  GETMBR	R8	R8	K7
-      0x8C24030C,  //  004D  GETMET	R9	R1	K12
-      0x8C2C1114,  //  004E  GETMET	R11	R8	K20
-      0x7C2C0200,  //  004F  CALL	R11	1
-      0x7C240400,  //  0050  CALL	R9	2
-      0x60240010,  //  0051  GETGBL	R9	G16
-      0x94280606,  //  0052  GETIDX	R10	R3	R6
-      0x7C240200,  //  0053  CALL	R9	1
-      0xA802000A,  //  0054  EXBLK	0	#0060
-      0x5C281200,  //  0055  MOVE	R10	R9
-      0x7C280000,  //  0056  CALL	R10	0
-      0x8C2C030C,  //  0057  GETMET	R11	R1	K12
-      0x58340015,  //  0058  LDCONST	R13	K21
-      0x7C2C0400,  //  0059  CALL	R11	2
-      0x8C2C1516,  //  005A  GETMET	R11	R10	K22
-      0x7C2C0200,  //  005B  CALL	R11	1
-      0x8C2C030C,  //  005C  GETMET	R11	R1	K12
-      0x58340017,  //  005D  LDCONST	R13	K23
-      0x7C2C0400,  //  005E  CALL	R11	2
-      0x7001FFF4,  //  005F  JMP		#0055
-      0x58240018,  //  0060  LDCONST	R9	K24
-      0xAC240200,  //  0061  CATCH	R9	1	0
-      0xB0080000,  //  0062  RAISE	2	R0	R0
-      0x7001FFD8,  //  0063  JMP		#003D
-      0x58140018,  //  0064  LDCONST	R5	K24
-      0xAC140200,  //  0065  CATCH	R5	1	0
-      0xB0080000,  //  0066  RAISE	2	R0	R0
-      0x8C14030C,  //  0067  GETMET	R5	R1	K12
-      0x581C0019,  //  0068  LDCONST	R7	K25
-      0x7C140400,  //  0069  CALL	R5	2
-      0x80000000,  //  006A  RET	0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x580C0001,  //  0002  LDCONST	R3	K1
+      0x6010000C,  //  0003  GETGBL	R4	G12
+      0x88140102,  //  0004  GETMBR	R5	R0	K2
+      0x88140B03,  //  0005  GETMBR	R5	R5	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x14100604,  //  0007  LT	R4	R3	R4
+      0x7812001D,  //  0008  JMPF	R4	#0027
+      0x88100102,  //  0009  GETMBR	R4	R0	K2
+      0x88100903,  //  000A  GETMBR	R4	R4	K3
+      0x94100803,  //  000B  GETIDX	R4	R4	R3
+      0x6014000F,  //  000C  GETGBL	R5	G15
+      0x5C180800,  //  000D  MOVE	R6	R4
+      0xB81E0800,  //  000E  GETNGBL	R7	K4
+      0x881C0F05,  //  000F  GETMBR	R7	R7	K5
+      0x7C140400,  //  0010  CALL	R5	2
+      0x78160012,  //  0011  JMPF	R5	#0025
+      0x4C140000,  //  0012  LDNIL	R5
+      0x1C140405,  //  0013  EQ	R5	R2	R5
+      0x78160002,  //  0014  JMPF	R5	#0018
+      0x60140013,  //  0015  GETGBL	R5	G19
+      0x7C140000,  //  0016  CALL	R5	0
+      0x5C080A00,  //  0017  MOVE	R2	R5
+      0x88140906,  //  0018  GETMBR	R5	R4	K6
+      0x88140B07,  //  0019  GETMBR	R5	R5	K7
+      0x8C180508,  //  001A  GETMET	R6	R2	K8
+      0x5C200A00,  //  001B  MOVE	R8	R5
+      0x7C180400,  //  001C  CALL	R6	2
+      0x741A0002,  //  001D  JMPT	R6	#0021
+      0x60180012,  //  001E  GETGBL	R6	G18
+      0x7C180000,  //  001F  CALL	R6	0
+      0x98080A06,  //  0020  SETIDX	R2	R5	R6
+      0x94180405,  //  0021  GETIDX	R6	R2	R5
+      0x8C180D09,  //  0022  GETMET	R6	R6	K9
+      0x5C200800,  //  0023  MOVE	R8	R4
+      0x7C180400,  //  0024  CALL	R6	2
+      0x000C070A,  //  0025  ADD	R3	R3	K10
+      0x7001FFDB,  //  0026  JMP		#0003
+      0x4C100000,  //  0027  LDNIL	R4
+      0x1C100404,  //  0028  EQ	R4	R2	R4
+      0x78120000,  //  0029  JMPF	R4	#002B
+      0x80000800,  //  002A  RET	0
+      0x8C10030B,  //  002B  GETMET	R4	R1	K11
+      0x5818000C,  //  002C  LDCONST	R6	K12
+      0x7C100400,  //  002D  CALL	R4	2
+      0x8C10030B,  //  002E  GETMET	R4	R1	K11
+      0x5818000D,  //  002F  LDCONST	R6	K13
+      0x7C100400,  //  0030  CALL	R4	2
+      0x8C10030B,  //  0031  GETMET	R4	R1	K11
+      0xB81A0800,  //  0032  GETNGBL	R6	K4
+      0x88180D0E,  //  0033  GETMBR	R6	R6	K14
+      0x7C100400,  //  0034  CALL	R4	2
+      0x60100010,  //  0035  GETGBL	R4	G16
+      0x88140102,  //  0036  GETMBR	R5	R0	K2
+      0x8C140B0F,  //  0037  GETMET	R5	R5	K15
+      0x5C1C0400,  //  0038  MOVE	R7	R2
+      0x7C140400,  //  0039  CALL	R5	2
+      0x7C100200,  //  003A  CALL	R4	1
+      0xA8020026,  //  003B  EXBLK	0	#0063
+      0x5C140800,  //  003C  MOVE	R5	R4
+      0x7C140000,  //  003D  CALL	R5	0
+      0x8C180310,  //  003E  GETMET	R6	R1	K16
+      0x5C200A00,  //  003F  MOVE	R8	R5
+      0x7C180400,  //  0040  CALL	R6	2
+      0x8C1C030B,  //  0041  GETMET	R7	R1	K11
+      0x60240018,  //  0042  GETGBL	R9	G24
+      0x58280011,  //  0043  LDCONST	R10	K17
+      0x5C2C0C00,  //  0044  MOVE	R11	R6
+      0x5C300C00,  //  0045  MOVE	R12	R6
+      0x5C340C00,  //  0046  MOVE	R13	R6
+      0x7C240800,  //  0047  CALL	R9	4
+      0x7C1C0400,  //  0048  CALL	R7	2
+      0x941C0405,  //  0049  GETIDX	R7	R2	R5
+      0x941C0F01,  //  004A  GETIDX	R7	R7	K1
+      0x881C0F06,  //  004B  GETMBR	R7	R7	K6
+      0x8C20030B,  //  004C  GETMET	R8	R1	K11
+      0x8C280F12,  //  004D  GETMET	R10	R7	K18
+      0x7C280200,  //  004E  CALL	R10	1
+      0x7C200400,  //  004F  CALL	R8	2
+      0x60200010,  //  0050  GETGBL	R8	G16
+      0x94240405,  //  0051  GETIDX	R9	R2	R5
+      0x7C200200,  //  0052  CALL	R8	1
+      0xA802000A,  //  0053  EXBLK	0	#005F
+      0x5C241000,  //  0054  MOVE	R9	R8
+      0x7C240000,  //  0055  CALL	R9	0
+      0x8C28030B,  //  0056  GETMET	R10	R1	K11
+      0x58300013,  //  0057  LDCONST	R12	K19
+      0x7C280400,  //  0058  CALL	R10	2
+      0x8C281314,  //  0059  GETMET	R10	R9	K20
+      0x7C280200,  //  005A  CALL	R10	1
+      0x8C28030B,  //  005B  GETMET	R10	R1	K11
+      0x58300015,  //  005C  LDCONST	R12	K21
+      0x7C280400,  //  005D  CALL	R10	2
+      0x7001FFF4,  //  005E  JMP		#0054
+      0x58200016,  //  005F  LDCONST	R8	K22
+      0xAC200200,  //  0060  CATCH	R8	1	0
+      0xB0080000,  //  0061  RAISE	2	R0	R0
+      0x7001FFD8,  //  0062  JMP		#003C
+      0x58100016,  //  0063  LDCONST	R4	K22
+      0xAC100200,  //  0064  CATCH	R4	1	0
+      0xB0080000,  //  0065  RAISE	2	R0	R0
+      0x8C10030B,  //  0066  GETMET	R4	R1	K11
+      0x58180017,  //  0067  LDCONST	R6	K23
+      0x7C100400,  //  0068  CALL	R4	2
+      0x80000000,  //  0069  RET	0
     })
   )
 );
@@ -2167,7 +2149,7 @@ be_local_closure(Matter_UI_show_passcode_form,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_page_part_ctl,   /* name */
   be_nested_proto(
-    25,                          /* nstack */
+    24,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2175,7 +2157,7 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[100]) {     /* constants */
+    ( &(const bvalue[99]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_nested_str_weak(check_privileged_access),
     /* K2   */  be_nested_str_weak(string),
@@ -2186,96 +2168,95 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
     /* K7   */  be_const_int(1),
     /* K8   */  be_nested_str_weak(tasmota),
     /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(format),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20Arg_X25i_X20_X27_X25s_X27_X20_X3D_X20_X27_X25s_X27),
-    /* K12  */  be_nested_str_weak(arg_name),
-    /* K13  */  be_nested_str_weak(arg),
-    /* K14  */  be_nested_str_weak(stop_iteration),
-    /* K15  */  be_nested_str_weak(has_arg),
-    /* K16  */  be_nested_str_weak(passcode),
-    /* K17  */  be_nested_str_weak(discriminator),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X2Fmatterc_X20received_X20_X27_X25s_X27_X20command),
-    /* K19  */  be_const_int(3),
-    /* K20  */  be_nested_str_weak(device),
-    /* K21  */  be_nested_str_weak(root_passcode),
-    /* K22  */  be_nested_str_weak(root_discriminator),
-    /* K23  */  be_nested_str_weak(ipv4only),
-    /* K24  */  be_nested_str_weak(ipv4),
-    /* K25  */  be_nested_str_weak(on),
-    /* K26  */  be_nested_str_weak(save_param),
-    /* K27  */  be_nested_str_weak(redirect),
-    /* K28  */  be_nested_str_weak(_X2F_X3Frst_X3D),
-    /* K29  */  be_nested_str_weak(save),
-    /* K30  */  be_nested_str_weak(menable),
-    /* K31  */  be_nested_str_weak(comm),
-    /* K32  */  be_nested_str_weak(matter_enabled),
-    /* K33  */  be_nested_str_weak(enable),
-    /* K34  */  be_nested_str_weak(cmd),
-    /* K35  */  be_nested_str_weak(SetOption),
-    /* K36  */  be_nested_str_weak(matter),
-    /* K37  */  be_nested_str_weak(MATTER_OPTION),
-    /* K38  */  be_nested_str_weak(_X201),
-    /* K39  */  be_nested_str_weak(disable),
-    /* K40  */  be_nested_str_weak(_X200),
-    /* K41  */  be_nested_str_weak(commissioning_open),
-    /* K42  */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K43  */  be_nested_str_weak(stop_basic_commissioning),
-    /* K44  */  be_nested_str_weak(_X2F),
-    /* K45  */  be_nested_str_weak(del_fabric),
-    /* K46  */  be_nested_str_weak(sessions),
-    /* K47  */  be_nested_str_weak(fabrics),
-    /* K48  */  be_nested_str_weak(get_fabric_index),
-    /* K49  */  be_nested_str_weak(remove_fabric),
-    /* K50  */  be_nested_str_weak(_X2Fmatterc_X3F),
-    /* K51  */  be_nested_str_weak(auto),
-    /* K52  */  be_nested_str_weak(plugins_persist),
-    /* K53  */  be_nested_str_weak(config),
-    /* K54  */  be_nested_str_weak(find),
-    /* K55  */  be_const_int(2147483647),
-    /* K56  */  be_nested_str_weak(plugins_config),
-    /* K57  */  be_nested_str_weak(plugins_classes),
-    /* K58  */  be_nested_str_weak(type),
-    /* K59  */  be_nested_str_weak(),
-    /* K60  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20arg_X3D_X25s),
-    /* K61  */  be_nested_str_weak(ui_conf_to_string),
-    /* K62  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20prev_arg_X3D_X27_X25s_X27_X20arg_X3D_X27_X25s_X27_X20_X25s),
-    /* K63  */  be_nested_str_weak(changed),
-    /* K64  */  be_nested_str_weak(ui_string_to_conf),
-    /* K65  */  be_nested_str_weak(find_plugin_by_endpoint),
-    /* K66  */  be_nested_str_weak(MTR_X3A_X20apply_X20conf_X20_X27_X25s_X27_X20_X28_X25i_X29_X20to_X20_X25s),
-    /* K67  */  be_nested_str_weak(parse_configuration),
-    /* K68  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20not_X20found),
-    /* K69  */  be_nested_str_weak(nam),
-    /* K70  */  be_nested_str_weak(name),
-    /* K71  */  be_nested_str_weak(set_name),
-    /* K72  */  be_nested_str_weak(remove),
-    /* K73  */  be_nested_str_weak(MTR_X3A_X20apply_X20name_X20_X27_X25s_X27_X20_X28_X25i_X29_X20to_X20_X25s),
-    /* K74  */  be_nested_str_weak(MTR_X3A_X20config_X20_X3D_X20_X25s),
-    /* K75  */  be_nested_str_weak(MTR_X3A_X20config_X20error_X20_X3D_X20_X25s),
-    /* K76  */  be_nested_str_weak(addep),
-    /* K77  */  be_nested_str_weak(pi),
-    /* K78  */  be_nested_str_weak(MTR_X3A_X20add_X20endpoint_X20typ_X3D_X27_X25s_X27_X20arg_X3D_X27_X25s_X27),
-    /* K79  */  be_nested_str_weak(bridge_add_endpoint),
-    /* K80  */  be_nested_str_weak(addrem),
-    /* K81  */  be_nested_str_weak(url),
-    /* K82  */  be_nested_str_weak(value_error),
-    /* K83  */  be_nested_str_weak(url_X20shouldn_X27t_X20be_X20null),
-    /* K84  */  be_nested_str_weak(equal_map),
-    /* K85  */  be_nested_str_weak(MTR_X3A_X20remote_X20add_X20url_X3D_X27_X25s_X27_X20type_X3D_X27_X25s_X27_X20arg_X3D_X27_X25s_X27),
-    /* K86  */  be_nested_str_weak(del),
-    /* K87  */  be_nested_str_weak(bridge_remove_endpoint),
-    /* K88  */  be_nested_str_weak(content_start),
-    /* K89  */  be_nested_str_weak(Parameter_X20error),
-    /* K90  */  be_nested_str_weak(content_send_style),
-    /* K91  */  be_nested_str_weak(content_send),
-    /* K92  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EError_X3A_X3C_X2Fb_X3E_X25s_X3C_X2Fp_X3E),
-    /* K93  */  be_nested_str_weak(html_escape),
-    /* K94  */  be_nested_str_weak(content_button),
-    /* K95  */  be_nested_str_weak(BUTTON_CONFIGURATION),
-    /* K96  */  be_nested_str_weak(content_stop),
-    /* K97  */  be_nested_str_weak(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    /* K98  */  be_const_int(2),
-    /* K99  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20Arg_X25i_X20_X27_X25s_X27_X20_X3D_X20_X27_X25s_X27),
+    /* K11  */  be_nested_str_weak(arg_name),
+    /* K12  */  be_nested_str_weak(arg),
+    /* K13  */  be_nested_str_weak(stop_iteration),
+    /* K14  */  be_nested_str_weak(has_arg),
+    /* K15  */  be_nested_str_weak(passcode),
+    /* K16  */  be_nested_str_weak(discriminator),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20_X2Fmatterc_X20received_X20_X27_X25s_X27_X20command),
+    /* K18  */  be_const_int(3),
+    /* K19  */  be_nested_str_weak(device),
+    /* K20  */  be_nested_str_weak(root_passcode),
+    /* K21  */  be_nested_str_weak(root_discriminator),
+    /* K22  */  be_nested_str_weak(ipv4only),
+    /* K23  */  be_nested_str_weak(ipv4),
+    /* K24  */  be_nested_str_weak(on),
+    /* K25  */  be_nested_str_weak(save_param),
+    /* K26  */  be_nested_str_weak(redirect),
+    /* K27  */  be_nested_str_weak(_X2F_X3Frst_X3D),
+    /* K28  */  be_nested_str_weak(save),
+    /* K29  */  be_nested_str_weak(menable),
+    /* K30  */  be_nested_str_weak(comm),
+    /* K31  */  be_nested_str_weak(matter_enabled),
+    /* K32  */  be_nested_str_weak(enable),
+    /* K33  */  be_nested_str_weak(cmd),
+    /* K34  */  be_nested_str_weak(SetOption),
+    /* K35  */  be_nested_str_weak(matter),
+    /* K36  */  be_nested_str_weak(MATTER_OPTION),
+    /* K37  */  be_nested_str_weak(_X201),
+    /* K38  */  be_nested_str_weak(disable),
+    /* K39  */  be_nested_str_weak(_X200),
+    /* K40  */  be_nested_str_weak(commissioning_open),
+    /* K41  */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K42  */  be_nested_str_weak(stop_basic_commissioning),
+    /* K43  */  be_nested_str_weak(_X2F),
+    /* K44  */  be_nested_str_weak(del_fabric),
+    /* K45  */  be_nested_str_weak(sessions),
+    /* K46  */  be_nested_str_weak(fabrics),
+    /* K47  */  be_nested_str_weak(get_fabric_index),
+    /* K48  */  be_nested_str_weak(remove_fabric),
+    /* K49  */  be_nested_str_weak(_X2Fmatterc_X3F),
+    /* K50  */  be_nested_str_weak(auto),
+    /* K51  */  be_nested_str_weak(plugins_persist),
+    /* K52  */  be_nested_str_weak(config),
+    /* K53  */  be_nested_str_weak(find),
+    /* K54  */  be_const_int(2147483647),
+    /* K55  */  be_nested_str_weak(plugins_config),
+    /* K56  */  be_nested_str_weak(plugins_classes),
+    /* K57  */  be_nested_str_weak(type),
+    /* K58  */  be_nested_str_weak(),
+    /* K59  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20arg_X3D_X25s),
+    /* K60  */  be_nested_str_weak(ui_conf_to_string),
+    /* K61  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20prev_arg_X3D_X27_X25s_X27_X20arg_X3D_X27_X25s_X27_X20_X25s),
+    /* K62  */  be_nested_str_weak(changed),
+    /* K63  */  be_nested_str_weak(ui_string_to_conf),
+    /* K64  */  be_nested_str_weak(find_plugin_by_endpoint),
+    /* K65  */  be_nested_str_weak(MTR_X3A_X20apply_X20conf_X20_X27_X25s_X27_X20_X28_X25i_X29_X20to_X20_X25s),
+    /* K66  */  be_nested_str_weak(parse_configuration),
+    /* K67  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20not_X20found),
+    /* K68  */  be_nested_str_weak(nam),
+    /* K69  */  be_nested_str_weak(name),
+    /* K70  */  be_nested_str_weak(set_name),
+    /* K71  */  be_nested_str_weak(remove),
+    /* K72  */  be_nested_str_weak(MTR_X3A_X20apply_X20name_X20_X27_X25s_X27_X20_X28_X25i_X29_X20to_X20_X25s),
+    /* K73  */  be_nested_str_weak(MTR_X3A_X20config_X20_X3D_X20_X25s),
+    /* K74  */  be_nested_str_weak(MTR_X3A_X20config_X20error_X20_X3D_X20_X25s),
+    /* K75  */  be_nested_str_weak(addep),
+    /* K76  */  be_nested_str_weak(pi),
+    /* K77  */  be_nested_str_weak(MTR_X3A_X20add_X20endpoint_X20typ_X3D_X27_X25s_X27_X20arg_X3D_X27_X25s_X27),
+    /* K78  */  be_nested_str_weak(bridge_add_endpoint),
+    /* K79  */  be_nested_str_weak(addrem),
+    /* K80  */  be_nested_str_weak(url),
+    /* K81  */  be_nested_str_weak(value_error),
+    /* K82  */  be_nested_str_weak(url_X20shouldn_X27t_X20be_X20null),
+    /* K83  */  be_nested_str_weak(equal_map),
+    /* K84  */  be_nested_str_weak(MTR_X3A_X20remote_X20add_X20url_X3D_X27_X25s_X27_X20type_X3D_X27_X25s_X27_X20arg_X3D_X27_X25s_X27),
+    /* K85  */  be_nested_str_weak(del),
+    /* K86  */  be_nested_str_weak(bridge_remove_endpoint),
+    /* K87  */  be_nested_str_weak(content_start),
+    /* K88  */  be_nested_str_weak(Parameter_X20error),
+    /* K89  */  be_nested_str_weak(content_send_style),
+    /* K90  */  be_nested_str_weak(content_send),
+    /* K91  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EError_X3A_X3C_X2Fb_X3E_X25s_X3C_X2Fp_X3E),
+    /* K92  */  be_nested_str_weak(html_escape),
+    /* K93  */  be_nested_str_weak(content_button),
+    /* K94  */  be_nested_str_weak(BUTTON_CONFIGURATION),
+    /* K95  */  be_nested_str_weak(content_stop),
+    /* K96  */  be_nested_str_weak(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+    /* K97  */  be_const_int(2),
+    /* K98  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E),
     }),
     be_str_weak(page_part_ctl),
     &be_const_str_solidified,
@@ -2302,224 +2283,224 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x7C1C0000,  //  0013  CALL	R7	0
       0xB8221000,  //  0014  GETNGBL	R8	K8
       0x8C201109,  //  0015  GETMET	R8	R8	K9
-      0x8C28050A,  //  0016  GETMET	R10	R2	K10
-      0x5830000B,  //  0017  LDCONST	R12	K11
-      0x5C340E00,  //  0018  MOVE	R13	R7
-      0x8C38030C,  //  0019  GETMET	R14	R1	K12
-      0x5C400E00,  //  001A  MOVE	R16	R7
-      0x7C380400,  //  001B  CALL	R14	2
-      0x8C3C030D,  //  001C  GETMET	R15	R1	K13
-      0x5C440E00,  //  001D  MOVE	R17	R7
-      0x7C3C0400,  //  001E  CALL	R15	2
-      0x7C280A00,  //  001F  CALL	R10	5
+      0x60280018,  //  0016  GETGBL	R10	G24
+      0x582C000A,  //  0017  LDCONST	R11	K10
+      0x5C300E00,  //  0018  MOVE	R12	R7
+      0x8C34030B,  //  0019  GETMET	R13	R1	K11
+      0x5C3C0E00,  //  001A  MOVE	R15	R7
+      0x7C340400,  //  001B  CALL	R13	2
+      0x8C38030C,  //  001C  GETMET	R14	R1	K12
+      0x5C400E00,  //  001D  MOVE	R16	R7
+      0x7C380400,  //  001E  CALL	R14	2
+      0x7C280800,  //  001F  CALL	R10	4
       0x7C200400,  //  0020  CALL	R8	2
       0x7001FFEF,  //  0021  JMP		#0012
-      0x5818000E,  //  0022  LDCONST	R6	K14
+      0x5818000D,  //  0022  LDCONST	R6	K13
       0xAC180200,  //  0023  CATCH	R6	1	0
       0xB0080000,  //  0024  RAISE	2	R0	R0
-      0x8C18030F,  //  0025  GETMET	R6	R1	K15
-      0x58200010,  //  0026  LDCONST	R8	K16
+      0x8C18030E,  //  0025  GETMET	R6	R1	K14
+      0x5820000F,  //  0026  LDCONST	R8	K15
       0x7C180400,  //  0027  CALL	R6	2
       0x741A0003,  //  0028  JMPT	R6	#002D
-      0x8C18030F,  //  0029  GETMET	R6	R1	K15
-      0x58200011,  //  002A  LDCONST	R8	K17
+      0x8C18030E,  //  0029  GETMET	R6	R1	K14
+      0x58200010,  //  002A  LDCONST	R8	K16
       0x7C180400,  //  002B  CALL	R6	2
       0x781A002A,  //  002C  JMPF	R6	#0058
       0xB81A1000,  //  002D  GETNGBL	R6	K8
       0x8C180D09,  //  002E  GETMET	R6	R6	K9
-      0x8C20050A,  //  002F  GETMET	R8	R2	K10
-      0x58280012,  //  0030  LDCONST	R10	K18
-      0x582C0010,  //  0031  LDCONST	R11	K16
-      0x7C200600,  //  0032  CALL	R8	3
-      0x58240013,  //  0033  LDCONST	R9	K19
+      0x60200018,  //  002F  GETGBL	R8	G24
+      0x58240011,  //  0030  LDCONST	R9	K17
+      0x5828000F,  //  0031  LDCONST	R10	K15
+      0x7C200400,  //  0032  CALL	R8	2
+      0x58240012,  //  0033  LDCONST	R9	K18
       0x7C180600,  //  0034  CALL	R6	3
-      0x8C18030F,  //  0035  GETMET	R6	R1	K15
-      0x58200010,  //  0036  LDCONST	R8	K16
+      0x8C18030E,  //  0035  GETMET	R6	R1	K14
+      0x5820000F,  //  0036  LDCONST	R8	K15
       0x7C180400,  //  0037  CALL	R6	2
       0x781A0006,  //  0038  JMPF	R6	#0040
-      0x88180114,  //  0039  GETMBR	R6	R0	K20
+      0x88180113,  //  0039  GETMBR	R6	R0	K19
       0x601C0009,  //  003A  GETGBL	R7	G9
-      0x8C20030D,  //  003B  GETMET	R8	R1	K13
-      0x58280010,  //  003C  LDCONST	R10	K16
+      0x8C20030C,  //  003B  GETMET	R8	R1	K12
+      0x5828000F,  //  003C  LDCONST	R10	K15
       0x7C200400,  //  003D  CALL	R8	2
       0x7C1C0200,  //  003E  CALL	R7	1
-      0x901A2A07,  //  003F  SETMBR	R6	K21	R7
-      0x8C18030F,  //  0040  GETMET	R6	R1	K15
-      0x58200011,  //  0041  LDCONST	R8	K17
+      0x901A2807,  //  003F  SETMBR	R6	K20	R7
+      0x8C18030E,  //  0040  GETMET	R6	R1	K14
+      0x58200010,  //  0041  LDCONST	R8	K16
       0x7C180400,  //  0042  CALL	R6	2
       0x781A0006,  //  0043  JMPF	R6	#004B
-      0x88180114,  //  0044  GETMBR	R6	R0	K20
+      0x88180113,  //  0044  GETMBR	R6	R0	K19
       0x601C0009,  //  0045  GETGBL	R7	G9
-      0x8C20030D,  //  0046  GETMET	R8	R1	K13
-      0x58280011,  //  0047  LDCONST	R10	K17
+      0x8C20030C,  //  0046  GETMET	R8	R1	K12
+      0x58280010,  //  0047  LDCONST	R10	K16
       0x7C200400,  //  0048  CALL	R8	2
       0x7C1C0200,  //  0049  CALL	R7	1
-      0x901A2C07,  //  004A  SETMBR	R6	K22	R7
-      0x88180114,  //  004B  GETMBR	R6	R0	K20
-      0x8C1C030D,  //  004C  GETMET	R7	R1	K13
-      0x58240018,  //  004D  LDCONST	R9	K24
+      0x901A2A07,  //  004A  SETMBR	R6	K21	R7
+      0x88180113,  //  004B  GETMBR	R6	R0	K19
+      0x8C1C030C,  //  004C  GETMET	R7	R1	K12
+      0x58240017,  //  004D  LDCONST	R9	K23
       0x7C1C0400,  //  004E  CALL	R7	2
-      0x1C1C0F19,  //  004F  EQ	R7	R7	K25
-      0x901A2E07,  //  0050  SETMBR	R6	K23	R7
-      0x88180114,  //  0051  GETMBR	R6	R0	K20
-      0x8C180D1A,  //  0052  GETMET	R6	R6	K26
+      0x1C1C0F18,  //  004F  EQ	R7	R7	K24
+      0x901A2C07,  //  0050  SETMBR	R6	K22	R7
+      0x88180113,  //  0051  GETMBR	R6	R0	K19
+      0x8C180D19,  //  0052  GETMET	R6	R6	K25
       0x7C180200,  //  0053  CALL	R6	1
-      0x8C18031B,  //  0054  GETMET	R6	R1	K27
-      0x5820001C,  //  0055  LDCONST	R8	K28
+      0x8C18031A,  //  0054  GETMET	R6	R1	K26
+      0x5820001B,  //  0055  LDCONST	R8	K27
       0x7C180400,  //  0056  CALL	R6	2
       0x70020223,  //  0057  JMP		#027C
-      0x8C18030F,  //  0058  GETMET	R6	R1	K15
-      0x5820001D,  //  0059  LDCONST	R8	K29
+      0x8C18030E,  //  0058  GETMET	R6	R1	K14
+      0x5820001C,  //  0059  LDCONST	R8	K28
       0x7C180400,  //  005A  CALL	R6	2
       0x781A0047,  //  005B  JMPF	R6	#00A4
-      0x8C18030F,  //  005C  GETMET	R6	R1	K15
-      0x5820001E,  //  005D  LDCONST	R8	K30
+      0x8C18030E,  //  005C  GETMET	R6	R1	K14
+      0x5820001D,  //  005D  LDCONST	R8	K29
       0x7C180400,  //  005E  CALL	R6	2
-      0x8C1C030F,  //  005F  GETMET	R7	R1	K15
-      0x5824001F,  //  0060  LDCONST	R9	K31
+      0x8C1C030E,  //  005F  GETMET	R7	R1	K14
+      0x5824001E,  //  0060  LDCONST	R9	K30
       0x7C1C0400,  //  0061  CALL	R7	2
-      0x8C200120,  //  0062  GETMET	R8	R0	K32
+      0x8C20011F,  //  0062  GETMET	R8	R0	K31
       0x7C200200,  //  0063  CALL	R8	1
       0x20200C08,  //  0064  NE	R8	R6	R8
       0x78220027,  //  0065  JMPF	R8	#008E
       0x781A0011,  //  0066  JMPF	R6	#0079
       0xB8221000,  //  0067  GETNGBL	R8	K8
       0x8C201109,  //  0068  GETMET	R8	R8	K9
-      0x8C28050A,  //  0069  GETMET	R10	R2	K10
-      0x58300012,  //  006A  LDCONST	R12	K18
-      0x58340021,  //  006B  LDCONST	R13	K33
-      0x7C280600,  //  006C  CALL	R10	3
-      0x582C0013,  //  006D  LDCONST	R11	K19
+      0x60280018,  //  0069  GETGBL	R10	G24
+      0x582C0011,  //  006A  LDCONST	R11	K17
+      0x58300020,  //  006B  LDCONST	R12	K32
+      0x7C280400,  //  006C  CALL	R10	2
+      0x582C0012,  //  006D  LDCONST	R11	K18
       0x7C200600,  //  006E  CALL	R8	3
       0xB8221000,  //  006F  GETNGBL	R8	K8
-      0x8C201122,  //  0070  GETMET	R8	R8	K34
+      0x8C201121,  //  0070  GETMET	R8	R8	K33
       0x60280008,  //  0071  GETGBL	R10	G8
-      0xB82E4800,  //  0072  GETNGBL	R11	K36
-      0x882C1725,  //  0073  GETMBR	R11	R11	K37
+      0xB82E4600,  //  0072  GETNGBL	R11	K35
+      0x882C1724,  //  0073  GETMBR	R11	R11	K36
       0x7C280200,  //  0074  CALL	R10	1
-      0x002A460A,  //  0075  ADD	R10	K35	R10
-      0x00281526,  //  0076  ADD	R10	R10	K38
+      0x002A440A,  //  0075  ADD	R10	K34	R10
+      0x00281525,  //  0076  ADD	R10	R10	K37
       0x7C200400,  //  0077  CALL	R8	2
       0x70020010,  //  0078  JMP		#008A
       0xB8221000,  //  0079  GETNGBL	R8	K8
       0x8C201109,  //  007A  GETMET	R8	R8	K9
-      0x8C28050A,  //  007B  GETMET	R10	R2	K10
-      0x58300012,  //  007C  LDCONST	R12	K18
-      0x58340027,  //  007D  LDCONST	R13	K39
-      0x7C280600,  //  007E  CALL	R10	3
-      0x582C0013,  //  007F  LDCONST	R11	K19
+      0x60280018,  //  007B  GETGBL	R10	G24
+      0x582C0011,  //  007C  LDCONST	R11	K17
+      0x58300026,  //  007D  LDCONST	R12	K38
+      0x7C280400,  //  007E  CALL	R10	2
+      0x582C0012,  //  007F  LDCONST	R11	K18
       0x7C200600,  //  0080  CALL	R8	3
       0xB8221000,  //  0081  GETNGBL	R8	K8
-      0x8C201122,  //  0082  GETMET	R8	R8	K34
+      0x8C201121,  //  0082  GETMET	R8	R8	K33
       0x60280008,  //  0083  GETGBL	R10	G8
-      0xB82E4800,  //  0084  GETNGBL	R11	K36
-      0x882C1725,  //  0085  GETMBR	R11	R11	K37
+      0xB82E4600,  //  0084  GETNGBL	R11	K35
+      0x882C1724,  //  0085  GETMBR	R11	R11	K36
       0x7C280200,  //  0086  CALL	R10	1
-      0x002A460A,  //  0087  ADD	R10	K35	R10
-      0x00281528,  //  0088  ADD	R10	R10	K40
+      0x002A440A,  //  0087  ADD	R10	K34	R10
+      0x00281527,  //  0088  ADD	R10	R10	K39
       0x7C200400,  //  0089  CALL	R8	2
-      0x8C20031B,  //  008A  GETMET	R8	R1	K27
-      0x5828001C,  //  008B  LDCONST	R10	K28
+      0x8C20031A,  //  008A  GETMET	R8	R1	K26
+      0x5828001B,  //  008B  LDCONST	R10	K27
       0x7C200400,  //  008C  CALL	R8	2
       0x70020014,  //  008D  JMP		#00A3
-      0x88200114,  //  008E  GETMBR	R8	R0	K20
-      0x88201129,  //  008F  GETMBR	R8	R8	K41
+      0x88200113,  //  008E  GETMBR	R8	R0	K19
+      0x88201128,  //  008F  GETMBR	R8	R8	K40
       0x4C240000,  //  0090  LDNIL	R9
       0x20201009,  //  0091  NE	R8	R8	R9
       0x20200E08,  //  0092  NE	R8	R7	R8
       0x7822000B,  //  0093  JMPF	R8	#00A0
       0x781E0003,  //  0094  JMPF	R7	#0099
-      0x88200114,  //  0095  GETMBR	R8	R0	K20
-      0x8C20112A,  //  0096  GETMET	R8	R8	K42
+      0x88200113,  //  0095  GETMBR	R8	R0	K19
+      0x8C201129,  //  0096  GETMET	R8	R8	K41
       0x7C200200,  //  0097  CALL	R8	1
       0x70020002,  //  0098  JMP		#009C
-      0x88200114,  //  0099  GETMBR	R8	R0	K20
-      0x8C20112B,  //  009A  GETMET	R8	R8	K43
+      0x88200113,  //  0099  GETMBR	R8	R0	K19
+      0x8C20112A,  //  009A  GETMET	R8	R8	K42
       0x7C200200,  //  009B  CALL	R8	1
-      0x8C20031B,  //  009C  GETMET	R8	R1	K27
-      0x5828002C,  //  009D  LDCONST	R10	K44
+      0x8C20031A,  //  009C  GETMET	R8	R1	K26
+      0x5828002B,  //  009D  LDCONST	R10	K43
       0x7C200400,  //  009E  CALL	R8	2
       0x70020002,  //  009F  JMP		#00A3
-      0x8C20031B,  //  00A0  GETMET	R8	R1	K27
-      0x5828002C,  //  00A1  LDCONST	R10	K44
+      0x8C20031A,  //  00A0  GETMET	R8	R1	K26
+      0x5828002B,  //  00A1  LDCONST	R10	K43
       0x7C200400,  //  00A2  CALL	R8	2
       0x700201D7,  //  00A3  JMP		#027C
-      0x8C18030F,  //  00A4  GETMET	R6	R1	K15
-      0x5820002D,  //  00A5  LDCONST	R8	K45
+      0x8C18030E,  //  00A4  GETMET	R6	R1	K14
+      0x5820002C,  //  00A5  LDCONST	R8	K44
       0x7C180400,  //  00A6  CALL	R6	2
       0x781A0026,  //  00A7  JMPF	R6	#00CF
       0xB81A1000,  //  00A8  GETNGBL	R6	K8
       0x8C180D09,  //  00A9  GETMET	R6	R6	K9
-      0x8C20050A,  //  00AA  GETMET	R8	R2	K10
-      0x58280012,  //  00AB  LDCONST	R10	K18
-      0x582C002D,  //  00AC  LDCONST	R11	K45
-      0x7C200600,  //  00AD  CALL	R8	3
-      0x58240013,  //  00AE  LDCONST	R9	K19
+      0x60200018,  //  00AA  GETGBL	R8	G24
+      0x58240011,  //  00AB  LDCONST	R9	K17
+      0x5828002C,  //  00AC  LDCONST	R10	K44
+      0x7C200400,  //  00AD  CALL	R8	2
+      0x58240012,  //  00AE  LDCONST	R9	K18
       0x7C180600,  //  00AF  CALL	R6	3
       0x60180009,  //  00B0  GETGBL	R6	G9
-      0x8C1C030D,  //  00B1  GETMET	R7	R1	K13
-      0x5824002D,  //  00B2  LDCONST	R9	K45
+      0x8C1C030C,  //  00B1  GETMET	R7	R1	K12
+      0x5824002C,  //  00B2  LDCONST	R9	K44
       0x7C1C0400,  //  00B3  CALL	R7	2
       0x7C180200,  //  00B4  CALL	R6	1
       0x581C0005,  //  00B5  LDCONST	R7	K5
-      0x88200114,  //  00B6  GETMBR	R8	R0	K20
-      0x8820112E,  //  00B7  GETMBR	R8	R8	K46
-      0x8820112F,  //  00B8  GETMBR	R8	R8	K47
+      0x88200113,  //  00B6  GETMBR	R8	R0	K19
+      0x8820112D,  //  00B7  GETMBR	R8	R8	K45
+      0x8820112E,  //  00B8  GETMBR	R8	R8	K46
       0x6024000C,  //  00B9  GETGBL	R9	G12
       0x5C281000,  //  00BA  MOVE	R10	R8
       0x7C240200,  //  00BB  CALL	R9	1
       0x14240E09,  //  00BC  LT	R9	R7	R9
       0x7826000C,  //  00BD  JMPF	R9	#00CB
       0x94241007,  //  00BE  GETIDX	R9	R8	R7
-      0x8C241330,  //  00BF  GETMET	R9	R9	K48
+      0x8C24132F,  //  00BF  GETMET	R9	R9	K47
       0x7C240200,  //  00C0  CALL	R9	1
       0x1C241206,  //  00C1  EQ	R9	R9	R6
       0x78260005,  //  00C2  JMPF	R9	#00C9
-      0x88240114,  //  00C3  GETMBR	R9	R0	K20
-      0x8C241331,  //  00C4  GETMET	R9	R9	K49
+      0x88240113,  //  00C3  GETMBR	R9	R0	K19
+      0x8C241330,  //  00C4  GETMET	R9	R9	K48
       0x942C1007,  //  00C5  GETIDX	R11	R8	R7
       0x7C240400,  //  00C6  CALL	R9	2
       0x70020002,  //  00C7  JMP		#00CB
       0x70020000,  //  00C8  JMP		#00CA
       0x001C0F07,  //  00C9  ADD	R7	R7	K7
       0x7001FFED,  //  00CA  JMP		#00B9
-      0x8C24031B,  //  00CB  GETMET	R9	R1	K27
-      0x582C0032,  //  00CC  LDCONST	R11	K50
+      0x8C24031A,  //  00CB  GETMET	R9	R1	K26
+      0x582C0031,  //  00CC  LDCONST	R11	K49
       0x7C240400,  //  00CD  CALL	R9	2
       0x700201AC,  //  00CE  JMP		#027C
-      0x8C18030F,  //  00CF  GETMET	R6	R1	K15
-      0x58200033,  //  00D0  LDCONST	R8	K51
+      0x8C18030E,  //  00CF  GETMET	R6	R1	K14
+      0x58200032,  //  00D0  LDCONST	R8	K50
       0x7C180400,  //  00D1  CALL	R6	2
       0x781A0011,  //  00D2  JMPF	R6	#00E5
       0xB81A1000,  //  00D3  GETNGBL	R6	K8
       0x8C180D09,  //  00D4  GETMET	R6	R6	K9
-      0x8C20050A,  //  00D5  GETMET	R8	R2	K10
-      0x58280012,  //  00D6  LDCONST	R10	K18
-      0x582C0033,  //  00D7  LDCONST	R11	K51
-      0x7C200600,  //  00D8  CALL	R8	3
-      0x58240013,  //  00D9  LDCONST	R9	K19
+      0x60200018,  //  00D5  GETGBL	R8	G24
+      0x58240011,  //  00D6  LDCONST	R9	K17
+      0x58280032,  //  00D7  LDCONST	R10	K50
+      0x7C200400,  //  00D8  CALL	R8	2
+      0x58240012,  //  00D9  LDCONST	R9	K18
       0x7C180600,  //  00DA  CALL	R6	3
-      0x88180114,  //  00DB  GETMBR	R6	R0	K20
+      0x88180113,  //  00DB  GETMBR	R6	R0	K19
       0x501C0000,  //  00DC  LDBOOL	R7	0	0
-      0x901A6807,  //  00DD  SETMBR	R6	K52	R7
-      0x88180114,  //  00DE  GETMBR	R6	R0	K20
-      0x8C180D1A,  //  00DF  GETMET	R6	R6	K26
+      0x901A6607,  //  00DD  SETMBR	R6	K51	R7
+      0x88180113,  //  00DE  GETMBR	R6	R0	K19
+      0x8C180D19,  //  00DF  GETMET	R6	R6	K25
       0x7C180200,  //  00E0  CALL	R6	1
-      0x8C18031B,  //  00E1  GETMET	R6	R1	K27
-      0x5820001C,  //  00E2  LDCONST	R8	K28
+      0x8C18031A,  //  00E1  GETMET	R6	R1	K26
+      0x5820001B,  //  00E2  LDCONST	R8	K27
       0x7C180400,  //  00E3  CALL	R6	2
       0x70020196,  //  00E4  JMP		#027C
-      0x8C18030F,  //  00E5  GETMET	R6	R1	K15
-      0x58200035,  //  00E6  LDCONST	R8	K53
+      0x8C18030E,  //  00E5  GETMET	R6	R1	K14
+      0x58200034,  //  00E6  LDCONST	R8	K52
       0x7C180400,  //  00E7  CALL	R6	2
       0x781A00D6,  //  00E8  JMPF	R6	#01C0
       0xB81A1000,  //  00E9  GETNGBL	R6	K8
       0x8C180D09,  //  00EA  GETMET	R6	R6	K9
-      0x8C20050A,  //  00EB  GETMET	R8	R2	K10
-      0x58280012,  //  00EC  LDCONST	R10	K18
-      0x582C0035,  //  00ED  LDCONST	R11	K53
-      0x7C200600,  //  00EE  CALL	R8	3
-      0x58240013,  //  00EF  LDCONST	R9	K19
+      0x60200018,  //  00EB  GETGBL	R8	G24
+      0x58240011,  //  00EC  LDCONST	R9	K17
+      0x58280034,  //  00ED  LDCONST	R10	K52
+      0x7C200400,  //  00EE  CALL	R8	2
+      0x58240012,  //  00EF  LDCONST	R9	K18
       0x7C180600,  //  00F0  CALL	R6	3
       0x50180000,  //  00F1  LDBOOL	R6	0	0
       0x601C0010,  //  00F2  GETGBL	R7	G16
@@ -2531,25 +2512,25 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0xA80200A0,  //  00F8  EXBLK	0	#019A
       0x5C200E00,  //  00F9  MOVE	R8	R7
       0x7C200000,  //  00FA  CALL	R8	0
-      0x8C24030C,  //  00FB  GETMET	R9	R1	K12
+      0x8C24030B,  //  00FB  GETMET	R9	R1	K11
       0x5C2C1000,  //  00FC  MOVE	R11	R8
       0x7C240400,  //  00FD  CALL	R9	2
-      0x8C280536,  //  00FE  GETMET	R10	R2	K54
+      0x8C280535,  //  00FE  GETMET	R10	R2	K53
       0x5C301200,  //  00FF  MOVE	R12	R9
-      0x5834000D,  //  0100  LDCONST	R13	K13
+      0x5834000C,  //  0100  LDCONST	R13	K12
       0x7C280600,  //  0101  CALL	R10	3
       0x1C281505,  //  0102  EQ	R10	R10	K5
       0x782A005B,  //  0103  JMPF	R10	#0160
       0x60280009,  //  0104  GETGBL	R10	G9
-      0x402E2737,  //  0105  CONNECT	R11	K19	K55
+      0x402E2536,  //  0105  CONNECT	R11	K18	K54
       0x942C120B,  //  0106  GETIDX	R11	R9	R11
       0x7C280200,  //  0107  CALL	R10	1
-      0x8C2C030D,  //  0108  GETMET	R11	R1	K13
+      0x8C2C030C,  //  0108  GETMET	R11	R1	K12
       0x5C341000,  //  0109  MOVE	R13	R8
       0x7C2C0400,  //  010A  CALL	R11	2
-      0x88300114,  //  010B  GETMBR	R12	R0	K20
-      0x88301938,  //  010C  GETMBR	R12	R12	K56
-      0x8C301936,  //  010D  GETMET	R12	R12	K54
+      0x88300113,  //  010B  GETMBR	R12	R0	K19
+      0x88301937,  //  010C  GETMBR	R12	R12	K55
+      0x8C301935,  //  010D  GETMET	R12	R12	K53
       0x60380008,  //  010E  GETGBL	R14	G8
       0x5C3C1400,  //  010F  MOVE	R15	R10
       0x7C380200,  //  0110  CALL	R14	1
@@ -2557,12 +2538,12 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x4C340000,  //  0112  LDNIL	R13
       0x2034180D,  //  0113  NE	R13	R12	R13
       0x78360041,  //  0114  JMPF	R13	#0157
-      0x88340114,  //  0115  GETMBR	R13	R0	K20
-      0x88341B39,  //  0116  GETMBR	R13	R13	K57
-      0x8C341B36,  //  0117  GETMET	R13	R13	K54
-      0x8C3C1936,  //  0118  GETMET	R15	R12	K54
-      0x5844003A,  //  0119  LDCONST	R17	K58
-      0x5848003B,  //  011A  LDCONST	R18	K59
+      0x88340113,  //  0115  GETMBR	R13	R0	K19
+      0x88341B38,  //  0116  GETMBR	R13	R13	K56
+      0x8C341B35,  //  0117  GETMET	R13	R13	K53
+      0x8C3C1935,  //  0118  GETMET	R15	R12	K53
+      0x58440039,  //  0119  LDCONST	R17	K57
+      0x5848003A,  //  011A  LDCONST	R18	K58
       0x7C3C0600,  //  011B  CALL	R15	3
       0x7C340400,  //  011C  CALL	R13	2
       0x4C380000,  //  011D  LDNIL	R14
@@ -2570,84 +2551,84 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x783A0035,  //  011F  JMPF	R14	#0156
       0xB83A1000,  //  0120  GETNGBL	R14	K8
       0x8C381D09,  //  0121  GETMET	R14	R14	K9
-      0x8C40050A,  //  0122  GETMET	R16	R2	K10
-      0x5848003C,  //  0123  LDCONST	R18	K60
-      0x5C4C1400,  //  0124  MOVE	R19	R10
-      0x5C501600,  //  0125  MOVE	R20	R11
-      0x7C400800,  //  0126  CALL	R16	4
-      0x58440013,  //  0127  LDCONST	R17	K19
+      0x60400018,  //  0122  GETGBL	R16	G24
+      0x5844003B,  //  0123  LDCONST	R17	K59
+      0x5C481400,  //  0124  MOVE	R18	R10
+      0x5C4C1600,  //  0125  MOVE	R19	R11
+      0x7C400600,  //  0126  CALL	R16	3
+      0x58440012,  //  0127  LDCONST	R17	K18
       0x7C380600,  //  0128  CALL	R14	3
-      0x8C381B3D,  //  0129  GETMET	R14	R13	K61
+      0x8C381B3C,  //  0129  GETMET	R14	R13	K60
       0x5C401A00,  //  012A  MOVE	R16	R13
       0x5C441800,  //  012B  MOVE	R17	R12
       0x7C380600,  //  012C  CALL	R14	3
       0x203C1C0B,  //  012D  NE	R15	R14	R11
       0xB8421000,  //  012E  GETNGBL	R16	K8
       0x8C402109,  //  012F  GETMET	R16	R16	K9
-      0x8C48050A,  //  0130  GETMET	R18	R2	K10
-      0x5850003E,  //  0131  LDCONST	R20	K62
-      0x5C541400,  //  0132  MOVE	R21	R10
-      0x5C581C00,  //  0133  MOVE	R22	R14
-      0x5C5C1600,  //  0134  MOVE	R23	R11
-      0x20601C0B,  //  0135  NE	R24	R14	R11
-      0x78620001,  //  0136  JMPF	R24	#0139
-      0x5860003F,  //  0137  LDCONST	R24	K63
+      0x60480018,  //  0130  GETGBL	R18	G24
+      0x584C003D,  //  0131  LDCONST	R19	K61
+      0x5C501400,  //  0132  MOVE	R20	R10
+      0x5C541C00,  //  0133  MOVE	R21	R14
+      0x5C581600,  //  0134  MOVE	R22	R11
+      0x205C1C0B,  //  0135  NE	R23	R14	R11
+      0x785E0001,  //  0136  JMPF	R23	#0139
+      0x585C003E,  //  0137  LDCONST	R23	K62
       0x70020000,  //  0138  JMP		#013A
-      0x5860003B,  //  0139  LDCONST	R24	K59
-      0x7C480C00,  //  013A  CALL	R18	6
-      0x584C0013,  //  013B  LDCONST	R19	K19
+      0x585C003A,  //  0139  LDCONST	R23	K58
+      0x7C480A00,  //  013A  CALL	R18	5
+      0x584C0012,  //  013B  LDCONST	R19	K18
       0x7C400600,  //  013C  CALL	R16	3
       0x783E0017,  //  013D  JMPF	R15	#0156
       0x50180200,  //  013E  LDBOOL	R6	1	0
-      0x8C401B40,  //  013F  GETMET	R16	R13	K64
+      0x8C401B3F,  //  013F  GETMET	R16	R13	K63
       0x5C481A00,  //  0140  MOVE	R18	R13
       0x5C4C1800,  //  0141  MOVE	R19	R12
       0x5C501600,  //  0142  MOVE	R20	R11
       0x7C400800,  //  0143  CALL	R16	4
-      0x88400114,  //  0144  GETMBR	R16	R0	K20
-      0x8C402141,  //  0145  GETMET	R16	R16	K65
+      0x88400113,  //  0144  GETMBR	R16	R0	K19
+      0x8C402140,  //  0145  GETMET	R16	R16	K64
       0x5C481400,  //  0146  MOVE	R18	R10
       0x7C400400,  //  0147  CALL	R16	2
       0x7842000C,  //  0148  JMPF	R16	#0156
       0xB8461000,  //  0149  GETNGBL	R17	K8
       0x8C442309,  //  014A  GETMET	R17	R17	K9
-      0x8C4C050A,  //  014B  GETMET	R19	R2	K10
-      0x58540042,  //  014C  LDCONST	R21	K66
-      0x5C581800,  //  014D  MOVE	R22	R12
-      0x5C5C1400,  //  014E  MOVE	R23	R10
-      0x5C602000,  //  014F  MOVE	R24	R16
-      0x7C4C0A00,  //  0150  CALL	R19	5
-      0x58500013,  //  0151  LDCONST	R20	K19
+      0x604C0018,  //  014B  GETGBL	R19	G24
+      0x58500041,  //  014C  LDCONST	R20	K65
+      0x5C541800,  //  014D  MOVE	R21	R12
+      0x5C581400,  //  014E  MOVE	R22	R10
+      0x5C5C2000,  //  014F  MOVE	R23	R16
+      0x7C4C0800,  //  0150  CALL	R19	4
+      0x58500012,  //  0151  LDCONST	R20	K18
       0x7C440600,  //  0152  CALL	R17	3
-      0x8C442143,  //  0153  GETMET	R17	R16	K67
+      0x8C442142,  //  0153  GETMET	R17	R16	K66
       0x5C4C1800,  //  0154  MOVE	R19	R12
       0x7C440400,  //  0155  CALL	R17	2
       0x70020007,  //  0156  JMP		#015F
       0xB8361000,  //  0157  GETNGBL	R13	K8
       0x8C341B09,  //  0158  GETMET	R13	R13	K9
-      0x8C3C050A,  //  0159  GETMET	R15	R2	K10
-      0x58440044,  //  015A  LDCONST	R17	K68
-      0x5C481400,  //  015B  MOVE	R18	R10
-      0x7C3C0600,  //  015C  CALL	R15	3
-      0x58400013,  //  015D  LDCONST	R16	K19
+      0x603C0018,  //  0159  GETGBL	R15	G24
+      0x58400043,  //  015A  LDCONST	R16	K67
+      0x5C441400,  //  015B  MOVE	R17	R10
+      0x7C3C0400,  //  015C  CALL	R15	2
+      0x58400012,  //  015D  LDCONST	R16	K18
       0x7C340600,  //  015E  CALL	R13	3
       0x70020038,  //  015F  JMP		#0199
-      0x8C280536,  //  0160  GETMET	R10	R2	K54
+      0x8C280535,  //  0160  GETMET	R10	R2	K53
       0x5C301200,  //  0161  MOVE	R12	R9
-      0x58340045,  //  0162  LDCONST	R13	K69
+      0x58340044,  //  0162  LDCONST	R13	K68
       0x7C280600,  //  0163  CALL	R10	3
       0x1C281505,  //  0164  EQ	R10	R10	K5
       0x782A0032,  //  0165  JMPF	R10	#0199
       0x60280009,  //  0166  GETGBL	R10	G9
-      0x402E2737,  //  0167  CONNECT	R11	K19	K55
+      0x402E2536,  //  0167  CONNECT	R11	K18	K54
       0x942C120B,  //  0168  GETIDX	R11	R9	R11
       0x7C280200,  //  0169  CALL	R10	1
-      0x8C2C030D,  //  016A  GETMET	R11	R1	K13
+      0x8C2C030C,  //  016A  GETMET	R11	R1	K12
       0x5C341000,  //  016B  MOVE	R13	R8
       0x7C2C0400,  //  016C  CALL	R11	2
-      0x88300114,  //  016D  GETMBR	R12	R0	K20
-      0x88301938,  //  016E  GETMBR	R12	R12	K56
-      0x8C301936,  //  016F  GETMET	R12	R12	K54
+      0x88300113,  //  016D  GETMBR	R12	R0	K19
+      0x88301937,  //  016E  GETMBR	R12	R12	K55
+      0x8C301935,  //  016F  GETMET	R12	R12	K53
       0x60380008,  //  0170  GETGBL	R14	G8
       0x5C3C1400,  //  0171  MOVE	R15	R10
       0x7C380200,  //  0172  CALL	R14	1
@@ -2655,104 +2636,104 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x4C340000,  //  0174  LDNIL	R13
       0x2034180D,  //  0175  NE	R13	R12	R13
       0x78360021,  //  0176  JMPF	R13	#0199
-      0x8C341936,  //  0177  GETMET	R13	R12	K54
-      0x583C0046,  //  0178  LDCONST	R15	K70
-      0x5840003B,  //  0179  LDCONST	R16	K59
+      0x8C341935,  //  0177  GETMET	R13	R12	K53
+      0x583C0045,  //  0178  LDCONST	R15	K69
+      0x5840003A,  //  0179  LDCONST	R16	K58
       0x7C340600,  //  017A  CALL	R13	3
       0x20381A0B,  //  017B  NE	R14	R13	R11
       0x783A001B,  //  017C  JMPF	R14	#0199
       0x50180200,  //  017D  LDBOOL	R6	1	0
-      0x883C0114,  //  017E  GETMBR	R15	R0	K20
-      0x8C3C1F41,  //  017F  GETMET	R15	R15	K65
+      0x883C0113,  //  017E  GETMBR	R15	R0	K19
+      0x8C3C1F40,  //  017F  GETMET	R15	R15	K64
       0x5C441400,  //  0180  MOVE	R17	R10
       0x7C3C0400,  //  0181  CALL	R15	2
       0x783E0015,  //  0182  JMPF	R15	#0199
-      0x8C401F47,  //  0183  GETMET	R16	R15	K71
+      0x8C401F46,  //  0183  GETMET	R16	R15	K70
       0x5C481600,  //  0184  MOVE	R18	R11
       0x7C400400,  //  0185  CALL	R16	2
       0x782E0001,  //  0186  JMPF	R11	#0189
-      0x98328C0B,  //  0187  SETIDX	R12	K70	R11
+      0x98328A0B,  //  0187  SETIDX	R12	K69	R11
       0x70020002,  //  0188  JMP		#018C
-      0x8C401948,  //  0189  GETMET	R16	R12	K72
-      0x58480046,  //  018A  LDCONST	R18	K70
+      0x8C401947,  //  0189  GETMET	R16	R12	K71
+      0x58480045,  //  018A  LDCONST	R18	K69
       0x7C400400,  //  018B  CALL	R16	2
       0xB8421000,  //  018C  GETNGBL	R16	K8
       0x8C402109,  //  018D  GETMET	R16	R16	K9
-      0x8C48050A,  //  018E  GETMET	R18	R2	K10
-      0x58500049,  //  018F  LDCONST	R20	K73
-      0x5C541800,  //  0190  MOVE	R21	R12
-      0x5C581400,  //  0191  MOVE	R22	R10
-      0x5C5C1E00,  //  0192  MOVE	R23	R15
-      0x7C480A00,  //  0193  CALL	R18	5
-      0x584C0013,  //  0194  LDCONST	R19	K19
+      0x60480018,  //  018E  GETGBL	R18	G24
+      0x584C0048,  //  018F  LDCONST	R19	K72
+      0x5C501800,  //  0190  MOVE	R20	R12
+      0x5C541400,  //  0191  MOVE	R21	R10
+      0x5C581E00,  //  0192  MOVE	R22	R15
+      0x7C480800,  //  0193  CALL	R18	4
+      0x584C0012,  //  0194  LDCONST	R19	K18
       0x7C400600,  //  0195  CALL	R16	3
-      0x8C401F43,  //  0196  GETMET	R16	R15	K67
+      0x8C401F42,  //  0196  GETMET	R16	R15	K66
       0x5C481800,  //  0197  MOVE	R18	R12
       0x7C400400,  //  0198  CALL	R16	2
       0x7001FF5E,  //  0199  JMP		#00F9
-      0x581C000E,  //  019A  LDCONST	R7	K14
+      0x581C000D,  //  019A  LDCONST	R7	K13
       0xAC1C0200,  //  019B  CATCH	R7	1	0
       0xB0080000,  //  019C  RAISE	2	R0	R0
       0xB81E1000,  //  019D  GETNGBL	R7	K8
       0x8C1C0F09,  //  019E  GETMET	R7	R7	K9
-      0x8C24050A,  //  019F  GETMET	R9	R2	K10
-      0x582C004A,  //  01A0  LDCONST	R11	K74
-      0x60300008,  //  01A1  GETGBL	R12	G8
-      0x88340114,  //  01A2  GETMBR	R13	R0	K20
-      0x88341B38,  //  01A3  GETMBR	R13	R13	K56
-      0x7C300200,  //  01A4  CALL	R12	1
-      0x7C240600,  //  01A5  CALL	R9	3
-      0x58280013,  //  01A6  LDCONST	R10	K19
+      0x60240018,  //  019F  GETGBL	R9	G24
+      0x58280049,  //  01A0  LDCONST	R10	K73
+      0x602C0008,  //  01A1  GETGBL	R11	G8
+      0x88300113,  //  01A2  GETMBR	R12	R0	K19
+      0x88301937,  //  01A3  GETMBR	R12	R12	K55
+      0x7C2C0200,  //  01A4  CALL	R11	1
+      0x7C240400,  //  01A5  CALL	R9	2
+      0x58280012,  //  01A6  LDCONST	R10	K18
       0x7C1C0600,  //  01A7  CALL	R7	3
       0x78160008,  //  01A8  JMPF	R5	#01B2
       0xB81E1000,  //  01A9  GETNGBL	R7	K8
       0x8C1C0F09,  //  01AA  GETMET	R7	R7	K9
-      0x8C24050A,  //  01AB  GETMET	R9	R2	K10
-      0x582C004B,  //  01AC  LDCONST	R11	K75
-      0x5C300A00,  //  01AD  MOVE	R12	R5
-      0x7C240600,  //  01AE  CALL	R9	3
-      0x58280013,  //  01AF  LDCONST	R10	K19
+      0x60240018,  //  01AB  GETGBL	R9	G24
+      0x5828004A,  //  01AC  LDCONST	R10	K74
+      0x5C2C0A00,  //  01AD  MOVE	R11	R5
+      0x7C240400,  //  01AE  CALL	R9	2
+      0x58280012,  //  01AF  LDCONST	R10	K18
       0x7C1C0600,  //  01B0  CALL	R7	3
       0x7002000C,  //  01B1  JMP		#01BF
       0x741A0002,  //  01B2  JMPT	R6	#01B6
-      0x881C0114,  //  01B3  GETMBR	R7	R0	K20
-      0x881C0F34,  //  01B4  GETMBR	R7	R7	K52
+      0x881C0113,  //  01B3  GETMBR	R7	R0	K19
+      0x881C0F33,  //  01B4  GETMBR	R7	R7	K51
       0x741E0005,  //  01B5  JMPT	R7	#01BC
-      0x881C0114,  //  01B6  GETMBR	R7	R0	K20
+      0x881C0113,  //  01B6  GETMBR	R7	R0	K19
       0x50200200,  //  01B7  LDBOOL	R8	1	0
-      0x901E6808,  //  01B8  SETMBR	R7	K52	R8
-      0x881C0114,  //  01B9  GETMBR	R7	R0	K20
-      0x8C1C0F1A,  //  01BA  GETMET	R7	R7	K26
+      0x901E6608,  //  01B8  SETMBR	R7	K51	R8
+      0x881C0113,  //  01B9  GETMBR	R7	R0	K19
+      0x8C1C0F19,  //  01BA  GETMET	R7	R7	K25
       0x7C1C0200,  //  01BB  CALL	R7	1
-      0x8C1C031B,  //  01BC  GETMET	R7	R1	K27
-      0x58240032,  //  01BD  LDCONST	R9	K50
+      0x8C1C031A,  //  01BC  GETMET	R7	R1	K26
+      0x58240031,  //  01BD  LDCONST	R9	K49
       0x7C1C0400,  //  01BE  CALL	R7	2
       0x700200BB,  //  01BF  JMP		#027C
-      0x8C18030F,  //  01C0  GETMET	R6	R1	K15
-      0x5820004C,  //  01C1  LDCONST	R8	K76
+      0x8C18030E,  //  01C0  GETMET	R6	R1	K14
+      0x5820004B,  //  01C1  LDCONST	R8	K75
       0x7C180400,  //  01C2  CALL	R6	2
       0x781A002B,  //  01C3  JMPF	R6	#01F0
-      0x8C18030D,  //  01C4  GETMET	R6	R1	K13
-      0x5820004D,  //  01C5  LDCONST	R8	K77
+      0x8C18030C,  //  01C4  GETMET	R6	R1	K12
+      0x5820004C,  //  01C5  LDCONST	R8	K76
       0x7C180400,  //  01C6  CALL	R6	2
-      0x8C1C030D,  //  01C7  GETMET	R7	R1	K13
-      0x5824000D,  //  01C8  LDCONST	R9	K13
+      0x8C1C030C,  //  01C7  GETMET	R7	R1	K12
+      0x5824000C,  //  01C8  LDCONST	R9	K12
       0x7C1C0400,  //  01C9  CALL	R7	2
-      0x8C20030D,  //  01CA  GETMET	R8	R1	K13
-      0x58280045,  //  01CB  LDCONST	R10	K69
+      0x8C20030C,  //  01CA  GETMET	R8	R1	K12
+      0x58280044,  //  01CB  LDCONST	R10	K68
       0x7C200400,  //  01CC  CALL	R8	2
       0xB8261000,  //  01CD  GETNGBL	R9	K8
       0x8C241309,  //  01CE  GETMET	R9	R9	K9
-      0x8C2C050A,  //  01CF  GETMET	R11	R2	K10
-      0x5834004E,  //  01D0  LDCONST	R13	K78
-      0x5C380C00,  //  01D1  MOVE	R14	R6
-      0x5C3C0E00,  //  01D2  MOVE	R15	R7
-      0x7C2C0800,  //  01D3  CALL	R11	4
-      0x58300013,  //  01D4  LDCONST	R12	K19
+      0x602C0018,  //  01CF  GETGBL	R11	G24
+      0x5830004D,  //  01D0  LDCONST	R12	K77
+      0x5C340C00,  //  01D1  MOVE	R13	R6
+      0x5C380E00,  //  01D2  MOVE	R14	R7
+      0x7C2C0600,  //  01D3  CALL	R11	3
+      0x58300012,  //  01D4  LDCONST	R12	K18
       0x7C240600,  //  01D5  CALL	R9	3
-      0x88240114,  //  01D6  GETMBR	R9	R0	K20
-      0x88241339,  //  01D7  GETMBR	R9	R9	K57
-      0x8C241336,  //  01D8  GETMET	R9	R9	K54
+      0x88240113,  //  01D6  GETMBR	R9	R0	K19
+      0x88241338,  //  01D7  GETMBR	R9	R9	K56
+      0x8C241335,  //  01D8  GETMET	R9	R9	K53
       0x5C2C0C00,  //  01D9  MOVE	R11	R6
       0x7C240400,  //  01DA  CALL	R9	2
       0x4C280000,  //  01DB  LDNIL	R10
@@ -2761,56 +2742,56 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x60280013,  //  01DE  GETGBL	R10	G19
       0x7C280000,  //  01DF  CALL	R10	0
       0x78220000,  //  01E0  JMPF	R8	#01E2
-      0x982A8C08,  //  01E1  SETIDX	R10	K70	R8
-      0x8C2C1340,  //  01E2  GETMET	R11	R9	K64
+      0x982A8A08,  //  01E1  SETIDX	R10	K69	R8
+      0x8C2C133F,  //  01E2  GETMET	R11	R9	K63
       0x5C341200,  //  01E3  MOVE	R13	R9
       0x5C381400,  //  01E4  MOVE	R14	R10
       0x5C3C0E00,  //  01E5  MOVE	R15	R7
       0x7C2C0800,  //  01E6  CALL	R11	4
-      0x882C0114,  //  01E7  GETMBR	R11	R0	K20
-      0x8C2C174F,  //  01E8  GETMET	R11	R11	K79
+      0x882C0113,  //  01E7  GETMBR	R11	R0	K19
+      0x8C2C174E,  //  01E8  GETMET	R11	R11	K78
       0x5C340C00,  //  01E9  MOVE	R13	R6
       0x5C381400,  //  01EA  MOVE	R14	R10
       0x7C2C0600,  //  01EB  CALL	R11	3
-      0x8C28031B,  //  01EC  GETMET	R10	R1	K27
-      0x58300032,  //  01ED  LDCONST	R12	K50
+      0x8C28031A,  //  01EC  GETMET	R10	R1	K26
+      0x58300031,  //  01ED  LDCONST	R12	K49
       0x7C280400,  //  01EE  CALL	R10	2
       0x7002008B,  //  01EF  JMP		#027C
-      0x8C18030F,  //  01F0  GETMET	R6	R1	K15
-      0x58200050,  //  01F1  LDCONST	R8	K80
+      0x8C18030E,  //  01F0  GETMET	R6	R1	K14
+      0x5820004F,  //  01F1  LDCONST	R8	K79
       0x7C180400,  //  01F2  CALL	R6	2
       0x781A005E,  //  01F3  JMPF	R6	#0253
-      0x8C18030D,  //  01F4  GETMET	R6	R1	K13
-      0x58200051,  //  01F5  LDCONST	R8	K81
+      0x8C18030C,  //  01F4  GETMET	R6	R1	K12
+      0x58200050,  //  01F5  LDCONST	R8	K80
       0x7C180400,  //  01F6  CALL	R6	2
       0x4C1C0000,  //  01F7  LDNIL	R7
       0x1C1C0C07,  //  01F8  EQ	R7	R6	R7
       0x741E0001,  //  01F9  JMPT	R7	#01FC
-      0x1C1C0D3B,  //  01FA  EQ	R7	R6	K59
+      0x1C1C0D3A,  //  01FA  EQ	R7	R6	K58
       0x781E0000,  //  01FB  JMPF	R7	#01FD
-      0xB006A553,  //  01FC  RAISE	1	K82	K83
+      0xB006A352,  //  01FC  RAISE	1	K81	K82
       0x581C0005,  //  01FD  LDCONST	R7	K5
       0x60200008,  //  01FE  GETGBL	R8	G8
       0x5C240E00,  //  01FF  MOVE	R9	R7
       0x7C200200,  //  0200  CALL	R8	1
-      0x8C24030F,  //  0201  GETMET	R9	R1	K15
-      0x002E9A08,  //  0202  ADD	R11	K77	R8
+      0x8C24030E,  //  0201  GETMET	R9	R1	K14
+      0x002E9808,  //  0202  ADD	R11	K76	R8
       0x7C240400,  //  0203  CALL	R9	2
       0x78260049,  //  0204  JMPF	R9	#024F
-      0x8C24030D,  //  0205  GETMET	R9	R1	K13
-      0x002E9A08,  //  0206  ADD	R11	K77	R8
+      0x8C24030C,  //  0205  GETMET	R9	R1	K12
+      0x002E9808,  //  0206  ADD	R11	K76	R8
       0x7C240400,  //  0207  CALL	R9	2
-      0x8C28030D,  //  0208  GETMET	R10	R1	K13
-      0x00321A08,  //  0209  ADD	R12	K13	R8
+      0x8C28030C,  //  0208  GETMET	R10	R1	K12
+      0x00321808,  //  0209  ADD	R12	K12	R8
       0x7C280400,  //  020A  CALL	R10	2
-      0x8C2C030D,  //  020B  GETMET	R11	R1	K13
-      0x00368A08,  //  020C  ADD	R13	K69	R8
+      0x8C2C030C,  //  020B  GETMET	R11	R1	K12
+      0x00368808,  //  020C  ADD	R13	K68	R8
       0x7C2C0400,  //  020D  CALL	R11	2
-      0x2030133B,  //  020E  NE	R12	R9	K59
+      0x2030133A,  //  020E  NE	R12	R9	K58
       0x78320038,  //  020F  JMPF	R12	#0249
-      0x88300114,  //  0210  GETMBR	R12	R0	K20
-      0x88301939,  //  0211  GETMBR	R12	R12	K57
-      0x8C301936,  //  0212  GETMET	R12	R12	K54
+      0x88300113,  //  0210  GETMBR	R12	R0	K19
+      0x88301938,  //  0211  GETMBR	R12	R12	K56
+      0x8C301935,  //  0212  GETMET	R12	R12	K53
       0x5C381200,  //  0213  MOVE	R14	R9
       0x7C300400,  //  0214  CALL	R12	2
       0x4C340000,  //  0215  LDNIL	R13
@@ -2818,24 +2799,24 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x78360030,  //  0217  JMPF	R13	#0249
       0x60340013,  //  0218  GETGBL	R13	G19
       0x7C340000,  //  0219  CALL	R13	0
-      0x9836A206,  //  021A  SETIDX	R13	K81	R6
-      0x98367409,  //  021B  SETIDX	R13	K58	R9
+      0x9836A006,  //  021A  SETIDX	R13	K80	R6
+      0x98367209,  //  021B  SETIDX	R13	K57	R9
       0x782E0000,  //  021C  JMPF	R11	#021E
-      0x98368C0B,  //  021D  SETIDX	R13	K70	R11
-      0x8C381940,  //  021E  GETMET	R14	R12	K64
+      0x98368A0B,  //  021D  SETIDX	R13	K69	R11
+      0x8C38193F,  //  021E  GETMET	R14	R12	K63
       0x5C401800,  //  021F  MOVE	R16	R12
       0x5C441A00,  //  0220  MOVE	R17	R13
       0x5C481400,  //  0221  MOVE	R18	R10
       0x7C380800,  //  0222  CALL	R14	4
       0x50380000,  //  0223  LDBOOL	R14	0	0
       0x603C0010,  //  0224  GETGBL	R15	G16
-      0x88400114,  //  0225  GETMBR	R16	R0	K20
-      0x88402138,  //  0226  GETMBR	R16	R16	K56
+      0x88400113,  //  0225  GETMBR	R16	R0	K19
+      0x88402137,  //  0226  GETMBR	R16	R16	K55
       0x7C3C0200,  //  0227  CALL	R15	1
       0xA802000B,  //  0228  EXBLK	0	#0235
       0x5C401E00,  //  0229  MOVE	R16	R15
       0x7C400000,  //  022A  CALL	R16	0
-      0x8C440154,  //  022B  GETMET	R17	R0	K84
+      0x8C440153,  //  022B  GETMET	R17	R0	K83
       0x5C4C2000,  //  022C  MOVE	R19	R16
       0x5C501A00,  //  022D  MOVE	R20	R13
       0x7C440600,  //  022E  CALL	R17	3
@@ -2845,23 +2826,23 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x7001FFF5,  //  0232  JMP		#0229
       0xA8040001,  //  0233  EXBLK	1	1
       0x70020002,  //  0234  JMP		#0238
-      0x583C000E,  //  0235  LDCONST	R15	K14
+      0x583C000D,  //  0235  LDCONST	R15	K13
       0xAC3C0200,  //  0236  CATCH	R15	1	0
       0xB0080000,  //  0237  RAISE	2	R0	R0
       0x5C3C1C00,  //  0238  MOVE	R15	R14
       0x743E000E,  //  0239  JMPT	R15	#0249
       0xB83E1000,  //  023A  GETNGBL	R15	K8
       0x8C3C1F09,  //  023B  GETMET	R15	R15	K9
-      0x8C44050A,  //  023C  GETMET	R17	R2	K10
-      0x584C0055,  //  023D  LDCONST	R19	K85
-      0x5C500C00,  //  023E  MOVE	R20	R6
-      0x5C541200,  //  023F  MOVE	R21	R9
-      0x5C581400,  //  0240  MOVE	R22	R10
-      0x7C440A00,  //  0241  CALL	R17	5
-      0x58480013,  //  0242  LDCONST	R18	K19
+      0x60440018,  //  023C  GETGBL	R17	G24
+      0x58480054,  //  023D  LDCONST	R18	K84
+      0x5C4C0C00,  //  023E  MOVE	R19	R6
+      0x5C501200,  //  023F  MOVE	R20	R9
+      0x5C541400,  //  0240  MOVE	R21	R10
+      0x7C440800,  //  0241  CALL	R17	4
+      0x58480012,  //  0242  LDCONST	R18	K18
       0x7C3C0600,  //  0243  CALL	R15	3
-      0x883C0114,  //  0244  GETMBR	R15	R0	K20
-      0x8C3C1F4F,  //  0245  GETMET	R15	R15	K79
+      0x883C0113,  //  0244  GETMBR	R15	R0	K19
+      0x8C3C1F4E,  //  0245  GETMET	R15	R15	K78
       0x5C441200,  //  0246  MOVE	R17	R9
       0x5C481A00,  //  0247  MOVE	R18	R13
       0x7C3C0600,  //  0248  CALL	R15	3
@@ -2871,8 +2852,8 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x7C300200,  //  024C  CALL	R12	1
       0x5C201800,  //  024D  MOVE	R8	R12
       0x7001FFB1,  //  024E  JMP		#0201
-      0x8C24031B,  //  024F  GETMET	R9	R1	K27
-      0x582C0032,  //  0250  LDCONST	R11	K50
+      0x8C24031A,  //  024F  GETMET	R9	R1	K26
+      0x582C0031,  //  0250  LDCONST	R11	K49
       0x7C240400,  //  0251  CALL	R9	2
       0x70020028,  //  0252  JMP		#027C
       0x4C180000,  //  0253  LDNIL	R6
@@ -2885,17 +2866,17 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0xA8020013,  //  025A  EXBLK	0	#026F
       0x5C200E00,  //  025B  MOVE	R8	R7
       0x7C200000,  //  025C  CALL	R8	0
-      0x8C24030C,  //  025D  GETMET	R9	R1	K12
+      0x8C24030B,  //  025D  GETMET	R9	R1	K11
       0x5C2C1000,  //  025E  MOVE	R11	R8
       0x7C240400,  //  025F  CALL	R9	2
-      0x8C280536,  //  0260  GETMET	R10	R2	K54
+      0x8C280535,  //  0260  GETMET	R10	R2	K53
       0x5C301200,  //  0261  MOVE	R12	R9
-      0x58340056,  //  0262  LDCONST	R13	K86
+      0x58340055,  //  0262  LDCONST	R13	K85
       0x7C280600,  //  0263  CALL	R10	3
       0x1C281505,  //  0264  EQ	R10	R10	K5
       0x782A0005,  //  0265  JMPF	R10	#026C
       0x60280009,  //  0266  GETGBL	R10	G9
-      0x402E2737,  //  0267  CONNECT	R11	K19	K55
+      0x402E2536,  //  0267  CONNECT	R11	K18	K54
       0x942C120B,  //  0268  GETIDX	R11	R9	R11
       0x7C280200,  //  0269  CALL	R10	1
       0x5C181400,  //  026A  MOVE	R6	R10
@@ -2903,37 +2884,37 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x7001FFED,  //  026C  JMP		#025B
       0xA8040001,  //  026D  EXBLK	1	1
       0x70020002,  //  026E  JMP		#0272
-      0x581C000E,  //  026F  LDCONST	R7	K14
+      0x581C000D,  //  026F  LDCONST	R7	K13
       0xAC1C0200,  //  0270  CATCH	R7	1	0
       0xB0080000,  //  0271  RAISE	2	R0	R0
       0x4C1C0000,  //  0272  LDNIL	R7
       0x201C0C07,  //  0273  NE	R7	R6	R7
       0x781E0006,  //  0274  JMPF	R7	#027C
-      0x881C0114,  //  0275  GETMBR	R7	R0	K20
-      0x8C1C0F57,  //  0276  GETMET	R7	R7	K87
+      0x881C0113,  //  0275  GETMBR	R7	R0	K19
+      0x8C1C0F56,  //  0276  GETMET	R7	R7	K86
       0x5C240C00,  //  0277  MOVE	R9	R6
       0x7C1C0400,  //  0278  CALL	R7	2
-      0x8C1C031B,  //  0279  GETMET	R7	R1	K27
-      0x58240032,  //  027A  LDCONST	R9	K50
+      0x8C1C031A,  //  0279  GETMET	R7	R1	K26
+      0x58240031,  //  027A  LDCONST	R9	K49
       0x7C1C0400,  //  027B  CALL	R7	2
       0x78160011,  //  027C  JMPF	R5	#028F
-      0x8C180358,  //  027D  GETMET	R6	R1	K88
-      0x58200059,  //  027E  LDCONST	R8	K89
+      0x8C180357,  //  027D  GETMET	R6	R1	K87
+      0x58200058,  //  027E  LDCONST	R8	K88
       0x7C180400,  //  027F  CALL	R6	2
-      0x8C18035A,  //  0280  GETMET	R6	R1	K90
+      0x8C180359,  //  0280  GETMET	R6	R1	K89
       0x7C180200,  //  0281  CALL	R6	1
-      0x8C18035B,  //  0282  GETMET	R6	R1	K91
-      0x8C20050A,  //  0283  GETMET	R8	R2	K10
-      0x5828005C,  //  0284  LDCONST	R10	K92
-      0x8C2C035D,  //  0285  GETMET	R11	R1	K93
-      0x5C340A00,  //  0286  MOVE	R13	R5
-      0x7C2C0400,  //  0287  CALL	R11	2
-      0x7C200600,  //  0288  CALL	R8	3
+      0x8C18035A,  //  0282  GETMET	R6	R1	K90
+      0x60200018,  //  0283  GETGBL	R8	G24
+      0x5824005B,  //  0284  LDCONST	R9	K91
+      0x8C28035C,  //  0285  GETMET	R10	R1	K92
+      0x5C300A00,  //  0286  MOVE	R12	R5
+      0x7C280400,  //  0287  CALL	R10	2
+      0x7C200400,  //  0288  CALL	R8	2
       0x7C180400,  //  0289  CALL	R6	2
-      0x8C18035E,  //  028A  GETMET	R6	R1	K94
-      0x8820035F,  //  028B  GETMBR	R8	R1	K95
+      0x8C18035D,  //  028A  GETMET	R6	R1	K93
+      0x8820035E,  //  028B  GETMBR	R8	R1	K94
       0x7C180400,  //  028C  CALL	R6	2
-      0x8C180360,  //  028D  GETMET	R6	R1	K96
+      0x8C18035F,  //  028D  GETMET	R6	R1	K95
       0x7C180200,  //  028E  CALL	R6	1
       0xA8040001,  //  028F  EXBLK	1	1
       0x7002001D,  //  0290  JMP		#02AF
@@ -2941,29 +2922,29 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x7002001A,  //  0292  JMP		#02AE
       0xB8221000,  //  0293  GETNGBL	R8	K8
       0x8C201109,  //  0294  GETMET	R8	R8	K9
-      0x8C28050A,  //  0295  GETMET	R10	R2	K10
-      0x58300061,  //  0296  LDCONST	R12	K97
-      0x5C340C00,  //  0297  MOVE	R13	R6
-      0x5C380E00,  //  0298  MOVE	R14	R7
-      0x7C280800,  //  0299  CALL	R10	4
-      0x582C0062,  //  029A  LDCONST	R11	K98
+      0x60280018,  //  0295  GETGBL	R10	G24
+      0x582C0060,  //  0296  LDCONST	R11	K96
+      0x5C300C00,  //  0297  MOVE	R12	R6
+      0x5C340E00,  //  0298  MOVE	R13	R7
+      0x7C280600,  //  0299  CALL	R10	3
+      0x582C0061,  //  029A  LDCONST	R11	K97
       0x7C200600,  //  029B  CALL	R8	3
-      0x8C200358,  //  029C  GETMET	R8	R1	K88
-      0x58280059,  //  029D  LDCONST	R10	K89
+      0x8C200357,  //  029C  GETMET	R8	R1	K87
+      0x58280058,  //  029D  LDCONST	R10	K88
       0x7C200400,  //  029E  CALL	R8	2
-      0x8C20035A,  //  029F  GETMET	R8	R1	K90
+      0x8C200359,  //  029F  GETMET	R8	R1	K89
       0x7C200200,  //  02A0  CALL	R8	1
-      0x8C20035B,  //  02A1  GETMET	R8	R1	K91
-      0x8C28050A,  //  02A2  GETMET	R10	R2	K10
-      0x58300063,  //  02A3  LDCONST	R12	K99
-      0x5C340C00,  //  02A4  MOVE	R13	R6
-      0x5C380E00,  //  02A5  MOVE	R14	R7
-      0x7C280800,  //  02A6  CALL	R10	4
+      0x8C20035A,  //  02A1  GETMET	R8	R1	K90
+      0x60280018,  //  02A2  GETGBL	R10	G24
+      0x582C0062,  //  02A3  LDCONST	R11	K98
+      0x5C300C00,  //  02A4  MOVE	R12	R6
+      0x5C340E00,  //  02A5  MOVE	R13	R7
+      0x7C280600,  //  02A6  CALL	R10	3
       0x7C200400,  //  02A7  CALL	R8	2
-      0x8C20035E,  //  02A8  GETMET	R8	R1	K94
-      0x8828035F,  //  02A9  GETMBR	R10	R1	K95
+      0x8C20035D,  //  02A8  GETMET	R8	R1	K93
+      0x8828035E,  //  02A9  GETMBR	R10	R1	K94
       0x7C200400,  //  02AA  CALL	R8	2
-      0x8C200360,  //  02AB  GETMET	R8	R1	K96
+      0x8C20035F,  //  02AB  GETMET	R8	R1	K95
       0x7C200200,  //  02AC  CALL	R8	1
       0x70020000,  //  02AD  JMP		#02AF
       0xB0080000,  //  02AE  RAISE	2	R0	R0

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_inspect.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_inspect.h
@@ -110,7 +110,7 @@ be_local_closure(matter_jitter,   /* name */
 ********************************************************************/
 be_local_closure(matter_inspect,   /* name */
   be_nested_proto(
-    16,                          /* nstack */
+    14,                          /* nstack */
     1,                          /* argc */
     0,                          /* varg */
     0,                          /* has upvals */
@@ -118,113 +118,110 @@ be_local_closure(matter_inspect,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(members),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_nested_str_weak(function),
-    /* K5   */  be_nested_str_weak(push),
-    /* K6   */  be_nested_str_weak(stop_iteration),
-    /* K7   */  be_nested_str_weak(matter),
-    /* K8   */  be_nested_str_weak(sort),
-    /* K9   */  be_nested_str_weak(format),
-    /* K10  */  be_nested_str_weak(_X27_X25s_X27_X3A_X20_X25s),
-    /* K11  */  be_nested_str_weak(_X7B),
-    /* K12  */  be_nested_str_weak(concat),
-    /* K13  */  be_nested_str_weak(_X2C_X20),
-    /* K14  */  be_nested_str_weak(_X7D),
-    /* K15  */  be_nested_str_weak(Exception_X3A),
-    /* K16  */  be_nested_str_weak(_X7C),
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(introspect),
+    /* K1   */  be_nested_str_weak(members),
+    /* K2   */  be_nested_str_weak(get),
+    /* K3   */  be_nested_str_weak(function),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    /* K6   */  be_nested_str_weak(matter),
+    /* K7   */  be_nested_str_weak(sort),
+    /* K8   */  be_nested_str_weak(_X27_X25s_X27_X3A_X20_X25s),
+    /* K9   */  be_nested_str_weak(_X7B),
+    /* K10  */  be_nested_str_weak(concat),
+    /* K11  */  be_nested_str_weak(_X2C_X20),
+    /* K12  */  be_nested_str_weak(_X7D),
+    /* K13  */  be_nested_str_weak(Exception_X3A),
+    /* K14  */  be_nested_str_weak(_X7C),
     }),
     be_str_weak(inspect),
     &be_const_str_solidified,
-    ( &(const binstruction[85]) {  /* code */
-      0xA8020044,  //  0000  EXBLK	0	#0046
+    ( &(const binstruction[84]) {  /* code */
+      0xA8020043,  //  0000  EXBLK	0	#0045
       0xA4060000,  //  0001  IMPORT	R1	K0
-      0xA40A0200,  //  0002  IMPORT	R2	K1
-      0x600C0012,  //  0003  GETGBL	R3	G18
-      0x7C0C0000,  //  0004  CALL	R3	0
-      0x60100010,  //  0005  GETGBL	R4	G16
-      0x8C140502,  //  0006  GETMET	R5	R2	K2
-      0x5C1C0000,  //  0007  MOVE	R7	R0
-      0x7C140400,  //  0008  CALL	R5	2
-      0x7C100200,  //  0009  CALL	R4	1
-      0xA802000E,  //  000A  EXBLK	0	#001A
-      0x5C140800,  //  000B  MOVE	R5	R4
-      0x7C140000,  //  000C  CALL	R5	0
-      0x8C180503,  //  000D  GETMET	R6	R2	K3
-      0x5C200000,  //  000E  MOVE	R8	R0
-      0x5C240A00,  //  000F  MOVE	R9	R5
-      0x7C180600,  //  0010  CALL	R6	3
-      0x601C0004,  //  0011  GETGBL	R7	G4
-      0x5C200C00,  //  0012  MOVE	R8	R6
-      0x7C1C0200,  //  0013  CALL	R7	1
-      0x201C0F04,  //  0014  NE	R7	R7	K4
-      0x781E0002,  //  0015  JMPF	R7	#0019
-      0x8C1C0705,  //  0016  GETMET	R7	R3	K5
-      0x5C240A00,  //  0017  MOVE	R9	R5
-      0x7C1C0400,  //  0018  CALL	R7	2
-      0x7001FFF0,  //  0019  JMP		#000B
-      0x58100006,  //  001A  LDCONST	R4	K6
-      0xAC100200,  //  001B  CATCH	R4	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0xB8120E00,  //  001D  GETNGBL	R4	K7
-      0x8C100908,  //  001E  GETMET	R4	R4	K8
-      0x5C180600,  //  001F  MOVE	R6	R3
-      0x7C100400,  //  0020  CALL	R4	2
-      0x5C0C0800,  //  0021  MOVE	R3	R4
-      0x60100012,  //  0022  GETGBL	R4	G18
-      0x7C100000,  //  0023  CALL	R4	0
-      0x60140010,  //  0024  GETGBL	R5	G16
-      0x5C180600,  //  0025  MOVE	R6	R3
-      0x7C140200,  //  0026  CALL	R5	1
-      0xA8020011,  //  0027  EXBLK	0	#003A
-      0x5C180A00,  //  0028  MOVE	R6	R5
-      0x7C180000,  //  0029  CALL	R6	0
-      0x8C1C0503,  //  002A  GETMET	R7	R2	K3
-      0x5C240000,  //  002B  MOVE	R9	R0
-      0x5C280C00,  //  002C  MOVE	R10	R6
-      0x7C1C0600,  //  002D  CALL	R7	3
-      0x8C200905,  //  002E  GETMET	R8	R4	K5
-      0x8C280309,  //  002F  GETMET	R10	R1	K9
-      0x5830000A,  //  0030  LDCONST	R12	K10
-      0x60340008,  //  0031  GETGBL	R13	G8
-      0x5C380C00,  //  0032  MOVE	R14	R6
-      0x7C340200,  //  0033  CALL	R13	1
-      0x60380008,  //  0034  GETGBL	R14	G8
-      0x5C3C0E00,  //  0035  MOVE	R15	R7
-      0x7C380200,  //  0036  CALL	R14	1
-      0x7C280800,  //  0037  CALL	R10	4
-      0x7C200400,  //  0038  CALL	R8	2
-      0x7001FFED,  //  0039  JMP		#0028
-      0x58140006,  //  003A  LDCONST	R5	K6
-      0xAC140200,  //  003B  CATCH	R5	1	0
-      0xB0080000,  //  003C  RAISE	2	R0	R0
-      0x8C14090C,  //  003D  GETMET	R5	R4	K12
-      0x581C000D,  //  003E  LDCONST	R7	K13
-      0x7C140400,  //  003F  CALL	R5	2
-      0x00161605,  //  0040  ADD	R5	K11	R5
-      0x00140B0E,  //  0041  ADD	R5	R5	K14
-      0xA8040001,  //  0042  EXBLK	1	1
-      0x80040A00,  //  0043  RET	1	R5
-      0xA8040001,  //  0044  EXBLK	1	1
-      0x7002000D,  //  0045  JMP		#0054
-      0xAC040002,  //  0046  CATCH	R1	0	2
-      0x7002000A,  //  0047  JMP		#0053
-      0x600C0008,  //  0048  GETGBL	R3	G8
-      0x5C100200,  //  0049  MOVE	R4	R1
-      0x7C0C0200,  //  004A  CALL	R3	1
-      0x000E1E03,  //  004B  ADD	R3	K15	R3
-      0x000C0710,  //  004C  ADD	R3	R3	K16
-      0x60100008,  //  004D  GETGBL	R4	G8
-      0x5C140400,  //  004E  MOVE	R5	R2
-      0x7C100200,  //  004F  CALL	R4	1
-      0x000C0604,  //  0050  ADD	R3	R3	R4
-      0x80040600,  //  0051  RET	1	R3
-      0x70020000,  //  0052  JMP		#0054
-      0xB0080000,  //  0053  RAISE	2	R0	R0
-      0x80000000,  //  0054  RET	0
+      0x60080012,  //  0002  GETGBL	R2	G18
+      0x7C080000,  //  0003  CALL	R2	0
+      0x600C0010,  //  0004  GETGBL	R3	G16
+      0x8C100301,  //  0005  GETMET	R4	R1	K1
+      0x5C180000,  //  0006  MOVE	R6	R0
+      0x7C100400,  //  0007  CALL	R4	2
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0xA802000E,  //  0009  EXBLK	0	#0019
+      0x5C100600,  //  000A  MOVE	R4	R3
+      0x7C100000,  //  000B  CALL	R4	0
+      0x8C140302,  //  000C  GETMET	R5	R1	K2
+      0x5C1C0000,  //  000D  MOVE	R7	R0
+      0x5C200800,  //  000E  MOVE	R8	R4
+      0x7C140600,  //  000F  CALL	R5	3
+      0x60180004,  //  0010  GETGBL	R6	G4
+      0x5C1C0A00,  //  0011  MOVE	R7	R5
+      0x7C180200,  //  0012  CALL	R6	1
+      0x20180D03,  //  0013  NE	R6	R6	K3
+      0x781A0002,  //  0014  JMPF	R6	#0018
+      0x8C180504,  //  0015  GETMET	R6	R2	K4
+      0x5C200800,  //  0016  MOVE	R8	R4
+      0x7C180400,  //  0017  CALL	R6	2
+      0x7001FFF0,  //  0018  JMP		#000A
+      0x580C0005,  //  0019  LDCONST	R3	K5
+      0xAC0C0200,  //  001A  CATCH	R3	1	0
+      0xB0080000,  //  001B  RAISE	2	R0	R0
+      0xB80E0C00,  //  001C  GETNGBL	R3	K6
+      0x8C0C0707,  //  001D  GETMET	R3	R3	K7
+      0x5C140400,  //  001E  MOVE	R5	R2
+      0x7C0C0400,  //  001F  CALL	R3	2
+      0x5C080600,  //  0020  MOVE	R2	R3
+      0x600C0012,  //  0021  GETGBL	R3	G18
+      0x7C0C0000,  //  0022  CALL	R3	0
+      0x60100010,  //  0023  GETGBL	R4	G16
+      0x5C140400,  //  0024  MOVE	R5	R2
+      0x7C100200,  //  0025  CALL	R4	1
+      0xA8020011,  //  0026  EXBLK	0	#0039
+      0x5C140800,  //  0027  MOVE	R5	R4
+      0x7C140000,  //  0028  CALL	R5	0
+      0x8C180302,  //  0029  GETMET	R6	R1	K2
+      0x5C200000,  //  002A  MOVE	R8	R0
+      0x5C240A00,  //  002B  MOVE	R9	R5
+      0x7C180600,  //  002C  CALL	R6	3
+      0x8C1C0704,  //  002D  GETMET	R7	R3	K4
+      0x60240018,  //  002E  GETGBL	R9	G24
+      0x58280008,  //  002F  LDCONST	R10	K8
+      0x602C0008,  //  0030  GETGBL	R11	G8
+      0x5C300A00,  //  0031  MOVE	R12	R5
+      0x7C2C0200,  //  0032  CALL	R11	1
+      0x60300008,  //  0033  GETGBL	R12	G8
+      0x5C340C00,  //  0034  MOVE	R13	R6
+      0x7C300200,  //  0035  CALL	R12	1
+      0x7C240600,  //  0036  CALL	R9	3
+      0x7C1C0400,  //  0037  CALL	R7	2
+      0x7001FFED,  //  0038  JMP		#0027
+      0x58100005,  //  0039  LDCONST	R4	K5
+      0xAC100200,  //  003A  CATCH	R4	1	0
+      0xB0080000,  //  003B  RAISE	2	R0	R0
+      0x8C10070A,  //  003C  GETMET	R4	R3	K10
+      0x5818000B,  //  003D  LDCONST	R6	K11
+      0x7C100400,  //  003E  CALL	R4	2
+      0x00121204,  //  003F  ADD	R4	K9	R4
+      0x0010090C,  //  0040  ADD	R4	R4	K12
+      0xA8040001,  //  0041  EXBLK	1	1
+      0x80040800,  //  0042  RET	1	R4
+      0xA8040001,  //  0043  EXBLK	1	1
+      0x7002000D,  //  0044  JMP		#0053
+      0xAC040002,  //  0045  CATCH	R1	0	2
+      0x7002000A,  //  0046  JMP		#0052
+      0x600C0008,  //  0047  GETGBL	R3	G8
+      0x5C100200,  //  0048  MOVE	R4	R1
+      0x7C0C0200,  //  0049  CALL	R3	1
+      0x000E1A03,  //  004A  ADD	R3	K13	R3
+      0x000C070E,  //  004B  ADD	R3	R3	K14
+      0x60100008,  //  004C  GETGBL	R4	G8
+      0x5C140400,  //  004D  MOVE	R5	R2
+      0x7C100200,  //  004E  CALL	R4	1
+      0x000C0604,  //  004F  ADD	R3	R3	R4
+      0x80040600,  //  0050  RET	1	R3
+      0x70020000,  //  0051  JMP		#0053
+      0xB0080000,  //  0052  RAISE	2	R0	R0
+      0x80000000,  //  0053  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Matter, most `import.string` are not needed anymore, and `string.format` is now replaced with `replace` which is a builtin global and does not need anymore a lookup.

Saving 2.3KB

Also fixed a bug when `\n` and `\r` are present in f-strings

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
