### PR TITLE
More user-friendly defaults for DisplayMode and DisplayDimmer

### DIFF
--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -1289,12 +1289,12 @@ void SettingsDefaultSet2(void) {
 
   // Display
 //  Settings->display_model = 0;
-  Settings->display_mode = 1;
+  Settings->display_mode = 0;
   Settings->display_refresh = 2;
   Settings->display_rows = 2;
   Settings->display_cols[0] = 16;
   Settings->display_cols[1] = 8;
-  Settings->display_dimmer_protected = -10;  // 10%
+  Settings->display_dimmer_protected = -50;  // 50%
   Settings->display_size = 1;
   Settings->display_font = 1;
 //  Settings->display_rotate = 0;


### PR DESCRIPTION
## Description:

Changing default for DisplayMode from 1 to 0. Users are getting confused by the display doing something they did not ask for (and not being aware of DisplayMode). This got worse with LVGL/HASPmota displays becoming common, with users having much less reason to dive into the old DisplayXxxxx commands. And it may even be hard to see that it is even a display of time/date causing the display to flicker.

Changing default for DisplayDimmer from 10% to 50%. The low brightness of 10% is not always easy to see, especially in daylight. 50% is generally better, while not going "full blast" with 100%.

**Related issue (if applicable):** fixes #[18996](https://github.com/arendst/Tasmota/discussions/18996),

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
