### PR TITLE
use LTO for riscv too for Tasmota Core 3.0.0

### DIFF
--- a/platformio_tasmota_core3_env_sample.ini
+++ b/platformio_tasmota_core3_env_sample.ini
@@ -129,11 +129,9 @@ lib_ignore              = ${env:arduino30.lib_ignore}
 extends                 = env:arduino30
 board                   = esp32c2
 build_unflags           = ${env:arduino30.build_unflags}
-                          -flto
                           -mtarget-align
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -fno-lto
                           -DOTA_URL='""'
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
@@ -142,11 +140,9 @@ lib_ignore              = ${env:arduino30.lib_ignore}
 extends                 = env:arduino30
 board                   = esp32c3
 build_unflags           = ${env:arduino30.build_unflags}
-                          -flto
                           -mtarget-align
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -fno-lto
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
 
@@ -154,11 +150,9 @@ lib_ignore              = ${env:arduino30.lib_ignore}
 extends                 = env:arduino30
 board                   = esp32c3cdc
 build_unflags           = ${env:arduino30.build_unflags}
-                          -flto
                           -mtarget-align
 build_flags             = ${env:arduino30.build_flags}
                           -DFIRMWARE_ARDUINO30
-                          -fno-lto
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}
 
@@ -166,10 +160,8 @@ lib_ignore              = ${env:arduino30.lib_ignore}
 extends                 = env:arduino30
 board                   = esp32c6
 build_unflags           = ${env:arduino30.build_unflags}
-                          -flto
                           -mtarget-align
 build_flags             = ${env:arduino30.build_flags}
-                          -fno-lto
                           -DFIRMWARE_ARDUINO30
                           -DOTA_URL='""'
 monitor_filters         = esp32_exception_decoder
@@ -179,10 +171,8 @@ lib_ignore              = ${env:arduino30.lib_ignore}
 extends                 = env:arduino30
 board                   = esp32c6cdc
 build_unflags           = ${env:arduino30.build_unflags}
-                          -flto
                           -mtarget-align
 build_flags             = ${env:arduino30.build_flags}
-                          -fno-lto
                           -DFIRMWARE_ARDUINO30
                           -DOTA_URL='""'
 monitor_filters         = esp32_exception_decoder
@@ -192,10 +182,8 @@ lib_ignore              = ${env:arduino30.lib_ignore}
 extends                 = env:arduino30
 board                   = esp32c6cdc
 build_unflags           = ${env:arduino30.build_unflags}
-                          -flto
                           -mtarget-align
 build_flags             = ${env:arduino30.build_flags}
-                          -fno-lto
                           -DFIRMWARE_ARDUINO30
                           -DUSE_MI_EXT_GUI
                           -DUSE_MI_ESP32


### PR DESCRIPTION
LTO riscv issue is fixed in gcc used for building core 3

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
