### PR TITLE
Matter display the remote Device Name instead of IP address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Matter add friendly-name (NodeLabel) to each endpoint
 - Berry add global function `format` as a simpler syntax to `string.format`
 - Berry added f-strings as an alternative to string formatting
+- Matter display the remote Device Name instead of IP address
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
@@ -33,6 +33,7 @@ class Matter_Device
   var plugins_persist                 # true if plugins configuration needs to be saved
   var plugins_classes                 # map of registered classes by type name
   var plugins_config                  # map of JSON configuration for plugins
+  var plugins_config_remotes          # map of information on each remote under "remotes" key, '{}' when empty
   var udp_server                      # `matter.UDPServer()` object
   var message_handler                 # `matter.MessageHandler()` object
   var sessions                        # `matter.Session_Store()` objet
@@ -57,7 +58,7 @@ class Matter_Device
   var mdns_pase_eth                   # do we have an active PASE mDNS announce for eth
   var mdns_pase_wifi                  # do we have an active PASE mDNS announce for wifi
   # for brige mode, list of HTTP_remote objects (only one instance per remote object)
-  var http_remotes                    # map of 'domain:port' or `nil` if no bridge
+  var http_remotes                    # map of 'domain:port' to `Matter_HTTP_remote` instance or `nil` if no bridges
   # saved in parameters
   var root_discriminator              # as `int`
   var root_passcode                   # as `int`
@@ -83,6 +84,7 @@ class Matter_Device
     self.plugins = []
     self.plugins_persist = false                  # plugins need to saved only when the first fabric is associated
     self.plugins_classes = {}
+    self.plugins_config_remotes = {}
     self.register_native_classes()                # register all native classes
     self.vendorid = self.VENDOR_ID
     self.productid = self.PRODUCT_ID
@@ -624,10 +626,16 @@ class Matter_Device
   # 
   def save_param()
     import json
+    self.update_remotes_info()    # update self.plugins_config_remotes
+
     var j = format('{"distinguish":%i,"passcode":%i,"ipv4only":%s,"nextep":%i', self.root_discriminator, self.root_passcode, self.ipv4only ? 'true':'false', self.next_ep)
     if self.plugins_persist
       j += ',"config":'
       j += json.dump(self.plugins_config)
+      if size(self.plugins_config_remotes) > 0
+        j += ',"remotes":'
+        j += json.dump(self.plugins_config_remotes)
+      end
     end
     j += '}'
     try
@@ -640,6 +648,34 @@ class Matter_Device
       tasmota.log("MTR: Session_Store::save Exception:" + str(e) + "|" + str(m), 2)
       return j
     end
+  end
+
+  #############################################################
+  # Get remote info by url
+  #
+  # Return a map, potentially empty
+  def get_plugin_remote_info(url)
+    return self.plugins_config_remotes.find(url, {})
+  end
+    
+  #############################################################
+  # update back all remote information from actual remotes
+  #
+  # returns a map or `nil` if no information
+  # also stores in `self.plugins_config_remotes`
+  def update_remotes_info()
+    var ret = {}
+    if self.http_remotes != nil
+      for url:self.http_remotes.keys()
+        var info = self.http_remotes[url].get_info()
+        if info != nil && size(info) > 0
+          ret[url] = info
+        end
+      end
+    end
+
+    self.plugins_config_remotes = ret
+    return ret
   end
 
   #############################################################
@@ -663,6 +699,10 @@ class Matter_Device
         tasmota.log("MTR: load_config = " + str(self.plugins_config), 3)
         self.adjust_next_ep()
         self.plugins_persist = true
+      end
+      self.plugins_config_remotes = j.find("remotes", {})
+      if self.plugins_config_remotes
+        tasmota.log("MTR: load_remotes = " + str(self.plugins_config_remotes), 3)
       end
     except .. as e, m
       if e != "io_error"
@@ -1011,6 +1051,7 @@ class Matter_Device
 
     if !self.plugins_persist
       self.plugins_config = self.autoconf_device_map()
+      self.plugins_config_remotes = {}
       self.adjust_next_ep()
       tasmota.log("MTR: autoconfig = " + str(self.plugins_config), 3)
     end
@@ -1210,7 +1251,7 @@ class Matter_Device
         self.register_plugin_class(v)
       end
     end
-    tasmota.log("MTR: registered classes "+str(self.k2l(self.plugins_classes)), 3)
+    # tasmota.log("MTR: registered classes "+str(self.k2l(self.plugins_classes)), 3)
   end
   
   #############################################################
@@ -1357,7 +1398,10 @@ class Matter_Device
         http_remote.set_timeout(timeout)          # reduce timeout if new value is shorter
       end
     else
-      http_remote = matter.HTTP_remote(addr, timeout)
+      http_remote = matter.HTTP_remote(self, addr, timeout)
+      if self.plugins_config_remotes.contains(addr)
+        http_remote.set_info(self.plugins_config_remotes[addr])
+      end
       self.http_remotes[addr] = http_remote
     end
     return http_remote

--- a/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_async.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_async.be
@@ -201,12 +201,14 @@ class Matter_HTTP_async : Matter_TCP_async
             self.chunk_size = int('0x'+m[1])
             # if chunk size is zero, finished
             if self.chunk_size == 0
-              self.close()
               self.status = 2   # finished
               self.response = ''    # free space
               self.response_offset = 0
-              self.http_status = 1        # ok
-              self.event_http_finished()
+              self.close()
+              # if self.http_status == 0    # this is now handled by the close event
+              #   self.http_status = 1
+              #   self.event_http_finished()
+              # end
               return
             end
           end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_remote.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_remote.be
@@ -38,6 +38,7 @@ class Matter_HTTP_async end
 #    we only send every 2 seconds and dispatch results to all plugins.
 
 class Matter_HTTP_remote : Matter_HTTP_async
+  var device                                        # reference to matter_device
   var probe_update_time_map                         # number of milliseconds to wait for each async command (map)
   var probe_next_timestamp_map                      # timestamp for last probe (in millis()) for each `Status <x>`
                                                     # if timestamp is `0`, this should be scheduled in priority
@@ -49,16 +50,137 @@ class Matter_HTTP_remote : Matter_HTTP_async
   var reachable                                     # is the device reachable
   var reachable_utc                                 # last tick when the reachability was seen (avoids sending superfluous ping commands)
                                                   
+  # information gathered about the remote device (name, version...)
+  static var UPDATE_TIME = 5000                     # update every 5s until first response
+  static var UPDATE_TIME2 = 300000                  # then update every 5 minutes
+  static var UPDATE_CMD0 = "Status"                 # command to send for updates
+  static var UPDATE_CMD2 = "Status 2"               # command to send for updates
+  static var UPDATE_CMD5 = "Status 5"               # command to send for updates
+  var info                                          # as a map
                                                   
   #############################################################
   # init
-  def init(addr, timeout, fastloop)
+  def init(device, addr, timeout, fastloop)
+    self.device = device                            # if device is null, it's a temporary object not linked to a device
     self.probe_update_time_map    = {}
     self.probe_next_timestamp_map = {}
     self.async_cb_map = {}
     self.current_cmd = nil
     self.reachable = false                          # force a valid bool value
     super(self).init(addr, 80, timeout, fastloop)
+
+    # set up some reading information about the device
+    self.info = {}
+    if self.device
+      # we need different callbacks per command (don't create a single one for both calls)
+      self.add_schedule(self.UPDATE_CMD0, self.UPDATE_TIME, / status,payload,cmd -> self.parse_status_response(status,payload,cmd))
+      self.add_schedule(self.UPDATE_CMD2, self.UPDATE_TIME, / status,payload,cmd -> self.parse_status_response(status,payload,cmd))
+      self.add_schedule(self.UPDATE_CMD5, self.UPDATE_TIME, / status,payload,cmd -> self.parse_status_response(status,payload,cmd))
+    end
+  end
+
+  #############################################################
+  # get/set remote_info map
+  def get_info()      return self.info                    end
+  def set_info(v)     self.info = v                       end
+  def info_changed()  self.device.save_param()            end     # send a signal to global device that remote information changed
+
+  #############################################################
+  # parse response for `Status` and `Status 2`
+  def parse_status_response(status, payload, cmd)
+    if status != nil && status > 0
+      # device is known to be reachable
+      self.device_is_alive(true)
+
+      import json
+      var j = json.load(payload)
+      var code = nil                        # index of Status
+      if j
+        # filter
+        if   j.contains("Status")           # Status 0 (actually `Status` wihtout any number)
+          j = j["Status"]
+          code = 0
+        elif j.contains("StatusFWR")        # Status 2
+          j = j["StatusFWR"]
+          code = 2
+        elif j.contains("StatusNET")        # Status 5
+          j = j["StatusNET"]
+          code = 5
+        end
+        # convert to shadow values
+        self.parse_update(j, code)          # call parser
+      end
+    end
+  end
+  
+  #############################################################
+  # Stub for updating shadow values (local copies of what we published to the Matter gateway)
+  #
+  # This call is synnchronous and blocking.
+  def parse_update(data, index)
+    var changed = false
+    if index == 0                               # Status
+      var device_name = data.find("DeviceName")              # we consider 'Tasmota' as the non-information default
+      if device_name == "Tasmota"   device_name = nil   end
+
+      # did the value changed?
+      if self.info.find('name') != device_name
+        if device_name != nil
+          self.info['name'] = device_name
+        else
+          self.info.remove("name")
+        end
+        tasmota.log(f"MTR: update '{self.addr}' name='{device_name}'", 3)
+        changed = true
+      end
+
+      # reduce the update time after a read is succesful
+      self.change_schedule(self.UPDATE_CMD0, self.UPDATE_TIME2)
+    elif index == 2                             # Status 2
+      var version = data.find("Version")
+      var hardware = data.find("Hardware")
+
+      if self.info.find('version') != version
+        if version != nil
+          self.info['version'] = version
+        else
+          self.info.remove('version')
+        end
+        tasmota.log(f"MTR: update '{self.addr}' version='{version}'", 3)
+        changed = true
+      end
+
+      if self.info.find('hardware') != hardware
+        if hardware != nil
+          self.info['hardware'] = hardware
+        else
+          self.info.remove('hardware')
+        end
+        tasmota.log(f"MTR: update '{self.addr}' hardware='{hardware}'", 3)
+        changed = true
+      end
+
+      # reduce the update time after a read is succesful
+      self.change_schedule(self.UPDATE_CMD2, self.UPDATE_TIME2)
+    elif index == 5
+      var mac = data.find("Mac")
+
+      # did the value changed?
+      if self.info.find('mac') != mac
+        if mac != nil
+          self.info['mac'] = mac
+        else
+          self.info.remove("mac")
+        end
+        tasmota.log(f"MTR: update '{self.addr}' mac='{mac}'", 3)
+        changed = true
+      end
+
+      # reduce the update time after a read is succesful
+      self.change_schedule(self.UPDATE_CMD0, self.UPDATE_TIME2)
+    end
+
+    if changed      self.info_changed()   end
   end
 
   #############################################################
@@ -89,6 +211,15 @@ class Matter_HTTP_remote : Matter_HTTP_async
     # do we add a cb?
     if cb != nil
       self.add_async_cb(cb, cmd)
+    end
+  end
+
+  #############################################################
+  # Change schedule of current cmd
+  def change_schedule(cmd, update_time)
+    if self.probe_update_time_map.contains(cmd)
+      self.probe_update_time_map[cmd] = update_time
+      self.probe_next_timestamp_map[cmd] = matter.jitter(update_time)
     end
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
@@ -184,7 +184,7 @@ class Matter_IM
       if message
         return message.status_ok_received(msg)         # re-arm the sending of next packets for the same exchange
       else
-        tasmota.log(format("MTR: >OK        (%6i) exch=%i not found", msg.session.local_session_id, msg.exchange_id), 3)      # don't show 'SUCCESS' to not overflow logs with non-information
+        tasmota.log(format("MTR: >OK        (%6i) exch=%i not found", msg.session.local_session_id, msg.exchange_id), 4)      # don't show 'SUCCESS' to not overflow logs with non-information
       end
     else
       # error

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin.be
@@ -205,6 +205,8 @@ class Matter_Plugin
 
       if   attribute == 0x0011          #  ---------- Reachable / bool ----------
         return TLV.create_TLV(TLV.BOOL, 1)     # by default we are reachable
+      else
+        return super(self).read_attribute(session, ctx)   # rest is handled by 0x0028
       end
     else
       return nil

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_HTTP.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_HTTP.be
@@ -182,8 +182,32 @@ class Matter_Plugin_Bridge_HTTP : Matter_Plugin_Device
 
     # ====================================================================================================
     if   cluster == 0x0039              # ========== Bridged Device Basic Information 9.13 p.485 ==========
+      import string
 
-      if   attribute == 0x0011          #  ---------- Reachable / bool ----------
+      if   attribute == 0x0003         #  ---------- ProductName / string ----------
+        var name = self.http_remote.get_info().find("name")
+        if name
+          return TLV.create_TLV(TLV.UTF1, name)
+        else
+          return TLV.create_TLV(TLV.NULL, nil)
+        end
+      elif attribute == 0x000A          #  ---------- SoftwareVersionString / string ----------
+        var version_full = self.http_remote.get_info().find("version")
+        if version_full
+          var version_end = string.find(version_full, '(')
+          if version_end > 0    version_full = version_full[0..version_end - 1]   end
+          return TLV.create_TLV(TLV.UTF1, version_full)
+        else
+          return TLV.create_TLV(TLV.NULL, nil)
+        end
+      elif attribute == 0x000F || attribute == 0x0012          #  ---------- SerialNumber || UniqueID / string ----------
+        var mac = self.http_remote.get_info().find("mac")
+        if mac
+          return TLV.create_TLV(TLV.UTF1, mac)
+        else
+          return TLV.create_TLV(TLV.NULL, nil)
+        end
+      elif attribute == 0x0011          #  ---------- Reachable / bool ----------
         # self.is_reachable_lazy_sync()   # Not needed anymore
         return TLV.create_TLV(TLV.BOOL, self.http_remote.reachable)     # TODO find a way to do a ping
       else

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
@@ -32,7 +32,7 @@ class Matter_Plugin_Root : Matter_Plugin
   static var CLUSTERS  = {
     # 0x001D: inherited               # Descriptor Cluster 9.5 p.453
     0x001F: [0,2,3,4],                # Access Control Cluster, p.461
-    0x0028: [0,1,2,3,4,5,6,7,8,9,0x0A,0x0F,0x12,0x13],# Basic Information Cluster cluster 11.1 p.565
+    0x0028: [0,1,2,3,4,5,6,7,8,9,0x0A,0x0F,0x11,0x12,0x13],# Basic Information Cluster cluster 11.1 p.565
     # 0x002A: [0,1,2,3],                # OTA Software Update Requestor Cluster Definition 11.19.7 p.762
     0x002B: [0,1],                    # Localization Configuration Cluster 11.3 p.580
     0x002C: [0,1,2],                  # Time Format Localization Cluster 11.4 p.581
@@ -240,6 +240,8 @@ class Matter_Plugin_Root : Matter_Plugin
         return TLV.create_TLV(TLV.UTF1, version_full)
       elif attribute == 0x000F          #  ---------- SerialNumber / string ----------
         return TLV.create_TLV(TLV.UTF1, tasmota.wifi().find("mac", ""))
+      elif attribute == 0x0011          #  ---------- Reachable / bool ----------
+        return TLV.create_TLV(TLV.BOOL, 1)     # by default we are reachable
       elif attribute == 0x0012          #  ---------- UniqueID / string 32 max ----------
         return TLV.create_TLV(TLV.UTF1, tasmota.wifi().find("mac", ""))
       elif attribute == 0x0013          #  ---------- CapabilityMinima / CapabilityMinimaStruct ----------

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -366,7 +366,8 @@ class Matter_UI
     for remote: remotes
 
       var remote_html = webserver.html_escape(remote)
-      webserver.content_send(f"&#x1F517; <a target='_blank' href=\"http://{remote_html}/?\">{remote_html}</a>")
+      var host_device_name = webserver.html_escape( self.device.get_plugin_remote_info(remote).find('name', remote) )
+      webserver.content_send(f"&#x1F517; <a target='_blank' title='http://{remote_html}/' href=\"http://{remote_html}/?\">{host_device_name}</a>")
       webserver.content_send("<table style='width:100%'>")
       webserver.content_send("<tr>"
                              "<td width='25'></td>"
@@ -617,7 +618,7 @@ class Matter_UI
 
     if url == ''  return end
     var timeout = matter.Plugin_Bridge_HTTP.PROBE_TIMEOUT
-    var http_remote = matter.HTTP_remote(url, timeout)
+    var http_remote = matter.HTTP_remote(nil, url, timeout)
     # Status 8
     var status8 = http_remote.call_sync('Status 8', timeout)
     if status8 != nil   status8 = json.load(status8)                end
@@ -640,7 +641,8 @@ class Matter_UI
       webserver.content_send("<fieldset><legend><b>&nbsp;Matter Remote Device&nbsp;</b></legend><p></p>"
                              "<p><b>Add Remote sensor or device</b></p>")
 
-      webserver.content_send(format("<p>&#x1F517; <a target='_blank' href=\"http://%s/?\">%s</a></p>", webserver.html_escape(url), webserver.html_escape(url)))
+      var remote_html = webserver.html_escape(url)
+      webserver.content_send(f"<p>&#x1F517; <a target='_blank' href=\"http://{remote_html}/?\">{remote_html}</a></p>")
 
       # Add new endpoint section
       webserver.content_send("<form action='/matterc' method='post'>"
@@ -1028,7 +1030,8 @@ class Matter_UI
 
     for host: self.device.k2l(bridge_plugin_by_host)
       var host_html = webserver.html_escape(host)
-      webserver.content_send(format("<tr class='ztdm htrm'><td>&#x1F517; <a target='_blank' title='http://%s/' href=\"http://%s/?\"'>%s</a></td>", host_html, host_html, host_html))
+      var host_device_name = webserver.html_escape( self.device.get_plugin_remote_info(host).find('name', host) )
+      webserver.content_send(f"<tr class='ztdm htrm'><td>&#x1F517; <a target='_blank' title='http://{host_html}/' href=\"http://{host_html}/?\"'>{host_device_name}</a></td>")
       var http_remote = bridge_plugin_by_host[host][0].http_remote    # get the http_remote object from the first in list
       webserver.content_send(http_remote.web_last_seen())
 

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
@@ -7,9 +7,96 @@
 extern const bclass be_class_Matter_Device;
 
 /********************************************************************
-** Solidified function: is_commissioning_open
+** Solidified function: msg_received
 ********************************************************************/
-be_local_closure(Matter_Device_is_commissioning_open,   /* name */
+be_local_closure(Matter_Device_msg_received,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(msg_received),
+    }),
+    be_str_weak(msg_received),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x8C100901,  //  0001  GETMET	R4	R4	K1
+      0x5C180200,  //  0002  MOVE	R6	R1
+      0x5C1C0400,  //  0003  MOVE	R7	R2
+      0x5C200600,  //  0004  MOVE	R8	R3
+      0x7C100800,  //  0005  CALL	R4	4
+      0x80040800,  //  0006  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: conf_to_log
+********************************************************************/
+be_local_closure(Matter_Device_conf_to_log,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Device),
+    /* K1   */  be_nested_str_weak(),
+    /* K2   */  be_nested_str_weak(k2l),
+    /* K3   */  be_nested_str_weak(type),
+    /* K4   */  be_nested_str_weak(_X20_X25s_X3A_X25s),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(conf_to_log),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x58080001,  //  0001  LDCONST	R2	K1
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x8C100302,  //  0003  GETMET	R4	R1	K2
+      0x5C180000,  //  0004  MOVE	R6	R0
+      0x7C100400,  //  0005  CALL	R4	2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0xA802000B,  //  0007  EXBLK	0	#0014
+      0x5C100600,  //  0008  MOVE	R4	R3
+      0x7C100000,  //  0009  CALL	R4	0
+      0x1C140903,  //  000A  EQ	R5	R4	K3
+      0x78160000,  //  000B  JMPF	R5	#000D
+      0x7001FFFA,  //  000C  JMP		#0008
+      0x60140018,  //  000D  GETGBL	R5	G24
+      0x58180004,  //  000E  LDCONST	R6	K4
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x94200004,  //  0010  GETIDX	R8	R0	R4
+      0x7C140600,  //  0011  CALL	R5	3
+      0x00080405,  //  0012  ADD	R2	R2	R5
+      0x7001FFF3,  //  0013  JMP		#0008
+      0x580C0005,  //  0014  LDCONST	R3	K5
+      0xAC0C0200,  //  0015  CATCH	R3	1	0
+      0xB0080000,  //  0016  RAISE	2	R0	R0
+      0x80040400,  //  0017  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_before_restart
+********************************************************************/
+be_local_closure(Matter_Device_save_before_restart,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -19,16 +106,3834 @@ be_local_closure(Matter_Device_is_commissioning_open,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K1   */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
     }),
-    be_str_weak(is_commissioning_open),
+    be_str_weak(save_before_restart),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x7C040200,  //  0003  CALL	R1	1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_native_classes
+********************************************************************/
+be_local_closure(Matter_Device_register_native_classes,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(introspect),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(members),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(get),
+    /* K5   */  be_nested_str_weak(class),
+    /* K6   */  be_nested_str_weak(find),
+    /* K7   */  be_nested_str_weak(Plugin_),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(register_plugin_class),
+    /* K10  */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(register_native_classes),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xA4120200,  //  0001  IMPORT	R4	K1
+      0x60140010,  //  0002  GETGBL	R5	G16
+      0x8C180702,  //  0003  GETMET	R6	R3	K2
+      0xB8220600,  //  0004  GETNGBL	R8	K3
+      0x7C180400,  //  0005  CALL	R6	2
+      0x7C140200,  //  0006  CALL	R5	1
+      0xA8020014,  //  0007  EXBLK	0	#001D
+      0x5C180A00,  //  0008  MOVE	R6	R5
+      0x7C180000,  //  0009  CALL	R6	0
+      0x8C1C0704,  //  000A  GETMET	R7	R3	K4
+      0xB8260600,  //  000B  GETNGBL	R9	K3
+      0x5C280C00,  //  000C  MOVE	R10	R6
+      0x7C1C0600,  //  000D  CALL	R7	3
+      0x60200004,  //  000E  GETGBL	R8	G4
+      0x5C240E00,  //  000F  MOVE	R9	R7
+      0x7C200200,  //  0010  CALL	R8	1
+      0x1C201105,  //  0011  EQ	R8	R8	K5
+      0x78220008,  //  0012  JMPF	R8	#001C
+      0x8C200906,  //  0013  GETMET	R8	R4	K6
+      0x5C280C00,  //  0014  MOVE	R10	R6
+      0x582C0007,  //  0015  LDCONST	R11	K7
+      0x7C200600,  //  0016  CALL	R8	3
+      0x1C201108,  //  0017  EQ	R8	R8	K8
+      0x78220002,  //  0018  JMPF	R8	#001C
+      0x8C200109,  //  0019  GETMET	R8	R0	K9
+      0x5C280E00,  //  001A  MOVE	R10	R7
+      0x7C200400,  //  001B  CALL	R8	2
+      0x7001FFEA,  //  001C  JMP		#0008
+      0x5814000A,  //  001D  LDCONST	R5	K10
+      0xAC140200,  //  001E  CATCH	R5	1	0
+      0xB0080000,  //  001F  RAISE	2	R0	R0
+      0x80000000,  //  0020  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _compute_pbkdf
+********************************************************************/
+be_local_closure(Matter_Device__compute_pbkdf,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(add),
+    /* K2   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
+    /* K3   */  be_nested_str_weak(derive),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(root_w0),
+    /* K6   */  be_nested_str_weak(EC_P256),
+    /* K7   */  be_nested_str_weak(mod),
+    /* K8   */  be_nested_str_weak(root_L),
+    /* K9   */  be_nested_str_weak(public_key),
+    }),
+    be_str_weak(_compute_pbkdf),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0xA4120000,  //  0000  IMPORT	R4	K0
+      0x60140015,  //  0001  GETGBL	R5	G21
+      0x7C140000,  //  0002  CALL	R5	0
+      0x8C140B01,  //  0003  GETMET	R5	R5	K1
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x54220003,  //  0005  LDINT	R8	4
+      0x7C140600,  //  0006  CALL	R5	3
+      0x8C180902,  //  0007  GETMET	R6	R4	K2
+      0x7C180200,  //  0008  CALL	R6	1
+      0x8C180D03,  //  0009  GETMET	R6	R6	K3
+      0x5C200A00,  //  000A  MOVE	R8	R5
+      0x5C240600,  //  000B  MOVE	R9	R3
+      0x5C280400,  //  000C  MOVE	R10	R2
+      0x542E004F,  //  000D  LDINT	R11	80
+      0x7C180A00,  //  000E  CALL	R6	5
+      0x541E0026,  //  000F  LDINT	R7	39
+      0x401E0807,  //  0010  CONNECT	R7	K4	R7
+      0x941C0C07,  //  0011  GETIDX	R7	R6	R7
+      0x54220027,  //  0012  LDINT	R8	40
+      0x5426004E,  //  0013  LDINT	R9	79
+      0x40201009,  //  0014  CONNECT	R8	R8	R9
+      0x94200C08,  //  0015  GETIDX	R8	R6	R8
+      0x8C240906,  //  0016  GETMET	R9	R4	K6
+      0x7C240200,  //  0017  CALL	R9	1
+      0x8C241307,  //  0018  GETMET	R9	R9	K7
+      0x5C2C0E00,  //  0019  MOVE	R11	R7
+      0x7C240400,  //  001A  CALL	R9	2
+      0x90020A09,  //  001B  SETMBR	R0	K5	R9
+      0x8C240906,  //  001C  GETMET	R9	R4	K6
+      0x7C240200,  //  001D  CALL	R9	1
+      0x8C241307,  //  001E  GETMET	R9	R9	K7
+      0x5C2C1000,  //  001F  MOVE	R11	R8
+      0x7C240400,  //  0020  CALL	R9	2
+      0x8C280906,  //  0021  GETMET	R10	R4	K6
+      0x7C280200,  //  0022  CALL	R10	1
+      0x8C281509,  //  0023  GETMET	R10	R10	K9
+      0x5C301200,  //  0024  MOVE	R12	R9
+      0x7C280400,  //  0025  CALL	R10	2
+      0x9002100A,  //  0026  SETMBR	R0	K8	R10
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(Matter_Device_every_250ms,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(every_250ms),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(plugins),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x58040002,  //  0003  LDCONST	R1	K2
+      0x6008000C,  //  0004  GETGBL	R2	G12
+      0x880C0103,  //  0005  GETMBR	R3	R0	K3
+      0x7C080200,  //  0006  CALL	R2	1
+      0x14080202,  //  0007  LT	R2	R1	R2
+      0x780A0005,  //  0008  JMPF	R2	#000F
+      0x88080103,  //  0009  GETMBR	R2	R0	K3
+      0x94080401,  //  000A  GETIDX	R2	R2	R1
+      0x8C080501,  //  000B  GETMET	R2	R2	K1
+      0x7C080200,  //  000C  CALL	R2	1
+      0x00040304,  //  000D  ADD	R1	R1	K4
+      0x7001FFF4,  //  000E  JMP		#0004
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_remove_PASE
+********************************************************************/
+be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[20]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(mdns_pase_eth),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eremove_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
+    /* K5   */  be_nested_str_weak(_matterc),
+    /* K6   */  be_nested_str_weak(_udp),
+    /* K7   */  be_nested_str_weak(commissioning_instance_eth),
+    /* K8   */  be_nested_str_weak(hostname_eth),
+    /* K9   */  be_const_int(3),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
+    /* K11  */  be_nested_str_weak(eth),
+    /* K12  */  be_nested_str_weak(remove_service),
+    /* K13  */  be_nested_str_weak(mdns_pase_wifi),
+    /* K14  */  be_nested_str_weak(commissioning_instance_wifi),
+    /* K15  */  be_nested_str_weak(hostname_wifi),
+    /* K16  */  be_nested_str_weak(wifi),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K18  */  be_nested_str_weak(_X7C),
+    /* K19  */  be_const_int(2),
+    }),
+    be_str_weak(mdns_remove_PASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[82]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA802003D,  //  0001  EXBLK	0	#0040
+      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x780A001B,  //  0003  JMPF	R2	#0020
+      0xB80A0400,  //  0004  GETNGBL	R2	K2
+      0x8C080503,  //  0005  GETMET	R2	R2	K3
+      0x60100018,  //  0006  GETGBL	R4	G24
+      0x58140004,  //  0007  LDCONST	R5	K4
+      0x58180005,  //  0008  LDCONST	R6	K5
+      0x581C0006,  //  0009  LDCONST	R7	K6
+      0x88200107,  //  000A  GETMBR	R8	R0	K7
+      0x88240108,  //  000B  GETMBR	R9	R0	K8
+      0x7C100A00,  //  000C  CALL	R4	5
+      0x58140009,  //  000D  LDCONST	R5	K9
+      0x7C080600,  //  000E  CALL	R2	3
+      0xB80A0400,  //  000F  GETNGBL	R2	K2
+      0x8C080503,  //  0010  GETMET	R2	R2	K3
+      0x60100018,  //  0011  GETGBL	R4	G24
+      0x5814000A,  //  0012  LDCONST	R5	K10
+      0x5818000B,  //  0013  LDCONST	R6	K11
+      0x881C0107,  //  0014  GETMBR	R7	R0	K7
+      0x7C100600,  //  0015  CALL	R4	3
+      0x58140009,  //  0016  LDCONST	R5	K9
+      0x7C080600,  //  0017  CALL	R2	3
+      0x50080000,  //  0018  LDBOOL	R2	0	0
+      0x90020202,  //  0019  SETMBR	R0	K1	R2
+      0x8C08030C,  //  001A  GETMET	R2	R1	K12
+      0x58100005,  //  001B  LDCONST	R4	K5
+      0x58140006,  //  001C  LDCONST	R5	K6
+      0x88180107,  //  001D  GETMBR	R6	R0	K7
+      0x881C0108,  //  001E  GETMBR	R7	R0	K8
+      0x7C080A00,  //  001F  CALL	R2	5
+      0x8808010D,  //  0020  GETMBR	R2	R0	K13
+      0x780A001B,  //  0021  JMPF	R2	#003E
+      0xB80A0400,  //  0022  GETNGBL	R2	K2
+      0x8C080503,  //  0023  GETMET	R2	R2	K3
+      0x60100018,  //  0024  GETGBL	R4	G24
+      0x58140004,  //  0025  LDCONST	R5	K4
+      0x58180005,  //  0026  LDCONST	R6	K5
+      0x581C0006,  //  0027  LDCONST	R7	K6
+      0x8820010E,  //  0028  GETMBR	R8	R0	K14
+      0x8824010F,  //  0029  GETMBR	R9	R0	K15
+      0x7C100A00,  //  002A  CALL	R4	5
+      0x58140009,  //  002B  LDCONST	R5	K9
+      0x7C080600,  //  002C  CALL	R2	3
+      0xB80A0400,  //  002D  GETNGBL	R2	K2
+      0x8C080503,  //  002E  GETMET	R2	R2	K3
+      0x60100018,  //  002F  GETGBL	R4	G24
+      0x5814000A,  //  0030  LDCONST	R5	K10
+      0x58180010,  //  0031  LDCONST	R6	K16
+      0x881C010E,  //  0032  GETMBR	R7	R0	K14
+      0x7C100600,  //  0033  CALL	R4	3
+      0x58140009,  //  0034  LDCONST	R5	K9
+      0x7C080600,  //  0035  CALL	R2	3
+      0x50080000,  //  0036  LDBOOL	R2	0	0
+      0x90021A02,  //  0037  SETMBR	R0	K13	R2
+      0x8C08030C,  //  0038  GETMET	R2	R1	K12
+      0x58100005,  //  0039  LDCONST	R4	K5
+      0x58140006,  //  003A  LDCONST	R5	K6
+      0x8818010E,  //  003B  GETMBR	R6	R0	K14
+      0x881C010F,  //  003C  GETMBR	R7	R0	K15
+      0x7C080A00,  //  003D  CALL	R2	5
+      0xA8040001,  //  003E  EXBLK	1	1
+      0x70020010,  //  003F  JMP		#0051
+      0xAC080002,  //  0040  CATCH	R2	0	2
+      0x7002000D,  //  0041  JMP		#0050
+      0xB8120400,  //  0042  GETNGBL	R4	K2
+      0x8C100903,  //  0043  GETMET	R4	R4	K3
+      0x60180008,  //  0044  GETGBL	R6	G8
+      0x5C1C0400,  //  0045  MOVE	R7	R2
+      0x7C180200,  //  0046  CALL	R6	1
+      0x001A2206,  //  0047  ADD	R6	K17	R6
+      0x00180D12,  //  0048  ADD	R6	R6	K18
+      0x601C0008,  //  0049  GETGBL	R7	G8
+      0x5C200600,  //  004A  MOVE	R8	R3
+      0x7C1C0200,  //  004B  CALL	R7	1
+      0x00180C07,  //  004C  ADD	R6	R6	R7
+      0x581C0013,  //  004D  LDCONST	R7	K19
+      0x7C100600,  //  004E  CALL	R4	3
+      0x70020000,  //  004F  JMP		#0051
+      0xB0080000,  //  0050  RAISE	2	R0	R0
+      0x80000000,  //  0051  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _instantiate_plugins_from_config
+********************************************************************/
+be_local_closure(Matter_Device__instantiate_plugins_from_config,   /* name */
+  be_nested_proto(
+    18,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[30]) {     /* constants */
+    /* K0   */  be_nested_str_weak(k2l_num),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20Configuring_X20endpoints),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_nested_str_weak(plugins),
+    /* K6   */  be_nested_str_weak(push),
+    /* K7   */  be_nested_str_weak(matter),
+    /* K8   */  be_nested_str_weak(Plugin_Root),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X20_X20endpoint_X20_X3D_X20_X255i_X20type_X3A_X25s_X25s),
+    /* K11  */  be_nested_str_weak(root),
+    /* K12  */  be_nested_str_weak(),
+    /* K13  */  be_nested_str_weak(Plugin_Aggregator),
+    /* K14  */  be_nested_str_weak(find),
+    /* K15  */  be_nested_str_weak(type),
+    /* K16  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
+    /* K17  */  be_const_int(3),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20only_X20one_X20root_X20node_X20allowed),
+    /* K19  */  be_nested_str_weak(plugins_classes),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+    /* K21  */  be_nested_str_weak(_X27_X20skipping),
+    /* K22  */  be_nested_str_weak(conf_to_log),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K24  */  be_nested_str_weak(_X7C),
+    /* K25  */  be_nested_str_weak(stop_iteration),
+    /* K26  */  be_nested_str_weak(aggregator),
+    /* K27  */  be_nested_str_weak(publish_result),
+    /* K28  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
+    /* K29  */  be_nested_str_weak(Matter),
+    }),
+    be_str_weak(_instantiate_plugins_from_config),
+    &be_const_str_solidified,
+    ( &(const binstruction[152]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0xB80E0200,  //  0003  GETNGBL	R3	K1
+      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x58180004,  //  0006  LDCONST	R6	K4
+      0x7C0C0600,  //  0007  CALL	R3	3
+      0x880C0105,  //  0008  GETMBR	R3	R0	K5
+      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
+      0xB8160E00,  //  000A  GETNGBL	R5	K7
+      0x8C140B08,  //  000B  GETMET	R5	R5	K8
+      0x5C1C0000,  //  000C  MOVE	R7	R0
+      0x58200009,  //  000D  LDCONST	R8	K9
+      0x60240013,  //  000E  GETGBL	R9	G19
+      0x7C240000,  //  000F  CALL	R9	0
+      0x7C140800,  //  0010  CALL	R5	4
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0xB80E0200,  //  0012  GETNGBL	R3	K1
+      0x8C0C0702,  //  0013  GETMET	R3	R3	K2
+      0x60140018,  //  0014  GETGBL	R5	G24
+      0x5818000A,  //  0015  LDCONST	R6	K10
+      0x581C0009,  //  0016  LDCONST	R7	K9
+      0x5820000B,  //  0017  LDCONST	R8	K11
+      0x5824000C,  //  0018  LDCONST	R9	K12
+      0x7C140800,  //  0019  CALL	R5	4
+      0x58180004,  //  001A  LDCONST	R6	K4
+      0x7C0C0600,  //  001B  CALL	R3	3
+      0x880C0105,  //  001C  GETMBR	R3	R0	K5
+      0x8C0C0706,  //  001D  GETMET	R3	R3	K6
+      0xB8160E00,  //  001E  GETNGBL	R5	K7
+      0x8C140B0D,  //  001F  GETMET	R5	R5	K13
+      0x5C1C0000,  //  0020  MOVE	R7	R0
+      0x5422FEFF,  //  0021  LDINT	R8	65280
+      0x60240013,  //  0022  GETGBL	R9	G19
+      0x7C240000,  //  0023  CALL	R9	0
+      0x7C140800,  //  0024  CALL	R5	4
+      0x7C0C0400,  //  0025  CALL	R3	2
+      0x600C0010,  //  0026  GETGBL	R3	G16
+      0x5C100400,  //  0027  MOVE	R4	R2
+      0x7C0C0200,  //  0028  CALL	R3	1
+      0xA802005A,  //  0029  EXBLK	0	#0085
+      0x5C100600,  //  002A  MOVE	R4	R3
+      0x7C100000,  //  002B  CALL	R4	0
+      0x1C140909,  //  002C  EQ	R5	R4	K9
+      0x78160000,  //  002D  JMPF	R5	#002F
+      0x7001FFFA,  //  002E  JMP		#002A
+      0xA8020042,  //  002F  EXBLK	0	#0073
+      0x60140008,  //  0030  GETGBL	R5	G8
+      0x5C180800,  //  0031  MOVE	R6	R4
+      0x7C140200,  //  0032  CALL	R5	1
+      0x94140205,  //  0033  GETIDX	R5	R1	R5
+      0x8C180B0E,  //  0034  GETMET	R6	R5	K14
+      0x5820000F,  //  0035  LDCONST	R8	K15
+      0x7C180400,  //  0036  CALL	R6	2
+      0x4C1C0000,  //  0037  LDNIL	R7
+      0x1C1C0C07,  //  0038  EQ	R7	R6	R7
+      0x781E0006,  //  0039  JMPF	R7	#0041
+      0xB81E0200,  //  003A  GETNGBL	R7	K1
+      0x8C1C0F02,  //  003B  GETMET	R7	R7	K2
+      0x58240010,  //  003C  LDCONST	R9	K16
+      0x58280011,  //  003D  LDCONST	R10	K17
+      0x7C1C0600,  //  003E  CALL	R7	3
+      0xA8040001,  //  003F  EXBLK	1	1
+      0x7001FFE8,  //  0040  JMP		#002A
+      0x1C1C0D0B,  //  0041  EQ	R7	R6	K11
+      0x781E0006,  //  0042  JMPF	R7	#004A
+      0xB81E0200,  //  0043  GETNGBL	R7	K1
+      0x8C1C0F02,  //  0044  GETMET	R7	R7	K2
+      0x58240012,  //  0045  LDCONST	R9	K18
+      0x58280011,  //  0046  LDCONST	R10	K17
+      0x7C1C0600,  //  0047  CALL	R7	3
+      0xA8040001,  //  0048  EXBLK	1	1
+      0x7001FFDF,  //  0049  JMP		#002A
+      0x881C0113,  //  004A  GETMBR	R7	R0	K19
+      0x8C1C0F0E,  //  004B  GETMET	R7	R7	K14
+      0x5C240C00,  //  004C  MOVE	R9	R6
+      0x7C1C0400,  //  004D  CALL	R7	2
+      0x4C200000,  //  004E  LDNIL	R8
+      0x1C200E08,  //  004F  EQ	R8	R7	R8
+      0x7822000A,  //  0050  JMPF	R8	#005C
+      0xB8220200,  //  0051  GETNGBL	R8	K1
+      0x8C201102,  //  0052  GETMET	R8	R8	K2
+      0x60280008,  //  0053  GETGBL	R10	G8
+      0x5C2C0C00,  //  0054  MOVE	R11	R6
+      0x7C280200,  //  0055  CALL	R10	1
+      0x002A280A,  //  0056  ADD	R10	K20	R10
+      0x00281515,  //  0057  ADD	R10	R10	K21
+      0x582C0004,  //  0058  LDCONST	R11	K4
+      0x7C200600,  //  0059  CALL	R8	3
+      0xA8040001,  //  005A  EXBLK	1	1
+      0x7001FFCD,  //  005B  JMP		#002A
+      0x5C200E00,  //  005C  MOVE	R8	R7
+      0x5C240000,  //  005D  MOVE	R9	R0
+      0x5C280800,  //  005E  MOVE	R10	R4
+      0x5C2C0A00,  //  005F  MOVE	R11	R5
+      0x7C200600,  //  0060  CALL	R8	3
+      0x88240105,  //  0061  GETMBR	R9	R0	K5
+      0x8C241306,  //  0062  GETMET	R9	R9	K6
+      0x5C2C1000,  //  0063  MOVE	R11	R8
+      0x7C240400,  //  0064  CALL	R9	2
+      0xB8260200,  //  0065  GETNGBL	R9	K1
+      0x8C241302,  //  0066  GETMET	R9	R9	K2
+      0x602C0018,  //  0067  GETGBL	R11	G24
+      0x5830000A,  //  0068  LDCONST	R12	K10
+      0x5C340800,  //  0069  MOVE	R13	R4
+      0x5C380C00,  //  006A  MOVE	R14	R6
+      0x8C3C0116,  //  006B  GETMET	R15	R0	K22
+      0x5C440A00,  //  006C  MOVE	R17	R5
+      0x7C3C0400,  //  006D  CALL	R15	2
+      0x7C2C0800,  //  006E  CALL	R11	4
+      0x58300004,  //  006F  LDCONST	R12	K4
+      0x7C240600,  //  0070  CALL	R9	3
+      0xA8040001,  //  0071  EXBLK	1	1
+      0x70020010,  //  0072  JMP		#0084
+      0xAC140002,  //  0073  CATCH	R5	0	2
+      0x7002000D,  //  0074  JMP		#0083
+      0xB81E0200,  //  0075  GETNGBL	R7	K1
+      0x8C1C0F02,  //  0076  GETMET	R7	R7	K2
+      0x60240008,  //  0077  GETGBL	R9	G8
+      0x5C280A00,  //  0078  MOVE	R10	R5
+      0x7C240200,  //  0079  CALL	R9	1
+      0x00262E09,  //  007A  ADD	R9	K23	R9
+      0x00241318,  //  007B  ADD	R9	R9	K24
+      0x60280008,  //  007C  GETGBL	R10	G8
+      0x5C2C0C00,  //  007D  MOVE	R11	R6
+      0x7C280200,  //  007E  CALL	R10	1
+      0x0024120A,  //  007F  ADD	R9	R9	R10
+      0x58280004,  //  0080  LDCONST	R10	K4
+      0x7C1C0600,  //  0081  CALL	R7	3
+      0x70020000,  //  0082  JMP		#0084
+      0xB0080000,  //  0083  RAISE	2	R0	R0
+      0x7001FFA4,  //  0084  JMP		#002A
+      0x580C0019,  //  0085  LDCONST	R3	K25
+      0xAC0C0200,  //  0086  CATCH	R3	1	0
+      0xB0080000,  //  0087  RAISE	2	R0	R0
+      0xB80E0200,  //  0088  GETNGBL	R3	K1
+      0x8C0C0702,  //  0089  GETMET	R3	R3	K2
+      0x60140018,  //  008A  GETGBL	R5	G24
+      0x5818000A,  //  008B  LDCONST	R6	K10
+      0x541EFEFF,  //  008C  LDINT	R7	65280
+      0x5820001A,  //  008D  LDCONST	R8	K26
+      0x5824000C,  //  008E  LDCONST	R9	K12
+      0x7C140800,  //  008F  CALL	R5	4
+      0x58180004,  //  0090  LDCONST	R6	K4
+      0x7C0C0600,  //  0091  CALL	R3	3
+      0xB80E0200,  //  0092  GETNGBL	R3	K1
+      0x8C0C071B,  //  0093  GETMET	R3	R3	K27
+      0x5814001C,  //  0094  LDCONST	R5	K28
+      0x5818001D,  //  0095  LDCONST	R6	K29
+      0x7C0C0600,  //  0096  CALL	R3	3
+      0x80000000,  //  0097  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_root_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(PASE_TIMEOUT),
+    /* K1   */  be_nested_str_weak(compute_manual_pairing_code),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s),
+    /* K5   */  be_const_int(2),
+    /* K6   */  be_nested_str_weak(compute_qrcode_content),
+    /* K7   */  be_nested_str_weak(publish_result),
+    /* K8   */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A1_X2C_X22PairingCode_X22_X3A_X22_X25s_X22_X2C_X22QRCode_X22_X3A_X22_X25s_X22_X7D_X7D),
+    /* K9   */  be_nested_str_weak(Matter),
+    /* K10  */  be_nested_str_weak(_compute_pbkdf),
+    /* K11  */  be_nested_str_weak(root_passcode),
+    /* K12  */  be_nested_str_weak(root_iterations),
+    /* K13  */  be_nested_str_weak(root_salt),
+    /* K14  */  be_nested_str_weak(start_basic_commissioning),
+    /* K15  */  be_nested_str_weak(root_discriminator),
+    /* K16  */  be_nested_str_weak(root_w0),
+    /* K17  */  be_nested_str_weak(root_L),
+    }),
+    be_str_weak(start_root_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x88040100,  //  0003  GETMBR	R1	R0	K0
+      0x8C080101,  //  0004  GETMET	R2	R0	K1
+      0x7C080200,  //  0005  CALL	R2	1
+      0xB80E0400,  //  0006  GETNGBL	R3	K2
+      0x8C0C0703,  //  0007  GETMET	R3	R3	K3
+      0x60140018,  //  0008  GETGBL	R5	G24
+      0x58180004,  //  0009  LDCONST	R6	K4
+      0x5C1C0400,  //  000A  MOVE	R7	R2
+      0x7C140400,  //  000B  CALL	R5	2
+      0x58180005,  //  000C  LDCONST	R6	K5
+      0x7C0C0600,  //  000D  CALL	R3	3
+      0x8C0C0106,  //  000E  GETMET	R3	R0	K6
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0xB8120400,  //  0010  GETNGBL	R4	K2
+      0x8C100907,  //  0011  GETMET	R4	R4	K7
+      0x60180018,  //  0012  GETGBL	R6	G24
+      0x581C0008,  //  0013  LDCONST	R7	K8
+      0x5C200400,  //  0014  MOVE	R8	R2
+      0x5C240600,  //  0015  MOVE	R9	R3
+      0x7C180600,  //  0016  CALL	R6	3
+      0x581C0009,  //  0017  LDCONST	R7	K9
+      0x7C100600,  //  0018  CALL	R4	3
+      0x8C10010A,  //  0019  GETMET	R4	R0	K10
+      0x8818010B,  //  001A  GETMBR	R6	R0	K11
+      0x881C010C,  //  001B  GETMBR	R7	R0	K12
+      0x8820010D,  //  001C  GETMBR	R8	R0	K13
+      0x7C100800,  //  001D  CALL	R4	4
+      0x8C10010E,  //  001E  GETMET	R4	R0	K14
+      0x5C180200,  //  001F  MOVE	R6	R1
+      0x881C010C,  //  0020  GETMBR	R7	R0	K12
+      0x8820010F,  //  0021  GETMBR	R8	R0	K15
+      0x8824010D,  //  0022  GETMBR	R9	R0	K13
+      0x88280110,  //  0023  GETMBR	R10	R0	K16
+      0x882C0111,  //  0024  GETMBR	R11	R0	K17
+      0x4C300000,  //  0025  LDNIL	R12
+      0x7C101000,  //  0026  CALL	R4	8
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: compute_qrcode_content
+********************************************************************/
+be_local_closure(Matter_Device_compute_qrcode_content,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(resize),
+    /* K1   */  be_nested_str_weak(setbits),
+    /* K2   */  be_const_int(3),
+    /* K3   */  be_nested_str_weak(vendorid),
+    /* K4   */  be_nested_str_weak(productid),
+    /* K5   */  be_nested_str_weak(root_discriminator),
+    /* K6   */  be_nested_str_weak(root_passcode),
+    /* K7   */  be_const_int(134217727),
+    /* K8   */  be_nested_str_weak(MT_X3A),
+    /* K9   */  be_nested_str_weak(matter),
+    /* K10  */  be_nested_str_weak(Base38),
+    /* K11  */  be_nested_str_weak(encode),
+    }),
+    be_str_weak(compute_qrcode_content),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0x60040015,  //  0000  GETGBL	R1	G21
+      0x7C040000,  //  0001  CALL	R1	0
+      0x8C040300,  //  0002  GETMET	R1	R1	K0
+      0x540E000A,  //  0003  LDINT	R3	11
+      0x7C040400,  //  0004  CALL	R1	2
+      0x8C080301,  //  0005  GETMET	R2	R1	K1
+      0x58100002,  //  0006  LDCONST	R4	K2
+      0x5416000F,  //  0007  LDINT	R5	16
+      0x88180103,  //  0008  GETMBR	R6	R0	K3
+      0x7C080800,  //  0009  CALL	R2	4
+      0x8C080301,  //  000A  GETMET	R2	R1	K1
+      0x54120012,  //  000B  LDINT	R4	19
+      0x5416000F,  //  000C  LDINT	R5	16
+      0x88180104,  //  000D  GETMBR	R6	R0	K4
+      0x7C080800,  //  000E  CALL	R2	4
+      0x8C080301,  //  000F  GETMET	R2	R1	K1
+      0x54120024,  //  0010  LDINT	R4	37
+      0x54160007,  //  0011  LDINT	R5	8
+      0x541A0003,  //  0012  LDINT	R6	4
+      0x7C080800,  //  0013  CALL	R2	4
+      0x8C080301,  //  0014  GETMET	R2	R1	K1
+      0x5412002C,  //  0015  LDINT	R4	45
+      0x5416000B,  //  0016  LDINT	R5	12
+      0x88180105,  //  0017  GETMBR	R6	R0	K5
+      0x541E0FFE,  //  0018  LDINT	R7	4095
+      0x2C180C07,  //  0019  AND	R6	R6	R7
+      0x7C080800,  //  001A  CALL	R2	4
+      0x8C080301,  //  001B  GETMET	R2	R1	K1
+      0x54120038,  //  001C  LDINT	R4	57
+      0x5416001A,  //  001D  LDINT	R5	27
+      0x88180106,  //  001E  GETMBR	R6	R0	K6
+      0x2C180D07,  //  001F  AND	R6	R6	K7
+      0x7C080800,  //  0020  CALL	R2	4
+      0xB80A1200,  //  0021  GETNGBL	R2	K9
+      0x8808050A,  //  0022  GETMBR	R2	R2	K10
+      0x8C08050B,  //  0023  GETMET	R2	R2	K11
+      0x5C100200,  //  0024  MOVE	R4	R1
+      0x7C080400,  //  0025  CALL	R2	2
+      0x000A1002,  //  0026  ADD	R2	K8	R2
+      0x80040400,  //  0027  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: bridge_remove_endpoint
+********************************************************************/
+be_local_closure(Matter_Device_bridge_remove_endpoint,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(plugins_config),
+    /* K2   */  be_nested_str_weak(contains),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
+    /* K6   */  be_const_int(3),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
+    /* K8   */  be_const_int(2),
+    /* K9   */  be_nested_str_weak(remove),
+    /* K10  */  be_nested_str_weak(plugins_persist),
+    /* K11  */  be_nested_str_weak(save_param),
+    /* K12  */  be_nested_str_weak(signal_endpoints_changed),
+    /* K13  */  be_const_int(0),
+    /* K14  */  be_nested_str_weak(plugins),
+    /* K15  */  be_nested_str_weak(get_endpoint),
+    /* K16  */  be_const_int(1),
+    /* K17  */  be_nested_str_weak(clean_remotes),
+    }),
+    be_str_weak(bridge_remove_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[60]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x600C0008,  //  0001  GETGBL	R3	G8
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x4C100000,  //  0004  LDNIL	R4
+      0x4C140000,  //  0005  LDNIL	R5
+      0x88180101,  //  0006  GETMBR	R6	R0	K1
+      0x8C180D02,  //  0007  GETMET	R6	R6	K2
+      0x5C200600,  //  0008  MOVE	R8	R3
+      0x7C180400,  //  0009  CALL	R6	2
+      0x741A0005,  //  000A  JMPT	R6	#0011
+      0xB81A0600,  //  000B  GETNGBL	R6	K3
+      0x8C180D04,  //  000C  GETMET	R6	R6	K4
+      0x00220A03,  //  000D  ADD	R8	K5	R3
+      0x58240006,  //  000E  LDCONST	R9	K6
+      0x7C180600,  //  000F  CALL	R6	3
+      0x80000C00,  //  0010  RET	0
+      0xB81A0600,  //  0011  GETNGBL	R6	K3
+      0x8C180D04,  //  0012  GETMET	R6	R6	K4
+      0x60200018,  //  0013  GETGBL	R8	G24
+      0x58240007,  //  0014  LDCONST	R9	K7
+      0x5C280200,  //  0015  MOVE	R10	R1
+      0x7C200400,  //  0016  CALL	R8	2
+      0x58240008,  //  0017  LDCONST	R9	K8
+      0x7C180600,  //  0018  CALL	R6	3
+      0x88180101,  //  0019  GETMBR	R6	R0	K1
+      0x8C180D09,  //  001A  GETMET	R6	R6	K9
+      0x5C200600,  //  001B  MOVE	R8	R3
+      0x7C180400,  //  001C  CALL	R6	2
+      0x50180200,  //  001D  LDBOOL	R6	1	0
+      0x90021406,  //  001E  SETMBR	R0	K10	R6
+      0x8C18010B,  //  001F  GETMET	R6	R0	K11
+      0x7C180200,  //  0020  CALL	R6	1
+      0x8C18010C,  //  0021  GETMET	R6	R0	K12
+      0x7C180200,  //  0022  CALL	R6	1
+      0x5818000D,  //  0023  LDCONST	R6	K13
+      0x601C000C,  //  0024  GETGBL	R7	G12
+      0x8820010E,  //  0025  GETMBR	R8	R0	K14
+      0x7C1C0200,  //  0026  CALL	R7	1
+      0x141C0C07,  //  0027  LT	R7	R6	R7
+      0x781E000F,  //  0028  JMPF	R7	#0039
+      0x881C010E,  //  0029  GETMBR	R7	R0	K14
+      0x941C0E06,  //  002A  GETIDX	R7	R7	R6
+      0x8C1C0F0F,  //  002B  GETMET	R7	R7	K15
+      0x7C1C0200,  //  002C  CALL	R7	1
+      0x1C1C0207,  //  002D  EQ	R7	R1	R7
+      0x781E0007,  //  002E  JMPF	R7	#0037
+      0x881C010E,  //  002F  GETMBR	R7	R0	K14
+      0x8C1C0F09,  //  0030  GETMET	R7	R7	K9
+      0x5C240C00,  //  0031  MOVE	R9	R6
+      0x7C1C0400,  //  0032  CALL	R7	2
+      0x8C1C010C,  //  0033  GETMET	R7	R0	K12
+      0x7C1C0200,  //  0034  CALL	R7	1
+      0x70020002,  //  0035  JMP		#0039
+      0x70020000,  //  0036  JMP		#0038
+      0x00180D10,  //  0037  ADD	R6	R6	K16
+      0x7001FFEA,  //  0038  JMP		#0024
+      0x8C1C0111,  //  0039  GETMET	R7	R0	K17
+      0x7C1C0200,  //  003A  CALL	R7	1
+      0x80000000,  //  003B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sort_distinct
+********************************************************************/
+be_local_closure(Matter_Device_sort_distinct,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Device),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_nested_str_weak(remove),
+    }),
+    be_str_weak(sort_distinct),
+    &be_const_str_solidified,
+    ( &(const binstruction[53]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x60080010,  //  0001  GETGBL	R2	G16
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x040C0701,  //  0005  SUB	R3	R3	K1
+      0x400E0203,  //  0006  CONNECT	R3	K1	R3
+      0x7C080200,  //  0007  CALL	R2	1
+      0xA8020010,  //  0008  EXBLK	0	#001A
+      0x5C0C0400,  //  0009  MOVE	R3	R2
+      0x7C0C0000,  //  000A  CALL	R3	0
+      0x94100003,  //  000B  GETIDX	R4	R0	R3
+      0x5C140600,  //  000C  MOVE	R5	R3
+      0x24180B02,  //  000D  GT	R6	R5	K2
+      0x781A0008,  //  000E  JMPF	R6	#0018
+      0x04180B01,  //  000F  SUB	R6	R5	K1
+      0x94180006,  //  0010  GETIDX	R6	R0	R6
+      0x24180C04,  //  0011  GT	R6	R6	R4
+      0x781A0004,  //  0012  JMPF	R6	#0018
+      0x04180B01,  //  0013  SUB	R6	R5	K1
+      0x94180006,  //  0014  GETIDX	R6	R0	R6
+      0x98000A06,  //  0015  SETIDX	R0	R5	R6
+      0x04140B01,  //  0016  SUB	R5	R5	K1
+      0x7001FFF4,  //  0017  JMP		#000D
+      0x98000A04,  //  0018  SETIDX	R0	R5	R4
+      0x7001FFEE,  //  0019  JMP		#0009
+      0x58080003,  //  001A  LDCONST	R2	K3
+      0xAC080200,  //  001B  CATCH	R2	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x58080001,  //  001D  LDCONST	R2	K1
+      0x600C000C,  //  001E  GETGBL	R3	G12
+      0x5C100000,  //  001F  MOVE	R4	R0
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x180C0701,  //  0021  LE	R3	R3	K1
+      0x780E0000,  //  0022  JMPF	R3	#0024
+      0x80040000,  //  0023  RET	1	R0
+      0x940C0102,  //  0024  GETIDX	R3	R0	K2
+      0x6010000C,  //  0025  GETGBL	R4	G12
+      0x5C140000,  //  0026  MOVE	R5	R0
+      0x7C100200,  //  0027  CALL	R4	1
+      0x14100404,  //  0028  LT	R4	R2	R4
+      0x78120009,  //  0029  JMPF	R4	#0034
+      0x94100002,  //  002A  GETIDX	R4	R0	R2
+      0x1C100803,  //  002B  EQ	R4	R4	R3
+      0x78120003,  //  002C  JMPF	R4	#0031
+      0x8C100104,  //  002D  GETMET	R4	R0	K4
+      0x5C180400,  //  002E  MOVE	R6	R2
+      0x7C100400,  //  002F  CALL	R4	2
+      0x70020001,  //  0030  JMP		#0033
+      0x940C0002,  //  0031  GETIDX	R3	R0	R2
+      0x00080501,  //  0032  ADD	R2	R2	K1
+      0x7001FFF0,  //  0033  JMP		#0025
+      0x80040000,  //  0034  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_announce_PASE
+********************************************************************/
+be_local_closure(Matter_Device_mdns_announce_PASE,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[41]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(crypto),
+    /* K2   */  be_nested_str_weak(VP),
+    /* K3   */  be_nested_str_weak(vendorid),
+    /* K4   */  be_nested_str_weak(_X2B),
+    /* K5   */  be_nested_str_weak(productid),
+    /* K6   */  be_nested_str_weak(D),
+    /* K7   */  be_nested_str_weak(commissioning_discriminator),
+    /* K8   */  be_nested_str_weak(CM),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(T),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_weak(SII),
+    /* K13  */  be_nested_str_weak(SAI),
+    /* K14  */  be_nested_str_weak(commissioning_instance_wifi),
+    /* K15  */  be_nested_str_weak(random),
+    /* K16  */  be_nested_str_weak(tohex),
+    /* K17  */  be_nested_str_weak(commissioning_instance_eth),
+    /* K18  */  be_nested_str_weak(hostname_eth),
+    /* K19  */  be_nested_str_weak(add_service),
+    /* K20  */  be_nested_str_weak(_matterc),
+    /* K21  */  be_nested_str_weak(_udp),
+    /* K22  */  be_nested_str_weak(mdns_pase_eth),
+    /* K23  */  be_nested_str_weak(tasmota),
+    /* K24  */  be_nested_str_weak(log),
+    /* K25  */  be_nested_str_weak(MTR_X3A_X20announce_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K26  */  be_nested_str_weak(eth),
+    /* K27  */  be_const_int(2),
+    /* K28  */  be_nested_str_weak(_L),
+    /* K29  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
+    /* K30  */  be_const_int(3),
+    /* K31  */  be_nested_str_weak(add_subtype),
+    /* K32  */  be_nested_str_weak(_S),
+    /* K33  */  be_nested_str_weak(_V),
+    /* K34  */  be_nested_str_weak(_CM1),
+    /* K35  */  be_nested_str_weak(hostname_wifi),
+    /* K36  */  be_nested_str_weak(mdns_pase_wifi),
+    /* K37  */  be_nested_str_weak(MTR_X3A_X20starting_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K38  */  be_nested_str_weak(wifi),
+    /* K39  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K40  */  be_nested_str_weak(_X7C),
+    }),
+    be_str_weak(mdns_announce_PASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[236]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0x600C0013,  //  0002  GETGBL	R3	G19
+      0x7C0C0000,  //  0003  CALL	R3	0
+      0x60100008,  //  0004  GETGBL	R4	G8
+      0x88140103,  //  0005  GETMBR	R5	R0	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x00100904,  //  0007  ADD	R4	R4	K4
+      0x60140008,  //  0008  GETGBL	R5	G8
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x7C140200,  //  000A  CALL	R5	1
+      0x00100805,  //  000B  ADD	R4	R4	R5
+      0x980E0404,  //  000C  SETIDX	R3	K2	R4
+      0x88100107,  //  000D  GETMBR	R4	R0	K7
+      0x980E0C04,  //  000E  SETIDX	R3	K6	R4
+      0x980E1109,  //  000F  SETIDX	R3	K8	K9
+      0x980E150B,  //  0010  SETIDX	R3	K10	K11
+      0x54121387,  //  0011  LDINT	R4	5000
+      0x980E1804,  //  0012  SETIDX	R3	K12	R4
+      0x5412012B,  //  0013  LDINT	R4	300
+      0x980E1A04,  //  0014  SETIDX	R3	K13	R4
+      0x8C10050F,  //  0015  GETMET	R4	R2	K15
+      0x541A0007,  //  0016  LDINT	R6	8
+      0x7C100400,  //  0017  CALL	R4	2
+      0x8C100910,  //  0018  GETMET	R4	R4	K16
+      0x7C100200,  //  0019  CALL	R4	1
+      0x90021C04,  //  001A  SETMBR	R0	K14	R4
+      0x8C10050F,  //  001B  GETMET	R4	R2	K15
+      0x541A0007,  //  001C  LDINT	R6	8
+      0x7C100400,  //  001D  CALL	R4	2
+      0x8C100910,  //  001E  GETMET	R4	R4	K16
+      0x7C100200,  //  001F  CALL	R4	1
+      0x90022204,  //  0020  SETMBR	R0	K17	R4
+      0xA80200B7,  //  0021  EXBLK	0	#00DA
+      0x88100112,  //  0022  GETMBR	R4	R0	K18
+      0x78120058,  //  0023  JMPF	R4	#007D
+      0x8C100313,  //  0024  GETMET	R4	R1	K19
+      0x58180014,  //  0025  LDCONST	R6	K20
+      0x581C0015,  //  0026  LDCONST	R7	K21
+      0x542215A3,  //  0027  LDINT	R8	5540
+      0x5C240600,  //  0028  MOVE	R9	R3
+      0x88280111,  //  0029  GETMBR	R10	R0	K17
+      0x882C0112,  //  002A  GETMBR	R11	R0	K18
+      0x7C100E00,  //  002B  CALL	R4	7
+      0x50100200,  //  002C  LDBOOL	R4	1	0
+      0x90022C04,  //  002D  SETMBR	R0	K22	R4
+      0xB8122E00,  //  002E  GETNGBL	R4	K23
+      0x8C100918,  //  002F  GETMET	R4	R4	K24
+      0x60180018,  //  0030  GETGBL	R6	G24
+      0x581C0019,  //  0031  LDCONST	R7	K25
+      0x5820001A,  //  0032  LDCONST	R8	K26
+      0x88240111,  //  0033  GETMBR	R9	R0	K17
+      0x88280112,  //  0034  GETMBR	R10	R0	K18
+      0x7C180800,  //  0035  CALL	R6	4
+      0x581C001B,  //  0036  LDCONST	R7	K27
+      0x7C100600,  //  0037  CALL	R4	3
+      0x60100008,  //  0038  GETGBL	R4	G8
+      0x88140107,  //  0039  GETMBR	R5	R0	K7
+      0x541A0FFE,  //  003A  LDINT	R6	4095
+      0x2C140A06,  //  003B  AND	R5	R5	R6
+      0x7C100200,  //  003C  CALL	R4	1
+      0x00123804,  //  003D  ADD	R4	K28	R4
+      0xB8162E00,  //  003E  GETNGBL	R5	K23
+      0x8C140B18,  //  003F  GETMET	R5	R5	K24
+      0x001E3A04,  //  0040  ADD	R7	K29	R4
+      0x5820001E,  //  0041  LDCONST	R8	K30
+      0x7C140600,  //  0042  CALL	R5	3
+      0x8C14031F,  //  0043  GETMET	R5	R1	K31
+      0x581C0014,  //  0044  LDCONST	R7	K20
+      0x58200015,  //  0045  LDCONST	R8	K21
+      0x88240111,  //  0046  GETMBR	R9	R0	K17
+      0x88280112,  //  0047  GETMBR	R10	R0	K18
+      0x5C2C0800,  //  0048  MOVE	R11	R4
+      0x7C140C00,  //  0049  CALL	R5	6
+      0x60140008,  //  004A  GETGBL	R5	G8
+      0x88180107,  //  004B  GETMBR	R6	R0	K7
+      0x541E0EFF,  //  004C  LDINT	R7	3840
+      0x2C180C07,  //  004D  AND	R6	R6	R7
+      0x541E0007,  //  004E  LDINT	R7	8
+      0x3C180C07,  //  004F  SHR	R6	R6	R7
+      0x7C140200,  //  0050  CALL	R5	1
+      0x00164005,  //  0051  ADD	R5	K32	R5
+      0x5C100A00,  //  0052  MOVE	R4	R5
+      0xB8162E00,  //  0053  GETNGBL	R5	K23
+      0x8C140B18,  //  0054  GETMET	R5	R5	K24
+      0x001E3A04,  //  0055  ADD	R7	K29	R4
+      0x5820001E,  //  0056  LDCONST	R8	K30
+      0x7C140600,  //  0057  CALL	R5	3
+      0x8C14031F,  //  0058  GETMET	R5	R1	K31
+      0x581C0014,  //  0059  LDCONST	R7	K20
+      0x58200015,  //  005A  LDCONST	R8	K21
+      0x88240111,  //  005B  GETMBR	R9	R0	K17
+      0x88280112,  //  005C  GETMBR	R10	R0	K18
+      0x5C2C0800,  //  005D  MOVE	R11	R4
+      0x7C140C00,  //  005E  CALL	R5	6
+      0x60140008,  //  005F  GETGBL	R5	G8
+      0x88180103,  //  0060  GETMBR	R6	R0	K3
+      0x7C140200,  //  0061  CALL	R5	1
+      0x00164205,  //  0062  ADD	R5	K33	R5
+      0x5C100A00,  //  0063  MOVE	R4	R5
+      0xB8162E00,  //  0064  GETNGBL	R5	K23
+      0x8C140B18,  //  0065  GETMET	R5	R5	K24
+      0x001E3A04,  //  0066  ADD	R7	K29	R4
+      0x5820001E,  //  0067  LDCONST	R8	K30
+      0x7C140600,  //  0068  CALL	R5	3
+      0x8C14031F,  //  0069  GETMET	R5	R1	K31
+      0x581C0014,  //  006A  LDCONST	R7	K20
+      0x58200015,  //  006B  LDCONST	R8	K21
+      0x88240111,  //  006C  GETMBR	R9	R0	K17
+      0x88280112,  //  006D  GETMBR	R10	R0	K18
+      0x5C2C0800,  //  006E  MOVE	R11	R4
+      0x7C140C00,  //  006F  CALL	R5	6
+      0x58100022,  //  0070  LDCONST	R4	K34
+      0xB8162E00,  //  0071  GETNGBL	R5	K23
+      0x8C140B18,  //  0072  GETMET	R5	R5	K24
+      0x001E3A04,  //  0073  ADD	R7	K29	R4
+      0x5820001E,  //  0074  LDCONST	R8	K30
+      0x7C140600,  //  0075  CALL	R5	3
+      0x8C14031F,  //  0076  GETMET	R5	R1	K31
+      0x581C0014,  //  0077  LDCONST	R7	K20
+      0x58200015,  //  0078  LDCONST	R8	K21
+      0x88240111,  //  0079  GETMBR	R9	R0	K17
+      0x88280112,  //  007A  GETMBR	R10	R0	K18
+      0x5C2C0800,  //  007B  MOVE	R11	R4
+      0x7C140C00,  //  007C  CALL	R5	6
+      0x88100123,  //  007D  GETMBR	R4	R0	K35
+      0x78120058,  //  007E  JMPF	R4	#00D8
+      0x8C100313,  //  007F  GETMET	R4	R1	K19
+      0x58180014,  //  0080  LDCONST	R6	K20
+      0x581C0015,  //  0081  LDCONST	R7	K21
+      0x542215A3,  //  0082  LDINT	R8	5540
+      0x5C240600,  //  0083  MOVE	R9	R3
+      0x8828010E,  //  0084  GETMBR	R10	R0	K14
+      0x882C0123,  //  0085  GETMBR	R11	R0	K35
+      0x7C100E00,  //  0086  CALL	R4	7
+      0x50100200,  //  0087  LDBOOL	R4	1	0
+      0x90024804,  //  0088  SETMBR	R0	K36	R4
+      0xB8122E00,  //  0089  GETNGBL	R4	K23
+      0x8C100918,  //  008A  GETMET	R4	R4	K24
+      0x60180018,  //  008B  GETGBL	R6	G24
+      0x581C0025,  //  008C  LDCONST	R7	K37
+      0x58200026,  //  008D  LDCONST	R8	K38
+      0x8824010E,  //  008E  GETMBR	R9	R0	K14
+      0x88280123,  //  008F  GETMBR	R10	R0	K35
+      0x7C180800,  //  0090  CALL	R6	4
+      0x581C001E,  //  0091  LDCONST	R7	K30
+      0x7C100600,  //  0092  CALL	R4	3
+      0x60100008,  //  0093  GETGBL	R4	G8
+      0x88140107,  //  0094  GETMBR	R5	R0	K7
+      0x541A0FFE,  //  0095  LDINT	R6	4095
+      0x2C140A06,  //  0096  AND	R5	R5	R6
+      0x7C100200,  //  0097  CALL	R4	1
+      0x00123804,  //  0098  ADD	R4	K28	R4
+      0xB8162E00,  //  0099  GETNGBL	R5	K23
+      0x8C140B18,  //  009A  GETMET	R5	R5	K24
+      0x001E3A04,  //  009B  ADD	R7	K29	R4
+      0x5820001E,  //  009C  LDCONST	R8	K30
+      0x7C140600,  //  009D  CALL	R5	3
+      0x8C14031F,  //  009E  GETMET	R5	R1	K31
+      0x581C0014,  //  009F  LDCONST	R7	K20
+      0x58200015,  //  00A0  LDCONST	R8	K21
+      0x8824010E,  //  00A1  GETMBR	R9	R0	K14
+      0x88280123,  //  00A2  GETMBR	R10	R0	K35
+      0x5C2C0800,  //  00A3  MOVE	R11	R4
+      0x7C140C00,  //  00A4  CALL	R5	6
+      0x60140008,  //  00A5  GETGBL	R5	G8
+      0x88180107,  //  00A6  GETMBR	R6	R0	K7
+      0x541E0EFF,  //  00A7  LDINT	R7	3840
+      0x2C180C07,  //  00A8  AND	R6	R6	R7
+      0x541E0007,  //  00A9  LDINT	R7	8
+      0x3C180C07,  //  00AA  SHR	R6	R6	R7
+      0x7C140200,  //  00AB  CALL	R5	1
+      0x00164005,  //  00AC  ADD	R5	K32	R5
+      0x5C100A00,  //  00AD  MOVE	R4	R5
+      0xB8162E00,  //  00AE  GETNGBL	R5	K23
+      0x8C140B18,  //  00AF  GETMET	R5	R5	K24
+      0x001E3A04,  //  00B0  ADD	R7	K29	R4
+      0x5820001E,  //  00B1  LDCONST	R8	K30
+      0x7C140600,  //  00B2  CALL	R5	3
+      0x8C14031F,  //  00B3  GETMET	R5	R1	K31
+      0x581C0014,  //  00B4  LDCONST	R7	K20
+      0x58200015,  //  00B5  LDCONST	R8	K21
+      0x8824010E,  //  00B6  GETMBR	R9	R0	K14
+      0x88280123,  //  00B7  GETMBR	R10	R0	K35
+      0x5C2C0800,  //  00B8  MOVE	R11	R4
+      0x7C140C00,  //  00B9  CALL	R5	6
+      0x60140008,  //  00BA  GETGBL	R5	G8
+      0x88180103,  //  00BB  GETMBR	R6	R0	K3
+      0x7C140200,  //  00BC  CALL	R5	1
+      0x00164205,  //  00BD  ADD	R5	K33	R5
+      0x5C100A00,  //  00BE  MOVE	R4	R5
+      0xB8162E00,  //  00BF  GETNGBL	R5	K23
+      0x8C140B18,  //  00C0  GETMET	R5	R5	K24
+      0x001E3A04,  //  00C1  ADD	R7	K29	R4
+      0x5820001E,  //  00C2  LDCONST	R8	K30
+      0x7C140600,  //  00C3  CALL	R5	3
+      0x8C14031F,  //  00C4  GETMET	R5	R1	K31
+      0x581C0014,  //  00C5  LDCONST	R7	K20
+      0x58200015,  //  00C6  LDCONST	R8	K21
+      0x8824010E,  //  00C7  GETMBR	R9	R0	K14
+      0x88280123,  //  00C8  GETMBR	R10	R0	K35
+      0x5C2C0800,  //  00C9  MOVE	R11	R4
+      0x7C140C00,  //  00CA  CALL	R5	6
+      0x58100022,  //  00CB  LDCONST	R4	K34
+      0xB8162E00,  //  00CC  GETNGBL	R5	K23
+      0x8C140B18,  //  00CD  GETMET	R5	R5	K24
+      0x001E3A04,  //  00CE  ADD	R7	K29	R4
+      0x5820001E,  //  00CF  LDCONST	R8	K30
+      0x7C140600,  //  00D0  CALL	R5	3
+      0x8C14031F,  //  00D1  GETMET	R5	R1	K31
+      0x581C0014,  //  00D2  LDCONST	R7	K20
+      0x58200015,  //  00D3  LDCONST	R8	K21
+      0x8824010E,  //  00D4  GETMBR	R9	R0	K14
+      0x88280123,  //  00D5  GETMBR	R10	R0	K35
+      0x5C2C0800,  //  00D6  MOVE	R11	R4
+      0x7C140C00,  //  00D7  CALL	R5	6
+      0xA8040001,  //  00D8  EXBLK	1	1
+      0x70020010,  //  00D9  JMP		#00EB
+      0xAC100002,  //  00DA  CATCH	R4	0	2
+      0x7002000D,  //  00DB  JMP		#00EA
+      0xB81A2E00,  //  00DC  GETNGBL	R6	K23
+      0x8C180D18,  //  00DD  GETMET	R6	R6	K24
+      0x60200008,  //  00DE  GETGBL	R8	G8
+      0x5C240800,  //  00DF  MOVE	R9	R4
+      0x7C200200,  //  00E0  CALL	R8	1
+      0x00224E08,  //  00E1  ADD	R8	K39	R8
+      0x00201128,  //  00E2  ADD	R8	R8	K40
+      0x60240008,  //  00E3  GETGBL	R9	G8
+      0x5C280A00,  //  00E4  MOVE	R10	R5
+      0x7C240200,  //  00E5  CALL	R9	1
+      0x00201009,  //  00E6  ADD	R8	R8	R9
+      0x5824001B,  //  00E7  LDCONST	R9	K27
+      0x7C180600,  //  00E8  CALL	R6	3
+      0x70020000,  //  00E9  JMP		#00EB
+      0xB0080000,  //  00EA  RAISE	2	R0	R0
+      0x80000000,  //  00EB  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_http_remote
+********************************************************************/
+be_local_closure(Matter_Device_register_http_remote,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(http_remotes),
+    /* K1   */  be_nested_str_weak(contains),
+    /* K2   */  be_nested_str_weak(get_timeout),
+    /* K3   */  be_nested_str_weak(set_timeout),
+    /* K4   */  be_nested_str_weak(matter),
+    /* K5   */  be_nested_str_weak(HTTP_remote),
+    /* K6   */  be_nested_str_weak(plugins_config_remotes),
+    /* K7   */  be_nested_str_weak(set_info),
+    }),
+    be_str_weak(register_http_remote),
+    &be_const_str_solidified,
+    ( &(const binstruction[42]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x4C100000,  //  0001  LDNIL	R4
+      0x1C0C0604,  //  0002  EQ	R3	R3	R4
+      0x780E0002,  //  0003  JMPF	R3	#0007
+      0x600C0013,  //  0004  GETGBL	R3	G19
+      0x7C0C0000,  //  0005  CALL	R3	0
+      0x90020003,  //  0006  SETMBR	R0	K0	R3
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x88100100,  //  0008  GETMBR	R4	R0	K0
+      0x8C100901,  //  0009  GETMET	R4	R4	K1
+      0x5C180200,  //  000A  MOVE	R6	R1
+      0x7C100400,  //  000B  CALL	R4	2
+      0x78120009,  //  000C  JMPF	R4	#0017
+      0x88100100,  //  000D  GETMBR	R4	R0	K0
+      0x940C0801,  //  000E  GETIDX	R3	R4	R1
+      0x8C140702,  //  000F  GETMET	R5	R3	K2
+      0x7C140200,  //  0010  CALL	R5	1
+      0x14140405,  //  0011  LT	R5	R2	R5
+      0x78160002,  //  0012  JMPF	R5	#0016
+      0x8C140703,  //  0013  GETMET	R5	R3	K3
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x7C140400,  //  0015  CALL	R5	2
+      0x70020011,  //  0016  JMP		#0029
+      0xB8120800,  //  0017  GETNGBL	R4	K4
+      0x8C100905,  //  0018  GETMET	R4	R4	K5
+      0x5C180000,  //  0019  MOVE	R6	R0
+      0x5C1C0200,  //  001A  MOVE	R7	R1
+      0x5C200400,  //  001B  MOVE	R8	R2
+      0x7C100800,  //  001C  CALL	R4	4
+      0x5C0C0800,  //  001D  MOVE	R3	R4
+      0x88100106,  //  001E  GETMBR	R4	R0	K6
+      0x8C100901,  //  001F  GETMET	R4	R4	K1
+      0x5C180200,  //  0020  MOVE	R6	R1
+      0x7C100400,  //  0021  CALL	R4	2
+      0x78120003,  //  0022  JMPF	R4	#0027
+      0x8C100707,  //  0023  GETMET	R4	R3	K7
+      0x88180106,  //  0024  GETMBR	R6	R0	K6
+      0x94180C01,  //  0025  GETIDX	R6	R6	R1
+      0x7C100400,  //  0026  CALL	R4	2
+      0x88100100,  //  0027  GETMBR	R4	R0	K0
+      0x98100203,  //  0028  SETIDX	R4	R1	R3
+      0x80040600,  //  0029  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_plugin_class_arg
+********************************************************************/
+be_local_closure(Matter_Device_get_plugin_class_arg,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_classes),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(ARG),
+    /* K3   */  be_nested_str_weak(),
+    }),
+    be_str_weak(get_plugin_class_arg),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x880C0502,  //  0005  GETMBR	R3	R2	K2
+      0x70020000,  //  0006  JMP		#0008
+      0x580C0003,  //  0007  LDCONST	R3	K3
+      0x80040600,  //  0008  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_fabrics_saved
+********************************************************************/
+be_local_closure(Matter_Device_event_fabrics_saved,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(count_active_fabrics),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(plugins_persist),
+    /* K4   */  be_nested_str_weak(save_param),
+    }),
+    be_str_weak(event_fabrics_saved),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x24040302,  //  0003  GT	R1	R1	K2
+      0x78060005,  //  0004  JMPF	R1	#000B
+      0x88040103,  //  0005  GETMBR	R1	R0	K3
+      0x74060003,  //  0006  JMPT	R1	#000B
+      0x50040200,  //  0007  LDBOOL	R1	1	0
+      0x90020601,  //  0008  SETMBR	R0	K3	R1
+      0x8C040104,  //  0009  GETMET	R1	R0	K4
+      0x7C040200,  //  000A  CALL	R1	1
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_commands
+********************************************************************/
+be_local_closure(Matter_Device_register_commands,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        10,                          /* nstack */
+        4,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(MtrJoin),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 8]) {  /* code */
+          0x68100000,  //  0000  GETUPV	R4	U0
+          0x8C100900,  //  0001  GETMET	R4	R4	K0
+          0x5C180000,  //  0002  MOVE	R6	R0
+          0x5C1C0200,  //  0003  MOVE	R7	R1
+          0x5C200400,  //  0004  MOVE	R8	R2
+          0x5C240600,  //  0005  MOVE	R9	R3
+          0x7C100A00,  //  0006  CALL	R4	5
+          0x80040800,  //  0007  RET	1	R4
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(add_cmd),
+    /* K2   */  be_nested_str_weak(MtrJoin),
+    }),
+    be_str_weak(register_commands),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x580C0002,  //  0002  LDCONST	R3	K2
+      0x84100000,  //  0003  CLOSURE	R4	P0
+      0x7C040600,  //  0004  CALL	R1	3
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_commissioning_complete_deferred
+********************************************************************/
+be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        3,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 2]) {  /* upvals */
+          be_local_const_upval(1, 0),
+          be_local_const_upval(1, 1),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start_commissioning_complete),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x68080001,  //  0002  GETUPV	R2	U1
+          0x7C000400,  //  0003  CALL	R0	2
+          0x80040000,  //  0004  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(set_timer),
+    /* K2   */  be_const_int(0),
+    }),
+    be_str_weak(start_commissioning_complete_deferred),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x84140000,  //  0003  CLOSURE	R5	P0
+      0x7C080600,  //  0004  CALL	R2	3
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _init_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device__init_basic_commissioning,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(count_active_fabrics),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(start_root_basic_commissioning),
+    }),
+    be_str_weak(_init_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x1C040302,  //  0003  EQ	R1	R1	K2
+      0x78060001,  //  0004  JMPF	R1	#0007
+      0x8C040103,  //  0005  GETMET	R1	R0	K3
+      0x7C040200,  //  0006  CALL	R1	1
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_active_endpoints
+********************************************************************/
+be_local_closure(Matter_Device_get_active_endpoints,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins),
+    /* K1   */  be_nested_str_weak(get_endpoint),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(find),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(get_active_endpoints),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x88100100,  //  0003  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0xA8020011,  //  0005  EXBLK	0	#0018
+      0x5C100600,  //  0006  MOVE	R4	R3
+      0x7C100000,  //  0007  CALL	R4	0
+      0x8C140901,  //  0008  GETMET	R5	R4	K1
+      0x7C140200,  //  0009  CALL	R5	1
+      0x78060002,  //  000A  JMPF	R1	#000E
+      0x1C180B02,  //  000B  EQ	R6	R5	K2
+      0x781A0000,  //  000C  JMPF	R6	#000E
+      0x7001FFF7,  //  000D  JMP		#0006
+      0x8C180503,  //  000E  GETMET	R6	R2	K3
+      0x5C200A00,  //  000F  MOVE	R8	R5
+      0x7C180400,  //  0010  CALL	R6	2
+      0x4C1C0000,  //  0011  LDNIL	R7
+      0x1C180C07,  //  0012  EQ	R6	R6	R7
+      0x781A0002,  //  0013  JMPF	R6	#0017
+      0x8C180504,  //  0014  GETMET	R6	R2	K4
+      0x5C200A00,  //  0015  MOVE	R8	R5
+      0x7C180400,  //  0016  CALL	R6	2
+      0x7001FFED,  //  0017  JMP		#0006
+      0x580C0005,  //  0018  LDCONST	R3	K5
+      0xAC0C0200,  //  0019  CATCH	R3	1	0
+      0xB0080000,  //  001A  RAISE	2	R0	R0
+      0x80040400,  //  001B  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_remove_op_discovery
+********************************************************************/
+be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[23]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(get_device_id),
+    /* K2   */  be_nested_str_weak(copy),
+    /* K3   */  be_nested_str_weak(reverse),
+    /* K4   */  be_nested_str_weak(get_fabric_compressed),
+    /* K5   */  be_nested_str_weak(tohex),
+    /* K6   */  be_nested_str_weak(_X2D),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(eth),
+    /* K9   */  be_nested_str_weak(find),
+    /* K10  */  be_nested_str_weak(up),
+    /* K11  */  be_nested_str_weak(log),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
+    /* K13  */  be_const_int(3),
+    /* K14  */  be_nested_str_weak(remove_service),
+    /* K15  */  be_nested_str_weak(_matter),
+    /* K16  */  be_nested_str_weak(_tcp),
+    /* K17  */  be_nested_str_weak(hostname_eth),
+    /* K18  */  be_nested_str_weak(wifi),
+    /* K19  */  be_nested_str_weak(hostname_wifi),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K21  */  be_nested_str_weak(_X7C),
+    /* K22  */  be_const_int(2),
+    }),
+    be_str_weak(mdns_remove_op_discovery),
+    &be_const_str_solidified,
+    ( &(const binstruction[80]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA802003B,  //  0001  EXBLK	0	#003E
+      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x8C100304,  //  0008  GETMET	R4	R1	K4
+      0x7C100200,  //  0009  CALL	R4	1
+      0x8C140905,  //  000A  GETMET	R5	R4	K5
+      0x7C140200,  //  000B  CALL	R5	1
+      0x00140B06,  //  000C  ADD	R5	R5	K6
+      0x8C180705,  //  000D  GETMET	R6	R3	K5
+      0x7C180200,  //  000E  CALL	R6	1
+      0x00140A06,  //  000F  ADD	R5	R5	R6
+      0xB81A0E00,  //  0010  GETNGBL	R6	K7
+      0x8C180D08,  //  0011  GETMET	R6	R6	K8
+      0x7C180200,  //  0012  CALL	R6	1
+      0x8C180D09,  //  0013  GETMET	R6	R6	K9
+      0x5820000A,  //  0014  LDCONST	R8	K10
+      0x7C180400,  //  0015  CALL	R6	2
+      0x781A000E,  //  0016  JMPF	R6	#0026
+      0xB81A0E00,  //  0017  GETNGBL	R6	K7
+      0x8C180D0B,  //  0018  GETMET	R6	R6	K11
+      0x60200018,  //  0019  GETGBL	R8	G24
+      0x5824000C,  //  001A  LDCONST	R9	K12
+      0x58280008,  //  001B  LDCONST	R10	K8
+      0x5C2C0A00,  //  001C  MOVE	R11	R5
+      0x7C200600,  //  001D  CALL	R8	3
+      0x5824000D,  //  001E  LDCONST	R9	K13
+      0x7C180600,  //  001F  CALL	R6	3
+      0x8C18050E,  //  0020  GETMET	R6	R2	K14
+      0x5820000F,  //  0021  LDCONST	R8	K15
+      0x58240010,  //  0022  LDCONST	R9	K16
+      0x5C280A00,  //  0023  MOVE	R10	R5
+      0x882C0111,  //  0024  GETMBR	R11	R0	K17
+      0x7C180A00,  //  0025  CALL	R6	5
+      0xB81A0E00,  //  0026  GETNGBL	R6	K7
+      0x8C180D12,  //  0027  GETMET	R6	R6	K18
+      0x7C180200,  //  0028  CALL	R6	1
+      0x8C180D09,  //  0029  GETMET	R6	R6	K9
+      0x5820000A,  //  002A  LDCONST	R8	K10
+      0x7C180400,  //  002B  CALL	R6	2
+      0x781A000E,  //  002C  JMPF	R6	#003C
+      0xB81A0E00,  //  002D  GETNGBL	R6	K7
+      0x8C180D0B,  //  002E  GETMET	R6	R6	K11
+      0x60200018,  //  002F  GETGBL	R8	G24
+      0x5824000C,  //  0030  LDCONST	R9	K12
+      0x58280012,  //  0031  LDCONST	R10	K18
+      0x5C2C0A00,  //  0032  MOVE	R11	R5
+      0x7C200600,  //  0033  CALL	R8	3
+      0x5824000D,  //  0034  LDCONST	R9	K13
+      0x7C180600,  //  0035  CALL	R6	3
+      0x8C18050E,  //  0036  GETMET	R6	R2	K14
+      0x5820000F,  //  0037  LDCONST	R8	K15
+      0x58240010,  //  0038  LDCONST	R9	K16
+      0x5C280A00,  //  0039  MOVE	R10	R5
+      0x882C0113,  //  003A  GETMBR	R11	R0	K19
+      0x7C180A00,  //  003B  CALL	R6	5
+      0xA8040001,  //  003C  EXBLK	1	1
+      0x70020010,  //  003D  JMP		#004F
+      0xAC0C0002,  //  003E  CATCH	R3	0	2
+      0x7002000D,  //  003F  JMP		#004E
+      0xB8160E00,  //  0040  GETNGBL	R5	K7
+      0x8C140B0B,  //  0041  GETMET	R5	R5	K11
+      0x601C0008,  //  0042  GETGBL	R7	G8
+      0x5C200600,  //  0043  MOVE	R8	R3
+      0x7C1C0200,  //  0044  CALL	R7	1
+      0x001E2807,  //  0045  ADD	R7	K20	R7
+      0x001C0F15,  //  0046  ADD	R7	R7	K21
+      0x60200008,  //  0047  GETGBL	R8	G8
+      0x5C240800,  //  0048  MOVE	R9	R4
+      0x7C200200,  //  0049  CALL	R8	1
+      0x001C0E08,  //  004A  ADD	R7	R7	R8
+      0x58200016,  //  004B  LDCONST	R8	K22
+      0x7C140600,  //  004C  CALL	R5	3
+      0x70020000,  //  004D  JMP		#004F
+      0xB0080000,  //  004E  RAISE	2	R0	R0
+      0x80000000,  //  004F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Device_init,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_start),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0004,  //  0006  LDCONST	R3	K4
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Eth_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_start),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0004,  //  0006  LDCONST	R3	K4
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[43]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(get_option),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(MATTER_OPTION),
+    /* K5   */  be_nested_str_weak(UI),
+    /* K6   */  be_nested_str_weak(started),
+    /* K7   */  be_nested_str_weak(tick),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(plugins),
+    /* K10  */  be_nested_str_weak(plugins_persist),
+    /* K11  */  be_nested_str_weak(plugins_classes),
+    /* K12  */  be_nested_str_weak(plugins_config_remotes),
+    /* K13  */  be_nested_str_weak(register_native_classes),
+    /* K14  */  be_nested_str_weak(vendorid),
+    /* K15  */  be_nested_str_weak(VENDOR_ID),
+    /* K16  */  be_nested_str_weak(productid),
+    /* K17  */  be_nested_str_weak(PRODUCT_ID),
+    /* K18  */  be_nested_str_weak(root_iterations),
+    /* K19  */  be_nested_str_weak(PBKDF_ITERATIONS),
+    /* K20  */  be_nested_str_weak(next_ep),
+    /* K21  */  be_const_int(1),
+    /* K22  */  be_nested_str_weak(root_salt),
+    /* K23  */  be_nested_str_weak(random),
+    /* K24  */  be_nested_str_weak(ipv4only),
+    /* K25  */  be_nested_str_weak(load_param),
+    /* K26  */  be_nested_str_weak(sessions),
+    /* K27  */  be_nested_str_weak(Session_Store),
+    /* K28  */  be_nested_str_weak(load_fabrics),
+    /* K29  */  be_nested_str_weak(message_handler),
+    /* K30  */  be_nested_str_weak(MessageHandler),
+    /* K31  */  be_nested_str_weak(ui),
+    /* K32  */  be_nested_str_weak(wifi),
+    /* K33  */  be_nested_str_weak(up),
+    /* K34  */  be_nested_str_weak(eth),
+    /* K35  */  be_nested_str_weak(start),
+    /* K36  */  be_nested_str_weak(add_rule),
+    /* K37  */  be_nested_str_weak(Wifi_X23Connected),
+    /* K38  */  be_nested_str_weak(matter_start),
+    /* K39  */  be_nested_str_weak(Eth_X23Connected),
+    /* K40  */  be_nested_str_weak(_init_basic_commissioning),
+    /* K41  */  be_nested_str_weak(add_driver),
+    /* K42  */  be_nested_str_weak(register_commands),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[105]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0xB8120600,  //  0003  GETNGBL	R4	K3
+      0x88100904,  //  0004  GETMBR	R4	R4	K4
+      0x7C080400,  //  0005  CALL	R2	2
+      0x740A0004,  //  0006  JMPT	R2	#000C
+      0xB80A0600,  //  0007  GETNGBL	R2	K3
+      0x8C080505,  //  0008  GETMET	R2	R2	K5
+      0x5C100000,  //  0009  MOVE	R4	R0
+      0x7C080400,  //  000A  CALL	R2	2
+      0x80000400,  //  000B  RET	0
+      0x50080000,  //  000C  LDBOOL	R2	0	0
+      0x90020C02,  //  000D  SETMBR	R0	K6	R2
+      0x90020F08,  //  000E  SETMBR	R0	K7	K8
+      0x60080012,  //  000F  GETGBL	R2	G18
+      0x7C080000,  //  0010  CALL	R2	0
+      0x90021202,  //  0011  SETMBR	R0	K9	R2
+      0x50080000,  //  0012  LDBOOL	R2	0	0
+      0x90021402,  //  0013  SETMBR	R0	K10	R2
+      0x60080013,  //  0014  GETGBL	R2	G19
+      0x7C080000,  //  0015  CALL	R2	0
+      0x90021602,  //  0016  SETMBR	R0	K11	R2
+      0x60080013,  //  0017  GETGBL	R2	G19
+      0x7C080000,  //  0018  CALL	R2	0
+      0x90021802,  //  0019  SETMBR	R0	K12	R2
+      0x8C08010D,  //  001A  GETMET	R2	R0	K13
+      0x7C080200,  //  001B  CALL	R2	1
+      0x8808010F,  //  001C  GETMBR	R2	R0	K15
+      0x90021C02,  //  001D  SETMBR	R0	K14	R2
+      0x88080111,  //  001E  GETMBR	R2	R0	K17
+      0x90022002,  //  001F  SETMBR	R0	K16	R2
+      0x88080113,  //  0020  GETMBR	R2	R0	K19
+      0x90022402,  //  0021  SETMBR	R0	K18	R2
+      0x90022915,  //  0022  SETMBR	R0	K20	K21
+      0x8C080317,  //  0023  GETMET	R2	R1	K23
+      0x5412000F,  //  0024  LDINT	R4	16
+      0x7C080400,  //  0025  CALL	R2	2
+      0x90022C02,  //  0026  SETMBR	R0	K22	R2
+      0x50080000,  //  0027  LDBOOL	R2	0	0
+      0x90023002,  //  0028  SETMBR	R0	K24	R2
+      0x8C080119,  //  0029  GETMET	R2	R0	K25
+      0x7C080200,  //  002A  CALL	R2	1
+      0xB80A0600,  //  002B  GETNGBL	R2	K3
+      0x8C08051B,  //  002C  GETMET	R2	R2	K27
+      0x5C100000,  //  002D  MOVE	R4	R0
+      0x7C080400,  //  002E  CALL	R2	2
+      0x90023402,  //  002F  SETMBR	R0	K26	R2
+      0x8808011A,  //  0030  GETMBR	R2	R0	K26
+      0x8C08051C,  //  0031  GETMET	R2	R2	K28
+      0x7C080200,  //  0032  CALL	R2	1
+      0xB80A0600,  //  0033  GETNGBL	R2	K3
+      0x8C08051E,  //  0034  GETMET	R2	R2	K30
+      0x5C100000,  //  0035  MOVE	R4	R0
+      0x7C080400,  //  0036  CALL	R2	2
+      0x90023A02,  //  0037  SETMBR	R0	K29	R2
+      0xB80A0600,  //  0038  GETNGBL	R2	K3
+      0x8C080505,  //  0039  GETMET	R2	R2	K5
+      0x5C100000,  //  003A  MOVE	R4	R0
+      0x7C080400,  //  003B  CALL	R2	2
+      0x90023E02,  //  003C  SETMBR	R0	K31	R2
+      0xB80A0200,  //  003D  GETNGBL	R2	K1
+      0x8C080520,  //  003E  GETMET	R2	R2	K32
+      0x7C080200,  //  003F  CALL	R2	1
+      0x94080521,  //  0040  GETIDX	R2	R2	K33
+      0x740A0004,  //  0041  JMPT	R2	#0047
+      0xB80A0200,  //  0042  GETNGBL	R2	K1
+      0x8C080522,  //  0043  GETMET	R2	R2	K34
+      0x7C080200,  //  0044  CALL	R2	1
+      0x94080521,  //  0045  GETIDX	R2	R2	K33
+      0x780A0001,  //  0046  JMPF	R2	#0049
+      0x8C080123,  //  0047  GETMET	R2	R0	K35
+      0x7C080200,  //  0048  CALL	R2	1
+      0xB80A0200,  //  0049  GETNGBL	R2	K1
+      0x8C080520,  //  004A  GETMET	R2	R2	K32
+      0x7C080200,  //  004B  CALL	R2	1
+      0x94080521,  //  004C  GETIDX	R2	R2	K33
+      0x740A0005,  //  004D  JMPT	R2	#0054
+      0xB80A0200,  //  004E  GETNGBL	R2	K1
+      0x8C080524,  //  004F  GETMET	R2	R2	K36
+      0x58100025,  //  0050  LDCONST	R4	K37
+      0x84140000,  //  0051  CLOSURE	R5	P0
+      0x58180026,  //  0052  LDCONST	R6	K38
+      0x7C080800,  //  0053  CALL	R2	4
+      0xB80A0200,  //  0054  GETNGBL	R2	K1
+      0x8C080522,  //  0055  GETMET	R2	R2	K34
+      0x7C080200,  //  0056  CALL	R2	1
+      0x94080521,  //  0057  GETIDX	R2	R2	K33
+      0x740A0005,  //  0058  JMPT	R2	#005F
+      0xB80A0200,  //  0059  GETNGBL	R2	K1
+      0x8C080524,  //  005A  GETMET	R2	R2	K36
+      0x58100027,  //  005B  LDCONST	R4	K39
+      0x84140001,  //  005C  CLOSURE	R5	P1
+      0x58180026,  //  005D  LDCONST	R6	K38
+      0x7C080800,  //  005E  CALL	R2	4
+      0x8C080128,  //  005F  GETMET	R2	R0	K40
+      0x7C080200,  //  0060  CALL	R2	1
+      0xB80A0200,  //  0061  GETNGBL	R2	K1
+      0x8C080529,  //  0062  GETMET	R2	R2	K41
+      0x5C100000,  //  0063  MOVE	R4	R0
+      0x7C080400,  //  0064  CALL	R2	2
+      0x8C08012A,  //  0065  GETMET	R2	R0	K42
+      0x7C080200,  //  0066  CALL	R2	1
+      0xA0000000,  //  0067  CLOSE	R0
+      0x80000000,  //  0068  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: k2l
+********************************************************************/
+be_local_closure(Matter_Device_k2l,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Device),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(push),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_const_int(0),
+    }),
+    be_str_weak(k2l),
+    &be_const_str_solidified,
+    ( &(const binstruction[50]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0003,  //  0004  EQ	R3	R0	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80040400,  //  0006  RET	1	R2
+      0x600C0010,  //  0007  GETGBL	R3	G16
+      0x8C100101,  //  0008  GETMET	R4	R0	K1
+      0x7C100200,  //  0009  CALL	R4	1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0xA8020005,  //  000B  EXBLK	0	#0012
+      0x5C100600,  //  000C  MOVE	R4	R3
+      0x7C100000,  //  000D  CALL	R4	0
+      0x8C140502,  //  000E  GETMET	R5	R2	K2
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x7C140400,  //  0010  CALL	R5	2
+      0x7001FFF9,  //  0011  JMP		#000C
+      0x580C0003,  //  0012  LDCONST	R3	K3
+      0xAC0C0200,  //  0013  CATCH	R3	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x600C0010,  //  0015  GETGBL	R3	G16
+      0x6010000C,  //  0016  GETGBL	R4	G12
+      0x5C140400,  //  0017  MOVE	R5	R2
+      0x7C100200,  //  0018  CALL	R4	1
+      0x04100904,  //  0019  SUB	R4	R4	K4
+      0x40120804,  //  001A  CONNECT	R4	K4	R4
+      0x7C0C0200,  //  001B  CALL	R3	1
+      0xA8020010,  //  001C  EXBLK	0	#002E
+      0x5C100600,  //  001D  MOVE	R4	R3
+      0x7C100000,  //  001E  CALL	R4	0
+      0x94140404,  //  001F  GETIDX	R5	R2	R4
+      0x5C180800,  //  0020  MOVE	R6	R4
+      0x241C0D05,  //  0021  GT	R7	R6	K5
+      0x781E0008,  //  0022  JMPF	R7	#002C
+      0x041C0D04,  //  0023  SUB	R7	R6	K4
+      0x941C0407,  //  0024  GETIDX	R7	R2	R7
+      0x241C0E05,  //  0025  GT	R7	R7	R5
+      0x781E0004,  //  0026  JMPF	R7	#002C
+      0x041C0D04,  //  0027  SUB	R7	R6	K4
+      0x941C0407,  //  0028  GETIDX	R7	R2	R7
+      0x98080C07,  //  0029  SETIDX	R2	R6	R7
+      0x04180D04,  //  002A  SUB	R6	R6	K4
+      0x7001FFF4,  //  002B  JMP		#0021
+      0x98080C05,  //  002C  SETIDX	R2	R6	R5
+      0x7001FFEE,  //  002D  JMP		#001D
+      0x580C0003,  //  002E  LDCONST	R3	K3
+      0xAC0C0200,  //  002F  CATCH	R3	1	0
+      0xB0080000,  //  0030  RAISE	2	R0	R0
+      0x80040400,  //  0031  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: adjust_next_ep
+********************************************************************/
+be_local_closure(Matter_Device_adjust_next_ep,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_config),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(next_ep),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(adjust_next_ep),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000A,  //  0005  EXBLK	0	#0011
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x600C0009,  //  0008  GETGBL	R3	G9
+      0x5C100400,  //  0009  MOVE	R4	R2
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x88100102,  //  000B  GETMBR	R4	R0	K2
+      0x28100604,  //  000C  GE	R4	R3	R4
+      0x78120001,  //  000D  JMPF	R4	#0010
+      0x00100703,  //  000E  ADD	R4	R3	K3
+      0x90020404,  //  000F  SETMBR	R0	K2	R4
+      0x7001FFF4,  //  0010  JMP		#0006
+      0x58040004,  //  0011  LDCONST	R1	K4
+      0xAC040200,  //  0012  CATCH	R1	1	0
+      0xB0080000,  //  0013  RAISE	2	R0	R0
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: autoconf_sensors_list
+********************************************************************/
+be_local_closure(Matter_Device_autoconf_sensors_list,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(k2l),
+    /* K1   */  be_nested_str_weak(contains),
+    /* K2   */  be_nested_str_weak(Temperature),
+    /* K3   */  be_nested_str_weak(_X23Temperature),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_nested_str_weak(type),
+    /* K6   */  be_nested_str_weak(temperature),
+    /* K7   */  be_nested_str_weak(filter),
+    /* K8   */  be_nested_str_weak(stop_iteration),
+    /* K9   */  be_nested_str_weak(Pressure),
+    /* K10  */  be_nested_str_weak(_X23Pressure),
+    /* K11  */  be_nested_str_weak(pressure),
+    /* K12  */  be_nested_str_weak(Illuminance),
+    /* K13  */  be_nested_str_weak(_X23Illuminance),
+    /* K14  */  be_nested_str_weak(illuminance),
+    /* K15  */  be_nested_str_weak(Humidity),
+    /* K16  */  be_nested_str_weak(_X23Humidity),
+    /* K17  */  be_nested_str_weak(humidity),
+    }),
+    be_str_weak(autoconf_sensors_list),
+    &be_const_str_solidified,
+    ( &(const binstruction[119]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x8C100100,  //  0003  GETMET	R4	R0	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x7C100400,  //  0005  CALL	R4	2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0xA8020013,  //  0007  EXBLK	0	#001C
+      0x5C100600,  //  0008  MOVE	R4	R3
+      0x7C100000,  //  0009  CALL	R4	0
+      0x94140204,  //  000A  GETIDX	R5	R1	R4
+      0x6018000F,  //  000B  GETGBL	R6	G15
+      0x5C1C0A00,  //  000C  MOVE	R7	R5
+      0x60200013,  //  000D  GETGBL	R8	G19
+      0x7C180400,  //  000E  CALL	R6	2
+      0x781A000A,  //  000F  JMPF	R6	#001B
+      0x8C180B01,  //  0010  GETMET	R6	R5	K1
+      0x58200002,  //  0011  LDCONST	R8	K2
+      0x7C180400,  //  0012  CALL	R6	2
+      0x781A0006,  //  0013  JMPF	R6	#001B
+      0x00180903,  //  0014  ADD	R6	R4	K3
+      0x8C1C0504,  //  0015  GETMET	R7	R2	K4
+      0x60240013,  //  0016  GETGBL	R9	G19
+      0x7C240000,  //  0017  CALL	R9	0
+      0x98260B06,  //  0018  SETIDX	R9	K5	K6
+      0x98260E06,  //  0019  SETIDX	R9	K7	R6
+      0x7C1C0400,  //  001A  CALL	R7	2
+      0x7001FFEB,  //  001B  JMP		#0008
+      0x580C0008,  //  001C  LDCONST	R3	K8
+      0xAC0C0200,  //  001D  CATCH	R3	1	0
+      0xB0080000,  //  001E  RAISE	2	R0	R0
+      0x600C0010,  //  001F  GETGBL	R3	G16
+      0x8C100100,  //  0020  GETMET	R4	R0	K0
+      0x5C180200,  //  0021  MOVE	R6	R1
+      0x7C100400,  //  0022  CALL	R4	2
+      0x7C0C0200,  //  0023  CALL	R3	1
+      0xA8020013,  //  0024  EXBLK	0	#0039
+      0x5C100600,  //  0025  MOVE	R4	R3
+      0x7C100000,  //  0026  CALL	R4	0
+      0x94140204,  //  0027  GETIDX	R5	R1	R4
+      0x6018000F,  //  0028  GETGBL	R6	G15
+      0x5C1C0A00,  //  0029  MOVE	R7	R5
+      0x60200013,  //  002A  GETGBL	R8	G19
+      0x7C180400,  //  002B  CALL	R6	2
+      0x781A000A,  //  002C  JMPF	R6	#0038
+      0x8C180B01,  //  002D  GETMET	R6	R5	K1
+      0x58200009,  //  002E  LDCONST	R8	K9
+      0x7C180400,  //  002F  CALL	R6	2
+      0x781A0006,  //  0030  JMPF	R6	#0038
+      0x0018090A,  //  0031  ADD	R6	R4	K10
+      0x8C1C0504,  //  0032  GETMET	R7	R2	K4
+      0x60240013,  //  0033  GETGBL	R9	G19
+      0x7C240000,  //  0034  CALL	R9	0
+      0x98260B0B,  //  0035  SETIDX	R9	K5	K11
+      0x98260E06,  //  0036  SETIDX	R9	K7	R6
+      0x7C1C0400,  //  0037  CALL	R7	2
+      0x7001FFEB,  //  0038  JMP		#0025
+      0x580C0008,  //  0039  LDCONST	R3	K8
+      0xAC0C0200,  //  003A  CATCH	R3	1	0
+      0xB0080000,  //  003B  RAISE	2	R0	R0
+      0x600C0010,  //  003C  GETGBL	R3	G16
+      0x8C100100,  //  003D  GETMET	R4	R0	K0
+      0x5C180200,  //  003E  MOVE	R6	R1
+      0x7C100400,  //  003F  CALL	R4	2
+      0x7C0C0200,  //  0040  CALL	R3	1
+      0xA8020013,  //  0041  EXBLK	0	#0056
+      0x5C100600,  //  0042  MOVE	R4	R3
+      0x7C100000,  //  0043  CALL	R4	0
+      0x94140204,  //  0044  GETIDX	R5	R1	R4
+      0x6018000F,  //  0045  GETGBL	R6	G15
+      0x5C1C0A00,  //  0046  MOVE	R7	R5
+      0x60200013,  //  0047  GETGBL	R8	G19
+      0x7C180400,  //  0048  CALL	R6	2
+      0x781A000A,  //  0049  JMPF	R6	#0055
+      0x8C180B01,  //  004A  GETMET	R6	R5	K1
+      0x5820000C,  //  004B  LDCONST	R8	K12
+      0x7C180400,  //  004C  CALL	R6	2
+      0x781A0006,  //  004D  JMPF	R6	#0055
+      0x0018090D,  //  004E  ADD	R6	R4	K13
+      0x8C1C0504,  //  004F  GETMET	R7	R2	K4
+      0x60240013,  //  0050  GETGBL	R9	G19
+      0x7C240000,  //  0051  CALL	R9	0
+      0x98260B0E,  //  0052  SETIDX	R9	K5	K14
+      0x98260E06,  //  0053  SETIDX	R9	K7	R6
+      0x7C1C0400,  //  0054  CALL	R7	2
+      0x7001FFEB,  //  0055  JMP		#0042
+      0x580C0008,  //  0056  LDCONST	R3	K8
+      0xAC0C0200,  //  0057  CATCH	R3	1	0
+      0xB0080000,  //  0058  RAISE	2	R0	R0
+      0x600C0010,  //  0059  GETGBL	R3	G16
+      0x8C100100,  //  005A  GETMET	R4	R0	K0
+      0x5C180200,  //  005B  MOVE	R6	R1
+      0x7C100400,  //  005C  CALL	R4	2
+      0x7C0C0200,  //  005D  CALL	R3	1
+      0xA8020013,  //  005E  EXBLK	0	#0073
+      0x5C100600,  //  005F  MOVE	R4	R3
+      0x7C100000,  //  0060  CALL	R4	0
+      0x94140204,  //  0061  GETIDX	R5	R1	R4
+      0x6018000F,  //  0062  GETGBL	R6	G15
+      0x5C1C0A00,  //  0063  MOVE	R7	R5
+      0x60200013,  //  0064  GETGBL	R8	G19
+      0x7C180400,  //  0065  CALL	R6	2
+      0x781A000A,  //  0066  JMPF	R6	#0072
+      0x8C180B01,  //  0067  GETMET	R6	R5	K1
+      0x5820000F,  //  0068  LDCONST	R8	K15
+      0x7C180400,  //  0069  CALL	R6	2
+      0x781A0006,  //  006A  JMPF	R6	#0072
+      0x00180910,  //  006B  ADD	R6	R4	K16
+      0x8C1C0504,  //  006C  GETMET	R7	R2	K4
+      0x60240013,  //  006D  GETGBL	R9	G19
+      0x7C240000,  //  006E  CALL	R9	0
+      0x98260B11,  //  006F  SETIDX	R9	K5	K17
+      0x98260E06,  //  0070  SETIDX	R9	K7	R6
+      0x7C1C0400,  //  0071  CALL	R7	2
+      0x7001FFEB,  //  0072  JMP		#005F
+      0x580C0008,  //  0073  LDCONST	R3	K8
+      0xAC0C0200,  //  0074  CATCH	R3	1	0
+      0xB0080000,  //  0075  RAISE	2	R0	R0
+      0x80040400,  //  0076  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_50ms
+********************************************************************/
+be_local_closure(Matter_Device_every_50ms,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tick),
+    /* K1   */  be_const_int(1),
+    }),
+    be_str_weak(every_50ms),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x00040301,  //  0001  ADD	R1	R1	K1
+      0x90020001,  //  0002  SETMBR	R0	K0	R1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    8,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 4]) {     /* constants */
+        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0000,  //  0006  LDCONST	R3	K0
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 4]) {     /* constants */
+        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Eth_X23Connected),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0000,  //  0006  LDCONST	R3	K0
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(millis),
+    /* K3   */  be_nested_str_weak(commissioning_iterations),
+    /* K4   */  be_nested_str_weak(commissioning_discriminator),
+    /* K5   */  be_nested_str_weak(commissioning_salt),
+    /* K6   */  be_nested_str_weak(commissioning_w0),
+    /* K7   */  be_nested_str_weak(commissioning_L),
+    /* K8   */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K9   */  be_nested_str_weak(wifi),
+    /* K10  */  be_nested_str_weak(up),
+    /* K11  */  be_nested_str_weak(eth),
+    /* K12  */  be_nested_str_weak(mdns_announce_PASE),
+    /* K13  */  be_nested_str_weak(add_rule),
+    /* K14  */  be_nested_str_weak(Wifi_X23Connected),
+    /* K15  */  be_nested_str_weak(Eth_X23Connected),
+    }),
+    be_str_weak(start_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0xB8220200,  //  0000  GETNGBL	R8	K1
+      0x8C201102,  //  0001  GETMET	R8	R8	K2
+      0x7C200200,  //  0002  CALL	R8	1
+      0x542603E7,  //  0003  LDINT	R9	1000
+      0x08240209,  //  0004  MUL	R9	R1	R9
+      0x00201009,  //  0005  ADD	R8	R8	R9
+      0x90020008,  //  0006  SETMBR	R0	K0	R8
+      0x90020602,  //  0007  SETMBR	R0	K3	R2
+      0x90020803,  //  0008  SETMBR	R0	K4	R3
+      0x90020A04,  //  0009  SETMBR	R0	K5	R4
+      0x90020C05,  //  000A  SETMBR	R0	K6	R5
+      0x90020E06,  //  000B  SETMBR	R0	K7	R6
+      0x90021007,  //  000C  SETMBR	R0	K8	R7
+      0xB8220200,  //  000D  GETNGBL	R8	K1
+      0x8C201109,  //  000E  GETMET	R8	R8	K9
+      0x7C200200,  //  000F  CALL	R8	1
+      0x9420110A,  //  0010  GETIDX	R8	R8	K10
+      0x74220004,  //  0011  JMPT	R8	#0017
+      0xB8220200,  //  0012  GETNGBL	R8	K1
+      0x8C20110B,  //  0013  GETMET	R8	R8	K11
+      0x7C200200,  //  0014  CALL	R8	1
+      0x9420110A,  //  0015  GETIDX	R8	R8	K10
+      0x78220002,  //  0016  JMPF	R8	#001A
+      0x8C20010C,  //  0017  GETMET	R8	R0	K12
+      0x7C200200,  //  0018  CALL	R8	1
+      0x7002000B,  //  0019  JMP		#0026
+      0xB8220200,  //  001A  GETNGBL	R8	K1
+      0x8C20110D,  //  001B  GETMET	R8	R8	K13
+      0x5828000E,  //  001C  LDCONST	R10	K14
+      0x842C0000,  //  001D  CLOSURE	R11	P0
+      0x5830000C,  //  001E  LDCONST	R12	K12
+      0x7C200800,  //  001F  CALL	R8	4
+      0xB8220200,  //  0020  GETNGBL	R8	K1
+      0x8C20110D,  //  0021  GETMET	R8	R8	K13
+      0x5828000F,  //  0022  LDCONST	R10	K15
+      0x842C0001,  //  0023  CLOSURE	R11	P1
+      0x5830000C,  //  0024  LDCONST	R12	K12
+      0x7C200800,  //  0025  CALL	R8	4
+      0xA0000000,  //  0026  CLOSE	R0
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop
+********************************************************************/
+be_local_closure(Matter_Device_stop,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(remove_driver),
+    /* K2   */  be_nested_str_weak(udp_server),
+    /* K3   */  be_nested_str_weak(stop),
+    }),
+    be_str_weak(stop),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x88040102,  //  0004  GETMBR	R1	R0	K2
+      0x78060002,  //  0005  JMPF	R1	#0009
+      0x88040102,  //  0006  GETMBR	R1	R0	K2
+      0x8C040303,  //  0007  GETMET	R1	R1	K3
+      0x7C040200,  //  0008  CALL	R1	1
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_operational_discovery
+********************************************************************/
+be_local_closure(Matter_Device_start_operational_discovery,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(mdns),
+    /* K2   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K3   */  be_nested_str_weak(root_w0),
+    /* K4   */  be_nested_str_weak(root_L),
+    /* K5   */  be_nested_str_weak(mdns_announce_op_discovery),
+    }),
+    be_str_weak(start_operational_discovery),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0x8C100102,  //  0002  GETMET	R4	R0	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x4C100000,  //  0004  LDNIL	R4
+      0x90020604,  //  0005  SETMBR	R0	K3	R4
+      0x4C100000,  //  0006  LDNIL	R4
+      0x90020804,  //  0007  SETMBR	R0	K4	R4
+      0x8C100105,  //  0008  GETMET	R4	R0	K5
+      0x5C180200,  //  0009  MOVE	R6	R1
+      0x7C100400,  //  000A  CALL	R4	2
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_commissioning_complete
+********************************************************************/
+be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_fabric),
+    /* K1   */  be_nested_str_weak(get_fabric_id),
+    /* K2   */  be_nested_str_weak(copy),
+    /* K3   */  be_nested_str_weak(reverse),
+    /* K4   */  be_nested_str_weak(tohex),
+    /* K5   */  be_nested_str_weak(get_admin_vendor_name),
+    /* K6   */  be_nested_str_weak(tasmota),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X2D_X2D_X2D_X20Commissioning_X20complete_X20for_X20Fabric_X20_X27_X25s_X27_X20_X28Vendor_X20_X25s_X29_X20_X2D_X2D_X2D),
+    /* K9   */  be_const_int(2),
+    /* K10  */  be_nested_str_weak(stop_basic_commissioning),
+    }),
+    be_str_weak(start_commissioning_complete),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x8C080300,  //  0000  GETMET	R2	R1	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x8C0C0501,  //  0002  GETMET	R3	R2	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x8C0C0704,  //  0008  GETMET	R3	R3	K4
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x8C100505,  //  000A  GETMET	R4	R2	K5
+      0x7C100200,  //  000B  CALL	R4	1
+      0xB8160C00,  //  000C  GETNGBL	R5	K6
+      0x8C140B07,  //  000D  GETMET	R5	R5	K7
+      0x601C0018,  //  000E  GETGBL	R7	G24
+      0x58200008,  //  000F  LDCONST	R8	K8
+      0x5C240600,  //  0010  MOVE	R9	R3
+      0x5C280800,  //  0011  MOVE	R10	R4
+      0x7C1C0600,  //  0012  CALL	R7	3
+      0x58200009,  //  0013  LDCONST	R8	K9
+      0x7C140600,  //  0014  CALL	R5	3
+      0x8C14010A,  //  0015  GETMET	R5	R0	K10
+      0x7C140200,  //  0016  CALL	R5	1
+      0x80000000,  //  0017  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_operational_discovery_deferred
+********************************************************************/
+be_local_closure(Matter_Device_start_operational_discovery_deferred,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        3,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 2]) {  /* upvals */
+          be_local_const_upval(1, 0),
+          be_local_const_upval(1, 1),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start_operational_discovery),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x68080001,  //  0002  GETUPV	R2	U1
+          0x7C000400,  //  0003  CALL	R0	2
+          0x80040000,  //  0004  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(set_timer),
+    /* K2   */  be_const_int(0),
+    }),
+    be_str_weak(start_operational_discovery_deferred),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x84140000,  //  0003  CLOSURE	R5	P0
+      0x7C080600,  //  0004  CALL	R2	3
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_fabric
+********************************************************************/
+be_local_closure(Matter_Device_remove_fabric,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[20]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(find_children_fabrics),
+    /* K2   */  be_nested_str_weak(get_fabric_index),
+    /* K3   */  be_nested_str_weak(find_fabric_by_index),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
+    /* K7   */  be_nested_str_weak(get_fabric_id),
+    /* K8   */  be_nested_str_weak(copy),
+    /* K9   */  be_nested_str_weak(reverse),
+    /* K10  */  be_nested_str_weak(tohex),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_nested_str_weak(message_handler),
+    /* K13  */  be_nested_str_weak(im),
+    /* K14  */  be_nested_str_weak(subs_shop),
+    /* K15  */  be_nested_str_weak(remove_by_fabric),
+    /* K16  */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K17  */  be_nested_str_weak(remove_fabric),
+    /* K18  */  be_nested_str_weak(stop_iteration),
+    /* K19  */  be_nested_str_weak(save_fabrics),
+    }),
+    be_str_weak(remove_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[56]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8C100302,  //  0002  GETMET	R4	R1	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x7C080400,  //  0004  CALL	R2	2
+      0x4C0C0000,  //  0005  LDNIL	R3
+      0x1C0C0403,  //  0006  EQ	R3	R2	R3
+      0x780E0000,  //  0007  JMPF	R3	#0009
+      0x80000600,  //  0008  RET	0
+      0x600C0010,  //  0009  GETGBL	R3	G16
+      0x5C100400,  //  000A  MOVE	R4	R2
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0xA8020023,  //  000C  EXBLK	0	#0031
+      0x5C100600,  //  000D  MOVE	R4	R3
+      0x7C100000,  //  000E  CALL	R4	0
+      0x88140100,  //  000F  GETMBR	R5	R0	K0
+      0x8C140B03,  //  0010  GETMET	R5	R5	K3
+      0x5C1C0800,  //  0011  MOVE	R7	R4
+      0x7C140400,  //  0012  CALL	R5	2
+      0x4C180000,  //  0013  LDNIL	R6
+      0x20180A06,  //  0014  NE	R6	R5	R6
+      0x781A0019,  //  0015  JMPF	R6	#0030
+      0xB81A0800,  //  0016  GETNGBL	R6	K4
+      0x8C180D05,  //  0017  GETMET	R6	R6	K5
+      0x8C200B07,  //  0018  GETMET	R8	R5	K7
+      0x7C200200,  //  0019  CALL	R8	1
+      0x8C201108,  //  001A  GETMET	R8	R8	K8
+      0x7C200200,  //  001B  CALL	R8	1
+      0x8C201109,  //  001C  GETMET	R8	R8	K9
+      0x7C200200,  //  001D  CALL	R8	1
+      0x8C20110A,  //  001E  GETMET	R8	R8	K10
+      0x7C200200,  //  001F  CALL	R8	1
+      0x00220C08,  //  0020  ADD	R8	K6	R8
+      0x5824000B,  //  0021  LDCONST	R9	K11
+      0x7C180600,  //  0022  CALL	R6	3
+      0x8818010C,  //  0023  GETMBR	R6	R0	K12
+      0x88180D0D,  //  0024  GETMBR	R6	R6	K13
+      0x88180D0E,  //  0025  GETMBR	R6	R6	K14
+      0x8C180D0F,  //  0026  GETMET	R6	R6	K15
+      0x5C200A00,  //  0027  MOVE	R8	R5
+      0x7C180400,  //  0028  CALL	R6	2
+      0x8C180110,  //  0029  GETMET	R6	R0	K16
+      0x5C200A00,  //  002A  MOVE	R8	R5
+      0x7C180400,  //  002B  CALL	R6	2
+      0x88180100,  //  002C  GETMBR	R6	R0	K0
+      0x8C180D11,  //  002D  GETMET	R6	R6	K17
+      0x5C200A00,  //  002E  MOVE	R8	R5
+      0x7C180400,  //  002F  CALL	R6	2
+      0x7001FFDB,  //  0030  JMP		#000D
+      0x580C0012,  //  0031  LDCONST	R3	K18
+      0xAC0C0200,  //  0032  CATCH	R3	1	0
+      0xB0080000,  //  0033  RAISE	2	R0	R0
+      0x880C0100,  //  0034  GETMBR	R3	R0	K0
+      0x8C0C0713,  //  0035  GETMET	R3	R3	K19
+      0x7C0C0200,  //  0036  CALL	R3	1
+      0x80000000,  //  0037  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: received_ack
+********************************************************************/
+be_local_closure(Matter_Device_received_ack,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(received_ack),
+    }),
+    be_str_weak(received_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: MtrJoin
+********************************************************************/
+be_local_closure(Matter_Device_MtrJoin,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K1   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(resp_cmnd_done),
+    }),
+    be_str_weak(MtrJoin),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x60140009,  //  0000  GETGBL	R5	G9
+      0x5C180600,  //  0001  MOVE	R6	R3
+      0x7C140200,  //  0002  CALL	R5	1
+      0x78160002,  //  0003  JMPF	R5	#0007
+      0x8C180100,  //  0004  GETMET	R6	R0	K0
+      0x7C180200,  //  0005  CALL	R6	1
+      0x70020001,  //  0006  JMP		#0009
+      0x8C180101,  //  0007  GETMET	R6	R0	K1
+      0x7C180200,  //  0008  CALL	R6	1
+      0xB81A0400,  //  0009  GETNGBL	R6	K2
+      0x8C180D03,  //  000A  GETMET	R6	R6	K3
+      0x7C180200,  //  000B  CALL	R6	1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_plugin_class_displayname
+********************************************************************/
+be_local_closure(Matter_Device_get_plugin_class_displayname,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_classes),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(NAME),
+    /* K3   */  be_nested_str_weak(),
+    }),
+    be_str_weak(get_plugin_class_displayname),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x880C0502,  //  0005  GETMBR	R3	R2	K2
+      0x70020000,  //  0006  JMP		#0008
+      0x580C0003,  //  0007  LDCONST	R3	K3
+      0x80040600,  //  0008  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_remotes_info
+********************************************************************/
+be_local_closure(Matter_Device_update_remotes_info,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(http_remotes),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(get_info),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(stop_iteration),
+    /* K5   */  be_nested_str_weak(plugins_config_remotes),
+    }),
+    be_str_weak(update_remotes_info),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x60040013,  //  0000  GETGBL	R1	G19
+      0x7C040000,  //  0001  CALL	R1	0
+      0x88080100,  //  0002  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x20080403,  //  0004  NE	R2	R2	R3
+      0x780A0018,  //  0005  JMPF	R2	#001F
+      0x60080010,  //  0006  GETGBL	R2	G16
+      0x880C0100,  //  0007  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0008  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x7C080200,  //  000A  CALL	R2	1
+      0xA802000F,  //  000B  EXBLK	0	#001C
+      0x5C0C0400,  //  000C  MOVE	R3	R2
+      0x7C0C0000,  //  000D  CALL	R3	0
+      0x88100100,  //  000E  GETMBR	R4	R0	K0
+      0x94100803,  //  000F  GETIDX	R4	R4	R3
+      0x8C100902,  //  0010  GETMET	R4	R4	K2
+      0x7C100200,  //  0011  CALL	R4	1
+      0x4C140000,  //  0012  LDNIL	R5
+      0x20140805,  //  0013  NE	R5	R4	R5
+      0x78160005,  //  0014  JMPF	R5	#001B
+      0x6014000C,  //  0015  GETGBL	R5	G12
+      0x5C180800,  //  0016  MOVE	R6	R4
+      0x7C140200,  //  0017  CALL	R5	1
+      0x24140B03,  //  0018  GT	R5	R5	K3
+      0x78160000,  //  0019  JMPF	R5	#001B
+      0x98040604,  //  001A  SETIDX	R1	R3	R4
+      0x7001FFEF,  //  001B  JMP		#000C
+      0x58080004,  //  001C  LDCONST	R2	K4
+      0xAC080200,  //  001D  CATCH	R2	1	0
+      0xB0080000,  //  001E  RAISE	2	R0	R0
+      0x90020A01,  //  001F  SETMBR	R0	K5	R1
+      0x80040200,  //  0020  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: autoconf_device
+********************************************************************/
+be_local_closure(Matter_Device_autoconf_device,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(plugins),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(plugins_persist),
+    /* K4   */  be_nested_str_weak(plugins_config),
+    /* K5   */  be_nested_str_weak(autoconf_device_map),
+    /* K6   */  be_nested_str_weak(plugins_config_remotes),
+    /* K7   */  be_nested_str_weak(adjust_next_ep),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(log),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(_instantiate_plugins_from_config),
+    /* K13  */  be_nested_str_weak(sessions),
+    /* K14  */  be_nested_str_weak(count_active_fabrics),
+    /* K15  */  be_nested_str_weak(save_param),
+    }),
+    be_str_weak(autoconf_device),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x24080502,  //  0004  GT	R2	R2	K2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x80000400,  //  0006  RET	0
+      0x88080103,  //  0007  GETMBR	R2	R0	K3
+      0x740A000F,  //  0008  JMPT	R2	#0019
+      0x8C080105,  //  0009  GETMET	R2	R0	K5
+      0x7C080200,  //  000A  CALL	R2	1
+      0x90020802,  //  000B  SETMBR	R0	K4	R2
+      0x60080013,  //  000C  GETGBL	R2	G19
+      0x7C080000,  //  000D  CALL	R2	0
+      0x90020C02,  //  000E  SETMBR	R0	K6	R2
+      0x8C080107,  //  000F  GETMET	R2	R0	K7
+      0x7C080200,  //  0010  CALL	R2	1
+      0xB80A1000,  //  0011  GETNGBL	R2	K8
+      0x8C080509,  //  0012  GETMET	R2	R2	K9
+      0x60100008,  //  0013  GETGBL	R4	G8
+      0x88140104,  //  0014  GETMBR	R5	R0	K4
+      0x7C100200,  //  0015  CALL	R4	1
+      0x00121404,  //  0016  ADD	R4	K10	R4
+      0x5814000B,  //  0017  LDCONST	R5	K11
+      0x7C080600,  //  0018  CALL	R2	3
+      0x8C08010C,  //  0019  GETMET	R2	R0	K12
+      0x88100104,  //  001A  GETMBR	R4	R0	K4
+      0x7C080400,  //  001B  CALL	R2	2
+      0x88080103,  //  001C  GETMBR	R2	R0	K3
+      0x740A0008,  //  001D  JMPT	R2	#0027
+      0x8808010D,  //  001E  GETMBR	R2	R0	K13
+      0x8C08050E,  //  001F  GETMET	R2	R2	K14
+      0x7C080200,  //  0020  CALL	R2	1
+      0x24080502,  //  0021  GT	R2	R2	K2
+      0x780A0003,  //  0022  JMPF	R2	#0027
+      0x50080200,  //  0023  LDBOOL	R2	1	0
+      0x90020602,  //  0024  SETMBR	R0	K3	R2
+      0x8C08010F,  //  0025  GETMET	R2	R0	K15
+      0x7C080200,  //  0026  CALL	R2	1
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clean_remotes
+********************************************************************/
+be_local_closure(Matter_Device_clean_remotes,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[17]) {     /* constants */
+    /* K0   */  be_nested_str_weak(introspect),
+    /* K1   */  be_nested_str_weak(http_remotes),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_nested_str_weak(plugins),
+    /* K5   */  be_nested_str_weak(get),
+    /* K6   */  be_nested_str_weak(http_remote),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(keys),
+    /* K10  */  be_nested_str_weak(tasmota),
+    /* K11  */  be_nested_str_weak(log),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
+    /* K13  */  be_nested_str_weak(addr),
+    /* K14  */  be_const_int(3),
+    /* K15  */  be_nested_str_weak(close),
+    /* K16  */  be_nested_str_weak(remove),
+    }),
+    be_str_weak(clean_remotes),
+    &be_const_str_solidified,
+    ( &(const binstruction[66]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x780A003D,  //  0002  JMPF	R2	#0041
+      0x60080013,  //  0003  GETGBL	R2	G19
+      0x7C080000,  //  0004  CALL	R2	0
+      0x600C0010,  //  0005  GETGBL	R3	G16
+      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0xA8020003,  //  0008  EXBLK	0	#000D
+      0x5C100600,  //  0009  MOVE	R4	R3
+      0x7C100000,  //  000A  CALL	R4	0
+      0x98080902,  //  000B  SETIDX	R2	R4	K2
+      0x7001FFFB,  //  000C  JMP		#0009
+      0x580C0003,  //  000D  LDCONST	R3	K3
+      0xAC0C0200,  //  000E  CATCH	R3	1	0
+      0xB0080000,  //  000F  RAISE	2	R0	R0
+      0x600C0010,  //  0010  GETGBL	R3	G16
+      0x88100104,  //  0011  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  0012  CALL	R3	1
+      0xA802000F,  //  0013  EXBLK	0	#0024
+      0x5C100600,  //  0014  MOVE	R4	R3
+      0x7C100000,  //  0015  CALL	R4	0
+      0x8C140305,  //  0016  GETMET	R5	R1	K5
+      0x5C1C0800,  //  0017  MOVE	R7	R4
+      0x58200006,  //  0018  LDCONST	R8	K6
+      0x7C140600,  //  0019  CALL	R5	3
+      0x4C180000,  //  001A  LDNIL	R6
+      0x20180A06,  //  001B  NE	R6	R5	R6
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C180507,  //  001D  GETMET	R6	R2	K7
+      0x5C200A00,  //  001E  MOVE	R8	R5
+      0x58240002,  //  001F  LDCONST	R9	K2
+      0x7C180600,  //  0020  CALL	R6	3
+      0x00180D08,  //  0021  ADD	R6	R6	K8
+      0x98080A06,  //  0022  SETIDX	R2	R5	R6
+      0x7001FFEF,  //  0023  JMP		#0014
+      0x580C0003,  //  0024  LDCONST	R3	K3
+      0xAC0C0200,  //  0025  CATCH	R3	1	0
+      0xB0080000,  //  0026  RAISE	2	R0	R0
+      0x600C0010,  //  0027  GETGBL	R3	G16
+      0x8C100509,  //  0028  GETMET	R4	R2	K9
+      0x7C100200,  //  0029  CALL	R4	1
+      0x7C0C0200,  //  002A  CALL	R3	1
+      0xA8020011,  //  002B  EXBLK	0	#003E
+      0x5C100600,  //  002C  MOVE	R4	R3
+      0x7C100000,  //  002D  CALL	R4	0
+      0x94140404,  //  002E  GETIDX	R5	R2	R4
+      0x1C140B02,  //  002F  EQ	R5	R5	K2
+      0x7816000B,  //  0030  JMPF	R5	#003D
+      0xB8161400,  //  0031  GETNGBL	R5	K10
+      0x8C140B0B,  //  0032  GETMET	R5	R5	K11
+      0x881C090D,  //  0033  GETMBR	R7	R4	K13
+      0x001E1807,  //  0034  ADD	R7	K12	R7
+      0x5820000E,  //  0035  LDCONST	R8	K14
+      0x7C140600,  //  0036  CALL	R5	3
+      0x8C14090F,  //  0037  GETMET	R5	R4	K15
+      0x7C140200,  //  0038  CALL	R5	1
+      0x88140101,  //  0039  GETMBR	R5	R0	K1
+      0x8C140B10,  //  003A  GETMET	R5	R5	K16
+      0x5C1C0800,  //  003B  MOVE	R7	R4
+      0x7C140400,  //  003C  CALL	R5	2
+      0x7001FFED,  //  003D  JMP		#002C
+      0x580C0003,  //  003E  LDCONST	R3	K3
+      0xAC0C0200,  //  003F  CATCH	R3	1	0
+      0xB0080000,  //  0040  RAISE	2	R0	R0
+      0x80000000,  //  0041  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_announce_op_discovery_all_fabrics
+********************************************************************/
+be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(active_fabrics),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(mdns_announce_op_discovery),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(mdns_announce_op_discovery_all_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000B,  //  0005  EXBLK	0	#0012
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x780E0005,  //  000A  JMPF	R3	#0011
+      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x780E0002,  //  000D  JMPF	R3	#0011
+      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x7001FFF3,  //  0011  JMP		#0006
+      0x58040005,  //  0012  LDCONST	R1	K5
+      0xAC040200,  //  0013  CATCH	R1	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _trigger_read_sensors
+********************************************************************/
+be_local_closure(Matter_Device__trigger_read_sensors,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(read_sensors),
+    /* K3   */  be_nested_str_weak(load),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(plugins),
+    /* K6   */  be_nested_str_weak(parse_sensors),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
+    /* K10  */  be_const_int(3),
+    }),
+    be_str_weak(_trigger_read_sensors),
+    &be_const_str_solidified,
+    ( &(const binstruction[37]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x7C080200,  //  0003  CALL	R2	1
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x1C0C0403,  //  0005  EQ	R3	R2	R3
+      0x780E0000,  //  0006  JMPF	R3	#0008
+      0x80000600,  //  0007  RET	0
+      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
+      0x5C140400,  //  0009  MOVE	R5	R2
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x4C100000,  //  000B  LDNIL	R4
+      0x20100604,  //  000C  NE	R4	R3	R4
+      0x7812000D,  //  000D  JMPF	R4	#001C
+      0x58100004,  //  000E  LDCONST	R4	K4
+      0x6014000C,  //  000F  GETGBL	R5	G12
+      0x88180105,  //  0010  GETMBR	R6	R0	K5
+      0x7C140200,  //  0011  CALL	R5	1
+      0x14140805,  //  0012  LT	R5	R4	R5
+      0x78160006,  //  0013  JMPF	R5	#001B
+      0x88140105,  //  0014  GETMBR	R5	R0	K5
+      0x94140A04,  //  0015  GETIDX	R5	R5	R4
+      0x8C140B06,  //  0016  GETMET	R5	R5	K6
+      0x5C1C0600,  //  0017  MOVE	R7	R3
+      0x7C140400,  //  0018  CALL	R5	2
+      0x00100907,  //  0019  ADD	R4	R4	K7
+      0x7001FFF3,  //  001A  JMP		#000F
+      0x70020007,  //  001B  JMP		#0024
+      0xB8120200,  //  001C  GETNGBL	R4	K1
+      0x8C100908,  //  001D  GETMET	R4	R4	K8
+      0x60180008,  //  001E  GETGBL	R6	G8
+      0x5C1C0400,  //  001F  MOVE	R7	R2
+      0x7C180200,  //  0020  CALL	R6	1
+      0x001A1206,  //  0021  ADD	R6	K9	R6
+      0x581C000A,  //  0022  LDCONST	R7	K10
+      0x7C100600,  //  0023  CALL	R4	3
+      0x80000000,  //  0024  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_root_commissioning_open
+********************************************************************/
+be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    /* K1   */  be_nested_str_weak(commissioning_admin_fabric),
+    }),
+    be_str_weak(is_root_commissioning_open),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x4C080000,  //  0001  LDNIL	R2
       0x20040202,  //  0002  NE	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
+      0x78060003,  //  0003  JMPF	R1	#0008
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x4C080000,  //  0005  LDNIL	R2
+      0x1C040202,  //  0006  EQ	R1	R1	R2
+      0x74060000,  //  0007  JMPT	R1	#0009
+      0x50040001,  //  0008  LDBOOL	R1	0	1
+      0x50040200,  //  0009  LDBOOL	R1	1	0
+      0x80040200,  //  000A  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: compute_manual_pairing_code
+********************************************************************/
+be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(root_discriminator),
+    /* K1   */  be_nested_str_weak(root_passcode),
+    /* K2   */  be_nested_str_weak(_X251i_X2505i_X2504i),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(Verhoeff),
+    /* K5   */  be_nested_str_weak(checksum),
+    }),
+    be_str_weak(compute_manual_pairing_code),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x540A0FFE,  //  0001  LDINT	R2	4095
+      0x2C040202,  //  0002  AND	R1	R1	R2
+      0x540A0009,  //  0003  LDINT	R2	10
+      0x3C040202,  //  0004  SHR	R1	R1	R2
+      0x88080100,  //  0005  GETMBR	R2	R0	K0
+      0x540E02FF,  //  0006  LDINT	R3	768
+      0x2C080403,  //  0007  AND	R2	R2	R3
+      0x540E0005,  //  0008  LDINT	R3	6
+      0x38080403,  //  0009  SHL	R2	R2	R3
+      0x880C0101,  //  000A  GETMBR	R3	R0	K1
+      0x54123FFE,  //  000B  LDINT	R4	16383
+      0x2C0C0604,  //  000C  AND	R3	R3	R4
+      0x30080403,  //  000D  OR	R2	R2	R3
+      0x880C0101,  //  000E  GETMBR	R3	R0	K1
+      0x5412000D,  //  000F  LDINT	R4	14
+      0x3C0C0604,  //  0010  SHR	R3	R3	R4
+      0x60100018,  //  0011  GETGBL	R4	G24
+      0x58140002,  //  0012  LDCONST	R5	K2
+      0x5C180200,  //  0013  MOVE	R6	R1
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x5C200600,  //  0015  MOVE	R8	R3
+      0x7C100800,  //  0016  CALL	R4	4
+      0xB8160600,  //  0017  GETNGBL	R5	K3
+      0x88140B04,  //  0018  GETMBR	R5	R5	K4
+      0x8C140B05,  //  0019  GETMET	R5	R5	K5
+      0x5C1C0800,  //  001A  MOVE	R7	R4
+      0x7C140400,  //  001B  CALL	R5	2
+      0x00100805,  //  001C  ADD	R4	R4	R5
+      0x80040800,  //  001D  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: msg_send
+********************************************************************/
+be_local_closure(Matter_Device_msg_send,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(send_UDP),
+    }),
+    be_str_weak(msg_send),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(Matter_Device_start,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_trigger_read_sensors),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80000000,  //  0003  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(started),
+    /* K1   */  be_nested_str_weak(autoconf_device),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(add_cron),
+    /* K4   */  be_nested_str_weak(_X2A_X2F30_X20_X2A_X20_X2A_X20_X2A_X20_X2A_X20_X2A),
+    /* K5   */  be_nested_str_weak(matter_sensors_30s),
+    /* K6   */  be_nested_str_weak(_start_udp),
+    /* K7   */  be_nested_str_weak(UDP_PORT),
+    /* K8   */  be_nested_str_weak(start_mdns_announce_hostnames),
+    }),
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060000,  //  0001  JMPF	R1	#0003
+      0x80000200,  //  0002  RET	0
+      0x8C040101,  //  0003  GETMET	R1	R0	K1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xB8060400,  //  0005  GETNGBL	R1	K2
+      0x8C040303,  //  0006  GETMET	R1	R1	K3
+      0x580C0004,  //  0007  LDCONST	R3	K4
+      0x84100000,  //  0008  CLOSURE	R4	P0
+      0x58140005,  //  0009  LDCONST	R5	K5
+      0x7C040800,  //  000A  CALL	R1	4
+      0x8C040106,  //  000B  GETMET	R1	R0	K6
+      0x880C0107,  //  000C  GETMBR	R3	R0	K7
+      0x7C040400,  //  000D  CALL	R1	2
+      0x8C040108,  //  000E  GETMET	R1	R0	K8
+      0x7C040200,  //  000F  CALL	R1	1
+      0x50040200,  //  0010  LDBOOL	R1	1	0
+      0x90020001,  //  0011  SETMBR	R0	K0	R1
+      0xA0000000,  //  0012  CLOSE	R0
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: bridge_add_endpoint
+********************************************************************/
+be_local_closure(Matter_Device_bridge_add_endpoint,   /* name */
+  be_nested_proto(
+    17,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[21]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_classes),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+    /* K5   */  be_nested_str_weak(_X27_X20skipping),
+    /* K6   */  be_const_int(3),
+    /* K7   */  be_nested_str_weak(next_ep),
+    /* K8   */  be_nested_str_weak(plugins),
+    /* K9   */  be_nested_str_weak(push),
+    /* K10  */  be_nested_str_weak(type),
+    /* K11  */  be_nested_str_weak(keys),
+    /* K12  */  be_nested_str_weak(stop_iteration),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
+    /* K14  */  be_nested_str_weak(conf_to_log),
+    /* K15  */  be_const_int(2),
+    /* K16  */  be_nested_str_weak(plugins_config),
+    /* K17  */  be_nested_str_weak(plugins_persist),
+    /* K18  */  be_const_int(1),
+    /* K19  */  be_nested_str_weak(save_param),
+    /* K20  */  be_nested_str_weak(signal_endpoints_changed),
+    }),
+    be_str_weak(bridge_add_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[70]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x4C100000,  //  0004  LDNIL	R4
+      0x1C100604,  //  0005  EQ	R4	R3	R4
+      0x78120009,  //  0006  JMPF	R4	#0011
+      0xB8120400,  //  0007  GETNGBL	R4	K2
+      0x8C100903,  //  0008  GETMET	R4	R4	K3
+      0x60180008,  //  0009  GETGBL	R6	G8
+      0x5C1C0200,  //  000A  MOVE	R7	R1
+      0x7C180200,  //  000B  CALL	R6	1
+      0x001A0806,  //  000C  ADD	R6	K4	R6
+      0x00180D05,  //  000D  ADD	R6	R6	K5
+      0x581C0006,  //  000E  LDCONST	R7	K6
+      0x7C100600,  //  000F  CALL	R4	3
+      0x80000800,  //  0010  RET	0
+      0x88100107,  //  0011  GETMBR	R4	R0	K7
+      0x60140008,  //  0012  GETGBL	R5	G8
+      0x5C180800,  //  0013  MOVE	R6	R4
+      0x7C140200,  //  0014  CALL	R5	1
+      0x5C180600,  //  0015  MOVE	R6	R3
+      0x5C1C0000,  //  0016  MOVE	R7	R0
+      0x5C200800,  //  0017  MOVE	R8	R4
+      0x5C240400,  //  0018  MOVE	R9	R2
+      0x7C180600,  //  0019  CALL	R6	3
+      0x881C0108,  //  001A  GETMBR	R7	R0	K8
+      0x8C1C0F09,  //  001B  GETMET	R7	R7	K9
+      0x5C240C00,  //  001C  MOVE	R9	R6
+      0x7C1C0400,  //  001D  CALL	R7	2
+      0x601C0013,  //  001E  GETGBL	R7	G19
+      0x7C1C0000,  //  001F  CALL	R7	0
+      0x981E1401,  //  0020  SETIDX	R7	K10	R1
+      0x60200010,  //  0021  GETGBL	R8	G16
+      0x8C24050B,  //  0022  GETMET	R9	R2	K11
+      0x7C240200,  //  0023  CALL	R9	1
+      0x7C200200,  //  0024  CALL	R8	1
+      0xA8020004,  //  0025  EXBLK	0	#002B
+      0x5C241000,  //  0026  MOVE	R9	R8
+      0x7C240000,  //  0027  CALL	R9	0
+      0x94280409,  //  0028  GETIDX	R10	R2	R9
+      0x981C120A,  //  0029  SETIDX	R7	R9	R10
+      0x7001FFFA,  //  002A  JMP		#0026
+      0x5820000C,  //  002B  LDCONST	R8	K12
+      0xAC200200,  //  002C  CATCH	R8	1	0
+      0xB0080000,  //  002D  RAISE	2	R0	R0
+      0xB8220400,  //  002E  GETNGBL	R8	K2
+      0x8C201103,  //  002F  GETMET	R8	R8	K3
+      0x60280018,  //  0030  GETGBL	R10	G24
+      0x582C000D,  //  0031  LDCONST	R11	K13
+      0x5C300800,  //  0032  MOVE	R12	R4
+      0x5C340200,  //  0033  MOVE	R13	R1
+      0x8C38010E,  //  0034  GETMET	R14	R0	K14
+      0x5C400400,  //  0035  MOVE	R16	R2
+      0x7C380400,  //  0036  CALL	R14	2
+      0x7C280800,  //  0037  CALL	R10	4
+      0x582C000F,  //  0038  LDCONST	R11	K15
+      0x7C200600,  //  0039  CALL	R8	3
+      0x88200110,  //  003A  GETMBR	R8	R0	K16
+      0x98200A07,  //  003B  SETIDX	R8	R5	R7
+      0x50200200,  //  003C  LDBOOL	R8	1	0
+      0x90022208,  //  003D  SETMBR	R0	K17	R8
+      0x88200107,  //  003E  GETMBR	R8	R0	K7
+      0x00201112,  //  003F  ADD	R8	R8	K18
+      0x90020E08,  //  0040  SETMBR	R0	K7	R8
+      0x8C200113,  //  0041  GETMET	R8	R0	K19
+      0x7C200200,  //  0042  CALL	R8	1
+      0x8C200114,  //  0043  GETMET	R8	R0	K20
+      0x7C200200,  //  0044  CALL	R8	1
+      0x80040800,  //  0045  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Device_every_second,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(every_second),
+    /* K2   */  be_nested_str_weak(message_handler),
+    /* K3   */  be_nested_str_weak(commissioning_open),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(time_reached),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040102,  //  0003  GETMBR	R1	R0	K2
+      0x8C040301,  //  0004  GETMET	R1	R1	K1
+      0x7C040200,  //  0005  CALL	R1	1
+      0x88040103,  //  0006  GETMBR	R1	R0	K3
+      0x4C080000,  //  0007  LDNIL	R2
+      0x20040202,  //  0008  NE	R1	R1	R2
+      0x78060006,  //  0009  JMPF	R1	#0011
+      0xB8060800,  //  000A  GETNGBL	R1	K4
+      0x8C040305,  //  000B  GETMET	R1	R1	K5
+      0x880C0103,  //  000C  GETMBR	R3	R0	K3
+      0x7C040400,  //  000D  CALL	R1	2
+      0x78060001,  //  000E  JMPF	R1	#0011
+      0x4C040000,  //  000F  LDNIL	R1
+      0x90020601,  //  0010  SETMBR	R0	K3	R1
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_plugin_remote_info
+********************************************************************/
+be_local_closure(Matter_Device_get_plugin_remote_info,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_config_remotes),
+    /* K1   */  be_nested_str_weak(find),
+    }),
+    be_str_weak(get_plugin_remote_info),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x60140013,  //  0003  GETGBL	R5	G19
+      0x7C140000,  //  0004  CALL	R5	0
+      0x7C080600,  //  0005  CALL	R2	3
+      0x80040400,  //  0006  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Device_invoke_request,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(endpoint),
+    /* K2   */  be_nested_str_weak(plugins),
+    /* K3   */  be_nested_str_weak(invoke_request),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(status),
+    /* K6   */  be_nested_str_weak(matter),
+    /* K7   */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+    }),
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58100000,  //  0000  LDCONST	R4	K0
+      0x88140701,  //  0001  GETMBR	R5	R3	K1
+      0x6018000C,  //  0002  GETGBL	R6	G12
+      0x881C0102,  //  0003  GETMBR	R7	R0	K2
+      0x7C180200,  //  0004  CALL	R6	1
+      0x14180806,  //  0005  LT	R6	R4	R6
+      0x781A000C,  //  0006  JMPF	R6	#0014
+      0x88180102,  //  0007  GETMBR	R6	R0	K2
+      0x94180C04,  //  0008  GETIDX	R6	R6	R4
+      0x881C0D01,  //  0009  GETMBR	R7	R6	K1
+      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
+      0x781E0005,  //  000B  JMPF	R7	#0012
+      0x8C1C0D03,  //  000C  GETMET	R7	R6	K3
+      0x5C240200,  //  000D  MOVE	R9	R1
+      0x5C280400,  //  000E  MOVE	R10	R2
+      0x5C2C0600,  //  000F  MOVE	R11	R3
+      0x7C1C0800,  //  0010  CALL	R7	4
+      0x80040E00,  //  0011  RET	1	R7
+      0x00100904,  //  0012  ADD	R4	R4	K4
+      0x7001FFED,  //  0013  JMP		#0002
+      0xB81A0C00,  //  0014  GETNGBL	R6	K6
+      0x88180D07,  //  0015  GETMBR	R6	R6	K7
+      0x900E0A06,  //  0016  SETMBR	R3	K5	R6
+      0x80000000,  //  0017  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: attribute_updated
+********************************************************************/
+be_local_closure(Matter_Device_attribute_updated,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Path),
+    /* K2   */  be_nested_str_weak(endpoint),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_nested_str_weak(message_handler),
+    /* K6   */  be_nested_str_weak(im),
+    /* K7   */  be_nested_str_weak(subs_shop),
+    /* K8   */  be_nested_str_weak(attribute_updated_ctx),
+    }),
+    be_str_weak(attribute_updated),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140805,  //  0001  EQ	R5	R4	R5
+      0x78160000,  //  0002  JMPF	R5	#0004
+      0x50100000,  //  0003  LDBOOL	R4	0	0
+      0xB8160000,  //  0004  GETNGBL	R5	K0
+      0x8C140B01,  //  0005  GETMET	R5	R5	K1
+      0x7C140200,  //  0006  CALL	R5	1
+      0x90160401,  //  0007  SETMBR	R5	K2	R1
+      0x90160602,  //  0008  SETMBR	R5	K3	R2
+      0x90160803,  //  0009  SETMBR	R5	K4	R3
+      0x88180105,  //  000A  GETMBR	R6	R0	K5
+      0x88180D06,  //  000B  GETMBR	R6	R6	K6
+      0x88180D07,  //  000C  GETMBR	R6	R6	K7
+      0x8C180D08,  //  000D  GETMET	R6	R6	K8
+      0x5C200A00,  //  000E  MOVE	R8	R5
+      0x5C240800,  //  000F  MOVE	R9	R4
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_plugin_class
+********************************************************************/
+be_local_closure(Matter_Device_register_plugin_class,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(introspect),
+    /* K1   */  be_nested_str_weak(get),
+    /* K2   */  be_nested_str_weak(TYPE),
+    /* K3   */  be_nested_str_weak(plugins_classes),
+    }),
+    be_str_weak(register_plugin_class),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x58180002,  //  0003  LDCONST	R6	K2
+      0x7C0C0600,  //  0004  CALL	R3	3
+      0x780E0001,  //  0005  JMPF	R3	#0008
+      0x88100103,  //  0006  GETMBR	R4	R0	K3
+      0x98100601,  //  0007  SETIDX	R4	R3	R1
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_param
+********************************************************************/
+be_local_closure(Matter_Device_save_param,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[30]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(update_remotes_info),
+    /* K2   */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
+    /* K3   */  be_nested_str_weak(root_discriminator),
+    /* K4   */  be_nested_str_weak(root_passcode),
+    /* K5   */  be_nested_str_weak(ipv4only),
+    /* K6   */  be_nested_str_weak(true),
+    /* K7   */  be_nested_str_weak(false),
+    /* K8   */  be_nested_str_weak(next_ep),
+    /* K9   */  be_nested_str_weak(plugins_persist),
+    /* K10  */  be_nested_str_weak(_X2C_X22config_X22_X3A),
+    /* K11  */  be_nested_str_weak(dump),
+    /* K12  */  be_nested_str_weak(plugins_config),
+    /* K13  */  be_nested_str_weak(plugins_config_remotes),
+    /* K14  */  be_const_int(0),
+    /* K15  */  be_nested_str_weak(_X2C_X22remotes_X22_X3A),
+    /* K16  */  be_nested_str_weak(_X7D),
+    /* K17  */  be_nested_str_weak(FILENAME),
+    /* K18  */  be_nested_str_weak(w),
+    /* K19  */  be_nested_str_weak(write),
+    /* K20  */  be_nested_str_weak(close),
+    /* K21  */  be_nested_str_weak(tasmota),
+    /* K22  */  be_nested_str_weak(log),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
+    /* K24  */  be_nested_str_weak(_X20and_X20configuration),
+    /* K25  */  be_nested_str_weak(),
+    /* K26  */  be_const_int(3),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+    /* K28  */  be_nested_str_weak(_X7C),
+    /* K29  */  be_const_int(2),
+    }),
+    be_str_weak(save_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[77]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x60080018,  //  0003  GETGBL	R2	G24
+      0x580C0002,  //  0004  LDCONST	R3	K2
+      0x88100103,  //  0005  GETMBR	R4	R0	K3
+      0x88140104,  //  0006  GETMBR	R5	R0	K4
+      0x88180105,  //  0007  GETMBR	R6	R0	K5
+      0x781A0001,  //  0008  JMPF	R6	#000B
+      0x58180006,  //  0009  LDCONST	R6	K6
+      0x70020000,  //  000A  JMP		#000C
+      0x58180007,  //  000B  LDCONST	R6	K7
+      0x881C0108,  //  000C  GETMBR	R7	R0	K8
+      0x7C080A00,  //  000D  CALL	R2	5
+      0x880C0109,  //  000E  GETMBR	R3	R0	K9
+      0x780E000E,  //  000F  JMPF	R3	#001F
+      0x0008050A,  //  0010  ADD	R2	R2	K10
+      0x8C0C030B,  //  0011  GETMET	R3	R1	K11
+      0x8814010C,  //  0012  GETMBR	R5	R0	K12
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x00080403,  //  0014  ADD	R2	R2	R3
+      0x600C000C,  //  0015  GETGBL	R3	G12
+      0x8810010D,  //  0016  GETMBR	R4	R0	K13
+      0x7C0C0200,  //  0017  CALL	R3	1
+      0x240C070E,  //  0018  GT	R3	R3	K14
+      0x780E0004,  //  0019  JMPF	R3	#001F
+      0x0008050F,  //  001A  ADD	R2	R2	K15
+      0x8C0C030B,  //  001B  GETMET	R3	R1	K11
+      0x8814010D,  //  001C  GETMBR	R5	R0	K13
+      0x7C0C0400,  //  001D  CALL	R3	2
+      0x00080403,  //  001E  ADD	R2	R2	R3
+      0x00080510,  //  001F  ADD	R2	R2	K16
+      0xA8020018,  //  0020  EXBLK	0	#003A
+      0x600C0011,  //  0021  GETGBL	R3	G17
+      0x88100111,  //  0022  GETMBR	R4	R0	K17
+      0x58140012,  //  0023  LDCONST	R5	K18
+      0x7C0C0400,  //  0024  CALL	R3	2
+      0x8C100713,  //  0025  GETMET	R4	R3	K19
+      0x5C180400,  //  0026  MOVE	R6	R2
+      0x7C100400,  //  0027  CALL	R4	2
+      0x8C100714,  //  0028  GETMET	R4	R3	K20
+      0x7C100200,  //  0029  CALL	R4	1
+      0xB8122A00,  //  002A  GETNGBL	R4	K21
+      0x8C100916,  //  002B  GETMET	R4	R4	K22
+      0x60180018,  //  002C  GETGBL	R6	G24
+      0x581C0017,  //  002D  LDCONST	R7	K23
+      0x88200109,  //  002E  GETMBR	R8	R0	K9
+      0x78220001,  //  002F  JMPF	R8	#0032
+      0x58200018,  //  0030  LDCONST	R8	K24
+      0x70020000,  //  0031  JMP		#0033
+      0x58200019,  //  0032  LDCONST	R8	K25
+      0x7C180400,  //  0033  CALL	R6	2
+      0x581C001A,  //  0034  LDCONST	R7	K26
+      0x7C100600,  //  0035  CALL	R4	3
+      0xA8040001,  //  0036  EXBLK	1	1
+      0x80040400,  //  0037  RET	1	R2
+      0xA8040001,  //  0038  EXBLK	1	1
+      0x70020011,  //  0039  JMP		#004C
+      0xAC0C0002,  //  003A  CATCH	R3	0	2
+      0x7002000E,  //  003B  JMP		#004B
+      0xB8162A00,  //  003C  GETNGBL	R5	K21
+      0x8C140B16,  //  003D  GETMET	R5	R5	K22
+      0x601C0008,  //  003E  GETGBL	R7	G8
+      0x5C200600,  //  003F  MOVE	R8	R3
+      0x7C1C0200,  //  0040  CALL	R7	1
+      0x001E3607,  //  0041  ADD	R7	K27	R7
+      0x001C0F1C,  //  0042  ADD	R7	R7	K28
+      0x60200008,  //  0043  GETGBL	R8	G8
+      0x5C240800,  //  0044  MOVE	R9	R4
+      0x7C200200,  //  0045  CALL	R8	1
+      0x001C0E08,  //  0046  ADD	R7	R7	R8
+      0x5820001D,  //  0047  LDCONST	R8	K29
+      0x7C140600,  //  0048  CALL	R5	3
+      0x80040400,  //  0049  RET	1	R2
+      0x70020000,  //  004A  JMP		#004C
+      0xB0080000,  //  004B  RAISE	2	R0	R0
+      0x80000000,  //  004C  RET	0
     })
   )
 );
@@ -219,470 +4124,6 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
       0x8C100119,  //  0089  GETMET	R4	R0	K25
       0x7C100200,  //  008A  CALL	R4	1
       0x80000000,  //  008B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_before_restart
-********************************************************************/
-be_local_closure(Matter_Device_save_before_restart,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K1   */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
-    }),
-    be_str_weak(save_before_restart),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
-      0x7C040200,  //  0003  CALL	R1	1
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_remove_op_discovery
-********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(get_device_id),
-    /* K2   */  be_nested_str_weak(copy),
-    /* K3   */  be_nested_str_weak(reverse),
-    /* K4   */  be_nested_str_weak(get_fabric_compressed),
-    /* K5   */  be_nested_str_weak(tohex),
-    /* K6   */  be_nested_str_weak(_X2D),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(eth),
-    /* K9   */  be_nested_str_weak(find),
-    /* K10  */  be_nested_str_weak(up),
-    /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(remove_service),
-    /* K15  */  be_nested_str_weak(_matter),
-    /* K16  */  be_nested_str_weak(_tcp),
-    /* K17  */  be_nested_str_weak(hostname_eth),
-    /* K18  */  be_nested_str_weak(wifi),
-    /* K19  */  be_nested_str_weak(hostname_wifi),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K21  */  be_nested_str_weak(_X7C),
-    /* K22  */  be_const_int(2),
-    }),
-    be_str_weak(mdns_remove_op_discovery),
-    &be_const_str_solidified,
-    ( &(const binstruction[80]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA802003B,  //  0001  EXBLK	0	#003E
-      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x8C100304,  //  0008  GETMET	R4	R1	K4
-      0x7C100200,  //  0009  CALL	R4	1
-      0x8C140905,  //  000A  GETMET	R5	R4	K5
-      0x7C140200,  //  000B  CALL	R5	1
-      0x00140B06,  //  000C  ADD	R5	R5	K6
-      0x8C180705,  //  000D  GETMET	R6	R3	K5
-      0x7C180200,  //  000E  CALL	R6	1
-      0x00140A06,  //  000F  ADD	R5	R5	R6
-      0xB81A0E00,  //  0010  GETNGBL	R6	K7
-      0x8C180D08,  //  0011  GETMET	R6	R6	K8
-      0x7C180200,  //  0012  CALL	R6	1
-      0x8C180D09,  //  0013  GETMET	R6	R6	K9
-      0x5820000A,  //  0014  LDCONST	R8	K10
-      0x7C180400,  //  0015  CALL	R6	2
-      0x781A000E,  //  0016  JMPF	R6	#0026
-      0xB81A0E00,  //  0017  GETNGBL	R6	K7
-      0x8C180D0B,  //  0018  GETMET	R6	R6	K11
-      0x60200018,  //  0019  GETGBL	R8	G24
-      0x5824000C,  //  001A  LDCONST	R9	K12
-      0x58280008,  //  001B  LDCONST	R10	K8
-      0x5C2C0A00,  //  001C  MOVE	R11	R5
-      0x7C200600,  //  001D  CALL	R8	3
-      0x5824000D,  //  001E  LDCONST	R9	K13
-      0x7C180600,  //  001F  CALL	R6	3
-      0x8C18050E,  //  0020  GETMET	R6	R2	K14
-      0x5820000F,  //  0021  LDCONST	R8	K15
-      0x58240010,  //  0022  LDCONST	R9	K16
-      0x5C280A00,  //  0023  MOVE	R10	R5
-      0x882C0111,  //  0024  GETMBR	R11	R0	K17
-      0x7C180A00,  //  0025  CALL	R6	5
-      0xB81A0E00,  //  0026  GETNGBL	R6	K7
-      0x8C180D12,  //  0027  GETMET	R6	R6	K18
-      0x7C180200,  //  0028  CALL	R6	1
-      0x8C180D09,  //  0029  GETMET	R6	R6	K9
-      0x5820000A,  //  002A  LDCONST	R8	K10
-      0x7C180400,  //  002B  CALL	R6	2
-      0x781A000E,  //  002C  JMPF	R6	#003C
-      0xB81A0E00,  //  002D  GETNGBL	R6	K7
-      0x8C180D0B,  //  002E  GETMET	R6	R6	K11
-      0x60200018,  //  002F  GETGBL	R8	G24
-      0x5824000C,  //  0030  LDCONST	R9	K12
-      0x58280012,  //  0031  LDCONST	R10	K18
-      0x5C2C0A00,  //  0032  MOVE	R11	R5
-      0x7C200600,  //  0033  CALL	R8	3
-      0x5824000D,  //  0034  LDCONST	R9	K13
-      0x7C180600,  //  0035  CALL	R6	3
-      0x8C18050E,  //  0036  GETMET	R6	R2	K14
-      0x5820000F,  //  0037  LDCONST	R8	K15
-      0x58240010,  //  0038  LDCONST	R9	K16
-      0x5C280A00,  //  0039  MOVE	R10	R5
-      0x882C0113,  //  003A  GETMBR	R11	R0	K19
-      0x7C180A00,  //  003B  CALL	R6	5
-      0xA8040001,  //  003C  EXBLK	1	1
-      0x70020010,  //  003D  JMP		#004F
-      0xAC0C0002,  //  003E  CATCH	R3	0	2
-      0x7002000D,  //  003F  JMP		#004E
-      0xB8160E00,  //  0040  GETNGBL	R5	K7
-      0x8C140B0B,  //  0041  GETMET	R5	R5	K11
-      0x601C0008,  //  0042  GETGBL	R7	G8
-      0x5C200600,  //  0043  MOVE	R8	R3
-      0x7C1C0200,  //  0044  CALL	R7	1
-      0x001E2807,  //  0045  ADD	R7	K20	R7
-      0x001C0F15,  //  0046  ADD	R7	R7	K21
-      0x60200008,  //  0047  GETGBL	R8	G8
-      0x5C240800,  //  0048  MOVE	R9	R4
-      0x7C200200,  //  0049  CALL	R8	1
-      0x001C0E08,  //  004A  ADD	R7	R7	R8
-      0x58200016,  //  004B  LDCONST	R8	K22
-      0x7C140600,  //  004C  CALL	R5	3
-      0x70020000,  //  004D  JMP		#004F
-      0xB0080000,  //  004E  RAISE	2	R0	R0
-      0x80000000,  //  004F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(Matter_Device_every_second,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(every_second),
-    /* K2   */  be_nested_str_weak(message_handler),
-    /* K3   */  be_nested_str_weak(commissioning_open),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(time_reached),
-    }),
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040102,  //  0003  GETMBR	R1	R0	K2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
-      0x7C040200,  //  0005  CALL	R1	1
-      0x88040103,  //  0006  GETMBR	R1	R0	K3
-      0x4C080000,  //  0007  LDNIL	R2
-      0x20040202,  //  0008  NE	R1	R1	R2
-      0x78060006,  //  0009  JMPF	R1	#0011
-      0xB8060800,  //  000A  GETNGBL	R1	K4
-      0x8C040305,  //  000B  GETMET	R1	R1	K5
-      0x880C0103,  //  000C  GETMBR	R3	R0	K3
-      0x7C040400,  //  000D  CALL	R1	2
-      0x78060001,  //  000E  JMPF	R1	#0011
-      0x4C040000,  //  000F  LDNIL	R1
-      0x90020601,  //  0010  SETMBR	R0	K3	R1
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_announce_op_discovery_all_fabrics
-********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(active_fabrics),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(mdns_announce_op_discovery),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(mdns_announce_op_discovery_all_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000B,  //  0005  EXBLK	0	#0012
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x780E0005,  //  000A  JMPF	R3	#0011
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x780E0002,  //  000D  JMPF	R3	#0011
-      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x7001FFF3,  //  0011  JMP		#0006
-      0x58040005,  //  0012  LDCONST	R1	K5
-      0xAC040200,  //  0013  CATCH	R1	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: autoconf_sensors_list
-********************************************************************/
-be_local_closure(Matter_Device_autoconf_sensors_list,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(k2l),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(Temperature),
-    /* K3   */  be_nested_str_weak(_X23Temperature),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_nested_str_weak(type),
-    /* K6   */  be_nested_str_weak(temperature),
-    /* K7   */  be_nested_str_weak(filter),
-    /* K8   */  be_nested_str_weak(stop_iteration),
-    /* K9   */  be_nested_str_weak(Pressure),
-    /* K10  */  be_nested_str_weak(_X23Pressure),
-    /* K11  */  be_nested_str_weak(pressure),
-    /* K12  */  be_nested_str_weak(Illuminance),
-    /* K13  */  be_nested_str_weak(_X23Illuminance),
-    /* K14  */  be_nested_str_weak(illuminance),
-    /* K15  */  be_nested_str_weak(Humidity),
-    /* K16  */  be_nested_str_weak(_X23Humidity),
-    /* K17  */  be_nested_str_weak(humidity),
-    }),
-    be_str_weak(autoconf_sensors_list),
-    &be_const_str_solidified,
-    ( &(const binstruction[119]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x8C100100,  //  0003  GETMET	R4	R0	K0
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x7C100400,  //  0005  CALL	R4	2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0xA8020013,  //  0007  EXBLK	0	#001C
-      0x5C100600,  //  0008  MOVE	R4	R3
-      0x7C100000,  //  0009  CALL	R4	0
-      0x94140204,  //  000A  GETIDX	R5	R1	R4
-      0x6018000F,  //  000B  GETGBL	R6	G15
-      0x5C1C0A00,  //  000C  MOVE	R7	R5
-      0x60200013,  //  000D  GETGBL	R8	G19
-      0x7C180400,  //  000E  CALL	R6	2
-      0x781A000A,  //  000F  JMPF	R6	#001B
-      0x8C180B01,  //  0010  GETMET	R6	R5	K1
-      0x58200002,  //  0011  LDCONST	R8	K2
-      0x7C180400,  //  0012  CALL	R6	2
-      0x781A0006,  //  0013  JMPF	R6	#001B
-      0x00180903,  //  0014  ADD	R6	R4	K3
-      0x8C1C0504,  //  0015  GETMET	R7	R2	K4
-      0x60240013,  //  0016  GETGBL	R9	G19
-      0x7C240000,  //  0017  CALL	R9	0
-      0x98260B06,  //  0018  SETIDX	R9	K5	K6
-      0x98260E06,  //  0019  SETIDX	R9	K7	R6
-      0x7C1C0400,  //  001A  CALL	R7	2
-      0x7001FFEB,  //  001B  JMP		#0008
-      0x580C0008,  //  001C  LDCONST	R3	K8
-      0xAC0C0200,  //  001D  CATCH	R3	1	0
-      0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x600C0010,  //  001F  GETGBL	R3	G16
-      0x8C100100,  //  0020  GETMET	R4	R0	K0
-      0x5C180200,  //  0021  MOVE	R6	R1
-      0x7C100400,  //  0022  CALL	R4	2
-      0x7C0C0200,  //  0023  CALL	R3	1
-      0xA8020013,  //  0024  EXBLK	0	#0039
-      0x5C100600,  //  0025  MOVE	R4	R3
-      0x7C100000,  //  0026  CALL	R4	0
-      0x94140204,  //  0027  GETIDX	R5	R1	R4
-      0x6018000F,  //  0028  GETGBL	R6	G15
-      0x5C1C0A00,  //  0029  MOVE	R7	R5
-      0x60200013,  //  002A  GETGBL	R8	G19
-      0x7C180400,  //  002B  CALL	R6	2
-      0x781A000A,  //  002C  JMPF	R6	#0038
-      0x8C180B01,  //  002D  GETMET	R6	R5	K1
-      0x58200009,  //  002E  LDCONST	R8	K9
-      0x7C180400,  //  002F  CALL	R6	2
-      0x781A0006,  //  0030  JMPF	R6	#0038
-      0x0018090A,  //  0031  ADD	R6	R4	K10
-      0x8C1C0504,  //  0032  GETMET	R7	R2	K4
-      0x60240013,  //  0033  GETGBL	R9	G19
-      0x7C240000,  //  0034  CALL	R9	0
-      0x98260B0B,  //  0035  SETIDX	R9	K5	K11
-      0x98260E06,  //  0036  SETIDX	R9	K7	R6
-      0x7C1C0400,  //  0037  CALL	R7	2
-      0x7001FFEB,  //  0038  JMP		#0025
-      0x580C0008,  //  0039  LDCONST	R3	K8
-      0xAC0C0200,  //  003A  CATCH	R3	1	0
-      0xB0080000,  //  003B  RAISE	2	R0	R0
-      0x600C0010,  //  003C  GETGBL	R3	G16
-      0x8C100100,  //  003D  GETMET	R4	R0	K0
-      0x5C180200,  //  003E  MOVE	R6	R1
-      0x7C100400,  //  003F  CALL	R4	2
-      0x7C0C0200,  //  0040  CALL	R3	1
-      0xA8020013,  //  0041  EXBLK	0	#0056
-      0x5C100600,  //  0042  MOVE	R4	R3
-      0x7C100000,  //  0043  CALL	R4	0
-      0x94140204,  //  0044  GETIDX	R5	R1	R4
-      0x6018000F,  //  0045  GETGBL	R6	G15
-      0x5C1C0A00,  //  0046  MOVE	R7	R5
-      0x60200013,  //  0047  GETGBL	R8	G19
-      0x7C180400,  //  0048  CALL	R6	2
-      0x781A000A,  //  0049  JMPF	R6	#0055
-      0x8C180B01,  //  004A  GETMET	R6	R5	K1
-      0x5820000C,  //  004B  LDCONST	R8	K12
-      0x7C180400,  //  004C  CALL	R6	2
-      0x781A0006,  //  004D  JMPF	R6	#0055
-      0x0018090D,  //  004E  ADD	R6	R4	K13
-      0x8C1C0504,  //  004F  GETMET	R7	R2	K4
-      0x60240013,  //  0050  GETGBL	R9	G19
-      0x7C240000,  //  0051  CALL	R9	0
-      0x98260B0E,  //  0052  SETIDX	R9	K5	K14
-      0x98260E06,  //  0053  SETIDX	R9	K7	R6
-      0x7C1C0400,  //  0054  CALL	R7	2
-      0x7001FFEB,  //  0055  JMP		#0042
-      0x580C0008,  //  0056  LDCONST	R3	K8
-      0xAC0C0200,  //  0057  CATCH	R3	1	0
-      0xB0080000,  //  0058  RAISE	2	R0	R0
-      0x600C0010,  //  0059  GETGBL	R3	G16
-      0x8C100100,  //  005A  GETMET	R4	R0	K0
-      0x5C180200,  //  005B  MOVE	R6	R1
-      0x7C100400,  //  005C  CALL	R4	2
-      0x7C0C0200,  //  005D  CALL	R3	1
-      0xA8020013,  //  005E  EXBLK	0	#0073
-      0x5C100600,  //  005F  MOVE	R4	R3
-      0x7C100000,  //  0060  CALL	R4	0
-      0x94140204,  //  0061  GETIDX	R5	R1	R4
-      0x6018000F,  //  0062  GETGBL	R6	G15
-      0x5C1C0A00,  //  0063  MOVE	R7	R5
-      0x60200013,  //  0064  GETGBL	R8	G19
-      0x7C180400,  //  0065  CALL	R6	2
-      0x781A000A,  //  0066  JMPF	R6	#0072
-      0x8C180B01,  //  0067  GETMET	R6	R5	K1
-      0x5820000F,  //  0068  LDCONST	R8	K15
-      0x7C180400,  //  0069  CALL	R6	2
-      0x781A0006,  //  006A  JMPF	R6	#0072
-      0x00180910,  //  006B  ADD	R6	R4	K16
-      0x8C1C0504,  //  006C  GETMET	R7	R2	K4
-      0x60240013,  //  006D  GETGBL	R9	G19
-      0x7C240000,  //  006E  CALL	R9	0
-      0x98260B11,  //  006F  SETIDX	R9	K5	K17
-      0x98260E06,  //  0070  SETIDX	R9	K7	R6
-      0x7C1C0400,  //  0071  CALL	R7	2
-      0x7001FFEB,  //  0072  JMP		#005F
-      0x580C0008,  //  0073  LDCONST	R3	K8
-      0xAC0C0200,  //  0074  CATCH	R3	1	0
-      0xB0080000,  //  0075  RAISE	2	R0	R0
-      0x80040400,  //  0076  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_250ms
-********************************************************************/
-be_local_closure(Matter_Device_every_250ms,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(every_250ms),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(plugins),
-    /* K4   */  be_const_int(1),
-    }),
-    be_str_weak(every_250ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x58040002,  //  0003  LDCONST	R1	K2
-      0x6008000C,  //  0004  GETGBL	R2	G12
-      0x880C0103,  //  0005  GETMBR	R3	R0	K3
-      0x7C080200,  //  0006  CALL	R2	1
-      0x14080202,  //  0007  LT	R2	R1	R2
-      0x780A0005,  //  0008  JMPF	R2	#000F
-      0x88080103,  //  0009  GETMBR	R2	R0	K3
-      0x94080401,  //  000A  GETIDX	R2	R2	R1
-      0x8C080501,  //  000B  GETMET	R2	R2	K1
-      0x7C080200,  //  000C  CALL	R2	1
-      0x00040304,  //  000D  ADD	R1	R1	K4
-      0x7001FFF4,  //  000E  JMP		#0004
-      0x80000000,  //  000F  RET	0
     })
   )
 );
@@ -1002,182 +4443,6 @@ be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
 
 
 /********************************************************************
-** Solidified function: _compute_pbkdf
-********************************************************************/
-be_local_closure(Matter_Device__compute_pbkdf,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(add),
-    /* K2   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
-    /* K3   */  be_nested_str_weak(derive),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(root_w0),
-    /* K6   */  be_nested_str_weak(EC_P256),
-    /* K7   */  be_nested_str_weak(mod),
-    /* K8   */  be_nested_str_weak(root_L),
-    /* K9   */  be_nested_str_weak(public_key),
-    }),
-    be_str_weak(_compute_pbkdf),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0x60140015,  //  0001  GETGBL	R5	G21
-      0x7C140000,  //  0002  CALL	R5	0
-      0x8C140B01,  //  0003  GETMET	R5	R5	K1
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x54220003,  //  0005  LDINT	R8	4
-      0x7C140600,  //  0006  CALL	R5	3
-      0x8C180902,  //  0007  GETMET	R6	R4	K2
-      0x7C180200,  //  0008  CALL	R6	1
-      0x8C180D03,  //  0009  GETMET	R6	R6	K3
-      0x5C200A00,  //  000A  MOVE	R8	R5
-      0x5C240600,  //  000B  MOVE	R9	R3
-      0x5C280400,  //  000C  MOVE	R10	R2
-      0x542E004F,  //  000D  LDINT	R11	80
-      0x7C180A00,  //  000E  CALL	R6	5
-      0x541E0026,  //  000F  LDINT	R7	39
-      0x401E0807,  //  0010  CONNECT	R7	K4	R7
-      0x941C0C07,  //  0011  GETIDX	R7	R6	R7
-      0x54220027,  //  0012  LDINT	R8	40
-      0x5426004E,  //  0013  LDINT	R9	79
-      0x40201009,  //  0014  CONNECT	R8	R8	R9
-      0x94200C08,  //  0015  GETIDX	R8	R6	R8
-      0x8C240906,  //  0016  GETMET	R9	R4	K6
-      0x7C240200,  //  0017  CALL	R9	1
-      0x8C241307,  //  0018  GETMET	R9	R9	K7
-      0x5C2C0E00,  //  0019  MOVE	R11	R7
-      0x7C240400,  //  001A  CALL	R9	2
-      0x90020A09,  //  001B  SETMBR	R0	K5	R9
-      0x8C240906,  //  001C  GETMET	R9	R4	K6
-      0x7C240200,  //  001D  CALL	R9	1
-      0x8C241307,  //  001E  GETMET	R9	R9	K7
-      0x5C2C1000,  //  001F  MOVE	R11	R8
-      0x7C240400,  //  0020  CALL	R9	2
-      0x8C280906,  //  0021  GETMET	R10	R4	K6
-      0x7C280200,  //  0022  CALL	R10	1
-      0x8C281509,  //  0023  GETMET	R10	R10	K9
-      0x5C301200,  //  0024  MOVE	R12	R9
-      0x7C280400,  //  0025  CALL	R10	2
-      0x9002100A,  //  0026  SETMBR	R0	K8	R10
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: bridge_remove_endpoint
-********************************************************************/
-be_local_closure(Matter_Device_bridge_remove_endpoint,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(plugins_config),
-    /* K2   */  be_nested_str_weak(contains),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
-    /* K6   */  be_const_int(3),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(remove),
-    /* K10  */  be_nested_str_weak(plugins_persist),
-    /* K11  */  be_nested_str_weak(save_param),
-    /* K12  */  be_nested_str_weak(signal_endpoints_changed),
-    /* K13  */  be_const_int(0),
-    /* K14  */  be_nested_str_weak(plugins),
-    /* K15  */  be_nested_str_weak(get_endpoint),
-    /* K16  */  be_const_int(1),
-    /* K17  */  be_nested_str_weak(clean_remotes),
-    }),
-    be_str_weak(bridge_remove_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[60]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x600C0008,  //  0001  GETGBL	R3	G8
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x4C100000,  //  0004  LDNIL	R4
-      0x4C140000,  //  0005  LDNIL	R5
-      0x88180101,  //  0006  GETMBR	R6	R0	K1
-      0x8C180D02,  //  0007  GETMET	R6	R6	K2
-      0x5C200600,  //  0008  MOVE	R8	R3
-      0x7C180400,  //  0009  CALL	R6	2
-      0x741A0005,  //  000A  JMPT	R6	#0011
-      0xB81A0600,  //  000B  GETNGBL	R6	K3
-      0x8C180D04,  //  000C  GETMET	R6	R6	K4
-      0x00220A03,  //  000D  ADD	R8	K5	R3
-      0x58240006,  //  000E  LDCONST	R9	K6
-      0x7C180600,  //  000F  CALL	R6	3
-      0x80000C00,  //  0010  RET	0
-      0xB81A0600,  //  0011  GETNGBL	R6	K3
-      0x8C180D04,  //  0012  GETMET	R6	R6	K4
-      0x60200018,  //  0013  GETGBL	R8	G24
-      0x58240007,  //  0014  LDCONST	R9	K7
-      0x5C280200,  //  0015  MOVE	R10	R1
-      0x7C200400,  //  0016  CALL	R8	2
-      0x58240008,  //  0017  LDCONST	R9	K8
-      0x7C180600,  //  0018  CALL	R6	3
-      0x88180101,  //  0019  GETMBR	R6	R0	K1
-      0x8C180D09,  //  001A  GETMET	R6	R6	K9
-      0x5C200600,  //  001B  MOVE	R8	R3
-      0x7C180400,  //  001C  CALL	R6	2
-      0x50180200,  //  001D  LDBOOL	R6	1	0
-      0x90021406,  //  001E  SETMBR	R0	K10	R6
-      0x8C18010B,  //  001F  GETMET	R6	R0	K11
-      0x7C180200,  //  0020  CALL	R6	1
-      0x8C18010C,  //  0021  GETMET	R6	R0	K12
-      0x7C180200,  //  0022  CALL	R6	1
-      0x5818000D,  //  0023  LDCONST	R6	K13
-      0x601C000C,  //  0024  GETGBL	R7	G12
-      0x8820010E,  //  0025  GETMBR	R8	R0	K14
-      0x7C1C0200,  //  0026  CALL	R7	1
-      0x141C0C07,  //  0027  LT	R7	R6	R7
-      0x781E000F,  //  0028  JMPF	R7	#0039
-      0x881C010E,  //  0029  GETMBR	R7	R0	K14
-      0x941C0E06,  //  002A  GETIDX	R7	R7	R6
-      0x8C1C0F0F,  //  002B  GETMET	R7	R7	K15
-      0x7C1C0200,  //  002C  CALL	R7	1
-      0x1C1C0207,  //  002D  EQ	R7	R1	R7
-      0x781E0007,  //  002E  JMPF	R7	#0037
-      0x881C010E,  //  002F  GETMBR	R7	R0	K14
-      0x8C1C0F09,  //  0030  GETMET	R7	R7	K9
-      0x5C240C00,  //  0031  MOVE	R9	R6
-      0x7C1C0400,  //  0032  CALL	R7	2
-      0x8C1C010C,  //  0033  GETMET	R7	R0	K12
-      0x7C1C0200,  //  0034  CALL	R7	1
-      0x70020002,  //  0035  JMP		#0039
-      0x70020000,  //  0036  JMP		#0038
-      0x00180D10,  //  0037  ADD	R6	R6	K16
-      0x7001FFEA,  //  0038  JMP		#0024
-      0x8C1C0111,  //  0039  GETMET	R7	R0	K17
-      0x7C1C0200,  //  003A  CALL	R7	1
-      0x80000000,  //  003B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: stop_basic_commissioning
 ********************************************************************/
 be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
@@ -1240,873 +4505,11 @@ be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
 
 
 /********************************************************************
-** Solidified function: remove_fabric
+** Solidified function: load_param
 ********************************************************************/
-be_local_closure(Matter_Device_remove_fabric,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(find_children_fabrics),
-    /* K2   */  be_nested_str_weak(get_fabric_index),
-    /* K3   */  be_nested_str_weak(find_fabric_by_index),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
-    /* K7   */  be_nested_str_weak(get_fabric_id),
-    /* K8   */  be_nested_str_weak(copy),
-    /* K9   */  be_nested_str_weak(reverse),
-    /* K10  */  be_nested_str_weak(tohex),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(message_handler),
-    /* K13  */  be_nested_str_weak(im),
-    /* K14  */  be_nested_str_weak(subs_shop),
-    /* K15  */  be_nested_str_weak(remove_by_fabric),
-    /* K16  */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K17  */  be_nested_str_weak(remove_fabric),
-    /* K18  */  be_nested_str_weak(stop_iteration),
-    /* K19  */  be_nested_str_weak(save_fabrics),
-    }),
-    be_str_weak(remove_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[56]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x8C100302,  //  0002  GETMET	R4	R1	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x7C080400,  //  0004  CALL	R2	2
-      0x4C0C0000,  //  0005  LDNIL	R3
-      0x1C0C0403,  //  0006  EQ	R3	R2	R3
-      0x780E0000,  //  0007  JMPF	R3	#0009
-      0x80000600,  //  0008  RET	0
-      0x600C0010,  //  0009  GETGBL	R3	G16
-      0x5C100400,  //  000A  MOVE	R4	R2
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0xA8020023,  //  000C  EXBLK	0	#0031
-      0x5C100600,  //  000D  MOVE	R4	R3
-      0x7C100000,  //  000E  CALL	R4	0
-      0x88140100,  //  000F  GETMBR	R5	R0	K0
-      0x8C140B03,  //  0010  GETMET	R5	R5	K3
-      0x5C1C0800,  //  0011  MOVE	R7	R4
-      0x7C140400,  //  0012  CALL	R5	2
-      0x4C180000,  //  0013  LDNIL	R6
-      0x20180A06,  //  0014  NE	R6	R5	R6
-      0x781A0019,  //  0015  JMPF	R6	#0030
-      0xB81A0800,  //  0016  GETNGBL	R6	K4
-      0x8C180D05,  //  0017  GETMET	R6	R6	K5
-      0x8C200B07,  //  0018  GETMET	R8	R5	K7
-      0x7C200200,  //  0019  CALL	R8	1
-      0x8C201108,  //  001A  GETMET	R8	R8	K8
-      0x7C200200,  //  001B  CALL	R8	1
-      0x8C201109,  //  001C  GETMET	R8	R8	K9
-      0x7C200200,  //  001D  CALL	R8	1
-      0x8C20110A,  //  001E  GETMET	R8	R8	K10
-      0x7C200200,  //  001F  CALL	R8	1
-      0x00220C08,  //  0020  ADD	R8	K6	R8
-      0x5824000B,  //  0021  LDCONST	R9	K11
-      0x7C180600,  //  0022  CALL	R6	3
-      0x8818010C,  //  0023  GETMBR	R6	R0	K12
-      0x88180D0D,  //  0024  GETMBR	R6	R6	K13
-      0x88180D0E,  //  0025  GETMBR	R6	R6	K14
-      0x8C180D0F,  //  0026  GETMET	R6	R6	K15
-      0x5C200A00,  //  0027  MOVE	R8	R5
-      0x7C180400,  //  0028  CALL	R6	2
-      0x8C180110,  //  0029  GETMET	R6	R0	K16
-      0x5C200A00,  //  002A  MOVE	R8	R5
-      0x7C180400,  //  002B  CALL	R6	2
-      0x88180100,  //  002C  GETMBR	R6	R0	K0
-      0x8C180D11,  //  002D  GETMET	R6	R6	K17
-      0x5C200A00,  //  002E  MOVE	R8	R5
-      0x7C180400,  //  002F  CALL	R6	2
-      0x7001FFDB,  //  0030  JMP		#000D
-      0x580C0012,  //  0031  LDCONST	R3	K18
-      0xAC0C0200,  //  0032  CATCH	R3	1	0
-      0xB0080000,  //  0033  RAISE	2	R0	R0
-      0x880C0100,  //  0034  GETMBR	R3	R0	K0
-      0x8C0C0713,  //  0035  GETMET	R3	R3	K19
-      0x7C0C0200,  //  0036  CALL	R3	1
-      0x80000000,  //  0037  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_param
-********************************************************************/
-be_local_closure(Matter_Device_save_param,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
-    /* K2   */  be_nested_str_weak(root_discriminator),
-    /* K3   */  be_nested_str_weak(root_passcode),
-    /* K4   */  be_nested_str_weak(ipv4only),
-    /* K5   */  be_nested_str_weak(true),
-    /* K6   */  be_nested_str_weak(false),
-    /* K7   */  be_nested_str_weak(next_ep),
-    /* K8   */  be_nested_str_weak(plugins_persist),
-    /* K9   */  be_nested_str_weak(_X2C_X22config_X22_X3A),
-    /* K10  */  be_nested_str_weak(dump),
-    /* K11  */  be_nested_str_weak(plugins_config),
-    /* K12  */  be_nested_str_weak(_X7D),
-    /* K13  */  be_nested_str_weak(FILENAME),
-    /* K14  */  be_nested_str_weak(w),
-    /* K15  */  be_nested_str_weak(write),
-    /* K16  */  be_nested_str_weak(close),
-    /* K17  */  be_nested_str_weak(tasmota),
-    /* K18  */  be_nested_str_weak(log),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
-    /* K20  */  be_nested_str_weak(_X20and_X20configuration),
-    /* K21  */  be_nested_str_weak(),
-    /* K22  */  be_const_int(3),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K24  */  be_nested_str_weak(_X7C),
-    /* K25  */  be_const_int(2),
-    }),
-    be_str_weak(save_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[65]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x60080018,  //  0001  GETGBL	R2	G24
-      0x580C0001,  //  0002  LDCONST	R3	K1
-      0x88100102,  //  0003  GETMBR	R4	R0	K2
-      0x88140103,  //  0004  GETMBR	R5	R0	K3
-      0x88180104,  //  0005  GETMBR	R6	R0	K4
-      0x781A0001,  //  0006  JMPF	R6	#0009
-      0x58180005,  //  0007  LDCONST	R6	K5
-      0x70020000,  //  0008  JMP		#000A
-      0x58180006,  //  0009  LDCONST	R6	K6
-      0x881C0107,  //  000A  GETMBR	R7	R0	K7
-      0x7C080A00,  //  000B  CALL	R2	5
-      0x880C0108,  //  000C  GETMBR	R3	R0	K8
-      0x780E0004,  //  000D  JMPF	R3	#0013
-      0x00080509,  //  000E  ADD	R2	R2	K9
-      0x8C0C030A,  //  000F  GETMET	R3	R1	K10
-      0x8814010B,  //  0010  GETMBR	R5	R0	K11
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x00080403,  //  0012  ADD	R2	R2	R3
-      0x0008050C,  //  0013  ADD	R2	R2	K12
-      0xA8020018,  //  0014  EXBLK	0	#002E
-      0x600C0011,  //  0015  GETGBL	R3	G17
-      0x8810010D,  //  0016  GETMBR	R4	R0	K13
-      0x5814000E,  //  0017  LDCONST	R5	K14
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x8C10070F,  //  0019  GETMET	R4	R3	K15
-      0x5C180400,  //  001A  MOVE	R6	R2
-      0x7C100400,  //  001B  CALL	R4	2
-      0x8C100710,  //  001C  GETMET	R4	R3	K16
-      0x7C100200,  //  001D  CALL	R4	1
-      0xB8122200,  //  001E  GETNGBL	R4	K17
-      0x8C100912,  //  001F  GETMET	R4	R4	K18
-      0x60180018,  //  0020  GETGBL	R6	G24
-      0x581C0013,  //  0021  LDCONST	R7	K19
-      0x88200108,  //  0022  GETMBR	R8	R0	K8
-      0x78220001,  //  0023  JMPF	R8	#0026
-      0x58200014,  //  0024  LDCONST	R8	K20
-      0x70020000,  //  0025  JMP		#0027
-      0x58200015,  //  0026  LDCONST	R8	K21
-      0x7C180400,  //  0027  CALL	R6	2
-      0x581C0016,  //  0028  LDCONST	R7	K22
-      0x7C100600,  //  0029  CALL	R4	3
-      0xA8040001,  //  002A  EXBLK	1	1
-      0x80040400,  //  002B  RET	1	R2
-      0xA8040001,  //  002C  EXBLK	1	1
-      0x70020011,  //  002D  JMP		#0040
-      0xAC0C0002,  //  002E  CATCH	R3	0	2
-      0x7002000E,  //  002F  JMP		#003F
-      0xB8162200,  //  0030  GETNGBL	R5	K17
-      0x8C140B12,  //  0031  GETMET	R5	R5	K18
-      0x601C0008,  //  0032  GETGBL	R7	G8
-      0x5C200600,  //  0033  MOVE	R8	R3
-      0x7C1C0200,  //  0034  CALL	R7	1
-      0x001E2E07,  //  0035  ADD	R7	K23	R7
-      0x001C0F18,  //  0036  ADD	R7	R7	K24
-      0x60200008,  //  0037  GETGBL	R8	G8
-      0x5C240800,  //  0038  MOVE	R9	R4
-      0x7C200200,  //  0039  CALL	R8	1
-      0x001C0E08,  //  003A  ADD	R7	R7	R8
-      0x58200019,  //  003B  LDCONST	R8	K25
-      0x7C140600,  //  003C  CALL	R5	3
-      0x80040400,  //  003D  RET	1	R2
-      0x70020000,  //  003E  JMP		#0040
-      0xB0080000,  //  003F  RAISE	2	R0	R0
-      0x80000000,  //  0040  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_plugin_class_arg
-********************************************************************/
-be_local_closure(Matter_Device_get_plugin_class_arg,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins_classes),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(ARG),
-    /* K3   */  be_nested_str_weak(),
-    }),
-    be_str_weak(get_plugin_class_arg),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x880C0502,  //  0005  GETMBR	R3	R2	K2
-      0x70020000,  //  0006  JMP		#0008
-      0x580C0003,  //  0007  LDCONST	R3	K3
-      0x80040600,  //  0008  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_remove_PASE
-********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(mdns_pase_eth),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eremove_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
-    /* K5   */  be_nested_str_weak(_matterc),
-    /* K6   */  be_nested_str_weak(_udp),
-    /* K7   */  be_nested_str_weak(commissioning_instance_eth),
-    /* K8   */  be_nested_str_weak(hostname_eth),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
-    /* K11  */  be_nested_str_weak(eth),
-    /* K12  */  be_nested_str_weak(remove_service),
-    /* K13  */  be_nested_str_weak(mdns_pase_wifi),
-    /* K14  */  be_nested_str_weak(commissioning_instance_wifi),
-    /* K15  */  be_nested_str_weak(hostname_wifi),
-    /* K16  */  be_nested_str_weak(wifi),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K18  */  be_nested_str_weak(_X7C),
-    /* K19  */  be_const_int(2),
-    }),
-    be_str_weak(mdns_remove_PASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[82]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA802003D,  //  0001  EXBLK	0	#0040
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x780A001B,  //  0003  JMPF	R2	#0020
-      0xB80A0400,  //  0004  GETNGBL	R2	K2
-      0x8C080503,  //  0005  GETMET	R2	R2	K3
-      0x60100018,  //  0006  GETGBL	R4	G24
-      0x58140004,  //  0007  LDCONST	R5	K4
-      0x58180005,  //  0008  LDCONST	R6	K5
-      0x581C0006,  //  0009  LDCONST	R7	K6
-      0x88200107,  //  000A  GETMBR	R8	R0	K7
-      0x88240108,  //  000B  GETMBR	R9	R0	K8
-      0x7C100A00,  //  000C  CALL	R4	5
-      0x58140009,  //  000D  LDCONST	R5	K9
-      0x7C080600,  //  000E  CALL	R2	3
-      0xB80A0400,  //  000F  GETNGBL	R2	K2
-      0x8C080503,  //  0010  GETMET	R2	R2	K3
-      0x60100018,  //  0011  GETGBL	R4	G24
-      0x5814000A,  //  0012  LDCONST	R5	K10
-      0x5818000B,  //  0013  LDCONST	R6	K11
-      0x881C0107,  //  0014  GETMBR	R7	R0	K7
-      0x7C100600,  //  0015  CALL	R4	3
-      0x58140009,  //  0016  LDCONST	R5	K9
-      0x7C080600,  //  0017  CALL	R2	3
-      0x50080000,  //  0018  LDBOOL	R2	0	0
-      0x90020202,  //  0019  SETMBR	R0	K1	R2
-      0x8C08030C,  //  001A  GETMET	R2	R1	K12
-      0x58100005,  //  001B  LDCONST	R4	K5
-      0x58140006,  //  001C  LDCONST	R5	K6
-      0x88180107,  //  001D  GETMBR	R6	R0	K7
-      0x881C0108,  //  001E  GETMBR	R7	R0	K8
-      0x7C080A00,  //  001F  CALL	R2	5
-      0x8808010D,  //  0020  GETMBR	R2	R0	K13
-      0x780A001B,  //  0021  JMPF	R2	#003E
-      0xB80A0400,  //  0022  GETNGBL	R2	K2
-      0x8C080503,  //  0023  GETMET	R2	R2	K3
-      0x60100018,  //  0024  GETGBL	R4	G24
-      0x58140004,  //  0025  LDCONST	R5	K4
-      0x58180005,  //  0026  LDCONST	R6	K5
-      0x581C0006,  //  0027  LDCONST	R7	K6
-      0x8820010E,  //  0028  GETMBR	R8	R0	K14
-      0x8824010F,  //  0029  GETMBR	R9	R0	K15
-      0x7C100A00,  //  002A  CALL	R4	5
-      0x58140009,  //  002B  LDCONST	R5	K9
-      0x7C080600,  //  002C  CALL	R2	3
-      0xB80A0400,  //  002D  GETNGBL	R2	K2
-      0x8C080503,  //  002E  GETMET	R2	R2	K3
-      0x60100018,  //  002F  GETGBL	R4	G24
-      0x5814000A,  //  0030  LDCONST	R5	K10
-      0x58180010,  //  0031  LDCONST	R6	K16
-      0x881C010E,  //  0032  GETMBR	R7	R0	K14
-      0x7C100600,  //  0033  CALL	R4	3
-      0x58140009,  //  0034  LDCONST	R5	K9
-      0x7C080600,  //  0035  CALL	R2	3
-      0x50080000,  //  0036  LDBOOL	R2	0	0
-      0x90021A02,  //  0037  SETMBR	R0	K13	R2
-      0x8C08030C,  //  0038  GETMET	R2	R1	K12
-      0x58100005,  //  0039  LDCONST	R4	K5
-      0x58140006,  //  003A  LDCONST	R5	K6
-      0x8818010E,  //  003B  GETMBR	R6	R0	K14
-      0x881C010F,  //  003C  GETMBR	R7	R0	K15
-      0x7C080A00,  //  003D  CALL	R2	5
-      0xA8040001,  //  003E  EXBLK	1	1
-      0x70020010,  //  003F  JMP		#0051
-      0xAC080002,  //  0040  CATCH	R2	0	2
-      0x7002000D,  //  0041  JMP		#0050
-      0xB8120400,  //  0042  GETNGBL	R4	K2
-      0x8C100903,  //  0043  GETMET	R4	R4	K3
-      0x60180008,  //  0044  GETGBL	R6	G8
-      0x5C1C0400,  //  0045  MOVE	R7	R2
-      0x7C180200,  //  0046  CALL	R6	1
-      0x001A2206,  //  0047  ADD	R6	K17	R6
-      0x00180D12,  //  0048  ADD	R6	R6	K18
-      0x601C0008,  //  0049  GETGBL	R7	G8
-      0x5C200600,  //  004A  MOVE	R8	R3
-      0x7C1C0200,  //  004B  CALL	R7	1
-      0x00180C07,  //  004C  ADD	R6	R6	R7
-      0x581C0013,  //  004D  LDCONST	R7	K19
-      0x7C100600,  //  004E  CALL	R4	3
-      0x70020000,  //  004F  JMP		#0051
-      0xB0080000,  //  0050  RAISE	2	R0	R0
-      0x80000000,  //  0051  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: event_fabrics_saved
-********************************************************************/
-be_local_closure(Matter_Device_event_fabrics_saved,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(count_active_fabrics),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(plugins_persist),
-    /* K4   */  be_nested_str_weak(save_param),
-    }),
-    be_str_weak(event_fabrics_saved),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x24040302,  //  0003  GT	R1	R1	K2
-      0x78060005,  //  0004  JMPF	R1	#000B
-      0x88040103,  //  0005  GETMBR	R1	R0	K3
-      0x74060003,  //  0006  JMPT	R1	#000B
-      0x50040200,  //  0007  LDBOOL	R1	1	0
-      0x90020601,  //  0008  SETMBR	R0	K3	R1
-      0x8C040104,  //  0009  GETMET	R1	R0	K4
-      0x7C040200,  //  000A  CALL	R1	1
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_commissioning_complete
-********************************************************************/
-be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
+be_local_closure(Matter_Device_load_param,   /* name */
   be_nested_proto(
     11,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_fabric),
-    /* K1   */  be_nested_str_weak(get_fabric_id),
-    /* K2   */  be_nested_str_weak(copy),
-    /* K3   */  be_nested_str_weak(reverse),
-    /* K4   */  be_nested_str_weak(tohex),
-    /* K5   */  be_nested_str_weak(get_admin_vendor_name),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X2D_X2D_X2D_X20Commissioning_X20complete_X20for_X20Fabric_X20_X27_X25s_X27_X20_X28Vendor_X20_X25s_X29_X20_X2D_X2D_X2D),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_nested_str_weak(stop_basic_commissioning),
-    }),
-    be_str_weak(start_commissioning_complete),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
-      0x7C080200,  //  0001  CALL	R2	1
-      0x8C0C0501,  //  0002  GETMET	R3	R2	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x8C0C0704,  //  0008  GETMET	R3	R3	K4
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x8C100505,  //  000A  GETMET	R4	R2	K5
-      0x7C100200,  //  000B  CALL	R4	1
-      0xB8160C00,  //  000C  GETNGBL	R5	K6
-      0x8C140B07,  //  000D  GETMET	R5	R5	K7
-      0x601C0018,  //  000E  GETGBL	R7	G24
-      0x58200008,  //  000F  LDCONST	R8	K8
-      0x5C240600,  //  0010  MOVE	R9	R3
-      0x5C280800,  //  0011  MOVE	R10	R4
-      0x7C1C0600,  //  0012  CALL	R7	3
-      0x58200009,  //  0013  LDCONST	R8	K9
-      0x7C140600,  //  0014  CALL	R5	3
-      0x8C14010A,  //  0015  GETMET	R5	R0	K10
-      0x7C140200,  //  0016  CALL	R5	1
-      0x80000000,  //  0017  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: msg_received
-********************************************************************/
-be_local_closure(Matter_Device_msg_received,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(msg_received),
-    }),
-    be_str_weak(msg_received),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
-      0x8C100901,  //  0001  GETMET	R4	R4	K1
-      0x5C180200,  //  0002  MOVE	R6	R1
-      0x5C1C0400,  //  0003  MOVE	R7	R2
-      0x5C200600,  //  0004  MOVE	R8	R3
-      0x7C100800,  //  0005  CALL	R4	4
-      0x80040800,  //  0006  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _instantiate_plugins_from_config
-********************************************************************/
-be_local_closure(Matter_Device__instantiate_plugins_from_config,   /* name */
-  be_nested_proto(
-    18,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
-    /* K0   */  be_nested_str_weak(k2l_num),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20Configuring_X20endpoints),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(plugins),
-    /* K6   */  be_nested_str_weak(push),
-    /* K7   */  be_nested_str_weak(matter),
-    /* K8   */  be_nested_str_weak(Plugin_Root),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X20_X20endpoint_X20_X3D_X20_X255i_X20type_X3A_X25s_X25s),
-    /* K11  */  be_nested_str_weak(root),
-    /* K12  */  be_nested_str_weak(),
-    /* K13  */  be_nested_str_weak(Plugin_Aggregator),
-    /* K14  */  be_nested_str_weak(find),
-    /* K15  */  be_nested_str_weak(type),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
-    /* K17  */  be_const_int(3),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20only_X20one_X20root_X20node_X20allowed),
-    /* K19  */  be_nested_str_weak(plugins_classes),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-    /* K21  */  be_nested_str_weak(_X27_X20skipping),
-    /* K22  */  be_nested_str_weak(conf_to_log),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K24  */  be_nested_str_weak(_X7C),
-    /* K25  */  be_nested_str_weak(stop_iteration),
-    /* K26  */  be_nested_str_weak(aggregator),
-    /* K27  */  be_nested_str_weak(publish_result),
-    /* K28  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
-    /* K29  */  be_nested_str_weak(Matter),
-    }),
-    be_str_weak(_instantiate_plugins_from_config),
-    &be_const_str_solidified,
-    ( &(const binstruction[152]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0xB80E0200,  //  0003  GETNGBL	R3	K1
-      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x58180004,  //  0006  LDCONST	R6	K4
-      0x7C0C0600,  //  0007  CALL	R3	3
-      0x880C0105,  //  0008  GETMBR	R3	R0	K5
-      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
-      0xB8160E00,  //  000A  GETNGBL	R5	K7
-      0x8C140B08,  //  000B  GETMET	R5	R5	K8
-      0x5C1C0000,  //  000C  MOVE	R7	R0
-      0x58200009,  //  000D  LDCONST	R8	K9
-      0x60240013,  //  000E  GETGBL	R9	G19
-      0x7C240000,  //  000F  CALL	R9	0
-      0x7C140800,  //  0010  CALL	R5	4
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0xB80E0200,  //  0012  GETNGBL	R3	K1
-      0x8C0C0702,  //  0013  GETMET	R3	R3	K2
-      0x60140018,  //  0014  GETGBL	R5	G24
-      0x5818000A,  //  0015  LDCONST	R6	K10
-      0x581C0009,  //  0016  LDCONST	R7	K9
-      0x5820000B,  //  0017  LDCONST	R8	K11
-      0x5824000C,  //  0018  LDCONST	R9	K12
-      0x7C140800,  //  0019  CALL	R5	4
-      0x58180004,  //  001A  LDCONST	R6	K4
-      0x7C0C0600,  //  001B  CALL	R3	3
-      0x880C0105,  //  001C  GETMBR	R3	R0	K5
-      0x8C0C0706,  //  001D  GETMET	R3	R3	K6
-      0xB8160E00,  //  001E  GETNGBL	R5	K7
-      0x8C140B0D,  //  001F  GETMET	R5	R5	K13
-      0x5C1C0000,  //  0020  MOVE	R7	R0
-      0x5422FEFF,  //  0021  LDINT	R8	65280
-      0x60240013,  //  0022  GETGBL	R9	G19
-      0x7C240000,  //  0023  CALL	R9	0
-      0x7C140800,  //  0024  CALL	R5	4
-      0x7C0C0400,  //  0025  CALL	R3	2
-      0x600C0010,  //  0026  GETGBL	R3	G16
-      0x5C100400,  //  0027  MOVE	R4	R2
-      0x7C0C0200,  //  0028  CALL	R3	1
-      0xA802005A,  //  0029  EXBLK	0	#0085
-      0x5C100600,  //  002A  MOVE	R4	R3
-      0x7C100000,  //  002B  CALL	R4	0
-      0x1C140909,  //  002C  EQ	R5	R4	K9
-      0x78160000,  //  002D  JMPF	R5	#002F
-      0x7001FFFA,  //  002E  JMP		#002A
-      0xA8020042,  //  002F  EXBLK	0	#0073
-      0x60140008,  //  0030  GETGBL	R5	G8
-      0x5C180800,  //  0031  MOVE	R6	R4
-      0x7C140200,  //  0032  CALL	R5	1
-      0x94140205,  //  0033  GETIDX	R5	R1	R5
-      0x8C180B0E,  //  0034  GETMET	R6	R5	K14
-      0x5820000F,  //  0035  LDCONST	R8	K15
-      0x7C180400,  //  0036  CALL	R6	2
-      0x4C1C0000,  //  0037  LDNIL	R7
-      0x1C1C0C07,  //  0038  EQ	R7	R6	R7
-      0x781E0006,  //  0039  JMPF	R7	#0041
-      0xB81E0200,  //  003A  GETNGBL	R7	K1
-      0x8C1C0F02,  //  003B  GETMET	R7	R7	K2
-      0x58240010,  //  003C  LDCONST	R9	K16
-      0x58280011,  //  003D  LDCONST	R10	K17
-      0x7C1C0600,  //  003E  CALL	R7	3
-      0xA8040001,  //  003F  EXBLK	1	1
-      0x7001FFE8,  //  0040  JMP		#002A
-      0x1C1C0D0B,  //  0041  EQ	R7	R6	K11
-      0x781E0006,  //  0042  JMPF	R7	#004A
-      0xB81E0200,  //  0043  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0044  GETMET	R7	R7	K2
-      0x58240012,  //  0045  LDCONST	R9	K18
-      0x58280011,  //  0046  LDCONST	R10	K17
-      0x7C1C0600,  //  0047  CALL	R7	3
-      0xA8040001,  //  0048  EXBLK	1	1
-      0x7001FFDF,  //  0049  JMP		#002A
-      0x881C0113,  //  004A  GETMBR	R7	R0	K19
-      0x8C1C0F0E,  //  004B  GETMET	R7	R7	K14
-      0x5C240C00,  //  004C  MOVE	R9	R6
-      0x7C1C0400,  //  004D  CALL	R7	2
-      0x4C200000,  //  004E  LDNIL	R8
-      0x1C200E08,  //  004F  EQ	R8	R7	R8
-      0x7822000A,  //  0050  JMPF	R8	#005C
-      0xB8220200,  //  0051  GETNGBL	R8	K1
-      0x8C201102,  //  0052  GETMET	R8	R8	K2
-      0x60280008,  //  0053  GETGBL	R10	G8
-      0x5C2C0C00,  //  0054  MOVE	R11	R6
-      0x7C280200,  //  0055  CALL	R10	1
-      0x002A280A,  //  0056  ADD	R10	K20	R10
-      0x00281515,  //  0057  ADD	R10	R10	K21
-      0x582C0004,  //  0058  LDCONST	R11	K4
-      0x7C200600,  //  0059  CALL	R8	3
-      0xA8040001,  //  005A  EXBLK	1	1
-      0x7001FFCD,  //  005B  JMP		#002A
-      0x5C200E00,  //  005C  MOVE	R8	R7
-      0x5C240000,  //  005D  MOVE	R9	R0
-      0x5C280800,  //  005E  MOVE	R10	R4
-      0x5C2C0A00,  //  005F  MOVE	R11	R5
-      0x7C200600,  //  0060  CALL	R8	3
-      0x88240105,  //  0061  GETMBR	R9	R0	K5
-      0x8C241306,  //  0062  GETMET	R9	R9	K6
-      0x5C2C1000,  //  0063  MOVE	R11	R8
-      0x7C240400,  //  0064  CALL	R9	2
-      0xB8260200,  //  0065  GETNGBL	R9	K1
-      0x8C241302,  //  0066  GETMET	R9	R9	K2
-      0x602C0018,  //  0067  GETGBL	R11	G24
-      0x5830000A,  //  0068  LDCONST	R12	K10
-      0x5C340800,  //  0069  MOVE	R13	R4
-      0x5C380C00,  //  006A  MOVE	R14	R6
-      0x8C3C0116,  //  006B  GETMET	R15	R0	K22
-      0x5C440A00,  //  006C  MOVE	R17	R5
-      0x7C3C0400,  //  006D  CALL	R15	2
-      0x7C2C0800,  //  006E  CALL	R11	4
-      0x58300004,  //  006F  LDCONST	R12	K4
-      0x7C240600,  //  0070  CALL	R9	3
-      0xA8040001,  //  0071  EXBLK	1	1
-      0x70020010,  //  0072  JMP		#0084
-      0xAC140002,  //  0073  CATCH	R5	0	2
-      0x7002000D,  //  0074  JMP		#0083
-      0xB81E0200,  //  0075  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0076  GETMET	R7	R7	K2
-      0x60240008,  //  0077  GETGBL	R9	G8
-      0x5C280A00,  //  0078  MOVE	R10	R5
-      0x7C240200,  //  0079  CALL	R9	1
-      0x00262E09,  //  007A  ADD	R9	K23	R9
-      0x00241318,  //  007B  ADD	R9	R9	K24
-      0x60280008,  //  007C  GETGBL	R10	G8
-      0x5C2C0C00,  //  007D  MOVE	R11	R6
-      0x7C280200,  //  007E  CALL	R10	1
-      0x0024120A,  //  007F  ADD	R9	R9	R10
-      0x58280004,  //  0080  LDCONST	R10	K4
-      0x7C1C0600,  //  0081  CALL	R7	3
-      0x70020000,  //  0082  JMP		#0084
-      0xB0080000,  //  0083  RAISE	2	R0	R0
-      0x7001FFA4,  //  0084  JMP		#002A
-      0x580C0019,  //  0085  LDCONST	R3	K25
-      0xAC0C0200,  //  0086  CATCH	R3	1	0
-      0xB0080000,  //  0087  RAISE	2	R0	R0
-      0xB80E0200,  //  0088  GETNGBL	R3	K1
-      0x8C0C0702,  //  0089  GETMET	R3	R3	K2
-      0x60140018,  //  008A  GETGBL	R5	G24
-      0x5818000A,  //  008B  LDCONST	R6	K10
-      0x541EFEFF,  //  008C  LDINT	R7	65280
-      0x5820001A,  //  008D  LDCONST	R8	K26
-      0x5824000C,  //  008E  LDCONST	R9	K12
-      0x7C140800,  //  008F  CALL	R5	4
-      0x58180004,  //  0090  LDCONST	R6	K4
-      0x7C0C0600,  //  0091  CALL	R3	3
-      0xB80E0200,  //  0092  GETNGBL	R3	K1
-      0x8C0C071B,  //  0093  GETMET	R3	R3	K27
-      0x5814001C,  //  0094  LDCONST	R5	K28
-      0x5818001D,  //  0095  LDCONST	R6	K29
-      0x7C0C0600,  //  0096  CALL	R3	3
-      0x80000000,  //  0097  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_active_endpoints
-********************************************************************/
-be_local_closure(Matter_Device_get_active_endpoints,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins),
-    /* K1   */  be_nested_str_weak(get_endpoint),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(find),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(get_active_endpoints),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x88100100,  //  0003  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0xA8020011,  //  0005  EXBLK	0	#0018
-      0x5C100600,  //  0006  MOVE	R4	R3
-      0x7C100000,  //  0007  CALL	R4	0
-      0x8C140901,  //  0008  GETMET	R5	R4	K1
-      0x7C140200,  //  0009  CALL	R5	1
-      0x78060002,  //  000A  JMPF	R1	#000E
-      0x1C180B02,  //  000B  EQ	R6	R5	K2
-      0x781A0000,  //  000C  JMPF	R6	#000E
-      0x7001FFF7,  //  000D  JMP		#0006
-      0x8C180503,  //  000E  GETMET	R6	R2	K3
-      0x5C200A00,  //  000F  MOVE	R8	R5
-      0x7C180400,  //  0010  CALL	R6	2
-      0x4C1C0000,  //  0011  LDNIL	R7
-      0x1C180C07,  //  0012  EQ	R6	R6	R7
-      0x781A0002,  //  0013  JMPF	R6	#0017
-      0x8C180504,  //  0014  GETMET	R6	R2	K4
-      0x5C200A00,  //  0015  MOVE	R8	R5
-      0x7C180400,  //  0016  CALL	R6	2
-      0x7001FFED,  //  0017  JMP		#0006
-      0x580C0005,  //  0018  LDCONST	R3	K5
-      0xAC0C0200,  //  0019  CATCH	R3	1	0
-      0xB0080000,  //  001A  RAISE	2	R0	R0
-      0x80040400,  //  001B  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _start_udp
-********************************************************************/
-be_local_closure(Matter_Device__start_udp,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        8,                          /* nstack */
-        3,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(msg_received),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 7]) {  /* code */
-          0x680C0000,  //  0000  GETUPV	R3	U0
-          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
-          0x5C140000,  //  0002  MOVE	R5	R0
-          0x5C180200,  //  0003  MOVE	R6	R1
-          0x5C1C0400,  //  0004  MOVE	R7	R2
-          0x7C0C0800,  //  0005  CALL	R3	4
-          0x80040600,  //  0006  RET	1	R3
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(UDPServer),
-    /* K7   */  be_nested_str_weak(),
-    /* K8   */  be_nested_str_weak(start),
-    }),
-    be_str_weak(_start_udp),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80000400,  //  0002  RET	0
-      0x4C080000,  //  0003  LDNIL	R2
-      0x1C080202,  //  0004  EQ	R2	R1	R2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x540615A3,  //  0006  LDINT	R1	5540
-      0xB80A0200,  //  0007  GETNGBL	R2	K1
-      0x8C080502,  //  0008  GETMET	R2	R2	K2
-      0x60100008,  //  0009  GETGBL	R4	G8
-      0x5C140200,  //  000A  MOVE	R5	R1
-      0x7C100200,  //  000B  CALL	R4	1
-      0x00120604,  //  000C  ADD	R4	K3	R4
-      0x58140004,  //  000D  LDCONST	R5	K4
-      0x7C080600,  //  000E  CALL	R2	3
-      0xB80A0A00,  //  000F  GETNGBL	R2	K5
-      0x8C080506,  //  0010  GETMET	R2	R2	K6
-      0x58100007,  //  0011  LDCONST	R4	K7
-      0x5C140200,  //  0012  MOVE	R5	R1
-      0x7C080600,  //  0013  CALL	R2	3
-      0x90020002,  //  0014  SETMBR	R0	K0	R2
-      0x88080100,  //  0015  GETMBR	R2	R0	K0
-      0x8C080508,  //  0016  GETMET	R2	R2	K8
-      0x84100000,  //  0017  CLOSURE	R4	P0
-      0x7C080400,  //  0018  CALL	R2	2
-      0xA0000000,  //  0019  CLOSE	R0
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_root_commissioning_open
-********************************************************************/
-be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2114,825 +4517,165 @@ be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(commissioning_admin_fabric),
-    }),
-    be_str_weak(is_root_commissioning_open),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060003,  //  0003  JMPF	R1	#0008
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x4C080000,  //  0005  LDNIL	R2
-      0x1C040202,  //  0006  EQ	R1	R1	R2
-      0x74060000,  //  0007  JMPT	R1	#0009
-      0x50040001,  //  0008  LDBOOL	R1	0	1
-      0x50040200,  //  0009  LDBOOL	R1	1	0
-      0x80040200,  //  000A  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_root_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(PASE_TIMEOUT),
-    /* K1   */  be_nested_str_weak(compute_manual_pairing_code),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_nested_str_weak(compute_qrcode_content),
-    /* K7   */  be_nested_str_weak(publish_result),
-    /* K8   */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A1_X2C_X22PairingCode_X22_X3A_X22_X25s_X22_X2C_X22QRCode_X22_X3A_X22_X25s_X22_X7D_X7D),
-    /* K9   */  be_nested_str_weak(Matter),
-    /* K10  */  be_nested_str_weak(_compute_pbkdf),
-    /* K11  */  be_nested_str_weak(root_passcode),
-    /* K12  */  be_nested_str_weak(root_iterations),
-    /* K13  */  be_nested_str_weak(root_salt),
-    /* K14  */  be_nested_str_weak(start_basic_commissioning),
-    /* K15  */  be_nested_str_weak(root_discriminator),
-    /* K16  */  be_nested_str_weak(root_w0),
-    /* K17  */  be_nested_str_weak(root_L),
-    }),
-    be_str_weak(start_root_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0x88040100,  //  0003  GETMBR	R1	R0	K0
-      0x8C080101,  //  0004  GETMET	R2	R0	K1
-      0x7C080200,  //  0005  CALL	R2	1
-      0xB80E0400,  //  0006  GETNGBL	R3	K2
-      0x8C0C0703,  //  0007  GETMET	R3	R3	K3
-      0x60140018,  //  0008  GETGBL	R5	G24
-      0x58180004,  //  0009  LDCONST	R6	K4
-      0x5C1C0400,  //  000A  MOVE	R7	R2
-      0x7C140400,  //  000B  CALL	R5	2
-      0x58180005,  //  000C  LDCONST	R6	K5
-      0x7C0C0600,  //  000D  CALL	R3	3
-      0x8C0C0106,  //  000E  GETMET	R3	R0	K6
-      0x7C0C0200,  //  000F  CALL	R3	1
-      0xB8120400,  //  0010  GETNGBL	R4	K2
-      0x8C100907,  //  0011  GETMET	R4	R4	K7
-      0x60180018,  //  0012  GETGBL	R6	G24
-      0x581C0008,  //  0013  LDCONST	R7	K8
-      0x5C200400,  //  0014  MOVE	R8	R2
-      0x5C240600,  //  0015  MOVE	R9	R3
-      0x7C180600,  //  0016  CALL	R6	3
-      0x581C0009,  //  0017  LDCONST	R7	K9
-      0x7C100600,  //  0018  CALL	R4	3
-      0x8C10010A,  //  0019  GETMET	R4	R0	K10
-      0x8818010B,  //  001A  GETMBR	R6	R0	K11
-      0x881C010C,  //  001B  GETMBR	R7	R0	K12
-      0x8820010D,  //  001C  GETMBR	R8	R0	K13
-      0x7C100800,  //  001D  CALL	R4	4
-      0x8C10010E,  //  001E  GETMET	R4	R0	K14
-      0x5C180200,  //  001F  MOVE	R6	R1
-      0x881C010C,  //  0020  GETMBR	R7	R0	K12
-      0x8820010F,  //  0021  GETMBR	R8	R0	K15
-      0x8824010D,  //  0022  GETMBR	R9	R0	K13
-      0x88280110,  //  0023  GETMBR	R10	R0	K16
-      0x882C0111,  //  0024  GETMBR	R11	R0	K17
-      0x4C300000,  //  0025  LDNIL	R12
-      0x7C101000,  //  0026  CALL	R4	8
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_commissioning_complete_deferred
-********************************************************************/
-be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        3,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 2]) {  /* upvals */
-          be_local_const_upval(1, 0),
-          be_local_const_upval(1, 1),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_commissioning_complete),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080001,  //  0002  GETUPV	R2	U1
-          0x7C000400,  //  0003  CALL	R0	2
-          0x80040000,  //  0004  RET	1	R0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(set_timer),
-    /* K2   */  be_const_int(0),
-    }),
-    be_str_weak(start_commissioning_complete_deferred),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x84140000,  //  0003  CLOSURE	R5	P0
-      0x7C080600,  //  0004  CALL	R2	3
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: MtrJoin
-********************************************************************/
-be_local_closure(Matter_Device_MtrJoin,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K1   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(resp_cmnd_done),
-    }),
-    be_str_weak(MtrJoin),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x60140009,  //  0000  GETGBL	R5	G9
-      0x5C180600,  //  0001  MOVE	R6	R3
-      0x7C140200,  //  0002  CALL	R5	1
-      0x78160002,  //  0003  JMPF	R5	#0007
-      0x8C180100,  //  0004  GETMET	R6	R0	K0
-      0x7C180200,  //  0005  CALL	R6	1
-      0x70020001,  //  0006  JMP		#0009
-      0x8C180101,  //  0007  GETMET	R6	R0	K1
-      0x7C180200,  //  0008  CALL	R6	1
-      0xB81A0400,  //  0009  GETNGBL	R6	K2
-      0x8C180D03,  //  000A  GETMET	R6	R6	K3
-      0x7C180200,  //  000B  CALL	R6	1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start
-********************************************************************/
-be_local_closure(Matter_Device_start,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_trigger_read_sensors),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80000000,  //  0003  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(started),
-    /* K1   */  be_nested_str_weak(autoconf_device),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(add_cron),
-    /* K4   */  be_nested_str_weak(_X2A_X2F30_X20_X2A_X20_X2A_X20_X2A_X20_X2A_X20_X2A),
-    /* K5   */  be_nested_str_weak(matter_sensors_30s),
-    /* K6   */  be_nested_str_weak(_start_udp),
-    /* K7   */  be_nested_str_weak(UDP_PORT),
-    /* K8   */  be_nested_str_weak(start_mdns_announce_hostnames),
-    }),
-    be_str_weak(start),
-    &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060000,  //  0001  JMPF	R1	#0003
-      0x80000200,  //  0002  RET	0
-      0x8C040101,  //  0003  GETMET	R1	R0	K1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xB8060400,  //  0005  GETNGBL	R1	K2
-      0x8C040303,  //  0006  GETMET	R1	R1	K3
-      0x580C0004,  //  0007  LDCONST	R3	K4
-      0x84100000,  //  0008  CLOSURE	R4	P0
-      0x58140005,  //  0009  LDCONST	R5	K5
-      0x7C040800,  //  000A  CALL	R1	4
-      0x8C040106,  //  000B  GETMET	R1	R0	K6
-      0x880C0107,  //  000C  GETMBR	R3	R0	K7
-      0x7C040400,  //  000D  CALL	R1	2
-      0x8C040108,  //  000E  GETMET	R1	R0	K8
-      0x7C040200,  //  000F  CALL	R1	1
-      0x50040200,  //  0010  LDBOOL	R1	1	0
-      0x90020001,  //  0011  SETMBR	R0	K0	R1
-      0xA0000000,  //  0012  CLOSE	R0
-      0x80000000,  //  0013  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: conf_to_log
-********************************************************************/
-be_local_closure(Matter_Device_conf_to_log,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_nested_str_weak(),
-    /* K2   */  be_nested_str_weak(k2l),
-    /* K3   */  be_nested_str_weak(type),
-    /* K4   */  be_nested_str_weak(_X20_X25s_X3A_X25s),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(conf_to_log),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x58080001,  //  0001  LDCONST	R2	K1
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x5C180000,  //  0004  MOVE	R6	R0
-      0x7C100400,  //  0005  CALL	R4	2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0xA802000B,  //  0007  EXBLK	0	#0014
-      0x5C100600,  //  0008  MOVE	R4	R3
-      0x7C100000,  //  0009  CALL	R4	0
-      0x1C140903,  //  000A  EQ	R5	R4	K3
-      0x78160000,  //  000B  JMPF	R5	#000D
-      0x7001FFFA,  //  000C  JMP		#0008
-      0x60140018,  //  000D  GETGBL	R5	G24
-      0x58180004,  //  000E  LDCONST	R6	K4
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x94200004,  //  0010  GETIDX	R8	R0	R4
-      0x7C140600,  //  0011  CALL	R5	3
-      0x00080405,  //  0012  ADD	R2	R2	R5
-      0x7001FFF3,  //  0013  JMP		#0008
-      0x580C0005,  //  0014  LDCONST	R3	K5
-      0xAC0C0200,  //  0015  CATCH	R3	1	0
-      0xB0080000,  //  0016  RAISE	2	R0	R0
-      0x80040400,  //  0017  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: attribute_updated
-********************************************************************/
-be_local_closure(Matter_Device_attribute_updated,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Path),
-    /* K2   */  be_nested_str_weak(endpoint),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(message_handler),
-    /* K6   */  be_nested_str_weak(im),
-    /* K7   */  be_nested_str_weak(subs_shop),
-    /* K8   */  be_nested_str_weak(attribute_updated_ctx),
-    }),
-    be_str_weak(attribute_updated),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x1C140805,  //  0001  EQ	R5	R4	R5
-      0x78160000,  //  0002  JMPF	R5	#0004
-      0x50100000,  //  0003  LDBOOL	R4	0	0
-      0xB8160000,  //  0004  GETNGBL	R5	K0
-      0x8C140B01,  //  0005  GETMET	R5	R5	K1
-      0x7C140200,  //  0006  CALL	R5	1
-      0x90160401,  //  0007  SETMBR	R5	K2	R1
-      0x90160602,  //  0008  SETMBR	R5	K3	R2
-      0x90160803,  //  0009  SETMBR	R5	K4	R3
-      0x88180105,  //  000A  GETMBR	R6	R0	K5
-      0x88180D06,  //  000B  GETMBR	R6	R6	K6
-      0x88180D07,  //  000C  GETMBR	R6	R6	K7
-      0x8C180D08,  //  000D  GETMET	R6	R6	K8
-      0x5C200A00,  //  000E  MOVE	R8	R5
-      0x5C240800,  //  000F  MOVE	R9	R4
-      0x7C180600,  //  0010  CALL	R6	3
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _init_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device__init_basic_commissioning,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(count_active_fabrics),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(start_root_basic_commissioning),
-    }),
-    be_str_weak(_init_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x1C040302,  //  0003  EQ	R1	R1	K2
-      0x78060001,  //  0004  JMPF	R1	#0007
-      0x8C040103,  //  0005  GETMET	R1	R0	K3
-      0x7C040200,  //  0006  CALL	R1	1
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Device_init,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_start),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0004,  //  0006  LDCONST	R3	K4
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_start),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0004,  //  0006  LDCONST	R3	K4
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[42]) {     /* constants */
+    ( &(const bvalue[34]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(get_option),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(MATTER_OPTION),
-    /* K5   */  be_nested_str_weak(UI),
-    /* K6   */  be_nested_str_weak(started),
-    /* K7   */  be_nested_str_weak(tick),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(plugins),
-    /* K10  */  be_nested_str_weak(plugins_persist),
-    /* K11  */  be_nested_str_weak(plugins_classes),
-    /* K12  */  be_nested_str_weak(register_native_classes),
-    /* K13  */  be_nested_str_weak(vendorid),
-    /* K14  */  be_nested_str_weak(VENDOR_ID),
-    /* K15  */  be_nested_str_weak(productid),
-    /* K16  */  be_nested_str_weak(PRODUCT_ID),
-    /* K17  */  be_nested_str_weak(root_iterations),
-    /* K18  */  be_nested_str_weak(PBKDF_ITERATIONS),
-    /* K19  */  be_nested_str_weak(next_ep),
-    /* K20  */  be_const_int(1),
-    /* K21  */  be_nested_str_weak(root_salt),
-    /* K22  */  be_nested_str_weak(random),
-    /* K23  */  be_nested_str_weak(ipv4only),
-    /* K24  */  be_nested_str_weak(load_param),
-    /* K25  */  be_nested_str_weak(sessions),
-    /* K26  */  be_nested_str_weak(Session_Store),
-    /* K27  */  be_nested_str_weak(load_fabrics),
-    /* K28  */  be_nested_str_weak(message_handler),
-    /* K29  */  be_nested_str_weak(MessageHandler),
-    /* K30  */  be_nested_str_weak(ui),
-    /* K31  */  be_nested_str_weak(wifi),
-    /* K32  */  be_nested_str_weak(up),
-    /* K33  */  be_nested_str_weak(eth),
-    /* K34  */  be_nested_str_weak(start),
-    /* K35  */  be_nested_str_weak(add_rule),
-    /* K36  */  be_nested_str_weak(Wifi_X23Connected),
-    /* K37  */  be_nested_str_weak(matter_start),
-    /* K38  */  be_nested_str_weak(Eth_X23Connected),
-    /* K39  */  be_nested_str_weak(_init_basic_commissioning),
-    /* K40  */  be_nested_str_weak(add_driver),
-    /* K41  */  be_nested_str_weak(register_commands),
+    /* K1   */  be_nested_str_weak(FILENAME),
+    /* K2   */  be_nested_str_weak(read),
+    /* K3   */  be_nested_str_weak(close),
+    /* K4   */  be_nested_str_weak(json),
+    /* K5   */  be_nested_str_weak(load),
+    /* K6   */  be_nested_str_weak(root_discriminator),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_nested_str_weak(distinguish),
+    /* K9   */  be_nested_str_weak(root_passcode),
+    /* K10  */  be_nested_str_weak(passcode),
+    /* K11  */  be_nested_str_weak(ipv4only),
+    /* K12  */  be_nested_str_weak(next_ep),
+    /* K13  */  be_nested_str_weak(nextep),
+    /* K14  */  be_nested_str_weak(plugins_config),
+    /* K15  */  be_nested_str_weak(config),
+    /* K16  */  be_nested_str_weak(tasmota),
+    /* K17  */  be_nested_str_weak(log),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20load_config_X20_X3D_X20),
+    /* K19  */  be_const_int(3),
+    /* K20  */  be_nested_str_weak(adjust_next_ep),
+    /* K21  */  be_nested_str_weak(plugins_persist),
+    /* K22  */  be_nested_str_weak(plugins_config_remotes),
+    /* K23  */  be_nested_str_weak(remotes),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
+    /* K25  */  be_nested_str_weak(io_error),
+    /* K26  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
+    /* K27  */  be_nested_str_weak(_X7C),
+    /* K28  */  be_const_int(2),
+    /* K29  */  be_nested_str_weak(random),
+    /* K30  */  be_nested_str_weak(get),
+    /* K31  */  be_const_int(0),
+    /* K32  */  be_nested_str_weak(generate_random_passcode),
+    /* K33  */  be_nested_str_weak(save_param),
     }),
-    be_str_weak(init),
+    be_str_weak(load_param),
     &be_const_str_solidified,
-    ( &(const binstruction[102]) {  /* code */
+    ( &(const binstruction[120]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0xB8120600,  //  0003  GETNGBL	R4	K3
-      0x88100904,  //  0004  GETMBR	R4	R4	K4
-      0x7C080400,  //  0005  CALL	R2	2
-      0x740A0004,  //  0006  JMPT	R2	#000C
-      0xB80A0600,  //  0007  GETNGBL	R2	K3
-      0x8C080505,  //  0008  GETMET	R2	R2	K5
-      0x5C100000,  //  0009  MOVE	R4	R0
-      0x7C080400,  //  000A  CALL	R2	2
-      0x80000400,  //  000B  RET	0
-      0x50080000,  //  000C  LDBOOL	R2	0	0
-      0x90020C02,  //  000D  SETMBR	R0	K6	R2
-      0x90020F08,  //  000E  SETMBR	R0	K7	K8
-      0x60080012,  //  000F  GETGBL	R2	G18
-      0x7C080000,  //  0010  CALL	R2	0
-      0x90021202,  //  0011  SETMBR	R0	K9	R2
-      0x50080000,  //  0012  LDBOOL	R2	0	0
-      0x90021402,  //  0013  SETMBR	R0	K10	R2
-      0x60080013,  //  0014  GETGBL	R2	G19
-      0x7C080000,  //  0015  CALL	R2	0
-      0x90021602,  //  0016  SETMBR	R0	K11	R2
-      0x8C08010C,  //  0017  GETMET	R2	R0	K12
-      0x7C080200,  //  0018  CALL	R2	1
-      0x8808010E,  //  0019  GETMBR	R2	R0	K14
-      0x90021A02,  //  001A  SETMBR	R0	K13	R2
-      0x88080110,  //  001B  GETMBR	R2	R0	K16
-      0x90021E02,  //  001C  SETMBR	R0	K15	R2
-      0x88080112,  //  001D  GETMBR	R2	R0	K18
-      0x90022202,  //  001E  SETMBR	R0	K17	R2
-      0x90022714,  //  001F  SETMBR	R0	K19	K20
-      0x8C080316,  //  0020  GETMET	R2	R1	K22
-      0x5412000F,  //  0021  LDINT	R4	16
-      0x7C080400,  //  0022  CALL	R2	2
-      0x90022A02,  //  0023  SETMBR	R0	K21	R2
-      0x50080000,  //  0024  LDBOOL	R2	0	0
-      0x90022E02,  //  0025  SETMBR	R0	K23	R2
-      0x8C080118,  //  0026  GETMET	R2	R0	K24
-      0x7C080200,  //  0027  CALL	R2	1
-      0xB80A0600,  //  0028  GETNGBL	R2	K3
-      0x8C08051A,  //  0029  GETMET	R2	R2	K26
-      0x5C100000,  //  002A  MOVE	R4	R0
-      0x7C080400,  //  002B  CALL	R2	2
-      0x90023202,  //  002C  SETMBR	R0	K25	R2
-      0x88080119,  //  002D  GETMBR	R2	R0	K25
-      0x8C08051B,  //  002E  GETMET	R2	R2	K27
-      0x7C080200,  //  002F  CALL	R2	1
-      0xB80A0600,  //  0030  GETNGBL	R2	K3
-      0x8C08051D,  //  0031  GETMET	R2	R2	K29
-      0x5C100000,  //  0032  MOVE	R4	R0
-      0x7C080400,  //  0033  CALL	R2	2
-      0x90023802,  //  0034  SETMBR	R0	K28	R2
-      0xB80A0600,  //  0035  GETNGBL	R2	K3
-      0x8C080505,  //  0036  GETMET	R2	R2	K5
-      0x5C100000,  //  0037  MOVE	R4	R0
-      0x7C080400,  //  0038  CALL	R2	2
-      0x90023C02,  //  0039  SETMBR	R0	K30	R2
-      0xB80A0200,  //  003A  GETNGBL	R2	K1
-      0x8C08051F,  //  003B  GETMET	R2	R2	K31
-      0x7C080200,  //  003C  CALL	R2	1
-      0x94080520,  //  003D  GETIDX	R2	R2	K32
-      0x740A0004,  //  003E  JMPT	R2	#0044
-      0xB80A0200,  //  003F  GETNGBL	R2	K1
-      0x8C080521,  //  0040  GETMET	R2	R2	K33
-      0x7C080200,  //  0041  CALL	R2	1
-      0x94080520,  //  0042  GETIDX	R2	R2	K32
-      0x780A0001,  //  0043  JMPF	R2	#0046
-      0x8C080122,  //  0044  GETMET	R2	R0	K34
-      0x7C080200,  //  0045  CALL	R2	1
-      0xB80A0200,  //  0046  GETNGBL	R2	K1
-      0x8C08051F,  //  0047  GETMET	R2	R2	K31
-      0x7C080200,  //  0048  CALL	R2	1
-      0x94080520,  //  0049  GETIDX	R2	R2	K32
-      0x740A0005,  //  004A  JMPT	R2	#0051
-      0xB80A0200,  //  004B  GETNGBL	R2	K1
-      0x8C080523,  //  004C  GETMET	R2	R2	K35
-      0x58100024,  //  004D  LDCONST	R4	K36
-      0x84140000,  //  004E  CLOSURE	R5	P0
-      0x58180025,  //  004F  LDCONST	R6	K37
-      0x7C080800,  //  0050  CALL	R2	4
-      0xB80A0200,  //  0051  GETNGBL	R2	K1
-      0x8C080521,  //  0052  GETMET	R2	R2	K33
-      0x7C080200,  //  0053  CALL	R2	1
-      0x94080520,  //  0054  GETIDX	R2	R2	K32
-      0x740A0005,  //  0055  JMPT	R2	#005C
-      0xB80A0200,  //  0056  GETNGBL	R2	K1
-      0x8C080523,  //  0057  GETMET	R2	R2	K35
-      0x58100026,  //  0058  LDCONST	R4	K38
-      0x84140001,  //  0059  CLOSURE	R5	P1
-      0x58180025,  //  005A  LDCONST	R6	K37
-      0x7C080800,  //  005B  CALL	R2	4
-      0x8C080127,  //  005C  GETMET	R2	R0	K39
-      0x7C080200,  //  005D  CALL	R2	1
-      0xB80A0200,  //  005E  GETNGBL	R2	K1
-      0x8C080528,  //  005F  GETMET	R2	R2	K40
-      0x5C100000,  //  0060  MOVE	R4	R0
-      0x7C080400,  //  0061  CALL	R2	2
-      0x8C080129,  //  0062  GETMET	R2	R0	K41
-      0x7C080200,  //  0063  CALL	R2	1
-      0xA0000000,  //  0064  CLOSE	R0
-      0x80000000,  //  0065  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: k2l
-********************************************************************/
-be_local_closure(Matter_Device_k2l,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(push),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_const_int(0),
-    }),
-    be_str_weak(k2l),
-    &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0003,  //  0004  EQ	R3	R0	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80040400,  //  0006  RET	1	R2
-      0x600C0010,  //  0007  GETGBL	R3	G16
-      0x8C100101,  //  0008  GETMET	R4	R0	K1
-      0x7C100200,  //  0009  CALL	R4	1
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0xA8020005,  //  000B  EXBLK	0	#0012
-      0x5C100600,  //  000C  MOVE	R4	R3
-      0x7C100000,  //  000D  CALL	R4	0
-      0x8C140502,  //  000E  GETMET	R5	R2	K2
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x7C140400,  //  0010  CALL	R5	2
-      0x7001FFF9,  //  0011  JMP		#000C
-      0x580C0003,  //  0012  LDCONST	R3	K3
-      0xAC0C0200,  //  0013  CATCH	R3	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x600C0010,  //  0015  GETGBL	R3	G16
-      0x6010000C,  //  0016  GETGBL	R4	G12
-      0x5C140400,  //  0017  MOVE	R5	R2
-      0x7C100200,  //  0018  CALL	R4	1
-      0x04100904,  //  0019  SUB	R4	R4	K4
-      0x40120804,  //  001A  CONNECT	R4	K4	R4
-      0x7C0C0200,  //  001B  CALL	R3	1
-      0xA8020010,  //  001C  EXBLK	0	#002E
-      0x5C100600,  //  001D  MOVE	R4	R3
-      0x7C100000,  //  001E  CALL	R4	0
-      0x94140404,  //  001F  GETIDX	R5	R2	R4
-      0x5C180800,  //  0020  MOVE	R6	R4
-      0x241C0D05,  //  0021  GT	R7	R6	K5
-      0x781E0008,  //  0022  JMPF	R7	#002C
-      0x041C0D04,  //  0023  SUB	R7	R6	K4
-      0x941C0407,  //  0024  GETIDX	R7	R2	R7
-      0x241C0E05,  //  0025  GT	R7	R7	R5
-      0x781E0004,  //  0026  JMPF	R7	#002C
-      0x041C0D04,  //  0027  SUB	R7	R6	K4
-      0x941C0407,  //  0028  GETIDX	R7	R2	R7
-      0x98080C07,  //  0029  SETIDX	R2	R6	R7
-      0x04180D04,  //  002A  SUB	R6	R6	K4
-      0x7001FFF4,  //  002B  JMP		#0021
-      0x98080C05,  //  002C  SETIDX	R2	R6	R5
-      0x7001FFEE,  //  002D  JMP		#001D
-      0x580C0003,  //  002E  LDCONST	R3	K3
-      0xAC0C0200,  //  002F  CATCH	R3	1	0
-      0xB0080000,  //  0030  RAISE	2	R0	R0
-      0x80040400,  //  0031  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: adjust_next_ep
-********************************************************************/
-be_local_closure(Matter_Device_adjust_next_ep,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins_config),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(next_ep),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(adjust_next_ep),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000A,  //  0005  EXBLK	0	#0011
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x600C0009,  //  0008  GETGBL	R3	G9
-      0x5C100400,  //  0009  MOVE	R4	R2
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x88100102,  //  000B  GETMBR	R4	R0	K2
-      0x28100604,  //  000C  GE	R4	R3	R4
-      0x78120001,  //  000D  JMPF	R4	#0010
-      0x00100703,  //  000E  ADD	R4	R3	K3
-      0x90020404,  //  000F  SETMBR	R0	K2	R4
-      0x7001FFF4,  //  0010  JMP		#0006
-      0x58040004,  //  0011  LDCONST	R1	K4
-      0xAC040200,  //  0012  CATCH	R1	1	0
-      0xB0080000,  //  0013  RAISE	2	R0	R0
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_plugin_class_displayname
-********************************************************************/
-be_local_closure(Matter_Device_get_plugin_class_displayname,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins_classes),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(NAME),
-    /* K3   */  be_nested_str_weak(),
-    }),
-    be_str_weak(get_plugin_class_displayname),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x880C0502,  //  0005  GETMBR	R3	R2	K2
-      0x70020000,  //  0006  JMP		#0008
-      0x580C0003,  //  0007  LDCONST	R3	K3
-      0x80040600,  //  0008  RET	1	R3
+      0xA8020046,  //  0001  EXBLK	0	#0049
+      0x60080011,  //  0002  GETGBL	R2	G17
+      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x7C080200,  //  0004  CALL	R2	1
+      0x8C0C0502,  //  0005  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0x8C100503,  //  0007  GETMET	R4	R2	K3
+      0x7C100200,  //  0008  CALL	R4	1
+      0xA4120800,  //  0009  IMPORT	R4	K4
+      0x8C140905,  //  000A  GETMET	R5	R4	K5
+      0x5C1C0600,  //  000B  MOVE	R7	R3
+      0x7C140400,  //  000C  CALL	R5	2
+      0x8C180B07,  //  000D  GETMET	R6	R5	K7
+      0x58200008,  //  000E  LDCONST	R8	K8
+      0x88240106,  //  000F  GETMBR	R9	R0	K6
+      0x7C180600,  //  0010  CALL	R6	3
+      0x90020C06,  //  0011  SETMBR	R0	K6	R6
+      0x8C180B07,  //  0012  GETMET	R6	R5	K7
+      0x5820000A,  //  0013  LDCONST	R8	K10
+      0x88240109,  //  0014  GETMBR	R9	R0	K9
+      0x7C180600,  //  0015  CALL	R6	3
+      0x90021206,  //  0016  SETMBR	R0	K9	R6
+      0x60180017,  //  0017  GETGBL	R6	G23
+      0x8C1C0B07,  //  0018  GETMET	R7	R5	K7
+      0x5824000B,  //  0019  LDCONST	R9	K11
+      0x50280000,  //  001A  LDBOOL	R10	0	0
+      0x7C1C0600,  //  001B  CALL	R7	3
+      0x7C180200,  //  001C  CALL	R6	1
+      0x90021606,  //  001D  SETMBR	R0	K11	R6
+      0x8C180B07,  //  001E  GETMET	R6	R5	K7
+      0x5820000D,  //  001F  LDCONST	R8	K13
+      0x8824010C,  //  0020  GETMBR	R9	R0	K12
+      0x7C180600,  //  0021  CALL	R6	3
+      0x90021806,  //  0022  SETMBR	R0	K12	R6
+      0x8C180B07,  //  0023  GETMET	R6	R5	K7
+      0x5820000F,  //  0024  LDCONST	R8	K15
+      0x7C180400,  //  0025  CALL	R6	2
+      0x90021C06,  //  0026  SETMBR	R0	K14	R6
+      0x8818010E,  //  0027  GETMBR	R6	R0	K14
+      0x4C1C0000,  //  0028  LDNIL	R7
+      0x20180C07,  //  0029  NE	R6	R6	R7
+      0x781A000B,  //  002A  JMPF	R6	#0037
+      0xB81A2000,  //  002B  GETNGBL	R6	K16
+      0x8C180D11,  //  002C  GETMET	R6	R6	K17
+      0x60200008,  //  002D  GETGBL	R8	G8
+      0x8824010E,  //  002E  GETMBR	R9	R0	K14
+      0x7C200200,  //  002F  CALL	R8	1
+      0x00222408,  //  0030  ADD	R8	K18	R8
+      0x58240013,  //  0031  LDCONST	R9	K19
+      0x7C180600,  //  0032  CALL	R6	3
+      0x8C180114,  //  0033  GETMET	R6	R0	K20
+      0x7C180200,  //  0034  CALL	R6	1
+      0x50180200,  //  0035  LDBOOL	R6	1	0
+      0x90022A06,  //  0036  SETMBR	R0	K21	R6
+      0x8C180B07,  //  0037  GETMET	R6	R5	K7
+      0x58200017,  //  0038  LDCONST	R8	K23
+      0x60240013,  //  0039  GETGBL	R9	G19
+      0x7C240000,  //  003A  CALL	R9	0
+      0x7C180600,  //  003B  CALL	R6	3
+      0x90022C06,  //  003C  SETMBR	R0	K22	R6
+      0x88180116,  //  003D  GETMBR	R6	R0	K22
+      0x781A0007,  //  003E  JMPF	R6	#0047
+      0xB81A2000,  //  003F  GETNGBL	R6	K16
+      0x8C180D11,  //  0040  GETMET	R6	R6	K17
+      0x60200008,  //  0041  GETGBL	R8	G8
+      0x88240116,  //  0042  GETMBR	R9	R0	K22
+      0x7C200200,  //  0043  CALL	R8	1
+      0x00223008,  //  0044  ADD	R8	K24	R8
+      0x58240013,  //  0045  LDCONST	R9	K19
+      0x7C180600,  //  0046  CALL	R6	3
+      0xA8040001,  //  0047  EXBLK	1	1
+      0x70020012,  //  0048  JMP		#005C
+      0xAC080002,  //  0049  CATCH	R2	0	2
+      0x7002000F,  //  004A  JMP		#005B
+      0x20100519,  //  004B  NE	R4	R2	K25
+      0x7812000C,  //  004C  JMPF	R4	#005A
+      0xB8122000,  //  004D  GETNGBL	R4	K16
+      0x8C100911,  //  004E  GETMET	R4	R4	K17
+      0x60180008,  //  004F  GETGBL	R6	G8
+      0x5C1C0400,  //  0050  MOVE	R7	R2
+      0x7C180200,  //  0051  CALL	R6	1
+      0x001A3406,  //  0052  ADD	R6	K26	R6
+      0x00180D1B,  //  0053  ADD	R6	R6	K27
+      0x601C0008,  //  0054  GETGBL	R7	G8
+      0x5C200600,  //  0055  MOVE	R8	R3
+      0x7C1C0200,  //  0056  CALL	R7	1
+      0x00180C07,  //  0057  ADD	R6	R6	R7
+      0x581C001C,  //  0058  LDCONST	R7	K28
+      0x7C100600,  //  0059  CALL	R4	3
+      0x70020000,  //  005A  JMP		#005C
+      0xB0080000,  //  005B  RAISE	2	R0	R0
+      0x50080000,  //  005C  LDBOOL	R2	0	0
+      0x880C0106,  //  005D  GETMBR	R3	R0	K6
+      0x4C100000,  //  005E  LDNIL	R4
+      0x1C0C0604,  //  005F  EQ	R3	R3	R4
+      0x780E000A,  //  0060  JMPF	R3	#006C
+      0x8C0C031D,  //  0061  GETMET	R3	R1	K29
+      0x5814001C,  //  0062  LDCONST	R5	K28
+      0x7C0C0400,  //  0063  CALL	R3	2
+      0x8C0C071E,  //  0064  GETMET	R3	R3	K30
+      0x5814001F,  //  0065  LDCONST	R5	K31
+      0x5818001C,  //  0066  LDCONST	R6	K28
+      0x7C0C0600,  //  0067  CALL	R3	3
+      0x54120FFE,  //  0068  LDINT	R4	4095
+      0x2C0C0604,  //  0069  AND	R3	R3	R4
+      0x90020C03,  //  006A  SETMBR	R0	K6	R3
+      0x50080200,  //  006B  LDBOOL	R2	1	0
+      0x880C0109,  //  006C  GETMBR	R3	R0	K9
+      0x4C100000,  //  006D  LDNIL	R4
+      0x1C0C0604,  //  006E  EQ	R3	R3	R4
+      0x780E0003,  //  006F  JMPF	R3	#0074
+      0x8C0C0120,  //  0070  GETMET	R3	R0	K32
+      0x7C0C0200,  //  0071  CALL	R3	1
+      0x90021203,  //  0072  SETMBR	R0	K9	R3
+      0x50080200,  //  0073  LDBOOL	R2	1	0
+      0x780A0001,  //  0074  JMPF	R2	#0077
+      0x8C0C0121,  //  0075  GETMET	R3	R0	K33
+      0x7C0C0200,  //  0076  CALL	R3	1
+      0x80000000,  //  0077  RET	0
     })
   )
 );
@@ -3112,1006 +4855,12 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
 
 
 /********************************************************************
-** Solidified function: clean_remotes
+** Solidified function: generate_random_passcode
 ********************************************************************/
-be_local_closure(Matter_Device_clean_remotes,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(http_remotes),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_nested_str_weak(plugins),
-    /* K5   */  be_nested_str_weak(get),
-    /* K6   */  be_nested_str_weak(http_remote),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(keys),
-    /* K10  */  be_nested_str_weak(tasmota),
-    /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
-    /* K13  */  be_nested_str_weak(addr),
-    /* K14  */  be_const_int(3),
-    /* K15  */  be_nested_str_weak(close),
-    /* K16  */  be_nested_str_weak(remove),
-    }),
-    be_str_weak(clean_remotes),
-    &be_const_str_solidified,
-    ( &(const binstruction[66]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x780A003D,  //  0002  JMPF	R2	#0041
-      0x60080013,  //  0003  GETGBL	R2	G19
-      0x7C080000,  //  0004  CALL	R2	0
-      0x600C0010,  //  0005  GETGBL	R3	G16
-      0x88100101,  //  0006  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0xA8020003,  //  0008  EXBLK	0	#000D
-      0x5C100600,  //  0009  MOVE	R4	R3
-      0x7C100000,  //  000A  CALL	R4	0
-      0x98080902,  //  000B  SETIDX	R2	R4	K2
-      0x7001FFFB,  //  000C  JMP		#0009
-      0x580C0003,  //  000D  LDCONST	R3	K3
-      0xAC0C0200,  //  000E  CATCH	R3	1	0
-      0xB0080000,  //  000F  RAISE	2	R0	R0
-      0x600C0010,  //  0010  GETGBL	R3	G16
-      0x88100104,  //  0011  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0xA802000F,  //  0013  EXBLK	0	#0024
-      0x5C100600,  //  0014  MOVE	R4	R3
-      0x7C100000,  //  0015  CALL	R4	0
-      0x8C140305,  //  0016  GETMET	R5	R1	K5
-      0x5C1C0800,  //  0017  MOVE	R7	R4
-      0x58200006,  //  0018  LDCONST	R8	K6
-      0x7C140600,  //  0019  CALL	R5	3
-      0x4C180000,  //  001A  LDNIL	R6
-      0x20180A06,  //  001B  NE	R6	R5	R6
-      0x781A0005,  //  001C  JMPF	R6	#0023
-      0x8C180507,  //  001D  GETMET	R6	R2	K7
-      0x5C200A00,  //  001E  MOVE	R8	R5
-      0x58240002,  //  001F  LDCONST	R9	K2
-      0x7C180600,  //  0020  CALL	R6	3
-      0x00180D08,  //  0021  ADD	R6	R6	K8
-      0x98080A06,  //  0022  SETIDX	R2	R5	R6
-      0x7001FFEF,  //  0023  JMP		#0014
-      0x580C0003,  //  0024  LDCONST	R3	K3
-      0xAC0C0200,  //  0025  CATCH	R3	1	0
-      0xB0080000,  //  0026  RAISE	2	R0	R0
-      0x600C0010,  //  0027  GETGBL	R3	G16
-      0x8C100509,  //  0028  GETMET	R4	R2	K9
-      0x7C100200,  //  0029  CALL	R4	1
-      0x7C0C0200,  //  002A  CALL	R3	1
-      0xA8020011,  //  002B  EXBLK	0	#003E
-      0x5C100600,  //  002C  MOVE	R4	R3
-      0x7C100000,  //  002D  CALL	R4	0
-      0x94140404,  //  002E  GETIDX	R5	R2	R4
-      0x1C140B02,  //  002F  EQ	R5	R5	K2
-      0x7816000B,  //  0030  JMPF	R5	#003D
-      0xB8161400,  //  0031  GETNGBL	R5	K10
-      0x8C140B0B,  //  0032  GETMET	R5	R5	K11
-      0x881C090D,  //  0033  GETMBR	R7	R4	K13
-      0x001E1807,  //  0034  ADD	R7	K12	R7
-      0x5820000E,  //  0035  LDCONST	R8	K14
-      0x7C140600,  //  0036  CALL	R5	3
-      0x8C14090F,  //  0037  GETMET	R5	R4	K15
-      0x7C140200,  //  0038  CALL	R5	1
-      0x88140101,  //  0039  GETMBR	R5	R0	K1
-      0x8C140B10,  //  003A  GETMET	R5	R5	K16
-      0x5C1C0800,  //  003B  MOVE	R7	R4
-      0x7C140400,  //  003C  CALL	R5	2
-      0x7001FFED,  //  003D  JMP		#002C
-      0x580C0003,  //  003E  LDCONST	R3	K3
-      0xAC0C0200,  //  003F  CATCH	R3	1	0
-      0xB0080000,  //  0040  RAISE	2	R0	R0
-      0x80000000,  //  0041  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: k2l_num
-********************************************************************/
-be_local_closure(Matter_Device_k2l_num,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(push),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_const_int(0),
-    }),
-    be_str_weak(k2l_num),
-    &be_const_str_solidified,
-    ( &(const binstruction[52]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0003,  //  0004  EQ	R3	R0	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80040400,  //  0006  RET	1	R2
-      0x600C0010,  //  0007  GETGBL	R3	G16
-      0x8C100101,  //  0008  GETMET	R4	R0	K1
-      0x7C100200,  //  0009  CALL	R4	1
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0xA8020007,  //  000B  EXBLK	0	#0014
-      0x5C100600,  //  000C  MOVE	R4	R3
-      0x7C100000,  //  000D  CALL	R4	0
-      0x8C140502,  //  000E  GETMET	R5	R2	K2
-      0x601C0009,  //  000F  GETGBL	R7	G9
-      0x5C200800,  //  0010  MOVE	R8	R4
-      0x7C1C0200,  //  0011  CALL	R7	1
-      0x7C140400,  //  0012  CALL	R5	2
-      0x7001FFF7,  //  0013  JMP		#000C
-      0x580C0003,  //  0014  LDCONST	R3	K3
-      0xAC0C0200,  //  0015  CATCH	R3	1	0
-      0xB0080000,  //  0016  RAISE	2	R0	R0
-      0x600C0010,  //  0017  GETGBL	R3	G16
-      0x6010000C,  //  0018  GETGBL	R4	G12
-      0x5C140400,  //  0019  MOVE	R5	R2
-      0x7C100200,  //  001A  CALL	R4	1
-      0x04100904,  //  001B  SUB	R4	R4	K4
-      0x40120804,  //  001C  CONNECT	R4	K4	R4
-      0x7C0C0200,  //  001D  CALL	R3	1
-      0xA8020010,  //  001E  EXBLK	0	#0030
-      0x5C100600,  //  001F  MOVE	R4	R3
-      0x7C100000,  //  0020  CALL	R4	0
-      0x94140404,  //  0021  GETIDX	R5	R2	R4
-      0x5C180800,  //  0022  MOVE	R6	R4
-      0x241C0D05,  //  0023  GT	R7	R6	K5
-      0x781E0008,  //  0024  JMPF	R7	#002E
-      0x041C0D04,  //  0025  SUB	R7	R6	K4
-      0x941C0407,  //  0026  GETIDX	R7	R2	R7
-      0x241C0E05,  //  0027  GT	R7	R7	R5
-      0x781E0004,  //  0028  JMPF	R7	#002E
-      0x041C0D04,  //  0029  SUB	R7	R6	K4
-      0x941C0407,  //  002A  GETIDX	R7	R2	R7
-      0x98080C07,  //  002B  SETIDX	R2	R6	R7
-      0x04180D04,  //  002C  SUB	R6	R6	K4
-      0x7001FFF4,  //  002D  JMP		#0023
-      0x98080C05,  //  002E  SETIDX	R2	R6	R5
-      0x7001FFEE,  //  002F  JMP		#001F
-      0x580C0003,  //  0030  LDCONST	R3	K3
-      0xAC0C0200,  //  0031  CATCH	R3	1	0
-      0xB0080000,  //  0032  RAISE	2	R0	R0
-      0x80040400,  //  0033  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_50ms
-********************************************************************/
-be_local_closure(Matter_Device_every_50ms,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tick),
-    /* K1   */  be_const_int(1),
-    }),
-    be_str_weak(every_50ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x00040301,  //  0001  ADD	R1	R1	K1
-      0x90020001,  //  0002  SETMBR	R0	K0	R1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop
-********************************************************************/
-be_local_closure(Matter_Device_stop,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(remove_driver),
-    /* K2   */  be_nested_str_weak(udp_server),
-    /* K3   */  be_nested_str_weak(stop),
-    }),
-    be_str_weak(stop),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x88040102,  //  0004  GETMBR	R1	R0	K2
-      0x78060002,  //  0005  JMPF	R1	#0009
-      0x88040102,  //  0006  GETMBR	R1	R0	K2
-      0x8C040303,  //  0007  GETMET	R1	R1	K3
-      0x7C040200,  //  0008  CALL	R1	1
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_remove_op_discovery_all_fabrics
-********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(active_fabrics),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(mdns_remove_op_discovery_all_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000B,  //  0005  EXBLK	0	#0012
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x780E0005,  //  000A  JMPF	R3	#0011
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x780E0002,  //  000D  JMPF	R3	#0011
-      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x7001FFF3,  //  0011  JMP		#0006
-      0x58040005,  //  0012  LDCONST	R1	K5
-      0xAC040200,  //  0013  CATCH	R1	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_commands
-********************************************************************/
-be_local_closure(Matter_Device_register_commands,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        10,                          /* nstack */
-        4,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(MtrJoin),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 8]) {  /* code */
-          0x68100000,  //  0000  GETUPV	R4	U0
-          0x8C100900,  //  0001  GETMET	R4	R4	K0
-          0x5C180000,  //  0002  MOVE	R6	R0
-          0x5C1C0200,  //  0003  MOVE	R7	R1
-          0x5C200400,  //  0004  MOVE	R8	R2
-          0x5C240600,  //  0005  MOVE	R9	R3
-          0x7C100A00,  //  0006  CALL	R4	5
-          0x80040800,  //  0007  RET	1	R4
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(add_cmd),
-    /* K2   */  be_nested_str_weak(MtrJoin),
-    }),
-    be_str_weak(register_commands),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x580C0002,  //  0002  LDCONST	R3	K2
-      0x84100000,  //  0003  CLOSURE	R4	P0
-      0x7C040600,  //  0004  CALL	R1	3
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_http_remote
-********************************************************************/
-be_local_closure(Matter_Device_register_http_remote,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(http_remotes),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(get_timeout),
-    /* K3   */  be_nested_str_weak(set_timeout),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(HTTP_remote),
-    }),
-    be_str_weak(register_http_remote),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x4C100000,  //  0001  LDNIL	R4
-      0x1C0C0604,  //  0002  EQ	R3	R3	R4
-      0x780E0002,  //  0003  JMPF	R3	#0007
-      0x600C0013,  //  0004  GETGBL	R3	G19
-      0x7C0C0000,  //  0005  CALL	R3	0
-      0x90020003,  //  0006  SETMBR	R0	K0	R3
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x88100100,  //  0008  GETMBR	R4	R0	K0
-      0x8C100901,  //  0009  GETMET	R4	R4	K1
-      0x5C180200,  //  000A  MOVE	R6	R1
-      0x7C100400,  //  000B  CALL	R4	2
-      0x78120009,  //  000C  JMPF	R4	#0017
-      0x88100100,  //  000D  GETMBR	R4	R0	K0
-      0x940C0801,  //  000E  GETIDX	R3	R4	R1
-      0x8C140702,  //  000F  GETMET	R5	R3	K2
-      0x7C140200,  //  0010  CALL	R5	1
-      0x14140405,  //  0011  LT	R5	R2	R5
-      0x78160002,  //  0012  JMPF	R5	#0016
-      0x8C140703,  //  0013  GETMET	R5	R3	K3
-      0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x7C140400,  //  0015  CALL	R5	2
-      0x70020007,  //  0016  JMP		#001F
-      0xB8120800,  //  0017  GETNGBL	R4	K4
-      0x8C100905,  //  0018  GETMET	R4	R4	K5
-      0x5C180200,  //  0019  MOVE	R6	R1
-      0x5C1C0400,  //  001A  MOVE	R7	R2
-      0x7C100600,  //  001B  CALL	R4	3
-      0x5C0C0800,  //  001C  MOVE	R3	R4
-      0x88100100,  //  001D  GETMBR	R4	R0	K0
-      0x98100203,  //  001E  SETIDX	R4	R1	R3
-      0x80040600,  //  001F  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: compute_qrcode_content
-********************************************************************/
-be_local_closure(Matter_Device_compute_qrcode_content,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(resize),
-    /* K1   */  be_nested_str_weak(setbits),
-    /* K2   */  be_const_int(3),
-    /* K3   */  be_nested_str_weak(vendorid),
-    /* K4   */  be_nested_str_weak(productid),
-    /* K5   */  be_nested_str_weak(root_discriminator),
-    /* K6   */  be_nested_str_weak(root_passcode),
-    /* K7   */  be_const_int(134217727),
-    /* K8   */  be_nested_str_weak(MT_X3A),
-    /* K9   */  be_nested_str_weak(matter),
-    /* K10  */  be_nested_str_weak(Base38),
-    /* K11  */  be_nested_str_weak(encode),
-    }),
-    be_str_weak(compute_qrcode_content),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0x60040015,  //  0000  GETGBL	R1	G21
-      0x7C040000,  //  0001  CALL	R1	0
-      0x8C040300,  //  0002  GETMET	R1	R1	K0
-      0x540E000A,  //  0003  LDINT	R3	11
-      0x7C040400,  //  0004  CALL	R1	2
-      0x8C080301,  //  0005  GETMET	R2	R1	K1
-      0x58100002,  //  0006  LDCONST	R4	K2
-      0x5416000F,  //  0007  LDINT	R5	16
-      0x88180103,  //  0008  GETMBR	R6	R0	K3
-      0x7C080800,  //  0009  CALL	R2	4
-      0x8C080301,  //  000A  GETMET	R2	R1	K1
-      0x54120012,  //  000B  LDINT	R4	19
-      0x5416000F,  //  000C  LDINT	R5	16
-      0x88180104,  //  000D  GETMBR	R6	R0	K4
-      0x7C080800,  //  000E  CALL	R2	4
-      0x8C080301,  //  000F  GETMET	R2	R1	K1
-      0x54120024,  //  0010  LDINT	R4	37
-      0x54160007,  //  0011  LDINT	R5	8
-      0x541A0003,  //  0012  LDINT	R6	4
-      0x7C080800,  //  0013  CALL	R2	4
-      0x8C080301,  //  0014  GETMET	R2	R1	K1
-      0x5412002C,  //  0015  LDINT	R4	45
-      0x5416000B,  //  0016  LDINT	R5	12
-      0x88180105,  //  0017  GETMBR	R6	R0	K5
-      0x541E0FFE,  //  0018  LDINT	R7	4095
-      0x2C180C07,  //  0019  AND	R6	R6	R7
-      0x7C080800,  //  001A  CALL	R2	4
-      0x8C080301,  //  001B  GETMET	R2	R1	K1
-      0x54120038,  //  001C  LDINT	R4	57
-      0x5416001A,  //  001D  LDINT	R5	27
-      0x88180106,  //  001E  GETMBR	R6	R0	K6
-      0x2C180D07,  //  001F  AND	R6	R6	K7
-      0x7C080800,  //  0020  CALL	R2	4
-      0xB80A1200,  //  0021  GETNGBL	R2	K9
-      0x8808050A,  //  0022  GETMBR	R2	R2	K10
-      0x8C08050B,  //  0023  GETMET	R2	R2	K11
-      0x5C100200,  //  0024  MOVE	R4	R1
-      0x7C080400,  //  0025  CALL	R2	2
-      0x000A1002,  //  0026  ADD	R2	K8	R2
-      0x80040400,  //  0027  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_operational_discovery
-********************************************************************/
-be_local_closure(Matter_Device_start_operational_discovery,   /* name */
+be_local_closure(Matter_Device_generate_random_passcode,   /* name */
   be_nested_proto(
     7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(mdns),
-    /* K2   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K3   */  be_nested_str_weak(root_w0),
-    /* K4   */  be_nested_str_weak(root_L),
-    /* K5   */  be_nested_str_weak(mdns_announce_op_discovery),
-    }),
-    be_str_weak(start_operational_discovery),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0x8C100102,  //  0002  GETMET	R4	R0	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x4C100000,  //  0004  LDNIL	R4
-      0x90020604,  //  0005  SETMBR	R0	K3	R4
-      0x4C100000,  //  0006  LDNIL	R4
-      0x90020804,  //  0007  SETMBR	R0	K4	R4
-      0x8C100105,  //  0008  GETMET	R4	R0	K5
-      0x5C180200,  //  0009  MOVE	R6	R1
-      0x7C100400,  //  000A  CALL	R4	2
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_plugin_class
-********************************************************************/
-be_local_closure(Matter_Device_register_plugin_class,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(get),
-    /* K2   */  be_nested_str_weak(TYPE),
-    /* K3   */  be_nested_str_weak(plugins_classes),
-    }),
-    be_str_weak(register_plugin_class),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x58180002,  //  0003  LDCONST	R6	K2
-      0x7C0C0600,  //  0004  CALL	R3	3
-      0x780E0001,  //  0005  JMPF	R3	#0008
-      0x88100103,  //  0006  GETMBR	R4	R0	K3
-      0x98100601,  //  0007  SETIDX	R4	R3	R1
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _trigger_read_sensors
-********************************************************************/
-be_local_closure(Matter_Device__trigger_read_sensors,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(read_sensors),
-    /* K3   */  be_nested_str_weak(load),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(plugins),
-    /* K6   */  be_nested_str_weak(parse_sensors),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
-    /* K10  */  be_const_int(3),
-    }),
-    be_str_weak(_trigger_read_sensors),
-    &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x1C0C0403,  //  0005  EQ	R3	R2	R3
-      0x780E0000,  //  0006  JMPF	R3	#0008
-      0x80000600,  //  0007  RET	0
-      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
-      0x5C140400,  //  0009  MOVE	R5	R2
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x4C100000,  //  000B  LDNIL	R4
-      0x20100604,  //  000C  NE	R4	R3	R4
-      0x7812000D,  //  000D  JMPF	R4	#001C
-      0x58100004,  //  000E  LDCONST	R4	K4
-      0x6014000C,  //  000F  GETGBL	R5	G12
-      0x88180105,  //  0010  GETMBR	R6	R0	K5
-      0x7C140200,  //  0011  CALL	R5	1
-      0x14140805,  //  0012  LT	R5	R4	R5
-      0x78160006,  //  0013  JMPF	R5	#001B
-      0x88140105,  //  0014  GETMBR	R5	R0	K5
-      0x94140A04,  //  0015  GETIDX	R5	R5	R4
-      0x8C140B06,  //  0016  GETMET	R5	R5	K6
-      0x5C1C0600,  //  0017  MOVE	R7	R3
-      0x7C140400,  //  0018  CALL	R5	2
-      0x00100907,  //  0019  ADD	R4	R4	K7
-      0x7001FFF3,  //  001A  JMP		#000F
-      0x70020007,  //  001B  JMP		#0024
-      0xB8120200,  //  001C  GETNGBL	R4	K1
-      0x8C100908,  //  001D  GETMET	R4	R4	K8
-      0x60180008,  //  001E  GETGBL	R6	G8
-      0x5C1C0400,  //  001F  MOVE	R7	R2
-      0x7C180200,  //  0020  CALL	R6	1
-      0x001A1206,  //  0021  ADD	R6	K9	R6
-      0x581C000A,  //  0022  LDCONST	R7	K10
-      0x7C100600,  //  0023  CALL	R4	3
-      0x80000000,  //  0024  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: bridge_add_endpoint
-********************************************************************/
-be_local_closure(Matter_Device_bridge_add_endpoint,   /* name */
-  be_nested_proto(
-    17,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins_classes),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-    /* K5   */  be_nested_str_weak(_X27_X20skipping),
-    /* K6   */  be_const_int(3),
-    /* K7   */  be_nested_str_weak(next_ep),
-    /* K8   */  be_nested_str_weak(plugins),
-    /* K9   */  be_nested_str_weak(push),
-    /* K10  */  be_nested_str_weak(type),
-    /* K11  */  be_nested_str_weak(keys),
-    /* K12  */  be_nested_str_weak(stop_iteration),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
-    /* K14  */  be_nested_str_weak(conf_to_log),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_nested_str_weak(plugins_config),
-    /* K17  */  be_nested_str_weak(plugins_persist),
-    /* K18  */  be_const_int(1),
-    /* K19  */  be_nested_str_weak(save_param),
-    /* K20  */  be_nested_str_weak(signal_endpoints_changed),
-    }),
-    be_str_weak(bridge_add_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[70]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x4C100000,  //  0004  LDNIL	R4
-      0x1C100604,  //  0005  EQ	R4	R3	R4
-      0x78120009,  //  0006  JMPF	R4	#0011
-      0xB8120400,  //  0007  GETNGBL	R4	K2
-      0x8C100903,  //  0008  GETMET	R4	R4	K3
-      0x60180008,  //  0009  GETGBL	R6	G8
-      0x5C1C0200,  //  000A  MOVE	R7	R1
-      0x7C180200,  //  000B  CALL	R6	1
-      0x001A0806,  //  000C  ADD	R6	K4	R6
-      0x00180D05,  //  000D  ADD	R6	R6	K5
-      0x581C0006,  //  000E  LDCONST	R7	K6
-      0x7C100600,  //  000F  CALL	R4	3
-      0x80000800,  //  0010  RET	0
-      0x88100107,  //  0011  GETMBR	R4	R0	K7
-      0x60140008,  //  0012  GETGBL	R5	G8
-      0x5C180800,  //  0013  MOVE	R6	R4
-      0x7C140200,  //  0014  CALL	R5	1
-      0x5C180600,  //  0015  MOVE	R6	R3
-      0x5C1C0000,  //  0016  MOVE	R7	R0
-      0x5C200800,  //  0017  MOVE	R8	R4
-      0x5C240400,  //  0018  MOVE	R9	R2
-      0x7C180600,  //  0019  CALL	R6	3
-      0x881C0108,  //  001A  GETMBR	R7	R0	K8
-      0x8C1C0F09,  //  001B  GETMET	R7	R7	K9
-      0x5C240C00,  //  001C  MOVE	R9	R6
-      0x7C1C0400,  //  001D  CALL	R7	2
-      0x601C0013,  //  001E  GETGBL	R7	G19
-      0x7C1C0000,  //  001F  CALL	R7	0
-      0x981E1401,  //  0020  SETIDX	R7	K10	R1
-      0x60200010,  //  0021  GETGBL	R8	G16
-      0x8C24050B,  //  0022  GETMET	R9	R2	K11
-      0x7C240200,  //  0023  CALL	R9	1
-      0x7C200200,  //  0024  CALL	R8	1
-      0xA8020004,  //  0025  EXBLK	0	#002B
-      0x5C241000,  //  0026  MOVE	R9	R8
-      0x7C240000,  //  0027  CALL	R9	0
-      0x94280409,  //  0028  GETIDX	R10	R2	R9
-      0x981C120A,  //  0029  SETIDX	R7	R9	R10
-      0x7001FFFA,  //  002A  JMP		#0026
-      0x5820000C,  //  002B  LDCONST	R8	K12
-      0xAC200200,  //  002C  CATCH	R8	1	0
-      0xB0080000,  //  002D  RAISE	2	R0	R0
-      0xB8220400,  //  002E  GETNGBL	R8	K2
-      0x8C201103,  //  002F  GETMET	R8	R8	K3
-      0x60280018,  //  0030  GETGBL	R10	G24
-      0x582C000D,  //  0031  LDCONST	R11	K13
-      0x5C300800,  //  0032  MOVE	R12	R4
-      0x5C340200,  //  0033  MOVE	R13	R1
-      0x8C38010E,  //  0034  GETMET	R14	R0	K14
-      0x5C400400,  //  0035  MOVE	R16	R2
-      0x7C380400,  //  0036  CALL	R14	2
-      0x7C280800,  //  0037  CALL	R10	4
-      0x582C000F,  //  0038  LDCONST	R11	K15
-      0x7C200600,  //  0039  CALL	R8	3
-      0x88200110,  //  003A  GETMBR	R8	R0	K16
-      0x98200A07,  //  003B  SETIDX	R8	R5	R7
-      0x50200200,  //  003C  LDBOOL	R8	1	0
-      0x90022208,  //  003D  SETMBR	R0	K17	R8
-      0x88200107,  //  003E  GETMBR	R8	R0	K7
-      0x00201112,  //  003F  ADD	R8	R8	K18
-      0x90020E08,  //  0040  SETMBR	R0	K7	R8
-      0x8C200113,  //  0041  GETMET	R8	R0	K19
-      0x7C200200,  //  0042  CALL	R8	1
-      0x8C200114,  //  0043  GETMET	R8	R0	K20
-      0x7C200200,  //  0044  CALL	R8	1
-      0x80040800,  //  0045  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: load_param
-********************************************************************/
-be_local_closure(Matter_Device_load_param,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[31]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(FILENAME),
-    /* K2   */  be_nested_str_weak(read),
-    /* K3   */  be_nested_str_weak(close),
-    /* K4   */  be_nested_str_weak(json),
-    /* K5   */  be_nested_str_weak(load),
-    /* K6   */  be_nested_str_weak(root_discriminator),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_nested_str_weak(distinguish),
-    /* K9   */  be_nested_str_weak(root_passcode),
-    /* K10  */  be_nested_str_weak(passcode),
-    /* K11  */  be_nested_str_weak(ipv4only),
-    /* K12  */  be_nested_str_weak(next_ep),
-    /* K13  */  be_nested_str_weak(nextep),
-    /* K14  */  be_nested_str_weak(plugins_config),
-    /* K15  */  be_nested_str_weak(config),
-    /* K16  */  be_nested_str_weak(tasmota),
-    /* K17  */  be_nested_str_weak(log),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20load_config_X20_X3D_X20),
-    /* K19  */  be_const_int(3),
-    /* K20  */  be_nested_str_weak(adjust_next_ep),
-    /* K21  */  be_nested_str_weak(plugins_persist),
-    /* K22  */  be_nested_str_weak(io_error),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
-    /* K24  */  be_nested_str_weak(_X7C),
-    /* K25  */  be_const_int(2),
-    /* K26  */  be_nested_str_weak(random),
-    /* K27  */  be_nested_str_weak(get),
-    /* K28  */  be_const_int(0),
-    /* K29  */  be_nested_str_weak(generate_random_passcode),
-    /* K30  */  be_nested_str_weak(save_param),
-    }),
-    be_str_weak(load_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[104]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA8020036,  //  0001  EXBLK	0	#0039
-      0x60080011,  //  0002  GETGBL	R2	G17
-      0x880C0101,  //  0003  GETMBR	R3	R0	K1
-      0x7C080200,  //  0004  CALL	R2	1
-      0x8C0C0502,  //  0005  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0x8C100503,  //  0007  GETMET	R4	R2	K3
-      0x7C100200,  //  0008  CALL	R4	1
-      0xA4120800,  //  0009  IMPORT	R4	K4
-      0x8C140905,  //  000A  GETMET	R5	R4	K5
-      0x5C1C0600,  //  000B  MOVE	R7	R3
-      0x7C140400,  //  000C  CALL	R5	2
-      0x8C180B07,  //  000D  GETMET	R6	R5	K7
-      0x58200008,  //  000E  LDCONST	R8	K8
-      0x88240106,  //  000F  GETMBR	R9	R0	K6
-      0x7C180600,  //  0010  CALL	R6	3
-      0x90020C06,  //  0011  SETMBR	R0	K6	R6
-      0x8C180B07,  //  0012  GETMET	R6	R5	K7
-      0x5820000A,  //  0013  LDCONST	R8	K10
-      0x88240109,  //  0014  GETMBR	R9	R0	K9
-      0x7C180600,  //  0015  CALL	R6	3
-      0x90021206,  //  0016  SETMBR	R0	K9	R6
-      0x60180017,  //  0017  GETGBL	R6	G23
-      0x8C1C0B07,  //  0018  GETMET	R7	R5	K7
-      0x5824000B,  //  0019  LDCONST	R9	K11
-      0x50280000,  //  001A  LDBOOL	R10	0	0
-      0x7C1C0600,  //  001B  CALL	R7	3
-      0x7C180200,  //  001C  CALL	R6	1
-      0x90021606,  //  001D  SETMBR	R0	K11	R6
-      0x8C180B07,  //  001E  GETMET	R6	R5	K7
-      0x5820000D,  //  001F  LDCONST	R8	K13
-      0x8824010C,  //  0020  GETMBR	R9	R0	K12
-      0x7C180600,  //  0021  CALL	R6	3
-      0x90021806,  //  0022  SETMBR	R0	K12	R6
-      0x8C180B07,  //  0023  GETMET	R6	R5	K7
-      0x5820000F,  //  0024  LDCONST	R8	K15
-      0x7C180400,  //  0025  CALL	R6	2
-      0x90021C06,  //  0026  SETMBR	R0	K14	R6
-      0x8818010E,  //  0027  GETMBR	R6	R0	K14
-      0x4C1C0000,  //  0028  LDNIL	R7
-      0x20180C07,  //  0029  NE	R6	R6	R7
-      0x781A000B,  //  002A  JMPF	R6	#0037
-      0xB81A2000,  //  002B  GETNGBL	R6	K16
-      0x8C180D11,  //  002C  GETMET	R6	R6	K17
-      0x60200008,  //  002D  GETGBL	R8	G8
-      0x8824010E,  //  002E  GETMBR	R9	R0	K14
-      0x7C200200,  //  002F  CALL	R8	1
-      0x00222408,  //  0030  ADD	R8	K18	R8
-      0x58240013,  //  0031  LDCONST	R9	K19
-      0x7C180600,  //  0032  CALL	R6	3
-      0x8C180114,  //  0033  GETMET	R6	R0	K20
-      0x7C180200,  //  0034  CALL	R6	1
-      0x50180200,  //  0035  LDBOOL	R6	1	0
-      0x90022A06,  //  0036  SETMBR	R0	K21	R6
-      0xA8040001,  //  0037  EXBLK	1	1
-      0x70020012,  //  0038  JMP		#004C
-      0xAC080002,  //  0039  CATCH	R2	0	2
-      0x7002000F,  //  003A  JMP		#004B
-      0x20100516,  //  003B  NE	R4	R2	K22
-      0x7812000C,  //  003C  JMPF	R4	#004A
-      0xB8122000,  //  003D  GETNGBL	R4	K16
-      0x8C100911,  //  003E  GETMET	R4	R4	K17
-      0x60180008,  //  003F  GETGBL	R6	G8
-      0x5C1C0400,  //  0040  MOVE	R7	R2
-      0x7C180200,  //  0041  CALL	R6	1
-      0x001A2E06,  //  0042  ADD	R6	K23	R6
-      0x00180D18,  //  0043  ADD	R6	R6	K24
-      0x601C0008,  //  0044  GETGBL	R7	G8
-      0x5C200600,  //  0045  MOVE	R8	R3
-      0x7C1C0200,  //  0046  CALL	R7	1
-      0x00180C07,  //  0047  ADD	R6	R6	R7
-      0x581C0019,  //  0048  LDCONST	R7	K25
-      0x7C100600,  //  0049  CALL	R4	3
-      0x70020000,  //  004A  JMP		#004C
-      0xB0080000,  //  004B  RAISE	2	R0	R0
-      0x50080000,  //  004C  LDBOOL	R2	0	0
-      0x880C0106,  //  004D  GETMBR	R3	R0	K6
-      0x4C100000,  //  004E  LDNIL	R4
-      0x1C0C0604,  //  004F  EQ	R3	R3	R4
-      0x780E000A,  //  0050  JMPF	R3	#005C
-      0x8C0C031A,  //  0051  GETMET	R3	R1	K26
-      0x58140019,  //  0052  LDCONST	R5	K25
-      0x7C0C0400,  //  0053  CALL	R3	2
-      0x8C0C071B,  //  0054  GETMET	R3	R3	K27
-      0x5814001C,  //  0055  LDCONST	R5	K28
-      0x58180019,  //  0056  LDCONST	R6	K25
-      0x7C0C0600,  //  0057  CALL	R3	3
-      0x54120FFE,  //  0058  LDINT	R4	4095
-      0x2C0C0604,  //  0059  AND	R3	R3	R4
-      0x90020C03,  //  005A  SETMBR	R0	K6	R3
-      0x50080200,  //  005B  LDBOOL	R2	1	0
-      0x880C0109,  //  005C  GETMBR	R3	R0	K9
-      0x4C100000,  //  005D  LDNIL	R4
-      0x1C0C0604,  //  005E  EQ	R3	R3	R4
-      0x780E0003,  //  005F  JMPF	R3	#0064
-      0x8C0C011D,  //  0060  GETMET	R3	R0	K29
-      0x7C0C0200,  //  0061  CALL	R3	1
-      0x90021203,  //  0062  SETMBR	R0	K9	R3
-      0x50080200,  //  0063  LDBOOL	R2	1	0
-      0x780A0001,  //  0064  JMPF	R2	#0067
-      0x8C0C011E,  //  0065  GETMET	R3	R0	K30
-      0x7C0C0200,  //  0066  CALL	R3	1
-      0x80000000,  //  0067  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: compute_manual_pairing_code
-********************************************************************/
-be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(root_discriminator),
-    /* K1   */  be_nested_str_weak(root_passcode),
-    /* K2   */  be_nested_str_weak(_X251i_X2505i_X2504i),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Verhoeff),
-    /* K5   */  be_nested_str_weak(checksum),
-    }),
-    be_str_weak(compute_manual_pairing_code),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x540A0FFE,  //  0001  LDINT	R2	4095
-      0x2C040202,  //  0002  AND	R1	R1	R2
-      0x540A0009,  //  0003  LDINT	R2	10
-      0x3C040202,  //  0004  SHR	R1	R1	R2
-      0x88080100,  //  0005  GETMBR	R2	R0	K0
-      0x540E02FF,  //  0006  LDINT	R3	768
-      0x2C080403,  //  0007  AND	R2	R2	R3
-      0x540E0005,  //  0008  LDINT	R3	6
-      0x38080403,  //  0009  SHL	R2	R2	R3
-      0x880C0101,  //  000A  GETMBR	R3	R0	K1
-      0x54123FFE,  //  000B  LDINT	R4	16383
-      0x2C0C0604,  //  000C  AND	R3	R3	R4
-      0x30080403,  //  000D  OR	R2	R2	R3
-      0x880C0101,  //  000E  GETMBR	R3	R0	K1
-      0x5412000D,  //  000F  LDINT	R4	14
-      0x3C0C0604,  //  0010  SHR	R3	R3	R4
-      0x60100018,  //  0011  GETGBL	R4	G24
-      0x58140002,  //  0012  LDCONST	R5	K2
-      0x5C180200,  //  0013  MOVE	R6	R1
-      0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x5C200600,  //  0015  MOVE	R8	R3
-      0x7C100800,  //  0016  CALL	R4	4
-      0xB8160600,  //  0017  GETNGBL	R5	K3
-      0x88140B04,  //  0018  GETMBR	R5	R5	K4
-      0x8C140B05,  //  0019  GETMET	R5	R5	K5
-      0x5C1C0800,  //  001A  MOVE	R7	R4
-      0x7C140400,  //  001B  CALL	R5	2
-      0x00100805,  //  001C  ADD	R4	R4	R5
-      0x80040800,  //  001D  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(Matter_Device_invoke_request,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -4119,42 +4868,53 @@ be_local_closure(Matter_Device_invoke_request,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(plugins),
-    /* K3   */  be_nested_str_weak(invoke_request),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(status),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(random),
+    /* K2   */  be_nested_str_weak(get),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_const_int(134217727),
+    /* K5   */  be_const_int(99999998),
+    /* K6   */  be_nested_str_weak(PASSCODE_INVALID),
+    /* K7   */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(invoke_request),
+    be_str_weak(generate_random_passcode),
     &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58100000,  //  0000  LDCONST	R4	K0
-      0x88140701,  //  0001  GETMBR	R5	R3	K1
-      0x6018000C,  //  0002  GETGBL	R6	G12
-      0x881C0102,  //  0003  GETMBR	R7	R0	K2
-      0x7C180200,  //  0004  CALL	R6	1
-      0x14180806,  //  0005  LT	R6	R4	R6
-      0x781A000C,  //  0006  JMPF	R6	#0014
-      0x88180102,  //  0007  GETMBR	R6	R0	K2
-      0x94180C04,  //  0008  GETIDX	R6	R6	R4
-      0x881C0D01,  //  0009  GETMBR	R7	R6	K1
-      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0D03,  //  000C  GETMET	R7	R6	K3
-      0x5C240200,  //  000D  MOVE	R9	R1
-      0x5C280400,  //  000E  MOVE	R10	R2
-      0x5C2C0600,  //  000F  MOVE	R11	R3
-      0x7C1C0800,  //  0010  CALL	R7	4
-      0x80040E00,  //  0011  RET	1	R7
-      0x00100904,  //  0012  ADD	R4	R4	K4
-      0x7001FFED,  //  0013  JMP		#0002
-      0xB81A0C00,  //  0014  GETNGBL	R6	K6
-      0x88180D07,  //  0015  GETMBR	R6	R6	K7
-      0x900E0A06,  //  0016  SETMBR	R3	K5	R6
-      0x80000000,  //  0017  RET	0
+    ( &(const binstruction[35]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x500C0200,  //  0002  LDBOOL	R3	1	0
+      0x780E001D,  //  0003  JMPF	R3	#0022
+      0x8C0C0301,  //  0004  GETMET	R3	R1	K1
+      0x54160003,  //  0005  LDINT	R5	4
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
+      0x58140003,  //  0008  LDCONST	R5	K3
+      0x541A0003,  //  0009  LDINT	R6	4
+      0x7C0C0600,  //  000A  CALL	R3	3
+      0x2C0C0704,  //  000B  AND	R3	R3	K4
+      0x5C080600,  //  000C  MOVE	R2	R3
+      0x240C0505,  //  000D  GT	R3	R2	K5
+      0x780E0000,  //  000E  JMPF	R3	#0010
+      0x7001FFF1,  //  000F  JMP		#0002
+      0x600C0010,  //  0010  GETGBL	R3	G16
+      0x88100106,  //  0011  GETMBR	R4	R0	K6
+      0x7C0C0200,  //  0012  CALL	R3	1
+      0xA8020005,  //  0013  EXBLK	0	#001A
+      0x5C100600,  //  0014  MOVE	R4	R3
+      0x7C100000,  //  0015  CALL	R4	0
+      0x1C140404,  //  0016  EQ	R5	R2	R4
+      0x78160000,  //  0017  JMPF	R5	#0019
+      0x4C080000,  //  0018  LDNIL	R2
+      0x7001FFF9,  //  0019  JMP		#0014
+      0x580C0007,  //  001A  LDCONST	R3	K7
+      0xAC0C0200,  //  001B  CATCH	R3	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x4C0C0000,  //  001D  LDNIL	R3
+      0x200C0403,  //  001E  NE	R3	R2	R3
+      0x780E0000,  //  001F  JMPF	R3	#0021
+      0x80040400,  //  0020  RET	1	R2
+      0x7001FFDF,  //  0021  JMP		#0002
+      0x80000000,  //  0022  RET	0
     })
   )
 );
@@ -4162,59 +4922,28 @@ be_local_closure(Matter_Device_invoke_request,   /* name */
 
 
 /********************************************************************
-** Solidified function: start_operational_discovery_deferred
+** Solidified function: is_commissioning_open
 ********************************************************************/
-be_local_closure(Matter_Device_start_operational_discovery_deferred,   /* name */
+be_local_closure(Matter_Device_is_commissioning_open,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
+    3,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        3,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 2]) {  /* upvals */
-          be_local_const_upval(1, 0),
-          be_local_const_upval(1, 1),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_operational_discovery),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080001,  //  0002  GETUPV	R2	U1
-          0x7C000400,  //  0003  CALL	R0	2
-          0x80040000,  //  0004  RET	1	R0
-        })
-      ),
-    }),
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(set_timer),
-    /* K2   */  be_const_int(0),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
     }),
-    be_str_weak(start_operational_discovery_deferred),
+    be_str_weak(is_commissioning_open),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x84140000,  //  0003  CLOSURE	R5	P0
-      0x7C080600,  //  0004  CALL	R2	3
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
     })
   )
 );
@@ -4481,332 +5210,6 @@ be_local_closure(Matter_Device_autoconf_device_map,   /* name */
 
 
 /********************************************************************
-** Solidified function: autoconf_device
-********************************************************************/
-be_local_closure(Matter_Device_autoconf_device,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(plugins),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(plugins_persist),
-    /* K4   */  be_nested_str_weak(plugins_config),
-    /* K5   */  be_nested_str_weak(autoconf_device_map),
-    /* K6   */  be_nested_str_weak(adjust_next_ep),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(_instantiate_plugins_from_config),
-    /* K12  */  be_nested_str_weak(sessions),
-    /* K13  */  be_nested_str_weak(count_active_fabrics),
-    /* K14  */  be_nested_str_weak(save_param),
-    }),
-    be_str_weak(autoconf_device),
-    &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x24080502,  //  0004  GT	R2	R2	K2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x80000400,  //  0006  RET	0
-      0x88080103,  //  0007  GETMBR	R2	R0	K3
-      0x740A000C,  //  0008  JMPT	R2	#0016
-      0x8C080105,  //  0009  GETMET	R2	R0	K5
-      0x7C080200,  //  000A  CALL	R2	1
-      0x90020802,  //  000B  SETMBR	R0	K4	R2
-      0x8C080106,  //  000C  GETMET	R2	R0	K6
-      0x7C080200,  //  000D  CALL	R2	1
-      0xB80A0E00,  //  000E  GETNGBL	R2	K7
-      0x8C080508,  //  000F  GETMET	R2	R2	K8
-      0x60100008,  //  0010  GETGBL	R4	G8
-      0x88140104,  //  0011  GETMBR	R5	R0	K4
-      0x7C100200,  //  0012  CALL	R4	1
-      0x00121204,  //  0013  ADD	R4	K9	R4
-      0x5814000A,  //  0014  LDCONST	R5	K10
-      0x7C080600,  //  0015  CALL	R2	3
-      0x8C08010B,  //  0016  GETMET	R2	R0	K11
-      0x88100104,  //  0017  GETMBR	R4	R0	K4
-      0x7C080400,  //  0018  CALL	R2	2
-      0x88080103,  //  0019  GETMBR	R2	R0	K3
-      0x740A0008,  //  001A  JMPT	R2	#0024
-      0x8808010C,  //  001B  GETMBR	R2	R0	K12
-      0x8C08050D,  //  001C  GETMET	R2	R2	K13
-      0x7C080200,  //  001D  CALL	R2	1
-      0x24080502,  //  001E  GT	R2	R2	K2
-      0x780A0003,  //  001F  JMPF	R2	#0024
-      0x50080200,  //  0020  LDBOOL	R2	1	0
-      0x90020602,  //  0021  SETMBR	R0	K3	R2
-      0x8C08010E,  //  0022  GETMET	R2	R0	K14
-      0x7C080200,  //  0023  CALL	R2	1
-      0x80000000,  //  0024  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: received_ack
-********************************************************************/
-be_local_closure(Matter_Device_received_ack,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(received_ack),
-    }),
-    be_str_weak(received_ack),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: msg_send
-********************************************************************/
-be_local_closure(Matter_Device_msg_send,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(send_UDP),
-    }),
-    be_str_weak(msg_send),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    8,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
-        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
-        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(commissioning_iterations),
-    /* K4   */  be_nested_str_weak(commissioning_discriminator),
-    /* K5   */  be_nested_str_weak(commissioning_salt),
-    /* K6   */  be_nested_str_weak(commissioning_w0),
-    /* K7   */  be_nested_str_weak(commissioning_L),
-    /* K8   */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K9   */  be_nested_str_weak(wifi),
-    /* K10  */  be_nested_str_weak(up),
-    /* K11  */  be_nested_str_weak(eth),
-    /* K12  */  be_nested_str_weak(mdns_announce_PASE),
-    /* K13  */  be_nested_str_weak(add_rule),
-    /* K14  */  be_nested_str_weak(Wifi_X23Connected),
-    /* K15  */  be_nested_str_weak(Eth_X23Connected),
-    }),
-    be_str_weak(start_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0xB8220200,  //  0000  GETNGBL	R8	K1
-      0x8C201102,  //  0001  GETMET	R8	R8	K2
-      0x7C200200,  //  0002  CALL	R8	1
-      0x542603E7,  //  0003  LDINT	R9	1000
-      0x08240209,  //  0004  MUL	R9	R1	R9
-      0x00201009,  //  0005  ADD	R8	R8	R9
-      0x90020008,  //  0006  SETMBR	R0	K0	R8
-      0x90020602,  //  0007  SETMBR	R0	K3	R2
-      0x90020803,  //  0008  SETMBR	R0	K4	R3
-      0x90020A04,  //  0009  SETMBR	R0	K5	R4
-      0x90020C05,  //  000A  SETMBR	R0	K6	R5
-      0x90020E06,  //  000B  SETMBR	R0	K7	R6
-      0x90021007,  //  000C  SETMBR	R0	K8	R7
-      0xB8220200,  //  000D  GETNGBL	R8	K1
-      0x8C201109,  //  000E  GETMET	R8	R8	K9
-      0x7C200200,  //  000F  CALL	R8	1
-      0x9420110A,  //  0010  GETIDX	R8	R8	K10
-      0x74220004,  //  0011  JMPT	R8	#0017
-      0xB8220200,  //  0012  GETNGBL	R8	K1
-      0x8C20110B,  //  0013  GETMET	R8	R8	K11
-      0x7C200200,  //  0014  CALL	R8	1
-      0x9420110A,  //  0015  GETIDX	R8	R8	K10
-      0x78220002,  //  0016  JMPF	R8	#001A
-      0x8C20010C,  //  0017  GETMET	R8	R0	K12
-      0x7C200200,  //  0018  CALL	R8	1
-      0x7002000B,  //  0019  JMP		#0026
-      0xB8220200,  //  001A  GETNGBL	R8	K1
-      0x8C20110D,  //  001B  GETMET	R8	R8	K13
-      0x5828000E,  //  001C  LDCONST	R10	K14
-      0x842C0000,  //  001D  CLOSURE	R11	P0
-      0x5830000C,  //  001E  LDCONST	R12	K12
-      0x7C200800,  //  001F  CALL	R8	4
-      0xB8220200,  //  0020  GETNGBL	R8	K1
-      0x8C20110D,  //  0021  GETMET	R8	R8	K13
-      0x5828000F,  //  0022  LDCONST	R10	K15
-      0x842C0001,  //  0023  CLOSURE	R11	P1
-      0x5830000C,  //  0024  LDCONST	R12	K12
-      0x7C200800,  //  0025  CALL	R8	4
-      0xA0000000,  //  0026  CLOSE	R0
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_plugin_by_endpoint
-********************************************************************/
-be_local_closure(Matter_Device_find_plugin_by_endpoint,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(plugins),
-    /* K2   */  be_nested_str_weak(get_endpoint),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(find_plugin_by_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0008,  //  0005  JMPF	R3	#000F
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x8C100702,  //  0008  GETMET	R4	R3	K2
-      0x7C100200,  //  0009  CALL	R4	1
-      0x1C100801,  //  000A  EQ	R4	R4	R1
-      0x78120000,  //  000B  JMPF	R4	#000D
-      0x80040600,  //  000C  RET	1	R3
-      0x00080503,  //  000D  ADD	R2	R2	K3
-      0x7001FFF1,  //  000E  JMP		#0001
-      0x4C0C0000,  //  000F  LDNIL	R3
-      0x80040600,  //  0010  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: start_mdns_announce_hostnames
 ********************************************************************/
 be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
@@ -4939,11 +5342,11 @@ be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
 
 
 /********************************************************************
-** Solidified function: mdns_announce_PASE
+** Solidified function: mdns_remove_op_discovery_all_fabrics
 ********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_PASE,   /* name */
+be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -4951,288 +5354,39 @@ be_local_closure(Matter_Device_mdns_announce_PASE,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[41]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(VP),
-    /* K3   */  be_nested_str_weak(vendorid),
-    /* K4   */  be_nested_str_weak(_X2B),
-    /* K5   */  be_nested_str_weak(productid),
-    /* K6   */  be_nested_str_weak(D),
-    /* K7   */  be_nested_str_weak(commissioning_discriminator),
-    /* K8   */  be_nested_str_weak(CM),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(T),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(SII),
-    /* K13  */  be_nested_str_weak(SAI),
-    /* K14  */  be_nested_str_weak(commissioning_instance_wifi),
-    /* K15  */  be_nested_str_weak(random),
-    /* K16  */  be_nested_str_weak(tohex),
-    /* K17  */  be_nested_str_weak(commissioning_instance_eth),
-    /* K18  */  be_nested_str_weak(hostname_eth),
-    /* K19  */  be_nested_str_weak(add_service),
-    /* K20  */  be_nested_str_weak(_matterc),
-    /* K21  */  be_nested_str_weak(_udp),
-    /* K22  */  be_nested_str_weak(mdns_pase_eth),
-    /* K23  */  be_nested_str_weak(tasmota),
-    /* K24  */  be_nested_str_weak(log),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20announce_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K26  */  be_nested_str_weak(eth),
-    /* K27  */  be_const_int(2),
-    /* K28  */  be_nested_str_weak(_L),
-    /* K29  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
-    /* K30  */  be_const_int(3),
-    /* K31  */  be_nested_str_weak(add_subtype),
-    /* K32  */  be_nested_str_weak(_S),
-    /* K33  */  be_nested_str_weak(_V),
-    /* K34  */  be_nested_str_weak(_CM1),
-    /* K35  */  be_nested_str_weak(hostname_wifi),
-    /* K36  */  be_nested_str_weak(mdns_pase_wifi),
-    /* K37  */  be_nested_str_weak(MTR_X3A_X20starting_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K38  */  be_nested_str_weak(wifi),
-    /* K39  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K40  */  be_nested_str_weak(_X7C),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(active_fabrics),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K5   */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(mdns_announce_PASE),
+    be_str_weak(mdns_remove_op_discovery_all_fabrics),
     &be_const_str_solidified,
-    ( &(const binstruction[236]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x600C0013,  //  0002  GETGBL	R3	G19
-      0x7C0C0000,  //  0003  CALL	R3	0
-      0x60100008,  //  0004  GETGBL	R4	G8
-      0x88140103,  //  0005  GETMBR	R5	R0	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x00100904,  //  0007  ADD	R4	R4	K4
-      0x60140008,  //  0008  GETGBL	R5	G8
-      0x88180105,  //  0009  GETMBR	R6	R0	K5
-      0x7C140200,  //  000A  CALL	R5	1
-      0x00100805,  //  000B  ADD	R4	R4	R5
-      0x980E0404,  //  000C  SETIDX	R3	K2	R4
-      0x88100107,  //  000D  GETMBR	R4	R0	K7
-      0x980E0C04,  //  000E  SETIDX	R3	K6	R4
-      0x980E1109,  //  000F  SETIDX	R3	K8	K9
-      0x980E150B,  //  0010  SETIDX	R3	K10	K11
-      0x54121387,  //  0011  LDINT	R4	5000
-      0x980E1804,  //  0012  SETIDX	R3	K12	R4
-      0x5412012B,  //  0013  LDINT	R4	300
-      0x980E1A04,  //  0014  SETIDX	R3	K13	R4
-      0x8C10050F,  //  0015  GETMET	R4	R2	K15
-      0x541A0007,  //  0016  LDINT	R6	8
-      0x7C100400,  //  0017  CALL	R4	2
-      0x8C100910,  //  0018  GETMET	R4	R4	K16
-      0x7C100200,  //  0019  CALL	R4	1
-      0x90021C04,  //  001A  SETMBR	R0	K14	R4
-      0x8C10050F,  //  001B  GETMET	R4	R2	K15
-      0x541A0007,  //  001C  LDINT	R6	8
-      0x7C100400,  //  001D  CALL	R4	2
-      0x8C100910,  //  001E  GETMET	R4	R4	K16
-      0x7C100200,  //  001F  CALL	R4	1
-      0x90022204,  //  0020  SETMBR	R0	K17	R4
-      0xA80200B7,  //  0021  EXBLK	0	#00DA
-      0x88100112,  //  0022  GETMBR	R4	R0	K18
-      0x78120058,  //  0023  JMPF	R4	#007D
-      0x8C100313,  //  0024  GETMET	R4	R1	K19
-      0x58180014,  //  0025  LDCONST	R6	K20
-      0x581C0015,  //  0026  LDCONST	R7	K21
-      0x542215A3,  //  0027  LDINT	R8	5540
-      0x5C240600,  //  0028  MOVE	R9	R3
-      0x88280111,  //  0029  GETMBR	R10	R0	K17
-      0x882C0112,  //  002A  GETMBR	R11	R0	K18
-      0x7C100E00,  //  002B  CALL	R4	7
-      0x50100200,  //  002C  LDBOOL	R4	1	0
-      0x90022C04,  //  002D  SETMBR	R0	K22	R4
-      0xB8122E00,  //  002E  GETNGBL	R4	K23
-      0x8C100918,  //  002F  GETMET	R4	R4	K24
-      0x60180018,  //  0030  GETGBL	R6	G24
-      0x581C0019,  //  0031  LDCONST	R7	K25
-      0x5820001A,  //  0032  LDCONST	R8	K26
-      0x88240111,  //  0033  GETMBR	R9	R0	K17
-      0x88280112,  //  0034  GETMBR	R10	R0	K18
-      0x7C180800,  //  0035  CALL	R6	4
-      0x581C001B,  //  0036  LDCONST	R7	K27
-      0x7C100600,  //  0037  CALL	R4	3
-      0x60100008,  //  0038  GETGBL	R4	G8
-      0x88140107,  //  0039  GETMBR	R5	R0	K7
-      0x541A0FFE,  //  003A  LDINT	R6	4095
-      0x2C140A06,  //  003B  AND	R5	R5	R6
-      0x7C100200,  //  003C  CALL	R4	1
-      0x00123804,  //  003D  ADD	R4	K28	R4
-      0xB8162E00,  //  003E  GETNGBL	R5	K23
-      0x8C140B18,  //  003F  GETMET	R5	R5	K24
-      0x001E3A04,  //  0040  ADD	R7	K29	R4
-      0x5820001E,  //  0041  LDCONST	R8	K30
-      0x7C140600,  //  0042  CALL	R5	3
-      0x8C14031F,  //  0043  GETMET	R5	R1	K31
-      0x581C0014,  //  0044  LDCONST	R7	K20
-      0x58200015,  //  0045  LDCONST	R8	K21
-      0x88240111,  //  0046  GETMBR	R9	R0	K17
-      0x88280112,  //  0047  GETMBR	R10	R0	K18
-      0x5C2C0800,  //  0048  MOVE	R11	R4
-      0x7C140C00,  //  0049  CALL	R5	6
-      0x60140008,  //  004A  GETGBL	R5	G8
-      0x88180107,  //  004B  GETMBR	R6	R0	K7
-      0x541E0EFF,  //  004C  LDINT	R7	3840
-      0x2C180C07,  //  004D  AND	R6	R6	R7
-      0x541E0007,  //  004E  LDINT	R7	8
-      0x3C180C07,  //  004F  SHR	R6	R6	R7
-      0x7C140200,  //  0050  CALL	R5	1
-      0x00164005,  //  0051  ADD	R5	K32	R5
-      0x5C100A00,  //  0052  MOVE	R4	R5
-      0xB8162E00,  //  0053  GETNGBL	R5	K23
-      0x8C140B18,  //  0054  GETMET	R5	R5	K24
-      0x001E3A04,  //  0055  ADD	R7	K29	R4
-      0x5820001E,  //  0056  LDCONST	R8	K30
-      0x7C140600,  //  0057  CALL	R5	3
-      0x8C14031F,  //  0058  GETMET	R5	R1	K31
-      0x581C0014,  //  0059  LDCONST	R7	K20
-      0x58200015,  //  005A  LDCONST	R8	K21
-      0x88240111,  //  005B  GETMBR	R9	R0	K17
-      0x88280112,  //  005C  GETMBR	R10	R0	K18
-      0x5C2C0800,  //  005D  MOVE	R11	R4
-      0x7C140C00,  //  005E  CALL	R5	6
-      0x60140008,  //  005F  GETGBL	R5	G8
-      0x88180103,  //  0060  GETMBR	R6	R0	K3
-      0x7C140200,  //  0061  CALL	R5	1
-      0x00164205,  //  0062  ADD	R5	K33	R5
-      0x5C100A00,  //  0063  MOVE	R4	R5
-      0xB8162E00,  //  0064  GETNGBL	R5	K23
-      0x8C140B18,  //  0065  GETMET	R5	R5	K24
-      0x001E3A04,  //  0066  ADD	R7	K29	R4
-      0x5820001E,  //  0067  LDCONST	R8	K30
-      0x7C140600,  //  0068  CALL	R5	3
-      0x8C14031F,  //  0069  GETMET	R5	R1	K31
-      0x581C0014,  //  006A  LDCONST	R7	K20
-      0x58200015,  //  006B  LDCONST	R8	K21
-      0x88240111,  //  006C  GETMBR	R9	R0	K17
-      0x88280112,  //  006D  GETMBR	R10	R0	K18
-      0x5C2C0800,  //  006E  MOVE	R11	R4
-      0x7C140C00,  //  006F  CALL	R5	6
-      0x58100022,  //  0070  LDCONST	R4	K34
-      0xB8162E00,  //  0071  GETNGBL	R5	K23
-      0x8C140B18,  //  0072  GETMET	R5	R5	K24
-      0x001E3A04,  //  0073  ADD	R7	K29	R4
-      0x5820001E,  //  0074  LDCONST	R8	K30
-      0x7C140600,  //  0075  CALL	R5	3
-      0x8C14031F,  //  0076  GETMET	R5	R1	K31
-      0x581C0014,  //  0077  LDCONST	R7	K20
-      0x58200015,  //  0078  LDCONST	R8	K21
-      0x88240111,  //  0079  GETMBR	R9	R0	K17
-      0x88280112,  //  007A  GETMBR	R10	R0	K18
-      0x5C2C0800,  //  007B  MOVE	R11	R4
-      0x7C140C00,  //  007C  CALL	R5	6
-      0x88100123,  //  007D  GETMBR	R4	R0	K35
-      0x78120058,  //  007E  JMPF	R4	#00D8
-      0x8C100313,  //  007F  GETMET	R4	R1	K19
-      0x58180014,  //  0080  LDCONST	R6	K20
-      0x581C0015,  //  0081  LDCONST	R7	K21
-      0x542215A3,  //  0082  LDINT	R8	5540
-      0x5C240600,  //  0083  MOVE	R9	R3
-      0x8828010E,  //  0084  GETMBR	R10	R0	K14
-      0x882C0123,  //  0085  GETMBR	R11	R0	K35
-      0x7C100E00,  //  0086  CALL	R4	7
-      0x50100200,  //  0087  LDBOOL	R4	1	0
-      0x90024804,  //  0088  SETMBR	R0	K36	R4
-      0xB8122E00,  //  0089  GETNGBL	R4	K23
-      0x8C100918,  //  008A  GETMET	R4	R4	K24
-      0x60180018,  //  008B  GETGBL	R6	G24
-      0x581C0025,  //  008C  LDCONST	R7	K37
-      0x58200026,  //  008D  LDCONST	R8	K38
-      0x8824010E,  //  008E  GETMBR	R9	R0	K14
-      0x88280123,  //  008F  GETMBR	R10	R0	K35
-      0x7C180800,  //  0090  CALL	R6	4
-      0x581C001E,  //  0091  LDCONST	R7	K30
-      0x7C100600,  //  0092  CALL	R4	3
-      0x60100008,  //  0093  GETGBL	R4	G8
-      0x88140107,  //  0094  GETMBR	R5	R0	K7
-      0x541A0FFE,  //  0095  LDINT	R6	4095
-      0x2C140A06,  //  0096  AND	R5	R5	R6
-      0x7C100200,  //  0097  CALL	R4	1
-      0x00123804,  //  0098  ADD	R4	K28	R4
-      0xB8162E00,  //  0099  GETNGBL	R5	K23
-      0x8C140B18,  //  009A  GETMET	R5	R5	K24
-      0x001E3A04,  //  009B  ADD	R7	K29	R4
-      0x5820001E,  //  009C  LDCONST	R8	K30
-      0x7C140600,  //  009D  CALL	R5	3
-      0x8C14031F,  //  009E  GETMET	R5	R1	K31
-      0x581C0014,  //  009F  LDCONST	R7	K20
-      0x58200015,  //  00A0  LDCONST	R8	K21
-      0x8824010E,  //  00A1  GETMBR	R9	R0	K14
-      0x88280123,  //  00A2  GETMBR	R10	R0	K35
-      0x5C2C0800,  //  00A3  MOVE	R11	R4
-      0x7C140C00,  //  00A4  CALL	R5	6
-      0x60140008,  //  00A5  GETGBL	R5	G8
-      0x88180107,  //  00A6  GETMBR	R6	R0	K7
-      0x541E0EFF,  //  00A7  LDINT	R7	3840
-      0x2C180C07,  //  00A8  AND	R6	R6	R7
-      0x541E0007,  //  00A9  LDINT	R7	8
-      0x3C180C07,  //  00AA  SHR	R6	R6	R7
-      0x7C140200,  //  00AB  CALL	R5	1
-      0x00164005,  //  00AC  ADD	R5	K32	R5
-      0x5C100A00,  //  00AD  MOVE	R4	R5
-      0xB8162E00,  //  00AE  GETNGBL	R5	K23
-      0x8C140B18,  //  00AF  GETMET	R5	R5	K24
-      0x001E3A04,  //  00B0  ADD	R7	K29	R4
-      0x5820001E,  //  00B1  LDCONST	R8	K30
-      0x7C140600,  //  00B2  CALL	R5	3
-      0x8C14031F,  //  00B3  GETMET	R5	R1	K31
-      0x581C0014,  //  00B4  LDCONST	R7	K20
-      0x58200015,  //  00B5  LDCONST	R8	K21
-      0x8824010E,  //  00B6  GETMBR	R9	R0	K14
-      0x88280123,  //  00B7  GETMBR	R10	R0	K35
-      0x5C2C0800,  //  00B8  MOVE	R11	R4
-      0x7C140C00,  //  00B9  CALL	R5	6
-      0x60140008,  //  00BA  GETGBL	R5	G8
-      0x88180103,  //  00BB  GETMBR	R6	R0	K3
-      0x7C140200,  //  00BC  CALL	R5	1
-      0x00164205,  //  00BD  ADD	R5	K33	R5
-      0x5C100A00,  //  00BE  MOVE	R4	R5
-      0xB8162E00,  //  00BF  GETNGBL	R5	K23
-      0x8C140B18,  //  00C0  GETMET	R5	R5	K24
-      0x001E3A04,  //  00C1  ADD	R7	K29	R4
-      0x5820001E,  //  00C2  LDCONST	R8	K30
-      0x7C140600,  //  00C3  CALL	R5	3
-      0x8C14031F,  //  00C4  GETMET	R5	R1	K31
-      0x581C0014,  //  00C5  LDCONST	R7	K20
-      0x58200015,  //  00C6  LDCONST	R8	K21
-      0x8824010E,  //  00C7  GETMBR	R9	R0	K14
-      0x88280123,  //  00C8  GETMBR	R10	R0	K35
-      0x5C2C0800,  //  00C9  MOVE	R11	R4
-      0x7C140C00,  //  00CA  CALL	R5	6
-      0x58100022,  //  00CB  LDCONST	R4	K34
-      0xB8162E00,  //  00CC  GETNGBL	R5	K23
-      0x8C140B18,  //  00CD  GETMET	R5	R5	K24
-      0x001E3A04,  //  00CE  ADD	R7	K29	R4
-      0x5820001E,  //  00CF  LDCONST	R8	K30
-      0x7C140600,  //  00D0  CALL	R5	3
-      0x8C14031F,  //  00D1  GETMET	R5	R1	K31
-      0x581C0014,  //  00D2  LDCONST	R7	K20
-      0x58200015,  //  00D3  LDCONST	R8	K21
-      0x8824010E,  //  00D4  GETMBR	R9	R0	K14
-      0x88280123,  //  00D5  GETMBR	R10	R0	K35
-      0x5C2C0800,  //  00D6  MOVE	R11	R4
-      0x7C140C00,  //  00D7  CALL	R5	6
-      0xA8040001,  //  00D8  EXBLK	1	1
-      0x70020010,  //  00D9  JMP		#00EB
-      0xAC100002,  //  00DA  CATCH	R4	0	2
-      0x7002000D,  //  00DB  JMP		#00EA
-      0xB81A2E00,  //  00DC  GETNGBL	R6	K23
-      0x8C180D18,  //  00DD  GETMET	R6	R6	K24
-      0x60200008,  //  00DE  GETGBL	R8	G8
-      0x5C240800,  //  00DF  MOVE	R9	R4
-      0x7C200200,  //  00E0  CALL	R8	1
-      0x00224E08,  //  00E1  ADD	R8	K39	R8
-      0x00201128,  //  00E2  ADD	R8	R8	K40
-      0x60240008,  //  00E3  GETGBL	R9	G8
-      0x5C280A00,  //  00E4  MOVE	R10	R5
-      0x7C240200,  //  00E5  CALL	R9	1
-      0x00201009,  //  00E6  ADD	R8	R8	R9
-      0x5824001B,  //  00E7  LDCONST	R9	K27
-      0x7C180600,  //  00E8  CALL	R6	3
-      0x70020000,  //  00E9  JMP		#00EB
-      0xB0080000,  //  00EA  RAISE	2	R0	R0
-      0x80000000,  //  00EB  RET	0
+    ( &(const binstruction[22]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000B,  //  0005  EXBLK	0	#0012
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x780E0005,  //  000A  JMPF	R3	#0011
+      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x780E0002,  //  000D  JMPF	R3	#0011
+      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x7001FFF3,  //  0011  JMP		#0006
+      0x58040005,  //  0012  LDCONST	R1	K5
+      0xAC040200,  //  0013  CATCH	R1	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x80000000,  //  0015  RET	0
     })
   )
 );
@@ -5240,162 +5394,11 @@ be_local_closure(Matter_Device_mdns_announce_PASE,   /* name */
 
 
 /********************************************************************
-** Solidified function: generate_random_passcode
+** Solidified function: k2l_num
 ********************************************************************/
-be_local_closure(Matter_Device_generate_random_passcode,   /* name */
+be_local_closure(Matter_Device_k2l_num,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(random),
-    /* K2   */  be_nested_str_weak(get),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_const_int(134217727),
-    /* K5   */  be_const_int(99999998),
-    /* K6   */  be_nested_str_weak(PASSCODE_INVALID),
-    /* K7   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(generate_random_passcode),
-    &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x500C0200,  //  0002  LDBOOL	R3	1	0
-      0x780E001D,  //  0003  JMPF	R3	#0022
-      0x8C0C0301,  //  0004  GETMET	R3	R1	K1
-      0x54160003,  //  0005  LDINT	R5	4
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
-      0x58140003,  //  0008  LDCONST	R5	K3
-      0x541A0003,  //  0009  LDINT	R6	4
-      0x7C0C0600,  //  000A  CALL	R3	3
-      0x2C0C0704,  //  000B  AND	R3	R3	K4
-      0x5C080600,  //  000C  MOVE	R2	R3
-      0x240C0505,  //  000D  GT	R3	R2	K5
-      0x780E0000,  //  000E  JMPF	R3	#0010
-      0x7001FFF1,  //  000F  JMP		#0002
-      0x600C0010,  //  0010  GETGBL	R3	G16
-      0x88100106,  //  0011  GETMBR	R4	R0	K6
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0xA8020005,  //  0013  EXBLK	0	#001A
-      0x5C100600,  //  0014  MOVE	R4	R3
-      0x7C100000,  //  0015  CALL	R4	0
-      0x1C140404,  //  0016  EQ	R5	R2	R4
-      0x78160000,  //  0017  JMPF	R5	#0019
-      0x4C080000,  //  0018  LDNIL	R2
-      0x7001FFF9,  //  0019  JMP		#0014
-      0x580C0007,  //  001A  LDCONST	R3	K7
-      0xAC0C0200,  //  001B  CATCH	R3	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x4C0C0000,  //  001D  LDNIL	R3
-      0x200C0403,  //  001E  NE	R3	R2	R3
-      0x780E0000,  //  001F  JMPF	R3	#0021
-      0x80040400,  //  0020  RET	1	R2
-      0x7001FFDF,  //  0021  JMP		#0002
-      0x80000000,  //  0022  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_native_classes
-********************************************************************/
-be_local_closure(Matter_Device_register_native_classes,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(members),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(get),
-    /* K5   */  be_nested_str_weak(class),
-    /* K6   */  be_nested_str_weak(find),
-    /* K7   */  be_nested_str_weak(Plugin_),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(register_plugin_class),
-    /* K10  */  be_nested_str_weak(stop_iteration),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20registered_X20classes_X20),
-    /* K14  */  be_nested_str_weak(k2l),
-    /* K15  */  be_nested_str_weak(plugins_classes),
-    /* K16  */  be_const_int(3),
-    }),
-    be_str_weak(register_native_classes),
-    &be_const_str_solidified,
-    ( &(const binstruction[43]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xA4120200,  //  0001  IMPORT	R4	K1
-      0x60140010,  //  0002  GETGBL	R5	G16
-      0x8C180702,  //  0003  GETMET	R6	R3	K2
-      0xB8220600,  //  0004  GETNGBL	R8	K3
-      0x7C180400,  //  0005  CALL	R6	2
-      0x7C140200,  //  0006  CALL	R5	1
-      0xA8020014,  //  0007  EXBLK	0	#001D
-      0x5C180A00,  //  0008  MOVE	R6	R5
-      0x7C180000,  //  0009  CALL	R6	0
-      0x8C1C0704,  //  000A  GETMET	R7	R3	K4
-      0xB8260600,  //  000B  GETNGBL	R9	K3
-      0x5C280C00,  //  000C  MOVE	R10	R6
-      0x7C1C0600,  //  000D  CALL	R7	3
-      0x60200004,  //  000E  GETGBL	R8	G4
-      0x5C240E00,  //  000F  MOVE	R9	R7
-      0x7C200200,  //  0010  CALL	R8	1
-      0x1C201105,  //  0011  EQ	R8	R8	K5
-      0x78220008,  //  0012  JMPF	R8	#001C
-      0x8C200906,  //  0013  GETMET	R8	R4	K6
-      0x5C280C00,  //  0014  MOVE	R10	R6
-      0x582C0007,  //  0015  LDCONST	R11	K7
-      0x7C200600,  //  0016  CALL	R8	3
-      0x1C201108,  //  0017  EQ	R8	R8	K8
-      0x78220002,  //  0018  JMPF	R8	#001C
-      0x8C200109,  //  0019  GETMET	R8	R0	K9
-      0x5C280E00,  //  001A  MOVE	R10	R7
-      0x7C200400,  //  001B  CALL	R8	2
-      0x7001FFEA,  //  001C  JMP		#0008
-      0x5814000A,  //  001D  LDCONST	R5	K10
-      0xAC140200,  //  001E  CATCH	R5	1	0
-      0xB0080000,  //  001F  RAISE	2	R0	R0
-      0xB8161600,  //  0020  GETNGBL	R5	K11
-      0x8C140B0C,  //  0021  GETMET	R5	R5	K12
-      0x601C0008,  //  0022  GETGBL	R7	G8
-      0x8C20010E,  //  0023  GETMET	R8	R0	K14
-      0x8828010F,  //  0024  GETMBR	R10	R0	K15
-      0x7C200400,  //  0025  CALL	R8	2
-      0x7C1C0200,  //  0026  CALL	R7	1
-      0x001E1A07,  //  0027  ADD	R7	K13	R7
-      0x58200010,  //  0028  LDCONST	R8	K16
-      0x7C140600,  //  0029  CALL	R5	3
-      0x80000000,  //  002A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: sort_distinct
-********************************************************************/
-be_local_closure(Matter_Device_sort_distinct,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
+    9,                          /* nstack */
     1,                          /* argc */
     4,                          /* varg */
     0,                          /* has upvals */
@@ -5403,69 +5406,201 @@ be_local_closure(Matter_Device_sort_distinct,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(push),
     /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_nested_str_weak(remove),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_const_int(0),
     }),
-    be_str_weak(sort_distinct),
+    be_str_weak(k2l_num),
     &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
+    ( &(const binstruction[52]) {  /* code */
       0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080010,  //  0001  GETGBL	R2	G16
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x040C0701,  //  0005  SUB	R3	R3	K1
-      0x400E0203,  //  0006  CONNECT	R3	K1	R3
-      0x7C080200,  //  0007  CALL	R2	1
-      0xA8020010,  //  0008  EXBLK	0	#001A
-      0x5C0C0400,  //  0009  MOVE	R3	R2
-      0x7C0C0000,  //  000A  CALL	R3	0
-      0x94100003,  //  000B  GETIDX	R4	R0	R3
-      0x5C140600,  //  000C  MOVE	R5	R3
-      0x24180B02,  //  000D  GT	R6	R5	K2
-      0x781A0008,  //  000E  JMPF	R6	#0018
-      0x04180B01,  //  000F  SUB	R6	R5	K1
-      0x94180006,  //  0010  GETIDX	R6	R0	R6
-      0x24180C04,  //  0011  GT	R6	R6	R4
-      0x781A0004,  //  0012  JMPF	R6	#0018
-      0x04180B01,  //  0013  SUB	R6	R5	K1
-      0x94180006,  //  0014  GETIDX	R6	R0	R6
-      0x98000A06,  //  0015  SETIDX	R0	R5	R6
-      0x04140B01,  //  0016  SUB	R5	R5	K1
-      0x7001FFF4,  //  0017  JMP		#000D
-      0x98000A04,  //  0018  SETIDX	R0	R5	R4
-      0x7001FFEE,  //  0019  JMP		#0009
-      0x58080003,  //  001A  LDCONST	R2	K3
-      0xAC080200,  //  001B  CATCH	R2	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x58080001,  //  001D  LDCONST	R2	K1
-      0x600C000C,  //  001E  GETGBL	R3	G12
-      0x5C100000,  //  001F  MOVE	R4	R0
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x180C0701,  //  0021  LE	R3	R3	K1
-      0x780E0000,  //  0022  JMPF	R3	#0024
-      0x80040000,  //  0023  RET	1	R0
-      0x940C0102,  //  0024  GETIDX	R3	R0	K2
-      0x6010000C,  //  0025  GETGBL	R4	G12
-      0x5C140000,  //  0026  MOVE	R5	R0
-      0x7C100200,  //  0027  CALL	R4	1
-      0x14100404,  //  0028  LT	R4	R2	R4
-      0x78120009,  //  0029  JMPF	R4	#0034
-      0x94100002,  //  002A  GETIDX	R4	R0	R2
-      0x1C100803,  //  002B  EQ	R4	R4	R3
-      0x78120003,  //  002C  JMPF	R4	#0031
-      0x8C100104,  //  002D  GETMET	R4	R0	K4
-      0x5C180400,  //  002E  MOVE	R6	R2
-      0x7C100400,  //  002F  CALL	R4	2
-      0x70020001,  //  0030  JMP		#0033
-      0x940C0002,  //  0031  GETIDX	R3	R0	R2
-      0x00080501,  //  0032  ADD	R2	R2	K1
-      0x7001FFF0,  //  0033  JMP		#0025
-      0x80040000,  //  0034  RET	1	R0
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0003,  //  0004  EQ	R3	R0	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80040400,  //  0006  RET	1	R2
+      0x600C0010,  //  0007  GETGBL	R3	G16
+      0x8C100101,  //  0008  GETMET	R4	R0	K1
+      0x7C100200,  //  0009  CALL	R4	1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0xA8020007,  //  000B  EXBLK	0	#0014
+      0x5C100600,  //  000C  MOVE	R4	R3
+      0x7C100000,  //  000D  CALL	R4	0
+      0x8C140502,  //  000E  GETMET	R5	R2	K2
+      0x601C0009,  //  000F  GETGBL	R7	G9
+      0x5C200800,  //  0010  MOVE	R8	R4
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x7C140400,  //  0012  CALL	R5	2
+      0x7001FFF7,  //  0013  JMP		#000C
+      0x580C0003,  //  0014  LDCONST	R3	K3
+      0xAC0C0200,  //  0015  CATCH	R3	1	0
+      0xB0080000,  //  0016  RAISE	2	R0	R0
+      0x600C0010,  //  0017  GETGBL	R3	G16
+      0x6010000C,  //  0018  GETGBL	R4	G12
+      0x5C140400,  //  0019  MOVE	R5	R2
+      0x7C100200,  //  001A  CALL	R4	1
+      0x04100904,  //  001B  SUB	R4	R4	K4
+      0x40120804,  //  001C  CONNECT	R4	K4	R4
+      0x7C0C0200,  //  001D  CALL	R3	1
+      0xA8020010,  //  001E  EXBLK	0	#0030
+      0x5C100600,  //  001F  MOVE	R4	R3
+      0x7C100000,  //  0020  CALL	R4	0
+      0x94140404,  //  0021  GETIDX	R5	R2	R4
+      0x5C180800,  //  0022  MOVE	R6	R4
+      0x241C0D05,  //  0023  GT	R7	R6	K5
+      0x781E0008,  //  0024  JMPF	R7	#002E
+      0x041C0D04,  //  0025  SUB	R7	R6	K4
+      0x941C0407,  //  0026  GETIDX	R7	R2	R7
+      0x241C0E05,  //  0027  GT	R7	R7	R5
+      0x781E0004,  //  0028  JMPF	R7	#002E
+      0x041C0D04,  //  0029  SUB	R7	R6	K4
+      0x941C0407,  //  002A  GETIDX	R7	R2	R7
+      0x98080C07,  //  002B  SETIDX	R2	R6	R7
+      0x04180D04,  //  002C  SUB	R6	R6	K4
+      0x7001FFF4,  //  002D  JMP		#0023
+      0x98080C05,  //  002E  SETIDX	R2	R6	R5
+      0x7001FFEE,  //  002F  JMP		#001F
+      0x580C0003,  //  0030  LDCONST	R3	K3
+      0xAC0C0200,  //  0031  CATCH	R3	1	0
+      0xB0080000,  //  0032  RAISE	2	R0	R0
+      0x80040400,  //  0033  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_plugin_by_endpoint
+********************************************************************/
+be_local_closure(Matter_Device_find_plugin_by_endpoint,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(plugins),
+    /* K2   */  be_nested_str_weak(get_endpoint),
+    /* K3   */  be_const_int(1),
+    }),
+    be_str_weak(find_plugin_by_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0008,  //  0005  JMPF	R3	#000F
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x8C100702,  //  0008  GETMET	R4	R3	K2
+      0x7C100200,  //  0009  CALL	R4	1
+      0x1C100801,  //  000A  EQ	R4	R4	R1
+      0x78120000,  //  000B  JMPF	R4	#000D
+      0x80040600,  //  000C  RET	1	R3
+      0x00080503,  //  000D  ADD	R2	R2	K3
+      0x7001FFF1,  //  000E  JMP		#0001
+      0x4C0C0000,  //  000F  LDNIL	R3
+      0x80040600,  //  0010  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _start_udp
+********************************************************************/
+be_local_closure(Matter_Device__start_udp,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(msg_received),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(UDPServer),
+    /* K7   */  be_nested_str_weak(),
+    /* K8   */  be_nested_str_weak(start),
+    }),
+    be_str_weak(_start_udp),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80000400,  //  0002  RET	0
+      0x4C080000,  //  0003  LDNIL	R2
+      0x1C080202,  //  0004  EQ	R2	R1	R2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x540615A3,  //  0006  LDINT	R1	5540
+      0xB80A0200,  //  0007  GETNGBL	R2	K1
+      0x8C080502,  //  0008  GETMET	R2	R2	K2
+      0x60100008,  //  0009  GETGBL	R4	G8
+      0x5C140200,  //  000A  MOVE	R5	R1
+      0x7C100200,  //  000B  CALL	R4	1
+      0x00120604,  //  000C  ADD	R4	K3	R4
+      0x58140004,  //  000D  LDCONST	R5	K4
+      0x7C080600,  //  000E  CALL	R2	3
+      0xB80A0A00,  //  000F  GETNGBL	R2	K5
+      0x8C080506,  //  0010  GETMET	R2	R2	K6
+      0x58100007,  //  0011  LDCONST	R4	K7
+      0x5C140200,  //  0012  MOVE	R5	R1
+      0x7C080600,  //  0013  CALL	R2	3
+      0x90020002,  //  0014  SETMBR	R0	K0	R2
+      0x88080100,  //  0015  GETMBR	R2	R0	K0
+      0x8C080508,  //  0016  GETMET	R2	R2	K8
+      0x84100000,  //  0017  CLOSURE	R4	P0
+      0x7C080400,  //  0018  CALL	R2	2
+      0xA0000000,  //  0019  CLOSE	R0
+      0x80000000,  //  001A  RET	0
     })
   )
 );
@@ -5516,56 +5651,12 @@ be_local_closure(Matter_Device_signal_endpoints_changed,   /* name */
 ** Solidified class: Matter_Device
 ********************************************************************/
 be_local_class(Matter_Device,
-    34,
+    35,
     NULL,
-    be_nested_map(104,
+    be_nested_map(107,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(hostname_eth, -1), be_const_var(20) },
-        { be_const_key_weak(save_before_restart, -1), be_const_closure(Matter_Device_save_before_restart_closure) },
-        { be_const_key_weak(is_commissioning_open, 65), be_const_closure(Matter_Device_is_commissioning_open_closure) },
-        { be_const_key_weak(plugins, 94), be_const_var(1) },
-        { be_const_key_weak(plugins_config, 1), be_const_var(4) },
-        { be_const_key_weak(save_param, 4), be_const_closure(Matter_Device_save_param_closure) },
-        { be_const_key_weak(root_L, 24), be_const_var(33) },
-        { be_const_key_weak(mdns_remove_op_discovery, 86), be_const_closure(Matter_Device_mdns_remove_op_discovery_closure) },
-        { be_const_key_weak(plugins_classes, 36), be_const_var(3) },
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Device_every_second_closure) },
-        { be_const_key_weak(root_salt, -1), be_const_var(31) },
-        { be_const_key_weak(mdns_announce_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics_closure) },
-        { be_const_key_weak(sessions, -1), be_const_var(7) },
-        { be_const_key_weak(autoconf_sensors_list, 29), be_const_closure(Matter_Device_autoconf_sensors_list_closure) },
-        { be_const_key_weak(mdns_remove_PASE, -1), be_const_closure(Matter_Device_mdns_remove_PASE_closure) },
-        { be_const_key_weak(process_attribute_expansion, 60), be_const_closure(Matter_Device_process_attribute_expansion_closure) },
-        { be_const_key_weak(mdns_pase_eth, -1), be_const_var(23) },
-        { be_const_key_weak(_compute_pbkdf, 76), be_const_closure(Matter_Device__compute_pbkdf_closure) },
-        { be_const_key_weak(commissioning_w0, -1), be_const_var(14) },
-        { be_const_key_weak(bridge_remove_endpoint, 48), be_const_closure(Matter_Device_bridge_remove_endpoint_closure) },
-        { be_const_key_weak(stop_basic_commissioning, -1), be_const_closure(Matter_Device_stop_basic_commissioning_closure) },
-        { be_const_key_weak(http_remotes, -1), be_const_var(25) },
-        { be_const_key_weak(vendorid, 56), be_const_var(21) },
-        { be_const_key_weak(remove_fabric, -1), be_const_closure(Matter_Device_remove_fabric_closure) },
-        { be_const_key_weak(_start_udp, -1), be_const_closure(Matter_Device__start_udp_closure) },
-        { be_const_key_weak(productid, -1), be_const_var(22) },
-        { be_const_key_weak(_mdns_announce_hostname, 5), be_const_closure(Matter_Device__mdns_announce_hostname_closure) },
-        { be_const_key_weak(get_plugin_class_arg, -1), be_const_closure(Matter_Device_get_plugin_class_arg_closure) },
-        { be_const_key_weak(plugins_persist, -1), be_const_var(2) },
-        { be_const_key_weak(generate_random_passcode, -1), be_const_closure(Matter_Device_generate_random_passcode_closure) },
-        { be_const_key_weak(event_fabrics_saved, -1), be_const_closure(Matter_Device_event_fabrics_saved_closure) },
-        { be_const_key_weak(start_commissioning_complete, 82), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
-        { be_const_key_weak(msg_received, 54), be_const_closure(Matter_Device_msg_received_closure) },
-        { be_const_key_weak(_instantiate_plugins_from_config, -1), be_const_closure(Matter_Device__instantiate_plugins_from_config_closure) },
-        { be_const_key_weak(commissioning_instance_wifi, 74), be_const_var(17) },
-        { be_const_key_weak(get_active_endpoints, 69), be_const_closure(Matter_Device_get_active_endpoints_closure) },
-        { be_const_key_weak(commissioning_admin_fabric, -1), be_const_var(16) },
-        { be_const_key_weak(mdns_announce_PASE, -1), be_const_closure(Matter_Device_mdns_announce_PASE_closure) },
-        { be_const_key_weak(root_passcode, 88), be_const_var(27) },
-        { be_const_key_weak(message_handler, -1), be_const_var(6) },
-        { be_const_key_weak(FILENAME, 95), be_nested_str_weak(_matter_device_X2Ejson) },
-        { be_const_key_weak(VENDOR_ID, 42), be_const_int(65521) },
-        { be_const_key_weak(root_w0, 96), be_const_var(32) },
-        { be_const_key_weak(MtrJoin, -1), be_const_closure(Matter_Device_MtrJoin_closure) },
-        { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Device_attribute_updated_closure) },
-        { be_const_key_weak(PASSCODE_INVALID, 62), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        { be_const_key_weak(msg_received, -1), be_const_closure(Matter_Device_msg_received_closure) },
+        { be_const_key_weak(PASSCODE_INVALID, 91), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(12,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(0),
@@ -5581,64 +5672,111 @@ be_local_class(Matter_Device,
         be_const_int(12345678),
         be_const_int(87654321),
     }))    ) } )) },
-        { be_const_key_weak(started, 55), be_const_var(0) },
-        { be_const_key_weak(start, -1), be_const_closure(Matter_Device_start_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Device_init_closure) },
-        { be_const_key_weak(commissioning_salt, -1), be_const_var(13) },
-        { be_const_key_weak(commissioning_instance_eth, 75), be_const_var(18) },
-        { be_const_key_weak(k2l, -1), be_const_static_closure(Matter_Device_k2l_closure) },
-        { be_const_key_weak(hostname_wifi, 51), be_const_var(19) },
-        { be_const_key_weak(_init_basic_commissioning, -1), be_const_closure(Matter_Device__init_basic_commissioning_closure) },
-        { be_const_key_weak(received_ack, -1), be_const_closure(Matter_Device_received_ack_closure) },
-        { be_const_key_weak(clean_remotes, 43), be_const_closure(Matter_Device_clean_remotes_closure) },
-        { be_const_key_weak(autoconf_device_map, -1), be_const_closure(Matter_Device_autoconf_device_map_closure) },
-        { be_const_key_weak(commissioning_open, -1), be_const_var(10) },
-        { be_const_key_weak(get_plugin_class_displayname, -1), be_const_closure(Matter_Device_get_plugin_class_displayname_closure) },
-        { be_const_key_weak(commissioning_discriminator, 37), be_const_var(12) },
-        { be_const_key_weak(is_root_commissioning_open, -1), be_const_closure(Matter_Device_is_root_commissioning_open_closure) },
-        { be_const_key_weak(mdns_pase_wifi, -1), be_const_var(24) },
-        { be_const_key_weak(stop, -1), be_const_closure(Matter_Device_stop_closure) },
-        { be_const_key_weak(mdns_remove_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics_closure) },
-        { be_const_key_weak(every_250ms, 85), be_const_closure(Matter_Device_every_250ms_closure) },
-        { be_const_key_weak(compute_manual_pairing_code, -1), be_const_closure(Matter_Device_compute_manual_pairing_code_closure) },
-        { be_const_key_weak(adjust_next_ep, 63), be_const_closure(Matter_Device_adjust_next_ep_closure) },
-        { be_const_key_weak(register_commands, -1), be_const_closure(Matter_Device_register_commands_closure) },
-        { be_const_key_weak(register_http_remote, -1), be_const_closure(Matter_Device_register_http_remote_closure) },
-        { be_const_key_weak(load_param, -1), be_const_closure(Matter_Device_load_param_closure) },
-        { be_const_key_weak(root_discriminator, -1), be_const_var(26) },
-        { be_const_key_weak(compute_qrcode_content, -1), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
-        { be_const_key_weak(conf_to_log, 81), be_const_static_closure(Matter_Device_conf_to_log_closure) },
-        { be_const_key_weak(start_operational_discovery, -1), be_const_closure(Matter_Device_start_operational_discovery_closure) },
-        { be_const_key_weak(UDP_PORT, 14), be_const_int(5540) },
-        { be_const_key_weak(root_iterations, -1), be_const_var(30) },
-        { be_const_key_weak(register_plugin_class, -1), be_const_closure(Matter_Device_register_plugin_class_closure) },
-        { be_const_key_weak(commissioning_iterations, -1), be_const_var(11) },
-        { be_const_key_weak(udp_server, -1), be_const_var(5) },
-        { be_const_key_weak(_trigger_read_sensors, -1), be_const_closure(Matter_Device__trigger_read_sensors_closure) },
-        { be_const_key_weak(bridge_add_endpoint, -1), be_const_closure(Matter_Device_bridge_add_endpoint_closure) },
-        { be_const_key_weak(ipv4only, -1), be_const_var(28) },
-        { be_const_key_weak(PBKDF_ITERATIONS, 44), be_const_int(1000) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Device_invoke_request_closure) },
+        { be_const_key_weak(signal_endpoints_changed, 56), be_const_closure(Matter_Device_signal_endpoints_changed_closure) },
+        { be_const_key_weak(register_native_classes, 65), be_const_closure(Matter_Device_register_native_classes_closure) },
+        { be_const_key_weak(_compute_pbkdf, -1), be_const_closure(Matter_Device__compute_pbkdf_closure) },
+        { be_const_key_weak(hostname_eth, -1), be_const_var(21) },
+        { be_const_key_weak(productid, -1), be_const_var(23) },
         { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
-        { be_const_key_weak(every_50ms, -1), be_const_closure(Matter_Device_every_50ms_closure) },
-        { be_const_key_weak(k2l_num, -1), be_const_static_closure(Matter_Device_k2l_num_closure) },
-        { be_const_key_weak(autoconf_device, -1), be_const_closure(Matter_Device_autoconf_device_closure) },
-        { be_const_key_weak(mdns_announce_op_discovery, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_closure) },
-        { be_const_key_weak(msg_send, -1), be_const_closure(Matter_Device_msg_send_closure) },
+        { be_const_key_weak(_start_udp, -1), be_const_closure(Matter_Device__start_udp_closure) },
+        { be_const_key_weak(started, 69), be_const_var(0) },
+        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(Matter_Device_get_active_endpoints_closure) },
+        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
+        { be_const_key_weak(root_discriminator, -1), be_const_var(27) },
+        { be_const_key_weak(root_w0, 98), be_const_var(33) },
+        { be_const_key_weak(mdns_remove_PASE, 27), be_const_closure(Matter_Device_mdns_remove_PASE_closure) },
+        { be_const_key_weak(ui, -1), be_const_var(9) },
+        { be_const_key_weak(commissioning_w0, -1), be_const_var(15) },
+        { be_const_key_weak(commissioning_instance_eth, -1), be_const_var(19) },
+        { be_const_key_weak(bridge_remove_endpoint, 15), be_const_closure(Matter_Device_bridge_remove_endpoint_closure) },
+        { be_const_key_weak(save_before_restart, 5), be_const_closure(Matter_Device_save_before_restart_closure) },
+        { be_const_key_weak(k2l, -1), be_const_static_closure(Matter_Device_k2l_closure) },
+        { be_const_key_weak(mdns_announce_PASE, -1), be_const_closure(Matter_Device_mdns_announce_PASE_closure) },
+        { be_const_key_weak(vendorid, -1), be_const_var(22) },
+        { be_const_key_weak(start_operational_discovery_deferred, -1), be_const_closure(Matter_Device_start_operational_discovery_deferred_closure) },
+        { be_const_key_weak(get_plugin_class_arg, -1), be_const_closure(Matter_Device_get_plugin_class_arg_closure) },
+        { be_const_key_weak(event_fabrics_saved, -1), be_const_closure(Matter_Device_event_fabrics_saved_closure) },
+        { be_const_key_weak(register_commands, 16), be_const_closure(Matter_Device_register_commands_closure) },
+        { be_const_key_weak(VENDOR_ID, 106), be_const_int(65521) },
+        { be_const_key_weak(plugins_config_remotes, -1), be_const_var(5) },
+        { be_const_key_weak(commissioning_iterations, -1), be_const_var(12) },
+        { be_const_key_weak(_init_basic_commissioning, -1), be_const_closure(Matter_Device__init_basic_commissioning_closure) },
+        { be_const_key_weak(plugins_config, 93), be_const_var(4) },
+        { be_const_key_weak(commissioning_admin_fabric, 57), be_const_var(17) },
+        { be_const_key_weak(mdns_pase_wifi, 10), be_const_var(25) },
+        { be_const_key_weak(root_passcode, -1), be_const_var(28) },
+        { be_const_key_weak(register_http_remote, 99), be_const_closure(Matter_Device_register_http_remote_closure) },
+        { be_const_key_weak(start_operational_discovery, -1), be_const_closure(Matter_Device_start_operational_discovery_closure) },
+        { be_const_key_weak(compute_qrcode_content, 20), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
+        { be_const_key_weak(adjust_next_ep, -1), be_const_closure(Matter_Device_adjust_next_ep_closure) },
+        { be_const_key_weak(update_remotes_info, -1), be_const_closure(Matter_Device_update_remotes_info_closure) },
+        { be_const_key_weak(autoconf_sensors_list, -1), be_const_closure(Matter_Device_autoconf_sensors_list_closure) },
+        { be_const_key_weak(next_ep, -1), be_const_var(30) },
+        { be_const_key_weak(message_handler, -1), be_const_var(7) },
         { be_const_key_weak(start_basic_commissioning, -1), be_const_closure(Matter_Device_start_basic_commissioning_closure) },
-        { be_const_key_weak(commissioning_L, -1), be_const_var(15) },
+        { be_const_key_weak(get_plugin_class_displayname, -1), be_const_closure(Matter_Device_get_plugin_class_displayname_closure) },
+        { be_const_key_weak(hostname_wifi, 36), be_const_var(20) },
+        { be_const_key_weak(start_commissioning_complete, -1), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
+        { be_const_key_weak(stop, 60), be_const_closure(Matter_Device_stop_closure) },
+        { be_const_key_weak(remove_fabric, -1), be_const_closure(Matter_Device_remove_fabric_closure) },
+        { be_const_key_weak(generate_random_passcode, 52), be_const_closure(Matter_Device_generate_random_passcode_closure) },
+        { be_const_key_weak(received_ack, -1), be_const_closure(Matter_Device_received_ack_closure) },
+        { be_const_key_weak(MtrJoin, 39), be_const_closure(Matter_Device_MtrJoin_closure) },
+        { be_const_key_weak(mdns_announce_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics_closure) },
+        { be_const_key_weak(load_param, -1), be_const_closure(Matter_Device_load_param_closure) },
+        { be_const_key_weak(ipv4only, 1), be_const_var(29) },
+        { be_const_key_weak(stop_basic_commissioning, 41), be_const_closure(Matter_Device_stop_basic_commissioning_closure) },
+        { be_const_key_weak(commissioning_salt, -1), be_const_var(14) },
+        { be_const_key_weak(commissioning_discriminator, 44), be_const_var(13) },
+        { be_const_key_weak(sessions, -1), be_const_var(8) },
+        { be_const_key_weak(start_commissioning_complete_deferred, 49), be_const_closure(Matter_Device_start_commissioning_complete_deferred_closure) },
+        { be_const_key_weak(root_L, 23), be_const_var(34) },
+        { be_const_key_weak(plugins_persist, -1), be_const_var(2) },
+        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
+        { be_const_key_weak(tick, 61), be_const_var(10) },
+        { be_const_key_weak(register_plugin_class, 87), be_const_closure(Matter_Device_register_plugin_class_closure) },
+        { be_const_key_weak(compute_manual_pairing_code, -1), be_const_closure(Matter_Device_compute_manual_pairing_code_closure) },
+        { be_const_key_weak(is_root_commissioning_open, -1), be_const_closure(Matter_Device_is_root_commissioning_open_closure) },
+        { be_const_key_weak(plugins, -1), be_const_var(1) },
+        { be_const_key_weak(start, -1), be_const_closure(Matter_Device_start_closure) },
+        { be_const_key_weak(commissioning_L, 68), be_const_var(16) },
+        { be_const_key_weak(bridge_add_endpoint, -1), be_const_closure(Matter_Device_bridge_add_endpoint_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Device_every_second_closure) },
+        { be_const_key_weak(conf_to_log, 74), be_const_static_closure(Matter_Device_conf_to_log_closure) },
+        { be_const_key_weak(udp_server, -1), be_const_var(6) },
+        { be_const_key_weak(get_plugin_remote_info, -1), be_const_closure(Matter_Device_get_plugin_remote_info_closure) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Device_invoke_request_closure) },
+        { be_const_key_weak(msg_send, 67), be_const_closure(Matter_Device_msg_send_closure) },
+        { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Device_attribute_updated_closure) },
+        { be_const_key_weak(every_250ms, 64), be_const_closure(Matter_Device_every_250ms_closure) },
+        { be_const_key_weak(save_param, -1), be_const_closure(Matter_Device_save_param_closure) },
+        { be_const_key_weak(commissioning_open, -1), be_const_var(11) },
+        { be_const_key_weak(_mdns_announce_hostname, -1), be_const_closure(Matter_Device__mdns_announce_hostname_closure) },
+        { be_const_key_weak(PASE_TIMEOUT, 32), be_const_int(600) },
+        { be_const_key_weak(process_attribute_expansion, -1), be_const_closure(Matter_Device_process_attribute_expansion_closure) },
+        { be_const_key_weak(_instantiate_plugins_from_config, 55), be_const_closure(Matter_Device__instantiate_plugins_from_config_closure) },
+        { be_const_key_weak(every_50ms, 53), be_const_closure(Matter_Device_every_50ms_closure) },
+        { be_const_key_weak(mdns_announce_op_discovery, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_closure) },
+        { be_const_key_weak(clean_remotes, -1), be_const_closure(Matter_Device_clean_remotes_closure) },
+        { be_const_key_weak(mdns_pase_eth, -1), be_const_var(24) },
+        { be_const_key_weak(is_commissioning_open, -1), be_const_closure(Matter_Device_is_commissioning_open_closure) },
+        { be_const_key_weak(autoconf_device_map, -1), be_const_closure(Matter_Device_autoconf_device_map_closure) },
+        { be_const_key_weak(http_remotes, -1), be_const_var(26) },
+        { be_const_key_weak(autoconf_device, 34), be_const_closure(Matter_Device_autoconf_device_closure) },
+        { be_const_key_weak(root_salt, 58), be_const_var(32) },
+        { be_const_key_weak(mdns_remove_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics_closure) },
+        { be_const_key_weak(k2l_num, -1), be_const_static_closure(Matter_Device_k2l_num_closure) },
+        { be_const_key_weak(start_mdns_announce_hostnames, 22), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
         { be_const_key_weak(find_plugin_by_endpoint, -1), be_const_closure(Matter_Device_find_plugin_by_endpoint_closure) },
-        { be_const_key_weak(start_mdns_announce_hostnames, -1), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
-        { be_const_key_weak(start_commissioning_complete_deferred, -1), be_const_closure(Matter_Device_start_commissioning_complete_deferred_closure) },
-        { be_const_key_weak(next_ep, -1), be_const_var(29) },
-        { be_const_key_weak(start_root_basic_commissioning, -1), be_const_closure(Matter_Device_start_root_basic_commissioning_closure) },
-        { be_const_key_weak(start_operational_discovery_deferred, 25), be_const_closure(Matter_Device_start_operational_discovery_deferred_closure) },
-        { be_const_key_weak(PASE_TIMEOUT, -1), be_const_int(600) },
-        { be_const_key_weak(ui, 16), be_const_var(8) },
-        { be_const_key_weak(tick, -1), be_const_var(9) },
-        { be_const_key_weak(register_native_classes, -1), be_const_closure(Matter_Device_register_native_classes_closure) },
         { be_const_key_weak(sort_distinct, -1), be_const_static_closure(Matter_Device_sort_distinct_closure) },
-        { be_const_key_weak(signal_endpoints_changed, -1), be_const_closure(Matter_Device_signal_endpoints_changed_closure) },
+        { be_const_key_weak(mdns_remove_op_discovery, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_closure) },
+        { be_const_key_weak(_trigger_read_sensors, 11), be_const_closure(Matter_Device__trigger_read_sensors_closure) },
+        { be_const_key_weak(root_iterations, -1), be_const_var(31) },
+        { be_const_key_weak(commissioning_instance_wifi, 8), be_const_var(18) },
+        { be_const_key_weak(init, 6), be_const_closure(Matter_Device_init_closure) },
+        { be_const_key_weak(PBKDF_ITERATIONS, -1), be_const_int(1000) },
+        { be_const_key_weak(start_root_basic_commissioning, 2), be_const_closure(Matter_Device_start_root_basic_commissioning_closure) },
+        { be_const_key_weak(plugins_classes, -1), be_const_var(3) },
     })),
     be_str_weak(Matter_Device)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_async.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_async.h
@@ -388,7 +388,7 @@ be_local_closure(Matter_HTTP_async_parse_http_payload,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
+    ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(is_chunked),
     /* K1   */  be_nested_str_weak(chunk_size),
     /* K2   */  be_nested_str_weak(global),
@@ -399,33 +399,31 @@ be_local_closure(Matter_HTTP_async_parse_http_payload,   /* name */
     /* K7   */  be_const_int(0),
     /* K8   */  be_nested_str_weak(0x),
     /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(close),
-    /* K11  */  be_nested_str_weak(status),
-    /* K12  */  be_const_int(2),
-    /* K13  */  be_nested_str_weak(),
-    /* K14  */  be_nested_str_weak(http_status),
-    /* K15  */  be_nested_str_weak(event_http_finished),
-    /* K16  */  be_nested_str_weak(payload),
-    /* K17  */  be_const_int(2147483647),
+    /* K10  */  be_nested_str_weak(status),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_nested_str_weak(),
+    /* K13  */  be_nested_str_weak(close),
+    /* K14  */  be_nested_str_weak(payload),
+    /* K15  */  be_const_int(2147483647),
     }),
     be_str_weak(parse_http_payload),
     &be_const_str_solidified,
-    ( &(const binstruction[85]) {  /* code */
+    ( &(const binstruction[82]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060048,  //  0001  JMPF	R1	#004B
+      0x78060045,  //  0001  JMPF	R1	#0048
       0x50040200,  //  0002  LDBOOL	R1	1	0
-      0x78060045,  //  0003  JMPF	R1	#004A
+      0x78060042,  //  0003  JMPF	R1	#0047
       0x88040101,  //  0004  GETMBR	R1	R0	K1
       0x4C080000,  //  0005  LDNIL	R2
       0x1C040202,  //  0006  EQ	R1	R1	R2
-      0x7806001B,  //  0007  JMPF	R1	#0024
+      0x78060018,  //  0007  JMPF	R1	#0021
       0xB8060400,  //  0008  GETNGBL	R1	K2
       0x88040303,  //  0009  GETMBR	R1	R1	K3
       0x8C040304,  //  000A  GETMET	R1	R1	K4
       0x880C0105,  //  000B  GETMBR	R3	R0	K5
       0x88100106,  //  000C  GETMBR	R4	R0	K6
       0x7C040600,  //  000D  CALL	R1	3
-      0x78060014,  //  000E  JMPF	R1	#0024
+      0x78060011,  //  000E  JMPF	R1	#0021
       0x88080106,  //  000F  GETMBR	R2	R0	K6
       0x940C0307,  //  0010  GETIDX	R3	R1	K7
       0x00080403,  //  0011  ADD	R2	R2	R3
@@ -437,65 +435,62 @@ be_local_closure(Matter_HTTP_async_parse_http_payload,   /* name */
       0x90020202,  //  0017  SETMBR	R0	K1	R2
       0x88080101,  //  0018  GETMBR	R2	R0	K1
       0x1C080507,  //  0019  EQ	R2	R2	K7
-      0x780A0008,  //  001A  JMPF	R2	#0024
-      0x8C08010A,  //  001B  GETMET	R2	R0	K10
-      0x7C080200,  //  001C  CALL	R2	1
-      0x9002170C,  //  001D  SETMBR	R0	K11	K12
-      0x90020B0D,  //  001E  SETMBR	R0	K5	K13
-      0x90020D07,  //  001F  SETMBR	R0	K6	K7
-      0x90021D09,  //  0020  SETMBR	R0	K14	K9
-      0x8C08010F,  //  0021  GETMET	R2	R0	K15
-      0x7C080200,  //  0022  CALL	R2	1
-      0x80000400,  //  0023  RET	0
-      0x88040101,  //  0024  GETMBR	R1	R0	K1
-      0x4C080000,  //  0025  LDNIL	R2
-      0x20040202,  //  0026  NE	R1	R1	R2
-      0x7806001F,  //  0027  JMPF	R1	#0048
-      0x88040101,  //  0028  GETMBR	R1	R0	K1
-      0x6008000C,  //  0029  GETGBL	R2	G12
-      0x880C0105,  //  002A  GETMBR	R3	R0	K5
-      0x7C080200,  //  002B  CALL	R2	1
-      0x880C0106,  //  002C  GETMBR	R3	R0	K6
-      0x04080403,  //  002D  SUB	R2	R2	R3
-      0x18040202,  //  002E  LE	R1	R1	R2
-      0x78060015,  //  002F  JMPF	R1	#0046
-      0x88080106,  //  0030  GETMBR	R2	R0	K6
-      0x880C0106,  //  0031  GETMBR	R3	R0	K6
-      0x88100101,  //  0032  GETMBR	R4	R0	K1
-      0x000C0604,  //  0033  ADD	R3	R3	R4
-      0x040C0709,  //  0034  SUB	R3	R3	K9
-      0x40080403,  //  0035  CONNECT	R2	R2	R3
-      0x880C0105,  //  0036  GETMBR	R3	R0	K5
-      0x88040110,  //  0037  GETMBR	R1	R0	K16
-      0x94080602,  //  0038  GETIDX	R2	R3	R2
-      0x00040202,  //  0039  ADD	R1	R1	R2
-      0x90022001,  //  003A  SETMBR	R0	K16	R1
-      0x88040106,  //  003B  GETMBR	R1	R0	K6
-      0x88080101,  //  003C  GETMBR	R2	R0	K1
-      0x00040202,  //  003D  ADD	R1	R1	R2
-      0x40040311,  //  003E  CONNECT	R1	R1	K17
-      0x88080105,  //  003F  GETMBR	R2	R0	K5
-      0x94040401,  //  0040  GETIDX	R1	R2	R1
-      0x90020A01,  //  0041  SETMBR	R0	K5	R1
-      0x90020D07,  //  0042  SETMBR	R0	K6	K7
-      0x4C040000,  //  0043  LDNIL	R1
-      0x90020201,  //  0044  SETMBR	R0	K1	R1
-      0x70020000,  //  0045  JMP		#0047
-      0x80000200,  //  0046  RET	0
-      0x70020000,  //  0047  JMP		#0049
-      0x80000200,  //  0048  RET	0
-      0x7001FFB7,  //  0049  JMP		#0002
-      0x70020008,  //  004A  JMP		#0054
-      0x88080106,  //  004B  GETMBR	R2	R0	K6
-      0x40080511,  //  004C  CONNECT	R2	R2	K17
-      0x880C0105,  //  004D  GETMBR	R3	R0	K5
-      0x88040110,  //  004E  GETMBR	R1	R0	K16
-      0x94080602,  //  004F  GETIDX	R2	R3	R2
-      0x00040202,  //  0050  ADD	R1	R1	R2
-      0x90022001,  //  0051  SETMBR	R0	K16	R1
-      0x90020B0D,  //  0052  SETMBR	R0	K5	K13
-      0x90020D07,  //  0053  SETMBR	R0	K6	K7
-      0x80000000,  //  0054  RET	0
+      0x780A0005,  //  001A  JMPF	R2	#0021
+      0x9002150B,  //  001B  SETMBR	R0	K10	K11
+      0x90020B0C,  //  001C  SETMBR	R0	K5	K12
+      0x90020D07,  //  001D  SETMBR	R0	K6	K7
+      0x8C08010D,  //  001E  GETMET	R2	R0	K13
+      0x7C080200,  //  001F  CALL	R2	1
+      0x80000400,  //  0020  RET	0
+      0x88040101,  //  0021  GETMBR	R1	R0	K1
+      0x4C080000,  //  0022  LDNIL	R2
+      0x20040202,  //  0023  NE	R1	R1	R2
+      0x7806001F,  //  0024  JMPF	R1	#0045
+      0x88040101,  //  0025  GETMBR	R1	R0	K1
+      0x6008000C,  //  0026  GETGBL	R2	G12
+      0x880C0105,  //  0027  GETMBR	R3	R0	K5
+      0x7C080200,  //  0028  CALL	R2	1
+      0x880C0106,  //  0029  GETMBR	R3	R0	K6
+      0x04080403,  //  002A  SUB	R2	R2	R3
+      0x18040202,  //  002B  LE	R1	R1	R2
+      0x78060015,  //  002C  JMPF	R1	#0043
+      0x88080106,  //  002D  GETMBR	R2	R0	K6
+      0x880C0106,  //  002E  GETMBR	R3	R0	K6
+      0x88100101,  //  002F  GETMBR	R4	R0	K1
+      0x000C0604,  //  0030  ADD	R3	R3	R4
+      0x040C0709,  //  0031  SUB	R3	R3	K9
+      0x40080403,  //  0032  CONNECT	R2	R2	R3
+      0x880C0105,  //  0033  GETMBR	R3	R0	K5
+      0x8804010E,  //  0034  GETMBR	R1	R0	K14
+      0x94080602,  //  0035  GETIDX	R2	R3	R2
+      0x00040202,  //  0036  ADD	R1	R1	R2
+      0x90021C01,  //  0037  SETMBR	R0	K14	R1
+      0x88040106,  //  0038  GETMBR	R1	R0	K6
+      0x88080101,  //  0039  GETMBR	R2	R0	K1
+      0x00040202,  //  003A  ADD	R1	R1	R2
+      0x4004030F,  //  003B  CONNECT	R1	R1	K15
+      0x88080105,  //  003C  GETMBR	R2	R0	K5
+      0x94040401,  //  003D  GETIDX	R1	R2	R1
+      0x90020A01,  //  003E  SETMBR	R0	K5	R1
+      0x90020D07,  //  003F  SETMBR	R0	K6	K7
+      0x4C040000,  //  0040  LDNIL	R1
+      0x90020201,  //  0041  SETMBR	R0	K1	R1
+      0x70020000,  //  0042  JMP		#0044
+      0x80000200,  //  0043  RET	0
+      0x70020000,  //  0044  JMP		#0046
+      0x80000200,  //  0045  RET	0
+      0x7001FFBA,  //  0046  JMP		#0002
+      0x70020008,  //  0047  JMP		#0051
+      0x88080106,  //  0048  GETMBR	R2	R0	K6
+      0x4008050F,  //  0049  CONNECT	R2	R2	K15
+      0x880C0105,  //  004A  GETMBR	R3	R0	K5
+      0x8804010E,  //  004B  GETMBR	R1	R0	K14
+      0x94080602,  //  004C  GETIDX	R2	R3	R2
+      0x00040202,  //  004D  ADD	R1	R1	R2
+      0x90021C01,  //  004E  SETMBR	R0	K14	R1
+      0x90020B0C,  //  004F  SETMBR	R0	K5	K12
+      0x90020D07,  //  0050  SETMBR	R0	K6	K7
+      0x80000000,  //  0051  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_remote.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_remote.h
@@ -48,6 +48,202 @@ be_local_closure(Matter_HTTP_remote_device_is_alive,   /* name */
 
 
 /********************************************************************
+** Solidified function: parse_update
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_parse_update,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[27]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(DeviceName),
+    /* K3   */  be_nested_str_weak(Tasmota),
+    /* K4   */  be_nested_str_weak(info),
+    /* K5   */  be_nested_str_weak(name),
+    /* K6   */  be_nested_str_weak(remove),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20name_X3D_X27_X25s_X27),
+    /* K10  */  be_nested_str_weak(addr),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(change_schedule),
+    /* K13  */  be_nested_str_weak(UPDATE_CMD0),
+    /* K14  */  be_nested_str_weak(UPDATE_TIME2),
+    /* K15  */  be_const_int(2),
+    /* K16  */  be_nested_str_weak(Version),
+    /* K17  */  be_nested_str_weak(Hardware),
+    /* K18  */  be_nested_str_weak(version),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20version_X3D_X27_X25s_X27),
+    /* K20  */  be_nested_str_weak(hardware),
+    /* K21  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20hardware_X3D_X27_X25s_X27),
+    /* K22  */  be_nested_str_weak(UPDATE_CMD2),
+    /* K23  */  be_nested_str_weak(Mac),
+    /* K24  */  be_nested_str_weak(mac),
+    /* K25  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20mac_X3D_X27_X25s_X27),
+    /* K26  */  be_nested_str_weak(info_changed),
+    }),
+    be_str_weak(parse_update),
+    &be_const_str_solidified,
+    ( &(const binstruction[145]) {  /* code */
+      0x500C0000,  //  0000  LDBOOL	R3	0	0
+      0x1C100500,  //  0001  EQ	R4	R2	K0
+      0x78120024,  //  0002  JMPF	R4	#0028
+      0x8C100301,  //  0003  GETMET	R4	R1	K1
+      0x58180002,  //  0004  LDCONST	R6	K2
+      0x7C100400,  //  0005  CALL	R4	2
+      0x1C140903,  //  0006  EQ	R5	R4	K3
+      0x78160000,  //  0007  JMPF	R5	#0009
+      0x4C100000,  //  0008  LDNIL	R4
+      0x88140104,  //  0009  GETMBR	R5	R0	K4
+      0x8C140B01,  //  000A  GETMET	R5	R5	K1
+      0x581C0005,  //  000B  LDCONST	R7	K5
+      0x7C140400,  //  000C  CALL	R5	2
+      0x20140A04,  //  000D  NE	R5	R5	R4
+      0x78160013,  //  000E  JMPF	R5	#0023
+      0x4C140000,  //  000F  LDNIL	R5
+      0x20140805,  //  0010  NE	R5	R4	R5
+      0x78160002,  //  0011  JMPF	R5	#0015
+      0x88140104,  //  0012  GETMBR	R5	R0	K4
+      0x98160A04,  //  0013  SETIDX	R5	K5	R4
+      0x70020003,  //  0014  JMP		#0019
+      0x88140104,  //  0015  GETMBR	R5	R0	K4
+      0x8C140B06,  //  0016  GETMET	R5	R5	K6
+      0x581C0005,  //  0017  LDCONST	R7	K5
+      0x7C140400,  //  0018  CALL	R5	2
+      0xB8160E00,  //  0019  GETNGBL	R5	K7
+      0x8C140B08,  //  001A  GETMET	R5	R5	K8
+      0x601C0018,  //  001B  GETGBL	R7	G24
+      0x58200009,  //  001C  LDCONST	R8	K9
+      0x8824010A,  //  001D  GETMBR	R9	R0	K10
+      0x5C280800,  //  001E  MOVE	R10	R4
+      0x7C1C0600,  //  001F  CALL	R7	3
+      0x5820000B,  //  0020  LDCONST	R8	K11
+      0x7C140600,  //  0021  CALL	R5	3
+      0x500C0200,  //  0022  LDBOOL	R3	1	0
+      0x8C14010C,  //  0023  GETMET	R5	R0	K12
+      0x881C010D,  //  0024  GETMBR	R7	R0	K13
+      0x8820010E,  //  0025  GETMBR	R8	R0	K14
+      0x7C140600,  //  0026  CALL	R5	3
+      0x70020064,  //  0027  JMP		#008D
+      0x1C10050F,  //  0028  EQ	R4	R2	K15
+      0x7812003E,  //  0029  JMPF	R4	#0069
+      0x8C100301,  //  002A  GETMET	R4	R1	K1
+      0x58180010,  //  002B  LDCONST	R6	K16
+      0x7C100400,  //  002C  CALL	R4	2
+      0x8C140301,  //  002D  GETMET	R5	R1	K1
+      0x581C0011,  //  002E  LDCONST	R7	K17
+      0x7C140400,  //  002F  CALL	R5	2
+      0x88180104,  //  0030  GETMBR	R6	R0	K4
+      0x8C180D01,  //  0031  GETMET	R6	R6	K1
+      0x58200012,  //  0032  LDCONST	R8	K18
+      0x7C180400,  //  0033  CALL	R6	2
+      0x20180C04,  //  0034  NE	R6	R6	R4
+      0x781A0013,  //  0035  JMPF	R6	#004A
+      0x4C180000,  //  0036  LDNIL	R6
+      0x20180806,  //  0037  NE	R6	R4	R6
+      0x781A0002,  //  0038  JMPF	R6	#003C
+      0x88180104,  //  0039  GETMBR	R6	R0	K4
+      0x981A2404,  //  003A  SETIDX	R6	K18	R4
+      0x70020003,  //  003B  JMP		#0040
+      0x88180104,  //  003C  GETMBR	R6	R0	K4
+      0x8C180D06,  //  003D  GETMET	R6	R6	K6
+      0x58200012,  //  003E  LDCONST	R8	K18
+      0x7C180400,  //  003F  CALL	R6	2
+      0xB81A0E00,  //  0040  GETNGBL	R6	K7
+      0x8C180D08,  //  0041  GETMET	R6	R6	K8
+      0x60200018,  //  0042  GETGBL	R8	G24
+      0x58240013,  //  0043  LDCONST	R9	K19
+      0x8828010A,  //  0044  GETMBR	R10	R0	K10
+      0x5C2C0800,  //  0045  MOVE	R11	R4
+      0x7C200600,  //  0046  CALL	R8	3
+      0x5824000B,  //  0047  LDCONST	R9	K11
+      0x7C180600,  //  0048  CALL	R6	3
+      0x500C0200,  //  0049  LDBOOL	R3	1	0
+      0x88180104,  //  004A  GETMBR	R6	R0	K4
+      0x8C180D01,  //  004B  GETMET	R6	R6	K1
+      0x58200014,  //  004C  LDCONST	R8	K20
+      0x7C180400,  //  004D  CALL	R6	2
+      0x20180C05,  //  004E  NE	R6	R6	R5
+      0x781A0013,  //  004F  JMPF	R6	#0064
+      0x4C180000,  //  0050  LDNIL	R6
+      0x20180A06,  //  0051  NE	R6	R5	R6
+      0x781A0002,  //  0052  JMPF	R6	#0056
+      0x88180104,  //  0053  GETMBR	R6	R0	K4
+      0x981A2805,  //  0054  SETIDX	R6	K20	R5
+      0x70020003,  //  0055  JMP		#005A
+      0x88180104,  //  0056  GETMBR	R6	R0	K4
+      0x8C180D06,  //  0057  GETMET	R6	R6	K6
+      0x58200014,  //  0058  LDCONST	R8	K20
+      0x7C180400,  //  0059  CALL	R6	2
+      0xB81A0E00,  //  005A  GETNGBL	R6	K7
+      0x8C180D08,  //  005B  GETMET	R6	R6	K8
+      0x60200018,  //  005C  GETGBL	R8	G24
+      0x58240015,  //  005D  LDCONST	R9	K21
+      0x8828010A,  //  005E  GETMBR	R10	R0	K10
+      0x5C2C0A00,  //  005F  MOVE	R11	R5
+      0x7C200600,  //  0060  CALL	R8	3
+      0x5824000B,  //  0061  LDCONST	R9	K11
+      0x7C180600,  //  0062  CALL	R6	3
+      0x500C0200,  //  0063  LDBOOL	R3	1	0
+      0x8C18010C,  //  0064  GETMET	R6	R0	K12
+      0x88200116,  //  0065  GETMBR	R8	R0	K22
+      0x8824010E,  //  0066  GETMBR	R9	R0	K14
+      0x7C180600,  //  0067  CALL	R6	3
+      0x70020023,  //  0068  JMP		#008D
+      0x54120004,  //  0069  LDINT	R4	5
+      0x1C100404,  //  006A  EQ	R4	R2	R4
+      0x78120020,  //  006B  JMPF	R4	#008D
+      0x8C100301,  //  006C  GETMET	R4	R1	K1
+      0x58180017,  //  006D  LDCONST	R6	K23
+      0x7C100400,  //  006E  CALL	R4	2
+      0x88140104,  //  006F  GETMBR	R5	R0	K4
+      0x8C140B01,  //  0070  GETMET	R5	R5	K1
+      0x581C0018,  //  0071  LDCONST	R7	K24
+      0x7C140400,  //  0072  CALL	R5	2
+      0x20140A04,  //  0073  NE	R5	R5	R4
+      0x78160013,  //  0074  JMPF	R5	#0089
+      0x4C140000,  //  0075  LDNIL	R5
+      0x20140805,  //  0076  NE	R5	R4	R5
+      0x78160002,  //  0077  JMPF	R5	#007B
+      0x88140104,  //  0078  GETMBR	R5	R0	K4
+      0x98163004,  //  0079  SETIDX	R5	K24	R4
+      0x70020003,  //  007A  JMP		#007F
+      0x88140104,  //  007B  GETMBR	R5	R0	K4
+      0x8C140B06,  //  007C  GETMET	R5	R5	K6
+      0x581C0018,  //  007D  LDCONST	R7	K24
+      0x7C140400,  //  007E  CALL	R5	2
+      0xB8160E00,  //  007F  GETNGBL	R5	K7
+      0x8C140B08,  //  0080  GETMET	R5	R5	K8
+      0x601C0018,  //  0081  GETGBL	R7	G24
+      0x58200019,  //  0082  LDCONST	R8	K25
+      0x8824010A,  //  0083  GETMBR	R9	R0	K10
+      0x5C280800,  //  0084  MOVE	R10	R4
+      0x7C1C0600,  //  0085  CALL	R7	3
+      0x5820000B,  //  0086  LDCONST	R8	K11
+      0x7C140600,  //  0087  CALL	R5	3
+      0x500C0200,  //  0088  LDBOOL	R3	1	0
+      0x8C14010C,  //  0089  GETMET	R5	R0	K12
+      0x881C010D,  //  008A  GETMBR	R7	R0	K13
+      0x8820010E,  //  008B  GETMBR	R8	R0	K14
+      0x7C140600,  //  008C  CALL	R5	3
+      0x780E0001,  //  008D  JMPF	R3	#0090
+      0x8C10011A,  //  008E  GETMET	R4	R0	K26
+      0x7C100200,  //  008F  CALL	R4	1
+      0x80000000,  //  0090  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: call_sync
 ********************************************************************/
 be_local_closure(Matter_HTTP_remote_call_sync,   /* name */
@@ -168,6 +364,89 @@ be_local_closure(Matter_HTTP_remote_call_sync,   /* name */
 
 
 /********************************************************************
+** Solidified function: event_http_finished
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_event_http_finished,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(current_cmd),
+    /* K1   */  be_nested_str_weak(payload),
+    /* K2   */  be_nested_str_weak(nil),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(_X2E_X2E_X2E),
+    /* K5   */  be_nested_str_weak(tasmota),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20async_X2Dresp_X20in_X20_X25i_X20ms_X20from_X20_X25s_X3A_X20_X5B_X25i_X5D_X20_X27_X25s_X27),
+    /* K8   */  be_nested_str_weak(millis),
+    /* K9   */  be_nested_str_weak(time_start),
+    /* K10  */  be_nested_str_weak(addr),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(dispatch_cb),
+    /* K13  */  be_nested_str_weak(http_status),
+    }),
+    be_str_weak(event_http_finished),
+    &be_const_str_solidified,
+    ( &(const binstruction[45]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060000,  //  0003  JMPF	R1	#0005
+      0x80000200,  //  0004  RET	0
+      0x88040101,  //  0005  GETMBR	R1	R0	K1
+      0x4C080000,  //  0006  LDNIL	R2
+      0x20040202,  //  0007  NE	R1	R1	R2
+      0x78060001,  //  0008  JMPF	R1	#000B
+      0x88040101,  //  0009  GETMBR	R1	R0	K1
+      0x70020000,  //  000A  JMP		#000C
+      0x58040002,  //  000B  LDCONST	R1	K2
+      0x6008000C,  //  000C  GETGBL	R2	G12
+      0x5C0C0200,  //  000D  MOVE	R3	R1
+      0x7C080200,  //  000E  CALL	R2	1
+      0x540E001D,  //  000F  LDINT	R3	30
+      0x24080403,  //  0010  GT	R2	R2	R3
+      0x780A0004,  //  0011  JMPF	R2	#0017
+      0x540A001C,  //  0012  LDINT	R2	29
+      0x400A0602,  //  0013  CONNECT	R2	K3	R2
+      0x94080202,  //  0014  GETIDX	R2	R1	R2
+      0x00080504,  //  0015  ADD	R2	R2	K4
+      0x5C040400,  //  0016  MOVE	R1	R2
+      0xB80A0A00,  //  0017  GETNGBL	R2	K5
+      0x8C080506,  //  0018  GETMET	R2	R2	K6
+      0x60100018,  //  0019  GETGBL	R4	G24
+      0x58140007,  //  001A  LDCONST	R5	K7
+      0xB81A0A00,  //  001B  GETNGBL	R6	K5
+      0x8C180D08,  //  001C  GETMET	R6	R6	K8
+      0x7C180200,  //  001D  CALL	R6	1
+      0x881C0109,  //  001E  GETMBR	R7	R0	K9
+      0x04180C07,  //  001F  SUB	R6	R6	R7
+      0x881C010A,  //  0020  GETMBR	R7	R0	K10
+      0x6020000C,  //  0021  GETGBL	R8	G12
+      0x88240101,  //  0022  GETMBR	R9	R0	K1
+      0x7C200200,  //  0023  CALL	R8	1
+      0x5C240200,  //  0024  MOVE	R9	R1
+      0x7C100A00,  //  0025  CALL	R4	5
+      0x5814000B,  //  0026  LDCONST	R5	K11
+      0x7C080600,  //  0027  CALL	R2	3
+      0x8C08010C,  //  0028  GETMET	R2	R0	K12
+      0x8810010D,  //  0029  GETMBR	R4	R0	K13
+      0x88140101,  //  002A  GETMBR	R5	R0	K1
+      0x7C080600,  //  002B  CALL	R2	3
+      0x80000000,  //  002C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: web_last_seen
 ********************************************************************/
 be_local_closure(Matter_HTTP_remote_web_last_seen,   /* name */
@@ -217,55 +496,232 @@ be_local_closure(Matter_HTTP_remote_web_last_seen,   /* name */
 
 
 /********************************************************************
-** Solidified function: dispatch_cb
+** Solidified function: event_http_failed
 ********************************************************************/
-be_local_closure(Matter_HTTP_remote_dispatch_cb,   /* name */
+be_local_closure(Matter_HTTP_remote_event_http_failed,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
+    5,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(async_cb_map),
-    /* K2   */  be_nested_str_weak(keys),
-    /* K3   */  be_nested_str_weak(current_cmd),
-    /* K4   */  be_nested_str_weak(stop_iteration),
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(current_cmd),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20failed),
+    /* K4   */  be_const_int(3),
+    /* K5   */  be_nested_str_weak(dispatch_cb),
+    /* K6   */  be_nested_str_weak(http_status),
     }),
-    be_str_weak(dispatch_cb),
+    be_str_weak(event_http_failed),
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x580C0000,  //  0000  LDCONST	R3	K0
-      0x60100010,  //  0001  GETGBL	R4	G16
-      0x88140101,  //  0002  GETMBR	R5	R0	K1
-      0x8C140B02,  //  0003  GETMET	R5	R5	K2
-      0x7C140200,  //  0004  CALL	R5	1
-      0x7C100200,  //  0005  CALL	R4	1
-      0xA802000F,  //  0006  EXBLK	0	#0017
-      0x5C140800,  //  0007  MOVE	R5	R4
-      0x7C140000,  //  0008  CALL	R5	0
-      0x88180101,  //  0009  GETMBR	R6	R0	K1
-      0x94180C05,  //  000A  GETIDX	R6	R6	R5
-      0x881C0103,  //  000B  GETMBR	R7	R0	K3
-      0x1C1C0C07,  //  000C  EQ	R7	R6	R7
-      0x741E0002,  //  000D  JMPT	R7	#0011
-      0x4C1C0000,  //  000E  LDNIL	R7
-      0x1C1C0C07,  //  000F  EQ	R7	R6	R7
-      0x781E0004,  //  0010  JMPF	R7	#0016
-      0x5C1C0A00,  //  0011  MOVE	R7	R5
-      0x5C200200,  //  0012  MOVE	R8	R1
-      0x5C240400,  //  0013  MOVE	R9	R2
-      0x88280103,  //  0014  GETMBR	R10	R0	K3
-      0x7C1C0600,  //  0015  CALL	R7	3
-      0x7001FFEF,  //  0016  JMP		#0007
-      0x58100004,  //  0017  LDCONST	R4	K4
-      0xAC100200,  //  0018  CATCH	R4	1	0
-      0xB0080000,  //  0019  RAISE	2	R0	R0
-      0x80000000,  //  001A  RET	0
+    ( &(const binstruction[15]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060000,  //  0003  JMPF	R1	#0005
+      0x80000200,  //  0004  RET	0
+      0xB8060200,  //  0005  GETNGBL	R1	K1
+      0x8C040302,  //  0006  GETMET	R1	R1	K2
+      0x580C0003,  //  0007  LDCONST	R3	K3
+      0x58100004,  //  0008  LDCONST	R4	K4
+      0x7C040600,  //  0009  CALL	R1	3
+      0x8C040105,  //  000A  GETMET	R1	R0	K5
+      0x880C0106,  //  000B  GETMBR	R3	R0	K6
+      0x4C100000,  //  000C  LDNIL	R4
+      0x7C040600,  //  000D  CALL	R1	3
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_status_response
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_parse_status_response,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(device_is_alive),
+    /* K2   */  be_nested_str_weak(json),
+    /* K3   */  be_nested_str_weak(load),
+    /* K4   */  be_nested_str_weak(contains),
+    /* K5   */  be_nested_str_weak(Status),
+    /* K6   */  be_nested_str_weak(StatusFWR),
+    /* K7   */  be_const_int(2),
+    /* K8   */  be_nested_str_weak(StatusNET),
+    /* K9   */  be_nested_str_weak(parse_update),
+    }),
+    be_str_weak(parse_status_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[39]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x20100204,  //  0001  NE	R4	R1	R4
+      0x78120022,  //  0002  JMPF	R4	#0026
+      0x24100300,  //  0003  GT	R4	R1	K0
+      0x78120020,  //  0004  JMPF	R4	#0026
+      0x8C100101,  //  0005  GETMET	R4	R0	K1
+      0x50180200,  //  0006  LDBOOL	R6	1	0
+      0x7C100400,  //  0007  CALL	R4	2
+      0xA4120400,  //  0008  IMPORT	R4	K2
+      0x8C140903,  //  0009  GETMET	R5	R4	K3
+      0x5C1C0400,  //  000A  MOVE	R7	R2
+      0x7C140400,  //  000B  CALL	R5	2
+      0x4C180000,  //  000C  LDNIL	R6
+      0x78160017,  //  000D  JMPF	R5	#0026
+      0x8C1C0B04,  //  000E  GETMET	R7	R5	K4
+      0x58240005,  //  000F  LDCONST	R9	K5
+      0x7C1C0400,  //  0010  CALL	R7	2
+      0x781E0002,  //  0011  JMPF	R7	#0015
+      0x94140B05,  //  0012  GETIDX	R5	R5	K5
+      0x58180000,  //  0013  LDCONST	R6	K0
+      0x7002000C,  //  0014  JMP		#0022
+      0x8C1C0B04,  //  0015  GETMET	R7	R5	K4
+      0x58240006,  //  0016  LDCONST	R9	K6
+      0x7C1C0400,  //  0017  CALL	R7	2
+      0x781E0002,  //  0018  JMPF	R7	#001C
+      0x94140B06,  //  0019  GETIDX	R5	R5	K6
+      0x58180007,  //  001A  LDCONST	R6	K7
+      0x70020005,  //  001B  JMP		#0022
+      0x8C1C0B04,  //  001C  GETMET	R7	R5	K4
+      0x58240008,  //  001D  LDCONST	R9	K8
+      0x7C1C0400,  //  001E  CALL	R7	2
+      0x781E0001,  //  001F  JMPF	R7	#0022
+      0x94140B08,  //  0020  GETIDX	R5	R5	K8
+      0x541A0004,  //  0021  LDINT	R6	5
+      0x8C1C0109,  //  0022  GETMET	R7	R0	K9
+      0x5C240A00,  //  0023  MOVE	R9	R5
+      0x5C280C00,  //  0024  MOVE	R10	R6
+      0x7C1C0600,  //  0025  CALL	R7	3
+      0x80000000,  //  0026  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_info
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_get_info,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(info),
+    }),
+    be_str_weak(get_info),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_http_timeout
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_event_http_timeout,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(current_cmd),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20timeout_X20http_status_X3D_X25i_X20phase_X3D_X25i_X20tcp_status_X3D_X25i_X20size_payload_X3D_X25i),
+    /* K4   */  be_nested_str_weak(http_status),
+    /* K5   */  be_nested_str_weak(phase),
+    /* K6   */  be_nested_str_weak(status),
+    /* K7   */  be_nested_str_weak(payload),
+    /* K8   */  be_const_int(3),
+    /* K9   */  be_nested_str_weak(dispatch_cb),
+    }),
+    be_str_weak(event_http_timeout),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060000,  //  0003  JMPF	R1	#0005
+      0x80000200,  //  0004  RET	0
+      0xB8060200,  //  0005  GETNGBL	R1	K1
+      0x8C040302,  //  0006  GETMET	R1	R1	K2
+      0x600C0018,  //  0007  GETGBL	R3	G24
+      0x58100003,  //  0008  LDCONST	R4	K3
+      0x88140104,  //  0009  GETMBR	R5	R0	K4
+      0x88180105,  //  000A  GETMBR	R6	R0	K5
+      0x881C0106,  //  000B  GETMBR	R7	R0	K6
+      0x6020000C,  //  000C  GETGBL	R8	G12
+      0x88240107,  //  000D  GETMBR	R9	R0	K7
+      0x7C200200,  //  000E  CALL	R8	1
+      0x7C0C0A00,  //  000F  CALL	R3	5
+      0x58100008,  //  0010  LDCONST	R4	K8
+      0x7C040600,  //  0011  CALL	R1	3
+      0x8C040109,  //  0012  GETMET	R1	R0	K9
+      0x880C0104,  //  0013  GETMBR	R3	R0	K4
+      0x4C100000,  //  0014  LDNIL	R4
+      0x7C040600,  //  0015  CALL	R1	3
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: info_changed
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_info_changed,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(save_param),
+    }),
+    be_str_weak(info_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
     })
   )
 );
@@ -373,82 +829,54 @@ be_local_closure(Matter_HTTP_remote_scheduler,   /* name */
 
 
 /********************************************************************
-** Solidified function: event_http_finished
+** Solidified function: add_schedule
 ********************************************************************/
-be_local_closure(Matter_HTTP_remote_event_http_finished,   /* name */
+be_local_closure(Matter_HTTP_remote_add_schedule,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
+    8,                          /* nstack */
+    4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(current_cmd),
-    /* K1   */  be_nested_str_weak(payload),
-    /* K2   */  be_nested_str_weak(nil),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(_X2E_X2E_X2E),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20async_X2Dresp_X20in_X20_X25i_X20ms_X20from_X20_X25s_X3A_X20_X5B_X25i_X5D_X20_X27_X25s_X27),
-    /* K8   */  be_nested_str_weak(millis),
-    /* K9   */  be_nested_str_weak(time_start),
-    /* K10  */  be_nested_str_weak(addr),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(dispatch_cb),
-    /* K13  */  be_nested_str_weak(http_status),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(probe_update_time_map),
+    /* K1   */  be_nested_str_weak(contains),
+    /* K2   */  be_nested_str_weak(probe_next_timestamp_map),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(jitter),
+    /* K5   */  be_nested_str_weak(add_async_cb),
     }),
-    be_str_weak(event_http_finished),
+    be_str_weak(add_schedule),
     &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x78060000,  //  0003  JMPF	R1	#0005
-      0x80000200,  //  0004  RET	0
-      0x88040101,  //  0005  GETMBR	R1	R0	K1
-      0x4C080000,  //  0006  LDNIL	R2
-      0x20040202,  //  0007  NE	R1	R1	R2
-      0x78060001,  //  0008  JMPF	R1	#000B
-      0x88040101,  //  0009  GETMBR	R1	R0	K1
-      0x70020000,  //  000A  JMP		#000C
-      0x58040002,  //  000B  LDCONST	R1	K2
-      0x6008000C,  //  000C  GETGBL	R2	G12
-      0x5C0C0200,  //  000D  MOVE	R3	R1
-      0x7C080200,  //  000E  CALL	R2	1
-      0x540E001D,  //  000F  LDINT	R3	30
-      0x24080403,  //  0010  GT	R2	R2	R3
-      0x780A0004,  //  0011  JMPF	R2	#0017
-      0x540A001C,  //  0012  LDINT	R2	29
-      0x400A0602,  //  0013  CONNECT	R2	K3	R2
-      0x94080202,  //  0014  GETIDX	R2	R1	R2
-      0x00080504,  //  0015  ADD	R2	R2	K4
-      0x5C040400,  //  0016  MOVE	R1	R2
-      0xB80A0A00,  //  0017  GETNGBL	R2	K5
-      0x8C080506,  //  0018  GETMET	R2	R2	K6
-      0x60100018,  //  0019  GETGBL	R4	G24
-      0x58140007,  //  001A  LDCONST	R5	K7
-      0xB81A0A00,  //  001B  GETNGBL	R6	K5
-      0x8C180D08,  //  001C  GETMET	R6	R6	K8
-      0x7C180200,  //  001D  CALL	R6	1
-      0x881C0109,  //  001E  GETMBR	R7	R0	K9
-      0x04180C07,  //  001F  SUB	R6	R6	R7
-      0x881C010A,  //  0020  GETMBR	R7	R0	K10
-      0x6020000C,  //  0021  GETGBL	R8	G12
-      0x88240101,  //  0022  GETMBR	R9	R0	K1
-      0x7C200200,  //  0023  CALL	R8	1
-      0x5C240200,  //  0024  MOVE	R9	R1
-      0x7C100A00,  //  0025  CALL	R4	5
-      0x5814000B,  //  0026  LDCONST	R5	K11
-      0x7C080600,  //  0027  CALL	R2	3
-      0x8C08010C,  //  0028  GETMET	R2	R0	K12
-      0x8810010D,  //  0029  GETMBR	R4	R0	K13
-      0x88140101,  //  002A  GETMBR	R5	R0	K1
-      0x7C080600,  //  002B  CALL	R2	3
-      0x80000000,  //  002C  RET	0
+    ( &(const binstruction[25]) {  /* code */
+      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x8C100901,  //  0001  GETMET	R4	R4	K1
+      0x5C180200,  //  0002  MOVE	R6	R1
+      0x7C100400,  //  0003  CALL	R4	2
+      0x78120003,  //  0004  JMPF	R4	#0009
+      0x88100100,  //  0005  GETMBR	R4	R0	K0
+      0x94100801,  //  0006  GETIDX	R4	R4	R1
+      0x14100404,  //  0007  LT	R4	R2	R4
+      0x78120007,  //  0008  JMPF	R4	#0011
+      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0x98100202,  //  000A  SETIDX	R4	R1	R2
+      0x88100102,  //  000B  GETMBR	R4	R0	K2
+      0xB8160600,  //  000C  GETNGBL	R5	K3
+      0x8C140B04,  //  000D  GETMET	R5	R5	K4
+      0x5C1C0400,  //  000E  MOVE	R7	R2
+      0x7C140400,  //  000F  CALL	R5	2
+      0x98100205,  //  0010  SETIDX	R4	R1	R5
+      0x4C100000,  //  0011  LDNIL	R4
+      0x20100604,  //  0012  NE	R4	R3	R4
+      0x78120003,  //  0013  JMPF	R4	#0018
+      0x8C100105,  //  0014  GETMET	R4	R0	K5
+      0x5C180600,  //  0015  MOVE	R6	R3
+      0x5C1C0200,  //  0016  MOVE	R7	R1
+      0x7C100600,  //  0017  CALL	R4	3
+      0x80000000,  //  0018  RET	0
     })
   )
 );
@@ -532,162 +960,6 @@ be_local_closure(Matter_HTTP_remote_probe_async,   /* name */
 
 
 /********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_HTTP_remote_init,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(probe_update_time_map),
-    /* K1   */  be_nested_str_weak(probe_next_timestamp_map),
-    /* K2   */  be_nested_str_weak(async_cb_map),
-    /* K3   */  be_nested_str_weak(current_cmd),
-    /* K4   */  be_nested_str_weak(reachable),
-    /* K5   */  be_nested_str_weak(init),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x60100013,  //  0000  GETGBL	R4	G19
-      0x7C100000,  //  0001  CALL	R4	0
-      0x90020004,  //  0002  SETMBR	R0	K0	R4
-      0x60100013,  //  0003  GETGBL	R4	G19
-      0x7C100000,  //  0004  CALL	R4	0
-      0x90020204,  //  0005  SETMBR	R0	K1	R4
-      0x60100013,  //  0006  GETGBL	R4	G19
-      0x7C100000,  //  0007  CALL	R4	0
-      0x90020404,  //  0008  SETMBR	R0	K2	R4
-      0x4C100000,  //  0009  LDNIL	R4
-      0x90020604,  //  000A  SETMBR	R0	K3	R4
-      0x50100000,  //  000B  LDBOOL	R4	0	0
-      0x90020804,  //  000C  SETMBR	R0	K4	R4
-      0x60100003,  //  000D  GETGBL	R4	G3
-      0x5C140000,  //  000E  MOVE	R5	R0
-      0x7C100200,  //  000F  CALL	R4	1
-      0x8C100905,  //  0010  GETMET	R4	R4	K5
-      0x5C180200,  //  0011  MOVE	R6	R1
-      0x541E004F,  //  0012  LDINT	R7	80
-      0x5C200400,  //  0013  MOVE	R8	R2
-      0x5C240600,  //  0014  MOVE	R9	R3
-      0x7C100A00,  //  0015  CALL	R4	5
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: event_http_failed
-********************************************************************/
-be_local_closure(Matter_HTTP_remote_event_http_failed,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(current_cmd),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20failed),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(dispatch_cb),
-    /* K6   */  be_nested_str_weak(http_status),
-    }),
-    be_str_weak(event_http_failed),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x78060000,  //  0003  JMPF	R1	#0005
-      0x80000200,  //  0004  RET	0
-      0xB8060200,  //  0005  GETNGBL	R1	K1
-      0x8C040302,  //  0006  GETMET	R1	R1	K2
-      0x580C0003,  //  0007  LDCONST	R3	K3
-      0x58100004,  //  0008  LDCONST	R4	K4
-      0x7C040600,  //  0009  CALL	R1	3
-      0x8C040105,  //  000A  GETMET	R1	R0	K5
-      0x880C0106,  //  000B  GETMBR	R3	R0	K6
-      0x4C100000,  //  000C  LDNIL	R4
-      0x7C040600,  //  000D  CALL	R1	3
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: event_http_timeout
-********************************************************************/
-be_local_closure(Matter_HTTP_remote_event_http_timeout,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(current_cmd),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20timeout_X20http_status_X3D_X25i_X20phase_X3D_X25i_X20tcp_status_X3D_X25i_X20size_payload_X3D_X25i),
-    /* K4   */  be_nested_str_weak(http_status),
-    /* K5   */  be_nested_str_weak(phase),
-    /* K6   */  be_nested_str_weak(status),
-    /* K7   */  be_nested_str_weak(payload),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str_weak(dispatch_cb),
-    }),
-    be_str_weak(event_http_timeout),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x78060000,  //  0003  JMPF	R1	#0005
-      0x80000200,  //  0004  RET	0
-      0xB8060200,  //  0005  GETNGBL	R1	K1
-      0x8C040302,  //  0006  GETMET	R1	R1	K2
-      0x600C0018,  //  0007  GETGBL	R3	G24
-      0x58100003,  //  0008  LDCONST	R4	K3
-      0x88140104,  //  0009  GETMBR	R5	R0	K4
-      0x88180105,  //  000A  GETMBR	R6	R0	K5
-      0x881C0106,  //  000B  GETMBR	R7	R0	K6
-      0x6020000C,  //  000C  GETGBL	R8	G12
-      0x88240107,  //  000D  GETMBR	R9	R0	K7
-      0x7C200200,  //  000E  CALL	R8	1
-      0x7C0C0A00,  //  000F  CALL	R3	5
-      0x58100008,  //  0010  LDCONST	R4	K8
-      0x7C040600,  //  0011  CALL	R1	3
-      0x8C040109,  //  0012  GETMET	R1	R0	K9
-      0x880C0104,  //  0013  GETMBR	R3	R0	K4
-      0x4C100000,  //  0014  LDNIL	R4
-      0x7C040600,  //  0015  CALL	R1	3
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: add_async_cb
 ********************************************************************/
 be_local_closure(Matter_HTTP_remote_add_async_cb,   /* name */
@@ -716,54 +988,286 @@ be_local_closure(Matter_HTTP_remote_add_async_cb,   /* name */
 
 
 /********************************************************************
-** Solidified function: add_schedule
+** Solidified function: set_info
 ********************************************************************/
-be_local_closure(Matter_HTTP_remote_add_schedule,   /* name */
+be_local_closure(Matter_HTTP_remote_set_info,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    4,                          /* argc */
+    2,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(info),
+    }),
+    be_str_weak(set_info),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: dispatch_cb
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_dispatch_cb,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(async_cb_map),
+    /* K2   */  be_nested_str_weak(keys),
+    /* K3   */  be_nested_str_weak(current_cmd),
+    /* K4   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(dispatch_cb),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x580C0000,  //  0000  LDCONST	R3	K0
+      0x60100010,  //  0001  GETGBL	R4	G16
+      0x88140101,  //  0002  GETMBR	R5	R0	K1
+      0x8C140B02,  //  0003  GETMET	R5	R5	K2
+      0x7C140200,  //  0004  CALL	R5	1
+      0x7C100200,  //  0005  CALL	R4	1
+      0xA802000F,  //  0006  EXBLK	0	#0017
+      0x5C140800,  //  0007  MOVE	R5	R4
+      0x7C140000,  //  0008  CALL	R5	0
+      0x88180101,  //  0009  GETMBR	R6	R0	K1
+      0x94180C05,  //  000A  GETIDX	R6	R6	R5
+      0x881C0103,  //  000B  GETMBR	R7	R0	K3
+      0x1C1C0C07,  //  000C  EQ	R7	R6	R7
+      0x741E0002,  //  000D  JMPT	R7	#0011
+      0x4C1C0000,  //  000E  LDNIL	R7
+      0x1C1C0C07,  //  000F  EQ	R7	R6	R7
+      0x781E0004,  //  0010  JMPF	R7	#0016
+      0x5C1C0A00,  //  0011  MOVE	R7	R5
+      0x5C200200,  //  0012  MOVE	R8	R1
+      0x5C240400,  //  0013  MOVE	R9	R2
+      0x88280103,  //  0014  GETMBR	R10	R0	K3
+      0x7C1C0600,  //  0015  CALL	R7	3
+      0x7001FFEF,  //  0016  JMP		#0007
+      0x58100004,  //  0017  LDCONST	R4	K4
+      0xAC100200,  //  0018  CATCH	R4	1	0
+      0xB0080000,  //  0019  RAISE	2	R0	R0
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: change_schedule
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_change_schedule,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(probe_update_time_map),
     /* K1   */  be_nested_str_weak(contains),
     /* K2   */  be_nested_str_weak(probe_next_timestamp_map),
     /* K3   */  be_nested_str_weak(matter),
     /* K4   */  be_nested_str_weak(jitter),
-    /* K5   */  be_nested_str_weak(add_async_cb),
     }),
-    be_str_weak(add_schedule),
+    be_str_weak(change_schedule),
     &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
-      0x8C100901,  //  0001  GETMET	R4	R4	K1
-      0x5C180200,  //  0002  MOVE	R6	R1
-      0x7C100400,  //  0003  CALL	R4	2
-      0x78120003,  //  0004  JMPF	R4	#0009
-      0x88100100,  //  0005  GETMBR	R4	R0	K0
-      0x94100801,  //  0006  GETIDX	R4	R4	R1
-      0x14100404,  //  0007  LT	R4	R2	R4
-      0x78120007,  //  0008  JMPF	R4	#0011
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
-      0x98100202,  //  000A  SETIDX	R4	R1	R2
-      0x88100102,  //  000B  GETMBR	R4	R0	K2
-      0xB8160600,  //  000C  GETNGBL	R5	K3
-      0x8C140B04,  //  000D  GETMET	R5	R5	K4
-      0x5C1C0400,  //  000E  MOVE	R7	R2
-      0x7C140400,  //  000F  CALL	R5	2
-      0x98100205,  //  0010  SETIDX	R4	R1	R5
-      0x4C100000,  //  0011  LDNIL	R4
-      0x20100604,  //  0012  NE	R4	R3	R4
-      0x78120003,  //  0013  JMPF	R4	#0018
-      0x8C100105,  //  0014  GETMET	R4	R0	K5
-      0x5C180600,  //  0015  MOVE	R6	R3
-      0x5C1C0200,  //  0016  MOVE	R7	R1
-      0x7C100600,  //  0017  CALL	R4	3
-      0x80000000,  //  0018  RET	0
+    ( &(const binstruction[14]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x780E0007,  //  0004  JMPF	R3	#000D
+      0x880C0100,  //  0005  GETMBR	R3	R0	K0
+      0x980C0202,  //  0006  SETIDX	R3	R1	R2
+      0x880C0102,  //  0007  GETMBR	R3	R0	K2
+      0xB8120600,  //  0008  GETNGBL	R4	K3
+      0x8C100904,  //  0009  GETMET	R4	R4	K4
+      0x5C180400,  //  000A  MOVE	R6	R2
+      0x7C100400,  //  000B  CALL	R4	2
+      0x980C0204,  //  000C  SETIDX	R3	R1	R4
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_HTTP_remote_init,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 3]) {
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(parse_status_response),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(parse_status_response),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(parse_status_response),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(probe_update_time_map),
+    /* K2   */  be_nested_str_weak(probe_next_timestamp_map),
+    /* K3   */  be_nested_str_weak(async_cb_map),
+    /* K4   */  be_nested_str_weak(current_cmd),
+    /* K5   */  be_nested_str_weak(reachable),
+    /* K6   */  be_nested_str_weak(init),
+    /* K7   */  be_nested_str_weak(info),
+    /* K8   */  be_nested_str_weak(add_schedule),
+    /* K9   */  be_nested_str_weak(UPDATE_CMD0),
+    /* K10  */  be_nested_str_weak(UPDATE_TIME),
+    /* K11  */  be_nested_str_weak(UPDATE_CMD2),
+    /* K12  */  be_nested_str_weak(UPDATE_CMD5),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[45]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x60140013,  //  0001  GETGBL	R5	G19
+      0x7C140000,  //  0002  CALL	R5	0
+      0x90020205,  //  0003  SETMBR	R0	K1	R5
+      0x60140013,  //  0004  GETGBL	R5	G19
+      0x7C140000,  //  0005  CALL	R5	0
+      0x90020405,  //  0006  SETMBR	R0	K2	R5
+      0x60140013,  //  0007  GETGBL	R5	G19
+      0x7C140000,  //  0008  CALL	R5	0
+      0x90020605,  //  0009  SETMBR	R0	K3	R5
+      0x4C140000,  //  000A  LDNIL	R5
+      0x90020805,  //  000B  SETMBR	R0	K4	R5
+      0x50140000,  //  000C  LDBOOL	R5	0	0
+      0x90020A05,  //  000D  SETMBR	R0	K5	R5
+      0x60140003,  //  000E  GETGBL	R5	G3
+      0x5C180000,  //  000F  MOVE	R6	R0
+      0x7C140200,  //  0010  CALL	R5	1
+      0x8C140B06,  //  0011  GETMET	R5	R5	K6
+      0x5C1C0400,  //  0012  MOVE	R7	R2
+      0x5422004F,  //  0013  LDINT	R8	80
+      0x5C240600,  //  0014  MOVE	R9	R3
+      0x5C280800,  //  0015  MOVE	R10	R4
+      0x7C140A00,  //  0016  CALL	R5	5
+      0x60140013,  //  0017  GETGBL	R5	G19
+      0x7C140000,  //  0018  CALL	R5	0
+      0x90020E05,  //  0019  SETMBR	R0	K7	R5
+      0x88140100,  //  001A  GETMBR	R5	R0	K0
+      0x7816000E,  //  001B  JMPF	R5	#002B
+      0x8C140108,  //  001C  GETMET	R5	R0	K8
+      0x881C0109,  //  001D  GETMBR	R7	R0	K9
+      0x8820010A,  //  001E  GETMBR	R8	R0	K10
+      0x84240000,  //  001F  CLOSURE	R9	P0
+      0x7C140800,  //  0020  CALL	R5	4
+      0x8C140108,  //  0021  GETMET	R5	R0	K8
+      0x881C010B,  //  0022  GETMBR	R7	R0	K11
+      0x8820010A,  //  0023  GETMBR	R8	R0	K10
+      0x84240001,  //  0024  CLOSURE	R9	P1
+      0x7C140800,  //  0025  CALL	R5	4
+      0x8C140108,  //  0026  GETMET	R5	R0	K8
+      0x881C010C,  //  0027  GETMBR	R7	R0	K12
+      0x8820010A,  //  0028  GETMBR	R8	R0	K10
+      0x84240002,  //  0029  CLOSURE	R9	P2
+      0x7C140800,  //  002A  CALL	R5	4
+      0xA0000000,  //  002B  CLOSE	R0
+      0x80000000,  //  002C  RET	0
     })
   )
 );
@@ -775,28 +1279,41 @@ be_local_closure(Matter_HTTP_remote_add_schedule,   /* name */
 ********************************************************************/
 extern const bclass be_class_Matter_HTTP_async;
 be_local_class(Matter_HTTP_remote,
-    6,
+    8,
     &be_class_Matter_HTTP_async,
-    be_nested_map(18,
+    be_nested_map(31,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(device_is_alive, 4), be_const_closure(Matter_HTTP_remote_device_is_alive_closure) },
-        { be_const_key_weak(current_cmd, -1), be_const_var(3) },
-        { be_const_key_weak(reachable, -1), be_const_var(4) },
-        { be_const_key_weak(probe_next_timestamp_map, -1), be_const_var(1) },
-        { be_const_key_weak(web_last_seen, -1), be_const_closure(Matter_HTTP_remote_web_last_seen_closure) },
-        { be_const_key_weak(dispatch_cb, -1), be_const_closure(Matter_HTTP_remote_dispatch_cb_closure) },
-        { be_const_key_weak(async_cb_map, -1), be_const_var(2) },
-        { be_const_key_weak(add_async_cb, -1), be_const_closure(Matter_HTTP_remote_add_async_cb_closure) },
-        { be_const_key_weak(probe_update_time_map, 11), be_const_var(0) },
-        { be_const_key_weak(event_http_finished, -1), be_const_closure(Matter_HTTP_remote_event_http_finished_closure) },
-        { be_const_key_weak(probe_async, -1), be_const_closure(Matter_HTTP_remote_probe_async_closure) },
-        { be_const_key_weak(scheduler, -1), be_const_closure(Matter_HTTP_remote_scheduler_closure) },
-        { be_const_key_weak(event_http_failed, -1), be_const_closure(Matter_HTTP_remote_event_http_failed_closure) },
-        { be_const_key_weak(reachable_utc, -1), be_const_var(5) },
+        { be_const_key_weak(device_is_alive, -1), be_const_closure(Matter_HTTP_remote_device_is_alive_closure) },
+        { be_const_key_weak(reachable, 21), be_const_var(5) },
+        { be_const_key_weak(parse_update, -1), be_const_closure(Matter_HTTP_remote_parse_update_closure) },
+        { be_const_key_weak(UPDATE_TIME, 7), be_const_int(5000) },
+        { be_const_key_weak(web_last_seen, 30), be_const_closure(Matter_HTTP_remote_web_last_seen_closure) },
+        { be_const_key_weak(call_sync, 4), be_const_closure(Matter_HTTP_remote_call_sync_closure) },
+        { be_const_key_weak(change_schedule, 19), be_const_closure(Matter_HTTP_remote_change_schedule_closure) },
+        { be_const_key_weak(device, -1), be_const_var(0) },
+        { be_const_key_weak(UPDATE_CMD5, -1), be_nested_str_weak(Status_X205) },
+        { be_const_key_weak(get_info, 17), be_const_closure(Matter_HTTP_remote_get_info_closure) },
+        { be_const_key_weak(info, -1), be_const_var(7) },
         { be_const_key_weak(event_http_timeout, -1), be_const_closure(Matter_HTTP_remote_event_http_timeout_closure) },
-        { be_const_key_weak(init, 7), be_const_closure(Matter_HTTP_remote_init_closure) },
+        { be_const_key_weak(info_changed, -1), be_const_closure(Matter_HTTP_remote_info_changed_closure) },
         { be_const_key_weak(add_schedule, -1), be_const_closure(Matter_HTTP_remote_add_schedule_closure) },
-        { be_const_key_weak(call_sync, 3), be_const_closure(Matter_HTTP_remote_call_sync_closure) },
+        { be_const_key_weak(UPDATE_TIME2, -1), be_const_int(300000) },
+        { be_const_key_weak(scheduler, -1), be_const_closure(Matter_HTTP_remote_scheduler_closure) },
+        { be_const_key_weak(parse_status_response, 13), be_const_closure(Matter_HTTP_remote_parse_status_response_closure) },
+        { be_const_key_weak(probe_async, 18), be_const_closure(Matter_HTTP_remote_probe_async_closure) },
+        { be_const_key_weak(probe_update_time_map, -1), be_const_var(1) },
+        { be_const_key_weak(reachable_utc, -1), be_const_var(6) },
+        { be_const_key_weak(probe_next_timestamp_map, -1), be_const_var(2) },
+        { be_const_key_weak(async_cb_map, -1), be_const_var(3) },
+        { be_const_key_weak(current_cmd, -1), be_const_var(4) },
+        { be_const_key_weak(set_info, -1), be_const_closure(Matter_HTTP_remote_set_info_closure) },
+        { be_const_key_weak(dispatch_cb, -1), be_const_closure(Matter_HTTP_remote_dispatch_cb_closure) },
+        { be_const_key_weak(UPDATE_CMD2, -1), be_nested_str_weak(Status_X202) },
+        { be_const_key_weak(UPDATE_CMD0, -1), be_nested_str_weak(Status) },
+        { be_const_key_weak(event_http_failed, 3), be_const_closure(Matter_HTTP_remote_event_http_failed_closure) },
+        { be_const_key_weak(add_async_cb, 6), be_const_closure(Matter_HTTP_remote_add_async_cb_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_HTTP_remote_init_closure) },
+        { be_const_key_weak(event_http_finished, -1), be_const_closure(Matter_HTTP_remote_event_http_finished_closure) },
     })),
     be_str_weak(Matter_HTTP_remote)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -1976,8 +1976,8 @@ be_local_closure(Matter_IM_process_status_response,   /* name */
     /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3EOK_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i_X20not_X20found),
     /* K10  */  be_nested_str_weak(session),
     /* K11  */  be_nested_str_weak(local_session_id),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
+    /* K13  */  be_const_int(3),
     /* K14  */  be_nested_str_weak(status_error_received),
     /* K15  */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
     }),
@@ -2009,16 +2009,16 @@ be_local_closure(Matter_IM_process_status_response,   /* name */
       0x8824130B,  //  0016  GETMBR	R9	R9	K11
       0x88280303,  //  0017  GETMBR	R10	R1	K3
       0x7C1C0600,  //  0018  CALL	R7	3
-      0x5820000C,  //  0019  LDCONST	R8	K12
+      0x54220003,  //  0019  LDINT	R8	4
       0x7C140600,  //  001A  CALL	R5	3
       0x7002000E,  //  001B  JMP		#002B
       0xB8160E00,  //  001C  GETNGBL	R5	K7
       0x8C140B08,  //  001D  GETMET	R5	R5	K8
       0x601C0018,  //  001E  GETGBL	R7	G24
-      0x5820000D,  //  001F  LDCONST	R8	K13
+      0x5820000C,  //  001F  LDCONST	R8	K12
       0x5C240600,  //  0020  MOVE	R9	R3
       0x7C1C0400,  //  0021  CALL	R7	2
-      0x5820000C,  //  0022  LDCONST	R8	K12
+      0x5820000D,  //  0022  LDCONST	R8	K13
       0x7C140600,  //  0023  CALL	R5	3
       0x78120005,  //  0024  JMPF	R4	#002B
       0x8C14090E,  //  0025  GETMET	R5	R4	K14

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
@@ -724,7 +724,7 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
+    ( &(const bvalue[20]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
@@ -744,10 +744,11 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
     /* K16  */  be_const_int(3),
     /* K17  */  be_nested_str_weak(create_TLV),
     /* K18  */  be_nested_str_weak(BOOL),
+    /* K19  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[104]) {  /* code */
+    ( &(const binstruction[113]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x880C0701,  //  0001  GETMBR	R3	R3	K1
       0x88100502,  //  0002  GETMBR	R4	R2	K2
@@ -836,22 +837,31 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
       0x5824000B,  //  0055  LDCONST	R9	K11
       0x7C180600,  //  0056  CALL	R6	3
       0x80040C00,  //  0057  RET	1	R6
-      0x7002000D,  //  0058  JMP		#0067
+      0x70020016,  //  0058  JMP		#0070
       0x541A0038,  //  0059  LDINT	R6	57
       0x1C180806,  //  005A  EQ	R6	R4	R6
-      0x781A0008,  //  005B  JMPF	R6	#0065
+      0x781A0011,  //  005B  JMPF	R6	#006E
       0x541A0010,  //  005C  LDINT	R6	17
       0x1C180A06,  //  005D  EQ	R6	R5	R6
-      0x781A0004,  //  005E  JMPF	R6	#0064
+      0x781A0005,  //  005E  JMPF	R6	#0065
       0x8C180711,  //  005F  GETMET	R6	R3	K17
       0x88200712,  //  0060  GETMBR	R8	R3	K18
       0x5824000B,  //  0061  LDCONST	R9	K11
       0x7C180600,  //  0062  CALL	R6	3
       0x80040C00,  //  0063  RET	1	R6
-      0x70020001,  //  0064  JMP		#0067
-      0x4C180000,  //  0065  LDNIL	R6
-      0x80040C00,  //  0066  RET	1	R6
-      0x80000000,  //  0067  RET	0
+      0x70020007,  //  0064  JMP		#006D
+      0x60180003,  //  0065  GETGBL	R6	G3
+      0x5C1C0000,  //  0066  MOVE	R7	R0
+      0x7C180200,  //  0067  CALL	R6	1
+      0x8C180D13,  //  0068  GETMET	R6	R6	K19
+      0x5C200200,  //  0069  MOVE	R8	R1
+      0x5C240400,  //  006A  MOVE	R9	R2
+      0x7C180600,  //  006B  CALL	R6	3
+      0x80040C00,  //  006C  RET	1	R6
+      0x70020001,  //  006D  JMP		#0070
+      0x4C180000,  //  006E  LDNIL	R6
+      0x80040C00,  //  006F  RET	1	R6
+      0x80000000,  //  0070  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_HTTP.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_HTTP.h
@@ -567,7 +567,7 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_web_values_prefix,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_HTTP_read_attribute,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    13,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -575,55 +575,145 @@ be_local_closure(Matter_Plugin_Bridge_HTTP_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[21]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(attribute),
-    /* K4   */  be_nested_str_weak(create_TLV),
-    /* K5   */  be_nested_str_weak(BOOL),
+    /* K4   */  be_nested_str_weak(string),
+    /* K5   */  be_const_int(3),
     /* K6   */  be_nested_str_weak(http_remote),
-    /* K7   */  be_nested_str_weak(reachable),
-    /* K8   */  be_nested_str_weak(read_attribute),
+    /* K7   */  be_nested_str_weak(get_info),
+    /* K8   */  be_nested_str_weak(find),
+    /* K9   */  be_nested_str_weak(name),
+    /* K10  */  be_nested_str_weak(create_TLV),
+    /* K11  */  be_nested_str_weak(UTF1),
+    /* K12  */  be_nested_str_weak(NULL),
+    /* K13  */  be_nested_str_weak(version),
+    /* K14  */  be_nested_str_weak(_X28),
+    /* K15  */  be_const_int(0),
+    /* K16  */  be_const_int(1),
+    /* K17  */  be_nested_str_weak(mac),
+    /* K18  */  be_nested_str_weak(BOOL),
+    /* K19  */  be_nested_str_weak(reachable),
+    /* K20  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
+    ( &(const binstruction[113]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x880C0701,  //  0001  GETMBR	R3	R3	K1
       0x88100502,  //  0002  GETMBR	R4	R2	K2
       0x88140503,  //  0003  GETMBR	R5	R2	K3
       0x541A0038,  //  0004  LDINT	R6	57
       0x1C180806,  //  0005  EQ	R6	R4	R6
-      0x781A0012,  //  0006  JMPF	R6	#001A
-      0x541A0010,  //  0007  LDINT	R6	17
-      0x1C180A06,  //  0008  EQ	R6	R5	R6
-      0x781A0006,  //  0009  JMPF	R6	#0011
-      0x8C180704,  //  000A  GETMET	R6	R3	K4
-      0x88200705,  //  000B  GETMBR	R8	R3	K5
-      0x88240106,  //  000C  GETMBR	R9	R0	K6
-      0x88241307,  //  000D  GETMBR	R9	R9	K7
-      0x7C180600,  //  000E  CALL	R6	3
-      0x80040C00,  //  000F  RET	1	R6
-      0x70020007,  //  0010  JMP		#0019
-      0x60180003,  //  0011  GETGBL	R6	G3
-      0x5C1C0000,  //  0012  MOVE	R7	R0
-      0x7C180200,  //  0013  CALL	R6	1
-      0x8C180D08,  //  0014  GETMET	R6	R6	K8
-      0x5C200200,  //  0015  MOVE	R8	R1
-      0x5C240400,  //  0016  MOVE	R9	R2
-      0x7C180600,  //  0017  CALL	R6	3
-      0x80040C00,  //  0018  RET	1	R6
-      0x70020007,  //  0019  JMP		#0022
-      0x60180003,  //  001A  GETGBL	R6	G3
-      0x5C1C0000,  //  001B  MOVE	R7	R0
-      0x7C180200,  //  001C  CALL	R6	1
-      0x8C180D08,  //  001D  GETMET	R6	R6	K8
-      0x5C200200,  //  001E  MOVE	R8	R1
-      0x5C240400,  //  001F  MOVE	R9	R2
-      0x7C180600,  //  0020  CALL	R6	3
-      0x80040C00,  //  0021  RET	1	R6
-      0x80000000,  //  0022  RET	0
+      0x781A0060,  //  0006  JMPF	R6	#0068
+      0xA41A0800,  //  0007  IMPORT	R6	K4
+      0x1C1C0B05,  //  0008  EQ	R7	R5	K5
+      0x781E0012,  //  0009  JMPF	R7	#001D
+      0x881C0106,  //  000A  GETMBR	R7	R0	K6
+      0x8C1C0F07,  //  000B  GETMET	R7	R7	K7
+      0x7C1C0200,  //  000C  CALL	R7	1
+      0x8C1C0F08,  //  000D  GETMET	R7	R7	K8
+      0x58240009,  //  000E  LDCONST	R9	K9
+      0x7C1C0400,  //  000F  CALL	R7	2
+      0x781E0005,  //  0010  JMPF	R7	#0017
+      0x8C20070A,  //  0011  GETMET	R8	R3	K10
+      0x8828070B,  //  0012  GETMBR	R10	R3	K11
+      0x5C2C0E00,  //  0013  MOVE	R11	R7
+      0x7C200600,  //  0014  CALL	R8	3
+      0x80041000,  //  0015  RET	1	R8
+      0x70020004,  //  0016  JMP		#001C
+      0x8C20070A,  //  0017  GETMET	R8	R3	K10
+      0x8828070C,  //  0018  GETMBR	R10	R3	K12
+      0x4C2C0000,  //  0019  LDNIL	R11
+      0x7C200600,  //  001A  CALL	R8	3
+      0x80041000,  //  001B  RET	1	R8
+      0x70020049,  //  001C  JMP		#0067
+      0x541E0009,  //  001D  LDINT	R7	10
+      0x1C1C0A07,  //  001E  EQ	R7	R5	R7
+      0x781E001B,  //  001F  JMPF	R7	#003C
+      0x881C0106,  //  0020  GETMBR	R7	R0	K6
+      0x8C1C0F07,  //  0021  GETMET	R7	R7	K7
+      0x7C1C0200,  //  0022  CALL	R7	1
+      0x8C1C0F08,  //  0023  GETMET	R7	R7	K8
+      0x5824000D,  //  0024  LDCONST	R9	K13
+      0x7C1C0400,  //  0025  CALL	R7	2
+      0x781E000E,  //  0026  JMPF	R7	#0036
+      0x8C200D08,  //  0027  GETMET	R8	R6	K8
+      0x5C280E00,  //  0028  MOVE	R10	R7
+      0x582C000E,  //  0029  LDCONST	R11	K14
+      0x7C200600,  //  002A  CALL	R8	3
+      0x2424110F,  //  002B  GT	R9	R8	K15
+      0x78260002,  //  002C  JMPF	R9	#0030
+      0x04241110,  //  002D  SUB	R9	R8	K16
+      0x40261E09,  //  002E  CONNECT	R9	K15	R9
+      0x941C0E09,  //  002F  GETIDX	R7	R7	R9
+      0x8C24070A,  //  0030  GETMET	R9	R3	K10
+      0x882C070B,  //  0031  GETMBR	R11	R3	K11
+      0x5C300E00,  //  0032  MOVE	R12	R7
+      0x7C240600,  //  0033  CALL	R9	3
+      0x80041200,  //  0034  RET	1	R9
+      0x70020004,  //  0035  JMP		#003B
+      0x8C20070A,  //  0036  GETMET	R8	R3	K10
+      0x8828070C,  //  0037  GETMBR	R10	R3	K12
+      0x4C2C0000,  //  0038  LDNIL	R11
+      0x7C200600,  //  0039  CALL	R8	3
+      0x80041000,  //  003A  RET	1	R8
+      0x7002002A,  //  003B  JMP		#0067
+      0x541E000E,  //  003C  LDINT	R7	15
+      0x1C1C0A07,  //  003D  EQ	R7	R5	R7
+      0x741E0002,  //  003E  JMPT	R7	#0042
+      0x541E0011,  //  003F  LDINT	R7	18
+      0x1C1C0A07,  //  0040  EQ	R7	R5	R7
+      0x781E0012,  //  0041  JMPF	R7	#0055
+      0x881C0106,  //  0042  GETMBR	R7	R0	K6
+      0x8C1C0F07,  //  0043  GETMET	R7	R7	K7
+      0x7C1C0200,  //  0044  CALL	R7	1
+      0x8C1C0F08,  //  0045  GETMET	R7	R7	K8
+      0x58240011,  //  0046  LDCONST	R9	K17
+      0x7C1C0400,  //  0047  CALL	R7	2
+      0x781E0005,  //  0048  JMPF	R7	#004F
+      0x8C20070A,  //  0049  GETMET	R8	R3	K10
+      0x8828070B,  //  004A  GETMBR	R10	R3	K11
+      0x5C2C0E00,  //  004B  MOVE	R11	R7
+      0x7C200600,  //  004C  CALL	R8	3
+      0x80041000,  //  004D  RET	1	R8
+      0x70020004,  //  004E  JMP		#0054
+      0x8C20070A,  //  004F  GETMET	R8	R3	K10
+      0x8828070C,  //  0050  GETMBR	R10	R3	K12
+      0x4C2C0000,  //  0051  LDNIL	R11
+      0x7C200600,  //  0052  CALL	R8	3
+      0x80041000,  //  0053  RET	1	R8
+      0x70020011,  //  0054  JMP		#0067
+      0x541E0010,  //  0055  LDINT	R7	17
+      0x1C1C0A07,  //  0056  EQ	R7	R5	R7
+      0x781E0006,  //  0057  JMPF	R7	#005F
+      0x8C1C070A,  //  0058  GETMET	R7	R3	K10
+      0x88240712,  //  0059  GETMBR	R9	R3	K18
+      0x88280106,  //  005A  GETMBR	R10	R0	K6
+      0x88281513,  //  005B  GETMBR	R10	R10	K19
+      0x7C1C0600,  //  005C  CALL	R7	3
+      0x80040E00,  //  005D  RET	1	R7
+      0x70020007,  //  005E  JMP		#0067
+      0x601C0003,  //  005F  GETGBL	R7	G3
+      0x5C200000,  //  0060  MOVE	R8	R0
+      0x7C1C0200,  //  0061  CALL	R7	1
+      0x8C1C0F14,  //  0062  GETMET	R7	R7	K20
+      0x5C240200,  //  0063  MOVE	R9	R1
+      0x5C280400,  //  0064  MOVE	R10	R2
+      0x7C1C0600,  //  0065  CALL	R7	3
+      0x80040E00,  //  0066  RET	1	R7
+      0x70020007,  //  0067  JMP		#0070
+      0x60180003,  //  0068  GETGBL	R6	G3
+      0x5C1C0000,  //  0069  MOVE	R7	R0
+      0x7C180200,  //  006A  CALL	R6	1
+      0x8C180D14,  //  006B  GETMET	R6	R6	K20
+      0x5C200200,  //  006C  MOVE	R8	R1
+      0x5C240400,  //  006D  MOVE	R9	R2
+      0x7C180600,  //  006E  CALL	R6	3
+      0x80040C00,  //  006F  RET	1	R6
+      0x80000000,  //  0070  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Device.h
@@ -210,7 +210,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
+    ( &(const bvalue[35]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
@@ -232,12 +232,24 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
     /* K18  */  be_nested_str_weak(find),
     /* K19  */  be_nested_str_weak(get_admin_vendor),
     /* K20  */  be_nested_str_weak(read_attribute),
-    /* K21  */  be_nested_str_weak(UTF1),
-    /* K22  */  be_nested_str_weak(get_name),
+    /* K21  */  be_nested_str_weak(string),
+    /* K22  */  be_nested_str_weak(UTF1),
+    /* K23  */  be_nested_str_weak(tasmota),
+    /* K24  */  be_nested_str_weak(cmd),
+    /* K25  */  be_nested_str_weak(DeviceName),
+    /* K26  */  be_nested_str_weak(get_name),
+    /* K27  */  be_nested_str_weak(Status_X202),
+    /* K28  */  be_nested_str_weak(StatusFWR),
+    /* K29  */  be_nested_str_weak(Version),
+    /* K30  */  be_nested_str_weak(_X28),
+    /* K31  */  be_nested_str_weak(wifi),
+    /* K32  */  be_nested_str_weak(mac),
+    /* K33  */  be_nested_str_weak(),
+    /* K34  */  be_nested_str_weak(BOOL),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[180]) {  /* code */
+    ( &(const binstruction[258]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x880C0701,  //  0001  GETMBR	R3	R3	K1
       0x88100502,  //  0002  GETMBR	R4	R2	K2
@@ -277,7 +289,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x54260003,  //  0024  LDINT	R9	4
       0x7C180600,  //  0025  CALL	R6	3
       0x80040C00,  //  0026  RET	1	R6
-      0x7002008A,  //  0027  JMP		#00B3
+      0x700200D8,  //  0027  JMP		#0101
       0x541A0003,  //  0028  LDINT	R6	4
       0x1C180806,  //  0029  EQ	R6	R4	R6
       0x781A0016,  //  002A  JMPF	R6	#0042
@@ -303,7 +315,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x54260003,  //  003E  LDINT	R9	4
       0x7C180600,  //  003F  CALL	R6	3
       0x80040C00,  //  0040  RET	1	R6
-      0x70020070,  //  0041  JMP		#00B3
+      0x700200BE,  //  0041  JMP		#0101
       0x541A0004,  //  0042  LDINT	R6	5
       0x1C180806,  //  0043  EQ	R6	R4	R6
       0x781A0011,  //  0044  JMPF	R6	#0057
@@ -324,7 +336,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x54260003,  //  0053  LDINT	R9	4
       0x7C180600,  //  0054  CALL	R6	3
       0x80040C00,  //  0055  RET	1	R6
-      0x7002005B,  //  0056  JMP		#00B3
+      0x700200A9,  //  0056  JMP		#0101
       0x541A001C,  //  0057  LDINT	R6	29
       0x1C180806,  //  0058  EQ	R6	R4	R6
       0x781A003A,  //  0059  JMPF	R6	#0095
@@ -386,38 +398,116 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x5C240400,  //  0091  MOVE	R9	R2
       0x7C180600,  //  0092  CALL	R6	3
       0x80040C00,  //  0093  RET	1	R6
-      0x7002001D,  //  0094  JMP		#00B3
+      0x7002006B,  //  0094  JMP		#0101
       0x541A0038,  //  0095  LDINT	R6	57
       0x1C180806,  //  0096  EQ	R6	R4	R6
-      0x781A0012,  //  0097  JMPF	R6	#00AB
-      0x541A0004,  //  0098  LDINT	R6	5
-      0x1C180A06,  //  0099  EQ	R6	R5	R6
-      0x781A0006,  //  009A  JMPF	R6	#00A2
-      0x8C180706,  //  009B  GETMET	R6	R3	K6
-      0x88200715,  //  009C  GETMBR	R8	R3	K21
-      0x8C240116,  //  009D  GETMET	R9	R0	K22
-      0x7C240200,  //  009E  CALL	R9	1
-      0x7C180600,  //  009F  CALL	R6	3
-      0x80040C00,  //  00A0  RET	1	R6
-      0x70020007,  //  00A1  JMP		#00AA
-      0x60180003,  //  00A2  GETGBL	R6	G3
-      0x5C1C0000,  //  00A3  MOVE	R7	R0
-      0x7C180200,  //  00A4  CALL	R6	1
-      0x8C180D14,  //  00A5  GETMET	R6	R6	K20
-      0x5C200200,  //  00A6  MOVE	R8	R1
-      0x5C240400,  //  00A7  MOVE	R9	R2
-      0x7C180600,  //  00A8  CALL	R6	3
-      0x80040C00,  //  00A9  RET	1	R6
-      0x70020007,  //  00AA  JMP		#00B3
-      0x60180003,  //  00AB  GETGBL	R6	G3
-      0x5C1C0000,  //  00AC  MOVE	R7	R0
-      0x7C180200,  //  00AD  CALL	R6	1
-      0x8C180D14,  //  00AE  GETMET	R6	R6	K20
-      0x5C200200,  //  00AF  MOVE	R8	R1
-      0x5C240400,  //  00B0  MOVE	R9	R2
-      0x7C180600,  //  00B1  CALL	R6	3
-      0x80040C00,  //  00B2  RET	1	R6
-      0x80000000,  //  00B3  RET	0
+      0x781A0060,  //  0097  JMPF	R6	#00F9
+      0xA41A2A00,  //  0098  IMPORT	R6	K21
+      0x1C1C0B04,  //  0099  EQ	R7	R5	K4
+      0x781E000A,  //  009A  JMPF	R7	#00A6
+      0x8C1C0706,  //  009B  GETMET	R7	R3	K6
+      0x88240716,  //  009C  GETMBR	R9	R3	K22
+      0xB82A2E00,  //  009D  GETNGBL	R10	K23
+      0x8C281518,  //  009E  GETMET	R10	R10	K24
+      0x58300019,  //  009F  LDCONST	R12	K25
+      0x50340200,  //  00A0  LDBOOL	R13	1	0
+      0x7C280600,  //  00A1  CALL	R10	3
+      0x94281519,  //  00A2  GETIDX	R10	R10	K25
+      0x7C1C0600,  //  00A3  CALL	R7	3
+      0x80040E00,  //  00A4  RET	1	R7
+      0x70020051,  //  00A5  JMP		#00F8
+      0x541E0004,  //  00A6  LDINT	R7	5
+      0x1C1C0A07,  //  00A7  EQ	R7	R5	R7
+      0x781E0006,  //  00A8  JMPF	R7	#00B0
+      0x8C1C0706,  //  00A9  GETMET	R7	R3	K6
+      0x88240716,  //  00AA  GETMBR	R9	R3	K22
+      0x8C28011A,  //  00AB  GETMET	R10	R0	K26
+      0x7C280200,  //  00AC  CALL	R10	1
+      0x7C1C0600,  //  00AD  CALL	R7	3
+      0x80040E00,  //  00AE  RET	1	R7
+      0x70020047,  //  00AF  JMP		#00F8
+      0x541E0009,  //  00B0  LDINT	R7	10
+      0x1C1C0A07,  //  00B1  EQ	R7	R5	R7
+      0x781E0015,  //  00B2  JMPF	R7	#00C9
+      0xB81E2E00,  //  00B3  GETNGBL	R7	K23
+      0x8C1C0F18,  //  00B4  GETMET	R7	R7	K24
+      0x5824001B,  //  00B5  LDCONST	R9	K27
+      0x50280200,  //  00B6  LDBOOL	R10	1	0
+      0x7C1C0600,  //  00B7  CALL	R7	3
+      0x941C0F1C,  //  00B8  GETIDX	R7	R7	K28
+      0x941C0F1D,  //  00B9  GETIDX	R7	R7	K29
+      0x8C200D12,  //  00BA  GETMET	R8	R6	K18
+      0x5C280E00,  //  00BB  MOVE	R10	R7
+      0x582C001E,  //  00BC  LDCONST	R11	K30
+      0x7C200600,  //  00BD  CALL	R8	3
+      0x24241105,  //  00BE  GT	R9	R8	K5
+      0x78260002,  //  00BF  JMPF	R9	#00C3
+      0x04241108,  //  00C0  SUB	R9	R8	K8
+      0x40260A09,  //  00C1  CONNECT	R9	K5	R9
+      0x941C0E09,  //  00C2  GETIDX	R7	R7	R9
+      0x8C240706,  //  00C3  GETMET	R9	R3	K6
+      0x882C0716,  //  00C4  GETMBR	R11	R3	K22
+      0x5C300E00,  //  00C5  MOVE	R12	R7
+      0x7C240600,  //  00C6  CALL	R9	3
+      0x80041200,  //  00C7  RET	1	R9
+      0x7002002E,  //  00C8  JMP		#00F8
+      0x541E000E,  //  00C9  LDINT	R7	15
+      0x1C1C0A07,  //  00CA  EQ	R7	R5	R7
+      0x781E000B,  //  00CB  JMPF	R7	#00D8
+      0x8C1C0706,  //  00CC  GETMET	R7	R3	K6
+      0x88240716,  //  00CD  GETMBR	R9	R3	K22
+      0xB82A2E00,  //  00CE  GETNGBL	R10	K23
+      0x8C28151F,  //  00CF  GETMET	R10	R10	K31
+      0x7C280200,  //  00D0  CALL	R10	1
+      0x8C281512,  //  00D1  GETMET	R10	R10	K18
+      0x58300020,  //  00D2  LDCONST	R12	K32
+      0x58340021,  //  00D3  LDCONST	R13	K33
+      0x7C280600,  //  00D4  CALL	R10	3
+      0x7C1C0600,  //  00D5  CALL	R7	3
+      0x80040E00,  //  00D6  RET	1	R7
+      0x7002001F,  //  00D7  JMP		#00F8
+      0x541E0010,  //  00D8  LDINT	R7	17
+      0x1C1C0A07,  //  00D9  EQ	R7	R5	R7
+      0x781E0005,  //  00DA  JMPF	R7	#00E1
+      0x8C1C0706,  //  00DB  GETMET	R7	R3	K6
+      0x88240722,  //  00DC  GETMBR	R9	R3	K34
+      0x58280008,  //  00DD  LDCONST	R10	K8
+      0x7C1C0600,  //  00DE  CALL	R7	3
+      0x80040E00,  //  00DF  RET	1	R7
+      0x70020016,  //  00E0  JMP		#00F8
+      0x541E0011,  //  00E1  LDINT	R7	18
+      0x1C1C0A07,  //  00E2  EQ	R7	R5	R7
+      0x781E000B,  //  00E3  JMPF	R7	#00F0
+      0x8C1C0706,  //  00E4  GETMET	R7	R3	K6
+      0x88240716,  //  00E5  GETMBR	R9	R3	K22
+      0xB82A2E00,  //  00E6  GETNGBL	R10	K23
+      0x8C28151F,  //  00E7  GETMET	R10	R10	K31
+      0x7C280200,  //  00E8  CALL	R10	1
+      0x8C281512,  //  00E9  GETMET	R10	R10	K18
+      0x58300020,  //  00EA  LDCONST	R12	K32
+      0x58340021,  //  00EB  LDCONST	R13	K33
+      0x7C280600,  //  00EC  CALL	R10	3
+      0x7C1C0600,  //  00ED  CALL	R7	3
+      0x80040E00,  //  00EE  RET	1	R7
+      0x70020007,  //  00EF  JMP		#00F8
+      0x601C0003,  //  00F0  GETGBL	R7	G3
+      0x5C200000,  //  00F1  MOVE	R8	R0
+      0x7C1C0200,  //  00F2  CALL	R7	1
+      0x8C1C0F14,  //  00F3  GETMET	R7	R7	K20
+      0x5C240200,  //  00F4  MOVE	R9	R1
+      0x5C280400,  //  00F5  MOVE	R10	R2
+      0x7C1C0600,  //  00F6  CALL	R7	3
+      0x80040E00,  //  00F7  RET	1	R7
+      0x70020007,  //  00F8  JMP		#0101
+      0x60180003,  //  00F9  GETGBL	R6	G3
+      0x5C1C0000,  //  00FA  MOVE	R7	R0
+      0x7C180200,  //  00FB  CALL	R6	1
+      0x8C180D14,  //  00FC  GETMET	R6	R6	K20
+      0x5C200200,  //  00FD  MOVE	R8	R1
+      0x5C240400,  //  00FE  MOVE	R9	R2
+      0x7C180600,  //  00FF  CALL	R6	3
+      0x80040C00,  //  0100  RET	1	R6
+      0x80000000,  //  0101  RET	0
     })
   )
 );
@@ -461,9 +551,14 @@ be_local_class(Matter_Plugin_Device,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, 2), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(1,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(3),
         be_const_int(5),
+        be_const_int(10),
+        be_const_int(15),
+        be_const_int(17),
+        be_const_int(18),
     }))    ) } )) },
         { be_const_key_int(5, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(8,

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
@@ -970,7 +970,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[888]) {  /* code */
+    ( &(const binstruction[897]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0xB8120200,  //  0001  GETNGBL	R4	K1
       0x88100902,  //  0002  GETMBR	R4	R4	K2
@@ -1027,11 +1027,11 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x50280000,  //  0035  LDBOOL	R10	0	0
       0x7C1C0600,  //  0036  CALL	R7	3
       0x80040E00,  //  0037  RET	1	R7
-      0x7002033D,  //  0038  JMP		#0377
+      0x70020346,  //  0038  JMP		#0380
       0x541E0031,  //  0039  LDINT	R7	50
       0x1C1C0A07,  //  003A  EQ	R7	R5	R7
       0x781E0000,  //  003B  JMPF	R7	#003D
-      0x70020339,  //  003C  JMP		#0377
+      0x70020342,  //  003C  JMP		#0380
       0x541E0032,  //  003D  LDINT	R7	51
       0x1C1C0A07,  //  003E  EQ	R7	R5	R7
       0x781E00DC,  //  003F  JMPF	R7	#011D
@@ -1255,11 +1255,11 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x50280000,  //  0119  LDBOOL	R10	0	0
       0x7C1C0600,  //  011A  CALL	R7	3
       0x80040E00,  //  011B  RET	1	R7
-      0x70020259,  //  011C  JMP		#0377
+      0x70020262,  //  011C  JMP		#0380
       0x541E0033,  //  011D  LDINT	R7	52
       0x1C1C0A07,  //  011E  EQ	R7	R5	R7
       0x781E0000,  //  011F  JMPF	R7	#0121
-      0x70020255,  //  0120  JMP		#0377
+      0x7002025E,  //  0120  JMP		#0380
       0x541E0037,  //  0121  LDINT	R7	56
       0x1C1C0A07,  //  0122  EQ	R7	R5	R7
       0x781E002C,  //  0123  JMPF	R7	#0151
@@ -1307,7 +1307,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x5C2C0E00,  //  014D  MOVE	R11	R7
       0x7C200600,  //  014E  CALL	R8	3
       0x80041000,  //  014F  RET	1	R8
-      0x70020225,  //  0150  JMP		#0377
+      0x7002022E,  //  0150  JMP		#0380
       0x541E003D,  //  0151  LDINT	R7	62
       0x1C1C0A07,  //  0152  EQ	R7	R5	R7
       0x781E0090,  //  0153  JMPF	R7	#01E5
@@ -1455,7 +1455,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x5C2C0E00,  //  01E1  MOVE	R11	R7
       0x7C200600,  //  01E2  CALL	R8	3
       0x80041000,  //  01E3  RET	1	R8
-      0x70020191,  //  01E4  JMP		#0377
+      0x7002019A,  //  01E4  JMP		#0380
       0x541E003B,  //  01E5  LDINT	R7	60
       0x1C1C0A07,  //  01E6  EQ	R7	R5	R7
       0x781E003C,  //  01E7  JMPF	R7	#0225
@@ -1519,10 +1519,10 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x4C2C0000,  //  0221  LDNIL	R11
       0x7C200600,  //  0222  CALL	R8	3
       0x80041000,  //  0223  RET	1	R8
-      0x70020151,  //  0224  JMP		#0377
+      0x7002015A,  //  0224  JMP		#0380
       0x541E0027,  //  0225  LDINT	R7	40
       0x1C1C0A07,  //  0226  EQ	R7	R5	R7
-      0x781E00AE,  //  0227  JMPF	R7	#02D7
+      0x781E00B7,  //  0227  JMPF	R7	#02E0
       0x1C1C0D05,  //  0228  EQ	R7	R6	K5
       0x781E0005,  //  0229  JMPF	R7	#0230
       0x8C1C0906,  //  022A  GETMET	R7	R4	K6
@@ -1530,7 +1530,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x58280009,  //  022C  LDCONST	R10	K9
       0x7C1C0600,  //  022D  CALL	R7	3
       0x80040E00,  //  022E  RET	1	R7
-      0x700200A5,  //  022F  JMP		#02D6
+      0x700200AE,  //  022F  JMP		#02DF
       0x1C1C0D09,  //  0230  EQ	R7	R6	K9
       0x781E0005,  //  0231  JMPF	R7	#0238
       0x8C1C0906,  //  0232  GETMET	R7	R4	K6
@@ -1538,7 +1538,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x58280049,  //  0234  LDCONST	R10	K73
       0x7C1C0600,  //  0235  CALL	R7	3
       0x80040E00,  //  0236  RET	1	R7
-      0x7002009D,  //  0237  JMP		#02D6
+      0x700200A6,  //  0237  JMP		#02DF
       0x1C1C0D0D,  //  0238  EQ	R7	R6	K13
       0x781E0006,  //  0239  JMPF	R7	#0241
       0x8C1C0906,  //  023A  GETMET	R7	R4	K6
@@ -1547,7 +1547,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x8828154A,  //  023D  GETMBR	R10	R10	K74
       0x7C1C0600,  //  023E  CALL	R7	3
       0x80040E00,  //  023F  RET	1	R7
-      0x70020094,  //  0240  JMP		#02D6
+      0x7002009D,  //  0240  JMP		#02DF
       0x1C1C0D0F,  //  0241  EQ	R7	R6	K15
       0x781E000A,  //  0242  JMPF	R7	#024E
       0x8C1C0906,  //  0243  GETMET	R7	R4	K6
@@ -1560,7 +1560,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x9428154B,  //  024A  GETIDX	R10	R10	K75
       0x7C1C0600,  //  024B  CALL	R7	3
       0x80040E00,  //  024C  RET	1	R7
-      0x70020087,  //  024D  JMP		#02D6
+      0x70020090,  //  024D  JMP		#02DF
       0x541E0003,  //  024E  LDINT	R7	4
       0x1C1C0C07,  //  024F  EQ	R7	R6	R7
       0x781E0005,  //  0250  JMPF	R7	#0257
@@ -1569,7 +1569,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x542A7FFF,  //  0253  LDINT	R10	32768
       0x7C1C0600,  //  0254  CALL	R7	3
       0x80040E00,  //  0255  RET	1	R7
-      0x7002007E,  //  0256  JMP		#02D6
+      0x70020087,  //  0256  JMP		#02DF
       0x541E0004,  //  0257  LDINT	R7	5
       0x1C1C0C07,  //  0258  EQ	R7	R6	R7
       0x781E000A,  //  0259  JMPF	R7	#0265
@@ -1583,7 +1583,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x9428154D,  //  0261  GETIDX	R10	R10	K77
       0x7C1C0600,  //  0262  CALL	R7	3
       0x80040E00,  //  0263  RET	1	R7
-      0x70020070,  //  0264  JMP		#02D6
+      0x70020079,  //  0264  JMP		#02DF
       0x541E0005,  //  0265  LDINT	R7	6
       0x1C1C0C07,  //  0266  EQ	R7	R6	R7
       0x781E0005,  //  0267  JMPF	R7	#026E
@@ -1592,7 +1592,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x5828004E,  //  026A  LDCONST	R10	K78
       0x7C1C0600,  //  026B  CALL	R7	3
       0x80040E00,  //  026C  RET	1	R7
-      0x70020067,  //  026D  JMP		#02D6
+      0x70020070,  //  026D  JMP		#02DF
       0x541E0006,  //  026E  LDINT	R7	7
       0x1C1C0C07,  //  026F  EQ	R7	R6	R7
       0x781E0005,  //  0270  JMPF	R7	#0277
@@ -1601,7 +1601,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x58280005,  //  0273  LDCONST	R10	K5
       0x7C1C0600,  //  0274  CALL	R7	3
       0x80040E00,  //  0275  RET	1	R7
-      0x7002005E,  //  0276  JMP		#02D6
+      0x70020067,  //  0276  JMP		#02DF
       0x541E0007,  //  0277  LDINT	R7	8
       0x1C1C0C07,  //  0278  EQ	R7	R6	R7
       0x781E000B,  //  0279  JMPF	R7	#0286
@@ -1616,7 +1616,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x94281551,  //  0282  GETIDX	R10	R10	K81
       0x7C1C0600,  //  0283  CALL	R7	3
       0x80040E00,  //  0284  RET	1	R7
-      0x7002004F,  //  0285  JMP		#02D6
+      0x70020058,  //  0285  JMP		#02DF
       0x541E0008,  //  0286  LDINT	R7	9
       0x1C1C0C07,  //  0287  EQ	R7	R6	R7
       0x781E0005,  //  0288  JMPF	R7	#028F
@@ -1625,7 +1625,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x58280009,  //  028B  LDCONST	R10	K9
       0x7C1C0600,  //  028C  CALL	R7	3
       0x80040E00,  //  028D  RET	1	R7
-      0x70020046,  //  028E  JMP		#02D6
+      0x7002004F,  //  028E  JMP		#02DF
       0x541E0009,  //  028F  LDINT	R7	10
       0x1C1C0C07,  //  0290  EQ	R7	R6	R7
       0x781E0015,  //  0291  JMPF	R7	#02A8
@@ -1650,7 +1650,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x5C300E00,  //  02A4  MOVE	R12	R7
       0x7C240600,  //  02A5  CALL	R9	3
       0x80041200,  //  02A6  RET	1	R9
-      0x7002002D,  //  02A7  JMP		#02D6
+      0x70020036,  //  02A7  JMP		#02DF
       0x541E000E,  //  02A8  LDINT	R7	15
       0x1C1C0C07,  //  02A9  EQ	R7	R6	R7
       0x781E000B,  //  02AA  JMPF	R7	#02B7
@@ -1665,189 +1665,189 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x7C280600,  //  02B3  CALL	R10	3
       0x7C1C0600,  //  02B4  CALL	R7	3
       0x80040E00,  //  02B5  RET	1	R7
-      0x7002001E,  //  02B6  JMP		#02D6
-      0x541E0011,  //  02B7  LDINT	R7	18
+      0x70020027,  //  02B6  JMP		#02DF
+      0x541E0010,  //  02B7  LDINT	R7	17
       0x1C1C0C07,  //  02B8  EQ	R7	R6	R7
-      0x781E000B,  //  02B9  JMPF	R7	#02C6
+      0x781E0005,  //  02B9  JMPF	R7	#02C0
       0x8C1C0906,  //  02BA  GETMET	R7	R4	K6
-      0x88240916,  //  02BB  GETMBR	R9	R4	K22
-      0xB82A2400,  //  02BC  GETNGBL	R10	K18
-      0x8C281525,  //  02BD  GETMET	R10	R10	K37
-      0x7C280200,  //  02BE  CALL	R10	1
-      0x8C28151B,  //  02BF  GETMET	R10	R10	K27
-      0x5830001C,  //  02C0  LDCONST	R12	K28
-      0x5834001D,  //  02C1  LDCONST	R13	K29
-      0x7C280600,  //  02C2  CALL	R10	3
-      0x7C1C0600,  //  02C3  CALL	R7	3
-      0x80040E00,  //  02C4  RET	1	R7
-      0x7002000F,  //  02C5  JMP		#02D6
-      0x541E0012,  //  02C6  LDINT	R7	19
-      0x1C1C0C07,  //  02C7  EQ	R7	R6	R7
-      0x781E000C,  //  02C8  JMPF	R7	#02D6
-      0x8C1C090A,  //  02C9  GETMET	R7	R4	K10
-      0x7C1C0200,  //  02CA  CALL	R7	1
-      0x8C200F0B,  //  02CB  GETMET	R8	R7	K11
-      0x58280005,  //  02CC  LDCONST	R10	K5
-      0x882C090C,  //  02CD  GETMBR	R11	R4	K12
-      0x5830000F,  //  02CE  LDCONST	R12	K15
-      0x7C200800,  //  02CF  CALL	R8	4
-      0x8C200F0B,  //  02D0  GETMET	R8	R7	K11
-      0x58280009,  //  02D1  LDCONST	R10	K9
-      0x882C090C,  //  02D2  GETMBR	R11	R4	K12
-      0x5830000F,  //  02D3  LDCONST	R12	K15
-      0x7C200800,  //  02D4  CALL	R8	4
-      0x80040E00,  //  02D5  RET	1	R7
-      0x7002009F,  //  02D6  JMP		#0377
-      0x541E003E,  //  02D7  LDINT	R7	63
-      0x1C1C0A07,  //  02D8  EQ	R7	R5	R7
-      0x781E0000,  //  02D9  JMPF	R7	#02DB
-      0x7002009B,  //  02DA  JMP		#0377
-      0x541E0029,  //  02DB  LDINT	R7	42
-      0x1C1C0A07,  //  02DC  EQ	R7	R5	R7
-      0x781E001D,  //  02DD  JMPF	R7	#02FC
-      0x1C1C0D05,  //  02DE  EQ	R7	R6	K5
-      0x781E0003,  //  02DF  JMPF	R7	#02E4
-      0x8C1C0911,  //  02E0  GETMET	R7	R4	K17
-      0x7C1C0200,  //  02E1  CALL	R7	1
-      0x80040E00,  //  02E2  RET	1	R7
-      0x70020016,  //  02E3  JMP		#02FB
-      0x1C1C0D09,  //  02E4  EQ	R7	R6	K9
-      0x781E0005,  //  02E5  JMPF	R7	#02EC
-      0x8C1C0906,  //  02E6  GETMET	R7	R4	K6
-      0x88240910,  //  02E7  GETMBR	R9	R4	K16
-      0x58280005,  //  02E8  LDCONST	R10	K5
-      0x7C1C0600,  //  02E9  CALL	R7	3
-      0x80040E00,  //  02EA  RET	1	R7
-      0x7002000E,  //  02EB  JMP		#02FB
-      0x1C1C0D0D,  //  02EC  EQ	R7	R6	K13
-      0x781E0005,  //  02ED  JMPF	R7	#02F4
-      0x8C1C0906,  //  02EE  GETMET	R7	R4	K6
-      0x8824090E,  //  02EF  GETMBR	R9	R4	K14
-      0x58280009,  //  02F0  LDCONST	R10	K9
-      0x7C1C0600,  //  02F1  CALL	R7	3
-      0x80040E00,  //  02F2  RET	1	R7
-      0x70020006,  //  02F3  JMP		#02FB
-      0x1C1C0D0F,  //  02F4  EQ	R7	R6	K15
-      0x781E0004,  //  02F5  JMPF	R7	#02FB
-      0x8C1C0906,  //  02F6  GETMET	R7	R4	K6
-      0x88240918,  //  02F7  GETMBR	R9	R4	K24
-      0x4C280000,  //  02F8  LDNIL	R10
-      0x7C1C0600,  //  02F9  CALL	R7	3
-      0x80040E00,  //  02FA  RET	1	R7
-      0x7002007A,  //  02FB  JMP		#0377
-      0x541E002A,  //  02FC  LDINT	R7	43
-      0x1C1C0A07,  //  02FD  EQ	R7	R5	R7
-      0x781E0016,  //  02FE  JMPF	R7	#0316
-      0x1C1C0D05,  //  02FF  EQ	R7	R6	K5
-      0x781E0007,  //  0300  JMPF	R7	#0309
-      0x8C1C0906,  //  0301  GETMET	R7	R4	K6
-      0x88240916,  //  0302  GETMBR	R9	R4	K22
-      0xB82A2400,  //  0303  GETNGBL	R10	K18
-      0x8C281554,  //  0304  GETMET	R10	R10	K84
-      0x7C280200,  //  0305  CALL	R10	1
-      0x7C1C0600,  //  0306  CALL	R7	3
-      0x80040E00,  //  0307  RET	1	R7
-      0x7002000B,  //  0308  JMP		#0315
-      0x1C1C0D09,  //  0309  EQ	R7	R6	K9
-      0x781E0009,  //  030A  JMPF	R7	#0315
-      0x8C1C0911,  //  030B  GETMET	R7	R4	K17
-      0x7C1C0200,  //  030C  CALL	R7	1
-      0x8C200F0B,  //  030D  GETMET	R8	R7	K11
-      0x4C280000,  //  030E  LDNIL	R10
-      0x882C0916,  //  030F  GETMBR	R11	R4	K22
-      0xB8322400,  //  0310  GETNGBL	R12	K18
-      0x8C301954,  //  0311  GETMET	R12	R12	K84
-      0x7C300200,  //  0312  CALL	R12	1
-      0x7C200800,  //  0313  CALL	R8	4
-      0x80040E00,  //  0314  RET	1	R7
-      0x70020060,  //  0315  JMP		#0377
-      0x541E002B,  //  0316  LDINT	R7	44
-      0x1C1C0A07,  //  0317  EQ	R7	R5	R7
-      0x781E001C,  //  0318  JMPF	R7	#0336
-      0x1C1C0D05,  //  0319  EQ	R7	R6	K5
-      0x781E0005,  //  031A  JMPF	R7	#0321
-      0x8C1C0906,  //  031B  GETMET	R7	R4	K6
-      0x8824090E,  //  031C  GETMBR	R9	R4	K14
-      0x58280009,  //  031D  LDCONST	R10	K9
-      0x7C1C0600,  //  031E  CALL	R7	3
-      0x80040E00,  //  031F  RET	1	R7
-      0x70020013,  //  0320  JMP		#0335
-      0x1C1C0D09,  //  0321  EQ	R7	R6	K9
-      0x781E0005,  //  0322  JMPF	R7	#0329
-      0x8C1C0906,  //  0323  GETMET	R7	R4	K6
-      0x8824090E,  //  0324  GETMBR	R9	R4	K14
-      0x542A0003,  //  0325  LDINT	R10	4
-      0x7C1C0600,  //  0326  CALL	R7	3
-      0x80040E00,  //  0327  RET	1	R7
-      0x7002000B,  //  0328  JMP		#0335
-      0x1C1C0D0D,  //  0329  EQ	R7	R6	K13
-      0x781E0009,  //  032A  JMPF	R7	#0335
-      0x8C1C0911,  //  032B  GETMET	R7	R4	K17
-      0x7C1C0200,  //  032C  CALL	R7	1
-      0x8C200F0B,  //  032D  GETMET	R8	R7	K11
-      0x4C280000,  //  032E  LDNIL	R10
-      0x8C2C0906,  //  032F  GETMET	R11	R4	K6
-      0x8834090E,  //  0330  GETMBR	R13	R4	K14
-      0x543A0003,  //  0331  LDINT	R14	4
-      0x7C2C0600,  //  0332  CALL	R11	3
-      0x7C200600,  //  0333  CALL	R8	3
-      0x80040E00,  //  0334  RET	1	R7
-      0x70020040,  //  0335  JMP		#0377
-      0x541E0030,  //  0336  LDINT	R7	49
-      0x1C1C0A07,  //  0337  EQ	R7	R5	R7
-      0x781E0010,  //  0338  JMPF	R7	#034A
-      0x1C1C0D0F,  //  0339  EQ	R7	R6	K15
-      0x781E0005,  //  033A  JMPF	R7	#0341
-      0x8C1C0906,  //  033B  GETMET	R7	R4	K6
-      0x8824090E,  //  033C  GETMBR	R9	R4	K14
-      0x542A001D,  //  033D  LDINT	R10	30
-      0x7C1C0600,  //  033E  CALL	R7	3
-      0x80040E00,  //  033F  RET	1	R7
-      0x70020007,  //  0340  JMP		#0349
-      0x541EFFFB,  //  0341  LDINT	R7	65532
-      0x1C1C0C07,  //  0342  EQ	R7	R6	R7
-      0x781E0004,  //  0343  JMPF	R7	#0349
+      0x88240910,  //  02BB  GETMBR	R9	R4	K16
+      0x58280009,  //  02BC  LDCONST	R10	K9
+      0x7C1C0600,  //  02BD  CALL	R7	3
+      0x80040E00,  //  02BE  RET	1	R7
+      0x7002001E,  //  02BF  JMP		#02DF
+      0x541E0011,  //  02C0  LDINT	R7	18
+      0x1C1C0C07,  //  02C1  EQ	R7	R6	R7
+      0x781E000B,  //  02C2  JMPF	R7	#02CF
+      0x8C1C0906,  //  02C3  GETMET	R7	R4	K6
+      0x88240916,  //  02C4  GETMBR	R9	R4	K22
+      0xB82A2400,  //  02C5  GETNGBL	R10	K18
+      0x8C281525,  //  02C6  GETMET	R10	R10	K37
+      0x7C280200,  //  02C7  CALL	R10	1
+      0x8C28151B,  //  02C8  GETMET	R10	R10	K27
+      0x5830001C,  //  02C9  LDCONST	R12	K28
+      0x5834001D,  //  02CA  LDCONST	R13	K29
+      0x7C280600,  //  02CB  CALL	R10	3
+      0x7C1C0600,  //  02CC  CALL	R7	3
+      0x80040E00,  //  02CD  RET	1	R7
+      0x7002000F,  //  02CE  JMP		#02DF
+      0x541E0012,  //  02CF  LDINT	R7	19
+      0x1C1C0C07,  //  02D0  EQ	R7	R6	R7
+      0x781E000C,  //  02D1  JMPF	R7	#02DF
+      0x8C1C090A,  //  02D2  GETMET	R7	R4	K10
+      0x7C1C0200,  //  02D3  CALL	R7	1
+      0x8C200F0B,  //  02D4  GETMET	R8	R7	K11
+      0x58280005,  //  02D5  LDCONST	R10	K5
+      0x882C090C,  //  02D6  GETMBR	R11	R4	K12
+      0x5830000F,  //  02D7  LDCONST	R12	K15
+      0x7C200800,  //  02D8  CALL	R8	4
+      0x8C200F0B,  //  02D9  GETMET	R8	R7	K11
+      0x58280009,  //  02DA  LDCONST	R10	K9
+      0x882C090C,  //  02DB  GETMBR	R11	R4	K12
+      0x5830000F,  //  02DC  LDCONST	R12	K15
+      0x7C200800,  //  02DD  CALL	R8	4
+      0x80040E00,  //  02DE  RET	1	R7
+      0x7002009F,  //  02DF  JMP		#0380
+      0x541E003E,  //  02E0  LDINT	R7	63
+      0x1C1C0A07,  //  02E1  EQ	R7	R5	R7
+      0x781E0000,  //  02E2  JMPF	R7	#02E4
+      0x7002009B,  //  02E3  JMP		#0380
+      0x541E0029,  //  02E4  LDINT	R7	42
+      0x1C1C0A07,  //  02E5  EQ	R7	R5	R7
+      0x781E001D,  //  02E6  JMPF	R7	#0305
+      0x1C1C0D05,  //  02E7  EQ	R7	R6	K5
+      0x781E0003,  //  02E8  JMPF	R7	#02ED
+      0x8C1C0911,  //  02E9  GETMET	R7	R4	K17
+      0x7C1C0200,  //  02EA  CALL	R7	1
+      0x80040E00,  //  02EB  RET	1	R7
+      0x70020016,  //  02EC  JMP		#0304
+      0x1C1C0D09,  //  02ED  EQ	R7	R6	K9
+      0x781E0005,  //  02EE  JMPF	R7	#02F5
+      0x8C1C0906,  //  02EF  GETMET	R7	R4	K6
+      0x88240910,  //  02F0  GETMBR	R9	R4	K16
+      0x58280005,  //  02F1  LDCONST	R10	K5
+      0x7C1C0600,  //  02F2  CALL	R7	3
+      0x80040E00,  //  02F3  RET	1	R7
+      0x7002000E,  //  02F4  JMP		#0304
+      0x1C1C0D0D,  //  02F5  EQ	R7	R6	K13
+      0x781E0005,  //  02F6  JMPF	R7	#02FD
+      0x8C1C0906,  //  02F7  GETMET	R7	R4	K6
+      0x8824090E,  //  02F8  GETMBR	R9	R4	K14
+      0x58280009,  //  02F9  LDCONST	R10	K9
+      0x7C1C0600,  //  02FA  CALL	R7	3
+      0x80040E00,  //  02FB  RET	1	R7
+      0x70020006,  //  02FC  JMP		#0304
+      0x1C1C0D0F,  //  02FD  EQ	R7	R6	K15
+      0x781E0004,  //  02FE  JMPF	R7	#0304
+      0x8C1C0906,  //  02FF  GETMET	R7	R4	K6
+      0x88240918,  //  0300  GETMBR	R9	R4	K24
+      0x4C280000,  //  0301  LDNIL	R10
+      0x7C1C0600,  //  0302  CALL	R7	3
+      0x80040E00,  //  0303  RET	1	R7
+      0x7002007A,  //  0304  JMP		#0380
+      0x541E002A,  //  0305  LDINT	R7	43
+      0x1C1C0A07,  //  0306  EQ	R7	R5	R7
+      0x781E0016,  //  0307  JMPF	R7	#031F
+      0x1C1C0D05,  //  0308  EQ	R7	R6	K5
+      0x781E0007,  //  0309  JMPF	R7	#0312
+      0x8C1C0906,  //  030A  GETMET	R7	R4	K6
+      0x88240916,  //  030B  GETMBR	R9	R4	K22
+      0xB82A2400,  //  030C  GETNGBL	R10	K18
+      0x8C281554,  //  030D  GETMET	R10	R10	K84
+      0x7C280200,  //  030E  CALL	R10	1
+      0x7C1C0600,  //  030F  CALL	R7	3
+      0x80040E00,  //  0310  RET	1	R7
+      0x7002000B,  //  0311  JMP		#031E
+      0x1C1C0D09,  //  0312  EQ	R7	R6	K9
+      0x781E0009,  //  0313  JMPF	R7	#031E
+      0x8C1C0911,  //  0314  GETMET	R7	R4	K17
+      0x7C1C0200,  //  0315  CALL	R7	1
+      0x8C200F0B,  //  0316  GETMET	R8	R7	K11
+      0x4C280000,  //  0317  LDNIL	R10
+      0x882C0916,  //  0318  GETMBR	R11	R4	K22
+      0xB8322400,  //  0319  GETNGBL	R12	K18
+      0x8C301954,  //  031A  GETMET	R12	R12	K84
+      0x7C300200,  //  031B  CALL	R12	1
+      0x7C200800,  //  031C  CALL	R8	4
+      0x80040E00,  //  031D  RET	1	R7
+      0x70020060,  //  031E  JMP		#0380
+      0x541E002B,  //  031F  LDINT	R7	44
+      0x1C1C0A07,  //  0320  EQ	R7	R5	R7
+      0x781E001C,  //  0321  JMPF	R7	#033F
+      0x1C1C0D05,  //  0322  EQ	R7	R6	K5
+      0x781E0005,  //  0323  JMPF	R7	#032A
+      0x8C1C0906,  //  0324  GETMET	R7	R4	K6
+      0x8824090E,  //  0325  GETMBR	R9	R4	K14
+      0x58280009,  //  0326  LDCONST	R10	K9
+      0x7C1C0600,  //  0327  CALL	R7	3
+      0x80040E00,  //  0328  RET	1	R7
+      0x70020013,  //  0329  JMP		#033E
+      0x1C1C0D09,  //  032A  EQ	R7	R6	K9
+      0x781E0005,  //  032B  JMPF	R7	#0332
+      0x8C1C0906,  //  032C  GETMET	R7	R4	K6
+      0x8824090E,  //  032D  GETMBR	R9	R4	K14
+      0x542A0003,  //  032E  LDINT	R10	4
+      0x7C1C0600,  //  032F  CALL	R7	3
+      0x80040E00,  //  0330  RET	1	R7
+      0x7002000B,  //  0331  JMP		#033E
+      0x1C1C0D0D,  //  0332  EQ	R7	R6	K13
+      0x781E0009,  //  0333  JMPF	R7	#033E
+      0x8C1C0911,  //  0334  GETMET	R7	R4	K17
+      0x7C1C0200,  //  0335  CALL	R7	1
+      0x8C200F0B,  //  0336  GETMET	R8	R7	K11
+      0x4C280000,  //  0337  LDNIL	R10
+      0x8C2C0906,  //  0338  GETMET	R11	R4	K6
+      0x8834090E,  //  0339  GETMBR	R13	R4	K14
+      0x543A0003,  //  033A  LDINT	R14	4
+      0x7C2C0600,  //  033B  CALL	R11	3
+      0x7C200600,  //  033C  CALL	R8	3
+      0x80040E00,  //  033D  RET	1	R7
+      0x70020040,  //  033E  JMP		#0380
+      0x541E0030,  //  033F  LDINT	R7	49
+      0x1C1C0A07,  //  0340  EQ	R7	R5	R7
+      0x781E0010,  //  0341  JMPF	R7	#0353
+      0x1C1C0D0F,  //  0342  EQ	R7	R6	K15
+      0x781E0005,  //  0343  JMPF	R7	#034A
       0x8C1C0906,  //  0344  GETMET	R7	R4	K6
-      0x8824092A,  //  0345  GETMBR	R9	R4	K42
-      0x542A0003,  //  0346  LDINT	R10	4
+      0x8824090E,  //  0345  GETMBR	R9	R4	K14
+      0x542A001D,  //  0346  LDINT	R10	30
       0x7C1C0600,  //  0347  CALL	R7	3
       0x80040E00,  //  0348  RET	1	R7
-      0x7002002C,  //  0349  JMP		#0377
-      0x541E001C,  //  034A  LDINT	R7	29
-      0x1C1C0A07,  //  034B  EQ	R7	R5	R7
-      0x781E0021,  //  034C  JMPF	R7	#036F
-      0x1C1C0D0F,  //  034D  EQ	R7	R6	K15
-      0x781E0016,  //  034E  JMPF	R7	#0366
-      0x8C1C0911,  //  034F  GETMET	R7	R4	K17
-      0x7C1C0200,  //  0350  CALL	R7	1
-      0x88200133,  //  0351  GETMBR	R8	R0	K51
-      0x8C201155,  //  0352  GETMET	R8	R8	K85
-      0x50280200,  //  0353  LDBOOL	R10	1	0
-      0x7C200400,  //  0354  CALL	R8	2
-      0x60240010,  //  0355  GETGBL	R9	G16
-      0x5C281000,  //  0356  MOVE	R10	R8
-      0x7C240200,  //  0357  CALL	R9	1
-      0xA8020007,  //  0358  EXBLK	0	#0361
-      0x5C281200,  //  0359  MOVE	R10	R9
-      0x7C280000,  //  035A  CALL	R10	0
-      0x8C2C0F0B,  //  035B  GETMET	R11	R7	K11
-      0x4C340000,  //  035C  LDNIL	R13
-      0x8838090C,  //  035D  GETMBR	R14	R4	K12
-      0x5C3C1400,  //  035E  MOVE	R15	R10
-      0x7C2C0800,  //  035F  CALL	R11	4
-      0x7001FFF7,  //  0360  JMP		#0359
-      0x5824003A,  //  0361  LDCONST	R9	K58
-      0xAC240200,  //  0362  CATCH	R9	1	0
-      0xB0080000,  //  0363  RAISE	2	R0	R0
-      0x80040E00,  //  0364  RET	1	R7
-      0x70020007,  //  0365  JMP		#036E
-      0x601C0003,  //  0366  GETGBL	R7	G3
-      0x5C200000,  //  0367  MOVE	R8	R0
-      0x7C1C0200,  //  0368  CALL	R7	1
-      0x8C1C0F56,  //  0369  GETMET	R7	R7	K86
-      0x5C240200,  //  036A  MOVE	R9	R1
-      0x5C280400,  //  036B  MOVE	R10	R2
-      0x7C1C0600,  //  036C  CALL	R7	3
+      0x70020007,  //  0349  JMP		#0352
+      0x541EFFFB,  //  034A  LDINT	R7	65532
+      0x1C1C0C07,  //  034B  EQ	R7	R6	R7
+      0x781E0004,  //  034C  JMPF	R7	#0352
+      0x8C1C0906,  //  034D  GETMET	R7	R4	K6
+      0x8824092A,  //  034E  GETMBR	R9	R4	K42
+      0x542A0003,  //  034F  LDINT	R10	4
+      0x7C1C0600,  //  0350  CALL	R7	3
+      0x80040E00,  //  0351  RET	1	R7
+      0x7002002C,  //  0352  JMP		#0380
+      0x541E001C,  //  0353  LDINT	R7	29
+      0x1C1C0A07,  //  0354  EQ	R7	R5	R7
+      0x781E0021,  //  0355  JMPF	R7	#0378
+      0x1C1C0D0F,  //  0356  EQ	R7	R6	K15
+      0x781E0016,  //  0357  JMPF	R7	#036F
+      0x8C1C0911,  //  0358  GETMET	R7	R4	K17
+      0x7C1C0200,  //  0359  CALL	R7	1
+      0x88200133,  //  035A  GETMBR	R8	R0	K51
+      0x8C201155,  //  035B  GETMET	R8	R8	K85
+      0x50280200,  //  035C  LDBOOL	R10	1	0
+      0x7C200400,  //  035D  CALL	R8	2
+      0x60240010,  //  035E  GETGBL	R9	G16
+      0x5C281000,  //  035F  MOVE	R10	R8
+      0x7C240200,  //  0360  CALL	R9	1
+      0xA8020007,  //  0361  EXBLK	0	#036A
+      0x5C281200,  //  0362  MOVE	R10	R9
+      0x7C280000,  //  0363  CALL	R10	0
+      0x8C2C0F0B,  //  0364  GETMET	R11	R7	K11
+      0x4C340000,  //  0365  LDNIL	R13
+      0x8838090C,  //  0366  GETMBR	R14	R4	K12
+      0x5C3C1400,  //  0367  MOVE	R15	R10
+      0x7C2C0800,  //  0368  CALL	R11	4
+      0x7001FFF7,  //  0369  JMP		#0362
+      0x5824003A,  //  036A  LDCONST	R9	K58
+      0xAC240200,  //  036B  CATCH	R9	1	0
+      0xB0080000,  //  036C  RAISE	2	R0	R0
       0x80040E00,  //  036D  RET	1	R7
       0x70020007,  //  036E  JMP		#0377
       0x601C0003,  //  036F  GETGBL	R7	G3
@@ -1858,7 +1858,16 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x5C280400,  //  0374  MOVE	R10	R2
       0x7C1C0600,  //  0375  CALL	R7	3
       0x80040E00,  //  0376  RET	1	R7
-      0x80000000,  //  0377  RET	0
+      0x70020007,  //  0377  JMP		#0380
+      0x601C0003,  //  0378  GETGBL	R7	G3
+      0x5C200000,  //  0379  MOVE	R8	R0
+      0x7C1C0200,  //  037A  CALL	R7	1
+      0x8C1C0F56,  //  037B  GETMET	R7	R7	K86
+      0x5C240200,  //  037C  MOVE	R9	R1
+      0x5C280400,  //  037D  MOVE	R10	R2
+      0x7C1C0600,  //  037E  CALL	R7	3
+      0x80040E00,  //  037F  RET	1	R7
+      0x80000000,  //  0380  RET	0
     })
   )
 );
@@ -2021,7 +2030,7 @@ be_local_class(Matter_Plugin_Root,
     ( (struct bvalue*) &(const bvalue[]) {
     }))    ) } )) },
         { be_const_key_int(40, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(14,
+        be_const_list( *     be_nested_list(15,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(0),
         be_const_int(1),
@@ -2035,6 +2044,7 @@ be_local_class(Matter_Plugin_Root,
         be_const_int(9),
         be_const_int(10),
         be_const_int(15),
+        be_const_int(17),
         be_const_int(18),
         be_const_int(19),
     }))    ) } )) },

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
@@ -572,7 +572,7 @@ be_local_closure(Matter_UI_page_part_mgr_add,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_show_plugins_configuration,   /* name */
   be_nested_proto(
-    27,                          /* nstack */
+    28,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -580,7 +580,7 @@ be_local_closure(Matter_UI_show_plugins_configuration,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[62]) {     /* constants */
+    ( &(const bvalue[63]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(introspect),
@@ -617,36 +617,37 @@ be_local_closure(Matter_UI_show_plugins_configuration,   /* name */
     /* K33  */  be_nested_str_weak(push),
     /* K34  */  be_nested_str_weak(stop_iteration),
     /* K35  */  be_nested_str_weak(sort_distinct),
-    /* K36  */  be_nested_str_weak(_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X3E_X25s_X3C_X2Fa_X3E),
-    /* K37  */  be_nested_str_weak(_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
-    /* K38  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X2725_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2778_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2715_X27_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-    /* K39  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X2722_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X25i_X3C_X2Fb_X3E_X3C_X2Ftd_X3E),
-    /* K40  */  be_nested_str_weak(_X3Ctd_X20width_X3D_X2778_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X3E_X3C_X2Ftd_X3E),
-    /* K41  */  be_nested_str_weak(_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E),
-    /* K42  */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X278_X27_X20value_X3D_X27_X25s_X27_X3E_X3C_X2Ftd_X3E),
-    /* K43  */  be_nested_str_weak(_X3Ctd_X20width_X3D_X2715_X27_X20style_X3D_X27text_X2Dalign_X3Acenter_X3B_X27_X3E_X3Cbutton_X20name_X3D_X27del_X25i_X27_X20style_X3D_X27background_X3Anone_X3Bborder_X3Anone_X3Bline_X2Dheight_X3A1_X3B_X27_X20onclick_X3D_X22return_X20confirm_X28_X27Confirm_X20removing_X20endpoint_X27_X29_X22_X3E_X26_X23128293_X3B_X3C_X2Fbutton_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-    /* K44  */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    /* K45  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27config_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X20configuration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E),
-    /* K46  */  be_nested_str_weak(show_plugins_hints_js),
-    /* K47  */  be_nested_str_weak(_CLASSES_TYPES),
-    /* K48  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BAdd_X20to_X20Configuration_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    /* K49  */  be_nested_str_weak(_X3Cp_X3E_X3Cb_X3EAdd_X20local_X20sensor_X20or_X20device_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
-    /* K50  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X27100_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EName_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EType_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EParameter_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-    /* K51  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cselect_X20id_X3D_X27pi_X27_X20name_X3D_X27pi_X27_X20onchange_X3D_X27otm_X28_X22arg_X22_X2Cthis_X2Evalue_X29_X27_X3E),
-    /* K52  */  be_nested_str_weak(plugin_option),
-    /* K53  */  be_nested_str_weak(_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E),
-    /* K54  */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X27_X20name_X3D_X27arg_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E_X3C_X2Ftable_X3E),
-    /* K55  */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E),
-    /* K56  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27addep_X27_X20class_X3D_X27button_X20bgrn_X27_X3ECreate_X20new_X20endpoint_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E),
-    /* K57  */  be_nested_str_weak(_X3Chr_X3E_X3Cp_X3E_X3Cb_X3EAdd_X20Remote_X20Tasmota_X20or_X20OpenBK_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Cform_X20action_X3D_X27_X2Fmatteradd_X27_X20method_X3D_X27get_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
-    /* K58  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X2730_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3Ehttp_X3A_X2F_X2F_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3Ctd_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27url_X27_X20size_X3D_X278_X27_X20value_X3D_X27_X27_X20required_X20placeholder_X3D_X27IP_X20or_X20domain_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2710_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X2F_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E_X3C_X2Ftr_X3E_X3C_X2Ftable_X3E),
-    /* K59  */  be_nested_str_weak(_X3Cbutton_X20class_X3D_X27button_X20bgrn_X27_X3EAuto_X2Dconfigure_X20remote_X20Tasmota_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3Chr_X3E),
-    /* K60  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20RESET_X20the_X20configuration_X20to_X20the_X20default_X2E_X20You_X20will_X20need_X20to_X20associate_X20again_X2E_X22_X29_X3B_X27_X3E_X3Cbutton_X20name_X3D_X27auto_X27_X20class_X3D_X27button_X20bred_X27_X3EReset_X20all_X20and_X20Auto_X2Ddiscover_X3C_X2Fbutton_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Fform_X3E),
-    /* K61  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E),
+    /* K36  */  be_nested_str_weak(get_plugin_remote_info),
+    /* K37  */  be_nested_str_weak(_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20title_X3D_X27http_X3A_X2F_X2F_X25s_X2F_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X3E_X25s_X3C_X2Fa_X3E),
+    /* K38  */  be_nested_str_weak(_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
+    /* K39  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X2725_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2778_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2715_X27_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+    /* K40  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X2722_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X25i_X3C_X2Fb_X3E_X3C_X2Ftd_X3E),
+    /* K41  */  be_nested_str_weak(_X3Ctd_X20width_X3D_X2778_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X3E_X3C_X2Ftd_X3E),
+    /* K42  */  be_nested_str_weak(_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E),
+    /* K43  */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X278_X27_X20value_X3D_X27_X25s_X27_X3E_X3C_X2Ftd_X3E),
+    /* K44  */  be_nested_str_weak(_X3Ctd_X20width_X3D_X2715_X27_X20style_X3D_X27text_X2Dalign_X3Acenter_X3B_X27_X3E_X3Cbutton_X20name_X3D_X27del_X25i_X27_X20style_X3D_X27background_X3Anone_X3Bborder_X3Anone_X3Bline_X2Dheight_X3A1_X3B_X27_X20onclick_X3D_X22return_X20confirm_X28_X27Confirm_X20removing_X20endpoint_X27_X29_X22_X3E_X26_X23128293_X3B_X3C_X2Fbutton_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+    /* K45  */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K46  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27config_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X20configuration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E),
+    /* K47  */  be_nested_str_weak(show_plugins_hints_js),
+    /* K48  */  be_nested_str_weak(_CLASSES_TYPES),
+    /* K49  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BAdd_X20to_X20Configuration_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K50  */  be_nested_str_weak(_X3Cp_X3E_X3Cb_X3EAdd_X20local_X20sensor_X20or_X20device_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
+    /* K51  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X27100_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EName_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EType_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EParameter_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+    /* K52  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cselect_X20id_X3D_X27pi_X27_X20name_X3D_X27pi_X27_X20onchange_X3D_X27otm_X28_X22arg_X22_X2Cthis_X2Evalue_X29_X27_X3E),
+    /* K53  */  be_nested_str_weak(plugin_option),
+    /* K54  */  be_nested_str_weak(_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E),
+    /* K55  */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X27_X20name_X3D_X27arg_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E_X3C_X2Ftable_X3E),
+    /* K56  */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E),
+    /* K57  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27addep_X27_X20class_X3D_X27button_X20bgrn_X27_X3ECreate_X20new_X20endpoint_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E),
+    /* K58  */  be_nested_str_weak(_X3Chr_X3E_X3Cp_X3E_X3Cb_X3EAdd_X20Remote_X20Tasmota_X20or_X20OpenBK_X3C_X2Fb_X3E_X3C_X2Fp_X3E_X3Cform_X20action_X3D_X27_X2Fmatteradd_X27_X20method_X3D_X27get_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E),
+    /* K59  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20width_X3D_X2730_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3Ehttp_X3A_X2F_X2F_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3Ctd_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27url_X27_X20size_X3D_X278_X27_X20value_X3D_X27_X27_X20required_X20placeholder_X3D_X27IP_X20or_X20domain_X27_X3E_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X2710_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cb_X3E_X2F_X3C_X2Fb_X3E_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E_X3C_X2Ftr_X3E_X3C_X2Ftable_X3E),
+    /* K60  */  be_nested_str_weak(_X3Cbutton_X20class_X3D_X27button_X20bgrn_X27_X3EAuto_X2Dconfigure_X20remote_X20Tasmota_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3Chr_X3E),
+    /* K61  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20RESET_X20the_X20configuration_X20to_X20the_X20default_X2E_X20You_X20will_X20need_X20to_X20associate_X20again_X2E_X22_X29_X3B_X27_X3E_X3Cbutton_X20name_X3D_X27auto_X27_X20class_X3D_X27button_X20bred_X27_X3EReset_X20all_X20and_X20Auto_X2Ddiscover_X3C_X2Fbutton_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Fform_X3E),
+    /* K62  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E),
     }),
     be_str_weak(show_plugins_configuration),
     &be_const_str_solidified,
-    ( &(const binstruction[341]) {  /* code */
+    ( &(const binstruction[352]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xA40A0200,  //  0001  IMPORT	R2	K1
       0xA40E0400,  //  0002  IMPORT	R3	K2
@@ -806,188 +807,199 @@ be_local_closure(Matter_UI_show_plugins_configuration,   /* name */
       0x60200010,  //  009C  GETGBL	R8	G16
       0x5C240E00,  //  009D  MOVE	R9	R7
       0x7C200200,  //  009E  CALL	R8	1
-      0xA8020077,  //  009F  EXBLK	0	#0118
+      0xA8020082,  //  009F  EXBLK	0	#0123
       0x5C241000,  //  00A0  MOVE	R9	R8
       0x7C240000,  //  00A1  CALL	R9	0
       0x8C280316,  //  00A2  GETMET	R10	R1	K22
       0x5C301200,  //  00A3  MOVE	R12	R9
       0x7C280400,  //  00A4  CALL	R10	2
-      0x8C2C0303,  //  00A5  GETMET	R11	R1	K3
-      0x60340018,  //  00A6  GETGBL	R13	G24
-      0x58380024,  //  00A7  LDCONST	R14	K36
-      0x5C3C1400,  //  00A8  MOVE	R15	R10
-      0x5C401400,  //  00A9  MOVE	R16	R10
-      0x7C340600,  //  00AA  CALL	R13	3
-      0x7C2C0400,  //  00AB  CALL	R11	2
-      0x8C2C0303,  //  00AC  GETMET	R11	R1	K3
-      0x58340025,  //  00AD  LDCONST	R13	K37
+      0x8C2C0316,  //  00A5  GETMET	R11	R1	K22
+      0x88340107,  //  00A6  GETMBR	R13	R0	K7
+      0x8C341B24,  //  00A7  GETMET	R13	R13	K36
+      0x5C3C1200,  //  00A8  MOVE	R15	R9
+      0x7C340400,  //  00A9  CALL	R13	2
+      0x8C341B0D,  //  00AA  GETMET	R13	R13	K13
+      0x583C0017,  //  00AB  LDCONST	R15	K23
+      0x5C401200,  //  00AC  MOVE	R16	R9
+      0x7C340600,  //  00AD  CALL	R13	3
       0x7C2C0400,  //  00AE  CALL	R11	2
-      0x8C2C0303,  //  00AF  GETMET	R11	R1	K3
-      0x58340026,  //  00B0  LDCONST	R13	K38
-      0x7C2C0400,  //  00B1  CALL	R11	2
-      0x50180000,  //  00B2  LDBOOL	R6	0	0
-      0x5814000C,  //  00B3  LDCONST	R5	K12
-      0x602C000C,  //  00B4  GETGBL	R11	G12
-      0x5C300800,  //  00B5  MOVE	R12	R4
-      0x7C2C0200,  //  00B6  CALL	R11	1
-      0x142C0A0B,  //  00B7  LT	R11	R5	R11
-      0x782E005A,  //  00B8  JMPF	R11	#0114
-      0x942C0805,  //  00B9  GETIDX	R11	R4	R5
-      0x88300107,  //  00BA  GETMBR	R12	R0	K7
-      0x88301908,  //  00BB  GETMBR	R12	R12	K8
-      0x8C30190D,  //  00BC  GETMET	R12	R12	K13
-      0x60380008,  //  00BD  GETGBL	R14	G8
-      0x5C3C1600,  //  00BE  MOVE	R15	R11
-      0x7C380200,  //  00BF  CALL	R14	1
-      0x7C300400,  //  00C0  CALL	R12	2
-      0x8C34190D,  //  00C1  GETMET	R13	R12	K13
-      0x583C000E,  //  00C2  LDCONST	R15	K14
-      0x7C340400,  //  00C3  CALL	R13	2
-      0x5C381A00,  //  00C4  MOVE	R14	R13
-      0x743A0001,  //  00C5  JMPT	R14	#00C8
-      0x00140B0F,  //  00C6  ADD	R5	R5	K15
-      0x7001FFEB,  //  00C7  JMP		#00B4
-      0x8C38050D,  //  00C8  GETMET	R14	R2	K13
-      0x5C401A00,  //  00C9  MOVE	R16	R13
-      0x58440010,  //  00CA  LDCONST	R17	K16
-      0x7C380600,  //  00CB  CALL	R14	3
-      0x20381D0C,  //  00CC  NE	R14	R14	K12
-      0x783A0001,  //  00CD  JMPF	R14	#00D0
-      0x00140B0F,  //  00CE  ADD	R5	R5	K15
-      0x7001FFE3,  //  00CF  JMP		#00B4
-      0x8C38190D,  //  00D0  GETMET	R14	R12	K13
-      0x58400020,  //  00D1  LDCONST	R16	K32
-      0x7C380400,  //  00D2  CALL	R14	2
-      0x20381C09,  //  00D3  NE	R14	R14	R9
-      0x783A0001,  //  00D4  JMPF	R14	#00D7
-      0x00140B0F,  //  00D5  ADD	R5	R5	K15
-      0x7001FFDC,  //  00D6  JMP		#00B4
-      0x88380107,  //  00D7  GETMBR	R14	R0	K7
-      0x88381D11,  //  00D8  GETMBR	R14	R14	K17
-      0x8C381D0D,  //  00D9  GETMET	R14	R14	K13
-      0x5C401A00,  //  00DA  MOVE	R16	R13
-      0x7C380400,  //  00DB  CALL	R14	2
-      0x583C0012,  //  00DC  LDCONST	R15	K18
-      0x4C400000,  //  00DD  LDNIL	R16
-      0x20401C10,  //  00DE  NE	R16	R14	R16
-      0x78420004,  //  00DF  JMPF	R16	#00E5
-      0x8C401D13,  //  00E0  GETMET	R16	R14	K19
-      0x5C481C00,  //  00E1  MOVE	R18	R14
-      0x5C4C1800,  //  00E2  MOVE	R19	R12
-      0x7C400600,  //  00E3  CALL	R16	3
-      0x5C3C2000,  //  00E4  MOVE	R15	R16
-      0x50180200,  //  00E5  LDBOOL	R6	1	0
-      0x8C400303,  //  00E6  GETMET	R16	R1	K3
-      0x60480018,  //  00E7  GETGBL	R18	G24
-      0x584C0027,  //  00E8  LDCONST	R19	K39
-      0x5C501600,  //  00E9  MOVE	R20	R11
-      0x7C480400,  //  00EA  CALL	R18	2
-      0x7C400400,  //  00EB  CALL	R16	2
-      0x8C400303,  //  00EC  GETMET	R16	R1	K3
-      0x60480018,  //  00ED  GETGBL	R18	G24
-      0x584C0028,  //  00EE  LDCONST	R19	K40
-      0x5C501600,  //  00EF  MOVE	R20	R11
-      0x8C540316,  //  00F0  GETMET	R21	R1	K22
-      0x8C5C190D,  //  00F1  GETMET	R23	R12	K13
-      0x58640017,  //  00F2  LDCONST	R25	K23
-      0x58680012,  //  00F3  LDCONST	R26	K18
-      0x7C5C0600,  //  00F4  CALL	R23	3
-      0x7C540400,  //  00F5  CALL	R21	2
-      0x7C480600,  //  00F6  CALL	R18	3
-      0x7C400400,  //  00F7  CALL	R16	2
-      0x8C400303,  //  00F8  GETMET	R16	R1	K3
-      0x60480018,  //  00F9  GETGBL	R18	G24
-      0x584C0029,  //  00FA  LDCONST	R19	K41
-      0x8C500119,  //  00FB  GETMET	R20	R0	K25
-      0x8C58190D,  //  00FC  GETMET	R22	R12	K13
-      0x5860000E,  //  00FD  LDCONST	R24	K14
-      0x58640012,  //  00FE  LDCONST	R25	K18
-      0x7C580600,  //  00FF  CALL	R22	3
-      0x7C500400,  //  0100  CALL	R20	2
-      0x7C480400,  //  0101  CALL	R18	2
-      0x7C400400,  //  0102  CALL	R16	2
-      0x8C400303,  //  0103  GETMET	R16	R1	K3
-      0x60480018,  //  0104  GETGBL	R18	G24
-      0x584C002A,  //  0105  LDCONST	R19	K42
-      0x5C501600,  //  0106  MOVE	R20	R11
-      0x8C540316,  //  0107  GETMET	R21	R1	K22
-      0x5C5C1E00,  //  0108  MOVE	R23	R15
-      0x7C540400,  //  0109  CALL	R21	2
-      0x7C480600,  //  010A  CALL	R18	3
-      0x7C400400,  //  010B  CALL	R16	2
-      0x8C400303,  //  010C  GETMET	R16	R1	K3
-      0x60480018,  //  010D  GETGBL	R18	G24
-      0x584C002B,  //  010E  LDCONST	R19	K43
-      0x5C501600,  //  010F  MOVE	R20	R11
-      0x7C480400,  //  0110  CALL	R18	2
-      0x7C400400,  //  0111  CALL	R16	2
-      0x00140B0F,  //  0112  ADD	R5	R5	K15
-      0x7001FF9F,  //  0113  JMP		#00B4
-      0x8C2C0303,  //  0114  GETMET	R11	R1	K3
-      0x5834002C,  //  0115  LDCONST	R13	K44
-      0x7C2C0400,  //  0116  CALL	R11	2
-      0x7001FF87,  //  0117  JMP		#00A0
-      0x58200022,  //  0118  LDCONST	R8	K34
-      0xAC200200,  //  0119  CATCH	R8	1	0
-      0xB0080000,  //  011A  RAISE	2	R0	R0
-      0x5C200C00,  //  011B  MOVE	R8	R6
-      0x74220002,  //  011C  JMPT	R8	#0120
-      0x8C200303,  //  011D  GETMET	R8	R1	K3
-      0x5828001E,  //  011E  LDCONST	R10	K30
-      0x7C200400,  //  011F  CALL	R8	2
-      0x8C200303,  //  0120  GETMET	R8	R1	K3
-      0x5828002D,  //  0121  LDCONST	R10	K45
-      0x7C200400,  //  0122  CALL	R8	2
-      0x8C20012E,  //  0123  GETMET	R8	R0	K46
-      0x8828012F,  //  0124  GETMBR	R10	R0	K47
-      0x7C200400,  //  0125  CALL	R8	2
-      0x8C200303,  //  0126  GETMET	R8	R1	K3
-      0x58280030,  //  0127  LDCONST	R10	K48
-      0x7C200400,  //  0128  CALL	R8	2
-      0x8C200303,  //  0129  GETMET	R8	R1	K3
-      0x58280031,  //  012A  LDCONST	R10	K49
-      0x7C200400,  //  012B  CALL	R8	2
-      0x8C200303,  //  012C  GETMET	R8	R1	K3
-      0x58280032,  //  012D  LDCONST	R10	K50
-      0x7C200400,  //  012E  CALL	R8	2
-      0x8C200303,  //  012F  GETMET	R8	R1	K3
-      0x58280033,  //  0130  LDCONST	R10	K51
-      0x7C200400,  //  0131  CALL	R8	2
-      0x8C200134,  //  0132  GETMET	R8	R0	K52
-      0x58280012,  //  0133  LDCONST	R10	K18
-      0x882C012F,  //  0134  GETMBR	R11	R0	K47
-      0x7C200600,  //  0135  CALL	R8	3
-      0x8C200303,  //  0136  GETMET	R8	R1	K3
-      0x58280035,  //  0137  LDCONST	R10	K53
-      0x7C200400,  //  0138  CALL	R8	2
-      0x8C200303,  //  0139  GETMET	R8	R1	K3
-      0x58280036,  //  013A  LDCONST	R10	K54
-      0x7C200400,  //  013B  CALL	R8	2
-      0x8C200303,  //  013C  GETMET	R8	R1	K3
-      0x58280037,  //  013D  LDCONST	R10	K55
-      0x7C200400,  //  013E  CALL	R8	2
-      0x8C200303,  //  013F  GETMET	R8	R1	K3
-      0x58280038,  //  0140  LDCONST	R10	K56
-      0x7C200400,  //  0141  CALL	R8	2
-      0x8C200303,  //  0142  GETMET	R8	R1	K3
-      0x58280039,  //  0143  LDCONST	R10	K57
-      0x7C200400,  //  0144  CALL	R8	2
-      0x8C200303,  //  0145  GETMET	R8	R1	K3
-      0x5828003A,  //  0146  LDCONST	R10	K58
-      0x7C200400,  //  0147  CALL	R8	2
-      0x8C200303,  //  0148  GETMET	R8	R1	K3
-      0x58280037,  //  0149  LDCONST	R10	K55
-      0x7C200400,  //  014A  CALL	R8	2
-      0x8C200303,  //  014B  GETMET	R8	R1	K3
-      0x5828003B,  //  014C  LDCONST	R10	K59
-      0x7C200400,  //  014D  CALL	R8	2
-      0x8C200303,  //  014E  GETMET	R8	R1	K3
-      0x5828003C,  //  014F  LDCONST	R10	K60
-      0x7C200400,  //  0150  CALL	R8	2
-      0x8C200303,  //  0151  GETMET	R8	R1	K3
-      0x5828003D,  //  0152  LDCONST	R10	K61
-      0x7C200400,  //  0153  CALL	R8	2
-      0x80000000,  //  0154  RET	0
+      0x8C300303,  //  00AF  GETMET	R12	R1	K3
+      0x60380018,  //  00B0  GETGBL	R14	G24
+      0x583C0025,  //  00B1  LDCONST	R15	K37
+      0x5C401400,  //  00B2  MOVE	R16	R10
+      0x5C441400,  //  00B3  MOVE	R17	R10
+      0x5C481600,  //  00B4  MOVE	R18	R11
+      0x7C380800,  //  00B5  CALL	R14	4
+      0x7C300400,  //  00B6  CALL	R12	2
+      0x8C300303,  //  00B7  GETMET	R12	R1	K3
+      0x58380026,  //  00B8  LDCONST	R14	K38
+      0x7C300400,  //  00B9  CALL	R12	2
+      0x8C300303,  //  00BA  GETMET	R12	R1	K3
+      0x58380027,  //  00BB  LDCONST	R14	K39
+      0x7C300400,  //  00BC  CALL	R12	2
+      0x50180000,  //  00BD  LDBOOL	R6	0	0
+      0x5814000C,  //  00BE  LDCONST	R5	K12
+      0x6030000C,  //  00BF  GETGBL	R12	G12
+      0x5C340800,  //  00C0  MOVE	R13	R4
+      0x7C300200,  //  00C1  CALL	R12	1
+      0x14300A0C,  //  00C2  LT	R12	R5	R12
+      0x7832005A,  //  00C3  JMPF	R12	#011F
+      0x94300805,  //  00C4  GETIDX	R12	R4	R5
+      0x88340107,  //  00C5  GETMBR	R13	R0	K7
+      0x88341B08,  //  00C6  GETMBR	R13	R13	K8
+      0x8C341B0D,  //  00C7  GETMET	R13	R13	K13
+      0x603C0008,  //  00C8  GETGBL	R15	G8
+      0x5C401800,  //  00C9  MOVE	R16	R12
+      0x7C3C0200,  //  00CA  CALL	R15	1
+      0x7C340400,  //  00CB  CALL	R13	2
+      0x8C381B0D,  //  00CC  GETMET	R14	R13	K13
+      0x5840000E,  //  00CD  LDCONST	R16	K14
+      0x7C380400,  //  00CE  CALL	R14	2
+      0x5C3C1C00,  //  00CF  MOVE	R15	R14
+      0x743E0001,  //  00D0  JMPT	R15	#00D3
+      0x00140B0F,  //  00D1  ADD	R5	R5	K15
+      0x7001FFEB,  //  00D2  JMP		#00BF
+      0x8C3C050D,  //  00D3  GETMET	R15	R2	K13
+      0x5C441C00,  //  00D4  MOVE	R17	R14
+      0x58480010,  //  00D5  LDCONST	R18	K16
+      0x7C3C0600,  //  00D6  CALL	R15	3
+      0x203C1F0C,  //  00D7  NE	R15	R15	K12
+      0x783E0001,  //  00D8  JMPF	R15	#00DB
+      0x00140B0F,  //  00D9  ADD	R5	R5	K15
+      0x7001FFE3,  //  00DA  JMP		#00BF
+      0x8C3C1B0D,  //  00DB  GETMET	R15	R13	K13
+      0x58440020,  //  00DC  LDCONST	R17	K32
+      0x7C3C0400,  //  00DD  CALL	R15	2
+      0x203C1E09,  //  00DE  NE	R15	R15	R9
+      0x783E0001,  //  00DF  JMPF	R15	#00E2
+      0x00140B0F,  //  00E0  ADD	R5	R5	K15
+      0x7001FFDC,  //  00E1  JMP		#00BF
+      0x883C0107,  //  00E2  GETMBR	R15	R0	K7
+      0x883C1F11,  //  00E3  GETMBR	R15	R15	K17
+      0x8C3C1F0D,  //  00E4  GETMET	R15	R15	K13
+      0x5C441C00,  //  00E5  MOVE	R17	R14
+      0x7C3C0400,  //  00E6  CALL	R15	2
+      0x58400012,  //  00E7  LDCONST	R16	K18
+      0x4C440000,  //  00E8  LDNIL	R17
+      0x20441E11,  //  00E9  NE	R17	R15	R17
+      0x78460004,  //  00EA  JMPF	R17	#00F0
+      0x8C441F13,  //  00EB  GETMET	R17	R15	K19
+      0x5C4C1E00,  //  00EC  MOVE	R19	R15
+      0x5C501A00,  //  00ED  MOVE	R20	R13
+      0x7C440600,  //  00EE  CALL	R17	3
+      0x5C402200,  //  00EF  MOVE	R16	R17
+      0x50180200,  //  00F0  LDBOOL	R6	1	0
+      0x8C440303,  //  00F1  GETMET	R17	R1	K3
+      0x604C0018,  //  00F2  GETGBL	R19	G24
+      0x58500028,  //  00F3  LDCONST	R20	K40
+      0x5C541800,  //  00F4  MOVE	R21	R12
+      0x7C4C0400,  //  00F5  CALL	R19	2
+      0x7C440400,  //  00F6  CALL	R17	2
+      0x8C440303,  //  00F7  GETMET	R17	R1	K3
+      0x604C0018,  //  00F8  GETGBL	R19	G24
+      0x58500029,  //  00F9  LDCONST	R20	K41
+      0x5C541800,  //  00FA  MOVE	R21	R12
+      0x8C580316,  //  00FB  GETMET	R22	R1	K22
+      0x8C601B0D,  //  00FC  GETMET	R24	R13	K13
+      0x58680017,  //  00FD  LDCONST	R26	K23
+      0x586C0012,  //  00FE  LDCONST	R27	K18
+      0x7C600600,  //  00FF  CALL	R24	3
+      0x7C580400,  //  0100  CALL	R22	2
+      0x7C4C0600,  //  0101  CALL	R19	3
+      0x7C440400,  //  0102  CALL	R17	2
+      0x8C440303,  //  0103  GETMET	R17	R1	K3
+      0x604C0018,  //  0104  GETGBL	R19	G24
+      0x5850002A,  //  0105  LDCONST	R20	K42
+      0x8C540119,  //  0106  GETMET	R21	R0	K25
+      0x8C5C1B0D,  //  0107  GETMET	R23	R13	K13
+      0x5864000E,  //  0108  LDCONST	R25	K14
+      0x58680012,  //  0109  LDCONST	R26	K18
+      0x7C5C0600,  //  010A  CALL	R23	3
+      0x7C540400,  //  010B  CALL	R21	2
+      0x7C4C0400,  //  010C  CALL	R19	2
+      0x7C440400,  //  010D  CALL	R17	2
+      0x8C440303,  //  010E  GETMET	R17	R1	K3
+      0x604C0018,  //  010F  GETGBL	R19	G24
+      0x5850002B,  //  0110  LDCONST	R20	K43
+      0x5C541800,  //  0111  MOVE	R21	R12
+      0x8C580316,  //  0112  GETMET	R22	R1	K22
+      0x5C602000,  //  0113  MOVE	R24	R16
+      0x7C580400,  //  0114  CALL	R22	2
+      0x7C4C0600,  //  0115  CALL	R19	3
+      0x7C440400,  //  0116  CALL	R17	2
+      0x8C440303,  //  0117  GETMET	R17	R1	K3
+      0x604C0018,  //  0118  GETGBL	R19	G24
+      0x5850002C,  //  0119  LDCONST	R20	K44
+      0x5C541800,  //  011A  MOVE	R21	R12
+      0x7C4C0400,  //  011B  CALL	R19	2
+      0x7C440400,  //  011C  CALL	R17	2
+      0x00140B0F,  //  011D  ADD	R5	R5	K15
+      0x7001FF9F,  //  011E  JMP		#00BF
+      0x8C300303,  //  011F  GETMET	R12	R1	K3
+      0x5838002D,  //  0120  LDCONST	R14	K45
+      0x7C300400,  //  0121  CALL	R12	2
+      0x7001FF7C,  //  0122  JMP		#00A0
+      0x58200022,  //  0123  LDCONST	R8	K34
+      0xAC200200,  //  0124  CATCH	R8	1	0
+      0xB0080000,  //  0125  RAISE	2	R0	R0
+      0x5C200C00,  //  0126  MOVE	R8	R6
+      0x74220002,  //  0127  JMPT	R8	#012B
+      0x8C200303,  //  0128  GETMET	R8	R1	K3
+      0x5828001E,  //  0129  LDCONST	R10	K30
+      0x7C200400,  //  012A  CALL	R8	2
+      0x8C200303,  //  012B  GETMET	R8	R1	K3
+      0x5828002E,  //  012C  LDCONST	R10	K46
+      0x7C200400,  //  012D  CALL	R8	2
+      0x8C20012F,  //  012E  GETMET	R8	R0	K47
+      0x88280130,  //  012F  GETMBR	R10	R0	K48
+      0x7C200400,  //  0130  CALL	R8	2
+      0x8C200303,  //  0131  GETMET	R8	R1	K3
+      0x58280031,  //  0132  LDCONST	R10	K49
+      0x7C200400,  //  0133  CALL	R8	2
+      0x8C200303,  //  0134  GETMET	R8	R1	K3
+      0x58280032,  //  0135  LDCONST	R10	K50
+      0x7C200400,  //  0136  CALL	R8	2
+      0x8C200303,  //  0137  GETMET	R8	R1	K3
+      0x58280033,  //  0138  LDCONST	R10	K51
+      0x7C200400,  //  0139  CALL	R8	2
+      0x8C200303,  //  013A  GETMET	R8	R1	K3
+      0x58280034,  //  013B  LDCONST	R10	K52
+      0x7C200400,  //  013C  CALL	R8	2
+      0x8C200135,  //  013D  GETMET	R8	R0	K53
+      0x58280012,  //  013E  LDCONST	R10	K18
+      0x882C0130,  //  013F  GETMBR	R11	R0	K48
+      0x7C200600,  //  0140  CALL	R8	3
+      0x8C200303,  //  0141  GETMET	R8	R1	K3
+      0x58280036,  //  0142  LDCONST	R10	K54
+      0x7C200400,  //  0143  CALL	R8	2
+      0x8C200303,  //  0144  GETMET	R8	R1	K3
+      0x58280037,  //  0145  LDCONST	R10	K55
+      0x7C200400,  //  0146  CALL	R8	2
+      0x8C200303,  //  0147  GETMET	R8	R1	K3
+      0x58280038,  //  0148  LDCONST	R10	K56
+      0x7C200400,  //  0149  CALL	R8	2
+      0x8C200303,  //  014A  GETMET	R8	R1	K3
+      0x58280039,  //  014B  LDCONST	R10	K57
+      0x7C200400,  //  014C  CALL	R8	2
+      0x8C200303,  //  014D  GETMET	R8	R1	K3
+      0x5828003A,  //  014E  LDCONST	R10	K58
+      0x7C200400,  //  014F  CALL	R8	2
+      0x8C200303,  //  0150  GETMET	R8	R1	K3
+      0x5828003B,  //  0151  LDCONST	R10	K59
+      0x7C200400,  //  0152  CALL	R8	2
+      0x8C200303,  //  0153  GETMET	R8	R1	K3
+      0x58280038,  //  0154  LDCONST	R10	K56
+      0x7C200400,  //  0155  CALL	R8	2
+      0x8C200303,  //  0156  GETMET	R8	R1	K3
+      0x5828003C,  //  0157  LDCONST	R10	K60
+      0x7C200400,  //  0158  CALL	R8	2
+      0x8C200303,  //  0159  GETMET	R8	R1	K3
+      0x5828003D,  //  015A  LDCONST	R10	K61
+      0x7C200400,  //  015B  CALL	R8	2
+      0x8C200303,  //  015C  GETMET	R8	R1	K3
+      0x5828003E,  //  015D  LDCONST	R10	K62
+      0x7C200400,  //  015E  CALL	R8	2
+      0x80000000,  //  015F  RET	0
     })
   )
 );
@@ -1098,7 +1110,7 @@ be_local_closure(Matter_UI_show_commissioning_info,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_show_remote_autoconf,   /* name */
   be_nested_proto(
-    24,                          /* nstack */
+    25,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1130,8 +1142,8 @@ be_local_closure(Matter_UI_show_remote_autoconf,   /* name */
     /* K20  */  be_nested_str_weak(_CLASSES_TYPES2),
     /* K21  */  be_nested_str_weak(content_send),
     /* K22  */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20Remote_X20Device_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3EAdd_X20Remote_X20sensor_X20or_X20device_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
-    /* K23  */  be_nested_str_weak(_X3Cp_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Fp_X3E),
-    /* K24  */  be_nested_str_weak(html_escape),
+    /* K23  */  be_nested_str_weak(html_escape),
+    /* K24  */  be_nested_str_weak(_X3Cp_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Fp_X3E),
     /* K25  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E_X3Ctr_X3E_X3Ctd_X20width_X3D_X27100_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EName_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EType_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EParameter_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
     /* K26  */  be_nested_str_weak(_X3Cinput_X20name_X3D_X27url_X27_X20type_X3D_X27hidden_X27_X20value_X3D_X27_X25s_X27_X3E),
     /* K27  */  be_const_int(0),
@@ -1168,219 +1180,219 @@ be_local_closure(Matter_UI_show_remote_autoconf,   /* name */
       0x88100905,  //  0007  GETMBR	R4	R4	K5
       0xB8160600,  //  0008  GETNGBL	R5	K3
       0x8C140B06,  //  0009  GETMET	R5	R5	K6
-      0x5C1C0200,  //  000A  MOVE	R7	R1
-      0x5C200800,  //  000B  MOVE	R8	R4
-      0x7C140600,  //  000C  CALL	R5	3
-      0x8C180B07,  //  000D  GETMET	R6	R5	K7
-      0x58200008,  //  000E  LDCONST	R8	K8
-      0x5C240800,  //  000F  MOVE	R9	R4
-      0x7C180600,  //  0010  CALL	R6	3
-      0x4C1C0000,  //  0011  LDNIL	R7
-      0x201C0C07,  //  0012  NE	R7	R6	R7
-      0x781E0003,  //  0013  JMPF	R7	#0018
-      0x8C1C0709,  //  0014  GETMET	R7	R3	K9
-      0x5C240C00,  //  0015  MOVE	R9	R6
-      0x7C1C0400,  //  0016  CALL	R7	2
-      0x5C180E00,  //  0017  MOVE	R6	R7
-      0x4C1C0000,  //  0018  LDNIL	R7
-      0x201C0C07,  //  0019  NE	R7	R6	R7
-      0x781E0003,  //  001A  JMPF	R7	#001F
-      0x8C1C0D0A,  //  001B  GETMET	R7	R6	K10
-      0x5824000B,  //  001C  LDCONST	R9	K11
-      0x7C1C0400,  //  001D  CALL	R7	2
-      0x5C180E00,  //  001E  MOVE	R6	R7
-      0x4C1C0000,  //  001F  LDNIL	R7
-      0x4C200000,  //  0020  LDNIL	R8
-      0x20200C08,  //  0021  NE	R8	R6	R8
-      0x78220012,  //  0022  JMPF	R8	#0036
-      0x8C200B07,  //  0023  GETMET	R8	R5	K7
-      0x5828000C,  //  0024  LDCONST	R10	K12
-      0x5C2C0800,  //  0025  MOVE	R11	R4
-      0x7C200600,  //  0026  CALL	R8	3
-      0x5C1C1000,  //  0027  MOVE	R7	R8
-      0x4C200000,  //  0028  LDNIL	R8
-      0x20200E08,  //  0029  NE	R8	R7	R8
-      0x78220003,  //  002A  JMPF	R8	#002F
-      0x8C200709,  //  002B  GETMET	R8	R3	K9
-      0x5C280E00,  //  002C  MOVE	R10	R7
-      0x7C200400,  //  002D  CALL	R8	2
-      0x5C1C1000,  //  002E  MOVE	R7	R8
-      0x4C200000,  //  002F  LDNIL	R8
-      0x20200E08,  //  0030  NE	R8	R7	R8
-      0x78220003,  //  0031  JMPF	R8	#0036
-      0x8C200F0A,  //  0032  GETMET	R8	R7	K10
-      0x5828000D,  //  0033  LDCONST	R10	K13
-      0x7C200400,  //  0034  CALL	R8	2
-      0x5C1C1000,  //  0035  MOVE	R7	R8
-      0x4C200000,  //  0036  LDNIL	R8
-      0x20200C08,  //  0037  NE	R8	R6	R8
-      0x782200A1,  //  0038  JMPF	R8	#00DB
-      0x4C200000,  //  0039  LDNIL	R8
-      0x20200E08,  //  003A  NE	R8	R7	R8
-      0x7822009E,  //  003B  JMPF	R8	#00DB
-      0xB8221C00,  //  003C  GETNGBL	R8	K14
-      0x8C20110F,  //  003D  GETMET	R8	R8	K15
-      0x60280018,  //  003E  GETGBL	R10	G24
-      0x582C0010,  //  003F  LDCONST	R11	K16
-      0x5C300200,  //  0040  MOVE	R12	R1
-      0x60340008,  //  0041  GETGBL	R13	G8
-      0x5C380C00,  //  0042  MOVE	R14	R6
-      0x7C340200,  //  0043  CALL	R13	1
-      0x60380008,  //  0044  GETGBL	R14	G8
-      0x5C3C0E00,  //  0045  MOVE	R15	R7
-      0x7C380200,  //  0046  CALL	R14	1
-      0x7C280800,  //  0047  CALL	R10	4
-      0x582C0011,  //  0048  LDCONST	R11	K17
-      0x7C200600,  //  0049  CALL	R8	3
-      0x8C200112,  //  004A  GETMET	R8	R0	K18
-      0x5C280C00,  //  004B  MOVE	R10	R6
-      0x5C2C0E00,  //  004C  MOVE	R11	R7
-      0x7C200600,  //  004D  CALL	R8	3
-      0x8C240113,  //  004E  GETMET	R9	R0	K19
-      0x882C0114,  //  004F  GETMBR	R11	R0	K20
-      0x7C240400,  //  0050  CALL	R9	2
-      0x8C240515,  //  0051  GETMET	R9	R2	K21
-      0x582C0016,  //  0052  LDCONST	R11	K22
-      0x7C240400,  //  0053  CALL	R9	2
-      0x8C240515,  //  0054  GETMET	R9	R2	K21
-      0x602C0018,  //  0055  GETGBL	R11	G24
-      0x58300017,  //  0056  LDCONST	R12	K23
-      0x8C340518,  //  0057  GETMET	R13	R2	K24
-      0x5C3C0200,  //  0058  MOVE	R15	R1
-      0x7C340400,  //  0059  CALL	R13	2
-      0x8C380518,  //  005A  GETMET	R14	R2	K24
-      0x5C400200,  //  005B  MOVE	R16	R1
-      0x7C380400,  //  005C  CALL	R14	2
-      0x7C2C0600,  //  005D  CALL	R11	3
-      0x7C240400,  //  005E  CALL	R9	2
-      0x8C240515,  //  005F  GETMET	R9	R2	K21
-      0x582C0019,  //  0060  LDCONST	R11	K25
-      0x7C240400,  //  0061  CALL	R9	2
-      0x8C240515,  //  0062  GETMET	R9	R2	K21
-      0x602C0018,  //  0063  GETGBL	R11	G24
-      0x5830001A,  //  0064  LDCONST	R12	K26
-      0x8C340518,  //  0065  GETMET	R13	R2	K24
-      0x5C3C0200,  //  0066  MOVE	R15	R1
-      0x7C340400,  //  0067  CALL	R13	2
-      0x7C2C0400,  //  0068  CALL	R11	2
-      0x7C240400,  //  0069  CALL	R9	2
-      0x5824001B,  //  006A  LDCONST	R9	K27
-      0x6028000C,  //  006B  GETGBL	R10	G12
-      0x5C2C1000,  //  006C  MOVE	R11	R8
-      0x7C280200,  //  006D  CALL	R10	1
-      0x1428120A,  //  006E  LT	R10	R9	R10
-      0x782A003E,  //  006F  JMPF	R10	#00AF
-      0x94281009,  //  0070  GETIDX	R10	R8	R9
-      0x8C2C150A,  //  0071  GETMET	R11	R10	K10
-      0x5834001C,  //  0072  LDCONST	R13	K28
-      0x58380002,  //  0073  LDCONST	R14	K2
-      0x7C2C0600,  //  0074  CALL	R11	3
-      0x20301702,  //  0075  NE	R12	R11	K2
-      0x78320000,  //  0076  JMPF	R12	#0078
-      0x002E3A0B,  //  0077  ADD	R11	K29	R11
-      0x8830011E,  //  0078  GETMBR	R12	R0	K30
-      0x8830191F,  //  0079  GETMBR	R12	R12	K31
-      0x8C30190A,  //  007A  GETMET	R12	R12	K10
-      0x5C381600,  //  007B  MOVE	R14	R11
-      0x7C300400,  //  007C  CALL	R12	2
-      0x58340002,  //  007D  LDCONST	R13	K2
-      0x4C380000,  //  007E  LDNIL	R14
-      0x2038180E,  //  007F  NE	R14	R12	R14
-      0x783A0004,  //  0080  JMPF	R14	#0086
-      0x8C381920,  //  0081  GETMET	R14	R12	K32
-      0x5C401800,  //  0082  MOVE	R16	R12
-      0x5C441400,  //  0083  MOVE	R17	R10
-      0x7C380600,  //  0084  CALL	R14	3
-      0x5C341C00,  //  0085  MOVE	R13	R14
-      0x8C380515,  //  0086  GETMET	R14	R2	K21
-      0x60400018,  //  0087  GETGBL	R16	G24
-      0x58440021,  //  0088  LDCONST	R17	K33
-      0x5C481200,  //  0089  MOVE	R18	R9
-      0x7C400400,  //  008A  CALL	R16	2
-      0x7C380400,  //  008B  CALL	R14	2
-      0x8C380515,  //  008C  GETMET	R14	R2	K21
-      0x60400018,  //  008D  GETGBL	R16	G24
-      0x58440022,  //  008E  LDCONST	R17	K34
-      0x5C481200,  //  008F  MOVE	R18	R9
-      0x5C4C1200,  //  0090  MOVE	R19	R9
-      0x7C400600,  //  0091  CALL	R16	3
-      0x7C380400,  //  0092  CALL	R14	2
-      0x8C380123,  //  0093  GETMET	R14	R0	K35
-      0x5C401600,  //  0094  MOVE	R16	R11
-      0x88440114,  //  0095  GETMBR	R17	R0	K20
-      0x7C380600,  //  0096  CALL	R14	3
-      0x8C380515,  //  0097  GETMET	R14	R2	K21
-      0x58400024,  //  0098  LDCONST	R16	K36
-      0x7C380400,  //  0099  CALL	R14	2
-      0x8C380515,  //  009A  GETMET	R14	R2	K21
-      0x60400018,  //  009B  GETGBL	R16	G24
-      0x58440025,  //  009C  LDCONST	R17	K37
-      0x5C481200,  //  009D  MOVE	R18	R9
-      0x5C4C1200,  //  009E  MOVE	R19	R9
-      0x8C500518,  //  009F  GETMET	R20	R2	K24
-      0x5C581A00,  //  00A0  MOVE	R22	R13
-      0x7C500400,  //  00A1  CALL	R20	2
-      0x78320003,  //  00A2  JMPF	R12	#00A7
-      0x8C540518,  //  00A3  GETMET	R21	R2	K24
-      0x885C1926,  //  00A4  GETMBR	R23	R12	K38
-      0x7C540400,  //  00A5  CALL	R21	2
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x5C200200,  //  000B  MOVE	R8	R1
+      0x5C240800,  //  000C  MOVE	R9	R4
+      0x7C140800,  //  000D  CALL	R5	4
+      0x8C180B07,  //  000E  GETMET	R6	R5	K7
+      0x58200008,  //  000F  LDCONST	R8	K8
+      0x5C240800,  //  0010  MOVE	R9	R4
+      0x7C180600,  //  0011  CALL	R6	3
+      0x4C1C0000,  //  0012  LDNIL	R7
+      0x201C0C07,  //  0013  NE	R7	R6	R7
+      0x781E0003,  //  0014  JMPF	R7	#0019
+      0x8C1C0709,  //  0015  GETMET	R7	R3	K9
+      0x5C240C00,  //  0016  MOVE	R9	R6
+      0x7C1C0400,  //  0017  CALL	R7	2
+      0x5C180E00,  //  0018  MOVE	R6	R7
+      0x4C1C0000,  //  0019  LDNIL	R7
+      0x201C0C07,  //  001A  NE	R7	R6	R7
+      0x781E0003,  //  001B  JMPF	R7	#0020
+      0x8C1C0D0A,  //  001C  GETMET	R7	R6	K10
+      0x5824000B,  //  001D  LDCONST	R9	K11
+      0x7C1C0400,  //  001E  CALL	R7	2
+      0x5C180E00,  //  001F  MOVE	R6	R7
+      0x4C1C0000,  //  0020  LDNIL	R7
+      0x4C200000,  //  0021  LDNIL	R8
+      0x20200C08,  //  0022  NE	R8	R6	R8
+      0x78220012,  //  0023  JMPF	R8	#0037
+      0x8C200B07,  //  0024  GETMET	R8	R5	K7
+      0x5828000C,  //  0025  LDCONST	R10	K12
+      0x5C2C0800,  //  0026  MOVE	R11	R4
+      0x7C200600,  //  0027  CALL	R8	3
+      0x5C1C1000,  //  0028  MOVE	R7	R8
+      0x4C200000,  //  0029  LDNIL	R8
+      0x20200E08,  //  002A  NE	R8	R7	R8
+      0x78220003,  //  002B  JMPF	R8	#0030
+      0x8C200709,  //  002C  GETMET	R8	R3	K9
+      0x5C280E00,  //  002D  MOVE	R10	R7
+      0x7C200400,  //  002E  CALL	R8	2
+      0x5C1C1000,  //  002F  MOVE	R7	R8
+      0x4C200000,  //  0030  LDNIL	R8
+      0x20200E08,  //  0031  NE	R8	R7	R8
+      0x78220003,  //  0032  JMPF	R8	#0037
+      0x8C200F0A,  //  0033  GETMET	R8	R7	K10
+      0x5828000D,  //  0034  LDCONST	R10	K13
+      0x7C200400,  //  0035  CALL	R8	2
+      0x5C1C1000,  //  0036  MOVE	R7	R8
+      0x4C200000,  //  0037  LDNIL	R8
+      0x20200C08,  //  0038  NE	R8	R6	R8
+      0x782200A0,  //  0039  JMPF	R8	#00DB
+      0x4C200000,  //  003A  LDNIL	R8
+      0x20200E08,  //  003B  NE	R8	R7	R8
+      0x7822009D,  //  003C  JMPF	R8	#00DB
+      0xB8221C00,  //  003D  GETNGBL	R8	K14
+      0x8C20110F,  //  003E  GETMET	R8	R8	K15
+      0x60280018,  //  003F  GETGBL	R10	G24
+      0x582C0010,  //  0040  LDCONST	R11	K16
+      0x5C300200,  //  0041  MOVE	R12	R1
+      0x60340008,  //  0042  GETGBL	R13	G8
+      0x5C380C00,  //  0043  MOVE	R14	R6
+      0x7C340200,  //  0044  CALL	R13	1
+      0x60380008,  //  0045  GETGBL	R14	G8
+      0x5C3C0E00,  //  0046  MOVE	R15	R7
+      0x7C380200,  //  0047  CALL	R14	1
+      0x7C280800,  //  0048  CALL	R10	4
+      0x582C0011,  //  0049  LDCONST	R11	K17
+      0x7C200600,  //  004A  CALL	R8	3
+      0x8C200112,  //  004B  GETMET	R8	R0	K18
+      0x5C280C00,  //  004C  MOVE	R10	R6
+      0x5C2C0E00,  //  004D  MOVE	R11	R7
+      0x7C200600,  //  004E  CALL	R8	3
+      0x8C240113,  //  004F  GETMET	R9	R0	K19
+      0x882C0114,  //  0050  GETMBR	R11	R0	K20
+      0x7C240400,  //  0051  CALL	R9	2
+      0x8C240515,  //  0052  GETMET	R9	R2	K21
+      0x582C0016,  //  0053  LDCONST	R11	K22
+      0x7C240400,  //  0054  CALL	R9	2
+      0x8C240517,  //  0055  GETMET	R9	R2	K23
+      0x5C2C0200,  //  0056  MOVE	R11	R1
+      0x7C240400,  //  0057  CALL	R9	2
+      0x8C280515,  //  0058  GETMET	R10	R2	K21
+      0x60300018,  //  0059  GETGBL	R12	G24
+      0x58340018,  //  005A  LDCONST	R13	K24
+      0x5C381200,  //  005B  MOVE	R14	R9
+      0x5C3C1200,  //  005C  MOVE	R15	R9
+      0x7C300600,  //  005D  CALL	R12	3
+      0x7C280400,  //  005E  CALL	R10	2
+      0x8C280515,  //  005F  GETMET	R10	R2	K21
+      0x58300019,  //  0060  LDCONST	R12	K25
+      0x7C280400,  //  0061  CALL	R10	2
+      0x8C280515,  //  0062  GETMET	R10	R2	K21
+      0x60300018,  //  0063  GETGBL	R12	G24
+      0x5834001A,  //  0064  LDCONST	R13	K26
+      0x8C380517,  //  0065  GETMET	R14	R2	K23
+      0x5C400200,  //  0066  MOVE	R16	R1
+      0x7C380400,  //  0067  CALL	R14	2
+      0x7C300400,  //  0068  CALL	R12	2
+      0x7C280400,  //  0069  CALL	R10	2
+      0x5828001B,  //  006A  LDCONST	R10	K27
+      0x602C000C,  //  006B  GETGBL	R11	G12
+      0x5C301000,  //  006C  MOVE	R12	R8
+      0x7C2C0200,  //  006D  CALL	R11	1
+      0x142C140B,  //  006E  LT	R11	R10	R11
+      0x782E003E,  //  006F  JMPF	R11	#00AF
+      0x942C100A,  //  0070  GETIDX	R11	R8	R10
+      0x8C30170A,  //  0071  GETMET	R12	R11	K10
+      0x5838001C,  //  0072  LDCONST	R14	K28
+      0x583C0002,  //  0073  LDCONST	R15	K2
+      0x7C300600,  //  0074  CALL	R12	3
+      0x20341902,  //  0075  NE	R13	R12	K2
+      0x78360000,  //  0076  JMPF	R13	#0078
+      0x00323A0C,  //  0077  ADD	R12	K29	R12
+      0x8834011E,  //  0078  GETMBR	R13	R0	K30
+      0x88341B1F,  //  0079  GETMBR	R13	R13	K31
+      0x8C341B0A,  //  007A  GETMET	R13	R13	K10
+      0x5C3C1800,  //  007B  MOVE	R15	R12
+      0x7C340400,  //  007C  CALL	R13	2
+      0x58380002,  //  007D  LDCONST	R14	K2
+      0x4C3C0000,  //  007E  LDNIL	R15
+      0x203C1A0F,  //  007F  NE	R15	R13	R15
+      0x783E0004,  //  0080  JMPF	R15	#0086
+      0x8C3C1B20,  //  0081  GETMET	R15	R13	K32
+      0x5C441A00,  //  0082  MOVE	R17	R13
+      0x5C481600,  //  0083  MOVE	R18	R11
+      0x7C3C0600,  //  0084  CALL	R15	3
+      0x5C381E00,  //  0085  MOVE	R14	R15
+      0x8C3C0515,  //  0086  GETMET	R15	R2	K21
+      0x60440018,  //  0087  GETGBL	R17	G24
+      0x58480021,  //  0088  LDCONST	R18	K33
+      0x5C4C1400,  //  0089  MOVE	R19	R10
+      0x7C440400,  //  008A  CALL	R17	2
+      0x7C3C0400,  //  008B  CALL	R15	2
+      0x8C3C0515,  //  008C  GETMET	R15	R2	K21
+      0x60440018,  //  008D  GETGBL	R17	G24
+      0x58480022,  //  008E  LDCONST	R18	K34
+      0x5C4C1400,  //  008F  MOVE	R19	R10
+      0x5C501400,  //  0090  MOVE	R20	R10
+      0x7C440600,  //  0091  CALL	R17	3
+      0x7C3C0400,  //  0092  CALL	R15	2
+      0x8C3C0123,  //  0093  GETMET	R15	R0	K35
+      0x5C441800,  //  0094  MOVE	R17	R12
+      0x88480114,  //  0095  GETMBR	R18	R0	K20
+      0x7C3C0600,  //  0096  CALL	R15	3
+      0x8C3C0515,  //  0097  GETMET	R15	R2	K21
+      0x58440024,  //  0098  LDCONST	R17	K36
+      0x7C3C0400,  //  0099  CALL	R15	2
+      0x8C3C0515,  //  009A  GETMET	R15	R2	K21
+      0x60440018,  //  009B  GETGBL	R17	G24
+      0x58480025,  //  009C  LDCONST	R18	K37
+      0x5C4C1400,  //  009D  MOVE	R19	R10
+      0x5C501400,  //  009E  MOVE	R20	R10
+      0x8C540517,  //  009F  GETMET	R21	R2	K23
+      0x5C5C1C00,  //  00A0  MOVE	R23	R14
+      0x7C540400,  //  00A1  CALL	R21	2
+      0x78360003,  //  00A2  JMPF	R13	#00A7
+      0x8C580517,  //  00A3  GETMET	R22	R2	K23
+      0x88601B26,  //  00A4  GETMBR	R24	R13	K38
+      0x7C580400,  //  00A5  CALL	R22	2
       0x70020000,  //  00A6  JMP		#00A8
-      0x58540002,  //  00A7  LDCONST	R21	K2
-      0x7C400A00,  //  00A8  CALL	R16	5
-      0x7C380400,  //  00A9  CALL	R14	2
-      0x8C380515,  //  00AA  GETMET	R14	R2	K21
-      0x58400027,  //  00AB  LDCONST	R16	K39
-      0x7C380400,  //  00AC  CALL	R14	2
-      0x00241328,  //  00AD  ADD	R9	R9	K40
+      0x58580002,  //  00A7  LDCONST	R22	K2
+      0x7C440A00,  //  00A8  CALL	R17	5
+      0x7C3C0400,  //  00A9  CALL	R15	2
+      0x8C3C0515,  //  00AA  GETMET	R15	R2	K21
+      0x58440027,  //  00AB  LDCONST	R17	K39
+      0x7C3C0400,  //  00AC  CALL	R15	2
+      0x00281528,  //  00AD  ADD	R10	R10	K40
       0x7001FFBB,  //  00AE  JMP		#006B
-      0x8C280515,  //  00AF  GETMET	R10	R2	K21
-      0x60300018,  //  00B0  GETGBL	R12	G24
-      0x58340021,  //  00B1  LDCONST	R13	K33
-      0x5C381200,  //  00B2  MOVE	R14	R9
-      0x7C300400,  //  00B3  CALL	R12	2
-      0x7C280400,  //  00B4  CALL	R10	2
-      0x8C280515,  //  00B5  GETMET	R10	R2	K21
-      0x60300018,  //  00B6  GETGBL	R12	G24
-      0x58340022,  //  00B7  LDCONST	R13	K34
-      0x5C381200,  //  00B8  MOVE	R14	R9
-      0x5C3C1200,  //  00B9  MOVE	R15	R9
-      0x7C300600,  //  00BA  CALL	R12	3
-      0x7C280400,  //  00BB  CALL	R10	2
-      0x8C280123,  //  00BC  GETMET	R10	R0	K35
-      0x58300002,  //  00BD  LDCONST	R12	K2
-      0x88340114,  //  00BE  GETMBR	R13	R0	K20
-      0x7C280600,  //  00BF  CALL	R10	3
-      0x8C280515,  //  00C0  GETMET	R10	R2	K21
-      0x58300024,  //  00C1  LDCONST	R12	K36
-      0x7C280400,  //  00C2  CALL	R10	2
-      0x8C280515,  //  00C3  GETMET	R10	R2	K21
-      0x60300018,  //  00C4  GETGBL	R12	G24
-      0x58340029,  //  00C5  LDCONST	R13	K41
-      0x5C381200,  //  00C6  MOVE	R14	R9
-      0x5C3C1200,  //  00C7  MOVE	R15	R9
-      0x58400002,  //  00C8  LDCONST	R16	K2
-      0x7C300800,  //  00C9  CALL	R12	4
-      0x7C280400,  //  00CA  CALL	R10	2
-      0x8C280515,  //  00CB  GETMET	R10	R2	K21
-      0x58300027,  //  00CC  LDCONST	R12	K39
-      0x7C280400,  //  00CD  CALL	R10	2
-      0x8C280515,  //  00CE  GETMET	R10	R2	K21
-      0x5830002A,  //  00CF  LDCONST	R12	K42
-      0x7C280400,  //  00D0  CALL	R10	2
-      0x8C280515,  //  00D1  GETMET	R10	R2	K21
-      0x5830002B,  //  00D2  LDCONST	R12	K43
-      0x7C280400,  //  00D3  CALL	R10	2
-      0x8C280515,  //  00D4  GETMET	R10	R2	K21
-      0x5830002C,  //  00D5  LDCONST	R12	K44
-      0x7C280400,  //  00D6  CALL	R10	2
-      0x8C280515,  //  00D7  GETMET	R10	R2	K21
-      0x5830002D,  //  00D8  LDCONST	R12	K45
-      0x7C280400,  //  00D9  CALL	R10	2
+      0x8C2C0515,  //  00AF  GETMET	R11	R2	K21
+      0x60340018,  //  00B0  GETGBL	R13	G24
+      0x58380021,  //  00B1  LDCONST	R14	K33
+      0x5C3C1400,  //  00B2  MOVE	R15	R10
+      0x7C340400,  //  00B3  CALL	R13	2
+      0x7C2C0400,  //  00B4  CALL	R11	2
+      0x8C2C0515,  //  00B5  GETMET	R11	R2	K21
+      0x60340018,  //  00B6  GETGBL	R13	G24
+      0x58380022,  //  00B7  LDCONST	R14	K34
+      0x5C3C1400,  //  00B8  MOVE	R15	R10
+      0x5C401400,  //  00B9  MOVE	R16	R10
+      0x7C340600,  //  00BA  CALL	R13	3
+      0x7C2C0400,  //  00BB  CALL	R11	2
+      0x8C2C0123,  //  00BC  GETMET	R11	R0	K35
+      0x58340002,  //  00BD  LDCONST	R13	K2
+      0x88380114,  //  00BE  GETMBR	R14	R0	K20
+      0x7C2C0600,  //  00BF  CALL	R11	3
+      0x8C2C0515,  //  00C0  GETMET	R11	R2	K21
+      0x58340024,  //  00C1  LDCONST	R13	K36
+      0x7C2C0400,  //  00C2  CALL	R11	2
+      0x8C2C0515,  //  00C3  GETMET	R11	R2	K21
+      0x60340018,  //  00C4  GETGBL	R13	G24
+      0x58380029,  //  00C5  LDCONST	R14	K41
+      0x5C3C1400,  //  00C6  MOVE	R15	R10
+      0x5C401400,  //  00C7  MOVE	R16	R10
+      0x58440002,  //  00C8  LDCONST	R17	K2
+      0x7C340800,  //  00C9  CALL	R13	4
+      0x7C2C0400,  //  00CA  CALL	R11	2
+      0x8C2C0515,  //  00CB  GETMET	R11	R2	K21
+      0x58340027,  //  00CC  LDCONST	R13	K39
+      0x7C2C0400,  //  00CD  CALL	R11	2
+      0x8C2C0515,  //  00CE  GETMET	R11	R2	K21
+      0x5834002A,  //  00CF  LDCONST	R13	K42
+      0x7C2C0400,  //  00D0  CALL	R11	2
+      0x8C2C0515,  //  00D1  GETMET	R11	R2	K21
+      0x5834002B,  //  00D2  LDCONST	R13	K43
+      0x7C2C0400,  //  00D3  CALL	R11	2
+      0x8C2C0515,  //  00D4  GETMET	R11	R2	K21
+      0x5834002C,  //  00D5  LDCONST	R13	K44
+      0x7C2C0400,  //  00D6  CALL	R11	2
+      0x8C2C0515,  //  00D7  GETMET	R11	R2	K21
+      0x5834002D,  //  00D8  LDCONST	R13	K45
+      0x7C2C0400,  //  00D9  CALL	R11	2
       0x70020007,  //  00DA  JMP		#00E3
       0x8C200515,  //  00DB  GETMET	R8	R2	K21
       0x60280018,  //  00DC  GETGBL	R10	G24
       0x582C002E,  //  00DD  LDCONST	R11	K46
-      0x8C300518,  //  00DE  GETMET	R12	R2	K24
+      0x8C300517,  //  00DE  GETMET	R12	R2	K23
       0x5C380200,  //  00DF  MOVE	R14	R1
       0x7C300400,  //  00E0  CALL	R12	2
       0x7C280400,  //  00E1  CALL	R10	2
@@ -1769,7 +1781,7 @@ be_local_closure(Matter_UI_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_show_bridge_status,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    15,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1777,7 +1789,7 @@ be_local_closure(Matter_UI_show_bridge_status,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
+    ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_const_int(0),
     /* K2   */  be_nested_str_weak(device),
@@ -1795,17 +1807,20 @@ be_local_closure(Matter_UI_show_bridge_status,   /* name */
     /* K14  */  be_nested_str_weak(_STYLESHEET),
     /* K15  */  be_nested_str_weak(k2l),
     /* K16  */  be_nested_str_weak(html_escape),
-    /* K17  */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27ztdm_X20htrm_X27_X3E_X3Ctd_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20title_X3D_X27http_X3A_X2F_X2F_X25s_X2F_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X27_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Ftd_X3E),
-    /* K18  */  be_nested_str_weak(web_last_seen),
-    /* K19  */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27htrm_X27_X3E_X3Ctd_X20colspan_X3D_X272_X27_X3E),
-    /* K20  */  be_nested_str_weak(web_values),
-    /* K21  */  be_nested_str_weak(_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-    /* K22  */  be_nested_str_weak(stop_iteration),
-    /* K23  */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Chr_X3E),
+    /* K17  */  be_nested_str_weak(get_plugin_remote_info),
+    /* K18  */  be_nested_str_weak(find),
+    /* K19  */  be_nested_str_weak(name),
+    /* K20  */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27ztdm_X20htrm_X27_X3E_X3Ctd_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20title_X3D_X27http_X3A_X2F_X2F_X25s_X2F_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X27_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Ftd_X3E),
+    /* K21  */  be_nested_str_weak(web_last_seen),
+    /* K22  */  be_nested_str_weak(_X3Ctr_X20class_X3D_X27htrm_X27_X3E_X3Ctd_X20colspan_X3D_X272_X27_X3E),
+    /* K23  */  be_nested_str_weak(web_values),
+    /* K24  */  be_nested_str_weak(_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+    /* K25  */  be_nested_str_weak(stop_iteration),
+    /* K26  */  be_nested_str_weak(_X3C_X2Ftable_X3E_X3Chr_X3E),
     }),
     be_str_weak(show_bridge_status),
     &be_const_str_solidified,
-    ( &(const binstruction[106]) {  /* code */
+    ( &(const binstruction[116]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x4C080000,  //  0001  LDNIL	R2
       0x580C0001,  //  0002  LDCONST	R3	K1
@@ -1865,53 +1880,63 @@ be_local_closure(Matter_UI_show_bridge_status,   /* name */
       0x5C1C0400,  //  0038  MOVE	R7	R2
       0x7C140400,  //  0039  CALL	R5	2
       0x7C100200,  //  003A  CALL	R4	1
-      0xA8020026,  //  003B  EXBLK	0	#0063
+      0xA8020030,  //  003B  EXBLK	0	#006D
       0x5C140800,  //  003C  MOVE	R5	R4
       0x7C140000,  //  003D  CALL	R5	0
       0x8C180310,  //  003E  GETMET	R6	R1	K16
       0x5C200A00,  //  003F  MOVE	R8	R5
       0x7C180400,  //  0040  CALL	R6	2
-      0x8C1C030B,  //  0041  GETMET	R7	R1	K11
-      0x60240018,  //  0042  GETGBL	R9	G24
-      0x58280011,  //  0043  LDCONST	R10	K17
-      0x5C2C0C00,  //  0044  MOVE	R11	R6
-      0x5C300C00,  //  0045  MOVE	R12	R6
-      0x5C340C00,  //  0046  MOVE	R13	R6
-      0x7C240800,  //  0047  CALL	R9	4
-      0x7C1C0400,  //  0048  CALL	R7	2
-      0x941C0405,  //  0049  GETIDX	R7	R2	R5
-      0x941C0F01,  //  004A  GETIDX	R7	R7	K1
-      0x881C0F06,  //  004B  GETMBR	R7	R7	K6
-      0x8C20030B,  //  004C  GETMET	R8	R1	K11
-      0x8C280F12,  //  004D  GETMET	R10	R7	K18
-      0x7C280200,  //  004E  CALL	R10	1
-      0x7C200400,  //  004F  CALL	R8	2
-      0x60200010,  //  0050  GETGBL	R8	G16
-      0x94240405,  //  0051  GETIDX	R9	R2	R5
-      0x7C200200,  //  0052  CALL	R8	1
-      0xA802000A,  //  0053  EXBLK	0	#005F
-      0x5C241000,  //  0054  MOVE	R9	R8
-      0x7C240000,  //  0055  CALL	R9	0
-      0x8C28030B,  //  0056  GETMET	R10	R1	K11
-      0x58300013,  //  0057  LDCONST	R12	K19
-      0x7C280400,  //  0058  CALL	R10	2
-      0x8C281314,  //  0059  GETMET	R10	R9	K20
-      0x7C280200,  //  005A  CALL	R10	1
-      0x8C28030B,  //  005B  GETMET	R10	R1	K11
-      0x58300015,  //  005C  LDCONST	R12	K21
-      0x7C280400,  //  005D  CALL	R10	2
-      0x7001FFF4,  //  005E  JMP		#0054
-      0x58200016,  //  005F  LDCONST	R8	K22
-      0xAC200200,  //  0060  CATCH	R8	1	0
-      0xB0080000,  //  0061  RAISE	2	R0	R0
-      0x7001FFD8,  //  0062  JMP		#003C
-      0x58100016,  //  0063  LDCONST	R4	K22
-      0xAC100200,  //  0064  CATCH	R4	1	0
-      0xB0080000,  //  0065  RAISE	2	R0	R0
-      0x8C10030B,  //  0066  GETMET	R4	R1	K11
-      0x58180017,  //  0067  LDCONST	R6	K23
-      0x7C100400,  //  0068  CALL	R4	2
-      0x80000000,  //  0069  RET	0
+      0x8C1C0310,  //  0041  GETMET	R7	R1	K16
+      0x88240102,  //  0042  GETMBR	R9	R0	K2
+      0x8C241311,  //  0043  GETMET	R9	R9	K17
+      0x5C2C0A00,  //  0044  MOVE	R11	R5
+      0x7C240400,  //  0045  CALL	R9	2
+      0x8C241312,  //  0046  GETMET	R9	R9	K18
+      0x582C0013,  //  0047  LDCONST	R11	K19
+      0x5C300A00,  //  0048  MOVE	R12	R5
+      0x7C240600,  //  0049  CALL	R9	3
+      0x7C1C0400,  //  004A  CALL	R7	2
+      0x8C20030B,  //  004B  GETMET	R8	R1	K11
+      0x60280018,  //  004C  GETGBL	R10	G24
+      0x582C0014,  //  004D  LDCONST	R11	K20
+      0x5C300C00,  //  004E  MOVE	R12	R6
+      0x5C340C00,  //  004F  MOVE	R13	R6
+      0x5C380E00,  //  0050  MOVE	R14	R7
+      0x7C280800,  //  0051  CALL	R10	4
+      0x7C200400,  //  0052  CALL	R8	2
+      0x94200405,  //  0053  GETIDX	R8	R2	R5
+      0x94201101,  //  0054  GETIDX	R8	R8	K1
+      0x88201106,  //  0055  GETMBR	R8	R8	K6
+      0x8C24030B,  //  0056  GETMET	R9	R1	K11
+      0x8C2C1115,  //  0057  GETMET	R11	R8	K21
+      0x7C2C0200,  //  0058  CALL	R11	1
+      0x7C240400,  //  0059  CALL	R9	2
+      0x60240010,  //  005A  GETGBL	R9	G16
+      0x94280405,  //  005B  GETIDX	R10	R2	R5
+      0x7C240200,  //  005C  CALL	R9	1
+      0xA802000A,  //  005D  EXBLK	0	#0069
+      0x5C281200,  //  005E  MOVE	R10	R9
+      0x7C280000,  //  005F  CALL	R10	0
+      0x8C2C030B,  //  0060  GETMET	R11	R1	K11
+      0x58340016,  //  0061  LDCONST	R13	K22
+      0x7C2C0400,  //  0062  CALL	R11	2
+      0x8C2C1517,  //  0063  GETMET	R11	R10	K23
+      0x7C2C0200,  //  0064  CALL	R11	1
+      0x8C2C030B,  //  0065  GETMET	R11	R1	K11
+      0x58340018,  //  0066  LDCONST	R13	K24
+      0x7C2C0400,  //  0067  CALL	R11	2
+      0x7001FFF4,  //  0068  JMP		#005E
+      0x58240019,  //  0069  LDCONST	R9	K25
+      0xAC240200,  //  006A  CATCH	R9	1	0
+      0xB0080000,  //  006B  RAISE	2	R0	R0
+      0x7001FFCE,  //  006C  JMP		#003C
+      0x58100019,  //  006D  LDCONST	R4	K25
+      0xAC100200,  //  006E  CATCH	R4	1	0
+      0xB0080000,  //  006F  RAISE	2	R0	R0
+      0x8C10030B,  //  0070  GETMET	R4	R1	K11
+      0x5818001A,  //  0071  LDCONST	R6	K26
+      0x7C100400,  //  0072  CALL	R4	2
+      0x80000000,  //  0073  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Matter: now remotely detect the Device Name of remote Tasmota and display in UI. The IP address is still displayed when you pass the pointer over the name
![image](https://github.com/arendst/Tasmota/assets/49731213/67b9a4df-b40c-471c-8b0a-6d122e5d095d)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
