### PR TITLE
Berry update grammar

### DIFF
--- a/lib/libesp32/berry/tools/grammar/berry.ebnf
+++ b/lib/libesp32/berry/tools/grammar/berry.ebnf
@@ -5,9 +5,10 @@ block = {statement};
 (* statement define *)
 statement = class_stmt | func_stmt | var_stmt | if_stmt | while_stmt |
          for_stmt | break_stmt | return_stmt | expr_stmt | import_stmt |
-         try_stmt | throw_stmt | ';';
+         try_stmt | throw_stmt | do_stmt | ';';
 if_stmt = 'if' expr block {'elif' expr block} ['else' block] 'end';
 while_stmt = 'while' expr block 'end';
+do_stmt = 'do' block 'end';
 for_stmt = 'for' ID ':' expr block 'end';
 break_stmt = 'break' | 'continue';
 return_stmt = 'return' [expr];
@@ -28,7 +29,7 @@ throw_stmt = 'raise' expr [',' expr];
 var_stmt = 'var' ID ['=' expr] {',' ID ['=' expr]};
 (* expression define *)
 expr_stmt = expr [assign_op expr];
-expr = suffix_expr | unop expr | expr binop expr | range_expr | cond_expr;
+expr = suffix_expr | unop expr | expr binop expr | range_expr | cond_expr | walrus_expr;
 cond_expr = expr '?' expr ':' expr; (* conditional expression *)
 assign_op = '=' | '+=' | '-=' | '*=' | '/=' |
             '%=' | '&=' | '|=' | '^=' | '<<=' | '>>=';
@@ -36,9 +37,11 @@ binop = '<' | '<=' | '==' | '!=' | '>' | '>=' | '||' | '&&' |
         '<<' | '>>' | '&' | '|' | '^' | '+' | '-' | '*' | '/' | '%';
 range_expr = expr '..' [expr]
 unop = '-' | '!' | '~';
+walrus_expr = expr ':=' expr
 suffix_expr = primary_expr {call_expr | ('.' ID) | '[' expr ']'};
 primary_expr = '(' expr ')' | simple_expr | list_expr | map_expr | anon_func | lambda_expr;
-simple_expr =  INTEGER | REAL | STRING | ID | 'true' | 'false' | 'nil';
+simple_expr =  INTEGER | REAL | STRING | ID | 'true' | 'false' | 'nil' | f_string;
+f_string = 'f' STRING
 call_expr = '(' [expr {',' expr}] ')';
 list_expr = '[' {expr ','} [expr] ']';
 map_expr = '{' {expr ':' expr ','} [expr ':' expr] '}';


### PR DESCRIPTION
## Description:

Update informal ebnf grammar definition:
- add `do` block `end` (seemed to be forgotten for a while)
- add `walrus_expr`
- add `f_string`

No change to the firmware.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
