### PR TITLE
fix compilation without PARTITION_WIZARD

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -761,6 +761,7 @@ void HandleBerryConsole(void)
   WSContentStop();
 }
 
+#ifdef USE_BERRY_PARTITION_WIZARD
 // Display a Button to dynamically load the Partition Wizard
 void HandleBerryPartiionWizardLoaderButton(void) {
   bvm * vm = berry.vm;
@@ -785,6 +786,7 @@ void HandleBerryPartitionWizardLoader(void) {
     Webserver->send(302, "text/plain", "");
   }
 }
+#endif //USE_BERRY_PARTITION_WIZARD
 
 // return true if successful
 bool BerryBECLoader(const char * url) {


### PR DESCRIPTION
## Description:

Add the missing #define to allow compilation without USE_BERRY_PARTITION_WIZARD.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
