### PR TITLE
Add command ``GpioRead``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - I2C bus2 support to SHTxX temperature and humidity sensor
 - I2C bus2 support to HYTxxx temperature and humidity sensor
 - I2C bus2 support to SI1145/6/7 Ultra violet index and light sensor
+- Add command ``GpioRead``
 
 ### Breaking Changed
 

--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -302,6 +302,7 @@
 #define D_CMND_GPIO "GPIO"
   #define D_JSON_NOT_SUPPORTED "Not supported"
 #define D_CMND_GPIOS "GPIOs"
+#define D_CMND_GPIOREAD "GPIORead"
 #define D_CMND_PWM "PWM"
 #define D_CMND_PWMFREQUENCY "PWMFrequency"
 #define D_CMND_PWMRANGE "PWMRange"

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -1774,12 +1774,11 @@ void CmndGpioRead(void)
   myio template_gp;
   TemplateGpios(&template_gp);
   bool jsflg = false;
+  Response_P(PSTR("{\"" D_CMND_GPIOREAD "\":{"));
   for (uint32_t i = 0; i < nitems(Settings->my_gp.io); i++) {
     uint32_t sensor_type = template_gp.io[i];
     if ((sensor_type != GPIO_NONE) && (AGPIO(GPIO_USER) != sensor_type)) {
-      if (!jsflg) {
-        Response_P(PSTR("{"));
-      } else {
+      if (jsflg) {
         ResponseAppend_P(PSTR(","));
       }
       jsflg = true;
@@ -1787,11 +1786,7 @@ void CmndGpioRead(void)
       ResponseAppend_P(PSTR("\"" D_CMND_GPIO "%d\":%d"), i, state);
     }
   }
-  if (jsflg) {
-    ResponseJsonEnd();
-  } else {
-     Response_P(PSTR("{}"));
-  }
+  ResponseAppend_P(PSTR("}}"));
 }
 
 void ShowGpios(const uint16_t *NiceList, uint32_t size, uint32_t offset, uint32_t &lines) {

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -27,7 +27,7 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
   D_CMND_POWERONSTATE "|" D_CMND_PULSETIME "|" D_CMND_BLINKTIME "|" D_CMND_BLINKCOUNT "|" D_CMND_SAVEDATA "|"
   D_CMND_SO "|" D_CMND_SETOPTION "|" D_CMND_TEMPERATURE_RESOLUTION "|" D_CMND_HUMIDITY_RESOLUTION "|" D_CMND_PRESSURE_RESOLUTION "|" D_CMND_POWER_RESOLUTION "|"
   D_CMND_VOLTAGE_RESOLUTION "|" D_CMND_FREQUENCY_RESOLUTION "|" D_CMND_CURRENT_RESOLUTION "|" D_CMND_ENERGY_RESOLUTION "|" D_CMND_WEIGHT_RESOLUTION "|"
-  D_CMND_MODULE "|" D_CMND_MODULES "|" D_CMND_GPIO "|" D_CMND_GPIOS "|" D_CMND_TEMPLATE "|" D_CMND_PWM "|" D_CMND_PWMFREQUENCY "|" D_CMND_PWMRANGE "|"
+  D_CMND_MODULE "|" D_CMND_MODULES "|" D_CMND_GPIO "|" D_CMND_GPIOREAD "|" D_CMND_GPIOS "|" D_CMND_TEMPLATE "|" D_CMND_PWM "|" D_CMND_PWMFREQUENCY "|" D_CMND_PWMRANGE "|"
   D_CMND_BUTTONDEBOUNCE "|" D_CMND_SWITCHDEBOUNCE "|" D_CMND_SYSLOG "|" D_CMND_LOGHOST "|" D_CMND_LOGPORT "|"
   D_CMND_SERIALBUFFER "|" D_CMND_SERIALSEND "|" D_CMND_BAUDRATE "|" D_CMND_SERIALCONFIG "|" D_CMND_SERIALDELIMITER "|"
   D_CMND_IPADDRESS "|" D_CMND_NTPSERVER "|" D_CMND_AP "|" D_CMND_SSID "|" D_CMND_PASSWORD "|" D_CMND_HOSTNAME "|" D_CMND_WIFICONFIG "|" D_CMND_WIFI "|" D_CMND_DNSTIMEOUT "|"
@@ -67,7 +67,7 @@ void (* const TasmotaCommand[])(void) PROGMEM = {
   &CmndPowerOnState, &CmndPulsetime, &CmndBlinktime, &CmndBlinkcount, &CmndSavedata,
   &CmndSetoption, &CmndSetoption, &CmndTemperatureResolution, &CmndHumidityResolution, &CmndPressureResolution, &CmndPowerResolution,
   &CmndVoltageResolution, &CmndFrequencyResolution, &CmndCurrentResolution, &CmndEnergyResolution, &CmndWeightResolution,
-  &CmndModule, &CmndModules, &CmndGpio, &CmndGpios, &CmndTemplate, &CmndPwm, &CmndPwmfrequency, &CmndPwmrange,
+  &CmndModule, &CmndModules, &CmndGpio, &CmndGpioRead, &CmndGpios, &CmndTemplate, &CmndPwm, &CmndPwmfrequency, &CmndPwmrange,
   &CmndButtonDebounce, &CmndSwitchDebounce, &CmndSyslog, &CmndLoghost, &CmndLogport,
   &CmndSerialBuffer, &CmndSerialSend, &CmndBaudrate, &CmndSerialConfig, &CmndSerialDelimiter,
   &CmndIpAddress, &CmndNtpServer, &CmndAp, &CmndSsid, &CmndPassword, &CmndHostname, &CmndWifiConfig, &CmndWifi, &CmndDnsTimeout,
@@ -1765,6 +1765,32 @@ void CmndGpio(void)
         ResponseCmndChar(PSTR(D_JSON_NOT_SUPPORTED));
       }
     }
+  }
+}
+
+// Perform a digitalRead on each configured PGIO
+void CmndGpioRead(void)
+{
+  myio template_gp;
+  TemplateGpios(&template_gp);
+  bool jsflg = false;
+  for (uint32_t i = 0; i < nitems(Settings->my_gp.io); i++) {
+    uint32_t sensor_type = template_gp.io[i];
+    if ((sensor_type != GPIO_NONE) && (AGPIO(GPIO_USER) != sensor_type)) {
+      if (!jsflg) {
+        Response_P(PSTR("{"));
+      } else {
+        ResponseAppend_P(PSTR(","));
+      }
+      jsflg = true;
+      bool state = digitalRead(i);
+      ResponseAppend_P(PSTR("\"" D_CMND_GPIO "%d\":%d"), i, state);
+    }
+  }
+  if (jsflg) {
+    ResponseJsonEnd();
+  } else {
+     Response_P(PSTR("{}"));
   }
 }
 


### PR DESCRIPTION
## Description:

Add command `GpioRead` which is used to quickly debug digital inputs giving their current values. `digitalRead()` is called on all configured GPIO although the static value may not be of any sense for many protocols (I2C...).

Examples:
```
GpioRead

14:45:08.240 RSL: RESULT = {"GPIORead":{"GPIO32":0,"GPIO33":0}}
```
 
**Related issue (if applicable):** fixes #19810

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
