### PR TITLE
Fix audio Arduino 3

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio_idf51.ino
@@ -963,7 +963,7 @@ void CmndI2SGain(void) {
 
 void CmndI2SSay(void) {
   if (XdrvMailbox.data_len > 0) {
-    if (I2SPrepareTx()) {
+    if (I2SPrepareTx() != I2S_OK) {
       ResponseCmndChar("I2S output not configured");
       return;
     } else {


### PR DESCRIPTION
## Description:

Fix audio for Arudino Core 3.
Now I2S configuration (bits per seconds, channels) is decorrelated from bps/channels of the AudioOutput.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
