### PR TITLE
Berry example: instantiate correct class Rainbow_stripes

### DIFF
--- a/tasmota/berry/leds/rainbow.be
+++ b/tasmota/berry/leds/rainbow.be
@@ -106,7 +106,7 @@ end
 #-
 
 var strip = Leds.matrix(5,5, gpio.pin(gpio.WS2812, 1))
-var r = Rainbow_Matrix(strip, 0.5)
+var r = Rainbow_stripes(strip, 0.5)
 r.start()
 
 -#


### PR DESCRIPTION
## Description:

@s-hadinger I suppose, that this is the intended call.

BTW, all LED matrix function are broken (wrong pixel positions), when used on the Ulanzi pixel clock. Will explore further ....

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
