### PR TITLE
HDMI CEC: Fix set HDMIType command

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_70_1_hdmi_cec.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_70_1_hdmi_cec.ino
@@ -189,7 +189,7 @@ void CmndHDMISend(void) {
 //
 void CmndHDMIType(void) {
   if (XdrvMailbox.data_len > 0) {
-    if ((XdrvMailbox.payload < 1) && (XdrvMailbox.payload >= CEC_Device::CDT_LAST)) {
+    if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload < CEC_Device::CDT_LAST)) {
       uint8_t type = XdrvMailbox.payload;
       if (type != Settings->hdmi_cec_device_type) {
         Settings->hdmi_cec_device_type = XdrvMailbox.payload;


### PR DESCRIPTION
## Description:

According to documentation HDMIType is from 0 to 5 but the actual check is lower than 1 and above or equal 6, so the function is never applied. Also note that setting the HDMIType to 0 use the default type value 4, that make impossible the emulation of a TV device.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
