### PR TITLE
Berry add AES CCM decrypting in a single call to avoid any object allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Berry add `energy.update_total()` to call `EnergyUpdateTotal()` from energy driver
 - Berry add metrics for memory allocation/deallocation/reallocation
 - Berry `tasmota.loglevel()` and `tasmota.rtc_utc()` for faster performance
+- Berry add AES CCM decrypting in a single call to avoid any object allocation
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
@@ -14,8 +14,9 @@ extern int m_crypto_random(bvm *vm);
 extern int m_rsa_rsassa_pkcs1_v1_5(bvm *vm);
 
 extern int m_aes_ccm_init(bvm *vm);
-extern int m_aes_ccm_encryt(bvm *vm);
-extern int m_aes_ccm_decryt(bvm *vm);
+extern int m_aes_ccm_encrypt(bvm *vm);
+extern int m_aes_ccm_decrypt(bvm *vm);
+extern int m_aes_ccm_decrypt1(bvm *vm);
 extern int m_aes_ccm_tag(bvm *vm);
 
 extern int m_aes_gcm_init(bvm *vm);
@@ -134,9 +135,11 @@ class be_class_aes_ccm (scope: global, name: AES_CCM) {
     .p2, var
 
     init, func(m_aes_ccm_init)
-    encrypt, func(m_aes_ccm_encryt)
-    decrypt, func(m_aes_ccm_decryt)
+    encrypt, func(m_aes_ccm_encrypt)
+    decrypt, func(m_aes_ccm_decrypt)
     tag, func(m_aes_ccm_tag)
+
+    decrypt1, static_func(m_aes_ccm_decrypt1)
 }
 
 class be_class_aes_gcm (scope: global, name: AES_GCM) {


### PR DESCRIPTION
## Description:

Berry add `crypto.AES_CCM.decrypt1()` to decrypt and check the MIC in a single call. This prevents any Berry object allocation, decryption is done in-place.

```berry
AES_CCM.decrypt1(
      secret_key:bytes(16 or 32),
      iv:bytes(), iv_start:int, iv_len:int (7..13),
      aad:bytes(), aad_start:int, aad_len:int,
      data:bytes(), data_start:int, data_len:int,
      tag:bytes(), tag_start:int, tag_len:int (4..16))
      -> bool (true if tag matches)
```

Example from Matter:
```berry
# raw_in is the received frame
raw_in = bytes("00A0DE009A5E3D0F3E85246C0EB1AA630A99042B82EC903483E26A4148C8AC909B12EF8CDB6B144493ABD6278EDBA8859C9B2C")

payload_idx = 8     # unencrypted header is 8 bytes
tag_len = 16        # MIC is 16 bytes

p = raw[payload_idx .. -tag_len - 1]   # payload
mic = raw[-tag_len .. ]                # MIC
a = raw[0 .. payload_idx - 1]          # AAD

i2r = bytes("92027B9F0DBC82491D4C3B3AFA5F2DEB")   # key
# p   = bytes("3E85246C0EB1AA630A99042B82EC903483E26A4148C8AC909B12EF")
# a 	= bytes("00A0DE009A5E3D0F")
n   = bytes("009A5E3D0F0000000000000000")         # nonce / IV
# mic = bytes("8CDB6B144493ABD6278EDBA8859C9B2C")

# expected cleartext
clr = bytes("05024FF601001536001724020024031D2404031818290324FF0118")

# method 1 - with distinct calls
import crypto
aes = crypto.AES_CCM(i2r, n, a, size(p), 16)
cleartext = aes.decrypt(p)
tag = aes.tag()

assert(cleartext == clr)
assert(tag == mic)

# method 2 - single call
raw = raw_in.copy()      # copy first if we want to keep the encrypted version
var ret = crypto.AES_CCM.decrypt1(i2r, n, 0, size(n), raw, 0, payload_idx, raw, payload_idx, size(raw) - payload_idx - tag_len, raw, size(raw) - tag_len, tag_len)

assert(ret)
assert(raw[payload_idx .. -tag_len - 1] == clr)
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
