### PR TITLE
Zigbee decode Aqara 0000/FF01 attribute 03 as Temperature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Support for MAX17043 fuel-gauge systems Lipo batteries (#18788)
 - Support for multiple PCA9685 with extended functionality (#18805)
+- Zigbee decode Aqara 0000/FF01 attribute 03 as Temperature
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -1214,6 +1214,8 @@ void ZCLFrame::syntheticAqaraSensor(Z_attribute_list &attr_list, class Z_attribu
         attr_list.addAttribute(0x0001, 0x0020).setFloat(batteryvoltage);
         uint8_t batterypercentage = toPercentageCR2032(uval32);
         attr_list.addAttribute(0x0001, 0x0021).setUInt(batterypercentage * 2);
+      } else if (0x03 == attrid) {
+        attr_list.addAttributePMEM("Temperature").copyVal(attr);   // Temperature
       } else if ((nullptr != modelId) && ((0 == getManufCode()) || (0x115F == getManufCode()))) {
         translated = true;
         if (modelId.startsWith(F("lumi.sensor_magnet"))) {   // door / window sensor

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -1215,7 +1215,7 @@ void ZCLFrame::syntheticAqaraSensor(Z_attribute_list &attr_list, class Z_attribu
         uint8_t batterypercentage = toPercentageCR2032(uval32);
         attr_list.addAttribute(0x0001, 0x0021).setUInt(batterypercentage * 2);
       } else if (0x03 == attrid) {
-        attr_list.addAttributePMEM("Temperature").copyVal(attr);   // Temperature
+        attr_list.addAttributePMEM("AqaraTemperature").copyVal(attr);   // Temperature
       } else if ((nullptr != modelId) && ((0 == getManufCode()) || (0x115F == getManufCode()))) {
         translated = true;
         if (modelId.startsWith(F("lumi.sensor_magnet"))) {   // door / window sensor


### PR DESCRIPTION
## Description:

Decodes attribute "03" from Aqara specific attribute 0000/FF01. This attribute is known to be temperature as an int.

To avoid scrambling more precise temperature readings, this measure is published as "AqaraTemperature".

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
