### PR TITLE
Properly detect HDC1080 device is offline after maximum misses reached

### DIFF
--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -825,6 +825,7 @@
 #define D_LOG_BERRY "BRY: "        // Berry scripting language
 #define D_LOG_LVGL "LVG: "         // LVGL graphics engine
 #define D_LOG_THERMOSTAT "THE: "   // Thermostat driver
+#define D_LOG_SENSOR "SNS: "       // Sensor driver
 
 /********************************************************************************************/
 


### PR DESCRIPTION
## Description:

The driver doesn't always detect a device as offline after it becomes faulty/disconnected.

This PR maintains a proper count of the number of sequential misses and subsequently excludes sensor data from the json output and web frontend. A restart will be required before the device can be re-detected (if the fault was intermittent).

**Related issue (if applicable):** closes: #19294 relates: #16985 

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
