### PR TITLE
MI32 legacy: add optional argument to BLE.run()

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
@@ -64,8 +64,8 @@ BE_FUNC_CTYPE_DECLARE(be_BLE_set_MAC, "", "@(bytes)~[i]");
 extern void be_BLE_set_characteristic(struct bvm *vm, const char *Chr);
 BE_FUNC_CTYPE_DECLARE(be_BLE_set_characteristic, "", "@s");
 
-extern void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response);
-BE_FUNC_CTYPE_DECLARE(be_BLE_run, "", "@i[b]");
+extern void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response, int32_t arg1);
+BE_FUNC_CTYPE_DECLARE(be_BLE_run, "", "@i[bi]");
 
 extern void be_BLE_set_service(struct bvm *vm, const char *Svc, bbool discoverAttributes);
 BE_FUNC_CTYPE_DECLARE(be_BLE_set_service, "", "@s[b]");

--- a/lib/libesp32_div/esp-nimble-cpp/src/NimBLEAdvertising.cpp
+++ b/lib/libesp32_div/esp-nimble-cpp/src/NimBLEAdvertising.cpp
@@ -67,7 +67,7 @@ void NimBLEAdvertising::reset() {
     m_advParams.disc_mode            = BLE_GAP_DISC_MODE_GEN;
     m_customAdvData                  = false;
     m_customScanResponseData         = false;
-    m_scanResp                       = true;
+    m_scanResp                       = false;
     m_advDataSet                     = false;
     // Set this to non-zero to prevent auto start if host reset before started by app.
     m_duration                       = BLE_HS_FOREVER;

--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -156,11 +156,13 @@ struct MI32connectionContextBerry_t{
   NimBLEUUID charUUID;
   uint16_t returnCharUUID;
   uint16_t handle;
-  uint8_t MAC[6];
   uint8_t * buffer;
+  uint8_t MAC[6];
   uint8_t operation;
   uint8_t addrType;
   int error;
+  int32_t arg1;
+  bool hasArg1;
   bool oneOp;
   bool response;
 };

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
@@ -80,7 +80,7 @@ extern "C" {
   extern void MI32setBerryAdvCB(void* function, uint8_t *buffer);
   extern void MI32setBerryConnCB(void* function, uint8_t *buffer);
   extern void MI32setBerryServerCB(void* function, uint8_t *buffer);
-  extern bool MI32runBerryConnection(uint8_t operation, bbool response);
+  extern bool MI32runBerryConnection(uint8_t operation, bbool response, int32_t *arg1);
   extern bool MI32setBerryCtxSvc(const char *Svc, bbool discoverAttributes);
   extern bool MI32setBerryCtxChr(const char *Chr);
   extern bool MI32setBerryCtxMAC(uint8_t *MAC, uint8_t type);
@@ -161,13 +161,19 @@ extern "C" {
     be_raisef(vm, "ble_error", "BLE: could not set characteristic");
   }
 
-  void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response);
-  void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response){
+  void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response, int32_t arg1);
+  void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response, int32_t arg1){
+    int32_t argc = be_top(vm); // Get the number of arguments
     bool _response = false;    
     if(response){
       _response = response;
     }
-    if (MI32runBerryConnection(operation,_response)) return;
+    int32_t *ptr_arg1 = nullptr;
+    int32_t _arg1 = arg1;
+    if(argc == 3){
+      ptr_arg1 = &_arg1;
+    }
+    if (MI32runBerryConnection(operation, _response, ptr_arg1)) return;
 
     be_raisef(vm, "ble_error", "BLE: could not run operation");
   }


### PR DESCRIPTION
## Description:

Related to the operation this optional argument has different meanings.

For op codes 1 -3 (peripheral role -  read, write, subscribe) it becomes the handle - overriding service and characteristic of the current context.
Can be used to shorten the code, example for microphone read of a BPR2S BLE remote:
```
BLE.set_svc("AB5E0001-5A21-4F05-BC7D-AF01F617B664")
BLE.set_chr("AB5E0004-5A21-4F05-BC7D-AF01F617B664")
BLE.run(3)
```
can also be done with:
```
 BLE.run(3,false,0x4d) # (false is default for write response, 0x4d is the uint16_t handle of the UUID's from above)
```

For central/server role this argument becomes:
`NIMBLE_PROPERTY` (int value of the enum) for creation of a characteristic (allows more efficient server creation with the properties , that are really needed)
or 
`AdvertisementType` (int value of the enum) for first set of advertisement (for non standard advertisements)

bugfix:
Add internal delay for server start as work around, that can otherwise lead to crash. This is not a real solution and very likely a bug in the NimBLE stack, that will hopefully be resolved from that side later on.

More consistent report of handles in the callback functions.
Set scan response for advertisement only if data is provided for it, thus setting default to `false`.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
