### PR TITLE
Berry counter 0-base

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_gpio.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_gpio.ino
@@ -249,7 +249,7 @@ extern "C" {
 #ifdef USE_COUNTER
     int32_t argc = be_top(vm); // Get the number of arguments
     if (argc >= 1 && be_isint(vm, 1)) {
-      int32_t counter = be_toint(vm, 1);
+      int32_t counter = be_toint(vm, 1) + 1;    // counter are 0 based in Berry, 1 based in Tasmota
 
       // is `index` refering to a counter?
       if (CounterPinConfigured(counter)) {
@@ -270,7 +270,7 @@ extern "C" {
 #ifdef USE_COUNTER
     int32_t argc = be_top(vm); // Get the number of arguments
     if (argc >= 2 && be_isint(vm, 1) && be_isint(vm, 2)) {
-      int32_t counter = be_toint(vm, 1);
+      int32_t counter = be_toint(vm, 1) + 1;    // counter are 0 based in Berry, 1 based in Tasmota
       int32_t value = be_toint(vm, 2);
 
       // is `index` refering to a counter?


### PR DESCRIPTION
## Description:

For consistency with Berry 0-based indices, `gpio.counter_xxx(i)` is now 0-based.

I.e. use `gpio.counter_read(0)` to read the value of `Counter1`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.13
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
