### PR TITLE
Matter add option to disable bridge mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [13.0.0.1]
 ### Added
+- Matter add option to disable bridge mode
 
 ### Breaking Changed
 - Berry `bool( [] )` and `bool( {} )` now evaluate as `false` (#18986)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
@@ -63,6 +63,7 @@ class Matter_Device
   var root_discriminator              # as `int`
   var root_passcode                   # as `int`
   var ipv4only                        # advertize only IPv4 addresses (no IPv6)
+  var disable_bridge_mode             # default is bridge mode, this flag disables this mode for some non-compliant controllers
   var next_ep                         # next endpoint to be allocated for bridge, start at 1
   # context for PBKDF
   var root_iterations                 # PBKDF number of iterations
@@ -92,6 +93,7 @@ class Matter_Device
     self.next_ep = 1                              # start at endpoint 1 for dynamically allocated endpoints
     self.root_salt = crypto.random(16)
     self.ipv4only = false
+    self.disable_bridge_mode = false
     self.load_param()
 
     self.sessions = matter.Session_Store(self)
@@ -628,7 +630,7 @@ class Matter_Device
     import json
     self.update_remotes_info()    # update self.plugins_config_remotes
 
-    var j = format('{"distinguish":%i,"passcode":%i,"ipv4only":%s,"nextep":%i', self.root_discriminator, self.root_passcode, self.ipv4only ? 'true':'false', self.next_ep)
+    var j = format('{"distinguish":%i,"passcode":%i,"ipv4only":%s,"disable_bridge_mode":%s,"nextep":%i', self.root_discriminator, self.root_passcode, self.ipv4only ? 'true':'false', self.disable_bridge_mode ? 'true':'false', self.next_ep)
     if self.plugins_persist
       j += ',"config":'
       j += json.dump(self.plugins_config)
@@ -693,6 +695,7 @@ class Matter_Device
       self.root_discriminator = j.find("distinguish", self.root_discriminator)
       self.root_passcode = j.find("passcode", self.root_passcode)
       self.ipv4only = bool(j.find("ipv4only", false))
+      self.disable_bridge_mode = bool(j.find("disable_bridge_mode", false))
       self.next_ep = j.find("nextep", self.next_ep)
       self.plugins_config = j.find("config")
       if self.plugins_config != nil

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Device.be
@@ -104,7 +104,7 @@ class Matter_Plugin_Device : Matter_Plugin
           d1.add_TLV(1, TLV.U2, types[dt])      # Revision
         end
         # if fabric is not Alexa
-        if self.NON_BRIDGE_VENDOR.find(session.get_admin_vendor()) == nil
+        if (self.NON_BRIDGE_VENDOR.find(session.get_admin_vendor()) == nil) && (!self.device.disable_bridge_mode)
           var d1 = dtl.add_struct()
           d1.add_TLV(0, TLV.U2, 0x0013)     # DeviceType
           d1.add_TLV(1, TLV.U2, 1)      # Revision

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -197,6 +197,8 @@ class Matter_UI
     webserver.content_send(f"<input type='number' min='0' max='4095' name='discriminator' value='{self.device.root_discriminator:i}'>")
     var ipv4only_checked = self.device.ipv4only ? " checked" : ""
     webserver.content_send(f"<p><input type='checkbox' name='ipv4'{ipv4only_checked}>IPv4 only</p>")
+    var disable_bridge_mode_checked = self.device.disable_bridge_mode ? " checked" : ""
+    webserver.content_send(f"<p><input type='checkbox' name='nobridge'{disable_bridge_mode_checked}>Disable bridge mode (not recommended)</p>")
     webserver.content_send("<p></p><button name='passcode' class='button bgrn'>Change</button></form></p>"
                            "<p></p></fieldset><p></p>")
 
@@ -755,6 +757,7 @@ class Matter_UI
           self.device.root_discriminator = int(webserver.arg("discriminator"))
         end
         self.device.ipv4only = webserver.arg("ipv4") == 'on'
+        self.device.disable_bridge_mode = webserver.arg("nobridge") == 'on'
         self.device.save_param()
 
         #- and force restart -#

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
@@ -7,86 +7,36 @@
 extern const bclass be_class_Matter_Device;
 
 /********************************************************************
-** Solidified function: msg_received
+** Solidified function: register_plugin_class
 ********************************************************************/
-be_local_closure(Matter_Device_msg_received,   /* name */
+be_local_closure(Matter_Device_register_plugin_class,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
+    7,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(msg_received),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(introspect),
+    /* K1   */  be_nested_str_weak(get),
+    /* K2   */  be_nested_str_weak(TYPE),
+    /* K3   */  be_nested_str_weak(plugins_classes),
     }),
-    be_str_weak(msg_received),
+    be_str_weak(register_plugin_class),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
-      0x8C100901,  //  0001  GETMET	R4	R4	K1
-      0x5C180200,  //  0002  MOVE	R6	R1
-      0x5C1C0400,  //  0003  MOVE	R7	R2
-      0x5C200600,  //  0004  MOVE	R8	R3
-      0x7C100800,  //  0005  CALL	R4	4
-      0x80040800,  //  0006  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: conf_to_log
-********************************************************************/
-be_local_closure(Matter_Device_conf_to_log,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_nested_str_weak(),
-    /* K2   */  be_nested_str_weak(k2l),
-    /* K3   */  be_nested_str_weak(type),
-    /* K4   */  be_nested_str_weak(_X20_X25s_X3A_X25s),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(conf_to_log),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x58080001,  //  0001  LDCONST	R2	K1
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x5C180000,  //  0004  MOVE	R6	R0
-      0x7C100400,  //  0005  CALL	R4	2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0xA802000B,  //  0007  EXBLK	0	#0014
-      0x5C100600,  //  0008  MOVE	R4	R3
-      0x7C100000,  //  0009  CALL	R4	0
-      0x1C140903,  //  000A  EQ	R5	R4	K3
-      0x78160000,  //  000B  JMPF	R5	#000D
-      0x7001FFFA,  //  000C  JMP		#0008
-      0x60140018,  //  000D  GETGBL	R5	G24
-      0x58180004,  //  000E  LDCONST	R6	K4
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x94200004,  //  0010  GETIDX	R8	R0	R4
-      0x7C140600,  //  0011  CALL	R5	3
-      0x00080405,  //  0012  ADD	R2	R2	R5
-      0x7001FFF3,  //  0013  JMP		#0008
-      0x580C0005,  //  0014  LDCONST	R3	K5
-      0xAC0C0200,  //  0015  CATCH	R3	1	0
-      0xB0080000,  //  0016  RAISE	2	R0	R0
-      0x80040400,  //  0017  RET	1	R2
+    ( &(const binstruction[ 9]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x58180002,  //  0003  LDCONST	R6	K2
+      0x7C0C0600,  //  0004  CALL	R3	3
+      0x780E0001,  //  0005  JMPF	R3	#0008
+      0x88100103,  //  0006  GETMBR	R4	R0	K3
+      0x98100601,  //  0007  SETIDX	R4	R3	R1
+      0x80000000,  //  0008  RET	0
     })
   )
 );
@@ -125,153 +75,11 @@ be_local_closure(Matter_Device_save_before_restart,   /* name */
 
 
 /********************************************************************
-** Solidified function: register_native_classes
+** Solidified function: is_commissioning_open
 ********************************************************************/
-be_local_closure(Matter_Device_register_native_classes,   /* name */
+be_local_closure(Matter_Device_is_commissioning_open,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(members),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(get),
-    /* K5   */  be_nested_str_weak(class),
-    /* K6   */  be_nested_str_weak(find),
-    /* K7   */  be_nested_str_weak(Plugin_),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(register_plugin_class),
-    /* K10  */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(register_native_classes),
-    &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xA4120200,  //  0001  IMPORT	R4	K1
-      0x60140010,  //  0002  GETGBL	R5	G16
-      0x8C180702,  //  0003  GETMET	R6	R3	K2
-      0xB8220600,  //  0004  GETNGBL	R8	K3
-      0x7C180400,  //  0005  CALL	R6	2
-      0x7C140200,  //  0006  CALL	R5	1
-      0xA8020014,  //  0007  EXBLK	0	#001D
-      0x5C180A00,  //  0008  MOVE	R6	R5
-      0x7C180000,  //  0009  CALL	R6	0
-      0x8C1C0704,  //  000A  GETMET	R7	R3	K4
-      0xB8260600,  //  000B  GETNGBL	R9	K3
-      0x5C280C00,  //  000C  MOVE	R10	R6
-      0x7C1C0600,  //  000D  CALL	R7	3
-      0x60200004,  //  000E  GETGBL	R8	G4
-      0x5C240E00,  //  000F  MOVE	R9	R7
-      0x7C200200,  //  0010  CALL	R8	1
-      0x1C201105,  //  0011  EQ	R8	R8	K5
-      0x78220008,  //  0012  JMPF	R8	#001C
-      0x8C200906,  //  0013  GETMET	R8	R4	K6
-      0x5C280C00,  //  0014  MOVE	R10	R6
-      0x582C0007,  //  0015  LDCONST	R11	K7
-      0x7C200600,  //  0016  CALL	R8	3
-      0x1C201108,  //  0017  EQ	R8	R8	K8
-      0x78220002,  //  0018  JMPF	R8	#001C
-      0x8C200109,  //  0019  GETMET	R8	R0	K9
-      0x5C280E00,  //  001A  MOVE	R10	R7
-      0x7C200400,  //  001B  CALL	R8	2
-      0x7001FFEA,  //  001C  JMP		#0008
-      0x5814000A,  //  001D  LDCONST	R5	K10
-      0xAC140200,  //  001E  CATCH	R5	1	0
-      0xB0080000,  //  001F  RAISE	2	R0	R0
-      0x80000000,  //  0020  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _compute_pbkdf
-********************************************************************/
-be_local_closure(Matter_Device__compute_pbkdf,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(add),
-    /* K2   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
-    /* K3   */  be_nested_str_weak(derive),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(root_w0),
-    /* K6   */  be_nested_str_weak(EC_P256),
-    /* K7   */  be_nested_str_weak(mod),
-    /* K8   */  be_nested_str_weak(root_L),
-    /* K9   */  be_nested_str_weak(public_key),
-    }),
-    be_str_weak(_compute_pbkdf),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0x60140015,  //  0001  GETGBL	R5	G21
-      0x7C140000,  //  0002  CALL	R5	0
-      0x8C140B01,  //  0003  GETMET	R5	R5	K1
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x54220003,  //  0005  LDINT	R8	4
-      0x7C140600,  //  0006  CALL	R5	3
-      0x8C180902,  //  0007  GETMET	R6	R4	K2
-      0x7C180200,  //  0008  CALL	R6	1
-      0x8C180D03,  //  0009  GETMET	R6	R6	K3
-      0x5C200A00,  //  000A  MOVE	R8	R5
-      0x5C240600,  //  000B  MOVE	R9	R3
-      0x5C280400,  //  000C  MOVE	R10	R2
-      0x542E004F,  //  000D  LDINT	R11	80
-      0x7C180A00,  //  000E  CALL	R6	5
-      0x541E0026,  //  000F  LDINT	R7	39
-      0x401E0807,  //  0010  CONNECT	R7	K4	R7
-      0x941C0C07,  //  0011  GETIDX	R7	R6	R7
-      0x54220027,  //  0012  LDINT	R8	40
-      0x5426004E,  //  0013  LDINT	R9	79
-      0x40201009,  //  0014  CONNECT	R8	R8	R9
-      0x94200C08,  //  0015  GETIDX	R8	R6	R8
-      0x8C240906,  //  0016  GETMET	R9	R4	K6
-      0x7C240200,  //  0017  CALL	R9	1
-      0x8C241307,  //  0018  GETMET	R9	R9	K7
-      0x5C2C0E00,  //  0019  MOVE	R11	R7
-      0x7C240400,  //  001A  CALL	R9	2
-      0x90020A09,  //  001B  SETMBR	R0	K5	R9
-      0x8C240906,  //  001C  GETMET	R9	R4	K6
-      0x7C240200,  //  001D  CALL	R9	1
-      0x8C241307,  //  001E  GETMET	R9	R9	K7
-      0x5C2C1000,  //  001F  MOVE	R11	R8
-      0x7C240400,  //  0020  CALL	R9	2
-      0x8C280906,  //  0021  GETMET	R10	R4	K6
-      0x7C280200,  //  0022  CALL	R10	1
-      0x8C281509,  //  0023  GETMET	R10	R10	K9
-      0x5C301200,  //  0024  MOVE	R12	R9
-      0x7C280400,  //  0025  CALL	R10	2
-      0x9002100A,  //  0026  SETMBR	R0	K8	R10
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_250ms
-********************************************************************/
-be_local_closure(Matter_Device_every_250ms,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
+    3,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -279,32 +87,16 @@ be_local_closure(Matter_Device_every_250ms,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(every_250ms),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(plugins),
-    /* K4   */  be_const_int(1),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
     }),
-    be_str_weak(every_250ms),
+    be_str_weak(is_commissioning_open),
     &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
+    ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x58040002,  //  0003  LDCONST	R1	K2
-      0x6008000C,  //  0004  GETGBL	R2	G12
-      0x880C0103,  //  0005  GETMBR	R3	R0	K3
-      0x7C080200,  //  0006  CALL	R2	1
-      0x14080202,  //  0007  LT	R2	R1	R2
-      0x780A0005,  //  0008  JMPF	R2	#000F
-      0x88080103,  //  0009  GETMBR	R2	R0	K3
-      0x94080401,  //  000A  GETIDX	R2	R2	R1
-      0x8C080501,  //  000B  GETMET	R2	R2	K1
-      0x7C080200,  //  000C  CALL	R2	1
-      0x00040304,  //  000D  ADD	R1	R1	K4
-      0x7001FFF4,  //  000E  JMP		#0004
-      0x80000000,  //  000F  RET	0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
     })
   )
 );
@@ -431,6 +223,137 @@ be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
       0x70020000,  //  004F  JMP		#0051
       0xB0080000,  //  0050  RAISE	2	R0	R0
       0x80000000,  //  0051  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(Matter_Device_every_250ms,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(every_250ms),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(plugins),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x58040002,  //  0003  LDCONST	R1	K2
+      0x6008000C,  //  0004  GETGBL	R2	G12
+      0x880C0103,  //  0005  GETMBR	R3	R0	K3
+      0x7C080200,  //  0006  CALL	R2	1
+      0x14080202,  //  0007  LT	R2	R1	R2
+      0x780A0005,  //  0008  JMPF	R2	#000F
+      0x88080103,  //  0009  GETMBR	R2	R0	K3
+      0x94080401,  //  000A  GETIDX	R2	R2	R1
+      0x8C080501,  //  000B  GETMET	R2	R2	K1
+      0x7C080200,  //  000C  CALL	R2	1
+      0x00040304,  //  000D  ADD	R1	R1	K4
+      0x7001FFF4,  //  000E  JMP		#0004
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Device_invoke_request,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(endpoint),
+    /* K2   */  be_nested_str_weak(plugins),
+    /* K3   */  be_nested_str_weak(invoke_request),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(status),
+    /* K6   */  be_nested_str_weak(matter),
+    /* K7   */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+    }),
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58100000,  //  0000  LDCONST	R4	K0
+      0x88140701,  //  0001  GETMBR	R5	R3	K1
+      0x6018000C,  //  0002  GETGBL	R6	G12
+      0x881C0102,  //  0003  GETMBR	R7	R0	K2
+      0x7C180200,  //  0004  CALL	R6	1
+      0x14180806,  //  0005  LT	R6	R4	R6
+      0x781A000C,  //  0006  JMPF	R6	#0014
+      0x88180102,  //  0007  GETMBR	R6	R0	K2
+      0x94180C04,  //  0008  GETIDX	R6	R6	R4
+      0x881C0D01,  //  0009  GETMBR	R7	R6	K1
+      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
+      0x781E0005,  //  000B  JMPF	R7	#0012
+      0x8C1C0D03,  //  000C  GETMET	R7	R6	K3
+      0x5C240200,  //  000D  MOVE	R9	R1
+      0x5C280400,  //  000E  MOVE	R10	R2
+      0x5C2C0600,  //  000F  MOVE	R11	R3
+      0x7C1C0800,  //  0010  CALL	R7	4
+      0x80040E00,  //  0011  RET	1	R7
+      0x00100904,  //  0012  ADD	R4	R4	K4
+      0x7001FFED,  //  0013  JMP		#0002
+      0xB81A0C00,  //  0014  GETNGBL	R6	K6
+      0x88180D07,  //  0015  GETMBR	R6	R6	K7
+      0x900E0A06,  //  0016  SETMBR	R3	K5	R6
+      0x80000000,  //  0017  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_50ms
+********************************************************************/
+be_local_closure(Matter_Device_every_50ms,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tick),
+    /* K1   */  be_const_int(1),
+    }),
+    be_str_weak(every_50ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x00040301,  //  0001  ADD	R1	R1	K1
+      0x90020001,  //  0002  SETMBR	R0	K0	R1
+      0x80000000,  //  0003  RET	0
     })
   )
 );
@@ -644,88 +567,6 @@ be_local_closure(Matter_Device__instantiate_plugins_from_config,   /* name */
 
 
 /********************************************************************
-** Solidified function: start_root_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(PASE_TIMEOUT),
-    /* K1   */  be_nested_str_weak(compute_manual_pairing_code),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_nested_str_weak(compute_qrcode_content),
-    /* K7   */  be_nested_str_weak(publish_result),
-    /* K8   */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A1_X2C_X22PairingCode_X22_X3A_X22_X25s_X22_X2C_X22QRCode_X22_X3A_X22_X25s_X22_X7D_X7D),
-    /* K9   */  be_nested_str_weak(Matter),
-    /* K10  */  be_nested_str_weak(_compute_pbkdf),
-    /* K11  */  be_nested_str_weak(root_passcode),
-    /* K12  */  be_nested_str_weak(root_iterations),
-    /* K13  */  be_nested_str_weak(root_salt),
-    /* K14  */  be_nested_str_weak(start_basic_commissioning),
-    /* K15  */  be_nested_str_weak(root_discriminator),
-    /* K16  */  be_nested_str_weak(root_w0),
-    /* K17  */  be_nested_str_weak(root_L),
-    }),
-    be_str_weak(start_root_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0x88040100,  //  0003  GETMBR	R1	R0	K0
-      0x8C080101,  //  0004  GETMET	R2	R0	K1
-      0x7C080200,  //  0005  CALL	R2	1
-      0xB80E0400,  //  0006  GETNGBL	R3	K2
-      0x8C0C0703,  //  0007  GETMET	R3	R3	K3
-      0x60140018,  //  0008  GETGBL	R5	G24
-      0x58180004,  //  0009  LDCONST	R6	K4
-      0x5C1C0400,  //  000A  MOVE	R7	R2
-      0x7C140400,  //  000B  CALL	R5	2
-      0x58180005,  //  000C  LDCONST	R6	K5
-      0x7C0C0600,  //  000D  CALL	R3	3
-      0x8C0C0106,  //  000E  GETMET	R3	R0	K6
-      0x7C0C0200,  //  000F  CALL	R3	1
-      0xB8120400,  //  0010  GETNGBL	R4	K2
-      0x8C100907,  //  0011  GETMET	R4	R4	K7
-      0x60180018,  //  0012  GETGBL	R6	G24
-      0x581C0008,  //  0013  LDCONST	R7	K8
-      0x5C200400,  //  0014  MOVE	R8	R2
-      0x5C240600,  //  0015  MOVE	R9	R3
-      0x7C180600,  //  0016  CALL	R6	3
-      0x581C0009,  //  0017  LDCONST	R7	K9
-      0x7C100600,  //  0018  CALL	R4	3
-      0x8C10010A,  //  0019  GETMET	R4	R0	K10
-      0x8818010B,  //  001A  GETMBR	R6	R0	K11
-      0x881C010C,  //  001B  GETMBR	R7	R0	K12
-      0x8820010D,  //  001C  GETMBR	R8	R0	K13
-      0x7C100800,  //  001D  CALL	R4	4
-      0x8C10010E,  //  001E  GETMET	R4	R0	K14
-      0x5C180200,  //  001F  MOVE	R6	R1
-      0x881C010C,  //  0020  GETMBR	R7	R0	K12
-      0x8820010F,  //  0021  GETMBR	R8	R0	K15
-      0x8824010D,  //  0022  GETMBR	R9	R0	K13
-      0x88280110,  //  0023  GETMBR	R10	R0	K16
-      0x882C0111,  //  0024  GETMBR	R11	R0	K17
-      0x4C300000,  //  0025  LDNIL	R12
-      0x7C101000,  //  0026  CALL	R4	8
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: compute_qrcode_content
 ********************************************************************/
 be_local_closure(Matter_Device_compute_qrcode_content,   /* name */
@@ -802,11 +643,11 @@ be_local_closure(Matter_Device_compute_qrcode_content,   /* name */
 
 
 /********************************************************************
-** Solidified function: bridge_remove_endpoint
+** Solidified function: find_plugin_by_endpoint
 ********************************************************************/
-be_local_closure(Matter_Device_bridge_remove_endpoint,   /* name */
+be_local_closure(Matter_Device_find_plugin_by_endpoint,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    6,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -814,89 +655,68 @@ be_local_closure(Matter_Device_bridge_remove_endpoint,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(plugins_config),
-    /* K2   */  be_nested_str_weak(contains),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
-    /* K6   */  be_const_int(3),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(remove),
-    /* K10  */  be_nested_str_weak(plugins_persist),
-    /* K11  */  be_nested_str_weak(save_param),
-    /* K12  */  be_nested_str_weak(signal_endpoints_changed),
-    /* K13  */  be_const_int(0),
-    /* K14  */  be_nested_str_weak(plugins),
-    /* K15  */  be_nested_str_weak(get_endpoint),
-    /* K16  */  be_const_int(1),
-    /* K17  */  be_nested_str_weak(clean_remotes),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(plugins),
+    /* K2   */  be_nested_str_weak(get_endpoint),
+    /* K3   */  be_const_int(1),
     }),
-    be_str_weak(bridge_remove_endpoint),
+    be_str_weak(find_plugin_by_endpoint),
     &be_const_str_solidified,
-    ( &(const binstruction[60]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x600C0008,  //  0001  GETGBL	R3	G8
-      0x5C100200,  //  0002  MOVE	R4	R1
+    ( &(const binstruction[17]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
       0x7C0C0200,  //  0003  CALL	R3	1
-      0x4C100000,  //  0004  LDNIL	R4
-      0x4C140000,  //  0005  LDNIL	R5
-      0x88180101,  //  0006  GETMBR	R6	R0	K1
-      0x8C180D02,  //  0007  GETMET	R6	R6	K2
-      0x5C200600,  //  0008  MOVE	R8	R3
-      0x7C180400,  //  0009  CALL	R6	2
-      0x741A0005,  //  000A  JMPT	R6	#0011
-      0xB81A0600,  //  000B  GETNGBL	R6	K3
-      0x8C180D04,  //  000C  GETMET	R6	R6	K4
-      0x00220A03,  //  000D  ADD	R8	K5	R3
-      0x58240006,  //  000E  LDCONST	R9	K6
-      0x7C180600,  //  000F  CALL	R6	3
-      0x80000C00,  //  0010  RET	0
-      0xB81A0600,  //  0011  GETNGBL	R6	K3
-      0x8C180D04,  //  0012  GETMET	R6	R6	K4
-      0x60200018,  //  0013  GETGBL	R8	G24
-      0x58240007,  //  0014  LDCONST	R9	K7
-      0x5C280200,  //  0015  MOVE	R10	R1
-      0x7C200400,  //  0016  CALL	R8	2
-      0x58240008,  //  0017  LDCONST	R9	K8
-      0x7C180600,  //  0018  CALL	R6	3
-      0x88180101,  //  0019  GETMBR	R6	R0	K1
-      0x8C180D09,  //  001A  GETMET	R6	R6	K9
-      0x5C200600,  //  001B  MOVE	R8	R3
-      0x7C180400,  //  001C  CALL	R6	2
-      0x50180200,  //  001D  LDBOOL	R6	1	0
-      0x90021406,  //  001E  SETMBR	R0	K10	R6
-      0x8C18010B,  //  001F  GETMET	R6	R0	K11
-      0x7C180200,  //  0020  CALL	R6	1
-      0x8C18010C,  //  0021  GETMET	R6	R0	K12
-      0x7C180200,  //  0022  CALL	R6	1
-      0x5818000D,  //  0023  LDCONST	R6	K13
-      0x601C000C,  //  0024  GETGBL	R7	G12
-      0x8820010E,  //  0025  GETMBR	R8	R0	K14
-      0x7C1C0200,  //  0026  CALL	R7	1
-      0x141C0C07,  //  0027  LT	R7	R6	R7
-      0x781E000F,  //  0028  JMPF	R7	#0039
-      0x881C010E,  //  0029  GETMBR	R7	R0	K14
-      0x941C0E06,  //  002A  GETIDX	R7	R7	R6
-      0x8C1C0F0F,  //  002B  GETMET	R7	R7	K15
-      0x7C1C0200,  //  002C  CALL	R7	1
-      0x1C1C0207,  //  002D  EQ	R7	R1	R7
-      0x781E0007,  //  002E  JMPF	R7	#0037
-      0x881C010E,  //  002F  GETMBR	R7	R0	K14
-      0x8C1C0F09,  //  0030  GETMET	R7	R7	K9
-      0x5C240C00,  //  0031  MOVE	R9	R6
-      0x7C1C0400,  //  0032  CALL	R7	2
-      0x8C1C010C,  //  0033  GETMET	R7	R0	K12
-      0x7C1C0200,  //  0034  CALL	R7	1
-      0x70020002,  //  0035  JMP		#0039
-      0x70020000,  //  0036  JMP		#0038
-      0x00180D10,  //  0037  ADD	R6	R6	K16
-      0x7001FFEA,  //  0038  JMP		#0024
-      0x8C1C0111,  //  0039  GETMET	R7	R0	K17
-      0x7C1C0200,  //  003A  CALL	R7	1
-      0x80000000,  //  003B  RET	0
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0008,  //  0005  JMPF	R3	#000F
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x8C100702,  //  0008  GETMET	R4	R3	K2
+      0x7C100200,  //  0009  CALL	R4	1
+      0x1C100801,  //  000A  EQ	R4	R4	R1
+      0x78120000,  //  000B  JMPF	R4	#000D
+      0x80040600,  //  000C  RET	1	R3
+      0x00080503,  //  000D  ADD	R2	R2	K3
+      0x7001FFF1,  //  000E  JMP		#0001
+      0x4C0C0000,  //  000F  LDNIL	R3
+      0x80040600,  //  0010  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _init_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device__init_basic_commissioning,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(count_active_fabrics),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(start_root_basic_commissioning),
+    }),
+    be_str_weak(_init_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x1C040302,  //  0003  EQ	R1	R1	K2
+      0x78060001,  //  0004  JMPF	R1	#0007
+      0x8C040103,  //  0005  GETMET	R1	R0	K3
+      0x7C040200,  //  0006  CALL	R1	1
+      0x80000000,  //  0007  RET	0
     })
   )
 );
@@ -986,1583 +806,6 @@ be_local_closure(Matter_Device_sort_distinct,   /* name */
 
 
 /********************************************************************
-** Solidified function: mdns_announce_PASE
-********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_PASE,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[41]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(VP),
-    /* K3   */  be_nested_str_weak(vendorid),
-    /* K4   */  be_nested_str_weak(_X2B),
-    /* K5   */  be_nested_str_weak(productid),
-    /* K6   */  be_nested_str_weak(D),
-    /* K7   */  be_nested_str_weak(commissioning_discriminator),
-    /* K8   */  be_nested_str_weak(CM),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(T),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(SII),
-    /* K13  */  be_nested_str_weak(SAI),
-    /* K14  */  be_nested_str_weak(commissioning_instance_wifi),
-    /* K15  */  be_nested_str_weak(random),
-    /* K16  */  be_nested_str_weak(tohex),
-    /* K17  */  be_nested_str_weak(commissioning_instance_eth),
-    /* K18  */  be_nested_str_weak(hostname_eth),
-    /* K19  */  be_nested_str_weak(add_service),
-    /* K20  */  be_nested_str_weak(_matterc),
-    /* K21  */  be_nested_str_weak(_udp),
-    /* K22  */  be_nested_str_weak(mdns_pase_eth),
-    /* K23  */  be_nested_str_weak(tasmota),
-    /* K24  */  be_nested_str_weak(log),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20announce_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K26  */  be_nested_str_weak(eth),
-    /* K27  */  be_const_int(2),
-    /* K28  */  be_nested_str_weak(_L),
-    /* K29  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
-    /* K30  */  be_const_int(3),
-    /* K31  */  be_nested_str_weak(add_subtype),
-    /* K32  */  be_nested_str_weak(_S),
-    /* K33  */  be_nested_str_weak(_V),
-    /* K34  */  be_nested_str_weak(_CM1),
-    /* K35  */  be_nested_str_weak(hostname_wifi),
-    /* K36  */  be_nested_str_weak(mdns_pase_wifi),
-    /* K37  */  be_nested_str_weak(MTR_X3A_X20starting_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K38  */  be_nested_str_weak(wifi),
-    /* K39  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K40  */  be_nested_str_weak(_X7C),
-    }),
-    be_str_weak(mdns_announce_PASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[236]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x600C0013,  //  0002  GETGBL	R3	G19
-      0x7C0C0000,  //  0003  CALL	R3	0
-      0x60100008,  //  0004  GETGBL	R4	G8
-      0x88140103,  //  0005  GETMBR	R5	R0	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x00100904,  //  0007  ADD	R4	R4	K4
-      0x60140008,  //  0008  GETGBL	R5	G8
-      0x88180105,  //  0009  GETMBR	R6	R0	K5
-      0x7C140200,  //  000A  CALL	R5	1
-      0x00100805,  //  000B  ADD	R4	R4	R5
-      0x980E0404,  //  000C  SETIDX	R3	K2	R4
-      0x88100107,  //  000D  GETMBR	R4	R0	K7
-      0x980E0C04,  //  000E  SETIDX	R3	K6	R4
-      0x980E1109,  //  000F  SETIDX	R3	K8	K9
-      0x980E150B,  //  0010  SETIDX	R3	K10	K11
-      0x54121387,  //  0011  LDINT	R4	5000
-      0x980E1804,  //  0012  SETIDX	R3	K12	R4
-      0x5412012B,  //  0013  LDINT	R4	300
-      0x980E1A04,  //  0014  SETIDX	R3	K13	R4
-      0x8C10050F,  //  0015  GETMET	R4	R2	K15
-      0x541A0007,  //  0016  LDINT	R6	8
-      0x7C100400,  //  0017  CALL	R4	2
-      0x8C100910,  //  0018  GETMET	R4	R4	K16
-      0x7C100200,  //  0019  CALL	R4	1
-      0x90021C04,  //  001A  SETMBR	R0	K14	R4
-      0x8C10050F,  //  001B  GETMET	R4	R2	K15
-      0x541A0007,  //  001C  LDINT	R6	8
-      0x7C100400,  //  001D  CALL	R4	2
-      0x8C100910,  //  001E  GETMET	R4	R4	K16
-      0x7C100200,  //  001F  CALL	R4	1
-      0x90022204,  //  0020  SETMBR	R0	K17	R4
-      0xA80200B7,  //  0021  EXBLK	0	#00DA
-      0x88100112,  //  0022  GETMBR	R4	R0	K18
-      0x78120058,  //  0023  JMPF	R4	#007D
-      0x8C100313,  //  0024  GETMET	R4	R1	K19
-      0x58180014,  //  0025  LDCONST	R6	K20
-      0x581C0015,  //  0026  LDCONST	R7	K21
-      0x542215A3,  //  0027  LDINT	R8	5540
-      0x5C240600,  //  0028  MOVE	R9	R3
-      0x88280111,  //  0029  GETMBR	R10	R0	K17
-      0x882C0112,  //  002A  GETMBR	R11	R0	K18
-      0x7C100E00,  //  002B  CALL	R4	7
-      0x50100200,  //  002C  LDBOOL	R4	1	0
-      0x90022C04,  //  002D  SETMBR	R0	K22	R4
-      0xB8122E00,  //  002E  GETNGBL	R4	K23
-      0x8C100918,  //  002F  GETMET	R4	R4	K24
-      0x60180018,  //  0030  GETGBL	R6	G24
-      0x581C0019,  //  0031  LDCONST	R7	K25
-      0x5820001A,  //  0032  LDCONST	R8	K26
-      0x88240111,  //  0033  GETMBR	R9	R0	K17
-      0x88280112,  //  0034  GETMBR	R10	R0	K18
-      0x7C180800,  //  0035  CALL	R6	4
-      0x581C001B,  //  0036  LDCONST	R7	K27
-      0x7C100600,  //  0037  CALL	R4	3
-      0x60100008,  //  0038  GETGBL	R4	G8
-      0x88140107,  //  0039  GETMBR	R5	R0	K7
-      0x541A0FFE,  //  003A  LDINT	R6	4095
-      0x2C140A06,  //  003B  AND	R5	R5	R6
-      0x7C100200,  //  003C  CALL	R4	1
-      0x00123804,  //  003D  ADD	R4	K28	R4
-      0xB8162E00,  //  003E  GETNGBL	R5	K23
-      0x8C140B18,  //  003F  GETMET	R5	R5	K24
-      0x001E3A04,  //  0040  ADD	R7	K29	R4
-      0x5820001E,  //  0041  LDCONST	R8	K30
-      0x7C140600,  //  0042  CALL	R5	3
-      0x8C14031F,  //  0043  GETMET	R5	R1	K31
-      0x581C0014,  //  0044  LDCONST	R7	K20
-      0x58200015,  //  0045  LDCONST	R8	K21
-      0x88240111,  //  0046  GETMBR	R9	R0	K17
-      0x88280112,  //  0047  GETMBR	R10	R0	K18
-      0x5C2C0800,  //  0048  MOVE	R11	R4
-      0x7C140C00,  //  0049  CALL	R5	6
-      0x60140008,  //  004A  GETGBL	R5	G8
-      0x88180107,  //  004B  GETMBR	R6	R0	K7
-      0x541E0EFF,  //  004C  LDINT	R7	3840
-      0x2C180C07,  //  004D  AND	R6	R6	R7
-      0x541E0007,  //  004E  LDINT	R7	8
-      0x3C180C07,  //  004F  SHR	R6	R6	R7
-      0x7C140200,  //  0050  CALL	R5	1
-      0x00164005,  //  0051  ADD	R5	K32	R5
-      0x5C100A00,  //  0052  MOVE	R4	R5
-      0xB8162E00,  //  0053  GETNGBL	R5	K23
-      0x8C140B18,  //  0054  GETMET	R5	R5	K24
-      0x001E3A04,  //  0055  ADD	R7	K29	R4
-      0x5820001E,  //  0056  LDCONST	R8	K30
-      0x7C140600,  //  0057  CALL	R5	3
-      0x8C14031F,  //  0058  GETMET	R5	R1	K31
-      0x581C0014,  //  0059  LDCONST	R7	K20
-      0x58200015,  //  005A  LDCONST	R8	K21
-      0x88240111,  //  005B  GETMBR	R9	R0	K17
-      0x88280112,  //  005C  GETMBR	R10	R0	K18
-      0x5C2C0800,  //  005D  MOVE	R11	R4
-      0x7C140C00,  //  005E  CALL	R5	6
-      0x60140008,  //  005F  GETGBL	R5	G8
-      0x88180103,  //  0060  GETMBR	R6	R0	K3
-      0x7C140200,  //  0061  CALL	R5	1
-      0x00164205,  //  0062  ADD	R5	K33	R5
-      0x5C100A00,  //  0063  MOVE	R4	R5
-      0xB8162E00,  //  0064  GETNGBL	R5	K23
-      0x8C140B18,  //  0065  GETMET	R5	R5	K24
-      0x001E3A04,  //  0066  ADD	R7	K29	R4
-      0x5820001E,  //  0067  LDCONST	R8	K30
-      0x7C140600,  //  0068  CALL	R5	3
-      0x8C14031F,  //  0069  GETMET	R5	R1	K31
-      0x581C0014,  //  006A  LDCONST	R7	K20
-      0x58200015,  //  006B  LDCONST	R8	K21
-      0x88240111,  //  006C  GETMBR	R9	R0	K17
-      0x88280112,  //  006D  GETMBR	R10	R0	K18
-      0x5C2C0800,  //  006E  MOVE	R11	R4
-      0x7C140C00,  //  006F  CALL	R5	6
-      0x58100022,  //  0070  LDCONST	R4	K34
-      0xB8162E00,  //  0071  GETNGBL	R5	K23
-      0x8C140B18,  //  0072  GETMET	R5	R5	K24
-      0x001E3A04,  //  0073  ADD	R7	K29	R4
-      0x5820001E,  //  0074  LDCONST	R8	K30
-      0x7C140600,  //  0075  CALL	R5	3
-      0x8C14031F,  //  0076  GETMET	R5	R1	K31
-      0x581C0014,  //  0077  LDCONST	R7	K20
-      0x58200015,  //  0078  LDCONST	R8	K21
-      0x88240111,  //  0079  GETMBR	R9	R0	K17
-      0x88280112,  //  007A  GETMBR	R10	R0	K18
-      0x5C2C0800,  //  007B  MOVE	R11	R4
-      0x7C140C00,  //  007C  CALL	R5	6
-      0x88100123,  //  007D  GETMBR	R4	R0	K35
-      0x78120058,  //  007E  JMPF	R4	#00D8
-      0x8C100313,  //  007F  GETMET	R4	R1	K19
-      0x58180014,  //  0080  LDCONST	R6	K20
-      0x581C0015,  //  0081  LDCONST	R7	K21
-      0x542215A3,  //  0082  LDINT	R8	5540
-      0x5C240600,  //  0083  MOVE	R9	R3
-      0x8828010E,  //  0084  GETMBR	R10	R0	K14
-      0x882C0123,  //  0085  GETMBR	R11	R0	K35
-      0x7C100E00,  //  0086  CALL	R4	7
-      0x50100200,  //  0087  LDBOOL	R4	1	0
-      0x90024804,  //  0088  SETMBR	R0	K36	R4
-      0xB8122E00,  //  0089  GETNGBL	R4	K23
-      0x8C100918,  //  008A  GETMET	R4	R4	K24
-      0x60180018,  //  008B  GETGBL	R6	G24
-      0x581C0025,  //  008C  LDCONST	R7	K37
-      0x58200026,  //  008D  LDCONST	R8	K38
-      0x8824010E,  //  008E  GETMBR	R9	R0	K14
-      0x88280123,  //  008F  GETMBR	R10	R0	K35
-      0x7C180800,  //  0090  CALL	R6	4
-      0x581C001E,  //  0091  LDCONST	R7	K30
-      0x7C100600,  //  0092  CALL	R4	3
-      0x60100008,  //  0093  GETGBL	R4	G8
-      0x88140107,  //  0094  GETMBR	R5	R0	K7
-      0x541A0FFE,  //  0095  LDINT	R6	4095
-      0x2C140A06,  //  0096  AND	R5	R5	R6
-      0x7C100200,  //  0097  CALL	R4	1
-      0x00123804,  //  0098  ADD	R4	K28	R4
-      0xB8162E00,  //  0099  GETNGBL	R5	K23
-      0x8C140B18,  //  009A  GETMET	R5	R5	K24
-      0x001E3A04,  //  009B  ADD	R7	K29	R4
-      0x5820001E,  //  009C  LDCONST	R8	K30
-      0x7C140600,  //  009D  CALL	R5	3
-      0x8C14031F,  //  009E  GETMET	R5	R1	K31
-      0x581C0014,  //  009F  LDCONST	R7	K20
-      0x58200015,  //  00A0  LDCONST	R8	K21
-      0x8824010E,  //  00A1  GETMBR	R9	R0	K14
-      0x88280123,  //  00A2  GETMBR	R10	R0	K35
-      0x5C2C0800,  //  00A3  MOVE	R11	R4
-      0x7C140C00,  //  00A4  CALL	R5	6
-      0x60140008,  //  00A5  GETGBL	R5	G8
-      0x88180107,  //  00A6  GETMBR	R6	R0	K7
-      0x541E0EFF,  //  00A7  LDINT	R7	3840
-      0x2C180C07,  //  00A8  AND	R6	R6	R7
-      0x541E0007,  //  00A9  LDINT	R7	8
-      0x3C180C07,  //  00AA  SHR	R6	R6	R7
-      0x7C140200,  //  00AB  CALL	R5	1
-      0x00164005,  //  00AC  ADD	R5	K32	R5
-      0x5C100A00,  //  00AD  MOVE	R4	R5
-      0xB8162E00,  //  00AE  GETNGBL	R5	K23
-      0x8C140B18,  //  00AF  GETMET	R5	R5	K24
-      0x001E3A04,  //  00B0  ADD	R7	K29	R4
-      0x5820001E,  //  00B1  LDCONST	R8	K30
-      0x7C140600,  //  00B2  CALL	R5	3
-      0x8C14031F,  //  00B3  GETMET	R5	R1	K31
-      0x581C0014,  //  00B4  LDCONST	R7	K20
-      0x58200015,  //  00B5  LDCONST	R8	K21
-      0x8824010E,  //  00B6  GETMBR	R9	R0	K14
-      0x88280123,  //  00B7  GETMBR	R10	R0	K35
-      0x5C2C0800,  //  00B8  MOVE	R11	R4
-      0x7C140C00,  //  00B9  CALL	R5	6
-      0x60140008,  //  00BA  GETGBL	R5	G8
-      0x88180103,  //  00BB  GETMBR	R6	R0	K3
-      0x7C140200,  //  00BC  CALL	R5	1
-      0x00164205,  //  00BD  ADD	R5	K33	R5
-      0x5C100A00,  //  00BE  MOVE	R4	R5
-      0xB8162E00,  //  00BF  GETNGBL	R5	K23
-      0x8C140B18,  //  00C0  GETMET	R5	R5	K24
-      0x001E3A04,  //  00C1  ADD	R7	K29	R4
-      0x5820001E,  //  00C2  LDCONST	R8	K30
-      0x7C140600,  //  00C3  CALL	R5	3
-      0x8C14031F,  //  00C4  GETMET	R5	R1	K31
-      0x581C0014,  //  00C5  LDCONST	R7	K20
-      0x58200015,  //  00C6  LDCONST	R8	K21
-      0x8824010E,  //  00C7  GETMBR	R9	R0	K14
-      0x88280123,  //  00C8  GETMBR	R10	R0	K35
-      0x5C2C0800,  //  00C9  MOVE	R11	R4
-      0x7C140C00,  //  00CA  CALL	R5	6
-      0x58100022,  //  00CB  LDCONST	R4	K34
-      0xB8162E00,  //  00CC  GETNGBL	R5	K23
-      0x8C140B18,  //  00CD  GETMET	R5	R5	K24
-      0x001E3A04,  //  00CE  ADD	R7	K29	R4
-      0x5820001E,  //  00CF  LDCONST	R8	K30
-      0x7C140600,  //  00D0  CALL	R5	3
-      0x8C14031F,  //  00D1  GETMET	R5	R1	K31
-      0x581C0014,  //  00D2  LDCONST	R7	K20
-      0x58200015,  //  00D3  LDCONST	R8	K21
-      0x8824010E,  //  00D4  GETMBR	R9	R0	K14
-      0x88280123,  //  00D5  GETMBR	R10	R0	K35
-      0x5C2C0800,  //  00D6  MOVE	R11	R4
-      0x7C140C00,  //  00D7  CALL	R5	6
-      0xA8040001,  //  00D8  EXBLK	1	1
-      0x70020010,  //  00D9  JMP		#00EB
-      0xAC100002,  //  00DA  CATCH	R4	0	2
-      0x7002000D,  //  00DB  JMP		#00EA
-      0xB81A2E00,  //  00DC  GETNGBL	R6	K23
-      0x8C180D18,  //  00DD  GETMET	R6	R6	K24
-      0x60200008,  //  00DE  GETGBL	R8	G8
-      0x5C240800,  //  00DF  MOVE	R9	R4
-      0x7C200200,  //  00E0  CALL	R8	1
-      0x00224E08,  //  00E1  ADD	R8	K39	R8
-      0x00201128,  //  00E2  ADD	R8	R8	K40
-      0x60240008,  //  00E3  GETGBL	R9	G8
-      0x5C280A00,  //  00E4  MOVE	R10	R5
-      0x7C240200,  //  00E5  CALL	R9	1
-      0x00201009,  //  00E6  ADD	R8	R8	R9
-      0x5824001B,  //  00E7  LDCONST	R9	K27
-      0x7C180600,  //  00E8  CALL	R6	3
-      0x70020000,  //  00E9  JMP		#00EB
-      0xB0080000,  //  00EA  RAISE	2	R0	R0
-      0x80000000,  //  00EB  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_http_remote
-********************************************************************/
-be_local_closure(Matter_Device_register_http_remote,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(http_remotes),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(get_timeout),
-    /* K3   */  be_nested_str_weak(set_timeout),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(HTTP_remote),
-    /* K6   */  be_nested_str_weak(plugins_config_remotes),
-    /* K7   */  be_nested_str_weak(set_info),
-    }),
-    be_str_weak(register_http_remote),
-    &be_const_str_solidified,
-    ( &(const binstruction[42]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x4C100000,  //  0001  LDNIL	R4
-      0x1C0C0604,  //  0002  EQ	R3	R3	R4
-      0x780E0002,  //  0003  JMPF	R3	#0007
-      0x600C0013,  //  0004  GETGBL	R3	G19
-      0x7C0C0000,  //  0005  CALL	R3	0
-      0x90020003,  //  0006  SETMBR	R0	K0	R3
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x88100100,  //  0008  GETMBR	R4	R0	K0
-      0x8C100901,  //  0009  GETMET	R4	R4	K1
-      0x5C180200,  //  000A  MOVE	R6	R1
-      0x7C100400,  //  000B  CALL	R4	2
-      0x78120009,  //  000C  JMPF	R4	#0017
-      0x88100100,  //  000D  GETMBR	R4	R0	K0
-      0x940C0801,  //  000E  GETIDX	R3	R4	R1
-      0x8C140702,  //  000F  GETMET	R5	R3	K2
-      0x7C140200,  //  0010  CALL	R5	1
-      0x14140405,  //  0011  LT	R5	R2	R5
-      0x78160002,  //  0012  JMPF	R5	#0016
-      0x8C140703,  //  0013  GETMET	R5	R3	K3
-      0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x7C140400,  //  0015  CALL	R5	2
-      0x70020011,  //  0016  JMP		#0029
-      0xB8120800,  //  0017  GETNGBL	R4	K4
-      0x8C100905,  //  0018  GETMET	R4	R4	K5
-      0x5C180000,  //  0019  MOVE	R6	R0
-      0x5C1C0200,  //  001A  MOVE	R7	R1
-      0x5C200400,  //  001B  MOVE	R8	R2
-      0x7C100800,  //  001C  CALL	R4	4
-      0x5C0C0800,  //  001D  MOVE	R3	R4
-      0x88100106,  //  001E  GETMBR	R4	R0	K6
-      0x8C100901,  //  001F  GETMET	R4	R4	K1
-      0x5C180200,  //  0020  MOVE	R6	R1
-      0x7C100400,  //  0021  CALL	R4	2
-      0x78120003,  //  0022  JMPF	R4	#0027
-      0x8C100707,  //  0023  GETMET	R4	R3	K7
-      0x88180106,  //  0024  GETMBR	R6	R0	K6
-      0x94180C01,  //  0025  GETIDX	R6	R6	R1
-      0x7C100400,  //  0026  CALL	R4	2
-      0x88100100,  //  0027  GETMBR	R4	R0	K0
-      0x98100203,  //  0028  SETIDX	R4	R1	R3
-      0x80040600,  //  0029  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_plugin_class_arg
-********************************************************************/
-be_local_closure(Matter_Device_get_plugin_class_arg,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins_classes),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(ARG),
-    /* K3   */  be_nested_str_weak(),
-    }),
-    be_str_weak(get_plugin_class_arg),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x880C0502,  //  0005  GETMBR	R3	R2	K2
-      0x70020000,  //  0006  JMP		#0008
-      0x580C0003,  //  0007  LDCONST	R3	K3
-      0x80040600,  //  0008  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: event_fabrics_saved
-********************************************************************/
-be_local_closure(Matter_Device_event_fabrics_saved,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(count_active_fabrics),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(plugins_persist),
-    /* K4   */  be_nested_str_weak(save_param),
-    }),
-    be_str_weak(event_fabrics_saved),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x24040302,  //  0003  GT	R1	R1	K2
-      0x78060005,  //  0004  JMPF	R1	#000B
-      0x88040103,  //  0005  GETMBR	R1	R0	K3
-      0x74060003,  //  0006  JMPT	R1	#000B
-      0x50040200,  //  0007  LDBOOL	R1	1	0
-      0x90020601,  //  0008  SETMBR	R0	K3	R1
-      0x8C040104,  //  0009  GETMET	R1	R0	K4
-      0x7C040200,  //  000A  CALL	R1	1
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_commands
-********************************************************************/
-be_local_closure(Matter_Device_register_commands,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        10,                          /* nstack */
-        4,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(MtrJoin),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 8]) {  /* code */
-          0x68100000,  //  0000  GETUPV	R4	U0
-          0x8C100900,  //  0001  GETMET	R4	R4	K0
-          0x5C180000,  //  0002  MOVE	R6	R0
-          0x5C1C0200,  //  0003  MOVE	R7	R1
-          0x5C200400,  //  0004  MOVE	R8	R2
-          0x5C240600,  //  0005  MOVE	R9	R3
-          0x7C100A00,  //  0006  CALL	R4	5
-          0x80040800,  //  0007  RET	1	R4
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(add_cmd),
-    /* K2   */  be_nested_str_weak(MtrJoin),
-    }),
-    be_str_weak(register_commands),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x580C0002,  //  0002  LDCONST	R3	K2
-      0x84100000,  //  0003  CLOSURE	R4	P0
-      0x7C040600,  //  0004  CALL	R1	3
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_commissioning_complete_deferred
-********************************************************************/
-be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        3,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 2]) {  /* upvals */
-          be_local_const_upval(1, 0),
-          be_local_const_upval(1, 1),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_commissioning_complete),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080001,  //  0002  GETUPV	R2	U1
-          0x7C000400,  //  0003  CALL	R0	2
-          0x80040000,  //  0004  RET	1	R0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(set_timer),
-    /* K2   */  be_const_int(0),
-    }),
-    be_str_weak(start_commissioning_complete_deferred),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x84140000,  //  0003  CLOSURE	R5	P0
-      0x7C080600,  //  0004  CALL	R2	3
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _init_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device__init_basic_commissioning,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(count_active_fabrics),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(start_root_basic_commissioning),
-    }),
-    be_str_weak(_init_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x1C040302,  //  0003  EQ	R1	R1	K2
-      0x78060001,  //  0004  JMPF	R1	#0007
-      0x8C040103,  //  0005  GETMET	R1	R0	K3
-      0x7C040200,  //  0006  CALL	R1	1
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_active_endpoints
-********************************************************************/
-be_local_closure(Matter_Device_get_active_endpoints,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins),
-    /* K1   */  be_nested_str_weak(get_endpoint),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(find),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(get_active_endpoints),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x88100100,  //  0003  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0xA8020011,  //  0005  EXBLK	0	#0018
-      0x5C100600,  //  0006  MOVE	R4	R3
-      0x7C100000,  //  0007  CALL	R4	0
-      0x8C140901,  //  0008  GETMET	R5	R4	K1
-      0x7C140200,  //  0009  CALL	R5	1
-      0x78060002,  //  000A  JMPF	R1	#000E
-      0x1C180B02,  //  000B  EQ	R6	R5	K2
-      0x781A0000,  //  000C  JMPF	R6	#000E
-      0x7001FFF7,  //  000D  JMP		#0006
-      0x8C180503,  //  000E  GETMET	R6	R2	K3
-      0x5C200A00,  //  000F  MOVE	R8	R5
-      0x7C180400,  //  0010  CALL	R6	2
-      0x4C1C0000,  //  0011  LDNIL	R7
-      0x1C180C07,  //  0012  EQ	R6	R6	R7
-      0x781A0002,  //  0013  JMPF	R6	#0017
-      0x8C180504,  //  0014  GETMET	R6	R2	K4
-      0x5C200A00,  //  0015  MOVE	R8	R5
-      0x7C180400,  //  0016  CALL	R6	2
-      0x7001FFED,  //  0017  JMP		#0006
-      0x580C0005,  //  0018  LDCONST	R3	K5
-      0xAC0C0200,  //  0019  CATCH	R3	1	0
-      0xB0080000,  //  001A  RAISE	2	R0	R0
-      0x80040400,  //  001B  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_remove_op_discovery
-********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(get_device_id),
-    /* K2   */  be_nested_str_weak(copy),
-    /* K3   */  be_nested_str_weak(reverse),
-    /* K4   */  be_nested_str_weak(get_fabric_compressed),
-    /* K5   */  be_nested_str_weak(tohex),
-    /* K6   */  be_nested_str_weak(_X2D),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(eth),
-    /* K9   */  be_nested_str_weak(find),
-    /* K10  */  be_nested_str_weak(up),
-    /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(remove_service),
-    /* K15  */  be_nested_str_weak(_matter),
-    /* K16  */  be_nested_str_weak(_tcp),
-    /* K17  */  be_nested_str_weak(hostname_eth),
-    /* K18  */  be_nested_str_weak(wifi),
-    /* K19  */  be_nested_str_weak(hostname_wifi),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K21  */  be_nested_str_weak(_X7C),
-    /* K22  */  be_const_int(2),
-    }),
-    be_str_weak(mdns_remove_op_discovery),
-    &be_const_str_solidified,
-    ( &(const binstruction[80]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA802003B,  //  0001  EXBLK	0	#003E
-      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x8C100304,  //  0008  GETMET	R4	R1	K4
-      0x7C100200,  //  0009  CALL	R4	1
-      0x8C140905,  //  000A  GETMET	R5	R4	K5
-      0x7C140200,  //  000B  CALL	R5	1
-      0x00140B06,  //  000C  ADD	R5	R5	K6
-      0x8C180705,  //  000D  GETMET	R6	R3	K5
-      0x7C180200,  //  000E  CALL	R6	1
-      0x00140A06,  //  000F  ADD	R5	R5	R6
-      0xB81A0E00,  //  0010  GETNGBL	R6	K7
-      0x8C180D08,  //  0011  GETMET	R6	R6	K8
-      0x7C180200,  //  0012  CALL	R6	1
-      0x8C180D09,  //  0013  GETMET	R6	R6	K9
-      0x5820000A,  //  0014  LDCONST	R8	K10
-      0x7C180400,  //  0015  CALL	R6	2
-      0x781A000E,  //  0016  JMPF	R6	#0026
-      0xB81A0E00,  //  0017  GETNGBL	R6	K7
-      0x8C180D0B,  //  0018  GETMET	R6	R6	K11
-      0x60200018,  //  0019  GETGBL	R8	G24
-      0x5824000C,  //  001A  LDCONST	R9	K12
-      0x58280008,  //  001B  LDCONST	R10	K8
-      0x5C2C0A00,  //  001C  MOVE	R11	R5
-      0x7C200600,  //  001D  CALL	R8	3
-      0x5824000D,  //  001E  LDCONST	R9	K13
-      0x7C180600,  //  001F  CALL	R6	3
-      0x8C18050E,  //  0020  GETMET	R6	R2	K14
-      0x5820000F,  //  0021  LDCONST	R8	K15
-      0x58240010,  //  0022  LDCONST	R9	K16
-      0x5C280A00,  //  0023  MOVE	R10	R5
-      0x882C0111,  //  0024  GETMBR	R11	R0	K17
-      0x7C180A00,  //  0025  CALL	R6	5
-      0xB81A0E00,  //  0026  GETNGBL	R6	K7
-      0x8C180D12,  //  0027  GETMET	R6	R6	K18
-      0x7C180200,  //  0028  CALL	R6	1
-      0x8C180D09,  //  0029  GETMET	R6	R6	K9
-      0x5820000A,  //  002A  LDCONST	R8	K10
-      0x7C180400,  //  002B  CALL	R6	2
-      0x781A000E,  //  002C  JMPF	R6	#003C
-      0xB81A0E00,  //  002D  GETNGBL	R6	K7
-      0x8C180D0B,  //  002E  GETMET	R6	R6	K11
-      0x60200018,  //  002F  GETGBL	R8	G24
-      0x5824000C,  //  0030  LDCONST	R9	K12
-      0x58280012,  //  0031  LDCONST	R10	K18
-      0x5C2C0A00,  //  0032  MOVE	R11	R5
-      0x7C200600,  //  0033  CALL	R8	3
-      0x5824000D,  //  0034  LDCONST	R9	K13
-      0x7C180600,  //  0035  CALL	R6	3
-      0x8C18050E,  //  0036  GETMET	R6	R2	K14
-      0x5820000F,  //  0037  LDCONST	R8	K15
-      0x58240010,  //  0038  LDCONST	R9	K16
-      0x5C280A00,  //  0039  MOVE	R10	R5
-      0x882C0113,  //  003A  GETMBR	R11	R0	K19
-      0x7C180A00,  //  003B  CALL	R6	5
-      0xA8040001,  //  003C  EXBLK	1	1
-      0x70020010,  //  003D  JMP		#004F
-      0xAC0C0002,  //  003E  CATCH	R3	0	2
-      0x7002000D,  //  003F  JMP		#004E
-      0xB8160E00,  //  0040  GETNGBL	R5	K7
-      0x8C140B0B,  //  0041  GETMET	R5	R5	K11
-      0x601C0008,  //  0042  GETGBL	R7	G8
-      0x5C200600,  //  0043  MOVE	R8	R3
-      0x7C1C0200,  //  0044  CALL	R7	1
-      0x001E2807,  //  0045  ADD	R7	K20	R7
-      0x001C0F15,  //  0046  ADD	R7	R7	K21
-      0x60200008,  //  0047  GETGBL	R8	G8
-      0x5C240800,  //  0048  MOVE	R9	R4
-      0x7C200200,  //  0049  CALL	R8	1
-      0x001C0E08,  //  004A  ADD	R7	R7	R8
-      0x58200016,  //  004B  LDCONST	R8	K22
-      0x7C140600,  //  004C  CALL	R5	3
-      0x70020000,  //  004D  JMP		#004F
-      0xB0080000,  //  004E  RAISE	2	R0	R0
-      0x80000000,  //  004F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Device_init,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_start),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0004,  //  0006  LDCONST	R3	K4
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_start),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0004,  //  0006  LDCONST	R3	K4
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[43]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(get_option),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(MATTER_OPTION),
-    /* K5   */  be_nested_str_weak(UI),
-    /* K6   */  be_nested_str_weak(started),
-    /* K7   */  be_nested_str_weak(tick),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(plugins),
-    /* K10  */  be_nested_str_weak(plugins_persist),
-    /* K11  */  be_nested_str_weak(plugins_classes),
-    /* K12  */  be_nested_str_weak(plugins_config_remotes),
-    /* K13  */  be_nested_str_weak(register_native_classes),
-    /* K14  */  be_nested_str_weak(vendorid),
-    /* K15  */  be_nested_str_weak(VENDOR_ID),
-    /* K16  */  be_nested_str_weak(productid),
-    /* K17  */  be_nested_str_weak(PRODUCT_ID),
-    /* K18  */  be_nested_str_weak(root_iterations),
-    /* K19  */  be_nested_str_weak(PBKDF_ITERATIONS),
-    /* K20  */  be_nested_str_weak(next_ep),
-    /* K21  */  be_const_int(1),
-    /* K22  */  be_nested_str_weak(root_salt),
-    /* K23  */  be_nested_str_weak(random),
-    /* K24  */  be_nested_str_weak(ipv4only),
-    /* K25  */  be_nested_str_weak(load_param),
-    /* K26  */  be_nested_str_weak(sessions),
-    /* K27  */  be_nested_str_weak(Session_Store),
-    /* K28  */  be_nested_str_weak(load_fabrics),
-    /* K29  */  be_nested_str_weak(message_handler),
-    /* K30  */  be_nested_str_weak(MessageHandler),
-    /* K31  */  be_nested_str_weak(ui),
-    /* K32  */  be_nested_str_weak(wifi),
-    /* K33  */  be_nested_str_weak(up),
-    /* K34  */  be_nested_str_weak(eth),
-    /* K35  */  be_nested_str_weak(start),
-    /* K36  */  be_nested_str_weak(add_rule),
-    /* K37  */  be_nested_str_weak(Wifi_X23Connected),
-    /* K38  */  be_nested_str_weak(matter_start),
-    /* K39  */  be_nested_str_weak(Eth_X23Connected),
-    /* K40  */  be_nested_str_weak(_init_basic_commissioning),
-    /* K41  */  be_nested_str_weak(add_driver),
-    /* K42  */  be_nested_str_weak(register_commands),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[105]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0xB8120600,  //  0003  GETNGBL	R4	K3
-      0x88100904,  //  0004  GETMBR	R4	R4	K4
-      0x7C080400,  //  0005  CALL	R2	2
-      0x740A0004,  //  0006  JMPT	R2	#000C
-      0xB80A0600,  //  0007  GETNGBL	R2	K3
-      0x8C080505,  //  0008  GETMET	R2	R2	K5
-      0x5C100000,  //  0009  MOVE	R4	R0
-      0x7C080400,  //  000A  CALL	R2	2
-      0x80000400,  //  000B  RET	0
-      0x50080000,  //  000C  LDBOOL	R2	0	0
-      0x90020C02,  //  000D  SETMBR	R0	K6	R2
-      0x90020F08,  //  000E  SETMBR	R0	K7	K8
-      0x60080012,  //  000F  GETGBL	R2	G18
-      0x7C080000,  //  0010  CALL	R2	0
-      0x90021202,  //  0011  SETMBR	R0	K9	R2
-      0x50080000,  //  0012  LDBOOL	R2	0	0
-      0x90021402,  //  0013  SETMBR	R0	K10	R2
-      0x60080013,  //  0014  GETGBL	R2	G19
-      0x7C080000,  //  0015  CALL	R2	0
-      0x90021602,  //  0016  SETMBR	R0	K11	R2
-      0x60080013,  //  0017  GETGBL	R2	G19
-      0x7C080000,  //  0018  CALL	R2	0
-      0x90021802,  //  0019  SETMBR	R0	K12	R2
-      0x8C08010D,  //  001A  GETMET	R2	R0	K13
-      0x7C080200,  //  001B  CALL	R2	1
-      0x8808010F,  //  001C  GETMBR	R2	R0	K15
-      0x90021C02,  //  001D  SETMBR	R0	K14	R2
-      0x88080111,  //  001E  GETMBR	R2	R0	K17
-      0x90022002,  //  001F  SETMBR	R0	K16	R2
-      0x88080113,  //  0020  GETMBR	R2	R0	K19
-      0x90022402,  //  0021  SETMBR	R0	K18	R2
-      0x90022915,  //  0022  SETMBR	R0	K20	K21
-      0x8C080317,  //  0023  GETMET	R2	R1	K23
-      0x5412000F,  //  0024  LDINT	R4	16
-      0x7C080400,  //  0025  CALL	R2	2
-      0x90022C02,  //  0026  SETMBR	R0	K22	R2
-      0x50080000,  //  0027  LDBOOL	R2	0	0
-      0x90023002,  //  0028  SETMBR	R0	K24	R2
-      0x8C080119,  //  0029  GETMET	R2	R0	K25
-      0x7C080200,  //  002A  CALL	R2	1
-      0xB80A0600,  //  002B  GETNGBL	R2	K3
-      0x8C08051B,  //  002C  GETMET	R2	R2	K27
-      0x5C100000,  //  002D  MOVE	R4	R0
-      0x7C080400,  //  002E  CALL	R2	2
-      0x90023402,  //  002F  SETMBR	R0	K26	R2
-      0x8808011A,  //  0030  GETMBR	R2	R0	K26
-      0x8C08051C,  //  0031  GETMET	R2	R2	K28
-      0x7C080200,  //  0032  CALL	R2	1
-      0xB80A0600,  //  0033  GETNGBL	R2	K3
-      0x8C08051E,  //  0034  GETMET	R2	R2	K30
-      0x5C100000,  //  0035  MOVE	R4	R0
-      0x7C080400,  //  0036  CALL	R2	2
-      0x90023A02,  //  0037  SETMBR	R0	K29	R2
-      0xB80A0600,  //  0038  GETNGBL	R2	K3
-      0x8C080505,  //  0039  GETMET	R2	R2	K5
-      0x5C100000,  //  003A  MOVE	R4	R0
-      0x7C080400,  //  003B  CALL	R2	2
-      0x90023E02,  //  003C  SETMBR	R0	K31	R2
-      0xB80A0200,  //  003D  GETNGBL	R2	K1
-      0x8C080520,  //  003E  GETMET	R2	R2	K32
-      0x7C080200,  //  003F  CALL	R2	1
-      0x94080521,  //  0040  GETIDX	R2	R2	K33
-      0x740A0004,  //  0041  JMPT	R2	#0047
-      0xB80A0200,  //  0042  GETNGBL	R2	K1
-      0x8C080522,  //  0043  GETMET	R2	R2	K34
-      0x7C080200,  //  0044  CALL	R2	1
-      0x94080521,  //  0045  GETIDX	R2	R2	K33
-      0x780A0001,  //  0046  JMPF	R2	#0049
-      0x8C080123,  //  0047  GETMET	R2	R0	K35
-      0x7C080200,  //  0048  CALL	R2	1
-      0xB80A0200,  //  0049  GETNGBL	R2	K1
-      0x8C080520,  //  004A  GETMET	R2	R2	K32
-      0x7C080200,  //  004B  CALL	R2	1
-      0x94080521,  //  004C  GETIDX	R2	R2	K33
-      0x740A0005,  //  004D  JMPT	R2	#0054
-      0xB80A0200,  //  004E  GETNGBL	R2	K1
-      0x8C080524,  //  004F  GETMET	R2	R2	K36
-      0x58100025,  //  0050  LDCONST	R4	K37
-      0x84140000,  //  0051  CLOSURE	R5	P0
-      0x58180026,  //  0052  LDCONST	R6	K38
-      0x7C080800,  //  0053  CALL	R2	4
-      0xB80A0200,  //  0054  GETNGBL	R2	K1
-      0x8C080522,  //  0055  GETMET	R2	R2	K34
-      0x7C080200,  //  0056  CALL	R2	1
-      0x94080521,  //  0057  GETIDX	R2	R2	K33
-      0x740A0005,  //  0058  JMPT	R2	#005F
-      0xB80A0200,  //  0059  GETNGBL	R2	K1
-      0x8C080524,  //  005A  GETMET	R2	R2	K36
-      0x58100027,  //  005B  LDCONST	R4	K39
-      0x84140001,  //  005C  CLOSURE	R5	P1
-      0x58180026,  //  005D  LDCONST	R6	K38
-      0x7C080800,  //  005E  CALL	R2	4
-      0x8C080128,  //  005F  GETMET	R2	R0	K40
-      0x7C080200,  //  0060  CALL	R2	1
-      0xB80A0200,  //  0061  GETNGBL	R2	K1
-      0x8C080529,  //  0062  GETMET	R2	R2	K41
-      0x5C100000,  //  0063  MOVE	R4	R0
-      0x7C080400,  //  0064  CALL	R2	2
-      0x8C08012A,  //  0065  GETMET	R2	R0	K42
-      0x7C080200,  //  0066  CALL	R2	1
-      0xA0000000,  //  0067  CLOSE	R0
-      0x80000000,  //  0068  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: k2l
-********************************************************************/
-be_local_closure(Matter_Device_k2l,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(push),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_const_int(0),
-    }),
-    be_str_weak(k2l),
-    &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0003,  //  0004  EQ	R3	R0	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80040400,  //  0006  RET	1	R2
-      0x600C0010,  //  0007  GETGBL	R3	G16
-      0x8C100101,  //  0008  GETMET	R4	R0	K1
-      0x7C100200,  //  0009  CALL	R4	1
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0xA8020005,  //  000B  EXBLK	0	#0012
-      0x5C100600,  //  000C  MOVE	R4	R3
-      0x7C100000,  //  000D  CALL	R4	0
-      0x8C140502,  //  000E  GETMET	R5	R2	K2
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x7C140400,  //  0010  CALL	R5	2
-      0x7001FFF9,  //  0011  JMP		#000C
-      0x580C0003,  //  0012  LDCONST	R3	K3
-      0xAC0C0200,  //  0013  CATCH	R3	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x600C0010,  //  0015  GETGBL	R3	G16
-      0x6010000C,  //  0016  GETGBL	R4	G12
-      0x5C140400,  //  0017  MOVE	R5	R2
-      0x7C100200,  //  0018  CALL	R4	1
-      0x04100904,  //  0019  SUB	R4	R4	K4
-      0x40120804,  //  001A  CONNECT	R4	K4	R4
-      0x7C0C0200,  //  001B  CALL	R3	1
-      0xA8020010,  //  001C  EXBLK	0	#002E
-      0x5C100600,  //  001D  MOVE	R4	R3
-      0x7C100000,  //  001E  CALL	R4	0
-      0x94140404,  //  001F  GETIDX	R5	R2	R4
-      0x5C180800,  //  0020  MOVE	R6	R4
-      0x241C0D05,  //  0021  GT	R7	R6	K5
-      0x781E0008,  //  0022  JMPF	R7	#002C
-      0x041C0D04,  //  0023  SUB	R7	R6	K4
-      0x941C0407,  //  0024  GETIDX	R7	R2	R7
-      0x241C0E05,  //  0025  GT	R7	R7	R5
-      0x781E0004,  //  0026  JMPF	R7	#002C
-      0x041C0D04,  //  0027  SUB	R7	R6	K4
-      0x941C0407,  //  0028  GETIDX	R7	R2	R7
-      0x98080C07,  //  0029  SETIDX	R2	R6	R7
-      0x04180D04,  //  002A  SUB	R6	R6	K4
-      0x7001FFF4,  //  002B  JMP		#0021
-      0x98080C05,  //  002C  SETIDX	R2	R6	R5
-      0x7001FFEE,  //  002D  JMP		#001D
-      0x580C0003,  //  002E  LDCONST	R3	K3
-      0xAC0C0200,  //  002F  CATCH	R3	1	0
-      0xB0080000,  //  0030  RAISE	2	R0	R0
-      0x80040400,  //  0031  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: adjust_next_ep
-********************************************************************/
-be_local_closure(Matter_Device_adjust_next_ep,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins_config),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(next_ep),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(adjust_next_ep),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000A,  //  0005  EXBLK	0	#0011
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x600C0009,  //  0008  GETGBL	R3	G9
-      0x5C100400,  //  0009  MOVE	R4	R2
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x88100102,  //  000B  GETMBR	R4	R0	K2
-      0x28100604,  //  000C  GE	R4	R3	R4
-      0x78120001,  //  000D  JMPF	R4	#0010
-      0x00100703,  //  000E  ADD	R4	R3	K3
-      0x90020404,  //  000F  SETMBR	R0	K2	R4
-      0x7001FFF4,  //  0010  JMP		#0006
-      0x58040004,  //  0011  LDCONST	R1	K4
-      0xAC040200,  //  0012  CATCH	R1	1	0
-      0xB0080000,  //  0013  RAISE	2	R0	R0
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: autoconf_sensors_list
-********************************************************************/
-be_local_closure(Matter_Device_autoconf_sensors_list,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(k2l),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(Temperature),
-    /* K3   */  be_nested_str_weak(_X23Temperature),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_nested_str_weak(type),
-    /* K6   */  be_nested_str_weak(temperature),
-    /* K7   */  be_nested_str_weak(filter),
-    /* K8   */  be_nested_str_weak(stop_iteration),
-    /* K9   */  be_nested_str_weak(Pressure),
-    /* K10  */  be_nested_str_weak(_X23Pressure),
-    /* K11  */  be_nested_str_weak(pressure),
-    /* K12  */  be_nested_str_weak(Illuminance),
-    /* K13  */  be_nested_str_weak(_X23Illuminance),
-    /* K14  */  be_nested_str_weak(illuminance),
-    /* K15  */  be_nested_str_weak(Humidity),
-    /* K16  */  be_nested_str_weak(_X23Humidity),
-    /* K17  */  be_nested_str_weak(humidity),
-    }),
-    be_str_weak(autoconf_sensors_list),
-    &be_const_str_solidified,
-    ( &(const binstruction[119]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x8C100100,  //  0003  GETMET	R4	R0	K0
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x7C100400,  //  0005  CALL	R4	2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0xA8020013,  //  0007  EXBLK	0	#001C
-      0x5C100600,  //  0008  MOVE	R4	R3
-      0x7C100000,  //  0009  CALL	R4	0
-      0x94140204,  //  000A  GETIDX	R5	R1	R4
-      0x6018000F,  //  000B  GETGBL	R6	G15
-      0x5C1C0A00,  //  000C  MOVE	R7	R5
-      0x60200013,  //  000D  GETGBL	R8	G19
-      0x7C180400,  //  000E  CALL	R6	2
-      0x781A000A,  //  000F  JMPF	R6	#001B
-      0x8C180B01,  //  0010  GETMET	R6	R5	K1
-      0x58200002,  //  0011  LDCONST	R8	K2
-      0x7C180400,  //  0012  CALL	R6	2
-      0x781A0006,  //  0013  JMPF	R6	#001B
-      0x00180903,  //  0014  ADD	R6	R4	K3
-      0x8C1C0504,  //  0015  GETMET	R7	R2	K4
-      0x60240013,  //  0016  GETGBL	R9	G19
-      0x7C240000,  //  0017  CALL	R9	0
-      0x98260B06,  //  0018  SETIDX	R9	K5	K6
-      0x98260E06,  //  0019  SETIDX	R9	K7	R6
-      0x7C1C0400,  //  001A  CALL	R7	2
-      0x7001FFEB,  //  001B  JMP		#0008
-      0x580C0008,  //  001C  LDCONST	R3	K8
-      0xAC0C0200,  //  001D  CATCH	R3	1	0
-      0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x600C0010,  //  001F  GETGBL	R3	G16
-      0x8C100100,  //  0020  GETMET	R4	R0	K0
-      0x5C180200,  //  0021  MOVE	R6	R1
-      0x7C100400,  //  0022  CALL	R4	2
-      0x7C0C0200,  //  0023  CALL	R3	1
-      0xA8020013,  //  0024  EXBLK	0	#0039
-      0x5C100600,  //  0025  MOVE	R4	R3
-      0x7C100000,  //  0026  CALL	R4	0
-      0x94140204,  //  0027  GETIDX	R5	R1	R4
-      0x6018000F,  //  0028  GETGBL	R6	G15
-      0x5C1C0A00,  //  0029  MOVE	R7	R5
-      0x60200013,  //  002A  GETGBL	R8	G19
-      0x7C180400,  //  002B  CALL	R6	2
-      0x781A000A,  //  002C  JMPF	R6	#0038
-      0x8C180B01,  //  002D  GETMET	R6	R5	K1
-      0x58200009,  //  002E  LDCONST	R8	K9
-      0x7C180400,  //  002F  CALL	R6	2
-      0x781A0006,  //  0030  JMPF	R6	#0038
-      0x0018090A,  //  0031  ADD	R6	R4	K10
-      0x8C1C0504,  //  0032  GETMET	R7	R2	K4
-      0x60240013,  //  0033  GETGBL	R9	G19
-      0x7C240000,  //  0034  CALL	R9	0
-      0x98260B0B,  //  0035  SETIDX	R9	K5	K11
-      0x98260E06,  //  0036  SETIDX	R9	K7	R6
-      0x7C1C0400,  //  0037  CALL	R7	2
-      0x7001FFEB,  //  0038  JMP		#0025
-      0x580C0008,  //  0039  LDCONST	R3	K8
-      0xAC0C0200,  //  003A  CATCH	R3	1	0
-      0xB0080000,  //  003B  RAISE	2	R0	R0
-      0x600C0010,  //  003C  GETGBL	R3	G16
-      0x8C100100,  //  003D  GETMET	R4	R0	K0
-      0x5C180200,  //  003E  MOVE	R6	R1
-      0x7C100400,  //  003F  CALL	R4	2
-      0x7C0C0200,  //  0040  CALL	R3	1
-      0xA8020013,  //  0041  EXBLK	0	#0056
-      0x5C100600,  //  0042  MOVE	R4	R3
-      0x7C100000,  //  0043  CALL	R4	0
-      0x94140204,  //  0044  GETIDX	R5	R1	R4
-      0x6018000F,  //  0045  GETGBL	R6	G15
-      0x5C1C0A00,  //  0046  MOVE	R7	R5
-      0x60200013,  //  0047  GETGBL	R8	G19
-      0x7C180400,  //  0048  CALL	R6	2
-      0x781A000A,  //  0049  JMPF	R6	#0055
-      0x8C180B01,  //  004A  GETMET	R6	R5	K1
-      0x5820000C,  //  004B  LDCONST	R8	K12
-      0x7C180400,  //  004C  CALL	R6	2
-      0x781A0006,  //  004D  JMPF	R6	#0055
-      0x0018090D,  //  004E  ADD	R6	R4	K13
-      0x8C1C0504,  //  004F  GETMET	R7	R2	K4
-      0x60240013,  //  0050  GETGBL	R9	G19
-      0x7C240000,  //  0051  CALL	R9	0
-      0x98260B0E,  //  0052  SETIDX	R9	K5	K14
-      0x98260E06,  //  0053  SETIDX	R9	K7	R6
-      0x7C1C0400,  //  0054  CALL	R7	2
-      0x7001FFEB,  //  0055  JMP		#0042
-      0x580C0008,  //  0056  LDCONST	R3	K8
-      0xAC0C0200,  //  0057  CATCH	R3	1	0
-      0xB0080000,  //  0058  RAISE	2	R0	R0
-      0x600C0010,  //  0059  GETGBL	R3	G16
-      0x8C100100,  //  005A  GETMET	R4	R0	K0
-      0x5C180200,  //  005B  MOVE	R6	R1
-      0x7C100400,  //  005C  CALL	R4	2
-      0x7C0C0200,  //  005D  CALL	R3	1
-      0xA8020013,  //  005E  EXBLK	0	#0073
-      0x5C100600,  //  005F  MOVE	R4	R3
-      0x7C100000,  //  0060  CALL	R4	0
-      0x94140204,  //  0061  GETIDX	R5	R1	R4
-      0x6018000F,  //  0062  GETGBL	R6	G15
-      0x5C1C0A00,  //  0063  MOVE	R7	R5
-      0x60200013,  //  0064  GETGBL	R8	G19
-      0x7C180400,  //  0065  CALL	R6	2
-      0x781A000A,  //  0066  JMPF	R6	#0072
-      0x8C180B01,  //  0067  GETMET	R6	R5	K1
-      0x5820000F,  //  0068  LDCONST	R8	K15
-      0x7C180400,  //  0069  CALL	R6	2
-      0x781A0006,  //  006A  JMPF	R6	#0072
-      0x00180910,  //  006B  ADD	R6	R4	K16
-      0x8C1C0504,  //  006C  GETMET	R7	R2	K4
-      0x60240013,  //  006D  GETGBL	R9	G19
-      0x7C240000,  //  006E  CALL	R9	0
-      0x98260B11,  //  006F  SETIDX	R9	K5	K17
-      0x98260E06,  //  0070  SETIDX	R9	K7	R6
-      0x7C1C0400,  //  0071  CALL	R7	2
-      0x7001FFEB,  //  0072  JMP		#005F
-      0x580C0008,  //  0073  LDCONST	R3	K8
-      0xAC0C0200,  //  0074  CATCH	R3	1	0
-      0xB0080000,  //  0075  RAISE	2	R0	R0
-      0x80040400,  //  0076  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_50ms
-********************************************************************/
-be_local_closure(Matter_Device_every_50ms,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tick),
-    /* K1   */  be_const_int(1),
-    }),
-    be_str_weak(every_50ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x00040301,  //  0001  ADD	R1	R1	K1
-      0x90020001,  //  0002  SETMBR	R0	K0	R1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    8,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
-        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
-        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(commissioning_iterations),
-    /* K4   */  be_nested_str_weak(commissioning_discriminator),
-    /* K5   */  be_nested_str_weak(commissioning_salt),
-    /* K6   */  be_nested_str_weak(commissioning_w0),
-    /* K7   */  be_nested_str_weak(commissioning_L),
-    /* K8   */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K9   */  be_nested_str_weak(wifi),
-    /* K10  */  be_nested_str_weak(up),
-    /* K11  */  be_nested_str_weak(eth),
-    /* K12  */  be_nested_str_weak(mdns_announce_PASE),
-    /* K13  */  be_nested_str_weak(add_rule),
-    /* K14  */  be_nested_str_weak(Wifi_X23Connected),
-    /* K15  */  be_nested_str_weak(Eth_X23Connected),
-    }),
-    be_str_weak(start_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0xB8220200,  //  0000  GETNGBL	R8	K1
-      0x8C201102,  //  0001  GETMET	R8	R8	K2
-      0x7C200200,  //  0002  CALL	R8	1
-      0x542603E7,  //  0003  LDINT	R9	1000
-      0x08240209,  //  0004  MUL	R9	R1	R9
-      0x00201009,  //  0005  ADD	R8	R8	R9
-      0x90020008,  //  0006  SETMBR	R0	K0	R8
-      0x90020602,  //  0007  SETMBR	R0	K3	R2
-      0x90020803,  //  0008  SETMBR	R0	K4	R3
-      0x90020A04,  //  0009  SETMBR	R0	K5	R4
-      0x90020C05,  //  000A  SETMBR	R0	K6	R5
-      0x90020E06,  //  000B  SETMBR	R0	K7	R6
-      0x90021007,  //  000C  SETMBR	R0	K8	R7
-      0xB8220200,  //  000D  GETNGBL	R8	K1
-      0x8C201109,  //  000E  GETMET	R8	R8	K9
-      0x7C200200,  //  000F  CALL	R8	1
-      0x9420110A,  //  0010  GETIDX	R8	R8	K10
-      0x74220004,  //  0011  JMPT	R8	#0017
-      0xB8220200,  //  0012  GETNGBL	R8	K1
-      0x8C20110B,  //  0013  GETMET	R8	R8	K11
-      0x7C200200,  //  0014  CALL	R8	1
-      0x9420110A,  //  0015  GETIDX	R8	R8	K10
-      0x78220002,  //  0016  JMPF	R8	#001A
-      0x8C20010C,  //  0017  GETMET	R8	R0	K12
-      0x7C200200,  //  0018  CALL	R8	1
-      0x7002000B,  //  0019  JMP		#0026
-      0xB8220200,  //  001A  GETNGBL	R8	K1
-      0x8C20110D,  //  001B  GETMET	R8	R8	K13
-      0x5828000E,  //  001C  LDCONST	R10	K14
-      0x842C0000,  //  001D  CLOSURE	R11	P0
-      0x5830000C,  //  001E  LDCONST	R12	K12
-      0x7C200800,  //  001F  CALL	R8	4
-      0xB8220200,  //  0020  GETNGBL	R8	K1
-      0x8C20110D,  //  0021  GETMET	R8	R8	K13
-      0x5828000F,  //  0022  LDCONST	R10	K15
-      0x842C0001,  //  0023  CLOSURE	R11	P1
-      0x5830000C,  //  0024  LDCONST	R12	K12
-      0x7C200800,  //  0025  CALL	R8	4
-      0xA0000000,  //  0026  CLOSE	R0
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop
-********************************************************************/
-be_local_closure(Matter_Device_stop,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(remove_driver),
-    /* K2   */  be_nested_str_weak(udp_server),
-    /* K3   */  be_nested_str_weak(stop),
-    }),
-    be_str_weak(stop),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x88040102,  //  0004  GETMBR	R1	R0	K2
-      0x78060002,  //  0005  JMPF	R1	#0009
-      0x88040102,  //  0006  GETMBR	R1	R0	K2
-      0x8C040303,  //  0007  GETMET	R1	R1	K3
-      0x7C040200,  //  0008  CALL	R1	1
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_operational_discovery
-********************************************************************/
-be_local_closure(Matter_Device_start_operational_discovery,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(mdns),
-    /* K2   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K3   */  be_nested_str_weak(root_w0),
-    /* K4   */  be_nested_str_weak(root_L),
-    /* K5   */  be_nested_str_weak(mdns_announce_op_discovery),
-    }),
-    be_str_weak(start_operational_discovery),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0x8C100102,  //  0002  GETMET	R4	R0	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x4C100000,  //  0004  LDNIL	R4
-      0x90020604,  //  0005  SETMBR	R0	K3	R4
-      0x4C100000,  //  0006  LDNIL	R4
-      0x90020804,  //  0007  SETMBR	R0	K4	R4
-      0x8C100105,  //  0008  GETMET	R4	R0	K5
-      0x5C180200,  //  0009  MOVE	R6	R1
-      0x7C100400,  //  000A  CALL	R4	2
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: start_commissioning_complete
 ********************************************************************/
 be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
@@ -2615,854 +858,6 @@ be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
       0x8C14010A,  //  0015  GETMET	R5	R0	K10
       0x7C140200,  //  0016  CALL	R5	1
       0x80000000,  //  0017  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_operational_discovery_deferred
-********************************************************************/
-be_local_closure(Matter_Device_start_operational_discovery_deferred,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        3,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 2]) {  /* upvals */
-          be_local_const_upval(1, 0),
-          be_local_const_upval(1, 1),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_operational_discovery),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080001,  //  0002  GETUPV	R2	U1
-          0x7C000400,  //  0003  CALL	R0	2
-          0x80040000,  //  0004  RET	1	R0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(set_timer),
-    /* K2   */  be_const_int(0),
-    }),
-    be_str_weak(start_operational_discovery_deferred),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x84140000,  //  0003  CLOSURE	R5	P0
-      0x7C080600,  //  0004  CALL	R2	3
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_fabric
-********************************************************************/
-be_local_closure(Matter_Device_remove_fabric,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(find_children_fabrics),
-    /* K2   */  be_nested_str_weak(get_fabric_index),
-    /* K3   */  be_nested_str_weak(find_fabric_by_index),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
-    /* K7   */  be_nested_str_weak(get_fabric_id),
-    /* K8   */  be_nested_str_weak(copy),
-    /* K9   */  be_nested_str_weak(reverse),
-    /* K10  */  be_nested_str_weak(tohex),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(message_handler),
-    /* K13  */  be_nested_str_weak(im),
-    /* K14  */  be_nested_str_weak(subs_shop),
-    /* K15  */  be_nested_str_weak(remove_by_fabric),
-    /* K16  */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K17  */  be_nested_str_weak(remove_fabric),
-    /* K18  */  be_nested_str_weak(stop_iteration),
-    /* K19  */  be_nested_str_weak(save_fabrics),
-    }),
-    be_str_weak(remove_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[56]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x8C100302,  //  0002  GETMET	R4	R1	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x7C080400,  //  0004  CALL	R2	2
-      0x4C0C0000,  //  0005  LDNIL	R3
-      0x1C0C0403,  //  0006  EQ	R3	R2	R3
-      0x780E0000,  //  0007  JMPF	R3	#0009
-      0x80000600,  //  0008  RET	0
-      0x600C0010,  //  0009  GETGBL	R3	G16
-      0x5C100400,  //  000A  MOVE	R4	R2
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0xA8020023,  //  000C  EXBLK	0	#0031
-      0x5C100600,  //  000D  MOVE	R4	R3
-      0x7C100000,  //  000E  CALL	R4	0
-      0x88140100,  //  000F  GETMBR	R5	R0	K0
-      0x8C140B03,  //  0010  GETMET	R5	R5	K3
-      0x5C1C0800,  //  0011  MOVE	R7	R4
-      0x7C140400,  //  0012  CALL	R5	2
-      0x4C180000,  //  0013  LDNIL	R6
-      0x20180A06,  //  0014  NE	R6	R5	R6
-      0x781A0019,  //  0015  JMPF	R6	#0030
-      0xB81A0800,  //  0016  GETNGBL	R6	K4
-      0x8C180D05,  //  0017  GETMET	R6	R6	K5
-      0x8C200B07,  //  0018  GETMET	R8	R5	K7
-      0x7C200200,  //  0019  CALL	R8	1
-      0x8C201108,  //  001A  GETMET	R8	R8	K8
-      0x7C200200,  //  001B  CALL	R8	1
-      0x8C201109,  //  001C  GETMET	R8	R8	K9
-      0x7C200200,  //  001D  CALL	R8	1
-      0x8C20110A,  //  001E  GETMET	R8	R8	K10
-      0x7C200200,  //  001F  CALL	R8	1
-      0x00220C08,  //  0020  ADD	R8	K6	R8
-      0x5824000B,  //  0021  LDCONST	R9	K11
-      0x7C180600,  //  0022  CALL	R6	3
-      0x8818010C,  //  0023  GETMBR	R6	R0	K12
-      0x88180D0D,  //  0024  GETMBR	R6	R6	K13
-      0x88180D0E,  //  0025  GETMBR	R6	R6	K14
-      0x8C180D0F,  //  0026  GETMET	R6	R6	K15
-      0x5C200A00,  //  0027  MOVE	R8	R5
-      0x7C180400,  //  0028  CALL	R6	2
-      0x8C180110,  //  0029  GETMET	R6	R0	K16
-      0x5C200A00,  //  002A  MOVE	R8	R5
-      0x7C180400,  //  002B  CALL	R6	2
-      0x88180100,  //  002C  GETMBR	R6	R0	K0
-      0x8C180D11,  //  002D  GETMET	R6	R6	K17
-      0x5C200A00,  //  002E  MOVE	R8	R5
-      0x7C180400,  //  002F  CALL	R6	2
-      0x7001FFDB,  //  0030  JMP		#000D
-      0x580C0012,  //  0031  LDCONST	R3	K18
-      0xAC0C0200,  //  0032  CATCH	R3	1	0
-      0xB0080000,  //  0033  RAISE	2	R0	R0
-      0x880C0100,  //  0034  GETMBR	R3	R0	K0
-      0x8C0C0713,  //  0035  GETMET	R3	R3	K19
-      0x7C0C0200,  //  0036  CALL	R3	1
-      0x80000000,  //  0037  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: received_ack
-********************************************************************/
-be_local_closure(Matter_Device_received_ack,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(received_ack),
-    }),
-    be_str_weak(received_ack),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: MtrJoin
-********************************************************************/
-be_local_closure(Matter_Device_MtrJoin,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K1   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(resp_cmnd_done),
-    }),
-    be_str_weak(MtrJoin),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x60140009,  //  0000  GETGBL	R5	G9
-      0x5C180600,  //  0001  MOVE	R6	R3
-      0x7C140200,  //  0002  CALL	R5	1
-      0x78160002,  //  0003  JMPF	R5	#0007
-      0x8C180100,  //  0004  GETMET	R6	R0	K0
-      0x7C180200,  //  0005  CALL	R6	1
-      0x70020001,  //  0006  JMP		#0009
-      0x8C180101,  //  0007  GETMET	R6	R0	K1
-      0x7C180200,  //  0008  CALL	R6	1
-      0xB81A0400,  //  0009  GETNGBL	R6	K2
-      0x8C180D03,  //  000A  GETMET	R6	R6	K3
-      0x7C180200,  //  000B  CALL	R6	1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_plugin_class_displayname
-********************************************************************/
-be_local_closure(Matter_Device_get_plugin_class_displayname,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins_classes),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(NAME),
-    /* K3   */  be_nested_str_weak(),
-    }),
-    be_str_weak(get_plugin_class_displayname),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x880C0502,  //  0005  GETMBR	R3	R2	K2
-      0x70020000,  //  0006  JMP		#0008
-      0x580C0003,  //  0007  LDCONST	R3	K3
-      0x80040600,  //  0008  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_remotes_info
-********************************************************************/
-be_local_closure(Matter_Device_update_remotes_info,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(http_remotes),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(get_info),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(stop_iteration),
-    /* K5   */  be_nested_str_weak(plugins_config_remotes),
-    }),
-    be_str_weak(update_remotes_info),
-    &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x60040013,  //  0000  GETGBL	R1	G19
-      0x7C040000,  //  0001  CALL	R1	0
-      0x88080100,  //  0002  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x20080403,  //  0004  NE	R2	R2	R3
-      0x780A0018,  //  0005  JMPF	R2	#001F
-      0x60080010,  //  0006  GETGBL	R2	G16
-      0x880C0100,  //  0007  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0008  GETMET	R3	R3	K1
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x7C080200,  //  000A  CALL	R2	1
-      0xA802000F,  //  000B  EXBLK	0	#001C
-      0x5C0C0400,  //  000C  MOVE	R3	R2
-      0x7C0C0000,  //  000D  CALL	R3	0
-      0x88100100,  //  000E  GETMBR	R4	R0	K0
-      0x94100803,  //  000F  GETIDX	R4	R4	R3
-      0x8C100902,  //  0010  GETMET	R4	R4	K2
-      0x7C100200,  //  0011  CALL	R4	1
-      0x4C140000,  //  0012  LDNIL	R5
-      0x20140805,  //  0013  NE	R5	R4	R5
-      0x78160005,  //  0014  JMPF	R5	#001B
-      0x6014000C,  //  0015  GETGBL	R5	G12
-      0x5C180800,  //  0016  MOVE	R6	R4
-      0x7C140200,  //  0017  CALL	R5	1
-      0x24140B03,  //  0018  GT	R5	R5	K3
-      0x78160000,  //  0019  JMPF	R5	#001B
-      0x98040604,  //  001A  SETIDX	R1	R3	R4
-      0x7001FFEF,  //  001B  JMP		#000C
-      0x58080004,  //  001C  LDCONST	R2	K4
-      0xAC080200,  //  001D  CATCH	R2	1	0
-      0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x90020A01,  //  001F  SETMBR	R0	K5	R1
-      0x80040200,  //  0020  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: autoconf_device
-********************************************************************/
-be_local_closure(Matter_Device_autoconf_device,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(plugins),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(plugins_persist),
-    /* K4   */  be_nested_str_weak(plugins_config),
-    /* K5   */  be_nested_str_weak(autoconf_device_map),
-    /* K6   */  be_nested_str_weak(plugins_config_remotes),
-    /* K7   */  be_nested_str_weak(adjust_next_ep),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(_instantiate_plugins_from_config),
-    /* K13  */  be_nested_str_weak(sessions),
-    /* K14  */  be_nested_str_weak(count_active_fabrics),
-    /* K15  */  be_nested_str_weak(save_param),
-    }),
-    be_str_weak(autoconf_device),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x24080502,  //  0004  GT	R2	R2	K2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x80000400,  //  0006  RET	0
-      0x88080103,  //  0007  GETMBR	R2	R0	K3
-      0x740A000F,  //  0008  JMPT	R2	#0019
-      0x8C080105,  //  0009  GETMET	R2	R0	K5
-      0x7C080200,  //  000A  CALL	R2	1
-      0x90020802,  //  000B  SETMBR	R0	K4	R2
-      0x60080013,  //  000C  GETGBL	R2	G19
-      0x7C080000,  //  000D  CALL	R2	0
-      0x90020C02,  //  000E  SETMBR	R0	K6	R2
-      0x8C080107,  //  000F  GETMET	R2	R0	K7
-      0x7C080200,  //  0010  CALL	R2	1
-      0xB80A1000,  //  0011  GETNGBL	R2	K8
-      0x8C080509,  //  0012  GETMET	R2	R2	K9
-      0x60100008,  //  0013  GETGBL	R4	G8
-      0x88140104,  //  0014  GETMBR	R5	R0	K4
-      0x7C100200,  //  0015  CALL	R4	1
-      0x00121404,  //  0016  ADD	R4	K10	R4
-      0x5814000B,  //  0017  LDCONST	R5	K11
-      0x7C080600,  //  0018  CALL	R2	3
-      0x8C08010C,  //  0019  GETMET	R2	R0	K12
-      0x88100104,  //  001A  GETMBR	R4	R0	K4
-      0x7C080400,  //  001B  CALL	R2	2
-      0x88080103,  //  001C  GETMBR	R2	R0	K3
-      0x740A0008,  //  001D  JMPT	R2	#0027
-      0x8808010D,  //  001E  GETMBR	R2	R0	K13
-      0x8C08050E,  //  001F  GETMET	R2	R2	K14
-      0x7C080200,  //  0020  CALL	R2	1
-      0x24080502,  //  0021  GT	R2	R2	K2
-      0x780A0003,  //  0022  JMPF	R2	#0027
-      0x50080200,  //  0023  LDBOOL	R2	1	0
-      0x90020602,  //  0024  SETMBR	R0	K3	R2
-      0x8C08010F,  //  0025  GETMET	R2	R0	K15
-      0x7C080200,  //  0026  CALL	R2	1
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clean_remotes
-********************************************************************/
-be_local_closure(Matter_Device_clean_remotes,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(http_remotes),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_nested_str_weak(plugins),
-    /* K5   */  be_nested_str_weak(get),
-    /* K6   */  be_nested_str_weak(http_remote),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(keys),
-    /* K10  */  be_nested_str_weak(tasmota),
-    /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
-    /* K13  */  be_nested_str_weak(addr),
-    /* K14  */  be_const_int(3),
-    /* K15  */  be_nested_str_weak(close),
-    /* K16  */  be_nested_str_weak(remove),
-    }),
-    be_str_weak(clean_remotes),
-    &be_const_str_solidified,
-    ( &(const binstruction[66]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x780A003D,  //  0002  JMPF	R2	#0041
-      0x60080013,  //  0003  GETGBL	R2	G19
-      0x7C080000,  //  0004  CALL	R2	0
-      0x600C0010,  //  0005  GETGBL	R3	G16
-      0x88100101,  //  0006  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0xA8020003,  //  0008  EXBLK	0	#000D
-      0x5C100600,  //  0009  MOVE	R4	R3
-      0x7C100000,  //  000A  CALL	R4	0
-      0x98080902,  //  000B  SETIDX	R2	R4	K2
-      0x7001FFFB,  //  000C  JMP		#0009
-      0x580C0003,  //  000D  LDCONST	R3	K3
-      0xAC0C0200,  //  000E  CATCH	R3	1	0
-      0xB0080000,  //  000F  RAISE	2	R0	R0
-      0x600C0010,  //  0010  GETGBL	R3	G16
-      0x88100104,  //  0011  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0xA802000F,  //  0013  EXBLK	0	#0024
-      0x5C100600,  //  0014  MOVE	R4	R3
-      0x7C100000,  //  0015  CALL	R4	0
-      0x8C140305,  //  0016  GETMET	R5	R1	K5
-      0x5C1C0800,  //  0017  MOVE	R7	R4
-      0x58200006,  //  0018  LDCONST	R8	K6
-      0x7C140600,  //  0019  CALL	R5	3
-      0x4C180000,  //  001A  LDNIL	R6
-      0x20180A06,  //  001B  NE	R6	R5	R6
-      0x781A0005,  //  001C  JMPF	R6	#0023
-      0x8C180507,  //  001D  GETMET	R6	R2	K7
-      0x5C200A00,  //  001E  MOVE	R8	R5
-      0x58240002,  //  001F  LDCONST	R9	K2
-      0x7C180600,  //  0020  CALL	R6	3
-      0x00180D08,  //  0021  ADD	R6	R6	K8
-      0x98080A06,  //  0022  SETIDX	R2	R5	R6
-      0x7001FFEF,  //  0023  JMP		#0014
-      0x580C0003,  //  0024  LDCONST	R3	K3
-      0xAC0C0200,  //  0025  CATCH	R3	1	0
-      0xB0080000,  //  0026  RAISE	2	R0	R0
-      0x600C0010,  //  0027  GETGBL	R3	G16
-      0x8C100509,  //  0028  GETMET	R4	R2	K9
-      0x7C100200,  //  0029  CALL	R4	1
-      0x7C0C0200,  //  002A  CALL	R3	1
-      0xA8020011,  //  002B  EXBLK	0	#003E
-      0x5C100600,  //  002C  MOVE	R4	R3
-      0x7C100000,  //  002D  CALL	R4	0
-      0x94140404,  //  002E  GETIDX	R5	R2	R4
-      0x1C140B02,  //  002F  EQ	R5	R5	K2
-      0x7816000B,  //  0030  JMPF	R5	#003D
-      0xB8161400,  //  0031  GETNGBL	R5	K10
-      0x8C140B0B,  //  0032  GETMET	R5	R5	K11
-      0x881C090D,  //  0033  GETMBR	R7	R4	K13
-      0x001E1807,  //  0034  ADD	R7	K12	R7
-      0x5820000E,  //  0035  LDCONST	R8	K14
-      0x7C140600,  //  0036  CALL	R5	3
-      0x8C14090F,  //  0037  GETMET	R5	R4	K15
-      0x7C140200,  //  0038  CALL	R5	1
-      0x88140101,  //  0039  GETMBR	R5	R0	K1
-      0x8C140B10,  //  003A  GETMET	R5	R5	K16
-      0x5C1C0800,  //  003B  MOVE	R7	R4
-      0x7C140400,  //  003C  CALL	R5	2
-      0x7001FFED,  //  003D  JMP		#002C
-      0x580C0003,  //  003E  LDCONST	R3	K3
-      0xAC0C0200,  //  003F  CATCH	R3	1	0
-      0xB0080000,  //  0040  RAISE	2	R0	R0
-      0x80000000,  //  0041  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_announce_op_discovery_all_fabrics
-********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(active_fabrics),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(mdns_announce_op_discovery),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(mdns_announce_op_discovery_all_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000B,  //  0005  EXBLK	0	#0012
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x780E0005,  //  000A  JMPF	R3	#0011
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x780E0002,  //  000D  JMPF	R3	#0011
-      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x7001FFF3,  //  0011  JMP		#0006
-      0x58040005,  //  0012  LDCONST	R1	K5
-      0xAC040200,  //  0013  CATCH	R1	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _trigger_read_sensors
-********************************************************************/
-be_local_closure(Matter_Device__trigger_read_sensors,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(read_sensors),
-    /* K3   */  be_nested_str_weak(load),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(plugins),
-    /* K6   */  be_nested_str_weak(parse_sensors),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
-    /* K10  */  be_const_int(3),
-    }),
-    be_str_weak(_trigger_read_sensors),
-    &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x1C0C0403,  //  0005  EQ	R3	R2	R3
-      0x780E0000,  //  0006  JMPF	R3	#0008
-      0x80000600,  //  0007  RET	0
-      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
-      0x5C140400,  //  0009  MOVE	R5	R2
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x4C100000,  //  000B  LDNIL	R4
-      0x20100604,  //  000C  NE	R4	R3	R4
-      0x7812000D,  //  000D  JMPF	R4	#001C
-      0x58100004,  //  000E  LDCONST	R4	K4
-      0x6014000C,  //  000F  GETGBL	R5	G12
-      0x88180105,  //  0010  GETMBR	R6	R0	K5
-      0x7C140200,  //  0011  CALL	R5	1
-      0x14140805,  //  0012  LT	R5	R4	R5
-      0x78160006,  //  0013  JMPF	R5	#001B
-      0x88140105,  //  0014  GETMBR	R5	R0	K5
-      0x94140A04,  //  0015  GETIDX	R5	R5	R4
-      0x8C140B06,  //  0016  GETMET	R5	R5	K6
-      0x5C1C0600,  //  0017  MOVE	R7	R3
-      0x7C140400,  //  0018  CALL	R5	2
-      0x00100907,  //  0019  ADD	R4	R4	K7
-      0x7001FFF3,  //  001A  JMP		#000F
-      0x70020007,  //  001B  JMP		#0024
-      0xB8120200,  //  001C  GETNGBL	R4	K1
-      0x8C100908,  //  001D  GETMET	R4	R4	K8
-      0x60180008,  //  001E  GETGBL	R6	G8
-      0x5C1C0400,  //  001F  MOVE	R7	R2
-      0x7C180200,  //  0020  CALL	R6	1
-      0x001A1206,  //  0021  ADD	R6	K9	R6
-      0x581C000A,  //  0022  LDCONST	R7	K10
-      0x7C100600,  //  0023  CALL	R4	3
-      0x80000000,  //  0024  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_root_commissioning_open
-********************************************************************/
-be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(commissioning_admin_fabric),
-    }),
-    be_str_weak(is_root_commissioning_open),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060003,  //  0003  JMPF	R1	#0008
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x4C080000,  //  0005  LDNIL	R2
-      0x1C040202,  //  0006  EQ	R1	R1	R2
-      0x74060000,  //  0007  JMPT	R1	#0009
-      0x50040001,  //  0008  LDBOOL	R1	0	1
-      0x50040200,  //  0009  LDBOOL	R1	1	0
-      0x80040200,  //  000A  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: compute_manual_pairing_code
-********************************************************************/
-be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(root_discriminator),
-    /* K1   */  be_nested_str_weak(root_passcode),
-    /* K2   */  be_nested_str_weak(_X251i_X2505i_X2504i),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Verhoeff),
-    /* K5   */  be_nested_str_weak(checksum),
-    }),
-    be_str_weak(compute_manual_pairing_code),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x540A0FFE,  //  0001  LDINT	R2	4095
-      0x2C040202,  //  0002  AND	R1	R1	R2
-      0x540A0009,  //  0003  LDINT	R2	10
-      0x3C040202,  //  0004  SHR	R1	R1	R2
-      0x88080100,  //  0005  GETMBR	R2	R0	K0
-      0x540E02FF,  //  0006  LDINT	R3	768
-      0x2C080403,  //  0007  AND	R2	R2	R3
-      0x540E0005,  //  0008  LDINT	R3	6
-      0x38080403,  //  0009  SHL	R2	R2	R3
-      0x880C0101,  //  000A  GETMBR	R3	R0	K1
-      0x54123FFE,  //  000B  LDINT	R4	16383
-      0x2C0C0604,  //  000C  AND	R3	R3	R4
-      0x30080403,  //  000D  OR	R2	R2	R3
-      0x880C0101,  //  000E  GETMBR	R3	R0	K1
-      0x5412000D,  //  000F  LDINT	R4	14
-      0x3C0C0604,  //  0010  SHR	R3	R3	R4
-      0x60100018,  //  0011  GETGBL	R4	G24
-      0x58140002,  //  0012  LDCONST	R5	K2
-      0x5C180200,  //  0013  MOVE	R6	R1
-      0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x5C200600,  //  0015  MOVE	R8	R3
-      0x7C100800,  //  0016  CALL	R4	4
-      0xB8160600,  //  0017  GETNGBL	R5	K3
-      0x88140B04,  //  0018  GETMBR	R5	R5	K4
-      0x8C140B05,  //  0019  GETMET	R5	R5	K5
-      0x5C1C0800,  //  001A  MOVE	R7	R4
-      0x7C140400,  //  001B  CALL	R5	2
-      0x00100805,  //  001C  ADD	R4	R4	R5
-      0x80040800,  //  001D  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: msg_send
-********************************************************************/
-be_local_closure(Matter_Device_msg_send,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(send_UDP),
-    }),
-    be_str_weak(msg_send),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start
-********************************************************************/
-be_local_closure(Matter_Device_start,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_trigger_read_sensors),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80000000,  //  0003  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(started),
-    /* K1   */  be_nested_str_weak(autoconf_device),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(add_cron),
-    /* K4   */  be_nested_str_weak(_X2A_X2F30_X20_X2A_X20_X2A_X20_X2A_X20_X2A_X20_X2A),
-    /* K5   */  be_nested_str_weak(matter_sensors_30s),
-    /* K6   */  be_nested_str_weak(_start_udp),
-    /* K7   */  be_nested_str_weak(UDP_PORT),
-    /* K8   */  be_nested_str_weak(start_mdns_announce_hostnames),
-    }),
-    be_str_weak(start),
-    &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060000,  //  0001  JMPF	R1	#0003
-      0x80000200,  //  0002  RET	0
-      0x8C040101,  //  0003  GETMET	R1	R0	K1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xB8060400,  //  0005  GETNGBL	R1	K2
-      0x8C040303,  //  0006  GETMET	R1	R1	K3
-      0x580C0004,  //  0007  LDCONST	R3	K4
-      0x84100000,  //  0008  CLOSURE	R4	P0
-      0x58140005,  //  0009  LDCONST	R5	K5
-      0x7C040800,  //  000A  CALL	R1	4
-      0x8C040106,  //  000B  GETMET	R1	R0	K6
-      0x880C0107,  //  000C  GETMBR	R3	R0	K7
-      0x7C040400,  //  000D  CALL	R1	2
-      0x8C040108,  //  000E  GETMET	R1	R0	K8
-      0x7C040200,  //  000F  CALL	R1	1
-      0x50040200,  //  0010  LDBOOL	R1	1	0
-      0x90020001,  //  0011  SETMBR	R0	K0	R1
-      0xA0000000,  //  0012  CLOSE	R0
-      0x80000000,  //  0013  RET	0
     })
   )
 );
@@ -3585,11 +980,11 @@ be_local_closure(Matter_Device_bridge_add_endpoint,   /* name */
 
 
 /********************************************************************
-** Solidified function: every_second
+** Solidified function: generate_random_passcode
 ********************************************************************/
-be_local_closure(Matter_Device_every_second,   /* name */
+be_local_closure(Matter_Device_generate_random_passcode,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    7,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3597,35 +992,54 @@ be_local_closure(Matter_Device_every_second,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(every_second),
-    /* K2   */  be_nested_str_weak(message_handler),
-    /* K3   */  be_nested_str_weak(commissioning_open),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(time_reached),
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(random),
+    /* K2   */  be_nested_str_weak(get),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_const_int(134217727),
+    /* K5   */  be_const_int(99999998),
+    /* K6   */  be_nested_str_weak(PASSCODE_INVALID),
+    /* K7   */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(every_second),
+    be_str_weak(generate_random_passcode),
     &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040102,  //  0003  GETMBR	R1	R0	K2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
-      0x7C040200,  //  0005  CALL	R1	1
-      0x88040103,  //  0006  GETMBR	R1	R0	K3
-      0x4C080000,  //  0007  LDNIL	R2
-      0x20040202,  //  0008  NE	R1	R1	R2
-      0x78060006,  //  0009  JMPF	R1	#0011
-      0xB8060800,  //  000A  GETNGBL	R1	K4
-      0x8C040305,  //  000B  GETMET	R1	R1	K5
-      0x880C0103,  //  000C  GETMBR	R3	R0	K3
-      0x7C040400,  //  000D  CALL	R1	2
-      0x78060001,  //  000E  JMPF	R1	#0011
-      0x4C040000,  //  000F  LDNIL	R1
-      0x90020601,  //  0010  SETMBR	R0	K3	R1
-      0x80000000,  //  0011  RET	0
+    ( &(const binstruction[35]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x500C0200,  //  0002  LDBOOL	R3	1	0
+      0x780E001D,  //  0003  JMPF	R3	#0022
+      0x8C0C0301,  //  0004  GETMET	R3	R1	K1
+      0x54160003,  //  0005  LDINT	R5	4
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
+      0x58140003,  //  0008  LDCONST	R5	K3
+      0x541A0003,  //  0009  LDINT	R6	4
+      0x7C0C0600,  //  000A  CALL	R3	3
+      0x2C0C0704,  //  000B  AND	R3	R3	K4
+      0x5C080600,  //  000C  MOVE	R2	R3
+      0x240C0505,  //  000D  GT	R3	R2	K5
+      0x780E0000,  //  000E  JMPF	R3	#0010
+      0x7001FFF1,  //  000F  JMP		#0002
+      0x600C0010,  //  0010  GETGBL	R3	G16
+      0x88100106,  //  0011  GETMBR	R4	R0	K6
+      0x7C0C0200,  //  0012  CALL	R3	1
+      0xA8020005,  //  0013  EXBLK	0	#001A
+      0x5C100600,  //  0014  MOVE	R4	R3
+      0x7C100000,  //  0015  CALL	R4	0
+      0x1C140404,  //  0016  EQ	R5	R2	R4
+      0x78160000,  //  0017  JMPF	R5	#0019
+      0x4C080000,  //  0018  LDNIL	R2
+      0x7001FFF9,  //  0019  JMP		#0014
+      0x580C0007,  //  001A  LDCONST	R3	K7
+      0xAC0C0200,  //  001B  CATCH	R3	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x4C0C0000,  //  001D  LDNIL	R3
+      0x200C0403,  //  001E  NE	R3	R2	R3
+      0x780E0000,  //  001F  JMPF	R3	#0021
+      0x80040400,  //  0020  RET	1	R2
+      0x7001FFDF,  //  0021  JMP		#0002
+      0x80000000,  //  0022  RET	0
     })
   )
 );
@@ -3633,45 +1047,12 @@ be_local_closure(Matter_Device_every_second,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_plugin_remote_info
+** Solidified function: register_http_remote
 ********************************************************************/
-be_local_closure(Matter_Device_get_plugin_remote_info,   /* name */
+be_local_closure(Matter_Device_register_http_remote,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins_config_remotes),
-    /* K1   */  be_nested_str_weak(find),
-    }),
-    be_str_weak(get_plugin_remote_info),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x60140013,  //  0003  GETGBL	R5	G19
-      0x7C140000,  //  0004  CALL	R5	0
-      0x7C080600,  //  0005  CALL	R2	3
-      0x80040400,  //  0006  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(Matter_Device_invoke_request,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
+    9,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -3679,42 +1060,60 @@ be_local_closure(Matter_Device_invoke_request,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(plugins),
-    /* K3   */  be_nested_str_weak(invoke_request),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(status),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+    /* K0   */  be_nested_str_weak(http_remotes),
+    /* K1   */  be_nested_str_weak(contains),
+    /* K2   */  be_nested_str_weak(get_timeout),
+    /* K3   */  be_nested_str_weak(set_timeout),
+    /* K4   */  be_nested_str_weak(matter),
+    /* K5   */  be_nested_str_weak(HTTP_remote),
+    /* K6   */  be_nested_str_weak(plugins_config_remotes),
+    /* K7   */  be_nested_str_weak(set_info),
     }),
-    be_str_weak(invoke_request),
+    be_str_weak(register_http_remote),
     &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58100000,  //  0000  LDCONST	R4	K0
-      0x88140701,  //  0001  GETMBR	R5	R3	K1
-      0x6018000C,  //  0002  GETGBL	R6	G12
-      0x881C0102,  //  0003  GETMBR	R7	R0	K2
-      0x7C180200,  //  0004  CALL	R6	1
-      0x14180806,  //  0005  LT	R6	R4	R6
-      0x781A000C,  //  0006  JMPF	R6	#0014
-      0x88180102,  //  0007  GETMBR	R6	R0	K2
-      0x94180C04,  //  0008  GETIDX	R6	R6	R4
-      0x881C0D01,  //  0009  GETMBR	R7	R6	K1
-      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0D03,  //  000C  GETMET	R7	R6	K3
-      0x5C240200,  //  000D  MOVE	R9	R1
-      0x5C280400,  //  000E  MOVE	R10	R2
-      0x5C2C0600,  //  000F  MOVE	R11	R3
-      0x7C1C0800,  //  0010  CALL	R7	4
-      0x80040E00,  //  0011  RET	1	R7
-      0x00100904,  //  0012  ADD	R4	R4	K4
-      0x7001FFED,  //  0013  JMP		#0002
-      0xB81A0C00,  //  0014  GETNGBL	R6	K6
-      0x88180D07,  //  0015  GETMBR	R6	R6	K7
-      0x900E0A06,  //  0016  SETMBR	R3	K5	R6
-      0x80000000,  //  0017  RET	0
+    ( &(const binstruction[42]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x4C100000,  //  0001  LDNIL	R4
+      0x1C0C0604,  //  0002  EQ	R3	R3	R4
+      0x780E0002,  //  0003  JMPF	R3	#0007
+      0x600C0013,  //  0004  GETGBL	R3	G19
+      0x7C0C0000,  //  0005  CALL	R3	0
+      0x90020003,  //  0006  SETMBR	R0	K0	R3
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x88100100,  //  0008  GETMBR	R4	R0	K0
+      0x8C100901,  //  0009  GETMET	R4	R4	K1
+      0x5C180200,  //  000A  MOVE	R6	R1
+      0x7C100400,  //  000B  CALL	R4	2
+      0x78120009,  //  000C  JMPF	R4	#0017
+      0x88100100,  //  000D  GETMBR	R4	R0	K0
+      0x940C0801,  //  000E  GETIDX	R3	R4	R1
+      0x8C140702,  //  000F  GETMET	R5	R3	K2
+      0x7C140200,  //  0010  CALL	R5	1
+      0x14140405,  //  0011  LT	R5	R2	R5
+      0x78160002,  //  0012  JMPF	R5	#0016
+      0x8C140703,  //  0013  GETMET	R5	R3	K3
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x7C140400,  //  0015  CALL	R5	2
+      0x70020011,  //  0016  JMP		#0029
+      0xB8120800,  //  0017  GETNGBL	R4	K4
+      0x8C100905,  //  0018  GETMET	R4	R4	K5
+      0x5C180000,  //  0019  MOVE	R6	R0
+      0x5C1C0200,  //  001A  MOVE	R7	R1
+      0x5C200400,  //  001B  MOVE	R8	R2
+      0x7C100800,  //  001C  CALL	R4	4
+      0x5C0C0800,  //  001D  MOVE	R3	R4
+      0x88100106,  //  001E  GETMBR	R4	R0	K6
+      0x8C100901,  //  001F  GETMET	R4	R4	K1
+      0x5C180200,  //  0020  MOVE	R6	R1
+      0x7C100400,  //  0021  CALL	R4	2
+      0x78120003,  //  0022  JMPF	R4	#0027
+      0x8C100707,  //  0023  GETMET	R4	R3	K7
+      0x88180106,  //  0024  GETMBR	R6	R0	K6
+      0x94180C01,  //  0025  GETIDX	R6	R6	R1
+      0x7C100400,  //  0026  CALL	R4	2
+      0x88100100,  //  0027  GETMBR	R4	R0	K0
+      0x98100203,  //  0028  SETIDX	R4	R1	R3
+      0x80040600,  //  0029  RET	1	R3
     })
   )
 );
@@ -3722,50 +1121,32 @@ be_local_closure(Matter_Device_invoke_request,   /* name */
 
 
 /********************************************************************
-** Solidified function: attribute_updated
+** Solidified function: msg_received
 ********************************************************************/
-be_local_closure(Matter_Device_attribute_updated,   /* name */
+be_local_closure(Matter_Device_msg_received,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
+    9,                          /* nstack */
+    4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Path),
-    /* K2   */  be_nested_str_weak(endpoint),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(message_handler),
-    /* K6   */  be_nested_str_weak(im),
-    /* K7   */  be_nested_str_weak(subs_shop),
-    /* K8   */  be_nested_str_weak(attribute_updated_ctx),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(msg_received),
     }),
-    be_str_weak(attribute_updated),
+    be_str_weak(msg_received),
     &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x1C140805,  //  0001  EQ	R5	R4	R5
-      0x78160000,  //  0002  JMPF	R5	#0004
-      0x50100000,  //  0003  LDBOOL	R4	0	0
-      0xB8160000,  //  0004  GETNGBL	R5	K0
-      0x8C140B01,  //  0005  GETMET	R5	R5	K1
-      0x7C140200,  //  0006  CALL	R5	1
-      0x90160401,  //  0007  SETMBR	R5	K2	R1
-      0x90160602,  //  0008  SETMBR	R5	K3	R2
-      0x90160803,  //  0009  SETMBR	R5	K4	R3
-      0x88180105,  //  000A  GETMBR	R6	R0	K5
-      0x88180D06,  //  000B  GETMBR	R6	R6	K6
-      0x88180D07,  //  000C  GETMBR	R6	R6	K7
-      0x8C180D08,  //  000D  GETMET	R6	R6	K8
-      0x5C200A00,  //  000E  MOVE	R8	R5
-      0x5C240800,  //  000F  MOVE	R9	R4
-      0x7C180600,  //  0010  CALL	R6	3
-      0x80000000,  //  0011  RET	0
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x8C100901,  //  0001  GETMET	R4	R4	K1
+      0x5C180200,  //  0002  MOVE	R6	R1
+      0x5C1C0400,  //  0003  MOVE	R7	R2
+      0x5C200600,  //  0004  MOVE	R8	R3
+      0x7C100800,  //  0005  CALL	R4	4
+      0x80040800,  //  0006  RET	1	R4
     })
   )
 );
@@ -3773,11 +1154,11 @@ be_local_closure(Matter_Device_attribute_updated,   /* name */
 
 
 /********************************************************************
-** Solidified function: register_plugin_class
+** Solidified function: get_plugin_class_arg
 ********************************************************************/
-be_local_closure(Matter_Device_register_plugin_class,   /* name */
+be_local_closure(Matter_Device_get_plugin_class_arg,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3786,23 +1167,23 @@ be_local_closure(Matter_Device_register_plugin_class,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(get),
-    /* K2   */  be_nested_str_weak(TYPE),
-    /* K3   */  be_nested_str_weak(plugins_classes),
+    /* K0   */  be_nested_str_weak(plugins_classes),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(ARG),
+    /* K3   */  be_nested_str_weak(),
     }),
-    be_str_weak(register_plugin_class),
+    be_str_weak(get_plugin_class_arg),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x58180002,  //  0003  LDCONST	R6	K2
-      0x7C0C0600,  //  0004  CALL	R3	3
-      0x780E0001,  //  0005  JMPF	R3	#0008
-      0x88100103,  //  0006  GETMBR	R4	R0	K3
-      0x98100601,  //  0007  SETIDX	R4	R3	R1
-      0x80000000,  //  0008  RET	0
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x880C0502,  //  0005  GETMBR	R3	R2	K2
+      0x70020000,  //  0006  JMP		#0008
+      0x580C0003,  //  0007  LDCONST	R3	K3
+      0x80040600,  //  0008  RET	1	R3
     })
   )
 );
@@ -3810,130 +1191,131 @@ be_local_closure(Matter_Device_register_plugin_class,   /* name */
 
 
 /********************************************************************
-** Solidified function: save_param
+** Solidified function: start_mdns_announce_hostnames
 ********************************************************************/
-be_local_closure(Matter_Device_save_param,   /* name */
+be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(update_remotes_info),
-    /* K2   */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
-    /* K3   */  be_nested_str_weak(root_discriminator),
-    /* K4   */  be_nested_str_weak(root_passcode),
-    /* K5   */  be_nested_str_weak(ipv4only),
-    /* K6   */  be_nested_str_weak(true),
-    /* K7   */  be_nested_str_weak(false),
-    /* K8   */  be_nested_str_weak(next_ep),
-    /* K9   */  be_nested_str_weak(plugins_persist),
-    /* K10  */  be_nested_str_weak(_X2C_X22config_X22_X3A),
-    /* K11  */  be_nested_str_weak(dump),
-    /* K12  */  be_nested_str_weak(plugins_config),
-    /* K13  */  be_nested_str_weak(plugins_config_remotes),
-    /* K14  */  be_const_int(0),
-    /* K15  */  be_nested_str_weak(_X2C_X22remotes_X22_X3A),
-    /* K16  */  be_nested_str_weak(_X7D),
-    /* K17  */  be_nested_str_weak(FILENAME),
-    /* K18  */  be_nested_str_weak(w),
-    /* K19  */  be_nested_str_weak(write),
-    /* K20  */  be_nested_str_weak(close),
-    /* K21  */  be_nested_str_weak(tasmota),
-    /* K22  */  be_nested_str_weak(log),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
-    /* K24  */  be_nested_str_weak(_X20and_X20configuration),
-    /* K25  */  be_nested_str_weak(),
-    /* K26  */  be_const_int(3),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K28  */  be_nested_str_weak(_X7C),
-    /* K29  */  be_const_int(2),
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_mdns_host),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[10]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x50080000,  //  0002  LDBOOL	R2	0	0
+          0x7C000400,  //  0003  CALL	R0	2
+          0xB8020200,  //  0004  GETNGBL	R0	K1
+          0x8C000102,  //  0005  GETMET	R0	R0	K2
+          0x58080003,  //  0006  LDCONST	R2	K3
+          0x580C0004,  //  0007  LDCONST	R3	K4
+          0x7C000600,  //  0008  CALL	R0	3
+          0x80000000,  //  0009  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Eth_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_mdns_host),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[10]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x50080200,  //  0002  LDBOOL	R2	1	0
+          0x7C000400,  //  0003  CALL	R0	2
+          0xB8020200,  //  0004  GETNGBL	R0	K1
+          0x8C000102,  //  0005  GETMET	R0	R0	K2
+          0x58080003,  //  0006  LDCONST	R2	K3
+          0x580C0004,  //  0007  LDCONST	R3	K4
+          0x7C000600,  //  0008  CALL	R0	3
+          0x80000000,  //  0009  RET	0
+        })
+      ),
     }),
-    be_str_weak(save_param),
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(wifi),
+    /* K2   */  be_nested_str_weak(up),
+    /* K3   */  be_nested_str_weak(_mdns_announce_hostname),
+    /* K4   */  be_nested_str_weak(add_rule),
+    /* K5   */  be_nested_str_weak(Wifi_X23Connected),
+    /* K6   */  be_nested_str_weak(matter_mdns_host),
+    /* K7   */  be_nested_str_weak(eth),
+    /* K8   */  be_nested_str_weak(Eth_X23Connected),
+    }),
+    be_str_weak(start_mdns_announce_hostnames),
     &be_const_str_solidified,
-    ( &(const binstruction[77]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080101,  //  0001  GETMET	R2	R0	K1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x60080018,  //  0003  GETGBL	R2	G24
-      0x580C0002,  //  0004  LDCONST	R3	K2
-      0x88100103,  //  0005  GETMBR	R4	R0	K3
-      0x88140104,  //  0006  GETMBR	R5	R0	K4
-      0x88180105,  //  0007  GETMBR	R6	R0	K5
-      0x781A0001,  //  0008  JMPF	R6	#000B
-      0x58180006,  //  0009  LDCONST	R6	K6
-      0x70020000,  //  000A  JMP		#000C
-      0x58180007,  //  000B  LDCONST	R6	K7
-      0x881C0108,  //  000C  GETMBR	R7	R0	K8
-      0x7C080A00,  //  000D  CALL	R2	5
-      0x880C0109,  //  000E  GETMBR	R3	R0	K9
-      0x780E000E,  //  000F  JMPF	R3	#001F
-      0x0008050A,  //  0010  ADD	R2	R2	K10
-      0x8C0C030B,  //  0011  GETMET	R3	R1	K11
-      0x8814010C,  //  0012  GETMBR	R5	R0	K12
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x00080403,  //  0014  ADD	R2	R2	R3
-      0x600C000C,  //  0015  GETGBL	R3	G12
-      0x8810010D,  //  0016  GETMBR	R4	R0	K13
-      0x7C0C0200,  //  0017  CALL	R3	1
-      0x240C070E,  //  0018  GT	R3	R3	K14
-      0x780E0004,  //  0019  JMPF	R3	#001F
-      0x0008050F,  //  001A  ADD	R2	R2	K15
-      0x8C0C030B,  //  001B  GETMET	R3	R1	K11
-      0x8814010D,  //  001C  GETMBR	R5	R0	K13
-      0x7C0C0400,  //  001D  CALL	R3	2
-      0x00080403,  //  001E  ADD	R2	R2	R3
-      0x00080510,  //  001F  ADD	R2	R2	K16
-      0xA8020018,  //  0020  EXBLK	0	#003A
-      0x600C0011,  //  0021  GETGBL	R3	G17
-      0x88100111,  //  0022  GETMBR	R4	R0	K17
-      0x58140012,  //  0023  LDCONST	R5	K18
-      0x7C0C0400,  //  0024  CALL	R3	2
-      0x8C100713,  //  0025  GETMET	R4	R3	K19
-      0x5C180400,  //  0026  MOVE	R6	R2
-      0x7C100400,  //  0027  CALL	R4	2
-      0x8C100714,  //  0028  GETMET	R4	R3	K20
-      0x7C100200,  //  0029  CALL	R4	1
-      0xB8122A00,  //  002A  GETNGBL	R4	K21
-      0x8C100916,  //  002B  GETMET	R4	R4	K22
-      0x60180018,  //  002C  GETGBL	R6	G24
-      0x581C0017,  //  002D  LDCONST	R7	K23
-      0x88200109,  //  002E  GETMBR	R8	R0	K9
-      0x78220001,  //  002F  JMPF	R8	#0032
-      0x58200018,  //  0030  LDCONST	R8	K24
-      0x70020000,  //  0031  JMP		#0033
-      0x58200019,  //  0032  LDCONST	R8	K25
-      0x7C180400,  //  0033  CALL	R6	2
-      0x581C001A,  //  0034  LDCONST	R7	K26
-      0x7C100600,  //  0035  CALL	R4	3
-      0xA8040001,  //  0036  EXBLK	1	1
-      0x80040400,  //  0037  RET	1	R2
-      0xA8040001,  //  0038  EXBLK	1	1
-      0x70020011,  //  0039  JMP		#004C
-      0xAC0C0002,  //  003A  CATCH	R3	0	2
-      0x7002000E,  //  003B  JMP		#004B
-      0xB8162A00,  //  003C  GETNGBL	R5	K21
-      0x8C140B16,  //  003D  GETMET	R5	R5	K22
-      0x601C0008,  //  003E  GETGBL	R7	G8
-      0x5C200600,  //  003F  MOVE	R8	R3
-      0x7C1C0200,  //  0040  CALL	R7	1
-      0x001E3607,  //  0041  ADD	R7	K27	R7
-      0x001C0F1C,  //  0042  ADD	R7	R7	K28
-      0x60200008,  //  0043  GETGBL	R8	G8
-      0x5C240800,  //  0044  MOVE	R9	R4
-      0x7C200200,  //  0045  CALL	R8	1
-      0x001C0E08,  //  0046  ADD	R7	R7	R8
-      0x5820001D,  //  0047  LDCONST	R8	K29
-      0x7C140600,  //  0048  CALL	R5	3
-      0x80040400,  //  0049  RET	1	R2
-      0x70020000,  //  004A  JMP		#004C
-      0xB0080000,  //  004B  RAISE	2	R0	R0
-      0x80000000,  //  004C  RET	0
+    ( &(const binstruction[32]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x94040302,  //  0003  GETIDX	R1	R1	K2
+      0x78060003,  //  0004  JMPF	R1	#0009
+      0x8C040103,  //  0005  GETMET	R1	R0	K3
+      0x500C0000,  //  0006  LDBOOL	R3	0	0
+      0x7C040400,  //  0007  CALL	R1	2
+      0x70020005,  //  0008  JMP		#000F
+      0xB8060000,  //  0009  GETNGBL	R1	K0
+      0x8C040304,  //  000A  GETMET	R1	R1	K4
+      0x580C0005,  //  000B  LDCONST	R3	K5
+      0x84100000,  //  000C  CLOSURE	R4	P0
+      0x58140006,  //  000D  LDCONST	R5	K6
+      0x7C040800,  //  000E  CALL	R1	4
+      0xB8060000,  //  000F  GETNGBL	R1	K0
+      0x8C040307,  //  0010  GETMET	R1	R1	K7
+      0x7C040200,  //  0011  CALL	R1	1
+      0x94040302,  //  0012  GETIDX	R1	R1	K2
+      0x78060003,  //  0013  JMPF	R1	#0018
+      0x8C040103,  //  0014  GETMET	R1	R0	K3
+      0x500C0200,  //  0015  LDBOOL	R3	1	0
+      0x7C040400,  //  0016  CALL	R1	2
+      0x70020005,  //  0017  JMP		#001E
+      0xB8060000,  //  0018  GETNGBL	R1	K0
+      0x8C040304,  //  0019  GETMET	R1	R1	K4
+      0x580C0008,  //  001A  LDCONST	R3	K8
+      0x84100001,  //  001B  CLOSURE	R4	P1
+      0x58140006,  //  001C  LDCONST	R5	K6
+      0x7C040800,  //  001D  CALL	R1	4
+      0xA0000000,  //  001E  CLOSE	R0
+      0x80000000,  //  001F  RET	0
     })
   )
 );
@@ -3941,9 +1323,9 @@ be_local_closure(Matter_Device_save_param,   /* name */
 
 
 /********************************************************************
-** Solidified function: _mdns_announce_hostname
+** Solidified function: mdns_announce_op_discovery
 ********************************************************************/
-be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
+be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
   be_nested_proto(
     14,                          /* nstack */
     2,                          /* argc */
@@ -3953,177 +1335,231 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
+    ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(start),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(eth),
-    /* K5   */  be_nested_str_weak(hostname_eth),
-    /* K6   */  be_nested_str_weak(replace),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_nested_str_weak(mac),
-    /* K9   */  be_nested_str_weak(_X3A),
-    /* K10  */  be_nested_str_weak(),
-    /* K11  */  be_nested_str_weak(ipv4only),
-    /* K12  */  be_nested_str_weak(add_hostname),
-    /* K13  */  be_nested_str_weak(ip6local),
-    /* K14  */  be_nested_str_weak(ip),
-    /* K15  */  be_nested_str_weak(ip6),
-    /* K16  */  be_nested_str_weak(log),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eadd_hostname_X28_X25s_X2C_X20_X25s_X29),
-    /* K18  */  be_const_int(3),
-    /* K19  */  be_nested_str_weak(wifi),
-    /* K20  */  be_nested_str_weak(hostname_wifi),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20start_X20mDNS_X20on_X20_X25s_X20host_X20_X27_X25s_X2Elocal_X27),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K23  */  be_nested_str_weak(_X7C),
-    /* K24  */  be_const_int(2),
-    /* K25  */  be_nested_str_weak(mdns_announce_op_discovery_all_fabrics),
+    /* K1   */  be_nested_str_weak(get_device_id),
+    /* K2   */  be_nested_str_weak(copy),
+    /* K3   */  be_nested_str_weak(reverse),
+    /* K4   */  be_nested_str_weak(get_fabric_compressed),
+    /* K5   */  be_nested_str_weak(tohex),
+    /* K6   */  be_nested_str_weak(_X2D),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(eth),
+    /* K12  */  be_nested_str_weak(find),
+    /* K13  */  be_nested_str_weak(up),
+    /* K14  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K15  */  be_nested_str_weak(hostname_eth),
+    /* K16  */  be_nested_str_weak(add_service),
+    /* K17  */  be_nested_str_weak(_matter),
+    /* K18  */  be_nested_str_weak(_tcp),
+    /* K19  */  be_nested_str_weak(_I),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
+    /* K21  */  be_nested_str_weak(add_subtype),
+    /* K22  */  be_nested_str_weak(wifi),
+    /* K23  */  be_nested_str_weak(hostname_wifi),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K25  */  be_nested_str_weak(_X7C),
+    /* K26  */  be_const_int(2),
     }),
-    be_str_weak(_mdns_announce_hostname),
+    be_str_weak(mdns_announce_op_discovery),
     &be_const_str_solidified,
-    ( &(const binstruction[140]) {  /* code */
+    ( &(const binstruction[121]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0x8C100502,  //  0002  GETMET	R4	R2	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0xA8020072,  //  0004  EXBLK	0	#0078
-      0x78060030,  //  0005  JMPF	R1	#0037
-      0xB8120600,  //  0006  GETNGBL	R4	K3
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C140706,  //  0009  GETMET	R5	R3	K6
-      0x8C1C0907,  //  000A  GETMET	R7	R4	K7
-      0x58240008,  //  000B  LDCONST	R9	K8
-      0x7C1C0400,  //  000C  CALL	R7	2
-      0x58200009,  //  000D  LDCONST	R8	K9
-      0x5824000A,  //  000E  LDCONST	R9	K10
-      0x7C140800,  //  000F  CALL	R5	4
-      0x90020A05,  //  0010  SETMBR	R0	K5	R5
-      0x8814010B,  //  0011  GETMBR	R5	R0	K11
-      0x7416000F,  //  0012  JMPT	R5	#0023
-      0x8C14050C,  //  0013  GETMET	R5	R2	K12
-      0x881C0105,  //  0014  GETMBR	R7	R0	K5
-      0x8C200907,  //  0015  GETMET	R8	R4	K7
-      0x5828000D,  //  0016  LDCONST	R10	K13
-      0x582C000A,  //  0017  LDCONST	R11	K10
-      0x7C200600,  //  0018  CALL	R8	3
-      0x8C240907,  //  0019  GETMET	R9	R4	K7
-      0x582C000E,  //  001A  LDCONST	R11	K14
-      0x5830000A,  //  001B  LDCONST	R12	K10
-      0x7C240600,  //  001C  CALL	R9	3
-      0x8C280907,  //  001D  GETMET	R10	R4	K7
-      0x5830000F,  //  001E  LDCONST	R12	K15
-      0x5834000A,  //  001F  LDCONST	R13	K10
-      0x7C280600,  //  0020  CALL	R10	3
-      0x7C140A00,  //  0021  CALL	R5	5
-      0x70020012,  //  0022  JMP		#0036
-      0xB8160600,  //  0023  GETNGBL	R5	K3
-      0x8C140B10,  //  0024  GETMET	R5	R5	K16
-      0x601C0018,  //  0025  GETGBL	R7	G24
-      0x58200011,  //  0026  LDCONST	R8	K17
-      0x88240105,  //  0027  GETMBR	R9	R0	K5
-      0x8C280907,  //  0028  GETMET	R10	R4	K7
-      0x5830000E,  //  0029  LDCONST	R12	K14
-      0x5834000A,  //  002A  LDCONST	R13	K10
-      0x7C280600,  //  002B  CALL	R10	3
-      0x7C1C0600,  //  002C  CALL	R7	3
-      0x58200012,  //  002D  LDCONST	R8	K18
-      0x7C140600,  //  002E  CALL	R5	3
-      0x8C14050C,  //  002F  GETMET	R5	R2	K12
-      0x881C0105,  //  0030  GETMBR	R7	R0	K5
-      0x8C200907,  //  0031  GETMET	R8	R4	K7
-      0x5828000E,  //  0032  LDCONST	R10	K14
-      0x582C000A,  //  0033  LDCONST	R11	K10
-      0x7C200600,  //  0034  CALL	R8	3
-      0x7C140600,  //  0035  CALL	R5	3
-      0x7002002F,  //  0036  JMP		#0067
-      0xB8120600,  //  0037  GETNGBL	R4	K3
-      0x8C100913,  //  0038  GETMET	R4	R4	K19
-      0x7C100200,  //  0039  CALL	R4	1
-      0x8C140706,  //  003A  GETMET	R5	R3	K6
-      0x8C1C0907,  //  003B  GETMET	R7	R4	K7
-      0x58240008,  //  003C  LDCONST	R9	K8
-      0x7C1C0400,  //  003D  CALL	R7	2
-      0x58200009,  //  003E  LDCONST	R8	K9
-      0x5824000A,  //  003F  LDCONST	R9	K10
-      0x7C140800,  //  0040  CALL	R5	4
-      0x90022805,  //  0041  SETMBR	R0	K20	R5
-      0x8814010B,  //  0042  GETMBR	R5	R0	K11
-      0x7416000F,  //  0043  JMPT	R5	#0054
-      0x8C14050C,  //  0044  GETMET	R5	R2	K12
-      0x881C0114,  //  0045  GETMBR	R7	R0	K20
-      0x8C200907,  //  0046  GETMET	R8	R4	K7
-      0x5828000D,  //  0047  LDCONST	R10	K13
-      0x582C000A,  //  0048  LDCONST	R11	K10
-      0x7C200600,  //  0049  CALL	R8	3
-      0x8C240907,  //  004A  GETMET	R9	R4	K7
-      0x582C000E,  //  004B  LDCONST	R11	K14
-      0x5830000A,  //  004C  LDCONST	R12	K10
-      0x7C240600,  //  004D  CALL	R9	3
-      0x8C280907,  //  004E  GETMET	R10	R4	K7
-      0x5830000F,  //  004F  LDCONST	R12	K15
-      0x5834000A,  //  0050  LDCONST	R13	K10
-      0x7C280600,  //  0051  CALL	R10	3
-      0x7C140A00,  //  0052  CALL	R5	5
-      0x70020012,  //  0053  JMP		#0067
-      0xB8160600,  //  0054  GETNGBL	R5	K3
-      0x8C140B10,  //  0055  GETMET	R5	R5	K16
-      0x601C0018,  //  0056  GETGBL	R7	G24
-      0x58200011,  //  0057  LDCONST	R8	K17
-      0x88240105,  //  0058  GETMBR	R9	R0	K5
-      0x8C280907,  //  0059  GETMET	R10	R4	K7
-      0x5830000E,  //  005A  LDCONST	R12	K14
-      0x5834000A,  //  005B  LDCONST	R13	K10
-      0x7C280600,  //  005C  CALL	R10	3
+      0xA8020064,  //  0001  EXBLK	0	#0067
+      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x8C100304,  //  0008  GETMET	R4	R1	K4
+      0x7C100200,  //  0009  CALL	R4	1
+      0x8C140905,  //  000A  GETMET	R5	R4	K5
+      0x7C140200,  //  000B  CALL	R5	1
+      0x00140B06,  //  000C  ADD	R5	R5	K6
+      0x8C180705,  //  000D  GETMET	R6	R3	K5
+      0x7C180200,  //  000E  CALL	R6	1
+      0x00140A06,  //  000F  ADD	R5	R5	R6
+      0xB81A0E00,  //  0010  GETNGBL	R6	K7
+      0x8C180D08,  //  0011  GETMET	R6	R6	K8
+      0x00221205,  //  0012  ADD	R8	K9	R5
+      0x5824000A,  //  0013  LDCONST	R9	K10
+      0x7C180600,  //  0014  CALL	R6	3
+      0xB81A0E00,  //  0015  GETNGBL	R6	K7
+      0x8C180D0B,  //  0016  GETMET	R6	R6	K11
+      0x7C180200,  //  0017  CALL	R6	1
+      0x8C180D0C,  //  0018  GETMET	R6	R6	K12
+      0x5820000D,  //  0019  LDCONST	R8	K13
+      0x7C180400,  //  001A  CALL	R6	2
+      0x781A0020,  //  001B  JMPF	R6	#003D
+      0xB81A0E00,  //  001C  GETNGBL	R6	K7
+      0x8C180D08,  //  001D  GETMET	R6	R6	K8
+      0x60200018,  //  001E  GETGBL	R8	G24
+      0x5824000E,  //  001F  LDCONST	R9	K14
+      0x5828000B,  //  0020  LDCONST	R10	K11
+      0x5C2C0A00,  //  0021  MOVE	R11	R5
+      0x8830010F,  //  0022  GETMBR	R12	R0	K15
+      0x7C200800,  //  0023  CALL	R8	4
+      0x5824000A,  //  0024  LDCONST	R9	K10
+      0x7C180600,  //  0025  CALL	R6	3
+      0x8C180510,  //  0026  GETMET	R6	R2	K16
+      0x58200011,  //  0027  LDCONST	R8	K17
+      0x58240012,  //  0028  LDCONST	R9	K18
+      0x542A15A3,  //  0029  LDINT	R10	5540
+      0x4C2C0000,  //  002A  LDNIL	R11
+      0x5C300A00,  //  002B  MOVE	R12	R5
+      0x8834010F,  //  002C  GETMBR	R13	R0	K15
+      0x7C180E00,  //  002D  CALL	R6	7
+      0x8C180905,  //  002E  GETMET	R6	R4	K5
+      0x7C180200,  //  002F  CALL	R6	1
+      0x001A2606,  //  0030  ADD	R6	K19	R6
+      0xB81E0E00,  //  0031  GETNGBL	R7	K7
+      0x8C1C0F08,  //  0032  GETMET	R7	R7	K8
+      0x00262806,  //  0033  ADD	R9	K20	R6
+      0x5828000A,  //  0034  LDCONST	R10	K10
+      0x7C1C0600,  //  0035  CALL	R7	3
+      0x8C1C0515,  //  0036  GETMET	R7	R2	K21
+      0x58240011,  //  0037  LDCONST	R9	K17
+      0x58280012,  //  0038  LDCONST	R10	K18
+      0x5C2C0A00,  //  0039  MOVE	R11	R5
+      0x8830010F,  //  003A  GETMBR	R12	R0	K15
+      0x5C340C00,  //  003B  MOVE	R13	R6
+      0x7C1C0C00,  //  003C  CALL	R7	6
+      0xB81A0E00,  //  003D  GETNGBL	R6	K7
+      0x8C180D16,  //  003E  GETMET	R6	R6	K22
+      0x7C180200,  //  003F  CALL	R6	1
+      0x8C180D0C,  //  0040  GETMET	R6	R6	K12
+      0x5820000D,  //  0041  LDCONST	R8	K13
+      0x7C180400,  //  0042  CALL	R6	2
+      0x781A0020,  //  0043  JMPF	R6	#0065
+      0xB81A0E00,  //  0044  GETNGBL	R6	K7
+      0x8C180D08,  //  0045  GETMET	R6	R6	K8
+      0x60200018,  //  0046  GETGBL	R8	G24
+      0x5824000E,  //  0047  LDCONST	R9	K14
+      0x58280016,  //  0048  LDCONST	R10	K22
+      0x5C2C0A00,  //  0049  MOVE	R11	R5
+      0x88300117,  //  004A  GETMBR	R12	R0	K23
+      0x7C200800,  //  004B  CALL	R8	4
+      0x5824000A,  //  004C  LDCONST	R9	K10
+      0x7C180600,  //  004D  CALL	R6	3
+      0x8C180510,  //  004E  GETMET	R6	R2	K16
+      0x58200011,  //  004F  LDCONST	R8	K17
+      0x58240012,  //  0050  LDCONST	R9	K18
+      0x542A15A3,  //  0051  LDINT	R10	5540
+      0x4C2C0000,  //  0052  LDNIL	R11
+      0x5C300A00,  //  0053  MOVE	R12	R5
+      0x88340117,  //  0054  GETMBR	R13	R0	K23
+      0x7C180E00,  //  0055  CALL	R6	7
+      0x8C180905,  //  0056  GETMET	R6	R4	K5
+      0x7C180200,  //  0057  CALL	R6	1
+      0x001A2606,  //  0058  ADD	R6	K19	R6
+      0xB81E0E00,  //  0059  GETNGBL	R7	K7
+      0x8C1C0F08,  //  005A  GETMET	R7	R7	K8
+      0x00262806,  //  005B  ADD	R9	K20	R6
+      0x5828000A,  //  005C  LDCONST	R10	K10
       0x7C1C0600,  //  005D  CALL	R7	3
-      0x58200012,  //  005E  LDCONST	R8	K18
-      0x7C140600,  //  005F  CALL	R5	3
-      0x8C14050C,  //  0060  GETMET	R5	R2	K12
-      0x881C0114,  //  0061  GETMBR	R7	R0	K20
-      0x8C200907,  //  0062  GETMET	R8	R4	K7
-      0x5828000E,  //  0063  LDCONST	R10	K14
-      0x582C000A,  //  0064  LDCONST	R11	K10
-      0x7C200600,  //  0065  CALL	R8	3
-      0x7C140600,  //  0066  CALL	R5	3
-      0xB8120600,  //  0067  GETNGBL	R4	K3
-      0x8C100910,  //  0068  GETMET	R4	R4	K16
-      0x60180018,  //  0069  GETGBL	R6	G24
-      0x581C0015,  //  006A  LDCONST	R7	K21
-      0x78060001,  //  006B  JMPF	R1	#006E
-      0x58200004,  //  006C  LDCONST	R8	K4
-      0x70020000,  //  006D  JMP		#006F
-      0x58200013,  //  006E  LDCONST	R8	K19
-      0x78060001,  //  006F  JMPF	R1	#0072
-      0x88240105,  //  0070  GETMBR	R9	R0	K5
-      0x70020000,  //  0071  JMP		#0073
-      0x88240114,  //  0072  GETMBR	R9	R0	K20
-      0x7C180600,  //  0073  CALL	R6	3
-      0x581C0012,  //  0074  LDCONST	R7	K18
-      0x7C100600,  //  0075  CALL	R4	3
-      0xA8040001,  //  0076  EXBLK	1	1
-      0x70020010,  //  0077  JMP		#0089
-      0xAC100002,  //  0078  CATCH	R4	0	2
-      0x7002000D,  //  0079  JMP		#0088
-      0xB81A0600,  //  007A  GETNGBL	R6	K3
-      0x8C180D10,  //  007B  GETMET	R6	R6	K16
-      0x60200008,  //  007C  GETGBL	R8	G8
-      0x5C240800,  //  007D  MOVE	R9	R4
-      0x7C200200,  //  007E  CALL	R8	1
-      0x00222C08,  //  007F  ADD	R8	K22	R8
-      0x00201117,  //  0080  ADD	R8	R8	K23
-      0x60240008,  //  0081  GETGBL	R9	G8
-      0x5C280A00,  //  0082  MOVE	R10	R5
-      0x7C240200,  //  0083  CALL	R9	1
-      0x00201009,  //  0084  ADD	R8	R8	R9
-      0x58240018,  //  0085  LDCONST	R9	K24
-      0x7C180600,  //  0086  CALL	R6	3
-      0x70020000,  //  0087  JMP		#0089
-      0xB0080000,  //  0088  RAISE	2	R0	R0
-      0x8C100119,  //  0089  GETMET	R4	R0	K25
-      0x7C100200,  //  008A  CALL	R4	1
-      0x80000000,  //  008B  RET	0
+      0x8C1C0515,  //  005E  GETMET	R7	R2	K21
+      0x58240011,  //  005F  LDCONST	R9	K17
+      0x58280012,  //  0060  LDCONST	R10	K18
+      0x5C2C0A00,  //  0061  MOVE	R11	R5
+      0x88300117,  //  0062  GETMBR	R12	R0	K23
+      0x5C340C00,  //  0063  MOVE	R13	R6
+      0x7C1C0C00,  //  0064  CALL	R7	6
+      0xA8040001,  //  0065  EXBLK	1	1
+      0x70020010,  //  0066  JMP		#0078
+      0xAC0C0002,  //  0067  CATCH	R3	0	2
+      0x7002000D,  //  0068  JMP		#0077
+      0xB8160E00,  //  0069  GETNGBL	R5	K7
+      0x8C140B08,  //  006A  GETMET	R5	R5	K8
+      0x601C0008,  //  006B  GETGBL	R7	G8
+      0x5C200600,  //  006C  MOVE	R8	R3
+      0x7C1C0200,  //  006D  CALL	R7	1
+      0x001E3007,  //  006E  ADD	R7	K24	R7
+      0x001C0F19,  //  006F  ADD	R7	R7	K25
+      0x60200008,  //  0070  GETGBL	R8	G8
+      0x5C240800,  //  0071  MOVE	R9	R4
+      0x7C200200,  //  0072  CALL	R8	1
+      0x001C0E08,  //  0073  ADD	R7	R7	R8
+      0x5820001A,  //  0074  LDCONST	R8	K26
+      0x7C140600,  //  0075  CALL	R5	3
+      0x70020000,  //  0076  JMP		#0078
+      0xB0080000,  //  0077  RAISE	2	R0	R0
+      0x80000000,  //  0078  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _trigger_read_sensors
+********************************************************************/
+be_local_closure(Matter_Device__trigger_read_sensors,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(read_sensors),
+    /* K3   */  be_nested_str_weak(load),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(plugins),
+    /* K6   */  be_nested_str_weak(parse_sensors),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
+    /* K10  */  be_const_int(3),
+    }),
+    be_str_weak(_trigger_read_sensors),
+    &be_const_str_solidified,
+    ( &(const binstruction[37]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x7C080200,  //  0003  CALL	R2	1
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x1C0C0403,  //  0005  EQ	R3	R2	R3
+      0x780E0000,  //  0006  JMPF	R3	#0008
+      0x80000600,  //  0007  RET	0
+      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
+      0x5C140400,  //  0009  MOVE	R5	R2
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x4C100000,  //  000B  LDNIL	R4
+      0x20100604,  //  000C  NE	R4	R3	R4
+      0x7812000D,  //  000D  JMPF	R4	#001C
+      0x58100004,  //  000E  LDCONST	R4	K4
+      0x6014000C,  //  000F  GETGBL	R5	G12
+      0x88180105,  //  0010  GETMBR	R6	R0	K5
+      0x7C140200,  //  0011  CALL	R5	1
+      0x14140805,  //  0012  LT	R5	R4	R5
+      0x78160006,  //  0013  JMPF	R5	#001B
+      0x88140105,  //  0014  GETMBR	R5	R0	K5
+      0x94140A04,  //  0015  GETIDX	R5	R5	R4
+      0x8C140B06,  //  0016  GETMET	R5	R5	K6
+      0x5C1C0600,  //  0017  MOVE	R7	R3
+      0x7C140400,  //  0018  CALL	R5	2
+      0x00100907,  //  0019  ADD	R4	R4	K7
+      0x7001FFF3,  //  001A  JMP		#000F
+      0x70020007,  //  001B  JMP		#0024
+      0xB8120200,  //  001C  GETNGBL	R4	K1
+      0x8C100908,  //  001D  GETMET	R4	R4	K8
+      0x60180008,  //  001E  GETGBL	R6	G8
+      0x5C1C0400,  //  001F  MOVE	R7	R2
+      0x7C180200,  //  0020  CALL	R6	1
+      0x001A1206,  //  0021  ADD	R6	K9	R6
+      0x581C000A,  //  0022  LDCONST	R7	K10
+      0x7C100600,  //  0023  CALL	R4	3
+      0x80000000,  //  0024  RET	0
     })
   )
 );
@@ -4443,6 +1879,1610 @@ be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
 
 
 /********************************************************************
+** Solidified function: k2l_num
+********************************************************************/
+be_local_closure(Matter_Device_k2l_num,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Device),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(push),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_const_int(0),
+    }),
+    be_str_weak(k2l_num),
+    &be_const_str_solidified,
+    ( &(const binstruction[52]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0003,  //  0004  EQ	R3	R0	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80040400,  //  0006  RET	1	R2
+      0x600C0010,  //  0007  GETGBL	R3	G16
+      0x8C100101,  //  0008  GETMET	R4	R0	K1
+      0x7C100200,  //  0009  CALL	R4	1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0xA8020007,  //  000B  EXBLK	0	#0014
+      0x5C100600,  //  000C  MOVE	R4	R3
+      0x7C100000,  //  000D  CALL	R4	0
+      0x8C140502,  //  000E  GETMET	R5	R2	K2
+      0x601C0009,  //  000F  GETGBL	R7	G9
+      0x5C200800,  //  0010  MOVE	R8	R4
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x7C140400,  //  0012  CALL	R5	2
+      0x7001FFF7,  //  0013  JMP		#000C
+      0x580C0003,  //  0014  LDCONST	R3	K3
+      0xAC0C0200,  //  0015  CATCH	R3	1	0
+      0xB0080000,  //  0016  RAISE	2	R0	R0
+      0x600C0010,  //  0017  GETGBL	R3	G16
+      0x6010000C,  //  0018  GETGBL	R4	G12
+      0x5C140400,  //  0019  MOVE	R5	R2
+      0x7C100200,  //  001A  CALL	R4	1
+      0x04100904,  //  001B  SUB	R4	R4	K4
+      0x40120804,  //  001C  CONNECT	R4	K4	R4
+      0x7C0C0200,  //  001D  CALL	R3	1
+      0xA8020010,  //  001E  EXBLK	0	#0030
+      0x5C100600,  //  001F  MOVE	R4	R3
+      0x7C100000,  //  0020  CALL	R4	0
+      0x94140404,  //  0021  GETIDX	R5	R2	R4
+      0x5C180800,  //  0022  MOVE	R6	R4
+      0x241C0D05,  //  0023  GT	R7	R6	K5
+      0x781E0008,  //  0024  JMPF	R7	#002E
+      0x041C0D04,  //  0025  SUB	R7	R6	K4
+      0x941C0407,  //  0026  GETIDX	R7	R2	R7
+      0x241C0E05,  //  0027  GT	R7	R7	R5
+      0x781E0004,  //  0028  JMPF	R7	#002E
+      0x041C0D04,  //  0029  SUB	R7	R6	K4
+      0x941C0407,  //  002A  GETIDX	R7	R2	R7
+      0x98080C07,  //  002B  SETIDX	R2	R6	R7
+      0x04180D04,  //  002C  SUB	R6	R6	K4
+      0x7001FFF4,  //  002D  JMP		#0023
+      0x98080C05,  //  002E  SETIDX	R2	R6	R5
+      0x7001FFEE,  //  002F  JMP		#001F
+      0x580C0003,  //  0030  LDCONST	R3	K3
+      0xAC0C0200,  //  0031  CATCH	R3	1	0
+      0xB0080000,  //  0032  RAISE	2	R0	R0
+      0x80040400,  //  0033  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: signal_endpoints_changed
+********************************************************************/
+be_local_closure(Matter_Device_signal_endpoints_changed,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(attribute_updated),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_const_int(3),
+    }),
+    be_str_weak(signal_endpoints_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x580C0001,  //  0001  LDCONST	R3	K1
+      0x5412001C,  //  0002  LDINT	R4	29
+      0x58140002,  //  0003  LDCONST	R5	K2
+      0x50180000,  //  0004  LDBOOL	R6	0	0
+      0x7C040A00,  //  0005  CALL	R1	5
+      0x8C040100,  //  0006  GETMET	R1	R0	K0
+      0x540EFEFF,  //  0007  LDINT	R3	65280
+      0x5412001C,  //  0008  LDINT	R4	29
+      0x58140002,  //  0009  LDCONST	R5	K2
+      0x50180000,  //  000A  LDBOOL	R6	0	0
+      0x7C040A00,  //  000B  CALL	R1	5
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_remotes_info
+********************************************************************/
+be_local_closure(Matter_Device_update_remotes_info,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(http_remotes),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(get_info),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(stop_iteration),
+    /* K5   */  be_nested_str_weak(plugins_config_remotes),
+    }),
+    be_str_weak(update_remotes_info),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x60040013,  //  0000  GETGBL	R1	G19
+      0x7C040000,  //  0001  CALL	R1	0
+      0x88080100,  //  0002  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x20080403,  //  0004  NE	R2	R2	R3
+      0x780A0018,  //  0005  JMPF	R2	#001F
+      0x60080010,  //  0006  GETGBL	R2	G16
+      0x880C0100,  //  0007  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0008  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x7C080200,  //  000A  CALL	R2	1
+      0xA802000F,  //  000B  EXBLK	0	#001C
+      0x5C0C0400,  //  000C  MOVE	R3	R2
+      0x7C0C0000,  //  000D  CALL	R3	0
+      0x88100100,  //  000E  GETMBR	R4	R0	K0
+      0x94100803,  //  000F  GETIDX	R4	R4	R3
+      0x8C100902,  //  0010  GETMET	R4	R4	K2
+      0x7C100200,  //  0011  CALL	R4	1
+      0x4C140000,  //  0012  LDNIL	R5
+      0x20140805,  //  0013  NE	R5	R4	R5
+      0x78160005,  //  0014  JMPF	R5	#001B
+      0x6014000C,  //  0015  GETGBL	R5	G12
+      0x5C180800,  //  0016  MOVE	R6	R4
+      0x7C140200,  //  0017  CALL	R5	1
+      0x24140B03,  //  0018  GT	R5	R5	K3
+      0x78160000,  //  0019  JMPF	R5	#001B
+      0x98040604,  //  001A  SETIDX	R1	R3	R4
+      0x7001FFEF,  //  001B  JMP		#000C
+      0x58080004,  //  001C  LDCONST	R2	K4
+      0xAC080200,  //  001D  CATCH	R2	1	0
+      0xB0080000,  //  001E  RAISE	2	R0	R0
+      0x90020A01,  //  001F  SETMBR	R0	K5	R1
+      0x80040200,  //  0020  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: compute_manual_pairing_code
+********************************************************************/
+be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(root_discriminator),
+    /* K1   */  be_nested_str_weak(root_passcode),
+    /* K2   */  be_nested_str_weak(_X251i_X2505i_X2504i),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(Verhoeff),
+    /* K5   */  be_nested_str_weak(checksum),
+    }),
+    be_str_weak(compute_manual_pairing_code),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x540A0FFE,  //  0001  LDINT	R2	4095
+      0x2C040202,  //  0002  AND	R1	R1	R2
+      0x540A0009,  //  0003  LDINT	R2	10
+      0x3C040202,  //  0004  SHR	R1	R1	R2
+      0x88080100,  //  0005  GETMBR	R2	R0	K0
+      0x540E02FF,  //  0006  LDINT	R3	768
+      0x2C080403,  //  0007  AND	R2	R2	R3
+      0x540E0005,  //  0008  LDINT	R3	6
+      0x38080403,  //  0009  SHL	R2	R2	R3
+      0x880C0101,  //  000A  GETMBR	R3	R0	K1
+      0x54123FFE,  //  000B  LDINT	R4	16383
+      0x2C0C0604,  //  000C  AND	R3	R3	R4
+      0x30080403,  //  000D  OR	R2	R2	R3
+      0x880C0101,  //  000E  GETMBR	R3	R0	K1
+      0x5412000D,  //  000F  LDINT	R4	14
+      0x3C0C0604,  //  0010  SHR	R3	R3	R4
+      0x60100018,  //  0011  GETGBL	R4	G24
+      0x58140002,  //  0012  LDCONST	R5	K2
+      0x5C180200,  //  0013  MOVE	R6	R1
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x5C200600,  //  0015  MOVE	R8	R3
+      0x7C100800,  //  0016  CALL	R4	4
+      0xB8160600,  //  0017  GETNGBL	R5	K3
+      0x88140B04,  //  0018  GETMBR	R5	R5	K4
+      0x8C140B05,  //  0019  GETMET	R5	R5	K5
+      0x5C1C0800,  //  001A  MOVE	R7	R4
+      0x7C140400,  //  001B  CALL	R5	2
+      0x00100805,  //  001C  ADD	R4	R4	R5
+      0x80040800,  //  001D  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_plugin_remote_info
+********************************************************************/
+be_local_closure(Matter_Device_get_plugin_remote_info,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_config_remotes),
+    /* K1   */  be_nested_str_weak(find),
+    }),
+    be_str_weak(get_plugin_remote_info),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x60140013,  //  0003  GETGBL	R5	G19
+      0x7C140000,  //  0004  CALL	R5	0
+      0x7C080600,  //  0005  CALL	R2	3
+      0x80040400,  //  0006  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_announce_op_discovery_all_fabrics
+********************************************************************/
+be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(active_fabrics),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(mdns_announce_op_discovery),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(mdns_announce_op_discovery_all_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000B,  //  0005  EXBLK	0	#0012
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x780E0005,  //  000A  JMPF	R3	#0011
+      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x780E0002,  //  000D  JMPF	R3	#0011
+      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x7001FFF3,  //  0011  JMP		#0006
+      0x58040005,  //  0012  LDCONST	R1	K5
+      0xAC040200,  //  0013  CATCH	R1	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: MtrJoin
+********************************************************************/
+be_local_closure(Matter_Device_MtrJoin,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K1   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(resp_cmnd_done),
+    }),
+    be_str_weak(MtrJoin),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x60140009,  //  0000  GETGBL	R5	G9
+      0x5C180600,  //  0001  MOVE	R6	R3
+      0x7C140200,  //  0002  CALL	R5	1
+      0x78160002,  //  0003  JMPF	R5	#0007
+      0x8C180100,  //  0004  GETMET	R6	R0	K0
+      0x7C180200,  //  0005  CALL	R6	1
+      0x70020001,  //  0006  JMP		#0009
+      0x8C180101,  //  0007  GETMET	R6	R0	K1
+      0x7C180200,  //  0008  CALL	R6	1
+      0xB81A0400,  //  0009  GETNGBL	R6	K2
+      0x8C180D03,  //  000A  GETMET	R6	R6	K3
+      0x7C180200,  //  000B  CALL	R6	1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(Matter_Device_start,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_trigger_read_sensors),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80000000,  //  0003  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(started),
+    /* K1   */  be_nested_str_weak(autoconf_device),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(add_cron),
+    /* K4   */  be_nested_str_weak(_X2A_X2F30_X20_X2A_X20_X2A_X20_X2A_X20_X2A_X20_X2A),
+    /* K5   */  be_nested_str_weak(matter_sensors_30s),
+    /* K6   */  be_nested_str_weak(_start_udp),
+    /* K7   */  be_nested_str_weak(UDP_PORT),
+    /* K8   */  be_nested_str_weak(start_mdns_announce_hostnames),
+    }),
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060000,  //  0001  JMPF	R1	#0003
+      0x80000200,  //  0002  RET	0
+      0x8C040101,  //  0003  GETMET	R1	R0	K1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xB8060400,  //  0005  GETNGBL	R1	K2
+      0x8C040303,  //  0006  GETMET	R1	R1	K3
+      0x580C0004,  //  0007  LDCONST	R3	K4
+      0x84100000,  //  0008  CLOSURE	R4	P0
+      0x58140005,  //  0009  LDCONST	R5	K5
+      0x7C040800,  //  000A  CALL	R1	4
+      0x8C040106,  //  000B  GETMET	R1	R0	K6
+      0x880C0107,  //  000C  GETMBR	R3	R0	K7
+      0x7C040400,  //  000D  CALL	R1	2
+      0x8C040108,  //  000E  GETMET	R1	R0	K8
+      0x7C040200,  //  000F  CALL	R1	1
+      0x50040200,  //  0010  LDBOOL	R1	1	0
+      0x90020001,  //  0011  SETMBR	R0	K0	R1
+      0xA0000000,  //  0012  CLOSE	R0
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: load_param
+********************************************************************/
+be_local_closure(Matter_Device_load_param,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[35]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(FILENAME),
+    /* K2   */  be_nested_str_weak(read),
+    /* K3   */  be_nested_str_weak(close),
+    /* K4   */  be_nested_str_weak(json),
+    /* K5   */  be_nested_str_weak(load),
+    /* K6   */  be_nested_str_weak(root_discriminator),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_nested_str_weak(distinguish),
+    /* K9   */  be_nested_str_weak(root_passcode),
+    /* K10  */  be_nested_str_weak(passcode),
+    /* K11  */  be_nested_str_weak(ipv4only),
+    /* K12  */  be_nested_str_weak(disable_bridge_mode),
+    /* K13  */  be_nested_str_weak(next_ep),
+    /* K14  */  be_nested_str_weak(nextep),
+    /* K15  */  be_nested_str_weak(plugins_config),
+    /* K16  */  be_nested_str_weak(config),
+    /* K17  */  be_nested_str_weak(tasmota),
+    /* K18  */  be_nested_str_weak(log),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20load_config_X20_X3D_X20),
+    /* K20  */  be_const_int(3),
+    /* K21  */  be_nested_str_weak(adjust_next_ep),
+    /* K22  */  be_nested_str_weak(plugins_persist),
+    /* K23  */  be_nested_str_weak(plugins_config_remotes),
+    /* K24  */  be_nested_str_weak(remotes),
+    /* K25  */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
+    /* K26  */  be_nested_str_weak(io_error),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
+    /* K28  */  be_nested_str_weak(_X7C),
+    /* K29  */  be_const_int(2),
+    /* K30  */  be_nested_str_weak(random),
+    /* K31  */  be_nested_str_weak(get),
+    /* K32  */  be_const_int(0),
+    /* K33  */  be_nested_str_weak(generate_random_passcode),
+    /* K34  */  be_nested_str_weak(save_param),
+    }),
+    be_str_weak(load_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[127]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA802004D,  //  0001  EXBLK	0	#0050
+      0x60080011,  //  0002  GETGBL	R2	G17
+      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x7C080200,  //  0004  CALL	R2	1
+      0x8C0C0502,  //  0005  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0x8C100503,  //  0007  GETMET	R4	R2	K3
+      0x7C100200,  //  0008  CALL	R4	1
+      0xA4120800,  //  0009  IMPORT	R4	K4
+      0x8C140905,  //  000A  GETMET	R5	R4	K5
+      0x5C1C0600,  //  000B  MOVE	R7	R3
+      0x7C140400,  //  000C  CALL	R5	2
+      0x8C180B07,  //  000D  GETMET	R6	R5	K7
+      0x58200008,  //  000E  LDCONST	R8	K8
+      0x88240106,  //  000F  GETMBR	R9	R0	K6
+      0x7C180600,  //  0010  CALL	R6	3
+      0x90020C06,  //  0011  SETMBR	R0	K6	R6
+      0x8C180B07,  //  0012  GETMET	R6	R5	K7
+      0x5820000A,  //  0013  LDCONST	R8	K10
+      0x88240109,  //  0014  GETMBR	R9	R0	K9
+      0x7C180600,  //  0015  CALL	R6	3
+      0x90021206,  //  0016  SETMBR	R0	K9	R6
+      0x60180017,  //  0017  GETGBL	R6	G23
+      0x8C1C0B07,  //  0018  GETMET	R7	R5	K7
+      0x5824000B,  //  0019  LDCONST	R9	K11
+      0x50280000,  //  001A  LDBOOL	R10	0	0
+      0x7C1C0600,  //  001B  CALL	R7	3
+      0x7C180200,  //  001C  CALL	R6	1
+      0x90021606,  //  001D  SETMBR	R0	K11	R6
+      0x60180017,  //  001E  GETGBL	R6	G23
+      0x8C1C0B07,  //  001F  GETMET	R7	R5	K7
+      0x5824000C,  //  0020  LDCONST	R9	K12
+      0x50280000,  //  0021  LDBOOL	R10	0	0
+      0x7C1C0600,  //  0022  CALL	R7	3
+      0x7C180200,  //  0023  CALL	R6	1
+      0x90021806,  //  0024  SETMBR	R0	K12	R6
+      0x8C180B07,  //  0025  GETMET	R6	R5	K7
+      0x5820000E,  //  0026  LDCONST	R8	K14
+      0x8824010D,  //  0027  GETMBR	R9	R0	K13
+      0x7C180600,  //  0028  CALL	R6	3
+      0x90021A06,  //  0029  SETMBR	R0	K13	R6
+      0x8C180B07,  //  002A  GETMET	R6	R5	K7
+      0x58200010,  //  002B  LDCONST	R8	K16
+      0x7C180400,  //  002C  CALL	R6	2
+      0x90021E06,  //  002D  SETMBR	R0	K15	R6
+      0x8818010F,  //  002E  GETMBR	R6	R0	K15
+      0x4C1C0000,  //  002F  LDNIL	R7
+      0x20180C07,  //  0030  NE	R6	R6	R7
+      0x781A000B,  //  0031  JMPF	R6	#003E
+      0xB81A2200,  //  0032  GETNGBL	R6	K17
+      0x8C180D12,  //  0033  GETMET	R6	R6	K18
+      0x60200008,  //  0034  GETGBL	R8	G8
+      0x8824010F,  //  0035  GETMBR	R9	R0	K15
+      0x7C200200,  //  0036  CALL	R8	1
+      0x00222608,  //  0037  ADD	R8	K19	R8
+      0x58240014,  //  0038  LDCONST	R9	K20
+      0x7C180600,  //  0039  CALL	R6	3
+      0x8C180115,  //  003A  GETMET	R6	R0	K21
+      0x7C180200,  //  003B  CALL	R6	1
+      0x50180200,  //  003C  LDBOOL	R6	1	0
+      0x90022C06,  //  003D  SETMBR	R0	K22	R6
+      0x8C180B07,  //  003E  GETMET	R6	R5	K7
+      0x58200018,  //  003F  LDCONST	R8	K24
+      0x60240013,  //  0040  GETGBL	R9	G19
+      0x7C240000,  //  0041  CALL	R9	0
+      0x7C180600,  //  0042  CALL	R6	3
+      0x90022E06,  //  0043  SETMBR	R0	K23	R6
+      0x88180117,  //  0044  GETMBR	R6	R0	K23
+      0x781A0007,  //  0045  JMPF	R6	#004E
+      0xB81A2200,  //  0046  GETNGBL	R6	K17
+      0x8C180D12,  //  0047  GETMET	R6	R6	K18
+      0x60200008,  //  0048  GETGBL	R8	G8
+      0x88240117,  //  0049  GETMBR	R9	R0	K23
+      0x7C200200,  //  004A  CALL	R8	1
+      0x00223208,  //  004B  ADD	R8	K25	R8
+      0x58240014,  //  004C  LDCONST	R9	K20
+      0x7C180600,  //  004D  CALL	R6	3
+      0xA8040001,  //  004E  EXBLK	1	1
+      0x70020012,  //  004F  JMP		#0063
+      0xAC080002,  //  0050  CATCH	R2	0	2
+      0x7002000F,  //  0051  JMP		#0062
+      0x2010051A,  //  0052  NE	R4	R2	K26
+      0x7812000C,  //  0053  JMPF	R4	#0061
+      0xB8122200,  //  0054  GETNGBL	R4	K17
+      0x8C100912,  //  0055  GETMET	R4	R4	K18
+      0x60180008,  //  0056  GETGBL	R6	G8
+      0x5C1C0400,  //  0057  MOVE	R7	R2
+      0x7C180200,  //  0058  CALL	R6	1
+      0x001A3606,  //  0059  ADD	R6	K27	R6
+      0x00180D1C,  //  005A  ADD	R6	R6	K28
+      0x601C0008,  //  005B  GETGBL	R7	G8
+      0x5C200600,  //  005C  MOVE	R8	R3
+      0x7C1C0200,  //  005D  CALL	R7	1
+      0x00180C07,  //  005E  ADD	R6	R6	R7
+      0x581C001D,  //  005F  LDCONST	R7	K29
+      0x7C100600,  //  0060  CALL	R4	3
+      0x70020000,  //  0061  JMP		#0063
+      0xB0080000,  //  0062  RAISE	2	R0	R0
+      0x50080000,  //  0063  LDBOOL	R2	0	0
+      0x880C0106,  //  0064  GETMBR	R3	R0	K6
+      0x4C100000,  //  0065  LDNIL	R4
+      0x1C0C0604,  //  0066  EQ	R3	R3	R4
+      0x780E000A,  //  0067  JMPF	R3	#0073
+      0x8C0C031E,  //  0068  GETMET	R3	R1	K30
+      0x5814001D,  //  0069  LDCONST	R5	K29
+      0x7C0C0400,  //  006A  CALL	R3	2
+      0x8C0C071F,  //  006B  GETMET	R3	R3	K31
+      0x58140020,  //  006C  LDCONST	R5	K32
+      0x5818001D,  //  006D  LDCONST	R6	K29
+      0x7C0C0600,  //  006E  CALL	R3	3
+      0x54120FFE,  //  006F  LDINT	R4	4095
+      0x2C0C0604,  //  0070  AND	R3	R3	R4
+      0x90020C03,  //  0071  SETMBR	R0	K6	R3
+      0x50080200,  //  0072  LDBOOL	R2	1	0
+      0x880C0109,  //  0073  GETMBR	R3	R0	K9
+      0x4C100000,  //  0074  LDNIL	R4
+      0x1C0C0604,  //  0075  EQ	R3	R3	R4
+      0x780E0003,  //  0076  JMPF	R3	#007B
+      0x8C0C0121,  //  0077  GETMET	R3	R0	K33
+      0x7C0C0200,  //  0078  CALL	R3	1
+      0x90021203,  //  0079  SETMBR	R0	K9	R3
+      0x50080200,  //  007A  LDBOOL	R2	1	0
+      0x780A0001,  //  007B  JMPF	R2	#007E
+      0x8C0C0122,  //  007C  GETMET	R3	R0	K34
+      0x7C0C0200,  //  007D  CALL	R3	1
+      0x80000000,  //  007E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_commissioning_complete_deferred
+********************************************************************/
+be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        3,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 2]) {  /* upvals */
+          be_local_const_upval(1, 0),
+          be_local_const_upval(1, 1),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start_commissioning_complete),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x68080001,  //  0002  GETUPV	R2	U1
+          0x7C000400,  //  0003  CALL	R0	2
+          0x80040000,  //  0004  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(set_timer),
+    /* K2   */  be_const_int(0),
+    }),
+    be_str_weak(start_commissioning_complete_deferred),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x84140000,  //  0003  CLOSURE	R5	P0
+      0x7C080600,  //  0004  CALL	R2	3
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: bridge_remove_endpoint
+********************************************************************/
+be_local_closure(Matter_Device_bridge_remove_endpoint,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(plugins_config),
+    /* K2   */  be_nested_str_weak(contains),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
+    /* K6   */  be_const_int(3),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
+    /* K8   */  be_const_int(2),
+    /* K9   */  be_nested_str_weak(remove),
+    /* K10  */  be_nested_str_weak(plugins_persist),
+    /* K11  */  be_nested_str_weak(save_param),
+    /* K12  */  be_nested_str_weak(signal_endpoints_changed),
+    /* K13  */  be_const_int(0),
+    /* K14  */  be_nested_str_weak(plugins),
+    /* K15  */  be_nested_str_weak(get_endpoint),
+    /* K16  */  be_const_int(1),
+    /* K17  */  be_nested_str_weak(clean_remotes),
+    }),
+    be_str_weak(bridge_remove_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[60]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x600C0008,  //  0001  GETGBL	R3	G8
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x4C100000,  //  0004  LDNIL	R4
+      0x4C140000,  //  0005  LDNIL	R5
+      0x88180101,  //  0006  GETMBR	R6	R0	K1
+      0x8C180D02,  //  0007  GETMET	R6	R6	K2
+      0x5C200600,  //  0008  MOVE	R8	R3
+      0x7C180400,  //  0009  CALL	R6	2
+      0x741A0005,  //  000A  JMPT	R6	#0011
+      0xB81A0600,  //  000B  GETNGBL	R6	K3
+      0x8C180D04,  //  000C  GETMET	R6	R6	K4
+      0x00220A03,  //  000D  ADD	R8	K5	R3
+      0x58240006,  //  000E  LDCONST	R9	K6
+      0x7C180600,  //  000F  CALL	R6	3
+      0x80000C00,  //  0010  RET	0
+      0xB81A0600,  //  0011  GETNGBL	R6	K3
+      0x8C180D04,  //  0012  GETMET	R6	R6	K4
+      0x60200018,  //  0013  GETGBL	R8	G24
+      0x58240007,  //  0014  LDCONST	R9	K7
+      0x5C280200,  //  0015  MOVE	R10	R1
+      0x7C200400,  //  0016  CALL	R8	2
+      0x58240008,  //  0017  LDCONST	R9	K8
+      0x7C180600,  //  0018  CALL	R6	3
+      0x88180101,  //  0019  GETMBR	R6	R0	K1
+      0x8C180D09,  //  001A  GETMET	R6	R6	K9
+      0x5C200600,  //  001B  MOVE	R8	R3
+      0x7C180400,  //  001C  CALL	R6	2
+      0x50180200,  //  001D  LDBOOL	R6	1	0
+      0x90021406,  //  001E  SETMBR	R0	K10	R6
+      0x8C18010B,  //  001F  GETMET	R6	R0	K11
+      0x7C180200,  //  0020  CALL	R6	1
+      0x8C18010C,  //  0021  GETMET	R6	R0	K12
+      0x7C180200,  //  0022  CALL	R6	1
+      0x5818000D,  //  0023  LDCONST	R6	K13
+      0x601C000C,  //  0024  GETGBL	R7	G12
+      0x8820010E,  //  0025  GETMBR	R8	R0	K14
+      0x7C1C0200,  //  0026  CALL	R7	1
+      0x141C0C07,  //  0027  LT	R7	R6	R7
+      0x781E000F,  //  0028  JMPF	R7	#0039
+      0x881C010E,  //  0029  GETMBR	R7	R0	K14
+      0x941C0E06,  //  002A  GETIDX	R7	R7	R6
+      0x8C1C0F0F,  //  002B  GETMET	R7	R7	K15
+      0x7C1C0200,  //  002C  CALL	R7	1
+      0x1C1C0207,  //  002D  EQ	R7	R1	R7
+      0x781E0007,  //  002E  JMPF	R7	#0037
+      0x881C010E,  //  002F  GETMBR	R7	R0	K14
+      0x8C1C0F09,  //  0030  GETMET	R7	R7	K9
+      0x5C240C00,  //  0031  MOVE	R9	R6
+      0x7C1C0400,  //  0032  CALL	R7	2
+      0x8C1C010C,  //  0033  GETMET	R7	R0	K12
+      0x7C1C0200,  //  0034  CALL	R7	1
+      0x70020002,  //  0035  JMP		#0039
+      0x70020000,  //  0036  JMP		#0038
+      0x00180D10,  //  0037  ADD	R6	R6	K16
+      0x7001FFEA,  //  0038  JMP		#0024
+      0x8C1C0111,  //  0039  GETMET	R7	R0	K17
+      0x7C1C0200,  //  003A  CALL	R7	1
+      0x80000000,  //  003B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_root_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(PASE_TIMEOUT),
+    /* K1   */  be_nested_str_weak(compute_manual_pairing_code),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s),
+    /* K5   */  be_const_int(2),
+    /* K6   */  be_nested_str_weak(compute_qrcode_content),
+    /* K7   */  be_nested_str_weak(publish_result),
+    /* K8   */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A1_X2C_X22PairingCode_X22_X3A_X22_X25s_X22_X2C_X22QRCode_X22_X3A_X22_X25s_X22_X7D_X7D),
+    /* K9   */  be_nested_str_weak(Matter),
+    /* K10  */  be_nested_str_weak(_compute_pbkdf),
+    /* K11  */  be_nested_str_weak(root_passcode),
+    /* K12  */  be_nested_str_weak(root_iterations),
+    /* K13  */  be_nested_str_weak(root_salt),
+    /* K14  */  be_nested_str_weak(start_basic_commissioning),
+    /* K15  */  be_nested_str_weak(root_discriminator),
+    /* K16  */  be_nested_str_weak(root_w0),
+    /* K17  */  be_nested_str_weak(root_L),
+    }),
+    be_str_weak(start_root_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x88040100,  //  0003  GETMBR	R1	R0	K0
+      0x8C080101,  //  0004  GETMET	R2	R0	K1
+      0x7C080200,  //  0005  CALL	R2	1
+      0xB80E0400,  //  0006  GETNGBL	R3	K2
+      0x8C0C0703,  //  0007  GETMET	R3	R3	K3
+      0x60140018,  //  0008  GETGBL	R5	G24
+      0x58180004,  //  0009  LDCONST	R6	K4
+      0x5C1C0400,  //  000A  MOVE	R7	R2
+      0x7C140400,  //  000B  CALL	R5	2
+      0x58180005,  //  000C  LDCONST	R6	K5
+      0x7C0C0600,  //  000D  CALL	R3	3
+      0x8C0C0106,  //  000E  GETMET	R3	R0	K6
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0xB8120400,  //  0010  GETNGBL	R4	K2
+      0x8C100907,  //  0011  GETMET	R4	R4	K7
+      0x60180018,  //  0012  GETGBL	R6	G24
+      0x581C0008,  //  0013  LDCONST	R7	K8
+      0x5C200400,  //  0014  MOVE	R8	R2
+      0x5C240600,  //  0015  MOVE	R9	R3
+      0x7C180600,  //  0016  CALL	R6	3
+      0x581C0009,  //  0017  LDCONST	R7	K9
+      0x7C100600,  //  0018  CALL	R4	3
+      0x8C10010A,  //  0019  GETMET	R4	R0	K10
+      0x8818010B,  //  001A  GETMBR	R6	R0	K11
+      0x881C010C,  //  001B  GETMBR	R7	R0	K12
+      0x8820010D,  //  001C  GETMBR	R8	R0	K13
+      0x7C100800,  //  001D  CALL	R4	4
+      0x8C10010E,  //  001E  GETMET	R4	R0	K14
+      0x5C180200,  //  001F  MOVE	R6	R1
+      0x881C010C,  //  0020  GETMBR	R7	R0	K12
+      0x8820010F,  //  0021  GETMBR	R8	R0	K15
+      0x8824010D,  //  0022  GETMBR	R9	R0	K13
+      0x88280110,  //  0023  GETMBR	R10	R0	K16
+      0x882C0111,  //  0024  GETMBR	R11	R0	K17
+      0x4C300000,  //  0025  LDNIL	R12
+      0x7C101000,  //  0026  CALL	R4	8
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: k2l
+********************************************************************/
+be_local_closure(Matter_Device_k2l,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Device),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(push),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_const_int(0),
+    }),
+    be_str_weak(k2l),
+    &be_const_str_solidified,
+    ( &(const binstruction[50]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0003,  //  0004  EQ	R3	R0	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80040400,  //  0006  RET	1	R2
+      0x600C0010,  //  0007  GETGBL	R3	G16
+      0x8C100101,  //  0008  GETMET	R4	R0	K1
+      0x7C100200,  //  0009  CALL	R4	1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0xA8020005,  //  000B  EXBLK	0	#0012
+      0x5C100600,  //  000C  MOVE	R4	R3
+      0x7C100000,  //  000D  CALL	R4	0
+      0x8C140502,  //  000E  GETMET	R5	R2	K2
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x7C140400,  //  0010  CALL	R5	2
+      0x7001FFF9,  //  0011  JMP		#000C
+      0x580C0003,  //  0012  LDCONST	R3	K3
+      0xAC0C0200,  //  0013  CATCH	R3	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x600C0010,  //  0015  GETGBL	R3	G16
+      0x6010000C,  //  0016  GETGBL	R4	G12
+      0x5C140400,  //  0017  MOVE	R5	R2
+      0x7C100200,  //  0018  CALL	R4	1
+      0x04100904,  //  0019  SUB	R4	R4	K4
+      0x40120804,  //  001A  CONNECT	R4	K4	R4
+      0x7C0C0200,  //  001B  CALL	R3	1
+      0xA8020010,  //  001C  EXBLK	0	#002E
+      0x5C100600,  //  001D  MOVE	R4	R3
+      0x7C100000,  //  001E  CALL	R4	0
+      0x94140404,  //  001F  GETIDX	R5	R2	R4
+      0x5C180800,  //  0020  MOVE	R6	R4
+      0x241C0D05,  //  0021  GT	R7	R6	K5
+      0x781E0008,  //  0022  JMPF	R7	#002C
+      0x041C0D04,  //  0023  SUB	R7	R6	K4
+      0x941C0407,  //  0024  GETIDX	R7	R2	R7
+      0x241C0E05,  //  0025  GT	R7	R7	R5
+      0x781E0004,  //  0026  JMPF	R7	#002C
+      0x041C0D04,  //  0027  SUB	R7	R6	K4
+      0x941C0407,  //  0028  GETIDX	R7	R2	R7
+      0x98080C07,  //  0029  SETIDX	R2	R6	R7
+      0x04180D04,  //  002A  SUB	R6	R6	K4
+      0x7001FFF4,  //  002B  JMP		#0021
+      0x98080C05,  //  002C  SETIDX	R2	R6	R5
+      0x7001FFEE,  //  002D  JMP		#001D
+      0x580C0003,  //  002E  LDCONST	R3	K3
+      0xAC0C0200,  //  002F  CATCH	R3	1	0
+      0xB0080000,  //  0030  RAISE	2	R0	R0
+      0x80040400,  //  0031  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: adjust_next_ep
+********************************************************************/
+be_local_closure(Matter_Device_adjust_next_ep,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_config),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(next_ep),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(adjust_next_ep),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000A,  //  0005  EXBLK	0	#0011
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x600C0009,  //  0008  GETGBL	R3	G9
+      0x5C100400,  //  0009  MOVE	R4	R2
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x88100102,  //  000B  GETMBR	R4	R0	K2
+      0x28100604,  //  000C  GE	R4	R3	R4
+      0x78120001,  //  000D  JMPF	R4	#0010
+      0x00100703,  //  000E  ADD	R4	R3	K3
+      0x90020404,  //  000F  SETMBR	R0	K2	R4
+      0x7001FFF4,  //  0010  JMP		#0006
+      0x58040004,  //  0011  LDCONST	R1	K4
+      0xAC040200,  //  0012  CATCH	R1	1	0
+      0xB0080000,  //  0013  RAISE	2	R0	R0
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _mdns_announce_hostname
+********************************************************************/
+be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[26]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(start),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(eth),
+    /* K5   */  be_nested_str_weak(hostname_eth),
+    /* K6   */  be_nested_str_weak(replace),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_nested_str_weak(mac),
+    /* K9   */  be_nested_str_weak(_X3A),
+    /* K10  */  be_nested_str_weak(),
+    /* K11  */  be_nested_str_weak(ipv4only),
+    /* K12  */  be_nested_str_weak(add_hostname),
+    /* K13  */  be_nested_str_weak(ip6local),
+    /* K14  */  be_nested_str_weak(ip),
+    /* K15  */  be_nested_str_weak(ip6),
+    /* K16  */  be_nested_str_weak(log),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eadd_hostname_X28_X25s_X2C_X20_X25s_X29),
+    /* K18  */  be_const_int(3),
+    /* K19  */  be_nested_str_weak(wifi),
+    /* K20  */  be_nested_str_weak(hostname_wifi),
+    /* K21  */  be_nested_str_weak(MTR_X3A_X20start_X20mDNS_X20on_X20_X25s_X20host_X20_X27_X25s_X2Elocal_X27),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K23  */  be_nested_str_weak(_X7C),
+    /* K24  */  be_const_int(2),
+    /* K25  */  be_nested_str_weak(mdns_announce_op_discovery_all_fabrics),
+    }),
+    be_str_weak(_mdns_announce_hostname),
+    &be_const_str_solidified,
+    ( &(const binstruction[140]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0x8C100502,  //  0002  GETMET	R4	R2	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0xA8020072,  //  0004  EXBLK	0	#0078
+      0x78060030,  //  0005  JMPF	R1	#0037
+      0xB8120600,  //  0006  GETNGBL	R4	K3
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C140706,  //  0009  GETMET	R5	R3	K6
+      0x8C1C0907,  //  000A  GETMET	R7	R4	K7
+      0x58240008,  //  000B  LDCONST	R9	K8
+      0x7C1C0400,  //  000C  CALL	R7	2
+      0x58200009,  //  000D  LDCONST	R8	K9
+      0x5824000A,  //  000E  LDCONST	R9	K10
+      0x7C140800,  //  000F  CALL	R5	4
+      0x90020A05,  //  0010  SETMBR	R0	K5	R5
+      0x8814010B,  //  0011  GETMBR	R5	R0	K11
+      0x7416000F,  //  0012  JMPT	R5	#0023
+      0x8C14050C,  //  0013  GETMET	R5	R2	K12
+      0x881C0105,  //  0014  GETMBR	R7	R0	K5
+      0x8C200907,  //  0015  GETMET	R8	R4	K7
+      0x5828000D,  //  0016  LDCONST	R10	K13
+      0x582C000A,  //  0017  LDCONST	R11	K10
+      0x7C200600,  //  0018  CALL	R8	3
+      0x8C240907,  //  0019  GETMET	R9	R4	K7
+      0x582C000E,  //  001A  LDCONST	R11	K14
+      0x5830000A,  //  001B  LDCONST	R12	K10
+      0x7C240600,  //  001C  CALL	R9	3
+      0x8C280907,  //  001D  GETMET	R10	R4	K7
+      0x5830000F,  //  001E  LDCONST	R12	K15
+      0x5834000A,  //  001F  LDCONST	R13	K10
+      0x7C280600,  //  0020  CALL	R10	3
+      0x7C140A00,  //  0021  CALL	R5	5
+      0x70020012,  //  0022  JMP		#0036
+      0xB8160600,  //  0023  GETNGBL	R5	K3
+      0x8C140B10,  //  0024  GETMET	R5	R5	K16
+      0x601C0018,  //  0025  GETGBL	R7	G24
+      0x58200011,  //  0026  LDCONST	R8	K17
+      0x88240105,  //  0027  GETMBR	R9	R0	K5
+      0x8C280907,  //  0028  GETMET	R10	R4	K7
+      0x5830000E,  //  0029  LDCONST	R12	K14
+      0x5834000A,  //  002A  LDCONST	R13	K10
+      0x7C280600,  //  002B  CALL	R10	3
+      0x7C1C0600,  //  002C  CALL	R7	3
+      0x58200012,  //  002D  LDCONST	R8	K18
+      0x7C140600,  //  002E  CALL	R5	3
+      0x8C14050C,  //  002F  GETMET	R5	R2	K12
+      0x881C0105,  //  0030  GETMBR	R7	R0	K5
+      0x8C200907,  //  0031  GETMET	R8	R4	K7
+      0x5828000E,  //  0032  LDCONST	R10	K14
+      0x582C000A,  //  0033  LDCONST	R11	K10
+      0x7C200600,  //  0034  CALL	R8	3
+      0x7C140600,  //  0035  CALL	R5	3
+      0x7002002F,  //  0036  JMP		#0067
+      0xB8120600,  //  0037  GETNGBL	R4	K3
+      0x8C100913,  //  0038  GETMET	R4	R4	K19
+      0x7C100200,  //  0039  CALL	R4	1
+      0x8C140706,  //  003A  GETMET	R5	R3	K6
+      0x8C1C0907,  //  003B  GETMET	R7	R4	K7
+      0x58240008,  //  003C  LDCONST	R9	K8
+      0x7C1C0400,  //  003D  CALL	R7	2
+      0x58200009,  //  003E  LDCONST	R8	K9
+      0x5824000A,  //  003F  LDCONST	R9	K10
+      0x7C140800,  //  0040  CALL	R5	4
+      0x90022805,  //  0041  SETMBR	R0	K20	R5
+      0x8814010B,  //  0042  GETMBR	R5	R0	K11
+      0x7416000F,  //  0043  JMPT	R5	#0054
+      0x8C14050C,  //  0044  GETMET	R5	R2	K12
+      0x881C0114,  //  0045  GETMBR	R7	R0	K20
+      0x8C200907,  //  0046  GETMET	R8	R4	K7
+      0x5828000D,  //  0047  LDCONST	R10	K13
+      0x582C000A,  //  0048  LDCONST	R11	K10
+      0x7C200600,  //  0049  CALL	R8	3
+      0x8C240907,  //  004A  GETMET	R9	R4	K7
+      0x582C000E,  //  004B  LDCONST	R11	K14
+      0x5830000A,  //  004C  LDCONST	R12	K10
+      0x7C240600,  //  004D  CALL	R9	3
+      0x8C280907,  //  004E  GETMET	R10	R4	K7
+      0x5830000F,  //  004F  LDCONST	R12	K15
+      0x5834000A,  //  0050  LDCONST	R13	K10
+      0x7C280600,  //  0051  CALL	R10	3
+      0x7C140A00,  //  0052  CALL	R5	5
+      0x70020012,  //  0053  JMP		#0067
+      0xB8160600,  //  0054  GETNGBL	R5	K3
+      0x8C140B10,  //  0055  GETMET	R5	R5	K16
+      0x601C0018,  //  0056  GETGBL	R7	G24
+      0x58200011,  //  0057  LDCONST	R8	K17
+      0x88240105,  //  0058  GETMBR	R9	R0	K5
+      0x8C280907,  //  0059  GETMET	R10	R4	K7
+      0x5830000E,  //  005A  LDCONST	R12	K14
+      0x5834000A,  //  005B  LDCONST	R13	K10
+      0x7C280600,  //  005C  CALL	R10	3
+      0x7C1C0600,  //  005D  CALL	R7	3
+      0x58200012,  //  005E  LDCONST	R8	K18
+      0x7C140600,  //  005F  CALL	R5	3
+      0x8C14050C,  //  0060  GETMET	R5	R2	K12
+      0x881C0114,  //  0061  GETMBR	R7	R0	K20
+      0x8C200907,  //  0062  GETMET	R8	R4	K7
+      0x5828000E,  //  0063  LDCONST	R10	K14
+      0x582C000A,  //  0064  LDCONST	R11	K10
+      0x7C200600,  //  0065  CALL	R8	3
+      0x7C140600,  //  0066  CALL	R5	3
+      0xB8120600,  //  0067  GETNGBL	R4	K3
+      0x8C100910,  //  0068  GETMET	R4	R4	K16
+      0x60180018,  //  0069  GETGBL	R6	G24
+      0x581C0015,  //  006A  LDCONST	R7	K21
+      0x78060001,  //  006B  JMPF	R1	#006E
+      0x58200004,  //  006C  LDCONST	R8	K4
+      0x70020000,  //  006D  JMP		#006F
+      0x58200013,  //  006E  LDCONST	R8	K19
+      0x78060001,  //  006F  JMPF	R1	#0072
+      0x88240105,  //  0070  GETMBR	R9	R0	K5
+      0x70020000,  //  0071  JMP		#0073
+      0x88240114,  //  0072  GETMBR	R9	R0	K20
+      0x7C180600,  //  0073  CALL	R6	3
+      0x581C0012,  //  0074  LDCONST	R7	K18
+      0x7C100600,  //  0075  CALL	R4	3
+      0xA8040001,  //  0076  EXBLK	1	1
+      0x70020010,  //  0077  JMP		#0089
+      0xAC100002,  //  0078  CATCH	R4	0	2
+      0x7002000D,  //  0079  JMP		#0088
+      0xB81A0600,  //  007A  GETNGBL	R6	K3
+      0x8C180D10,  //  007B  GETMET	R6	R6	K16
+      0x60200008,  //  007C  GETGBL	R8	G8
+      0x5C240800,  //  007D  MOVE	R9	R4
+      0x7C200200,  //  007E  CALL	R8	1
+      0x00222C08,  //  007F  ADD	R8	K22	R8
+      0x00201117,  //  0080  ADD	R8	R8	K23
+      0x60240008,  //  0081  GETGBL	R9	G8
+      0x5C280A00,  //  0082  MOVE	R10	R5
+      0x7C240200,  //  0083  CALL	R9	1
+      0x00201009,  //  0084  ADD	R8	R8	R9
+      0x58240018,  //  0085  LDCONST	R9	K24
+      0x7C180600,  //  0086  CALL	R6	3
+      0x70020000,  //  0087  JMP		#0089
+      0xB0080000,  //  0088  RAISE	2	R0	R0
+      0x8C100119,  //  0089  GETMET	R4	R0	K25
+      0x7C100200,  //  008A  CALL	R4	1
+      0x80000000,  //  008B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_root_commissioning_open
+********************************************************************/
+be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    /* K1   */  be_nested_str_weak(commissioning_admin_fabric),
+    }),
+    be_str_weak(is_root_commissioning_open),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060003,  //  0003  JMPF	R1	#0008
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x4C080000,  //  0005  LDNIL	R2
+      0x1C040202,  //  0006  EQ	R1	R1	R2
+      0x74060000,  //  0007  JMPT	R1	#0009
+      0x50040001,  //  0008  LDBOOL	R1	0	1
+      0x50040200,  //  0009  LDBOOL	R1	1	0
+      0x80040200,  //  000A  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _start_udp
+********************************************************************/
+be_local_closure(Matter_Device__start_udp,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(msg_received),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(UDPServer),
+    /* K7   */  be_nested_str_weak(),
+    /* K8   */  be_nested_str_weak(start),
+    }),
+    be_str_weak(_start_udp),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80000400,  //  0002  RET	0
+      0x4C080000,  //  0003  LDNIL	R2
+      0x1C080202,  //  0004  EQ	R2	R1	R2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x540615A3,  //  0006  LDINT	R1	5540
+      0xB80A0200,  //  0007  GETNGBL	R2	K1
+      0x8C080502,  //  0008  GETMET	R2	R2	K2
+      0x60100008,  //  0009  GETGBL	R4	G8
+      0x5C140200,  //  000A  MOVE	R5	R1
+      0x7C100200,  //  000B  CALL	R4	1
+      0x00120604,  //  000C  ADD	R4	K3	R4
+      0x58140004,  //  000D  LDCONST	R5	K4
+      0x7C080600,  //  000E  CALL	R2	3
+      0xB80A0A00,  //  000F  GETNGBL	R2	K5
+      0x8C080506,  //  0010  GETMET	R2	R2	K6
+      0x58100007,  //  0011  LDCONST	R4	K7
+      0x5C140200,  //  0012  MOVE	R5	R1
+      0x7C080600,  //  0013  CALL	R2	3
+      0x90020002,  //  0014  SETMBR	R0	K0	R2
+      0x88080100,  //  0015  GETMBR	R2	R0	K0
+      0x8C080508,  //  0016  GETMET	R2	R2	K8
+      0x84100000,  //  0017  CLOSURE	R4	P0
+      0x7C080400,  //  0018  CALL	R2	2
+      0xA0000000,  //  0019  CLOSE	R0
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop
+********************************************************************/
+be_local_closure(Matter_Device_stop,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(remove_driver),
+    /* K2   */  be_nested_str_weak(udp_server),
+    /* K3   */  be_nested_str_weak(stop),
+    }),
+    be_str_weak(stop),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x88040102,  //  0004  GETMBR	R1	R0	K2
+      0x78060002,  //  0005  JMPF	R1	#0009
+      0x88040102,  //  0006  GETMBR	R1	R0	K2
+      0x8C040303,  //  0007  GETMET	R1	R1	K3
+      0x7C040200,  //  0008  CALL	R1	1
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_fabric
+********************************************************************/
+be_local_closure(Matter_Device_remove_fabric,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[20]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(find_children_fabrics),
+    /* K2   */  be_nested_str_weak(get_fabric_index),
+    /* K3   */  be_nested_str_weak(find_fabric_by_index),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
+    /* K7   */  be_nested_str_weak(get_fabric_id),
+    /* K8   */  be_nested_str_weak(copy),
+    /* K9   */  be_nested_str_weak(reverse),
+    /* K10  */  be_nested_str_weak(tohex),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_nested_str_weak(message_handler),
+    /* K13  */  be_nested_str_weak(im),
+    /* K14  */  be_nested_str_weak(subs_shop),
+    /* K15  */  be_nested_str_weak(remove_by_fabric),
+    /* K16  */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K17  */  be_nested_str_weak(remove_fabric),
+    /* K18  */  be_nested_str_weak(stop_iteration),
+    /* K19  */  be_nested_str_weak(save_fabrics),
+    }),
+    be_str_weak(remove_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[56]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x8C100302,  //  0002  GETMET	R4	R1	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x7C080400,  //  0004  CALL	R2	2
+      0x4C0C0000,  //  0005  LDNIL	R3
+      0x1C0C0403,  //  0006  EQ	R3	R2	R3
+      0x780E0000,  //  0007  JMPF	R3	#0009
+      0x80000600,  //  0008  RET	0
+      0x600C0010,  //  0009  GETGBL	R3	G16
+      0x5C100400,  //  000A  MOVE	R4	R2
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0xA8020023,  //  000C  EXBLK	0	#0031
+      0x5C100600,  //  000D  MOVE	R4	R3
+      0x7C100000,  //  000E  CALL	R4	0
+      0x88140100,  //  000F  GETMBR	R5	R0	K0
+      0x8C140B03,  //  0010  GETMET	R5	R5	K3
+      0x5C1C0800,  //  0011  MOVE	R7	R4
+      0x7C140400,  //  0012  CALL	R5	2
+      0x4C180000,  //  0013  LDNIL	R6
+      0x20180A06,  //  0014  NE	R6	R5	R6
+      0x781A0019,  //  0015  JMPF	R6	#0030
+      0xB81A0800,  //  0016  GETNGBL	R6	K4
+      0x8C180D05,  //  0017  GETMET	R6	R6	K5
+      0x8C200B07,  //  0018  GETMET	R8	R5	K7
+      0x7C200200,  //  0019  CALL	R8	1
+      0x8C201108,  //  001A  GETMET	R8	R8	K8
+      0x7C200200,  //  001B  CALL	R8	1
+      0x8C201109,  //  001C  GETMET	R8	R8	K9
+      0x7C200200,  //  001D  CALL	R8	1
+      0x8C20110A,  //  001E  GETMET	R8	R8	K10
+      0x7C200200,  //  001F  CALL	R8	1
+      0x00220C08,  //  0020  ADD	R8	K6	R8
+      0x5824000B,  //  0021  LDCONST	R9	K11
+      0x7C180600,  //  0022  CALL	R6	3
+      0x8818010C,  //  0023  GETMBR	R6	R0	K12
+      0x88180D0D,  //  0024  GETMBR	R6	R6	K13
+      0x88180D0E,  //  0025  GETMBR	R6	R6	K14
+      0x8C180D0F,  //  0026  GETMET	R6	R6	K15
+      0x5C200A00,  //  0027  MOVE	R8	R5
+      0x7C180400,  //  0028  CALL	R6	2
+      0x8C180110,  //  0029  GETMET	R6	R0	K16
+      0x5C200A00,  //  002A  MOVE	R8	R5
+      0x7C180400,  //  002B  CALL	R6	2
+      0x88180100,  //  002C  GETMBR	R6	R0	K0
+      0x8C180D11,  //  002D  GETMET	R6	R6	K17
+      0x5C200A00,  //  002E  MOVE	R8	R5
+      0x7C180400,  //  002F  CALL	R6	2
+      0x7001FFDB,  //  0030  JMP		#000D
+      0x580C0012,  //  0031  LDCONST	R3	K18
+      0xAC0C0200,  //  0032  CATCH	R3	1	0
+      0xB0080000,  //  0033  RAISE	2	R0	R0
+      0x880C0100,  //  0034  GETMBR	R3	R0	K0
+      0x8C0C0713,  //  0035  GETMET	R3	R3	K19
+      0x7C0C0200,  //  0036  CALL	R3	1
+      0x80000000,  //  0037  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_plugin_class_displayname
+********************************************************************/
+be_local_closure(Matter_Device_get_plugin_class_displayname,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_classes),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(NAME),
+    /* K3   */  be_nested_str_weak(),
+    }),
+    be_str_weak(get_plugin_class_displayname),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x880C0502,  //  0005  GETMBR	R3	R2	K2
+      0x70020000,  //  0006  JMP		#0008
+      0x580C0003,  //  0007  LDCONST	R3	K3
+      0x80040600,  //  0008  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clean_remotes
+********************************************************************/
+be_local_closure(Matter_Device_clean_remotes,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[17]) {     /* constants */
+    /* K0   */  be_nested_str_weak(introspect),
+    /* K1   */  be_nested_str_weak(http_remotes),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_nested_str_weak(plugins),
+    /* K5   */  be_nested_str_weak(get),
+    /* K6   */  be_nested_str_weak(http_remote),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(keys),
+    /* K10  */  be_nested_str_weak(tasmota),
+    /* K11  */  be_nested_str_weak(log),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
+    /* K13  */  be_nested_str_weak(addr),
+    /* K14  */  be_const_int(3),
+    /* K15  */  be_nested_str_weak(close),
+    /* K16  */  be_nested_str_weak(remove),
+    }),
+    be_str_weak(clean_remotes),
+    &be_const_str_solidified,
+    ( &(const binstruction[66]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x780A003D,  //  0002  JMPF	R2	#0041
+      0x60080013,  //  0003  GETGBL	R2	G19
+      0x7C080000,  //  0004  CALL	R2	0
+      0x600C0010,  //  0005  GETGBL	R3	G16
+      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0xA8020003,  //  0008  EXBLK	0	#000D
+      0x5C100600,  //  0009  MOVE	R4	R3
+      0x7C100000,  //  000A  CALL	R4	0
+      0x98080902,  //  000B  SETIDX	R2	R4	K2
+      0x7001FFFB,  //  000C  JMP		#0009
+      0x580C0003,  //  000D  LDCONST	R3	K3
+      0xAC0C0200,  //  000E  CATCH	R3	1	0
+      0xB0080000,  //  000F  RAISE	2	R0	R0
+      0x600C0010,  //  0010  GETGBL	R3	G16
+      0x88100104,  //  0011  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  0012  CALL	R3	1
+      0xA802000F,  //  0013  EXBLK	0	#0024
+      0x5C100600,  //  0014  MOVE	R4	R3
+      0x7C100000,  //  0015  CALL	R4	0
+      0x8C140305,  //  0016  GETMET	R5	R1	K5
+      0x5C1C0800,  //  0017  MOVE	R7	R4
+      0x58200006,  //  0018  LDCONST	R8	K6
+      0x7C140600,  //  0019  CALL	R5	3
+      0x4C180000,  //  001A  LDNIL	R6
+      0x20180A06,  //  001B  NE	R6	R5	R6
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C180507,  //  001D  GETMET	R6	R2	K7
+      0x5C200A00,  //  001E  MOVE	R8	R5
+      0x58240002,  //  001F  LDCONST	R9	K2
+      0x7C180600,  //  0020  CALL	R6	3
+      0x00180D08,  //  0021  ADD	R6	R6	K8
+      0x98080A06,  //  0022  SETIDX	R2	R5	R6
+      0x7001FFEF,  //  0023  JMP		#0014
+      0x580C0003,  //  0024  LDCONST	R3	K3
+      0xAC0C0200,  //  0025  CATCH	R3	1	0
+      0xB0080000,  //  0026  RAISE	2	R0	R0
+      0x600C0010,  //  0027  GETGBL	R3	G16
+      0x8C100509,  //  0028  GETMET	R4	R2	K9
+      0x7C100200,  //  0029  CALL	R4	1
+      0x7C0C0200,  //  002A  CALL	R3	1
+      0xA8020011,  //  002B  EXBLK	0	#003E
+      0x5C100600,  //  002C  MOVE	R4	R3
+      0x7C100000,  //  002D  CALL	R4	0
+      0x94140404,  //  002E  GETIDX	R5	R2	R4
+      0x1C140B02,  //  002F  EQ	R5	R5	K2
+      0x7816000B,  //  0030  JMPF	R5	#003D
+      0xB8161400,  //  0031  GETNGBL	R5	K10
+      0x8C140B0B,  //  0032  GETMET	R5	R5	K11
+      0x881C090D,  //  0033  GETMBR	R7	R4	K13
+      0x001E1807,  //  0034  ADD	R7	K12	R7
+      0x5820000E,  //  0035  LDCONST	R8	K14
+      0x7C140600,  //  0036  CALL	R5	3
+      0x8C14090F,  //  0037  GETMET	R5	R4	K15
+      0x7C140200,  //  0038  CALL	R5	1
+      0x88140101,  //  0039  GETMBR	R5	R0	K1
+      0x8C140B10,  //  003A  GETMET	R5	R5	K16
+      0x5C1C0800,  //  003B  MOVE	R7	R4
+      0x7C140400,  //  003C  CALL	R5	2
+      0x7001FFED,  //  003D  JMP		#002C
+      0x580C0003,  //  003E  LDCONST	R3	K3
+      0xAC0C0200,  //  003F  CATCH	R3	1	0
+      0xB0080000,  //  0040  RAISE	2	R0	R0
+      0x80000000,  //  0041  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: stop_basic_commissioning
 ********************************************************************/
 be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
@@ -4505,11 +3545,11 @@ be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
 
 
 /********************************************************************
-** Solidified function: load_param
+** Solidified function: mdns_announce_PASE
 ********************************************************************/
-be_local_closure(Matter_Device_load_param,   /* name */
+be_local_closure(Matter_Device_mdns_announce_PASE,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    12,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -4517,165 +3557,288 @@ be_local_closure(Matter_Device_load_param,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[34]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(FILENAME),
-    /* K2   */  be_nested_str_weak(read),
-    /* K3   */  be_nested_str_weak(close),
-    /* K4   */  be_nested_str_weak(json),
-    /* K5   */  be_nested_str_weak(load),
-    /* K6   */  be_nested_str_weak(root_discriminator),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_nested_str_weak(distinguish),
-    /* K9   */  be_nested_str_weak(root_passcode),
-    /* K10  */  be_nested_str_weak(passcode),
-    /* K11  */  be_nested_str_weak(ipv4only),
-    /* K12  */  be_nested_str_weak(next_ep),
-    /* K13  */  be_nested_str_weak(nextep),
-    /* K14  */  be_nested_str_weak(plugins_config),
-    /* K15  */  be_nested_str_weak(config),
-    /* K16  */  be_nested_str_weak(tasmota),
-    /* K17  */  be_nested_str_weak(log),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20load_config_X20_X3D_X20),
-    /* K19  */  be_const_int(3),
-    /* K20  */  be_nested_str_weak(adjust_next_ep),
-    /* K21  */  be_nested_str_weak(plugins_persist),
-    /* K22  */  be_nested_str_weak(plugins_config_remotes),
-    /* K23  */  be_nested_str_weak(remotes),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
-    /* K25  */  be_nested_str_weak(io_error),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
-    /* K27  */  be_nested_str_weak(_X7C),
-    /* K28  */  be_const_int(2),
-    /* K29  */  be_nested_str_weak(random),
-    /* K30  */  be_nested_str_weak(get),
-    /* K31  */  be_const_int(0),
-    /* K32  */  be_nested_str_weak(generate_random_passcode),
-    /* K33  */  be_nested_str_weak(save_param),
+    ( &(const bvalue[41]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(crypto),
+    /* K2   */  be_nested_str_weak(VP),
+    /* K3   */  be_nested_str_weak(vendorid),
+    /* K4   */  be_nested_str_weak(_X2B),
+    /* K5   */  be_nested_str_weak(productid),
+    /* K6   */  be_nested_str_weak(D),
+    /* K7   */  be_nested_str_weak(commissioning_discriminator),
+    /* K8   */  be_nested_str_weak(CM),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(T),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_weak(SII),
+    /* K13  */  be_nested_str_weak(SAI),
+    /* K14  */  be_nested_str_weak(commissioning_instance_wifi),
+    /* K15  */  be_nested_str_weak(random),
+    /* K16  */  be_nested_str_weak(tohex),
+    /* K17  */  be_nested_str_weak(commissioning_instance_eth),
+    /* K18  */  be_nested_str_weak(hostname_eth),
+    /* K19  */  be_nested_str_weak(add_service),
+    /* K20  */  be_nested_str_weak(_matterc),
+    /* K21  */  be_nested_str_weak(_udp),
+    /* K22  */  be_nested_str_weak(mdns_pase_eth),
+    /* K23  */  be_nested_str_weak(tasmota),
+    /* K24  */  be_nested_str_weak(log),
+    /* K25  */  be_nested_str_weak(MTR_X3A_X20announce_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K26  */  be_nested_str_weak(eth),
+    /* K27  */  be_const_int(2),
+    /* K28  */  be_nested_str_weak(_L),
+    /* K29  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
+    /* K30  */  be_const_int(3),
+    /* K31  */  be_nested_str_weak(add_subtype),
+    /* K32  */  be_nested_str_weak(_S),
+    /* K33  */  be_nested_str_weak(_V),
+    /* K34  */  be_nested_str_weak(_CM1),
+    /* K35  */  be_nested_str_weak(hostname_wifi),
+    /* K36  */  be_nested_str_weak(mdns_pase_wifi),
+    /* K37  */  be_nested_str_weak(MTR_X3A_X20starting_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K38  */  be_nested_str_weak(wifi),
+    /* K39  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K40  */  be_nested_str_weak(_X7C),
     }),
-    be_str_weak(load_param),
+    be_str_weak(mdns_announce_PASE),
     &be_const_str_solidified,
-    ( &(const binstruction[120]) {  /* code */
+    ( &(const binstruction[236]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA8020046,  //  0001  EXBLK	0	#0049
-      0x60080011,  //  0002  GETGBL	R2	G17
-      0x880C0101,  //  0003  GETMBR	R3	R0	K1
-      0x7C080200,  //  0004  CALL	R2	1
-      0x8C0C0502,  //  0005  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0x8C100503,  //  0007  GETMET	R4	R2	K3
-      0x7C100200,  //  0008  CALL	R4	1
-      0xA4120800,  //  0009  IMPORT	R4	K4
-      0x8C140905,  //  000A  GETMET	R5	R4	K5
-      0x5C1C0600,  //  000B  MOVE	R7	R3
-      0x7C140400,  //  000C  CALL	R5	2
-      0x8C180B07,  //  000D  GETMET	R6	R5	K7
-      0x58200008,  //  000E  LDCONST	R8	K8
-      0x88240106,  //  000F  GETMBR	R9	R0	K6
-      0x7C180600,  //  0010  CALL	R6	3
-      0x90020C06,  //  0011  SETMBR	R0	K6	R6
-      0x8C180B07,  //  0012  GETMET	R6	R5	K7
-      0x5820000A,  //  0013  LDCONST	R8	K10
-      0x88240109,  //  0014  GETMBR	R9	R0	K9
-      0x7C180600,  //  0015  CALL	R6	3
-      0x90021206,  //  0016  SETMBR	R0	K9	R6
-      0x60180017,  //  0017  GETGBL	R6	G23
-      0x8C1C0B07,  //  0018  GETMET	R7	R5	K7
-      0x5824000B,  //  0019  LDCONST	R9	K11
-      0x50280000,  //  001A  LDBOOL	R10	0	0
-      0x7C1C0600,  //  001B  CALL	R7	3
-      0x7C180200,  //  001C  CALL	R6	1
-      0x90021606,  //  001D  SETMBR	R0	K11	R6
-      0x8C180B07,  //  001E  GETMET	R6	R5	K7
-      0x5820000D,  //  001F  LDCONST	R8	K13
-      0x8824010C,  //  0020  GETMBR	R9	R0	K12
-      0x7C180600,  //  0021  CALL	R6	3
-      0x90021806,  //  0022  SETMBR	R0	K12	R6
-      0x8C180B07,  //  0023  GETMET	R6	R5	K7
-      0x5820000F,  //  0024  LDCONST	R8	K15
-      0x7C180400,  //  0025  CALL	R6	2
-      0x90021C06,  //  0026  SETMBR	R0	K14	R6
-      0x8818010E,  //  0027  GETMBR	R6	R0	K14
-      0x4C1C0000,  //  0028  LDNIL	R7
-      0x20180C07,  //  0029  NE	R6	R6	R7
-      0x781A000B,  //  002A  JMPF	R6	#0037
-      0xB81A2000,  //  002B  GETNGBL	R6	K16
-      0x8C180D11,  //  002C  GETMET	R6	R6	K17
-      0x60200008,  //  002D  GETGBL	R8	G8
-      0x8824010E,  //  002E  GETMBR	R9	R0	K14
-      0x7C200200,  //  002F  CALL	R8	1
-      0x00222408,  //  0030  ADD	R8	K18	R8
-      0x58240013,  //  0031  LDCONST	R9	K19
-      0x7C180600,  //  0032  CALL	R6	3
-      0x8C180114,  //  0033  GETMET	R6	R0	K20
-      0x7C180200,  //  0034  CALL	R6	1
-      0x50180200,  //  0035  LDBOOL	R6	1	0
-      0x90022A06,  //  0036  SETMBR	R0	K21	R6
-      0x8C180B07,  //  0037  GETMET	R6	R5	K7
-      0x58200017,  //  0038  LDCONST	R8	K23
-      0x60240013,  //  0039  GETGBL	R9	G19
-      0x7C240000,  //  003A  CALL	R9	0
-      0x7C180600,  //  003B  CALL	R6	3
-      0x90022C06,  //  003C  SETMBR	R0	K22	R6
-      0x88180116,  //  003D  GETMBR	R6	R0	K22
-      0x781A0007,  //  003E  JMPF	R6	#0047
-      0xB81A2000,  //  003F  GETNGBL	R6	K16
-      0x8C180D11,  //  0040  GETMET	R6	R6	K17
-      0x60200008,  //  0041  GETGBL	R8	G8
-      0x88240116,  //  0042  GETMBR	R9	R0	K22
-      0x7C200200,  //  0043  CALL	R8	1
-      0x00223008,  //  0044  ADD	R8	K24	R8
-      0x58240013,  //  0045  LDCONST	R9	K19
-      0x7C180600,  //  0046  CALL	R6	3
-      0xA8040001,  //  0047  EXBLK	1	1
-      0x70020012,  //  0048  JMP		#005C
-      0xAC080002,  //  0049  CATCH	R2	0	2
-      0x7002000F,  //  004A  JMP		#005B
-      0x20100519,  //  004B  NE	R4	R2	K25
-      0x7812000C,  //  004C  JMPF	R4	#005A
-      0xB8122000,  //  004D  GETNGBL	R4	K16
-      0x8C100911,  //  004E  GETMET	R4	R4	K17
-      0x60180008,  //  004F  GETGBL	R6	G8
-      0x5C1C0400,  //  0050  MOVE	R7	R2
-      0x7C180200,  //  0051  CALL	R6	1
-      0x001A3406,  //  0052  ADD	R6	K26	R6
-      0x00180D1B,  //  0053  ADD	R6	R6	K27
-      0x601C0008,  //  0054  GETGBL	R7	G8
-      0x5C200600,  //  0055  MOVE	R8	R3
-      0x7C1C0200,  //  0056  CALL	R7	1
-      0x00180C07,  //  0057  ADD	R6	R6	R7
-      0x581C001C,  //  0058  LDCONST	R7	K28
-      0x7C100600,  //  0059  CALL	R4	3
-      0x70020000,  //  005A  JMP		#005C
-      0xB0080000,  //  005B  RAISE	2	R0	R0
-      0x50080000,  //  005C  LDBOOL	R2	0	0
-      0x880C0106,  //  005D  GETMBR	R3	R0	K6
-      0x4C100000,  //  005E  LDNIL	R4
-      0x1C0C0604,  //  005F  EQ	R3	R3	R4
-      0x780E000A,  //  0060  JMPF	R3	#006C
-      0x8C0C031D,  //  0061  GETMET	R3	R1	K29
-      0x5814001C,  //  0062  LDCONST	R5	K28
-      0x7C0C0400,  //  0063  CALL	R3	2
-      0x8C0C071E,  //  0064  GETMET	R3	R3	K30
-      0x5814001F,  //  0065  LDCONST	R5	K31
-      0x5818001C,  //  0066  LDCONST	R6	K28
-      0x7C0C0600,  //  0067  CALL	R3	3
-      0x54120FFE,  //  0068  LDINT	R4	4095
-      0x2C0C0604,  //  0069  AND	R3	R3	R4
-      0x90020C03,  //  006A  SETMBR	R0	K6	R3
-      0x50080200,  //  006B  LDBOOL	R2	1	0
-      0x880C0109,  //  006C  GETMBR	R3	R0	K9
-      0x4C100000,  //  006D  LDNIL	R4
-      0x1C0C0604,  //  006E  EQ	R3	R3	R4
-      0x780E0003,  //  006F  JMPF	R3	#0074
-      0x8C0C0120,  //  0070  GETMET	R3	R0	K32
-      0x7C0C0200,  //  0071  CALL	R3	1
-      0x90021203,  //  0072  SETMBR	R0	K9	R3
-      0x50080200,  //  0073  LDBOOL	R2	1	0
-      0x780A0001,  //  0074  JMPF	R2	#0077
-      0x8C0C0121,  //  0075  GETMET	R3	R0	K33
-      0x7C0C0200,  //  0076  CALL	R3	1
-      0x80000000,  //  0077  RET	0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0x600C0013,  //  0002  GETGBL	R3	G19
+      0x7C0C0000,  //  0003  CALL	R3	0
+      0x60100008,  //  0004  GETGBL	R4	G8
+      0x88140103,  //  0005  GETMBR	R5	R0	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x00100904,  //  0007  ADD	R4	R4	K4
+      0x60140008,  //  0008  GETGBL	R5	G8
+      0x88180105,  //  0009  GETMBR	R6	R0	K5
+      0x7C140200,  //  000A  CALL	R5	1
+      0x00100805,  //  000B  ADD	R4	R4	R5
+      0x980E0404,  //  000C  SETIDX	R3	K2	R4
+      0x88100107,  //  000D  GETMBR	R4	R0	K7
+      0x980E0C04,  //  000E  SETIDX	R3	K6	R4
+      0x980E1109,  //  000F  SETIDX	R3	K8	K9
+      0x980E150B,  //  0010  SETIDX	R3	K10	K11
+      0x54121387,  //  0011  LDINT	R4	5000
+      0x980E1804,  //  0012  SETIDX	R3	K12	R4
+      0x5412012B,  //  0013  LDINT	R4	300
+      0x980E1A04,  //  0014  SETIDX	R3	K13	R4
+      0x8C10050F,  //  0015  GETMET	R4	R2	K15
+      0x541A0007,  //  0016  LDINT	R6	8
+      0x7C100400,  //  0017  CALL	R4	2
+      0x8C100910,  //  0018  GETMET	R4	R4	K16
+      0x7C100200,  //  0019  CALL	R4	1
+      0x90021C04,  //  001A  SETMBR	R0	K14	R4
+      0x8C10050F,  //  001B  GETMET	R4	R2	K15
+      0x541A0007,  //  001C  LDINT	R6	8
+      0x7C100400,  //  001D  CALL	R4	2
+      0x8C100910,  //  001E  GETMET	R4	R4	K16
+      0x7C100200,  //  001F  CALL	R4	1
+      0x90022204,  //  0020  SETMBR	R0	K17	R4
+      0xA80200B7,  //  0021  EXBLK	0	#00DA
+      0x88100112,  //  0022  GETMBR	R4	R0	K18
+      0x78120058,  //  0023  JMPF	R4	#007D
+      0x8C100313,  //  0024  GETMET	R4	R1	K19
+      0x58180014,  //  0025  LDCONST	R6	K20
+      0x581C0015,  //  0026  LDCONST	R7	K21
+      0x542215A3,  //  0027  LDINT	R8	5540
+      0x5C240600,  //  0028  MOVE	R9	R3
+      0x88280111,  //  0029  GETMBR	R10	R0	K17
+      0x882C0112,  //  002A  GETMBR	R11	R0	K18
+      0x7C100E00,  //  002B  CALL	R4	7
+      0x50100200,  //  002C  LDBOOL	R4	1	0
+      0x90022C04,  //  002D  SETMBR	R0	K22	R4
+      0xB8122E00,  //  002E  GETNGBL	R4	K23
+      0x8C100918,  //  002F  GETMET	R4	R4	K24
+      0x60180018,  //  0030  GETGBL	R6	G24
+      0x581C0019,  //  0031  LDCONST	R7	K25
+      0x5820001A,  //  0032  LDCONST	R8	K26
+      0x88240111,  //  0033  GETMBR	R9	R0	K17
+      0x88280112,  //  0034  GETMBR	R10	R0	K18
+      0x7C180800,  //  0035  CALL	R6	4
+      0x581C001B,  //  0036  LDCONST	R7	K27
+      0x7C100600,  //  0037  CALL	R4	3
+      0x60100008,  //  0038  GETGBL	R4	G8
+      0x88140107,  //  0039  GETMBR	R5	R0	K7
+      0x541A0FFE,  //  003A  LDINT	R6	4095
+      0x2C140A06,  //  003B  AND	R5	R5	R6
+      0x7C100200,  //  003C  CALL	R4	1
+      0x00123804,  //  003D  ADD	R4	K28	R4
+      0xB8162E00,  //  003E  GETNGBL	R5	K23
+      0x8C140B18,  //  003F  GETMET	R5	R5	K24
+      0x001E3A04,  //  0040  ADD	R7	K29	R4
+      0x5820001E,  //  0041  LDCONST	R8	K30
+      0x7C140600,  //  0042  CALL	R5	3
+      0x8C14031F,  //  0043  GETMET	R5	R1	K31
+      0x581C0014,  //  0044  LDCONST	R7	K20
+      0x58200015,  //  0045  LDCONST	R8	K21
+      0x88240111,  //  0046  GETMBR	R9	R0	K17
+      0x88280112,  //  0047  GETMBR	R10	R0	K18
+      0x5C2C0800,  //  0048  MOVE	R11	R4
+      0x7C140C00,  //  0049  CALL	R5	6
+      0x60140008,  //  004A  GETGBL	R5	G8
+      0x88180107,  //  004B  GETMBR	R6	R0	K7
+      0x541E0EFF,  //  004C  LDINT	R7	3840
+      0x2C180C07,  //  004D  AND	R6	R6	R7
+      0x541E0007,  //  004E  LDINT	R7	8
+      0x3C180C07,  //  004F  SHR	R6	R6	R7
+      0x7C140200,  //  0050  CALL	R5	1
+      0x00164005,  //  0051  ADD	R5	K32	R5
+      0x5C100A00,  //  0052  MOVE	R4	R5
+      0xB8162E00,  //  0053  GETNGBL	R5	K23
+      0x8C140B18,  //  0054  GETMET	R5	R5	K24
+      0x001E3A04,  //  0055  ADD	R7	K29	R4
+      0x5820001E,  //  0056  LDCONST	R8	K30
+      0x7C140600,  //  0057  CALL	R5	3
+      0x8C14031F,  //  0058  GETMET	R5	R1	K31
+      0x581C0014,  //  0059  LDCONST	R7	K20
+      0x58200015,  //  005A  LDCONST	R8	K21
+      0x88240111,  //  005B  GETMBR	R9	R0	K17
+      0x88280112,  //  005C  GETMBR	R10	R0	K18
+      0x5C2C0800,  //  005D  MOVE	R11	R4
+      0x7C140C00,  //  005E  CALL	R5	6
+      0x60140008,  //  005F  GETGBL	R5	G8
+      0x88180103,  //  0060  GETMBR	R6	R0	K3
+      0x7C140200,  //  0061  CALL	R5	1
+      0x00164205,  //  0062  ADD	R5	K33	R5
+      0x5C100A00,  //  0063  MOVE	R4	R5
+      0xB8162E00,  //  0064  GETNGBL	R5	K23
+      0x8C140B18,  //  0065  GETMET	R5	R5	K24
+      0x001E3A04,  //  0066  ADD	R7	K29	R4
+      0x5820001E,  //  0067  LDCONST	R8	K30
+      0x7C140600,  //  0068  CALL	R5	3
+      0x8C14031F,  //  0069  GETMET	R5	R1	K31
+      0x581C0014,  //  006A  LDCONST	R7	K20
+      0x58200015,  //  006B  LDCONST	R8	K21
+      0x88240111,  //  006C  GETMBR	R9	R0	K17
+      0x88280112,  //  006D  GETMBR	R10	R0	K18
+      0x5C2C0800,  //  006E  MOVE	R11	R4
+      0x7C140C00,  //  006F  CALL	R5	6
+      0x58100022,  //  0070  LDCONST	R4	K34
+      0xB8162E00,  //  0071  GETNGBL	R5	K23
+      0x8C140B18,  //  0072  GETMET	R5	R5	K24
+      0x001E3A04,  //  0073  ADD	R7	K29	R4
+      0x5820001E,  //  0074  LDCONST	R8	K30
+      0x7C140600,  //  0075  CALL	R5	3
+      0x8C14031F,  //  0076  GETMET	R5	R1	K31
+      0x581C0014,  //  0077  LDCONST	R7	K20
+      0x58200015,  //  0078  LDCONST	R8	K21
+      0x88240111,  //  0079  GETMBR	R9	R0	K17
+      0x88280112,  //  007A  GETMBR	R10	R0	K18
+      0x5C2C0800,  //  007B  MOVE	R11	R4
+      0x7C140C00,  //  007C  CALL	R5	6
+      0x88100123,  //  007D  GETMBR	R4	R0	K35
+      0x78120058,  //  007E  JMPF	R4	#00D8
+      0x8C100313,  //  007F  GETMET	R4	R1	K19
+      0x58180014,  //  0080  LDCONST	R6	K20
+      0x581C0015,  //  0081  LDCONST	R7	K21
+      0x542215A3,  //  0082  LDINT	R8	5540
+      0x5C240600,  //  0083  MOVE	R9	R3
+      0x8828010E,  //  0084  GETMBR	R10	R0	K14
+      0x882C0123,  //  0085  GETMBR	R11	R0	K35
+      0x7C100E00,  //  0086  CALL	R4	7
+      0x50100200,  //  0087  LDBOOL	R4	1	0
+      0x90024804,  //  0088  SETMBR	R0	K36	R4
+      0xB8122E00,  //  0089  GETNGBL	R4	K23
+      0x8C100918,  //  008A  GETMET	R4	R4	K24
+      0x60180018,  //  008B  GETGBL	R6	G24
+      0x581C0025,  //  008C  LDCONST	R7	K37
+      0x58200026,  //  008D  LDCONST	R8	K38
+      0x8824010E,  //  008E  GETMBR	R9	R0	K14
+      0x88280123,  //  008F  GETMBR	R10	R0	K35
+      0x7C180800,  //  0090  CALL	R6	4
+      0x581C001E,  //  0091  LDCONST	R7	K30
+      0x7C100600,  //  0092  CALL	R4	3
+      0x60100008,  //  0093  GETGBL	R4	G8
+      0x88140107,  //  0094  GETMBR	R5	R0	K7
+      0x541A0FFE,  //  0095  LDINT	R6	4095
+      0x2C140A06,  //  0096  AND	R5	R5	R6
+      0x7C100200,  //  0097  CALL	R4	1
+      0x00123804,  //  0098  ADD	R4	K28	R4
+      0xB8162E00,  //  0099  GETNGBL	R5	K23
+      0x8C140B18,  //  009A  GETMET	R5	R5	K24
+      0x001E3A04,  //  009B  ADD	R7	K29	R4
+      0x5820001E,  //  009C  LDCONST	R8	K30
+      0x7C140600,  //  009D  CALL	R5	3
+      0x8C14031F,  //  009E  GETMET	R5	R1	K31
+      0x581C0014,  //  009F  LDCONST	R7	K20
+      0x58200015,  //  00A0  LDCONST	R8	K21
+      0x8824010E,  //  00A1  GETMBR	R9	R0	K14
+      0x88280123,  //  00A2  GETMBR	R10	R0	K35
+      0x5C2C0800,  //  00A3  MOVE	R11	R4
+      0x7C140C00,  //  00A4  CALL	R5	6
+      0x60140008,  //  00A5  GETGBL	R5	G8
+      0x88180107,  //  00A6  GETMBR	R6	R0	K7
+      0x541E0EFF,  //  00A7  LDINT	R7	3840
+      0x2C180C07,  //  00A8  AND	R6	R6	R7
+      0x541E0007,  //  00A9  LDINT	R7	8
+      0x3C180C07,  //  00AA  SHR	R6	R6	R7
+      0x7C140200,  //  00AB  CALL	R5	1
+      0x00164005,  //  00AC  ADD	R5	K32	R5
+      0x5C100A00,  //  00AD  MOVE	R4	R5
+      0xB8162E00,  //  00AE  GETNGBL	R5	K23
+      0x8C140B18,  //  00AF  GETMET	R5	R5	K24
+      0x001E3A04,  //  00B0  ADD	R7	K29	R4
+      0x5820001E,  //  00B1  LDCONST	R8	K30
+      0x7C140600,  //  00B2  CALL	R5	3
+      0x8C14031F,  //  00B3  GETMET	R5	R1	K31
+      0x581C0014,  //  00B4  LDCONST	R7	K20
+      0x58200015,  //  00B5  LDCONST	R8	K21
+      0x8824010E,  //  00B6  GETMBR	R9	R0	K14
+      0x88280123,  //  00B7  GETMBR	R10	R0	K35
+      0x5C2C0800,  //  00B8  MOVE	R11	R4
+      0x7C140C00,  //  00B9  CALL	R5	6
+      0x60140008,  //  00BA  GETGBL	R5	G8
+      0x88180103,  //  00BB  GETMBR	R6	R0	K3
+      0x7C140200,  //  00BC  CALL	R5	1
+      0x00164205,  //  00BD  ADD	R5	K33	R5
+      0x5C100A00,  //  00BE  MOVE	R4	R5
+      0xB8162E00,  //  00BF  GETNGBL	R5	K23
+      0x8C140B18,  //  00C0  GETMET	R5	R5	K24
+      0x001E3A04,  //  00C1  ADD	R7	K29	R4
+      0x5820001E,  //  00C2  LDCONST	R8	K30
+      0x7C140600,  //  00C3  CALL	R5	3
+      0x8C14031F,  //  00C4  GETMET	R5	R1	K31
+      0x581C0014,  //  00C5  LDCONST	R7	K20
+      0x58200015,  //  00C6  LDCONST	R8	K21
+      0x8824010E,  //  00C7  GETMBR	R9	R0	K14
+      0x88280123,  //  00C8  GETMBR	R10	R0	K35
+      0x5C2C0800,  //  00C9  MOVE	R11	R4
+      0x7C140C00,  //  00CA  CALL	R5	6
+      0x58100022,  //  00CB  LDCONST	R4	K34
+      0xB8162E00,  //  00CC  GETNGBL	R5	K23
+      0x8C140B18,  //  00CD  GETMET	R5	R5	K24
+      0x001E3A04,  //  00CE  ADD	R7	K29	R4
+      0x5820001E,  //  00CF  LDCONST	R8	K30
+      0x7C140600,  //  00D0  CALL	R5	3
+      0x8C14031F,  //  00D1  GETMET	R5	R1	K31
+      0x581C0014,  //  00D2  LDCONST	R7	K20
+      0x58200015,  //  00D3  LDCONST	R8	K21
+      0x8824010E,  //  00D4  GETMBR	R9	R0	K14
+      0x88280123,  //  00D5  GETMBR	R10	R0	K35
+      0x5C2C0800,  //  00D6  MOVE	R11	R4
+      0x7C140C00,  //  00D7  CALL	R5	6
+      0xA8040001,  //  00D8  EXBLK	1	1
+      0x70020010,  //  00D9  JMP		#00EB
+      0xAC100002,  //  00DA  CATCH	R4	0	2
+      0x7002000D,  //  00DB  JMP		#00EA
+      0xB81A2E00,  //  00DC  GETNGBL	R6	K23
+      0x8C180D18,  //  00DD  GETMET	R6	R6	K24
+      0x60200008,  //  00DE  GETGBL	R8	G8
+      0x5C240800,  //  00DF  MOVE	R9	R4
+      0x7C200200,  //  00E0  CALL	R8	1
+      0x00224E08,  //  00E1  ADD	R8	K39	R8
+      0x00201128,  //  00E2  ADD	R8	R8	K40
+      0x60240008,  //  00E3  GETGBL	R9	G8
+      0x5C280A00,  //  00E4  MOVE	R10	R5
+      0x7C240200,  //  00E5  CALL	R9	1
+      0x00201009,  //  00E6  ADD	R8	R8	R9
+      0x5824001B,  //  00E7  LDCONST	R9	K27
+      0x7C180600,  //  00E8  CALL	R6	3
+      0x70020000,  //  00E9  JMP		#00EB
+      0xB0080000,  //  00EA  RAISE	2	R0	R0
+      0x80000000,  //  00EB  RET	0
     })
   )
 );
@@ -4683,11 +3846,65 @@ be_local_closure(Matter_Device_load_param,   /* name */
 
 
 /********************************************************************
-** Solidified function: mdns_announce_op_discovery
+** Solidified function: conf_to_log
 ********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
+be_local_closure(Matter_Device_conf_to_log,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    9,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Device),
+    /* K1   */  be_nested_str_weak(),
+    /* K2   */  be_nested_str_weak(k2l),
+    /* K3   */  be_nested_str_weak(type),
+    /* K4   */  be_nested_str_weak(_X20_X25s_X3A_X25s),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(conf_to_log),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x58080001,  //  0001  LDCONST	R2	K1
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x8C100302,  //  0003  GETMET	R4	R1	K2
+      0x5C180000,  //  0004  MOVE	R6	R0
+      0x7C100400,  //  0005  CALL	R4	2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0xA802000B,  //  0007  EXBLK	0	#0014
+      0x5C100600,  //  0008  MOVE	R4	R3
+      0x7C100000,  //  0009  CALL	R4	0
+      0x1C140903,  //  000A  EQ	R5	R4	K3
+      0x78160000,  //  000B  JMPF	R5	#000D
+      0x7001FFFA,  //  000C  JMP		#0008
+      0x60140018,  //  000D  GETGBL	R5	G24
+      0x58180004,  //  000E  LDCONST	R6	K4
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x94200004,  //  0010  GETIDX	R8	R0	R4
+      0x7C140600,  //  0011  CALL	R5	3
+      0x00080405,  //  0012  ADD	R2	R2	R5
+      0x7001FFF3,  //  0013  JMP		#0008
+      0x580C0005,  //  0014  LDCONST	R3	K5
+      0xAC0C0200,  //  0015  CATCH	R3	1	0
+      0xB0080000,  //  0016  RAISE	2	R0	R0
+      0x80040400,  //  0017  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_operational_discovery
+********************************************************************/
+be_local_closure(Matter_Device_start_operational_discovery,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -4695,7 +3912,521 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(mdns),
+    /* K2   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K3   */  be_nested_str_weak(root_w0),
+    /* K4   */  be_nested_str_weak(root_L),
+    /* K5   */  be_nested_str_weak(mdns_announce_op_discovery),
+    }),
+    be_str_weak(start_operational_discovery),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0x8C100102,  //  0002  GETMET	R4	R0	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x4C100000,  //  0004  LDNIL	R4
+      0x90020604,  //  0005  SETMBR	R0	K3	R4
+      0x4C100000,  //  0006  LDNIL	R4
+      0x90020804,  //  0007  SETMBR	R0	K4	R4
+      0x8C100105,  //  0008  GETMET	R4	R0	K5
+      0x5C180200,  //  0009  MOVE	R6	R1
+      0x7C100400,  //  000A  CALL	R4	2
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_remove_op_discovery_all_fabrics
+********************************************************************/
+be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(active_fabrics),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(mdns_remove_op_discovery_all_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000B,  //  0005  EXBLK	0	#0012
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x780E0005,  //  000A  JMPF	R3	#0011
+      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x780E0002,  //  000D  JMPF	R3	#0011
+      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x7001FFF3,  //  0011  JMP		#0006
+      0x58040005,  //  0012  LDCONST	R1	K5
+      0xAC040200,  //  0013  CATCH	R1	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_fabrics_saved
+********************************************************************/
+be_local_closure(Matter_Device_event_fabrics_saved,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(count_active_fabrics),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(plugins_persist),
+    /* K4   */  be_nested_str_weak(save_param),
+    }),
+    be_str_weak(event_fabrics_saved),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x24040302,  //  0003  GT	R1	R1	K2
+      0x78060005,  //  0004  JMPF	R1	#000B
+      0x88040103,  //  0005  GETMBR	R1	R0	K3
+      0x74060003,  //  0006  JMPT	R1	#000B
+      0x50040200,  //  0007  LDBOOL	R1	1	0
+      0x90020601,  //  0008  SETMBR	R0	K3	R1
+      0x8C040104,  //  0009  GETMET	R1	R0	K4
+      0x7C040200,  //  000A  CALL	R1	1
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_active_endpoints
+********************************************************************/
+be_local_closure(Matter_Device_get_active_endpoints,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins),
+    /* K1   */  be_nested_str_weak(get_endpoint),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(find),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(get_active_endpoints),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x88100100,  //  0003  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0xA8020011,  //  0005  EXBLK	0	#0018
+      0x5C100600,  //  0006  MOVE	R4	R3
+      0x7C100000,  //  0007  CALL	R4	0
+      0x8C140901,  //  0008  GETMET	R5	R4	K1
+      0x7C140200,  //  0009  CALL	R5	1
+      0x78060002,  //  000A  JMPF	R1	#000E
+      0x1C180B02,  //  000B  EQ	R6	R5	K2
+      0x781A0000,  //  000C  JMPF	R6	#000E
+      0x7001FFF7,  //  000D  JMP		#0006
+      0x8C180503,  //  000E  GETMET	R6	R2	K3
+      0x5C200A00,  //  000F  MOVE	R8	R5
+      0x7C180400,  //  0010  CALL	R6	2
+      0x4C1C0000,  //  0011  LDNIL	R7
+      0x1C180C07,  //  0012  EQ	R6	R6	R7
+      0x781A0002,  //  0013  JMPF	R6	#0017
+      0x8C180504,  //  0014  GETMET	R6	R2	K4
+      0x5C200A00,  //  0015  MOVE	R8	R5
+      0x7C180400,  //  0016  CALL	R6	2
+      0x7001FFED,  //  0017  JMP		#0006
+      0x580C0005,  //  0018  LDCONST	R3	K5
+      0xAC0C0200,  //  0019  CATCH	R3	1	0
+      0xB0080000,  //  001A  RAISE	2	R0	R0
+      0x80040400,  //  001B  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: received_ack
+********************************************************************/
+be_local_closure(Matter_Device_received_ack,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(received_ack),
+    }),
+    be_str_weak(received_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: msg_send
+********************************************************************/
+be_local_closure(Matter_Device_msg_send,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(send_UDP),
+    }),
+    be_str_weak(msg_send),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_param
+********************************************************************/
+be_local_closure(Matter_Device_save_param,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[31]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(update_remotes_info),
+    /* K2   */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22disable_bridge_mode_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
+    /* K3   */  be_nested_str_weak(root_discriminator),
+    /* K4   */  be_nested_str_weak(root_passcode),
+    /* K5   */  be_nested_str_weak(ipv4only),
+    /* K6   */  be_nested_str_weak(true),
+    /* K7   */  be_nested_str_weak(false),
+    /* K8   */  be_nested_str_weak(disable_bridge_mode),
+    /* K9   */  be_nested_str_weak(next_ep),
+    /* K10  */  be_nested_str_weak(plugins_persist),
+    /* K11  */  be_nested_str_weak(_X2C_X22config_X22_X3A),
+    /* K12  */  be_nested_str_weak(dump),
+    /* K13  */  be_nested_str_weak(plugins_config),
+    /* K14  */  be_nested_str_weak(plugins_config_remotes),
+    /* K15  */  be_const_int(0),
+    /* K16  */  be_nested_str_weak(_X2C_X22remotes_X22_X3A),
+    /* K17  */  be_nested_str_weak(_X7D),
+    /* K18  */  be_nested_str_weak(FILENAME),
+    /* K19  */  be_nested_str_weak(w),
+    /* K20  */  be_nested_str_weak(write),
+    /* K21  */  be_nested_str_weak(close),
+    /* K22  */  be_nested_str_weak(tasmota),
+    /* K23  */  be_nested_str_weak(log),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
+    /* K25  */  be_nested_str_weak(_X20and_X20configuration),
+    /* K26  */  be_nested_str_weak(),
+    /* K27  */  be_const_int(3),
+    /* K28  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+    /* K29  */  be_nested_str_weak(_X7C),
+    /* K30  */  be_const_int(2),
+    }),
+    be_str_weak(save_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[82]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080101,  //  0001  GETMET	R2	R0	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x60080018,  //  0003  GETGBL	R2	G24
+      0x580C0002,  //  0004  LDCONST	R3	K2
+      0x88100103,  //  0005  GETMBR	R4	R0	K3
+      0x88140104,  //  0006  GETMBR	R5	R0	K4
+      0x88180105,  //  0007  GETMBR	R6	R0	K5
+      0x781A0001,  //  0008  JMPF	R6	#000B
+      0x58180006,  //  0009  LDCONST	R6	K6
+      0x70020000,  //  000A  JMP		#000C
+      0x58180007,  //  000B  LDCONST	R6	K7
+      0x881C0108,  //  000C  GETMBR	R7	R0	K8
+      0x781E0001,  //  000D  JMPF	R7	#0010
+      0x581C0006,  //  000E  LDCONST	R7	K6
+      0x70020000,  //  000F  JMP		#0011
+      0x581C0007,  //  0010  LDCONST	R7	K7
+      0x88200109,  //  0011  GETMBR	R8	R0	K9
+      0x7C080C00,  //  0012  CALL	R2	6
+      0x880C010A,  //  0013  GETMBR	R3	R0	K10
+      0x780E000E,  //  0014  JMPF	R3	#0024
+      0x0008050B,  //  0015  ADD	R2	R2	K11
+      0x8C0C030C,  //  0016  GETMET	R3	R1	K12
+      0x8814010D,  //  0017  GETMBR	R5	R0	K13
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x00080403,  //  0019  ADD	R2	R2	R3
+      0x600C000C,  //  001A  GETGBL	R3	G12
+      0x8810010E,  //  001B  GETMBR	R4	R0	K14
+      0x7C0C0200,  //  001C  CALL	R3	1
+      0x240C070F,  //  001D  GT	R3	R3	K15
+      0x780E0004,  //  001E  JMPF	R3	#0024
+      0x00080510,  //  001F  ADD	R2	R2	K16
+      0x8C0C030C,  //  0020  GETMET	R3	R1	K12
+      0x8814010E,  //  0021  GETMBR	R5	R0	K14
+      0x7C0C0400,  //  0022  CALL	R3	2
+      0x00080403,  //  0023  ADD	R2	R2	R3
+      0x00080511,  //  0024  ADD	R2	R2	K17
+      0xA8020018,  //  0025  EXBLK	0	#003F
+      0x600C0011,  //  0026  GETGBL	R3	G17
+      0x88100112,  //  0027  GETMBR	R4	R0	K18
+      0x58140013,  //  0028  LDCONST	R5	K19
+      0x7C0C0400,  //  0029  CALL	R3	2
+      0x8C100714,  //  002A  GETMET	R4	R3	K20
+      0x5C180400,  //  002B  MOVE	R6	R2
+      0x7C100400,  //  002C  CALL	R4	2
+      0x8C100715,  //  002D  GETMET	R4	R3	K21
+      0x7C100200,  //  002E  CALL	R4	1
+      0xB8122C00,  //  002F  GETNGBL	R4	K22
+      0x8C100917,  //  0030  GETMET	R4	R4	K23
+      0x60180018,  //  0031  GETGBL	R6	G24
+      0x581C0018,  //  0032  LDCONST	R7	K24
+      0x8820010A,  //  0033  GETMBR	R8	R0	K10
+      0x78220001,  //  0034  JMPF	R8	#0037
+      0x58200019,  //  0035  LDCONST	R8	K25
+      0x70020000,  //  0036  JMP		#0038
+      0x5820001A,  //  0037  LDCONST	R8	K26
+      0x7C180400,  //  0038  CALL	R6	2
+      0x581C001B,  //  0039  LDCONST	R7	K27
+      0x7C100600,  //  003A  CALL	R4	3
+      0xA8040001,  //  003B  EXBLK	1	1
+      0x80040400,  //  003C  RET	1	R2
+      0xA8040001,  //  003D  EXBLK	1	1
+      0x70020011,  //  003E  JMP		#0051
+      0xAC0C0002,  //  003F  CATCH	R3	0	2
+      0x7002000E,  //  0040  JMP		#0050
+      0xB8162C00,  //  0041  GETNGBL	R5	K22
+      0x8C140B17,  //  0042  GETMET	R5	R5	K23
+      0x601C0008,  //  0043  GETGBL	R7	G8
+      0x5C200600,  //  0044  MOVE	R8	R3
+      0x7C1C0200,  //  0045  CALL	R7	1
+      0x001E3807,  //  0046  ADD	R7	K28	R7
+      0x001C0F1D,  //  0047  ADD	R7	R7	K29
+      0x60200008,  //  0048  GETGBL	R8	G8
+      0x5C240800,  //  0049  MOVE	R9	R4
+      0x7C200200,  //  004A  CALL	R8	1
+      0x001C0E08,  //  004B  ADD	R7	R7	R8
+      0x5820001E,  //  004C  LDCONST	R8	K30
+      0x7C140600,  //  004D  CALL	R5	3
+      0x80040400,  //  004E  RET	1	R2
+      0x70020000,  //  004F  JMP		#0051
+      0xB0080000,  //  0050  RAISE	2	R0	R0
+      0x80000000,  //  0051  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _compute_pbkdf
+********************************************************************/
+be_local_closure(Matter_Device__compute_pbkdf,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(add),
+    /* K2   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
+    /* K3   */  be_nested_str_weak(derive),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(root_w0),
+    /* K6   */  be_nested_str_weak(EC_P256),
+    /* K7   */  be_nested_str_weak(mod),
+    /* K8   */  be_nested_str_weak(root_L),
+    /* K9   */  be_nested_str_weak(public_key),
+    }),
+    be_str_weak(_compute_pbkdf),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0xA4120000,  //  0000  IMPORT	R4	K0
+      0x60140015,  //  0001  GETGBL	R5	G21
+      0x7C140000,  //  0002  CALL	R5	0
+      0x8C140B01,  //  0003  GETMET	R5	R5	K1
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x54220003,  //  0005  LDINT	R8	4
+      0x7C140600,  //  0006  CALL	R5	3
+      0x8C180902,  //  0007  GETMET	R6	R4	K2
+      0x7C180200,  //  0008  CALL	R6	1
+      0x8C180D03,  //  0009  GETMET	R6	R6	K3
+      0x5C200A00,  //  000A  MOVE	R8	R5
+      0x5C240600,  //  000B  MOVE	R9	R3
+      0x5C280400,  //  000C  MOVE	R10	R2
+      0x542E004F,  //  000D  LDINT	R11	80
+      0x7C180A00,  //  000E  CALL	R6	5
+      0x541E0026,  //  000F  LDINT	R7	39
+      0x401E0807,  //  0010  CONNECT	R7	K4	R7
+      0x941C0C07,  //  0011  GETIDX	R7	R6	R7
+      0x54220027,  //  0012  LDINT	R8	40
+      0x5426004E,  //  0013  LDINT	R9	79
+      0x40201009,  //  0014  CONNECT	R8	R8	R9
+      0x94200C08,  //  0015  GETIDX	R8	R6	R8
+      0x8C240906,  //  0016  GETMET	R9	R4	K6
+      0x7C240200,  //  0017  CALL	R9	1
+      0x8C241307,  //  0018  GETMET	R9	R9	K7
+      0x5C2C0E00,  //  0019  MOVE	R11	R7
+      0x7C240400,  //  001A  CALL	R9	2
+      0x90020A09,  //  001B  SETMBR	R0	K5	R9
+      0x8C240906,  //  001C  GETMET	R9	R4	K6
+      0x7C240200,  //  001D  CALL	R9	1
+      0x8C241307,  //  001E  GETMET	R9	R9	K7
+      0x5C2C1000,  //  001F  MOVE	R11	R8
+      0x7C240400,  //  0020  CALL	R9	2
+      0x8C280906,  //  0021  GETMET	R10	R4	K6
+      0x7C280200,  //  0022  CALL	R10	1
+      0x8C281509,  //  0023  GETMET	R10	R10	K9
+      0x5C301200,  //  0024  MOVE	R12	R9
+      0x7C280400,  //  0025  CALL	R10	2
+      0x9002100A,  //  0026  SETMBR	R0	K8	R10
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Device_every_second,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(every_second),
+    /* K2   */  be_nested_str_weak(message_handler),
+    /* K3   */  be_nested_str_weak(commissioning_open),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(time_reached),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040102,  //  0003  GETMBR	R1	R0	K2
+      0x8C040301,  //  0004  GETMET	R1	R1	K1
+      0x7C040200,  //  0005  CALL	R1	1
+      0x88040103,  //  0006  GETMBR	R1	R0	K3
+      0x4C080000,  //  0007  LDNIL	R2
+      0x20040202,  //  0008  NE	R1	R1	R2
+      0x78060006,  //  0009  JMPF	R1	#0011
+      0xB8060800,  //  000A  GETNGBL	R1	K4
+      0x8C040305,  //  000B  GETMET	R1	R1	K5
+      0x880C0103,  //  000C  GETMBR	R3	R0	K3
+      0x7C040400,  //  000D  CALL	R1	2
+      0x78060001,  //  000E  JMPF	R1	#0011
+      0x4C040000,  //  000F  LDNIL	R1
+      0x90020601,  //  0010  SETMBR	R0	K3	R1
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_remove_op_discovery
+********************************************************************/
+be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
     /* K1   */  be_nested_str_weak(get_device_id),
     /* K2   */  be_nested_str_weak(copy),
@@ -4704,31 +4435,27 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
     /* K5   */  be_nested_str_weak(tohex),
     /* K6   */  be_nested_str_weak(_X2D),
     /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(eth),
-    /* K12  */  be_nested_str_weak(find),
-    /* K13  */  be_nested_str_weak(up),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K15  */  be_nested_str_weak(hostname_eth),
-    /* K16  */  be_nested_str_weak(add_service),
-    /* K17  */  be_nested_str_weak(_matter),
-    /* K18  */  be_nested_str_weak(_tcp),
-    /* K19  */  be_nested_str_weak(_I),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
-    /* K21  */  be_nested_str_weak(add_subtype),
-    /* K22  */  be_nested_str_weak(wifi),
-    /* K23  */  be_nested_str_weak(hostname_wifi),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K25  */  be_nested_str_weak(_X7C),
-    /* K26  */  be_const_int(2),
+    /* K8   */  be_nested_str_weak(eth),
+    /* K9   */  be_nested_str_weak(find),
+    /* K10  */  be_nested_str_weak(up),
+    /* K11  */  be_nested_str_weak(log),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
+    /* K13  */  be_const_int(3),
+    /* K14  */  be_nested_str_weak(remove_service),
+    /* K15  */  be_nested_str_weak(_matter),
+    /* K16  */  be_nested_str_weak(_tcp),
+    /* K17  */  be_nested_str_weak(hostname_eth),
+    /* K18  */  be_nested_str_weak(wifi),
+    /* K19  */  be_nested_str_weak(hostname_wifi),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K21  */  be_nested_str_weak(_X7C),
+    /* K22  */  be_const_int(2),
     }),
-    be_str_weak(mdns_announce_op_discovery),
+    be_str_weak(mdns_remove_op_discovery),
     &be_const_str_solidified,
-    ( &(const binstruction[121]) {  /* code */
+    ( &(const binstruction[80]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA8020064,  //  0001  EXBLK	0	#0067
+      0xA802003B,  //  0001  EXBLK	0	#003E
       0x8C0C0301,  //  0002  GETMET	R3	R1	K1
       0x7C0C0200,  //  0003  CALL	R3	1
       0x8C0C0702,  //  0004  GETMET	R3	R3	K2
@@ -4745,205 +4472,68 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
       0x00140A06,  //  000F  ADD	R5	R5	R6
       0xB81A0E00,  //  0010  GETNGBL	R6	K7
       0x8C180D08,  //  0011  GETMET	R6	R6	K8
-      0x00221205,  //  0012  ADD	R8	K9	R5
-      0x5824000A,  //  0013  LDCONST	R9	K10
-      0x7C180600,  //  0014  CALL	R6	3
-      0xB81A0E00,  //  0015  GETNGBL	R6	K7
-      0x8C180D0B,  //  0016  GETMET	R6	R6	K11
-      0x7C180200,  //  0017  CALL	R6	1
-      0x8C180D0C,  //  0018  GETMET	R6	R6	K12
-      0x5820000D,  //  0019  LDCONST	R8	K13
-      0x7C180400,  //  001A  CALL	R6	2
-      0x781A0020,  //  001B  JMPF	R6	#003D
-      0xB81A0E00,  //  001C  GETNGBL	R6	K7
-      0x8C180D08,  //  001D  GETMET	R6	R6	K8
-      0x60200018,  //  001E  GETGBL	R8	G24
-      0x5824000E,  //  001F  LDCONST	R9	K14
-      0x5828000B,  //  0020  LDCONST	R10	K11
-      0x5C2C0A00,  //  0021  MOVE	R11	R5
-      0x8830010F,  //  0022  GETMBR	R12	R0	K15
-      0x7C200800,  //  0023  CALL	R8	4
-      0x5824000A,  //  0024  LDCONST	R9	K10
-      0x7C180600,  //  0025  CALL	R6	3
-      0x8C180510,  //  0026  GETMET	R6	R2	K16
-      0x58200011,  //  0027  LDCONST	R8	K17
-      0x58240012,  //  0028  LDCONST	R9	K18
-      0x542A15A3,  //  0029  LDINT	R10	5540
-      0x4C2C0000,  //  002A  LDNIL	R11
-      0x5C300A00,  //  002B  MOVE	R12	R5
-      0x8834010F,  //  002C  GETMBR	R13	R0	K15
-      0x7C180E00,  //  002D  CALL	R6	7
-      0x8C180905,  //  002E  GETMET	R6	R4	K5
-      0x7C180200,  //  002F  CALL	R6	1
-      0x001A2606,  //  0030  ADD	R6	K19	R6
-      0xB81E0E00,  //  0031  GETNGBL	R7	K7
-      0x8C1C0F08,  //  0032  GETMET	R7	R7	K8
-      0x00262806,  //  0033  ADD	R9	K20	R6
-      0x5828000A,  //  0034  LDCONST	R10	K10
-      0x7C1C0600,  //  0035  CALL	R7	3
-      0x8C1C0515,  //  0036  GETMET	R7	R2	K21
-      0x58240011,  //  0037  LDCONST	R9	K17
-      0x58280012,  //  0038  LDCONST	R10	K18
-      0x5C2C0A00,  //  0039  MOVE	R11	R5
-      0x8830010F,  //  003A  GETMBR	R12	R0	K15
-      0x5C340C00,  //  003B  MOVE	R13	R6
-      0x7C1C0C00,  //  003C  CALL	R7	6
-      0xB81A0E00,  //  003D  GETNGBL	R6	K7
-      0x8C180D16,  //  003E  GETMET	R6	R6	K22
-      0x7C180200,  //  003F  CALL	R6	1
-      0x8C180D0C,  //  0040  GETMET	R6	R6	K12
-      0x5820000D,  //  0041  LDCONST	R8	K13
-      0x7C180400,  //  0042  CALL	R6	2
-      0x781A0020,  //  0043  JMPF	R6	#0065
-      0xB81A0E00,  //  0044  GETNGBL	R6	K7
-      0x8C180D08,  //  0045  GETMET	R6	R6	K8
-      0x60200018,  //  0046  GETGBL	R8	G24
-      0x5824000E,  //  0047  LDCONST	R9	K14
-      0x58280016,  //  0048  LDCONST	R10	K22
-      0x5C2C0A00,  //  0049  MOVE	R11	R5
-      0x88300117,  //  004A  GETMBR	R12	R0	K23
-      0x7C200800,  //  004B  CALL	R8	4
-      0x5824000A,  //  004C  LDCONST	R9	K10
-      0x7C180600,  //  004D  CALL	R6	3
-      0x8C180510,  //  004E  GETMET	R6	R2	K16
-      0x58200011,  //  004F  LDCONST	R8	K17
-      0x58240012,  //  0050  LDCONST	R9	K18
-      0x542A15A3,  //  0051  LDINT	R10	5540
-      0x4C2C0000,  //  0052  LDNIL	R11
-      0x5C300A00,  //  0053  MOVE	R12	R5
-      0x88340117,  //  0054  GETMBR	R13	R0	K23
-      0x7C180E00,  //  0055  CALL	R6	7
-      0x8C180905,  //  0056  GETMET	R6	R4	K5
-      0x7C180200,  //  0057  CALL	R6	1
-      0x001A2606,  //  0058  ADD	R6	K19	R6
-      0xB81E0E00,  //  0059  GETNGBL	R7	K7
-      0x8C1C0F08,  //  005A  GETMET	R7	R7	K8
-      0x00262806,  //  005B  ADD	R9	K20	R6
-      0x5828000A,  //  005C  LDCONST	R10	K10
-      0x7C1C0600,  //  005D  CALL	R7	3
-      0x8C1C0515,  //  005E  GETMET	R7	R2	K21
-      0x58240011,  //  005F  LDCONST	R9	K17
-      0x58280012,  //  0060  LDCONST	R10	K18
-      0x5C2C0A00,  //  0061  MOVE	R11	R5
-      0x88300117,  //  0062  GETMBR	R12	R0	K23
-      0x5C340C00,  //  0063  MOVE	R13	R6
-      0x7C1C0C00,  //  0064  CALL	R7	6
-      0xA8040001,  //  0065  EXBLK	1	1
-      0x70020010,  //  0066  JMP		#0078
-      0xAC0C0002,  //  0067  CATCH	R3	0	2
-      0x7002000D,  //  0068  JMP		#0077
-      0xB8160E00,  //  0069  GETNGBL	R5	K7
-      0x8C140B08,  //  006A  GETMET	R5	R5	K8
-      0x601C0008,  //  006B  GETGBL	R7	G8
-      0x5C200600,  //  006C  MOVE	R8	R3
-      0x7C1C0200,  //  006D  CALL	R7	1
-      0x001E3007,  //  006E  ADD	R7	K24	R7
-      0x001C0F19,  //  006F  ADD	R7	R7	K25
-      0x60200008,  //  0070  GETGBL	R8	G8
-      0x5C240800,  //  0071  MOVE	R9	R4
-      0x7C200200,  //  0072  CALL	R8	1
-      0x001C0E08,  //  0073  ADD	R7	R7	R8
-      0x5820001A,  //  0074  LDCONST	R8	K26
-      0x7C140600,  //  0075  CALL	R5	3
-      0x70020000,  //  0076  JMP		#0078
-      0xB0080000,  //  0077  RAISE	2	R0	R0
-      0x80000000,  //  0078  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: generate_random_passcode
-********************************************************************/
-be_local_closure(Matter_Device_generate_random_passcode,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(random),
-    /* K2   */  be_nested_str_weak(get),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_const_int(134217727),
-    /* K5   */  be_const_int(99999998),
-    /* K6   */  be_nested_str_weak(PASSCODE_INVALID),
-    /* K7   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(generate_random_passcode),
-    &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x500C0200,  //  0002  LDBOOL	R3	1	0
-      0x780E001D,  //  0003  JMPF	R3	#0022
-      0x8C0C0301,  //  0004  GETMET	R3	R1	K1
-      0x54160003,  //  0005  LDINT	R5	4
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
-      0x58140003,  //  0008  LDCONST	R5	K3
-      0x541A0003,  //  0009  LDINT	R6	4
-      0x7C0C0600,  //  000A  CALL	R3	3
-      0x2C0C0704,  //  000B  AND	R3	R3	K4
-      0x5C080600,  //  000C  MOVE	R2	R3
-      0x240C0505,  //  000D  GT	R3	R2	K5
-      0x780E0000,  //  000E  JMPF	R3	#0010
-      0x7001FFF1,  //  000F  JMP		#0002
-      0x600C0010,  //  0010  GETGBL	R3	G16
-      0x88100106,  //  0011  GETMBR	R4	R0	K6
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0xA8020005,  //  0013  EXBLK	0	#001A
-      0x5C100600,  //  0014  MOVE	R4	R3
-      0x7C100000,  //  0015  CALL	R4	0
-      0x1C140404,  //  0016  EQ	R5	R2	R4
-      0x78160000,  //  0017  JMPF	R5	#0019
-      0x4C080000,  //  0018  LDNIL	R2
-      0x7001FFF9,  //  0019  JMP		#0014
-      0x580C0007,  //  001A  LDCONST	R3	K7
-      0xAC0C0200,  //  001B  CATCH	R3	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x4C0C0000,  //  001D  LDNIL	R3
-      0x200C0403,  //  001E  NE	R3	R2	R3
-      0x780E0000,  //  001F  JMPF	R3	#0021
-      0x80040400,  //  0020  RET	1	R2
-      0x7001FFDF,  //  0021  JMP		#0002
-      0x80000000,  //  0022  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_commissioning_open
-********************************************************************/
-be_local_closure(Matter_Device_is_commissioning_open,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    }),
-    be_str_weak(is_commissioning_open),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
+      0x7C180200,  //  0012  CALL	R6	1
+      0x8C180D09,  //  0013  GETMET	R6	R6	K9
+      0x5820000A,  //  0014  LDCONST	R8	K10
+      0x7C180400,  //  0015  CALL	R6	2
+      0x781A000E,  //  0016  JMPF	R6	#0026
+      0xB81A0E00,  //  0017  GETNGBL	R6	K7
+      0x8C180D0B,  //  0018  GETMET	R6	R6	K11
+      0x60200018,  //  0019  GETGBL	R8	G24
+      0x5824000C,  //  001A  LDCONST	R9	K12
+      0x58280008,  //  001B  LDCONST	R10	K8
+      0x5C2C0A00,  //  001C  MOVE	R11	R5
+      0x7C200600,  //  001D  CALL	R8	3
+      0x5824000D,  //  001E  LDCONST	R9	K13
+      0x7C180600,  //  001F  CALL	R6	3
+      0x8C18050E,  //  0020  GETMET	R6	R2	K14
+      0x5820000F,  //  0021  LDCONST	R8	K15
+      0x58240010,  //  0022  LDCONST	R9	K16
+      0x5C280A00,  //  0023  MOVE	R10	R5
+      0x882C0111,  //  0024  GETMBR	R11	R0	K17
+      0x7C180A00,  //  0025  CALL	R6	5
+      0xB81A0E00,  //  0026  GETNGBL	R6	K7
+      0x8C180D12,  //  0027  GETMET	R6	R6	K18
+      0x7C180200,  //  0028  CALL	R6	1
+      0x8C180D09,  //  0029  GETMET	R6	R6	K9
+      0x5820000A,  //  002A  LDCONST	R8	K10
+      0x7C180400,  //  002B  CALL	R6	2
+      0x781A000E,  //  002C  JMPF	R6	#003C
+      0xB81A0E00,  //  002D  GETNGBL	R6	K7
+      0x8C180D0B,  //  002E  GETMET	R6	R6	K11
+      0x60200018,  //  002F  GETGBL	R8	G24
+      0x5824000C,  //  0030  LDCONST	R9	K12
+      0x58280012,  //  0031  LDCONST	R10	K18
+      0x5C2C0A00,  //  0032  MOVE	R11	R5
+      0x7C200600,  //  0033  CALL	R8	3
+      0x5824000D,  //  0034  LDCONST	R9	K13
+      0x7C180600,  //  0035  CALL	R6	3
+      0x8C18050E,  //  0036  GETMET	R6	R2	K14
+      0x5820000F,  //  0037  LDCONST	R8	K15
+      0x58240010,  //  0038  LDCONST	R9	K16
+      0x5C280A00,  //  0039  MOVE	R10	R5
+      0x882C0113,  //  003A  GETMBR	R11	R0	K19
+      0x7C180A00,  //  003B  CALL	R6	5
+      0xA8040001,  //  003C  EXBLK	1	1
+      0x70020010,  //  003D  JMP		#004F
+      0xAC0C0002,  //  003E  CATCH	R3	0	2
+      0x7002000D,  //  003F  JMP		#004E
+      0xB8160E00,  //  0040  GETNGBL	R5	K7
+      0x8C140B0B,  //  0041  GETMET	R5	R5	K11
+      0x601C0008,  //  0042  GETGBL	R7	G8
+      0x5C200600,  //  0043  MOVE	R8	R3
+      0x7C1C0200,  //  0044  CALL	R7	1
+      0x001E2807,  //  0045  ADD	R7	K20	R7
+      0x001C0F15,  //  0046  ADD	R7	R7	K21
+      0x60200008,  //  0047  GETGBL	R8	G8
+      0x5C240800,  //  0048  MOVE	R9	R4
+      0x7C200200,  //  0049  CALL	R8	1
+      0x001C0E08,  //  004A  ADD	R7	R7	R8
+      0x58200016,  //  004B  LDCONST	R8	K22
+      0x7C140600,  //  004C  CALL	R5	3
+      0x70020000,  //  004D  JMP		#004F
+      0xB0080000,  //  004E  RAISE	2	R0	R0
+      0x80000000,  //  004F  RET	0
     })
   )
 );
@@ -5210,11 +4800,282 @@ be_local_closure(Matter_Device_autoconf_device_map,   /* name */
 
 
 /********************************************************************
-** Solidified function: start_mdns_announce_hostnames
+** Solidified function: start_operational_discovery_deferred
 ********************************************************************/
-be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
+be_local_closure(Matter_Device_start_operational_discovery_deferred,   /* name */
   be_nested_proto(
     6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        3,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 2]) {  /* upvals */
+          be_local_const_upval(1, 0),
+          be_local_const_upval(1, 1),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start_operational_discovery),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x68080001,  //  0002  GETUPV	R2	U1
+          0x7C000400,  //  0003  CALL	R0	2
+          0x80040000,  //  0004  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(set_timer),
+    /* K2   */  be_const_int(0),
+    }),
+    be_str_weak(start_operational_discovery_deferred),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x84140000,  //  0003  CLOSURE	R5	P0
+      0x7C080600,  //  0004  CALL	R2	3
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    8,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 4]) {     /* constants */
+        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0000,  //  0006  LDCONST	R3	K0
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 4]) {     /* constants */
+        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Eth_X23Connected),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0000,  //  0006  LDCONST	R3	K0
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(millis),
+    /* K3   */  be_nested_str_weak(commissioning_iterations),
+    /* K4   */  be_nested_str_weak(commissioning_discriminator),
+    /* K5   */  be_nested_str_weak(commissioning_salt),
+    /* K6   */  be_nested_str_weak(commissioning_w0),
+    /* K7   */  be_nested_str_weak(commissioning_L),
+    /* K8   */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K9   */  be_nested_str_weak(wifi),
+    /* K10  */  be_nested_str_weak(up),
+    /* K11  */  be_nested_str_weak(eth),
+    /* K12  */  be_nested_str_weak(mdns_announce_PASE),
+    /* K13  */  be_nested_str_weak(add_rule),
+    /* K14  */  be_nested_str_weak(Wifi_X23Connected),
+    /* K15  */  be_nested_str_weak(Eth_X23Connected),
+    }),
+    be_str_weak(start_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0xB8220200,  //  0000  GETNGBL	R8	K1
+      0x8C201102,  //  0001  GETMET	R8	R8	K2
+      0x7C200200,  //  0002  CALL	R8	1
+      0x542603E7,  //  0003  LDINT	R9	1000
+      0x08240209,  //  0004  MUL	R9	R1	R9
+      0x00201009,  //  0005  ADD	R8	R8	R9
+      0x90020008,  //  0006  SETMBR	R0	K0	R8
+      0x90020602,  //  0007  SETMBR	R0	K3	R2
+      0x90020803,  //  0008  SETMBR	R0	K4	R3
+      0x90020A04,  //  0009  SETMBR	R0	K5	R4
+      0x90020C05,  //  000A  SETMBR	R0	K6	R5
+      0x90020E06,  //  000B  SETMBR	R0	K7	R6
+      0x90021007,  //  000C  SETMBR	R0	K8	R7
+      0xB8220200,  //  000D  GETNGBL	R8	K1
+      0x8C201109,  //  000E  GETMET	R8	R8	K9
+      0x7C200200,  //  000F  CALL	R8	1
+      0x9420110A,  //  0010  GETIDX	R8	R8	K10
+      0x74220004,  //  0011  JMPT	R8	#0017
+      0xB8220200,  //  0012  GETNGBL	R8	K1
+      0x8C20110B,  //  0013  GETMET	R8	R8	K11
+      0x7C200200,  //  0014  CALL	R8	1
+      0x9420110A,  //  0015  GETIDX	R8	R8	K10
+      0x78220002,  //  0016  JMPF	R8	#001A
+      0x8C20010C,  //  0017  GETMET	R8	R0	K12
+      0x7C200200,  //  0018  CALL	R8	1
+      0x7002000B,  //  0019  JMP		#0026
+      0xB8220200,  //  001A  GETNGBL	R8	K1
+      0x8C20110D,  //  001B  GETMET	R8	R8	K13
+      0x5828000E,  //  001C  LDCONST	R10	K14
+      0x842C0000,  //  001D  CLOSURE	R11	P0
+      0x5830000C,  //  001E  LDCONST	R12	K12
+      0x7C200800,  //  001F  CALL	R8	4
+      0xB8220200,  //  0020  GETNGBL	R8	K1
+      0x8C20110D,  //  0021  GETMET	R8	R8	K13
+      0x5828000F,  //  0022  LDCONST	R10	K15
+      0x842C0001,  //  0023  CLOSURE	R11	P1
+      0x5830000C,  //  0024  LDCONST	R12	K12
+      0x7C200800,  //  0025  CALL	R8	4
+      0xA0000000,  //  0026  CLOSE	R0
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_native_classes
+********************************************************************/
+be_local_closure(Matter_Device_register_native_classes,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(introspect),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(members),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(get),
+    /* K5   */  be_nested_str_weak(class),
+    /* K6   */  be_nested_str_weak(find),
+    /* K7   */  be_nested_str_weak(Plugin_),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(register_plugin_class),
+    /* K10  */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(register_native_classes),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xA4120200,  //  0001  IMPORT	R4	K1
+      0x60140010,  //  0002  GETGBL	R5	G16
+      0x8C180702,  //  0003  GETMET	R6	R3	K2
+      0xB8220600,  //  0004  GETNGBL	R8	K3
+      0x7C180400,  //  0005  CALL	R6	2
+      0x7C140200,  //  0006  CALL	R5	1
+      0xA8020014,  //  0007  EXBLK	0	#001D
+      0x5C180A00,  //  0008  MOVE	R6	R5
+      0x7C180000,  //  0009  CALL	R6	0
+      0x8C1C0704,  //  000A  GETMET	R7	R3	K4
+      0xB8260600,  //  000B  GETNGBL	R9	K3
+      0x5C280C00,  //  000C  MOVE	R10	R6
+      0x7C1C0600,  //  000D  CALL	R7	3
+      0x60200004,  //  000E  GETGBL	R8	G4
+      0x5C240E00,  //  000F  MOVE	R9	R7
+      0x7C200200,  //  0010  CALL	R8	1
+      0x1C201105,  //  0011  EQ	R8	R8	K5
+      0x78220008,  //  0012  JMPF	R8	#001C
+      0x8C200906,  //  0013  GETMET	R8	R4	K6
+      0x5C280C00,  //  0014  MOVE	R10	R6
+      0x582C0007,  //  0015  LDCONST	R11	K7
+      0x7C200600,  //  0016  CALL	R8	3
+      0x1C201108,  //  0017  EQ	R8	R8	K8
+      0x78220002,  //  0018  JMPF	R8	#001C
+      0x8C200109,  //  0019  GETMET	R8	R0	K9
+      0x5C280E00,  //  001A  MOVE	R10	R7
+      0x7C200400,  //  001B  CALL	R8	2
+      0x7001FFEA,  //  001C  JMP		#0008
+      0x5814000A,  //  001D  LDCONST	R5	K10
+      0xAC140200,  //  001E  CATCH	R5	1	0
+      0xB0080000,  //  001F  RAISE	2	R0	R0
+      0x80000000,  //  0020  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Device_init,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -5233,25 +5094,24 @@ be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
+        /* K0   */  be_nested_str_weak(start),
         /* K1   */  be_nested_str_weak(tasmota),
         /* K2   */  be_nested_str_weak(remove_rule),
         /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_mdns_host),
+        /* K4   */  be_nested_str_weak(matter_start),
         }),
         be_str_weak(_anonymous_),
         &be_const_str_solidified,
-        ( &(const binstruction[10]) {  /* code */
+        ( &(const binstruction[ 9]) {  /* code */
           0x68000000,  //  0000  GETUPV	R0	U0
           0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x50080000,  //  0002  LDBOOL	R2	0	0
-          0x7C000400,  //  0003  CALL	R0	2
-          0xB8020200,  //  0004  GETNGBL	R0	K1
-          0x8C000102,  //  0005  GETMET	R0	R0	K2
-          0x58080003,  //  0006  LDCONST	R2	K3
-          0x580C0004,  //  0007  LDCONST	R3	K4
-          0x7C000600,  //  0008  CALL	R0	3
-          0x80000000,  //  0009  RET	0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0004,  //  0006  LDCONST	R3	K4
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
         })
       ),
       be_nested_proto(
@@ -5266,75 +5126,235 @@ be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
+        /* K0   */  be_nested_str_weak(start),
         /* K1   */  be_nested_str_weak(tasmota),
         /* K2   */  be_nested_str_weak(remove_rule),
         /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_mdns_host),
+        /* K4   */  be_nested_str_weak(matter_start),
         }),
         be_str_weak(_anonymous_),
         &be_const_str_solidified,
-        ( &(const binstruction[10]) {  /* code */
+        ( &(const binstruction[ 9]) {  /* code */
           0x68000000,  //  0000  GETUPV	R0	U0
           0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x50080200,  //  0002  LDBOOL	R2	1	0
-          0x7C000400,  //  0003  CALL	R0	2
-          0xB8020200,  //  0004  GETNGBL	R0	K1
-          0x8C000102,  //  0005  GETMET	R0	R0	K2
-          0x58080003,  //  0006  LDCONST	R2	K3
-          0x580C0004,  //  0007  LDCONST	R3	K4
-          0x7C000600,  //  0008  CALL	R0	3
-          0x80000000,  //  0009  RET	0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0004,  //  0006  LDCONST	R3	K4
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
         })
       ),
     }),
     1,                          /* has constants */
+    ( &(const bvalue[44]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(get_option),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(MATTER_OPTION),
+    /* K5   */  be_nested_str_weak(UI),
+    /* K6   */  be_nested_str_weak(started),
+    /* K7   */  be_nested_str_weak(tick),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(plugins),
+    /* K10  */  be_nested_str_weak(plugins_persist),
+    /* K11  */  be_nested_str_weak(plugins_classes),
+    /* K12  */  be_nested_str_weak(plugins_config_remotes),
+    /* K13  */  be_nested_str_weak(register_native_classes),
+    /* K14  */  be_nested_str_weak(vendorid),
+    /* K15  */  be_nested_str_weak(VENDOR_ID),
+    /* K16  */  be_nested_str_weak(productid),
+    /* K17  */  be_nested_str_weak(PRODUCT_ID),
+    /* K18  */  be_nested_str_weak(root_iterations),
+    /* K19  */  be_nested_str_weak(PBKDF_ITERATIONS),
+    /* K20  */  be_nested_str_weak(next_ep),
+    /* K21  */  be_const_int(1),
+    /* K22  */  be_nested_str_weak(root_salt),
+    /* K23  */  be_nested_str_weak(random),
+    /* K24  */  be_nested_str_weak(ipv4only),
+    /* K25  */  be_nested_str_weak(disable_bridge_mode),
+    /* K26  */  be_nested_str_weak(load_param),
+    /* K27  */  be_nested_str_weak(sessions),
+    /* K28  */  be_nested_str_weak(Session_Store),
+    /* K29  */  be_nested_str_weak(load_fabrics),
+    /* K30  */  be_nested_str_weak(message_handler),
+    /* K31  */  be_nested_str_weak(MessageHandler),
+    /* K32  */  be_nested_str_weak(ui),
+    /* K33  */  be_nested_str_weak(wifi),
+    /* K34  */  be_nested_str_weak(up),
+    /* K35  */  be_nested_str_weak(eth),
+    /* K36  */  be_nested_str_weak(start),
+    /* K37  */  be_nested_str_weak(add_rule),
+    /* K38  */  be_nested_str_weak(Wifi_X23Connected),
+    /* K39  */  be_nested_str_weak(matter_start),
+    /* K40  */  be_nested_str_weak(Eth_X23Connected),
+    /* K41  */  be_nested_str_weak(_init_basic_commissioning),
+    /* K42  */  be_nested_str_weak(add_driver),
+    /* K43  */  be_nested_str_weak(register_commands),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[107]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0xB8120600,  //  0003  GETNGBL	R4	K3
+      0x88100904,  //  0004  GETMBR	R4	R4	K4
+      0x7C080400,  //  0005  CALL	R2	2
+      0x740A0004,  //  0006  JMPT	R2	#000C
+      0xB80A0600,  //  0007  GETNGBL	R2	K3
+      0x8C080505,  //  0008  GETMET	R2	R2	K5
+      0x5C100000,  //  0009  MOVE	R4	R0
+      0x7C080400,  //  000A  CALL	R2	2
+      0x80000400,  //  000B  RET	0
+      0x50080000,  //  000C  LDBOOL	R2	0	0
+      0x90020C02,  //  000D  SETMBR	R0	K6	R2
+      0x90020F08,  //  000E  SETMBR	R0	K7	K8
+      0x60080012,  //  000F  GETGBL	R2	G18
+      0x7C080000,  //  0010  CALL	R2	0
+      0x90021202,  //  0011  SETMBR	R0	K9	R2
+      0x50080000,  //  0012  LDBOOL	R2	0	0
+      0x90021402,  //  0013  SETMBR	R0	K10	R2
+      0x60080013,  //  0014  GETGBL	R2	G19
+      0x7C080000,  //  0015  CALL	R2	0
+      0x90021602,  //  0016  SETMBR	R0	K11	R2
+      0x60080013,  //  0017  GETGBL	R2	G19
+      0x7C080000,  //  0018  CALL	R2	0
+      0x90021802,  //  0019  SETMBR	R0	K12	R2
+      0x8C08010D,  //  001A  GETMET	R2	R0	K13
+      0x7C080200,  //  001B  CALL	R2	1
+      0x8808010F,  //  001C  GETMBR	R2	R0	K15
+      0x90021C02,  //  001D  SETMBR	R0	K14	R2
+      0x88080111,  //  001E  GETMBR	R2	R0	K17
+      0x90022002,  //  001F  SETMBR	R0	K16	R2
+      0x88080113,  //  0020  GETMBR	R2	R0	K19
+      0x90022402,  //  0021  SETMBR	R0	K18	R2
+      0x90022915,  //  0022  SETMBR	R0	K20	K21
+      0x8C080317,  //  0023  GETMET	R2	R1	K23
+      0x5412000F,  //  0024  LDINT	R4	16
+      0x7C080400,  //  0025  CALL	R2	2
+      0x90022C02,  //  0026  SETMBR	R0	K22	R2
+      0x50080000,  //  0027  LDBOOL	R2	0	0
+      0x90023002,  //  0028  SETMBR	R0	K24	R2
+      0x50080000,  //  0029  LDBOOL	R2	0	0
+      0x90023202,  //  002A  SETMBR	R0	K25	R2
+      0x8C08011A,  //  002B  GETMET	R2	R0	K26
+      0x7C080200,  //  002C  CALL	R2	1
+      0xB80A0600,  //  002D  GETNGBL	R2	K3
+      0x8C08051C,  //  002E  GETMET	R2	R2	K28
+      0x5C100000,  //  002F  MOVE	R4	R0
+      0x7C080400,  //  0030  CALL	R2	2
+      0x90023602,  //  0031  SETMBR	R0	K27	R2
+      0x8808011B,  //  0032  GETMBR	R2	R0	K27
+      0x8C08051D,  //  0033  GETMET	R2	R2	K29
+      0x7C080200,  //  0034  CALL	R2	1
+      0xB80A0600,  //  0035  GETNGBL	R2	K3
+      0x8C08051F,  //  0036  GETMET	R2	R2	K31
+      0x5C100000,  //  0037  MOVE	R4	R0
+      0x7C080400,  //  0038  CALL	R2	2
+      0x90023C02,  //  0039  SETMBR	R0	K30	R2
+      0xB80A0600,  //  003A  GETNGBL	R2	K3
+      0x8C080505,  //  003B  GETMET	R2	R2	K5
+      0x5C100000,  //  003C  MOVE	R4	R0
+      0x7C080400,  //  003D  CALL	R2	2
+      0x90024002,  //  003E  SETMBR	R0	K32	R2
+      0xB80A0200,  //  003F  GETNGBL	R2	K1
+      0x8C080521,  //  0040  GETMET	R2	R2	K33
+      0x7C080200,  //  0041  CALL	R2	1
+      0x94080522,  //  0042  GETIDX	R2	R2	K34
+      0x740A0004,  //  0043  JMPT	R2	#0049
+      0xB80A0200,  //  0044  GETNGBL	R2	K1
+      0x8C080523,  //  0045  GETMET	R2	R2	K35
+      0x7C080200,  //  0046  CALL	R2	1
+      0x94080522,  //  0047  GETIDX	R2	R2	K34
+      0x780A0001,  //  0048  JMPF	R2	#004B
+      0x8C080124,  //  0049  GETMET	R2	R0	K36
+      0x7C080200,  //  004A  CALL	R2	1
+      0xB80A0200,  //  004B  GETNGBL	R2	K1
+      0x8C080521,  //  004C  GETMET	R2	R2	K33
+      0x7C080200,  //  004D  CALL	R2	1
+      0x94080522,  //  004E  GETIDX	R2	R2	K34
+      0x740A0005,  //  004F  JMPT	R2	#0056
+      0xB80A0200,  //  0050  GETNGBL	R2	K1
+      0x8C080525,  //  0051  GETMET	R2	R2	K37
+      0x58100026,  //  0052  LDCONST	R4	K38
+      0x84140000,  //  0053  CLOSURE	R5	P0
+      0x58180027,  //  0054  LDCONST	R6	K39
+      0x7C080800,  //  0055  CALL	R2	4
+      0xB80A0200,  //  0056  GETNGBL	R2	K1
+      0x8C080523,  //  0057  GETMET	R2	R2	K35
+      0x7C080200,  //  0058  CALL	R2	1
+      0x94080522,  //  0059  GETIDX	R2	R2	K34
+      0x740A0005,  //  005A  JMPT	R2	#0061
+      0xB80A0200,  //  005B  GETNGBL	R2	K1
+      0x8C080525,  //  005C  GETMET	R2	R2	K37
+      0x58100028,  //  005D  LDCONST	R4	K40
+      0x84140001,  //  005E  CLOSURE	R5	P1
+      0x58180027,  //  005F  LDCONST	R6	K39
+      0x7C080800,  //  0060  CALL	R2	4
+      0x8C080129,  //  0061  GETMET	R2	R0	K41
+      0x7C080200,  //  0062  CALL	R2	1
+      0xB80A0200,  //  0063  GETNGBL	R2	K1
+      0x8C08052A,  //  0064  GETMET	R2	R2	K42
+      0x5C100000,  //  0065  MOVE	R4	R0
+      0x7C080400,  //  0066  CALL	R2	2
+      0x8C08012B,  //  0067  GETMET	R2	R0	K43
+      0x7C080200,  //  0068  CALL	R2	1
+      0xA0000000,  //  0069  CLOSE	R0
+      0x80000000,  //  006A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: attribute_updated
+********************************************************************/
+be_local_closure(Matter_Device_attribute_updated,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
     ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(wifi),
-    /* K2   */  be_nested_str_weak(up),
-    /* K3   */  be_nested_str_weak(_mdns_announce_hostname),
-    /* K4   */  be_nested_str_weak(add_rule),
-    /* K5   */  be_nested_str_weak(Wifi_X23Connected),
-    /* K6   */  be_nested_str_weak(matter_mdns_host),
-    /* K7   */  be_nested_str_weak(eth),
-    /* K8   */  be_nested_str_weak(Eth_X23Connected),
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Path),
+    /* K2   */  be_nested_str_weak(endpoint),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_nested_str_weak(message_handler),
+    /* K6   */  be_nested_str_weak(im),
+    /* K7   */  be_nested_str_weak(subs_shop),
+    /* K8   */  be_nested_str_weak(attribute_updated_ctx),
     }),
-    be_str_weak(start_mdns_announce_hostnames),
+    be_str_weak(attribute_updated),
     &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x94040302,  //  0003  GETIDX	R1	R1	K2
-      0x78060003,  //  0004  JMPF	R1	#0009
-      0x8C040103,  //  0005  GETMET	R1	R0	K3
-      0x500C0000,  //  0006  LDBOOL	R3	0	0
-      0x7C040400,  //  0007  CALL	R1	2
-      0x70020005,  //  0008  JMP		#000F
-      0xB8060000,  //  0009  GETNGBL	R1	K0
-      0x8C040304,  //  000A  GETMET	R1	R1	K4
-      0x580C0005,  //  000B  LDCONST	R3	K5
-      0x84100000,  //  000C  CLOSURE	R4	P0
-      0x58140006,  //  000D  LDCONST	R5	K6
-      0x7C040800,  //  000E  CALL	R1	4
-      0xB8060000,  //  000F  GETNGBL	R1	K0
-      0x8C040307,  //  0010  GETMET	R1	R1	K7
-      0x7C040200,  //  0011  CALL	R1	1
-      0x94040302,  //  0012  GETIDX	R1	R1	K2
-      0x78060003,  //  0013  JMPF	R1	#0018
-      0x8C040103,  //  0014  GETMET	R1	R0	K3
-      0x500C0200,  //  0015  LDBOOL	R3	1	0
-      0x7C040400,  //  0016  CALL	R1	2
-      0x70020005,  //  0017  JMP		#001E
-      0xB8060000,  //  0018  GETNGBL	R1	K0
-      0x8C040304,  //  0019  GETMET	R1	R1	K4
-      0x580C0008,  //  001A  LDCONST	R3	K8
-      0x84100001,  //  001B  CLOSURE	R4	P1
-      0x58140006,  //  001C  LDCONST	R5	K6
-      0x7C040800,  //  001D  CALL	R1	4
-      0xA0000000,  //  001E  CLOSE	R0
-      0x80000000,  //  001F  RET	0
+    ( &(const binstruction[18]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140805,  //  0001  EQ	R5	R4	R5
+      0x78160000,  //  0002  JMPF	R5	#0004
+      0x50100000,  //  0003  LDBOOL	R4	0	0
+      0xB8160000,  //  0004  GETNGBL	R5	K0
+      0x8C140B01,  //  0005  GETMET	R5	R5	K1
+      0x7C140200,  //  0006  CALL	R5	1
+      0x90160401,  //  0007  SETMBR	R5	K2	R1
+      0x90160602,  //  0008  SETMBR	R5	K3	R2
+      0x90160803,  //  0009  SETMBR	R5	K4	R3
+      0x88180105,  //  000A  GETMBR	R6	R0	K5
+      0x88180D06,  //  000B  GETMBR	R6	R6	K6
+      0x88180D07,  //  000C  GETMBR	R6	R6	K7
+      0x8C180D08,  //  000D  GETMET	R6	R6	K8
+      0x5C200A00,  //  000E  MOVE	R8	R5
+      0x5C240800,  //  000F  MOVE	R9	R4
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80000000,  //  0011  RET	0
     })
   )
 );
@@ -5342,199 +5362,20 @@ be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
 
 
 /********************************************************************
-** Solidified function: mdns_remove_op_discovery_all_fabrics
+** Solidified function: register_commands
 ********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name */
+be_local_closure(Matter_Device_register_commands,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(active_fabrics),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(mdns_remove_op_discovery_all_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000B,  //  0005  EXBLK	0	#0012
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x780E0005,  //  000A  JMPF	R3	#0011
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x780E0002,  //  000D  JMPF	R3	#0011
-      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x7001FFF3,  //  0011  JMP		#0006
-      0x58040005,  //  0012  LDCONST	R1	K5
-      0xAC040200,  //  0013  CATCH	R1	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: k2l_num
-********************************************************************/
-be_local_closure(Matter_Device_k2l_num,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(push),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_const_int(0),
-    }),
-    be_str_weak(k2l_num),
-    &be_const_str_solidified,
-    ( &(const binstruction[52]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0003,  //  0004  EQ	R3	R0	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80040400,  //  0006  RET	1	R2
-      0x600C0010,  //  0007  GETGBL	R3	G16
-      0x8C100101,  //  0008  GETMET	R4	R0	K1
-      0x7C100200,  //  0009  CALL	R4	1
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0xA8020007,  //  000B  EXBLK	0	#0014
-      0x5C100600,  //  000C  MOVE	R4	R3
-      0x7C100000,  //  000D  CALL	R4	0
-      0x8C140502,  //  000E  GETMET	R5	R2	K2
-      0x601C0009,  //  000F  GETGBL	R7	G9
-      0x5C200800,  //  0010  MOVE	R8	R4
-      0x7C1C0200,  //  0011  CALL	R7	1
-      0x7C140400,  //  0012  CALL	R5	2
-      0x7001FFF7,  //  0013  JMP		#000C
-      0x580C0003,  //  0014  LDCONST	R3	K3
-      0xAC0C0200,  //  0015  CATCH	R3	1	0
-      0xB0080000,  //  0016  RAISE	2	R0	R0
-      0x600C0010,  //  0017  GETGBL	R3	G16
-      0x6010000C,  //  0018  GETGBL	R4	G12
-      0x5C140400,  //  0019  MOVE	R5	R2
-      0x7C100200,  //  001A  CALL	R4	1
-      0x04100904,  //  001B  SUB	R4	R4	K4
-      0x40120804,  //  001C  CONNECT	R4	K4	R4
-      0x7C0C0200,  //  001D  CALL	R3	1
-      0xA8020010,  //  001E  EXBLK	0	#0030
-      0x5C100600,  //  001F  MOVE	R4	R3
-      0x7C100000,  //  0020  CALL	R4	0
-      0x94140404,  //  0021  GETIDX	R5	R2	R4
-      0x5C180800,  //  0022  MOVE	R6	R4
-      0x241C0D05,  //  0023  GT	R7	R6	K5
-      0x781E0008,  //  0024  JMPF	R7	#002E
-      0x041C0D04,  //  0025  SUB	R7	R6	K4
-      0x941C0407,  //  0026  GETIDX	R7	R2	R7
-      0x241C0E05,  //  0027  GT	R7	R7	R5
-      0x781E0004,  //  0028  JMPF	R7	#002E
-      0x041C0D04,  //  0029  SUB	R7	R6	K4
-      0x941C0407,  //  002A  GETIDX	R7	R2	R7
-      0x98080C07,  //  002B  SETIDX	R2	R6	R7
-      0x04180D04,  //  002C  SUB	R6	R6	K4
-      0x7001FFF4,  //  002D  JMP		#0023
-      0x98080C05,  //  002E  SETIDX	R2	R6	R5
-      0x7001FFEE,  //  002F  JMP		#001F
-      0x580C0003,  //  0030  LDCONST	R3	K3
-      0xAC0C0200,  //  0031  CATCH	R3	1	0
-      0xB0080000,  //  0032  RAISE	2	R0	R0
-      0x80040400,  //  0033  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_plugin_by_endpoint
-********************************************************************/
-be_local_closure(Matter_Device_find_plugin_by_endpoint,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(plugins),
-    /* K2   */  be_nested_str_weak(get_endpoint),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(find_plugin_by_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0008,  //  0005  JMPF	R3	#000F
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x8C100702,  //  0008  GETMET	R4	R3	K2
-      0x7C100200,  //  0009  CALL	R4	1
-      0x1C100801,  //  000A  EQ	R4	R4	R1
-      0x78120000,  //  000B  JMPF	R4	#000D
-      0x80040600,  //  000C  RET	1	R3
-      0x00080503,  //  000D  ADD	R2	R2	K3
-      0x7001FFF1,  //  000E  JMP		#0001
-      0x4C0C0000,  //  000F  LDNIL	R3
-      0x80040600,  //  0010  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _start_udp
-********************************************************************/
-be_local_closure(Matter_Device__start_udp,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
     ( &(const struct bproto*[ 1]) {
       be_nested_proto(
-        8,                          /* nstack */
-        3,                          /* argc */
+        10,                          /* nstack */
+        4,                          /* argc */
         0,                          /* varg */
         1,                          /* has upvals */
         ( &(const bupvaldesc[ 1]) {  /* upvals */
@@ -5544,63 +5385,38 @@ be_local_closure(Matter_Device__start_udp,   /* name */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(msg_received),
+        /* K0   */  be_nested_str_weak(MtrJoin),
         }),
         be_str_weak(_X3Clambda_X3E),
         &be_const_str_solidified,
-        ( &(const binstruction[ 7]) {  /* code */
-          0x680C0000,  //  0000  GETUPV	R3	U0
-          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
-          0x5C140000,  //  0002  MOVE	R5	R0
-          0x5C180200,  //  0003  MOVE	R6	R1
-          0x5C1C0400,  //  0004  MOVE	R7	R2
-          0x7C0C0800,  //  0005  CALL	R3	4
-          0x80040600,  //  0006  RET	1	R3
+        ( &(const binstruction[ 8]) {  /* code */
+          0x68100000,  //  0000  GETUPV	R4	U0
+          0x8C100900,  //  0001  GETMET	R4	R4	K0
+          0x5C180000,  //  0002  MOVE	R6	R0
+          0x5C1C0200,  //  0003  MOVE	R7	R1
+          0x5C200400,  //  0004  MOVE	R8	R2
+          0x5C240600,  //  0005  MOVE	R9	R3
+          0x7C100A00,  //  0006  CALL	R4	5
+          0x80040800,  //  0007  RET	1	R4
         })
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(UDPServer),
-    /* K7   */  be_nested_str_weak(),
-    /* K8   */  be_nested_str_weak(start),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(add_cmd),
+    /* K2   */  be_nested_str_weak(MtrJoin),
     }),
-    be_str_weak(_start_udp),
+    be_str_weak(register_commands),
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80000400,  //  0002  RET	0
-      0x4C080000,  //  0003  LDNIL	R2
-      0x1C080202,  //  0004  EQ	R2	R1	R2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x540615A3,  //  0006  LDINT	R1	5540
-      0xB80A0200,  //  0007  GETNGBL	R2	K1
-      0x8C080502,  //  0008  GETMET	R2	R2	K2
-      0x60100008,  //  0009  GETGBL	R4	G8
-      0x5C140200,  //  000A  MOVE	R5	R1
-      0x7C100200,  //  000B  CALL	R4	1
-      0x00120604,  //  000C  ADD	R4	K3	R4
-      0x58140004,  //  000D  LDCONST	R5	K4
-      0x7C080600,  //  000E  CALL	R2	3
-      0xB80A0A00,  //  000F  GETNGBL	R2	K5
-      0x8C080506,  //  0010  GETMET	R2	R2	K6
-      0x58100007,  //  0011  LDCONST	R4	K7
-      0x5C140200,  //  0012  MOVE	R5	R1
-      0x7C080600,  //  0013  CALL	R2	3
-      0x90020002,  //  0014  SETMBR	R0	K0	R2
-      0x88080100,  //  0015  GETMBR	R2	R0	K0
-      0x8C080508,  //  0016  GETMET	R2	R2	K8
-      0x84100000,  //  0017  CLOSURE	R4	P0
-      0x7C080400,  //  0018  CALL	R2	2
-      0xA0000000,  //  0019  CLOSE	R0
-      0x80000000,  //  001A  RET	0
+    ( &(const binstruction[ 7]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x580C0002,  //  0002  LDCONST	R3	K2
+      0x84100000,  //  0003  CLOSURE	R4	P0
+      0x7C040600,  //  0004  CALL	R1	3
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -5608,11 +5424,172 @@ be_local_closure(Matter_Device__start_udp,   /* name */
 
 
 /********************************************************************
-** Solidified function: signal_endpoints_changed
+** Solidified function: autoconf_sensors_list
 ********************************************************************/
-be_local_closure(Matter_Device_signal_endpoints_changed,   /* name */
+be_local_closure(Matter_Device_autoconf_sensors_list,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    10,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(k2l),
+    /* K1   */  be_nested_str_weak(contains),
+    /* K2   */  be_nested_str_weak(Temperature),
+    /* K3   */  be_nested_str_weak(_X23Temperature),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_nested_str_weak(type),
+    /* K6   */  be_nested_str_weak(temperature),
+    /* K7   */  be_nested_str_weak(filter),
+    /* K8   */  be_nested_str_weak(stop_iteration),
+    /* K9   */  be_nested_str_weak(Pressure),
+    /* K10  */  be_nested_str_weak(_X23Pressure),
+    /* K11  */  be_nested_str_weak(pressure),
+    /* K12  */  be_nested_str_weak(Illuminance),
+    /* K13  */  be_nested_str_weak(_X23Illuminance),
+    /* K14  */  be_nested_str_weak(illuminance),
+    /* K15  */  be_nested_str_weak(Humidity),
+    /* K16  */  be_nested_str_weak(_X23Humidity),
+    /* K17  */  be_nested_str_weak(humidity),
+    }),
+    be_str_weak(autoconf_sensors_list),
+    &be_const_str_solidified,
+    ( &(const binstruction[119]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x8C100100,  //  0003  GETMET	R4	R0	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x7C100400,  //  0005  CALL	R4	2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0xA8020013,  //  0007  EXBLK	0	#001C
+      0x5C100600,  //  0008  MOVE	R4	R3
+      0x7C100000,  //  0009  CALL	R4	0
+      0x94140204,  //  000A  GETIDX	R5	R1	R4
+      0x6018000F,  //  000B  GETGBL	R6	G15
+      0x5C1C0A00,  //  000C  MOVE	R7	R5
+      0x60200013,  //  000D  GETGBL	R8	G19
+      0x7C180400,  //  000E  CALL	R6	2
+      0x781A000A,  //  000F  JMPF	R6	#001B
+      0x8C180B01,  //  0010  GETMET	R6	R5	K1
+      0x58200002,  //  0011  LDCONST	R8	K2
+      0x7C180400,  //  0012  CALL	R6	2
+      0x781A0006,  //  0013  JMPF	R6	#001B
+      0x00180903,  //  0014  ADD	R6	R4	K3
+      0x8C1C0504,  //  0015  GETMET	R7	R2	K4
+      0x60240013,  //  0016  GETGBL	R9	G19
+      0x7C240000,  //  0017  CALL	R9	0
+      0x98260B06,  //  0018  SETIDX	R9	K5	K6
+      0x98260E06,  //  0019  SETIDX	R9	K7	R6
+      0x7C1C0400,  //  001A  CALL	R7	2
+      0x7001FFEB,  //  001B  JMP		#0008
+      0x580C0008,  //  001C  LDCONST	R3	K8
+      0xAC0C0200,  //  001D  CATCH	R3	1	0
+      0xB0080000,  //  001E  RAISE	2	R0	R0
+      0x600C0010,  //  001F  GETGBL	R3	G16
+      0x8C100100,  //  0020  GETMET	R4	R0	K0
+      0x5C180200,  //  0021  MOVE	R6	R1
+      0x7C100400,  //  0022  CALL	R4	2
+      0x7C0C0200,  //  0023  CALL	R3	1
+      0xA8020013,  //  0024  EXBLK	0	#0039
+      0x5C100600,  //  0025  MOVE	R4	R3
+      0x7C100000,  //  0026  CALL	R4	0
+      0x94140204,  //  0027  GETIDX	R5	R1	R4
+      0x6018000F,  //  0028  GETGBL	R6	G15
+      0x5C1C0A00,  //  0029  MOVE	R7	R5
+      0x60200013,  //  002A  GETGBL	R8	G19
+      0x7C180400,  //  002B  CALL	R6	2
+      0x781A000A,  //  002C  JMPF	R6	#0038
+      0x8C180B01,  //  002D  GETMET	R6	R5	K1
+      0x58200009,  //  002E  LDCONST	R8	K9
+      0x7C180400,  //  002F  CALL	R6	2
+      0x781A0006,  //  0030  JMPF	R6	#0038
+      0x0018090A,  //  0031  ADD	R6	R4	K10
+      0x8C1C0504,  //  0032  GETMET	R7	R2	K4
+      0x60240013,  //  0033  GETGBL	R9	G19
+      0x7C240000,  //  0034  CALL	R9	0
+      0x98260B0B,  //  0035  SETIDX	R9	K5	K11
+      0x98260E06,  //  0036  SETIDX	R9	K7	R6
+      0x7C1C0400,  //  0037  CALL	R7	2
+      0x7001FFEB,  //  0038  JMP		#0025
+      0x580C0008,  //  0039  LDCONST	R3	K8
+      0xAC0C0200,  //  003A  CATCH	R3	1	0
+      0xB0080000,  //  003B  RAISE	2	R0	R0
+      0x600C0010,  //  003C  GETGBL	R3	G16
+      0x8C100100,  //  003D  GETMET	R4	R0	K0
+      0x5C180200,  //  003E  MOVE	R6	R1
+      0x7C100400,  //  003F  CALL	R4	2
+      0x7C0C0200,  //  0040  CALL	R3	1
+      0xA8020013,  //  0041  EXBLK	0	#0056
+      0x5C100600,  //  0042  MOVE	R4	R3
+      0x7C100000,  //  0043  CALL	R4	0
+      0x94140204,  //  0044  GETIDX	R5	R1	R4
+      0x6018000F,  //  0045  GETGBL	R6	G15
+      0x5C1C0A00,  //  0046  MOVE	R7	R5
+      0x60200013,  //  0047  GETGBL	R8	G19
+      0x7C180400,  //  0048  CALL	R6	2
+      0x781A000A,  //  0049  JMPF	R6	#0055
+      0x8C180B01,  //  004A  GETMET	R6	R5	K1
+      0x5820000C,  //  004B  LDCONST	R8	K12
+      0x7C180400,  //  004C  CALL	R6	2
+      0x781A0006,  //  004D  JMPF	R6	#0055
+      0x0018090D,  //  004E  ADD	R6	R4	K13
+      0x8C1C0504,  //  004F  GETMET	R7	R2	K4
+      0x60240013,  //  0050  GETGBL	R9	G19
+      0x7C240000,  //  0051  CALL	R9	0
+      0x98260B0E,  //  0052  SETIDX	R9	K5	K14
+      0x98260E06,  //  0053  SETIDX	R9	K7	R6
+      0x7C1C0400,  //  0054  CALL	R7	2
+      0x7001FFEB,  //  0055  JMP		#0042
+      0x580C0008,  //  0056  LDCONST	R3	K8
+      0xAC0C0200,  //  0057  CATCH	R3	1	0
+      0xB0080000,  //  0058  RAISE	2	R0	R0
+      0x600C0010,  //  0059  GETGBL	R3	G16
+      0x8C100100,  //  005A  GETMET	R4	R0	K0
+      0x5C180200,  //  005B  MOVE	R6	R1
+      0x7C100400,  //  005C  CALL	R4	2
+      0x7C0C0200,  //  005D  CALL	R3	1
+      0xA8020013,  //  005E  EXBLK	0	#0073
+      0x5C100600,  //  005F  MOVE	R4	R3
+      0x7C100000,  //  0060  CALL	R4	0
+      0x94140204,  //  0061  GETIDX	R5	R1	R4
+      0x6018000F,  //  0062  GETGBL	R6	G15
+      0x5C1C0A00,  //  0063  MOVE	R7	R5
+      0x60200013,  //  0064  GETGBL	R8	G19
+      0x7C180400,  //  0065  CALL	R6	2
+      0x781A000A,  //  0066  JMPF	R6	#0072
+      0x8C180B01,  //  0067  GETMET	R6	R5	K1
+      0x5820000F,  //  0068  LDCONST	R8	K15
+      0x7C180400,  //  0069  CALL	R6	2
+      0x781A0006,  //  006A  JMPF	R6	#0072
+      0x00180910,  //  006B  ADD	R6	R4	K16
+      0x8C1C0504,  //  006C  GETMET	R7	R2	K4
+      0x60240013,  //  006D  GETGBL	R9	G19
+      0x7C240000,  //  006E  CALL	R9	0
+      0x98260B11,  //  006F  SETIDX	R9	K5	K17
+      0x98260E06,  //  0070  SETIDX	R9	K7	R6
+      0x7C1C0400,  //  0071  CALL	R7	2
+      0x7001FFEB,  //  0072  JMP		#005F
+      0x580C0008,  //  0073  LDCONST	R3	K8
+      0xAC0C0200,  //  0074  CATCH	R3	1	0
+      0xB0080000,  //  0075  RAISE	2	R0	R0
+      0x80040400,  //  0076  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: autoconf_device
+********************************************************************/
+be_local_closure(Matter_Device_autoconf_device,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -5620,27 +5597,67 @@ be_local_closure(Matter_Device_signal_endpoints_changed,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_updated),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(3),
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(plugins),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(plugins_persist),
+    /* K4   */  be_nested_str_weak(plugins_config),
+    /* K5   */  be_nested_str_weak(autoconf_device_map),
+    /* K6   */  be_nested_str_weak(plugins_config_remotes),
+    /* K7   */  be_nested_str_weak(adjust_next_ep),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(log),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(_instantiate_plugins_from_config),
+    /* K13  */  be_nested_str_weak(sessions),
+    /* K14  */  be_nested_str_weak(count_active_fabrics),
+    /* K15  */  be_nested_str_weak(save_param),
     }),
-    be_str_weak(signal_endpoints_changed),
+    be_str_weak(autoconf_device),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x580C0001,  //  0001  LDCONST	R3	K1
-      0x5412001C,  //  0002  LDINT	R4	29
-      0x58140002,  //  0003  LDCONST	R5	K2
-      0x50180000,  //  0004  LDBOOL	R6	0	0
-      0x7C040A00,  //  0005  CALL	R1	5
-      0x8C040100,  //  0006  GETMET	R1	R0	K0
-      0x540EFEFF,  //  0007  LDINT	R3	65280
-      0x5412001C,  //  0008  LDINT	R4	29
-      0x58140002,  //  0009  LDCONST	R5	K2
-      0x50180000,  //  000A  LDBOOL	R6	0	0
-      0x7C040A00,  //  000B  CALL	R1	5
-      0x80000000,  //  000C  RET	0
+    ( &(const binstruction[40]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x24080502,  //  0004  GT	R2	R2	K2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x80000400,  //  0006  RET	0
+      0x88080103,  //  0007  GETMBR	R2	R0	K3
+      0x740A000F,  //  0008  JMPT	R2	#0019
+      0x8C080105,  //  0009  GETMET	R2	R0	K5
+      0x7C080200,  //  000A  CALL	R2	1
+      0x90020802,  //  000B  SETMBR	R0	K4	R2
+      0x60080013,  //  000C  GETGBL	R2	G19
+      0x7C080000,  //  000D  CALL	R2	0
+      0x90020C02,  //  000E  SETMBR	R0	K6	R2
+      0x8C080107,  //  000F  GETMET	R2	R0	K7
+      0x7C080200,  //  0010  CALL	R2	1
+      0xB80A1000,  //  0011  GETNGBL	R2	K8
+      0x8C080509,  //  0012  GETMET	R2	R2	K9
+      0x60100008,  //  0013  GETGBL	R4	G8
+      0x88140104,  //  0014  GETMBR	R5	R0	K4
+      0x7C100200,  //  0015  CALL	R4	1
+      0x00121404,  //  0016  ADD	R4	K10	R4
+      0x5814000B,  //  0017  LDCONST	R5	K11
+      0x7C080600,  //  0018  CALL	R2	3
+      0x8C08010C,  //  0019  GETMET	R2	R0	K12
+      0x88100104,  //  001A  GETMBR	R4	R0	K4
+      0x7C080400,  //  001B  CALL	R2	2
+      0x88080103,  //  001C  GETMBR	R2	R0	K3
+      0x740A0008,  //  001D  JMPT	R2	#0027
+      0x8808010D,  //  001E  GETMBR	R2	R0	K13
+      0x8C08050E,  //  001F  GETMET	R2	R2	K14
+      0x7C080200,  //  0020  CALL	R2	1
+      0x24080502,  //  0021  GT	R2	R2	K2
+      0x780A0003,  //  0022  JMPF	R2	#0027
+      0x50080200,  //  0023  LDBOOL	R2	1	0
+      0x90020602,  //  0024  SETMBR	R0	K3	R2
+      0x8C08010F,  //  0025  GETMET	R2	R0	K15
+      0x7C080200,  //  0026  CALL	R2	1
+      0x80000000,  //  0027  RET	0
     })
   )
 );
@@ -5651,12 +5668,32 @@ be_local_closure(Matter_Device_signal_endpoints_changed,   /* name */
 ** Solidified class: Matter_Device
 ********************************************************************/
 be_local_class(Matter_Device,
-    35,
+    36,
     NULL,
-    be_nested_map(107,
+    be_nested_map(108,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(msg_received, -1), be_const_closure(Matter_Device_msg_received_closure) },
-        { be_const_key_weak(PASSCODE_INVALID, 91), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        { be_const_key_weak(mdns_remove_PASE, -1), be_const_closure(Matter_Device_mdns_remove_PASE_closure) },
+        { be_const_key_weak(sort_distinct, -1), be_const_static_closure(Matter_Device_sort_distinct_closure) },
+        { be_const_key_weak(is_commissioning_open, 0), be_const_closure(Matter_Device_is_commissioning_open_closure) },
+        { be_const_key_weak(autoconf_sensors_list, -1), be_const_closure(Matter_Device_autoconf_sensors_list_closure) },
+        { be_const_key_weak(plugins_persist, -1), be_const_var(2) },
+        { be_const_key_weak(root_w0, -1), be_const_var(34) },
+        { be_const_key_weak(register_commands, -1), be_const_closure(Matter_Device_register_commands_closure) },
+        { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Device_attribute_updated_closure) },
+        { be_const_key_weak(every_50ms, -1), be_const_closure(Matter_Device_every_50ms_closure) },
+        { be_const_key_weak(commissioning_instance_wifi, -1), be_const_var(18) },
+        { be_const_key_weak(PASE_TIMEOUT, 57), be_const_int(600) },
+        { be_const_key_weak(init, 96), be_const_closure(Matter_Device_init_closure) },
+        { be_const_key_weak(start_commissioning_complete, -1), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
+        { be_const_key_weak(start_basic_commissioning, 87), be_const_closure(Matter_Device_start_basic_commissioning_closure) },
+        { be_const_key_weak(vendorid, 1), be_const_var(22) },
+        { be_const_key_weak(mdns_pase_eth, -1), be_const_var(24) },
+        { be_const_key_weak(find_plugin_by_endpoint, -1), be_const_closure(Matter_Device_find_plugin_by_endpoint_closure) },
+        { be_const_key_weak(_init_basic_commissioning, -1), be_const_closure(Matter_Device__init_basic_commissioning_closure) },
+        { be_const_key_weak(message_handler, -1), be_const_var(7) },
+        { be_const_key_weak(start_operational_discovery_deferred, -1), be_const_closure(Matter_Device_start_operational_discovery_deferred_closure) },
+        { be_const_key_weak(FILENAME, 94), be_nested_str_weak(_matter_device_X2Ejson) },
+        { be_const_key_weak(PASSCODE_INVALID, 36), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(12,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(0),
@@ -5672,111 +5709,92 @@ be_local_class(Matter_Device,
         be_const_int(12345678),
         be_const_int(87654321),
     }))    ) } )) },
-        { be_const_key_weak(signal_endpoints_changed, 56), be_const_closure(Matter_Device_signal_endpoints_changed_closure) },
-        { be_const_key_weak(register_native_classes, 65), be_const_closure(Matter_Device_register_native_classes_closure) },
-        { be_const_key_weak(_compute_pbkdf, -1), be_const_closure(Matter_Device__compute_pbkdf_closure) },
-        { be_const_key_weak(hostname_eth, -1), be_const_var(21) },
-        { be_const_key_weak(productid, -1), be_const_var(23) },
-        { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
-        { be_const_key_weak(_start_udp, -1), be_const_closure(Matter_Device__start_udp_closure) },
-        { be_const_key_weak(started, 69), be_const_var(0) },
-        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(Matter_Device_get_active_endpoints_closure) },
         { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
-        { be_const_key_weak(root_discriminator, -1), be_const_var(27) },
-        { be_const_key_weak(root_w0, 98), be_const_var(33) },
-        { be_const_key_weak(mdns_remove_PASE, 27), be_const_closure(Matter_Device_mdns_remove_PASE_closure) },
-        { be_const_key_weak(ui, -1), be_const_var(9) },
-        { be_const_key_weak(commissioning_w0, -1), be_const_var(15) },
-        { be_const_key_weak(commissioning_instance_eth, -1), be_const_var(19) },
-        { be_const_key_weak(bridge_remove_endpoint, 15), be_const_closure(Matter_Device_bridge_remove_endpoint_closure) },
-        { be_const_key_weak(save_before_restart, 5), be_const_closure(Matter_Device_save_before_restart_closure) },
-        { be_const_key_weak(k2l, -1), be_const_static_closure(Matter_Device_k2l_closure) },
-        { be_const_key_weak(mdns_announce_PASE, -1), be_const_closure(Matter_Device_mdns_announce_PASE_closure) },
-        { be_const_key_weak(vendorid, -1), be_const_var(22) },
-        { be_const_key_weak(start_operational_discovery_deferred, -1), be_const_closure(Matter_Device_start_operational_discovery_deferred_closure) },
-        { be_const_key_weak(get_plugin_class_arg, -1), be_const_closure(Matter_Device_get_plugin_class_arg_closure) },
-        { be_const_key_weak(event_fabrics_saved, -1), be_const_closure(Matter_Device_event_fabrics_saved_closure) },
-        { be_const_key_weak(register_commands, 16), be_const_closure(Matter_Device_register_commands_closure) },
-        { be_const_key_weak(VENDOR_ID, 106), be_const_int(65521) },
-        { be_const_key_weak(plugins_config_remotes, -1), be_const_var(5) },
-        { be_const_key_weak(commissioning_iterations, -1), be_const_var(12) },
-        { be_const_key_weak(_init_basic_commissioning, -1), be_const_closure(Matter_Device__init_basic_commissioning_closure) },
-        { be_const_key_weak(plugins_config, 93), be_const_var(4) },
-        { be_const_key_weak(commissioning_admin_fabric, 57), be_const_var(17) },
-        { be_const_key_weak(mdns_pase_wifi, 10), be_const_var(25) },
-        { be_const_key_weak(root_passcode, -1), be_const_var(28) },
-        { be_const_key_weak(register_http_remote, 99), be_const_closure(Matter_Device_register_http_remote_closure) },
-        { be_const_key_weak(start_operational_discovery, -1), be_const_closure(Matter_Device_start_operational_discovery_closure) },
-        { be_const_key_weak(compute_qrcode_content, 20), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
-        { be_const_key_weak(adjust_next_ep, -1), be_const_closure(Matter_Device_adjust_next_ep_closure) },
-        { be_const_key_weak(update_remotes_info, -1), be_const_closure(Matter_Device_update_remotes_info_closure) },
-        { be_const_key_weak(autoconf_sensors_list, -1), be_const_closure(Matter_Device_autoconf_sensors_list_closure) },
-        { be_const_key_weak(next_ep, -1), be_const_var(30) },
-        { be_const_key_weak(message_handler, -1), be_const_var(7) },
-        { be_const_key_weak(start_basic_commissioning, -1), be_const_closure(Matter_Device_start_basic_commissioning_closure) },
-        { be_const_key_weak(get_plugin_class_displayname, -1), be_const_closure(Matter_Device_get_plugin_class_displayname_closure) },
-        { be_const_key_weak(hostname_wifi, 36), be_const_var(20) },
-        { be_const_key_weak(start_commissioning_complete, -1), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
-        { be_const_key_weak(stop, 60), be_const_closure(Matter_Device_stop_closure) },
-        { be_const_key_weak(remove_fabric, -1), be_const_closure(Matter_Device_remove_fabric_closure) },
-        { be_const_key_weak(generate_random_passcode, 52), be_const_closure(Matter_Device_generate_random_passcode_closure) },
-        { be_const_key_weak(received_ack, -1), be_const_closure(Matter_Device_received_ack_closure) },
-        { be_const_key_weak(MtrJoin, 39), be_const_closure(Matter_Device_MtrJoin_closure) },
-        { be_const_key_weak(mdns_announce_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics_closure) },
-        { be_const_key_weak(load_param, -1), be_const_closure(Matter_Device_load_param_closure) },
-        { be_const_key_weak(ipv4only, 1), be_const_var(29) },
-        { be_const_key_weak(stop_basic_commissioning, 41), be_const_closure(Matter_Device_stop_basic_commissioning_closure) },
-        { be_const_key_weak(commissioning_salt, -1), be_const_var(14) },
-        { be_const_key_weak(commissioning_discriminator, 44), be_const_var(13) },
-        { be_const_key_weak(sessions, -1), be_const_var(8) },
-        { be_const_key_weak(start_commissioning_complete_deferred, 49), be_const_closure(Matter_Device_start_commissioning_complete_deferred_closure) },
-        { be_const_key_weak(root_L, 23), be_const_var(34) },
-        { be_const_key_weak(plugins_persist, -1), be_const_var(2) },
-        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
-        { be_const_key_weak(tick, 61), be_const_var(10) },
-        { be_const_key_weak(register_plugin_class, 87), be_const_closure(Matter_Device_register_plugin_class_closure) },
-        { be_const_key_weak(compute_manual_pairing_code, -1), be_const_closure(Matter_Device_compute_manual_pairing_code_closure) },
-        { be_const_key_weak(is_root_commissioning_open, -1), be_const_closure(Matter_Device_is_root_commissioning_open_closure) },
-        { be_const_key_weak(plugins, -1), be_const_var(1) },
-        { be_const_key_weak(start, -1), be_const_closure(Matter_Device_start_closure) },
-        { be_const_key_weak(commissioning_L, 68), be_const_var(16) },
+        { be_const_key_weak(invoke_request, 12), be_const_closure(Matter_Device_invoke_request_closure) },
         { be_const_key_weak(bridge_add_endpoint, -1), be_const_closure(Matter_Device_bridge_add_endpoint_closure) },
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Device_every_second_closure) },
-        { be_const_key_weak(conf_to_log, 74), be_const_static_closure(Matter_Device_conf_to_log_closure) },
-        { be_const_key_weak(udp_server, -1), be_const_var(6) },
-        { be_const_key_weak(get_plugin_remote_info, -1), be_const_closure(Matter_Device_get_plugin_remote_info_closure) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Device_invoke_request_closure) },
-        { be_const_key_weak(msg_send, 67), be_const_closure(Matter_Device_msg_send_closure) },
-        { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Device_attribute_updated_closure) },
-        { be_const_key_weak(every_250ms, 64), be_const_closure(Matter_Device_every_250ms_closure) },
-        { be_const_key_weak(save_param, -1), be_const_closure(Matter_Device_save_param_closure) },
-        { be_const_key_weak(commissioning_open, -1), be_const_var(11) },
-        { be_const_key_weak(_mdns_announce_hostname, -1), be_const_closure(Matter_Device__mdns_announce_hostname_closure) },
-        { be_const_key_weak(PASE_TIMEOUT, 32), be_const_int(600) },
-        { be_const_key_weak(process_attribute_expansion, -1), be_const_closure(Matter_Device_process_attribute_expansion_closure) },
-        { be_const_key_weak(_instantiate_plugins_from_config, 55), be_const_closure(Matter_Device__instantiate_plugins_from_config_closure) },
-        { be_const_key_weak(every_50ms, 53), be_const_closure(Matter_Device_every_50ms_closure) },
-        { be_const_key_weak(mdns_announce_op_discovery, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_closure) },
-        { be_const_key_weak(clean_remotes, -1), be_const_closure(Matter_Device_clean_remotes_closure) },
-        { be_const_key_weak(mdns_pase_eth, -1), be_const_var(24) },
-        { be_const_key_weak(is_commissioning_open, -1), be_const_closure(Matter_Device_is_commissioning_open_closure) },
+        { be_const_key_weak(generate_random_passcode, -1), be_const_closure(Matter_Device_generate_random_passcode_closure) },
         { be_const_key_weak(autoconf_device_map, -1), be_const_closure(Matter_Device_autoconf_device_map_closure) },
-        { be_const_key_weak(http_remotes, -1), be_const_var(26) },
-        { be_const_key_weak(autoconf_device, 34), be_const_closure(Matter_Device_autoconf_device_closure) },
-        { be_const_key_weak(root_salt, 58), be_const_var(32) },
-        { be_const_key_weak(mdns_remove_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics_closure) },
-        { be_const_key_weak(k2l_num, -1), be_const_static_closure(Matter_Device_k2l_num_closure) },
-        { be_const_key_weak(start_mdns_announce_hostnames, 22), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
-        { be_const_key_weak(find_plugin_by_endpoint, -1), be_const_closure(Matter_Device_find_plugin_by_endpoint_closure) },
-        { be_const_key_weak(sort_distinct, -1), be_const_static_closure(Matter_Device_sort_distinct_closure) },
+        { be_const_key_weak(plugins, 100), be_const_var(1) },
+        { be_const_key_weak(msg_received, 56), be_const_closure(Matter_Device_msg_received_closure) },
+        { be_const_key_weak(commissioning_open, 19), be_const_var(11) },
+        { be_const_key_weak(plugins_config_remotes, 104), be_const_var(5) },
         { be_const_key_weak(mdns_remove_op_discovery, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_closure) },
-        { be_const_key_weak(_trigger_read_sensors, 11), be_const_closure(Matter_Device__trigger_read_sensors_closure) },
-        { be_const_key_weak(root_iterations, -1), be_const_var(31) },
-        { be_const_key_weak(commissioning_instance_wifi, 8), be_const_var(18) },
-        { be_const_key_weak(init, 6), be_const_closure(Matter_Device_init_closure) },
-        { be_const_key_weak(PBKDF_ITERATIONS, -1), be_const_int(1000) },
-        { be_const_key_weak(start_root_basic_commissioning, 2), be_const_closure(Matter_Device_start_root_basic_commissioning_closure) },
+        { be_const_key_weak(tick, -1), be_const_var(10) },
+        { be_const_key_weak(register_plugin_class, 50), be_const_closure(Matter_Device_register_plugin_class_closure) },
+        { be_const_key_weak(mdns_announce_op_discovery, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_closure) },
+        { be_const_key_weak(_trigger_read_sensors, -1), be_const_closure(Matter_Device__trigger_read_sensors_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Device_every_second_closure) },
+        { be_const_key_weak(adjust_next_ep, -1), be_const_closure(Matter_Device_adjust_next_ep_closure) },
+        { be_const_key_weak(root_passcode, 13), be_const_var(28) },
+        { be_const_key_weak(compute_qrcode_content, 99), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
         { be_const_key_weak(plugins_classes, -1), be_const_var(3) },
+        { be_const_key_weak(update_remotes_info, -1), be_const_closure(Matter_Device_update_remotes_info_closure) },
+        { be_const_key_weak(compute_manual_pairing_code, 63), be_const_closure(Matter_Device_compute_manual_pairing_code_closure) },
+        { be_const_key_weak(get_plugin_remote_info, 49), be_const_closure(Matter_Device_get_plugin_remote_info_closure) },
+        { be_const_key_weak(hostname_wifi, -1), be_const_var(20) },
+        { be_const_key_weak(disable_bridge_mode, -1), be_const_var(30) },
+        { be_const_key_weak(MtrJoin, 37), be_const_closure(Matter_Device_MtrJoin_closure) },
+        { be_const_key_weak(start, 18), be_const_closure(Matter_Device_start_closure) },
+        { be_const_key_weak(commissioning_admin_fabric, 66), be_const_var(17) },
+        { be_const_key_weak(PBKDF_ITERATIONS, -1), be_const_int(1000) },
+        { be_const_key_weak(commissioning_iterations, 101), be_const_var(12) },
+        { be_const_key_weak(mdns_announce_op_discovery_all_fabrics, 11), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics_closure) },
+        { be_const_key_weak(productid, -1), be_const_var(23) },
+        { be_const_key_weak(start_root_basic_commissioning, -1), be_const_closure(Matter_Device_start_root_basic_commissioning_closure) },
+        { be_const_key_weak(udp_server, -1), be_const_var(6) },
+        { be_const_key_weak(sessions, -1), be_const_var(8) },
+        { be_const_key_weak(ipv4only, 85), be_const_var(29) },
+        { be_const_key_weak(get_plugin_class_displayname, -1), be_const_closure(Matter_Device_get_plugin_class_displayname_closure) },
+        { be_const_key_weak(started, 26), be_const_var(0) },
+        { be_const_key_weak(is_root_commissioning_open, -1), be_const_closure(Matter_Device_is_root_commissioning_open_closure) },
+        { be_const_key_weak(msg_send, -1), be_const_closure(Matter_Device_msg_send_closure) },
+        { be_const_key_weak(mdns_pase_wifi, 60), be_const_var(25) },
+        { be_const_key_weak(_mdns_announce_hostname, 90), be_const_closure(Matter_Device__mdns_announce_hostname_closure) },
+        { be_const_key_weak(clean_remotes, -1), be_const_closure(Matter_Device_clean_remotes_closure) },
+        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(Matter_Device_get_active_endpoints_closure) },
+        { be_const_key_weak(stop, 52), be_const_closure(Matter_Device_stop_closure) },
+        { be_const_key_weak(stop_basic_commissioning, 95), be_const_closure(Matter_Device_stop_basic_commissioning_closure) },
+        { be_const_key_weak(remove_fabric, 31), be_const_closure(Matter_Device_remove_fabric_closure) },
+        { be_const_key_weak(commissioning_instance_eth, -1), be_const_var(19) },
+        { be_const_key_weak(mdns_announce_PASE, -1), be_const_closure(Matter_Device_mdns_announce_PASE_closure) },
+        { be_const_key_weak(root_discriminator, -1), be_const_var(27) },
+        { be_const_key_weak(start_operational_discovery, -1), be_const_closure(Matter_Device_start_operational_discovery_closure) },
+        { be_const_key_weak(mdns_remove_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics_closure) },
+        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
+        { be_const_key_weak(commissioning_w0, 68), be_const_var(15) },
+        { be_const_key_weak(get_plugin_class_arg, 69), be_const_closure(Matter_Device_get_plugin_class_arg_closure) },
+        { be_const_key_weak(conf_to_log, -1), be_const_static_closure(Matter_Device_conf_to_log_closure) },
+        { be_const_key_weak(_instantiate_plugins_from_config, 71), be_const_closure(Matter_Device__instantiate_plugins_from_config_closure) },
+        { be_const_key_weak(root_iterations, 72), be_const_var(32) },
+        { be_const_key_weak(commissioning_L, -1), be_const_var(16) },
+        { be_const_key_weak(hostname_eth, -1), be_const_var(21) },
+        { be_const_key_weak(http_remotes, -1), be_const_var(26) },
+        { be_const_key_weak(event_fabrics_saved, -1), be_const_closure(Matter_Device_event_fabrics_saved_closure) },
+        { be_const_key_weak(ui, 64), be_const_var(9) },
+        { be_const_key_weak(received_ack, -1), be_const_closure(Matter_Device_received_ack_closure) },
+        { be_const_key_weak(next_ep, -1), be_const_var(31) },
+        { be_const_key_weak(save_param, -1), be_const_closure(Matter_Device_save_param_closure) },
+        { be_const_key_weak(root_salt, -1), be_const_var(33) },
+        { be_const_key_weak(register_http_remote, 55), be_const_closure(Matter_Device_register_http_remote_closure) },
+        { be_const_key_weak(commissioning_salt, -1), be_const_var(14) },
+        { be_const_key_weak(_start_udp, -1), be_const_closure(Matter_Device__start_udp_closure) },
+        { be_const_key_weak(commissioning_discriminator, 6), be_const_var(13) },
+        { be_const_key_weak(every_250ms, 44), be_const_closure(Matter_Device_every_250ms_closure) },
+        { be_const_key_weak(_compute_pbkdf, -1), be_const_closure(Matter_Device__compute_pbkdf_closure) },
+        { be_const_key_weak(k2l, -1), be_const_static_closure(Matter_Device_k2l_closure) },
+        { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
+        { be_const_key_weak(bridge_remove_endpoint, 97), be_const_closure(Matter_Device_bridge_remove_endpoint_closure) },
+        { be_const_key_weak(start_commissioning_complete_deferred, 98), be_const_closure(Matter_Device_start_commissioning_complete_deferred_closure) },
+        { be_const_key_weak(load_param, -1), be_const_closure(Matter_Device_load_param_closure) },
+        { be_const_key_weak(signal_endpoints_changed, -1), be_const_closure(Matter_Device_signal_endpoints_changed_closure) },
+        { be_const_key_weak(k2l_num, -1), be_const_static_closure(Matter_Device_k2l_num_closure) },
+        { be_const_key_weak(start_mdns_announce_hostnames, -1), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
+        { be_const_key_weak(save_before_restart, 9), be_const_closure(Matter_Device_save_before_restart_closure) },
+        { be_const_key_weak(process_attribute_expansion, 7), be_const_closure(Matter_Device_process_attribute_expansion_closure) },
+        { be_const_key_weak(root_L, -1), be_const_var(35) },
+        { be_const_key_weak(register_native_classes, 3), be_const_closure(Matter_Device_register_native_classes_closure) },
+        { be_const_key_weak(plugins_config, -1), be_const_var(4) },
+        { be_const_key_weak(autoconf_device, -1), be_const_closure(Matter_Device_autoconf_device_closure) },
     })),
     be_str_weak(Matter_Device)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Device.h
@@ -210,7 +210,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[35]) {     /* constants */
+    ( &(const bvalue[37]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
@@ -231,25 +231,27 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
     /* K17  */  be_nested_str_weak(NON_BRIDGE_VENDOR),
     /* K18  */  be_nested_str_weak(find),
     /* K19  */  be_nested_str_weak(get_admin_vendor),
-    /* K20  */  be_nested_str_weak(read_attribute),
-    /* K21  */  be_nested_str_weak(string),
-    /* K22  */  be_nested_str_weak(UTF1),
-    /* K23  */  be_nested_str_weak(tasmota),
-    /* K24  */  be_nested_str_weak(cmd),
-    /* K25  */  be_nested_str_weak(DeviceName),
-    /* K26  */  be_nested_str_weak(get_name),
-    /* K27  */  be_nested_str_weak(Status_X202),
-    /* K28  */  be_nested_str_weak(StatusFWR),
-    /* K29  */  be_nested_str_weak(Version),
-    /* K30  */  be_nested_str_weak(_X28),
-    /* K31  */  be_nested_str_weak(wifi),
-    /* K32  */  be_nested_str_weak(mac),
-    /* K33  */  be_nested_str_weak(),
-    /* K34  */  be_nested_str_weak(BOOL),
+    /* K20  */  be_nested_str_weak(device),
+    /* K21  */  be_nested_str_weak(disable_bridge_mode),
+    /* K22  */  be_nested_str_weak(read_attribute),
+    /* K23  */  be_nested_str_weak(string),
+    /* K24  */  be_nested_str_weak(UTF1),
+    /* K25  */  be_nested_str_weak(tasmota),
+    /* K26  */  be_nested_str_weak(cmd),
+    /* K27  */  be_nested_str_weak(DeviceName),
+    /* K28  */  be_nested_str_weak(get_name),
+    /* K29  */  be_nested_str_weak(Status_X202),
+    /* K30  */  be_nested_str_weak(StatusFWR),
+    /* K31  */  be_nested_str_weak(Version),
+    /* K32  */  be_nested_str_weak(_X28),
+    /* K33  */  be_nested_str_weak(wifi),
+    /* K34  */  be_nested_str_weak(mac),
+    /* K35  */  be_nested_str_weak(),
+    /* K36  */  be_nested_str_weak(BOOL),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[258]) {  /* code */
+    ( &(const binstruction[261]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x880C0701,  //  0001  GETMBR	R3	R3	K1
       0x88100502,  //  0002  GETMBR	R4	R2	K2
@@ -289,7 +291,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x54260003,  //  0024  LDINT	R9	4
       0x7C180600,  //  0025  CALL	R6	3
       0x80040C00,  //  0026  RET	1	R6
-      0x700200D8,  //  0027  JMP		#0101
+      0x700200DB,  //  0027  JMP		#0104
       0x541A0003,  //  0028  LDINT	R6	4
       0x1C180806,  //  0029  EQ	R6	R4	R6
       0x781A0016,  //  002A  JMPF	R6	#0042
@@ -315,7 +317,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x54260003,  //  003E  LDINT	R9	4
       0x7C180600,  //  003F  CALL	R6	3
       0x80040C00,  //  0040  RET	1	R6
-      0x700200BE,  //  0041  JMP		#0101
+      0x700200C1,  //  0041  JMP		#0104
       0x541A0004,  //  0042  LDINT	R6	5
       0x1C180806,  //  0043  EQ	R6	R4	R6
       0x781A0011,  //  0044  JMPF	R6	#0057
@@ -336,12 +338,12 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x54260003,  //  0053  LDINT	R9	4
       0x7C180600,  //  0054  CALL	R6	3
       0x80040C00,  //  0055  RET	1	R6
-      0x700200A9,  //  0056  JMP		#0101
+      0x700200AC,  //  0056  JMP		#0104
       0x541A001C,  //  0057  LDINT	R6	29
       0x1C180806,  //  0058  EQ	R6	R4	R6
-      0x781A003A,  //  0059  JMPF	R6	#0095
+      0x781A003D,  //  0059  JMPF	R6	#0098
       0x1C180B05,  //  005A  EQ	R6	R5	K5
-      0x781A002F,  //  005B  JMPF	R6	#008C
+      0x781A0032,  //  005B  JMPF	R6	#008F
       0x8C18070B,  //  005C  GETMET	R6	R3	K11
       0x7C180200,  //  005D  CALL	R6	1
       0x881C010C,  //  005E  GETMBR	R7	R0	K12
@@ -375,139 +377,142 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x7C200400,  //  007A  CALL	R8	2
       0x4C240000,  //  007B  LDNIL	R9
       0x1C201009,  //  007C  EQ	R8	R8	R9
-      0x7822000B,  //  007D  JMPF	R8	#008A
-      0x8C200D0E,  //  007E  GETMET	R8	R6	K14
-      0x7C200200,  //  007F  CALL	R8	1
-      0x8C24110F,  //  0080  GETMET	R9	R8	K15
-      0x582C0005,  //  0081  LDCONST	R11	K5
-      0x88300707,  //  0082  GETMBR	R12	R3	K7
-      0x54360012,  //  0083  LDINT	R13	19
-      0x7C240800,  //  0084  CALL	R9	4
-      0x8C24110F,  //  0085  GETMET	R9	R8	K15
-      0x582C0008,  //  0086  LDCONST	R11	K8
-      0x88300707,  //  0087  GETMBR	R12	R3	K7
-      0x58340008,  //  0088  LDCONST	R13	K8
-      0x7C240800,  //  0089  CALL	R9	4
-      0x80040C00,  //  008A  RET	1	R6
-      0x70020007,  //  008B  JMP		#0094
-      0x60180003,  //  008C  GETGBL	R6	G3
-      0x5C1C0000,  //  008D  MOVE	R7	R0
-      0x7C180200,  //  008E  CALL	R6	1
-      0x8C180D14,  //  008F  GETMET	R6	R6	K20
-      0x5C200200,  //  0090  MOVE	R8	R1
-      0x5C240400,  //  0091  MOVE	R9	R2
-      0x7C180600,  //  0092  CALL	R6	3
-      0x80040C00,  //  0093  RET	1	R6
-      0x7002006B,  //  0094  JMP		#0101
-      0x541A0038,  //  0095  LDINT	R6	57
-      0x1C180806,  //  0096  EQ	R6	R4	R6
-      0x781A0060,  //  0097  JMPF	R6	#00F9
-      0xA41A2A00,  //  0098  IMPORT	R6	K21
-      0x1C1C0B04,  //  0099  EQ	R7	R5	K4
-      0x781E000A,  //  009A  JMPF	R7	#00A6
-      0x8C1C0706,  //  009B  GETMET	R7	R3	K6
-      0x88240716,  //  009C  GETMBR	R9	R3	K22
-      0xB82A2E00,  //  009D  GETNGBL	R10	K23
-      0x8C281518,  //  009E  GETMET	R10	R10	K24
-      0x58300019,  //  009F  LDCONST	R12	K25
-      0x50340200,  //  00A0  LDBOOL	R13	1	0
-      0x7C280600,  //  00A1  CALL	R10	3
-      0x94281519,  //  00A2  GETIDX	R10	R10	K25
-      0x7C1C0600,  //  00A3  CALL	R7	3
-      0x80040E00,  //  00A4  RET	1	R7
-      0x70020051,  //  00A5  JMP		#00F8
-      0x541E0004,  //  00A6  LDINT	R7	5
-      0x1C1C0A07,  //  00A7  EQ	R7	R5	R7
-      0x781E0006,  //  00A8  JMPF	R7	#00B0
-      0x8C1C0706,  //  00A9  GETMET	R7	R3	K6
-      0x88240716,  //  00AA  GETMBR	R9	R3	K22
-      0x8C28011A,  //  00AB  GETMET	R10	R0	K26
-      0x7C280200,  //  00AC  CALL	R10	1
-      0x7C1C0600,  //  00AD  CALL	R7	3
-      0x80040E00,  //  00AE  RET	1	R7
-      0x70020047,  //  00AF  JMP		#00F8
-      0x541E0009,  //  00B0  LDINT	R7	10
-      0x1C1C0A07,  //  00B1  EQ	R7	R5	R7
-      0x781E0015,  //  00B2  JMPF	R7	#00C9
-      0xB81E2E00,  //  00B3  GETNGBL	R7	K23
-      0x8C1C0F18,  //  00B4  GETMET	R7	R7	K24
-      0x5824001B,  //  00B5  LDCONST	R9	K27
-      0x50280200,  //  00B6  LDBOOL	R10	1	0
-      0x7C1C0600,  //  00B7  CALL	R7	3
-      0x941C0F1C,  //  00B8  GETIDX	R7	R7	K28
-      0x941C0F1D,  //  00B9  GETIDX	R7	R7	K29
-      0x8C200D12,  //  00BA  GETMET	R8	R6	K18
-      0x5C280E00,  //  00BB  MOVE	R10	R7
-      0x582C001E,  //  00BC  LDCONST	R11	K30
-      0x7C200600,  //  00BD  CALL	R8	3
-      0x24241105,  //  00BE  GT	R9	R8	K5
-      0x78260002,  //  00BF  JMPF	R9	#00C3
-      0x04241108,  //  00C0  SUB	R9	R8	K8
-      0x40260A09,  //  00C1  CONNECT	R9	K5	R9
-      0x941C0E09,  //  00C2  GETIDX	R7	R7	R9
-      0x8C240706,  //  00C3  GETMET	R9	R3	K6
-      0x882C0716,  //  00C4  GETMBR	R11	R3	K22
-      0x5C300E00,  //  00C5  MOVE	R12	R7
-      0x7C240600,  //  00C6  CALL	R9	3
-      0x80041200,  //  00C7  RET	1	R9
-      0x7002002E,  //  00C8  JMP		#00F8
-      0x541E000E,  //  00C9  LDINT	R7	15
-      0x1C1C0A07,  //  00CA  EQ	R7	R5	R7
-      0x781E000B,  //  00CB  JMPF	R7	#00D8
-      0x8C1C0706,  //  00CC  GETMET	R7	R3	K6
-      0x88240716,  //  00CD  GETMBR	R9	R3	K22
-      0xB82A2E00,  //  00CE  GETNGBL	R10	K23
-      0x8C28151F,  //  00CF  GETMET	R10	R10	K31
-      0x7C280200,  //  00D0  CALL	R10	1
-      0x8C281512,  //  00D1  GETMET	R10	R10	K18
-      0x58300020,  //  00D2  LDCONST	R12	K32
-      0x58340021,  //  00D3  LDCONST	R13	K33
-      0x7C280600,  //  00D4  CALL	R10	3
-      0x7C1C0600,  //  00D5  CALL	R7	3
-      0x80040E00,  //  00D6  RET	1	R7
-      0x7002001F,  //  00D7  JMP		#00F8
-      0x541E0010,  //  00D8  LDINT	R7	17
-      0x1C1C0A07,  //  00D9  EQ	R7	R5	R7
-      0x781E0005,  //  00DA  JMPF	R7	#00E1
-      0x8C1C0706,  //  00DB  GETMET	R7	R3	K6
-      0x88240722,  //  00DC  GETMBR	R9	R3	K34
-      0x58280008,  //  00DD  LDCONST	R10	K8
-      0x7C1C0600,  //  00DE  CALL	R7	3
-      0x80040E00,  //  00DF  RET	1	R7
-      0x70020016,  //  00E0  JMP		#00F8
-      0x541E0011,  //  00E1  LDINT	R7	18
-      0x1C1C0A07,  //  00E2  EQ	R7	R5	R7
-      0x781E000B,  //  00E3  JMPF	R7	#00F0
-      0x8C1C0706,  //  00E4  GETMET	R7	R3	K6
-      0x88240716,  //  00E5  GETMBR	R9	R3	K22
-      0xB82A2E00,  //  00E6  GETNGBL	R10	K23
-      0x8C28151F,  //  00E7  GETMET	R10	R10	K31
-      0x7C280200,  //  00E8  CALL	R10	1
-      0x8C281512,  //  00E9  GETMET	R10	R10	K18
-      0x58300020,  //  00EA  LDCONST	R12	K32
-      0x58340021,  //  00EB  LDCONST	R13	K33
-      0x7C280600,  //  00EC  CALL	R10	3
-      0x7C1C0600,  //  00ED  CALL	R7	3
-      0x80040E00,  //  00EE  RET	1	R7
-      0x70020007,  //  00EF  JMP		#00F8
-      0x601C0003,  //  00F0  GETGBL	R7	G3
-      0x5C200000,  //  00F1  MOVE	R8	R0
-      0x7C1C0200,  //  00F2  CALL	R7	1
-      0x8C1C0F14,  //  00F3  GETMET	R7	R7	K20
-      0x5C240200,  //  00F4  MOVE	R9	R1
-      0x5C280400,  //  00F5  MOVE	R10	R2
-      0x7C1C0600,  //  00F6  CALL	R7	3
-      0x80040E00,  //  00F7  RET	1	R7
-      0x70020007,  //  00F8  JMP		#0101
-      0x60180003,  //  00F9  GETGBL	R6	G3
-      0x5C1C0000,  //  00FA  MOVE	R7	R0
-      0x7C180200,  //  00FB  CALL	R6	1
-      0x8C180D14,  //  00FC  GETMET	R6	R6	K20
-      0x5C200200,  //  00FD  MOVE	R8	R1
-      0x5C240400,  //  00FE  MOVE	R9	R2
-      0x7C180600,  //  00FF  CALL	R6	3
-      0x80040C00,  //  0100  RET	1	R6
-      0x80000000,  //  0101  RET	0
+      0x7822000E,  //  007D  JMPF	R8	#008D
+      0x88200114,  //  007E  GETMBR	R8	R0	K20
+      0x88201115,  //  007F  GETMBR	R8	R8	K21
+      0x7422000B,  //  0080  JMPT	R8	#008D
+      0x8C200D0E,  //  0081  GETMET	R8	R6	K14
+      0x7C200200,  //  0082  CALL	R8	1
+      0x8C24110F,  //  0083  GETMET	R9	R8	K15
+      0x582C0005,  //  0084  LDCONST	R11	K5
+      0x88300707,  //  0085  GETMBR	R12	R3	K7
+      0x54360012,  //  0086  LDINT	R13	19
+      0x7C240800,  //  0087  CALL	R9	4
+      0x8C24110F,  //  0088  GETMET	R9	R8	K15
+      0x582C0008,  //  0089  LDCONST	R11	K8
+      0x88300707,  //  008A  GETMBR	R12	R3	K7
+      0x58340008,  //  008B  LDCONST	R13	K8
+      0x7C240800,  //  008C  CALL	R9	4
+      0x80040C00,  //  008D  RET	1	R6
+      0x70020007,  //  008E  JMP		#0097
+      0x60180003,  //  008F  GETGBL	R6	G3
+      0x5C1C0000,  //  0090  MOVE	R7	R0
+      0x7C180200,  //  0091  CALL	R6	1
+      0x8C180D16,  //  0092  GETMET	R6	R6	K22
+      0x5C200200,  //  0093  MOVE	R8	R1
+      0x5C240400,  //  0094  MOVE	R9	R2
+      0x7C180600,  //  0095  CALL	R6	3
+      0x80040C00,  //  0096  RET	1	R6
+      0x7002006B,  //  0097  JMP		#0104
+      0x541A0038,  //  0098  LDINT	R6	57
+      0x1C180806,  //  0099  EQ	R6	R4	R6
+      0x781A0060,  //  009A  JMPF	R6	#00FC
+      0xA41A2E00,  //  009B  IMPORT	R6	K23
+      0x1C1C0B04,  //  009C  EQ	R7	R5	K4
+      0x781E000A,  //  009D  JMPF	R7	#00A9
+      0x8C1C0706,  //  009E  GETMET	R7	R3	K6
+      0x88240718,  //  009F  GETMBR	R9	R3	K24
+      0xB82A3200,  //  00A0  GETNGBL	R10	K25
+      0x8C28151A,  //  00A1  GETMET	R10	R10	K26
+      0x5830001B,  //  00A2  LDCONST	R12	K27
+      0x50340200,  //  00A3  LDBOOL	R13	1	0
+      0x7C280600,  //  00A4  CALL	R10	3
+      0x9428151B,  //  00A5  GETIDX	R10	R10	K27
+      0x7C1C0600,  //  00A6  CALL	R7	3
+      0x80040E00,  //  00A7  RET	1	R7
+      0x70020051,  //  00A8  JMP		#00FB
+      0x541E0004,  //  00A9  LDINT	R7	5
+      0x1C1C0A07,  //  00AA  EQ	R7	R5	R7
+      0x781E0006,  //  00AB  JMPF	R7	#00B3
+      0x8C1C0706,  //  00AC  GETMET	R7	R3	K6
+      0x88240718,  //  00AD  GETMBR	R9	R3	K24
+      0x8C28011C,  //  00AE  GETMET	R10	R0	K28
+      0x7C280200,  //  00AF  CALL	R10	1
+      0x7C1C0600,  //  00B0  CALL	R7	3
+      0x80040E00,  //  00B1  RET	1	R7
+      0x70020047,  //  00B2  JMP		#00FB
+      0x541E0009,  //  00B3  LDINT	R7	10
+      0x1C1C0A07,  //  00B4  EQ	R7	R5	R7
+      0x781E0015,  //  00B5  JMPF	R7	#00CC
+      0xB81E3200,  //  00B6  GETNGBL	R7	K25
+      0x8C1C0F1A,  //  00B7  GETMET	R7	R7	K26
+      0x5824001D,  //  00B8  LDCONST	R9	K29
+      0x50280200,  //  00B9  LDBOOL	R10	1	0
+      0x7C1C0600,  //  00BA  CALL	R7	3
+      0x941C0F1E,  //  00BB  GETIDX	R7	R7	K30
+      0x941C0F1F,  //  00BC  GETIDX	R7	R7	K31
+      0x8C200D12,  //  00BD  GETMET	R8	R6	K18
+      0x5C280E00,  //  00BE  MOVE	R10	R7
+      0x582C0020,  //  00BF  LDCONST	R11	K32
+      0x7C200600,  //  00C0  CALL	R8	3
+      0x24241105,  //  00C1  GT	R9	R8	K5
+      0x78260002,  //  00C2  JMPF	R9	#00C6
+      0x04241108,  //  00C3  SUB	R9	R8	K8
+      0x40260A09,  //  00C4  CONNECT	R9	K5	R9
+      0x941C0E09,  //  00C5  GETIDX	R7	R7	R9
+      0x8C240706,  //  00C6  GETMET	R9	R3	K6
+      0x882C0718,  //  00C7  GETMBR	R11	R3	K24
+      0x5C300E00,  //  00C8  MOVE	R12	R7
+      0x7C240600,  //  00C9  CALL	R9	3
+      0x80041200,  //  00CA  RET	1	R9
+      0x7002002E,  //  00CB  JMP		#00FB
+      0x541E000E,  //  00CC  LDINT	R7	15
+      0x1C1C0A07,  //  00CD  EQ	R7	R5	R7
+      0x781E000B,  //  00CE  JMPF	R7	#00DB
+      0x8C1C0706,  //  00CF  GETMET	R7	R3	K6
+      0x88240718,  //  00D0  GETMBR	R9	R3	K24
+      0xB82A3200,  //  00D1  GETNGBL	R10	K25
+      0x8C281521,  //  00D2  GETMET	R10	R10	K33
+      0x7C280200,  //  00D3  CALL	R10	1
+      0x8C281512,  //  00D4  GETMET	R10	R10	K18
+      0x58300022,  //  00D5  LDCONST	R12	K34
+      0x58340023,  //  00D6  LDCONST	R13	K35
+      0x7C280600,  //  00D7  CALL	R10	3
+      0x7C1C0600,  //  00D8  CALL	R7	3
+      0x80040E00,  //  00D9  RET	1	R7
+      0x7002001F,  //  00DA  JMP		#00FB
+      0x541E0010,  //  00DB  LDINT	R7	17
+      0x1C1C0A07,  //  00DC  EQ	R7	R5	R7
+      0x781E0005,  //  00DD  JMPF	R7	#00E4
+      0x8C1C0706,  //  00DE  GETMET	R7	R3	K6
+      0x88240724,  //  00DF  GETMBR	R9	R3	K36
+      0x58280008,  //  00E0  LDCONST	R10	K8
+      0x7C1C0600,  //  00E1  CALL	R7	3
+      0x80040E00,  //  00E2  RET	1	R7
+      0x70020016,  //  00E3  JMP		#00FB
+      0x541E0011,  //  00E4  LDINT	R7	18
+      0x1C1C0A07,  //  00E5  EQ	R7	R5	R7
+      0x781E000B,  //  00E6  JMPF	R7	#00F3
+      0x8C1C0706,  //  00E7  GETMET	R7	R3	K6
+      0x88240718,  //  00E8  GETMBR	R9	R3	K24
+      0xB82A3200,  //  00E9  GETNGBL	R10	K25
+      0x8C281521,  //  00EA  GETMET	R10	R10	K33
+      0x7C280200,  //  00EB  CALL	R10	1
+      0x8C281512,  //  00EC  GETMET	R10	R10	K18
+      0x58300022,  //  00ED  LDCONST	R12	K34
+      0x58340023,  //  00EE  LDCONST	R13	K35
+      0x7C280600,  //  00EF  CALL	R10	3
+      0x7C1C0600,  //  00F0  CALL	R7	3
+      0x80040E00,  //  00F1  RET	1	R7
+      0x70020007,  //  00F2  JMP		#00FB
+      0x601C0003,  //  00F3  GETGBL	R7	G3
+      0x5C200000,  //  00F4  MOVE	R8	R0
+      0x7C1C0200,  //  00F5  CALL	R7	1
+      0x8C1C0F16,  //  00F6  GETMET	R7	R7	K22
+      0x5C240200,  //  00F7  MOVE	R9	R1
+      0x5C280400,  //  00F8  MOVE	R10	R2
+      0x7C1C0600,  //  00F9  CALL	R7	3
+      0x80040E00,  //  00FA  RET	1	R7
+      0x70020007,  //  00FB  JMP		#0104
+      0x60180003,  //  00FC  GETGBL	R6	G3
+      0x5C1C0000,  //  00FD  MOVE	R7	R0
+      0x7C180200,  //  00FE  CALL	R6	1
+      0x8C180D16,  //  00FF  GETMET	R6	R6	K22
+      0x5C200200,  //  0100  MOVE	R8	R1
+      0x5C240400,  //  0101  MOVE	R9	R2
+      0x7C180600,  //  0102  CALL	R6	3
+      0x80040C00,  //  0103  RET	1	R6
+      0x80000000,  //  0104  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
@@ -2095,7 +2095,7 @@ be_local_closure(Matter_UI_web_add_handler,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_show_passcode_form,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    9,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2103,7 +2103,7 @@ be_local_closure(Matter_UI_show_passcode_form,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
+    ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_nested_str_weak(content_send),
     /* K2   */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20Advanced_X20Configuration_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
@@ -2118,11 +2118,13 @@ be_local_closure(Matter_UI_show_passcode_form,   /* name */
     /* K11  */  be_nested_str_weak(_X20checked),
     /* K12  */  be_nested_str_weak(),
     /* K13  */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20type_X3D_X27checkbox_X27_X20name_X3D_X27ipv4_X27_X25s_X3EIPv4_X20only_X3C_X2Fp_X3E),
-    /* K14  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27passcode_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K14  */  be_nested_str_weak(disable_bridge_mode),
+    /* K15  */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20type_X3D_X27checkbox_X27_X20name_X3D_X27nobridge_X27_X25s_X3EDisable_X20bridge_X20mode_X20_X28not_X20recommended_X29_X3C_X2Fp_X3E),
+    /* K16  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27passcode_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
     }),
     be_str_weak(show_passcode_form),
     &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
+    ( &(const binstruction[52]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x8C080301,  //  0001  GETMET	R2	R1	K1
       0x58100002,  //  0002  LDCONST	R4	K2
@@ -2159,10 +2161,22 @@ be_local_closure(Matter_UI_show_passcode_form,   /* name */
       0x5C1C0400,  //  0021  MOVE	R7	R2
       0x7C140400,  //  0022  CALL	R5	2
       0x7C0C0400,  //  0023  CALL	R3	2
-      0x8C0C0301,  //  0024  GETMET	R3	R1	K1
-      0x5814000E,  //  0025  LDCONST	R5	K14
-      0x7C0C0400,  //  0026  CALL	R3	2
-      0x80000000,  //  0027  RET	0
+      0x880C0105,  //  0024  GETMBR	R3	R0	K5
+      0x880C070E,  //  0025  GETMBR	R3	R3	K14
+      0x780E0001,  //  0026  JMPF	R3	#0029
+      0x580C000B,  //  0027  LDCONST	R3	K11
+      0x70020000,  //  0028  JMP		#002A
+      0x580C000C,  //  0029  LDCONST	R3	K12
+      0x8C100301,  //  002A  GETMET	R4	R1	K1
+      0x60180018,  //  002B  GETGBL	R6	G24
+      0x581C000F,  //  002C  LDCONST	R7	K15
+      0x5C200600,  //  002D  MOVE	R8	R3
+      0x7C180400,  //  002E  CALL	R6	2
+      0x7C100400,  //  002F  CALL	R4	2
+      0x8C100301,  //  0030  GETMET	R4	R1	K1
+      0x58180010,  //  0031  LDCONST	R6	K16
+      0x7C100400,  //  0032  CALL	R4	2
+      0x80000000,  //  0033  RET	0
     })
   )
 );
@@ -2182,7 +2196,7 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[99]) {     /* constants */
+    ( &(const bvalue[101]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_nested_str_weak(check_privileged_access),
     /* K2   */  be_nested_str_weak(string),
@@ -2208,84 +2222,86 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
     /* K22  */  be_nested_str_weak(ipv4only),
     /* K23  */  be_nested_str_weak(ipv4),
     /* K24  */  be_nested_str_weak(on),
-    /* K25  */  be_nested_str_weak(save_param),
-    /* K26  */  be_nested_str_weak(redirect),
-    /* K27  */  be_nested_str_weak(_X2F_X3Frst_X3D),
-    /* K28  */  be_nested_str_weak(save),
-    /* K29  */  be_nested_str_weak(menable),
-    /* K30  */  be_nested_str_weak(comm),
-    /* K31  */  be_nested_str_weak(matter_enabled),
-    /* K32  */  be_nested_str_weak(enable),
-    /* K33  */  be_nested_str_weak(cmd),
-    /* K34  */  be_nested_str_weak(SetOption),
-    /* K35  */  be_nested_str_weak(matter),
-    /* K36  */  be_nested_str_weak(MATTER_OPTION),
-    /* K37  */  be_nested_str_weak(_X201),
-    /* K38  */  be_nested_str_weak(disable),
-    /* K39  */  be_nested_str_weak(_X200),
-    /* K40  */  be_nested_str_weak(commissioning_open),
-    /* K41  */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K42  */  be_nested_str_weak(stop_basic_commissioning),
-    /* K43  */  be_nested_str_weak(_X2F),
-    /* K44  */  be_nested_str_weak(del_fabric),
-    /* K45  */  be_nested_str_weak(sessions),
-    /* K46  */  be_nested_str_weak(fabrics),
-    /* K47  */  be_nested_str_weak(get_fabric_index),
-    /* K48  */  be_nested_str_weak(remove_fabric),
-    /* K49  */  be_nested_str_weak(_X2Fmatterc_X3F),
-    /* K50  */  be_nested_str_weak(auto),
-    /* K51  */  be_nested_str_weak(plugins_persist),
-    /* K52  */  be_nested_str_weak(config),
-    /* K53  */  be_nested_str_weak(find),
-    /* K54  */  be_const_int(2147483647),
-    /* K55  */  be_nested_str_weak(plugins_config),
-    /* K56  */  be_nested_str_weak(plugins_classes),
-    /* K57  */  be_nested_str_weak(type),
-    /* K58  */  be_nested_str_weak(),
-    /* K59  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20arg_X3D_X25s),
-    /* K60  */  be_nested_str_weak(ui_conf_to_string),
-    /* K61  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20prev_arg_X3D_X27_X25s_X27_X20arg_X3D_X27_X25s_X27_X20_X25s),
-    /* K62  */  be_nested_str_weak(changed),
-    /* K63  */  be_nested_str_weak(ui_string_to_conf),
-    /* K64  */  be_nested_str_weak(find_plugin_by_endpoint),
-    /* K65  */  be_nested_str_weak(MTR_X3A_X20apply_X20conf_X20_X27_X25s_X27_X20_X28_X25i_X29_X20to_X20_X25s),
-    /* K66  */  be_nested_str_weak(parse_configuration),
-    /* K67  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20not_X20found),
-    /* K68  */  be_nested_str_weak(nam),
-    /* K69  */  be_nested_str_weak(name),
-    /* K70  */  be_nested_str_weak(set_name),
-    /* K71  */  be_nested_str_weak(remove),
-    /* K72  */  be_nested_str_weak(MTR_X3A_X20apply_X20name_X20_X27_X25s_X27_X20_X28_X25i_X29_X20to_X20_X25s),
-    /* K73  */  be_nested_str_weak(MTR_X3A_X20config_X20_X3D_X20_X25s),
-    /* K74  */  be_nested_str_weak(MTR_X3A_X20config_X20error_X20_X3D_X20_X25s),
-    /* K75  */  be_nested_str_weak(addep),
-    /* K76  */  be_nested_str_weak(pi),
-    /* K77  */  be_nested_str_weak(MTR_X3A_X20add_X20endpoint_X20typ_X3D_X27_X25s_X27_X20arg_X3D_X27_X25s_X27),
-    /* K78  */  be_nested_str_weak(bridge_add_endpoint),
-    /* K79  */  be_nested_str_weak(addrem),
-    /* K80  */  be_nested_str_weak(url),
-    /* K81  */  be_nested_str_weak(value_error),
-    /* K82  */  be_nested_str_weak(url_X20shouldn_X27t_X20be_X20null),
-    /* K83  */  be_nested_str_weak(equal_map),
-    /* K84  */  be_nested_str_weak(MTR_X3A_X20remote_X20add_X20url_X3D_X27_X25s_X27_X20type_X3D_X27_X25s_X27_X20arg_X3D_X27_X25s_X27),
-    /* K85  */  be_nested_str_weak(del),
-    /* K86  */  be_nested_str_weak(bridge_remove_endpoint),
-    /* K87  */  be_nested_str_weak(content_start),
-    /* K88  */  be_nested_str_weak(Parameter_X20error),
-    /* K89  */  be_nested_str_weak(content_send_style),
-    /* K90  */  be_nested_str_weak(content_send),
-    /* K91  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EError_X3A_X3C_X2Fb_X3E_X25s_X3C_X2Fp_X3E),
-    /* K92  */  be_nested_str_weak(html_escape),
-    /* K93  */  be_nested_str_weak(content_button),
-    /* K94  */  be_nested_str_weak(BUTTON_CONFIGURATION),
-    /* K95  */  be_nested_str_weak(content_stop),
-    /* K96  */  be_nested_str_weak(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    /* K97  */  be_const_int(2),
-    /* K98  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E),
+    /* K25  */  be_nested_str_weak(disable_bridge_mode),
+    /* K26  */  be_nested_str_weak(nobridge),
+    /* K27  */  be_nested_str_weak(save_param),
+    /* K28  */  be_nested_str_weak(redirect),
+    /* K29  */  be_nested_str_weak(_X2F_X3Frst_X3D),
+    /* K30  */  be_nested_str_weak(save),
+    /* K31  */  be_nested_str_weak(menable),
+    /* K32  */  be_nested_str_weak(comm),
+    /* K33  */  be_nested_str_weak(matter_enabled),
+    /* K34  */  be_nested_str_weak(enable),
+    /* K35  */  be_nested_str_weak(cmd),
+    /* K36  */  be_nested_str_weak(SetOption),
+    /* K37  */  be_nested_str_weak(matter),
+    /* K38  */  be_nested_str_weak(MATTER_OPTION),
+    /* K39  */  be_nested_str_weak(_X201),
+    /* K40  */  be_nested_str_weak(disable),
+    /* K41  */  be_nested_str_weak(_X200),
+    /* K42  */  be_nested_str_weak(commissioning_open),
+    /* K43  */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K44  */  be_nested_str_weak(stop_basic_commissioning),
+    /* K45  */  be_nested_str_weak(_X2F),
+    /* K46  */  be_nested_str_weak(del_fabric),
+    /* K47  */  be_nested_str_weak(sessions),
+    /* K48  */  be_nested_str_weak(fabrics),
+    /* K49  */  be_nested_str_weak(get_fabric_index),
+    /* K50  */  be_nested_str_weak(remove_fabric),
+    /* K51  */  be_nested_str_weak(_X2Fmatterc_X3F),
+    /* K52  */  be_nested_str_weak(auto),
+    /* K53  */  be_nested_str_weak(plugins_persist),
+    /* K54  */  be_nested_str_weak(config),
+    /* K55  */  be_nested_str_weak(find),
+    /* K56  */  be_const_int(2147483647),
+    /* K57  */  be_nested_str_weak(plugins_config),
+    /* K58  */  be_nested_str_weak(plugins_classes),
+    /* K59  */  be_nested_str_weak(type),
+    /* K60  */  be_nested_str_weak(),
+    /* K61  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20arg_X3D_X25s),
+    /* K62  */  be_nested_str_weak(ui_conf_to_string),
+    /* K63  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20prev_arg_X3D_X27_X25s_X27_X20arg_X3D_X27_X25s_X27_X20_X25s),
+    /* K64  */  be_nested_str_weak(changed),
+    /* K65  */  be_nested_str_weak(ui_string_to_conf),
+    /* K66  */  be_nested_str_weak(find_plugin_by_endpoint),
+    /* K67  */  be_nested_str_weak(MTR_X3A_X20apply_X20conf_X20_X27_X25s_X27_X20_X28_X25i_X29_X20to_X20_X25s),
+    /* K68  */  be_nested_str_weak(parse_configuration),
+    /* K69  */  be_nested_str_weak(MTR_X3A_X20ep_X3D_X25i_X20not_X20found),
+    /* K70  */  be_nested_str_weak(nam),
+    /* K71  */  be_nested_str_weak(name),
+    /* K72  */  be_nested_str_weak(set_name),
+    /* K73  */  be_nested_str_weak(remove),
+    /* K74  */  be_nested_str_weak(MTR_X3A_X20apply_X20name_X20_X27_X25s_X27_X20_X28_X25i_X29_X20to_X20_X25s),
+    /* K75  */  be_nested_str_weak(MTR_X3A_X20config_X20_X3D_X20_X25s),
+    /* K76  */  be_nested_str_weak(MTR_X3A_X20config_X20error_X20_X3D_X20_X25s),
+    /* K77  */  be_nested_str_weak(addep),
+    /* K78  */  be_nested_str_weak(pi),
+    /* K79  */  be_nested_str_weak(MTR_X3A_X20add_X20endpoint_X20typ_X3D_X27_X25s_X27_X20arg_X3D_X27_X25s_X27),
+    /* K80  */  be_nested_str_weak(bridge_add_endpoint),
+    /* K81  */  be_nested_str_weak(addrem),
+    /* K82  */  be_nested_str_weak(url),
+    /* K83  */  be_nested_str_weak(value_error),
+    /* K84  */  be_nested_str_weak(url_X20shouldn_X27t_X20be_X20null),
+    /* K85  */  be_nested_str_weak(equal_map),
+    /* K86  */  be_nested_str_weak(MTR_X3A_X20remote_X20add_X20url_X3D_X27_X25s_X27_X20type_X3D_X27_X25s_X27_X20arg_X3D_X27_X25s_X27),
+    /* K87  */  be_nested_str_weak(del),
+    /* K88  */  be_nested_str_weak(bridge_remove_endpoint),
+    /* K89  */  be_nested_str_weak(content_start),
+    /* K90  */  be_nested_str_weak(Parameter_X20error),
+    /* K91  */  be_nested_str_weak(content_send_style),
+    /* K92  */  be_nested_str_weak(content_send),
+    /* K93  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EError_X3A_X3C_X2Fb_X3E_X25s_X3C_X2Fp_X3E),
+    /* K94  */  be_nested_str_weak(html_escape),
+    /* K95  */  be_nested_str_weak(content_button),
+    /* K96  */  be_nested_str_weak(BUTTON_CONFIGURATION),
+    /* K97  */  be_nested_str_weak(content_stop),
+    /* K98  */  be_nested_str_weak(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+    /* K99  */  be_const_int(2),
+    /* K100 */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E),
     }),
     be_str_weak(page_part_ctl),
     &be_const_str_solidified,
-    ( &(const binstruction[688]) {  /* code */
+    ( &(const binstruction[694]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x8C080301,  //  0001  GETMET	R2	R1	K1
       0x7C080200,  //  0002  CALL	R2	1
@@ -2296,7 +2312,7 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0xA40E0600,  //  0007  IMPORT	R3	K3
       0xA4120800,  //  0008  IMPORT	R4	K4
       0x4C140000,  //  0009  LDNIL	R5
-      0xA8020285,  //  000A  EXBLK	0	#0291
+      0xA802028B,  //  000A  EXBLK	0	#0297
       0x60180010,  //  000B  GETGBL	R6	G16
       0x8C1C0306,  //  000C  GETMET	R7	R1	K6
       0x7C1C0200,  //  000D  CALL	R7	1
@@ -2330,7 +2346,7 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x8C18030E,  //  0029  GETMET	R6	R1	K14
       0x58200010,  //  002A  LDCONST	R8	K16
       0x7C180400,  //  002B  CALL	R6	2
-      0x781A002A,  //  002C  JMPF	R6	#0058
+      0x781A0030,  //  002C  JMPF	R6	#005E
       0xB81A1000,  //  002D  GETNGBL	R6	K8
       0x8C180D09,  //  002E  GETMET	R6	R6	K9
       0x60200018,  //  002F  GETGBL	R8	G24
@@ -2368,612 +2384,618 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x1C1C0F18,  //  004F  EQ	R7	R7	K24
       0x901A2C07,  //  0050  SETMBR	R6	K22	R7
       0x88180113,  //  0051  GETMBR	R6	R0	K19
-      0x8C180D19,  //  0052  GETMET	R6	R6	K25
-      0x7C180200,  //  0053  CALL	R6	1
-      0x8C18031A,  //  0054  GETMET	R6	R1	K26
-      0x5820001B,  //  0055  LDCONST	R8	K27
-      0x7C180400,  //  0056  CALL	R6	2
-      0x70020223,  //  0057  JMP		#027C
-      0x8C18030E,  //  0058  GETMET	R6	R1	K14
-      0x5820001C,  //  0059  LDCONST	R8	K28
-      0x7C180400,  //  005A  CALL	R6	2
-      0x781A0047,  //  005B  JMPF	R6	#00A4
-      0x8C18030E,  //  005C  GETMET	R6	R1	K14
-      0x5820001D,  //  005D  LDCONST	R8	K29
-      0x7C180400,  //  005E  CALL	R6	2
-      0x8C1C030E,  //  005F  GETMET	R7	R1	K14
-      0x5824001E,  //  0060  LDCONST	R9	K30
-      0x7C1C0400,  //  0061  CALL	R7	2
-      0x8C20011F,  //  0062  GETMET	R8	R0	K31
-      0x7C200200,  //  0063  CALL	R8	1
-      0x20200C08,  //  0064  NE	R8	R6	R8
-      0x78220027,  //  0065  JMPF	R8	#008E
-      0x781A0011,  //  0066  JMPF	R6	#0079
-      0xB8221000,  //  0067  GETNGBL	R8	K8
-      0x8C201109,  //  0068  GETMET	R8	R8	K9
-      0x60280018,  //  0069  GETGBL	R10	G24
-      0x582C0011,  //  006A  LDCONST	R11	K17
-      0x58300020,  //  006B  LDCONST	R12	K32
-      0x7C280400,  //  006C  CALL	R10	2
-      0x582C0012,  //  006D  LDCONST	R11	K18
-      0x7C200600,  //  006E  CALL	R8	3
-      0xB8221000,  //  006F  GETNGBL	R8	K8
-      0x8C201121,  //  0070  GETMET	R8	R8	K33
-      0x60280008,  //  0071  GETGBL	R10	G8
-      0xB82E4600,  //  0072  GETNGBL	R11	K35
-      0x882C1724,  //  0073  GETMBR	R11	R11	K36
-      0x7C280200,  //  0074  CALL	R10	1
-      0x002A440A,  //  0075  ADD	R10	K34	R10
-      0x00281525,  //  0076  ADD	R10	R10	K37
-      0x7C200400,  //  0077  CALL	R8	2
-      0x70020010,  //  0078  JMP		#008A
-      0xB8221000,  //  0079  GETNGBL	R8	K8
-      0x8C201109,  //  007A  GETMET	R8	R8	K9
-      0x60280018,  //  007B  GETGBL	R10	G24
-      0x582C0011,  //  007C  LDCONST	R11	K17
-      0x58300026,  //  007D  LDCONST	R12	K38
-      0x7C280400,  //  007E  CALL	R10	2
-      0x582C0012,  //  007F  LDCONST	R11	K18
-      0x7C200600,  //  0080  CALL	R8	3
-      0xB8221000,  //  0081  GETNGBL	R8	K8
-      0x8C201121,  //  0082  GETMET	R8	R8	K33
-      0x60280008,  //  0083  GETGBL	R10	G8
-      0xB82E4600,  //  0084  GETNGBL	R11	K35
-      0x882C1724,  //  0085  GETMBR	R11	R11	K36
-      0x7C280200,  //  0086  CALL	R10	1
-      0x002A440A,  //  0087  ADD	R10	K34	R10
-      0x00281527,  //  0088  ADD	R10	R10	K39
-      0x7C200400,  //  0089  CALL	R8	2
-      0x8C20031A,  //  008A  GETMET	R8	R1	K26
-      0x5828001B,  //  008B  LDCONST	R10	K27
-      0x7C200400,  //  008C  CALL	R8	2
-      0x70020014,  //  008D  JMP		#00A3
-      0x88200113,  //  008E  GETMBR	R8	R0	K19
-      0x88201128,  //  008F  GETMBR	R8	R8	K40
-      0x4C240000,  //  0090  LDNIL	R9
-      0x20201009,  //  0091  NE	R8	R8	R9
-      0x20200E08,  //  0092  NE	R8	R7	R8
-      0x7822000B,  //  0093  JMPF	R8	#00A0
-      0x781E0003,  //  0094  JMPF	R7	#0099
-      0x88200113,  //  0095  GETMBR	R8	R0	K19
-      0x8C201129,  //  0096  GETMET	R8	R8	K41
-      0x7C200200,  //  0097  CALL	R8	1
-      0x70020002,  //  0098  JMP		#009C
-      0x88200113,  //  0099  GETMBR	R8	R0	K19
-      0x8C20112A,  //  009A  GETMET	R8	R8	K42
-      0x7C200200,  //  009B  CALL	R8	1
-      0x8C20031A,  //  009C  GETMET	R8	R1	K26
-      0x5828002B,  //  009D  LDCONST	R10	K43
-      0x7C200400,  //  009E  CALL	R8	2
-      0x70020002,  //  009F  JMP		#00A3
-      0x8C20031A,  //  00A0  GETMET	R8	R1	K26
-      0x5828002B,  //  00A1  LDCONST	R10	K43
-      0x7C200400,  //  00A2  CALL	R8	2
-      0x700201D7,  //  00A3  JMP		#027C
-      0x8C18030E,  //  00A4  GETMET	R6	R1	K14
-      0x5820002C,  //  00A5  LDCONST	R8	K44
-      0x7C180400,  //  00A6  CALL	R6	2
-      0x781A0026,  //  00A7  JMPF	R6	#00CF
-      0xB81A1000,  //  00A8  GETNGBL	R6	K8
-      0x8C180D09,  //  00A9  GETMET	R6	R6	K9
-      0x60200018,  //  00AA  GETGBL	R8	G24
-      0x58240011,  //  00AB  LDCONST	R9	K17
-      0x5828002C,  //  00AC  LDCONST	R10	K44
-      0x7C200400,  //  00AD  CALL	R8	2
-      0x58240012,  //  00AE  LDCONST	R9	K18
-      0x7C180600,  //  00AF  CALL	R6	3
-      0x60180009,  //  00B0  GETGBL	R6	G9
-      0x8C1C030C,  //  00B1  GETMET	R7	R1	K12
-      0x5824002C,  //  00B2  LDCONST	R9	K44
-      0x7C1C0400,  //  00B3  CALL	R7	2
-      0x7C180200,  //  00B4  CALL	R6	1
-      0x581C0005,  //  00B5  LDCONST	R7	K5
-      0x88200113,  //  00B6  GETMBR	R8	R0	K19
-      0x8820112D,  //  00B7  GETMBR	R8	R8	K45
-      0x8820112E,  //  00B8  GETMBR	R8	R8	K46
-      0x6024000C,  //  00B9  GETGBL	R9	G12
-      0x5C281000,  //  00BA  MOVE	R10	R8
-      0x7C240200,  //  00BB  CALL	R9	1
-      0x14240E09,  //  00BC  LT	R9	R7	R9
-      0x7826000C,  //  00BD  JMPF	R9	#00CB
-      0x94241007,  //  00BE  GETIDX	R9	R8	R7
-      0x8C24132F,  //  00BF  GETMET	R9	R9	K47
-      0x7C240200,  //  00C0  CALL	R9	1
-      0x1C241206,  //  00C1  EQ	R9	R9	R6
-      0x78260005,  //  00C2  JMPF	R9	#00C9
-      0x88240113,  //  00C3  GETMBR	R9	R0	K19
-      0x8C241330,  //  00C4  GETMET	R9	R9	K48
-      0x942C1007,  //  00C5  GETIDX	R11	R8	R7
-      0x7C240400,  //  00C6  CALL	R9	2
-      0x70020002,  //  00C7  JMP		#00CB
-      0x70020000,  //  00C8  JMP		#00CA
-      0x001C0F07,  //  00C9  ADD	R7	R7	K7
-      0x7001FFED,  //  00CA  JMP		#00B9
-      0x8C24031A,  //  00CB  GETMET	R9	R1	K26
-      0x582C0031,  //  00CC  LDCONST	R11	K49
-      0x7C240400,  //  00CD  CALL	R9	2
-      0x700201AC,  //  00CE  JMP		#027C
-      0x8C18030E,  //  00CF  GETMET	R6	R1	K14
-      0x58200032,  //  00D0  LDCONST	R8	K50
-      0x7C180400,  //  00D1  CALL	R6	2
-      0x781A0011,  //  00D2  JMPF	R6	#00E5
-      0xB81A1000,  //  00D3  GETNGBL	R6	K8
-      0x8C180D09,  //  00D4  GETMET	R6	R6	K9
-      0x60200018,  //  00D5  GETGBL	R8	G24
-      0x58240011,  //  00D6  LDCONST	R9	K17
-      0x58280032,  //  00D7  LDCONST	R10	K50
-      0x7C200400,  //  00D8  CALL	R8	2
-      0x58240012,  //  00D9  LDCONST	R9	K18
-      0x7C180600,  //  00DA  CALL	R6	3
-      0x88180113,  //  00DB  GETMBR	R6	R0	K19
-      0x501C0000,  //  00DC  LDBOOL	R7	0	0
-      0x901A6607,  //  00DD  SETMBR	R6	K51	R7
-      0x88180113,  //  00DE  GETMBR	R6	R0	K19
-      0x8C180D19,  //  00DF  GETMET	R6	R6	K25
-      0x7C180200,  //  00E0  CALL	R6	1
-      0x8C18031A,  //  00E1  GETMET	R6	R1	K26
-      0x5820001B,  //  00E2  LDCONST	R8	K27
-      0x7C180400,  //  00E3  CALL	R6	2
-      0x70020196,  //  00E4  JMP		#027C
-      0x8C18030E,  //  00E5  GETMET	R6	R1	K14
-      0x58200034,  //  00E6  LDCONST	R8	K52
-      0x7C180400,  //  00E7  CALL	R6	2
-      0x781A00D6,  //  00E8  JMPF	R6	#01C0
-      0xB81A1000,  //  00E9  GETNGBL	R6	K8
-      0x8C180D09,  //  00EA  GETMET	R6	R6	K9
-      0x60200018,  //  00EB  GETGBL	R8	G24
-      0x58240011,  //  00EC  LDCONST	R9	K17
-      0x58280034,  //  00ED  LDCONST	R10	K52
-      0x7C200400,  //  00EE  CALL	R8	2
-      0x58240012,  //  00EF  LDCONST	R9	K18
-      0x7C180600,  //  00F0  CALL	R6	3
-      0x50180000,  //  00F1  LDBOOL	R6	0	0
-      0x601C0010,  //  00F2  GETGBL	R7	G16
-      0x8C200306,  //  00F3  GETMET	R8	R1	K6
-      0x7C200200,  //  00F4  CALL	R8	1
-      0x04201107,  //  00F5  SUB	R8	R8	K7
-      0x40220A08,  //  00F6  CONNECT	R8	K5	R8
-      0x7C1C0200,  //  00F7  CALL	R7	1
-      0xA80200A0,  //  00F8  EXBLK	0	#019A
-      0x5C200E00,  //  00F9  MOVE	R8	R7
-      0x7C200000,  //  00FA  CALL	R8	0
-      0x8C24030B,  //  00FB  GETMET	R9	R1	K11
-      0x5C2C1000,  //  00FC  MOVE	R11	R8
-      0x7C240400,  //  00FD  CALL	R9	2
-      0x8C280535,  //  00FE  GETMET	R10	R2	K53
-      0x5C301200,  //  00FF  MOVE	R12	R9
-      0x5834000C,  //  0100  LDCONST	R13	K12
-      0x7C280600,  //  0101  CALL	R10	3
-      0x1C281505,  //  0102  EQ	R10	R10	K5
-      0x782A005B,  //  0103  JMPF	R10	#0160
-      0x60280009,  //  0104  GETGBL	R10	G9
-      0x402E2536,  //  0105  CONNECT	R11	K18	K54
-      0x942C120B,  //  0106  GETIDX	R11	R9	R11
-      0x7C280200,  //  0107  CALL	R10	1
-      0x8C2C030C,  //  0108  GETMET	R11	R1	K12
-      0x5C341000,  //  0109  MOVE	R13	R8
-      0x7C2C0400,  //  010A  CALL	R11	2
-      0x88300113,  //  010B  GETMBR	R12	R0	K19
-      0x88301937,  //  010C  GETMBR	R12	R12	K55
-      0x8C301935,  //  010D  GETMET	R12	R12	K53
-      0x60380008,  //  010E  GETGBL	R14	G8
-      0x5C3C1400,  //  010F  MOVE	R15	R10
-      0x7C380200,  //  0110  CALL	R14	1
-      0x7C300400,  //  0111  CALL	R12	2
-      0x4C340000,  //  0112  LDNIL	R13
-      0x2034180D,  //  0113  NE	R13	R12	R13
-      0x78360041,  //  0114  JMPF	R13	#0157
-      0x88340113,  //  0115  GETMBR	R13	R0	K19
-      0x88341B38,  //  0116  GETMBR	R13	R13	K56
-      0x8C341B35,  //  0117  GETMET	R13	R13	K53
-      0x8C3C1935,  //  0118  GETMET	R15	R12	K53
-      0x58440039,  //  0119  LDCONST	R17	K57
-      0x5848003A,  //  011A  LDCONST	R18	K58
-      0x7C3C0600,  //  011B  CALL	R15	3
-      0x7C340400,  //  011C  CALL	R13	2
-      0x4C380000,  //  011D  LDNIL	R14
-      0x20381A0E,  //  011E  NE	R14	R13	R14
-      0x783A0035,  //  011F  JMPF	R14	#0156
-      0xB83A1000,  //  0120  GETNGBL	R14	K8
-      0x8C381D09,  //  0121  GETMET	R14	R14	K9
-      0x60400018,  //  0122  GETGBL	R16	G24
-      0x5844003B,  //  0123  LDCONST	R17	K59
-      0x5C481400,  //  0124  MOVE	R18	R10
-      0x5C4C1600,  //  0125  MOVE	R19	R11
-      0x7C400600,  //  0126  CALL	R16	3
-      0x58440012,  //  0127  LDCONST	R17	K18
-      0x7C380600,  //  0128  CALL	R14	3
-      0x8C381B3C,  //  0129  GETMET	R14	R13	K60
-      0x5C401A00,  //  012A  MOVE	R16	R13
-      0x5C441800,  //  012B  MOVE	R17	R12
-      0x7C380600,  //  012C  CALL	R14	3
-      0x203C1C0B,  //  012D  NE	R15	R14	R11
-      0xB8421000,  //  012E  GETNGBL	R16	K8
-      0x8C402109,  //  012F  GETMET	R16	R16	K9
-      0x60480018,  //  0130  GETGBL	R18	G24
-      0x584C003D,  //  0131  LDCONST	R19	K61
-      0x5C501400,  //  0132  MOVE	R20	R10
-      0x5C541C00,  //  0133  MOVE	R21	R14
-      0x5C581600,  //  0134  MOVE	R22	R11
-      0x205C1C0B,  //  0135  NE	R23	R14	R11
-      0x785E0001,  //  0136  JMPF	R23	#0139
-      0x585C003E,  //  0137  LDCONST	R23	K62
-      0x70020000,  //  0138  JMP		#013A
-      0x585C003A,  //  0139  LDCONST	R23	K58
-      0x7C480A00,  //  013A  CALL	R18	5
-      0x584C0012,  //  013B  LDCONST	R19	K18
-      0x7C400600,  //  013C  CALL	R16	3
-      0x783E0017,  //  013D  JMPF	R15	#0156
-      0x50180200,  //  013E  LDBOOL	R6	1	0
-      0x8C401B3F,  //  013F  GETMET	R16	R13	K63
-      0x5C481A00,  //  0140  MOVE	R18	R13
-      0x5C4C1800,  //  0141  MOVE	R19	R12
-      0x5C501600,  //  0142  MOVE	R20	R11
-      0x7C400800,  //  0143  CALL	R16	4
-      0x88400113,  //  0144  GETMBR	R16	R0	K19
-      0x8C402140,  //  0145  GETMET	R16	R16	K64
-      0x5C481400,  //  0146  MOVE	R18	R10
-      0x7C400400,  //  0147  CALL	R16	2
-      0x7842000C,  //  0148  JMPF	R16	#0156
-      0xB8461000,  //  0149  GETNGBL	R17	K8
-      0x8C442309,  //  014A  GETMET	R17	R17	K9
-      0x604C0018,  //  014B  GETGBL	R19	G24
-      0x58500041,  //  014C  LDCONST	R20	K65
-      0x5C541800,  //  014D  MOVE	R21	R12
-      0x5C581400,  //  014E  MOVE	R22	R10
-      0x5C5C2000,  //  014F  MOVE	R23	R16
-      0x7C4C0800,  //  0150  CALL	R19	4
-      0x58500012,  //  0151  LDCONST	R20	K18
-      0x7C440600,  //  0152  CALL	R17	3
-      0x8C442142,  //  0153  GETMET	R17	R16	K66
-      0x5C4C1800,  //  0154  MOVE	R19	R12
-      0x7C440400,  //  0155  CALL	R17	2
-      0x70020007,  //  0156  JMP		#015F
-      0xB8361000,  //  0157  GETNGBL	R13	K8
-      0x8C341B09,  //  0158  GETMET	R13	R13	K9
-      0x603C0018,  //  0159  GETGBL	R15	G24
-      0x58400043,  //  015A  LDCONST	R16	K67
-      0x5C441400,  //  015B  MOVE	R17	R10
-      0x7C3C0400,  //  015C  CALL	R15	2
-      0x58400012,  //  015D  LDCONST	R16	K18
-      0x7C340600,  //  015E  CALL	R13	3
-      0x70020038,  //  015F  JMP		#0199
-      0x8C280535,  //  0160  GETMET	R10	R2	K53
-      0x5C301200,  //  0161  MOVE	R12	R9
-      0x58340044,  //  0162  LDCONST	R13	K68
-      0x7C280600,  //  0163  CALL	R10	3
-      0x1C281505,  //  0164  EQ	R10	R10	K5
-      0x782A0032,  //  0165  JMPF	R10	#0199
-      0x60280009,  //  0166  GETGBL	R10	G9
-      0x402E2536,  //  0167  CONNECT	R11	K18	K54
-      0x942C120B,  //  0168  GETIDX	R11	R9	R11
-      0x7C280200,  //  0169  CALL	R10	1
-      0x8C2C030C,  //  016A  GETMET	R11	R1	K12
-      0x5C341000,  //  016B  MOVE	R13	R8
-      0x7C2C0400,  //  016C  CALL	R11	2
-      0x88300113,  //  016D  GETMBR	R12	R0	K19
-      0x88301937,  //  016E  GETMBR	R12	R12	K55
-      0x8C301935,  //  016F  GETMET	R12	R12	K53
-      0x60380008,  //  0170  GETGBL	R14	G8
-      0x5C3C1400,  //  0171  MOVE	R15	R10
-      0x7C380200,  //  0172  CALL	R14	1
-      0x7C300400,  //  0173  CALL	R12	2
-      0x4C340000,  //  0174  LDNIL	R13
-      0x2034180D,  //  0175  NE	R13	R12	R13
-      0x78360021,  //  0176  JMPF	R13	#0199
-      0x8C341935,  //  0177  GETMET	R13	R12	K53
-      0x583C0045,  //  0178  LDCONST	R15	K69
-      0x5840003A,  //  0179  LDCONST	R16	K58
-      0x7C340600,  //  017A  CALL	R13	3
-      0x20381A0B,  //  017B  NE	R14	R13	R11
-      0x783A001B,  //  017C  JMPF	R14	#0199
-      0x50180200,  //  017D  LDBOOL	R6	1	0
-      0x883C0113,  //  017E  GETMBR	R15	R0	K19
-      0x8C3C1F40,  //  017F  GETMET	R15	R15	K64
-      0x5C441400,  //  0180  MOVE	R17	R10
-      0x7C3C0400,  //  0181  CALL	R15	2
-      0x783E0015,  //  0182  JMPF	R15	#0199
-      0x8C401F46,  //  0183  GETMET	R16	R15	K70
-      0x5C481600,  //  0184  MOVE	R18	R11
-      0x7C400400,  //  0185  CALL	R16	2
-      0x782E0001,  //  0186  JMPF	R11	#0189
-      0x98328A0B,  //  0187  SETIDX	R12	K69	R11
-      0x70020002,  //  0188  JMP		#018C
-      0x8C401947,  //  0189  GETMET	R16	R12	K71
-      0x58480045,  //  018A  LDCONST	R18	K69
+      0x8C1C030C,  //  0052  GETMET	R7	R1	K12
+      0x5824001A,  //  0053  LDCONST	R9	K26
+      0x7C1C0400,  //  0054  CALL	R7	2
+      0x1C1C0F18,  //  0055  EQ	R7	R7	K24
+      0x901A3207,  //  0056  SETMBR	R6	K25	R7
+      0x88180113,  //  0057  GETMBR	R6	R0	K19
+      0x8C180D1B,  //  0058  GETMET	R6	R6	K27
+      0x7C180200,  //  0059  CALL	R6	1
+      0x8C18031C,  //  005A  GETMET	R6	R1	K28
+      0x5820001D,  //  005B  LDCONST	R8	K29
+      0x7C180400,  //  005C  CALL	R6	2
+      0x70020223,  //  005D  JMP		#0282
+      0x8C18030E,  //  005E  GETMET	R6	R1	K14
+      0x5820001E,  //  005F  LDCONST	R8	K30
+      0x7C180400,  //  0060  CALL	R6	2
+      0x781A0047,  //  0061  JMPF	R6	#00AA
+      0x8C18030E,  //  0062  GETMET	R6	R1	K14
+      0x5820001F,  //  0063  LDCONST	R8	K31
+      0x7C180400,  //  0064  CALL	R6	2
+      0x8C1C030E,  //  0065  GETMET	R7	R1	K14
+      0x58240020,  //  0066  LDCONST	R9	K32
+      0x7C1C0400,  //  0067  CALL	R7	2
+      0x8C200121,  //  0068  GETMET	R8	R0	K33
+      0x7C200200,  //  0069  CALL	R8	1
+      0x20200C08,  //  006A  NE	R8	R6	R8
+      0x78220027,  //  006B  JMPF	R8	#0094
+      0x781A0011,  //  006C  JMPF	R6	#007F
+      0xB8221000,  //  006D  GETNGBL	R8	K8
+      0x8C201109,  //  006E  GETMET	R8	R8	K9
+      0x60280018,  //  006F  GETGBL	R10	G24
+      0x582C0011,  //  0070  LDCONST	R11	K17
+      0x58300022,  //  0071  LDCONST	R12	K34
+      0x7C280400,  //  0072  CALL	R10	2
+      0x582C0012,  //  0073  LDCONST	R11	K18
+      0x7C200600,  //  0074  CALL	R8	3
+      0xB8221000,  //  0075  GETNGBL	R8	K8
+      0x8C201123,  //  0076  GETMET	R8	R8	K35
+      0x60280008,  //  0077  GETGBL	R10	G8
+      0xB82E4A00,  //  0078  GETNGBL	R11	K37
+      0x882C1726,  //  0079  GETMBR	R11	R11	K38
+      0x7C280200,  //  007A  CALL	R10	1
+      0x002A480A,  //  007B  ADD	R10	K36	R10
+      0x00281527,  //  007C  ADD	R10	R10	K39
+      0x7C200400,  //  007D  CALL	R8	2
+      0x70020010,  //  007E  JMP		#0090
+      0xB8221000,  //  007F  GETNGBL	R8	K8
+      0x8C201109,  //  0080  GETMET	R8	R8	K9
+      0x60280018,  //  0081  GETGBL	R10	G24
+      0x582C0011,  //  0082  LDCONST	R11	K17
+      0x58300028,  //  0083  LDCONST	R12	K40
+      0x7C280400,  //  0084  CALL	R10	2
+      0x582C0012,  //  0085  LDCONST	R11	K18
+      0x7C200600,  //  0086  CALL	R8	3
+      0xB8221000,  //  0087  GETNGBL	R8	K8
+      0x8C201123,  //  0088  GETMET	R8	R8	K35
+      0x60280008,  //  0089  GETGBL	R10	G8
+      0xB82E4A00,  //  008A  GETNGBL	R11	K37
+      0x882C1726,  //  008B  GETMBR	R11	R11	K38
+      0x7C280200,  //  008C  CALL	R10	1
+      0x002A480A,  //  008D  ADD	R10	K36	R10
+      0x00281529,  //  008E  ADD	R10	R10	K41
+      0x7C200400,  //  008F  CALL	R8	2
+      0x8C20031C,  //  0090  GETMET	R8	R1	K28
+      0x5828001D,  //  0091  LDCONST	R10	K29
+      0x7C200400,  //  0092  CALL	R8	2
+      0x70020014,  //  0093  JMP		#00A9
+      0x88200113,  //  0094  GETMBR	R8	R0	K19
+      0x8820112A,  //  0095  GETMBR	R8	R8	K42
+      0x4C240000,  //  0096  LDNIL	R9
+      0x20201009,  //  0097  NE	R8	R8	R9
+      0x20200E08,  //  0098  NE	R8	R7	R8
+      0x7822000B,  //  0099  JMPF	R8	#00A6
+      0x781E0003,  //  009A  JMPF	R7	#009F
+      0x88200113,  //  009B  GETMBR	R8	R0	K19
+      0x8C20112B,  //  009C  GETMET	R8	R8	K43
+      0x7C200200,  //  009D  CALL	R8	1
+      0x70020002,  //  009E  JMP		#00A2
+      0x88200113,  //  009F  GETMBR	R8	R0	K19
+      0x8C20112C,  //  00A0  GETMET	R8	R8	K44
+      0x7C200200,  //  00A1  CALL	R8	1
+      0x8C20031C,  //  00A2  GETMET	R8	R1	K28
+      0x5828002D,  //  00A3  LDCONST	R10	K45
+      0x7C200400,  //  00A4  CALL	R8	2
+      0x70020002,  //  00A5  JMP		#00A9
+      0x8C20031C,  //  00A6  GETMET	R8	R1	K28
+      0x5828002D,  //  00A7  LDCONST	R10	K45
+      0x7C200400,  //  00A8  CALL	R8	2
+      0x700201D7,  //  00A9  JMP		#0282
+      0x8C18030E,  //  00AA  GETMET	R6	R1	K14
+      0x5820002E,  //  00AB  LDCONST	R8	K46
+      0x7C180400,  //  00AC  CALL	R6	2
+      0x781A0026,  //  00AD  JMPF	R6	#00D5
+      0xB81A1000,  //  00AE  GETNGBL	R6	K8
+      0x8C180D09,  //  00AF  GETMET	R6	R6	K9
+      0x60200018,  //  00B0  GETGBL	R8	G24
+      0x58240011,  //  00B1  LDCONST	R9	K17
+      0x5828002E,  //  00B2  LDCONST	R10	K46
+      0x7C200400,  //  00B3  CALL	R8	2
+      0x58240012,  //  00B4  LDCONST	R9	K18
+      0x7C180600,  //  00B5  CALL	R6	3
+      0x60180009,  //  00B6  GETGBL	R6	G9
+      0x8C1C030C,  //  00B7  GETMET	R7	R1	K12
+      0x5824002E,  //  00B8  LDCONST	R9	K46
+      0x7C1C0400,  //  00B9  CALL	R7	2
+      0x7C180200,  //  00BA  CALL	R6	1
+      0x581C0005,  //  00BB  LDCONST	R7	K5
+      0x88200113,  //  00BC  GETMBR	R8	R0	K19
+      0x8820112F,  //  00BD  GETMBR	R8	R8	K47
+      0x88201130,  //  00BE  GETMBR	R8	R8	K48
+      0x6024000C,  //  00BF  GETGBL	R9	G12
+      0x5C281000,  //  00C0  MOVE	R10	R8
+      0x7C240200,  //  00C1  CALL	R9	1
+      0x14240E09,  //  00C2  LT	R9	R7	R9
+      0x7826000C,  //  00C3  JMPF	R9	#00D1
+      0x94241007,  //  00C4  GETIDX	R9	R8	R7
+      0x8C241331,  //  00C5  GETMET	R9	R9	K49
+      0x7C240200,  //  00C6  CALL	R9	1
+      0x1C241206,  //  00C7  EQ	R9	R9	R6
+      0x78260005,  //  00C8  JMPF	R9	#00CF
+      0x88240113,  //  00C9  GETMBR	R9	R0	K19
+      0x8C241332,  //  00CA  GETMET	R9	R9	K50
+      0x942C1007,  //  00CB  GETIDX	R11	R8	R7
+      0x7C240400,  //  00CC  CALL	R9	2
+      0x70020002,  //  00CD  JMP		#00D1
+      0x70020000,  //  00CE  JMP		#00D0
+      0x001C0F07,  //  00CF  ADD	R7	R7	K7
+      0x7001FFED,  //  00D0  JMP		#00BF
+      0x8C24031C,  //  00D1  GETMET	R9	R1	K28
+      0x582C0033,  //  00D2  LDCONST	R11	K51
+      0x7C240400,  //  00D3  CALL	R9	2
+      0x700201AC,  //  00D4  JMP		#0282
+      0x8C18030E,  //  00D5  GETMET	R6	R1	K14
+      0x58200034,  //  00D6  LDCONST	R8	K52
+      0x7C180400,  //  00D7  CALL	R6	2
+      0x781A0011,  //  00D8  JMPF	R6	#00EB
+      0xB81A1000,  //  00D9  GETNGBL	R6	K8
+      0x8C180D09,  //  00DA  GETMET	R6	R6	K9
+      0x60200018,  //  00DB  GETGBL	R8	G24
+      0x58240011,  //  00DC  LDCONST	R9	K17
+      0x58280034,  //  00DD  LDCONST	R10	K52
+      0x7C200400,  //  00DE  CALL	R8	2
+      0x58240012,  //  00DF  LDCONST	R9	K18
+      0x7C180600,  //  00E0  CALL	R6	3
+      0x88180113,  //  00E1  GETMBR	R6	R0	K19
+      0x501C0000,  //  00E2  LDBOOL	R7	0	0
+      0x901A6A07,  //  00E3  SETMBR	R6	K53	R7
+      0x88180113,  //  00E4  GETMBR	R6	R0	K19
+      0x8C180D1B,  //  00E5  GETMET	R6	R6	K27
+      0x7C180200,  //  00E6  CALL	R6	1
+      0x8C18031C,  //  00E7  GETMET	R6	R1	K28
+      0x5820001D,  //  00E8  LDCONST	R8	K29
+      0x7C180400,  //  00E9  CALL	R6	2
+      0x70020196,  //  00EA  JMP		#0282
+      0x8C18030E,  //  00EB  GETMET	R6	R1	K14
+      0x58200036,  //  00EC  LDCONST	R8	K54
+      0x7C180400,  //  00ED  CALL	R6	2
+      0x781A00D6,  //  00EE  JMPF	R6	#01C6
+      0xB81A1000,  //  00EF  GETNGBL	R6	K8
+      0x8C180D09,  //  00F0  GETMET	R6	R6	K9
+      0x60200018,  //  00F1  GETGBL	R8	G24
+      0x58240011,  //  00F2  LDCONST	R9	K17
+      0x58280036,  //  00F3  LDCONST	R10	K54
+      0x7C200400,  //  00F4  CALL	R8	2
+      0x58240012,  //  00F5  LDCONST	R9	K18
+      0x7C180600,  //  00F6  CALL	R6	3
+      0x50180000,  //  00F7  LDBOOL	R6	0	0
+      0x601C0010,  //  00F8  GETGBL	R7	G16
+      0x8C200306,  //  00F9  GETMET	R8	R1	K6
+      0x7C200200,  //  00FA  CALL	R8	1
+      0x04201107,  //  00FB  SUB	R8	R8	K7
+      0x40220A08,  //  00FC  CONNECT	R8	K5	R8
+      0x7C1C0200,  //  00FD  CALL	R7	1
+      0xA80200A0,  //  00FE  EXBLK	0	#01A0
+      0x5C200E00,  //  00FF  MOVE	R8	R7
+      0x7C200000,  //  0100  CALL	R8	0
+      0x8C24030B,  //  0101  GETMET	R9	R1	K11
+      0x5C2C1000,  //  0102  MOVE	R11	R8
+      0x7C240400,  //  0103  CALL	R9	2
+      0x8C280537,  //  0104  GETMET	R10	R2	K55
+      0x5C301200,  //  0105  MOVE	R12	R9
+      0x5834000C,  //  0106  LDCONST	R13	K12
+      0x7C280600,  //  0107  CALL	R10	3
+      0x1C281505,  //  0108  EQ	R10	R10	K5
+      0x782A005B,  //  0109  JMPF	R10	#0166
+      0x60280009,  //  010A  GETGBL	R10	G9
+      0x402E2538,  //  010B  CONNECT	R11	K18	K56
+      0x942C120B,  //  010C  GETIDX	R11	R9	R11
+      0x7C280200,  //  010D  CALL	R10	1
+      0x8C2C030C,  //  010E  GETMET	R11	R1	K12
+      0x5C341000,  //  010F  MOVE	R13	R8
+      0x7C2C0400,  //  0110  CALL	R11	2
+      0x88300113,  //  0111  GETMBR	R12	R0	K19
+      0x88301939,  //  0112  GETMBR	R12	R12	K57
+      0x8C301937,  //  0113  GETMET	R12	R12	K55
+      0x60380008,  //  0114  GETGBL	R14	G8
+      0x5C3C1400,  //  0115  MOVE	R15	R10
+      0x7C380200,  //  0116  CALL	R14	1
+      0x7C300400,  //  0117  CALL	R12	2
+      0x4C340000,  //  0118  LDNIL	R13
+      0x2034180D,  //  0119  NE	R13	R12	R13
+      0x78360041,  //  011A  JMPF	R13	#015D
+      0x88340113,  //  011B  GETMBR	R13	R0	K19
+      0x88341B3A,  //  011C  GETMBR	R13	R13	K58
+      0x8C341B37,  //  011D  GETMET	R13	R13	K55
+      0x8C3C1937,  //  011E  GETMET	R15	R12	K55
+      0x5844003B,  //  011F  LDCONST	R17	K59
+      0x5848003C,  //  0120  LDCONST	R18	K60
+      0x7C3C0600,  //  0121  CALL	R15	3
+      0x7C340400,  //  0122  CALL	R13	2
+      0x4C380000,  //  0123  LDNIL	R14
+      0x20381A0E,  //  0124  NE	R14	R13	R14
+      0x783A0035,  //  0125  JMPF	R14	#015C
+      0xB83A1000,  //  0126  GETNGBL	R14	K8
+      0x8C381D09,  //  0127  GETMET	R14	R14	K9
+      0x60400018,  //  0128  GETGBL	R16	G24
+      0x5844003D,  //  0129  LDCONST	R17	K61
+      0x5C481400,  //  012A  MOVE	R18	R10
+      0x5C4C1600,  //  012B  MOVE	R19	R11
+      0x7C400600,  //  012C  CALL	R16	3
+      0x58440012,  //  012D  LDCONST	R17	K18
+      0x7C380600,  //  012E  CALL	R14	3
+      0x8C381B3E,  //  012F  GETMET	R14	R13	K62
+      0x5C401A00,  //  0130  MOVE	R16	R13
+      0x5C441800,  //  0131  MOVE	R17	R12
+      0x7C380600,  //  0132  CALL	R14	3
+      0x203C1C0B,  //  0133  NE	R15	R14	R11
+      0xB8421000,  //  0134  GETNGBL	R16	K8
+      0x8C402109,  //  0135  GETMET	R16	R16	K9
+      0x60480018,  //  0136  GETGBL	R18	G24
+      0x584C003F,  //  0137  LDCONST	R19	K63
+      0x5C501400,  //  0138  MOVE	R20	R10
+      0x5C541C00,  //  0139  MOVE	R21	R14
+      0x5C581600,  //  013A  MOVE	R22	R11
+      0x205C1C0B,  //  013B  NE	R23	R14	R11
+      0x785E0001,  //  013C  JMPF	R23	#013F
+      0x585C0040,  //  013D  LDCONST	R23	K64
+      0x70020000,  //  013E  JMP		#0140
+      0x585C003C,  //  013F  LDCONST	R23	K60
+      0x7C480A00,  //  0140  CALL	R18	5
+      0x584C0012,  //  0141  LDCONST	R19	K18
+      0x7C400600,  //  0142  CALL	R16	3
+      0x783E0017,  //  0143  JMPF	R15	#015C
+      0x50180200,  //  0144  LDBOOL	R6	1	0
+      0x8C401B41,  //  0145  GETMET	R16	R13	K65
+      0x5C481A00,  //  0146  MOVE	R18	R13
+      0x5C4C1800,  //  0147  MOVE	R19	R12
+      0x5C501600,  //  0148  MOVE	R20	R11
+      0x7C400800,  //  0149  CALL	R16	4
+      0x88400113,  //  014A  GETMBR	R16	R0	K19
+      0x8C402142,  //  014B  GETMET	R16	R16	K66
+      0x5C481400,  //  014C  MOVE	R18	R10
+      0x7C400400,  //  014D  CALL	R16	2
+      0x7842000C,  //  014E  JMPF	R16	#015C
+      0xB8461000,  //  014F  GETNGBL	R17	K8
+      0x8C442309,  //  0150  GETMET	R17	R17	K9
+      0x604C0018,  //  0151  GETGBL	R19	G24
+      0x58500043,  //  0152  LDCONST	R20	K67
+      0x5C541800,  //  0153  MOVE	R21	R12
+      0x5C581400,  //  0154  MOVE	R22	R10
+      0x5C5C2000,  //  0155  MOVE	R23	R16
+      0x7C4C0800,  //  0156  CALL	R19	4
+      0x58500012,  //  0157  LDCONST	R20	K18
+      0x7C440600,  //  0158  CALL	R17	3
+      0x8C442144,  //  0159  GETMET	R17	R16	K68
+      0x5C4C1800,  //  015A  MOVE	R19	R12
+      0x7C440400,  //  015B  CALL	R17	2
+      0x70020007,  //  015C  JMP		#0165
+      0xB8361000,  //  015D  GETNGBL	R13	K8
+      0x8C341B09,  //  015E  GETMET	R13	R13	K9
+      0x603C0018,  //  015F  GETGBL	R15	G24
+      0x58400045,  //  0160  LDCONST	R16	K69
+      0x5C441400,  //  0161  MOVE	R17	R10
+      0x7C3C0400,  //  0162  CALL	R15	2
+      0x58400012,  //  0163  LDCONST	R16	K18
+      0x7C340600,  //  0164  CALL	R13	3
+      0x70020038,  //  0165  JMP		#019F
+      0x8C280537,  //  0166  GETMET	R10	R2	K55
+      0x5C301200,  //  0167  MOVE	R12	R9
+      0x58340046,  //  0168  LDCONST	R13	K70
+      0x7C280600,  //  0169  CALL	R10	3
+      0x1C281505,  //  016A  EQ	R10	R10	K5
+      0x782A0032,  //  016B  JMPF	R10	#019F
+      0x60280009,  //  016C  GETGBL	R10	G9
+      0x402E2538,  //  016D  CONNECT	R11	K18	K56
+      0x942C120B,  //  016E  GETIDX	R11	R9	R11
+      0x7C280200,  //  016F  CALL	R10	1
+      0x8C2C030C,  //  0170  GETMET	R11	R1	K12
+      0x5C341000,  //  0171  MOVE	R13	R8
+      0x7C2C0400,  //  0172  CALL	R11	2
+      0x88300113,  //  0173  GETMBR	R12	R0	K19
+      0x88301939,  //  0174  GETMBR	R12	R12	K57
+      0x8C301937,  //  0175  GETMET	R12	R12	K55
+      0x60380008,  //  0176  GETGBL	R14	G8
+      0x5C3C1400,  //  0177  MOVE	R15	R10
+      0x7C380200,  //  0178  CALL	R14	1
+      0x7C300400,  //  0179  CALL	R12	2
+      0x4C340000,  //  017A  LDNIL	R13
+      0x2034180D,  //  017B  NE	R13	R12	R13
+      0x78360021,  //  017C  JMPF	R13	#019F
+      0x8C341937,  //  017D  GETMET	R13	R12	K55
+      0x583C0047,  //  017E  LDCONST	R15	K71
+      0x5840003C,  //  017F  LDCONST	R16	K60
+      0x7C340600,  //  0180  CALL	R13	3
+      0x20381A0B,  //  0181  NE	R14	R13	R11
+      0x783A001B,  //  0182  JMPF	R14	#019F
+      0x50180200,  //  0183  LDBOOL	R6	1	0
+      0x883C0113,  //  0184  GETMBR	R15	R0	K19
+      0x8C3C1F42,  //  0185  GETMET	R15	R15	K66
+      0x5C441400,  //  0186  MOVE	R17	R10
+      0x7C3C0400,  //  0187  CALL	R15	2
+      0x783E0015,  //  0188  JMPF	R15	#019F
+      0x8C401F48,  //  0189  GETMET	R16	R15	K72
+      0x5C481600,  //  018A  MOVE	R18	R11
       0x7C400400,  //  018B  CALL	R16	2
-      0xB8421000,  //  018C  GETNGBL	R16	K8
-      0x8C402109,  //  018D  GETMET	R16	R16	K9
-      0x60480018,  //  018E  GETGBL	R18	G24
-      0x584C0048,  //  018F  LDCONST	R19	K72
-      0x5C501800,  //  0190  MOVE	R20	R12
-      0x5C541400,  //  0191  MOVE	R21	R10
-      0x5C581E00,  //  0192  MOVE	R22	R15
-      0x7C480800,  //  0193  CALL	R18	4
-      0x584C0012,  //  0194  LDCONST	R19	K18
-      0x7C400600,  //  0195  CALL	R16	3
-      0x8C401F42,  //  0196  GETMET	R16	R15	K66
-      0x5C481800,  //  0197  MOVE	R18	R12
-      0x7C400400,  //  0198  CALL	R16	2
-      0x7001FF5E,  //  0199  JMP		#00F9
-      0x581C000D,  //  019A  LDCONST	R7	K13
-      0xAC1C0200,  //  019B  CATCH	R7	1	0
-      0xB0080000,  //  019C  RAISE	2	R0	R0
-      0xB81E1000,  //  019D  GETNGBL	R7	K8
-      0x8C1C0F09,  //  019E  GETMET	R7	R7	K9
-      0x60240018,  //  019F  GETGBL	R9	G24
-      0x58280049,  //  01A0  LDCONST	R10	K73
-      0x602C0008,  //  01A1  GETGBL	R11	G8
-      0x88300113,  //  01A2  GETMBR	R12	R0	K19
-      0x88301937,  //  01A3  GETMBR	R12	R12	K55
-      0x7C2C0200,  //  01A4  CALL	R11	1
-      0x7C240400,  //  01A5  CALL	R9	2
-      0x58280012,  //  01A6  LDCONST	R10	K18
-      0x7C1C0600,  //  01A7  CALL	R7	3
-      0x78160008,  //  01A8  JMPF	R5	#01B2
-      0xB81E1000,  //  01A9  GETNGBL	R7	K8
-      0x8C1C0F09,  //  01AA  GETMET	R7	R7	K9
-      0x60240018,  //  01AB  GETGBL	R9	G24
-      0x5828004A,  //  01AC  LDCONST	R10	K74
-      0x5C2C0A00,  //  01AD  MOVE	R11	R5
-      0x7C240400,  //  01AE  CALL	R9	2
-      0x58280012,  //  01AF  LDCONST	R10	K18
-      0x7C1C0600,  //  01B0  CALL	R7	3
-      0x7002000C,  //  01B1  JMP		#01BF
-      0x741A0002,  //  01B2  JMPT	R6	#01B6
-      0x881C0113,  //  01B3  GETMBR	R7	R0	K19
-      0x881C0F33,  //  01B4  GETMBR	R7	R7	K51
-      0x741E0005,  //  01B5  JMPT	R7	#01BC
-      0x881C0113,  //  01B6  GETMBR	R7	R0	K19
-      0x50200200,  //  01B7  LDBOOL	R8	1	0
-      0x901E6608,  //  01B8  SETMBR	R7	K51	R8
+      0x782E0001,  //  018C  JMPF	R11	#018F
+      0x98328E0B,  //  018D  SETIDX	R12	K71	R11
+      0x70020002,  //  018E  JMP		#0192
+      0x8C401949,  //  018F  GETMET	R16	R12	K73
+      0x58480047,  //  0190  LDCONST	R18	K71
+      0x7C400400,  //  0191  CALL	R16	2
+      0xB8421000,  //  0192  GETNGBL	R16	K8
+      0x8C402109,  //  0193  GETMET	R16	R16	K9
+      0x60480018,  //  0194  GETGBL	R18	G24
+      0x584C004A,  //  0195  LDCONST	R19	K74
+      0x5C501800,  //  0196  MOVE	R20	R12
+      0x5C541400,  //  0197  MOVE	R21	R10
+      0x5C581E00,  //  0198  MOVE	R22	R15
+      0x7C480800,  //  0199  CALL	R18	4
+      0x584C0012,  //  019A  LDCONST	R19	K18
+      0x7C400600,  //  019B  CALL	R16	3
+      0x8C401F44,  //  019C  GETMET	R16	R15	K68
+      0x5C481800,  //  019D  MOVE	R18	R12
+      0x7C400400,  //  019E  CALL	R16	2
+      0x7001FF5E,  //  019F  JMP		#00FF
+      0x581C000D,  //  01A0  LDCONST	R7	K13
+      0xAC1C0200,  //  01A1  CATCH	R7	1	0
+      0xB0080000,  //  01A2  RAISE	2	R0	R0
+      0xB81E1000,  //  01A3  GETNGBL	R7	K8
+      0x8C1C0F09,  //  01A4  GETMET	R7	R7	K9
+      0x60240018,  //  01A5  GETGBL	R9	G24
+      0x5828004B,  //  01A6  LDCONST	R10	K75
+      0x602C0008,  //  01A7  GETGBL	R11	G8
+      0x88300113,  //  01A8  GETMBR	R12	R0	K19
+      0x88301939,  //  01A9  GETMBR	R12	R12	K57
+      0x7C2C0200,  //  01AA  CALL	R11	1
+      0x7C240400,  //  01AB  CALL	R9	2
+      0x58280012,  //  01AC  LDCONST	R10	K18
+      0x7C1C0600,  //  01AD  CALL	R7	3
+      0x78160008,  //  01AE  JMPF	R5	#01B8
+      0xB81E1000,  //  01AF  GETNGBL	R7	K8
+      0x8C1C0F09,  //  01B0  GETMET	R7	R7	K9
+      0x60240018,  //  01B1  GETGBL	R9	G24
+      0x5828004C,  //  01B2  LDCONST	R10	K76
+      0x5C2C0A00,  //  01B3  MOVE	R11	R5
+      0x7C240400,  //  01B4  CALL	R9	2
+      0x58280012,  //  01B5  LDCONST	R10	K18
+      0x7C1C0600,  //  01B6  CALL	R7	3
+      0x7002000C,  //  01B7  JMP		#01C5
+      0x741A0002,  //  01B8  JMPT	R6	#01BC
       0x881C0113,  //  01B9  GETMBR	R7	R0	K19
-      0x8C1C0F19,  //  01BA  GETMET	R7	R7	K25
-      0x7C1C0200,  //  01BB  CALL	R7	1
-      0x8C1C031A,  //  01BC  GETMET	R7	R1	K26
-      0x58240031,  //  01BD  LDCONST	R9	K49
-      0x7C1C0400,  //  01BE  CALL	R7	2
-      0x700200BB,  //  01BF  JMP		#027C
-      0x8C18030E,  //  01C0  GETMET	R6	R1	K14
-      0x5820004B,  //  01C1  LDCONST	R8	K75
-      0x7C180400,  //  01C2  CALL	R6	2
-      0x781A002B,  //  01C3  JMPF	R6	#01F0
-      0x8C18030C,  //  01C4  GETMET	R6	R1	K12
-      0x5820004C,  //  01C5  LDCONST	R8	K76
-      0x7C180400,  //  01C6  CALL	R6	2
-      0x8C1C030C,  //  01C7  GETMET	R7	R1	K12
-      0x5824000C,  //  01C8  LDCONST	R9	K12
-      0x7C1C0400,  //  01C9  CALL	R7	2
-      0x8C20030C,  //  01CA  GETMET	R8	R1	K12
-      0x58280044,  //  01CB  LDCONST	R10	K68
-      0x7C200400,  //  01CC  CALL	R8	2
-      0xB8261000,  //  01CD  GETNGBL	R9	K8
-      0x8C241309,  //  01CE  GETMET	R9	R9	K9
-      0x602C0018,  //  01CF  GETGBL	R11	G24
-      0x5830004D,  //  01D0  LDCONST	R12	K77
-      0x5C340C00,  //  01D1  MOVE	R13	R6
-      0x5C380E00,  //  01D2  MOVE	R14	R7
-      0x7C2C0600,  //  01D3  CALL	R11	3
-      0x58300012,  //  01D4  LDCONST	R12	K18
-      0x7C240600,  //  01D5  CALL	R9	3
-      0x88240113,  //  01D6  GETMBR	R9	R0	K19
-      0x88241338,  //  01D7  GETMBR	R9	R9	K56
-      0x8C241335,  //  01D8  GETMET	R9	R9	K53
-      0x5C2C0C00,  //  01D9  MOVE	R11	R6
-      0x7C240400,  //  01DA  CALL	R9	2
-      0x4C280000,  //  01DB  LDNIL	R10
-      0x2028120A,  //  01DC  NE	R10	R9	R10
-      0x782A000D,  //  01DD  JMPF	R10	#01EC
-      0x60280013,  //  01DE  GETGBL	R10	G19
-      0x7C280000,  //  01DF  CALL	R10	0
-      0x78220000,  //  01E0  JMPF	R8	#01E2
-      0x982A8A08,  //  01E1  SETIDX	R10	K69	R8
-      0x8C2C133F,  //  01E2  GETMET	R11	R9	K63
-      0x5C341200,  //  01E3  MOVE	R13	R9
-      0x5C381400,  //  01E4  MOVE	R14	R10
-      0x5C3C0E00,  //  01E5  MOVE	R15	R7
-      0x7C2C0800,  //  01E6  CALL	R11	4
-      0x882C0113,  //  01E7  GETMBR	R11	R0	K19
-      0x8C2C174E,  //  01E8  GETMET	R11	R11	K78
-      0x5C340C00,  //  01E9  MOVE	R13	R6
+      0x881C0F35,  //  01BA  GETMBR	R7	R7	K53
+      0x741E0005,  //  01BB  JMPT	R7	#01C2
+      0x881C0113,  //  01BC  GETMBR	R7	R0	K19
+      0x50200200,  //  01BD  LDBOOL	R8	1	0
+      0x901E6A08,  //  01BE  SETMBR	R7	K53	R8
+      0x881C0113,  //  01BF  GETMBR	R7	R0	K19
+      0x8C1C0F1B,  //  01C0  GETMET	R7	R7	K27
+      0x7C1C0200,  //  01C1  CALL	R7	1
+      0x8C1C031C,  //  01C2  GETMET	R7	R1	K28
+      0x58240033,  //  01C3  LDCONST	R9	K51
+      0x7C1C0400,  //  01C4  CALL	R7	2
+      0x700200BB,  //  01C5  JMP		#0282
+      0x8C18030E,  //  01C6  GETMET	R6	R1	K14
+      0x5820004D,  //  01C7  LDCONST	R8	K77
+      0x7C180400,  //  01C8  CALL	R6	2
+      0x781A002B,  //  01C9  JMPF	R6	#01F6
+      0x8C18030C,  //  01CA  GETMET	R6	R1	K12
+      0x5820004E,  //  01CB  LDCONST	R8	K78
+      0x7C180400,  //  01CC  CALL	R6	2
+      0x8C1C030C,  //  01CD  GETMET	R7	R1	K12
+      0x5824000C,  //  01CE  LDCONST	R9	K12
+      0x7C1C0400,  //  01CF  CALL	R7	2
+      0x8C20030C,  //  01D0  GETMET	R8	R1	K12
+      0x58280046,  //  01D1  LDCONST	R10	K70
+      0x7C200400,  //  01D2  CALL	R8	2
+      0xB8261000,  //  01D3  GETNGBL	R9	K8
+      0x8C241309,  //  01D4  GETMET	R9	R9	K9
+      0x602C0018,  //  01D5  GETGBL	R11	G24
+      0x5830004F,  //  01D6  LDCONST	R12	K79
+      0x5C340C00,  //  01D7  MOVE	R13	R6
+      0x5C380E00,  //  01D8  MOVE	R14	R7
+      0x7C2C0600,  //  01D9  CALL	R11	3
+      0x58300012,  //  01DA  LDCONST	R12	K18
+      0x7C240600,  //  01DB  CALL	R9	3
+      0x88240113,  //  01DC  GETMBR	R9	R0	K19
+      0x8824133A,  //  01DD  GETMBR	R9	R9	K58
+      0x8C241337,  //  01DE  GETMET	R9	R9	K55
+      0x5C2C0C00,  //  01DF  MOVE	R11	R6
+      0x7C240400,  //  01E0  CALL	R9	2
+      0x4C280000,  //  01E1  LDNIL	R10
+      0x2028120A,  //  01E2  NE	R10	R9	R10
+      0x782A000D,  //  01E3  JMPF	R10	#01F2
+      0x60280013,  //  01E4  GETGBL	R10	G19
+      0x7C280000,  //  01E5  CALL	R10	0
+      0x78220000,  //  01E6  JMPF	R8	#01E8
+      0x982A8E08,  //  01E7  SETIDX	R10	K71	R8
+      0x8C2C1341,  //  01E8  GETMET	R11	R9	K65
+      0x5C341200,  //  01E9  MOVE	R13	R9
       0x5C381400,  //  01EA  MOVE	R14	R10
-      0x7C2C0600,  //  01EB  CALL	R11	3
-      0x8C28031A,  //  01EC  GETMET	R10	R1	K26
-      0x58300031,  //  01ED  LDCONST	R12	K49
-      0x7C280400,  //  01EE  CALL	R10	2
-      0x7002008B,  //  01EF  JMP		#027C
-      0x8C18030E,  //  01F0  GETMET	R6	R1	K14
-      0x5820004F,  //  01F1  LDCONST	R8	K79
-      0x7C180400,  //  01F2  CALL	R6	2
-      0x781A005E,  //  01F3  JMPF	R6	#0253
-      0x8C18030C,  //  01F4  GETMET	R6	R1	K12
-      0x58200050,  //  01F5  LDCONST	R8	K80
-      0x7C180400,  //  01F6  CALL	R6	2
-      0x4C1C0000,  //  01F7  LDNIL	R7
-      0x1C1C0C07,  //  01F8  EQ	R7	R6	R7
-      0x741E0001,  //  01F9  JMPT	R7	#01FC
-      0x1C1C0D3A,  //  01FA  EQ	R7	R6	K58
-      0x781E0000,  //  01FB  JMPF	R7	#01FD
-      0xB006A352,  //  01FC  RAISE	1	K81	K82
-      0x581C0005,  //  01FD  LDCONST	R7	K5
-      0x60200008,  //  01FE  GETGBL	R8	G8
-      0x5C240E00,  //  01FF  MOVE	R9	R7
-      0x7C200200,  //  0200  CALL	R8	1
-      0x8C24030E,  //  0201  GETMET	R9	R1	K14
-      0x002E9808,  //  0202  ADD	R11	K76	R8
-      0x7C240400,  //  0203  CALL	R9	2
-      0x78260049,  //  0204  JMPF	R9	#024F
-      0x8C24030C,  //  0205  GETMET	R9	R1	K12
-      0x002E9808,  //  0206  ADD	R11	K76	R8
-      0x7C240400,  //  0207  CALL	R9	2
-      0x8C28030C,  //  0208  GETMET	R10	R1	K12
-      0x00321808,  //  0209  ADD	R12	K12	R8
-      0x7C280400,  //  020A  CALL	R10	2
-      0x8C2C030C,  //  020B  GETMET	R11	R1	K12
-      0x00368808,  //  020C  ADD	R13	K68	R8
-      0x7C2C0400,  //  020D  CALL	R11	2
-      0x2030133A,  //  020E  NE	R12	R9	K58
-      0x78320038,  //  020F  JMPF	R12	#0249
-      0x88300113,  //  0210  GETMBR	R12	R0	K19
-      0x88301938,  //  0211  GETMBR	R12	R12	K56
-      0x8C301935,  //  0212  GETMET	R12	R12	K53
-      0x5C381200,  //  0213  MOVE	R14	R9
-      0x7C300400,  //  0214  CALL	R12	2
-      0x4C340000,  //  0215  LDNIL	R13
-      0x2034180D,  //  0216  NE	R13	R12	R13
-      0x78360030,  //  0217  JMPF	R13	#0249
-      0x60340013,  //  0218  GETGBL	R13	G19
-      0x7C340000,  //  0219  CALL	R13	0
-      0x9836A006,  //  021A  SETIDX	R13	K80	R6
-      0x98367209,  //  021B  SETIDX	R13	K57	R9
-      0x782E0000,  //  021C  JMPF	R11	#021E
-      0x98368A0B,  //  021D  SETIDX	R13	K69	R11
-      0x8C38193F,  //  021E  GETMET	R14	R12	K63
-      0x5C401800,  //  021F  MOVE	R16	R12
-      0x5C441A00,  //  0220  MOVE	R17	R13
-      0x5C481400,  //  0221  MOVE	R18	R10
-      0x7C380800,  //  0222  CALL	R14	4
-      0x50380000,  //  0223  LDBOOL	R14	0	0
-      0x603C0010,  //  0224  GETGBL	R15	G16
-      0x88400113,  //  0225  GETMBR	R16	R0	K19
-      0x88402137,  //  0226  GETMBR	R16	R16	K55
-      0x7C3C0200,  //  0227  CALL	R15	1
-      0xA802000B,  //  0228  EXBLK	0	#0235
-      0x5C401E00,  //  0229  MOVE	R16	R15
-      0x7C400000,  //  022A  CALL	R16	0
-      0x8C440153,  //  022B  GETMET	R17	R0	K83
-      0x5C4C2000,  //  022C  MOVE	R19	R16
-      0x5C501A00,  //  022D  MOVE	R20	R13
-      0x7C440600,  //  022E  CALL	R17	3
-      0x78460001,  //  022F  JMPF	R17	#0232
-      0x50380200,  //  0230  LDBOOL	R14	1	0
-      0x70020000,  //  0231  JMP		#0233
-      0x7001FFF5,  //  0232  JMP		#0229
-      0xA8040001,  //  0233  EXBLK	1	1
-      0x70020002,  //  0234  JMP		#0238
-      0x583C000D,  //  0235  LDCONST	R15	K13
-      0xAC3C0200,  //  0236  CATCH	R15	1	0
-      0xB0080000,  //  0237  RAISE	2	R0	R0
-      0x5C3C1C00,  //  0238  MOVE	R15	R14
-      0x743E000E,  //  0239  JMPT	R15	#0249
-      0xB83E1000,  //  023A  GETNGBL	R15	K8
-      0x8C3C1F09,  //  023B  GETMET	R15	R15	K9
-      0x60440018,  //  023C  GETGBL	R17	G24
-      0x58480054,  //  023D  LDCONST	R18	K84
-      0x5C4C0C00,  //  023E  MOVE	R19	R6
-      0x5C501200,  //  023F  MOVE	R20	R9
-      0x5C541400,  //  0240  MOVE	R21	R10
-      0x7C440800,  //  0241  CALL	R17	4
-      0x58480012,  //  0242  LDCONST	R18	K18
-      0x7C3C0600,  //  0243  CALL	R15	3
-      0x883C0113,  //  0244  GETMBR	R15	R0	K19
-      0x8C3C1F4E,  //  0245  GETMET	R15	R15	K78
-      0x5C441200,  //  0246  MOVE	R17	R9
-      0x5C481A00,  //  0247  MOVE	R18	R13
-      0x7C3C0600,  //  0248  CALL	R15	3
-      0x001C0F07,  //  0249  ADD	R7	R7	K7
-      0x60300008,  //  024A  GETGBL	R12	G8
-      0x5C340E00,  //  024B  MOVE	R13	R7
-      0x7C300200,  //  024C  CALL	R12	1
-      0x5C201800,  //  024D  MOVE	R8	R12
-      0x7001FFB1,  //  024E  JMP		#0201
-      0x8C24031A,  //  024F  GETMET	R9	R1	K26
-      0x582C0031,  //  0250  LDCONST	R11	K49
-      0x7C240400,  //  0251  CALL	R9	2
-      0x70020028,  //  0252  JMP		#027C
-      0x4C180000,  //  0253  LDNIL	R6
-      0x601C0010,  //  0254  GETGBL	R7	G16
-      0x8C200306,  //  0255  GETMET	R8	R1	K6
-      0x7C200200,  //  0256  CALL	R8	1
-      0x04201107,  //  0257  SUB	R8	R8	K7
-      0x40220A08,  //  0258  CONNECT	R8	K5	R8
-      0x7C1C0200,  //  0259  CALL	R7	1
-      0xA8020013,  //  025A  EXBLK	0	#026F
-      0x5C200E00,  //  025B  MOVE	R8	R7
-      0x7C200000,  //  025C  CALL	R8	0
-      0x8C24030B,  //  025D  GETMET	R9	R1	K11
-      0x5C2C1000,  //  025E  MOVE	R11	R8
-      0x7C240400,  //  025F  CALL	R9	2
-      0x8C280535,  //  0260  GETMET	R10	R2	K53
-      0x5C301200,  //  0261  MOVE	R12	R9
-      0x58340055,  //  0262  LDCONST	R13	K85
-      0x7C280600,  //  0263  CALL	R10	3
-      0x1C281505,  //  0264  EQ	R10	R10	K5
-      0x782A0005,  //  0265  JMPF	R10	#026C
-      0x60280009,  //  0266  GETGBL	R10	G9
-      0x402E2536,  //  0267  CONNECT	R11	K18	K54
-      0x942C120B,  //  0268  GETIDX	R11	R9	R11
-      0x7C280200,  //  0269  CALL	R10	1
-      0x5C181400,  //  026A  MOVE	R6	R10
-      0x70020000,  //  026B  JMP		#026D
-      0x7001FFED,  //  026C  JMP		#025B
-      0xA8040001,  //  026D  EXBLK	1	1
-      0x70020002,  //  026E  JMP		#0272
-      0x581C000D,  //  026F  LDCONST	R7	K13
-      0xAC1C0200,  //  0270  CATCH	R7	1	0
-      0xB0080000,  //  0271  RAISE	2	R0	R0
-      0x4C1C0000,  //  0272  LDNIL	R7
-      0x201C0C07,  //  0273  NE	R7	R6	R7
-      0x781E0006,  //  0274  JMPF	R7	#027C
-      0x881C0113,  //  0275  GETMBR	R7	R0	K19
-      0x8C1C0F56,  //  0276  GETMET	R7	R7	K86
-      0x5C240C00,  //  0277  MOVE	R9	R6
-      0x7C1C0400,  //  0278  CALL	R7	2
-      0x8C1C031A,  //  0279  GETMET	R7	R1	K26
-      0x58240031,  //  027A  LDCONST	R9	K49
-      0x7C1C0400,  //  027B  CALL	R7	2
-      0x78160011,  //  027C  JMPF	R5	#028F
-      0x8C180357,  //  027D  GETMET	R6	R1	K87
-      0x58200058,  //  027E  LDCONST	R8	K88
-      0x7C180400,  //  027F  CALL	R6	2
-      0x8C180359,  //  0280  GETMET	R6	R1	K89
-      0x7C180200,  //  0281  CALL	R6	1
-      0x8C18035A,  //  0282  GETMET	R6	R1	K90
-      0x60200018,  //  0283  GETGBL	R8	G24
-      0x5824005B,  //  0284  LDCONST	R9	K91
-      0x8C28035C,  //  0285  GETMET	R10	R1	K92
-      0x5C300A00,  //  0286  MOVE	R12	R5
-      0x7C280400,  //  0287  CALL	R10	2
-      0x7C200400,  //  0288  CALL	R8	2
-      0x7C180400,  //  0289  CALL	R6	2
-      0x8C18035D,  //  028A  GETMET	R6	R1	K93
-      0x8820035E,  //  028B  GETMBR	R8	R1	K94
-      0x7C180400,  //  028C  CALL	R6	2
-      0x8C18035F,  //  028D  GETMET	R6	R1	K95
-      0x7C180200,  //  028E  CALL	R6	1
-      0xA8040001,  //  028F  EXBLK	1	1
-      0x7002001D,  //  0290  JMP		#02AF
-      0xAC180002,  //  0291  CATCH	R6	0	2
-      0x7002001A,  //  0292  JMP		#02AE
-      0xB8221000,  //  0293  GETNGBL	R8	K8
-      0x8C201109,  //  0294  GETMET	R8	R8	K9
-      0x60280018,  //  0295  GETGBL	R10	G24
-      0x582C0060,  //  0296  LDCONST	R11	K96
-      0x5C300C00,  //  0297  MOVE	R12	R6
-      0x5C340E00,  //  0298  MOVE	R13	R7
-      0x7C280600,  //  0299  CALL	R10	3
-      0x582C0061,  //  029A  LDCONST	R11	K97
-      0x7C200600,  //  029B  CALL	R8	3
-      0x8C200357,  //  029C  GETMET	R8	R1	K87
-      0x58280058,  //  029D  LDCONST	R10	K88
-      0x7C200400,  //  029E  CALL	R8	2
-      0x8C200359,  //  029F  GETMET	R8	R1	K89
-      0x7C200200,  //  02A0  CALL	R8	1
-      0x8C20035A,  //  02A1  GETMET	R8	R1	K90
-      0x60280018,  //  02A2  GETGBL	R10	G24
-      0x582C0062,  //  02A3  LDCONST	R11	K98
-      0x5C300C00,  //  02A4  MOVE	R12	R6
-      0x5C340E00,  //  02A5  MOVE	R13	R7
-      0x7C280600,  //  02A6  CALL	R10	3
-      0x7C200400,  //  02A7  CALL	R8	2
-      0x8C20035D,  //  02A8  GETMET	R8	R1	K93
-      0x8828035E,  //  02A9  GETMBR	R10	R1	K94
-      0x7C200400,  //  02AA  CALL	R8	2
-      0x8C20035F,  //  02AB  GETMET	R8	R1	K95
-      0x7C200200,  //  02AC  CALL	R8	1
-      0x70020000,  //  02AD  JMP		#02AF
-      0xB0080000,  //  02AE  RAISE	2	R0	R0
-      0x80000000,  //  02AF  RET	0
+      0x5C3C0E00,  //  01EB  MOVE	R15	R7
+      0x7C2C0800,  //  01EC  CALL	R11	4
+      0x882C0113,  //  01ED  GETMBR	R11	R0	K19
+      0x8C2C1750,  //  01EE  GETMET	R11	R11	K80
+      0x5C340C00,  //  01EF  MOVE	R13	R6
+      0x5C381400,  //  01F0  MOVE	R14	R10
+      0x7C2C0600,  //  01F1  CALL	R11	3
+      0x8C28031C,  //  01F2  GETMET	R10	R1	K28
+      0x58300033,  //  01F3  LDCONST	R12	K51
+      0x7C280400,  //  01F4  CALL	R10	2
+      0x7002008B,  //  01F5  JMP		#0282
+      0x8C18030E,  //  01F6  GETMET	R6	R1	K14
+      0x58200051,  //  01F7  LDCONST	R8	K81
+      0x7C180400,  //  01F8  CALL	R6	2
+      0x781A005E,  //  01F9  JMPF	R6	#0259
+      0x8C18030C,  //  01FA  GETMET	R6	R1	K12
+      0x58200052,  //  01FB  LDCONST	R8	K82
+      0x7C180400,  //  01FC  CALL	R6	2
+      0x4C1C0000,  //  01FD  LDNIL	R7
+      0x1C1C0C07,  //  01FE  EQ	R7	R6	R7
+      0x741E0001,  //  01FF  JMPT	R7	#0202
+      0x1C1C0D3C,  //  0200  EQ	R7	R6	K60
+      0x781E0000,  //  0201  JMPF	R7	#0203
+      0xB006A754,  //  0202  RAISE	1	K83	K84
+      0x581C0005,  //  0203  LDCONST	R7	K5
+      0x60200008,  //  0204  GETGBL	R8	G8
+      0x5C240E00,  //  0205  MOVE	R9	R7
+      0x7C200200,  //  0206  CALL	R8	1
+      0x8C24030E,  //  0207  GETMET	R9	R1	K14
+      0x002E9C08,  //  0208  ADD	R11	K78	R8
+      0x7C240400,  //  0209  CALL	R9	2
+      0x78260049,  //  020A  JMPF	R9	#0255
+      0x8C24030C,  //  020B  GETMET	R9	R1	K12
+      0x002E9C08,  //  020C  ADD	R11	K78	R8
+      0x7C240400,  //  020D  CALL	R9	2
+      0x8C28030C,  //  020E  GETMET	R10	R1	K12
+      0x00321808,  //  020F  ADD	R12	K12	R8
+      0x7C280400,  //  0210  CALL	R10	2
+      0x8C2C030C,  //  0211  GETMET	R11	R1	K12
+      0x00368C08,  //  0212  ADD	R13	K70	R8
+      0x7C2C0400,  //  0213  CALL	R11	2
+      0x2030133C,  //  0214  NE	R12	R9	K60
+      0x78320038,  //  0215  JMPF	R12	#024F
+      0x88300113,  //  0216  GETMBR	R12	R0	K19
+      0x8830193A,  //  0217  GETMBR	R12	R12	K58
+      0x8C301937,  //  0218  GETMET	R12	R12	K55
+      0x5C381200,  //  0219  MOVE	R14	R9
+      0x7C300400,  //  021A  CALL	R12	2
+      0x4C340000,  //  021B  LDNIL	R13
+      0x2034180D,  //  021C  NE	R13	R12	R13
+      0x78360030,  //  021D  JMPF	R13	#024F
+      0x60340013,  //  021E  GETGBL	R13	G19
+      0x7C340000,  //  021F  CALL	R13	0
+      0x9836A406,  //  0220  SETIDX	R13	K82	R6
+      0x98367609,  //  0221  SETIDX	R13	K59	R9
+      0x782E0000,  //  0222  JMPF	R11	#0224
+      0x98368E0B,  //  0223  SETIDX	R13	K71	R11
+      0x8C381941,  //  0224  GETMET	R14	R12	K65
+      0x5C401800,  //  0225  MOVE	R16	R12
+      0x5C441A00,  //  0226  MOVE	R17	R13
+      0x5C481400,  //  0227  MOVE	R18	R10
+      0x7C380800,  //  0228  CALL	R14	4
+      0x50380000,  //  0229  LDBOOL	R14	0	0
+      0x603C0010,  //  022A  GETGBL	R15	G16
+      0x88400113,  //  022B  GETMBR	R16	R0	K19
+      0x88402139,  //  022C  GETMBR	R16	R16	K57
+      0x7C3C0200,  //  022D  CALL	R15	1
+      0xA802000B,  //  022E  EXBLK	0	#023B
+      0x5C401E00,  //  022F  MOVE	R16	R15
+      0x7C400000,  //  0230  CALL	R16	0
+      0x8C440155,  //  0231  GETMET	R17	R0	K85
+      0x5C4C2000,  //  0232  MOVE	R19	R16
+      0x5C501A00,  //  0233  MOVE	R20	R13
+      0x7C440600,  //  0234  CALL	R17	3
+      0x78460001,  //  0235  JMPF	R17	#0238
+      0x50380200,  //  0236  LDBOOL	R14	1	0
+      0x70020000,  //  0237  JMP		#0239
+      0x7001FFF5,  //  0238  JMP		#022F
+      0xA8040001,  //  0239  EXBLK	1	1
+      0x70020002,  //  023A  JMP		#023E
+      0x583C000D,  //  023B  LDCONST	R15	K13
+      0xAC3C0200,  //  023C  CATCH	R15	1	0
+      0xB0080000,  //  023D  RAISE	2	R0	R0
+      0x5C3C1C00,  //  023E  MOVE	R15	R14
+      0x743E000E,  //  023F  JMPT	R15	#024F
+      0xB83E1000,  //  0240  GETNGBL	R15	K8
+      0x8C3C1F09,  //  0241  GETMET	R15	R15	K9
+      0x60440018,  //  0242  GETGBL	R17	G24
+      0x58480056,  //  0243  LDCONST	R18	K86
+      0x5C4C0C00,  //  0244  MOVE	R19	R6
+      0x5C501200,  //  0245  MOVE	R20	R9
+      0x5C541400,  //  0246  MOVE	R21	R10
+      0x7C440800,  //  0247  CALL	R17	4
+      0x58480012,  //  0248  LDCONST	R18	K18
+      0x7C3C0600,  //  0249  CALL	R15	3
+      0x883C0113,  //  024A  GETMBR	R15	R0	K19
+      0x8C3C1F50,  //  024B  GETMET	R15	R15	K80
+      0x5C441200,  //  024C  MOVE	R17	R9
+      0x5C481A00,  //  024D  MOVE	R18	R13
+      0x7C3C0600,  //  024E  CALL	R15	3
+      0x001C0F07,  //  024F  ADD	R7	R7	K7
+      0x60300008,  //  0250  GETGBL	R12	G8
+      0x5C340E00,  //  0251  MOVE	R13	R7
+      0x7C300200,  //  0252  CALL	R12	1
+      0x5C201800,  //  0253  MOVE	R8	R12
+      0x7001FFB1,  //  0254  JMP		#0207
+      0x8C24031C,  //  0255  GETMET	R9	R1	K28
+      0x582C0033,  //  0256  LDCONST	R11	K51
+      0x7C240400,  //  0257  CALL	R9	2
+      0x70020028,  //  0258  JMP		#0282
+      0x4C180000,  //  0259  LDNIL	R6
+      0x601C0010,  //  025A  GETGBL	R7	G16
+      0x8C200306,  //  025B  GETMET	R8	R1	K6
+      0x7C200200,  //  025C  CALL	R8	1
+      0x04201107,  //  025D  SUB	R8	R8	K7
+      0x40220A08,  //  025E  CONNECT	R8	K5	R8
+      0x7C1C0200,  //  025F  CALL	R7	1
+      0xA8020013,  //  0260  EXBLK	0	#0275
+      0x5C200E00,  //  0261  MOVE	R8	R7
+      0x7C200000,  //  0262  CALL	R8	0
+      0x8C24030B,  //  0263  GETMET	R9	R1	K11
+      0x5C2C1000,  //  0264  MOVE	R11	R8
+      0x7C240400,  //  0265  CALL	R9	2
+      0x8C280537,  //  0266  GETMET	R10	R2	K55
+      0x5C301200,  //  0267  MOVE	R12	R9
+      0x58340057,  //  0268  LDCONST	R13	K87
+      0x7C280600,  //  0269  CALL	R10	3
+      0x1C281505,  //  026A  EQ	R10	R10	K5
+      0x782A0005,  //  026B  JMPF	R10	#0272
+      0x60280009,  //  026C  GETGBL	R10	G9
+      0x402E2538,  //  026D  CONNECT	R11	K18	K56
+      0x942C120B,  //  026E  GETIDX	R11	R9	R11
+      0x7C280200,  //  026F  CALL	R10	1
+      0x5C181400,  //  0270  MOVE	R6	R10
+      0x70020000,  //  0271  JMP		#0273
+      0x7001FFED,  //  0272  JMP		#0261
+      0xA8040001,  //  0273  EXBLK	1	1
+      0x70020002,  //  0274  JMP		#0278
+      0x581C000D,  //  0275  LDCONST	R7	K13
+      0xAC1C0200,  //  0276  CATCH	R7	1	0
+      0xB0080000,  //  0277  RAISE	2	R0	R0
+      0x4C1C0000,  //  0278  LDNIL	R7
+      0x201C0C07,  //  0279  NE	R7	R6	R7
+      0x781E0006,  //  027A  JMPF	R7	#0282
+      0x881C0113,  //  027B  GETMBR	R7	R0	K19
+      0x8C1C0F58,  //  027C  GETMET	R7	R7	K88
+      0x5C240C00,  //  027D  MOVE	R9	R6
+      0x7C1C0400,  //  027E  CALL	R7	2
+      0x8C1C031C,  //  027F  GETMET	R7	R1	K28
+      0x58240033,  //  0280  LDCONST	R9	K51
+      0x7C1C0400,  //  0281  CALL	R7	2
+      0x78160011,  //  0282  JMPF	R5	#0295
+      0x8C180359,  //  0283  GETMET	R6	R1	K89
+      0x5820005A,  //  0284  LDCONST	R8	K90
+      0x7C180400,  //  0285  CALL	R6	2
+      0x8C18035B,  //  0286  GETMET	R6	R1	K91
+      0x7C180200,  //  0287  CALL	R6	1
+      0x8C18035C,  //  0288  GETMET	R6	R1	K92
+      0x60200018,  //  0289  GETGBL	R8	G24
+      0x5824005D,  //  028A  LDCONST	R9	K93
+      0x8C28035E,  //  028B  GETMET	R10	R1	K94
+      0x5C300A00,  //  028C  MOVE	R12	R5
+      0x7C280400,  //  028D  CALL	R10	2
+      0x7C200400,  //  028E  CALL	R8	2
+      0x7C180400,  //  028F  CALL	R6	2
+      0x8C18035F,  //  0290  GETMET	R6	R1	K95
+      0x88200360,  //  0291  GETMBR	R8	R1	K96
+      0x7C180400,  //  0292  CALL	R6	2
+      0x8C180361,  //  0293  GETMET	R6	R1	K97
+      0x7C180200,  //  0294  CALL	R6	1
+      0xA8040001,  //  0295  EXBLK	1	1
+      0x7002001D,  //  0296  JMP		#02B5
+      0xAC180002,  //  0297  CATCH	R6	0	2
+      0x7002001A,  //  0298  JMP		#02B4
+      0xB8221000,  //  0299  GETNGBL	R8	K8
+      0x8C201109,  //  029A  GETMET	R8	R8	K9
+      0x60280018,  //  029B  GETGBL	R10	G24
+      0x582C0062,  //  029C  LDCONST	R11	K98
+      0x5C300C00,  //  029D  MOVE	R12	R6
+      0x5C340E00,  //  029E  MOVE	R13	R7
+      0x7C280600,  //  029F  CALL	R10	3
+      0x582C0063,  //  02A0  LDCONST	R11	K99
+      0x7C200600,  //  02A1  CALL	R8	3
+      0x8C200359,  //  02A2  GETMET	R8	R1	K89
+      0x5828005A,  //  02A3  LDCONST	R10	K90
+      0x7C200400,  //  02A4  CALL	R8	2
+      0x8C20035B,  //  02A5  GETMET	R8	R1	K91
+      0x7C200200,  //  02A6  CALL	R8	1
+      0x8C20035C,  //  02A7  GETMET	R8	R1	K92
+      0x60280018,  //  02A8  GETGBL	R10	G24
+      0x582C0064,  //  02A9  LDCONST	R11	K100
+      0x5C300C00,  //  02AA  MOVE	R12	R6
+      0x5C340E00,  //  02AB  MOVE	R13	R7
+      0x7C280600,  //  02AC  CALL	R10	3
+      0x7C200400,  //  02AD  CALL	R8	2
+      0x8C20035F,  //  02AE  GETMET	R8	R1	K95
+      0x88280360,  //  02AF  GETMBR	R10	R1	K96
+      0x7C200400,  //  02B0  CALL	R8	2
+      0x8C200361,  //  02B1  GETMET	R8	R1	K97
+      0x7C200200,  //  02B2  CALL	R8	1
+      0x70020000,  //  02B3  JMP		#02B5
+      0xB0080000,  //  02B4  RAISE	2	R0	R0
+      0x80000000,  //  02B5  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Add Matter option to disable bridge mode, which seems temporarily necessary for Google Home. Disabling bridge mode means that you can't add or remove dynamically endpoints without pairing again.
![image](https://github.com/arendst/Tasmota/assets/49731213/0ab04277-01c1-4c70-9492-911fbe939235)


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
