### PR TITLE
Optionally add timezone to DeepSleep wake up time

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_29_deepsleep.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_29_deepsleep.ino
@@ -130,6 +130,9 @@ void DeepSleepStart(void)
   }
 
   String dt = GetDT(RtcSettings.nextwakeup);  // 2017-03-07T11:08:02
+  if (Settings->flag3.time_append_timezone) {  // SetOption52 - Append timezone to JSON time
+    dt += GetTimeZone();    // 2017-03-07T11:08:02-07:00
+  }
   // Limit sleeptime to DEEPSLEEP_MAX_CYCLE
   // uint32_t deepsleep_sleeptime = DEEPSLEEP_MAX_CYCLE < (RtcSettings.nextwakeup - LocalTime()) ? (uint32_t)DEEPSLEEP_MAX_CYCLE : RtcSettings.nextwakeup - LocalTime();
   deepsleep_sleeptime = tmin((uint32_t)DEEPSLEEP_MAX_CYCLE ,RtcSettings.nextwakeup - LocalTime());
@@ -138,13 +141,6 @@ void DeepSleepStart(void)
   Response_P(PSTR("{\"" D_PRFX_DEEPSLEEP "\":{\"" D_JSON_TIME "\":\"%s\",\"" D_PRFX_DEEPSLEEP "\":%d,\"Wakeup\":%d}}"), (char*)dt.c_str(), LocalTime(), RtcSettings.nextwakeup);
   MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR(D_PRFX_DEEPSLEEP), true);
 
-  // Change LWT Topic to Sleep to ensure automation see different state
-  //GetTopic_P(stopic, TELE, TasmotaGlobal.mqtt_topic, S_LWT);
-  //Response_P(PSTR(D_PRFX_DEEPSLEEP));
-  //MqttPublish(stopic, true);
-
-  //MqttClient.disconnect(true);
-  //EspClient.stop();
   WifiShutdown();
   RtcSettings.ultradeepsleep = RtcSettings.nextwakeup - LocalTime();
   RtcSettingsSave();


### PR DESCRIPTION
## Description:

The JSON output for DeepSleep doesn't include the timezone and the timestamp is not fully ISO8601. So it's not accepted by Home Assistant (for example) as a timestamp. This PR honours [SetOption52](https://tasmota.github.io/docs/Commands/#setoption52) by optionally appending the timezone to the timestamp.

Note that the other 2 json values are unix timestamps in local time. There isn't an easy way to interpret this given lack of timestamp data. I opted not to fix at this stage since a lot of the deep sleep logic is built around the same localtime variables.

fix: add timezone to DeepSleep wake up time
chore: remove old commented code for clarity

**Related issue (if applicable):** fixes # N/A

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.11
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
