### PR TITLE
Account for MAX17043 alert status on start

### DIFF
--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -238,6 +238,7 @@
 #define D_JSON_MY "YaxisInduction"
 #define D_JSON_MZ "ZaxisInduction"
 #define D_JSON_MAGNETICFLD "MagneticInduction"
+#define D_JSON_ALERT "Alert"
 #define D_JSON_BATTPERCENT "BatteryPercentage"
 #define D_RSLT_ENERGY "ENERGY"
 #define D_RSLT_HASS_STATE "HASS_STATE"

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -716,6 +716,7 @@
 //    #define TC74_MAX_FAILCOUNT 8                 // Maximum failed polls before it's marked inactive until reprobing later
 //  #define USE_PCA9557                            // [I2cDriver81] Enable PCA9557 8-bit I/O Expander (I2C addresses 0x18 - 0x1F) (+2k5 code)
 //  #define USE_MAX17043                           // [I2cDriver83] Enable MAX17043 fuel-gauge systems Lipo batteries sensor (I2C address 0x36) (+0k9 code)
+//  #define MAX17043_ALERT_THRESHOLD 32            // [I2cDriver83] Define the alert threshold for low battery level percentage 1-32
 
 //  #define USE_RTC_CHIPS                          // Enable RTC chip support and NTP server - Select only one
 //    #define USE_DS3231                           // [I2cDriver26] Enable DS3231 RTC (I2C address 0x68) (+1k2 code)


### PR DESCRIPTION
## Description:

The current driver tests for an expected value in the configuration register to confirm the I2C device is a MAX17043. It then sets the alert threshold to 32%. I'm not sure why this was done.

When the device powers up (or restarts after deep sleep) and if the battery level is below 32% (if in deep sleep or soft restart) or 4% (if a physical power on) then the alert pin will have been switched high. This alert status is also present in the configuration register used in the above test and this results in the device not being identified and subsequently ignored.

This PR masks out the alert status (along with sleep bit and another undefined bit) in the configuration register before testing.

Since 32% is perhaps rather high as a low battery threshold I took the opportunity to allow custom compile of the alert threshold (leaving the default as previous) - FYI the power on reset default threshold is 4%. I also added the boolean status of alert to the mqtt sensor message.

fix: account for MAX17043 alert status on start
add: alert flag output on mqtt sensor document
add: compile time define for alert threshold

**Related issue (if applicable):** fixes #19701 

I've compiled for ESP32 and 8266 but don't have the hardware to test on 8266.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
