### PR TITLE
Fix for CmndHDMIAddr function.

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_70_0_hdmi_cec.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_70_0_hdmi_cec.ino
@@ -1116,7 +1116,7 @@ bool IRAM_ATTR CEC_Device::setLineState(bool state, bool check)
 // manage callbacks
 void CEC_Device::OnReady(int logical_address)
 {
-  if (_on_rx_cb) { _on_ready_cb(this, logical_address); }
+  if (_on_ready_cb) { _on_ready_cb(this, logical_address); }
 
 	// This is called after the logical address has been allocated
   int physical_address = getPhysicalAddress();

--- a/tasmota/tasmota_xdrv_driver/xdrv_70_1_hdmi_cec.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_70_1_hdmi_cec.ino
@@ -284,13 +284,13 @@ uint16_t HDMIGetPhysicalAddress(void) {
 
 void CmndHDMIAddr(void) {
   if (XdrvMailbox.data_len > 0) {
-    if ((XdrvMailbox.payload < 1)) {
+    if ((XdrvMailbox.payload > 0)) {
       uint16_t hdmi_addr = XdrvMailbox.payload;
       Settings->hdmi_addr[0] = (hdmi_addr) & 0xFF;
       Settings->hdmi_addr[1] = (hdmi_addr >> 8) & 0xFF;
     }
   }
-  uint16_t hdmi_addr = HDMIGetPhysicalAddress();
+  uint16_t hdmi_addr = HDMI_CEC_device->discoverPhysicalAddress();
   Response_P(PSTR("{\"%s\":\"0x%04X\"}"), XdrvMailbox.command, hdmi_addr);
 }
 


### PR DESCRIPTION
1. Typical values for XdrvMailbox.payload are 0x1000...0x4000. Hence the check should be (value > 0).
2. Don't overwrite the user supplied value with value read from the hardware.

## Description:

https://github.com/arendst/Tasmota/discussions/19128#discussioncomment-6892010

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
