### PR TITLE
Add c3 env for rev. <3

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -46,6 +46,18 @@ build_flags                 = ${env:tasmota32_base.build_flags}
                               -DUSE_LVGL_OPENHASP
                               -DOTA_URL='""'
 
+;*** Tasmota ESP32-C3 version before ROM revision 3
+;*** Actual used Arduino/IDF does not support this old revisions
+;*** Includes only basic drivers to fit in smaller app partition
+[env:tasmota32c3-old]
+extends                 = env:tasmota32c3
+platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.9.20230531/framework-arduinoespressif32.zip
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DOTA_URL='""'
+; *** Do not use safe boot scheme, since safeboot is build with new core!!
+board_build.partitions  = partitions/esp32_partition_app1856k_fs320k.csv
+; Safeboot not used in this partition scheme -> an empty entry needed to overwrite the default setting
+board_upload.arduino.flash_extra_images =
 
 [env:tasmota32c3-bluetooth]
 extends                     = env:tasmota32c3

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -48,6 +48,7 @@ build_flags                 = ${env:tasmota32_base.build_flags}
 
 ;*** Tasmota ESP32-C3 version before ROM revision 3
 ;*** Actual used Arduino/IDF does not support this old revisions
+;*** This build env is without any support, unexpected issues can happen
 ;*** Includes only basic drivers to fit in smaller app partition
 [env:tasmota32c3-old]
 extends                 = env:tasmota32c3


### PR DESCRIPTION
## Description:

Provide an C3 env for board rev. < 3

This old revisions are not supported anymore from espressif in actual IDF/Arduino.
To build Tasmota for old revisions Arduino Core 2.0.9 needs to be used.

**W A R N I N G:** There is no support for this build variant. 

Please replace this old C3 with an actual one.
If you cant/wont replace the MCU, the last recommended Tasmota version is v12.5.0 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
