### PR TITLE
Fix pragma generated warning

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_lvgl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_lvgl.ino
@@ -25,7 +25,9 @@
 
 // silence warning with Core3
 #pragma GCC diagnostic push
+#if defined(__GNUC__) && (__GNUC__ >= 10)
 #pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion"
+#endif
 #include "lvgl.h"
 #pragma GCC diagnostic pop
 


### PR DESCRIPTION
## Description:

enable Pragma command only for core3 newer used gcc version. Fixes warning with gcc 8.4 used with core 2.0.14

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
