### PR TITLE
Matter improve latency for remote commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Matter support for temperature in Fahrenheit (`SetOption8 1`) (#18987)
 - Matter improve responsiveness
 - ESP32 LVGL library from v8.3.7 to v8.3.8 (no functional change)
+- Matter improve latency for remote commands
 
 ### Fixed
 - Berry various fixes for Walrus Operator (#18982)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light0.be
@@ -83,6 +83,7 @@ class Matter_Plugin_Bridge_Light0 : Matter_Plugin_Bridge_HTTP
     var ret = self.call_remote_sync("Power" + str(self.tasmota_relay_index), v ? "1" : "0")
     if ret != nil
       self.parse_update(ret, 11)        # update shadow from return value
+      # self.tick = self.device.tick      # prevent an explicit Status11 for as it is not needed if the subscription update is sent in same tick
     end
   end
 
@@ -122,7 +123,6 @@ class Matter_Plugin_Bridge_Light0 : Matter_Plugin_Bridge_HTTP
 
     # ====================================================================================================
     if   cluster == 0x0006              # ========== On/Off 1.5 p.48 ==========
-      self.update_shadow_lazy()
       if   command == 0x0000            # ---------- Off ----------
         self.set_onoff(false)
         return true

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light1.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light1.be
@@ -127,7 +127,6 @@ class Matter_Plugin_Bridge_Light1 : Matter_Plugin_Bridge_Light0
 
     # ====================================================================================================
     if   cluster == 0x0008              # ========== Level Control 1.6 p.57 ==========
-      self.update_shadow_lazy()
       if   command == 0x0000            # ---------- MoveToLevel ----------
         var bri_in = val.findsubval(0)  # Hue 0..254
         self.set_bri(bri_in)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light2.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light2.be
@@ -143,7 +143,6 @@ class Matter_Plugin_Bridge_Light2 : Matter_Plugin_Bridge_Light1
 
     # ====================================================================================================
     if   cluster == 0x0300              # ========== Color Control 3.2 p.111 ==========
-      self.update_shadow_lazy()
       if   command == 0x000A            # ---------- MoveToColorTemperature ----------
         var ct_in = val.findsubval(0)  # CT
         if ct_in < self.ct_min  ct_in = self.ct_min   end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light3.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Bridge_Light3.be
@@ -153,7 +153,6 @@ class Matter_Plugin_Bridge_Light3 : Matter_Plugin_Bridge_Light1
 
     # ====================================================================================================
     if   cluster == 0x0300              # ========== Color Control 3.2 p.111 ==========
-      self.update_shadow_lazy()
       if   command == 0x0000            # ---------- MoveToHue ----------
         var hue_in = val.findsubval(0)  # Hue 0..254
         self.set_hue(hue_in)

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light0.h
@@ -300,57 +300,54 @@ be_local_closure(Matter_Plugin_Bridge_Light0_invoke_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(command),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(set_onoff),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(shadow_onoff),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(set_onoff),
+    /* K6   */  be_const_int(1),
+    /* K7   */  be_const_int(2),
+    /* K8   */  be_nested_str_weak(shadow_onoff),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[36]) {  /* code */
+    ( &(const binstruction[34]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140702,  //  0002  GETMBR	R5	R3	K2
       0x88180703,  //  0003  GETMBR	R6	R3	K3
       0x541E0005,  //  0004  LDINT	R7	6
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E001B,  //  0006  JMPF	R7	#0023
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
-      0x7C1C0200,  //  0008  CALL	R7	1
-      0x1C1C0D05,  //  0009  EQ	R7	R6	K5
-      0x781E0005,  //  000A  JMPF	R7	#0011
-      0x8C1C0106,  //  000B  GETMET	R7	R0	K6
-      0x50240000,  //  000C  LDBOOL	R9	0	0
-      0x7C1C0400,  //  000D  CALL	R7	2
-      0x501C0200,  //  000E  LDBOOL	R7	1	0
-      0x80040E00,  //  000F  RET	1	R7
-      0x70020011,  //  0010  JMP		#0023
-      0x1C1C0D07,  //  0011  EQ	R7	R6	K7
-      0x781E0005,  //  0012  JMPF	R7	#0019
-      0x8C1C0106,  //  0013  GETMET	R7	R0	K6
-      0x50240200,  //  0014  LDBOOL	R9	1	0
-      0x7C1C0400,  //  0015  CALL	R7	2
-      0x501C0200,  //  0016  LDBOOL	R7	1	0
-      0x80040E00,  //  0017  RET	1	R7
-      0x70020009,  //  0018  JMP		#0023
-      0x1C1C0D08,  //  0019  EQ	R7	R6	K8
-      0x781E0007,  //  001A  JMPF	R7	#0023
-      0x8C1C0106,  //  001B  GETMET	R7	R0	K6
-      0x88240109,  //  001C  GETMBR	R9	R0	K9
-      0x78260000,  //  001D  JMPF	R9	#001F
-      0x50240001,  //  001E  LDBOOL	R9	0	1
-      0x50240200,  //  001F  LDBOOL	R9	1	0
-      0x7C1C0400,  //  0020  CALL	R7	2
-      0x501C0200,  //  0021  LDBOOL	R7	1	0
-      0x80040E00,  //  0022  RET	1	R7
-      0x80000000,  //  0023  RET	0
+      0x781E0019,  //  0006  JMPF	R7	#0021
+      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x781E0005,  //  0008  JMPF	R7	#000F
+      0x8C1C0105,  //  0009  GETMET	R7	R0	K5
+      0x50240000,  //  000A  LDBOOL	R9	0	0
+      0x7C1C0400,  //  000B  CALL	R7	2
+      0x501C0200,  //  000C  LDBOOL	R7	1	0
+      0x80040E00,  //  000D  RET	1	R7
+      0x70020011,  //  000E  JMP		#0021
+      0x1C1C0D06,  //  000F  EQ	R7	R6	K6
+      0x781E0005,  //  0010  JMPF	R7	#0017
+      0x8C1C0105,  //  0011  GETMET	R7	R0	K5
+      0x50240200,  //  0012  LDBOOL	R9	1	0
+      0x7C1C0400,  //  0013  CALL	R7	2
+      0x501C0200,  //  0014  LDBOOL	R7	1	0
+      0x80040E00,  //  0015  RET	1	R7
+      0x70020009,  //  0016  JMP		#0021
+      0x1C1C0D07,  //  0017  EQ	R7	R6	K7
+      0x781E0007,  //  0018  JMPF	R7	#0021
+      0x8C1C0105,  //  0019  GETMET	R7	R0	K5
+      0x88240108,  //  001A  GETMBR	R9	R0	K8
+      0x78260000,  //  001B  JMPF	R9	#001D
+      0x50240001,  //  001C  LDBOOL	R9	0	1
+      0x50240200,  //  001D  LDBOOL	R9	1	0
+      0x7C1C0400,  //  001E  CALL	R7	2
+      0x501C0200,  //  001F  LDBOOL	R7	1	0
+      0x80040E00,  //  0020  RET	1	R7
+      0x80000000,  //  0021  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light1.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light1.h
@@ -19,115 +19,112 @@ be_local_closure(Matter_Plugin_Bridge_Light1_invoke_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
+    ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(command),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(findsubval),
-    /* K7   */  be_nested_str_weak(set_bri),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(bri_X3A),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(set_onoff),
-    /* K14  */  be_nested_str_weak(invoke_request),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(findsubval),
+    /* K6   */  be_nested_str_weak(set_bri),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(bri_X3A),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(set_onoff),
+    /* K13  */  be_nested_str_weak(invoke_request),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[89]) {  /* code */
+    ( &(const binstruction[87]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140702,  //  0002  GETMBR	R5	R3	K2
       0x88180703,  //  0003  GETMBR	R6	R3	K3
       0x541E0007,  //  0004  LDINT	R7	8
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E0047,  //  0006  JMPF	R7	#004F
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
-      0x7C1C0200,  //  0008  CALL	R7	1
-      0x1C1C0D05,  //  0009  EQ	R7	R6	K5
-      0x781E000D,  //  000A  JMPF	R7	#0019
-      0x8C1C0506,  //  000B  GETMET	R7	R2	K6
-      0x58240005,  //  000C  LDCONST	R9	K5
-      0x7C1C0400,  //  000D  CALL	R7	2
-      0x8C200107,  //  000E  GETMET	R8	R0	K7
-      0x5C280E00,  //  000F  MOVE	R10	R7
-      0x7C200400,  //  0010  CALL	R8	2
-      0x60200008,  //  0011  GETGBL	R8	G8
-      0x5C240E00,  //  0012  MOVE	R9	R7
-      0x7C200200,  //  0013  CALL	R8	1
-      0x00221208,  //  0014  ADD	R8	K9	R8
-      0x900E1008,  //  0015  SETMBR	R3	K8	R8
-      0x50200200,  //  0016  LDBOOL	R8	1	0
-      0x80041000,  //  0017  RET	1	R8
-      0x70020034,  //  0018  JMP		#004E
-      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
-      0x781E0002,  //  001A  JMPF	R7	#001E
-      0x501C0200,  //  001B  LDBOOL	R7	1	0
-      0x80040E00,  //  001C  RET	1	R7
-      0x7002002F,  //  001D  JMP		#004E
-      0x1C1C0D0B,  //  001E  EQ	R7	R6	K11
-      0x781E0002,  //  001F  JMPF	R7	#0023
-      0x501C0200,  //  0020  LDBOOL	R7	1	0
-      0x80040E00,  //  0021  RET	1	R7
-      0x7002002A,  //  0022  JMP		#004E
-      0x1C1C0D0C,  //  0023  EQ	R7	R6	K12
-      0x781E0002,  //  0024  JMPF	R7	#0028
-      0x501C0200,  //  0025  LDBOOL	R7	1	0
-      0x80040E00,  //  0026  RET	1	R7
-      0x70020025,  //  0027  JMP		#004E
-      0x541E0003,  //  0028  LDINT	R7	4
-      0x1C1C0C07,  //  0029  EQ	R7	R6	R7
-      0x781E0011,  //  002A  JMPF	R7	#003D
-      0x8C1C0506,  //  002B  GETMET	R7	R2	K6
-      0x58240005,  //  002C  LDCONST	R9	K5
-      0x7C1C0400,  //  002D  CALL	R7	2
-      0x8C200107,  //  002E  GETMET	R8	R0	K7
-      0x5C280E00,  //  002F  MOVE	R10	R7
-      0x7C200400,  //  0030  CALL	R8	2
-      0x24200F05,  //  0031  GT	R8	R7	K5
-      0x8C24010D,  //  0032  GETMET	R9	R0	K13
-      0x5C2C1000,  //  0033  MOVE	R11	R8
-      0x7C240400,  //  0034  CALL	R9	2
-      0x60240008,  //  0035  GETGBL	R9	G8
-      0x5C280E00,  //  0036  MOVE	R10	R7
-      0x7C240200,  //  0037  CALL	R9	1
-      0x00261209,  //  0038  ADD	R9	K9	R9
-      0x900E1009,  //  0039  SETMBR	R3	K8	R9
-      0x50240200,  //  003A  LDBOOL	R9	1	0
-      0x80041200,  //  003B  RET	1	R9
-      0x70020010,  //  003C  JMP		#004E
-      0x541E0004,  //  003D  LDINT	R7	5
-      0x1C1C0C07,  //  003E  EQ	R7	R6	R7
-      0x781E0002,  //  003F  JMPF	R7	#0043
-      0x501C0200,  //  0040  LDBOOL	R7	1	0
-      0x80040E00,  //  0041  RET	1	R7
-      0x7002000A,  //  0042  JMP		#004E
-      0x541E0005,  //  0043  LDINT	R7	6
-      0x1C1C0C07,  //  0044  EQ	R7	R6	R7
-      0x781E0002,  //  0045  JMPF	R7	#0049
-      0x501C0200,  //  0046  LDBOOL	R7	1	0
-      0x80040E00,  //  0047  RET	1	R7
-      0x70020004,  //  0048  JMP		#004E
-      0x541E0006,  //  0049  LDINT	R7	7
-      0x1C1C0C07,  //  004A  EQ	R7	R6	R7
-      0x781E0001,  //  004B  JMPF	R7	#004E
-      0x501C0200,  //  004C  LDBOOL	R7	1	0
-      0x80040E00,  //  004D  RET	1	R7
-      0x70020008,  //  004E  JMP		#0058
-      0x601C0003,  //  004F  GETGBL	R7	G3
-      0x5C200000,  //  0050  MOVE	R8	R0
-      0x7C1C0200,  //  0051  CALL	R7	1
-      0x8C1C0F0E,  //  0052  GETMET	R7	R7	K14
-      0x5C240200,  //  0053  MOVE	R9	R1
-      0x5C280400,  //  0054  MOVE	R10	R2
-      0x5C2C0600,  //  0055  MOVE	R11	R3
-      0x7C1C0800,  //  0056  CALL	R7	4
-      0x80040E00,  //  0057  RET	1	R7
-      0x80000000,  //  0058  RET	0
+      0x781E0045,  //  0006  JMPF	R7	#004D
+      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x781E000D,  //  0008  JMPF	R7	#0017
+      0x8C1C0505,  //  0009  GETMET	R7	R2	K5
+      0x58240004,  //  000A  LDCONST	R9	K4
+      0x7C1C0400,  //  000B  CALL	R7	2
+      0x8C200106,  //  000C  GETMET	R8	R0	K6
+      0x5C280E00,  //  000D  MOVE	R10	R7
+      0x7C200400,  //  000E  CALL	R8	2
+      0x60200008,  //  000F  GETGBL	R8	G8
+      0x5C240E00,  //  0010  MOVE	R9	R7
+      0x7C200200,  //  0011  CALL	R8	1
+      0x00221008,  //  0012  ADD	R8	K8	R8
+      0x900E0E08,  //  0013  SETMBR	R3	K7	R8
+      0x50200200,  //  0014  LDBOOL	R8	1	0
+      0x80041000,  //  0015  RET	1	R8
+      0x70020034,  //  0016  JMP		#004C
+      0x1C1C0D09,  //  0017  EQ	R7	R6	K9
+      0x781E0002,  //  0018  JMPF	R7	#001C
+      0x501C0200,  //  0019  LDBOOL	R7	1	0
+      0x80040E00,  //  001A  RET	1	R7
+      0x7002002F,  //  001B  JMP		#004C
+      0x1C1C0D0A,  //  001C  EQ	R7	R6	K10
+      0x781E0002,  //  001D  JMPF	R7	#0021
+      0x501C0200,  //  001E  LDBOOL	R7	1	0
+      0x80040E00,  //  001F  RET	1	R7
+      0x7002002A,  //  0020  JMP		#004C
+      0x1C1C0D0B,  //  0021  EQ	R7	R6	K11
+      0x781E0002,  //  0022  JMPF	R7	#0026
+      0x501C0200,  //  0023  LDBOOL	R7	1	0
+      0x80040E00,  //  0024  RET	1	R7
+      0x70020025,  //  0025  JMP		#004C
+      0x541E0003,  //  0026  LDINT	R7	4
+      0x1C1C0C07,  //  0027  EQ	R7	R6	R7
+      0x781E0011,  //  0028  JMPF	R7	#003B
+      0x8C1C0505,  //  0029  GETMET	R7	R2	K5
+      0x58240004,  //  002A  LDCONST	R9	K4
+      0x7C1C0400,  //  002B  CALL	R7	2
+      0x8C200106,  //  002C  GETMET	R8	R0	K6
+      0x5C280E00,  //  002D  MOVE	R10	R7
+      0x7C200400,  //  002E  CALL	R8	2
+      0x24200F04,  //  002F  GT	R8	R7	K4
+      0x8C24010C,  //  0030  GETMET	R9	R0	K12
+      0x5C2C1000,  //  0031  MOVE	R11	R8
+      0x7C240400,  //  0032  CALL	R9	2
+      0x60240008,  //  0033  GETGBL	R9	G8
+      0x5C280E00,  //  0034  MOVE	R10	R7
+      0x7C240200,  //  0035  CALL	R9	1
+      0x00261009,  //  0036  ADD	R9	K8	R9
+      0x900E0E09,  //  0037  SETMBR	R3	K7	R9
+      0x50240200,  //  0038  LDBOOL	R9	1	0
+      0x80041200,  //  0039  RET	1	R9
+      0x70020010,  //  003A  JMP		#004C
+      0x541E0004,  //  003B  LDINT	R7	5
+      0x1C1C0C07,  //  003C  EQ	R7	R6	R7
+      0x781E0002,  //  003D  JMPF	R7	#0041
+      0x501C0200,  //  003E  LDBOOL	R7	1	0
+      0x80040E00,  //  003F  RET	1	R7
+      0x7002000A,  //  0040  JMP		#004C
+      0x541E0005,  //  0041  LDINT	R7	6
+      0x1C1C0C07,  //  0042  EQ	R7	R6	R7
+      0x781E0002,  //  0043  JMPF	R7	#0047
+      0x501C0200,  //  0044  LDBOOL	R7	1	0
+      0x80040E00,  //  0045  RET	1	R7
+      0x70020004,  //  0046  JMP		#004C
+      0x541E0006,  //  0047  LDINT	R7	7
+      0x1C1C0C07,  //  0048  EQ	R7	R6	R7
+      0x781E0001,  //  0049  JMPF	R7	#004C
+      0x501C0200,  //  004A  LDBOOL	R7	1	0
+      0x80040E00,  //  004B  RET	1	R7
+      0x70020008,  //  004C  JMP		#0056
+      0x601C0003,  //  004D  GETGBL	R7	G3
+      0x5C200000,  //  004E  MOVE	R8	R0
+      0x7C1C0200,  //  004F  CALL	R7	1
+      0x8C1C0F0D,  //  0050  GETMET	R7	R7	K13
+      0x5C240200,  //  0051  MOVE	R9	R1
+      0x5C280400,  //  0052  MOVE	R10	R2
+      0x5C2C0600,  //  0053  MOVE	R11	R3
+      0x7C1C0800,  //  0054  CALL	R7	4
+      0x80040E00,  //  0055  RET	1	R7
+      0x80000000,  //  0056  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light2.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light2.h
@@ -260,86 +260,83 @@ be_local_closure(Matter_Plugin_Bridge_Light2_invoke_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
+    ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(command),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_nested_str_weak(findsubval),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(ct_min),
-    /* K8   */  be_nested_str_weak(ct_max),
-    /* K9   */  be_nested_str_weak(set_ct),
-    /* K10  */  be_nested_str_weak(log),
-    /* K11  */  be_nested_str_weak(ct_X3A),
-    /* K12  */  be_nested_str_weak(invoke_request),
+    /* K4   */  be_nested_str_weak(findsubval),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(ct_min),
+    /* K7   */  be_nested_str_weak(ct_max),
+    /* K8   */  be_nested_str_weak(set_ct),
+    /* K9   */  be_nested_str_weak(log),
+    /* K10  */  be_nested_str_weak(ct_X3A),
+    /* K11  */  be_nested_str_weak(invoke_request),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[62]) {  /* code */
+    ( &(const binstruction[60]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140702,  //  0002  GETMBR	R5	R3	K2
       0x88180703,  //  0003  GETMBR	R6	R3	K3
       0x541E02FF,  //  0004  LDINT	R7	768
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E002C,  //  0006  JMPF	R7	#0034
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
-      0x7C1C0200,  //  0008  CALL	R7	1
-      0x541E0009,  //  0009  LDINT	R7	10
-      0x1C1C0C07,  //  000A  EQ	R7	R6	R7
-      0x781E0015,  //  000B  JMPF	R7	#0022
-      0x8C1C0505,  //  000C  GETMET	R7	R2	K5
-      0x58240006,  //  000D  LDCONST	R9	K6
-      0x7C1C0400,  //  000E  CALL	R7	2
-      0x88200107,  //  000F  GETMBR	R8	R0	K7
-      0x14200E08,  //  0010  LT	R8	R7	R8
-      0x78220000,  //  0011  JMPF	R8	#0013
-      0x881C0107,  //  0012  GETMBR	R7	R0	K7
-      0x88200108,  //  0013  GETMBR	R8	R0	K8
-      0x24200E08,  //  0014  GT	R8	R7	R8
-      0x78220000,  //  0015  JMPF	R8	#0017
-      0x881C0108,  //  0016  GETMBR	R7	R0	K8
-      0x8C200109,  //  0017  GETMET	R8	R0	K9
-      0x5C280E00,  //  0018  MOVE	R10	R7
-      0x7C200400,  //  0019  CALL	R8	2
-      0x60200008,  //  001A  GETGBL	R8	G8
-      0x5C240E00,  //  001B  MOVE	R9	R7
-      0x7C200200,  //  001C  CALL	R8	1
-      0x00221608,  //  001D  ADD	R8	K11	R8
-      0x900E1408,  //  001E  SETMBR	R3	K10	R8
-      0x50200200,  //  001F  LDBOOL	R8	1	0
-      0x80041000,  //  0020  RET	1	R8
-      0x70020010,  //  0021  JMP		#0033
-      0x541E0046,  //  0022  LDINT	R7	71
-      0x1C1C0C07,  //  0023  EQ	R7	R6	R7
-      0x781E0002,  //  0024  JMPF	R7	#0028
-      0x501C0200,  //  0025  LDBOOL	R7	1	0
-      0x80040E00,  //  0026  RET	1	R7
-      0x7002000A,  //  0027  JMP		#0033
-      0x541E004A,  //  0028  LDINT	R7	75
-      0x1C1C0C07,  //  0029  EQ	R7	R6	R7
-      0x781E0002,  //  002A  JMPF	R7	#002E
-      0x501C0200,  //  002B  LDBOOL	R7	1	0
-      0x80040E00,  //  002C  RET	1	R7
-      0x70020004,  //  002D  JMP		#0033
-      0x541E004B,  //  002E  LDINT	R7	76
-      0x1C1C0C07,  //  002F  EQ	R7	R6	R7
-      0x781E0001,  //  0030  JMPF	R7	#0033
-      0x501C0200,  //  0031  LDBOOL	R7	1	0
-      0x80040E00,  //  0032  RET	1	R7
-      0x70020008,  //  0033  JMP		#003D
-      0x601C0003,  //  0034  GETGBL	R7	G3
-      0x5C200000,  //  0035  MOVE	R8	R0
-      0x7C1C0200,  //  0036  CALL	R7	1
-      0x8C1C0F0C,  //  0037  GETMET	R7	R7	K12
-      0x5C240200,  //  0038  MOVE	R9	R1
-      0x5C280400,  //  0039  MOVE	R10	R2
-      0x5C2C0600,  //  003A  MOVE	R11	R3
-      0x7C1C0800,  //  003B  CALL	R7	4
-      0x80040E00,  //  003C  RET	1	R7
-      0x80000000,  //  003D  RET	0
+      0x781E002A,  //  0006  JMPF	R7	#0032
+      0x541E0009,  //  0007  LDINT	R7	10
+      0x1C1C0C07,  //  0008  EQ	R7	R6	R7
+      0x781E0015,  //  0009  JMPF	R7	#0020
+      0x8C1C0504,  //  000A  GETMET	R7	R2	K4
+      0x58240005,  //  000B  LDCONST	R9	K5
+      0x7C1C0400,  //  000C  CALL	R7	2
+      0x88200106,  //  000D  GETMBR	R8	R0	K6
+      0x14200E08,  //  000E  LT	R8	R7	R8
+      0x78220000,  //  000F  JMPF	R8	#0011
+      0x881C0106,  //  0010  GETMBR	R7	R0	K6
+      0x88200107,  //  0011  GETMBR	R8	R0	K7
+      0x24200E08,  //  0012  GT	R8	R7	R8
+      0x78220000,  //  0013  JMPF	R8	#0015
+      0x881C0107,  //  0014  GETMBR	R7	R0	K7
+      0x8C200108,  //  0015  GETMET	R8	R0	K8
+      0x5C280E00,  //  0016  MOVE	R10	R7
+      0x7C200400,  //  0017  CALL	R8	2
+      0x60200008,  //  0018  GETGBL	R8	G8
+      0x5C240E00,  //  0019  MOVE	R9	R7
+      0x7C200200,  //  001A  CALL	R8	1
+      0x00221408,  //  001B  ADD	R8	K10	R8
+      0x900E1208,  //  001C  SETMBR	R3	K9	R8
+      0x50200200,  //  001D  LDBOOL	R8	1	0
+      0x80041000,  //  001E  RET	1	R8
+      0x70020010,  //  001F  JMP		#0031
+      0x541E0046,  //  0020  LDINT	R7	71
+      0x1C1C0C07,  //  0021  EQ	R7	R6	R7
+      0x781E0002,  //  0022  JMPF	R7	#0026
+      0x501C0200,  //  0023  LDBOOL	R7	1	0
+      0x80040E00,  //  0024  RET	1	R7
+      0x7002000A,  //  0025  JMP		#0031
+      0x541E004A,  //  0026  LDINT	R7	75
+      0x1C1C0C07,  //  0027  EQ	R7	R6	R7
+      0x781E0002,  //  0028  JMPF	R7	#002C
+      0x501C0200,  //  0029  LDBOOL	R7	1	0
+      0x80040E00,  //  002A  RET	1	R7
+      0x70020004,  //  002B  JMP		#0031
+      0x541E004B,  //  002C  LDINT	R7	76
+      0x1C1C0C07,  //  002D  EQ	R7	R6	R7
+      0x781E0001,  //  002E  JMPF	R7	#0031
+      0x501C0200,  //  002F  LDBOOL	R7	1	0
+      0x80040E00,  //  0030  RET	1	R7
+      0x70020008,  //  0031  JMP		#003B
+      0x601C0003,  //  0032  GETGBL	R7	G3
+      0x5C200000,  //  0033  MOVE	R8	R0
+      0x7C1C0200,  //  0034  CALL	R7	1
+      0x8C1C0F0B,  //  0035  GETMET	R7	R7	K11
+      0x5C240200,  //  0036  MOVE	R9	R1
+      0x5C280400,  //  0037  MOVE	R10	R2
+      0x5C2C0600,  //  0038  MOVE	R11	R3
+      0x7C1C0800,  //  0039  CALL	R7	4
+      0x80040E00,  //  003A  RET	1	R7
+      0x80000000,  //  003B  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light3.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Bridge_Light3.h
@@ -308,135 +308,132 @@ be_local_closure(Matter_Plugin_Bridge_Light3_invoke_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
+    ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(command),
-    /* K4   */  be_nested_str_weak(update_shadow_lazy),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(findsubval),
-    /* K7   */  be_nested_str_weak(set_hue),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(hue_X3A),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_const_int(3),
-    /* K13  */  be_nested_str_weak(set_sat),
-    /* K14  */  be_nested_str_weak(sat_X3A),
-    /* K15  */  be_nested_str_weak(_X20sat_X3A),
-    /* K16  */  be_nested_str_weak(invoke_request),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(findsubval),
+    /* K6   */  be_nested_str_weak(set_hue),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(hue_X3A),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(set_sat),
+    /* K13  */  be_nested_str_weak(sat_X3A),
+    /* K14  */  be_nested_str_weak(_X20sat_X3A),
+    /* K15  */  be_nested_str_weak(invoke_request),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[107]) {  /* code */
+    ( &(const binstruction[105]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140702,  //  0002  GETMBR	R5	R3	K2
       0x88180703,  //  0003  GETMBR	R6	R3	K3
       0x541E02FF,  //  0004  LDINT	R7	768
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E0059,  //  0006  JMPF	R7	#0061
-      0x8C1C0104,  //  0007  GETMET	R7	R0	K4
-      0x7C1C0200,  //  0008  CALL	R7	1
-      0x1C1C0D05,  //  0009  EQ	R7	R6	K5
-      0x781E000D,  //  000A  JMPF	R7	#0019
-      0x8C1C0506,  //  000B  GETMET	R7	R2	K6
-      0x58240005,  //  000C  LDCONST	R9	K5
-      0x7C1C0400,  //  000D  CALL	R7	2
-      0x8C200107,  //  000E  GETMET	R8	R0	K7
-      0x5C280E00,  //  000F  MOVE	R10	R7
-      0x7C200400,  //  0010  CALL	R8	2
-      0x60200008,  //  0011  GETGBL	R8	G8
-      0x5C240E00,  //  0012  MOVE	R9	R7
-      0x7C200200,  //  0013  CALL	R8	1
-      0x00221208,  //  0014  ADD	R8	K9	R8
-      0x900E1008,  //  0015  SETMBR	R3	K8	R8
-      0x50200200,  //  0016  LDBOOL	R8	1	0
-      0x80041000,  //  0017  RET	1	R8
-      0x70020046,  //  0018  JMP		#0060
-      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
-      0x781E0002,  //  001A  JMPF	R7	#001E
-      0x501C0200,  //  001B  LDBOOL	R7	1	0
-      0x80040E00,  //  001C  RET	1	R7
-      0x70020041,  //  001D  JMP		#0060
-      0x1C1C0D0B,  //  001E  EQ	R7	R6	K11
-      0x781E0002,  //  001F  JMPF	R7	#0023
-      0x501C0200,  //  0020  LDBOOL	R7	1	0
-      0x80040E00,  //  0021  RET	1	R7
-      0x7002003C,  //  0022  JMP		#0060
-      0x1C1C0D0C,  //  0023  EQ	R7	R6	K12
-      0x781E000D,  //  0024  JMPF	R7	#0033
-      0x8C1C0506,  //  0025  GETMET	R7	R2	K6
-      0x58240005,  //  0026  LDCONST	R9	K5
-      0x7C1C0400,  //  0027  CALL	R7	2
-      0x8C20010D,  //  0028  GETMET	R8	R0	K13
-      0x5C280E00,  //  0029  MOVE	R10	R7
-      0x7C200400,  //  002A  CALL	R8	2
-      0x60200008,  //  002B  GETGBL	R8	G8
-      0x5C240E00,  //  002C  MOVE	R9	R7
-      0x7C200200,  //  002D  CALL	R8	1
-      0x00221C08,  //  002E  ADD	R8	K14	R8
-      0x900E1008,  //  002F  SETMBR	R3	K8	R8
-      0x50200200,  //  0030  LDBOOL	R8	1	0
-      0x80041000,  //  0031  RET	1	R8
-      0x7002002C,  //  0032  JMP		#0060
-      0x541E0003,  //  0033  LDINT	R7	4
-      0x1C1C0C07,  //  0034  EQ	R7	R6	R7
-      0x781E0002,  //  0035  JMPF	R7	#0039
-      0x501C0200,  //  0036  LDBOOL	R7	1	0
-      0x80040E00,  //  0037  RET	1	R7
-      0x70020026,  //  0038  JMP		#0060
-      0x541E0004,  //  0039  LDINT	R7	5
-      0x1C1C0C07,  //  003A  EQ	R7	R6	R7
-      0x781E0002,  //  003B  JMPF	R7	#003F
-      0x501C0200,  //  003C  LDBOOL	R7	1	0
-      0x80040E00,  //  003D  RET	1	R7
-      0x70020020,  //  003E  JMP		#0060
-      0x541E0005,  //  003F  LDINT	R7	6
-      0x1C1C0C07,  //  0040  EQ	R7	R6	R7
-      0x781E0018,  //  0041  JMPF	R7	#005B
-      0x8C1C0506,  //  0042  GETMET	R7	R2	K6
-      0x58240005,  //  0043  LDCONST	R9	K5
-      0x7C1C0400,  //  0044  CALL	R7	2
-      0x8C200506,  //  0045  GETMET	R8	R2	K6
-      0x5828000A,  //  0046  LDCONST	R10	K10
-      0x7C200400,  //  0047  CALL	R8	2
-      0x8C240107,  //  0048  GETMET	R9	R0	K7
-      0x5C2C0E00,  //  0049  MOVE	R11	R7
-      0x7C240400,  //  004A  CALL	R9	2
-      0x8C24010D,  //  004B  GETMET	R9	R0	K13
-      0x5C2C1000,  //  004C  MOVE	R11	R8
-      0x7C240400,  //  004D  CALL	R9	2
-      0x60240008,  //  004E  GETGBL	R9	G8
-      0x5C280E00,  //  004F  MOVE	R10	R7
-      0x7C240200,  //  0050  CALL	R9	1
-      0x00261209,  //  0051  ADD	R9	K9	R9
-      0x0024130F,  //  0052  ADD	R9	R9	K15
-      0x60280008,  //  0053  GETGBL	R10	G8
-      0x5C2C1000,  //  0054  MOVE	R11	R8
-      0x7C280200,  //  0055  CALL	R10	1
-      0x0024120A,  //  0056  ADD	R9	R9	R10
-      0x900E1009,  //  0057  SETMBR	R3	K8	R9
-      0x50240200,  //  0058  LDBOOL	R9	1	0
-      0x80041200,  //  0059  RET	1	R9
-      0x70020004,  //  005A  JMP		#0060
-      0x541E0046,  //  005B  LDINT	R7	71
-      0x1C1C0C07,  //  005C  EQ	R7	R6	R7
-      0x781E0001,  //  005D  JMPF	R7	#0060
-      0x501C0200,  //  005E  LDBOOL	R7	1	0
-      0x80040E00,  //  005F  RET	1	R7
-      0x70020008,  //  0060  JMP		#006A
-      0x601C0003,  //  0061  GETGBL	R7	G3
-      0x5C200000,  //  0062  MOVE	R8	R0
-      0x7C1C0200,  //  0063  CALL	R7	1
-      0x8C1C0F10,  //  0064  GETMET	R7	R7	K16
-      0x5C240200,  //  0065  MOVE	R9	R1
-      0x5C280400,  //  0066  MOVE	R10	R2
-      0x5C2C0600,  //  0067  MOVE	R11	R3
-      0x7C1C0800,  //  0068  CALL	R7	4
-      0x80040E00,  //  0069  RET	1	R7
-      0x80000000,  //  006A  RET	0
+      0x781E0057,  //  0006  JMPF	R7	#005F
+      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
+      0x781E000D,  //  0008  JMPF	R7	#0017
+      0x8C1C0505,  //  0009  GETMET	R7	R2	K5
+      0x58240004,  //  000A  LDCONST	R9	K4
+      0x7C1C0400,  //  000B  CALL	R7	2
+      0x8C200106,  //  000C  GETMET	R8	R0	K6
+      0x5C280E00,  //  000D  MOVE	R10	R7
+      0x7C200400,  //  000E  CALL	R8	2
+      0x60200008,  //  000F  GETGBL	R8	G8
+      0x5C240E00,  //  0010  MOVE	R9	R7
+      0x7C200200,  //  0011  CALL	R8	1
+      0x00221008,  //  0012  ADD	R8	K8	R8
+      0x900E0E08,  //  0013  SETMBR	R3	K7	R8
+      0x50200200,  //  0014  LDBOOL	R8	1	0
+      0x80041000,  //  0015  RET	1	R8
+      0x70020046,  //  0016  JMP		#005E
+      0x1C1C0D09,  //  0017  EQ	R7	R6	K9
+      0x781E0002,  //  0018  JMPF	R7	#001C
+      0x501C0200,  //  0019  LDBOOL	R7	1	0
+      0x80040E00,  //  001A  RET	1	R7
+      0x70020041,  //  001B  JMP		#005E
+      0x1C1C0D0A,  //  001C  EQ	R7	R6	K10
+      0x781E0002,  //  001D  JMPF	R7	#0021
+      0x501C0200,  //  001E  LDBOOL	R7	1	0
+      0x80040E00,  //  001F  RET	1	R7
+      0x7002003C,  //  0020  JMP		#005E
+      0x1C1C0D0B,  //  0021  EQ	R7	R6	K11
+      0x781E000D,  //  0022  JMPF	R7	#0031
+      0x8C1C0505,  //  0023  GETMET	R7	R2	K5
+      0x58240004,  //  0024  LDCONST	R9	K4
+      0x7C1C0400,  //  0025  CALL	R7	2
+      0x8C20010C,  //  0026  GETMET	R8	R0	K12
+      0x5C280E00,  //  0027  MOVE	R10	R7
+      0x7C200400,  //  0028  CALL	R8	2
+      0x60200008,  //  0029  GETGBL	R8	G8
+      0x5C240E00,  //  002A  MOVE	R9	R7
+      0x7C200200,  //  002B  CALL	R8	1
+      0x00221A08,  //  002C  ADD	R8	K13	R8
+      0x900E0E08,  //  002D  SETMBR	R3	K7	R8
+      0x50200200,  //  002E  LDBOOL	R8	1	0
+      0x80041000,  //  002F  RET	1	R8
+      0x7002002C,  //  0030  JMP		#005E
+      0x541E0003,  //  0031  LDINT	R7	4
+      0x1C1C0C07,  //  0032  EQ	R7	R6	R7
+      0x781E0002,  //  0033  JMPF	R7	#0037
+      0x501C0200,  //  0034  LDBOOL	R7	1	0
+      0x80040E00,  //  0035  RET	1	R7
+      0x70020026,  //  0036  JMP		#005E
+      0x541E0004,  //  0037  LDINT	R7	5
+      0x1C1C0C07,  //  0038  EQ	R7	R6	R7
+      0x781E0002,  //  0039  JMPF	R7	#003D
+      0x501C0200,  //  003A  LDBOOL	R7	1	0
+      0x80040E00,  //  003B  RET	1	R7
+      0x70020020,  //  003C  JMP		#005E
+      0x541E0005,  //  003D  LDINT	R7	6
+      0x1C1C0C07,  //  003E  EQ	R7	R6	R7
+      0x781E0018,  //  003F  JMPF	R7	#0059
+      0x8C1C0505,  //  0040  GETMET	R7	R2	K5
+      0x58240004,  //  0041  LDCONST	R9	K4
+      0x7C1C0400,  //  0042  CALL	R7	2
+      0x8C200505,  //  0043  GETMET	R8	R2	K5
+      0x58280009,  //  0044  LDCONST	R10	K9
+      0x7C200400,  //  0045  CALL	R8	2
+      0x8C240106,  //  0046  GETMET	R9	R0	K6
+      0x5C2C0E00,  //  0047  MOVE	R11	R7
+      0x7C240400,  //  0048  CALL	R9	2
+      0x8C24010C,  //  0049  GETMET	R9	R0	K12
+      0x5C2C1000,  //  004A  MOVE	R11	R8
+      0x7C240400,  //  004B  CALL	R9	2
+      0x60240008,  //  004C  GETGBL	R9	G8
+      0x5C280E00,  //  004D  MOVE	R10	R7
+      0x7C240200,  //  004E  CALL	R9	1
+      0x00261009,  //  004F  ADD	R9	K8	R9
+      0x0024130E,  //  0050  ADD	R9	R9	K14
+      0x60280008,  //  0051  GETGBL	R10	G8
+      0x5C2C1000,  //  0052  MOVE	R11	R8
+      0x7C280200,  //  0053  CALL	R10	1
+      0x0024120A,  //  0054  ADD	R9	R9	R10
+      0x900E0E09,  //  0055  SETMBR	R3	K7	R9
+      0x50240200,  //  0056  LDBOOL	R9	1	0
+      0x80041200,  //  0057  RET	1	R9
+      0x70020004,  //  0058  JMP		#005E
+      0x541E0046,  //  0059  LDINT	R7	71
+      0x1C1C0C07,  //  005A  EQ	R7	R6	R7
+      0x781E0001,  //  005B  JMPF	R7	#005E
+      0x501C0200,  //  005C  LDBOOL	R7	1	0
+      0x80040E00,  //  005D  RET	1	R7
+      0x70020008,  //  005E  JMP		#0068
+      0x601C0003,  //  005F  GETGBL	R7	G3
+      0x5C200000,  //  0060  MOVE	R8	R0
+      0x7C1C0200,  //  0061  CALL	R7	1
+      0x8C1C0F0F,  //  0062  GETMET	R7	R7	K15
+      0x5C240200,  //  0063  MOVE	R9	R1
+      0x5C280400,  //  0064  MOVE	R10	R2
+      0x5C2C0600,  //  0065  MOVE	R11	R3
+      0x7C1C0800,  //  0066  CALL	R7	4
+      0x80040E00,  //  0067  RET	1	R7
+      0x80000000,  //  0068  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Matter when a command is sent to a remote light, we don't send anymore the `Status 11` command prior to the actual command. This saves typically ~100ms of user latency between the command and the action.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
