### PR TITLE
Update Platformio Platform to 2023.12.00

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -93,7 +93,7 @@ lib_ignore                  =
 
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.11.01/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2023.12.00/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

- Fix LittleFS download from device via VSC/Platformio
- Small fixes and updates in Platform 
- No changes in framework -> No changes in Tasmota code

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
