### PR TITLE
Remove `WiFiClientSecure`

### DIFF
--- a/lib/libesp32/HttpClientLight/src/HttpClientLight.cpp
+++ b/lib/libesp32/HttpClientLight/src/HttpClientLight.cpp
@@ -32,7 +32,6 @@
 
 #ifdef HTTPCLIENT_1_1_COMPATIBLE
 #include <WiFi.h>
-#include <WiFiClientSecure.h>
 #endif
 
 #include <StreamString.h>

--- a/lib/libesp32/HttpClientLight/src/HttpClientLight.h
+++ b/lib/libesp32/HttpClientLight/src/HttpClientLight.h
@@ -32,7 +32,6 @@
 #include <memory>
 #include <Arduino.h>
 #include <WiFiClient.h>
-#include <WiFiClientSecure.h>
 
 #include <HTTPClient.h>     // import definitions from the original code
 

--- a/tasmota/include/Powerwall.h
+++ b/tasmota/include/Powerwall.h
@@ -4,12 +4,7 @@
 #define Powerwall_h
 
 // include libraries
-#ifdef ESP8266
 #include "WiFiClientSecureLightBearSSL.h"
-#else
-#include <WiFiClientSecure.h>
-#endif //ESP8266
-
 
 class Powerwall {
    private:

--- a/tasmota/tasmota_xdrv_driver/xdrv_10_scripter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_scripter.ino
@@ -11953,11 +11953,7 @@ int32_t call2pwl(const char *url) {
 #endif // TESLA_POWERWALL
 
 
-#ifdef ESP8266
 #include "WiFiClientSecureLightBearSSL.h"
-#else
-#include <WiFiClientSecure.h>
-#endif //ESP8266
 
 // get https info page json string
 uint32_t call2https(const char *host, const char *path) {


### PR DESCRIPTION
## Description:

Tasmota uses BearSSL. `WiFiClientSecure` is based on mbedTLS.  `WiFiClientSecure` code part will be removed in next Tasmota Arduino framework build. 

Saves 3K of flash

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
