### PR TITLE
Updated ESP32 Arduino Core 2.0.11

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -42,28 +42,28 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
                               post:pio-tools/post_esp32.py
                               ${esp_defaults.extra_scripts}
 
+[safeboot_flags]
+lib_ignore                  = ESP Mail Client
+                              IRremoteESP8266
+                              NeoPixelBus
+                              OneWire
+                              MFRC522
+                              universal display Library
+                              ESP8266Audio
+                              ESP8266SAM
+                              FFat
+                              Berry
+                              Berry mapping to C
+                              Berry Tasmota mapping
+                              Berry int64 implementation for 32 bits architecture
+                              Berry Matter protocol implementation
+                              Micro-RTSP
+                              re1.5
+                              DHT sensor library
+                              ccronexpr
+
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.07.00/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.08.00/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
-
-[safeboot_flags]
-lib_ignore              =   ESP Mail Client
-                            IRremoteESP8266
-                            NeoPixelBus
-                            OneWire
-                            MFRC522
-                            universal display Library
-                            ESP8266Audio
-                            ESP8266SAM
-                            FFat
-                            Berry
-                            Berry mapping to C
-                            Berry Tasmota mapping
-                            Berry int64 implementation for 32 bits architecture
-                            Berry Matter protocol implementation
-                            Micro-RTSP
-                            re1.5
-                            DHT sensor library
-                            ccronexpr


### PR DESCRIPTION
## Description:

Changed IDF sdkconfig settings to reduce flash and RAM size usage. This is mainly achieved by deactivating not in Tasmota used cryptography protocols.

Thx @Staars for solving the gordian knot how to enable only specific crypto stuff.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
