### PR TITLE
MI32 legacy: several updates, small bugfix

### DIFF
--- a/lib/libesp32_div/esp-nimble-cpp/src/NimBLERemoteCharacteristic.cpp
+++ b/lib/libesp32_div/esp-nimble-cpp/src/NimBLERemoteCharacteristic.cpp
@@ -134,6 +134,15 @@ bool NimBLERemoteCharacteristic::canWriteNoResponse() {
     return (m_charProp & BLE_GATT_CHR_PROP_WRITE_NO_RSP) != 0;
 } // canWriteNoResponse
 
+/**
+ * @brief Return properties as bitfield
+ * 
+ * @return uint8_t 
+ */
+uint8_t NimBLERemoteCharacteristic::getProperties() {
+    return m_charProp;
+}
+
 
 /**
  * @brief Callback used by the API when a descriptor is discovered or search complete.

--- a/lib/libesp32_div/esp-nimble-cpp/src/NimBLERemoteCharacteristic.h
+++ b/lib/libesp32_div/esp-nimble-cpp/src/NimBLERemoteCharacteristic.h
@@ -52,6 +52,7 @@ public:
     bool                                           canRead();
     bool                                           canWrite();
     bool                                           canWriteNoResponse();
+    uint8_t                                        getProperties();
     std::vector<NimBLERemoteDescriptor*>::iterator begin();
     std::vector<NimBLERemoteDescriptor*>::iterator end();
     NimBLERemoteDescriptor*                        getDescriptor(const NimBLEUUID &uuid);

--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -141,6 +141,13 @@ struct ATCPacket_t{ //and PVVX
   };
 };
 
+struct BLEringBufferItem_t{
+  uint16_t returnCharUUID;
+  uint16_t handle;
+  uint32_t type;
+  uint8_t length;
+};
+
 #pragma pack(0)
 
 
@@ -156,11 +163,6 @@ struct MI32connectionContextBerry_t{
   int error;
   bool oneOp;
   bool response;
-};
-
-struct MI32notificationBuffer_t{
-  uint8_t buffer[256];
-  uint16_t returnCharUUID;
 };
 
 struct BLEqueueBuffer_t{


### PR DESCRIPTION
## Description:

New:
- opcode 6 to retrieve all services of a central device
- opcode 7 to retrieve all characteristics of a service
- automatically subscribe to all characteristics with the same UUID
- return handle in the callback when running as a peripheral (like already done when running as a server/central device)
- using ringbuffer for BLE packet queue - fixing a small memory leak and improving performance
- removing a useless function, that even can have negative side effects with some BLE devices

Example code will follow in the comment section.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
