### PR TITLE
disable not compatible libs

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -182,6 +182,7 @@ lib_ignore              =
                           Micro-RTSP
                           epdiy
                           mp3_shine_esp32
+                          ESP32-HomeKit
 
 [env:tasmota32c3cdc-safeboot]
 extends                 = env:tasmota32c3-safeboot
@@ -218,6 +219,7 @@ lib_ignore              =
                           NimBLE-Arduino
                           Micro-RTSP
                           epdiy
+                          ESP32-HomeKit
 
 [env:tasmota32s2cdc-safeboot]
 extends                 = env:tasmota32s2-safeboot
@@ -252,6 +254,7 @@ lib_ignore              =
                           TTGO TWatch Library
                           Micro-RTSP
                           epdiy
+                          ESP32-HomeKit
 
 [env:tasmota32s3cdc-safeboot]
 extends                 = env:tasmota32s3-safeboot


### PR DESCRIPTION
## Description:

fix compile error after second build run for the C3 env 

@barbudor please test

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
