### PR TITLE
Align arduino3 firmware build to Tasmota32

### DIFF
--- a/platformio_tasmota_core3_env_sample.ini
+++ b/platformio_tasmota_core3_env_sample.ini
@@ -23,7 +23,6 @@ board                   = esp32
 build_unflags           = ${env:arduino30.build_unflags}
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -DUSE_MATTER_DEVICE
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
 
@@ -33,7 +32,6 @@ board                   = esp32_solo1
 build_unflags           = ${env:arduino30.build_unflags}
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -DUSE_MATTER_DEVICE
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
 
@@ -45,7 +43,6 @@ board_build.f_cpu       = 240000000L
 build_unflags           = ${env:arduino30.build_unflags}
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -DUSE_MATTER_DEVICE
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
 
@@ -55,7 +52,6 @@ board                   = esp32s2
 build_unflags           = ${env:arduino30.build_unflags}
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -DUSE_MATTER_DEVICE
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
 
@@ -65,7 +61,6 @@ board                   = esp32s2cdc
 build_unflags           = ${env:arduino30.build_unflags}
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -DUSE_MATTER_DEVICE
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
 
@@ -77,7 +72,6 @@ board_build.f_flash     = 80000000L
 build_unflags           = ${env:arduino30.build_unflags}
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -DUSE_MATTER_DEVICE
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
 
@@ -89,7 +83,6 @@ board_build.f_flash     = 80000000L
 build_unflags           = ${env:arduino30.build_unflags}
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -DUSE_MATTER_DEVICE
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
 
@@ -99,7 +92,6 @@ board                   = esp32s3-qio_qspi
 build_unflags           = ${env:arduino30.build_unflags}
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -DUSE_MATTER_DEVICE
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
 
@@ -124,7 +116,6 @@ build_unflags           = ${env:arduino30.build_unflags}
                           -DUSE_IPV6
                           -mtarget-align
 build_flags             = ${env:arduino30.build_flags}
-                          -DFIRMWARE_ARDUINO30
                           -DOTA_URL='""'
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
@@ -137,7 +128,6 @@ build_unflags           = ${env:arduino30.build_unflags}
                           -mtarget-align
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -DUSE_MATTER_DEVICE
                           -fno-lto
                           -DOTA_URL='""'
 monitor_filters         = esp32_exception_decoder
@@ -151,7 +141,6 @@ build_unflags           = ${env:arduino30.build_unflags}
                           -mtarget-align
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -DUSE_MATTER_DEVICE
                           -fno-lto
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
@@ -164,7 +153,6 @@ build_unflags           = ${env:arduino30.build_unflags}
                           -mtarget-align
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -DUSE_MATTER_DEVICE
                           -fno-lto
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
@@ -178,7 +166,6 @@ build_unflags           = ${env:arduino30.build_unflags}
 build_flags             = ${env:arduino30.build_flags}
                           -fno-lto
                           -DFIRMWARE_ARDUINO30
-                          -DUSE_MATTER_DEVICE
                           -DOTA_URL='""'
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
@@ -192,7 +179,6 @@ build_unflags           = ${env:arduino30.build_unflags}
 build_flags             = ${env:arduino30.build_flags}
                           -fno-lto
                           -DFIRMWARE_ARDUINO30
-                          -DUSE_MATTER_DEVICE
                           -DOTA_URL='""'
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -200,30 +200,7 @@
   #define CODE_IMAGE_STR "arduino30"
 #endif
 
-
-#undef FIRMWARE_LITE                            // Disable tasmota-lite with no sensors
-#undef FIRMWARE_SENSORS                         // Disable tasmota-sensors with useful sensors enabled
-#undef FIRMWARE_KNX_NO_EMULATION                // Disable tasmota-knx with KNX but without Emulation
-#undef FIRMWARE_DISPLAYS                        // Disable tasmota-display with display drivers enabled
-#undef FIRMWARE_IR                              // Disable tasmota-ir with IR full protocols activated
-#undef FIRMWARE_WEBCAM
-#undef FIRMWARE_BLUETOOTH
-#undef FIRMWARE_LVGL
-#undef FIRMWARE_TASMOTA32
-
-
-// -- Optional modules ----------------------------
-#undef USE_SHUTTER                               // Disable Shutter support for up to 4 shutter with different motortypes (+6k code)
-#define USE_AC_ZERO_CROSS_DIMMER                  // Enable support for AC_ZERO_CROSS_DIMMER
-
-#define USE_IR_REMOTE                            // Enable IR driver
-
-#define USE_TLS
-#define USE_WEBSERVER
-#define USE_WEBCLIENT
-#define USE_WEBCLIENT_HTTPS
-#define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge console Tee (+2k code)
-#define USE_ETHERNET
+#define FIRMWARE_TASMOTA32
 
 #endif  // FIRMWARE_ARDUINO30
 


### PR DESCRIPTION
## Description:

Step1 of removing firmware build variant `Arduino30`. All drivers are compiling so no need anymore to have different settings between core2 and core3
Now firmware build `Arduino30` == `Tasmota32` 
In Step2 variant `Arduino30` will be removed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
