### PR TITLE
Reduced log level for TeleInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 Framework (Core) from v2.0.10 to v2.0.11
 - Berry `mqtt.publish` now distinguishes between `string` and `bytes`
 - IRremoteESP8266 library from v2.8.5 to v2.8.6
+- Reduced log level for TeleInfo
 
 ### Fixed
 - Initial battery level percentage (#19160)

--- a/tasmota/tasmota_xnrg_energy/xnrg_15_teleinfo.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_15_teleinfo.ino
@@ -406,7 +406,7 @@ void DataCallback(struct _ValueList * me, uint8_t  flags)
                     AddLog(LOG_LEVEL_DEBUG, PSTR("TIC: HC:%ld  HP:%ld  Total:%ld"), hc, hp, total_wh);
                 }
 
-                AddLog (LOG_LEVEL_INFO, PSTR ("TIC: Total counter updated to %ld Wh"), total_wh);
+                AddLog (LOG_LEVEL_DEBUG_MORE, PSTR ("TIC: Total counter updated to %ld Wh"), total_wh);
                 if (total_wh>0) {
                     Energy->total[0] = (float) total_wh / 1000.0f;
                     Energy->import_active[0] = Energy->total[0];
@@ -422,17 +422,17 @@ void DataCallback(struct _ValueList * me, uint8_t  flags)
                 total_wh = atol(me->value);
                 Energy->total[0] = (float) total_wh / 1000.0f;
                 Energy->import_active[0] = Energy->total[0];
-                AddLog(LOG_LEVEL_DEBUG, PSTR("TIC: Total:%ldWh"), total_wh);
+                AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("TIC: Total:%ldWh"), total_wh);
             }
 
             // Wh indexes (standard)
             else if ( ilabel == LABEL_EASF01)
             {
-                AddLog(LOG_LEVEL_DEBUG, PSTR("TIC: HC:%ld"), atol(me->value));
+                AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("TIC: HC:%ld"), atol(me->value));
             }
             else if ( ilabel == LABEL_EASF02)
             {
-                AddLog(LOG_LEVEL_DEBUG, PSTR("TIC: HP:%ld"), atol(me->value));
+                AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("TIC: HP:%ld"), atol(me->value));
             }
 
             // Contract subscribed (legacy)
@@ -468,7 +468,7 @@ void DataCallback(struct _ValueList * me, uint8_t  flags)
             else if (ilabel == LABEL_ISOUSC)
             {
                 isousc = atoi( me->value);
-                AddLog(LOG_LEVEL_DEBUG, PSTR("TIC: ISousc set to %d"), isousc);
+                AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("TIC: ISousc set to %d"), isousc);
             }
 
             // Contract subscribed (Power in KVA)
@@ -477,20 +477,20 @@ void DataCallback(struct _ValueList * me, uint8_t  flags)
                 // Convert KVA to A
                 isousc  = atoi( me->value) * 5  ;
 
-                AddLog(LOG_LEVEL_DEBUG, PSTR("TIC: ISousc set to %d"), isousc);
+                AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("TIC: ISousc set to %d"), isousc);
             }
 
             // Serial Number of device
             else if (ilabel == LABEL_ADCO || ilabel == LABEL_ADSC)
             {
                 strcpy(serialNumber, me->value);
-                AddLog(LOG_LEVEL_DEBUG, PSTR("TIC: %s set to %s"), me->name, serialNumber);
+                AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("TIC: %s set to %s"), me->name, serialNumber);
             }
             // Status
             else if (ilabel == LABEL_STGE)
             {
                 status_register = strtol(me->value, nullptr, 16);
-                AddLog(LOG_LEVEL_DEBUG, PSTR("Status Resister : %s set to %08X"), me->name, status_register);
+                AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Status Resister : %s set to %08X"), me->name, status_register);
             }
             
         }
@@ -786,7 +786,7 @@ bool TInfoCmd(void) {
     // At least "EnergyConfig"
     if (CMND_ENERGYCONFIG == Energy->command_code) {
 
-        AddLog(LOG_LEVEL_DEBUG, PSTR("TIC: len %d, data '%s'"), XdrvMailbox.data_len, XdrvMailbox.data ? XdrvMailbox.data : "null" );
+        AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("TIC: len %d, data '%s'"), XdrvMailbox.data_len, XdrvMailbox.data ? XdrvMailbox.data : "null" );
 
         // Just "EnergyConfig" no more parameter
         // Show Teleinfo configuration
@@ -838,7 +838,7 @@ bool TInfoCmd(void) {
 
             int command_code = GetCommandCode(command, sizeof(command), pParam, kTInfo_Commands);
 
-            AddLog(LOG_LEVEL_DEBUG, PSTR("TIC: param '%s' cmnd %d"), pParam, command_code);
+            AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("TIC: param '%s' cmnd %d"), pParam, command_code);
 
             switch (command_code) {
                 case CMND_TELEINFO_STANDARD:
@@ -1002,7 +1002,7 @@ void TInfoProcess(void)
     // if needed, update energy total every hour
     if (tick_update++ > 3600 * 4) {
         EnergyUpdateTotal();
-        AddLog (LOG_LEVEL_INFO, PSTR ("TIC: Total counter updated to %lu Wh"), total_wh);
+        AddLog (LOG_LEVEL_DEBUG, PSTR ("TIC: Total counter updated to %lu Wh"), total_wh);
         tick_update = 0;
     }
 


### PR DESCRIPTION
## Description:

I took the liberty of reducing log level for TeleInfo. It used to output logs every 6 seconds which is too verbose for normal operations.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
