### PR TITLE
Update xdsp_15_tm1637.ino

### DIFF
--- a/tasmota/tasmota_xdsp_display/xdsp_15_tm1637.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_15_tm1637.ino
@@ -1131,7 +1131,7 @@ void TM1637Dim(void)
   {
     for (uint8_t dev_addr = 0; dev_addr < Settings->display_width / 8; dev_addr++)
     {
-      max7219display->setIntensity(MAX7219_ADDR, brightness); // 0 - 7
+      max7219display->setIntensity(MAX7219_ADDR  + dev_addr, brightness); // 0 - 7
     }
   }
 }


### PR DESCRIPTION
Displaydimmer command has not worked correctly on 2 daisy-Chained MAX7219 7-Segment Display Modules. 
Only the first Module (8 Segments) changed their brightness. Other commands work on both Modules except the Brightness Settings.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
