### PR TITLE
changing reference to xsns109

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_110_max17043.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_110_max17043.ino
@@ -1,5 +1,5 @@
 /*
-  xsns_109_max17043.ino - Support for MAX17043 fuel-gauge systems Lipo batteries for Tasmota
+  xsns_110_max17043.ino - Support for MAX17043 fuel-gauge systems Lipo batteries for Tasmota
 
   Copyright (C) 2023  Vincent de Groot
 
@@ -48,7 +48,7 @@
  * 
  \*********************************************************************************************/
 
-#define XSNS_109        109
+#define XSNS_110        110
 
 const char *mqttId = "MAX17043";
 
@@ -104,7 +104,7 @@ void Max17043Show(void) {
  *  Interface
 \*********************************************************************************************/
 
-bool Xsns109(uint32_t function) {
+bool Xsns110(uint32_t function) {
 if (!I2cEnabled(MAX17043_ADDRESS)) { return false; } 
 
   if (FUNC_INIT == function) {


### PR DESCRIPTION
## Description:

For some reason there still was a reference to xsns109 in this file, did not see this yesterday. Yesterday I used tasmota32-base environment, today I switched to tasmota32 environment and got a problem with compiling.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
