### PR TITLE
Prep Arduino 3.0: fix shine for gcc12

### DIFF
--- a/lib/libesp32_audio/mp3_shine_esp32/src/l3bitstream.cpp
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/l3bitstream.cpp
@@ -34,7 +34,7 @@ void shine_format_bitstream(shine_global_config *config) {
     for ( gr = 0; gr < config->mpeg.granules_per_frame; gr++ )
       {
         int *pi = &config->l3_enc[ch][gr][0];
-        int32_t *pr = &config->mdct_freq[ch][gr][0];
+        int *pr = &config->mdct_freq[ch][gr][0];
         for ( i = 0; i < GRANULE_SIZE; i++ )
           {
             if ( (pr[i] < 0) && (pi[i] > 0) )

--- a/lib/libesp32_audio/mp3_shine_esp32/src/l3loop.cpp
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/l3loop.cpp
@@ -31,7 +31,7 @@ static void calc_xmin( gr_info *cod_info, shine_psy_xmin_t *l3_xmin, int gr, int
 static int quantize(int ix[GRANULE_SIZE], int stepsize, shine_global_config *config);
 
 
-int32_t sqrt_int(int32_t r) {
+int sqrt_int(int r) {
     float x;
     float rr = r;
     float y = rr*0.5;
@@ -40,7 +40,7 @@ int32_t sqrt_int(int32_t r) {
     x = (1.5f*x) - (x*x)*(x*y);
     if(r>101123) x = (1.5f*x) - (x*x)*(x*y);
 
-    int32_t is = (int32_t)(x*rr + 0.5f);
+    int is = (int)(x*rr + 0.5f);
     return is + ((r - is*is)>>31);
 }
 
@@ -382,7 +382,7 @@ void shine_loop_initialise(shine_global_config *config) {
        * In quantize, the long multiply does not shift it's result left one
        * bit to compensate.
        */
-      config->l3loop->steptabi[i] = (int32_t)((config->l3loop->steptab[i]*2) + 0.5);
+      config->l3loop->steptabi[i] = (int)((config->l3loop->steptab[i]*2) + 0.5);
   }
 
   /* quantize: vector conversion, three quarter power table.
@@ -401,7 +401,7 @@ void shine_loop_initialise(shine_global_config *config) {
 int quantize(int ix[GRANULE_SIZE], int stepsize, shine_global_config *config )
 {
   int i, max, ln;
-  int32_t scalei;
+  int scalei;
   float scale, dbl;
 
   scalei = config->l3loop->steptabi[stepsize+127]; /* 2**(-stepsize/4) */

--- a/lib/libesp32_audio/mp3_shine_esp32/src/l3mdct.cpp
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/l3mdct.cpp
@@ -5,8 +5,8 @@
 #include "l3subband.h"
 
 /* This is table B.9: coefficients for aliasing reduction */
-#define MDCT_CA(coef)	(int32_t)(coef / sqrt(1.0 + (coef * coef)) * 0x7fffffff)
-#define MDCT_CS(coef)	(int32_t)(1.0  / sqrt(1.0 + (coef * coef)) * 0x7fffffff)
+#define MDCT_CA(coef)	(int)(coef / sqrt(1.0 + (coef * coef)) * 0x7fffffff)
+#define MDCT_CS(coef)	(int)(1.0  / sqrt(1.0 + (coef * coef)) * 0x7fffffff)
 
 #define MDCT_CA0	MDCT_CA(-0.6)
 #define MDCT_CA1	MDCT_CA(-0.535)
@@ -38,7 +38,7 @@ void shine_mdct_initialise(shine_global_config *config) {
     for(k=36; k--; )
       /* combine window and mdct coefficients into a single table */
       /* scale and convert to fixed point before storing */
-      config->mdct.cos_l[m][k] = (int32_t)(sin(PI36*(k+0.5))
+      config->mdct.cos_l[m][k] = (int)(sin(PI36*(k+0.5))
                                       * cos((PI/72)*(2*k+19)*(2*m+1)) * 0x7fffffff);
 }
 
@@ -50,17 +50,17 @@ void shine_mdct_sub(shine_global_config *config, int stride) {
   /* note. we wish to access the array 'config->mdct_freq[2][2][576]' as
    * [2][2][32][18]. (32*18=576),
    */
-  int32_t (*mdct_enc)[18];
+  int (*mdct_enc)[18];
 
   int  ch,gr,band,j,k;
-  int32_t mdct_in[36];
+  int mdct_in[36];
 
   for(ch=config->wave.channels; ch--; )
   {
     for(gr=0; gr<config->mpeg.granules_per_frame; gr++)
     {
       /* set up pointer to the part of config->mdct_freq we're using */
-      mdct_enc = (int32_t (*)[18]) config->mdct_freq[ch][gr];
+      mdct_enc = (int (*)[18]) config->mdct_freq[ch][gr];
 
       /* polyphase filtering */
       for(k=0; k<18; k+=2)
@@ -91,7 +91,7 @@ void shine_mdct_sub(shine_global_config *config, int stride) {
 
         for(k=18; k--; )
         {
-		  int32_t vm;
+		  int vm;
 #ifdef __BORLANDC__
 		  uint32_t vm_lo;
 #else

--- a/lib/libesp32_audio/mp3_shine_esp32/src/l3subband.cpp
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/l3subband.cpp
@@ -28,7 +28,7 @@ void shine_subband_initialise(shine_global_config *config) {
       else
         modf(filter-0.5, &filter);
       /* scale and convert to fixed point before storing */
-      config->subband.fl[i][j] = (int32_t)(filter * (0x7fffffff * 1e-9));
+      config->subband.fl[i][j] = (int)(filter * (0x7fffffff * 1e-9));
     }
 }
 
@@ -46,20 +46,20 @@ void shine_subband_initialise(shine_global_config *config) {
  * picking out values from the windowed samples, and then multiplying
  * them by the filter matrix, producing 32 subband samples.
  */
-void shine_window_filter_subband(int16_t **buffer, int32_t s[SBLIMIT], int ch, shine_global_config *config, int stride) {
-  int32_t y[64];
+void shine_window_filter_subband(int16_t **buffer, int s[SBLIMIT], int ch, shine_global_config *config, int stride) {
+  int y[64];
   int i,j;
   int16_t *ptr = *buffer;
 
   /* replace 32 oldest samples with 32 new samples */
   for (i=32;i--;) {
-    config->subband.x[ch][i+config->subband.off[ch]] = ((int32_t)*ptr) << 16;
+    config->subband.x[ch][i+config->subband.off[ch]] = ((int)*ptr) << 16;
     ptr += stride;
   }
   *buffer = ptr;
 
   for (i=64; i--; ) {
-	int32_t s_value;
+	int s_value;
 #ifdef __BORLANDC__
 	uint32_t s_value_lo;
 #else
@@ -81,7 +81,7 @@ void shine_window_filter_subband(int16_t **buffer, int32_t s[SBLIMIT], int ch, s
   config->subband.off[ch] = (config->subband.off[ch] + 480) & (HAN_SIZE-1); /* offset is modulo (HAN_SIZE)*/
 
   for (i=SBLIMIT; i--; ) {
-	int32_t s_value;
+	int s_value;
 #ifdef __BORLANDC__
 	uint32_t s_value_lo;
 #else

--- a/lib/libesp32_audio/mp3_shine_esp32/src/l3subband.h
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/l3subband.h
@@ -4,6 +4,6 @@
 #include <stdint.h>
 
 void shine_subband_initialise( shine_global_config *config );
-void shine_window_filter_subband(int16_t **buffer, int32_t s[SBLIMIT], int k, shine_global_config *config, int stride);
+void shine_window_filter_subband(int16_t **buffer, int s[SBLIMIT], int k, shine_global_config *config, int stride);
 
 #endif

--- a/lib/libesp32_audio/mp3_shine_esp32/src/layer3.cpp
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/layer3.cpp
@@ -106,12 +106,12 @@ shine_global_config *shine_initialise(shine_config_t *pub_config) {
   for (x = 0; x < MAX_CHANNELS; x++) {
       for (y = 0; y < MAX_GRANULES; y++) {
         // 2 * 2 * 576 each
-        config->l3_enc[x][y] = (int*)heap_caps_malloc_prefer(sizeof(int32_t)*GRANULE_SIZE, MALLOC_CAP_32BIT, MALLOC_CAP_SPIRAM|MALLOC_CAP_32BIT); //Significant performance hit in IRAM
+        config->l3_enc[x][y] = (int*)heap_caps_malloc_prefer(4*GRANULE_SIZE, MALLOC_CAP_32BIT, MALLOC_CAP_SPIRAM|MALLOC_CAP_32BIT); //Significant performance hit in IRAM
         if (!config->l3_enc[x][y]) {
           // error should never occur because of spiram size
           //config->l3_enc[x][y] = (int*)heap_caps_malloc(sizeof(int32_t)*GRANULE_SIZE,MALLOC_CAP_SPIRAM|MALLOC_CAP_32BIT);
         }
-        config->mdct_freq[x][y] = (int*)heap_caps_malloc_prefer(sizeof(int32_t)*GRANULE_SIZE, MALLOC_CAP_32BIT, MALLOC_CAP_SPIRAM|MALLOC_CAP_32BIT); //OK 1%
+        config->mdct_freq[x][y] = (int*)heap_caps_malloc_prefer(4*GRANULE_SIZE, MALLOC_CAP_32BIT, MALLOC_CAP_SPIRAM|MALLOC_CAP_32BIT); //OK 1%
         if (!config->mdct_freq[x][y]) {
           // error
           //config->mdct_freq[x][y] = (int*)heap_caps_malloc(sizeof(int32_t)*GRANULE_SIZE, MALLOC_CAP_SPIRAM|MALLOC_CAP_32BIT);
@@ -123,15 +123,15 @@ shine_global_config *shine_initialise(shine_config_t *pub_config) {
 #endif
   config->l3loop = (l3loop_t*)heap_caps_malloc(sizeof(l3loop_t), MALLOC_CAP_SPIRAM);
 #ifdef  SHINE_DEBUG
-  printf("xrsq & xrabs each: %d\n", sizeof(int32_t)*GRANULE_SIZE);
+  printf("xrsq & xrabs each: %d\n", sizeof(int)*GRANULE_SIZE);
 #endif
-  config->l3loop->xrsq = (int*)heap_caps_malloc_prefer(sizeof(int32_t)*GRANULE_SIZE, MALLOC_CAP_32BIT, MALLOC_CAP_SPIRAM|MALLOC_CAP_32BIT); //OK 0.5%
+  config->l3loop->xrsq = (int*)heap_caps_malloc_prefer(4*GRANULE_SIZE, MALLOC_CAP_32BIT, MALLOC_CAP_SPIRAM|MALLOC_CAP_32BIT); //OK 0.5%
   if (!config->l3loop->xrsq) {
     // error
     //config->l3loop->xrsq = (int*)heap_caps_malloc(sizeof(int32_t)*GRANULE_SIZE, MALLOC_CAP_SPIRAM|MALLOC_CAP_32BIT); //OK 0.5%
   }
 
-  config->l3loop->xrabs = (int*)heap_caps_malloc_prefer(sizeof(int32_t)*GRANULE_SIZE, MALLOC_CAP_32BIT, MALLOC_CAP_SPIRAM|MALLOC_CAP_32BIT); //OK 0.5%
+  config->l3loop->xrabs = (int*)heap_caps_malloc_prefer(4*GRANULE_SIZE, MALLOC_CAP_32BIT, MALLOC_CAP_SPIRAM|MALLOC_CAP_32BIT); //OK 0.5%
   if (!config->l3loop->xrabs) {
     //config->l3loop->xrabs = (int*)heap_caps_malloc(sizeof(int32_t)*GRANULE_SIZE, MALLOC_CAP_SPIRAM|MALLOC_CAP_32BIT); //OK 0.5%
   }

--- a/lib/libesp32_audio/mp3_shine_esp32/src/mult_mips_gcc.h
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/mult_mips_gcc.h
@@ -2,7 +2,7 @@
 
 #define mul(a,b) \
 ({ \
-	register int32_t res; \
+	register int res; \
 	__asm__ __volatile__("mult %0, %1" : : "r" (a), "r" (b)); \
 	__asm__ __volatile__("mfhi %0" : "=r" (res)); \
 	res; \
@@ -19,14 +19,14 @@
 
 #define mulz(hi,lo) \
 do { \
-	register int32_t t; \
+	register int t; \
 	__asm__ __volatile__("mfhi %0" : "=r" (t)); \
 	(hi) = t; \
 } while (0)
 
 #define cmuls(dre, dim, are, aim, bre, bim) \
 do { \
-	register int32_t t1, t2, tre; \
+	register int t1, t2, tre; \
 	__asm__ __volatile__("mult %0, %1" : : "r" (are), "r" (bre)); \
 	__asm__ __volatile__("msub %0, %1" : : "r" (aim), "r" (bim)); \
 	__asm__ __volatile__("mfhi %0; mflo %1" : "=r" (t1), "=r" (t2)); \

--- a/lib/libesp32_audio/mp3_shine_esp32/src/mult_noarch_gcc.h
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/mult_noarch_gcc.h
@@ -1,11 +1,11 @@
 #include <stdint.h>
 
 #ifndef asm_mul
-//#define              /// mul(a,b)   (int32_t)  ( ( ((int64_t) a) * ((int64_t) b) ) >>32 )
+//#define              /// mul(a,b)   (int)  ( ( ((int64_t) a) * ((int64_t) b) ) >>32 )
 
 #define asm_mul(x,y) \
 ({ \
-    register int32_t result; \
+    register int result; \
     asm ("mulsh %0, %2, %1" : "=r" (result) : "r" (x), "r" (y)); \
     result ;\
 })
@@ -15,7 +15,7 @@
 #ifndef asm_muls     //Not sure about this
 #define asm_muls(x,y) \
 ({ \
-    register int32_t result; \
+    register int result; \
     asm ( \
     	"mulsh %0, %2, %1\n\t" \
     	"add %0, %0, %0" \
@@ -25,24 +25,24 @@
 
 
 
-//#define muls(a,b)  (int32_t)  ( ( ((int64_t) a) * ((int64_t) b) ) >>31 )
+//#define muls(a,b)  (int)  ( ( ((int64_t) a) * ((int64_t) b) ) >>31 )
 #endif
 
 #ifndef asm_mulr    //no rounding shortcut
 #define asm_mulr(x,y) \
 ({ \
-    register int32_t result; \
+    register int result; \
     asm ("mulsh %0, %2, %1" : "=r" (result) : "r" (x), "r" (y)); \
     result ;\
 })
 
-//#define mulr(a,b)  (int32_t)  ( ( ( ((int64_t) a) * ((int64_t) b)) + 0x80000000LL ) >>32 )
+//#define mulr(a,b)  (int)  ( ( ( ((int64_t) a) * ((int64_t) b)) + 0x80000000LL ) >>32 )
 #endif
 
 #ifndef asm_mulsr   //no rounding shortcut
 #define asm_mulsr(x,y) \
 ({ \
-    register int32_t result; \
+    register int result; \
     asm ( \
         "mulsh %0, %2, %1\n\t" \
         "add %0, %0, %0" \
@@ -50,7 +50,7 @@
     result ;\
 })
 
-//#define mulsr(a,b) (int32_t)  ( ( ( ((int64_t) a) * ((int64_t) b)) + 0x40000000LL ) >>31 )
+//#define mulsr(a,b) (int)  ( ( ( ((int64_t) a) * ((int64_t) b)) + 0x40000000LL ) >>31 )
 #endif
 
 #ifndef asm_mul0
@@ -84,7 +84,7 @@
 /*
  #define cmuls(dre, dim, are, aim, bre, bim) \
 do { \
-    register int32_t tre, tim; \
+    register int tre, tim; \
     asm ( \
         "mull %0, %2, %4\n\t" \  //mulsh
         "mulsh r3, %2, %4\n\t" \  //mulsh
@@ -111,9 +111,9 @@ do { \
 
 #define asm_cmuls(dre, dim, are, aim, bre, bim) \
 do { \
-	int32_t tre; \
-	(tre) = (int32_t) (((int64_t) (are) * (int64_t) (bre) - (int64_t) (aim) * (int64_t) (bim)) >> 31); \
-	(dim) = (int32_t) (((int64_t) (are) * (int64_t) (bim) + (int64_t) (aim) * (int64_t) (bre)) >> 31); \
+	int tre; \
+	(tre) = (int) (((int64_t) (are) * (int64_t) (bre) - (int64_t) (aim) * (int64_t) (bim)) >> 31); \
+	(dim) = (int) (((int64_t) (are) * (int64_t) (bim) + (int64_t) (aim) * (int64_t) (bre)) >> 31); \
 	(dre) = tre; \
 } while (0)
 #endif

--- a/lib/libesp32_audio/mp3_shine_esp32/src/mult_sarm_gcc.h
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/mult_sarm_gcc.h
@@ -4,14 +4,14 @@
 #if __ARM_ARCH >= 6
 #define mul(x,y) \
 ({ \
-    register int32_t result; \
+    register int result; \
     asm ("smmul %0, %2, %1" : "=r" (result) : "r" (x), "r" (y)); \
     result ;\
 })
 #else
 #define mul(x,y) \
 ({ \
-    register int32_t result; \
+    register int result; \
     asm ("smull r3, %0, %2, %1" : "=r" (result) : "r" (x), "r" (y) : "r3"); \
     result ; \
 })
@@ -20,7 +20,7 @@
 /* Fractional multiply with single bit left shift. */
 #define muls(x,y) \
 ({ \
-    register int32_t result; \
+    register int result; \
     asm ( \
         "smull r3, %0, %2, %1\n\t" \
         "movs r3, r3, lsl #1\n\t" \
@@ -34,7 +34,7 @@
 #if __ARM_ARCH >= 6
 #define mulr(x,y) \
 ({ \
-    register int32_t result; \
+    register int result; \
     asm ( \
         "smmulr %0, %2, %1" : "=r" (result) : "r" (x), "r" (y) \
     ); \
@@ -43,7 +43,7 @@
 #else
 #define mulr(x,y) \
 ({ \
-    register int32_t result; \
+    register int result; \
     asm ( \
         "smull r3, %0, %2, %1\n\t" \
         "adds r3, r3, #0x80000000\n\t" \
@@ -56,7 +56,7 @@
 
 #define mulsr(x,y) \
 ({ \
-    register int32_t result; \
+    register int result; \
     asm ( \
         "smull r3, %0, %1, %2\n\t" \
         "movs r3, r3, lsl #1\n\t" \
@@ -81,7 +81,7 @@
 
 #define cmuls(dre, dim, are, aim, bre, bim) \
 do { \
-    register int32_t tre, tim; \
+    register int tre, tim; \
     asm ( \
         "smull r3, %0, %2, %4\n\t" \
         "smlal r3, %0, %3, %5\n\t" \

--- a/lib/libesp32_audio/mp3_shine_esp32/src/tables.cpp
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/tables.cpp
@@ -66,11 +66,11 @@ const int shine_scale_fact_band_index[9][23] =
 
 /* note. 0.035781 is shine_enwindow maximum value */
 /* scale and convert to fixed point before storing */
-#define SHINE_EW(x)					(int32_t)((double)(x) * 0x7fffffff)
+#define SHINE_EW(x)					(int)((double)(x) * 0x7fffffff)
 #define SHINE_EW2(a,b)					SHINE_EW(a), SHINE_EW(b)
 #define SHINE_EW10(a,b,c,d,e,f,g,h,i,j)	SHINE_EW2(a,b), SHINE_EW2(c,d), SHINE_EW2(e,f), SHINE_EW2(g,h), SHINE_EW2(i,j)
 
-const int32_t shine_enwindow[] = {
+const int shine_enwindow[] = {
 SHINE_EW10(   0.000000, -0.000000, -0.000000, -0.000000, -0.000000, -0.000000, -0.000000, -0.000001, -0.000001, -0.000001),
 SHINE_EW10(  -0.000001, -0.000001, -0.000001, -0.000002, -0.000002, -0.000002, -0.000002, -0.000003, -0.000003, -0.000003),
 SHINE_EW10(  -0.000004, -0.000004, -0.000005, -0.000005, -0.000006, -0.000007, -0.000008, -0.000008, -0.000009, -0.000010),

--- a/lib/libesp32_audio/mp3_shine_esp32/src/tables.h
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/tables.h
@@ -10,7 +10,7 @@ extern const int samplerates[9];
 extern const int bitrates[16][4];
 
 extern const int  shine_scale_fact_band_index[9][23];
-extern const int32_t shine_enwindow[];
+extern const int shine_enwindow[];
 
 #endif
 

--- a/lib/libesp32_audio/mp3_shine_esp32/src/types.h
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/types.h
@@ -85,27 +85,27 @@ typedef struct {
 } priv_shine_mpeg_t;
 
 typedef struct {
-  int32_t *xr;                    /* magnitudes of the spectral values */
-  int32_t *xrsq;     /* xr squared */
-  int32_t *xrabs;    /* xr absolute */
-  int32_t xrmax;                  /* maximum of xrabs array */
-  int32_t en_tot[MAX_GRANULES];   /* gr */
-  int32_t en[MAX_GRANULES][21];
-  int32_t xm[MAX_GRANULES][21];
-  int32_t xrmaxl[MAX_GRANULES];
+  int *xr;                    /* magnitudes of the spectral values */
+  int *xrsq;     /* xr squared */
+  int *xrabs;    /* xr absolute */
+  int xrmax;                  /* maximum of xrabs array */
+  int en_tot[MAX_GRANULES];   /* gr */
+  int en[MAX_GRANULES][21];
+  int xm[MAX_GRANULES][21];
+  int xrmaxl[MAX_GRANULES];
   double steptab[128]; /* 2**(-x/4)  for x = -127..0 */
-  int32_t steptabi[128];  /* 2**(-x/4)  for x = -127..0 */
+  int steptabi[128];  /* 2**(-x/4)  for x = -127..0 */
   int16_t int2idx[10000]; /* x**(3/4)   for x = 0..9999 */
 } l3loop_t;
 
 typedef struct {
-  int32_t cos_l[18][36];
+  int cos_l[18][36];
 } mdct_t;
 
 typedef struct {
   int off[MAX_CHANNELS];
-  int32_t fl[SBLIMIT][64];
-  int32_t x[MAX_CHANNELS][HAN_SIZE];
+  int fl[SBLIMIT][64];
+  int x[MAX_CHANNELS][HAN_SIZE];
 } subband_t;
 
 /* Side information */
@@ -150,8 +150,8 @@ typedef struct {
 } shine_psy_xmin_t;
 
 typedef struct {
-    int32_t l[MAX_GRANULES][MAX_CHANNELS][22];            /* [cb] */
-    int32_t s[MAX_GRANULES][MAX_CHANNELS][13][3];         /* [window][cb] */
+    int l[MAX_GRANULES][MAX_CHANNELS][22];            /* [cb] */
+    int s[MAX_GRANULES][MAX_CHANNELS][13][3];         /* [window][cb] */
 } shine_scalefac_t;
 
 
@@ -167,8 +167,8 @@ typedef struct shine_global_flags {
   int16_t       *buffer[MAX_CHANNELS];
   double          pe[MAX_CHANNELS][MAX_GRANULES];
   int            *l3_enc[MAX_CHANNELS][MAX_GRANULES]; //4% reduction in performance IRAM
-  int32_t        l3_sb_sample[MAX_CHANNELS][MAX_GRANULES+1][18][SBLIMIT];
-  int32_t        *mdct_freq[MAX_CHANNELS][MAX_GRANULES]; //1% reduction in perormance IRAM
+  int        l3_sb_sample[MAX_CHANNELS][MAX_GRANULES+1][18][SBLIMIT];
+  int        *mdct_freq[MAX_CHANNELS][MAX_GRANULES]; //1% reduction in perormance IRAM
   int            ResvSize;
   int            ResvMax;
   l3loop_t       *l3loop;


### PR DESCRIPTION
## Description:

GCC 12 is very strict about types and does not allow to cast `int` to `int32_t` and vice versa, so this PR just makes everything `int`.

I can confirm that the I2S microphone and MP3 encoding is working with Arduino 3.0 and Tasmota, but the needed changes will come later.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
