### PR TITLE
HDMI CEC: Allow TV device type emulation.

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_70_1_hdmi_cec.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_70_1_hdmi_cec.ino
@@ -65,7 +65,7 @@ void HdmiCecInit(void)
 {
   // CEC device type
   CEC_Device::CEC_DEVICE_TYPE device_type = (CEC_Device::CEC_DEVICE_TYPE) Settings->hdmi_cec_device_type;
-  if (device_type == CEC_Device::CDT_TV || device_type >= CEC_Device::CDT_LAST) {
+  if (device_type < 0 || device_type >= CEC_Device::CDT_LAST) {
     // if type in Settings is invalid, default to PLAYBACK_DEVICE
     device_type = CEC_Device::CDT_PLAYBACK_DEVICE;
     Settings->hdmi_cec_device_type = (uint8_t) device_type;


### PR DESCRIPTION
## Description:

The previous check set device type to default when HDMIType was set to CEC_Device::CDT_TV.
In check routine i removed the usage of CEC_Device::CDT_TV as it is not revelant, minimal value is barely 0.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
