### PR TITLE
MI32 legacy / Berry: add wifi_probe for BLE commissioning

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
@@ -73,6 +73,9 @@ BE_FUNC_CTYPE_DECLARE(be_BLE_adv_watch, "", "@(bytes)~[i]");
 extern void be_BLE_adv_block(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type);
 BE_FUNC_CTYPE_DECLARE(be_BLE_adv_block, "", "@(bytes)~[i]");
 
+extern bbool be_BLE_wifi_probe(struct bvm *vm, const char *ssid, const char *password);
+BE_FUNC_CTYPE_DECLARE(be_BLE_wifi_probe, "b", "@ss");
+
 
 #include "be_fixed_BLE.h"
 
@@ -88,6 +91,7 @@ module BLE (scope: global) {
   adv_watch,  ctype_func(be_BLE_adv_watch)
   adv_block,  ctype_func(be_BLE_adv_block)
   serv_cb,    ctype_func(be_BLE_reg_server_cb)
+  wifi_probe, ctype_func(be_BLE_wifi_probe)
 }
 @const_object_info_end */
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
@@ -94,6 +94,10 @@ extern "C" {
     be_raise(vm, "ble_error", "BLE: device not initialized");
     be_return_nil(vm);
   }
+ 
+  bool be_BLE_wifi_probe(struct bvm *vm, const char *ssid, const char *password){
+    return WiFi.begin(ssid, password);
+  }
 
   void be_BLE_reg_conn_cb(void* function, uint8_t *buffer);
   void be_BLE_reg_conn_cb(void* function, uint8_t *buffer){    


### PR DESCRIPTION
## Description:

In order to use Bluetooth for sending Wifi credentials in initial device setup using the open standard **Improv**, it is useful to test, if an AP is really accessible at runtime - without reboot in the running Bluetooth session.
This PR adds the command `wifi_probe(string ssid, string password)`to the BLE module of Berry, that will try to connect (typically when in Tasmotas AP mode). The result can later be checked with something like `tasmota.wifi()['ip']`, that should not be "0.0.0.0" or throw an exception in the case of success.

This function is not Bluetooth specific, but at the moment there is no other known use case. That's why it gets added to an optional non-core module. If needed it should move to another module in the future.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
