### PR TITLE
Revert "build safeboot bin for C2/C6"

### DIFF
--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -90,9 +90,6 @@ jobs:
           - tasmota32s2cdc-safeboot
           - tasmota32s3-safeboot
           - tasmota32s3cdc-safeboot
-          - tasmota32c2-safeboot
-          - tasmota32c6-safeboot
-          - tasmota32c6cdc-safeboot
     steps:
       - uses: actions/checkout@v3
         with:
@@ -105,7 +102,6 @@ jobs:
         run: |
           pip install wheel
           pip install -U platformio
-          cp ./platformio_tasmota_core3_env_sample.ini ./platformio_tasmota_core3_env.ini
       - name: Run PlatformIO
         run: platformio run -e ${{ matrix.variant }}
       - name: Upload safeboot firmware artifacts

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -29,9 +29,6 @@ jobs:
           - tasmota32s2cdc-safeboot
           - tasmota32s3-safeboot
           - tasmota32s3cdc-safeboot
-          - tasmota32c2-safeboot
-          - tasmota32c6-safeboot
-          - tasmota32c6cdc-safeboot
     steps:
       - uses: actions/checkout@v3
         with:
@@ -44,7 +41,6 @@ jobs:
         run: |
           pip install wheel
           pip install -U platformio
-          cp ./platformio_tasmota_core3_env_sample.ini ./platformio_tasmota_core3_env.ini
       - name: Run PlatformIO
         run: platformio run -e ${{ matrix.variant }}
       - name: Upload safeboot firmware artifacts

--- a/.github/workflows/build_all_the_things.yml
+++ b/.github/workflows/build_all_the_things.yml
@@ -112,9 +112,6 @@ jobs:
           - tasmota32s2cdc-safeboot
           - tasmota32s3-safeboot
           - tasmota32s3cdc-safeboot
-          - tasmota32c2-safeboot
-          - tasmota32c6-safeboot
-          - tasmota32c6cdc-safeboot
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -128,7 +125,6 @@ jobs:
           pip install -U platformio
           #platformio upgrade --dev
           #platformio update
-          cp ./platformio_tasmota_core3_env_sample.ini ./platformio_tasmota_core3_env.ini
       - name: Run PlatformIO
         run: platformio run -e ${{ matrix.variant }}
       - uses: actions/upload-artifact@v3

--- a/platformio_tasmota_core3_env_sample.ini
+++ b/platformio_tasmota_core3_env_sample.ini
@@ -256,6 +256,15 @@ build_flags             = ${env:tasmota32s3-arduino30.build_flags}
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
+[env:tasmota32c2-safeboot]
+extends                 = env:tasmota32c2-arduino30
+build_unflags           = ${env:tasmota32c2-arduino30.build_unflags}
+                          -DFIRMWARE_ARDUINO30
+build_flags             = ${env:tasmota32c2-arduino30.build_flags}
+                          -DFIRMWARE_SAFEBOOT
+lib_extra_dirs          = lib/lib_ssl, lib/libesp32
+lib_ignore              = ${safeboot_flags.lib_ignore}
+
 [env:tasmota32c3-safeboot]
 extends                 = env:tasmota32c3-arduino30
 build_unflags           = ${env:tasmota32c3-arduino30.build_unflags}
@@ -271,6 +280,25 @@ board                   = esp32c3cdc
 build_unflags           = ${env:tasmota32c3-arduino30.build_unflags}
                           -DFIRMWARE_ARDUINO30
 build_flags             = ${env:tasmota32c3-arduino30.build_flags}
+                          -DFIRMWARE_SAFEBOOT
+lib_extra_dirs          = lib/lib_ssl, lib/libesp32
+lib_ignore              = ${safeboot_flags.lib_ignore}
+
+[env:tasmota32c6-safeboot]
+extends                 = env:tasmota32c6-arduino30
+build_unflags           = ${env:tasmota32c6-arduino30.build_unflags}
+                          -DFIRMWARE_ARDUINO30
+build_flags             = ${env:tasmota32c6-arduino30.build_flags}
+                          -DFIRMWARE_SAFEBOOT
+lib_extra_dirs          = lib/lib_ssl, lib/libesp32
+lib_ignore              = ${safeboot_flags.lib_ignore}
+
+[env:tasmota32c6cdc-safeboot]
+extends                 = env:tasmota32c6-arduino30
+board                   = esp32c6cdc
+build_unflags           = ${env:tasmota32c6-arduino30.build_unflags}
+                          -DFIRMWARE_ARDUINO30
+build_flags             = ${env:tasmota32c6-arduino30.build_flags}
                           -DFIRMWARE_SAFEBOOT
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -253,34 +253,6 @@ lib_ignore              =
                           Micro-RTSP
                           epdiy
 
-[env:tasmota32c2-safeboot]
-extends                 = env:tasmota32c2-arduino30
-build_unflags           = ${env:tasmota32c2-arduino30.build_unflags}
-                          -DFIRMWARE_ARDUINO30
-build_flags             = ${env:tasmota32c2-arduino30.build_flags}
-                          -DFIRMWARE_SAFEBOOT
-lib_extra_dirs          = lib/lib_ssl, lib/libesp32
-lib_ignore              = ${safeboot_flags.lib_ignore}
-
-[env:tasmota32c6-safeboot]
-extends                 = env:tasmota32c6-arduino30
-build_unflags           = ${env:tasmota32c6-arduino30.build_unflags}
-                          -DFIRMWARE_ARDUINO30
-build_flags             = ${env:tasmota32c6-arduino30.build_flags}
-                          -DFIRMWARE_SAFEBOOT
-lib_extra_dirs          = lib/lib_ssl, lib/libesp32
-lib_ignore              = ${safeboot_flags.lib_ignore}
-
-[env:tasmota32c6cdc-safeboot]
-extends                 = env:tasmota32c6-arduino30
-board                   = esp32c6cdc
-build_unflags           = ${env:tasmota32c6-arduino30.build_unflags}
-                          -DFIRMWARE_ARDUINO30
-build_flags             = ${env:tasmota32c6-arduino30.build_flags}
-                          -DFIRMWARE_SAFEBOOT
-lib_extra_dirs          = lib/lib_ssl, lib/libesp32
-lib_ignore              = ${safeboot_flags.lib_ignore}
-
 [env:tasmota32s3cdc-safeboot]
 extends                 = env:tasmota32s3-safeboot
 board                   = esp32s3cdc-qio_qspi


### PR DESCRIPTION
Reverts arendst/Tasmota#19422
since all safeboot are build with Arduino 3.0