### PR TITLE
Display invert setting after tasmota start in uDisplay driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .cache
 data
 unpacked_fs
+unpacked_boards
 tasmota/user_config_override.h
 build
 build_output/*

--- a/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
@@ -823,6 +823,15 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
       RulesVarReplace(commands, F("%ZBENDPOINT%"), String(Z_GetLastEndpoint()));
 #endif
 
+      for (uint32_t i = 0; i < MAX_RELAYS; i++) {
+        snprintf_P(stemp, sizeof(stemp), PSTR("%%POWER%d%%"), i +1);
+        RulesVarReplace(commands, stemp, String(bitRead(TasmotaGlobal.power, i)));
+      }
+      for (uint32_t i = 0; i < MAX_SWITCHES_SET; i++) {
+        snprintf_P(stemp, sizeof(stemp), PSTR("%%SWITCH%d%%"), i +1);
+        RulesVarReplace(commands, stemp, String(SwitchState(i)));
+      }
+
       char command[commands.length() +1];
       strlcpy(command, commands.c_str(), sizeof(command));
 

--- a/tasmota/tasmota_xdsp_display/xdsp_17_universal.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_17_universal.ino
@@ -454,6 +454,16 @@ int8_t cs;
     Settings->display_width = renderer->width();
     Settings->display_height = renderer->height();
 
+    bool iniinv = Settings->display_options.invert;
+
+    cp = strstr(ddesc, ":n,");
+    if (cp) {
+      cp+=3;
+      iniinv = strtol(cp, &cp, 10);
+      Settings->display_options.invert = iniinv;
+    }
+    renderer->invertDisplay(iniinv);
+
     ApplyDisplayDimmer();
 
 #ifdef SHOW_SPLASH


### PR DESCRIPTION
## Description:

Display invert setting after tasmota start in uDisplay driver


In uDisplay Driver "Display invert" is fix set to false in DisplayInit() function.

After tasmota is started display invert is every time off. The display command shows '... "Invert":1 ...' but it is off. In display discriptor file initial register (:I) is register for invert set on but invert on display is off. The DisplayInit() function overwrite this.

With this fix the user can define the display invert status after start in two ways.

- Console command "displayinvert 1", the value is store persistent

or

- With the discriptor element in "display.ini" discriptor file

:n,X Defines optional display invert X=0 or 1

The discriptor element is optional and if exist overwrites the persistent "displayinvert" value.

I tested it with an ST7789, ILI9341 and GC9A01 display.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
