### PR TITLE
Neopool enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Berry ``debug.gcdebug()`` to enable GC debugging (#19936)
 - NeoPool sensor delta trigger (command ``NPTelePeriod``)
 - NeoPool store settings on unified file system
+- NeoPool command ``NPBoost``
 
 ### Breaking Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Scripter TCP client (#19914)
 - Berry ``debug.gcdebug()`` to enable GC debugging (#19936)
 - NeoPool sensor delta trigger (command ``NPTelePeriod``)
+- NeoPool store settings on unified file system
 
 ### Breaking Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Scripter TCP client (#19914)
 - Berry ``debug.gcdebug()`` to enable GC debugging (#19936)
+- NeoPool sensor delta trigger (command ``NPTelePeriod``)
 
 ### Breaking Changed
 

--- a/tasmota/include/tasmota_configurations.h
+++ b/tasmota/include/tasmota_configurations.h
@@ -823,7 +823,7 @@
 #undef USE_HRE                                   // Disable support for Badger HR-E Water Meter (+1k4 code)
 #undef USE_A4988_STEPPER                         // Disable support for A4988_Stepper
 #undef USE_PROMETHEUS                            // Disable support for https://prometheus.io/ metrics exporting over HTTP /metrics endpoint
-#undef USE_NEOPOOL                               // Disable support for Sugar Valley NeoPool Controller - also known under brands Hidrolife, Aquascenic, Oxilife, Bionet, Hidroniser, UVScenic, Station, Brilix, Bayrol and Hay (+6k flash, +60 mem)
+#undef USE_NEOPOOL                               // Disable support for Sugar Valley NeoPool Controller - also known under brands Hidrolife, Aquascenic, Oxilife, Bionet, Hidroniser, UVScenic, Station, Brilix, Bayrol and Hay (+14k flash, +120 mem)
 #undef USE_THERMOSTAT                            // Disable support for Thermostat
 #undef DEBUG_THEO                                // Disable debug code
 #undef USE_DEBUG_DRIVER                          // Disable debug code

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1029,7 +1029,7 @@
 
 //#define USE_PROMETHEUS                           // Add support for https://prometheus.io/ metrics exporting over HTTP /metrics endpoint
 
-//#define USE_NEOPOOL                              // Add support for Sugar Valley NeoPool Controller - also known under brands Hidrolife, Aquascenic, Oxilife, Bionet, Hidroniser, UVScenic, Station, Brilix, Bayrol and Hay (+6k flash, +60 mem)
+//#define USE_NEOPOOL                              // Add support for Sugar Valley NeoPool Controller - also known under brands Hidrolife, Aquascenic, Oxilife, Bionet, Hidroniser, UVScenic, Station, Brilix, Bayrol and Hay (+14k flash, +120 mem)
 //  #define NEOPOOL_MODBUS_ADDRESS       1         // Any modbus address
 
 //#define USE_FLOWRATEMETER                        // Add support for water flow meter YF-DN50 and similary (+1k7 code)


### PR DESCRIPTION
## Description:

- add sensor delta trigger using `NPTelePeriod <sec>`, default disabled (`NPTelePeriod 0`).
Send an MQTT telemetry message if device data changes: 
  * immediately for data that changes less frequently (status changes for relays, settings etc.) 
  * for sensor data such as temperature, redox etc. if they change but earliest after the specified `NPTeleperiod` time (in sec)
- add store settings in unified file system - save settings for  `NPPHRes`, `NPCLRes`, `NPIonRes`, `NPresult` and `NPTelePeriod` if unified file system is enabled (USE_UFILESYS, default for ESP32)
- add command `NPBoost` (no more extra rule/script needed)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
