### PR TITLE
Berry fix bytes getter for 3-bytes big-endian

### DIFF
--- a/lib/libesp32/berry/src/be_byteslib.c
+++ b/lib/libesp32/berry/src/be_byteslib.c
@@ -364,7 +364,7 @@ static uint32_t buf_get3_le(buf_impl* attr, size_t offset)
     return 0;
 }
 
-static uint16_t buf_get3_be(buf_impl* attr, size_t offset)
+static uint32_t buf_get3_be(buf_impl* attr, size_t offset)
 {
     if ((int32_t)offset + 2 < attr->len) {
         return attr->bufptr[offset+2] | (attr->bufptr[offset+1] << 8) | (attr->bufptr[offset] << 16);


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
