### PR TITLE
Fix Core3 warnings when compiling LVGL

### DIFF
--- a/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.cpp
+++ b/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.cpp
@@ -205,7 +205,9 @@ LvGLStatus Adafruit_LvGL_Glue::begin(Renderer *tft, void *touch, bool debug) {
   lvgl_buffer_size = tft->width() * (flushlines ? flushlines:LV_BUFFER_ROWS);
   if (tft->lvgl_pars()->use_dma) {
     lvgl_buffer_size /= 2;
-    lv_pixel_buf2 = new lv_color_t[lvgl_buffer_size];
+    if (lvgl_buffer_size < 1000000) {
+      lv_pixel_buf2 = new lv_color_t[lvgl_buffer_size];
+    }
     if (!lv_pixel_buf2) {
       return status;
     }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_lvgl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_lvgl.ino
@@ -22,7 +22,13 @@
 #ifdef USE_LVGL
 
 #include <berry.h>
+
+// silence warning with Core3
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion"
 #include "lvgl.h"
+#pragma GCC diagnostic pop
+
 #include "be_mapping.h"
 #include "be_ctypes.h"
 #include "lv_berry.h"


### PR DESCRIPTION
## Description:

Remove compiler warnings when compiling LVGL variant for Arduino Core 3.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
