### PR TITLE
Sensor57 TSL2591 Light Sensor Commands

### DIFF
--- a/lib/lib_i2c/Adafruit_TSL2591_Library/Adafruit_TSL2591.cpp
+++ b/lib/lib_i2c/Adafruit_TSL2591_Library/Adafruit_TSL2591.cpp
@@ -117,7 +117,7 @@ enum
 Adafruit_TSL2591::Adafruit_TSL2591()
 {
   _initialized = false;
-  _integration = TSL2591_INTEGRATIONTIME_300MS;
+  _integration = TSL2591_INTEGRATIONTIME_100MS;
   _gain        = TSL2591_GAIN_MED;
 
   // we cant do wire initialization till later, because we havent loaded Wire yet

--- a/lib/lib_i2c/Adafruit_TSL2591_Library/Adafruit_TSL2591.cpp
+++ b/lib/lib_i2c/Adafruit_TSL2591_Library/Adafruit_TSL2591.cpp
@@ -117,7 +117,7 @@ enum
 Adafruit_TSL2591::Adafruit_TSL2591()
 {
   _initialized = false;
-  _integration = TSL2591_INTEGRATIONTIME_100MS;
+  _integration = TSL2591_INTEGRATIONTIME_300MS;
   _gain        = TSL2591_GAIN_MED;
 
   // we cant do wire initialization till later, because we havent loaded Wire yet

--- a/tasmota/tasmota_xsns_sensor/xsns_57_tsl2591.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_57_tsl2591.ino
@@ -108,8 +108,8 @@ bool tsl2591CommandSensor() {
   tsl.setGain(gain_enum_array[XdrvMailbox.payload-1]);
   tsl.setTiming(int_enum_array[value-1]);
 
-  Response_P(PSTR(" {Gain input = %d} {Gain hex = %d}"),XdrvMailbox.payload,tsl.getGain());
-  ResponseAppend_P(PSTR(" {Timing input = %d} {Timing hex = %d}"),value,tsl.getTiming());
+  Response_P(PSTR("{\"Gain input\":%d,\"Gain hex\":0x%x,"),XdrvMailbox.payload,tsl.getGain());
+  ResponseAppend_P(PSTR("\"Timing input\":%d,\"Timing hex\":0x0%x}"),value,tsl.getTiming());
   return serviced;
 }
 

--- a/tasmota/tasmota_xsns_sensor/xsns_57_tsl2591.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_57_tsl2591.ino
@@ -39,6 +39,9 @@ uint8_t tsl2591_type = 0;
 uint8_t tsl2591_valid = 0;
 float tsl2591_lux = 0;
 
+tsl2591Gain_t gain_enum_array[4] = {TSL2591_GAIN_LOW,TSL2591_GAIN_MED,TSL2591_GAIN_HIGH,TSL2591_GAIN_MAX};
+tsl2591IntegrationTime_t int_enum_array[6] = {TSL2591_INTEGRATIONTIME_100MS,TSL2591_INTEGRATIONTIME_200MS,TSL2591_INTEGRATIONTIME_300MS,TSL2591_INTEGRATIONTIME_400MS,TSL2591_INTEGRATIONTIME_500MS,TSL2591_INTEGRATIONTIME_600MS};
+
 void Tsl2591Init(void)
 {
 //  if (I2cSetDevice(0x29) || I2cSetDevice(0x39) || I2cSetDevice(0x49)) {
@@ -94,49 +97,17 @@ bool tsl2591CommandSensor() {
   bool serviced = true;
   char argument[XdrvMailbox.data_len];
   long value = 0;
-  
+
   for (uint32_t ca = 0; ca < XdrvMailbox.data_len; ca++) {
     if ((' ' == XdrvMailbox.data[ca]) || ('=' == XdrvMailbox.data[ca])) { XdrvMailbox.data[ca] = ','; }
   }
-  
+
   bool any_value = (strchr(XdrvMailbox.data, ',') != nullptr);
   if (any_value) { value = strtol(ArgV(argument, 2), nullptr, 10); }
-  switch (XdrvMailbox.payload) {
-    case 1:
-      tsl.setGain(TSL2591_GAIN_LOW);
-      break;
-    case 2:
-      tsl.setGain(TSL2591_GAIN_MED);
-      break;
-    case 3:
-      tsl.setGain(TSL2591_GAIN_HIGH);
-      break;
-    case 4:
-      tsl.setGain(TSL2591_GAIN_MAX);
-      break;
-  }
-  if (any_value) {
-    switch (value) {
-        case 1:
-          tsl.setTiming(TSL2591_INTEGRATIONTIME_100MS);
-          break;
-        case 2:
-          tsl.setTiming(TSL2591_INTEGRATIONTIME_200MS);
-          break;
-        case 3:
-          tsl.setTiming(TSL2591_INTEGRATIONTIME_300MS);
-          break;
-        case 4:
-          tsl.setTiming(TSL2591_INTEGRATIONTIME_400MS);
-          break;
-        case 5:
-          tsl.setTiming(TSL2591_INTEGRATIONTIME_500MS);
-          break;
-        case 6:
-          tsl.setTiming(TSL2591_INTEGRATIONTIME_600MS);
-          break;
-      }
-  }
+
+  tsl.setGain(gain_enum_array[XdrvMailbox.payload-1]);
+  tsl.setTiming(int_enum_array[value-1]);
+
   Response_P(PSTR(" {Gain input = %d} {Gain hex = %d}"),XdrvMailbox.payload,tsl.getGain());
   ResponseAppend_P(PSTR(" {Timing input = %d} {Timing hex = %d}"),value,tsl.getTiming());
   return serviced;

--- a/tasmota/tasmota_xsns_sensor/xsns_57_tsl2591.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_57_tsl2591.ino
@@ -90,6 +90,62 @@ void Tsl2591Show(bool json)
   }
 }
 
+bool tsl2591CommandSensor() {
+  bool serviced = true;
+
+  //tsl.setGain(TSL2591_GAIN_LOW);
+  //Response_P("test");
+
+  char argument[XdrvMailbox.data_len];
+
+  long value = 0;
+  for (uint32_t ca = 0; ca < XdrvMailbox.data_len; ca++) {
+    if ((' ' == XdrvMailbox.data[ca]) || ('=' == XdrvMailbox.data[ca])) { XdrvMailbox.data[ca] = ','; }
+  }
+
+  bool any_value = (strchr(XdrvMailbox.data, ',') != nullptr);
+
+  if (any_value) { value = strtol(ArgV(argument, 2), nullptr, 10); }
+
+  switch (XdrvMailbox.payload) {
+    case 1:
+      tsl.setGain(TSL2591_GAIN_LOW);
+      break;
+    case 2:
+      tsl.setGain(TSL2591_GAIN_MED);
+      break;
+    case 3:
+      tsl.setGain(TSL2591_GAIN_HIGH);
+      break;
+    case 4:
+      tsl.setGain(TSL2591_GAIN_MAX);
+      break;
+  }
+  if (any_value) {
+    switch (value) {
+        case 1:
+          tsl.setTiming(TSL2591_INTEGRATIONTIME_100MS);
+          break;
+        case 2:
+          tsl.setTiming(TSL2591_INTEGRATIONTIME_200MS);
+          break;
+        case 3:
+          tsl.setTiming(TSL2591_INTEGRATIONTIME_300MS);
+          break;
+        case 4:
+          tsl.setTiming(TSL2591_INTEGRATIONTIME_400MS);
+          break;
+        case 5:
+          tsl.setTiming(TSL2591_INTEGRATIONTIME_500MS);
+          break;
+        case 6:
+          tsl.setTiming(TSL2591_INTEGRATIONTIME_600MS);
+          break;
+      }
+  }
+  return serviced;
+}
+
 /*********************************************************************************************\
  * Interface
 \*********************************************************************************************/
@@ -116,6 +172,11 @@ bool Xsns57(uint32_t function)
         Tsl2591Show(0);
         break;
 #endif  // USE_WEBSERVER
+      case FUNC_COMMAND_SENSOR:
+        if (XSNS_57 == XdrvMailbox.index) {
+          result = tsl2591CommandSensor();
+        }
+        break;
     }
   }
   return result;

--- a/tasmota/tasmota_xsns_sensor/xsns_57_tsl2591.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_57_tsl2591.ino
@@ -92,21 +92,15 @@ void Tsl2591Show(bool json)
 
 bool tsl2591CommandSensor() {
   bool serviced = true;
-
-  //tsl.setGain(TSL2591_GAIN_LOW);
-  //Response_P("test");
-
   char argument[XdrvMailbox.data_len];
-
   long value = 0;
+  
   for (uint32_t ca = 0; ca < XdrvMailbox.data_len; ca++) {
     if ((' ' == XdrvMailbox.data[ca]) || ('=' == XdrvMailbox.data[ca])) { XdrvMailbox.data[ca] = ','; }
   }
-
+  
   bool any_value = (strchr(XdrvMailbox.data, ',') != nullptr);
-
   if (any_value) { value = strtol(ArgV(argument, 2), nullptr, 10); }
-
   switch (XdrvMailbox.payload) {
     case 1:
       tsl.setGain(TSL2591_GAIN_LOW);
@@ -143,6 +137,8 @@ bool tsl2591CommandSensor() {
           break;
       }
   }
+  Response_P(PSTR(" {Gain input = %d} {Gain hex = %d}"),XdrvMailbox.payload,tsl.getGain());
+  ResponseAppend_P(PSTR(" {Timing input = %d} {Timing hex = %d}"),value,tsl.getTiming());
   return serviced;
 }
 


### PR DESCRIPTION
## Description:
Added command functionality to the Sensor57 TSL2591 module via console. The commands allow users to adjust the gain and integration time of the sensor for the light values being returned. The tree is as follows:

`Sensor57 <gain> <integration>`

For `gain`:
- `1` is low
- `2` is medium
- `3` is high
- `4` is max

For `integration` time:
- `1` is 100ms
- `2` is 200ms
- `3` is 300ms
- `4` is 400ms
- `5` is 500ms
- `6` is 600ms

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).