### PR TITLE
Berry improve `tasmota.scale_uint()`

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
@@ -112,7 +112,7 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     yield, func(l_yield)
     delay, func(l_delay)
     delay_microseconds, func(l_delay_microseconds)
-    scale_uint, func(l_scaleuint)
+    scale_uint, static_func(l_scaleuint)
     log, func(l_logInfo)
     loglevel, func(l_loglevel)
     save, func(l_save)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -395,7 +395,18 @@ extern "C" {
   //
   int32_t l_scaleuint(struct bvm *vm);
   int32_t l_scaleuint(struct bvm *vm) {
-    return be_call_c_func(vm, (void*) &changeUIntScale, "i", "-iiiii");
+    int32_t top = be_top(vm); // Get the number of arguments
+    if (top == 5 && be_isint(vm, 1) && be_isint(vm, 2) && be_isint(vm, 3) && be_isint(vm, 4) && be_isint(vm, 5)) {
+      int32_t val = be_toint(vm, 1);
+      int32_t from_min = be_toint(vm, 2);
+      int32_t from_max = be_toint(vm, 3);
+      int32_t to_min = be_toint(vm, 4);
+      int32_t to_max = be_toint(vm, 5);
+      int32_t scaled = changeUIntScale(val, from_min, from_max, to_min, to_max);
+      be_pushint(vm, scaled);
+      be_return(vm);
+    }
+    be_raise(vm, kTypeError, nullptr);
   }
 
   int32_t l_respCmnd(bvm *vm);


### PR DESCRIPTION
## Description:

Move `tasmota.scale_uint()` as static function, and refactor as native function instead of berry_mapping to improve performance.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
