### PR TITLE
Enables support for IM350

### DIFF
--- a/lib/lib_div/ams/GcmParser.cpp
+++ b/lib/lib_div/ams/GcmParser.cpp
@@ -36,10 +36,6 @@ int8_t GCMParser::parse(uint8_t *d, DataParserContext &ctx) {
     int len = 0;
     int headersize = 2 + systemTitleLength;
     ptr += systemTitleLength;
-#ifdef USE_IM350
-    len=*ptr;
-    ptr++;
-#else
     if(((*ptr) & 0xFF) == 0x81) {
         ptr++;
         len = *ptr;
@@ -62,8 +58,11 @@ int8_t GCMParser::parse(uint8_t *d, DataParserContext &ctx) {
     // ???????? single frame did only decode with this compare
         ptr++;
         headersize++;
+    } else {
+        len = *ptr;
+        ptr++;
+        headersize++;
     }
-#endif
     if(len + headersize > ctx.length)
         return DATA_PARSE_INCOMPLETE;
 

--- a/lib/lib_div/ams/GcmParser.cpp
+++ b/lib/lib_div/ams/GcmParser.cpp
@@ -36,6 +36,10 @@ int8_t GCMParser::parse(uint8_t *d, DataParserContext &ctx) {
     int len = 0;
     int headersize = 2 + systemTitleLength;
     ptr += systemTitleLength;
+#ifdef USE_IM350
+    len=*ptr;
+    ptr++;
+#else
     if(((*ptr) & 0xFF) == 0x81) {
         ptr++;
         len = *ptr;
@@ -59,6 +63,7 @@ int8_t GCMParser::parse(uint8_t *d, DataParserContext &ctx) {
         ptr++;
         headersize++;
     }
+#endif
     if(len + headersize > ctx.length)
         return DATA_PARSE_INCOMPLETE;
 


### PR DESCRIPTION
## Description:

Fixes the decryption code for the Simens IM350 issued by Wiener Netze

It has been implemented using the define USE_IM350 to grantee compatibility with older versions and other devices.

During dry runs also solved #18560 / #18561

## Checklist:
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
