### PR TITLE
fix compile error with new email lib

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_01_2_webserver_esp32_mail.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_2_webserver_esp32_mail.ino
@@ -294,7 +294,9 @@ void attach_File(char *path) {
     }
     att.descr.filename = cp;
     att.descr.mime = "application/octet-stream"; //binary data
+#if ESP_MAIL_VERSION_NUM<30409
     att.file.storage_type = esp_mail_file_storage_type_univ;
+#endif
     att.descr.transfer_encoding = Content_Transfer_Encoding::enc_base64;
     email_mptr->addAttachment(att);
     email_mptr->resetAttachItem(att);


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #19521

fixes compile error until file system problems with email lib are solved

however no more file attachments in mail

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.13
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
