### PR TITLE
Berry add option to remove source file name and save flash space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Berry `webclient.url_encode()` is now a static class method, no change required to existing code (#18775)
 - Matter Bridge mode always on
 - ESP32 Framework (Core) from v2.0.9 to v2.0.10
+- Berry code size optimizations
 
 ### Fixed
 - Interaction of ``SetOption92``, ``VirtualCT``, and ``RGBWWTable`` (#18768)

--- a/lib/libesp32/berry/default/berry_conf.h
+++ b/lib/libesp32/berry/default/berry_conf.h
@@ -60,6 +60,14 @@
  **/
 #define BE_USE_PRECOMPILED_OBJECT       1
 
+/* Macro: BE_DEBUG_SOURCE_FILE
+ * Indicate if each function remembers its source file name
+ * 0: do not keep the file name (saves 4 bytes per function)
+ * 1: keep the source file name
+ * Default: 1
+ **/
+#define BE_DEBUG_SOURCE_FILE            0
+
 /* Macro: BE_DEBUG_RUNTIME_INFO
  * Set runtime error debugging information.
  * 0: unable to output source file and line number at runtime.

--- a/lib/libesp32/berry/src/be_bytecode.c
+++ b/lib/libesp32/berry/src/be_bytecode.c
@@ -114,6 +114,8 @@ static void save_string(void *fp, bstring *s)
         const char *data = str(s);
         save_word(fp, length);
         be_fwrite(fp, data, length);
+    } else {
+        save_word(fp, 0);
     }
 }
 
@@ -247,7 +249,11 @@ static void save_proto(bvm *vm, void *fp, bproto *proto)
 {
     if (proto) {
         save_string(fp, proto->name); /* name */
+#if BE_DEBUG_SOURCE_FILE
         save_string(fp, proto->source); /* source */
+#else
+        save_string(fp, NULL); /* source */
+#endif
         save_byte(fp, proto->argc); /* argc */
         save_byte(fp, proto->nstack); /* nstack */
         save_byte(fp, proto->varg); /* varg */
@@ -551,7 +557,11 @@ static bbool load_proto(bvm *vm, void *fp, bproto **proto, int info, int version
     if (str_len(name)) {
         *proto = be_newproto(vm);
         (*proto)->name = name;
+#if BE_DEBUG_SOURCE_FILE
         (*proto)->source = load_string(vm, fp);
+#else
+        load_string(vm, fp);    /* discard name */
+#endif
         (*proto)->argc = load_byte(fp);
         (*proto)->nstack = load_byte(fp);
         if (version > 1) {

--- a/lib/libesp32/berry/src/be_debug.c
+++ b/lib/libesp32/berry/src/be_debug.c
@@ -156,7 +156,9 @@ void be_dumpclosure(bclosure *cl)
 #if BE_DEBUG_RUNTIME_INFO
     blineinfo *lineinfo = proto->lineinfo;
 #endif
+#if BE_DEBUG_SOURCE_FILE
     logfmt("source '%s', ", str(proto->source));
+#endif
     logfmt("function '%s':\n", str(proto->name));
 #if BE_DEBUG_RUNTIME_INFO
     if (lineinfo) { /* first line */
@@ -185,7 +187,9 @@ static void sourceinfo(bproto *proto, binstruction *ip)
         int pc = cast_int(ip - proto->code - 1); /* now vm->ip has been increased */
         for (; it < end && pc > it->endpc; ++it);
         snprintf(buf, sizeof(buf), ":%d:", it->linenumber);
+#if BE_DEBUG_SOURCE_FILE
         be_writestring(str(proto->source));
+#endif
         be_writestring(buf);
     } else {
         be_writestring("<unknown source>:");

--- a/lib/libesp32/berry/src/be_func.c
+++ b/lib/libesp32/berry/src/be_func.c
@@ -108,7 +108,9 @@ bproto* be_newproto(bvm *vm)
         p->codesize = 0;
         p->argc = 0;
         p->varg = 0;
+#if BE_DEBUG_SOURCE_FILE
         p->source = NULL;
+#endif
 #if BE_DEBUG_RUNTIME_INFO
         p->lineinfo = NULL;
         p->nlineinfo = 0;

--- a/lib/libesp32/berry/src/be_gc.c
+++ b/lib/libesp32/berry/src/be_gc.c
@@ -231,7 +231,9 @@ static void mark_proto(bvm *vm, bgcobject *obj)
             mark_gray(vm, gc_object(*ptab));
         }
         gc_setdark_safe(p->name);
+#if BE_DEBUG_SOURCE_FILE
         gc_setdark_safe(p->source);
+#endif
 #if BE_DEBUG_VAR_INFO
         if (p->nvarinfo) {
             bvarinfo *vinfo = p->varinfo;

--- a/lib/libesp32/berry/src/be_module.c
+++ b/lib/libesp32/berry/src/be_module.c
@@ -128,11 +128,15 @@ static char* fixpath(bvm *vm, bstring *path, size_t *size)
     const char *split, *base;
     bvalue *func = vm->cf->func;
     bclosure *cl = var_toobj(func);
+#if BE_DEBUG_SOURCE_FILE
     if (var_isclosure(func)) {
         base = str(cl->proto->source); /* get the source file path */
     } else {
         base = "/";
     }
+#else
+    base = "/";
+#endif
     split = be_splitpath(base);
     *size = split - base + (size_t)str_len(path) + SUFFIX_LEN;
     buffer = be_malloc(vm, *size);

--- a/lib/libesp32/berry/src/be_object.h
+++ b/lib/libesp32/berry/src/be_object.h
@@ -160,7 +160,9 @@ typedef struct bproto {
     struct bproto **ptab; /* proto table */
     binstruction *code; /* instructions sequence */
     bstring *name; /* function name */
+#if BE_DEBUG_SOURCE_FILE
     bstring *source; /* source file name */
+#endif
 #if BE_DEBUG_RUNTIME_INFO /* debug information */
     blineinfo *lineinfo;
     int nlineinfo;

--- a/lib/libesp32/berry/src/be_parser.c
+++ b/lib/libesp32/berry/src/be_parser.c
@@ -228,9 +228,11 @@ static void end_block(bparser *parser)
    `stdin` or the name of the current function */
 static bstring* parser_source(bparser *parser)
 {
+#if BE_DEBUG_SOURCE_FILE
     if (parser->finfo) {
         return parser->finfo->proto->source;
     }
+#endif
     return be_newstr(parser->vm, parser->lexer.fname);
 }
 
@@ -250,7 +252,9 @@ static void begin_func(bparser *parser, bfuncinfo *finfo, bblockinfo *binfo)
     be_vector_init(vm, &finfo->pvec, sizeof(bproto*)); /* vector for subprotos */
     proto->ptab = be_vector_data(&finfo->pvec);
     proto->nproto = be_vector_capacity(&finfo->pvec);
+#if BE_DEBUG_SOURCE_FILE
     proto->source = parser_source(parser); /* keep a copy of source for function */
+#endif
     finfo->local = be_list_new(vm); /* list for local variables */
     var_setlist(vm->top, finfo->local); /* push list of local variables on the stack (avoid gc) */
     be_stackpush(vm);

--- a/lib/libesp32/berry/src/berry.h
+++ b/lib/libesp32/berry/src/berry.h
@@ -482,6 +482,18 @@ typedef bclass_ptr bclass_array[];
  * @brief conditional block in bproto depending on compilation options
  *
  */
+#if BE_SOURCE_FILE
+  #define PROTO_SOURCE_FILE(n)   \
+    ((bstring*) _source),                                       /**< source */
+#else
+  #define PROTO_SOURCE_FILE(n)
+#endif
+
+/**
+ * @def PROTO_RUNTIME_BLOCK
+ * @brief conditional block in bproto depending on compilation options
+ *
+ */
 #if BE_DEBUG_RUNTIME_INFO
   #define PROTO_RUNTIME_BLOCK   \
     NULL,     /**< varinfo */ \
@@ -554,7 +566,7 @@ typedef bclass_ptr bclass_array[];
     (struct bproto**) _protos,                                  /**< bproto **ptab */        \
     (binstruction*) _code,                                      /**< code */                 \
     ((bstring*) _fname),                                        /**< name */                 \
-    ((bstring*) _source),                                       /**< source */               \
+    PROTO_SOURCE_FILE(_source)                                  /**< source */               \
     PROTO_RUNTIME_BLOCK                                         /**< */                      \
     PROTO_VAR_INFO_BLOCK                                        /**< */                      \
   }


### PR DESCRIPTION
## Description:

Add an option to Berry to not keep the source file name for each function. This is anyways not very useful in the context of Tasmota where most function are solidified and the source file name is irrelevant.

For Matter, this saves 4KB.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
