### PR TITLE
Add missing UPDATE_COMMANDS for Occupancy sensor

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Occupancy.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Occupancy.be
@@ -30,6 +30,7 @@ class Matter_Plugin_Sensor_Occupancy : Matter_Plugin_Device
   static var ARG_HINT = "Switch<x> number"
   static var ARG_TYPE = / x -> int(x)               # function to convert argument to the right type
   static var UPDATE_TIME = 750                      # update every 750ms
+  static var UPDATE_COMMANDS = matter.UC_LIST(_class, "Occupancy")
   static var CLUSTERS  = matter.consolidate_clusters(_class, {
     0x0406: [0,1,2,0xFFFC,0xFFFD],                  # Occupancy Sensing p.105 - no writable
   })


### PR DESCRIPTION
Add missing UPDATE_COMMANDS for Occupancy sensor

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.13
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
