### PR TITLE
HC8 sensor support

### DIFF
--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -44,6 +44,7 @@ enum UserSelectablePins {
   GPIO_DSB, GPIO_DSB_OUT,              // DS18B20 or DS18S20
   GPIO_WS2812,                         // WS2812 Led string
   GPIO_MHZ_TXD, GPIO_MHZ_RXD,          // MH-Z19 Serial interface
+  GPIO_HC8_RXD,          // HC8 Serial interface
   GPIO_PZEM0XX_TX, GPIO_PZEM004_RX, GPIO_PZEM016_RX, GPIO_PZEM017_RX, // PZEM Serial Modbus interface
   GPIO_SAIR_TX, GPIO_SAIR_RX,          // SenseAir Serial interface
   GPIO_PMS5003_TX, GPIO_PMS5003_RX,    // Plantower PMS5003 Serial interface
@@ -302,6 +303,7 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_DS18X20 "|" D_SENSOR_DS18X20 "_o|"
   D_SENSOR_WS2812 "|"
   D_SENSOR_MHZ_TX "|" D_SENSOR_MHZ_RX "|"
+  D_SENSOR_HC8_RX "|"
   D_SENSOR_PZEM0XX_TX "|" D_SENSOR_PZEM004_RX "|" D_SENSOR_PZEM016_RX "|" D_SENSOR_PZEM017_RX "|"
   D_SENSOR_SAIR_TX "|" D_SENSOR_SAIR_RX "|"
   D_SENSOR_PMS5003_TX "|" D_SENSOR_PMS5003_RX "|"
@@ -958,6 +960,9 @@ const uint16_t kGpioNiceList[] PROGMEM = {
 #ifdef USE_MHZ19
   AGPIO(GPIO_MHZ_TXD),                  // MH-Z19 Serial interface
   AGPIO(GPIO_MHZ_RXD),                  // MH-Z19 Serial interface
+#endif
+#ifdef USE_HC8
+  AGPIO(GPIO_HC8_RXD),                  // HC8 Serial interface
 #endif
 #ifdef USE_SENSEAIR
   AGPIO(GPIO_SAIR_TX),                  // SenseAir Serial interface

--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -44,7 +44,6 @@ enum UserSelectablePins {
   GPIO_DSB, GPIO_DSB_OUT,              // DS18B20 or DS18S20
   GPIO_WS2812,                         // WS2812 Led string
   GPIO_MHZ_TXD, GPIO_MHZ_RXD,          // MH-Z19 Serial interface
-  GPIO_HC8_RXD,          // HC8 Serial interface
   GPIO_PZEM0XX_TX, GPIO_PZEM004_RX, GPIO_PZEM016_RX, GPIO_PZEM017_RX, // PZEM Serial Modbus interface
   GPIO_SAIR_TX, GPIO_SAIR_RX,          // SenseAir Serial interface
   GPIO_PMS5003_TX, GPIO_PMS5003_RX,    // Plantower PMS5003 Serial interface
@@ -213,6 +212,7 @@ enum UserSelectablePins {
   GPIO_GM861_TX, GPIO_GM861_RX,         // GM861 Serial interface
   GPIO_DINGTIAN_OE,                     // New version of Dingtian relay board where PL is not shared with OE
   GPIO_HDMI_CEC,                        // Support for HDMI CEC
+  GPIO_HC8_RXD,                         // HC8 Serial interface
   GPIO_SENSOR_END };
 
 // Error as warning to rethink GPIO usage with max 2045
@@ -303,7 +303,6 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_DS18X20 "|" D_SENSOR_DS18X20 "_o|"
   D_SENSOR_WS2812 "|"
   D_SENSOR_MHZ_TX "|" D_SENSOR_MHZ_RX "|"
-  D_SENSOR_HC8_RX "|"
   D_SENSOR_PZEM0XX_TX "|" D_SENSOR_PZEM004_RX "|" D_SENSOR_PZEM016_RX "|" D_SENSOR_PZEM017_RX "|"
   D_SENSOR_SAIR_TX "|" D_SENSOR_SAIR_RX "|"
   D_SENSOR_PMS5003_TX "|" D_SENSOR_PMS5003_RX "|"
@@ -473,6 +472,7 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_GM861_TX "|" D_SENSOR_GM861_RX "|"
   D_GPIO_DINGTIAN_OE "|"
   D_SENSOR_HDMI_CEC "|"
+  D_SENSOR_HC8_RX "|"
   ;
 
 const char kSensorNamesFixed[] PROGMEM =

--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRontvanger"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/ca_AD.h
+++ b/tasmota/language/ca_AD.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "Receptor IR"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IR Rx"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IR Rx"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IR vevő"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV                 "IR - RX"
 #define D_SENSOR_MHZ_RX                 "MHZ - RX"
 #define D_SENSOR_MHZ_TX                 "MHZ - TX"
+#define D_SENSOR_HC8_RX                 "HC8 - Rx"
 #define D_SENSOR_PZEM004_RX             "PZEM004 - RX"
 #define D_SENSOR_PZEM016_RX             "PZEM016 - RX"
 #define D_SENSOR_PZEM017_RX             "PZEM017 - RX"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -674,6 +674,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -673,6 +673,7 @@
 #define D_SENSOR_IRRECV        "IRrecv"
 #define D_SENSOR_MHZ_RX        "MHZ Rx"
 #define D_SENSOR_MHZ_TX        "MHZ Tx"
+#define D_SENSOR_HC8_RX        "HC8 Rx"
 #define D_SENSOR_PZEM004_RX    "PZEM004 Rx"
 #define D_SENSOR_PZEM016_RX    "PZEM016 Rx"
 #define D_SENSOR_PZEM017_RX    "PZEM017 Rx"

--- a/tasmota/tasmota_xsns_sensor/xsns_113_hc8.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_113_hc8.ino
@@ -97,7 +97,7 @@ void Hc8Show(bool json)
   char model[4] = "HC8";
 
   if (json) {
-    ResponseAppend_P(PSTR(",\"%s\":{\"" D_JSON_MODEL "\":\"%s\",\"" D_JSON_CO2 "\":%d\"}"),
+    ResponseAppend_P(PSTR(",\"%s\":{\"" D_JSON_MODEL "\":\"%s\",\"" D_JSON_CO2 "\":\"%d\"}"),
         types, model, hc8_last_ppm);
 #ifdef USE_DOMOTICZ
     if (0 == TasmotaGlobal.tele_period) {

--- a/tasmota/tasmota_xsns_sensor/xsns_113_hc8.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_113_hc8.ino
@@ -1,0 +1,146 @@
+/*
+  xsns_113_hc8.ino - HC8 CO2 sensor support for Tasmota
+
+  Copyright (C) 2023 Daniel Maier
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_HC8
+/*********************************************************************************************\
+ * HC8 - CO2 sensor
+ *
+ * Hardware Serial will be selected if GPIO1 = [HC8 Rx]
+ */
+
+#define XSNS_113                      113
+
+
+/*********************************************************************************************\
+ * Source: https://spezifisch.codeberg.page/posts/2022-08-23/co2-sensor-reverse-engineering/
+ *
+\*********************************************************************************************/
+
+#include <TasmotaSerial.h>
+
+TasmotaSerial *Hc8Serial;
+
+uint16_t hc8_last_ppm = 0;
+bool Hc8Initialized = false;
+
+/*********************************************************************************************/
+
+
+uint8_t Hc8CalculateChecksum(uint8_t *array) {
+  uint8_t checksum = 0;
+  for(int i = 0; i < 15; i++) {
+    checksum += array[i];
+  }
+  return checksum;
+}
+
+void Hc8EverySecond(void)
+{
+  if(!Hc8Initialized)
+    return;
+
+  uint8_t hc8_response[16];
+  if(Hc8Serial->available() >= 16) {
+    while(Hc8Serial->available()) {
+      hc8_response[0] = Hc8Serial->read();
+      if(hc8_response[0] == 0x42)
+        break;
+    }
+
+    for(int i = 1; i < 16; i++) {
+      hc8_response[i] = Hc8Serial->read();
+    }
+
+    if(*(uint16_t*)hc8_response != 0x4d42) {
+      return;
+    }
+
+    uint8_t checksum = Hc8CalculateChecksum(hc8_response);
+    if(hc8_response[15] != checksum) {
+      return;
+    }
+
+    hc8_last_ppm = (hc8_response[6]<<8) | hc8_response[7];
+  }
+}
+
+void Hc8Init(void)
+{
+  if (PinUsed(GPIO_HC8_RXD)) {
+    Hc8Serial = new TasmotaSerial(Pin(GPIO_HC8_RXD), -1, 1);
+    if (Hc8Serial->begin(9600)) {
+      if (Hc8Serial->hardwareSerial()) { ClaimSerial(); }
+      Hc8Initialized = true;
+    }
+  }
+}
+
+void Hc8Show(bool json)
+{
+  char types[4] = "HC8";
+  char model[4] = "HC8";
+
+  if (json) {
+    ResponseAppend_P(PSTR(",\"%s\":{\"" D_JSON_MODEL "\":\"%s\",\"" D_JSON_CO2 "\":%d\"}"),
+        types, model, hc8_last_ppm);
+#ifdef USE_DOMOTICZ
+    if (0 == TasmotaGlobal.tele_period) {
+      DomoticzSensor(DZ_AIRQUALITY, hc8_last_ppm);
+    }
+#endif  // USE_DOMOTICZ
+#ifdef USE_WEBSERVER
+  } else {
+    WSContentSend_PD(HTTP_SNS_CO2, types, hc8_last_ppm);
+#endif  // USE_WEBSERVER
+  }
+}
+
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xsns113(uint32_t function)
+{
+  bool result = false;
+  switch (function) {
+    case FUNC_INIT:
+      Hc8Init();
+      break;
+    case FUNC_EVERY_SECOND:
+      Hc8EverySecond();
+      break;
+    case FUNC_COMMAND_SENSOR:
+      if (XSNS_113 == XdrvMailbox.index) {
+        result = true;
+      }
+      break;
+    case FUNC_JSON_APPEND:
+      Hc8Show(1);
+      break;
+#ifdef USE_WEBSERVER
+    case FUNC_WEB_SENSOR:
+      Hc8Show(0);
+      break;
+#endif  // USE_WEBSERVER
+  }
+  return result;
+}
+
+#endif  // USE_HC8


### PR DESCRIPTION
## Description:

HC8 CO2 sensor support

This sensor is similar to the common MH-Z19 sensor family, but it uses a different protocol.

Protocol documentation https://spezifisch.codeberg.page/posts/2022-08-23/co2-sensor-reverse-engineering/

This PR implements support for the active output mode sent by the sensor every 1s. 

## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
