### PR TITLE
Fix modbus receive handling for float types

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_63_modbus_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_63_modbus_bridge.ino
@@ -825,7 +825,7 @@ void CmndModbusBridgeSend(void)
   else if (strcmp(stype, "float") == 0)
   {
     modbusBridge.type = ModbusBridgeType::mb_float;
-    modbusBridge.dataCount = bitMode ? 2 * modbusBridge.count : modbusBridge.count;
+    modbusBridge.dataCount = bitMode ? modbusBridge.count : 2 * modbusBridge.count;
   }
   else if (strcmp(stype, "raw") == 0)
   {


### PR DESCRIPTION
## Description:

Modbus module:

float is 32bit and should be treated like other 32 bit types.

When you call ModbusSend the end of the message is always 0 because the buffer will not be filled.
With this patch there will be valid data.
See the reference output.

Output from development branch:
18:36:26.010 CMD: ModbusSend {"deviceAddress":100, "functionCode":4, "startAddress":0, "type":"float", "count":18, "endian":"msb"}
18:36:26.022 SRC: WebConsole from 192.168.177.212
18:36:26.023 CMD: Grp 0, Cmd 'MODBUSSEND', Idx 1, Len 121, Pld -99, Data '{"deviceAddress":100, "functionCode":4, "startAddress":0, "type":"float", "count":18, "endian":"msb", "RetryReceive": 10}'
18:36:26.036 MQT: stat/solarpowermeter/RESULT = {"ModbusSend":"Done"}
18:36:26.130 MQT: tele/solarpowermeter/RESULT = {"ModbusReceived":{"DeviceAddress":100,"FunctionCode":4,"StartAddress":0,"Length":41,"Count":18,"Values":[231.5265350342,229.1959533691,230.8569641113,0.0619665682,0.0000000000,0.0502408743,3.7392051220,0.0000000000,1.9624860287,9104722578972676672037778.1894,0.0000000000,0.0000000000,0.0000000000,0.0000000000,0.0000000000,0.0000000000,0.0000000000,0.0000000000]}}

Output with this fix:
18:59:37.664 CMD: ModbusSend {"deviceAddress":100, "functionCode":4, "startAddress":0, "type":"float", "count":18, "endian":"msb"}
18:59:37.677 SRC: WebConsole from 192.168.177.212
18:59:37.678 CMD: Grp 0, Cmd 'MODBUSSEND', Idx 1, Len 101, Pld -99, Data '{"deviceAddress":100, "functionCode":4, "startAddress":0, "type":"float", "count":18, "endian":"msb"}'
18:59:37.690 MQT: stat/solarpowermeter/RESULT = {"ModbusSend":"Done"}
18:59:37.828 MQT: tele/solarpowermeter/RESULT = {"ModbusReceived":{"DeviceAddress":100,"FunctionCode":4,"StartAddress":0,"Length":77,"Count":18,"Values":[231.3769226074,230.4935607910,232.0218963623,0.0602983646,0.0000000000,0.0509612113,3.6130239964,0.0000000000,1.9416227341,12.2808637619,0.0000000000,9.3146982193,-11.7373619080,0.0000000000,-9.1100883484,0.2941994965,0.0000000000,0.2084472030]}}

## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [ x] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
