### PR TITLE
use common safeboot flags

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -88,10 +88,7 @@ build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
-lib_ignore              =
-                          Micro-RTSP
-                          ESP Mail Client
-                          DHT sensor library
+lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32]
 extends                 = env:tasmota32_base
@@ -176,10 +173,7 @@ build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32solo1-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
-lib_ignore              =
-                          Micro-RTSP
-                          ESP Mail Client
-                          DHT sensor library
+lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32-zbbrdgpro]
 extends                 = env:tasmota32_base
@@ -214,10 +208,7 @@ build_flags             = ${env:tasmota32_base.build_flags}
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3-safeboot.bin"'
                           -fno-lto
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
-lib_ignore              =
-                          Micro-RTSP
-                          ESP Mail Client
-                          DHT sensor library
+lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32c3]
 extends                 = env:tasmota32_base
@@ -257,10 +248,7 @@ build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
-lib_ignore              =
-                          Micro-RTSP
-                          ESP Mail Client
-                          DHT sensor library
+lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32s2]
 extends                 = env:tasmota32_base
@@ -295,10 +283,7 @@ build_flags             = ${env:tasmota32_base.build_flags}
                          -DFIRMWARE_SAFEBOOT
                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
-lib_ignore              =
-                          Micro-RTSP
-                          ESP Mail Client
-                          DHT sensor library
+lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32s3]
 extends                 = env:tasmota32_base


### PR DESCRIPTION
## Description:

Should speed up safeboot firmware builds in CI by a very small amount.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
