### PR TITLE
regression of MAX_SHUTTERS for stepper motors

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
@@ -668,6 +668,8 @@ void ShutterInit(void)
         break;
         case SHT_COUNTER:
           ShutterGlobal.open_velocity_max = ShutterSettings.open_velocity_max;
+	  // Limit the numbers of shutter to 4 because only 4 counters can be defined
+          TasmotaGlobal.shutters_present = tmin(TasmotaGlobal.shutters_present, 4);
         break; 
       }
            


### PR DESCRIPTION
maximize on 4 stepper shutters due to limits in number of counter

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
