### PR TITLE
Add flash mode `OPI` to Tasmota info page

### DIFF
--- a/pio-tools/pre_source_dir.py
+++ b/pio-tools/pre_source_dir.py
@@ -12,6 +12,11 @@ def FindInoNodes(env):
 env.AddMethod(FindInoNodes)
 
 # Pass flashmode at build time to macro
-tasmota_flash_mode = "-DCONFIG_TASMOTA_FLASHMODE_" + (env.BoardConfig().get("build.flash_mode", "dio")).upper()
+memory_type = env.BoardConfig().get("build.arduino.memory_type", "").upper()
+flash_mode = env.BoardConfig().get("build.flash_mode", "dio").upper()
+if "OPI_" in memory_type:
+    flash_mode = "OPI"
+
+tasmota_flash_mode = "-DCONFIG_TASMOTA_FLASHMODE_" + flash_mode
 env.Append(CXXFLAGS=[tasmota_flash_mode])
 print(tasmota_flash_mode)

--- a/tasmota/include/tasmota_globals.h
+++ b/tasmota/include/tasmota_globals.h
@@ -74,7 +74,9 @@ String EthernetMacAddress(void);
 \*-------------------------------------------------------------------------------------------*/
 
 // created in pio-tools/pre_source_dir.py
-#if defined(CONFIG_TASMOTA_FLASHMODE_QIO)
+#if defined(CONFIG_TASMOTA_FLASHMODE_OPI)
+  #define D_TASMOTA_FLASHMODE "OPI"
+#elif (CONFIG_TASMOTA_FLASHMODE_QIO)
   #define D_TASMOTA_FLASHMODE "QIO"
 #elif defined(CONFIG_TASMOTA_FLASHMODE_QOUT)
    #define D_TASMOTA_FLASHMODE "QOUT"


### PR DESCRIPTION
## Description:

Currently the flash mode `DOUT` is shown for OPI flash

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
