### PR TITLE
add BLE MI envs to `platformio_tasmota_cenv_sample.ini`

### DIFF
--- a/boards/esp32c3cdc.json
+++ b/boards/esp32c3cdc.json
@@ -17,6 +17,10 @@
       "bluetooth"
     ],
     "debug": {
+      "default_tool": "esp-builtin",
+      "onboard_tools": [
+        "esp-builtin"
+      ],
       "openocd_target": "esp32c3.cfg"
     },
     "frameworks": [

--- a/boards/esp32c6cdc.json
+++ b/boards/esp32c6cdc.json
@@ -17,6 +17,10 @@
       "bluetooth"
     ],
     "debug": {
+      "default_tool": "esp-builtin",
+      "onboard_tools": [
+        "esp-builtin"
+      ],
       "openocd_target": "esp32c6.cfg"
     },
     "frameworks": [

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -49,7 +49,7 @@ default_envs            =
 ;
 ;                          tasmota32-arduino30
 ;                          tasmota32solo1-arduino30
-;                          tasmota32-odroid30
+;                          tasmota32-psramfix_ard3
 ;                          tasmota32s2-arduino30
 ;                          tasmota32s2cdc-arduino30
 ;                          tasmota32s3-arduino30

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -96,6 +96,48 @@ lib_ignore                  = TTGO TWatch Library
                               Micro-RTSP
                               epdiy
 
+[env:tasmota32-mi32]
+extends                     = env:tasmota32_base
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DUSE_MI_EXT_GUI
+                              -DUSE_MI_ESP32
+                              -DOTA_URL='""'
+lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
+lib_ignore                  = ESP8266Audio
+                              ESP8266SAM
+                              TTGO TWatch Library
+                              Micro-RTSP
+                              epdiy
+                              NimBLE-Arduino
+
+[env:tasmota32c3-mi32]
+extends                     = env:tasmota32c3
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DUSE_MI_EXT_GUI
+                              -DUSE_MI_ESP32
+                              -DOTA_URL='""'
+lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
+lib_ignore                  = ESP8266Audio
+                              ESP8266SAM
+                              TTGO TWatch Library
+                              Micro-RTSP
+                              epdiy
+                              NimBLE-Arduino
+
+[env:tasmota32s3-mi32]
+extends                     = env:tasmota32s3
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DUSE_MI_EXT_GUI
+                              -DUSE_MI_ESP32
+                              -DOTA_URL='""'
+lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
+lib_ignore                  = ESP8266Audio
+                              ESP8266SAM
+                              TTGO TWatch Library
+                              Micro-RTSP
+                              epdiy
+                              NimBLE-Arduino
+
 ; *** Debug version used for PlatformIO Home Project Inspection
 [env:tasmota-debug]
 build_type                  = debug

--- a/platformio_tasmota_core3_env_sample.ini
+++ b/platformio_tasmota_core3_env_sample.ini
@@ -37,7 +37,8 @@ build_flags             = ${env:arduino30.build_flags}
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
 
-[env:tasmota32-odroid30]
+; *** ESP32 rev.0/1 with PSRAM needs a fix for faulty PSRAM ROM code
+[env:tasmota32-psramfix_ard3]
 extends                 = env:arduino30
 board                   = esp32-fix
 board_build.f_cpu       = 240000000L

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -297,17 +297,11 @@
 
 #define USE_ADC
 //#undef USE_BERRY                                 // Disable Berry scripting language
-#if defined(USE_MI_HOMEKIT)                      // Switch between Homekit and full BLE driver
-  #define USE_MI_ESP32
-  #if(USE_MI_HOMEKIT != 1)                       // Enable(1)/ Disable(0) Homekit, only for the .c-file
-    #undef USE_MI_HOMEKIT
-  #endif // disable USE_MI_HOMEKIT
-#else
-  #define USE_ETHERNET                             // Add support for ethernet (+20k code)
-  #define USE_BLE_ESP32                          // Enable full BLE driver
-  #define USE_EQ3_ESP32
-  #define USE_MI_ESP32                           // (ESP32 only) Add support for ESP32 as a BLE-bridge (+9k2 mem, +292k flash)
-#endif // enable USE_MI_HOMEKIT
+
+#define USE_ETHERNET                             // Add support for ethernet (+20k code)
+#define USE_BLE_ESP32                            // Enable full BLE driver
+#define USE_EQ3_ESP32
+#define USE_MI_ESP32                             // (ESP32 only) Add support for ESP32 as a BLE-bridge (+9k2 mem, +292k flash)
 
 #endif  // FIRMWARE_BLUETOOTH
 


### PR DESCRIPTION
## Description

* rename odroid ard3 env to tasmota32-psramfix_ard3
* add inbuilt JTAG debugger to CDC env
* rm Homekit leftovers
* add MI env

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
