### PR TITLE
Add Button to dynamically load GPIO Viewer with Berry backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - HASPmota `haspmota.page_show()` to change page (#20333)
 - Berry `introspect.set()` for class attributes (#20339)
 - Support negative power on BL0942 using index 5..8 (#20322)
+- Button to dynamically load GPIO Viewer with Berry backend
 
 ### Breaking Changed
 - Refactoring of Berry `animate` module for WS2812 Leds (#20236)

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1146,6 +1146,8 @@
     #define USE_BERRY_WEBCLIENT_TIMEOUT  2000    // Default timeout in milliseconds
     //#define USE_BERRY_PARTITION_WIZARD           // Add a button to dynamically load the Partion Wizard from a bec file online (+1.3KB Flash)
     #define USE_BERRY_PARTITION_WIZARD_URL      "http://ota.tasmota.com/tapp/partition_wizard.bec"
+    //#define USE_BERRY_GPIOVIEWER                 // Add a button to dynamocally load the GPIO Viewer from a bec file online
+    #define USE_BERRY_GPIOVIEWER_URL            "http://ota.tasmota.com/tapp/gpioviewer.bec"
   #define USE_BERRY_TCPSERVER                    // Enable TCP socket server (+0.6k)
   // #define USE_BERRY_ULP                          // Enable ULP (Ultra Low Power) support (+4.9k)
   // Berry crypto extensions below:

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_0_berry_struct.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_0_berry_struct.ino
@@ -96,6 +96,9 @@ public:
 #ifdef USE_BERRY_PARTITION_WIZARD
   bool partition_wizard_loaded = false; // did we already load Parition_Wizard
 #endif // USE_BERRY_PARTITION_WIZARD
+#ifdef USE_BERRY_GPIOVIEWER
+  bool gpviewer_loaded = false;         // did we already load GPIOViewer
+#endif // USE_BERRY_GPIOVIEWER
   bool autoexec_done = false;           // do we still need to load 'autoexec.be'
   bool repl_active = false;             // is REPL running (activates log recording)
   // output log is stored as a LinkedList of buffers
@@ -106,5 +109,42 @@ BerrySupport berry;
 
 // multi-purpose serial logging
 extern "C" void serial_debug(const char * berry_buf, ...);
+
+
+/*********************************************************************************************\
+ * Handle dynamic code from Berry bec files
+ *
+\*********************************************************************************************/
+struct BeBECCode_t {
+  const char * display_name;      // display name in Web UI (must be URL encoded)
+  const char * id;                // id in requested URL, also don't load if the global name already exists in Berry
+  const char * url;               // absolute URL to download the bec file
+  const char * redirect;          // relative URI to redirect after loading
+  bool * loaded;
+};
+
+const BeBECCode_t BECCode[] = {
+#ifdef USE_BERRY_PARTITION_WIZARD
+  {
+    "Partition Wizard",
+    "partition_wizard",
+    USE_BERRY_PARTITION_WIZARD_URL,
+    "/part_wiz",
+    &berry.partition_wizard_loaded
+  },
+#endif // USE_BERRY_PARTITION_WIZARD
+
+#ifdef USE_BERRY_GPIOVIEWER
+  {
+    "GPIO Viewer",
+    "gpioviewer",
+    USE_BERRY_GPIOVIEWER_URL,
+    "/mn?",
+    &berry.gpviewer_loaded
+  },
+#endif // USE_BERRY_GPIOVIEWER
+
+};
+
 
 #endif  // USE_BERRY


### PR DESCRIPTION
## Description:

Add compile option to add a button for GPIO Viewer - the code is dynamically loaded from an online source and takes no memory nor flash until used.

Requires: `#define USE_BERRY_GPIOVIEWER`

<img width="351" alt="image" src="https://github.com/arendst/Tasmota/assets/49731213/031a9ac7-6a5d-4ddf-beb0-643a46c6084e">


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
