### PR TITLE
Add HRG-15 command data to cmnd response

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_90_hrg15.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_90_hrg15.ino
@@ -242,7 +242,9 @@ bool Rg15Command(void) {
       Rg15.init_step = 5;                    // Perform RG-15 init
     }
 
-    ResponseCmndDone();
+    ResponseCmndIdxChar(XdrvMailbox.data);
+  } else {
+    ResponseCmndIdxError();
   }
 
   return serviced;


### PR DESCRIPTION
## Description:

Currently, after executing a `Sensor90` command the response is always `Done` or none at all if invalid argument length passed in. Several HRG commands don't provide any output on the serial connection, so there's no way of knowing if a specific command has been run (eg by a rule). An example is `Sensor90 O`. This PR provides the command index response such as `RESULT = {"Sensor90":"O"}`.

Furthermore, the sensor only accepts single character commands. The logic doesn't give any response at all if more than 1 character is provided (eg `Sensor90 OR`). This PR provides `RESULT = {"Sensor90":"Error"}`.

add: output the sensor90 command argument as a response
fix: display command error for non single character commands

I have compiled against ESP8266 with `USE_HRG15` but don't have a device to install and execute.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.12
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
