### PR TITLE
Add new board setting "download speed" to esp32x boards json

### DIFF
--- a/boards/esp32-fix.json
+++ b/boards/esp32-fix.json
@@ -41,6 +41,9 @@
     "require_upload_port": true,
     "speed": 460800
   },
+  "download": {
+    "speed": 230400
+  },
   "url": "https://en.wikipedia.org/wiki/ESP32",
   "vendor": "Espressif"
 }

--- a/boards/esp32.json
+++ b/boards/esp32.json
@@ -41,6 +41,9 @@
       "require_upload_port": true,
       "speed": 460800
     },
+    "download": {
+      "speed": 230400
+    },
     "url": "https://en.wikipedia.org/wiki/ESP32",
     "vendor": "Espressif"
   }

--- a/boards/esp32_solo1.json
+++ b/boards/esp32_solo1.json
@@ -41,6 +41,9 @@
     "require_upload_port": true,
     "speed": 460800
   },
+  "download": {
+    "speed": 230400
+  },
   "url": "https://en.wikipedia.org/wiki/ESP32",
   "vendor": "Espressif"
 }

--- a/boards/esp32c2.json
+++ b/boards/esp32c2.json
@@ -39,6 +39,9 @@
       "require_upload_port": true,
       "speed": 460800
     },
+    "download": {
+      "speed": 230400
+    },
     "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/index.html",
     "vendor": "Espressif"
   }

--- a/boards/esp32c2_2M.json
+++ b/boards/esp32c2_2M.json
@@ -39,6 +39,9 @@
       "require_upload_port": true,
       "speed": 460800
     },
+    "download": {
+      "speed": 230400
+    },
     "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/index.html",
     "vendor": "Espressif"
   }

--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -39,6 +39,9 @@
       "require_upload_port": true,
       "speed": 460800
     },
+    "download": {
+      "speed": 230400
+    },
     "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html",
     "vendor": "Espressif"
   }

--- a/boards/esp32c3cdc.json
+++ b/boards/esp32c3cdc.json
@@ -41,7 +41,10 @@
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
       "require_upload_port": true,
-      "speed": 460800
+      "speed": 2000000
+    },
+    "download": {
+      "speed": 2000000
     },
     "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html",
     "vendor": "Espressif"

--- a/boards/esp32c6.json
+++ b/boards/esp32c6.json
@@ -39,6 +39,9 @@
       "require_upload_port": true,
       "speed": 460800
     },
+    "download": {
+      "speed": 230400
+    },
     "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/index.html",
     "vendor": "Espressif"
   }

--- a/boards/esp32c6cdc.json
+++ b/boards/esp32c6cdc.json
@@ -41,7 +41,10 @@
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
       "require_upload_port": true,
-      "speed": 460800
+      "speed": 2000000
+    },
+    "download": {
+      "speed": 2000000
     },
     "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/index.html",
     "vendor": "Espressif"

--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -38,6 +38,9 @@
     "require_upload_port": true,
     "speed": 460800
   },
+  "download": {
+    "speed": 230400
+  },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html",
   "vendor": "Espressif"
 }

--- a/boards/esp32s2cdc.json
+++ b/boards/esp32s2cdc.json
@@ -37,7 +37,10 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "before_reset": "usb_reset",
-    "speed": 460800
+    "speed": 2000000
+  },
+  "download": {
+    "speed": 2000000
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html",
   "vendor": "Espressif"

--- a/boards/esp32s3-opi_opi.json
+++ b/boards/esp32s3-opi_opi.json
@@ -41,6 +41,9 @@
       "require_upload_port": true,
       "speed": 460800
     },
+    "download": {
+      "speed": 230400
+    },
     "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
     "vendor": "Espressif"
   }

--- a/boards/esp32s3-qio_opi.json
+++ b/boards/esp32s3-qio_opi.json
@@ -41,6 +41,9 @@
     "require_upload_port": true,
     "speed": 460800
   },
+  "download": {
+    "speed": 230400
+  },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
   "vendor": "Espressif"
 }

--- a/boards/esp32s3-qio_qspi.json
+++ b/boards/esp32s3-qio_qspi.json
@@ -41,6 +41,9 @@
     "require_upload_port": true,
     "speed": 460800
   },
+  "download": {
+    "speed": 230400
+  },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
   "vendor": "Espressif"
 }

--- a/boards/esp32s3cdc-opi_opi.json
+++ b/boards/esp32s3cdc-opi_opi.json
@@ -49,7 +49,10 @@
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
       "require_upload_port": true,
-      "speed": 460800
+      "speed": 2000000
+    },
+    "download": {
+      "speed": 2000000
     },
     "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
     "vendor": "Espressif"

--- a/boards/esp32s3cdc-qio_opi.json
+++ b/boards/esp32s3cdc-qio_opi.json
@@ -49,7 +49,10 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 460800
+    "speed": 2000000
+  },
+  "download": {
+    "speed": 2000000
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
   "vendor": "Espressif"

--- a/boards/esp32s3cdc-qio_qspi.json
+++ b/boards/esp32s3cdc-qio_qspi.json
@@ -49,7 +49,10 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 460800
+    "speed": 2000000
+  },
+  "download": {
+    "speed": 2000000
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
   "vendor": "Espressif"

--- a/pio-tools/custom_target.py
+++ b/pio-tools/custom_target.py
@@ -186,6 +186,7 @@ def parse_partition_table(content):
 def get_partition_table():
     esptoolpy = join(platform.get_package_dir("tool-esptoolpy") or "", "esptool.py")
     upload_port = join(env.get("UPLOAD_PORT", "none"))
+    download_speed = join(str(board.get("download.speed", "115200")))
     if "none" in upload_port:
         env.AutodetectUploadPort()
         upload_port = join(env.get("UPLOAD_PORT", "none"))
@@ -193,7 +194,7 @@ def get_partition_table():
     esptoolpy_flags = [
             "--chip", mcu,
             "--port", upload_port,
-            "--baud",  env.subst("$UPLOAD_SPEED"),
+            "--baud",  download_speed,
             "--before", "default_reset",
             "--after", "hard_reset",
             "read_flash",
@@ -246,6 +247,7 @@ def download_fs(fs_info: FSInfo):
     print(fs_info)
     esptoolpy = join(platform.get_package_dir("tool-esptoolpy") or "", "esptool.py")
     upload_port = join(env.get("UPLOAD_PORT", "none"))
+    download_speed = join(str(board.get("download.speed", "115200")))
     if "none" in upload_port:
         env.AutodetectUploadPort()
         upload_port = join(env.get("UPLOAD_PORT", "none"))
@@ -253,7 +255,7 @@ def download_fs(fs_info: FSInfo):
     esptoolpy_flags = [
             "--chip", mcu,
             "--port", upload_port,
-            "--baud",  env.subst("$UPLOAD_SPEED"),
+            "--baud",  download_speed,
             "--before", "default_reset",
             "--after", "hard_reset",
             "read_flash",
@@ -278,7 +280,7 @@ def unpack_fs(fs_info: FSInfo, downloaded_file: str):
     unpack_dir = env.GetProjectOption("custom_unpack_dir", "unpacked_fs")
     #unpack_dir = "unpacked_fs"
     if not os.path.exists(downloaded_file):
-        print(f"ERROR: {downloaded_file} with filesystem not found, maybe download failed due to upload_speed setting being too high.")
+        print(f"ERROR: {downloaded_file} with filesystem not found, maybe download failed due to download_speed setting being too high.")
         assert(0)
     try:
         if os.path.exists(unpack_dir):
@@ -305,7 +307,7 @@ def display_fs(extracted_dir):
     print("Extracted " + str(file_count) + " file(s) from filesystem.")
 
 def command_download_fs(*args, **kwargs):
-    print("Entrypoint")
+    #print("Entrypoint")
     #print(env.Dump())
     get_partition_table()
     info = get_fs_type_start_and_length()
@@ -356,3 +358,4 @@ env.AddCustomTarget(
     title="Flash factory",
     description="Flash factory firmware"
 )
+


### PR DESCRIPTION
## Description:

- Downloading content needs most of the time a lower speeds than the upload speed.
Now there is the possibility to have different speed for flash up- and download.
- Change upload speed for CDC devices to 2000000
- The LittleFS image script for esp32x does use the download speed setting

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
