### PR TITLE
SGP4X Driver - Adding SGP40 support to Universal SGP4X Driver

### DIFF
--- a/lib/lib_i2c/arduino-i2c-sgp41/src/SensirionI2CSgp4x.cpp
+++ b/lib/lib_i2c/arduino-i2c-sgp41/src/SensirionI2CSgp4x.cpp
@@ -178,6 +178,28 @@ uint16_t SensirionI2CSgp4x::readSelfTestValue(uint16_t& testResult) {
     return error;
 }
 
+uint16_t SensirionI2CSgp4x::getFeaturesValue(uint16_t& featureResult) {
+    uint16_t error;
+    uint8_t buffer[3];
+    SensirionI2CTxFrame txFrame =
+        SensirionI2CTxFrame::createWithUInt16Command(0x202F, buffer, 3);
+
+    error = SensirionI2CCommunication::sendFrame(SGP4X_I2C_ADDRESS, txFrame,
+                                                 *_i2cBus);
+
+    if (error) {
+        return error;
+    }
+
+    delay(1); // 1ms delay for feature request
+    SensirionI2CRxFrame rxFrame(buffer, 3);
+    error = SensirionI2CCommunication::receiveFrame(SGP4X_I2C_ADDRESS, 3,
+                                                    rxFrame, *_i2cBus);
+
+    error |= rxFrame.getUInt16(featureResult);
+    return error;
+}
+
 uint16_t SensirionI2CSgp4x::turnHeaterOff() {
     uint16_t error;
     uint8_t buffer[2];

--- a/lib/lib_i2c/arduino-i2c-sgp41/src/SensirionI2CSgp4x.h
+++ b/lib/lib_i2c/arduino-i2c-sgp41/src/SensirionI2CSgp4x.h
@@ -120,6 +120,8 @@ class SensirionI2CSgp4x {
     uint16_t sendSelfTestCmd(void);
     uint16_t readSelfTestValue(uint16_t& testResult);
 
+    uint16_t getFeaturesValue(uint16_t& featureResult);
+
     /**
      * turnHeaterOff() - This command turns the hotplate off and stops the
      * measurement. Subsequently, the sensor enters the idle mode.


### PR DESCRIPTION
## Description:

This patch adds supports for the SGP40 sensor as well, eliminating the need for a separate SGP40 library. Previously, one had to custom compile Tasmota for the ESP8266, and disabled the SGP40 (`i2cdriver69`) in order for it to work. This can handle both pieces of hardware now. Eventually the SGP40 driver can be retired.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.13
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
