### PR TITLE
MI32: fix restart on C6

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -2003,7 +2003,7 @@ void CmndMi32Option(void){
       if(XdrvMailbox.data_len>0){
         if(MI32.option.activeScan != onOff){
           MI32.option.activeScan = onOff;
-          if(MI32.mode.runningScan){
+          if(MI32.mode.runningScan == 1){
             MI32.mode.updateScan = 1;
           }
           else{
@@ -2487,10 +2487,9 @@ void MI32Show(bool json)
 int ExtStopBLE(){
       if(Settings->flag5.mi32_enable == 0) return 0;
       if (MI32.ScanTask != nullptr){
-        MI32Scan->stop();
         MI32.mode.deleteScanTask = 1;
         AddLog(LOG_LEVEL_INFO,PSTR("M32: stop BLE"));
-        while (MI32.mode.runningScan) yield();
+        while (MI32.mode.runningScan == 1) delay(5);
       }
       return 0;
 }


### PR DESCRIPTION
## Description:

IDK why `yield()` does not work here on the ESP32-C6, but `delay()` does the job.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
