### PR TITLE
add AES_CBC to crypto module of Berry

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
@@ -1,9 +1,9 @@
 /********************************************************************
- * Berry module `webserver`
+ * Berry module `crypto`
  * 
- * To use: `import webserver`
+ * To use: `import crypto`
  * 
- * Allows to respond to HTTP request
+ * Allows to use crypto functions
  *******************************************************************/
 #include "be_constobj.h"
 #include "be_mapping.h"
@@ -28,6 +28,9 @@ extern int m_aes_gcm_tag(bvm *vm);
 extern int m_aes_ctr_init(bvm *vm);
 extern int m_aes_ctr_run(bvm *vm);
 extern int m_aes_ctr_tag(bvm *vm);
+
+extern int m_aes_cbc_encrypt1(bvm *vm);
+extern int m_aes_cbc_decrypt1(bvm *vm);
 
 extern int m_ec_p256_pubkey(bvm *vm);
 extern int m_ec_p256_sharedkey(bvm *vm);
@@ -64,6 +67,7 @@ extern const bclass be_class_md5;
 #include "be_fixed_be_class_aes_ccm.h"
 #include "be_fixed_be_class_aes_gcm.h"
 #include "be_fixed_be_class_aes_ctr.h"
+#include "be_fixed_be_class_aes_cbc.h"
 #include "be_fixed_be_class_ec_p256.h"
 #include "be_fixed_be_class_ec_c25519.h"
 #include "be_fixed_be_class_sha256.h"
@@ -86,6 +90,10 @@ const be_const_member_t be_crypto_members[] = {
 #ifdef USE_BERRY_CRYPTO_AES_GCM
   { "/AES_GCM", (intptr_t) &be_class_aes_gcm },
 #endif // USE_BERRY_CRYPTO_AES_GCM
+
+#ifdef USE_BERRY_CRYPTO_AES_CBC
+  { "/AES_CBC", (intptr_t) &be_class_aes_cbc },
+#endif // USE_BERRY_CRYPTO_AES_CBC
 
 #ifdef USE_BERRY_CRYPTO_EC_C25519
   { "/EC_C25519", (intptr_t) &be_class_ec_c25519 },
@@ -160,6 +168,11 @@ class be_class_aes_ctr (scope: global, name: AES_CTR) {
     init, func(m_aes_ctr_init)
     encrypt, func(m_aes_ctr_run)
     decrypt, func(m_aes_ctr_run)
+}
+
+class be_class_aes_cbc (scope: global, name: AES_CBC) {
+    decrypt1, static_func(m_aes_cbc_decrypt1)
+    encrypt1, static_func(m_aes_cbc_encrypt1)
 }
 
 class be_class_ec_p256 (scope: global, name: EC_P256) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_crypto.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_crypto.ino
@@ -534,6 +534,89 @@ extern "C" {
 }
 
 /*********************************************************************************************\
+ * AES_CBC class
+ * 
+\*********************************************************************************************/
+extern "C" {
+  // `AES_CBC.encrypt1(secret_key:bytes(16),iv:bytes(16),data:bytes(n*16))-> bool (true)
+  int32_t m_aes_cbc_encrypt1(bvm *vm);
+  int32_t m_aes_cbc_encrypt1(bvm *vm) {
+    int32_t argc = be_top(vm); // Get the number of arguments
+    if (argc >= 3  && be_isbytes(vm, 1)    // secret_key  - 16 bytes
+                   && be_isbytes(vm, 2)    // iv          - 16 bytes
+                   && be_isbytes(vm, 3)    // data/cipher - multiple 16 bytes
+                   ) {
+
+      size_t key_len = 0;
+      const void * key = be_tobytes(vm, 1, &key_len);
+      if (key_len != 16) {
+        be_raise(vm, "value_error", "Key size must be 16 bytes");
+      }
+
+      size_t iv_len = 0;
+      void * iv = (void *) be_tobytes(vm, 2, &iv_len);
+      if (iv_len != 16) {
+        be_raise(vm, "value_error", "IV size must be 16");
+      }
+
+      size_t data_len = 0;
+      void * data = (void *) be_tobytes(vm, 3, &data_len);
+      if (data_len%16 != 0) {
+        be_raise(vm, "value_error", "Data size must be multiple of 16");
+      }
+
+      // Initialize an AES CBC encryption structure with the secret key, then run with IV and data
+      br_aes_small_cbcenc_keys cbc_ctx;
+      br_aes_small_cbcenc_init(&cbc_ctx, key, 16);
+      br_aes_small_cbcenc_run( &cbc_ctx, iv, data, data_len );
+      
+      // (unchecked )success
+      be_pushbool(vm, btrue);
+      be_return(vm);
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
+  // `AES_CBC.decrypt1(secret_key:bytes(16),iv:bytes(16),cipher:bytes(n*16))-> bool (true)
+  int32_t m_aes_cbc_decrypt1(bvm *vm);
+  int32_t m_aes_cbc_decrypt1(bvm *vm) {
+    int32_t argc = be_top(vm); // Get the number of arguments
+    if (argc >= 3  && be_isbytes(vm, 1)    // secret_key  - 16 bytes
+                   && be_isbytes(vm, 2)    // iv          - 16 bytes
+                   && be_isbytes(vm, 3)    // cipher/data - multiple 16 bytes
+                   ) {
+
+      size_t key_len = 0;
+      const void * key = be_tobytes(vm, 1, &key_len);
+      if (key_len != 16) {
+        be_raise(vm, "value_error", "Key size must be 16 bytes");
+      }
+
+      size_t iv_len = 0;
+      void * iv = (void *) be_tobytes(vm, 2, &iv_len);
+      if (iv_len != 16) {
+        be_raise(vm, "value_error", "IV size must be 16");
+      }
+
+      size_t data_len = 0;
+      void * data = (void *) be_tobytes(vm, 3, &data_len);
+      if (data_len%16 != 0) {
+        be_raise(vm, "value_error", "Cipher size must be multiple of 16");
+      }
+
+      // Initialize an AES CBC decryption structure with the secret key, then run with IV and data
+      br_aes_small_cbcdec_keys cbc_ctx;
+      br_aes_small_cbcdec_init(&cbc_ctx, key, 16);
+      br_aes_small_cbcdec_run( &cbc_ctx, iv, data, data_len );
+      
+      // (unchecked )success
+      be_pushbool(vm, btrue);
+      be_return(vm);
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
+}
+
+/*********************************************************************************************\
  * SHA256 class
  * 
 \*********************************************************************************************/


### PR DESCRIPTION
## Description:

Adds CBC mode to AES crypto functions in Berry (needed for Tuya BLE).
Follows the naming conventions of 'encrypt1' and 'decrypt1' of the CCM mode.
Not active by default, activate with `-DUSE_BERRY_CRYPTO_AES_CBC=1` in build env.
Test example:
```
var b = bytes().fromstring("hello world_____") # 16-byte aligned
var key = bytes().fromstring("1122334455667788") # 16 bytes
var iv = bytes().fromstring("8877665544332211") # 16 bytes

print("data:",b.asstring())
import crypto
aes = crypto.AES_CBC()
aes.encrypt1(key, iv, b)
print("cipher:",b)
iv = bytes().fromstring("8877665544332211")
aes.decrypt1(key, iv, b)
print("decrypted data:",b.asstring())
```

Test with comparable Python example:
```
from Crypto.Cipher import AES
import binascii

def decrypt(data, iv, key):
    cipher = AES.new(key, AES.MODE_CBC, iv)
    return cipher.decrypt(data)


def encrypt(data, iv, key):
    cipher = AES.new(key, AES.MODE_CBC, iv)
    return cipher.encrypt(data)

data = "hello world_____".encode('utf-8') # "padded" with __ to 16 byte
key = "1122334455667788".encode('utf-8') # 16-byte
iv = "8877665544332211".encode('utf-8')  # 16-byte

print(data)
cipher = encrypt(data,iv,key)
print(binascii.hexlify(cipher))
decrypted = decrypt(cipher,iv,key)
print(decrypted)
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
