### PR TITLE
Berry `debug.caller`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Berry provide lightweight options for `tasmota.wifi/eth/memory/rtc` (#20448)
 - Berry `tasmota.webcolor` (#20454)
 - Support for pipsolar inverter (#20408)
+- Berry `debug.caller`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_byteslib.c
+++ b/lib/libesp32/berry/src/be_byteslib.c
@@ -1768,6 +1768,7 @@ void be_load_byteslib(bvm *vm)
         { "clear", m_clear },
         { "reverse", m_reverse },
         { "copy", m_copy },
+        { "append", m_connect },
         { "+", m_merge },
         { "..", m_connect },
         { "==", m_equal },
@@ -1815,6 +1816,7 @@ class be_class_bytes (scope: global, name: bytes) {
     clear, func(m_clear)
     reverse, func(m_reverse)
     copy, func(m_copy)
+    append, func(m_connect)
     +, func(m_merge)
     .., func(m_connect)
     ==, func(m_equal)

--- a/lib/libesp32/berry/src/be_debuglib.c
+++ b/lib/libesp32/berry/src/be_debuglib.c
@@ -13,6 +13,7 @@
 #include "be_debug.h"
 #include "be_map.h"
 #include "be_vm.h"
+#include "be_exec.h"
 #include <string.h>
 
 #if BE_USE_DEBUG_MODULE
@@ -101,6 +102,26 @@ static int m_traceback(bvm *vm)
 {
     be_tracestack(vm);
     be_return_nil(vm);
+}
+
+static int m_caller(bvm *vm)
+{
+    int depth = 1;
+    if (be_top(vm) >= 1 && be_isint(vm, 1)) {
+        depth = be_toint(vm, 1);
+        if (depth < 0) {
+            depth = -depth;         /* take absolute value */
+        }
+    }
+    bcallframe *cf = (bcallframe*)be_stack_top(&vm->callstack) - depth;
+    bcallframe *base = be_stack_base(&vm->callstack);
+    if (cf >= base) {
+        bvalue *reg = be_incrtop(vm);
+        var_setval(reg, cf->func);
+        be_return(vm);
+    } else {
+        be_return_nil(vm);
+    }
 }
 
 #if BE_USE_DEBUG_HOOK
@@ -236,6 +257,7 @@ be_native_module_attr_table(debug) {
     be_native_module_function("varname", m_varname),
     be_native_module_function("upvname", m_upvname)
 #endif
+    be_native_module_function("caller", m_caller),
     be_native_module_function("gcdebug", m_gcdebug)
 };
 
@@ -252,6 +274,7 @@ module debug (scope: global, depend: BE_USE_DEBUG_MODULE) {
     top, func(m_top)
     varname, func(m_varname), BE_DEBUG_VAR_INFO
     upvname, func(m_upvname), BE_DEBUG_VAR_INFO
+    caller, func(m_caller)
     // individual counters
     allocs, func(m_allocs)
     frees, func(m_frees)

--- a/lib/libesp32/berry/tests/bytes.be
+++ b/lib/libesp32/berry/tests/bytes.be
@@ -110,10 +110,17 @@ assert(str(b) == "bytes('AA')")
 b = b1 + '01'
 assert(str(b) == "bytes('AA3031')")
 
-#- .. -#
+#- .. and append as synonym-#
 b1 = bytes("1122")
 b2 = bytes("334455")
 b = b1..b2
+assert(str(b1) == "bytes('1122334455')")
+assert(str(b2) == "bytes('334455')")
+assert(str(b) == "bytes('1122334455')")
+#
+b1 = bytes("1122")
+b2 = bytes("334455")
+b = b1.append(b2)
 assert(str(b1) == "bytes('1122334455')")
 assert(str(b2) == "bytes('334455')")
 assert(str(b) == "bytes('1122334455')")
@@ -123,6 +130,12 @@ b1 = bytes("AA")
 b1 .. ''
 assert(str(b1) == "bytes('AA')")
 b1 .. '01'
+assert(str(b1) == "bytes('AA3031')")
+#
+b1 = bytes("AA")
+b1.append('')
+assert(str(b1) == "bytes('AA')")
+b1.append('01')
 assert(str(b1) == "bytes('AA3031')")
 
 #- item -#

--- a/lib/libesp32/berry/tests/debug.be
+++ b/lib/libesp32/berry/tests/debug.be
@@ -2,3 +2,28 @@ import debug
 
 class A end
 debug.attrdump(A)   #- should not crash -#
+
+# debug.caller()
+def caller_name_chain()
+    import debug
+    import introspect
+    var i = 1
+    var ret = []
+    var caller = debug.caller(i)
+    while caller
+        ret.push(introspect.name(caller))
+        i += 1
+        caller = debug.caller(i)
+    end
+    return ret
+end
+var chain = caller_name_chain()
+assert(chain[0] == 'caller_name_chain')
+
+def guess_my_name__()
+    return caller_name_chain()
+end
+chain = guess_my_name__()
+print(chain)
+assert(chain[0] == 'caller_name_chain')
+assert(chain[1] == 'guess_my_name__')


### PR DESCRIPTION
## Description:

Berry add `debug.caller()` to get the functions from the calling hierarchy.

Sync from https://github.com/berry-lang/berry/pull/390

`debug.caller()`with the following semantics:

- `debug.caller(nil) -> function or nil` return current function
- `debug.caller(int) -> function or nil` return the nth caller in chain (default is `1`).

One typical use-case is to get the name of the current function, or the name of the caller function. Note: use `introspect.name()` to get the name of a function.

Example:
```berry
def guess_my_name()
    import debug
    import introspect
    var func = debug.caller()
    var func_name = introspect.name(func)
    print(func_name)
end
guess_my_name()
# prints: guess_my_name
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
