### PR TITLE
Simplify animate

### DIFF
--- a/lib/libesp32/berry_tasmota/src/embedded/animate_0_core.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/animate_0_core.be
@@ -67,7 +67,9 @@ class Animate_core
   end
 
   def add_animator(anim)
-    self.animators.push(anim)
+    if self.animators.find(anim) == nil
+      self.animators.push(anim)
+    end
   end
 
   # remove a specific animator
@@ -93,7 +95,9 @@ class Animate_core
 
 
   def add_painter(painter)
-    self.painters.push(painter)
+    if self.painters.find(painter) == nil
+      self.painters.push(painter)
+    end
   end
 
   def clear()

--- a/lib/libesp32/berry_tasmota/src/embedded/animate_0_core.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/animate_0_core.be
@@ -32,6 +32,7 @@ class Animate_core
 
   def init(strip, bri)
     import animate
+
     self.strip = strip
     if (bri == nil)   bri = 50    end
     self.bri = bri      # percentage of brightness 0..100
@@ -46,6 +47,13 @@ class Animate_core
     #
     self.fast_loop_cb = def() self.fast_loop() end
     self.back_color = 0x000000
+    #
+    self.set_current()
+  end
+
+  # set this animate.core as the current animator for configuration
+  def set_current()
+    global._cur_anim = self       # declare the current animate.core for painters and animators to register
   end
 
   # cb

--- a/lib/libesp32/berry_tasmota/src/embedded/animate_1_animate_effects.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/animate_1_animate_effects.be
@@ -1,5 +1,25 @@
 # class Animate_pulse
 
+#@ solidify:Animate_painter,weak
+# painter superclass
+class Animate_painter
+
+  def init()
+    # register ourselves into the current animate.core
+    var core = global._cur_anim
+    if (core != nil)
+      core.add_painter(self)
+    end
+  end
+
+  # return true if buffer was filled successfully
+  #
+  # Needs to be overwritten
+  def paint(frame)
+  end
+
+end
+
 ##########################################################################################
 #
 # class Animate_pulse
@@ -22,7 +42,7 @@
 ##########################################################################################
 
 #@ solidify:Animate_pulse,weak
-class Animate_pulse
+class Animate_pulse : Animate_painter
   var color
   var back_color
   var pos
@@ -30,6 +50,8 @@ class Animate_pulse
   var pulse_size
 
   def init(color, pulse_size, slew_size)
+    super(self).init()
+    
     if (color == nil)         color = 0xFFFFFF  end     # white by default
     if (pulse_size == nil)   pulse_size = 1   end
     if (slew_size == nil)     slew_size = 0     end

--- a/lib/libesp32/berry_tasmota/src/embedded/animate_9_module.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/animate_9_module.be
@@ -96,8 +96,12 @@ class Animate_animator
   var obj               # object to call
   var mth               # object method to call
 
-  def init(duration_ms)
-    self.duration_ms = duration_ms
+  def init()
+    # register ourselves into the current animate.core
+    var core = global._cur_anim
+    if (core != nil)
+      core.add_animator(self)
+    end
   end
 
   def set_duration_ms(duration_ms)
@@ -155,16 +159,27 @@ class Animate_palette : Animate_animator
   var color             # instance of light_state, used for color calculation (reuse of object)
 
   def init(palette, duration_ms)
-    super(self).init(duration_ms)
+    super(self).init()
+
+    self.duration_ms = duration_ms
     self.running = false
+    self.bri = 100
+    self.color = light_state(light_state.RGB)
+    #
+    self.set_palette(palette)
+  end
+
+  # load or change palette
+  def set_palette(palette)
     if (type(palette) == 'ptr')   palette = self.ptr_to_palette(palette)    end   # convert comptr to palette buffer
     self.palette = palette
-    self.bri = 100
     self.slots = size(palette) / 4
-    if duration_ms != nil
-      self.set_duration(duration_ms)
+    # recompute palette
+    if self.duration_ms != nil
+      self.set_duration(self.duration_ms)
+    elif (self.range_min != nil) && (self.range_max != nil)
+      self.set_range(self.range_min, self.range_max)
     end
-    self.color = light_state(light_state.RGB)
   end
 
   # setter to be used as cb
@@ -415,6 +430,7 @@ class Animate_oscillator : Animate_animator
   var value
   
   def init(a, b, duration_ms, form)
+    super(self).init()
     self.phase = 0
     self.duty_cycle = 50
     self.a = a

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_animate_0_core.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_animate_0_core.h
@@ -7,6 +7,466 @@
 extern const bclass be_class_Animate_core;
 
 /********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(Animate_core_start,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(running),
+    /* K1   */  be_nested_str_weak(animators),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(start),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(fast_loop_next),
+    /* K6   */  be_nested_str_weak(tasmota),
+    /* K7   */  be_nested_str_weak(add_fast_loop),
+    /* K8   */  be_nested_str_weak(fast_loop_cb),
+    }),
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0x50040200,  //  0000  LDBOOL	R1	1	0
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x58080002,  //  0003  LDCONST	R2	K2
+      0x600C000C,  //  0004  GETGBL	R3	G12
+      0x5C100200,  //  0005  MOVE	R4	R1
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0x140C0403,  //  0007  LT	R3	R2	R3
+      0x780E0004,  //  0008  JMPF	R3	#000E
+      0x940C0202,  //  0009  GETIDX	R3	R1	R2
+      0x8C0C0703,  //  000A  GETMET	R3	R3	K3
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x00080504,  //  000C  ADD	R2	R2	K4
+      0x7001FFF5,  //  000D  JMP		#0004
+      0x90020B02,  //  000E  SETMBR	R0	K5	K2
+      0xB80E0C00,  //  000F  GETNGBL	R3	K6
+      0x8C0C0707,  //  0010  GETMET	R3	R3	K7
+      0x88140108,  //  0011  GETMBR	R5	R0	K8
+      0x7C0C0400,  //  0012  CALL	R3	2
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove
+********************************************************************/
+be_local_closure(Animate_core_remove,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(clear),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(remove_fast_loop),
+    /* K3   */  be_nested_str_weak(fast_loop_cb),
+    }),
+    be_str_weak(remove),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0xB8060200,  //  0002  GETNGBL	R1	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x880C0103,  //  0004  GETMBR	R3	R0	K3
+      0x7C040400,  //  0005  CALL	R1	2
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_background_animator
+********************************************************************/
+be_local_closure(Animate_core_add_background_animator,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_cb),
+    /* K1   */  be_nested_str_weak(set_back_color),
+    /* K2   */  be_nested_str_weak(add_animator),
+    }),
+    be_str_weak(add_background_animator),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x8C080300,  //  0000  GETMET	R2	R1	K0
+      0x5C100000,  //  0001  MOVE	R4	R0
+      0x88140101,  //  0002  GETMBR	R5	R0	K1
+      0x7C080600,  //  0003  CALL	R2	3
+      0x8C080102,  //  0004  GETMET	R2	R0	K2
+      0x5C100200,  //  0005  MOVE	R4	R1
+      0x7C080400,  //  0006  CALL	R2	2
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_painter
+********************************************************************/
+be_local_closure(Animate_core_remove_painter,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(painters),
+    /* K1   */  be_nested_str_weak(remove),
+    /* K2   */  be_nested_str_weak(find),
+    /* K3   */  be_nested_str_weak(clear),
+    }),
+    be_str_weak(remove_painter),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x200C0203,  //  0002  NE	R3	R1	R3
+      0x780E0005,  //  0003  JMPF	R3	#000A
+      0x8C0C0501,  //  0004  GETMET	R3	R2	K1
+      0x8C140502,  //  0005  GETMET	R5	R2	K2
+      0x5C1C0200,  //  0006  MOVE	R7	R1
+      0x7C140400,  //  0007  CALL	R5	2
+      0x7C0C0400,  //  0008  CALL	R3	2
+      0x70020001,  //  0009  JMP		#000C
+      0x8C0C0503,  //  000A  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_animator
+********************************************************************/
+be_local_closure(Animate_core_add_animator,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animators),
+    /* K1   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(add_animator),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: animate
+********************************************************************/
+be_local_closure(Animate_core_animate,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(animate),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clear
+********************************************************************/
+be_local_closure(Animate_core_clear,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(stop),
+    /* K1   */  be_nested_str_weak(strip),
+    /* K2   */  be_nested_str_weak(clear),
+    }),
+    be_str_weak(clear),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop
+********************************************************************/
+be_local_closure(Animate_core_stop,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(running),
+    /* K1   */  be_nested_str_weak(animators),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(stop),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(tasmota),
+    /* K6   */  be_nested_str_weak(remove_fast_loop),
+    /* K7   */  be_nested_str_weak(fast_loop_cb),
+    }),
+    be_str_weak(stop),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0x50040000,  //  0000  LDBOOL	R1	0	0
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x58080002,  //  0003  LDCONST	R2	K2
+      0x600C000C,  //  0004  GETGBL	R3	G12
+      0x5C100200,  //  0005  MOVE	R4	R1
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0x140C0403,  //  0007  LT	R3	R2	R3
+      0x780E0004,  //  0008  JMPF	R3	#000E
+      0x940C0202,  //  0009  GETIDX	R3	R1	R2
+      0x8C0C0703,  //  000A  GETMET	R3	R3	K3
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x00080504,  //  000C  ADD	R2	R2	K4
+      0x7001FFF5,  //  000D  JMP		#0004
+      0xB80E0A00,  //  000E  GETNGBL	R3	K5
+      0x8C0C0706,  //  000F  GETMET	R3	R3	K6
+      0x88140107,  //  0010  GETMBR	R5	R0	K7
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_painter
+********************************************************************/
+be_local_closure(Animate_core_add_painter,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(painters),
+    /* K1   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(add_painter),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_bri
+********************************************************************/
+be_local_closure(Animate_core_set_bri,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(bri),
+    }),
+    be_str_weak(set_bri),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_current
+********************************************************************/
+be_local_closure(Animate_core_set_current,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(global),
+    /* K1   */  be_nested_str_weak(_cur_anim),
+    }),
+    be_str_weak(set_current),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x90060200,  //  0001  SETMBR	R1	K1	R0
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_animator
+********************************************************************/
+be_local_closure(Animate_core_remove_animator,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animators),
+    /* K1   */  be_nested_str_weak(remove),
+    /* K2   */  be_nested_str_weak(find),
+    /* K3   */  be_nested_str_weak(clear),
+    }),
+    be_str_weak(remove_animator),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x200C0203,  //  0002  NE	R3	R1	R3
+      0x780E0005,  //  0003  JMPF	R3	#000A
+      0x8C0C0501,  //  0004  GETMET	R3	R2	K1
+      0x8C140502,  //  0005  GETMET	R5	R2	K2
+      0x5C1C0200,  //  0006  MOVE	R7	R1
+      0x7C140400,  //  0007  CALL	R5	2
+      0x7C0C0400,  //  0008  CALL	R3	2
+      0x70020001,  //  0009  JMP		#000C
+      0x8C0C0503,  //  000A  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_cb
+********************************************************************/
+be_local_closure(Animate_core_set_cb,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(obj),
+    /* K1   */  be_nested_str_weak(mth),
+    }),
+    be_str_weak(set_cb),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: fast_loop
 ********************************************************************/
 be_local_closure(Animate_core_fast_loop,   /* name */
@@ -140,11 +600,11 @@ be_local_closure(Animate_core_fast_loop,   /* name */
 
 
 /********************************************************************
-** Solidified function: add_animator
+** Solidified function: set_back_color
 ********************************************************************/
-be_local_closure(Animate_core_add_animator,   /* name */
+be_local_closure(Animate_core_set_back_color,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
+    2,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -152,256 +612,14 @@ be_local_closure(Animate_core_add_animator,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animators),
-    /* K1   */  be_nested_str_weak(push),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(back_color),
     }),
-    be_str_weak(add_animator),
+    be_str_weak(set_back_color),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_painter
-********************************************************************/
-be_local_closure(Animate_core_remove_painter,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(painters),
-    /* K1   */  be_nested_str_weak(remove),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(clear),
-    }),
-    be_str_weak(remove_painter),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x200C0203,  //  0002  NE	R3	R1	R3
-      0x780E0005,  //  0003  JMPF	R3	#000A
-      0x8C0C0501,  //  0004  GETMET	R3	R2	K1
-      0x8C140502,  //  0005  GETMET	R5	R2	K2
-      0x5C1C0200,  //  0006  MOVE	R7	R1
-      0x7C140400,  //  0007  CALL	R5	2
-      0x7C0C0400,  //  0008  CALL	R3	2
-      0x70020001,  //  0009  JMP		#000C
-      0x8C0C0503,  //  000A  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_animator
-********************************************************************/
-be_local_closure(Animate_core_remove_animator,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animators),
-    /* K1   */  be_nested_str_weak(remove),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(clear),
-    }),
-    be_str_weak(remove_animator),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x200C0203,  //  0002  NE	R3	R1	R3
-      0x780E0005,  //  0003  JMPF	R3	#000A
-      0x8C0C0501,  //  0004  GETMET	R3	R2	K1
-      0x8C140502,  //  0005  GETMET	R5	R2	K2
-      0x5C1C0200,  //  0006  MOVE	R7	R1
-      0x7C140400,  //  0007  CALL	R5	2
-      0x7C0C0400,  //  0008  CALL	R3	2
-      0x70020001,  //  0009  JMP		#000C
-      0x8C0C0503,  //  000A  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove
-********************************************************************/
-be_local_closure(Animate_core_remove,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(clear),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(remove_fast_loop),
-    /* K3   */  be_nested_str_weak(fast_loop_cb),
-    }),
-    be_str_weak(remove),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0xB8060200,  //  0002  GETNGBL	R1	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
-      0x880C0103,  //  0004  GETMBR	R3	R0	K3
-      0x7C040400,  //  0005  CALL	R1	2
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_background_animator
-********************************************************************/
-be_local_closure(Animate_core_add_background_animator,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_cb),
-    /* K1   */  be_nested_str_weak(set_back_color),
-    /* K2   */  be_nested_str_weak(add_animator),
-    }),
-    be_str_weak(add_background_animator),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x88140101,  //  0002  GETMBR	R5	R0	K1
-      0x7C080600,  //  0003  CALL	R2	3
-      0x8C080102,  //  0004  GETMET	R2	R0	K2
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x7C080400,  //  0006  CALL	R2	2
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start
-********************************************************************/
-be_local_closure(Animate_core_start,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(running),
-    /* K1   */  be_nested_str_weak(animators),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(start),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(fast_loop_next),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(add_fast_loop),
-    /* K8   */  be_nested_str_weak(fast_loop_cb),
-    }),
-    be_str_weak(start),
-    &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0x50040200,  //  0000  LDBOOL	R1	1	0
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x58080002,  //  0003  LDCONST	R2	K2
-      0x600C000C,  //  0004  GETGBL	R3	G12
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0x140C0403,  //  0007  LT	R3	R2	R3
-      0x780E0004,  //  0008  JMPF	R3	#000E
-      0x940C0202,  //  0009  GETIDX	R3	R1	R2
-      0x8C0C0703,  //  000A  GETMET	R3	R3	K3
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x00080504,  //  000C  ADD	R2	R2	K4
-      0x7001FFF5,  //  000D  JMP		#0004
-      0x90020B02,  //  000E  SETMBR	R0	K5	K2
-      0xB80E0C00,  //  000F  GETNGBL	R3	K6
-      0x8C0C0707,  //  0010  GETMET	R3	R3	K7
-      0x88140108,  //  0011  GETMBR	R5	R0	K8
-      0x7C0C0400,  //  0012  CALL	R3	2
-      0x80000000,  //  0013  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clear
-********************************************************************/
-be_local_closure(Animate_core_clear,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(stop),
-    /* K1   */  be_nested_str_weak(strip),
-    /* K2   */  be_nested_str_weak(clear),
-    }),
-    be_str_weak(clear),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80000000,  //  0005  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
     })
   )
 );
@@ -445,7 +663,7 @@ be_local_closure(Animate_core_init,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
+    ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(animate),
     /* K1   */  be_nested_str_weak(strip),
     /* K2   */  be_nested_str_weak(bri),
@@ -459,10 +677,11 @@ be_local_closure(Animate_core_init,   /* name */
     /* K10  */  be_nested_str_weak(fast_loop_cb),
     /* K11  */  be_nested_str_weak(back_color),
     /* K12  */  be_const_int(0),
+    /* K13  */  be_nested_str_weak(set_current),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
+    ( &(const binstruction[35]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0x90020201,  //  0001  SETMBR	R0	K1	R1
       0x4C100000,  //  0002  LDNIL	R4
@@ -494,143 +713,10 @@ be_local_closure(Animate_core_init,   /* name */
       0x84100000,  //  001C  CLOSURE	R4	P0
       0x90021404,  //  001D  SETMBR	R0	K10	R4
       0x9002170C,  //  001E  SETMBR	R0	K11	K12
-      0xA0000000,  //  001F  CLOSE	R0
-      0x80000000,  //  0020  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop
-********************************************************************/
-be_local_closure(Animate_core_stop,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(running),
-    /* K1   */  be_nested_str_weak(animators),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(stop),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(remove_fast_loop),
-    /* K7   */  be_nested_str_weak(fast_loop_cb),
-    }),
-    be_str_weak(stop),
-    &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0x50040000,  //  0000  LDBOOL	R1	0	0
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x58080002,  //  0003  LDCONST	R2	K2
-      0x600C000C,  //  0004  GETGBL	R3	G12
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0x140C0403,  //  0007  LT	R3	R2	R3
-      0x780E0004,  //  0008  JMPF	R3	#000E
-      0x940C0202,  //  0009  GETIDX	R3	R1	R2
-      0x8C0C0703,  //  000A  GETMET	R3	R3	K3
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x00080504,  //  000C  ADD	R2	R2	K4
-      0x7001FFF5,  //  000D  JMP		#0004
-      0xB80E0A00,  //  000E  GETNGBL	R3	K5
-      0x8C0C0706,  //  000F  GETMET	R3	R3	K6
-      0x88140107,  //  0010  GETMBR	R5	R0	K7
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x80000000,  //  0012  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: animate
-********************************************************************/
-be_local_closure(Animate_core_animate,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(animate),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_cb
-********************************************************************/
-be_local_closure(Animate_core_set_cb,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(obj),
-    /* K1   */  be_nested_str_weak(mth),
-    }),
-    be_str_weak(set_cb),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_painter
-********************************************************************/
-be_local_closure(Animate_core_add_painter,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(painters),
-    /* K1   */  be_nested_str_weak(push),
-    }),
-    be_str_weak(add_painter),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80000000,  //  0004  RET	0
+      0x8C10010D,  //  001F  GETMET	R4	R0	K13
+      0x7C100200,  //  0020  CALL	R4	1
+      0xA0000000,  //  0021  CLOSE	R0
+      0x80000000,  //  0022  RET	0
     })
   )
 );
@@ -665,97 +751,44 @@ be_local_closure(Animate_core_get_bri,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_back_color
-********************************************************************/
-be_local_closure(Animate_core_set_back_color,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(back_color),
-    }),
-    be_str_weak(set_back_color),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_bri
-********************************************************************/
-be_local_closure(Animate_core_set_bri,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(bri),
-    }),
-    be_str_weak(set_bri),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Animate_core
 ********************************************************************/
 be_local_class(Animate_core,
     13,
     NULL,
-    be_nested_map(30,
+    be_nested_map(31,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(running, -1), be_const_var(3) },
-        { be_const_key_weak(pixel_count, -1), be_const_var(1) },
-        { be_const_key_weak(fast_loop, -1), be_const_closure(Animate_core_fast_loop_closure) },
-        { be_const_key_weak(animators, 8), be_const_var(4) },
-        { be_const_key_weak(fast_loop_cb, 7), be_const_var(6) },
-        { be_const_key_weak(set_back_color, 26), be_const_closure(Animate_core_set_back_color_closure) },
-        { be_const_key_weak(add_animator, -1), be_const_closure(Animate_core_add_animator_closure) },
-        { be_const_key_weak(frame, -1), be_const_var(10) },
-        { be_const_key_weak(strip, 27), be_const_var(0) },
-        { be_const_key_weak(remove_animator, 5), be_const_closure(Animate_core_remove_animator_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Animate_core_init_closure) },
-        { be_const_key_weak(start, -1), be_const_closure(Animate_core_start_closure) },
-        { be_const_key_weak(mth, -1), be_const_var(9) },
-        { be_const_key_weak(add_painter, -1), be_const_closure(Animate_core_add_painter_closure) },
-        { be_const_key_weak(clear, -1), be_const_closure(Animate_core_clear_closure) },
-        { be_const_key_weak(remove_painter, 23), be_const_closure(Animate_core_remove_painter_closure) },
-        { be_const_key_weak(layer, -1), be_const_var(11) },
-        { be_const_key_weak(stop, -1), be_const_closure(Animate_core_stop_closure) },
-        { be_const_key_weak(fast_loop_next, 16), be_const_var(7) },
-        { be_const_key_weak(FAST_LOOP_MIN, -1), be_const_int(20) },
-        { be_const_key_weak(animate, -1), be_const_closure(Animate_core_animate_closure) },
-        { be_const_key_weak(back_color, -1), be_const_var(12) },
-        { be_const_key_weak(obj, 21), be_const_var(8) },
-        { be_const_key_weak(set_cb, 10), be_const_closure(Animate_core_set_cb_closure) },
-        { be_const_key_weak(bri, 13), be_const_var(2) },
         { be_const_key_weak(get_bri, -1), be_const_closure(Animate_core_get_bri_closure) },
-        { be_const_key_weak(painters, 28), be_const_var(5) },
-        { be_const_key_weak(add_background_animator, 1), be_const_closure(Animate_core_add_background_animator_closure) },
         { be_const_key_weak(remove, -1), be_const_closure(Animate_core_remove_closure) },
+        { be_const_key_weak(painters, -1), be_const_var(5) },
+        { be_const_key_weak(fast_loop_cb, -1), be_const_var(6) },
+        { be_const_key_weak(start, 6), be_const_closure(Animate_core_start_closure) },
+        { be_const_key_weak(add_background_animator, -1), be_const_closure(Animate_core_add_background_animator_closure) },
+        { be_const_key_weak(set_back_color, 30), be_const_closure(Animate_core_set_back_color_closure) },
+        { be_const_key_weak(add_animator, -1), be_const_closure(Animate_core_add_animator_closure) },
+        { be_const_key_weak(strip, 3), be_const_var(0) },
+        { be_const_key_weak(animate, 14), be_const_closure(Animate_core_animate_closure) },
+        { be_const_key_weak(clear, 0), be_const_closure(Animate_core_clear_closure) },
+        { be_const_key_weak(stop, -1), be_const_closure(Animate_core_stop_closure) },
+        { be_const_key_weak(remove_painter, 28), be_const_closure(Animate_core_remove_painter_closure) },
+        { be_const_key_weak(fast_loop_next, 21), be_const_var(7) },
+        { be_const_key_weak(animators, -1), be_const_var(4) },
+        { be_const_key_weak(add_painter, -1), be_const_closure(Animate_core_add_painter_closure) },
         { be_const_key_weak(set_bri, -1), be_const_closure(Animate_core_set_bri_closure) },
+        { be_const_key_weak(frame, -1), be_const_var(10) },
+        { be_const_key_weak(mth, 26), be_const_var(9) },
+        { be_const_key_weak(back_color, -1), be_const_var(12) },
+        { be_const_key_weak(set_current, -1), be_const_closure(Animate_core_set_current_closure) },
+        { be_const_key_weak(bri, -1), be_const_var(2) },
+        { be_const_key_weak(fast_loop, -1), be_const_closure(Animate_core_fast_loop_closure) },
+        { be_const_key_weak(layer, -1), be_const_var(11) },
+        { be_const_key_weak(set_cb, 23), be_const_closure(Animate_core_set_cb_closure) },
+        { be_const_key_weak(remove_animator, 22), be_const_closure(Animate_core_remove_animator_closure) },
+        { be_const_key_weak(FAST_LOOP_MIN, -1), be_const_int(20) },
+        { be_const_key_weak(pixel_count, -1), be_const_var(1) },
+        { be_const_key_weak(obj, -1), be_const_var(8) },
+        { be_const_key_weak(init, -1), be_const_closure(Animate_core_init_closure) },
+        { be_const_key_weak(running, -1), be_const_var(3) },
     })),
     be_str_weak(Animate_core)
 );

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_animate_0_core.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_animate_0_core.h
@@ -183,18 +183,26 @@ be_local_closure(Animate_core_add_animator,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
+    ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(animators),
-    /* K1   */  be_nested_str_weak(push),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(push),
     }),
     be_str_weak(add_animator),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
+    ( &(const binstruction[12]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
-      0x80000000,  //  0004  RET	0
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x1C080403,  //  0005  EQ	R2	R2	R3
+      0x780A0003,  //  0006  JMPF	R2	#000B
+      0x88080100,  //  0007  GETMBR	R2	R0	K0
+      0x8C080502,  //  0008  GETMET	R2	R2	K2
+      0x5C100200,  //  0009  MOVE	R4	R1
+      0x7C080400,  //  000A  CALL	R2	2
+      0x80000000,  //  000B  RET	0
     })
   )
 );
@@ -322,18 +330,26 @@ be_local_closure(Animate_core_add_painter,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
+    ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(painters),
-    /* K1   */  be_nested_str_weak(push),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(push),
     }),
     be_str_weak(add_painter),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
+    ( &(const binstruction[12]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
-      0x80000000,  //  0004  RET	0
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x1C080403,  //  0005  EQ	R2	R2	R3
+      0x780A0003,  //  0006  JMPF	R2	#000B
+      0x88080100,  //  0007  GETMBR	R2	R0	K0
+      0x8C080502,  //  0008  GETMET	R2	R2	K2
+      0x5C100200,  //  0009  MOVE	R4	R1
+      0x7C080400,  //  000A  CALL	R2	2
+      0x80000000,  //  000B  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_animate_1_animate_effects.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_animate_1_animate_effects.h
@@ -4,6 +4,89 @@
 \********************************************************************/
 #include "be_constobj.h"
 
+extern const bclass be_class_Animate_painter;
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Animate_painter_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(global),
+    /* K1   */  be_nested_str_weak(_cur_anim),
+    /* K2   */  be_nested_str_weak(add_painter),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x4C080000,  //  0002  LDNIL	R2
+      0x20080202,  //  0003  NE	R2	R1	R2
+      0x780A0002,  //  0004  JMPF	R2	#0008
+      0x8C080302,  //  0005  GETMET	R2	R1	K2
+      0x5C100000,  //  0006  MOVE	R4	R0
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: paint
+********************************************************************/
+be_local_closure(Animate_painter_paint,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(paint),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Animate_painter
+********************************************************************/
+be_local_class(Animate_painter,
+    0,
+    NULL,
+    be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(paint, -1), be_const_closure(Animate_painter_paint_closure) },
+        { be_const_key_weak(init, 0), be_const_closure(Animate_painter_init_closure) },
+    })),
+    be_str_weak(Animate_painter)
+);
+/*******************************************************************/
+
+void be_load_Animate_painter_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_Animate_painter);
+    be_setglobal(vm, "Animate_painter");
+    be_pop(vm, 1);
+}
+
 extern const bclass be_class_Animate_pulse;
 
 /********************************************************************
@@ -146,7 +229,7 @@ be_local_closure(Animate_pulse_set_color,   /* name */
 ********************************************************************/
 be_local_closure(Animate_pulse_init,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
+    6,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -154,44 +237,50 @@ be_local_closure(Animate_pulse_init,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_const_int(16777215),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(color),
-    /* K4   */  be_nested_str_weak(back_color),
-    /* K5   */  be_const_int(-16777216),
-    /* K6   */  be_nested_str_weak(pulse_size),
-    /* K7   */  be_nested_str_weak(slew_size),
-    /* K8   */  be_nested_str_weak(pos),
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_const_int(16777215),
+    /* K2   */  be_const_int(1),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(color),
+    /* K5   */  be_nested_str_weak(back_color),
+    /* K6   */  be_const_int(-16777216),
+    /* K7   */  be_nested_str_weak(pulse_size),
+    /* K8   */  be_nested_str_weak(slew_size),
+    /* K9   */  be_nested_str_weak(pos),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x1C100204,  //  0001  EQ	R4	R1	R4
-      0x78120000,  //  0002  JMPF	R4	#0004
-      0x58040000,  //  0003  LDCONST	R1	K0
-      0x4C100000,  //  0004  LDNIL	R4
-      0x1C100404,  //  0005  EQ	R4	R2	R4
-      0x78120000,  //  0006  JMPF	R4	#0008
-      0x58080001,  //  0007  LDCONST	R2	K1
-      0x4C100000,  //  0008  LDNIL	R4
-      0x1C100604,  //  0009  EQ	R4	R3	R4
-      0x78120000,  //  000A  JMPF	R4	#000C
-      0x580C0002,  //  000B  LDCONST	R3	K2
-      0x90020601,  //  000C  SETMBR	R0	K3	R1
-      0x90020905,  //  000D  SETMBR	R0	K4	K5
-      0x14100502,  //  000E  LT	R4	R2	K2
+    ( &(const binstruction[29]) {  /* code */
+      0x60100003,  //  0000  GETGBL	R4	G3
+      0x5C140000,  //  0001  MOVE	R5	R0
+      0x7C100200,  //  0002  CALL	R4	1
+      0x8C100900,  //  0003  GETMET	R4	R4	K0
+      0x7C100200,  //  0004  CALL	R4	1
+      0x4C100000,  //  0005  LDNIL	R4
+      0x1C100204,  //  0006  EQ	R4	R1	R4
+      0x78120000,  //  0007  JMPF	R4	#0009
+      0x58040001,  //  0008  LDCONST	R1	K1
+      0x4C100000,  //  0009  LDNIL	R4
+      0x1C100404,  //  000A  EQ	R4	R2	R4
+      0x78120000,  //  000B  JMPF	R4	#000D
+      0x58080002,  //  000C  LDCONST	R2	K2
+      0x4C100000,  //  000D  LDNIL	R4
+      0x1C100604,  //  000E  EQ	R4	R3	R4
       0x78120000,  //  000F  JMPF	R4	#0011
-      0x58080002,  //  0010  LDCONST	R2	K2
-      0x90020C02,  //  0011  SETMBR	R0	K6	R2
-      0x14100702,  //  0012  LT	R4	R3	K2
-      0x78120000,  //  0013  JMPF	R4	#0015
-      0x580C0002,  //  0014  LDCONST	R3	K2
-      0x90020E03,  //  0015  SETMBR	R0	K7	R3
-      0x90021102,  //  0016  SETMBR	R0	K8	K2
-      0x80000000,  //  0017  RET	0
+      0x580C0003,  //  0010  LDCONST	R3	K3
+      0x90020801,  //  0011  SETMBR	R0	K4	R1
+      0x90020B06,  //  0012  SETMBR	R0	K5	K6
+      0x14100503,  //  0013  LT	R4	R2	K3
+      0x78120000,  //  0014  JMPF	R4	#0016
+      0x58080003,  //  0015  LDCONST	R2	K3
+      0x90020E02,  //  0016  SETMBR	R0	K7	R2
+      0x14100703,  //  0017  LT	R4	R3	K3
+      0x78120000,  //  0018  JMPF	R4	#001A
+      0x580C0003,  //  0019  LDCONST	R3	K3
+      0x90021003,  //  001A  SETMBR	R0	K8	R3
+      0x90021303,  //  001B  SETMBR	R0	K9	K3
+      0x80000000,  //  001C  RET	0
     })
   )
 );
@@ -329,9 +418,10 @@ be_local_closure(Animate_pulse_paint,   /* name */
 /********************************************************************
 ** Solidified class: Animate_pulse
 ********************************************************************/
+extern const bclass be_class_Animate_painter;
 be_local_class(Animate_pulse,
     5,
-    NULL,
+    &be_class_Animate_painter,
     be_nested_map(12,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_weak(paint, -1), be_const_closure(Animate_pulse_paint_closure) },

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_animate_9_module.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_animate_9_module.h
@@ -64,22 +64,31 @@ be_local_closure(Animate_animator_beat,   /* name */
 ********************************************************************/
 be_local_closure(Animate_animator_init,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
+    5,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(duration_ms),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(global),
+    /* K1   */  be_nested_str_weak(_cur_anim),
+    /* K2   */  be_nested_str_weak(add_animator),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
+    ( &(const binstruction[ 9]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x4C080000,  //  0002  LDNIL	R2
+      0x20080202,  //  0003  NE	R2	R1	R2
+      0x780A0002,  //  0004  JMPF	R2	#0008
+      0x8C080302,  //  0005  GETMET	R2	R1	K2
+      0x5C100000,  //  0006  MOVE	R4	R0
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80000000,  //  0008  RET	0
     })
   )
 );
@@ -252,72 +261,72 @@ void be_load_Animate_animator_class(bvm *vm) {
 extern const bclass be_class_Animate_palette;
 
 /********************************************************************
-** Solidified function: init
+** Solidified function: ptr_to_palette
 ********************************************************************/
-be_local_closure(Animate_palette_init,   /* name */
+be_local_closure(Animate_palette_ptr_to_palette,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
+    8,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(running),
-    /* K2   */  be_nested_str_weak(ptr),
-    /* K3   */  be_nested_str_weak(ptr_to_palette),
-    /* K4   */  be_nested_str_weak(palette),
-    /* K5   */  be_nested_str_weak(bri),
-    /* K6   */  be_nested_str_weak(slots),
-    /* K7   */  be_nested_str_weak(set_duration),
-    /* K8   */  be_nested_str_weak(color),
-    /* K9   */  be_nested_str_weak(light_state),
-    /* K10  */  be_nested_str_weak(RGB),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Animate_palette),
+    /* K1   */  be_nested_str_weak(ptr),
+    /* K2   */  be_const_int(1),
+    /* K3   */  be_const_int(0),
     }),
-    be_str_weak(init),
+    be_str_weak(ptr_to_palette),
     &be_const_str_solidified,
-    ( &(const binstruction[38]) {  /* code */
-      0x600C0003,  //  0000  GETGBL	R3	G3
-      0x5C100000,  //  0001  MOVE	R4	R0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x500C0000,  //  0006  LDBOOL	R3	0	0
-      0x90020203,  //  0007  SETMBR	R0	K1	R3
-      0x600C0004,  //  0008  GETGBL	R3	G4
-      0x5C100200,  //  0009  MOVE	R4	R1
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x1C0C0702,  //  000B  EQ	R3	R3	K2
-      0x780E0003,  //  000C  JMPF	R3	#0011
-      0x8C0C0103,  //  000D  GETMET	R3	R0	K3
-      0x5C140200,  //  000E  MOVE	R5	R1
-      0x7C0C0400,  //  000F  CALL	R3	2
-      0x5C040600,  //  0010  MOVE	R1	R3
-      0x90020801,  //  0011  SETMBR	R0	K4	R1
-      0x540E0063,  //  0012  LDINT	R3	100
-      0x90020A03,  //  0013  SETMBR	R0	K5	R3
-      0x600C000C,  //  0014  GETGBL	R3	G12
-      0x5C100200,  //  0015  MOVE	R4	R1
-      0x7C0C0200,  //  0016  CALL	R3	1
-      0x54120003,  //  0017  LDINT	R4	4
-      0x0C0C0604,  //  0018  DIV	R3	R3	R4
-      0x90020C03,  //  0019  SETMBR	R0	K6	R3
-      0x4C0C0000,  //  001A  LDNIL	R3
-      0x200C0403,  //  001B  NE	R3	R2	R3
-      0x780E0002,  //  001C  JMPF	R3	#0020
-      0x8C0C0107,  //  001D  GETMET	R3	R0	K7
-      0x5C140400,  //  001E  MOVE	R5	R2
-      0x7C0C0400,  //  001F  CALL	R3	2
-      0xB80E1200,  //  0020  GETNGBL	R3	K9
-      0xB8121200,  //  0021  GETNGBL	R4	K9
-      0x8810090A,  //  0022  GETMBR	R4	R4	K10
-      0x7C0C0200,  //  0023  CALL	R3	1
-      0x90021003,  //  0024  SETMBR	R0	K8	R3
-      0x80000000,  //  0025  RET	0
+    ( &(const binstruction[45]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x60080004,  //  0001  GETGBL	R2	G4
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C080200,  //  0003  CALL	R2	1
+      0x1C080501,  //  0004  EQ	R2	R2	K1
+      0x780A0025,  //  0005  JMPF	R2	#002C
+      0x60080015,  //  0006  GETGBL	R2	G21
+      0x5C0C0000,  //  0007  MOVE	R3	R0
+      0x541207CF,  //  0008  LDINT	R4	2000
+      0x7C080400,  //  0009  CALL	R2	2
+      0x580C0002,  //  000A  LDCONST	R3	K2
+      0x94100503,  //  000B  GETIDX	R4	R2	K3
+      0x20100903,  //  000C  NE	R4	R4	K3
+      0x7812000A,  //  000D  JMPF	R4	#0019
+      0x50100200,  //  000E  LDBOOL	R4	1	0
+      0x78120007,  //  000F  JMPF	R4	#0018
+      0x54120003,  //  0010  LDINT	R4	4
+      0x08100604,  //  0011  MUL	R4	R3	R4
+      0x94100404,  //  0012  GETIDX	R4	R2	R4
+      0x1C100903,  //  0013  EQ	R4	R4	K3
+      0x78120000,  //  0014  JMPF	R4	#0016
+      0x70020001,  //  0015  JMP		#0018
+      0x000C0702,  //  0016  ADD	R3	R3	K2
+      0x7001FFF5,  //  0017  JMP		#000E
+      0x7002000A,  //  0018  JMP		#0024
+      0x50100200,  //  0019  LDBOOL	R4	1	0
+      0x78120008,  //  001A  JMPF	R4	#0024
+      0x54120003,  //  001B  LDINT	R4	4
+      0x08100604,  //  001C  MUL	R4	R3	R4
+      0x94100404,  //  001D  GETIDX	R4	R2	R4
+      0x541600FE,  //  001E  LDINT	R5	255
+      0x1C100805,  //  001F  EQ	R4	R4	R5
+      0x78120000,  //  0020  JMPF	R4	#0022
+      0x70020001,  //  0021  JMP		#0024
+      0x000C0702,  //  0022  ADD	R3	R3	K2
+      0x7001FFF4,  //  0023  JMP		#0019
+      0x00100702,  //  0024  ADD	R4	R3	K2
+      0x54160003,  //  0025  LDINT	R5	4
+      0x08100805,  //  0026  MUL	R4	R4	R5
+      0x60140015,  //  0027  GETGBL	R5	G21
+      0x5C180000,  //  0028  MOVE	R6	R0
+      0x5C1C0800,  //  0029  MOVE	R7	R4
+      0x7C140400,  //  002A  CALL	R5	2
+      0x80040A00,  //  002B  RET	1	R5
+      0x80000000,  //  002C  RET	0
     })
   )
 );
@@ -563,72 +572,69 @@ be_local_closure(Animate_palette_animate,   /* name */
 
 
 /********************************************************************
-** Solidified function: ptr_to_palette
+** Solidified function: set_palette
 ********************************************************************/
-be_local_closure(Animate_palette_ptr_to_palette,   /* name */
+be_local_closure(Animate_palette_set_palette,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Animate_palette),
-    /* K1   */  be_nested_str_weak(ptr),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_const_int(0),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ptr),
+    /* K1   */  be_nested_str_weak(ptr_to_palette),
+    /* K2   */  be_nested_str_weak(palette),
+    /* K3   */  be_nested_str_weak(slots),
+    /* K4   */  be_nested_str_weak(duration_ms),
+    /* K5   */  be_nested_str_weak(set_duration),
+    /* K6   */  be_nested_str_weak(range_min),
+    /* K7   */  be_nested_str_weak(range_max),
+    /* K8   */  be_nested_str_weak(set_range),
     }),
-    be_str_weak(ptr_to_palette),
+    be_str_weak(set_palette),
     &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080004,  //  0001  GETGBL	R2	G4
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C080200,  //  0003  CALL	R2	1
-      0x1C080501,  //  0004  EQ	R2	R2	K1
-      0x780A0025,  //  0005  JMPF	R2	#002C
-      0x60080015,  //  0006  GETGBL	R2	G21
-      0x5C0C0000,  //  0007  MOVE	R3	R0
-      0x541207CF,  //  0008  LDINT	R4	2000
-      0x7C080400,  //  0009  CALL	R2	2
-      0x580C0002,  //  000A  LDCONST	R3	K2
-      0x94100503,  //  000B  GETIDX	R4	R2	K3
-      0x20100903,  //  000C  NE	R4	R4	K3
-      0x7812000A,  //  000D  JMPF	R4	#0019
-      0x50100200,  //  000E  LDBOOL	R4	1	0
-      0x78120007,  //  000F  JMPF	R4	#0018
-      0x54120003,  //  0010  LDINT	R4	4
-      0x08100604,  //  0011  MUL	R4	R3	R4
-      0x94100404,  //  0012  GETIDX	R4	R2	R4
-      0x1C100903,  //  0013  EQ	R4	R4	K3
-      0x78120000,  //  0014  JMPF	R4	#0016
-      0x70020001,  //  0015  JMP		#0018
-      0x000C0702,  //  0016  ADD	R3	R3	K2
-      0x7001FFF5,  //  0017  JMP		#000E
-      0x7002000A,  //  0018  JMP		#0024
-      0x50100200,  //  0019  LDBOOL	R4	1	0
-      0x78120008,  //  001A  JMPF	R4	#0024
-      0x54120003,  //  001B  LDINT	R4	4
-      0x08100604,  //  001C  MUL	R4	R3	R4
-      0x94100404,  //  001D  GETIDX	R4	R2	R4
-      0x541600FE,  //  001E  LDINT	R5	255
-      0x1C100805,  //  001F  EQ	R4	R4	R5
-      0x78120000,  //  0020  JMPF	R4	#0022
-      0x70020001,  //  0021  JMP		#0024
-      0x000C0702,  //  0022  ADD	R3	R3	K2
-      0x7001FFF4,  //  0023  JMP		#0019
-      0x00100702,  //  0024  ADD	R4	R3	K2
-      0x54160003,  //  0025  LDINT	R5	4
-      0x08100805,  //  0026  MUL	R4	R4	R5
-      0x60140015,  //  0027  GETGBL	R5	G21
-      0x5C180000,  //  0028  MOVE	R6	R0
-      0x5C1C0800,  //  0029  MOVE	R7	R4
-      0x7C140400,  //  002A  CALL	R5	2
-      0x80040A00,  //  002B  RET	1	R5
-      0x80000000,  //  002C  RET	0
+    ( &(const binstruction[37]) {  /* code */
+      0x60080004,  //  0000  GETGBL	R2	G4
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x1C080500,  //  0003  EQ	R2	R2	K0
+      0x780A0003,  //  0004  JMPF	R2	#0009
+      0x8C080101,  //  0005  GETMET	R2	R0	K1
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x5C040400,  //  0008  MOVE	R1	R2
+      0x90020401,  //  0009  SETMBR	R0	K2	R1
+      0x6008000C,  //  000A  GETGBL	R2	G12
+      0x5C0C0200,  //  000B  MOVE	R3	R1
+      0x7C080200,  //  000C  CALL	R2	1
+      0x540E0003,  //  000D  LDINT	R3	4
+      0x0C080403,  //  000E  DIV	R2	R2	R3
+      0x90020602,  //  000F  SETMBR	R0	K3	R2
+      0x88080104,  //  0010  GETMBR	R2	R0	K4
+      0x4C0C0000,  //  0011  LDNIL	R3
+      0x20080403,  //  0012  NE	R2	R2	R3
+      0x780A0003,  //  0013  JMPF	R2	#0018
+      0x8C080105,  //  0014  GETMET	R2	R0	K5
+      0x88100104,  //  0015  GETMBR	R4	R0	K4
+      0x7C080400,  //  0016  CALL	R2	2
+      0x7002000B,  //  0017  JMP		#0024
+      0x88080106,  //  0018  GETMBR	R2	R0	K6
+      0x4C0C0000,  //  0019  LDNIL	R3
+      0x20080403,  //  001A  NE	R2	R2	R3
+      0x780A0007,  //  001B  JMPF	R2	#0024
+      0x88080107,  //  001C  GETMBR	R2	R0	K7
+      0x4C0C0000,  //  001D  LDNIL	R3
+      0x20080403,  //  001E  NE	R2	R2	R3
+      0x780A0003,  //  001F  JMPF	R2	#0024
+      0x8C080108,  //  0020  GETMET	R2	R0	K8
+      0x88100106,  //  0021  GETMBR	R4	R0	K6
+      0x88140107,  //  0022  GETMBR	R5	R0	K7
+      0x7C080600,  //  0023  CALL	R2	3
+      0x80000000,  //  0024  RET	0
     })
   )
 );
@@ -636,40 +642,109 @@ be_local_closure(Animate_palette_ptr_to_palette,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_range
+** Solidified function: to_css_gradient
 ********************************************************************/
-be_local_closure(Animate_palette_set_range,   /* name */
+be_local_closure(Animate_palette_to_css_gradient,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
+    17,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Animate_palette),
+    /* K1   */  be_nested_str_weak(parse_palette),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(background_X3Alinear_X2Dgradient_X28to_X20right),
+    /* K4   */  be_nested_str_weak(palette),
+    /* K5   */  be_nested_str_weak(get),
+    /* K6   */  be_nested_str_weak(_X2C_X23_X2502X_X2502X_X2502X_X20_X25_X2E1f_X25_X25),
+    /* K7   */  be_const_real_hex(0x41200000),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(_X29_X3B),
+    }),
+    be_str_weak(to_css_gradient),
+    &be_const_str_solidified,
+    ( &(const binstruction[46]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x5C080200,  //  0001  MOVE	R2	R1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C080200,  //  0003  CALL	R2	1
+      0x8C0C0501,  //  0004  GETMET	R3	R2	K1
+      0x58140002,  //  0005  LDCONST	R5	K2
+      0x541A03E7,  //  0006  LDINT	R6	1000
+      0x7C0C0600,  //  0007  CALL	R3	3
+      0x58100003,  //  0008  LDCONST	R4	K3
+      0x58140002,  //  0009  LDCONST	R5	K2
+      0x6018000C,  //  000A  GETGBL	R6	G12
+      0x5C1C0600,  //  000B  MOVE	R7	R3
+      0x7C180200,  //  000C  CALL	R6	1
+      0x14180A06,  //  000D  LT	R6	R5	R6
+      0x781A001C,  //  000E  JMPF	R6	#002C
+      0x94180605,  //  000F  GETIDX	R6	R3	R5
+      0x881C0504,  //  0010  GETMBR	R7	R2	K4
+      0x8C1C0F05,  //  0011  GETMET	R7	R7	K5
+      0x54260003,  //  0012  LDINT	R9	4
+      0x08240A09,  //  0013  MUL	R9	R5	R9
+      0x542A0003,  //  0014  LDINT	R10	4
+      0x7C1C0600,  //  0015  CALL	R7	3
+      0x54220007,  //  0016  LDINT	R8	8
+      0x3C200E08,  //  0017  SHR	R8	R7	R8
+      0x542600FE,  //  0018  LDINT	R9	255
+      0x2C201009,  //  0019  AND	R8	R8	R9
+      0x5426000F,  //  001A  LDINT	R9	16
+      0x3C240E09,  //  001B  SHR	R9	R7	R9
+      0x542A00FE,  //  001C  LDINT	R10	255
+      0x2C24120A,  //  001D  AND	R9	R9	R10
+      0x542A0017,  //  001E  LDINT	R10	24
+      0x3C280E0A,  //  001F  SHR	R10	R7	R10
+      0x542E00FE,  //  0020  LDINT	R11	255
+      0x2C28140B,  //  0021  AND	R10	R10	R11
+      0x602C0018,  //  0022  GETGBL	R11	G24
+      0x58300006,  //  0023  LDCONST	R12	K6
+      0x5C341000,  //  0024  MOVE	R13	R8
+      0x5C381200,  //  0025  MOVE	R14	R9
+      0x5C3C1400,  //  0026  MOVE	R15	R10
+      0x0C400D07,  //  0027  DIV	R16	R6	K7
+      0x7C2C0A00,  //  0028  CALL	R11	5
+      0x0010080B,  //  0029  ADD	R4	R4	R11
+      0x00140B08,  //  002A  ADD	R5	R5	K8
+      0x7001FFDD,  //  002B  JMP		#000A
+      0x00100909,  //  002C  ADD	R4	R4	K9
+      0x80040800,  //  002D  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_bri
+********************************************************************/
+be_local_closure(Animate_palette_set_bri,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(value_error),
-    /* K1   */  be_nested_str_weak(min_X20must_X20be_X20lower_X20than_X20mex),
-    /* K2   */  be_nested_str_weak(range_min),
-    /* K3   */  be_nested_str_weak(range_max),
-    /* K4   */  be_nested_str_weak(slots_arr),
-    /* K5   */  be_nested_str_weak(parse_palette),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(bri),
     }),
-    be_str_weak(set_range),
+    be_str_weak(set_bri),
     &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x280C0202,  //  0000  GE	R3	R1	R2
-      0x780E0000,  //  0001  JMPF	R3	#0003
-      0xB0060101,  //  0002  RAISE	1	K0	K1
-      0x90020401,  //  0003  SETMBR	R0	K2	R1
-      0x90020602,  //  0004  SETMBR	R0	K3	R2
-      0x8C0C0105,  //  0005  GETMET	R3	R0	K5
-      0x5C140200,  //  0006  MOVE	R5	R1
-      0x5C180400,  //  0007  MOVE	R6	R2
-      0x7C0C0600,  //  0008  CALL	R3	3
-      0x90020803,  //  0009  SETMBR	R0	K4	R3
-      0x80000000,  //  000A  RET	0
+    ( &(const binstruction[ 5]) {  /* code */
+      0x60080009,  //  0000  GETGBL	R2	G9
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x80000000,  //  0004  RET	0
     })
   )
 );
@@ -780,74 +855,40 @@ be_local_closure(Animate_palette_parse_palette,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_bri
+** Solidified function: set_range
 ********************************************************************/
-be_local_closure(Animate_palette_set_bri,   /* name */
+be_local_closure(Animate_palette_set_range,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
+    7,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(bri),
-    }),
-    be_str_weak(set_bri),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x60080009,  //  0000  GETGBL	R2	G9
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_duration
-********************************************************************/
-be_local_closure(Animate_palette_set_duration,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(value_error),
-    /* K2   */  be_nested_str_weak(duration_ms_X20must_X20be_X20positive),
-    /* K3   */  be_nested_str_weak(duration_ms),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(value_error),
+    /* K1   */  be_nested_str_weak(min_X20must_X20be_X20lower_X20than_X20mex),
+    /* K2   */  be_nested_str_weak(range_min),
+    /* K3   */  be_nested_str_weak(range_max),
     /* K4   */  be_nested_str_weak(slots_arr),
     /* K5   */  be_nested_str_weak(parse_palette),
-    /* K6   */  be_const_int(1),
     }),
-    be_str_weak(set_duration),
+    be_str_weak(set_range),
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0x80000400,  //  0003  RET	0
-      0x18080300,  //  0004  LE	R2	R1	K0
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0xB0060302,  //  0006  RAISE	1	K1	K2
-      0x90020601,  //  0007  SETMBR	R0	K3	R1
-      0x8C080105,  //  0008  GETMET	R2	R0	K5
-      0x58100000,  //  0009  LDCONST	R4	K0
-      0x04140306,  //  000A  SUB	R5	R1	K6
-      0x7C080600,  //  000B  CALL	R2	3
-      0x90020802,  //  000C  SETMBR	R0	K4	R2
-      0x80000000,  //  000D  RET	0
+    ( &(const binstruction[11]) {  /* code */
+      0x280C0202,  //  0000  GE	R3	R1	R2
+      0x780E0000,  //  0001  JMPF	R3	#0003
+      0xB0060101,  //  0002  RAISE	1	K0	K1
+      0x90020401,  //  0003  SETMBR	R0	K2	R1
+      0x90020602,  //  0004  SETMBR	R0	K3	R2
+      0x8C0C0105,  //  0005  GETMET	R3	R0	K5
+      0x5C140200,  //  0006  MOVE	R5	R1
+      0x5C180400,  //  0007  MOVE	R6	R2
+      0x7C0C0600,  //  0008  CALL	R3	3
+      0x90020803,  //  0009  SETMBR	R0	K4	R3
+      0x80000000,  //  000A  RET	0
     })
   )
 );
@@ -988,79 +1029,95 @@ be_local_closure(Animate_palette_set_value,   /* name */
 
 
 /********************************************************************
-** Solidified function: to_css_gradient
+** Solidified function: set_duration
 ********************************************************************/
-be_local_closure(Animate_palette_to_css_gradient,   /* name */
+be_local_closure(Animate_palette_set_duration,   /* name */
   be_nested_proto(
-    17,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Animate_palette),
-    /* K1   */  be_nested_str_weak(parse_palette),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(background_X3Alinear_X2Dgradient_X28to_X20right),
-    /* K4   */  be_nested_str_weak(palette),
-    /* K5   */  be_nested_str_weak(get),
-    /* K6   */  be_nested_str_weak(_X2C_X23_X2502X_X2502X_X2502X_X20_X25_X2E1f_X25_X25),
-    /* K7   */  be_const_real_hex(0x41200000),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(_X29_X3B),
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(value_error),
+    /* K2   */  be_nested_str_weak(duration_ms_X20must_X20be_X20positive),
+    /* K3   */  be_nested_str_weak(duration_ms),
+    /* K4   */  be_nested_str_weak(slots_arr),
+    /* K5   */  be_nested_str_weak(parse_palette),
+    /* K6   */  be_const_int(1),
     }),
-    be_str_weak(to_css_gradient),
+    be_str_weak(set_duration),
     &be_const_str_solidified,
-    ( &(const binstruction[46]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x5C080200,  //  0001  MOVE	R2	R1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0501,  //  0004  GETMET	R3	R2	K1
-      0x58140002,  //  0005  LDCONST	R5	K2
-      0x541A03E7,  //  0006  LDINT	R6	1000
-      0x7C0C0600,  //  0007  CALL	R3	3
-      0x58100003,  //  0008  LDCONST	R4	K3
-      0x58140002,  //  0009  LDCONST	R5	K2
-      0x6018000C,  //  000A  GETGBL	R6	G12
-      0x5C1C0600,  //  000B  MOVE	R7	R3
-      0x7C180200,  //  000C  CALL	R6	1
-      0x14180A06,  //  000D  LT	R6	R5	R6
-      0x781A001C,  //  000E  JMPF	R6	#002C
-      0x94180605,  //  000F  GETIDX	R6	R3	R5
-      0x881C0504,  //  0010  GETMBR	R7	R2	K4
-      0x8C1C0F05,  //  0011  GETMET	R7	R7	K5
-      0x54260003,  //  0012  LDINT	R9	4
-      0x08240A09,  //  0013  MUL	R9	R5	R9
-      0x542A0003,  //  0014  LDINT	R10	4
-      0x7C1C0600,  //  0015  CALL	R7	3
-      0x54220007,  //  0016  LDINT	R8	8
-      0x3C200E08,  //  0017  SHR	R8	R7	R8
-      0x542600FE,  //  0018  LDINT	R9	255
-      0x2C201009,  //  0019  AND	R8	R8	R9
-      0x5426000F,  //  001A  LDINT	R9	16
-      0x3C240E09,  //  001B  SHR	R9	R7	R9
-      0x542A00FE,  //  001C  LDINT	R10	255
-      0x2C24120A,  //  001D  AND	R9	R9	R10
-      0x542A0017,  //  001E  LDINT	R10	24
-      0x3C280E0A,  //  001F  SHR	R10	R7	R10
-      0x542E00FE,  //  0020  LDINT	R11	255
-      0x2C28140B,  //  0021  AND	R10	R10	R11
-      0x602C0018,  //  0022  GETGBL	R11	G24
-      0x58300006,  //  0023  LDCONST	R12	K6
-      0x5C341000,  //  0024  MOVE	R13	R8
-      0x5C381200,  //  0025  MOVE	R14	R9
-      0x5C3C1400,  //  0026  MOVE	R15	R10
-      0x0C400D07,  //  0027  DIV	R16	R6	K7
-      0x7C2C0A00,  //  0028  CALL	R11	5
-      0x0010080B,  //  0029  ADD	R4	R4	R11
-      0x00140B08,  //  002A  ADD	R5	R5	K8
-      0x7001FFDD,  //  002B  JMP		#000A
-      0x00100909,  //  002C  ADD	R4	R4	K9
-      0x80040800,  //  002D  RET	1	R4
+    ( &(const binstruction[14]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x80000400,  //  0003  RET	0
+      0x18080300,  //  0004  LE	R2	R1	K0
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0xB0060302,  //  0006  RAISE	1	K1	K2
+      0x90020601,  //  0007  SETMBR	R0	K3	R1
+      0x8C080105,  //  0008  GETMET	R2	R0	K5
+      0x58100000,  //  0009  LDCONST	R4	K0
+      0x04140306,  //  000A  SUB	R5	R1	K6
+      0x7C080600,  //  000B  CALL	R2	3
+      0x90020802,  //  000C  SETMBR	R0	K4	R2
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Animate_palette_init,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(duration_ms),
+    /* K2   */  be_nested_str_weak(running),
+    /* K3   */  be_nested_str_weak(bri),
+    /* K4   */  be_nested_str_weak(color),
+    /* K5   */  be_nested_str_weak(light_state),
+    /* K6   */  be_nested_str_weak(RGB),
+    /* K7   */  be_nested_str_weak(set_palette),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0x600C0003,  //  0000  GETGBL	R3	G3
+      0x5C100000,  //  0001  MOVE	R4	R0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0700,  //  0003  GETMET	R3	R3	K0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x90020202,  //  0005  SETMBR	R0	K1	R2
+      0x500C0000,  //  0006  LDBOOL	R3	0	0
+      0x90020403,  //  0007  SETMBR	R0	K2	R3
+      0x540E0063,  //  0008  LDINT	R3	100
+      0x90020603,  //  0009  SETMBR	R0	K3	R3
+      0xB80E0A00,  //  000A  GETNGBL	R3	K5
+      0xB8120A00,  //  000B  GETNGBL	R4	K5
+      0x88100906,  //  000C  GETMBR	R4	R4	K6
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x90020803,  //  000E  SETMBR	R0	K4	R3
+      0x8C0C0107,  //  000F  GETMET	R3	R0	K7
+      0x5C140200,  //  0010  MOVE	R5	R1
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x80000000,  //  0012  RET	0
     })
   )
 );
@@ -1074,24 +1131,25 @@ extern const bclass be_class_Animate_animator;
 be_local_class(Animate_palette,
     7,
     &be_class_Animate_animator,
-    be_nested_map(16,
+    be_nested_map(17,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(palette, 5), be_const_var(0) },
-        { be_const_key_weak(range_min, -1), be_const_var(3) },
-        { be_const_key_weak(slots_arr, -1), be_const_var(1) },
-        { be_const_key_weak(init, -1), be_const_closure(Animate_palette_init_closure) },
-        { be_const_key_weak(bri, 14), be_const_var(5) },
-        { be_const_key_weak(animate, -1), be_const_closure(Animate_palette_animate_closure) },
+        { be_const_key_weak(color, 13), be_const_var(6) },
         { be_const_key_weak(slots, -1), be_const_var(2) },
-        { be_const_key_weak(ptr_to_palette, -1), be_const_static_closure(Animate_palette_ptr_to_palette_closure) },
-        { be_const_key_weak(color, -1), be_const_var(6) },
-        { be_const_key_weak(set_range, 10), be_const_closure(Animate_palette_set_range_closure) },
-        { be_const_key_weak(to_css_gradient, -1), be_const_static_closure(Animate_palette_to_css_gradient_closure) },
+        { be_const_key_weak(animate, 11), be_const_closure(Animate_palette_animate_closure) },
+        { be_const_key_weak(range_max, 10), be_const_var(4) },
+        { be_const_key_weak(set_palette, -1), be_const_closure(Animate_palette_set_palette_closure) },
         { be_const_key_weak(set_bri, -1), be_const_closure(Animate_palette_set_bri_closure) },
-        { be_const_key_weak(set_duration, -1), be_const_closure(Animate_palette_set_duration_closure) },
+        { be_const_key_weak(bri, -1), be_const_var(5) },
+        { be_const_key_weak(to_css_gradient, 12), be_const_static_closure(Animate_palette_to_css_gradient_closure) },
+        { be_const_key_weak(slots_arr, 1), be_const_var(1) },
+        { be_const_key_weak(range_min, 5), be_const_var(3) },
         { be_const_key_weak(set_value, -1), be_const_closure(Animate_palette_set_value_closure) },
+        { be_const_key_weak(set_range, -1), be_const_closure(Animate_palette_set_range_closure) },
         { be_const_key_weak(parse_palette, -1), be_const_closure(Animate_palette_parse_palette_closure) },
-        { be_const_key_weak(range_max, -1), be_const_var(4) },
+        { be_const_key_weak(palette, -1), be_const_var(0) },
+        { be_const_key_weak(set_duration, -1), be_const_closure(Animate_palette_set_duration_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Animate_palette_init_closure) },
+        { be_const_key_weak(ptr_to_palette, 0), be_const_static_closure(Animate_palette_ptr_to_palette_closure) },
     })),
     be_str_weak(Animate_palette)
 );
@@ -1266,7 +1324,7 @@ be_local_closure(Animate_oscillator_set_phase,   /* name */
 ********************************************************************/
 be_local_closure(Animate_oscillator_init,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    7,                          /* nstack */
     5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1274,33 +1332,39 @@ be_local_closure(Animate_oscillator_init,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(phase),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(duty_cycle),
-    /* K3   */  be_nested_str_weak(a),
-    /* K4   */  be_nested_str_weak(b),
-    /* K5   */  be_nested_str_weak(duration_ms),
-    /* K6   */  be_nested_str_weak(value),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(form),
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    /* K1   */  be_nested_str_weak(phase),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(duty_cycle),
+    /* K4   */  be_nested_str_weak(a),
+    /* K5   */  be_nested_str_weak(b),
+    /* K6   */  be_nested_str_weak(duration_ms),
+    /* K7   */  be_nested_str_weak(value),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(form),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x90020101,  //  0000  SETMBR	R0	K0	K1
-      0x54160031,  //  0001  LDINT	R5	50
-      0x90020405,  //  0002  SETMBR	R0	K2	R5
-      0x90020601,  //  0003  SETMBR	R0	K3	R1
-      0x90020802,  //  0004  SETMBR	R0	K4	R2
-      0x90020A03,  //  0005  SETMBR	R0	K5	R3
-      0x90020C01,  //  0006  SETMBR	R0	K6	R1
-      0x4C140000,  //  0007  LDNIL	R5
-      0x1C140805,  //  0008  EQ	R5	R4	R5
-      0x78160000,  //  0009  JMPF	R5	#000B
-      0x58100007,  //  000A  LDCONST	R4	K7
-      0x90021004,  //  000B  SETMBR	R0	K8	R4
-      0x80000000,  //  000C  RET	0
+    ( &(const binstruction[18]) {  /* code */
+      0x60140003,  //  0000  GETGBL	R5	G3
+      0x5C180000,  //  0001  MOVE	R6	R0
+      0x7C140200,  //  0002  CALL	R5	1
+      0x8C140B00,  //  0003  GETMET	R5	R5	K0
+      0x7C140200,  //  0004  CALL	R5	1
+      0x90020302,  //  0005  SETMBR	R0	K1	K2
+      0x54160031,  //  0006  LDINT	R5	50
+      0x90020605,  //  0007  SETMBR	R0	K3	R5
+      0x90020801,  //  0008  SETMBR	R0	K4	R1
+      0x90020A02,  //  0009  SETMBR	R0	K5	R2
+      0x90020C03,  //  000A  SETMBR	R0	K6	R3
+      0x90020E01,  //  000B  SETMBR	R0	K7	R1
+      0x4C140000,  //  000C  LDNIL	R5
+      0x1C140805,  //  000D  EQ	R5	R4	R5
+      0x78160000,  //  000E  JMPF	R5	#0010
+      0x58100008,  //  000F  LDCONST	R4	K8
+      0x90021204,  //  0010  SETMBR	R0	K9	R4
+      0x80000000,  //  0011  RET	0
     })
   )
 );

--- a/tasmota/berry/animate_demo/animate_demo_breathe.be
+++ b/tasmota/berry/animate_demo/animate_demo_breathe.be
@@ -1,0 +1,28 @@
+#
+# Example for M5Stack Led Matrix
+# 5 x 5 WS2812
+#
+import animate
+
+var PALETTE_BLACK_RED = bytes(
+    "00"  "000000"    # black
+    "88"  "880000"    # red
+    "FF"  "FF5500"    # orange
+  )
+  
+  var duration = 3000
+  var leds = 25
+  
+  var strip = Leds(leds, gpio.pin(gpio.WS2812, 0))
+  var anim = animate.core(strip, 100)
+  anim.set_back_color(0x000000)
+  
+  var pulse = animate.pulse(0xFF0000, leds, 0)
+  var palette = animate.palette(PALETTE_BLACK_RED)
+  palette.set_range(0, 255)
+  palette.set_cb(pulse, pulse.set_color)
+  
+  var osc1 = animate.oscillator(50, 255, duration, animate.COSINE)
+  osc1.set_cb(palette, palette.set_value)
+  
+  anim.start()

--- a/tasmota/berry/animate_demo/animate_demo_pulse.be
+++ b/tasmota/berry/animate_demo/animate_demo_pulse.be
@@ -12,12 +12,8 @@ var pulse = animate.pulse(0xFF4444, 2, 1)
 var osc1 = animate.oscillator(-3, 26, 5000, animate.COSINE)
 osc1.set_cb(pulse, pulse.set_pos)
 
-anim.add_animator(osc1)
-anim.add_painter(pulse)
-
 # animate color of pulse
 var palette = animate.palette(animate.PALETTE_RAINBOW_WHITE, 30000)
 palette.set_cb(pulse, pulse.set_color)
-anim.add_animator(palette)
 
 anim.start()


### PR DESCRIPTION
## Description:

Simplify `animate` module, now the current `animate.core` is memorized, and you don't need to call `add_animator()` nor `add_painter()`.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
