### PR TITLE
HASPmota add styling properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - NeoPool hydrolysis setpoint and max
 - NeoPool command ``NPFiltrationSpeed`` to set non-standard filtration type speed
 - NeoPool ``SetOption157`` to output sensitive data
+- HASPmota add styling properties
 
 ### Breaking Changed
 - NeoPool SENSOR topic ``Power`` renamed to ``Powerunit``

--- a/lib/libesp32/berry_tasmota/src/be_lv_haspmota.c
+++ b/lib/libesp32/berry_tasmota/src/be_lv_haspmota.c
@@ -212,13 +212,38 @@ be_local_closure(lvh_page_get_scr,   /* name */
 ********************************************************************/
 be_local_closure(lvh_page_show,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    13,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
     ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        3,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 3),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 2]) {     /* constants */
+        /* K0   */  be_nested_str_weak(tasmota),
+        /* K1   */  be_nested_str_weak(publish_rule),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0xB8020000,  //  0000  GETNGBL	R0	K0
+          0x8C000101,  //  0001  GETMET	R0	R0	K1
+          0x68080000,  //  0002  GETUPV	R2	U0
+          0x7C000400,  //  0003  CALL	R0	2
+          0x80040000,  //  0004  RET	1	R0
+        })
+      ),
       be_nested_proto(
         3,                          /* nstack */
         0,                          /* argc */
@@ -244,34 +269,9 @@ be_local_closure(lvh_page_show,   /* name */
           0x80040000,  //  0004  RET	1	R0
         })
       ),
-      be_nested_proto(
-        3,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 5),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 2]) {     /* constants */
-        /* K0   */  be_nested_str_weak(tasmota),
-        /* K1   */  be_nested_str_weak(publish_rule),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0xB8020000,  //  0000  GETNGBL	R0	K0
-          0x8C000101,  //  0001  GETMET	R0	R0	K1
-          0x68080000,  //  0002  GETUPV	R2	U0
-          0x7C000400,  //  0003  CALL	R0	2
-          0x80040000,  //  0004  RET	1	R0
-        })
-      ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
+    ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_scr),
     /* K1   */  be_nested_str_weak(_p),
     /* K2   */  be_nested_str_weak(lv),
@@ -279,23 +279,21 @@ be_local_closure(lvh_page_show,   /* name */
     /* K4   */  be_nested_str_weak(_oh),
     /* K5   */  be_nested_str_weak(page_dir_to),
     /* K6   */  be_nested_str_weak(id),
-    /* K7   */  be_nested_str_weak(string),
-    /* K8   */  be_nested_str_weak(format),
-    /* K9   */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25i_X22_X3A_X22out_X22_X7D_X7D),
-    /* K10  */  be_nested_str_weak(lvh_page_cur_idx),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(set_timer),
-    /* K13  */  be_const_int(0),
-    /* K14  */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25i_X22_X3A_X22in_X22_X7D_X7D),
-    /* K15  */  be_nested_str_weak(_page_id),
-    /* K16  */  be_nested_str_weak(show_anim),
-    /* K17  */  be_nested_str_weak(find),
-    /* K18  */  be_nested_str_weak(SCR_LOAD_ANIM_NONE),
-    /* K19  */  be_nested_str_weak(scr_load_anim),
+    /* K7   */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25i_X22_X3A_X22out_X22_X7D_X7D),
+    /* K8   */  be_nested_str_weak(lvh_page_cur_idx),
+    /* K9   */  be_nested_str_weak(tasmota),
+    /* K10  */  be_nested_str_weak(set_timer),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25i_X22_X3A_X22in_X22_X7D_X7D),
+    /* K13  */  be_nested_str_weak(_page_id),
+    /* K14  */  be_nested_str_weak(show_anim),
+    /* K15  */  be_nested_str_weak(find),
+    /* K16  */  be_nested_str_weak(SCR_LOAD_ANIM_NONE),
+    /* K17  */  be_nested_str_weak(scr_load_anim),
     }),
     be_str_weak(show),
     &be_const_str_solidified,
-    ( &(const binstruction[67]) {  /* code */
+    ( &(const binstruction[66]) {  /* code */
       0x880C0100,  //  0000  GETMBR	R3	R0	K0
       0x4C100000,  //  0001  LDNIL	R4
       0x1C0C0604,  //  0002  EQ	R3	R3	R4
@@ -324,45 +322,44 @@ be_local_closure(lvh_page_show,   /* name */
       0x7C140200,  //  0019  CALL	R5	1
       0x7C0C0400,  //  001A  CALL	R3	2
       0x5C040600,  //  001B  MOVE	R1	R3
-      0xA40E0E00,  //  001C  IMPORT	R3	K7
-      0x8C100708,  //  001D  GETMET	R4	R3	K8
-      0x58180009,  //  001E  LDCONST	R6	K9
-      0x881C0104,  //  001F  GETMBR	R7	R0	K4
-      0x881C0F0A,  //  0020  GETMBR	R7	R7	K10
-      0x7C100600,  //  0021  CALL	R4	3
-      0xB8161600,  //  0022  GETNGBL	R5	K11
-      0x8C140B0C,  //  0023  GETMET	R5	R5	K12
-      0x581C000D,  //  0024  LDCONST	R7	K13
-      0x84200000,  //  0025  CLOSURE	R8	P0
-      0x7C140600,  //  0026  CALL	R5	3
-      0x8C140708,  //  0027  GETMET	R5	R3	K8
-      0x581C000E,  //  0028  LDCONST	R7	K14
-      0x8820010F,  //  0029  GETMBR	R8	R0	K15
-      0x7C140600,  //  002A  CALL	R5	3
-      0xB81A1600,  //  002B  GETNGBL	R6	K11
-      0x8C180D0C,  //  002C  GETMET	R6	R6	K12
-      0x5820000D,  //  002D  LDCONST	R8	K13
-      0x84240001,  //  002E  CLOSURE	R9	P1
-      0x7C180600,  //  002F  CALL	R6	3
-      0x88180104,  //  0030  GETMBR	R6	R0	K4
-      0x881C010F,  //  0031  GETMBR	R7	R0	K15
-      0x901A1407,  //  0032  SETMBR	R6	K10	R7
-      0x88180110,  //  0033  GETMBR	R6	R0	K16
-      0x8C180D11,  //  0034  GETMET	R6	R6	K17
-      0x5C200200,  //  0035  MOVE	R8	R1
-      0xB8260400,  //  0036  GETNGBL	R9	K2
-      0x88241312,  //  0037  GETMBR	R9	R9	K18
-      0x7C180600,  //  0038  CALL	R6	3
-      0xB81E0400,  //  0039  GETNGBL	R7	K2
-      0x8C1C0F13,  //  003A  GETMET	R7	R7	K19
-      0x88240100,  //  003B  GETMBR	R9	R0	K0
-      0x5C280C00,  //  003C  MOVE	R10	R6
-      0x5C2C0400,  //  003D  MOVE	R11	R2
-      0x5830000D,  //  003E  LDCONST	R12	K13
-      0x50340000,  //  003F  LDBOOL	R13	0	0
-      0x7C1C0C00,  //  0040  CALL	R7	6
-      0xA0000000,  //  0041  CLOSE	R0
-      0x80000000,  //  0042  RET	0
+      0x600C0018,  //  001C  GETGBL	R3	G24
+      0x58100007,  //  001D  LDCONST	R4	K7
+      0x88140104,  //  001E  GETMBR	R5	R0	K4
+      0x88140B08,  //  001F  GETMBR	R5	R5	K8
+      0x7C0C0400,  //  0020  CALL	R3	2
+      0xB8121200,  //  0021  GETNGBL	R4	K9
+      0x8C10090A,  //  0022  GETMET	R4	R4	K10
+      0x5818000B,  //  0023  LDCONST	R6	K11
+      0x841C0000,  //  0024  CLOSURE	R7	P0
+      0x7C100600,  //  0025  CALL	R4	3
+      0x60100018,  //  0026  GETGBL	R4	G24
+      0x5814000C,  //  0027  LDCONST	R5	K12
+      0x8818010D,  //  0028  GETMBR	R6	R0	K13
+      0x7C100400,  //  0029  CALL	R4	2
+      0xB8161200,  //  002A  GETNGBL	R5	K9
+      0x8C140B0A,  //  002B  GETMET	R5	R5	K10
+      0x581C000B,  //  002C  LDCONST	R7	K11
+      0x84200001,  //  002D  CLOSURE	R8	P1
+      0x7C140600,  //  002E  CALL	R5	3
+      0x88140104,  //  002F  GETMBR	R5	R0	K4
+      0x8818010D,  //  0030  GETMBR	R6	R0	K13
+      0x90161006,  //  0031  SETMBR	R5	K8	R6
+      0x8814010E,  //  0032  GETMBR	R5	R0	K14
+      0x8C140B0F,  //  0033  GETMET	R5	R5	K15
+      0x5C1C0200,  //  0034  MOVE	R7	R1
+      0xB8220400,  //  0035  GETNGBL	R8	K2
+      0x88201110,  //  0036  GETMBR	R8	R8	K16
+      0x7C140600,  //  0037  CALL	R5	3
+      0xB81A0400,  //  0038  GETNGBL	R6	K2
+      0x8C180D11,  //  0039  GETMET	R6	R6	K17
+      0x88200100,  //  003A  GETMBR	R8	R0	K0
+      0x5C240A00,  //  003B  MOVE	R9	R5
+      0x5C280400,  //  003C  MOVE	R10	R2
+      0x582C000B,  //  003D  LDCONST	R11	K11
+      0x50300000,  //  003E  LDBOOL	R12	0	0
+      0x7C180C00,  //  003F  CALL	R6	6
+      0xA0000000,  //  0040  CLOSE	R0
+      0x80000000,  //  0041  RET	0
     })
   )
 );
@@ -466,6 +463,2033 @@ void be_load_lvh_page_class(bvm *vm) {
 }
 
 extern const bclass be_class_lvh_obj;
+
+/********************************************************************
+** Solidified function: get_text_rule
+********************************************************************/
+be_local_closure(lvh_obj_get_text_rule,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_text_rule),
+    }),
+    be_str_weak(get_text_rule),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_val_rule
+********************************************************************/
+be_local_closure(lvh_obj_set_val_rule,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        1,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(val_rule_matched),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68040000,  //  0000  GETUPV	R1	U0
+          0x8C040300,  //  0001  GETMET	R1	R1	K0
+          0x5C0C0000,  //  0002  MOVE	R3	R0
+          0x7C040400,  //  0003  CALL	R1	2
+          0x80040200,  //  0004  RET	1	R1
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_val_rule),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(remove_rule),
+    /* K3   */  be_nested_str_weak(add_rule),
+    }),
+    be_str_weak(set_val_rule),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0004,  //  0003  JMPF	R2	#0009
+      0xB80A0200,  //  0004  GETNGBL	R2	K1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x88100100,  //  0006  GETMBR	R4	R0	K0
+      0x5C140000,  //  0007  MOVE	R5	R0
+      0x7C080600,  //  0008  CALL	R2	3
+      0x60080008,  //  0009  GETGBL	R2	G8
+      0x5C0C0200,  //  000A  MOVE	R3	R1
+      0x7C080200,  //  000B  CALL	R2	1
+      0x90020002,  //  000C  SETMBR	R0	K0	R2
+      0xB80A0200,  //  000D  GETNGBL	R2	K1
+      0x8C080503,  //  000E  GETMET	R2	R2	K3
+      0x88100100,  //  000F  GETMBR	R4	R0	K0
+      0x84140000,  //  0010  CLOSURE	R5	P0
+      0x5C180000,  //  0011  MOVE	R6	R0
+      0x7C080800,  //  0012  CALL	R2	4
+      0xA0000000,  //  0013  CLOSE	R0
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_value_str
+********************************************************************/
+be_local_closure(lvh_obj_set_value_str,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_text),
+    }),
+    be_str_weak(set_value_str),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_text_color
+********************************************************************/
+be_local_closure(lvh_obj_set_text_color,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(set_style_text_color),
+    /* K2   */  be_nested_str_weak(parse_color),
+    }),
+    be_str_weak(set_text_color),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x8C140102,  //  0002  GETMET	R5	R0	K2
+      0x5C1C0200,  //  0003  MOVE	R7	R1
+      0x7C140400,  //  0004  CALL	R5	2
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_align
+********************************************************************/
+be_local_closure(lvh_obj_set_align,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(check_label),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(left),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(TEXT_ALIGN_LEFT),
+    /* K5   */  be_const_int(1),
+    /* K6   */  be_nested_str_weak(center),
+    /* K7   */  be_nested_str_weak(TEXT_ALIGN_CENTER),
+    /* K8   */  be_const_int(2),
+    /* K9   */  be_nested_str_weak(right),
+    /* K10  */  be_nested_str_weak(TEXT_ALIGN_RIGHT),
+    /* K11  */  be_nested_str_weak(_lv_label),
+    /* K12  */  be_nested_str_weak(set_style_text_align),
+    }),
+    be_str_weak(set_align),
+    &be_const_str_solidified,
+    ( &(const binstruction[29]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x8C0C0100,  //  0001  GETMET	R3	R0	K0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x1C0C0301,  //  0003  EQ	R3	R1	K1
+      0x740E0001,  //  0004  JMPT	R3	#0007
+      0x1C0C0302,  //  0005  EQ	R3	R1	K2
+      0x780E0002,  //  0006  JMPF	R3	#000A
+      0xB80E0600,  //  0007  GETNGBL	R3	K3
+      0x88080704,  //  0008  GETMBR	R2	R3	K4
+      0x7002000C,  //  0009  JMP		#0017
+      0x1C0C0305,  //  000A  EQ	R3	R1	K5
+      0x740E0001,  //  000B  JMPT	R3	#000E
+      0x1C0C0306,  //  000C  EQ	R3	R1	K6
+      0x780E0002,  //  000D  JMPF	R3	#0011
+      0xB80E0600,  //  000E  GETNGBL	R3	K3
+      0x88080707,  //  000F  GETMBR	R2	R3	K7
+      0x70020005,  //  0010  JMP		#0017
+      0x1C0C0308,  //  0011  EQ	R3	R1	K8
+      0x740E0001,  //  0012  JMPT	R3	#0015
+      0x1C0C0309,  //  0013  EQ	R3	R1	K9
+      0x780E0001,  //  0014  JMPF	R3	#0017
+      0xB80E0600,  //  0015  GETNGBL	R3	K3
+      0x8808070A,  //  0016  GETMBR	R2	R3	K10
+      0x880C010B,  //  0017  GETMBR	R3	R0	K11
+      0x8C0C070C,  //  0018  GETMET	R3	R3	K12
+      0x5C140400,  //  0019  MOVE	R5	R2
+      0x58180001,  //  001A  LDCONST	R6	K1
+      0x7C0C0600,  //  001B  CALL	R3	3
+      0x80000000,  //  001C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_pad_bottom2
+********************************************************************/
+be_local_closure(lvh_obj_set_pad_bottom2,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(set_style_pad_bottom),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(set_pad_bottom2),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0009,  //  0003  JMPF	R2	#000E
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x60100009,  //  0006  GETGBL	R4	G9
+      0x5C140200,  //  0007  MOVE	R5	R1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x88140100,  //  0009  GETMBR	R5	R0	K0
+      0xB81A0600,  //  000A  GETNGBL	R6	K3
+      0x88180D04,  //  000B  GETMBR	R6	R6	K4
+      0x30140A06,  //  000C  OR	R5	R5	R6
+      0x7C080600,  //  000D  CALL	R2	3
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_action
+********************************************************************/
+be_local_closure(lvh_obj_set_action,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_action),
+    }),
+    be_str_weak(set_action),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x60080008,  //  0000  GETGBL	R2	G8
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_cb
+********************************************************************/
+be_local_closure(lvh_obj_event_cb,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 3]) {  /* upvals */
+          be_local_const_upval(1, 2),
+          be_local_const_upval(1, 0),
+          be_local_const_upval(1, 3),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(do_action),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 6]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x68080001,  //  0002  GETUPV	R2	U1
+          0x680C0002,  //  0003  GETUPV	R3	U2
+          0x7C000600,  //  0004  CALL	R0	3
+          0x80040000,  //  0005  RET	1	R0
+        })
+      ),
+      be_nested_proto(
+        3,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 7),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 2]) {     /* constants */
+        /* K0   */  be_nested_str_weak(tasmota),
+        /* K1   */  be_nested_str_weak(publish_rule),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0xB8020000,  //  0000  GETNGBL	R0	K0
+          0x8C000101,  //  0001  GETMET	R0	R0	K1
+          0x68080000,  //  0002  GETUPV	R2	U0
+          0x7C000400,  //  0003  CALL	R0	2
+          0x80040000,  //  0004  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[22]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_page),
+    /* K1   */  be_nested_str_weak(_oh),
+    /* K2   */  be_nested_str_weak(code),
+    /* K3   */  be_nested_str_weak(action),
+    /* K4   */  be_nested_str_weak(),
+    /* K5   */  be_nested_str_weak(lv),
+    /* K6   */  be_nested_str_weak(EVENT_CLICKED),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(set_timer),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_nested_str_weak(_event_map),
+    /* K11  */  be_nested_str_weak(find),
+    /* K12  */  be_nested_str_weak(json),
+    /* K13  */  be_nested_str_weak(EVENT_VALUE_CHANGED),
+    /* K14  */  be_nested_str_weak(val),
+    /* K15  */  be_nested_str_weak(_X2C_X22val_X22_X3A_X25s),
+    /* K16  */  be_nested_str_weak(dump),
+    /* K17  */  be_nested_str_weak(text),
+    /* K18  */  be_nested_str_weak(_X2C_X22text_X22_X3A),
+    /* K19  */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25ib_X25i_X22_X3A_X7B_X22event_X22_X3A_X22_X25s_X22_X25s_X7D_X7D_X7D),
+    /* K20  */  be_nested_str_weak(_page_id),
+    /* K21  */  be_nested_str_weak(id),
+    }),
+    be_str_weak(event_cb),
+    &be_const_str_solidified,
+    ( &(const binstruction[72]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080501,  //  0001  GETMBR	R2	R2	K1
+      0x880C0302,  //  0002  GETMBR	R3	R1	K2
+      0x88100103,  //  0003  GETMBR	R4	R0	K3
+      0x20100904,  //  0004  NE	R4	R4	K4
+      0x78120008,  //  0005  JMPF	R4	#000F
+      0xB8120A00,  //  0006  GETNGBL	R4	K5
+      0x88100906,  //  0007  GETMBR	R4	R4	K6
+      0x1C100604,  //  0008  EQ	R4	R3	R4
+      0x78120004,  //  0009  JMPF	R4	#000F
+      0xB8120E00,  //  000A  GETNGBL	R4	K7
+      0x8C100908,  //  000B  GETMET	R4	R4	K8
+      0x58180009,  //  000C  LDCONST	R6	K9
+      0x841C0000,  //  000D  CLOSURE	R7	P0
+      0x7C100600,  //  000E  CALL	R4	3
+      0x8810010A,  //  000F  GETMBR	R4	R0	K10
+      0x8C10090B,  //  0010  GETMET	R4	R4	K11
+      0x5C180600,  //  0011  MOVE	R6	R3
+      0x7C100400,  //  0012  CALL	R4	2
+      0x4C140000,  //  0013  LDNIL	R5
+      0x20140805,  //  0014  NE	R5	R4	R5
+      0x7816002F,  //  0015  JMPF	R5	#0046
+      0xA4161800,  //  0016  IMPORT	R5	K12
+      0x58180004,  //  0017  LDCONST	R6	K4
+      0x881C0302,  //  0018  GETMBR	R7	R1	K2
+      0xB8220A00,  //  0019  GETNGBL	R8	K5
+      0x8820110D,  //  001A  GETMBR	R8	R8	K13
+      0x1C1C0E08,  //  001B  EQ	R7	R7	R8
+      0x781E001A,  //  001C  JMPF	R7	#0038
+      0xA8020015,  //  001D  EXBLK	0	#0034
+      0x881C010E,  //  001E  GETMBR	R7	R0	K14
+      0x4C200000,  //  001F  LDNIL	R8
+      0x20200E08,  //  0020  NE	R8	R7	R8
+      0x78220006,  //  0021  JMPF	R8	#0029
+      0x60200018,  //  0022  GETGBL	R8	G24
+      0x5824000F,  //  0023  LDCONST	R9	K15
+      0x8C280B10,  //  0024  GETMET	R10	R5	K16
+      0x5C300E00,  //  0025  MOVE	R12	R7
+      0x7C280400,  //  0026  CALL	R10	2
+      0x7C200400,  //  0027  CALL	R8	2
+      0x5C181000,  //  0028  MOVE	R6	R8
+      0x88200111,  //  0029  GETMBR	R8	R0	K17
+      0x4C240000,  //  002A  LDNIL	R9
+      0x20241009,  //  002B  NE	R9	R8	R9
+      0x78260004,  //  002C  JMPF	R9	#0032
+      0x00180D12,  //  002D  ADD	R6	R6	K18
+      0x8C240B10,  //  002E  GETMET	R9	R5	K16
+      0x5C2C1000,  //  002F  MOVE	R11	R8
+      0x7C240400,  //  0030  CALL	R9	2
+      0x00180C09,  //  0031  ADD	R6	R6	R9
+      0xA8040001,  //  0032  EXBLK	1	1
+      0x70020003,  //  0033  JMP		#0038
+      0xAC1C0000,  //  0034  CATCH	R7	0	0
+      0x70020000,  //  0035  JMP		#0037
+      0x70020000,  //  0036  JMP		#0038
+      0xB0080000,  //  0037  RAISE	2	R0	R0
+      0x601C0018,  //  0038  GETGBL	R7	G24
+      0x58200013,  //  0039  LDCONST	R8	K19
+      0x88240100,  //  003A  GETMBR	R9	R0	K0
+      0x88241314,  //  003B  GETMBR	R9	R9	K20
+      0x88280115,  //  003C  GETMBR	R10	R0	K21
+      0x5C2C0800,  //  003D  MOVE	R11	R4
+      0x5C300C00,  //  003E  MOVE	R12	R6
+      0x7C1C0A00,  //  003F  CALL	R7	5
+      0xB8220E00,  //  0040  GETNGBL	R8	K7
+      0x8C201108,  //  0041  GETMET	R8	R8	K8
+      0x58280009,  //  0042  LDCONST	R10	K9
+      0x842C0001,  //  0043  CLOSURE	R11	P1
+      0x7C200600,  //  0044  CALL	R8	3
+      0xA0140000,  //  0045  CLOSE	R5
+      0xA0000000,  //  0046  CLOSE	R0
+      0x80000000,  //  0047  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_pad_all2
+********************************************************************/
+be_local_closure(lvh_obj_set_pad_all2,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(set_style_pad_all),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(set_pad_all2),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0009,  //  0003  JMPF	R2	#000E
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x60100009,  //  0006  GETGBL	R4	G9
+      0x5C140200,  //  0007  MOVE	R5	R1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x88140100,  //  0009  GETMBR	R5	R0	K0
+      0xB81A0600,  //  000A  GETNGBL	R6	K3
+      0x88180D04,  //  000B  GETMBR	R6	R6	K4
+      0x30140A06,  //  000C  OR	R5	R5	R6
+      0x7C080600,  //  000D  CALL	R2	3
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: text_rule_matched
+********************************************************************/
+be_local_closure(lvh_obj_text_rule_matched,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(int),
+    /* K1   */  be_nested_str_weak(_text_rule_function),
+    /* K2   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20run_X20self_X2E_text_rule_function_X20_X2D_X20_X25s_X20_X28_X25s_X29),
+    /* K3   */  be_nested_str_weak(_text_rule_format),
+    /* K4   */  be_nested_str_weak(string),
+    /* K5   */  be_nested_str_weak(),
+    /* K6   */  be_nested_str_weak(text),
+    }),
+    be_str_weak(text_rule_matched),
+    &be_const_str_solidified,
+    ( &(const binstruction[47]) {  /* code */
+      0x60080004,  //  0000  GETGBL	R2	G4
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x1C080500,  //  0003  EQ	R2	R2	K0
+      0x780A0003,  //  0004  JMPF	R2	#0009
+      0x6008000A,  //  0005  GETGBL	R2	G10
+      0x5C0C0200,  //  0006  MOVE	R3	R1
+      0x7C080200,  //  0007  CALL	R2	1
+      0x5C040400,  //  0008  MOVE	R1	R2
+      0x88080101,  //  0009  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  000A  LDNIL	R3
+      0x200C0403,  //  000B  NE	R3	R2	R3
+      0x780E0011,  //  000C  JMPF	R3	#001F
+      0xA8020005,  //  000D  EXBLK	0	#0014
+      0x5C0C0400,  //  000E  MOVE	R3	R2
+      0x5C100200,  //  000F  MOVE	R4	R1
+      0x7C0C0200,  //  0010  CALL	R3	1
+      0x5C040600,  //  0011  MOVE	R1	R3
+      0xA8040001,  //  0012  EXBLK	1	1
+      0x7002000A,  //  0013  JMP		#001F
+      0xAC0C0002,  //  0014  CATCH	R3	0	2
+      0x70020007,  //  0015  JMP		#001E
+      0x60140001,  //  0016  GETGBL	R5	G1
+      0x60180018,  //  0017  GETGBL	R6	G24
+      0x581C0002,  //  0018  LDCONST	R7	K2
+      0x5C200600,  //  0019  MOVE	R8	R3
+      0x5C240800,  //  001A  MOVE	R9	R4
+      0x7C180600,  //  001B  CALL	R6	3
+      0x7C140200,  //  001C  CALL	R5	1
+      0x70020000,  //  001D  JMP		#001F
+      0xB0080000,  //  001E  RAISE	2	R0	R0
+      0x880C0103,  //  001F  GETMBR	R3	R0	K3
+      0x60100004,  //  0020  GETGBL	R4	G4
+      0x5C140600,  //  0021  MOVE	R5	R3
+      0x7C100200,  //  0022  CALL	R4	1
+      0x1C100904,  //  0023  EQ	R4	R4	K4
+      0x78120005,  //  0024  JMPF	R4	#002B
+      0x60100018,  //  0025  GETGBL	R4	G24
+      0x5C140600,  //  0026  MOVE	R5	R3
+      0x5C180200,  //  0027  MOVE	R6	R1
+      0x7C100400,  //  0028  CALL	R4	2
+      0x5C0C0800,  //  0029  MOVE	R3	R4
+      0x70020000,  //  002A  JMP		#002C
+      0x580C0005,  //  002B  LDCONST	R3	K5
+      0x90020C03,  //  002C  SETMBR	R0	K6	R3
+      0x50100000,  //  002D  LDBOOL	R4	0	0
+      0x80040800,  //  002E  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_value_ofs_x
+********************************************************************/
+be_local_closure(lvh_obj_set_value_ofs_x,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(check_label),
+    /* K1   */  be_nested_str_weak(_lv_label),
+    /* K2   */  be_nested_str_weak(set_x),
+    }),
+    be_str_weak(set_value_ofs_x),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x8C080502,  //  0003  GETMET	R2	R2	K2
+      0x60100009,  //  0004  GETGBL	R4	G9
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x7C100200,  //  0006  CALL	R4	1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_pad_right2
+********************************************************************/
+be_local_closure(lvh_obj_set_pad_right2,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(set_style_pad_right),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(set_pad_right2),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0009,  //  0003  JMPF	R2	#000E
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x60100009,  //  0006  GETGBL	R4	G9
+      0x5C140200,  //  0007  MOVE	R5	R1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x88140100,  //  0009  GETMBR	R5	R0	K0
+      0xB81A0600,  //  000A  GETNGBL	R6	K3
+      0x88180D04,  //  000B  GETMBR	R6	R6	K4
+      0x30140A06,  //  000C  OR	R5	R5	R6
+      0x7C080600,  //  000D  CALL	R2	3
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_align
+********************************************************************/
+be_local_closure(lvh_obj_get_align,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_label),
+    /* K1   */  be_nested_str_weak(get_style_text_align),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(TEXT_ALIGN_LEFT),
+    /* K5   */  be_nested_str_weak(left),
+    /* K6   */  be_nested_str_weak(TEXT_ALIGN_CENTER),
+    /* K7   */  be_nested_str_weak(center),
+    /* K8   */  be_nested_str_weak(TEXT_ALIGN_RIGHT),
+    /* K9   */  be_nested_str_weak(right),
+    }),
+    be_str_weak(get_align),
+    &be_const_str_solidified,
+    ( &(const binstruction[32]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060001,  //  0003  JMPF	R1	#0006
+      0x4C040000,  //  0004  LDNIL	R1
+      0x80040200,  //  0005  RET	1	R1
+      0x4C040000,  //  0006  LDNIL	R1
+      0x88080100,  //  0007  GETMBR	R2	R0	K0
+      0x8C080501,  //  0008  GETMET	R2	R2	K1
+      0x58100002,  //  0009  LDCONST	R4	K2
+      0x7C080400,  //  000A  CALL	R2	2
+      0xB80A0600,  //  000B  GETNGBL	R2	K3
+      0x88080504,  //  000C  GETMBR	R2	R2	K4
+      0x1C080202,  //  000D  EQ	R2	R1	R2
+      0x780A0001,  //  000E  JMPF	R2	#0011
+      0x80060A00,  //  000F  RET	1	K5
+      0x7002000D,  //  0010  JMP		#001F
+      0xB80A0600,  //  0011  GETNGBL	R2	K3
+      0x88080506,  //  0012  GETMBR	R2	R2	K6
+      0x1C080202,  //  0013  EQ	R2	R1	R2
+      0x780A0001,  //  0014  JMPF	R2	#0017
+      0x80060E00,  //  0015  RET	1	K7
+      0x70020007,  //  0016  JMP		#001F
+      0xB80A0600,  //  0017  GETNGBL	R2	K3
+      0x88080508,  //  0018  GETMBR	R2	R2	K8
+      0x1C080202,  //  0019  EQ	R2	R1	R2
+      0x780A0001,  //  001A  JMPF	R2	#001D
+      0x80061200,  //  001B  RET	1	K9
+      0x70020001,  //  001C  JMP		#001F
+      0x4C080000,  //  001D  LDNIL	R2
+      0x80040400,  //  001E  RET	1	R2
+      0x80000000,  //  001F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_enabled
+********************************************************************/
+be_local_closure(lvh_obj_get_enabled,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(has_state),
+    /* K2   */  be_nested_str_weak(lv),
+    /* K3   */  be_nested_str_weak(STATE_DISABLED),
+    }),
+    be_str_weak(get_enabled),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0xB80E0400,  //  0002  GETNGBL	R3	K2
+      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0x7C040400,  //  0004  CALL	R1	2
+      0x78060000,  //  0005  JMPF	R1	#0007
+      0x50040001,  //  0006  LDBOOL	R1	0	1
+      0x50040200,  //  0007  LDBOOL	R1	1	0
+      0x80040200,  //  0008  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(lvh_obj_init,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_page),
+    /* K1   */  be_nested_str_weak(_lv_class),
+    /* K2   */  be_nested_str_weak(_lv_obj),
+    /* K3   */  be_nested_str_weak(post_init),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x90020002,  //  0000  SETMBR	R0	K0	R2
+      0x4C140000,  //  0001  LDNIL	R5
+      0x1C140805,  //  0002  EQ	R5	R4	R5
+      0x78160007,  //  0003  JMPF	R5	#000C
+      0x88140101,  //  0004  GETMBR	R5	R0	K1
+      0x78160005,  //  0005  JMPF	R5	#000C
+      0x88140101,  //  0006  GETMBR	R5	R0	K1
+      0x5C180A00,  //  0007  MOVE	R6	R5
+      0x5C1C0200,  //  0008  MOVE	R7	R1
+      0x7C180200,  //  0009  CALL	R6	1
+      0x90020406,  //  000A  SETMBR	R0	K2	R6
+      0x70020000,  //  000B  JMP		#000D
+      0x90020404,  //  000C  SETMBR	R0	K2	R4
+      0x8C140103,  //  000D  GETMET	R5	R0	K3
+      0x7C140200,  //  000E  CALL	R5	1
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_text
+********************************************************************/
+be_local_closure(lvh_obj_get_text,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_label),
+    /* K1   */  be_nested_str_weak(get_text),
+    }),
+    be_str_weak(get_text),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060001,  //  0003  JMPF	R1	#0006
+      0x4C040000,  //  0004  LDNIL	R1
+      0x80040200,  //  0005  RET	1	R1
+      0x88040100,  //  0006  GETMBR	R1	R0	K0
+      0x8C040301,  //  0007  GETMET	R1	R1	K1
+      0x7C040200,  //  0008  CALL	R1	1
+      0x80040200,  //  0009  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_line_width
+********************************************************************/
+be_local_closure(lvh_obj_get_line_width,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(get_style_line_width),
+    }),
+    be_str_weak(get_line_width),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_obj
+********************************************************************/
+be_local_closure(lvh_obj_get_obj,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    }),
+    be_str_weak(get_obj),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_val_rule_formula
+********************************************************************/
+be_local_closure(lvh_obj_set_val_rule_formula,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_val_rule_formula),
+    /* K1   */  be_nested_str_weak(return_X20_X2F_X20val_X20_X2D_X3E_X20_X28),
+    /* K2   */  be_nested_str_weak(_X29),
+    /* K3   */  be_nested_str_weak(_val_rule_function),
+    /* K4   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20compile_X20_X27_X25s_X27_X20_X2D_X20_X25s_X20_X28_X25s_X29),
+    }),
+    be_str_weak(set_val_rule_formula),
+    &be_const_str_solidified,
+    ( &(const binstruction[29]) {  /* code */
+      0x60080008,  //  0000  GETGBL	R2	G8
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x000A0202,  //  0005  ADD	R2	K1	R2
+      0x00080502,  //  0006  ADD	R2	R2	K2
+      0xA8020007,  //  0007  EXBLK	0	#0010
+      0x600C000D,  //  0008  GETGBL	R3	G13
+      0x5C100400,  //  0009  MOVE	R4	R2
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x5C100600,  //  000B  MOVE	R4	R3
+      0x7C100000,  //  000C  CALL	R4	0
+      0x90020604,  //  000D  SETMBR	R0	K3	R4
+      0xA8040001,  //  000E  EXBLK	1	1
+      0x7002000B,  //  000F  JMP		#001C
+      0xAC0C0002,  //  0010  CATCH	R3	0	2
+      0x70020008,  //  0011  JMP		#001B
+      0x60140001,  //  0012  GETGBL	R5	G1
+      0x60180018,  //  0013  GETGBL	R6	G24
+      0x581C0004,  //  0014  LDCONST	R7	K4
+      0x5C200400,  //  0015  MOVE	R8	R2
+      0x5C240600,  //  0016  MOVE	R9	R3
+      0x5C280800,  //  0017  MOVE	R10	R4
+      0x7C180800,  //  0018  CALL	R6	4
+      0x7C140200,  //  0019  CALL	R5	1
+      0x70020000,  //  001A  JMP		#001C
+      0xB0080000,  //  001B  RAISE	2	R0	R0
+      0x80000000,  //  001C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_click
+********************************************************************/
+be_local_closure(lvh_obj_get_click,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_enabled),
+    }),
+    be_str_weak(get_click),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_value_font
+********************************************************************/
+be_local_closure(lvh_obj_set_value_font,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_text_font),
+    }),
+    be_str_weak(set_value_font),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_toggle
+********************************************************************/
+be_local_closure(lvh_obj_set_toggle,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(toupper),
+    /* K2   */  be_nested_str_weak(TRUE),
+    /* K3   */  be_nested_str_weak(FALSE),
+    /* K4   */  be_nested_str_weak(_lv_obj),
+    /* K5   */  be_nested_str_weak(add_state),
+    /* K6   */  be_nested_str_weak(lv),
+    /* K7   */  be_nested_str_weak(STATE_CHECKED),
+    /* K8   */  be_nested_str_weak(clear_state),
+    }),
+    be_str_weak(set_toggle),
+    &be_const_str_solidified,
+    ( &(const binstruction[32]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x600C0004,  //  0001  GETGBL	R3	G4
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x1C0C0700,  //  0004  EQ	R3	R3	K0
+      0x780E000C,  //  0005  JMPF	R3	#0013
+      0x8C0C0501,  //  0006  GETMET	R3	R2	K1
+      0x60140008,  //  0007  GETGBL	R5	G8
+      0x5C180200,  //  0008  MOVE	R6	R1
+      0x7C140200,  //  0009  CALL	R5	1
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x5C040600,  //  000B  MOVE	R1	R3
+      0x1C0C0302,  //  000C  EQ	R3	R1	K2
+      0x780E0001,  //  000D  JMPF	R3	#0010
+      0x50040200,  //  000E  LDBOOL	R1	1	0
+      0x70020002,  //  000F  JMP		#0013
+      0x1C0C0303,  //  0010  EQ	R3	R1	K3
+      0x780E0000,  //  0011  JMPF	R3	#0013
+      0x50040000,  //  0012  LDBOOL	R1	0	0
+      0x78060005,  //  0013  JMPF	R1	#001A
+      0x880C0104,  //  0014  GETMBR	R3	R0	K4
+      0x8C0C0705,  //  0015  GETMET	R3	R3	K5
+      0xB8160C00,  //  0016  GETNGBL	R5	K6
+      0x88140B07,  //  0017  GETMBR	R5	R5	K7
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x70020004,  //  0019  JMP		#001F
+      0x880C0104,  //  001A  GETMBR	R3	R0	K4
+      0x8C0C0708,  //  001B  GETMET	R3	R3	K8
+      0xB8160C00,  //  001C  GETNGBL	R5	K6
+      0x88140B07,  //  001D  GETMBR	R5	R5	K7
+      0x7C0C0400,  //  001E  CALL	R3	2
+      0x80000000,  //  001F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_value_ofs_y
+********************************************************************/
+be_local_closure(lvh_obj_get_value_ofs_y,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_label),
+    /* K1   */  be_nested_str_weak(get_y),
+    }),
+    be_str_weak(get_value_ofs_y),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_text_rule_formula
+********************************************************************/
+be_local_closure(lvh_obj_set_text_rule_formula,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_text_rule_formula),
+    /* K1   */  be_nested_str_weak(return_X20_X2F_X20val_X20_X2D_X3E_X20_X28),
+    /* K2   */  be_nested_str_weak(_X29),
+    /* K3   */  be_nested_str_weak(_text_rule_function),
+    /* K4   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20compile_X20_X27_X25s_X27_X20_X2D_X20_X25s_X20_X28_X25s_X29),
+    }),
+    be_str_weak(set_text_rule_formula),
+    &be_const_str_solidified,
+    ( &(const binstruction[29]) {  /* code */
+      0x60080008,  //  0000  GETGBL	R2	G8
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x000A0202,  //  0005  ADD	R2	K1	R2
+      0x00080502,  //  0006  ADD	R2	R2	K2
+      0xA8020007,  //  0007  EXBLK	0	#0010
+      0x600C000D,  //  0008  GETGBL	R3	G13
+      0x5C100400,  //  0009  MOVE	R4	R2
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x5C100600,  //  000B  MOVE	R4	R3
+      0x7C100000,  //  000C  CALL	R4	0
+      0x90020604,  //  000D  SETMBR	R0	K3	R4
+      0xA8040001,  //  000E  EXBLK	1	1
+      0x7002000B,  //  000F  JMP		#001C
+      0xAC0C0002,  //  0010  CATCH	R3	0	2
+      0x70020008,  //  0011  JMP		#001B
+      0x60140001,  //  0012  GETGBL	R5	G1
+      0x60180018,  //  0013  GETGBL	R6	G24
+      0x581C0004,  //  0014  LDCONST	R7	K4
+      0x5C200400,  //  0015  MOVE	R8	R2
+      0x5C240600,  //  0016  MOVE	R9	R3
+      0x5C280800,  //  0017  MOVE	R10	R4
+      0x7C180800,  //  0018  CALL	R6	4
+      0x7C140200,  //  0019  CALL	R5	1
+      0x70020000,  //  001A  JMP		#001C
+      0xB0080000,  //  001B  RAISE	2	R0	R0
+      0x80000000,  //  001C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_event_cb
+********************************************************************/
+be_local_closure(lvh_obj_register_event_cb,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_page),
+    /* K1   */  be_nested_str_weak(_oh),
+    /* K2   */  be_nested_str_weak(_event_map),
+    /* K3   */  be_nested_str_weak(keys),
+    /* K4   */  be_nested_str_weak(register_event),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(register_event_cb),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x60080010,  //  0002  GETGBL	R2	G16
+      0x880C0102,  //  0003  GETMBR	R3	R0	K2
+      0x8C0C0703,  //  0004  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x7C080200,  //  0006  CALL	R2	1
+      0xA8020006,  //  0007  EXBLK	0	#000F
+      0x5C0C0400,  //  0008  MOVE	R3	R2
+      0x7C0C0000,  //  0009  CALL	R3	0
+      0x8C100304,  //  000A  GETMET	R4	R1	K4
+      0x5C180000,  //  000B  MOVE	R6	R0
+      0x5C1C0600,  //  000C  MOVE	R7	R3
+      0x7C100600,  //  000D  CALL	R4	3
+      0x7001FFF8,  //  000E  JMP		#0008
+      0x58080005,  //  000F  LDCONST	R2	K5
+      0xAC080200,  //  0010  CATCH	R2	1	0
+      0xB0080000,  //  0011  RAISE	2	R0	R0
+      0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: digits_to_style
+********************************************************************/
+be_local_closure(lvh_obj_digits_to_style,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(_digit2part),
+    /* K2   */  be_nested_str_weak(_digit2state),
+    /* K3   */  be_nested_str_weak(invalid_X20style_X20suffix_X20_X2502i),
+    /* K4   */  be_nested_str_weak(value_error),
+    }),
+    be_str_weak(digits_to_style),
+    &be_const_str_solidified,
+    ( &(const binstruction[44]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x80060000,  //  0003  RET	1	K0
+      0x540A0009,  //  0004  LDINT	R2	10
+      0x0C080202,  //  0005  DIV	R2	R1	R2
+      0x540E0009,  //  0006  LDINT	R3	10
+      0x10080403,  //  0007  MOD	R2	R2	R3
+      0x540E0009,  //  0008  LDINT	R3	10
+      0x100C0203,  //  0009  MOD	R3	R1	R3
+      0x58100000,  //  000A  LDCONST	R4	K0
+      0x28140500,  //  000B  GE	R5	R2	K0
+      0x78160008,  //  000C  JMPF	R5	#0016
+      0x6014000C,  //  000D  GETGBL	R5	G12
+      0x88180101,  //  000E  GETMBR	R6	R0	K1
+      0x7C140200,  //  000F  CALL	R5	1
+      0x14140405,  //  0010  LT	R5	R2	R5
+      0x78160003,  //  0011  JMPF	R5	#0016
+      0x88140101,  //  0012  GETMBR	R5	R0	K1
+      0x94140A02,  //  0013  GETIDX	R5	R5	R2
+      0x30100805,  //  0014  OR	R4	R4	R5
+      0x70020000,  //  0015  JMP		#0017
+      0x4C100000,  //  0016  LDNIL	R4
+      0x28140700,  //  0017  GE	R5	R3	K0
+      0x78160008,  //  0018  JMPF	R5	#0022
+      0x6014000C,  //  0019  GETGBL	R5	G12
+      0x88180102,  //  001A  GETMBR	R6	R0	K2
+      0x7C140200,  //  001B  CALL	R5	1
+      0x14140605,  //  001C  LT	R5	R3	R5
+      0x78160003,  //  001D  JMPF	R5	#0022
+      0x88140102,  //  001E  GETMBR	R5	R0	K2
+      0x94140A03,  //  001F  GETIDX	R5	R5	R3
+      0x30100805,  //  0020  OR	R4	R4	R5
+      0x70020000,  //  0021  JMP		#0023
+      0x4C100000,  //  0022  LDNIL	R4
+      0x4C140000,  //  0023  LDNIL	R5
+      0x1C140805,  //  0024  EQ	R5	R4	R5
+      0x78160004,  //  0025  JMPF	R5	#002B
+      0x60140018,  //  0026  GETGBL	R5	G24
+      0x58180003,  //  0027  LDCONST	R6	K3
+      0x5C1C0200,  //  0028  MOVE	R7	R1
+      0x7C140400,  //  0029  CALL	R5	2
+      0xB0060805,  //  002A  RAISE	1	K4	R5
+      0x80040800,  //  002B  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_value_color
+********************************************************************/
+be_local_closure(lvh_obj_get_value_color,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_value_color),
+    }),
+    be_str_weak(get_value_color),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_text_color
+********************************************************************/
+be_local_closure(lvh_obj_get_text_color,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(get_style_text_color),
+    }),
+    be_str_weak(get_text_color),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_val
+********************************************************************/
+be_local_closure(lvh_obj_set_val,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(set_value),
+    }),
+    be_str_weak(set_val),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: setmember
+********************************************************************/
+be_local_closure(lvh_obj_setmember,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[22]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(introspect),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_const_int(3),
+    /* K4   */  be_nested_str_weak(set_),
+    /* K5   */  be_nested_str_weak(get_),
+    /* K6   */  be_nested_str_weak(byte),
+    /* K7   */  be_const_int(2147483647),
+    /* K8   */  be_nested_str_weak(digits_to_style),
+    /* K9   */  be_nested_str_weak(_attr_ignore),
+    /* K10  */  be_nested_str_weak(find),
+    /* K11  */  be_nested_str_weak(get),
+    /* K12  */  be_nested_str_weak(function),
+    /* K13  */  be_nested_str_weak(_attr_map),
+    /* K14  */  be_nested_str_weak(contains),
+    /* K15  */  be_nested_str_weak(_lv_obj),
+    /* K16  */  be_nested_str_weak(is_color_attribute),
+    /* K17  */  be_nested_str_weak(parse_color),
+    /* K18  */  be_nested_str_weak(style_),
+    /* K19  */  be_nested_str_weak(_X20for_X20),
+    /* K20  */  be_nested_str_weak(HSP_X3A_X20Could_X20not_X20find_X20function_X20set_),
+    /* K21  */  be_nested_str_weak(HSP_X3A_X20unknown_X20attribute_X3A),
+    }),
+    be_str_weak(setmember),
+    &be_const_str_solidified,
+    ( &(const binstruction[134]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xA4120200,  //  0001  IMPORT	R4	K1
+      0x40160503,  //  0002  CONNECT	R5	K2	K3
+      0x94140205,  //  0003  GETIDX	R5	R1	R5
+      0x1C180B04,  //  0004  EQ	R6	R5	K4
+      0x741A0001,  //  0005  JMPT	R6	#0008
+      0x1C180B05,  //  0006  EQ	R6	R5	K5
+      0x781A0000,  //  0007  JMPF	R6	#0009
+      0x80000C00,  //  0008  RET	0
+      0x58180002,  //  0009  LDCONST	R6	K2
+      0x601C000C,  //  000A  GETGBL	R7	G12
+      0x5C200200,  //  000B  MOVE	R8	R1
+      0x7C1C0200,  //  000C  CALL	R7	1
+      0x281C0F03,  //  000D  GE	R7	R7	K3
+      0x781E0021,  //  000E  JMPF	R7	#0031
+      0x8C1C0706,  //  000F  GETMET	R7	R3	K6
+      0x5425FFFE,  //  0010  LDINT	R9	-1
+      0x94240209,  //  0011  GETIDX	R9	R1	R9
+      0x7C1C0400,  //  0012  CALL	R7	2
+      0x8C200706,  //  0013  GETMET	R8	R3	K6
+      0x5429FFFD,  //  0014  LDINT	R10	-2
+      0x9428020A,  //  0015  GETIDX	R10	R1	R10
+      0x7C200400,  //  0016  CALL	R8	2
+      0x4C240000,  //  0017  LDNIL	R9
+      0x542A002F,  //  0018  LDINT	R10	48
+      0x28280E0A,  //  0019  GE	R10	R7	R10
+      0x782A0011,  //  001A  JMPF	R10	#002D
+      0x542A0038,  //  001B  LDINT	R10	57
+      0x18280E0A,  //  001C  LE	R10	R7	R10
+      0x782A000E,  //  001D  JMPF	R10	#002D
+      0x542A002F,  //  001E  LDINT	R10	48
+      0x2828100A,  //  001F  GE	R10	R8	R10
+      0x782A000B,  //  0020  JMPF	R10	#002D
+      0x542A0038,  //  0021  LDINT	R10	57
+      0x1828100A,  //  0022  LE	R10	R8	R10
+      0x782A0008,  //  0023  JMPF	R10	#002D
+      0x60280009,  //  0024  GETGBL	R10	G9
+      0x542DFFFD,  //  0025  LDINT	R11	-2
+      0x402C1707,  //  0026  CONNECT	R11	R11	K7
+      0x942C020B,  //  0027  GETIDX	R11	R1	R11
+      0x7C280200,  //  0028  CALL	R10	1
+      0x5C241400,  //  0029  MOVE	R9	R10
+      0x5429FFFC,  //  002A  LDINT	R10	-3
+      0x402A040A,  //  002B  CONNECT	R10	K2	R10
+      0x9404020A,  //  002C  GETIDX	R1	R1	R10
+      0x8C280108,  //  002D  GETMET	R10	R0	K8
+      0x5C301200,  //  002E  MOVE	R12	R9
+      0x7C280400,  //  002F  CALL	R10	2
+      0x5C181400,  //  0030  MOVE	R6	R10
+      0x881C0109,  //  0031  GETMBR	R7	R0	K9
+      0x8C1C0F0A,  //  0032  GETMET	R7	R7	K10
+      0x5C240200,  //  0033  MOVE	R9	R1
+      0x7C1C0400,  //  0034  CALL	R7	2
+      0x4C200000,  //  0035  LDNIL	R8
+      0x201C0E08,  //  0036  NE	R7	R7	R8
+      0x781E0000,  //  0037  JMPF	R7	#0039
+      0x80000E00,  //  0038  RET	0
+      0x8C1C090B,  //  0039  GETMET	R7	R4	K11
+      0x5C240000,  //  003A  MOVE	R9	R0
+      0x002A0801,  //  003B  ADD	R10	K4	R1
+      0x7C1C0600,  //  003C  CALL	R7	3
+      0x60200004,  //  003D  GETGBL	R8	G4
+      0x5C240E00,  //  003E  MOVE	R9	R7
+      0x7C200200,  //  003F  CALL	R8	1
+      0x1C20110C,  //  0040  EQ	R8	R8	K12
+      0x78220005,  //  0041  JMPF	R8	#0048
+      0x5C200E00,  //  0042  MOVE	R8	R7
+      0x5C240000,  //  0043  MOVE	R9	R0
+      0x5C280400,  //  0044  MOVE	R10	R2
+      0x5C2C0C00,  //  0045  MOVE	R11	R6
+      0x7C200600,  //  0046  CALL	R8	3
+      0x80001000,  //  0047  RET	0
+      0x8820010D,  //  0048  GETMBR	R8	R0	K13
+      0x8C20110E,  //  0049  GETMET	R8	R8	K14
+      0x5C280200,  //  004A  MOVE	R10	R1
+      0x7C200400,  //  004B  CALL	R8	2
+      0x78220033,  //  004C  JMPF	R8	#0081
+      0x8820010D,  //  004D  GETMBR	R8	R0	K13
+      0x94201001,  //  004E  GETIDX	R8	R8	R1
+      0x8C24090B,  //  004F  GETMET	R9	R4	K11
+      0x882C010F,  //  0050  GETMBR	R11	R0	K15
+      0x00320808,  //  0051  ADD	R12	K4	R8
+      0x7C240600,  //  0052  CALL	R9	3
+      0x5C1C1200,  //  0053  MOVE	R7	R9
+      0x8C240110,  //  0054  GETMET	R9	R0	K16
+      0x5C2C1000,  //  0055  MOVE	R11	R8
+      0x7C240400,  //  0056  CALL	R9	2
+      0x78260003,  //  0057  JMPF	R9	#005C
+      0x8C240111,  //  0058  GETMET	R9	R0	K17
+      0x5C2C0400,  //  0059  MOVE	R11	R2
+      0x7C240400,  //  005A  CALL	R9	2
+      0x5C081200,  //  005B  MOVE	R2	R9
+      0x60240004,  //  005C  GETGBL	R9	G4
+      0x5C280E00,  //  005D  MOVE	R10	R7
+      0x7C240200,  //  005E  CALL	R9	1
+      0x1C24130C,  //  005F  EQ	R9	R9	K12
+      0x7826001B,  //  0060  JMPF	R9	#007D
+      0xA8020011,  //  0061  EXBLK	0	#0074
+      0x8C24070A,  //  0062  GETMET	R9	R3	K10
+      0x5C2C1000,  //  0063  MOVE	R11	R8
+      0x58300012,  //  0064  LDCONST	R12	K18
+      0x7C240600,  //  0065  CALL	R9	3
+      0x1C241302,  //  0066  EQ	R9	R9	K2
+      0x78260005,  //  0067  JMPF	R9	#006E
+      0x5C240E00,  //  0068  MOVE	R9	R7
+      0x8828010F,  //  0069  GETMBR	R10	R0	K15
+      0x5C2C0400,  //  006A  MOVE	R11	R2
+      0x5C300C00,  //  006B  MOVE	R12	R6
+      0x7C240600,  //  006C  CALL	R9	3
+      0x70020003,  //  006D  JMP		#0072
+      0x5C240E00,  //  006E  MOVE	R9	R7
+      0x8828010F,  //  006F  GETMBR	R10	R0	K15
+      0x5C2C0400,  //  0070  MOVE	R11	R2
+      0x7C240400,  //  0071  CALL	R9	2
+      0xA8040001,  //  0072  EXBLK	1	1
+      0x70020006,  //  0073  JMP		#007B
+      0xAC240002,  //  0074  CATCH	R9	0	2
+      0x70020003,  //  0075  JMP		#007A
+      0x002C1513,  //  0076  ADD	R11	R10	K19
+      0x002C1601,  //  0077  ADD	R11	R11	R1
+      0xB004120B,  //  0078  RAISE	1	R9	R11
+      0x70020000,  //  0079  JMP		#007B
+      0xB0080000,  //  007A  RAISE	2	R0	R0
+      0x80001200,  //  007B  RET	0
+      0x70020002,  //  007C  JMP		#0080
+      0x60240001,  //  007D  GETGBL	R9	G1
+      0x002A2808,  //  007E  ADD	R10	K20	R8
+      0x7C240200,  //  007F  CALL	R9	1
+      0x70020003,  //  0080  JMP		#0085
+      0x60200001,  //  0081  GETGBL	R8	G1
+      0x58240015,  //  0082  LDCONST	R9	K21
+      0x5C280200,  //  0083  MOVE	R10	R1
+      0x7C200400,  //  0084  CALL	R8	2
+      0x80000000,  //  0085  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: check_label
+********************************************************************/
+be_local_closure(lvh_obj_check_label,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_label),
+    /* K1   */  be_nested_str_weak(lv),
+    /* K2   */  be_nested_str_weak(label),
+    /* K3   */  be_nested_str_weak(get_obj),
+    /* K4   */  be_nested_str_weak(set_align),
+    /* K5   */  be_nested_str_weak(ALIGN_CENTER),
+    }),
+    be_str_weak(check_label),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x7806000A,  //  0003  JMPF	R1	#000F
+      0xB8060200,  //  0004  GETNGBL	R1	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x8C0C0103,  //  0006  GETMET	R3	R0	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x7C040400,  //  0008  CALL	R1	2
+      0x90020001,  //  0009  SETMBR	R0	K0	R1
+      0x88040100,  //  000A  GETMBR	R1	R0	K0
+      0x8C040304,  //  000B  GETMET	R1	R1	K4
+      0xB80E0200,  //  000C  GETNGBL	R3	K1
+      0x880C0705,  //  000D  GETMBR	R3	R3	K5
+      0x7C040400,  //  000E  CALL	R1	2
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_mode
+********************************************************************/
+be_local_closure(lvh_obj_get_mode,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(get_mode),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_enabled
+********************************************************************/
+be_local_closure(lvh_obj_set_enabled,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(clear_state),
+    /* K2   */  be_nested_str_weak(lv),
+    /* K3   */  be_nested_str_weak(STATE_DISABLED),
+    /* K4   */  be_nested_str_weak(add_state),
+    }),
+    be_str_weak(set_enabled),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x78060005,  //  0000  JMPF	R1	#0007
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0xB8120400,  //  0003  GETNGBL	R4	K2
+      0x88100903,  //  0004  GETMBR	R4	R4	K3
+      0x7C080400,  //  0005  CALL	R2	2
+      0x70020004,  //  0006  JMP		#000C
+      0x88080100,  //  0007  GETMBR	R2	R0	K0
+      0x8C080504,  //  0008  GETMET	R2	R2	K4
+      0xB8120400,  //  0009  GETNGBL	R4	K2
+      0x88100903,  //  000A  GETMBR	R4	R4	K3
+      0x7C080400,  //  000B  CALL	R2	2
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_pad_left2
+********************************************************************/
+be_local_closure(lvh_obj_set_pad_left2,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(set_style_pad_left),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(set_pad_left2),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0009,  //  0003  JMPF	R2	#000E
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x60100009,  //  0006  GETGBL	R4	G9
+      0x5C140200,  //  0007  MOVE	R5	R1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x88140100,  //  0009  GETMBR	R5	R0	K0
+      0xB81A0600,  //  000A  GETNGBL	R6	K3
+      0x88180D04,  //  000B  GETMBR	R6	R6	K4
+      0x30140A06,  //  000C  OR	R5	R5	R6
+      0x7C080600,  //  000D  CALL	R2	3
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pad_bottom
+********************************************************************/
+be_local_closure(lvh_obj_get_pad_bottom,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(get_style_pad_bottom),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(get_pad_bottom),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060007,  //  0003  JMPF	R1	#000C
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0xB8120600,  //  0007  GETNGBL	R4	K3
+      0x88100904,  //  0008  GETMBR	R4	R4	K4
+      0x300C0604,  //  0009  OR	R3	R3	R4
+      0x7C040400,  //  000A  CALL	R1	2
+      0x80040200,  //  000B  RET	1	R1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: member
+********************************************************************/
+be_local_closure(lvh_obj_member,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[19]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(introspect),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_const_int(3),
+    /* K4   */  be_nested_str_weak(set_),
+    /* K5   */  be_nested_str_weak(get_),
+    /* K6   */  be_nested_str_weak(byte),
+    /* K7   */  be_const_int(2147483647),
+    /* K8   */  be_nested_str_weak(digits_to_style),
+    /* K9   */  be_nested_str_weak(_attr_ignore),
+    /* K10  */  be_nested_str_weak(find),
+    /* K11  */  be_nested_str_weak(get),
+    /* K12  */  be_nested_str_weak(function),
+    /* K13  */  be_nested_str_weak(_attr_map),
+    /* K14  */  be_nested_str_weak(contains),
+    /* K15  */  be_nested_str_weak(_lv_obj),
+    /* K16  */  be_nested_str_weak(style_),
+    /* K17  */  be_nested_str_weak(unknown_X20attribute_X20),
+    /* K18  */  be_nested_str_weak(value_error),
+    }),
+    be_str_weak(member),
+    &be_const_str_solidified,
+    ( &(const binstruction[110]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0x40120503,  //  0002  CONNECT	R4	K2	K3
+      0x94100204,  //  0003  GETIDX	R4	R1	R4
+      0x1C140904,  //  0004  EQ	R5	R4	K4
+      0x74160001,  //  0005  JMPT	R5	#0008
+      0x1C140905,  //  0006  EQ	R5	R4	K5
+      0x78160000,  //  0007  JMPF	R5	#0009
+      0x80000A00,  //  0008  RET	0
+      0x58140002,  //  0009  LDCONST	R5	K2
+      0x6018000C,  //  000A  GETGBL	R6	G12
+      0x5C1C0200,  //  000B  MOVE	R7	R1
+      0x7C180200,  //  000C  CALL	R6	1
+      0x28180D03,  //  000D  GE	R6	R6	K3
+      0x781A0021,  //  000E  JMPF	R6	#0031
+      0x8C180506,  //  000F  GETMET	R6	R2	K6
+      0x5421FFFE,  //  0010  LDINT	R8	-1
+      0x94200208,  //  0011  GETIDX	R8	R1	R8
+      0x7C180400,  //  0012  CALL	R6	2
+      0x8C1C0506,  //  0013  GETMET	R7	R2	K6
+      0x5425FFFD,  //  0014  LDINT	R9	-2
+      0x94240209,  //  0015  GETIDX	R9	R1	R9
+      0x7C1C0400,  //  0016  CALL	R7	2
+      0x4C200000,  //  0017  LDNIL	R8
+      0x5426002F,  //  0018  LDINT	R9	48
+      0x28240C09,  //  0019  GE	R9	R6	R9
+      0x78260011,  //  001A  JMPF	R9	#002D
+      0x54260038,  //  001B  LDINT	R9	57
+      0x18240C09,  //  001C  LE	R9	R6	R9
+      0x7826000E,  //  001D  JMPF	R9	#002D
+      0x5426002F,  //  001E  LDINT	R9	48
+      0x28240E09,  //  001F  GE	R9	R7	R9
+      0x7826000B,  //  0020  JMPF	R9	#002D
+      0x54260038,  //  0021  LDINT	R9	57
+      0x18240E09,  //  0022  LE	R9	R7	R9
+      0x78260008,  //  0023  JMPF	R9	#002D
+      0x60240009,  //  0024  GETGBL	R9	G9
+      0x5429FFFD,  //  0025  LDINT	R10	-2
+      0x40281507,  //  0026  CONNECT	R10	R10	K7
+      0x9428020A,  //  0027  GETIDX	R10	R1	R10
+      0x7C240200,  //  0028  CALL	R9	1
+      0x5C201200,  //  0029  MOVE	R8	R9
+      0x5425FFFC,  //  002A  LDINT	R9	-3
+      0x40260409,  //  002B  CONNECT	R9	K2	R9
+      0x94040209,  //  002C  GETIDX	R1	R1	R9
+      0x8C240108,  //  002D  GETMET	R9	R0	K8
+      0x5C2C1000,  //  002E  MOVE	R11	R8
+      0x7C240400,  //  002F  CALL	R9	2
+      0x5C141200,  //  0030  MOVE	R5	R9
+      0x88180109,  //  0031  GETMBR	R6	R0	K9
+      0x8C180D0A,  //  0032  GETMET	R6	R6	K10
+      0x5C200200,  //  0033  MOVE	R8	R1
+      0x7C180400,  //  0034  CALL	R6	2
+      0x4C1C0000,  //  0035  LDNIL	R7
+      0x20180C07,  //  0036  NE	R6	R6	R7
+      0x781A0000,  //  0037  JMPF	R6	#0039
+      0x80000C00,  //  0038  RET	0
+      0x8C18070B,  //  0039  GETMET	R6	R3	K11
+      0x5C200000,  //  003A  MOVE	R8	R0
+      0x00260A01,  //  003B  ADD	R9	K5	R1
+      0x7C180600,  //  003C  CALL	R6	3
+      0x601C0004,  //  003D  GETGBL	R7	G4
+      0x5C200C00,  //  003E  MOVE	R8	R6
+      0x7C1C0200,  //  003F  CALL	R7	1
+      0x1C1C0F0C,  //  0040  EQ	R7	R7	K12
+      0x781E0004,  //  0041  JMPF	R7	#0047
+      0x5C1C0C00,  //  0042  MOVE	R7	R6
+      0x5C200000,  //  0043  MOVE	R8	R0
+      0x5C240A00,  //  0044  MOVE	R9	R5
+      0x7C1C0400,  //  0045  CALL	R7	2
+      0x80040E00,  //  0046  RET	1	R7
+      0x881C010D,  //  0047  GETMBR	R7	R0	K13
+      0x8C1C0F0E,  //  0048  GETMET	R7	R7	K14
+      0x5C240200,  //  0049  MOVE	R9	R1
+      0x7C1C0400,  //  004A  CALL	R7	2
+      0x781E001B,  //  004B  JMPF	R7	#0068
+      0x881C010D,  //  004C  GETMBR	R7	R0	K13
+      0x941C0E01,  //  004D  GETIDX	R7	R7	R1
+      0x8C20070B,  //  004E  GETMET	R8	R3	K11
+      0x8828010F,  //  004F  GETMBR	R10	R0	K15
+      0x002E0A07,  //  0050  ADD	R11	K5	R7
+      0x7C200600,  //  0051  CALL	R8	3
+      0x5C181000,  //  0052  MOVE	R6	R8
+      0x60200004,  //  0053  GETGBL	R8	G4
+      0x5C240C00,  //  0054  MOVE	R9	R6
+      0x7C200200,  //  0055  CALL	R8	1
+      0x1C20110C,  //  0056  EQ	R8	R8	K12
+      0x7822000F,  //  0057  JMPF	R8	#0068
+      0x8C20050A,  //  0058  GETMET	R8	R2	K10
+      0x5C280E00,  //  0059  MOVE	R10	R7
+      0x582C0010,  //  005A  LDCONST	R11	K16
+      0x7C200600,  //  005B  CALL	R8	3
+      0x1C201102,  //  005C  EQ	R8	R8	K2
+      0x78220005,  //  005D  JMPF	R8	#0064
+      0x5C200C00,  //  005E  MOVE	R8	R6
+      0x8824010F,  //  005F  GETMBR	R9	R0	K15
+      0x5C280A00,  //  0060  MOVE	R10	R5
+      0x7C200400,  //  0061  CALL	R8	2
+      0x80041000,  //  0062  RET	1	R8
+      0x70020003,  //  0063  JMP		#0068
+      0x5C200C00,  //  0064  MOVE	R8	R6
+      0x8824010F,  //  0065  GETMBR	R9	R0	K15
+      0x7C200200,  //  0066  CALL	R8	1
+      0x80041000,  //  0067  RET	1	R8
+      0x601C0008,  //  0068  GETGBL	R7	G8
+      0x5C200200,  //  0069  MOVE	R8	R1
+      0x7C1C0200,  //  006A  CALL	R7	1
+      0x001E2207,  //  006B  ADD	R7	K17	R7
+      0xB0062407,  //  006C  RAISE	1	K18	R7
+      0x80000000,  //  006D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_line_width
+********************************************************************/
+be_local_closure(lvh_obj_set_line_width,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(set_style_line_width),
+    }),
+    be_str_weak(set_line_width),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x60140009,  //  0002  GETGBL	R5	G9
+      0x5C180200,  //  0003  MOVE	R6	R1
+      0x7C140200,  //  0004  CALL	R5	1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_text_rule_format
+********************************************************************/
+be_local_closure(lvh_obj_get_text_rule_format,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_text_rule_format),
+    }),
+    be_str_weak(get_text_rule_format),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_text
+********************************************************************/
+be_local_closure(lvh_obj_set_text,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(check_label),
+    /* K1   */  be_nested_str_weak(_lv_label),
+    /* K2   */  be_nested_str_weak(set_text),
+    }),
+    be_str_weak(set_text),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x8C080502,  //  0003  GETMET	R2	R2	K2
+      0x60100008,  //  0004  GETGBL	R4	G8
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x7C100200,  //  0006  CALL	R4	1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
 
 /********************************************************************
 ** Solidified function: parse_color
@@ -629,55 +2653,11 @@ be_local_closure(lvh_obj_parse_color,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_pad_top2
+** Solidified function: get_val
 ********************************************************************/
-be_local_closure(lvh_obj_set_pad_top2,   /* name */
+be_local_closure(lvh_obj_get_val,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_top),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(set_pad_top2),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0009,  //  0003  JMPF	R2	#000E
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x60100009,  //  0006  GETGBL	R4	G9
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x7C100200,  //  0008  CALL	R4	1
-      0x88140100,  //  0009  GETMBR	R5	R0	K0
-      0xB81A0600,  //  000A  GETNGBL	R6	K3
-      0x88180D04,  //  000B  GETMBR	R6	R6	K4
-      0x30140A06,  //  000C  OR	R5	R5	R6
-      0x7C080600,  //  000D  CALL	R2	3
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_text_rule
-********************************************************************/
-be_local_closure(lvh_obj_get_text_rule,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
+    3,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -685,41 +2665,17 @@ be_local_closure(lvh_obj_get_text_rule,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule),
-    }),
-    be_str_weak(get_text_rule),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_obj
-********************************************************************/
-be_local_closure(lvh_obj_get_obj,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
+    ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(get_value),
     }),
-    be_str_weak(get_obj),
+    be_str_weak(get_val),
     &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
+    ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
     })
   )
 );
@@ -727,53 +2683,9 @@ be_local_closure(lvh_obj_get_obj,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_pad_left2
+** Solidified function: get_pad_right
 ********************************************************************/
-be_local_closure(lvh_obj_set_pad_left2,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_left),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(set_pad_left2),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0009,  //  0003  JMPF	R2	#000E
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x60100009,  //  0006  GETGBL	R4	G9
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x7C100200,  //  0008  CALL	R4	1
-      0x88140100,  //  0009  GETMBR	R5	R0	K0
-      0xB81A0600,  //  000A  GETNGBL	R6	K3
-      0x88180D04,  //  000B  GETMBR	R6	R6	K4
-      0x30140A06,  //  000C  OR	R5	R5	R6
-      0x7C080600,  //  000D  CALL	R2	3
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_align
-********************************************************************/
-be_local_closure(lvh_obj_get_align,   /* name */
+be_local_closure(lvh_obj_get_pad_right,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
@@ -783,131 +2695,29 @@ be_local_closure(lvh_obj_get_align,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(get_style_text_align),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(TEXT_ALIGN_LEFT),
-    /* K5   */  be_nested_str_weak(left),
-    /* K6   */  be_nested_str_weak(TEXT_ALIGN_CENTER),
-    /* K7   */  be_nested_str_weak(center),
-    /* K8   */  be_nested_str_weak(TEXT_ALIGN_RIGHT),
-    /* K9   */  be_nested_str_weak(right),
-    }),
-    be_str_weak(get_align),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x78060001,  //  0003  JMPF	R1	#0006
-      0x4C040000,  //  0004  LDNIL	R1
-      0x80040200,  //  0005  RET	1	R1
-      0x4C040000,  //  0006  LDNIL	R1
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x8C080501,  //  0008  GETMET	R2	R2	K1
-      0x58100002,  //  0009  LDCONST	R4	K2
-      0x7C080400,  //  000A  CALL	R2	2
-      0xB80A0600,  //  000B  GETNGBL	R2	K3
-      0x88080504,  //  000C  GETMBR	R2	R2	K4
-      0x1C080202,  //  000D  EQ	R2	R1	R2
-      0x780A0001,  //  000E  JMPF	R2	#0011
-      0x80060A00,  //  000F  RET	1	K5
-      0x7002000D,  //  0010  JMP		#001F
-      0xB80A0600,  //  0011  GETNGBL	R2	K3
-      0x88080506,  //  0012  GETMBR	R2	R2	K6
-      0x1C080202,  //  0013  EQ	R2	R1	R2
-      0x780A0001,  //  0014  JMPF	R2	#0017
-      0x80060E00,  //  0015  RET	1	K7
-      0x70020007,  //  0016  JMP		#001F
-      0xB80A0600,  //  0017  GETNGBL	R2	K3
-      0x88080508,  //  0018  GETMBR	R2	R2	K8
-      0x1C080202,  //  0019  EQ	R2	R1	R2
-      0x780A0001,  //  001A  JMPF	R2	#001D
-      0x80061200,  //  001B  RET	1	K9
-      0x70020001,  //  001C  JMP		#001F
-      0x4C080000,  //  001D  LDNIL	R2
-      0x80040400,  //  001E  RET	1	R2
-      0x80000000,  //  001F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_hidden
-********************************************************************/
-be_local_closure(lvh_obj_set_hidden,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(add_flag),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_HIDDEN),
-    /* K4   */  be_nested_str_weak(clear_flag),
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(get_style_pad_right),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
     }),
-    be_str_weak(set_hidden),
+    be_str_weak(get_pad_right),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
-      0x78060005,  //  0000  JMPF	R1	#0007
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0xB8120400,  //  0003  GETNGBL	R4	K2
-      0x88100903,  //  0004  GETMBR	R4	R4	K3
-      0x7C080400,  //  0005  CALL	R2	2
-      0x70020004,  //  0006  JMP		#000C
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x8C080504,  //  0008  GETMET	R2	R2	K4
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x88100903,  //  000A  GETMBR	R4	R4	K3
-      0x7C080400,  //  000B  CALL	R2	2
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060007,  //  0003  JMPF	R1	#000C
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0xB8120600,  //  0007  GETNGBL	R4	K3
+      0x88100904,  //  0008  GETMBR	R4	R4	K4
+      0x300C0604,  //  0009  OR	R3	R3	R4
+      0x7C040400,  //  000A  CALL	R1	2
+      0x80040200,  //  000B  RET	1	R1
       0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_text_color
-********************************************************************/
-be_local_closure(lvh_obj_set_text_color,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_style_text_color),
-    /* K2   */  be_nested_str_weak(parse_color),
-    /* K3   */  be_const_int(0),
-    }),
-    be_str_weak(set_text_color),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x8C100102,  //  0002  GETMET	R4	R0	K2
-      0x5C180200,  //  0003  MOVE	R6	R1
-      0x7C100400,  //  0004  CALL	R4	2
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x7C080600,  //  0006  CALL	R2	3
-      0x80000000,  //  0007  RET	0
     })
   )
 );
@@ -943,117 +2753,9 @@ be_local_closure(lvh_obj_get_value_font,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_pad_bottom
+** Solidified function: get_toggle
 ********************************************************************/
-be_local_closure(lvh_obj_get_pad_bottom,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_pad_bottom),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(get_pad_bottom),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060007,  //  0003  JMPF	R1	#000C
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0xB8120600,  //  0007  GETNGBL	R4	K3
-      0x88100904,  //  0008  GETMBR	R4	R4	K4
-      0x300C0604,  //  0009  OR	R3	R3	R4
-      0x7C040400,  //  000A  CALL	R1	2
-      0x80040200,  //  000B  RET	1	R1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: val_rule_matched
-********************************************************************/
-be_local_closure(lvh_obj_val_rule_matched,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule_function),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(format),
-    /* K3   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20run_X20self_X2E_val_rule_function_X20_X2D_X20_X25s_X20_X28_X25s_X29),
-    /* K4   */  be_nested_str_weak(val),
-    }),
-    be_str_weak(val_rule_matched),
-    &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0x6008000A,  //  0000  GETGBL	R2	G10
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0403,  //  0004  EQ	R3	R2	R3
-      0x780E0001,  //  0005  JMPF	R3	#0008
-      0x500C0000,  //  0006  LDBOOL	R3	0	0
-      0x80040600,  //  0007  RET	1	R3
-      0x880C0100,  //  0008  GETMBR	R3	R0	K0
-      0x4C100000,  //  0009  LDNIL	R4
-      0x20100604,  //  000A  NE	R4	R3	R4
-      0x78120012,  //  000B  JMPF	R4	#001F
-      0xA8020005,  //  000C  EXBLK	0	#0013
-      0x5C100600,  //  000D  MOVE	R4	R3
-      0x5C140400,  //  000E  MOVE	R5	R2
-      0x7C100200,  //  000F  CALL	R4	1
-      0x5C080800,  //  0010  MOVE	R2	R4
-      0xA8040001,  //  0011  EXBLK	1	1
-      0x7002000B,  //  0012  JMP		#001F
-      0xAC100002,  //  0013  CATCH	R4	0	2
-      0x70020008,  //  0014  JMP		#001E
-      0xA41A0200,  //  0015  IMPORT	R6	K1
-      0x601C0001,  //  0016  GETGBL	R7	G1
-      0x8C200D02,  //  0017  GETMET	R8	R6	K2
-      0x58280003,  //  0018  LDCONST	R10	K3
-      0x5C2C0800,  //  0019  MOVE	R11	R4
-      0x5C300A00,  //  001A  MOVE	R12	R5
-      0x7C200800,  //  001B  CALL	R8	4
-      0x7C1C0200,  //  001C  CALL	R7	1
-      0x70020000,  //  001D  JMP		#001F
-      0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x60100009,  //  001F  GETGBL	R4	G9
-      0x5C140400,  //  0020  MOVE	R5	R2
-      0x7C100200,  //  0021  CALL	R4	1
-      0x90020804,  //  0022  SETMBR	R0	K4	R4
-      0x50100000,  //  0023  LDBOOL	R4	0	0
-      0x80040800,  //  0024  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_enabled
-********************************************************************/
-be_local_closure(lvh_obj_get_enabled,   /* name */
+be_local_closure(lvh_obj_get_toggle,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -1065,11 +2767,11 @@ be_local_closure(lvh_obj_get_enabled,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(has_flag),
+    /* K1   */  be_nested_str_weak(has_state),
     /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_CLICKABLE),
+    /* K3   */  be_nested_str_weak(STATE_CHECKED),
     }),
-    be_str_weak(get_enabled),
+    be_str_weak(get_toggle),
     &be_const_str_solidified,
     ( &(const binstruction[ 6]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
@@ -1112,33 +2814,6 @@ be_local_closure(lvh_obj_set_meta,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_val_rule
-********************************************************************/
-be_local_closure(lvh_obj_get_val_rule,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule),
-    }),
-    be_str_weak(get_val_rule),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: set_text_rule_format
 ********************************************************************/
 be_local_closure(lvh_obj_set_text_rule_format,   /* name */
@@ -1162,386 +2837,6 @@ be_local_closure(lvh_obj_set_text_rule_format,   /* name */
       0x7C080200,  //  0002  CALL	R2	1
       0x90020002,  //  0003  SETMBR	R0	K0	R2
       0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(lvh_obj_init,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_page),
-    /* K1   */  be_nested_str_weak(_lv_class),
-    /* K2   */  be_nested_str_weak(_lv_obj),
-    /* K3   */  be_nested_str_weak(post_init),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x90020002,  //  0000  SETMBR	R0	K0	R2
-      0x4C140000,  //  0001  LDNIL	R5
-      0x1C140805,  //  0002  EQ	R5	R4	R5
-      0x78160007,  //  0003  JMPF	R5	#000C
-      0x88140101,  //  0004  GETMBR	R5	R0	K1
-      0x78160005,  //  0005  JMPF	R5	#000C
-      0x88140101,  //  0006  GETMBR	R5	R0	K1
-      0x5C180A00,  //  0007  MOVE	R6	R5
-      0x5C1C0200,  //  0008  MOVE	R7	R1
-      0x7C180200,  //  0009  CALL	R6	1
-      0x90020406,  //  000A  SETMBR	R0	K2	R6
-      0x70020000,  //  000B  JMP		#000D
-      0x90020404,  //  000C  SETMBR	R0	K2	R4
-      0x8C140103,  //  000D  GETMET	R5	R0	K3
-      0x7C140200,  //  000E  CALL	R5	1
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_value_font
-********************************************************************/
-be_local_closure(lvh_obj_set_value_font,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_text_font),
-    }),
-    be_str_weak(set_value_font),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: check_label
-********************************************************************/
-be_local_closure(lvh_obj_check_label,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(lv),
-    /* K2   */  be_nested_str_weak(label),
-    /* K3   */  be_nested_str_weak(get_obj),
-    /* K4   */  be_nested_str_weak(set_align),
-    /* K5   */  be_nested_str_weak(ALIGN_CENTER),
-    }),
-    be_str_weak(check_label),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x7806000A,  //  0003  JMPF	R1	#000F
-      0xB8060200,  //  0004  GETNGBL	R1	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x8C0C0103,  //  0006  GETMET	R3	R0	K3
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x7C040400,  //  0008  CALL	R1	2
-      0x90020001,  //  0009  SETMBR	R0	K0	R1
-      0x88040100,  //  000A  GETMBR	R1	R0	K0
-      0x8C040304,  //  000B  GETMET	R1	R1	K4
-      0xB80E0200,  //  000C  GETNGBL	R3	K1
-      0x880C0705,  //  000D  GETMBR	R3	R3	K5
-      0x7C040400,  //  000E  CALL	R1	2
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_meta
-********************************************************************/
-be_local_closure(lvh_obj_get_meta,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_meta),
-    }),
-    be_str_weak(get_meta),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_val_rule
-********************************************************************/
-be_local_closure(lvh_obj_set_val_rule,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        1,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(val_rule_matched),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0x68040000,  //  0000  GETUPV	R1	U0
-          0x8C040300,  //  0001  GETMET	R1	R1	K0
-          0x5C0C0000,  //  0002  MOVE	R3	R0
-          0x7C040400,  //  0003  CALL	R1	2
-          0x80040200,  //  0004  RET	1	R1
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(remove_rule),
-    /* K3   */  be_nested_str_weak(add_rule),
-    }),
-    be_str_weak(set_val_rule),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0004,  //  0003  JMPF	R2	#0009
-      0xB80A0200,  //  0004  GETNGBL	R2	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x88100100,  //  0006  GETMBR	R4	R0	K0
-      0x5C140000,  //  0007  MOVE	R5	R0
-      0x7C080600,  //  0008  CALL	R2	3
-      0x60080008,  //  0009  GETGBL	R2	G8
-      0x5C0C0200,  //  000A  MOVE	R3	R1
-      0x7C080200,  //  000B  CALL	R2	1
-      0x90020002,  //  000C  SETMBR	R0	K0	R2
-      0xB80A0200,  //  000D  GETNGBL	R2	K1
-      0x8C080503,  //  000E  GETMET	R2	R2	K3
-      0x88100100,  //  000F  GETMBR	R4	R0	K0
-      0x84140000,  //  0010  CLOSURE	R5	P0
-      0x5C180000,  //  0011  MOVE	R6	R0
-      0x7C080800,  //  0012  CALL	R2	4
-      0xA0000000,  //  0013  CLOSE	R0
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_enabled
-********************************************************************/
-be_local_closure(lvh_obj_set_enabled,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(add_flag),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_CLICKABLE),
-    /* K4   */  be_nested_str_weak(clear_flag),
-    }),
-    be_str_weak(set_enabled),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x78060005,  //  0000  JMPF	R1	#0007
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0xB8120400,  //  0003  GETNGBL	R4	K2
-      0x88100903,  //  0004  GETMBR	R4	R4	K3
-      0x7C080400,  //  0005  CALL	R2	2
-      0x70020004,  //  0006  JMP		#000C
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x8C080504,  //  0008  GETMET	R2	R2	K4
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x88100903,  //  000A  GETMBR	R4	R4	K3
-      0x7C080400,  //  000B  CALL	R2	2
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_action
-********************************************************************/
-be_local_closure(lvh_obj_get_action,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_action),
-    /* K1   */  be_nested_str_weak(),
-    }),
-    be_str_weak(get_action),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060001,  //  0001  JMPF	R1	#0004
-      0x5C080200,  //  0002  MOVE	R2	R1
-      0x70020000,  //  0003  JMP		#0005
-      0x58080001,  //  0004  LDCONST	R2	K1
-      0x80040400,  //  0005  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_radius2
-********************************************************************/
-be_local_closure(lvh_obj_get_radius2,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_radius),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(get_radius2),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060007,  //  0003  JMPF	R1	#000C
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0xB8120600,  //  0007  GETNGBL	R4	K3
-      0x88100904,  //  0008  GETMBR	R4	R4	K4
-      0x300C0604,  //  0009  OR	R3	R3	R4
-      0x7C040400,  //  000A  CALL	R1	2
-      0x80040200,  //  000B  RET	1	R1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_pad_right2
-********************************************************************/
-be_local_closure(lvh_obj_set_pad_right2,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_right),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(set_pad_right2),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0009,  //  0003  JMPF	R2	#000E
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x60100009,  //  0006  GETGBL	R4	G9
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x7C100200,  //  0008  CALL	R4	1
-      0x88140100,  //  0009  GETMBR	R5	R0	K0
-      0xB81A0600,  //  000A  GETNGBL	R6	K3
-      0x88180D04,  //  000B  GETMBR	R6	R6	K4
-      0x30140A06,  //  000C  OR	R5	R5	R6
-      0x7C080600,  //  000D  CALL	R2	3
-      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -1579,339 +2874,38 @@ be_local_closure(lvh_obj_get_value_ofs_x,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_value_color
+** Solidified function: is_color_attribute
 ********************************************************************/
-be_local_closure(lvh_obj_get_value_color,   /* name */
+be_local_closure(lvh_obj_is_color_attribute,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
+    9,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_value_color),
-    }),
-    be_str_weak(get_value_color),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_pad_bottom2
-********************************************************************/
-be_local_closure(lvh_obj_set_pad_bottom2,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_bottom),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(set_pad_bottom2),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0009,  //  0003  JMPF	R2	#000E
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x60100009,  //  0006  GETGBL	R4	G9
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x7C100200,  //  0008  CALL	R4	1
-      0x88140100,  //  0009  GETMBR	R5	R0	K0
-      0xB81A0600,  //  000A  GETNGBL	R6	K3
-      0x88180D04,  //  000B  GETMBR	R6	R6	K4
-      0x30140A06,  //  000C  OR	R5	R5	R6
-      0x7C080600,  //  000D  CALL	R2	3
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_text_color
-********************************************************************/
-be_local_closure(lvh_obj_get_text_color,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_style_text_color),
-    /* K2   */  be_const_int(0),
-    }),
-    be_str_weak(get_text_color),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x580C0002,  //  0002  LDCONST	R3	K2
-      0x7C040400,  //  0003  CALL	R1	2
-      0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_click
-********************************************************************/
-be_local_closure(lvh_obj_get_click,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_enabled),
-    }),
-    be_str_weak(get_click),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: event_cb
-********************************************************************/
-be_local_closure(lvh_obj_event_cb,   /* name */
-  be_nested_proto(
-    15,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 3]) {  /* upvals */
-          be_local_const_upval(1, 2),
-          be_local_const_upval(1, 0),
-          be_local_const_upval(1, 3),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(do_action),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 6]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080001,  //  0002  GETUPV	R2	U1
-          0x680C0002,  //  0003  GETUPV	R3	U2
-          0x7C000600,  //  0004  CALL	R0	3
-          0x80040000,  //  0005  RET	1	R0
-        })
-      ),
-      be_nested_proto(
-        3,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 8),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 2]) {     /* constants */
-        /* K0   */  be_nested_str_weak(tasmota),
-        /* K1   */  be_nested_str_weak(publish_rule),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0xB8020000,  //  0000  GETNGBL	R0	K0
-          0x8C000101,  //  0001  GETMET	R0	R0	K1
-          0x68080000,  //  0002  GETUPV	R2	U0
-          0x7C000400,  //  0003  CALL	R0	2
-          0x80040000,  //  0004  RET	1	R0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_page),
-    /* K1   */  be_nested_str_weak(_oh),
-    /* K2   */  be_nested_str_weak(code),
-    /* K3   */  be_nested_str_weak(action),
-    /* K4   */  be_nested_str_weak(),
-    /* K5   */  be_nested_str_weak(lv),
-    /* K6   */  be_nested_str_weak(EVENT_CLICKED),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(set_timer),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(_event_map),
-    /* K11  */  be_nested_str_weak(find),
-    /* K12  */  be_nested_str_weak(string),
-    /* K13  */  be_nested_str_weak(json),
-    /* K14  */  be_nested_str_weak(EVENT_VALUE_CHANGED),
-    /* K15  */  be_nested_str_weak(val),
-    /* K16  */  be_nested_str_weak(format),
-    /* K17  */  be_nested_str_weak(_X2C_X22val_X22_X3A_X25s),
-    /* K18  */  be_nested_str_weak(dump),
-    /* K19  */  be_nested_str_weak(text),
-    /* K20  */  be_nested_str_weak(_X2C_X22text_X22_X3A),
-    /* K21  */  be_nested_str_weak(_X7B_X22hasp_X22_X3A_X7B_X22p_X25ib_X25i_X22_X3A_X7B_X22event_X22_X3A_X22_X25s_X22_X25s_X7D_X7D_X7D),
-    /* K22  */  be_nested_str_weak(_page_id),
-    /* K23  */  be_nested_str_weak(id),
-    }),
-    be_str_weak(event_cb),
-    &be_const_str_solidified,
-    ( &(const binstruction[73]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x88080501,  //  0001  GETMBR	R2	R2	K1
-      0x880C0302,  //  0002  GETMBR	R3	R1	K2
-      0x88100103,  //  0003  GETMBR	R4	R0	K3
-      0x20100904,  //  0004  NE	R4	R4	K4
-      0x78120008,  //  0005  JMPF	R4	#000F
-      0xB8120A00,  //  0006  GETNGBL	R4	K5
-      0x88100906,  //  0007  GETMBR	R4	R4	K6
-      0x1C100604,  //  0008  EQ	R4	R3	R4
-      0x78120004,  //  0009  JMPF	R4	#000F
-      0xB8120E00,  //  000A  GETNGBL	R4	K7
-      0x8C100908,  //  000B  GETMET	R4	R4	K8
-      0x58180009,  //  000C  LDCONST	R6	K9
-      0x841C0000,  //  000D  CLOSURE	R7	P0
-      0x7C100600,  //  000E  CALL	R4	3
-      0x8810010A,  //  000F  GETMBR	R4	R0	K10
-      0x8C10090B,  //  0010  GETMET	R4	R4	K11
-      0x5C180600,  //  0011  MOVE	R6	R3
-      0x7C100400,  //  0012  CALL	R4	2
-      0x4C140000,  //  0013  LDNIL	R5
-      0x20140805,  //  0014  NE	R5	R4	R5
-      0x78160030,  //  0015  JMPF	R5	#0047
-      0xA4161800,  //  0016  IMPORT	R5	K12
-      0xA41A1A00,  //  0017  IMPORT	R6	K13
-      0x581C0004,  //  0018  LDCONST	R7	K4
-      0x88200302,  //  0019  GETMBR	R8	R1	K2
-      0xB8260A00,  //  001A  GETNGBL	R9	K5
-      0x8824130E,  //  001B  GETMBR	R9	R9	K14
-      0x1C201009,  //  001C  EQ	R8	R8	R9
-      0x7822001A,  //  001D  JMPF	R8	#0039
-      0xA8020015,  //  001E  EXBLK	0	#0035
-      0x8820010F,  //  001F  GETMBR	R8	R0	K15
-      0x4C240000,  //  0020  LDNIL	R9
-      0x20241009,  //  0021  NE	R9	R8	R9
-      0x78260006,  //  0022  JMPF	R9	#002A
-      0x8C240B10,  //  0023  GETMET	R9	R5	K16
-      0x582C0011,  //  0024  LDCONST	R11	K17
-      0x8C300D12,  //  0025  GETMET	R12	R6	K18
-      0x5C381000,  //  0026  MOVE	R14	R8
-      0x7C300400,  //  0027  CALL	R12	2
-      0x7C240600,  //  0028  CALL	R9	3
-      0x5C1C1200,  //  0029  MOVE	R7	R9
-      0x88240113,  //  002A  GETMBR	R9	R0	K19
-      0x4C280000,  //  002B  LDNIL	R10
-      0x2028120A,  //  002C  NE	R10	R9	R10
-      0x782A0004,  //  002D  JMPF	R10	#0033
-      0x001C0F14,  //  002E  ADD	R7	R7	K20
-      0x8C280D12,  //  002F  GETMET	R10	R6	K18
-      0x5C301200,  //  0030  MOVE	R12	R9
-      0x7C280400,  //  0031  CALL	R10	2
-      0x001C0E0A,  //  0032  ADD	R7	R7	R10
-      0xA8040001,  //  0033  EXBLK	1	1
-      0x70020003,  //  0034  JMP		#0039
-      0xAC200000,  //  0035  CATCH	R8	0	0
-      0x70020000,  //  0036  JMP		#0038
-      0x70020000,  //  0037  JMP		#0039
-      0xB0080000,  //  0038  RAISE	2	R0	R0
-      0x8C200B10,  //  0039  GETMET	R8	R5	K16
-      0x58280015,  //  003A  LDCONST	R10	K21
-      0x882C0100,  //  003B  GETMBR	R11	R0	K0
-      0x882C1716,  //  003C  GETMBR	R11	R11	K22
-      0x88300117,  //  003D  GETMBR	R12	R0	K23
-      0x5C340800,  //  003E  MOVE	R13	R4
-      0x5C380E00,  //  003F  MOVE	R14	R7
-      0x7C200C00,  //  0040  CALL	R8	6
-      0xB8260E00,  //  0041  GETNGBL	R9	K7
-      0x8C241308,  //  0042  GETMET	R9	R9	K8
-      0x582C0009,  //  0043  LDCONST	R11	K9
-      0x84300001,  //  0044  CLOSURE	R12	P1
-      0x7C240600,  //  0045  CALL	R9	3
-      0xA0140000,  //  0046  CLOSE	R5
-      0xA0000000,  //  0047  CLOSE	R0
-      0x80000000,  //  0048  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_toggle
-********************************************************************/
-be_local_closure(lvh_obj_get_toggle,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
+    4,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(has_state),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(STATE_CHECKED),
+    /* K0   */  be_const_class(be_class_lvh_obj),
+    /* K1   */  be_nested_str_weak(re),
+    /* K2   */  be_nested_str_weak(search),
+    /* K3   */  be_nested_str_weak(color_X24),
     }),
-    be_str_weak(get_toggle),
+    be_str_weak(is_color_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
+    ( &(const binstruction[11]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0x600C0017,  //  0002  GETGBL	R3	G23
+      0x8C100502,  //  0003  GETMET	R4	R2	K2
+      0x58180003,  //  0004  LDCONST	R6	K3
+      0x601C0008,  //  0005  GETGBL	R7	G8
+      0x5C200000,  //  0006  MOVE	R8	R0
+      0x7C1C0200,  //  0007  CALL	R7	1
+      0x7C100600,  //  0008  CALL	R4	3
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x80040600,  //  000A  RET	1	R3
     })
   )
 );
@@ -1919,11 +2913,38 @@ be_local_closure(lvh_obj_get_toggle,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_text_rule_formula
+** Solidified function: get_text_rule_formula
 ********************************************************************/
-be_local_closure(lvh_obj_set_text_rule_formula,   /* name */
+be_local_closure(lvh_obj_get_text_rule_formula,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_text_rule_formula),
+    }),
+    be_str_weak(get_text_rule_formula),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_value_color
+********************************************************************/
+be_local_closure(lvh_obj_set_value_color,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1931,48 +2952,16 @@ be_local_closure(lvh_obj_set_text_rule_formula,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule_formula),
-    /* K1   */  be_nested_str_weak(return_X20_X2F_X20val_X20_X2D_X3E_X20_X28),
-    /* K2   */  be_nested_str_weak(_X29),
-    /* K3   */  be_nested_str_weak(_text_rule_function),
-    /* K4   */  be_nested_str_weak(string),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20compile_X20_X27_X25s_X27_X20_X2D_X20_X25s_X20_X28_X25s_X29),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_text_color),
     }),
-    be_str_weak(set_text_rule_formula),
+    be_str_weak(set_value_color),
     &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x60080008,  //  0000  GETGBL	R2	G8
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x000A0202,  //  0005  ADD	R2	K1	R2
-      0x00080502,  //  0006  ADD	R2	R2	K2
-      0xA8020007,  //  0007  EXBLK	0	#0010
-      0x600C000D,  //  0008  GETGBL	R3	G13
-      0x5C100400,  //  0009  MOVE	R4	R2
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x5C100600,  //  000B  MOVE	R4	R3
-      0x7C100000,  //  000C  CALL	R4	0
-      0x90020604,  //  000D  SETMBR	R0	K3	R4
-      0xA8040001,  //  000E  EXBLK	1	1
-      0x7002000C,  //  000F  JMP		#001D
-      0xAC0C0002,  //  0010  CATCH	R3	0	2
-      0x70020009,  //  0011  JMP		#001C
-      0xA4160800,  //  0012  IMPORT	R5	K4
-      0x60180001,  //  0013  GETGBL	R6	G1
-      0x8C1C0B05,  //  0014  GETMET	R7	R5	K5
-      0x58240006,  //  0015  LDCONST	R9	K6
-      0x5C280400,  //  0016  MOVE	R10	R2
-      0x5C2C0600,  //  0017  MOVE	R11	R3
-      0x5C300800,  //  0018  MOVE	R12	R4
-      0x7C1C0A00,  //  0019  CALL	R7	5
-      0x7C180200,  //  001A  CALL	R6	1
-      0x70020000,  //  001B  JMP		#001D
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x80000000,  //  001D  RET	0
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x80000000,  //  0003  RET	0
     })
   )
 );
@@ -2022,6 +3011,253 @@ be_local_closure(lvh_obj_get_pad_top,   /* name */
 
 
 /********************************************************************
+** Solidified function: get_hidden
+********************************************************************/
+be_local_closure(lvh_obj_get_hidden,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(has_flag),
+    /* K2   */  be_nested_str_weak(lv),
+    /* K3   */  be_nested_str_weak(OBJ_FLAG_HIDDEN),
+    }),
+    be_str_weak(get_hidden),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0xB80E0400,  //  0002  GETNGBL	R3	K2
+      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0x7C040400,  //  0004  CALL	R1	2
+      0x80040200,  //  0005  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pad_left
+********************************************************************/
+be_local_closure(lvh_obj_get_pad_left,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(get_style_pad_left),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(get_pad_left),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060007,  //  0003  JMPF	R1	#000C
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0xB8120600,  //  0007  GETNGBL	R4	K3
+      0x88100904,  //  0008  GETMBR	R4	R4	K4
+      0x300C0604,  //  0009  OR	R3	R3	R4
+      0x7C040400,  //  000A  CALL	R1	2
+      0x80040200,  //  000B  RET	1	R1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_radius2
+********************************************************************/
+be_local_closure(lvh_obj_get_radius2,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(get_style_radius),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(get_radius2),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060007,  //  0003  JMPF	R1	#000C
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0xB8120600,  //  0007  GETNGBL	R4	K3
+      0x88100904,  //  0008  GETMBR	R4	R4	K4
+      0x300C0604,  //  0009  OR	R3	R3	R4
+      0x7C040400,  //  000A  CALL	R1	2
+      0x80040200,  //  000B  RET	1	R1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pad_all
+********************************************************************/
+be_local_closure(lvh_obj_get_pad_all,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(get_pad_all),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_click
+********************************************************************/
+be_local_closure(lvh_obj_set_click,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_enabled),
+    }),
+    be_str_weak(set_click),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_pad_top2
+********************************************************************/
+be_local_closure(lvh_obj_set_pad_top2,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(set_style_pad_top),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(set_pad_top2),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0009,  //  0003  JMPF	R2	#000E
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x60100009,  //  0006  GETGBL	R4	G9
+      0x5C140200,  //  0007  MOVE	R5	R1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x88140100,  //  0009  GETMBR	R5	R0	K0
+      0xB81A0600,  //  000A  GETNGBL	R6	K3
+      0x88180D04,  //  000B  GETMBR	R6	R6	K4
+      0x30140A06,  //  000C  OR	R5	R5	R6
+      0x7C080600,  //  000D  CALL	R2	3
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_action
+********************************************************************/
+be_local_closure(lvh_obj_get_action,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_action),
+    /* K1   */  be_nested_str_weak(),
+    }),
+    be_str_weak(get_action),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060001,  //  0001  JMPF	R1	#0004
+      0x5C080200,  //  0002  MOVE	R2	R1
+      0x70020000,  //  0003  JMP		#0005
+      0x58080001,  //  0004  LDCONST	R2	K1
+      0x80040400,  //  0005  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: set_adjustable
 ********************************************************************/
 be_local_closure(lvh_obj_set_adjustable,   /* name */
@@ -2064,9 +3300,45 @@ be_local_closure(lvh_obj_set_adjustable,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_value_color
+** Solidified function: set_value_ofs_y
 ********************************************************************/
-be_local_closure(lvh_obj_set_value_color,   /* name */
+be_local_closure(lvh_obj_set_value_ofs_y,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(check_label),
+    /* K1   */  be_nested_str_weak(_lv_label),
+    /* K2   */  be_nested_str_weak(set_y),
+    }),
+    be_str_weak(set_value_ofs_y),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x8C080502,  //  0003  GETMET	R2	R2	K2
+      0x60100009,  //  0004  GETGBL	R4	G9
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x7C100200,  //  0006  CALL	R4	1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_hidden
+********************************************************************/
+be_local_closure(lvh_obj_set_hidden,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
@@ -2076,194 +3348,29 @@ be_local_closure(lvh_obj_set_value_color,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_text_color),
-    }),
-    be_str_weak(set_value_color),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_event_cb
-********************************************************************/
-be_local_closure(lvh_obj_register_event_cb,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_page),
-    /* K1   */  be_nested_str_weak(_oh),
-    /* K2   */  be_nested_str_weak(_event_map),
-    /* K3   */  be_nested_str_weak(keys),
-    /* K4   */  be_nested_str_weak(register_event),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(register_event_cb),
-    &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x60080010,  //  0002  GETGBL	R2	G16
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0004  GETMET	R3	R3	K3
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x7C080200,  //  0006  CALL	R2	1
-      0xA8020006,  //  0007  EXBLK	0	#000F
-      0x5C0C0400,  //  0008  MOVE	R3	R2
-      0x7C0C0000,  //  0009  CALL	R3	0
-      0x8C100304,  //  000A  GETMET	R4	R1	K4
-      0x5C180000,  //  000B  MOVE	R6	R0
-      0x5C1C0600,  //  000C  MOVE	R7	R3
-      0x7C100600,  //  000D  CALL	R4	3
-      0x7001FFF8,  //  000E  JMP		#0008
-      0x58080005,  //  000F  LDCONST	R2	K5
-      0xAC080200,  //  0010  CATCH	R2	1	0
-      0xB0080000,  //  0011  RAISE	2	R0	R0
-      0x80000000,  //  0012  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_pad_all2
-********************************************************************/
-be_local_closure(lvh_obj_set_pad_all2,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_all),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(set_pad_all2),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0009,  //  0003  JMPF	R2	#000E
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x60100009,  //  0006  GETGBL	R4	G9
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x7C100200,  //  0008  CALL	R4	1
-      0x88140100,  //  0009  GETMBR	R5	R0	K0
-      0xB81A0600,  //  000A  GETNGBL	R6	K3
-      0x88180D04,  //  000B  GETMBR	R6	R6	K4
-      0x30140A06,  //  000C  OR	R5	R5	R6
-      0x7C080600,  //  000D  CALL	R2	3
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_text_rule_formula
-********************************************************************/
-be_local_closure(lvh_obj_get_text_rule_formula,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule_formula),
-    }),
-    be_str_weak(get_text_rule_formula),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_text_font
-********************************************************************/
-be_local_closure(lvh_obj_get_text_font,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(get_text_font),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_hidden
-********************************************************************/
-be_local_closure(lvh_obj_get_hidden,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(has_flag),
+    /* K1   */  be_nested_str_weak(add_flag),
     /* K2   */  be_nested_str_weak(lv),
     /* K3   */  be_nested_str_weak(OBJ_FLAG_HIDDEN),
+    /* K4   */  be_nested_str_weak(clear_flag),
     }),
-    be_str_weak(get_hidden),
+    be_str_weak(set_hidden),
     &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
+    ( &(const binstruction[13]) {  /* code */
+      0x78060005,  //  0000  JMPF	R1	#0007
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0xB8120400,  //  0003  GETNGBL	R4	K2
+      0x88100903,  //  0004  GETMBR	R4	R4	K3
+      0x7C080400,  //  0005  CALL	R2	2
+      0x70020004,  //  0006  JMP		#000C
+      0x88080100,  //  0007  GETMBR	R2	R0	K0
+      0x8C080504,  //  0008  GETMET	R2	R2	K4
+      0xB8120400,  //  0009  GETNGBL	R4	K2
+      0x88100903,  //  000A  GETMBR	R4	R4	K3
+      0x7C080400,  //  000B  CALL	R2	2
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -2299,282 +3406,23 @@ be_local_closure(lvh_obj_get_value_str,   /* name */
 
 
 /********************************************************************
-** Solidified function: remove_trailing_zeroes
+** Solidified function: get_text_font
 ********************************************************************/
-be_local_closure(lvh_obj_remove_trailing_zeroes,   /* name */
+be_local_closure(lvh_obj_get_text_font,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_lvh_obj),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(resize),
-    }),
-    be_str_weak(remove_trailing_zeroes),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C080200,  //  0003  CALL	R2	1
-      0x580C0001,  //  0004  LDCONST	R3	K1
-      0x14100602,  //  0005  LT	R4	R3	R2
-      0x78120007,  //  0006  JMPF	R4	#000F
-      0x5411FFFE,  //  0007  LDINT	R4	-1
-      0x04100803,  //  0008  SUB	R4	R4	R3
-      0x94100004,  //  0009  GETIDX	R4	R0	R4
-      0x20100901,  //  000A  NE	R4	R4	K1
-      0x78120000,  //  000B  JMPF	R4	#000D
-      0x70020001,  //  000C  JMP		#000F
-      0x000C0702,  //  000D  ADD	R3	R3	K2
-      0x7001FFF5,  //  000E  JMP		#0005
-      0x24100701,  //  000F  GT	R4	R3	K1
-      0x78120005,  //  0010  JMPF	R4	#0017
-      0x8C100103,  //  0011  GETMET	R4	R0	K3
-      0x6018000C,  //  0012  GETGBL	R6	G12
-      0x5C1C0000,  //  0013  MOVE	R7	R0
-      0x7C180200,  //  0014  CALL	R6	1
-      0x04180C03,  //  0015  SUB	R6	R6	R3
-      0x7C100400,  //  0016  CALL	R4	2
-      0x80040000,  //  0017  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_click
-********************************************************************/
-be_local_closure(lvh_obj_set_click,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_enabled),
-    }),
-    be_str_weak(set_click),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_text
-********************************************************************/
-be_local_closure(lvh_obj_get_text,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
+    1,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(get_text),
-    }),
-    be_str_weak(get_text),
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(get_text_font),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x78060001,  //  0003  JMPF	R1	#0006
-      0x4C040000,  //  0004  LDNIL	R1
-      0x80040200,  //  0005  RET	1	R1
-      0x88040100,  //  0006  GETMBR	R1	R0	K0
-      0x8C040301,  //  0007  GETMET	R1	R1	K1
-      0x7C040200,  //  0008  CALL	R1	1
-      0x80040200,  //  0009  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_action
-********************************************************************/
-be_local_closure(lvh_obj_set_action,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_action),
-    }),
-    be_str_weak(set_action),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x60080008,  //  0000  GETGBL	R2	G8
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: setmember
-********************************************************************/
-be_local_closure(lvh_obj_setmember,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_const_int(3),
-    /* K4   */  be_nested_str_weak(set_),
-    /* K5   */  be_nested_str_weak(get_),
-    /* K6   */  be_nested_str_weak(_attr_ignore),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_nested_str_weak(get),
-    /* K9   */  be_nested_str_weak(function),
-    /* K10  */  be_nested_str_weak(_attr_map),
-    /* K11  */  be_nested_str_weak(contains),
-    /* K12  */  be_nested_str_weak(_lv_obj),
-    /* K13  */  be_nested_str_weak(is_color_attribute),
-    /* K14  */  be_nested_str_weak(parse_color),
-    /* K15  */  be_nested_str_weak(style_),
-    /* K16  */  be_nested_str_weak(_X20for_X20),
-    /* K17  */  be_nested_str_weak(HSP_X3A_X20Could_X20not_X20find_X20function_X20set_),
-    /* K18  */  be_nested_str_weak(HSP_X3A_X20unknown_X20attribute_X3A),
-    }),
-    be_str_weak(setmember),
-    &be_const_str_solidified,
-    ( &(const binstruction[93]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xA4120200,  //  0001  IMPORT	R4	K1
-      0x40160503,  //  0002  CONNECT	R5	K2	K3
-      0x94140205,  //  0003  GETIDX	R5	R1	R5
-      0x1C180B04,  //  0004  EQ	R6	R5	K4
-      0x741A0001,  //  0005  JMPT	R6	#0008
-      0x1C180B05,  //  0006  EQ	R6	R5	K5
-      0x781A0000,  //  0007  JMPF	R6	#0009
-      0x80000C00,  //  0008  RET	0
-      0x88180106,  //  0009  GETMBR	R6	R0	K6
-      0x8C180D07,  //  000A  GETMET	R6	R6	K7
-      0x5C200200,  //  000B  MOVE	R8	R1
-      0x7C180400,  //  000C  CALL	R6	2
-      0x4C1C0000,  //  000D  LDNIL	R7
-      0x20180C07,  //  000E  NE	R6	R6	R7
-      0x781A0000,  //  000F  JMPF	R6	#0011
-      0x80000C00,  //  0010  RET	0
-      0x8C180908,  //  0011  GETMET	R6	R4	K8
-      0x5C200000,  //  0012  MOVE	R8	R0
-      0x00260801,  //  0013  ADD	R9	K4	R1
-      0x7C180600,  //  0014  CALL	R6	3
-      0x601C0004,  //  0015  GETGBL	R7	G4
-      0x5C200C00,  //  0016  MOVE	R8	R6
-      0x7C1C0200,  //  0017  CALL	R7	1
-      0x1C1C0F09,  //  0018  EQ	R7	R7	K9
-      0x781E0004,  //  0019  JMPF	R7	#001F
-      0x5C1C0C00,  //  001A  MOVE	R7	R6
-      0x5C200000,  //  001B  MOVE	R8	R0
-      0x5C240400,  //  001C  MOVE	R9	R2
-      0x7C1C0400,  //  001D  CALL	R7	2
-      0x80000E00,  //  001E  RET	0
-      0x881C010A,  //  001F  GETMBR	R7	R0	K10
-      0x8C1C0F0B,  //  0020  GETMET	R7	R7	K11
-      0x5C240200,  //  0021  MOVE	R9	R1
-      0x7C1C0400,  //  0022  CALL	R7	2
-      0x781E0033,  //  0023  JMPF	R7	#0058
-      0x881C010A,  //  0024  GETMBR	R7	R0	K10
-      0x941C0E01,  //  0025  GETIDX	R7	R7	R1
-      0x8C200908,  //  0026  GETMET	R8	R4	K8
-      0x8828010C,  //  0027  GETMBR	R10	R0	K12
-      0x002E0807,  //  0028  ADD	R11	K4	R7
-      0x7C200600,  //  0029  CALL	R8	3
-      0x5C181000,  //  002A  MOVE	R6	R8
-      0x8C20010D,  //  002B  GETMET	R8	R0	K13
-      0x5C280E00,  //  002C  MOVE	R10	R7
-      0x7C200400,  //  002D  CALL	R8	2
-      0x78220003,  //  002E  JMPF	R8	#0033
-      0x8C20010E,  //  002F  GETMET	R8	R0	K14
-      0x5C280400,  //  0030  MOVE	R10	R2
-      0x7C200400,  //  0031  CALL	R8	2
-      0x5C081000,  //  0032  MOVE	R2	R8
-      0x60200004,  //  0033  GETGBL	R8	G4
-      0x5C240C00,  //  0034  MOVE	R9	R6
-      0x7C200200,  //  0035  CALL	R8	1
-      0x1C201109,  //  0036  EQ	R8	R8	K9
-      0x7822001B,  //  0037  JMPF	R8	#0054
-      0xA8020011,  //  0038  EXBLK	0	#004B
-      0x8C200707,  //  0039  GETMET	R8	R3	K7
-      0x5C280E00,  //  003A  MOVE	R10	R7
-      0x582C000F,  //  003B  LDCONST	R11	K15
-      0x7C200600,  //  003C  CALL	R8	3
-      0x1C201102,  //  003D  EQ	R8	R8	K2
-      0x78220005,  //  003E  JMPF	R8	#0045
-      0x5C200C00,  //  003F  MOVE	R8	R6
-      0x8824010C,  //  0040  GETMBR	R9	R0	K12
-      0x5C280400,  //  0041  MOVE	R10	R2
-      0x582C0002,  //  0042  LDCONST	R11	K2
-      0x7C200600,  //  0043  CALL	R8	3
-      0x70020003,  //  0044  JMP		#0049
-      0x5C200C00,  //  0045  MOVE	R8	R6
-      0x8824010C,  //  0046  GETMBR	R9	R0	K12
-      0x5C280400,  //  0047  MOVE	R10	R2
-      0x7C200400,  //  0048  CALL	R8	2
-      0xA8040001,  //  0049  EXBLK	1	1
-      0x70020006,  //  004A  JMP		#0052
-      0xAC200002,  //  004B  CATCH	R8	0	2
-      0x70020003,  //  004C  JMP		#0051
-      0x00281310,  //  004D  ADD	R10	R9	K16
-      0x00281401,  //  004E  ADD	R10	R10	R1
-      0xB004100A,  //  004F  RAISE	1	R8	R10
-      0x70020000,  //  0050  JMP		#0052
-      0xB0080000,  //  0051  RAISE	2	R0	R0
-      0x80001000,  //  0052  RET	0
-      0x70020002,  //  0053  JMP		#0057
-      0x60200001,  //  0054  GETGBL	R8	G1
-      0x00262207,  //  0055  ADD	R9	K17	R7
-      0x7C200200,  //  0056  CALL	R8	1
-      0x70020003,  //  0057  JMP		#005C
-      0x601C0001,  //  0058  GETGBL	R7	G1
-      0x58200012,  //  0059  LDCONST	R8	K18
-      0x5C240200,  //  005A  MOVE	R9	R1
-      0x7C1C0400,  //  005B  CALL	R7	2
-      0x80000000,  //  005C  RET	0
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
     })
   )
 );
@@ -2656,150 +3504,12 @@ be_local_closure(lvh_obj_set_text_rule,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_adjustable
+** Solidified function: get_meta
 ********************************************************************/
-be_local_closure(lvh_obj_get_adjustable,   /* name */
+be_local_closure(lvh_obj_get_meta,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    2,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(has_flag),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_CLICKABLE),
-    }),
-    be_str_weak(get_adjustable),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pad_all
-********************************************************************/
-be_local_closure(lvh_obj_get_pad_all,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(get_pad_all),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_radius2
-********************************************************************/
-be_local_closure(lvh_obj_set_radius2,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_radius),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(set_radius2),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0009,  //  0003  JMPF	R2	#000E
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x60100009,  //  0006  GETGBL	R4	G9
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x7C100200,  //  0008  CALL	R4	1
-      0x88140100,  //  0009  GETMBR	R5	R0	K0
-      0xB81A0600,  //  000A  GETNGBL	R6	K3
-      0x88180D04,  //  000B  GETMBR	R6	R6	K4
-      0x30140A06,  //  000C  OR	R5	R5	R6
-      0x7C080600,  //  000D  CALL	R2	3
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_value_ofs_y
-********************************************************************/
-be_local_closure(lvh_obj_set_value_ofs_y,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(check_label),
-    /* K1   */  be_nested_str_weak(_lv_label),
-    /* K2   */  be_nested_str_weak(set_y),
-    }),
-    be_str_weak(set_value_ofs_y),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x7C080200,  //  0001  CALL	R2	1
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x8C080502,  //  0003  GETMET	R2	R2	K2
-      0x60100009,  //  0004  GETGBL	R4	G9
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x7C100200,  //  0006  CALL	R4	1
-      0x7C080400,  //  0007  CALL	R2	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_value_str
-********************************************************************/
-be_local_closure(lvh_obj_set_value_str,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -2807,15 +3517,40 @@ be_local_closure(lvh_obj_set_value_str,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_text),
+    /* K0   */  be_nested_str_weak(_meta),
     }),
-    be_str_weak(set_value_str),
+    be_str_weak(get_meta),
     &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x80000000,  //  0003  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_val_rule
+********************************************************************/
+be_local_closure(lvh_obj_get_val_rule,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_val_rule),
+    }),
+    be_str_weak(get_val_rule),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -3011,9 +3746,9 @@ be_local_closure(lvh_obj_set_text_font,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_align
+** Solidified function: set_radius2
 ********************************************************************/
-be_local_closure(lvh_obj_set_align,   /* name */
+be_local_closure(lvh_obj_set_radius2,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
@@ -3023,695 +3758,31 @@ be_local_closure(lvh_obj_set_align,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(check_label),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(left),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(TEXT_ALIGN_LEFT),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(center),
-    /* K7   */  be_nested_str_weak(TEXT_ALIGN_CENTER),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(right),
-    /* K10  */  be_nested_str_weak(TEXT_ALIGN_RIGHT),
-    /* K11  */  be_nested_str_weak(_lv_label),
-    /* K12  */  be_nested_str_weak(set_style_text_align),
-    }),
-    be_str_weak(set_align),
-    &be_const_str_solidified,
-    ( &(const binstruction[29]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x8C0C0100,  //  0001  GETMET	R3	R0	K0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x1C0C0301,  //  0003  EQ	R3	R1	K1
-      0x740E0001,  //  0004  JMPT	R3	#0007
-      0x1C0C0302,  //  0005  EQ	R3	R1	K2
-      0x780E0002,  //  0006  JMPF	R3	#000A
-      0xB80E0600,  //  0007  GETNGBL	R3	K3
-      0x88080704,  //  0008  GETMBR	R2	R3	K4
-      0x7002000C,  //  0009  JMP		#0017
-      0x1C0C0305,  //  000A  EQ	R3	R1	K5
-      0x740E0001,  //  000B  JMPT	R3	#000E
-      0x1C0C0306,  //  000C  EQ	R3	R1	K6
-      0x780E0002,  //  000D  JMPF	R3	#0011
-      0xB80E0600,  //  000E  GETNGBL	R3	K3
-      0x88080707,  //  000F  GETMBR	R2	R3	K7
-      0x70020005,  //  0010  JMP		#0017
-      0x1C0C0308,  //  0011  EQ	R3	R1	K8
-      0x740E0001,  //  0012  JMPT	R3	#0015
-      0x1C0C0309,  //  0013  EQ	R3	R1	K9
-      0x780E0001,  //  0014  JMPF	R3	#0017
-      0xB80E0600,  //  0015  GETNGBL	R3	K3
-      0x8808070A,  //  0016  GETMBR	R2	R3	K10
-      0x880C010B,  //  0017  GETMBR	R3	R0	K11
-      0x8C0C070C,  //  0018  GETMET	R3	R3	K12
-      0x5C140400,  //  0019  MOVE	R5	R2
-      0x58180001,  //  001A  LDCONST	R6	K1
-      0x7C0C0600,  //  001B  CALL	R3	3
-      0x80000000,  //  001C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: text_rule_matched
-********************************************************************/
-be_local_closure(lvh_obj_text_rule_matched,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(int),
-    /* K1   */  be_nested_str_weak(_text_rule_function),
-    /* K2   */  be_nested_str_weak(string),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20run_X20self_X2E_text_rule_function_X20_X2D_X20_X25s_X20_X28_X25s_X29),
-    /* K5   */  be_nested_str_weak(_text_rule_format),
-    /* K6   */  be_nested_str_weak(),
-    /* K7   */  be_nested_str_weak(text),
-    }),
-    be_str_weak(text_rule_matched),
-    &be_const_str_solidified,
-    ( &(const binstruction[49]) {  /* code */
-      0x60080004,  //  0000  GETGBL	R2	G4
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x1C080500,  //  0003  EQ	R2	R2	K0
-      0x780A0003,  //  0004  JMPF	R2	#0009
-      0x6008000A,  //  0005  GETGBL	R2	G10
-      0x5C0C0200,  //  0006  MOVE	R3	R1
-      0x7C080200,  //  0007  CALL	R2	1
-      0x5C040400,  //  0008  MOVE	R1	R2
-      0x88080101,  //  0009  GETMBR	R2	R0	K1
-      0x4C0C0000,  //  000A  LDNIL	R3
-      0x200C0403,  //  000B  NE	R3	R2	R3
-      0x780E0012,  //  000C  JMPF	R3	#0020
-      0xA8020005,  //  000D  EXBLK	0	#0014
-      0x5C0C0400,  //  000E  MOVE	R3	R2
-      0x5C100200,  //  000F  MOVE	R4	R1
-      0x7C0C0200,  //  0010  CALL	R3	1
-      0x5C040600,  //  0011  MOVE	R1	R3
-      0xA8040001,  //  0012  EXBLK	1	1
-      0x7002000B,  //  0013  JMP		#0020
-      0xAC0C0002,  //  0014  CATCH	R3	0	2
-      0x70020008,  //  0015  JMP		#001F
-      0xA4160400,  //  0016  IMPORT	R5	K2
-      0x60180001,  //  0017  GETGBL	R6	G1
-      0x8C1C0B03,  //  0018  GETMET	R7	R5	K3
-      0x58240004,  //  0019  LDCONST	R9	K4
-      0x5C280600,  //  001A  MOVE	R10	R3
-      0x5C2C0800,  //  001B  MOVE	R11	R4
-      0x7C1C0800,  //  001C  CALL	R7	4
-      0x7C180200,  //  001D  CALL	R6	1
-      0x70020000,  //  001E  JMP		#0020
-      0xB0080000,  //  001F  RAISE	2	R0	R0
-      0x880C0105,  //  0020  GETMBR	R3	R0	K5
-      0x60100004,  //  0021  GETGBL	R4	G4
-      0x5C140600,  //  0022  MOVE	R5	R3
-      0x7C100200,  //  0023  CALL	R4	1
-      0x1C100902,  //  0024  EQ	R4	R4	K2
-      0x78120006,  //  0025  JMPF	R4	#002D
-      0xA4120400,  //  0026  IMPORT	R4	K2
-      0x8C140903,  //  0027  GETMET	R5	R4	K3
-      0x5C1C0600,  //  0028  MOVE	R7	R3
-      0x5C200200,  //  0029  MOVE	R8	R1
-      0x7C140600,  //  002A  CALL	R5	3
-      0x5C0C0A00,  //  002B  MOVE	R3	R5
-      0x70020000,  //  002C  JMP		#002E
-      0x580C0006,  //  002D  LDCONST	R3	K6
-      0x90020E03,  //  002E  SETMBR	R0	K7	R3
-      0x50100000,  //  002F  LDBOOL	R4	0	0
-      0x80040800,  //  0030  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_line_width
-********************************************************************/
-be_local_closure(lvh_obj_set_line_width,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_style_line_width),
-    /* K2   */  be_const_int(0),
-    }),
-    be_str_weak(set_line_width),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x60100009,  //  0002  GETGBL	R4	G9
-      0x5C140200,  //  0003  MOVE	R5	R1
-      0x7C100200,  //  0004  CALL	R4	1
-      0x58140002,  //  0005  LDCONST	R5	K2
-      0x7C080600,  //  0006  CALL	R2	3
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_val_rule_formula
-********************************************************************/
-be_local_closure(lvh_obj_get_val_rule_formula,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule_formula),
-    }),
-    be_str_weak(get_val_rule_formula),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_val_rule_formula
-********************************************************************/
-be_local_closure(lvh_obj_set_val_rule_formula,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule_formula),
-    /* K1   */  be_nested_str_weak(return_X20_X2F_X20val_X20_X2D_X3E_X20_X28),
-    /* K2   */  be_nested_str_weak(_X29),
-    /* K3   */  be_nested_str_weak(_val_rule_function),
-    /* K4   */  be_nested_str_weak(string),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20compile_X20_X27_X25s_X27_X20_X2D_X20_X25s_X20_X28_X25s_X29),
-    }),
-    be_str_weak(set_val_rule_formula),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x60080008,  //  0000  GETGBL	R2	G8
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x000A0202,  //  0005  ADD	R2	K1	R2
-      0x00080502,  //  0006  ADD	R2	R2	K2
-      0xA8020007,  //  0007  EXBLK	0	#0010
-      0x600C000D,  //  0008  GETGBL	R3	G13
-      0x5C100400,  //  0009  MOVE	R4	R2
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x5C100600,  //  000B  MOVE	R4	R3
-      0x7C100000,  //  000C  CALL	R4	0
-      0x90020604,  //  000D  SETMBR	R0	K3	R4
-      0xA8040001,  //  000E  EXBLK	1	1
-      0x7002000C,  //  000F  JMP		#001D
-      0xAC0C0002,  //  0010  CATCH	R3	0	2
-      0x70020009,  //  0011  JMP		#001C
-      0xA4160800,  //  0012  IMPORT	R5	K4
-      0x60180001,  //  0013  GETGBL	R6	G1
-      0x8C1C0B05,  //  0014  GETMET	R7	R5	K5
-      0x58240006,  //  0015  LDCONST	R9	K6
-      0x5C280400,  //  0016  MOVE	R10	R2
-      0x5C2C0600,  //  0017  MOVE	R11	R3
-      0x5C300800,  //  0018  MOVE	R12	R4
-      0x7C1C0A00,  //  0019  CALL	R7	5
-      0x7C180200,  //  001A  CALL	R6	1
-      0x70020000,  //  001B  JMP		#001D
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x80000000,  //  001D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_value_ofs_x
-********************************************************************/
-be_local_closure(lvh_obj_set_value_ofs_x,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(check_label),
-    /* K1   */  be_nested_str_weak(_lv_label),
-    /* K2   */  be_nested_str_weak(set_x),
-    }),
-    be_str_weak(set_value_ofs_x),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x7C080200,  //  0001  CALL	R2	1
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x8C080502,  //  0003  GETMET	R2	R2	K2
-      0x60100009,  //  0004  GETGBL	R4	G9
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x7C100200,  //  0006  CALL	R4	1
-      0x7C080400,  //  0007  CALL	R2	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pad_left
-********************************************************************/
-be_local_closure(lvh_obj_get_pad_left,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_part2_selector),
     /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_pad_left),
+    /* K2   */  be_nested_str_weak(set_style_radius),
     /* K3   */  be_nested_str_weak(lv),
     /* K4   */  be_nested_str_weak(STATE_DEFAULT),
     }),
-    be_str_weak(get_pad_left),
+    be_str_weak(set_radius2),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060007,  //  0003  JMPF	R1	#000C
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0xB8120600,  //  0007  GETNGBL	R4	K3
-      0x88100904,  //  0008  GETMBR	R4	R4	K4
-      0x300C0604,  //  0009  OR	R3	R3	R4
-      0x7C040400,  //  000A  CALL	R1	2
-      0x80040200,  //  000B  RET	1	R1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: post_init
-********************************************************************/
-be_local_closure(lvh_obj_post_init,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(register_event_cb),
-    }),
-    be_str_weak(post_init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_text_rule_format
-********************************************************************/
-be_local_closure(lvh_obj_get_text_rule_format,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule_format),
-    }),
-    be_str_weak(get_text_rule_format),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: member
-********************************************************************/
-be_local_closure(lvh_obj_member,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_const_int(3),
-    /* K4   */  be_nested_str_weak(set_),
-    /* K5   */  be_nested_str_weak(get_),
-    /* K6   */  be_nested_str_weak(_attr_ignore),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_nested_str_weak(get),
-    /* K9   */  be_nested_str_weak(function),
-    /* K10  */  be_nested_str_weak(_attr_map),
-    /* K11  */  be_nested_str_weak(contains),
-    /* K12  */  be_nested_str_weak(_lv_obj),
-    /* K13  */  be_nested_str_weak(style_),
-    /* K14  */  be_nested_str_weak(unknown_X20attribute_X20),
-    /* K15  */  be_nested_str_weak(value_error),
-    }),
-    be_str_weak(member),
-    &be_const_str_solidified,
-    ( &(const binstruction[69]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0x40120503,  //  0002  CONNECT	R4	K2	K3
-      0x94100204,  //  0003  GETIDX	R4	R1	R4
-      0x1C140904,  //  0004  EQ	R5	R4	K4
-      0x74160001,  //  0005  JMPT	R5	#0008
-      0x1C140905,  //  0006  EQ	R5	R4	K5
-      0x78160000,  //  0007  JMPF	R5	#0009
-      0x80000A00,  //  0008  RET	0
-      0x88140106,  //  0009  GETMBR	R5	R0	K6
-      0x8C140B07,  //  000A  GETMET	R5	R5	K7
-      0x5C1C0200,  //  000B  MOVE	R7	R1
-      0x7C140400,  //  000C  CALL	R5	2
-      0x4C180000,  //  000D  LDNIL	R6
-      0x20140A06,  //  000E  NE	R5	R5	R6
-      0x78160000,  //  000F  JMPF	R5	#0011
-      0x80000A00,  //  0010  RET	0
-      0x8C140708,  //  0011  GETMET	R5	R3	K8
-      0x5C1C0000,  //  0012  MOVE	R7	R0
-      0x00220A01,  //  0013  ADD	R8	K5	R1
-      0x7C140600,  //  0014  CALL	R5	3
-      0x60180004,  //  0015  GETGBL	R6	G4
-      0x5C1C0A00,  //  0016  MOVE	R7	R5
-      0x7C180200,  //  0017  CALL	R6	1
-      0x1C180D09,  //  0018  EQ	R6	R6	K9
-      0x781A0003,  //  0019  JMPF	R6	#001E
-      0x5C180A00,  //  001A  MOVE	R6	R5
-      0x5C1C0000,  //  001B  MOVE	R7	R0
-      0x7C180200,  //  001C  CALL	R6	1
-      0x80040C00,  //  001D  RET	1	R6
-      0x8818010A,  //  001E  GETMBR	R6	R0	K10
-      0x8C180D0B,  //  001F  GETMET	R6	R6	K11
-      0x5C200200,  //  0020  MOVE	R8	R1
-      0x7C180400,  //  0021  CALL	R6	2
-      0x781A001B,  //  0022  JMPF	R6	#003F
-      0x8818010A,  //  0023  GETMBR	R6	R0	K10
-      0x94180C01,  //  0024  GETIDX	R6	R6	R1
-      0x8C1C0708,  //  0025  GETMET	R7	R3	K8
-      0x8824010C,  //  0026  GETMBR	R9	R0	K12
-      0x002A0A06,  //  0027  ADD	R10	K5	R6
-      0x7C1C0600,  //  0028  CALL	R7	3
-      0x5C140E00,  //  0029  MOVE	R5	R7
-      0x601C0004,  //  002A  GETGBL	R7	G4
-      0x5C200A00,  //  002B  MOVE	R8	R5
-      0x7C1C0200,  //  002C  CALL	R7	1
-      0x1C1C0F09,  //  002D  EQ	R7	R7	K9
-      0x781E000F,  //  002E  JMPF	R7	#003F
-      0x8C1C0507,  //  002F  GETMET	R7	R2	K7
-      0x5C240C00,  //  0030  MOVE	R9	R6
-      0x5828000D,  //  0031  LDCONST	R10	K13
-      0x7C1C0600,  //  0032  CALL	R7	3
-      0x1C1C0F02,  //  0033  EQ	R7	R7	K2
-      0x781E0005,  //  0034  JMPF	R7	#003B
-      0x5C1C0A00,  //  0035  MOVE	R7	R5
-      0x8820010C,  //  0036  GETMBR	R8	R0	K12
-      0x58240002,  //  0037  LDCONST	R9	K2
-      0x7C1C0400,  //  0038  CALL	R7	2
-      0x80040E00,  //  0039  RET	1	R7
-      0x70020003,  //  003A  JMP		#003F
-      0x5C1C0A00,  //  003B  MOVE	R7	R5
-      0x8820010C,  //  003C  GETMBR	R8	R0	K12
-      0x7C1C0200,  //  003D  CALL	R7	1
-      0x80040E00,  //  003E  RET	1	R7
-      0x60180008,  //  003F  GETGBL	R6	G8
-      0x5C1C0200,  //  0040  MOVE	R7	R1
-      0x7C180200,  //  0041  CALL	R6	1
-      0x001A1C06,  //  0042  ADD	R6	K14	R6
-      0xB0061E06,  //  0043  RAISE	1	K15	R6
-      0x80000000,  //  0044  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_color_attribute
-********************************************************************/
-be_local_closure(lvh_obj_is_color_attribute,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_lvh_obj),
-    /* K1   */  be_nested_str_weak(re),
-    /* K2   */  be_nested_str_weak(search),
-    /* K3   */  be_nested_str_weak(color_X24),
-    }),
-    be_str_weak(is_color_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0x600C0017,  //  0002  GETGBL	R3	G23
-      0x8C100502,  //  0003  GETMET	R4	R2	K2
-      0x58180003,  //  0004  LDCONST	R6	K3
-      0x601C0008,  //  0005  GETGBL	R7	G8
-      0x5C200000,  //  0006  MOVE	R8	R0
-      0x7C1C0200,  //  0007  CALL	R7	1
-      0x7C100600,  //  0008  CALL	R4	3
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x80040600,  //  000A  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_val
-********************************************************************/
-be_local_closure(lvh_obj_get_val,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_value),
-    }),
-    be_str_weak(get_val),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_mode
-********************************************************************/
-be_local_closure(lvh_obj_get_mode,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(get_mode),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pad_right
-********************************************************************/
-be_local_closure(lvh_obj_get_pad_right,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_pad_right),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(get_pad_right),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060007,  //  0003  JMPF	R1	#000C
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0xB8120600,  //  0007  GETNGBL	R4	K3
-      0x88100904,  //  0008  GETMBR	R4	R4	K4
-      0x300C0604,  //  0009  OR	R3	R3	R4
-      0x7C040400,  //  000A  CALL	R1	2
-      0x80040200,  //  000B  RET	1	R1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_value_ofs_y
-********************************************************************/
-be_local_closure(lvh_obj_get_value_ofs_y,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(get_y),
-    }),
-    be_str_weak(get_value_ofs_y),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_val
-********************************************************************/
-be_local_closure(lvh_obj_set_val,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_value),
-    }),
-    be_str_weak(set_val),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
+    ( &(const binstruction[15]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80000000,  //  0004  RET	0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0009,  //  0003  JMPF	R2	#000E
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x60100009,  //  0006  GETGBL	R4	G9
+      0x5C140200,  //  0007  MOVE	R5	R1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x88140100,  //  0009  GETMBR	R5	R0	K0
+      0xB81A0600,  //  000A  GETNGBL	R6	K3
+      0x88180D04,  //  000B  GETMBR	R6	R6	K4
+      0x30140A06,  //  000C  OR	R5	R5	R6
+      0x7C080600,  //  000D  CALL	R2	3
+      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -3719,74 +3790,9 @@ be_local_closure(lvh_obj_set_val,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_toggle
+** Solidified function: get_adjustable
 ********************************************************************/
-be_local_closure(lvh_obj_set_toggle,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(toupper),
-    /* K2   */  be_nested_str_weak(TRUE),
-    /* K3   */  be_nested_str_weak(FALSE),
-    /* K4   */  be_nested_str_weak(_lv_obj),
-    /* K5   */  be_nested_str_weak(add_state),
-    /* K6   */  be_nested_str_weak(lv),
-    /* K7   */  be_nested_str_weak(STATE_CHECKED),
-    /* K8   */  be_nested_str_weak(clear_state),
-    }),
-    be_str_weak(set_toggle),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0x60080004,  //  0000  GETGBL	R2	G4
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x1C080500,  //  0003  EQ	R2	R2	K0
-      0x780A000D,  //  0004  JMPF	R2	#0013
-      0xA40A0000,  //  0005  IMPORT	R2	K0
-      0x8C0C0501,  //  0006  GETMET	R3	R2	K1
-      0x60140008,  //  0007  GETGBL	R5	G8
-      0x5C180200,  //  0008  MOVE	R6	R1
-      0x7C140200,  //  0009  CALL	R5	1
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x5C040600,  //  000B  MOVE	R1	R3
-      0x1C0C0302,  //  000C  EQ	R3	R1	K2
-      0x780E0001,  //  000D  JMPF	R3	#0010
-      0x50040200,  //  000E  LDBOOL	R1	1	0
-      0x70020002,  //  000F  JMP		#0013
-      0x1C0C0303,  //  0010  EQ	R3	R1	K3
-      0x780E0000,  //  0011  JMPF	R3	#0013
-      0x50040000,  //  0012  LDBOOL	R1	0	0
-      0x78060005,  //  0013  JMPF	R1	#001A
-      0x88080104,  //  0014  GETMBR	R2	R0	K4
-      0x8C080505,  //  0015  GETMET	R2	R2	K5
-      0xB8120C00,  //  0016  GETNGBL	R4	K6
-      0x88100907,  //  0017  GETMBR	R4	R4	K7
-      0x7C080400,  //  0018  CALL	R2	2
-      0x70020004,  //  0019  JMP		#001F
-      0x88080104,  //  001A  GETMBR	R2	R0	K4
-      0x8C080508,  //  001B  GETMET	R2	R2	K8
-      0xB8120C00,  //  001C  GETNGBL	R4	K6
-      0x88100907,  //  001D  GETMBR	R4	R4	K7
-      0x7C080400,  //  001E  CALL	R2	2
-      0x80000000,  //  001F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_line_width
-********************************************************************/
-be_local_closure(lvh_obj_get_line_width,   /* name */
+be_local_closure(lvh_obj_get_adjustable,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -3796,55 +3802,21 @@ be_local_closure(lvh_obj_get_line_width,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_style_line_width),
-    /* K2   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(has_flag),
+    /* K2   */  be_nested_str_weak(lv),
+    /* K3   */  be_nested_str_weak(OBJ_FLAG_CLICKABLE),
     }),
-    be_str_weak(get_line_width),
+    be_str_weak(get_adjustable),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
+    ( &(const binstruction[ 6]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x580C0002,  //  0002  LDCONST	R3	K2
-      0x7C040400,  //  0003  CALL	R1	2
-      0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_text
-********************************************************************/
-be_local_closure(lvh_obj_set_text,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(check_label),
-    /* K1   */  be_nested_str_weak(_lv_label),
-    /* K2   */  be_nested_str_weak(set_text),
-    }),
-    be_str_weak(set_text),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x7C080200,  //  0001  CALL	R2	1
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x8C080502,  //  0003  GETMET	R2	R2	K2
-      0x60100008,  //  0004  GETGBL	R4	G8
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x7C100200,  //  0006  CALL	R4	1
-      0x7C080400,  //  0007  CALL	R2	2
-      0x80000000,  //  0008  RET	0
+      0xB80E0400,  //  0002  GETNGBL	R3	K2
+      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0x7C040400,  //  0004  CALL	R1	2
+      0x80040200,  //  0005  RET	1	R1
     })
   )
 );
@@ -3937,22 +3909,204 @@ be_local_closure(lvh_obj_set_mode,   /* name */
 
 
 /********************************************************************
+** Solidified function: get_val_rule_formula
+********************************************************************/
+be_local_closure(lvh_obj_get_val_rule_formula,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_val_rule_formula),
+    }),
+    be_str_weak(get_val_rule_formula),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_trailing_zeroes
+********************************************************************/
+be_local_closure(lvh_obj_remove_trailing_zeroes,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_class(be_class_lvh_obj),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_const_int(1),
+    /* K3   */  be_nested_str_weak(resize),
+    }),
+    be_str_weak(remove_trailing_zeroes),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C080200,  //  0003  CALL	R2	1
+      0x580C0001,  //  0004  LDCONST	R3	K1
+      0x14100602,  //  0005  LT	R4	R3	R2
+      0x78120007,  //  0006  JMPF	R4	#000F
+      0x5411FFFE,  //  0007  LDINT	R4	-1
+      0x04100803,  //  0008  SUB	R4	R4	R3
+      0x94100004,  //  0009  GETIDX	R4	R0	R4
+      0x20100901,  //  000A  NE	R4	R4	K1
+      0x78120000,  //  000B  JMPF	R4	#000D
+      0x70020001,  //  000C  JMP		#000F
+      0x000C0702,  //  000D  ADD	R3	R3	K2
+      0x7001FFF5,  //  000E  JMP		#0005
+      0x24100701,  //  000F  GT	R4	R3	K1
+      0x78120005,  //  0010  JMPF	R4	#0017
+      0x8C100103,  //  0011  GETMET	R4	R0	K3
+      0x6018000C,  //  0012  GETGBL	R6	G12
+      0x5C1C0000,  //  0013  MOVE	R7	R0
+      0x7C180200,  //  0014  CALL	R6	1
+      0x04180C03,  //  0015  SUB	R6	R6	R3
+      0x7C100400,  //  0016  CALL	R4	2
+      0x80040000,  //  0017  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: post_init
+********************************************************************/
+be_local_closure(lvh_obj_post_init,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(register_event_cb),
+    }),
+    be_str_weak(post_init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: val_rule_matched
+********************************************************************/
+be_local_closure(lvh_obj_val_rule_matched,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_val_rule_function),
+    /* K1   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20run_X20self_X2E_val_rule_function_X20_X2D_X20_X25s_X20_X28_X25s_X29),
+    /* K2   */  be_nested_str_weak(val),
+    }),
+    be_str_weak(val_rule_matched),
+    &be_const_str_solidified,
+    ( &(const binstruction[36]) {  /* code */
+      0x6008000A,  //  0000  GETGBL	R2	G10
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0403,  //  0004  EQ	R3	R2	R3
+      0x780E0001,  //  0005  JMPF	R3	#0008
+      0x500C0000,  //  0006  LDBOOL	R3	0	0
+      0x80040600,  //  0007  RET	1	R3
+      0x880C0100,  //  0008  GETMBR	R3	R0	K0
+      0x4C100000,  //  0009  LDNIL	R4
+      0x20100604,  //  000A  NE	R4	R3	R4
+      0x78120011,  //  000B  JMPF	R4	#001E
+      0xA8020005,  //  000C  EXBLK	0	#0013
+      0x5C100600,  //  000D  MOVE	R4	R3
+      0x5C140400,  //  000E  MOVE	R5	R2
+      0x7C100200,  //  000F  CALL	R4	1
+      0x5C080800,  //  0010  MOVE	R2	R4
+      0xA8040001,  //  0011  EXBLK	1	1
+      0x7002000A,  //  0012  JMP		#001E
+      0xAC100002,  //  0013  CATCH	R4	0	2
+      0x70020007,  //  0014  JMP		#001D
+      0x60180001,  //  0015  GETGBL	R6	G1
+      0x601C0018,  //  0016  GETGBL	R7	G24
+      0x58200001,  //  0017  LDCONST	R8	K1
+      0x5C240800,  //  0018  MOVE	R9	R4
+      0x5C280A00,  //  0019  MOVE	R10	R5
+      0x7C1C0600,  //  001A  CALL	R7	3
+      0x7C180200,  //  001B  CALL	R6	1
+      0x70020000,  //  001C  JMP		#001E
+      0xB0080000,  //  001D  RAISE	2	R0	R0
+      0x60100009,  //  001E  GETGBL	R4	G9
+      0x5C140400,  //  001F  MOVE	R5	R2
+      0x7C100200,  //  0020  CALL	R4	1
+      0x90020404,  //  0021  SETMBR	R0	K2	R4
+      0x50100000,  //  0022  LDBOOL	R4	0	0
+      0x80040800,  //  0023  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: lvh_obj
 ********************************************************************/
 be_local_class(lvh_obj,
     13,
     NULL,
-    be_nested_map(91,
+    be_nested_map(94,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(parse_color, 3), be_const_static_closure(lvh_obj_parse_color_closure) },
-        { be_const_key_weak(set_mode, 8), be_const_closure(lvh_obj_set_mode_closure) },
-        { be_const_key_weak(set_pad_top2, -1), be_const_closure(lvh_obj_set_pad_top2_closure) },
-        { be_const_key_weak(set_pad_left2, -1), be_const_closure(lvh_obj_set_pad_left2_closure) },
-        { be_const_key_weak(get_obj, -1), be_const_closure(lvh_obj_get_obj_closure) },
-        { be_const_key_weak(get_line_width, 84), be_const_closure(lvh_obj_get_line_width_closure) },
-        { be_const_key_weak(get_align, -1), be_const_closure(lvh_obj_get_align_closure) },
-        { be_const_key_weak(_text_rule, -1), be_const_var(9) },
-        { be_const_key_weak(_attr_ignore, 42), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        { be_const_key_weak(val_rule_matched, 9), be_const_closure(lvh_obj_val_rule_matched_closure) },
+        { be_const_key_weak(post_init, 18), be_const_closure(lvh_obj_post_init_closure) },
+        { be_const_key_weak(set_val_rule, -1), be_const_closure(lvh_obj_set_val_rule_closure) },
+        { be_const_key_weak(remove_trailing_zeroes, -1), be_const_static_closure(lvh_obj_remove_trailing_zeroes_closure) },
+        { be_const_key_weak(_action, -1), be_const_var(4) },
+        { be_const_key_weak(id, -1), be_const_var(0) },
+        { be_const_key_weak(get_val_rule_formula, -1), be_const_closure(lvh_obj_get_val_rule_formula_closure) },
+        { be_const_key_weak(set_mode, 80), be_const_closure(lvh_obj_set_mode_closure) },
+        { be_const_key_weak(get_adjustable, -1), be_const_closure(lvh_obj_get_adjustable_closure) },
+        { be_const_key_weak(set_radius2, -1), be_const_closure(lvh_obj_set_radius2_closure) },
+        { be_const_key_weak(set_text_font, -1), be_const_closure(lvh_obj_set_text_font_closure) },
+        { be_const_key_weak(set_pad_all2, -1), be_const_closure(lvh_obj_set_pad_all2_closure) },
+        { be_const_key_weak(text_rule_matched, -1), be_const_closure(lvh_obj_text_rule_matched_closure) },
+        { be_const_key_weak(set_value_ofs_x, -1), be_const_closure(lvh_obj_set_value_ofs_x_closure) },
+        { be_const_key_weak(_text_rule, 45), be_const_var(9) },
+        { be_const_key_weak(_page, -1), be_const_var(3) },
+        { be_const_key_weak(get_val_rule, 73), be_const_closure(lvh_obj_get_val_rule_closure) },
+        { be_const_key_weak(get_text_color, -1), be_const_closure(lvh_obj_get_text_color_closure) },
+        { be_const_key_weak(set_text_rule, -1), be_const_closure(lvh_obj_set_text_rule_closure) },
+        { be_const_key_weak(get_enabled, -1), be_const_closure(lvh_obj_get_enabled_closure) },
+        { be_const_key_weak(_attr_ignore, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(10,
     ( (struct bvalue*) &(const bvalue[]) {
         be_nested_str_weak(tostring),
@@ -3966,45 +4120,26 @@ be_local_class(lvh_obj,
         be_nested_str_weak(back),
         be_nested_str_weak(berry_run),
     }))    ) } )) },
-        { be_const_key_weak(get_value_font, -1), be_const_closure(lvh_obj_get_value_font_closure) },
-        { be_const_key_weak(id, 64), be_const_var(0) },
-        { be_const_key_weak(_val_rule, 65), be_const_var(6) },
-        { be_const_key_weak(_val_rule_function, -1), be_const_var(8) },
-        { be_const_key_weak(get_pad_bottom, -1), be_const_closure(lvh_obj_get_pad_bottom_closure) },
-        { be_const_key_weak(val_rule_matched, -1), be_const_closure(lvh_obj_val_rule_matched_closure) },
-        { be_const_key_weak(get_enabled, 86), be_const_closure(lvh_obj_get_enabled_closure) },
-        { be_const_key_weak(set_meta, 35), be_const_closure(lvh_obj_set_meta_closure) },
-        { be_const_key_weak(get_val_rule, 52), be_const_closure(lvh_obj_get_val_rule_closure) },
-        { be_const_key_weak(_page, 47), be_const_var(3) },
         { be_const_key_weak(init, -1), be_const_closure(lvh_obj_init_closure) },
-        { be_const_key_weak(set_toggle, 36), be_const_closure(lvh_obj_set_toggle_closure) },
-        { be_const_key_weak(_text_rule_function, -1), be_const_var(11) },
-        { be_const_key_weak(check_label, 49), be_const_closure(lvh_obj_check_label_closure) },
-        { be_const_key_weak(get_meta, -1), be_const_closure(lvh_obj_get_meta_closure) },
-        { be_const_key_weak(set_val_rule, 59), be_const_closure(lvh_obj_set_val_rule_closure) },
-        { be_const_key_weak(set_enabled, -1), be_const_closure(lvh_obj_set_enabled_closure) },
-        { be_const_key_weak(get_action, -1), be_const_closure(lvh_obj_get_action_closure) },
-        { be_const_key_weak(get_radius2, 18), be_const_closure(lvh_obj_get_radius2_closure) },
-        { be_const_key_weak(_lv_obj, -1), be_const_var(1) },
-        { be_const_key_weak(get_text_rule_formula, -1), be_const_closure(lvh_obj_get_text_rule_formula_closure) },
-        { be_const_key_weak(get_value_ofs_x, -1), be_const_closure(lvh_obj_get_value_ofs_x_closure) },
-        { be_const_key_weak(get_value_color, -1), be_const_closure(lvh_obj_get_value_color_closure) },
-        { be_const_key_weak(set_pad_bottom2, -1), be_const_closure(lvh_obj_set_pad_bottom2_closure) },
-        { be_const_key_weak(get_text_color, -1), be_const_closure(lvh_obj_get_text_color_closure) },
-        { be_const_key_weak(get_value_ofs_y, 71), be_const_closure(lvh_obj_get_value_ofs_y_closure) },
+        { be_const_key_weak(_text_rule_format, -1), be_const_var(12) },
+        { be_const_key_weak(get_text, -1), be_const_closure(lvh_obj_get_text_closure) },
         { be_const_key_weak(get_text_font, -1), be_const_closure(lvh_obj_get_text_font_closure) },
-        { be_const_key_weak(get_mode, -1), be_const_closure(lvh_obj_get_mode_closure) },
-        { be_const_key_weak(_text_rule_formula, 5), be_const_var(10) },
-        { be_const_key_weak(set_text_rule_formula, -1), be_const_closure(lvh_obj_set_text_rule_formula_closure) },
-        { be_const_key_weak(get_pad_top, -1), be_const_closure(lvh_obj_get_pad_top_closure) },
-        { be_const_key_weak(set_adjustable, -1), be_const_closure(lvh_obj_set_adjustable_closure) },
-        { be_const_key_weak(set_value_color, -1), be_const_closure(lvh_obj_set_value_color_closure) },
-        { be_const_key_weak(get_val, 67), be_const_closure(lvh_obj_get_val_closure) },
-        { be_const_key_weak(set_pad_all2, -1), be_const_closure(lvh_obj_set_pad_all2_closure) },
-        { be_const_key_weak(_lv_label, 29), be_const_var(2) },
-        { be_const_key_weak(_lv_class, -1), be_const_class(be_class_lv_obj) },
-        { be_const_key_weak(setmember, 88), be_const_closure(lvh_obj_setmember_closure) },
-        { be_const_key_weak(_attr_map, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(_lv_class, 87), be_const_class(be_class_lv_obj) },
+        { be_const_key_weak(get_value_str, -1), be_const_closure(lvh_obj_get_value_str_closure) },
+        { be_const_key_weak(set_align, 42), be_const_closure(lvh_obj_set_align_closure) },
+        { be_const_key_weak(set_val_rule_formula, -1), be_const_closure(lvh_obj_set_val_rule_formula_closure) },
+        { be_const_key_weak(_text_rule_function, 30), be_const_var(11) },
+        { be_const_key_weak(set_enabled, 79), be_const_closure(lvh_obj_set_enabled_closure) },
+        { be_const_key_weak(set_value_font, -1), be_const_closure(lvh_obj_set_value_font_closure) },
+        { be_const_key_weak(set_toggle, -1), be_const_closure(lvh_obj_set_toggle_closure) },
+        { be_const_key_weak(_val_rule_function, -1), be_const_var(8) },
+        { be_const_key_weak(get_value_ofs_y, -1), be_const_closure(lvh_obj_get_value_ofs_y_closure) },
+        { be_const_key_weak(_text_rule_formula, 88), be_const_var(10) },
+        { be_const_key_weak(set_pad_left2, 93), be_const_closure(lvh_obj_set_pad_left2_closure) },
+        { be_const_key_weak(digits_to_style, -1), be_const_closure(lvh_obj_digits_to_style_closure) },
+        { be_const_key_weak(get_action, -1), be_const_closure(lvh_obj_get_action_closure) },
+        { be_const_key_weak(get_obj, 84), be_const_closure(lvh_obj_get_obj_closure) },
+        { be_const_key_weak(_attr_map, 50), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(26,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_weak(rotation, -1), be_nested_str_weak(rotation) },
@@ -4034,16 +4169,79 @@ be_local_class(lvh_obj,
         { be_const_key_weak(pad_top, 16), be_nested_str_weak(style_pad_top) },
         { be_const_key_weak(bg_grad_dir, 14), be_nested_str_weak(style_bg_grad_dir) },
     }))    ) } )) },
-        { be_const_key_weak(remove_trailing_zeroes, -1), be_const_static_closure(lvh_obj_remove_trailing_zeroes_closure) },
-        { be_const_key_weak(_action, -1), be_const_var(4) },
-        { be_const_key_weak(get_text, -1), be_const_closure(lvh_obj_get_text_closure) },
-        { be_const_key_weak(_val_rule_formula, -1), be_const_var(7) },
+        { be_const_key_weak(register_event_cb, 17), be_const_closure(lvh_obj_register_event_cb_closure) },
+        { be_const_key_weak(set_pad_top2, 61), be_const_closure(lvh_obj_set_pad_top2_closure) },
+        { be_const_key_weak(event_cb, 7), be_const_closure(lvh_obj_event_cb_closure) },
+        { be_const_key_weak(check_label, -1), be_const_closure(lvh_obj_check_label_closure) },
+        { be_const_key_weak(_lv_part2_selector, -1), be_const_nil() },
+        { be_const_key_weak(_digit2part, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(10,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(131072),
+        be_const_int(196608),
+        be_const_int(327680),
+        be_const_int(327680),
+        be_const_int(262144),
+        be_const_int(393216),
+        be_const_int(458752),
+        be_const_int(65536),
+        be_const_int(524288),
+    }))    ) } )) },
+        { be_const_key_weak(get_val, 75), be_const_closure(lvh_obj_get_val_closure) },
         { be_const_key_weak(get_pad_all, -1), be_const_closure(lvh_obj_get_pad_all_closure) },
-        { be_const_key_weak(set_action, -1), be_const_closure(lvh_obj_set_action_closure) },
-        { be_const_key_weak(set_hidden, 46), be_const_closure(lvh_obj_set_hidden_closure) },
-        { be_const_key_weak(get_text_rule, 75), be_const_closure(lvh_obj_get_text_rule_closure) },
-        { be_const_key_weak(get_adjustable, -1), be_const_closure(lvh_obj_get_adjustable_closure) },
-        { be_const_key_weak(_event_map, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(get_pad_bottom, 66), be_const_closure(lvh_obj_get_pad_bottom_closure) },
+        { be_const_key_weak(get_toggle, -1), be_const_closure(lvh_obj_get_toggle_closure) },
+        { be_const_key_weak(set_line_width, -1), be_const_closure(lvh_obj_set_line_width_closure) },
+        { be_const_key_weak(get_text_rule_format, -1), be_const_closure(lvh_obj_get_text_rule_format_closure) },
+        { be_const_key_weak(set_pad_bottom2, 74), be_const_closure(lvh_obj_set_pad_bottom2_closure) },
+        { be_const_key_weak(set_action, 16), be_const_closure(lvh_obj_set_action_closure) },
+        { be_const_key_weak(set_text_color, 47), be_const_closure(lvh_obj_set_text_color_closure) },
+        { be_const_key_weak(get_pad_right, -1), be_const_closure(lvh_obj_get_pad_right_closure) },
+        { be_const_key_weak(get_value_font, -1), be_const_closure(lvh_obj_get_value_font_closure) },
+        { be_const_key_weak(get_text_rule, 40), be_const_closure(lvh_obj_get_text_rule_closure) },
+        { be_const_key_weak(set_meta, 8), be_const_closure(lvh_obj_set_meta_closure) },
+        { be_const_key_weak(set_text_rule_format, -1), be_const_closure(lvh_obj_set_text_rule_format_closure) },
+        { be_const_key_weak(get_line_width, -1), be_const_closure(lvh_obj_get_line_width_closure) },
+        { be_const_key_weak(_digit2state, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(6,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(1),
+        be_const_int(32),
+        be_const_int(33),
+        be_const_int(128),
+        be_const_int(160),
+    }))    ) } )) },
+        { be_const_key_weak(get_value_ofs_x, -1), be_const_closure(lvh_obj_get_value_ofs_x_closure) },
+        { be_const_key_weak(is_color_attribute, -1), be_const_static_closure(lvh_obj_is_color_attribute_closure) },
+        { be_const_key_weak(get_text_rule_formula, 26), be_const_closure(lvh_obj_get_text_rule_formula_closure) },
+        { be_const_key_weak(set_value_color, -1), be_const_closure(lvh_obj_set_value_color_closure) },
+        { be_const_key_weak(get_pad_top, -1), be_const_closure(lvh_obj_get_pad_top_closure) },
+        { be_const_key_weak(get_hidden, -1), be_const_closure(lvh_obj_get_hidden_closure) },
+        { be_const_key_weak(get_pad_left, -1), be_const_closure(lvh_obj_get_pad_left_closure) },
+        { be_const_key_weak(get_radius2, -1), be_const_closure(lvh_obj_get_radius2_closure) },
+        { be_const_key_weak(set_value_str, 48), be_const_closure(lvh_obj_set_value_str_closure) },
+        { be_const_key_weak(set_click, -1), be_const_closure(lvh_obj_set_click_closure) },
+        { be_const_key_weak(parse_color, 82), be_const_static_closure(lvh_obj_parse_color_closure) },
+        { be_const_key_weak(set_text, 36), be_const_closure(lvh_obj_set_text_closure) },
+        { be_const_key_weak(member, -1), be_const_closure(lvh_obj_member_closure) },
+        { be_const_key_weak(set_pad_right2, 38), be_const_closure(lvh_obj_set_pad_right2_closure) },
+        { be_const_key_weak(set_adjustable, -1), be_const_closure(lvh_obj_set_adjustable_closure) },
+        { be_const_key_weak(set_value_ofs_y, -1), be_const_closure(lvh_obj_set_value_ofs_y_closure) },
+        { be_const_key_weak(get_mode, 28), be_const_closure(lvh_obj_get_mode_closure) },
+        { be_const_key_weak(setmember, -1), be_const_closure(lvh_obj_setmember_closure) },
+        { be_const_key_weak(_val_rule_formula, 24), be_const_var(7) },
+        { be_const_key_weak(get_click, -1), be_const_closure(lvh_obj_get_click_closure) },
+        { be_const_key_weak(get_meta, -1), be_const_closure(lvh_obj_get_meta_closure) },
+        { be_const_key_weak(get_value_color, -1), be_const_closure(lvh_obj_get_value_color_closure) },
+        { be_const_key_weak(_meta, 10), be_const_var(5) },
+        { be_const_key_weak(_val_rule, 0), be_const_var(6) },
+        { be_const_key_weak(_lv_label, -1), be_const_var(2) },
+        { be_const_key_weak(set_text_rule_formula, -1), be_const_closure(lvh_obj_set_text_rule_formula_closure) },
+        { be_const_key_weak(set_val, 6), be_const_closure(lvh_obj_set_val_closure) },
+        { be_const_key_weak(set_hidden, 5), be_const_closure(lvh_obj_set_hidden_closure) },
+        { be_const_key_weak(_event_map, 3), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(7,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(28, 2), be_nested_str_weak(changed) },
@@ -4054,39 +4252,8 @@ be_local_class(lvh_obj,
         { be_const_key_int(5, -1), be_nested_str_weak(long) },
         { be_const_key_int(6, -1), be_nested_str_weak(hold) },
     }))    ) } )) },
-        { be_const_key_weak(set_radius2, 78), be_const_closure(lvh_obj_set_radius2_closure) },
-        { be_const_key_weak(get_pad_left, -1), be_const_closure(lvh_obj_get_pad_left_closure) },
-        { be_const_key_weak(get_value_str, 58), be_const_closure(lvh_obj_get_value_str_closure) },
-        { be_const_key_weak(set_value_ofs_y, -1), be_const_closure(lvh_obj_set_value_ofs_y_closure) },
-        { be_const_key_weak(_lv_part2_selector, -1), be_const_nil() },
-        { be_const_key_weak(set_text_font, -1), be_const_closure(lvh_obj_set_text_font_closure) },
-        { be_const_key_weak(set_value_ofs_x, 45), be_const_closure(lvh_obj_set_value_ofs_x_closure) },
-        { be_const_key_weak(text_rule_matched, 79), be_const_closure(lvh_obj_text_rule_matched_closure) },
-        { be_const_key_weak(set_line_width, -1), be_const_closure(lvh_obj_set_line_width_closure) },
-        { be_const_key_weak(get_val_rule_formula, 69), be_const_closure(lvh_obj_get_val_rule_formula_closure) },
-        { be_const_key_weak(set_val_rule_formula, -1), be_const_closure(lvh_obj_set_val_rule_formula_closure) },
-        { be_const_key_weak(set_align, -1), be_const_closure(lvh_obj_set_align_closure) },
-        { be_const_key_weak(set_text_rule_format, 62), be_const_closure(lvh_obj_set_text_rule_format_closure) },
-        { be_const_key_weak(set_value_str, -1), be_const_closure(lvh_obj_set_value_str_closure) },
-        { be_const_key_weak(_text_rule_format, -1), be_const_var(12) },
-        { be_const_key_weak(post_init, -1), be_const_closure(lvh_obj_post_init_closure) },
-        { be_const_key_weak(get_text_rule_format, -1), be_const_closure(lvh_obj_get_text_rule_format_closure) },
-        { be_const_key_weak(set_text_rule, -1), be_const_closure(lvh_obj_set_text_rule_closure) },
-        { be_const_key_weak(member, -1), be_const_closure(lvh_obj_member_closure) },
-        { be_const_key_weak(is_color_attribute, -1), be_const_static_closure(lvh_obj_is_color_attribute_closure) },
-        { be_const_key_weak(set_click, -1), be_const_closure(lvh_obj_set_click_closure) },
-        { be_const_key_weak(get_hidden, -1), be_const_closure(lvh_obj_get_hidden_closure) },
-        { be_const_key_weak(get_pad_right, -1), be_const_closure(lvh_obj_get_pad_right_closure) },
-        { be_const_key_weak(event_cb, 34), be_const_closure(lvh_obj_event_cb_closure) },
-        { be_const_key_weak(set_val, -1), be_const_closure(lvh_obj_set_val_closure) },
-        { be_const_key_weak(set_text_color, 20), be_const_closure(lvh_obj_set_text_color_closure) },
-        { be_const_key_weak(get_toggle, -1), be_const_closure(lvh_obj_get_toggle_closure) },
-        { be_const_key_weak(register_event_cb, 11), be_const_closure(lvh_obj_register_event_cb_closure) },
-        { be_const_key_weak(get_click, -1), be_const_closure(lvh_obj_get_click_closure) },
-        { be_const_key_weak(set_value_font, 7), be_const_closure(lvh_obj_set_value_font_closure) },
-        { be_const_key_weak(set_pad_right2, -1), be_const_closure(lvh_obj_set_pad_right2_closure) },
-        { be_const_key_weak(set_text, -1), be_const_closure(lvh_obj_set_text_closure) },
-        { be_const_key_weak(_meta, 1), be_const_var(5) },
+        { be_const_key_weak(_lv_obj, 1), be_const_var(1) },
+        { be_const_key_weak(get_align, -1), be_const_closure(lvh_obj_get_align_closure) },
     })),
     be_str_weak(lvh_obj)
 );
@@ -4147,11 +4314,11 @@ void be_load_lvh_btn_class(bvm *vm) {
 extern const bclass be_class_lvh_switch;
 
 /********************************************************************
-** Solidified function: set_radius20
+** Solidified function: set_val
 ********************************************************************/
-be_local_closure(lvh_switch_set_radius20,   /* name */
+be_local_closure(lvh_switch_set_val,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -4159,28 +4326,16 @@ be_local_closure(lvh_switch_set_radius20,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_style_radius),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(PART_KNOB),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_toggle),
     }),
-    be_str_weak(set_radius20),
+    be_str_weak(set_val),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x60100009,  //  0002  GETGBL	R4	G9
-      0x5C140200,  //  0003  MOVE	R5	R1
-      0x7C100200,  //  0004  CALL	R4	1
-      0xB8160400,  //  0005  GETNGBL	R5	K2
-      0x88140B03,  //  0006  GETMBR	R5	R5	K3
-      0xB81A0400,  //  0007  GETNGBL	R6	K2
-      0x88180D04,  //  0008  GETMBR	R6	R6	K4
-      0x30140A06,  //  0009  OR	R5	R5	R6
-      0x7C080600,  //  000A  CALL	R2	3
-      0x80000000,  //  000B  RET	0
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x80040400,  //  0003  RET	1	R2
     })
   )
 );
@@ -4216,239 +4371,18 @@ be_local_closure(lvh_switch_get_val,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_bg_color10
-********************************************************************/
-be_local_closure(lvh_switch_get_bg_color10,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_style_bg_color),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(PART_INDICATOR),
-    }),
-    be_str_weak(get_bg_color10),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_bg_color20
-********************************************************************/
-be_local_closure(lvh_switch_set_bg_color20,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_style_bg_color),
-    /* K2   */  be_nested_str_weak(parse_color),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(PART_KNOB),
-    /* K5   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(set_bg_color20),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x8C100102,  //  0002  GETMET	R4	R0	K2
-      0x5C180200,  //  0003  MOVE	R6	R1
-      0x7C100400,  //  0004  CALL	R4	2
-      0xB8160600,  //  0005  GETNGBL	R5	K3
-      0x88140B04,  //  0006  GETMBR	R5	R5	K4
-      0xB81A0600,  //  0007  GETNGBL	R6	K3
-      0x88180D05,  //  0008  GETMBR	R6	R6	K5
-      0x30140A06,  //  0009  OR	R5	R5	R6
-      0x7C080600,  //  000A  CALL	R2	3
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_bg_color10
-********************************************************************/
-be_local_closure(lvh_switch_set_bg_color10,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_style_bg_color),
-    /* K2   */  be_nested_str_weak(parse_color),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(PART_INDICATOR),
-    /* K5   */  be_nested_str_weak(STATE_CHECKED),
-    }),
-    be_str_weak(set_bg_color10),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x8C100102,  //  0002  GETMET	R4	R0	K2
-      0x5C180200,  //  0003  MOVE	R6	R1
-      0x7C100400,  //  0004  CALL	R4	2
-      0xB8160600,  //  0005  GETNGBL	R5	K3
-      0x88140B04,  //  0006  GETMBR	R5	R5	K4
-      0xB81A0600,  //  0007  GETNGBL	R6	K3
-      0x88180D05,  //  0008  GETMBR	R6	R6	K5
-      0x30140A06,  //  0009  OR	R5	R5	R6
-      0x7C080600,  //  000A  CALL	R2	3
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_val
-********************************************************************/
-be_local_closure(lvh_switch_set_val,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_toggle),
-    }),
-    be_str_weak(set_val),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x80040400,  //  0003  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_radius20
-********************************************************************/
-be_local_closure(lvh_switch_get_radius20,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_style_radius),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(PART_KNOB),
-    }),
-    be_str_weak(get_radius20),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_bg_color20
-********************************************************************/
-be_local_closure(lvh_switch_get_bg_color20,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_style_bg_color),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(PART_KNOB),
-    }),
-    be_str_weak(get_bg_color20),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: lvh_switch
 ********************************************************************/
 extern const bclass be_class_lvh_obj;
 be_local_class(lvh_switch,
     0,
     &be_class_lvh_obj,
-    be_nested_map(10,
+    be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(set_radius20, -1), be_const_closure(lvh_switch_set_radius20_closure) },
-        { be_const_key_weak(get_val, -1), be_const_closure(lvh_switch_get_val_closure) },
-        { be_const_key_weak(get_bg_color10, 9), be_const_closure(lvh_switch_get_bg_color10_closure) },
-        { be_const_key_weak(set_bg_color20, 8), be_const_closure(lvh_switch_set_bg_color20_closure) },
-        { be_const_key_weak(set_bg_color10, -1), be_const_closure(lvh_switch_set_bg_color10_closure) },
+        { be_const_key_weak(get_val, 1), be_const_closure(lvh_switch_get_val_closure) },
         { be_const_key_weak(set_val, -1), be_const_closure(lvh_switch_set_val_closure) },
-        { be_const_key_weak(get_radius20, -1), be_const_closure(lvh_switch_get_radius20_closure) },
-        { be_const_key_weak(_lv_class, -1), be_const_class(be_class_lv_switch) },
-        { be_const_key_weak(get_bg_color20, -1), be_const_closure(lvh_switch_get_bg_color20_closure) },
         { be_const_key_weak(_lv_part2_selector, -1), be_const_int(196608) },
+        { be_const_key_weak(_lv_class, 0), be_const_class(be_class_lv_switch) },
     })),
     be_str_weak(lvh_switch)
 );
@@ -5345,27 +5279,26 @@ be_local_closure(lvh_arc_get_max,   /* name */
 ********************************************************************/
 be_local_closure(lvh_arc_get_line_width,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
+    5,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
     /* K1   */  be_nested_str_weak(get_arc_line_width),
-    /* K2   */  be_const_int(0),
     }),
     be_str_weak(get_line_width),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x580C0002,  //  0002  LDCONST	R3	K2
-      0x7C040400,  //  0003  CALL	R1	2
-      0x80040200,  //  0004  RET	1	R1
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
     })
   )
 );
@@ -5481,29 +5414,28 @@ be_local_closure(lvh_arc_get_line_width1,   /* name */
 ********************************************************************/
 be_local_closure(lvh_arc_set_line_width,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
+    7,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_lv_obj),
     /* K1   */  be_nested_str_weak(set_style_arc_width),
-    /* K2   */  be_const_int(0),
     }),
     be_str_weak(set_line_width),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x60100009,  //  0002  GETGBL	R4	G9
-      0x5C140200,  //  0003  MOVE	R5	R1
-      0x7C100200,  //  0004  CALL	R4	1
-      0x58140002,  //  0005  LDCONST	R5	K2
-      0x7C080600,  //  0006  CALL	R2	3
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x60140009,  //  0002  GETGBL	R5	G9
+      0x5C180200,  //  0003  MOVE	R6	R1
+      0x7C140200,  //  0004  CALL	R5	1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
       0x80000000,  //  0007  RET	0
     })
   )
@@ -6405,9 +6337,9 @@ be_local_closure(HASPmota_do_action,   /* name */
       0x780E0000,  //  0003  JMPF	R3	#0005
       0x80000600,  //  0004  RET	0
       0x880C0302,  //  0005  GETMBR	R3	R1	K2
-      0x88100104,  //  0006  GETMBR	R4	R0	K4
-      0x88140103,  //  0007  GETMBR	R5	R0	K3
-      0x94100A04,  //  0008  GETIDX	R4	R5	R4
+      0x88100103,  //  0006  GETMBR	R4	R0	K3
+      0x88140104,  //  0007  GETMBR	R5	R0	K4
+      0x94100805,  //  0008  GETIDX	R4	R4	R5
       0x4C140000,  //  0009  LDNIL	R5
       0x8C180105,  //  000A  GETMET	R6	R0	K5
       0x88200104,  //  000B  GETMBR	R8	R0	K4
@@ -6579,9 +6511,9 @@ be_local_closure(HASPmota_get_page_cur,   /* name */
     be_str_weak(get_page_cur),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x94040401,  //  0002  GETIDX	R1	R2	R1
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x94040202,  //  0002  GETIDX	R1	R1	R2
       0x80040200,  //  0003  RET	1	R1
     })
   )
@@ -7138,9 +7070,9 @@ be_local_closure(HASPmota__load,   /* name */
       0x7C240400,  //  0027  CALL	R9	2
       0x8C24010F,  //  0028  GETMET	R9	R0	K15
       0x5C2C1000,  //  0029  MOVE	R11	R8
-      0x88300102,  //  002A  GETMBR	R12	R0	K2
-      0x88340105,  //  002B  GETMBR	R13	R0	K5
-      0x94301A0C,  //  002C  GETIDX	R12	R13	R12
+      0x88300105,  //  002A  GETMBR	R12	R0	K5
+      0x88340102,  //  002B  GETMBR	R13	R0	K2
+      0x9430180D,  //  002C  GETIDX	R12	R12	R13
       0x7C240600,  //  002D  CALL	R9	3
       0x4C200000,  //  002E  LDNIL	R8
       0x8C240F10,  //  002F  GETMET	R9	R7	K16
@@ -7197,9 +7129,9 @@ be_local_closure(HASPmota_parse,   /* name */
       0x7C100400,  //  000B  CALL	R4	2
       0x8C100104,  //  000C  GETMET	R4	R0	K4
       0x5C180600,  //  000D  MOVE	R6	R3
-      0x881C0106,  //  000E  GETMBR	R7	R0	K6
-      0x88200105,  //  000F  GETMBR	R8	R0	K5
-      0x941C1007,  //  0010  GETIDX	R7	R8	R7
+      0x881C0105,  //  000E  GETMBR	R7	R0	K5
+      0x88200106,  //  000F  GETMBR	R8	R0	K6
+      0x941C0E08,  //  0010  GETIDX	R7	R7	R8
       0x7C100600,  //  0011  CALL	R4	3
       0x70020000,  //  0012  JMP		#0014
       0xB0060F08,  //  0013  RAISE	1	K7	K8
@@ -7273,7 +7205,7 @@ be_local_closure(HASPmota_sort,   /* name */
 ********************************************************************/
 be_local_closure(HASPmota_parse_obj,   /* name */
   be_nested_proto(
-    21,                          /* nstack */
+    20,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -7281,261 +7213,258 @@ be_local_closure(HASPmota_parse_obj,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[32]) {     /* constants */
+    ( &(const bvalue[30]) {     /* constants */
     /* K0   */  be_nested_str_weak(global),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(introspect),
-    /* K3   */  be_nested_str_weak(find),
-    /* K4   */  be_nested_str_weak(id),
-    /* K5   */  be_nested_str_weak(obj),
-    /* K6   */  be_nested_str_weak(get_page_cur),
-    /* K7   */  be_nested_str_weak(berry_run),
-    /* K8   */  be_nested_str_weak(nil),
-    /* K9   */  be_nested_str_weak(format),
-    /* K10  */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20compile_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(HSP_X3A_X20invalid_X20_X27id_X27_X3A_X20),
-    /* K13  */  be_nested_str_weak(_X20for_X20_X27obj_X27_X3A),
-    /* K14  */  be_nested_str_weak(parentid),
-    /* K15  */  be_nested_str_weak(get_obj),
-    /* K16  */  be_nested_str_weak(_lv_obj),
-    /* K17  */  be_nested_str_weak(get_scr),
-    /* K18  */  be_nested_str_weak(get),
-    /* K19  */  be_nested_str_weak(lvh_),
-    /* K20  */  be_nested_str_weak(class),
-    /* K21  */  be_nested_str_weak(lvh_obj),
-    /* K22  */  be_nested_str_weak(module),
-    /* K23  */  be_nested_str_weak(HSP_X3A_X20cannot_X20find_X20object_X20of_X20type_X20),
-    /* K24  */  be_nested_str_weak(set_obj),
-    /* K25  */  be_nested_str_weak(p_X25ib_X25i),
-    /* K26  */  be_nested_str_weak(function),
-    /* K27  */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20run_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    /* K28  */  be_const_int(0),
-    /* K29  */  be_nested_str_weak(HSP_X3A_X20cannot_X20specify_X20_X27obj_X27_X20for_X20_X27id_X27_X3A0),
-    /* K30  */  be_nested_str_weak(keys),
-    /* K31  */  be_nested_str_weak(stop_iteration),
+    /* K1   */  be_nested_str_weak(introspect),
+    /* K2   */  be_nested_str_weak(find),
+    /* K3   */  be_nested_str_weak(id),
+    /* K4   */  be_nested_str_weak(obj),
+    /* K5   */  be_nested_str_weak(get_page_cur),
+    /* K6   */  be_nested_str_weak(berry_run),
+    /* K7   */  be_nested_str_weak(nil),
+    /* K8   */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20compile_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(HSP_X3A_X20invalid_X20_X27id_X27_X3A_X20),
+    /* K11  */  be_nested_str_weak(_X20for_X20_X27obj_X27_X3A),
+    /* K12  */  be_nested_str_weak(parentid),
+    /* K13  */  be_nested_str_weak(get_obj),
+    /* K14  */  be_nested_str_weak(_lv_obj),
+    /* K15  */  be_nested_str_weak(get_scr),
+    /* K16  */  be_nested_str_weak(get),
+    /* K17  */  be_nested_str_weak(lvh_),
+    /* K18  */  be_nested_str_weak(class),
+    /* K19  */  be_nested_str_weak(lvh_obj),
+    /* K20  */  be_nested_str_weak(module),
+    /* K21  */  be_nested_str_weak(HSP_X3A_X20cannot_X20find_X20object_X20of_X20type_X20),
+    /* K22  */  be_nested_str_weak(set_obj),
+    /* K23  */  be_nested_str_weak(p_X25ib_X25i),
+    /* K24  */  be_nested_str_weak(function),
+    /* K25  */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20run_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+    /* K26  */  be_const_int(0),
+    /* K27  */  be_nested_str_weak(HSP_X3A_X20cannot_X20specify_X20_X27obj_X27_X20for_X20_X27id_X27_X3A0),
+    /* K28  */  be_nested_str_weak(keys),
+    /* K29  */  be_nested_str_weak(stop_iteration),
     }),
     be_str_weak(parse_obj),
     &be_const_str_solidified,
-    ( &(const binstruction[218]) {  /* code */
+    ( &(const binstruction[217]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0xA4120200,  //  0001  IMPORT	R4	K1
-      0xA4160400,  //  0002  IMPORT	R5	K2
-      0x60180009,  //  0003  GETGBL	R6	G9
-      0x8C1C0303,  //  0004  GETMET	R7	R1	K3
-      0x58240004,  //  0005  LDCONST	R9	K4
-      0x7C1C0400,  //  0006  CALL	R7	2
-      0x7C180200,  //  0007  CALL	R6	1
-      0x601C0008,  //  0008  GETGBL	R7	G8
-      0x8C200303,  //  0009  GETMET	R8	R1	K3
-      0x58280005,  //  000A  LDCONST	R10	K5
-      0x7C200400,  //  000B  CALL	R8	2
-      0x7C1C0200,  //  000C  CALL	R7	1
-      0x4C200000,  //  000D  LDNIL	R8
-      0x8C240106,  //  000E  GETMET	R9	R0	K6
-      0x7C240200,  //  000F  CALL	R9	1
-      0x60280008,  //  0010  GETGBL	R10	G8
-      0x8C2C0303,  //  0011  GETMET	R11	R1	K3
-      0x58340007,  //  0012  LDCONST	R13	K7
-      0x7C2C0400,  //  0013  CALL	R11	2
-      0x7C280200,  //  0014  CALL	R10	1
-      0x4C2C0000,  //  0015  LDNIL	R11
-      0x20301508,  //  0016  NE	R12	R10	K8
-      0x78320012,  //  0017  JMPF	R12	#002B
-      0xA8020005,  //  0018  EXBLK	0	#001F
-      0x6030000D,  //  0019  GETGBL	R12	G13
-      0x5C341400,  //  001A  MOVE	R13	R10
-      0x7C300200,  //  001B  CALL	R12	1
-      0x5C2C1800,  //  001C  MOVE	R11	R12
-      0xA8040001,  //  001D  EXBLK	1	1
-      0x7002000B,  //  001E  JMP		#002B
-      0xAC300002,  //  001F  CATCH	R12	0	2
-      0x70020008,  //  0020  JMP		#002A
-      0x60380001,  //  0021  GETGBL	R14	G1
-      0x8C3C0909,  //  0022  GETMET	R15	R4	K9
-      0x5844000A,  //  0023  LDCONST	R17	K10
-      0x5C481400,  //  0024  MOVE	R18	R10
-      0x5C4C1800,  //  0025  MOVE	R19	R12
-      0x5C501A00,  //  0026  MOVE	R20	R13
-      0x7C3C0A00,  //  0027  CALL	R15	5
-      0x7C380200,  //  0028  CALL	R14	1
-      0x70020000,  //  0029  JMP		#002B
-      0xB0080000,  //  002A  RAISE	2	R0	R0
-      0x4C300000,  //  002B  LDNIL	R12
-      0x1C300C0C,  //  002C  EQ	R12	R6	R12
-      0x78320000,  //  002D  JMPF	R12	#002F
-      0x80001800,  //  002E  RET	0
-      0x20300F08,  //  002F  NE	R12	R7	K8
-      0x7832006E,  //  0030  JMPF	R12	#00A0
-      0x4C300000,  //  0031  LDNIL	R12
-      0x20300C0C,  //  0032  NE	R12	R6	R12
-      0x7832006B,  //  0033  JMPF	R12	#00A0
-      0x14300D0B,  //  0034  LT	R12	R6	K11
-      0x74320002,  //  0035  JMPT	R12	#0039
-      0x543200FD,  //  0036  LDINT	R12	254
-      0x24300C0C,  //  0037  GT	R12	R6	R12
-      0x78320008,  //  0038  JMPF	R12	#0042
-      0x60300001,  //  0039  GETGBL	R12	G1
-      0x60340008,  //  003A  GETGBL	R13	G8
-      0x5C380C00,  //  003B  MOVE	R14	R6
-      0x7C340200,  //  003C  CALL	R13	1
-      0x0036180D,  //  003D  ADD	R13	K12	R13
-      0x00341B0D,  //  003E  ADD	R13	R13	K13
-      0x00341A07,  //  003F  ADD	R13	R13	R7
-      0x7C300200,  //  0040  CALL	R12	1
-      0x80001800,  //  0041  RET	0
-      0x4C300000,  //  0042  LDNIL	R12
-      0x60340009,  //  0043  GETGBL	R13	G9
-      0x8C380303,  //  0044  GETMET	R14	R1	K3
-      0x5840000E,  //  0045  LDCONST	R16	K14
-      0x7C380400,  //  0046  CALL	R14	2
-      0x7C340200,  //  0047  CALL	R13	1
-      0x4C380000,  //  0048  LDNIL	R14
-      0x20381A0E,  //  0049  NE	R14	R13	R14
-      0x783A0006,  //  004A  JMPF	R14	#0052
-      0x8C38130F,  //  004B  GETMET	R14	R9	K15
-      0x5C401A00,  //  004C  MOVE	R16	R13
-      0x7C380400,  //  004D  CALL	R14	2
-      0x4C3C0000,  //  004E  LDNIL	R15
-      0x203C1C0F,  //  004F  NE	R15	R14	R15
-      0x783E0000,  //  0050  JMPF	R15	#0052
-      0x88301D10,  //  0051  GETMBR	R12	R14	K16
-      0x4C380000,  //  0052  LDNIL	R14
-      0x1C38180E,  //  0053  EQ	R14	R12	R14
-      0x783A0002,  //  0054  JMPF	R14	#0058
-      0x8C381311,  //  0055  GETMET	R14	R9	K17
-      0x7C380200,  //  0056  CALL	R14	1
-      0x5C301C00,  //  0057  MOVE	R12	R14
-      0x8C380B12,  //  0058  GETMET	R14	R5	K18
-      0x5C400000,  //  0059  MOVE	R16	R0
-      0x00462607,  //  005A  ADD	R17	K19	R7
-      0x7C380600,  //  005B  CALL	R14	3
+      0x60140009,  //  0002  GETGBL	R5	G9
+      0x8C180302,  //  0003  GETMET	R6	R1	K2
+      0x58200003,  //  0004  LDCONST	R8	K3
+      0x7C180400,  //  0005  CALL	R6	2
+      0x7C140200,  //  0006  CALL	R5	1
+      0x60180008,  //  0007  GETGBL	R6	G8
+      0x8C1C0302,  //  0008  GETMET	R7	R1	K2
+      0x58240004,  //  0009  LDCONST	R9	K4
+      0x7C1C0400,  //  000A  CALL	R7	2
+      0x7C180200,  //  000B  CALL	R6	1
+      0x4C1C0000,  //  000C  LDNIL	R7
+      0x8C200105,  //  000D  GETMET	R8	R0	K5
+      0x7C200200,  //  000E  CALL	R8	1
+      0x60240008,  //  000F  GETGBL	R9	G8
+      0x8C280302,  //  0010  GETMET	R10	R1	K2
+      0x58300006,  //  0011  LDCONST	R12	K6
+      0x7C280400,  //  0012  CALL	R10	2
+      0x7C240200,  //  0013  CALL	R9	1
+      0x4C280000,  //  0014  LDNIL	R10
+      0x202C1307,  //  0015  NE	R11	R9	K7
+      0x782E0012,  //  0016  JMPF	R11	#002A
+      0xA8020005,  //  0017  EXBLK	0	#001E
+      0x602C000D,  //  0018  GETGBL	R11	G13
+      0x5C301200,  //  0019  MOVE	R12	R9
+      0x7C2C0200,  //  001A  CALL	R11	1
+      0x5C281600,  //  001B  MOVE	R10	R11
+      0xA8040001,  //  001C  EXBLK	1	1
+      0x7002000B,  //  001D  JMP		#002A
+      0xAC2C0002,  //  001E  CATCH	R11	0	2
+      0x70020008,  //  001F  JMP		#0029
+      0x60340001,  //  0020  GETGBL	R13	G1
+      0x60380018,  //  0021  GETGBL	R14	G24
+      0x583C0008,  //  0022  LDCONST	R15	K8
+      0x5C401200,  //  0023  MOVE	R16	R9
+      0x5C441600,  //  0024  MOVE	R17	R11
+      0x5C481800,  //  0025  MOVE	R18	R12
+      0x7C380800,  //  0026  CALL	R14	4
+      0x7C340200,  //  0027  CALL	R13	1
+      0x70020000,  //  0028  JMP		#002A
+      0xB0080000,  //  0029  RAISE	2	R0	R0
+      0x4C2C0000,  //  002A  LDNIL	R11
+      0x1C2C0A0B,  //  002B  EQ	R11	R5	R11
+      0x782E0000,  //  002C  JMPF	R11	#002E
+      0x80001600,  //  002D  RET	0
+      0x202C0D07,  //  002E  NE	R11	R6	K7
+      0x782E006E,  //  002F  JMPF	R11	#009F
+      0x4C2C0000,  //  0030  LDNIL	R11
+      0x202C0A0B,  //  0031  NE	R11	R5	R11
+      0x782E006B,  //  0032  JMPF	R11	#009F
+      0x142C0B09,  //  0033  LT	R11	R5	K9
+      0x742E0002,  //  0034  JMPT	R11	#0038
+      0x542E00FD,  //  0035  LDINT	R11	254
+      0x242C0A0B,  //  0036  GT	R11	R5	R11
+      0x782E0008,  //  0037  JMPF	R11	#0041
+      0x602C0001,  //  0038  GETGBL	R11	G1
+      0x60300008,  //  0039  GETGBL	R12	G8
+      0x5C340A00,  //  003A  MOVE	R13	R5
+      0x7C300200,  //  003B  CALL	R12	1
+      0x0032140C,  //  003C  ADD	R12	K10	R12
+      0x0030190B,  //  003D  ADD	R12	R12	K11
+      0x00301806,  //  003E  ADD	R12	R12	R6
+      0x7C2C0200,  //  003F  CALL	R11	1
+      0x80001600,  //  0040  RET	0
+      0x4C2C0000,  //  0041  LDNIL	R11
+      0x60300009,  //  0042  GETGBL	R12	G9
+      0x8C340302,  //  0043  GETMET	R13	R1	K2
+      0x583C000C,  //  0044  LDCONST	R15	K12
+      0x7C340400,  //  0045  CALL	R13	2
+      0x7C300200,  //  0046  CALL	R12	1
+      0x4C340000,  //  0047  LDNIL	R13
+      0x2034180D,  //  0048  NE	R13	R12	R13
+      0x78360006,  //  0049  JMPF	R13	#0051
+      0x8C34110D,  //  004A  GETMET	R13	R8	K13
+      0x5C3C1800,  //  004B  MOVE	R15	R12
+      0x7C340400,  //  004C  CALL	R13	2
+      0x4C380000,  //  004D  LDNIL	R14
+      0x20381A0E,  //  004E  NE	R14	R13	R14
+      0x783A0000,  //  004F  JMPF	R14	#0051
+      0x882C1B0E,  //  0050  GETMBR	R11	R13	K14
+      0x4C340000,  //  0051  LDNIL	R13
+      0x1C34160D,  //  0052  EQ	R13	R11	R13
+      0x78360002,  //  0053  JMPF	R13	#0057
+      0x8C34110F,  //  0054  GETMET	R13	R8	K15
+      0x7C340200,  //  0055  CALL	R13	1
+      0x5C2C1A00,  //  0056  MOVE	R11	R13
+      0x8C340910,  //  0057  GETMET	R13	R4	K16
+      0x5C3C0000,  //  0058  MOVE	R15	R0
+      0x00422206,  //  0059  ADD	R16	K17	R6
+      0x7C340600,  //  005A  CALL	R13	3
+      0x4C380000,  //  005B  LDNIL	R14
       0x4C3C0000,  //  005C  LDNIL	R15
-      0x4C400000,  //  005D  LDNIL	R16
-      0x1C401C10,  //  005E  EQ	R16	R14	R16
-      0x78420010,  //  005F  JMPF	R16	#0071
-      0x8C400B12,  //  0060  GETMET	R16	R5	K18
-      0x5C480600,  //  0061  MOVE	R18	R3
-      0x5C4C0E00,  //  0062  MOVE	R19	R7
-      0x7C400600,  //  0063  CALL	R16	3
-      0x4C440000,  //  0064  LDNIL	R17
-      0x20442011,  //  0065  NE	R17	R16	R17
-      0x78460009,  //  0066  JMPF	R17	#0071
-      0x60440004,  //  0067  GETGBL	R17	G4
-      0x5C482000,  //  0068  MOVE	R18	R16
-      0x7C440200,  //  0069  CALL	R17	1
-      0x1C442314,  //  006A  EQ	R17	R17	K20
-      0x78460004,  //  006B  JMPF	R17	#0071
-      0x5C442000,  //  006C  MOVE	R17	R16
-      0x5C481800,  //  006D  MOVE	R18	R12
-      0x7C440200,  //  006E  CALL	R17	1
-      0x5C3C2200,  //  006F  MOVE	R15	R17
-      0x88380115,  //  0070  GETMBR	R14	R0	K21
-      0x4C400000,  //  0071  LDNIL	R16
-      0x1C401C10,  //  0072  EQ	R16	R14	R16
-      0x7842000F,  //  0073  JMPF	R16	#0084
-      0x8C400B16,  //  0074  GETMET	R16	R5	K22
-      0x5C480E00,  //  0075  MOVE	R18	R7
-      0x7C400400,  //  0076  CALL	R16	2
-      0x4C440000,  //  0077  LDNIL	R17
-      0x20442011,  //  0078  NE	R17	R16	R17
-      0x78460009,  //  0079  JMPF	R17	#0084
-      0x60440004,  //  007A  GETGBL	R17	G4
-      0x5C482000,  //  007B  MOVE	R18	R16
-      0x7C440200,  //  007C  CALL	R17	1
-      0x1C442314,  //  007D  EQ	R17	R17	K20
-      0x78460004,  //  007E  JMPF	R17	#0084
-      0x5C442000,  //  007F  MOVE	R17	R16
-      0x5C481800,  //  0080  MOVE	R18	R12
-      0x7C440200,  //  0081  CALL	R17	1
-      0x5C3C2200,  //  0082  MOVE	R15	R17
-      0x88380115,  //  0083  GETMBR	R14	R0	K21
-      0x4C400000,  //  0084  LDNIL	R16
-      0x1C401C10,  //  0085  EQ	R16	R14	R16
-      0x78420006,  //  0086  JMPF	R16	#008E
-      0x60400001,  //  0087  GETGBL	R16	G1
-      0x60440008,  //  0088  GETGBL	R17	G8
-      0x5C480E00,  //  0089  MOVE	R18	R7
-      0x7C440200,  //  008A  CALL	R17	1
-      0x00462E11,  //  008B  ADD	R17	K23	R17
-      0x7C400200,  //  008C  CALL	R16	1
-      0x80002000,  //  008D  RET	0
-      0x5C401C00,  //  008E  MOVE	R16	R14
-      0x5C441800,  //  008F  MOVE	R17	R12
-      0x5C480400,  //  0090  MOVE	R18	R2
-      0x5C4C0200,  //  0091  MOVE	R19	R1
-      0x5C501E00,  //  0092  MOVE	R20	R15
-      0x7C400800,  //  0093  CALL	R16	4
-      0x5C202000,  //  0094  MOVE	R8	R16
-      0x8C401318,  //  0095  GETMET	R16	R9	K24
-      0x5C480C00,  //  0096  MOVE	R18	R6
-      0x5C4C1000,  //  0097  MOVE	R19	R8
-      0x7C400600,  //  0098  CALL	R16	3
-      0x8C400909,  //  0099  GETMET	R16	R4	K9
-      0x58480019,  //  009A  LDCONST	R18	K25
-      0x8C4C1304,  //  009B  GETMET	R19	R9	K4
-      0x7C4C0200,  //  009C  CALL	R19	1
-      0x5C500C00,  //  009D  MOVE	R20	R6
-      0x7C400800,  //  009E  CALL	R16	4
-      0x900C2008,  //  009F  SETMBR	R3	R16	R8
-      0x4C300000,  //  00A0  LDNIL	R12
-      0x2030160C,  //  00A1  NE	R12	R11	R12
-      0x78320018,  //  00A2  JMPF	R12	#00BC
-      0xA802000B,  //  00A3  EXBLK	0	#00B0
-      0x5C301600,  //  00A4  MOVE	R12	R11
-      0x7C300000,  //  00A5  CALL	R12	0
-      0x60340004,  //  00A6  GETGBL	R13	G4
-      0x5C381800,  //  00A7  MOVE	R14	R12
-      0x7C340200,  //  00A8  CALL	R13	1
-      0x1C341B1A,  //  00A9  EQ	R13	R13	K26
-      0x78360002,  //  00AA  JMPF	R13	#00AE
-      0x5C341800,  //  00AB  MOVE	R13	R12
-      0x5C381000,  //  00AC  MOVE	R14	R8
-      0x7C340200,  //  00AD  CALL	R13	1
-      0xA8040001,  //  00AE  EXBLK	1	1
-      0x7002000B,  //  00AF  JMP		#00BC
-      0xAC300002,  //  00B0  CATCH	R12	0	2
-      0x70020008,  //  00B1  JMP		#00BB
-      0x60380001,  //  00B2  GETGBL	R14	G1
-      0x8C3C0909,  //  00B3  GETMET	R15	R4	K9
-      0x5844001B,  //  00B4  LDCONST	R17	K27
-      0x5C481400,  //  00B5  MOVE	R18	R10
-      0x5C4C1800,  //  00B6  MOVE	R19	R12
-      0x5C501A00,  //  00B7  MOVE	R20	R13
-      0x7C3C0A00,  //  00B8  CALL	R15	5
-      0x7C380200,  //  00B9  CALL	R14	1
-      0x70020000,  //  00BA  JMP		#00BC
-      0xB0080000,  //  00BB  RAISE	2	R0	R0
-      0x1C300D1C,  //  00BC  EQ	R12	R6	K28
-      0x78320005,  //  00BD  JMPF	R12	#00C4
-      0x20300F08,  //  00BE  NE	R12	R7	K8
-      0x78320003,  //  00BF  JMPF	R12	#00C4
-      0x60300001,  //  00C0  GETGBL	R12	G1
-      0x5834001D,  //  00C1  LDCONST	R13	K29
-      0x7C300200,  //  00C2  CALL	R12	1
-      0x80001800,  //  00C3  RET	0
-      0x1C300D1C,  //  00C4  EQ	R12	R6	K28
-      0x78320005,  //  00C5  JMPF	R12	#00CC
-      0x8C300106,  //  00C6  GETMET	R12	R0	K6
-      0x7C300200,  //  00C7  CALL	R12	1
-      0x8C30190F,  //  00C8  GETMET	R12	R12	K15
-      0x5838001C,  //  00C9  LDCONST	R14	K28
-      0x7C300400,  //  00CA  CALL	R12	2
-      0x5C201800,  //  00CB  MOVE	R8	R12
-      0x60300010,  //  00CC  GETGBL	R12	G16
-      0x8C34031E,  //  00CD  GETMET	R13	R1	K30
-      0x7C340200,  //  00CE  CALL	R13	1
-      0x7C300200,  //  00CF  CALL	R12	1
-      0xA8020004,  //  00D0  EXBLK	0	#00D6
-      0x5C341800,  //  00D1  MOVE	R13	R12
-      0x7C340000,  //  00D2  CALL	R13	0
-      0x9438020D,  //  00D3  GETIDX	R14	R1	R13
-      0x90201A0E,  //  00D4  SETMBR	R8	R13	R14
-      0x7001FFFA,  //  00D5  JMP		#00D1
-      0x5830001F,  //  00D6  LDCONST	R12	K31
-      0xAC300200,  //  00D7  CATCH	R12	1	0
-      0xB0080000,  //  00D8  RAISE	2	R0	R0
-      0x80000000,  //  00D9  RET	0
+      0x1C3C1A0F,  //  005D  EQ	R15	R13	R15
+      0x783E0010,  //  005E  JMPF	R15	#0070
+      0x8C3C0910,  //  005F  GETMET	R15	R4	K16
+      0x5C440600,  //  0060  MOVE	R17	R3
+      0x5C480C00,  //  0061  MOVE	R18	R6
+      0x7C3C0600,  //  0062  CALL	R15	3
+      0x4C400000,  //  0063  LDNIL	R16
+      0x20401E10,  //  0064  NE	R16	R15	R16
+      0x78420009,  //  0065  JMPF	R16	#0070
+      0x60400004,  //  0066  GETGBL	R16	G4
+      0x5C441E00,  //  0067  MOVE	R17	R15
+      0x7C400200,  //  0068  CALL	R16	1
+      0x1C402112,  //  0069  EQ	R16	R16	K18
+      0x78420004,  //  006A  JMPF	R16	#0070
+      0x5C401E00,  //  006B  MOVE	R16	R15
+      0x5C441600,  //  006C  MOVE	R17	R11
+      0x7C400200,  //  006D  CALL	R16	1
+      0x5C382000,  //  006E  MOVE	R14	R16
+      0x88340113,  //  006F  GETMBR	R13	R0	K19
+      0x4C3C0000,  //  0070  LDNIL	R15
+      0x1C3C1A0F,  //  0071  EQ	R15	R13	R15
+      0x783E000F,  //  0072  JMPF	R15	#0083
+      0x8C3C0914,  //  0073  GETMET	R15	R4	K20
+      0x5C440C00,  //  0074  MOVE	R17	R6
+      0x7C3C0400,  //  0075  CALL	R15	2
+      0x4C400000,  //  0076  LDNIL	R16
+      0x20401E10,  //  0077  NE	R16	R15	R16
+      0x78420009,  //  0078  JMPF	R16	#0083
+      0x60400004,  //  0079  GETGBL	R16	G4
+      0x5C441E00,  //  007A  MOVE	R17	R15
+      0x7C400200,  //  007B  CALL	R16	1
+      0x1C402112,  //  007C  EQ	R16	R16	K18
+      0x78420004,  //  007D  JMPF	R16	#0083
+      0x5C401E00,  //  007E  MOVE	R16	R15
+      0x5C441600,  //  007F  MOVE	R17	R11
+      0x7C400200,  //  0080  CALL	R16	1
+      0x5C382000,  //  0081  MOVE	R14	R16
+      0x88340113,  //  0082  GETMBR	R13	R0	K19
+      0x4C3C0000,  //  0083  LDNIL	R15
+      0x1C3C1A0F,  //  0084  EQ	R15	R13	R15
+      0x783E0006,  //  0085  JMPF	R15	#008D
+      0x603C0001,  //  0086  GETGBL	R15	G1
+      0x60400008,  //  0087  GETGBL	R16	G8
+      0x5C440C00,  //  0088  MOVE	R17	R6
+      0x7C400200,  //  0089  CALL	R16	1
+      0x00422A10,  //  008A  ADD	R16	K21	R16
+      0x7C3C0200,  //  008B  CALL	R15	1
+      0x80001E00,  //  008C  RET	0
+      0x5C3C1A00,  //  008D  MOVE	R15	R13
+      0x5C401600,  //  008E  MOVE	R16	R11
+      0x5C440400,  //  008F  MOVE	R17	R2
+      0x5C480200,  //  0090  MOVE	R18	R1
+      0x5C4C1C00,  //  0091  MOVE	R19	R14
+      0x7C3C0800,  //  0092  CALL	R15	4
+      0x5C1C1E00,  //  0093  MOVE	R7	R15
+      0x8C3C1116,  //  0094  GETMET	R15	R8	K22
+      0x5C440A00,  //  0095  MOVE	R17	R5
+      0x5C480E00,  //  0096  MOVE	R18	R7
+      0x7C3C0600,  //  0097  CALL	R15	3
+      0x603C0018,  //  0098  GETGBL	R15	G24
+      0x58400017,  //  0099  LDCONST	R16	K23
+      0x8C441103,  //  009A  GETMET	R17	R8	K3
+      0x7C440200,  //  009B  CALL	R17	1
+      0x5C480A00,  //  009C  MOVE	R18	R5
+      0x7C3C0600,  //  009D  CALL	R15	3
+      0x900C1E07,  //  009E  SETMBR	R3	R15	R7
+      0x4C2C0000,  //  009F  LDNIL	R11
+      0x202C140B,  //  00A0  NE	R11	R10	R11
+      0x782E0018,  //  00A1  JMPF	R11	#00BB
+      0xA802000B,  //  00A2  EXBLK	0	#00AF
+      0x5C2C1400,  //  00A3  MOVE	R11	R10
+      0x7C2C0000,  //  00A4  CALL	R11	0
+      0x60300004,  //  00A5  GETGBL	R12	G4
+      0x5C341600,  //  00A6  MOVE	R13	R11
+      0x7C300200,  //  00A7  CALL	R12	1
+      0x1C301918,  //  00A8  EQ	R12	R12	K24
+      0x78320002,  //  00A9  JMPF	R12	#00AD
+      0x5C301600,  //  00AA  MOVE	R12	R11
+      0x5C340E00,  //  00AB  MOVE	R13	R7
+      0x7C300200,  //  00AC  CALL	R12	1
+      0xA8040001,  //  00AD  EXBLK	1	1
+      0x7002000B,  //  00AE  JMP		#00BB
+      0xAC2C0002,  //  00AF  CATCH	R11	0	2
+      0x70020008,  //  00B0  JMP		#00BA
+      0x60340001,  //  00B1  GETGBL	R13	G1
+      0x60380018,  //  00B2  GETGBL	R14	G24
+      0x583C0019,  //  00B3  LDCONST	R15	K25
+      0x5C401200,  //  00B4  MOVE	R16	R9
+      0x5C441600,  //  00B5  MOVE	R17	R11
+      0x5C481800,  //  00B6  MOVE	R18	R12
+      0x7C380800,  //  00B7  CALL	R14	4
+      0x7C340200,  //  00B8  CALL	R13	1
+      0x70020000,  //  00B9  JMP		#00BB
+      0xB0080000,  //  00BA  RAISE	2	R0	R0
+      0x1C2C0B1A,  //  00BB  EQ	R11	R5	K26
+      0x782E0005,  //  00BC  JMPF	R11	#00C3
+      0x202C0D07,  //  00BD  NE	R11	R6	K7
+      0x782E0003,  //  00BE  JMPF	R11	#00C3
+      0x602C0001,  //  00BF  GETGBL	R11	G1
+      0x5830001B,  //  00C0  LDCONST	R12	K27
+      0x7C2C0200,  //  00C1  CALL	R11	1
+      0x80001600,  //  00C2  RET	0
+      0x1C2C0B1A,  //  00C3  EQ	R11	R5	K26
+      0x782E0005,  //  00C4  JMPF	R11	#00CB
+      0x8C2C0105,  //  00C5  GETMET	R11	R0	K5
+      0x7C2C0200,  //  00C6  CALL	R11	1
+      0x8C2C170D,  //  00C7  GETMET	R11	R11	K13
+      0x5834001A,  //  00C8  LDCONST	R13	K26
+      0x7C2C0400,  //  00C9  CALL	R11	2
+      0x5C1C1600,  //  00CA  MOVE	R7	R11
+      0x602C0010,  //  00CB  GETGBL	R11	G16
+      0x8C30031C,  //  00CC  GETMET	R12	R1	K28
+      0x7C300200,  //  00CD  CALL	R12	1
+      0x7C2C0200,  //  00CE  CALL	R11	1
+      0xA8020004,  //  00CF  EXBLK	0	#00D5
+      0x5C301600,  //  00D0  MOVE	R12	R11
+      0x7C300000,  //  00D1  CALL	R12	0
+      0x9434020C,  //  00D2  GETIDX	R13	R1	R12
+      0x901C180D,  //  00D3  SETMBR	R7	R12	R13
+      0x7001FFFA,  //  00D4  JMP		#00D0
+      0x582C001D,  //  00D5  LDCONST	R11	K29
+      0xAC2C0200,  //  00D6  CATCH	R11	1	0
+      0xB0080000,  //  00D7  RAISE	2	R0	R0
+      0x80000000,  //  00D8  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_tasmota/src/embedded/tasmota_class.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/tasmota_class.be
@@ -428,6 +428,10 @@ class Tasmota
           return true
         except .. as e, m
           print(format("BRY: failed to run compiled code '%s' - %s", e, m))
+          if self._debug_present
+            import debug
+            debug.traceback()
+          end
         end
       end
       return false

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
@@ -1803,20 +1803,25 @@ be_local_closure(Tasmota_load,   /* name */
         8,                          /* nstack */
         1,                          /* argc */
         0,                          /* varg */
-        0,                          /* has upvals */
-        NULL,                       /* no upvals */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
+        ( &(const bvalue[ 4]) {     /* constants */
         /* K0   */  be_nested_str(BRY_X3A_X20failed_X20to_X20run_X20compiled_X20code_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+        /* K1   */  be_nested_str(_debug_present),
+        /* K2   */  be_nested_str(debug),
+        /* K3   */  be_nested_str(traceback),
         }),
         &be_const_str_try_run_compiled,
         &be_const_str_solidified,
-        ( &(const binstruction[24]) {  /* code */
+        ( &(const binstruction[30]) {  /* code */
           0x4C040000,  //  0000  LDNIL	R1
           0x20040001,  //  0001  NE	R1	R0	R1
-          0x78060012,  //  0002  JMPF	R1	#0016
+          0x78060018,  //  0002  JMPF	R1	#001C
           0xA8020006,  //  0003  EXBLK	0	#000B
           0x5C040000,  //  0004  MOVE	R1	R0
           0x7C040000,  //  0005  CALL	R1	0
@@ -1824,9 +1829,9 @@ be_local_closure(Tasmota_load,   /* name */
           0xA8040001,  //  0007  EXBLK	1	1
           0x80040200,  //  0008  RET	1	R1
           0xA8040001,  //  0009  EXBLK	1	1
-          0x7002000A,  //  000A  JMP		#0016
+          0x70020010,  //  000A  JMP		#001C
           0xAC040002,  //  000B  CATCH	R1	0	2
-          0x70020007,  //  000C  JMP		#0015
+          0x7002000D,  //  000C  JMP		#001B
           0x600C0001,  //  000D  GETGBL	R3	G1
           0x60100018,  //  000E  GETGBL	R4	G24
           0x58140000,  //  000F  LDCONST	R5	K0
@@ -1834,10 +1839,16 @@ be_local_closure(Tasmota_load,   /* name */
           0x5C1C0400,  //  0011  MOVE	R7	R2
           0x7C100600,  //  0012  CALL	R4	3
           0x7C0C0200,  //  0013  CALL	R3	1
-          0x70020000,  //  0014  JMP		#0016
-          0xB0080000,  //  0015  RAISE	2	R0	R0
-          0x50040000,  //  0016  LDBOOL	R1	0	0
-          0x80040200,  //  0017  RET	1	R1
+          0x680C0000,  //  0014  GETUPV	R3	U0
+          0x880C0701,  //  0015  GETMBR	R3	R3	K1
+          0x780E0002,  //  0016  JMPF	R3	#001A
+          0xA40E0400,  //  0017  IMPORT	R3	K2
+          0x8C100703,  //  0018  GETMET	R4	R3	K3
+          0x7C100200,  //  0019  CALL	R4	1
+          0x70020000,  //  001A  JMP		#001C
+          0xB0080000,  //  001B  RAISE	2	R0	R0
+          0x50040000,  //  001C  LDBOOL	R1	0	0
+          0x80040200,  //  001D  RET	1	R1
         })
       ),
     }),
@@ -1867,7 +1878,7 @@ be_local_closure(Tasmota_load,   /* name */
     }),
     &be_const_str_load,
     &be_const_str_solidified,
-    ( &(const binstruction[176]) {  /* code */
+    ( &(const binstruction[180]) {  /* code */
       0x84080000,  //  0000  CLOSURE	R2	P0
       0x840C0001,  //  0001  CLOSURE	R3	P1
       0x84100002,  //  0002  CLOSURE	R4	P2
@@ -1880,170 +1891,174 @@ be_local_closure(Tasmota_load,   /* name */
       0x5C2C0200,  //  0009  MOVE	R11	R1
       0x7C280200,  //  000A  CALL	R10	1
       0x1C281502,  //  000B  EQ	R10	R10	K2
-      0x782A0001,  //  000C  JMPF	R10	#000F
+      0x782A0002,  //  000C  JMPF	R10	#0010
       0x50280000,  //  000D  LDBOOL	R10	0	0
-      0x80041400,  //  000E  RET	1	R10
-      0x94280302,  //  000F  GETIDX	R10	R1	K2
-      0x20281503,  //  0010  NE	R10	R10	K3
-      0x782A0000,  //  0011  JMPF	R10	#0013
-      0x00060601,  //  0012  ADD	R1	K3	R1
-      0x8C281104,  //  0013  GETMET	R10	R8	K4
-      0x5C300200,  //  0014  MOVE	R12	R1
-      0x58340005,  //  0015  LDCONST	R13	K5
-      0x7C280600,  //  0016  CALL	R10	3
-      0x942C1502,  //  0017  GETIDX	R11	R10	K2
-      0x5431FFFE,  //  0018  LDINT	R12	-1
-      0x9430140C,  //  0019  GETIDX	R12	R10	R12
-      0x6034000C,  //  001A  GETGBL	R13	G12
-      0x5C381400,  //  001B  MOVE	R14	R10
-      0x7C340200,  //  001C  CALL	R13	1
-      0x24341B06,  //  001D  GT	R13	R13	K6
-      0x8C381107,  //  001E  GETMET	R14	R8	K7
-      0x5C401800,  //  001F  MOVE	R16	R12
-      0x58440008,  //  0020  LDCONST	R17	K8
-      0x7C380600,  //  0021  CALL	R14	3
-      0x14381D02,  //  0022  LT	R14	R14	K2
-      0x783A0001,  //  0023  JMPF	R14	#0026
-      0x00040309,  //  0024  ADD	R1	R1	K9
-      0x00301909,  //  0025  ADD	R12	R12	K9
-      0x5439FFFC,  //  0026  LDINT	R14	-3
-      0x543DFFFE,  //  0027  LDINT	R15	-1
-      0x40381C0F,  //  0028  CONNECT	R14	R14	R15
-      0x9438180E,  //  0029  GETIDX	R14	R12	R14
-      0x1C381D09,  //  002A  EQ	R14	R14	K9
-      0x543DFFFB,  //  002B  LDINT	R15	-4
-      0x5441FFFE,  //  002C  LDINT	R16	-1
-      0x403C1E10,  //  002D  CONNECT	R15	R15	R16
-      0x943C180F,  //  002E  GETIDX	R15	R12	R15
-      0x1C3C1F0A,  //  002F  EQ	R15	R15	K10
-      0x5C401C00,  //  0030  MOVE	R16	R14
-      0x74420002,  //  0031  JMPT	R16	#0035
-      0x5C401E00,  //  0032  MOVE	R16	R15
-      0x74420000,  //  0033  JMPT	R16	#0035
-      0xB006170C,  //  0034  RAISE	1	K11	K12
-      0x8C40130D,  //  0035  GETMET	R16	R9	K13
-      0x5C480200,  //  0036  MOVE	R18	R1
-      0x7C400400,  //  0037  CALL	R16	2
-      0x783E0001,  //  0038  JMPF	R15	#003B
-      0x5C440200,  //  0039  MOVE	R17	R1
-      0x70020000,  //  003A  JMP		#003C
-      0x0044030E,  //  003B  ADD	R17	R1	K14
-      0x783E0005,  //  003C  JMPF	R15	#0043
-      0x4C480000,  //  003D  LDNIL	R18
-      0x1C482012,  //  003E  EQ	R18	R16	R18
-      0x784A0001,  //  003F  JMPF	R18	#0042
-      0x50480000,  //  0040  LDBOOL	R18	0	0
-      0x80042400,  //  0041  RET	1	R18
-      0x70020013,  //  0042  JMP		#0057
-      0x8C48130D,  //  0043  GETMET	R18	R9	K13
-      0x5C502200,  //  0044  MOVE	R20	R17
-      0x7C480400,  //  0045  CALL	R18	2
-      0x4C4C0000,  //  0046  LDNIL	R19
-      0x1C4C2013,  //  0047  EQ	R19	R16	R19
-      0x784E0004,  //  0048  JMPF	R19	#004E
-      0x4C4C0000,  //  0049  LDNIL	R19
-      0x1C4C2413,  //  004A  EQ	R19	R18	R19
-      0x784E0001,  //  004B  JMPF	R19	#004E
-      0x504C0000,  //  004C  LDBOOL	R19	0	0
-      0x80042600,  //  004D  RET	1	R19
-      0x4C4C0000,  //  004E  LDNIL	R19
-      0x204C2413,  //  004F  NE	R19	R18	R19
-      0x784E0005,  //  0050  JMPF	R19	#0057
+      0xA0000000,  //  000E  CLOSE	R0
+      0x80041400,  //  000F  RET	1	R10
+      0x94280302,  //  0010  GETIDX	R10	R1	K2
+      0x20281503,  //  0011  NE	R10	R10	K3
+      0x782A0000,  //  0012  JMPF	R10	#0014
+      0x00060601,  //  0013  ADD	R1	K3	R1
+      0x8C281104,  //  0014  GETMET	R10	R8	K4
+      0x5C300200,  //  0015  MOVE	R12	R1
+      0x58340005,  //  0016  LDCONST	R13	K5
+      0x7C280600,  //  0017  CALL	R10	3
+      0x942C1502,  //  0018  GETIDX	R11	R10	K2
+      0x5431FFFE,  //  0019  LDINT	R12	-1
+      0x9430140C,  //  001A  GETIDX	R12	R10	R12
+      0x6034000C,  //  001B  GETGBL	R13	G12
+      0x5C381400,  //  001C  MOVE	R14	R10
+      0x7C340200,  //  001D  CALL	R13	1
+      0x24341B06,  //  001E  GT	R13	R13	K6
+      0x8C381107,  //  001F  GETMET	R14	R8	K7
+      0x5C401800,  //  0020  MOVE	R16	R12
+      0x58440008,  //  0021  LDCONST	R17	K8
+      0x7C380600,  //  0022  CALL	R14	3
+      0x14381D02,  //  0023  LT	R14	R14	K2
+      0x783A0001,  //  0024  JMPF	R14	#0027
+      0x00040309,  //  0025  ADD	R1	R1	K9
+      0x00301909,  //  0026  ADD	R12	R12	K9
+      0x5439FFFC,  //  0027  LDINT	R14	-3
+      0x543DFFFE,  //  0028  LDINT	R15	-1
+      0x40381C0F,  //  0029  CONNECT	R14	R14	R15
+      0x9438180E,  //  002A  GETIDX	R14	R12	R14
+      0x1C381D09,  //  002B  EQ	R14	R14	K9
+      0x543DFFFB,  //  002C  LDINT	R15	-4
+      0x5441FFFE,  //  002D  LDINT	R16	-1
+      0x403C1E10,  //  002E  CONNECT	R15	R15	R16
+      0x943C180F,  //  002F  GETIDX	R15	R12	R15
+      0x1C3C1F0A,  //  0030  EQ	R15	R15	K10
+      0x5C401C00,  //  0031  MOVE	R16	R14
+      0x74420002,  //  0032  JMPT	R16	#0036
+      0x5C401E00,  //  0033  MOVE	R16	R15
+      0x74420000,  //  0034  JMPT	R16	#0036
+      0xB006170C,  //  0035  RAISE	1	K11	K12
+      0x8C40130D,  //  0036  GETMET	R16	R9	K13
+      0x5C480200,  //  0037  MOVE	R18	R1
+      0x7C400400,  //  0038  CALL	R16	2
+      0x783E0001,  //  0039  JMPF	R15	#003C
+      0x5C440200,  //  003A  MOVE	R17	R1
+      0x70020000,  //  003B  JMP		#003D
+      0x0044030E,  //  003C  ADD	R17	R1	K14
+      0x783E0006,  //  003D  JMPF	R15	#0045
+      0x4C480000,  //  003E  LDNIL	R18
+      0x1C482012,  //  003F  EQ	R18	R16	R18
+      0x784A0002,  //  0040  JMPF	R18	#0044
+      0x50480000,  //  0041  LDBOOL	R18	0	0
+      0xA0000000,  //  0042  CLOSE	R0
+      0x80042400,  //  0043  RET	1	R18
+      0x70020014,  //  0044  JMP		#005A
+      0x8C48130D,  //  0045  GETMET	R18	R9	K13
+      0x5C502200,  //  0046  MOVE	R20	R17
+      0x7C480400,  //  0047  CALL	R18	2
+      0x4C4C0000,  //  0048  LDNIL	R19
+      0x1C4C2013,  //  0049  EQ	R19	R16	R19
+      0x784E0005,  //  004A  JMPF	R19	#0051
+      0x4C4C0000,  //  004B  LDNIL	R19
+      0x1C4C2413,  //  004C  EQ	R19	R18	R19
+      0x784E0002,  //  004D  JMPF	R19	#0051
+      0x504C0000,  //  004E  LDBOOL	R19	0	0
+      0xA0000000,  //  004F  CLOSE	R0
+      0x80042600,  //  0050  RET	1	R19
       0x4C4C0000,  //  0051  LDNIL	R19
-      0x1C4C2013,  //  0052  EQ	R19	R16	R19
-      0x744E0001,  //  0053  JMPT	R19	#0056
-      0x284C2410,  //  0054  GE	R19	R18	R16
-      0x784E0000,  //  0055  JMPF	R19	#0057
-      0x503C0200,  //  0056  LDBOOL	R15	1	0
-      0x78360005,  //  0057  JMPF	R13	#005E
-      0x00481705,  //  0058  ADD	R18	R11	K5
-      0x90021E12,  //  0059  SETMBR	R0	K15	R18
-      0x5C480400,  //  005A  MOVE	R18	R2
-      0x884C010F,  //  005B  GETMBR	R19	R0	K15
-      0x7C480200,  //  005C  CALL	R18	1
-      0x70020000,  //  005D  JMP		#005F
-      0x90021F10,  //  005E  SETMBR	R0	K15	K16
-      0x4C480000,  //  005F  LDNIL	R18
-      0x783E0025,  //  0060  JMPF	R15	#0087
-      0x5C4C0800,  //  0061  MOVE	R19	R4
-      0x5C502200,  //  0062  MOVE	R20	R17
-      0x7C4C0200,  //  0063  CALL	R19	1
-      0x50500200,  //  0064  LDBOOL	R20	1	0
-      0x4C540000,  //  0065  LDNIL	R21
-      0x1C542615,  //  0066  EQ	R21	R19	R21
-      0x78560007,  //  0067  JMPF	R21	#0070
-      0x60540001,  //  0068  GETGBL	R21	G1
-      0x60580018,  //  0069  GETGBL	R22	G24
-      0x585C0011,  //  006A  LDCONST	R23	K17
-      0x5C602200,  //  006B  MOVE	R24	R17
-      0x7C580400,  //  006C  CALL	R22	2
-      0x7C540200,  //  006D  CALL	R21	1
-      0x50500000,  //  006E  LDBOOL	R20	0	0
-      0x7002000A,  //  006F  JMP		#007B
-      0x54560003,  //  0070  LDINT	R21	4
-      0x20542615,  //  0071  NE	R21	R19	R21
-      0x78560007,  //  0072  JMPF	R21	#007B
-      0x60540001,  //  0073  GETGBL	R21	G1
-      0x60580018,  //  0074  GETGBL	R22	G24
-      0x585C0012,  //  0075  LDCONST	R23	K18
-      0x5C602200,  //  0076  MOVE	R24	R17
-      0x5C642600,  //  0077  MOVE	R25	R19
-      0x7C580600,  //  0078  CALL	R22	3
-      0x7C540200,  //  0079  CALL	R21	1
-      0x50500000,  //  007A  LDBOOL	R20	0	0
-      0x78520003,  //  007B  JMPF	R20	#0080
-      0x5C540C00,  //  007C  MOVE	R21	R6
-      0x5C582200,  //  007D  MOVE	R22	R17
-      0x7C540200,  //  007E  CALL	R21	1
-      0x5C482A00,  //  007F  MOVE	R18	R21
-      0x4C540000,  //  0080  LDNIL	R21
-      0x1C542415,  //  0081  EQ	R21	R18	R21
-      0x78560003,  //  0082  JMPF	R21	#0087
-      0x5C540A00,  //  0083  MOVE	R21	R5
-      0x5C582200,  //  0084  MOVE	R22	R17
-      0x7C540200,  //  0085  CALL	R21	1
-      0x503C0000,  //  0086  LDBOOL	R15	0	0
-      0x783A0006,  //  0087  JMPF	R14	#008F
-      0x4C4C0000,  //  0088  LDNIL	R19
-      0x1C4C2413,  //  0089  EQ	R19	R18	R19
-      0x784E0003,  //  008A  JMPF	R19	#008F
-      0x5C4C0C00,  //  008B  MOVE	R19	R6
-      0x5C500200,  //  008C  MOVE	R20	R1
-      0x7C4C0200,  //  008D  CALL	R19	1
-      0x5C482600,  //  008E  MOVE	R18	R19
-      0x4C4C0000,  //  008F  LDNIL	R19
-      0x204C2413,  //  0090  NE	R19	R18	R19
-      0x784E0015,  //  0091  JMPF	R19	#00A8
-      0x5C4C1E00,  //  0092  MOVE	R19	R15
-      0x744E0013,  //  0093  JMPT	R19	#00A8
-      0x5C4C1A00,  //  0094  MOVE	R19	R13
-      0x744E0011,  //  0095  JMPT	R19	#00A8
-      0xA8020005,  //  0096  EXBLK	0	#009D
-      0x8C4C0113,  //  0097  GETMET	R19	R0	K19
-      0x5C542200,  //  0098  MOVE	R21	R17
-      0x5C582400,  //  0099  MOVE	R22	R18
-      0x7C4C0600,  //  009A  CALL	R19	3
-      0xA8040001,  //  009B  EXBLK	1	1
-      0x7002000A,  //  009C  JMP		#00A8
-      0xAC4C0001,  //  009D  CATCH	R19	0	1
-      0x70020007,  //  009E  JMP		#00A7
-      0x60500001,  //  009F  GETGBL	R20	G1
-      0x60540018,  //  00A0  GETGBL	R21	G24
-      0x58580014,  //  00A1  LDCONST	R22	K20
-      0x5C5C2200,  //  00A2  MOVE	R23	R17
-      0x5C602600,  //  00A3  MOVE	R24	R19
-      0x7C540600,  //  00A4  CALL	R21	3
-      0x7C500200,  //  00A5  CALL	R20	1
-      0x70020000,  //  00A6  JMP		#00A8
-      0xB0080000,  //  00A7  RAISE	2	R0	R0
-      0x5C4C0E00,  //  00A8  MOVE	R19	R7
-      0x5C502400,  //  00A9  MOVE	R20	R18
-      0x7C4C0200,  //  00AA  CALL	R19	1
-      0x78360002,  //  00AB  JMPF	R13	#00AF
-      0x5C500600,  //  00AC  MOVE	R20	R3
-      0x00541705,  //  00AD  ADD	R21	R11	K5
-      0x7C500200,  //  00AE  CALL	R20	1
-      0x80042600,  //  00AF  RET	1	R19
+      0x204C2413,  //  0052  NE	R19	R18	R19
+      0x784E0005,  //  0053  JMPF	R19	#005A
+      0x4C4C0000,  //  0054  LDNIL	R19
+      0x1C4C2013,  //  0055  EQ	R19	R16	R19
+      0x744E0001,  //  0056  JMPT	R19	#0059
+      0x284C2410,  //  0057  GE	R19	R18	R16
+      0x784E0000,  //  0058  JMPF	R19	#005A
+      0x503C0200,  //  0059  LDBOOL	R15	1	0
+      0x78360005,  //  005A  JMPF	R13	#0061
+      0x00481705,  //  005B  ADD	R18	R11	K5
+      0x90021E12,  //  005C  SETMBR	R0	K15	R18
+      0x5C480400,  //  005D  MOVE	R18	R2
+      0x884C010F,  //  005E  GETMBR	R19	R0	K15
+      0x7C480200,  //  005F  CALL	R18	1
+      0x70020000,  //  0060  JMP		#0062
+      0x90021F10,  //  0061  SETMBR	R0	K15	K16
+      0x4C480000,  //  0062  LDNIL	R18
+      0x783E0025,  //  0063  JMPF	R15	#008A
+      0x5C4C0800,  //  0064  MOVE	R19	R4
+      0x5C502200,  //  0065  MOVE	R20	R17
+      0x7C4C0200,  //  0066  CALL	R19	1
+      0x50500200,  //  0067  LDBOOL	R20	1	0
+      0x4C540000,  //  0068  LDNIL	R21
+      0x1C542615,  //  0069  EQ	R21	R19	R21
+      0x78560007,  //  006A  JMPF	R21	#0073
+      0x60540001,  //  006B  GETGBL	R21	G1
+      0x60580018,  //  006C  GETGBL	R22	G24
+      0x585C0011,  //  006D  LDCONST	R23	K17
+      0x5C602200,  //  006E  MOVE	R24	R17
+      0x7C580400,  //  006F  CALL	R22	2
+      0x7C540200,  //  0070  CALL	R21	1
+      0x50500000,  //  0071  LDBOOL	R20	0	0
+      0x7002000A,  //  0072  JMP		#007E
+      0x54560003,  //  0073  LDINT	R21	4
+      0x20542615,  //  0074  NE	R21	R19	R21
+      0x78560007,  //  0075  JMPF	R21	#007E
+      0x60540001,  //  0076  GETGBL	R21	G1
+      0x60580018,  //  0077  GETGBL	R22	G24
+      0x585C0012,  //  0078  LDCONST	R23	K18
+      0x5C602200,  //  0079  MOVE	R24	R17
+      0x5C642600,  //  007A  MOVE	R25	R19
+      0x7C580600,  //  007B  CALL	R22	3
+      0x7C540200,  //  007C  CALL	R21	1
+      0x50500000,  //  007D  LDBOOL	R20	0	0
+      0x78520003,  //  007E  JMPF	R20	#0083
+      0x5C540C00,  //  007F  MOVE	R21	R6
+      0x5C582200,  //  0080  MOVE	R22	R17
+      0x7C540200,  //  0081  CALL	R21	1
+      0x5C482A00,  //  0082  MOVE	R18	R21
+      0x4C540000,  //  0083  LDNIL	R21
+      0x1C542415,  //  0084  EQ	R21	R18	R21
+      0x78560003,  //  0085  JMPF	R21	#008A
+      0x5C540A00,  //  0086  MOVE	R21	R5
+      0x5C582200,  //  0087  MOVE	R22	R17
+      0x7C540200,  //  0088  CALL	R21	1
+      0x503C0000,  //  0089  LDBOOL	R15	0	0
+      0x783A0006,  //  008A  JMPF	R14	#0092
+      0x4C4C0000,  //  008B  LDNIL	R19
+      0x1C4C2413,  //  008C  EQ	R19	R18	R19
+      0x784E0003,  //  008D  JMPF	R19	#0092
+      0x5C4C0C00,  //  008E  MOVE	R19	R6
+      0x5C500200,  //  008F  MOVE	R20	R1
+      0x7C4C0200,  //  0090  CALL	R19	1
+      0x5C482600,  //  0091  MOVE	R18	R19
+      0x4C4C0000,  //  0092  LDNIL	R19
+      0x204C2413,  //  0093  NE	R19	R18	R19
+      0x784E0015,  //  0094  JMPF	R19	#00AB
+      0x5C4C1E00,  //  0095  MOVE	R19	R15
+      0x744E0013,  //  0096  JMPT	R19	#00AB
+      0x5C4C1A00,  //  0097  MOVE	R19	R13
+      0x744E0011,  //  0098  JMPT	R19	#00AB
+      0xA8020005,  //  0099  EXBLK	0	#00A0
+      0x8C4C0113,  //  009A  GETMET	R19	R0	K19
+      0x5C542200,  //  009B  MOVE	R21	R17
+      0x5C582400,  //  009C  MOVE	R22	R18
+      0x7C4C0600,  //  009D  CALL	R19	3
+      0xA8040001,  //  009E  EXBLK	1	1
+      0x7002000A,  //  009F  JMP		#00AB
+      0xAC4C0001,  //  00A0  CATCH	R19	0	1
+      0x70020007,  //  00A1  JMP		#00AA
+      0x60500001,  //  00A2  GETGBL	R20	G1
+      0x60540018,  //  00A3  GETGBL	R21	G24
+      0x58580014,  //  00A4  LDCONST	R22	K20
+      0x5C5C2200,  //  00A5  MOVE	R23	R17
+      0x5C602600,  //  00A6  MOVE	R24	R19
+      0x7C540600,  //  00A7  CALL	R21	3
+      0x7C500200,  //  00A8  CALL	R20	1
+      0x70020000,  //  00A9  JMP		#00AB
+      0xB0080000,  //  00AA  RAISE	2	R0	R0
+      0x5C4C0E00,  //  00AB  MOVE	R19	R7
+      0x5C502400,  //  00AC  MOVE	R20	R18
+      0x7C4C0200,  //  00AD  CALL	R19	1
+      0x78360002,  //  00AE  JMPF	R13	#00B2
+      0x5C500600,  //  00AF  MOVE	R20	R3
+      0x00541705,  //  00B0  ADD	R21	R11	K5
+      0x7C500200,  //  00B1  CALL	R20	1
+      0xA0000000,  //  00B2  CLOSE	R0
+      0x80042600,  //  00B3  RET	1	R19
     })
   )
 );


### PR DESCRIPTION
## Description:

Add styling properties to HASPmota, according to definition from OpenHASP: https://www.openhasp.com/0.6.3/design/styling/#suffixes

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
