### PR TITLE
ignore esp-nimble-cpp lib with core 2.0.11

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -25,6 +25,7 @@ lib_ignore              =
                           ESP32 Azure IoT Arduino
                           ESP32 Async UDP
                           ESP32 BLE Arduino
+                          esp-nimble-cpp
                           SimpleBLE
                           NetBIOS
                           ESP32


### PR DESCRIPTION
to avoid possible conflicts and unneeded compile. The lib `esp-nimble-cpp` is currently only used with Core 3.0.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
