### PR TITLE
quote path

### DIFF
--- a/pio-tools/metrics-firmware.py
+++ b/pio-tools/metrics-firmware.py
@@ -7,7 +7,7 @@ from os.path import join
 def firm_metrics(source, target, env):
     if env["PIOPLATFORM"] == "espressif32":
         import tasmota_metrics
-        env.Execute("$PYTHONEXE -m tasmota_metrics " + str(tasmotapiolib.get_source_map_path(env).resolve()))
+        env.Execute("$PYTHONEXE -m tasmota_metrics \"" + str(tasmotapiolib.get_source_map_path(env).resolve()) + "\"")
     elif env["PIOPLATFORM"] == "espressif8266":
         map_file = join(env.subst("$BUILD_DIR")) + os.sep + "firmware.map"
         with open(map_file,'r') as f:


### PR DESCRIPTION
## Description:
building an environment from a path that contains whitespaces an error will be thrown.
Path: `/Volumes/My Code/Tasmota`
Error:
```
esp_idf_size: error: argument map_file: can't open '/Volumes/My': [Errno 2] No such file or directory: '/Volumes/My'
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
