### PR TITLE
[DS18x20] Enhance use of aliases

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_05_ds18x20.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_05_ds18x20.ino
@@ -50,6 +50,8 @@
 #define DS18X20_MAX_SENSORS  8
 #endif
 
+#define DS18X20_ALIAS_LEN    17
+
 const char kDs18x20Types[] PROGMEM = "DS18x20|DS18S20|DS1822|DS18B20|MAX31850";
 
 uint8_t ds18x20_chipids[] = { 0, DS18S20_CHIPID, DS1822_CHIPID, DS18B20_CHIPID, MAX31850_CHIPID };
@@ -63,7 +65,7 @@ struct {
   uint8_t valid;
   int8_t pins_id;
 #ifdef DS18x20_USE_ID_ALIAS
-  char alias[17] = "0";
+  char *alias = (char*)calloc(DS18X20_ALIAS_LEN, 1);
 #endif  // DS18x20_USE_ID_ALIAS
 } ds18x20_sensor[DS18X20_MAX_SENSORS];
 
@@ -357,6 +359,9 @@ void Ds18x20Init(void) {
         for (uint32_t j = 6; j > 0; j--) {
           ids[DS18X20Data.sensors] = ids[DS18X20Data.sensors] << 8 | ds18x20_sensor[DS18X20Data.sensors].address[j];
         }
+#ifdef DS18x20_USE_ID_ALIAS
+        ds18x20_sensor[DS18X20Data.sensors].alias[0] = '0';
+#endif
         ds18x20_sensor[DS18X20Data.sensors].pins_id = pins;
         DS18X20Data.sensors++;
       }
@@ -590,7 +595,7 @@ void CmndDSAlias(void) {
         sprintf(address+2*j, "%02X", ds18x20_sensor[i].address[7-j]);
       }
       if (!strncmp(Argument1, address, 12) && Argument2[0]) {
-        snprintf_P(ds18x20_sensor[i].alias, sizeof(ds18x20_sensor[i].alias), PSTR("%s"), Argument2);
+        snprintf_P(ds18x20_sensor[i].alias, DS18X20_ALIAS_LEN, PSTR("%s"), Argument2);
         break;
       }
     }

--- a/tasmota/tasmota_xsns_sensor/xsns_05_ds18x20.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_05_ds18x20.ino
@@ -31,7 +31,8 @@
 /* #define DS18x20_USE_ID_ALIAS in my_user_config.h or user_config_override.h
   * Use alias for fixed sensor name in scripts by autoexec. Command: DS18Alias XXXXXXXXXXXXXXXX,N where XXXXXXXXXXXXXXXX full serial and N number 1-255
   * Result in JSON:  "DS18Sens_2":{"Id":"000003287CD8","Temperature":26.3} (example with N=2)
-  * add 8 bytes used memory
+  * Setting N to an alphanumeric value, the complete name is replaced with it
+  * Result in JSON:  "Outside1":{"Id":"000003287CD8","Temperature":26.3} (example with N=Outside1)
 */
 
 #define DS18S20_CHIPID       0x10  // +/-0.5C 9-bit
@@ -62,7 +63,7 @@ struct {
   uint8_t valid;
   int8_t pins_id;
 #ifdef DS18x20_USE_ID_ALIAS
-  uint8_t alias;
+  char alias[17] = "0";
 #endif  // DS18x20_USE_ID_ALIAS
 } ds18x20_sensor[DS18X20_MAX_SENSORS];
 
@@ -356,9 +357,6 @@ void Ds18x20Init(void) {
         for (uint32_t j = 6; j > 0; j--) {
           ids[DS18X20Data.sensors] = ids[DS18X20Data.sensors] << 8 | ds18x20_sensor[DS18X20Data.sensors].address[j];
         }
-#ifdef DS18x20_USE_ID_ALIAS
-        ds18x20_sensor[DS18X20Data.sensors].alias=0;
-#endif
         ds18x20_sensor[DS18X20Data.sensors].pins_id = pins;
         DS18X20Data.sensors++;
       }
@@ -472,24 +470,28 @@ void Ds18x20Name(uint8_t sensor) {
     }
   }
   GetTextIndexed(DS18X20Data.name, sizeof(DS18X20Data.name), index, kDs18x20Types);
-  if (DS18X20Data.sensors > 1) {
+
 #ifdef DS18x20_USE_ID_AS_NAME
-    char address[17];
-    for (uint32_t j = 0; j < 3; j++) {
-      sprintf(address+2*j, "%02X", ds18x20_sensor[ds18x20_sensor[sensor].index].address[3-j]);  // Only last 3 bytes
-    }
-    snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s%c%s"), DS18X20Data.name, IndexSeparator(), address);
-#else
-uint8_t print_ind = sensor +1;
-#ifdef DS18x20_USE_ID_ALIAS
-    if (ds18x20_sensor[sensor].alias) {
-      snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("DS18Sens"));
-      print_ind = ds18x20_sensor[sensor].alias;
-    }
-#endif
-    snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s%c%d"), DS18X20Data.name, IndexSeparator(), print_ind);
-#endif
+  char address[17];
+  for (uint32_t j = 0; j < 3; j++) {
+    sprintf(address+2*j, "%02X", ds18x20_sensor[ds18x20_sensor[sensor].index].address[3-j]);  // Only last 3 bytes
   }
+  snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s%c%s"), DS18X20Data.name, IndexSeparator(), address);
+#elif defined(DS18x20_USE_ID_ALIAS)
+  if (ds18x20_sensor[sensor].alias[0] != '0') {
+    if (isdigit(ds18x20_sensor[sensor].alias[0])) {
+      snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("DS18Sens%c%d"), IndexSeparator(), atoi(ds18x20_sensor[sensor].alias));
+    } else {
+      snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s"), ds18x20_sensor[sensor].alias);
+    }
+  } else {
+    snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s%c%d"), DS18X20Data.name, IndexSeparator(), sensor + 1);
+  }
+#else // no #defines set
+  if (DS18X20Data.sensors > 1) {
+    snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s%c%d"), DS18X20Data.name, IndexSeparator(), sensor + 1);
+  }
+#endif
 }
 
 /********************************************************************************************/
@@ -574,25 +576,26 @@ void (* const DSCommand[])(void) PROGMEM = {
   &CmndDSAlias };
 
 void CmndDSAlias(void) {
-  uint8_t tmp;
-  uint8_t sensor=255;
-  char argument[XdrvMailbox.data_len];
+  char Argument1[XdrvMailbox.data_len];
+  char Argument2[XdrvMailbox.data_len];
   char address[17];
 
   if (ArgC()==2) {
-    tmp=atoi(ArgV(argument, 2));
-    ArgV(argument,1);
+    ArgV(Argument1, 1);
+    ArgV(Argument2, 2);
+    TrimSpace(Argument2);
 
     for (uint32_t i = 0; i < DS18X20Data.sensors; i++) {
       for (uint32_t j = 0; j < 8; j++) {
         sprintf(address+2*j, "%02X", ds18x20_sensor[i].address[7-j]);
       }
-      if (!strncmp(argument,address,12)) {
-        ds18x20_sensor[i].alias=tmp;
+      if (!strncmp(Argument1, address, 12) && Argument2[0]) {
+        snprintf_P(ds18x20_sensor[i].alias, sizeof(ds18x20_sensor[i].alias), PSTR("%s"), Argument2);
         break;
       }
     }
   }
+
   Response_P(PSTR("{"));
   for (uint32_t i = 0; i < DS18X20Data.sensors; i++) {
     Ds18x20Name(i);
@@ -601,7 +604,7 @@ void CmndDSAlias(void) {
       sprintf(address+2*j, "%02X", ds18x20_sensor[i].address[7-j]);  // Skip sensor type and crc
     }
     ResponseAppend_P(PSTR("\"%s\":{\"" D_JSON_ID "\":\"%s\"}"),DS18X20Data.name, address);
-    if (i < DS18X20Data.sensors-1) {ResponseAppend_P(PSTR(","));}
+    if (i < DS18X20Data.sensors-1) ResponseAppend_P(PSTR(","));
   }
   ResponseAppend_P(PSTR("}"));
 }

--- a/tasmota/tasmota_xsns_sensor/xsns_05_esp32_ds18x20.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_05_esp32_ds18x20.ino
@@ -29,8 +29,9 @@
 
 /* #define DS18x20_USE_ID_ALIAS in my_user_config.h or user_config_override.h
   * Use alias for fixed sensor name in scripts by autoexec. Command: DS18Alias XXXXXXXXXXXXXXXX,N where XXXXXXXXXXXXXXXX full serial and N number 1-255
-  * Result in JSON:  "DS18Alias_2":{"Id":"000003287CD8","Temperature":26.3} (example with N=2)
-  * add 8 bytes used memory
+  * Result in JSON:  "DS18Sens_2":{"Id":"000003287CD8","Temperature":26.3} (example with N=2)
+  * Setting N to an alphanumeric value, the complete name is replaced with it
+  * Result in JSON:  "Outside1":{"Id":"000003287CD8","Temperature":26.3} (example with N=Outside1)
 */
 
 #define DS18S20_CHIPID       0x10  // +/-0.5C 9-bit
@@ -61,7 +62,7 @@ struct {
   uint8_t valid;
   int8_t pins_id;
 #ifdef DS18x20_USE_ID_ALIAS
-  uint8_t alias;
+  char alias[17] = "0";
 #endif //DS18x20_USE_ID_ALIAS
 } ds18x20_sensor[DS18X20_MAX_SENSORS];
 
@@ -107,9 +108,6 @@ void Ds18x20Search(void) {
           (ds18x20_sensor[num_sensors].address[0] == DS1822_CHIPID) ||
           (ds18x20_sensor[num_sensors].address[0] == DS18B20_CHIPID) ||
           (ds18x20_sensor[num_sensors].address[0] == MAX31850_CHIPID))) {
-#ifdef DS18x20_USE_ID_ALIAS
-        ds18x20_sensor[num_sensors].alias=0;
-#endif
         ds18x20_sensor[num_sensors].pins_id = pins;
         num_sensors++;
       }
@@ -214,24 +212,28 @@ void Ds18x20Name(uint8_t sensor) {
     }
   }
   GetTextIndexed(DS18X20Data.name, sizeof(DS18X20Data.name), index, kDs18x20Types);
-  if (DS18X20Data.sensors > 1) {
+
 #ifdef DS18x20_USE_ID_AS_NAME
-    char address[17];
-    for (uint32_t j = 0; j < 3; j++) {
-      sprintf(address+2*j, "%02X", ds18x20_sensor[ds18x20_sensor[sensor].index].address[3-j]);  // Only last 3 bytes
-    }
-    snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s%c%s"), DS18X20Data.name, IndexSeparator(), address);
-#else
-uint8_t print_ind = sensor +1;
-#ifdef DS18x20_USE_ID_ALIAS
-    if (ds18x20_sensor[sensor].alias) {
-      snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("DS18Sens"));
-      print_ind = ds18x20_sensor[sensor].alias;
-    }
-#endif
-    snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s%c%d"), DS18X20Data.name, IndexSeparator(), print_ind);
-#endif
+  char address[17];
+  for (uint32_t j = 0; j < 3; j++) {
+    sprintf(address+2*j, "%02X", ds18x20_sensor[ds18x20_sensor[sensor].index].address[3-j]);  // Only last 3 bytes
   }
+  snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s%c%s"), DS18X20Data.name, IndexSeparator(), address);
+#elif defined(DS18x20_USE_ID_ALIAS)
+  if (ds18x20_sensor[sensor].alias[0] != '0') {
+    if (isdigit(ds18x20_sensor[sensor].alias[0])) {
+      snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("DS18Sens%c%d"), IndexSeparator(), atoi(ds18x20_sensor[sensor].alias));
+    } else {
+      snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s"), ds18x20_sensor[sensor].alias);
+    }
+  } else {
+    snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s%c%d"), DS18X20Data.name, IndexSeparator(), sensor + 1);
+  }
+#else // no #defines set
+  if (DS18X20Data.sensors > 1) {
+    snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s%c%d"), DS18X20Data.name, IndexSeparator(), sensor + 1);
+  }
+#endif
 }
 
 /********************************************************************************************/
@@ -317,25 +319,26 @@ void (* const DSCommand[])(void) PROGMEM = {
   &CmndDSAlias };
 
 void CmndDSAlias(void) {
-  uint8_t tmp;
-  uint8_t sensor=255;
-  char argument[XdrvMailbox.data_len];
+  char Argument1[XdrvMailbox.data_len];
+  char Argument2[XdrvMailbox.data_len];
   char address[17];
 
   if (ArgC()==2) {
-    tmp=atoi(ArgV(argument, 2));
-    ArgV(argument,1);
+    ArgV(Argument1, 1);
+    ArgV(Argument2, 2);
+    TrimSpace(Argument2);
 
     for (uint32_t i = 0; i < DS18X20Data.sensors; i++) {
       for (uint32_t j = 0; j < 8; j++) {
         sprintf(address+2*j, "%02X", ds18x20_sensor[i].address[7-j]);
       }
-      if (!strncmp(argument,address,12)) {
-        ds18x20_sensor[i].alias=tmp;
+      if (!strncmp(Argument1, address, 12) && Argument2[0]) {
+        snprintf_P(ds18x20_sensor[i].alias, sizeof(ds18x20_sensor[i].alias), PSTR("%s"), Argument2);
         break;
       }
     }
   }
+
   Response_P(PSTR("{"));
   for (uint32_t i = 0; i < DS18X20Data.sensors; i++) {
     Ds18x20Name(i);
@@ -344,7 +347,7 @@ void CmndDSAlias(void) {
       sprintf(address+2*j, "%02X", ds18x20_sensor[i].address[7-j]);  // Skip sensor type and crc
     }
     ResponseAppend_P(PSTR("\"%s\":{\"" D_JSON_ID "\":\"%s\"}"),DS18X20Data.name, address);
-    if (i < DS18X20Data.sensors-1) {ResponseAppend_P(PSTR(","));}
+    if (i < DS18X20Data.sensors-1) ResponseAppend_P(PSTR(","));
   }
   ResponseAppend_P(PSTR("}"));
 }

--- a/tasmota/tasmota_xsns_sensor/xsns_05_esp32_ds18x20.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_05_esp32_ds18x20.ino
@@ -47,6 +47,8 @@
 #define DS18X20_MAX_SENSORS  8
 #endif
 
+#define DS18X20_ALIAS_LEN    17
+
 const char kDs18x20Types[] PROGMEM = "DS18x20|DS18S20|DS1822|DS18B20|MAX31850";
 
 uint8_t ds18x20_chipids[] = { 0, DS18S20_CHIPID, DS1822_CHIPID, DS18B20_CHIPID, MAX31850_CHIPID };
@@ -62,7 +64,7 @@ struct {
   uint8_t valid;
   int8_t pins_id;
 #ifdef DS18x20_USE_ID_ALIAS
-  char alias[17] = "0";
+  char *alias = (char*)calloc(DS18X20_ALIAS_LEN, 1);
 #endif //DS18x20_USE_ID_ALIAS
 } ds18x20_sensor[DS18X20_MAX_SENSORS];
 
@@ -108,6 +110,9 @@ void Ds18x20Search(void) {
           (ds18x20_sensor[num_sensors].address[0] == DS1822_CHIPID) ||
           (ds18x20_sensor[num_sensors].address[0] == DS18B20_CHIPID) ||
           (ds18x20_sensor[num_sensors].address[0] == MAX31850_CHIPID))) {
+#ifdef DS18x20_USE_ID_ALIAS
+        ds18x20_sensor[DS18X20Data.sensors].alias[0] = '0';
+#endif
         ds18x20_sensor[num_sensors].pins_id = pins;
         num_sensors++;
       }
@@ -333,7 +338,7 @@ void CmndDSAlias(void) {
         sprintf(address+2*j, "%02X", ds18x20_sensor[i].address[7-j]);
       }
       if (!strncmp(Argument1, address, 12) && Argument2[0]) {
-        snprintf_P(ds18x20_sensor[i].alias, sizeof(ds18x20_sensor[i].alias), PSTR("%s"), Argument2);
+        snprintf_P(ds18x20_sensor[i].alias, DS18X20_ALIAS_LEN, PSTR("%s"), Argument2);
         break;
       }
     }


### PR DESCRIPTION
## Description:

`#define DS18x20_USE_ID_AS_NAME`: Always show part of the address, even for one sensor 
`#define DS18x20_USE_ID_ALIAS`: The command `DS18Alias` can now be use with alphanumeric aliases, which replace the sensor name

**Related issue (if applicable):** fixes #6970 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

