### PR TITLE
Berry fix syntax highlighting for escaped chars

### DIFF
--- a/lib/libesp32/berry/tools/plugins/vscode/skiars.berry-1.1.0/syntaxes/berry.json
+++ b/lib/libesp32/berry/tools/plugins/vscode/skiars.berry-1.1.0/syntaxes/berry.json
@@ -49,7 +49,7 @@
                     "patterns": [
                         {
                           "name": "constant.character.escape.berry",
-                          "match": "\\\\."
+                          "match": "(\\\\x[\\h]{2})|(\\\\[0-7]{3})|(\\\\\\\\)|(\\\\\")|(\\\\')|(\\\\a)|(\\\\b)|(\\\\f)|(\\\\n)|(\\\\r)|(\\\\t)|(\\\\v)"
                         }
                     ]
                 },
@@ -60,7 +60,7 @@
                     "patterns": [
                         {
                           "name": "constant.character.escape.berry",
-                          "match": "\\\\."
+                          "match": "(\\\\x[\\h]{2})|(\\\\[0-7]{3})|(\\\\\\\\)|(\\\\\")|(\\\\')|(\\\\a)|(\\\\b)|(\\\\f)|(\\\\n)|(\\\\r)|(\\\\t)|(\\\\v)"
                         },
                         {
                             "name": "string.quoted.other.berry",
@@ -111,7 +111,7 @@
         "keywords": {
             "patterns": [{
                 "name": "keyword.berry",
-                "match": "\\b(var|static|def|class|true|false|nil|self|super|import|as)\\b"
+                "match": "\\b(var|static|def|class|true|false|nil|self|super|import|as|_class)\\b"
             }]
         },
         "identifier": {


### PR DESCRIPTION
## Description:

Now supports: `\a` `\b` `\f` `\n` `\r``\t` `\v` as well as octal `\123` and hex `\xFE`

![image](https://github.com/arendst/Tasmota/assets/49731213/930f105e-53d0-4c3c-bc15-044e7cec83b5)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
