### PR TITLE
Berry `tasmota.webcolor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Berry `debug_panel.tapp` to display real-time heap and wifi rssi
 - Berry `webserver.header` to read browser sent headers
 - Berry provide lightweight options for `tasmota.wifi/eth/memory/rtc`
+- Berry `tasmota.webcolor`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
@@ -56,6 +56,8 @@ extern int l_respAppend(bvm *vm);
 extern int l_webSend(bvm *vm);
 extern int l_webSendDecimal(bvm *vm);
 
+extern int l_webcolor(bvm *vm);
+
 extern int l_getlight(bvm *vm);
 extern int l_setlight(bvm *vm);
 extern int l_getpower(bvm *vm);
@@ -143,6 +145,7 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     response_append, func(l_respAppend)
     web_send, func(l_webSend)
     web_send_decimal, func(l_webSendDecimal)
+    webcolor, static_func(l_webcolor)
 
     get_power, func(l_getpower)
     set_power, func(l_setpower)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -820,6 +820,33 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
+  // get webcolors
+  int32_t l_webcolor(bvm *vm);
+  int32_t l_webcolor(bvm *vm) {
+    char tmp[16];
+    int32_t top = be_top(vm); // Get the number of arguments
+    if (top >= 1 && be_isint(vm, 1)) {  // argument is int
+      int32_t idx = be_toint(vm, 1);
+      if (idx >= 0 && idx < COL_LAST) {
+        snprintf_P(tmp, sizeof(tmp), PSTR("#%06x"), WebColor(idx));
+        be_pushstring(vm, tmp);
+        be_return(vm);
+      } else {
+        be_return_nil(vm);
+      }
+    } else {
+      be_newobject(vm, "list");
+      for (uint32_t i = 0; i < COL_LAST; i++) {
+        snprintf_P(tmp, sizeof(tmp), PSTR("#%06x"), WebColor(i));
+        be_pushstring(vm, tmp);
+        be_data_push(vm, -2);
+        be_pop(vm, 1);
+      }
+      be_pop(vm, 1);
+      be_return(vm);
+    }
+  }
+
   // get power
   int32_t l_getpower(bvm *vm);
   int32_t l_getpower(bvm *vm) {


### PR DESCRIPTION
## Description:

Berry add `tasmota.webcolor() -> list of strings` or `tasmota.webcolor(int) -> string`. Retrieve all the webcolors or a specific value as `#RRGGBB`.

```berry
tasmota.webcolor()
# ['#eaeaea', '#252525', '#4f4f4f', '#000000', '#dddddd', '#65c115', '#1f1f1f', '#ff5661', '#008000', '#faffff', '#1fa3ec', '#0e70a4', '#d43535', '#931f1f', '#47c266', '#5aaf6f', '#faffff', '#999999', '#eaeaea']

tasmota.webcolor(2)
# '#4f4f4f'
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
