### PR TITLE
prepare transition to esp-nimble-cpp

### DIFF
--- a/lib/libesp32_div/NimBLE-Arduino/src/nimconfig.h
+++ b/lib/libesp32_div/NimBLE-Arduino/src/nimconfig.h
@@ -149,6 +149,12 @@
  End Arduino user-config
 **********************************/
 
+#ifndef CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE
+#define CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE 4096
+#endif
+
+#ifndef CONFIG_BT_NIMBLE_ROLE_CENTRAL // means for Tasmota: nimble was already embedded into the Arduino framework
+
 /* This section should not be altered */
 #ifndef CONFIG_BT_NIMBLE_ROLE_CENTRAL_DISABLED
 #define CONFIG_BT_NIMBLE_ROLE_CENTRAL
@@ -168,10 +174,6 @@
 
 #ifndef CONFIG_BT_NIMBLE_PINNED_TO_CORE
 #define CONFIG_BT_NIMBLE_PINNED_TO_CORE 0
-#endif
-
-#ifndef CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE
-#define CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE 4096
 #endif
 
 #ifndef CONFIG_BT_NIMBLE_MEM_ALLOC_MODE_EXTERNAL
@@ -324,9 +326,12 @@
 #define CONFIG_BT_NIMBLE_ROLE_BROADCASTER
 #endif
 
+#endif //CONFIG_BT_NIMBLE_ROLE_CENTRAL
+
 /* Enables the use of Arduino String class for attribute values */
 #if defined __has_include
 #  if __has_include (<Arduino.h>)
 #    define NIMBLE_CPP_ARDUINO_STRING_AVAILABLE
 #  endif
 #endif
+


### PR DESCRIPTION
## Description:

This change will help to do a smooth and silent transition from `NimBLE-Arduino` to `esp-nimble-cpp`.
It allows to compile Tasmota builds with any of the BLE drivers with Arduino frameworks that include or do not include the nimble BLE stack without warnings.
No code changes to the resulting firmware binaries.

Note:  `esp-nimble-cpp` will be needed for all newer chips like C2 and C6 due to changes in the ESP-IDF. 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
