### PR TITLE
Berry fix audio MP3

### DIFF
--- a/lib/libesp32/berry/default/be_modtab.c
+++ b/lib/libesp32/berry/default/be_modtab.c
@@ -208,7 +208,6 @@ be_extern_native_class(OneWire);
 be_extern_native_class(Leds_ntv);
 be_extern_native_class(Leds);
 be_extern_native_class(Leds_animator);
-be_extern_native_class(AudioOutput);
 be_extern_native_class(AudioGenerator);
 be_extern_native_class(AudioFileSource);
 be_extern_native_class(AudioOutputI2S);
@@ -296,7 +295,6 @@ BERRY_LOCAL bclass_array be_class_table = {
 #endif // USE_LVGL
 
 #ifdef USE_I2S_AUDIO_BERRY
-    &be_native_class(AudioOutput),
     &be_native_class(AudioGenerator),
     &be_native_class(AudioFileSource),
     &be_native_class(AudioOutputI2S),

--- a/lib/libesp32/berry_tasmota/src/be_i2s_audio_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_i2s_audio_lib.c
@@ -10,8 +10,6 @@
 
 #include "be_mapping.h"
 
-extern int i2s_output_i2s_init(bvm *vm);
-extern int i2s_output_i2s_deinit(bvm *vm);
 extern int i2s_output_i2s_stop(bvm *vm);
 
 extern int i2s_generator_wav_init(bvm *vm);
@@ -34,9 +32,25 @@ extern int i2s_file_source_fs_deinit(bvm *vm);
 #endif // USE_UFILESYS
 
 
-// AudioOutput.set_rate(rate_hz:int) -> bool
-extern void* be_audio_output_init(void);
-BE_FUNC_CTYPE_DECLARE(be_audio_output_init, "+.p", "");
+// AudioOutputI2S.init() -> instance 
+extern void* be_audio_output_i2s_init(void);
+BE_FUNC_CTYPE_DECLARE(be_audio_output_i2s_init, "+.p", "");
+
+// AudioOutputI2S.deinit()-> void
+extern void* be_audio_output_i2s_deinit(void* instance);
+BE_FUNC_CTYPE_DECLARE(be_audio_output_i2s_deinit, "", ".");
+
+// AudioOutput.begin() -> bool
+extern int be_audio_output_i2s_begin(void* out);
+BE_FUNC_CTYPE_DECLARE(be_audio_output_i2s_begin, "b", ".");
+
+// AudioOutput.stop() -> bool
+extern int be_audio_output_i2s_stop(void* out);
+BE_FUNC_CTYPE_DECLARE(be_audio_output_i2s_stop, "b", ".");
+
+// AudioOutput.flush() -> bool
+extern void be_audio_output_i2s_flush(void* out);
+BE_FUNC_CTYPE_DECLARE(be_audio_output_i2s_flush, "", ".");
 
 // AudioOutput.set_rate(rate_hz:int) -> bool
 extern int be_audio_output_set_rate(void* out, int hz);
@@ -54,17 +68,7 @@ BE_FUNC_CTYPE_DECLARE(be_audio_output_set_channels, "b", ".i");
 extern int be_audio_output_set_gain(void* out, float gain);
 BE_FUNC_CTYPE_DECLARE(be_audio_output_set_gain, "b", ".f");
 
-// AudioOutput.begin() -> bool
-extern int be_audio_output_begin(void* out);
-BE_FUNC_CTYPE_DECLARE(be_audio_output_begin, "b", ".");
 
-// AudioOutput.stop() -> bool
-extern int be_audio_output_stop(void* out);
-BE_FUNC_CTYPE_DECLARE(be_audio_output_stop, "b", ".");
-
-// AudioOutput.flush() -> bool
-extern void be_audio_output_flush(void* out);
-BE_FUNC_CTYPE_DECLARE(be_audio_output_flush, "", ".");
 
 // AudioOutput.consume_mono(bytes) -> int
 extern int be_audio_output_consume_mono(void* out, uint16_t *pcm, int bytes_len, int index);
@@ -83,7 +87,6 @@ extern int i2s_output_i2s_set_lsb_justified(void* out, bbool lsbJustified);
 BE_FUNC_CTYPE_DECLARE(i2s_output_i2s_set_lsb_justified, "b", ".b");
 
 
-#include "be_fixed_be_class_AudioOutput.h"
 #include "be_fixed_be_class_AudioOutputI2S.h"
 #include "be_fixed_be_class_AudioGenerator.h"
 #include "be_fixed_be_class_AudioGeneratorWAV.h"
@@ -93,13 +96,22 @@ BE_FUNC_CTYPE_DECLARE(i2s_output_i2s_set_lsb_justified, "b", ".b");
 
 /* @const_object_info_begin
 
-class be_class_AudioOutput (scope: global, name: AudioOutput, strings: weak) {
+class be_class_AudioGenerator (scope: global, name: AudioGenerator, strings: weak) {
     .p, var
-    init, ctype_func(be_audio_output_init)
+}
 
-    begin, ctype_func(be_audio_output_begin)
-    stop, ctype_func(be_audio_output_stop)
-    flush, ctype_func(be_audio_output_flush)
+class be_class_AudioFileSource (scope: global, name: AudioFileSource, strings: weak) {
+    .p, var
+}
+
+class be_class_AudioOutputI2S (scope: global, name: AudioOutputI2S, strings: weak) {
+    .p, var
+    init, ctype_func(be_audio_output_i2s_init)
+    deinit, ctype_func(be_audio_output_i2s_deinit)
+
+    begin, ctype_func(be_audio_output_i2s_begin)
+    stop, ctype_func(be_audio_output_i2s_stop)
+    flush, ctype_func(be_audio_output_i2s_flush)
 
     consume_mono, ctype_func(be_audio_output_consume_mono)
     consume_stereo, ctype_func(be_audio_output_consume_stereo)
@@ -109,20 +121,6 @@ class be_class_AudioOutput (scope: global, name: AudioOutput, strings: weak) {
     set_bits_per_sample, ctype_func(be_audio_output_set_bits_per_sample)
     set_channels, ctype_func(be_audio_output_set_channels)
     set_gain, ctype_func(be_audio_output_set_gain)
-}
-
-class be_class_AudioGenerator (scope: global, name: AudioGenerator, strings: weak) {
-    .p, var
-}
-
-class be_class_AudioFileSource (scope: global, name: AudioFileSource, strings: weak) {
-    .p, var
-}
-
-class be_class_AudioOutputI2S (scope: global, name: AudioOutputI2S, super: be_class_AudioOutput, strings: weak) {
-    init, func(i2s_output_i2s_init)
-    deinit, func(i2s_output_i2s_deinit)
-    stop, func(i2s_output_i2s_stop)
 }
 
 class be_class_AudioGeneratorWAV (scope: global, name: AudioGeneratorWAV, super: be_class_AudioGenerator, strings: weak) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_audio.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_audio.ino
@@ -38,10 +38,31 @@
 \*********************************************************************************************/
 extern "C" {
 
-  // AudioOutput.set_rate(rate_hz:int) -> bool
-  void* be_audio_output_init(void) {
-    return new AudioOutput();
+  // AudioOutputI2S.init() -> instance 
+  void* be_audio_output_i2s_init(void) {
+    return audio_i2s.out;               // return the singleton of TasmotaAudioOutputI2S which is already initialized
   }
+
+  // AudioOutputI2S.deinit()-> void
+  void be_audio_output_i2s_deinit(TasmotaAudioOutputI2S * out) {
+    out->stop();
+  }
+
+  // AudioOutputI2S.begin() -> bool
+  int be_audio_output_i2s_begin(TasmotaAudioOutputI2S* out) {
+    return out->begin();
+  }
+
+  // AudioOutputI2S.stop() -> bool
+  int be_audio_output_i2s_stop(TasmotaAudioOutputI2S* out) {
+    return out->stop();
+  }
+
+  // AudioOutputI2S.flush() -> bool
+  void be_audio_output_i2s_flush(AudioOutput* out) {
+    out->flush();
+  }
+
   // AudioOutput.set_rate(rate_hz:int) -> bool
   int be_audio_output_set_rate(AudioOutput* out, int hz) {
     return out->SetRate(hz);
@@ -60,21 +81,6 @@ extern "C" {
   // AudioOutput.set_gain(gain:real) -> bool
   int be_audio_output_set_gain(AudioOutput* out, float gain) {
     return out->SetGain(gain);
-  }
-
-  // AudioOutput.begin() -> bool
-  int be_audio_output_begin(AudioOutput* out) {
-    return out->begin();
-  }
-
-  // AudioOutput.stop() -> bool
-  int be_audio_output_stop(AudioOutput* out) {
-    return out->stop();
-  }
-
-  // AudioOutput.flush() -> bool
-  void be_audio_output_flush(AudioOutput* out) {
-    out->flush();
   }
 
   // AudioOutput.consume_mono(bytes) -> int
@@ -136,16 +142,6 @@ extern "C" {
       be_setmember(vm, 1, ".p");
     }
 
-    be_return_nil(vm);
-  }
-
-  int i2s_output_i2s_stop(bvm *vm) {
-    int argc = be_top(vm);
-    be_getmember(vm, 1, ".p");
-    TasmotaAudioOutputI2S * audio = (TasmotaAudioOutputI2S *) be_tocomptr(vm, -1);
-    if (audio) {
-      audio->stop();
-    }
     be_return_nil(vm);
   }
 


### PR DESCRIPTION
## Description:

Fix Berry audio mapping, MP3 example working.

```berry

class MP3_Player : Driver
  var audio_output, audio_mp3, fast_loop_closure
  def init()
    self.audio_output = AudioOutputI2S()
    self.audio_mp3 = AudioGeneratorMP3()
    self.fast_loop_closure = def () self.fast_loop() end
    tasmota.add_fast_loop(self.fast_loop_closure)
  end

  def play(mp3_fname)
    if self.audio_mp3.isrunning()
      self.audio_mp3.stop()
    end
    var audio_file = AudioFileSourceFS(mp3_fname)
    self.audio_mp3.begin(audio_file, self.audio_output)
    self.audio_mp3.loop()    #- start playing now -#
  end

  def fast_loop()
    if self.audio_mp3.isrunning()
      if !self.audio_mp3.loop()
        self.audio_mp3.stop()
        tasmota.remove_fast_loop(self.fast_loop_closure)
      end
    end
  end
end

mp3_player = MP3_Player()
mp3_player.play("/pno-cs.mp3")
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.13
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
