### PR TITLE
post_esp32.py: Allow renaming of files from URLs on the fly

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -70,9 +70,12 @@ def esp32_build_filesystem(fs_size):
         if "no_files" in file:
             continue
         if "http" and "://" in file:
-            response = requests.get(file)
+            response = requests.get(file.split(" ")[0])
             if response.ok:
                 target = join(filesystem_dir,file.split(os.path.sep)[-1])
+                if len(file.split(" ")) > 1:
+                    target = join(filesystem_dir,file.split(" ")[1])
+                    print("Renaming",(file.split(os.path.sep)[-1]).split(" ")[0],"to",file.split(" ")[1])
                 open(target, "wb").write(response.content)
             else:
                 print("Failed to download: ",file)


### PR DESCRIPTION
## Description:

When adding files to the filesystem of a factory image from an URL in platform_tasmota_cenv.ini it is sometimes convenient to store a Berry driver and the corresponding `autoexec.be` in the repo with a more descriptive name for `autoexec.be` like `autoexec-mydriver.be`.
When building this file must be renamed to `autoexec.be` again.
This can now be done by adding the target name separated by a space in the same line:
```
custom_files_upload         = ${env:tasmota32_base.custom_files_upload}
                              https://raw.githubusercontent.com/user/repo/driver
                              https://raw.githubusercontent.com/user/repo/autoexec-driver.be autoexec.be
```

No breaking change for old ..._cenv.ini files.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
