### PR TITLE
Hot fix for gitpod and CI  (pio core v6.1.8 is faulty)

### DIFF
--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install wheel
-          pip install -U platformio
+          pip install -U platformio==6.1.7
       - name: Run PlatformIO
         run: platformio run -e ${{ matrix.variant }}
       - name: Upload safeboot firmware artifacts
@@ -139,7 +139,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install wheel
-          pip install -U platformio
+          pip install -U platformio==6.1.7
       - name: Run PlatformIO
         run: platformio run -e ${{ matrix.variant }}
       - name: Upload firmware artifacts
@@ -182,7 +182,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install wheel
-          pip install -U platformio
+          pip install -U platformio==6.1.7
       - name: Download safeboot firmwares
         uses: actions/download-artifact@v3
         with:
@@ -219,7 +219,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install wheel
-          pip install -U platformio
+          pip install -U platformio==6.1.7
       - name: Download safeboot firmwares
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install wheel
-          pip install -U platformio
+          pip install -U platformio==6.1.7
       - name: Run PlatformIO
         run: platformio run -e ${{ matrix.variant }}
       - name: Upload safeboot firmware artifacts
@@ -77,7 +77,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install wheel
-          pip install -U platformio
+          pip install -U platformio==6.1.7
       - name: Run PlatformIO
         run: platformio run -e ${{ matrix.variant }}
       - name: Upload firmware artifacts
@@ -120,7 +120,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install wheel
-          pip install -U platformio
+          pip install -U platformio==6.1.7
       - name: Download safeboot firmwares
         uses: actions/download-artifact@v3
         with:
@@ -157,7 +157,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install wheel
-          pip install -U platformio
+          pip install -U platformio==6.1.7
       - name: Download safeboot firmwares
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build_all_the_things.yml
+++ b/.github/workflows/build_all_the_things.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           pip install wheel
           #python -m pip install --upgrade pip
-          pip install -U platformio
+          pip install -U platformio==6.1.7
           #platformio upgrade --dev
           #platformio update
       - name: Run PlatformIO
@@ -63,7 +63,7 @@ jobs:
         run: |
           pip install wheel
           #python -m pip install --upgrade pip
-          pip install -U platformio
+          pip install -U platformio==6.1.7
           #platformio upgrade --dev
           #platformio update
       - name: Run PlatformIO
@@ -122,7 +122,7 @@ jobs:
         run: |
           pip install wheel
           #python -m pip install --upgrade pip
-          pip install -U platformio
+          pip install -U platformio==6.1.7
           #platformio upgrade --dev
           #platformio update
       - name: Run PlatformIO
@@ -150,7 +150,7 @@ jobs:
         run: |
           pip install wheel
           #python -m pip install --upgrade pip
-          pip install -U platformio
+          pip install -U platformio==6.1.7
           #platformio upgrade --dev
           #platformio update
       - name: Run PlatformIO

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
-  - command: pip3 install -U platformio && platformio run -e tasmota
+  - command: pip3 install -U platformio==6.1.7 && platformio run -e tasmota
 
 image:
   file: .gitpod.Dockerfile


### PR DESCRIPTION
## Description:

Compile of all Tasmota32 env do fail. Fix use v6.1.7

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
