### PR TITLE
Berry add `energy.update_total()` to call `EnergyUpdateTotal()` from energy driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Partition Wizard is now able to convert to safeboot from Shelly partition layout (#19034)
 - Matter mini-profiler (#19075)
 - Berry `_class` can be used in `static var` initialization code (#19088)
+- Berry add `energy.update_total()` to call `EnergyUpdateTotal()` from energy driver
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_energylib.c
+++ b/lib/libesp32/berry_tasmota/src/be_energylib.c
@@ -10,6 +10,7 @@
 #ifdef USE_ENERGY_SENSOR
 
 extern struct ENERGY Energy;
+extern int energy_update_total(bvm *vm);
 
 #include "solidify/solidified_energy.h"
 #include "be_fixed_energy.h"
@@ -24,6 +25,8 @@ module energy (scope: global) {
   read, closure(energy_read_closure)
   member, closure(energy_member_closure)
   setmember, closure(energy_setmember_closure)
+
+  update_total, func(energy_update_total)
 }
 
 @const_object_info_end */

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_energy.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_energy.ino
@@ -31,6 +31,15 @@
  *
 \*********************************************************************************************/
 extern "C" {
+
+  int32_t energy_update_total(struct bvm *vm);
+  int32_t energy_update_total(struct bvm *vm) {
+    EnergyUpdateTotal();
+    be_return_nil(vm);
+  }
+
+
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Winvalid-offsetof"   // avoid warnings since we're using offsetof() in a risky way
 


### PR DESCRIPTION
## Description:

Experimental feature allowing to call `EnergyUpdateTotal()` from a Berry driver: 

```
import energy
energy.update_total()    # returns nil
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
