### PR TITLE
ESP32: pass flashmode at build time to macro definition

### DIFF
--- a/pio-tools/add_c_flags.py
+++ b/pio-tools/add_c_flags.py
@@ -5,7 +5,3 @@ env.Append(CFLAGS=["-Wno-discarded-qualifiers", "-Wno-implicit-function-declarat
 
 # General options that are passed to the C++ compiler
 env.Append(CXXFLAGS=["-Wno-volatile"])
-
-# Pass flashmode at build time to macro
-tasmota_flash_mode = "-DCONFIG_TASMOTA_FLASHMODE_" + (env.BoardConfig().get("build.flash_mode", "dio")).upper()
-env.Append(CXXFLAGS=[tasmota_flash_mode])

--- a/pio-tools/add_c_flags.py
+++ b/pio-tools/add_c_flags.py
@@ -5,3 +5,7 @@ env.Append(CFLAGS=["-Wno-discarded-qualifiers", "-Wno-implicit-function-declarat
 
 # General options that are passed to the C++ compiler
 env.Append(CXXFLAGS=["-Wno-volatile"])
+
+# Pass flashmode at build time to macro
+tasmota_flash_mode = "-DCONFIG_TASMOTA_FLASHMODE_" + (env.BoardConfig().get("build.flash_mode", "dio")).upper()
+env.Append(CXXFLAGS=[tasmota_flash_mode])

--- a/pio-tools/pre_source_dir.py
+++ b/pio-tools/pre_source_dir.py
@@ -10,3 +10,8 @@ def FindInoNodes(env):
     )
 
 env.AddMethod(FindInoNodes)
+
+# Pass flashmode at build time to macro
+tasmota_flash_mode = "-DCONFIG_TASMOTA_FLASHMODE_" + (env.BoardConfig().get("build.flash_mode", "dio")).upper()
+env.Append(CXXFLAGS=[tasmota_flash_mode])
+print(tasmota_flash_mode)

--- a/tasmota/include/tasmota_globals.h
+++ b/tasmota/include/tasmota_globals.h
@@ -118,6 +118,24 @@ String EthernetMacAddress(void);
 /*-------------------------------------------------------------------------------------------*\
  * End ESP32 specific parameters
 \*-------------------------------------------------------------------------------------------*/
+
+/*-------------------------------------------------------------------------------------------*\
+ * ESP32 build time definitions
+\*-------------------------------------------------------------------------------------------*/
+
+// created in pio-tools/add_c_flags.py
+#if defined(CONFIG_TASMOTA_FLASHMODE_QIO)
+  #define D_TASMOTA_FLASHMODE "QIO"
+#elif defined(CONFIG_TASMOTA_FLASHMODE_QOUT)
+   #define D_TASMOTA_FLASHMODE "QOUT"
+#elif defined(CONFIG_TASMOTA_FLASHMODE_DIO)
+  #define D_TASMOTA_FLASHMODE "DIO"
+#elif defined(CONFIG_TASMOTA_FLASHMODE_DOUT)
+  #define D_TASMOTA_FLASHMODE "DOUT"
+#else
+#error "Please add missing flashmode definition in the lines above!" // could be upcoming octal modes
+#endif // value check of CONFIG_TASMOTA_FLASHMODE
+
 /*-------------------------------------------------------------------------------------------*\
  * Start ESP32-C32 specific parameters - disable features not present in ESP32-C3
 \*-------------------------------------------------------------------------------------------*/

--- a/tasmota/include/tasmota_globals.h
+++ b/tasmota/include/tasmota_globals.h
@@ -69,6 +69,23 @@ String EthernetMacAddress(void);
 
 #include "include/tasmota_configurations.h"            // Preconfigured configurations
 
+/*-------------------------------------------------------------------------------------------*\
+ * ESP8266 and ESP32 build time definitions
+\*-------------------------------------------------------------------------------------------*/
+
+// created in pio-tools/pre_source_dir.py
+#if defined(CONFIG_TASMOTA_FLASHMODE_QIO)
+  #define D_TASMOTA_FLASHMODE "QIO"
+#elif defined(CONFIG_TASMOTA_FLASHMODE_QOUT)
+   #define D_TASMOTA_FLASHMODE "QOUT"
+#elif defined(CONFIG_TASMOTA_FLASHMODE_DIO)
+  #define D_TASMOTA_FLASHMODE "DIO"
+#elif defined(CONFIG_TASMOTA_FLASHMODE_DOUT)
+  #define D_TASMOTA_FLASHMODE "DOUT"
+#else
+#error "Please add missing flashmode definition in the lines above!" // could be upcoming octal modes
+#endif // value check of CONFIG_TASMOTA_FLASHMODE
+
 /*********************************************************************************************\
  * ESP8266 specific parameters
 \*********************************************************************************************/
@@ -118,23 +135,6 @@ String EthernetMacAddress(void);
 /*-------------------------------------------------------------------------------------------*\
  * End ESP32 specific parameters
 \*-------------------------------------------------------------------------------------------*/
-
-/*-------------------------------------------------------------------------------------------*\
- * ESP32 build time definitions
-\*-------------------------------------------------------------------------------------------*/
-
-// created in pio-tools/add_c_flags.py
-#if defined(CONFIG_TASMOTA_FLASHMODE_QIO)
-  #define D_TASMOTA_FLASHMODE "QIO"
-#elif defined(CONFIG_TASMOTA_FLASHMODE_QOUT)
-   #define D_TASMOTA_FLASHMODE "QOUT"
-#elif defined(CONFIG_TASMOTA_FLASHMODE_DIO)
-  #define D_TASMOTA_FLASHMODE "DIO"
-#elif defined(CONFIG_TASMOTA_FLASHMODE_DOUT)
-  #define D_TASMOTA_FLASHMODE "DOUT"
-#else
-#error "Please add missing flashmode definition in the lines above!" // could be upcoming octal modes
-#endif // value check of CONFIG_TASMOTA_FLASHMODE
 
 /*-------------------------------------------------------------------------------------------*\
  * Start ESP32-C32 specific parameters - disable features not present in ESP32-C3

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -829,7 +829,7 @@ void CmndStatus(void)
 #endif  // ESP32
                           D_JSON_PROGRAMFLASHSIZE "\":%d,\"" D_JSON_FLASHSIZE "\":%d"
                           ",\"" D_JSON_FLASHCHIPID "\":\"%06X\""
-                          ",\"FlashFrequency\":%d,\"" D_JSON_FLASHMODE "\":\"%s\""),
+                          ",\"FlashFrequency\":%d,\"" D_JSON_FLASHMODE "\":\"" D_TASMOTA_FLASHMODE "\""),
                           ESP_getSketchSize()/1024, ESP_getFreeSketchSpace()/1024, ESP_getFreeHeap1024(),
 #ifdef ESP32
                           uxTaskGetStackHighWaterMark(nullptr) / 1024, ESP.getPsramSize()/1024, ESP.getFreePsram()/1024,
@@ -839,7 +839,7 @@ void CmndStatus(void)
                           ESP_getFlashChipSize()/1024, ESP.getFlashChipRealSize()/1024
 #endif // ESP8266
                           , ESP_getFlashChipId()
-                          , ESP.getFlashChipSpeed()/1000000, ESP_getFlashChipMode().c_str());
+                          , ESP.getFlashChipSpeed()/1000000);
     ResponseAppendFeatures();
     XsnsDriverState();
     ResponseAppend_P(PSTR(",\"Sensors\":"));

--- a/tasmota/tasmota_support/support_esp.ino
+++ b/tasmota/tasmota_support/support_esp.ino
@@ -1171,25 +1171,6 @@ float ESP_getFreeHeap1024(void) {
 }
 */
 
-const char kFlashModes[] PROGMEM = "QIO|QOUT|DIO|DOUT|Fast|Slow";
-/*
-typedef enum {
-    FM_QIO = 0x00,
-    FM_QOUT = 0x01,
-    FM_DIO = 0x02,
-    FM_DOUT = 0x03,
-    FM_FAST_READ = 0x04,
-    FM_SLOW_READ = 0x05,
-    FM_UNKNOWN = 0xff
-} FlashMode_t;
-*/
-String ESP_getFlashChipMode(void) {
-  uint32_t flash_mode = ESP.getFlashChipMode();
-  if (flash_mode > 5) { flash_mode = 3; }
-  char stemp[6];
-  return GetTextIndexed(stemp, sizeof(stemp), flash_mode, kFlashModes);
-}
-
 /*********************************************************************************************\
  * High entropy hardware random generator
  * Thanks to DigitalAlchemist

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -2465,7 +2465,7 @@ void HandleInformation(void)
 
   WSContentSend_P(PSTR("}1}2&nbsp;"));  // Empty line
   WSContentSend_P(PSTR("}1" D_ESP_CHIP_ID "}2%d (%s)"), ESP_getChipId(), GetDeviceHardwareRevision().c_str());
-  WSContentSend_P(PSTR("}1" D_FLASH_CHIP_ID "}20x%06X (%s)"), ESP_getFlashChipId(), ESP_getFlashChipMode().c_str());
+  WSContentSend_P(PSTR("}1" D_FLASH_CHIP_ID "}20x%06X (" D_TASMOTA_FLASHMODE ")"), ESP_getFlashChipId());
 #ifdef ESP32
   WSContentSend_P(PSTR("}1" D_FLASH_CHIP_SIZE "}2%d KB"), ESP.getFlashChipSize() / 1024);
   WSContentSend_P(PSTR("}1" D_PROGRAM_FLASH_SIZE "}2%d KB"), ESP_getFlashChipMagicSize() / 1024);


### PR DESCRIPTION
## Description:

This removes all run time computations as this value is known at build time.
The flash mode is taken from the build environment, passed as a build flag and converted to a string literal by the preprocessor.
Saves 200 bytes of flash on the ESP32, is faster at run time (not perceptible) and should be pretty future proof aka extensible.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
