### PR TITLE
Fix Berry `gpio.dac_voltage()` broken in 13.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Scripter timer issue (#19914)
 - Zero-Cross Dimmer for ESP32 with Core3 (#19929)
 - Matter flow sensor (#19961)
+- Berry ``gpio.dac_voltage()`` broken in 13.2.0
 
 ### Removed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_gpio.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_gpio.ino
@@ -160,8 +160,8 @@ extern "C" {
         esp_err_t err =  dac_oneshot_new_channel(&channel_cfg, &channel_handle);
 #else
         dac_channel_t channel = (25 == pin) ? DAC_CHANNEL_1 : DAC_CHANNEL_2;
-//        esp_err_t err = dac_output_voltage(channel, dac_value);
-        esp_err_t err = dac_output_enable(channel);
+        esp_err_t err = dac_output_voltage(channel, dac_value);
+        // err = dac_output_enable(channel);
 #endif
         if (err) {
           be_raisef(vm, "internal_error", "Error: esp_err_tdac_output_voltage(%i, %i) -> %i", channel, dac_value, err);
@@ -180,8 +180,8 @@ extern "C" {
         esp_err_t err =  dac_oneshot_new_channel(&channel_cfg, &channel_handle);
 #else
         dac_channel_t channel = (17 == pin) ? DAC_CHANNEL_1 : DAC_CHANNEL_2;
-//        esp_err_t err = dac_output_voltage(channel, dac_value);
-        esp_err_t err = dac_output_enable(channel);
+        esp_err_t err = dac_output_voltage(channel, dac_value);
+        // err = dac_output_enable(channel);
 #endif
         if (err) {
           be_raisef(vm, "internal_error", "Error: esp_err_tdac_output_voltage(%i, %i) -> %i", channel, dac_value, err);


### PR DESCRIPTION
## Description:

Fix Berry `gpio.dac_voltage()` that was broken in 13.2.0, in this commit: https://discord.com/channels/479389167382691863/490244847568158751/1173364184164077799

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
