### PR TITLE
Improvement in shuttersetup

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
@@ -2099,6 +2099,7 @@ void CmndShutterSetup(void) {
   uint32_t new_opentime;
   uint32_t new_closetime;
   uint8_t  max_runtime = 120; // max 120 seconds runtime
+  float daily_kWh[ENERGY_MAX_PHASES];           // 123.123 kWh
 
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= TasmotaGlobal.shutters_present)) {
     index_no = XdrvMailbox.index-1; // save, because will be changed in following operations
@@ -2107,6 +2108,9 @@ void CmndShutterSetup(void) {
     ShutterSettings.shutter_position[index_no]  = 0;
     ShutterSettings.shutter_closetime[index_no] = max_runtime * 10;
     ShutterSettings.shutter_opentime[index_no]  = max_runtime * 10;
+    for (uint8_t i = 0; i < ENERGY_MAX_PHASES; i++) {
+      daily_kWh[i] = Energy->daily_kWh[i];
+    }
     ShutterInit();
     if (Energy->phase_count > 1) {
       AddLog(LOG_LEVEL_ERROR, PSTR("SHT: Setup: Ensure shutter is close. Now open, autostop detect. max duration is 2min Phase:%d"),Energy->phase_count);
@@ -2139,6 +2143,9 @@ void CmndShutterSetup(void) {
       } 
     } 
     ShutterGlobal.callibration_run = false;
+    for (uint8_t i = 0; i < ENERGY_MAX_PHASES; i++) {
+       Energy->daily_kWh[i] = daily_kWh[i];
+    }
   } else {
     // print out help instructions
     // will only work without TILT configuration


### PR DESCRIPTION
- reduce call of energy to 10x a sec.
- stop detection more rigid to avoid wrong messages
- more accurate calculation of duration

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
try to fix: #19562


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.13
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
