### PR TITLE
Change HX711 default calibration percentage to 10 from 1

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_34_hx711.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_34_hx711.ino
@@ -44,7 +44,7 @@
 #define HX_SCALE             120     // Default result of measured weight / reference weight when scale is 1
 #endif
 #ifndef HX711_CAL_PRECISION
-#define HX711_CAL_PRECISION  1     // When calibration is to course, raise this value.
+#define HX711_CAL_PRECISION  10     // When calibration is too course, raise this value.
 #endif
 
 


### PR DESCRIPTION
Current calibration resolution of 1 gives a resolution of +/-75g on a 20kg load cell, whereas the cheap aliexpress HX711 modules are generally able to output 1g precision on those load cells (https://forum.arduino.cc/t/hx711-noise-free-resolution-tests/351959). Setting calibration precision to 10 or higher allows more accurate calibration. @jeroenst did the PR for this, he may have insight on why the current default is 1.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [x ] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
