### PR TITLE
Restart 4 option to do a ESP.deepSleep(0)

### DIFF
--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -1151,6 +1151,9 @@ void CmndRestart(void)
     }
     break;
 #endif  // ESP32
+  case 4:
+    ESP.deepSleep(0);  // deep sleep mode with only hardware triggered wake up
+    break;
   case -1:
     CmndCrash();    // force a crash
     break;


### PR DESCRIPTION
## Description:
Implementing a "restart 4" option in order to put tasmota into deep sleep without wake up time for usage in battery dependent use cases where deep sleep wake up should only happen by hardware triggers. 

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
https://github.com/arendst/Tasmota/discussions/19016

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_