### PR TITLE
Rename VERSION to TASMOTA_VERSION as a guard against external macros

### DIFF
--- a/tasmota/include/tasmota_version.h
+++ b/tasmota/include/tasmota_version.h
@@ -20,6 +20,6 @@
 #ifndef _TASMOTA_VERSION_H_
 #define _TASMOTA_VERSION_H_
 
-const uint32_t VERSION = 0x0D010003;   // 13.1.0.3
+const uint32_t TASMOTA_VERSION = 0x0D010003;   // 13.1.0.3
 
 #endif  // _TASMOTA_VERSION_H_

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -601,9 +601,9 @@ void setup(void) {
 
   memcpy_P(TasmotaGlobal.version, VERSION_MARKER, 1);  // Dummy for compiler saving VERSION_MARKER
 
-  snprintf_P(TasmotaGlobal.version, sizeof(TasmotaGlobal.version), PSTR("%d.%d.%d"), VERSION >> 24 & 0xff, VERSION >> 16 & 0xff, VERSION >> 8 & 0xff);  // Release version 6.3.0
-  if (VERSION & 0xff) {  // Development or patched version 6.3.0.10
-    snprintf_P(TasmotaGlobal.version, sizeof(TasmotaGlobal.version), PSTR("%s.%d"), TasmotaGlobal.version, VERSION & 0xff);
+  snprintf_P(TasmotaGlobal.version, sizeof(TasmotaGlobal.version), PSTR("%d.%d.%d"), TASMOTA_VERSION >> 24 & 0xff, TASMOTA_VERSION >> 16 & 0xff, TASMOTA_VERSION >> 8 & 0xff);  // Release version 6.3.0
+  if (TASMOTA_VERSION & 0xff) {  // Development or patched version 6.3.0.10
+    snprintf_P(TasmotaGlobal.version, sizeof(TasmotaGlobal.version), PSTR("%s.%d"), TasmotaGlobal.version, TASMOTA_VERSION & 0xff);
   }
 
   // Thehackbox inserts "release" or "commit number" before compiling using sed -i -e 's/PSTR("(%s)")/PSTR("(85cff52-%s)")/g' tasmota.ino

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -937,7 +937,7 @@ void SettingsDefaultSet1(void) {
   Settings->cfg_holder = (uint16_t)CFG_HOLDER;
   Settings->cfg_size = sizeof(TSettings);
 //  Settings->save_flag = 0;
-  Settings->version = VERSION;
+  Settings->version = TASMOTA_VERSION;
 //  Settings->bootcount = 0;
 //  Settings->cfg_crc = 0;
 }
@@ -1467,7 +1467,7 @@ void SettingsEnableAllI2cDrivers(void) {
 /********************************************************************************************/
 
 void SettingsDelta(void) {
-  if (Settings->version != VERSION) {      // Fix version dependent changes
+  if (Settings->version != TASMOTA_VERSION) {      // Fix version dependent changes
 
 #ifdef ESP8266
 #ifndef UPGRADE_V8_MIN
@@ -1763,7 +1763,7 @@ void SettingsDelta(void) {
       Settings->battery_level_percent = 101;
     }
 
-    Settings->version = VERSION;
+    Settings->version = TASMOTA_VERSION;
     SettingsSave(1);
   }
 

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -727,7 +727,7 @@ bool NewerVersion(char* version_str) {
   char version_dup[strlen(version_str) +1];
   strncpy(version_dup, version_str, sizeof(version_dup));  // Duplicate the version_str as strtok_r will modify it.
   // Loop through the version string, splitting on '.' seperators.
-  for (char *str = strtok_r(version_dup, ".", &str_ptr); str && i < sizeof(VERSION); str = strtok_r(nullptr, ".", &str_ptr), i++) {
+  for (char *str = strtok_r(version_dup, ".", &str_ptr); str && i < sizeof(TASMOTA_VERSION); str = strtok_r(nullptr, ".", &str_ptr), i++) {
     int field = atoi(str);
     // The fields in a version string can only range from 0-255.
     if ((field < 0) || (field > 255)) {
@@ -744,17 +744,17 @@ bool NewerVersion(char* version_str) {
   }
   // A version string should have 2-4 fields. e.g. 1.2, 1.2.3, or 1.2.3a (= 1.2.3.1).
   // If not, then don't consider it a valid version string.
-  if ((i < 2) || (i > sizeof(VERSION))) {
+  if ((i < 2) || (i > sizeof(TASMOTA_VERSION))) {
     return false;
   }
   // Keep shifting the parsed version until we hit the maximum number of tokens.
   // VERSION stores the major number of the version in the most significant byte of the uint32_t.
-  while (i < sizeof(VERSION)) {
+  while (i < sizeof(TASMOTA_VERSION)) {
     version <<= 8;
     i++;
   }
   // Now we should have a fully constructed version number in uint32_t form.
-  return (version > VERSION);
+  return (version > TASMOTA_VERSION);
 }
 
 int32_t UpdateDevicesPresent(int32_t change) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -537,7 +537,7 @@ extern "C" {
   }
 
   int32_t be_Tasmota_version(void) {
-    return VERSION;
+    return TASMOTA_VERSION;
   }
 
   /*


### PR DESCRIPTION
## Description:

Related to:
https://github.com/Jason2866/Tasmota-build/actions/runs/6394601232/job/17356385986

If we include an external library with not-so-smart naming conventions regarding macros we can run into compile errors with Tasmotas global variable `VERSION`.

This error could be fixed in an external library too, but maybe we give our variable a more specific name in this case. For my eyes this make our code a tiny bit more readable, but in the end it is a matter of personal preference.

@arendst Please take a look.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.13
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
