### PR TITLE
warn for whitespaces in project path

### DIFF
--- a/pio-tools/override_copy.py
+++ b/pio-tools/override_copy.py
@@ -1,7 +1,12 @@
 Import('env')
 
 import os
+import pathlib
+from os.path import join
 import shutil
+
+if " " in join(pathlib.Path(env["PROJECT_DIR"])):
+    print ("\u001b[31;1m*** Whitespace(s) in project path, unexpected issues/errors can happen ***\u001b[0m")
 
 # copy tasmota/user_config_override_sample.h to tasmota/user_config_override.h
 if os.path.isfile("tasmota/user_config_override.h"):


### PR DESCRIPTION
## Description:

since not supported.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
