### PR TITLE
Berry add `tasmota.urlbecload(url:string) -> bool`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - HASPmota type `chart` (#20372)
 - Berry add support for `tcpclientasync` in `tcpserver`
+- Berry add `tasmota.urlbecload(url:string) -> bool`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
@@ -6,6 +6,7 @@
 #include "be_constobj.h"
 #include "be_ctypes.h"
 #include "be_mapping.h"
+#include "be_ctypes.h"
 
 extern struct TasmotaGlobal_t TasmotaGlobal;
 extern struct TSettings * Settings;
@@ -68,6 +69,9 @@ extern int tasm_apply_str_op(bvm *vm);
 // tasmota.version() -> int
 extern int32_t be_Tasmota_version(void);
 BE_FUNC_CTYPE_DECLARE(be_Tasmota_version, "i", "-");
+
+extern bbool BerryBECLoader(const char * url);
+BE_FUNC_CTYPE_DECLARE(BerryBECLoader, "b", "s")
 
 #include "solidify/solidified_tasmota_class.h"
 #include "solidify/solidified_rule_matcher.h"
@@ -177,6 +181,7 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     time_str, closure(Tasmota_time_str_closure)
     urlfetch, closure(Tasmota_urlfetch_closure)
     urlfetch_cmd, closure(Tasmota_urlfetch_cmd_closure)
+    urlbecload, static_ctype_func(BerryBECLoader)
 
     add_cron, closure(Tasmota_add_cron_closure)
     run_cron, closure(Tasmota_run_cron_closure)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -778,6 +778,7 @@ void HandleBerryPartiionWizardLoaderButton(void) {
   }
 }
 
+extern "C" bbool BerryBECLoader(const char * url);
 void HandleBerryPartitionWizardLoader(void) {
   if (BerryBECLoader(USE_BERRY_PARTITION_WIZARD_URL)) {
     // All good, redirect
@@ -792,7 +793,7 @@ void HandleBerryPartitionWizardLoader(void) {
 #endif //USE_BERRY_PARTITION_WIZARD
 
 // return true if successful
-bool BerryBECLoader(const char * url) {
+extern "C" bbool BerryBECLoader(const char * url) {
   bvm *vm = berry.vm;
 
   HTTPClientLight cl;


### PR DESCRIPTION
## Description:

Allows to dynamically load `.bec` file from URL, used for ex by Partition Wizard.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
