### PR TITLE
Support for IPv6 link-local zones for esp-idf 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Berry make mdns compatible with non-IPv6 builds
 - ESP32 Shutter migration (#19454)
 - ESP32 Shutter multi press button events (#19465)
+- Support for IPv6 link-local zones for esp-idf 5.1 (necessary for Matter)
 
 ### Removed
 

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -567,15 +567,6 @@ bool WifiFindIPv6(IPAddress *ip, bool is_local, const char * if_type = "st") {
   }
   return false;
 }
-// add an IPv6 link-local address to all netif
-void CreateLinkLocalIPv6(void)
-{
-#ifdef ESP32
-  for (auto intf = esp_netif_next(NULL); intf != NULL; intf = esp_netif_next(intf)) {
-    esp_netif_create_ip6_linklocal(intf);
-  }
-#endif // ESP32
-}
 
 
 // Returns only IPv6 global address (no loopback and no link-local)
@@ -1266,11 +1257,32 @@ bool WifiDNSGetIPv6Priority(void) {
 }
 
 bool WifiHostByName(const char* aHostname, IPAddress& aResult) {
+#ifdef USE_IPV6
+#if ESP_IDF_VERSION_MAJOR >= 5
+  // try converting directly to IP
+  if (aResult.fromString(aHostname)) {
+    return true;   // we're done
+  }
+#endif
+#endif // USE_IPV6
+
   uint32_t dns_start = millis();
   bool success = WiFi.hostByName(aHostname, aResult, Settings->dns_timeout);
   uint32_t dns_end = millis();
   if (success) {
     // Host name resolved
+#ifdef USE_IPV6
+#if ESP_IDF_VERSION_MAJOR >= 5
+    // check if there is a zone-id
+    // look for '%' in string
+    const char *s = aHostname;
+    while (*s && *s != '%') { s++; }
+    if (*s == '%') {
+        // we have a zone id
+        aResult.setZone(netif_name_to_index(s + 1));
+    }
+#endif
+#endif // USE_IPV6
     if (0xFFFFFFFF != (uint32_t)aResult) {
       AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_WIFI "DNS resolved '%s' (%s) in %i ms"), aHostname, aResult.toString().c_str(), dns_end - dns_start);
       return true;

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tcpclientasync.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tcpclientasync.ino
@@ -75,6 +75,9 @@ public:
         tmpaddr->sin6_family = AF_INET6;
         memcpy(tmpaddr->sin6_addr.un.u8_addr, &ip[0], 16);
         tmpaddr->sin6_port = htons(port);
+#if ESP_IDF_VERSION_MAJOR >= 5
+        tmpaddr->sin6_scope_id = ip.zone();
+#endif
     } else {
 #endif
         struct sockaddr_in *tmpaddr = (struct sockaddr_in *)&serveraddr;
@@ -314,7 +317,6 @@ public:
           struct sockaddr_in *s = (struct sockaddr_in *)&local_address;
           local_port = ntohs(s->sin_port);
           local_addr = IPAddress((uint32_t)(s->sin_addr.s_addr));
-          // return IPAddress((uint32_t)(s->sin_addr.s_addr));
       }
 #ifdef USE_IPV6
       // IPv6, but it might be IPv4 mapped address
@@ -323,10 +325,12 @@ public:
           local_port = ntohs(saddr6->sin6_port);
           if (T_IN6_IS_ADDR_V4MAPPED(saddr6->sin6_addr.un.u32_addr)) {
               local_addr = IPAddress(IPv4, (uint8_t*)saddr6->sin6_addr.s6_addr+12);
-              // return IPAddress(IPv4, (uint8_t*)saddr6->sin6_addr.s6_addr+12);
           } else {
+#if ESP_IDF_VERSION_MAJOR >= 5
+              local_addr = IPAddress(IPv6, (uint8_t*)(saddr6->sin6_addr.s6_addr), saddr6->sin6_scope_id);
+#else
               local_addr = IPAddress(IPv6, (uint8_t*)(saddr6->sin6_addr.s6_addr));
-              // return IPAddress(IPv6, (uint8_t*)(saddr6->sin6_addr.s6_addr));
+#endif
           }
       }
 #endif // USE_IPV6

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_udp.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_udp.ino
@@ -79,7 +79,7 @@ extern "C" {
     if (!WifiHostByName(host, addr)){
         return 0;
     }
-    // AddLog(LOG_LEVEL_DEBUG, "BRY: udp.begin got host '%s'", addr.toString().c_str());
+    // AddLog(LOG_LEVEL_DEBUG, "BRY: be_udp_send_ntv host '%s'", addr.toString().c_str());
     if (!udp->beginPacket(addr, port)) { return 0; }
     int bw = udp->write(buf, len);
     if (!bw) { return 0; }


### PR DESCRIPTION
## Description:

On Arduino 3 / esp-idf 5.1, now link-local addresses need to be used with a zone suffix

![ipv6_zone](https://github.com/arendst/Tasmota/assets/49731213/e9816b89-5478-4c7c-b02f-3e072381a1a1)

Typically:
- `%st1` for wifi only devices
- `%st2` or `%en1` for wifi + ethernet

In general, there should be no change in Berry code since `remote_ip` also contains the zone id of the source when receiving a message.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
