### PR TITLE
add section safeboot_flags in platform_tasmota32.ini

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -47,3 +47,23 @@ platform                    = https://github.com/tasmota/platform-espressif32/re
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
+
+[safeboot_flags]
+lib_ignore              =   ESP Mail Client
+                            IRremoteESP8266
+                            NeoPixelBus
+                            OneWire
+                            MFRC522
+                            universal display Library
+                            ESP8266Audio
+                            ESP8266SAM
+                            FFat
+                            Berry
+                            Berry mapping to C
+                            Berry Tasmota mapping
+                            Berry int64 implementation for 32 bits architceture
+                            Berry Matter protocol implementation
+                            Micro-RTSP
+                            re1.5
+                            DHT sensor library
+                            ccronexpr


### PR DESCRIPTION
This will make it easier to ignore a bunch of libraries in order to speed up builds without polluting the ENV sections too much.

Usage:
[env:my_safeboot_env]
lib_ignore              = ${safeboot_flags.lib_ignore}

Will need additional PR's to activate it.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
