### PR TITLE
More audio refactoring for core3

### DIFF
--- a/tasmota/berry/include/be_gpio_defines.h
+++ b/tasmota/berry/include/be_gpio_defines.h
@@ -101,6 +101,7 @@ const be_const_member_t lv_gpio_constants[] = {
     { "HX711_SCK", (int32_t) GPIO_HX711_SCK },
     { "I2C_SCL", (int32_t) GPIO_I2C_SCL },
     { "I2C_SDA", (int32_t) GPIO_I2C_SDA },
+    { "I2S_DAC", (int32_t) GPIO_I2S_DAC },
     { "I2S_IN_CLK", (int32_t) GPIO_I2S_BCLK_IN },
     { "I2S_IN_DATA", (int32_t) GPIO_I2S_DIN },
     { "I2S_IN_SLCT", (int32_t) GPIO_I2S_WS_IN },

--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -213,6 +213,7 @@ enum UserSelectablePins {
   GPIO_DINGTIAN_OE,                     // New version of Dingtian relay board where PL is not shared with OE
   GPIO_HDMI_CEC,                        // Support for HDMI CEC
   GPIO_HC8_RXD,                         // HC8 Serial interface
+  GPIO_I2S_DAC,                         // Audio DAC support for ESP32 and ESP32S2
   GPIO_SENSOR_END };
 
 // Error as warning to rethink GPIO usage with max 2045
@@ -473,6 +474,7 @@ const char kSensorNames[] PROGMEM =
   D_GPIO_DINGTIAN_OE "|"
   D_SENSOR_HDMI_CEC "|"
   D_SENSOR_HC8_RX "|"
+  D_SENSOR_I2S_DAC "|"
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -578,9 +580,10 @@ const uint16_t kGpioNiceList[] PROGMEM = {
 #if defined(USE_I2S_AUDIO) || defined (USE_I2S)
   AGPIO(GPIO_I2S_MCLK) + MAX_I2S,       // I2S master clock
   AGPIO(GPIO_I2S_BCLK) + MAX_I2S,       // I2S bit clock
+  AGPIO(GPIO_I2S_DOUT) + MAX_I2S,       // I2S Out Data
+  AGPIO(GPIO_I2S_DAC) + 2,              // I2S DAC Output
   AGPIO(GPIO_I2S_WS) + MAX_I2S,         // I2S word select
   AGPIO(GPIO_I2S_DIN) + MAX_I2S,        // I2S IN Data
-  AGPIO(GPIO_I2S_DOUT) + MAX_I2S,       // I2S Out Data
 #endif
 #ifdef USE_I2S
   AGPIO(GPIO_I2S_BCLK_IN) + MAX_I2S,    // I2S bit clock in

--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Speler"

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/ca_AD.h
+++ b/tasmota/language/ca_AD.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "Reproductor MP3"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS In"
 #define D_SENSOR_I2S_DIN       "I2S DIn"
 #define D_SENSOR_I2S_DOUT      "I2S DOut"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Speler"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "נגן מוזיקה"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 lejátszó"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN            "I2S - WS IN"
 #define D_SENSOR_I2S_DIN                "I2S - DIN"
 #define D_SENSOR_I2S_DOUT               "I2S - DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC               "HDMI CEC"
 #define D_SENSOR_WS2812                 "WS2812"
 #define D_SENSOR_DFR562                 "Riproduttore MP3"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Speler"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "Odtwarzacz MP3"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "Leitor de MP3"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -658,6 +658,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 spelare"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -657,6 +657,7 @@
 #define D_SENSOR_I2S_BCLK_IN   "I2S WS IN"
 #define D_SENSOR_I2S_DIN       "I2S DIN"
 #define D_SENSOR_I2S_DOUT      "I2S DOUT"
+#define D_SENSOR_I2S_DAC       "I2S DAC"
 #define D_SENSOR_HDMI_CEC      "HDMI CEC"
 #define D_SENSOR_WS2812        "WS2812"
 #define D_SENSOR_DFR562        "MP3 Player"

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
@@ -25,20 +25,6 @@
 #include "driver/gpio.h"
 #include "soc/soc_caps.h"
 
-#include "AudioFileSourcePROGMEM.h"
-#include "AudioFileSourceID3.h"
-#include "AudioGeneratorMP3.h"
-
-#include <ESP8266SAM.h>
-#include "AudioFileSourceFS.h"
-#include "AudioGeneratorTalkie.h"
-#include "AudioFileSourceICYStream.h"
-#include "AudioFileSourceBuffer.h"
-#include "AudioGeneratorAAC.h"
-
-#include <layer3.h>
-#include <types.h>
-
 /*********************************************************************************************\
  * Driver Settings in memory
 \*********************************************************************************************/
@@ -134,41 +120,8 @@ struct AUDIO_I2S_t {
   tI2SSettings *Settings;
 
   i2s_chan_handle_t rx_handle = nullptr;
-
-  AudioGeneratorMP3 *mp3 = nullptr;
-  AudioFileSourceFS *file = nullptr;
-
   TasmotaI2S *out = nullptr;        // instance used for I2S output, or `nullptr` if none
   TasmotaI2S *in = nullptr;         // instance used for I2S input, or `nullptr` if none (it can be the same as `out` in case of full duplex)
-
-  AudioFileSourceID3 *id3 = nullptr;
-  AudioGeneratorMP3 *decoder = NULL;
-  void *mp3ram = NULL;
-
-  TaskHandle_t mp3_task_handle;
-  TaskHandle_t mic_task_handle;
-
-  char mic_path[32];
-  uint8_t mic_stop;
-  int8_t mic_error;
-  bool use_stream = false;
-
-
-// SHINE
-  uint32_t recdur;
-  uint8_t  stream_active;
-  uint8_t  stream_enable;
-  WiFiClient client;
-  ESP8266WebServer *MP3Server;
-
-// I2S_BRIDGE
-  BRIDGE_MODE bridge_mode;
-  WiFiUDP i2s_bridge_udp;
-  WiFiUDP i2s_bridgec_udp;
-  IPAddress i2s_bridge_ip;
-  TaskHandle_t i2s_bridge_h;
-  int8_t ptt_pin = -1;
-
 } audio_i2s;
 
 #endif // USE_I2S_AUDIO

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_1_i2s_mp3mic.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_1_i2s_mp3mic.ino
@@ -18,7 +18,7 @@
 */
 
 
-#ifdef ESP32
+#if ESP32 && (ESP_IDF_VERSION_MAJOR < 5)
 #if ( (defined(USE_I2S_AUDIO) && defined(USE_I2S_MIC)) || defined(USE_M5STACK_CORE2) || defined(ESP32S3_BOX) )
 
 uint32_t SpeakerMic(uint8_t spkr) {
@@ -332,4 +332,4 @@ void Cmd_MicGain(void) {
 }
 
 #endif // USE_I2S_AUDIO
-#endif // ESP32
+#endif // ESP32 && (ESP_IDF_VERSION_MAJOR < 5)

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_1_i2s_mp3mic_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_1_i2s_mp3mic_idf51.ino
@@ -1,0 +1,238 @@
+/*
+  xdrv_42_i2s_audio.ino - Audio dac support for Tasmota
+
+  Copyright (C) 2021  Gerhard Mutz and Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#if defined(ESP32) && ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_I2S_AUDIO
+
+uint32_t SpeakerMic(uint8_t spkr) {
+esp_err_t err = ESP_OK;
+
+//  audio_i2s.mode = spkr;
+  return err;
+}
+
+#ifdef USE_SHINE
+
+#include <layer3.h>
+#include <types.h>
+
+// micro to mp3 file or stream
+void mic_task(void *arg){
+  int8_t error = 0;
+  uint8_t *ucp;
+  int written;
+  shine_config_t  config;
+  shine_t s = nullptr;
+  uint16_t samples_per_pass;
+  File mp3_out = (File)nullptr;
+  int16_t *buffer = nullptr;
+  uint16_t bytesize;
+  uint16_t bwritten;
+  uint32_t ctime;
+
+  if (!audio_i2s_mp3.use_stream) {
+    mp3_out = ufsp->open(audio_i2s_mp3.mic_path, "w");
+    if (!mp3_out) {
+      error = 1;
+      goto exit;
+    }
+  } else {
+    if (!audio_i2s_mp3.stream_active) {
+      error = 2;
+      audio_i2s_mp3.use_stream = 0;
+      goto exit;
+    }
+    audio_i2s_mp3.client.flush();
+    audio_i2s_mp3.client.setTimeout(3);
+    audio_i2s_mp3.client.print("HTTP/1.1 200 OK\r\n"
+    "Content-Type: audio/mpeg;\r\n\r\n");
+
+   //  Webserver->send(200, "application/octet-stream", "");
+    //"Content-Type: audio/mp3;\r\n\r\n");
+  }
+
+  shine_set_config_mpeg_defaults(&config.mpeg);
+
+  if (audio_i2s.mic_channels == 1) {
+    config.mpeg.mode = MONO;
+  } else {
+    config.mpeg.mode = STEREO;
+  }
+  config.mpeg.bitr = 128;
+  config.wave.samplerate = audio_i2s.mic_rate;
+  config.wave.channels = (channels)audio_i2s.mic_channels;
+
+  if (shine_check_config(config.wave.samplerate, config.mpeg.bitr) < 0) {
+    error = 3;
+    goto exit;
+  }
+
+  s = shine_initialise(&config);
+  if (!s) {
+    error = 4;
+    goto exit;
+  }
+
+  samples_per_pass = shine_samples_per_pass(s);
+  bytesize = samples_per_pass * 2 * audio_i2s.mic_channels;
+
+  buffer = (int16_t*)malloc(bytesize);
+  if (!buffer) {
+    error = 5;
+    goto exit;
+  }
+
+  ctime = TasmotaGlobal.uptime;
+
+  while (!audio_i2s_mp3.mic_stop) {
+      uint32_t bytes_read;
+      i2s_read(audio_i2s.mic_port, (char *)buffer, bytesize, &bytes_read, (100 / portTICK_RATE_MS));
+
+      if (audio_i2s.mic_gain > 1) {
+        // set gain
+        for (uint32_t cnt = 0; cnt < bytes_read / 2; cnt++) {
+          buffer[cnt] *= audio_i2s.mic_gain;
+        }
+      }
+      ucp = shine_encode_buffer_interleaved(s, buffer, &written);
+
+      if (!audio_i2s_mp3.use_stream) {
+        bwritten = mp3_out.write(ucp, written);
+        if (bwritten != written) {
+          break;
+        }
+      } else {
+        audio_i2s_mp3.client.write((const char*)ucp, written);
+
+        if (!audio_i2s_mp3.client.connected()) {
+          break;
+        }
+      }
+      audio_i2s_mp3.recdur = TasmotaGlobal.uptime - ctime;
+  }
+
+  ucp = shine_flush(s, &written);
+
+  if (!audio_i2s_mp3.use_stream) {
+    mp3_out.write(ucp, written);
+  } else {
+    audio_i2s_mp3.client.write((const char*)ucp, written);
+  }
+
+
+exit:
+  if (s) {
+    shine_close(s);
+  }
+  if (mp3_out) {
+    mp3_out.close();
+  }
+  if (buffer) {
+    free(buffer);
+  }
+
+  if (audio_i2s_mp3.use_stream) {
+    audio_i2s_mp3.client.stop();
+  }
+
+  SpeakerMic(MODE_SPK);
+  audio_i2s_mp3.mic_stop = 0;
+  audio_i2s_mp3.mic_error = error;
+  AddLog(LOG_LEVEL_INFO, PSTR("mp3task result code: %d"), error);
+  audio_i2s.mic_task_h = 0;
+  audio_i2s_mp3.recdur = 0;
+  audio_i2s_mp3.stream_active = 0;
+  vTaskDelete(NULL);
+
+}
+
+int32_t i2s_record_shine(char *path) {
+esp_err_t err = ESP_OK;
+
+  if (audio_i2s.mic_port == 0) {
+    if (audio_i2s_mp3.decoder || audio_i2s_mp3.mp3) return 0;
+  }
+
+  err = SpeakerMic(MODE_MIC);
+  if (err) {
+    if (audio_i2s.mic_port == 0) {
+      SpeakerMic(MODE_SPK);
+    }
+    AddLog(LOG_LEVEL_INFO, PSTR("mic init error: %d"), err);
+    return err;
+  }
+
+  strlcpy(audio_i2s_mp3.mic_path, path, sizeof(audio_i2s_mp3.mic_path));
+
+  audio_i2s_mp3.mic_stop = 0;
+
+  uint32_t stack = 4096;
+
+  audio_i2s_mp3.use_stream = !strcmp(audio_i2s_mp3.mic_path, "stream.mp3");
+
+  if (audio_i2s_mp3.use_stream) {
+    stack = 8000;
+  }
+
+  err = xTaskCreatePinnedToCore(mic_task, "MIC", stack, NULL, 3, &audio_i2s.mic_task_h, 1);
+
+  return err;
+}
+
+void Cmd_MicRec(void) {
+
+  if (XdrvMailbox.data_len > 0) {
+    if (!strncmp(XdrvMailbox.data, "-?", 2)) {
+      Response_P("{\"I2SREC-duration\":%d}", audio_i2s_mp3.recdur);
+    } else {
+      i2s_record_shine(XdrvMailbox.data);
+      ResponseCmndChar(XdrvMailbox.data);
+    }
+  } else {
+    if (audio_i2s.mic_task_h) {
+      // stop task
+      audio_i2s_mp3.mic_stop = 1;
+      while (audio_i2s_mp3.mic_stop) {
+        delay(1);
+      }
+      ResponseCmndChar_P(PSTR("Stopped"));
+    }
+  }
+
+}
+#endif // USE_SHINE
+
+
+// mic gain in factor not percent
+void Cmd_MicGain(void) {
+  if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 256)) {
+    if (audio_i2s.in) {
+      audio_i2s.in->setRxGain(XdrvMailbox.payload);
+    }
+    if (audio_i2s.Settings) {
+      audio_i2s.Settings->rx.gain = XdrvMailbox.payload * 16;
+    }
+    I2SSettingsSave(AUDIO_CONFIG_FILENAME);
+  }
+  ResponseCmndNumber(audio_i2s.Settings->rx.gain / 16);
+}
+
+#endif // USE_I2S_AUDIO
+#endif // defined(ESP32) && ESP_IDF_VERSION_MAJOR >= 5

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_7_i2s_webradio_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_7_i2s_webradio_idf51.ino
@@ -65,17 +65,17 @@ void Webradio(const char *url) {
     return;
   }
 
-  if (audio_i2s.decoder || audio_i2s.mp3) return;
+  // if (audio_i2s_mp3.decoder || audio_i2s_mp3.mp3) return;
   if (!audio_i2s.out) return;
   I2SAudioPower(true);
   Audio_webradio.ifile = new AudioFileSourceICYStream(url);
   Audio_webradio.ifile->RegisterMetadataCB(I2sMDCallback, NULL);
   Audio_webradio.buff = new AudioFileSourceBuffer(Audio_webradio.ifile, Audio_webradio.preallocateBuffer, preallocateBufferSize);
   Audio_webradio.buff->RegisterStatusCB(I2sStatusCallback, NULL);
-  audio_i2s.decoder = new AudioGeneratorMP3(Audio_webradio.preallocateCodec, preallocateCodecSize);
-  audio_i2s.decoder->RegisterStatusCB(I2sStatusCallback, NULL);
-  audio_i2s.decoder->begin(Audio_webradio.buff, audio_i2s.out);
-  if (!audio_i2s.decoder->isRunning()) {
+  audio_i2s_mp3.decoder = new AudioGeneratorMP3(Audio_webradio.preallocateCodec, preallocateCodecSize);
+  audio_i2s_mp3.decoder->RegisterStatusCB(I2sStatusCallback, NULL);
+  audio_i2s_mp3.decoder->begin(Audio_webradio.buff, audio_i2s.out);
+  if (!audio_i2s_mp3.decoder->isRunning()) {
   //  Serial.printf_P(PSTR("Can't connect to URL"));
     I2sStopPlaying();
   //  strcpy_P(status, PSTR("Unable to connect to URL"));
@@ -83,7 +83,7 @@ void Webradio(const char *url) {
   }
 
   AddLog(LOG_LEVEL_DEBUG,PSTR("I2S: will launch webradio task"));
-  xTaskCreatePinnedToCore(I2sMp3Task2, "MP3-2", 8192, NULL, 3, &audio_i2s.mp3_task_handle, 1);
+  xTaskCreatePinnedToCore(I2sMp3Task2, "MP3-2", 8192, NULL, 3, &audio_i2s_mp3.mp3_task_handle, 1);
 }
 
 #ifdef USE_WEBSERVER
@@ -91,7 +91,7 @@ const char HTTP_WEBRADIO[] PROGMEM =
    "{s}" "I2S_WR-Title" "{m}%s{e}";
 
 void I2sWrShow(bool json) {
-    if (audio_i2s.decoder) {
+    if (audio_i2s_mp3.decoder) {
       if (json) {
         ResponseAppend_P(PSTR(",\"WebRadio\":{\"Title\":\"%s\"}"), Audio_webradio.wr_title);
       } else {
@@ -104,7 +104,7 @@ void I2sWrShow(bool json) {
 void CmndI2SWebRadio(void) {
   if (!audio_i2s.out) return;
 
-  if (audio_i2s.decoder) {
+  if (audio_i2s_mp3.decoder) {
     I2sStopPlaying();
   }
   if (XdrvMailbox.data_len > 0) {


### PR DESCRIPTION
## Description:

More audio refactoring for Arduino core 3 and esp-idf 5.1:
- full support for exclusive mode (Atom Echo, M5Stack Core2)
- prepare support for DAC output (not working yet)
- added `I2S DAC` gpio type for easier configuration

Not yet working:
- DAC audio almost there
- ESP32C3 does not compile, because PDM is not supported on C3. It will need more #ifdefs

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
