### PR TITLE
Berry check arguments for `range()`

### DIFF
--- a/lib/libesp32/berry/src/be_rangelib.c
+++ b/lib/libesp32/berry/src/be_rangelib.c
@@ -12,6 +12,8 @@
 static int m_init(bvm *vm)
 {
     int argc = be_top(vm);
+    if (argc < 3) { be_raise(vm, "value_error", "missing arguments"); }
+    if (!be_isint(vm, 2) || !be_isint(vm, 3)) { be_raise(vm, "value_error", "argmunets must be 'int'"); }
     be_pushvalue(vm, 2);
     be_setmember(vm, 1, "__lower__");
     be_pop(vm, 1);
@@ -19,6 +21,7 @@ static int m_init(bvm *vm)
     be_setmember(vm, 1, "__upper__");
     int incr = 1;   /* default increment is '1' */
     if (argc >= 4) {
+        if (!be_isint(vm, 4)) { be_raise(vm, "value_error", "argmunets must be 'int'"); }
         incr = be_toint(vm, 4);
         if (incr == 0) { be_raise(vm, "value_error", "increment cannot be zero"); }
     }
@@ -96,6 +99,8 @@ static int m_incr(bvm *vm)
 static int m_setrange(bvm *vm)
 {
     int argc = be_top(vm);
+    if (argc < 3) { be_raise(vm, "value_error", "missing arguments"); }
+    if (!be_isint(vm, 2) || !be_isint(vm, 3)) { be_raise(vm, "value_error", "argmunets must be 'int'"); }
     be_pushvalue(vm, 2);
     be_setmember(vm, 1, "__lower__");
     be_pop(vm, 1);
@@ -103,6 +108,7 @@ static int m_setrange(bvm *vm)
     be_setmember(vm, 1, "__upper__");
     int incr = 1;   /* default increment is '1' */
     if (argc >= 4) {
+        if (!be_isint(vm, 4)) { be_raise(vm, "value_error", "argmunets must be 'int'"); }
         incr = be_toint(vm, 4);
         if (incr == 0) { be_raise(vm, "value_error", "increment cannot be zero"); }
     }


### PR DESCRIPTION
## Description:

Berry: check that arguments to `range()` are always `int`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
