### PR TITLE
Extended rules (up to 8 rules-sets)

### DIFF
--- a/tasmota/include/tasmota.h
+++ b/tasmota/include/tasmota.h
@@ -89,7 +89,12 @@ const uint8_t MAX_SHUTTER_KEYS = 4;         // Max number of shutter keys or but
 const uint8_t MAX_PCF8574 = 4;              // Max number of PCF8574 devices
 const uint8_t MAX_DS3502 = 4;               // Max number of DS3502 digitsal potentiometer devices
 const uint8_t MAX_IRSEND = 16;              // Max number of IRSEND GPIOs
+const uint8_t MAX_RULE_SETS_SETTINGS = 3;   // Max number of rule sets of size 512 characters
+#ifdef USE_RULES_EXTENDED
+const uint8_t MAX_RULE_SETS = 8;            // Max number of rule sets of size 512 characters
+#else
 const uint8_t MAX_RULE_SETS = 3;            // Max number of rule sets of size 512 characters
+#endif
 const uint16_t MAX_RULE_SIZE = 512;         // Max number of characters in rules
 const uint16_t VL53LXX_MAX_SENSORS = 8;     // Max number of VL53L0X sensors
 

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -761,7 +761,7 @@ typedef struct {
   uint32_t      energy_frequency_calibration;  // 7C8  Also used by HX711 to save last weight
   uint16_t      web_refresh;               // 7CC
   char          script_pram[5][10];        // 7CE
-  char          rules[MAX_RULE_SETS][MAX_RULE_SIZE];  // 800  Uses 512 bytes in v5.12.0m, 3 x 512 bytes in v5.14.0b
+  char          rules[MAX_RULE_SETS_SETTINGS][MAX_RULE_SIZE];  // 800  Uses 512 bytes in v5.12.0m, 3 x 512 bytes in v5.14.0b
   TuyaFnidDpidMap tuya_fnid_map[MAX_TUYA_FUNCTIONS];  // E00  32 bytes
   uint16_t      ina226_r_shunt[4];         // E20
   uint16_t      ina226_i_fs[4];            // E28

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -499,6 +499,10 @@
 //  #define USER_RULE1 "<Any rule1 data>"          // Add rule1 data saved at initial firmware load or when command reset is executed
 //  #define USER_RULE2 "<Any rule2 data>"          // Add rule2 data saved at initial firmware load or when command reset is executed
 //  #define USER_RULE3 "<Any rule3 data>"          // Add rule3 data saved at initial firmware load or when command reset is executed
+//  USE_RULES_EXTENDED                                Allows up to 8 rules, requieres filesystem and specific compile settings
+//                                                    Flash: +460 bytes, not counting the mandatory file system
+//                                                    RAM : +2648 bytes
+//                                                    IMPORTANT: IT CAN'T BE ENABLED HERE NOR IN USER_CONFIG_OVERRIDE.H - READ THE DOC
 
 //#define USE_SCRIPT                               // Add support for script (+17k code)
 //  #define USE_SCRIPT_FATFS 4                     // Script: Add FAT FileSystem Support


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #15832

This PR add the capability to extended rules up to 8 rules set.
- The 5 new additional rules requires USE_UFILESYS in order to save the rules to a file (and restore at boot). Without filesystem, the extended rules work but would not be saved.
- All Rules features are supported including compression.
- All extended rules are also 512 bytes as the original ones.

NOTE : Because some constants have to be updated before `user_config_override.h` is included, this feature cannot be simply enabled from `user_config_override.h`. It requires a dedicated environment in `platformio_tasmota_cenv.ini`

Exemple with ESP8266, 4MB flash with 2MB filesystem (USE_UFILESYS is implicit when using an ESP8266 board > 1M):
```
[env:tasmota-rulesext4m]
build_flags             = ${env.build_flags} -DUSE_RULES_EXTENDED
board                   = esp8266_4M2M
```
Exemple with ESP32, 4MB flash with 320KB filesystem (USE_UFILESYS is implicit when using ESP32):
```
[env:tasmota32-rulesext4m]
extends                 = env:tasmota32_base
build_flags             = ${env:tasmota32_base.build_flags} -DUSE_RULES_EXTENDED
```

Flash usage: +460 bytes, not counting the mandatory filesystem
Ram usage: + 2648 bytes


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
