### PR TITLE
Fix compilation of IRRemoteESP8266 for core3

### DIFF
--- a/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/src/IRrecv.cpp
+++ b/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/src/IRrecv.cpp
@@ -13,6 +13,11 @@ extern "C" {
 }
 #endif  // ESP8266
 #include <Arduino.h>
+#if defined(ESP32)
+#if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
+#include <driver/gpio.h>
+#endif  // ESP_ARDUINO_VERSION_MAJOR >= 3
+#endif
 #endif  // UNIT_TEST
 #include <algorithm>
 #ifdef UNIT_TEST
@@ -242,8 +247,13 @@ static void USE_IRAM_ATTR gpio_intr() {
   // @see https://github.com/espressif/arduino-esp32/blob/6b0114366baf986c155e8173ab7c22bc0c5fcedc/cores/esp32/esp32-hal-timer.c#L176-L178
   timer->dev->config.alarm_en = 1;
 #else  // _ESP32_IRRECV_TIMER_HACK
+#if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
+  timerAlarm(timer, MS_TO_USEC(params.timeout), ONCE, 0);
+  timerAttachInterrupt(timer, &read_timeout);
+#else // ESP_ARDUINO_VERSION_MAJOR >= 3
   timerWrite(timer, 0);
   timerAlarmEnable(timer);
+#endif  // ESP_ARDUINO_VERSION_MAJOR >= 3
 #endif  // _ESP32_IRRECV_TIMER_HACK
 #endif  // ESP32
 }
@@ -359,7 +369,11 @@ void IRrecv::enableIRIn(const bool pullup) {
 #if defined(ESP32)
   // Initialise the ESP32 timer.
   // 80MHz / 80 = 1 uSec granularity.
+#if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
+  timer = timerBegin(80);
+#else // ESP_ARDUINO_VERSION_MAJOR >= 3
   timer = timerBegin(_timer_num, 80, true);
+#endif  // ESP_ARDUINO_VERSION_MAJOR >= 3
 #ifdef DEBUG
   if (timer == NULL) {
     DPRINT("FATAL: Unable enable system timer: ");
@@ -367,12 +381,17 @@ void IRrecv::enableIRIn(const bool pullup) {
   }
 #endif  // DEBUG
   assert(timer != NULL);  // Check we actually got the timer.
+#if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
+  timerAlarm(timer, MS_TO_USEC(params.timeout), ONCE, 0);
+  timerAttachInterrupt(timer, &read_timeout);
+#else // ESP_ARDUINO_VERSION_MAJOR >= 3
   // Set the timer so it only fires once, and set it's trigger in uSeconds.
   timerAlarmWrite(timer, MS_TO_USEC(params.timeout), ONCE);
   // Note: Interrupt needs to be attached before it can be enabled or disabled.
   // Note: EDGE (true) is not supported, use LEVEL (false). Ref: #1713
   // See: https://github.com/espressif/arduino-esp32/blob/caef4006af491130136b219c1205bdcf8f08bf2b/cores/esp32/esp32-hal-timer.c#L224-L227
   timerAttachInterrupt(timer, &read_timeout, false);
+#endif  // ESP_ARDUINO_VERSION_MAJOR >= 3
 #endif  // ESP32
 
   // Initialise state machine variables
@@ -398,9 +417,13 @@ void IRrecv::disableIRIn(void) {
   os_timer_disarm(&timer);
 #endif  // ESP8266
 #if defined(ESP32)
+#if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
+  timerEnd(timer);
+#else // ESP_ARDUINO_VERSION_MAJOR >= 3
   timerAlarmDisable(timer);
   timerDetachInterrupt(timer);
   timerEnd(timer);
+#endif // ESP_ARDUINO_VERSION_MAJOR >= 3
 #endif  // ESP32
   detachInterrupt(params.recvpin);
 #endif  // UNIT_TEST
@@ -426,7 +449,11 @@ void IRrecv::resume(void) {
   params.rawlen = 0;
   params.overflow = false;
 #if defined(ESP32)
+#if ( defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR >= 3) )
+  timerEnd(timer);
+#else // ESP_ARDUINO_VERSION_MAJOR >= 3
   timerAlarmDisable(timer);
+#endif // ESP_ARDUINO_VERSION_MAJOR >= 3
   gpio_intr_enable((gpio_num_t)params.recvpin);
 #endif  // ESP32
 }


### PR DESCRIPTION
## Description:

It compiles and I think it does what it's supposed to do. I haven't tested.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
