### PR TITLE
Berry `tasmota.loglevel()` and `tasmota.rtc_utc()` for faster performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Berry `_class` can be used in `static var` initialization code (#19088)
 - Berry add `energy.update_total()` to call `EnergyUpdateTotal()` from energy driver
 - Berry add metrics for memory allocation/deallocation/reallocation
+- Berry `tasmota.loglevel()` and `tasmota.rtc_utc()` for faster performance
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
@@ -21,6 +21,7 @@ extern int l_getoption(bvm *vm);
 extern int l_millis(bvm *vm);
 extern int l_timereached(bvm *vm);
 extern int l_rtc(bvm *vm);
+extern int l_rtc_utc(bvm *vm);
 extern int l_time_dump(bvm *vm);
 extern int l_strftime(bvm *vm);
 extern int l_strptime(bvm *vm);
@@ -33,6 +34,7 @@ extern int l_delay(bvm *vm);
 extern int l_delay_microseconds(bvm *vm);
 extern int l_scaleuint(bvm *vm);
 extern int l_logInfo(bvm *vm);
+extern int l_loglevel(bvm *vm);
 extern int l_save(bvm *vm);
 extern int t_random_byte(bvm *vm);
 extern int l_locale(bvm *vm);
@@ -99,6 +101,7 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     millis, func(l_millis)
     time_reached, func(l_timereached)
     rtc, func(l_rtc)
+    rtc_utc, func(l_rtc_utc)
     time_dump, func(l_time_dump)
     strftime, func(l_strftime)
     strptime, func(l_strptime)
@@ -111,6 +114,7 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     delay_microseconds, func(l_delay_microseconds)
     scale_uint, func(l_scaleuint)
     log, func(l_logInfo)
+    loglevel, func(l_loglevel)
     save, func(l_save)
     locale, func(l_locale)
 

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -2478,13 +2478,18 @@ void AddLogData(uint32_t loglevel, const char* log_data, const char* log_data_pa
   }
 }
 
-void AddLog(uint32_t loglevel, PGM_P formatP, ...) {
+uint32_t HighestLogLevel() {
   uint32_t highest_loglevel = TasmotaGlobal.seriallog_level;
   if (Settings->weblog_level > highest_loglevel) { highest_loglevel = Settings->weblog_level; }
   if (Settings->mqttlog_level > highest_loglevel) { highest_loglevel = Settings->mqttlog_level; }
   if (TasmotaGlobal.syslog_level > highest_loglevel) { highest_loglevel = TasmotaGlobal.syslog_level; }
   if (TasmotaGlobal.templog_level > highest_loglevel) { highest_loglevel = TasmotaGlobal.templog_level; }
   if (TasmotaGlobal.uptime < 3) { highest_loglevel = LOG_LEVEL_DEBUG_MORE; }  // Log all before setup correct log level
+  return highest_loglevel;
+}
+
+void AddLog(uint32_t loglevel, PGM_P formatP, ...) {
+  uint32_t highest_loglevel = HighestLogLevel();
 
   // If no logging is requested then do not access heap to fight fragmentation
   if ((loglevel <= highest_loglevel) && (TasmotaGlobal.masterlog_level <= highest_loglevel)) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -183,6 +183,14 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
+  // Berry: tasmota.rtc_utc() -> int
+  //
+  int32_t l_rtc_utc(struct bvm *vm);
+  int32_t l_rtc_utc(struct bvm *vm) {
+    be_pushint(vm, Rtc.utc_time);
+    be_return(vm);
+  }
+
   // Berry: tasmota.memory() -> map
   //
   int32_t l_memory(struct bvm *vm);
@@ -790,6 +798,23 @@ extern "C" {
  *
 \*********************************************************************************************/
 extern "C" {
+  // Berry: `loglevel() -> int`
+  // or
+  // Berry: `loglevel(int) -> bool`
+  // return the highest log level currently in place
+  int32_t l_loglevel(struct bvm *vm);
+  int32_t l_loglevel(struct bvm *vm) {
+    int32_t top = be_top(vm); // Get the number of arguments
+    uint32_t highest_loglevel = HighestLogLevel();
+    if (top >= 2 && be_isint(vm, 2)) {
+      int32_t log_level = be_toint(vm, 2);
+      be_pushbool(vm, log_level <= highest_loglevel);
+    } else {
+      be_pushint(vm, HighestLogLevel());
+    }
+    be_return(vm);
+  }
+
   // Berry: `log(msg:string [,log_level:int]) ->nil`
   // Logs the string at LOG_LEVEL_INFO (loglevel=2)
   // We allow this function to be called as a method or a direct function


### PR DESCRIPTION
## Description:

Berry, add the following functions to `tasmota` object, which allows improved performance:
- `tasmota.rtc_utc() -> int` returns the current time in seconds in UTC. This is equivalent to `tasmota.rtc()['UTC']` but saves the allocation of a map.
- `tasmota.loglevel() -> int` returns the current highest log_level, or `tasmota.loglevel(int) -> bool` returns true if the passed level is logged.

You can now gate logs with the following:
```berry
[...]
if tasmota.loglevel(4)
  tasmota.log("ZZZ: my logs", 4)
end
[...]
```

Examples:
```berry
> tasmota.rtc_utc()
1689792536

> tasmota.loglevel()
3

> tasmota.loglevel(3)
true

> tasmota.loglevel(4)
false
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
