### PR TITLE
Fixing logic for SGP4x Sgp4xShow() function

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_109_sgp4x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_109_sgp4x.ino
@@ -265,9 +265,9 @@ void Sgp4xShow(bool json)
   if (sgp4x_state == STATE_SGP4X_NORMAL) {
     if (json) {
       if (sgp4x_type == TYPE_SGP41) {
-        ResponseAppend_P(PSTR(",\"SGP40\":{\"VOC_" D_JSON_RAW "\":%d,\"NOX_" D_JSON_RAW "\":%d,\"" D_TVOC "\":%d,\"" D_NOX "\":%d"), srawVoc, srawNox, voc_index_sgp4x, nox_index_sgp4x);
+        ResponseAppend_P(PSTR(",\"SGP41\":{\"VOC_" D_JSON_RAW "\":%d,\"NOX_" D_JSON_RAW "\":%d,\"" D_TVOC "\":%d,\"" D_NOX "\":%d"), srawVoc, srawNox, voc_index_sgp4x, nox_index_sgp4x);
       } else {
-        ResponseAppend_P(PSTR(",\"SGP41\":{\"VOC_" D_JSON_RAW "\":%d,,\"" D_TVOC "\":%d,"), srawVoc, voc_index_sgp4x);
+        ResponseAppend_P(PSTR(",\"SGP40\":{\"VOC_" D_JSON_RAW "\":%d,,\"" D_TVOC "\":%d,"), srawVoc, voc_index_sgp4x);
       }
       ResponseJsonEnd();
 #ifdef USE_DOMOTICZ


### PR DESCRIPTION
## Description: The Sgp4xShow() function in the SGP4X driver was not appending the right sensor name within the JSON. This PR fixes that bug.

Bug was reported here: https://github.com/arendst/Tasmota/discussions/18867#discussioncomment-8055759

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).