### PR TITLE
Berry `mqtt.publish` now distinguishes between `string` and `bytes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Initial ``DisplayMode`` from 1 to 0 and ``DisplayDimmmer`` from 10% to 50% (#19138)
 - ESP32 Framework (Core) from v2.0.10 to v2.0.11
+- Berry `mqtt.publish` now distinguishes between `string` and `bytes`
 
 ### Fixed
 - Initial battery level percentage (#19160)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mqtt.ino
@@ -33,8 +33,10 @@ extern "C" {
       bool retain = false;
       int32_t payload_start = 0;
       int32_t len = -1;   // send all of it
+      bool is_binary = be_isbytes(vm, 3);       // is this a binary payload (or false = string)
       if (top >= 4) { retain = be_tobool(vm, 4); }
       if (top >= 5) {
+        if (!is_binary) { be_raise(vm, "argument_error", "start and len are not allowed with string payloads"); }
         payload_start = be_toint(vm, 5);
         if (payload_start < 0) payload_start = 0;
       }
@@ -60,7 +62,7 @@ extern "C" {
 
       be_pop(vm, be_top(vm));   // clear stack to avoid any indirect warning message in subsequent calls to Berry
 
-      MqttPublishPayload(topic, payload, len, retain);
+      MqttPublishPayload(topic, payload, is_binary ? len : 0 /*if string don't send length*/, retain);
 
       be_return_nil(vm); // Return
     }


### PR DESCRIPTION
## Description:

Berry was sending all mqtt messages as raw bytes, which pollutes the logs. Now Berry sends payload from `mqtt.publish()` as `string` or `bytes` depending on the type of the argument.

Note: when sending strings, argument `start` and `len` are not allowed; in such case create the substring before calling `mqtt.publish()`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
