### PR TITLE
[Thermostat] Fix JSON index

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
@@ -2049,7 +2049,7 @@ void CmndEnableOutputSet(void)
 \*********************************************************************************************/
 
 #ifdef USE_WEBSERVER
-const char HTTP_THERMOSTAT_INFO[]           PROGMEM = "{s}" D_THERMOSTAT "{m}%s{e}";
+const char HTTP_THERMOSTAT_INFO[]           PROGMEM = "{s}" D_THERMOSTAT " %d{m}%s{e}";
 const char HTTP_THERMOSTAT_TEMPERATURE[]    PROGMEM = "{s}%s{m}%*_f " D_UNIT_DEGREE "%c{e}";
 const char HTTP_THERMOSTAT_TEMP_GRAD[]      PROGMEM = "{s}" D_THERMOSTAT_GRADIENT "{m}%c%*_f " D_UNIT_DEGREE "%c/" D_UNIT_HOUR "{e}";
 const char HTTP_THERMOSTAT_DUTY_CYCLE[]     PROGMEM = "{s}" D_THERMOSTAT_DUTY_CYCLE "{m}%d " D_UNIT_PERCENT "{e}";
@@ -2068,7 +2068,7 @@ void ThermostatShow(uint8_t ctr_output, bool json)
 {
   if (json) {
     float f_target_temp = Thermostat[ctr_output].temp_target_level / 10.0f;
-    ResponseAppend_P(PSTR(",\"Thermostat%i\":{"), ctr_output);
+    ResponseAppend_P(PSTR(",\"Thermostat%i\":{"), ctr_output + 1);
     ResponseAppend_P(PSTR("%s\"%s\":%i"), "", D_CMND_THERMOSTATMODESET, Thermostat[ctr_output].status.thermostat_mode);
     ResponseAppend_P(PSTR("%s\"%s\":%2_f"), ",", D_CMND_TEMPTARGETSET, &f_target_temp);
     ResponseAppend_P(PSTR("%s\"%s\":%i"), ",", D_CMND_CTRDUTYCYCLEREAD, ThermostatGetDutyCycle(ctr_output));
@@ -2083,13 +2083,13 @@ void ThermostatShow(uint8_t ctr_output, bool json)
   WSContentSend_P(HTTP_THERMOSTAT_HL);
 
   if (Thermostat[ctr_output].status.thermostat_mode == THERMOSTAT_OFF) {
-    WSContentSend_P(HTTP_THERMOSTAT_INFO, D_DISABLED );
+    WSContentSend_P(HTTP_THERMOSTAT_INFO, ctr_output + 1, D_DISABLED );
 
   } else {
     char c_unit = Thermostat[ctr_output].status.temp_format==TEMP_CELSIUS ? D_UNIT_CELSIUS[0] : D_UNIT_FAHRENHEIT[0];
     float f_temperature;
 
-    WSContentSend_P(HTTP_THERMOSTAT_INFO, D_ENABLED);
+    WSContentSend_P(HTTP_THERMOSTAT_INFO, ctr_output + 1, D_ENABLED);
 
     f_temperature = Thermostat[ctr_output].temp_target_level / 10.0f;
     WSContentSend_PD(HTTP_THERMOSTAT_TEMPERATURE, D_THERMOSTAT_SET_POINT, Settings->flag2.temperature_resolution, &f_temperature, c_unit);

--- a/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
@@ -1285,7 +1285,7 @@ void ThermostatDebug(uint8_t ctr_output)
 {
   char ctr_output_chr[FLOATSZ];
   char result_chr[FLOATSZ];
-  dtostrfd(ctr_output, 0, ctr_output_chr);
+  dtostrfd(ctr_output + 1, 0, ctr_output_chr);
   dtostrfd(Thermostat[ctr_output].status.counter_seconds, 0, result_chr);
   AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].status.counter_seconds: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].status.thermostat_mode, 0, result_chr);
@@ -1340,7 +1340,7 @@ void DebugControllerParameters(uint8_t ctr_output)
 {
   char ctr_output_chr[FLOATSZ];
   char result_chr[FLOATSZ];
-  dtostrfd(ctr_output, 0, ctr_output_chr);
+  dtostrfd(ctr_output + 1, 0, ctr_output_chr);
   dtostrfd(Thermostat[ctr_output].status.controller_mode, 0, result_chr);
   AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_THERMOSTAT "Thermostat[%s].CONTROLLERMODESET: %s"), ctr_output_chr, result_chr);
   dtostrfd(Thermostat[ctr_output].time_pi_cycle, 0, result_chr);


### PR DESCRIPTION
## Description:

The index count of thermostat instances begins with `1`, but in the tele/SENSOR message it starts with `0`. This fixes the index to start always with `1`.

**Please pay attention:** Because of changing the index, the parsing of the JSON message has to be adjusted!
| old | new |
|--------|--------|
|`"Thermostat0":{"ThermostatModeSet":1,...`|`"Thermostat1":{"ThermostatModeSet":1,...`|

Also the index will be shown in the WebUI.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).