### PR TITLE
Berry ULP - API changes for IDF5.x

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_ULP_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_ULP_lib.c
@@ -8,11 +8,6 @@
 
 #if defined(USE_BERRY_ULP) &&  (defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3))
 
-// #include "esp32/ulp.h"
-#include "driver/rtc_io.h"
-#include "driver/gpio.h"
-#include "driver/adc.h"
-
 extern void be_ULP_run(int32_t entry);
 BE_FUNC_CTYPE_DECLARE(be_ULP_run, "", "[i]");
 
@@ -25,10 +20,10 @@ BE_FUNC_CTYPE_DECLARE(be_ULP_set_mem, "i", "ii");
 extern int32_t be_ULP_get_mem(int32_t pos);
 BE_FUNC_CTYPE_DECLARE(be_ULP_get_mem, "i", "i");
 
-extern int32_t be_ULP_gpio_init(gpio_num_t pin, rtc_gpio_mode_t mode);
+extern int32_t be_ULP_gpio_init(int32_t pin, int32_t mode);
 BE_FUNC_CTYPE_DECLARE(be_ULP_gpio_init, "i", "ii");
 
-extern void be_ULP_adc_config(struct bvm *vm, adc1_channel_t channel, adc_atten_t attenuation, adc_bits_width_t width);
+extern void be_ULP_adc_config(struct bvm *vm, int32_t channel, int32_t attenuation, int32_t width);
 BE_FUNC_CTYPE_DECLARE(be_ULP_adc_config, "", "@iii");
 
 extern void be_ULP_sleep(int32_t wake_up_s);

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_ulp.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_ulp.ino
@@ -26,19 +26,29 @@
 #if defined(CONFIG_IDF_TARGET_ESP32)
 #include "esp32/ulp.h"
 #endif // esp32
-#if defined(CONFIG_IDF_TARGET_ESP32S2)
-#include "esp32s2/ulp.h"
-#include "esp32s2/ulp_riscv.h"
-#include "esp32s2/ulp_riscv_adc.h"
-#endif // s2
-#if defined(CONFIG_IDF_TARGET_ESP32S3)
-#include "esp32s3/ulp.h"
-#include "esp32s3/ulp_riscv.h"
-#include "esp32s3/ulp_riscv_adc.h"
-#endif //s3
+#if ESP_IDF_VERSION_MAJOR < 5
+  #if defined(CONFIG_IDF_TARGET_ESP32S2)
+  #include "esp32s2/ulp.h"
+  #include "esp32s2/ulp_riscv.h"
+  #include "esp32s2/ulp_riscv_adc.h"
+  #endif // s2
+  #if defined(CONFIG_IDF_TARGET_ESP32S3)
+  #include "esp32s3/ulp.h"
+  #include "esp32s3/ulp_riscv.h"
+  #include "esp32s3/ulp_riscv_adc.h"
+  #endif //s3
+#endif // ESP_IDF_VERSION_MAJOR < 5
 #include "driver/rtc_io.h"
 #include "driver/gpio.h"
-#include "driver/adc.h"
+#if ESP_IDF_VERSION_MAJOR >= 5
+  #include "esp_adc/adc_oneshot.h"
+  #include "ulp_adc.h"
+  #if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3)
+    #include "ulp_riscv.h"
+  #endif // defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3)
+#else
+  #include "driver/adc.h"
+#endif // ESP_IDF_VERSION_MAJOR >= 5
 
 #include "sdkconfig.h"
 
@@ -92,20 +102,45 @@ extern "C" {
   // enums: channel 0-7, attenuation 0-3, width  0-3
   void be_ULP_adc_config(struct bvm *vm, int32_t channel, int32_t attenuation, int32_t width) {
 #if defined(CONFIG_IDF_TARGET_ESP32)
+#if ESP_IDF_VERSION_MAJOR >= 5
+    ulp_adc_cfg_t cfg = {
+        .adc_n    = ADC_UNIT_1,
+        .channel  = (adc_channel_t)channel,
+        .atten    = (adc_atten_t)attenuation,
+        .width    = (adc_bitwidth_t)width,
+        .ulp_mode = ADC_ULP_MODE_FSM,
+    };
+    esp_err_t err = ulp_adc_init(&cfg);
+#else
     esp_err_t err = adc1_config_channel_atten((adc1_channel_t)channel, (adc_atten_t)attenuation);
     err += adc1_config_width((adc_bits_width_t)width);
+#endif // ESP_IDF_VERSION_MAJOR >= 5
     if (err != ESP_OK) {
       be_raisef(vm, "ulp_adc_config_error", "ULP: invalid code err=%i", err);
-    } else {
+    }
+#if ESP_IDF_VERSION_MAJOR < 5
+    else {
         adc1_ulp_enable();
     }
+#endif // ESP_IDF_VERSION_MAJOR < 5
 #else // S2 or S3
+#if ESP_IDF_VERSION_MAJOR >= 5
+    ulp_adc_cfg_t cfg = {
+        .adc_n    = ADC_UNIT_1,
+        .channel  = (adc_channel_t)channel,
+        .atten    = (adc_atten_t)attenuation,
+        .width    = (adc_bitwidth_t)width,
+        .ulp_mode = ADC_ULP_MODE_RISCV,
+    };
+    esp_err_t err = ulp_adc_init(&cfg);
+#else
     ulp_riscv_adc_cfg_t cfg = {
       .channel = (adc_channel_t)channel,
       .atten   = (adc_atten_t)attenuation,
       .width   = (adc_bits_width_t)width
     };
     esp_err_t err = ulp_riscv_adc_init(&cfg);
+#endif // ESP_IDF_VERSION_MAJOR >= 5
     if (err != ESP_OK) {
       be_raisef(vm, "ulp_adc_config_error", "ULP: invalid code err=%i", err);
     }


### PR DESCRIPTION
## Description:

Adds compatibility for IDF5.x/Arduino3.x.
There is one tiny change in the API, which is related to the change of the underlying enum for `adc_bits_width_t`. This still gets passed as the uint value, but as this was enumerated in ascending order from 0 to 4, now the enum value equals the actual bit width, thus e.g. 12 bit would change from 3 to 12.

example:
old: `ULP.adc_config(0,3,3)`
new: `ULP.adc_config(0,3,12)`

Tested on ESP32 and ESP32S3.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
