### PR TITLE
pio proper lib_ignore fix

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -115,6 +115,23 @@ build_flags                 = ${esp_defaults.build_flags}
                               -DMIMETYPE_MINIMAL
                               ; uncomment the following to enable TLS with 4096 RSA certificates
                               ;-DUSE_4K_RSA
+lib_ignore                  =
+                              Servo(esp8266)
+                              ESP8266AVRISP
+                              ESP8266LLMNR
+                              ESP8266NetBIOS
+                              ESP8266SSDP
+                              SP8266WiFiMesh
+                              Ethernet(esp8266)
+                              GDBStub
+                              TFT_Touch_Shield_V2
+                              ESP8266HTTPUpdateServer
+                              ESP8266WiFiMesh
+                              EspSoftwareSerial
+                              SPISlave
+                              Hash
+; Disable next if you want to use ArduinoOTA in Tasmota (default disabled)
+                              ArduinoOTA
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -68,23 +68,6 @@ default_envs            =
 ; *** Define serial port used for erasing/flashing/terminal
 ;upload_port             = COM4
 ;monitor_port            = COM4
-lib_ignore              =
-                          Servo(esp8266)
-                          ESP8266AVRISP
-                          ESP8266LLMNR
-                          ESP8266NetBIOS
-                          ESP8266SSDP
-                          SP8266WiFiMesh
-                          Ethernet(esp8266)
-                          GDBStub
-                          TFT_Touch_Shield_V2
-                          ESP8266HTTPUpdateServer
-                          ESP8266WiFiMesh
-                          EspSoftwareSerial
-                          SPISlave
-                          Hash
-; Disable next if you want to use ArduinoOTA in Tasmota (default disabled)
-                          ArduinoOTA
 lib_extra_dirs          = ${library.lib_extra_dirs}
 
 
@@ -110,22 +93,6 @@ lib_extra_dirs          = ${library.lib_extra_dirs}
 ;upload_speed            = 115200
 monitor_speed           = 115200
 upload_resetmethod      = ${common.upload_resetmethod}
-lib_ignore              =
-                          HTTPUpdateServer
-                          ESP RainMaker
-                          WiFiProv
-                          USB
-                          SPIFFS
-                          ESP32 Azure IoT Arduino
-                          ESP32 Async UDP
-                          ESP32 BLE Arduino
-                          SimpleBLE
-                          NetBIOS
-                          ESP32
-                          Preferences
-                          BluetoothSerial
-                          ArduinoOTA
-
 lib_extra_dirs           = ${library.lib_extra_dirs}
 ; *** ESP32 lib. ALWAYS needed for ESP32 !!!
                           lib/libesp32

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -36,6 +36,16 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Wl,--wrap=panicHandler -Wl,--wrap=xt_unhandled_exception
                               -Wl,--wrap=_Z11analogWritehi  ; `analogWrite(unsigned char, int)` use the Tasmota version of analogWrite for deeper integration and phase control
                               -Wl,--wrap=ledcReadFreq  ; `uint32_t ledcReadFreq(uint8_t chan)`
+lib_ignore                  =
+                              HTTPUpdateServer
+                              USB
+                              ESP32 Async UDP
+                              esp-nimble-cpp
+                              NetBIOS
+                              Preferences
+                              BluetoothSerial
+                              ArduinoOTA
+                              ESP32-HomeKit
 extra_scripts               = pre:pio-tools/add_c_flags.py
                               pre:pio-tools/get_flash_size.py
                               pre:pio-tools/gen-berry-structures.py

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -13,25 +13,9 @@ extra_scripts               = ${esp_defaults.extra_scripts}
 lib_ldf_mode                = ${common.lib_ldf_mode}
 lib_compat_mode             = ${common.lib_compat_mode}
 lib_extra_dirs              = ${common.lib_extra_dirs}
-lib_ignore                  =
-                              Servo(esp8266)
-                              ESP8266AVRISP
-                              ESP8266LLMNR
-                              ESP8266NetBIOS
-                              ESP8266SSDP
-                              SP8266WiFiMesh
-                              Ethernet(esp8266)
-                              GDBStub
-                              TFT_Touch_Shield_V2
-                              ESP8266HTTPUpdateServer
-                              ESP8266WiFiMesh
-                              EspSoftwareSerial
-                              SPISlave
-                              Hash
-; Disable next if you want to use ArduinoOTA in Tasmota (default disabled)
-                              ArduinoOTA
+lib_ignore                  = ${esp82xx_defaults.lib_ignore}
 ; Add files to Filesystem for all env (global). Remove no files entry and add add a line with the file to include
-custom_files_upload     = no_files
+custom_files_upload         = no_files
 
 [env:tasmota]
 build_flags             = ${env.build_flags} -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota.bin.gz"'

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -17,23 +17,7 @@ lib_extra_dirs          = ${common.lib_extra_dirs}
                           lib/libesp32
                           lib/libesp32_lvgl
                           lib/libesp32_audio
-lib_ignore              =
-                          HTTPUpdateServer
-                          ESP RainMaker
-                          WiFiProv
-                          USB
-                          SPIFFS
-                          ESP32 Azure IoT Arduino
-                          ESP32 Async UDP
-                          ESP32 BLE Arduino
-                          esp-nimble-cpp
-                          SimpleBLE
-                          NetBIOS
-                          ESP32
-                          Preferences
-                          BluetoothSerial
-                          ArduinoOTA
-                          ESP32-HomeKit
+lib_ignore              = ${esp32_defaults.lib_ignore}
 ; Add files to Filesystem for all env (global). Remove no files entry and add add a line with the file to include
 ; Example for adding the Partition Manager
 ; custom_files_upload =
@@ -178,12 +162,11 @@ build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3.bin"'
                           -fno-lto
-lib_ignore              =
+lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           TTGO TWatch Library
                           Micro-RTSP
                           epdiy
                           mp3_shine_esp32
-                          ESP32-HomeKit
 
 [env:tasmota32c3cdc-safeboot]
 extends                 = env:tasmota32c3-safeboot
@@ -215,12 +198,11 @@ board                   = esp32s2
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2.bin"'
-lib_ignore              =
+lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           TTGO TWatch Library
                           NimBLE-Arduino
                           Micro-RTSP
                           epdiy
-                          ESP32-HomeKit
 
 [env:tasmota32s2cdc-safeboot]
 extends                 = env:tasmota32s2-safeboot
@@ -251,11 +233,10 @@ board                   = esp32s3-qio_qspi
 build_flags             = ${env:tasmota32_base.build_flags}
                          -DFIRMWARE_TASMOTA32
                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3.bin"'
-lib_ignore              =
+lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           TTGO TWatch Library
                           Micro-RTSP
                           epdiy
-                          ESP32-HomeKit
 
 [env:tasmota32s3cdc-safeboot]
 extends                 = env:tasmota32s3-safeboot


### PR DESCRIPTION
## Description:

Follow up of #19740 which partially fixed the `lib_ignore` issue.
`lib_ignore` can not be overridden without unwanted side effects. It is now removed from the  `platformio_override.ini`setup file. Libs which needs or wanted to be ignored have to be placed in the `env`

Can be seen in `[env:tasmota32c3]` how to be done

@barbudor Please test this version. It does work for me. Thx!

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
