### PR TITLE
Update be_lexer.c

### DIFF
--- a/lib/libesp32/berry/src/be_lexer.c
+++ b/lib/libesp32/berry/src/be_lexer.c
@@ -260,6 +260,7 @@ static void skip_comment(blexer *lexer)
 {
     next(lexer); /* skip '#' */
     if (lgetc(lexer) == '-') { /* mult-line comment */
+        int lno = lexer->linenumber;
         int mark, c = 'x'; /* skip first '-' (#- ... -#) */
         do {
             mark = c == '-';
@@ -269,6 +270,11 @@ static void skip_comment(blexer *lexer)
             }
             c = next(lexer);
         } while (!(mark && c == '#') && c != EOS);
+        if (c == EOS) {
+        	char tmp[64];
+        	sprintf(tmp, "unterminated comment block started in line %d", lno);
+            be_lexerror(lexer, tmp);
+        }
         next(lexer); /* skip '#' */
     } else { /* line comment */
         while (!is_newline(lgetc(lexer)) && lgetc(lexer)) {


### PR DESCRIPTION
Added check for unterminated block comments

## Description:

Comment blocks started with '#-' but not closed caused a read past EOS and threw a message concerning this erroneous token - but gave no hint, that an unterminated comment was the culprit in the first place.

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
