### PR TITLE
The webserver for the esp32-cam stream doesn't get started on boot

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
@@ -1239,7 +1239,11 @@ void CmndWebcam(void) {
 void CmndWebcamStream(void) {
   if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 1)) {
     Settings->webcam_config.stream = XdrvMailbox.payload;
-    if (!Settings->webcam_config.stream) { WcInterruptControl(); }  // Stop stream
+    if (!Settings->webcam_config.stream) { 
+      WcInterruptControl();  // Stop stream
+    } else {
+      WcSetStreamserver(Settings->webcam_config.stream);  // Ensure server is running
+    }
   }
   ResponseCmndStateText(Settings->webcam_config.stream);
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task.ino
@@ -701,6 +701,7 @@ void WcInterrupt(uint32_t state) {
   // Stop camera ISR if active to fix TG1WDT_SYS_RESET
   if (!Wc.up) { return; }
 
+  WcSetStreamserver(state);
   if (state) {
     // Re-enable interrupts
     cam_start();


### PR DESCRIPTION
…lly.

This ensures that it does start when the WcStream (or WcInterrupt) are run.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ X ] The pull request is done against the latest development branch
  - [ X ] Only relevant files were touched
  - [ X ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ X ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [ ]X  I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
