### PR TITLE
fix codec compilation on IDF5.1

### DIFF
--- a/lib/libesp32_audio/es7210/src/es7210.cpp
+++ b/lib/libesp32_audio/es7210/src/es7210.cpp
@@ -27,6 +27,7 @@
 #include <Wire.h>
 #include <string.h>
 #include "esp_log.h"
+#include "rom/ets_sys.h"
 #include "es7210.h"
 
 

--- a/lib/libesp32_audio/es7243e/src/es7243e.cpp
+++ b/lib/libesp32_audio/es7243e/src/es7243e.cpp
@@ -27,7 +27,8 @@
  #include <freertos/FreeRTOS.h>
  #include "string.h"
  #include "esp_log.h"
-#include "es7243e.h"
+ #include "rom/ets_sys.h"
+ #include "es7243e.h"
 
 
 static const char *TAG = "DRV7243E";

--- a/lib/libesp32_audio/es8156/src/es8156.cpp
+++ b/lib/libesp32_audio/es8156/src/es8156.cpp
@@ -28,6 +28,7 @@
 #include <freertos/FreeRTOS.h>
 #include "string.h"
 #include "esp_log.h"
+#include "rom/ets_sys.h"
 #include "es8156.h"
 
 /*

--- a/lib/libesp32_audio/es8311/src/es8311.cpp
+++ b/lib/libesp32_audio/es8311/src/es8311.cpp
@@ -27,6 +27,7 @@
 #include <Wire.h>
 #include <string.h>
 #include "esp_log.h"
+#include "rom/ets_sys.h"
 #include "es8311.h"
 
 


### PR DESCRIPTION
## Description:

Only purpose is to let this compile with Arduino 3.0/ IDF 5.1.

IMHO everything here should be possible to be implemented in Berry, so that the support for very specific hardware is possible without adding very rarely used code to Tasmotas core.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.13
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
