### PR TITLE
Support LWT messages when using TASMESH

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -395,7 +395,9 @@
                                                  // Enabled by default on ESP32 and variants
 
 // -- ESP-NOW -------------------------------------
-//#define USE_TASMESH                              // Enable Tasmota Mesh using ESP-NOW (+11k code)
+#define USE_TASMESH                              // Enable Tasmota Mesh using ESP-NOW (+11k code)
+#define TASMESH_HEARTBEAT      1                 // If enabled, the broker will detect when nodes come online and offline and send Birth and LWT messages over MQTT correspondingly (0 = off, 1 = on)
+#define TASMESH_OFFLINE_DELAY  3                 // Maximum number of seconds since the last heartbeat before the broker considers a node to be offline
 
 // -- OTA -----------------------------------------
 //#define USE_ARDUINO_OTA                          // Add optional support for Arduino OTA with ESP8266 (+13k code)

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -395,9 +395,9 @@
                                                  // Enabled by default on ESP32 and variants
 
 // -- ESP-NOW -------------------------------------
-#define USE_TASMESH                              // Enable Tasmota Mesh using ESP-NOW (+11k code)
-#define USE_TASMESH_HEARTBEAT                    // If enabled, the broker will detect when nodes come online and offline and send Birth and LWT messages over MQTT correspondingly
-#define TASMESH_OFFLINE_DELAY  3                 // Maximum number of seconds since the last heartbeat before the broker considers a node to be offline
+//#define USE_TASMESH                              // Enable Tasmota Mesh using ESP-NOW (+11k code)
+//#define USE_TASMESH_HEARTBEAT                    // If enabled, the broker will detect when nodes come online and offline and send Birth and LWT messages over MQTT correspondingly
+//#define TASMESH_OFFLINE_DELAY  3                 // Maximum number of seconds since the last heartbeat before the broker considers a node to be offline
 
 // -- OTA -----------------------------------------
 //#define USE_ARDUINO_OTA                          // Add optional support for Arduino OTA with ESP8266 (+13k code)

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -396,7 +396,7 @@
 
 // -- ESP-NOW -------------------------------------
 #define USE_TASMESH                              // Enable Tasmota Mesh using ESP-NOW (+11k code)
-#define TASMESH_HEARTBEAT      1                 // If enabled, the broker will detect when nodes come online and offline and send Birth and LWT messages over MQTT correspondingly (0 = off, 1 = on)
+#define USE_TASMESH_HEARTBEAT                    // If enabled, the broker will detect when nodes come online and offline and send Birth and LWT messages over MQTT correspondingly
 #define TASMESH_OFFLINE_DELAY  3                 // Maximum number of seconds since the last heartbeat before the broker considers a node to be offline
 
 // -- OTA -----------------------------------------

--- a/tasmota/tasmota_xdrv_driver/xdrv_57_1_tasmesh_support.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_57_1_tasmesh_support.ino
@@ -90,6 +90,8 @@ struct mesh_peer_t {
   uint8_t MAC[6];
   uint32_t lastMessageFromPeer;    // Time of last message from peer
 #ifdef ESP32
+  bool isAlive;                    // True if we have gotten a heartbeat recently
+  uint32_t lastHeartbeatFromPeer;  // Time of last heartbeat from peer
   char topic[MESH_TOPICSZ];
 #endif //ESP32
 };
@@ -164,7 +166,8 @@ enum MESH_Packet_Type {            // Type of packet
   PACKET_TYPE_REGISTER_NODE,       // register a node with encrypted broker-MAC, announce mqtt topic to ESP32-proxy - broker will send time ASAP
   PACKET_TYPE_REFRESH_NODE,        // refresh node infos with encrypted broker-MAC, announce mqtt topic to ESP32-proxy - broker will send time slightly delayed
   PACKET_TYPE_MQTT,                // send regular mqtt messages, single or multipackets
-  PACKET_TYPE_WANTTOPIC            // the broker has no topic for this peer/node
+  PACKET_TYPE_WANTTOPIC,           // the broker has no topic for this peer/node
+  PACKET_TYPE_HEARTBEAT
 };
 
 /*********************************************************************************************\

--- a/tasmota/tasmota_xdrv_driver/xdrv_57_1_tasmesh_support.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_57_1_tasmesh_support.ino
@@ -91,8 +91,10 @@ struct mesh_peer_t {
   uint32_t lastMessageFromPeer;    // Time of last message from peer
 #ifdef ESP32
   bool isAlive;                    // True if we have gotten a heartbeat recently
-  uint32_t lastHeartbeatFromPeer;  // Time of last heartbeat from peer
   char topic[MESH_TOPICSZ];
+#if TASMESH_HEARTBEAT
+  uint32_t lastHeartbeatFromPeer;  // Time of last heartbeat from peer
+#endif // TASMESH_HEARTBEAT
 #endif //ESP32
 };
 
@@ -167,7 +169,9 @@ enum MESH_Packet_Type {            // Type of packet
   PACKET_TYPE_REFRESH_NODE,        // refresh node infos with encrypted broker-MAC, announce mqtt topic to ESP32-proxy - broker will send time slightly delayed
   PACKET_TYPE_MQTT,                // send regular mqtt messages, single or multipackets
   PACKET_TYPE_WANTTOPIC,           // the broker has no topic for this peer/node
-  PACKET_TYPE_HEARTBEAT
+#if TASMESH_HEARTBEAT
+  PACKET_TYPE_HEARTBEAT            // sent periodically from nodes to the broker to signal aliveness
+#endif // TASMESH_HEARTBEAT
 };
 
 /*********************************************************************************************\

--- a/tasmota/tasmota_xdrv_driver/xdrv_57_1_tasmesh_support.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_57_1_tasmesh_support.ino
@@ -90,11 +90,11 @@ struct mesh_peer_t {
   uint8_t MAC[6];
   uint32_t lastMessageFromPeer;    // Time of last message from peer
 #ifdef ESP32
-  bool isAlive;                    // True if we have gotten a heartbeat recently
   char topic[MESH_TOPICSZ];
-#if TASMESH_HEARTBEAT
+#ifdef USE_TASMESH_HEARTBEAT
+  bool isAlive;                    // True if we have gotten a heartbeat recently
   uint32_t lastHeartbeatFromPeer;  // Time of last heartbeat from peer
-#endif // TASMESH_HEARTBEAT
+#endif // USE_TASMESH_HEARTBEAT
 #endif //ESP32
 };
 
@@ -169,9 +169,9 @@ enum MESH_Packet_Type {            // Type of packet
   PACKET_TYPE_REFRESH_NODE,        // refresh node infos with encrypted broker-MAC, announce mqtt topic to ESP32-proxy - broker will send time slightly delayed
   PACKET_TYPE_MQTT,                // send regular mqtt messages, single or multipackets
   PACKET_TYPE_WANTTOPIC,           // the broker has no topic for this peer/node
-#if TASMESH_HEARTBEAT
+#ifdef USE_TASMESH_HEARTBEAT
   PACKET_TYPE_HEARTBEAT            // sent periodically from nodes to the broker to signal aliveness
-#endif // TASMESH_HEARTBEAT
+#endif // USE_TASMESH_HEARTBEAT
 };
 
 /*********************************************************************************************\

--- a/tasmota/tasmota_xdrv_driver/xdrv_57_9_tasmesh.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_57_9_tasmesh.ino
@@ -554,7 +554,7 @@ void MESHevery50MSecond(void) {
               if (!_peer.isAlive) {
                 _peer.isAlive = true;
                 char stopic[TOPSZ];
-                GetTopic_P(stopic, TELE, _peer.topic, PSTR("LWT"));
+                GetTopic_P(stopic, TELE, _peer.topic, S_LWT);
                 MqttPublishPayload(stopic, PSTR(MQTT_LWT_ONLINE));
               }
               break;
@@ -602,7 +602,7 @@ void MESHEverySecond(void) {
     if (_peer.isAlive && TimePassedSince(_peer.lastHeartbeatFromPeer) > 3000) {
       _peer.isAlive = false;
       char stopic[TOPSZ];
-      GetTopic_P(stopic, TELE, _peer.topic, PSTR("LWT"));
+      GetTopic_P(stopic, TELE, _peer.topic, S_LWT);
       MqttPublishPayload(stopic, PSTR(MQTT_LWT_OFFLINE));
     }
   }

--- a/tasmota/tasmota_xdrv_driver/xdrv_57_9_tasmesh.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_57_9_tasmesh.ino
@@ -547,7 +547,7 @@ void MESHevery50MSecond(void) {
         }
         break;
       case PACKET_TYPE_HEARTBEAT:
-#if TASMESH_HEARTBEAT
+#ifdef USE_TASMESH_HEARTBEAT
         for (auto &_peer : MESH.peers){
           if (memcmp(_peer.MAC, MESH.packetToConsume.front().sender, 6) == 0) {
             _peer.lastHeartbeatFromPeer = millis();
@@ -561,7 +561,7 @@ void MESHevery50MSecond(void) {
             break;
           }
         }
-#endif // TASMESH_HEARTBEAT
+#endif // USE_TASMESH_HEARTBEAT
         break;
 
       default:
@@ -601,7 +601,7 @@ void MESHEverySecond(void) {
     MESH.multiPackets.erase(MESH.multiPackets.begin());
   }
 
-#if TASMESH_HEARTBEAT
+#ifdef USE_TASMESH_HEARTBEAT
   for (auto &_peer : MESH.peers){
     if (_peer.isAlive && TimePassedSince(_peer.lastHeartbeatFromPeer) > TASMESH_OFFLINE_DELAY * 1000) {
       _peer.isAlive = false;
@@ -610,7 +610,7 @@ void MESHEverySecond(void) {
       MqttPublishPayload(stopic, PSTR(MQTT_LWT_OFFLINE));
     }
   }
-#endif TASMESH_HEARTBEAT
+#endif // USE_TASMESH_HEARTBEAT
 }
 
 #else  // ESP8266
@@ -679,7 +679,7 @@ void MESHEverySecond(void) {
       WifiBegin(3, MESH.channel);
     }
 
-#if TASMESH_HEARTBEAT
+#ifdef USE_TASMESH_HEARTBEAT
     MESH.sendPacket.counter++;
     MESH.sendPacket.TTL = 2;
     MESH.sendPacket.chunks = 0;
@@ -687,7 +687,7 @@ void MESHEverySecond(void) {
     MESH.sendPacket.chunkSize = 0;
     MESH.sendPacket.type = PACKET_TYPE_HEARTBEAT;
     MESHsendPacket(&MESH.sendPacket);
-#endif // TASMESH_HEARTBEAT
+#endif // USE_TASMESH_HEARTBEAT
   }
 }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_57_9_tasmesh.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_57_9_tasmesh.ino
@@ -548,22 +548,21 @@ void MESHevery50MSecond(void) {
         break;
       case PACKET_TYPE_HEARTBEAT:
 #if TASMESH_HEARTBEAT
-          for (auto &_peer : MESH.peers){
-            if (memcmp(_peer.MAC, MESH.packetToConsume.front().sender, 6) == 0) {
-              _peer.lastHeartbeatFromPeer = millis();
+        for (auto &_peer : MESH.peers){
+          if (memcmp(_peer.MAC, MESH.packetToConsume.front().sender, 6) == 0) {
+            _peer.lastHeartbeatFromPeer = millis();
 
-              if (!_peer.isAlive) {
-                _peer.isAlive = true;
-                char stopic[TOPSZ];
-                GetTopic_P(stopic, TELE, _peer.topic, S_LWT);
-                MqttPublishPayload(stopic, PSTR(MQTT_LWT_ONLINE));
-              }
-              break;
+            if (!_peer.isAlive) {
+              _peer.isAlive = true;
+              char stopic[TOPSZ];
+              GetTopic_P(stopic, TELE, _peer.topic, S_LWT);
+              MqttPublishPayload(stopic, PSTR(MQTT_LWT_ONLINE));
             }
+            break;
           }
-#else
-        break;
+        }
 #endif // TASMESH_HEARTBEAT
+        break;
 
       default:
         AddLogBuffer(LOG_LEVEL_DEBUG, (uint8_t *)&MESH.packetToConsume.front(), MESH.packetToConsume.front().chunkSize +5);


### PR DESCRIPTION
## Description:

This PR enables the TASMESH broker to detect when nodes come online and offline through the use of heartbeat packets. When a change is detected, the corresponding LWT Online or Offline message is sent through MQTT.

**Related issue (if applicable):** fixes #20369 and #20375

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
