### PR TITLE
Update xsns_02_analog.ino for calibrated values on ESP32

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_02_analog.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_02_analog.ino
@@ -335,10 +335,17 @@ uint16_t AdcRead(uint32_t pin, uint32_t factor) {
   uint32_t samples = 1 << factor;
   uint32_t analog = 0;
   for (uint32_t i = 0; i < samples; i++) {
+#ifdef ESP32 
+    analog += analogReadMilliVolts(pin);  // get the value corrected by calibrated values from the eFuses
+#else
     analog += analogRead(pin);
+#endif
     delay(1);
   }
   analog >>= factor;
+#ifdef ESP32
+  analog = analog/(ANALOG_V33*1000) * ANALOG_RANGE; // go back from mV to ADC
+#endif
   return analog;
 }
 


### PR DESCRIPTION
ESP32  ADC has variables errors, but calibrations values are put in eFuses at factory test. analogReadMilliVolts() from api correct the ADC reading with tata values. Since now the value are mV and not ADC numbers, the fast solution is to revert it back to ADC numbers: divide by Vcc  => ANALOG_V33*1000  and multiply by ANALOG_RANGE Other way is to modify all sensor cases to account for the different unit.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [X ] Only relevant files were touched
  - [X ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [X ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
