### PR TITLE
Berry `webserver.header` to read browser sent headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Berry add `string` to `bytes()` (#20420)
 - Berry button to dynamically load GPIO Viewer with Berry backend (#20424)
 - Berry `debug_panel.tapp` to display real-time heap and wifi rssi
+- Berry `webserver.header` to read browser sent headers
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
@@ -34,6 +34,7 @@ extern int w_webserver_arg(bvm *vm);
 extern int w_webserver_arg_name(bvm *vm);
 extern int w_webserver_has_arg(bvm *vm);
 
+extern int w_webserver_header(bvm *vm);
 
 // To allow a full restart of the Berry VM, we need to supplement the webserver Request Handler
 // model from Arduino framework.
@@ -160,6 +161,8 @@ module webserver (scope: global) {
     arg, func(w_webserver_arg)
     arg_name, func(w_webserver_arg_name)
     has_arg, func(w_webserver_has_arg)
+
+    header, func(w_webserver_header)
 }
 @const_object_info_end */
 #include "be_fixed_webserver.h"

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
@@ -335,6 +335,23 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
+  // Berry: `webserver.header(name:string) -> string or nil`
+  int32_t w_webserver_header(struct bvm *vm);
+  int32_t w_webserver_header(struct bvm *vm) {
+    int32_t argc = be_top(vm); // Get the number of arguments
+    if (argc >= 1 && be_isstring(vm, 1)) {
+      const char * header_name = be_tostring(vm, 1);
+      String header = Webserver->header(header_name);
+      if (header.length() > 0) {
+        be_pushstring(vm, header.c_str());
+        be_return(vm);
+      } else {
+        be_return_nil(vm);
+      }
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
+
 }
 
 #endif // USE_WEBSERVER


### PR DESCRIPTION
## Description:

Berry add `webserver.header(name: string) -> string or nil` return the header with key `name` sent by the browser. The name is case sensitive. Return `nil` if the header is not present or not collected. Currently only `Referer`, `Host`, `Authorization` and `If-None-Match`.

```berry
import webserver
var host = webserver.header("Host")
print(host)
``` 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
