### PR TITLE
Berry ``debug.gcdebug()`` to enable GC debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [13.2.0.2]
 ### Added
 - Scripter TCP client (#19914)
+- Berry ``debug.gcdebug()`` to enable GC debugging
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_debuglib.c
+++ b/lib/libesp32/berry/src/be_debuglib.c
@@ -84,6 +84,19 @@ static int m_codedump(bvm *vm)
     be_return_nil(vm);
 }
 
+static int m_gcdebug(bvm *vm) {
+    int argc = be_top(vm);
+    if (argc >= 1 && be_isbool(vm, 1)) {
+        if (be_tobool(vm, 1)) {
+            comp_set_gc_debug(vm);
+        } else {
+            comp_clear_gc_debug(vm);
+        }
+    }
+    be_pushbool(vm, comp_is_gc_debug(vm));
+    be_return(vm);
+}
+
 static int m_traceback(bvm *vm)
 {
     be_tracestack(vm);
@@ -223,6 +236,7 @@ be_native_module_attr_table(debug) {
     be_native_module_function("varname", m_varname),
     be_native_module_function("upvname", m_upvname)
 #endif
+    be_native_module_function("gcdebug", m_gcdebug)
 };
 
 be_define_native_module(debug, NULL);
@@ -242,6 +256,8 @@ module debug (scope: global, depend: BE_USE_DEBUG_MODULE) {
     allocs, func(m_allocs)
     frees, func(m_frees)
     reallocs, func(m_reallocs)
+    // GC debug mode
+    gcdebug, func(m_gcdebug)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_debug.h"

--- a/lib/libesp32/berry/src/be_gc.c
+++ b/lib/libesp32/berry/src/be_gc.c
@@ -545,15 +545,9 @@ static void reset_fixedlist(bvm *vm)
 
 void be_gc_auto(bvm *vm)
 {
-#if BE_USE_DEBUG_GC
-    if (vm->gc.status & GC_PAUSE) { /* force gc each time it's possible */
+    if (vm->gc.status & GC_PAUSE && (BE_USE_DEBUG_GC || vm->gc.usage > vm->gc.threshold || comp_is_gc_debug(vm))) {
         be_gc_collect(vm);
     }
-#else
-    if (vm->gc.status & GC_PAUSE && vm->gc.usage > vm->gc.threshold) {
-        be_gc_collect(vm);
-    }
-#endif
 }
 
 size_t be_gc_memcount(bvm *vm)

--- a/lib/libesp32/berry/src/be_mem.c
+++ b/lib/libesp32/berry/src/be_mem.c
@@ -73,9 +73,9 @@ BERRY_API void* be_realloc(bvm *vm, void *ptr, size_t old_size, size_t new_size)
             vm->counter_mem_free++;
 #endif
             if (ptr == NULL) { return NULL; }   /* safeguard */
-#if BE_USE_DEBUG_GC
-            memset(ptr, 0xFF, old_size); /* fill the structure with invalid pointers */
-#endif
+            if (BE_USE_DEBUG_GC || comp_is_gc_debug(vm)) {
+                memset(ptr, 0xFF, old_size); /* fill the structure with invalid pointers */
+            }
             free_from_pool(vm, ptr, old_size);
             break;    /* early exit */
         }

--- a/lib/libesp32/berry/src/be_string.c
+++ b/lib/libesp32/berry/src/be_string.c
@@ -268,13 +268,13 @@ void be_gcstrtab(bvm *vm)
             }
         }
     }
-#if BE_USE_DEBUG_GC == 0
-    if (tab->count < size >> 2 && size > 8) {
-        resize(vm, size >> 1);
+    if (BE_USE_DEBUG_GC || comp_is_gc_debug(vm)) {
+        resize(vm, tab->count + 4);
+    } else {
+        if (tab->count < size >> 2 && size > 8) {
+            resize(vm, size >> 1);
+        }
     }
-#else
-    resize(vm, tab->count + 4);
-#endif
 }
 
 uint32_t be_strhash(const bstring *s)

--- a/lib/libesp32/berry/src/be_vm.h
+++ b/lib/libesp32/berry/src/be_vm.h
@@ -14,14 +14,19 @@
 #define comp_set_named_gbl(vm)      ((vm)->compopt |= (1<<COMP_NAMED_GBL))
 #define comp_clear_named_gbl(vm)    ((vm)->compopt &= ~(1<<COMP_NAMED_GBL))
 
-#define comp_is_strict(vm)       ((vm)->compopt & (1<<COMP_STRICT))
-#define comp_set_strict(vm)      ((vm)->compopt |= (1<<COMP_STRICT))
-#define comp_clear_strict(vm)    ((vm)->compopt &= ~(1<<COMP_STRICT))
+#define comp_is_strict(vm)          ((vm)->compopt & (1<<COMP_STRICT))
+#define comp_set_strict(vm)         ((vm)->compopt |= (1<<COMP_STRICT))
+#define comp_clear_strict(vm)       ((vm)->compopt &= ~(1<<COMP_STRICT))
+
+#define comp_is_gc_debug(vm)       ((vm)->compopt & (1<<COMP_GC_DEBUG))
+#define comp_set_gc_debug(vm)      ((vm)->compopt |= (1<<COMP_GC_DEBUG))
+#define comp_clear_gc_debug(vm)    ((vm)->compopt &= ~(1<<COMP_GC_DEBUG))
 
 /* Compilation options */
 typedef enum {
-    COMP_NAMED_GBL = 0x00, /* compile with named globals */
-    COMP_STRICT = 0x01, /* compile with named globals */
+    COMP_NAMED_GBL = 0x00,  /* compile with named globals */
+    COMP_STRICT = 0x01,     /* compile with named globals */
+    COMP_GC_DEBUG = 0x02,   /* compile with gc debug */
 } compoptmask;
 
 typedef struct {


### PR DESCRIPTION
## Description:

To ease debugging of the Garbage Collector, a new function `debug.gcdebug([bool])-> bool` allows to force an automatic GC after each memory allocation or reallocation.

```
import debug

# set gc debugging
debug.gcdebug(true)

# disable gc debugging
debug.gcdebug(false)

# query state
print(debug.gcdebug())
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
