### PR TITLE
Command ``BrRestart`` to restart the Berry VM (experimental)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Command ``Delay -1`` to wait until next second (#18984)
 - Matter add option to disable bridge mode (#18992)
 - Support for SGP41 TVOC/NOx Sensor (#18880)
+- Command ``BrRestart`` to restart the Berry VM (experimental)
 
 ### Breaking Changed
 - Berry `bool( [] )` and `bool( {} )` now evaluate as `false` (#18986)

--- a/lib/libesp32/berry_mapping/src/be_cb_module.c
+++ b/lib/libesp32/berry_mapping/src/be_cb_module.c
@@ -250,6 +250,7 @@ static int32_t call_berry_cb(int32_t num, int32_t v0, int32_t v1, int32_t v2, in
 
   bvm * vm = be_cb_hooks[num].vm;
   bvalue *f = &be_cb_hooks[num].f;
+  if (vm == NULL) { return 0; }     // function is not alive anymore, don't crash
 
   // push function (don't check type)
   bvalue *top = be_incrtop(vm);
@@ -269,6 +270,26 @@ static int32_t call_berry_cb(int32_t num, int32_t v0, int32_t v1, int32_t v2, in
   ret = be_toint(vm, -5);
   be_pop(vm, 5);    // remove result
   return ret;
+}
+
+/*********************************************************************************************\
+ * `be_cb_deinit`:
+ *  Clean any callback for this VM, they shouldn't call the registerd function anymore
+\*********************************************************************************************/
+void be_cb_deinit(bvm *vm) {
+  // remove all cb for this vm
+  for (int32_t slot = 0; slot < BE_MAX_CB; slot++) {
+    if (be_cb_hooks[slot].vm == vm) {
+      be_cb_hooks[slot].vm = NULL;
+      be_cb_hooks[slot].f.type == BE_NIL;
+    }
+  }
+  // remove the vm gen_cb for this vm
+  for (be_callback_handler_list_t **elt_ptr = &be_callback_handler_list_head; *elt_ptr != NULL; elt_ptr = &(*elt_ptr)->next) {
+    if (((*elt_ptr)->next != NULL) && ((*elt_ptr)->next->vm == vm)) {
+      (*elt_ptr)->next = (*elt_ptr)->next->next;
+    }
+  }
 }
 
 /* @const_object_info_begin

--- a/lib/libesp32/berry_mapping/src/be_mapping.h
+++ b/lib/libesp32/berry_mapping/src/be_mapping.h
@@ -109,6 +109,8 @@ extern int be_check_arg_type(bvm *vm, int arg_start, int argc, const char * arg_
 extern int be_call_c_func(bvm *vm, const void * func, const char * return_type, const char * arg_type);
 extern int be_call_ctype_func(bvm *vm, const void *definition);     /* handler for Berry vm */
 
+extern void be_cb_deinit(bvm *vm);   /* remove all callbacks from the VM (just before shutdown of VM) */
+
 #ifdef __cplusplus
 }
 #endif

--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -764,6 +764,7 @@
 // Commands xdrv_52_berry.ino - Berry scripting language
 #define D_PRFX_BR "Br"
 #define D_CMND_BR_RUN ""
+#define D_CMND_BR_RESTART "Restart"
 #define D_BR_NOT_STARTED  "Berry not started"
 
 // Commands xdrv_60_shift595.ino - 74x595 family shift register driver

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
@@ -138,7 +138,6 @@ extern "C" {
       const char * uri = be_tostring(vm, 1);
       Webserver->sendHeader("Location", uri, true);
       Webserver->send(302, "text/plain", "");
-      // Webserver->sendHeader(F("Location"), String(F("http://")) + Webserver->client().localIP().toString(), true);
       be_return_nil(vm);
     }
     be_raise(vm, kTypeError, nullptr);

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -37,11 +37,11 @@ extern "C" {
 }
 
 const char kBrCommands[] PROGMEM = D_PRFX_BR "|"    // prefix
-  D_CMND_BR_RUN
+  D_CMND_BR_RUN "|" D_CMND_BR_RESTART
   ;
 
 void (* const BerryCommand[])(void) PROGMEM = {
-  CmndBrRun,
+  CmndBrRun, CmndBrRestart
   };
 
 int32_t callBerryEventDispatcher(const char *type, const char *cmd, int32_t idx, const char *payload, uint32_t data_len = 0);
@@ -307,6 +307,7 @@ void BrShowState(void) {
 void BerryInit(void) {
   // clean previous VM if any
   if (berry.vm != nullptr) {
+    be_cb_deinit(berry.vm);   // deregister any C callback for this VM
     be_vm_delete(berry.vm);
     berry.vm = nullptr;
   }
@@ -365,6 +366,17 @@ void BerryInit(void) {
       berry.vm = nullptr;
     }
   }
+}
+
+/*********************************************************************************************\
+ * BrRestart - restart a fresh new Berry vm, unloading everything from previous VM
+\*********************************************************************************************/
+void CmndBrRestart(void) {
+  if (berry.vm == nullptr) {
+    ResponseCmndChar_P("Berry VM not started");
+  }
+  BerryInit();
+  ResponseCmndChar_P("Berry VM restarted");
 }
 
 /*********************************************************************************************\

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -310,6 +310,10 @@ void BerryInit(void) {
     be_cb_deinit(berry.vm);   // deregister any C callback for this VM
     be_vm_delete(berry.vm);
     berry.vm = nullptr;
+    berry.autoexec_done = false;
+    berry.repl_active = false;
+    berry.rules_busy = false;
+    berry.timeout = 0;
   }
 
   int32_t ret_code1, ret_code2;
@@ -665,14 +669,16 @@ const char HTTP_BERRY_FORM_CMND[] PROGMEM =
       "Check the <a href='https://tasmota.github.io/docs/Berry/' target='_blank'>documentation</a>."
     "</div>"
   "</div>"
-  // "<textarea readonly id='t1' cols='340' wrap='off'></textarea>"
-  // "<br><br>"
   "<form method='get' id='fo' onsubmit='return l(1);'>"
   "<textarea id='c1' class='br0 bri' rows='4' cols='340' wrap='soft' autofocus required></textarea>"
-  // "<input id='c1' class='bri' type='text' rows='5' placeholder='" D_ENTER_COMMAND "' autofocus><br>"
-  // "<input type='submit' value=\"Run code (or press 'Enter' twice)\">"
   "<button type='submit'>Run code (or press 'Enter' twice)</button>"
-  "</form>";
+  "</form>"
+#ifdef USE_BERRY_DEBUG
+  "<p><form method='post' >"
+  "<button type='submit' name='rst' class='bred' onclick=\"if(confirm('Confirm removing endpoint')){clearTimeout(lt);return true;}else{return false;}\">Restart Berry VM (for devs only)</button>"
+  "</form></p>"
+#endif // USE_BERRY_DEBUG
+  ;
 
 const char HTTP_BTN_BERRY_CONSOLE[] PROGMEM =
   "<p><form action='bc' method='get'><button>Berry Scripting console</button></form></p>";
@@ -716,6 +722,12 @@ void HandleBerryConsole(void)
   if (Webserver->hasArg(F("c2"))) {      // Console refresh requested
     HandleBerryConsoleRefresh();
     return;
+  }
+
+  if (Webserver->hasArg(F("rst"))) {      // restart VM
+    BerryInit();
+    Webserver->sendHeader("Location", "/bc", true);
+    Webserver->send(302, "text/plain", "");
   }
 
   AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_HTTP "Berry " D_CONSOLE));


### PR DESCRIPTION
## Description:

The command `BrRestart` deletes the current Berry Virtual Machine and creates a new one, and initalize it (including loading of `autoexec.be`).

This is an experimental feature only useful for Berry developers, and facilitates testing without waiting for a full Tasmota restart.

Limitations: unfortunately Arduino is not able to deregister Request Handlers in the local web server. So restarting the Berry VM breaks all WebUI implemented in Berry (`webser.on()`). I don't see any way to solve this for now.

If `#define USE_BERRY_DEBUG` is defined, a new "Restart Berry VM" button is added to the Berry console:
<img width="439" alt="image" src="https://github.com/arendst/Tasmota/assets/49731213/f9249b12-641b-48b6-b7fd-8e773edb0479">


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
