### PR TITLE
Signal exit sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [13.1.0.2]
 ### Added
+- internal signal to exit sleep mode usable from ISR
 
 ### Breaking Changed
 

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -327,7 +327,7 @@ struct TasmotaGlobal_t {
   uint8_t state_250mS;                      // State 250msecond per second flag
   uint8_t latching_relay_pulse;             // Latching relay pulse timer
   uint8_t active_device;                    // Active device in ExecuteCommandPower
-  uint8_t sleep;                   // Current copy of Settings->sleep
+  uint8_t sleep;                            // Current copy of Settings->sleep
   uint8_t leds_present;                     // Max number of LED supported
   uint8_t led_inverted;                     // LED inverted flag (1 = (0 = On, 1 = Off))
   uint8_t led_power;                        // LED power state


### PR DESCRIPTION
## Description:

While working on HDMI CEC, I need to publish and handle messages quickly as they arrive, and not necessarily wait for the next tick which can be 50ms in the future.

I added a simple flag, marked as `volatile` to be usable from ISR, that sends a virtual `signal` to exit the (dynamic) sleep and trigger a tick event. Therefore the maximum delay is 1ms. The signal is reset when exiting sleep.

A driver may request to run in fast loop mode (equivalent of `Sleep 0`) by continuously setting the signal at each `FUNC_LOOP` for as long as needed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
