### PR TITLE
Fixed Zigbee Aqara attributes on ESP32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Header `Host` is now collected by Webserver
 
 ### Fixed
+- Fixed Zigbee Aqara attributes on ESP32
 
 ### Removed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -1304,42 +1304,36 @@ void ZCLFrame::syntheticAqaraCubeOrButton(class Z_attribute_list &attr_list, cla
 
   if (modelId.startsWith(F("lumi.sensor_cube"))) {   // only for Aqara cube
     int32_t val = attr.getInt();
-#ifdef ESP8266
-    const __FlashStringHelper *aqara_cube = F("AqaraCube");
-    const __FlashStringHelper *aqara_cube_side = F("AqaraCubeSide");
-    const __FlashStringHelper *aqara_cube_from_side = F("AqaraCubeFromSide");
-#else
-    const char *aqara_cube = "AqaraCube";
-    const char *aqara_cube_side = "AqaraCubeSide";
-    const char *aqara_cube_from_side = "AqaraCubeFromSide";
-#endif
+    static const char *aqara_cube = PSTR("AqaraCube");
+    static const char *aqara_cube_side = PSTR("AqaraCubeSide");
+    static const char *aqara_cube_from_side = PSTR("AqaraCubeFromSide");
 
     switch (val) {
       case 0:
-        attr_list.addAttribute(aqara_cube).setStr(PSTR("shake"));
+        attr_list.addAttributePMEM(aqara_cube).setStr(PSTR("shake"));
         break;
       case 2:
-        attr_list.addAttribute(aqara_cube).setStr(PSTR("wakeup"));
+        attr_list.addAttributePMEM(aqara_cube).setStr(PSTR("wakeup"));
         break;
       case 3:
-        attr_list.addAttribute(aqara_cube).setStr(PSTR("fall"));
+        attr_list.addAttributePMEM(aqara_cube).setStr(PSTR("fall"));
         break;
       case 64 ... 127:
-        attr_list.addAttribute(aqara_cube).setStr(PSTR("flip90"));
-        attr_list.addAttribute(aqara_cube_side).setInt(val % 8);
-        attr_list.addAttribute(aqara_cube_from_side).setInt((val - 64) / 8);
+        attr_list.addAttributePMEM(aqara_cube).setStr(PSTR("flip90"));
+        attr_list.addAttributePMEM(aqara_cube_side).setInt(val % 8);
+        attr_list.addAttributePMEM(aqara_cube_from_side).setInt((val - 64) / 8);
         break;
       case 128 ... 132:
-        attr_list.addAttribute(aqara_cube).setStr(PSTR("flip180"));
-        attr_list.addAttribute(aqara_cube_side).setInt(val - 128);
+        attr_list.addAttributePMEM(aqara_cube).setStr(PSTR("flip180"));
+        attr_list.addAttributePMEM(aqara_cube_side).setInt(val - 128);
         break;
       case 256 ... 261:
-        attr_list.addAttribute(aqara_cube).setStr(PSTR("slide"));
-        attr_list.addAttribute(aqara_cube_side).setInt(val - 256);
+        attr_list.addAttributePMEM(aqara_cube).setStr(PSTR("slide"));
+        attr_list.addAttributePMEM(aqara_cube_side).setInt(val - 256);
         break;
       case 512 ... 517:
-        attr_list.addAttribute(aqara_cube).setStr(PSTR("tap"));
-        attr_list.addAttribute(aqara_cube_side).setInt(val - 512);
+        attr_list.addAttributePMEM(aqara_cube).setStr(PSTR("tap"));
+        attr_list.addAttributePMEM(aqara_cube_side).setInt(val - 512);
         break;
     }
     attr_list.removeAttribute(&attr);
@@ -1363,26 +1357,21 @@ void ZCLFrame::syntheticAqaraCubeOrButton(class Z_attribute_list &attr_list, cla
     //     presentValue = x + 512 = double tap while side x is on top
   } else if (modelId.startsWith(F("lumi.remote")) || modelId.startsWith(F("lumi.sensor_swit"))) {   // only for Aqara buttons WXKG11LM & WXKG12LM, 'swit' because of #9923
     int32_t val = attr.getInt();
-#ifdef ESP8266
-    const __FlashStringHelper *aqara_click = F("click");    // deprecated
-    const __FlashStringHelper *aqara_action = F("action");  // deprecated
-#else
-    const char *aqara_click = "click";    // deprecated
-    const char *aqara_action = "action";  // deprecated
-#endif
+    static const char *aqara_click = PSTR("click");    // deprecated
+    static const char *aqara_action = PSTR("action");  // deprecated
     Z_attribute & attr_click = attr_list.addAttribute(PSTR("Click"), true);
 
     switch (val) {
       case 0:
-        attr_list.addAttribute(aqara_action).setStr(PSTR("hold"));            // deprecated
+        attr_list.addAttributePMEM(aqara_action).setStr(PSTR("hold"));            // deprecated
         attr_click.setStr(PSTR("hold"));
         break;
       case 1:
-        attr_list.addAttribute(aqara_click).setStr(PSTR("single"));            // deprecated
+        attr_list.addAttributePMEM(aqara_click).setStr(PSTR("single"));            // deprecated
         attr_click.setStr(PSTR("single"));
         break;
       case 2:
-        attr_list.addAttribute(aqara_click).setStr(PSTR("double"));            // deprecated
+        attr_list.addAttributePMEM(aqara_click).setStr(PSTR("double"));            // deprecated
         attr_click.setStr(PSTR("double"));
         break;
       case 3:
@@ -1392,23 +1381,23 @@ void ZCLFrame::syntheticAqaraCubeOrButton(class Z_attribute_list &attr_list, cla
         attr_click.setStr(PSTR("quadruple"));
         break;
       case 16:
-        attr_list.addAttribute(aqara_action).setStr(PSTR("hold"));            // deprecated
+        attr_list.addAttributePMEM(aqara_action).setStr(PSTR("hold"));            // deprecated
         attr_click.setStr(PSTR("hold"));
         break;
       case 17:
-        attr_list.addAttribute(aqara_action).setStr(PSTR("release"));            // deprecated
+        attr_list.addAttributePMEM(aqara_action).setStr(PSTR("release"));            // deprecated
         attr_click.setStr(PSTR("release"));
         break;
       case 18:
-        attr_list.addAttribute(aqara_action).setStr(PSTR("shake"));            // deprecated
+        attr_list.addAttributePMEM(aqara_action).setStr(PSTR("shake"));            // deprecated
         attr_click.setStr(PSTR("shake"));
         break;
       case 255:
-        attr_list.addAttribute(aqara_action).setStr(PSTR("release"));            // deprecated
+        attr_list.addAttributePMEM(aqara_action).setStr(PSTR("release"));            // deprecated
         attr_click.setStr(PSTR("release"));
         break;
       default:
-        attr_list.addAttribute(aqara_click).setUInt(val);
+        attr_list.addAttributePMEM(aqara_click).setUInt(val);
         attr_click.setStr(PSTR("release"));
         break;
     }


### PR DESCRIPTION
## Description:

Fix display of Aqara  fields on ESP32, see https://github.com/arendst/Tasmota/pull/18432#issuecomment-1882735773

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
