### PR TITLE
build process: simplify driver selection for BLE

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -105,8 +105,8 @@ lib_ignore                  = TTGO TWatch Library
 [env:tasmota32-mi32]
 extends                     = env:tasmota32_base
 build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
-                              -DUSE_MI_ESP32
                               -DOTA_URL='""'
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
 lib_ignore                  = ESP8266Audio
@@ -119,8 +119,8 @@ lib_ignore                  = ESP8266Audio
 [env:tasmota32c3-mi32]
 extends                     = env:tasmota32c3
 build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
-                              -DUSE_MI_ESP32
                               -DOTA_URL='""'
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
 lib_ignore                  = ESP8266Audio
@@ -133,8 +133,8 @@ lib_ignore                  = ESP8266Audio
 [env:tasmota32s3-mi32]
 extends                     = env:tasmota32s3
 build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
-                              -DUSE_MI_ESP32
                               -DOTA_URL='""'
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
 lib_ignore                  = ESP8266Audio

--- a/platformio_tasmota_core3_env_sample.ini
+++ b/platformio_tasmota_core3_env_sample.ini
@@ -184,9 +184,8 @@ board                   = esp32c6cdc
 build_unflags           = ${env:arduino30.build_unflags}
                           -mtarget-align
 build_flags             = ${env:arduino30.build_flags}
-                          -DFIRMWARE_ARDUINO30
+                          -DFIRMWARE_BLUETOOTH
                           -DUSE_MI_EXT_GUI
-                          -DUSE_MI_ESP32
                           -DOTA_URL='""'
 monitor_filters         = esp32_exception_decoder
 lib_ignore              = ${env:arduino30.lib_ignore}

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -272,12 +272,16 @@
 
 #define USE_SDCARD
 
-#define USE_ADC
+#ifndef USE_BERRY_ULP                              // potential performance gains with ULP
+  #define USE_ADC                                  // so do not use common ADC funtions in that case
+#endif
 //#undef USE_BERRY                                 // Disable Berry scripting language
 
 #define USE_ETHERNET                             // Add support for ethernet (+20k code)
-#define USE_BLE_ESP32                            // Enable full BLE driver
-#define USE_EQ3_ESP32
+#ifndef USE_MI_EXT_GUI
+  #define USE_BLE_ESP32                            // Enable full BLE driver
+  #define USE_EQ3_ESP32
+#endif // USE_MI_EXT_GUI
 #define USE_MI_ESP32                             // (ESP32 only) Add support for ESP32 as a BLE-bridge (+9k2 mem, +292k flash)
 
 #endif  // FIRMWARE_BLUETOOTH


### PR DESCRIPTION
## Description:

@Jason2866 
IMHO this makes it easier to select the intended Bluetooth driver.

`-DFIRMWARE_BLUETOOTH` will still select the main BLE driver by default.
But adding `-DUSE_MI_EXT_GUI` will fall back to the legacy driver.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
