### PR TITLE
Berry fix warning in be_lexer

### DIFF
--- a/lib/libesp32/berry/src/be_lexer.c
+++ b/lib/libesp32/berry/src/be_lexer.c
@@ -271,9 +271,7 @@ static void skip_comment(blexer *lexer)
             c = next(lexer);
         } while (!(mark && c == '#') && c != EOS);
         if (c == EOS) {
-        	char tmp[64];
-        	sprintf(tmp, "unterminated comment block started in line %d", lno);
-            be_lexerror(lexer, tmp);
+            be_lexerror(lexer, be_pushfstring(lexer->vm, "unterminated comment block started in line %d", lno));
         }
         next(lexer); /* skip '#' */
     } else { /* line comment */


### PR DESCRIPTION
## Description:

Fix compilation warning introduced in #19856

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
