### PR TITLE
[Thermostat] Save and restore XdrvMailbox if relay gets switched off

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino
@@ -1442,7 +1442,9 @@ void CmndThermostatModeSet(void)
         // Make sure the relay is switched to off once if the thermostat is being disabled,
         // or it will get stuck on (danger!)
         Thermostat[ctr_output].status.command_output = IFACE_OFF;
+        struct XDRVMAILBOX save_XdrvMailbox = XdrvMailbox;
         ThermostatOutputRelay(ctr_output, Thermostat[ctr_output].status.command_output);
+        XdrvMailbox = save_XdrvMailbox;
       }
       if ((value > THERMOSTAT_OFF) && (value < THERMOSTAT_MODES_MAX)) {
         DebugControllerParameters(ctr_output);


### PR DESCRIPTION
## Description:

When multiple thermostats are used, disabling a thermostat whose relay is enabled (eventually) triggers `SetDevicePower(..)` to ensure the relay is off. This overrides the current `XdrvMailbox` state,  causing `ResponseCmndIdxNumber(..)` to incorrectly use the `XdrvMailbox.index` meant for relays. 

---
For debugging purposes I injected some extra log statements here: https://github.com/arendst/Tasmota/blob/af2b90caac0aff12edaf01de9fac72d186276d79/tasmota/tasmota_xdrv_driver/xdrv_39_thermostat.ino#L1445C29-L1445C29
```cpp
AddLog(LOG_LEVEL_ERROR, PSTR(D_LOG_THERMOSTAT "Before relay off: XdrvMailbox.index = %d"), XdrvMailbox.index);
ThermostatOutputRelay(ctr_output, Thermostat[ctr_output].status.command_output);
AddLog(LOG_LEVEL_ERROR, PSTR(D_LOG_THERMOSTAT "After relay off: XdrvMailbox.index = %d"), XdrvMailbox.index);
```

- With all other relays (except the thermostat one) off, the index gets changed to 0:
```
Jan  5 15:16:55 whc-0886 ESP-CMD: Grp 0, Cmd 'THERMOSTATMODESET', Idx 1, Len 1, Pld 0, Data '0'
Jan  5 15:15:01 whc-0886 ESP-THE: Before relay off: XdrvMailbox.index = 1
Jan  5 15:15:01 whc-0886 ESP-SRC: Thermostat
Jan  5 15:15:01 whc-0886 ESP-MQT: stat/whc/RESULT = {"POWER3":"OFF"}
Jan  5 15:15:01 whc-0886 ESP-MQT: stat/whc/POWER3 = OFF
Jan  5 15:15:01 whc-0886 ESP-MQT: domoticz/in = {"idx":791,"nvalue":0,"svalue":""}
Jan  5 15:15:01 whc-0886 ESP-THE: After relay off: XdrvMailbox.index = 0
Jan  5 15:15:01 whc-0886 ESP-MQT: stat/whc/RESULT = {"ThermostatModeSet0":0}
```

- With all relays on (I have 6 in total), index gets changed to `59 = 0b111011` (i.e. relay 3 off, which in my case corresponds to thermostat1):
```
Jan  5 15:16:58 whc-0886 ESP-CMD: Grp 0, Cmd 'THERMOSTATMODESET', Idx 1, Len 1, Pld 0, Data '0'
Jan  5 15:16:58 whc-0886 ESP-THE: Before relay off: XdrvMailbox.index = 1
Jan  5 15:16:58 whc-0886 ESP-SRC: Thermostat
Jan  5 15:16:58 whc-0886 ESP-MQT: stat/whc/RESULT = {"POWER3":"OFF"}
Jan  5 15:16:58 whc-0886 ESP-MQT: stat/whc/POWER3 = OFF
Jan  5 15:16:58 whc-0886 ESP-MQT: domoticz/in = {"idx":791,"nvalue":0,"svalue":""}
Jan  5 15:16:58 whc-0886 ESP-THE: After relay off: XdrvMailbox.index = 59
Jan  5 15:16:58 whc-0886 ESP-MQT: stat/whc/RESULT = {"ThermostatModeSet59":0}
```
---

This commit temporarily saves the current `XdrvMailbox` before setting the relay state, then restores it afterwards.
I took inspiration from the following:
https://github.com/arendst/Tasmota/blob/af2b90caac0aff12edaf01de9fac72d186276d79/tasmota/tasmota_support/support_device_groups.ino#L839-L841

This was tested on a Sonoff 4CH PRO R3.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
