### PR TITLE
Matter support for large atribute responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - Zero cross dimmer minimum interrupt time (#19211)
 - Fade would fail when the difference between start and target would be too small (#19248)
 - Inverted shutter (#19243)
+- Matter support for large atribute responses
 
 ### Removed
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
@@ -176,18 +176,24 @@ class Matter_Device
 
   #####################################################################
   # Remove a fabric and clean all corresponding values and mDNS entries
-  def remove_fabric(fabric_parent)
-    var sub_fabrics = self.sessions.find_children_fabrics(fabric_parent.get_fabric_index())
-    if sub_fabrics == nil return end
-    for fabric_index : sub_fabrics
-      var fabric = self.sessions.find_fabric_by_index(fabric_index)
-      if fabric != nil
-        tasmota.log("MTR: removing fabric " + fabric.get_fabric_id().copy().reverse().tohex(), 2)
-        self.message_handler.im.subs_shop.remove_by_fabric(fabric)
-        self.mdns_remove_op_discovery(fabric)
-        self.sessions.remove_fabric(fabric)
-      end
+  def remove_fabric(fabric)
+    if fabric != nil
+      tasmota.log("MTR: removing fabric " + fabric.get_fabric_id().copy().reverse().tohex(), 2)
+      self.message_handler.im.subs_shop.remove_by_fabric(fabric)
+      self.mdns_remove_op_discovery(fabric)
+      self.sessions.remove_fabric(fabric)
     end
+    # var sub_fabrics = self.sessions.find_children_fabrics(fabric_parent.get_fabric_index())
+    # if sub_fabrics == nil return end
+    # for fabric_index : sub_fabrics
+    #   var fabric = self.sessions.find_fabric_by_index(fabric_index)
+    #   if fabric != nil
+    #     tasmota.log("MTR: removing fabric " + fabric.get_fabric_id().copy().reverse().tohex(), 2)
+    #     self.message_handler.im.subs_shop.remove_by_fabric(fabric)
+    #     self.mdns_remove_op_discovery(fabric)
+    #     self.sessions.remove_fabric(fabric)
+    #   end
+    # end
     self.sessions.save_fabrics()
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
@@ -225,7 +225,7 @@ class Matter_IM
   # Inner code shared between read_attributes and subscribe_request
   #
   # query: `ReadRequestMessage` or `SubscribeRequestMessage`
-  def _inner_process_read_request(session, query, no_log)
+  def _inner_process_read_request(session, query, msg, no_log)
 
     ### Inner function to be iterated upon
     # ret is the ReportDataMessage list to send back
@@ -243,22 +243,47 @@ class Matter_IM
       # Special case to report unsupported item, if pi==nil
       var res = (pi != nil) ? pi.read_attribute(session, ctx, self.tlv_solo) : nil
       var found = true                # stop expansion since we have a value
-      var a1_raw                      # this is the bytes() block we need to add to response (or nil)
+      var a1_raw_or_list              # contains either a bytes() buffer to append, or a list of bytes(), or nil
       if res != nil
-        var res_str = res.to_str_val()  # get the value with anonymous tag before it is tagged, for logging
+        var res_str = ""
+        if !no_log
+          res_str = res.to_str_val()  # get the value with anonymous tag before it is tagged, for logging
+        end
 
-        # encode directly raw bytes()
-        a1_raw = bytes(48)      # pre-reserve 48 bytes
-        self.attributedata2raw(a1_raw, ctx, res)
+        # check if too big to encode as a single packet
+        if (res.is_list || res.is_array) && res.encode_len() > matter.IM_ReportData.MAX_MESSAGE
+          # tasmota.log(f"MTR: >>>>>> long response", 3)
+          a1_raw_or_list = []         # we return a list of block
+          var a1_raw = bytes(48)
+          var empty_list = TLV.Matter_TLV_array()
+          self.attributedata2raw(a1_raw, ctx, empty_list, false)
+          a1_raw_or_list.push(a1_raw)
+          # tasmota.log(f"MTR: >>>>>> long response global DELETE {a1_raw.tohex()}", 3)
+
+          for elt:res.val
+            a1_raw = bytes(48)
+            # var list_item = TLV.Matter_TLV_array()
+            # list_item.val.push(elt)
+            self.attributedata2raw(a1_raw, ctx, elt, true #- add ListIndex:null -#)
+            # tasmota.log(f"MTR: >>>>>> long response global ADD {a1_raw.tohex()}", 3)
+            a1_raw_or_list.push(a1_raw)
+          end
+          # tasmota.log(f"MTR: >>>>>> long response global {a1_raw_or_list}", 3)
+        else
+          # normal encoding
+          # encode directly raw bytes()
+          a1_raw_or_list = bytes(48)      # pre-reserve 48 bytes
+          self.attributedata2raw(a1_raw_or_list, ctx, res)
+        end
 
         if !no_log
-          tasmota.log(format("MTR: >Read_Attr (%6i) %s%s - %s", session.local_session_id, str(ctx), attr_name, res_str), 3)
+          tasmota.log(f"MTR: >Read_Attr ({session.local_session_id:6i}) {ctx}{attr_name} - {res_str}", 3)
         end          
       elif ctx.status != nil
         if direct                           # we report an error only if a concrete direct read, not with wildcards
           # encode directly raw bytes()
-          a1_raw = bytes(48)      # pre-reserve 48 bytes
-          self.attributestatus2raw(a1_raw, ctx, ctx.status)
+          a1_raw_or_list = bytes(48)      # pre-reserve 48 bytes
+          self.attributestatus2raw(a1_raw_or_list, ctx, ctx.status)
 
           if tasmota.loglevel(3)
             tasmota.log(format("MTR: >Read_Attr (%6i) %s%s - STATUS: 0x%02X %s", session.local_session_id, str(ctx), attr_name, ctx.status, ctx.status == matter.UNSUPPORTED_ATTRIBUTE ? "UNSUPPORTED_ATTRIBUTE" : ""), 3)
@@ -270,20 +295,47 @@ class Matter_IM
         found = false
       end
 
-      # check if we still have enough room in last block
-      if a1_raw         # do we have bytes to add, and it's not zero size
+      # a1_raw_or_list if either nil, bytes(), of list(bytes())
+      var idx = isinstance(a1_raw_or_list, list) ? 0 : nil      # index in list, or nil if non-list
+      while a1_raw_or_list != nil
+        var elt = (idx == nil) ? a1_raw_or_list : a1_raw_or_list[idx]   # dereference
+
         if size(ret.attribute_reports) == 0
-          ret.attribute_reports.push(a1_raw)      # push raw binary instead of a TLV
+          ret.attribute_reports.push(elt)                       # push raw binary instead of a TLV
         else    # already blocks present, see if we can add to the latest, or need to create a new block
           var last_block = ret.attribute_reports[-1]
-          if size(last_block) + size(a1_raw) <= matter.IM_ReportData.MAX_MESSAGE
+          if size(last_block) + size(elt) <= matter.IM_ReportData.MAX_MESSAGE
             # add to last block
-            last_block .. a1_raw
+            last_block .. elt
           else
-            ret.attribute_reports.push(a1_raw)      # push raw binary instead of a TLV
+            ret.attribute_reports.push(elt)      # push raw binary instead of a TLV
+          end
+        end
+
+        if idx == nil
+          a1_raw_or_list = nil                    # stop loop
+        else
+          idx += 1
+          if idx >= size(a1_raw_or_list)
+            a1_raw_or_list = nil                    # stop loop
           end
         end
       end
+
+      # check if we still have enough room in last block
+      # if a1_raw_or_list         # do we have bytes to add, and it's not zero size
+      #   if size(ret.attribute_reports) == 0
+      #     ret.attribute_reports.push(a1_raw_or_list)      # push raw binary instead of a TLV
+      #   else    # already blocks present, see if we can add to the latest, or need to create a new block
+      #     var last_block = ret.attribute_reports[-1]
+      #     if size(last_block) + size(a1_raw_or_list) <= matter.IM_ReportData.MAX_MESSAGE
+      #       # add to last block
+      #       last_block .. a1_raw_or_list
+      #     else
+      #       ret.attribute_reports.push(a1_raw_or_list)      # push raw binary instead of a TLV
+      #     end
+      #   end
+      # end
 
       return found          # return true if we had a match
     end
@@ -291,6 +343,7 @@ class Matter_IM
     var endpoints = self.device.get_active_endpoints()
     # structure is `ReadRequestMessage` 10.6.2 p.558
     var ctx = matter.Path()
+    ctx.msg = msg
 
     # prepare the response
     var ret = matter.ReportDataMessage()
@@ -347,8 +400,10 @@ class Matter_IM
   #       2402 01    	2 = 1U (U1)
   #       2403 39 	3 = 0x39U (U1)
   #       2404 11 	4 = 0x11U (U1)
+  #       [OPTIONAL ListIndex]
+  #       3405      5 = NULL
   #     18
-  def path2raw(raw, ctx, sub_tag)
+  def path2raw(raw, ctx, sub_tag, list_index_null)
     # open struct
     raw.add(0x37, 1)              # add 37
     raw.add(sub_tag, 1)           # add sub_tag
@@ -382,6 +437,11 @@ class Matter_IM
       raw.add(0x2604, -2)          # add 2604
       raw.add(ctx.attribute, 4)
     end
+    # do we add ListIndex: null
+    if list_index_null
+      raw.add(0x3405, -2)          # add 3405
+    end
+    # close
     raw.add(0x18, 1)               # add 18
   end
 
@@ -418,15 +478,18 @@ class Matter_IM
   #       2402 01    	2 = 1U (U1)
   #       2403 39 	3 = 0x39U (U1)
   #       2404 11 	4 = 0x11U (U1)
+  #       [OPTIONAL ListIndex]
+  #       3405      5 = NULL
+  #
   #     18
   #     2902		2 = True
   #   18
   # 18
-  def attributedata2raw(raw, ctx, val)
+  def attributedata2raw(raw, ctx, val, list_index_null)
     raw.add(0x15350124, -4)             # add 15350124
     raw.add(0x0001, -2)                 # add 0001
 
-    self.path2raw(raw, ctx, 0x01)
+    self.path2raw(raw, ctx, 0x01, list_index_null)
     
     # add value with tag 2
     val.tag_sub = 2
@@ -615,7 +678,7 @@ class Matter_IM
     var query = matter.ReadRequestMessage().from_TLV(val)
     # matter.profiler.log(str(query))
     if query.attributes_requests != nil
-      var ret = self._inner_process_read_request(msg.session, query)
+      var ret = self._inner_process_read_request(msg.session, query, msg)
       self.send_report_data(msg, ret)
     end
 
@@ -629,15 +692,10 @@ class Matter_IM
   # returns `true` if processed, `false` if silently ignored,
   # or raises an exception
   def process_read_request_solo(msg, ctx)
-    # matter.profiler.log("read_request_solo start")
-    # matter.profiler.log(str(val))
-    # var query = matter.ReadRequestMessage().from_TLV(val)
-    # matter.profiler.log("read_request_start-TLV")
-    
     # prepare fallback error
     ctx.status = matter.INVALID_ACTION
+    ctx.msg = msg
 
-    # TODO
     # find pi for this endpoint/cluster/attribute
     var pi = self.device.process_attribute_read_solo(ctx)
     var res = nil
@@ -653,6 +711,15 @@ class Matter_IM
 
     if res != nil
 
+      # check if the payload is a complex structure and too long to fit in a single response packet
+      if (res.is_list || res.is_array) && res.encode_len() > matter.IM_ReportData.MAX_MESSAGE
+        # revert to standard 
+        # the attribute will be read again, but it's hard to avoid it
+        res = nil       # indicated to GC that we don't need it again
+        tasmota.log(f"MTR:                     Response to big, revert to non-solo", 3)
+        var val = matter.TLV.parse(msg.raw, msg.app_payload_idx)
+        return self.process_read_request(msg, val)
+      end
       # encode directly raw bytes()
       raw = bytes(48)      # pre-reserve 48 bytes
 
@@ -664,8 +731,6 @@ class Matter_IM
       # add suffix 1824FF0118
       raw.add(0x1824FF01, -4)        # add 1824FF01
       raw.add(0x18, 1)               # add 18
-
-      # matter.profiler.log("read_request_solo raw done")
 
     elif ctx.status != nil
       
@@ -686,31 +751,14 @@ class Matter_IM
       return false
     end
 
-    # matter.profiler.log("read_request_solo res ready")
-    # tasmota.log(f"MTR: process_read_request_solo {raw=}")
-
     # send packet
-    # self.send_report_data_solo(msg, ret)
-    # var report_solo = matter.IM_ReportData_solo(msg, ret)
     var resp = msg.build_response(0x05 #-Report Data-#, true)
 
-    # super(self).reset(msg, 0x05 #-Report Data-#, true)
-    # matter.profiler.log("read_request_solo report_solo")
-
-    # send_im()
-    # report_solo.send_im(self.device.message_handler)
     var responder = self.device.message_handler
-    # matter.profiler.log("read_request_solo send_im-1")
-    # if tasmota.loglevel(3)    # TODO remove before flight
-    #   tasmota.log(f">>>: data_raw={raw.tohex()}", 3)
-    # end
-    # matter.profiler.log("read_request_solo send_im-2")
     var msg_raw = msg.raw
     msg_raw.clear()
     resp.encode_frame(raw, msg_raw)    # payload in cleartext
-    # matter.profiler.log("read_request_solo send_im-3")
     resp.encrypt()
-    # matter.profiler.log("read_request_solo send_im-encrypted")
     if tasmota.loglevel(4)
       tasmota.log(format("MTR: <snd       (%6i) id=%i exch=%i rack=%s", resp.session.local_session_id, resp.message_counter, resp.exchange_id, resp.ack_message_counter), 4)
     end
@@ -779,7 +827,7 @@ class Matter_IM
       tasmota.log(f"MTR: >Subscribe (%6i) event_requests_size={size(query.event_requests)}", 3)
     end
 
-    var ret = self._inner_process_read_request(msg.session, query, true #-no_log-#)
+    var ret = self._inner_process_read_request(msg.session, query, msg, true #-no_log-#)
     # ret is of type `Matter_ReportDataMessage`
     ret.subscription_id = sub.subscription_id     # enrich with subscription id TODO
     self.send_subscribe_response(msg, ret, sub)
@@ -853,11 +901,7 @@ class Matter_IM
         end
       end
 
-      # tasmota.log("MTR: invoke_responses="+str(ret.invoke_responses), 4)
       if size(ret.invoke_responses) > 0
-        # tasmota.log("MTR: InvokeResponse=" + str(ret), 4)
-        # tasmota.log("MTR: InvokeResponseTLV=" + str(ret.to_TLV()), 3)
-
         self.send_invoke_response(msg, ret)
       else
         return false        # we don't send anything, hence the responder sends a simple packet ack
@@ -1009,6 +1053,7 @@ class Matter_IM
     # structure is `ReadRequestMessage` 10.6.2 p.558
     # tasmota.log("MTR: IM:write_request processing start", 4)
     var ctx = matter.Path()
+    ctx.msg = msg
 
     if query.write_requests != nil
       # prepare the response
@@ -1112,7 +1157,7 @@ class Matter_IM
     tasmota.log(format("MTR: <Sub_Data  (%6i) sub=%i", session.local_session_id, sub.subscription_id), 3)
     sub.is_keep_alive = false             # sending an actual data update
 
-    var ret = self._inner_process_read_request(session, fake_read)
+    var ret = self._inner_process_read_request(session, fake_read, nil #-no msg-#)
     ret.suppress_response = false
     ret.subscription_id = sub.subscription_id
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin.be
@@ -64,8 +64,12 @@ class Matter_Plugin
   end
 
   # proxy for the same method in IM
-  def send_ack_now(msg)
-    self.device.message_handler.im.send_ack_now(msg)
+  def ack_request(ctx)
+    var msg = ctx.msg
+    if msg != nil
+      self.device.message_handler.im.send_ack_now(msg)
+    end
+    ctx.msg = nil
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
@@ -151,7 +151,7 @@ class Matter_Plugin_Root : Matter_Plugin
 
     # ====================================================================================================
     elif cluster == 0x003E              # ========== Node Operational Credentials Cluster 11.17 p.704 ==========
-      self.send_ack_now(ctx.msg)      # long operation, send Ack first
+      self.ack_request(ctx)             # long operation, send Ack first
 
       if   attribute == 0x0000          #  ---------- NOCs / list[NOCStruct] ----------
         var nocl = TLV.Matter_TLV_array() # NOCs, p.711
@@ -217,7 +217,7 @@ class Matter_Plugin_Root : Matter_Plugin
         
     # ====================================================================================================
     elif cluster == 0x0028              # ========== Basic Information Cluster cluster 11.1 p.565 ==========
-      self.send_ack_now(ctx.msg)      # long operation, send Ack first
+      self.ack_request(ctx)             # long operation, send Ack first
 
       if   attribute == 0x0000          #  ---------- DataModelRevision / CommissioningWindowStatus ----------
         return tlv_solo.set(TLV.U2, 1)
@@ -374,7 +374,7 @@ class Matter_Plugin_Root : Matter_Plugin
         return srcr
 
       elif command == 0x0004            # ---------- CommissioningComplete p.636 ----------
-        self.send_ack_now(ctx.msg)      # long operation, send Ack first
+        self.ack_request(ctx)           # long operation, send Ack first
         # no data
         if session._fabric
           session._breadcrumb = 0          # clear breadcrumb
@@ -442,7 +442,7 @@ class Matter_Plugin_Root : Matter_Plugin
         return ar
 
       elif command == 0x0004            # ---------- CSRRequest ----------
-        self.send_ack_now(ctx.msg)      # long operation, send Ack first
+        self.ack_request(ctx)           # long operation, send Ack first
         var CSRNonce = val.findsubval(0)     # octstr 32
         if size(CSRNonce) != 32   return nil end    # check size on nonce
         var IsForUpdateNOC = val.findsubval(1, false)     # bool

--- a/lib/libesp32/berry_matter/src/embedded/Matter_TLV.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_TLV.be
@@ -94,6 +94,9 @@ class Matter_TLV
   static class Matter_TLV_item
     # we keep a shortcut reference to the Matter_TLV class
     static var TLV = Matter_TLV
+    static var is_list = false
+    static var is_array = false
+    static var is_struct = false
     # parent tag to inherit vendor/profile/tag
     var parent
     var next_idx              # next idx in buffer (when parsing)
@@ -607,7 +610,10 @@ class Matter_TLV
 # class Matter_TLV_struct var _ end
 
   static class Matter_TLV_list : Matter_TLV_item
-    static var is_struct = false
+    # inherited
+    static var is_list = true
+    # static var is_array = false
+    # static var is_struct = false
 
     #################################################################################
     def init(parent)
@@ -825,6 +831,8 @@ class Matter_TLV
   # Matter_TLV_struct class
   #################################################################################
   static class Matter_TLV_struct : Matter_TLV_list
+    static var is_list = false
+  # static var is_array = false
     static var is_struct = true
 
     def init(parent)
@@ -843,6 +851,10 @@ class Matter_TLV
   # Matter_TLV_array class
   #################################################################################
   static class Matter_TLV_array : Matter_TLV_list
+    static var is_list = false
+    static var is_array = true
+  # static var is_struct = false
+
     def init(parent)
       super(self).init(parent)
       self.typ = self.TLV.ARRAY

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
@@ -5507,7 +5507,7 @@ be_local_closure(Matter_Device_autoconf_device,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Device_remove_fabric,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    6,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -5515,87 +5515,60 @@ be_local_closure(Matter_Device_remove_fabric,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(find_children_fabrics),
-    /* K2   */  be_nested_str_weak(get_fabric_index),
-    /* K3   */  be_nested_str_weak(find_fabric_by_index),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
-    /* K7   */  be_nested_str_weak(get_fabric_id),
-    /* K8   */  be_nested_str_weak(copy),
-    /* K9   */  be_nested_str_weak(reverse),
-    /* K10  */  be_nested_str_weak(tohex),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(message_handler),
-    /* K13  */  be_nested_str_weak(im),
-    /* K14  */  be_nested_str_weak(subs_shop),
-    /* K15  */  be_nested_str_weak(remove_by_fabric),
-    /* K16  */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K17  */  be_nested_str_weak(remove_fabric),
-    /* K18  */  be_nested_str_weak(stop_iteration),
-    /* K19  */  be_nested_str_weak(save_fabrics),
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(copy),
+    /* K5   */  be_nested_str_weak(reverse),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_const_int(2),
+    /* K8   */  be_nested_str_weak(message_handler),
+    /* K9   */  be_nested_str_weak(im),
+    /* K10  */  be_nested_str_weak(subs_shop),
+    /* K11  */  be_nested_str_weak(remove_by_fabric),
+    /* K12  */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K13  */  be_nested_str_weak(sessions),
+    /* K14  */  be_nested_str_weak(remove_fabric),
+    /* K15  */  be_nested_str_weak(save_fabrics),
     }),
     be_str_weak(remove_fabric),
     &be_const_str_solidified,
-    ( &(const binstruction[56]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x8C100302,  //  0002  GETMET	R4	R1	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x7C080400,  //  0004  CALL	R2	2
-      0x4C0C0000,  //  0005  LDNIL	R3
-      0x1C0C0403,  //  0006  EQ	R3	R2	R3
-      0x780E0000,  //  0007  JMPF	R3	#0009
-      0x80000600,  //  0008  RET	0
-      0x600C0010,  //  0009  GETGBL	R3	G16
-      0x5C100400,  //  000A  MOVE	R4	R2
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0xA8020023,  //  000C  EXBLK	0	#0031
-      0x5C100600,  //  000D  MOVE	R4	R3
-      0x7C100000,  //  000E  CALL	R4	0
-      0x88140100,  //  000F  GETMBR	R5	R0	K0
-      0x8C140B03,  //  0010  GETMET	R5	R5	K3
-      0x5C1C0800,  //  0011  MOVE	R7	R4
-      0x7C140400,  //  0012  CALL	R5	2
-      0x4C180000,  //  0013  LDNIL	R6
-      0x20180A06,  //  0014  NE	R6	R5	R6
-      0x781A0019,  //  0015  JMPF	R6	#0030
-      0xB81A0800,  //  0016  GETNGBL	R6	K4
-      0x8C180D05,  //  0017  GETMET	R6	R6	K5
-      0x8C200B07,  //  0018  GETMET	R8	R5	K7
-      0x7C200200,  //  0019  CALL	R8	1
-      0x8C201108,  //  001A  GETMET	R8	R8	K8
-      0x7C200200,  //  001B  CALL	R8	1
-      0x8C201109,  //  001C  GETMET	R8	R8	K9
-      0x7C200200,  //  001D  CALL	R8	1
-      0x8C20110A,  //  001E  GETMET	R8	R8	K10
-      0x7C200200,  //  001F  CALL	R8	1
-      0x00220C08,  //  0020  ADD	R8	K6	R8
-      0x5824000B,  //  0021  LDCONST	R9	K11
-      0x7C180600,  //  0022  CALL	R6	3
-      0x8818010C,  //  0023  GETMBR	R6	R0	K12
-      0x88180D0D,  //  0024  GETMBR	R6	R6	K13
-      0x88180D0E,  //  0025  GETMBR	R6	R6	K14
-      0x8C180D0F,  //  0026  GETMET	R6	R6	K15
-      0x5C200A00,  //  0027  MOVE	R8	R5
-      0x7C180400,  //  0028  CALL	R6	2
-      0x8C180110,  //  0029  GETMET	R6	R0	K16
-      0x5C200A00,  //  002A  MOVE	R8	R5
-      0x7C180400,  //  002B  CALL	R6	2
-      0x88180100,  //  002C  GETMBR	R6	R0	K0
-      0x8C180D11,  //  002D  GETMET	R6	R6	K17
-      0x5C200A00,  //  002E  MOVE	R8	R5
-      0x7C180400,  //  002F  CALL	R6	2
-      0x7001FFDB,  //  0030  JMP		#000D
-      0x580C0012,  //  0031  LDCONST	R3	K18
-      0xAC0C0200,  //  0032  CATCH	R3	1	0
-      0xB0080000,  //  0033  RAISE	2	R0	R0
-      0x880C0100,  //  0034  GETMBR	R3	R0	K0
-      0x8C0C0713,  //  0035  GETMET	R3	R3	K19
-      0x7C0C0200,  //  0036  CALL	R3	1
-      0x80000000,  //  0037  RET	0
+    ( &(const binstruction[33]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x20080202,  //  0001  NE	R2	R1	R2
+      0x780A0019,  //  0002  JMPF	R2	#001D
+      0xB80A0000,  //  0003  GETNGBL	R2	K0
+      0x8C080501,  //  0004  GETMET	R2	R2	K1
+      0x8C100303,  //  0005  GETMET	R4	R1	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C100905,  //  0009  GETMET	R4	R4	K5
+      0x7C100200,  //  000A  CALL	R4	1
+      0x8C100906,  //  000B  GETMET	R4	R4	K6
+      0x7C100200,  //  000C  CALL	R4	1
+      0x00120404,  //  000D  ADD	R4	K2	R4
+      0x58140007,  //  000E  LDCONST	R5	K7
+      0x7C080600,  //  000F  CALL	R2	3
+      0x88080108,  //  0010  GETMBR	R2	R0	K8
+      0x88080509,  //  0011  GETMBR	R2	R2	K9
+      0x8808050A,  //  0012  GETMBR	R2	R2	K10
+      0x8C08050B,  //  0013  GETMET	R2	R2	K11
+      0x5C100200,  //  0014  MOVE	R4	R1
+      0x7C080400,  //  0015  CALL	R2	2
+      0x8C08010C,  //  0016  GETMET	R2	R0	K12
+      0x5C100200,  //  0017  MOVE	R4	R1
+      0x7C080400,  //  0018  CALL	R2	2
+      0x8808010D,  //  0019  GETMBR	R2	R0	K13
+      0x8C08050E,  //  001A  GETMET	R2	R2	K14
+      0x5C100200,  //  001B  MOVE	R4	R1
+      0x7C080400,  //  001C  CALL	R2	2
+      0x8808010D,  //  001D  GETMBR	R2	R0	K13
+      0x8C08050F,  //  001E  GETMET	R2	R2	K15
+      0x7C080200,  //  001F  CALL	R2	1
+      0x80000000,  //  0020  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -292,8 +292,8 @@ be_local_closure(Matter_IM_process_timed_request,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_attributedata2raw,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
+    11,                          /* nstack */
+    5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -311,29 +311,30 @@ be_local_closure(Matter_IM_attributedata2raw,   /* name */
     }),
     be_str_weak(attributedata2raw),
     &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x8C100300,  //  0000  GETMET	R4	R1	K0
-      0x58180001,  //  0001  LDCONST	R6	K1
-      0x541DFFFB,  //  0002  LDINT	R7	-4
-      0x7C100600,  //  0003  CALL	R4	3
-      0x8C100300,  //  0004  GETMET	R4	R1	K0
-      0x58180002,  //  0005  LDCONST	R6	K2
-      0x541DFFFD,  //  0006  LDINT	R7	-2
-      0x7C100600,  //  0007  CALL	R4	3
-      0x8C100103,  //  0008  GETMET	R4	R0	K3
-      0x5C180200,  //  0009  MOVE	R6	R1
-      0x5C1C0400,  //  000A  MOVE	R7	R2
-      0x58200002,  //  000B  LDCONST	R8	K2
-      0x7C100800,  //  000C  CALL	R4	4
-      0x900E0905,  //  000D  SETMBR	R3	K4	K5
-      0x8C100706,  //  000E  GETMET	R4	R3	K6
-      0x5C180200,  //  000F  MOVE	R6	R1
-      0x7C100400,  //  0010  CALL	R4	2
-      0x8C100300,  //  0011  GETMET	R4	R1	K0
-      0x541A1817,  //  0012  LDINT	R6	6168
-      0x541DFFFD,  //  0013  LDINT	R7	-2
-      0x7C100600,  //  0014  CALL	R4	3
-      0x80000000,  //  0015  RET	0
+    ( &(const binstruction[23]) {  /* code */
+      0x8C140300,  //  0000  GETMET	R5	R1	K0
+      0x581C0001,  //  0001  LDCONST	R7	K1
+      0x5421FFFB,  //  0002  LDINT	R8	-4
+      0x7C140600,  //  0003  CALL	R5	3
+      0x8C140300,  //  0004  GETMET	R5	R1	K0
+      0x581C0002,  //  0005  LDCONST	R7	K2
+      0x5421FFFD,  //  0006  LDINT	R8	-2
+      0x7C140600,  //  0007  CALL	R5	3
+      0x8C140103,  //  0008  GETMET	R5	R0	K3
+      0x5C1C0200,  //  0009  MOVE	R7	R1
+      0x5C200400,  //  000A  MOVE	R8	R2
+      0x58240002,  //  000B  LDCONST	R9	K2
+      0x5C280800,  //  000C  MOVE	R10	R4
+      0x7C140A00,  //  000D  CALL	R5	5
+      0x900E0905,  //  000E  SETMBR	R3	K4	K5
+      0x8C140706,  //  000F  GETMET	R5	R3	K6
+      0x5C1C0200,  //  0010  MOVE	R7	R1
+      0x7C140400,  //  0011  CALL	R5	2
+      0x8C140300,  //  0012  GETMET	R5	R1	K0
+      0x541E1817,  //  0013  LDINT	R7	6168
+      0x5421FFFD,  //  0014  LDINT	R8	-2
+      0x7C140600,  //  0015  CALL	R5	3
+      0x80000000,  //  0016  RET	0
     })
   )
 );
@@ -1177,7 +1178,7 @@ be_local_closure(Matter_IM_process_read_request,   /* name */
     }),
     be_str_weak(process_read_request),
     &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
+    ( &(const binstruction[26]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x880C0701,  //  0001  GETMBR	R3	R3	K1
       0x8C0C0702,  //  0002  GETMET	R3	R3	K2
@@ -1192,17 +1193,18 @@ be_local_closure(Matter_IM_process_read_request,   /* name */
       0x88100706,  //  000B  GETMBR	R4	R3	K6
       0x4C140000,  //  000C  LDNIL	R5
       0x20100805,  //  000D  NE	R4	R4	R5
-      0x78120007,  //  000E  JMPF	R4	#0017
+      0x78120008,  //  000E  JMPF	R4	#0018
       0x8C100107,  //  000F  GETMET	R4	R0	K7
       0x88180308,  //  0010  GETMBR	R6	R1	K8
       0x5C1C0600,  //  0011  MOVE	R7	R3
-      0x7C100600,  //  0012  CALL	R4	3
-      0x8C140109,  //  0013  GETMET	R5	R0	K9
-      0x5C1C0200,  //  0014  MOVE	R7	R1
-      0x5C200800,  //  0015  MOVE	R8	R4
-      0x7C140600,  //  0016  CALL	R5	3
-      0x50100200,  //  0017  LDBOOL	R4	1	0
-      0x80040800,  //  0018  RET	1	R4
+      0x5C200200,  //  0012  MOVE	R8	R1
+      0x7C100800,  //  0013  CALL	R4	4
+      0x8C140109,  //  0014  GETMET	R5	R0	K9
+      0x5C1C0200,  //  0015  MOVE	R7	R1
+      0x5C200800,  //  0016  MOVE	R8	R4
+      0x7C140600,  //  0017  CALL	R5	3
+      0x50100200,  //  0018  LDBOOL	R4	1	0
+      0x80040800,  //  0019  RET	1	R4
     })
   )
 );
@@ -1469,7 +1471,7 @@ be_local_closure(Matter_IM_process_write_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
+    ( &(const bvalue[30]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(WriteRequestMessage),
     /* K2   */  be_nested_str_weak(from_TLV),
@@ -1477,32 +1479,33 @@ be_local_closure(Matter_IM_process_write_request,   /* name */
     /* K4   */  be_nested_str_weak(device),
     /* K5   */  be_nested_str_weak(get_active_endpoints),
     /* K6   */  be_nested_str_weak(Path),
-    /* K7   */  be_nested_str_weak(write_requests),
-    /* K8   */  be_nested_str_weak(WriteResponseMessage),
-    /* K9   */  be_nested_str_weak(write_responses),
-    /* K10  */  be_nested_str_weak(path),
-    /* K11  */  be_nested_str_weak(data),
-    /* K12  */  be_nested_str_weak(endpoint),
-    /* K13  */  be_nested_str_weak(cluster),
-    /* K14  */  be_nested_str_weak(attribute),
-    /* K15  */  be_nested_str_weak(status),
-    /* K16  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    /* K17  */  be_nested_str_weak(INVALID_ACTION),
-    /* K18  */  be_nested_str_weak(get_attribute_name),
-    /* K19  */  be_nested_str_weak(tasmota),
-    /* K20  */  be_nested_str_weak(log),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
-    /* K22  */  be_nested_str_weak(_X20_X28),
-    /* K23  */  be_nested_str_weak(_X29),
-    /* K24  */  be_nested_str_weak(),
-    /* K25  */  be_const_int(3),
-    /* K26  */  be_nested_str_weak(process_attribute_expansion),
-    /* K27  */  be_nested_str_weak(stop_iteration),
-    /* K28  */  be_nested_str_weak(send_write_response),
+    /* K7   */  be_nested_str_weak(msg),
+    /* K8   */  be_nested_str_weak(write_requests),
+    /* K9   */  be_nested_str_weak(WriteResponseMessage),
+    /* K10  */  be_nested_str_weak(write_responses),
+    /* K11  */  be_nested_str_weak(path),
+    /* K12  */  be_nested_str_weak(data),
+    /* K13  */  be_nested_str_weak(endpoint),
+    /* K14  */  be_nested_str_weak(cluster),
+    /* K15  */  be_nested_str_weak(attribute),
+    /* K16  */  be_nested_str_weak(status),
+    /* K17  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+    /* K18  */  be_nested_str_weak(INVALID_ACTION),
+    /* K19  */  be_nested_str_weak(get_attribute_name),
+    /* K20  */  be_nested_str_weak(tasmota),
+    /* K21  */  be_nested_str_weak(log),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
+    /* K23  */  be_nested_str_weak(_X20_X28),
+    /* K24  */  be_nested_str_weak(_X29),
+    /* K25  */  be_nested_str_weak(),
+    /* K26  */  be_const_int(3),
+    /* K27  */  be_nested_str_weak(process_attribute_expansion),
+    /* K28  */  be_nested_str_weak(stop_iteration),
+    /* K29  */  be_nested_str_weak(send_write_response),
     }),
     be_str_weak(process_write_request),
     &be_const_str_solidified,
-    ( &(const binstruction[103]) {  /* code */
+    ( &(const binstruction[104]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x8C0C0701,  //  0001  GETMET	R3	R3	K1
       0x7C0C0200,  //  0002  CALL	R3	1
@@ -1517,95 +1520,96 @@ be_local_closure(Matter_IM_process_write_request,   /* name */
       0xB81E0000,  //  000B  GETNGBL	R7	K0
       0x8C1C0F06,  //  000C  GETMET	R7	R7	K6
       0x7C1C0200,  //  000D  CALL	R7	1
-      0x88200707,  //  000E  GETMBR	R8	R3	K7
-      0x4C240000,  //  000F  LDNIL	R9
-      0x20201009,  //  0010  NE	R8	R8	R9
-      0x78220051,  //  0011  JMPF	R8	#0064
-      0xB8220000,  //  0012  GETNGBL	R8	K0
-      0x8C201108,  //  0013  GETMET	R8	R8	K8
-      0x7C200200,  //  0014  CALL	R8	1
-      0x60240012,  //  0015  GETGBL	R9	G18
-      0x7C240000,  //  0016  CALL	R9	0
-      0x90221209,  //  0017  SETMBR	R8	K9	R9
-      0x60240010,  //  0018  GETGBL	R9	G16
-      0x88280707,  //  0019  GETMBR	R10	R3	K7
-      0x7C240200,  //  001A  CALL	R9	1
-      0xA802003D,  //  001B  EXBLK	0	#005A
-      0x5C281200,  //  001C  MOVE	R10	R9
-      0x7C280000,  //  001D  CALL	R10	0
-      0x882C150A,  //  001E  GETMBR	R11	R10	K10
-      0x8830150B,  //  001F  GETMBR	R12	R10	K11
-      0x8834170C,  //  0020  GETMBR	R13	R11	K12
-      0x901E180D,  //  0021  SETMBR	R7	K12	R13
-      0x8834170D,  //  0022  GETMBR	R13	R11	K13
-      0x901E1A0D,  //  0023  SETMBR	R7	K13	R13
-      0x8834170E,  //  0024  GETMBR	R13	R11	K14
-      0x901E1C0D,  //  0025  SETMBR	R7	K14	R13
-      0xB8360000,  //  0026  GETNGBL	R13	K0
-      0x88341B10,  //  0027  GETMBR	R13	R13	K16
-      0x901E1E0D,  //  0028  SETMBR	R7	K15	R13
-      0x88340F0D,  //  0029  GETMBR	R13	R7	K13
-      0x4C380000,  //  002A  LDNIL	R14
-      0x1C341A0E,  //  002B  EQ	R13	R13	R14
-      0x74360003,  //  002C  JMPT	R13	#0031
-      0x88340F0E,  //  002D  GETMBR	R13	R7	K14
-      0x4C380000,  //  002E  LDNIL	R14
-      0x1C341A0E,  //  002F  EQ	R13	R13	R14
-      0x7836000A,  //  0030  JMPF	R13	#003C
-      0xB8360000,  //  0031  GETNGBL	R13	K0
-      0x88341B11,  //  0032  GETMBR	R13	R13	K17
-      0x901E1E0D,  //  0033  SETMBR	R7	K15	R13
-      0x5C340C00,  //  0034  MOVE	R13	R6
-      0x5C381000,  //  0035  MOVE	R14	R8
-      0x4C3C0000,  //  0036  LDNIL	R15
-      0x5C400E00,  //  0037  MOVE	R16	R7
-      0x4C440000,  //  0038  LDNIL	R17
-      0x50480200,  //  0039  LDBOOL	R18	1	0
-      0x7C340A00,  //  003A  CALL	R13	5
-      0x7001FFDF,  //  003B  JMP		#001C
-      0x88340F0C,  //  003C  GETMBR	R13	R7	K12
-      0x4C380000,  //  003D  LDNIL	R14
-      0x1C341A0E,  //  003E  EQ	R13	R13	R14
-      0x78360012,  //  003F  JMPF	R13	#0053
-      0xB8360000,  //  0040  GETNGBL	R13	K0
-      0x8C341B12,  //  0041  GETMET	R13	R13	K18
-      0x883C0F0D,  //  0042  GETMBR	R15	R7	K13
-      0x88400F0E,  //  0043  GETMBR	R16	R7	K14
-      0x7C340600,  //  0044  CALL	R13	3
-      0xB83A2600,  //  0045  GETNGBL	R14	K19
-      0x8C381D14,  //  0046  GETMET	R14	R14	K20
-      0x60400008,  //  0047  GETGBL	R16	G8
-      0x5C440E00,  //  0048  MOVE	R17	R7
-      0x7C400200,  //  0049  CALL	R16	1
-      0x00422A10,  //  004A  ADD	R16	K21	R16
-      0x78360002,  //  004B  JMPF	R13	#004F
-      0x00462C0D,  //  004C  ADD	R17	K22	R13
-      0x00442317,  //  004D  ADD	R17	R17	K23
-      0x70020000,  //  004E  JMP		#0050
-      0x58440018,  //  004F  LDCONST	R17	K24
-      0x00402011,  //  0050  ADD	R16	R16	R17
-      0x58440019,  //  0051  LDCONST	R17	K25
-      0x7C380600,  //  0052  CALL	R14	3
-      0x88340104,  //  0053  GETMBR	R13	R0	K4
-      0x8C341B1A,  //  0054  GETMET	R13	R13	K26
-      0x5C3C0E00,  //  0055  MOVE	R15	R7
-      0x84400001,  //  0056  CLOSURE	R16	P1
-      0x7C340600,  //  0057  CALL	R13	3
-      0xA0240000,  //  0058  CLOSE	R9
-      0x7001FFC1,  //  0059  JMP		#001C
-      0x5824001B,  //  005A  LDCONST	R9	K27
-      0xAC240200,  //  005B  CATCH	R9	1	0
-      0xB0080000,  //  005C  RAISE	2	R0	R0
-      0x5C240800,  //  005D  MOVE	R9	R4
-      0x74260003,  //  005E  JMPT	R9	#0063
-      0x8C24011C,  //  005F  GETMET	R9	R0	K28
-      0x5C2C0200,  //  0060  MOVE	R11	R1
-      0x5C301000,  //  0061  MOVE	R12	R8
-      0x7C240600,  //  0062  CALL	R9	3
-      0xA0200000,  //  0063  CLOSE	R8
-      0x50200200,  //  0064  LDBOOL	R8	1	0
-      0xA0000000,  //  0065  CLOSE	R0
-      0x80041000,  //  0066  RET	1	R8
+      0x901E0E01,  //  000E  SETMBR	R7	K7	R1
+      0x88200708,  //  000F  GETMBR	R8	R3	K8
+      0x4C240000,  //  0010  LDNIL	R9
+      0x20201009,  //  0011  NE	R8	R8	R9
+      0x78220051,  //  0012  JMPF	R8	#0065
+      0xB8220000,  //  0013  GETNGBL	R8	K0
+      0x8C201109,  //  0014  GETMET	R8	R8	K9
+      0x7C200200,  //  0015  CALL	R8	1
+      0x60240012,  //  0016  GETGBL	R9	G18
+      0x7C240000,  //  0017  CALL	R9	0
+      0x90221409,  //  0018  SETMBR	R8	K10	R9
+      0x60240010,  //  0019  GETGBL	R9	G16
+      0x88280708,  //  001A  GETMBR	R10	R3	K8
+      0x7C240200,  //  001B  CALL	R9	1
+      0xA802003D,  //  001C  EXBLK	0	#005B
+      0x5C281200,  //  001D  MOVE	R10	R9
+      0x7C280000,  //  001E  CALL	R10	0
+      0x882C150B,  //  001F  GETMBR	R11	R10	K11
+      0x8830150C,  //  0020  GETMBR	R12	R10	K12
+      0x8834170D,  //  0021  GETMBR	R13	R11	K13
+      0x901E1A0D,  //  0022  SETMBR	R7	K13	R13
+      0x8834170E,  //  0023  GETMBR	R13	R11	K14
+      0x901E1C0D,  //  0024  SETMBR	R7	K14	R13
+      0x8834170F,  //  0025  GETMBR	R13	R11	K15
+      0x901E1E0D,  //  0026  SETMBR	R7	K15	R13
+      0xB8360000,  //  0027  GETNGBL	R13	K0
+      0x88341B11,  //  0028  GETMBR	R13	R13	K17
+      0x901E200D,  //  0029  SETMBR	R7	K16	R13
+      0x88340F0E,  //  002A  GETMBR	R13	R7	K14
+      0x4C380000,  //  002B  LDNIL	R14
+      0x1C341A0E,  //  002C  EQ	R13	R13	R14
+      0x74360003,  //  002D  JMPT	R13	#0032
+      0x88340F0F,  //  002E  GETMBR	R13	R7	K15
+      0x4C380000,  //  002F  LDNIL	R14
+      0x1C341A0E,  //  0030  EQ	R13	R13	R14
+      0x7836000A,  //  0031  JMPF	R13	#003D
+      0xB8360000,  //  0032  GETNGBL	R13	K0
+      0x88341B12,  //  0033  GETMBR	R13	R13	K18
+      0x901E200D,  //  0034  SETMBR	R7	K16	R13
+      0x5C340C00,  //  0035  MOVE	R13	R6
+      0x5C381000,  //  0036  MOVE	R14	R8
+      0x4C3C0000,  //  0037  LDNIL	R15
+      0x5C400E00,  //  0038  MOVE	R16	R7
+      0x4C440000,  //  0039  LDNIL	R17
+      0x50480200,  //  003A  LDBOOL	R18	1	0
+      0x7C340A00,  //  003B  CALL	R13	5
+      0x7001FFDF,  //  003C  JMP		#001D
+      0x88340F0D,  //  003D  GETMBR	R13	R7	K13
+      0x4C380000,  //  003E  LDNIL	R14
+      0x1C341A0E,  //  003F  EQ	R13	R13	R14
+      0x78360012,  //  0040  JMPF	R13	#0054
+      0xB8360000,  //  0041  GETNGBL	R13	K0
+      0x8C341B13,  //  0042  GETMET	R13	R13	K19
+      0x883C0F0E,  //  0043  GETMBR	R15	R7	K14
+      0x88400F0F,  //  0044  GETMBR	R16	R7	K15
+      0x7C340600,  //  0045  CALL	R13	3
+      0xB83A2800,  //  0046  GETNGBL	R14	K20
+      0x8C381D15,  //  0047  GETMET	R14	R14	K21
+      0x60400008,  //  0048  GETGBL	R16	G8
+      0x5C440E00,  //  0049  MOVE	R17	R7
+      0x7C400200,  //  004A  CALL	R16	1
+      0x00422C10,  //  004B  ADD	R16	K22	R16
+      0x78360002,  //  004C  JMPF	R13	#0050
+      0x00462E0D,  //  004D  ADD	R17	K23	R13
+      0x00442318,  //  004E  ADD	R17	R17	K24
+      0x70020000,  //  004F  JMP		#0051
+      0x58440019,  //  0050  LDCONST	R17	K25
+      0x00402011,  //  0051  ADD	R16	R16	R17
+      0x5844001A,  //  0052  LDCONST	R17	K26
+      0x7C380600,  //  0053  CALL	R14	3
+      0x88340104,  //  0054  GETMBR	R13	R0	K4
+      0x8C341B1B,  //  0055  GETMET	R13	R13	K27
+      0x5C3C0E00,  //  0056  MOVE	R15	R7
+      0x84400001,  //  0057  CLOSURE	R16	P1
+      0x7C340600,  //  0058  CALL	R13	3
+      0xA0240000,  //  0059  CLOSE	R9
+      0x7001FFC1,  //  005A  JMP		#001D
+      0x5824001C,  //  005B  LDCONST	R9	K28
+      0xAC240200,  //  005C  CATCH	R9	1	0
+      0xB0080000,  //  005D  RAISE	2	R0	R0
+      0x5C240800,  //  005E  MOVE	R9	R4
+      0x74260003,  //  005F  JMPT	R9	#0064
+      0x8C24011D,  //  0060  GETMET	R9	R0	K29
+      0x5C2C0200,  //  0061  MOVE	R11	R1
+      0x5C301000,  //  0062  MOVE	R12	R8
+      0x7C240600,  //  0063  CALL	R9	3
+      0xA0200000,  //  0064  CLOSE	R8
+      0x50200200,  //  0065  LDBOOL	R8	1	0
+      0xA0000000,  //  0066  CLOSE	R0
+      0x80041000,  //  0067  RET	1	R8
     })
   )
 );
@@ -1617,8 +1621,8 @@ be_local_closure(Matter_IM_process_write_request,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_path2raw,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    4,                          /* argc */
+    9,                          /* nstack */
+    5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1635,109 +1639,114 @@ be_local_closure(Matter_IM_path2raw,   /* name */
     }),
     be_str_weak(path2raw),
     &be_const_str_solidified,
-    ( &(const binstruction[102]) {  /* code */
-      0x8C100300,  //  0000  GETMET	R4	R1	K0
-      0x541A0036,  //  0001  LDINT	R6	55
-      0x581C0001,  //  0002  LDCONST	R7	K1
-      0x7C100600,  //  0003  CALL	R4	3
-      0x8C100300,  //  0004  GETMET	R4	R1	K0
-      0x5C180600,  //  0005  MOVE	R6	R3
-      0x581C0001,  //  0006  LDCONST	R7	K1
-      0x7C100600,  //  0007  CALL	R4	3
-      0x88100502,  //  0008  GETMBR	R4	R2	K2
-      0x541600FE,  //  0009  LDINT	R5	255
-      0x18100805,  //  000A  LE	R4	R4	R5
-      0x78120008,  //  000B  JMPF	R4	#0015
-      0x8C100300,  //  000C  GETMET	R4	R1	K0
-      0x541A2401,  //  000D  LDINT	R6	9218
-      0x541DFFFD,  //  000E  LDINT	R7	-2
-      0x7C100600,  //  000F  CALL	R4	3
-      0x8C100300,  //  0010  GETMET	R4	R1	K0
-      0x88180502,  //  0011  GETMBR	R6	R2	K2
-      0x581C0001,  //  0012  LDCONST	R7	K1
-      0x7C100600,  //  0013  CALL	R4	3
+    ( &(const binstruction[107]) {  /* code */
+      0x8C140300,  //  0000  GETMET	R5	R1	K0
+      0x541E0036,  //  0001  LDINT	R7	55
+      0x58200001,  //  0002  LDCONST	R8	K1
+      0x7C140600,  //  0003  CALL	R5	3
+      0x8C140300,  //  0004  GETMET	R5	R1	K0
+      0x5C1C0600,  //  0005  MOVE	R7	R3
+      0x58200001,  //  0006  LDCONST	R8	K1
+      0x7C140600,  //  0007  CALL	R5	3
+      0x88140502,  //  0008  GETMBR	R5	R2	K2
+      0x541A00FE,  //  0009  LDINT	R6	255
+      0x18140A06,  //  000A  LE	R5	R5	R6
+      0x78160008,  //  000B  JMPF	R5	#0015
+      0x8C140300,  //  000C  GETMET	R5	R1	K0
+      0x541E2401,  //  000D  LDINT	R7	9218
+      0x5421FFFD,  //  000E  LDINT	R8	-2
+      0x7C140600,  //  000F  CALL	R5	3
+      0x8C140300,  //  0010  GETMET	R5	R1	K0
+      0x881C0502,  //  0011  GETMBR	R7	R2	K2
+      0x58200001,  //  0012  LDCONST	R8	K1
+      0x7C140600,  //  0013  CALL	R5	3
       0x70020007,  //  0014  JMP		#001D
-      0x8C100300,  //  0015  GETMET	R4	R1	K0
-      0x541A2501,  //  0016  LDINT	R6	9474
-      0x541DFFFD,  //  0017  LDINT	R7	-2
-      0x7C100600,  //  0018  CALL	R4	3
-      0x8C100300,  //  0019  GETMET	R4	R1	K0
-      0x88180502,  //  001A  GETMBR	R6	R2	K2
-      0x581C0003,  //  001B  LDCONST	R7	K3
-      0x7C100600,  //  001C  CALL	R4	3
-      0x88100504,  //  001D  GETMBR	R4	R2	K4
-      0x541600FE,  //  001E  LDINT	R5	255
-      0x18100805,  //  001F  LE	R4	R4	R5
-      0x78120008,  //  0020  JMPF	R4	#002A
-      0x8C100300,  //  0021  GETMET	R4	R1	K0
-      0x541A2402,  //  0022  LDINT	R6	9219
-      0x541DFFFD,  //  0023  LDINT	R7	-2
-      0x7C100600,  //  0024  CALL	R4	3
-      0x8C100300,  //  0025  GETMET	R4	R1	K0
-      0x88180504,  //  0026  GETMBR	R6	R2	K4
-      0x581C0001,  //  0027  LDCONST	R7	K1
-      0x7C100600,  //  0028  CALL	R4	3
+      0x8C140300,  //  0015  GETMET	R5	R1	K0
+      0x541E2501,  //  0016  LDINT	R7	9474
+      0x5421FFFD,  //  0017  LDINT	R8	-2
+      0x7C140600,  //  0018  CALL	R5	3
+      0x8C140300,  //  0019  GETMET	R5	R1	K0
+      0x881C0502,  //  001A  GETMBR	R7	R2	K2
+      0x58200003,  //  001B  LDCONST	R8	K3
+      0x7C140600,  //  001C  CALL	R5	3
+      0x88140504,  //  001D  GETMBR	R5	R2	K4
+      0x541A00FE,  //  001E  LDINT	R6	255
+      0x18140A06,  //  001F  LE	R5	R5	R6
+      0x78160008,  //  0020  JMPF	R5	#002A
+      0x8C140300,  //  0021  GETMET	R5	R1	K0
+      0x541E2402,  //  0022  LDINT	R7	9219
+      0x5421FFFD,  //  0023  LDINT	R8	-2
+      0x7C140600,  //  0024  CALL	R5	3
+      0x8C140300,  //  0025  GETMET	R5	R1	K0
+      0x881C0504,  //  0026  GETMBR	R7	R2	K4
+      0x58200001,  //  0027  LDCONST	R8	K1
+      0x7C140600,  //  0028  CALL	R5	3
       0x70020014,  //  0029  JMP		#003F
-      0x88100504,  //  002A  GETMBR	R4	R2	K4
-      0x5416FFFE,  //  002B  LDINT	R5	65535
-      0x18100805,  //  002C  LE	R4	R4	R5
-      0x78120008,  //  002D  JMPF	R4	#0037
-      0x8C100300,  //  002E  GETMET	R4	R1	K0
-      0x541A2502,  //  002F  LDINT	R6	9475
-      0x541DFFFD,  //  0030  LDINT	R7	-2
-      0x7C100600,  //  0031  CALL	R4	3
-      0x8C100300,  //  0032  GETMET	R4	R1	K0
-      0x88180504,  //  0033  GETMBR	R6	R2	K4
-      0x581C0003,  //  0034  LDCONST	R7	K3
-      0x7C100600,  //  0035  CALL	R4	3
+      0x88140504,  //  002A  GETMBR	R5	R2	K4
+      0x541AFFFE,  //  002B  LDINT	R6	65535
+      0x18140A06,  //  002C  LE	R5	R5	R6
+      0x78160008,  //  002D  JMPF	R5	#0037
+      0x8C140300,  //  002E  GETMET	R5	R1	K0
+      0x541E2502,  //  002F  LDINT	R7	9475
+      0x5421FFFD,  //  0030  LDINT	R8	-2
+      0x7C140600,  //  0031  CALL	R5	3
+      0x8C140300,  //  0032  GETMET	R5	R1	K0
+      0x881C0504,  //  0033  GETMBR	R7	R2	K4
+      0x58200003,  //  0034  LDCONST	R8	K3
+      0x7C140600,  //  0035  CALL	R5	3
       0x70020007,  //  0036  JMP		#003F
-      0x8C100300,  //  0037  GETMET	R4	R1	K0
-      0x541A2602,  //  0038  LDINT	R6	9731
-      0x541DFFFD,  //  0039  LDINT	R7	-2
-      0x7C100600,  //  003A  CALL	R4	3
-      0x8C100300,  //  003B  GETMET	R4	R1	K0
-      0x88180504,  //  003C  GETMBR	R6	R2	K4
-      0x541E0003,  //  003D  LDINT	R7	4
-      0x7C100600,  //  003E  CALL	R4	3
-      0x88100505,  //  003F  GETMBR	R4	R2	K5
-      0x541600FE,  //  0040  LDINT	R5	255
-      0x18100805,  //  0041  LE	R4	R4	R5
-      0x78120008,  //  0042  JMPF	R4	#004C
-      0x8C100300,  //  0043  GETMET	R4	R1	K0
-      0x541A2403,  //  0044  LDINT	R6	9220
-      0x541DFFFD,  //  0045  LDINT	R7	-2
-      0x7C100600,  //  0046  CALL	R4	3
-      0x8C100300,  //  0047  GETMET	R4	R1	K0
-      0x88180505,  //  0048  GETMBR	R6	R2	K5
-      0x581C0001,  //  0049  LDCONST	R7	K1
-      0x7C100600,  //  004A  CALL	R4	3
+      0x8C140300,  //  0037  GETMET	R5	R1	K0
+      0x541E2602,  //  0038  LDINT	R7	9731
+      0x5421FFFD,  //  0039  LDINT	R8	-2
+      0x7C140600,  //  003A  CALL	R5	3
+      0x8C140300,  //  003B  GETMET	R5	R1	K0
+      0x881C0504,  //  003C  GETMBR	R7	R2	K4
+      0x54220003,  //  003D  LDINT	R8	4
+      0x7C140600,  //  003E  CALL	R5	3
+      0x88140505,  //  003F  GETMBR	R5	R2	K5
+      0x541A00FE,  //  0040  LDINT	R6	255
+      0x18140A06,  //  0041  LE	R5	R5	R6
+      0x78160008,  //  0042  JMPF	R5	#004C
+      0x8C140300,  //  0043  GETMET	R5	R1	K0
+      0x541E2403,  //  0044  LDINT	R7	9220
+      0x5421FFFD,  //  0045  LDINT	R8	-2
+      0x7C140600,  //  0046  CALL	R5	3
+      0x8C140300,  //  0047  GETMET	R5	R1	K0
+      0x881C0505,  //  0048  GETMBR	R7	R2	K5
+      0x58200001,  //  0049  LDCONST	R8	K1
+      0x7C140600,  //  004A  CALL	R5	3
       0x70020014,  //  004B  JMP		#0061
-      0x88100505,  //  004C  GETMBR	R4	R2	K5
-      0x5416FFFE,  //  004D  LDINT	R5	65535
-      0x18100805,  //  004E  LE	R4	R4	R5
-      0x78120008,  //  004F  JMPF	R4	#0059
-      0x8C100300,  //  0050  GETMET	R4	R1	K0
-      0x541A2503,  //  0051  LDINT	R6	9476
-      0x541DFFFD,  //  0052  LDINT	R7	-2
-      0x7C100600,  //  0053  CALL	R4	3
-      0x8C100300,  //  0054  GETMET	R4	R1	K0
-      0x88180505,  //  0055  GETMBR	R6	R2	K5
-      0x581C0003,  //  0056  LDCONST	R7	K3
-      0x7C100600,  //  0057  CALL	R4	3
+      0x88140505,  //  004C  GETMBR	R5	R2	K5
+      0x541AFFFE,  //  004D  LDINT	R6	65535
+      0x18140A06,  //  004E  LE	R5	R5	R6
+      0x78160008,  //  004F  JMPF	R5	#0059
+      0x8C140300,  //  0050  GETMET	R5	R1	K0
+      0x541E2503,  //  0051  LDINT	R7	9476
+      0x5421FFFD,  //  0052  LDINT	R8	-2
+      0x7C140600,  //  0053  CALL	R5	3
+      0x8C140300,  //  0054  GETMET	R5	R1	K0
+      0x881C0505,  //  0055  GETMBR	R7	R2	K5
+      0x58200003,  //  0056  LDCONST	R8	K3
+      0x7C140600,  //  0057  CALL	R5	3
       0x70020007,  //  0058  JMP		#0061
-      0x8C100300,  //  0059  GETMET	R4	R1	K0
-      0x541A2603,  //  005A  LDINT	R6	9732
-      0x541DFFFD,  //  005B  LDINT	R7	-2
-      0x7C100600,  //  005C  CALL	R4	3
-      0x8C100300,  //  005D  GETMET	R4	R1	K0
-      0x88180505,  //  005E  GETMBR	R6	R2	K5
-      0x541E0003,  //  005F  LDINT	R7	4
-      0x7C100600,  //  0060  CALL	R4	3
-      0x8C100300,  //  0061  GETMET	R4	R1	K0
-      0x541A0017,  //  0062  LDINT	R6	24
-      0x581C0001,  //  0063  LDCONST	R7	K1
-      0x7C100600,  //  0064  CALL	R4	3
-      0x80000000,  //  0065  RET	0
+      0x8C140300,  //  0059  GETMET	R5	R1	K0
+      0x541E2603,  //  005A  LDINT	R7	9732
+      0x5421FFFD,  //  005B  LDINT	R8	-2
+      0x7C140600,  //  005C  CALL	R5	3
+      0x8C140300,  //  005D  GETMET	R5	R1	K0
+      0x881C0505,  //  005E  GETMBR	R7	R2	K5
+      0x54220003,  //  005F  LDINT	R8	4
+      0x7C140600,  //  0060  CALL	R5	3
+      0x78120003,  //  0061  JMPF	R4	#0066
+      0x8C140300,  //  0062  GETMET	R5	R1	K0
+      0x541E3404,  //  0063  LDINT	R7	13317
+      0x5421FFFD,  //  0064  LDINT	R8	-2
+      0x7C140600,  //  0065  CALL	R5	3
+      0x8C140300,  //  0066  GETMET	R5	R1	K0
+      0x541E0017,  //  0067  LDINT	R7	24
+      0x58200001,  //  0068  LDCONST	R8	K1
+      0x7C140600,  //  0069  CALL	R5	3
+      0x80000000,  //  006A  RET	0
     })
   )
 );
@@ -1786,7 +1795,7 @@ be_local_closure(Matter_IM_send_subscribe_update,   /* name */
     }),
     be_str_weak(send_subscribe_update),
     &be_const_str_solidified,
-    ( &(const binstruction[66]) {  /* code */
+    ( &(const binstruction[67]) {  /* code */
       0x88080300,  //  0000  GETMBR	R2	R1	K0
       0xB80E0200,  //  0001  GETNGBL	R3	K1
       0x8C0C0702,  //  0002  GETMET	R3	R3	K2
@@ -1833,26 +1842,27 @@ be_local_closure(Matter_IM_send_subscribe_update,   /* name */
       0x8C100113,  //  002B  GETMET	R4	R0	K19
       0x5C180400,  //  002C  MOVE	R6	R2
       0x5C1C0600,  //  002D  MOVE	R7	R3
-      0x7C100600,  //  002E  CALL	R4	3
-      0x50140000,  //  002F  LDBOOL	R5	0	0
-      0x90122805,  //  0030  SETMBR	R4	K20	R5
-      0x88140310,  //  0031  GETMBR	R5	R1	K16
-      0x90122005,  //  0032  SETMBR	R4	K16	R5
-      0xB8160200,  //  0033  GETNGBL	R5	K1
-      0x8C140B15,  //  0034  GETMET	R5	R5	K21
-      0x881C0516,  //  0035  GETMBR	R7	R2	K22
-      0x5C200400,  //  0036  MOVE	R8	R2
-      0x5C240800,  //  0037  MOVE	R9	R4
-      0x5C280200,  //  0038  MOVE	R10	R1
-      0x7C140A00,  //  0039  CALL	R5	5
-      0x88180117,  //  003A  GETMBR	R6	R0	K23
-      0x8C180D0A,  //  003B  GETMET	R6	R6	K10
-      0x5C200A00,  //  003C  MOVE	R8	R5
-      0x7C180400,  //  003D  CALL	R6	2
-      0x8C180118,  //  003E  GETMET	R6	R0	K24
-      0x88200516,  //  003F  GETMBR	R8	R2	K22
-      0x7C180400,  //  0040  CALL	R6	2
-      0x80000000,  //  0041  RET	0
+      0x4C200000,  //  002E  LDNIL	R8
+      0x7C100800,  //  002F  CALL	R4	4
+      0x50140000,  //  0030  LDBOOL	R5	0	0
+      0x90122805,  //  0031  SETMBR	R4	K20	R5
+      0x88140310,  //  0032  GETMBR	R5	R1	K16
+      0x90122005,  //  0033  SETMBR	R4	K16	R5
+      0xB8160200,  //  0034  GETNGBL	R5	K1
+      0x8C140B15,  //  0035  GETMET	R5	R5	K21
+      0x881C0516,  //  0036  GETMBR	R7	R2	K22
+      0x5C200400,  //  0037  MOVE	R8	R2
+      0x5C240800,  //  0038  MOVE	R9	R4
+      0x5C280200,  //  0039  MOVE	R10	R1
+      0x7C140A00,  //  003A  CALL	R5	5
+      0x88180117,  //  003B  GETMBR	R6	R0	K23
+      0x8C180D0A,  //  003C  GETMET	R6	R6	K10
+      0x5C200A00,  //  003D  MOVE	R8	R5
+      0x7C180400,  //  003E  CALL	R6	2
+      0x8C180118,  //  003F  GETMET	R6	R0	K24
+      0x88200516,  //  0040  GETMBR	R8	R2	K22
+      0x7C180400,  //  0041  CALL	R6	2
+      0x80000000,  //  0042  RET	0
     })
   )
 );
@@ -2199,27 +2209,27 @@ be_local_closure(Matter_IM_send_status,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM__inner_process_read_request,   /* name */
   be_nested_proto(
-    18,                          /* nstack */
-    4,                          /* argc */
+    19,                          /* nstack */
+    5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
     ( &(const struct bproto*[ 2]) {
       be_nested_proto(
-        19,                          /* nstack */
+        20,                          /* nstack */
         4,                          /* argc */
         0,                          /* varg */
         1,                          /* has upvals */
         ( &(const bupvaldesc[ 3]) {  /* upvals */
           be_local_const_upval(1, 1),
           be_local_const_upval(1, 0),
-          be_local_const_upval(1, 3),
+          be_local_const_upval(1, 4),
         }),
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
-        ( &(const bvalue[28]) {     /* constants */
+        ( &(const bvalue[35]) {     /* constants */
         /* K0   */  be_nested_str_weak(matter),
         /* K1   */  be_nested_str_weak(TLV),
         /* K2   */  be_nested_str_weak(get_attribute_name),
@@ -2231,27 +2241,34 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
         /* K8   */  be_nested_str_weak(read_attribute),
         /* K9   */  be_nested_str_weak(tlv_solo),
         /* K10  */  be_nested_str_weak(to_str_val),
-        /* K11  */  be_nested_str_weak(attributedata2raw),
-        /* K12  */  be_nested_str_weak(tasmota),
-        /* K13  */  be_nested_str_weak(log),
-        /* K14  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
-        /* K15  */  be_nested_str_weak(local_session_id),
-        /* K16  */  be_const_int(3),
-        /* K17  */  be_nested_str_weak(status),
-        /* K18  */  be_nested_str_weak(attributestatus2raw),
-        /* K19  */  be_nested_str_weak(loglevel),
-        /* K20  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
-        /* K21  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-        /* K22  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20IGNORED),
-        /* K23  */  be_nested_str_weak(attribute_reports),
-        /* K24  */  be_const_int(0),
-        /* K25  */  be_nested_str_weak(push),
-        /* K26  */  be_nested_str_weak(IM_ReportData),
-        /* K27  */  be_nested_str_weak(MAX_MESSAGE),
+        /* K11  */  be_nested_str_weak(is_list),
+        /* K12  */  be_nested_str_weak(is_array),
+        /* K13  */  be_nested_str_weak(encode_len),
+        /* K14  */  be_nested_str_weak(IM_ReportData),
+        /* K15  */  be_nested_str_weak(MAX_MESSAGE),
+        /* K16  */  be_nested_str_weak(Matter_TLV_array),
+        /* K17  */  be_nested_str_weak(attributedata2raw),
+        /* K18  */  be_nested_str_weak(push),
+        /* K19  */  be_nested_str_weak(val),
+        /* K20  */  be_nested_str_weak(stop_iteration),
+        /* K21  */  be_nested_str_weak(tasmota),
+        /* K22  */  be_nested_str_weak(log),
+        /* K23  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
+        /* K24  */  be_nested_str_weak(local_session_id),
+        /* K25  */  be_const_int(3),
+        /* K26  */  be_nested_str_weak(status),
+        /* K27  */  be_nested_str_weak(attributestatus2raw),
+        /* K28  */  be_nested_str_weak(loglevel),
+        /* K29  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
+        /* K30  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+        /* K31  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20IGNORED),
+        /* K32  */  be_const_int(0),
+        /* K33  */  be_nested_str_weak(attribute_reports),
+        /* K34  */  be_const_int(1),
         }),
         be_str_weak(read_single_attribute),
         &be_const_str_solidified,
-        ( &(const binstruction[148]) {  /* code */
+        ( &(const binstruction[233]) {  /* code */
           0xB8120000,  //  0000  GETNGBL	R4	K0
           0x88100901,  //  0001  GETMBR	R4	R4	K1
           0xB8160000,  //  0002  GETNGBL	R5	K0
@@ -2280,126 +2297,211 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
           0x4C200000,  //  0019  LDNIL	R8
           0x4C240000,  //  001A  LDNIL	R9
           0x20240C09,  //  001B  NE	R9	R6	R9
-          0x7826001C,  //  001C  JMPF	R9	#003A
-          0x8C240D0A,  //  001D  GETMET	R9	R6	K10
-          0x7C240200,  //  001E  CALL	R9	1
-          0x60280015,  //  001F  GETGBL	R10	G21
-          0x542E002F,  //  0020  LDINT	R11	48
+          0x78260054,  //  001C  JMPF	R9	#0072
+          0x58240007,  //  001D  LDCONST	R9	K7
+          0x68280002,  //  001E  GETUPV	R10	U2
+          0x742A0002,  //  001F  JMPT	R10	#0023
+          0x8C280D0A,  //  0020  GETMET	R10	R6	K10
           0x7C280200,  //  0021  CALL	R10	1
-          0x5C201400,  //  0022  MOVE	R8	R10
-          0x68280001,  //  0023  GETUPV	R10	U1
-          0x8C28150B,  //  0024  GETMET	R10	R10	K11
-          0x5C301000,  //  0025  MOVE	R12	R8
-          0x5C340400,  //  0026  MOVE	R13	R2
-          0x5C380C00,  //  0027  MOVE	R14	R6
-          0x7C280800,  //  0028  CALL	R10	4
-          0x68280002,  //  0029  GETUPV	R10	U2
-          0x742A000D,  //  002A  JMPT	R10	#0039
-          0xB82A1800,  //  002B  GETNGBL	R10	K12
-          0x8C28150D,  //  002C  GETMET	R10	R10	K13
-          0x60300018,  //  002D  GETGBL	R12	G24
-          0x5834000E,  //  002E  LDCONST	R13	K14
-          0x68380000,  //  002F  GETUPV	R14	U0
-          0x88381D0F,  //  0030  GETMBR	R14	R14	K15
-          0x603C0008,  //  0031  GETGBL	R15	G8
-          0x5C400400,  //  0032  MOVE	R16	R2
-          0x7C3C0200,  //  0033  CALL	R15	1
-          0x5C400A00,  //  0034  MOVE	R16	R5
-          0x5C441200,  //  0035  MOVE	R17	R9
-          0x7C300A00,  //  0036  CALL	R12	5
-          0x58340010,  //  0037  LDCONST	R13	K16
-          0x7C280600,  //  0038  CALL	R10	3
-          0x70020038,  //  0039  JMP		#0073
-          0x88240511,  //  003A  GETMBR	R9	R2	K17
-          0x4C280000,  //  003B  LDNIL	R10
-          0x2024120A,  //  003C  NE	R9	R9	R10
-          0x78260026,  //  003D  JMPF	R9	#0065
-          0x780E0024,  //  003E  JMPF	R3	#0064
-          0x60240015,  //  003F  GETGBL	R9	G21
-          0x542A002F,  //  0040  LDINT	R10	48
-          0x7C240200,  //  0041  CALL	R9	1
-          0x5C201200,  //  0042  MOVE	R8	R9
-          0x68240001,  //  0043  GETUPV	R9	U1
-          0x8C241312,  //  0044  GETMET	R9	R9	K18
-          0x5C2C1000,  //  0045  MOVE	R11	R8
-          0x5C300400,  //  0046  MOVE	R12	R2
-          0x88340511,  //  0047  GETMBR	R13	R2	K17
-          0x7C240800,  //  0048  CALL	R9	4
-          0xB8261800,  //  0049  GETNGBL	R9	K12
-          0x8C241313,  //  004A  GETMET	R9	R9	K19
-          0x582C0010,  //  004B  LDCONST	R11	K16
-          0x7C240400,  //  004C  CALL	R9	2
-          0x78260015,  //  004D  JMPF	R9	#0064
-          0xB8261800,  //  004E  GETNGBL	R9	K12
-          0x8C24130D,  //  004F  GETMET	R9	R9	K13
-          0x602C0018,  //  0050  GETGBL	R11	G24
-          0x58300014,  //  0051  LDCONST	R12	K20
-          0x68340000,  //  0052  GETUPV	R13	U0
-          0x88341B0F,  //  0053  GETMBR	R13	R13	K15
-          0x60380008,  //  0054  GETGBL	R14	G8
-          0x5C3C0400,  //  0055  MOVE	R15	R2
-          0x7C380200,  //  0056  CALL	R14	1
-          0x5C3C0A00,  //  0057  MOVE	R15	R5
-          0x88400511,  //  0058  GETMBR	R16	R2	K17
-          0x88440511,  //  0059  GETMBR	R17	R2	K17
-          0xB84A0000,  //  005A  GETNGBL	R18	K0
-          0x88482515,  //  005B  GETMBR	R18	R18	K21
-          0x1C442212,  //  005C  EQ	R17	R17	R18
-          0x78460001,  //  005D  JMPF	R17	#0060
-          0x58440015,  //  005E  LDCONST	R17	K21
-          0x70020000,  //  005F  JMP		#0061
-          0x58440007,  //  0060  LDCONST	R17	K7
-          0x7C2C0C00,  //  0061  CALL	R11	6
-          0x58300010,  //  0062  LDCONST	R12	K16
-          0x7C240600,  //  0063  CALL	R9	3
-          0x7002000D,  //  0064  JMP		#0073
-          0xB8261800,  //  0065  GETNGBL	R9	K12
-          0x8C24130D,  //  0066  GETMET	R9	R9	K13
-          0x602C0018,  //  0067  GETGBL	R11	G24
-          0x58300016,  //  0068  LDCONST	R12	K22
-          0x68340000,  //  0069  GETUPV	R13	U0
-          0x88341B0F,  //  006A  GETMBR	R13	R13	K15
-          0x60380008,  //  006B  GETGBL	R14	G8
-          0x5C3C0400,  //  006C  MOVE	R15	R2
-          0x7C380200,  //  006D  CALL	R14	1
-          0x5C3C0A00,  //  006E  MOVE	R15	R5
-          0x7C2C0800,  //  006F  CALL	R11	4
-          0x58300010,  //  0070  LDCONST	R12	K16
-          0x7C240600,  //  0071  CALL	R9	3
-          0x501C0000,  //  0072  LDBOOL	R7	0	0
-          0x7822001E,  //  0073  JMPF	R8	#0093
-          0x6024000C,  //  0074  GETGBL	R9	G12
-          0x88280117,  //  0075  GETMBR	R10	R0	K23
-          0x7C240200,  //  0076  CALL	R9	1
-          0x1C241318,  //  0077  EQ	R9	R9	K24
-          0x78260004,  //  0078  JMPF	R9	#007E
-          0x88240117,  //  0079  GETMBR	R9	R0	K23
-          0x8C241319,  //  007A  GETMET	R9	R9	K25
-          0x5C2C1000,  //  007B  MOVE	R11	R8
-          0x7C240400,  //  007C  CALL	R9	2
-          0x70020014,  //  007D  JMP		#0093
-          0x5425FFFE,  //  007E  LDINT	R9	-1
-          0x88280117,  //  007F  GETMBR	R10	R0	K23
-          0x94241409,  //  0080  GETIDX	R9	R10	R9
-          0x602C000C,  //  0081  GETGBL	R11	G12
-          0x5C301200,  //  0082  MOVE	R12	R9
-          0x7C2C0200,  //  0083  CALL	R11	1
-          0x6030000C,  //  0084  GETGBL	R12	G12
-          0x5C341000,  //  0085  MOVE	R13	R8
-          0x7C300200,  //  0086  CALL	R12	1
-          0x002C160C,  //  0087  ADD	R11	R11	R12
-          0xB8320000,  //  0088  GETNGBL	R12	K0
-          0x8830191A,  //  0089  GETMBR	R12	R12	K26
-          0x8830191B,  //  008A  GETMBR	R12	R12	K27
-          0x182C160C,  //  008B  LE	R11	R11	R12
-          0x782E0001,  //  008C  JMPF	R11	#008F
-          0x402C1208,  //  008D  CONNECT	R11	R9	R8
-          0x70020003,  //  008E  JMP		#0093
-          0x88280117,  //  008F  GETMBR	R10	R0	K23
-          0x8C281519,  //  0090  GETMET	R10	R10	K25
-          0x5C301000,  //  0091  MOVE	R12	R8
-          0x7C280400,  //  0092  CALL	R10	2
-          0x80040E00,  //  0093  RET	1	R7
+          0x5C241400,  //  0022  MOVE	R9	R10
+          0x88280D0B,  //  0023  GETMBR	R10	R6	K11
+          0x742A0001,  //  0024  JMPT	R10	#0027
+          0x88280D0C,  //  0025  GETMBR	R10	R6	K12
+          0x782A0031,  //  0026  JMPF	R10	#0059
+          0x8C280D0D,  //  0027  GETMET	R10	R6	K13
+          0x7C280200,  //  0028  CALL	R10	1
+          0xB82E0000,  //  0029  GETNGBL	R11	K0
+          0x882C170E,  //  002A  GETMBR	R11	R11	K14
+          0x882C170F,  //  002B  GETMBR	R11	R11	K15
+          0x2428140B,  //  002C  GT	R10	R10	R11
+          0x782A002A,  //  002D  JMPF	R10	#0059
+          0x60280012,  //  002E  GETGBL	R10	G18
+          0x7C280000,  //  002F  CALL	R10	0
+          0x5C201400,  //  0030  MOVE	R8	R10
+          0x60280015,  //  0031  GETGBL	R10	G21
+          0x542E002F,  //  0032  LDINT	R11	48
+          0x7C280200,  //  0033  CALL	R10	1
+          0x8C2C0910,  //  0034  GETMET	R11	R4	K16
+          0x7C2C0200,  //  0035  CALL	R11	1
+          0x68300001,  //  0036  GETUPV	R12	U1
+          0x8C301911,  //  0037  GETMET	R12	R12	K17
+          0x5C381400,  //  0038  MOVE	R14	R10
+          0x5C3C0400,  //  0039  MOVE	R15	R2
+          0x5C401600,  //  003A  MOVE	R16	R11
+          0x50440000,  //  003B  LDBOOL	R17	0	0
+          0x7C300A00,  //  003C  CALL	R12	5
+          0x8C301112,  //  003D  GETMET	R12	R8	K18
+          0x5C381400,  //  003E  MOVE	R14	R10
+          0x7C300400,  //  003F  CALL	R12	2
+          0x60300010,  //  0040  GETGBL	R12	G16
+          0x88340D13,  //  0041  GETMBR	R13	R6	K19
+          0x7C300200,  //  0042  CALL	R12	1
+          0xA8020010,  //  0043  EXBLK	0	#0055
+          0x5C341800,  //  0044  MOVE	R13	R12
+          0x7C340000,  //  0045  CALL	R13	0
+          0x60380015,  //  0046  GETGBL	R14	G21
+          0x543E002F,  //  0047  LDINT	R15	48
+          0x7C380200,  //  0048  CALL	R14	1
+          0x5C281C00,  //  0049  MOVE	R10	R14
+          0x68380001,  //  004A  GETUPV	R14	U1
+          0x8C381D11,  //  004B  GETMET	R14	R14	K17
+          0x5C401400,  //  004C  MOVE	R16	R10
+          0x5C440400,  //  004D  MOVE	R17	R2
+          0x5C481A00,  //  004E  MOVE	R18	R13
+          0x504C0200,  //  004F  LDBOOL	R19	1	0
+          0x7C380A00,  //  0050  CALL	R14	5
+          0x8C381112,  //  0051  GETMET	R14	R8	K18
+          0x5C401400,  //  0052  MOVE	R16	R10
+          0x7C380400,  //  0053  CALL	R14	2
+          0x7001FFEE,  //  0054  JMP		#0044
+          0x58300014,  //  0055  LDCONST	R12	K20
+          0xAC300200,  //  0056  CATCH	R12	1	0
+          0xB0080000,  //  0057  RAISE	2	R0	R0
+          0x70020009,  //  0058  JMP		#0063
+          0x60280015,  //  0059  GETGBL	R10	G21
+          0x542E002F,  //  005A  LDINT	R11	48
+          0x7C280200,  //  005B  CALL	R10	1
+          0x5C201400,  //  005C  MOVE	R8	R10
+          0x68280001,  //  005D  GETUPV	R10	U1
+          0x8C281511,  //  005E  GETMET	R10	R10	K17
+          0x5C301000,  //  005F  MOVE	R12	R8
+          0x5C340400,  //  0060  MOVE	R13	R2
+          0x5C380C00,  //  0061  MOVE	R14	R6
+          0x7C280800,  //  0062  CALL	R10	4
+          0x68280002,  //  0063  GETUPV	R10	U2
+          0x742A000B,  //  0064  JMPT	R10	#0071
+          0xB82A2A00,  //  0065  GETNGBL	R10	K21
+          0x8C281516,  //  0066  GETMET	R10	R10	K22
+          0x60300018,  //  0067  GETGBL	R12	G24
+          0x58340017,  //  0068  LDCONST	R13	K23
+          0x68380000,  //  0069  GETUPV	R14	U0
+          0x88381D18,  //  006A  GETMBR	R14	R14	K24
+          0x5C3C0400,  //  006B  MOVE	R15	R2
+          0x5C400A00,  //  006C  MOVE	R16	R5
+          0x5C441200,  //  006D  MOVE	R17	R9
+          0x7C300A00,  //  006E  CALL	R12	5
+          0x58340019,  //  006F  LDCONST	R13	K25
+          0x7C280600,  //  0070  CALL	R10	3
+          0x70020038,  //  0071  JMP		#00AB
+          0x8824051A,  //  0072  GETMBR	R9	R2	K26
+          0x4C280000,  //  0073  LDNIL	R10
+          0x2024120A,  //  0074  NE	R9	R9	R10
+          0x78260026,  //  0075  JMPF	R9	#009D
+          0x780E0024,  //  0076  JMPF	R3	#009C
+          0x60240015,  //  0077  GETGBL	R9	G21
+          0x542A002F,  //  0078  LDINT	R10	48
+          0x7C240200,  //  0079  CALL	R9	1
+          0x5C201200,  //  007A  MOVE	R8	R9
+          0x68240001,  //  007B  GETUPV	R9	U1
+          0x8C24131B,  //  007C  GETMET	R9	R9	K27
+          0x5C2C1000,  //  007D  MOVE	R11	R8
+          0x5C300400,  //  007E  MOVE	R12	R2
+          0x8834051A,  //  007F  GETMBR	R13	R2	K26
+          0x7C240800,  //  0080  CALL	R9	4
+          0xB8262A00,  //  0081  GETNGBL	R9	K21
+          0x8C24131C,  //  0082  GETMET	R9	R9	K28
+          0x582C0019,  //  0083  LDCONST	R11	K25
+          0x7C240400,  //  0084  CALL	R9	2
+          0x78260015,  //  0085  JMPF	R9	#009C
+          0xB8262A00,  //  0086  GETNGBL	R9	K21
+          0x8C241316,  //  0087  GETMET	R9	R9	K22
+          0x602C0018,  //  0088  GETGBL	R11	G24
+          0x5830001D,  //  0089  LDCONST	R12	K29
+          0x68340000,  //  008A  GETUPV	R13	U0
+          0x88341B18,  //  008B  GETMBR	R13	R13	K24
+          0x60380008,  //  008C  GETGBL	R14	G8
+          0x5C3C0400,  //  008D  MOVE	R15	R2
+          0x7C380200,  //  008E  CALL	R14	1
+          0x5C3C0A00,  //  008F  MOVE	R15	R5
+          0x8840051A,  //  0090  GETMBR	R16	R2	K26
+          0x8844051A,  //  0091  GETMBR	R17	R2	K26
+          0xB84A0000,  //  0092  GETNGBL	R18	K0
+          0x8848251E,  //  0093  GETMBR	R18	R18	K30
+          0x1C442212,  //  0094  EQ	R17	R17	R18
+          0x78460001,  //  0095  JMPF	R17	#0098
+          0x5844001E,  //  0096  LDCONST	R17	K30
+          0x70020000,  //  0097  JMP		#0099
+          0x58440007,  //  0098  LDCONST	R17	K7
+          0x7C2C0C00,  //  0099  CALL	R11	6
+          0x58300019,  //  009A  LDCONST	R12	K25
+          0x7C240600,  //  009B  CALL	R9	3
+          0x7002000D,  //  009C  JMP		#00AB
+          0xB8262A00,  //  009D  GETNGBL	R9	K21
+          0x8C241316,  //  009E  GETMET	R9	R9	K22
+          0x602C0018,  //  009F  GETGBL	R11	G24
+          0x5830001F,  //  00A0  LDCONST	R12	K31
+          0x68340000,  //  00A1  GETUPV	R13	U0
+          0x88341B18,  //  00A2  GETMBR	R13	R13	K24
+          0x60380008,  //  00A3  GETGBL	R14	G8
+          0x5C3C0400,  //  00A4  MOVE	R15	R2
+          0x7C380200,  //  00A5  CALL	R14	1
+          0x5C3C0A00,  //  00A6  MOVE	R15	R5
+          0x7C2C0800,  //  00A7  CALL	R11	4
+          0x58300019,  //  00A8  LDCONST	R12	K25
+          0x7C240600,  //  00A9  CALL	R9	3
+          0x501C0000,  //  00AA  LDBOOL	R7	0	0
+          0x6024000F,  //  00AB  GETGBL	R9	G15
+          0x5C281000,  //  00AC  MOVE	R10	R8
+          0x602C0012,  //  00AD  GETGBL	R11	G18
+          0x7C240400,  //  00AE  CALL	R9	2
+          0x78260001,  //  00AF  JMPF	R9	#00B2
+          0x58240020,  //  00B0  LDCONST	R9	K32
+          0x70020000,  //  00B1  JMP		#00B3
+          0x4C240000,  //  00B2  LDNIL	R9
+          0x4C280000,  //  00B3  LDNIL	R10
+          0x2028100A,  //  00B4  NE	R10	R8	R10
+          0x782A0031,  //  00B5  JMPF	R10	#00E8
+          0x4C280000,  //  00B6  LDNIL	R10
+          0x1C28120A,  //  00B7  EQ	R10	R9	R10
+          0x782A0001,  //  00B8  JMPF	R10	#00BB
+          0x5C281000,  //  00B9  MOVE	R10	R8
+          0x70020000,  //  00BA  JMP		#00BC
+          0x94281009,  //  00BB  GETIDX	R10	R8	R9
+          0x602C000C,  //  00BC  GETGBL	R11	G12
+          0x88300121,  //  00BD  GETMBR	R12	R0	K33
+          0x7C2C0200,  //  00BE  CALL	R11	1
+          0x1C2C1720,  //  00BF  EQ	R11	R11	K32
+          0x782E0004,  //  00C0  JMPF	R11	#00C6
+          0x882C0121,  //  00C1  GETMBR	R11	R0	K33
+          0x8C2C1712,  //  00C2  GETMET	R11	R11	K18
+          0x5C341400,  //  00C3  MOVE	R13	R10
+          0x7C2C0400,  //  00C4  CALL	R11	2
+          0x70020014,  //  00C5  JMP		#00DB
+          0x542DFFFE,  //  00C6  LDINT	R11	-1
+          0x88300121,  //  00C7  GETMBR	R12	R0	K33
+          0x942C180B,  //  00C8  GETIDX	R11	R12	R11
+          0x6034000C,  //  00C9  GETGBL	R13	G12
+          0x5C381600,  //  00CA  MOVE	R14	R11
+          0x7C340200,  //  00CB  CALL	R13	1
+          0x6038000C,  //  00CC  GETGBL	R14	G12
+          0x5C3C1400,  //  00CD  MOVE	R15	R10
+          0x7C380200,  //  00CE  CALL	R14	1
+          0x00341A0E,  //  00CF  ADD	R13	R13	R14
+          0xB83A0000,  //  00D0  GETNGBL	R14	K0
+          0x88381D0E,  //  00D1  GETMBR	R14	R14	K14
+          0x88381D0F,  //  00D2  GETMBR	R14	R14	K15
+          0x18341A0E,  //  00D3  LE	R13	R13	R14
+          0x78360001,  //  00D4  JMPF	R13	#00D7
+          0x4034160A,  //  00D5  CONNECT	R13	R11	R10
+          0x70020003,  //  00D6  JMP		#00DB
+          0x88300121,  //  00D7  GETMBR	R12	R0	K33
+          0x8C301912,  //  00D8  GETMET	R12	R12	K18
+          0x5C381400,  //  00D9  MOVE	R14	R10
+          0x7C300400,  //  00DA  CALL	R12	2
+          0x4C2C0000,  //  00DB  LDNIL	R11
+          0x1C2C120B,  //  00DC  EQ	R11	R9	R11
+          0x782E0001,  //  00DD  JMPF	R11	#00E0
+          0x4C200000,  //  00DE  LDNIL	R8
+          0x70020006,  //  00DF  JMP		#00E7
+          0x00241322,  //  00E0  ADD	R9	R9	K34
+          0x602C000C,  //  00E1  GETGBL	R11	G12
+          0x5C301000,  //  00E2  MOVE	R12	R8
+          0x7C2C0200,  //  00E3  CALL	R11	1
+          0x282C120B,  //  00E4  GE	R11	R9	R11
+          0x782E0000,  //  00E5  JMPF	R11	#00E7
+          0x4C200000,  //  00E6  LDNIL	R8
+          0x7001FFCA,  //  00E7  JMP		#00B3
+          0x80040E00,  //  00E8  RET	1	R7
         })
       ),
       be_nested_proto(
@@ -2408,8 +2510,8 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
         0,                          /* varg */
         1,                          /* has upvals */
         ( &(const bupvaldesc[ 2]) {  /* upvals */
-          be_local_const_upval(1, 4),
-          be_local_const_upval(1, 7),
+          be_local_const_upval(1, 5),
+          be_local_const_upval(1, 8),
         }),
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
@@ -2429,130 +2531,132 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
+    ( &(const bvalue[25]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
     /* K1   */  be_nested_str_weak(get_active_endpoints),
     /* K2   */  be_nested_str_weak(matter),
     /* K3   */  be_nested_str_weak(Path),
-    /* K4   */  be_nested_str_weak(ReportDataMessage),
-    /* K5   */  be_nested_str_weak(attribute_reports),
-    /* K6   */  be_nested_str_weak(attributes_requests),
-    /* K7   */  be_nested_str_weak(endpoint),
-    /* K8   */  be_nested_str_weak(cluster),
-    /* K9   */  be_nested_str_weak(attribute),
-    /* K10  */  be_nested_str_weak(fabric_filtered),
-    /* K11  */  be_nested_str_weak(status),
-    /* K12  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    /* K13  */  be_nested_str_weak(get_attribute_name),
-    /* K14  */  be_nested_str_weak(tasmota),
-    /* K15  */  be_nested_str_weak(log),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s),
-    /* K17  */  be_nested_str_weak(local_session_id),
-    /* K18  */  be_nested_str_weak(_X20_X28),
-    /* K19  */  be_nested_str_weak(_X29),
-    /* K20  */  be_nested_str_weak(),
-    /* K21  */  be_const_int(3),
-    /* K22  */  be_nested_str_weak(process_attribute_expansion),
-    /* K23  */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_nested_str_weak(msg),
+    /* K5   */  be_nested_str_weak(ReportDataMessage),
+    /* K6   */  be_nested_str_weak(attribute_reports),
+    /* K7   */  be_nested_str_weak(attributes_requests),
+    /* K8   */  be_nested_str_weak(endpoint),
+    /* K9   */  be_nested_str_weak(cluster),
+    /* K10  */  be_nested_str_weak(attribute),
+    /* K11  */  be_nested_str_weak(fabric_filtered),
+    /* K12  */  be_nested_str_weak(status),
+    /* K13  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+    /* K14  */  be_nested_str_weak(get_attribute_name),
+    /* K15  */  be_nested_str_weak(tasmota),
+    /* K16  */  be_nested_str_weak(log),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s),
+    /* K18  */  be_nested_str_weak(local_session_id),
+    /* K19  */  be_nested_str_weak(_X20_X28),
+    /* K20  */  be_nested_str_weak(_X29),
+    /* K21  */  be_nested_str_weak(),
+    /* K22  */  be_const_int(3),
+    /* K23  */  be_nested_str_weak(process_attribute_expansion),
+    /* K24  */  be_nested_str_weak(stop_iteration),
     }),
     be_str_weak(_inner_process_read_request),
     &be_const_str_solidified,
-    ( &(const binstruction[95]) {  /* code */
-      0x84100000,  //  0000  CLOSURE	R4	P0
-      0x88140100,  //  0001  GETMBR	R5	R0	K0
-      0x8C140B01,  //  0002  GETMET	R5	R5	K1
-      0x7C140200,  //  0003  CALL	R5	1
-      0xB81A0400,  //  0004  GETNGBL	R6	K2
-      0x8C180D03,  //  0005  GETMET	R6	R6	K3
-      0x7C180200,  //  0006  CALL	R6	1
-      0xB81E0400,  //  0007  GETNGBL	R7	K2
-      0x8C1C0F04,  //  0008  GETMET	R7	R7	K4
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x60200012,  //  000A  GETGBL	R8	G18
-      0x7C200000,  //  000B  CALL	R8	0
-      0x901E0A08,  //  000C  SETMBR	R7	K5	R8
-      0x60200010,  //  000D  GETGBL	R8	G16
-      0x88240506,  //  000E  GETMBR	R9	R2	K6
-      0x7C200200,  //  000F  CALL	R8	1
-      0xA8020048,  //  0010  EXBLK	0	#005A
-      0x5C241000,  //  0011  MOVE	R9	R8
-      0x7C240000,  //  0012  CALL	R9	0
-      0x88281307,  //  0013  GETMBR	R10	R9	K7
-      0x901A0E0A,  //  0014  SETMBR	R6	K7	R10
-      0x88281308,  //  0015  GETMBR	R10	R9	K8
-      0x901A100A,  //  0016  SETMBR	R6	K8	R10
-      0x88281309,  //  0017  GETMBR	R10	R9	K9
-      0x901A120A,  //  0018  SETMBR	R6	K9	R10
-      0x8828050A,  //  0019  GETMBR	R10	R2	K10
-      0x901A140A,  //  001A  SETMBR	R6	K10	R10
-      0xB82A0400,  //  001B  GETNGBL	R10	K2
-      0x8828150C,  //  001C  GETMBR	R10	R10	K12
-      0x901A160A,  //  001D  SETMBR	R6	K11	R10
-      0x88280D07,  //  001E  GETMBR	R10	R6	K7
-      0x4C2C0000,  //  001F  LDNIL	R11
-      0x1C28140B,  //  0020  EQ	R10	R10	R11
-      0x742A0007,  //  0021  JMPT	R10	#002A
-      0x88280D08,  //  0022  GETMBR	R10	R6	K8
-      0x4C2C0000,  //  0023  LDNIL	R11
-      0x1C28140B,  //  0024  EQ	R10	R10	R11
-      0x742A0003,  //  0025  JMPT	R10	#002A
-      0x88280D09,  //  0026  GETMBR	R10	R6	K9
-      0x4C2C0000,  //  0027  LDNIL	R11
-      0x1C28140B,  //  0028  EQ	R10	R10	R11
-      0x782A0029,  //  0029  JMPF	R10	#0054
-      0x88280D08,  //  002A  GETMBR	R10	R6	K8
-      0x4C2C0000,  //  002B  LDNIL	R11
-      0x2028140B,  //  002C  NE	R10	R10	R11
-      0x782A001A,  //  002D  JMPF	R10	#0049
-      0x88280D09,  //  002E  GETMBR	R10	R6	K9
-      0x4C2C0000,  //  002F  LDNIL	R11
-      0x2028140B,  //  0030  NE	R10	R10	R11
-      0x782A0016,  //  0031  JMPF	R10	#0049
-      0xB82A0400,  //  0032  GETNGBL	R10	K2
-      0x8C28150D,  //  0033  GETMET	R10	R10	K13
-      0x88300D08,  //  0034  GETMBR	R12	R6	K8
-      0x88340D09,  //  0035  GETMBR	R13	R6	K9
-      0x7C280600,  //  0036  CALL	R10	3
-      0xB82E1C00,  //  0037  GETNGBL	R11	K14
-      0x8C2C170F,  //  0038  GETMET	R11	R11	K15
-      0x60340018,  //  0039  GETGBL	R13	G24
-      0x58380010,  //  003A  LDCONST	R14	K16
-      0x883C0311,  //  003B  GETMBR	R15	R1	K17
-      0x60400008,  //  003C  GETGBL	R16	G8
-      0x5C440C00,  //  003D  MOVE	R17	R6
-      0x7C400200,  //  003E  CALL	R16	1
-      0x782A0002,  //  003F  JMPF	R10	#0043
-      0x0046240A,  //  0040  ADD	R17	K18	R10
-      0x00442313,  //  0041  ADD	R17	R17	K19
-      0x70020000,  //  0042  JMP		#0044
-      0x58440014,  //  0043  LDCONST	R17	K20
-      0x00402011,  //  0044  ADD	R16	R16	R17
-      0x7C340600,  //  0045  CALL	R13	3
-      0x58380015,  //  0046  LDCONST	R14	K21
-      0x7C2C0600,  //  0047  CALL	R11	3
-      0x7002000A,  //  0048  JMP		#0054
-      0xB82A1C00,  //  0049  GETNGBL	R10	K14
-      0x8C28150F,  //  004A  GETMET	R10	R10	K15
-      0x60300018,  //  004B  GETGBL	R12	G24
-      0x58340010,  //  004C  LDCONST	R13	K16
-      0x88380311,  //  004D  GETMBR	R14	R1	K17
-      0x603C0008,  //  004E  GETGBL	R15	G8
-      0x5C400C00,  //  004F  MOVE	R16	R6
-      0x7C3C0200,  //  0050  CALL	R15	1
-      0x7C300600,  //  0051  CALL	R12	3
-      0x58340015,  //  0052  LDCONST	R13	K21
-      0x7C280600,  //  0053  CALL	R10	3
-      0x88280100,  //  0054  GETMBR	R10	R0	K0
-      0x8C281516,  //  0055  GETMET	R10	R10	K22
-      0x5C300C00,  //  0056  MOVE	R12	R6
-      0x84340001,  //  0057  CLOSURE	R13	P1
-      0x7C280600,  //  0058  CALL	R10	3
-      0x7001FFB6,  //  0059  JMP		#0011
-      0x58200017,  //  005A  LDCONST	R8	K23
-      0xAC200200,  //  005B  CATCH	R8	1	0
-      0xB0080000,  //  005C  RAISE	2	R0	R0
-      0xA0000000,  //  005D  CLOSE	R0
-      0x80040E00,  //  005E  RET	1	R7
+    ( &(const binstruction[96]) {  /* code */
+      0x84140000,  //  0000  CLOSURE	R5	P0
+      0x88180100,  //  0001  GETMBR	R6	R0	K0
+      0x8C180D01,  //  0002  GETMET	R6	R6	K1
+      0x7C180200,  //  0003  CALL	R6	1
+      0xB81E0400,  //  0004  GETNGBL	R7	K2
+      0x8C1C0F03,  //  0005  GETMET	R7	R7	K3
+      0x7C1C0200,  //  0006  CALL	R7	1
+      0x901E0803,  //  0007  SETMBR	R7	K4	R3
+      0xB8220400,  //  0008  GETNGBL	R8	K2
+      0x8C201105,  //  0009  GETMET	R8	R8	K5
+      0x7C200200,  //  000A  CALL	R8	1
+      0x60240012,  //  000B  GETGBL	R9	G18
+      0x7C240000,  //  000C  CALL	R9	0
+      0x90220C09,  //  000D  SETMBR	R8	K6	R9
+      0x60240010,  //  000E  GETGBL	R9	G16
+      0x88280507,  //  000F  GETMBR	R10	R2	K7
+      0x7C240200,  //  0010  CALL	R9	1
+      0xA8020048,  //  0011  EXBLK	0	#005B
+      0x5C281200,  //  0012  MOVE	R10	R9
+      0x7C280000,  //  0013  CALL	R10	0
+      0x882C1508,  //  0014  GETMBR	R11	R10	K8
+      0x901E100B,  //  0015  SETMBR	R7	K8	R11
+      0x882C1509,  //  0016  GETMBR	R11	R10	K9
+      0x901E120B,  //  0017  SETMBR	R7	K9	R11
+      0x882C150A,  //  0018  GETMBR	R11	R10	K10
+      0x901E140B,  //  0019  SETMBR	R7	K10	R11
+      0x882C050B,  //  001A  GETMBR	R11	R2	K11
+      0x901E160B,  //  001B  SETMBR	R7	K11	R11
+      0xB82E0400,  //  001C  GETNGBL	R11	K2
+      0x882C170D,  //  001D  GETMBR	R11	R11	K13
+      0x901E180B,  //  001E  SETMBR	R7	K12	R11
+      0x882C0F08,  //  001F  GETMBR	R11	R7	K8
+      0x4C300000,  //  0020  LDNIL	R12
+      0x1C2C160C,  //  0021  EQ	R11	R11	R12
+      0x742E0007,  //  0022  JMPT	R11	#002B
+      0x882C0F09,  //  0023  GETMBR	R11	R7	K9
+      0x4C300000,  //  0024  LDNIL	R12
+      0x1C2C160C,  //  0025  EQ	R11	R11	R12
+      0x742E0003,  //  0026  JMPT	R11	#002B
+      0x882C0F0A,  //  0027  GETMBR	R11	R7	K10
+      0x4C300000,  //  0028  LDNIL	R12
+      0x1C2C160C,  //  0029  EQ	R11	R11	R12
+      0x782E0029,  //  002A  JMPF	R11	#0055
+      0x882C0F09,  //  002B  GETMBR	R11	R7	K9
+      0x4C300000,  //  002C  LDNIL	R12
+      0x202C160C,  //  002D  NE	R11	R11	R12
+      0x782E001A,  //  002E  JMPF	R11	#004A
+      0x882C0F0A,  //  002F  GETMBR	R11	R7	K10
+      0x4C300000,  //  0030  LDNIL	R12
+      0x202C160C,  //  0031  NE	R11	R11	R12
+      0x782E0016,  //  0032  JMPF	R11	#004A
+      0xB82E0400,  //  0033  GETNGBL	R11	K2
+      0x8C2C170E,  //  0034  GETMET	R11	R11	K14
+      0x88340F09,  //  0035  GETMBR	R13	R7	K9
+      0x88380F0A,  //  0036  GETMBR	R14	R7	K10
+      0x7C2C0600,  //  0037  CALL	R11	3
+      0xB8321E00,  //  0038  GETNGBL	R12	K15
+      0x8C301910,  //  0039  GETMET	R12	R12	K16
+      0x60380018,  //  003A  GETGBL	R14	G24
+      0x583C0011,  //  003B  LDCONST	R15	K17
+      0x88400312,  //  003C  GETMBR	R16	R1	K18
+      0x60440008,  //  003D  GETGBL	R17	G8
+      0x5C480E00,  //  003E  MOVE	R18	R7
+      0x7C440200,  //  003F  CALL	R17	1
+      0x782E0002,  //  0040  JMPF	R11	#0044
+      0x004A260B,  //  0041  ADD	R18	K19	R11
+      0x00482514,  //  0042  ADD	R18	R18	K20
+      0x70020000,  //  0043  JMP		#0045
+      0x58480015,  //  0044  LDCONST	R18	K21
+      0x00442212,  //  0045  ADD	R17	R17	R18
+      0x7C380600,  //  0046  CALL	R14	3
+      0x583C0016,  //  0047  LDCONST	R15	K22
+      0x7C300600,  //  0048  CALL	R12	3
+      0x7002000A,  //  0049  JMP		#0055
+      0xB82E1E00,  //  004A  GETNGBL	R11	K15
+      0x8C2C1710,  //  004B  GETMET	R11	R11	K16
+      0x60340018,  //  004C  GETGBL	R13	G24
+      0x58380011,  //  004D  LDCONST	R14	K17
+      0x883C0312,  //  004E  GETMBR	R15	R1	K18
+      0x60400008,  //  004F  GETGBL	R16	G8
+      0x5C440E00,  //  0050  MOVE	R17	R7
+      0x7C400200,  //  0051  CALL	R16	1
+      0x7C340600,  //  0052  CALL	R13	3
+      0x58380016,  //  0053  LDCONST	R14	K22
+      0x7C2C0600,  //  0054  CALL	R11	3
+      0x882C0100,  //  0055  GETMBR	R11	R0	K0
+      0x8C2C1717,  //  0056  GETMET	R11	R11	K23
+      0x5C340E00,  //  0057  MOVE	R13	R7
+      0x84380001,  //  0058  CLOSURE	R14	P1
+      0x7C2C0600,  //  0059  CALL	R11	3
+      0x7001FFB6,  //  005A  JMP		#0012
+      0x58240018,  //  005B  LDCONST	R9	K24
+      0xAC240200,  //  005C  CATCH	R9	1	0
+      0xB0080000,  //  005D  RAISE	2	R0	R0
+      0xA0000000,  //  005E  CLOSE	R0
+      0x80041000,  //  005F  RET	1	R8
     })
   )
 );
@@ -2809,275 +2913,317 @@ be_local_closure(Matter_IM_process_read_request_solo,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[44]) {     /* constants */
+    ( &(const bvalue[55]) {     /* constants */
     /* K0   */  be_nested_str_weak(status),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(INVALID_ACTION),
-    /* K3   */  be_nested_str_weak(device),
-    /* K4   */  be_nested_str_weak(process_attribute_read_solo),
-    /* K5   */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    /* K6   */  be_nested_str_weak(read_attribute),
-    /* K7   */  be_nested_str_weak(session),
-    /* K8   */  be_nested_str_weak(tlv_solo),
-    /* K9   */  be_nested_str_weak(profiler),
-    /* K10  */  be_nested_str_weak(log),
-    /* K11  */  be_nested_str_weak(read_request_solo_X20read_X20done),
-    /* K12  */  be_nested_str_weak(add),
-    /* K13  */  be_const_int(1),
-    /* K14  */  be_nested_str_weak(attributedata2raw),
-    /* K15  */  be_const_int(405077761),
-    /* K16  */  be_nested_str_weak(attributestatus2raw),
-    /* K17  */  be_nested_str_weak(tasmota),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X20_X2D_X20IGNORED),
-    /* K19  */  be_nested_str_weak(local_session_id),
+    /* K3   */  be_nested_str_weak(msg),
+    /* K4   */  be_nested_str_weak(device),
+    /* K5   */  be_nested_str_weak(process_attribute_read_solo),
+    /* K6   */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+    /* K7   */  be_nested_str_weak(read_attribute),
+    /* K8   */  be_nested_str_weak(session),
+    /* K9   */  be_nested_str_weak(tlv_solo),
+    /* K10  */  be_nested_str_weak(profiler),
+    /* K11  */  be_nested_str_weak(log),
+    /* K12  */  be_nested_str_weak(read_request_solo_X20read_X20done),
+    /* K13  */  be_nested_str_weak(is_list),
+    /* K14  */  be_nested_str_weak(is_array),
+    /* K15  */  be_nested_str_weak(encode_len),
+    /* K16  */  be_nested_str_weak(IM_ReportData),
+    /* K17  */  be_nested_str_weak(MAX_MESSAGE),
+    /* K18  */  be_nested_str_weak(tasmota),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Response_X20to_X20big_X2C_X20revert_X20to_X20non_X2Dsolo),
     /* K20  */  be_const_int(3),
-    /* K21  */  be_nested_str_weak(build_response),
-    /* K22  */  be_nested_str_weak(message_handler),
+    /* K21  */  be_nested_str_weak(TLV),
+    /* K22  */  be_nested_str_weak(parse),
     /* K23  */  be_nested_str_weak(raw),
-    /* K24  */  be_nested_str_weak(clear),
-    /* K25  */  be_nested_str_weak(encode_frame),
-    /* K26  */  be_nested_str_weak(encrypt),
-    /* K27  */  be_nested_str_weak(loglevel),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25i_X20exch_X3D_X25i_X20rack_X3D_X25s),
-    /* K29  */  be_nested_str_weak(message_counter),
-    /* K30  */  be_nested_str_weak(exchange_id),
-    /* K31  */  be_nested_str_weak(ack_message_counter),
-    /* K32  */  be_nested_str_weak(send_response_frame),
-    /* K33  */  be_nested_str_weak(RESPONSE_X20SENT),
-    /* K34  */  be_nested_str_weak(get_attribute_name),
-    /* K35  */  be_nested_str_weak(cluster),
-    /* K36  */  be_nested_str_weak(attribute),
-    /* K37  */  be_nested_str_weak(_X20_X28),
-    /* K38  */  be_nested_str_weak(_X29),
-    /* K39  */  be_nested_str_weak(),
-    /* K40  */  be_nested_str_weak(to_str_val),
-    /* K41  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr1_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
-    /* K42  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr1_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
-    /* K43  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr1_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20IGNORED),
+    /* K24  */  be_nested_str_weak(app_payload_idx),
+    /* K25  */  be_nested_str_weak(process_read_request),
+    /* K26  */  be_nested_str_weak(add),
+    /* K27  */  be_const_int(1),
+    /* K28  */  be_nested_str_weak(attributedata2raw),
+    /* K29  */  be_const_int(405077761),
+    /* K30  */  be_nested_str_weak(attributestatus2raw),
+    /* K31  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X20_X2D_X20IGNORED),
+    /* K32  */  be_nested_str_weak(local_session_id),
+    /* K33  */  be_nested_str_weak(build_response),
+    /* K34  */  be_nested_str_weak(message_handler),
+    /* K35  */  be_nested_str_weak(clear),
+    /* K36  */  be_nested_str_weak(encode_frame),
+    /* K37  */  be_nested_str_weak(encrypt),
+    /* K38  */  be_nested_str_weak(loglevel),
+    /* K39  */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25i_X20exch_X3D_X25i_X20rack_X3D_X25s),
+    /* K40  */  be_nested_str_weak(message_counter),
+    /* K41  */  be_nested_str_weak(exchange_id),
+    /* K42  */  be_nested_str_weak(ack_message_counter),
+    /* K43  */  be_nested_str_weak(send_response_frame),
+    /* K44  */  be_nested_str_weak(RESPONSE_X20SENT),
+    /* K45  */  be_nested_str_weak(get_attribute_name),
+    /* K46  */  be_nested_str_weak(cluster),
+    /* K47  */  be_nested_str_weak(attribute),
+    /* K48  */  be_nested_str_weak(_X20_X28),
+    /* K49  */  be_nested_str_weak(_X29),
+    /* K50  */  be_nested_str_weak(),
+    /* K51  */  be_nested_str_weak(to_str_val),
+    /* K52  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr1_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
+    /* K53  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr1_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
+    /* K54  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr1_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20IGNORED),
     }),
     be_str_weak(process_read_request_solo),
     &be_const_str_solidified,
-    ( &(const binstruction[220]) {  /* code */
+    ( &(const binstruction[251]) {  /* code */
       0xB80E0200,  //  0000  GETNGBL	R3	K1
       0x880C0702,  //  0001  GETMBR	R3	R3	K2
       0x900A0003,  //  0002  SETMBR	R2	K0	R3
-      0x880C0103,  //  0003  GETMBR	R3	R0	K3
-      0x8C0C0704,  //  0004  GETMET	R3	R3	K4
-      0x5C140400,  //  0005  MOVE	R5	R2
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x4C100000,  //  0007  LDNIL	R4
-      0x4C140000,  //  0008  LDNIL	R5
-      0x4C180000,  //  0009  LDNIL	R6
-      0x20180606,  //  000A  NE	R6	R3	R6
-      0x781A0008,  //  000B  JMPF	R6	#0015
-      0xB81A0200,  //  000C  GETNGBL	R6	K1
-      0x88180D05,  //  000D  GETMBR	R6	R6	K5
-      0x900A0006,  //  000E  SETMBR	R2	K0	R6
-      0x8C180706,  //  000F  GETMET	R6	R3	K6
-      0x88200307,  //  0010  GETMBR	R8	R1	K7
-      0x5C240400,  //  0011  MOVE	R9	R2
-      0x88280108,  //  0012  GETMBR	R10	R0	K8
-      0x7C180800,  //  0013  CALL	R6	4
-      0x5C100C00,  //  0014  MOVE	R4	R6
-      0xB81A0200,  //  0015  GETNGBL	R6	K1
-      0x88180D09,  //  0016  GETMBR	R6	R6	K9
-      0x8C180D0A,  //  0017  GETMET	R6	R6	K10
-      0x5820000B,  //  0018  LDCONST	R8	K11
-      0x7C180400,  //  0019  CALL	R6	2
-      0x4C180000,  //  001A  LDNIL	R6
-      0x20180806,  //  001B  NE	R6	R4	R6
-      0x781A0019,  //  001C  JMPF	R6	#0037
-      0x60180015,  //  001D  GETGBL	R6	G21
-      0x541E002F,  //  001E  LDINT	R7	48
-      0x7C180200,  //  001F  CALL	R6	1
-      0x5C140C00,  //  0020  MOVE	R5	R6
-      0x8C180B0C,  //  0021  GETMET	R6	R5	K12
-      0x54220014,  //  0022  LDINT	R8	21
-      0x5824000D,  //  0023  LDCONST	R9	K13
-      0x7C180600,  //  0024  CALL	R6	3
-      0x8C180B0C,  //  0025  GETMET	R6	R5	K12
-      0x54223600,  //  0026  LDINT	R8	13825
-      0x5425FFFD,  //  0027  LDINT	R9	-2
-      0x7C180600,  //  0028  CALL	R6	3
-      0x8C18010E,  //  0029  GETMET	R6	R0	K14
-      0x5C200A00,  //  002A  MOVE	R8	R5
-      0x5C240400,  //  002B  MOVE	R9	R2
-      0x5C280800,  //  002C  MOVE	R10	R4
-      0x7C180800,  //  002D  CALL	R6	4
-      0x8C180B0C,  //  002E  GETMET	R6	R5	K12
-      0x5820000F,  //  002F  LDCONST	R8	K15
-      0x5425FFFB,  //  0030  LDINT	R9	-4
-      0x7C180600,  //  0031  CALL	R6	3
-      0x8C180B0C,  //  0032  GETMET	R6	R5	K12
-      0x54220017,  //  0033  LDINT	R8	24
-      0x5824000D,  //  0034  LDCONST	R9	K13
-      0x7C180600,  //  0035  CALL	R6	3
-      0x70020029,  //  0036  JMP		#0061
-      0x88180500,  //  0037  GETMBR	R6	R2	K0
-      0x4C1C0000,  //  0038  LDNIL	R7
-      0x20180C07,  //  0039  NE	R6	R6	R7
-      0x781A0019,  //  003A  JMPF	R6	#0055
-      0x60180015,  //  003B  GETGBL	R6	G21
-      0x541E002F,  //  003C  LDINT	R7	48
-      0x7C180200,  //  003D  CALL	R6	1
-      0x5C140C00,  //  003E  MOVE	R5	R6
-      0x8C180B0C,  //  003F  GETMET	R6	R5	K12
-      0x54220014,  //  0040  LDINT	R8	21
-      0x5824000D,  //  0041  LDCONST	R9	K13
-      0x7C180600,  //  0042  CALL	R6	3
-      0x8C180B0C,  //  0043  GETMET	R6	R5	K12
-      0x54223600,  //  0044  LDINT	R8	13825
-      0x5425FFFD,  //  0045  LDINT	R9	-2
-      0x7C180600,  //  0046  CALL	R6	3
-      0x8C180110,  //  0047  GETMET	R6	R0	K16
-      0x5C200A00,  //  0048  MOVE	R8	R5
-      0x5C240400,  //  0049  MOVE	R9	R2
-      0x88280500,  //  004A  GETMBR	R10	R2	K0
-      0x7C180800,  //  004B  CALL	R6	4
-      0x8C180B0C,  //  004C  GETMET	R6	R5	K12
-      0x5820000F,  //  004D  LDCONST	R8	K15
-      0x5425FFFB,  //  004E  LDINT	R9	-4
-      0x7C180600,  //  004F  CALL	R6	3
-      0x8C180B0C,  //  0050  GETMET	R6	R5	K12
-      0x54220017,  //  0051  LDINT	R8	24
-      0x5824000D,  //  0052  LDCONST	R9	K13
-      0x7C180600,  //  0053  CALL	R6	3
-      0x7002000B,  //  0054  JMP		#0061
-      0xB81A2200,  //  0055  GETNGBL	R6	K17
-      0x8C180D0A,  //  0056  GETMET	R6	R6	K10
-      0x60200018,  //  0057  GETGBL	R8	G24
-      0x58240012,  //  0058  LDCONST	R9	K18
-      0x88280307,  //  0059  GETMBR	R10	R1	K7
-      0x88281513,  //  005A  GETMBR	R10	R10	K19
-      0x5C2C0400,  //  005B  MOVE	R11	R2
-      0x7C200600,  //  005C  CALL	R8	3
-      0x58240014,  //  005D  LDCONST	R9	K20
-      0x7C180600,  //  005E  CALL	R6	3
-      0x50180000,  //  005F  LDBOOL	R6	0	0
-      0x80040C00,  //  0060  RET	1	R6
-      0x8C180315,  //  0061  GETMET	R6	R1	K21
-      0x54220004,  //  0062  LDINT	R8	5
-      0x50240200,  //  0063  LDBOOL	R9	1	0
-      0x7C180600,  //  0064  CALL	R6	3
-      0x881C0103,  //  0065  GETMBR	R7	R0	K3
-      0x881C0F16,  //  0066  GETMBR	R7	R7	K22
-      0x88200317,  //  0067  GETMBR	R8	R1	K23
-      0x8C241118,  //  0068  GETMET	R9	R8	K24
-      0x7C240200,  //  0069  CALL	R9	1
-      0x8C240D19,  //  006A  GETMET	R9	R6	K25
-      0x5C2C0A00,  //  006B  MOVE	R11	R5
-      0x5C301000,  //  006C  MOVE	R12	R8
-      0x7C240600,  //  006D  CALL	R9	3
-      0x8C240D1A,  //  006E  GETMET	R9	R6	K26
-      0x7C240200,  //  006F  CALL	R9	1
-      0xB8262200,  //  0070  GETNGBL	R9	K17
-      0x8C24131B,  //  0071  GETMET	R9	R9	K27
-      0x542E0003,  //  0072  LDINT	R11	4
-      0x7C240400,  //  0073  CALL	R9	2
-      0x7826000B,  //  0074  JMPF	R9	#0081
-      0xB8262200,  //  0075  GETNGBL	R9	K17
-      0x8C24130A,  //  0076  GETMET	R9	R9	K10
-      0x602C0018,  //  0077  GETGBL	R11	G24
-      0x5830001C,  //  0078  LDCONST	R12	K28
-      0x88340D07,  //  0079  GETMBR	R13	R6	K7
-      0x88341B13,  //  007A  GETMBR	R13	R13	K19
-      0x88380D1D,  //  007B  GETMBR	R14	R6	K29
-      0x883C0D1E,  //  007C  GETMBR	R15	R6	K30
-      0x88400D1F,  //  007D  GETMBR	R16	R6	K31
-      0x7C2C0A00,  //  007E  CALL	R11	5
-      0x54320003,  //  007F  LDINT	R12	4
-      0x7C240600,  //  0080  CALL	R9	3
-      0x8C240F20,  //  0081  GETMET	R9	R7	K32
-      0x5C2C0C00,  //  0082  MOVE	R11	R6
-      0x7C240400,  //  0083  CALL	R9	2
-      0xB8260200,  //  0084  GETNGBL	R9	K1
-      0x88241309,  //  0085  GETMBR	R9	R9	K9
-      0x8C24130A,  //  0086  GETMET	R9	R9	K10
-      0x582C0021,  //  0087  LDCONST	R11	K33
-      0x7C240400,  //  0088  CALL	R9	2
-      0xB8260200,  //  0089  GETNGBL	R9	K1
-      0x8C241322,  //  008A  GETMET	R9	R9	K34
-      0x882C0523,  //  008B  GETMBR	R11	R2	K35
-      0x88300524,  //  008C  GETMBR	R12	R2	K36
-      0x7C240600,  //  008D  CALL	R9	3
-      0x78260002,  //  008E  JMPF	R9	#0092
-      0x002A4A09,  //  008F  ADD	R10	K37	R9
-      0x00281526,  //  0090  ADD	R10	R10	K38
-      0x70020000,  //  0091  JMP		#0093
-      0x58280027,  //  0092  LDCONST	R10	K39
-      0x5C241400,  //  0093  MOVE	R9	R10
-      0x4C280000,  //  0094  LDNIL	R10
-      0x2028080A,  //  0095  NE	R10	R4	R10
-      0x782A0013,  //  0096  JMPF	R10	#00AB
-      0x8C280928,  //  0097  GETMET	R10	R4	K40
-      0x7C280200,  //  0098  CALL	R10	1
-      0xB82E2200,  //  0099  GETNGBL	R11	K17
-      0x8C2C171B,  //  009A  GETMET	R11	R11	K27
-      0x58340014,  //  009B  LDCONST	R13	K20
-      0x7C2C0400,  //  009C  CALL	R11	2
-      0x782E000B,  //  009D  JMPF	R11	#00AA
-      0xB82E2200,  //  009E  GETNGBL	R11	K17
-      0x8C2C170A,  //  009F  GETMET	R11	R11	K10
-      0x60340018,  //  00A0  GETGBL	R13	G24
-      0x58380029,  //  00A1  LDCONST	R14	K41
-      0x883C0307,  //  00A2  GETMBR	R15	R1	K7
-      0x883C1F13,  //  00A3  GETMBR	R15	R15	K19
-      0x5C400400,  //  00A4  MOVE	R16	R2
-      0x5C441200,  //  00A5  MOVE	R17	R9
-      0x5C481400,  //  00A6  MOVE	R18	R10
-      0x7C340A00,  //  00A7  CALL	R13	5
-      0x58380014,  //  00A8  LDCONST	R14	K20
-      0x7C2C0600,  //  00A9  CALL	R11	3
-      0x7002002E,  //  00AA  JMP		#00DA
-      0x88280500,  //  00AB  GETMBR	R10	R2	K0
-      0x4C2C0000,  //  00AC  LDNIL	R11
-      0x2028140B,  //  00AD  NE	R10	R10	R11
-      0x782A001A,  //  00AE  JMPF	R10	#00CA
-      0x88280500,  //  00AF  GETMBR	R10	R2	K0
-      0xB82E0200,  //  00B0  GETNGBL	R11	K1
-      0x882C1705,  //  00B1  GETMBR	R11	R11	K5
-      0x1C28140B,  //  00B2  EQ	R10	R10	R11
-      0x782A0001,  //  00B3  JMPF	R10	#00B6
-      0x58280005,  //  00B4  LDCONST	R10	K5
-      0x70020000,  //  00B5  JMP		#00B7
-      0x58280027,  //  00B6  LDCONST	R10	K39
-      0xB82E2200,  //  00B7  GETNGBL	R11	K17
-      0x8C2C171B,  //  00B8  GETMET	R11	R11	K27
-      0x58340014,  //  00B9  LDCONST	R13	K20
-      0x7C2C0400,  //  00BA  CALL	R11	2
-      0x782E000C,  //  00BB  JMPF	R11	#00C9
-      0xB82E2200,  //  00BC  GETNGBL	R11	K17
-      0x8C2C170A,  //  00BD  GETMET	R11	R11	K10
-      0x60340018,  //  00BE  GETGBL	R13	G24
-      0x5838002A,  //  00BF  LDCONST	R14	K42
-      0x883C0307,  //  00C0  GETMBR	R15	R1	K7
-      0x883C1F13,  //  00C1  GETMBR	R15	R15	K19
-      0x5C400400,  //  00C2  MOVE	R16	R2
-      0x5C441200,  //  00C3  MOVE	R17	R9
-      0x88480500,  //  00C4  GETMBR	R18	R2	K0
-      0x5C4C1400,  //  00C5  MOVE	R19	R10
-      0x7C340C00,  //  00C6  CALL	R13	6
+      0x900A0601,  //  0003  SETMBR	R2	K3	R1
+      0x880C0104,  //  0004  GETMBR	R3	R0	K4
+      0x8C0C0705,  //  0005  GETMET	R3	R3	K5
+      0x5C140400,  //  0006  MOVE	R5	R2
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x4C100000,  //  0008  LDNIL	R4
+      0x4C140000,  //  0009  LDNIL	R5
+      0x4C180000,  //  000A  LDNIL	R6
+      0x20180606,  //  000B  NE	R6	R3	R6
+      0x781A0008,  //  000C  JMPF	R6	#0016
+      0xB81A0200,  //  000D  GETNGBL	R6	K1
+      0x88180D06,  //  000E  GETMBR	R6	R6	K6
+      0x900A0006,  //  000F  SETMBR	R2	K0	R6
+      0x8C180707,  //  0010  GETMET	R6	R3	K7
+      0x88200308,  //  0011  GETMBR	R8	R1	K8
+      0x5C240400,  //  0012  MOVE	R9	R2
+      0x88280109,  //  0013  GETMBR	R10	R0	K9
+      0x7C180800,  //  0014  CALL	R6	4
+      0x5C100C00,  //  0015  MOVE	R4	R6
+      0xB81A0200,  //  0016  GETNGBL	R6	K1
+      0x88180D0A,  //  0017  GETMBR	R6	R6	K10
+      0x8C180D0B,  //  0018  GETMET	R6	R6	K11
+      0x5820000C,  //  0019  LDCONST	R8	K12
+      0x7C180400,  //  001A  CALL	R6	2
+      0x4C180000,  //  001B  LDNIL	R6
+      0x20180806,  //  001C  NE	R6	R4	R6
+      0x781A0037,  //  001D  JMPF	R6	#0056
+      0x8818090D,  //  001E  GETMBR	R6	R4	K13
+      0x741A0001,  //  001F  JMPT	R6	#0022
+      0x8818090E,  //  0020  GETMBR	R6	R4	K14
+      0x781A0019,  //  0021  JMPF	R6	#003C
+      0x8C18090F,  //  0022  GETMET	R6	R4	K15
+      0x7C180200,  //  0023  CALL	R6	1
+      0xB81E0200,  //  0024  GETNGBL	R7	K1
+      0x881C0F10,  //  0025  GETMBR	R7	R7	K16
+      0x881C0F11,  //  0026  GETMBR	R7	R7	K17
+      0x24180C07,  //  0027  GT	R6	R6	R7
+      0x781A0012,  //  0028  JMPF	R6	#003C
+      0x4C100000,  //  0029  LDNIL	R4
+      0xB81A2400,  //  002A  GETNGBL	R6	K18
+      0x8C180D0B,  //  002B  GETMET	R6	R6	K11
+      0x60200018,  //  002C  GETGBL	R8	G24
+      0x58240013,  //  002D  LDCONST	R9	K19
+      0x7C200200,  //  002E  CALL	R8	1
+      0x58240014,  //  002F  LDCONST	R9	K20
+      0x7C180600,  //  0030  CALL	R6	3
+      0xB81A0200,  //  0031  GETNGBL	R6	K1
+      0x88180D15,  //  0032  GETMBR	R6	R6	K21
+      0x8C180D16,  //  0033  GETMET	R6	R6	K22
+      0x88200317,  //  0034  GETMBR	R8	R1	K23
+      0x88240318,  //  0035  GETMBR	R9	R1	K24
+      0x7C180600,  //  0036  CALL	R6	3
+      0x8C1C0119,  //  0037  GETMET	R7	R0	K25
+      0x5C240200,  //  0038  MOVE	R9	R1
+      0x5C280C00,  //  0039  MOVE	R10	R6
+      0x7C1C0600,  //  003A  CALL	R7	3
+      0x80040E00,  //  003B  RET	1	R7
+      0x60180015,  //  003C  GETGBL	R6	G21
+      0x541E002F,  //  003D  LDINT	R7	48
+      0x7C180200,  //  003E  CALL	R6	1
+      0x5C140C00,  //  003F  MOVE	R5	R6
+      0x8C180B1A,  //  0040  GETMET	R6	R5	K26
+      0x54220014,  //  0041  LDINT	R8	21
+      0x5824001B,  //  0042  LDCONST	R9	K27
+      0x7C180600,  //  0043  CALL	R6	3
+      0x8C180B1A,  //  0044  GETMET	R6	R5	K26
+      0x54223600,  //  0045  LDINT	R8	13825
+      0x5425FFFD,  //  0046  LDINT	R9	-2
+      0x7C180600,  //  0047  CALL	R6	3
+      0x8C18011C,  //  0048  GETMET	R6	R0	K28
+      0x5C200A00,  //  0049  MOVE	R8	R5
+      0x5C240400,  //  004A  MOVE	R9	R2
+      0x5C280800,  //  004B  MOVE	R10	R4
+      0x7C180800,  //  004C  CALL	R6	4
+      0x8C180B1A,  //  004D  GETMET	R6	R5	K26
+      0x5820001D,  //  004E  LDCONST	R8	K29
+      0x5425FFFB,  //  004F  LDINT	R9	-4
+      0x7C180600,  //  0050  CALL	R6	3
+      0x8C180B1A,  //  0051  GETMET	R6	R5	K26
+      0x54220017,  //  0052  LDINT	R8	24
+      0x5824001B,  //  0053  LDCONST	R9	K27
+      0x7C180600,  //  0054  CALL	R6	3
+      0x70020029,  //  0055  JMP		#0080
+      0x88180500,  //  0056  GETMBR	R6	R2	K0
+      0x4C1C0000,  //  0057  LDNIL	R7
+      0x20180C07,  //  0058  NE	R6	R6	R7
+      0x781A0019,  //  0059  JMPF	R6	#0074
+      0x60180015,  //  005A  GETGBL	R6	G21
+      0x541E002F,  //  005B  LDINT	R7	48
+      0x7C180200,  //  005C  CALL	R6	1
+      0x5C140C00,  //  005D  MOVE	R5	R6
+      0x8C180B1A,  //  005E  GETMET	R6	R5	K26
+      0x54220014,  //  005F  LDINT	R8	21
+      0x5824001B,  //  0060  LDCONST	R9	K27
+      0x7C180600,  //  0061  CALL	R6	3
+      0x8C180B1A,  //  0062  GETMET	R6	R5	K26
+      0x54223600,  //  0063  LDINT	R8	13825
+      0x5425FFFD,  //  0064  LDINT	R9	-2
+      0x7C180600,  //  0065  CALL	R6	3
+      0x8C18011E,  //  0066  GETMET	R6	R0	K30
+      0x5C200A00,  //  0067  MOVE	R8	R5
+      0x5C240400,  //  0068  MOVE	R9	R2
+      0x88280500,  //  0069  GETMBR	R10	R2	K0
+      0x7C180800,  //  006A  CALL	R6	4
+      0x8C180B1A,  //  006B  GETMET	R6	R5	K26
+      0x5820001D,  //  006C  LDCONST	R8	K29
+      0x5425FFFB,  //  006D  LDINT	R9	-4
+      0x7C180600,  //  006E  CALL	R6	3
+      0x8C180B1A,  //  006F  GETMET	R6	R5	K26
+      0x54220017,  //  0070  LDINT	R8	24
+      0x5824001B,  //  0071  LDCONST	R9	K27
+      0x7C180600,  //  0072  CALL	R6	3
+      0x7002000B,  //  0073  JMP		#0080
+      0xB81A2400,  //  0074  GETNGBL	R6	K18
+      0x8C180D0B,  //  0075  GETMET	R6	R6	K11
+      0x60200018,  //  0076  GETGBL	R8	G24
+      0x5824001F,  //  0077  LDCONST	R9	K31
+      0x88280308,  //  0078  GETMBR	R10	R1	K8
+      0x88281520,  //  0079  GETMBR	R10	R10	K32
+      0x5C2C0400,  //  007A  MOVE	R11	R2
+      0x7C200600,  //  007B  CALL	R8	3
+      0x58240014,  //  007C  LDCONST	R9	K20
+      0x7C180600,  //  007D  CALL	R6	3
+      0x50180000,  //  007E  LDBOOL	R6	0	0
+      0x80040C00,  //  007F  RET	1	R6
+      0x8C180321,  //  0080  GETMET	R6	R1	K33
+      0x54220004,  //  0081  LDINT	R8	5
+      0x50240200,  //  0082  LDBOOL	R9	1	0
+      0x7C180600,  //  0083  CALL	R6	3
+      0x881C0104,  //  0084  GETMBR	R7	R0	K4
+      0x881C0F22,  //  0085  GETMBR	R7	R7	K34
+      0x88200317,  //  0086  GETMBR	R8	R1	K23
+      0x8C241123,  //  0087  GETMET	R9	R8	K35
+      0x7C240200,  //  0088  CALL	R9	1
+      0x8C240D24,  //  0089  GETMET	R9	R6	K36
+      0x5C2C0A00,  //  008A  MOVE	R11	R5
+      0x5C301000,  //  008B  MOVE	R12	R8
+      0x7C240600,  //  008C  CALL	R9	3
+      0x8C240D25,  //  008D  GETMET	R9	R6	K37
+      0x7C240200,  //  008E  CALL	R9	1
+      0xB8262400,  //  008F  GETNGBL	R9	K18
+      0x8C241326,  //  0090  GETMET	R9	R9	K38
+      0x542E0003,  //  0091  LDINT	R11	4
+      0x7C240400,  //  0092  CALL	R9	2
+      0x7826000B,  //  0093  JMPF	R9	#00A0
+      0xB8262400,  //  0094  GETNGBL	R9	K18
+      0x8C24130B,  //  0095  GETMET	R9	R9	K11
+      0x602C0018,  //  0096  GETGBL	R11	G24
+      0x58300027,  //  0097  LDCONST	R12	K39
+      0x88340D08,  //  0098  GETMBR	R13	R6	K8
+      0x88341B20,  //  0099  GETMBR	R13	R13	K32
+      0x88380D28,  //  009A  GETMBR	R14	R6	K40
+      0x883C0D29,  //  009B  GETMBR	R15	R6	K41
+      0x88400D2A,  //  009C  GETMBR	R16	R6	K42
+      0x7C2C0A00,  //  009D  CALL	R11	5
+      0x54320003,  //  009E  LDINT	R12	4
+      0x7C240600,  //  009F  CALL	R9	3
+      0x8C240F2B,  //  00A0  GETMET	R9	R7	K43
+      0x5C2C0C00,  //  00A1  MOVE	R11	R6
+      0x7C240400,  //  00A2  CALL	R9	2
+      0xB8260200,  //  00A3  GETNGBL	R9	K1
+      0x8824130A,  //  00A4  GETMBR	R9	R9	K10
+      0x8C24130B,  //  00A5  GETMET	R9	R9	K11
+      0x582C002C,  //  00A6  LDCONST	R11	K44
+      0x7C240400,  //  00A7  CALL	R9	2
+      0xB8260200,  //  00A8  GETNGBL	R9	K1
+      0x8C24132D,  //  00A9  GETMET	R9	R9	K45
+      0x882C052E,  //  00AA  GETMBR	R11	R2	K46
+      0x8830052F,  //  00AB  GETMBR	R12	R2	K47
+      0x7C240600,  //  00AC  CALL	R9	3
+      0x78260002,  //  00AD  JMPF	R9	#00B1
+      0x002A6009,  //  00AE  ADD	R10	K48	R9
+      0x00281531,  //  00AF  ADD	R10	R10	K49
+      0x70020000,  //  00B0  JMP		#00B2
+      0x58280032,  //  00B1  LDCONST	R10	K50
+      0x5C241400,  //  00B2  MOVE	R9	R10
+      0x4C280000,  //  00B3  LDNIL	R10
+      0x2028080A,  //  00B4  NE	R10	R4	R10
+      0x782A0013,  //  00B5  JMPF	R10	#00CA
+      0x8C280933,  //  00B6  GETMET	R10	R4	K51
+      0x7C280200,  //  00B7  CALL	R10	1
+      0xB82E2400,  //  00B8  GETNGBL	R11	K18
+      0x8C2C1726,  //  00B9  GETMET	R11	R11	K38
+      0x58340014,  //  00BA  LDCONST	R13	K20
+      0x7C2C0400,  //  00BB  CALL	R11	2
+      0x782E000B,  //  00BC  JMPF	R11	#00C9
+      0xB82E2400,  //  00BD  GETNGBL	R11	K18
+      0x8C2C170B,  //  00BE  GETMET	R11	R11	K11
+      0x60340018,  //  00BF  GETGBL	R13	G24
+      0x58380034,  //  00C0  LDCONST	R14	K52
+      0x883C0308,  //  00C1  GETMBR	R15	R1	K8
+      0x883C1F20,  //  00C2  GETMBR	R15	R15	K32
+      0x5C400400,  //  00C3  MOVE	R16	R2
+      0x5C441200,  //  00C4  MOVE	R17	R9
+      0x5C481400,  //  00C5  MOVE	R18	R10
+      0x7C340A00,  //  00C6  CALL	R13	5
       0x58380014,  //  00C7  LDCONST	R14	K20
       0x7C2C0600,  //  00C8  CALL	R11	3
-      0x7002000F,  //  00C9  JMP		#00DA
-      0xB82A2200,  //  00CA  GETNGBL	R10	K17
-      0x8C28151B,  //  00CB  GETMET	R10	R10	K27
-      0x58300014,  //  00CC  LDCONST	R12	K20
-      0x7C280400,  //  00CD  CALL	R10	2
-      0x782A000A,  //  00CE  JMPF	R10	#00DA
-      0xB82A2200,  //  00CF  GETNGBL	R10	K17
-      0x8C28150A,  //  00D0  GETMET	R10	R10	K10
-      0x60300018,  //  00D1  GETGBL	R12	G24
-      0x5834002B,  //  00D2  LDCONST	R13	K43
-      0x88380307,  //  00D3  GETMBR	R14	R1	K7
-      0x88381D13,  //  00D4  GETMBR	R14	R14	K19
-      0x5C3C0400,  //  00D5  MOVE	R15	R2
-      0x5C401200,  //  00D6  MOVE	R16	R9
-      0x7C300800,  //  00D7  CALL	R12	4
+      0x7002002E,  //  00C9  JMP		#00F9
+      0x88280500,  //  00CA  GETMBR	R10	R2	K0
+      0x4C2C0000,  //  00CB  LDNIL	R11
+      0x2028140B,  //  00CC  NE	R10	R10	R11
+      0x782A001A,  //  00CD  JMPF	R10	#00E9
+      0x88280500,  //  00CE  GETMBR	R10	R2	K0
+      0xB82E0200,  //  00CF  GETNGBL	R11	K1
+      0x882C1706,  //  00D0  GETMBR	R11	R11	K6
+      0x1C28140B,  //  00D1  EQ	R10	R10	R11
+      0x782A0001,  //  00D2  JMPF	R10	#00D5
+      0x58280006,  //  00D3  LDCONST	R10	K6
+      0x70020000,  //  00D4  JMP		#00D6
+      0x58280032,  //  00D5  LDCONST	R10	K50
+      0xB82E2400,  //  00D6  GETNGBL	R11	K18
+      0x8C2C1726,  //  00D7  GETMET	R11	R11	K38
       0x58340014,  //  00D8  LDCONST	R13	K20
-      0x7C280600,  //  00D9  CALL	R10	3
-      0x50280200,  //  00DA  LDBOOL	R10	1	0
-      0x80041400,  //  00DB  RET	1	R10
+      0x7C2C0400,  //  00D9  CALL	R11	2
+      0x782E000C,  //  00DA  JMPF	R11	#00E8
+      0xB82E2400,  //  00DB  GETNGBL	R11	K18
+      0x8C2C170B,  //  00DC  GETMET	R11	R11	K11
+      0x60340018,  //  00DD  GETGBL	R13	G24
+      0x58380035,  //  00DE  LDCONST	R14	K53
+      0x883C0308,  //  00DF  GETMBR	R15	R1	K8
+      0x883C1F20,  //  00E0  GETMBR	R15	R15	K32
+      0x5C400400,  //  00E1  MOVE	R16	R2
+      0x5C441200,  //  00E2  MOVE	R17	R9
+      0x88480500,  //  00E3  GETMBR	R18	R2	K0
+      0x5C4C1400,  //  00E4  MOVE	R19	R10
+      0x7C340C00,  //  00E5  CALL	R13	6
+      0x58380014,  //  00E6  LDCONST	R14	K20
+      0x7C2C0600,  //  00E7  CALL	R11	3
+      0x7002000F,  //  00E8  JMP		#00F9
+      0xB82A2400,  //  00E9  GETNGBL	R10	K18
+      0x8C281526,  //  00EA  GETMET	R10	R10	K38
+      0x58300014,  //  00EB  LDCONST	R12	K20
+      0x7C280400,  //  00EC  CALL	R10	2
+      0x782A000A,  //  00ED  JMPF	R10	#00F9
+      0xB82A2400,  //  00EE  GETNGBL	R10	K18
+      0x8C28150B,  //  00EF  GETMET	R10	R10	K11
+      0x60300018,  //  00F0  GETGBL	R12	G24
+      0x58340036,  //  00F1  LDCONST	R13	K54
+      0x88380308,  //  00F2  GETMBR	R14	R1	K8
+      0x88381D20,  //  00F3  GETMBR	R14	R14	K32
+      0x5C3C0400,  //  00F4  MOVE	R15	R2
+      0x5C401200,  //  00F5  MOVE	R16	R9
+      0x7C300800,  //  00F6  CALL	R12	4
+      0x58340014,  //  00F7  LDCONST	R13	K20
+      0x7C280600,  //  00F8  CALL	R10	3
+      0x50280200,  //  00F9  LDBOOL	R10	1	0
+      0x80041400,  //  00FA  RET	1	R10
     })
   )
 );
@@ -3319,7 +3465,7 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
     }),
     be_str_weak(subscribe_request),
     &be_const_str_solidified,
-    ( &(const binstruction[98]) {  /* code */
+    ( &(const binstruction[99]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x8C0C0701,  //  0001  GETMET	R3	R3	K1
       0x7C0C0200,  //  0002  CALL	R3	1
@@ -3407,17 +3553,18 @@ be_local_closure(Matter_IM_subscribe_request,   /* name */
       0x8C1C011F,  //  0054  GETMET	R7	R0	K31
       0x88240306,  //  0055  GETMBR	R9	R1	K6
       0x5C280600,  //  0056  MOVE	R10	R3
-      0x502C0200,  //  0057  LDBOOL	R11	1	0
-      0x7C1C0800,  //  0058  CALL	R7	4
-      0x8820091A,  //  0059  GETMBR	R8	R4	K26
-      0x901E3408,  //  005A  SETMBR	R7	K26	R8
-      0x8C200120,  //  005B  GETMET	R8	R0	K32
-      0x5C280200,  //  005C  MOVE	R10	R1
-      0x5C2C0E00,  //  005D  MOVE	R11	R7
-      0x5C300800,  //  005E  MOVE	R12	R4
-      0x7C200800,  //  005F  CALL	R8	4
-      0x50200200,  //  0060  LDBOOL	R8	1	0
-      0x80041000,  //  0061  RET	1	R8
+      0x5C2C0200,  //  0057  MOVE	R11	R1
+      0x50300200,  //  0058  LDBOOL	R12	1	0
+      0x7C1C0A00,  //  0059  CALL	R7	5
+      0x8820091A,  //  005A  GETMBR	R8	R4	K26
+      0x901E3408,  //  005B  SETMBR	R7	K26	R8
+      0x8C200120,  //  005C  GETMET	R8	R0	K32
+      0x5C280200,  //  005D  MOVE	R10	R1
+      0x5C2C0E00,  //  005E  MOVE	R11	R7
+      0x5C300800,  //  005F  MOVE	R12	R4
+      0x7C200800,  //  0060  CALL	R8	4
+      0x50200200,  //  0061  LDBOOL	R8	1	0
+      0x80041000,  //  0062  RET	1	R8
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
@@ -296,6 +296,49 @@ be_local_closure(Matter_Plugin_parse_sensors,   /* name */
 
 
 /********************************************************************
+** Solidified function: has
+********************************************************************/
+be_local_closure(Matter_Plugin_has,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(clusters),
+    /* K1   */  be_nested_str_weak(contains),
+    /* K2   */  be_nested_str_weak(endpoints),
+    /* K3   */  be_nested_str_weak(find),
+    }),
+    be_str_weak(has),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x780E0006,  //  0004  JMPF	R3	#000C
+      0x880C0102,  //  0005  GETMBR	R3	R0	K2
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x5C140400,  //  0007  MOVE	R5	R2
+      0x7C0C0400,  //  0008  CALL	R3	2
+      0x4C100000,  //  0009  LDNIL	R4
+      0x200C0604,  //  000A  NE	R3	R3	R4
+      0x740E0000,  //  000B  JMPT	R3	#000D
+      0x500C0001,  //  000C  LDBOOL	R3	0	1
+      0x500C0200,  //  000D  LDBOOL	R3	1	0
+      0x80040600,  //  000E  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: parse_configuration
 ********************************************************************/
 be_local_closure(Matter_Plugin_parse_configuration,   /* name */
@@ -382,69 +425,41 @@ be_local_closure(Matter_Plugin_subscribe_attribute,   /* name */
 
 
 /********************************************************************
-** Solidified function: has
+** Solidified function: ack_request
 ********************************************************************/
-be_local_closure(Matter_Plugin_has,   /* name */
+be_local_closure(Matter_Plugin_ack_request,   /* name */
   be_nested_proto(
     6,                          /* nstack */
-    3,                          /* argc */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(clusters),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(endpoints),
-    /* K3   */  be_nested_str_weak(find),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(msg),
+    /* K1   */  be_nested_str_weak(device),
+    /* K2   */  be_nested_str_weak(message_handler),
+    /* K3   */  be_nested_str_weak(im),
+    /* K4   */  be_nested_str_weak(send_ack_now),
     }),
-    be_str_weak(has),
+    be_str_weak(ack_request),
     &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x780E0006,  //  0004  JMPF	R3	#000C
-      0x880C0102,  //  0005  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
-      0x5C140400,  //  0007  MOVE	R5	R2
-      0x7C0C0400,  //  0008  CALL	R3	2
-      0x4C100000,  //  0009  LDNIL	R4
-      0x200C0604,  //  000A  NE	R3	R3	R4
-      0x740E0000,  //  000B  JMPT	R3	#000D
-      0x500C0001,  //  000C  LDBOOL	R3	0	1
-      0x500C0200,  //  000D  LDBOOL	R3	1	0
-      0x80040600,  //  000E  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_endpoint
-********************************************************************/
-be_local_closure(Matter_Plugin_get_endpoint,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(endpoint),
-    }),
-    be_str_weak(get_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
+    ( &(const binstruction[13]) {  /* code */
+      0x88080300,  //  0000  GETMBR	R2	R1	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x200C0403,  //  0002  NE	R3	R2	R3
+      0x780E0005,  //  0003  JMPF	R3	#000A
+      0x880C0101,  //  0004  GETMBR	R3	R0	K1
+      0x880C0702,  //  0005  GETMBR	R3	R3	K2
+      0x880C0703,  //  0006  GETMBR	R3	R3	K3
+      0x8C0C0704,  //  0007  GETMET	R3	R3	K4
+      0x5C140400,  //  0008  MOVE	R5	R2
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x4C0C0000,  //  000A  LDNIL	R3
+      0x90060003,  //  000B  SETMBR	R1	K0	R3
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -687,34 +702,26 @@ be_local_closure(Matter_Plugin_contains_cluster,   /* name */
 
 
 /********************************************************************
-** Solidified function: send_ack_now
+** Solidified function: <lambda>
 ********************************************************************/
-be_local_closure(Matter_Plugin_send_ack_now,   /* name */
+be_local_closure(Matter_Plugin__X3Clambda_X3E,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
+    3,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(message_handler),
-    /* K2   */  be_nested_str_weak(im),
-    /* K3   */  be_nested_str_weak(send_ack_now),
-    }),
-    be_str_weak(send_ack_now),
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(_X3Clambda_X3E),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x88080501,  //  0001  GETMBR	R2	R2	K1
-      0x88080502,  //  0002  GETMBR	R2	R2	K2
-      0x8C080503,  //  0003  GETMET	R2	R2	K3
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x80000000,  //  0006  RET	0
+    ( &(const binstruction[ 4]) {  /* code */
+      0x60040008,  //  0000  GETGBL	R1	G8
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
     })
   )
 );
@@ -820,26 +827,26 @@ be_local_closure(Matter_Plugin_update_shadow_lazy,   /* name */
 
 
 /********************************************************************
-** Solidified function: <lambda>
+** Solidified function: get_endpoint
 ********************************************************************/
-be_local_closure(Matter_Plugin__X3Clambda_X3E,   /* name */
+be_local_closure(Matter_Plugin_get_endpoint,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
+    2,                          /* nstack */
     1,                          /* argc */
-    0,                          /* varg */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(_X3Clambda_X3E),
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(endpoint),
+    }),
+    be_str_weak(get_endpoint),
     &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x60040008,  //  0000  GETGBL	R1	G8
-      0x5C080000,  //  0001  MOVE	R2	R0
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -1071,13 +1078,16 @@ be_local_class(Matter_Plugin,
     be_nested_map(37,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_init_closure) },
-        { be_const_key_weak(read_event, 8), be_const_closure(Matter_Plugin_read_event_closure) },
+        { be_const_key_weak(read_event, 11), be_const_closure(Matter_Plugin_read_event_closure) },
         { be_const_key_weak(tick, -1), be_const_var(4) },
         { be_const_key_weak(is_local_device, 18), be_const_closure(Matter_Plugin_is_local_device_closure) },
         { be_const_key_weak(UPDATE_TIME, -1), be_const_int(5000) },
         { be_const_key_weak(get_attribute_list, -1), be_const_closure(Matter_Plugin_get_attribute_list_closure) },
-        { be_const_key_weak(ui_conf_to_string, 28), be_const_static_closure(Matter_Plugin_ui_conf_to_string_closure) },
+        { be_const_key_weak(ui_conf_to_string, 26), be_const_static_closure(Matter_Plugin_ui_conf_to_string_closure) },
         { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_Plugin_every_250ms_closure) },
+        { be_const_key_weak(ack_request, -1), be_const_closure(Matter_Plugin_ack_request_closure) },
+        { be_const_key_weak(NAME, -1), be_nested_str_weak() },
+        { be_const_key_weak(parse_sensors, -1), be_const_closure(Matter_Plugin_parse_sensors_closure) },
         { be_const_key_weak(CLUSTERS, 36), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
@@ -1097,28 +1107,25 @@ be_local_class(Matter_Plugin,
         be_const_int(17),
     }))    ) } )) },
     }))    ) } )) },
-        { be_const_key_weak(NAME, -1), be_nested_str_weak() },
-        { be_const_key_weak(parse_sensors, -1), be_const_closure(Matter_Plugin_parse_sensors_closure) },
-        { be_const_key_weak(get_endpoint, -1), be_const_closure(Matter_Plugin_get_endpoint_closure) },
         { be_const_key_weak(parse_configuration, -1), be_const_closure(Matter_Plugin_parse_configuration_closure) },
         { be_const_key_weak(ui_string_to_conf, -1), be_const_static_closure(Matter_Plugin_ui_string_to_conf_closure) },
         { be_const_key_weak(contains_cluster, -1), be_const_closure(Matter_Plugin_contains_cluster_closure) },
-        { be_const_key_weak(attribute_updated, 11), be_const_closure(Matter_Plugin_attribute_updated_closure) },
-        { be_const_key_weak(has, -1), be_const_closure(Matter_Plugin_has_closure) },
+        { be_const_key_weak(ARG_TYPE, -1), be_const_static_closure(Matter_Plugin__X3Clambda_X3E_closure) },
+        { be_const_key_weak(has, 8), be_const_closure(Matter_Plugin_has_closure) },
         { be_const_key_weak(device, 4), be_const_var(1) },
         { be_const_key_weak(timed_request, -1), be_const_closure(Matter_Plugin_timed_request_closure) },
         { be_const_key_weak(get_cluster_list, -1), be_const_closure(Matter_Plugin_get_cluster_list_closure) },
         { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_read_attribute_closure) },
         { be_const_key_weak(ARG, 14), be_nested_str_weak() },
-        { be_const_key_weak(send_ack_now, -1), be_const_closure(Matter_Plugin_send_ack_now_closure) },
-        { be_const_key_weak(subscribe_attribute, 26), be_const_closure(Matter_Plugin_subscribe_attribute_closure) },
-        { be_const_key_weak(clusters, -1), be_const_var(3) },
-        { be_const_key_weak(write_attribute, 24), be_const_closure(Matter_Plugin_write_attribute_closure) },
-        { be_const_key_weak(ARG_TYPE, 15), be_const_static_closure(Matter_Plugin__X3Clambda_X3E_closure) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_invoke_request_closure) },
+        { be_const_key_weak(subscribe_attribute, 24), be_const_closure(Matter_Plugin_subscribe_attribute_closure) },
+        { be_const_key_weak(get_endpoint, 30), be_const_closure(Matter_Plugin_get_endpoint_closure) },
+        { be_const_key_weak(write_attribute, 28), be_const_closure(Matter_Plugin_write_attribute_closure) },
+        { be_const_key_weak(ARG_HINT, 22), be_nested_str_weak(_Not_X20used_) },
         { be_const_key_weak(update_shadow_lazy, -1), be_const_closure(Matter_Plugin_update_shadow_lazy_closure) },
-        { be_const_key_weak(invoke_request, 30), be_const_closure(Matter_Plugin_invoke_request_closure) },
+        { be_const_key_weak(clusters, -1), be_const_var(3) },
         { be_const_key_weak(endpoint, -1), be_const_var(2) },
-        { be_const_key_weak(ARG_HINT, -1), be_nested_str_weak(_Not_X20used_) },
+        { be_const_key_weak(attribute_updated, 15), be_const_closure(Matter_Plugin_attribute_updated_closure) },
         { be_const_key_weak(subscribe_event, -1), be_const_closure(Matter_Plugin_subscribe_event_closure) },
         { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_update_shadow_closure) },
         { be_const_key_weak(consolidate_clusters, -1), be_const_closure(Matter_Plugin_consolidate_clusters_closure) },

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
@@ -47,7 +47,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[101]) {     /* constants */
+    ( &(const bvalue[100]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
@@ -65,90 +65,89 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
     /* K14  */  be_const_int(2),
     /* K15  */  be_nested_str_weak(XX),
     /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(send_ack_now),
-    /* K18  */  be_nested_str_weak(msg),
-    /* K19  */  be_nested_str_weak(_fabric),
-    /* K20  */  be_nested_str_weak(fabric_completed),
-    /* K21  */  be_nested_str_weak(set_no_expiration),
-    /* K22  */  be_nested_str_weak(save),
-    /* K23  */  be_nested_str_weak(device),
-    /* K24  */  be_nested_str_weak(start_commissioning_complete_deferred),
-    /* K25  */  be_nested_str_weak(context_error),
-    /* K26  */  be_nested_str_weak(CommissioningComplete_X3A_X20no_X20fabric_X20attached),
-    /* K27  */  be_nested_str_weak(status),
-    /* K28  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
-    /* K29  */  be_nested_str_weak(B2),
-    /* K30  */  be_nested_str_weak(DAC_Cert_FFF1_8000),
-    /* K31  */  be_nested_str_weak(PAI_Cert_FFF1),
-    /* K32  */  be_nested_str_weak(CD_FFF1_8000),
-    /* K33  */  be_nested_str_weak(B1),
-    /* K34  */  be_nested_str_weak(U4),
-    /* K35  */  be_nested_str_weak(tasmota),
-    /* K36  */  be_nested_str_weak(rtc_utc),
-    /* K37  */  be_nested_str_weak(tlv2raw),
-    /* K38  */  be_nested_str_weak(get_ac),
-    /* K39  */  be_nested_str_weak(EC_P256),
-    /* K40  */  be_nested_str_weak(ecdsa_sign_sha256),
-    /* K41  */  be_nested_str_weak(DAC_Priv_FFF1_8000),
-    /* K42  */  be_nested_str_weak(gen_CSR),
-    /* K43  */  be_nested_str_weak(set_temp_ca),
-    /* K44  */  be_nested_str_weak(SUCCESS),
-    /* K45  */  be_nested_str_weak(log),
-    /* K46  */  be_nested_str_weak(MTR_X3A_X20AddNoc_X20Args_X3D),
-    /* K47  */  be_nested_str_weak(get_temp_ca),
-    /* K48  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20AdNOC_X20without_X20CA),
-    /* K49  */  be_nested_str_weak(sessions),
-    /* K50  */  be_nested_str_weak(create_fabric),
-    /* K51  */  be_nested_str_weak(set_ca),
-    /* K52  */  be_nested_str_weak(set_noc_icac),
-    /* K53  */  be_nested_str_weak(set_ipk_epoch_key),
-    /* K54  */  be_nested_str_weak(set_admin_subject_vendor),
-    /* K55  */  be_nested_str_weak(set_pk),
-    /* K56  */  be_nested_str_weak(get_pk),
-    /* K57  */  be_nested_str_weak(parse),
-    /* K58  */  be_nested_str_weak(findsub),
-    /* K59  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20no_X20fabricid_X20nor_X20deviceid_X20in_X20NOC_X20certificate),
-    /* K60  */  be_nested_str_weak(int),
-    /* K61  */  be_nested_str_weak(int64),
-    /* K62  */  be_nested_str_weak(fromu32),
-    /* K63  */  be_nested_str_weak(tobytes),
-    /* K64  */  be_nested_str_weak(get_temp_ca_pub),
-    /* K65  */  be_const_int(2147483647),
-    /* K66  */  be_nested_str_weak(fromstring),
-    /* K67  */  be_nested_str_weak(CompressedFabric),
-    /* K68  */  be_nested_str_weak(HKDF_SHA256),
-    /* K69  */  be_nested_str_weak(copy),
-    /* K70  */  be_nested_str_weak(reverse),
-    /* K71  */  be_nested_str_weak(derive),
-    /* K72  */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K73  */  be_nested_str_weak(set_fabric_device),
-    /* K74  */  be_nested_str_weak(fabric_candidate),
-    /* K75  */  be_nested_str_weak(start_operational_discovery_deferred),
-    /* K76  */  be_nested_str_weak(is_PASE),
-    /* K77  */  be_nested_str_weak(set_expire_in_seconds),
-    /* K78  */  be_nested_str_weak(log_new_fabric),
-    /* K79  */  be_nested_str_weak(set_fabric_label),
-    /* K80  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Update_X20fabric_X20_X27_X25s_X27_X20label_X3D_X27_X25s_X27),
-    /* K81  */  be_nested_str_weak(get_fabric_id),
-    /* K82  */  be_nested_str_weak(tohex),
-    /* K83  */  be_nested_str_weak(fabric_index_X3A),
-    /* K84  */  be_nested_str_weak(active_fabrics),
-    /* K85  */  be_nested_str_weak(get_fabric_index),
-    /* K86  */  be_nested_str_weak(set_timer),
-    /* K87  */  be_nested_str_weak(stop_iteration),
-    /* K88  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
-    /* K89  */  be_nested_str_weak(_X29_X20not_X20found),
-    /* K90  */  be_nested_str_weak(INVALID_ACTION),
-    /* K91  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
-    /* K92  */  be_nested_str_weak(INVALID_DATA_TYPE),
-    /* K93  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
-    /* K94  */  be_nested_str_weak(CONSTRAINT_ERROR),
-    /* K95  */  be_nested_str_weak(start_basic_commissioning),
-    /* K96  */  be_nested_str_weak(get_fabric),
-    /* K97  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
-    /* K98  */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K99  */  be_nested_str_weak(stop_basic_commissioning),
-    /* K100 */  be_nested_str_weak(invoke_request),
+    /* K17  */  be_nested_str_weak(ack_request),
+    /* K18  */  be_nested_str_weak(_fabric),
+    /* K19  */  be_nested_str_weak(fabric_completed),
+    /* K20  */  be_nested_str_weak(set_no_expiration),
+    /* K21  */  be_nested_str_weak(save),
+    /* K22  */  be_nested_str_weak(device),
+    /* K23  */  be_nested_str_weak(start_commissioning_complete_deferred),
+    /* K24  */  be_nested_str_weak(context_error),
+    /* K25  */  be_nested_str_weak(CommissioningComplete_X3A_X20no_X20fabric_X20attached),
+    /* K26  */  be_nested_str_weak(status),
+    /* K27  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
+    /* K28  */  be_nested_str_weak(B2),
+    /* K29  */  be_nested_str_weak(DAC_Cert_FFF1_8000),
+    /* K30  */  be_nested_str_weak(PAI_Cert_FFF1),
+    /* K31  */  be_nested_str_weak(CD_FFF1_8000),
+    /* K32  */  be_nested_str_weak(B1),
+    /* K33  */  be_nested_str_weak(U4),
+    /* K34  */  be_nested_str_weak(tasmota),
+    /* K35  */  be_nested_str_weak(rtc_utc),
+    /* K36  */  be_nested_str_weak(tlv2raw),
+    /* K37  */  be_nested_str_weak(get_ac),
+    /* K38  */  be_nested_str_weak(EC_P256),
+    /* K39  */  be_nested_str_weak(ecdsa_sign_sha256),
+    /* K40  */  be_nested_str_weak(DAC_Priv_FFF1_8000),
+    /* K41  */  be_nested_str_weak(gen_CSR),
+    /* K42  */  be_nested_str_weak(set_temp_ca),
+    /* K43  */  be_nested_str_weak(SUCCESS),
+    /* K44  */  be_nested_str_weak(log),
+    /* K45  */  be_nested_str_weak(MTR_X3A_X20AddNoc_X20Args_X3D),
+    /* K46  */  be_nested_str_weak(get_temp_ca),
+    /* K47  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20AdNOC_X20without_X20CA),
+    /* K48  */  be_nested_str_weak(sessions),
+    /* K49  */  be_nested_str_weak(create_fabric),
+    /* K50  */  be_nested_str_weak(set_ca),
+    /* K51  */  be_nested_str_weak(set_noc_icac),
+    /* K52  */  be_nested_str_weak(set_ipk_epoch_key),
+    /* K53  */  be_nested_str_weak(set_admin_subject_vendor),
+    /* K54  */  be_nested_str_weak(set_pk),
+    /* K55  */  be_nested_str_weak(get_pk),
+    /* K56  */  be_nested_str_weak(parse),
+    /* K57  */  be_nested_str_weak(findsub),
+    /* K58  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20no_X20fabricid_X20nor_X20deviceid_X20in_X20NOC_X20certificate),
+    /* K59  */  be_nested_str_weak(int),
+    /* K60  */  be_nested_str_weak(int64),
+    /* K61  */  be_nested_str_weak(fromu32),
+    /* K62  */  be_nested_str_weak(tobytes),
+    /* K63  */  be_nested_str_weak(get_temp_ca_pub),
+    /* K64  */  be_const_int(2147483647),
+    /* K65  */  be_nested_str_weak(fromstring),
+    /* K66  */  be_nested_str_weak(CompressedFabric),
+    /* K67  */  be_nested_str_weak(HKDF_SHA256),
+    /* K68  */  be_nested_str_weak(copy),
+    /* K69  */  be_nested_str_weak(reverse),
+    /* K70  */  be_nested_str_weak(derive),
+    /* K71  */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K72  */  be_nested_str_weak(set_fabric_device),
+    /* K73  */  be_nested_str_weak(fabric_candidate),
+    /* K74  */  be_nested_str_weak(start_operational_discovery_deferred),
+    /* K75  */  be_nested_str_weak(is_PASE),
+    /* K76  */  be_nested_str_weak(set_expire_in_seconds),
+    /* K77  */  be_nested_str_weak(log_new_fabric),
+    /* K78  */  be_nested_str_weak(set_fabric_label),
+    /* K79  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Update_X20fabric_X20_X27_X25s_X27_X20label_X3D_X27_X25s_X27),
+    /* K80  */  be_nested_str_weak(get_fabric_id),
+    /* K81  */  be_nested_str_weak(tohex),
+    /* K82  */  be_nested_str_weak(fabric_index_X3A),
+    /* K83  */  be_nested_str_weak(active_fabrics),
+    /* K84  */  be_nested_str_weak(get_fabric_index),
+    /* K85  */  be_nested_str_weak(set_timer),
+    /* K86  */  be_nested_str_weak(stop_iteration),
+    /* K87  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
+    /* K88  */  be_nested_str_weak(_X29_X20not_X20found),
+    /* K89  */  be_nested_str_weak(INVALID_ACTION),
+    /* K90  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
+    /* K91  */  be_nested_str_weak(INVALID_DATA_TYPE),
+    /* K92  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
+    /* K93  */  be_nested_str_weak(CONSTRAINT_ERROR),
+    /* K94  */  be_nested_str_weak(start_basic_commissioning),
+    /* K95  */  be_nested_str_weak(get_fabric),
+    /* K96  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
+    /* K97  */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K98  */  be_nested_str_weak(stop_basic_commissioning),
+    /* K99  */  be_nested_str_weak(invoke_request),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
@@ -220,17 +219,17 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x1C200E08,  //  0040  EQ	R8	R7	R8
       0x78220021,  //  0041  JMPF	R8	#0064
       0x8C200111,  //  0042  GETMET	R8	R0	K17
-      0x88280712,  //  0043  GETMBR	R10	R3	K18
+      0x5C280600,  //  0043  MOVE	R10	R3
       0x7C200400,  //  0044  CALL	R8	2
-      0x88200313,  //  0045  GETMBR	R8	R1	K19
+      0x88200312,  //  0045  GETMBR	R8	R1	K18
       0x7822001B,  //  0046  JMPF	R8	#0063
       0x90061105,  //  0047  SETMBR	R1	K8	K5
-      0x88200313,  //  0048  GETMBR	R8	R1	K19
-      0x8C201114,  //  0049  GETMET	R8	R8	K20
+      0x88200312,  //  0048  GETMBR	R8	R1	K18
+      0x8C201113,  //  0049  GETMET	R8	R8	K19
       0x7C200200,  //  004A  CALL	R8	1
-      0x8C200315,  //  004B  GETMET	R8	R1	K21
+      0x8C200314,  //  004B  GETMET	R8	R1	K20
       0x7C200200,  //  004C  CALL	R8	1
-      0x8C200316,  //  004D  GETMET	R8	R1	K22
+      0x8C200315,  //  004D  GETMET	R8	R1	K21
       0x7C200200,  //  004E  CALL	R8	1
       0x8C200B09,  //  004F  GETMET	R8	R5	K9
       0x7C200200,  //  0050  CALL	R8	1
@@ -246,13 +245,13 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C240800,  //  005A  CALL	R9	4
       0x54260004,  //  005B  LDINT	R9	5
       0x900E0809,  //  005C  SETMBR	R3	K4	R9
-      0x88240117,  //  005D  GETMBR	R9	R0	K23
-      0x8C241318,  //  005E  GETMET	R9	R9	K24
+      0x88240116,  //  005D  GETMBR	R9	R0	K22
+      0x8C241317,  //  005E  GETMET	R9	R9	K23
       0x5C2C0200,  //  005F  MOVE	R11	R1
       0x7C240400,  //  0060  CALL	R9	2
       0x80041000,  //  0061  RET	1	R8
       0x70020000,  //  0062  JMP		#0064
-      0xB006331A,  //  0063  RAISE	1	K25	K26
+      0xB0063119,  //  0063  RAISE	1	K24	K25
       0x70020261,  //  0064  JMP		#02C7
       0x5422003D,  //  0065  LDINT	R8	62
       0x1C200C08,  //  0066  EQ	R8	R6	R8
@@ -267,23 +266,23 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x2024110E,  //  006F  NE	R9	R8	K14
       0x78260004,  //  0070  JMPF	R9	#0076
       0xB8260200,  //  0071  GETNGBL	R9	K1
-      0x8824131C,  //  0072  GETMBR	R9	R9	K28
-      0x900E3609,  //  0073  SETMBR	R3	K27	R9
+      0x8824131B,  //  0072  GETMBR	R9	R9	K27
+      0x900E3409,  //  0073  SETMBR	R3	K26	R9
       0x4C240000,  //  0074  LDNIL	R9
       0x80041200,  //  0075  RET	1	R9
       0x8C240B09,  //  0076  GETMET	R9	R5	K9
       0x7C240200,  //  0077  CALL	R9	1
       0x8C28130A,  //  0078  GETMET	R10	R9	K10
       0x58300005,  //  0079  LDCONST	R12	K5
-      0x88340B1D,  //  007A  GETMBR	R13	R5	K29
+      0x88340B1C,  //  007A  GETMBR	R13	R5	K28
       0x1C381107,  //  007B  EQ	R14	R8	K7
       0x783A0003,  //  007C  JMPF	R14	#0081
       0xB83A0200,  //  007D  GETNGBL	R14	K1
-      0x8C381D1E,  //  007E  GETMET	R14	R14	K30
+      0x8C381D1D,  //  007E  GETMET	R14	R14	K29
       0x7C380200,  //  007F  CALL	R14	1
       0x70020002,  //  0080  JMP		#0084
       0xB83A0200,  //  0081  GETNGBL	R14	K1
-      0x8C381D1F,  //  0082  GETMET	R14	R14	K31
+      0x8C381D1E,  //  0082  GETMET	R14	R14	K30
       0x7C380200,  //  0083  CALL	R14	1
       0x7C280800,  //  0084  CALL	R10	4
       0x900E0910,  //  0085  SETMBR	R3	K4	K16
@@ -307,33 +306,33 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C240200,  //  0097  CALL	R9	1
       0x8C28130A,  //  0098  GETMET	R10	R9	K10
       0x58300007,  //  0099  LDCONST	R12	K7
-      0x88340B1D,  //  009A  GETMBR	R13	R5	K29
+      0x88340B1C,  //  009A  GETMBR	R13	R5	K28
       0xB83A0200,  //  009B  GETNGBL	R14	K1
-      0x8C381D20,  //  009C  GETMET	R14	R14	K32
+      0x8C381D1F,  //  009C  GETMET	R14	R14	K31
       0x7C380200,  //  009D  CALL	R14	1
       0x7C280800,  //  009E  CALL	R10	4
       0x8C28130A,  //  009F  GETMET	R10	R9	K10
       0x5830000E,  //  00A0  LDCONST	R12	K14
-      0x88340B21,  //  00A1  GETMBR	R13	R5	K33
+      0x88340B20,  //  00A1  GETMBR	R13	R5	K32
       0x5C381000,  //  00A2  MOVE	R14	R8
       0x7C280800,  //  00A3  CALL	R10	4
       0x8C28130A,  //  00A4  GETMET	R10	R9	K10
       0x58300010,  //  00A5  LDCONST	R12	K16
-      0x88340B22,  //  00A6  GETMBR	R13	R5	K34
-      0xB83A4600,  //  00A7  GETNGBL	R14	K35
-      0x8C381D24,  //  00A8  GETMET	R14	R14	K36
+      0x88340B21,  //  00A6  GETMBR	R13	R5	K33
+      0xB83A4400,  //  00A7  GETNGBL	R14	K34
+      0x8C381D23,  //  00A8  GETMET	R14	R14	K35
       0x7C380200,  //  00A9  CALL	R14	1
       0x7C280800,  //  00AA  CALL	R10	4
-      0x8C281325,  //  00AB  GETMET	R10	R9	K37
+      0x8C281324,  //  00AB  GETMET	R10	R9	K36
       0x7C280200,  //  00AC  CALL	R10	1
-      0x8C2C0326,  //  00AD  GETMET	R11	R1	K38
+      0x8C2C0325,  //  00AD  GETMET	R11	R1	K37
       0x7C2C0200,  //  00AE  CALL	R11	1
       0x0030140B,  //  00AF  ADD	R12	R10	R11
-      0x8C340927,  //  00B0  GETMET	R13	R4	K39
+      0x8C340926,  //  00B0  GETMET	R13	R4	K38
       0x7C340200,  //  00B1  CALL	R13	1
-      0x8C341B28,  //  00B2  GETMET	R13	R13	K40
+      0x8C341B27,  //  00B2  GETMET	R13	R13	K39
       0xB83E0200,  //  00B3  GETNGBL	R15	K1
-      0x8C3C1F29,  //  00B4  GETMET	R15	R15	K41
+      0x8C3C1F28,  //  00B4  GETMET	R15	R15	K40
       0x7C3C0200,  //  00B5  CALL	R15	1
       0x5C401800,  //  00B6  MOVE	R16	R12
       0x7C340600,  //  00B7  CALL	R13	3
@@ -341,12 +340,12 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C380200,  //  00B9  CALL	R14	1
       0x8C3C1D0A,  //  00BA  GETMET	R15	R14	K10
       0x58440005,  //  00BB  LDCONST	R17	K5
-      0x88480B1D,  //  00BC  GETMBR	R18	R5	K29
+      0x88480B1C,  //  00BC  GETMBR	R18	R5	K28
       0x5C4C1400,  //  00BD  MOVE	R19	R10
       0x7C3C0800,  //  00BE  CALL	R15	4
       0x8C3C1D0A,  //  00BF  GETMET	R15	R14	K10
       0x58440007,  //  00C0  LDCONST	R17	K7
-      0x88480B21,  //  00C1  GETMBR	R18	R5	K33
+      0x88480B20,  //  00C1  GETMBR	R18	R5	K32
       0x5C4C1A00,  //  00C2  MOVE	R19	R13
       0x7C3C0800,  //  00C3  CALL	R15	4
       0x900E0907,  //  00C4  SETMBR	R3	K4	K7
@@ -356,7 +355,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x1C200E08,  //  00C8  EQ	R8	R7	R8
       0x7822003C,  //  00C9  JMPF	R8	#0107
       0x8C200111,  //  00CA  GETMET	R8	R0	K17
-      0x88280712,  //  00CB  GETMBR	R10	R3	K18
+      0x5C280600,  //  00CB  MOVE	R10	R3
       0x7C200400,  //  00CC  CALL	R8	2
       0x8C200506,  //  00CD  GETMET	R8	R2	K6
       0x58280005,  //  00CE  LDCONST	R10	K5
@@ -373,30 +372,30 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x582C0007,  //  00D9  LDCONST	R11	K7
       0x50300000,  //  00DA  LDBOOL	R12	0	0
       0x7C240600,  //  00DB  CALL	R9	3
-      0x8C28032A,  //  00DC  GETMET	R10	R1	K42
+      0x8C280329,  //  00DC  GETMET	R10	R1	K41
       0x7C280200,  //  00DD  CALL	R10	1
       0x8C2C0B09,  //  00DE  GETMET	R11	R5	K9
       0x7C2C0200,  //  00DF  CALL	R11	1
       0x8C30170A,  //  00E0  GETMET	R12	R11	K10
       0x58380007,  //  00E1  LDCONST	R14	K7
-      0x883C0B1D,  //  00E2  GETMBR	R15	R5	K29
+      0x883C0B1C,  //  00E2  GETMBR	R15	R5	K28
       0x5C401400,  //  00E3  MOVE	R16	R10
       0x7C300800,  //  00E4  CALL	R12	4
       0x8C30170A,  //  00E5  GETMET	R12	R11	K10
       0x5838000E,  //  00E6  LDCONST	R14	K14
-      0x883C0B21,  //  00E7  GETMBR	R15	R5	K33
+      0x883C0B20,  //  00E7  GETMBR	R15	R5	K32
       0x5C401000,  //  00E8  MOVE	R16	R8
       0x7C300800,  //  00E9  CALL	R12	4
-      0x8C301725,  //  00EA  GETMET	R12	R11	K37
+      0x8C301724,  //  00EA  GETMET	R12	R11	K36
       0x7C300200,  //  00EB  CALL	R12	1
-      0x8C340326,  //  00EC  GETMET	R13	R1	K38
+      0x8C340325,  //  00EC  GETMET	R13	R1	K37
       0x7C340200,  //  00ED  CALL	R13	1
       0x0034180D,  //  00EE  ADD	R13	R12	R13
-      0x8C380927,  //  00EF  GETMET	R14	R4	K39
+      0x8C380926,  //  00EF  GETMET	R14	R4	K38
       0x7C380200,  //  00F0  CALL	R14	1
-      0x8C381D28,  //  00F1  GETMET	R14	R14	K40
+      0x8C381D27,  //  00F1  GETMET	R14	R14	K39
       0xB8420200,  //  00F2  GETNGBL	R16	K1
-      0x8C402129,  //  00F3  GETMET	R16	R16	K41
+      0x8C402128,  //  00F3  GETMET	R16	R16	K40
       0x7C400200,  //  00F4  CALL	R16	1
       0x5C441A00,  //  00F5  MOVE	R17	R13
       0x7C380600,  //  00F6  CALL	R14	3
@@ -404,12 +403,12 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C3C0200,  //  00F8  CALL	R15	1
       0x8C401F0A,  //  00F9  GETMET	R16	R15	K10
       0x58480005,  //  00FA  LDCONST	R18	K5
-      0x884C0B1D,  //  00FB  GETMBR	R19	R5	K29
+      0x884C0B1C,  //  00FB  GETMBR	R19	R5	K28
       0x5C501800,  //  00FC  MOVE	R20	R12
       0x7C400800,  //  00FD  CALL	R16	4
       0x8C401F0A,  //  00FE  GETMET	R16	R15	K10
       0x58480007,  //  00FF  LDCONST	R18	K7
-      0x884C0B21,  //  0100  GETMBR	R19	R5	K33
+      0x884C0B20,  //  0100  GETMBR	R19	R5	K32
       0x5C501C00,  //  0101  MOVE	R20	R14
       0x7C400800,  //  0102  CALL	R16	4
       0x54420004,  //  0103  LDINT	R16	5
@@ -422,24 +421,24 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x8C200506,  //  010A  GETMET	R8	R2	K6
       0x58280005,  //  010B  LDCONST	R10	K5
       0x7C200400,  //  010C  CALL	R8	2
-      0x8C24032B,  //  010D  GETMET	R9	R1	K43
+      0x8C24032A,  //  010D  GETMET	R9	R1	K42
       0x5C2C1000,  //  010E  MOVE	R11	R8
       0x7C240400,  //  010F  CALL	R9	2
       0xB8260200,  //  0110  GETNGBL	R9	K1
-      0x8824132C,  //  0111  GETMBR	R9	R9	K44
-      0x900E3609,  //  0112  SETMBR	R3	K27	R9
+      0x8824132B,  //  0111  GETMBR	R9	R9	K43
+      0x900E3409,  //  0112  SETMBR	R3	K26	R9
       0x4C240000,  //  0113  LDNIL	R9
       0x80041200,  //  0114  RET	1	R9
       0x70020113,  //  0115  JMP		#022A
       0x54220005,  //  0116  LDINT	R8	6
       0x1C200E08,  //  0117  EQ	R8	R7	R8
       0x782200B9,  //  0118  JMPF	R8	#01D3
-      0xB8224600,  //  0119  GETNGBL	R8	K35
-      0x8C20112D,  //  011A  GETMET	R8	R8	K45
+      0xB8224400,  //  0119  GETNGBL	R8	K34
+      0x8C20112C,  //  011A  GETMET	R8	R8	K44
       0x60280008,  //  011B  GETGBL	R10	G8
       0x5C2C0400,  //  011C  MOVE	R11	R2
       0x7C280200,  //  011D  CALL	R10	1
-      0x002A5C0A,  //  011E  ADD	R10	K46	R10
+      0x002A5A0A,  //  011E  ADD	R10	K45	R10
       0x542E0003,  //  011F  LDINT	R11	4
       0x7C200600,  //  0120  CALL	R8	3
       0x8C200506,  //  0121  GETMET	R8	R2	K6
@@ -463,47 +462,47 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x8C300506,  //  0133  GETMET	R12	R2	K6
       0x543A0003,  //  0134  LDINT	R14	4
       0x7C300400,  //  0135  CALL	R12	2
-      0x8C34032F,  //  0136  GETMET	R13	R1	K47
+      0x8C34032E,  //  0136  GETMET	R13	R1	K46
       0x7C340200,  //  0137  CALL	R13	1
       0x4C380000,  //  0138  LDNIL	R14
       0x1C341A0E,  //  0139  EQ	R13	R13	R14
       0x78360006,  //  013A  JMPF	R13	#0142
-      0xB8364600,  //  013B  GETNGBL	R13	K35
-      0x8C341B2D,  //  013C  GETMET	R13	R13	K45
-      0x583C0030,  //  013D  LDCONST	R15	K48
+      0xB8364400,  //  013B  GETNGBL	R13	K34
+      0x8C341B2C,  //  013C  GETMET	R13	R13	K44
+      0x583C002F,  //  013D  LDCONST	R15	K47
       0x5840000E,  //  013E  LDCONST	R16	K14
       0x7C340600,  //  013F  CALL	R13	3
       0x4C340000,  //  0140  LDNIL	R13
       0x80041A00,  //  0141  RET	1	R13
-      0x88340117,  //  0142  GETMBR	R13	R0	K23
-      0x88341B31,  //  0143  GETMBR	R13	R13	K49
-      0x8C341B32,  //  0144  GETMET	R13	R13	K50
+      0x88340116,  //  0142  GETMBR	R13	R0	K22
+      0x88341B30,  //  0143  GETMBR	R13	R13	K48
+      0x8C341B31,  //  0144  GETMET	R13	R13	K49
       0x7C340200,  //  0145  CALL	R13	1
-      0x8C381B33,  //  0146  GETMET	R14	R13	K51
-      0x8C40032F,  //  0147  GETMET	R16	R1	K47
+      0x8C381B32,  //  0146  GETMET	R14	R13	K50
+      0x8C40032E,  //  0147  GETMET	R16	R1	K46
       0x7C400200,  //  0148  CALL	R16	1
       0x7C380400,  //  0149  CALL	R14	2
-      0x8C381B34,  //  014A  GETMET	R14	R13	K52
+      0x8C381B33,  //  014A  GETMET	R14	R13	K51
       0x5C401000,  //  014B  MOVE	R16	R8
       0x5C441200,  //  014C  MOVE	R17	R9
       0x7C380600,  //  014D  CALL	R14	3
-      0x8C381B35,  //  014E  GETMET	R14	R13	K53
+      0x8C381B34,  //  014E  GETMET	R14	R13	K52
       0x5C401400,  //  014F  MOVE	R16	R10
       0x7C380400,  //  0150  CALL	R14	2
-      0x8C381B36,  //  0151  GETMET	R14	R13	K54
+      0x8C381B35,  //  0151  GETMET	R14	R13	K53
       0x5C401600,  //  0152  MOVE	R16	R11
       0x5C441800,  //  0153  MOVE	R17	R12
       0x7C380600,  //  0154  CALL	R14	3
-      0x8C381B37,  //  0155  GETMET	R14	R13	K55
-      0x8C400338,  //  0156  GETMET	R16	R1	K56
+      0x8C381B36,  //  0155  GETMET	R14	R13	K54
+      0x8C400337,  //  0156  GETMET	R16	R1	K55
       0x7C400200,  //  0157  CALL	R16	1
       0x7C380400,  //  0158  CALL	R14	2
       0xB83A0200,  //  0159  GETNGBL	R14	K1
       0x88381D02,  //  015A  GETMBR	R14	R14	K2
-      0x8C381D39,  //  015B  GETMET	R14	R14	K57
+      0x8C381D38,  //  015B  GETMET	R14	R14	K56
       0x5C401000,  //  015C  MOVE	R16	R8
       0x7C380400,  //  015D  CALL	R14	2
-      0x8C3C1D3A,  //  015E  GETMET	R15	R14	K58
+      0x8C3C1D39,  //  015E  GETMET	R15	R14	K57
       0x54460005,  //  015F  LDINT	R17	6
       0x7C3C0400,  //  0160  CALL	R15	2
       0x8C401F06,  //  0161  GETMET	R16	R15	K6
@@ -516,9 +515,9 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x784A0001,  //  0168  JMPF	R18	#016B
       0x5C482200,  //  0169  MOVE	R18	R17
       0x744A0006,  //  016A  JMPT	R18	#0172
-      0xB84A4600,  //  016B  GETNGBL	R18	K35
-      0x8C48252D,  //  016C  GETMET	R18	R18	K45
-      0x5850003B,  //  016D  LDCONST	R20	K59
+      0xB84A4400,  //  016B  GETNGBL	R18	K34
+      0x8C48252C,  //  016C  GETMET	R18	R18	K44
+      0x5850003A,  //  016D  LDCONST	R20	K58
       0x5854000E,  //  016E  LDCONST	R21	K14
       0x7C480600,  //  016F  CALL	R18	3
       0x50480000,  //  0170  LDBOOL	R18	0	0
@@ -526,82 +525,82 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x60480004,  //  0172  GETGBL	R18	G4
       0x5C4C2000,  //  0173  MOVE	R19	R16
       0x7C480200,  //  0174  CALL	R18	1
-      0x1C48253C,  //  0175  EQ	R18	R18	K60
+      0x1C48253B,  //  0175  EQ	R18	R18	K59
       0x784A0007,  //  0176  JMPF	R18	#017F
-      0xB84A7A00,  //  0177  GETNGBL	R18	K61
-      0x8C48253E,  //  0178  GETMET	R18	R18	K62
+      0xB84A7800,  //  0177  GETNGBL	R18	K60
+      0x8C48253D,  //  0178  GETMET	R18	R18	K61
       0x5C502000,  //  0179  MOVE	R20	R16
       0x7C480400,  //  017A  CALL	R18	2
-      0x8C48253F,  //  017B  GETMET	R18	R18	K63
+      0x8C48253E,  //  017B  GETMET	R18	R18	K62
       0x7C480200,  //  017C  CALL	R18	1
       0x5C402400,  //  017D  MOVE	R16	R18
       0x70020002,  //  017E  JMP		#0182
-      0x8C48213F,  //  017F  GETMET	R18	R16	K63
+      0x8C48213E,  //  017F  GETMET	R18	R16	K62
       0x7C480200,  //  0180  CALL	R18	1
       0x5C402400,  //  0181  MOVE	R16	R18
       0x60480004,  //  0182  GETGBL	R18	G4
       0x5C4C2200,  //  0183  MOVE	R19	R17
       0x7C480200,  //  0184  CALL	R18	1
-      0x1C48253C,  //  0185  EQ	R18	R18	K60
+      0x1C48253B,  //  0185  EQ	R18	R18	K59
       0x784A0007,  //  0186  JMPF	R18	#018F
-      0xB84A7A00,  //  0187  GETNGBL	R18	K61
-      0x8C48253E,  //  0188  GETMET	R18	R18	K62
+      0xB84A7800,  //  0187  GETNGBL	R18	K60
+      0x8C48253D,  //  0188  GETMET	R18	R18	K61
       0x5C502200,  //  0189  MOVE	R20	R17
       0x7C480400,  //  018A  CALL	R18	2
-      0x8C48253F,  //  018B  GETMET	R18	R18	K63
+      0x8C48253E,  //  018B  GETMET	R18	R18	K62
       0x7C480200,  //  018C  CALL	R18	1
       0x5C442400,  //  018D  MOVE	R17	R18
       0x70020002,  //  018E  JMP		#0192
-      0x8C48233F,  //  018F  GETMET	R18	R17	K63
+      0x8C48233E,  //  018F  GETMET	R18	R17	K62
       0x7C480200,  //  0190  CALL	R18	1
       0x5C442400,  //  0191  MOVE	R17	R18
-      0x8C480340,  //  0192  GETMET	R18	R1	K64
+      0x8C48033F,  //  0192  GETMET	R18	R1	K63
       0x7C480200,  //  0193  CALL	R18	1
-      0x404E0F41,  //  0194  CONNECT	R19	K7	K65
+      0x404E0F40,  //  0194  CONNECT	R19	K7	K64
       0x94482413,  //  0195  GETIDX	R18	R18	R19
       0x60500015,  //  0196  GETGBL	R20	G21
       0x7C500000,  //  0197  CALL	R20	0
-      0x8C502942,  //  0198  GETMET	R20	R20	K66
-      0x58580043,  //  0199  LDCONST	R22	K67
+      0x8C502941,  //  0198  GETMET	R20	R20	K65
+      0x58580042,  //  0199  LDCONST	R22	K66
       0x7C500400,  //  019A  CALL	R20	2
       0x5C4C2800,  //  019B  MOVE	R19	R20
-      0x8C500944,  //  019C  GETMET	R20	R4	K68
+      0x8C500943,  //  019C  GETMET	R20	R4	K67
       0x7C500200,  //  019D  CALL	R20	1
-      0x8C542145,  //  019E  GETMET	R21	R16	K69
+      0x8C542144,  //  019E  GETMET	R21	R16	K68
       0x7C540200,  //  019F  CALL	R21	1
-      0x8C542B46,  //  01A0  GETMET	R21	R21	K70
+      0x8C542B45,  //  01A0  GETMET	R21	R21	K69
       0x7C540200,  //  01A1  CALL	R21	1
-      0x8C582947,  //  01A2  GETMET	R22	R20	K71
+      0x8C582946,  //  01A2  GETMET	R22	R20	K70
       0x5C602400,  //  01A3  MOVE	R24	R18
       0x5C642A00,  //  01A4  MOVE	R25	R21
       0x5C682600,  //  01A5  MOVE	R26	R19
       0x546E0007,  //  01A6  LDINT	R27	8
       0x7C580A00,  //  01A7  CALL	R22	5
-      0x885C0313,  //  01A8  GETMBR	R23	R1	K19
+      0x885C0312,  //  01A8  GETMBR	R23	R1	K18
       0x785E0001,  //  01A9  JMPF	R23	#01AC
-      0x885C0313,  //  01AA  GETMBR	R23	R1	K19
+      0x885C0312,  //  01AA  GETMBR	R23	R1	K18
       0x70020001,  //  01AB  JMP		#01AE
-      0x885C0117,  //  01AC  GETMBR	R23	R0	K23
-      0x885C2F48,  //  01AD  GETMBR	R23	R23	K72
-      0x8C601B49,  //  01AE  GETMET	R24	R13	K73
+      0x885C0116,  //  01AC  GETMBR	R23	R0	K22
+      0x885C2F47,  //  01AD  GETMBR	R23	R23	K71
+      0x8C601B48,  //  01AE  GETMET	R24	R13	K72
       0x5C682000,  //  01AF  MOVE	R26	R16
       0x5C6C2200,  //  01B0  MOVE	R27	R17
       0x5C702C00,  //  01B1  MOVE	R28	R22
       0x5C742E00,  //  01B2  MOVE	R29	R23
       0x7C600A00,  //  01B3  CALL	R24	5
-      0x8C601B4A,  //  01B4  GETMET	R24	R13	K74
+      0x8C601B49,  //  01B4  GETMET	R24	R13	K73
       0x7C600200,  //  01B5  CALL	R24	1
-      0x88600117,  //  01B6  GETMBR	R24	R0	K23
-      0x8C60314B,  //  01B7  GETMET	R24	R24	K75
+      0x88600116,  //  01B6  GETMBR	R24	R0	K22
+      0x8C60314A,  //  01B7  GETMET	R24	R24	K74
       0x5C681A00,  //  01B8  MOVE	R26	R13
       0x7C600400,  //  01B9  CALL	R24	2
-      0x8C60034C,  //  01BA  GETMET	R24	R1	K76
+      0x8C60034B,  //  01BA  GETMET	R24	R1	K75
       0x7C600200,  //  01BB  CALL	R24	1
       0x78620002,  //  01BC  JMPF	R24	#01C0
-      0x8C60034D,  //  01BD  GETMET	R24	R1	K77
+      0x8C60034C,  //  01BD  GETMET	R24	R1	K76
       0x546A003B,  //  01BE  LDINT	R26	60
       0x7C600400,  //  01BF  CALL	R24	2
-      0x8C601B4E,  //  01C0  GETMET	R24	R13	K78
+      0x8C601B4D,  //  01C0  GETMET	R24	R13	K77
       0x7C600200,  //  01C1  CALL	R24	1
       0x8C600B09,  //  01C2  GETMET	R24	R5	K9
       0x7C600200,  //  01C3  CALL	R24	1
@@ -609,7 +608,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x586C0005,  //  01C5  LDCONST	R27	K5
       0x88700B0B,  //  01C6  GETMBR	R28	R5	K11
       0xB8760200,  //  01C7  GETNGBL	R29	K1
-      0x88743B2C,  //  01C8  GETMBR	R29	R29	K44
+      0x88743B2B,  //  01C8  GETMBR	R29	R29	K43
       0x7C640800,  //  01C9  CALL	R25	4
       0x8C64310A,  //  01CA  GETMET	R25	R24	K10
       0x586C0007,  //  01CB  LDCONST	R27	K7
@@ -626,21 +625,21 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x8C200506,  //  01D6  GETMET	R8	R2	K6
       0x58280005,  //  01D7  LDCONST	R10	K5
       0x7C200400,  //  01D8  CALL	R8	2
-      0x8C24034F,  //  01D9  GETMET	R9	R1	K79
+      0x8C24034E,  //  01D9  GETMET	R9	R1	K78
       0x5C2C1000,  //  01DA  MOVE	R11	R8
       0x7C240400,  //  01DB  CALL	R9	2
-      0xB8264600,  //  01DC  GETNGBL	R9	K35
-      0x8C24132D,  //  01DD  GETMET	R9	R9	K45
+      0xB8264400,  //  01DC  GETNGBL	R9	K34
+      0x8C24132C,  //  01DD  GETMET	R9	R9	K44
       0x602C0018,  //  01DE  GETGBL	R11	G24
-      0x58300050,  //  01DF  LDCONST	R12	K80
-      0x88340313,  //  01E0  GETMBR	R13	R1	K19
-      0x8C341B51,  //  01E1  GETMET	R13	R13	K81
+      0x5830004F,  //  01DF  LDCONST	R12	K79
+      0x88340312,  //  01E0  GETMBR	R13	R1	K18
+      0x8C341B50,  //  01E1  GETMET	R13	R13	K80
       0x7C340200,  //  01E2  CALL	R13	1
-      0x8C341B45,  //  01E3  GETMET	R13	R13	K69
+      0x8C341B44,  //  01E3  GETMET	R13	R13	K68
       0x7C340200,  //  01E4  CALL	R13	1
-      0x8C341B46,  //  01E5  GETMET	R13	R13	K70
+      0x8C341B45,  //  01E5  GETMET	R13	R13	K69
       0x7C340200,  //  01E6  CALL	R13	1
-      0x8C341B52,  //  01E7  GETMET	R13	R13	K82
+      0x8C341B51,  //  01E7  GETMET	R13	R13	K81
       0x7C340200,  //  01E8  CALL	R13	1
       0x60380008,  //  01E9  GETGBL	R14	G8
       0x5C3C1000,  //  01EA  MOVE	R15	R8
@@ -649,8 +648,8 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x58300010,  //  01ED  LDCONST	R12	K16
       0x7C240600,  //  01EE  CALL	R9	3
       0xB8260200,  //  01EF  GETNGBL	R9	K1
-      0x8824132C,  //  01F0  GETMBR	R9	R9	K44
-      0x900E3609,  //  01F1  SETMBR	R3	K27	R9
+      0x8824132B,  //  01F0  GETMBR	R9	R9	K43
+      0x900E3409,  //  01F1  SETMBR	R3	K26	R9
       0x4C240000,  //  01F2  LDNIL	R9
       0x80041200,  //  01F3  RET	1	R9
       0x70020034,  //  01F4  JMP		#022A
@@ -663,23 +662,23 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x60240008,  //  01FB  GETGBL	R9	G8
       0x5C281000,  //  01FC  MOVE	R10	R8
       0x7C240200,  //  01FD  CALL	R9	1
-      0x0026A609,  //  01FE  ADD	R9	K83	R9
-      0x900E5A09,  //  01FF  SETMBR	R3	K45	R9
+      0x0026A409,  //  01FE  ADD	R9	K82	R9
+      0x900E5809,  //  01FF  SETMBR	R3	K44	R9
       0x60240010,  //  0200  GETGBL	R9	G16
-      0x88280117,  //  0201  GETMBR	R10	R0	K23
-      0x88281531,  //  0202  GETMBR	R10	R10	K49
-      0x8C281554,  //  0203  GETMET	R10	R10	K84
+      0x88280116,  //  0201  GETMBR	R10	R0	K22
+      0x88281530,  //  0202  GETMBR	R10	R10	K48
+      0x8C281553,  //  0203  GETMET	R10	R10	K83
       0x7C280200,  //  0204  CALL	R10	1
       0x7C240200,  //  0205  CALL	R9	1
       0xA8020010,  //  0206  EXBLK	0	#0218
       0x5C281200,  //  0207  MOVE	R10	R9
       0x7C280000,  //  0208  CALL	R10	0
-      0x8C2C1555,  //  0209  GETMET	R11	R10	K85
+      0x8C2C1554,  //  0209  GETMET	R11	R10	K84
       0x7C2C0200,  //  020A  CALL	R11	1
       0x1C2C1608,  //  020B  EQ	R11	R11	R8
       0x782E0008,  //  020C  JMPF	R11	#0216
-      0xB82E4600,  //  020D  GETNGBL	R11	K35
-      0x8C2C1756,  //  020E  GETMET	R11	R11	K86
+      0xB82E4400,  //  020D  GETNGBL	R11	K34
+      0x8C2C1755,  //  020E  GETMET	R11	R11	K85
       0x543607CF,  //  020F  LDINT	R13	2000
       0x84380000,  //  0210  CLOSURE	R14	P0
       0x7C2C0600,  //  0211  CALL	R11	3
@@ -689,21 +688,21 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x80041600,  //  0215  RET	1	R11
       0xA0240000,  //  0216  CLOSE	R9
       0x7001FFEE,  //  0217  JMP		#0207
-      0x58240057,  //  0218  LDCONST	R9	K87
+      0x58240056,  //  0218  LDCONST	R9	K86
       0xAC240200,  //  0219  CATCH	R9	1	0
       0xB0080000,  //  021A  RAISE	2	R0	R0
-      0xB8264600,  //  021B  GETNGBL	R9	K35
-      0x8C24132D,  //  021C  GETMET	R9	R9	K45
+      0xB8264400,  //  021B  GETNGBL	R9	K34
+      0x8C24132C,  //  021C  GETMET	R9	R9	K44
       0x602C0008,  //  021D  GETGBL	R11	G8
       0x5C301000,  //  021E  MOVE	R12	R8
       0x7C2C0200,  //  021F  CALL	R11	1
-      0x002EB00B,  //  0220  ADD	R11	K88	R11
-      0x002C1759,  //  0221  ADD	R11	R11	K89
+      0x002EAE0B,  //  0220  ADD	R11	K87	R11
+      0x002C1758,  //  0221  ADD	R11	R11	K88
       0x5830000E,  //  0222  LDCONST	R12	K14
       0x7C240600,  //  0223  CALL	R9	3
       0xB8260200,  //  0224  GETNGBL	R9	K1
-      0x8824135A,  //  0225  GETMBR	R9	R9	K90
-      0x900E3609,  //  0226  SETMBR	R3	K27	R9
+      0x88241359,  //  0225  GETMBR	R9	R9	K89
+      0x900E3409,  //  0226  SETMBR	R3	K26	R9
       0x4C240000,  //  0227  LDNIL	R9
       0xA0000000,  //  0228  CLOSE	R0
       0x80041200,  //  0229  RET	1	R9
@@ -728,16 +727,16 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x8C300506,  //  023C  GETMET	R12	R2	K6
       0x543A0003,  //  023D  LDINT	R14	4
       0x7C300400,  //  023E  CALL	R12	2
-      0xB8364600,  //  023F  GETNGBL	R13	K35
-      0x8C341B2D,  //  0240  GETMET	R13	R13	K45
+      0xB8364400,  //  023F  GETNGBL	R13	K34
+      0x8C341B2C,  //  0240  GETMET	R13	R13	K44
       0x603C0018,  //  0241  GETGBL	R15	G24
-      0x5840005B,  //  0242  LDCONST	R16	K91
+      0x5840005A,  //  0242  LDCONST	R16	K90
       0x5C441000,  //  0243  MOVE	R17	R8
-      0x8C481352,  //  0244  GETMET	R18	R9	K82
+      0x8C481351,  //  0244  GETMET	R18	R9	K81
       0x7C480200,  //  0245  CALL	R18	1
       0x5C4C1400,  //  0246  MOVE	R19	R10
       0x5C501600,  //  0247  MOVE	R20	R11
-      0x8C541952,  //  0248  GETMET	R21	R12	K82
+      0x8C541951,  //  0248  GETMET	R21	R12	K81
       0x7C540200,  //  0249  CALL	R21	1
       0x7C3C0C00,  //  024A  CALL	R15	6
       0x54420003,  //  024B  LDINT	R16	4
@@ -758,8 +757,8 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x1C34180D,  //  025A  EQ	R13	R12	R13
       0x78360005,  //  025B  JMPF	R13	#0262
       0xB8360200,  //  025C  GETNGBL	R13	K1
-      0x88341B5C,  //  025D  GETMBR	R13	R13	K92
-      0x900E360D,  //  025E  SETMBR	R3	K27	R13
+      0x88341B5B,  //  025D  GETMBR	R13	R13	K91
+      0x900E340D,  //  025E  SETMBR	R3	K26	R13
       0x4C340000,  //  025F  LDNIL	R13
       0xA0000000,  //  0260  CLOSE	R0
       0x80041A00,  //  0261  RET	1	R13
@@ -783,14 +782,14 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x543A001F,  //  0273  LDINT	R14	32
       0x24341A0E,  //  0274  GT	R13	R13	R14
       0x7836000A,  //  0275  JMPF	R13	#0281
-      0xB8364600,  //  0276  GETNGBL	R13	K35
-      0x8C341B2D,  //  0277  GETMET	R13	R13	K45
-      0x583C005D,  //  0278  LDCONST	R15	K93
+      0xB8364400,  //  0276  GETNGBL	R13	K34
+      0x8C341B2C,  //  0277  GETMET	R13	R13	K44
+      0x583C005C,  //  0278  LDCONST	R15	K92
       0x5840000E,  //  0279  LDCONST	R16	K14
       0x7C340600,  //  027A  CALL	R13	3
       0xB8360200,  //  027B  GETNGBL	R13	K1
-      0x88341B5E,  //  027C  GETMBR	R13	R13	K94
-      0x900E360D,  //  027D  SETMBR	R3	K27	R13
+      0x88341B5D,  //  027C  GETMBR	R13	R13	K93
+      0x900E340D,  //  027D  SETMBR	R3	K26	R13
       0x4C340000,  //  027E  LDNIL	R13
       0xA0000000,  //  027F  CLOSE	R0
       0x80041A00,  //  0280  RET	1	R13
@@ -798,17 +797,17 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x40360A0D,  //  0282  CONNECT	R13	K5	R13
       0x9434120D,  //  0283  GETIDX	R13	R9	R13
       0x543A001F,  //  0284  LDINT	R14	32
-      0x40381D41,  //  0285  CONNECT	R14	R14	K65
+      0x40381D40,  //  0285  CONNECT	R14	R14	K64
       0x9438120E,  //  0286  GETIDX	R14	R9	R14
-      0x883C0117,  //  0287  GETMBR	R15	R0	K23
-      0x8C3C1F5F,  //  0288  GETMET	R15	R15	K95
+      0x883C0116,  //  0287  GETMBR	R15	R0	K22
+      0x8C3C1F5E,  //  0288  GETMET	R15	R15	K94
       0x5C441000,  //  0289  MOVE	R17	R8
       0x5C481600,  //  028A  MOVE	R18	R11
       0x5C4C1400,  //  028B  MOVE	R19	R10
       0x5C501800,  //  028C  MOVE	R20	R12
       0x5C541A00,  //  028D  MOVE	R21	R13
       0x5C581C00,  //  028E  MOVE	R22	R14
-      0x8C5C0360,  //  028F  GETMET	R23	R1	K96
+      0x8C5C035F,  //  028F  GETMET	R23	R1	K95
       0x7C5C0200,  //  0290  CALL	R23	1
       0x7C3C1000,  //  0291  CALL	R15	8
       0x503C0200,  //  0292  LDBOOL	R15	1	0
@@ -820,16 +819,16 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x8C200506,  //  0298  GETMET	R8	R2	K6
       0x58280005,  //  0299  LDCONST	R10	K5
       0x7C200400,  //  029A  CALL	R8	2
-      0xB8264600,  //  029B  GETNGBL	R9	K35
-      0x8C24132D,  //  029C  GETMET	R9	R9	K45
+      0xB8264400,  //  029B  GETNGBL	R9	K34
+      0x8C24132C,  //  029C  GETMET	R9	R9	K44
       0x602C0008,  //  029D  GETGBL	R11	G8
       0x5C301000,  //  029E  MOVE	R12	R8
       0x7C2C0200,  //  029F  CALL	R11	1
-      0x002EC20B,  //  02A0  ADD	R11	K97	R11
+      0x002EC00B,  //  02A0  ADD	R11	K96	R11
       0x58300010,  //  02A1  LDCONST	R12	K16
       0x7C240600,  //  02A2  CALL	R9	3
-      0x88240117,  //  02A3  GETMBR	R9	R0	K23
-      0x8C241362,  //  02A4  GETMET	R9	R9	K98
+      0x88240116,  //  02A3  GETMBR	R9	R0	K22
+      0x8C241361,  //  02A4  GETMET	R9	R9	K97
       0x5C2C1000,  //  02A5  MOVE	R11	R8
       0x7C240400,  //  02A6  CALL	R9	2
       0x50240200,  //  02A7  LDBOOL	R9	1	0
@@ -838,8 +837,8 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x70020007,  //  02AA  JMP		#02B3
       0x1C200F0E,  //  02AB  EQ	R8	R7	K14
       0x78220005,  //  02AC  JMPF	R8	#02B3
-      0x88200117,  //  02AD  GETMBR	R8	R0	K23
-      0x8C201163,  //  02AE  GETMET	R8	R8	K99
+      0x88200116,  //  02AD  GETMBR	R8	R0	K22
+      0x8C201162,  //  02AE  GETMET	R8	R8	K98
       0x7C200200,  //  02AF  CALL	R8	1
       0x50200200,  //  02B0  LDBOOL	R8	1	0
       0xA0000000,  //  02B1  CLOSE	R0
@@ -857,7 +856,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x60200003,  //  02BD  GETGBL	R8	G3
       0x5C240000,  //  02BE  MOVE	R9	R0
       0x7C200200,  //  02BF  CALL	R8	1
-      0x8C201164,  //  02C0  GETMET	R8	R8	K100
+      0x8C201163,  //  02C0  GETMET	R8	R8	K99
       0x5C280200,  //  02C1  MOVE	R10	R1
       0x5C2C0400,  //  02C2  MOVE	R11	R2
       0x5C300600,  //  02C3  MOVE	R12	R3
@@ -885,7 +884,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[93]) {     /* constants */
+    ( &(const bvalue[92]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
@@ -937,48 +936,47 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
     /* K48  */  be_const_int(1000000),
     /* K49  */  be_nested_str_weak(rtc),
     /* K50  */  be_nested_str_weak(local),
-    /* K51  */  be_nested_str_weak(send_ack_now),
-    /* K52  */  be_nested_str_weak(msg),
-    /* K53  */  be_nested_str_weak(fabric_filtered),
-    /* K54  */  be_nested_str_weak(get_fabric),
-    /* K55  */  be_nested_str_weak(device),
-    /* K56  */  be_nested_str_weak(sessions),
-    /* K57  */  be_nested_str_weak(active_fabrics),
-    /* K58  */  be_nested_str_weak(B2),
-    /* K59  */  be_nested_str_weak(get_noc),
-    /* K60  */  be_nested_str_weak(get_icac),
-    /* K61  */  be_nested_str_weak(get_fabric_index),
-    /* K62  */  be_nested_str_weak(stop_iteration),
-    /* K63  */  be_nested_str_weak(parse),
-    /* K64  */  be_nested_str_weak(get_ca),
-    /* K65  */  be_nested_str_weak(findsubval),
-    /* K66  */  be_nested_str_weak(get_admin_vendor),
-    /* K67  */  be_nested_str_weak(get_fabric_id),
-    /* K68  */  be_nested_str_weak(get_device_id),
-    /* K69  */  be_nested_str_weak(get_fabric_label),
-    /* K70  */  be_nested_str_weak(Fabric),
-    /* K71  */  be_nested_str_weak(_MAX_CASE),
-    /* K72  */  be_nested_str_weak(count_active_fabrics),
-    /* K73  */  be_nested_str_weak(_fabric),
-    /* K74  */  be_nested_str_weak(is_commissioning_open),
-    /* K75  */  be_nested_str_weak(is_root_commissioning_open),
-    /* K76  */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K77  */  be_nested_str_weak(Tasmota),
-    /* K78  */  be_nested_str_weak(vendorid),
-    /* K79  */  be_nested_str_weak(DeviceName),
-    /* K80  */  be_nested_str_weak(FriendlyName),
-    /* K81  */  be_nested_str_weak(FriendlyName1),
-    /* K82  */  be_nested_str_weak(XX),
-    /* K83  */  be_nested_str_weak(Status_X202),
-    /* K84  */  be_nested_str_weak(StatusFWR),
-    /* K85  */  be_nested_str_weak(Hardware),
-    /* K86  */  be_nested_str_weak(Version),
-    /* K87  */  be_nested_str_weak(_X28),
-    /* K88  */  be_nested_str_weak(locale),
-    /* K89  */  be_nested_str_weak(create_TLV),
-    /* K90  */  be_nested_str_weak(get_active_endpoints),
-    /* K91  */  be_nested_str_weak(disable_bridge_mode),
-    /* K92  */  be_nested_str_weak(read_attribute),
+    /* K51  */  be_nested_str_weak(ack_request),
+    /* K52  */  be_nested_str_weak(fabric_filtered),
+    /* K53  */  be_nested_str_weak(get_fabric),
+    /* K54  */  be_nested_str_weak(device),
+    /* K55  */  be_nested_str_weak(sessions),
+    /* K56  */  be_nested_str_weak(active_fabrics),
+    /* K57  */  be_nested_str_weak(B2),
+    /* K58  */  be_nested_str_weak(get_noc),
+    /* K59  */  be_nested_str_weak(get_icac),
+    /* K60  */  be_nested_str_weak(get_fabric_index),
+    /* K61  */  be_nested_str_weak(stop_iteration),
+    /* K62  */  be_nested_str_weak(parse),
+    /* K63  */  be_nested_str_weak(get_ca),
+    /* K64  */  be_nested_str_weak(findsubval),
+    /* K65  */  be_nested_str_weak(get_admin_vendor),
+    /* K66  */  be_nested_str_weak(get_fabric_id),
+    /* K67  */  be_nested_str_weak(get_device_id),
+    /* K68  */  be_nested_str_weak(get_fabric_label),
+    /* K69  */  be_nested_str_weak(Fabric),
+    /* K70  */  be_nested_str_weak(_MAX_CASE),
+    /* K71  */  be_nested_str_weak(count_active_fabrics),
+    /* K72  */  be_nested_str_weak(_fabric),
+    /* K73  */  be_nested_str_weak(is_commissioning_open),
+    /* K74  */  be_nested_str_weak(is_root_commissioning_open),
+    /* K75  */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K76  */  be_nested_str_weak(Tasmota),
+    /* K77  */  be_nested_str_weak(vendorid),
+    /* K78  */  be_nested_str_weak(DeviceName),
+    /* K79  */  be_nested_str_weak(FriendlyName),
+    /* K80  */  be_nested_str_weak(FriendlyName1),
+    /* K81  */  be_nested_str_weak(XX),
+    /* K82  */  be_nested_str_weak(Status_X202),
+    /* K83  */  be_nested_str_weak(StatusFWR),
+    /* K84  */  be_nested_str_weak(Hardware),
+    /* K85  */  be_nested_str_weak(Version),
+    /* K86  */  be_nested_str_weak(_X28),
+    /* K87  */  be_nested_str_weak(locale),
+    /* K88  */  be_nested_str_weak(create_TLV),
+    /* K89  */  be_nested_str_weak(get_active_endpoints),
+    /* K90  */  be_nested_str_weak(disable_bridge_mode),
+    /* K91  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
@@ -1323,23 +1321,23 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x1C200C08,  //  0151  EQ	R8	R6	R8
       0x782200AD,  //  0152  JMPF	R8	#0201
       0x8C200133,  //  0153  GETMET	R8	R0	K51
-      0x88280534,  //  0154  GETMBR	R10	R2	K52
+      0x5C280400,  //  0154  MOVE	R10	R2
       0x7C200400,  //  0155  CALL	R8	2
       0x1C200F05,  //  0156  EQ	R8	R7	K5
       0x78220032,  //  0157  JMPF	R8	#018B
       0x8C200B11,  //  0158  GETMET	R8	R5	K17
       0x7C200200,  //  0159  CALL	R8	1
-      0x88240535,  //  015A  GETMBR	R9	R2	K53
+      0x88240534,  //  015A  GETMBR	R9	R2	K52
       0x78260005,  //  015B  JMPF	R9	#0162
       0x60240012,  //  015C  GETGBL	R9	G18
       0x7C240000,  //  015D  CALL	R9	0
-      0x8C280336,  //  015E  GETMET	R10	R1	K54
+      0x8C280335,  //  015E  GETMET	R10	R1	K53
       0x7C280200,  //  015F  CALL	R10	1
       0x4028120A,  //  0160  CONNECT	R10	R9	R10
       0x70020003,  //  0161  JMP		#0166
-      0x88240137,  //  0162  GETMBR	R9	R0	K55
-      0x88241338,  //  0163  GETMBR	R9	R9	K56
-      0x8C241339,  //  0164  GETMET	R9	R9	K57
+      0x88240136,  //  0162  GETMBR	R9	R0	K54
+      0x88241337,  //  0163  GETMBR	R9	R9	K55
+      0x8C241338,  //  0164  GETMET	R9	R9	K56
       0x7C240200,  //  0165  CALL	R9	1
       0x60280010,  //  0166  GETGBL	R10	G16
       0x5C2C1200,  //  0167  MOVE	R11	R9
@@ -1356,24 +1354,24 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x7C300400,  //  0172  CALL	R12	2
       0x8C34190B,  //  0173  GETMET	R13	R12	K11
       0x583C0009,  //  0174  LDCONST	R15	K9
-      0x88400B3A,  //  0175  GETMBR	R16	R5	K58
-      0x8C44173B,  //  0176  GETMET	R17	R11	K59
+      0x88400B39,  //  0175  GETMBR	R16	R5	K57
+      0x8C44173A,  //  0176  GETMET	R17	R11	K58
       0x7C440200,  //  0177  CALL	R17	1
       0x7C340800,  //  0178  CALL	R13	4
       0x8C34190B,  //  0179  GETMET	R13	R12	K11
       0x583C000D,  //  017A  LDCONST	R15	K13
-      0x88400B3A,  //  017B  GETMBR	R16	R5	K58
-      0x8C44173C,  //  017C  GETMET	R17	R11	K60
+      0x88400B39,  //  017B  GETMBR	R16	R5	K57
+      0x8C44173B,  //  017C  GETMET	R17	R11	K59
       0x7C440200,  //  017D  CALL	R17	1
       0x7C340800,  //  017E  CALL	R13	4
       0x8C34190B,  //  017F  GETMET	R13	R12	K11
       0x543E00FD,  //  0180  LDINT	R15	254
       0x88400B0C,  //  0181  GETMBR	R16	R5	K12
-      0x8C44173D,  //  0182  GETMET	R17	R11	K61
+      0x8C44173C,  //  0182  GETMET	R17	R11	K60
       0x7C440200,  //  0183  CALL	R17	1
       0x7C340800,  //  0184  CALL	R13	4
       0x7001FFE3,  //  0185  JMP		#016A
-      0x5828003E,  //  0186  LDCONST	R10	K62
+      0x5828003D,  //  0186  LDCONST	R10	K61
       0xAC280200,  //  0187  CATCH	R10	1	0
       0xB0080000,  //  0188  RAISE	2	R0	R0
       0x80041000,  //  0189  RET	1	R8
@@ -1382,17 +1380,17 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x78220049,  //  018C  JMPF	R8	#01D7
       0x8C200B11,  //  018D  GETMET	R8	R5	K17
       0x7C200200,  //  018E  CALL	R8	1
-      0x88240535,  //  018F  GETMBR	R9	R2	K53
+      0x88240534,  //  018F  GETMBR	R9	R2	K52
       0x78260005,  //  0190  JMPF	R9	#0197
       0x60240012,  //  0191  GETGBL	R9	G18
       0x7C240000,  //  0192  CALL	R9	0
-      0x8C280336,  //  0193  GETMET	R10	R1	K54
+      0x8C280335,  //  0193  GETMET	R10	R1	K53
       0x7C280200,  //  0194  CALL	R10	1
       0x4028120A,  //  0195  CONNECT	R10	R9	R10
       0x70020003,  //  0196  JMP		#019B
-      0x88240137,  //  0197  GETMBR	R9	R0	K55
-      0x88241338,  //  0198  GETMBR	R9	R9	K56
-      0x8C241339,  //  0199  GETMET	R9	R9	K57
+      0x88240136,  //  0197  GETMBR	R9	R0	K54
+      0x88241337,  //  0198  GETMBR	R9	R9	K55
+      0x8C241338,  //  0199  GETMET	R9	R9	K56
       0x7C240200,  //  019A  CALL	R9	1
       0x60280010,  //  019B  GETGBL	R10	G16
       0x5C2C1200,  //  019C  MOVE	R11	R9
@@ -1404,8 +1402,8 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x1C30160C,  //  01A2  EQ	R12	R11	R12
       0x78320000,  //  01A3  JMPF	R12	#01A5
       0x7001FFF9,  //  01A4  JMP		#019F
-      0x8C300B3F,  //  01A5  GETMET	R12	R5	K63
-      0x8C381740,  //  01A6  GETMET	R14	R11	K64
+      0x8C300B3E,  //  01A5  GETMET	R12	R5	K62
+      0x8C38173F,  //  01A6  GETMET	R14	R11	K63
       0x7C380200,  //  01A7  CALL	R14	1
       0x7C300400,  //  01A8  CALL	R12	2
       0x8C341115,  //  01A9  GETMET	R13	R8	K21
@@ -1413,43 +1411,43 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x7C340400,  //  01AB  CALL	R13	2
       0x8C381B0B,  //  01AC  GETMET	R14	R13	K11
       0x58400009,  //  01AD  LDCONST	R16	K9
-      0x88440B3A,  //  01AE  GETMBR	R17	R5	K58
-      0x8C481941,  //  01AF  GETMET	R18	R12	K65
+      0x88440B39,  //  01AE  GETMBR	R17	R5	K57
+      0x8C481940,  //  01AF  GETMET	R18	R12	K64
       0x54520008,  //  01B0  LDINT	R20	9
       0x7C480400,  //  01B1  CALL	R18	2
       0x7C380800,  //  01B2  CALL	R14	4
       0x8C381B0B,  //  01B3  GETMET	R14	R13	K11
       0x5840000D,  //  01B4  LDCONST	R16	K13
       0x88440B0C,  //  01B5  GETMBR	R17	R5	K12
-      0x8C481742,  //  01B6  GETMET	R18	R11	K66
+      0x8C481741,  //  01B6  GETMET	R18	R11	K65
       0x7C480200,  //  01B7  CALL	R18	1
       0x7C380800,  //  01B8  CALL	R14	4
       0x8C381B0B,  //  01B9  GETMET	R14	R13	K11
       0x5840000F,  //  01BA  LDCONST	R16	K15
       0x88440B07,  //  01BB  GETMBR	R17	R5	K7
-      0x8C481743,  //  01BC  GETMET	R18	R11	K67
+      0x8C481742,  //  01BC  GETMET	R18	R11	K66
       0x7C480200,  //  01BD  CALL	R18	1
       0x7C380800,  //  01BE  CALL	R14	4
       0x8C381B0B,  //  01BF  GETMET	R14	R13	K11
       0x54420003,  //  01C0  LDINT	R16	4
       0x88440B07,  //  01C1  GETMBR	R17	R5	K7
-      0x8C481744,  //  01C2  GETMET	R18	R11	K68
+      0x8C481743,  //  01C2  GETMET	R18	R11	K67
       0x7C480200,  //  01C3  CALL	R18	1
       0x7C380800,  //  01C4  CALL	R14	4
       0x8C381B0B,  //  01C5  GETMET	R14	R13	K11
       0x54420004,  //  01C6  LDINT	R16	5
       0x88440B16,  //  01C7  GETMBR	R17	R5	K22
-      0x8C481745,  //  01C8  GETMET	R18	R11	K69
+      0x8C481744,  //  01C8  GETMET	R18	R11	K68
       0x7C480200,  //  01C9  CALL	R18	1
       0x7C380800,  //  01CA  CALL	R14	4
       0x8C381B0B,  //  01CB  GETMET	R14	R13	K11
       0x544200FD,  //  01CC  LDINT	R16	254
       0x88440B0C,  //  01CD  GETMBR	R17	R5	K12
-      0x8C48173D,  //  01CE  GETMET	R18	R11	K61
+      0x8C48173C,  //  01CE  GETMET	R18	R11	K60
       0x7C480200,  //  01CF  CALL	R18	1
       0x7C380800,  //  01D0  CALL	R14	4
       0x7001FFCC,  //  01D1  JMP		#019F
-      0x5828003E,  //  01D2  LDCONST	R10	K62
+      0x5828003D,  //  01D2  LDCONST	R10	K61
       0xAC280200,  //  01D3  CATCH	R10	1	0
       0xB0080000,  //  01D4  RAISE	2	R0	R0
       0x80041000,  //  01D5  RET	1	R8
@@ -1459,16 +1457,16 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x8C200706,  //  01D9  GETMET	R8	R3	K6
       0x88280B0E,  //  01DA  GETMBR	R10	R5	K14
       0xB82E0200,  //  01DB  GETNGBL	R11	K1
-      0x882C1746,  //  01DC  GETMBR	R11	R11	K70
-      0x882C1747,  //  01DD  GETMBR	R11	R11	K71
+      0x882C1745,  //  01DC  GETMBR	R11	R11	K69
+      0x882C1746,  //  01DD  GETMBR	R11	R11	K70
       0x7C200600,  //  01DE  CALL	R8	3
       0x80041000,  //  01DF  RET	1	R8
       0x7002001E,  //  01E0  JMP		#0200
       0x1C200F0F,  //  01E1  EQ	R8	R7	K15
       0x78220009,  //  01E2  JMPF	R8	#01ED
-      0x88200137,  //  01E3  GETMBR	R8	R0	K55
-      0x88201138,  //  01E4  GETMBR	R8	R8	K56
-      0x8C201148,  //  01E5  GETMET	R8	R8	K72
+      0x88200136,  //  01E3  GETMBR	R8	R0	K54
+      0x88201137,  //  01E4  GETMBR	R8	R8	K55
+      0x8C201147,  //  01E5  GETMET	R8	R8	K71
       0x7C200200,  //  01E6  CALL	R8	1
       0x8C240706,  //  01E7  GETMET	R9	R3	K6
       0x882C0B0E,  //  01E8  GETMBR	R11	R5	K14
@@ -1483,8 +1481,8 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x54220004,  //  01F1  LDINT	R8	5
       0x1C200E08,  //  01F2  EQ	R8	R7	R8
       0x7822000B,  //  01F3  JMPF	R8	#0200
-      0x88200349,  //  01F4  GETMBR	R8	R1	K73
-      0x8C20113D,  //  01F5  GETMET	R8	R8	K61
+      0x88200348,  //  01F4  GETMBR	R8	R1	K72
+      0x8C20113C,  //  01F5  GETMET	R8	R8	K60
       0x7C200200,  //  01F6  CALL	R8	1
       0x4C240000,  //  01F7  LDNIL	R9
       0x1C241009,  //  01F8  EQ	R9	R8	R9
@@ -1501,11 +1499,11 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x7822003C,  //  0203  JMPF	R8	#0241
       0x1C200F05,  //  0204  EQ	R8	R7	K5
       0x78220012,  //  0205  JMPF	R8	#0219
-      0x88200137,  //  0206  GETMBR	R8	R0	K55
-      0x8C20114A,  //  0207  GETMET	R8	R8	K74
+      0x88200136,  //  0206  GETMBR	R8	R0	K54
+      0x8C201149,  //  0207  GETMET	R8	R8	K73
       0x7C200200,  //  0208  CALL	R8	1
-      0x88240137,  //  0209  GETMBR	R9	R0	K55
-      0x8C24134B,  //  020A  GETMET	R9	R9	K75
+      0x88240136,  //  0209  GETMBR	R9	R0	K54
+      0x8C24134A,  //  020A  GETMET	R9	R9	K74
       0x7C240200,  //  020B  CALL	R9	1
       0x78220004,  //  020C  JMPF	R8	#0212
       0x78260001,  //  020D  JMPF	R9	#0210
@@ -1522,14 +1520,14 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x70020026,  //  0218  JMP		#0240
       0x1C200F09,  //  0219  EQ	R8	R7	K9
       0x78220011,  //  021A  JMPF	R8	#022D
-      0x88200137,  //  021B  GETMBR	R8	R0	K55
-      0x8820114C,  //  021C  GETMBR	R8	R8	K76
+      0x88200136,  //  021B  GETMBR	R8	R0	K54
+      0x8820114B,  //  021C  GETMBR	R8	R8	K75
       0x4C240000,  //  021D  LDNIL	R9
       0x20241009,  //  021E  NE	R9	R8	R9
       0x78260006,  //  021F  JMPF	R9	#0227
       0x8C240706,  //  0220  GETMET	R9	R3	K6
       0x882C0B0C,  //  0221  GETMBR	R11	R5	K12
-      0x8C30113D,  //  0222  GETMET	R12	R8	K61
+      0x8C30113C,  //  0222  GETMET	R12	R8	K60
       0x7C300200,  //  0223  CALL	R12	1
       0x7C240600,  //  0224  CALL	R9	3
       0x80041200,  //  0225  RET	1	R9
@@ -1542,14 +1540,14 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x70020012,  //  022C  JMP		#0240
       0x1C200F0D,  //  022D  EQ	R8	R7	K13
       0x78220010,  //  022E  JMPF	R8	#0240
-      0x88200137,  //  022F  GETMBR	R8	R0	K55
-      0x8820114C,  //  0230  GETMBR	R8	R8	K76
+      0x88200136,  //  022F  GETMBR	R8	R0	K54
+      0x8820114B,  //  0230  GETMBR	R8	R8	K75
       0x4C240000,  //  0231  LDNIL	R9
       0x20241009,  //  0232  NE	R9	R8	R9
       0x78260006,  //  0233  JMPF	R9	#023B
       0x8C240706,  //  0234  GETMET	R9	R3	K6
       0x882C0B0C,  //  0235  GETMBR	R11	R5	K12
-      0x8C301142,  //  0236  GETMET	R12	R8	K66
+      0x8C301141,  //  0236  GETMET	R12	R8	K65
       0x7C300200,  //  0237  CALL	R12	1
       0x7C240600,  //  0238  CALL	R9	3
       0x80041200,  //  0239  RET	1	R9
@@ -1564,7 +1562,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x1C200C08,  //  0242  EQ	R8	R6	R8
       0x782200BA,  //  0243  JMPF	R8	#02FF
       0x8C200133,  //  0244  GETMET	R8	R0	K51
-      0x88280534,  //  0245  GETMBR	R10	R2	K52
+      0x5C280400,  //  0245  MOVE	R10	R2
       0x7C200400,  //  0246  CALL	R8	2
       0x1C200F05,  //  0247  EQ	R8	R7	K5
       0x78220005,  //  0248  JMPF	R8	#024F
@@ -1578,7 +1576,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x78220005,  //  0250  JMPF	R8	#0257
       0x8C200706,  //  0251  GETMET	R8	R3	K6
       0x88280B16,  //  0252  GETMBR	R10	R5	K22
-      0x582C004D,  //  0253  LDCONST	R11	K77
+      0x582C004C,  //  0253  LDCONST	R11	K76
       0x7C200600,  //  0254  CALL	R8	3
       0x80041000,  //  0255  RET	1	R8
       0x700200A6,  //  0256  JMP		#02FE
@@ -1586,8 +1584,8 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x78220006,  //  0258  JMPF	R8	#0260
       0x8C200706,  //  0259  GETMET	R8	R3	K6
       0x88280B0C,  //  025A  GETMBR	R10	R5	K12
-      0x882C0137,  //  025B  GETMBR	R11	R0	K55
-      0x882C174E,  //  025C  GETMBR	R11	R11	K78
+      0x882C0136,  //  025B  GETMBR	R11	R0	K54
+      0x882C174D,  //  025C  GETMBR	R11	R11	K77
       0x7C200600,  //  025D  CALL	R8	3
       0x80041000,  //  025E  RET	1	R8
       0x7002009D,  //  025F  JMP		#02FE
@@ -1597,10 +1595,10 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x88280B16,  //  0263  GETMBR	R10	R5	K22
       0xB82E2400,  //  0264  GETNGBL	R11	K18
       0x8C2C1726,  //  0265  GETMET	R11	R11	K38
-      0x5834004F,  //  0266  LDCONST	R13	K79
+      0x5834004E,  //  0266  LDCONST	R13	K78
       0x50380200,  //  0267  LDBOOL	R14	1	0
       0x7C2C0600,  //  0268  CALL	R11	3
-      0x942C174F,  //  0269  GETIDX	R11	R11	K79
+      0x942C174E,  //  0269  GETIDX	R11	R11	K78
       0x7C200600,  //  026A  CALL	R8	3
       0x80041000,  //  026B  RET	1	R8
       0x70020090,  //  026C  JMP		#02FE
@@ -1620,10 +1618,10 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x88280B16,  //  027A  GETMBR	R10	R5	K22
       0xB82E2400,  //  027B  GETNGBL	R11	K18
       0x8C2C1726,  //  027C  GETMET	R11	R11	K38
-      0x58340050,  //  027D  LDCONST	R13	K80
+      0x5834004F,  //  027D  LDCONST	R13	K79
       0x50380200,  //  027E  LDBOOL	R14	1	0
       0x7C2C0600,  //  027F  CALL	R11	3
-      0x942C1751,  //  0280  GETIDX	R11	R11	K81
+      0x942C1750,  //  0280  GETIDX	R11	R11	K80
       0x7C200600,  //  0281  CALL	R8	3
       0x80041000,  //  0282  RET	1	R8
       0x70020079,  //  0283  JMP		#02FE
@@ -1632,7 +1630,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x78220005,  //  0286  JMPF	R8	#028D
       0x8C200706,  //  0287  GETMET	R8	R3	K6
       0x88280B16,  //  0288  GETMBR	R10	R5	K22
-      0x582C0052,  //  0289  LDCONST	R11	K82
+      0x582C0051,  //  0289  LDCONST	R11	K81
       0x7C200600,  //  028A  CALL	R8	3
       0x80041000,  //  028B  RET	1	R8
       0x70020070,  //  028C  JMP		#02FE
@@ -1652,11 +1650,11 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x88280B16,  //  029A  GETMBR	R10	R5	K22
       0xB82E2400,  //  029B  GETNGBL	R11	K18
       0x8C2C1726,  //  029C  GETMET	R11	R11	K38
-      0x58340053,  //  029D  LDCONST	R13	K83
+      0x58340052,  //  029D  LDCONST	R13	K82
       0x50380200,  //  029E  LDBOOL	R14	1	0
       0x7C2C0600,  //  029F  CALL	R11	3
-      0x942C1754,  //  02A0  GETIDX	R11	R11	K84
-      0x942C1755,  //  02A1  GETIDX	R11	R11	K85
+      0x942C1753,  //  02A0  GETIDX	R11	R11	K83
+      0x942C1754,  //  02A1  GETIDX	R11	R11	K84
       0x7C200600,  //  02A2  CALL	R8	3
       0x80041000,  //  02A3  RET	1	R8
       0x70020058,  //  02A4  JMP		#02FE
@@ -1674,14 +1672,14 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x78220015,  //  02B0  JMPF	R8	#02C7
       0xB8222400,  //  02B1  GETNGBL	R8	K18
       0x8C201126,  //  02B2  GETMET	R8	R8	K38
-      0x58280053,  //  02B3  LDCONST	R10	K83
+      0x58280052,  //  02B3  LDCONST	R10	K82
       0x502C0200,  //  02B4  LDBOOL	R11	1	0
       0x7C200600,  //  02B5  CALL	R8	3
-      0x94201154,  //  02B6  GETIDX	R8	R8	K84
-      0x94201156,  //  02B7  GETIDX	R8	R8	K86
+      0x94201153,  //  02B6  GETIDX	R8	R8	K83
+      0x94201155,  //  02B7  GETIDX	R8	R8	K85
       0x8C24091B,  //  02B8  GETMET	R9	R4	K27
       0x5C2C1000,  //  02B9  MOVE	R11	R8
-      0x58300057,  //  02BA  LDCONST	R12	K87
+      0x58300056,  //  02BA  LDCONST	R12	K86
       0x7C240600,  //  02BB  CALL	R9	3
       0x24281305,  //  02BC  GT	R10	R9	K5
       0x782A0002,  //  02BD  JMPF	R10	#02C1
@@ -1795,7 +1793,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x8C200706,  //  0329  GETMET	R8	R3	K6
       0x88280B16,  //  032A  GETMBR	R10	R5	K22
       0xB82E2400,  //  032B  GETNGBL	R11	K18
-      0x8C2C1758,  //  032C  GETMET	R11	R11	K88
+      0x8C2C1757,  //  032C  GETMET	R11	R11	K87
       0x7C2C0200,  //  032D  CALL	R11	1
       0x7C200600,  //  032E  CALL	R8	3
       0x80041000,  //  032F  RET	1	R8
@@ -1808,7 +1806,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x4C2C0000,  //  0336  LDNIL	R11
       0x88300B16,  //  0337  GETMBR	R12	R5	K22
       0xB8362400,  //  0338  GETNGBL	R13	K18
-      0x8C341B58,  //  0339  GETMET	R13	R13	K88
+      0x8C341B57,  //  0339  GETMET	R13	R13	K87
       0x7C340200,  //  033A  CALL	R13	1
       0x7C240800,  //  033B  CALL	R9	4
       0x80041000,  //  033C  RET	1	R8
@@ -1838,7 +1836,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x7C200200,  //  0354  CALL	R8	1
       0x8C24110B,  //  0355  GETMET	R9	R8	K11
       0x4C2C0000,  //  0356  LDNIL	R11
-      0x8C300B59,  //  0357  GETMET	R12	R5	K89
+      0x8C300B58,  //  0357  GETMET	R12	R5	K88
       0x88380B0E,  //  0358  GETMBR	R14	R5	K14
       0x543E0003,  //  0359  LDINT	R15	4
       0x7C300600,  //  035A  CALL	R12	3
@@ -1872,12 +1870,12 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x7822001D,  //  0376  JMPF	R8	#0395
       0x8C200B11,  //  0377  GETMET	R8	R5	K17
       0x7C200200,  //  0378  CALL	R8	1
-      0x88240137,  //  0379  GETMBR	R9	R0	K55
-      0x8C24135A,  //  037A  GETMET	R9	R9	K90
+      0x88240136,  //  0379  GETMBR	R9	R0	K54
+      0x8C241359,  //  037A  GETMET	R9	R9	K89
       0x502C0200,  //  037B  LDBOOL	R11	1	0
       0x7C240400,  //  037C  CALL	R9	2
-      0x88280137,  //  037D  GETMBR	R10	R0	K55
-      0x8828155B,  //  037E  GETMBR	R10	R10	K91
+      0x88280136,  //  037D  GETMBR	R10	R0	K54
+      0x8828155A,  //  037E  GETMBR	R10	R10	K90
       0x602C0010,  //  037F  GETGBL	R11	G16
       0x5C301200,  //  0380  MOVE	R12	R9
       0x7C2C0200,  //  0381  CALL	R11	1
@@ -1895,7 +1893,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x5C441800,  //  038D  MOVE	R17	R12
       0x7C340800,  //  038E  CALL	R13	4
       0x7001FFF2,  //  038F  JMP		#0383
-      0x582C003E,  //  0390  LDCONST	R11	K62
+      0x582C003D,  //  0390  LDCONST	R11	K61
       0xAC2C0200,  //  0391  CATCH	R11	1	0
       0xB0080000,  //  0392  RAISE	2	R0	R0
       0x80041000,  //  0393  RET	1	R8
@@ -1903,7 +1901,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x60200003,  //  0395  GETGBL	R8	G3
       0x5C240000,  //  0396  MOVE	R9	R0
       0x7C200200,  //  0397  CALL	R8	1
-      0x8C20115C,  //  0398  GETMET	R8	R8	K92
+      0x8C20115B,  //  0398  GETMET	R8	R8	K91
       0x5C280200,  //  0399  MOVE	R10	R1
       0x5C2C0400,  //  039A  MOVE	R11	R2
       0x5C300600,  //  039B  MOVE	R12	R3
@@ -1913,7 +1911,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x60200003,  //  039F  GETGBL	R8	G3
       0x5C240000,  //  03A0  MOVE	R9	R0
       0x7C200200,  //  03A1  CALL	R8	1
-      0x8C20115C,  //  03A2  GETMET	R8	R8	K92
+      0x8C20115B,  //  03A2  GETMET	R8	R8	K91
       0x5C280200,  //  03A3  MOVE	R10	R1
       0x5C2C0400,  //  03A4  MOVE	R11	R2
       0x5C300600,  //  03A5  MOVE	R12	R3

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
@@ -7,6 +7,333 @@
 extern const bclass be_class_Matter_TLV_item;
 
 /********************************************************************
+** Solidified function: to_TLV
+********************************************************************/
+be_local_closure(Matter_TLV_item_to_TLV,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(to_TLV),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80040000,  //  0000  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_parent
+********************************************************************/
+be_local_closure(Matter_TLV_item_set_parent,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(parent),
+    }),
+    be_str_weak(set_parent),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_fulltag
+********************************************************************/
+be_local_closure(Matter_TLV_item_set_fulltag,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tag_vendor),
+    /* K1   */  be_nested_str_weak(tag_profile),
+    /* K2   */  be_nested_str_weak(tag_number),
+    /* K3   */  be_nested_str_weak(tag_sub),
+    }),
+    be_str_weak(set_fulltag),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x60100009,  //  0000  GETGBL	R4	G9
+      0x5C140200,  //  0001  MOVE	R5	R1
+      0x7C100200,  //  0002  CALL	R4	1
+      0x90020004,  //  0003  SETMBR	R0	K0	R4
+      0x60100009,  //  0004  GETGBL	R4	G9
+      0x5C140400,  //  0005  MOVE	R5	R2
+      0x7C100200,  //  0006  CALL	R4	1
+      0x90020204,  //  0007  SETMBR	R0	K1	R4
+      0x60100009,  //  0008  GETGBL	R4	G9
+      0x5C140600,  //  0009  MOVE	R5	R3
+      0x7C100200,  //  000A  CALL	R4	1
+      0x90020404,  //  000B  SETMBR	R0	K2	R4
+      0x4C100000,  //  000C  LDNIL	R4
+      0x90020604,  //  000D  SETMBR	R0	K3	R4
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_contextspecific
+********************************************************************/
+be_local_closure(Matter_TLV_item_set_contextspecific,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_fulltag),
+    /* K1   */  be_nested_str_weak(tag_sub),
+    }),
+    be_str_weak(set_contextspecific),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x60080009,  //  0002  GETGBL	R2	G9
+      0x5C0C0200,  //  0003  MOVE	R3	R1
+      0x7C080200,  //  0004  CALL	R2	1
+      0x90020202,  //  0005  SETMBR	R0	K1	R2
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sort
+********************************************************************/
+be_local_closure(Matter_TLV_item_sort,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_TLV_item),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(_cmp_gt),
+    /* K4   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(sort),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x60080010,  //  0001  GETGBL	R2	G16
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x040C0701,  //  0005  SUB	R3	R3	K1
+      0x400E0203,  //  0006  CONNECT	R3	K1	R3
+      0x7C080200,  //  0007  CALL	R2	1
+      0xA8020013,  //  0008  EXBLK	0	#001D
+      0x5C0C0400,  //  0009  MOVE	R3	R2
+      0x7C0C0000,  //  000A  CALL	R3	0
+      0x94100003,  //  000B  GETIDX	R4	R0	R3
+      0x5C140600,  //  000C  MOVE	R5	R3
+      0x24180B02,  //  000D  GT	R6	R5	K2
+      0x781A000B,  //  000E  JMPF	R6	#001B
+      0x04180B01,  //  000F  SUB	R6	R5	K1
+      0x94180006,  //  0010  GETIDX	R6	R0	R6
+      0x8C180D03,  //  0011  GETMET	R6	R6	K3
+      0x5C200800,  //  0012  MOVE	R8	R4
+      0x7C180400,  //  0013  CALL	R6	2
+      0x24180D02,  //  0014  GT	R6	R6	K2
+      0x781A0004,  //  0015  JMPF	R6	#001B
+      0x04180B01,  //  0016  SUB	R6	R5	K1
+      0x94180006,  //  0017  GETIDX	R6	R0	R6
+      0x98000A06,  //  0018  SETIDX	R0	R5	R6
+      0x04140B01,  //  0019  SUB	R5	R5	K1
+      0x7001FFF1,  //  001A  JMP		#000D
+      0x98000A04,  //  001B  SETIDX	R0	R5	R4
+      0x7001FFEB,  //  001C  JMP		#0009
+      0x58080004,  //  001D  LDCONST	R2	K4
+      0xAC080200,  //  001E  CATCH	R2	1	0
+      0xB0080000,  //  001F  RAISE	2	R0	R0
+      0x80040000,  //  0020  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: to_str_val
+********************************************************************/
+be_local_closure(Matter_TLV_item_to_str_val,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(val),
+    /* K1   */  be_nested_str_weak(int),
+    /* K2   */  be_nested_str_weak(typ),
+    /* K3   */  be_nested_str_weak(TLV),
+    /* K4   */  be_nested_str_weak(U1),
+    /* K5   */  be_nested_str_weak(U8),
+    /* K6   */  be_nested_str_weak(U),
+    /* K7   */  be_nested_str_weak(bool),
+    /* K8   */  be_nested_str_weak(true),
+    /* K9   */  be_nested_str_weak(false),
+    /* K10  */  be_nested_str_weak(null),
+    /* K11  */  be_nested_str_weak(real),
+    /* K12  */  be_nested_str_weak(string),
+    /* K13  */  be_nested_str_weak(int64),
+    /* K14  */  be_nested_str_weak(tostring),
+    /* K15  */  be_nested_str_weak(instance),
+    }),
+    be_str_weak(to_str_val),
+    &be_const_str_solidified,
+    ( &(const binstruction[98]) {  /* code */
+      0x60040004,  //  0000  GETGBL	R1	G4
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x1C040301,  //  0003  EQ	R1	R1	K1
+      0x78060014,  //  0004  JMPF	R1	#001A
+      0x88040102,  //  0005  GETMBR	R1	R0	K2
+      0x88080103,  //  0006  GETMBR	R2	R0	K3
+      0x88080504,  //  0007  GETMBR	R2	R2	K4
+      0x28040202,  //  0008  GE	R1	R1	R2
+      0x7806000A,  //  0009  JMPF	R1	#0015
+      0x88040102,  //  000A  GETMBR	R1	R0	K2
+      0x88080103,  //  000B  GETMBR	R2	R0	K3
+      0x88080505,  //  000C  GETMBR	R2	R2	K5
+      0x18040202,  //  000D  LE	R1	R1	R2
+      0x78060005,  //  000E  JMPF	R1	#0015
+      0x60040008,  //  000F  GETGBL	R1	G8
+      0x88080100,  //  0010  GETMBR	R2	R0	K0
+      0x7C040200,  //  0011  CALL	R1	1
+      0x00040306,  //  0012  ADD	R1	R1	K6
+      0x80040200,  //  0013  RET	1	R1
+      0x70020003,  //  0014  JMP		#0019
+      0x60040008,  //  0015  GETGBL	R1	G8
+      0x88080100,  //  0016  GETMBR	R2	R0	K0
+      0x7C040200,  //  0017  CALL	R1	1
+      0x80040200,  //  0018  RET	1	R1
+      0x70020046,  //  0019  JMP		#0061
+      0x60040004,  //  001A  GETGBL	R1	G4
+      0x88080100,  //  001B  GETMBR	R2	R0	K0
+      0x7C040200,  //  001C  CALL	R1	1
+      0x1C040307,  //  001D  EQ	R1	R1	K7
+      0x78060006,  //  001E  JMPF	R1	#0026
+      0x88040100,  //  001F  GETMBR	R1	R0	K0
+      0x78060001,  //  0020  JMPF	R1	#0023
+      0x58040008,  //  0021  LDCONST	R1	K8
+      0x70020000,  //  0022  JMP		#0024
+      0x58040009,  //  0023  LDCONST	R1	K9
+      0x80040200,  //  0024  RET	1	R1
+      0x7002003A,  //  0025  JMP		#0061
+      0x88040100,  //  0026  GETMBR	R1	R0	K0
+      0x4C080000,  //  0027  LDNIL	R2
+      0x1C040202,  //  0028  EQ	R1	R1	R2
+      0x78060001,  //  0029  JMPF	R1	#002C
+      0x80061400,  //  002A  RET	1	K10
+      0x70020034,  //  002B  JMP		#0061
+      0x60040004,  //  002C  GETGBL	R1	G4
+      0x88080100,  //  002D  GETMBR	R2	R0	K0
+      0x7C040200,  //  002E  CALL	R1	1
+      0x1C04030B,  //  002F  EQ	R1	R1	K11
+      0x78060004,  //  0030  JMPF	R1	#0036
+      0x60040008,  //  0031  GETGBL	R1	G8
+      0x88080100,  //  0032  GETMBR	R2	R0	K0
+      0x7C040200,  //  0033  CALL	R1	1
+      0x80040200,  //  0034  RET	1	R1
+      0x7002002A,  //  0035  JMP		#0061
+      0x60040004,  //  0036  GETGBL	R1	G4
+      0x88080100,  //  0037  GETMBR	R2	R0	K0
+      0x7C040200,  //  0038  CALL	R1	1
+      0x1C04030C,  //  0039  EQ	R1	R1	K12
+      0x78060002,  //  003A  JMPF	R1	#003E
+      0x88040100,  //  003B  GETMBR	R1	R0	K0
+      0x80040200,  //  003C  RET	1	R1
+      0x70020022,  //  003D  JMP		#0061
+      0x6004000F,  //  003E  GETGBL	R1	G15
+      0x88080100,  //  003F  GETMBR	R2	R0	K0
+      0xB80E1A00,  //  0040  GETNGBL	R3	K13
+      0x7C040400,  //  0041  CALL	R1	2
+      0x78060014,  //  0042  JMPF	R1	#0058
+      0x88040102,  //  0043  GETMBR	R1	R0	K2
+      0x88080103,  //  0044  GETMBR	R2	R0	K3
+      0x88080504,  //  0045  GETMBR	R2	R2	K4
+      0x28040202,  //  0046  GE	R1	R1	R2
+      0x7806000A,  //  0047  JMPF	R1	#0053
+      0x88040102,  //  0048  GETMBR	R1	R0	K2
+      0x88080103,  //  0049  GETMBR	R2	R0	K3
+      0x88080505,  //  004A  GETMBR	R2	R2	K5
+      0x18040202,  //  004B  LE	R1	R1	R2
+      0x78060005,  //  004C  JMPF	R1	#0053
+      0x88040100,  //  004D  GETMBR	R1	R0	K0
+      0x8C04030E,  //  004E  GETMET	R1	R1	K14
+      0x7C040200,  //  004F  CALL	R1	1
+      0x00040306,  //  0050  ADD	R1	R1	K6
+      0x80040200,  //  0051  RET	1	R1
+      0x70020003,  //  0052  JMP		#0057
+      0x88040100,  //  0053  GETMBR	R1	R0	K0
+      0x8C04030E,  //  0054  GETMET	R1	R1	K14
+      0x7C040200,  //  0055  CALL	R1	1
+      0x80040200,  //  0056  RET	1	R1
+      0x70020008,  //  0057  JMP		#0061
+      0x60040004,  //  0058  GETGBL	R1	G4
+      0x88080100,  //  0059  GETMBR	R2	R0	K0
+      0x7C040200,  //  005A  CALL	R1	1
+      0x1C04030F,  //  005B  EQ	R1	R1	K15
+      0x78060003,  //  005C  JMPF	R1	#0061
+      0x8C04010E,  //  005D  GETMET	R1	R0	K14
+      0x500C0200,  //  005E  LDBOOL	R3	1	0
+      0x7C040400,  //  005F  CALL	R1	2
+      0x80040200,  //  0060  RET	1	R1
+      0x80000000,  //  0061  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: encode_len
 ********************************************************************/
 be_local_closure(Matter_TLV_item_encode_len,   /* name */
@@ -321,137 +648,81 @@ be_local_closure(Matter_TLV_item_encode_len,   /* name */
 
 
 /********************************************************************
-** Solidified function: to_str_val
+** Solidified function: reset
 ********************************************************************/
-be_local_closure(Matter_TLV_item_to_str_val,   /* name */
+be_local_closure(Matter_TLV_item_reset,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
+    3,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(val),
-    /* K1   */  be_nested_str_weak(int),
-    /* K2   */  be_nested_str_weak(typ),
-    /* K3   */  be_nested_str_weak(TLV),
-    /* K4   */  be_nested_str_weak(U1),
-    /* K5   */  be_nested_str_weak(U8),
-    /* K6   */  be_nested_str_weak(U),
-    /* K7   */  be_nested_str_weak(bool),
-    /* K8   */  be_nested_str_weak(true),
-    /* K9   */  be_nested_str_weak(false),
-    /* K10  */  be_nested_str_weak(null),
-    /* K11  */  be_nested_str_weak(real),
-    /* K12  */  be_nested_str_weak(string),
-    /* K13  */  be_nested_str_weak(int64),
-    /* K14  */  be_nested_str_weak(tostring),
-    /* K15  */  be_nested_str_weak(instance),
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(parent),
+    /* K1   */  be_nested_str_weak(next_idx),
+    /* K2   */  be_nested_str_weak(tag_vendor),
+    /* K3   */  be_nested_str_weak(tag_profile),
+    /* K4   */  be_nested_str_weak(tag_number),
+    /* K5   */  be_nested_str_weak(tag_sub),
+    /* K6   */  be_nested_str_weak(typ),
+    /* K7   */  be_nested_str_weak(val),
     }),
-    be_str_weak(to_str_val),
+    be_str_weak(reset),
     &be_const_str_solidified,
-    ( &(const binstruction[98]) {  /* code */
-      0x60040004,  //  0000  GETGBL	R1	G4
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x7C040200,  //  0002  CALL	R1	1
-      0x1C040301,  //  0003  EQ	R1	R1	K1
-      0x78060014,  //  0004  JMPF	R1	#001A
-      0x88040102,  //  0005  GETMBR	R1	R0	K2
-      0x88080103,  //  0006  GETMBR	R2	R0	K3
-      0x88080504,  //  0007  GETMBR	R2	R2	K4
-      0x28040202,  //  0008  GE	R1	R1	R2
-      0x7806000A,  //  0009  JMPF	R1	#0015
-      0x88040102,  //  000A  GETMBR	R1	R0	K2
-      0x88080103,  //  000B  GETMBR	R2	R0	K3
-      0x88080505,  //  000C  GETMBR	R2	R2	K5
-      0x18040202,  //  000D  LE	R1	R1	R2
-      0x78060005,  //  000E  JMPF	R1	#0015
-      0x60040008,  //  000F  GETGBL	R1	G8
-      0x88080100,  //  0010  GETMBR	R2	R0	K0
-      0x7C040200,  //  0011  CALL	R1	1
-      0x00040306,  //  0012  ADD	R1	R1	K6
-      0x80040200,  //  0013  RET	1	R1
-      0x70020003,  //  0014  JMP		#0019
-      0x60040008,  //  0015  GETGBL	R1	G8
-      0x88080100,  //  0016  GETMBR	R2	R0	K0
-      0x7C040200,  //  0017  CALL	R1	1
-      0x80040200,  //  0018  RET	1	R1
-      0x70020046,  //  0019  JMP		#0061
-      0x60040004,  //  001A  GETGBL	R1	G4
-      0x88080100,  //  001B  GETMBR	R2	R0	K0
-      0x7C040200,  //  001C  CALL	R1	1
-      0x1C040307,  //  001D  EQ	R1	R1	K7
-      0x78060006,  //  001E  JMPF	R1	#0026
-      0x88040100,  //  001F  GETMBR	R1	R0	K0
-      0x78060001,  //  0020  JMPF	R1	#0023
-      0x58040008,  //  0021  LDCONST	R1	K8
-      0x70020000,  //  0022  JMP		#0024
-      0x58040009,  //  0023  LDCONST	R1	K9
-      0x80040200,  //  0024  RET	1	R1
-      0x7002003A,  //  0025  JMP		#0061
-      0x88040100,  //  0026  GETMBR	R1	R0	K0
-      0x4C080000,  //  0027  LDNIL	R2
-      0x1C040202,  //  0028  EQ	R1	R1	R2
-      0x78060001,  //  0029  JMPF	R1	#002C
-      0x80061400,  //  002A  RET	1	K10
-      0x70020034,  //  002B  JMP		#0061
-      0x60040004,  //  002C  GETGBL	R1	G4
-      0x88080100,  //  002D  GETMBR	R2	R0	K0
-      0x7C040200,  //  002E  CALL	R1	1
-      0x1C04030B,  //  002F  EQ	R1	R1	K11
-      0x78060004,  //  0030  JMPF	R1	#0036
-      0x60040008,  //  0031  GETGBL	R1	G8
-      0x88080100,  //  0032  GETMBR	R2	R0	K0
-      0x7C040200,  //  0033  CALL	R1	1
-      0x80040200,  //  0034  RET	1	R1
-      0x7002002A,  //  0035  JMP		#0061
-      0x60040004,  //  0036  GETGBL	R1	G4
-      0x88080100,  //  0037  GETMBR	R2	R0	K0
-      0x7C040200,  //  0038  CALL	R1	1
-      0x1C04030C,  //  0039  EQ	R1	R1	K12
-      0x78060002,  //  003A  JMPF	R1	#003E
-      0x88040100,  //  003B  GETMBR	R1	R0	K0
-      0x80040200,  //  003C  RET	1	R1
-      0x70020022,  //  003D  JMP		#0061
-      0x6004000F,  //  003E  GETGBL	R1	G15
-      0x88080100,  //  003F  GETMBR	R2	R0	K0
-      0xB80E1A00,  //  0040  GETNGBL	R3	K13
-      0x7C040400,  //  0041  CALL	R1	2
-      0x78060014,  //  0042  JMPF	R1	#0058
-      0x88040102,  //  0043  GETMBR	R1	R0	K2
-      0x88080103,  //  0044  GETMBR	R2	R0	K3
-      0x88080504,  //  0045  GETMBR	R2	R2	K4
-      0x28040202,  //  0046  GE	R1	R1	R2
-      0x7806000A,  //  0047  JMPF	R1	#0053
-      0x88040102,  //  0048  GETMBR	R1	R0	K2
-      0x88080103,  //  0049  GETMBR	R2	R0	K3
-      0x88080505,  //  004A  GETMBR	R2	R2	K5
-      0x18040202,  //  004B  LE	R1	R1	R2
-      0x78060005,  //  004C  JMPF	R1	#0053
-      0x88040100,  //  004D  GETMBR	R1	R0	K0
-      0x8C04030E,  //  004E  GETMET	R1	R1	K14
-      0x7C040200,  //  004F  CALL	R1	1
-      0x00040306,  //  0050  ADD	R1	R1	K6
-      0x80040200,  //  0051  RET	1	R1
-      0x70020003,  //  0052  JMP		#0057
-      0x88040100,  //  0053  GETMBR	R1	R0	K0
-      0x8C04030E,  //  0054  GETMET	R1	R1	K14
-      0x7C040200,  //  0055  CALL	R1	1
-      0x80040200,  //  0056  RET	1	R1
-      0x70020008,  //  0057  JMP		#0061
-      0x60040004,  //  0058  GETGBL	R1	G4
-      0x88080100,  //  0059  GETMBR	R2	R0	K0
-      0x7C040200,  //  005A  CALL	R1	1
-      0x1C04030F,  //  005B  EQ	R1	R1	K15
-      0x78060003,  //  005C  JMPF	R1	#0061
-      0x8C04010E,  //  005D  GETMET	R1	R0	K14
-      0x500C0200,  //  005E  LDBOOL	R3	1	0
-      0x7C040400,  //  005F  CALL	R1	2
-      0x80040200,  //  0060  RET	1	R1
-      0x80000000,  //  0061  RET	0
+    ( &(const binstruction[10]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x90020202,  //  0002  SETMBR	R0	K1	R2
+      0x90020402,  //  0003  SETMBR	R0	K2	R2
+      0x90020602,  //  0004  SETMBR	R0	K3	R2
+      0x90020802,  //  0005  SETMBR	R0	K4	R2
+      0x90020A02,  //  0006  SETMBR	R0	K5	R2
+      0x90020C02,  //  0007  SETMBR	R0	K6	R2
+      0x90020E02,  //  0008  SETMBR	R0	K7	R2
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: create_TLV
+********************************************************************/
+be_local_closure(Matter_TLV_item_create_TLV,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_TLV_item),
+    /* K1   */  be_nested_str_weak(typ),
+    /* K2   */  be_nested_str_weak(val),
+    }),
+    be_str_weak(create_TLV),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x200C0203,  //  0002  NE	R3	R1	R3
+      0x740E0002,  //  0003  JMPT	R3	#0007
+      0x540E0013,  //  0004  LDINT	R3	20
+      0x1C0C0003,  //  0005  EQ	R3	R0	R3
+      0x780E0004,  //  0006  JMPF	R3	#000C
+      0x5C0C0400,  //  0007  MOVE	R3	R2
+      0x7C0C0000,  //  0008  CALL	R3	0
+      0x900E0200,  //  0009  SETMBR	R3	K1	R0
+      0x900E0401,  //  000A  SETMBR	R3	K2	R1
+      0x80040600,  //  000B  RET	1	R3
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -613,377 +884,12 @@ be_local_closure(Matter_TLV_item_parse,   /* name */
 
 
 /********************************************************************
-** Solidified function: _cmp_gt
+** Solidified function: _encode_tag_len
 ********************************************************************/
-be_local_closure(Matter_TLV_item__cmp_gt,   /* name */
+be_local_closure(Matter_TLV_item__encode_tag_len,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tag_vendor),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(tag_profile),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(tag_number),
-    /* K5   */  be_nested_str_weak(tag_sub),
-    }),
-    be_str_weak(_cmp_gt),
-    &be_const_str_solidified,
-    ( &(const binstruction[72]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0012,  //  0003  JMPF	R2	#0017
-      0x88080300,  //  0004  GETMBR	R2	R1	K0
-      0x4C0C0000,  //  0005  LDNIL	R3
-      0x1C080403,  //  0006  EQ	R2	R2	R3
-      0x780A0000,  //  0007  JMPF	R2	#0009
-      0x80060200,  //  0008  RET	1	K1
-      0x88080100,  //  0009  GETMBR	R2	R0	K0
-      0x880C0300,  //  000A  GETMBR	R3	R1	K0
-      0x24080403,  //  000B  GT	R2	R2	R3
-      0x780A0000,  //  000C  JMPF	R2	#000E
-      0x80060200,  //  000D  RET	1	K1
-      0x88080100,  //  000E  GETMBR	R2	R0	K0
-      0x880C0300,  //  000F  GETMBR	R3	R1	K0
-      0x1C080403,  //  0010  EQ	R2	R2	R3
-      0x780A0004,  //  0011  JMPF	R2	#0017
-      0x88080102,  //  0012  GETMBR	R2	R0	K2
-      0x880C0302,  //  0013  GETMBR	R3	R1	K2
-      0x24080403,  //  0014  GT	R2	R2	R3
-      0x780A0000,  //  0015  JMPF	R2	#0017
-      0x80060200,  //  0016  RET	1	K1
-      0x88080102,  //  0017  GETMBR	R2	R0	K2
-      0x540DFFFE,  //  0018  LDINT	R3	-1
-      0x1C080403,  //  0019  EQ	R2	R2	R3
-      0x780A0005,  //  001A  JMPF	R2	#0021
-      0x88080302,  //  001B  GETMBR	R2	R1	K2
-      0x4C0C0000,  //  001C  LDNIL	R3
-      0x1C080403,  //  001D  EQ	R2	R2	R3
-      0x780A0000,  //  001E  JMPF	R2	#0020
-      0x80060200,  //  001F  RET	1	K1
-      0x70020008,  //  0020  JMP		#002A
-      0x88080102,  //  0021  GETMBR	R2	R0	K2
-      0x4C0C0000,  //  0022  LDNIL	R3
-      0x1C080403,  //  0023  EQ	R2	R2	R3
-      0x780A0004,  //  0024  JMPF	R2	#002A
-      0x88080302,  //  0025  GETMBR	R2	R1	K2
-      0x540DFFFE,  //  0026  LDINT	R3	-1
-      0x1C080403,  //  0027  EQ	R2	R2	R3
-      0x780A0000,  //  0028  JMPF	R2	#002A
-      0x80060600,  //  0029  RET	1	K3
-      0x88080104,  //  002A  GETMBR	R2	R0	K4
-      0x4C0C0000,  //  002B  LDNIL	R3
-      0x20080403,  //  002C  NE	R2	R2	R3
-      0x780A000A,  //  002D  JMPF	R2	#0039
-      0x88080304,  //  002E  GETMBR	R2	R1	K4
-      0x4C0C0000,  //  002F  LDNIL	R3
-      0x1C080403,  //  0030  EQ	R2	R2	R3
-      0x780A0000,  //  0031  JMPF	R2	#0033
-      0x80060200,  //  0032  RET	1	K1
-      0x88080104,  //  0033  GETMBR	R2	R0	K4
-      0x880C0304,  //  0034  GETMBR	R3	R1	K4
-      0x24080403,  //  0035  GT	R2	R2	R3
-      0x780A0000,  //  0036  JMPF	R2	#0038
-      0x80060200,  //  0037  RET	1	K1
-      0x80060600,  //  0038  RET	1	K3
-      0x88080105,  //  0039  GETMBR	R2	R0	K5
-      0x4C0C0000,  //  003A  LDNIL	R3
-      0x20080403,  //  003B  NE	R2	R2	R3
-      0x780A0009,  //  003C  JMPF	R2	#0047
-      0x88080305,  //  003D  GETMBR	R2	R1	K5
-      0x4C0C0000,  //  003E  LDNIL	R3
-      0x1C080403,  //  003F  EQ	R2	R2	R3
-      0x780A0000,  //  0040  JMPF	R2	#0042
-      0x80060200,  //  0041  RET	1	K1
-      0x88080105,  //  0042  GETMBR	R2	R0	K5
-      0x880C0305,  //  0043  GETMBR	R3	R1	K5
-      0x24080403,  //  0044  GT	R2	R2	R3
-      0x780A0000,  //  0045  JMPF	R2	#0047
-      0x80060200,  //  0046  RET	1	K1
-      0x80060600,  //  0047  RET	1	K3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: create_TLV
-********************************************************************/
-be_local_closure(Matter_TLV_item_create_TLV,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_TLV_item),
-    /* K1   */  be_nested_str_weak(typ),
-    /* K2   */  be_nested_str_weak(val),
-    }),
-    be_str_weak(create_TLV),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x200C0203,  //  0002  NE	R3	R1	R3
-      0x740E0002,  //  0003  JMPT	R3	#0007
-      0x540E0013,  //  0004  LDINT	R3	20
-      0x1C0C0003,  //  0005  EQ	R3	R0	R3
-      0x780E0004,  //  0006  JMPF	R3	#000C
-      0x5C0C0400,  //  0007  MOVE	R3	R2
-      0x7C0C0000,  //  0008  CALL	R3	0
-      0x900E0200,  //  0009  SETMBR	R3	K1	R0
-      0x900E0401,  //  000A  SETMBR	R3	K2	R1
-      0x80040600,  //  000B  RET	1	R3
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: to_TLV
-********************************************************************/
-be_local_closure(Matter_TLV_item_to_TLV,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(to_TLV),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80040000,  //  0000  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _encode_tag
-********************************************************************/
-be_local_closure(Matter_TLV_item__encode_tag,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tag_number),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(tag_vendor),
-    /* K3   */  be_nested_str_weak(add),
-    /* K4   */  be_nested_str_weak(typ),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_const_int(2),
-    /* K7   */  be_nested_str_weak(tag_profile),
-    /* K8   */  be_nested_str_weak(tag_sub),
-    }),
-    be_str_weak(_encode_tag),
-    &be_const_str_solidified,
-    ( &(const binstruction[133]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0001,  //  0003  JMPF	R2	#0006
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x70020000,  //  0005  JMP		#0007
-      0x58080001,  //  0006  LDCONST	R2	K1
-      0x540EFFFF,  //  0007  LDINT	R3	65536
-      0x280C0403,  //  0008  GE	R3	R2	R3
-      0x740E0002,  //  0009  JMPT	R3	#000D
-      0x140C0501,  //  000A  LT	R3	R2	K1
-      0x740E0000,  //  000B  JMPT	R3	#000D
-      0x500C0001,  //  000C  LDBOOL	R3	0	1
-      0x500C0200,  //  000D  LDBOOL	R3	1	0
-      0x58100001,  //  000E  LDCONST	R4	K1
-      0x88140102,  //  000F  GETMBR	R5	R0	K2
-      0x4C180000,  //  0010  LDNIL	R6
-      0x20140A06,  //  0011  NE	R5	R5	R6
-      0x78160026,  //  0012  JMPF	R5	#003A
-      0x780E0012,  //  0013  JMPF	R3	#0027
-      0x8C140303,  //  0014  GETMET	R5	R1	K3
-      0x541E00DF,  //  0015  LDINT	R7	224
-      0x88200104,  //  0016  GETMBR	R8	R0	K4
-      0x001C0E08,  //  0017  ADD	R7	R7	R8
-      0x58200005,  //  0018  LDCONST	R8	K5
-      0x7C140600,  //  0019  CALL	R5	3
-      0x8C140303,  //  001A  GETMET	R5	R1	K3
-      0x881C0102,  //  001B  GETMBR	R7	R0	K2
-      0x58200006,  //  001C  LDCONST	R8	K6
-      0x7C140600,  //  001D  CALL	R5	3
-      0x8C140303,  //  001E  GETMET	R5	R1	K3
-      0x881C0107,  //  001F  GETMBR	R7	R0	K7
-      0x58200006,  //  0020  LDCONST	R8	K6
-      0x7C140600,  //  0021  CALL	R5	3
-      0x8C140303,  //  0022  GETMET	R5	R1	K3
-      0x881C0100,  //  0023  GETMBR	R7	R0	K0
-      0x54220003,  //  0024  LDINT	R8	4
-      0x7C140600,  //  0025  CALL	R5	3
-      0x70020011,  //  0026  JMP		#0039
-      0x8C140303,  //  0027  GETMET	R5	R1	K3
-      0x541E00BF,  //  0028  LDINT	R7	192
-      0x88200104,  //  0029  GETMBR	R8	R0	K4
-      0x001C0E08,  //  002A  ADD	R7	R7	R8
-      0x58200005,  //  002B  LDCONST	R8	K5
-      0x7C140600,  //  002C  CALL	R5	3
-      0x8C140303,  //  002D  GETMET	R5	R1	K3
-      0x881C0102,  //  002E  GETMBR	R7	R0	K2
-      0x58200006,  //  002F  LDCONST	R8	K6
-      0x7C140600,  //  0030  CALL	R5	3
-      0x8C140303,  //  0031  GETMET	R5	R1	K3
-      0x881C0107,  //  0032  GETMBR	R7	R0	K7
-      0x58200006,  //  0033  LDCONST	R8	K6
-      0x7C140600,  //  0034  CALL	R5	3
-      0x8C140303,  //  0035  GETMET	R5	R1	K3
-      0x881C0100,  //  0036  GETMBR	R7	R0	K0
-      0x58200006,  //  0037  LDCONST	R8	K6
-      0x7C140600,  //  0038  CALL	R5	3
-      0x70020049,  //  0039  JMP		#0084
-      0x88140107,  //  003A  GETMBR	R5	R0	K7
-      0x5419FFFE,  //  003B  LDINT	R6	-1
-      0x1C140A06,  //  003C  EQ	R5	R5	R6
-      0x78160016,  //  003D  JMPF	R5	#0055
-      0x780E000A,  //  003E  JMPF	R3	#004A
-      0x8C140303,  //  003F  GETMET	R5	R1	K3
-      0x541E005F,  //  0040  LDINT	R7	96
-      0x88200104,  //  0041  GETMBR	R8	R0	K4
-      0x001C0E08,  //  0042  ADD	R7	R7	R8
-      0x58200005,  //  0043  LDCONST	R8	K5
-      0x7C140600,  //  0044  CALL	R5	3
-      0x8C140303,  //  0045  GETMET	R5	R1	K3
-      0x881C0100,  //  0046  GETMBR	R7	R0	K0
-      0x54220003,  //  0047  LDINT	R8	4
-      0x7C140600,  //  0048  CALL	R5	3
-      0x70020009,  //  0049  JMP		#0054
-      0x8C140303,  //  004A  GETMET	R5	R1	K3
-      0x541E003F,  //  004B  LDINT	R7	64
-      0x88200104,  //  004C  GETMBR	R8	R0	K4
-      0x001C0E08,  //  004D  ADD	R7	R7	R8
-      0x58200005,  //  004E  LDCONST	R8	K5
-      0x7C140600,  //  004F  CALL	R5	3
-      0x8C140303,  //  0050  GETMET	R5	R1	K3
-      0x881C0100,  //  0051  GETMBR	R7	R0	K0
-      0x58200006,  //  0052  LDCONST	R8	K6
-      0x7C140600,  //  0053  CALL	R5	3
-      0x7002002E,  //  0054  JMP		#0084
-      0x88140107,  //  0055  GETMBR	R5	R0	K7
-      0x4C180000,  //  0056  LDNIL	R6
-      0x20140A06,  //  0057  NE	R5	R5	R6
-      0x78160016,  //  0058  JMPF	R5	#0070
-      0x780E000A,  //  0059  JMPF	R3	#0065
-      0x8C140303,  //  005A  GETMET	R5	R1	K3
-      0x541E009F,  //  005B  LDINT	R7	160
-      0x88200104,  //  005C  GETMBR	R8	R0	K4
-      0x001C0E08,  //  005D  ADD	R7	R7	R8
-      0x58200005,  //  005E  LDCONST	R8	K5
-      0x7C140600,  //  005F  CALL	R5	3
-      0x8C140303,  //  0060  GETMET	R5	R1	K3
-      0x881C0100,  //  0061  GETMBR	R7	R0	K0
-      0x54220003,  //  0062  LDINT	R8	4
-      0x7C140600,  //  0063  CALL	R5	3
-      0x70020009,  //  0064  JMP		#006F
-      0x8C140303,  //  0065  GETMET	R5	R1	K3
-      0x541E007F,  //  0066  LDINT	R7	128
-      0x88200104,  //  0067  GETMBR	R8	R0	K4
-      0x001C0E08,  //  0068  ADD	R7	R7	R8
-      0x58200005,  //  0069  LDCONST	R8	K5
-      0x7C140600,  //  006A  CALL	R5	3
-      0x8C140303,  //  006B  GETMET	R5	R1	K3
-      0x881C0100,  //  006C  GETMBR	R7	R0	K0
-      0x58200006,  //  006D  LDCONST	R8	K6
-      0x7C140600,  //  006E  CALL	R5	3
-      0x70020013,  //  006F  JMP		#0084
-      0x88140108,  //  0070  GETMBR	R5	R0	K8
-      0x4C180000,  //  0071  LDNIL	R6
-      0x20140A06,  //  0072  NE	R5	R5	R6
-      0x7816000A,  //  0073  JMPF	R5	#007F
-      0x8C140303,  //  0074  GETMET	R5	R1	K3
-      0x541E001F,  //  0075  LDINT	R7	32
-      0x88200104,  //  0076  GETMBR	R8	R0	K4
-      0x001C0E08,  //  0077  ADD	R7	R7	R8
-      0x58200005,  //  0078  LDCONST	R8	K5
-      0x7C140600,  //  0079  CALL	R5	3
-      0x8C140303,  //  007A  GETMET	R5	R1	K3
-      0x881C0108,  //  007B  GETMBR	R7	R0	K8
-      0x58200005,  //  007C  LDCONST	R8	K5
-      0x7C140600,  //  007D  CALL	R5	3
-      0x70020004,  //  007E  JMP		#0084
-      0x8C140303,  //  007F  GETMET	R5	R1	K3
-      0x881C0104,  //  0080  GETMBR	R7	R0	K4
-      0x001E0207,  //  0081  ADD	R7	K1	R7
-      0x58200005,  //  0082  LDCONST	R8	K5
-      0x7C140600,  //  0083  CALL	R5	3
-      0x80000000,  //  0084  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_contextspecific
-********************************************************************/
-be_local_closure(Matter_TLV_item_set_contextspecific,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_fulltag),
-    /* K1   */  be_nested_str_weak(tag_sub),
-    }),
-    be_str_weak(set_contextspecific),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x7C080200,  //  0001  CALL	R2	1
-      0x60080009,  //  0002  GETGBL	R2	G9
-      0x5C0C0200,  //  0003  MOVE	R3	R1
-      0x7C080200,  //  0004  CALL	R2	1
-      0x90020202,  //  0005  SETMBR	R0	K1	R2
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: reset
-********************************************************************/
-be_local_closure(Matter_TLV_item_reset,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -991,28 +897,72 @@ be_local_closure(Matter_TLV_item_reset,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parent),
-    /* K1   */  be_nested_str_weak(next_idx),
+    /* K0   */  be_nested_str_weak(tag_number),
+    /* K1   */  be_const_int(0),
     /* K2   */  be_nested_str_weak(tag_vendor),
     /* K3   */  be_nested_str_weak(tag_profile),
-    /* K4   */  be_nested_str_weak(tag_number),
+    /* K4   */  be_const_int(3),
     /* K5   */  be_nested_str_weak(tag_sub),
-    /* K6   */  be_nested_str_weak(typ),
-    /* K7   */  be_nested_str_weak(val),
+    /* K6   */  be_const_int(2),
+    /* K7   */  be_const_int(1),
     }),
-    be_str_weak(reset),
+    be_str_weak(_encode_tag_len),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x90020202,  //  0002  SETMBR	R0	K1	R2
-      0x90020402,  //  0003  SETMBR	R0	K2	R2
-      0x90020602,  //  0004  SETMBR	R0	K3	R2
-      0x90020802,  //  0005  SETMBR	R0	K4	R2
-      0x90020A02,  //  0006  SETMBR	R0	K5	R2
-      0x90020C02,  //  0007  SETMBR	R0	K6	R2
-      0x90020E02,  //  0008  SETMBR	R0	K7	R2
-      0x80000000,  //  0009  RET	0
+    ( &(const binstruction[54]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060001,  //  0003  JMPF	R1	#0006
+      0x88040100,  //  0004  GETMBR	R1	R0	K0
+      0x70020000,  //  0005  JMP		#0007
+      0x58040001,  //  0006  LDCONST	R1	K1
+      0x540AFFFF,  //  0007  LDINT	R2	65536
+      0x28080202,  //  0008  GE	R2	R1	R2
+      0x740A0002,  //  0009  JMPT	R2	#000D
+      0x14080301,  //  000A  LT	R2	R1	K1
+      0x740A0000,  //  000B  JMPT	R2	#000D
+      0x50080001,  //  000C  LDBOOL	R2	0	1
+      0x50080200,  //  000D  LDBOOL	R2	1	0
+      0x580C0001,  //  000E  LDCONST	R3	K1
+      0x88100102,  //  000F  GETMBR	R4	R0	K2
+      0x4C140000,  //  0010  LDNIL	R5
+      0x20100805,  //  0011  NE	R4	R4	R5
+      0x78120006,  //  0012  JMPF	R4	#001A
+      0x780A0002,  //  0013  JMPF	R2	#0017
+      0x54120008,  //  0014  LDINT	R4	9
+      0x80040800,  //  0015  RET	1	R4
+      0x70020001,  //  0016  JMP		#0019
+      0x54120006,  //  0017  LDINT	R4	7
+      0x80040800,  //  0018  RET	1	R4
+      0x7002001A,  //  0019  JMP		#0035
+      0x88100103,  //  001A  GETMBR	R4	R0	K3
+      0x5415FFFE,  //  001B  LDINT	R5	-1
+      0x1C100805,  //  001C  EQ	R4	R4	R5
+      0x78120005,  //  001D  JMPF	R4	#0024
+      0x780A0002,  //  001E  JMPF	R2	#0022
+      0x54120004,  //  001F  LDINT	R4	5
+      0x80040800,  //  0020  RET	1	R4
+      0x70020000,  //  0021  JMP		#0023
+      0x80060800,  //  0022  RET	1	K4
+      0x70020010,  //  0023  JMP		#0035
+      0x88100103,  //  0024  GETMBR	R4	R0	K3
+      0x4C140000,  //  0025  LDNIL	R5
+      0x20100805,  //  0026  NE	R4	R4	R5
+      0x78120005,  //  0027  JMPF	R4	#002E
+      0x780A0002,  //  0028  JMPF	R2	#002C
+      0x54120004,  //  0029  LDINT	R4	5
+      0x80040800,  //  002A  RET	1	R4
+      0x70020000,  //  002B  JMP		#002D
+      0x80060800,  //  002C  RET	1	K4
+      0x70020006,  //  002D  JMP		#0035
+      0x88100105,  //  002E  GETMBR	R4	R0	K5
+      0x4C140000,  //  002F  LDNIL	R5
+      0x20100805,  //  0030  NE	R4	R4	R5
+      0x78120001,  //  0031  JMPF	R4	#0034
+      0x80060C00,  //  0032  RET	1	K6
+      0x70020000,  //  0033  JMP		#0035
+      0x80060E00,  //  0034  RET	1	K7
+      0x80000000,  //  0035  RET	0
     })
   )
 );
@@ -1020,411 +970,38 @@ be_local_closure(Matter_TLV_item_reset,   /* name */
 
 
 /********************************************************************
-** Solidified function: sort
+** Solidified function: set
 ********************************************************************/
-be_local_closure(Matter_TLV_item_sort,   /* name */
+be_local_closure(Matter_TLV_item_set,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_TLV_item),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(_cmp_gt),
-    /* K4   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(sort),
-    &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080010,  //  0001  GETGBL	R2	G16
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x040C0701,  //  0005  SUB	R3	R3	K1
-      0x400E0203,  //  0006  CONNECT	R3	K1	R3
-      0x7C080200,  //  0007  CALL	R2	1
-      0xA8020013,  //  0008  EXBLK	0	#001D
-      0x5C0C0400,  //  0009  MOVE	R3	R2
-      0x7C0C0000,  //  000A  CALL	R3	0
-      0x94100003,  //  000B  GETIDX	R4	R0	R3
-      0x5C140600,  //  000C  MOVE	R5	R3
-      0x24180B02,  //  000D  GT	R6	R5	K2
-      0x781A000B,  //  000E  JMPF	R6	#001B
-      0x04180B01,  //  000F  SUB	R6	R5	K1
-      0x94180006,  //  0010  GETIDX	R6	R0	R6
-      0x8C180D03,  //  0011  GETMET	R6	R6	K3
-      0x5C200800,  //  0012  MOVE	R8	R4
-      0x7C180400,  //  0013  CALL	R6	2
-      0x24180D02,  //  0014  GT	R6	R6	K2
-      0x781A0004,  //  0015  JMPF	R6	#001B
-      0x04180B01,  //  0016  SUB	R6	R5	K1
-      0x94180006,  //  0017  GETIDX	R6	R0	R6
-      0x98000A06,  //  0018  SETIDX	R0	R5	R6
-      0x04140B01,  //  0019  SUB	R5	R5	K1
-      0x7001FFF1,  //  001A  JMP		#000D
-      0x98000A04,  //  001B  SETIDX	R0	R5	R4
-      0x7001FFEB,  //  001C  JMP		#0009
-      0x58080004,  //  001D  LDCONST	R2	K4
-      0xAC080200,  //  001E  CATCH	R2	1	0
-      0xB0080000,  //  001F  RAISE	2	R0	R0
-      0x80040000,  //  0020  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_fulltag
-********************************************************************/
-be_local_closure(Matter_TLV_item_set_fulltag,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    4,                          /* argc */
+    5,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tag_vendor),
-    /* K1   */  be_nested_str_weak(tag_profile),
-    /* K2   */  be_nested_str_weak(tag_number),
-    /* K3   */  be_nested_str_weak(tag_sub),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(reset),
+    /* K1   */  be_nested_str_weak(typ),
+    /* K2   */  be_nested_str_weak(val),
     }),
-    be_str_weak(set_fulltag),
+    be_str_weak(set),
     &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x60100009,  //  0000  GETGBL	R4	G9
-      0x5C140200,  //  0001  MOVE	R5	R1
-      0x7C100200,  //  0002  CALL	R4	1
-      0x90020004,  //  0003  SETMBR	R0	K0	R4
-      0x60100009,  //  0004  GETGBL	R4	G9
-      0x5C140400,  //  0005  MOVE	R5	R2
-      0x7C100200,  //  0006  CALL	R4	1
-      0x90020204,  //  0007  SETMBR	R0	K1	R4
-      0x60100009,  //  0008  GETGBL	R4	G9
-      0x5C140600,  //  0009  MOVE	R5	R3
-      0x7C100200,  //  000A  CALL	R4	1
-      0x90020404,  //  000B  SETMBR	R0	K2	R4
-      0x4C100000,  //  000C  LDNIL	R4
-      0x90020604,  //  000D  SETMBR	R0	K3	R4
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_parent
-********************************************************************/
-be_local_closure(Matter_TLV_item_set_parent,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parent),
-    }),
-    be_str_weak(set_parent),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(Matter_TLV_item_tostring,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[34]) {     /* constants */
-    /* K0   */  be_nested_str_weak(),
-    /* K1   */  be_nested_str_weak(tag_profile),
-    /* K2   */  be_nested_str_weak(Matter_X3A_X3A),
-    /* K3   */  be_nested_str_weak(tag_number),
-    /* K4   */  be_nested_str_weak(0x_X2508X_X20),
-    /* K5   */  be_nested_str_weak(tag_vendor),
-    /* K6   */  be_nested_str_weak(0x_X2504X_X3A_X3A),
-    /* K7   */  be_nested_str_weak(0x_X2504X_X3A),
-    /* K8   */  be_nested_str_weak(tag_sub),
-    /* K9   */  be_nested_str_weak(_X25i_X20),
-    /* K10  */  be_const_int(0),
-    /* K11  */  be_nested_str_weak(_X3D_X20),
-    /* K12  */  be_nested_str_weak(val),
-    /* K13  */  be_nested_str_weak(int),
-    /* K14  */  be_nested_str_weak(_X25i),
-    /* K15  */  be_nested_str_weak(typ),
-    /* K16  */  be_nested_str_weak(TLV),
-    /* K17  */  be_nested_str_weak(U1),
-    /* K18  */  be_nested_str_weak(U8),
-    /* K19  */  be_nested_str_weak(U),
-    /* K20  */  be_nested_str_weak(bool),
-    /* K21  */  be_nested_str_weak(true),
-    /* K22  */  be_nested_str_weak(false),
-    /* K23  */  be_nested_str_weak(null),
-    /* K24  */  be_nested_str_weak(real),
-    /* K25  */  be_nested_str_weak(_X25g),
-    /* K26  */  be_nested_str_weak(string),
-    /* K27  */  be_nested_str_weak(_X22_X25s_X22),
-    /* K28  */  be_nested_str_weak(int64),
-    /* K29  */  be_nested_str_weak(tostring),
-    /* K30  */  be_nested_str_weak(instance),
-    /* K31  */  be_nested_str_weak(_X25s),
-    /* K32  */  be_nested_str_weak(tohex),
-    /* K33  */  be_nested_str_weak(_X20),
-    }),
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[167]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0xA802009C,  //  0001  EXBLK	0	#009F
-      0x500C0200,  //  0002  LDBOOL	R3	1	0
-      0x200C0203,  //  0003  NE	R3	R1	R3
-      0x780E0038,  //  0004  JMPF	R3	#003E
-      0x880C0101,  //  0005  GETMBR	R3	R0	K1
-      0x5411FFFE,  //  0006  LDINT	R4	-1
-      0x1C0C0604,  //  0007  EQ	R3	R3	R4
-      0x780E000A,  //  0008  JMPF	R3	#0014
-      0x00080502,  //  0009  ADD	R2	R2	K2
-      0x880C0103,  //  000A  GETMBR	R3	R0	K3
-      0x4C100000,  //  000B  LDNIL	R4
-      0x200C0604,  //  000C  NE	R3	R3	R4
-      0x780E0004,  //  000D  JMPF	R3	#0013
-      0x600C0018,  //  000E  GETGBL	R3	G24
-      0x58100004,  //  000F  LDCONST	R4	K4
-      0x88140103,  //  0010  GETMBR	R5	R0	K3
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x00080403,  //  0012  ADD	R2	R2	R3
-      0x70020023,  //  0013  JMP		#0038
-      0x880C0105,  //  0014  GETMBR	R3	R0	K5
-      0x4C100000,  //  0015  LDNIL	R4
-      0x200C0604,  //  0016  NE	R3	R3	R4
-      0x780E0004,  //  0017  JMPF	R3	#001D
-      0x600C0018,  //  0018  GETGBL	R3	G24
-      0x58100006,  //  0019  LDCONST	R4	K6
-      0x88140105,  //  001A  GETMBR	R5	R0	K5
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x00080403,  //  001C  ADD	R2	R2	R3
-      0x880C0101,  //  001D  GETMBR	R3	R0	K1
-      0x4C100000,  //  001E  LDNIL	R4
-      0x200C0604,  //  001F  NE	R3	R3	R4
-      0x780E0004,  //  0020  JMPF	R3	#0026
-      0x600C0018,  //  0021  GETGBL	R3	G24
-      0x58100007,  //  0022  LDCONST	R4	K7
-      0x88140101,  //  0023  GETMBR	R5	R0	K1
-      0x7C0C0400,  //  0024  CALL	R3	2
-      0x00080403,  //  0025  ADD	R2	R2	R3
-      0x880C0103,  //  0026  GETMBR	R3	R0	K3
-      0x4C100000,  //  0027  LDNIL	R4
-      0x200C0604,  //  0028  NE	R3	R3	R4
-      0x780E0004,  //  0029  JMPF	R3	#002F
-      0x600C0018,  //  002A  GETGBL	R3	G24
-      0x58100004,  //  002B  LDCONST	R4	K4
-      0x88140103,  //  002C  GETMBR	R5	R0	K3
-      0x7C0C0400,  //  002D  CALL	R3	2
-      0x00080403,  //  002E  ADD	R2	R2	R3
-      0x880C0108,  //  002F  GETMBR	R3	R0	K8
-      0x4C100000,  //  0030  LDNIL	R4
-      0x200C0604,  //  0031  NE	R3	R3	R4
-      0x780E0004,  //  0032  JMPF	R3	#0038
-      0x600C0018,  //  0033  GETGBL	R3	G24
-      0x58100009,  //  0034  LDCONST	R4	K9
-      0x88140108,  //  0035  GETMBR	R5	R0	K8
-      0x7C0C0400,  //  0036  CALL	R3	2
-      0x00080403,  //  0037  ADD	R2	R2	R3
-      0x600C000C,  //  0038  GETGBL	R3	G12
-      0x5C100400,  //  0039  MOVE	R4	R2
-      0x7C0C0200,  //  003A  CALL	R3	1
-      0x240C070A,  //  003B  GT	R3	R3	K10
-      0x780E0000,  //  003C  JMPF	R3	#003E
-      0x0008050B,  //  003D  ADD	R2	R2	K11
-      0x600C0004,  //  003E  GETGBL	R3	G4
-      0x8810010C,  //  003F  GETMBR	R4	R0	K12
-      0x7C0C0200,  //  0040  CALL	R3	1
-      0x1C0C070D,  //  0041  EQ	R3	R3	K13
-      0x780E0010,  //  0042  JMPF	R3	#0054
-      0x600C0018,  //  0043  GETGBL	R3	G24
-      0x5810000E,  //  0044  LDCONST	R4	K14
-      0x8814010C,  //  0045  GETMBR	R5	R0	K12
-      0x7C0C0400,  //  0046  CALL	R3	2
-      0x00080403,  //  0047  ADD	R2	R2	R3
-      0x880C010F,  //  0048  GETMBR	R3	R0	K15
-      0x88100110,  //  0049  GETMBR	R4	R0	K16
-      0x88100911,  //  004A  GETMBR	R4	R4	K17
-      0x280C0604,  //  004B  GE	R3	R3	R4
-      0x780E0005,  //  004C  JMPF	R3	#0053
-      0x880C010F,  //  004D  GETMBR	R3	R0	K15
-      0x88100110,  //  004E  GETMBR	R4	R0	K16
-      0x88100912,  //  004F  GETMBR	R4	R4	K18
-      0x180C0604,  //  0050  LE	R3	R3	R4
-      0x780E0000,  //  0051  JMPF	R3	#0053
-      0x00080513,  //  0052  ADD	R2	R2	K19
-      0x70020048,  //  0053  JMP		#009D
-      0x600C0004,  //  0054  GETGBL	R3	G4
-      0x8810010C,  //  0055  GETMBR	R4	R0	K12
-      0x7C0C0200,  //  0056  CALL	R3	1
-      0x1C0C0714,  //  0057  EQ	R3	R3	K20
-      0x780E0006,  //  0058  JMPF	R3	#0060
-      0x880C010C,  //  0059  GETMBR	R3	R0	K12
-      0x780E0001,  //  005A  JMPF	R3	#005D
-      0x580C0015,  //  005B  LDCONST	R3	K21
-      0x70020000,  //  005C  JMP		#005E
-      0x580C0016,  //  005D  LDCONST	R3	K22
-      0x00080403,  //  005E  ADD	R2	R2	R3
-      0x7002003C,  //  005F  JMP		#009D
-      0x880C010C,  //  0060  GETMBR	R3	R0	K12
-      0x4C100000,  //  0061  LDNIL	R4
-      0x1C0C0604,  //  0062  EQ	R3	R3	R4
-      0x780E0001,  //  0063  JMPF	R3	#0066
-      0x00080517,  //  0064  ADD	R2	R2	K23
-      0x70020036,  //  0065  JMP		#009D
-      0x600C0004,  //  0066  GETGBL	R3	G4
-      0x8810010C,  //  0067  GETMBR	R4	R0	K12
-      0x7C0C0200,  //  0068  CALL	R3	1
-      0x1C0C0718,  //  0069  EQ	R3	R3	K24
-      0x780E0005,  //  006A  JMPF	R3	#0071
-      0x600C0018,  //  006B  GETGBL	R3	G24
-      0x58100019,  //  006C  LDCONST	R4	K25
-      0x8814010C,  //  006D  GETMBR	R5	R0	K12
-      0x7C0C0400,  //  006E  CALL	R3	2
-      0x00080403,  //  006F  ADD	R2	R2	R3
-      0x7002002B,  //  0070  JMP		#009D
-      0x600C0004,  //  0071  GETGBL	R3	G4
-      0x8810010C,  //  0072  GETMBR	R4	R0	K12
-      0x7C0C0200,  //  0073  CALL	R3	1
-      0x1C0C071A,  //  0074  EQ	R3	R3	K26
-      0x780E0005,  //  0075  JMPF	R3	#007C
-      0x600C0018,  //  0076  GETGBL	R3	G24
-      0x5810001B,  //  0077  LDCONST	R4	K27
-      0x8814010C,  //  0078  GETMBR	R5	R0	K12
-      0x7C0C0400,  //  0079  CALL	R3	2
-      0x00080403,  //  007A  ADD	R2	R2	R3
-      0x70020020,  //  007B  JMP		#009D
-      0x600C000F,  //  007C  GETGBL	R3	G15
-      0x8810010C,  //  007D  GETMBR	R4	R0	K12
-      0xB8163800,  //  007E  GETNGBL	R5	K28
-      0x7C0C0400,  //  007F  CALL	R3	2
-      0x780E000F,  //  0080  JMPF	R3	#0091
-      0x880C010C,  //  0081  GETMBR	R3	R0	K12
-      0x8C0C071D,  //  0082  GETMET	R3	R3	K29
-      0x7C0C0200,  //  0083  CALL	R3	1
-      0x00080403,  //  0084  ADD	R2	R2	R3
-      0x880C010F,  //  0085  GETMBR	R3	R0	K15
-      0x88100110,  //  0086  GETMBR	R4	R0	K16
-      0x88100911,  //  0087  GETMBR	R4	R4	K17
-      0x280C0604,  //  0088  GE	R3	R3	R4
-      0x780E0005,  //  0089  JMPF	R3	#0090
-      0x880C010F,  //  008A  GETMBR	R3	R0	K15
-      0x88100110,  //  008B  GETMBR	R4	R0	K16
-      0x88100912,  //  008C  GETMBR	R4	R4	K18
-      0x180C0604,  //  008D  LE	R3	R3	R4
-      0x780E0000,  //  008E  JMPF	R3	#0090
-      0x00080513,  //  008F  ADD	R2	R2	K19
-      0x7002000B,  //  0090  JMP		#009D
-      0x600C0004,  //  0091  GETGBL	R3	G4
-      0x8810010C,  //  0092  GETMBR	R4	R0	K12
-      0x7C0C0200,  //  0093  CALL	R3	1
-      0x1C0C071E,  //  0094  EQ	R3	R3	K30
-      0x780E0006,  //  0095  JMPF	R3	#009D
-      0x600C0018,  //  0096  GETGBL	R3	G24
-      0x5810001F,  //  0097  LDCONST	R4	K31
-      0x8814010C,  //  0098  GETMBR	R5	R0	K12
-      0x8C140B20,  //  0099  GETMET	R5	R5	K32
-      0x7C140200,  //  009A  CALL	R5	1
-      0x7C0C0400,  //  009B  CALL	R3	2
-      0x00080403,  //  009C  ADD	R2	R2	R3
-      0xA8040001,  //  009D  EXBLK	1	1
-      0x70020006,  //  009E  JMP		#00A6
-      0xAC0C0002,  //  009F  CATCH	R3	0	2
-      0x70020003,  //  00A0  JMP		#00A5
-      0x00140721,  //  00A1  ADD	R5	R3	K33
-      0x00140A04,  //  00A2  ADD	R5	R5	R4
-      0x80040A00,  //  00A3  RET	1	R5
-      0x70020000,  //  00A4  JMP		#00A6
-      0xB0080000,  //  00A5  RAISE	2	R0	R0
-      0x80040400,  //  00A6  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_anonymoustag
-********************************************************************/
-be_local_closure(Matter_TLV_item_set_anonymoustag,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_fulltag),
-    }),
-    be_str_weak(set_anonymoustag),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_TLV_item_init,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(parent),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
+    ( &(const binstruction[12]) {  /* code */
+      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x7C0C0200,  //  0001  CALL	R3	1
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x200C0403,  //  0003  NE	R3	R2	R3
+      0x740E0002,  //  0004  JMPT	R3	#0008
+      0x540E0013,  //  0005  LDINT	R3	20
+      0x1C0C0203,  //  0006  EQ	R3	R1	R3
+      0x780E0002,  //  0007  JMPF	R3	#000B
+      0x90020201,  //  0008  SETMBR	R0	K1	R1
+      0x90020402,  //  0009  SETMBR	R0	K2	R2
+      0x80040000,  //  000A  RET	1	R0
+      0x80000000,  //  000B  RET	0
     })
   )
 );
@@ -1866,11 +1443,11 @@ be_local_closure(Matter_TLV_item_tlv2raw,   /* name */
 
 
 /********************************************************************
-** Solidified function: _encode_tag_len
+** Solidified function: set_anonymoustag
 ********************************************************************/
-be_local_closure(Matter_TLV_item__encode_tag_len,   /* name */
+be_local_closure(Matter_TLV_item_set_anonymoustag,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    3,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1878,73 +1455,508 @@ be_local_closure(Matter_TLV_item__encode_tag_len,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_fulltag),
+    }),
+    be_str_weak(set_anonymoustag),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _cmp_gt
+********************************************************************/
+be_local_closure(Matter_TLV_item__cmp_gt,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tag_vendor),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_nested_str_weak(tag_profile),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(tag_number),
+    /* K5   */  be_nested_str_weak(tag_sub),
+    }),
+    be_str_weak(_cmp_gt),
+    &be_const_str_solidified,
+    ( &(const binstruction[72]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0012,  //  0003  JMPF	R2	#0017
+      0x88080300,  //  0004  GETMBR	R2	R1	K0
+      0x4C0C0000,  //  0005  LDNIL	R3
+      0x1C080403,  //  0006  EQ	R2	R2	R3
+      0x780A0000,  //  0007  JMPF	R2	#0009
+      0x80060200,  //  0008  RET	1	K1
+      0x88080100,  //  0009  GETMBR	R2	R0	K0
+      0x880C0300,  //  000A  GETMBR	R3	R1	K0
+      0x24080403,  //  000B  GT	R2	R2	R3
+      0x780A0000,  //  000C  JMPF	R2	#000E
+      0x80060200,  //  000D  RET	1	K1
+      0x88080100,  //  000E  GETMBR	R2	R0	K0
+      0x880C0300,  //  000F  GETMBR	R3	R1	K0
+      0x1C080403,  //  0010  EQ	R2	R2	R3
+      0x780A0004,  //  0011  JMPF	R2	#0017
+      0x88080102,  //  0012  GETMBR	R2	R0	K2
+      0x880C0302,  //  0013  GETMBR	R3	R1	K2
+      0x24080403,  //  0014  GT	R2	R2	R3
+      0x780A0000,  //  0015  JMPF	R2	#0017
+      0x80060200,  //  0016  RET	1	K1
+      0x88080102,  //  0017  GETMBR	R2	R0	K2
+      0x540DFFFE,  //  0018  LDINT	R3	-1
+      0x1C080403,  //  0019  EQ	R2	R2	R3
+      0x780A0005,  //  001A  JMPF	R2	#0021
+      0x88080302,  //  001B  GETMBR	R2	R1	K2
+      0x4C0C0000,  //  001C  LDNIL	R3
+      0x1C080403,  //  001D  EQ	R2	R2	R3
+      0x780A0000,  //  001E  JMPF	R2	#0020
+      0x80060200,  //  001F  RET	1	K1
+      0x70020008,  //  0020  JMP		#002A
+      0x88080102,  //  0021  GETMBR	R2	R0	K2
+      0x4C0C0000,  //  0022  LDNIL	R3
+      0x1C080403,  //  0023  EQ	R2	R2	R3
+      0x780A0004,  //  0024  JMPF	R2	#002A
+      0x88080302,  //  0025  GETMBR	R2	R1	K2
+      0x540DFFFE,  //  0026  LDINT	R3	-1
+      0x1C080403,  //  0027  EQ	R2	R2	R3
+      0x780A0000,  //  0028  JMPF	R2	#002A
+      0x80060600,  //  0029  RET	1	K3
+      0x88080104,  //  002A  GETMBR	R2	R0	K4
+      0x4C0C0000,  //  002B  LDNIL	R3
+      0x20080403,  //  002C  NE	R2	R2	R3
+      0x780A000A,  //  002D  JMPF	R2	#0039
+      0x88080304,  //  002E  GETMBR	R2	R1	K4
+      0x4C0C0000,  //  002F  LDNIL	R3
+      0x1C080403,  //  0030  EQ	R2	R2	R3
+      0x780A0000,  //  0031  JMPF	R2	#0033
+      0x80060200,  //  0032  RET	1	K1
+      0x88080104,  //  0033  GETMBR	R2	R0	K4
+      0x880C0304,  //  0034  GETMBR	R3	R1	K4
+      0x24080403,  //  0035  GT	R2	R2	R3
+      0x780A0000,  //  0036  JMPF	R2	#0038
+      0x80060200,  //  0037  RET	1	K1
+      0x80060600,  //  0038  RET	1	K3
+      0x88080105,  //  0039  GETMBR	R2	R0	K5
+      0x4C0C0000,  //  003A  LDNIL	R3
+      0x20080403,  //  003B  NE	R2	R2	R3
+      0x780A0009,  //  003C  JMPF	R2	#0047
+      0x88080305,  //  003D  GETMBR	R2	R1	K5
+      0x4C0C0000,  //  003E  LDNIL	R3
+      0x1C080403,  //  003F  EQ	R2	R2	R3
+      0x780A0000,  //  0040  JMPF	R2	#0042
+      0x80060200,  //  0041  RET	1	K1
+      0x88080105,  //  0042  GETMBR	R2	R0	K5
+      0x880C0305,  //  0043  GETMBR	R3	R1	K5
+      0x24080403,  //  0044  GT	R2	R2	R3
+      0x780A0000,  //  0045  JMPF	R2	#0047
+      0x80060200,  //  0046  RET	1	K1
+      0x80060600,  //  0047  RET	1	K3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _encode_tag
+********************************************************************/
+be_local_closure(Matter_TLV_item__encode_tag,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(tag_number),
     /* K1   */  be_const_int(0),
     /* K2   */  be_nested_str_weak(tag_vendor),
-    /* K3   */  be_nested_str_weak(tag_profile),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(tag_sub),
+    /* K3   */  be_nested_str_weak(add),
+    /* K4   */  be_nested_str_weak(typ),
+    /* K5   */  be_const_int(1),
     /* K6   */  be_const_int(2),
-    /* K7   */  be_const_int(1),
+    /* K7   */  be_nested_str_weak(tag_profile),
+    /* K8   */  be_nested_str_weak(tag_sub),
     }),
-    be_str_weak(_encode_tag_len),
+    be_str_weak(_encode_tag),
     &be_const_str_solidified,
-    ( &(const binstruction[54]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060001,  //  0003  JMPF	R1	#0006
-      0x88040100,  //  0004  GETMBR	R1	R0	K0
+    ( &(const binstruction[133]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0001,  //  0003  JMPF	R2	#0006
+      0x88080100,  //  0004  GETMBR	R2	R0	K0
       0x70020000,  //  0005  JMP		#0007
-      0x58040001,  //  0006  LDCONST	R1	K1
-      0x540AFFFF,  //  0007  LDINT	R2	65536
-      0x28080202,  //  0008  GE	R2	R1	R2
-      0x740A0002,  //  0009  JMPT	R2	#000D
-      0x14080301,  //  000A  LT	R2	R1	K1
-      0x740A0000,  //  000B  JMPT	R2	#000D
-      0x50080001,  //  000C  LDBOOL	R2	0	1
-      0x50080200,  //  000D  LDBOOL	R2	1	0
-      0x580C0001,  //  000E  LDCONST	R3	K1
-      0x88100102,  //  000F  GETMBR	R4	R0	K2
-      0x4C140000,  //  0010  LDNIL	R5
-      0x20100805,  //  0011  NE	R4	R4	R5
-      0x78120006,  //  0012  JMPF	R4	#001A
-      0x780A0002,  //  0013  JMPF	R2	#0017
-      0x54120008,  //  0014  LDINT	R4	9
-      0x80040800,  //  0015  RET	1	R4
-      0x70020001,  //  0016  JMP		#0019
-      0x54120006,  //  0017  LDINT	R4	7
-      0x80040800,  //  0018  RET	1	R4
-      0x7002001A,  //  0019  JMP		#0035
-      0x88100103,  //  001A  GETMBR	R4	R0	K3
-      0x5415FFFE,  //  001B  LDINT	R5	-1
-      0x1C100805,  //  001C  EQ	R4	R4	R5
-      0x78120005,  //  001D  JMPF	R4	#0024
-      0x780A0002,  //  001E  JMPF	R2	#0022
-      0x54120004,  //  001F  LDINT	R4	5
-      0x80040800,  //  0020  RET	1	R4
-      0x70020000,  //  0021  JMP		#0023
-      0x80060800,  //  0022  RET	1	K4
-      0x70020010,  //  0023  JMP		#0035
-      0x88100103,  //  0024  GETMBR	R4	R0	K3
-      0x4C140000,  //  0025  LDNIL	R5
-      0x20100805,  //  0026  NE	R4	R4	R5
-      0x78120005,  //  0027  JMPF	R4	#002E
-      0x780A0002,  //  0028  JMPF	R2	#002C
-      0x54120004,  //  0029  LDINT	R4	5
-      0x80040800,  //  002A  RET	1	R4
-      0x70020000,  //  002B  JMP		#002D
-      0x80060800,  //  002C  RET	1	K4
-      0x70020006,  //  002D  JMP		#0035
-      0x88100105,  //  002E  GETMBR	R4	R0	K5
-      0x4C140000,  //  002F  LDNIL	R5
-      0x20100805,  //  0030  NE	R4	R4	R5
-      0x78120001,  //  0031  JMPF	R4	#0034
-      0x80060C00,  //  0032  RET	1	K6
-      0x70020000,  //  0033  JMP		#0035
-      0x80060E00,  //  0034  RET	1	K7
-      0x80000000,  //  0035  RET	0
+      0x58080001,  //  0006  LDCONST	R2	K1
+      0x540EFFFF,  //  0007  LDINT	R3	65536
+      0x280C0403,  //  0008  GE	R3	R2	R3
+      0x740E0002,  //  0009  JMPT	R3	#000D
+      0x140C0501,  //  000A  LT	R3	R2	K1
+      0x740E0000,  //  000B  JMPT	R3	#000D
+      0x500C0001,  //  000C  LDBOOL	R3	0	1
+      0x500C0200,  //  000D  LDBOOL	R3	1	0
+      0x58100001,  //  000E  LDCONST	R4	K1
+      0x88140102,  //  000F  GETMBR	R5	R0	K2
+      0x4C180000,  //  0010  LDNIL	R6
+      0x20140A06,  //  0011  NE	R5	R5	R6
+      0x78160026,  //  0012  JMPF	R5	#003A
+      0x780E0012,  //  0013  JMPF	R3	#0027
+      0x8C140303,  //  0014  GETMET	R5	R1	K3
+      0x541E00DF,  //  0015  LDINT	R7	224
+      0x88200104,  //  0016  GETMBR	R8	R0	K4
+      0x001C0E08,  //  0017  ADD	R7	R7	R8
+      0x58200005,  //  0018  LDCONST	R8	K5
+      0x7C140600,  //  0019  CALL	R5	3
+      0x8C140303,  //  001A  GETMET	R5	R1	K3
+      0x881C0102,  //  001B  GETMBR	R7	R0	K2
+      0x58200006,  //  001C  LDCONST	R8	K6
+      0x7C140600,  //  001D  CALL	R5	3
+      0x8C140303,  //  001E  GETMET	R5	R1	K3
+      0x881C0107,  //  001F  GETMBR	R7	R0	K7
+      0x58200006,  //  0020  LDCONST	R8	K6
+      0x7C140600,  //  0021  CALL	R5	3
+      0x8C140303,  //  0022  GETMET	R5	R1	K3
+      0x881C0100,  //  0023  GETMBR	R7	R0	K0
+      0x54220003,  //  0024  LDINT	R8	4
+      0x7C140600,  //  0025  CALL	R5	3
+      0x70020011,  //  0026  JMP		#0039
+      0x8C140303,  //  0027  GETMET	R5	R1	K3
+      0x541E00BF,  //  0028  LDINT	R7	192
+      0x88200104,  //  0029  GETMBR	R8	R0	K4
+      0x001C0E08,  //  002A  ADD	R7	R7	R8
+      0x58200005,  //  002B  LDCONST	R8	K5
+      0x7C140600,  //  002C  CALL	R5	3
+      0x8C140303,  //  002D  GETMET	R5	R1	K3
+      0x881C0102,  //  002E  GETMBR	R7	R0	K2
+      0x58200006,  //  002F  LDCONST	R8	K6
+      0x7C140600,  //  0030  CALL	R5	3
+      0x8C140303,  //  0031  GETMET	R5	R1	K3
+      0x881C0107,  //  0032  GETMBR	R7	R0	K7
+      0x58200006,  //  0033  LDCONST	R8	K6
+      0x7C140600,  //  0034  CALL	R5	3
+      0x8C140303,  //  0035  GETMET	R5	R1	K3
+      0x881C0100,  //  0036  GETMBR	R7	R0	K0
+      0x58200006,  //  0037  LDCONST	R8	K6
+      0x7C140600,  //  0038  CALL	R5	3
+      0x70020049,  //  0039  JMP		#0084
+      0x88140107,  //  003A  GETMBR	R5	R0	K7
+      0x5419FFFE,  //  003B  LDINT	R6	-1
+      0x1C140A06,  //  003C  EQ	R5	R5	R6
+      0x78160016,  //  003D  JMPF	R5	#0055
+      0x780E000A,  //  003E  JMPF	R3	#004A
+      0x8C140303,  //  003F  GETMET	R5	R1	K3
+      0x541E005F,  //  0040  LDINT	R7	96
+      0x88200104,  //  0041  GETMBR	R8	R0	K4
+      0x001C0E08,  //  0042  ADD	R7	R7	R8
+      0x58200005,  //  0043  LDCONST	R8	K5
+      0x7C140600,  //  0044  CALL	R5	3
+      0x8C140303,  //  0045  GETMET	R5	R1	K3
+      0x881C0100,  //  0046  GETMBR	R7	R0	K0
+      0x54220003,  //  0047  LDINT	R8	4
+      0x7C140600,  //  0048  CALL	R5	3
+      0x70020009,  //  0049  JMP		#0054
+      0x8C140303,  //  004A  GETMET	R5	R1	K3
+      0x541E003F,  //  004B  LDINT	R7	64
+      0x88200104,  //  004C  GETMBR	R8	R0	K4
+      0x001C0E08,  //  004D  ADD	R7	R7	R8
+      0x58200005,  //  004E  LDCONST	R8	K5
+      0x7C140600,  //  004F  CALL	R5	3
+      0x8C140303,  //  0050  GETMET	R5	R1	K3
+      0x881C0100,  //  0051  GETMBR	R7	R0	K0
+      0x58200006,  //  0052  LDCONST	R8	K6
+      0x7C140600,  //  0053  CALL	R5	3
+      0x7002002E,  //  0054  JMP		#0084
+      0x88140107,  //  0055  GETMBR	R5	R0	K7
+      0x4C180000,  //  0056  LDNIL	R6
+      0x20140A06,  //  0057  NE	R5	R5	R6
+      0x78160016,  //  0058  JMPF	R5	#0070
+      0x780E000A,  //  0059  JMPF	R3	#0065
+      0x8C140303,  //  005A  GETMET	R5	R1	K3
+      0x541E009F,  //  005B  LDINT	R7	160
+      0x88200104,  //  005C  GETMBR	R8	R0	K4
+      0x001C0E08,  //  005D  ADD	R7	R7	R8
+      0x58200005,  //  005E  LDCONST	R8	K5
+      0x7C140600,  //  005F  CALL	R5	3
+      0x8C140303,  //  0060  GETMET	R5	R1	K3
+      0x881C0100,  //  0061  GETMBR	R7	R0	K0
+      0x54220003,  //  0062  LDINT	R8	4
+      0x7C140600,  //  0063  CALL	R5	3
+      0x70020009,  //  0064  JMP		#006F
+      0x8C140303,  //  0065  GETMET	R5	R1	K3
+      0x541E007F,  //  0066  LDINT	R7	128
+      0x88200104,  //  0067  GETMBR	R8	R0	K4
+      0x001C0E08,  //  0068  ADD	R7	R7	R8
+      0x58200005,  //  0069  LDCONST	R8	K5
+      0x7C140600,  //  006A  CALL	R5	3
+      0x8C140303,  //  006B  GETMET	R5	R1	K3
+      0x881C0100,  //  006C  GETMBR	R7	R0	K0
+      0x58200006,  //  006D  LDCONST	R8	K6
+      0x7C140600,  //  006E  CALL	R5	3
+      0x70020013,  //  006F  JMP		#0084
+      0x88140108,  //  0070  GETMBR	R5	R0	K8
+      0x4C180000,  //  0071  LDNIL	R6
+      0x20140A06,  //  0072  NE	R5	R5	R6
+      0x7816000A,  //  0073  JMPF	R5	#007F
+      0x8C140303,  //  0074  GETMET	R5	R1	K3
+      0x541E001F,  //  0075  LDINT	R7	32
+      0x88200104,  //  0076  GETMBR	R8	R0	K4
+      0x001C0E08,  //  0077  ADD	R7	R7	R8
+      0x58200005,  //  0078  LDCONST	R8	K5
+      0x7C140600,  //  0079  CALL	R5	3
+      0x8C140303,  //  007A  GETMET	R5	R1	K3
+      0x881C0108,  //  007B  GETMBR	R7	R0	K8
+      0x58200005,  //  007C  LDCONST	R8	K5
+      0x7C140600,  //  007D  CALL	R5	3
+      0x70020004,  //  007E  JMP		#0084
+      0x8C140303,  //  007F  GETMET	R5	R1	K3
+      0x881C0104,  //  0080  GETMBR	R7	R0	K4
+      0x001E0207,  //  0081  ADD	R7	K1	R7
+      0x58200005,  //  0082  LDCONST	R8	K5
+      0x7C140600,  //  0083  CALL	R5	3
+      0x80000000,  //  0084  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(Matter_TLV_item_tostring,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[34]) {     /* constants */
+    /* K0   */  be_nested_str_weak(),
+    /* K1   */  be_nested_str_weak(tag_profile),
+    /* K2   */  be_nested_str_weak(Matter_X3A_X3A),
+    /* K3   */  be_nested_str_weak(tag_number),
+    /* K4   */  be_nested_str_weak(0x_X2508X_X20),
+    /* K5   */  be_nested_str_weak(tag_vendor),
+    /* K6   */  be_nested_str_weak(0x_X2504X_X3A_X3A),
+    /* K7   */  be_nested_str_weak(0x_X2504X_X3A),
+    /* K8   */  be_nested_str_weak(tag_sub),
+    /* K9   */  be_nested_str_weak(_X25i_X20),
+    /* K10  */  be_const_int(0),
+    /* K11  */  be_nested_str_weak(_X3D_X20),
+    /* K12  */  be_nested_str_weak(val),
+    /* K13  */  be_nested_str_weak(int),
+    /* K14  */  be_nested_str_weak(_X25i),
+    /* K15  */  be_nested_str_weak(typ),
+    /* K16  */  be_nested_str_weak(TLV),
+    /* K17  */  be_nested_str_weak(U1),
+    /* K18  */  be_nested_str_weak(U8),
+    /* K19  */  be_nested_str_weak(U),
+    /* K20  */  be_nested_str_weak(bool),
+    /* K21  */  be_nested_str_weak(true),
+    /* K22  */  be_nested_str_weak(false),
+    /* K23  */  be_nested_str_weak(null),
+    /* K24  */  be_nested_str_weak(real),
+    /* K25  */  be_nested_str_weak(_X25g),
+    /* K26  */  be_nested_str_weak(string),
+    /* K27  */  be_nested_str_weak(_X22_X25s_X22),
+    /* K28  */  be_nested_str_weak(int64),
+    /* K29  */  be_nested_str_weak(tostring),
+    /* K30  */  be_nested_str_weak(instance),
+    /* K31  */  be_nested_str_weak(_X25s),
+    /* K32  */  be_nested_str_weak(tohex),
+    /* K33  */  be_nested_str_weak(_X20),
+    }),
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[167]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0xA802009C,  //  0001  EXBLK	0	#009F
+      0x500C0200,  //  0002  LDBOOL	R3	1	0
+      0x200C0203,  //  0003  NE	R3	R1	R3
+      0x780E0038,  //  0004  JMPF	R3	#003E
+      0x880C0101,  //  0005  GETMBR	R3	R0	K1
+      0x5411FFFE,  //  0006  LDINT	R4	-1
+      0x1C0C0604,  //  0007  EQ	R3	R3	R4
+      0x780E000A,  //  0008  JMPF	R3	#0014
+      0x00080502,  //  0009  ADD	R2	R2	K2
+      0x880C0103,  //  000A  GETMBR	R3	R0	K3
+      0x4C100000,  //  000B  LDNIL	R4
+      0x200C0604,  //  000C  NE	R3	R3	R4
+      0x780E0004,  //  000D  JMPF	R3	#0013
+      0x600C0018,  //  000E  GETGBL	R3	G24
+      0x58100004,  //  000F  LDCONST	R4	K4
+      0x88140103,  //  0010  GETMBR	R5	R0	K3
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x00080403,  //  0012  ADD	R2	R2	R3
+      0x70020023,  //  0013  JMP		#0038
+      0x880C0105,  //  0014  GETMBR	R3	R0	K5
+      0x4C100000,  //  0015  LDNIL	R4
+      0x200C0604,  //  0016  NE	R3	R3	R4
+      0x780E0004,  //  0017  JMPF	R3	#001D
+      0x600C0018,  //  0018  GETGBL	R3	G24
+      0x58100006,  //  0019  LDCONST	R4	K6
+      0x88140105,  //  001A  GETMBR	R5	R0	K5
+      0x7C0C0400,  //  001B  CALL	R3	2
+      0x00080403,  //  001C  ADD	R2	R2	R3
+      0x880C0101,  //  001D  GETMBR	R3	R0	K1
+      0x4C100000,  //  001E  LDNIL	R4
+      0x200C0604,  //  001F  NE	R3	R3	R4
+      0x780E0004,  //  0020  JMPF	R3	#0026
+      0x600C0018,  //  0021  GETGBL	R3	G24
+      0x58100007,  //  0022  LDCONST	R4	K7
+      0x88140101,  //  0023  GETMBR	R5	R0	K1
+      0x7C0C0400,  //  0024  CALL	R3	2
+      0x00080403,  //  0025  ADD	R2	R2	R3
+      0x880C0103,  //  0026  GETMBR	R3	R0	K3
+      0x4C100000,  //  0027  LDNIL	R4
+      0x200C0604,  //  0028  NE	R3	R3	R4
+      0x780E0004,  //  0029  JMPF	R3	#002F
+      0x600C0018,  //  002A  GETGBL	R3	G24
+      0x58100004,  //  002B  LDCONST	R4	K4
+      0x88140103,  //  002C  GETMBR	R5	R0	K3
+      0x7C0C0400,  //  002D  CALL	R3	2
+      0x00080403,  //  002E  ADD	R2	R2	R3
+      0x880C0108,  //  002F  GETMBR	R3	R0	K8
+      0x4C100000,  //  0030  LDNIL	R4
+      0x200C0604,  //  0031  NE	R3	R3	R4
+      0x780E0004,  //  0032  JMPF	R3	#0038
+      0x600C0018,  //  0033  GETGBL	R3	G24
+      0x58100009,  //  0034  LDCONST	R4	K9
+      0x88140108,  //  0035  GETMBR	R5	R0	K8
+      0x7C0C0400,  //  0036  CALL	R3	2
+      0x00080403,  //  0037  ADD	R2	R2	R3
+      0x600C000C,  //  0038  GETGBL	R3	G12
+      0x5C100400,  //  0039  MOVE	R4	R2
+      0x7C0C0200,  //  003A  CALL	R3	1
+      0x240C070A,  //  003B  GT	R3	R3	K10
+      0x780E0000,  //  003C  JMPF	R3	#003E
+      0x0008050B,  //  003D  ADD	R2	R2	K11
+      0x600C0004,  //  003E  GETGBL	R3	G4
+      0x8810010C,  //  003F  GETMBR	R4	R0	K12
+      0x7C0C0200,  //  0040  CALL	R3	1
+      0x1C0C070D,  //  0041  EQ	R3	R3	K13
+      0x780E0010,  //  0042  JMPF	R3	#0054
+      0x600C0018,  //  0043  GETGBL	R3	G24
+      0x5810000E,  //  0044  LDCONST	R4	K14
+      0x8814010C,  //  0045  GETMBR	R5	R0	K12
+      0x7C0C0400,  //  0046  CALL	R3	2
+      0x00080403,  //  0047  ADD	R2	R2	R3
+      0x880C010F,  //  0048  GETMBR	R3	R0	K15
+      0x88100110,  //  0049  GETMBR	R4	R0	K16
+      0x88100911,  //  004A  GETMBR	R4	R4	K17
+      0x280C0604,  //  004B  GE	R3	R3	R4
+      0x780E0005,  //  004C  JMPF	R3	#0053
+      0x880C010F,  //  004D  GETMBR	R3	R0	K15
+      0x88100110,  //  004E  GETMBR	R4	R0	K16
+      0x88100912,  //  004F  GETMBR	R4	R4	K18
+      0x180C0604,  //  0050  LE	R3	R3	R4
+      0x780E0000,  //  0051  JMPF	R3	#0053
+      0x00080513,  //  0052  ADD	R2	R2	K19
+      0x70020048,  //  0053  JMP		#009D
+      0x600C0004,  //  0054  GETGBL	R3	G4
+      0x8810010C,  //  0055  GETMBR	R4	R0	K12
+      0x7C0C0200,  //  0056  CALL	R3	1
+      0x1C0C0714,  //  0057  EQ	R3	R3	K20
+      0x780E0006,  //  0058  JMPF	R3	#0060
+      0x880C010C,  //  0059  GETMBR	R3	R0	K12
+      0x780E0001,  //  005A  JMPF	R3	#005D
+      0x580C0015,  //  005B  LDCONST	R3	K21
+      0x70020000,  //  005C  JMP		#005E
+      0x580C0016,  //  005D  LDCONST	R3	K22
+      0x00080403,  //  005E  ADD	R2	R2	R3
+      0x7002003C,  //  005F  JMP		#009D
+      0x880C010C,  //  0060  GETMBR	R3	R0	K12
+      0x4C100000,  //  0061  LDNIL	R4
+      0x1C0C0604,  //  0062  EQ	R3	R3	R4
+      0x780E0001,  //  0063  JMPF	R3	#0066
+      0x00080517,  //  0064  ADD	R2	R2	K23
+      0x70020036,  //  0065  JMP		#009D
+      0x600C0004,  //  0066  GETGBL	R3	G4
+      0x8810010C,  //  0067  GETMBR	R4	R0	K12
+      0x7C0C0200,  //  0068  CALL	R3	1
+      0x1C0C0718,  //  0069  EQ	R3	R3	K24
+      0x780E0005,  //  006A  JMPF	R3	#0071
+      0x600C0018,  //  006B  GETGBL	R3	G24
+      0x58100019,  //  006C  LDCONST	R4	K25
+      0x8814010C,  //  006D  GETMBR	R5	R0	K12
+      0x7C0C0400,  //  006E  CALL	R3	2
+      0x00080403,  //  006F  ADD	R2	R2	R3
+      0x7002002B,  //  0070  JMP		#009D
+      0x600C0004,  //  0071  GETGBL	R3	G4
+      0x8810010C,  //  0072  GETMBR	R4	R0	K12
+      0x7C0C0200,  //  0073  CALL	R3	1
+      0x1C0C071A,  //  0074  EQ	R3	R3	K26
+      0x780E0005,  //  0075  JMPF	R3	#007C
+      0x600C0018,  //  0076  GETGBL	R3	G24
+      0x5810001B,  //  0077  LDCONST	R4	K27
+      0x8814010C,  //  0078  GETMBR	R5	R0	K12
+      0x7C0C0400,  //  0079  CALL	R3	2
+      0x00080403,  //  007A  ADD	R2	R2	R3
+      0x70020020,  //  007B  JMP		#009D
+      0x600C000F,  //  007C  GETGBL	R3	G15
+      0x8810010C,  //  007D  GETMBR	R4	R0	K12
+      0xB8163800,  //  007E  GETNGBL	R5	K28
+      0x7C0C0400,  //  007F  CALL	R3	2
+      0x780E000F,  //  0080  JMPF	R3	#0091
+      0x880C010C,  //  0081  GETMBR	R3	R0	K12
+      0x8C0C071D,  //  0082  GETMET	R3	R3	K29
+      0x7C0C0200,  //  0083  CALL	R3	1
+      0x00080403,  //  0084  ADD	R2	R2	R3
+      0x880C010F,  //  0085  GETMBR	R3	R0	K15
+      0x88100110,  //  0086  GETMBR	R4	R0	K16
+      0x88100911,  //  0087  GETMBR	R4	R4	K17
+      0x280C0604,  //  0088  GE	R3	R3	R4
+      0x780E0005,  //  0089  JMPF	R3	#0090
+      0x880C010F,  //  008A  GETMBR	R3	R0	K15
+      0x88100110,  //  008B  GETMBR	R4	R0	K16
+      0x88100912,  //  008C  GETMBR	R4	R4	K18
+      0x180C0604,  //  008D  LE	R3	R3	R4
+      0x780E0000,  //  008E  JMPF	R3	#0090
+      0x00080513,  //  008F  ADD	R2	R2	K19
+      0x7002000B,  //  0090  JMP		#009D
+      0x600C0004,  //  0091  GETGBL	R3	G4
+      0x8810010C,  //  0092  GETMBR	R4	R0	K12
+      0x7C0C0200,  //  0093  CALL	R3	1
+      0x1C0C071E,  //  0094  EQ	R3	R3	K30
+      0x780E0006,  //  0095  JMPF	R3	#009D
+      0x600C0018,  //  0096  GETGBL	R3	G24
+      0x5810001F,  //  0097  LDCONST	R4	K31
+      0x8814010C,  //  0098  GETMBR	R5	R0	K12
+      0x8C140B20,  //  0099  GETMET	R5	R5	K32
+      0x7C140200,  //  009A  CALL	R5	1
+      0x7C0C0400,  //  009B  CALL	R3	2
+      0x00080403,  //  009C  ADD	R2	R2	R3
+      0xA8040001,  //  009D  EXBLK	1	1
+      0x70020006,  //  009E  JMP		#00A6
+      0xAC0C0002,  //  009F  CATCH	R3	0	2
+      0x70020003,  //  00A0  JMP		#00A5
+      0x00140721,  //  00A1  ADD	R5	R3	K33
+      0x00140A04,  //  00A2  ADD	R5	R5	R4
+      0x80040A00,  //  00A3  RET	1	R5
+      0x70020000,  //  00A4  JMP		#00A6
+      0xB0080000,  //  00A5  RAISE	2	R0	R0
+      0x80040400,  //  00A6  RET	1	R2
     })
   )
 );
@@ -1983,38 +1995,26 @@ be_local_closure(Matter_TLV_item_set_commonprofile,   /* name */
 
 
 /********************************************************************
-** Solidified function: set
+** Solidified function: init
 ********************************************************************/
-be_local_closure(Matter_TLV_item_set,   /* name */
+be_local_closure(Matter_TLV_item_init,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    3,                          /* argc */
+    2,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(reset),
-    /* K1   */  be_nested_str_weak(typ),
-    /* K2   */  be_nested_str_weak(val),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(parent),
     }),
-    be_str_weak(set),
+    be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
-      0x7C0C0200,  //  0001  CALL	R3	1
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x200C0403,  //  0003  NE	R3	R2	R3
-      0x740E0002,  //  0004  JMPT	R3	#0008
-      0x540E0013,  //  0005  LDINT	R3	20
-      0x1C0C0203,  //  0006  EQ	R3	R1	R3
-      0x780E0002,  //  0007  JMPF	R3	#000B
-      0x90020201,  //  0008  SETMBR	R0	K1	R1
-      0x90020402,  //  0009  SETMBR	R0	K2	R2
-      0x80040000,  //  000A  RET	1	R0
-      0x80000000,  //  000B  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
     })
   )
 );
@@ -2027,36 +2027,39 @@ be_local_closure(Matter_TLV_item_set,   /* name */
 be_local_class(Matter_TLV_item,
     8,
     NULL,
-    be_nested_map(28,
+    be_nested_map(31,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(parent, -1), be_const_var(0) },
-        { be_const_key_weak(TLV, 0), be_const_class(be_class_Matter_TLV) },
-        { be_const_key_weak(tag_sub, -1), be_const_var(5) },
-        { be_const_key_weak(encode_len, -1), be_const_closure(Matter_TLV_item_encode_len_closure) },
-        { be_const_key_weak(val, 5), be_const_var(7) },
-        { be_const_key_weak(_cmp_gt, -1), be_const_closure(Matter_TLV_item__cmp_gt_closure) },
-        { be_const_key_weak(create_TLV, -1), be_const_static_closure(Matter_TLV_item_create_TLV_closure) },
-        { be_const_key_weak(reset, -1), be_const_closure(Matter_TLV_item_reset_closure) },
-        { be_const_key_weak(to_str_val, 6), be_const_closure(Matter_TLV_item_to_str_val_closure) },
-        { be_const_key_weak(to_TLV, -1), be_const_closure(Matter_TLV_item_to_TLV_closure) },
-        { be_const_key_weak(_encode_tag_len, -1), be_const_closure(Matter_TLV_item__encode_tag_len_closure) },
-        { be_const_key_weak(set_contextspecific, -1), be_const_closure(Matter_TLV_item_set_contextspecific_closure) },
-        { be_const_key_weak(parse, 7), be_const_closure(Matter_TLV_item_parse_closure) },
-        { be_const_key_weak(set_anonymoustag, -1), be_const_closure(Matter_TLV_item_set_anonymoustag_closure) },
-        { be_const_key_weak(tlv2raw, -1), be_const_closure(Matter_TLV_item_tlv2raw_closure) },
-        { be_const_key_weak(set_fulltag, 10), be_const_closure(Matter_TLV_item_set_fulltag_closure) },
+        { be_const_key_weak(is_array, 17), be_const_bool(0) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_TLV_item_init_closure) },
         { be_const_key_weak(set_parent, -1), be_const_closure(Matter_TLV_item_set_parent_closure) },
-        { be_const_key_weak(tag_profile, 23), be_const_var(3) },
+        { be_const_key_weak(set_fulltag, -1), be_const_closure(Matter_TLV_item_set_fulltag_closure) },
         { be_const_key_weak(typ, -1), be_const_var(6) },
-        { be_const_key_weak(_encode_tag, 20), be_const_closure(Matter_TLV_item__encode_tag_closure) },
-        { be_const_key_weak(init, 13), be_const_closure(Matter_TLV_item_init_closure) },
-        { be_const_key_weak(sort, 14), be_const_static_closure(Matter_TLV_item_sort_closure) },
+        { be_const_key_weak(parse, 30), be_const_closure(Matter_TLV_item_parse_closure) },
+        { be_const_key_weak(parent, 22), be_const_var(0) },
+        { be_const_key_weak(to_str_val, -1), be_const_closure(Matter_TLV_item_to_str_val_closure) },
+        { be_const_key_weak(encode_len, 4), be_const_closure(Matter_TLV_item_encode_len_closure) },
+        { be_const_key_weak(TLV, 20), be_const_class(be_class_Matter_TLV) },
+        { be_const_key_weak(reset, 0), be_const_closure(Matter_TLV_item_reset_closure) },
+        { be_const_key_weak(tag_profile, -1), be_const_var(3) },
+        { be_const_key_weak(create_TLV, -1), be_const_static_closure(Matter_TLV_item_create_TLV_closure) },
+        { be_const_key_weak(tag_sub, -1), be_const_var(5) },
         { be_const_key_weak(tag_vendor, -1), be_const_var(2) },
         { be_const_key_weak(tostring, -1), be_const_closure(Matter_TLV_item_tostring_closure) },
-        { be_const_key_weak(next_idx, -1), be_const_var(1) },
-        { be_const_key_weak(tag_number, -1), be_const_var(4) },
-        { be_const_key_weak(set_commonprofile, -1), be_const_closure(Matter_TLV_item_set_commonprofile_closure) },
+        { be_const_key_weak(val, 5), be_const_var(7) },
+        { be_const_key_weak(_encode_tag, -1), be_const_closure(Matter_TLV_item__encode_tag_closure) },
+        { be_const_key_weak(_cmp_gt, -1), be_const_closure(Matter_TLV_item__cmp_gt_closure) },
+        { be_const_key_weak(_encode_tag_len, 25), be_const_closure(Matter_TLV_item__encode_tag_len_closure) },
+        { be_const_key_weak(is_struct, -1), be_const_bool(0) },
+        { be_const_key_weak(tlv2raw, -1), be_const_closure(Matter_TLV_item_tlv2raw_closure) },
+        { be_const_key_weak(sort, -1), be_const_static_closure(Matter_TLV_item_sort_closure) },
+        { be_const_key_weak(is_list, -1), be_const_bool(0) },
+        { be_const_key_weak(to_TLV, 18), be_const_closure(Matter_TLV_item_to_TLV_closure) },
         { be_const_key_weak(set, -1), be_const_closure(Matter_TLV_item_set_closure) },
+        { be_const_key_weak(set_anonymoustag, 15), be_const_closure(Matter_TLV_item_set_anonymoustag_closure) },
+        { be_const_key_weak(set_commonprofile, -1), be_const_closure(Matter_TLV_item_set_commonprofile_closure) },
+        { be_const_key_weak(tag_number, -1), be_const_var(4) },
+        { be_const_key_weak(next_idx, 1), be_const_var(1) },
+        { be_const_key_weak(set_contextspecific, -1), be_const_closure(Matter_TLV_item_set_contextspecific_closure) },
     })),
     be_str_weak(Matter_TLV_item)
 );
@@ -2504,55 +2507,6 @@ be_local_closure(Matter_TLV_list_item,   /* name */
 
 
 /********************************************************************
-** Solidified function: add_obj
-********************************************************************/
-be_local_closure(Matter_TLV_list_add_obj,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(val),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(to_TLV),
-    /* K3   */  be_nested_str_weak(tag_sub),
-    }),
-    be_str_weak(add_obj),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x200C0403,  //  0001  NE	R3	R2	R3
-      0x780E0010,  //  0002  JMPF	R3	#0014
-      0x600C000F,  //  0003  GETGBL	R3	G15
-      0x5C100400,  //  0004  MOVE	R4	R2
-      0x60140015,  //  0005  GETGBL	R5	G21
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x780E0004,  //  0007  JMPF	R3	#000D
-      0x880C0100,  //  0008  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0009  GETMET	R3	R3	K1
-      0x5C140400,  //  000A  MOVE	R5	R2
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x70020006,  //  000C  JMP		#0014
-      0x8C0C0502,  //  000D  GETMET	R3	R2	K2
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0x900E0601,  //  000F  SETMBR	R3	K3	R1
-      0x88100100,  //  0010  GETMBR	R4	R0	K0
-      0x8C100901,  //  0011  GETMET	R4	R4	K1
-      0x5C180600,  //  0012  MOVE	R6	R3
-      0x7C100400,  //  0013  CALL	R4	2
-      0x80040000,  //  0014  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: getsubval
 ********************************************************************/
 be_local_closure(Matter_TLV_list_getsubval,   /* name */
@@ -2619,11 +2573,11 @@ be_local_closure(Matter_TLV_list_getsub,   /* name */
 
 
 /********************************************************************
-** Solidified function: findsub
+** Solidified function: add_obj
 ********************************************************************/
-be_local_closure(Matter_TLV_list_findsub,   /* name */
+be_local_closure(Matter_TLV_list_add_obj,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    7,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2631,30 +2585,36 @@ be_local_closure(Matter_TLV_list_findsub,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(val),
-    /* K1   */  be_nested_str_weak(tag_sub),
-    /* K2   */  be_nested_str_weak(stop_iteration),
+    /* K1   */  be_nested_str_weak(push),
+    /* K2   */  be_nested_str_weak(to_TLV),
+    /* K3   */  be_nested_str_weak(tag_sub),
     }),
-    be_str_weak(findsub),
+    be_str_weak(add_obj),
     &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x600C0010,  //  0000  GETGBL	R3	G16
-      0x88100100,  //  0001  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0xA8020007,  //  0003  EXBLK	0	#000C
-      0x5C100600,  //  0004  MOVE	R4	R3
-      0x7C100000,  //  0005  CALL	R4	0
-      0x88140901,  //  0006  GETMBR	R5	R4	K1
-      0x1C140A01,  //  0007  EQ	R5	R5	R1
-      0x78160001,  //  0008  JMPF	R5	#000B
-      0xA8040001,  //  0009  EXBLK	1	1
-      0x80040800,  //  000A  RET	1	R4
-      0x7001FFF7,  //  000B  JMP		#0004
-      0x580C0002,  //  000C  LDCONST	R3	K2
-      0xAC0C0200,  //  000D  CATCH	R3	1	0
-      0xB0080000,  //  000E  RAISE	2	R0	R0
-      0x80040400,  //  000F  RET	1	R2
+    ( &(const binstruction[21]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x200C0403,  //  0001  NE	R3	R2	R3
+      0x780E0010,  //  0002  JMPF	R3	#0014
+      0x600C000F,  //  0003  GETGBL	R3	G15
+      0x5C100400,  //  0004  MOVE	R4	R2
+      0x60140015,  //  0005  GETGBL	R5	G21
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x780E0004,  //  0007  JMPF	R3	#000D
+      0x880C0100,  //  0008  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0009  GETMET	R3	R3	K1
+      0x5C140400,  //  000A  MOVE	R5	R2
+      0x7C0C0400,  //  000B  CALL	R3	2
+      0x70020006,  //  000C  JMP		#0014
+      0x8C0C0502,  //  000D  GETMET	R3	R2	K2
+      0x7C0C0200,  //  000E  CALL	R3	1
+      0x900E0601,  //  000F  SETMBR	R3	K3	R1
+      0x88100100,  //  0010  GETMBR	R4	R0	K0
+      0x8C100901,  //  0011  GETMET	R4	R4	K1
+      0x5C180600,  //  0012  MOVE	R6	R3
+      0x7C100400,  //  0013  CALL	R4	2
+      0x80040000,  //  0014  RET	1	R0
     })
   )
 );
@@ -2753,30 +2713,42 @@ be_local_closure(Matter_TLV_list_add_array,   /* name */
 
 
 /********************************************************************
-** Solidified function: push
+** Solidified function: findsub
 ********************************************************************/
-be_local_closure(Matter_TLV_list_push,   /* name */
+be_local_closure(Matter_TLV_list_findsub,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
+    6,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
+    ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(val),
-    /* K1   */  be_nested_str_weak(push),
+    /* K1   */  be_nested_str_weak(tag_sub),
+    /* K2   */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(push),
+    be_str_weak(findsub),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80000000,  //  0004  RET	0
+    ( &(const binstruction[16]) {  /* code */
+      0x600C0010,  //  0000  GETGBL	R3	G16
+      0x88100100,  //  0001  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0xA8020007,  //  0003  EXBLK	0	#000C
+      0x5C100600,  //  0004  MOVE	R4	R3
+      0x7C100000,  //  0005  CALL	R4	0
+      0x88140901,  //  0006  GETMBR	R5	R4	K1
+      0x1C140A01,  //  0007  EQ	R5	R5	R1
+      0x78160001,  //  0008  JMPF	R5	#000B
+      0xA8040001,  //  0009  EXBLK	1	1
+      0x80040800,  //  000A  RET	1	R4
+      0x7001FFF7,  //  000B  JMP		#0004
+      0x580C0002,  //  000C  LDCONST	R3	K2
+      0xAC0C0200,  //  000D  CATCH	R3	1	0
+      0xB0080000,  //  000E  RAISE	2	R0	R0
+      0x80040400,  //  000F  RET	1	R2
     })
   )
 );
@@ -2911,6 +2883,37 @@ be_local_closure(Matter_TLV_list_tostring_inner,   /* name */
 
 
 /********************************************************************
+** Solidified function: push
+********************************************************************/
+be_local_closure(Matter_TLV_list_push,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(val),
+    /* K1   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(push),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: findsubtyp
 ********************************************************************/
 be_local_closure(Matter_TLV_list_findsubtyp,   /* name */
@@ -3001,27 +3004,27 @@ be_local_class(Matter_TLV_list,
     &be_class_Matter_TLV_item,
     be_nested_map(22,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(encode_len, 14), be_const_closure(Matter_TLV_list_encode_len_closure) },
+        { be_const_key_weak(encode_len, 7), be_const_closure(Matter_TLV_list_encode_len_closure) },
         { be_const_key_weak(tlv2raw, -1), be_const_closure(Matter_TLV_list_tlv2raw_closure) },
-        { be_const_key_weak(to_str_val, 19), be_const_closure(Matter_TLV_list_to_str_val_closure) },
-        { be_const_key_weak(findsubval, 7), be_const_closure(Matter_TLV_list_findsubval_closure) },
+        { be_const_key_weak(to_str_val, 14), be_const_closure(Matter_TLV_list_to_str_val_closure) },
+        { be_const_key_weak(findsubval, 5), be_const_closure(Matter_TLV_list_findsubval_closure) },
         { be_const_key_weak(size, -1), be_const_closure(Matter_TLV_list_size_closure) },
-        { be_const_key_weak(is_struct, -1), be_const_bool(0) },
-        { be_const_key_weak(add_struct, 20), be_const_closure(Matter_TLV_list_add_struct_closure) },
         { be_const_key_weak(findsubtyp, 21), be_const_closure(Matter_TLV_list_findsubtyp_closure) },
+        { be_const_key_weak(add_struct, 19), be_const_closure(Matter_TLV_list_add_struct_closure) },
+        { be_const_key_weak(push, -1), be_const_closure(Matter_TLV_list_push_closure) },
         { be_const_key_weak(parse, -1), be_const_closure(Matter_TLV_list_parse_closure) },
         { be_const_key_weak(init, 0), be_const_closure(Matter_TLV_list_init_closure) },
         { be_const_key_weak(item, -1), be_const_closure(Matter_TLV_list_item_closure) },
         { be_const_key_weak(tostring_inner, -1), be_const_closure(Matter_TLV_list_tostring_inner_closure) },
-        { be_const_key_weak(getsubval, -1), be_const_closure(Matter_TLV_list_getsubval_closure) },
-        { be_const_key_weak(getsub, 5), be_const_closure(Matter_TLV_list_getsub_closure) },
-        { be_const_key_weak(push, -1), be_const_closure(Matter_TLV_list_push_closure) },
+        { be_const_key_weak(getsubval, 20), be_const_closure(Matter_TLV_list_getsubval_closure) },
+        { be_const_key_weak(getsub, -1), be_const_closure(Matter_TLV_list_getsub_closure) },
+        { be_const_key_weak(findsub, -1), be_const_closure(Matter_TLV_list_findsub_closure) },
         { be_const_key_weak(add_list, 17), be_const_closure(Matter_TLV_list_add_list_closure) },
         { be_const_key_weak(add_array, -1), be_const_closure(Matter_TLV_list_add_array_closure) },
         { be_const_key_weak(add_TLV, -1), be_const_closure(Matter_TLV_list_add_TLV_closure) },
         { be_const_key_weak(setitem, 11), be_const_closure(Matter_TLV_list_setitem_closure) },
-        { be_const_key_weak(findsub, -1), be_const_closure(Matter_TLV_list_findsub_closure) },
         { be_const_key_weak(add_obj, -1), be_const_closure(Matter_TLV_list_add_obj_closure) },
+        { be_const_key_weak(is_list, -1), be_const_bool(1) },
         { be_const_key_weak(tostring, -1), be_const_closure(Matter_TLV_list_tostring_closure) },
     })),
     be_str_weak(Matter_TLV_list)
@@ -3035,6 +3038,40 @@ void be_load_Matter_TLV_list_class(bvm *vm) {
 }
 
 extern const bclass be_class_Matter_TLV_struct;
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(Matter_TLV_struct_tostring,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tostring_inner),
+    /* K1   */  be_nested_str_weak(_X7B),
+    /* K2   */  be_nested_str_weak(_X7D),
+    }),
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x50100200,  //  0001  LDBOOL	R4	1	0
+      0x58140001,  //  0002  LDCONST	R5	K1
+      0x58180002,  //  0003  LDCONST	R6	K2
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x7C080A00,  //  0005  CALL	R2	5
+      0x80040400,  //  0006  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
 
 /********************************************************************
 ** Solidified function: init
@@ -3079,51 +3116,18 @@ be_local_closure(Matter_TLV_struct_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(Matter_TLV_struct_tostring,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tostring_inner),
-    /* K1   */  be_nested_str_weak(_X7B),
-    /* K2   */  be_nested_str_weak(_X7D),
-    }),
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x50100200,  //  0001  LDBOOL	R4	1	0
-      0x58140001,  //  0002  LDCONST	R5	K1
-      0x58180002,  //  0003  LDCONST	R6	K2
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x7C080A00,  //  0005  CALL	R2	5
-      0x80040400,  //  0006  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_TLV_struct
 ********************************************************************/
 extern const bclass be_class_Matter_TLV_list;
 be_local_class(Matter_TLV_struct,
     0,
     &be_class_Matter_TLV_list,
-    be_nested_map(3,
+    be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_weak(init, -1), be_const_closure(Matter_TLV_struct_init_closure) },
         { be_const_key_weak(tostring, -1), be_const_closure(Matter_TLV_struct_tostring_closure) },
-        { be_const_key_weak(is_struct, -1), be_const_bool(1) },
+        { be_const_key_weak(is_list, -1), be_const_bool(0) },
+        { be_const_key_weak(is_struct, 0), be_const_bool(1) },
     })),
     be_str_weak(Matter_TLV_struct)
 );
@@ -3136,6 +3140,40 @@ void be_load_Matter_TLV_struct_class(bvm *vm) {
 }
 
 extern const bclass be_class_Matter_TLV_array;
+
+/********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(Matter_TLV_array_tostring,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tostring_inner),
+    /* K1   */  be_nested_str_weak(_X5B),
+    /* K2   */  be_nested_str_weak(_X5D),
+    }),
+    be_str_weak(tostring),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x50100000,  //  0001  LDBOOL	R4	0	0
+      0x58140001,  //  0002  LDCONST	R5	K1
+      0x58180002,  //  0003  LDCONST	R6	K2
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x7C080A00,  //  0005  CALL	R2	5
+      0x80040400,  //  0006  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
 
 /********************************************************************
 ** Solidified function: init
@@ -3243,51 +3281,19 @@ be_local_closure(Matter_TLV_array_parse,   /* name */
 
 
 /********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(Matter_TLV_array_tostring,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tostring_inner),
-    /* K1   */  be_nested_str_weak(_X5B),
-    /* K2   */  be_nested_str_weak(_X5D),
-    }),
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x50100000,  //  0001  LDBOOL	R4	0	0
-      0x58140001,  //  0002  LDCONST	R5	K1
-      0x58180002,  //  0003  LDCONST	R6	K2
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x7C080A00,  //  0005  CALL	R2	5
-      0x80040400,  //  0006  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_TLV_array
 ********************************************************************/
 extern const bclass be_class_Matter_TLV_list;
 be_local_class(Matter_TLV_array,
     0,
     &be_class_Matter_TLV_list,
-    be_nested_map(3,
+    be_nested_map(5,
     ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(tostring, 1), be_const_closure(Matter_TLV_array_tostring_closure) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_TLV_array_init_closure) },
-        { be_const_key_weak(parse, 2), be_const_closure(Matter_TLV_array_parse_closure) },
-        { be_const_key_weak(tostring, -1), be_const_closure(Matter_TLV_array_tostring_closure) },
+        { be_const_key_weak(parse, 3), be_const_closure(Matter_TLV_array_parse_closure) },
+        { be_const_key_weak(is_list, -1), be_const_bool(0) },
+        { be_const_key_weak(is_array, -1), be_const_bool(1) },
     })),
     be_str_weak(Matter_TLV_array)
 );


### PR DESCRIPTION
## Description:

Support for responses (arrays) that do not fit in a single UDP packet. This happens when there are 4 or more fabrics.
Do not remove children fabrics

I have tested with a Tasmota light controlled by 5 parallel controllers **at the same time**:
- Alexa + Echo
- Apple Home + AppleTV
- Google Home + Nest mini
- esp-matter on iPhone
- chip-tool on RPi
This makes a total of 7 fabrics associated. And it works well!

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
