### PR TITLE
Fixes for tcpasync

### DIFF
--- a/lib/libesp32/berry_tasmota/solidify_all.be
+++ b/lib/libesp32/berry_tasmota/solidify_all.be
@@ -12,7 +12,7 @@ import sys
 sys.path().push('src/embedded')   # allow to import from src/embedded
 
 # globals that need to exist to make compilation succeed
-var globs = "path,ctypes_bytes_dyn,tasmota,ccronexpr,gpio,light,webclient,load,MD5,lv,light_state,udp,I2C_Driver,"
+var globs = "path,ctypes_bytes_dyn,tasmota,ccronexpr,gpio,light,webclient,load,MD5,lv,light_state,udp,I2C_Driver,tcpserver,"
             "lv_clock,lv_clock_icon,lv_signal_arcs,lv_signal_bars,lv_wifi_arcs_icon,lv_wifi_arcs,"
             "lv_wifi_bars_icon,lv_wifi_bars,"
             "_lvgl,"

--- a/lib/libesp32/berry_tasmota/src/embedded/tasmota_class.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/tasmota_class.be
@@ -557,8 +557,7 @@ class Tasmota
 
     # iterate and call each closure
     var i = 0
-    var sz = size(fl)
-    while i < sz
+    while i < size(fl)
       # note: this is not guarded in try/except for performance reasons. The inner function must not raise exceptions
       fl[i]()
       i += 1

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
@@ -110,12 +110,12 @@ be_local_closure(Tasmota_fast_loop,   /* name */
       0x600C000C,  //  0005  GETGBL	R3	G12
       0x5C100200,  //  0006  MOVE	R4	R1
       0x7C0C0200,  //  0007  CALL	R3	1
-      0x14100403,  //  0008  LT	R4	R2	R3
-      0x78120003,  //  0009  JMPF	R4	#000E
-      0x94100202,  //  000A  GETIDX	R4	R1	R2
-      0x7C100000,  //  000B  CALL	R4	0
+      0x140C0403,  //  0008  LT	R3	R2	R3
+      0x780E0003,  //  0009  JMPF	R3	#000E
+      0x940C0202,  //  000A  GETIDX	R3	R1	R2
+      0x7C0C0000,  //  000B  CALL	R3	0
       0x00080502,  //  000C  ADD	R2	R2	K2
-      0x7001FFF9,  //  000D  JMP		#0008
+      0x7001FFF6,  //  000D  JMP		#0005
       0x80000000,  //  000E  RET	0
     })
   )

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tcpclientasync.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tcpclientasync.ino
@@ -186,8 +186,7 @@ public:
             stop();
             break;
           default:
-            // AddLog(LOG_LEVEL_DEBUG, "BRY: tcpclientasync unexpected: RES: %d, ERR: %d", res, errno);
-            stop();
+            // AddLog(LOG_LEVEL_DEBUG, "BRY: tcpclientasync unexpected: RES: %d, ERR: %d, sockfd=%d", res, errno, sockfd);
             break;
         }
       } else {

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tcpserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tcpserver.ino
@@ -38,8 +38,6 @@ class WiFiServerAsync {
 
 
   public:
-    void listenOnLocalhost(){}
-
     WiFiServerAsync(uint16_t port=80, uint8_t max_clients=4):sockfd(-1),_accepted_sockfd(-1),_addr(),_port(port),_max_clients(max_clients),_listening(false),_noDelay(false) {
     }
     WiFiServerAsync(const IPAddress& addr, uint16_t port=80, uint8_t max_clients=4):sockfd(-1),_accepted_sockfd(-1),_addr(addr),_port(port),_max_clients(max_clients),_listening(false),_noDelay(false) {
@@ -117,8 +115,11 @@ AsyncTCPClient * WiFiServerAsync::availableAsync(){
     int val = 1;
     if(setsockopt(client_sock, SOL_SOCKET, SO_KEEPALIVE, (char*)&val, sizeof(int)) == ESP_OK) {
       val = _noDelay;
-      if(setsockopt(client_sock, IPPROTO_TCP, TCP_NODELAY, (char*)&val, sizeof(int)) == ESP_OK)
-        return new AsyncTCPClient(client_sock);
+      if(setsockopt(client_sock, IPPROTO_TCP, TCP_NODELAY, (char*)&val, sizeof(int)) == ESP_OK) {
+        if (fcntl(client_sock, F_SETFL, fcntl(sockfd, F_GETFL, 0) | O_NONBLOCK ) == ESP_OK) {    // set non-blocking
+          return new AsyncTCPClient(client_sock);
+        }
+      }
     }
   }
   return new AsyncTCPClient();


### PR DESCRIPTION
## Description:

Fixes for Berry tcp async server (preparing for async web server)
- Ignore unknown `errno` in tcpasync (copied from Arduino code) or it could unwillingly close connections
- Fix fast_loop to allow clients to unregister themselves when called
- make tcpasync socket non-blocking

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
