### PR TITLE
Fix crash of uDisplay on  ESP32S3 with IDF5.1

### DIFF
--- a/lib/lib_display/UDisplay/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/uDisplay.cpp
@@ -959,9 +959,16 @@ Renderer *uDisplay::Init(void) {
     uint16_t color = random(0xffff);
     ESP_ERROR_CHECK(_panel_handle->draw_bitmap(_panel_handle, 0, 0, 1, 1, &color));
 
+#if ESP_IDF_VERSION_MAJOR < 5
     _rgb_panel = __containerof(_panel_handle, esp_rgb_panel_t, base);
-
     rgb_fb = (uint16_t *)_rgb_panel->fb;
+#else
+    void * buf = NULL;
+    esp_lcd_rgb_panel_get_frame_buffer(_panel_handle, 1, &buf);
+    rgb_fb = (uint16_t *)buf;
+#endif
+
+
 
 #endif // USE_ESP32_S3
   }
@@ -1036,7 +1043,9 @@ Renderer *uDisplay::Init(void) {
 
     esp_lcd_new_i80_bus(&bus_config, &_i80_bus);
 
+#if ESP_IDF_VERSION_MAJOR < 5
     _dma_chan = _i80_bus->dma_chan;
+#endif
 
     uint32_t div_a, div_b, div_n, clkcnt;
     calcClockDiv(&div_a, &div_b, &div_n, &clkcnt, 240*1000*1000, spi_speed*1000000);

--- a/lib/lib_display/UDisplay/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/uDisplay.cpp
@@ -945,7 +945,11 @@ Renderer *uDisplay::Init(void) {
     _panel_config->disp_gpio_num = GPIO_NUM_NC;
 
     _panel_config->flags.disp_active_low = 0;
+#if ESP_IDF_VERSION_MAJOR >= 5
+    _panel_config->flags.refresh_on_demand = 0;
+#else
     _panel_config->flags.relax_on_idle = 0;
+#endif // ESP_IDF_VERSION_MAJOR >= 5
     _panel_config->flags.fb_in_psram = 1;             // allocate frame buffer in PSRAM
 
     ESP_ERROR_CHECK(esp_lcd_new_rgb_panel(_panel_config, &_panel_handle));
@@ -1037,7 +1041,7 @@ Renderer *uDisplay::Init(void) {
     uint32_t div_a, div_b, div_n, clkcnt;
     calcClockDiv(&div_a, &div_b, &div_n, &clkcnt, 240*1000*1000, spi_speed*1000000);
     lcd_cam_lcd_clock_reg_t lcd_clock;
-    lcd_clock.lcd_clkcnt_n = std::max(1u, clkcnt - 1);
+    lcd_clock.lcd_clkcnt_n = std::max((uint32_t)1u, clkcnt - 1); // ESP_IDF_VERSION_MAJOR >= 5
     lcd_clock.lcd_clk_equ_sysclk = (clkcnt == 1);
     lcd_clock.lcd_ck_idle_edge = true;
     lcd_clock.lcd_ck_out_edge = false;

--- a/lib/lib_display/UDisplay/uDisplay.h
+++ b/lib/lib_display/UDisplay/uDisplay.h
@@ -116,7 +116,7 @@ enum uColorType { uCOLOR_BW, uCOLOR_COLOR };
 #define SPI_DC_HIGH if (spi_dc >= 0) GPIO_SET_SLOW(spi_dc);
 
 
-#ifdef USE_ESP32_S3
+#if defined(USE_ESP32_S3) && ESP_IDF_VERSION_MAJOR < 5
 struct esp_lcd_i80_bus_t {
     int bus_id;            // Bus ID, index from 0
     portMUX_TYPE spinlock; // spinlock used to protect i80 bus members(hal, device_list, cur_trans)
@@ -149,9 +149,7 @@ struct esp_rgb_panel_t
   size_t resolution_hz;                                        // Peripheral clock resolution
   esp_lcd_rgb_timing_t timings;                                // RGB timing parameters (e.g. pclk, sync pulse, porch width)
   gdma_channel_handle_t dma_chan;                              // DMA channel handle
-#if ESP_IDF_VERSION_MAJOR < 5
   esp_lcd_rgb_panel_frame_trans_done_cb_t on_frame_trans_done; // Callback, invoked after frame trans done
-#endif // ESP_IDF_VERSION_MAJOR < 5
   void *user_ctx;                                              // Reserved user's data of callback functions
   int x_gap;                                                   // Extra gap in x coordinate, it's used when calculate the flush window
   int y_gap;                                                   // Extra gap in y coordinate, it's used when calculate the flush window
@@ -163,8 +161,7 @@ struct esp_rgb_panel_t
   } flags;
   dma_descriptor_t dma_nodes[]; // DMA descriptor pool of size `num_dma_nodes`
 };
-
-#endif
+#endif //USE_ESP32_S3 && ESP_IDF_VERSION_MAJOR < 5
 
 
 class uDisplay : public Renderer {
@@ -360,7 +357,9 @@ class uDisplay : public Renderer {
    uint16_t pclk_active_neg;
 
    esp_lcd_panel_handle_t _panel_handle = NULL;
+#if ESP_IDF_VERSION_MAJOR < 5
    esp_rgb_panel_t *_rgb_panel;
+#endif //ESP_IDF_VERSION_MAJOR < 5
    uint16_t *rgb_fb;
 
 

--- a/lib/lib_display/UDisplay/uDisplay.h
+++ b/lib/lib_display/UDisplay/uDisplay.h
@@ -13,6 +13,7 @@
 #include "driver/spi_master.h"
 #if ESP_IDF_VERSION_MAJOR >= 5
 #include "soc/gpio_periph.h"
+#include <rom/gpio.h>
 #endif // ESP_IDF_VERSION_MAJOR >= 5
 #endif
 
@@ -36,6 +37,9 @@ static inline void gpio_lo(int_fast8_t pin) { if (pin >= 0) *get_gpio_lo_reg(pin
 #include "esp_lcd_panel_ops.h"
 #include <hal/dma_types.h>
 #include <rom/cache.h>
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include "esp_rom_lldesc.h"
+#endif // ESP_IDF_VERSION_MAJOR >= 5
 #endif // USE_ESP32_S3
 
 #define _UDSP_I2C 1
@@ -145,7 +149,9 @@ struct esp_rgb_panel_t
   size_t resolution_hz;                                        // Peripheral clock resolution
   esp_lcd_rgb_timing_t timings;                                // RGB timing parameters (e.g. pclk, sync pulse, porch width)
   gdma_channel_handle_t dma_chan;                              // DMA channel handle
+#if ESP_IDF_VERSION_MAJOR < 5
   esp_lcd_rgb_panel_frame_trans_done_cb_t on_frame_trans_done; // Callback, invoked after frame trans done
+#endif // ESP_IDF_VERSION_MAJOR < 5
   void *user_ctx;                                              // Reserved user's data of callback functions
   int x_gap;                                                   // Extra gap in x coordinate, it's used when calculate the flush window
   int y_gap;                                                   // Extra gap in y coordinate, it's used when calculate the flush window


### PR DESCRIPTION
## Description:

Tested with an S3-Eye on Arduino 2.11 and 3.0 with LVGL build.
Uses new API when using IDF5.1, which reduces source code size for the Arduino 3.0 build (more things are out commented by undefines for it).

Removes the crash of the former version. Config glitches might occur and need more investigation. It is WIP.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
