### PR TITLE
remove Homekit env

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -73,51 +73,6 @@ lib_ignore                  = TTGO TWatch Library
                               Micro-RTSP
                               epdiy
 
-[env:tasmota32-mi32-homebridge]
-extends                     = env:tasmota32_base
-build_flags                 = ${env:tasmota32_base.build_flags}
-                              -DFIRMWARE_BLUETOOTH
-                              -DUSE_MI_EXT_GUI
-                              -DUSE_MI_HOMEKIT=1    ; 1 to enable; 0 to disable
-                              -DOTA_URL='""'
-lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
-lib_ignore                  = ESP8266Audio
-                              ESP8266SAM
-                              TTGO TWatch Library
-                              Micro-RTSP
-                              epdiy
-                              NimBLE-Arduino
-
-[env:tasmota32c3-mi32-homebridge]
-extends                     = env:tasmota32c3
-build_flags                 = ${env:tasmota32_base.build_flags}
-                              -DFIRMWARE_BLUETOOTH
-                              -DUSE_MI_EXT_GUI
-                              -DUSE_MI_HOMEKIT=1    ; 1 to enable; 0 to disable
-                              -DOTA_URL='""'
-lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
-lib_ignore                  = ESP8266Audio
-                              ESP8266SAM
-                              TTGO TWatch Library
-                              Micro-RTSP
-                              epdiy
-                              NimBLE-Arduino
-
-[env:tasmota32s3-mi32-homebridge]
-extends                     = env:tasmota32s3
-build_flags                 = ${env:tasmota32_base.build_flags}
-                              -DFIRMWARE_BLUETOOTH
-                              -DUSE_MI_EXT_GUI
-                              -DUSE_MI_HOMEKIT=1    ; 1 to enable; 0 to disable
-                              -DOTA_URL='""'
-lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
-lib_ignore                  = ESP8266Audio
-                              ESP8266SAM
-                              TTGO TWatch Library
-                              Micro-RTSP
-                              epdiy
-                              NimBLE-Arduino
-
 ; *** Debug version used for PlatformIO Home Project Inspection
 [env:tasmota-debug]
 build_type                  = debug


### PR DESCRIPTION
## Description:

Step 1 of removing Homekit support. Not easy portable to Arduino 3.0. -> Deprecated
There are no changes since a few month in this part. If Homekit is still needed it is recommended to use release v13.1.0

Similar functions can be achieved with Matter.

Step 2 will be done after the next Tasmota release.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
