### PR TITLE
Berry fix static allocation when superclass is a member

### DIFF
--- a/lib/libesp32/berry/src/be_parser.c
+++ b/lib/libesp32/berry/src/be_parser.c
@@ -1571,15 +1571,11 @@ static void class_stmt(bparser *parser)
         begin_block(parser->finfo, &binfo, 0);
 
         bstring *class_str = parser_newstr(parser, "_class");   /* we always define `_class` local variable */
-        if (e.type == ETLOCAL) {
-            bexpdesc e1;                        /* if inline class, we add a second local variable for _class */
-            init_exp(&e1, ETLOCAL, 0);
-            e1.v.idx = new_localvar(parser, class_str);
-            be_code_setvar(parser->finfo, &e1, &e, 1);
-        } else {                                /* if global class, we just reuse the newly created class in the register */
-            init_exp(&e, ETLOCAL, 0);
-            e.v.idx = new_localvar(parser, class_str);
-        }
+        bexpdesc e1;                        /* if inline class, we add a second local variable for _class */
+        init_exp(&e1, ETLOCAL, 0);
+        e1.v.idx = new_localvar(parser, class_str);
+        be_code_setvar(parser->finfo, &e1, &e, 1);
+
         begin_varinfo(parser, class_str);
 
         class_block(parser, c, &e);

--- a/lib/libesp32/berry/tests/class_static.be
+++ b/lib/libesp32/berry/tests/class_static.be
@@ -155,3 +155,12 @@ assert(A.a == 1)
 assert(A.b == A)
 assert(A.c == [1, A])
 assert(A.f(1) == A)
+
+# bug when superclass is a member
+# the following would break with:
+#
+# attribute_error: class 'B' cannot assign to static attribute 'aa'
+# stack traceback:
+#     stdin:1: in function `main`
+class B end m = module('m') m.B = B
+class A : m.B static aa = 1 end


### PR DESCRIPTION
## Description:

Apply fix from upstream: https://github.com/berry-lang/berry/pull/388

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
