### PR TITLE
Pio: add all libs to ignore, not needed for compiling of safeboot env

### DIFF
--- a/lib/default/headers/esp-knx-ip.h
+++ b/lib/default/headers/esp-knx-ip.h
@@ -53,7 +53,7 @@
  */
 
 #include "Arduino.h"
-#include <EEPROM.h>
+//#include <EEPROM.h>
 #include <ESP8266WiFi.h>
 #include <WiFiUdp.h>
 #include <ESP8266WebServer.h>

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -53,7 +53,8 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
                               ${esp_defaults.extra_scripts}
 
 [safeboot_flags]
-lib_ignore                  = ESP Mail Client
+lib_ignore                  = ${esp32_defaults.lib_ignore}
+                              ESP Mail Client
                               IRremoteESP8266
                               NeoPixelBus
                               OneWire

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -58,11 +58,16 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               IRremoteESP8266
                               NeoPixelBus
                               OneWire
+                              EEPROM
+                              EEPROM 24C128_256_521
                               MFRC522
                               universal display Library
                               ESP8266Audio
                               ESP8266SAM
                               FFat
+                              SD
+                              SD_MMC
+                              UdpListener
                               Berry
                               Berry mapping to C
                               Berry Tasmota mapping


### PR DESCRIPTION
## Description:

Speed up build process of safeboot firmwares
No changes in resulting compiled firmwares

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
