### PR TITLE
Matter support for temperature in Fahrenheit (`SetOption8 1`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Berry `bool( [] )` and `bool( {} )` now evaluate as `false`
 
 ### Changed
+- Matter support for temperature in Fahrenheit (`SetOption8 1`)
 
 ### Fixed
 - Berry various fixes for Walrus Operator

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor.be
@@ -39,6 +39,13 @@ class Matter_Plugin_Bridge_Sensor : Matter_Plugin_Bridge_HTTP
   var tasmota_sensor_filter                         # Rule-type filter to the value, like "ESP32#Temperature"
   var tasmota_sensor_matcher                        # Actual matcher object
   var shadow_value                                  # Last known value
+  var temp_unit                                     # temperature unit, "C" or "F"
+  static var TEMP_C = "C"
+  static var TEMP_F = "F"
+  var pressure_unit                                 # pressure unit, "hPa" or "mmHg" or "inHg"
+  static var PRESSURE_HPA = "hPa"
+  static var PRESSURE_MMHG = "mmHg"
+  static var PRESSURE_INHG = "inHg"
 
   #############################################################
   # parse_configuration
@@ -49,6 +56,8 @@ class Matter_Plugin_Bridge_Sensor : Matter_Plugin_Bridge_HTTP
     if self.tasmota_sensor_filter
       self.tasmota_sensor_matcher = tasmota.Rule_Matcher.parse(self.tasmota_sensor_filter)
     end
+    self.temp_unit = self.TEMP_C
+    self.pressure_unit = self.PRESSURE_HPA
   end
 
   #############################################################
@@ -57,6 +66,12 @@ class Matter_Plugin_Bridge_Sensor : Matter_Plugin_Bridge_HTTP
   # TO BE OVERRIDDEN
   def parse_update(data, index)
     if index == 8                               # Status 8
+      if data.contains("TempUnit")
+        self.temp_unit = data["TempUnit"]
+      end
+      if data.contains("PressureUnit")
+        self.pressure_unit = data["PressureUnit"]
+      end
       if self.tasmota_sensor_matcher
         var val = self.pre_value(real(self.tasmota_sensor_matcher.match(data)))
         if val != nil

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Temp.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Sensor_Temp.be
@@ -50,6 +50,9 @@ class Matter_Plugin_Bridge_Sensor_Temp : Matter_Plugin_Bridge_Sensor
   # This must be overriden.
   # This allows to convert the raw sensor value to the target one, typically int
   def pre_value(val)
+    if self.temp_unit == self.TEMP_F          # Fahrenheit
+      val = (val - 32) / 1.8
+    end
     return val != nil ? int(val * 100) : nil
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Temp.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Sensor_Temp.be
@@ -40,6 +40,9 @@ class Matter_Plugin_Sensor_Temp : Matter_Plugin_Sensor
   # This must be overriden.
   # This allows to convert the raw sensor value to the target one, typically int
   def pre_value(val)
+    if tasmota.get_option(8) == 1         # Fahrenheit
+      val = (val - 32) / 1.8
+    end
     return val != nil ? int(val * 100) : nil
   end
 

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor.h
@@ -7,6 +7,82 @@
 extern const bclass be_class_Matter_Plugin_Bridge_Sensor;
 
 /********************************************************************
+** Solidified function: parse_configuration
+********************************************************************/
+be_local_closure(Matter_Plugin_Bridge_Sensor_parse_configuration,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota_sensor_filter),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(ARG),
+    /* K3   */  be_nested_str_weak(tasmota_sensor_matcher),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(Rule_Matcher),
+    /* K6   */  be_nested_str_weak(parse),
+    /* K7   */  be_nested_str_weak(temp_unit),
+    /* K8   */  be_nested_str_weak(TEMP_C),
+    /* K9   */  be_nested_str_weak(pressure_unit),
+    /* K10  */  be_nested_str_weak(PRESSURE_HPA),
+    }),
+    be_str_weak(parse_configuration),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x8C080301,  //  0000  GETMET	R2	R1	K1
+      0x88100102,  //  0001  GETMBR	R4	R0	K2
+      0x7C080400,  //  0002  CALL	R2	2
+      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x780A0005,  //  0005  JMPF	R2	#000C
+      0xB80A0800,  //  0006  GETNGBL	R2	K4
+      0x88080505,  //  0007  GETMBR	R2	R2	K5
+      0x8C080506,  //  0008  GETMET	R2	R2	K6
+      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0x7C080400,  //  000A  CALL	R2	2
+      0x90020602,  //  000B  SETMBR	R0	K3	R2
+      0x88080108,  //  000C  GETMBR	R2	R0	K8
+      0x90020E02,  //  000D  SETMBR	R0	K7	R2
+      0x8808010A,  //  000E  GETMBR	R2	R0	K10
+      0x90021202,  //  000F  SETMBR	R0	K9	R2
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: value_changed
+********************************************************************/
+be_local_closure(Matter_Plugin_Bridge_Sensor_value_changed,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(value_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: web_values_prefix
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_web_values_prefix,   /* name */
@@ -58,98 +134,6 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_web_values_prefix,   /* name */
 
 
 /********************************************************************
-** Solidified function: parse_configuration
-********************************************************************/
-be_local_closure(Matter_Plugin_Bridge_Sensor_parse_configuration,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota_sensor_filter),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(ARG),
-    /* K3   */  be_nested_str_weak(tasmota_sensor_matcher),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(Rule_Matcher),
-    /* K6   */  be_nested_str_weak(parse),
-    }),
-    be_str_weak(parse_configuration),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x8C080301,  //  0000  GETMET	R2	R1	K1
-      0x88100102,  //  0001  GETMBR	R4	R0	K2
-      0x7C080400,  //  0002  CALL	R2	2
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x780A0005,  //  0005  JMPF	R2	#000C
-      0xB80A0800,  //  0006  GETNGBL	R2	K4
-      0x88080505,  //  0007  GETMBR	R2	R2	K5
-      0x8C080506,  //  0008  GETMET	R2	R2	K6
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
-      0x7C080400,  //  000A  CALL	R2	2
-      0x90020602,  //  000B  SETMBR	R0	K3	R2
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: value_changed
-********************************************************************/
-be_local_closure(Matter_Plugin_Bridge_Sensor_value_changed,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(value_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pre_value
-********************************************************************/
-be_local_closure(Matter_Plugin_Bridge_Sensor_pre_value,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(pre_value),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80040200,  //  0000  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: parse_update
 ********************************************************************/
 be_local_closure(Matter_Plugin_Bridge_Sensor_parse_update,   /* name */
@@ -162,40 +146,57 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_parse_update,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota_sensor_matcher),
-    /* K1   */  be_nested_str_weak(pre_value),
-    /* K2   */  be_nested_str_weak(match),
-    /* K3   */  be_nested_str_weak(shadow_value),
-    /* K4   */  be_nested_str_weak(value_changed),
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(contains),
+    /* K1   */  be_nested_str_weak(TempUnit),
+    /* K2   */  be_nested_str_weak(temp_unit),
+    /* K3   */  be_nested_str_weak(PressureUnit),
+    /* K4   */  be_nested_str_weak(pressure_unit),
+    /* K5   */  be_nested_str_weak(tasmota_sensor_matcher),
+    /* K6   */  be_nested_str_weak(pre_value),
+    /* K7   */  be_nested_str_weak(match),
+    /* K8   */  be_nested_str_weak(shadow_value),
+    /* K9   */  be_nested_str_weak(value_changed),
     }),
     be_str_weak(parse_update),
     &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
+    ( &(const binstruction[36]) {  /* code */
       0x540E0007,  //  0000  LDINT	R3	8
       0x1C0C0403,  //  0001  EQ	R3	R2	R3
-      0x780E0013,  //  0002  JMPF	R3	#0017
-      0x880C0100,  //  0003  GETMBR	R3	R0	K0
-      0x780E0011,  //  0004  JMPF	R3	#0017
-      0x8C0C0101,  //  0005  GETMET	R3	R0	K1
-      0x6014000A,  //  0006  GETGBL	R5	G10
-      0x88180100,  //  0007  GETMBR	R6	R0	K0
-      0x8C180D02,  //  0008  GETMET	R6	R6	K2
-      0x5C200200,  //  0009  MOVE	R8	R1
-      0x7C180400,  //  000A  CALL	R6	2
-      0x7C140200,  //  000B  CALL	R5	1
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x4C100000,  //  000D  LDNIL	R4
-      0x20100604,  //  000E  NE	R4	R3	R4
-      0x78120006,  //  000F  JMPF	R4	#0017
-      0x88100103,  //  0010  GETMBR	R4	R0	K3
-      0x20100604,  //  0011  NE	R4	R3	R4
-      0x78120002,  //  0012  JMPF	R4	#0016
-      0x8C100104,  //  0013  GETMET	R4	R0	K4
-      0x5C180600,  //  0014  MOVE	R6	R3
-      0x7C100400,  //  0015  CALL	R4	2
-      0x90020603,  //  0016  SETMBR	R0	K3	R3
-      0x80000000,  //  0017  RET	0
+      0x780E001F,  //  0002  JMPF	R3	#0023
+      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
+      0x58140001,  //  0004  LDCONST	R5	K1
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x780E0001,  //  0006  JMPF	R3	#0009
+      0x940C0301,  //  0007  GETIDX	R3	R1	K1
+      0x90020403,  //  0008  SETMBR	R0	K2	R3
+      0x8C0C0300,  //  0009  GETMET	R3	R1	K0
+      0x58140003,  //  000A  LDCONST	R5	K3
+      0x7C0C0400,  //  000B  CALL	R3	2
+      0x780E0001,  //  000C  JMPF	R3	#000F
+      0x940C0303,  //  000D  GETIDX	R3	R1	K3
+      0x90020803,  //  000E  SETMBR	R0	K4	R3
+      0x880C0105,  //  000F  GETMBR	R3	R0	K5
+      0x780E0011,  //  0010  JMPF	R3	#0023
+      0x8C0C0106,  //  0011  GETMET	R3	R0	K6
+      0x6014000A,  //  0012  GETGBL	R5	G10
+      0x88180105,  //  0013  GETMBR	R6	R0	K5
+      0x8C180D07,  //  0014  GETMET	R6	R6	K7
+      0x5C200200,  //  0015  MOVE	R8	R1
+      0x7C180400,  //  0016  CALL	R6	2
+      0x7C140200,  //  0017  CALL	R5	1
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x4C100000,  //  0019  LDNIL	R4
+      0x20100604,  //  001A  NE	R4	R3	R4
+      0x78120006,  //  001B  JMPF	R4	#0023
+      0x88100108,  //  001C  GETMBR	R4	R0	K8
+      0x20100604,  //  001D  NE	R4	R3	R4
+      0x78120002,  //  001E  JMPF	R4	#0022
+      0x8C100109,  //  001F  GETMET	R4	R0	K9
+      0x5C180600,  //  0020  MOVE	R6	R3
+      0x7C100400,  //  0021  CALL	R4	2
+      0x90021003,  //  0022  SETMBR	R0	K8	R3
+      0x80000000,  //  0023  RET	0
     })
   )
 );
@@ -248,29 +249,60 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_filter_name_html,   /* name */
 
 
 /********************************************************************
+** Solidified function: pre_value
+********************************************************************/
+be_local_closure(Matter_Plugin_Bridge_Sensor_pre_value,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(pre_value),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80040200,  //  0000  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_Plugin_Bridge_Sensor
 ********************************************************************/
 extern const bclass be_class_Matter_Plugin_Bridge_HTTP;
 be_local_class(Matter_Plugin_Bridge_Sensor,
-    3,
+    5,
     &be_class_Matter_Plugin_Bridge_HTTP,
-    be_nested_map(15,
+    be_nested_map(22,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(ARG_HINT, 7), be_nested_str_weak(Enter_X20Filter_X20pattern) },
-        { be_const_key_weak(tasmota_sensor_filter, 10), be_const_var(0) },
-        { be_const_key_weak(web_values_prefix, -1), be_const_closure(Matter_Plugin_Bridge_Sensor_web_values_prefix_closure) },
+        { be_const_key_weak(tasmota_sensor_filter, -1), be_const_var(0) },
+        { be_const_key_weak(ARG_HINT, -1), be_nested_str_weak(Enter_X20Filter_X20pattern) },
         { be_const_key_weak(shadow_value, -1), be_const_var(2) },
-        { be_const_key_weak(parse_configuration, -1), be_const_closure(Matter_Plugin_Bridge_Sensor_parse_configuration_closure) },
-        { be_const_key_weak(tasmota_sensor_matcher, -1), be_const_var(1) },
-        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(5000) },
+        { be_const_key_weak(pre_value, 10), be_const_closure(Matter_Plugin_Bridge_Sensor_pre_value_closure) },
         { be_const_key_weak(ARG_HTTP, -1), be_nested_str_weak(url) },
+        { be_const_key_weak(pressure_unit, -1), be_const_var(4) },
+        { be_const_key_weak(tasmota_sensor_matcher, -1), be_const_var(1) },
         { be_const_key_weak(ARG, -1), be_nested_str_weak(filter) },
-        { be_const_key_weak(UPDATE_CMD, 8), be_nested_str_weak(Status_X208) },
-        { be_const_key_weak(parse_update, 12), be_const_closure(Matter_Plugin_Bridge_Sensor_parse_update_closure) },
-        { be_const_key_weak(pre_value, -1), be_const_closure(Matter_Plugin_Bridge_Sensor_pre_value_closure) },
+        { be_const_key_weak(PRESSURE_MMHG, -1), be_nested_str_weak(mmHg) },
         { be_const_key_weak(value_changed, -1), be_const_closure(Matter_Plugin_Bridge_Sensor_value_changed_closure) },
-        { be_const_key_weak(PROBE_TIMEOUT, -1), be_const_int(1700) },
+        { be_const_key_weak(parse_update, -1), be_const_closure(Matter_Plugin_Bridge_Sensor_parse_update_closure) },
+        { be_const_key_weak(TEMP_C, -1), be_nested_str_weak(C) },
+        { be_const_key_weak(temp_unit, 4), be_const_var(3) },
+        { be_const_key_weak(PRESSURE_INHG, -1), be_nested_str_weak(inHg) },
+        { be_const_key_weak(PRESSURE_HPA, 18), be_nested_str_weak(hPa) },
+        { be_const_key_weak(PROBE_TIMEOUT, 16), be_const_int(1700) },
+        { be_const_key_weak(web_values_prefix, -1), be_const_closure(Matter_Plugin_Bridge_Sensor_web_values_prefix_closure) },
+        { be_const_key_weak(UPDATE_CMD, 13), be_nested_str_weak(Status_X208) },
+        { be_const_key_weak(TEMP_F, -1), be_nested_str_weak(F) },
         { be_const_key_weak(filter_name_html, -1), be_const_closure(Matter_Plugin_Bridge_Sensor_filter_name_html_closure) },
+        { be_const_key_weak(UPDATE_TIME, 3), be_const_int(5000) },
+        { be_const_key_weak(parse_configuration, 2), be_const_closure(Matter_Plugin_Bridge_Sensor_parse_configuration_closure) },
     })),
     be_str_weak(Matter_Plugin_Bridge_Sensor)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Temp.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Sensor_Temp.h
@@ -18,21 +18,33 @@ be_local_closure(Matter_Plugin_Bridge_Sensor_Temp_pre_value,   /* name */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(temp_unit),
+    /* K1   */  be_nested_str_weak(TEMP_F),
+    /* K2   */  be_const_real_hex(0x3FE66666),
+    }),
     be_str_weak(pre_value),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x20080202,  //  0001  NE	R2	R1	R2
-      0x780A0004,  //  0002  JMPF	R2	#0008
-      0x60080009,  //  0003  GETGBL	R2	G9
-      0x540E0063,  //  0004  LDINT	R3	100
-      0x080C0203,  //  0005  MUL	R3	R1	R3
-      0x7C080200,  //  0006  CALL	R2	1
-      0x70020000,  //  0007  JMP		#0009
+    ( &(const binstruction[18]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x1C080403,  //  0002  EQ	R2	R2	R3
+      0x780A0003,  //  0003  JMPF	R2	#0008
+      0x540A001F,  //  0004  LDINT	R2	32
+      0x04080202,  //  0005  SUB	R2	R1	R2
+      0x0C080502,  //  0006  DIV	R2	R2	K2
+      0x5C040400,  //  0007  MOVE	R1	R2
       0x4C080000,  //  0008  LDNIL	R2
-      0x80040400,  //  0009  RET	1	R2
+      0x20080202,  //  0009  NE	R2	R1	R2
+      0x780A0004,  //  000A  JMPF	R2	#0010
+      0x60080009,  //  000B  GETGBL	R2	G9
+      0x540E0063,  //  000C  LDINT	R3	100
+      0x080C0203,  //  000D  MUL	R3	R1	R3
+      0x7C080200,  //  000E  CALL	R2	1
+      0x70020000,  //  000F  JMP		#0011
+      0x4C080000,  //  0010  LDNIL	R2
+      0x80040400,  //  0011  RET	1	R2
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Temp.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Sensor_Temp.h
@@ -116,28 +116,43 @@ be_local_closure(Matter_Plugin_Sensor_Temp_read_attribute,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Sensor_Temp_pre_value,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(get_option),
+    /* K2   */  be_const_int(1),
+    /* K3   */  be_const_real_hex(0x3FE66666),
+    }),
     be_str_weak(pre_value),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x20080202,  //  0001  NE	R2	R1	R2
-      0x780A0004,  //  0002  JMPF	R2	#0008
-      0x60080009,  //  0003  GETGBL	R2	G9
-      0x540E0063,  //  0004  LDINT	R3	100
-      0x080C0203,  //  0005  MUL	R3	R1	R3
-      0x7C080200,  //  0006  CALL	R2	1
-      0x70020000,  //  0007  JMP		#0009
-      0x4C080000,  //  0008  LDNIL	R2
-      0x80040400,  //  0009  RET	1	R2
+    ( &(const binstruction[20]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x54120007,  //  0002  LDINT	R4	8
+      0x7C080400,  //  0003  CALL	R2	2
+      0x1C080502,  //  0004  EQ	R2	R2	K2
+      0x780A0003,  //  0005  JMPF	R2	#000A
+      0x540A001F,  //  0006  LDINT	R2	32
+      0x04080202,  //  0007  SUB	R2	R1	R2
+      0x0C080503,  //  0008  DIV	R2	R2	K3
+      0x5C040400,  //  0009  MOVE	R1	R2
+      0x4C080000,  //  000A  LDNIL	R2
+      0x20080202,  //  000B  NE	R2	R1	R2
+      0x780A0004,  //  000C  JMPF	R2	#0012
+      0x60080009,  //  000D  GETGBL	R2	G9
+      0x540E0063,  //  000E  LDINT	R3	100
+      0x080C0203,  //  000F  MUL	R3	R1	R3
+      0x7C080200,  //  0010  CALL	R2	1
+      0x70020000,  //  0011  JMP		#0013
+      0x4C080000,  //  0012  LDNIL	R2
+      0x80040400,  //  0013  RET	1	R2
     })
   )
 );


### PR DESCRIPTION
## Description:

Matter: support for temperatures in Fahrenheit, whether local or remote, when set with `SetOption8 1`.

Internally temperatures are always sent in Celsius within the Matter protocol.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
