### PR TITLE
Audio Core3 compilation for ESP32C3

### DIFF
--- a/lib/libesp32_audio/mp3_shine_esp32/src/layer3.cpp
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/layer3.cpp
@@ -226,7 +226,8 @@ Counters 2664123380 : 2664123448 : 2666717886 : 2668665908 : 2668859025
 
 
 static unsigned char *shine_encode_buffer_internal(shine_global_config *config, int *written, int stride) {
-  counter[0] = xthal_get_ccount();
+  counter[0] = portGET_RUN_TIME_COUNTER_VALUE();      // TASMOTA more portable solution
+  // counter[0] = xthal_get_ccount();
   if(config->mpeg.frac_slots_per_frame) {
     config->mpeg.padding   = (config->mpeg.slot_lag <= (config->mpeg.frac_slots_per_frame - 1.0));
     config->mpeg.slot_lag += (config->mpeg.padding - config->mpeg.frac_slots_per_frame);
@@ -234,18 +235,22 @@ static unsigned char *shine_encode_buffer_internal(shine_global_config *config, 
 
   config->mpeg.bits_per_frame = 8*(config->mpeg.whole_slots_per_frame + config->mpeg.padding);
   config->mean_bits = (config->mpeg.bits_per_frame - config->sideinfo_len)/config->mpeg.granules_per_frame;
-  counter[1] = xthal_get_ccount();
+  counter[1] = portGET_RUN_TIME_COUNTER_VALUE();      // TASMOTA more portable solution
+  // counter[1] = xthal_get_ccount();
   /* apply mdct to the polyphase output */
   // put on core 1
   shine_mdct_sub(config, stride);
-  counter[2] = xthal_get_ccount();
+  counter[2] = portGET_RUN_TIME_COUNTER_VALUE();      // TASMOTA more portable solution
+  // counter[2] = xthal_get_ccount();
   /* bit and noise allocation */
   //put on core 0
   shine_iteration_loop(config);
-  counter[3] = xthal_get_ccount();
+  counter[3] = portGET_RUN_TIME_COUNTER_VALUE();      // TASMOTA more portable solution
+  // counter[3] = xthal_get_ccount();
   /* write the frame to the bitstream */
   shine_format_bitstream(config);
-  counter[4] = xthal_get_ccount();
+  counter[4] = portGET_RUN_TIME_COUNTER_VALUE();      // TASMOTA more portable solution
+  // counter[4] = xthal_get_ccount();
   /* Return data. */
   *written = config->bs.data_position;
   config->bs.data_position = 0;

--- a/lib/libesp32_audio/mp3_shine_esp32/src/mult_noarch_gcc.h
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/mult_noarch_gcc.h
@@ -1,114 +1,30 @@
 #include <stdint.h>
 
 #ifndef asm_mul
-//#define              /// mul(a,b)   (int)  ( ( ((int64_t) a) * ((int64_t) b) ) >>32 )
-
-#define asm_mul(x,y) \
-({ \
-    int result; \
-    asm ("mulsh %0, %2, %1" : "=r" (result) : "r" (x), "r" (y)); \
-    result ;\
-})
-
+#define asm_mul(a,b)   (int)  ( ( ((int64_t) a) * ((int64_t) b) ) >>32 )
 #endif
 
 #ifndef asm_muls     //Not sure about this
-#define asm_muls(x,y) \
-({ \
-    register int result; \
-    asm ( \
-    	"mulsh %0, %2, %1\n\t" \
-    	"add %0, %0, %0" \
-    	: "=r" (result) : "r" (x), "r" (y)); \
-    result ;\
-})
-
-
-
-//#define muls(a,b)  (int)  ( ( ((int64_t) a) * ((int64_t) b) ) >>31 )
+#define asm_muls(a,b)  (int)  ( ( ((int64_t) a) * ((int64_t) b) ) >>31 )
 #endif
 
 #ifndef asm_mulr    //no rounding shortcut
-#define asm_mulr(x,y) \
-({ \
-    int result; \
-    asm ("mulsh %0, %2, %1" : "=r" (result) : "r" (x), "r" (y)); \
-    result ;\
-})
-
-//#define mulr(a,b)  (int)  ( ( ( ((int64_t) a) * ((int64_t) b)) + 0x80000000LL ) >>32 )
+#define asm_mulr(a,b)  (int)  ( ( ( ((int64_t) a) * ((int64_t) b)) + 0x80000000LL ) >>32 )
 #endif
 
 #ifndef asm_mulsr   //no rounding shortcut
-#define asm_mulsr(x,y) \
-({ \
-    int result; \
-    asm ( \
-        "mulsh %0, %2, %1\n\t" \
-        "add %0, %0, %0" \
-        : "=r" (result) : "r" (x), "r" (y)); \
-    result ;\
-})
-
-//#define mulsr(a,b) (int)  ( ( ( ((int64_t) a) * ((int64_t) b)) + 0x40000000LL ) >>31 )
+#define asm_mulsr(a,b) (int)  ( ( ( ((int64_t) a) * ((int64_t) b)) + 0x40000000LL ) >>31 )
 #endif
 
 #ifndef asm_mul0
 #define asm_mul0(hi,lo,a,b)     ((hi)  = asm_mul((a), (b)))
 
-// This didn't seem to help either
-#define asm_muladd(hi, lo, x, y) \
- ({  \
-    asm ( \
-    		"mulsh a7, %2, %1\n\t" \
-    		"add %0, %0, a7\n\t" \
-    		: "+r" (hi) : "r" (x), "r" (y) \
-    		: "a7");\
-})
-
-
-//#define asm_muladd(hi,lo,a,b)   ((hi) += mul((a), (b)))
- #define asm_mulsub(hi, lo, x, y) \
- ({  \
-    asm ( \
-            "mulsh a8, %2, %1\n\t" \
-            "sub %0, %0, a8\n\t" \
-            : "+r" (hi) : "r" (x), "r" (y) \
-            : "a8");\
-})
-//#define mulsub(hi,lo,a,b)   ((hi) -= mul((a), (b)))
+#define asm_muladd(hi,lo,a,b)   ((hi) += asm_mul((a), (b)))
+#define mulsub(hi,lo,a,b)   ((hi) -= asm_mul((a), (b)))
 #define asm_mulz(hi,lo)
 #endif
 
 #ifndef asm_cmuls
-/*
- #define cmuls(dre, dim, are, aim, bre, bim) \
-do { \
-    register int tre, tim; \
-    asm ( \
-        "mull %0, %2, %4\n\t" \  //mulsh
-        "mulsh r3, %2, %4\n\t" \  //mulsh
-        "mull r4, %3, %5\n\t" \  //mulsh
-        "mulsh r5, %3, %5\n\t" \  //mulsh
-        "add %0, %0, %0\n\t" \ shl
-
-        "smull r3, %0, %2, %4\n\t" \  //mulsh
-        "smlal r3, %0, %3, %5\n\t" \ //mulsh + add
-        "movs r3, r3, lsl #1\n\t" \  //add r to r
-        "adc %0, %0, %0\n\t" \. //add with carry
-        "smull r3, %1, %2, %6\n\t" \
-        "smlal r3, %1, %4, %3\n\t" \
-        "movs r3, r3, lsl #1\n\t" \
-        "adc %1, %1, %1\n\t" \
-        : "=&r" (tre), "=&r" (tim) \
-        : "r" (are), "r" (aim), "r" (bre), "r" (-(bim)), "r" (bim) \
-        : "r3", "cc" \
-    ); \
-    dre = tre; \
-    dim = tim; \
-} while (0)*/
-
-
 #define asm_cmuls(dre, dim, are, aim, bre, bim) \
 do { \
 	int tre; \

--- a/lib/libesp32_audio/mp3_shine_esp32/src/mult_xtensa_gcc.h
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/mult_xtensa_gcc.h
@@ -1,0 +1,119 @@
+#include <stdint.h>
+
+#ifndef asm_mul
+//#define              /// mul(a,b)   (int)  ( ( ((int64_t) a) * ((int64_t) b) ) >>32 )
+
+#define asm_mul(x,y) \
+({ \
+    int result; \
+    asm ("mulsh %0, %2, %1" : "=r" (result) : "r" (x), "r" (y)); \
+    result ;\
+})
+
+#endif
+
+#ifndef asm_muls     //Not sure about this
+#define asm_muls(x,y) \
+({ \
+    register int result; \
+    asm ( \
+    	"mulsh %0, %2, %1\n\t" \
+    	"add %0, %0, %0" \
+    	: "=r" (result) : "r" (x), "r" (y)); \
+    result ;\
+})
+
+
+
+//#define muls(a,b)  (int)  ( ( ((int64_t) a) * ((int64_t) b) ) >>31 )
+#endif
+
+#ifndef asm_mulr    //no rounding shortcut
+#define asm_mulr(x,y) \
+({ \
+    int result; \
+    asm ("mulsh %0, %2, %1" : "=r" (result) : "r" (x), "r" (y)); \
+    result ;\
+})
+
+//#define mulr(a,b)  (int)  ( ( ( ((int64_t) a) * ((int64_t) b)) + 0x80000000LL ) >>32 )
+#endif
+
+#ifndef asm_mulsr   //no rounding shortcut
+#define asm_mulsr(x,y) \
+({ \
+    int result; \
+    asm ( \
+        "mulsh %0, %2, %1\n\t" \
+        "add %0, %0, %0" \
+        : "=r" (result) : "r" (x), "r" (y)); \
+    result ;\
+})
+
+//#define mulsr(a,b) (int)  ( ( ( ((int64_t) a) * ((int64_t) b)) + 0x40000000LL ) >>31 )
+#endif
+
+#ifndef asm_mul0
+#define asm_mul0(hi,lo,a,b)     ((hi)  = asm_mul((a), (b)))
+
+// This didn't seem to help either
+#define asm_muladd(hi, lo, x, y) \
+ ({  \
+    asm ( \
+    		"mulsh a7, %2, %1\n\t" \
+    		"add %0, %0, a7\n\t" \
+    		: "+r" (hi) : "r" (x), "r" (y) \
+    		: "a7");\
+})
+
+
+//#define asm_muladd(hi,lo,a,b)   ((hi) += mul((a), (b)))
+ #define asm_mulsub(hi, lo, x, y) \
+ ({  \
+    asm ( \
+            "mulsh a8, %2, %1\n\t" \
+            "sub %0, %0, a8\n\t" \
+            : "+r" (hi) : "r" (x), "r" (y) \
+            : "a8");\
+})
+//#define mulsub(hi,lo,a,b)   ((hi) -= mul((a), (b)))
+#define asm_mulz(hi,lo)
+#endif
+
+#ifndef asm_cmuls
+/*
+ #define cmuls(dre, dim, are, aim, bre, bim) \
+do { \
+    register int tre, tim; \
+    asm ( \
+        "mull %0, %2, %4\n\t" \  //mulsh
+        "mulsh r3, %2, %4\n\t" \  //mulsh
+        "mull r4, %3, %5\n\t" \  //mulsh
+        "mulsh r5, %3, %5\n\t" \  //mulsh
+        "add %0, %0, %0\n\t" \ shl
+
+        "smull r3, %0, %2, %4\n\t" \  //mulsh
+        "smlal r3, %0, %3, %5\n\t" \ //mulsh + add
+        "movs r3, r3, lsl #1\n\t" \  //add r to r
+        "adc %0, %0, %0\n\t" \. //add with carry
+        "smull r3, %1, %2, %6\n\t" \
+        "smlal r3, %1, %4, %3\n\t" \
+        "movs r3, r3, lsl #1\n\t" \
+        "adc %1, %1, %1\n\t" \
+        : "=&r" (tre), "=&r" (tim) \
+        : "r" (are), "r" (aim), "r" (bre), "r" (-(bim)), "r" (bim) \
+        : "r3", "cc" \
+    ); \
+    dre = tre; \
+    dim = tim; \
+} while (0)*/
+
+
+#define asm_cmuls(dre, dim, are, aim, bre, bim) \
+do { \
+	int tre; \
+	(tre) = (int) (((int64_t) (are) * (int64_t) (bre) - (int64_t) (aim) * (int64_t) (bim)) >> 31); \
+	(dim) = (int) (((int64_t) (are) * (int64_t) (bim) + (int64_t) (aim) * (int64_t) (bre)) >> 31); \
+	(dre) = tre; \
+} while (0)
+#endif

--- a/lib/libesp32_audio/mp3_shine_esp32/src/types.h
+++ b/lib/libesp32_audio/mp3_shine_esp32/src/types.h
@@ -17,6 +17,8 @@
 #include "mult_mips_gcc.h"
 #elif defined(__arm__) && !defined(__thumb__)
 #include "mult_sarm_gcc.h"
+#elif defined(__XTENSA__)
+#include "mult_xtensa_gcc.h"
 #endif
 
 /* Include and define generic instructions,

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_lib_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_lib_idf51.ino
@@ -532,7 +532,9 @@ bool TasmotaI2S::startI2SChannel(bool tx, bool rx) {
       tx_std_cfg.slot_cfg = I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG((i2s_data_bit_width_t)bps, (i2s_slot_mode_t)channels);
     }
     if (_tx_slot_mask != I2S_SLOT_NOCHANGE) { tx_std_cfg.slot_cfg.slot_mask = (i2s_std_slot_mask_t)_tx_slot_mask; }
+#if SOC_I2S_SUPPORTS_APLL
     if (_apll) { tx_std_cfg.clk_cfg.clk_src = I2S_CLK_SRC_APLL; }
+#endif // SOC_I2S_SUPPORTS_APLL
 
     err = i2s_channel_init_std_mode(_tx_handle, &tx_std_cfg);
     AddLog(LOG_LEVEL_DEBUG, "I2S: i2s_channel_init_std_mode TX channel bits:%i channels:%i hertz:%i err=0x%04X", bps, channels, hertz, err);
@@ -589,6 +591,7 @@ bool TasmotaI2S::startI2SChannel(bool tx, bool rx) {
     err = i2s_new_channel(&rx_chan_cfg, NULL, &_rx_handle);
     AddLog(LOG_LEVEL_DEBUG, "I2S: i2s_new_channel Rx err:%i", err);
     switch (_rx_mode){
+#if SOC_I2S_SUPPORTS_PDM_RX
       case I2S_MODE_PDM:
         {
           i2s_pdm_rx_config_t rx_pdm_cfg = {
@@ -623,6 +626,7 @@ bool TasmotaI2S::startI2SChannel(bool tx, bool rx) {
           }
         }
         break;
+#endif // SOC_I2S_SUPPORTS_PDM_RX
       case I2S_MODE_STD:
         {        
           i2s_std_config_t rx_std_cfg = {


### PR DESCRIPTION
## Description:

Fix compilation of Core3 audio for ESP32C3:
- fix shine MP3 to use portable counter, and non-asm multiplication (performance may be non-optimal)
- conditional compilation for PDM RX and APLL which are not supported on ESP32C3

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
