### PR TITLE
move arduino30 default envs to `platformio_override_sample.ini`

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -45,7 +45,26 @@ default_envs            =
 ;                          tasmota32-odroidgo
 ;                          tasmota32-core2
 ;                          tasmota32-nspanel
-
+;
+; *** Build/upload environments for ESP32 Arduino Core 3.0
+;
+;                          tasmota32-arduino30
+;                          tasmota32solo1-arduino30
+;                          tasmota32-odroid30
+;                          tasmota32s2-arduino30
+;                          tasmota32s2cdc-arduino30
+;                          tasmota32s3-arduino30
+;                          tasmota32s3-qio_opi-ard30
+;                          tasmota32s3cdc-qio_opi-ard30
+;                          tasmota32s3cdc-webcam3
+;                          tasmota32c2-arduino30
+;                          tasmota32c3-arduino30
+;                          tasmota32c3cdc-arduino30
+;                          tasmota32c6-arduino30
+;                          tasmota32c6cdc-arduino30
+;                          tasmota32c2-safeboot
+;                          tasmota32c6-safeboot
+;                          tasmota32c6cdc-safeboot
 
 [env]
 ;build_unflags           = ${common.build_unflags}

--- a/platformio_tasmota_core3_env_sample.ini
+++ b/platformio_tasmota_core3_env_sample.ini
@@ -1,26 +1,3 @@
-[platformio]
-; *** Build/upload environments for ESP32 Arduino Core 3.0
-
-; *** Uncomment the line below and one or more env to select version(s)
-;default_envs =
-;                tasmota32-arduino30
-;                tasmota32solo1-arduino30
-;                tasmota32-odroid30
-;                tasmota32s2-arduino30
-;                tasmota32s2cdc-arduino30
-;                tasmota32s3-arduino30
-;                tasmota32s3-qio_opi-ard30
-;                tasmota32s3cdc-qio_opi-ard30
-;                tasmota32s3cdc-webcam3
-;                tasmota32c2-arduino30
-;                tasmota32c3-arduino30
-;                tasmota32c3cdc-arduino30
-;                tasmota32c6-arduino30
-;                tasmota32c6cdc-arduino30
-;                tasmota32c2-safeboot
-;                tasmota32c6-safeboot
-;                tasmota32c6cdc-safeboot
-
 [core32_30]
 platform                = https://github.com/tasmota/platform-espressif32/releases/download/2023.10.12/platform-espressif32.zip
 platform_packages       =


### PR DESCRIPTION
## Description:

so it is align how it is done for all other `env`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
