### PR TITLE
Fix compilation when IPv6 is not supported

### DIFF
--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/ESP8266WiFi.h
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/ESP8266WiFi.h
@@ -76,8 +76,8 @@ public:
 
     void scrubDNS(void);
 protected:
-    ip_addr_t dns_save4[DNS_MAX_SERVERS] = {};      // IPv4 DNS servers
 #ifdef USE_IPV6
+    ip_addr_t dns_save4[DNS_MAX_SERVERS] = {};      // IPv4 DNS servers
     ip_addr_t dns_save6[DNS_MAX_SERVERS] = {};      // IPv6 DNS servers
 #endif // USE_IPV6
 };


### PR DESCRIPTION
## Description:

Fixes compilation when there is no IPv6 support (prepare for Arduino future versions)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
