### PR TITLE
Add new 'tasmota-aws' platform environment

### DIFF
--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -130,6 +130,7 @@ jobs:
           - tasmota-knx
           - tasmota-lite
           - tasmota-sensors
+          - tasmota-aws
           - tasmota-zbbridge
           - tasmota-zigbee
     steps:

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -70,6 +70,7 @@ jobs:
           - tasmota-sensors
           - tasmota-zbbridge
           - tasmota-zigbee
+          - tasmota-aws
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_all_the_things.yml
+++ b/.github/workflows/build_all_the_things.yml
@@ -89,6 +89,7 @@ jobs:
           - tasmota-minimal
           - tasmota-sensors
           - tasmota-zbbridge
+          - tasmota-aws
           - tasmota32
           - tasmota32c3
           - tasmota32c6cdc-arduino30

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -26,6 +26,7 @@ default_envs            =
 ;                          tasmota-sensors
 ;                          tasmota-display
 ;                          tasmota-zbbridge
+;                          tasmota-aws
 ;                          tasmota-ir
 ;                          tasmota32
 ;                          tasmota32-zbbrdgpro

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -64,6 +64,13 @@ build_flags             = ${env.build_flags}
 board                   = esp8266_4M2M
 board_build.f_cpu       = 160000000L
 
+[env:tasmota-aws]
+build_flags             = ${env.build_flags}
+                          -DUSE_MQTT_TLS
+                          -DUSE_MQTT_AWS_IOT_LIGHT
+                          -DUSE_MQTT_TLS_CA_CERT
+                          -DOTA_URL='""'
+
 [env:tasmota-AD]
 build_flags             = ${env.build_flags} -DMY_LANGUAGE=ca_AD -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmot-AD.bin.gz"'
 

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -69,7 +69,7 @@ build_flags             = ${env.build_flags}
                           -DUSE_MQTT_TLS
                           -DUSE_MQTT_AWS_IOT_LIGHT
                           -DUSE_MQTT_TLS_CA_CERT
-                          -DOTA_URL='""'
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-aws.bin.gz"'
 
 [env:tasmota-AD]
 build_flags             = ${env.build_flags} -DMY_LANGUAGE=ca_AD -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmot-AD.bin.gz"'


### PR DESCRIPTION
## Description:

Add a new platform for ESP82xx with AWS + MQTT TLS enabled to make life easier for people that need this feature on ESP82xx.

Compile flags were taken from docs: https://tasmota.github.io/docs/AWS-IoT/

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [✅] The pull request is done against the latest development branch
  - [✅] Only relevant files were touched
  - [✅] Only one feature/fix was added per PR and the code change compiles without warnings
  - [✅ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [✅] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
