### PR TITLE
Add NeoPool NPHydrolysis percent and unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 keep FS intact when over flashing with VSC (#19816)
 - Increase MAX_HUE_DEVICES to 32 (#19820)
 - MI32 updates (#19893)
+- NeoPool ``NPHydrolysis`` percent and unit
 
 ### Fixed
 - NeoPool filtration mode display (#19801)


### PR DESCRIPTION
## Description

- NPHydrolysis also accepts percentage values as parameters (`<level> {%}`), even for devices using g/h
- telemetry message SENSOR now always contains the values in percent in addition to the unit:
```json
   "Hydrolysis": {
      "Data": 4.8,
      "Unit": "g/h",
      "Setpoint": 12,
      "Max": 16,
      "Percent": {
        "Data": 30,
        "Setpoint": 75
      },
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
