### PR TITLE
Berry add metrics for memory allocation/deallocation/reallocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Matter mini-profiler (#19075)
 - Berry `_class` can be used in `static var` initialization code (#19088)
 - Berry add `energy.update_total()` to call `EnergyUpdateTotal()` from energy driver
+- Berry add metrics for memory allocation/deallocation/reallocation
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_debuglib.c
+++ b/lib/libesp32/berry/src/be_debuglib.c
@@ -171,10 +171,40 @@ static int m_counters(bvm *vm)
     map_insert(vm, "try", vm->counter_try);
     map_insert(vm, "raise", vm->counter_exc);
     map_insert(vm, "objects", vm->counter_gc_kept);
+    map_insert(vm, "mem_alloc", vm->counter_mem_alloc);
+    map_insert(vm, "mem_free", vm->counter_mem_free);
+    map_insert(vm, "mem_realloc", vm->counter_mem_realloc);
     be_pop(vm, 1);
     be_return(vm);
 }
 #endif
+
+static int m_allocs(bvm *vm) {
+#if BE_USE_PERF_COUNTERS
+    be_pushint(vm, vm->counter_mem_alloc);
+    be_return(vm);
+#else
+    be_return_nil(vm);
+#endif
+}
+
+static int m_frees(bvm *vm) {
+#if BE_USE_PERF_COUNTERS
+    be_pushint(vm, vm->counter_mem_free);
+    be_return(vm);
+#else
+    be_return_nil(vm);
+#endif
+}
+
+static int m_reallocs(bvm *vm) {
+#if BE_USE_PERF_COUNTERS
+    be_pushint(vm, vm->counter_mem_realloc);
+    be_return(vm);
+#else
+    be_return_nil(vm);
+#endif
+}
 
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(debug) {
@@ -208,6 +238,10 @@ module debug (scope: global, depend: BE_USE_DEBUG_MODULE) {
     top, func(m_top)
     varname, func(m_varname), BE_DEBUG_VAR_INFO
     upvname, func(m_upvname), BE_DEBUG_VAR_INFO
+    // individual counters
+    allocs, func(m_allocs)
+    frees, func(m_frees)
+    reallocs, func(m_reallocs)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_debug.h"

--- a/lib/libesp32/berry/src/be_mem.c
+++ b/lib/libesp32/berry/src/be_mem.c
@@ -60,12 +60,18 @@ BERRY_API void* be_realloc(bvm *vm, void *ptr, size_t old_size, size_t new_size)
 
     while (1) {
         /* Case 1: new allocation */
+#if BE_USE_PERF_COUNTERS
+        vm->counter_mem_alloc++;
+#endif
         if (!ptr || (old_size == 0)) {
             block = malloc_from_pool(vm, new_size);
         }
     
         /* Case 2: deallocate */
         else if (new_size == 0) {
+#if BE_USE_PERF_COUNTERS
+            vm->counter_mem_free++;
+#endif
             if (ptr == NULL) { return NULL; }   /* safeguard */
 #if BE_USE_DEBUG_GC
             memset(ptr, 0xFF, old_size); /* fill the structure with invalid pointers */
@@ -76,6 +82,9 @@ BERRY_API void* be_realloc(bvm *vm, void *ptr, size_t old_size, size_t new_size)
 
         /* Case 3: reallocate with a different size */
         else if (new_size && old_size) {        // TODO we already know they are not null TODO
+#if BE_USE_PERF_COUNTERS
+            vm->counter_mem_realloc++;
+#endif
             if (new_size <= POOL32_SIZE || old_size <=POOL32_SIZE) {
                 /* complex case with different pools */
                 if (new_size <= POOL16_SIZE && old_size <= POOL16_SIZE) {

--- a/lib/libesp32/berry/src/be_vm.c
+++ b/lib/libesp32/berry/src/be_vm.c
@@ -512,6 +512,9 @@ BERRY_API bvm* be_vm_new(void)
     vm->counter_exc = 0;
     vm->counter_gc_kept = 0;
     vm->counter_gc_freed = 0;
+    vm->counter_mem_alloc = 0;
+    vm->counter_mem_free = 0;
+    vm->counter_mem_realloc = 0;
 #endif
     return vm;
 }

--- a/lib/libesp32/berry/src/be_vm.h
+++ b/lib/libesp32/berry/src/be_vm.h
@@ -119,6 +119,9 @@ struct bvm {
     uint32_t counter_exc; /* counter for raised exceptions */
     uint32_t counter_gc_kept; /* counter for objects scanned by last gc */
     uint32_t counter_gc_freed; /* counter for objects freed by last gc */
+    uint32_t counter_mem_alloc; /* counter for memory allocations */
+    uint32_t counter_mem_free; /* counter for memory frees */
+    uint32_t counter_mem_realloc; /* counter for memory reallocations */
 
     uint32_t micros_gc0;
     uint32_t micros_gc1;


### PR DESCRIPTION
## Description:

Berry add performance metrics for memory allocation/reallocation/deallocation. This is used in conjonction with profiling for performance improvements.

```berry
> import debug
> debug.counters()
{'mem_alloc': 690462, 'call': 9464190, 'getgbl': 970943, 'raise': 9801, 'mem_realloc': 26861, 'mem_free': 331487, 'get': 14289189, 'objects': 312, 'set': 130220, 'try': 226339, 'vmenter': 7523827, 'instruction': 70154895}

> debug.allocs()
696966

> debug.reallocs()
27203

> debug.frees()
336902
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
