### PR TITLE
fix resize for FS >16MB

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -113,9 +113,12 @@ def patch_partitions_bin(size_string):
         binary_data = file.read(0xb0)
         import hashlib
         bin_list = list(binary_data)
-        size = codecs.decode(size_string[2:], 'hex_codec') # 0xc50000 -> [c5,00,00]
-        bin_list[0x8a] = size[0]
-        bin_list[0x8b] = size[1]
+        size_string = int(size_string[2:],16)
+        size_string = f"{size_string:08X}"
+        size = codecs.decode(size_string, 'hex_codec') # 0xc50000 -> [00,c5,00,00]
+        bin_list[0x89] = size[2]
+        bin_list[0x8a] = size[1]
+        bin_list[0x8b] = size[0]
         result = hashlib.md5(bytes(bin_list[0:0xa0]))
         partition_data = bytes(bin_list) + result.digest()
         file.seek(0)


### PR DESCRIPTION
## Description:

The auto adjusting of the FS partition when building and flashing with VSC is currently only working for FS <16MB
With the change it is working with FS >16MB. Tested with a FS of 28992 KB 

Thx @Staars for fixing the Python error.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
