### PR TITLE
Berry `gpio.get_pin_type` and `gpio.ger_pin_type_index`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Berry add `tasmota.urlbecload(url:string) -> bool` (#20412)
 - GPIO Viewer to see realtime GPIO states. Enable with define USE_GPIO_VIEWER
 - Berry `gpio.read_pwm` and `gpio.read_pwm_resolution`
+- Berry `gpio.get_pin_type` and `gpio.ger_pin_type_index`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_gpio_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_gpio_lib.c
@@ -22,6 +22,9 @@ extern int gp_counter_add(bvm *vm);
 extern int gp_pin_used(bvm *vm);
 extern int gp_pin(bvm *vm);
 
+extern int gp_get_pin(int32_t pin);               BE_FUNC_CTYPE_DECLARE(gp_get_pin, "i", "i");
+extern int gp_get_pin_index(int32_t pin);               BE_FUNC_CTYPE_DECLARE(gp_get_pin_index, "i", "i");
+
 // esp_err_tledc_set_duty_and_update(ledc_mode_tspeed_mode, ledc_channel_tchannel, uint32_t duty, uint32_t hpoint)
 extern void gp_set_duty(int32_t pin, int32_t duty, int32_t hpoint);   BE_FUNC_CTYPE_DECLARE(gp_set_duty, "", "ii[i]");
 
@@ -33,6 +36,8 @@ module gpio (scope: global) {
     member, func(gp_member)
 
     pin_mode, func(gp_pin_mode)
+    get_pin_type, ctype_func(gp_get_pin)
+    get_pin_type_index, ctype_func(gp_get_pin_index)
     digital_write, func(gp_digital_write)
     digital_read, func(gp_digital_read)
     dac_voltage, func(gp_dac_voltage)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_gpio.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_gpio.ino
@@ -324,8 +324,25 @@ extern "C" {
     }
     return -1;
   }
-// extern void gp_get_duty(int32_t pin);               BE_FUNC_CTYPE_DECLARE(gp_get_duty, "i", "i");
-// extern void gp_get_duty_resolution(int32_t pin);    BE_FUNC_CTYPE_DECLARE(gp_get_duty_resolution, "i", "i");
+
+  // gpio.get_pin_type(phy_gpio:int) -> int
+  //
+  // Get the type configured for physical GPIO
+  // Return 0 if GPIO is not configured
+  extern int gp_get_pin(int32_t pin);
+  extern int gp_get_pin(int32_t pin) {
+    return GetPin(pin) / 32;
+  }
+
+  // gpio.get_pin_type_index(phy_gpio:int) -> int
+  //
+  // Get the sub-index for the type configured for physical GPIO
+  // Return 0 if GPIO is not configured
+  extern int gp_get_pin_index(int32_t pin);
+  extern int gp_get_pin_index(int32_t pin) {
+    return GetPin(pin) % 32;
+  }
+
 }
 
 #endif  // USE_BERRY


### PR DESCRIPTION
## Description:

Berry add:
- `gpio.get_pin_type(phy_gpio: int) -> int` return the Tasmota type configured for this physical GPIO, like `gpio.PMW1`
- `gpio.get_pint_type_index(phy_gpio:int) -> int` return the sub-type for the Tasmota type, like 1 for `PWM - 2` (index is zero based).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
