### PR TITLE
Fix crash in IRHVAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Shutter invert (#19341, #19374)
 - Teleinfo power (#19381)
+- Fix crash in IRHVAC
 
 ### Removed
 

--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -123,7 +123,7 @@
 #define D_JSON_MODEL "Model"
 #define D_JSON_MOISTURE "Moisture"
 #define D_JSON_MQTT_COUNT "MqttCount"
-#define D_JSON_NA "n/a"
+#define D_JSON_NULL "null"
 #define D_JSON_NO "No"
 #define D_JSON_NOISE "Noise"
 #define D_JSON_NONE "None"

--- a/tasmota/tasmota_xdrv_driver/xdrv_05_irremote_full.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_05_irremote_full.ino
@@ -227,7 +227,7 @@ namespace {
   void addFloatToJson(JsonGeneratorObject& json, const char* key, float value, float noValueConstant = NAN) {
     if (!isnan(noValueConstant) && value == noValueConstant) {
       //The "no sensor value" may not be straightforward (e.g.-100.0), hence replacing with explicit n/a
-      json.add(key, PSTR(D_JSON_NA));
+      json.addStrRaw(key, PSTR(D_JSON_NULL));
       return;
     }
     char s[6];  // Range: -99.9 <> 999.9 should be fine for any sensible temperature value :)


### PR DESCRIPTION
## Description:

Fix crash in IRHVAC.

The bug was far fetched. It is actually an old bug when trying to report a NaN value in a JSON. But this never happened before #18310. Now NaN are reported as `null` since `NaN` is not a valid JSON value.

```
IRHVAC {"Vendor":"LG", "Power":"On","Mode":"Hot","FanSpeed":3,"Temp":22.5}
09:01:48.655 CMD: IRHVAC {"Vendor":"LG", "Power":"On","Mode":"Hot","FanSpeed":3,"Temp":22.5}
09:01:48.775 RSL: RESULT = {"IRHVAC":{"Vendor":"LG","Model":-1,"Command":"Control","Mode":"Auto","Power":"On","Celsius":"On","Temp":22.5,"FanSpeed":"Medium","SwingV":"Off","SwingH":"Off","Quiet":"Off","Turbo":"Off","Econo":"Off","Light":"Off","Filter":"Off","Clean":"Off","Beep":"Off","Sleep":-1,"iFeel":"Off","SensorTemp":null}}
```

**Related issue (if applicable):** fixes #19387

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
