### PR TITLE
Berry reduce bproto structure by 8 bytes

### DIFF
--- a/lib/libesp32/berry/src/be_object.h
+++ b/lib/libesp32/berry/src/be_object.h
@@ -151,15 +151,15 @@ typedef struct bproto {
     bbyte nupvals; /* upvalue count */
     bbyte argc; /* argument count */
     bbyte varg; /* variable argument position + 1 */
+    int16_t codesize; /* code size */
+    int16_t nconst; /* constants count */
+    int16_t nproto; /* proto count */
     bgcobject *gray; /* for gc gray list */
     bupvaldesc *upvals;
     bvalue *ktab; /* constants table */
     struct bproto **ptab; /* proto table */
     binstruction *code; /* instructions sequence */
     bstring *name; /* function name */
-    int codesize; /* code size */
-    int nconst; /* constants count */
-    int nproto; /* proto count */
     bstring *source; /* source file name */
 #if BE_DEBUG_RUNTIME_INFO /* debug information */
     blineinfo *lineinfo;

--- a/lib/libesp32/berry/src/berry.h
+++ b/lib/libesp32/berry/src/berry.h
@@ -517,15 +517,15 @@ typedef bclass_ptr bclass_array[];
     BE_IIF(_is_upval)(sizeof(_name##_upvals)/sizeof(bupvaldesc),0),   /**< nupvals */              \
     (_argc),                                                          /**< argc */                 \
     0,                                                                /**< varg */                 \
+    sizeof(_name##_code)/sizeof(uint32_t),                            /**< codesize */             \
+    BE_IIF(_is_const)(sizeof(_name##_ktab)/sizeof(bvalue),0),         /**< nconst */               \
+    BE_IIF(_is_subproto)(sizeof(_name##_subproto)/sizeof(bproto*),0), /**< proto */                \
     NULL,                                                             /**< bgcobject *gray */      \
     BE_IIF(_is_upval)((bupvaldesc*)&_name##_upvals,NULL),             /**< bupvaldesc *upvals */   \
     BE_IIF(_is_const)((bvalue*)&_name##_ktab,NULL),                   /**< ktab */                 \
     BE_IIF(_is_subproto)((struct bproto**)&_name##_subproto,NULL),    /**< bproto **ptab */        \
     (binstruction*) &_name##_code,                                    /**< code */                 \
     be_local_const_str(_name##_str_name),                             /**< name */                 \
-    sizeof(_name##_code)/sizeof(uint32_t),                            /**< codesize */             \
-    BE_IIF(_is_const)(sizeof(_name##_ktab)/sizeof(bvalue),0),         /**< nconst */               \
-    BE_IIF(_is_subproto)(sizeof(_name##_subproto)/sizeof(bproto*),0), /**< proto */                \
     be_local_const_str(_name##_str_source),                           /**< source */               \
     PROTO_RUNTIME_BLOCK                                               /**< */                      \
     PROTO_VAR_INFO_BLOCK                                              /**< */                      \
@@ -545,15 +545,15 @@ typedef bclass_ptr bclass_array[];
     BE_IIF(_has_upval)(sizeof(*_upvals)/sizeof(bupvaldesc),0),  /**< nupvals */              \
     (_argc),                                                    /**< argc */                 \
     (_varg),                                                    /**< varg */                 \
+    sizeof(*_code)/sizeof(binstruction),                        /**< codesize */             \
+    BE_IIF(_has_const)(sizeof(*_ktab)/sizeof(bvalue),0),        /**< nconst */               \
+    BE_IIF(_has_subproto)(sizeof(*_protos)/sizeof(bproto*),0),  /**< proto */                \
     NULL,                                                       /**< bgcobject *gray */      \
     (bupvaldesc*) _upvals,                                      /**< bupvaldesc *upvals */   \
     (bvalue*) _ktab,                                            /**< ktab */                 \
     (struct bproto**) _protos,                                  /**< bproto **ptab */        \
     (binstruction*) _code,                                      /**< code */                 \
     ((bstring*) _fname),                                        /**< name */                 \
-    sizeof(*_code)/sizeof(binstruction),                        /**< codesize */             \
-    BE_IIF(_has_const)(sizeof(*_ktab)/sizeof(bvalue),0),        /**< nconst */               \
-    BE_IIF(_has_subproto)(sizeof(*_protos)/sizeof(bproto*),0),  /**< proto */                \
     ((bstring*) _source),                                       /**< source */               \
     PROTO_RUNTIME_BLOCK                                         /**< */                      \
     PROTO_VAR_INFO_BLOCK                                        /**< */                      \


### PR DESCRIPTION
## Description:

Optimize the `bproto` structure and reduce by 8 bytes. As a consequence, constants, code size and number of sub-functions are now limited to 32767 (which is out of reach anyways).

With Matter we have ~1000 Berry functions, this saves 8KB for Matter builds.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
