### PR TITLE
Berry Improve error message when constructor returns NULL

### DIFF
--- a/lib/libesp32/berry_mapping/src/be_class_wrapper.c
+++ b/lib/libesp32/berry_mapping/src/be_class_wrapper.c
@@ -399,7 +399,7 @@ int be_check_arg_type(bvm *vm, int arg_start, int argc, const char * arg_type, i
 //         `+` forbids any NULL value (raises an exception) while `=` allows a NULL value
 static void be_set_ctor_ptr(bvm *vm, void * ptr, const char *name) {
   if (name == NULL) return;    // do nothing if no name of attribute
-  if (name[0] == '+' && ptr == NULL)  { be_raise(vm, "value_error", "argument cannot be NULL"); }
+  if (name[0] == '+' && ptr == NULL)  { be_raise(vm, "value_error", "native constructor cannot return NULL"); }
   if (name[0] == '+' || name[0] == '=') { name++; }   // skip prefix '^' if any
   if (strlen(name) == 0) return;  // do nothing if name is empty
 


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
