### PR TITLE
MI32 Legacy: conform to API changes

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -166,16 +166,16 @@ class MI32AdvCallbacks: public NimBLEScanCallbacks {
 static std::queue<BLEqueueBuffer_t> BLEmessageQueue;
 
 class MI32ServerCallbacks: public NimBLEServerCallbacks {
-    void onConnect(NimBLEServer* pServer, ble_gap_conn_desc* desc) {
+    void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) {
         BLEqueueBuffer_t q;
         q.length = 6;
         q.type = BLE_OP_ON_CONNECT;
         q.buffer = new uint8_t[q.length];
-        memcpy(q.buffer,desc->peer_ota_addr.val,6);
+        memcpy(q.buffer,connInfo.getAddress().getNative(),6); // return MAC address in the queue buffer
         BLEmessageQueue.push(q);
         MI32.infoMsg = MI32_SERV_CLIENT_CONNECTED;
     };
-    void onDisconnect(NimBLEServer* pServer) {
+    void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) {
         BLEqueueBuffer_t q;
         q.length = 0;
         q.type = BLE_OP_ON_DISCONNECT;
@@ -187,7 +187,7 @@ class MI32ServerCallbacks: public NimBLEServerCallbacks {
 };
 
 class MI32CharacteristicCallbacks: public NimBLECharacteristicCallbacks {
-    void onRead(NimBLECharacteristic* pCharacteristic){
+    void onRead(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo){
         BLEqueueBuffer_t q;
         q.length = 0;
         q.type = BLE_OP_ON_READ;
@@ -196,7 +196,7 @@ class MI32CharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         BLEmessageQueue.push(q);
     };
 
-    void onWrite(NimBLECharacteristic* pCharacteristic) {
+    void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo) {
         BLEqueueBuffer_t q;
         q.type = BLE_OP_ON_WRITE;
         q.returnCharUUID = pCharacteristic->getUUID().getNative()->u16.value;
@@ -220,7 +220,7 @@ class MI32CharacteristicCallbacks: public NimBLECharacteristicCallbacks {
         BLEmessageQueue.push(q);
     };
 
-    void onSubscribe(NimBLECharacteristic* pCharacteristic, ble_gap_conn_desc* desc, uint16_t subValue) {
+    void onSubscribe(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo, uint16_t subValue) {
         BLEqueueBuffer_t q;
         q.length = 0;
         q.type = BLE_OP_ON_UNSUBSCRIBE + subValue;


### PR DESCRIPTION
## Description:

Fix all server related callbacks that were broken since the move to esp-nimble-cpp which has a slightly different API.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.13
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
