### PR TITLE
Matter no Ack for Invoke Request

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
@@ -66,7 +66,7 @@ class Matter_IM
     elif opcode == 0x07   # Write Response
       return self.process_write_response(msg, val)
     elif opcode == 0x08   # Invoke Request
-      self.send_ack_now(msg)
+      # self.send_ack_now(msg)      # to improve latency, we don't automatically Ack on invoke request
       return self.process_invoke_request(msg, val)
     elif opcode == 0x09   # Invoke Response
       return self.process_invoke_response(msg, val)
@@ -97,6 +97,7 @@ class Matter_IM
   #
   # returns `true` if packet could be sent
   def send_ack_now(msg)
+    if msg == nil   return  end
     msg.session._message_handler.send_encrypted_ack(msg, false #-not reliable-#)
   end
 
@@ -355,6 +356,7 @@ class Matter_IM
     # expand a string with all attributes requested
     var attr_req = []
     var ctx = matter.Path()
+    ctx.msg = msg
     for q:query.attributes_requests
       ctx.endpoint = q.endpoint
       ctx.cluster = q.cluster
@@ -381,6 +383,7 @@ class Matter_IM
     # structure is `ReadRequestMessage` 10.6.2 p.558
     # tasmota.log("MTR: IM:invoke_request processing start", 4)
     var ctx = matter.Path()
+    ctx.msg = msg
 
     var query = matter.InvokeRequestMessage().from_TLV(val)
     if query.invoke_requests != nil

--- a/lib/libesp32/berry_matter/src/embedded/Matter_MessageHandler.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_MessageHandler.be
@@ -138,7 +138,7 @@ class Matter_MessageHandler
        
         # check if it's a duplicate
         if !session.counter_rcv_validate(frame.message_counter, true)
-          tasmota.log("MTR: .          Duplicate encrypted message = " + str(frame.message_counter) + " counter=" + str(session.counter_rcv), 4)
+          tasmota.log("MTR: .          Duplicate encrypted message = " + str(frame.message_counter) + " counter=" + str(session.counter_rcv), 3)
           self.send_encrypted_ack(frame, false #-not reliable-#)
           return false
         end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Path.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Path.be
@@ -33,6 +33,19 @@ class Matter_Path
   var command                 # command
   var status                  # status to be returned (matter.SUCCESS or matter.<ERROR>)
   var log                     # any string that needs to be logged (used to show significant parameters for commands)
+  var msg                     # reference of the original message
+
+  # clear the context, allows reuse of the same object
+  def clear()
+    var n = nil
+    self.endpoint = n
+    self.cluster = n
+    self.attribute = n
+    self.command = n
+    self.status = n
+    self.log = n
+    self.msh = n
+  end
 
   def tostring()
     try

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin.be
@@ -63,6 +63,11 @@ class Matter_Plugin
     self.parse_configuration(config)
   end
 
+  # proxy for the same method in IM
+  def send_ack_now(msg)
+    self.device.message_handler.im.send_ack_now(msg)
+  end
+
   #############################################################
   # parse_configuration
   #

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
@@ -368,6 +368,7 @@ class Matter_Plugin_Root : Matter_Plugin
         return srcr
 
       elif command == 0x0004            # ---------- CommissioningComplete p.636 ----------
+        self.send_ack_now(ctx.msg)      # long operation, send Ack first
         # no data
         if session._fabric
           session._breadcrumb = 0          # clear breadcrumb
@@ -435,6 +436,7 @@ class Matter_Plugin_Root : Matter_Plugin
         return ar
 
       elif command == 0x0004            # ---------- CSRRequest ----------
+        self.send_ack_now(ctx.msg)      # long operation, send Ack first
         var CSRNonce = val.findsubval(0)     # octstr 32
         if size(CSRNonce) != 32   return nil end    # check size on nonce
         var IsForUpdateNOC = val.findsubval(1, false)     # bool

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -75,329 +75,331 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[43]) {     /* constants */
+    ( &(const bvalue[44]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(Path),
-    /* K2   */  be_nested_str_weak(InvokeRequestMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(invoke_requests),
-    /* K5   */  be_nested_str_weak(InvokeResponseMessage),
-    /* K6   */  be_nested_str_weak(suppress_response),
-    /* K7   */  be_nested_str_weak(invoke_responses),
-    /* K8   */  be_nested_str_weak(endpoint),
-    /* K9   */  be_nested_str_weak(command_path),
-    /* K10  */  be_nested_str_weak(cluster),
-    /* K11  */  be_nested_str_weak(command),
-    /* K12  */  be_nested_str_weak(status),
-    /* K13  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
-    /* K14  */  be_nested_str_weak(get_command_name),
-    /* K15  */  be_nested_str_weak(device),
-    /* K16  */  be_nested_str_weak(invoke_request),
-    /* K17  */  be_nested_str_weak(session),
-    /* K18  */  be_nested_str_weak(command_fields),
-    /* K19  */  be_nested_str_weak(log),
-    /* K20  */  be_nested_str_weak(_X28),
-    /* K21  */  be_nested_str_weak(_X29_X20),
-    /* K22  */  be_nested_str_weak(),
-    /* K23  */  be_nested_str_weak(tasmota),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20_X25s),
-    /* K25  */  be_nested_str_weak(local_session_id),
-    /* K26  */  be_const_int(0),
-    /* K27  */  be_const_int(2),
-    /* K28  */  be_const_int(3),
-    /* K29  */  be_nested_str_weak(InvokeResponseIB),
-    /* K30  */  be_nested_str_weak(SUCCESS),
-    /* K31  */  be_nested_str_weak(CommandStatusIB),
-    /* K32  */  be_nested_str_weak(CommandPathIB),
-    /* K33  */  be_nested_str_weak(StatusIB),
-    /* K34  */  be_nested_str_weak(push),
-    /* K35  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20OK_X20exch_X3D_X25i),
-    /* K36  */  be_nested_str_weak(exchange_id),
-    /* K37  */  be_nested_str_weak(CommandDataIB),
-    /* K38  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s),
-    /* K39  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20Status_X3D0x_X2502X_X20exch_X3D_X25i),
-    /* K40  */  be_nested_str_weak(MTR_X3A_X20_Ignore_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i),
-    /* K41  */  be_nested_str_weak(stop_iteration),
-    /* K42  */  be_nested_str_weak(send_invoke_response),
+    /* K2   */  be_nested_str_weak(msg),
+    /* K3   */  be_nested_str_weak(InvokeRequestMessage),
+    /* K4   */  be_nested_str_weak(from_TLV),
+    /* K5   */  be_nested_str_weak(invoke_requests),
+    /* K6   */  be_nested_str_weak(InvokeResponseMessage),
+    /* K7   */  be_nested_str_weak(suppress_response),
+    /* K8   */  be_nested_str_weak(invoke_responses),
+    /* K9   */  be_nested_str_weak(endpoint),
+    /* K10  */  be_nested_str_weak(command_path),
+    /* K11  */  be_nested_str_weak(cluster),
+    /* K12  */  be_nested_str_weak(command),
+    /* K13  */  be_nested_str_weak(status),
+    /* K14  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
+    /* K15  */  be_nested_str_weak(get_command_name),
+    /* K16  */  be_nested_str_weak(device),
+    /* K17  */  be_nested_str_weak(invoke_request),
+    /* K18  */  be_nested_str_weak(session),
+    /* K19  */  be_nested_str_weak(command_fields),
+    /* K20  */  be_nested_str_weak(log),
+    /* K21  */  be_nested_str_weak(_X28),
+    /* K22  */  be_nested_str_weak(_X29_X20),
+    /* K23  */  be_nested_str_weak(),
+    /* K24  */  be_nested_str_weak(tasmota),
+    /* K25  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20_X25s),
+    /* K26  */  be_nested_str_weak(local_session_id),
+    /* K27  */  be_const_int(0),
+    /* K28  */  be_const_int(2),
+    /* K29  */  be_const_int(3),
+    /* K30  */  be_nested_str_weak(InvokeResponseIB),
+    /* K31  */  be_nested_str_weak(SUCCESS),
+    /* K32  */  be_nested_str_weak(CommandStatusIB),
+    /* K33  */  be_nested_str_weak(CommandPathIB),
+    /* K34  */  be_nested_str_weak(StatusIB),
+    /* K35  */  be_nested_str_weak(push),
+    /* K36  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20OK_X20exch_X3D_X25i),
+    /* K37  */  be_nested_str_weak(exchange_id),
+    /* K38  */  be_nested_str_weak(CommandDataIB),
+    /* K39  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s),
+    /* K40  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20Status_X3D0x_X2502X_X20exch_X3D_X25i),
+    /* K41  */  be_nested_str_weak(MTR_X3A_X20_Ignore_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i),
+    /* K42  */  be_nested_str_weak(stop_iteration),
+    /* K43  */  be_nested_str_weak(send_invoke_response),
     }),
     be_str_weak(process_invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[275]) {  /* code */
+    ( &(const binstruction[276]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x8C0C0701,  //  0001  GETMET	R3	R3	K1
       0x7C0C0200,  //  0002  CALL	R3	1
-      0xB8120000,  //  0003  GETNGBL	R4	K0
-      0x8C100902,  //  0004  GETMET	R4	R4	K2
-      0x7C100200,  //  0005  CALL	R4	1
-      0x8C100903,  //  0006  GETMET	R4	R4	K3
-      0x5C180400,  //  0007  MOVE	R6	R2
-      0x7C100400,  //  0008  CALL	R4	2
-      0x88140904,  //  0009  GETMBR	R5	R4	K4
-      0x4C180000,  //  000A  LDNIL	R6
-      0x20140A06,  //  000B  NE	R5	R5	R6
-      0x78160104,  //  000C  JMPF	R5	#0112
-      0xB8160000,  //  000D  GETNGBL	R5	K0
-      0x8C140B05,  //  000E  GETMET	R5	R5	K5
-      0x7C140200,  //  000F  CALL	R5	1
-      0x50180000,  //  0010  LDBOOL	R6	0	0
-      0x90160C06,  //  0011  SETMBR	R5	K6	R6
-      0x60180012,  //  0012  GETGBL	R6	G18
-      0x7C180000,  //  0013  CALL	R6	0
-      0x90160E06,  //  0014  SETMBR	R5	K7	R6
-      0x60180010,  //  0015  GETGBL	R6	G16
-      0x881C0904,  //  0016  GETMBR	R7	R4	K4
-      0x7C180200,  //  0017  CALL	R6	1
-      0xA80200E7,  //  0018  EXBLK	0	#0101
-      0x5C1C0C00,  //  0019  MOVE	R7	R6
-      0x7C1C0000,  //  001A  CALL	R7	0
-      0x88200F09,  //  001B  GETMBR	R8	R7	K9
-      0x88201108,  //  001C  GETMBR	R8	R8	K8
-      0x900E1008,  //  001D  SETMBR	R3	K8	R8
-      0x88200F09,  //  001E  GETMBR	R8	R7	K9
-      0x8820110A,  //  001F  GETMBR	R8	R8	K10
-      0x900E1408,  //  0020  SETMBR	R3	K10	R8
-      0x88200F09,  //  0021  GETMBR	R8	R7	K9
-      0x8820110B,  //  0022  GETMBR	R8	R8	K11
-      0x900E1608,  //  0023  SETMBR	R3	K11	R8
-      0xB8220000,  //  0024  GETNGBL	R8	K0
-      0x8820110D,  //  0025  GETMBR	R8	R8	K13
-      0x900E1808,  //  0026  SETMBR	R3	K12	R8
-      0xB8220000,  //  0027  GETNGBL	R8	K0
-      0x8C20110E,  //  0028  GETMET	R8	R8	K14
-      0x8828070A,  //  0029  GETMBR	R10	R3	K10
-      0x882C070B,  //  002A  GETMBR	R11	R3	K11
-      0x7C200600,  //  002B  CALL	R8	3
-      0x60240008,  //  002C  GETGBL	R9	G8
-      0x5C280600,  //  002D  MOVE	R10	R3
-      0x7C240200,  //  002E  CALL	R9	1
-      0x8828010F,  //  002F  GETMBR	R10	R0	K15
-      0x8C281510,  //  0030  GETMET	R10	R10	K16
-      0x88300311,  //  0031  GETMBR	R12	R1	K17
-      0x88340F12,  //  0032  GETMBR	R13	R7	K18
-      0x5C380600,  //  0033  MOVE	R14	R3
-      0x7C280800,  //  0034  CALL	R10	4
-      0x882C0713,  //  0035  GETMBR	R11	R3	K19
-      0x4C300000,  //  0036  LDNIL	R12
-      0x202C160C,  //  0037  NE	R11	R11	R12
-      0x782E0005,  //  0038  JMPF	R11	#003F
-      0x602C0008,  //  0039  GETGBL	R11	G8
-      0x88300713,  //  003A  GETMBR	R12	R3	K19
-      0x7C2C0200,  //  003B  CALL	R11	1
-      0x002E280B,  //  003C  ADD	R11	K20	R11
-      0x002C1715,  //  003D  ADD	R11	R11	K21
-      0x70020000,  //  003E  JMP		#0040
-      0x582C0016,  //  003F  LDCONST	R11	K22
-      0xB8322E00,  //  0040  GETNGBL	R12	K23
-      0x8C301913,  //  0041  GETMET	R12	R12	K19
-      0x60380018,  //  0042  GETGBL	R14	G24
-      0x583C0018,  //  0043  LDCONST	R15	K24
-      0x88400311,  //  0044  GETMBR	R16	R1	K17
-      0x88402119,  //  0045  GETMBR	R16	R16	K25
-      0x5C441200,  //  0046  MOVE	R17	R9
-      0x78220001,  //  0047  JMPF	R8	#004A
-      0x5C481000,  //  0048  MOVE	R18	R8
-      0x70020000,  //  0049  JMP		#004B
-      0x58480016,  //  004A  LDCONST	R18	K22
-      0x5C4C1600,  //  004B  MOVE	R19	R11
-      0x7C380A00,  //  004C  CALL	R14	5
-      0x883C0708,  //  004D  GETMBR	R15	R3	K8
-      0x203C1F1A,  //  004E  NE	R15	R15	K26
-      0x783E0001,  //  004F  JMPF	R15	#0052
-      0x583C001B,  //  0050  LDCONST	R15	K27
-      0x70020000,  //  0051  JMP		#0053
-      0x583C001C,  //  0052  LDCONST	R15	K28
-      0x7C300600,  //  0053  CALL	R12	3
-      0x4C300000,  //  0054  LDNIL	R12
-      0x900E260C,  //  0055  SETMBR	R3	K19	R12
-      0xB8320000,  //  0056  GETNGBL	R12	K0
-      0x8C30191D,  //  0057  GETMET	R12	R12	K29
-      0x7C300200,  //  0058  CALL	R12	1
-      0x50340200,  //  0059  LDBOOL	R13	1	0
-      0x1C34140D,  //  005A  EQ	R13	R10	R13
-      0x74360004,  //  005B  JMPT	R13	#0061
-      0x8834070C,  //  005C  GETMBR	R13	R3	K12
-      0xB83A0000,  //  005D  GETNGBL	R14	K0
-      0x88381D1E,  //  005E  GETMBR	R14	R14	K30
-      0x1C341A0E,  //  005F  EQ	R13	R13	R14
-      0x7836002D,  //  0060  JMPF	R13	#008F
-      0xB8360000,  //  0061  GETNGBL	R13	K0
-      0x8C341B1F,  //  0062  GETMET	R13	R13	K31
-      0x7C340200,  //  0063  CALL	R13	1
-      0x9032180D,  //  0064  SETMBR	R12	K12	R13
-      0x8834190C,  //  0065  GETMBR	R13	R12	K12
-      0xB83A0000,  //  0066  GETNGBL	R14	K0
-      0x8C381D20,  //  0067  GETMET	R14	R14	K32
-      0x7C380200,  //  0068  CALL	R14	1
-      0x9036120E,  //  0069  SETMBR	R13	K9	R14
-      0x8834190C,  //  006A  GETMBR	R13	R12	K12
-      0x88341B09,  //  006B  GETMBR	R13	R13	K9
-      0x88380708,  //  006C  GETMBR	R14	R3	K8
-      0x9036100E,  //  006D  SETMBR	R13	K8	R14
-      0x8834190C,  //  006E  GETMBR	R13	R12	K12
-      0x88341B09,  //  006F  GETMBR	R13	R13	K9
-      0x8838070A,  //  0070  GETMBR	R14	R3	K10
-      0x9036140E,  //  0071  SETMBR	R13	K10	R14
-      0x8834190C,  //  0072  GETMBR	R13	R12	K12
-      0x88341B09,  //  0073  GETMBR	R13	R13	K9
-      0x8838070B,  //  0074  GETMBR	R14	R3	K11
-      0x9036160E,  //  0075  SETMBR	R13	K11	R14
-      0x8834190C,  //  0076  GETMBR	R13	R12	K12
-      0xB83A0000,  //  0077  GETNGBL	R14	K0
-      0x8C381D21,  //  0078  GETMET	R14	R14	K33
-      0x7C380200,  //  0079  CALL	R14	1
-      0x9036180E,  //  007A  SETMBR	R13	K12	R14
-      0x8834190C,  //  007B  GETMBR	R13	R12	K12
-      0x88341B0C,  //  007C  GETMBR	R13	R13	K12
-      0xB83A0000,  //  007D  GETNGBL	R14	K0
-      0x88381D1E,  //  007E  GETMBR	R14	R14	K30
-      0x9036180E,  //  007F  SETMBR	R13	K12	R14
-      0x88340B07,  //  0080  GETMBR	R13	R5	K7
-      0x8C341B22,  //  0081  GETMET	R13	R13	K34
-      0x5C3C1800,  //  0082  MOVE	R15	R12
-      0x7C340400,  //  0083  CALL	R13	2
-      0xB8362E00,  //  0084  GETNGBL	R13	K23
-      0x8C341B13,  //  0085  GETMET	R13	R13	K19
-      0x603C0018,  //  0086  GETGBL	R15	G24
-      0x58400023,  //  0087  LDCONST	R16	K35
-      0x88440311,  //  0088  GETMBR	R17	R1	K17
-      0x88442319,  //  0089  GETMBR	R17	R17	K25
-      0x88480324,  //  008A  GETMBR	R18	R1	K36
-      0x7C3C0600,  //  008B  CALL	R15	3
-      0x5840001C,  //  008C  LDCONST	R16	K28
-      0x7C340600,  //  008D  CALL	R13	3
-      0x70020070,  //  008E  JMP		#0100
-      0x4C340000,  //  008F  LDNIL	R13
-      0x2034140D,  //  0090  NE	R13	R10	R13
-      0x78360031,  //  0091  JMPF	R13	#00C4
-      0xB8360000,  //  0092  GETNGBL	R13	K0
-      0x8C341B25,  //  0093  GETMET	R13	R13	K37
-      0x7C340200,  //  0094  CALL	R13	1
-      0x9032160D,  //  0095  SETMBR	R12	K11	R13
-      0x8834190B,  //  0096  GETMBR	R13	R12	K11
-      0xB83A0000,  //  0097  GETNGBL	R14	K0
-      0x8C381D20,  //  0098  GETMET	R14	R14	K32
-      0x7C380200,  //  0099  CALL	R14	1
-      0x9036120E,  //  009A  SETMBR	R13	K9	R14
-      0x8834190B,  //  009B  GETMBR	R13	R12	K11
-      0x88341B09,  //  009C  GETMBR	R13	R13	K9
-      0x88380708,  //  009D  GETMBR	R14	R3	K8
-      0x9036100E,  //  009E  SETMBR	R13	K8	R14
-      0x8834190B,  //  009F  GETMBR	R13	R12	K11
-      0x88341B09,  //  00A0  GETMBR	R13	R13	K9
-      0x8838070A,  //  00A1  GETMBR	R14	R3	K10
-      0x9036140E,  //  00A2  SETMBR	R13	K10	R14
-      0x8834190B,  //  00A3  GETMBR	R13	R12	K11
-      0x88341B09,  //  00A4  GETMBR	R13	R13	K9
-      0x8838070B,  //  00A5  GETMBR	R14	R3	K11
-      0x9036160E,  //  00A6  SETMBR	R13	K11	R14
-      0x8834190B,  //  00A7  GETMBR	R13	R12	K11
-      0x9036240A,  //  00A8  SETMBR	R13	K18	R10
-      0x88340B07,  //  00A9  GETMBR	R13	R5	K7
-      0x8C341B22,  //  00AA  GETMET	R13	R13	K34
-      0x5C3C1800,  //  00AB  MOVE	R15	R12
-      0x7C340400,  //  00AC  CALL	R13	2
-      0xB8360000,  //  00AD  GETNGBL	R13	K0
-      0x8C341B0E,  //  00AE  GETMET	R13	R13	K14
-      0x883C070A,  //  00AF  GETMBR	R15	R3	K10
-      0x8840070B,  //  00B0  GETMBR	R16	R3	K11
-      0x7C340600,  //  00B1  CALL	R13	3
-      0x5C201A00,  //  00B2  MOVE	R8	R13
-      0xB8362E00,  //  00B3  GETNGBL	R13	K23
-      0x8C341B13,  //  00B4  GETMET	R13	R13	K19
-      0x603C0018,  //  00B5  GETGBL	R15	G24
-      0x58400026,  //  00B6  LDCONST	R16	K38
-      0x88440311,  //  00B7  GETMBR	R17	R1	K17
-      0x88442319,  //  00B8  GETMBR	R17	R17	K25
-      0x60480008,  //  00B9  GETGBL	R18	G8
-      0x5C4C0600,  //  00BA  MOVE	R19	R3
-      0x7C480200,  //  00BB  CALL	R18	1
-      0x78220001,  //  00BC  JMPF	R8	#00BF
-      0x5C4C1000,  //  00BD  MOVE	R19	R8
-      0x70020000,  //  00BE  JMP		#00C0
-      0x584C0016,  //  00BF  LDCONST	R19	K22
-      0x7C3C0800,  //  00C0  CALL	R15	4
-      0x5840001C,  //  00C1  LDCONST	R16	K28
-      0x7C340600,  //  00C2  CALL	R13	3
-      0x7002003B,  //  00C3  JMP		#0100
-      0x8834070C,  //  00C4  GETMBR	R13	R3	K12
-      0x4C380000,  //  00C5  LDNIL	R14
-      0x20341A0E,  //  00C6  NE	R13	R13	R14
-      0x7836002D,  //  00C7  JMPF	R13	#00F6
-      0xB8360000,  //  00C8  GETNGBL	R13	K0
-      0x8C341B1F,  //  00C9  GETMET	R13	R13	K31
-      0x7C340200,  //  00CA  CALL	R13	1
-      0x9032180D,  //  00CB  SETMBR	R12	K12	R13
-      0x8834190C,  //  00CC  GETMBR	R13	R12	K12
-      0xB83A0000,  //  00CD  GETNGBL	R14	K0
-      0x8C381D20,  //  00CE  GETMET	R14	R14	K32
-      0x7C380200,  //  00CF  CALL	R14	1
-      0x9036120E,  //  00D0  SETMBR	R13	K9	R14
-      0x8834190C,  //  00D1  GETMBR	R13	R12	K12
-      0x88341B09,  //  00D2  GETMBR	R13	R13	K9
-      0x88380708,  //  00D3  GETMBR	R14	R3	K8
-      0x9036100E,  //  00D4  SETMBR	R13	K8	R14
-      0x8834190C,  //  00D5  GETMBR	R13	R12	K12
-      0x88341B09,  //  00D6  GETMBR	R13	R13	K9
-      0x8838070A,  //  00D7  GETMBR	R14	R3	K10
-      0x9036140E,  //  00D8  SETMBR	R13	K10	R14
-      0x8834190C,  //  00D9  GETMBR	R13	R12	K12
-      0x88341B09,  //  00DA  GETMBR	R13	R13	K9
-      0x8838070B,  //  00DB  GETMBR	R14	R3	K11
-      0x9036160E,  //  00DC  SETMBR	R13	K11	R14
-      0x8834190C,  //  00DD  GETMBR	R13	R12	K12
-      0xB83A0000,  //  00DE  GETNGBL	R14	K0
-      0x8C381D21,  //  00DF  GETMET	R14	R14	K33
-      0x7C380200,  //  00E0  CALL	R14	1
-      0x9036180E,  //  00E1  SETMBR	R13	K12	R14
-      0x8834190C,  //  00E2  GETMBR	R13	R12	K12
-      0x88341B0C,  //  00E3  GETMBR	R13	R13	K12
-      0x8838070C,  //  00E4  GETMBR	R14	R3	K12
-      0x9036180E,  //  00E5  SETMBR	R13	K12	R14
-      0x88340B07,  //  00E6  GETMBR	R13	R5	K7
-      0x8C341B22,  //  00E7  GETMET	R13	R13	K34
-      0x5C3C1800,  //  00E8  MOVE	R15	R12
-      0x7C340400,  //  00E9  CALL	R13	2
-      0xB8362E00,  //  00EA  GETNGBL	R13	K23
-      0x8C341B13,  //  00EB  GETMET	R13	R13	K19
-      0x603C0018,  //  00EC  GETGBL	R15	G24
-      0x58400027,  //  00ED  LDCONST	R16	K39
-      0x88440311,  //  00EE  GETMBR	R17	R1	K17
-      0x88442319,  //  00EF  GETMBR	R17	R17	K25
-      0x8848070C,  //  00F0  GETMBR	R18	R3	K12
-      0x884C0324,  //  00F1  GETMBR	R19	R1	K36
-      0x7C3C0800,  //  00F2  CALL	R15	4
-      0x5840001C,  //  00F3  LDCONST	R16	K28
-      0x7C340600,  //  00F4  CALL	R13	3
-      0x70020009,  //  00F5  JMP		#0100
-      0xB8362E00,  //  00F6  GETNGBL	R13	K23
-      0x8C341B13,  //  00F7  GETMET	R13	R13	K19
-      0x603C0018,  //  00F8  GETGBL	R15	G24
-      0x58400028,  //  00F9  LDCONST	R16	K40
-      0x88440311,  //  00FA  GETMBR	R17	R1	K17
-      0x88442319,  //  00FB  GETMBR	R17	R17	K25
-      0x88480324,  //  00FC  GETMBR	R18	R1	K36
-      0x7C3C0600,  //  00FD  CALL	R15	3
-      0x5840001C,  //  00FE  LDCONST	R16	K28
-      0x7C340600,  //  00FF  CALL	R13	3
-      0x7001FF17,  //  0100  JMP		#0019
-      0x58180029,  //  0101  LDCONST	R6	K41
-      0xAC180200,  //  0102  CATCH	R6	1	0
-      0xB0080000,  //  0103  RAISE	2	R0	R0
-      0x6018000C,  //  0104  GETGBL	R6	G12
-      0x881C0B07,  //  0105  GETMBR	R7	R5	K7
-      0x7C180200,  //  0106  CALL	R6	1
-      0x24180D1A,  //  0107  GT	R6	R6	K26
-      0x781A0004,  //  0108  JMPF	R6	#010E
-      0x8C18012A,  //  0109  GETMET	R6	R0	K42
-      0x5C200200,  //  010A  MOVE	R8	R1
-      0x5C240A00,  //  010B  MOVE	R9	R5
-      0x7C180600,  //  010C  CALL	R6	3
-      0x70020001,  //  010D  JMP		#0110
-      0x50180000,  //  010E  LDBOOL	R6	0	0
-      0x80040C00,  //  010F  RET	1	R6
-      0x50180200,  //  0110  LDBOOL	R6	1	0
-      0x80040C00,  //  0111  RET	1	R6
-      0x80000000,  //  0112  RET	0
+      0x900E0401,  //  0003  SETMBR	R3	K2	R1
+      0xB8120000,  //  0004  GETNGBL	R4	K0
+      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x5C180400,  //  0008  MOVE	R6	R2
+      0x7C100400,  //  0009  CALL	R4	2
+      0x88140905,  //  000A  GETMBR	R5	R4	K5
+      0x4C180000,  //  000B  LDNIL	R6
+      0x20140A06,  //  000C  NE	R5	R5	R6
+      0x78160104,  //  000D  JMPF	R5	#0113
+      0xB8160000,  //  000E  GETNGBL	R5	K0
+      0x8C140B06,  //  000F  GETMET	R5	R5	K6
+      0x7C140200,  //  0010  CALL	R5	1
+      0x50180000,  //  0011  LDBOOL	R6	0	0
+      0x90160E06,  //  0012  SETMBR	R5	K7	R6
+      0x60180012,  //  0013  GETGBL	R6	G18
+      0x7C180000,  //  0014  CALL	R6	0
+      0x90161006,  //  0015  SETMBR	R5	K8	R6
+      0x60180010,  //  0016  GETGBL	R6	G16
+      0x881C0905,  //  0017  GETMBR	R7	R4	K5
+      0x7C180200,  //  0018  CALL	R6	1
+      0xA80200E7,  //  0019  EXBLK	0	#0102
+      0x5C1C0C00,  //  001A  MOVE	R7	R6
+      0x7C1C0000,  //  001B  CALL	R7	0
+      0x88200F0A,  //  001C  GETMBR	R8	R7	K10
+      0x88201109,  //  001D  GETMBR	R8	R8	K9
+      0x900E1208,  //  001E  SETMBR	R3	K9	R8
+      0x88200F0A,  //  001F  GETMBR	R8	R7	K10
+      0x8820110B,  //  0020  GETMBR	R8	R8	K11
+      0x900E1608,  //  0021  SETMBR	R3	K11	R8
+      0x88200F0A,  //  0022  GETMBR	R8	R7	K10
+      0x8820110C,  //  0023  GETMBR	R8	R8	K12
+      0x900E1808,  //  0024  SETMBR	R3	K12	R8
+      0xB8220000,  //  0025  GETNGBL	R8	K0
+      0x8820110E,  //  0026  GETMBR	R8	R8	K14
+      0x900E1A08,  //  0027  SETMBR	R3	K13	R8
+      0xB8220000,  //  0028  GETNGBL	R8	K0
+      0x8C20110F,  //  0029  GETMET	R8	R8	K15
+      0x8828070B,  //  002A  GETMBR	R10	R3	K11
+      0x882C070C,  //  002B  GETMBR	R11	R3	K12
+      0x7C200600,  //  002C  CALL	R8	3
+      0x60240008,  //  002D  GETGBL	R9	G8
+      0x5C280600,  //  002E  MOVE	R10	R3
+      0x7C240200,  //  002F  CALL	R9	1
+      0x88280110,  //  0030  GETMBR	R10	R0	K16
+      0x8C281511,  //  0031  GETMET	R10	R10	K17
+      0x88300312,  //  0032  GETMBR	R12	R1	K18
+      0x88340F13,  //  0033  GETMBR	R13	R7	K19
+      0x5C380600,  //  0034  MOVE	R14	R3
+      0x7C280800,  //  0035  CALL	R10	4
+      0x882C0714,  //  0036  GETMBR	R11	R3	K20
+      0x4C300000,  //  0037  LDNIL	R12
+      0x202C160C,  //  0038  NE	R11	R11	R12
+      0x782E0005,  //  0039  JMPF	R11	#0040
+      0x602C0008,  //  003A  GETGBL	R11	G8
+      0x88300714,  //  003B  GETMBR	R12	R3	K20
+      0x7C2C0200,  //  003C  CALL	R11	1
+      0x002E2A0B,  //  003D  ADD	R11	K21	R11
+      0x002C1716,  //  003E  ADD	R11	R11	K22
+      0x70020000,  //  003F  JMP		#0041
+      0x582C0017,  //  0040  LDCONST	R11	K23
+      0xB8323000,  //  0041  GETNGBL	R12	K24
+      0x8C301914,  //  0042  GETMET	R12	R12	K20
+      0x60380018,  //  0043  GETGBL	R14	G24
+      0x583C0019,  //  0044  LDCONST	R15	K25
+      0x88400312,  //  0045  GETMBR	R16	R1	K18
+      0x8840211A,  //  0046  GETMBR	R16	R16	K26
+      0x5C441200,  //  0047  MOVE	R17	R9
+      0x78220001,  //  0048  JMPF	R8	#004B
+      0x5C481000,  //  0049  MOVE	R18	R8
+      0x70020000,  //  004A  JMP		#004C
+      0x58480017,  //  004B  LDCONST	R18	K23
+      0x5C4C1600,  //  004C  MOVE	R19	R11
+      0x7C380A00,  //  004D  CALL	R14	5
+      0x883C0709,  //  004E  GETMBR	R15	R3	K9
+      0x203C1F1B,  //  004F  NE	R15	R15	K27
+      0x783E0001,  //  0050  JMPF	R15	#0053
+      0x583C001C,  //  0051  LDCONST	R15	K28
+      0x70020000,  //  0052  JMP		#0054
+      0x583C001D,  //  0053  LDCONST	R15	K29
+      0x7C300600,  //  0054  CALL	R12	3
+      0x4C300000,  //  0055  LDNIL	R12
+      0x900E280C,  //  0056  SETMBR	R3	K20	R12
+      0xB8320000,  //  0057  GETNGBL	R12	K0
+      0x8C30191E,  //  0058  GETMET	R12	R12	K30
+      0x7C300200,  //  0059  CALL	R12	1
+      0x50340200,  //  005A  LDBOOL	R13	1	0
+      0x1C34140D,  //  005B  EQ	R13	R10	R13
+      0x74360004,  //  005C  JMPT	R13	#0062
+      0x8834070D,  //  005D  GETMBR	R13	R3	K13
+      0xB83A0000,  //  005E  GETNGBL	R14	K0
+      0x88381D1F,  //  005F  GETMBR	R14	R14	K31
+      0x1C341A0E,  //  0060  EQ	R13	R13	R14
+      0x7836002D,  //  0061  JMPF	R13	#0090
+      0xB8360000,  //  0062  GETNGBL	R13	K0
+      0x8C341B20,  //  0063  GETMET	R13	R13	K32
+      0x7C340200,  //  0064  CALL	R13	1
+      0x90321A0D,  //  0065  SETMBR	R12	K13	R13
+      0x8834190D,  //  0066  GETMBR	R13	R12	K13
+      0xB83A0000,  //  0067  GETNGBL	R14	K0
+      0x8C381D21,  //  0068  GETMET	R14	R14	K33
+      0x7C380200,  //  0069  CALL	R14	1
+      0x9036140E,  //  006A  SETMBR	R13	K10	R14
+      0x8834190D,  //  006B  GETMBR	R13	R12	K13
+      0x88341B0A,  //  006C  GETMBR	R13	R13	K10
+      0x88380709,  //  006D  GETMBR	R14	R3	K9
+      0x9036120E,  //  006E  SETMBR	R13	K9	R14
+      0x8834190D,  //  006F  GETMBR	R13	R12	K13
+      0x88341B0A,  //  0070  GETMBR	R13	R13	K10
+      0x8838070B,  //  0071  GETMBR	R14	R3	K11
+      0x9036160E,  //  0072  SETMBR	R13	K11	R14
+      0x8834190D,  //  0073  GETMBR	R13	R12	K13
+      0x88341B0A,  //  0074  GETMBR	R13	R13	K10
+      0x8838070C,  //  0075  GETMBR	R14	R3	K12
+      0x9036180E,  //  0076  SETMBR	R13	K12	R14
+      0x8834190D,  //  0077  GETMBR	R13	R12	K13
+      0xB83A0000,  //  0078  GETNGBL	R14	K0
+      0x8C381D22,  //  0079  GETMET	R14	R14	K34
+      0x7C380200,  //  007A  CALL	R14	1
+      0x90361A0E,  //  007B  SETMBR	R13	K13	R14
+      0x8834190D,  //  007C  GETMBR	R13	R12	K13
+      0x88341B0D,  //  007D  GETMBR	R13	R13	K13
+      0xB83A0000,  //  007E  GETNGBL	R14	K0
+      0x88381D1F,  //  007F  GETMBR	R14	R14	K31
+      0x90361A0E,  //  0080  SETMBR	R13	K13	R14
+      0x88340B08,  //  0081  GETMBR	R13	R5	K8
+      0x8C341B23,  //  0082  GETMET	R13	R13	K35
+      0x5C3C1800,  //  0083  MOVE	R15	R12
+      0x7C340400,  //  0084  CALL	R13	2
+      0xB8363000,  //  0085  GETNGBL	R13	K24
+      0x8C341B14,  //  0086  GETMET	R13	R13	K20
+      0x603C0018,  //  0087  GETGBL	R15	G24
+      0x58400024,  //  0088  LDCONST	R16	K36
+      0x88440312,  //  0089  GETMBR	R17	R1	K18
+      0x8844231A,  //  008A  GETMBR	R17	R17	K26
+      0x88480325,  //  008B  GETMBR	R18	R1	K37
+      0x7C3C0600,  //  008C  CALL	R15	3
+      0x5840001D,  //  008D  LDCONST	R16	K29
+      0x7C340600,  //  008E  CALL	R13	3
+      0x70020070,  //  008F  JMP		#0101
+      0x4C340000,  //  0090  LDNIL	R13
+      0x2034140D,  //  0091  NE	R13	R10	R13
+      0x78360031,  //  0092  JMPF	R13	#00C5
+      0xB8360000,  //  0093  GETNGBL	R13	K0
+      0x8C341B26,  //  0094  GETMET	R13	R13	K38
+      0x7C340200,  //  0095  CALL	R13	1
+      0x9032180D,  //  0096  SETMBR	R12	K12	R13
+      0x8834190C,  //  0097  GETMBR	R13	R12	K12
+      0xB83A0000,  //  0098  GETNGBL	R14	K0
+      0x8C381D21,  //  0099  GETMET	R14	R14	K33
+      0x7C380200,  //  009A  CALL	R14	1
+      0x9036140E,  //  009B  SETMBR	R13	K10	R14
+      0x8834190C,  //  009C  GETMBR	R13	R12	K12
+      0x88341B0A,  //  009D  GETMBR	R13	R13	K10
+      0x88380709,  //  009E  GETMBR	R14	R3	K9
+      0x9036120E,  //  009F  SETMBR	R13	K9	R14
+      0x8834190C,  //  00A0  GETMBR	R13	R12	K12
+      0x88341B0A,  //  00A1  GETMBR	R13	R13	K10
+      0x8838070B,  //  00A2  GETMBR	R14	R3	K11
+      0x9036160E,  //  00A3  SETMBR	R13	K11	R14
+      0x8834190C,  //  00A4  GETMBR	R13	R12	K12
+      0x88341B0A,  //  00A5  GETMBR	R13	R13	K10
+      0x8838070C,  //  00A6  GETMBR	R14	R3	K12
+      0x9036180E,  //  00A7  SETMBR	R13	K12	R14
+      0x8834190C,  //  00A8  GETMBR	R13	R12	K12
+      0x9036260A,  //  00A9  SETMBR	R13	K19	R10
+      0x88340B08,  //  00AA  GETMBR	R13	R5	K8
+      0x8C341B23,  //  00AB  GETMET	R13	R13	K35
+      0x5C3C1800,  //  00AC  MOVE	R15	R12
+      0x7C340400,  //  00AD  CALL	R13	2
+      0xB8360000,  //  00AE  GETNGBL	R13	K0
+      0x8C341B0F,  //  00AF  GETMET	R13	R13	K15
+      0x883C070B,  //  00B0  GETMBR	R15	R3	K11
+      0x8840070C,  //  00B1  GETMBR	R16	R3	K12
+      0x7C340600,  //  00B2  CALL	R13	3
+      0x5C201A00,  //  00B3  MOVE	R8	R13
+      0xB8363000,  //  00B4  GETNGBL	R13	K24
+      0x8C341B14,  //  00B5  GETMET	R13	R13	K20
+      0x603C0018,  //  00B6  GETGBL	R15	G24
+      0x58400027,  //  00B7  LDCONST	R16	K39
+      0x88440312,  //  00B8  GETMBR	R17	R1	K18
+      0x8844231A,  //  00B9  GETMBR	R17	R17	K26
+      0x60480008,  //  00BA  GETGBL	R18	G8
+      0x5C4C0600,  //  00BB  MOVE	R19	R3
+      0x7C480200,  //  00BC  CALL	R18	1
+      0x78220001,  //  00BD  JMPF	R8	#00C0
+      0x5C4C1000,  //  00BE  MOVE	R19	R8
+      0x70020000,  //  00BF  JMP		#00C1
+      0x584C0017,  //  00C0  LDCONST	R19	K23
+      0x7C3C0800,  //  00C1  CALL	R15	4
+      0x5840001D,  //  00C2  LDCONST	R16	K29
+      0x7C340600,  //  00C3  CALL	R13	3
+      0x7002003B,  //  00C4  JMP		#0101
+      0x8834070D,  //  00C5  GETMBR	R13	R3	K13
+      0x4C380000,  //  00C6  LDNIL	R14
+      0x20341A0E,  //  00C7  NE	R13	R13	R14
+      0x7836002D,  //  00C8  JMPF	R13	#00F7
+      0xB8360000,  //  00C9  GETNGBL	R13	K0
+      0x8C341B20,  //  00CA  GETMET	R13	R13	K32
+      0x7C340200,  //  00CB  CALL	R13	1
+      0x90321A0D,  //  00CC  SETMBR	R12	K13	R13
+      0x8834190D,  //  00CD  GETMBR	R13	R12	K13
+      0xB83A0000,  //  00CE  GETNGBL	R14	K0
+      0x8C381D21,  //  00CF  GETMET	R14	R14	K33
+      0x7C380200,  //  00D0  CALL	R14	1
+      0x9036140E,  //  00D1  SETMBR	R13	K10	R14
+      0x8834190D,  //  00D2  GETMBR	R13	R12	K13
+      0x88341B0A,  //  00D3  GETMBR	R13	R13	K10
+      0x88380709,  //  00D4  GETMBR	R14	R3	K9
+      0x9036120E,  //  00D5  SETMBR	R13	K9	R14
+      0x8834190D,  //  00D6  GETMBR	R13	R12	K13
+      0x88341B0A,  //  00D7  GETMBR	R13	R13	K10
+      0x8838070B,  //  00D8  GETMBR	R14	R3	K11
+      0x9036160E,  //  00D9  SETMBR	R13	K11	R14
+      0x8834190D,  //  00DA  GETMBR	R13	R12	K13
+      0x88341B0A,  //  00DB  GETMBR	R13	R13	K10
+      0x8838070C,  //  00DC  GETMBR	R14	R3	K12
+      0x9036180E,  //  00DD  SETMBR	R13	K12	R14
+      0x8834190D,  //  00DE  GETMBR	R13	R12	K13
+      0xB83A0000,  //  00DF  GETNGBL	R14	K0
+      0x8C381D22,  //  00E0  GETMET	R14	R14	K34
+      0x7C380200,  //  00E1  CALL	R14	1
+      0x90361A0E,  //  00E2  SETMBR	R13	K13	R14
+      0x8834190D,  //  00E3  GETMBR	R13	R12	K13
+      0x88341B0D,  //  00E4  GETMBR	R13	R13	K13
+      0x8838070D,  //  00E5  GETMBR	R14	R3	K13
+      0x90361A0E,  //  00E6  SETMBR	R13	K13	R14
+      0x88340B08,  //  00E7  GETMBR	R13	R5	K8
+      0x8C341B23,  //  00E8  GETMET	R13	R13	K35
+      0x5C3C1800,  //  00E9  MOVE	R15	R12
+      0x7C340400,  //  00EA  CALL	R13	2
+      0xB8363000,  //  00EB  GETNGBL	R13	K24
+      0x8C341B14,  //  00EC  GETMET	R13	R13	K20
+      0x603C0018,  //  00ED  GETGBL	R15	G24
+      0x58400028,  //  00EE  LDCONST	R16	K40
+      0x88440312,  //  00EF  GETMBR	R17	R1	K18
+      0x8844231A,  //  00F0  GETMBR	R17	R17	K26
+      0x8848070D,  //  00F1  GETMBR	R18	R3	K13
+      0x884C0325,  //  00F2  GETMBR	R19	R1	K37
+      0x7C3C0800,  //  00F3  CALL	R15	4
+      0x5840001D,  //  00F4  LDCONST	R16	K29
+      0x7C340600,  //  00F5  CALL	R13	3
+      0x70020009,  //  00F6  JMP		#0101
+      0xB8363000,  //  00F7  GETNGBL	R13	K24
+      0x8C341B14,  //  00F8  GETMET	R13	R13	K20
+      0x603C0018,  //  00F9  GETGBL	R15	G24
+      0x58400029,  //  00FA  LDCONST	R16	K41
+      0x88440312,  //  00FB  GETMBR	R17	R1	K18
+      0x8844231A,  //  00FC  GETMBR	R17	R17	K26
+      0x88480325,  //  00FD  GETMBR	R18	R1	K37
+      0x7C3C0600,  //  00FE  CALL	R15	3
+      0x5840001D,  //  00FF  LDCONST	R16	K29
+      0x7C340600,  //  0100  CALL	R13	3
+      0x7001FF17,  //  0101  JMP		#001A
+      0x5818002A,  //  0102  LDCONST	R6	K42
+      0xAC180200,  //  0103  CATCH	R6	1	0
+      0xB0080000,  //  0104  RAISE	2	R0	R0
+      0x6018000C,  //  0105  GETGBL	R6	G12
+      0x881C0B08,  //  0106  GETMBR	R7	R5	K8
+      0x7C180200,  //  0107  CALL	R6	1
+      0x24180D1B,  //  0108  GT	R6	R6	K27
+      0x781A0004,  //  0109  JMPF	R6	#010F
+      0x8C18012B,  //  010A  GETMET	R6	R0	K43
+      0x5C200200,  //  010B  MOVE	R8	R1
+      0x5C240A00,  //  010C  MOVE	R9	R5
+      0x7C180600,  //  010D  CALL	R6	3
+      0x70020001,  //  010E  JMP		#0111
+      0x50180000,  //  010F  LDBOOL	R6	0	0
+      0x80040C00,  //  0110  RET	1	R6
+      0x50180200,  //  0111  LDBOOL	R6	1	0
+      0x80040C00,  //  0112  RET	1	R6
+      0x80000000,  //  0113  RET	0
     })
   )
 );
@@ -417,7 +419,7 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
+    ( &(const bvalue[30]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(SubscribeRequestMessage),
     /* K2   */  be_nested_str_weak(from_TLV),
@@ -427,30 +429,31 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
     /* K6   */  be_nested_str_weak(session),
     /* K7   */  be_nested_str_weak(new_subscription),
     /* K8   */  be_nested_str_weak(Path),
-    /* K9   */  be_nested_str_weak(attributes_requests),
-    /* K10  */  be_nested_str_weak(endpoint),
-    /* K11  */  be_nested_str_weak(cluster),
-    /* K12  */  be_nested_str_weak(attribute),
-    /* K13  */  be_nested_str_weak(push),
-    /* K14  */  be_nested_str_weak(stop_iteration),
-    /* K15  */  be_nested_str_weak(tasmota),
-    /* K16  */  be_nested_str_weak(log),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X2C_X20keep_X3D_X25i_X29_X20sub_X3D_X25i),
-    /* K18  */  be_nested_str_weak(local_session_id),
-    /* K19  */  be_nested_str_weak(concat),
-    /* K20  */  be_nested_str_weak(_X20),
-    /* K21  */  be_nested_str_weak(min_interval),
-    /* K22  */  be_nested_str_weak(max_interval),
-    /* K23  */  be_const_int(1),
-    /* K24  */  be_const_int(0),
-    /* K25  */  be_nested_str_weak(subscription_id),
-    /* K26  */  be_const_int(3),
-    /* K27  */  be_nested_str_weak(_inner_process_read_request),
-    /* K28  */  be_nested_str_weak(send_subscribe_response),
+    /* K9   */  be_nested_str_weak(msg),
+    /* K10  */  be_nested_str_weak(attributes_requests),
+    /* K11  */  be_nested_str_weak(endpoint),
+    /* K12  */  be_nested_str_weak(cluster),
+    /* K13  */  be_nested_str_weak(attribute),
+    /* K14  */  be_nested_str_weak(push),
+    /* K15  */  be_nested_str_weak(stop_iteration),
+    /* K16  */  be_nested_str_weak(tasmota),
+    /* K17  */  be_nested_str_weak(log),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X2C_X20keep_X3D_X25i_X29_X20sub_X3D_X25i),
+    /* K19  */  be_nested_str_weak(local_session_id),
+    /* K20  */  be_nested_str_weak(concat),
+    /* K21  */  be_nested_str_weak(_X20),
+    /* K22  */  be_nested_str_weak(min_interval),
+    /* K23  */  be_nested_str_weak(max_interval),
+    /* K24  */  be_const_int(1),
+    /* K25  */  be_const_int(0),
+    /* K26  */  be_nested_str_weak(subscription_id),
+    /* K27  */  be_const_int(3),
+    /* K28  */  be_nested_str_weak(_inner_process_read_request),
+    /* K29  */  be_nested_str_weak(send_subscribe_response),
     }),
     be_str_weak(subscribe_request),
     &be_const_str_solidified,
-    ( &(const binstruction[77]) {  /* code */
+    ( &(const binstruction[78]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x8C0C0701,  //  0001  GETMET	R3	R3	K1
       0x7C0C0200,  //  0002  CALL	R3	1
@@ -473,61 +476,62 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
       0xB81A0000,  //  0013  GETNGBL	R6	K0
       0x8C180D08,  //  0014  GETMET	R6	R6	K8
       0x7C180200,  //  0015  CALL	R6	1
-      0x601C0010,  //  0016  GETGBL	R7	G16
-      0x88200709,  //  0017  GETMBR	R8	R3	K9
-      0x7C1C0200,  //  0018  CALL	R7	1
-      0xA802000D,  //  0019  EXBLK	0	#0028
-      0x5C200E00,  //  001A  MOVE	R8	R7
-      0x7C200000,  //  001B  CALL	R8	0
-      0x8824110A,  //  001C  GETMBR	R9	R8	K10
-      0x901A1409,  //  001D  SETMBR	R6	K10	R9
-      0x8824110B,  //  001E  GETMBR	R9	R8	K11
-      0x901A1609,  //  001F  SETMBR	R6	K11	R9
-      0x8824110C,  //  0020  GETMBR	R9	R8	K12
-      0x901A1809,  //  0021  SETMBR	R6	K12	R9
-      0x8C240B0D,  //  0022  GETMET	R9	R5	K13
-      0x602C0008,  //  0023  GETGBL	R11	G8
-      0x5C300C00,  //  0024  MOVE	R12	R6
-      0x7C2C0200,  //  0025  CALL	R11	1
-      0x7C240400,  //  0026  CALL	R9	2
-      0x7001FFF1,  //  0027  JMP		#001A
-      0x581C000E,  //  0028  LDCONST	R7	K14
-      0xAC1C0200,  //  0029  CATCH	R7	1	0
-      0xB0080000,  //  002A  RAISE	2	R0	R0
-      0xB81E1E00,  //  002B  GETNGBL	R7	K15
-      0x8C1C0F10,  //  002C  GETMET	R7	R7	K16
-      0x60240018,  //  002D  GETGBL	R9	G24
-      0x58280011,  //  002E  LDCONST	R10	K17
-      0x882C0306,  //  002F  GETMBR	R11	R1	K6
-      0x882C1712,  //  0030  GETMBR	R11	R11	K18
-      0x8C300B13,  //  0031  GETMET	R12	R5	K19
-      0x58380014,  //  0032  LDCONST	R14	K20
-      0x7C300400,  //  0033  CALL	R12	2
-      0x88340915,  //  0034  GETMBR	R13	R4	K21
-      0x88380916,  //  0035  GETMBR	R14	R4	K22
-      0x883C0703,  //  0036  GETMBR	R15	R3	K3
-      0x783E0001,  //  0037  JMPF	R15	#003A
-      0x583C0017,  //  0038  LDCONST	R15	K23
-      0x70020000,  //  0039  JMP		#003B
-      0x583C0018,  //  003A  LDCONST	R15	K24
-      0x88400919,  //  003B  GETMBR	R16	R4	K25
-      0x7C240E00,  //  003C  CALL	R9	7
-      0x5828001A,  //  003D  LDCONST	R10	K26
-      0x7C1C0600,  //  003E  CALL	R7	3
-      0x8C1C011B,  //  003F  GETMET	R7	R0	K27
-      0x88240306,  //  0040  GETMBR	R9	R1	K6
-      0x5C280600,  //  0041  MOVE	R10	R3
-      0x502C0200,  //  0042  LDBOOL	R11	1	0
-      0x7C1C0800,  //  0043  CALL	R7	4
-      0x88200919,  //  0044  GETMBR	R8	R4	K25
-      0x901E3208,  //  0045  SETMBR	R7	K25	R8
-      0x8C20011C,  //  0046  GETMET	R8	R0	K28
-      0x5C280200,  //  0047  MOVE	R10	R1
-      0x5C2C0E00,  //  0048  MOVE	R11	R7
-      0x5C300800,  //  0049  MOVE	R12	R4
-      0x7C200800,  //  004A  CALL	R8	4
-      0x50200200,  //  004B  LDBOOL	R8	1	0
-      0x80041000,  //  004C  RET	1	R8
+      0x901A1201,  //  0016  SETMBR	R6	K9	R1
+      0x601C0010,  //  0017  GETGBL	R7	G16
+      0x8820070A,  //  0018  GETMBR	R8	R3	K10
+      0x7C1C0200,  //  0019  CALL	R7	1
+      0xA802000D,  //  001A  EXBLK	0	#0029
+      0x5C200E00,  //  001B  MOVE	R8	R7
+      0x7C200000,  //  001C  CALL	R8	0
+      0x8824110B,  //  001D  GETMBR	R9	R8	K11
+      0x901A1609,  //  001E  SETMBR	R6	K11	R9
+      0x8824110C,  //  001F  GETMBR	R9	R8	K12
+      0x901A1809,  //  0020  SETMBR	R6	K12	R9
+      0x8824110D,  //  0021  GETMBR	R9	R8	K13
+      0x901A1A09,  //  0022  SETMBR	R6	K13	R9
+      0x8C240B0E,  //  0023  GETMET	R9	R5	K14
+      0x602C0008,  //  0024  GETGBL	R11	G8
+      0x5C300C00,  //  0025  MOVE	R12	R6
+      0x7C2C0200,  //  0026  CALL	R11	1
+      0x7C240400,  //  0027  CALL	R9	2
+      0x7001FFF1,  //  0028  JMP		#001B
+      0x581C000F,  //  0029  LDCONST	R7	K15
+      0xAC1C0200,  //  002A  CATCH	R7	1	0
+      0xB0080000,  //  002B  RAISE	2	R0	R0
+      0xB81E2000,  //  002C  GETNGBL	R7	K16
+      0x8C1C0F11,  //  002D  GETMET	R7	R7	K17
+      0x60240018,  //  002E  GETGBL	R9	G24
+      0x58280012,  //  002F  LDCONST	R10	K18
+      0x882C0306,  //  0030  GETMBR	R11	R1	K6
+      0x882C1713,  //  0031  GETMBR	R11	R11	K19
+      0x8C300B14,  //  0032  GETMET	R12	R5	K20
+      0x58380015,  //  0033  LDCONST	R14	K21
+      0x7C300400,  //  0034  CALL	R12	2
+      0x88340916,  //  0035  GETMBR	R13	R4	K22
+      0x88380917,  //  0036  GETMBR	R14	R4	K23
+      0x883C0703,  //  0037  GETMBR	R15	R3	K3
+      0x783E0001,  //  0038  JMPF	R15	#003B
+      0x583C0018,  //  0039  LDCONST	R15	K24
+      0x70020000,  //  003A  JMP		#003C
+      0x583C0019,  //  003B  LDCONST	R15	K25
+      0x8840091A,  //  003C  GETMBR	R16	R4	K26
+      0x7C240E00,  //  003D  CALL	R9	7
+      0x5828001B,  //  003E  LDCONST	R10	K27
+      0x7C1C0600,  //  003F  CALL	R7	3
+      0x8C1C011C,  //  0040  GETMET	R7	R0	K28
+      0x88240306,  //  0041  GETMBR	R9	R1	K6
+      0x5C280600,  //  0042  MOVE	R10	R3
+      0x502C0200,  //  0043  LDBOOL	R11	1	0
+      0x7C1C0800,  //  0044  CALL	R7	4
+      0x8820091A,  //  0045  GETMBR	R8	R4	K26
+      0x901E3408,  //  0046  SETMBR	R7	K26	R8
+      0x8C20011D,  //  0047  GETMET	R8	R0	K29
+      0x5C280200,  //  0048  MOVE	R10	R1
+      0x5C2C0E00,  //  0049  MOVE	R11	R7
+      0x5C300800,  //  004A  MOVE	R12	R4
+      0x7C200800,  //  004B  CALL	R8	4
+      0x50200200,  //  004C  LDBOOL	R8	1	0
+      0x80041000,  //  004D  RET	1	R8
     })
   )
 );
@@ -1001,14 +1005,18 @@ be_local_closure(Matter_IM_send_ack_now,   /* name */
     }),
     be_str_weak(send_ack_now),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88080300,  //  0000  GETMBR	R2	R1	K0
-      0x88080501,  //  0001  GETMBR	R2	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x5C100200,  //  0003  MOVE	R4	R1
-      0x50140000,  //  0004  LDBOOL	R5	0	0
-      0x7C080600,  //  0005  CALL	R2	3
-      0x80000000,  //  0006  RET	0
+    ( &(const binstruction[11]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x80000400,  //  0003  RET	0
+      0x88080300,  //  0004  GETMBR	R2	R1	K0
+      0x88080501,  //  0005  GETMBR	R2	R2	K1
+      0x8C080502,  //  0006  GETMET	R2	R2	K2
+      0x5C100200,  //  0007  MOVE	R4	R1
+      0x50140000,  //  0008  LDBOOL	R5	0	0
+      0x7C080600,  //  0009  CALL	R2	3
+      0x80000000,  //  000A  RET	0
     })
   )
 );
@@ -1230,7 +1238,7 @@ be_local_closure(Matter_IM_process_incoming,   /* name */
     }),
     be_str_weak(process_incoming),
     &be_const_str_solidified,
-    ( &(const binstruction[110]) {  /* code */
+    ( &(const binstruction[107]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
       0x88080501,  //  0001  GETMBR	R2	R2	K1
       0x8C080502,  //  0002  GETMET	R2	R2	K2
@@ -1248,7 +1256,7 @@ be_local_closure(Matter_IM_process_incoming,   /* name */
       0x5C200400,  //  000E  MOVE	R8	R2
       0x7C140600,  //  000F  CALL	R5	3
       0x80040A00,  //  0010  RET	1	R5
-      0x70020059,  //  0011  JMP		#006C
+      0x70020056,  //  0011  JMP		#0069
       0x1C140909,  //  0012  EQ	R5	R4	K9
       0x78160008,  //  0013  JMPF	R5	#001D
       0x8C14010A,  //  0014  GETMET	R5	R0	K10
@@ -1259,7 +1267,7 @@ be_local_closure(Matter_IM_process_incoming,   /* name */
       0x5C200400,  //  0019  MOVE	R8	R2
       0x7C140600,  //  001A  CALL	R5	3
       0x80040A00,  //  001B  RET	1	R5
-      0x7002004E,  //  001C  JMP		#006C
+      0x7002004B,  //  001C  JMP		#0069
       0x1C14090C,  //  001D  EQ	R5	R4	K12
       0x78160008,  //  001E  JMPF	R5	#0028
       0x8C14010A,  //  001F  GETMET	R5	R0	K10
@@ -1270,7 +1278,7 @@ be_local_closure(Matter_IM_process_incoming,   /* name */
       0x5C200400,  //  0024  MOVE	R8	R2
       0x7C140600,  //  0025  CALL	R5	3
       0x80040A00,  //  0026  RET	1	R5
-      0x70020043,  //  0027  JMP		#006C
+      0x70020040,  //  0027  JMP		#0069
       0x54160003,  //  0028  LDINT	R5	4
       0x1C140805,  //  0029  EQ	R5	R4	R5
       0x78160005,  //  002A  JMPF	R5	#0031
@@ -1279,7 +1287,7 @@ be_local_closure(Matter_IM_process_incoming,   /* name */
       0x5C200400,  //  002D  MOVE	R8	R2
       0x7C140600,  //  002E  CALL	R5	3
       0x80040A00,  //  002F  RET	1	R5
-      0x7002003A,  //  0030  JMP		#006C
+      0x70020037,  //  0030  JMP		#0069
       0x54160004,  //  0031  LDINT	R5	5
       0x1C140805,  //  0032  EQ	R5	R4	R5
       0x78160005,  //  0033  JMPF	R5	#003A
@@ -1288,7 +1296,7 @@ be_local_closure(Matter_IM_process_incoming,   /* name */
       0x5C200400,  //  0036  MOVE	R8	R2
       0x7C140600,  //  0037  CALL	R5	3
       0x80040A00,  //  0038  RET	1	R5
-      0x70020031,  //  0039  JMP		#006C
+      0x7002002E,  //  0039  JMP		#0069
       0x54160005,  //  003A  LDINT	R5	6
       0x1C140805,  //  003B  EQ	R5	R4	R5
       0x78160008,  //  003C  JMPF	R5	#0046
@@ -1300,7 +1308,7 @@ be_local_closure(Matter_IM_process_incoming,   /* name */
       0x5C200400,  //  0042  MOVE	R8	R2
       0x7C140600,  //  0043  CALL	R5	3
       0x80040A00,  //  0044  RET	1	R5
-      0x70020025,  //  0045  JMP		#006C
+      0x70020022,  //  0045  JMP		#0069
       0x54160006,  //  0046  LDINT	R5	7
       0x1C140805,  //  0047  EQ	R5	R4	R5
       0x78160005,  //  0048  JMPF	R5	#004F
@@ -1309,38 +1317,35 @@ be_local_closure(Matter_IM_process_incoming,   /* name */
       0x5C200400,  //  004B  MOVE	R8	R2
       0x7C140600,  //  004C  CALL	R5	3
       0x80040A00,  //  004D  RET	1	R5
-      0x7002001C,  //  004E  JMP		#006C
+      0x70020019,  //  004E  JMP		#0069
       0x54160007,  //  004F  LDINT	R5	8
       0x1C140805,  //  0050  EQ	R5	R4	R5
-      0x78160008,  //  0051  JMPF	R5	#005B
-      0x8C14010A,  //  0052  GETMET	R5	R0	K10
+      0x78160005,  //  0051  JMPF	R5	#0058
+      0x8C140112,  //  0052  GETMET	R5	R0	K18
       0x5C1C0200,  //  0053  MOVE	R7	R1
-      0x7C140400,  //  0054  CALL	R5	2
-      0x8C140112,  //  0055  GETMET	R5	R0	K18
-      0x5C1C0200,  //  0056  MOVE	R7	R1
-      0x5C200400,  //  0057  MOVE	R8	R2
-      0x7C140600,  //  0058  CALL	R5	3
-      0x80040A00,  //  0059  RET	1	R5
-      0x70020010,  //  005A  JMP		#006C
-      0x54160008,  //  005B  LDINT	R5	9
-      0x1C140805,  //  005C  EQ	R5	R4	R5
-      0x78160005,  //  005D  JMPF	R5	#0064
-      0x8C140113,  //  005E  GETMET	R5	R0	K19
-      0x5C1C0200,  //  005F  MOVE	R7	R1
-      0x5C200400,  //  0060  MOVE	R8	R2
-      0x7C140600,  //  0061  CALL	R5	3
-      0x80040A00,  //  0062  RET	1	R5
-      0x70020007,  //  0063  JMP		#006C
-      0x54160009,  //  0064  LDINT	R5	10
-      0x1C140805,  //  0065  EQ	R5	R4	R5
-      0x78160004,  //  0066  JMPF	R5	#006C
-      0x8C140114,  //  0067  GETMET	R5	R0	K20
-      0x5C1C0200,  //  0068  MOVE	R7	R1
-      0x5C200400,  //  0069  MOVE	R8	R2
-      0x7C140600,  //  006A  CALL	R5	3
-      0x80040A00,  //  006B  RET	1	R5
-      0x50140000,  //  006C  LDBOOL	R5	0	0
-      0x80040A00,  //  006D  RET	1	R5
+      0x5C200400,  //  0054  MOVE	R8	R2
+      0x7C140600,  //  0055  CALL	R5	3
+      0x80040A00,  //  0056  RET	1	R5
+      0x70020010,  //  0057  JMP		#0069
+      0x54160008,  //  0058  LDINT	R5	9
+      0x1C140805,  //  0059  EQ	R5	R4	R5
+      0x78160005,  //  005A  JMPF	R5	#0061
+      0x8C140113,  //  005B  GETMET	R5	R0	K19
+      0x5C1C0200,  //  005C  MOVE	R7	R1
+      0x5C200400,  //  005D  MOVE	R8	R2
+      0x7C140600,  //  005E  CALL	R5	3
+      0x80040A00,  //  005F  RET	1	R5
+      0x70020007,  //  0060  JMP		#0069
+      0x54160009,  //  0061  LDINT	R5	10
+      0x1C140805,  //  0062  EQ	R5	R4	R5
+      0x78160004,  //  0063  JMPF	R5	#0069
+      0x8C140114,  //  0064  GETMET	R5	R0	K20
+      0x5C1C0200,  //  0065  MOVE	R7	R1
+      0x5C200400,  //  0066  MOVE	R8	R2
+      0x7C140600,  //  0067  CALL	R5	3
+      0x80040A00,  //  0068  RET	1	R5
+      0x50140000,  //  0069  LDBOOL	R5	0	0
+      0x80040A00,  //  006A  RET	1	R5
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
@@ -481,7 +481,7 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
       0x88300F2E,  //  00C2  GETMBR	R12	R7	K46
       0x7C2C0200,  //  00C3  CALL	R11	1
       0x0028140B,  //  00C4  ADD	R10	R10	R11
-      0x542E0003,  //  00C5  LDINT	R11	4
+      0x582C0020,  //  00C5  LDCONST	R11	K32
       0x7C200600,  //  00C6  CALL	R8	3
       0x8C20012F,  //  00C7  GETMET	R8	R0	K47
       0x5C280A00,  //  00C8  MOVE	R10	R5

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path.h
@@ -7,6 +7,46 @@
 extern const bclass be_class_Matter_Path;
 
 /********************************************************************
+** Solidified function: clear
+********************************************************************/
+be_local_closure(Matter_Path_clear,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(endpoint),
+    /* K1   */  be_nested_str_weak(cluster),
+    /* K2   */  be_nested_str_weak(attribute),
+    /* K3   */  be_nested_str_weak(command),
+    /* K4   */  be_nested_str_weak(status),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(msh),
+    }),
+    be_str_weak(clear),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x4C040000,  //  0000  LDNIL	R1
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x90020201,  //  0002  SETMBR	R0	K1	R1
+      0x90020401,  //  0003  SETMBR	R0	K2	R1
+      0x90020601,  //  0004  SETMBR	R0	K3	R1
+      0x90020801,  //  0005  SETMBR	R0	K4	R1
+      0x90020A01,  //  0006  SETMBR	R0	K5	R1
+      0x90020C01,  //  0007  SETMBR	R0	K6	R1
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: tostring
 ********************************************************************/
 be_local_closure(Matter_Path_tostring,   /* name */
@@ -121,17 +161,19 @@ be_local_closure(Matter_Path_tostring,   /* name */
 ** Solidified class: Matter_Path
 ********************************************************************/
 be_local_class(Matter_Path,
-    6,
+    7,
     NULL,
-    be_nested_map(7,
+    be_nested_map(9,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(log, 4), be_const_var(5) },
-        { be_const_key_weak(command, 2), be_const_var(3) },
-        { be_const_key_weak(status, -1), be_const_var(4) },
+        { be_const_key_weak(log, -1), be_const_var(5) },
+        { be_const_key_weak(cluster, -1), be_const_var(1) },
+        { be_const_key_weak(command, -1), be_const_var(3) },
         { be_const_key_weak(tostring, -1), be_const_closure(Matter_Path_tostring_closure) },
-        { be_const_key_weak(cluster, 5), be_const_var(1) },
-        { be_const_key_weak(endpoint, -1), be_const_var(0) },
-        { be_const_key_weak(attribute, -1), be_const_var(2) },
+        { be_const_key_weak(status, 1), be_const_var(4) },
+        { be_const_key_weak(attribute, 6), be_const_var(2) },
+        { be_const_key_weak(clear, -1), be_const_closure(Matter_Path_clear_closure) },
+        { be_const_key_weak(endpoint, 3), be_const_var(0) },
+        { be_const_key_weak(msg, -1), be_const_var(6) },
     })),
     be_str_weak(Matter_Path)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
@@ -7,61 +7,23 @@
 extern const bclass be_class_Matter_Plugin;
 
 /********************************************************************
-** Solidified function: every_250ms
+** Solidified function: parse_sensors
 ********************************************************************/
-be_local_closure(Matter_Plugin_every_250ms,   /* name */
+be_local_closure(Matter_Plugin_parse_sensors,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
+    2,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(update_next),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(jitter),
-    /* K3   */  be_nested_str_weak(UPDATE_TIME),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(time_reached),
-    /* K6   */  be_nested_str_weak(tick),
-    /* K7   */  be_nested_str_weak(device),
-    /* K8   */  be_nested_str_weak(update_shadow),
-    /* K9   */  be_nested_str_weak(millis),
-    }),
-    be_str_weak(every_250ms),
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(parse_sensors),
     &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x78060005,  //  0003  JMPF	R1	#000A
-      0xB8060200,  //  0004  GETNGBL	R1	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0103,  //  0006  GETMBR	R3	R0	K3
-      0x7C040400,  //  0007  CALL	R1	2
-      0x90020001,  //  0008  SETMBR	R0	K0	R1
-      0x70020010,  //  0009  JMP		#001B
-      0xB8060800,  //  000A  GETNGBL	R1	K4
-      0x8C040305,  //  000B  GETMET	R1	R1	K5
-      0x880C0100,  //  000C  GETMBR	R3	R0	K0
-      0x7C040400,  //  000D  CALL	R1	2
-      0x7806000B,  //  000E  JMPF	R1	#001B
-      0x88040106,  //  000F  GETMBR	R1	R0	K6
-      0x88080107,  //  0010  GETMBR	R2	R0	K7
-      0x88080506,  //  0011  GETMBR	R2	R2	K6
-      0x20040202,  //  0012  NE	R1	R1	R2
-      0x78060001,  //  0013  JMPF	R1	#0016
-      0x8C040108,  //  0014  GETMET	R1	R0	K8
-      0x7C040200,  //  0015  CALL	R1	1
-      0xB8060800,  //  0016  GETNGBL	R1	K4
-      0x8C040309,  //  0017  GETMET	R1	R1	K9
-      0x880C0103,  //  0018  GETMBR	R3	R0	K3
-      0x7C040400,  //  0019  CALL	R1	2
-      0x90020001,  //  001A  SETMBR	R0	K0	R1
-      0x80000000,  //  001B  RET	0
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
     })
   )
 );
@@ -115,58 +77,6 @@ be_local_closure(Matter_Plugin_get_cluster_list,   /* name */
 
 
 /********************************************************************
-** Solidified function: <lambda>
-********************************************************************/
-be_local_closure(Matter_Plugin__X3Clambda_X3E,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(_X3Clambda_X3E),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x60040008,  //  0000  GETGBL	R1	G8
-      0x5C080000,  //  0001  MOVE	R2	R0
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_local_device
-********************************************************************/
-be_local_closure(Matter_Plugin_is_local_device,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(is_local_device),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x50040200,  //  0000  LDBOOL	R1	1	0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: write_attribute
 ********************************************************************/
 be_local_closure(Matter_Plugin_write_attribute,   /* name */
@@ -185,389 +95,6 @@ be_local_closure(Matter_Plugin_write_attribute,   /* name */
     ( &(const binstruction[ 2]) {  /* code */
       0x4C100000,  //  0000  LDNIL	R4
       0x80040800,  //  0001  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(Matter_Plugin_invoke_request,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x80040800,  //  0001  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: consolidate_clusters
-********************************************************************/
-be_local_closure(Matter_Plugin_consolidate_clusters,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        3,                          /* nstack */
-        1,                          /* argc */
-        0,                          /* varg */
-        0,                          /* has upvals */
-        NULL,                       /* no upvals */
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        0,                          /* has constants */
-        NULL,                       /* no const */
-        be_str_weak(real_super),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x60040003,  //  0000  GETGBL	R1	G3
-          0x5C080000,  //  0001  MOVE	R2	R0
-          0x7C040200,  //  0002  CALL	R1	1
-          0x80040200,  //  0003  RET	1	R1
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(CLUSTERS),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(contains),
-    /* K3   */  be_nested_str_weak(find),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(consolidate_clusters),
-    &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
-      0x84040000,  //  0000  CLOSURE	R1	P0
-      0x60080013,  //  0001  GETGBL	R2	G19
-      0x7C080000,  //  0002  CALL	R2	0
-      0x5C0C0000,  //  0003  MOVE	R3	R0
-      0x4C100000,  //  0004  LDNIL	R4
-      0x20100604,  //  0005  NE	R4	R3	R4
-      0x7812002C,  //  0006  JMPF	R4	#0034
-      0x88100700,  //  0007  GETMBR	R4	R3	K0
-      0x60140010,  //  0008  GETGBL	R5	G16
-      0x8C180901,  //  0009  GETMET	R6	R4	K1
-      0x7C180200,  //  000A  CALL	R6	1
-      0x7C140200,  //  000B  CALL	R5	1
-      0xA802001E,  //  000C  EXBLK	0	#002C
-      0x5C180A00,  //  000D  MOVE	R6	R5
-      0x7C180000,  //  000E  CALL	R6	0
-      0x8C1C0502,  //  000F  GETMET	R7	R2	K2
-      0x5C240C00,  //  0010  MOVE	R9	R6
-      0x7C1C0400,  //  0011  CALL	R7	2
-      0x741E0002,  //  0012  JMPT	R7	#0016
-      0x601C0012,  //  0013  GETGBL	R7	G18
-      0x7C1C0000,  //  0014  CALL	R7	0
-      0x98080C07,  //  0015  SETIDX	R2	R6	R7
-      0x601C0010,  //  0016  GETGBL	R7	G16
-      0x94200806,  //  0017  GETIDX	R8	R4	R6
-      0x7C1C0200,  //  0018  CALL	R7	1
-      0xA802000D,  //  0019  EXBLK	0	#0028
-      0x5C200E00,  //  001A  MOVE	R8	R7
-      0x7C200000,  //  001B  CALL	R8	0
-      0x94240406,  //  001C  GETIDX	R9	R2	R6
-      0x8C241303,  //  001D  GETMET	R9	R9	K3
-      0x5C2C1000,  //  001E  MOVE	R11	R8
-      0x7C240400,  //  001F  CALL	R9	2
-      0x4C280000,  //  0020  LDNIL	R10
-      0x1C24120A,  //  0021  EQ	R9	R9	R10
-      0x78260003,  //  0022  JMPF	R9	#0027
-      0x94240406,  //  0023  GETIDX	R9	R2	R6
-      0x8C241304,  //  0024  GETMET	R9	R9	K4
-      0x5C2C1000,  //  0025  MOVE	R11	R8
-      0x7C240400,  //  0026  CALL	R9	2
-      0x7001FFF1,  //  0027  JMP		#001A
-      0x581C0005,  //  0028  LDCONST	R7	K5
-      0xAC1C0200,  //  0029  CATCH	R7	1	0
-      0xB0080000,  //  002A  RAISE	2	R0	R0
-      0x7001FFE0,  //  002B  JMP		#000D
-      0x58140005,  //  002C  LDCONST	R5	K5
-      0xAC140200,  //  002D  CATCH	R5	1	0
-      0xB0080000,  //  002E  RAISE	2	R0	R0
-      0x5C140200,  //  002F  MOVE	R5	R1
-      0x5C180600,  //  0030  MOVE	R6	R3
-      0x7C140200,  //  0031  CALL	R5	1
-      0x5C0C0A00,  //  0032  MOVE	R3	R5
-      0x7001FFCF,  //  0033  JMP		#0004
-      0x80040400,  //  0034  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: attribute_updated
-********************************************************************/
-be_local_closure(Matter_Plugin_attribute_updated,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(attribute_updated),
-    /* K2   */  be_nested_str_weak(endpoint),
-    }),
-    be_str_weak(attribute_updated),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
-      0x8C100901,  //  0001  GETMET	R4	R4	K1
-      0x88180102,  //  0002  GETMBR	R6	R0	K2
-      0x5C1C0200,  //  0003  MOVE	R7	R1
-      0x5C200400,  //  0004  MOVE	R8	R2
-      0x5C240600,  //  0005  MOVE	R9	R3
-      0x7C100A00,  //  0006  CALL	R4	5
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_sensors
-********************************************************************/
-be_local_closure(Matter_Plugin_parse_sensors,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(parse_sensors),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: has
-********************************************************************/
-be_local_closure(Matter_Plugin_has,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(clusters),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(endpoints),
-    /* K3   */  be_nested_str_weak(find),
-    }),
-    be_str_weak(has),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x780E0006,  //  0004  JMPF	R3	#000C
-      0x880C0102,  //  0005  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
-      0x5C140400,  //  0007  MOVE	R5	R2
-      0x7C0C0400,  //  0008  CALL	R3	2
-      0x4C100000,  //  0009  LDNIL	R4
-      0x200C0604,  //  000A  NE	R3	R3	R4
-      0x740E0000,  //  000B  JMPT	R3	#000D
-      0x500C0001,  //  000C  LDBOOL	R3	0	1
-      0x500C0200,  //  000D  LDBOOL	R3	1	0
-      0x80040600,  //  000E  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_shadow_lazy
-********************************************************************/
-be_local_closure(Matter_Plugin_update_shadow_lazy,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tick),
-    /* K1   */  be_nested_str_weak(device),
-    /* K2   */  be_nested_str_weak(update_shadow),
-    }),
-    be_str_weak(update_shadow_lazy),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x88080500,  //  0002  GETMBR	R2	R2	K0
-      0x20040202,  //  0003  NE	R1	R1	R2
-      0x78060004,  //  0004  JMPF	R1	#000A
-      0x8C040102,  //  0005  GETMET	R1	R0	K2
-      0x7C040200,  //  0006  CALL	R1	1
-      0x88040101,  //  0007  GETMBR	R1	R0	K1
-      0x88040300,  //  0008  GETMBR	R1	R1	K0
-      0x90020001,  //  0009  SETMBR	R0	K0	R1
-      0x80000000,  //  000A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_endpoint
-********************************************************************/
-be_local_closure(Matter_Plugin_get_endpoint,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(endpoint),
-    }),
-    be_str_weak(get_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Plugin_init,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(clusters),
-    /* K3   */  be_nested_str_weak(consolidate_clusters),
-    /* K4   */  be_nested_str_weak(parse_configuration),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x8C100103,  //  0002  GETMET	R4	R0	K3
-      0x7C100200,  //  0003  CALL	R4	1
-      0x90020404,  //  0004  SETMBR	R0	K2	R4
-      0x8C100104,  //  0005  GETMET	R4	R0	K4
-      0x5C180600,  //  0006  MOVE	R6	R3
-      0x7C100400,  //  0007  CALL	R4	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: read_event
-********************************************************************/
-be_local_closure(Matter_Plugin_read_event,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(read_event),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: subscribe_attribute
-********************************************************************/
-be_local_closure(Matter_Plugin_subscribe_attribute,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(subscribe_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
     })
   )
 );
@@ -599,112 +126,39 @@ be_local_closure(Matter_Plugin_parse_configuration,   /* name */
 
 
 /********************************************************************
-** Solidified function: subscribe_event
+** Solidified function: ui_conf_to_string
 ********************************************************************/
-be_local_closure(Matter_Plugin_subscribe_event,   /* name */
+be_local_closure(Matter_Plugin_ui_conf_to_string,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(subscribe_event),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_attribute_list
-********************************************************************/
-be_local_closure(Matter_Plugin_get_attribute_list,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
+    9,                          /* nstack */
+    2,                          /* argc */
+    4,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(clusters),
-    /* K1   */  be_nested_str_weak(find),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Plugin),
+    /* K1   */  be_nested_str_weak(ARG),
+    /* K2   */  be_nested_str_weak(find),
+    /* K3   */  be_nested_str_weak(),
     }),
-    be_str_weak(get_attribute_list),
+    be_str_weak(ui_conf_to_string),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x5C140400,  //  0002  MOVE	R5	R2
-      0x60180012,  //  0003  GETGBL	R6	G18
-      0x7C180000,  //  0004  CALL	R6	0
-      0x7C0C0600,  //  0005  CALL	R3	3
-      0x80040600,  //  0006  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: timed_request
-********************************************************************/
-be_local_closure(Matter_Plugin_timed_request,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(timed_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x80040800,  //  0001  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_shadow
-********************************************************************/
-be_local_closure(Matter_Plugin_update_shadow,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tick),
-    /* K1   */  be_nested_str_weak(device),
-    }),
-    be_str_weak(update_shadow),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x88040300,  //  0001  GETMBR	R1	R1	K0
-      0x90020001,  //  0002  SETMBR	R0	K0	R1
-      0x80000000,  //  0003  RET	0
+    ( &(const binstruction[12]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x780E0006,  //  0002  JMPF	R3	#000A
+      0x60100008,  //  0003  GETGBL	R4	G8
+      0x8C140302,  //  0004  GETMET	R5	R1	K2
+      0x5C1C0600,  //  0005  MOVE	R7	R3
+      0x58200003,  //  0006  LDCONST	R8	K3
+      0x7C140600,  //  0007  CALL	R5	3
+      0x7C100200,  //  0008  CALL	R4	1
+      0x70020000,  //  0009  JMP		#000B
+      0x58100003,  //  000A  LDCONST	R4	K3
+      0x80040800,  //  000B  RET	1	R4
     })
   )
 );
@@ -869,6 +323,139 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
 
 
 /********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Plugin_init,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(endpoint),
+    /* K2   */  be_nested_str_weak(clusters),
+    /* K3   */  be_nested_str_weak(consolidate_clusters),
+    /* K4   */  be_nested_str_weak(parse_configuration),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x8C100103,  //  0002  GETMET	R4	R0	K3
+      0x7C100200,  //  0003  CALL	R4	1
+      0x90020404,  //  0004  SETMBR	R0	K2	R4
+      0x8C100104,  //  0005  GETMET	R4	R0	K4
+      0x5C180600,  //  0006  MOVE	R6	R3
+      0x7C100400,  //  0007  CALL	R4	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: <lambda>
+********************************************************************/
+be_local_closure(Matter_Plugin__X3Clambda_X3E,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(_X3Clambda_X3E),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x60040008,  //  0000  GETGBL	R1	G8
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: has
+********************************************************************/
+be_local_closure(Matter_Plugin_has,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(clusters),
+    /* K1   */  be_nested_str_weak(contains),
+    /* K2   */  be_nested_str_weak(endpoints),
+    /* K3   */  be_nested_str_weak(find),
+    }),
+    be_str_weak(has),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x780E0006,  //  0004  JMPF	R3	#000C
+      0x880C0102,  //  0005  GETMBR	R3	R0	K2
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x5C140400,  //  0007  MOVE	R5	R2
+      0x7C0C0400,  //  0008  CALL	R3	2
+      0x4C100000,  //  0009  LDNIL	R4
+      0x200C0604,  //  000A  NE	R3	R3	R4
+      0x740E0000,  //  000B  JMPT	R3	#000D
+      0x500C0001,  //  000C  LDBOOL	R3	0	1
+      0x500C0200,  //  000D  LDBOOL	R3	1	0
+      0x80040600,  //  000E  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: subscribe_event
+********************************************************************/
+be_local_closure(Matter_Plugin_subscribe_event,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(subscribe_event),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x80040A00,  //  0001  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: ui_string_to_conf
 ********************************************************************/
 be_local_closure(Matter_Plugin_ui_string_to_conf,   /* name */
@@ -906,39 +493,487 @@ be_local_closure(Matter_Plugin_ui_string_to_conf,   /* name */
 
 
 /********************************************************************
-** Solidified function: ui_conf_to_string
+** Solidified function: update_shadow
 ********************************************************************/
-be_local_closure(Matter_Plugin_ui_conf_to_string,   /* name */
+be_local_closure(Matter_Plugin_update_shadow,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tick),
+    /* K1   */  be_nested_str_weak(device),
+    }),
+    be_str_weak(update_shadow),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x88040300,  //  0001  GETMBR	R1	R1	K0
+      0x90020001,  //  0002  SETMBR	R0	K0	R1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(Matter_Plugin_every_250ms,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(update_next),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(jitter),
+    /* K3   */  be_nested_str_weak(UPDATE_TIME),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(time_reached),
+    /* K6   */  be_nested_str_weak(tick),
+    /* K7   */  be_nested_str_weak(device),
+    /* K8   */  be_nested_str_weak(update_shadow),
+    /* K9   */  be_nested_str_weak(millis),
+    }),
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060005,  //  0003  JMPF	R1	#000A
+      0xB8060200,  //  0004  GETNGBL	R1	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x880C0103,  //  0006  GETMBR	R3	R0	K3
+      0x7C040400,  //  0007  CALL	R1	2
+      0x90020001,  //  0008  SETMBR	R0	K0	R1
+      0x70020010,  //  0009  JMP		#001B
+      0xB8060800,  //  000A  GETNGBL	R1	K4
+      0x8C040305,  //  000B  GETMET	R1	R1	K5
+      0x880C0100,  //  000C  GETMBR	R3	R0	K0
+      0x7C040400,  //  000D  CALL	R1	2
+      0x7806000B,  //  000E  JMPF	R1	#001B
+      0x88040106,  //  000F  GETMBR	R1	R0	K6
+      0x88080107,  //  0010  GETMBR	R2	R0	K7
+      0x88080506,  //  0011  GETMBR	R2	R2	K6
+      0x20040202,  //  0012  NE	R1	R1	R2
+      0x78060001,  //  0013  JMPF	R1	#0016
+      0x8C040108,  //  0014  GETMET	R1	R0	K8
+      0x7C040200,  //  0015  CALL	R1	1
+      0xB8060800,  //  0016  GETNGBL	R1	K4
+      0x8C040309,  //  0017  GETMET	R1	R1	K9
+      0x880C0103,  //  0018  GETMBR	R3	R0	K3
+      0x7C040400,  //  0019  CALL	R1	2
+      0x90020001,  //  001A  SETMBR	R0	K0	R1
+      0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_endpoint
+********************************************************************/
+be_local_closure(Matter_Plugin_get_endpoint,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(endpoint),
+    }),
+    be_str_weak(get_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: subscribe_attribute
+********************************************************************/
+be_local_closure(Matter_Plugin_subscribe_attribute,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(subscribe_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x80040A00,  //  0001  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: timed_request
+********************************************************************/
+be_local_closure(Matter_Plugin_timed_request,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(timed_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x80040800,  //  0001  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Plugin_invoke_request,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x80040800,  //  0001  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_shadow_lazy
+********************************************************************/
+be_local_closure(Matter_Plugin_update_shadow_lazy,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tick),
+    /* K1   */  be_nested_str_weak(device),
+    /* K2   */  be_nested_str_weak(update_shadow),
+    }),
+    be_str_weak(update_shadow_lazy),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x88080500,  //  0002  GETMBR	R2	R2	K0
+      0x20040202,  //  0003  NE	R1	R1	R2
+      0x78060004,  //  0004  JMPF	R1	#000A
+      0x8C040102,  //  0005  GETMET	R1	R0	K2
+      0x7C040200,  //  0006  CALL	R1	1
+      0x88040101,  //  0007  GETMBR	R1	R0	K1
+      0x88040300,  //  0008  GETMBR	R1	R1	K0
+      0x90020001,  //  0009  SETMBR	R0	K0	R1
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: attribute_updated
+********************************************************************/
+be_local_closure(Matter_Plugin_attribute_updated,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(attribute_updated),
+    /* K2   */  be_nested_str_weak(endpoint),
+    }),
+    be_str_weak(attribute_updated),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x8C100901,  //  0001  GETMET	R4	R4	K1
+      0x88180102,  //  0002  GETMBR	R6	R0	K2
+      0x5C1C0200,  //  0003  MOVE	R7	R1
+      0x5C200400,  //  0004  MOVE	R8	R2
+      0x5C240600,  //  0005  MOVE	R9	R3
+      0x7C100A00,  //  0006  CALL	R4	5
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_event
+********************************************************************/
+be_local_closure(Matter_Plugin_read_event,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(read_event),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x80040A00,  //  0001  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_attribute_list
+********************************************************************/
+be_local_closure(Matter_Plugin_get_attribute_list,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(clusters),
+    /* K1   */  be_nested_str_weak(find),
+    }),
+    be_str_weak(get_attribute_list),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140400,  //  0002  MOVE	R5	R2
+      0x60180012,  //  0003  GETGBL	R6	G18
+      0x7C180000,  //  0004  CALL	R6	0
+      0x7C0C0600,  //  0005  CALL	R3	3
+      0x80040600,  //  0006  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: consolidate_clusters
+********************************************************************/
+be_local_closure(Matter_Plugin_consolidate_clusters,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        3,                          /* nstack */
+        1,                          /* argc */
+        0,                          /* varg */
+        0,                          /* has upvals */
+        NULL,                       /* no upvals */
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        0,                          /* has constants */
+        NULL,                       /* no const */
+        be_str_weak(real_super),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x60040003,  //  0000  GETGBL	R1	G3
+          0x5C080000,  //  0001  MOVE	R2	R0
+          0x7C040200,  //  0002  CALL	R1	1
+          0x80040200,  //  0003  RET	1	R1
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(CLUSTERS),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(contains),
+    /* K3   */  be_nested_str_weak(find),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(consolidate_clusters),
+    &be_const_str_solidified,
+    ( &(const binstruction[53]) {  /* code */
+      0x84040000,  //  0000  CLOSURE	R1	P0
+      0x60080013,  //  0001  GETGBL	R2	G19
+      0x7C080000,  //  0002  CALL	R2	0
+      0x5C0C0000,  //  0003  MOVE	R3	R0
+      0x4C100000,  //  0004  LDNIL	R4
+      0x20100604,  //  0005  NE	R4	R3	R4
+      0x7812002C,  //  0006  JMPF	R4	#0034
+      0x88100700,  //  0007  GETMBR	R4	R3	K0
+      0x60140010,  //  0008  GETGBL	R5	G16
+      0x8C180901,  //  0009  GETMET	R6	R4	K1
+      0x7C180200,  //  000A  CALL	R6	1
+      0x7C140200,  //  000B  CALL	R5	1
+      0xA802001E,  //  000C  EXBLK	0	#002C
+      0x5C180A00,  //  000D  MOVE	R6	R5
+      0x7C180000,  //  000E  CALL	R6	0
+      0x8C1C0502,  //  000F  GETMET	R7	R2	K2
+      0x5C240C00,  //  0010  MOVE	R9	R6
+      0x7C1C0400,  //  0011  CALL	R7	2
+      0x741E0002,  //  0012  JMPT	R7	#0016
+      0x601C0012,  //  0013  GETGBL	R7	G18
+      0x7C1C0000,  //  0014  CALL	R7	0
+      0x98080C07,  //  0015  SETIDX	R2	R6	R7
+      0x601C0010,  //  0016  GETGBL	R7	G16
+      0x94200806,  //  0017  GETIDX	R8	R4	R6
+      0x7C1C0200,  //  0018  CALL	R7	1
+      0xA802000D,  //  0019  EXBLK	0	#0028
+      0x5C200E00,  //  001A  MOVE	R8	R7
+      0x7C200000,  //  001B  CALL	R8	0
+      0x94240406,  //  001C  GETIDX	R9	R2	R6
+      0x8C241303,  //  001D  GETMET	R9	R9	K3
+      0x5C2C1000,  //  001E  MOVE	R11	R8
+      0x7C240400,  //  001F  CALL	R9	2
+      0x4C280000,  //  0020  LDNIL	R10
+      0x1C24120A,  //  0021  EQ	R9	R9	R10
+      0x78260003,  //  0022  JMPF	R9	#0027
+      0x94240406,  //  0023  GETIDX	R9	R2	R6
+      0x8C241304,  //  0024  GETMET	R9	R9	K4
+      0x5C2C1000,  //  0025  MOVE	R11	R8
+      0x7C240400,  //  0026  CALL	R9	2
+      0x7001FFF1,  //  0027  JMP		#001A
+      0x581C0005,  //  0028  LDCONST	R7	K5
+      0xAC1C0200,  //  0029  CATCH	R7	1	0
+      0xB0080000,  //  002A  RAISE	2	R0	R0
+      0x7001FFE0,  //  002B  JMP		#000D
+      0x58140005,  //  002C  LDCONST	R5	K5
+      0xAC140200,  //  002D  CATCH	R5	1	0
+      0xB0080000,  //  002E  RAISE	2	R0	R0
+      0x5C140200,  //  002F  MOVE	R5	R1
+      0x5C180600,  //  0030  MOVE	R6	R3
+      0x7C140200,  //  0031  CALL	R5	1
+      0x5C0C0A00,  //  0032  MOVE	R3	R5
+      0x7001FFCF,  //  0033  JMP		#0004
+      0x80040400,  //  0034  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_local_device
+********************************************************************/
+be_local_closure(Matter_Plugin_is_local_device,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(is_local_device),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x50040200,  //  0000  LDBOOL	R1	1	0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_ack_now
+********************************************************************/
+be_local_closure(Matter_Plugin_send_ack_now,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
     2,                          /* argc */
-    4,                          /* varg */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Plugin),
-    /* K1   */  be_nested_str_weak(ARG),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(),
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(message_handler),
+    /* K2   */  be_nested_str_weak(im),
+    /* K3   */  be_nested_str_weak(send_ack_now),
     }),
-    be_str_weak(ui_conf_to_string),
+    be_str_weak(send_ack_now),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x780E0006,  //  0002  JMPF	R3	#000A
-      0x60100008,  //  0003  GETGBL	R4	G8
-      0x8C140302,  //  0004  GETMET	R5	R1	K2
-      0x5C1C0600,  //  0005  MOVE	R7	R3
-      0x58200003,  //  0006  LDCONST	R8	K3
-      0x7C140600,  //  0007  CALL	R5	3
-      0x7C100200,  //  0008  CALL	R4	1
-      0x70020000,  //  0009  JMP		#000B
-      0x58100003,  //  000A  LDCONST	R4	K3
-      0x80040800,  //  000B  RET	1	R4
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080501,  //  0001  GETMBR	R2	R2	K1
+      0x88080502,  //  0002  GETMBR	R2	R2	K2
+      0x8C080503,  //  0003  GETMET	R2	R2	K3
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -951,35 +986,23 @@ be_local_closure(Matter_Plugin_ui_conf_to_string,   /* name */
 be_local_class(Matter_Plugin,
     5,
     NULL,
-    be_nested_map(34,
+    be_nested_map(35,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(every_250ms, 18), be_const_closure(Matter_Plugin_every_250ms_closure) },
-        { be_const_key_weak(get_cluster_list, 3), be_const_closure(Matter_Plugin_get_cluster_list_closure) },
-        { be_const_key_weak(NAME, -1), be_nested_str_weak() },
+        { be_const_key_weak(send_ack_now, 22), be_const_closure(Matter_Plugin_send_ack_now_closure) },
+        { be_const_key_weak(parse_sensors, -1), be_const_closure(Matter_Plugin_parse_sensors_closure) },
+        { be_const_key_weak(get_cluster_list, -1), be_const_closure(Matter_Plugin_get_cluster_list_closure) },
+        { be_const_key_weak(NAME, 19), be_nested_str_weak() },
+        { be_const_key_weak(parse_configuration, 32), be_const_closure(Matter_Plugin_parse_configuration_closure) },
+        { be_const_key_weak(ui_conf_to_string, 34), be_const_static_closure(Matter_Plugin_ui_conf_to_string_closure) },
         { be_const_key_weak(device, -1), be_const_var(1) },
-        { be_const_key_weak(tick, -1), be_const_var(4) },
-        { be_const_key_weak(write_attribute, 27), be_const_closure(Matter_Plugin_write_attribute_closure) },
-        { be_const_key_weak(has, -1), be_const_closure(Matter_Plugin_has_closure) },
-        { be_const_key_weak(invoke_request, 6), be_const_closure(Matter_Plugin_invoke_request_closure) },
-        { be_const_key_weak(consolidate_clusters, 29), be_const_closure(Matter_Plugin_consolidate_clusters_closure) },
-        { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Plugin_attribute_updated_closure) },
-        { be_const_key_weak(update_shadow_lazy, -1), be_const_closure(Matter_Plugin_update_shadow_lazy_closure) },
-        { be_const_key_weak(ui_string_to_conf, -1), be_const_static_closure(Matter_Plugin_ui_string_to_conf_closure) },
-        { be_const_key_weak(is_local_device, 10), be_const_closure(Matter_Plugin_is_local_device_closure) },
-        { be_const_key_weak(get_endpoint, -1), be_const_closure(Matter_Plugin_get_endpoint_closure) },
-        { be_const_key_weak(clusters, -1), be_const_var(3) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_init_closure) },
-        { be_const_key_weak(read_event, 11), be_const_closure(Matter_Plugin_read_event_closure) },
-        { be_const_key_weak(read_attribute, 24), be_const_closure(Matter_Plugin_read_attribute_closure) },
+        { be_const_key_weak(read_attribute, 18), be_const_closure(Matter_Plugin_read_attribute_closure) },
         { be_const_key_weak(update_next, -1), be_const_var(0) },
+        { be_const_key_weak(ARG_TYPE, -1), be_const_static_closure(Matter_Plugin__X3Clambda_X3E_closure) },
+        { be_const_key_weak(has, -1), be_const_closure(Matter_Plugin_has_closure) },
         { be_const_key_weak(ARG_HINT, -1), be_nested_str_weak(_Not_X20used_) },
         { be_const_key_weak(subscribe_event, -1), be_const_closure(Matter_Plugin_subscribe_event_closure) },
-        { be_const_key_weak(get_attribute_list, -1), be_const_closure(Matter_Plugin_get_attribute_list_closure) },
-        { be_const_key_weak(timed_request, -1), be_const_closure(Matter_Plugin_timed_request_closure) },
-        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_update_shadow_closure) },
-        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(5000) },
-        { be_const_key_weak(ARG, -1), be_nested_str_weak() },
-        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(ui_string_to_conf, -1), be_const_static_closure(Matter_Plugin_ui_string_to_conf_closure) },
+        { be_const_key_weak(CLUSTERS, 33), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(29, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
@@ -998,13 +1021,26 @@ be_local_class(Matter_Plugin,
         be_const_int(17),
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(parse_configuration, -1), be_const_closure(Matter_Plugin_parse_configuration_closure) },
-        { be_const_key_weak(ARG_TYPE, 17), be_const_static_closure(Matter_Plugin__X3Clambda_X3E_closure) },
-        { be_const_key_weak(subscribe_attribute, 33), be_const_closure(Matter_Plugin_subscribe_attribute_closure) },
-        { be_const_key_weak(ui_conf_to_string, -1), be_const_static_closure(Matter_Plugin_ui_conf_to_string_closure) },
-        { be_const_key_weak(TYPE, -1), be_nested_str_weak() },
-        { be_const_key_weak(endpoint, 4), be_const_var(2) },
-        { be_const_key_weak(parse_sensors, -1), be_const_closure(Matter_Plugin_parse_sensors_closure) },
+        { be_const_key_weak(every_250ms, 0), be_const_closure(Matter_Plugin_every_250ms_closure) },
+        { be_const_key_weak(UPDATE_TIME, -1), be_const_int(5000) },
+        { be_const_key_weak(get_endpoint, -1), be_const_closure(Matter_Plugin_get_endpoint_closure) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_invoke_request_closure) },
+        { be_const_key_weak(get_attribute_list, -1), be_const_closure(Matter_Plugin_get_attribute_list_closure) },
+        { be_const_key_weak(tick, -1), be_const_var(4) },
+        { be_const_key_weak(timed_request, -1), be_const_closure(Matter_Plugin_timed_request_closure) },
+        { be_const_key_weak(read_event, -1), be_const_closure(Matter_Plugin_read_event_closure) },
+        { be_const_key_weak(update_shadow_lazy, -1), be_const_closure(Matter_Plugin_update_shadow_lazy_closure) },
+        { be_const_key_weak(TYPE, 20), be_nested_str_weak() },
+        { be_const_key_weak(write_attribute, 27), be_const_closure(Matter_Plugin_write_attribute_closure) },
+        { be_const_key_weak(clusters, -1), be_const_var(3) },
+        { be_const_key_weak(attribute_updated, 11), be_const_closure(Matter_Plugin_attribute_updated_closure) },
+        { be_const_key_weak(endpoint, -1), be_const_var(2) },
+        { be_const_key_weak(ARG, 3), be_nested_str_weak() },
+        { be_const_key_weak(consolidate_clusters, 8), be_const_closure(Matter_Plugin_consolidate_clusters_closure) },
+        { be_const_key_weak(is_local_device, -1), be_const_closure(Matter_Plugin_is_local_device_closure) },
+        { be_const_key_weak(subscribe_attribute, -1), be_const_closure(Matter_Plugin_subscribe_attribute_closure) },
+        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_update_shadow_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_init_closure) },
     })),
     be_str_weak(Matter_Plugin)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
@@ -47,7 +47,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[100]) {     /* constants */
+    ( &(const bvalue[102]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
@@ -65,93 +65,95 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
     /* K14  */  be_const_int(2),
     /* K15  */  be_nested_str_weak(XX),
     /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(_fabric),
-    /* K18  */  be_nested_str_weak(fabric_completed),
-    /* K19  */  be_nested_str_weak(set_no_expiration),
-    /* K20  */  be_nested_str_weak(save),
-    /* K21  */  be_nested_str_weak(device),
-    /* K22  */  be_nested_str_weak(start_commissioning_complete_deferred),
-    /* K23  */  be_nested_str_weak(context_error),
-    /* K24  */  be_nested_str_weak(CommissioningComplete_X3A_X20no_X20fabric_X20attached),
-    /* K25  */  be_nested_str_weak(status),
-    /* K26  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
-    /* K27  */  be_nested_str_weak(B2),
-    /* K28  */  be_nested_str_weak(DAC_Cert_FFF1_8000),
-    /* K29  */  be_nested_str_weak(PAI_Cert_FFF1),
-    /* K30  */  be_nested_str_weak(CD_FFF1_8000),
-    /* K31  */  be_nested_str_weak(B1),
-    /* K32  */  be_nested_str_weak(U4),
-    /* K33  */  be_nested_str_weak(tasmota),
-    /* K34  */  be_nested_str_weak(rtc),
-    /* K35  */  be_nested_str_weak(utc),
-    /* K36  */  be_nested_str_weak(tlv2raw),
-    /* K37  */  be_nested_str_weak(get_ac),
-    /* K38  */  be_nested_str_weak(EC_P256),
-    /* K39  */  be_nested_str_weak(ecdsa_sign_sha256),
-    /* K40  */  be_nested_str_weak(DAC_Priv_FFF1_8000),
-    /* K41  */  be_nested_str_weak(gen_CSR),
-    /* K42  */  be_nested_str_weak(set_temp_ca),
-    /* K43  */  be_nested_str_weak(SUCCESS),
-    /* K44  */  be_nested_str_weak(log),
-    /* K45  */  be_nested_str_weak(MTR_X3A_X20AddNoc_X20Args_X3D),
-    /* K46  */  be_nested_str_weak(get_temp_ca),
-    /* K47  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20AdNOC_X20without_X20CA),
-    /* K48  */  be_nested_str_weak(sessions),
-    /* K49  */  be_nested_str_weak(create_fabric),
-    /* K50  */  be_nested_str_weak(set_ca),
-    /* K51  */  be_nested_str_weak(set_noc_icac),
-    /* K52  */  be_nested_str_weak(set_ipk_epoch_key),
-    /* K53  */  be_nested_str_weak(set_admin_subject_vendor),
-    /* K54  */  be_nested_str_weak(set_pk),
-    /* K55  */  be_nested_str_weak(get_pk),
-    /* K56  */  be_nested_str_weak(parse),
-    /* K57  */  be_nested_str_weak(findsub),
-    /* K58  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20no_X20fabricid_X20nor_X20deviceid_X20in_X20NOC_X20certificate),
-    /* K59  */  be_nested_str_weak(int),
-    /* K60  */  be_nested_str_weak(int64),
-    /* K61  */  be_nested_str_weak(fromu32),
-    /* K62  */  be_nested_str_weak(tobytes),
-    /* K63  */  be_nested_str_weak(get_temp_ca_pub),
-    /* K64  */  be_const_int(2147483647),
-    /* K65  */  be_nested_str_weak(fromstring),
-    /* K66  */  be_nested_str_weak(CompressedFabric),
-    /* K67  */  be_nested_str_weak(HKDF_SHA256),
-    /* K68  */  be_nested_str_weak(copy),
-    /* K69  */  be_nested_str_weak(reverse),
-    /* K70  */  be_nested_str_weak(derive),
-    /* K71  */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K72  */  be_nested_str_weak(set_fabric_device),
-    /* K73  */  be_nested_str_weak(fabric_candidate),
-    /* K74  */  be_nested_str_weak(start_operational_discovery_deferred),
-    /* K75  */  be_nested_str_weak(is_PASE),
-    /* K76  */  be_nested_str_weak(set_expire_in_seconds),
-    /* K77  */  be_nested_str_weak(log_new_fabric),
-    /* K78  */  be_nested_str_weak(set_fabric_label),
-    /* K79  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Update_X20fabric_X20_X27_X25s_X27_X20label_X3D_X27_X25s_X27),
-    /* K80  */  be_nested_str_weak(get_fabric_id),
-    /* K81  */  be_nested_str_weak(tohex),
-    /* K82  */  be_nested_str_weak(fabric_index_X3A),
-    /* K83  */  be_nested_str_weak(active_fabrics),
-    /* K84  */  be_nested_str_weak(get_fabric_index),
-    /* K85  */  be_nested_str_weak(set_timer),
-    /* K86  */  be_nested_str_weak(stop_iteration),
-    /* K87  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
-    /* K88  */  be_nested_str_weak(_X29_X20not_X20found),
-    /* K89  */  be_nested_str_weak(INVALID_ACTION),
-    /* K90  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
-    /* K91  */  be_nested_str_weak(INVALID_DATA_TYPE),
-    /* K92  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
-    /* K93  */  be_nested_str_weak(CONSTRAINT_ERROR),
-    /* K94  */  be_nested_str_weak(start_basic_commissioning),
-    /* K95  */  be_nested_str_weak(get_fabric),
-    /* K96  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
-    /* K97  */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K98  */  be_nested_str_weak(stop_basic_commissioning),
-    /* K99  */  be_nested_str_weak(invoke_request),
+    /* K17  */  be_nested_str_weak(send_ack_now),
+    /* K18  */  be_nested_str_weak(msg),
+    /* K19  */  be_nested_str_weak(_fabric),
+    /* K20  */  be_nested_str_weak(fabric_completed),
+    /* K21  */  be_nested_str_weak(set_no_expiration),
+    /* K22  */  be_nested_str_weak(save),
+    /* K23  */  be_nested_str_weak(device),
+    /* K24  */  be_nested_str_weak(start_commissioning_complete_deferred),
+    /* K25  */  be_nested_str_weak(context_error),
+    /* K26  */  be_nested_str_weak(CommissioningComplete_X3A_X20no_X20fabric_X20attached),
+    /* K27  */  be_nested_str_weak(status),
+    /* K28  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
+    /* K29  */  be_nested_str_weak(B2),
+    /* K30  */  be_nested_str_weak(DAC_Cert_FFF1_8000),
+    /* K31  */  be_nested_str_weak(PAI_Cert_FFF1),
+    /* K32  */  be_nested_str_weak(CD_FFF1_8000),
+    /* K33  */  be_nested_str_weak(B1),
+    /* K34  */  be_nested_str_weak(U4),
+    /* K35  */  be_nested_str_weak(tasmota),
+    /* K36  */  be_nested_str_weak(rtc),
+    /* K37  */  be_nested_str_weak(utc),
+    /* K38  */  be_nested_str_weak(tlv2raw),
+    /* K39  */  be_nested_str_weak(get_ac),
+    /* K40  */  be_nested_str_weak(EC_P256),
+    /* K41  */  be_nested_str_weak(ecdsa_sign_sha256),
+    /* K42  */  be_nested_str_weak(DAC_Priv_FFF1_8000),
+    /* K43  */  be_nested_str_weak(gen_CSR),
+    /* K44  */  be_nested_str_weak(set_temp_ca),
+    /* K45  */  be_nested_str_weak(SUCCESS),
+    /* K46  */  be_nested_str_weak(log),
+    /* K47  */  be_nested_str_weak(MTR_X3A_X20AddNoc_X20Args_X3D),
+    /* K48  */  be_nested_str_weak(get_temp_ca),
+    /* K49  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20AdNOC_X20without_X20CA),
+    /* K50  */  be_nested_str_weak(sessions),
+    /* K51  */  be_nested_str_weak(create_fabric),
+    /* K52  */  be_nested_str_weak(set_ca),
+    /* K53  */  be_nested_str_weak(set_noc_icac),
+    /* K54  */  be_nested_str_weak(set_ipk_epoch_key),
+    /* K55  */  be_nested_str_weak(set_admin_subject_vendor),
+    /* K56  */  be_nested_str_weak(set_pk),
+    /* K57  */  be_nested_str_weak(get_pk),
+    /* K58  */  be_nested_str_weak(parse),
+    /* K59  */  be_nested_str_weak(findsub),
+    /* K60  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20no_X20fabricid_X20nor_X20deviceid_X20in_X20NOC_X20certificate),
+    /* K61  */  be_nested_str_weak(int),
+    /* K62  */  be_nested_str_weak(int64),
+    /* K63  */  be_nested_str_weak(fromu32),
+    /* K64  */  be_nested_str_weak(tobytes),
+    /* K65  */  be_nested_str_weak(get_temp_ca_pub),
+    /* K66  */  be_const_int(2147483647),
+    /* K67  */  be_nested_str_weak(fromstring),
+    /* K68  */  be_nested_str_weak(CompressedFabric),
+    /* K69  */  be_nested_str_weak(HKDF_SHA256),
+    /* K70  */  be_nested_str_weak(copy),
+    /* K71  */  be_nested_str_weak(reverse),
+    /* K72  */  be_nested_str_weak(derive),
+    /* K73  */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K74  */  be_nested_str_weak(set_fabric_device),
+    /* K75  */  be_nested_str_weak(fabric_candidate),
+    /* K76  */  be_nested_str_weak(start_operational_discovery_deferred),
+    /* K77  */  be_nested_str_weak(is_PASE),
+    /* K78  */  be_nested_str_weak(set_expire_in_seconds),
+    /* K79  */  be_nested_str_weak(log_new_fabric),
+    /* K80  */  be_nested_str_weak(set_fabric_label),
+    /* K81  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Update_X20fabric_X20_X27_X25s_X27_X20label_X3D_X27_X25s_X27),
+    /* K82  */  be_nested_str_weak(get_fabric_id),
+    /* K83  */  be_nested_str_weak(tohex),
+    /* K84  */  be_nested_str_weak(fabric_index_X3A),
+    /* K85  */  be_nested_str_weak(active_fabrics),
+    /* K86  */  be_nested_str_weak(get_fabric_index),
+    /* K87  */  be_nested_str_weak(set_timer),
+    /* K88  */  be_nested_str_weak(stop_iteration),
+    /* K89  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
+    /* K90  */  be_nested_str_weak(_X29_X20not_X20found),
+    /* K91  */  be_nested_str_weak(INVALID_ACTION),
+    /* K92  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
+    /* K93  */  be_nested_str_weak(INVALID_DATA_TYPE),
+    /* K94  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
+    /* K95  */  be_nested_str_weak(CONSTRAINT_ERROR),
+    /* K96  */  be_nested_str_weak(start_basic_commissioning),
+    /* K97  */  be_nested_str_weak(get_fabric),
+    /* K98  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
+    /* K99  */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K100 */  be_nested_str_weak(stop_basic_commissioning),
+    /* K101 */  be_nested_str_weak(invoke_request),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[708]) {  /* code */
+    ( &(const binstruction[714]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xB8160200,  //  0001  GETNGBL	R5	K1
       0x88140B02,  //  0002  GETMBR	R5	R5	K2
@@ -159,7 +161,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x881C0704,  //  0004  GETMBR	R7	R3	K4
       0x5422002F,  //  0005  LDINT	R8	48
       0x1C200C08,  //  0006  EQ	R8	R6	R8
-      0x78220059,  //  0007  JMPF	R8	#0062
+      0x7822005C,  //  0007  JMPF	R8	#0065
       0x1C200F05,  //  0008  EQ	R8	R7	K5
       0x78220017,  //  0009  JMPF	R8	#0022
       0x8C200506,  //  000A  GETMET	R8	R2	K6
@@ -185,7 +187,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C2C0800,  //  001E  CALL	R11	4
       0x900E0907,  //  001F  SETMBR	R3	K4	K7
       0x80041400,  //  0020  RET	1	R10
-      0x7002003E,  //  0021  JMP		#0061
+      0x70020041,  //  0021  JMP		#0064
       0x1C200F0E,  //  0022  EQ	R8	R7	K14
       0x7822001A,  //  0023  JMPF	R8	#003F
       0x8C200506,  //  0024  GETMET	R8	R2	K6
@@ -214,652 +216,658 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C300800,  //  003B  CALL	R12	4
       0x900E0910,  //  003C  SETMBR	R3	K4	K16
       0x80041600,  //  003D  RET	1	R11
-      0x70020021,  //  003E  JMP		#0061
+      0x70020024,  //  003E  JMP		#0064
       0x54220003,  //  003F  LDINT	R8	4
       0x1C200E08,  //  0040  EQ	R8	R7	R8
-      0x7822001E,  //  0041  JMPF	R8	#0061
-      0x88200311,  //  0042  GETMBR	R8	R1	K17
-      0x7822001B,  //  0043  JMPF	R8	#0060
-      0x90061105,  //  0044  SETMBR	R1	K8	K5
-      0x88200311,  //  0045  GETMBR	R8	R1	K17
-      0x8C201112,  //  0046  GETMET	R8	R8	K18
-      0x7C200200,  //  0047  CALL	R8	1
-      0x8C200313,  //  0048  GETMET	R8	R1	K19
-      0x7C200200,  //  0049  CALL	R8	1
-      0x8C200314,  //  004A  GETMET	R8	R1	K20
-      0x7C200200,  //  004B  CALL	R8	1
-      0x8C200B09,  //  004C  GETMET	R8	R5	K9
-      0x7C200200,  //  004D  CALL	R8	1
-      0x8C24110A,  //  004E  GETMET	R9	R8	K10
-      0x582C0005,  //  004F  LDCONST	R11	K5
-      0x88300B0B,  //  0050  GETMBR	R12	R5	K11
-      0x58340005,  //  0051  LDCONST	R13	K5
-      0x7C240800,  //  0052  CALL	R9	4
-      0x8C24110A,  //  0053  GETMET	R9	R8	K10
-      0x582C0007,  //  0054  LDCONST	R11	K7
-      0x88300B0C,  //  0055  GETMBR	R12	R5	K12
-      0x5834000D,  //  0056  LDCONST	R13	K13
-      0x7C240800,  //  0057  CALL	R9	4
-      0x54260004,  //  0058  LDINT	R9	5
-      0x900E0809,  //  0059  SETMBR	R3	K4	R9
-      0x88240115,  //  005A  GETMBR	R9	R0	K21
-      0x8C241316,  //  005B  GETMET	R9	R9	K22
-      0x5C2C0200,  //  005C  MOVE	R11	R1
-      0x7C240400,  //  005D  CALL	R9	2
-      0x80041000,  //  005E  RET	1	R8
-      0x70020000,  //  005F  JMP		#0061
-      0xB0062F18,  //  0060  RAISE	1	K23	K24
-      0x7002025F,  //  0061  JMP		#02C2
-      0x5422003D,  //  0062  LDINT	R8	62
-      0x1C200C08,  //  0063  EQ	R8	R6	R8
-      0x782201C0,  //  0064  JMPF	R8	#0226
-      0x1C200F0E,  //  0065  EQ	R8	R7	K14
-      0x7822001D,  //  0066  JMPF	R8	#0085
-      0x8C200506,  //  0067  GETMET	R8	R2	K6
-      0x58280005,  //  0068  LDCONST	R10	K5
-      0x7C200400,  //  0069  CALL	R8	2
-      0x20241107,  //  006A  NE	R9	R8	K7
-      0x78260006,  //  006B  JMPF	R9	#0073
-      0x2024110E,  //  006C  NE	R9	R8	K14
-      0x78260004,  //  006D  JMPF	R9	#0073
-      0xB8260200,  //  006E  GETNGBL	R9	K1
-      0x8824131A,  //  006F  GETMBR	R9	R9	K26
-      0x900E3209,  //  0070  SETMBR	R3	K25	R9
-      0x4C240000,  //  0071  LDNIL	R9
-      0x80041200,  //  0072  RET	1	R9
-      0x8C240B09,  //  0073  GETMET	R9	R5	K9
-      0x7C240200,  //  0074  CALL	R9	1
-      0x8C28130A,  //  0075  GETMET	R10	R9	K10
-      0x58300005,  //  0076  LDCONST	R12	K5
-      0x88340B1B,  //  0077  GETMBR	R13	R5	K27
-      0x1C381107,  //  0078  EQ	R14	R8	K7
-      0x783A0003,  //  0079  JMPF	R14	#007E
-      0xB83A0200,  //  007A  GETNGBL	R14	K1
-      0x8C381D1C,  //  007B  GETMET	R14	R14	K28
-      0x7C380200,  //  007C  CALL	R14	1
-      0x70020002,  //  007D  JMP		#0081
-      0xB83A0200,  //  007E  GETNGBL	R14	K1
-      0x8C381D1D,  //  007F  GETMET	R14	R14	K29
-      0x7C380200,  //  0080  CALL	R14	1
-      0x7C280800,  //  0081  CALL	R10	4
-      0x900E0910,  //  0082  SETMBR	R3	K4	K16
-      0x80041200,  //  0083  RET	1	R9
-      0x7002019F,  //  0084  JMP		#0225
-      0x1C200F05,  //  0085  EQ	R8	R7	K5
-      0x7822003D,  //  0086  JMPF	R8	#00C5
-      0x8C200506,  //  0087  GETMET	R8	R2	K6
-      0x58280005,  //  0088  LDCONST	R10	K5
-      0x7C200400,  //  0089  CALL	R8	2
-      0x6024000C,  //  008A  GETGBL	R9	G12
-      0x5C281000,  //  008B  MOVE	R10	R8
-      0x7C240200,  //  008C  CALL	R9	1
-      0x542A001F,  //  008D  LDINT	R10	32
-      0x2024120A,  //  008E  NE	R9	R9	R10
-      0x78260001,  //  008F  JMPF	R9	#0092
-      0x4C240000,  //  0090  LDNIL	R9
-      0x80041200,  //  0091  RET	1	R9
-      0x900E0907,  //  0092  SETMBR	R3	K4	K7
-      0x8C240B09,  //  0093  GETMET	R9	R5	K9
-      0x7C240200,  //  0094  CALL	R9	1
-      0x8C28130A,  //  0095  GETMET	R10	R9	K10
-      0x58300007,  //  0096  LDCONST	R12	K7
-      0x88340B1B,  //  0097  GETMBR	R13	R5	K27
-      0xB83A0200,  //  0098  GETNGBL	R14	K1
-      0x8C381D1E,  //  0099  GETMET	R14	R14	K30
-      0x7C380200,  //  009A  CALL	R14	1
-      0x7C280800,  //  009B  CALL	R10	4
-      0x8C28130A,  //  009C  GETMET	R10	R9	K10
-      0x5830000E,  //  009D  LDCONST	R12	K14
-      0x88340B1F,  //  009E  GETMBR	R13	R5	K31
-      0x5C381000,  //  009F  MOVE	R14	R8
-      0x7C280800,  //  00A0  CALL	R10	4
-      0x8C28130A,  //  00A1  GETMET	R10	R9	K10
-      0x58300010,  //  00A2  LDCONST	R12	K16
-      0x88340B20,  //  00A3  GETMBR	R13	R5	K32
-      0xB83A4200,  //  00A4  GETNGBL	R14	K33
-      0x8C381D22,  //  00A5  GETMET	R14	R14	K34
-      0x7C380200,  //  00A6  CALL	R14	1
-      0x94381D23,  //  00A7  GETIDX	R14	R14	K35
-      0x7C280800,  //  00A8  CALL	R10	4
-      0x8C281324,  //  00A9  GETMET	R10	R9	K36
-      0x7C280200,  //  00AA  CALL	R10	1
-      0x8C2C0325,  //  00AB  GETMET	R11	R1	K37
-      0x7C2C0200,  //  00AC  CALL	R11	1
-      0x0030140B,  //  00AD  ADD	R12	R10	R11
-      0x8C340926,  //  00AE  GETMET	R13	R4	K38
-      0x7C340200,  //  00AF  CALL	R13	1
-      0x8C341B27,  //  00B0  GETMET	R13	R13	K39
-      0xB83E0200,  //  00B1  GETNGBL	R15	K1
-      0x8C3C1F28,  //  00B2  GETMET	R15	R15	K40
-      0x7C3C0200,  //  00B3  CALL	R15	1
-      0x5C401800,  //  00B4  MOVE	R16	R12
-      0x7C340600,  //  00B5  CALL	R13	3
-      0x8C380B09,  //  00B6  GETMET	R14	R5	K9
-      0x7C380200,  //  00B7  CALL	R14	1
-      0x8C3C1D0A,  //  00B8  GETMET	R15	R14	K10
-      0x58440005,  //  00B9  LDCONST	R17	K5
-      0x88480B1B,  //  00BA  GETMBR	R18	R5	K27
-      0x5C4C1400,  //  00BB  MOVE	R19	R10
-      0x7C3C0800,  //  00BC  CALL	R15	4
-      0x8C3C1D0A,  //  00BD  GETMET	R15	R14	K10
-      0x58440007,  //  00BE  LDCONST	R17	K7
-      0x88480B1F,  //  00BF  GETMBR	R18	R5	K31
-      0x5C4C1A00,  //  00C0  MOVE	R19	R13
-      0x7C3C0800,  //  00C1  CALL	R15	4
-      0x900E0907,  //  00C2  SETMBR	R3	K4	K7
-      0x80041C00,  //  00C3  RET	1	R14
-      0x7002015F,  //  00C4  JMP		#0225
-      0x54220003,  //  00C5  LDINT	R8	4
-      0x1C200E08,  //  00C6  EQ	R8	R7	R8
-      0x78220039,  //  00C7  JMPF	R8	#0102
-      0x8C200506,  //  00C8  GETMET	R8	R2	K6
-      0x58280005,  //  00C9  LDCONST	R10	K5
-      0x7C200400,  //  00CA  CALL	R8	2
-      0x6024000C,  //  00CB  GETGBL	R9	G12
-      0x5C281000,  //  00CC  MOVE	R10	R8
-      0x7C240200,  //  00CD  CALL	R9	1
-      0x542A001F,  //  00CE  LDINT	R10	32
-      0x2024120A,  //  00CF  NE	R9	R9	R10
-      0x78260001,  //  00D0  JMPF	R9	#00D3
-      0x4C240000,  //  00D1  LDNIL	R9
-      0x80041200,  //  00D2  RET	1	R9
-      0x8C240506,  //  00D3  GETMET	R9	R2	K6
-      0x582C0007,  //  00D4  LDCONST	R11	K7
-      0x50300000,  //  00D5  LDBOOL	R12	0	0
-      0x7C240600,  //  00D6  CALL	R9	3
-      0x8C280329,  //  00D7  GETMET	R10	R1	K41
-      0x7C280200,  //  00D8  CALL	R10	1
-      0x8C2C0B09,  //  00D9  GETMET	R11	R5	K9
-      0x7C2C0200,  //  00DA  CALL	R11	1
-      0x8C30170A,  //  00DB  GETMET	R12	R11	K10
-      0x58380007,  //  00DC  LDCONST	R14	K7
-      0x883C0B1B,  //  00DD  GETMBR	R15	R5	K27
-      0x5C401400,  //  00DE  MOVE	R16	R10
-      0x7C300800,  //  00DF  CALL	R12	4
-      0x8C30170A,  //  00E0  GETMET	R12	R11	K10
-      0x5838000E,  //  00E1  LDCONST	R14	K14
-      0x883C0B1F,  //  00E2  GETMBR	R15	R5	K31
-      0x5C401000,  //  00E3  MOVE	R16	R8
-      0x7C300800,  //  00E4  CALL	R12	4
-      0x8C301724,  //  00E5  GETMET	R12	R11	K36
-      0x7C300200,  //  00E6  CALL	R12	1
-      0x8C340325,  //  00E7  GETMET	R13	R1	K37
-      0x7C340200,  //  00E8  CALL	R13	1
-      0x0034180D,  //  00E9  ADD	R13	R12	R13
-      0x8C380926,  //  00EA  GETMET	R14	R4	K38
-      0x7C380200,  //  00EB  CALL	R14	1
-      0x8C381D27,  //  00EC  GETMET	R14	R14	K39
-      0xB8420200,  //  00ED  GETNGBL	R16	K1
-      0x8C402128,  //  00EE  GETMET	R16	R16	K40
-      0x7C400200,  //  00EF  CALL	R16	1
-      0x5C441A00,  //  00F0  MOVE	R17	R13
-      0x7C380600,  //  00F1  CALL	R14	3
-      0x8C3C0B09,  //  00F2  GETMET	R15	R5	K9
-      0x7C3C0200,  //  00F3  CALL	R15	1
-      0x8C401F0A,  //  00F4  GETMET	R16	R15	K10
-      0x58480005,  //  00F5  LDCONST	R18	K5
-      0x884C0B1B,  //  00F6  GETMBR	R19	R5	K27
-      0x5C501800,  //  00F7  MOVE	R20	R12
-      0x7C400800,  //  00F8  CALL	R16	4
-      0x8C401F0A,  //  00F9  GETMET	R16	R15	K10
-      0x58480007,  //  00FA  LDCONST	R18	K7
-      0x884C0B1F,  //  00FB  GETMBR	R19	R5	K31
-      0x5C501C00,  //  00FC  MOVE	R20	R14
-      0x7C400800,  //  00FD  CALL	R16	4
-      0x54420004,  //  00FE  LDINT	R16	5
-      0x900E0810,  //  00FF  SETMBR	R3	K4	R16
-      0x80041E00,  //  0100  RET	1	R15
-      0x70020122,  //  0101  JMP		#0225
-      0x5422000A,  //  0102  LDINT	R8	11
-      0x1C200E08,  //  0103  EQ	R8	R7	R8
-      0x7822000B,  //  0104  JMPF	R8	#0111
-      0x8C200506,  //  0105  GETMET	R8	R2	K6
-      0x58280005,  //  0106  LDCONST	R10	K5
-      0x7C200400,  //  0107  CALL	R8	2
-      0x8C24032A,  //  0108  GETMET	R9	R1	K42
-      0x5C2C1000,  //  0109  MOVE	R11	R8
-      0x7C240400,  //  010A  CALL	R9	2
-      0xB8260200,  //  010B  GETNGBL	R9	K1
-      0x8824132B,  //  010C  GETMBR	R9	R9	K43
-      0x900E3209,  //  010D  SETMBR	R3	K25	R9
-      0x4C240000,  //  010E  LDNIL	R9
-      0x80041200,  //  010F  RET	1	R9
-      0x70020113,  //  0110  JMP		#0225
-      0x54220005,  //  0111  LDINT	R8	6
-      0x1C200E08,  //  0112  EQ	R8	R7	R8
-      0x782200B9,  //  0113  JMPF	R8	#01CE
-      0xB8224200,  //  0114  GETNGBL	R8	K33
-      0x8C20112C,  //  0115  GETMET	R8	R8	K44
-      0x60280008,  //  0116  GETGBL	R10	G8
-      0x5C2C0400,  //  0117  MOVE	R11	R2
-      0x7C280200,  //  0118  CALL	R10	1
-      0x002A5A0A,  //  0119  ADD	R10	K45	R10
-      0x542E0003,  //  011A  LDINT	R11	4
-      0x7C200600,  //  011B  CALL	R8	3
-      0x8C200506,  //  011C  GETMET	R8	R2	K6
-      0x58280005,  //  011D  LDCONST	R10	K5
-      0x7C200400,  //  011E  CALL	R8	2
-      0x8C240506,  //  011F  GETMET	R9	R2	K6
-      0x582C0007,  //  0120  LDCONST	R11	K7
-      0x7C240400,  //  0121  CALL	R9	2
-      0x6028000C,  //  0122  GETGBL	R10	G12
-      0x5C2C1200,  //  0123  MOVE	R11	R9
-      0x7C280200,  //  0124  CALL	R10	1
-      0x1C281505,  //  0125  EQ	R10	R10	K5
-      0x782A0000,  //  0126  JMPF	R10	#0128
-      0x4C240000,  //  0127  LDNIL	R9
-      0x8C280506,  //  0128  GETMET	R10	R2	K6
-      0x5830000E,  //  0129  LDCONST	R12	K14
-      0x7C280400,  //  012A  CALL	R10	2
-      0x8C2C0506,  //  012B  GETMET	R11	R2	K6
-      0x58340010,  //  012C  LDCONST	R13	K16
-      0x7C2C0400,  //  012D  CALL	R11	2
-      0x8C300506,  //  012E  GETMET	R12	R2	K6
-      0x543A0003,  //  012F  LDINT	R14	4
-      0x7C300400,  //  0130  CALL	R12	2
-      0x8C34032E,  //  0131  GETMET	R13	R1	K46
-      0x7C340200,  //  0132  CALL	R13	1
-      0x4C380000,  //  0133  LDNIL	R14
-      0x1C341A0E,  //  0134  EQ	R13	R13	R14
-      0x78360006,  //  0135  JMPF	R13	#013D
-      0xB8364200,  //  0136  GETNGBL	R13	K33
-      0x8C341B2C,  //  0137  GETMET	R13	R13	K44
-      0x583C002F,  //  0138  LDCONST	R15	K47
-      0x5840000E,  //  0139  LDCONST	R16	K14
-      0x7C340600,  //  013A  CALL	R13	3
-      0x4C340000,  //  013B  LDNIL	R13
-      0x80041A00,  //  013C  RET	1	R13
-      0x88340115,  //  013D  GETMBR	R13	R0	K21
-      0x88341B30,  //  013E  GETMBR	R13	R13	K48
-      0x8C341B31,  //  013F  GETMET	R13	R13	K49
-      0x7C340200,  //  0140  CALL	R13	1
-      0x8C381B32,  //  0141  GETMET	R14	R13	K50
-      0x8C40032E,  //  0142  GETMET	R16	R1	K46
-      0x7C400200,  //  0143  CALL	R16	1
-      0x7C380400,  //  0144  CALL	R14	2
-      0x8C381B33,  //  0145  GETMET	R14	R13	K51
-      0x5C401000,  //  0146  MOVE	R16	R8
-      0x5C441200,  //  0147  MOVE	R17	R9
-      0x7C380600,  //  0148  CALL	R14	3
-      0x8C381B34,  //  0149  GETMET	R14	R13	K52
-      0x5C401400,  //  014A  MOVE	R16	R10
-      0x7C380400,  //  014B  CALL	R14	2
-      0x8C381B35,  //  014C  GETMET	R14	R13	K53
-      0x5C401600,  //  014D  MOVE	R16	R11
-      0x5C441800,  //  014E  MOVE	R17	R12
-      0x7C380600,  //  014F  CALL	R14	3
-      0x8C381B36,  //  0150  GETMET	R14	R13	K54
-      0x8C400337,  //  0151  GETMET	R16	R1	K55
-      0x7C400200,  //  0152  CALL	R16	1
-      0x7C380400,  //  0153  CALL	R14	2
-      0xB83A0200,  //  0154  GETNGBL	R14	K1
-      0x88381D02,  //  0155  GETMBR	R14	R14	K2
-      0x8C381D38,  //  0156  GETMET	R14	R14	K56
-      0x5C401000,  //  0157  MOVE	R16	R8
-      0x7C380400,  //  0158  CALL	R14	2
-      0x8C3C1D39,  //  0159  GETMET	R15	R14	K57
-      0x54460005,  //  015A  LDINT	R17	6
-      0x7C3C0400,  //  015B  CALL	R15	2
-      0x8C401F06,  //  015C  GETMET	R16	R15	K6
-      0x544A0014,  //  015D  LDINT	R18	21
-      0x7C400400,  //  015E  CALL	R16	2
-      0x8C441F06,  //  015F  GETMET	R17	R15	K6
-      0x544E0010,  //  0160  LDINT	R19	17
-      0x7C440400,  //  0161  CALL	R17	2
-      0x5C482000,  //  0162  MOVE	R18	R16
-      0x784A0001,  //  0163  JMPF	R18	#0166
-      0x5C482200,  //  0164  MOVE	R18	R17
-      0x744A0006,  //  0165  JMPT	R18	#016D
-      0xB84A4200,  //  0166  GETNGBL	R18	K33
-      0x8C48252C,  //  0167  GETMET	R18	R18	K44
-      0x5850003A,  //  0168  LDCONST	R20	K58
-      0x5854000E,  //  0169  LDCONST	R21	K14
-      0x7C480600,  //  016A  CALL	R18	3
-      0x50480000,  //  016B  LDBOOL	R18	0	0
-      0x80042400,  //  016C  RET	1	R18
-      0x60480004,  //  016D  GETGBL	R18	G4
-      0x5C4C2000,  //  016E  MOVE	R19	R16
-      0x7C480200,  //  016F  CALL	R18	1
-      0x1C48253B,  //  0170  EQ	R18	R18	K59
-      0x784A0007,  //  0171  JMPF	R18	#017A
-      0xB84A7800,  //  0172  GETNGBL	R18	K60
-      0x8C48253D,  //  0173  GETMET	R18	R18	K61
-      0x5C502000,  //  0174  MOVE	R20	R16
-      0x7C480400,  //  0175  CALL	R18	2
-      0x8C48253E,  //  0176  GETMET	R18	R18	K62
-      0x7C480200,  //  0177  CALL	R18	1
-      0x5C402400,  //  0178  MOVE	R16	R18
-      0x70020002,  //  0179  JMP		#017D
-      0x8C48213E,  //  017A  GETMET	R18	R16	K62
-      0x7C480200,  //  017B  CALL	R18	1
-      0x5C402400,  //  017C  MOVE	R16	R18
-      0x60480004,  //  017D  GETGBL	R18	G4
-      0x5C4C2200,  //  017E  MOVE	R19	R17
-      0x7C480200,  //  017F  CALL	R18	1
-      0x1C48253B,  //  0180  EQ	R18	R18	K59
-      0x784A0007,  //  0181  JMPF	R18	#018A
-      0xB84A7800,  //  0182  GETNGBL	R18	K60
-      0x8C48253D,  //  0183  GETMET	R18	R18	K61
-      0x5C502200,  //  0184  MOVE	R20	R17
-      0x7C480400,  //  0185  CALL	R18	2
-      0x8C48253E,  //  0186  GETMET	R18	R18	K62
-      0x7C480200,  //  0187  CALL	R18	1
-      0x5C442400,  //  0188  MOVE	R17	R18
-      0x70020002,  //  0189  JMP		#018D
-      0x8C48233E,  //  018A  GETMET	R18	R17	K62
-      0x7C480200,  //  018B  CALL	R18	1
-      0x5C442400,  //  018C  MOVE	R17	R18
-      0x8C48033F,  //  018D  GETMET	R18	R1	K63
-      0x7C480200,  //  018E  CALL	R18	1
-      0x404E0F40,  //  018F  CONNECT	R19	K7	K64
-      0x94482413,  //  0190  GETIDX	R18	R18	R19
-      0x60500015,  //  0191  GETGBL	R20	G21
-      0x7C500000,  //  0192  CALL	R20	0
-      0x8C502941,  //  0193  GETMET	R20	R20	K65
-      0x58580042,  //  0194  LDCONST	R22	K66
-      0x7C500400,  //  0195  CALL	R20	2
-      0x5C4C2800,  //  0196  MOVE	R19	R20
-      0x8C500943,  //  0197  GETMET	R20	R4	K67
-      0x7C500200,  //  0198  CALL	R20	1
-      0x8C542144,  //  0199  GETMET	R21	R16	K68
-      0x7C540200,  //  019A  CALL	R21	1
-      0x8C542B45,  //  019B  GETMET	R21	R21	K69
-      0x7C540200,  //  019C  CALL	R21	1
-      0x8C582946,  //  019D  GETMET	R22	R20	K70
-      0x5C602400,  //  019E  MOVE	R24	R18
-      0x5C642A00,  //  019F  MOVE	R25	R21
-      0x5C682600,  //  01A0  MOVE	R26	R19
-      0x546E0007,  //  01A1  LDINT	R27	8
-      0x7C580A00,  //  01A2  CALL	R22	5
-      0x885C0311,  //  01A3  GETMBR	R23	R1	K17
-      0x785E0001,  //  01A4  JMPF	R23	#01A7
-      0x885C0311,  //  01A5  GETMBR	R23	R1	K17
-      0x70020001,  //  01A6  JMP		#01A9
-      0x885C0115,  //  01A7  GETMBR	R23	R0	K21
-      0x885C2F47,  //  01A8  GETMBR	R23	R23	K71
-      0x8C601B48,  //  01A9  GETMET	R24	R13	K72
-      0x5C682000,  //  01AA  MOVE	R26	R16
-      0x5C6C2200,  //  01AB  MOVE	R27	R17
-      0x5C702C00,  //  01AC  MOVE	R28	R22
-      0x5C742E00,  //  01AD  MOVE	R29	R23
-      0x7C600A00,  //  01AE  CALL	R24	5
-      0x8C601B49,  //  01AF  GETMET	R24	R13	K73
-      0x7C600200,  //  01B0  CALL	R24	1
-      0x88600115,  //  01B1  GETMBR	R24	R0	K21
-      0x8C60314A,  //  01B2  GETMET	R24	R24	K74
-      0x5C681A00,  //  01B3  MOVE	R26	R13
-      0x7C600400,  //  01B4  CALL	R24	2
-      0x8C60034B,  //  01B5  GETMET	R24	R1	K75
+      0x78220021,  //  0041  JMPF	R8	#0064
+      0x8C200111,  //  0042  GETMET	R8	R0	K17
+      0x88280712,  //  0043  GETMBR	R10	R3	K18
+      0x7C200400,  //  0044  CALL	R8	2
+      0x88200313,  //  0045  GETMBR	R8	R1	K19
+      0x7822001B,  //  0046  JMPF	R8	#0063
+      0x90061105,  //  0047  SETMBR	R1	K8	K5
+      0x88200313,  //  0048  GETMBR	R8	R1	K19
+      0x8C201114,  //  0049  GETMET	R8	R8	K20
+      0x7C200200,  //  004A  CALL	R8	1
+      0x8C200315,  //  004B  GETMET	R8	R1	K21
+      0x7C200200,  //  004C  CALL	R8	1
+      0x8C200316,  //  004D  GETMET	R8	R1	K22
+      0x7C200200,  //  004E  CALL	R8	1
+      0x8C200B09,  //  004F  GETMET	R8	R5	K9
+      0x7C200200,  //  0050  CALL	R8	1
+      0x8C24110A,  //  0051  GETMET	R9	R8	K10
+      0x582C0005,  //  0052  LDCONST	R11	K5
+      0x88300B0B,  //  0053  GETMBR	R12	R5	K11
+      0x58340005,  //  0054  LDCONST	R13	K5
+      0x7C240800,  //  0055  CALL	R9	4
+      0x8C24110A,  //  0056  GETMET	R9	R8	K10
+      0x582C0007,  //  0057  LDCONST	R11	K7
+      0x88300B0C,  //  0058  GETMBR	R12	R5	K12
+      0x5834000D,  //  0059  LDCONST	R13	K13
+      0x7C240800,  //  005A  CALL	R9	4
+      0x54260004,  //  005B  LDINT	R9	5
+      0x900E0809,  //  005C  SETMBR	R3	K4	R9
+      0x88240117,  //  005D  GETMBR	R9	R0	K23
+      0x8C241318,  //  005E  GETMET	R9	R9	K24
+      0x5C2C0200,  //  005F  MOVE	R11	R1
+      0x7C240400,  //  0060  CALL	R9	2
+      0x80041000,  //  0061  RET	1	R8
+      0x70020000,  //  0062  JMP		#0064
+      0xB006331A,  //  0063  RAISE	1	K25	K26
+      0x70020262,  //  0064  JMP		#02C8
+      0x5422003D,  //  0065  LDINT	R8	62
+      0x1C200C08,  //  0066  EQ	R8	R6	R8
+      0x782201C3,  //  0067  JMPF	R8	#022C
+      0x1C200F0E,  //  0068  EQ	R8	R7	K14
+      0x7822001D,  //  0069  JMPF	R8	#0088
+      0x8C200506,  //  006A  GETMET	R8	R2	K6
+      0x58280005,  //  006B  LDCONST	R10	K5
+      0x7C200400,  //  006C  CALL	R8	2
+      0x20241107,  //  006D  NE	R9	R8	K7
+      0x78260006,  //  006E  JMPF	R9	#0076
+      0x2024110E,  //  006F  NE	R9	R8	K14
+      0x78260004,  //  0070  JMPF	R9	#0076
+      0xB8260200,  //  0071  GETNGBL	R9	K1
+      0x8824131C,  //  0072  GETMBR	R9	R9	K28
+      0x900E3609,  //  0073  SETMBR	R3	K27	R9
+      0x4C240000,  //  0074  LDNIL	R9
+      0x80041200,  //  0075  RET	1	R9
+      0x8C240B09,  //  0076  GETMET	R9	R5	K9
+      0x7C240200,  //  0077  CALL	R9	1
+      0x8C28130A,  //  0078  GETMET	R10	R9	K10
+      0x58300005,  //  0079  LDCONST	R12	K5
+      0x88340B1D,  //  007A  GETMBR	R13	R5	K29
+      0x1C381107,  //  007B  EQ	R14	R8	K7
+      0x783A0003,  //  007C  JMPF	R14	#0081
+      0xB83A0200,  //  007D  GETNGBL	R14	K1
+      0x8C381D1E,  //  007E  GETMET	R14	R14	K30
+      0x7C380200,  //  007F  CALL	R14	1
+      0x70020002,  //  0080  JMP		#0084
+      0xB83A0200,  //  0081  GETNGBL	R14	K1
+      0x8C381D1F,  //  0082  GETMET	R14	R14	K31
+      0x7C380200,  //  0083  CALL	R14	1
+      0x7C280800,  //  0084  CALL	R10	4
+      0x900E0910,  //  0085  SETMBR	R3	K4	K16
+      0x80041200,  //  0086  RET	1	R9
+      0x700201A2,  //  0087  JMP		#022B
+      0x1C200F05,  //  0088  EQ	R8	R7	K5
+      0x7822003D,  //  0089  JMPF	R8	#00C8
+      0x8C200506,  //  008A  GETMET	R8	R2	K6
+      0x58280005,  //  008B  LDCONST	R10	K5
+      0x7C200400,  //  008C  CALL	R8	2
+      0x6024000C,  //  008D  GETGBL	R9	G12
+      0x5C281000,  //  008E  MOVE	R10	R8
+      0x7C240200,  //  008F  CALL	R9	1
+      0x542A001F,  //  0090  LDINT	R10	32
+      0x2024120A,  //  0091  NE	R9	R9	R10
+      0x78260001,  //  0092  JMPF	R9	#0095
+      0x4C240000,  //  0093  LDNIL	R9
+      0x80041200,  //  0094  RET	1	R9
+      0x900E0907,  //  0095  SETMBR	R3	K4	K7
+      0x8C240B09,  //  0096  GETMET	R9	R5	K9
+      0x7C240200,  //  0097  CALL	R9	1
+      0x8C28130A,  //  0098  GETMET	R10	R9	K10
+      0x58300007,  //  0099  LDCONST	R12	K7
+      0x88340B1D,  //  009A  GETMBR	R13	R5	K29
+      0xB83A0200,  //  009B  GETNGBL	R14	K1
+      0x8C381D20,  //  009C  GETMET	R14	R14	K32
+      0x7C380200,  //  009D  CALL	R14	1
+      0x7C280800,  //  009E  CALL	R10	4
+      0x8C28130A,  //  009F  GETMET	R10	R9	K10
+      0x5830000E,  //  00A0  LDCONST	R12	K14
+      0x88340B21,  //  00A1  GETMBR	R13	R5	K33
+      0x5C381000,  //  00A2  MOVE	R14	R8
+      0x7C280800,  //  00A3  CALL	R10	4
+      0x8C28130A,  //  00A4  GETMET	R10	R9	K10
+      0x58300010,  //  00A5  LDCONST	R12	K16
+      0x88340B22,  //  00A6  GETMBR	R13	R5	K34
+      0xB83A4600,  //  00A7  GETNGBL	R14	K35
+      0x8C381D24,  //  00A8  GETMET	R14	R14	K36
+      0x7C380200,  //  00A9  CALL	R14	1
+      0x94381D25,  //  00AA  GETIDX	R14	R14	K37
+      0x7C280800,  //  00AB  CALL	R10	4
+      0x8C281326,  //  00AC  GETMET	R10	R9	K38
+      0x7C280200,  //  00AD  CALL	R10	1
+      0x8C2C0327,  //  00AE  GETMET	R11	R1	K39
+      0x7C2C0200,  //  00AF  CALL	R11	1
+      0x0030140B,  //  00B0  ADD	R12	R10	R11
+      0x8C340928,  //  00B1  GETMET	R13	R4	K40
+      0x7C340200,  //  00B2  CALL	R13	1
+      0x8C341B29,  //  00B3  GETMET	R13	R13	K41
+      0xB83E0200,  //  00B4  GETNGBL	R15	K1
+      0x8C3C1F2A,  //  00B5  GETMET	R15	R15	K42
+      0x7C3C0200,  //  00B6  CALL	R15	1
+      0x5C401800,  //  00B7  MOVE	R16	R12
+      0x7C340600,  //  00B8  CALL	R13	3
+      0x8C380B09,  //  00B9  GETMET	R14	R5	K9
+      0x7C380200,  //  00BA  CALL	R14	1
+      0x8C3C1D0A,  //  00BB  GETMET	R15	R14	K10
+      0x58440005,  //  00BC  LDCONST	R17	K5
+      0x88480B1D,  //  00BD  GETMBR	R18	R5	K29
+      0x5C4C1400,  //  00BE  MOVE	R19	R10
+      0x7C3C0800,  //  00BF  CALL	R15	4
+      0x8C3C1D0A,  //  00C0  GETMET	R15	R14	K10
+      0x58440007,  //  00C1  LDCONST	R17	K7
+      0x88480B21,  //  00C2  GETMBR	R18	R5	K33
+      0x5C4C1A00,  //  00C3  MOVE	R19	R13
+      0x7C3C0800,  //  00C4  CALL	R15	4
+      0x900E0907,  //  00C5  SETMBR	R3	K4	K7
+      0x80041C00,  //  00C6  RET	1	R14
+      0x70020162,  //  00C7  JMP		#022B
+      0x54220003,  //  00C8  LDINT	R8	4
+      0x1C200E08,  //  00C9  EQ	R8	R7	R8
+      0x7822003C,  //  00CA  JMPF	R8	#0108
+      0x8C200111,  //  00CB  GETMET	R8	R0	K17
+      0x88280712,  //  00CC  GETMBR	R10	R3	K18
+      0x7C200400,  //  00CD  CALL	R8	2
+      0x8C200506,  //  00CE  GETMET	R8	R2	K6
+      0x58280005,  //  00CF  LDCONST	R10	K5
+      0x7C200400,  //  00D0  CALL	R8	2
+      0x6024000C,  //  00D1  GETGBL	R9	G12
+      0x5C281000,  //  00D2  MOVE	R10	R8
+      0x7C240200,  //  00D3  CALL	R9	1
+      0x542A001F,  //  00D4  LDINT	R10	32
+      0x2024120A,  //  00D5  NE	R9	R9	R10
+      0x78260001,  //  00D6  JMPF	R9	#00D9
+      0x4C240000,  //  00D7  LDNIL	R9
+      0x80041200,  //  00D8  RET	1	R9
+      0x8C240506,  //  00D9  GETMET	R9	R2	K6
+      0x582C0007,  //  00DA  LDCONST	R11	K7
+      0x50300000,  //  00DB  LDBOOL	R12	0	0
+      0x7C240600,  //  00DC  CALL	R9	3
+      0x8C28032B,  //  00DD  GETMET	R10	R1	K43
+      0x7C280200,  //  00DE  CALL	R10	1
+      0x8C2C0B09,  //  00DF  GETMET	R11	R5	K9
+      0x7C2C0200,  //  00E0  CALL	R11	1
+      0x8C30170A,  //  00E1  GETMET	R12	R11	K10
+      0x58380007,  //  00E2  LDCONST	R14	K7
+      0x883C0B1D,  //  00E3  GETMBR	R15	R5	K29
+      0x5C401400,  //  00E4  MOVE	R16	R10
+      0x7C300800,  //  00E5  CALL	R12	4
+      0x8C30170A,  //  00E6  GETMET	R12	R11	K10
+      0x5838000E,  //  00E7  LDCONST	R14	K14
+      0x883C0B21,  //  00E8  GETMBR	R15	R5	K33
+      0x5C401000,  //  00E9  MOVE	R16	R8
+      0x7C300800,  //  00EA  CALL	R12	4
+      0x8C301726,  //  00EB  GETMET	R12	R11	K38
+      0x7C300200,  //  00EC  CALL	R12	1
+      0x8C340327,  //  00ED  GETMET	R13	R1	K39
+      0x7C340200,  //  00EE  CALL	R13	1
+      0x0034180D,  //  00EF  ADD	R13	R12	R13
+      0x8C380928,  //  00F0  GETMET	R14	R4	K40
+      0x7C380200,  //  00F1  CALL	R14	1
+      0x8C381D29,  //  00F2  GETMET	R14	R14	K41
+      0xB8420200,  //  00F3  GETNGBL	R16	K1
+      0x8C40212A,  //  00F4  GETMET	R16	R16	K42
+      0x7C400200,  //  00F5  CALL	R16	1
+      0x5C441A00,  //  00F6  MOVE	R17	R13
+      0x7C380600,  //  00F7  CALL	R14	3
+      0x8C3C0B09,  //  00F8  GETMET	R15	R5	K9
+      0x7C3C0200,  //  00F9  CALL	R15	1
+      0x8C401F0A,  //  00FA  GETMET	R16	R15	K10
+      0x58480005,  //  00FB  LDCONST	R18	K5
+      0x884C0B1D,  //  00FC  GETMBR	R19	R5	K29
+      0x5C501800,  //  00FD  MOVE	R20	R12
+      0x7C400800,  //  00FE  CALL	R16	4
+      0x8C401F0A,  //  00FF  GETMET	R16	R15	K10
+      0x58480007,  //  0100  LDCONST	R18	K7
+      0x884C0B21,  //  0101  GETMBR	R19	R5	K33
+      0x5C501C00,  //  0102  MOVE	R20	R14
+      0x7C400800,  //  0103  CALL	R16	4
+      0x54420004,  //  0104  LDINT	R16	5
+      0x900E0810,  //  0105  SETMBR	R3	K4	R16
+      0x80041E00,  //  0106  RET	1	R15
+      0x70020122,  //  0107  JMP		#022B
+      0x5422000A,  //  0108  LDINT	R8	11
+      0x1C200E08,  //  0109  EQ	R8	R7	R8
+      0x7822000B,  //  010A  JMPF	R8	#0117
+      0x8C200506,  //  010B  GETMET	R8	R2	K6
+      0x58280005,  //  010C  LDCONST	R10	K5
+      0x7C200400,  //  010D  CALL	R8	2
+      0x8C24032C,  //  010E  GETMET	R9	R1	K44
+      0x5C2C1000,  //  010F  MOVE	R11	R8
+      0x7C240400,  //  0110  CALL	R9	2
+      0xB8260200,  //  0111  GETNGBL	R9	K1
+      0x8824132D,  //  0112  GETMBR	R9	R9	K45
+      0x900E3609,  //  0113  SETMBR	R3	K27	R9
+      0x4C240000,  //  0114  LDNIL	R9
+      0x80041200,  //  0115  RET	1	R9
+      0x70020113,  //  0116  JMP		#022B
+      0x54220005,  //  0117  LDINT	R8	6
+      0x1C200E08,  //  0118  EQ	R8	R7	R8
+      0x782200B9,  //  0119  JMPF	R8	#01D4
+      0xB8224600,  //  011A  GETNGBL	R8	K35
+      0x8C20112E,  //  011B  GETMET	R8	R8	K46
+      0x60280008,  //  011C  GETGBL	R10	G8
+      0x5C2C0400,  //  011D  MOVE	R11	R2
+      0x7C280200,  //  011E  CALL	R10	1
+      0x002A5E0A,  //  011F  ADD	R10	K47	R10
+      0x542E0003,  //  0120  LDINT	R11	4
+      0x7C200600,  //  0121  CALL	R8	3
+      0x8C200506,  //  0122  GETMET	R8	R2	K6
+      0x58280005,  //  0123  LDCONST	R10	K5
+      0x7C200400,  //  0124  CALL	R8	2
+      0x8C240506,  //  0125  GETMET	R9	R2	K6
+      0x582C0007,  //  0126  LDCONST	R11	K7
+      0x7C240400,  //  0127  CALL	R9	2
+      0x6028000C,  //  0128  GETGBL	R10	G12
+      0x5C2C1200,  //  0129  MOVE	R11	R9
+      0x7C280200,  //  012A  CALL	R10	1
+      0x1C281505,  //  012B  EQ	R10	R10	K5
+      0x782A0000,  //  012C  JMPF	R10	#012E
+      0x4C240000,  //  012D  LDNIL	R9
+      0x8C280506,  //  012E  GETMET	R10	R2	K6
+      0x5830000E,  //  012F  LDCONST	R12	K14
+      0x7C280400,  //  0130  CALL	R10	2
+      0x8C2C0506,  //  0131  GETMET	R11	R2	K6
+      0x58340010,  //  0132  LDCONST	R13	K16
+      0x7C2C0400,  //  0133  CALL	R11	2
+      0x8C300506,  //  0134  GETMET	R12	R2	K6
+      0x543A0003,  //  0135  LDINT	R14	4
+      0x7C300400,  //  0136  CALL	R12	2
+      0x8C340330,  //  0137  GETMET	R13	R1	K48
+      0x7C340200,  //  0138  CALL	R13	1
+      0x4C380000,  //  0139  LDNIL	R14
+      0x1C341A0E,  //  013A  EQ	R13	R13	R14
+      0x78360006,  //  013B  JMPF	R13	#0143
+      0xB8364600,  //  013C  GETNGBL	R13	K35
+      0x8C341B2E,  //  013D  GETMET	R13	R13	K46
+      0x583C0031,  //  013E  LDCONST	R15	K49
+      0x5840000E,  //  013F  LDCONST	R16	K14
+      0x7C340600,  //  0140  CALL	R13	3
+      0x4C340000,  //  0141  LDNIL	R13
+      0x80041A00,  //  0142  RET	1	R13
+      0x88340117,  //  0143  GETMBR	R13	R0	K23
+      0x88341B32,  //  0144  GETMBR	R13	R13	K50
+      0x8C341B33,  //  0145  GETMET	R13	R13	K51
+      0x7C340200,  //  0146  CALL	R13	1
+      0x8C381B34,  //  0147  GETMET	R14	R13	K52
+      0x8C400330,  //  0148  GETMET	R16	R1	K48
+      0x7C400200,  //  0149  CALL	R16	1
+      0x7C380400,  //  014A  CALL	R14	2
+      0x8C381B35,  //  014B  GETMET	R14	R13	K53
+      0x5C401000,  //  014C  MOVE	R16	R8
+      0x5C441200,  //  014D  MOVE	R17	R9
+      0x7C380600,  //  014E  CALL	R14	3
+      0x8C381B36,  //  014F  GETMET	R14	R13	K54
+      0x5C401400,  //  0150  MOVE	R16	R10
+      0x7C380400,  //  0151  CALL	R14	2
+      0x8C381B37,  //  0152  GETMET	R14	R13	K55
+      0x5C401600,  //  0153  MOVE	R16	R11
+      0x5C441800,  //  0154  MOVE	R17	R12
+      0x7C380600,  //  0155  CALL	R14	3
+      0x8C381B38,  //  0156  GETMET	R14	R13	K56
+      0x8C400339,  //  0157  GETMET	R16	R1	K57
+      0x7C400200,  //  0158  CALL	R16	1
+      0x7C380400,  //  0159  CALL	R14	2
+      0xB83A0200,  //  015A  GETNGBL	R14	K1
+      0x88381D02,  //  015B  GETMBR	R14	R14	K2
+      0x8C381D3A,  //  015C  GETMET	R14	R14	K58
+      0x5C401000,  //  015D  MOVE	R16	R8
+      0x7C380400,  //  015E  CALL	R14	2
+      0x8C3C1D3B,  //  015F  GETMET	R15	R14	K59
+      0x54460005,  //  0160  LDINT	R17	6
+      0x7C3C0400,  //  0161  CALL	R15	2
+      0x8C401F06,  //  0162  GETMET	R16	R15	K6
+      0x544A0014,  //  0163  LDINT	R18	21
+      0x7C400400,  //  0164  CALL	R16	2
+      0x8C441F06,  //  0165  GETMET	R17	R15	K6
+      0x544E0010,  //  0166  LDINT	R19	17
+      0x7C440400,  //  0167  CALL	R17	2
+      0x5C482000,  //  0168  MOVE	R18	R16
+      0x784A0001,  //  0169  JMPF	R18	#016C
+      0x5C482200,  //  016A  MOVE	R18	R17
+      0x744A0006,  //  016B  JMPT	R18	#0173
+      0xB84A4600,  //  016C  GETNGBL	R18	K35
+      0x8C48252E,  //  016D  GETMET	R18	R18	K46
+      0x5850003C,  //  016E  LDCONST	R20	K60
+      0x5854000E,  //  016F  LDCONST	R21	K14
+      0x7C480600,  //  0170  CALL	R18	3
+      0x50480000,  //  0171  LDBOOL	R18	0	0
+      0x80042400,  //  0172  RET	1	R18
+      0x60480004,  //  0173  GETGBL	R18	G4
+      0x5C4C2000,  //  0174  MOVE	R19	R16
+      0x7C480200,  //  0175  CALL	R18	1
+      0x1C48253D,  //  0176  EQ	R18	R18	K61
+      0x784A0007,  //  0177  JMPF	R18	#0180
+      0xB84A7C00,  //  0178  GETNGBL	R18	K62
+      0x8C48253F,  //  0179  GETMET	R18	R18	K63
+      0x5C502000,  //  017A  MOVE	R20	R16
+      0x7C480400,  //  017B  CALL	R18	2
+      0x8C482540,  //  017C  GETMET	R18	R18	K64
+      0x7C480200,  //  017D  CALL	R18	1
+      0x5C402400,  //  017E  MOVE	R16	R18
+      0x70020002,  //  017F  JMP		#0183
+      0x8C482140,  //  0180  GETMET	R18	R16	K64
+      0x7C480200,  //  0181  CALL	R18	1
+      0x5C402400,  //  0182  MOVE	R16	R18
+      0x60480004,  //  0183  GETGBL	R18	G4
+      0x5C4C2200,  //  0184  MOVE	R19	R17
+      0x7C480200,  //  0185  CALL	R18	1
+      0x1C48253D,  //  0186  EQ	R18	R18	K61
+      0x784A0007,  //  0187  JMPF	R18	#0190
+      0xB84A7C00,  //  0188  GETNGBL	R18	K62
+      0x8C48253F,  //  0189  GETMET	R18	R18	K63
+      0x5C502200,  //  018A  MOVE	R20	R17
+      0x7C480400,  //  018B  CALL	R18	2
+      0x8C482540,  //  018C  GETMET	R18	R18	K64
+      0x7C480200,  //  018D  CALL	R18	1
+      0x5C442400,  //  018E  MOVE	R17	R18
+      0x70020002,  //  018F  JMP		#0193
+      0x8C482340,  //  0190  GETMET	R18	R17	K64
+      0x7C480200,  //  0191  CALL	R18	1
+      0x5C442400,  //  0192  MOVE	R17	R18
+      0x8C480341,  //  0193  GETMET	R18	R1	K65
+      0x7C480200,  //  0194  CALL	R18	1
+      0x404E0F42,  //  0195  CONNECT	R19	K7	K66
+      0x94482413,  //  0196  GETIDX	R18	R18	R19
+      0x60500015,  //  0197  GETGBL	R20	G21
+      0x7C500000,  //  0198  CALL	R20	0
+      0x8C502943,  //  0199  GETMET	R20	R20	K67
+      0x58580044,  //  019A  LDCONST	R22	K68
+      0x7C500400,  //  019B  CALL	R20	2
+      0x5C4C2800,  //  019C  MOVE	R19	R20
+      0x8C500945,  //  019D  GETMET	R20	R4	K69
+      0x7C500200,  //  019E  CALL	R20	1
+      0x8C542146,  //  019F  GETMET	R21	R16	K70
+      0x7C540200,  //  01A0  CALL	R21	1
+      0x8C542B47,  //  01A1  GETMET	R21	R21	K71
+      0x7C540200,  //  01A2  CALL	R21	1
+      0x8C582948,  //  01A3  GETMET	R22	R20	K72
+      0x5C602400,  //  01A4  MOVE	R24	R18
+      0x5C642A00,  //  01A5  MOVE	R25	R21
+      0x5C682600,  //  01A6  MOVE	R26	R19
+      0x546E0007,  //  01A7  LDINT	R27	8
+      0x7C580A00,  //  01A8  CALL	R22	5
+      0x885C0313,  //  01A9  GETMBR	R23	R1	K19
+      0x785E0001,  //  01AA  JMPF	R23	#01AD
+      0x885C0313,  //  01AB  GETMBR	R23	R1	K19
+      0x70020001,  //  01AC  JMP		#01AF
+      0x885C0117,  //  01AD  GETMBR	R23	R0	K23
+      0x885C2F49,  //  01AE  GETMBR	R23	R23	K73
+      0x8C601B4A,  //  01AF  GETMET	R24	R13	K74
+      0x5C682000,  //  01B0  MOVE	R26	R16
+      0x5C6C2200,  //  01B1  MOVE	R27	R17
+      0x5C702C00,  //  01B2  MOVE	R28	R22
+      0x5C742E00,  //  01B3  MOVE	R29	R23
+      0x7C600A00,  //  01B4  CALL	R24	5
+      0x8C601B4B,  //  01B5  GETMET	R24	R13	K75
       0x7C600200,  //  01B6  CALL	R24	1
-      0x78620002,  //  01B7  JMPF	R24	#01BB
-      0x8C60034C,  //  01B8  GETMET	R24	R1	K76
-      0x546A003B,  //  01B9  LDINT	R26	60
+      0x88600117,  //  01B7  GETMBR	R24	R0	K23
+      0x8C60314C,  //  01B8  GETMET	R24	R24	K76
+      0x5C681A00,  //  01B9  MOVE	R26	R13
       0x7C600400,  //  01BA  CALL	R24	2
-      0x8C601B4D,  //  01BB  GETMET	R24	R13	K77
+      0x8C60034D,  //  01BB  GETMET	R24	R1	K77
       0x7C600200,  //  01BC  CALL	R24	1
-      0x8C600B09,  //  01BD  GETMET	R24	R5	K9
-      0x7C600200,  //  01BE  CALL	R24	1
-      0x8C64310A,  //  01BF  GETMET	R25	R24	K10
-      0x586C0005,  //  01C0  LDCONST	R27	K5
-      0x88700B0B,  //  01C1  GETMBR	R28	R5	K11
-      0xB8760200,  //  01C2  GETNGBL	R29	K1
-      0x88743B2B,  //  01C3  GETMBR	R29	R29	K43
-      0x7C640800,  //  01C4  CALL	R25	4
+      0x78620002,  //  01BD  JMPF	R24	#01C1
+      0x8C60034E,  //  01BE  GETMET	R24	R1	K78
+      0x546A003B,  //  01BF  LDINT	R26	60
+      0x7C600400,  //  01C0  CALL	R24	2
+      0x8C601B4F,  //  01C1  GETMET	R24	R13	K79
+      0x7C600200,  //  01C2  CALL	R24	1
+      0x8C600B09,  //  01C3  GETMET	R24	R5	K9
+      0x7C600200,  //  01C4  CALL	R24	1
       0x8C64310A,  //  01C5  GETMET	R25	R24	K10
-      0x586C0007,  //  01C6  LDCONST	R27	K7
+      0x586C0005,  //  01C6  LDCONST	R27	K5
       0x88700B0B,  //  01C7  GETMBR	R28	R5	K11
-      0x58740007,  //  01C8  LDCONST	R29	K7
-      0x7C640800,  //  01C9  CALL	R25	4
-      0x54660007,  //  01CA  LDINT	R25	8
-      0x900E0819,  //  01CB  SETMBR	R3	K4	R25
-      0x80043000,  //  01CC  RET	1	R24
-      0x70020056,  //  01CD  JMP		#0225
-      0x54220008,  //  01CE  LDINT	R8	9
-      0x1C200E08,  //  01CF  EQ	R8	R7	R8
-      0x7822001E,  //  01D0  JMPF	R8	#01F0
-      0x8C200506,  //  01D1  GETMET	R8	R2	K6
-      0x58280005,  //  01D2  LDCONST	R10	K5
-      0x7C200400,  //  01D3  CALL	R8	2
-      0x8C24034E,  //  01D4  GETMET	R9	R1	K78
-      0x5C2C1000,  //  01D5  MOVE	R11	R8
-      0x7C240400,  //  01D6  CALL	R9	2
-      0xB8264200,  //  01D7  GETNGBL	R9	K33
-      0x8C24132C,  //  01D8  GETMET	R9	R9	K44
-      0x602C0018,  //  01D9  GETGBL	R11	G24
-      0x5830004F,  //  01DA  LDCONST	R12	K79
-      0x88340311,  //  01DB  GETMBR	R13	R1	K17
-      0x8C341B50,  //  01DC  GETMET	R13	R13	K80
-      0x7C340200,  //  01DD  CALL	R13	1
-      0x8C341B44,  //  01DE  GETMET	R13	R13	K68
-      0x7C340200,  //  01DF  CALL	R13	1
-      0x8C341B45,  //  01E0  GETMET	R13	R13	K69
-      0x7C340200,  //  01E1  CALL	R13	1
-      0x8C341B51,  //  01E2  GETMET	R13	R13	K81
+      0xB8760200,  //  01C8  GETNGBL	R29	K1
+      0x88743B2D,  //  01C9  GETMBR	R29	R29	K45
+      0x7C640800,  //  01CA  CALL	R25	4
+      0x8C64310A,  //  01CB  GETMET	R25	R24	K10
+      0x586C0007,  //  01CC  LDCONST	R27	K7
+      0x88700B0B,  //  01CD  GETMBR	R28	R5	K11
+      0x58740007,  //  01CE  LDCONST	R29	K7
+      0x7C640800,  //  01CF  CALL	R25	4
+      0x54660007,  //  01D0  LDINT	R25	8
+      0x900E0819,  //  01D1  SETMBR	R3	K4	R25
+      0x80043000,  //  01D2  RET	1	R24
+      0x70020056,  //  01D3  JMP		#022B
+      0x54220008,  //  01D4  LDINT	R8	9
+      0x1C200E08,  //  01D5  EQ	R8	R7	R8
+      0x7822001E,  //  01D6  JMPF	R8	#01F6
+      0x8C200506,  //  01D7  GETMET	R8	R2	K6
+      0x58280005,  //  01D8  LDCONST	R10	K5
+      0x7C200400,  //  01D9  CALL	R8	2
+      0x8C240350,  //  01DA  GETMET	R9	R1	K80
+      0x5C2C1000,  //  01DB  MOVE	R11	R8
+      0x7C240400,  //  01DC  CALL	R9	2
+      0xB8264600,  //  01DD  GETNGBL	R9	K35
+      0x8C24132E,  //  01DE  GETMET	R9	R9	K46
+      0x602C0018,  //  01DF  GETGBL	R11	G24
+      0x58300051,  //  01E0  LDCONST	R12	K81
+      0x88340313,  //  01E1  GETMBR	R13	R1	K19
+      0x8C341B52,  //  01E2  GETMET	R13	R13	K82
       0x7C340200,  //  01E3  CALL	R13	1
-      0x60380008,  //  01E4  GETGBL	R14	G8
-      0x5C3C1000,  //  01E5  MOVE	R15	R8
-      0x7C380200,  //  01E6  CALL	R14	1
-      0x7C2C0600,  //  01E7  CALL	R11	3
-      0x58300010,  //  01E8  LDCONST	R12	K16
-      0x7C240600,  //  01E9  CALL	R9	3
-      0xB8260200,  //  01EA  GETNGBL	R9	K1
-      0x8824132B,  //  01EB  GETMBR	R9	R9	K43
-      0x900E3209,  //  01EC  SETMBR	R3	K25	R9
-      0x4C240000,  //  01ED  LDNIL	R9
-      0x80041200,  //  01EE  RET	1	R9
-      0x70020034,  //  01EF  JMP		#0225
-      0x54220009,  //  01F0  LDINT	R8	10
-      0x1C200E08,  //  01F1  EQ	R8	R7	R8
-      0x78220031,  //  01F2  JMPF	R8	#0225
-      0x8C200506,  //  01F3  GETMET	R8	R2	K6
-      0x58280005,  //  01F4  LDCONST	R10	K5
-      0x7C200400,  //  01F5  CALL	R8	2
-      0x60240008,  //  01F6  GETGBL	R9	G8
-      0x5C281000,  //  01F7  MOVE	R10	R8
-      0x7C240200,  //  01F8  CALL	R9	1
-      0x0026A409,  //  01F9  ADD	R9	K82	R9
-      0x900E5809,  //  01FA  SETMBR	R3	K44	R9
-      0x60240010,  //  01FB  GETGBL	R9	G16
-      0x88280115,  //  01FC  GETMBR	R10	R0	K21
-      0x88281530,  //  01FD  GETMBR	R10	R10	K48
-      0x8C281553,  //  01FE  GETMET	R10	R10	K83
-      0x7C280200,  //  01FF  CALL	R10	1
-      0x7C240200,  //  0200  CALL	R9	1
-      0xA8020010,  //  0201  EXBLK	0	#0213
-      0x5C281200,  //  0202  MOVE	R10	R9
-      0x7C280000,  //  0203  CALL	R10	0
-      0x8C2C1554,  //  0204  GETMET	R11	R10	K84
-      0x7C2C0200,  //  0205  CALL	R11	1
-      0x1C2C1608,  //  0206  EQ	R11	R11	R8
-      0x782E0008,  //  0207  JMPF	R11	#0211
-      0xB82E4200,  //  0208  GETNGBL	R11	K33
-      0x8C2C1755,  //  0209  GETMET	R11	R11	K85
-      0x543607CF,  //  020A  LDINT	R13	2000
-      0x84380000,  //  020B  CLOSURE	R14	P0
-      0x7C2C0600,  //  020C  CALL	R11	3
-      0x502C0200,  //  020D  LDBOOL	R11	1	0
-      0xA0000000,  //  020E  CLOSE	R0
-      0xA8040001,  //  020F  EXBLK	1	1
-      0x80041600,  //  0210  RET	1	R11
-      0xA0240000,  //  0211  CLOSE	R9
-      0x7001FFEE,  //  0212  JMP		#0202
-      0x58240056,  //  0213  LDCONST	R9	K86
-      0xAC240200,  //  0214  CATCH	R9	1	0
-      0xB0080000,  //  0215  RAISE	2	R0	R0
-      0xB8264200,  //  0216  GETNGBL	R9	K33
-      0x8C24132C,  //  0217  GETMET	R9	R9	K44
-      0x602C0008,  //  0218  GETGBL	R11	G8
-      0x5C301000,  //  0219  MOVE	R12	R8
-      0x7C2C0200,  //  021A  CALL	R11	1
-      0x002EAE0B,  //  021B  ADD	R11	K87	R11
-      0x002C1758,  //  021C  ADD	R11	R11	K88
-      0x5830000E,  //  021D  LDCONST	R12	K14
-      0x7C240600,  //  021E  CALL	R9	3
-      0xB8260200,  //  021F  GETNGBL	R9	K1
-      0x88241359,  //  0220  GETMBR	R9	R9	K89
-      0x900E3209,  //  0221  SETMBR	R3	K25	R9
-      0x4C240000,  //  0222  LDNIL	R9
-      0xA0000000,  //  0223  CLOSE	R0
-      0x80041200,  //  0224  RET	1	R9
-      0x7002009B,  //  0225  JMP		#02C2
-      0x5422003B,  //  0226  LDINT	R8	60
-      0x1C200C08,  //  0227  EQ	R8	R6	R8
-      0x78220085,  //  0228  JMPF	R8	#02AF
-      0x1C200F05,  //  0229  EQ	R8	R7	K5
-      0x78220065,  //  022A  JMPF	R8	#0291
-      0x8C200506,  //  022B  GETMET	R8	R2	K6
-      0x58280005,  //  022C  LDCONST	R10	K5
-      0x7C200400,  //  022D  CALL	R8	2
-      0x8C240506,  //  022E  GETMET	R9	R2	K6
-      0x582C0007,  //  022F  LDCONST	R11	K7
-      0x7C240400,  //  0230  CALL	R9	2
-      0x8C280506,  //  0231  GETMET	R10	R2	K6
-      0x5830000E,  //  0232  LDCONST	R12	K14
-      0x7C280400,  //  0233  CALL	R10	2
-      0x8C2C0506,  //  0234  GETMET	R11	R2	K6
-      0x58340010,  //  0235  LDCONST	R13	K16
-      0x7C2C0400,  //  0236  CALL	R11	2
-      0x8C300506,  //  0237  GETMET	R12	R2	K6
-      0x543A0003,  //  0238  LDINT	R14	4
-      0x7C300400,  //  0239  CALL	R12	2
-      0xB8364200,  //  023A  GETNGBL	R13	K33
-      0x8C341B2C,  //  023B  GETMET	R13	R13	K44
-      0x603C0018,  //  023C  GETGBL	R15	G24
-      0x5840005A,  //  023D  LDCONST	R16	K90
-      0x5C441000,  //  023E  MOVE	R17	R8
-      0x8C481351,  //  023F  GETMET	R18	R9	K81
-      0x7C480200,  //  0240  CALL	R18	1
-      0x5C4C1400,  //  0241  MOVE	R19	R10
-      0x5C501600,  //  0242  MOVE	R20	R11
-      0x8C541951,  //  0243  GETMET	R21	R12	K81
-      0x7C540200,  //  0244  CALL	R21	1
-      0x7C3C0C00,  //  0245  CALL	R15	6
-      0x54420003,  //  0246  LDINT	R16	4
-      0x7C340600,  //  0247  CALL	R13	3
-      0x4C340000,  //  0248  LDNIL	R13
-      0x1C34100D,  //  0249  EQ	R13	R8	R13
-      0x7436000B,  //  024A  JMPT	R13	#0257
-      0x4C340000,  //  024B  LDNIL	R13
-      0x1C34120D,  //  024C  EQ	R13	R9	R13
-      0x74360008,  //  024D  JMPT	R13	#0257
+      0x8C341B46,  //  01E4  GETMET	R13	R13	K70
+      0x7C340200,  //  01E5  CALL	R13	1
+      0x8C341B47,  //  01E6  GETMET	R13	R13	K71
+      0x7C340200,  //  01E7  CALL	R13	1
+      0x8C341B53,  //  01E8  GETMET	R13	R13	K83
+      0x7C340200,  //  01E9  CALL	R13	1
+      0x60380008,  //  01EA  GETGBL	R14	G8
+      0x5C3C1000,  //  01EB  MOVE	R15	R8
+      0x7C380200,  //  01EC  CALL	R14	1
+      0x7C2C0600,  //  01ED  CALL	R11	3
+      0x58300010,  //  01EE  LDCONST	R12	K16
+      0x7C240600,  //  01EF  CALL	R9	3
+      0xB8260200,  //  01F0  GETNGBL	R9	K1
+      0x8824132D,  //  01F1  GETMBR	R9	R9	K45
+      0x900E3609,  //  01F2  SETMBR	R3	K27	R9
+      0x4C240000,  //  01F3  LDNIL	R9
+      0x80041200,  //  01F4  RET	1	R9
+      0x70020034,  //  01F5  JMP		#022B
+      0x54220009,  //  01F6  LDINT	R8	10
+      0x1C200E08,  //  01F7  EQ	R8	R7	R8
+      0x78220031,  //  01F8  JMPF	R8	#022B
+      0x8C200506,  //  01F9  GETMET	R8	R2	K6
+      0x58280005,  //  01FA  LDCONST	R10	K5
+      0x7C200400,  //  01FB  CALL	R8	2
+      0x60240008,  //  01FC  GETGBL	R9	G8
+      0x5C281000,  //  01FD  MOVE	R10	R8
+      0x7C240200,  //  01FE  CALL	R9	1
+      0x0026A809,  //  01FF  ADD	R9	K84	R9
+      0x900E5C09,  //  0200  SETMBR	R3	K46	R9
+      0x60240010,  //  0201  GETGBL	R9	G16
+      0x88280117,  //  0202  GETMBR	R10	R0	K23
+      0x88281532,  //  0203  GETMBR	R10	R10	K50
+      0x8C281555,  //  0204  GETMET	R10	R10	K85
+      0x7C280200,  //  0205  CALL	R10	1
+      0x7C240200,  //  0206  CALL	R9	1
+      0xA8020010,  //  0207  EXBLK	0	#0219
+      0x5C281200,  //  0208  MOVE	R10	R9
+      0x7C280000,  //  0209  CALL	R10	0
+      0x8C2C1556,  //  020A  GETMET	R11	R10	K86
+      0x7C2C0200,  //  020B  CALL	R11	1
+      0x1C2C1608,  //  020C  EQ	R11	R11	R8
+      0x782E0008,  //  020D  JMPF	R11	#0217
+      0xB82E4600,  //  020E  GETNGBL	R11	K35
+      0x8C2C1757,  //  020F  GETMET	R11	R11	K87
+      0x543607CF,  //  0210  LDINT	R13	2000
+      0x84380000,  //  0211  CLOSURE	R14	P0
+      0x7C2C0600,  //  0212  CALL	R11	3
+      0x502C0200,  //  0213  LDBOOL	R11	1	0
+      0xA0000000,  //  0214  CLOSE	R0
+      0xA8040001,  //  0215  EXBLK	1	1
+      0x80041600,  //  0216  RET	1	R11
+      0xA0240000,  //  0217  CLOSE	R9
+      0x7001FFEE,  //  0218  JMP		#0208
+      0x58240058,  //  0219  LDCONST	R9	K88
+      0xAC240200,  //  021A  CATCH	R9	1	0
+      0xB0080000,  //  021B  RAISE	2	R0	R0
+      0xB8264600,  //  021C  GETNGBL	R9	K35
+      0x8C24132E,  //  021D  GETMET	R9	R9	K46
+      0x602C0008,  //  021E  GETGBL	R11	G8
+      0x5C301000,  //  021F  MOVE	R12	R8
+      0x7C2C0200,  //  0220  CALL	R11	1
+      0x002EB20B,  //  0221  ADD	R11	K89	R11
+      0x002C175A,  //  0222  ADD	R11	R11	K90
+      0x5830000E,  //  0223  LDCONST	R12	K14
+      0x7C240600,  //  0224  CALL	R9	3
+      0xB8260200,  //  0225  GETNGBL	R9	K1
+      0x8824135B,  //  0226  GETMBR	R9	R9	K91
+      0x900E3609,  //  0227  SETMBR	R3	K27	R9
+      0x4C240000,  //  0228  LDNIL	R9
+      0xA0000000,  //  0229  CLOSE	R0
+      0x80041200,  //  022A  RET	1	R9
+      0x7002009B,  //  022B  JMP		#02C8
+      0x5422003B,  //  022C  LDINT	R8	60
+      0x1C200C08,  //  022D  EQ	R8	R6	R8
+      0x78220085,  //  022E  JMPF	R8	#02B5
+      0x1C200F05,  //  022F  EQ	R8	R7	K5
+      0x78220065,  //  0230  JMPF	R8	#0297
+      0x8C200506,  //  0231  GETMET	R8	R2	K6
+      0x58280005,  //  0232  LDCONST	R10	K5
+      0x7C200400,  //  0233  CALL	R8	2
+      0x8C240506,  //  0234  GETMET	R9	R2	K6
+      0x582C0007,  //  0235  LDCONST	R11	K7
+      0x7C240400,  //  0236  CALL	R9	2
+      0x8C280506,  //  0237  GETMET	R10	R2	K6
+      0x5830000E,  //  0238  LDCONST	R12	K14
+      0x7C280400,  //  0239  CALL	R10	2
+      0x8C2C0506,  //  023A  GETMET	R11	R2	K6
+      0x58340010,  //  023B  LDCONST	R13	K16
+      0x7C2C0400,  //  023C  CALL	R11	2
+      0x8C300506,  //  023D  GETMET	R12	R2	K6
+      0x543A0003,  //  023E  LDINT	R14	4
+      0x7C300400,  //  023F  CALL	R12	2
+      0xB8364600,  //  0240  GETNGBL	R13	K35
+      0x8C341B2E,  //  0241  GETMET	R13	R13	K46
+      0x603C0018,  //  0242  GETGBL	R15	G24
+      0x5840005C,  //  0243  LDCONST	R16	K92
+      0x5C441000,  //  0244  MOVE	R17	R8
+      0x8C481353,  //  0245  GETMET	R18	R9	K83
+      0x7C480200,  //  0246  CALL	R18	1
+      0x5C4C1400,  //  0247  MOVE	R19	R10
+      0x5C501600,  //  0248  MOVE	R20	R11
+      0x8C541953,  //  0249  GETMET	R21	R12	K83
+      0x7C540200,  //  024A  CALL	R21	1
+      0x7C3C0C00,  //  024B  CALL	R15	6
+      0x54420003,  //  024C  LDINT	R16	4
+      0x7C340600,  //  024D  CALL	R13	3
       0x4C340000,  //  024E  LDNIL	R13
-      0x1C34140D,  //  024F  EQ	R13	R10	R13
-      0x74360005,  //  0250  JMPT	R13	#0257
+      0x1C34100D,  //  024F  EQ	R13	R8	R13
+      0x7436000B,  //  0250  JMPT	R13	#025D
       0x4C340000,  //  0251  LDNIL	R13
-      0x1C34160D,  //  0252  EQ	R13	R11	R13
-      0x74360002,  //  0253  JMPT	R13	#0257
+      0x1C34120D,  //  0252  EQ	R13	R9	R13
+      0x74360008,  //  0253  JMPT	R13	#025D
       0x4C340000,  //  0254  LDNIL	R13
-      0x1C34180D,  //  0255  EQ	R13	R12	R13
-      0x78360005,  //  0256  JMPF	R13	#025D
-      0xB8360200,  //  0257  GETNGBL	R13	K1
-      0x88341B5B,  //  0258  GETMBR	R13	R13	K91
-      0x900E320D,  //  0259  SETMBR	R3	K25	R13
+      0x1C34140D,  //  0255  EQ	R13	R10	R13
+      0x74360005,  //  0256  JMPT	R13	#025D
+      0x4C340000,  //  0257  LDNIL	R13
+      0x1C34160D,  //  0258  EQ	R13	R11	R13
+      0x74360002,  //  0259  JMPT	R13	#025D
       0x4C340000,  //  025A  LDNIL	R13
-      0xA0000000,  //  025B  CLOSE	R0
-      0x80041A00,  //  025C  RET	1	R13
-      0x6034000C,  //  025D  GETGBL	R13	G12
-      0x5C381200,  //  025E  MOVE	R14	R9
-      0x7C340200,  //  025F  CALL	R13	1
-      0x543A001F,  //  0260  LDINT	R14	32
-      0x543E0040,  //  0261  LDINT	R15	65
-      0x00381C0F,  //  0262  ADD	R14	R14	R15
-      0x20341A0E,  //  0263  NE	R13	R13	R14
-      0x7436000B,  //  0264  JMPT	R13	#0271
-      0x6034000C,  //  0265  GETGBL	R13	G12
-      0x5C381800,  //  0266  MOVE	R14	R12
-      0x7C340200,  //  0267  CALL	R13	1
-      0x543A000F,  //  0268  LDINT	R14	16
-      0x14341A0E,  //  0269  LT	R13	R13	R14
-      0x74360005,  //  026A  JMPT	R13	#0271
+      0x1C34180D,  //  025B  EQ	R13	R12	R13
+      0x78360005,  //  025C  JMPF	R13	#0263
+      0xB8360200,  //  025D  GETNGBL	R13	K1
+      0x88341B5D,  //  025E  GETMBR	R13	R13	K93
+      0x900E360D,  //  025F  SETMBR	R3	K27	R13
+      0x4C340000,  //  0260  LDNIL	R13
+      0xA0000000,  //  0261  CLOSE	R0
+      0x80041A00,  //  0262  RET	1	R13
+      0x6034000C,  //  0263  GETGBL	R13	G12
+      0x5C381200,  //  0264  MOVE	R14	R9
+      0x7C340200,  //  0265  CALL	R13	1
+      0x543A001F,  //  0266  LDINT	R14	32
+      0x543E0040,  //  0267  LDINT	R15	65
+      0x00381C0F,  //  0268  ADD	R14	R14	R15
+      0x20341A0E,  //  0269  NE	R13	R13	R14
+      0x7436000B,  //  026A  JMPT	R13	#0277
       0x6034000C,  //  026B  GETGBL	R13	G12
       0x5C381800,  //  026C  MOVE	R14	R12
       0x7C340200,  //  026D  CALL	R13	1
-      0x543A001F,  //  026E  LDINT	R14	32
-      0x24341A0E,  //  026F  GT	R13	R13	R14
-      0x7836000A,  //  0270  JMPF	R13	#027C
-      0xB8364200,  //  0271  GETNGBL	R13	K33
-      0x8C341B2C,  //  0272  GETMET	R13	R13	K44
-      0x583C005C,  //  0273  LDCONST	R15	K92
-      0x5840000E,  //  0274  LDCONST	R16	K14
-      0x7C340600,  //  0275  CALL	R13	3
-      0xB8360200,  //  0276  GETNGBL	R13	K1
-      0x88341B5D,  //  0277  GETMBR	R13	R13	K93
-      0x900E320D,  //  0278  SETMBR	R3	K25	R13
-      0x4C340000,  //  0279  LDNIL	R13
-      0xA0000000,  //  027A  CLOSE	R0
-      0x80041A00,  //  027B  RET	1	R13
-      0x5436001E,  //  027C  LDINT	R13	31
-      0x40360A0D,  //  027D  CONNECT	R13	K5	R13
-      0x9434120D,  //  027E  GETIDX	R13	R9	R13
-      0x543A001F,  //  027F  LDINT	R14	32
-      0x40381D40,  //  0280  CONNECT	R14	R14	K64
-      0x9438120E,  //  0281  GETIDX	R14	R9	R14
-      0x883C0115,  //  0282  GETMBR	R15	R0	K21
-      0x8C3C1F5E,  //  0283  GETMET	R15	R15	K94
-      0x5C441000,  //  0284  MOVE	R17	R8
-      0x5C481600,  //  0285  MOVE	R18	R11
-      0x5C4C1400,  //  0286  MOVE	R19	R10
-      0x5C501800,  //  0287  MOVE	R20	R12
-      0x5C541A00,  //  0288  MOVE	R21	R13
-      0x5C581C00,  //  0289  MOVE	R22	R14
-      0x8C5C035F,  //  028A  GETMET	R23	R1	K95
-      0x7C5C0200,  //  028B  CALL	R23	1
-      0x7C3C1000,  //  028C  CALL	R15	8
-      0x503C0200,  //  028D  LDBOOL	R15	1	0
-      0xA0000000,  //  028E  CLOSE	R0
-      0x80041E00,  //  028F  RET	1	R15
-      0x7002001C,  //  0290  JMP		#02AE
-      0x1C200F07,  //  0291  EQ	R8	R7	K7
-      0x78220012,  //  0292  JMPF	R8	#02A6
-      0x8C200506,  //  0293  GETMET	R8	R2	K6
-      0x58280005,  //  0294  LDCONST	R10	K5
-      0x7C200400,  //  0295  CALL	R8	2
-      0xB8264200,  //  0296  GETNGBL	R9	K33
-      0x8C24132C,  //  0297  GETMET	R9	R9	K44
-      0x602C0008,  //  0298  GETGBL	R11	G8
-      0x5C301000,  //  0299  MOVE	R12	R8
-      0x7C2C0200,  //  029A  CALL	R11	1
-      0x002EC00B,  //  029B  ADD	R11	K96	R11
-      0x58300010,  //  029C  LDCONST	R12	K16
-      0x7C240600,  //  029D  CALL	R9	3
-      0x88240115,  //  029E  GETMBR	R9	R0	K21
-      0x8C241361,  //  029F  GETMET	R9	R9	K97
-      0x5C2C1000,  //  02A0  MOVE	R11	R8
-      0x7C240400,  //  02A1  CALL	R9	2
-      0x50240200,  //  02A2  LDBOOL	R9	1	0
-      0xA0000000,  //  02A3  CLOSE	R0
-      0x80041200,  //  02A4  RET	1	R9
-      0x70020007,  //  02A5  JMP		#02AE
-      0x1C200F0E,  //  02A6  EQ	R8	R7	K14
-      0x78220005,  //  02A7  JMPF	R8	#02AE
-      0x88200115,  //  02A8  GETMBR	R8	R0	K21
-      0x8C201162,  //  02A9  GETMET	R8	R8	K98
-      0x7C200200,  //  02AA  CALL	R8	1
-      0x50200200,  //  02AB  LDBOOL	R8	1	0
-      0xA0000000,  //  02AC  CLOSE	R0
-      0x80041000,  //  02AD  RET	1	R8
-      0x70020012,  //  02AE  JMP		#02C2
-      0x54220029,  //  02AF  LDINT	R8	42
-      0x1C200C08,  //  02B0  EQ	R8	R6	R8
-      0x78220005,  //  02B1  JMPF	R8	#02B8
-      0x1C200F05,  //  02B2  EQ	R8	R7	K5
-      0x78220002,  //  02B3  JMPF	R8	#02B7
-      0x50200200,  //  02B4  LDBOOL	R8	1	0
-      0xA0000000,  //  02B5  CLOSE	R0
-      0x80041000,  //  02B6  RET	1	R8
-      0x70020009,  //  02B7  JMP		#02C2
-      0x60200003,  //  02B8  GETGBL	R8	G3
-      0x5C240000,  //  02B9  MOVE	R9	R0
-      0x7C200200,  //  02BA  CALL	R8	1
-      0x8C201163,  //  02BB  GETMET	R8	R8	K99
-      0x5C280200,  //  02BC  MOVE	R10	R1
-      0x5C2C0400,  //  02BD  MOVE	R11	R2
-      0x5C300600,  //  02BE  MOVE	R12	R3
-      0x7C200800,  //  02BF  CALL	R8	4
-      0xA0000000,  //  02C0  CLOSE	R0
-      0x80041000,  //  02C1  RET	1	R8
-      0xA0000000,  //  02C2  CLOSE	R0
-      0x80000000,  //  02C3  RET	0
+      0x543A000F,  //  026E  LDINT	R14	16
+      0x14341A0E,  //  026F  LT	R13	R13	R14
+      0x74360005,  //  0270  JMPT	R13	#0277
+      0x6034000C,  //  0271  GETGBL	R13	G12
+      0x5C381800,  //  0272  MOVE	R14	R12
+      0x7C340200,  //  0273  CALL	R13	1
+      0x543A001F,  //  0274  LDINT	R14	32
+      0x24341A0E,  //  0275  GT	R13	R13	R14
+      0x7836000A,  //  0276  JMPF	R13	#0282
+      0xB8364600,  //  0277  GETNGBL	R13	K35
+      0x8C341B2E,  //  0278  GETMET	R13	R13	K46
+      0x583C005E,  //  0279  LDCONST	R15	K94
+      0x5840000E,  //  027A  LDCONST	R16	K14
+      0x7C340600,  //  027B  CALL	R13	3
+      0xB8360200,  //  027C  GETNGBL	R13	K1
+      0x88341B5F,  //  027D  GETMBR	R13	R13	K95
+      0x900E360D,  //  027E  SETMBR	R3	K27	R13
+      0x4C340000,  //  027F  LDNIL	R13
+      0xA0000000,  //  0280  CLOSE	R0
+      0x80041A00,  //  0281  RET	1	R13
+      0x5436001E,  //  0282  LDINT	R13	31
+      0x40360A0D,  //  0283  CONNECT	R13	K5	R13
+      0x9434120D,  //  0284  GETIDX	R13	R9	R13
+      0x543A001F,  //  0285  LDINT	R14	32
+      0x40381D42,  //  0286  CONNECT	R14	R14	K66
+      0x9438120E,  //  0287  GETIDX	R14	R9	R14
+      0x883C0117,  //  0288  GETMBR	R15	R0	K23
+      0x8C3C1F60,  //  0289  GETMET	R15	R15	K96
+      0x5C441000,  //  028A  MOVE	R17	R8
+      0x5C481600,  //  028B  MOVE	R18	R11
+      0x5C4C1400,  //  028C  MOVE	R19	R10
+      0x5C501800,  //  028D  MOVE	R20	R12
+      0x5C541A00,  //  028E  MOVE	R21	R13
+      0x5C581C00,  //  028F  MOVE	R22	R14
+      0x8C5C0361,  //  0290  GETMET	R23	R1	K97
+      0x7C5C0200,  //  0291  CALL	R23	1
+      0x7C3C1000,  //  0292  CALL	R15	8
+      0x503C0200,  //  0293  LDBOOL	R15	1	0
+      0xA0000000,  //  0294  CLOSE	R0
+      0x80041E00,  //  0295  RET	1	R15
+      0x7002001C,  //  0296  JMP		#02B4
+      0x1C200F07,  //  0297  EQ	R8	R7	K7
+      0x78220012,  //  0298  JMPF	R8	#02AC
+      0x8C200506,  //  0299  GETMET	R8	R2	K6
+      0x58280005,  //  029A  LDCONST	R10	K5
+      0x7C200400,  //  029B  CALL	R8	2
+      0xB8264600,  //  029C  GETNGBL	R9	K35
+      0x8C24132E,  //  029D  GETMET	R9	R9	K46
+      0x602C0008,  //  029E  GETGBL	R11	G8
+      0x5C301000,  //  029F  MOVE	R12	R8
+      0x7C2C0200,  //  02A0  CALL	R11	1
+      0x002EC40B,  //  02A1  ADD	R11	K98	R11
+      0x58300010,  //  02A2  LDCONST	R12	K16
+      0x7C240600,  //  02A3  CALL	R9	3
+      0x88240117,  //  02A4  GETMBR	R9	R0	K23
+      0x8C241363,  //  02A5  GETMET	R9	R9	K99
+      0x5C2C1000,  //  02A6  MOVE	R11	R8
+      0x7C240400,  //  02A7  CALL	R9	2
+      0x50240200,  //  02A8  LDBOOL	R9	1	0
+      0xA0000000,  //  02A9  CLOSE	R0
+      0x80041200,  //  02AA  RET	1	R9
+      0x70020007,  //  02AB  JMP		#02B4
+      0x1C200F0E,  //  02AC  EQ	R8	R7	K14
+      0x78220005,  //  02AD  JMPF	R8	#02B4
+      0x88200117,  //  02AE  GETMBR	R8	R0	K23
+      0x8C201164,  //  02AF  GETMET	R8	R8	K100
+      0x7C200200,  //  02B0  CALL	R8	1
+      0x50200200,  //  02B1  LDBOOL	R8	1	0
+      0xA0000000,  //  02B2  CLOSE	R0
+      0x80041000,  //  02B3  RET	1	R8
+      0x70020012,  //  02B4  JMP		#02C8
+      0x54220029,  //  02B5  LDINT	R8	42
+      0x1C200C08,  //  02B6  EQ	R8	R6	R8
+      0x78220005,  //  02B7  JMPF	R8	#02BE
+      0x1C200F05,  //  02B8  EQ	R8	R7	K5
+      0x78220002,  //  02B9  JMPF	R8	#02BD
+      0x50200200,  //  02BA  LDBOOL	R8	1	0
+      0xA0000000,  //  02BB  CLOSE	R0
+      0x80041000,  //  02BC  RET	1	R8
+      0x70020009,  //  02BD  JMP		#02C8
+      0x60200003,  //  02BE  GETGBL	R8	G3
+      0x5C240000,  //  02BF  MOVE	R9	R0
+      0x7C200200,  //  02C0  CALL	R8	1
+      0x8C201165,  //  02C1  GETMET	R8	R8	K101
+      0x5C280200,  //  02C2  MOVE	R10	R1
+      0x5C2C0400,  //  02C3  MOVE	R11	R2
+      0x5C300600,  //  02C4  MOVE	R12	R3
+      0x7C200800,  //  02C5  CALL	R8	4
+      0xA0000000,  //  02C6  CLOSE	R0
+      0x80041000,  //  02C7  RET	1	R8
+      0xA0000000,  //  02C8  CLOSE	R0
+      0x80000000,  //  02C9  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

To slightly improve latency of commands, an independent Ack packet is not sent anymore, the Ack is part of the response. Only request with longer processing time send a first Ack; currently: `CSRRequest` and `CommissioningComplete`

Also added in logs when `duplicate` packets are sent, which means that the Ack wasn't sent fast enough.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
