### PR TITLE
move core3 platform to `platformio_tasmota32.ini`

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -28,7 +28,6 @@ default_envs            =
 ;                          tasmota-zbbridge
 ;                          tasmota-ir
 ;                          tasmota32
-;                          tasmota32-arduino30
 ;                          tasmota32-zbbrdgpro
 ;                          tasmota32-bluetooth
 ;                          tasmota32-webcam

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -82,3 +82,9 @@ platform                    = https://github.com/tasmota/platform-espressif32/re
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
+
+[core32_30]
+platform                = https://github.com/tasmota/platform-espressif32/releases/download/2023.10.12/platform-espressif32.zip
+platform_packages       =
+build_unflags           = ${core32.build_unflags}
+build_flags             = ${core32.build_flags}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -84,7 +84,7 @@ build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 [core32_30]
-platform                = https://github.com/tasmota/platform-espressif32/releases/download/2023.10.12/platform-espressif32.zip
-platform_packages       =
-build_unflags           = ${core32.build_unflags}
-build_flags             = ${core32.build_flags}
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.10.12/platform-espressif32.zip
+platform_packages           =
+build_unflags               = ${core32.build_unflags}
+build_flags                 = ${core32.build_flags}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -77,6 +77,21 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               DHT sensor library
                               ccronexpr
 
+[core32_30_flags]
+build_unflags               = ${core32_30.build_unflags}
+build_flags                 = ${core32_30.build_flags}
+lib_extra_dirs              = lib/lib_ssl, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_audio, lib/lib_display, lib/lib_rf, lib/libesp32, lib/libesp32_div, lib/libesp32_lvgl
+lib_ignore                  =
+                              HTTPUpdateServer
+                              USB
+                              ESP32 Async UDP
+                              NetBIOS
+                              Preferences
+                              ArduinoOTA
+                              IRremoteESP8266
+                              NimBLE-Arduino
+
+
 [core32]
 platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.10.06/platform-espressif32.zip
 platform_packages           =

--- a/platformio_tasmota_core3_env_sample.ini
+++ b/platformio_tasmota_core3_env_sample.ini
@@ -5,14 +5,11 @@ lib_extra_dirs          = lib/lib_ssl, lib/lib_basic, lib/lib_i2c, lib/lib_div, 
 lib_ignore              =
                           HTTPUpdateServer
                           USB
-                          SPIFFS
                           ESP32 Async UDP
                           NetBIOS
                           Preferences
-                          BluetoothSerial
                           ArduinoOTA
                           IRremoteESP8266
-                          ESP32-HomeKit
                           NimBLE-Arduino
 
 [env:arduino30]

--- a/platformio_tasmota_core3_env_sample.ini
+++ b/platformio_tasmota_core3_env_sample.ini
@@ -1,17 +1,3 @@
-[core32_30_flags]
-build_unflags           = ${core32_30.build_unflags}
-build_flags             = ${core32_30.build_flags}
-lib_extra_dirs          = lib/lib_ssl, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_audio, lib/lib_display, lib/lib_rf, lib/libesp32, lib/libesp32_div, lib/libesp32_lvgl
-lib_ignore              =
-                          HTTPUpdateServer
-                          USB
-                          ESP32 Async UDP
-                          NetBIOS
-                          Preferences
-                          ArduinoOTA
-                          IRremoteESP8266
-                          NimBLE-Arduino
-
 [env:arduino30]
 framework               = ${common.framework}
 platform                = ${core32_30.platform}
@@ -29,7 +15,6 @@ lib_ldf_mode            = ${common.lib_ldf_mode}
 lib_compat_mode         = ${common.lib_compat_mode}
 lib_extra_dirs          = ${core32_30_flags.lib_extra_dirs}
 lib_ignore              = ${core32_30_flags.lib_ignore}
-
 
 
 [env:tasmota32-arduino30]

--- a/platformio_tasmota_core3_env_sample.ini
+++ b/platformio_tasmota_core3_env_sample.ini
@@ -1,10 +1,3 @@
-[core32_30]
-platform                = https://github.com/tasmota/platform-espressif32/releases/download/2023.10.12/platform-espressif32.zip
-platform_packages       =
-
-build_unflags           = ${core32.build_unflags}
-build_flags             = ${core32.build_flags}
-
 [core32_30_flags]
 build_unflags           = ${core32_30.build_unflags}
 build_flags             = ${core32_30.build_flags}


### PR DESCRIPTION
## Description:

since it is more logical there.

@arendst @s-hadinger
No functional change but it may makes it necessary to adopt already existing Arduino 3.0 setup.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
