### PR TITLE
Add Rescan and RetryRead to onewire scan for bulletproove onewire

### DIFF
--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -792,7 +792,9 @@
 #define D_CMND_ADCPARAM "AdcParam"
 
 // Commands xsns_05_ds18x20.ino
-#define D_CMND_DS_ALIAS "DS18Alias"
+#define D_CMND_DS_ALIAS "Alias"
+#define D_CMND_DS_RESCAN "Rescan"
+#define D_CMND_DS_RETRYREAD "RetryRead"
 
 // xsns_70_veml6075.ino
 #define D_JSON_UVA_INTENSITY "UvaIntensity"

--- a/tasmota/tasmota_xsns_sensor/xsns_05_ds18x20.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_05_ds18x20.ino
@@ -574,7 +574,7 @@ void Ds18x20Show(bool json) {
 }
 
 #ifdef DS18x20_USE_ID_ALIAS
-const char kds18Commands[] PROGMEM = "|"  // No prefix
+const char kds18Commands[] PROGMEM = "DS18|"  // prefix
   D_CMND_DS_ALIAS;
 
 void (* const DSCommand[])(void) PROGMEM = {


### PR DESCRIPTION
## Description:
Sometimes onewire sensors get lost on the bus.
To reread lost sensors DS18RetryRead <count> was added. The sensors will "count" times retried when lost.
DS18Rescan can be used if a new sensor was added to the bus or when a sensor was lost in the first scan.

## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
