### PR TITLE
Improvements to thermostat debug output

### DIFF
--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -824,6 +824,7 @@
 #define D_LOG_TCP "TCP: "          // TCP bridge
 #define D_LOG_BERRY "BRY: "        // Berry scripting language
 #define D_LOG_LVGL "LVG: "         // LVGL graphics engine
+#define D_LOG_THERMOSTAT "THE: "   // Thermostat driver
 
 /********************************************************************************************/
 

--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -824,7 +824,6 @@
 #define D_LOG_TCP "TCP: "          // TCP bridge
 #define D_LOG_BERRY "BRY: "        // Berry scripting language
 #define D_LOG_LVGL "LVG: "         // LVGL graphics engine
-#define D_LOG_THERMOSTAT "THE: "   // Thermostat driver
 
 /********************************************************************************************/
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
@@ -1302,7 +1302,7 @@ void ThermostatDebug(uint8_t ctr_output)
   AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].status.sensor_alive: %s"), result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_cycle_active, 0, result_chr);
   AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].status.status_cycle_active: %s"), result_chr);
-  dtostrfd((float)Thermostat[ctr_output].temp_pi_error/10, 1, result_chr);
+  dtostrfd((float)Thermostat[ctr_output].temp_pi_error/100, 2, result_chr);
   AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_pi_error: %s degrees"), result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_pi_accum_error/100, 2, result_chr);
   AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_pi_accum_error: %s degrees"), result_chr);

--- a/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
@@ -192,7 +192,7 @@ void (* const ThermostatCommand[])(void) PROGMEM = {
   &CmndEnableOutputSet };
 
 struct THERMOSTAT {
-  ThermostatStateBitfield status;                                             // Bitfield including states as well as several flags
+  ThermostatStateBitfield status;                                             // Bittfield including states as well as several flags
   uint32_t timestamp_temp_measured_update = 0;                                // Timestamp of latest measurement update
   uint32_t timestamp_temp_meas_change_update = 0;                             // Timestamp of latest measurement value change (> or < to previous)
   uint32_t timestamp_output_off = 0;                                          // Timestamp of latest thermostat output Off state
@@ -215,7 +215,7 @@ struct THERMOSTAT {
   uint32_t time_rampup_deadtime = 0;                                          // Time constant of the thermostat system (step response time)
   uint32_t time_rampup_nextcycle = 0;                                         // Time where the ramp-up controller shall start the next cycle
   int16_t temp_measured = 0;                                                  // Temperature measurement received from sensor in tenths of degrees celsius
-  int16_t temp_rampup_output_off = 0;                                         // Temperature to switch off relay output within the ramp-up controller in tenths of degrees celsius
+  int16_t temp_rampup_output_off = 0;                                         // Temperature to swith off relay output within the ramp-up controller in tenths of degrees celsius
   uint8_t time_output_delay = THERMOSTAT_TIME_OUTPUT_DELAY;                   // Output delay between state change and real actuation event (f.i. valve open/closed)
   uint8_t counter_rampup_cycles = 0;                                          // Counter of ramp-up cycles
   uint8_t temp_rampup_pi_acc_error = THERMOSTAT_TEMP_PI_RAMPUP_ACC_E;         // Accumulated error when switching from ramp-up controller to PI in hundreths of degrees celsius
@@ -375,7 +375,7 @@ void ThermostatSignalPreProcessingSlow(uint8_t ctr_output)
     char result_chr[FLOATSZ];
 
     dtostrfd((TasmotaGlobal.uptime - Thermostat[ctr_output].timestamp_temp_measured_update), 0, result_chr);
-    AddLog(LOG_LEVEL_ERROR, PSTR(D_LOG_THERMOSTAT "Thermostat sensor has not been seen for %s seconds"), result_chr);
+    AddLog(LOG_LEVEL_ERROR, PSTR("Thermostat sensor has not been seen for %s seconds"), result_chr);
 
   }
 }
@@ -427,9 +427,6 @@ void ThermostatCtrState(uint8_t ctr_output)
         && ((flag_heating && (Thermostat[ctr_output].temp_measured_gradient < 0))
           ||(!flag_heating && (Thermostat[ctr_output].temp_measured_gradient > 0))))
       {
-        char ctr_output_chr[FLOATSZ];
-        dtostrfd(ctr_output, 0, ctr_output_chr);
-        AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] CTR_PI ends, switching to CTR_PI_AUTOTUNE"), ctr_output_chr);
         Thermostat[ctr_output].status.controller_mode = CTR_PI_AUTOTUNE;
         ThermostatPeakDetectorInit(ctr_output);
       }
@@ -454,9 +451,6 @@ void ThermostatCtrState(uint8_t ctr_output)
       if (Thermostat[ctr_output].status.autotune_flag == AUTOTUNE_OFF)
       {
         Thermostat[ctr_output].status.controller_mode = CTR_PI;
-        char ctr_output_chr[FLOATSZ];
-        dtostrfd(ctr_output, 0, ctr_output_chr);
-        AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] CTR_PI_AUTOTUNE ends, switching to CTR_PI"), ctr_output_chr);
       }
       break;
 #endif //USE_PI_AUTOTUNING
@@ -480,9 +474,6 @@ void ThermostatHybridCtrPhase(uint8_t ctr_output)
             Thermostat[ctr_output].time_ctr_changepoint = 0;
             // Set PI controller
             Thermostat[ctr_output].status.phase_hybrid_ctr = CTR_HYBRID_PI;
-            char ctr_output_chr[FLOATSZ];
-            dtostrfd(ctr_output, 0, ctr_output_chr);
-            AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] CTR_HYBRID_RAMP_UP ends, switching to CTR_HYBRID_PI"), ctr_output_chr);
           }
         break;
       // PI controller phase
@@ -505,9 +496,6 @@ void ThermostatHybridCtrPhase(uint8_t ctr_output)
               Thermostat[ctr_output].time_ctr_changepoint = 0;
               Thermostat[ctr_output].time_ctr_checkpoint = 0;
               Thermostat[ctr_output].status.phase_hybrid_ctr = CTR_HYBRID_RAMP_UP;
-              char ctr_output_chr[FLOATSZ];
-              dtostrfd(ctr_output, 0, ctr_output_chr);
-              AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] CTR_HYBRID_PI ends, switching to CTR_HYBRID_RAMP_UP"), ctr_output_chr);
           }
 #ifdef USE_PI_AUTOTUNING
           // If Autotune has been enabled (via flag)
@@ -519,9 +507,6 @@ void ThermostatHybridCtrPhase(uint8_t ctr_output)
             && ((flag_heating && (Thermostat[ctr_output].temp_measured_gradient < 0))
               ||(!flag_heating && (Thermostat[ctr_output].temp_measured_gradient > 0))))
           {
-            char ctr_output_chr[FLOATSZ];
-            dtostrfd(ctr_output, 0, ctr_output_chr);
-            AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] CTR_HYBRID_PI ends, switching to CTR_HYBRID_PI_AUTOTUNE"), ctr_output_chr);
             Thermostat[ctr_output].status.phase_hybrid_ctr = CTR_HYBRID_PI_AUTOTUNE;
             ThermostatPeakDetectorInit(ctr_output);
           }
@@ -535,9 +520,6 @@ void ThermostatHybridCtrPhase(uint8_t ctr_output)
         if (Thermostat[ctr_output].status.autotune_flag == AUTOTUNE_OFF)
         {
           Thermostat[ctr_output].status.phase_hybrid_ctr = CTR_HYBRID_PI;
-          char ctr_output_chr[FLOATSZ];
-          dtostrfd(ctr_output, 0, ctr_output_chr);
-          AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] CTR_HYBRID_PI_AUTOTUNE ends, switching to CTR_HYBRID_PI"), ctr_output_chr);
         }
       break;
 #endif // USE_PI_AUTOTUNING
@@ -650,9 +632,6 @@ void ThermostatCalculatePI(uint8_t ctr_output)
 
   bool flag_heating = (Thermostat[ctr_output].status.climate_mode == CLIMATE_HEATING);
   int32_t aux_temp_error;
-  char ctr_output_chr[FLOATSZ];
-  char output_chr[FLOATSZ];
-  dtostrfd(ctr_output, 0, ctr_output_chr);
 
   // Calculate error
   aux_temp_error = (int32_t)(Thermostat[ctr_output].temp_target_level_ctr - Thermostat[ctr_output].temp_measured) * 10;
@@ -673,9 +652,6 @@ void ThermostatCalculatePI(uint8_t ctr_output)
     Thermostat[ctr_output].temp_pi_error = (int16_t)aux_temp_error;
   }
 
-  dtostrfd(Thermostat[ctr_output].temp_pi_error/100, 2, output_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] actual temperature vs. target temperature error %s degrees"), ctr_output_chr, output_chr);
-
   // Kp = 100/PI.propBand. PI.propBand(Xp) = Proportional range (4K in 4K/200 controller)
   Thermostat[ctr_output].kP_pi = 100 / (uint16_t)(Thermostat[ctr_output].val_prop_band);
   // Calculate proportional
@@ -688,16 +664,13 @@ void ThermostatCalculatePI(uint8_t ctr_output)
   if ((Thermostat[ctr_output].time_proportional_pi < abs(((int32_t)Thermostat[ctr_output].time_min_action * 60)))
     && (Thermostat[ctr_output].time_proportional_pi > 0)) {
     Thermostat[ctr_output].time_proportional_pi = ((int32_t)Thermostat[ctr_output].time_min_action * 60);
-    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] proportional PI time limited to min action time"), ctr_output_chr, output_chr);
   }
 
   if (Thermostat[ctr_output].time_proportional_pi < 0) {
     Thermostat[ctr_output].time_proportional_pi = 0;
-    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] negative proportional PI time set to 0"), ctr_output_chr);
   }
   else if (Thermostat[ctr_output].time_proportional_pi > ((int32_t)Thermostat[ctr_output].time_pi_cycle * 60)) {
     Thermostat[ctr_output].time_proportional_pi = ((int32_t)Thermostat[ctr_output].time_pi_cycle * 60);
-    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] proportional PI time limited to PI cycle time"), ctr_output_chr);
   }
 
   // Calculate integral (resolution increased to avoid use of floats in consequent operations)
@@ -709,17 +682,16 @@ void ThermostatCalculatePI(uint8_t ctr_output)
   if (abs((Thermostat[ctr_output].temp_pi_error) / 10) > Thermostat[ctr_output].temp_reset_anti_windup) {
     Thermostat[ctr_output].time_integral_pi = 0;
     Thermostat[ctr_output].temp_pi_accum_error = 0;
-    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] temperature error greater than temperature anti windup, PI integral not used"), ctr_output_chr);
   }
   // Normal use of integrator
-  // result will be calculated with the accumulated previous error anterior
-  // and current error will be accumulated to the previous one
+  // result will be calculated with the cummulated previous error anterior
+  // and current error will be cummulated to the previous one
   else {
     // Hysteresis limiter
     // If error is less than or equal than hysteresis, limit output to 0, when temperature
-    // is rising, never when falling. Limit accumulated error. If this is not done,
+    // is rising, never when falling. Limit cummulated error. If this is not done,
     // there will be very strong control actions from the integral part due to a
-    // very high accumulated error when beginning hysteresis. This triggers high
+    // very high cummulated error when beingin hysteresis. This triggers high
     // integral actions
 
     // Update accumulated error
@@ -745,9 +717,8 @@ void ThermostatCalculatePI(uint8_t ctr_output)
           && (flag_heating))
         || ( (Thermostat[ctr_output].temp_measured_gradient < 0)
           && (!flag_heating)))) {
-      // Reduce accumulated error 20% in each cycle
+      // Reduce accumulator error 20% in each cycle
       Thermostat[ctr_output].temp_pi_accum_error *= 0.8;
-      AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] temperature not yet at the setpoint but we are inside hysteris, so reducing PI accumulated error by 20%"), ctr_output_chr);
     }
     // If we are over setpoint
     // AND temperature is rising for heating or sinking for cooling
@@ -756,12 +727,11 @@ void ThermostatCalculatePI(uint8_t ctr_output)
           && (flag_heating))
         || ( (Thermostat[ctr_output].temp_measured_gradient < 0)
           && (!flag_heating)))) {
-      // Reduce accumulated error 20% in each cycle
+      // Reduce accumulator error 20% in each cycle
       Thermostat[ctr_output].temp_pi_accum_error *= 0.8;
-      AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] temperature is increasing past the setpoint, so reducing PI accumulated error by 20%"), ctr_output_chr);
     }
 
-    // Limit lower limit of accumulated error to 0
+    // Limit lower limit of acumErr to 0
     if (Thermostat[ctr_output].temp_pi_accum_error < 0) {
       Thermostat[ctr_output].temp_pi_accum_error = 0;
     }
@@ -771,7 +741,7 @@ void ThermostatCalculatePI(uint8_t ctr_output)
 
     // Antiwindup of the integrator
     // If integral calculation is bigger than cycle time, adjust result
-    // to the cycle time and error will not be accumulated
+    // to the cycle time and error will not be cummulated
     if (Thermostat[ctr_output].time_integral_pi > ((uint32_t)Thermostat[ctr_output].time_pi_cycle * 60)) {
       Thermostat[ctr_output].time_integral_pi = ((uint32_t)Thermostat[ctr_output].time_pi_cycle * 60);
     }
@@ -782,7 +752,7 @@ void ThermostatCalculatePI(uint8_t ctr_output)
 
   // Antiwindup of the output
   // If result is bigger than cycle time, the result will be adjusted
-  // to the cycle time minus safety time and error will not be accumulated
+  // to the cylce time minus safety time and error will not be cummulated
   if (Thermostat[ctr_output].time_total_pi >= ((int32_t)Thermostat[ctr_output].time_pi_cycle * 60)) {
     // Limit to cycle time //at least switch down a minimum time
     Thermostat[ctr_output].time_total_pi = ((int32_t)Thermostat[ctr_output].time_pi_cycle * 60);
@@ -804,7 +774,7 @@ void ThermostatCalculatePI(uint8_t ctr_output)
     }
   }
   // If target value has not been reached
-  // AND we are within the hysteresis
+  // AND we are within the histeresis
   // AND gradient is positive for heating or negative for cooling
   // then set value to 0
   else if ((Thermostat[ctr_output].temp_pi_error > 0)
@@ -831,9 +801,6 @@ void ThermostatCalculatePI(uint8_t ctr_output)
   else if (Thermostat[ctr_output].time_total_pi > (((int32_t)Thermostat[ctr_output].time_pi_cycle * 60) - ((int32_t)Thermostat[ctr_output].time_min_turnoff_action * 60))) {
     Thermostat[ctr_output].time_total_pi = ((int32_t)Thermostat[ctr_output].time_pi_cycle * 60);
   }
-
-  dtostrfd(Thermostat[ctr_output].time_total_pi, 0, output_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] expecting output duration of %s seconds"), ctr_output_chr, output_chr);
 
   // Adjust output switch point
   Thermostat[ctr_output].time_ctr_changepoint = TasmotaGlobal.uptime + (uint32_t)Thermostat[ctr_output].time_total_pi;
@@ -1319,54 +1286,58 @@ void ThermostatDebug(uint8_t ctr_output)
   char ctr_output_chr[FLOATSZ];
   char result_chr[FLOATSZ];
   dtostrfd(ctr_output, 0, ctr_output_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(""));
+  AddLog(LOG_LEVEL_DEBUG, PSTR("------ Thermostat Start ------"));
   dtostrfd(Thermostat[ctr_output].status.counter_seconds, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.counter_seconds: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.counter_seconds: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.thermostat_mode, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.thermostat_mode: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.thermostat_mode: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].diag.state_emergency, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].diag.state_emergency: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].diag.state_emergency: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].diag.output_inconsist_ctr, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].diag.output_inconsist_ctr: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].diag.output_inconsist_ctr: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.controller_mode, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.controller_mode: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.controller_mode: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.command_output, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.command_output: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.command_output: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_output, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.status_output: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.status_output: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_input, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.status_input: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.status_input: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.phase_hybrid_ctr, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.phase_hybrid_ctr: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.phase_hybrid_ctr: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.sensor_alive, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.sensor_alive: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.sensor_alive: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_cycle_active, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.status_cycle_active: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.status_cycle_active: %s"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_pi_error/100, 2, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_pi_error: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_pi_error: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_pi_accum_error/100, 2, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_pi_accum_error: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_pi_accum_error: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_proportional_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_proportional_pi: %s seconds"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_proportional_pi: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_integral_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_integral_pi: %s seconds"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_integral_pi: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_total_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_total_pi: %s seconds"), ctr_output_chr, result_chr);
-  dtostrfd(Thermostat[ctr_output].time_rampup_deadtime, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_rampup_deadtime: %s seconds"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_total_pi: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_measured_gradient/1000, 3, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_measured_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_measured_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
+  dtostrfd(Thermostat[ctr_output].time_rampup_deadtime, 0, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_rampup_deadtime: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_rampup_meas_gradient/1000, 3, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_rampup_meas_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_rampup_meas_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_ctr_changepoint, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_ctr_changepoint: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_ctr_changepoint: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].temp_rampup_output_off, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_rampup_output_off: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_rampup_output_off: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_ctr_checkpoint, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_ctr_checkpoint: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_ctr_checkpoint: %s"), ctr_output_chr, result_chr);
   dtostrfd(TasmotaGlobal.uptime, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "uptime: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("uptime: %s"), result_chr);
   dtostrfd(TasmotaGlobal.power, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "power: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("power: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("------ Thermostat End ------"));
+  AddLog(LOG_LEVEL_DEBUG, PSTR(""));
 }
 
 void DebugControllerParameters(uint8_t ctr_output)
@@ -1375,29 +1346,29 @@ void DebugControllerParameters(uint8_t ctr_output)
   char result_chr[FLOATSZ];
   dtostrfd(ctr_output, 0, ctr_output_chr);
   dtostrfd(Thermostat[ctr_output].status.controller_mode, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].CONTROLLERMODESET: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].CONTROLLERMODESET: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_pi_cycle, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMEPICYCLESET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEPICYCLESET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_min_action, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMEMINACTIONSET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEMINACTIONSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_max_action, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMEMAXACTIONSET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEMAXACTIONSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_allow_rampup, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMEALLOWRAMPUPSET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEALLOWRAMPUPSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_rampup_cycle, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMERAMPUPCYCLESET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMERAMPUPCYCLESET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_rampup_max, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMERAMPUPMAXSET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMERAMPUPMAXSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_reset, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMERESETSET: %s seconds"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMERESETSET: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].val_prop_band, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].PROPBANDSET: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].PROPBANDSET: %s"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_reset_anti_windup/10, 1, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TEMPANTIWINDUPRESETSET: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TEMPANTIWINDUPRESETSET: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_hysteresis/10, 1, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TEMPHYSTSET: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TEMPHYSTSET: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].temp_rampup_delta_in, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TEMPRUPDELTINSET: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TEMPRUPDELTINSET: %s degrees"), ctr_output_chr, result_chr);
  }
 
 uint8_t ThermostatGetDutyCycle(uint8_t ctr_output)

--- a/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
@@ -1302,22 +1302,22 @@ void ThermostatDebug(uint8_t ctr_output)
   AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].status.sensor_alive: %s"), result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_cycle_active, 0, result_chr);
   AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].status.status_cycle_active: %s"), result_chr);
-  dtostrfd(Thermostat[ctr_output].temp_pi_error, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_pi_error: %s"), result_chr);
-  dtostrfd(Thermostat[ctr_output].temp_pi_accum_error, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_pi_accum_error: %s"), result_chr);
+  dtostrfd((float)Thermostat[ctr_output].temp_pi_error/10, 1, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_pi_error: %s degrees"), result_chr);
+  dtostrfd((float)Thermostat[ctr_output].temp_pi_accum_error/100, 2, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_pi_accum_error: %s degrees"), result_chr);
   dtostrfd(Thermostat[ctr_output].time_proportional_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_proportional_pi: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_proportional_pi: %s seconds"), result_chr);
   dtostrfd(Thermostat[ctr_output].time_integral_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_integral_pi: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_integral_pi: %s seconds"), result_chr);
   dtostrfd(Thermostat[ctr_output].time_total_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_total_pi: %s"), result_chr);
-  dtostrfd(Thermostat[ctr_output].temp_measured_gradient, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_measured_gradient: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_total_pi: %s seconds"), result_chr);
+  dtostrfd((float)Thermostat[ctr_output].temp_measured_gradient/1000, 3, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_measured_gradient: %s degrees/hour"), result_chr);
   dtostrfd(Thermostat[ctr_output].time_rampup_deadtime, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_rampup_deadtime: %s"), result_chr);
-  dtostrfd(Thermostat[ctr_output].temp_rampup_meas_gradient, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_rampup_meas_gradient: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_rampup_deadtime: %s seconds"), result_chr);
+  dtostrfd((float)Thermostat[ctr_output].temp_rampup_meas_gradient/1000, 3, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_rampup_meas_gradient: %s degrees/hour"), result_chr);
   dtostrfd(Thermostat[ctr_output].time_ctr_changepoint, 0, result_chr);
   AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_ctr_changepoint: %s"), result_chr);
   dtostrfd(Thermostat[ctr_output].temp_rampup_output_off, 0, result_chr);
@@ -1331,6 +1331,35 @@ void ThermostatDebug(uint8_t ctr_output)
   AddLog(LOG_LEVEL_DEBUG, PSTR("------ Thermostat End ------"));
   AddLog(LOG_LEVEL_DEBUG, PSTR(""));
 }
+
+void DebugControllerParameters(uint8_t ctr_output)
+{
+  char result_chr[FLOATSZ];
+  dtostrfd(Thermostat[ctr_output].status.controller_mode, 0, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].CONTROLLERMODESET: %s"), result_chr);
+  dtostrfd(Thermostat[ctr_output].time_pi_cycle, 0, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMEPICYCLESET: %s minutes"), result_chr);
+  dtostrfd(Thermostat[ctr_output].time_min_action, 0, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMEMINACTIONSET: %s minutes"), result_chr);
+  dtostrfd(Thermostat[ctr_output].time_max_action, 0, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMEMAXACTIONSET: %s minutes"), result_chr);
+  dtostrfd(Thermostat[ctr_output].time_allow_rampup, 0, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMEALLOWRAMPUPSET: %s minutes"), result_chr);
+  dtostrfd(Thermostat[ctr_output].time_rampup_cycle, 0, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMERAMPUPCYCLESET: %s minutes"), result_chr);
+  dtostrfd(Thermostat[ctr_output].time_rampup_max, 0, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMERAMPUPMAXSET: %s minutes"), result_chr);
+  dtostrfd(Thermostat[ctr_output].time_reset, 0, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMERESETSET: %s seconds"), result_chr);
+  dtostrfd(Thermostat[ctr_output].val_prop_band, 0, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].PROPBANDSET: %s"), result_chr);
+  dtostrfd((float)Thermostat[ctr_output].temp_reset_anti_windup/10, 1, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TEMPANTIWINDUPRESETSET: %s degrees"), result_chr);
+  dtostrfd((float)Thermostat[ctr_output].temp_hysteresis/10, 1, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TEMPHYSTSET: %s degrees"), result_chr);
+  dtostrfd(Thermostat[ctr_output].temp_rampup_delta_in, 0, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TEMPRUPDELTINSET: %s degrees"), result_chr);
+ }
 
 uint8_t ThermostatGetDutyCycle(uint8_t ctr_output)
 {
@@ -1412,6 +1441,9 @@ void CmndThermostatModeSet(void)
         // or it will get stuck on (danger!)
         Thermostat[ctr_output].status.command_output = IFACE_OFF;
         ThermostatOutputRelay(ctr_output, Thermostat[ctr_output].status.command_output);
+      }
+      if ((value > THERMOSTAT_OFF) && (value < THERMOSTAT_MODES_MAX)) {
+        DebugControllerParameters(ctr_output);
       }
     }
     ResponseCmndIdxNumber((int)Thermostat[ctr_output].status.thermostat_mode);

--- a/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
@@ -192,7 +192,7 @@ void (* const ThermostatCommand[])(void) PROGMEM = {
   &CmndEnableOutputSet };
 
 struct THERMOSTAT {
-  ThermostatStateBitfield status;                                             // Bittfield including states as well as several flags
+  ThermostatStateBitfield status;                                             // Bitfield including states as well as several flags
   uint32_t timestamp_temp_measured_update = 0;                                // Timestamp of latest measurement update
   uint32_t timestamp_temp_meas_change_update = 0;                             // Timestamp of latest measurement value change (> or < to previous)
   uint32_t timestamp_output_off = 0;                                          // Timestamp of latest thermostat output Off state
@@ -215,7 +215,7 @@ struct THERMOSTAT {
   uint32_t time_rampup_deadtime = 0;                                          // Time constant of the thermostat system (step response time)
   uint32_t time_rampup_nextcycle = 0;                                         // Time where the ramp-up controller shall start the next cycle
   int16_t temp_measured = 0;                                                  // Temperature measurement received from sensor in tenths of degrees celsius
-  int16_t temp_rampup_output_off = 0;                                         // Temperature to swith off relay output within the ramp-up controller in tenths of degrees celsius
+  int16_t temp_rampup_output_off = 0;                                         // Temperature to switch off relay output within the ramp-up controller in tenths of degrees celsius
   uint8_t time_output_delay = THERMOSTAT_TIME_OUTPUT_DELAY;                   // Output delay between state change and real actuation event (f.i. valve open/closed)
   uint8_t counter_rampup_cycles = 0;                                          // Counter of ramp-up cycles
   uint8_t temp_rampup_pi_acc_error = THERMOSTAT_TEMP_PI_RAMPUP_ACC_E;         // Accumulated error when switching from ramp-up controller to PI in hundreths of degrees celsius
@@ -375,7 +375,7 @@ void ThermostatSignalPreProcessingSlow(uint8_t ctr_output)
     char result_chr[FLOATSZ];
 
     dtostrfd((TasmotaGlobal.uptime - Thermostat[ctr_output].timestamp_temp_measured_update), 0, result_chr);
-    AddLog(LOG_LEVEL_ERROR, PSTR("Thermostat sensor has not been seen for %s seconds"), result_chr);
+    AddLog(LOG_LEVEL_ERROR, PSTR(D_LOG_THERMOSTAT "Thermostat sensor has not been seen for %s seconds"), result_chr);
 
   }
 }
@@ -427,6 +427,9 @@ void ThermostatCtrState(uint8_t ctr_output)
         && ((flag_heating && (Thermostat[ctr_output].temp_measured_gradient < 0))
           ||(!flag_heating && (Thermostat[ctr_output].temp_measured_gradient > 0))))
       {
+        char ctr_output_chr[FLOATSZ];
+        dtostrfd(ctr_output, 0, ctr_output_chr);
+        AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] CTR_PI ends, switching to CTR_PI_AUTOTUNE"), ctr_output_chr);
         Thermostat[ctr_output].status.controller_mode = CTR_PI_AUTOTUNE;
         ThermostatPeakDetectorInit(ctr_output);
       }
@@ -451,6 +454,9 @@ void ThermostatCtrState(uint8_t ctr_output)
       if (Thermostat[ctr_output].status.autotune_flag == AUTOTUNE_OFF)
       {
         Thermostat[ctr_output].status.controller_mode = CTR_PI;
+        char ctr_output_chr[FLOATSZ];
+        dtostrfd(ctr_output, 0, ctr_output_chr);
+        AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] CTR_PI_AUTOTUNE ends, switching to CTR_PI"), ctr_output_chr);
       }
       break;
 #endif //USE_PI_AUTOTUNING
@@ -474,6 +480,9 @@ void ThermostatHybridCtrPhase(uint8_t ctr_output)
             Thermostat[ctr_output].time_ctr_changepoint = 0;
             // Set PI controller
             Thermostat[ctr_output].status.phase_hybrid_ctr = CTR_HYBRID_PI;
+            char ctr_output_chr[FLOATSZ];
+            dtostrfd(ctr_output, 0, ctr_output_chr);
+            AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] CTR_HYBRID_RAMP_UP ends, switching to CTR_HYBRID_PI"), ctr_output_chr);
           }
         break;
       // PI controller phase
@@ -496,6 +505,9 @@ void ThermostatHybridCtrPhase(uint8_t ctr_output)
               Thermostat[ctr_output].time_ctr_changepoint = 0;
               Thermostat[ctr_output].time_ctr_checkpoint = 0;
               Thermostat[ctr_output].status.phase_hybrid_ctr = CTR_HYBRID_RAMP_UP;
+              char ctr_output_chr[FLOATSZ];
+              dtostrfd(ctr_output, 0, ctr_output_chr);
+              AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] CTR_HYBRID_PI ends, switching to CTR_HYBRID_RAMP_UP"), ctr_output_chr);
           }
 #ifdef USE_PI_AUTOTUNING
           // If Autotune has been enabled (via flag)
@@ -507,6 +519,9 @@ void ThermostatHybridCtrPhase(uint8_t ctr_output)
             && ((flag_heating && (Thermostat[ctr_output].temp_measured_gradient < 0))
               ||(!flag_heating && (Thermostat[ctr_output].temp_measured_gradient > 0))))
           {
+            char ctr_output_chr[FLOATSZ];
+            dtostrfd(ctr_output, 0, ctr_output_chr);
+            AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] CTR_HYBRID_PI ends, switching to CTR_HYBRID_PI_AUTOTUNE"), ctr_output_chr);
             Thermostat[ctr_output].status.phase_hybrid_ctr = CTR_HYBRID_PI_AUTOTUNE;
             ThermostatPeakDetectorInit(ctr_output);
           }
@@ -520,6 +535,9 @@ void ThermostatHybridCtrPhase(uint8_t ctr_output)
         if (Thermostat[ctr_output].status.autotune_flag == AUTOTUNE_OFF)
         {
           Thermostat[ctr_output].status.phase_hybrid_ctr = CTR_HYBRID_PI;
+          char ctr_output_chr[FLOATSZ];
+          dtostrfd(ctr_output, 0, ctr_output_chr);
+          AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] CTR_HYBRID_PI_AUTOTUNE ends, switching to CTR_HYBRID_PI"), ctr_output_chr);
         }
       break;
 #endif // USE_PI_AUTOTUNING
@@ -632,6 +650,9 @@ void ThermostatCalculatePI(uint8_t ctr_output)
 
   bool flag_heating = (Thermostat[ctr_output].status.climate_mode == CLIMATE_HEATING);
   int32_t aux_temp_error;
+  char ctr_output_chr[FLOATSZ];
+  char output_chr[FLOATSZ];
+  dtostrfd(ctr_output, 0, ctr_output_chr);
 
   // Calculate error
   aux_temp_error = (int32_t)(Thermostat[ctr_output].temp_target_level_ctr - Thermostat[ctr_output].temp_measured) * 10;
@@ -652,6 +673,9 @@ void ThermostatCalculatePI(uint8_t ctr_output)
     Thermostat[ctr_output].temp_pi_error = (int16_t)aux_temp_error;
   }
 
+  dtostrfd(Thermostat[ctr_output].temp_pi_error/100, 2, output_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] actual temperature vs. target temperature error %s degrees"), ctr_output_chr, output_chr);
+
   // Kp = 100/PI.propBand. PI.propBand(Xp) = Proportional range (4K in 4K/200 controller)
   Thermostat[ctr_output].kP_pi = 100 / (uint16_t)(Thermostat[ctr_output].val_prop_band);
   // Calculate proportional
@@ -664,13 +688,16 @@ void ThermostatCalculatePI(uint8_t ctr_output)
   if ((Thermostat[ctr_output].time_proportional_pi < abs(((int32_t)Thermostat[ctr_output].time_min_action * 60)))
     && (Thermostat[ctr_output].time_proportional_pi > 0)) {
     Thermostat[ctr_output].time_proportional_pi = ((int32_t)Thermostat[ctr_output].time_min_action * 60);
+    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] proportional PI time limited to min action time"), ctr_output_chr, output_chr);
   }
 
   if (Thermostat[ctr_output].time_proportional_pi < 0) {
     Thermostat[ctr_output].time_proportional_pi = 0;
+    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] negative proportional PI time set to 0"), ctr_output_chr);
   }
   else if (Thermostat[ctr_output].time_proportional_pi > ((int32_t)Thermostat[ctr_output].time_pi_cycle * 60)) {
     Thermostat[ctr_output].time_proportional_pi = ((int32_t)Thermostat[ctr_output].time_pi_cycle * 60);
+    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] proportional PI time limited to PI cycle time"), ctr_output_chr);
   }
 
   // Calculate integral (resolution increased to avoid use of floats in consequent operations)
@@ -682,16 +709,17 @@ void ThermostatCalculatePI(uint8_t ctr_output)
   if (abs((Thermostat[ctr_output].temp_pi_error) / 10) > Thermostat[ctr_output].temp_reset_anti_windup) {
     Thermostat[ctr_output].time_integral_pi = 0;
     Thermostat[ctr_output].temp_pi_accum_error = 0;
+    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] temperature error greater than temperature anti windup, PI integral not used"), ctr_output_chr);
   }
   // Normal use of integrator
-  // result will be calculated with the cummulated previous error anterior
-  // and current error will be cummulated to the previous one
+  // result will be calculated with the accumulated previous error anterior
+  // and current error will be accumulated to the previous one
   else {
     // Hysteresis limiter
     // If error is less than or equal than hysteresis, limit output to 0, when temperature
-    // is rising, never when falling. Limit cummulated error. If this is not done,
+    // is rising, never when falling. Limit accumulated error. If this is not done,
     // there will be very strong control actions from the integral part due to a
-    // very high cummulated error when beingin hysteresis. This triggers high
+    // very high accumulated error when beginning hysteresis. This triggers high
     // integral actions
 
     // Update accumulated error
@@ -717,8 +745,9 @@ void ThermostatCalculatePI(uint8_t ctr_output)
           && (flag_heating))
         || ( (Thermostat[ctr_output].temp_measured_gradient < 0)
           && (!flag_heating)))) {
-      // Reduce accumulator error 20% in each cycle
+      // Reduce accumulated error 20% in each cycle
       Thermostat[ctr_output].temp_pi_accum_error *= 0.8;
+      AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] temperature not yet at the setpoint but we are inside hysteris, so reducing PI accumulated error by 20%"), ctr_output_chr);
     }
     // If we are over setpoint
     // AND temperature is rising for heating or sinking for cooling
@@ -727,11 +756,12 @@ void ThermostatCalculatePI(uint8_t ctr_output)
           && (flag_heating))
         || ( (Thermostat[ctr_output].temp_measured_gradient < 0)
           && (!flag_heating)))) {
-      // Reduce accumulator error 20% in each cycle
+      // Reduce accumulated error 20% in each cycle
       Thermostat[ctr_output].temp_pi_accum_error *= 0.8;
+      AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] temperature is increasing past the setpoint, so reducing PI accumulated error by 20%"), ctr_output_chr);
     }
 
-    // Limit lower limit of acumErr to 0
+    // Limit lower limit of accumulated error to 0
     if (Thermostat[ctr_output].temp_pi_accum_error < 0) {
       Thermostat[ctr_output].temp_pi_accum_error = 0;
     }
@@ -741,7 +771,7 @@ void ThermostatCalculatePI(uint8_t ctr_output)
 
     // Antiwindup of the integrator
     // If integral calculation is bigger than cycle time, adjust result
-    // to the cycle time and error will not be cummulated
+    // to the cycle time and error will not be accumulated
     if (Thermostat[ctr_output].time_integral_pi > ((uint32_t)Thermostat[ctr_output].time_pi_cycle * 60)) {
       Thermostat[ctr_output].time_integral_pi = ((uint32_t)Thermostat[ctr_output].time_pi_cycle * 60);
     }
@@ -752,7 +782,7 @@ void ThermostatCalculatePI(uint8_t ctr_output)
 
   // Antiwindup of the output
   // If result is bigger than cycle time, the result will be adjusted
-  // to the cylce time minus safety time and error will not be cummulated
+  // to the cycle time minus safety time and error will not be accumulated
   if (Thermostat[ctr_output].time_total_pi >= ((int32_t)Thermostat[ctr_output].time_pi_cycle * 60)) {
     // Limit to cycle time //at least switch down a minimum time
     Thermostat[ctr_output].time_total_pi = ((int32_t)Thermostat[ctr_output].time_pi_cycle * 60);
@@ -774,7 +804,7 @@ void ThermostatCalculatePI(uint8_t ctr_output)
     }
   }
   // If target value has not been reached
-  // AND we are within the histeresis
+  // AND we are within the hysteresis
   // AND gradient is positive for heating or negative for cooling
   // then set value to 0
   else if ((Thermostat[ctr_output].temp_pi_error > 0)
@@ -801,6 +831,9 @@ void ThermostatCalculatePI(uint8_t ctr_output)
   else if (Thermostat[ctr_output].time_total_pi > (((int32_t)Thermostat[ctr_output].time_pi_cycle * 60) - ((int32_t)Thermostat[ctr_output].time_min_turnoff_action * 60))) {
     Thermostat[ctr_output].time_total_pi = ((int32_t)Thermostat[ctr_output].time_pi_cycle * 60);
   }
+
+  dtostrfd(Thermostat[ctr_output].time_total_pi, 0, output_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s] expecting output duration of %s seconds"), ctr_output_chr, output_chr);
 
   // Adjust output switch point
   Thermostat[ctr_output].time_ctr_changepoint = TasmotaGlobal.uptime + (uint32_t)Thermostat[ctr_output].time_total_pi;
@@ -1286,58 +1319,54 @@ void ThermostatDebug(uint8_t ctr_output)
   char ctr_output_chr[FLOATSZ];
   char result_chr[FLOATSZ];
   dtostrfd(ctr_output, 0, ctr_output_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(""));
-  AddLog(LOG_LEVEL_DEBUG, PSTR("------ Thermostat Start ------"));
   dtostrfd(Thermostat[ctr_output].status.counter_seconds, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.counter_seconds: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.counter_seconds: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.thermostat_mode, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.thermostat_mode: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.thermostat_mode: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].diag.state_emergency, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].diag.state_emergency: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].diag.state_emergency: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].diag.output_inconsist_ctr, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].diag.output_inconsist_ctr: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].diag.output_inconsist_ctr: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.controller_mode, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.controller_mode: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.controller_mode: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.command_output, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.command_output: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.command_output: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_output, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.status_output: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.status_output: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_input, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.status_input: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.status_input: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.phase_hybrid_ctr, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.phase_hybrid_ctr: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.phase_hybrid_ctr: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.sensor_alive, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.sensor_alive: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.sensor_alive: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_cycle_active, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.status_cycle_active: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.status_cycle_active: %s"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_pi_error/100, 2, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_pi_error: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_pi_error: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_pi_accum_error/100, 2, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_pi_accum_error: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_pi_accum_error: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_proportional_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_proportional_pi: %s seconds"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_proportional_pi: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_integral_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_integral_pi: %s seconds"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_integral_pi: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_total_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_total_pi: %s seconds"), ctr_output_chr, result_chr);
-  dtostrfd((float)Thermostat[ctr_output].temp_measured_gradient/1000, 3, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_measured_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_total_pi: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_rampup_deadtime, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_rampup_deadtime: %s seconds"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_rampup_deadtime: %s seconds"), ctr_output_chr, result_chr);
+  dtostrfd((float)Thermostat[ctr_output].temp_measured_gradient/1000, 3, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_measured_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_rampup_meas_gradient/1000, 3, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_rampup_meas_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_rampup_meas_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_ctr_changepoint, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_ctr_changepoint: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_ctr_changepoint: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].temp_rampup_output_off, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_rampup_output_off: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_rampup_output_off: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_ctr_checkpoint, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_ctr_checkpoint: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_ctr_checkpoint: %s"), ctr_output_chr, result_chr);
   dtostrfd(TasmotaGlobal.uptime, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("uptime: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "uptime: %s"), result_chr);
   dtostrfd(TasmotaGlobal.power, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("power: %s"), result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("------ Thermostat End ------"));
-  AddLog(LOG_LEVEL_DEBUG, PSTR(""));
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "power: %s"), result_chr);
 }
 
 void DebugControllerParameters(uint8_t ctr_output)
@@ -1346,29 +1375,29 @@ void DebugControllerParameters(uint8_t ctr_output)
   char result_chr[FLOATSZ];
   dtostrfd(ctr_output, 0, ctr_output_chr);
   dtostrfd(Thermostat[ctr_output].status.controller_mode, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].CONTROLLERMODESET: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].CONTROLLERMODESET: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_pi_cycle, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEPICYCLESET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMEPICYCLESET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_min_action, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEMINACTIONSET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMEMINACTIONSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_max_action, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEMAXACTIONSET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMEMAXACTIONSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_allow_rampup, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEALLOWRAMPUPSET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMEALLOWRAMPUPSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_rampup_cycle, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMERAMPUPCYCLESET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMERAMPUPCYCLESET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_rampup_max, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMERAMPUPMAXSET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMERAMPUPMAXSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_reset, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMERESETSET: %s seconds"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMERESETSET: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].val_prop_band, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].PROPBANDSET: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].PROPBANDSET: %s"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_reset_anti_windup/10, 1, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TEMPANTIWINDUPRESETSET: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TEMPANTIWINDUPRESETSET: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_hysteresis/10, 1, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TEMPHYSTSET: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TEMPHYSTSET: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].temp_rampup_delta_in, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TEMPRUPDELTINSET: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TEMPRUPDELTINSET: %s degrees"), ctr_output_chr, result_chr);
  }
 
 uint8_t ThermostatGetDutyCycle(uint8_t ctr_output)

--- a/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
@@ -192,7 +192,7 @@ void (* const ThermostatCommand[])(void) PROGMEM = {
   &CmndEnableOutputSet };
 
 struct THERMOSTAT {
-  ThermostatStateBitfield status;                                             // Bittfield including states as well as several flags
+  ThermostatStateBitfield status;                                             // Bitfield including states as well as several flags
   uint32_t timestamp_temp_measured_update = 0;                                // Timestamp of latest measurement update
   uint32_t timestamp_temp_meas_change_update = 0;                             // Timestamp of latest measurement value change (> or < to previous)
   uint32_t timestamp_output_off = 0;                                          // Timestamp of latest thermostat output Off state
@@ -215,8 +215,8 @@ struct THERMOSTAT {
   uint32_t time_rampup_deadtime = 0;                                          // Time constant of the thermostat system (step response time)
   uint32_t time_rampup_nextcycle = 0;                                         // Time where the ramp-up controller shall start the next cycle
   int16_t temp_measured = 0;                                                  // Temperature measurement received from sensor in tenths of degrees celsius
-  int16_t temp_rampup_output_off = 0;                                         // Temperature to swith off relay output within the ramp-up controller in tenths of degrees celsius
-  uint8_t time_output_delay = THERMOSTAT_TIME_OUTPUT_DELAY;                   // Output delay between state change and real actuation event (f.i. valve open/closed)
+  int16_t temp_rampup_output_off = 0;                                         // Temperature to switch off relay output within the ramp-up controller in tenths of degrees celsius
+  uint8_t time_output_delay = THERMOSTAT_TIME_OUTPUT_DELAY;                   // Output delay between state change and real actuation event (eg. valve open/closed)
   uint8_t counter_rampup_cycles = 0;                                          // Counter of ramp-up cycles
   uint8_t temp_rampup_pi_acc_error = THERMOSTAT_TEMP_PI_RAMPUP_ACC_E;         // Accumulated error when switching from ramp-up controller to PI in hundreths of degrees celsius
   uint8_t temp_rampup_delta_out = THERMOSTAT_TEMP_RAMPUP_DELTA_OUT;           // Minimum delta temperature to target to get out of the rampup mode, in tenths of degrees celsius
@@ -227,17 +227,17 @@ struct THERMOSTAT {
   uint16_t time_rampup_max = THERMOSTAT_TIME_RAMPUP_MAX;                      // Time maximum ramp-up controller duration in minutes
   uint16_t time_rampup_cycle = THERMOSTAT_TIME_RAMPUP_CYCLE;                  // Time ramp-up cycle in minutes
   uint16_t time_allow_rampup = THERMOSTAT_TIME_ALLOW_RAMPUP;                  // Time in minutes after last target update to allow ramp-up controller phase
-  uint16_t time_sens_lost = THERMOSTAT_TIME_SENS_LOST;                        // Maximum time w/o sensor update to set it as lost in minutes
+  uint16_t time_sens_lost = THERMOSTAT_TIME_SENS_LOST;                        // Maximum time without sensor update to set it as lost in minutes
   uint16_t time_manual_to_auto = THERMOSTAT_TIME_MANUAL_TO_AUTO;              // Time without input switch active to change from manual to automatic in minutes
   uint32_t time_reset = THERMOSTAT_TIME_RESET;                                // Reset time of the PI controller in seconds
   uint16_t time_pi_cycle = THERMOSTAT_TIME_PI_CYCLE;                          // Cycle time for the thermostat controller in minutes
   uint16_t time_max_action = THERMOSTAT_TIME_MAX_ACTION;                      // Maximum thermostat time per cycle in minutes
   uint16_t time_min_action = THERMOSTAT_TIME_MIN_ACTION;                      // Minimum thermostat time per cycle in minutes
-  uint16_t time_min_turnoff_action = THERMOSTAT_TIME_MIN_TURNOFF_ACTION;      // Minimum turnoff time in minutes, below it the thermostat will stay on
+  uint16_t time_min_turnoff_action = THERMOSTAT_TIME_MIN_TURNOFF_ACTION;      // Minimum turnoff time in minutes, below which the thermostat will stay on
   int16_t temp_frost_protect = THERMOSTAT_TEMP_FROST_PROTECT;                 // Minimum temperature for frost protection, in tenths of degrees celsius
   uint8_t temp_reset_anti_windup = THERMOSTAT_TEMP_RESET_ANTI_WINDUP;         // Range where reset antiwindup is disabled, in tenths of degrees celsius
   int8_t temp_hysteresis = THERMOSTAT_TEMP_HYSTERESIS;                        // Range hysteresis for temperature PI controller, in tenths of degrees celsius
-  ThermostatDiagBitfield diag;                                                // Bittfield including diagnostic flags
+  ThermostatDiagBitfield diag;                                                // Bitfield including diagnostic flags
 #ifdef USE_PI_AUTOTUNING
   uint8_t dutycycle_step_autotune = THERMOSTAT_DUTYCYCLE_AUTOTUNE;            // Duty cycle for the step response of the autotune PI function in %
   uint8_t peak_ctr = 0;                                                       // Peak counter for the autotuning function
@@ -249,8 +249,8 @@ struct THERMOSTAT {
   uint16_t kP_pi_atune = 0;                                                   // kP value calculated by the autotune PI function multiplied by 100 (to avoid floating point operations)
   uint16_t kI_pi_atune = 0;                                                   // kI value calulated by the autotune PI function multiplied by 100 (to avoid floating point operations)
   int16_t temp_peaks_atune[THERMOSTAT_PEAKNUMBER_AUTOTUNE];                   // Array to store temperature peaks to be used by the autotune PI function
-  int16_t temp_abs_max_atune;                                                 // Max temperature reached within autotune
-  int16_t temp_abs_min_atune;                                                 // Min temperature reached within autotune
+  int16_t temp_abs_max_atune;                                                 // Maximum temperature reached within autotune
+  int16_t temp_abs_min_atune;                                                 // Minimum temperature reached within autotune
   uint16_t time_peak_timestamps_atune[THERMOSTAT_PEAKNUMBER_AUTOTUNE];        // Array to store timestamps in minutes of the temperature peaks to be used by the autotune PI function
   uint16_t time_std_dev_peak_det_ok = THERMOSTAT_TIME_STD_DEV_PEAK_DET_OK;    // Standard deviation in minutes of the oscillation periods within the peak detection is successful
 #endif // USE_PI_AUTOTUNING
@@ -684,14 +684,14 @@ void ThermostatCalculatePI(uint8_t ctr_output)
     Thermostat[ctr_output].temp_pi_accum_error = 0;
   }
   // Normal use of integrator
-  // result will be calculated with the cummulated previous error anterior
-  // and current error will be cummulated to the previous one
+  // result will be calculated with the accumulated previous error anterior
+  // and current error will be accumulated to the previous one
   else {
     // Hysteresis limiter
     // If error is less than or equal than hysteresis, limit output to 0, when temperature
-    // is rising, never when falling. Limit cummulated error. If this is not done,
+    // is rising, never when falling. Limit accumulated error. If this is not done,
     // there will be very strong control actions from the integral part due to a
-    // very high cummulated error when beingin hysteresis. This triggers high
+    // very high accumulated error when beingin hysteresis. This triggers high
     // integral actions
 
     // Update accumulated error
@@ -741,7 +741,7 @@ void ThermostatCalculatePI(uint8_t ctr_output)
 
     // Antiwindup of the integrator
     // If integral calculation is bigger than cycle time, adjust result
-    // to the cycle time and error will not be cummulated
+    // to the cycle time and error will not be accumulated
     if (Thermostat[ctr_output].time_integral_pi > ((uint32_t)Thermostat[ctr_output].time_pi_cycle * 60)) {
       Thermostat[ctr_output].time_integral_pi = ((uint32_t)Thermostat[ctr_output].time_pi_cycle * 60);
     }
@@ -752,7 +752,7 @@ void ThermostatCalculatePI(uint8_t ctr_output)
 
   // Antiwindup of the output
   // If result is bigger than cycle time, the result will be adjusted
-  // to the cylce time minus safety time and error will not be cummulated
+  // to the cylce time minus safety time and error will not be accumulated
   if (Thermostat[ctr_output].time_total_pi >= ((int32_t)Thermostat[ctr_output].time_pi_cycle * 60)) {
     // Limit to cycle time //at least switch down a minimum time
     Thermostat[ctr_output].time_total_pi = ((int32_t)Thermostat[ctr_output].time_pi_cycle * 60);

--- a/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
@@ -371,6 +371,12 @@ void ThermostatSignalPreProcessingSlow(uint8_t ctr_output)
     Thermostat[ctr_output].status.sensor_alive = IFACE_OFF;
     Thermostat[ctr_output].temp_measured_gradient = 0;
     Thermostat[ctr_output].temp_measured = 0;
+
+    char result_chr[FLOATSZ];
+
+    dtostrfd((TasmotaGlobal.uptime - Thermostat[ctr_output].timestamp_temp_measured_update), 0, result_chr);
+    AddLog(LOG_LEVEL_ERROR, PSTR("Thermostat sensor has not been seen for %s seconds"), result_chr);
+
   }
 }
 
@@ -1277,53 +1283,55 @@ void ThermostatVirtualSwitchCtrState(uint8_t ctr_output)
 
 void ThermostatDebug(uint8_t ctr_output)
 {
+  char ctr_output_chr[FLOATSZ];
   char result_chr[FLOATSZ];
+  dtostrfd(ctr_output, 0, ctr_output_chr);
   AddLog(LOG_LEVEL_DEBUG, PSTR(""));
   AddLog(LOG_LEVEL_DEBUG, PSTR("------ Thermostat Start ------"));
   dtostrfd(Thermostat[ctr_output].status.counter_seconds, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].status.counter_seconds: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.counter_seconds: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.thermostat_mode, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].status.thermostat_mode: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.thermostat_mode: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].diag.state_emergency, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].diag.state_emergency: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].diag.state_emergency: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].diag.output_inconsist_ctr, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].diag.output_inconsist_ctr: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].diag.output_inconsist_ctr: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.controller_mode, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].status.controller_mode: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.controller_mode: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.command_output, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].status.command_output: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.command_output: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_output, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].status.status_output: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.status_output: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_input, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].status.status_input: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.status_input: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.phase_hybrid_ctr, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].status.phase_hybrid_ctr: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.phase_hybrid_ctr: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.sensor_alive, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].status.sensor_alive: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.sensor_alive: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_cycle_active, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].status.status_cycle_active: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.status_cycle_active: %s"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_pi_error/100, 2, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_pi_error: %s degrees"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_pi_error: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_pi_accum_error/100, 2, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_pi_accum_error: %s degrees"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_pi_accum_error: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_proportional_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_proportional_pi: %s seconds"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_proportional_pi: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_integral_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_integral_pi: %s seconds"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_integral_pi: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_total_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_total_pi: %s seconds"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_total_pi: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_measured_gradient/1000, 3, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_measured_gradient: %s degrees/hour"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_measured_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_rampup_deadtime, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_rampup_deadtime: %s seconds"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_rampup_deadtime: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_rampup_meas_gradient/1000, 3, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_rampup_meas_gradient: %s degrees/hour"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_rampup_meas_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_ctr_changepoint, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_ctr_changepoint: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_ctr_changepoint: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].temp_rampup_output_off, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].temp_rampup_output_off: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_rampup_output_off: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_ctr_checkpoint, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[ctr_output].time_ctr_checkpoint: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_ctr_checkpoint: %s"), ctr_output_chr, result_chr);
   dtostrfd(TasmotaGlobal.uptime, 0, result_chr);
   AddLog(LOG_LEVEL_DEBUG, PSTR("uptime: %s"), result_chr);
   dtostrfd(TasmotaGlobal.power, 0, result_chr);
@@ -1334,31 +1342,33 @@ void ThermostatDebug(uint8_t ctr_output)
 
 void DebugControllerParameters(uint8_t ctr_output)
 {
+  char ctr_output_chr[FLOATSZ];
   char result_chr[FLOATSZ];
+  dtostrfd(ctr_output, 0, ctr_output_chr);
   dtostrfd(Thermostat[ctr_output].status.controller_mode, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].CONTROLLERMODESET: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].CONTROLLERMODESET: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_pi_cycle, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMEPICYCLESET: %s minutes"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEPICYCLESET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_min_action, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMEMINACTIONSET: %s minutes"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEMINACTIONSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_max_action, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMEMAXACTIONSET: %s minutes"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEMAXACTIONSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_allow_rampup, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMEALLOWRAMPUPSET: %s minutes"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEALLOWRAMPUPSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_rampup_cycle, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMERAMPUPCYCLESET: %s minutes"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMERAMPUPCYCLESET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_rampup_max, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMERAMPUPMAXSET: %s minutes"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMERAMPUPMAXSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_reset, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TIMERESETSET: %s seconds"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMERESETSET: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].val_prop_band, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].PROPBANDSET: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].PROPBANDSET: %s"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_reset_anti_windup/10, 1, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TEMPANTIWINDUPRESETSET: %s degrees"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TEMPANTIWINDUPRESETSET: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_hysteresis/10, 1, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TEMPHYSTSET: %s degrees"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TEMPHYSTSET: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].temp_rampup_delta_in, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[ctr_output].TEMPRUPDELTINSET: %s degrees"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TEMPRUPDELTINSET: %s degrees"), ctr_output_chr, result_chr);
  }
 
 uint8_t ThermostatGetDutyCycle(uint8_t ctr_output)

--- a/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
@@ -375,7 +375,7 @@ void ThermostatSignalPreProcessingSlow(uint8_t ctr_output)
     char result_chr[FLOATSZ];
 
     dtostrfd((TasmotaGlobal.uptime - Thermostat[ctr_output].timestamp_temp_measured_update), 0, result_chr);
-    AddLog(LOG_LEVEL_ERROR, PSTR("Thermostat sensor has not been seen for %s seconds"), result_chr);
+    AddLog(LOG_LEVEL_ERROR, PSTR(D_LOG_THERMOSTAT "Thermostat sensor has not been seen for %s seconds"), result_chr);
 
   }
 }
@@ -1286,58 +1286,54 @@ void ThermostatDebug(uint8_t ctr_output)
   char ctr_output_chr[FLOATSZ];
   char result_chr[FLOATSZ];
   dtostrfd(ctr_output, 0, ctr_output_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR(""));
-  AddLog(LOG_LEVEL_DEBUG, PSTR("------ Thermostat Start ------"));
   dtostrfd(Thermostat[ctr_output].status.counter_seconds, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.counter_seconds: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.counter_seconds: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.thermostat_mode, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.thermostat_mode: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.thermostat_mode: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].diag.state_emergency, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].diag.state_emergency: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].diag.state_emergency: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].diag.output_inconsist_ctr, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].diag.output_inconsist_ctr: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].diag.output_inconsist_ctr: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.controller_mode, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.controller_mode: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.controller_mode: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.command_output, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.command_output: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.command_output: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_output, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.status_output: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.status_output: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_input, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.status_input: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.status_input: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.phase_hybrid_ctr, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.phase_hybrid_ctr: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.phase_hybrid_ctr: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.sensor_alive, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.sensor_alive: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.sensor_alive: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.status_cycle_active, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].status.status_cycle_active: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.status_cycle_active: %s"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_pi_error/100, 2, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_pi_error: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_pi_error: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_pi_accum_error/100, 2, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_pi_accum_error: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_pi_accum_error: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_proportional_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_proportional_pi: %s seconds"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_proportional_pi: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_integral_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_integral_pi: %s seconds"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_integral_pi: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_total_pi, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_total_pi: %s seconds"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_total_pi: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_measured_gradient/1000, 3, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_measured_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_measured_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_rampup_deadtime, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_rampup_deadtime: %s seconds"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_rampup_deadtime: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_rampup_meas_gradient/1000, 3, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_rampup_meas_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_rampup_meas_gradient: %s degrees/hour"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_ctr_changepoint, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_ctr_changepoint: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_ctr_changepoint: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].temp_rampup_output_off, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].temp_rampup_output_off: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].temp_rampup_output_off: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_ctr_checkpoint, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Thermostat[%s].time_ctr_checkpoint: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].time_ctr_checkpoint: %s"), ctr_output_chr, result_chr);
   dtostrfd(TasmotaGlobal.uptime, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("uptime: %s"), result_chr);
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "uptime: %s"), result_chr);
   dtostrfd(TasmotaGlobal.power, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("power: %s"), result_chr);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("------ Thermostat End ------"));
-  AddLog(LOG_LEVEL_DEBUG, PSTR(""));
+  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "power: %s"), result_chr);
 }
 
 void DebugControllerParameters(uint8_t ctr_output)
@@ -1346,29 +1342,29 @@ void DebugControllerParameters(uint8_t ctr_output)
   char result_chr[FLOATSZ];
   dtostrfd(ctr_output, 0, ctr_output_chr);
   dtostrfd(Thermostat[ctr_output].status.controller_mode, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].CONTROLLERMODESET: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].CONTROLLERMODESET: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_pi_cycle, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEPICYCLESET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMEPICYCLESET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_min_action, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEMINACTIONSET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMEMINACTIONSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_max_action, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEMAXACTIONSET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMEMAXACTIONSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_allow_rampup, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMEALLOWRAMPUPSET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMEALLOWRAMPUPSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_rampup_cycle, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMERAMPUPCYCLESET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMERAMPUPCYCLESET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_rampup_max, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMERAMPUPMAXSET: %s minutes"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMERAMPUPMAXSET: %s minutes"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_reset, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TIMERESETSET: %s seconds"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TIMERESETSET: %s seconds"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].val_prop_band, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].PROPBANDSET: %s"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].PROPBANDSET: %s"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_reset_anti_windup/10, 1, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TEMPANTIWINDUPRESETSET: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TEMPANTIWINDUPRESETSET: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd((float)Thermostat[ctr_output].temp_hysteresis/10, 1, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TEMPHYSTSET: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TEMPHYSTSET: %s degrees"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].temp_rampup_delta_in, 0, result_chr);
-  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Thermostat[%s].TEMPRUPDELTINSET: %s degrees"), ctr_output_chr, result_chr);
+  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].TEMPRUPDELTINSET: %s degrees"), ctr_output_chr, result_chr);
  }
 
 uint8_t ThermostatGetDutyCycle(uint8_t ctr_output)

--- a/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
@@ -597,11 +597,9 @@ void ThermostatOutputRelay(uint8_t ctr_output, uint32_t command)
   // then switch output to ON
   if ((command == IFACE_ON)
     && (Thermostat[ctr_output].status.status_output == IFACE_OFF)) {
-//#ifndef DEBUG_THERMOSTAT
     if (Thermostat[ctr_output].status.enable_output == IFACE_ON) {
       ExecuteCommandPower(Thermostat[ctr_output].status.output_relay_number, POWER_ON, SRC_THERMOSTAT);
     }
-//#endif // DEBUG_THERMOSTAT
     Thermostat[ctr_output].status.status_output = IFACE_ON;
 #ifdef DEBUG_THERMOSTAT
     ThermostatVirtualSwitch(ctr_output);
@@ -611,11 +609,9 @@ void ThermostatOutputRelay(uint8_t ctr_output, uint32_t command)
   // AND current output status is ON
   // then switch output to OFF
   else if ((command == IFACE_OFF) && (Thermostat[ctr_output].status.status_output == IFACE_ON)) {
-//#ifndef DEBUG_THERMOSTAT
     if (Thermostat[ctr_output].status.enable_output == IFACE_ON) {
       ExecuteCommandPower(Thermostat[ctr_output].status.output_relay_number, POWER_OFF, SRC_THERMOSTAT);
     }
-//#endif // DEBUG_THERMOSTAT
     Thermostat[ctr_output].timestamp_output_off = TasmotaGlobal.uptime;
     Thermostat[ctr_output].status.status_output = IFACE_OFF;
 #ifdef DEBUG_THERMOSTAT
@@ -1277,6 +1273,7 @@ void ThermostatVirtualSwitchCtrState(uint8_t ctr_output)
   Response_P(DOMOTICZ_MES, DOMOTICZ_IDX2, (0 == Thermostat[0].status.phase_hybrid_ctr) ? 0 : 1, "");
   MqttPublish(domoticz_in_topic);
 }
+#endif // DEBUG_THERMOSTAT
 
 void ThermostatDebug(uint8_t ctr_output)
 {
@@ -1334,7 +1331,6 @@ void ThermostatDebug(uint8_t ctr_output)
   AddLog(LOG_LEVEL_DEBUG, PSTR("------ Thermostat End ------"));
   AddLog(LOG_LEVEL_DEBUG, PSTR(""));
 }
-#endif // DEBUG_THERMOSTAT
 
 uint8_t ThermostatGetDutyCycle(uint8_t ctr_output)
 {
@@ -2167,9 +2163,7 @@ bool Xdrv39(uint32_t function)
           ThermostatSignalPreProcessingSlow(ctr_output);
           ThermostatController(ctr_output);
           ThermostatSignalPostProcessingSlow(ctr_output);
-#ifdef DEBUG_THERMOSTAT
           ThermostatDebug(ctr_output);
-#endif // DEBUG_THERMOSTAT
         }
       }
       break;


### PR DESCRIPTION
## Description:

It's very fairly difficult to figure out why the controller is behaving the way it does, so these changes to log lines only make this a lot easier. Also, debug output can now be grep'd for THE: to speed up logging analysis.

add: log prefix 'THE' added to debug output
add: error log message when sensor is detected as not alive
add: debug output of main controller parameters when thermostat enabled
add: update DEBUG_THERMOSTAT to only control the virtual switch (debug output can now be used when this flag has not been compiled in)
add: human readable output on debug lines eg 100ths of degrees also displayed as fractional degrees
fix: comment typos and small grammatical changes for clarity

**Related issue (if applicable):** fixes # N/A relates #16985 

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
