### PR TITLE
Refactoring of storing safeboot bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ data
 unpacked_fs
 unpacked_boards
 tasmota/user_config_override.h
+variants
+variants3
 build
 build_output/*
 firmware.map

--- a/boards/esp32-fix.json
+++ b/boards/esp32-fix.json
@@ -31,7 +31,7 @@
       "flash_extra_images": [
         [
           "0x10000",
-          "variants/tasmota/tasmota32-safeboot.bin"
+          "tasmota32-safeboot.bin"
         ]
       ]
     },

--- a/boards/esp32.json
+++ b/boards/esp32.json
@@ -31,7 +31,7 @@
         "flash_extra_images": [
           [
             "0x10000",
-            "variants/tasmota/tasmota32-safeboot.bin"
+            "tasmota32-safeboot.bin"
           ]
         ]
       },

--- a/boards/esp32_solo1.json
+++ b/boards/esp32_solo1.json
@@ -31,7 +31,7 @@
       "flash_extra_images": [
         [
           "0x10000",
-          "variants/tasmota/tasmota32solo1-safeboot.bin"
+          "tasmota32solo1-safeboot.bin"
         ]
       ]
     },

--- a/boards/esp32c2.json
+++ b/boards/esp32c2.json
@@ -29,7 +29,7 @@
         "flash_extra_images": [
           [
             "0x10000",
-            "variants/tasmota/tasmota32c2-safeboot.bin"
+            "tasmota32c2-safeboot.bin"
           ]
         ]
       },

--- a/boards/esp32c2_2M.json
+++ b/boards/esp32c2_2M.json
@@ -29,7 +29,7 @@
         "flash_extra_images": [
           [
             "0x10000",
-            "variants/tasmota/tasmota32c2-safeboot.bin"
+            "tasmota32c2-safeboot.bin"
           ]
         ]
       },

--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -29,7 +29,7 @@
         "flash_extra_images": [
           [
             "0x10000",
-            "variants/tasmota/tasmota32c3-safeboot.bin"
+            "tasmota32c3-safeboot.bin"
           ]
         ]
       },

--- a/boards/esp32c3cdc.json
+++ b/boards/esp32c3cdc.json
@@ -29,7 +29,7 @@
         "flash_extra_images": [
           [
             "0x10000",
-            "variants/tasmota/tasmota32c3cdc-safeboot.bin"
+            "tasmota32c3cdc-safeboot.bin"
           ]
         ]
       },

--- a/boards/esp32c6.json
+++ b/boards/esp32c6.json
@@ -29,7 +29,7 @@
         "flash_extra_images": [
           [
             "0x10000",
-            "variants/tasmota/tasmota32c6-safeboot.bin"
+            "tasmota32c6-safeboot.bin"
           ]
         ]
       },

--- a/boards/esp32c6cdc.json
+++ b/boards/esp32c6cdc.json
@@ -29,7 +29,7 @@
         "flash_extra_images": [
           [
             "0x10000",
-            "variants/tasmota/tasmota32c6cdc-safeboot.bin"
+            "tasmota32c6cdc-safeboot.bin"
           ]
         ]
       },

--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -28,7 +28,7 @@
       "flash_extra_images": [
         [
           "0x10000",
-          "variants/tasmota/tasmota32s2-safeboot.bin"
+          "tasmota32s2-safeboot.bin"
         ]
       ]
     },

--- a/boards/esp32s2cdc.json
+++ b/boards/esp32s2cdc.json
@@ -28,7 +28,7 @@
       "flash_extra_images": [
         [
           "0x10000",
-          "variants/tasmota/tasmota32s2cdc-safeboot.bin"
+          "tasmota32s2cdc-safeboot.bin"
         ]
       ]
     },

--- a/boards/esp32s3-qio_opi.json
+++ b/boards/esp32s3-qio_opi.json
@@ -31,7 +31,7 @@
       "flash_extra_images": [
         [
           "0x10000",
-          "variants/tasmota/tasmota32s3-safeboot.bin"
+          "tasmota32s3-safeboot.bin"
         ]
       ]
     },

--- a/boards/esp32s3-qio_qspi.json
+++ b/boards/esp32s3-qio_qspi.json
@@ -31,7 +31,7 @@
       "flash_extra_images": [
         [
           "0x10000",
-          "variants/tasmota/tasmota32s3-safeboot.bin"
+          "tasmota32s3-safeboot.bin"
         ]
       ]
     },

--- a/boards/esp32s3cdc-qio_opi.json
+++ b/boards/esp32s3cdc-qio_opi.json
@@ -41,7 +41,7 @@
       "flash_extra_images": [
         [
           "0x10000",
-          "variants/tasmota/tasmota32s3cdc-safeboot.bin"
+          "tasmota32s3cdc-safeboot.bin"
         ]
       ]
     },

--- a/boards/esp32s3cdc-qio_qspi.json
+++ b/boards/esp32s3cdc-qio_qspi.json
@@ -41,7 +41,7 @@
       "flash_extra_images": [
         [
           "0x10000",
-          "variants/tasmota/tasmota32s3cdc-safeboot.bin"
+          "tasmota32s3cdc-safeboot.bin"
         ]
       ]
     },

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -16,7 +16,7 @@
 # -  0x1000 | ~\.platformio\packages\framework-arduinoespressif32\tools\sdk\esp32\bin\bootloader_dout_40m.bin
 # -  0x8000 | ~\Tasmota\.pio\build\<env name>\partitions.bin
 # -  0xe000 | ~\.platformio\packages\framework-arduinoespressif32\tools\partitions\boot_app0.bin
-# - 0x10000 | ~\.platformio/packages/framework-arduinoespressif32/variants/tasmota/\<env name>-safeboot.bin
+# - 0x10000 | ~\Tasmota\<variants_dir>/<env name>-safeboot.bin
 # - 0xe0000 | ~\Tasmota\.pio\build\<env name>/firmware.bin
 # - 0x3b0000| ~\Tasmota\.pio\build\<env name>/littlefs.bin
 
@@ -37,6 +37,13 @@ from SCons.Script import COMMAND_LINE_TARGETS
 sys.path.append(join(platform.get_package_dir("tool-esptoolpy")))
 import esptool
 
+variants_dir = env.BoardConfig().get("build.variants_dir", "")
+variant = env.BoardConfig().get("build.variant", "")
+sections = env.subst(env.get("FLASH_EXTRA_IMAGES"))
+chip = env.get("BOARD_MCU")
+mcu_build_variant = env.BoardConfig().get("build.variant", "").lower()
+
+# Copy safeboots firmwares in place when running in Github
 github_actions = os.getenv('GITHUB_ACTIONS')
 extra_flags = ''.join([element.replace("-D", " ") for element in env.BoardConfig().get("build.extra_flags", "")])
 build_flags = ''.join([element.replace("-D", " ") for element in env.GetProjectOption("build_flags")])
@@ -45,16 +52,31 @@ if "CORE32SOLO1" in extra_flags or "FRAMEWORK_ARDUINO_SOLO1" in build_flags:
     FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-solo1")
     if github_actions and os.path.exists("./firmware/firmware"):
         shutil.copytree("./firmware/firmware", "/home/runner/.platformio/packages/framework-arduino-solo1/variants/tasmota")
+        if variants_dir:
+            shutil.copytree("./firmware/firmware", variants_dir, dirs_exist_ok=True)
 elif "CORE32ITEAD" in extra_flags or "FRAMEWORK_ARDUINO_ITEAD" in build_flags:
     FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-ITEAD")
     if github_actions and os.path.exists("./firmware/firmware"):
         shutil.copytree("./firmware/firmware", "/home/runner/.platformio/packages/framework-arduino-ITEAD/variants/tasmota")
+        if variants_dir:
+            shutil.copytree("./firmware/firmware", variants_dir, dirs_exist_ok=True)
 else:
     FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
     if github_actions and os.path.exists("./firmware/firmware"):
         shutil.copytree("./firmware/firmware", "/home/runner/.platformio/packages/framework-arduinoespressif32/variants/tasmota")
+        if variants_dir:
+            shutil.copytree("./firmware/firmware", variants_dir, dirs_exist_ok=True)
 
-variants_dir = join(FRAMEWORK_DIR, "variants", "tasmota")
+# Copy pins_arduino.h to variants folder
+if variants_dir:
+    mcu_build_variant_path = join(FRAMEWORK_DIR, "variants", mcu_build_variant, "pins_arduino.h")
+    custom_variant_build = join(env.subst("$PROJECT_DIR"), variants_dir , mcu_build_variant, "pins_arduino.h")
+    os.makedirs(join(env.subst("$PROJECT_DIR"), variants_dir , mcu_build_variant), exist_ok=True)
+    shutil.copy(mcu_build_variant_path, custom_variant_build)
+
+if not variants_dir:
+    variants_dir = join(FRAMEWORK_DIR, "variants", "tasmota")
+    env.BoardConfig().update("build.variants_dir", variants_dir)
 
 def esp32_detect_flashsize():
     uploader = env.subst("$UPLOADER")
@@ -195,9 +217,7 @@ def esp32_create_combined_bin(source, target, env):
 
 
     new_file_name = env.subst("$BUILD_DIR/${PROGNAME}.factory.bin")
-    sections = env.subst(env.get("FLASH_EXTRA_IMAGES"))
     firmware_name = env.subst("$BUILD_DIR/${PROGNAME}.bin")
-    chip = env.get("BOARD_MCU")
     tasmota_platform = esp32_create_chip_string(chip)
 
     if "-DUSE_USB_CDC_CONSOLE" in env.BoardConfig().get("build.extra_flags") and "cdc" not in tasmota_platform:
@@ -274,8 +294,8 @@ def esp32_create_combined_bin(source, target, env):
             )
             print("Will use custom upload command for flashing operation to add file system defined for this build target.")
 
-    #print('Using esptool.py arguments: %s' % ' '.join(cmd))
     if("safeboot" not in firmware_name):
+        #print('Using esptool.py arguments: %s' % ' '.join(cmd))
         esptool.main(cmd)
 
 

--- a/pio-tools/pre_source_dir.py
+++ b/pio-tools/pre_source_dir.py
@@ -1,12 +1,7 @@
 Import("env")
-env = DefaultEnvironment()
-platform = env.PioPlatform()
-
 
 import glob
 import os
-import shutil
-from os.path import join
 
 def FindInoNodes(env):
     src_dir = glob.escape(env.subst("$PROJECT_SRC_DIR"))

--- a/pio-tools/pre_source_dir.py
+++ b/pio-tools/pre_source_dir.py
@@ -1,7 +1,12 @@
 Import("env")
+env = DefaultEnvironment()
+platform = env.PioPlatform()
+
 
 import glob
 import os
+import shutil
+from os.path import join
 
 def FindInoNodes(env):
     src_dir = glob.escape(env.subst("$PROJECT_SRC_DIR"))

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,6 +32,7 @@ platform_packages           = ${core.platform_packages}
 framework                   = arduino
 board                       = esp8266_1M
 board_build.filesystem      = littlefs
+board_build.variants_dir    = variants/tasmota
 custom_unpack_dir           = unpacked_littlefs
 build_unflags               = ${core.build_unflags}
 build_flags                 = ${core.build_flags}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -78,7 +78,7 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.10.05/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.10.06/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota_core3_env_sample.ini
+++ b/platformio_tasmota_core3_env_sample.ini
@@ -50,6 +50,7 @@ framework               = ${common.framework}
 platform                = ${core32_30.platform}
 platform_packages       = ${core32_30.platform_packages}
 board_build.filesystem  = ${common.board_build.filesystem}
+board_build.variants_dir = variants/tas_ard3
 custom_unpack_dir       = ${common.custom_unpack_dir}
 board                   = esp32
 monitor_speed           = 115200

--- a/platformio_tasmota_core3_env_sample.ini
+++ b/platformio_tasmota_core3_env_sample.ini
@@ -22,7 +22,7 @@
 ;                tasmota32c6cdc-safeboot
 
 [core32_30]
-platform                = https://github.com/tasmota/platform-espressif32/releases/download/2023.10.11/platform-espressif32.zip
+platform                = https://github.com/tasmota/platform-espressif32/releases/download/2023.10.12/platform-espressif32.zip
 platform_packages       =
 
 build_unflags           = ${core32.build_unflags}
@@ -50,7 +50,7 @@ framework               = ${common.framework}
 platform                = ${core32_30.platform}
 platform_packages       = ${core32_30.platform_packages}
 board_build.filesystem  = ${common.board_build.filesystem}
-board_build.variants_dir = variants/tas_ard3
+board_build.variants_dir = variants/tasmota_ard3
 custom_unpack_dir       = ${common.custom_unpack_dir}
 board                   = esp32
 monitor_speed           = 115200

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -4,6 +4,7 @@ platform                = ${core32.platform}
 platform_packages       = ${core32.platform_packages}
 board_build.filesystem  = ${common.board_build.filesystem}
 custom_unpack_dir       = ${common.custom_unpack_dir}
+board_build.variants_dir = ${common.board_build.variants_dir}
 board                   = esp32
 monitor_speed           = ${common.monitor_speed}
 monitor_echo            = ${common.monitor_echo}

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -223,7 +223,7 @@ bool tasconsole_serial = false;
 
 #if ARDUINO_USB_MODE
 //#warning **** TasConsole ARDUINO_USB_MODE ****
-TASCONSOLE TasConsole{USBSerial};           // ESP32C3/C6/S3 embedded USB using JTAG interface
+TASCONSOLE TasConsole{HWCDCSerial};         // ESP32C3/C6/S3 embedded USB using JTAG interface
 //#warning **** TasConsole uses HWCDC ****
 #else   // No ARDUINO_USB_MODE
 #include "USB.h"


### PR DESCRIPTION
## Description:

- Switching between frameworks core 2.0.14 and 3.0.0 alpha currently deletes the local compiled safeboot binaries. Caused by installing the framework. Now the safeboot binaries are stored in Tasmota project folders which can be configured with the Platformio settings variable `board_build.variants_dir`. The setting can and is differently choosen for core 2.0.14 and core 3.0.0 alpha. The correct matching safeboots are used now for the different cores.

- Update Core 3.0.0. alpha to latest Arduino / IDF 5.1

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were changed
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
