### PR TITLE
MI32 legacy: Allow submitting WiFi credentials via BLE using Improv-WiFi.com

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -697,7 +697,9 @@ void MI32PreInit(void) {
 void MI32Init(void) {
   if (MI32.mode.init) { return; }
 
-  if (TasmotaGlobal.global_state.wifi_down && TasmotaGlobal.global_state.eth_down) { return; }
+  if (TasmotaGlobal.global_state.wifi_down && TasmotaGlobal.global_state.eth_down) {
+    if (!(WIFI_MANAGER == Wifi.config_type || WIFI_MANAGER_RESET_ONLY == Wifi.config_type)) return; 
+  }
 
   if (!TasmotaGlobal.global_state.wifi_down) {
     TasmotaGlobal.wifi_stay_asleep = true;


### PR DESCRIPTION
## Description:

Little change needed for https://www.improv-wifi.com/ to submit Wi-Fi credentials vie Bluetooth LE.

Can then be used by using an enhanced build environment, no other configuration needed.

```
[env:tasmota32-mi32-homebridge]
extends                     = env:tasmota32_base
build_flags                 = ${env:tasmota32_base.build_flags}
                              -DFIRMWARE_BLUETOOTH
                              -DUSE_MI_EXT_GUI
                              -DUSE_MI_HOMEKIT=1    ; 1 to enable; 0 to disable
                              -DOTA_URL='""'
                              -DUSE_BERRY_ULP
lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
lib_ignore                  = ESP8266Audio
                              ESP8266SAM
                              TTGO TWatch Library
                              Micro-RTSP
                              epdiy
                              NimBLE-Arduino
custom_files_upload         = ${env:tasmota32_base.custom_files_upload}
                              https://raw.githubusercontent.com/Staars/berry-examples/main/ble/improv.be
                              https://raw.githubusercontent.com/Staars/berry-examples/main/ble/autoexec-improv/autoexec.be

```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
