### PR TITLE
avoid unnecessary compiling of specific libraries in libesp32_div

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -15,7 +15,6 @@ lib_compat_mode         = ${common.lib_compat_mode}
 lib_extra_dirs          = ${common.lib_extra_dirs}
                           lib/libesp32
                           lib/libesp32_lvgl
-                          lib/libesp32_div
                           lib/libesp32_eink
                           lib/libesp32_audio
 lib_ignore              =


### PR DESCRIPTION
## Description:

Most builds do not need BLE, HomeKit or TTGO.
Removes some unneeded compilation steps and speeds up build by a tiny margin (on modern fast systems).

No changes in the resulting firmware binaries.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
