### PR TITLE
Teleinfo use Apparent Power as Active Power approximation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - MAX31855/MAX6675 sensors driver support up to 6 (#19329)
 - ESP32 analog from `analogRead()` to calibrated `analogReadMilliVolts()` (#19732)
 - I2S refactoring in preparation for core 3 (#19749)
+- Teleinfo use Apparent Power as Active Power approximation
 
 ### Fixed
 - ESP32 shutter frequency (#19717)

--- a/tasmota/tasmota_xnrg_energy/xnrg_15_teleinfo.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_15_teleinfo.ino
@@ -334,11 +334,11 @@ void DataCallback(struct _ValueList * me, uint8_t  flags)
             AddLog(LOG_LEVEL_DEBUG, PSTR("TIC: Power %s=%s, now %d"), me->name, me->value, (int) power);
 
             if (ilabel == LABEL_PAPP || ilabel == LABEL_SINSTS1 || (ilabel == LABEL_SINSTS && Energy->phase_count == 1)) {
-                Energy->apparent_power[0] = power;
+                Energy->active_power[0] = Energy->apparent_power[0] = power;
             } else if (ilabel == LABEL_SINSTS2) {
-                Energy->apparent_power[1] = power;
+                Energy->active_power[1] = Energy->apparent_power[1] = power;
             } else if (ilabel == LABEL_SINSTS3) {
-                Energy->apparent_power[2] = power;
+                Energy->active_power[2] = Energy->apparent_power[2] = power;
             }
         }
 


### PR DESCRIPTION
## Description:

#19381 removed Active Power in favor of Apparent Power (which is the only information provided by Teleinfo). However this was a breaking change and Active Power is always 0.

I propose to copy Apparent Power to Active Power as an approximation (which should not be too bad).

Note: Teleinfo provides instant current as IINST, but it's an integer which is not precise enough.

@hallard Are you ok with this? Do you have a better way to get Active Power?

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
