### PR TITLE
Optimize esptool reset options in boards.json

### DIFF
--- a/boards/esp32c3cdc.json
+++ b/boards/esp32c3cdc.json
@@ -37,7 +37,6 @@
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
       "require_upload_port": true,
-      "before_reset": "usb_reset",
       "speed": 460800
     },
     "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html",

--- a/boards/esp32c6cdc.json
+++ b/boards/esp32c6cdc.json
@@ -37,7 +37,6 @@
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
       "require_upload_port": true,
-      "before_reset": "usb_reset",
       "speed": 460800
     },
     "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/index.html",

--- a/boards/esp32s2cdc.json
+++ b/boards/esp32s2cdc.json
@@ -37,7 +37,6 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "before_reset": "usb_reset",
-    "after_reset": "no_reset",
     "speed": 460800
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html",

--- a/boards/esp32s3cdc-qio_opi.json
+++ b/boards/esp32s3cdc-qio_opi.json
@@ -49,7 +49,6 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "before_reset": "usb_reset",
     "speed": 460800
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",

--- a/boards/esp32s3cdc-qio_qspi.json
+++ b/boards/esp32s3cdc-qio_qspi.json
@@ -49,7 +49,6 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "before_reset": "usb_reset",
     "speed": 460800
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",


### PR DESCRIPTION
## Description:

- Newer esptool.py does not need the option `"before_reset": "usb_reset"` the option prevents flashing a CDC build to an UART device via VSC (TASCONSOLE).
- S2 can be reseted after first flashing of Tasmota, so removing the option `"after_reset": "no_reset"` which prevents directly booting of Tasmota

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
