### PR TITLE
Audio exclusive mode

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_audio.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_audio.ino
@@ -323,13 +323,13 @@ extern "C" {
   // AudioInputI2S.begin() -> bool
   int be_audio_input_i2s_begin(bvm *vm, TasmotaI2S* in) {
     if (I2SPrepareRx()) { be_raisef(vm, "internal_error", "I2SPrepareRx() failed"); be_return_nil(vm); } 
-    in->micInit();
+    in->startRx();
     return in->getRxRunning();
   }
 
   // AudioInputI2S.stop() -> bool
   int be_audio_input_i2s_stop(TasmotaI2S* in) {
-    in->micDeinit();
+    in->stopRx();
     return true;
   }
 


### PR DESCRIPTION
## Description:

Implement audio exclusive mode, when In and Out share a common GPIO and full-duplex is not supported (for ex PDM).

In exclusive mode, switching for Output and Input requires to uninstall and resinstall the drivers. This is the case for M5Stack Core2, or M5Stack Atom Echo.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
