### PR TITLE
Remove Berry `every_200ms` event which didn't work anyways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Command ``WebCanvas linear-gradient(#F02 7%,#F93,#FF4,#082,#00F,#708 93%)`` to set GUI canvas
 
 ### Breaking Changed
+- Remove Berry `every_200ms` event which didn't work anyways
 
 ### Changed
 - ESP32 LVGL library from v8.3.10 to v8.3.11 (no functional change)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -906,9 +906,6 @@ bool Xdrv52(uint32_t function)
     case FUNC_EVERY_100_MSECOND:
       callBerryEventDispatcher(PSTR("every_100ms"), nullptr, 0, nullptr);
       break;
-    case FUNC_EVERY_200_MSECOND:
-      callBerryEventDispatcher(PSTR("every_200ms"), nullptr, 0, nullptr);
-      break;
     case FUNC_EVERY_250_MSECOND:
       callBerryEventDispatcher(PSTR("every_250ms"), nullptr, 0, nullptr);
       break;


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
