### PR TITLE
Update esp8266 Platformio Platform

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
   - [ ] The pull request is done against the latest development branch
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
-  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
+  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
   - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,7 +140,7 @@ lib_ignore                  =
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
-platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2023.04.00/platform-espressif8266.zip
+platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2024.01.00/platform-espressif8266.zip
 platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}


### PR DESCRIPTION
## Description:

- Fix for Python helper Script warning 
- removed ArduinoIDE tool parts in framework
- Updated esptool.py 
- Bump version from 2.7.4.9 to 2.7.5 (no Arduino core code changes)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
