### PR TITLE
MI32 legacy: refactoring, use ringbuffer for server too

### DIFF
--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -141,7 +141,7 @@ struct ATCPacket_t{ //and PVVX
   };
 };
 
-struct BLEringBufferItem_t{
+struct BLERingBufferItem_t{
   uint16_t returnCharUUID;
   uint16_t handle;
   uint32_t type;
@@ -163,17 +163,6 @@ struct MI32connectionContextBerry_t{
   int error;
   bool oneOp;
   bool response;
-};
-
-struct BLEqueueBuffer_t{
-  union{
-    uint8_t *buffer;
-    int32_t value;
-  };
-  size_t length;
-  uint16_t returnCharUUID;
-  uint16_t handle;
-  uint16_t type;
 };
 
 struct {


### PR DESCRIPTION
## Description:

Only refactoring to unify internal messaging.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
