### PR TITLE
Matter support for fabric_filtered request (for Google compatibility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Support for multiple PCA9685 with extended functionality (#18805)
 - Zigbee decode Aqara 0000/FF01 attribute 03 as Temperature
 - Berry bytes `get` and `set` work for 3 bytes values
+- Matter support for fabric_filtered request (for Google compatibility)
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning.be
@@ -289,18 +289,22 @@ class Matter_Commisioning_Context
     import crypto
     # Validate Sigma1 Destination ID, p.162
     # traverse all existing fabrics
-    tasmota.log("MTR: SEARCHING: destinationId=" + destinationId.tohex(), 4)
+    if tasmota.loglevel(4)
+      tasmota.log("MTR: SEARCHING: destinationId=" + destinationId.tohex(), 4)
+    end
     for fabric : self.device.sessions.fabrics
       if fabric.noc == nil || fabric.fabric_id == nil || fabric.device_id == nil     continue end
       # compute candidateDestinationId, Section 4.13.2.4.1, “Destination Identifier”
       var destinationMessage = initiatorRandom + fabric.get_ca_pub() + fabric.fabric_id + fabric.device_id
       var key = fabric.get_ipk_group_key()
-      tasmota.log("MTR: SIGMA1: destinationMessage=" + destinationMessage.tohex(), 4)
+      # tasmota.log("MTR: SIGMA1: destinationMessage=" + destinationMessage.tohex(), 4)
       # tasmota.log("MTR: SIGMA1: key_ipk=" + key.tohex(), 4)
       var h = crypto.HMAC_SHA256(key)
       h.update(destinationMessage)
       var candidateDestinationId = h.out()
-      tasmota.log("MTR: SIGMA1: candidateDestinationId=" + candidateDestinationId.tohex(), 4)
+      if tasmota.loglevel(4)
+        tasmota.log("MTR: SIGMA1: candidateDestinationId=" + candidateDestinationId.tohex(), 4)
+      end
       if candidateDestinationId == destinationId
         return fabric
       end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
@@ -431,7 +431,7 @@ class Matter_Device
     var fabric = session.get_fabric()
     var fabric_id = fabric.get_fabric_id().copy().reverse().tohex()
     var vendor_name = fabric.get_admin_vendor_name()
-    tasmota.log(format("MTR: --- Commissioning complete for Fabric '%s' (Vendor %s) ---", fabric_id, vendor_name), 2)
+    tasmota.log(f"MTR: --- Commissioning complete for Fabric '{fabric_id}' (Vendor {vendor_name}) ---", 2)
     self.stop_basic_commissioning()     # by default close commissioning when it's complete
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
@@ -302,6 +302,7 @@ class Matter_IM
       ctx.endpoint = q.endpoint
       ctx.cluster = q.cluster
       ctx.attribute = q.attribute
+      ctx.fabric_filtered = query.fabric_filtered
       ctx.status = matter.UNSUPPORTED_ATTRIBUTE   #default error if returned `nil`
       
       # expand endpoint
@@ -772,8 +773,11 @@ class Matter_IM
       ctx.attribute = q.attribute
       attr_req.push(str(ctx))
     end
-    tasmota.log(format("MTR: >Subscribe (%6i) %s (min=%i, max=%i, keep=%i) sub=%i",
-                              msg.session.local_session_id, attr_req.concat(" "), sub.min_interval, sub.max_interval, query.keep_subscriptions ? 1 : 0, sub.subscription_id), 3)
+    tasmota.log(format("MTR: >Subscribe (%6i) %s (min=%i, max=%i, keep=%i) sub=%i fabric_filtered=%s",
+                              msg.session.local_session_id, attr_req.concat(" "), sub.min_interval, sub.max_interval, query.keep_subscriptions ? 1 : 0, sub.subscription_id, query.fabric_filtered), 3)
+    if query.event_requests != nil && size(query.event_requests) > 0
+      tasmota.log(f"MTR: >Subscribe (%6i) event_requests_size={size(query.event_requests)}", 3)
+    end
 
     var ret = self._inner_process_read_request(msg.session, query, true #-no_log-#)
     # ret is of type `Matter_ReportDataMessage`

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Path.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Path.be
@@ -56,6 +56,7 @@ class Matter_Path
       s += (self.cluster   != nil ? format("%04X/", self.cluster) : "****/")
       s += (self.attribute != nil ? format("%04X", self.attribute) : "")
       s += (self.command   != nil ? format("%04X", self.command) : "")
+      if self.fabric_filtered   s += "!"    end
       if self.attribute == nil && self.command == nil     s += "****" end
       return s
     except .. as e, m

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
@@ -155,7 +155,9 @@ class Matter_Plugin_Root : Matter_Plugin
 
       if   attribute == 0x0000          #  ---------- NOCs / list[NOCStruct] ----------
         var nocl = TLV.Matter_TLV_array() # NOCs, p.711
-        for loc_fabric: self.device.sessions.active_fabrics()
+        var fabs = ctx.fabric_filtered ? [session.get_fabric()] : self.device.sessions.active_fabrics()
+        for loc_fabric: fabs
+          if loc_fabric == nil    continue  end
           var nocs = nocl.add_struct(nil)
           nocs.add_TLV(1, TLV.B2, loc_fabric.get_noc())      # NOC
           nocs.add_TLV(2, TLV.B2, loc_fabric.get_icac())     # ICAC
@@ -164,7 +166,9 @@ class Matter_Plugin_Root : Matter_Plugin
         return nocl
       elif attribute == 0x0001          #  ---------- Fabrics / list[FabricDescriptorStruct] ----------
         var fabrics = TLV.Matter_TLV_array() # Fabrics, p.711
-        for loc_fabric: self.device.sessions.active_fabrics()
+        var fabs = ctx.fabric_filtered ? [session.get_fabric()] : self.device.sessions.active_fabrics()
+        for loc_fabric: fabs
+          if loc_fabric == nil    continue  end
           var root_ca_tlv = TLV.parse(loc_fabric.get_ca())
           var fab = fabrics.add_struct(nil)            # encoding see p.303
           fab.add_TLV(1, TLV.B2, root_ca_tlv.findsubval(9)) # RootPublicKey

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Session.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Session.be
@@ -254,7 +254,8 @@ class Matter_Session : Matter_Expirable
   def get_icac()              return self._fabric.icac              end
   def get_ipk_epoch_key()     return self._fabric.ipk_epoch_key     end
   def get_fabric_id()         return self._fabric.fabric_id         end
-  def get_device_id()         return self._fabric.device_id         end
+  def get_fabric_index()      return self._fabric ? self._fabric.fabric_index  : nil    end
+  def get_device_id()         return self._fabric ? self._fabric.device_id : nil        end
   def get_fabric_compressed() return self._fabric.fabric_compressed end
   def get_fabric_label()      return self._fabric.fabric_label      end
   def get_admin_subject()     return self._fabric.admin_subject     end

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
@@ -69,18 +69,18 @@ be_local_closure(Matter_Commisioning_Context_find_fabric_by_destination_id,   /*
     ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20SEARCHING_X3A_X20destinationId_X3D),
-    /* K4   */  be_nested_str_weak(tohex),
-    /* K5   */  be_nested_str_weak(device),
-    /* K6   */  be_nested_str_weak(sessions),
-    /* K7   */  be_nested_str_weak(fabrics),
-    /* K8   */  be_nested_str_weak(noc),
-    /* K9   */  be_nested_str_weak(fabric_id),
-    /* K10  */  be_nested_str_weak(device_id),
-    /* K11  */  be_nested_str_weak(get_ca_pub),
-    /* K12  */  be_nested_str_weak(get_ipk_group_key),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20SIGMA1_X3A_X20destinationMessage_X3D),
+    /* K2   */  be_nested_str_weak(loglevel),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20SEARCHING_X3A_X20destinationId_X3D),
+    /* K5   */  be_nested_str_weak(tohex),
+    /* K6   */  be_nested_str_weak(device),
+    /* K7   */  be_nested_str_weak(sessions),
+    /* K8   */  be_nested_str_weak(fabrics),
+    /* K9   */  be_nested_str_weak(noc),
+    /* K10  */  be_nested_str_weak(fabric_id),
+    /* K11  */  be_nested_str_weak(device_id),
+    /* K12  */  be_nested_str_weak(get_ca_pub),
+    /* K13  */  be_nested_str_weak(get_ipk_group_key),
     /* K14  */  be_nested_str_weak(HMAC_SHA256),
     /* K15  */  be_nested_str_weak(update),
     /* K16  */  be_nested_str_weak(out),
@@ -89,77 +89,80 @@ be_local_closure(Matter_Commisioning_Context_find_fabric_by_destination_id,   /*
     }),
     be_str_weak(find_fabric_by_destination_id),
     &be_const_str_solidified,
-    ( &(const binstruction[70]) {  /* code */
+    ( &(const binstruction[73]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0xB8120200,  //  0001  GETNGBL	R4	K1
       0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x8C180304,  //  0003  GETMET	R6	R1	K4
-      0x7C180200,  //  0004  CALL	R6	1
-      0x001A0606,  //  0005  ADD	R6	K3	R6
-      0x541E0003,  //  0006  LDINT	R7	4
-      0x7C100600,  //  0007  CALL	R4	3
-      0x60100010,  //  0008  GETGBL	R4	G16
-      0x88140105,  //  0009  GETMBR	R5	R0	K5
-      0x88140B06,  //  000A  GETMBR	R5	R5	K6
-      0x88140B07,  //  000B  GETMBR	R5	R5	K7
-      0x7C100200,  //  000C  CALL	R4	1
-      0xA8020032,  //  000D  EXBLK	0	#0041
-      0x5C140800,  //  000E  MOVE	R5	R4
-      0x7C140000,  //  000F  CALL	R5	0
-      0x88180B08,  //  0010  GETMBR	R6	R5	K8
-      0x4C1C0000,  //  0011  LDNIL	R7
-      0x1C180C07,  //  0012  EQ	R6	R6	R7
-      0x741A0007,  //  0013  JMPT	R6	#001C
-      0x88180B09,  //  0014  GETMBR	R6	R5	K9
-      0x4C1C0000,  //  0015  LDNIL	R7
-      0x1C180C07,  //  0016  EQ	R6	R6	R7
-      0x741A0003,  //  0017  JMPT	R6	#001C
-      0x88180B0A,  //  0018  GETMBR	R6	R5	K10
-      0x4C1C0000,  //  0019  LDNIL	R7
-      0x1C180C07,  //  001A  EQ	R6	R6	R7
-      0x781A0000,  //  001B  JMPF	R6	#001D
-      0x7001FFF0,  //  001C  JMP		#000E
-      0x8C180B0B,  //  001D  GETMET	R6	R5	K11
-      0x7C180200,  //  001E  CALL	R6	1
-      0x00180406,  //  001F  ADD	R6	R2	R6
-      0x881C0B09,  //  0020  GETMBR	R7	R5	K9
-      0x00180C07,  //  0021  ADD	R6	R6	R7
-      0x881C0B0A,  //  0022  GETMBR	R7	R5	K10
-      0x00180C07,  //  0023  ADD	R6	R6	R7
-      0x8C1C0B0C,  //  0024  GETMET	R7	R5	K12
-      0x7C1C0200,  //  0025  CALL	R7	1
-      0xB8220200,  //  0026  GETNGBL	R8	K1
-      0x8C201102,  //  0027  GETMET	R8	R8	K2
-      0x8C280D04,  //  0028  GETMET	R10	R6	K4
-      0x7C280200,  //  0029  CALL	R10	1
-      0x002A1A0A,  //  002A  ADD	R10	K13	R10
-      0x542E0003,  //  002B  LDINT	R11	4
-      0x7C200600,  //  002C  CALL	R8	3
-      0x8C20070E,  //  002D  GETMET	R8	R3	K14
-      0x5C280E00,  //  002E  MOVE	R10	R7
-      0x7C200400,  //  002F  CALL	R8	2
-      0x8C24110F,  //  0030  GETMET	R9	R8	K15
-      0x5C2C0C00,  //  0031  MOVE	R11	R6
-      0x7C240400,  //  0032  CALL	R9	2
-      0x8C241110,  //  0033  GETMET	R9	R8	K16
-      0x7C240200,  //  0034  CALL	R9	1
-      0xB82A0200,  //  0035  GETNGBL	R10	K1
-      0x8C281502,  //  0036  GETMET	R10	R10	K2
-      0x8C301304,  //  0037  GETMET	R12	R9	K4
-      0x7C300200,  //  0038  CALL	R12	1
-      0x0032220C,  //  0039  ADD	R12	K17	R12
-      0x54360003,  //  003A  LDINT	R13	4
-      0x7C280600,  //  003B  CALL	R10	3
-      0x1C281201,  //  003C  EQ	R10	R9	R1
-      0x782A0001,  //  003D  JMPF	R10	#0040
-      0xA8040001,  //  003E  EXBLK	1	1
-      0x80040A00,  //  003F  RET	1	R5
-      0x7001FFCC,  //  0040  JMP		#000E
-      0x58100012,  //  0041  LDCONST	R4	K18
-      0xAC100200,  //  0042  CATCH	R4	1	0
-      0xB0080000,  //  0043  RAISE	2	R0	R0
-      0x4C100000,  //  0044  LDNIL	R4
-      0x80040800,  //  0045  RET	1	R4
+      0x541A0003,  //  0003  LDINT	R6	4
+      0x7C100400,  //  0004  CALL	R4	2
+      0x78120006,  //  0005  JMPF	R4	#000D
+      0xB8120200,  //  0006  GETNGBL	R4	K1
+      0x8C100903,  //  0007  GETMET	R4	R4	K3
+      0x8C180305,  //  0008  GETMET	R6	R1	K5
+      0x7C180200,  //  0009  CALL	R6	1
+      0x001A0806,  //  000A  ADD	R6	K4	R6
+      0x541E0003,  //  000B  LDINT	R7	4
+      0x7C100600,  //  000C  CALL	R4	3
+      0x60100010,  //  000D  GETGBL	R4	G16
+      0x88140106,  //  000E  GETMBR	R5	R0	K6
+      0x88140B07,  //  000F  GETMBR	R5	R5	K7
+      0x88140B08,  //  0010  GETMBR	R5	R5	K8
+      0x7C100200,  //  0011  CALL	R4	1
+      0xA8020030,  //  0012  EXBLK	0	#0044
+      0x5C140800,  //  0013  MOVE	R5	R4
+      0x7C140000,  //  0014  CALL	R5	0
+      0x88180B09,  //  0015  GETMBR	R6	R5	K9
+      0x4C1C0000,  //  0016  LDNIL	R7
+      0x1C180C07,  //  0017  EQ	R6	R6	R7
+      0x741A0007,  //  0018  JMPT	R6	#0021
+      0x88180B0A,  //  0019  GETMBR	R6	R5	K10
+      0x4C1C0000,  //  001A  LDNIL	R7
+      0x1C180C07,  //  001B  EQ	R6	R6	R7
+      0x741A0003,  //  001C  JMPT	R6	#0021
+      0x88180B0B,  //  001D  GETMBR	R6	R5	K11
+      0x4C1C0000,  //  001E  LDNIL	R7
+      0x1C180C07,  //  001F  EQ	R6	R6	R7
+      0x781A0000,  //  0020  JMPF	R6	#0022
+      0x7001FFF0,  //  0021  JMP		#0013
+      0x8C180B0C,  //  0022  GETMET	R6	R5	K12
+      0x7C180200,  //  0023  CALL	R6	1
+      0x00180406,  //  0024  ADD	R6	R2	R6
+      0x881C0B0A,  //  0025  GETMBR	R7	R5	K10
+      0x00180C07,  //  0026  ADD	R6	R6	R7
+      0x881C0B0B,  //  0027  GETMBR	R7	R5	K11
+      0x00180C07,  //  0028  ADD	R6	R6	R7
+      0x8C1C0B0D,  //  0029  GETMET	R7	R5	K13
+      0x7C1C0200,  //  002A  CALL	R7	1
+      0x8C20070E,  //  002B  GETMET	R8	R3	K14
+      0x5C280E00,  //  002C  MOVE	R10	R7
+      0x7C200400,  //  002D  CALL	R8	2
+      0x8C24110F,  //  002E  GETMET	R9	R8	K15
+      0x5C2C0C00,  //  002F  MOVE	R11	R6
+      0x7C240400,  //  0030  CALL	R9	2
+      0x8C241110,  //  0031  GETMET	R9	R8	K16
+      0x7C240200,  //  0032  CALL	R9	1
+      0xB82A0200,  //  0033  GETNGBL	R10	K1
+      0x8C281502,  //  0034  GETMET	R10	R10	K2
+      0x54320003,  //  0035  LDINT	R12	4
+      0x7C280400,  //  0036  CALL	R10	2
+      0x782A0006,  //  0037  JMPF	R10	#003F
+      0xB82A0200,  //  0038  GETNGBL	R10	K1
+      0x8C281503,  //  0039  GETMET	R10	R10	K3
+      0x8C301305,  //  003A  GETMET	R12	R9	K5
+      0x7C300200,  //  003B  CALL	R12	1
+      0x0032220C,  //  003C  ADD	R12	K17	R12
+      0x54360003,  //  003D  LDINT	R13	4
+      0x7C280600,  //  003E  CALL	R10	3
+      0x1C281201,  //  003F  EQ	R10	R9	R1
+      0x782A0001,  //  0040  JMPF	R10	#0043
+      0xA8040001,  //  0041  EXBLK	1	1
+      0x80040A00,  //  0042  RET	1	R5
+      0x7001FFCE,  //  0043  JMP		#0013
+      0x58100012,  //  0044  LDCONST	R4	K18
+      0xAC100200,  //  0045  CATCH	R4	1	0
+      0xB0080000,  //  0046  RAISE	2	R0	R0
+      0x4C100000,  //  0047  LDNIL	R4
+      0x80040800,  //  0048  RET	1	R4
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -2429,7 +2429,7 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
+    ( &(const bvalue[24]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
     /* K1   */  be_nested_str_weak(get_active_endpoints),
     /* K2   */  be_nested_str_weak(matter),
@@ -2440,23 +2440,24 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
     /* K7   */  be_nested_str_weak(endpoint),
     /* K8   */  be_nested_str_weak(cluster),
     /* K9   */  be_nested_str_weak(attribute),
-    /* K10  */  be_nested_str_weak(status),
-    /* K11  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    /* K12  */  be_nested_str_weak(get_attribute_name),
-    /* K13  */  be_nested_str_weak(tasmota),
-    /* K14  */  be_nested_str_weak(log),
-    /* K15  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s),
-    /* K16  */  be_nested_str_weak(local_session_id),
-    /* K17  */  be_nested_str_weak(_X20_X28),
-    /* K18  */  be_nested_str_weak(_X29),
-    /* K19  */  be_nested_str_weak(),
-    /* K20  */  be_const_int(3),
-    /* K21  */  be_nested_str_weak(process_attribute_expansion),
-    /* K22  */  be_nested_str_weak(stop_iteration),
+    /* K10  */  be_nested_str_weak(fabric_filtered),
+    /* K11  */  be_nested_str_weak(status),
+    /* K12  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+    /* K13  */  be_nested_str_weak(get_attribute_name),
+    /* K14  */  be_nested_str_weak(tasmota),
+    /* K15  */  be_nested_str_weak(log),
+    /* K16  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s),
+    /* K17  */  be_nested_str_weak(local_session_id),
+    /* K18  */  be_nested_str_weak(_X20_X28),
+    /* K19  */  be_nested_str_weak(_X29),
+    /* K20  */  be_nested_str_weak(),
+    /* K21  */  be_const_int(3),
+    /* K22  */  be_nested_str_weak(process_attribute_expansion),
+    /* K23  */  be_nested_str_weak(stop_iteration),
     }),
     be_str_weak(_inner_process_read_request),
     &be_const_str_solidified,
-    ( &(const binstruction[93]) {  /* code */
+    ( &(const binstruction[95]) {  /* code */
       0x84100000,  //  0000  CLOSURE	R4	P0
       0x88140100,  //  0001  GETMBR	R5	R0	K0
       0x8C140B01,  //  0002  GETMET	R5	R5	K1
@@ -2473,7 +2474,7 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
       0x60200010,  //  000D  GETGBL	R8	G16
       0x88240506,  //  000E  GETMBR	R9	R2	K6
       0x7C200200,  //  000F  CALL	R8	1
-      0xA8020046,  //  0010  EXBLK	0	#0058
+      0xA8020048,  //  0010  EXBLK	0	#005A
       0x5C241000,  //  0011  MOVE	R9	R8
       0x7C240000,  //  0012  CALL	R9	0
       0x88281307,  //  0013  GETMBR	R10	R9	K7
@@ -2482,74 +2483,76 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
       0x901A100A,  //  0016  SETMBR	R6	K8	R10
       0x88281309,  //  0017  GETMBR	R10	R9	K9
       0x901A120A,  //  0018  SETMBR	R6	K9	R10
-      0xB82A0400,  //  0019  GETNGBL	R10	K2
-      0x8828150B,  //  001A  GETMBR	R10	R10	K11
-      0x901A140A,  //  001B  SETMBR	R6	K10	R10
-      0x88280D07,  //  001C  GETMBR	R10	R6	K7
-      0x4C2C0000,  //  001D  LDNIL	R11
-      0x1C28140B,  //  001E  EQ	R10	R10	R11
-      0x742A0007,  //  001F  JMPT	R10	#0028
-      0x88280D08,  //  0020  GETMBR	R10	R6	K8
-      0x4C2C0000,  //  0021  LDNIL	R11
-      0x1C28140B,  //  0022  EQ	R10	R10	R11
-      0x742A0003,  //  0023  JMPT	R10	#0028
-      0x88280D09,  //  0024  GETMBR	R10	R6	K9
-      0x4C2C0000,  //  0025  LDNIL	R11
-      0x1C28140B,  //  0026  EQ	R10	R10	R11
-      0x782A0029,  //  0027  JMPF	R10	#0052
-      0x88280D08,  //  0028  GETMBR	R10	R6	K8
-      0x4C2C0000,  //  0029  LDNIL	R11
-      0x2028140B,  //  002A  NE	R10	R10	R11
-      0x782A001A,  //  002B  JMPF	R10	#0047
-      0x88280D09,  //  002C  GETMBR	R10	R6	K9
-      0x4C2C0000,  //  002D  LDNIL	R11
-      0x2028140B,  //  002E  NE	R10	R10	R11
-      0x782A0016,  //  002F  JMPF	R10	#0047
-      0xB82A0400,  //  0030  GETNGBL	R10	K2
-      0x8C28150C,  //  0031  GETMET	R10	R10	K12
-      0x88300D08,  //  0032  GETMBR	R12	R6	K8
-      0x88340D09,  //  0033  GETMBR	R13	R6	K9
-      0x7C280600,  //  0034  CALL	R10	3
-      0xB82E1A00,  //  0035  GETNGBL	R11	K13
-      0x8C2C170E,  //  0036  GETMET	R11	R11	K14
-      0x60340018,  //  0037  GETGBL	R13	G24
-      0x5838000F,  //  0038  LDCONST	R14	K15
-      0x883C0310,  //  0039  GETMBR	R15	R1	K16
-      0x60400008,  //  003A  GETGBL	R16	G8
-      0x5C440C00,  //  003B  MOVE	R17	R6
-      0x7C400200,  //  003C  CALL	R16	1
-      0x782A0002,  //  003D  JMPF	R10	#0041
-      0x0046220A,  //  003E  ADD	R17	K17	R10
-      0x00442312,  //  003F  ADD	R17	R17	K18
-      0x70020000,  //  0040  JMP		#0042
-      0x58440013,  //  0041  LDCONST	R17	K19
-      0x00402011,  //  0042  ADD	R16	R16	R17
-      0x7C340600,  //  0043  CALL	R13	3
-      0x58380014,  //  0044  LDCONST	R14	K20
-      0x7C2C0600,  //  0045  CALL	R11	3
-      0x7002000A,  //  0046  JMP		#0052
-      0xB82A1A00,  //  0047  GETNGBL	R10	K13
-      0x8C28150E,  //  0048  GETMET	R10	R10	K14
-      0x60300018,  //  0049  GETGBL	R12	G24
-      0x5834000F,  //  004A  LDCONST	R13	K15
-      0x88380310,  //  004B  GETMBR	R14	R1	K16
-      0x603C0008,  //  004C  GETGBL	R15	G8
-      0x5C400C00,  //  004D  MOVE	R16	R6
-      0x7C3C0200,  //  004E  CALL	R15	1
-      0x7C300600,  //  004F  CALL	R12	3
-      0x58340014,  //  0050  LDCONST	R13	K20
-      0x7C280600,  //  0051  CALL	R10	3
-      0x88280100,  //  0052  GETMBR	R10	R0	K0
-      0x8C281515,  //  0053  GETMET	R10	R10	K21
-      0x5C300C00,  //  0054  MOVE	R12	R6
-      0x84340001,  //  0055  CLOSURE	R13	P1
-      0x7C280600,  //  0056  CALL	R10	3
-      0x7001FFB8,  //  0057  JMP		#0011
-      0x58200016,  //  0058  LDCONST	R8	K22
-      0xAC200200,  //  0059  CATCH	R8	1	0
-      0xB0080000,  //  005A  RAISE	2	R0	R0
-      0xA0000000,  //  005B  CLOSE	R0
-      0x80040E00,  //  005C  RET	1	R7
+      0x8828050A,  //  0019  GETMBR	R10	R2	K10
+      0x901A140A,  //  001A  SETMBR	R6	K10	R10
+      0xB82A0400,  //  001B  GETNGBL	R10	K2
+      0x8828150C,  //  001C  GETMBR	R10	R10	K12
+      0x901A160A,  //  001D  SETMBR	R6	K11	R10
+      0x88280D07,  //  001E  GETMBR	R10	R6	K7
+      0x4C2C0000,  //  001F  LDNIL	R11
+      0x1C28140B,  //  0020  EQ	R10	R10	R11
+      0x742A0007,  //  0021  JMPT	R10	#002A
+      0x88280D08,  //  0022  GETMBR	R10	R6	K8
+      0x4C2C0000,  //  0023  LDNIL	R11
+      0x1C28140B,  //  0024  EQ	R10	R10	R11
+      0x742A0003,  //  0025  JMPT	R10	#002A
+      0x88280D09,  //  0026  GETMBR	R10	R6	K9
+      0x4C2C0000,  //  0027  LDNIL	R11
+      0x1C28140B,  //  0028  EQ	R10	R10	R11
+      0x782A0029,  //  0029  JMPF	R10	#0054
+      0x88280D08,  //  002A  GETMBR	R10	R6	K8
+      0x4C2C0000,  //  002B  LDNIL	R11
+      0x2028140B,  //  002C  NE	R10	R10	R11
+      0x782A001A,  //  002D  JMPF	R10	#0049
+      0x88280D09,  //  002E  GETMBR	R10	R6	K9
+      0x4C2C0000,  //  002F  LDNIL	R11
+      0x2028140B,  //  0030  NE	R10	R10	R11
+      0x782A0016,  //  0031  JMPF	R10	#0049
+      0xB82A0400,  //  0032  GETNGBL	R10	K2
+      0x8C28150D,  //  0033  GETMET	R10	R10	K13
+      0x88300D08,  //  0034  GETMBR	R12	R6	K8
+      0x88340D09,  //  0035  GETMBR	R13	R6	K9
+      0x7C280600,  //  0036  CALL	R10	3
+      0xB82E1C00,  //  0037  GETNGBL	R11	K14
+      0x8C2C170F,  //  0038  GETMET	R11	R11	K15
+      0x60340018,  //  0039  GETGBL	R13	G24
+      0x58380010,  //  003A  LDCONST	R14	K16
+      0x883C0311,  //  003B  GETMBR	R15	R1	K17
+      0x60400008,  //  003C  GETGBL	R16	G8
+      0x5C440C00,  //  003D  MOVE	R17	R6
+      0x7C400200,  //  003E  CALL	R16	1
+      0x782A0002,  //  003F  JMPF	R10	#0043
+      0x0046240A,  //  0040  ADD	R17	K18	R10
+      0x00442313,  //  0041  ADD	R17	R17	K19
+      0x70020000,  //  0042  JMP		#0044
+      0x58440014,  //  0043  LDCONST	R17	K20
+      0x00402011,  //  0044  ADD	R16	R16	R17
+      0x7C340600,  //  0045  CALL	R13	3
+      0x58380015,  //  0046  LDCONST	R14	K21
+      0x7C2C0600,  //  0047  CALL	R11	3
+      0x7002000A,  //  0048  JMP		#0054
+      0xB82A1C00,  //  0049  GETNGBL	R10	K14
+      0x8C28150F,  //  004A  GETMET	R10	R10	K15
+      0x60300018,  //  004B  GETGBL	R12	G24
+      0x58340010,  //  004C  LDCONST	R13	K16
+      0x88380311,  //  004D  GETMBR	R14	R1	K17
+      0x603C0008,  //  004E  GETGBL	R15	G8
+      0x5C400C00,  //  004F  MOVE	R16	R6
+      0x7C3C0200,  //  0050  CALL	R15	1
+      0x7C300600,  //  0051  CALL	R12	3
+      0x58340015,  //  0052  LDCONST	R13	K21
+      0x7C280600,  //  0053  CALL	R10	3
+      0x88280100,  //  0054  GETMBR	R10	R0	K0
+      0x8C281516,  //  0055  GETMET	R10	R10	K22
+      0x5C300C00,  //  0056  MOVE	R12	R6
+      0x84340001,  //  0057  CLOSURE	R13	P1
+      0x7C280600,  //  0058  CALL	R10	3
+      0x7001FFB6,  //  0059  JMP		#0011
+      0x58200017,  //  005A  LDCONST	R8	K23
+      0xAC200200,  //  005B  CATCH	R8	1	0
+      0xB0080000,  //  005C  RAISE	2	R0	R0
+      0xA0000000,  //  005D  CLOSE	R0
+      0x80040E00,  //  005E  RET	1	R7
     })
   )
 );
@@ -3271,7 +3274,7 @@ be_local_closure(Matter_IM_expire_sendqueue,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_subscribe_request,   /* name */
   be_nested_proto(
-    17,                          /* nstack */
+    18,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3279,7 +3282,7 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
+    ( &(const bvalue[33]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(SubscribeRequestMessage),
     /* K2   */  be_nested_str_weak(from_TLV),
@@ -3298,7 +3301,7 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
     /* K15  */  be_nested_str_weak(stop_iteration),
     /* K16  */  be_nested_str_weak(tasmota),
     /* K17  */  be_nested_str_weak(log),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X2C_X20keep_X3D_X25i_X29_X20sub_X3D_X25i),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X2C_X20keep_X3D_X25i_X29_X20sub_X3D_X25i_X20fabric_filtered_X3D_X25s),
     /* K19  */  be_nested_str_weak(local_session_id),
     /* K20  */  be_nested_str_weak(concat),
     /* K21  */  be_nested_str_weak(_X20),
@@ -3307,13 +3310,16 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
     /* K24  */  be_const_int(1),
     /* K25  */  be_const_int(0),
     /* K26  */  be_nested_str_weak(subscription_id),
-    /* K27  */  be_const_int(3),
-    /* K28  */  be_nested_str_weak(_inner_process_read_request),
-    /* K29  */  be_nested_str_weak(send_subscribe_response),
+    /* K27  */  be_nested_str_weak(fabric_filtered),
+    /* K28  */  be_const_int(3),
+    /* K29  */  be_nested_str_weak(event_requests),
+    /* K30  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X25_X256i_X29_X20event_requests_size_X3D_X25s),
+    /* K31  */  be_nested_str_weak(_inner_process_read_request),
+    /* K32  */  be_nested_str_weak(send_subscribe_response),
     }),
     be_str_weak(subscribe_request),
     &be_const_str_solidified,
-    ( &(const binstruction[78]) {  /* code */
+    ( &(const binstruction[98]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x8C0C0701,  //  0001  GETMET	R3	R3	K1
       0x7C0C0200,  //  0002  CALL	R3	1
@@ -3375,23 +3381,43 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
       0x70020000,  //  003A  JMP		#003C
       0x583C0019,  //  003B  LDCONST	R15	K25
       0x8840091A,  //  003C  GETMBR	R16	R4	K26
-      0x7C240E00,  //  003D  CALL	R9	7
-      0x5828001B,  //  003E  LDCONST	R10	K27
-      0x7C1C0600,  //  003F  CALL	R7	3
-      0x8C1C011C,  //  0040  GETMET	R7	R0	K28
-      0x88240306,  //  0041  GETMBR	R9	R1	K6
-      0x5C280600,  //  0042  MOVE	R10	R3
-      0x502C0200,  //  0043  LDBOOL	R11	1	0
-      0x7C1C0800,  //  0044  CALL	R7	4
-      0x8820091A,  //  0045  GETMBR	R8	R4	K26
-      0x901E3408,  //  0046  SETMBR	R7	K26	R8
-      0x8C20011D,  //  0047  GETMET	R8	R0	K29
-      0x5C280200,  //  0048  MOVE	R10	R1
-      0x5C2C0E00,  //  0049  MOVE	R11	R7
-      0x5C300800,  //  004A  MOVE	R12	R4
-      0x7C200800,  //  004B  CALL	R8	4
-      0x50200200,  //  004C  LDBOOL	R8	1	0
-      0x80041000,  //  004D  RET	1	R8
+      0x8844071B,  //  003D  GETMBR	R17	R3	K27
+      0x7C241000,  //  003E  CALL	R9	8
+      0x5828001C,  //  003F  LDCONST	R10	K28
+      0x7C1C0600,  //  0040  CALL	R7	3
+      0x881C071D,  //  0041  GETMBR	R7	R3	K29
+      0x4C200000,  //  0042  LDNIL	R8
+      0x201C0E08,  //  0043  NE	R7	R7	R8
+      0x781E000E,  //  0044  JMPF	R7	#0054
+      0x601C000C,  //  0045  GETGBL	R7	G12
+      0x8820071D,  //  0046  GETMBR	R8	R3	K29
+      0x7C1C0200,  //  0047  CALL	R7	1
+      0x241C0F19,  //  0048  GT	R7	R7	K25
+      0x781E0009,  //  0049  JMPF	R7	#0054
+      0xB81E2000,  //  004A  GETNGBL	R7	K16
+      0x8C1C0F11,  //  004B  GETMET	R7	R7	K17
+      0x60240018,  //  004C  GETGBL	R9	G24
+      0x5828001E,  //  004D  LDCONST	R10	K30
+      0x602C000C,  //  004E  GETGBL	R11	G12
+      0x8830071D,  //  004F  GETMBR	R12	R3	K29
+      0x7C2C0200,  //  0050  CALL	R11	1
+      0x7C240400,  //  0051  CALL	R9	2
+      0x5828001C,  //  0052  LDCONST	R10	K28
+      0x7C1C0600,  //  0053  CALL	R7	3
+      0x8C1C011F,  //  0054  GETMET	R7	R0	K31
+      0x88240306,  //  0055  GETMBR	R9	R1	K6
+      0x5C280600,  //  0056  MOVE	R10	R3
+      0x502C0200,  //  0057  LDBOOL	R11	1	0
+      0x7C1C0800,  //  0058  CALL	R7	4
+      0x8820091A,  //  0059  GETMBR	R8	R4	K26
+      0x901E3408,  //  005A  SETMBR	R7	K26	R8
+      0x8C200120,  //  005B  GETMET	R8	R0	K32
+      0x5C280200,  //  005C  MOVE	R10	R1
+      0x5C2C0E00,  //  005D  MOVE	R11	R7
+      0x5C300800,  //  005E  MOVE	R12	R4
+      0x7C200800,  //  005F  CALL	R8	4
+      0x50200200,  //  0060  LDBOOL	R8	1	0
+      0x80041000,  //  0061  RET	1	R8
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path.h
@@ -19,7 +19,7 @@ be_local_closure(Matter_Path_tostring,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
+    ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(),
     /* K1   */  be_nested_str_weak(endpoint),
     /* K2   */  be_nested_str_weak(_X5B_X2502X_X5D),
@@ -30,14 +30,16 @@ be_local_closure(Matter_Path_tostring,   /* name */
     /* K7   */  be_nested_str_weak(attribute),
     /* K8   */  be_nested_str_weak(_X2504X),
     /* K9   */  be_nested_str_weak(command),
-    /* K10  */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
-    /* K11  */  be_nested_str_weak(Exception_X3E_X20),
-    /* K12  */  be_nested_str_weak(_X2C_X20),
+    /* K10  */  be_nested_str_weak(fabric_filtered),
+    /* K11  */  be_nested_str_weak(_X21),
+    /* K12  */  be_nested_str_weak(_X2A_X2A_X2A_X2A),
+    /* K13  */  be_nested_str_weak(Exception_X3E_X20),
+    /* K14  */  be_nested_str_weak(_X2C_X20),
     }),
     be_str_weak(tostring),
     &be_const_str_solidified,
-    ( &(const binstruction[74]) {  /* code */
-      0xA8020039,  //  0000  EXBLK	0	#003B
+    ( &(const binstruction[77]) {  /* code */
+      0xA802003C,  //  0000  EXBLK	0	#003E
       0x58040000,  //  0001  LDCONST	R1	K0
       0x88080101,  //  0002  GETMBR	R2	R0	K1
       0x4C0C0000,  //  0003  LDNIL	R3
@@ -83,34 +85,37 @@ be_local_closure(Matter_Path_tostring,   /* name */
       0x70020000,  //  002B  JMP		#002D
       0x58080000,  //  002C  LDCONST	R2	K0
       0x00040202,  //  002D  ADD	R1	R1	R2
-      0x88080107,  //  002E  GETMBR	R2	R0	K7
-      0x4C0C0000,  //  002F  LDNIL	R3
-      0x1C080403,  //  0030  EQ	R2	R2	R3
-      0x780A0004,  //  0031  JMPF	R2	#0037
-      0x88080109,  //  0032  GETMBR	R2	R0	K9
-      0x4C0C0000,  //  0033  LDNIL	R3
-      0x1C080403,  //  0034  EQ	R2	R2	R3
-      0x780A0000,  //  0035  JMPF	R2	#0037
-      0x0004030A,  //  0036  ADD	R1	R1	K10
-      0xA8040001,  //  0037  EXBLK	1	1
-      0x80040200,  //  0038  RET	1	R1
-      0xA8040001,  //  0039  EXBLK	1	1
-      0x7002000D,  //  003A  JMP		#0049
-      0xAC040002,  //  003B  CATCH	R1	0	2
-      0x7002000A,  //  003C  JMP		#0048
-      0x600C0008,  //  003D  GETGBL	R3	G8
-      0x5C100200,  //  003E  MOVE	R4	R1
-      0x7C0C0200,  //  003F  CALL	R3	1
-      0x000E1603,  //  0040  ADD	R3	K11	R3
-      0x000C070C,  //  0041  ADD	R3	R3	K12
-      0x60100008,  //  0042  GETGBL	R4	G8
-      0x5C140400,  //  0043  MOVE	R5	R2
-      0x7C100200,  //  0044  CALL	R4	1
-      0x000C0604,  //  0045  ADD	R3	R3	R4
-      0x80040600,  //  0046  RET	1	R3
-      0x70020000,  //  0047  JMP		#0049
-      0xB0080000,  //  0048  RAISE	2	R0	R0
-      0x80000000,  //  0049  RET	0
+      0x8808010A,  //  002E  GETMBR	R2	R0	K10
+      0x780A0000,  //  002F  JMPF	R2	#0031
+      0x0004030B,  //  0030  ADD	R1	R1	K11
+      0x88080107,  //  0031  GETMBR	R2	R0	K7
+      0x4C0C0000,  //  0032  LDNIL	R3
+      0x1C080403,  //  0033  EQ	R2	R2	R3
+      0x780A0004,  //  0034  JMPF	R2	#003A
+      0x88080109,  //  0035  GETMBR	R2	R0	K9
+      0x4C0C0000,  //  0036  LDNIL	R3
+      0x1C080403,  //  0037  EQ	R2	R2	R3
+      0x780A0000,  //  0038  JMPF	R2	#003A
+      0x0004030C,  //  0039  ADD	R1	R1	K12
+      0xA8040001,  //  003A  EXBLK	1	1
+      0x80040200,  //  003B  RET	1	R1
+      0xA8040001,  //  003C  EXBLK	1	1
+      0x7002000D,  //  003D  JMP		#004C
+      0xAC040002,  //  003E  CATCH	R1	0	2
+      0x7002000A,  //  003F  JMP		#004B
+      0x600C0008,  //  0040  GETGBL	R3	G8
+      0x5C100200,  //  0041  MOVE	R4	R1
+      0x7C0C0200,  //  0042  CALL	R3	1
+      0x000E1A03,  //  0043  ADD	R3	K13	R3
+      0x000C070E,  //  0044  ADD	R3	R3	K14
+      0x60100008,  //  0045  GETGBL	R4	G8
+      0x5C140400,  //  0046  MOVE	R5	R2
+      0x7C100200,  //  0047  CALL	R4	1
+      0x000C0604,  //  0048  ADD	R3	R3	R4
+      0x80040600,  //  0049  RET	1	R3
+      0x70020000,  //  004A  JMP		#004C
+      0xB0080000,  //  004B  RAISE	2	R0	R0
+      0x80000000,  //  004C  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
@@ -885,7 +885,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[91]) {     /* constants */
+    ( &(const bvalue[93]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
@@ -939,48 +939,50 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
     /* K50  */  be_nested_str_weak(local),
     /* K51  */  be_nested_str_weak(send_ack_now),
     /* K52  */  be_nested_str_weak(msg),
-    /* K53  */  be_nested_str_weak(device),
-    /* K54  */  be_nested_str_weak(sessions),
-    /* K55  */  be_nested_str_weak(active_fabrics),
-    /* K56  */  be_nested_str_weak(B2),
-    /* K57  */  be_nested_str_weak(get_noc),
-    /* K58  */  be_nested_str_weak(get_icac),
-    /* K59  */  be_nested_str_weak(get_fabric_index),
-    /* K60  */  be_nested_str_weak(stop_iteration),
-    /* K61  */  be_nested_str_weak(parse),
-    /* K62  */  be_nested_str_weak(get_ca),
-    /* K63  */  be_nested_str_weak(findsubval),
-    /* K64  */  be_nested_str_weak(get_admin_vendor),
-    /* K65  */  be_nested_str_weak(get_fabric_id),
-    /* K66  */  be_nested_str_weak(get_device_id),
-    /* K67  */  be_nested_str_weak(get_fabric_label),
-    /* K68  */  be_nested_str_weak(Fabric),
-    /* K69  */  be_nested_str_weak(_MAX_CASE),
-    /* K70  */  be_nested_str_weak(count_active_fabrics),
-    /* K71  */  be_nested_str_weak(_fabric),
-    /* K72  */  be_nested_str_weak(is_commissioning_open),
-    /* K73  */  be_nested_str_weak(is_root_commissioning_open),
-    /* K74  */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K75  */  be_nested_str_weak(Tasmota),
-    /* K76  */  be_nested_str_weak(vendorid),
-    /* K77  */  be_nested_str_weak(DeviceName),
-    /* K78  */  be_nested_str_weak(FriendlyName),
-    /* K79  */  be_nested_str_weak(FriendlyName1),
-    /* K80  */  be_nested_str_weak(XX),
-    /* K81  */  be_nested_str_weak(Status_X202),
-    /* K82  */  be_nested_str_weak(StatusFWR),
-    /* K83  */  be_nested_str_weak(Hardware),
-    /* K84  */  be_nested_str_weak(Version),
-    /* K85  */  be_nested_str_weak(_X28),
-    /* K86  */  be_nested_str_weak(locale),
-    /* K87  */  be_nested_str_weak(create_TLV),
-    /* K88  */  be_nested_str_weak(get_active_endpoints),
-    /* K89  */  be_nested_str_weak(disable_bridge_mode),
-    /* K90  */  be_nested_str_weak(read_attribute),
+    /* K53  */  be_nested_str_weak(fabric_filtered),
+    /* K54  */  be_nested_str_weak(get_fabric),
+    /* K55  */  be_nested_str_weak(device),
+    /* K56  */  be_nested_str_weak(sessions),
+    /* K57  */  be_nested_str_weak(active_fabrics),
+    /* K58  */  be_nested_str_weak(B2),
+    /* K59  */  be_nested_str_weak(get_noc),
+    /* K60  */  be_nested_str_weak(get_icac),
+    /* K61  */  be_nested_str_weak(get_fabric_index),
+    /* K62  */  be_nested_str_weak(stop_iteration),
+    /* K63  */  be_nested_str_weak(parse),
+    /* K64  */  be_nested_str_weak(get_ca),
+    /* K65  */  be_nested_str_weak(findsubval),
+    /* K66  */  be_nested_str_weak(get_admin_vendor),
+    /* K67  */  be_nested_str_weak(get_fabric_id),
+    /* K68  */  be_nested_str_weak(get_device_id),
+    /* K69  */  be_nested_str_weak(get_fabric_label),
+    /* K70  */  be_nested_str_weak(Fabric),
+    /* K71  */  be_nested_str_weak(_MAX_CASE),
+    /* K72  */  be_nested_str_weak(count_active_fabrics),
+    /* K73  */  be_nested_str_weak(_fabric),
+    /* K74  */  be_nested_str_weak(is_commissioning_open),
+    /* K75  */  be_nested_str_weak(is_root_commissioning_open),
+    /* K76  */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K77  */  be_nested_str_weak(Tasmota),
+    /* K78  */  be_nested_str_weak(vendorid),
+    /* K79  */  be_nested_str_weak(DeviceName),
+    /* K80  */  be_nested_str_weak(FriendlyName),
+    /* K81  */  be_nested_str_weak(FriendlyName1),
+    /* K82  */  be_nested_str_weak(XX),
+    /* K83  */  be_nested_str_weak(Status_X202),
+    /* K84  */  be_nested_str_weak(StatusFWR),
+    /* K85  */  be_nested_str_weak(Hardware),
+    /* K86  */  be_nested_str_weak(Version),
+    /* K87  */  be_nested_str_weak(_X28),
+    /* K88  */  be_nested_str_weak(locale),
+    /* K89  */  be_nested_str_weak(create_TLV),
+    /* K90  */  be_nested_str_weak(get_active_endpoints),
+    /* K91  */  be_nested_str_weak(disable_bridge_mode),
+    /* K92  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[911]) {  /* code */
+    ( &(const binstruction[937]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xB8160200,  //  0001  GETNGBL	R5	K1
       0x88140B02,  //  0002  GETMBR	R5	R5	K2
@@ -1037,11 +1039,11 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x502C0000,  //  0035  LDBOOL	R11	0	0
       0x7C200600,  //  0036  CALL	R8	3
       0x80041000,  //  0037  RET	1	R8
-      0x70020354,  //  0038  JMP		#038E
+      0x7002036E,  //  0038  JMP		#03A8
       0x54220031,  //  0039  LDINT	R8	50
       0x1C200C08,  //  003A  EQ	R8	R6	R8
       0x78220000,  //  003B  JMPF	R8	#003D
-      0x70020350,  //  003C  JMP		#038E
+      0x7002036A,  //  003C  JMP		#03A8
       0x54220032,  //  003D  LDINT	R8	51
       0x1C200C08,  //  003E  EQ	R8	R6	R8
       0x782200DC,  //  003F  JMPF	R8	#011D
@@ -1265,11 +1267,11 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x502C0000,  //  0119  LDBOOL	R11	0	0
       0x7C200600,  //  011A  CALL	R8	3
       0x80041000,  //  011B  RET	1	R8
-      0x70020270,  //  011C  JMP		#038E
+      0x7002028A,  //  011C  JMP		#03A8
       0x54220033,  //  011D  LDINT	R8	52
       0x1C200C08,  //  011E  EQ	R8	R6	R8
       0x78220000,  //  011F  JMPF	R8	#0121
-      0x7002026C,  //  0120  JMP		#038E
+      0x70020286,  //  0120  JMP		#03A8
       0x54220037,  //  0121  LDINT	R8	56
       0x1C200C08,  //  0122  EQ	R8	R6	R8
       0x7822002B,  //  0123  JMPF	R8	#0150
@@ -1316,582 +1318,608 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x5C301000,  //  014C  MOVE	R12	R8
       0x7C240600,  //  014D  CALL	R9	3
       0x80041200,  //  014E  RET	1	R9
-      0x7002023D,  //  014F  JMP		#038E
+      0x70020257,  //  014F  JMP		#03A8
       0x5422003D,  //  0150  LDINT	R8	62
       0x1C200C08,  //  0151  EQ	R8	R6	R8
-      0x78220093,  //  0152  JMPF	R8	#01E7
+      0x782200AD,  //  0152  JMPF	R8	#0201
       0x8C200133,  //  0153  GETMET	R8	R0	K51
       0x88280534,  //  0154  GETMBR	R10	R2	K52
       0x7C200400,  //  0155  CALL	R8	2
       0x1C200F05,  //  0156  EQ	R8	R7	K5
-      0x78220025,  //  0157  JMPF	R8	#017E
+      0x78220032,  //  0157  JMPF	R8	#018B
       0x8C200B11,  //  0158  GETMET	R8	R5	K17
       0x7C200200,  //  0159  CALL	R8	1
-      0x60240010,  //  015A  GETGBL	R9	G16
-      0x88280135,  //  015B  GETMBR	R10	R0	K53
-      0x88281536,  //  015C  GETMBR	R10	R10	K54
-      0x8C281537,  //  015D  GETMET	R10	R10	K55
-      0x7C280200,  //  015E  CALL	R10	1
-      0x7C240200,  //  015F  CALL	R9	1
-      0xA8020017,  //  0160  EXBLK	0	#0179
-      0x5C281200,  //  0161  MOVE	R10	R9
-      0x7C280000,  //  0162  CALL	R10	0
-      0x8C2C1115,  //  0163  GETMET	R11	R8	K21
-      0x4C340000,  //  0164  LDNIL	R13
-      0x7C2C0400,  //  0165  CALL	R11	2
-      0x8C30170B,  //  0166  GETMET	R12	R11	K11
-      0x58380009,  //  0167  LDCONST	R14	K9
-      0x883C0B38,  //  0168  GETMBR	R15	R5	K56
-      0x8C401539,  //  0169  GETMET	R16	R10	K57
-      0x7C400200,  //  016A  CALL	R16	1
-      0x7C300800,  //  016B  CALL	R12	4
-      0x8C30170B,  //  016C  GETMET	R12	R11	K11
-      0x5838000D,  //  016D  LDCONST	R14	K13
-      0x883C0B38,  //  016E  GETMBR	R15	R5	K56
-      0x8C40153A,  //  016F  GETMET	R16	R10	K58
-      0x7C400200,  //  0170  CALL	R16	1
-      0x7C300800,  //  0171  CALL	R12	4
-      0x8C30170B,  //  0172  GETMET	R12	R11	K11
-      0x543A00FD,  //  0173  LDINT	R14	254
-      0x883C0B0C,  //  0174  GETMBR	R15	R5	K12
-      0x8C40153B,  //  0175  GETMET	R16	R10	K59
-      0x7C400200,  //  0176  CALL	R16	1
-      0x7C300800,  //  0177  CALL	R12	4
-      0x7001FFE7,  //  0178  JMP		#0161
-      0x5824003C,  //  0179  LDCONST	R9	K60
-      0xAC240200,  //  017A  CATCH	R9	1	0
-      0xB0080000,  //  017B  RAISE	2	R0	R0
-      0x80041000,  //  017C  RET	1	R8
-      0x70020067,  //  017D  JMP		#01E6
-      0x1C200F09,  //  017E  EQ	R8	R7	K9
-      0x7822003C,  //  017F  JMPF	R8	#01BD
-      0x8C200B11,  //  0180  GETMET	R8	R5	K17
-      0x7C200200,  //  0181  CALL	R8	1
-      0x60240010,  //  0182  GETGBL	R9	G16
-      0x88280135,  //  0183  GETMBR	R10	R0	K53
-      0x88281536,  //  0184  GETMBR	R10	R10	K54
-      0x8C281537,  //  0185  GETMET	R10	R10	K55
-      0x7C280200,  //  0186  CALL	R10	1
-      0x7C240200,  //  0187  CALL	R9	1
-      0xA802002E,  //  0188  EXBLK	0	#01B8
-      0x5C281200,  //  0189  MOVE	R10	R9
-      0x7C280000,  //  018A  CALL	R10	0
-      0x8C2C0B3D,  //  018B  GETMET	R11	R5	K61
-      0x8C34153E,  //  018C  GETMET	R13	R10	K62
-      0x7C340200,  //  018D  CALL	R13	1
-      0x7C2C0400,  //  018E  CALL	R11	2
-      0x8C301115,  //  018F  GETMET	R12	R8	K21
-      0x4C380000,  //  0190  LDNIL	R14
-      0x7C300400,  //  0191  CALL	R12	2
-      0x8C34190B,  //  0192  GETMET	R13	R12	K11
-      0x583C0009,  //  0193  LDCONST	R15	K9
-      0x88400B38,  //  0194  GETMBR	R16	R5	K56
-      0x8C44173F,  //  0195  GETMET	R17	R11	K63
-      0x544E0008,  //  0196  LDINT	R19	9
-      0x7C440400,  //  0197  CALL	R17	2
-      0x7C340800,  //  0198  CALL	R13	4
-      0x8C34190B,  //  0199  GETMET	R13	R12	K11
-      0x583C000D,  //  019A  LDCONST	R15	K13
-      0x88400B0C,  //  019B  GETMBR	R16	R5	K12
-      0x8C441540,  //  019C  GETMET	R17	R10	K64
-      0x7C440200,  //  019D  CALL	R17	1
-      0x7C340800,  //  019E  CALL	R13	4
-      0x8C34190B,  //  019F  GETMET	R13	R12	K11
-      0x583C000F,  //  01A0  LDCONST	R15	K15
-      0x88400B07,  //  01A1  GETMBR	R16	R5	K7
-      0x8C441541,  //  01A2  GETMET	R17	R10	K65
-      0x7C440200,  //  01A3  CALL	R17	1
-      0x7C340800,  //  01A4  CALL	R13	4
-      0x8C34190B,  //  01A5  GETMET	R13	R12	K11
-      0x543E0003,  //  01A6  LDINT	R15	4
-      0x88400B07,  //  01A7  GETMBR	R16	R5	K7
-      0x8C441542,  //  01A8  GETMET	R17	R10	K66
-      0x7C440200,  //  01A9  CALL	R17	1
-      0x7C340800,  //  01AA  CALL	R13	4
-      0x8C34190B,  //  01AB  GETMET	R13	R12	K11
-      0x543E0004,  //  01AC  LDINT	R15	5
-      0x88400B16,  //  01AD  GETMBR	R16	R5	K22
-      0x8C441543,  //  01AE  GETMET	R17	R10	K67
-      0x7C440200,  //  01AF  CALL	R17	1
-      0x7C340800,  //  01B0  CALL	R13	4
-      0x8C34190B,  //  01B1  GETMET	R13	R12	K11
-      0x543E00FD,  //  01B2  LDINT	R15	254
-      0x88400B0C,  //  01B3  GETMBR	R16	R5	K12
-      0x8C44153B,  //  01B4  GETMET	R17	R10	K59
-      0x7C440200,  //  01B5  CALL	R17	1
-      0x7C340800,  //  01B6  CALL	R13	4
-      0x7001FFD0,  //  01B7  JMP		#0189
-      0x5824003C,  //  01B8  LDCONST	R9	K60
-      0xAC240200,  //  01B9  CATCH	R9	1	0
-      0xB0080000,  //  01BA  RAISE	2	R0	R0
-      0x80041000,  //  01BB  RET	1	R8
-      0x70020028,  //  01BC  JMP		#01E6
-      0x1C200F0D,  //  01BD  EQ	R8	R7	K13
-      0x78220007,  //  01BE  JMPF	R8	#01C7
-      0x8C200706,  //  01BF  GETMET	R8	R3	K6
-      0x88280B0E,  //  01C0  GETMBR	R10	R5	K14
-      0xB82E0200,  //  01C1  GETNGBL	R11	K1
-      0x882C1744,  //  01C2  GETMBR	R11	R11	K68
-      0x882C1745,  //  01C3  GETMBR	R11	R11	K69
-      0x7C200600,  //  01C4  CALL	R8	3
-      0x80041000,  //  01C5  RET	1	R8
-      0x7002001E,  //  01C6  JMP		#01E6
-      0x1C200F0F,  //  01C7  EQ	R8	R7	K15
-      0x78220009,  //  01C8  JMPF	R8	#01D3
-      0x88200135,  //  01C9  GETMBR	R8	R0	K53
-      0x88201136,  //  01CA  GETMBR	R8	R8	K54
-      0x8C201146,  //  01CB  GETMET	R8	R8	K70
-      0x7C200200,  //  01CC  CALL	R8	1
-      0x8C240706,  //  01CD  GETMET	R9	R3	K6
-      0x882C0B0E,  //  01CE  GETMBR	R11	R5	K14
-      0x5C301000,  //  01CF  MOVE	R12	R8
-      0x7C240600,  //  01D0  CALL	R9	3
-      0x80041200,  //  01D1  RET	1	R9
-      0x70020012,  //  01D2  JMP		#01E6
-      0x54220003,  //  01D3  LDINT	R8	4
-      0x1C200E08,  //  01D4  EQ	R8	R7	R8
-      0x78220000,  //  01D5  JMPF	R8	#01D7
-      0x7002000E,  //  01D6  JMP		#01E6
-      0x54220004,  //  01D7  LDINT	R8	5
-      0x1C200E08,  //  01D8  EQ	R8	R7	R8
-      0x7822000B,  //  01D9  JMPF	R8	#01E6
-      0x88200347,  //  01DA  GETMBR	R8	R1	K71
-      0x8C20113B,  //  01DB  GETMET	R8	R8	K59
-      0x7C200200,  //  01DC  CALL	R8	1
-      0x4C240000,  //  01DD  LDNIL	R9
-      0x1C241009,  //  01DE  EQ	R9	R8	R9
-      0x78260000,  //  01DF  JMPF	R9	#01E1
-      0x58200005,  //  01E0  LDCONST	R8	K5
-      0x8C240706,  //  01E1  GETMET	R9	R3	K6
-      0x882C0B0E,  //  01E2  GETMBR	R11	R5	K14
-      0x5C301000,  //  01E3  MOVE	R12	R8
-      0x7C240600,  //  01E4  CALL	R9	3
-      0x80041200,  //  01E5  RET	1	R9
-      0x700201A6,  //  01E6  JMP		#038E
-      0x5422003B,  //  01E7  LDINT	R8	60
-      0x1C200C08,  //  01E8  EQ	R8	R6	R8
-      0x7822003C,  //  01E9  JMPF	R8	#0227
-      0x1C200F05,  //  01EA  EQ	R8	R7	K5
-      0x78220012,  //  01EB  JMPF	R8	#01FF
-      0x88200135,  //  01EC  GETMBR	R8	R0	K53
-      0x8C201148,  //  01ED  GETMET	R8	R8	K72
-      0x7C200200,  //  01EE  CALL	R8	1
-      0x88240135,  //  01EF  GETMBR	R9	R0	K53
-      0x8C241349,  //  01F0  GETMET	R9	R9	K73
-      0x7C240200,  //  01F1  CALL	R9	1
-      0x78220004,  //  01F2  JMPF	R8	#01F8
-      0x78260001,  //  01F3  JMPF	R9	#01F6
-      0x5828000D,  //  01F4  LDCONST	R10	K13
-      0x70020000,  //  01F5  JMP		#01F7
-      0x58280009,  //  01F6  LDCONST	R10	K9
-      0x70020000,  //  01F7  JMP		#01F9
-      0x58280005,  //  01F8  LDCONST	R10	K5
-      0x8C2C0706,  //  01F9  GETMET	R11	R3	K6
-      0x88340B0E,  //  01FA  GETMBR	R13	R5	K14
-      0x5C381400,  //  01FB  MOVE	R14	R10
-      0x7C2C0600,  //  01FC  CALL	R11	3
-      0x80041600,  //  01FD  RET	1	R11
-      0x70020026,  //  01FE  JMP		#0226
-      0x1C200F09,  //  01FF  EQ	R8	R7	K9
-      0x78220011,  //  0200  JMPF	R8	#0213
-      0x88200135,  //  0201  GETMBR	R8	R0	K53
-      0x8820114A,  //  0202  GETMBR	R8	R8	K74
-      0x4C240000,  //  0203  LDNIL	R9
-      0x20241009,  //  0204  NE	R9	R8	R9
-      0x78260006,  //  0205  JMPF	R9	#020D
-      0x8C240706,  //  0206  GETMET	R9	R3	K6
-      0x882C0B0C,  //  0207  GETMBR	R11	R5	K12
-      0x8C30113B,  //  0208  GETMET	R12	R8	K59
-      0x7C300200,  //  0209  CALL	R12	1
-      0x7C240600,  //  020A  CALL	R9	3
-      0x80041200,  //  020B  RET	1	R9
-      0x70020004,  //  020C  JMP		#0212
-      0x8C240706,  //  020D  GETMET	R9	R3	K6
-      0x882C0B18,  //  020E  GETMBR	R11	R5	K24
-      0x4C300000,  //  020F  LDNIL	R12
-      0x7C240600,  //  0210  CALL	R9	3
-      0x80041200,  //  0211  RET	1	R9
-      0x70020012,  //  0212  JMP		#0226
-      0x1C200F0D,  //  0213  EQ	R8	R7	K13
-      0x78220010,  //  0214  JMPF	R8	#0226
-      0x88200135,  //  0215  GETMBR	R8	R0	K53
-      0x8820114A,  //  0216  GETMBR	R8	R8	K74
-      0x4C240000,  //  0217  LDNIL	R9
-      0x20241009,  //  0218  NE	R9	R8	R9
-      0x78260006,  //  0219  JMPF	R9	#0221
-      0x8C240706,  //  021A  GETMET	R9	R3	K6
-      0x882C0B0C,  //  021B  GETMBR	R11	R5	K12
-      0x8C301140,  //  021C  GETMET	R12	R8	K64
-      0x7C300200,  //  021D  CALL	R12	1
-      0x7C240600,  //  021E  CALL	R9	3
-      0x80041200,  //  021F  RET	1	R9
-      0x70020004,  //  0220  JMP		#0226
-      0x8C240706,  //  0221  GETMET	R9	R3	K6
-      0x882C0B18,  //  0222  GETMBR	R11	R5	K24
-      0x4C300000,  //  0223  LDNIL	R12
+      0x88240535,  //  015A  GETMBR	R9	R2	K53
+      0x78260005,  //  015B  JMPF	R9	#0162
+      0x60240012,  //  015C  GETGBL	R9	G18
+      0x7C240000,  //  015D  CALL	R9	0
+      0x8C280336,  //  015E  GETMET	R10	R1	K54
+      0x7C280200,  //  015F  CALL	R10	1
+      0x4028120A,  //  0160  CONNECT	R10	R9	R10
+      0x70020003,  //  0161  JMP		#0166
+      0x88240137,  //  0162  GETMBR	R9	R0	K55
+      0x88241338,  //  0163  GETMBR	R9	R9	K56
+      0x8C241339,  //  0164  GETMET	R9	R9	K57
+      0x7C240200,  //  0165  CALL	R9	1
+      0x60280010,  //  0166  GETGBL	R10	G16
+      0x5C2C1200,  //  0167  MOVE	R11	R9
+      0x7C280200,  //  0168  CALL	R10	1
+      0xA802001B,  //  0169  EXBLK	0	#0186
+      0x5C2C1400,  //  016A  MOVE	R11	R10
+      0x7C2C0000,  //  016B  CALL	R11	0
+      0x4C300000,  //  016C  LDNIL	R12
+      0x1C30160C,  //  016D  EQ	R12	R11	R12
+      0x78320000,  //  016E  JMPF	R12	#0170
+      0x7001FFF9,  //  016F  JMP		#016A
+      0x8C301115,  //  0170  GETMET	R12	R8	K21
+      0x4C380000,  //  0171  LDNIL	R14
+      0x7C300400,  //  0172  CALL	R12	2
+      0x8C34190B,  //  0173  GETMET	R13	R12	K11
+      0x583C0009,  //  0174  LDCONST	R15	K9
+      0x88400B3A,  //  0175  GETMBR	R16	R5	K58
+      0x8C44173B,  //  0176  GETMET	R17	R11	K59
+      0x7C440200,  //  0177  CALL	R17	1
+      0x7C340800,  //  0178  CALL	R13	4
+      0x8C34190B,  //  0179  GETMET	R13	R12	K11
+      0x583C000D,  //  017A  LDCONST	R15	K13
+      0x88400B3A,  //  017B  GETMBR	R16	R5	K58
+      0x8C44173C,  //  017C  GETMET	R17	R11	K60
+      0x7C440200,  //  017D  CALL	R17	1
+      0x7C340800,  //  017E  CALL	R13	4
+      0x8C34190B,  //  017F  GETMET	R13	R12	K11
+      0x543E00FD,  //  0180  LDINT	R15	254
+      0x88400B0C,  //  0181  GETMBR	R16	R5	K12
+      0x8C44173D,  //  0182  GETMET	R17	R11	K61
+      0x7C440200,  //  0183  CALL	R17	1
+      0x7C340800,  //  0184  CALL	R13	4
+      0x7001FFE3,  //  0185  JMP		#016A
+      0x5828003E,  //  0186  LDCONST	R10	K62
+      0xAC280200,  //  0187  CATCH	R10	1	0
+      0xB0080000,  //  0188  RAISE	2	R0	R0
+      0x80041000,  //  0189  RET	1	R8
+      0x70020074,  //  018A  JMP		#0200
+      0x1C200F09,  //  018B  EQ	R8	R7	K9
+      0x78220049,  //  018C  JMPF	R8	#01D7
+      0x8C200B11,  //  018D  GETMET	R8	R5	K17
+      0x7C200200,  //  018E  CALL	R8	1
+      0x88240535,  //  018F  GETMBR	R9	R2	K53
+      0x78260005,  //  0190  JMPF	R9	#0197
+      0x60240012,  //  0191  GETGBL	R9	G18
+      0x7C240000,  //  0192  CALL	R9	0
+      0x8C280336,  //  0193  GETMET	R10	R1	K54
+      0x7C280200,  //  0194  CALL	R10	1
+      0x4028120A,  //  0195  CONNECT	R10	R9	R10
+      0x70020003,  //  0196  JMP		#019B
+      0x88240137,  //  0197  GETMBR	R9	R0	K55
+      0x88241338,  //  0198  GETMBR	R9	R9	K56
+      0x8C241339,  //  0199  GETMET	R9	R9	K57
+      0x7C240200,  //  019A  CALL	R9	1
+      0x60280010,  //  019B  GETGBL	R10	G16
+      0x5C2C1200,  //  019C  MOVE	R11	R9
+      0x7C280200,  //  019D  CALL	R10	1
+      0xA8020032,  //  019E  EXBLK	0	#01D2
+      0x5C2C1400,  //  019F  MOVE	R11	R10
+      0x7C2C0000,  //  01A0  CALL	R11	0
+      0x4C300000,  //  01A1  LDNIL	R12
+      0x1C30160C,  //  01A2  EQ	R12	R11	R12
+      0x78320000,  //  01A3  JMPF	R12	#01A5
+      0x7001FFF9,  //  01A4  JMP		#019F
+      0x8C300B3F,  //  01A5  GETMET	R12	R5	K63
+      0x8C381740,  //  01A6  GETMET	R14	R11	K64
+      0x7C380200,  //  01A7  CALL	R14	1
+      0x7C300400,  //  01A8  CALL	R12	2
+      0x8C341115,  //  01A9  GETMET	R13	R8	K21
+      0x4C3C0000,  //  01AA  LDNIL	R15
+      0x7C340400,  //  01AB  CALL	R13	2
+      0x8C381B0B,  //  01AC  GETMET	R14	R13	K11
+      0x58400009,  //  01AD  LDCONST	R16	K9
+      0x88440B3A,  //  01AE  GETMBR	R17	R5	K58
+      0x8C481941,  //  01AF  GETMET	R18	R12	K65
+      0x54520008,  //  01B0  LDINT	R20	9
+      0x7C480400,  //  01B1  CALL	R18	2
+      0x7C380800,  //  01B2  CALL	R14	4
+      0x8C381B0B,  //  01B3  GETMET	R14	R13	K11
+      0x5840000D,  //  01B4  LDCONST	R16	K13
+      0x88440B0C,  //  01B5  GETMBR	R17	R5	K12
+      0x8C481742,  //  01B6  GETMET	R18	R11	K66
+      0x7C480200,  //  01B7  CALL	R18	1
+      0x7C380800,  //  01B8  CALL	R14	4
+      0x8C381B0B,  //  01B9  GETMET	R14	R13	K11
+      0x5840000F,  //  01BA  LDCONST	R16	K15
+      0x88440B07,  //  01BB  GETMBR	R17	R5	K7
+      0x8C481743,  //  01BC  GETMET	R18	R11	K67
+      0x7C480200,  //  01BD  CALL	R18	1
+      0x7C380800,  //  01BE  CALL	R14	4
+      0x8C381B0B,  //  01BF  GETMET	R14	R13	K11
+      0x54420003,  //  01C0  LDINT	R16	4
+      0x88440B07,  //  01C1  GETMBR	R17	R5	K7
+      0x8C481744,  //  01C2  GETMET	R18	R11	K68
+      0x7C480200,  //  01C3  CALL	R18	1
+      0x7C380800,  //  01C4  CALL	R14	4
+      0x8C381B0B,  //  01C5  GETMET	R14	R13	K11
+      0x54420004,  //  01C6  LDINT	R16	5
+      0x88440B16,  //  01C7  GETMBR	R17	R5	K22
+      0x8C481745,  //  01C8  GETMET	R18	R11	K69
+      0x7C480200,  //  01C9  CALL	R18	1
+      0x7C380800,  //  01CA  CALL	R14	4
+      0x8C381B0B,  //  01CB  GETMET	R14	R13	K11
+      0x544200FD,  //  01CC  LDINT	R16	254
+      0x88440B0C,  //  01CD  GETMBR	R17	R5	K12
+      0x8C48173D,  //  01CE  GETMET	R18	R11	K61
+      0x7C480200,  //  01CF  CALL	R18	1
+      0x7C380800,  //  01D0  CALL	R14	4
+      0x7001FFCC,  //  01D1  JMP		#019F
+      0x5828003E,  //  01D2  LDCONST	R10	K62
+      0xAC280200,  //  01D3  CATCH	R10	1	0
+      0xB0080000,  //  01D4  RAISE	2	R0	R0
+      0x80041000,  //  01D5  RET	1	R8
+      0x70020028,  //  01D6  JMP		#0200
+      0x1C200F0D,  //  01D7  EQ	R8	R7	K13
+      0x78220007,  //  01D8  JMPF	R8	#01E1
+      0x8C200706,  //  01D9  GETMET	R8	R3	K6
+      0x88280B0E,  //  01DA  GETMBR	R10	R5	K14
+      0xB82E0200,  //  01DB  GETNGBL	R11	K1
+      0x882C1746,  //  01DC  GETMBR	R11	R11	K70
+      0x882C1747,  //  01DD  GETMBR	R11	R11	K71
+      0x7C200600,  //  01DE  CALL	R8	3
+      0x80041000,  //  01DF  RET	1	R8
+      0x7002001E,  //  01E0  JMP		#0200
+      0x1C200F0F,  //  01E1  EQ	R8	R7	K15
+      0x78220009,  //  01E2  JMPF	R8	#01ED
+      0x88200137,  //  01E3  GETMBR	R8	R0	K55
+      0x88201138,  //  01E4  GETMBR	R8	R8	K56
+      0x8C201148,  //  01E5  GETMET	R8	R8	K72
+      0x7C200200,  //  01E6  CALL	R8	1
+      0x8C240706,  //  01E7  GETMET	R9	R3	K6
+      0x882C0B0E,  //  01E8  GETMBR	R11	R5	K14
+      0x5C301000,  //  01E9  MOVE	R12	R8
+      0x7C240600,  //  01EA  CALL	R9	3
+      0x80041200,  //  01EB  RET	1	R9
+      0x70020012,  //  01EC  JMP		#0200
+      0x54220003,  //  01ED  LDINT	R8	4
+      0x1C200E08,  //  01EE  EQ	R8	R7	R8
+      0x78220000,  //  01EF  JMPF	R8	#01F1
+      0x7002000E,  //  01F0  JMP		#0200
+      0x54220004,  //  01F1  LDINT	R8	5
+      0x1C200E08,  //  01F2  EQ	R8	R7	R8
+      0x7822000B,  //  01F3  JMPF	R8	#0200
+      0x88200349,  //  01F4  GETMBR	R8	R1	K73
+      0x8C20113D,  //  01F5  GETMET	R8	R8	K61
+      0x7C200200,  //  01F6  CALL	R8	1
+      0x4C240000,  //  01F7  LDNIL	R9
+      0x1C241009,  //  01F8  EQ	R9	R8	R9
+      0x78260000,  //  01F9  JMPF	R9	#01FB
+      0x58200005,  //  01FA  LDCONST	R8	K5
+      0x8C240706,  //  01FB  GETMET	R9	R3	K6
+      0x882C0B0E,  //  01FC  GETMBR	R11	R5	K14
+      0x5C301000,  //  01FD  MOVE	R12	R8
+      0x7C240600,  //  01FE  CALL	R9	3
+      0x80041200,  //  01FF  RET	1	R9
+      0x700201A6,  //  0200  JMP		#03A8
+      0x5422003B,  //  0201  LDINT	R8	60
+      0x1C200C08,  //  0202  EQ	R8	R6	R8
+      0x7822003C,  //  0203  JMPF	R8	#0241
+      0x1C200F05,  //  0204  EQ	R8	R7	K5
+      0x78220012,  //  0205  JMPF	R8	#0219
+      0x88200137,  //  0206  GETMBR	R8	R0	K55
+      0x8C20114A,  //  0207  GETMET	R8	R8	K74
+      0x7C200200,  //  0208  CALL	R8	1
+      0x88240137,  //  0209  GETMBR	R9	R0	K55
+      0x8C24134B,  //  020A  GETMET	R9	R9	K75
+      0x7C240200,  //  020B  CALL	R9	1
+      0x78220004,  //  020C  JMPF	R8	#0212
+      0x78260001,  //  020D  JMPF	R9	#0210
+      0x5828000D,  //  020E  LDCONST	R10	K13
+      0x70020000,  //  020F  JMP		#0211
+      0x58280009,  //  0210  LDCONST	R10	K9
+      0x70020000,  //  0211  JMP		#0213
+      0x58280005,  //  0212  LDCONST	R10	K5
+      0x8C2C0706,  //  0213  GETMET	R11	R3	K6
+      0x88340B0E,  //  0214  GETMBR	R13	R5	K14
+      0x5C381400,  //  0215  MOVE	R14	R10
+      0x7C2C0600,  //  0216  CALL	R11	3
+      0x80041600,  //  0217  RET	1	R11
+      0x70020026,  //  0218  JMP		#0240
+      0x1C200F09,  //  0219  EQ	R8	R7	K9
+      0x78220011,  //  021A  JMPF	R8	#022D
+      0x88200137,  //  021B  GETMBR	R8	R0	K55
+      0x8820114C,  //  021C  GETMBR	R8	R8	K76
+      0x4C240000,  //  021D  LDNIL	R9
+      0x20241009,  //  021E  NE	R9	R8	R9
+      0x78260006,  //  021F  JMPF	R9	#0227
+      0x8C240706,  //  0220  GETMET	R9	R3	K6
+      0x882C0B0C,  //  0221  GETMBR	R11	R5	K12
+      0x8C30113D,  //  0222  GETMET	R12	R8	K61
+      0x7C300200,  //  0223  CALL	R12	1
       0x7C240600,  //  0224  CALL	R9	3
       0x80041200,  //  0225  RET	1	R9
-      0x70020166,  //  0226  JMP		#038E
-      0x54220027,  //  0227  LDINT	R8	40
-      0x1C200C08,  //  0228  EQ	R8	R6	R8
-      0x782200BA,  //  0229  JMPF	R8	#02E5
-      0x8C200133,  //  022A  GETMET	R8	R0	K51
-      0x88280534,  //  022B  GETMBR	R10	R2	K52
-      0x7C200400,  //  022C  CALL	R8	2
-      0x1C200F05,  //  022D  EQ	R8	R7	K5
-      0x78220005,  //  022E  JMPF	R8	#0235
-      0x8C200706,  //  022F  GETMET	R8	R3	K6
-      0x88280B0C,  //  0230  GETMBR	R10	R5	K12
-      0x582C0009,  //  0231  LDCONST	R11	K9
-      0x7C200600,  //  0232  CALL	R8	3
-      0x80041000,  //  0233  RET	1	R8
-      0x700200AE,  //  0234  JMP		#02E4
-      0x1C200F09,  //  0235  EQ	R8	R7	K9
-      0x78220005,  //  0236  JMPF	R8	#023D
-      0x8C200706,  //  0237  GETMET	R8	R3	K6
-      0x88280B16,  //  0238  GETMBR	R10	R5	K22
-      0x582C004B,  //  0239  LDCONST	R11	K75
-      0x7C200600,  //  023A  CALL	R8	3
-      0x80041000,  //  023B  RET	1	R8
-      0x700200A6,  //  023C  JMP		#02E4
-      0x1C200F0D,  //  023D  EQ	R8	R7	K13
-      0x78220006,  //  023E  JMPF	R8	#0246
-      0x8C200706,  //  023F  GETMET	R8	R3	K6
-      0x88280B0C,  //  0240  GETMBR	R10	R5	K12
-      0x882C0135,  //  0241  GETMBR	R11	R0	K53
-      0x882C174C,  //  0242  GETMBR	R11	R11	K76
-      0x7C200600,  //  0243  CALL	R8	3
-      0x80041000,  //  0244  RET	1	R8
-      0x7002009D,  //  0245  JMP		#02E4
-      0x1C200F0F,  //  0246  EQ	R8	R7	K15
-      0x7822000A,  //  0247  JMPF	R8	#0253
-      0x8C200706,  //  0248  GETMET	R8	R3	K6
-      0x88280B16,  //  0249  GETMBR	R10	R5	K22
-      0xB82E2400,  //  024A  GETNGBL	R11	K18
-      0x8C2C1726,  //  024B  GETMET	R11	R11	K38
-      0x5834004D,  //  024C  LDCONST	R13	K77
-      0x50380200,  //  024D  LDBOOL	R14	1	0
-      0x7C2C0600,  //  024E  CALL	R11	3
-      0x942C174D,  //  024F  GETIDX	R11	R11	K77
-      0x7C200600,  //  0250  CALL	R8	3
-      0x80041000,  //  0251  RET	1	R8
-      0x70020090,  //  0252  JMP		#02E4
-      0x54220003,  //  0253  LDINT	R8	4
-      0x1C200E08,  //  0254  EQ	R8	R7	R8
-      0x78220005,  //  0255  JMPF	R8	#025C
-      0x8C200706,  //  0256  GETMET	R8	R3	K6
-      0x88280B0C,  //  0257  GETMBR	R10	R5	K12
-      0x542E7FFF,  //  0258  LDINT	R11	32768
-      0x7C200600,  //  0259  CALL	R8	3
-      0x80041000,  //  025A  RET	1	R8
-      0x70020087,  //  025B  JMP		#02E4
-      0x54220004,  //  025C  LDINT	R8	5
-      0x1C200E08,  //  025D  EQ	R8	R7	R8
-      0x7822000A,  //  025E  JMPF	R8	#026A
-      0x8C200706,  //  025F  GETMET	R8	R3	K6
-      0x88280B16,  //  0260  GETMBR	R10	R5	K22
-      0xB82E2400,  //  0261  GETNGBL	R11	K18
-      0x8C2C1726,  //  0262  GETMET	R11	R11	K38
-      0x5834004E,  //  0263  LDCONST	R13	K78
-      0x50380200,  //  0264  LDBOOL	R14	1	0
-      0x7C2C0600,  //  0265  CALL	R11	3
-      0x942C174F,  //  0266  GETIDX	R11	R11	K79
-      0x7C200600,  //  0267  CALL	R8	3
-      0x80041000,  //  0268  RET	1	R8
-      0x70020079,  //  0269  JMP		#02E4
-      0x54220005,  //  026A  LDINT	R8	6
-      0x1C200E08,  //  026B  EQ	R8	R7	R8
-      0x78220005,  //  026C  JMPF	R8	#0273
-      0x8C200706,  //  026D  GETMET	R8	R3	K6
-      0x88280B16,  //  026E  GETMBR	R10	R5	K22
-      0x582C0050,  //  026F  LDCONST	R11	K80
-      0x7C200600,  //  0270  CALL	R8	3
-      0x80041000,  //  0271  RET	1	R8
-      0x70020070,  //  0272  JMP		#02E4
-      0x54220006,  //  0273  LDINT	R8	7
-      0x1C200E08,  //  0274  EQ	R8	R7	R8
-      0x78220005,  //  0275  JMPF	R8	#027C
-      0x8C200706,  //  0276  GETMET	R8	R3	K6
-      0x88280B0C,  //  0277  GETMBR	R10	R5	K12
-      0x582C0005,  //  0278  LDCONST	R11	K5
-      0x7C200600,  //  0279  CALL	R8	3
-      0x80041000,  //  027A  RET	1	R8
-      0x70020067,  //  027B  JMP		#02E4
-      0x54220007,  //  027C  LDINT	R8	8
-      0x1C200E08,  //  027D  EQ	R8	R7	R8
-      0x7822000B,  //  027E  JMPF	R8	#028B
-      0x8C200706,  //  027F  GETMET	R8	R3	K6
-      0x88280B16,  //  0280  GETMBR	R10	R5	K22
-      0xB82E2400,  //  0281  GETNGBL	R11	K18
-      0x8C2C1726,  //  0282  GETMET	R11	R11	K38
-      0x58340051,  //  0283  LDCONST	R13	K81
-      0x50380200,  //  0284  LDBOOL	R14	1	0
-      0x7C2C0600,  //  0285  CALL	R11	3
-      0x942C1752,  //  0286  GETIDX	R11	R11	K82
-      0x942C1753,  //  0287  GETIDX	R11	R11	K83
-      0x7C200600,  //  0288  CALL	R8	3
-      0x80041000,  //  0289  RET	1	R8
-      0x70020058,  //  028A  JMP		#02E4
-      0x54220008,  //  028B  LDINT	R8	9
-      0x1C200E08,  //  028C  EQ	R8	R7	R8
-      0x78220005,  //  028D  JMPF	R8	#0294
-      0x8C200706,  //  028E  GETMET	R8	R3	K6
-      0x88280B0C,  //  028F  GETMBR	R10	R5	K12
-      0x582C0009,  //  0290  LDCONST	R11	K9
-      0x7C200600,  //  0291  CALL	R8	3
-      0x80041000,  //  0292  RET	1	R8
-      0x7002004F,  //  0293  JMP		#02E4
-      0x54220009,  //  0294  LDINT	R8	10
-      0x1C200E08,  //  0295  EQ	R8	R7	R8
-      0x78220015,  //  0296  JMPF	R8	#02AD
-      0xB8222400,  //  0297  GETNGBL	R8	K18
-      0x8C201126,  //  0298  GETMET	R8	R8	K38
-      0x58280051,  //  0299  LDCONST	R10	K81
-      0x502C0200,  //  029A  LDBOOL	R11	1	0
-      0x7C200600,  //  029B  CALL	R8	3
-      0x94201152,  //  029C  GETIDX	R8	R8	K82
-      0x94201154,  //  029D  GETIDX	R8	R8	K84
-      0x8C24091B,  //  029E  GETMET	R9	R4	K27
-      0x5C2C1000,  //  029F  MOVE	R11	R8
-      0x58300055,  //  02A0  LDCONST	R12	K85
-      0x7C240600,  //  02A1  CALL	R9	3
-      0x24281305,  //  02A2  GT	R10	R9	K5
-      0x782A0002,  //  02A3  JMPF	R10	#02A7
-      0x04281309,  //  02A4  SUB	R10	R9	K9
-      0x402A0A0A,  //  02A5  CONNECT	R10	K5	R10
-      0x9420100A,  //  02A6  GETIDX	R8	R8	R10
-      0x8C280706,  //  02A7  GETMET	R10	R3	K6
-      0x88300B16,  //  02A8  GETMBR	R12	R5	K22
-      0x5C341000,  //  02A9  MOVE	R13	R8
-      0x7C280600,  //  02AA  CALL	R10	3
-      0x80041400,  //  02AB  RET	1	R10
-      0x70020036,  //  02AC  JMP		#02E4
-      0x5422000E,  //  02AD  LDINT	R8	15
-      0x1C200E08,  //  02AE  EQ	R8	R7	R8
-      0x7822000B,  //  02AF  JMPF	R8	#02BC
-      0x8C200706,  //  02B0  GETMET	R8	R3	K6
-      0x88280B16,  //  02B1  GETMBR	R10	R5	K22
-      0xB82E2400,  //  02B2  GETNGBL	R11	K18
-      0x8C2C1725,  //  02B3  GETMET	R11	R11	K37
-      0x7C2C0200,  //  02B4  CALL	R11	1
-      0x8C2C171B,  //  02B5  GETMET	R11	R11	K27
-      0x5834001C,  //  02B6  LDCONST	R13	K28
-      0x5838001D,  //  02B7  LDCONST	R14	K29
-      0x7C2C0600,  //  02B8  CALL	R11	3
-      0x7C200600,  //  02B9  CALL	R8	3
-      0x80041000,  //  02BA  RET	1	R8
-      0x70020027,  //  02BB  JMP		#02E4
-      0x54220010,  //  02BC  LDINT	R8	17
-      0x1C200E08,  //  02BD  EQ	R8	R7	R8
-      0x78220005,  //  02BE  JMPF	R8	#02C5
-      0x8C200706,  //  02BF  GETMET	R8	R3	K6
-      0x88280B10,  //  02C0  GETMBR	R10	R5	K16
-      0x582C0009,  //  02C1  LDCONST	R11	K9
-      0x7C200600,  //  02C2  CALL	R8	3
-      0x80041000,  //  02C3  RET	1	R8
-      0x7002001E,  //  02C4  JMP		#02E4
-      0x54220011,  //  02C5  LDINT	R8	18
-      0x1C200E08,  //  02C6  EQ	R8	R7	R8
-      0x7822000B,  //  02C7  JMPF	R8	#02D4
-      0x8C200706,  //  02C8  GETMET	R8	R3	K6
-      0x88280B16,  //  02C9  GETMBR	R10	R5	K22
-      0xB82E2400,  //  02CA  GETNGBL	R11	K18
-      0x8C2C1725,  //  02CB  GETMET	R11	R11	K37
-      0x7C2C0200,  //  02CC  CALL	R11	1
-      0x8C2C171B,  //  02CD  GETMET	R11	R11	K27
-      0x5834001C,  //  02CE  LDCONST	R13	K28
-      0x5838001D,  //  02CF  LDCONST	R14	K29
-      0x7C2C0600,  //  02D0  CALL	R11	3
-      0x7C200600,  //  02D1  CALL	R8	3
-      0x80041000,  //  02D2  RET	1	R8
-      0x7002000F,  //  02D3  JMP		#02E4
-      0x54220012,  //  02D4  LDINT	R8	19
-      0x1C200E08,  //  02D5  EQ	R8	R7	R8
-      0x7822000C,  //  02D6  JMPF	R8	#02E4
-      0x8C200B0A,  //  02D7  GETMET	R8	R5	K10
-      0x7C200200,  //  02D8  CALL	R8	1
-      0x8C24110B,  //  02D9  GETMET	R9	R8	K11
-      0x582C0005,  //  02DA  LDCONST	R11	K5
-      0x88300B0C,  //  02DB  GETMBR	R12	R5	K12
-      0x5834000F,  //  02DC  LDCONST	R13	K15
-      0x7C240800,  //  02DD  CALL	R9	4
-      0x8C24110B,  //  02DE  GETMET	R9	R8	K11
-      0x582C0009,  //  02DF  LDCONST	R11	K9
-      0x88300B0C,  //  02E0  GETMBR	R12	R5	K12
-      0x5834000F,  //  02E1  LDCONST	R13	K15
-      0x7C240800,  //  02E2  CALL	R9	4
-      0x80041000,  //  02E3  RET	1	R8
-      0x700200A8,  //  02E4  JMP		#038E
-      0x5422003E,  //  02E5  LDINT	R8	63
-      0x1C200C08,  //  02E6  EQ	R8	R6	R8
-      0x78220000,  //  02E7  JMPF	R8	#02E9
-      0x700200A4,  //  02E8  JMP		#038E
-      0x54220029,  //  02E9  LDINT	R8	42
-      0x1C200C08,  //  02EA  EQ	R8	R6	R8
-      0x7822001D,  //  02EB  JMPF	R8	#030A
-      0x1C200F05,  //  02EC  EQ	R8	R7	K5
-      0x78220003,  //  02ED  JMPF	R8	#02F2
-      0x8C200B11,  //  02EE  GETMET	R8	R5	K17
-      0x7C200200,  //  02EF  CALL	R8	1
-      0x80041000,  //  02F0  RET	1	R8
-      0x70020016,  //  02F1  JMP		#0309
-      0x1C200F09,  //  02F2  EQ	R8	R7	K9
-      0x78220005,  //  02F3  JMPF	R8	#02FA
-      0x8C200706,  //  02F4  GETMET	R8	R3	K6
-      0x88280B10,  //  02F5  GETMBR	R10	R5	K16
-      0x582C0005,  //  02F6  LDCONST	R11	K5
-      0x7C200600,  //  02F7  CALL	R8	3
-      0x80041000,  //  02F8  RET	1	R8
-      0x7002000E,  //  02F9  JMP		#0309
-      0x1C200F0D,  //  02FA  EQ	R8	R7	K13
-      0x78220005,  //  02FB  JMPF	R8	#0302
-      0x8C200706,  //  02FC  GETMET	R8	R3	K6
-      0x88280B0E,  //  02FD  GETMBR	R10	R5	K14
-      0x582C0009,  //  02FE  LDCONST	R11	K9
-      0x7C200600,  //  02FF  CALL	R8	3
-      0x80041000,  //  0300  RET	1	R8
-      0x70020006,  //  0301  JMP		#0309
-      0x1C200F0F,  //  0302  EQ	R8	R7	K15
-      0x78220004,  //  0303  JMPF	R8	#0309
-      0x8C200706,  //  0304  GETMET	R8	R3	K6
-      0x88280B18,  //  0305  GETMBR	R10	R5	K24
-      0x4C2C0000,  //  0306  LDNIL	R11
-      0x7C200600,  //  0307  CALL	R8	3
-      0x80041000,  //  0308  RET	1	R8
-      0x70020083,  //  0309  JMP		#038E
-      0x5422002A,  //  030A  LDINT	R8	43
-      0x1C200C08,  //  030B  EQ	R8	R6	R8
-      0x78220016,  //  030C  JMPF	R8	#0324
-      0x1C200F05,  //  030D  EQ	R8	R7	K5
-      0x78220007,  //  030E  JMPF	R8	#0317
-      0x8C200706,  //  030F  GETMET	R8	R3	K6
-      0x88280B16,  //  0310  GETMBR	R10	R5	K22
-      0xB82E2400,  //  0311  GETNGBL	R11	K18
-      0x8C2C1756,  //  0312  GETMET	R11	R11	K86
-      0x7C2C0200,  //  0313  CALL	R11	1
-      0x7C200600,  //  0314  CALL	R8	3
-      0x80041000,  //  0315  RET	1	R8
-      0x7002000B,  //  0316  JMP		#0323
-      0x1C200F09,  //  0317  EQ	R8	R7	K9
-      0x78220009,  //  0318  JMPF	R8	#0323
-      0x8C200B11,  //  0319  GETMET	R8	R5	K17
-      0x7C200200,  //  031A  CALL	R8	1
-      0x8C24110B,  //  031B  GETMET	R9	R8	K11
-      0x4C2C0000,  //  031C  LDNIL	R11
-      0x88300B16,  //  031D  GETMBR	R12	R5	K22
-      0xB8362400,  //  031E  GETNGBL	R13	K18
-      0x8C341B56,  //  031F  GETMET	R13	R13	K86
-      0x7C340200,  //  0320  CALL	R13	1
-      0x7C240800,  //  0321  CALL	R9	4
+      0x70020004,  //  0226  JMP		#022C
+      0x8C240706,  //  0227  GETMET	R9	R3	K6
+      0x882C0B18,  //  0228  GETMBR	R11	R5	K24
+      0x4C300000,  //  0229  LDNIL	R12
+      0x7C240600,  //  022A  CALL	R9	3
+      0x80041200,  //  022B  RET	1	R9
+      0x70020012,  //  022C  JMP		#0240
+      0x1C200F0D,  //  022D  EQ	R8	R7	K13
+      0x78220010,  //  022E  JMPF	R8	#0240
+      0x88200137,  //  022F  GETMBR	R8	R0	K55
+      0x8820114C,  //  0230  GETMBR	R8	R8	K76
+      0x4C240000,  //  0231  LDNIL	R9
+      0x20241009,  //  0232  NE	R9	R8	R9
+      0x78260006,  //  0233  JMPF	R9	#023B
+      0x8C240706,  //  0234  GETMET	R9	R3	K6
+      0x882C0B0C,  //  0235  GETMBR	R11	R5	K12
+      0x8C301142,  //  0236  GETMET	R12	R8	K66
+      0x7C300200,  //  0237  CALL	R12	1
+      0x7C240600,  //  0238  CALL	R9	3
+      0x80041200,  //  0239  RET	1	R9
+      0x70020004,  //  023A  JMP		#0240
+      0x8C240706,  //  023B  GETMET	R9	R3	K6
+      0x882C0B18,  //  023C  GETMBR	R11	R5	K24
+      0x4C300000,  //  023D  LDNIL	R12
+      0x7C240600,  //  023E  CALL	R9	3
+      0x80041200,  //  023F  RET	1	R9
+      0x70020166,  //  0240  JMP		#03A8
+      0x54220027,  //  0241  LDINT	R8	40
+      0x1C200C08,  //  0242  EQ	R8	R6	R8
+      0x782200BA,  //  0243  JMPF	R8	#02FF
+      0x8C200133,  //  0244  GETMET	R8	R0	K51
+      0x88280534,  //  0245  GETMBR	R10	R2	K52
+      0x7C200400,  //  0246  CALL	R8	2
+      0x1C200F05,  //  0247  EQ	R8	R7	K5
+      0x78220005,  //  0248  JMPF	R8	#024F
+      0x8C200706,  //  0249  GETMET	R8	R3	K6
+      0x88280B0C,  //  024A  GETMBR	R10	R5	K12
+      0x582C0009,  //  024B  LDCONST	R11	K9
+      0x7C200600,  //  024C  CALL	R8	3
+      0x80041000,  //  024D  RET	1	R8
+      0x700200AE,  //  024E  JMP		#02FE
+      0x1C200F09,  //  024F  EQ	R8	R7	K9
+      0x78220005,  //  0250  JMPF	R8	#0257
+      0x8C200706,  //  0251  GETMET	R8	R3	K6
+      0x88280B16,  //  0252  GETMBR	R10	R5	K22
+      0x582C004D,  //  0253  LDCONST	R11	K77
+      0x7C200600,  //  0254  CALL	R8	3
+      0x80041000,  //  0255  RET	1	R8
+      0x700200A6,  //  0256  JMP		#02FE
+      0x1C200F0D,  //  0257  EQ	R8	R7	K13
+      0x78220006,  //  0258  JMPF	R8	#0260
+      0x8C200706,  //  0259  GETMET	R8	R3	K6
+      0x88280B0C,  //  025A  GETMBR	R10	R5	K12
+      0x882C0137,  //  025B  GETMBR	R11	R0	K55
+      0x882C174E,  //  025C  GETMBR	R11	R11	K78
+      0x7C200600,  //  025D  CALL	R8	3
+      0x80041000,  //  025E  RET	1	R8
+      0x7002009D,  //  025F  JMP		#02FE
+      0x1C200F0F,  //  0260  EQ	R8	R7	K15
+      0x7822000A,  //  0261  JMPF	R8	#026D
+      0x8C200706,  //  0262  GETMET	R8	R3	K6
+      0x88280B16,  //  0263  GETMBR	R10	R5	K22
+      0xB82E2400,  //  0264  GETNGBL	R11	K18
+      0x8C2C1726,  //  0265  GETMET	R11	R11	K38
+      0x5834004F,  //  0266  LDCONST	R13	K79
+      0x50380200,  //  0267  LDBOOL	R14	1	0
+      0x7C2C0600,  //  0268  CALL	R11	3
+      0x942C174F,  //  0269  GETIDX	R11	R11	K79
+      0x7C200600,  //  026A  CALL	R8	3
+      0x80041000,  //  026B  RET	1	R8
+      0x70020090,  //  026C  JMP		#02FE
+      0x54220003,  //  026D  LDINT	R8	4
+      0x1C200E08,  //  026E  EQ	R8	R7	R8
+      0x78220005,  //  026F  JMPF	R8	#0276
+      0x8C200706,  //  0270  GETMET	R8	R3	K6
+      0x88280B0C,  //  0271  GETMBR	R10	R5	K12
+      0x542E7FFF,  //  0272  LDINT	R11	32768
+      0x7C200600,  //  0273  CALL	R8	3
+      0x80041000,  //  0274  RET	1	R8
+      0x70020087,  //  0275  JMP		#02FE
+      0x54220004,  //  0276  LDINT	R8	5
+      0x1C200E08,  //  0277  EQ	R8	R7	R8
+      0x7822000A,  //  0278  JMPF	R8	#0284
+      0x8C200706,  //  0279  GETMET	R8	R3	K6
+      0x88280B16,  //  027A  GETMBR	R10	R5	K22
+      0xB82E2400,  //  027B  GETNGBL	R11	K18
+      0x8C2C1726,  //  027C  GETMET	R11	R11	K38
+      0x58340050,  //  027D  LDCONST	R13	K80
+      0x50380200,  //  027E  LDBOOL	R14	1	0
+      0x7C2C0600,  //  027F  CALL	R11	3
+      0x942C1751,  //  0280  GETIDX	R11	R11	K81
+      0x7C200600,  //  0281  CALL	R8	3
+      0x80041000,  //  0282  RET	1	R8
+      0x70020079,  //  0283  JMP		#02FE
+      0x54220005,  //  0284  LDINT	R8	6
+      0x1C200E08,  //  0285  EQ	R8	R7	R8
+      0x78220005,  //  0286  JMPF	R8	#028D
+      0x8C200706,  //  0287  GETMET	R8	R3	K6
+      0x88280B16,  //  0288  GETMBR	R10	R5	K22
+      0x582C0052,  //  0289  LDCONST	R11	K82
+      0x7C200600,  //  028A  CALL	R8	3
+      0x80041000,  //  028B  RET	1	R8
+      0x70020070,  //  028C  JMP		#02FE
+      0x54220006,  //  028D  LDINT	R8	7
+      0x1C200E08,  //  028E  EQ	R8	R7	R8
+      0x78220005,  //  028F  JMPF	R8	#0296
+      0x8C200706,  //  0290  GETMET	R8	R3	K6
+      0x88280B0C,  //  0291  GETMBR	R10	R5	K12
+      0x582C0005,  //  0292  LDCONST	R11	K5
+      0x7C200600,  //  0293  CALL	R8	3
+      0x80041000,  //  0294  RET	1	R8
+      0x70020067,  //  0295  JMP		#02FE
+      0x54220007,  //  0296  LDINT	R8	8
+      0x1C200E08,  //  0297  EQ	R8	R7	R8
+      0x7822000B,  //  0298  JMPF	R8	#02A5
+      0x8C200706,  //  0299  GETMET	R8	R3	K6
+      0x88280B16,  //  029A  GETMBR	R10	R5	K22
+      0xB82E2400,  //  029B  GETNGBL	R11	K18
+      0x8C2C1726,  //  029C  GETMET	R11	R11	K38
+      0x58340053,  //  029D  LDCONST	R13	K83
+      0x50380200,  //  029E  LDBOOL	R14	1	0
+      0x7C2C0600,  //  029F  CALL	R11	3
+      0x942C1754,  //  02A0  GETIDX	R11	R11	K84
+      0x942C1755,  //  02A1  GETIDX	R11	R11	K85
+      0x7C200600,  //  02A2  CALL	R8	3
+      0x80041000,  //  02A3  RET	1	R8
+      0x70020058,  //  02A4  JMP		#02FE
+      0x54220008,  //  02A5  LDINT	R8	9
+      0x1C200E08,  //  02A6  EQ	R8	R7	R8
+      0x78220005,  //  02A7  JMPF	R8	#02AE
+      0x8C200706,  //  02A8  GETMET	R8	R3	K6
+      0x88280B0C,  //  02A9  GETMBR	R10	R5	K12
+      0x582C0009,  //  02AA  LDCONST	R11	K9
+      0x7C200600,  //  02AB  CALL	R8	3
+      0x80041000,  //  02AC  RET	1	R8
+      0x7002004F,  //  02AD  JMP		#02FE
+      0x54220009,  //  02AE  LDINT	R8	10
+      0x1C200E08,  //  02AF  EQ	R8	R7	R8
+      0x78220015,  //  02B0  JMPF	R8	#02C7
+      0xB8222400,  //  02B1  GETNGBL	R8	K18
+      0x8C201126,  //  02B2  GETMET	R8	R8	K38
+      0x58280053,  //  02B3  LDCONST	R10	K83
+      0x502C0200,  //  02B4  LDBOOL	R11	1	0
+      0x7C200600,  //  02B5  CALL	R8	3
+      0x94201154,  //  02B6  GETIDX	R8	R8	K84
+      0x94201156,  //  02B7  GETIDX	R8	R8	K86
+      0x8C24091B,  //  02B8  GETMET	R9	R4	K27
+      0x5C2C1000,  //  02B9  MOVE	R11	R8
+      0x58300057,  //  02BA  LDCONST	R12	K87
+      0x7C240600,  //  02BB  CALL	R9	3
+      0x24281305,  //  02BC  GT	R10	R9	K5
+      0x782A0002,  //  02BD  JMPF	R10	#02C1
+      0x04281309,  //  02BE  SUB	R10	R9	K9
+      0x402A0A0A,  //  02BF  CONNECT	R10	K5	R10
+      0x9420100A,  //  02C0  GETIDX	R8	R8	R10
+      0x8C280706,  //  02C1  GETMET	R10	R3	K6
+      0x88300B16,  //  02C2  GETMBR	R12	R5	K22
+      0x5C341000,  //  02C3  MOVE	R13	R8
+      0x7C280600,  //  02C4  CALL	R10	3
+      0x80041400,  //  02C5  RET	1	R10
+      0x70020036,  //  02C6  JMP		#02FE
+      0x5422000E,  //  02C7  LDINT	R8	15
+      0x1C200E08,  //  02C8  EQ	R8	R7	R8
+      0x7822000B,  //  02C9  JMPF	R8	#02D6
+      0x8C200706,  //  02CA  GETMET	R8	R3	K6
+      0x88280B16,  //  02CB  GETMBR	R10	R5	K22
+      0xB82E2400,  //  02CC  GETNGBL	R11	K18
+      0x8C2C1725,  //  02CD  GETMET	R11	R11	K37
+      0x7C2C0200,  //  02CE  CALL	R11	1
+      0x8C2C171B,  //  02CF  GETMET	R11	R11	K27
+      0x5834001C,  //  02D0  LDCONST	R13	K28
+      0x5838001D,  //  02D1  LDCONST	R14	K29
+      0x7C2C0600,  //  02D2  CALL	R11	3
+      0x7C200600,  //  02D3  CALL	R8	3
+      0x80041000,  //  02D4  RET	1	R8
+      0x70020027,  //  02D5  JMP		#02FE
+      0x54220010,  //  02D6  LDINT	R8	17
+      0x1C200E08,  //  02D7  EQ	R8	R7	R8
+      0x78220005,  //  02D8  JMPF	R8	#02DF
+      0x8C200706,  //  02D9  GETMET	R8	R3	K6
+      0x88280B10,  //  02DA  GETMBR	R10	R5	K16
+      0x582C0009,  //  02DB  LDCONST	R11	K9
+      0x7C200600,  //  02DC  CALL	R8	3
+      0x80041000,  //  02DD  RET	1	R8
+      0x7002001E,  //  02DE  JMP		#02FE
+      0x54220011,  //  02DF  LDINT	R8	18
+      0x1C200E08,  //  02E0  EQ	R8	R7	R8
+      0x7822000B,  //  02E1  JMPF	R8	#02EE
+      0x8C200706,  //  02E2  GETMET	R8	R3	K6
+      0x88280B16,  //  02E3  GETMBR	R10	R5	K22
+      0xB82E2400,  //  02E4  GETNGBL	R11	K18
+      0x8C2C1725,  //  02E5  GETMET	R11	R11	K37
+      0x7C2C0200,  //  02E6  CALL	R11	1
+      0x8C2C171B,  //  02E7  GETMET	R11	R11	K27
+      0x5834001C,  //  02E8  LDCONST	R13	K28
+      0x5838001D,  //  02E9  LDCONST	R14	K29
+      0x7C2C0600,  //  02EA  CALL	R11	3
+      0x7C200600,  //  02EB  CALL	R8	3
+      0x80041000,  //  02EC  RET	1	R8
+      0x7002000F,  //  02ED  JMP		#02FE
+      0x54220012,  //  02EE  LDINT	R8	19
+      0x1C200E08,  //  02EF  EQ	R8	R7	R8
+      0x7822000C,  //  02F0  JMPF	R8	#02FE
+      0x8C200B0A,  //  02F1  GETMET	R8	R5	K10
+      0x7C200200,  //  02F2  CALL	R8	1
+      0x8C24110B,  //  02F3  GETMET	R9	R8	K11
+      0x582C0005,  //  02F4  LDCONST	R11	K5
+      0x88300B0C,  //  02F5  GETMBR	R12	R5	K12
+      0x5834000F,  //  02F6  LDCONST	R13	K15
+      0x7C240800,  //  02F7  CALL	R9	4
+      0x8C24110B,  //  02F8  GETMET	R9	R8	K11
+      0x582C0009,  //  02F9  LDCONST	R11	K9
+      0x88300B0C,  //  02FA  GETMBR	R12	R5	K12
+      0x5834000F,  //  02FB  LDCONST	R13	K15
+      0x7C240800,  //  02FC  CALL	R9	4
+      0x80041000,  //  02FD  RET	1	R8
+      0x700200A8,  //  02FE  JMP		#03A8
+      0x5422003E,  //  02FF  LDINT	R8	63
+      0x1C200C08,  //  0300  EQ	R8	R6	R8
+      0x78220000,  //  0301  JMPF	R8	#0303
+      0x700200A4,  //  0302  JMP		#03A8
+      0x54220029,  //  0303  LDINT	R8	42
+      0x1C200C08,  //  0304  EQ	R8	R6	R8
+      0x7822001D,  //  0305  JMPF	R8	#0324
+      0x1C200F05,  //  0306  EQ	R8	R7	K5
+      0x78220003,  //  0307  JMPF	R8	#030C
+      0x8C200B11,  //  0308  GETMET	R8	R5	K17
+      0x7C200200,  //  0309  CALL	R8	1
+      0x80041000,  //  030A  RET	1	R8
+      0x70020016,  //  030B  JMP		#0323
+      0x1C200F09,  //  030C  EQ	R8	R7	K9
+      0x78220005,  //  030D  JMPF	R8	#0314
+      0x8C200706,  //  030E  GETMET	R8	R3	K6
+      0x88280B10,  //  030F  GETMBR	R10	R5	K16
+      0x582C0005,  //  0310  LDCONST	R11	K5
+      0x7C200600,  //  0311  CALL	R8	3
+      0x80041000,  //  0312  RET	1	R8
+      0x7002000E,  //  0313  JMP		#0323
+      0x1C200F0D,  //  0314  EQ	R8	R7	K13
+      0x78220005,  //  0315  JMPF	R8	#031C
+      0x8C200706,  //  0316  GETMET	R8	R3	K6
+      0x88280B0E,  //  0317  GETMBR	R10	R5	K14
+      0x582C0009,  //  0318  LDCONST	R11	K9
+      0x7C200600,  //  0319  CALL	R8	3
+      0x80041000,  //  031A  RET	1	R8
+      0x70020006,  //  031B  JMP		#0323
+      0x1C200F0F,  //  031C  EQ	R8	R7	K15
+      0x78220004,  //  031D  JMPF	R8	#0323
+      0x8C200706,  //  031E  GETMET	R8	R3	K6
+      0x88280B18,  //  031F  GETMBR	R10	R5	K24
+      0x4C2C0000,  //  0320  LDNIL	R11
+      0x7C200600,  //  0321  CALL	R8	3
       0x80041000,  //  0322  RET	1	R8
-      0x70020069,  //  0323  JMP		#038E
-      0x5422002B,  //  0324  LDINT	R8	44
+      0x70020083,  //  0323  JMP		#03A8
+      0x5422002A,  //  0324  LDINT	R8	43
       0x1C200C08,  //  0325  EQ	R8	R6	R8
-      0x7822001C,  //  0326  JMPF	R8	#0344
+      0x78220016,  //  0326  JMPF	R8	#033E
       0x1C200F05,  //  0327  EQ	R8	R7	K5
-      0x78220005,  //  0328  JMPF	R8	#032F
+      0x78220007,  //  0328  JMPF	R8	#0331
       0x8C200706,  //  0329  GETMET	R8	R3	K6
-      0x88280B0E,  //  032A  GETMBR	R10	R5	K14
-      0x582C0009,  //  032B  LDCONST	R11	K9
-      0x7C200600,  //  032C  CALL	R8	3
-      0x80041000,  //  032D  RET	1	R8
-      0x70020013,  //  032E  JMP		#0343
-      0x1C200F09,  //  032F  EQ	R8	R7	K9
-      0x78220005,  //  0330  JMPF	R8	#0337
-      0x8C200706,  //  0331  GETMET	R8	R3	K6
-      0x88280B0E,  //  0332  GETMBR	R10	R5	K14
-      0x542E0003,  //  0333  LDINT	R11	4
-      0x7C200600,  //  0334  CALL	R8	3
-      0x80041000,  //  0335  RET	1	R8
-      0x7002000B,  //  0336  JMP		#0343
-      0x1C200F0D,  //  0337  EQ	R8	R7	K13
-      0x78220009,  //  0338  JMPF	R8	#0343
-      0x8C200B11,  //  0339  GETMET	R8	R5	K17
-      0x7C200200,  //  033A  CALL	R8	1
-      0x8C24110B,  //  033B  GETMET	R9	R8	K11
-      0x4C2C0000,  //  033C  LDNIL	R11
-      0x8C300B57,  //  033D  GETMET	R12	R5	K87
-      0x88380B0E,  //  033E  GETMBR	R14	R5	K14
-      0x543E0003,  //  033F  LDINT	R15	4
-      0x7C300600,  //  0340  CALL	R12	3
-      0x7C240600,  //  0341  CALL	R9	3
-      0x80041000,  //  0342  RET	1	R8
-      0x70020049,  //  0343  JMP		#038E
-      0x54220030,  //  0344  LDINT	R8	49
-      0x1C200C08,  //  0345  EQ	R8	R6	R8
-      0x78220010,  //  0346  JMPF	R8	#0358
-      0x1C200F0F,  //  0347  EQ	R8	R7	K15
-      0x78220005,  //  0348  JMPF	R8	#034F
-      0x8C200706,  //  0349  GETMET	R8	R3	K6
-      0x88280B0E,  //  034A  GETMBR	R10	R5	K14
-      0x542E001D,  //  034B  LDINT	R11	30
-      0x7C200600,  //  034C  CALL	R8	3
-      0x80041000,  //  034D  RET	1	R8
-      0x70020007,  //  034E  JMP		#0357
-      0x5422FFFB,  //  034F  LDINT	R8	65532
-      0x1C200E08,  //  0350  EQ	R8	R7	R8
-      0x78220004,  //  0351  JMPF	R8	#0357
-      0x8C200706,  //  0352  GETMET	R8	R3	K6
-      0x88280B2A,  //  0353  GETMBR	R10	R5	K42
-      0x542E0003,  //  0354  LDINT	R11	4
-      0x7C200600,  //  0355  CALL	R8	3
-      0x80041000,  //  0356  RET	1	R8
-      0x70020035,  //  0357  JMP		#038E
-      0x5422001C,  //  0358  LDINT	R8	29
-      0x1C200C08,  //  0359  EQ	R8	R6	R8
-      0x78220029,  //  035A  JMPF	R8	#0385
-      0x1C200F0F,  //  035B  EQ	R8	R7	K15
-      0x7822001D,  //  035C  JMPF	R8	#037B
-      0x8C200B11,  //  035D  GETMET	R8	R5	K17
-      0x7C200200,  //  035E  CALL	R8	1
-      0x88240135,  //  035F  GETMBR	R9	R0	K53
-      0x8C241358,  //  0360  GETMET	R9	R9	K88
-      0x502C0200,  //  0361  LDBOOL	R11	1	0
-      0x7C240400,  //  0362  CALL	R9	2
-      0x88280135,  //  0363  GETMBR	R10	R0	K53
-      0x88281559,  //  0364  GETMBR	R10	R10	K89
-      0x602C0010,  //  0365  GETGBL	R11	G16
-      0x5C301200,  //  0366  MOVE	R12	R9
-      0x7C2C0200,  //  0367  CALL	R11	1
-      0xA802000C,  //  0368  EXBLK	0	#0376
-      0x5C301600,  //  0369  MOVE	R12	R11
-      0x7C300000,  //  036A  CALL	R12	0
-      0x5C341400,  //  036B  MOVE	R13	R10
-      0x78360002,  //  036C  JMPF	R13	#0370
-      0x5436FEFF,  //  036D  LDINT	R13	65280
-      0x1434180D,  //  036E  LT	R13	R12	R13
-      0x78360004,  //  036F  JMPF	R13	#0375
-      0x8C34110B,  //  0370  GETMET	R13	R8	K11
-      0x4C3C0000,  //  0371  LDNIL	R15
-      0x88400B0C,  //  0372  GETMBR	R16	R5	K12
-      0x5C441800,  //  0373  MOVE	R17	R12
-      0x7C340800,  //  0374  CALL	R13	4
-      0x7001FFF2,  //  0375  JMP		#0369
-      0x582C003C,  //  0376  LDCONST	R11	K60
-      0xAC2C0200,  //  0377  CATCH	R11	1	0
-      0xB0080000,  //  0378  RAISE	2	R0	R0
-      0x80041000,  //  0379  RET	1	R8
-      0x70020008,  //  037A  JMP		#0384
-      0x60200003,  //  037B  GETGBL	R8	G3
-      0x5C240000,  //  037C  MOVE	R9	R0
-      0x7C200200,  //  037D  CALL	R8	1
-      0x8C20115A,  //  037E  GETMET	R8	R8	K90
-      0x5C280200,  //  037F  MOVE	R10	R1
-      0x5C2C0400,  //  0380  MOVE	R11	R2
-      0x5C300600,  //  0381  MOVE	R12	R3
-      0x7C200800,  //  0382  CALL	R8	4
-      0x80041000,  //  0383  RET	1	R8
-      0x70020008,  //  0384  JMP		#038E
-      0x60200003,  //  0385  GETGBL	R8	G3
-      0x5C240000,  //  0386  MOVE	R9	R0
-      0x7C200200,  //  0387  CALL	R8	1
-      0x8C20115A,  //  0388  GETMET	R8	R8	K90
-      0x5C280200,  //  0389  MOVE	R10	R1
-      0x5C2C0400,  //  038A  MOVE	R11	R2
-      0x5C300600,  //  038B  MOVE	R12	R3
-      0x7C200800,  //  038C  CALL	R8	4
-      0x80041000,  //  038D  RET	1	R8
-      0x80000000,  //  038E  RET	0
+      0x88280B16,  //  032A  GETMBR	R10	R5	K22
+      0xB82E2400,  //  032B  GETNGBL	R11	K18
+      0x8C2C1758,  //  032C  GETMET	R11	R11	K88
+      0x7C2C0200,  //  032D  CALL	R11	1
+      0x7C200600,  //  032E  CALL	R8	3
+      0x80041000,  //  032F  RET	1	R8
+      0x7002000B,  //  0330  JMP		#033D
+      0x1C200F09,  //  0331  EQ	R8	R7	K9
+      0x78220009,  //  0332  JMPF	R8	#033D
+      0x8C200B11,  //  0333  GETMET	R8	R5	K17
+      0x7C200200,  //  0334  CALL	R8	1
+      0x8C24110B,  //  0335  GETMET	R9	R8	K11
+      0x4C2C0000,  //  0336  LDNIL	R11
+      0x88300B16,  //  0337  GETMBR	R12	R5	K22
+      0xB8362400,  //  0338  GETNGBL	R13	K18
+      0x8C341B58,  //  0339  GETMET	R13	R13	K88
+      0x7C340200,  //  033A  CALL	R13	1
+      0x7C240800,  //  033B  CALL	R9	4
+      0x80041000,  //  033C  RET	1	R8
+      0x70020069,  //  033D  JMP		#03A8
+      0x5422002B,  //  033E  LDINT	R8	44
+      0x1C200C08,  //  033F  EQ	R8	R6	R8
+      0x7822001C,  //  0340  JMPF	R8	#035E
+      0x1C200F05,  //  0341  EQ	R8	R7	K5
+      0x78220005,  //  0342  JMPF	R8	#0349
+      0x8C200706,  //  0343  GETMET	R8	R3	K6
+      0x88280B0E,  //  0344  GETMBR	R10	R5	K14
+      0x582C0009,  //  0345  LDCONST	R11	K9
+      0x7C200600,  //  0346  CALL	R8	3
+      0x80041000,  //  0347  RET	1	R8
+      0x70020013,  //  0348  JMP		#035D
+      0x1C200F09,  //  0349  EQ	R8	R7	K9
+      0x78220005,  //  034A  JMPF	R8	#0351
+      0x8C200706,  //  034B  GETMET	R8	R3	K6
+      0x88280B0E,  //  034C  GETMBR	R10	R5	K14
+      0x542E0003,  //  034D  LDINT	R11	4
+      0x7C200600,  //  034E  CALL	R8	3
+      0x80041000,  //  034F  RET	1	R8
+      0x7002000B,  //  0350  JMP		#035D
+      0x1C200F0D,  //  0351  EQ	R8	R7	K13
+      0x78220009,  //  0352  JMPF	R8	#035D
+      0x8C200B11,  //  0353  GETMET	R8	R5	K17
+      0x7C200200,  //  0354  CALL	R8	1
+      0x8C24110B,  //  0355  GETMET	R9	R8	K11
+      0x4C2C0000,  //  0356  LDNIL	R11
+      0x8C300B59,  //  0357  GETMET	R12	R5	K89
+      0x88380B0E,  //  0358  GETMBR	R14	R5	K14
+      0x543E0003,  //  0359  LDINT	R15	4
+      0x7C300600,  //  035A  CALL	R12	3
+      0x7C240600,  //  035B  CALL	R9	3
+      0x80041000,  //  035C  RET	1	R8
+      0x70020049,  //  035D  JMP		#03A8
+      0x54220030,  //  035E  LDINT	R8	49
+      0x1C200C08,  //  035F  EQ	R8	R6	R8
+      0x78220010,  //  0360  JMPF	R8	#0372
+      0x1C200F0F,  //  0361  EQ	R8	R7	K15
+      0x78220005,  //  0362  JMPF	R8	#0369
+      0x8C200706,  //  0363  GETMET	R8	R3	K6
+      0x88280B0E,  //  0364  GETMBR	R10	R5	K14
+      0x542E001D,  //  0365  LDINT	R11	30
+      0x7C200600,  //  0366  CALL	R8	3
+      0x80041000,  //  0367  RET	1	R8
+      0x70020007,  //  0368  JMP		#0371
+      0x5422FFFB,  //  0369  LDINT	R8	65532
+      0x1C200E08,  //  036A  EQ	R8	R7	R8
+      0x78220004,  //  036B  JMPF	R8	#0371
+      0x8C200706,  //  036C  GETMET	R8	R3	K6
+      0x88280B2A,  //  036D  GETMBR	R10	R5	K42
+      0x542E0003,  //  036E  LDINT	R11	4
+      0x7C200600,  //  036F  CALL	R8	3
+      0x80041000,  //  0370  RET	1	R8
+      0x70020035,  //  0371  JMP		#03A8
+      0x5422001C,  //  0372  LDINT	R8	29
+      0x1C200C08,  //  0373  EQ	R8	R6	R8
+      0x78220029,  //  0374  JMPF	R8	#039F
+      0x1C200F0F,  //  0375  EQ	R8	R7	K15
+      0x7822001D,  //  0376  JMPF	R8	#0395
+      0x8C200B11,  //  0377  GETMET	R8	R5	K17
+      0x7C200200,  //  0378  CALL	R8	1
+      0x88240137,  //  0379  GETMBR	R9	R0	K55
+      0x8C24135A,  //  037A  GETMET	R9	R9	K90
+      0x502C0200,  //  037B  LDBOOL	R11	1	0
+      0x7C240400,  //  037C  CALL	R9	2
+      0x88280137,  //  037D  GETMBR	R10	R0	K55
+      0x8828155B,  //  037E  GETMBR	R10	R10	K91
+      0x602C0010,  //  037F  GETGBL	R11	G16
+      0x5C301200,  //  0380  MOVE	R12	R9
+      0x7C2C0200,  //  0381  CALL	R11	1
+      0xA802000C,  //  0382  EXBLK	0	#0390
+      0x5C301600,  //  0383  MOVE	R12	R11
+      0x7C300000,  //  0384  CALL	R12	0
+      0x5C341400,  //  0385  MOVE	R13	R10
+      0x78360002,  //  0386  JMPF	R13	#038A
+      0x5436FEFF,  //  0387  LDINT	R13	65280
+      0x1434180D,  //  0388  LT	R13	R12	R13
+      0x78360004,  //  0389  JMPF	R13	#038F
+      0x8C34110B,  //  038A  GETMET	R13	R8	K11
+      0x4C3C0000,  //  038B  LDNIL	R15
+      0x88400B0C,  //  038C  GETMBR	R16	R5	K12
+      0x5C441800,  //  038D  MOVE	R17	R12
+      0x7C340800,  //  038E  CALL	R13	4
+      0x7001FFF2,  //  038F  JMP		#0383
+      0x582C003E,  //  0390  LDCONST	R11	K62
+      0xAC2C0200,  //  0391  CATCH	R11	1	0
+      0xB0080000,  //  0392  RAISE	2	R0	R0
+      0x80041000,  //  0393  RET	1	R8
+      0x70020008,  //  0394  JMP		#039E
+      0x60200003,  //  0395  GETGBL	R8	G3
+      0x5C240000,  //  0396  MOVE	R9	R0
+      0x7C200200,  //  0397  CALL	R8	1
+      0x8C20115C,  //  0398  GETMET	R8	R8	K92
+      0x5C280200,  //  0399  MOVE	R10	R1
+      0x5C2C0400,  //  039A  MOVE	R11	R2
+      0x5C300600,  //  039B  MOVE	R12	R3
+      0x7C200800,  //  039C  CALL	R8	4
+      0x80041000,  //  039D  RET	1	R8
+      0x70020008,  //  039E  JMP		#03A8
+      0x60200003,  //  039F  GETGBL	R8	G3
+      0x5C240000,  //  03A0  MOVE	R9	R0
+      0x7C200200,  //  03A1  CALL	R8	1
+      0x8C20115C,  //  03A2  GETMET	R8	R8	K92
+      0x5C280200,  //  03A3  MOVE	R10	R1
+      0x5C2C0400,  //  03A4  MOVE	R11	R2
+      0x5C300600,  //  03A5  MOVE	R12	R3
+      0x7C200800,  //  03A6  CALL	R8	4
+      0x80041000,  //  03A7  RET	1	R8
+      0x80000000,  //  03A8  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
@@ -7,11 +7,11 @@
 extern const bclass be_class_Matter_Session;
 
 /********************************************************************
-** Solidified function: before_remove
+** Solidified function: close
 ********************************************************************/
-be_local_closure(Matter_Session_before_remove,   /* name */
+be_local_closure(Matter_Session_close,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    8,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,25 +19,93 @@ be_local_closure(Matter_Session_before_remove,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2DSession_X20_X20_X20_X28_X256i_X29_X20_X28removed_X29),
-    /* K3   */  be_nested_str_weak(local_session_id),
-    /* K4   */  be_const_int(3),
+    ( &(const bvalue[23]) {     /* constants */
+    /* K0   */  be_nested_str_weak(local_session_id),
+    /* K1   */  be_nested_str_weak(__future_local_session_id),
+    /* K2   */  be_nested_str_weak(initiator_session_id),
+    /* K3   */  be_nested_str_weak(__future_initiator_session_id),
+    /* K4   */  be_nested_str_weak(_counter_rcv_impl),
+    /* K5   */  be_nested_str_weak(reset),
+    /* K6   */  be_nested_str_weak(_counter_snd_impl),
+    /* K7   */  be_nested_str_weak(counter_rcv),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(counter_snd),
+    /* K10  */  be_nested_str_weak(next),
+    /* K11  */  be_nested_str_weak(i2rkey),
+    /* K12  */  be_nested_str_weak(_i2r_privacy),
+    /* K13  */  be_nested_str_weak(r2ikey),
+    /* K14  */  be_nested_str_weak(attestation_challenge),
+    /* K15  */  be_nested_str_weak(introspect),
+    /* K16  */  be_nested_str_weak(members),
+    /* K17  */  be_nested_str_weak(get),
+    /* K18  */  be_nested_str_weak(function),
+    /* K19  */  be_nested_str_weak(instance),
+    /* K20  */  be_nested_str_weak(_),
+    /* K21  */  be_const_int(1),
+    /* K22  */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(before_remove),
+    be_str_weak(close),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x600C0018,  //  0002  GETGBL	R3	G24
-      0x58100002,  //  0003  LDCONST	R4	K2
-      0x88140103,  //  0004  GETMBR	R5	R0	K3
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x58100004,  //  0006  LDCONST	R4	K4
-      0x7C040600,  //  0007  CALL	R1	3
-      0x80000000,  //  0008  RET	0
+    ( &(const binstruction[59]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x88040103,  //  0002  GETMBR	R1	R0	K3
+      0x90020401,  //  0003  SETMBR	R0	K2	R1
+      0x88040104,  //  0004  GETMBR	R1	R0	K4
+      0x8C040305,  //  0005  GETMET	R1	R1	K5
+      0x7C040200,  //  0006  CALL	R1	1
+      0x88040106,  //  0007  GETMBR	R1	R0	K6
+      0x8C040305,  //  0008  GETMET	R1	R1	K5
+      0x7C040200,  //  0009  CALL	R1	1
+      0x90020F08,  //  000A  SETMBR	R0	K7	K8
+      0x88040106,  //  000B  GETMBR	R1	R0	K6
+      0x8C04030A,  //  000C  GETMET	R1	R1	K10
+      0x7C040200,  //  000D  CALL	R1	1
+      0x90021201,  //  000E  SETMBR	R0	K9	R1
+      0x4C040000,  //  000F  LDNIL	R1
+      0x90021601,  //  0010  SETMBR	R0	K11	R1
+      0x4C040000,  //  0011  LDNIL	R1
+      0x90021801,  //  0012  SETMBR	R0	K12	R1
+      0x4C040000,  //  0013  LDNIL	R1
+      0x90021A01,  //  0014  SETMBR	R0	K13	R1
+      0x4C040000,  //  0015  LDNIL	R1
+      0x90021C01,  //  0016  SETMBR	R0	K14	R1
+      0xA4061E00,  //  0017  IMPORT	R1	K15
+      0x60080010,  //  0018  GETGBL	R2	G16
+      0x8C0C0310,  //  0019  GETMET	R3	R1	K16
+      0x5C140000,  //  001A  MOVE	R5	R0
+      0x7C0C0400,  //  001B  CALL	R3	2
+      0x7C080200,  //  001C  CALL	R2	1
+      0xA8020018,  //  001D  EXBLK	0	#0037
+      0x5C0C0400,  //  001E  MOVE	R3	R2
+      0x7C0C0000,  //  001F  CALL	R3	0
+      0x8C100311,  //  0020  GETMET	R4	R1	K17
+      0x5C180000,  //  0021  MOVE	R6	R0
+      0x5C1C0600,  //  0022  MOVE	R7	R3
+      0x7C100600,  //  0023  CALL	R4	3
+      0x60140004,  //  0024  GETGBL	R5	G4
+      0x5C180800,  //  0025  MOVE	R6	R4
+      0x7C140200,  //  0026  CALL	R5	1
+      0x20140B12,  //  0027  NE	R5	R5	K18
+      0x7816000C,  //  0028  JMPF	R5	#0036
+      0x60140004,  //  0029  GETGBL	R5	G4
+      0x5C180800,  //  002A  MOVE	R6	R4
+      0x7C140200,  //  002B  CALL	R5	1
+      0x20140B13,  //  002C  NE	R5	R5	K19
+      0x78160007,  //  002D  JMPF	R5	#0036
+      0x94140708,  //  002E  GETIDX	R5	R3	K8
+      0x1C140B14,  //  002F  EQ	R5	R5	K20
+      0x78160004,  //  0030  JMPF	R5	#0036
+      0x94140715,  //  0031  GETIDX	R5	R3	K21
+      0x1C140B14,  //  0032  EQ	R5	R5	K20
+      0x78160001,  //  0033  JMPF	R5	#0036
+      0x4C140000,  //  0034  LDNIL	R5
+      0x90000605,  //  0035  SETMBR	R0	R3	R5
+      0x7001FFE6,  //  0036  JMP		#001E
+      0x58080016,  //  0037  LDCONST	R2	K22
+      0xAC080200,  //  0038  CATCH	R2	1	0
+      0xB0080000,  //  0039  RAISE	2	R0	R0
+      0x80000000,  //  003A  RET	0
     })
   )
 );
@@ -45,11 +113,11 @@ be_local_closure(Matter_Session_before_remove,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_pk
+** Solidified function: update
 ********************************************************************/
-be_local_closure(Matter_Session_get_pk,   /* name */
+be_local_closure(Matter_Session_update,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
+    3,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -57,33 +125,46 @@ be_local_closure(Matter_Session_get_pk,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(get_pk),
-    /* K2   */  be_nested_str_weak(_temp_pk),
-    /* K3   */  be_nested_str_weak(crypto),
-    /* K4   */  be_nested_str_weak(random),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(last_used),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(rtc_utc),
     }),
-    be_str_weak(get_pk),
+    be_str_weak(update),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
+    ( &(const binstruction[ 5]) {  /* code */
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x8C040302,  //  0001  GETMET	R1	R1	K2
+      0x7C040200,  //  0002  CALL	R1	1
+      0x90020001,  //  0003  SETMBR	R0	K0	R1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ac
+********************************************************************/
+be_local_closure(Matter_Session_get_ac,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(attestation_challenge),
+    }),
+    be_str_weak(get_ac),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060004,  //  0001  JMPF	R1	#0007
-      0x88040100,  //  0002  GETMBR	R1	R0	K0
-      0x8C040301,  //  0003  GETMET	R1	R1	K1
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80040200,  //  0005  RET	1	R1
-      0x70020008,  //  0006  JMP		#0010
-      0x88040102,  //  0007  GETMBR	R1	R0	K2
-      0x74060004,  //  0008  JMPT	R1	#000E
-      0xA4060600,  //  0009  IMPORT	R1	K3
-      0x8C080304,  //  000A  GETMET	R2	R1	K4
-      0x5412001F,  //  000B  LDINT	R4	32
-      0x7C080400,  //  000C  CALL	R2	2
-      0x90020402,  //  000D  SETMBR	R0	K2	R2
-      0x88040102,  //  000E  GETMBR	R1	R0	K2
-      0x80040200,  //  000F  RET	1	R1
-      0x80000000,  //  0010  RET	0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -91,11 +172,11 @@ be_local_closure(Matter_Session_get_pk,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_mode_CASE
+** Solidified function: get_fabric
 ********************************************************************/
-be_local_closure(Matter_Session_set_mode_CASE,   /* name */
+be_local_closure(Matter_Session_get_fabric,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    2,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -103,17 +184,14 @@ be_local_closure(Matter_Session_set_mode_CASE,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_mode),
-    /* K1   */  be_nested_str_weak(_CASE),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
     }),
-    be_str_weak(set_mode_CASE),
+    be_str_weak(get_fabric),
     &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80000000,  //  0003  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -150,50 +228,9 @@ be_local_closure(Matter_Session_get_noc,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_temp_ca_pub
+** Solidified function: get_device_id
 ********************************************************************/
-be_local_closure(Matter_Session_get_temp_ca_pub,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_temp_root_ca_certificate),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(parse),
-    /* K4   */  be_nested_str_weak(findsubval),
-    }),
-    be_str_weak(get_temp_ca_pub),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060008,  //  0001  JMPF	R1	#000B
-      0xB80A0200,  //  0002  GETNGBL	R2	K1
-      0x88080502,  //  0003  GETMBR	R2	R2	K2
-      0x8C080503,  //  0004  GETMET	R2	R2	K3
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x7C080400,  //  0006  CALL	R2	2
-      0x8C0C0504,  //  0007  GETMET	R3	R2	K4
-      0x54160008,  //  0008  LDINT	R5	9
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x80040600,  //  000A  RET	1	R3
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric_compressed
-********************************************************************/
-be_local_closure(Matter_Session_get_fabric_compressed,   /* name */
+be_local_closure(Matter_Session_get_device_id,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -205,14 +242,18 @@ be_local_closure(Matter_Session_get_fabric_compressed,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_compressed),
+    /* K1   */  be_nested_str_weak(device_id),
     }),
-    be_str_weak(get_fabric_compressed),
+    be_str_weak(get_device_id),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
+    ( &(const binstruction[ 7]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
+      0x78060002,  //  0001  JMPF	R1	#0005
+      0x88040100,  //  0002  GETMBR	R1	R0	K0
+      0x88040301,  //  0003  GETMBR	R1	R1	K1
+      0x70020000,  //  0004  JMP		#0006
+      0x4C040000,  //  0005  LDNIL	R1
+      0x80040200,  //  0006  RET	1	R1
     })
   )
 );
@@ -220,28 +261,34 @@ be_local_closure(Matter_Session_get_fabric_compressed,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_fabric_label
+** Solidified function: set_fabric_label
 ********************************************************************/
-be_local_closure(Matter_Session_get_fabric_label,   /* name */
+be_local_closure(Matter_Session_set_fabric_label,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
+    4,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_label),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(_fabric),
+    /* K2   */  be_nested_str_weak(fabric_label),
     }),
-    be_str_weak(get_fabric_label),
+    be_str_weak(set_fabric_label),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
+    ( &(const binstruction[ 8]) {  /* code */
+      0x60080004,  //  0000  GETGBL	R2	G4
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x1C080500,  //  0003  EQ	R2	R2	K0
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x88080101,  //  0005  GETMBR	R2	R0	K1
+      0x900A0401,  //  0006  SETMBR	R2	K2	R1
+      0x80000000,  //  0007  RET	0
     })
   )
 );
@@ -278,93 +325,6 @@ be_local_closure(Matter_Session_set_keys,   /* name */
       0x90020603,  //  0004  SETMBR	R0	K3	R3
       0x90020804,  //  0005  SETMBR	R0	K4	R4
       0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_mode_PASE
-********************************************************************/
-be_local_closure(Matter_Session_set_mode_PASE,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_mode),
-    /* K1   */  be_nested_str_weak(_PASE),
-    }),
-    be_str_weak(set_mode_PASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_CASE
-********************************************************************/
-be_local_closure(Matter_Session_is_CASE,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mode),
-    /* K1   */  be_nested_str_weak(_CASE),
-    }),
-    be_str_weak(is_CASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_mode
-********************************************************************/
-be_local_closure(Matter_Session_get_mode,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mode),
-    }),
-    be_str_weak(get_mode),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -540,651 +500,6 @@ be_local_closure(Matter_Session_tojson,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_i2r
-********************************************************************/
-be_local_closure(Matter_Session_get_i2r,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(i2rkey),
-    }),
-    be_str_weak(get_i2r),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_PASE
-********************************************************************/
-be_local_closure(Matter_Session_is_PASE,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mode),
-    /* K1   */  be_nested_str_weak(_PASE),
-    }),
-    be_str_weak(is_PASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: gen_CSR
-********************************************************************/
-be_local_closure(Matter_Session_gen_CSR,   /* name */
-  be_nested_proto(
-    15,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_pk),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(EC_P256),
-    /* K3   */  be_nested_str_weak(public_key),
-    /* K4   */  be_nested_str_weak(3070020100300E310C300A060355040A0C034353523059301306072A8648CE3D020106082A8648CE3D030107034200),
-    /* K5   */  be_nested_str_weak(A000),
-    /* K6   */  be_nested_str_weak(300C06082A8648CE3D0403020500),
-    /* K7   */  be_nested_str_weak(ecdsa_sign_sha256_asn1),
-    /* K8   */  be_nested_str_weak(add),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(0),
-    }),
-    be_str_weak(gen_CSR),
-    &be_const_str_solidified,
-    ( &(const binstruction[73]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0xA40A0200,  //  0002  IMPORT	R2	K1
-      0x8C0C0502,  //  0003  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x8C100703,  //  0005  GETMET	R4	R3	K3
-      0x5C180200,  //  0006  MOVE	R6	R1
-      0x7C100400,  //  0007  CALL	R4	2
-      0x60140015,  //  0008  GETGBL	R5	G21
-      0x58180004,  //  0009  LDCONST	R6	K4
-      0x7C140200,  //  000A  CALL	R5	1
-      0x40180A04,  //  000B  CONNECT	R6	R5	R4
-      0x60180015,  //  000C  GETGBL	R6	G21
-      0x581C0005,  //  000D  LDCONST	R7	K5
-      0x7C180200,  //  000E  CALL	R6	1
-      0x40180A06,  //  000F  CONNECT	R6	R5	R6
-      0x60180015,  //  0010  GETGBL	R6	G21
-      0x581C0006,  //  0011  LDCONST	R7	K6
-      0x7C180200,  //  0012  CALL	R6	1
-      0x8C1C0707,  //  0013  GETMET	R7	R3	K7
-      0x5C240200,  //  0014  MOVE	R9	R1
-      0x5C280A00,  //  0015  MOVE	R10	R5
-      0x7C1C0600,  //  0016  CALL	R7	3
-      0x60200015,  //  0017  GETGBL	R8	G21
-      0x5426007F,  //  0018  LDINT	R9	128
-      0x7C200200,  //  0019  CALL	R8	1
-      0x8C241108,  //  001A  GETMET	R9	R8	K8
-      0x582C0009,  //  001B  LDCONST	R11	K9
-      0x5830000A,  //  001C  LDCONST	R12	K10
-      0x7C240600,  //  001D  CALL	R9	3
-      0x8C241108,  //  001E  GETMET	R9	R8	K8
-      0x602C000C,  //  001F  GETGBL	R11	G12
-      0x5C300E00,  //  0020  MOVE	R12	R7
-      0x7C2C0200,  //  0021  CALL	R11	1
-      0x002C170A,  //  0022  ADD	R11	R11	K10
-      0x5830000A,  //  0023  LDCONST	R12	K10
-      0x7C240600,  //  0024  CALL	R9	3
-      0x8C241108,  //  0025  GETMET	R9	R8	K8
-      0x582C000B,  //  0026  LDCONST	R11	K11
-      0x5830000A,  //  0027  LDCONST	R12	K10
-      0x7C240600,  //  0028  CALL	R9	3
-      0x40241007,  //  0029  CONNECT	R9	R8	R7
-      0x6024000C,  //  002A  GETGBL	R9	G12
-      0x5C280A00,  //  002B  MOVE	R10	R5
-      0x7C240200,  //  002C  CALL	R9	1
-      0x6028000C,  //  002D  GETGBL	R10	G12
-      0x5C2C0C00,  //  002E  MOVE	R11	R6
-      0x7C280200,  //  002F  CALL	R10	1
-      0x0024120A,  //  0030  ADD	R9	R9	R10
-      0x6028000C,  //  0031  GETGBL	R10	G12
-      0x5C2C1000,  //  0032  MOVE	R11	R8
-      0x7C280200,  //  0033  CALL	R10	1
-      0x0024120A,  //  0034  ADD	R9	R9	R10
-      0x60280015,  //  0035  GETGBL	R10	G21
-      0x542E00CF,  //  0036  LDINT	R11	208
-      0x7C280200,  //  0037  CALL	R10	1
-      0x8C2C1508,  //  0038  GETMET	R11	R10	K8
-      0x5436002F,  //  0039  LDINT	R13	48
-      0x5838000A,  //  003A  LDCONST	R14	K10
-      0x7C2C0600,  //  003B  CALL	R11	3
-      0x8C2C1508,  //  003C  GETMET	R11	R10	K8
-      0x54360080,  //  003D  LDINT	R13	129
-      0x5838000A,  //  003E  LDCONST	R14	K10
-      0x7C2C0600,  //  003F  CALL	R11	3
-      0x8C2C1508,  //  0040  GETMET	R11	R10	K8
-      0x543600FE,  //  0041  LDINT	R13	255
-      0x2C34120D,  //  0042  AND	R13	R9	R13
-      0x5838000A,  //  0043  LDCONST	R14	K10
-      0x7C2C0600,  //  0044  CALL	R11	3
-      0x402C1405,  //  0045  CONNECT	R11	R10	R5
-      0x402C1406,  //  0046  CONNECT	R11	R10	R6
-      0x402C1408,  //  0047  CONNECT	R11	R10	R8
-      0x80041400,  //  0048  RET	1	R10
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_temp_ca
-********************************************************************/
-be_local_closure(Matter_Session_get_temp_ca,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_temp_root_ca_certificate),
-    }),
-    be_str_weak(get_temp_ca),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: close
-********************************************************************/
-be_local_closure(Matter_Session_close,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_nested_str_weak(local_session_id),
-    /* K1   */  be_nested_str_weak(__future_local_session_id),
-    /* K2   */  be_nested_str_weak(initiator_session_id),
-    /* K3   */  be_nested_str_weak(__future_initiator_session_id),
-    /* K4   */  be_nested_str_weak(_counter_rcv_impl),
-    /* K5   */  be_nested_str_weak(reset),
-    /* K6   */  be_nested_str_weak(_counter_snd_impl),
-    /* K7   */  be_nested_str_weak(counter_rcv),
-    /* K8   */  be_const_int(0),
-    /* K9   */  be_nested_str_weak(counter_snd),
-    /* K10  */  be_nested_str_weak(next),
-    /* K11  */  be_nested_str_weak(i2rkey),
-    /* K12  */  be_nested_str_weak(_i2r_privacy),
-    /* K13  */  be_nested_str_weak(r2ikey),
-    /* K14  */  be_nested_str_weak(attestation_challenge),
-    /* K15  */  be_nested_str_weak(introspect),
-    /* K16  */  be_nested_str_weak(members),
-    /* K17  */  be_nested_str_weak(get),
-    /* K18  */  be_nested_str_weak(function),
-    /* K19  */  be_nested_str_weak(instance),
-    /* K20  */  be_nested_str_weak(_),
-    /* K21  */  be_const_int(1),
-    /* K22  */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(close),
-    &be_const_str_solidified,
-    ( &(const binstruction[59]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x88040103,  //  0002  GETMBR	R1	R0	K3
-      0x90020401,  //  0003  SETMBR	R0	K2	R1
-      0x88040104,  //  0004  GETMBR	R1	R0	K4
-      0x8C040305,  //  0005  GETMET	R1	R1	K5
-      0x7C040200,  //  0006  CALL	R1	1
-      0x88040106,  //  0007  GETMBR	R1	R0	K6
-      0x8C040305,  //  0008  GETMET	R1	R1	K5
-      0x7C040200,  //  0009  CALL	R1	1
-      0x90020F08,  //  000A  SETMBR	R0	K7	K8
-      0x88040106,  //  000B  GETMBR	R1	R0	K6
-      0x8C04030A,  //  000C  GETMET	R1	R1	K10
-      0x7C040200,  //  000D  CALL	R1	1
-      0x90021201,  //  000E  SETMBR	R0	K9	R1
-      0x4C040000,  //  000F  LDNIL	R1
-      0x90021601,  //  0010  SETMBR	R0	K11	R1
-      0x4C040000,  //  0011  LDNIL	R1
-      0x90021801,  //  0012  SETMBR	R0	K12	R1
-      0x4C040000,  //  0013  LDNIL	R1
-      0x90021A01,  //  0014  SETMBR	R0	K13	R1
-      0x4C040000,  //  0015  LDNIL	R1
-      0x90021C01,  //  0016  SETMBR	R0	K14	R1
-      0xA4061E00,  //  0017  IMPORT	R1	K15
-      0x60080010,  //  0018  GETGBL	R2	G16
-      0x8C0C0310,  //  0019  GETMET	R3	R1	K16
-      0x5C140000,  //  001A  MOVE	R5	R0
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x7C080200,  //  001C  CALL	R2	1
-      0xA8020018,  //  001D  EXBLK	0	#0037
-      0x5C0C0400,  //  001E  MOVE	R3	R2
-      0x7C0C0000,  //  001F  CALL	R3	0
-      0x8C100311,  //  0020  GETMET	R4	R1	K17
-      0x5C180000,  //  0021  MOVE	R6	R0
-      0x5C1C0600,  //  0022  MOVE	R7	R3
-      0x7C100600,  //  0023  CALL	R4	3
-      0x60140004,  //  0024  GETGBL	R5	G4
-      0x5C180800,  //  0025  MOVE	R6	R4
-      0x7C140200,  //  0026  CALL	R5	1
-      0x20140B12,  //  0027  NE	R5	R5	K18
-      0x7816000C,  //  0028  JMPF	R5	#0036
-      0x60140004,  //  0029  GETGBL	R5	G4
-      0x5C180800,  //  002A  MOVE	R6	R4
-      0x7C140200,  //  002B  CALL	R5	1
-      0x20140B13,  //  002C  NE	R5	R5	K19
-      0x78160007,  //  002D  JMPF	R5	#0036
-      0x94140708,  //  002E  GETIDX	R5	R3	K8
-      0x1C140B14,  //  002F  EQ	R5	R5	K20
-      0x78160004,  //  0030  JMPF	R5	#0036
-      0x94140715,  //  0031  GETIDX	R5	R3	K21
-      0x1C140B14,  //  0032  EQ	R5	R5	K20
-      0x78160001,  //  0033  JMPF	R5	#0036
-      0x4C140000,  //  0034  LDNIL	R5
-      0x90000605,  //  0035  SETMBR	R0	R3	R5
-      0x7001FFE6,  //  0036  JMP		#001E
-      0x58080016,  //  0037  LDCONST	R2	K22
-      0xAC080200,  //  0038  CATCH	R2	1	0
-      0xB0080000,  //  0039  RAISE	2	R0	R0
-      0x80000000,  //  003A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update
-********************************************************************/
-be_local_closure(Matter_Session_update,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(last_used),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(rtc_utc),
-    }),
-    be_str_weak(update),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x8C040302,  //  0001  GETMET	R1	R1	K2
-      0x7C040200,  //  0002  CALL	R1	1
-      0x90020001,  //  0003  SETMBR	R0	K0	R1
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_admin_vendor
-********************************************************************/
-be_local_closure(Matter_Session_get_admin_vendor,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(admin_vendor),
-    }),
-    be_str_weak(get_admin_vendor),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric
-********************************************************************/
-be_local_closure(Matter_Session_get_fabric,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    }),
-    be_str_weak(get_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_admin_subject
-********************************************************************/
-be_local_closure(Matter_Session_get_admin_subject,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(admin_subject),
-    }),
-    be_str_weak(get_admin_subject),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ipk_group_key
-********************************************************************/
-be_local_closure(Matter_Session_get_ipk_group_key,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(get_ipk_group_key),
-    }),
-    be_str_weak(get_ipk_group_key),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Session_init,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(_store),
-    /* K2   */  be_nested_str_weak(mode),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(local_session_id),
-    /* K5   */  be_nested_str_weak(initiator_session_id),
-    /* K6   */  be_nested_str_weak(_counter_snd_impl),
-    /* K7   */  be_nested_str_weak(matter),
-    /* K8   */  be_nested_str_weak(Counter),
-    /* K9   */  be_nested_str_weak(_counter_rcv_impl),
-    /* K10  */  be_nested_str_weak(counter_rcv),
-    /* K11  */  be_nested_str_weak(counter_snd),
-    /* K12  */  be_nested_str_weak(next),
-    /* K13  */  be_nested_str_weak(_COUNTER_SND_INCR),
-    /* K14  */  be_nested_str_weak(_counter_insecure_rcv),
-    /* K15  */  be_nested_str_weak(_counter_insecure_snd),
-    /* K16  */  be_nested_str_weak(_breadcrumb),
-    /* K17  */  be_nested_str_weak(_exchange_id),
-    /* K18  */  be_nested_str_weak(random),
-    /* K19  */  be_const_int(2),
-    /* K20  */  be_nested_str_weak(get),
-    /* K21  */  be_nested_str_weak(_fabric),
-    /* K22  */  be_nested_str_weak(update),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
-      0xA4160000,  //  0000  IMPORT	R5	K0
-      0x90020201,  //  0001  SETMBR	R0	K1	R1
-      0x90020503,  //  0002  SETMBR	R0	K2	K3
-      0x90020802,  //  0003  SETMBR	R0	K4	R2
-      0x90020A03,  //  0004  SETMBR	R0	K5	R3
-      0xB81A0E00,  //  0005  GETNGBL	R6	K7
-      0x8C180D08,  //  0006  GETMET	R6	R6	K8
-      0x7C180200,  //  0007  CALL	R6	1
-      0x90020C06,  //  0008  SETMBR	R0	K6	R6
-      0xB81A0E00,  //  0009  GETNGBL	R6	K7
-      0x8C180D08,  //  000A  GETMET	R6	R6	K8
-      0x7C180200,  //  000B  CALL	R6	1
-      0x90021206,  //  000C  SETMBR	R0	K9	R6
-      0x90021503,  //  000D  SETMBR	R0	K10	K3
-      0x88180106,  //  000E  GETMBR	R6	R0	K6
-      0x8C180D0C,  //  000F  GETMET	R6	R6	K12
-      0x7C180200,  //  0010  CALL	R6	1
-      0x881C010D,  //  0011  GETMBR	R7	R0	K13
-      0x00180C07,  //  0012  ADD	R6	R6	R7
-      0x90021606,  //  0013  SETMBR	R0	K11	R6
-      0xB81A0E00,  //  0014  GETNGBL	R6	K7
-      0x8C180D08,  //  0015  GETMET	R6	R6	K8
-      0x7C180200,  //  0016  CALL	R6	1
-      0x90021C06,  //  0017  SETMBR	R0	K14	R6
-      0xB81A0E00,  //  0018  GETNGBL	R6	K7
-      0x8C180D08,  //  0019  GETMET	R6	R6	K8
-      0x7C180200,  //  001A  CALL	R6	1
-      0x90021E06,  //  001B  SETMBR	R0	K15	R6
-      0x90022103,  //  001C  SETMBR	R0	K16	K3
-      0x8C180B12,  //  001D  GETMET	R6	R5	K18
-      0x58200013,  //  001E  LDCONST	R8	K19
-      0x7C180400,  //  001F  CALL	R6	2
-      0x8C180D14,  //  0020  GETMET	R6	R6	K20
-      0x58200003,  //  0021  LDCONST	R8	K3
-      0x58240013,  //  0022  LDCONST	R9	K19
-      0x7C180600,  //  0023  CALL	R6	3
-      0x90022206,  //  0024  SETMBR	R0	K17	R6
-      0x90022A04,  //  0025  SETMBR	R0	K21	R4
-      0x8C180116,  //  0026  GETMET	R6	R0	K22
-      0x7C180200,  //  0027  CALL	R6	1
-      0x80000000,  //  0028  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_device_id
-********************************************************************/
-be_local_closure(Matter_Session_get_device_id,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(device_id),
-    }),
-    be_str_weak(get_device_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_fabric_label
-********************************************************************/
-be_local_closure(Matter_Session_set_fabric_label,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(_fabric),
-    /* K2   */  be_nested_str_weak(fabric_label),
-    }),
-    be_str_weak(set_fabric_label),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x60080004,  //  0000  GETGBL	R2	G4
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x1C080500,  //  0003  EQ	R2	R2	K0
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x88080101,  //  0005  GETMBR	R2	R0	K1
-      0x900A0401,  //  0006  SETMBR	R2	K2	R1
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: hydrate_post
-********************************************************************/
-be_local_closure(Matter_Session_hydrate_post,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_counter_snd_impl),
-    /* K1   */  be_nested_str_weak(reset),
-    /* K2   */  be_nested_str_weak(counter_snd),
-    /* K3   */  be_nested_str_weak(_counter_rcv_impl),
-    /* K4   */  be_nested_str_weak(counter_rcv),
-    /* K5   */  be_nested_str_weak(val),
-    }),
-    be_str_weak(hydrate_post),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x7C040400,  //  0003  CALL	R1	2
-      0x88040103,  //  0004  GETMBR	R1	R0	K3
-      0x8C040301,  //  0005  GETMET	R1	R1	K1
-      0x880C0104,  //  0006  GETMBR	R3	R0	K4
-      0x7C040400,  //  0007  CALL	R1	2
-      0x88040100,  //  0008  GETMBR	R1	R0	K0
-      0x8C040305,  //  0009  GETMET	R1	R1	K5
-      0x7C040200,  //  000A  CALL	R1	1
-      0x90020401,  //  000B  SETMBR	R0	K2	R1
-      0x88040103,  //  000C  GETMBR	R1	R0	K3
-      0x8C040305,  //  000D  GETMET	R1	R1	K5
-      0x7C040200,  //  000E  CALL	R1	1
-      0x90020801,  //  000F  SETMBR	R0	K4	R1
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: fromjson
 ********************************************************************/
 be_local_closure(Matter_Session_fromjson,   /* name */
@@ -1301,6 +616,399 @@ be_local_closure(Matter_Session_fromjson,   /* name */
 
 
 /********************************************************************
+** Solidified function: gen_CSR
+********************************************************************/
+be_local_closure(Matter_Session_gen_CSR,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_pk),
+    /* K1   */  be_nested_str_weak(crypto),
+    /* K2   */  be_nested_str_weak(EC_P256),
+    /* K3   */  be_nested_str_weak(public_key),
+    /* K4   */  be_nested_str_weak(3070020100300E310C300A060355040A0C034353523059301306072A8648CE3D020106082A8648CE3D030107034200),
+    /* K5   */  be_nested_str_weak(A000),
+    /* K6   */  be_nested_str_weak(300C06082A8648CE3D0403020500),
+    /* K7   */  be_nested_str_weak(ecdsa_sign_sha256_asn1),
+    /* K8   */  be_nested_str_weak(add),
+    /* K9   */  be_const_int(3),
+    /* K10  */  be_const_int(1),
+    /* K11  */  be_const_int(0),
+    }),
+    be_str_weak(gen_CSR),
+    &be_const_str_solidified,
+    ( &(const binstruction[73]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0xA40A0200,  //  0002  IMPORT	R2	K1
+      0x8C0C0502,  //  0003  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x8C100703,  //  0005  GETMET	R4	R3	K3
+      0x5C180200,  //  0006  MOVE	R6	R1
+      0x7C100400,  //  0007  CALL	R4	2
+      0x60140015,  //  0008  GETGBL	R5	G21
+      0x58180004,  //  0009  LDCONST	R6	K4
+      0x7C140200,  //  000A  CALL	R5	1
+      0x40180A04,  //  000B  CONNECT	R6	R5	R4
+      0x60180015,  //  000C  GETGBL	R6	G21
+      0x581C0005,  //  000D  LDCONST	R7	K5
+      0x7C180200,  //  000E  CALL	R6	1
+      0x40180A06,  //  000F  CONNECT	R6	R5	R6
+      0x60180015,  //  0010  GETGBL	R6	G21
+      0x581C0006,  //  0011  LDCONST	R7	K6
+      0x7C180200,  //  0012  CALL	R6	1
+      0x8C1C0707,  //  0013  GETMET	R7	R3	K7
+      0x5C240200,  //  0014  MOVE	R9	R1
+      0x5C280A00,  //  0015  MOVE	R10	R5
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x60200015,  //  0017  GETGBL	R8	G21
+      0x5426007F,  //  0018  LDINT	R9	128
+      0x7C200200,  //  0019  CALL	R8	1
+      0x8C241108,  //  001A  GETMET	R9	R8	K8
+      0x582C0009,  //  001B  LDCONST	R11	K9
+      0x5830000A,  //  001C  LDCONST	R12	K10
+      0x7C240600,  //  001D  CALL	R9	3
+      0x8C241108,  //  001E  GETMET	R9	R8	K8
+      0x602C000C,  //  001F  GETGBL	R11	G12
+      0x5C300E00,  //  0020  MOVE	R12	R7
+      0x7C2C0200,  //  0021  CALL	R11	1
+      0x002C170A,  //  0022  ADD	R11	R11	K10
+      0x5830000A,  //  0023  LDCONST	R12	K10
+      0x7C240600,  //  0024  CALL	R9	3
+      0x8C241108,  //  0025  GETMET	R9	R8	K8
+      0x582C000B,  //  0026  LDCONST	R11	K11
+      0x5830000A,  //  0027  LDCONST	R12	K10
+      0x7C240600,  //  0028  CALL	R9	3
+      0x40241007,  //  0029  CONNECT	R9	R8	R7
+      0x6024000C,  //  002A  GETGBL	R9	G12
+      0x5C280A00,  //  002B  MOVE	R10	R5
+      0x7C240200,  //  002C  CALL	R9	1
+      0x6028000C,  //  002D  GETGBL	R10	G12
+      0x5C2C0C00,  //  002E  MOVE	R11	R6
+      0x7C280200,  //  002F  CALL	R10	1
+      0x0024120A,  //  0030  ADD	R9	R9	R10
+      0x6028000C,  //  0031  GETGBL	R10	G12
+      0x5C2C1000,  //  0032  MOVE	R11	R8
+      0x7C280200,  //  0033  CALL	R10	1
+      0x0024120A,  //  0034  ADD	R9	R9	R10
+      0x60280015,  //  0035  GETGBL	R10	G21
+      0x542E00CF,  //  0036  LDINT	R11	208
+      0x7C280200,  //  0037  CALL	R10	1
+      0x8C2C1508,  //  0038  GETMET	R11	R10	K8
+      0x5436002F,  //  0039  LDINT	R13	48
+      0x5838000A,  //  003A  LDCONST	R14	K10
+      0x7C2C0600,  //  003B  CALL	R11	3
+      0x8C2C1508,  //  003C  GETMET	R11	R10	K8
+      0x54360080,  //  003D  LDINT	R13	129
+      0x5838000A,  //  003E  LDCONST	R14	K10
+      0x7C2C0600,  //  003F  CALL	R11	3
+      0x8C2C1508,  //  0040  GETMET	R11	R10	K8
+      0x543600FE,  //  0041  LDINT	R13	255
+      0x2C34120D,  //  0042  AND	R13	R9	R13
+      0x5838000A,  //  0043  LDCONST	R14	K10
+      0x7C2C0600,  //  0044  CALL	R11	3
+      0x402C1405,  //  0045  CONNECT	R11	R10	R5
+      0x402C1406,  //  0046  CONNECT	R11	R10	R6
+      0x402C1408,  //  0047  CONNECT	R11	R10	R8
+      0x80041400,  //  0048  RET	1	R10
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ipk_epoch_key
+********************************************************************/
+be_local_closure(Matter_Session_get_ipk_epoch_key,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(ipk_epoch_key),
+    }),
+    be_str_weak(get_ipk_epoch_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: counter_rcv_validate
+********************************************************************/
+be_local_closure(Matter_Session_counter_rcv_validate,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_counter_rcv_impl),
+    /* K1   */  be_nested_str_weak(validate),
+    /* K2   */  be_nested_str_weak(counter_rcv),
+    /* K3   */  be_nested_str_weak(val),
+    }),
+    be_str_weak(counter_rcv_validate),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x5C180400,  //  0003  MOVE	R6	R2
+      0x7C0C0600,  //  0004  CALL	R3	3
+      0x780E0003,  //  0005  JMPF	R3	#000A
+      0x88100100,  //  0006  GETMBR	R4	R0	K0
+      0x8C100903,  //  0007  GETMET	R4	R4	K3
+      0x7C100200,  //  0008  CALL	R4	1
+      0x90020404,  //  0009  SETMBR	R0	K2	R4
+      0x80040600,  //  000A  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_admin_subject
+********************************************************************/
+be_local_closure(Matter_Session_get_admin_subject,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(admin_subject),
+    }),
+    be_str_weak(get_admin_subject),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_compressed
+********************************************************************/
+be_local_closure(Matter_Session_get_fabric_compressed,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(fabric_compressed),
+    }),
+    be_str_weak(get_fabric_compressed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: persist_to_fabric
+********************************************************************/
+be_local_closure(Matter_Session_persist_to_fabric,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(add_session),
+    }),
+    be_str_weak(persist_to_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ca
+********************************************************************/
+be_local_closure(Matter_Session_get_ca,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(root_ca_certificate),
+    }),
+    be_str_weak(get_ca),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_PASE
+********************************************************************/
+be_local_closure(Matter_Session_is_PASE,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mode),
+    /* K1   */  be_nested_str_weak(_PASE),
+    }),
+    be_str_weak(is_PASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_CASE
+********************************************************************/
+be_local_closure(Matter_Session_is_CASE,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mode),
+    /* K1   */  be_nested_str_weak(_CASE),
+    }),
+    be_str_weak(is_CASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: before_remove
+********************************************************************/
+be_local_closure(Matter_Session_before_remove,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2DSession_X20_X20_X20_X28_X256i_X29_X20_X28removed_X29),
+    /* K3   */  be_nested_str_weak(local_session_id),
+    /* K4   */  be_const_int(3),
+    }),
+    be_str_weak(before_remove),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x600C0018,  //  0002  GETGBL	R3	G24
+      0x58100002,  //  0003  LDCONST	R4	K2
+      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x58100004,  //  0006  LDCONST	R4	K4
+      0x7C040600,  //  0007  CALL	R1	3
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: save
 ********************************************************************/
 be_local_closure(Matter_Session_save,   /* name */
@@ -1360,12 +1068,113 @@ be_local_closure(Matter_Session_get_fabric_id,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_mode
+** Solidified function: get_ipk_group_key
 ********************************************************************/
-be_local_closure(Matter_Session_set_mode,   /* name */
+be_local_closure(Matter_Session_get_ipk_group_key,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(get_ipk_group_key),
+    }),
+    be_str_weak(get_ipk_group_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_temp_ca_pub
+********************************************************************/
+be_local_closure(Matter_Session_get_temp_ca_pub,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_temp_root_ca_certificate),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(parse),
+    /* K4   */  be_nested_str_weak(findsubval),
+    }),
+    be_str_weak(get_temp_ca_pub),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060008,  //  0001  JMPF	R1	#000B
+      0xB80A0200,  //  0002  GETNGBL	R2	K1
+      0x88080502,  //  0003  GETMBR	R2	R2	K2
+      0x8C080503,  //  0004  GETMET	R2	R2	K3
+      0x5C100200,  //  0005  MOVE	R4	R1
+      0x7C080400,  //  0006  CALL	R2	2
+      0x8C0C0504,  //  0007  GETMET	R3	R2	K4
+      0x54160008,  //  0008  LDINT	R5	9
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x80040600,  //  000A  RET	1	R3
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ca_pub
+********************************************************************/
+be_local_closure(Matter_Session_get_ca_pub,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(get_ca_pub),
+    }),
+    be_str_weak(get_ca_pub),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_mode
+********************************************************************/
+be_local_closure(Matter_Session_get_mode,   /* name */
   be_nested_proto(
     2,                          /* nstack */
-    2,                          /* argc */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1375,11 +1184,11 @@ be_local_closure(Matter_Session_set_mode,   /* name */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(mode),
     }),
-    be_str_weak(set_mode),
+    be_str_weak(get_mode),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -1387,26 +1196,186 @@ be_local_closure(Matter_Session_set_mode,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_temp_ca
+** Solidified function: hydrate_post
 ********************************************************************/
-be_local_closure(Matter_Session_set_temp_ca,   /* name */
+be_local_closure(Matter_Session_hydrate_post,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
+    4,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_temp_root_ca_certificate),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_counter_snd_impl),
+    /* K1   */  be_nested_str_weak(reset),
+    /* K2   */  be_nested_str_weak(counter_snd),
+    /* K3   */  be_nested_str_weak(_counter_rcv_impl),
+    /* K4   */  be_nested_str_weak(counter_rcv),
+    /* K5   */  be_nested_str_weak(val),
     }),
-    be_str_weak(set_temp_ca),
+    be_str_weak(hydrate_post),
     &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
+    ( &(const binstruction[17]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x7C040400,  //  0003  CALL	R1	2
+      0x88040103,  //  0004  GETMBR	R1	R0	K3
+      0x8C040301,  //  0005  GETMET	R1	R1	K1
+      0x880C0104,  //  0006  GETMBR	R3	R0	K4
+      0x7C040400,  //  0007  CALL	R1	2
+      0x88040100,  //  0008  GETMBR	R1	R0	K0
+      0x8C040305,  //  0009  GETMET	R1	R1	K5
+      0x7C040200,  //  000A  CALL	R1	1
+      0x90020401,  //  000B  SETMBR	R0	K2	R1
+      0x88040103,  //  000C  GETMBR	R1	R0	K3
+      0x8C040305,  //  000D  GETMET	R1	R1	K5
+      0x7C040200,  //  000E  CALL	R1	1
+      0x90020801,  //  000F  SETMBR	R0	K4	R1
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_label
+********************************************************************/
+be_local_closure(Matter_Session_get_fabric_label,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(fabric_label),
+    }),
+    be_str_weak(get_fabric_label),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_icac
+********************************************************************/
+be_local_closure(Matter_Session_get_icac,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(icac),
+    }),
+    be_str_weak(get_icac),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_mode_CASE
+********************************************************************/
+be_local_closure(Matter_Session_set_mode_CASE,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_mode),
+    /* K1   */  be_nested_str_weak(_CASE),
+    }),
+    be_str_weak(set_mode_CASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: counter_snd_next
+********************************************************************/
+be_local_closure(Matter_Session_counter_snd_next,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_counter_snd_impl),
+    /* K1   */  be_nested_str_weak(next),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(Counter),
+    /* K4   */  be_nested_str_weak(is_greater),
+    /* K5   */  be_nested_str_weak(counter_snd),
+    /* K6   */  be_nested_str_weak(_COUNTER_SND_INCR),
+    /* K7   */  be_nested_str_weak(does_persist),
+    /* K8   */  be_nested_str_weak(save),
+    }),
+    be_str_weak(counter_snd_next),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0xB80A0400,  //  0003  GETNGBL	R2	K2
+      0x88080503,  //  0004  GETMBR	R2	R2	K3
+      0x8C080504,  //  0005  GETMET	R2	R2	K4
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x88140105,  //  0007  GETMBR	R5	R0	K5
+      0x7C080600,  //  0008  CALL	R2	3
+      0x780A0007,  //  0009  JMPF	R2	#0012
+      0x88080106,  //  000A  GETMBR	R2	R0	K6
+      0x00080202,  //  000B  ADD	R2	R1	R2
+      0x90020A02,  //  000C  SETMBR	R0	K5	R2
+      0x8C080107,  //  000D  GETMET	R2	R0	K7
+      0x7C080200,  //  000E  CALL	R2	1
+      0x780A0001,  //  000F  JMPF	R2	#0012
+      0x8C080108,  //  0010  GETMET	R2	R0	K8
+      0x7C080200,  //  0011  CALL	R2	1
+      0x80040200,  //  0012  RET	1	R1
     })
   )
 );
@@ -1467,38 +1436,9 @@ be_local_closure(Matter_Session_get_i2r_privacy,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_ca
+** Solidified function: get_i2r
 ********************************************************************/
-be_local_closure(Matter_Session_get_ca,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(root_ca_certificate),
-    }),
-    be_str_weak(get_ca),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ac
-********************************************************************/
-be_local_closure(Matter_Session_get_ac,   /* name */
+be_local_closure(Matter_Session_get_i2r,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -1509,9 +1449,9 @@ be_local_closure(Matter_Session_get_ac,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attestation_challenge),
+    /* K0   */  be_nested_str_weak(i2rkey),
     }),
-    be_str_weak(get_ac),
+    be_str_weak(get_i2r),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
@@ -1523,100 +1463,9 @@ be_local_closure(Matter_Session_get_ac,   /* name */
 
 
 /********************************************************************
-** Solidified function: counter_snd_next
+** Solidified function: get_admin_vendor
 ********************************************************************/
-be_local_closure(Matter_Session_counter_snd_next,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_counter_snd_impl),
-    /* K1   */  be_nested_str_weak(next),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Counter),
-    /* K4   */  be_nested_str_weak(is_greater),
-    /* K5   */  be_nested_str_weak(counter_snd),
-    /* K6   */  be_nested_str_weak(_COUNTER_SND_INCR),
-    /* K7   */  be_nested_str_weak(does_persist),
-    /* K8   */  be_nested_str_weak(save),
-    }),
-    be_str_weak(counter_snd_next),
-    &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0xB80A0400,  //  0003  GETNGBL	R2	K2
-      0x88080503,  //  0004  GETMBR	R2	R2	K3
-      0x8C080504,  //  0005  GETMET	R2	R2	K4
-      0x5C100200,  //  0006  MOVE	R4	R1
-      0x88140105,  //  0007  GETMBR	R5	R0	K5
-      0x7C080600,  //  0008  CALL	R2	3
-      0x780A0007,  //  0009  JMPF	R2	#0012
-      0x88080106,  //  000A  GETMBR	R2	R0	K6
-      0x00080202,  //  000B  ADD	R2	R1	R2
-      0x90020A02,  //  000C  SETMBR	R0	K5	R2
-      0x8C080107,  //  000D  GETMET	R2	R0	K7
-      0x7C080200,  //  000E  CALL	R2	1
-      0x780A0001,  //  000F  JMPF	R2	#0012
-      0x8C080108,  //  0010  GETMET	R2	R0	K8
-      0x7C080200,  //  0011  CALL	R2	1
-      0x80040200,  //  0012  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: counter_rcv_validate
-********************************************************************/
-be_local_closure(Matter_Session_counter_rcv_validate,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_counter_rcv_impl),
-    /* K1   */  be_nested_str_weak(validate),
-    /* K2   */  be_nested_str_weak(counter_rcv),
-    /* K3   */  be_nested_str_weak(val),
-    }),
-    be_str_weak(counter_rcv_validate),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x5C180400,  //  0003  MOVE	R6	R2
-      0x7C0C0600,  //  0004  CALL	R3	3
-      0x780E0003,  //  0005  JMPF	R3	#000A
-      0x88100100,  //  0006  GETMBR	R4	R0	K0
-      0x8C100903,  //  0007  GETMET	R4	R4	K3
-      0x7C100200,  //  0008  CALL	R4	1
-      0x90020404,  //  0009  SETMBR	R0	K2	R4
-      0x80040600,  //  000A  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_icac
-********************************************************************/
-be_local_closure(Matter_Session_get_icac,   /* name */
+be_local_closure(Matter_Session_get_admin_vendor,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -1628,9 +1477,9 @@ be_local_closure(Matter_Session_get_icac,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(icac),
+    /* K1   */  be_nested_str_weak(admin_vendor),
     }),
-    be_str_weak(get_icac),
+    be_str_weak(get_admin_vendor),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
@@ -1643,29 +1492,26 @@ be_local_closure(Matter_Session_get_icac,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_ca_pub
+** Solidified function: set_temp_ca
 ********************************************************************/
-be_local_closure(Matter_Session_get_ca_pub,   /* name */
+be_local_closure(Matter_Session_set_temp_ca,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
+    2,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(get_ca_pub),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_temp_root_ca_certificate),
     }),
-    be_str_weak(get_ca_pub),
+    be_str_weak(set_temp_ca),
     &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
     })
   )
 );
@@ -1673,9 +1519,97 @@ be_local_closure(Matter_Session_get_ca_pub,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_ipk_epoch_key
+** Solidified function: init
 ********************************************************************/
-be_local_closure(Matter_Session_get_ipk_epoch_key,   /* name */
+be_local_closure(Matter_Session_init,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[23]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(_store),
+    /* K2   */  be_nested_str_weak(mode),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(local_session_id),
+    /* K5   */  be_nested_str_weak(initiator_session_id),
+    /* K6   */  be_nested_str_weak(_counter_snd_impl),
+    /* K7   */  be_nested_str_weak(matter),
+    /* K8   */  be_nested_str_weak(Counter),
+    /* K9   */  be_nested_str_weak(_counter_rcv_impl),
+    /* K10  */  be_nested_str_weak(counter_rcv),
+    /* K11  */  be_nested_str_weak(counter_snd),
+    /* K12  */  be_nested_str_weak(next),
+    /* K13  */  be_nested_str_weak(_COUNTER_SND_INCR),
+    /* K14  */  be_nested_str_weak(_counter_insecure_rcv),
+    /* K15  */  be_nested_str_weak(_counter_insecure_snd),
+    /* K16  */  be_nested_str_weak(_breadcrumb),
+    /* K17  */  be_nested_str_weak(_exchange_id),
+    /* K18  */  be_nested_str_weak(random),
+    /* K19  */  be_const_int(2),
+    /* K20  */  be_nested_str_weak(get),
+    /* K21  */  be_nested_str_weak(_fabric),
+    /* K22  */  be_nested_str_weak(update),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[41]) {  /* code */
+      0xA4160000,  //  0000  IMPORT	R5	K0
+      0x90020201,  //  0001  SETMBR	R0	K1	R1
+      0x90020503,  //  0002  SETMBR	R0	K2	K3
+      0x90020802,  //  0003  SETMBR	R0	K4	R2
+      0x90020A03,  //  0004  SETMBR	R0	K5	R3
+      0xB81A0E00,  //  0005  GETNGBL	R6	K7
+      0x8C180D08,  //  0006  GETMET	R6	R6	K8
+      0x7C180200,  //  0007  CALL	R6	1
+      0x90020C06,  //  0008  SETMBR	R0	K6	R6
+      0xB81A0E00,  //  0009  GETNGBL	R6	K7
+      0x8C180D08,  //  000A  GETMET	R6	R6	K8
+      0x7C180200,  //  000B  CALL	R6	1
+      0x90021206,  //  000C  SETMBR	R0	K9	R6
+      0x90021503,  //  000D  SETMBR	R0	K10	K3
+      0x88180106,  //  000E  GETMBR	R6	R0	K6
+      0x8C180D0C,  //  000F  GETMET	R6	R6	K12
+      0x7C180200,  //  0010  CALL	R6	1
+      0x881C010D,  //  0011  GETMBR	R7	R0	K13
+      0x00180C07,  //  0012  ADD	R6	R6	R7
+      0x90021606,  //  0013  SETMBR	R0	K11	R6
+      0xB81A0E00,  //  0014  GETNGBL	R6	K7
+      0x8C180D08,  //  0015  GETMET	R6	R6	K8
+      0x7C180200,  //  0016  CALL	R6	1
+      0x90021C06,  //  0017  SETMBR	R0	K14	R6
+      0xB81A0E00,  //  0018  GETNGBL	R6	K7
+      0x8C180D08,  //  0019  GETMET	R6	R6	K8
+      0x7C180200,  //  001A  CALL	R6	1
+      0x90021E06,  //  001B  SETMBR	R0	K15	R6
+      0x90022103,  //  001C  SETMBR	R0	K16	K3
+      0x8C180B12,  //  001D  GETMET	R6	R5	K18
+      0x58200013,  //  001E  LDCONST	R8	K19
+      0x7C180400,  //  001F  CALL	R6	2
+      0x8C180D14,  //  0020  GETMET	R6	R6	K20
+      0x58200003,  //  0021  LDCONST	R8	K3
+      0x58240013,  //  0022  LDCONST	R9	K19
+      0x7C180600,  //  0023  CALL	R6	3
+      0x90022206,  //  0024  SETMBR	R0	K17	R6
+      0x90022A04,  //  0025  SETMBR	R0	K21	R4
+      0x8C180116,  //  0026  GETMET	R6	R0	K22
+      0x7C180200,  //  0027  CALL	R6	1
+      0x80000000,  //  0028  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_index
+********************************************************************/
+be_local_closure(Matter_Session_get_fabric_index,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -1687,14 +1621,18 @@ be_local_closure(Matter_Session_get_ipk_epoch_key,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(ipk_epoch_key),
+    /* K1   */  be_nested_str_weak(fabric_index),
     }),
-    be_str_weak(get_ipk_epoch_key),
+    be_str_weak(get_fabric_index),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
+    ( &(const binstruction[ 7]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
+      0x78060002,  //  0001  JMPF	R1	#0005
+      0x88040100,  //  0002  GETMBR	R1	R0	K0
+      0x88040301,  //  0003  GETMBR	R1	R1	K1
+      0x70020000,  //  0004  JMP		#0006
+      0x4C040000,  //  0005  LDNIL	R1
+      0x80040200,  //  0006  RET	1	R1
     })
   )
 );
@@ -1702,9 +1640,82 @@ be_local_closure(Matter_Session_get_ipk_epoch_key,   /* name */
 
 
 /********************************************************************
-** Solidified function: persist_to_fabric
+** Solidified function: get_temp_ca
 ********************************************************************/
-be_local_closure(Matter_Session_persist_to_fabric,   /* name */
+be_local_closure(Matter_Session_get_temp_ca,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_temp_root_ca_certificate),
+    }),
+    be_str_weak(get_temp_ca),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pk
+********************************************************************/
+be_local_closure(Matter_Session_get_pk,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(get_pk),
+    /* K2   */  be_nested_str_weak(_temp_pk),
+    /* K3   */  be_nested_str_weak(crypto),
+    /* K4   */  be_nested_str_weak(random),
+    }),
+    be_str_weak(get_pk),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060004,  //  0001  JMPF	R1	#0007
+      0x88040100,  //  0002  GETMBR	R1	R0	K0
+      0x8C040301,  //  0003  GETMET	R1	R1	K1
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80040200,  //  0005  RET	1	R1
+      0x70020008,  //  0006  JMP		#0010
+      0x88040102,  //  0007  GETMBR	R1	R0	K2
+      0x74060004,  //  0008  JMPT	R1	#000E
+      0xA4060600,  //  0009  IMPORT	R1	K3
+      0x8C080304,  //  000A  GETMET	R2	R1	K4
+      0x5412001F,  //  000B  LDINT	R4	32
+      0x7C080400,  //  000C  CALL	R2	2
+      0x90020402,  //  000D  SETMBR	R0	K2	R2
+      0x88040102,  //  000E  GETMBR	R1	R0	K2
+      0x80040200,  //  000F  RET	1	R1
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_mode_PASE
+********************************************************************/
+be_local_closure(Matter_Session_set_mode_PASE,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -1715,17 +1726,43 @@ be_local_closure(Matter_Session_persist_to_fabric,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(add_session),
+    /* K0   */  be_nested_str_weak(set_mode),
+    /* K1   */  be_nested_str_weak(_PASE),
     }),
-    be_str_weak(persist_to_fabric),
+    be_str_weak(set_mode_PASE),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x80000000,  //  0004  RET	0
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_mode
+********************************************************************/
+be_local_closure(Matter_Session_set_mode,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mode),
+    }),
+    be_str_weak(set_mode),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
     })
   )
 );
@@ -1739,91 +1776,92 @@ extern const bclass be_class_Matter_Expirable;
 be_local_class(Matter_Session,
     38,
     &be_class_Matter_Expirable,
-    be_nested_map(83,
+    be_nested_map(84,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(resumption_id, -1), be_const_var(28) },
-        { be_const_key_weak(mode, 4), be_const_var(1) },
-        { be_const_key_weak(get_pk, -1), be_const_closure(Matter_Session_get_pk_closure) },
-        { be_const_key_weak(set_mode_CASE, 65), be_const_closure(Matter_Session_set_mode_CASE_closure) },
-        { be_const_key_weak(__spake_cA, 22), be_const_var(33) },
-        { be_const_key_weak(__initiator_pub, -1), be_const_var(32) },
-        { be_const_key_weak(get_temp_ca_pub, 55), be_const_closure(Matter_Session_get_temp_ca_pub_closure) },
-        { be_const_key_weak(get_i2r, -1), be_const_closure(Matter_Session_get_i2r_closure) },
-        { be_const_key_weak(_ip, 82), be_const_var(17) },
-        { be_const_key_weak(__Msg2, -1), be_const_var(36) },
-        { be_const_key_weak(get_fabric_label, 59), be_const_closure(Matter_Session_get_fabric_label_closure) },
-        { be_const_key_weak(__future_initiator_session_id, -1), be_const_var(10) },
-        { be_const_key_weak(set_keys, 0), be_const_closure(Matter_Session_set_keys_closure) },
-        { be_const_key_weak(set_mode_PASE, -1), be_const_closure(Matter_Session_set_mode_PASE_closure) },
-        { be_const_key_weak(_fabric, 7), be_const_var(2) },
-        { be_const_key_weak(get_temp_ca, -1), be_const_closure(Matter_Session_get_temp_ca_closure) },
-        { be_const_key_weak(attestation_challenge, -1), be_const_var(25) },
-        { be_const_key_weak(_temp_pk, -1), be_const_var(9) },
-        { be_const_key_weak(last_used, -1), be_const_var(6) },
-        { be_const_key_weak(peer_node_id, -1), be_const_var(26) },
-        { be_const_key_weak(is_CASE, -1), be_const_closure(Matter_Session_is_CASE_closure) },
-        { be_const_key_weak(get_ipk_epoch_key, 80), be_const_closure(Matter_Session_get_ipk_epoch_key_closure) },
-        { be_const_key_weak(_exchange_id, -1), be_const_var(16) },
-        { be_const_key_weak(__chunked_attr_reports, -1), be_const_var(37) },
-        { be_const_key_weak(counter_snd, -1), be_const_var(13) },
-        { be_const_key_weak(_i2r_privacy, -1), be_const_var(24) },
-        { be_const_key_weak(_PASE, -1), be_const_int(1) },
-        { be_const_key_weak(get_mode, 1), be_const_closure(Matter_Session_get_mode_closure) },
-        { be_const_key_weak(get_icac, 53), be_const_closure(Matter_Session_get_icac_closure) },
-        { be_const_key_weak(is_PASE, -1), be_const_closure(Matter_Session_is_PASE_closure) },
-        { be_const_key_weak(gen_CSR, -1), be_const_closure(Matter_Session_gen_CSR_closure) },
-        { be_const_key_weak(_message_handler, 51), be_const_var(19) },
-        { be_const_key_weak(__spake_Ke, -1), be_const_var(34) },
-        { be_const_key_weak(get_admin_subject, -1), be_const_closure(Matter_Session_get_admin_subject_closure) },
-        { be_const_key_weak(before_remove, 73), be_const_closure(Matter_Session_before_remove_closure) },
-        { be_const_key_weak(__responder_pub, -1), be_const_var(31) },
-        { be_const_key_weak(i2rkey, -1), be_const_var(22) },
-        { be_const_key_weak(created, -1), be_const_var(5) },
-        { be_const_key_weak(_CASE, -1), be_const_int(2) },
-        { be_const_key_weak(_port, -1), be_const_var(18) },
-        { be_const_key_weak(_store, -1), be_const_var(0) },
-        { be_const_key_weak(get_device_id, -1), be_const_closure(Matter_Session_get_device_id_closure) },
-        { be_const_key_weak(get_admin_vendor, -1), be_const_closure(Matter_Session_get_admin_vendor_closure) },
-        { be_const_key_weak(get_fabric, -1), be_const_closure(Matter_Session_get_fabric_closure) },
-        { be_const_key_weak(_counter_insecure_rcv, 28), be_const_var(20) },
-        { be_const_key_weak(get_ipk_group_key, -1), be_const_closure(Matter_Session_get_ipk_group_key_closure) },
-        { be_const_key_weak(__responder_priv, -1), be_const_var(30) },
-        { be_const_key_weak(_GROUP_KEY, 56), be_nested_str_weak(GroupKey_X20v1_X2E0) },
-        { be_const_key_weak(_temp_root_ca_certificate, -1), be_const_var(8) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Session_init_closure) },
-        { be_const_key_weak(get_noc, 41), be_const_closure(Matter_Session_get_noc_closure) },
-        { be_const_key_weak(set_fabric_label, 15), be_const_closure(Matter_Session_set_fabric_label_closure) },
-        { be_const_key_weak(shared_secret, -1), be_const_var(29) },
-        { be_const_key_weak(hydrate_post, 33), be_const_closure(Matter_Session_hydrate_post_closure) },
-        { be_const_key_weak(fromjson, -1), be_const_static_closure(Matter_Session_fromjson_closure) },
-        { be_const_key_weak(save, -1), be_const_closure(Matter_Session_save_closure) },
-        { be_const_key_weak(_source_node_id, -1), be_const_var(7) },
-        { be_const_key_weak(set_mode, 25), be_const_closure(Matter_Session_set_mode_closure) },
-        { be_const_key_weak(_counter_snd_impl, -1), be_const_var(15) },
-        { be_const_key_weak(__Msg1, 81), be_const_var(35) },
-        { be_const_key_weak(set_temp_ca, -1), be_const_closure(Matter_Session_set_temp_ca_closure) },
-        { be_const_key_weak(get_i2r_privacy, -1), be_const_closure(Matter_Session_get_i2r_privacy_closure) },
-        { be_const_key_weak(initiator_session_id, -1), be_const_var(4) },
-        { be_const_key_weak(__future_local_session_id, -1), be_const_var(11) },
-        { be_const_key_weak(r2ikey, -1), be_const_var(23) },
-        { be_const_key_weak(get_fabric_id, 72), be_const_closure(Matter_Session_get_fabric_id_closure) },
+        { be_const_key_weak(set_mode, 6), be_const_closure(Matter_Session_set_mode_closure) },
+        { be_const_key_weak(set_mode_PASE, 57), be_const_closure(Matter_Session_set_mode_PASE_closure) },
+        { be_const_key_weak(_counter_rcv_impl, 79), be_const_var(14) },
+        { be_const_key_weak(attestation_challenge, 56), be_const_var(25) },
         { be_const_key_weak(get_ac, -1), be_const_closure(Matter_Session_get_ac_closure) },
-        { be_const_key_weak(local_session_id, -1), be_const_var(3) },
-        { be_const_key_weak(counter_snd_next, -1), be_const_closure(Matter_Session_counter_snd_next_closure) },
-        { be_const_key_weak(counter_rcv_validate, -1), be_const_closure(Matter_Session_counter_rcv_validate_closure) },
-        { be_const_key_weak(get_ca, 35), be_const_closure(Matter_Session_get_ca_closure) },
-        { be_const_key_weak(_counter_rcv_impl, -1), be_const_var(14) },
-        { be_const_key_weak(update, -1), be_const_closure(Matter_Session_update_closure) },
-        { be_const_key_weak(close, 23), be_const_closure(Matter_Session_close_closure) },
-        { be_const_key_weak(get_ca_pub, -1), be_const_closure(Matter_Session_get_ca_pub_closure) },
+        { be_const_key_weak(get_fabric, -1), be_const_closure(Matter_Session_get_fabric_closure) },
+        { be_const_key_weak(get_temp_ca, 69), be_const_closure(Matter_Session_get_temp_ca_closure) },
+        { be_const_key_weak(_COUNTER_SND_INCR, -1), be_const_int(1024) },
+        { be_const_key_weak(_CASE, -1), be_const_int(2) },
+        { be_const_key_weak(_counter_insecure_rcv, 2), be_const_var(20) },
         { be_const_key_weak(_breadcrumb, -1), be_const_var(27) },
-        { be_const_key_weak(_COUNTER_SND_INCR, 21), be_const_int(1024) },
-        { be_const_key_weak(_counter_insecure_snd, -1), be_const_var(21) },
+        { be_const_key_weak(r2ikey, 82), be_const_var(23) },
+        { be_const_key_weak(set_keys, 52), be_const_closure(Matter_Session_set_keys_closure) },
+        { be_const_key_weak(_exchange_id, -1), be_const_var(16) },
+        { be_const_key_weak(peer_node_id, 8), be_const_var(26) },
+        { be_const_key_weak(last_used, 80), be_const_var(6) },
+        { be_const_key_weak(_source_node_id, 48), be_const_var(7) },
+        { be_const_key_weak(init, 36), be_const_closure(Matter_Session_init_closure) },
+        { be_const_key_weak(set_temp_ca, -1), be_const_closure(Matter_Session_set_temp_ca_closure) },
+        { be_const_key_weak(created, -1), be_const_var(5) },
         { be_const_key_weak(persist_to_fabric, -1), be_const_closure(Matter_Session_persist_to_fabric_closure) },
-        { be_const_key_weak(counter_rcv, 5), be_const_var(12) },
-        { be_const_key_weak(tojson, -1), be_const_closure(Matter_Session_tojson_closure) },
-        { be_const_key_weak(get_r2i, -1), be_const_closure(Matter_Session_get_r2i_closure) },
+        { be_const_key_weak(__initiator_pub, -1), be_const_var(32) },
+        { be_const_key_weak(gen_CSR, -1), be_const_closure(Matter_Session_gen_CSR_closure) },
+        { be_const_key_weak(_store, -1), be_const_var(0) },
+        { be_const_key_weak(get_ipk_epoch_key, 49), be_const_closure(Matter_Session_get_ipk_epoch_key_closure) },
+        { be_const_key_weak(__responder_priv, 7), be_const_var(30) },
+        { be_const_key_weak(counter_rcv_validate, -1), be_const_closure(Matter_Session_counter_rcv_validate_closure) },
+        { be_const_key_weak(_ip, -1), be_const_var(17) },
+        { be_const_key_weak(get_admin_subject, 40), be_const_closure(Matter_Session_get_admin_subject_closure) },
+        { be_const_key_weak(resumption_id, -1), be_const_var(28) },
+        { be_const_key_weak(_i2r_privacy, -1), be_const_var(24) },
         { be_const_key_weak(get_fabric_compressed, -1), be_const_closure(Matter_Session_get_fabric_compressed_closure) },
+        { be_const_key_weak(_temp_pk, -1), be_const_var(9) },
+        { be_const_key_weak(shared_secret, 74), be_const_var(29) },
+        { be_const_key_weak(_temp_root_ca_certificate, -1), be_const_var(8) },
+        { be_const_key_weak(get_ca, -1), be_const_closure(Matter_Session_get_ca_closure) },
+        { be_const_key_weak(_fabric, 10), be_const_var(2) },
+        { be_const_key_weak(__spake_cA, -1), be_const_var(33) },
+        { be_const_key_weak(get_ipk_group_key, -1), be_const_closure(Matter_Session_get_ipk_group_key_closure) },
+        { be_const_key_weak(initiator_session_id, 18), be_const_var(4) },
+        { be_const_key_weak(get_i2r_privacy, -1), be_const_closure(Matter_Session_get_i2r_privacy_closure) },
+        { be_const_key_weak(__chunked_attr_reports, -1), be_const_var(37) },
+        { be_const_key_weak(get_ca_pub, -1), be_const_closure(Matter_Session_get_ca_pub_closure) },
+        { be_const_key_weak(counter_snd, 20), be_const_var(13) },
+        { be_const_key_weak(set_fabric_label, 35), be_const_closure(Matter_Session_set_fabric_label_closure) },
+        { be_const_key_weak(_counter_snd_impl, 71), be_const_var(15) },
+        { be_const_key_weak(is_CASE, -1), be_const_closure(Matter_Session_is_CASE_closure) },
+        { be_const_key_weak(before_remove, -1), be_const_closure(Matter_Session_before_remove_closure) },
+        { be_const_key_weak(set_mode_CASE, -1), be_const_closure(Matter_Session_set_mode_CASE_closure) },
+        { be_const_key_weak(get_icac, -1), be_const_closure(Matter_Session_get_icac_closure) },
+        { be_const_key_weak(tojson, 61), be_const_closure(Matter_Session_tojson_closure) },
+        { be_const_key_weak(close, 1), be_const_closure(Matter_Session_close_closure) },
+        { be_const_key_weak(get_fabric_label, 42), be_const_closure(Matter_Session_get_fabric_label_closure) },
+        { be_const_key_weak(_counter_insecure_snd, -1), be_const_var(21) },
+        { be_const_key_weak(get_device_id, 63), be_const_closure(Matter_Session_get_device_id_closure) },
+        { be_const_key_weak(counter_rcv, 62), be_const_var(12) },
+        { be_const_key_weak(__Msg1, -1), be_const_var(35) },
+        { be_const_key_weak(hydrate_post, 66), be_const_closure(Matter_Session_hydrate_post_closure) },
+        { be_const_key_weak(_message_handler, -1), be_const_var(19) },
+        { be_const_key_weak(__future_initiator_session_id, -1), be_const_var(10) },
+        { be_const_key_weak(__spake_Ke, 32), be_const_var(34) },
+        { be_const_key_weak(__Msg2, 38), be_const_var(36) },
+        { be_const_key_weak(get_mode, -1), be_const_closure(Matter_Session_get_mode_closure) },
+        { be_const_key_weak(mode, -1), be_const_var(1) },
+        { be_const_key_weak(update, 16), be_const_closure(Matter_Session_update_closure) },
+        { be_const_key_weak(counter_snd_next, -1), be_const_closure(Matter_Session_counter_snd_next_closure) },
+        { be_const_key_weak(get_temp_ca_pub, -1), be_const_closure(Matter_Session_get_temp_ca_pub_closure) },
+        { be_const_key_weak(get_i2r, -1), be_const_closure(Matter_Session_get_i2r_closure) },
+        { be_const_key_weak(get_noc, 37), be_const_closure(Matter_Session_get_noc_closure) },
+        { be_const_key_weak(get_fabric_id, -1), be_const_closure(Matter_Session_get_fabric_id_closure) },
+        { be_const_key_weak(get_admin_vendor, -1), be_const_closure(Matter_Session_get_admin_vendor_closure) },
+        { be_const_key_weak(is_PASE, -1), be_const_closure(Matter_Session_is_PASE_closure) },
+        { be_const_key_weak(save, 21), be_const_closure(Matter_Session_save_closure) },
+        { be_const_key_weak(_GROUP_KEY, -1), be_nested_str_weak(GroupKey_X20v1_X2E0) },
+        { be_const_key_weak(local_session_id, 76), be_const_var(3) },
+        { be_const_key_weak(i2rkey, 17), be_const_var(22) },
+        { be_const_key_weak(__future_local_session_id, -1), be_const_var(11) },
+        { be_const_key_weak(_PASE, -1), be_const_int(1) },
+        { be_const_key_weak(get_fabric_index, -1), be_const_closure(Matter_Session_get_fabric_index_closure) },
+        { be_const_key_weak(_port, -1), be_const_var(18) },
+        { be_const_key_weak(get_r2i, -1), be_const_closure(Matter_Session_get_r2i_closure) },
+        { be_const_key_weak(get_pk, -1), be_const_closure(Matter_Session_get_pk_closure) },
+        { be_const_key_weak(__responder_pub, -1), be_const_var(31) },
+        { be_const_key_weak(fromjson, 0), be_const_static_closure(Matter_Session_fromjson_closure) },
     })),
     be_str_weak(Matter_Session)
 );


### PR DESCRIPTION
## Description:

Matter: now fabric_filtered request only return data related to the current fabric. This happened to be a problem for Google when already commissioned with Apple.

Now you can commission with Apple Home, then with Google Home and both work simultaneously 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
