### PR TITLE
Matter support for password for remote Tasmota devices

### DIFF
--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_async.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_async.h
@@ -7,375 +7,6 @@
 extern const bclass be_class_Matter_HTTP_async;
 
 /********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_HTTP_async_init,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(init),
-    /* K1   */  be_nested_str_weak(compile_re),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x60140003,  //  0000  GETGBL	R5	G3
-      0x5C180000,  //  0001  MOVE	R6	R0
-      0x7C140200,  //  0002  CALL	R5	1
-      0x8C140B00,  //  0003  GETMET	R5	R5	K0
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x5C200400,  //  0005  MOVE	R8	R2
-      0x5C240600,  //  0006  MOVE	R9	R3
-      0x5C280800,  //  0007  MOVE	R10	R4
-      0x7C140A00,  //  0008  CALL	R5	5
-      0x8C140101,  //  0009  GETMET	R5	R0	K1
-      0x7C140200,  //  000A  CALL	R5	1
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: event_http_failed
-********************************************************************/
-be_local_closure(Matter_HTTP_async_event_http_failed,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(event_http_failed),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: compile_re
-********************************************************************/
-be_local_closure(Matter_HTTP_async_compile_re,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(re),
-    /* K1   */  be_nested_str_weak(global),
-    /* K2   */  be_nested_str_weak(contains),
-    /* K3   */  be_nested_str_weak(_re_http_status),
-    /* K4   */  be_nested_str_weak(compile),
-    /* K5   */  be_nested_str_weak(HTTP_STATUS_REGEX),
-    /* K6   */  be_nested_str_weak(_re_http_header),
-    /* K7   */  be_nested_str_weak(HTTP_HEADER_REGEX),
-    /* K8   */  be_nested_str_weak(_re_http_body),
-    /* K9   */  be_nested_str_weak(HTTP_BODY_REGEX),
-    /* K10  */  be_nested_str_weak(_re_http_chunk),
-    /* K11  */  be_nested_str_weak(HTTP_CHUNK_REGEX),
-    }),
-    be_str_weak(compile_re),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x58100003,  //  0003  LDCONST	R4	K3
-      0x7C080400,  //  0004  CALL	R2	2
-      0x740A0013,  //  0005  JMPT	R2	#001A
-      0xB80A0200,  //  0006  GETNGBL	R2	K1
-      0x8C0C0304,  //  0007  GETMET	R3	R1	K4
-      0x88140105,  //  0008  GETMBR	R5	R0	K5
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x900A0603,  //  000A  SETMBR	R2	K3	R3
-      0xB80A0200,  //  000B  GETNGBL	R2	K1
-      0x8C0C0304,  //  000C  GETMET	R3	R1	K4
-      0x88140107,  //  000D  GETMBR	R5	R0	K7
-      0x7C0C0400,  //  000E  CALL	R3	2
-      0x900A0C03,  //  000F  SETMBR	R2	K6	R3
-      0xB80A0200,  //  0010  GETNGBL	R2	K1
-      0x8C0C0304,  //  0011  GETMET	R3	R1	K4
-      0x88140109,  //  0012  GETMBR	R5	R0	K9
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x900A1003,  //  0014  SETMBR	R2	K8	R3
-      0xB80A0200,  //  0015  GETNGBL	R2	K1
-      0x8C0C0304,  //  0016  GETMET	R3	R1	K4
-      0x8814010B,  //  0017  GETMBR	R5	R0	K11
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x900A1403,  //  0019  SETMBR	R2	K10	R3
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_http_response
-********************************************************************/
-be_local_closure(Matter_HTTP_async_parse_http_response,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(phase),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(parse_http_status_line),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(parse_http_headers),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_nested_str_weak(parse_http_payload),
-    }),
-    be_str_weak(parse_http_response),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x1C040301,  //  0001  EQ	R1	R1	K1
-      0x78060002,  //  0002  JMPF	R1	#0006
-      0x8C040102,  //  0003  GETMET	R1	R0	K2
-      0x7C040200,  //  0004  CALL	R1	1
-      0x7002000A,  //  0005  JMP		#0011
-      0x88040100,  //  0006  GETMBR	R1	R0	K0
-      0x1C040303,  //  0007  EQ	R1	R1	K3
-      0x78060002,  //  0008  JMPF	R1	#000C
-      0x8C040104,  //  0009  GETMET	R1	R0	K4
-      0x7C040200,  //  000A  CALL	R1	1
-      0x70020004,  //  000B  JMP		#0011
-      0x88040100,  //  000C  GETMBR	R1	R0	K0
-      0x1C040305,  //  000D  EQ	R1	R1	K5
-      0x78060001,  //  000E  JMPF	R1	#0011
-      0x8C040106,  //  000F  GETMET	R1	R0	K6
-      0x7C040200,  //  0010  CALL	R1	1
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: event_available
-********************************************************************/
-be_local_closure(Matter_HTTP_async_event_available,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(receive),
-    }),
-    be_str_weak(event_available),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: receive
-********************************************************************/
-be_local_closure(Matter_HTTP_async_receive,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tcp_connected),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(time_start),
-    /* K4   */  be_nested_str_weak(timeout),
-    /* K5   */  be_nested_str_weak(status),
-    /* K6   */  be_nested_str_weak(close),
-    /* K7   */  be_nested_str_weak(http_status),
-    /* K8   */  be_nested_str_weak(event_http_timeout),
-    /* K9   */  be_nested_str_weak(tcp),
-    /* K10  */  be_nested_str_weak(available),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(read),
-    /* K13  */  be_nested_str_weak(response),
-    /* K14  */  be_nested_str_weak(parse_http_response),
-    }),
-    be_str_weak(receive),
-    &be_const_str_solidified,
-    ( &(const binstruction[48]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x50080200,  //  0001  LDBOOL	R2	1	0
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060000,  //  0003  JMPF	R1	#0005
-      0x80000200,  //  0004  RET	0
-      0xB8060200,  //  0005  GETNGBL	R1	K1
-      0x8C040302,  //  0006  GETMET	R1	R1	K2
-      0x7C040200,  //  0007  CALL	R1	1
-      0x88080103,  //  0008  GETMBR	R2	R0	K3
-      0x04040202,  //  0009  SUB	R1	R1	R2
-      0x88080104,  //  000A  GETMBR	R2	R0	K4
-      0x24040202,  //  000B  GT	R1	R1	R2
-      0x78060008,  //  000C  JMPF	R1	#0016
-      0x5405FFFC,  //  000D  LDINT	R1	-3
-      0x90020A01,  //  000E  SETMBR	R0	K5	R1
-      0x8C040106,  //  000F  GETMET	R1	R0	K6
-      0x7C040200,  //  0010  CALL	R1	1
-      0x5405FFFD,  //  0011  LDINT	R1	-2
-      0x90020E01,  //  0012  SETMBR	R0	K7	R1
-      0x8C040108,  //  0013  GETMET	R1	R0	K8
-      0x7C040200,  //  0014  CALL	R1	1
-      0x70020018,  //  0015  JMP		#002F
-      0x88040109,  //  0016  GETMBR	R1	R0	K9
-      0x8C04030A,  //  0017  GETMET	R1	R1	K10
-      0x7C040200,  //  0018  CALL	R1	1
-      0x5808000B,  //  0019  LDCONST	R2	K11
-      0x240C030B,  //  001A  GT	R3	R1	K11
-      0x780E000E,  //  001B  JMPF	R3	#002B
-      0x880C0109,  //  001C  GETMBR	R3	R0	K9
-      0x8C0C070C,  //  001D  GETMET	R3	R3	K12
-      0x7C0C0200,  //  001E  CALL	R3	1
-      0x8810010D,  //  001F  GETMBR	R4	R0	K13
-      0x00100803,  //  0020  ADD	R4	R4	R3
-      0x90021A04,  //  0021  SETMBR	R0	K13	R4
-      0x6010000C,  //  0022  GETGBL	R4	G12
-      0x5C140600,  //  0023  MOVE	R5	R3
-      0x7C100200,  //  0024  CALL	R4	1
-      0x00080404,  //  0025  ADD	R2	R2	R4
-      0x88100109,  //  0026  GETMBR	R4	R0	K9
-      0x8C10090A,  //  0027  GETMET	R4	R4	K10
-      0x7C100200,  //  0028  CALL	R4	1
-      0x5C040800,  //  0029  MOVE	R1	R4
-      0x7001FFEE,  //  002A  JMP		#001A
-      0x240C050B,  //  002B  GT	R3	R2	K11
-      0x780E0001,  //  002C  JMPF	R3	#002F
-      0x8C0C010E,  //  002D  GETMET	R3	R0	K14
-      0x7C0C0200,  //  002E  CALL	R3	1
-      0x80000000,  //  002F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: reset
-********************************************************************/
-be_local_closure(Matter_HTTP_async_reset,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(reset),
-    /* K1   */  be_nested_str_weak(cmd),
-    /* K2   */  be_nested_str_weak(response),
-    /* K3   */  be_nested_str_weak(response_offset),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(payload),
-    /* K6   */  be_nested_str_weak(),
-    /* K7   */  be_nested_str_weak(phase),
-    /* K8   */  be_nested_str_weak(http_status),
-    /* K9   */  be_nested_str_weak(is_chunked),
-    /* K10  */  be_nested_str_weak(chunk_size),
-    }),
-    be_str_weak(reset),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x60040003,  //  0000  GETGBL	R1	G3
-      0x5C080000,  //  0001  MOVE	R2	R0
-      0x7C040200,  //  0002  CALL	R1	1
-      0x8C040300,  //  0003  GETMET	R1	R1	K0
-      0x7C040200,  //  0004  CALL	R1	1
-      0x4C040000,  //  0005  LDNIL	R1
-      0x90020201,  //  0006  SETMBR	R0	K1	R1
-      0x4C040000,  //  0007  LDNIL	R1
-      0x90020401,  //  0008  SETMBR	R0	K2	R1
-      0x90020704,  //  0009  SETMBR	R0	K3	K4
-      0x90020B06,  //  000A  SETMBR	R0	K5	K6
-      0x90020F04,  //  000B  SETMBR	R0	K7	K4
-      0x90021104,  //  000C  SETMBR	R0	K8	K4
-      0x50040000,  //  000D  LDBOOL	R1	0	0
-      0x90021201,  //  000E  SETMBR	R0	K9	R1
-      0x4C040000,  //  000F  LDNIL	R1
-      0x90021401,  //  0010  SETMBR	R0	K10	R1
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: event_http_status_code
-********************************************************************/
-be_local_closure(Matter_HTTP_async_event_http_status_code,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(status_code),
-    }),
-    be_str_weak(event_http_status_code),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: parse_http_payload
 ********************************************************************/
 be_local_closure(Matter_HTTP_async_parse_http_payload,   /* name */
@@ -498,149 +129,6 @@ be_local_closure(Matter_HTTP_async_parse_http_payload,   /* name */
 
 
 /********************************************************************
-** Solidified function: send_http
-********************************************************************/
-be_local_closure(Matter_HTTP_async_send_http,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(response),
-    /* K2   */  be_nested_str_weak(),
-    /* K3   */  be_nested_str_weak(addr),
-    /* K4   */  be_nested_str_weak(find),
-    /* K5   */  be_nested_str_weak(_X3A),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(_X5B),
-    /* K8   */  be_nested_str_weak(_X5D),
-    /* K9   */  be_nested_str_weak(HTTP_GET),
-    /* K10  */  be_nested_str_weak(cmd),
-    /* K11  */  be_nested_str_weak(port),
-    /* K12  */  be_nested_str_weak(write),
-    /* K13  */  be_nested_str_weak(close),
-    /* K14  */  be_nested_str_weak(status),
-    /* K15  */  be_nested_str_weak(http_status),
-    /* K16  */  be_nested_str_weak(event_http_failed),
-    }),
-    be_str_weak(send_http),
-    &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x90020302,  //  0001  SETMBR	R0	K1	K2
-      0x88080103,  //  0002  GETMBR	R2	R0	K3
-      0x8C0C0304,  //  0003  GETMET	R3	R1	K4
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x58180005,  //  0005  LDCONST	R6	K5
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x280C0706,  //  0007  GE	R3	R3	K6
-      0x780E0002,  //  0008  JMPF	R3	#000C
-      0x000E0E02,  //  0009  ADD	R3	K7	R2
-      0x000C0708,  //  000A  ADD	R3	R3	K8
-      0x5C080600,  //  000B  MOVE	R2	R3
-      0x600C0018,  //  000C  GETGBL	R3	G24
-      0x88100109,  //  000D  GETMBR	R4	R0	K9
-      0x8814010A,  //  000E  GETMBR	R5	R0	K10
-      0x5C180400,  //  000F  MOVE	R6	R2
-      0x881C010B,  //  0010  GETMBR	R7	R0	K11
-      0x7C0C0800,  //  0011  CALL	R3	4
-      0x8C10010C,  //  0012  GETMET	R4	R0	K12
-      0x5C180600,  //  0013  MOVE	R6	R3
-      0x7C100400,  //  0014  CALL	R4	2
-      0x6014000C,  //  0015  GETGBL	R5	G12
-      0x5C180600,  //  0016  MOVE	R6	R3
-      0x7C140200,  //  0017  CALL	R5	1
-      0x20140805,  //  0018  NE	R5	R4	R5
-      0x78160007,  //  0019  JMPF	R5	#0022
-      0x8C14010D,  //  001A  GETMET	R5	R0	K13
-      0x7C140200,  //  001B  CALL	R5	1
-      0x5415FFFB,  //  001C  LDINT	R5	-4
-      0x90021C05,  //  001D  SETMBR	R0	K14	R5
-      0x5415FFFE,  //  001E  LDINT	R5	-1
-      0x90021E05,  //  001F  SETMBR	R0	K15	R5
-      0x8C140110,  //  0020  GETMET	R5	R0	K16
-      0x7C140200,  //  0021  CALL	R5	1
-      0x80000000,  //  0022  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: begin_sync
-********************************************************************/
-be_local_closure(Matter_HTTP_async_begin_sync,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(timeout),
-    /* K1   */  be_nested_str_weak(set_timeout),
-    /* K2   */  be_nested_str_weak(SPINLOCK),
-    /* K3   */  be_nested_str_weak(begin),
-    /* K4   */  be_nested_str_weak(http_status),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(loop),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(delay),
-    /* K9   */  be_nested_str_weak(payload),
-    }),
-    be_str_weak(begin_sync),
-    &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x4C100000,  //  0001  LDNIL	R4
-      0x20100404,  //  0002  NE	R4	R2	R4
-      0x78120002,  //  0003  JMPF	R4	#0007
-      0x8C100101,  //  0004  GETMET	R4	R0	K1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0x4C100000,  //  0007  LDNIL	R4
-      0x88140102,  //  0008  GETMBR	R5	R0	K2
-      0x8C180103,  //  0009  GETMET	R6	R0	K3
-      0x5C200200,  //  000A  MOVE	R8	R1
-      0x7C180400,  //  000B  CALL	R6	2
-      0x781A0009,  //  000C  JMPF	R6	#0017
-      0x881C0104,  //  000D  GETMBR	R7	R0	K4
-      0x1C1C0F05,  //  000E  EQ	R7	R7	K5
-      0x781E0006,  //  000F  JMPF	R7	#0017
-      0x8C1C0106,  //  0010  GETMET	R7	R0	K6
-      0x7C1C0200,  //  0011  CALL	R7	1
-      0xB81E0E00,  //  0012  GETNGBL	R7	K7
-      0x8C1C0F08,  //  0013  GETMET	R7	R7	K8
-      0x5C240A00,  //  0014  MOVE	R9	R5
-      0x7C1C0400,  //  0015  CALL	R7	2
-      0x7001FFF5,  //  0016  JMP		#000D
-      0x8C1C0101,  //  0017  GETMET	R7	R0	K1
-      0x5C240600,  //  0018  MOVE	R9	R3
-      0x7C1C0400,  //  0019  CALL	R7	2
-      0x881C0104,  //  001A  GETMBR	R7	R0	K4
-      0x241C0F05,  //  001B  GT	R7	R7	K5
-      0x781E0001,  //  001C  JMPF	R7	#001F
-      0x881C0109,  //  001D  GETMBR	R7	R0	K9
-      0x70020000,  //  001E  JMP		#0020
-      0x4C1C0000,  //  001F  LDNIL	R7
-      0x80040E00,  //  0020  RET	1	R7
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: event_http_finished
 ********************************************************************/
 be_local_closure(Matter_HTTP_async_event_http_finished,   /* name */
@@ -665,30 +153,47 @@ be_local_closure(Matter_HTTP_async_event_http_finished,   /* name */
 
 
 /********************************************************************
-** Solidified function: event_timeout
+** Solidified function: event_http_header
 ********************************************************************/
-be_local_closure(Matter_HTTP_async_event_timeout,   /* name */
+be_local_closure(Matter_HTTP_async_event_http_header,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
+    7,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(http_status),
-    /* K1   */  be_nested_str_weak(event_http_timeout),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tolower),
+    /* K2   */  be_nested_str_weak(transfer_X2Dencoding),
+    /* K3   */  be_nested_str_weak(chunked),
+    /* K4   */  be_nested_str_weak(is_chunked),
     }),
-    be_str_weak(event_timeout),
+    be_str_weak(event_http_header),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x5405FFFD,  //  0000  LDINT	R1	-2
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
-      0x7C040200,  //  0003  CALL	R1	1
-      0x80000000,  //  0004  RET	0
+    ( &(const binstruction[19]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0x8C100701,  //  0001  GETMET	R4	R3	K1
+      0x5C180200,  //  0002  MOVE	R6	R1
+      0x7C100400,  //  0003  CALL	R4	2
+      0x5C040800,  //  0004  MOVE	R1	R4
+      0x8C100701,  //  0005  GETMET	R4	R3	K1
+      0x5C180400,  //  0006  MOVE	R6	R2
+      0x7C100400,  //  0007  CALL	R4	2
+      0x5C080800,  //  0008  MOVE	R2	R4
+      0x1C100302,  //  0009  EQ	R4	R1	K2
+      0x78120006,  //  000A  JMPF	R4	#0012
+      0x8C100701,  //  000B  GETMET	R4	R3	K1
+      0x5C180400,  //  000C  MOVE	R6	R2
+      0x7C100400,  //  000D  CALL	R4	2
+      0x1C100903,  //  000E  EQ	R4	R4	K3
+      0x78120001,  //  000F  JMPF	R4	#0012
+      0x50100200,  //  0010  LDBOOL	R4	1	0
+      0x90020804,  //  0011  SETMBR	R0	K4	R4
+      0x80000000,  //  0012  RET	0
     })
   )
 );
@@ -696,9 +201,104 @@ be_local_closure(Matter_HTTP_async_event_timeout,   /* name */
 
 
 /********************************************************************
-** Solidified function: event_established
+** Solidified function: init
 ********************************************************************/
-be_local_closure(Matter_HTTP_async_event_established,   /* name */
+be_local_closure(Matter_HTTP_async_init,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(_X40),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(auth),
+    /* K5   */  be_nested_str_weak(fromstring),
+    /* K6   */  be_const_int(1),
+    /* K7   */  be_nested_str_weak(tob64),
+    /* K8   */  be_const_int(2147483647),
+    /* K9   */  be_nested_str_weak(init),
+    /* K10  */  be_nested_str_weak(compile_re),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[36]) {  /* code */
+      0xA4160000,  //  0000  IMPORT	R5	K0
+      0x60180008,  //  0001  GETGBL	R6	G8
+      0x5C1C0200,  //  0002  MOVE	R7	R1
+      0x7C180200,  //  0003  CALL	R6	1
+      0x5C040C00,  //  0004  MOVE	R1	R6
+      0x8C180B01,  //  0005  GETMET	R6	R5	K1
+      0x5C200200,  //  0006  MOVE	R8	R1
+      0x58240002,  //  0007  LDCONST	R9	K2
+      0x7C180600,  //  0008  CALL	R6	3
+      0x281C0D03,  //  0009  GE	R7	R6	K3
+      0x781E000C,  //  000A  JMPF	R7	#0018
+      0x601C0015,  //  000B  GETGBL	R7	G21
+      0x7C1C0000,  //  000C  CALL	R7	0
+      0x8C1C0F05,  //  000D  GETMET	R7	R7	K5
+      0x04240D06,  //  000E  SUB	R9	R6	K6
+      0x40260609,  //  000F  CONNECT	R9	K3	R9
+      0x94240209,  //  0010  GETIDX	R9	R1	R9
+      0x7C1C0400,  //  0011  CALL	R7	2
+      0x8C1C0F07,  //  0012  GETMET	R7	R7	K7
+      0x7C1C0200,  //  0013  CALL	R7	1
+      0x90020807,  //  0014  SETMBR	R0	K4	R7
+      0x001C0D06,  //  0015  ADD	R7	R6	K6
+      0x401C0F08,  //  0016  CONNECT	R7	R7	K8
+      0x94040207,  //  0017  GETIDX	R1	R1	R7
+      0x601C0003,  //  0018  GETGBL	R7	G3
+      0x5C200000,  //  0019  MOVE	R8	R0
+      0x7C1C0200,  //  001A  CALL	R7	1
+      0x8C1C0F09,  //  001B  GETMET	R7	R7	K9
+      0x5C240200,  //  001C  MOVE	R9	R1
+      0x5C280400,  //  001D  MOVE	R10	R2
+      0x5C2C0600,  //  001E  MOVE	R11	R3
+      0x5C300800,  //  001F  MOVE	R12	R4
+      0x7C1C0A00,  //  0020  CALL	R7	5
+      0x8C1C010A,  //  0021  GETMET	R7	R0	K10
+      0x7C1C0200,  //  0022  CALL	R7	1
+      0x80000000,  //  0023  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_http_failed
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_http_failed,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(event_http_failed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_http_response
+********************************************************************/
+be_local_closure(Matter_HTTP_async_parse_http_response,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -708,15 +308,36 @@ be_local_closure(Matter_HTTP_async_event_established,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(send_http),
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(phase),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(parse_http_status_line),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(parse_http_headers),
+    /* K5   */  be_const_int(2),
+    /* K6   */  be_nested_str_weak(parse_http_payload),
     }),
-    be_str_weak(event_established),
+    be_str_weak(parse_http_response),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
+    ( &(const binstruction[18]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x1C040301,  //  0001  EQ	R1	R1	K1
+      0x78060002,  //  0002  JMPF	R1	#0006
+      0x8C040102,  //  0003  GETMET	R1	R0	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x7002000A,  //  0005  JMP		#0011
+      0x88040100,  //  0006  GETMBR	R1	R0	K0
+      0x1C040303,  //  0007  EQ	R1	R1	K3
+      0x78060002,  //  0008  JMPF	R1	#000C
+      0x8C040104,  //  0009  GETMET	R1	R0	K4
+      0x7C040200,  //  000A  CALL	R1	1
+      0x70020004,  //  000B  JMP		#0011
+      0x88040100,  //  000C  GETMBR	R1	R0	K0
+      0x1C040305,  //  000D  EQ	R1	R1	K5
+      0x78060001,  //  000E  JMPF	R1	#0011
+      0x8C040106,  //  000F  GETMET	R1	R0	K6
+      0x7C040200,  //  0010  CALL	R1	1
+      0x80000000,  //  0011  RET	0
     })
   )
 );
@@ -755,9 +376,9 @@ be_local_closure(Matter_HTTP_async_event_refused,   /* name */
 
 
 /********************************************************************
-** Solidified function: event_closed
+** Solidified function: reset
 ********************************************************************/
-be_local_closure(Matter_HTTP_async_event_closed,   /* name */
+be_local_closure(Matter_HTTP_async_reset,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -767,22 +388,40 @@ be_local_closure(Matter_HTTP_async_event_closed,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(http_status),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(event_http_finished),
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(reset),
+    /* K1   */  be_nested_str_weak(cmd),
+    /* K2   */  be_nested_str_weak(response),
+    /* K3   */  be_nested_str_weak(response_offset),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(payload),
+    /* K6   */  be_nested_str_weak(),
+    /* K7   */  be_nested_str_weak(phase),
+    /* K8   */  be_nested_str_weak(http_status),
+    /* K9   */  be_nested_str_weak(is_chunked),
+    /* K10  */  be_nested_str_weak(chunk_size),
     }),
-    be_str_weak(event_closed),
+    be_str_weak(reset),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x1C040301,  //  0001  EQ	R1	R1	K1
-      0x78060002,  //  0002  JMPF	R1	#0006
-      0x90020102,  //  0003  SETMBR	R0	K0	K2
-      0x8C040103,  //  0004  GETMET	R1	R0	K3
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
+    ( &(const binstruction[18]) {  /* code */
+      0x60040003,  //  0000  GETGBL	R1	G3
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0x7C040200,  //  0002  CALL	R1	1
+      0x8C040300,  //  0003  GETMET	R1	R1	K0
+      0x7C040200,  //  0004  CALL	R1	1
+      0x4C040000,  //  0005  LDNIL	R1
+      0x90020201,  //  0006  SETMBR	R0	K1	R1
+      0x4C040000,  //  0007  LDNIL	R1
+      0x90020401,  //  0008  SETMBR	R0	K2	R1
+      0x90020704,  //  0009  SETMBR	R0	K3	K4
+      0x90020B06,  //  000A  SETMBR	R0	K5	K6
+      0x90020F04,  //  000B  SETMBR	R0	K7	K4
+      0x90021104,  //  000C  SETMBR	R0	K8	K4
+      0x50040000,  //  000D  LDBOOL	R1	0	0
+      0x90021201,  //  000E  SETMBR	R0	K9	R1
+      0x4C040000,  //  000F  LDNIL	R1
+      0x90021401,  //  0010  SETMBR	R0	K10	R1
+      0x80000000,  //  0011  RET	0
     })
   )
 );
@@ -790,11 +429,44 @@ be_local_closure(Matter_HTTP_async_event_closed,   /* name */
 
 
 /********************************************************************
-** Solidified function: parse_http_status_line
+** Solidified function: begin
 ********************************************************************/
-be_local_closure(Matter_HTTP_async_parse_http_status_line,   /* name */
+be_local_closure(Matter_HTTP_async_begin,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(begin),
+    /* K1   */  be_nested_str_weak(cmd),
+    }),
+    be_str_weak(begin),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x60080003,  //  0000  GETGBL	R2	G3
+      0x5C0C0000,  //  0001  MOVE	R3	R0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080500,  //  0003  GETMET	R2	R2	K0
+      0x7C080200,  //  0004  CALL	R2	1
+      0x90020201,  //  0005  SETMBR	R0	K1	R1
+      0x80040400,  //  0006  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_established
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_established,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -802,51 +474,15 @@ be_local_closure(Matter_HTTP_async_parse_http_status_line,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(global),
-    /* K1   */  be_nested_str_weak(_re_http_status),
-    /* K2   */  be_nested_str_weak(match2),
-    /* K3   */  be_nested_str_weak(response),
-    /* K4   */  be_nested_str_weak(response_offset),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(status_code),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(phase),
-    /* K9   */  be_nested_str_weak(parse_http_headers),
-    /* K10  */  be_nested_str_weak(close),
-    /* K11  */  be_nested_str_weak(status),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(send_http),
     }),
-    be_str_weak(parse_http_status_line),
+    be_str_weak(event_established),
     &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x8C040302,  //  0002  GETMET	R1	R1	K2
-      0x880C0103,  //  0003  GETMBR	R3	R0	K3
-      0x88100104,  //  0004  GETMBR	R4	R0	K4
-      0x7C040600,  //  0005  CALL	R1	3
-      0x78060009,  //  0006  JMPF	R1	#0011
-      0x94080305,  //  0007  GETIDX	R2	R1	K5
-      0x90020802,  //  0008  SETMBR	R0	K4	R2
-      0x60080009,  //  0009  GETGBL	R2	G9
-      0x940C0307,  //  000A  GETIDX	R3	R1	K7
-      0x7C080200,  //  000B  CALL	R2	1
-      0x90020C02,  //  000C  SETMBR	R0	K6	R2
-      0x90021107,  //  000D  SETMBR	R0	K8	K7
-      0x8C080109,  //  000E  GETMET	R2	R0	K9
-      0x7C080200,  //  000F  CALL	R2	1
-      0x70020009,  //  0010  JMP		#001B
-      0x6008000C,  //  0011  GETGBL	R2	G12
-      0x880C0103,  //  0012  GETMBR	R3	R0	K3
-      0x7C080200,  //  0013  CALL	R2	1
-      0x540E0063,  //  0014  LDINT	R3	100
-      0x24080403,  //  0015  GT	R2	R2	R3
-      0x780A0003,  //  0016  JMPF	R2	#001B
-      0x8C08010A,  //  0017  GETMET	R2	R0	K10
-      0x7C080200,  //  0018  CALL	R2	1
-      0x5409FFFB,  //  0019  LDINT	R2	-4
-      0x90021602,  //  001A  SETMBR	R0	K11	R2
-      0x80000000,  //  001B  RET	0
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
     })
   )
 );
@@ -942,23 +578,316 @@ be_local_closure(Matter_HTTP_async_parse_http_headers,   /* name */
 
 
 /********************************************************************
-** Solidified function: event_http_timeout
+** Solidified function: event_available
 ********************************************************************/
-be_local_closure(Matter_HTTP_async_event_http_timeout,   /* name */
+be_local_closure(Matter_HTTP_async_event_available,   /* name */
   be_nested_proto(
-    1,                          /* nstack */
+    3,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(event_http_timeout),
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(receive),
+    }),
+    be_str_weak(event_available),
     &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_timeout
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_timeout,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(http_status),
+    /* K1   */  be_nested_str_weak(event_http_timeout),
+    }),
+    be_str_weak(event_timeout),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x5405FFFD,  //  0000  LDINT	R1	-2
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x7C040200,  //  0003  CALL	R1	1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: compile_re
+********************************************************************/
+be_local_closure(Matter_HTTP_async_compile_re,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(re),
+    /* K1   */  be_nested_str_weak(global),
+    /* K2   */  be_nested_str_weak(contains),
+    /* K3   */  be_nested_str_weak(_re_http_status),
+    /* K4   */  be_nested_str_weak(compile),
+    /* K5   */  be_nested_str_weak(HTTP_STATUS_REGEX),
+    /* K6   */  be_nested_str_weak(_re_http_header),
+    /* K7   */  be_nested_str_weak(HTTP_HEADER_REGEX),
+    /* K8   */  be_nested_str_weak(_re_http_body),
+    /* K9   */  be_nested_str_weak(HTTP_BODY_REGEX),
+    /* K10  */  be_nested_str_weak(_re_http_chunk),
+    /* K11  */  be_nested_str_weak(HTTP_CHUNK_REGEX),
+    }),
+    be_str_weak(compile_re),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x58100003,  //  0003  LDCONST	R4	K3
+      0x7C080400,  //  0004  CALL	R2	2
+      0x740A0013,  //  0005  JMPT	R2	#001A
+      0xB80A0200,  //  0006  GETNGBL	R2	K1
+      0x8C0C0304,  //  0007  GETMET	R3	R1	K4
+      0x88140105,  //  0008  GETMBR	R5	R0	K5
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x900A0603,  //  000A  SETMBR	R2	K3	R3
+      0xB80A0200,  //  000B  GETNGBL	R2	K1
+      0x8C0C0304,  //  000C  GETMET	R3	R1	K4
+      0x88140107,  //  000D  GETMBR	R5	R0	K7
+      0x7C0C0400,  //  000E  CALL	R3	2
+      0x900A0C03,  //  000F  SETMBR	R2	K6	R3
+      0xB80A0200,  //  0010  GETNGBL	R2	K1
+      0x8C0C0304,  //  0011  GETMET	R3	R1	K4
+      0x88140109,  //  0012  GETMBR	R5	R0	K9
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x900A1003,  //  0014  SETMBR	R2	K8	R3
+      0xB80A0200,  //  0015  GETNGBL	R2	K1
+      0x8C0C0304,  //  0016  GETMET	R3	R1	K4
+      0x8814010B,  //  0017  GETMBR	R5	R0	K11
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x900A1403,  //  0019  SETMBR	R2	K10	R3
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_closed
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_closed,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(http_status),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_const_int(1),
+    /* K3   */  be_nested_str_weak(event_http_finished),
+    }),
+    be_str_weak(event_closed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x1C040301,  //  0001  EQ	R1	R1	K1
+      0x78060002,  //  0002  JMPF	R1	#0006
+      0x90020102,  //  0003  SETMBR	R0	K0	K2
+      0x8C040103,  //  0004  GETMET	R1	R0	K3
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: begin_sync
+********************************************************************/
+be_local_closure(Matter_HTTP_async_begin_sync,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(timeout),
+    /* K1   */  be_nested_str_weak(set_timeout),
+    /* K2   */  be_nested_str_weak(SPINLOCK),
+    /* K3   */  be_nested_str_weak(begin),
+    /* K4   */  be_nested_str_weak(http_status),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(loop),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(delay),
+    /* K9   */  be_nested_str_weak(payload),
+    }),
+    be_str_weak(begin_sync),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x4C100000,  //  0001  LDNIL	R4
+      0x20100404,  //  0002  NE	R4	R2	R4
+      0x78120002,  //  0003  JMPF	R4	#0007
+      0x8C100101,  //  0004  GETMET	R4	R0	K1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C100400,  //  0006  CALL	R4	2
+      0x4C100000,  //  0007  LDNIL	R4
+      0x88140102,  //  0008  GETMBR	R5	R0	K2
+      0x8C180103,  //  0009  GETMET	R6	R0	K3
+      0x5C200200,  //  000A  MOVE	R8	R1
+      0x7C180400,  //  000B  CALL	R6	2
+      0x781A0009,  //  000C  JMPF	R6	#0017
+      0x881C0104,  //  000D  GETMBR	R7	R0	K4
+      0x1C1C0F05,  //  000E  EQ	R7	R7	K5
+      0x781E0006,  //  000F  JMPF	R7	#0017
+      0x8C1C0106,  //  0010  GETMET	R7	R0	K6
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0xB81E0E00,  //  0012  GETNGBL	R7	K7
+      0x8C1C0F08,  //  0013  GETMET	R7	R7	K8
+      0x5C240A00,  //  0014  MOVE	R9	R5
+      0x7C1C0400,  //  0015  CALL	R7	2
+      0x7001FFF5,  //  0016  JMP		#000D
+      0x8C1C0101,  //  0017  GETMET	R7	R0	K1
+      0x5C240600,  //  0018  MOVE	R9	R3
+      0x7C1C0400,  //  0019  CALL	R7	2
+      0x881C0104,  //  001A  GETMBR	R7	R0	K4
+      0x241C0F05,  //  001B  GT	R7	R7	K5
+      0x781E0001,  //  001C  JMPF	R7	#001F
+      0x881C0109,  //  001D  GETMBR	R7	R0	K9
+      0x70020000,  //  001E  JMP		#0020
+      0x4C1C0000,  //  001F  LDNIL	R7
+      0x80040E00,  //  0020  RET	1	R7
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_http
+********************************************************************/
+be_local_closure(Matter_HTTP_async_send_http,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[19]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(response),
+    /* K2   */  be_nested_str_weak(),
+    /* K3   */  be_nested_str_weak(addr),
+    /* K4   */  be_nested_str_weak(find),
+    /* K5   */  be_nested_str_weak(_X3A),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(_X5B),
+    /* K8   */  be_nested_str_weak(_X5D),
+    /* K9   */  be_nested_str_weak(auth),
+    /* K10  */  be_nested_str_weak(HTTP_GET),
+    /* K11  */  be_nested_str_weak(cmd),
+    /* K12  */  be_nested_str_weak(port),
+    /* K13  */  be_nested_str_weak(HTTP_GET_AUTH),
+    /* K14  */  be_nested_str_weak(write),
+    /* K15  */  be_nested_str_weak(close),
+    /* K16  */  be_nested_str_weak(status),
+    /* K17  */  be_nested_str_weak(http_status),
+    /* K18  */  be_nested_str_weak(event_http_failed),
+    }),
+    be_str_weak(send_http),
+    &be_const_str_solidified,
+    ( &(const binstruction[50]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x90020302,  //  0001  SETMBR	R0	K1	K2
+      0x88080103,  //  0002  GETMBR	R2	R0	K3
+      0x8C0C0304,  //  0003  GETMET	R3	R1	K4
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x58180005,  //  0005  LDCONST	R6	K5
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x280C0706,  //  0007  GE	R3	R3	K6
+      0x780E0002,  //  0008  JMPF	R3	#000C
+      0x000E0E02,  //  0009  ADD	R3	K7	R2
+      0x000C0708,  //  000A  ADD	R3	R3	K8
+      0x5C080600,  //  000B  MOVE	R2	R3
+      0x4C0C0000,  //  000C  LDNIL	R3
+      0x88100109,  //  000D  GETMBR	R4	R0	K9
+      0x4C140000,  //  000E  LDNIL	R5
+      0x1C100805,  //  000F  EQ	R4	R4	R5
+      0x78120007,  //  0010  JMPF	R4	#0019
+      0x60100018,  //  0011  GETGBL	R4	G24
+      0x8814010A,  //  0012  GETMBR	R5	R0	K10
+      0x8818010B,  //  0013  GETMBR	R6	R0	K11
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x8820010C,  //  0015  GETMBR	R8	R0	K12
+      0x7C100800,  //  0016  CALL	R4	4
+      0x5C0C0800,  //  0017  MOVE	R3	R4
+      0x70020007,  //  0018  JMP		#0021
+      0x60100018,  //  0019  GETGBL	R4	G24
+      0x8814010D,  //  001A  GETMBR	R5	R0	K13
+      0x8818010B,  //  001B  GETMBR	R6	R0	K11
+      0x5C1C0400,  //  001C  MOVE	R7	R2
+      0x8820010C,  //  001D  GETMBR	R8	R0	K12
+      0x88240109,  //  001E  GETMBR	R9	R0	K9
+      0x7C100A00,  //  001F  CALL	R4	5
+      0x5C0C0800,  //  0020  MOVE	R3	R4
+      0x8C10010E,  //  0021  GETMET	R4	R0	K14
+      0x5C180600,  //  0022  MOVE	R6	R3
+      0x7C100400,  //  0023  CALL	R4	2
+      0x6014000C,  //  0024  GETGBL	R5	G12
+      0x5C180600,  //  0025  MOVE	R6	R3
+      0x7C140200,  //  0026  CALL	R5	1
+      0x20140805,  //  0027  NE	R5	R4	R5
+      0x78160007,  //  0028  JMPF	R5	#0031
+      0x8C14010F,  //  0029  GETMET	R5	R0	K15
+      0x7C140200,  //  002A  CALL	R5	1
+      0x5415FFFB,  //  002B  LDINT	R5	-4
+      0x90022005,  //  002C  SETMBR	R0	K16	R5
+      0x5415FFFE,  //  002D  LDINT	R5	-1
+      0x90022205,  //  002E  SETMBR	R0	K17	R5
+      0x8C140112,  //  002F  GETMET	R5	R0	K18
+      0x7C140200,  //  0030  CALL	R5	1
+      0x80000000,  //  0031  RET	0
     })
   )
 );
@@ -1004,11 +933,11 @@ be_local_closure(Matter_HTTP_async_event_http_headers_end,   /* name */
 
 
 /********************************************************************
-** Solidified function: event_http_header
+** Solidified function: event_http_status_code
 ********************************************************************/
-be_local_closure(Matter_HTTP_async_event_http_header,   /* name */
+be_local_closure(Matter_HTTP_async_event_http_status_code,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    3,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1016,35 +945,14 @@ be_local_closure(Matter_HTTP_async_event_http_header,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tolower),
-    /* K2   */  be_nested_str_weak(transfer_X2Dencoding),
-    /* K3   */  be_nested_str_weak(chunked),
-    /* K4   */  be_nested_str_weak(is_chunked),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(status_code),
     }),
-    be_str_weak(event_http_header),
+    be_str_weak(event_http_status_code),
     &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x8C100701,  //  0001  GETMET	R4	R3	K1
-      0x5C180200,  //  0002  MOVE	R6	R1
-      0x7C100400,  //  0003  CALL	R4	2
-      0x5C040800,  //  0004  MOVE	R1	R4
-      0x8C100701,  //  0005  GETMET	R4	R3	K1
-      0x5C180400,  //  0006  MOVE	R6	R2
-      0x7C100400,  //  0007  CALL	R4	2
-      0x5C080800,  //  0008  MOVE	R2	R4
-      0x1C100302,  //  0009  EQ	R4	R1	K2
-      0x78120006,  //  000A  JMPF	R4	#0012
-      0x8C100701,  //  000B  GETMET	R4	R3	K1
-      0x5C180400,  //  000C  MOVE	R6	R2
-      0x7C100400,  //  000D  CALL	R4	2
-      0x1C100903,  //  000E  EQ	R4	R4	K3
-      0x78120001,  //  000F  JMPF	R4	#0012
-      0x50100200,  //  0010  LDBOOL	R4	1	0
-      0x90020804,  //  0011  SETMBR	R0	K4	R4
-      0x80000000,  //  0012  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
     })
   )
 );
@@ -1052,32 +960,174 @@ be_local_closure(Matter_HTTP_async_event_http_header,   /* name */
 
 
 /********************************************************************
-** Solidified function: begin
+** Solidified function: parse_http_status_line
 ********************************************************************/
-be_local_closure(Matter_HTTP_async_begin,   /* name */
+be_local_closure(Matter_HTTP_async_parse_http_status_line,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
+    5,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(begin),
-    /* K1   */  be_nested_str_weak(cmd),
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(global),
+    /* K1   */  be_nested_str_weak(_re_http_status),
+    /* K2   */  be_nested_str_weak(match2),
+    /* K3   */  be_nested_str_weak(response),
+    /* K4   */  be_nested_str_weak(response_offset),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(status_code),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(phase),
+    /* K9   */  be_nested_str_weak(parse_http_headers),
+    /* K10  */  be_nested_str_weak(close),
+    /* K11  */  be_nested_str_weak(status),
     }),
-    be_str_weak(begin),
+    be_str_weak(parse_http_status_line),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
-      0x7C080200,  //  0004  CALL	R2	1
-      0x90020201,  //  0005  SETMBR	R0	K1	R1
-      0x80040400,  //  0006  RET	1	R2
+    ( &(const binstruction[28]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x8C040302,  //  0002  GETMET	R1	R1	K2
+      0x880C0103,  //  0003  GETMBR	R3	R0	K3
+      0x88100104,  //  0004  GETMBR	R4	R0	K4
+      0x7C040600,  //  0005  CALL	R1	3
+      0x78060009,  //  0006  JMPF	R1	#0011
+      0x94080305,  //  0007  GETIDX	R2	R1	K5
+      0x90020802,  //  0008  SETMBR	R0	K4	R2
+      0x60080009,  //  0009  GETGBL	R2	G9
+      0x940C0307,  //  000A  GETIDX	R3	R1	K7
+      0x7C080200,  //  000B  CALL	R2	1
+      0x90020C02,  //  000C  SETMBR	R0	K6	R2
+      0x90021107,  //  000D  SETMBR	R0	K8	K7
+      0x8C080109,  //  000E  GETMET	R2	R0	K9
+      0x7C080200,  //  000F  CALL	R2	1
+      0x70020009,  //  0010  JMP		#001B
+      0x6008000C,  //  0011  GETGBL	R2	G12
+      0x880C0103,  //  0012  GETMBR	R3	R0	K3
+      0x7C080200,  //  0013  CALL	R2	1
+      0x540E0063,  //  0014  LDINT	R3	100
+      0x24080403,  //  0015  GT	R2	R2	R3
+      0x780A0003,  //  0016  JMPF	R2	#001B
+      0x8C08010A,  //  0017  GETMET	R2	R0	K10
+      0x7C080200,  //  0018  CALL	R2	1
+      0x5409FFFB,  //  0019  LDINT	R2	-4
+      0x90021602,  //  001A  SETMBR	R0	K11	R2
+      0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_http_timeout
+********************************************************************/
+be_local_closure(Matter_HTTP_async_event_http_timeout,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(event_http_timeout),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: receive
+********************************************************************/
+be_local_closure(Matter_HTTP_async_receive,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tcp_connected),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(millis),
+    /* K3   */  be_nested_str_weak(time_start),
+    /* K4   */  be_nested_str_weak(timeout),
+    /* K5   */  be_nested_str_weak(status),
+    /* K6   */  be_nested_str_weak(close),
+    /* K7   */  be_nested_str_weak(http_status),
+    /* K8   */  be_nested_str_weak(event_http_timeout),
+    /* K9   */  be_nested_str_weak(tcp),
+    /* K10  */  be_nested_str_weak(available),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_weak(read),
+    /* K13  */  be_nested_str_weak(response),
+    /* K14  */  be_nested_str_weak(parse_http_response),
+    }),
+    be_str_weak(receive),
+    &be_const_str_solidified,
+    ( &(const binstruction[48]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x50080200,  //  0001  LDBOOL	R2	1	0
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060000,  //  0003  JMPF	R1	#0005
+      0x80000200,  //  0004  RET	0
+      0xB8060200,  //  0005  GETNGBL	R1	K1
+      0x8C040302,  //  0006  GETMET	R1	R1	K2
+      0x7C040200,  //  0007  CALL	R1	1
+      0x88080103,  //  0008  GETMBR	R2	R0	K3
+      0x04040202,  //  0009  SUB	R1	R1	R2
+      0x88080104,  //  000A  GETMBR	R2	R0	K4
+      0x24040202,  //  000B  GT	R1	R1	R2
+      0x78060008,  //  000C  JMPF	R1	#0016
+      0x5405FFFC,  //  000D  LDINT	R1	-3
+      0x90020A01,  //  000E  SETMBR	R0	K5	R1
+      0x8C040106,  //  000F  GETMET	R1	R0	K6
+      0x7C040200,  //  0010  CALL	R1	1
+      0x5405FFFD,  //  0011  LDINT	R1	-2
+      0x90020E01,  //  0012  SETMBR	R0	K7	R1
+      0x8C040108,  //  0013  GETMET	R1	R0	K8
+      0x7C040200,  //  0014  CALL	R1	1
+      0x70020018,  //  0015  JMP		#002F
+      0x88040109,  //  0016  GETMBR	R1	R0	K9
+      0x8C04030A,  //  0017  GETMET	R1	R1	K10
+      0x7C040200,  //  0018  CALL	R1	1
+      0x5808000B,  //  0019  LDCONST	R2	K11
+      0x240C030B,  //  001A  GT	R3	R1	K11
+      0x780E000E,  //  001B  JMPF	R3	#002B
+      0x880C0109,  //  001C  GETMBR	R3	R0	K9
+      0x8C0C070C,  //  001D  GETMET	R3	R3	K12
+      0x7C0C0200,  //  001E  CALL	R3	1
+      0x8810010D,  //  001F  GETMBR	R4	R0	K13
+      0x00100803,  //  0020  ADD	R4	R4	R3
+      0x90021A04,  //  0021  SETMBR	R0	K13	R4
+      0x6010000C,  //  0022  GETGBL	R4	G12
+      0x5C140600,  //  0023  MOVE	R5	R3
+      0x7C100200,  //  0024  CALL	R4	1
+      0x00080404,  //  0025  ADD	R2	R2	R4
+      0x88100109,  //  0026  GETMBR	R4	R0	K9
+      0x8C10090A,  //  0027  GETMET	R4	R4	K10
+      0x7C100200,  //  0028  CALL	R4	1
+      0x5C040800,  //  0029  MOVE	R1	R4
+      0x7001FFEE,  //  002A  JMP		#001A
+      0x240C050B,  //  002B  GT	R3	R2	K11
+      0x780E0001,  //  002C  JMPF	R3	#002F
+      0x8C0C010E,  //  002D  GETMET	R3	R0	K14
+      0x7C0C0200,  //  002E  CALL	R3	1
+      0x80000000,  //  002F  RET	0
     })
   )
 );
@@ -1089,47 +1139,49 @@ be_local_closure(Matter_HTTP_async_begin,   /* name */
 ********************************************************************/
 extern const bclass be_class_Matter_TCP_async;
 be_local_class(Matter_HTTP_async,
-    9,
+    10,
     &be_class_Matter_TCP_async,
-    be_nested_map(37,
+    be_nested_map(39,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(init, 2), be_const_closure(Matter_HTTP_async_init_closure) },
-        { be_const_key_weak(response, 28), be_const_var(1) },
-        { be_const_key_weak(http_status, -1), be_const_var(5) },
-        { be_const_key_weak(HTTP_STATUS_REGEX, 14), be_nested_str_weak(HTTP_X2F1_X5C_X2E_X5B0_X2D1_X5D_X20_X28_X5Cd_X2B_X29_X20_X2E_X2A_X3F_X0D_X0A) },
-        { be_const_key_weak(HTTP_GET, 8), be_nested_str_weak(GET_X20_X25s_X20HTTP_X2F1_X2E1_X0D_X0AHost_X20_X25s_X3A_X25s_X0D_X0AConnection_X3A_X20close_X0D_X0A_X0D_X0A) },
-        { be_const_key_weak(response_offset, -1), be_const_var(2) },
-        { be_const_key_weak(compile_re, -1), be_const_closure(Matter_HTTP_async_compile_re_closure) },
-        { be_const_key_weak(event_http_header, -1), be_const_closure(Matter_HTTP_async_event_http_header_closure) },
-        { be_const_key_weak(event_http_status_code, -1), be_const_closure(Matter_HTTP_async_event_http_status_code_closure) },
-        { be_const_key_weak(payload, -1), be_const_var(4) },
-        { be_const_key_weak(event_available, -1), be_const_closure(Matter_HTTP_async_event_available_closure) },
-        { be_const_key_weak(chunk_size, 16), be_const_var(8) },
-        { be_const_key_weak(event_http_timeout, -1), be_const_closure(Matter_HTTP_async_event_http_timeout_closure) },
+        { be_const_key_weak(response, -1), be_const_var(2) },
         { be_const_key_weak(parse_http_payload, -1), be_const_closure(Matter_HTTP_async_parse_http_payload_closure) },
-        { be_const_key_weak(parse_http_status_line, 29), be_const_closure(Matter_HTTP_async_parse_http_status_line_closure) },
-        { be_const_key_weak(begin_sync, -1), be_const_closure(Matter_HTTP_async_begin_sync_closure) },
-        { be_const_key_weak(cmd, -1), be_const_var(0) },
-        { be_const_key_weak(event_http_failed, 13), be_const_closure(Matter_HTTP_async_event_http_failed_closure) },
-        { be_const_key_weak(SPINLOCK, -1), be_const_int(5) },
-        { be_const_key_weak(reset, 31), be_const_closure(Matter_HTTP_async_reset_closure) },
-        { be_const_key_weak(send_http, -1), be_const_closure(Matter_HTTP_async_send_http_closure) },
-        { be_const_key_weak(parse_http_response, 15), be_const_closure(Matter_HTTP_async_parse_http_response_closure) },
-        { be_const_key_weak(event_http_finished, -1), be_const_closure(Matter_HTTP_async_event_http_finished_closure) },
+        { be_const_key_weak(receive, 10), be_const_closure(Matter_HTTP_async_receive_closure) },
+        { be_const_key_weak(event_http_finished, 22), be_const_closure(Matter_HTTP_async_event_http_finished_closure) },
         { be_const_key_weak(HTTP_BODY_REGEX, -1), be_nested_str_weak(_X0D_X0A) },
+        { be_const_key_weak(HTTP_GET_AUTH, -1), be_nested_str_weak(GET_X20_X25s_X20HTTP_X2F1_X2E1_X0D_X0AHost_X20_X25s_X3A_X25s_X0D_X0AAuthorization_X3A_X20Basic_X20_X25s_X0D_X0AConnection_X3A_X20close_X0D_X0A_X0D_X0A) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_HTTP_async_init_closure) },
+        { be_const_key_weak(response_offset, 23), be_const_var(3) },
+        { be_const_key_weak(parse_http_response, -1), be_const_closure(Matter_HTTP_async_parse_http_response_closure) },
         { be_const_key_weak(event_refused, -1), be_const_closure(Matter_HTTP_async_event_refused_closure) },
-        { be_const_key_weak(HTTP_HEADER_REGEX, -1), be_nested_str_weak(_X28_X5BA_X2DZa_X2Dz0_X2D9_X2D_X5D_X2B_X29_X3A_X20_X28_X2E_X2A_X3F_X29_X0D_X0A) },
-        { be_const_key_weak(is_chunked, 25), be_const_var(7) },
-        { be_const_key_weak(event_established, 24), be_const_closure(Matter_HTTP_async_event_established_closure) },
-        { be_const_key_weak(HTTP_CHUNK_REGEX, -1), be_nested_str_weak(_X0D_X0A_X28_X5BA_X2DFa_X2Df0_X2D9_X5D_X2B_X29_X5B_X20_X09_X5D_X2A_X2E_X2A_X3F_X0D_X0A) },
-        { be_const_key_weak(receive, -1), be_const_closure(Matter_HTTP_async_receive_closure) },
-        { be_const_key_weak(event_closed, -1), be_const_closure(Matter_HTTP_async_event_closed_closure) },
-        { be_const_key_weak(phase, -1), be_const_var(6) },
-        { be_const_key_weak(parse_http_headers, -1), be_const_closure(Matter_HTTP_async_parse_http_headers_closure) },
-        { be_const_key_weak(event_timeout, 12), be_const_closure(Matter_HTTP_async_event_timeout_closure) },
+        { be_const_key_weak(event_http_timeout, -1), be_const_closure(Matter_HTTP_async_event_http_timeout_closure) },
+        { be_const_key_weak(HTTP_STATUS_REGEX, -1), be_nested_str_weak(HTTP_X2F1_X5C_X2E_X5B0_X2D1_X5D_X20_X28_X5Cd_X2B_X29_X20_X2E_X2A_X3F_X0D_X0A) },
+        { be_const_key_weak(cmd, -1), be_const_var(1) },
+        { be_const_key_weak(event_http_status_code, -1), be_const_closure(Matter_HTTP_async_event_http_status_code_closure) },
+        { be_const_key_weak(payload, -1), be_const_var(5) },
+        { be_const_key_weak(is_chunked, -1), be_const_var(8) },
+        { be_const_key_weak(HTTP_GET, -1), be_nested_str_weak(GET_X20_X25s_X20HTTP_X2F1_X2E1_X0D_X0AHost_X20_X25s_X3A_X25s_X0D_X0AConnection_X3A_X20close_X0D_X0A_X0D_X0A) },
+        { be_const_key_weak(chunk_size, 16), be_const_var(9) },
+        { be_const_key_weak(auth, 35), be_const_var(0) },
+        { be_const_key_weak(parse_http_headers, 26), be_const_closure(Matter_HTTP_async_parse_http_headers_closure) },
+        { be_const_key_weak(event_available, -1), be_const_closure(Matter_HTTP_async_event_available_closure) },
+        { be_const_key_weak(status_code, 11), be_const_var(4) },
+        { be_const_key_weak(phase, 36), be_const_var(7) },
         { be_const_key_weak(event_http_headers_end, -1), be_const_closure(Matter_HTTP_async_event_http_headers_end_closure) },
-        { be_const_key_weak(status_code, 7), be_const_var(3) },
-        { be_const_key_weak(begin, -1), be_const_closure(Matter_HTTP_async_begin_closure) },
+        { be_const_key_weak(reset, 31), be_const_closure(Matter_HTTP_async_reset_closure) },
+        { be_const_key_weak(begin_sync, -1), be_const_closure(Matter_HTTP_async_begin_sync_closure) },
+        { be_const_key_weak(send_http, -1), be_const_closure(Matter_HTTP_async_send_http_closure) },
+        { be_const_key_weak(event_timeout, 28), be_const_closure(Matter_HTTP_async_event_timeout_closure) },
+        { be_const_key_weak(HTTP_CHUNK_REGEX, -1), be_nested_str_weak(_X0D_X0A_X28_X5BA_X2DFa_X2Df0_X2D9_X5D_X2B_X29_X5B_X20_X09_X5D_X2A_X2E_X2A_X3F_X0D_X0A) },
+        { be_const_key_weak(compile_re, 7), be_const_closure(Matter_HTTP_async_compile_re_closure) },
+        { be_const_key_weak(HTTP_HEADER_REGEX, -1), be_nested_str_weak(_X28_X5BA_X2DZa_X2Dz0_X2D9_X2D_X5D_X2B_X29_X3A_X20_X28_X2E_X2A_X3F_X29_X0D_X0A) },
+        { be_const_key_weak(event_closed, 30), be_const_closure(Matter_HTTP_async_event_closed_closure) },
+        { be_const_key_weak(event_http_header, 14), be_const_closure(Matter_HTTP_async_event_http_header_closure) },
+        { be_const_key_weak(event_http_failed, 13), be_const_closure(Matter_HTTP_async_event_http_failed_closure) },
+        { be_const_key_weak(parse_http_status_line, -1), be_const_closure(Matter_HTTP_async_parse_http_status_line_closure) },
+        { be_const_key_weak(event_established, -1), be_const_closure(Matter_HTTP_async_event_established_closure) },
+        { be_const_key_weak(begin, 4), be_const_closure(Matter_HTTP_async_begin_closure) },
+        { be_const_key_weak(http_status, -1), be_const_var(6) },
+        { be_const_key_weak(SPINLOCK, 2), be_const_int(5) },
     })),
     be_str_weak(Matter_HTTP_async)
 );


### PR DESCRIPTION
## Description:

Matter support for remote (bridge mode) Tasmota devices with web password.

If the remote device has a password like `banana`, specify the address as `admin:banana@192.168.2.78`

![image](https://github.com/arendst/Tasmota/assets/49731213/6d21bdaf-463a-4c68-9951-a0b98e994773)


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
