### PR TITLE
Label of upload button

### DIFF
--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Herbegin"
 #define D_RESTARTING "Herbegin"
 #define D_RESTART_REASON "Herlaai rede"
-#define D_RESTORE "herstel"
 #define D_RETAINED "behou"
 #define D_RULE "Reël"
 #define D_SAVE "Stoor"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "opgradeer"
 #define D_UPLOAD "Laai op"
 #define D_UPTIME "Uptyd"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Stel die konfigurasie terug"
 #define D_BACKUP_CONFIGURATION "Rugsteun die konfigurasie"
 #define D_RESTORE_CONFIGURATION "Herstel die konfigurasie"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Hoofkieslys"
 
 #define D_MODULE_PARAMETERS "Moduleparameters"

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Рестартиране"
 #define D_RESTARTING "Рестартиране"
 #define D_RESTART_REASON "Причина за рестарт"
-#define D_RESTORE "възстановяване"
 #define D_RETAINED "запазено"
 #define D_RULE "Правило"
 #define D_SAVE "Запазване"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "Обновяване"
 #define D_UPLOAD "Качването е"
 #define D_UPTIME "Време на работа"
 #define D_USED "използвано"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Нулиране на настройки"
 #define D_BACKUP_CONFIGURATION "Резервно копие на настройки"
 #define D_RESTORE_CONFIGURATION "Възстановяване на настройки"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Начало"
 
 #define D_MODULE_PARAMETERS "Параметри на модула"

--- a/tasmota/language/ca_AD.h
+++ b/tasmota/language/ca_AD.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Reinici"
 #define D_RESTARTING "Reinciant"
 #define D_RESTART_REASON "Raó de resinici"
-#define D_RESTORE "recuperar"
 #define D_RETAINED "retingut"
 #define D_RULE "Regla"
 #define D_SAVE "Guardar"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "actualitza"
 #define D_UPLOAD "Envia"
 #define D_UPTIME "Temps engegat"
 #define D_USED "usat"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Reiniciar la Configuració"
 #define D_BACKUP_CONFIGURATION "Guardar la Configuració"
 #define D_RESTORE_CONFIGURATION "Restaurar la Configuració"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Menú Principal"
 
 #define D_MODULE_PARAMETERS "Paràmetes del Mòdul"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Restart"
 #define D_RESTARTING "Restartování"
 #define D_RESTART_REASON "Příčina restartu"
-#define D_RESTORE "Obnovit"
 #define D_RETAINED "Zachováno"
 #define D_RULE "Rule"
 #define D_SAVE "Ulož"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "aktualizace"
 #define D_UPLOAD "Nahrání..."
 #define D_UPTIME "Uptime"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Reset nastavení"
 #define D_BACKUP_CONFIGURATION "Záloha nastavení"
 #define D_RESTORE_CONFIGURATION "Obnovení nastavení"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Hlavní menu"
 
 #define D_MODULE_PARAMETERS "Nastavení modulu"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v13.1.0.4
+ * Updated until v13.2.0.2 - Last update 16.11.2023
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -166,7 +166,6 @@
 #define D_RESTART "Neustart"
 #define D_RESTARTING "starte neu"
 #define D_RESTART_REASON "Grund für Neustart"
-#define D_RESTORE "Wiederherstellung"
 #define D_RETAINED "beibehalten"
 #define D_RULE "Regel"
 #define D_SAVE "Speichern"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "astronomisch"
 #define D_TWILIGHT_CIVIL "zivil"
 #define D_TWILIGHT_NAUTICAL "nautisch"
-#define D_UPGRADE "update"
 #define D_UPLOAD "Upload"
 #define D_UPTIME "Laufzeit"
 #define D_USED "genutzt"
@@ -290,9 +288,10 @@
 #define D_RESET_CONFIGURATION "Konfiguration zurücksetzen"
 #define D_BACKUP_CONFIGURATION "Konfiguration sichern"
 #define D_RESTORE_CONFIGURATION "Konfiguration wiederherstellen"
+#define D_START_RESTORE "Wiederherstellung starten"
 #define D_MAIN_MENU "Hauptmenü"
 
-#define D_MODULE_PARAMETERS "Geräte-Einstellungen"
+#define D_MODULE_PARAMETERS "Geräteeinstellungen"
 #define D_MODULE_TYPE "Gerätetyp"
 #define D_PULLUP_ENABLE "Pull-up aktiv"
 #define D_ADC "ADC"
@@ -1199,7 +1198,7 @@
 #define D_NEOPOOL_RELAY_VALVE             "Ventil"
 #define D_NEOPOOL_RELAY_AUX               "Aux"
 #define D_NEOPOOL_TIME                    "Zeit"
-#define D_NEOPOOL_FILT_MODE               "Filtration mode"
+#define D_NEOPOOL_FILT_MODE               "Filtermodus"
 #define D_NEOPOOL_CELL_RUNTIME            "Laufzeit Zelle"
 #define D_NEOPOOL_POLARIZATION            "Pol"               // Sensor status
 #define D_NEOPOOL_PR_OFF                  "PrAus"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Επανεκκίνηση"
 #define D_RESTARTING "Επανεκκινεί"
 #define D_RESTART_REASON "Αιτία επανεκκίνησης"
-#define D_RESTORE "επαναφορά"
 #define D_RETAINED "διακράτηση"
 #define D_RULE "Κανόνας"
 #define D_SAVE "Αποθήκευση"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "αναβάθμιση"
 #define D_UPLOAD "Ανέβασμα"
 #define D_UPTIME "Χρόνος λειτουργίας"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Reset"
 #define D_BACKUP_CONFIGURATION "Εξαγωγή"
 #define D_RESTORE_CONFIGURATION "Επαναφορά"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Κεντρικό μενού"
 
 #define D_MODULE_PARAMETERS "Παράμετροι μονάδας"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Restart"
 #define D_RESTARTING "Restarting"
 #define D_RESTART_REASON "Restart Reason"
-#define D_RESTORE "restore"
 #define D_RETAINED "retained"
 #define D_RULE "Rule"
 #define D_SAVE "Save"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "upgrade"
 #define D_UPLOAD "Upload"
 #define D_UPTIME "Uptime"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Reset Configuration"
 #define D_BACKUP_CONFIGURATION "Backup Configuration"
 #define D_RESTORE_CONFIGURATION "Restore Configuration"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Main Menu"
 
 #define D_MODULE_PARAMETERS "Module parameters"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Reiniciar"
 #define D_RESTARTING "Reiniciando"
 #define D_RESTART_REASON "Causa Reinicio"
-#define D_RESTORE "Restauración"
 #define D_RETAINED "Grabado"
 #define D_RULE "Regla"
 #define D_SAVE "Grabar"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "Actualización"
 #define D_UPLOAD "Carga"
 #define D_UPTIME "Tiempo Encendido"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Reset de Configuración"
 #define D_BACKUP_CONFIGURATION "Backup de Configuración"
 #define D_RESTORE_CONFIGURATION "Restaurar Configuración"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Menú Principal"
 
 #define D_MODULE_PARAMETERS "Parámetros del módulo"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Redémarrage"
 #define D_RESTARTING "Redémarre"
 #define D_RESTART_REASON "Raison du redémarrage"
-#define D_RESTORE "restaurer"
 #define D_RETAINED "persistant"		   // MQTT
 #define D_RULE "Règle"
 #define D_SAVE "Enregistrer"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "la mise à jour" 	 // "Lancer la mise à jour"
 #define D_UPLOAD "Upload"            // Not better in french
 #define D_UPTIME "Durée d'activité"
 #define D_USED "utilisé"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Configuration par défaut"
 #define D_BACKUP_CONFIGURATION "Sauvegarde de la config."
 #define D_RESTORE_CONFIGURATION "Restauration de la config."
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Menu principal"
 
 #define D_MODULE_PARAMETERS "Paramètres module"

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Op 'e nij begjinne"
 #define D_RESTARTING "Op 'e nij begjinne"
 #define D_RESTART_REASON "Reden opnij starte"
-#define D_RESTORE "herstelle"
 #define D_RETAINED "beholden"
 #define D_RULE "Regel"
 #define D_SAVE "Bewarje"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "upgrade"
 #define D_UPLOAD "Stjoere"
 #define D_UPTIME "Betjenstiid"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Konfiguraasje weromsette"
 #define D_BACKUP_CONFIGURATION "Konfiguraasje opslaan"
 #define D_RESTORE_CONFIGURATION "Konfiguraasje herstelle"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Haadmenu"
 
 #define D_MODULE_PARAMETERS "Module parameters"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -166,7 +166,6 @@
 #define D_RESTART "איתחול"
 #define D_RESTARTING "הפעלה מחדש"
 #define D_RESTART_REASON "סיבת הפעלה מחדש"
-#define D_RESTORE "שחזור"
 #define D_RETAINED "שמור"
 #define D_RULE "חוק"
 #define D_SAVE "שמירה"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "שדרוג"
 #define D_UPLOAD "העלאה"
 #define D_UPTIME "זמן עליה"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "אתחול הגדרות"
 #define D_BACKUP_CONFIGURATION "גיבוי הגדרות"
 #define D_RESTORE_CONFIGURATION "שחזור הגדרות"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "תפריט ראשי"
 
 #define D_MODULE_PARAMETERS "מודול פרמטרים"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Újraindítás"
 #define D_RESTARTING "Újraindítás"
 #define D_RESTART_REASON "Utolsó újraindulás oka"
-#define D_RESTORE "Visszaállítás"
 #define D_RETAINED "megtartott"
 #define D_RULE "Szabály"
 #define D_SAVE "Mentés"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "Frissítés"
 #define D_UPLOAD "Feltöltés"
 #define D_UPTIME "Üzemidő"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Beállítások törlése"
 #define D_BACKUP_CONFIGURATION "Beállítások mentése"
 #define D_RESTORE_CONFIGURATION "Beállítások visszatöltése"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Menü"
 
 #define D_MODULE_PARAMETERS "Modul paraméterek"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -166,7 +166,6 @@
 #define D_RESTART              "Riavvia"
 #define D_RESTARTING           "Riavvio"
 #define D_RESTART_REASON       "Causa riavvio"
-#define D_RESTORE              "ripristino"
 #define D_RETAINED             "salvato"
 #define D_RULE                 "Regola"
 #define D_SAVE                 "Salva"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "astronomico"
 #define D_TWILIGHT_CIVIL       "civile"
 #define D_TWILIGHT_NAUTICAL    "nautico"
-#define D_UPGRADE              "aggiornamento"
 #define D_UPLOAD               "Caricamento"
 #define D_UPTIME               "Tempo accensione"
 #define D_USED                 "usati"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION          "Impostazioni predefinite"
 #define D_BACKUP_CONFIGURATION         "Salva impostazioni"
 #define D_RESTORE_CONFIGURATION        "Carica impostazioni"
+#define D_START_RESTORE                "Start restore"
 #define D_MAIN_MENU                    "Menu principale"
 
 #define D_MODULE_PARAMETERS  "Parametri modulo"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -166,7 +166,6 @@
 #define D_RESTART "재시작"
 #define D_RESTARTING "재시작 중.."
 #define D_RESTART_REASON "재시작 사유"
-#define D_RESTORE "복구"
 #define D_RETAINED "보류"
 #define D_RULE "규칙"
 #define D_SAVE "저장"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "업그레이드"
 #define D_UPLOAD "업로드"
 #define D_UPTIME "가동시간"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "설정 초기화"
 #define D_BACKUP_CONFIGURATION "설정 백업"
 #define D_RESTORE_CONFIGURATION "설정 복구"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "메인 메뉴"
 
 #define D_MODULE_PARAMETERS "모듈 설정"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Herstart"
 #define D_RESTARTING "Herstarten"
 #define D_RESTART_REASON "Reden herstart"
-#define D_RESTORE "herstellen"
 #define D_RETAINED "behouden"
 #define D_RULE "Regel"
 #define D_SAVE "Opslaan"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "opwaarderen"
 #define D_UPLOAD "Verzenden"
 #define D_UPTIME "Bedrijfstijd"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Reset Configuratie"
 #define D_BACKUP_CONFIGURATION "Bewaar Configuratie"
 #define D_RESTORE_CONFIGURATION "Herstel Configuration"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Hoofdmenu"
 
 #define D_MODULE_PARAMETERS "Module parameters"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Restart"
 #define D_RESTARTING "Restartowanie"
 #define D_RESTART_REASON "Przyczyna restartu"
-#define D_RESTORE "Przywracanie"
 #define D_RETAINED "Zachowane"
 #define D_RULE "Reguła"
 #define D_SAVE "Zapisz"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "aktualizacji"
 #define D_UPLOAD "Wgraj"
 #define D_UPTIME "Czas pracy"
 #define D_USED "użyte"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Reset ustawień"
 #define D_BACKUP_CONFIGURATION "Kopia ustawień"
 #define D_RESTORE_CONFIGURATION "Przywracanie ustawień"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Menu główne"
 
 #define D_MODULE_PARAMETERS "Parametry modułu"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Reiniciar"
 #define D_RESTARTING "Reiniciando"
 #define D_RESTART_REASON "Motivo do reinício"
-#define D_RESTORE "Restauração"
 #define D_RETAINED "Manter"
 #define D_RULE "Regra"
 #define D_SAVE "Salvar"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "atualização"
 #define D_UPLOAD "Enviar"
 #define D_UPTIME "Tempo de atividade"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Apagar configuração"
 #define D_BACKUP_CONFIGURATION "Salvar configuração"
 #define D_RESTORE_CONFIGURATION "Repor configuração"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Menu principal"
 
 #define D_MODULE_PARAMETERS "Parâmetros do módulo"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Reiniciar"
 #define D_RESTARTING "A reiniciar"
 #define D_RESTART_REASON "Razão do reinicio"
-#define D_RESTORE "Restauro"
 #define D_RETAINED "Manter"
 #define D_RULE "Regra"
 #define D_SAVE "Guardar"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "Atualizar"
 #define D_UPLOAD "Enviar"
 #define D_UPTIME "Tempo de Atividade"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Apagar configuração"
 #define D_BACKUP_CONFIGURATION "Guardar configuração"
 #define D_RESTORE_CONFIGURATION "Repor configuração"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Menu Principal"
 
 #define D_MODULE_PARAMETERS "Parametros do Módulo"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Restart"
 #define D_RESTARTING "Restartare"
 #define D_RESTART_REASON "Motiv Restartare"
-#define D_RESTORE "Restaurare"
 #define D_RETAINED "Păstrare"
 #define D_RULE "Regulă"
 #define D_SAVE "Salvare"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "actualizare"
 #define D_UPLOAD "Încărcăre"
 #define D_UPTIME "Folosință"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Resetează Configurare"
 #define D_BACKUP_CONFIGURATION "Backup Configurare"
 #define D_RESTORE_CONFIGURATION "Restaurează Configurație"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Meniu Principal"
 
 #define D_MODULE_PARAMETERS "Parametri modul"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -167,7 +167,6 @@
 #define D_RESTART "Перезагрузка"
 #define D_RESTARTING "Перезагрузка"
 #define D_RESTART_REASON "Причина перезагрузки"
-#define D_RESTORE "восстановление"
 #define D_RETAINED "нераспред."
 #define D_RULE "Правило"
 #define D_SAVE "Сохранить"
@@ -193,7 +192,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "обновление"
 #define D_UPLOAD "Загрузить"
 #define D_UPTIME "Аптайм"
 #define D_USED "использовано"
@@ -291,6 +289,7 @@
 #define D_RESET_CONFIGURATION "Сброс настроек"
 #define D_BACKUP_CONFIGURATION "Резервное копирование настроек"
 #define D_RESTORE_CONFIGURATION "Восстановление настроек"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Главное меню"
 
 #define D_MODULE_PARAMETERS "Настройки модуля"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Reštart"
 #define D_RESTARTING "Reštartuje sa"
 #define D_RESTART_REASON "Príčina reštartu"
-#define D_RESTORE "Obnoviť"
 #define D_RETAINED "Zachované"
 #define D_RULE "Pravidlo"
 #define D_SAVE "Ulož"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "aktualizáciu"
 #define D_UPLOAD "Nahrávanie..."
 #define D_UPTIME "Uptime"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Reset nastavení"
 #define D_BACKUP_CONFIGURATION "Záloha nastavení"
 #define D_RESTORE_CONFIGURATION "Obnovenie nastavení"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Hlavné menu"
 
 #define D_MODULE_PARAMETERS "Nastavenia modulu"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Omstart"
 #define D_RESTARTING "Startar om"
 #define D_RESTART_REASON "Omstartsorsak"
-#define D_RESTORE "återställ"
 #define D_RETAINED "bevarad"
 #define D_RULE "Regel"
 #define D_SAVE "Spara"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "uppgradera"
 #define D_UPLOAD "Ladda upp"
 #define D_UPTIME "Upptid"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Nollställ konfiguration"
 #define D_BACKUP_CONFIGURATION "Säkerhetskopiera konfiguration"
 #define D_RESTORE_CONFIGURATION "Återställ konfiguration"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Huvudmeny"
 
 #define D_MODULE_PARAMETERS "Modulparameterar"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Yeniden Başlat"
 #define D_RESTARTING "Yeniden Başlatılıyor"
 #define D_RESTART_REASON "Yeniden Başlatma Sebebi"
-#define D_RESTORE "restore"
 #define D_RETAINED "tutulan"
 #define D_RULE "Kural"
 #define D_SAVE "Kaydet"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "yükseltme"
 #define D_UPLOAD "Yükleme"
 #define D_UPTIME "Açık Kalma Süresi"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Tüm Ayarları Resetle"
 #define D_BACKUP_CONFIGURATION "Ayarları Yedekle"
 #define D_RESTORE_CONFIGURATION "Ayarları Geri Yükle"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Ana Menü"
 
 #define D_MODULE_PARAMETERS "Modül parametreleri"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Перезавантаження"
 #define D_RESTARTING "Перезавантаження"
 #define D_RESTART_REASON "Причина перезавантаження"
-#define D_RESTORE "відновлення"
 #define D_RETAINED "зберігати"
 #define D_RULE "Правило"
 #define D_SAVE "Зберегти"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "оновлення"
 #define D_UPLOAD "Завантажити"
 #define D_UPTIME "Час роботи"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Скидання конфігурації"
 #define D_BACKUP_CONFIGURATION "Резервне копіювання конфігурації"
 #define D_RESTORE_CONFIGURATION "Відновлення конфігурації"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Головне меню"
 
 #define D_MODULE_PARAMETERS "Параметри модуля"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -166,7 +166,6 @@
 #define D_RESTART "Khởi động lại"
 #define D_RESTARTING "Đang khởi động"
 #define D_RESTART_REASON "Lý do khởi động lại"
-#define D_RESTORE "khôi phục"
 #define D_RETAINED "lưu giữ"
 #define D_RULE "Quy luật"
 #define D_SAVE "Lưu"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "nâng cấp"
 #define D_UPLOAD "Tải lên"
 #define D_UPTIME "Thời gian chạy"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "Xóa cấu hình"
 #define D_BACKUP_CONFIGURATION "Tạo bản lưu cấu hình"
 #define D_RESTORE_CONFIGURATION "Khôi phục cấu hình"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "Màn hình chính"
 
 #define D_MODULE_PARAMETERS "Các thông số mô đun"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -166,7 +166,6 @@
 #define D_RESTART "重启"
 #define D_RESTARTING "正在重启"
 #define D_RESTART_REASON "重启原因"
-#define D_RESTORE "恢复"
 #define D_RETAINED "已保留"
 #define D_RULE "规则"
 #define D_SAVE "保存"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "升级"
 #define D_UPLOAD "上传"
 #define D_UPTIME "运行时间"
 #define D_USED "已使用"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "重置配置"
 #define D_BACKUP_CONFIGURATION "备份配置"
 #define D_RESTORE_CONFIGURATION "还原配置"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "主菜单"
 
 #define D_MODULE_PARAMETERS "模块设置"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -166,7 +166,6 @@
 #define D_RESTART "重新啟動"
 #define D_RESTARTING "正在重新啟動"
 #define D_RESTART_REASON "重新啟動的原因"
-#define D_RESTORE "讀取設定"
 #define D_RETAINED "已保留"
 #define D_RULE "規則"
 #define D_SAVE "儲存"
@@ -192,7 +191,6 @@
 #define D_TWILIGHT_ASTRONOMICAL "Astronomical"
 #define D_TWILIGHT_CIVIL "Civil"
 #define D_TWILIGHT_NAUTICAL "Nautical"
-#define D_UPGRADE "升級"
 #define D_UPLOAD "上傳"
 #define D_UPTIME "啟動時間"
 #define D_USED "used"
@@ -290,6 +288,7 @@
 #define D_RESET_CONFIGURATION "重設設定"
 #define D_BACKUP_CONFIGURATION "備份設定"
 #define D_RESTORE_CONFIGURATION "回復設定"
+#define D_START_RESTORE "Start restore"
 #define D_MAIN_MENU "主選單"
 
 #define D_MODULE_PARAMETERS "模組參數"

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -360,7 +360,7 @@ const char HTTP_FORM_RST_UPG[] PROGMEM =
   "<br><input type='file' name='u2'><br>"
   "<br><button type='submit' "
   "onclick='eb(\"f1\").style.display=\"none\";eb(\"f2\").style.display=\"block\";this.form.action+=this.form[\"u2\"].files[0].size;this.form.submit();'"
-    ">" D_START " %s</button></form>"
+    ">%s</button></form>"
   "</fieldset>"
   "</div>"
   "<div id='f2' style='display:none;text-align:center;'><b>" D_UPLOAD_STARTED "...</b></div>";
@@ -371,7 +371,7 @@ const char HTTP_FORM_RST_UPG_FCT[] PROGMEM =
   "<br><input type='file' name='u2'><br>"
   "<br><button type='submit' "
   "onclick='eb(\"f1\").style.display=\"none\";eb(\"f3\").style.display=\"block\";this.form.action+=this.form[\"u2\"].files[0].size;return upl(this);'"
-    ">" D_START " %s</button></form>"
+    ">%s</button></form>"
   "</fieldset>"
   "</div>"
   "<div id='f3' style='display:none;text-align:center;'><b>" D_UPLOAD_FACTORY "...</b></div>"
@@ -2318,7 +2318,7 @@ void HandleRestoreConfiguration(void)
   WSContentStart_P(PSTR(D_RESTORE_CONFIGURATION));
   WSContentSendStyle();
   WSContentSend_P(HTTP_FORM_RST);
-  WSContentSend_P(HTTP_FORM_RST_UPG, PSTR(D_RESTORE));
+  WSContentSend_P(HTTP_FORM_RST_UPG, PSTR(D_START_RESTORE));
   if (WifiIsInManagerMode()) {
     WSContentSpaceButton(BUTTON_MAIN);
   } else {
@@ -2627,12 +2627,12 @@ void HandleUpgradeFirmware(void) {
   WSContentSend_P(HTTP_FORM_UPG, SettingsText(SET_OTAURL));
 #ifdef ESP32
   if (EspSingleOtaPartition() && !EspRunningFactoryPartition()) {
-    WSContentSend_P(HTTP_FORM_RST_UPG_FCT, PSTR(D_UPGRADE));
+    WSContentSend_P(HTTP_FORM_RST_UPG_FCT, PSTR(D_START_UPGRADE));
   } else {
-    WSContentSend_P(HTTP_FORM_RST_UPG, PSTR(D_UPGRADE));
+    WSContentSend_P(HTTP_FORM_RST_UPG, PSTR(D_START_UPGRADE));
   }
 #else
-  WSContentSend_P(HTTP_FORM_RST_UPG, PSTR(D_UPGRADE));
+  WSContentSend_P(HTTP_FORM_RST_UPG, PSTR(D_START_UPGRADE));
 #endif
   WSContentSpaceButton(BUTTON_MAIN);
   WSContentStop();


### PR DESCRIPTION
## Description:

As the label of the upload button is concatenated at runtime, it does not match in all languages. To solve this, there is now a full label text for `Start upgrade` and `Start restore`.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).