### PR TITLE
Allow webbutton up to 32

### DIFF
--- a/tasmota/include/tasmota.h
+++ b/tasmota/include/tasmota.h
@@ -122,7 +122,7 @@ const uint8_t MAX_STATE_TEXT = 4;           // Max number of State names (OFF, O
 const uint8_t MAX_NTP_SERVERS = 3;          // Max number of NTP servers
 const uint8_t MAX_RULE_MEMS = 16;           // Max number of saved vars
 const uint8_t MAX_FRIENDLYNAMES = 8;        // Max number of Friendly names
-const uint8_t MAX_BUTTON_TEXT = 16;         // Max number of GUI button labels
+const uint8_t MAX_BUTTON_TEXT = 32;         // Max number of GUI button labels
 const uint8_t MAX_GROUP_TOPICS = 4;         // Max number of Group Topics
 const uint8_t MAX_DEV_GROUP_NAMES = 4;      // Max number of Device Group names
 
@@ -484,7 +484,12 @@ enum SettingsTextIndex { SET_OTAURL,
                          SET_SHD_PARAM,
                          SET_RGX_SSID, SET_RGX_PASSWORD,
                          SET_INFLUXDB_HOST, SET_INFLUXDB_PORT, SET_INFLUXDB_ORG, SET_INFLUXDB_TOKEN, SET_INFLUXDB_BUCKET, SET_INFLUXDB_RP,
-                         SET_MAX };
+                         SET_MAX, // limit of texts stored in Settings
+                         // Index above are not stored in Settings and should be handled specifically in SettingText()
+                         SET_BUTTON17, SET_BUTTON18, SET_BUTTON19, SET_BUTTON20, SET_BUTTON21, SET_BUTTON22, SET_BUTTON23, SET_BUTTON24,
+                         SET_BUTTON25, SET_BUTTON26, SET_BUTTON27, SET_BUTTON28, SET_BUTTON29, SET_BUTTON30, SET_BUTTON31, SET_BUTTON32,
+                         SET_FINAL_MAX
+                         };
 
 enum SpiInterfaces { SPI_NONE, SPI_MOSI, SPI_MISO, SPI_MOSI_MISO };
 

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -682,7 +682,11 @@ bool SettingsUpdateText(uint32_t index, const char* replace_me) {
 char* SettingsText(uint32_t index) {
   char* position = Settings->text_pool;
 
-  if (index >= SET_MAX) {
+  if (index >= SET_MAX) { // Index above SET_MAX are not stored in Settings
+#ifdef USE_WEBSERVER
+    if (SET_BUTTON17 <= index && index <= SET_BUTTON32)
+      return (char*)GetWebButton(index-SET_BUTTON17+16);
+#endif
     position += settings_text_size -1;  // Setting not supported - internal error - return empty string
   } else {
     SettingsUpdateFinished();

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -305,6 +305,7 @@ void ResponseCmndAll(uint32_t text_index, uint32_t count) {
 #ifdef MQTT_DATA_STRING
   for (uint32_t i = 0; i < count; i++) {
     if ((SET_MQTT_GRP_TOPIC == text_index) && (1 == i)) { real_index = SET_MQTT_GRP_TOPIC2 -1; }
+    if ((SET_BUTTON1 == text_index) && (16 == i)) { real_index = SET_BUTTON17 -16; }
     ResponseAppend_P(PSTR("%c\"%s%d\":\"%s\""), (i)?',':'{', XdrvMailbox.command, i +1, EscapeJSONString(SettingsText(real_index +i)).c_str());
   }
   ResponseJsonEnd();

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -3701,7 +3701,7 @@ String *WebButton1732[16] = {0,};
 void SetWebButton(uint8_t button_index, const char *text) {
   if (button_index < 16) 
     SettingsUpdateText(SET_BUTTON1 + button_index, text);
-  else if (button_index < 32) {
+  else if (button_index < MAX_BUTTON_TEXT) {
     button_index -= 16;
     if (!WebButton1732[button_index]) 
       WebButton1732[button_index] = new String(text);
@@ -3714,7 +3714,7 @@ const char* GetWebButton(uint8_t button_index) {
   static char empty[1] = {0};
   if (button_index < 16) 
     return SettingsText(SET_BUTTON1 + button_index);
-  else if (button_index < 32) {
+  else if (button_index < MAX_BUTTON_TEXT) {
     button_index -= 16;
     if (WebButton1732[button_index])
       return WebButton1732[button_index]->c_str();

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -1266,18 +1266,18 @@ void HandleRoot(void)
 #endif  // USE_SONOFF_IFAN
       uint32_t cols = WebDeviceColumns();
       for (uint32_t idx = 1; idx <= TasmotaGlobal.devices_present; idx++) {
-        bool set_button = ((idx <= MAX_BUTTON_TEXT) && strlen(SettingsText(SET_BUTTON1 + idx -1)));
+        bool set_button = ((idx <= MAX_BUTTON_TEXT) && strlen(GetWebButton(idx -1)));
 #ifdef USE_SHUTTER
         int32_t ShutterWebButton;
         if (ShutterWebButton = IsShutterWebButton(idx)) {
           WSContentSend_P(HTTP_DEVICE_CONTROL, 100 / cols, idx,
-            (set_button) ? SettingsText(SET_BUTTON1 + idx -1) : ((ShutterGetOptions(abs(ShutterWebButton)-1) & 2) /* is locked */ ? "-" : ((ShutterGetOptions(abs(ShutterWebButton)-1) & 8) /* invert web buttons */ ? ((ShutterWebButton>0) ? "&#9660;" : "&#9650;") : ((ShutterWebButton>0) ? "&#9650;" : "&#9660;"))),
+            (set_button) ? GetWebButton(idx -1) : ((ShutterGetOptions(abs(ShutterWebButton)-1) & 2) /* is locked */ ? "-" : ((ShutterGetOptions(abs(ShutterWebButton)-1) & 8) /* invert web buttons */ ? ((ShutterWebButton>0) ? "&#9660;" : "&#9650;") : ((ShutterWebButton>0) ? "&#9650;" : "&#9660;"))),
             "");
         } else {
 #endif  // USE_SHUTTER
           snprintf_P(stemp, sizeof(stemp), PSTR(" %d"), idx);
           WSContentSend_P(HTTP_DEVICE_CONTROL, 100 / cols, idx,
-            (set_button) ? SettingsText(SET_BUTTON1 + idx -1) : (cols < 5) ? PSTR(D_BUTTON_TOGGLE) : "",
+            (set_button) ? GetWebButton(idx -1) : (cols < 5) ? PSTR(D_BUTTON_TOGGLE) : "",
             (set_button) ? "" : (TasmotaGlobal.devices_present > 1) ? stemp : "");
 #ifdef USE_SHUTTER
         }
@@ -3696,6 +3696,32 @@ void CmndWebSensor(void)
   ResponseJsonEnd();
 }
 
+String *WebButton1732[16] = {0,};
+
+void SetWebButton(uint8_t button_index, const char *text) {
+  if (button_index < 16) 
+    SettingsUpdateText(SET_BUTTON1 + button_index, text);
+  else if (button_index < 32) {
+    button_index -= 16;
+    if (!WebButton1732[button_index]) 
+      WebButton1732[button_index] = new String(text);
+    else
+      *WebButton1732[button_index] = text;
+  }
+}
+
+const char* GetWebButton(uint8_t button_index) {
+  static char empty[1] = {0};
+  if (button_index < 16) 
+    return SettingsText(SET_BUTTON1 + button_index);
+  else if (button_index < 32) {
+    button_index -= 16;
+    if (WebButton1732[button_index])
+      return WebButton1732[button_index]->c_str();
+  }
+  return empty;
+}
+
 void CmndWebButton(void)
 {
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= MAX_BUTTON_TEXT)) {
@@ -3703,9 +3729,9 @@ void CmndWebButton(void)
       ResponseCmndAll(SET_BUTTON1, MAX_BUTTON_TEXT);
     } else {
       if (XdrvMailbox.data_len > 0) {
-        SettingsUpdateText(SET_BUTTON1 + XdrvMailbox.index -1, ('"' == XdrvMailbox.data[0]) ? "" : XdrvMailbox.data);
+        SetWebButton(XdrvMailbox.index -1, ('"' == XdrvMailbox.data[0]) ? "" : XdrvMailbox.data);
       }
-      ResponseCmndIdxChar(SettingsText(SET_BUTTON1 + XdrvMailbox.index -1));
+      ResponseCmndIdxChar(GetWebButton(XdrvMailbox.index -1));
     }
   }
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_06_snfbridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_06_snfbridge.ino
@@ -516,7 +516,7 @@ void SonoffBridgeAddButton(void) {
     for (uint32_t j = 0; j < 4; j++) {
       idx++;
       WSContentSend_P(PSTR("<td style='width:25%%'><button onclick='la(\"&k=%d\");'>%s</button></td>"), idx,  // &k is related to WebGetArg("k", tmp, sizeof(tmp));
-        (strlen(SettingsText(SET_BUTTON1 + idx -1))) ? SettingsText(SET_BUTTON1 + idx -1) : itoa(idx, number, 10));
+        (strlen(GetWebButton(idx -1))) ? GetWebButton(idx -1) : itoa(idx, number, 10));
     }
   }
   WSContentSend_P(PSTR("</tr></table>"));

--- a/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v1.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v1.ino
@@ -1600,7 +1600,7 @@ void TuyaAddButton(void) {
     char stemp[33];
     snprintf_P(stemp, sizeof(stemp), PSTR("" D_JSON_IRHVAC_MODE ""));
     WSContentSend_P(HTTP_DEVICE_CONTROL, 26, TasmotaGlobal.devices_present + 1,
-      (strlen(SettingsText(SET_BUTTON1 + TasmotaGlobal.devices_present))) ? SettingsText(SET_BUTTON1 + TasmotaGlobal.devices_present) : stemp, "");
+      (strlen(GetWebButton(TasmotaGlobal.devices_present))) ? GetWebButton(TasmotaGlobal.devices_present) : stemp, "");
     WSContentSend_P(PSTR("</tr></table>"));
   }
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v2.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v2.ino
@@ -2432,7 +2432,7 @@ void TuyaAddButton(void) {
     char stemp[33];
     snprintf_P(stemp, sizeof(stemp), PSTR("" D_JSON_IRHVAC_MODE ""));
     WSContentSend_P(HTTP_DEVICE_CONTROL, 26, TasmotaGlobal.devices_present + 1,
-      (strlen(SettingsText(SET_BUTTON1 + TasmotaGlobal.devices_present))) ? SettingsText(SET_BUTTON1 + TasmotaGlobal.devices_present) : stemp, "");
+      (strlen(GetWebButton(TasmotaGlobal.devices_present))) ? GetWebButton(TasmotaGlobal.devices_present) : stemp, "");
     WSContentSend_P(PSTR("</tr></table>"));
   }
 }

--- a/tasmota/tasmota_xlgt_light/xlgt_07_lsc_mcsl.ino
+++ b/tasmota/tasmota_xlgt_light/xlgt_07_lsc_mcsl.ino
@@ -252,7 +252,7 @@ void LscMcAddFuctionButtons(void) {
   uint32_t rows = 1;
   uint32_t cols = 8;
   for (uint32_t i = 0; i < 8; i++) {
-    if (strlen(SettingsText(SET_BUTTON1 + i +1))) {
+    if (strlen(GetWebButton(i +1))) {
       rows <<= 1;
       cols >>= 1;
       break;
@@ -269,7 +269,7 @@ void LscMcAddFuctionButtons(void) {
       WSContentSend_P(PSTR("<td style='width:%d%%'><button onclick='la(\"&lsc=%d\");'>%s</button></td>"),  // &lsc is related to WebGetArg("lsc", tmp, sizeof(tmp));
         100 / cols,
         idx -1,
-        (strlen(SettingsText(SET_BUTTON1 + idx))) ? SettingsText(SET_BUTTON1 + idx) : itoa(idx, number, 10));
+        (strlen(GetWebButton(idx))) ? GetWebButton(idx) : itoa(idx, number, 10));
     }
   }
   WSContentSend_P(PSTR("</tr></table>"));


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #19324

My proposition to support WebButton up to 32
No data stored in Settings => must use `autoexec.bat` or `on system#init` rule to set on each reboot
Usage:
- adds 176 B of flash
- adds 64 B of RAM

(Note: I have tested an alternative with +8 B of RAM instead of +64 but +224 B of flash, I believe it's better to optimize flash usage)

There's no #define. Not easy to add due to MAX_BUTTON_TEXT being defined as a const in tasmota.h (not overridable)

![image](https://github.com/arendst/Tasmota/assets/2996042/32b84c61-392f-4822-ba67-361b5da6dd1c)

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.13
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
