### PR TITLE
Fix migration error to filesystem settings

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
@@ -312,7 +312,7 @@ void ShutterSettingsLoad(bool erase) {
 void ShutterSettingsSave(void) {
   // Called from FUNC_SAVE_SETTINGS every SaveData second and at restart
   uint32_t crc32 = GetCfgCrc32((uint8_t*)&ShutterSettings +4, sizeof(ShutterSettings) -4);  // Skip crc32
-  if (crc32 != ShutterSettings.crc32) {
+  if (crc32 != ShutterSettings.crc32 && ShutterSettings.version > 0) {
     // Try to save file /.drvset027
     ShutterSettings.crc32 = crc32;
 


### PR DESCRIPTION
## Description:
File was saved before initialized. This causes migration error.
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
fix #19441

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
