### PR TITLE
Arduino.3.0: enable Audio libs compile by disabling incompatible I2S driver

### DIFF
--- a/lib/lib_audio/ESP8266Audio/src/AudioOutputI2S.cpp
+++ b/lib/lib_audio/ESP8266Audio/src/AudioOutputI2S.cpp
@@ -375,4 +375,4 @@ bool AudioOutputI2S::stop()
   i2sOn = false;
   return true;
 }
-#endif  // ARDUINO_ESP8266_MAJOR > 4
+#endif  // TODO Arduino 3.0 Port I2S

--- a/lib/lib_audio/ESP8266Audio/src/AudioOutputI2S.cpp
+++ b/lib/lib_audio/ESP8266Audio/src/AudioOutputI2S.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <Arduino.h>
+#if ESP_IDF_VERSION_MAJOR < 5   // TODO Arduino 3.0 Port I2S
 #ifdef ESP32
   #include "driver/i2s.h"
 #elif defined(ARDUINO_ARCH_RP2040) || ARDUINO_ESP8266_MAJOR >= 3
@@ -374,3 +375,4 @@ bool AudioOutputI2S::stop()
   i2sOn = false;
   return true;
 }
+#endif  // ARDUINO_ESP8266_MAJOR > 4

--- a/lib/lib_audio/ESP8266Audio/src/AudioOutputI2SNoDAC.cpp
+++ b/lib/lib_audio/ESP8266Audio/src/AudioOutputI2SNoDAC.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <Arduino.h>
+#if ESP_IDF_VERSION_MAJOR < 5   // TODO Arduino 3.0 Port I2S
 #ifdef ESP32
   #include "driver/i2s.h"
 #elif defined(ARDUINO_ARCH_RP2040) || ARDUINO_ESP8266_MAJOR >= 3
@@ -119,3 +120,4 @@ bool AudioOutputI2SNoDAC::ConsumeSample(int16_t sample[2])
 #endif
   return true;
 }
+#endif  // ESP_IDF_VERSION_MAJOR < 5   // TODO Arduino 3.0 Port I2S

--- a/lib/lib_audio/ESP8266Audio/src/AudioOutputSPDIF.cpp
+++ b/lib/lib_audio/ESP8266Audio/src/AudioOutputSPDIF.cpp
@@ -37,9 +37,11 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #if defined(ESP32) || defined(ESP8266)
 
 #include <Arduino.h>
+#if ESP_IDF_VERSION_MAJOR < 5   // TODO Arduino 3.0 Port I2S
 #if defined(ESP32)
   #include "driver/i2s.h"
   #include "soc/rtc.h"
@@ -293,3 +295,4 @@ bool AudioOutputSPDIF::stop()
 }
 
 #endif
+#endif  // ESP_IDF_VERSION_MAJOR < 5   // TODO Arduino 3.0 Port I2S

--- a/lib/lib_audio/ESP8266Audio/src/AudioOutputULP.cpp
+++ b/lib/lib_audio/ESP8266Audio/src/AudioOutputULP.cpp
@@ -18,6 +18,9 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <Arduino.h>
+#if ESP_IDF_VERSION_MAJOR < 5   // TODO Arduino 3.0 Port I2S
+
 #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
 
 #include "AudioOutputULP.h"
@@ -260,3 +263,4 @@ bool AudioOutputULP::stop()
 }
 
 #endif
+#endif  // ESP_IDF_VERSION_MAJOR < 5   // TODO Arduino 3.0 Port I2S

--- a/platformio_tasmota_core3_env_sample.ini
+++ b/platformio_tasmota_core3_env_sample.ini
@@ -23,7 +23,7 @@
 
 [core32_30]
 platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF5
-platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/1511/framework-arduinoespressif32-release_v5.1-90b05eff62.zip
+platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/1532/framework-arduinoespressif32-release_v5.1-303acc246e.zip
 build_unflags           = ${core32.build_unflags}
 build_flags             = ${core32.build_flags}
 
@@ -31,7 +31,7 @@ build_flags             = ${core32.build_flags}
 build_unflags           = ${core32_30.build_unflags}
                           -DUSE_IPV6
 build_flags             = ${core32_30.build_flags}
-lib_extra_dirs          = lib/lib_ssl, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_display, lib/lib_rf, lib/libesp32, lib/libesp32_div, lib/libesp32_lvgl
+lib_extra_dirs          = lib/lib_ssl, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_audio, lib/lib_display, lib/lib_rf, lib/libesp32, lib/libesp32_div, lib/libesp32_lvgl
 lib_ignore              =
                           HTTPUpdateServer
                           USB
@@ -43,8 +43,6 @@ lib_ignore              =
                           ArduinoOTA
                           ESP Mail Client
                           IRremoteESP8266
-                          ESP8266Audio
-                          ESP8266SAM
                           ESP32-HomeKit
                           NimBLE-Arduino
 

--- a/platformio_tasmota_core3_env_sample.ini
+++ b/platformio_tasmota_core3_env_sample.ini
@@ -80,7 +80,6 @@ lib_ignore              = ${env:arduino30.lib_ignore}
 extends                 = env:arduino30
 board                   = esp32-fix
 board_build.f_cpu       = 240000000L
-upload_port             = /dev/cu.SLAB_USBtoUART
 build_unflags           = ${env:arduino30.build_unflags}
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30


### PR DESCRIPTION
## Description:

removed lib_ignore for Audio libs 

- disabled in lib `ESP8266Audio` driver parts (for Arduino 3.0) using I2S to fix compile. Needs port of I2S to new API
- no change in lib `ESP8266` needed. Function NOT tested.

- updated Arduino core to Tasmota internal build No. 1532

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
