### PR TITLE
Fixed `changeUIntScale` for linearity when expanding range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Matter update hierarchy of plugins (#19915)
 - NeoPool ``NPHydrolysis`` percent and unit (#19924)
 - Thermostat JSON index from 0 to 1 (#20011)
+- Fixed `changeUIntScale` for linearity when expanding range
 
 ### Fixed
 - Scripter timer issue (#19914)

--- a/tasmota/tasmota_support/support_float.ino
+++ b/tasmota/tasmota_support/support_float.ino
@@ -412,8 +412,13 @@ uint16_t changeUIntScale(uint16_t inum, uint16_t ifrom_min, uint16_t ifrom_max,
 
   uint32_t result;
   if ((num - from_min) < 0x8000L) {   // no overflow possible
-    uint32_t numerator = ((num - from_min) * 2 + 1) * (to_max - to_min + 1);
-    result = numerator / ((from_max - from_min + 1) * 2) + to_min;
+    if (to_max - to_min > from_max - from_min) {
+      uint32_t numerator = (num - from_min) * (to_max - to_min) * 2;
+      result = ((numerator / (from_max - from_min)) + 1 ) / 2 + to_min;
+    } else {
+      uint32_t numerator = ((num - from_min) * 2 + 1) * (to_max - to_min + 1);
+      result = numerator / ((from_max - from_min + 1) * 2) + to_min;
+    }
   } else {    // no pre-rounding since it might create an overflow
     uint32_t numerator = (num - from_min) * (to_max - to_min + 1);
     result = numerator / (from_max - from_min) + to_min;


### PR DESCRIPTION
## Description:

Fixed `changeUIntScale` to force linearity when expanding range, while keeping a bucket approximation when shortening range.

Checked that going from 0..100 -> 0..255 -> 0..100 ends with the same number as the origin. This is useful for dimmer/brightness conversion without drift.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
