### PR TITLE
Reduce IRAM consumption of HDMI CEC to 1453 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Berry fast_loop is now called every 5ms whatever the Sleep value
+- Reduce IRAM consumption of HDMI CEC to 1453 bytes
 
 ### Fixed
 - PCF8574 mode 1 with base relays exception 3/28 regression from v12.4.0.4 (#19408)

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -784,7 +784,7 @@
 #endif  // USE_SPI
 
 // -- One wire sensors ----------------------------
-// #define USE_HDMI_CEC                              // Add support for HDMI CEC bus (+7k code)
+// #define USE_HDMI_CEC                              // Add support for HDMI CEC bus (+7k code, 1456 bytes IRAM)
 
 // -- Serial sensors ------------------------------
 //#define USE_MHZ19                                // Add support for MH-Z19 CO2 sensor (+2k code)


### PR DESCRIPTION
## Description:

Reduce HDMI CEC IRAM consumption by 1232 down to 1453 bytes.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
