### PR TITLE
fix compile errors on exotic windows codepages

### DIFF
--- a/lib/libesp32/berry/tools/coc/block_builder.py
+++ b/lib/libesp32/berry/tools/coc/block_builder.py
@@ -159,7 +159,7 @@ class block_builder:
     
     def writefile(self, filename, text):
         otext = "#include \"be_constobj.h\"\n\n" + text
-        with open(filename, "w") as f:
+        with open(filename, "w", encoding='utf-8') as f:
             f.write(otext)
 
     def dumpfile(self, path):

--- a/lib/libesp32/berry/tools/coc/coc
+++ b/lib/libesp32/berry/tools/coc/coc
@@ -34,7 +34,7 @@ class builder:
         if re.search(r"\.(h|c|cc|cpp)$", filename):
             # print(f"> parse {filename}")
             text = ""
-            with open(filename) as f:
+            with open(filename, encoding='utf-8') as f:
                 text = f.read()
             # print(f"> len(text)={len(text)}")
             parser = coc_parser(text)

--- a/lib/libesp32/berry/tools/coc/macro_table.py
+++ b/lib/libesp32/berry/tools/coc/macro_table.py
@@ -22,7 +22,7 @@ class macro_table:
     
     def scan_file(self, filename):
         str = ""
-        with open(filename) as f:
+        with open(filename, encoding='utf-8') as f:
            str = f.read()
         r = macro_table.pat.findall(str)
         for it in r:

--- a/lib/libesp32_lvgl/lv_binding_berry/tools/preprocessor.py
+++ b/lib/libesp32_lvgl/lv_binding_berry/tools/preprocessor.py
@@ -86,7 +86,7 @@ headers_names += list_files("../../LVGL_assets/src/", ["lv_theme_haspmota.h"])
 # headers_names = [ '../../lib/libesp32_lvgl/LVGL/src/lv_api_map.h' ]
 
 output_filename = "../mapping/lv_funcs.h"
-sys.stdout = open(output_filename, 'w')
+sys.stdout = open(output_filename, 'w', encoding='utf-8')
 
 print("""
 // Automatically generated from LVGL source with `python3 preprocessor.py`
@@ -121,7 +121,7 @@ lv_coord_t lv_get_ver_res(void);
 """)
 
 for header_name in headers_names:
-  with open(header_name) as f:
+  with open(header_name, encoding='utf-8') as f:
     print("// " + header_name)
     raw = clean_source(f.read())
 
@@ -198,7 +198,7 @@ lv_fun_globs = [
 headers_names = list_files(lv_src_prefix, lv_fun_globs)
 
 output_filename = "../mapping/lv_enum.h"
-sys.stdout = open(output_filename, 'w')
+sys.stdout = open(output_filename, 'w', encoding='utf-8')
 print("""// ======================================================================
 // Functions
 // ======================================================================

--- a/pio-tools/metrics-firmware.py
+++ b/pio-tools/metrics-firmware.py
@@ -10,7 +10,7 @@ def firm_metrics(source, target, env):
         env.Execute("$PYTHONEXE -m tasmota_metrics \"" + str(tasmotapiolib.get_source_map_path(env).resolve()) + "\"")
     elif env["PIOPLATFORM"] == "espressif8266":
         map_file = join(env.subst("$BUILD_DIR")) + os.sep + "firmware.map"
-        with open(map_file,'r') as f:
+        with open(map_file,'r', encoding='utf-8') as f:
             phrase = "_text_end = ABSOLUTE (.)"
             for line in f:
                 if  phrase in line:


### PR DESCRIPTION
## Description:

Fix compile fail on my exotic cp1250 codepage in windows by forcing UTF-8 encoding on open()

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.12
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
