### PR TITLE
Zero-Cross Dimmer fixes

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -2188,8 +2188,10 @@ void LightSetOutputs(const uint16_t *cur_col_10) {
         TasmotaGlobal.pwm_value[i] = cur_col;   // mark the new expected value
         // AddLog(LOG_LEVEL_DEBUG_MORE, "analogWrite-%i 0x%03X", i, cur_col);
 #else // ESP32
-        analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - cur_col : cur_col);
-        // AddLog(LOG_LEVEL_DEBUG_MORE, "analogWrite-%i 0x%03X", bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - cur_col : cur_col);
+        if (!Settings->flag4.zerocross_dimmer) {
+          analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - cur_col : cur_col);
+          // AddLog(LOG_LEVEL_DEBUG_MORE, "analogWrite-%i 0x%03X", bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - cur_col : cur_col);
+        }
 #endif // ESP32
       }
     }

--- a/tasmota/tasmota_xsns_sensor/xsns_01_counter.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_01_counter.ino
@@ -98,6 +98,9 @@ void IRAM_ATTR CounterIsrArg(void *arg) {
 void CounterInterruptDisable(bool state)
 {
   if (state) {   // Disable interrupts
+    if (Settings->flag4.zerocross_dimmer) {
+        return;
+    }
     if (Counter.any_counter) {
       for (uint32_t i = 0; i < MAX_COUNTERS; i++) {
         if (PinUsed(GPIO_CNTR1, i)) {


### PR DESCRIPTION
## Description:
- re-enabled DIMMER usage
- SAVEDATA does not change light anymore
- hopefully disco light at 0% fixed

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
#18949

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
