### PR TITLE
do not use NimBLE-Arduino for Mi32-legacy

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -86,6 +86,7 @@ lib_ignore                  = ESP8266Audio
                               TTGO TWatch Library
                               Micro-RTSP
                               epdiy
+                              NimBLE-Arduino
 
 [env:tasmota32c3-mi32-homebridge]
 extends                     = env:tasmota32c3
@@ -100,6 +101,7 @@ lib_ignore                  = ESP8266Audio
                               TTGO TWatch Library
                               Micro-RTSP
                               epdiy
+                              NimBLE-Arduino
 
 [env:tasmota32s3-mi32-homebridge]
 extends                     = env:tasmota32s3
@@ -114,6 +116,7 @@ lib_ignore                  = ESP8266Audio
                               TTGO TWatch Library
                               Micro-RTSP
                               epdiy
+                              NimBLE-Arduino
 
 ; *** Debug version used for PlatformIO Home Project Inspection
 [env:tasmota-debug]


### PR DESCRIPTION
## Description:

Switch from NimBLE-Arduino to esp-nimble-cpp in demo environments and thus fix compilation.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
