### PR TITLE
Berry `import strict` now detects useless expr without side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking Changed
 - Berry `bool( [] )` and `bool( {} )` now evaluate as `false` (#18986)
+- Berry `import strict` now detects useless expr without side effects
 
 ### Changed
 - Matter support for temperature in Fahrenheit (`SetOption8 1`) (#18987)

--- a/lib/libesp32/berry/src/be_parser.c
+++ b/lib/libesp32/berry/src/be_parser.c
@@ -196,6 +196,7 @@ static void begin_block(bfuncinfo *finfo, bblockinfo *binfo, int type)
     finfo->binfo = binfo; /* tell parser this is the current block */
     binfo->type = (bbyte)type;
     binfo->hasupval = 0;
+    binfo->sideeffect = 0;
     binfo->beginpc = finfo->pc; /* set starting pc for this block */
     binfo->nactlocals = (bbyte)be_list_count(finfo->local); /* count number of local variables in previous block */
     if (type & BLOCK_LOOP) {
@@ -796,6 +797,7 @@ static void call_expr(bparser *parser, bexpdesc *e)
     int argc = 0, base;
     int ismember = e->type == ETMEMBER;
 
+    parser->finfo->binfo->sideeffect = 1;   /* has side effect */
     /* func '(' [exprlist] ')' */
     check_var(parser, e);
     /* code function index to next register */
@@ -1030,11 +1032,13 @@ static void assign_expr(bparser *parser)
     bexpdesc e;
     btokentype op;
     int line = parser->lexer.linenumber;
+    parser->finfo->binfo->sideeffect = 0;      /* reinit side effect marker */
     expr(parser, &e); /* left expression */
     check_symbol(parser, &e);
     op = get_assign_op(parser);
     if (op != OP_NOT_ASSIGN) { /* assign operator */
         bexpdesc e1;
+        parser->finfo->binfo->sideeffect = 1;
         scan_next_token(parser);
         compound_assign(parser, op, &e, &e1);
         if (check_newvar(parser, &e)) { /* new variable */
@@ -1110,6 +1114,9 @@ static void sub_expr(bparser *parser, bexpdesc *e, int prio)
         check_var(parser, e);  /* check that left part is valid */
         scan_next_token(parser);  /* move to next token */
         be_code_prebinop(finfo, op, e); /* and or */
+        if (op == OptConnect) {
+            parser->finfo->binfo->sideeffect = 1;
+        }
         init_exp(&e2, ETVOID, 0);
         sub_expr(parser, &e2, binary_op_prio(op));  /* parse right side */
         if ((e2.type == ETVOID) && (op == OptConnect)) {
@@ -1758,6 +1765,9 @@ static void throw_stmt(bparser *parser)
 
 static void statement(bparser *parser)
 {
+    /* save value of sideeffect */
+    bbyte sideeffect = parser->finfo->binfo->sideeffect;
+    parser->finfo->binfo->sideeffect = 1;   /* by default declare side effect */
     switch (next_type(parser)) {
     case KeyIf: if_stmt(parser); break;
     case KeyWhile: while_stmt(parser); break;
@@ -1772,8 +1782,16 @@ static void statement(bparser *parser)
     case KeyVar: var_stmt(parser); break;
     case KeyTry: try_stmt(parser); break;
     case KeyRaise: throw_stmt(parser); break;
-    case OptSemic: scan_next_token(parser); break; /* empty statement */
-    default: expr_stmt(parser); break;
+    case OptSemic:
+        parser->finfo->binfo->sideeffect = sideeffect;      /* restore sideeffect */
+        scan_next_token(parser); break; /* empty statement */
+    default:
+        parser->finfo->binfo->sideeffect = sideeffect;      /* restore sideeffect */
+        expr_stmt(parser);
+        if (comp_is_strict(parser->vm) && parser->finfo->binfo->sideeffect == 0) {
+            push_error(parser, "strict: expression without side effect detected");
+        }
+        break;
     }
     be_assert(parser->finfo->freereg >= be_list_count(parser->finfo->local));
 }

--- a/lib/libesp32/berry/src/be_parser.h
+++ b/lib/libesp32/berry/src/be_parser.h
@@ -53,6 +53,7 @@ typedef struct bblockinfo {
     bbyte nactlocals; /* number of active local variables */
     bbyte type;       /* block type mask */
     bbyte hasupval;   /* has upvalue mark */
+    bbyte sideeffect; /* did the last expr/statement had a side effect */ 
     int breaklist;    /* break list */
     int beginpc;      /* begin pc */
     int continuelist; /* continue list */

--- a/lib/libesp32/berry_tasmota/src/embedded/persist.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/persist.be
@@ -111,7 +111,7 @@ class Persist
     import json
     if   isinstance(v, map)
       self.json_fdump_map(f, v)
-    elif isinstance(v, list)v
+    elif isinstance(v, list)
       self.json_fdump_list(f, v)
     else
       f.write(json.dump(v))


### PR DESCRIPTION
## Description:

Berry: new test added when compiling in strict mode `import strict`. Now the parser detects when statements or expression don't have any side effect, which means that they do nothing. It's most certainly a mistake.

This detects for example `self.attr 0` which should have been `self.attr = 0`, we was silently accepted as two useless expression.

```berry
> def f() 1 end
syntax_error: stdin:1: strict: expression without side effect detected

> def f(x) x 0 end
syntax_error: stdin:1: strict: expression without side effect detected

> def f(x) return x end     # this is ok
```

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
