### PR TITLE
Berry add `string` to `bytes()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - HASPmota `haspmota.page_show()` to change page (#20333)
 - Berry `introspect.set()` for class attributes (#20339)
 - Support negative power on BL0942 using index 5..8 (#20322)
+- Berry add `string` to `bytes()`
 
 ### Breaking Changed
 - Refactoring of Berry `animate` module for WS2812 Leds (#20236)

--- a/lib/libesp32/berry/tests/bytes.be
+++ b/lib/libesp32/berry/tests/bytes.be
@@ -103,6 +103,13 @@ assert(str(b) == "bytes('1122334455')")
 b = b2 + b1
 assert(str(b) == "bytes('3344551122')")
 
+#- + for string -#
+b1 = bytes("AA")
+b = b1 + ''
+assert(str(b) == "bytes('AA')")
+b = b1 + '01'
+assert(str(b) == "bytes('AA3031')")
+
 #- .. -#
 b1 = bytes("1122")
 b2 = bytes("334455")
@@ -110,6 +117,13 @@ b = b1..b2
 assert(str(b1) == "bytes('1122334455')")
 assert(str(b2) == "bytes('334455')")
 assert(str(b) == "bytes('1122334455')")
+
+#- .. with string -#
+b1 = bytes("AA")
+b1 .. ''
+assert(str(b1) == "bytes('AA')")
+b1 .. '01'
+assert(str(b1) == "bytes('AA3031')")
 
 #- item -#
 b = bytes("334455")
@@ -257,3 +271,8 @@ assert(!bytes())
 assert(bool(bytes("00")) == true)
 assert(bytes("01").tobool() == true)
 assert(bytes("02"))
+
+# retrieving 3-bytes little/big endian
+a = bytes("01020304")
+assert(a.get(1, 3) == 0x040302)
+assert(a.get(1, -3) == 0x020304)


### PR DESCRIPTION
## Description:

Applying https://github.com/berry-lang/berry/pull/389

Example:
```berry
b = bytes()
b .. 'hello'
print(b)
# bytes('68656C6C6F')
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
