### PR TITLE
Fix Ethernet driver for expected changes in Arduino 30

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
@@ -215,7 +215,11 @@ void EthernetInit(void) {
 //  }
 //  delay(1);
 //#endif // CONFIG_IDF_TARGET_ESP32
+#if ESP_IDF_VERSION_MAJOR >= 5
+  if (!ETH.begin( (eth_phy_type_t)Settings->eth_type, Settings->eth_address, eth_mdc, eth_mdio, eth_power, (eth_clock_mode_t)Settings->eth_clk_mode)) {
+#else
   if (!ETH.begin(Settings->eth_address, eth_power, eth_mdc, eth_mdio, (eth_phy_type_t)Settings->eth_type, (eth_clock_mode_t)Settings->eth_clk_mode)) {
+#endif
     AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_ETH "Bad PHY type or init error"));
     return;
   };


### PR DESCRIPTION
## Description:

There is a (tiny) API  change in a code change, that we expect to get merged in Arduino 3 soon. We will include this change in Tasmotas Arduino framework very soon and thus the esp32-ethernet-driver needs a small update.
No changes for Arduino 2.x builds.
Needs our Arduino 3.0 framework with Tag 1557 or later, which is ensured using

`platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF5`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
