### PR TITLE
Change shutterbutton hold behavior with grouptopic

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
@@ -1265,7 +1265,8 @@ bool ShutterButtonHandler(void)
   // handle on button release: start shutter on shortpress and stop running shutter after longpress.
   if (NOT_PRESSED == button
       && Shutter[shutter_index].direction != 0  // only act on shutters activly moving
-      && Button.hold_timer[button_index] > 0)   // kick in on first release of botton. do not check for multipress
+      && Button.hold_timer[button_index] > 0   // kick in on first release of botton. do not check for multipress
+      && !ShutterSettings.shutter_button[button_index].position[3].mqtt_broadcast ) // do not stop on hold release if broadcast
   {
     XdrvMailbox.index = shutter_index +1;
     XdrvMailbox.payload = -99;  // reset any payload to invalid

--- a/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
@@ -947,7 +947,11 @@ bool ShutterButtonHandler(void)
 
   if (NOT_PRESSED == button) {
     //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Shtr%d, Button %d, hold %d, dir %d, index %d, payload %d"), shutter_index+1, button_index+1, Button.hold_timer[button_index],Shutter[shutter_index].direction,XdrvMailbox.index,XdrvMailbox.payload);
-    if (Shutter[shutter_index].direction && (Button.hold_timer[button_index] > 0 && (!Settings->flag.button_single || Button.hold_timer[button_index] > 20))) {
+    if (Shutter[shutter_index].direction 
+        && (Button.hold_timer[button_index] > 0 
+            && (!Settings->flag.button_single 
+                || Button.hold_timer[button_index] > 20))
+        && !(Settings->shutter_button[button_index] & (0x01<<29))) {
       XdrvMailbox.index = shutter_index +1;
       XdrvMailbox.payload = XdrvMailbox.index;
       //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Shtr%d, Button %d, hold %d, dir %d, index %d, payload %d"), shutter_index+1, button_index+1, Button.hold_timer[button_index],Shutter[shutter_index].direction,XdrvMailbox.index,XdrvMailbox.payload);


### PR DESCRIPTION
## Description:
If mqtt grouptopic is defined on the hold event the local shutter will not stop after releasing the button. All shutters will move to the defined position.
If there if no group topic then still releasing the hold button on the local shutter will stop the shutter.


**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
fixes: #19234
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
