### PR TITLE
MI32 legacy: add mi32name, small fixes

### DIFF
--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -225,7 +225,6 @@ struct {
   } option;
 #ifdef USE_MI_EXT_GUI
   uint32_t widgetSlot;
-  bool openFetchRequest = false;
 #ifdef USE_ENERGY_SENSOR
   uint8_t *energy_history;
 #endif //USE_ENERGY_SENSOR

--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -225,12 +225,13 @@ struct {
   } option;
 #ifdef USE_MI_EXT_GUI
   uint32_t widgetSlot;
+  bool openFetchRequest = false;
 #ifdef USE_ENERGY_SENSOR
   uint8_t *energy_history;
 #endif //USE_ENERGY_SENSOR
 #endif //USE_MI_EXT_GUI
 
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
   void *outlet_hap_service[4]; //arbitrary chosen
   int8_t HKconnectedControllers = 0; //should never be < 0
   uint8_t HKinfoMsg = 0;
@@ -249,8 +250,8 @@ struct mi_sensor_t{
   uint8_t shallSendMQTT;
   uint8_t MAC[6];
   uint16_t PID;
-  uint8_t *key;
-  uint32_t lastTimeSeen;
+  uint8_t *key = nullptr;
+  char *name = nullptr;
   union {
     struct {
       uint32_t needsKey:1;
@@ -331,7 +332,7 @@ struct mi_sensor_t{
   union {
       uint8_t bat; // many values seem to be hard-coded garbage (LYWSD0x, GCD1)
   };
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
   //HAP handles
   void *temp_hap_service;
   void *hum_hap_service;
@@ -350,9 +351,9 @@ struct mi_sensor_t{
 
 #define D_CMND_MI32 "MI32"
 
-const char kMI32_Commands[] PROGMEM = D_CMND_MI32 "|Key|Cfg|Option";
+const char kMI32_Commands[] PROGMEM = D_CMND_MI32 "|Key|Name|Cfg|Option";
 
-void (*const MI32_Commands[])(void) PROGMEM = {&CmndMi32Key, &CmndMi32Cfg, &CmndMi32Option };
+void (*const MI32_Commands[])(void) PROGMEM = {&CmndMi32Key, &CmndMi32Name,&CmndMi32Cfg, &CmndMi32Option };
 
 #define UNKNOWN_MI  0
 #define FLORA       1
@@ -490,25 +491,23 @@ enum MI32_HKInfoMsg {
 const char HTTP_BTN_MENU_MI32[] PROGMEM = "<p><form action='m32' method='get'><button>Mi Dashboard</button></form></p>";
 
 const char HTTP_MI32_SCRIPT_1[] PROGMEM =
-  "function setUp(){setInterval(countUp,1000); setInterval(update,100);}"
+  "function setUp(){setInterval(countUp,1000); setInterval(update,1000);}"
   "function countUp(){let ti=document.querySelectorAll('.Ti');"
   "for(const el of ti){var t=parseInt(el.innerText);el.innerText=t+1;}}"
-  "function update(){"         //source, value
-    "var xr=new XMLHttpRequest();"
-    "xr.onreadystatechange=()=>{"
-      "if(xr.readyState==4&&xr.status==200){"
-            "var r = xr.response;" // new widget
-            "if(r.length>2000){return;};if(r.length==0){return;}"
-            "var d = document.createElement('div');"
-            "d.innerHTML = r.trim();"
-            "var old = eb(d.firstChild.id);"
-            "old.parentNode.replaceChild(d.firstChild,old);"
-        "};"
-      "};"
-    "xr.open('GET','/m32?wi=1',true);"
-    "xr.send();"
-    "};"
-  ;
+  "function update(){"
+    "fetch('/m32?wi=1').then(r=>r.text())"
+    ".then((r)=>{"
+      // console.log(r); // optional
+      "if(r.length>0){"
+        "var d=document.createElement('div');"
+        "d.innerHTML=r.trim();"
+        "var old=eb(d.firstChild.id);"
+        "old.parentNode.replaceChild(d.firstChild, old);"
+      "}"
+    "})"
+    //".catch((e) => {console.error(e);});" //optional
+  "};"
+;
 
 const char HTTP_MI32_STYLE[] PROGMEM =
   "<style onload=setTimeout(setUp,500)>.parent {display: flex;flex-wrap: wrap;justify-content: center;}svg{float:inline-end;}"
@@ -525,7 +524,7 @@ const char HTTP_MI32_PARENT_START[] PROGMEM =
       "<div class='box'><h2>MI32 Bridge</h2>"
           "Observing <span id='numDev'>%u</span> devices<br>"
           "Uptime: <span class='Ti'>%u</span> seconds<br>"
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
           "HomeKit setup code: %s<br>"
           "HAP controller connections: %d<br>"
 #else

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -71,7 +71,7 @@
 #if USE_MI_HOMEKIT==0
   #undef USE_MI_HOMEKIT
 #endif
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
 extern "C" void mi_homekit_main(void);
 extern "C" void mi_homekit_update_value(void* handle, float value, uint32_t type);
 extern "C" void mi_homekit_stop();
@@ -497,7 +497,7 @@ uint32_t MIBLEgetSensorSlot(uint8_t (&_MAC)[6], uint16_t _type, uint8_t counter)
       _newSensor.feature.fert=1;
       _newSensor.feature.lux=1;
       _newSensor.feature.bat=1;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
       _newSensor.light_hap_service = nullptr;
 #endif
       break;
@@ -506,7 +506,7 @@ uint32_t MIBLEgetSensorSlot(uint8_t (&_MAC)[6], uint16_t _type, uint8_t counter)
       _newSensor.feature.motion=1;
       _newSensor.feature.NMT=1;
       _newSensor.NMT=0;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
       _newSensor.motion_hap_service = nullptr;
 #endif //USE_MI_HOMEKIT
       break;
@@ -517,7 +517,7 @@ uint32_t MIBLEgetSensorSlot(uint8_t (&_MAC)[6], uint16_t _type, uint8_t counter)
       _newSensor.feature.NMT=1;
       _newSensor.feature.lux=1;
       _newSensor.feature.bat=1;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
       _newSensor.light_hap_service = nullptr;
       _newSensor.motion_hap_service = nullptr;
 #endif //USE_MI_HOMEKIT
@@ -531,7 +531,7 @@ uint32_t MIBLEgetSensorSlot(uint8_t (&_MAC)[6], uint16_t _type, uint8_t counter)
         _newSensor.feature.knob = 1;
         _newSensor.dimmer = 0;
       }
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
       _newSensor.button_hap_service[0] = nullptr;
 #endif //USE_MI_HOMEKIT
       break;
@@ -539,7 +539,7 @@ uint32_t MIBLEgetSensorSlot(uint8_t (&_MAC)[6], uint16_t _type, uint8_t counter)
       _newSensor.events=0x00;
       _newSensor.feature.bat=1;
       _newSensor.feature.door=1;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
       _newSensor.door_sensor_hap_service = nullptr;
 #endif //USE_MI_HOMEKIT
       _newSensor.door = 255;
@@ -549,7 +549,7 @@ uint32_t MIBLEgetSensorSlot(uint8_t (&_MAC)[6], uint16_t _type, uint8_t counter)
       _newSensor.feature.bat=1;
       _newSensor.feature.Btn=1;
       _newSensor.Btn=99;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
       _newSensor.leak_hap_service = nullptr;
       _newSensor.bat_hap_service = nullptr;
       _newSensor.button_hap_service[0] = nullptr;
@@ -562,7 +562,7 @@ uint32_t MIBLEgetSensorSlot(uint8_t (&_MAC)[6], uint16_t _type, uint8_t counter)
       _newSensor.feature.hum=1;
       _newSensor.feature.tempHum=1;
       _newSensor.feature.bat=1;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
       _newSensor.temp_hap_service = nullptr;
       _newSensor.hum_hap_service = nullptr;
       _newSensor.bat_hap_service = nullptr;
@@ -711,7 +711,7 @@ void MI32Init(void) {
 
   if(MI32.mode.didGetConfig && !Settings->flag5.zigbee_hide_bridge_topic){ // borrow SO125 1 to turn off HomeKit
     MI32.mode.didStartHAP = 0;
-  #ifdef USE_MI_HOMEKIT
+  #if USE_MI_HOMEKIT==1
     MI32getSetupCodeFromMAC(MI32.hk_setup_code);
     AddLog(LOG_LEVEL_INFO,PSTR("M32: Init HAP core"));
     mi_homekit_main();
@@ -910,6 +910,9 @@ extern "C" {
   }
 
   char * MI32getDeviceName(uint32_t slot){
+    if(MIBLEsensors[slot].name != nullptr){
+      return MIBLEsensors[slot].name;
+    }
     static char _name[12];
     if( MIBLEsensors[slot].type == UNKNOWN_MI){
       snprintf_P(_name,8,PSTR("MI_%04X"),MIBLEsensors[slot].PID);
@@ -924,7 +927,7 @@ extern "C" {
 /*********************************************************************************************\
  * Homekit section
 \*********************************************************************************************/
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
 extern "C" {
 
   const char * MI32getSetupCode(){
@@ -1093,18 +1096,29 @@ void MI32loadCfg(){
           }
           _val = _device[PSTR("key")];
           if (_val) {
-            mi_bindKey_t _keyMAC;
-            uint8_t *_key = (uint8_t*) malloc(16);
             char *_keyStr = (char *)_val.getStr();
-            if(strlen(_keyStr)==0){
-              continue;
+            if(strlen(_keyStr)>0){
+              if(strlen(_keyStr)==32){
+                uint8_t *_key = (uint8_t*) malloc(16);
+                MI32HexStringToBytes(_keyStr,_key);
+                MIBLEsensors[_numberOfDevices].key = _key;
+              }
+              else{
+                _error = true;
+                break;
+              }
             }
-            if(strlen(_keyStr)!=32){
-              _error = true;
-              break;
-            }
-            MI32HexStringToBytes(_keyStr,_key);
-            MIBLEsensors[_numberOfDevices].key = _key;
+          }
+          _val = _device[PSTR("name")];
+          if (_val) {
+            char *_name = (char *)_val.getStr();
+            MIBLEsensors[_numberOfDevices].name = new char[strlen(_name) + 1];
+            strcpy(MIBLEsensors[_numberOfDevices].name, _name);
+            AddLog(LOG_LEVEL_INFO,PSTR("M32: found name: %s"), _name);
+          }
+          _val = _device[PSTR("feat")];
+          if (_val) {
+            MIBLEsensors[_numberOfDevices].feature.raw = _val.getUInt();
           }
       }
       if(!_error){
@@ -1128,7 +1142,14 @@ void MI32saveConfig(){
     if(_sensor.key != nullptr){
       ToHex_P(_sensor.key,16,_key,33);
     }
-    uint32_t _inc = snprintf_P(_filebuf+_pos,200,PSTR("{\"MAC\":\"%s\",\"PID\":\"%04x\",\"key\":\"%s\"},"),_MAC,kMI32DeviceID[_sensor.type - 1],_key);
+    char _name_feat[64];
+    if(_sensor.name != nullptr){
+      snprintf_P(_name_feat,64,PSTR(",\"name\":\"%s\",\"feat\":%u"),_sensor.name,_sensor.feature.raw);
+    }
+    else{
+      _name_feat[0] = 0;
+    }
+    uint32_t _inc = snprintf_P(_filebuf+_pos,200,PSTR("{\"MAC\":\"%s\",\"PID\":\"%04x\",\"key\":\"%s\"%s},"),_MAC,kMI32DeviceID[_sensor.type - 1],_key,_name_feat);
     _pos += _inc;
   }
   _filebuf[_pos-1] = ']';
@@ -1202,7 +1223,7 @@ void MI32ScanTask(void *pvParameters){
 
   MI32Scan = NimBLEDevice::getScan();
 
-  MI32Scan->setScanCallbacks(&MI32ScanCallbacks,false);
+  MI32Scan->setScanCallbacks(&MI32ScanCallbacks,true);
   if(NimBLEDevice::getWhiteListCount()>0){
     MI32Scan->setFilterPolicy(BLE_HCI_SCAN_FILT_USE_WL);
   }
@@ -1630,7 +1651,7 @@ if(decryptRet!=0){
         MIBLEsensors[_slot].longpress = _payload.Btn.value;
         MI32.mode.shallTriggerTele = 1;
         MIBLEsensors[_slot].eventType.longpress = 1;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
       if((void**)MIBLEsensors[_slot].button_hap_service[0] != nullptr){
         mi_homekit_update_value(MIBLEsensors[_slot].button_hap_service[0], (float)2.0f, 0x01); // only one button, long press = 2
         }
@@ -1647,7 +1668,7 @@ if(decryptRet!=0){
       }
       MIBLEsensors[_slot].eventType.Btn = 1;
       MI32.mode.shallTriggerTele = 1;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
       if(MIBLEsensors[_slot].Btn>5) break; // hard coded limit for now
       if((void**)MIBLEsensors[_slot].button_hap_service[MIBLEsensors[_slot].Btn] != nullptr){
         // AddLog(LOG_LEVEL_DEBUG,PSTR("Send Button %u:  SingleLong:%u, pointer: %x"), MIBLEsensors[_slot].Btn,_singleLong,MIBLEsensors[_slot].button_hap_service[MIBLEsensors[_slot].Btn] );
@@ -1664,7 +1685,7 @@ if(decryptRet!=0){
         MIBLEsensors[_slot].eventType.temp = 1;
         DEBUG_SENSOR_LOG(PSTR("Mode 4: temp updated"));
       }
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
         mi_homekit_update_value(MIBLEsensors[_slot].temp_hap_service, _tempFloat, 0x04);
 #endif //USE_MI_HOMEKIT
 #ifdef USE_MI_EXT_GUI
@@ -1680,7 +1701,7 @@ if(decryptRet!=0){
         MIBLEsensors[_slot].eventType.hum = 1;
         DEBUG_SENSOR_LOG(PSTR("Mode 6: hum updated"));
       }
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
         mi_homekit_update_value(MIBLEsensors[_slot].hum_hap_service, _tempFloat,0x06);
 #endif //USE_MI_HOMEKIT
 #ifdef USE_MI_EXT_GUI
@@ -1695,7 +1716,7 @@ if(decryptRet!=0){
         MIBLEsensors[_slot].eventType.noMotion  = 1;
       }
       MIBLEsensors[_slot].eventType.lux  = 1;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
         mi_homekit_update_value(MIBLEsensors[_slot].light_hap_service, (float)MIBLEsensors[_slot].lux,0x07);
 #endif //USE_MI_HOMEKIT
 #ifdef USE_MI_EXT_GUI
@@ -1728,7 +1749,7 @@ if(decryptRet!=0){
         MIBLEsensors[_slot].bat = _payload.bat;
         MIBLEsensors[_slot].eventType.bat  = 1;
         DEBUG_SENSOR_LOG(PSTR("Mode a: bat updated"));
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
           mi_homekit_update_value(MIBLEsensors[_slot].bat_hap_service, (float)_payload.bat,0xa);
 #endif //USE_MI_HOMEKIT
       }
@@ -1759,7 +1780,7 @@ if(decryptRet!=0){
       MIBLEsensors[_slot].eventType.lux = 1;
       MIBLEsensors[_slot].NMT = 0;
       MI32.mode.shallTriggerTele = 1;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
         mi_homekit_update_value(MIBLEsensors[_slot].motion_hap_service, (float)1,0x0f);
         mi_homekit_update_value(MIBLEsensors[_slot].light_hap_service, (float)_payload.lux,0x07);
 #endif //USE_MI_HOMEKIT
@@ -1773,7 +1794,7 @@ if(decryptRet!=0){
       MIBLEsensors[_slot].leak = _payload.leak;
       MIBLEsensors[_slot].eventType.leak = 1;
       if(_payload.leak>0) MI32.mode.shallTriggerTele = 1;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
         mi_homekit_update_value(MIBLEsensors[_slot].leak_hap_service, (float)_payload.leak,0x14);
 #endif //USE_MI_HOMEKIT
       break;
@@ -1790,7 +1811,7 @@ if(decryptRet!=0){
       MIBLEsensors[_slot].eventType.door = 1;
       MIBLEsensors[_slot].events++;
       MI32.mode.shallTriggerTele = 1;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
         mi_homekit_update_value(MIBLEsensors[_slot].door_sensor_hap_service, (float)_payload.door,0x19);
 #endif //USE_MI_HOMEKIT
       // AddLog(LOG_LEVEL_DEBUG,PSTR("Mode 19: %u"), _payload.door);
@@ -1802,7 +1823,7 @@ if(decryptRet!=0){
         MIBLEsensors[_slot].events++;
         MIBLEsensors[_slot].NMT = 0;
         MI32.mode.shallTriggerTele = 1;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
           mi_homekit_update_value(MIBLEsensors[_slot].motion_hap_service, (float)1,0x0f);
 #endif //USE_MI_HOMEKIT
       }
@@ -1844,7 +1865,7 @@ void MI32ParseATCPacket(char * _buf, uint32_t length, uint8_t addr[6], int RSSI)
 
   MIBLEsensors[_slot].eventType.tempHum  = 1;
   MIBLEsensors[_slot].eventType.bat  = 1;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
     mi_homekit_update_value(MIBLEsensors[_slot].temp_hap_service, MIBLEsensors.at(_slot).temp,0x04);
     mi_homekit_update_value(MIBLEsensors[_slot].hum_hap_service, MIBLEsensors.at(_slot).hum,0x06);
     mi_homekit_update_value(MIBLEsensors[_slot].bat_hap_service, (float)MIBLEsensors.at(_slot).bat,0x0a);
@@ -1877,7 +1898,7 @@ void MI32parseCGD1Packet(char * _buf, uint32_t length, uint8_t addr[6], int RSSI
           MIBLEsensors[_slot].temp = _tempFloat;
           MIBLEsensors[_slot].eventType.temp  = 1;
           DEBUG_SENSOR_LOG(PSTR("CGD1: temp updated"));
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
             mi_homekit_update_value(MIBLEsensors[_slot].temp_hap_service, _tempFloat,0x04);
 #endif //USE_MI_HOMEKIT
 #ifdef USE_MI_EXT_GUI
@@ -1889,7 +1910,7 @@ void MI32parseCGD1Packet(char * _buf, uint32_t length, uint8_t addr[6], int RSSI
           MIBLEsensors[_slot].hum = _tempFloat;
           MIBLEsensors[_slot].eventType.hum  = 1;
           DEBUG_SENSOR_LOG(PSTR("CGD1: hum updated"));
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
             mi_homekit_update_value(MIBLEsensors[_slot].hum_hap_service, _tempFloat,0x06);
 #endif //USE_MI_HOMEKIT
 #ifdef USE_MI_EXT_GUI
@@ -2008,7 +2029,7 @@ void MI32Every50mSecond(){
     AddLog(LOG_LEVEL_DEBUG,PSTR("M32: %s"),_message);
     MI32.infoMsg = 0;
   }
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
   if(MI32.HKinfoMsg > 0){
     char _message[32];
     GetTextIndexed(_message, sizeof(_message), MI32.HKinfoMsg-1, kMI32_HKInfoMsg);
@@ -2025,7 +2046,7 @@ void MI32Every50mSecond(){
 
 void MI32EverySecond(bool restart){
 
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
   if(TasmotaGlobal.devices_present>0){
     for(uint32_t i=0;i<TasmotaGlobal.devices_present;i++){
       power_t mask = 1 << i;
@@ -2039,7 +2060,7 @@ void MI32EverySecond(bool restart){
   for (uint32_t i = 0; i < MIBLEsensors.size(); i++) {
     if(MIBLEsensors[i].type==NLIGHT || MIBLEsensors[i].type==MJYD2S){
       MIBLEsensors[i].NMT++;
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
       if(MIBLEsensors[i].NMT > 20){ //TODO: Make a choosable timeout later
         mi_homekit_update_value(MIBLEsensors[i].motion_hap_service,0.0f,0x0f);
       }
@@ -2065,6 +2086,20 @@ void CmndMi32Key(void) {
     MI32AddKey(keyMAC);
     ResponseCmndDone();
   }
+}
+
+void CmndMi32Name(void) {
+  if(MIBLEsensors[XdrvMailbox.index].name != nullptr){
+    delete []MIBLEsensors[XdrvMailbox.index].name;
+  }
+  if(XdrvMailbox.data_len==0){
+    MIBLEsensors[XdrvMailbox.index].name = nullptr;
+  }
+  else{
+    MIBLEsensors[XdrvMailbox.index].name = new char[XdrvMailbox.data_len + 1];
+    strcpy(MIBLEsensors[XdrvMailbox.index].name,XdrvMailbox.data);
+  }
+  ResponseCmndChar((const char*)MI32getDeviceName(XdrvMailbox.index));
 }
 
 void CmndMi32Cfg(void) {
@@ -2135,14 +2170,14 @@ bool MI32HandleWebGUIResponse(void){
   char tmp[16];
   WebGetArg(PSTR("wi"), tmp, sizeof(tmp));
   if (strlen(tmp)) {
-    WSContentBegin(200, CT_PLAIN);
-    if(MI32.widgetSlot==0) {WSContentEnd();return true;}
-    for(uint32_t i=0;i<32;i++){
-      if(bitRead(MI32.widgetSlot,i)){
-        MI32sendWidget(i);
-        WSContentEnd();
-        bitClear(MI32.widgetSlot,i);
-        return true;
+    WSContentBegin(200, CT_PLAIN);                         
+    if(MI32.widgetSlot!=0){
+      for(uint32_t i=0;i<32;i++){
+        if(bitRead(MI32.widgetSlot,i)){
+          MI32sendWidget(i);
+          bitClear(MI32.widgetSlot,i);
+          break;
+        }
       }
     }
     WSContentEnd();
@@ -2315,13 +2350,12 @@ void MI32InitGUI(void){
   MI32.widgetSlot=0;
   WSContentStart_P("m32");
   WSContentSend_P(HTTP_MI32_SCRIPT_1);
-  // WSContentSend_P(HTTP_MI32_SCRIPT_1);
   WSContentSendStyle();
   WSContentSend_P(HTTP_MI32_STYLE);
   WSContentSend_P(HTTP_MI32_STYLE_SVG,1,185,124,124,185,124,124);
   WSContentSend_P(HTTP_MI32_STYLE_SVG,2,151,190,216,151,190,216);
   WSContentSend_P(HTTP_MI32_STYLE_SVG,3,242,240,176,242,240,176);
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
   WSContentSend_P((HTTP_MI32_PARENT_START),MIBLEsensors.size(),UpTime(),MI32.hk_setup_code,MI32.HKconnectedControllers,ESP.getFreeHeap()/1024);
 #else
   const char _setupCode[1] = {0};
@@ -2374,24 +2408,30 @@ void MI32ShowContinuation(bool *commaflg) {
 void MI32Show(bool json)
 {
   if (json) {
-    if(!MI32.mode.triggeredTele){
-      if(MI32.option.noSummary) return; // no message at TELEPERIOD
+    if(MI32.mode.triggeredTele == 0){
+      if(MI32.option.noSummary == 1) return; // no message at TELEPERIOD
       }
     if(TasmotaGlobal.masterlog_level == LOG_LEVEL_DEBUG_MORE) return; // we want to announce sensors unlinked to the ESP, check for LOG_LEVEL_DEBUG_MORE is medium-safe
     MI32suspendScanTask();
     for (uint32_t i = 0; i < MIBLEsensors.size(); i++) {
-      if(MI32.mode.triggeredTele && MIBLEsensors[i].eventType.raw == 0) continue;
-      if(MI32.mode.triggeredTele && MIBLEsensors[i].shallSendMQTT==0) continue;
+      if(MI32.mode.triggeredTele == 1 && MIBLEsensors[i].eventType.raw == 0) continue;
+      if(MI32.mode.triggeredTele == 1 && MIBLEsensors[i].shallSendMQTT==0) continue;
 
       bool commaflg = false;
-      ResponseAppend_P(PSTR(",\"%s-%02x%02x%02x\":{"),
-        MI32getDeviceName(i),
-        MIBLEsensors[i].MAC[3], MIBLEsensors[i].MAC[4], MIBLEsensors[i].MAC[5]);
+      if( MIBLEsensors[i].name == nullptr){
+        ResponseAppend_P(PSTR(",\"%s-%02x%02x%02x\":{"),
+          MI32getDeviceName(i),
+          MIBLEsensors[i].MAC[3], MIBLEsensors[i].MAC[4], MIBLEsensors[i].MAC[5]);
+      }
+      else{
+        ResponseAppend_P(PSTR(",\"%s\":{"),
+          MI32getDeviceName(i));
+      }
 
-      if((!MI32.mode.triggeredTele && !MI32.option.minimalSummary)||MI32.mode.triggeredTele){
+      if((MI32.mode.triggeredTele == 1 && MI32.option.minimalSummary == 0)||MI32.mode.triggeredTele == 1){
         bool tempHumSended = false;
         if(MIBLEsensors[i].feature.tempHum){
-          if(MIBLEsensors[i].eventType.tempHum || !MI32.mode.triggeredTele || MI32.option.allwaysAggregate){
+          if(MIBLEsensors[i].eventType.tempHum || MI32.mode.triggeredTele == 0 || MI32.option.allwaysAggregate == 1){
             if (!isnan(MIBLEsensors[i].hum) && !isnan(MIBLEsensors[i].temp)) {
               MI32ShowContinuation(&commaflg);
               ResponseAppendTHD(MIBLEsensors[i].temp, MIBLEsensors[i].hum);
@@ -2400,7 +2440,7 @@ void MI32Show(bool json)
           }
         }
         if(MIBLEsensors[i].feature.temp && !tempHumSended){
-          if(MIBLEsensors[i].eventType.temp || !MI32.mode.triggeredTele || MI32.option.allwaysAggregate) {
+          if(MIBLEsensors[i].eventType.temp || MI32.mode.triggeredTele == 0 || MI32.option.allwaysAggregate == 1) {
             if (!isnan(MIBLEsensors[i].temp)) {
               MI32ShowContinuation(&commaflg);
               ResponseAppend_P(PSTR("\"" D_JSON_TEMPERATURE "\":%*_f"),
@@ -2409,7 +2449,7 @@ void MI32Show(bool json)
           }
         }
         if(MIBLEsensors[i].feature.hum && !tempHumSended){
-          if(MIBLEsensors[i].eventType.hum || !MI32.mode.triggeredTele || MI32.option.allwaysAggregate) {
+          if(MIBLEsensors[i].eventType.hum || MI32.mode.triggeredTele == 0 || MI32.option.allwaysAggregate == 1) {
             if (!isnan(MIBLEsensors[i].hum)) {
               char hum[FLOATSZ];
               dtostrfd(MIBLEsensors[i].hum, Settings->flag2.humidity_resolution, hum);
@@ -2419,7 +2459,7 @@ void MI32Show(bool json)
           }
         }
         if (MIBLEsensors[i].feature.lux){
-          if(MIBLEsensors[i].eventType.lux || !MI32.mode.triggeredTele || MI32.option.allwaysAggregate){
+          if(MIBLEsensors[i].eventType.lux || MI32.mode.triggeredTele == 0 || MI32.option.allwaysAggregate == 1){
             if ((MIBLEsensors[i].lux != 0x0ffffff)) { // this is the error code -> no lux
               MI32ShowContinuation(&commaflg);
               ResponseAppend_P(PSTR("\"" D_JSON_ILLUMINANCE "\":%u"), MIBLEsensors[i].lux);
@@ -2427,7 +2467,7 @@ void MI32Show(bool json)
           }
         }
         if (MIBLEsensors[i].feature.moist){
-          if(MIBLEsensors[i].eventType.moist || !MI32.mode.triggeredTele || MI32.option.allwaysAggregate){
+          if(MIBLEsensors[i].eventType.moist || MI32.mode.triggeredTele == 0 || MI32.option.allwaysAggregate == 1){
             if ((MIBLEsensors[i].moisture != 0xff)) {
               MI32ShowContinuation(&commaflg);
               ResponseAppend_P(PSTR("\"" D_JSON_MOISTURE "\":%u"), MIBLEsensors[i].moisture);
@@ -2435,7 +2475,7 @@ void MI32Show(bool json)
           }
         }
         if (MIBLEsensors[i].feature.fert){
-          if(MIBLEsensors[i].eventType.fert || !MI32.mode.triggeredTele || MI32.option.allwaysAggregate){
+          if(MIBLEsensors[i].eventType.fert || MI32.mode.triggeredTele == 0 || MI32.option.allwaysAggregate == 1){
             if ((MIBLEsensors[i].fertility != 0xffff)) {
               MI32ShowContinuation(&commaflg);
               ResponseAppend_P(PSTR("\"Fertility\":%u"), MIBLEsensors[i].fertility);
@@ -2464,7 +2504,7 @@ void MI32Show(bool json)
         }
       } // minimal summary
       if (MIBLEsensors[i].feature.motion){
-        if(MIBLEsensors[i].eventType.motion || !MI32.mode.triggeredTele){
+        if(MIBLEsensors[i].eventType.motion || MI32.mode.triggeredTele == 0){
           if(MI32.mode.triggeredTele) {
             MI32ShowContinuation(&commaflg);
             ResponseAppend_P(PSTR("\"Motion\":1")); // only real-time
@@ -2479,7 +2519,7 @@ void MI32Show(bool json)
       }
 
       if (MIBLEsensors[i].feature.door){
-        if(MIBLEsensors[i].eventType.door || !MI32.mode.triggeredTele){
+        if(MIBLEsensors[i].eventType.door || MI32.mode.triggeredTele == 0){
           if(MI32.mode.triggeredTele) {
             MI32ShowContinuation(&commaflg);
             ResponseAppend_P(PSTR("\"Door\":%u"),MIBLEsensors[i].door);
@@ -2489,21 +2529,21 @@ void MI32Show(bool json)
         }
       }
 
-      if (MIBLEsensors[i].type == FLORA && !MI32.mode.triggeredTele) {
+      if (MIBLEsensors[i].type == FLORA && MI32.mode.triggeredTele == 0) {
         if (MIBLEsensors[i].firmware[0] != '\0') { // this is the error code -> no firmware
           MI32ShowContinuation(&commaflg);
           ResponseAppend_P(PSTR("\"Firmware\":\"%s\""), MIBLEsensors[i].firmware);
         }
       }
 
-      if (MIBLEsensors[i].feature.NMT || !MI32.mode.triggeredTele){
+      if (MIBLEsensors[i].feature.NMT || MI32.mode.triggeredTele == 0){
         if(MIBLEsensors[i].eventType.NMT){
           MI32ShowContinuation(&commaflg);
           ResponseAppend_P(PSTR("\"NMT\":%u"), MIBLEsensors[i].NMT);
         }
       }
       if (MIBLEsensors[i].feature.bat){
-        if(MIBLEsensors[i].eventType.bat || !MI32.mode.triggeredTele || MI32.option.allwaysAggregate){
+        if(MIBLEsensors[i].eventType.bat || MI32.mode.triggeredTele == 0 || MI32.option.allwaysAggregate == 1){
           if ((MIBLEsensors[i].bat != 0x00)) {
             MI32ShowContinuation(&commaflg);
             ResponseAppend_P(PSTR("\"Battery\":%u"), MIBLEsensors[i].bat);
@@ -2511,8 +2551,8 @@ void MI32Show(bool json)
         }
       }
       MI32ShowContinuation(&commaflg);
-      ResponseAppend_P(PSTR("\"RSSI\":%d"), MIBLEsensors[i].RSSI);
-
+      ResponseAppend_P(PSTR("\"RSSI\":%d,"), MIBLEsensors[i].RSSI);
+      ResponseAppend_P(PSTR("\"MAC\":\"%02X%02X%02X%02X%02X%02X\""),MIBLEsensors[i].MAC[0],MIBLEsensors[i].MAC[1],MIBLEsensors[i].MAC[2],MIBLEsensors[i].MAC[3],MIBLEsensors[i].MAC[4],MIBLEsensors[i].MAC[5]);
       ResponseJsonEnd();
 
       MIBLEsensors[i].eventType.raw = 0;
@@ -2534,7 +2574,7 @@ void MI32Show(bool json)
       MI32suspendScanTask();
 
       WSContentSend_P(HTTP_MI32, MIBLEsensors.size());
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
       if(MI32.mode.didStartHAP){
         WSContentSend_PD(PSTR("{s}HomeKit Code{m} %s{e}"),MI32.hk_setup_code);
       }
@@ -2602,7 +2642,7 @@ int ExtStopBLE(){
         AddLog(LOG_LEVEL_INFO,PSTR("M32: stop BLE"));
         while (MI32.mode.runningScan) yield();
       }
-#ifdef USE_MI_HOMEKIT
+#if USE_MI_HOMEKIT==1
       if(MI32.mode.didStartHAP) {
         AddLog(LOG_LEVEL_INFO,PSTR("M32: stop Homebridge"));
         mi_homekit_stop();


### PR DESCRIPTION
## Description:

* Add command `mi32name` to better handle unknown/new sensors.
Usage:
`mi32name<slot> <new name>`, where slot is the position of the observed sensor in the the  internal array (reflected in the order of the sensors after `status 8`) starting with 0.
`mi32name<slot>` will delete the overridden sensor name and use the built-in one.
When an unknown sensor gets a name, the command `mi32cfg` will write this to the driver config. It could be changed in the mi32cfg-file too, as this is a JSON.

* An unknown sensor will "learn" its features over time with every received data packet. When all features have been learned, the command `mi32cfg`will save this feature descriptor in the mi32cfg-file. It is mandatory to give these sensors a name before.

* Adds MAC to every MQTT message, as with overridden names, the automatically suffixed OUI of the MAC for built-in names will not be there

* Use fetch instead of XMLHttpRequest in the embedded web dashboard JS code

* Reduce the traffic of the embedded dashboard by relaxing the update interval in order to slightly improve the currently observed memory leak of the webserver under Arduino 3.0. This bug will reduce the free heap after each fetch/XMLHttpRequest until there is not enough of it. The the system will likely slow down after awhile  and later recover "automagically" as if there is some kind of garbage collection in the background. Did not find the exact reason yet.

* Better handle the slightly changed API of esp-nimble-cpp to catch more sensor messages

* minor refactoring 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.13
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
