### PR TITLE
add matter as a default option in most env

### DIFF
--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -288,6 +288,7 @@
 #undef FALLBACK_MODULE
 #define FALLBACK_MODULE        WEMOS             // [Module2] Select default module on fast reboot where USER_MODULE is user template
 
+#define USE_MATTER_DEVICE
 #undef USE_DOMOTICZ
 #undef USE_HOME_ASSISTANT
 #define USE_TASMOTA_DISCOVERY                    // Enable Tasmota Discovery support (+2k code)
@@ -556,6 +557,8 @@
 #ifndef CODE_IMAGE_STR
   #define CODE_IMAGE_STR "tasmota32"
 #endif
+
+#define USE_MATTER_DEVICE
 
 #define USE_INFLUXDB                             // Enable influxdb support (+5k code)
 


### PR DESCRIPTION
## Description:

no extra builds for matter. Include in existing env.
After merge. PR #18932 should be reverted

fyi @arendst @s-hadinger 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
