### PR TITLE
Don't reset the MAX17043 battery fuel gauge after waking from Deep Sleep

### DIFF
--- a/tasmota/include/tasmota.h
+++ b/tasmota/include/tasmota.h
@@ -515,10 +515,10 @@ enum DevGroupShareItem { DGR_SHARE_POWER = 1, DGR_SHARE_LIGHT_BRI = 2, DGR_SHARE
 
 enum CommandSource { SRC_IGNORE, SRC_MQTT, SRC_RESTART, SRC_BUTTON, SRC_SWITCH, SRC_BACKLOG, SRC_SERIAL, SRC_WEBGUI, SRC_WEBCOMMAND, SRC_WEBCONSOLE, SRC_PULSETIMER,
                      SRC_TIMER, SRC_RULE, SRC_MAXPOWER, SRC_MAXENERGY, SRC_OVERTEMP, SRC_LIGHT, SRC_KNX, SRC_DISPLAY, SRC_WEMO, SRC_HUE, SRC_RETRY, SRC_REMOTE, SRC_SHUTTER,
-                     SRC_THERMOSTAT, SRC_CHAT, SRC_TCL, SRC_BERRY, SRC_FILE, SRC_SSERIAL, SRC_USBCONSOLE, SRC_SO47, SRC_MAX };
+                     SRC_THERMOSTAT, SRC_CHAT, SRC_TCL, SRC_BERRY, SRC_FILE, SRC_SSERIAL, SRC_USBCONSOLE, SRC_SO47, SRC_SENSOR, SRC_MAX };
 const char kCommandSource[] PROGMEM = "I|MQTT|Restart|Button|Switch|Backlog|Serial|WebGui|WebCommand|WebConsole|PulseTimer|"
                                       "Timer|Rule|MaxPower|MaxEnergy|Overtemp|Light|Knx|Display|Wemo|Hue|Retry|Remote|Shutter|"
-                                      "Thermostat|Chat|TCL|Berry|File|SSerial|UsbConsole|SO47";
+                                      "Thermostat|Chat|TCL|Berry|File|SSerial|UsbConsole|SO47|Sensor";
 
 const uint8_t kDefaultRfCode[9] PROGMEM = { 0x21, 0x16, 0x01, 0x0E, 0x03, 0x48, 0x2E, 0x1A, 0x00 };
 

--- a/tasmota/tasmota_xsns_sensor/xsns_110_max17043.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_110_max17043.ino
@@ -70,9 +70,9 @@ void Max17043Init(void) {
       // or our setting if power was maintained
       if (I2cRead16(MAX17043_ADDRESS, MAX17043_CONFIG) == MAX17043_CONFIG_NO_COMPENSATION
           || I2cRead16(MAX17043_ADDRESS, MAX17043_CONFIG) == MAX17043_CONFIG_POWER_UP_DEFAULT) {
-        AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("SNS: Waking from deep sleep - skipping MAX17043 Power on Reset & Quick Start"));
         max17043 = true;
         I2cSetActiveFound(MAX17043_ADDRESS, "MAX17043");
+        AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("SNS: Waking from deep sleep - skipping MAX17043 Power on Reset & Quick Start"));
       }
     } else {
       // otherwise perform a full Power on Reset (which is the same as disconnecting power)

--- a/tasmota/tasmota_xsns_sensor/xsns_110_max17043.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_110_max17043.ino
@@ -66,11 +66,11 @@ void Max17043Init(void) {
       // if the hardware design doesn't (to conserve battery) then we lose some of
       // the benefits of the device anyway as it'll be re-learning from scratch every DeepSleepTime seconds.
  
-      AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("SNS: Waking from deep sleep - skipping MAX17043 Power on Reset & Quick Start"));
       // to confirm this is a MAX17043 - check for both the default (if the MAX17043 did lose it's power)
       // or our setting if power was maintained
       if (I2cRead16(MAX17043_ADDRESS, MAX17043_CONFIG) == MAX17043_CONFIG_NO_COMPENSATION
           || I2cRead16(MAX17043_ADDRESS, MAX17043_CONFIG) == MAX17043_CONFIG_POWER_UP_DEFAULT) {
+        AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("SNS: Waking from deep sleep - skipping MAX17043 Power on Reset & Quick Start"));
         max17043 = true;
         I2cSetActiveFound(MAX17043_ADDRESS, "MAX17043");
       }


### PR DESCRIPTION
## Description:

The Analog Devices MAX17043 is designed to continually monitor battery voltage over time and using dynamic algorithms present a much more accurate battery percentage remaining value to the system. In reality, almost all such systems would use deep sleep to conserve battery power (waking for, say, 10 seconds every 10 minutes).

However, the current driver resets the chip on every boot resulting in its internal algorithm having to start again from scratch. It will eventually converge on a decent number but this is made much more difficult (or even impossible) if it's reset on every reboot. I have noted inconsistent spikes in percentage after a reboot.

This PR detects if waking from deep sleep and skips the MAX17043 `Power on Reset` and `Quick Start` device commands.

Note that this assumes the hardware has been designed so the MAX17043 remains powered up when the ESP deep sleeps. There is little point in using this device in another way if you want accurate convergence on remaining charge.

**NOTE:** @arendst I did consider adding code to issue the Tasmota `BatteryPercentage` command but all the existing code seems to be defined in Zigbee specific sources files eg `D_CMND_ZIGBEE_BATTPERCENT`. I'm happy to do this if maintainers are ok this is the right approach. Personally, this feels right as it would be automatically added to the state json payload.

- fix: don't reset or quick start the device when coming out of deep sleep
- add: update global battery percentage when max17043 reports new value
- chore: refactor command and config values as define directives
- chore: refactor percentage symbol to use Tasmota define directive

**Related issue (if applicable):** fixes #N/A

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
