### PR TITLE
LittleFS core updated to version with `grow`

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -63,7 +63,7 @@ lib_ignore                  = ESP Mail Client
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.09.01/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.10.00/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

- makes it possible to increase LittleFS without loosing FS content. Fully backwards compatible
  Not (yet) implemented in Tasmota

- not in Tasmota used SPIFFS removed in IDF and Arduino framework
- tool mklittlefs updated to support download and extract FS image partition
- esptool.py updated to v4.7-dev

@s-hadinger fyi

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.13
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
