### PR TITLE
Prepare for Arduino v3 / esp-idf v5 2nd batch

### DIFF
--- a/lib/default/TasmotaSerial-3.6.0/src/TasmotaSerial.cpp
+++ b/lib/default/TasmotaSerial-3.6.0/src/TasmotaSerial.cpp
@@ -39,6 +39,8 @@ TasmotaSerial *tms_obj_list[16];
 #ifdef ESP32
 
 #include "driver/uart.h"
+#include "driver/gpio.h"
+#include "esp_rom_gpio.h"
 
 static uint32_t tasmota_serial_uart_bitmap = 0;      // Assigned UARTs
 
@@ -466,6 +468,7 @@ size_t TasmotaSerial::write(uint8_t b) {
   return size;
 }
 
+#ifdef ESP8266
 void IRAM_ATTR TasmotaSerial::rxRead(void) {
   if (!m_nwmode) {
     uint32_t start = ESP.getCycleCount();
@@ -586,3 +589,4 @@ void IRAM_ATTR TasmotaSerial::rxRead(void) {
     }
   }
 }
+#endif // ESP8266

--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
@@ -53,7 +53,7 @@ uint8_t ledcReadResolution(uint8_t chan);
 // was not yet attached.
 //
 // Returns: hardware channel number, or -1 if it failed
-int analogAttach(uint32_t pin, bool output_invert = false);   // returns the ledc channel, or -1 if failed. This is implicitly called by analogWrite if the channel was not already allocated
+int32_t analogAttach(uint32_t pin, bool output_invert = false);   // returns the ledc channel, or -1 if failed. This is implicitly called by analogWrite if the channel was not already allocated
 
 // change both freq and range
 // `0`: set to global value

--- a/lib/libesp32/berry_mapping/src/be_cb_module.c
+++ b/lib/libesp32/berry_mapping/src/be_cb_module.c
@@ -22,10 +22,10 @@ enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_D
  * We allow 4 parameters, or 3 if method (first arg is `self`)
  * This could be extended if needed
 \*********************************************************************************************/
-typedef int32_t (*berry_callback_t)(int32_t v0, int32_t v1, int32_t v2, int32_t v3);
-static int32_t call_berry_cb(int32_t num, int32_t v0, int32_t v1, int32_t v2, int32_t v3);
+typedef int (*berry_callback_t)(int v0, int v1, int v2, int v3);
+static int call_berry_cb(int num, int v0, int v1, int v2, int v3);
 
-#define BERRY_CB(n) int32_t berry_cb_##n(int32_t v0, int32_t v1, int32_t v2, int32_t v3) { return call_berry_cb(n, v0, v1, v2, v3); }
+#define BERRY_CB(n) int berry_cb_##n(int v0, int v1, int v2, int v3) { return call_berry_cb(n, v0, v1, v2, v3); }
 // list the callbacks
 BERRY_CB(0);
 BERRY_CB(1);
@@ -85,7 +85,7 @@ typedef struct be_callback_handler_list_t {
 
 static be_callback_hook be_cb_hooks[BE_MAX_CB] = {0};
 
-static int32_t be_cb_gen_cb(bvm *vm);
+static int be_cb_gen_cb(bvm *vm);
 static be_callback_handler_list_t be_callback_default_gen_cb = {
   NULL,
   be_const_func(&be_cb_gen_cb),
@@ -102,7 +102,7 @@ static be_callback_handler_list_t *be_callback_handler_list_head = &be_callback_
  * 
  * arg1: function (or closure)
 \*********************************************************************************************/
-static int32_t be_cb_add_handler(bvm *vm) {
+static int be_cb_add_handler(bvm *vm) {
   int32_t top = be_top(vm);
   if (top >= 1 && be_isfunction(vm, 1)) {
     bvalue *v = be_indexof(vm, 1);
@@ -129,7 +129,7 @@ static int32_t be_cb_add_handler(bvm *vm) {
  * 
  * No args
 \*********************************************************************************************/
-static int32_t be_cb_list_handlers(bvm *vm) {
+static int be_cb_list_handlers(bvm *vm) {
   be_newobject(vm, "list");
   for (be_callback_handler_list_t *elt = be_callback_handler_list_head; elt != NULL; elt = elt->next) {
     if (elt->vm == vm) { /* on purpose don't show the default handler, just pretend it's not there since it's default */
@@ -153,7 +153,7 @@ static int32_t be_cb_list_handlers(bvm *vm) {
  * arg2: type name for callback (optional)
  * argN: any other callback specific arguments (unlimited number, passed as-is)
 \*********************************************************************************************/
-static int32_t be_cb_make_cb(bvm *vm) {
+static int be_cb_make_cb(bvm *vm) {
   int32_t argc = be_top(vm);
   if (argc >= 1 && be_isfunction(vm, 1)) {
 
@@ -187,7 +187,7 @@ static int32_t be_cb_make_cb(bvm *vm) {
  * 
  * arg1: function (or closure)
 \*********************************************************************************************/
-static int32_t be_cb_gen_cb(bvm *vm) {
+static int be_cb_gen_cb(bvm *vm) {
   int32_t top = be_top(vm);
   // tasmota_log_C(LOG_LEVEL_DEBUG, "BRY: gen_cb() called");
   if (top >= 1 && be_isfunction(vm, 1)) {
@@ -217,7 +217,7 @@ static int32_t be_cb_gen_cb(bvm *vm) {
  * `get_cb_list`: Return the list of callbacks for this vm
  * 
 \*********************************************************************************************/
-static int32_t be_cb_get_cb_list(bvm *vm) {
+static int be_cb_get_cb_list(bvm *vm) {
   be_newobject(vm, "list");
   for (uint32_t i=0; i < BE_MAX_CB; i++) {
     if (be_cb_hooks[i].vm) {
@@ -242,7 +242,7 @@ static int32_t be_cb_get_cb_list(bvm *vm) {
  * We allow 4 parameters, or 3 if method (first arg is `self`)
  * This could be extended if needed
 \*********************************************************************************************/
-static int32_t call_berry_cb(int32_t num, int32_t v0, int32_t v1, int32_t v2, int32_t v3) {
+static int call_berry_cb(int num, int v0, int v1, int v2, int v3) {
   // call berry cb dispatcher
   int32_t ret = 0;
   // retrieve vm and function

--- a/lib/libesp32/berry_matter/src/be_matter_misc.cpp
+++ b/lib/libesp32/berry_matter/src/be_matter_misc.cpp
@@ -31,6 +31,7 @@ static uint8_t ip_bytes[16] = {};
 extern "C" const void* matter_get_ip_bytes(const char* ip_str, size_t* ret_len) {
   IPAddress ip;
   if (ip.fromString(ip_str)) {
+#ifdef USE_IPV6
     if (ip.isV4()) {
       uint32_t ip_32 = ip;
       memcpy(ip_bytes, &ip_32, 4);
@@ -39,6 +40,11 @@ extern "C" const void* matter_get_ip_bytes(const char* ip_str, size_t* ret_len) 
       memcpy(ip_bytes, ip.raw6(), 16);
       *ret_len = 16;
     }
+#else
+    uint32_t ip_32 = ip;
+    memcpy(ip_bytes, &ip_32, 4);
+    *ret_len = 4;
+#endif
     return ip_bytes;
   } else {
     *ret_len = 0;

--- a/lib/libesp32/berry_matter/src/be_matter_qrcode.c
+++ b/lib/libesp32/berry_matter/src/be_matter_qrcode.c
@@ -32,7 +32,7 @@
 
 // `matter.QRCode.encode_str(content:string) -> map`
 //
-int32_t qr_encode_str(bvm *vm) {
+int qr_encode_str(bvm *vm) {
   int32_t argc = be_top(vm);
   if (argc >= 1 && be_isstring(vm, 1)) {
     const char * data_str = be_tostring(vm, 1);

--- a/lib/libesp32/berry_tasmota/include/be_ctypes.h
+++ b/lib/libesp32/berry_tasmota/include/be_ctypes.h
@@ -60,7 +60,13 @@ typedef struct be_ctypes_classes_t {
     const be_ctypes_class_t * classes;
 } be_ctypes_classes_t;
 
-BE_EXPORT_VARIABLE const bclass be_class_ctypes_bytes;
+#ifdef __cplusplus
+extern "C" {
+#endif
+    extern const bclass be_class_ctypes_bytes;
+#ifdef __cplusplus
+}
+#endif
 
 static void ctypes_register_class(bvm *vm, const bclass * ctypes_class) {
     be_pushntvclass(vm, ctypes_class);

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -406,6 +406,7 @@ void setup(void) {
 
 #ifdef CONFIG_IDF_TARGET_ESP32
   // restore GPIO16/17 if no PSRAM is found
+  #if ESP_IDF_VERSION_MAJOR < 5       // TODO for esp-idf 5
   if (!FoundPSRAM()) {
     // test if the CPU is not pico
     uint32_t chip_ver = REG_GET_FIELD(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_VER_PKG);
@@ -415,6 +416,7 @@ void setup(void) {
       gpio_reset_pin(GPIO_NUM_17);
     }
   }
+  #endif
 #endif  // CONFIG_IDF_TARGET_ESP32
 #endif  // ESP32
 

--- a/tasmota/tasmota_support/support_crash_recorder.ino
+++ b/tasmota/tasmota_support/support_crash_recorder.ino
@@ -30,7 +30,7 @@ void CmndWDT(void)
 {
   volatile uint32_t dummy = 0;
   while (1) {
-    dummy++;
+    dummy = dummy + 1;
   }
 }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webclient.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webclient.ino
@@ -582,6 +582,7 @@ public:
   size_t write(const uint8_t *buffer, size_t size) override {
     // AddLog(LOG_LEVEL_INFO, "FLASH: addr=%p  hex=%*_H  size=%i", addr_start + offset, 32, buffer, size);
     if (size > 0) {
+#if ESP_IDF_VERSION_MAJOR < 5     // TODO later
       esp_err_t ret = spi_flash_write(addr_start + offset, buffer, size);
       if (ret != ESP_OK)  { return 0; }  // error
       offset += size;
@@ -590,6 +591,7 @@ public:
       if (((offset - size) / STREAM_FLASH_PROGRESS_THRESHOLD) != (offset / STREAM_FLASH_PROGRESS_THRESHOLD)) {
         AddLog(LOG_LEVEL_DEBUG, D_LOG_UPLOAD "Progress %d kB", offset / 1024);
       }
+#endif
     }
     return size;
   }
@@ -611,6 +613,7 @@ protected:
 extern "C" {
   int32_t wc_writeflash(struct bvm *vm);
   int32_t wc_writeflash(struct bvm *vm) {
+#if ESP_IDF_VERSION_MAJOR < 5
     int32_t argc = be_top(vm);
     if (argc >= 2 && be_isint(vm, 2)) {
       HTTPClientLight * cl = wc_getclient(vm);
@@ -650,6 +653,7 @@ extern "C" {
       be_pushint(vm, written);
       be_return(vm);  /* return code */
     }
+#endif
     be_raise(vm, kTypeError, nullptr);
   }
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_68_zerocrossDimmer.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_68_zerocrossDimmer.ino
@@ -24,6 +24,9 @@
 
 #define XDRV_68             68
 
+
+#if !defined(ESP32) || (ESP_IDF_VERSION_MAJOR < 5)      // temporarily disable for IDF 5.0
+
 static const uint8_t TRIGGER_PERIOD = 75;
 
 #define ZCDIMMERSET_SHOW 1
@@ -298,4 +301,7 @@ bool Xdrv68(uint32_t function)
   }
   return result;
 }
+
+#endif // !enabled(ESP32) || (ESP_IDF_VERSION_MAJOR < 5)
+
 #endif  // USE_AC_ZERO_CROSS_DIMMER

--- a/tasmota/tasmota_xsns_sensor/xsns_02_analog.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_02_analog.ino
@@ -24,6 +24,12 @@
 
 #define XSNS_02                       2
 
+#ifdef ESP32
+  #if ESP_IDF_VERSION_MAJOR >= 5
+    #include "esp32-hal-adc.h"
+  #endif
+#endif
+
 #ifdef ESP8266
 #define ANALOG_RESOLUTION             10               // 12 = 4095, 11 = 2047, 10 = 1023
 #define ANALOG_RANGE                  1023             // 4095 = 12, 2047 = 11, 1023 = 10
@@ -175,6 +181,11 @@ struct {
 bool adcAttachPin(uint8_t pin) {
   return (ADC0_PIN == pin);
 }
+#endif
+#if defined(ESP32) && (ESP_IDF_VERSION_MAJOR >= 5)
+  bool adcAttachPin(uint8_t pin) {
+    return true;                        // TODO - no more needed?
+  }
 #endif
 
 void AdcSaveSettings(uint32_t idx) {


### PR DESCRIPTION
## Description:

Prepare for Arduino v3 / esp-idf v5:
- fix strict typing in Berry (int32_t vs int)
- add includes in TasmotaSerial and guard ESP8266 only code

On Arduino v3 (and only with this version) temporarily disable the following:
- disable support of flash in Berry (which means that Partition Wizard won't work)
- disable ZeroCross dimmer
- change support for ADC (which needs more testing)

Currently the following libs are not yet compatible:
```
lib_ignore              =
                          ESP Mail Client
                          IRremoteESP8266
                          NeoPixelBus
                          OneWire
                          MFRC522
                          universal display Library
                          ESP8266Audio
                          ESP8266SAM
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
