### PR TITLE
EnergyMargins - always send MQTT telemetry message

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_03_energy.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_03_energy.ino
@@ -564,7 +564,7 @@ void EnergyMarginCheck(void) {
   if (jsonflg) {
     ResponseJsonEndEnd();
     MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR(D_RSLT_MARGINS), MQTT_TELE_RETAIN);
-//    EnergyMqttShow();
+    EnergyMqttShow();
     Energy->margin_stable = 3;  // Allow 2 seconds to stabilize before reporting
   }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_03_esp32_energy.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_03_esp32_energy.ino
@@ -787,7 +787,7 @@ void EnergyMarginCheck(void) {
   if (jsonflg) {
     ResponseJsonEndEnd();
     MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR(D_RSLT_MARGINS), MQTT_TELE_RETAIN);
-//    EnergyMqttShow();
+    EnergyMqttShow();
     Energy->margin_stable = 3;  // Allow 2 seconds to stabilize before reporting
   }
 


### PR DESCRIPTION
## Description:

The issue https://github.com/arendst/Tasmota/issues/17751 was solved with the commit https://github.com/arendst/Tasmota/commit/86979646fff377a0acfdd88b1c7e1d202f97a5a6. This causes the behavior, which is discussed here https://github.com/arendst/Tasmota/discussions/19386.

This PR solves both problems:
- A MQTT message is send immediately when a margin fires.
- Additionally a message is send after 2 seconds when the energy reading is stable.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).