### PR TITLE
do not auto-resize FS with embedded files in the firmware

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_7_berry_embedded.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_7_berry_embedded.ino
@@ -43,12 +43,18 @@ const char berry_prog[] =
   "def log(m,l) tasmota.log(m,l) end "
   "def load(f) return tasmota.load(f) end "
 
-  // try to resize FS to max at first boot
+  // try to resize FS to max at first boot, if not already populated with embedded files
   // "tasmota.log('>>> bootcount=' + str(tasmota.settings.bootcount), 2) "
   "if tasmota.settings.bootcount == 0 "
-    "import partition_core "
-    "var p = partition_core.Partition() "
-    "p.resize_fs_to_max() "
+    "import path "
+    "var fc = size(path.listdir('/')) "
+    "if fc < 2 " // only .settings allowed to get deleted, do not delete custom files from the factory.bin
+      "import partition_core "
+      "var p = partition_core.Partition() "
+      "p.resize_fs_to_max() "
+    "else "
+      "log(f'BRY: {fc} files in FS, will not resize partition',2) "
+    "end "
   "end "
 
 #ifdef USE_AUTOCONF


### PR DESCRIPTION
## Description:

At first boot after flash or resetting the boot count to 0 with `reset 99` Tasmota will try to automatically resize the filesystem partition to the maximum size.
This is problematic when files are embedded in the firmware binary, because they are erased in this process which renders the whole file embedding useless.
Until now it was necessary to flash with fixed partition values to prevent this deletion.

This PR checks, if there are more files than `.settings` in path `/` and will not call the resize function.

This is not perfect, as we have to live with the smaller FS, but if a larger FS is needed, then another firmware (without embedded files) should be chosen anyway.

For the future it would be super nice to let the FS grow non-destructive in Tasmota or add some firmware patching magic to esptool.

@s-hadinger Please check, if there is a better solution to accomplish this.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
