### PR TITLE
update light when `VirtualCT` is invoked

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -3276,6 +3276,7 @@ void CmndVirtualCT(void)
     }
   }
   checkVirtualCT();
+  Light.update = true;
 
   Response_P(PSTR("{\"%s\":{"), XdrvMailbox.command);
   uint32_t pivot_len = CT_PIVOTS;


### PR DESCRIPTION
## Description:

This fixes a minor issue with `VirtualCT`: Suppose I have an RGBCW LED, `PowerOnState 3`, `SO106 1`, and I have an active rule
```
On Power1#Boot do virtualct {"153":"0000FFA000", "500":"FF000000A0"} endon
```
(note that the VirtualCT values are not stored in persistent memory). Now I set `CT 500` and `White 100` and restart the light. Then, after the restart, the warm white LED is 100 % on and the red LED is off (despite `VirtualCT` being invoked), which is not the desired behaviour. Any change to the power settings (like `White 99`) triggers a recompute of the dimmer values, and `VirtualCT` is engaged correctly.

The reason for that is that `VirtualCT` does not trigger a recompute of the light values, which this pull request fixes.

On a more abstract level, invoking `VirtualCT` can put the device into an inconsistent state at the moment (in the sense that any call to `Color1` makes it impossible to go to the previous light output without calling `VirtualCT` again).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10 (simulator tested)
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
