### PR TITLE
New DEEPSLEEP topic for HA + Battery Level % support

### DIFF
--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -733,8 +733,8 @@ typedef struct {
   uint16_t      artnet_universe;           // 734
   uint16_t      modbus_sbaudrate;          // 736
   uint16_t      shutter_motorstop;         // 738
-
-  uint8_t       free_73A[3];               // 73A
+  uint8_t       battery_level_percent;     // 73A
+  uint8_t       free_73B[2];               // 73B
 
   uint8_t       novasds_startingoffset;    // 73D
   uint8_t       web_color[18][3];          // 73E

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -980,6 +980,7 @@ void SettingsDefaultSet2(void) {
   if (Settings->sleep < 50) {
     Settings->sleep = 50;                // Default to 50 for sleep, for now
   }
+  Settings->battery_level_percent = 100;
 
   // Module
   flag.interlock |= APP_INTERLOCK_MODE;

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -980,7 +980,7 @@ void SettingsDefaultSet2(void) {
   if (Settings->sleep < 50) {
     Settings->sleep = 50;                // Default to 50 for sleep, for now
   }
-  Settings->battery_level_percent = 100;
+  Settings->battery_level_percent = 101;
 
   // Module
   flag.interlock |= APP_INTERLOCK_MODE;

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -34,6 +34,7 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
   D_CMND_DEVICENAME "|" D_CMND_FN "|" D_CMND_FRIENDLYNAME "|" D_CMND_SWITCHMODE "|" D_CMND_INTERLOCK "|" D_CMND_TELEPERIOD "|" D_CMND_RESET "|" D_CMND_TIME "|" D_CMND_TIMEZONE "|" D_CMND_TIMESTD "|"
   D_CMND_TIMEDST "|" D_CMND_ALTITUDE "|" D_CMND_LEDPOWER "|" D_CMND_LEDSTATE "|" D_CMND_LEDMASK "|" D_CMND_LEDPWM_ON "|" D_CMND_LEDPWM_OFF "|" D_CMND_LEDPWM_MODE "|"
   D_CMND_WIFIPOWER "|" D_CMND_TEMPOFFSET "|" D_CMND_HUMOFFSET "|" D_CMND_SPEEDUNIT "|" D_CMND_GLOBAL_TEMP "|" D_CMND_GLOBAL_HUM"|" D_CMND_GLOBAL_PRESS "|" D_CMND_SWITCHTEXT "|" D_CMND_WIFISCAN "|" D_CMND_WIFITEST "|"
+  D_CMND_ZIGBEE_BATTPERCENT "|"
 #ifdef USE_I2C
   D_CMND_I2CSCAN "|" D_CMND_I2CDRIVER "|"
 #endif
@@ -73,6 +74,7 @@ void (* const TasmotaCommand[])(void) PROGMEM = {
   &CmndDevicename, &CmndFriendlyname, &CmndFriendlyname, &CmndSwitchMode, &CmndInterlock, &CmndTeleperiod, &CmndReset, &CmndTime, &CmndTimezone, &CmndTimeStd,
   &CmndTimeDst, &CmndAltitude, &CmndLedPower, &CmndLedState, &CmndLedMask, &CmndLedPwmOn, &CmndLedPwmOff, &CmndLedPwmMode,
   &CmndWifiPower, &CmndTempOffset, &CmndHumOffset, &CmndSpeedUnit, &CmndGlobalTemp, &CmndGlobalHum, &CmndGlobalPress, &CmndSwitchText, &CmndWifiScan, &CmndWifiTest,
+  &CmndBatteryPercent,
 #ifdef USE_I2C
   &CmndI2cScan, &CmndI2cDriver,
 #endif
@@ -243,6 +245,14 @@ void CmndWifiTest(void)
 #else
   ResponseCmndError();
 #endif //USE_WEBSERVER
+}
+
+void CmndBatteryPercent(void) {
+  if (XdrvMailbox.payload > 100) XdrvMailbox.payload = 100;
+  if (XdrvMailbox.payload >= 0) {
+      Settings->battery_level_percent = XdrvMailbox.payload;
+  }
+  ResponseCmndNumber(Settings->battery_level_percent);
 }
 
 #endif  // not defined FIRMWARE_MINIMAL_ONLY

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -248,7 +248,7 @@ void CmndWifiTest(void)
 }
 
 void CmndBatteryPercent(void) {
-  if (XdrvMailbox.payload > 100) XdrvMailbox.payload = 100;
+  if (XdrvMailbox.payload > 101) XdrvMailbox.payload = 100;
   if (XdrvMailbox.payload >= 0) {
       Settings->battery_level_percent = XdrvMailbox.payload;
   }

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -829,6 +829,11 @@ void MqttShowState(void)
   ResponseAppendTime();
   ResponseAppend_P(PSTR(",\"" D_JSON_UPTIME "\":\"%s\",\"UptimeSec\":%u"), GetUptime().c_str(), UpTime());
 
+
+// Battery Level expliciet for deepsleep devices
+ResponseAppend_P(PSTR(",\"" D_CMND_ZIGBEE_BATTPERCENT "\":%d"), Settings->battery_level_percent);
+
+
 #ifdef ESP8266
 #ifdef USE_ADC_VCC
   dtostrfd((double)ESP.getVcc()/1000, 3, stemp1);

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -831,7 +831,9 @@ void MqttShowState(void)
 
 
 // Battery Level expliciet for deepsleep devices
-ResponseAppend_P(PSTR(",\"" D_CMND_ZIGBEE_BATTPERCENT "\":%d"), Settings->battery_level_percent);
+if (Settings->battery_level_percent != 101) {
+  ResponseAppend_P(PSTR(",\"" D_CMND_ZIGBEE_BATTPERCENT "\":%d"), Settings->battery_level_percent);
+}
 
 
 #ifdef ESP8266

--- a/tasmota/tasmota_xdrv_driver/xdrv_12_discovery.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_12_discovery.ino
@@ -185,6 +185,8 @@ void TasDiscoverMessage(void) {
                                 "\"117\":%d},"
                         "\"lk\":%d,"                           // Light CTRGB linked
                         "\"lt_st\":%d,"                        // Light SubType
+                        "\"bat\":%d,"                          // Battery operates yes/no
+                        "\"dslp\":%d,"                         // Deepsleep configured yes/no
                         "\"sho\":["),                          // Shutter Options (start)
                         Settings->flag.mqtt_response,
                         Settings->flag.button_swap,
@@ -198,7 +200,10 @@ void TasDiscoverMessage(void) {
                         Settings->flag5.mqtt_switches,
                         Settings->flag5.fade_fixed_duration,
                         light_controller_isCTRGBLinked,
-                        light_subtype);
+                        light_subtype,
+                        Settings->battery_level_percent==101?0:1,
+                        Settings->deepsleep==0?0:1
+                        );
 
   for (uint32_t i = 0; i < TasmotaGlobal.shutters_present; i++) {
 #ifdef USE_SHUTTER

--- a/tasmota/tasmota_xdrv_driver/xdrv_29_deepsleep.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_29_deepsleep.ino
@@ -139,12 +139,12 @@ void DeepSleepStart(void)
   MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR(D_PRFX_DEEPSLEEP), true);
 
   // Change LWT Topic to Sleep to ensure automation see different state
-  GetTopic_P(stopic, TELE, TasmotaGlobal.mqtt_topic, S_LWT);
-  Response_P(PSTR(D_PRFX_DEEPSLEEP));
-  MqttPublish(stopic, true);
+  //GetTopic_P(stopic, TELE, TasmotaGlobal.mqtt_topic, S_LWT);
+  //Response_P(PSTR(D_PRFX_DEEPSLEEP));
+  //MqttPublish(stopic, true);
 
-  MqttClient.disconnect(true);
-  EspClient.stop();
+  //MqttClient.disconnect(true);
+  //EspClient.stop();
   WifiShutdown();
   RtcSettings.ultradeepsleep = RtcSettings.nextwakeup - LocalTime();
   RtcSettingsSave();

--- a/tasmota/tasmota_xdrv_driver/xdrv_29_deepsleep.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_29_deepsleep.ino
@@ -197,6 +197,7 @@ void CmndDeepsleepTime(void)
         Settings->tele_period = TELE_PERIOD;  // Need teleperiod to go back to sleep
       }
     }
+    TasDiscovery();
   }
   ResponseCmndNumber(Settings->deepsleep);
 }


### PR DESCRIPTION
To allow better integration into HA LWT topic will report details of sleep status: 16:54:04.388 MQT: hm/tele/ESP_3284D1/LWT =
DeepSleep

Additionally introduce batterylevel from 0..100 % to be able to send to HA and similar integrations. batterypercentage must be set in a rule or something similar because ways to calculate can be very different. value = 101 does meant powerplug and value is not shown. This is the default

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
