### PR TITLE
Flash mode QIO for C2

### DIFF
--- a/boards/esp32c2.json
+++ b/boards/esp32c2.json
@@ -7,7 +7,7 @@
       "extra_flags": "-DESP32_4M -DESP32C2",
       "f_cpu": "120000000L",
       "f_flash": "60000000L",
-      "flash_mode": "dio",
+      "flash_mode": "qio",
       "mcu": "esp32c2",
       "variant": "esp32c2",
       "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"

--- a/boards/esp32c2_2M.json
+++ b/boards/esp32c2_2M.json
@@ -7,7 +7,7 @@
       "extra_flags": "-DESP32_2M -DESP32C2",
       "f_cpu": "120000000L",
       "f_flash": "60000000L",
-      "flash_mode": "dio",
+      "flash_mode": "qio",
       "mcu": "esp32c2",
       "variant": "esp32c2",
       "partitions": "partitions/esp32_partition_app1245k_fs64k.csv"


### PR DESCRIPTION
## Description:

all C2 boards support flash mode QIO 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
