### PR TITLE
Update xdrv_58_range_extender.ino - Fix invalid JSON

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_58_range_extender.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_58_range_extender.ino
@@ -377,7 +377,7 @@ void CmndRgxPort(void)
 void ResponseRgxConfig(void)
 {
   RgxCheckConfig();
-  Response_P(PSTR("{\"Rgx\":{\"Valid\":\"%s\",\"" D_CMND_SSID "\":\"%s\",\"" D_CMND_PASSWORD "\":\"%s\",\"" D_CMND_IPADDRESS "\":\"%_I\",\"" D_JSON_SUBNETMASK "\":\"%_I\"}"),
+  Response_P(PSTR("{\"Rgx\":{\"Valid\":\"%s\",\"" D_CMND_SSID "\":\"%s\",\"" D_CMND_PASSWORD "\":\"%s\",\"" D_CMND_IPADDRESS "\":\"%_I\",\"" D_JSON_SUBNETMASK "\":\"%_I\"}}"),
              (RgxSettings.status == RGX_CONFIG_INCOMPLETE) ? "false" : "true",
              EscapeJSONString(SettingsText(SET_RGX_SSID)).c_str(),
              EscapeJSONString(SettingsText(SET_RGX_PASSWORD)).c_str(),


### PR DESCRIPTION
RESULT to RgxSSId command is not valid JSON

BEFORE:
```
RSL: RESULT = {"Rgx":{"Valid":"true","SSId":"solar_5BDBFC","Password":"MyPassword","IPAddress":"192.168.99.1","Subnetmask":"255.255.255.0"}
```
AFTER
```
RSL: RESULT = {"Rgx":{"Valid":"true","SSId":"solar_5BDBFC","Password":"MyPassword","IPAddress":"192.168.99.1","Subnetmask":"255.255.255.0"}}
```
Note extra terminating '}'

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here> (No known issue report)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
