### PR TITLE
add tasmota32c6cdc-arduino30 to CI

### DIFF
--- a/.github/workflows/build_all_the_things.yml
+++ b/.github/workflows/build_all_the_things.yml
@@ -91,6 +91,7 @@ jobs:
           - tasmota-zbbridge
           - tasmota32
           - tasmota32c3
+          - tasmota32c6cdc-arduino30
           - tasmota32s2
           - tasmota32s3
           - tasmota32-zbbrdgpro


### PR DESCRIPTION
## Description:

add C6 build to CI to see not compatible Arduino 3.0 changes

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
