### PR TITLE
deactivate automatic flashsize detection

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -47,7 +47,7 @@ lib_ignore                  =
                               ArduinoOTA
                               ESP32-HomeKit
 extra_scripts               = pre:pio-tools/add_c_flags.py
-                              pre:pio-tools/get_flash_size.py
+                            ;   pre:pio-tools/get_flash_size.py
                               pre:pio-tools/gen-berry-structures.py
                               post:pio-tools/post_esp32.py
                               ${esp_defaults.extra_scripts}


### PR DESCRIPTION
## Description:

This feature should be no longer required since LittleFS can grow non-destructive now.
We'll remove the deactivated script and clean up the rest of the build scripts in the not so distant future.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
