### PR TITLE
Update the Web UI button for the iFan by replaceing the '0' button with 'TOGGLE'

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -1248,25 +1248,35 @@ void HandleRoot(void)
         }
       }  // Settings->flag3.pwm_multi_channels
     }
-#endif // USE_LIGHT
-    WSContentSend_P(HTTP_TABLE100);
-    WSContentSend_P(PSTR("<tr>"));
+// Check if the Sonoff iFan module is being used
 #ifdef USE_SONOFF_IFAN
     if (IsModuleIfan()) {
+      // Send a command to the web server to create a 'Toggle' button
+      // The '36' is the button type, '1' is the button number
+      // 'D_BUTTON_TOGGLE' is the label for the button
       WSContentSend_P(HTTP_DEVICE_CONTROL, 36, 1,
-        (strlen(SettingsText(SET_BUTTON1))) ? SettingsText(SET_BUTTON1) : PSTR(D_BUTTON_TOGGLE),
+        PSTR(D_BUTTON_TOGGLE),
         "");
+      // Loop through each fan speed
       for (uint32_t i = 0; i < MaxFanspeed(); i++) {
+        // Format a string with the fan speed number
         snprintf_P(stemp, sizeof(stemp), PSTR("%d"), i);
+        // Send a command to the web server to create a button for this fan speed
+        // The '16' is the button type, 'i +2' is the button number
+        // The label for the button is either a custom label from settings or the fan speed number
         WSContentSend_P(HTTP_DEVICE_CONTROL, 16, i +2,
           (strlen(SettingsText(SET_BUTTON2 + i))) ? SettingsText(SET_BUTTON2 + i) : stemp,
           "");
       }
     } else {
 #endif  // USE_SONOFF_IFAN
+      // Get the number of device columns for non-iFan modules
       uint32_t cols = WebDeviceColumns();
+      // Loop through each device present in non-iFan modules
       for (uint32_t idx = 1; idx <= TasmotaGlobal.devices_present; idx++) {
-        bool set_button = ((idx <= MAX_BUTTON_TEXT) && strlen(GetWebButton(idx -1)));
+        // Check if a custom label has been set for this button
+        bool set_button = ((idx <= MAX_BUTTON_TEXT) && strlen(SettingsText(SET_BUTTON1 + idx -1)));
+
 #ifdef USE_SHUTTER
         int32_t ShutterWebButton;
         if (ShutterWebButton = IsShutterWebButton(idx)) {


### PR DESCRIPTION
Modifying the web UI for SONOFF iFan by replaceing the '0' button with 'TOGGLE' that can turn turn on the fan on the last saved speed to flash before turning off.

## Description:

I considered opening this pull request based on my recent discussion https://github.com/arendst/Tasmota/discussions/19410 after modifying the code in the file  xdrv_01_9_webserver.ino that handles the Webserver UI and tried changing the button name, also please check my style I provided in that recent discussion I opened, including images and style changes (HTML and CSS) code, so if this update can be applied to my modified file so the UI can look good. I hope to check my request and if anyone can update something that needs to be changed, so everything can pass.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
