### PR TITLE
Mi32 legacy: allow Berry fast_loop for BLE module

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
@@ -46,6 +46,9 @@ module MI32 (scope: global) {
 
 extern int be_BLE_init(bvm *vm);
 
+extern void be_BLE_loop(void);
+BE_FUNC_CTYPE_DECLARE(be_BLE_loop, "", "");
+
 extern void be_BLE_reg_conn_cb(void* function, uint8_t *buffer);
 BE_FUNC_CTYPE_DECLARE(be_BLE_reg_conn_cb, "", "cc");
 
@@ -79,6 +82,7 @@ BE_FUNC_CTYPE_DECLARE(be_BLE_adv_block, "", "@(bytes)~[i]");
 /* @const_object_info_begin
 module BLE (scope: global) {
   init,       func(be_BLE_init)
+  loop,       ctype_func(be_BLE_loop)
   conn_cb,    ctype_func(be_BLE_reg_conn_cb)
   set_svc,    ctype_func(be_BLE_set_service)
   run,        ctype_func(be_BLE_run)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
@@ -76,6 +76,7 @@ extern "C" {
 **  BLE - generic BLE functions
 ********************************************************************/
   extern bool MI32checkBLEinitialization();
+  extern void MI32BerryLoop();
   extern void MI32setBerryAdvCB(void* function, uint8_t *buffer);
   extern void MI32setBerryConnCB(void* function, uint8_t *buffer);
   extern void MI32setBerryServerCB(void* function, uint8_t *buffer);
@@ -93,6 +94,10 @@ extern "C" {
     }
     be_raise(vm, "ble_error", "BLE: device not initialized");
     be_return_nil(vm);
+  }
+
+  void be_BLE_loop(void){
+    MI32BerryLoop();
   }
 
   void be_BLE_reg_conn_cb(void* function, uint8_t *buffer);

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -707,6 +707,10 @@ extern "C" {
     return (MI32.mode.init && Settings->flag5.mi32_enable);
   }
 
+  void MI32BerryLoop(){
+    MI32BLELoop();
+  }
+
   bool MI32runBerryServer(uint16_t operation, bool response){
     MI32.conCtx->operation = operation;
     MI32.conCtx->response = response;
@@ -1861,15 +1865,10 @@ void MI32ParseResponse(char *buf, uint16_t bufsize, uint8_t addr[6], int RSSI) {
 }
 
 /**
- * @brief Launch functions from Core 1 to make race conditions less likely
- *
- */
-
-void MI32Every50mSecond(){
-  if(MI32.mode.shallTriggerTele){
-      MI32.mode.shallTriggerTele = 0;
-      MI32triggerTele();
-  }
+ * Called automatically every 50 milliseconds or can be triggered from Berry with BLE.loop() - useful from fast_loop
+*/
+void MI32BLELoop()
+{
   if(MI32.mode.triggerBerryAdvCB == 1){
     if(MI32.beAdvCB != nullptr){
         // AddLogBuffer(LOG_LEVEL_DEBUG,MI32.beAdvBuf,40);
@@ -1945,14 +1944,25 @@ void MI32Every50mSecond(){
       }
     }
   }
-
   if(MI32.infoMsg > 0){
     char _message[32];
     GetTextIndexed(_message, sizeof(_message), MI32.infoMsg-1, kMI32_BLEInfoMsg);
     AddLog(LOG_LEVEL_DEBUG,PSTR("M32: %s"),_message);
     MI32.infoMsg = 0;
   }
+}
 
+/**
+ * @brief Launch functions from Core 1 to make race conditions less likely
+ *
+ */
+
+void MI32Every50mSecond(){
+  if(MI32.mode.shallTriggerTele){
+      MI32.mode.shallTriggerTele = 0;
+      MI32triggerTele();
+  }
+  MI32BLELoop();
 }
 
 /**


### PR DESCRIPTION
## Description:

Adds method `loop` to BLE module, which will trigger the callbacks for Berry, if there is new data in the BLE buffers.
This can be used like that for the fastest possible BLE data consumption, no other code changes needed in Berry:
`tasmota.add_fast_loop(/-> BLE.loop()) #  in an init function of a class`

This is no breaking change. If not used, callbacks will be fired every 50 milliseconds as before. 

Tested with an BPR2S Air mouse (a cheap BLE HID controller), that can now transmit not only button presses but cursor position movement in realtime too.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
