### PR TITLE
Move pulse_counter from volatile to atomic

### DIFF
--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -21,6 +21,7 @@
 #ifndef ESP32_STAGE                         // ESP32 Stage has no core_version.h file. Disable include via PlatformIO Option
 #include <core_version.h>                   // Arduino_Esp8266 version information (ARDUINO_ESP8266_RELEASE and ARDUINO_ESP8266_RELEASE_2_7_1)
 #endif // ESP32_STAGE
+#include <atomic>
 #include "include/tasmota_compat.h"
 #include "include/tasmota_version.h"        // Tasmota version information
 #include "include/tasmota.h"                // Enumeration used in my_user_config.h
@@ -149,13 +150,13 @@ TRtcReboot RtcReboot;
 static RTC_NOINIT_ATTR TRtcReboot RtcDataReboot;
 #endif  // ESP32
 
-typedef struct {
+struct TRtcSettings {
   uint16_t      valid;                     // 290  (RTC memory offset 100)
   uint8_t       oswatch_blocked_loop;      // 292
   uint8_t       ota_loader;                // 293
   uint32_t      ex_energy_kWhtoday;        // 294
   uint32_t      ex_energy_kWhtotal;        // 298
-  volatile uint32_t pulse_counter[MAX_COUNTERS];  // 29C - See #9521 why volatile
+  std::atomic<uint32_t> pulse_counter[MAX_COUNTERS];  // 29C - See #9521 why volatile
   power_t       power;                     // 2AC
   EnergyUsage   energy_usage;              // 2B0
   uint32_t      nextwakeup;                // 2C8
@@ -170,7 +171,7 @@ typedef struct {
   int32_t       energy_kWhtotal_ph[3];     // 2E4
   int32_t       energy_kWhexport_ph[3];    // 2F0
   uint32_t      utc_time;                  // 2FC
-} TRtcSettings;
+};
 TRtcSettings RtcSettings;
 #ifdef ESP32
 static RTC_NOINIT_ATTR TRtcSettings RtcDataSettings;

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -67,7 +67,7 @@ void RtcSettingsSave(void) {
     ESP.rtcUserMemoryWrite(100, (uint32_t*)&RtcSettings, sizeof(RtcSettings));
 #endif  // ESP8266
 #ifdef ESP32
-    RtcDataSettings = RtcSettings;
+    memcpy((void*)&RtcDataSettings, &RtcSettings, sizeof(RtcSettings));
 #endif  // ESP32
 
     rtc_settings_crc = GetRtcSettingsCrc();
@@ -79,7 +79,7 @@ bool RtcSettingsLoad(uint32_t update) {
   ESP.rtcUserMemoryRead(100, (uint32_t*)&RtcSettings, sizeof(RtcSettings));  // 0x290
 #endif  // ESP8266
 #ifdef ESP32
-  RtcSettings = RtcDataSettings;
+  memcpy((void*)&RtcSettings, &RtcDataSettings, sizeof(RtcSettings));
 #endif  // ESP32
 
   bool read_valid = (RTC_MEM_VALID == RtcSettings.valid);

--- a/tasmota/tasmota_xsns_sensor/xsns_01_counter.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_01_counter.ino
@@ -213,7 +213,7 @@ void CounterShow(bool json)
         dtostrfd((double)RtcSettings.pulse_counter[i] / 1000000, 6, counter);
       } else {
         dsxflg++;
-        snprintf_P(counter, sizeof(counter), PSTR("%lu"), RtcSettings.pulse_counter[i]);
+        snprintf_P(counter, sizeof(counter), PSTR("%lu"), RtcSettings.pulse_counter[i].load());
       }
 
       if (json) {


### PR DESCRIPTION
## Description:

Tentative change from `volatile` to `std::atomic` for Pulse_Counter. Unfortunately there is no simple way in C++ to copy a struct containing atomic values, so we use `memcpy` instead, thanks to the fact that each pulse_counter value is 32 bits aligned, so it is atomic per each value.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
