### PR TITLE
Adds rule variable power<x> and switch<x>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .cache
 data
 unpacked_fs
+unpacked_boards
 tasmota/user_config_override.h
 build
 build_output/*

--- a/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
@@ -823,6 +823,15 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
       RulesVarReplace(commands, F("%ZBENDPOINT%"), String(Z_GetLastEndpoint()));
 #endif
 
+      for (uint32_t i = 0; i < MAX_RELAYS; i++) {
+        snprintf_P(stemp, sizeof(stemp), PSTR("%%POWER%d%%"), i +1);
+        RulesVarReplace(commands, stemp, String(bitRead(TasmotaGlobal.power, i)));
+      }
+      for (uint32_t i = 0; i < MAX_SWITCHES_SET; i++) {
+        snprintf_P(stemp, sizeof(stemp), PSTR("%%SWITCH%d%%"), i +1);
+        RulesVarReplace(commands, stemp, String(SwitchState(i)));
+      }
+
       char command[commands.length() +1];
       strlcpy(command, commands.c_str(), sizeof(command));
 


### PR DESCRIPTION
## Description:

Adds rule variable power<x> and switch<x>

The variables can be used to query or use logic operation of the current status of the inputs and outputs. For example, in a 3-sockets with USB output, the USB output can be switched on when one of the sockets is switched on:

```
rule1 on power1#state do event usbpower endon on power2#state do event usbpower endon on power3#state do event usbpower endon
rule2 on event#usbpower do if ( %power1%==1 or %power2%==1 or %power3%==1 ) power4 1 else power4 0 endif endon
```

or if you want to send a message when the inputs have a defined status:

`rule3 on event#test do if ( %switch1%==1 and %switch2%==0 and %switch3%==1 ) publish stat/foo/bar hello endif endon`

To use the examples the feature #define USE_EXPRESSION and #define SUPPORT_IF_STATEMENT must compiled in.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
