### PR TITLE
Add the possibility to set global compile time settings

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -65,14 +65,9 @@ lib_extra_dirs              =
 ;enable_esp32_gz = 1
 ; Uncomment and specify a folder where to place the firmware file(s) (default set to folder build_output)
 ;bin_dir = /tmp/bin_files/
+; Global build flags (used for all env) can be overriden in "platformio_override.ini"
 build_unflags               =
-build_flags                 = -DTASMOTA  ; flag indicating that we are compiling Tasmota
-                              -DUSE_BERRY_PARTITION_WIZARD
-; *********************************************************************
-; *** Use custom settings from file user_config_override.h
-                              -DUSE_CONFIG_OVERRIDE
-; *********************************************************************
-
+build_flags                 =
 
 [scripts_defaults]
 extra_scripts               = pre:pio-tools/pre_source_dir.py
@@ -101,7 +96,11 @@ build_flags                 = ${tasmota.build_flags}
                               -free
                               -fipa-pta
                               -Wreturn-type
-
+                              -DTASMOTA  ; flag indicating that we are compiling Tasmota
+; *********************************************************************
+; *** Use custom settings from file user_config_override.h
+                              -DUSE_CONFIG_OVERRIDE
+; *********************************************************************
 [esp82xx_defaults]
 extra_scripts               = ${esp_defaults.extra_scripts}
 build_flags                 = ${esp_defaults.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -66,6 +66,14 @@ lib_extra_dirs              =
 ;enable_esp32_gz = 1
 ; Uncomment and specify a folder where to place the firmware file(s) (default set to folder build_output)
 ;bin_dir = /tmp/bin_files/
+build_unflags               =
+build_flags                 = -DTASMOTA  ; flag indicating that we are compiling Tasmota
+                              -DUSE_BERRY_PARTITION_WIZARD
+; *********************************************************************
+; *** Use custom settings from file user_config_override.h
+                              -DUSE_CONFIG_OVERRIDE
+; *********************************************************************
+
 
 [scripts_defaults]
 extra_scripts               = pre:pio-tools/pre_source_dir.py
@@ -81,10 +89,12 @@ extra_scripts               = post:pio-tools/name-firmware.py
 ;                              post:pio-tools/obj-dump.py
                               ${scripts_defaults.extra_scripts}
 ; *** remove undesired all warnings
-build_unflags               = -Wall
+build_unflags               = ${tasmota.build_unflags}
+                               -Wall
 ;                              -mtarget-align
                               -Wdeprecated-declarations
-build_flags                 = -DCORE_DEBUG_LEVEL=0
+build_flags                 = ${tasmota.build_flags}
+                              -DCORE_DEBUG_LEVEL=0
                               -Wl,-Map,firmware.map
                               -Wno-deprecated-declarations
 ;                              -mno-target-align
@@ -92,11 +102,6 @@ build_flags                 = -DCORE_DEBUG_LEVEL=0
                               -free
                               -fipa-pta
                               -Wreturn-type
-                              -DTASMOTA  ; flag indicating that we are compiling Tasmota
-; *********************************************************************
-; *** Use custom settings from file user_config_override.h
-                              -DUSE_CONFIG_OVERRIDE
-; *********************************************************************
 
 [esp82xx_defaults]
 extra_scripts               = ${esp_defaults.extra_scripts}

--- a/platformio.ini
+++ b/platformio.ini
@@ -101,6 +101,7 @@ build_flags                 = ${tasmota.build_flags}
 ; *** Use custom settings from file user_config_override.h
                               -DUSE_CONFIG_OVERRIDE
 ; *********************************************************************
+
 [esp82xx_defaults]
 extra_scripts               = ${esp_defaults.extra_scripts}
 build_flags                 = ${esp_defaults.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -55,7 +55,6 @@ lib_extra_dirs              =
                               lib/lib_div
 
 [tasmota]
-; *** Settings here do NOT affect firmware building ***
 ; Uncomment if you do NOT want gzipped map file(s)
 ;disable_map_gz = 1
 ; Uncomment and specify a folder where to place the map file(s) (default set to folder build_output)

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -65,6 +65,11 @@ default_envs            =
 ;                          tasmota32c6-safeboot
 ;                          tasmota32c6cdc-safeboot
 
+[tasmota]
+; *** Global build / unbuild compile time flags for ALL Tasmota / Tasmota32 [env]
+;build_unflags           =
+build_flags             = -DUSE_BERRY_PARTITION_WIZARD
+
 [env]
 ;build_unflags           = ${common.build_unflags}
 ;                          -Wswitch-unreachable

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -1,3 +1,9 @@
+[tasmota]
+; Reset global build / unbuild compile time flags for ALL Tasmota / Tasmota32 [env]
+; since custom env are designed to enable options individual
+build_unflags               =
+build_flags                 =
+
 [env:tasmota-rangeextender]
 build_flags                 = ${env.build_flags}
                               -DFIRMWARE_RANGE_EXTENDER

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1141,7 +1141,7 @@
                                                  // Note that only one cipher is enabled: ECDHE_RSA_WITH_AES_128_GCM_SHA256 which is very commonly used and highly secure
     #define USE_BERRY_WEBCLIENT_USERAGENT  "TasmotaClient" // default user-agent used, can be changed with `wc.set_useragent()`
     #define USE_BERRY_WEBCLIENT_TIMEOUT  2000    // Default timeout in milliseconds
-    #define USE_BERRY_PARTITION_WIZARD           // Add a button to dynamically load the Partion Wizard from a bec file online (+1.3KB Flash)
+    //#define USE_BERRY_PARTITION_WIZARD           // Add a button to dynamically load the Partion Wizard from a bec file online (+1.3KB Flash)
     #define USE_BERRY_PARTITION_WIZARD_URL      "http://ota.tasmota.com/tapp/partition_wizard.bec"
   #define USE_BERRY_TCPSERVER                    // Enable TCP socket server (+0.6k)
   // #define USE_BERRY_ULP                          // Enable ULP (Ultra Low Power) support (+4.9k)


### PR DESCRIPTION
## Description:

used in first step for the streaming Partition Wizard feature. The feature is great in most cases but for env trimmed to use as less as possible resources it is contra productive. 
Example: "accidently" hitting the Button on a C2 build can lead to a crash since 20k of heap needed for Partition Wizard can be to much.

@s-hadinger Comments, Opinions? Fine for you? 

It can now easily en/disabled in `platformio_override.ini`
in section [tasmota] with 

```
[tasmota]
; *** Global build / unbuild compile time flags for ALL Tasmota / Tasmota32 [env]
;build_unflags               =
build_flags                 =
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
