### PR TITLE
fix OneWire for IDF5.1 and C2/C6

### DIFF
--- a/lib/lib_basic/OneWire-Stickbreaker/OneWire.h
+++ b/lib/lib_basic/OneWire-Stickbreaker/OneWire.h
@@ -159,7 +159,7 @@
 static inline __attribute__((always_inline))
 IO_REG_TYPE directRead(IO_REG_TYPE pin)
 {
-#if defined(__riscv) // C2, C3, C6 have less than 32 pins, so watch out for potential coming Cx with more than 32 pins
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C2 || CONFIG_IDF_TARGET_ESP32C6 // max. usable Pins are 23 for C6 (below flash pins)
     return (GPIO.in.val >> pin) & 0x1;
 #else // plain ESP32
     if ( pin < 32 )
@@ -174,7 +174,7 @@ IO_REG_TYPE directRead(IO_REG_TYPE pin)
 static inline __attribute__((always_inline))
 void directWriteLow(IO_REG_TYPE pin)
 {
-#if defined(__riscv)
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C2 || CONFIG_IDF_TARGET_ESP32C6
     GPIO.out_w1tc.val = ((uint32_t)1 << pin);
 #else // plain ESP32
     if ( pin < 32 )
@@ -187,7 +187,7 @@ void directWriteLow(IO_REG_TYPE pin)
 static inline __attribute__((always_inline))
 void directWriteHigh(IO_REG_TYPE pin)
 {
-#if defined(__riscv)
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C2 || CONFIG_IDF_TARGET_ESP32C6
     GPIO.out_w1ts.val = ((uint32_t)1 << pin);
 #else // plain ESP32
     if ( pin < 32 )
@@ -200,7 +200,7 @@ void directWriteHigh(IO_REG_TYPE pin)
 static inline __attribute__((always_inline))
 void directModeInput(IO_REG_TYPE pin)
 {
-#if defined(__riscv)
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C2 || CONFIG_IDF_TARGET_ESP32C6
     GPIO.enable_w1tc.val = ((uint32_t)1 << (pin));
 #else
     if ( digitalPinIsValid(pin) )
@@ -226,7 +226,7 @@ void directModeInput(IO_REG_TYPE pin)
 static inline __attribute__((always_inline))
 void directModeOutput(IO_REG_TYPE pin)
 {
-#if defined(__riscv)
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C2 || CONFIG_IDF_TARGET_ESP32C6
     GPIO.enable_w1ts.val = ((uint32_t)1 << (pin));
 #else
     if ( digitalPinIsValid(pin) && pin <= 33 ) // pins above 33 can be only inputs

--- a/lib/lib_basic/OneWire-Stickbreaker/OneWire.h
+++ b/lib/lib_basic/OneWire-Stickbreaker/OneWire.h
@@ -147,6 +147,9 @@
 
 #elif defined(ARDUINO_ARCH_ESP32)
 #include <driver/rtc_io.h>
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include "soc/gpio_periph.h"
+#endif // ESP_IDF_VERSION_MAJOR >= 5
 #define PIN_TO_BASEREG(pin)             (0)
 #define PIN_TO_BITMASK(pin)             (pin)
 #define IO_REG_TYPE uint32_t
@@ -156,7 +159,7 @@
 static inline __attribute__((always_inline))
 IO_REG_TYPE directRead(IO_REG_TYPE pin)
 {
-#if CONFIG_IDF_TARGET_ESP32C3
+#if defined(__riscv) // C2, C3, C6 have less than 32 pins, so watch out for potential coming Cx with more than 32 pins
     return (GPIO.in.val >> pin) & 0x1;
 #else // plain ESP32
     if ( pin < 32 )
@@ -171,7 +174,7 @@ IO_REG_TYPE directRead(IO_REG_TYPE pin)
 static inline __attribute__((always_inline))
 void directWriteLow(IO_REG_TYPE pin)
 {
-#if CONFIG_IDF_TARGET_ESP32C3
+#if defined(__riscv)
     GPIO.out_w1tc.val = ((uint32_t)1 << pin);
 #else // plain ESP32
     if ( pin < 32 )
@@ -184,7 +187,7 @@ void directWriteLow(IO_REG_TYPE pin)
 static inline __attribute__((always_inline))
 void directWriteHigh(IO_REG_TYPE pin)
 {
-#if CONFIG_IDF_TARGET_ESP32C3
+#if defined(__riscv)
     GPIO.out_w1ts.val = ((uint32_t)1 << pin);
 #else // plain ESP32
     if ( pin < 32 )
@@ -197,7 +200,7 @@ void directWriteHigh(IO_REG_TYPE pin)
 static inline __attribute__((always_inline))
 void directModeInput(IO_REG_TYPE pin)
 {
-#if CONFIG_IDF_TARGET_ESP32C3
+#if defined(__riscv)
     GPIO.enable_w1tc.val = ((uint32_t)1 << (pin));
 #else
     if ( digitalPinIsValid(pin) )
@@ -223,7 +226,7 @@ void directModeInput(IO_REG_TYPE pin)
 static inline __attribute__((always_inline))
 void directModeOutput(IO_REG_TYPE pin)
 {
-#if CONFIG_IDF_TARGET_ESP32C3
+#if defined(__riscv)
     GPIO.enable_w1ts.val = ((uint32_t)1 << (pin));
 #else
     if ( digitalPinIsValid(pin) && pin <= 33 ) // pins above 33 can be only inputs

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -54,7 +54,6 @@ lib_ignore              =
                           ESP Mail Client
                           IRremoteESP8266
                           NeoPixelBus
-                          OneWire
                           MFRC522
                           universal display Library
                           ESP8266Audio
@@ -75,7 +74,6 @@ lib_ignore              =
                           ESP Mail Client
                           IRremoteESP8266
                           NeoPixelBus
-                          OneWire
                           MFRC522
                           universal display Library
                           ESP8266Audio


### PR DESCRIPTION
## Description:

Besides a new `include` the common difference is XTENSA vs RISCV.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
