### PR TITLE
Berry bytes `get` and `set` work for 3 bytes values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Support for MAX17043 fuel-gauge systems Lipo batteries (#18788)
 - Support for multiple PCA9685 with extended functionality (#18805)
 - Zigbee decode Aqara 0000/FF01 attribute 03 as Temperature
+- Berry bytes `get` and `set` work for 3 bytes values
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_byteslib.c
+++ b/lib/libesp32/berry/src/be_byteslib.c
@@ -356,6 +356,40 @@ static uint16_t buf_get2_be(buf_impl* attr, size_t offset)
     return 0;
 }
 
+static uint32_t buf_get3_le(buf_impl* attr, size_t offset)
+{
+    if ((int32_t)offset + 2 < attr->len) {
+        return attr->bufptr[offset] | (attr->bufptr[offset+1] << 8) | (attr->bufptr[offset+2] << 16);
+    }
+    return 0;
+}
+
+static uint16_t buf_get3_be(buf_impl* attr, size_t offset)
+{
+    if ((int32_t)offset + 2 < attr->len) {
+        return attr->bufptr[offset+2] | (attr->bufptr[offset+1] << 8) | (attr->bufptr[offset] << 16);
+    }
+    return 0;
+}
+
+static void buf_set3_le(buf_impl* attr, size_t offset, uint32_t data)
+{
+    if ((int32_t)offset + 2 < attr->len) {
+        attr->bufptr[offset] = data & 0xFF;
+        attr->bufptr[offset+1] = (data >> 8) & 0xFF;
+        attr->bufptr[offset+2] = (data >> 16) & 0xFF;
+    }
+}
+
+static void buf_set3_be(buf_impl* attr, size_t offset, uint32_t data)
+{
+    if ((int32_t)offset + 2 < attr->len) {
+        attr->bufptr[offset+2] = data & 0xFF;
+        attr->bufptr[offset+1] = (data >> 8) & 0xFF;
+        attr->bufptr[offset] = (data >> 16) & 0xFF;
+    }
+}
+
 static void buf_set4_le(buf_impl* attr, size_t offset, uint32_t data)
 {
     if ((int32_t)offset + 3 < attr->len) {
@@ -832,9 +866,15 @@ static int m_get(bvm *vm, bbool sign)
             case 2:     ret = buf_get2_le(&attr, idx);
                         if (sign) { ret = (int16_t)(uint16_t) ret; }
                         break;
+            case 3:     ret = buf_get3_le(&attr, idx);
+                        if (sign & (ret & 0x800000)) { ret = ret | 0xFF000000; }
+                        break;
             case 4:     ret = buf_get4_le(&attr, idx);    break;
             case -2:    ret = buf_get2_be(&attr, idx);
                         if (sign) { ret = (int16_t)(uint16_t) ret; }
+                        break;
+            case -3:    ret = buf_get3_be(&attr, idx);
+                        if (sign & (ret & 0x800000)) { ret = ret | 0xFF000000; }
                         break;
             case -4:    ret = buf_get4_be(&attr, idx);    break;
             default:    be_raise(vm, "type_error", "size must be -4, -2, -1, 0, 1, 2 or 4.");
@@ -911,8 +951,10 @@ static int m_set(bvm *vm)
             case -1:    /* fallback below */
             case 1:     buf_set1(&attr, idx, value);      break;
             case 2:     buf_set2_le(&attr, idx, value);   break;
+            case 3:     buf_set3_le(&attr, idx, value);   break;
             case 4:     buf_set4_le(&attr, idx, value);   break;
             case -2:    buf_set2_be(&attr, idx, value);   break;
+            case -3:    buf_set3_be(&attr, idx, value);   break;
             case -4:    buf_set4_be(&attr, idx, value);   break;
             default:    be_raise(vm, "type_error", "size must be -4, -2, -1, 0, 1, 2 or 4.");
         }

--- a/lib/libesp32/berry/src/be_byteslib.c
+++ b/lib/libesp32/berry/src/be_byteslib.c
@@ -877,7 +877,7 @@ static int m_get(bvm *vm, bbool sign)
                         if (sign & (ret & 0x800000)) { ret = ret | 0xFF000000; }
                         break;
             case -4:    ret = buf_get4_be(&attr, idx);    break;
-            default:    be_raise(vm, "type_error", "size must be -4, -2, -1, 0, 1, 2 or 4.");
+            default:    be_raise(vm, "type_error", "size must be -4, -3, -2, -1, 0, 1, 2, 3 or 4.");
         }
         be_pop(vm, argc - 1);
         if (vsize != 0) {
@@ -956,7 +956,7 @@ static int m_set(bvm *vm)
             case -2:    buf_set2_be(&attr, idx, value);   break;
             case -3:    buf_set3_be(&attr, idx, value);   break;
             case -4:    buf_set4_be(&attr, idx, value);   break;
-            default:    be_raise(vm, "type_error", "size must be -4, -2, -1, 0, 1, 2 or 4.");
+            default:    be_raise(vm, "type_error", "size must be -4, -3, -2, -1, 0, 1, 2, 3 or 4.");
         }
         be_pop(vm, argc - 1);
         m_write_attributes(vm, 1, &attr);  /* update attributes */


### PR DESCRIPTION
## Description:

Extend `bytes()` `get()` and `set()` to support 3-bytes integers. Before, only sizes 1/2/4 were accepted.

This will be useful to manipulate 0xRRGGBB values directly from raw binary.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
