### PR TITLE
Remove warnings when compiling Audio with Arduino 3

### DIFF
--- a/lib/lib_audio/ESP8266Audio/library.json
+++ b/lib/lib_audio/ESP8266Audio/library.json
@@ -19,5 +19,9 @@
     "frameworks": "Arduino",
     "examples": [
         "examples/*/*.ino"
-    ]
+    ],
+	"build": {
+		"includeDir": ".",
+		"flags": [ "-Wno-stringop-overread" ]
+	}
 }

--- a/lib/lib_audio/ESP8266Audio/src/libflac/stream_decoder.c
+++ b/lib/lib_audio/ESP8266Audio/src/libflac/stream_decoder.c
@@ -2783,7 +2783,7 @@ FLAC__bool read_residual_partitioned_rice_(FLAC__StreamDecoder *decoder, uint32_
 		if(rice_parameter < pesc) {
 			partitioned_rice_contents->raw_bits[partition] = 0;
 			u = (partition_order == 0 || partition > 0)? partition_samples : partition_samples - predictor_order;
-			if(!FLAC__bitreader_read_rice_signed_block(decoder->private_->input, residual + sample, u, rice_parameter))
+			if(!FLAC__bitreader_read_rice_signed_block(decoder->private_->input, (int*) residual + sample, u, rice_parameter))
 				return false; /* read_callback_ sets the state for us */
 			sample += u;
 		}
@@ -2792,7 +2792,7 @@ FLAC__bool read_residual_partitioned_rice_(FLAC__StreamDecoder *decoder, uint32_
 				return false; /* read_callback_ sets the state for us */
 			partitioned_rice_contents->raw_bits[partition] = rice_parameter;
 			for(u = (partition_order == 0 || partition > 0)? 0 : predictor_order; u < partition_samples; u++, sample++) {
-				if(!FLAC__bitreader_read_raw_int32(decoder->private_->input, &i, rice_parameter))
+				if(!FLAC__bitreader_read_raw_int32(decoder->private_->input, (long int*) &i, rice_parameter))
 					return false; /* read_callback_ sets the state for us */
 				residual[sample] = i;
 			}

--- a/lib/lib_audio/ESP8266Audio/src/libmad/layer3.c
+++ b/lib/lib_audio/ESP8266Audio/src/libmad/layer3.c
@@ -1636,7 +1636,7 @@ void III_imdct_l(mad_fixed_t const [18], mad_fixed_t [36], unsigned int);
 # else
 #  if 1
 static
-void fastsdct(mad_fixed_t const x[9], mad_fixed_t y[18])
+void fastsdct(mad_fixed_t const x[9], mad_fixed_t y[17])
 {
   mad_fixed_t a0,  a1,  a2,  a3,  a4,  a5,  a6,  a7,  a8,  a9,  a10, a11, a12;
   mad_fixed_t a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25;

--- a/lib/lib_audio/ESP8266Audio/tasmota_patches.txt
+++ b/lib/lib_audio/ESP8266Audio/tasmota_patches.txt
@@ -1,0 +1,27 @@
+# below are the high-level patches made to the standard ESP8266audio libraries
+
+# For Arduino 3 (gcc has a higher level of checks
+
+libmad/layer3.c replace (line 1639)
+    void fastsdct(mad_fixed_t const x[9], mad_fixed_t y[18])
+to
+    void fastsdct(mad_fixed_t const x[9], mad_fixed_t y[17])
+
+
+libflac/stream_decoder.c
+line 2786
+			if(!FLAC__bitreader_read_rice_signed_block(decoder->private_->input, residual + sample, u, rice_parameter))
+to
+			if(!FLAC__bitreader_read_rice_signed_block(decoder->private_->input, (int*) residual + sample, u, rice_parameter))
+
+line 2795
+				if(!FLAC__bitreader_read_raw_int32(decoder->private_->input, &i, rice_parameter))
+to
+				if(!FLAC__bitreader_read_raw_int32(decoder->private_->input, (long int*) &i, rice_parameter))
+
+
+l3loop.cpp
+remove all 'register'
+
+mult_noarch_gcc.h
+remove all 'register'

--- a/lib/libesp32/berry/default/be_modtab.c
+++ b/lib/libesp32/berry/default/be_modtab.c
@@ -295,7 +295,7 @@ BERRY_LOCAL bclass_array be_class_table = {
     &be_native_class(lv_clock_icon),
 #endif // USE_LVGL
 
-#ifdef USE_I2S_AUDIO_BERRY
+#if defined(USE_I2S_AUDIO_BERRY) && (ESP_IDF_VERSION_MAJOR >= 5)
     &be_native_class(AudioGenerator),
     &be_native_class(AudioFileSource),
     &be_native_class(AudioOutputI2S),
@@ -306,7 +306,7 @@ BERRY_LOCAL bclass_array be_class_table = {
 #endif // USE_UFILESYS
     &be_native_class(AudioOpusDecoder),
     &be_native_class(AudioInputI2S),
-#endif // USE_I2S_AUDIO_BERRY
+#endif // defined(USE_I2S_AUDIO_BERRY) && (ESP_IDF_VERSION_MAJOR >= 5)
 #if defined(USE_BERRY_INT64) || defined(USE_MATTER_DEVICE)
     &be_native_class(int64),
 #endif

--- a/lib/libesp32/berry_tasmota/src/be_audio_opus_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_audio_opus_lib.c
@@ -29,7 +29,7 @@ void *be_audio_opus_decoder_init_ntv(int freq, int channels) {
 
   return buf;
 }
-int32_t be_audio_opus_decoder_init(struct bvm *vm) {
+int be_audio_opus_decoder_init(struct bvm *vm) {
   return be_call_c_func(vm, (void*) &be_audio_opus_decoder_init_ntv, "+.p", "i[i]");
 }
 
@@ -38,13 +38,13 @@ void *be_audio_opus_decoder_deinit_ntv(OpusDecoder* buf) {
   if (buf) BE_EXPLICIT_FREE(buf);
   return NULL;
 }
-int32_t be_audio_opus_decoder_deinit(struct bvm *vm) {
+int be_audio_opus_decoder_deinit(struct bvm *vm) {
   return be_call_c_func(vm, (void*) &be_audio_opus_decoder_deinit_ntv, "", ".");
 }
 
 
 // decode(payload:bytes) -> pcm:bytes()
-int32_t be_audio_opus_decoder_decode(struct bvm *vm) {
+int be_audio_opus_decoder_decode(struct bvm *vm) {
   int32_t argc = be_top(vm);
   be_call_c_func(vm, NULL, NULL, ".(bytes)[ii]");
 

--- a/lib/libesp32_audio/mp3_shine_esp32/src/l3loop.cpp
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/l3loop.cpp
@@ -444,8 +444,8 @@ int quantize(int ix[GRANULE_SIZE], int stepsize, shine_global_config *config )
  * Function: Calculate the maximum of ix from 0 to 575
  */
 static inline int ix_max( int ix[GRANULE_SIZE], unsigned int begin, unsigned int end ) {
-  register int i;
-  register int max = 0;
+  int i;
+  int max = 0;
 
   for(i=begin;i<end;i++)
     if(max < ix[i])
@@ -756,8 +756,8 @@ int count_bit(int ix[GRANULE_SIZE],
               unsigned int end,
               unsigned int table ) {
   unsigned            linbits, ylen;
-  register int        i, sum;
-  register int        x,y;
+  int        i, sum;
+  int        x,y;
   const struct huffcodetab *h;
 
   if(!table)

--- a/lib/libesp32_audio/mp3_shine_esp32/src/mult_noarch_gcc.h
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/mult_noarch_gcc.h
@@ -5,7 +5,7 @@
 
 #define asm_mul(x,y) \
 ({ \
-    register int result; \
+    int result; \
     asm ("mulsh %0, %2, %1" : "=r" (result) : "r" (x), "r" (y)); \
     result ;\
 })
@@ -31,7 +31,7 @@
 #ifndef asm_mulr    //no rounding shortcut
 #define asm_mulr(x,y) \
 ({ \
-    register int result; \
+    int result; \
     asm ("mulsh %0, %2, %1" : "=r" (result) : "r" (x), "r" (y)); \
     result ;\
 })
@@ -42,7 +42,7 @@
 #ifndef asm_mulsr   //no rounding shortcut
 #define asm_mulsr(x,y) \
 ({ \
-    register int result; \
+    int result; \
     asm ( \
         "mulsh %0, %2, %1\n\t" \
         "add %0, %0, %0" \

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_audio.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_audio.ino
@@ -20,17 +20,13 @@
 
 #ifdef USE_BERRY
 
-#ifdef USE_I2S_AUDIO_BERRY
+#if defined(USE_I2S_AUDIO_BERRY) && (ESP_IDF_VERSION_MAJOR >= 5)
 
 #include "AudioGeneratorWAV.h"
 #include "AudioGeneratorMP3.h"
 #include "AudioFileSourceFS.h"
 
 #include <berry.h>
-
-#if ESP_IDF_VERSION_MAJOR < 5
-  #error "USE_I2S_AUDIO_BERRY is only supported for ESP-IDF 5.1 or later"
-#endif
 
 /*********************************************************************************************\
  * AudioOutput class
@@ -474,5 +470,5 @@ extern "C" {
   }
 }
 
-#endif  // USE_I2S_AUDIO_BERRY
+#endif  // defined(USE_I2S_AUDIO_BERRY) && (ESP_IDF_VERSION_MAJOR >= 5)
 #endif  // USE_BERRY


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
