### PR TITLE
Fix compilation of Zigbee for Core3

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
@@ -795,7 +795,7 @@ void Z_Device::jsonAddEndpoints(Z_attribute_list & attr_list) const {
   for (uint32_t i = 0; i < endpoints_max; i++) {
     uint8_t endpoint = endpoints[i];
     if (0x00 == endpoint) { break; }
-    arr_ep.add(endpoint);
+    arr_ep.add((uint32_t)endpoint);
   }
   attr_list.addAttributePMEM(PSTR("Endpoints")).setStrRaw(arr_ep.toString().c_str());
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -931,7 +931,7 @@ void ZCLFrame::parseReadAttributes(uint16_t shortaddr, Z_attribute_list& attr_li
   Z_attribute_list attr_names;
   while (len >= 2 + i) {
     uint16_t attrid = payload.get16(i);
-    attr_numbers.add(attrid);
+    attr_numbers.add((uint32_t)attrid);
     read_attr_ids[i/2] = attrid;
 
     // find the attribute name

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_6_0_commands.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_6_0_commands.ino
@@ -454,7 +454,7 @@ void convertClusterSpecific(class Z_attribute_list &attr_list, uint16_t cluster,
 
           JsonGeneratorArray group_list;
           for (uint32_t i = 0; i < xyz.y; i++) {
-            group_list.add(payload.get16(2 + 2*i));
+            group_list.add((uint32_t)payload.get16(2 + 2*i));
           }
           attr_list.addAttribute(command_name, true).setStrRaw(group_list.toString().c_str());
         }

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_6_1_greenpower.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_6_1_greenpower.ino
@@ -161,7 +161,7 @@ bool convertGPDF_Commissioning(class Z_attribute_list &attr_list, uint16_t short
       JsonGeneratorArray gpdi_list;
       for (uint32_t i = 0; i < gpid_len; i++) {
         if (idx_offset >= payload_len + payload_start) { break; }   // end of payload
-        gpdi_list.add(payload.get8(idx_offset++));
+        gpdi_list.add((uint32_t)payload.get8(idx_offset++));
       }
       ResponseAppend_P(PSTR(",\"commandid\":%s"), gpdi_list.toString().c_str());
     }
@@ -171,7 +171,7 @@ bool convertGPDF_Commissioning(class Z_attribute_list &attr_list, uint16_t short
       JsonGeneratorArray gpdi_list;
       for (uint32_t i = 0; i < clust_report_len; i++) {
         if (idx_offset >= payload_len + payload_start) { break; }   // end of payload
-        gpdi_list.add(payload.get16(idx_offset));
+        gpdi_list.add((uint32_t)payload.get16(idx_offset));
         idx_offset += 2;
       }
       ResponseAppend_P(PSTR(",\"clusterreports\":%s"), gpdi_list.toString().c_str());

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
@@ -550,7 +550,7 @@ extern "C" {
       } else if (mode == 12) {
         a->setKeyName("array");
         a->newJsonArray();
-        a->val.arrval->add(-1);
+        a->val.arrval->add((int32_t)-1);
         a->val.arrval->addStr("foo");
         a->val.arrval->addStr("bar");
         a->val.arrval->addStr("bar\"baz\'toto");


### PR DESCRIPTION
## Description:

Fix compilation for gcc used in Core3 that does not apply automatic promotion of 8/16 bit ints to 32 bit ints.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
