### PR TITLE
Fix xdrv_122_file_settings_demo buffer overflow

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_122_file_settings_demo.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_122_file_settings_demo.ino
@@ -48,7 +48,7 @@ struct {
   uint32_t  crc32;    // To detect file changes
   uint16_t  version;  // To detect driver function changes
   uint16_t  spare;
-  char      drv_text[DRV_DEMO_MAX_DRV_TEXT -1][10];
+  char      drv_text[DRV_DEMO_MAX_DRV_TEXT][10];
 } DrvDemoSettings;
 
 // Global structure containing driver non-saved variables


### PR DESCRIPTION
## Description:

Fix DrvText16 buffer overflow

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
