### PR TITLE
Berry Walrus operator ':='

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Berry add global function `format` as a simpler syntax to `string.format`
 - Berry added f-strings as an alternative to string formatting
 - Matter display the remote Device Name instead of IP address
+- Berry Walrus operator ':='
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_code.c
+++ b/lib/libesp32/berry/src/be_code.c
@@ -670,14 +670,15 @@ static void setsfxvar(bfuncinfo *finfo, bopcode op, bexpdesc *e1, int src)
 
 /* Assign expr e2 to e1 */
 /* e1 must be in a register and have a valid idx */
+/* if `keep_reg` is true, do not release registre */
 /* return 1 if assignment was possible, 0 if type is not compatible */
-int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2)
+int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, bbool keep_reg)
 {
     int src = exp2reg(finfo, e2,
         e1->type == ETLOCAL ? e1->v.idx : -1); /* Convert e2 to kreg */
         /* If e1 is a local variable, use the register */
 
-    if (e1->type != ETLOCAL || e1->v.idx != src) {
+    if (!keep_reg && (e1->type != ETLOCAL || e1->v.idx != src)) {
         free_expreg(finfo, e2); /* free source (checks only ETREG) */ /* TODO e2 is at top */
     }
     switch (e1->type) {
@@ -887,7 +888,7 @@ void be_code_import(bfuncinfo *finfo, bexpdesc *m, bexpdesc *v)
         codeABC(finfo, OP_IMPORT, dst, src, 0);
         m->type = ETREG;
         m->v.idx = dst;
-        be_code_setvar(finfo, v, m);
+        be_code_setvar(finfo, v, m, bfalse);
     }
 }
 

--- a/lib/libesp32/berry/src/be_code.h
+++ b/lib/libesp32/berry/src/be_code.h
@@ -16,7 +16,7 @@ int be_code_allocregs(bfuncinfo *finfo, int count);
 void be_code_prebinop(bfuncinfo *finfo, int op, bexpdesc *e);
 void be_code_binop(bfuncinfo *finfo, int op, bexpdesc *e1, bexpdesc *e2, int dst);
 int be_code_unop(bfuncinfo *finfo, int op, bexpdesc *e);
-int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2);
+int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, bbool keep_reg);
 int be_code_nextreg(bfuncinfo *finfo, bexpdesc *e);
 int be_code_jump(bfuncinfo *finfo);
 void be_code_jumpto(bfuncinfo *finfo, int dst);

--- a/lib/libesp32/berry/src/be_debug.c
+++ b/lib/libesp32/berry/src/be_debug.c
@@ -266,7 +266,9 @@ static void hook_callnative(bvm *vm, int mask)
     be_stack_require(vm, BE_STACK_FREE_MIN + 2);
     info.type = mask;
     info.line = cf->lineinfo->linenumber;
+#if BE_DEBUG_SOURCE_FILE
     info.source = str(cl->proto->source);
+#endif
     info.func_name = str(cl->proto->name);
     info.data = hb->data;
     hb->hook(vm, &info);

--- a/lib/libesp32/berry/src/be_lexer.c
+++ b/lib/libesp32/berry/src/be_lexer.c
@@ -752,7 +752,9 @@ static btokentype lexer_next(blexer *lexer)
         case '}': next(lexer); return OptRBR;
         case ',': next(lexer); return OptComma;
         case ';': next(lexer); return OptSemic;
-        case ':': next(lexer); return OptColon;
+        case ':':
+            next(lexer);
+            return check_next(lexer, '=') ? OptWalrus : OptColon;
         case '?': next(lexer); return OptQuestion;
         case '^': return scan_assign(lexer, OptXorAssign, OptBitXor);
         case '~': next(lexer); return OptFlip;

--- a/lib/libesp32/berry/src/be_lexer.h
+++ b/lib/libesp32/berry/src/be_lexer.h
@@ -89,7 +89,9 @@ typedef enum {
     KeyTry,         /* keyword try */
     KeyExcept,      /* keyword except */
     KeyRaise,       /* keyword raise */
-    KeyStatic       /* keyword static */
+    KeyStatic,      /* keyword static */
+    /* Walrus operator */
+    OptWalrus,      /* operator, := */
 } btokentype;
 
 struct blexerreader {

--- a/lib/libesp32/berry/src/be_module.c
+++ b/lib/libesp32/berry/src/be_module.c
@@ -126,9 +126,9 @@ static char* fixpath(bvm *vm, bstring *path, size_t *size)
 {
     char *buffer;
     const char *split, *base;
+#if BE_DEBUG_SOURCE_FILE
     bvalue *func = vm->cf->func;
     bclosure *cl = var_toobj(func);
-#if BE_DEBUG_SOURCE_FILE
     if (var_isclosure(func)) {
         base = str(cl->proto->source); /* get the source file path */
     } else {


### PR DESCRIPTION
## Description:

Add Berry Walrus operator, similar to Python3. This operator ':=' allows to do an assignment from within an expression:

```berry
[...]
    var sz
    if (sz := size(self.my_list)) > 0
        print(f"list size = {sz:i}")
    end
[...]
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
