### PR TITLE
Prepare for Arduino v3 / esp-idf v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Zigbee decode Aqara 0000/FF01 attribute 03 as Temperature (#19210)
 - Berry bytes `get` and `set` work for 3 bytes values (#19225)
 - Matter support for fabric_filtered request (for Google compatibility) (#19249)
+- Prepare for Arduino v3 / esp-idf v5
 
 ### Breaking Changed
 

--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/ESP32Wifi.cpp
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/ESP32Wifi.cpp
@@ -111,18 +111,6 @@ void WiFiClass32::scrubDNS(void) {
     } else {
       dns_setserver(i, IP4_ADDR_ANY);
     }
-#else // USE_IPV6
-    uint32_t ip_dns = ip_addr_get_ip4_u32(dns_getserver(i));
-    // Step 1. save valid values from DNS
-    if (has_v4 && (uint32_t)ip_dns != 0) {
-      ip_addr_set_ip4_u32_val(dns_save4[i], ip_dns);
-    }
-    // Step 2. scrub addresses not supported
-    if (!has_v4) {
-      ip_addr_set_ip4_u32_val(dns_save4[i], 0L);
-    }
-    // Step 3. restore saved value
-    dns_setserver(i, &dns_save4[i]);
 #endif // USE_IPV6
   }
   // AddLog(LOG_LEVEL_DEBUG, "IP>: DNS: from(%s %s) to (%s %s) has4/6:%i-%i", dns_entry0.c_str(), dns_entry1.c_str(), IPAddress(dns_getserver(0)).toString().c_str(),  IPAddress(dns_getserver(1)).toString().c_str(), has_v4, has_v6);

--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.cpp
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.cpp
@@ -16,6 +16,7 @@
 #ifdef ESP32
 
 #include "Arduino.h"
+#include "esp_idf_version.h"
 #include "esp8266toEsp32.h"
 #include "driver/ledc.h"
 
@@ -33,7 +34,11 @@ enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_D
 #else
 #define LEDC_DEFAULT_CLK        LEDC_AUTO_CLK
 #endif
-#define LEDC_MAX_BIT_WIDTH      SOC_LEDC_TIMER_BIT_WIDE_NUM
+#if (ESP_IDF_VERSION_MAJOR >= 5)
+  #define LEDC_MAX_BIT_WIDTH      SOC_LEDC_TIMER_BIT_WIDTH
+#else
+  #define LEDC_MAX_BIT_WIDTH      SOC_LEDC_TIMER_BIT_WIDE_NUM
+#endif
 
 // define our limits to ease any change from esp-idf
 #define MAX_TIMERS              LEDC_TIMER_MAX            // 4 timers for all ESP32 variants

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -189,6 +189,9 @@ bool RtcRebootValid(void) {
 
 extern "C" {
 #include "spi_flash.h"
+#if ESP_IDF_VERSION_MAJOR >= 5
+  #include "spi_flash_mmap.h"
+#endif
 }
 
 #ifdef ESP8266

--- a/tasmota/tasmota_support/support_crash_recorder.ino
+++ b/tasmota/tasmota_support/support_crash_recorder.ino
@@ -160,7 +160,10 @@ void CrashDumpClear(void)
 // esp_err_t IRAM_ATTR esp_backtrace_print(int depth)
 
 #include "freertos/xtensa_api.h"
-#if ESP_IDF_VERSION_MAJOR >= 4
+#if   ESP_IDF_VERSION_MAJOR >= 5
+  #include "esp_debug_helpers.h"
+  #include "esp_cpu_utils.h"
+#elif ESP_IDF_VERSION_MAJOR >= 4
   #include "esp_debug_helpers.h"
 #else  // IDF 3.x
   #include "esp_panic.h"

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -1921,6 +1921,8 @@ void TasConsoleInput(void) {
 //
 // This patched version of pinMode forces a full GPIO reset before setting new mode
 //
+#include "driver/gpio.h"
+
 extern "C" void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode);
 
 extern "C" void ARDUINO_ISR_ATTR pinMode(uint8_t pin, uint8_t mode) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tcpclientasync.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tcpclientasync.ino
@@ -68,6 +68,7 @@ public:
       state = AsyncTCPState::INPROGRESS;    // reset state
     }
 
+#ifdef USE_IPV6
     if (ip.type() == IPv6) {
         struct sockaddr_in6 *tmpaddr = (struct sockaddr_in6 *)&serveraddr;
         sockfd = socket(AF_INET6, SOCK_STREAM, 0);
@@ -75,12 +76,15 @@ public:
         memcpy(tmpaddr->sin6_addr.un.u8_addr, &ip[0], 16);
         tmpaddr->sin6_port = htons(port);
     } else {
+#endif
         struct sockaddr_in *tmpaddr = (struct sockaddr_in *)&serveraddr;
         sockfd = socket(AF_INET, SOCK_STREAM, 0);
         tmpaddr->sin_family = AF_INET;
         tmpaddr->sin_addr.s_addr = ip;
         tmpaddr->sin_port = htons(port);
+#ifdef USE_IPV6
     }
+#endif
     if (sockfd < 0) {
         AddLog(LOG_LEVEL_DEBUG, "BRY: Error: socket: %d", errno);
         return 0;
@@ -312,7 +316,7 @@ public:
           local_addr = IPAddress((uint32_t)(s->sin_addr.s_addr));
           // return IPAddress((uint32_t)(s->sin_addr.s_addr));
       }
-
+#ifdef USE_IPV6
       // IPv6, but it might be IPv4 mapped address
       if (((struct sockaddr*)&local_address)->sa_family == AF_INET6) {
           struct sockaddr_in6 *saddr6 = (struct sockaddr_in6 *)&local_address;
@@ -325,6 +329,7 @@ public:
               // return IPAddress(IPv6, (uint8_t*)(saddr6->sin6_addr.s6_addr));
           }
       }
+#endif // USE_IPV6
     }
   }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -64,10 +64,10 @@ void checkBeTop(void) {
  * Use PSRAM if available
 \*********************************************************************************************/
 extern "C" {
-  void *berry_malloc(uint32_t size);
+  void *berry_malloc(size_t size);
   void *berry_realloc(void *ptr, size_t size);
 #ifdef USE_BERRY_PSRAM
-  void *berry_malloc(uint32_t size) {
+  void *berry_malloc(size_t size) {
     return special_malloc(size);
   }
   void *berry_realloc(void *ptr, size_t size) {
@@ -77,7 +77,7 @@ extern "C" {
     return special_calloc(num, size);
   }
 #else
-  void *berry_malloc(uint32_t size) {
+  void *berry_malloc(size_t size) {
     return malloc(size);
   }
   void *berry_realloc(void *ptr, size_t size) {
@@ -89,7 +89,7 @@ extern "C" {
 #endif // USE_BERRY_PSRAM
 
 
-  void *berry_malloc32(uint32_t size) {
+  void *berry_malloc32(size_t size) {
   #ifdef USE_BERRY_IRAM
     return special_malloc32(size);
   #else

--- a/tasmota/tasmota_xsns_sensor/xsns_02_analog.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_02_analog.ino
@@ -297,7 +297,9 @@ void AdcInit(void) {
 
   if (Adcs.present) {
 #ifdef ESP32
+#if ESP_IDF_VERSION_MAJOR < 5
     analogSetClockDiv(1);               // Default 1
+#endif
 #if CONFIG_IDF_TARGET_ESP32
     analogSetWidth(ANALOG_RESOLUTION);  // Default 12 bits (0 - 4095)
 #endif  // CONFIG_IDF_TARGET_ESP32

--- a/tasmota/tasmota_xsns_sensor/xsns_127_esp32_sensors.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_127_esp32_sensors.ino
@@ -33,7 +33,7 @@
 
 #define XSNS_127                 127
 
-#if CONFIG_IDF_TARGET_ESP32
+#if CONFIG_IDF_TARGET_ESP32 && (ESP_IDF_VERSION_MAJOR < 5)         // Hall sensor is no more supported in esp-idf 5
 
 #define HALLEFFECT_SAMPLE_COUNT  32   // 32 takes about 12 mS at 80MHz CPU frequency
 
@@ -51,7 +51,7 @@ void Esp32SensorInit(void) {
   }
 }
 
-#endif  // CONFIG_IDF_TARGET_ESP32
+#endif  // CONFIG_IDF_TARGET_ESP32 && (ESP_IDF_VERSION_MAJOR < 5)
 
 void Esp32SensorShow(bool json) {
   bool json_end = false;
@@ -84,7 +84,7 @@ void Esp32SensorShow(bool json) {
     }
   }
 
-#if CONFIG_IDF_TARGET_ESP32
+#if CONFIG_IDF_TARGET_ESP32 && (ESP_IDF_VERSION_MAJOR < 5)         // Hall sensor is no more supported in esp-idf 5
   if (HEData.present) {
     int value = 0;
     for (uint32_t i = 0; i < HALLEFFECT_SAMPLE_COUNT; i++) {
@@ -115,7 +115,7 @@ void Esp32SensorShow(bool json) {
 #endif  // USE_WEBSERVER
     }
   }
-#endif  // CONFIG_IDF_TARGET_ESP32
+#endif  // CONFIG_IDF_TARGET_ESP32 && (ESP_IDF_VERSION_MAJOR < 5)
 
   if (json_end) {
     ResponseJsonEnd();
@@ -138,11 +138,11 @@ bool Xsns127(uint32_t function) {
       Esp32SensorShow(0);
       break;
 #endif  // USE_WEBSERVER
-#if CONFIG_IDF_TARGET_ESP32
+#if CONFIG_IDF_TARGET_ESP32 && (ESP_IDF_VERSION_MAJOR < 5)         // Hall sensor is no more supported in esp-idf 5
     case FUNC_INIT:
       Esp32SensorInit();
       break;
-#endif  // CONFIG_IDF_TARGET_ESP32
+#endif  // CONFIG_IDF_TARGET_ESP32 && (ESP_IDF_VERSION_MAJOR < 5)
   }
   return result;
 }


### PR DESCRIPTION
## Description:

Non-breaking changes to prepare for Arduino v3 / esp-idf v5:
- fix compilation if no support for IPv6
- fix a few includes
- fix `berry_malloc()` type inconsistency (previous compilers didn't complain) between `size_t` and `uint32_t` although they are supposed to be identical
- disable Hall sensor on ESP32 when using Arduino v3 (which was dropped by esp-idf v5)
- fix hardware version detection (needs to be checked)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
