### PR TITLE
Fix audio warning with Arduino core 3

### DIFF
--- a/lib/lib_audio/ESP8266Audio/library.json
+++ b/lib/lib_audio/ESP8266Audio/library.json
@@ -22,6 +22,6 @@
     ],
 	"build": {
 		"includeDir": ".",
-		"flags": [ "-Wno-stringop-overread" ]
+		"flags": [ "-Wno-stringop-overread", "-Wno-incompatible-pointer-types" ]
 	}
 }

--- a/lib/lib_audio/ESP8266Audio/library.json
+++ b/lib/lib_audio/ESP8266Audio/library.json
@@ -22,6 +22,6 @@
     ],
 	"build": {
 		"includeDir": ".",
-		"flags": [ "-Wno-stringop-overread", "-Wno-incompatible-pointer-types" ]
+		"flags": [ "-Wno-stringop-overread" ]
 	}
 }

--- a/pio-tools/add_c_flags_ard3.py
+++ b/pio-tools/add_c_flags_ard3.py
@@ -2,3 +2,6 @@ Import("env")
 
 # General options that are passed to the C++ compiler
 env.Append(CXXFLAGS=["-Wno-volatile"])
+
+# General options that are passed to the C compiler (C only; not C++).
+env.Append(CFLAGS=["-Wno-incompatible-pointer-types"])


### PR DESCRIPTION

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
