### PR TITLE
Berry fix compilation with integer index

### DIFF
--- a/lib/libesp32/berry/src/be_code.c
+++ b/lib/libesp32/berry/src/be_code.c
@@ -358,7 +358,7 @@ static int suffix_destreg(bfuncinfo *finfo, bexpdesc *e1, int dst, bbool no_reg_
         /* both are ETREG, we keep the lowest and discard the other */
         if (reg1 != reg2) {
             cand_dst = min(reg1, reg2);
-            be_code_freeregs(finfo, 1);  /* and free the other one */
+            be_code_freeregs(finfo, finfo->freereg - cand_dst);  /* and free the other one */
         } else {
             cand_dst = reg1;  /* both ETREG are equal, we return its value */
         }
@@ -726,8 +726,8 @@ int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, bbool keep_reg)
 /* if local or const, allocate a new register and copy value */
 int be_code_nextreg(bfuncinfo *finfo, bexpdesc *e)
 {
-    int dst = finfo->freereg;
     int src = exp2anyreg(finfo, e); /* get variable register index */
+    int dst = finfo->freereg;
     if ((e->type != ETREG) || (src < dst - 1)) { /* move local and const to new register, don't move if already top of stack */
         code_move(finfo, dst, src);
         be_code_allocregs(finfo, 1);
@@ -832,8 +832,8 @@ void be_code_ret(bfuncinfo *finfo, bexpdesc *e)
 /* Both expdesc are materialized in kregs */
 static void package_suffix(bfuncinfo *finfo, bexpdesc *c, bexpdesc *k)
 {
-    int key = exp2anyreg(finfo, k);
     c->v.ss.obj = exp2anyreg(finfo, c);
+    int key = exp2anyreg(finfo, k);
     c->v.ss.tt = c->type;
     c->v.ss.idx = key;
 }

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -2452,9 +2452,9 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
           0x5C341400,  //  00C3  MOVE	R13	R10
           0x7C2C0400,  //  00C4  CALL	R11	2
           0x70020014,  //  00C5  JMP		#00DB
-          0x542DFFFE,  //  00C6  LDINT	R11	-1
-          0x88300121,  //  00C7  GETMBR	R12	R0	K33
-          0x942C180B,  //  00C8  GETIDX	R11	R12	R11
+          0x882C0121,  //  00C6  GETMBR	R11	R0	K33
+          0x5431FFFE,  //  00C7  LDINT	R12	-1
+          0x942C160C,  //  00C8  GETIDX	R11	R11	R12
           0x6034000C,  //  00C9  GETGBL	R13	G12
           0x5C381600,  //  00CA  MOVE	R14	R11
           0x7C340200,  //  00CB  CALL	R13	1

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_animate_module.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_animate_module.h
@@ -600,9 +600,9 @@ be_local_closure(Animate_engine_animate,   /* name */
       0x140C0706,  //  0018  LT	R3	R3	K6
       0x780E0000,  //  0019  JMPF	R3	#001B
       0xB0060F08,  //  001A  RAISE	1	K7	K8
-      0x880C0104,  //  001B  GETMBR	R3	R0	K4
-      0x88100105,  //  001C  GETMBR	R4	R0	K5
-      0x940C0803,  //  001D  GETIDX	R3	R4	R3
+      0x880C0105,  //  001B  GETMBR	R3	R0	K5
+      0x88100104,  //  001C  GETMBR	R4	R0	K4
+      0x940C0604,  //  001D  GETIDX	R3	R3	R4
       0x6014000F,  //  001E  GETGBL	R5	G15
       0x5C180600,  //  001F  MOVE	R6	R3
       0xB81E1200,  //  0020  GETNGBL	R7	K9

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_partition_core.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_partition_core.h
@@ -1034,9 +1034,9 @@ be_local_closure(Partition_resize_fs_to_max,   /* name */
       0x7C080600,  //  000F  CALL	R2	3
       0x8C080106,  //  0010  GETMET	R2	R0	K6
       0x7C080200,  //  0011  CALL	R2	1
-      0x5409FFFE,  //  0012  LDINT	R2	-1
-      0x880C0107,  //  0013  GETMBR	R3	R0	K7
-      0x94080602,  //  0014  GETIDX	R2	R3	R2
+      0x88080107,  //  0012  GETMBR	R2	R0	K7
+      0x540DFFFE,  //  0013  LDINT	R3	-1
+      0x94080403,  //  0014  GETIDX	R2	R2	R3
       0x541603FF,  //  0015  LDINT	R5	1024
       0x08140205,  //  0016  MUL	R5	R1	R5
       0x88100508,  //  0017  GETMBR	R4	R2	K8
@@ -1414,9 +1414,9 @@ be_local_closure(Partition_invalidate_spiffs,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0x5409FFFE,  //  0001  LDINT	R2	-1
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
-      0x94080602,  //  0003  GETIDX	R2	R3	R2
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x540DFFFE,  //  0002  LDINT	R3	-1
+      0x94080403,  //  0003  GETIDX	R2	R2	R3
       0x8C100502,  //  0004  GETMET	R4	R2	K2
       0x7C100200,  //  0005  CALL	R4	1
       0x74120000,  //  0006  JMPT	R4	#0008
@@ -1556,9 +1556,9 @@ be_local_closure(Partition_get_unallocated_k,   /* name */
     &be_const_str_get_unallocated_k,
     &be_const_str_solidified,
     ( &(const binstruction[19]) {  /* code */
-      0x5405FFFE,  //  0000  LDINT	R1	-1
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x94040401,  //  0002  GETIDX	R1	R2	R1
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x5409FFFE,  //  0001  LDINT	R2	-1
+      0x94040202,  //  0002  GETIDX	R1	R1	R2
       0x8C0C0301,  //  0003  GETMET	R3	R1	K1
       0x7C0C0200,  //  0004  CALL	R3	1
       0x780E000B,  //  0005  JMPF	R3	#0012


### PR DESCRIPTION
## Description:

Berry compilation problem:

```berry
def f(self) print(self.a[128]) end
```

Compilation assigns unwanted registers:
```
      0x60040001,  //  0000  GETGBL     R1      G1
      0x540A007F,  //  0001  LDINT      R2      128
      0x880C0100,  //  0002  GETMBR     R3      R0      K0
      0x94080602,  //  0003  GETIDX     R2      R3      R2
      0x5C100400,  //  0004  MOVE       R4      R2         <- PROBLEM
      0x7C040200,  //  0005  CALL       R1      1
      0x80000000,  //  0006  RET        0
```

With the fix, the integer is retrieved in second place, and erroneous register is not allocated:
```
      0x60040001,  //  0000  GETGBL	R1	G1
      0x88080100,  //  0001  GETMBR	R2	R0	K0
      0x540E007F,  //  0002  LDINT	R3	128
      0x94080403,  //  0003  GETIDX	R2	R2	R3
      0x7C040200,  //  0004  CALL	R1	1
      0x80000000,  //  0005  RET	0
```


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.13
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
