### PR TITLE
Berry mark walrus operator as side-effect

### DIFF
--- a/lib/libesp32/berry/src/be_parser.c
+++ b/lib/libesp32/berry/src/be_parser.c
@@ -1140,6 +1140,7 @@ static void walrus_expr(bparser *parser, bexpdesc *e)
     if (op == OptWalrus) {
         check_symbol(parser, e);
         bexpdesc e1 = *e;           /* copy var to e1, e will get the result of expression */
+        parser->finfo->binfo->sideeffect = 1;   /* has side effect */
         scan_next_token(parser);    /* skip ':=' */
         expr(parser, e);
         check_var(parser, e);


### PR DESCRIPTION
## Description:

Fix for #18997 found by @sfromis 

Now the following is allowed and correctly detected as having a side effect:
```berry
var a,b
def f() a := b end
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
