### PR TITLE
add OPI / OPI boards

### DIFF
--- a/boards/esp32s3-opi_opi.json
+++ b/boards/esp32s3-opi_opi.json
@@ -1,0 +1,46 @@
+{
+    "build": {
+      "arduino":{
+        "ldscript": "esp32s3_out.ld",
+        "memory_type": "opi_opi"
+      },
+      "core": "esp32",
+      "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
+      "f_cpu": "240000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "dout",
+      "mcu": "esp32s3",
+      "variant": "esp32s3",
+      "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
+    },
+    "connectivity": [
+      "wifi",
+      "bluetooth",
+      "ethernet"
+    ],
+    "debug": {
+      "openocd_target": "esp32s3.cfg"
+    },
+    "frameworks": [
+      "espidf",
+      "arduino"
+    ],
+    "name": "Espressif Generic ESP32-S3 >= 4M OPI Flash + PSRAM, Tasmota 2880k Code/OTA, 320k FS",
+    "upload": {
+      "arduino": {
+        "flash_extra_images": [
+          [
+            "0x10000",
+            "tasmota32s3-safeboot.bin"
+          ]
+        ]
+      },
+      "flash_size": "4MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 4194304,
+      "require_upload_port": true,
+      "speed": 460800
+    },
+    "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
+    "vendor": "Espressif"
+  }

--- a/boards/esp32s3cdc-opi_opi.json
+++ b/boards/esp32s3cdc-opi_opi.json
@@ -1,0 +1,56 @@
+{
+    "build": {
+      "arduino":{
+        "ldscript": "esp32s3_out.ld",
+        "memory_type": "opi_opi"
+      },
+      "core": "esp32",
+      "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
+      "f_cpu": "240000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "dout",
+      "hwids": [
+        [
+          "0x303A",
+          "0x1001"
+        ]
+      ],
+      "mcu": "esp32s3",
+      "variant": "esp32s3",
+      "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
+    },
+    "connectivity": [
+      "wifi",
+      "bluetooth",
+      "ethernet"
+    ],
+    "debug": {
+      "default_tool": "esp-builtin",
+      "onboard_tools": [
+        "esp-builtin"
+      ],
+      "openocd_target": "esp32s3.cfg"
+    },
+    "frameworks": [
+      "espidf",
+      "arduino"
+    ],
+    "name": "Espressif Generic ESP32-S3 >= 4M OPI Flash + PSRAM, Tasmota 2880k Code/OTA, 320k FS",
+    "upload": {
+      "arduino": {
+        "flash_extra_images": [
+          [
+            "0x10000",
+            "tasmota32s3cdc-safeboot.bin"
+          ]
+        ]
+      },
+      "flash_size": "4MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 4194304,
+      "require_upload_port": true,
+      "speed": 460800
+    },
+    "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
+    "vendor": "Espressif"
+  }

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -39,6 +39,29 @@ build_flags                 = ${env:tasmota32_base.build_flags}
                               -DUSE_LVGL_OPENHASP
                               -DOTA_URL='""'
 
+[env:tasmota32s3-opi_opi]
+extends                     = env:tasmota32_base
+board                       = esp32s3-opi_opi
+board_build.f_cpu           = 240000000L
+board_build.f_flash         = 80000000L
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DUSE_BERRY_ULP
+                              -DFIRMWARE_LVGL
+                              -DUSE_LVGL_OPENHASP
+                              -DOTA_URL='""'
+
+[env:tasmota32s3cdc-opi_opi]
+extends                     = env:tasmota32_base
+board                       = esp32s3cdc-opi_opi
+board_build.f_cpu           = 240000000L
+board_build.f_flash         = 80000000L
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DUSE_BERRY_ULP
+                              -DFIRMWARE_LVGL
+                              -DUSE_LVGL_OPENHASP
+                              -DOTA_URL='""'
+
+
 ;*** Tasmota ESP32-C3 version before ROM revision 3
 ;*** Actual used Arduino/IDF does not support this old revisions
 ;*** This build env is without any support, unexpected issues can happen


### PR DESCRIPTION
## Description:

currently it is not possible to compile Tasmota for S3 boards with OPI Flash and PSRAM.
Added boards.json and in `platformio_tasmota_cenv_sample.ini` env for OPI/OPI to make this possible.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
