### PR TITLE
LVGL add `lv.str_arr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Berry `debug.caller` (#20470)
 - GPIO Viewer user selection of assets website now defaults to `https://ota.tasmota.com/tasmota|tasmota32/gpio_viewer/assets`
 - Support for HardwareSerial invert (#15461)
+- LVGL add `lv.str_arr`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_introspectlib.c
+++ b/lib/libesp32/berry/src/be_introspectlib.c
@@ -108,7 +108,10 @@ static int m_toptr(bvm *vm)
     int top = be_top(vm);
     if (top >= 1) {
         bvalue *v = be_indexof(vm, 1);
-        if (var_basetype(v) >= BE_FUNCTION || var_type(v) == BE_COMPTR) {
+        if (var_type(v) == BE_STRING) {
+            be_pushcomptr(vm, be_tostring(vm, 1));
+            be_return(vm);
+        } else if (var_basetype(v) >= BE_FUNCTION || var_type(v) == BE_COMPTR) {
             be_pushcomptr(vm, var_toobj(v));
             be_return(vm);
         } else if (var_type(v) == BE_INT) {

--- a/lib/libesp32_lvgl/lv_binding_berry/src/embedded/lvgl_extra.be
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/embedded/lvgl_extra.be
@@ -37,7 +37,6 @@ end
 class lv_point_arr : bytes
   def init(l)
     if type(l) != 'instance' || !isinstance(l, list)  raise "value_error", "argument must be a list" end
-    # size of the array is 2x number of elements
     super(self).init(size(l) * 4)
 
     for e: l
@@ -51,7 +50,6 @@ end
 class lv_style_prop_arr : bytes
   def init(l)
     if type(l) != 'instance' || !isinstance(l, list)  raise "value_error", "argument must be a list" end
-    # size of the array is 2x number of elements
     super(self).init(size(l) * 4)
 
     for e: l
@@ -60,9 +58,23 @@ class lv_style_prop_arr : bytes
   end
 end
 
+class lv_str_arr : bytes
+  var l                         # keep a copy of the list because we want the pointer to strings to remain valid
+  def init(l)
+    self.l = l
+    super(self).init(size(l) * 4)
+
+    import introspect
+    for e: l
+      self.add(int(introspect.toptr(e)), 4)
+    end
+  end
+end
+
 lv_extra.lv_coord_arr = lv_coord_arr
 lv_extra.lv_point_arr = lv_point_arr
 lv_extra.lv_style_prop_arr = lv_style_prop_arr
+lv_extra.lv_str_arr = lv_str_arr
 
 lv_extra.init = def (m)
   import global
@@ -73,6 +85,7 @@ lv_extra.init = def (m)
   lv.coord_arr = m.lv_coord_arr
   lv.point_arr = m.lv_point_arr
   lv.style_prop_arr = m.lv_style_prop_arr
+  lv.str_arr = m.lv_str_arr
 
   return m
 end

--- a/lib/libesp32_lvgl/lv_binding_berry/src/solidify/solidified_lvgl_extra.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/solidify/solidified_lvgl_extra.h
@@ -4,6 +4,194 @@
 \********************************************************************/
 #include "be_constobj.h"
 
+extern const bclass be_class_lv_style_prop_arr;
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(lv_style_prop_arr_init,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(instance),
+    /* K1   */  be_nested_str_weak(value_error),
+    /* K2   */  be_nested_str_weak(argument_X20must_X20be_X20a_X20list),
+    /* K3   */  be_nested_str_weak(init),
+    /* K4   */  be_nested_str_weak(add),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[38]) {  /* code */
+      0x60080004,  //  0000  GETGBL	R2	G4
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x20080500,  //  0003  NE	R2	R2	K0
+      0x740A0004,  //  0004  JMPT	R2	#000A
+      0x6008000F,  //  0005  GETGBL	R2	G15
+      0x5C0C0200,  //  0006  MOVE	R3	R1
+      0x60100012,  //  0007  GETGBL	R4	G18
+      0x7C080400,  //  0008  CALL	R2	2
+      0x740A0000,  //  0009  JMPT	R2	#000B
+      0xB0060302,  //  000A  RAISE	1	K1	K2
+      0x60080003,  //  000B  GETGBL	R2	G3
+      0x5C0C0000,  //  000C  MOVE	R3	R0
+      0x7C080200,  //  000D  CALL	R2	1
+      0x8C080503,  //  000E  GETMET	R2	R2	K3
+      0x6010000C,  //  000F  GETGBL	R4	G12
+      0x5C140200,  //  0010  MOVE	R5	R1
+      0x7C100200,  //  0011  CALL	R4	1
+      0x54160003,  //  0012  LDINT	R5	4
+      0x08100805,  //  0013  MUL	R4	R4	R5
+      0x7C080400,  //  0014  CALL	R2	2
+      0x60080010,  //  0015  GETGBL	R2	G16
+      0x5C0C0200,  //  0016  MOVE	R3	R1
+      0x7C080200,  //  0017  CALL	R2	1
+      0xA8020008,  //  0018  EXBLK	0	#0022
+      0x5C0C0400,  //  0019  MOVE	R3	R2
+      0x7C0C0000,  //  001A  CALL	R3	0
+      0x8C100104,  //  001B  GETMET	R4	R0	K4
+      0x60180009,  //  001C  GETGBL	R6	G9
+      0x5C1C0600,  //  001D  MOVE	R7	R3
+      0x7C180200,  //  001E  CALL	R6	1
+      0x541E0003,  //  001F  LDINT	R7	4
+      0x7C100600,  //  0020  CALL	R4	3
+      0x7001FFF6,  //  0021  JMP		#0019
+      0x58080005,  //  0022  LDCONST	R2	K5
+      0xAC080200,  //  0023  CATCH	R2	1	0
+      0xB0080000,  //  0024  RAISE	2	R0	R0
+      0x80000000,  //  0025  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: lv_style_prop_arr
+********************************************************************/
+extern const bclass be_class_bytes;
+be_local_class(lv_style_prop_arr,
+    0,
+    &be_class_bytes,
+    be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(init, -1), be_const_closure(lv_style_prop_arr_init_closure) },
+    })),
+    be_str_weak(lv_style_prop_arr)
+);
+
+extern const bclass be_class_lv_point_arr;
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(lv_point_arr_init,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(instance),
+    /* K1   */  be_nested_str_weak(value_error),
+    /* K2   */  be_nested_str_weak(argument_X20must_X20be_X20a_X20list),
+    /* K3   */  be_nested_str_weak(init),
+    /* K4   */  be_nested_str_weak(lv),
+    /* K5   */  be_nested_str_weak(lv_point),
+    /* K6   */  be_nested_str_weak(elements_X20must_X20be_X20a_X20lv_point),
+    /* K7   */  be_nested_str_weak(add),
+    /* K8   */  be_nested_str_weak(x),
+    /* K9   */  be_const_int(2),
+    /* K10  */  be_nested_str_weak(y),
+    /* K11  */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[52]) {  /* code */
+      0x60080004,  //  0000  GETGBL	R2	G4
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x20080500,  //  0003  NE	R2	R2	K0
+      0x740A0004,  //  0004  JMPT	R2	#000A
+      0x6008000F,  //  0005  GETGBL	R2	G15
+      0x5C0C0200,  //  0006  MOVE	R3	R1
+      0x60100012,  //  0007  GETGBL	R4	G18
+      0x7C080400,  //  0008  CALL	R2	2
+      0x740A0000,  //  0009  JMPT	R2	#000B
+      0xB0060302,  //  000A  RAISE	1	K1	K2
+      0x60080003,  //  000B  GETGBL	R2	G3
+      0x5C0C0000,  //  000C  MOVE	R3	R0
+      0x7C080200,  //  000D  CALL	R2	1
+      0x8C080503,  //  000E  GETMET	R2	R2	K3
+      0x6010000C,  //  000F  GETGBL	R4	G12
+      0x5C140200,  //  0010  MOVE	R5	R1
+      0x7C100200,  //  0011  CALL	R4	1
+      0x54160003,  //  0012  LDINT	R5	4
+      0x08100805,  //  0013  MUL	R4	R4	R5
+      0x7C080400,  //  0014  CALL	R2	2
+      0x60080010,  //  0015  GETGBL	R2	G16
+      0x5C0C0200,  //  0016  MOVE	R3	R1
+      0x7C080200,  //  0017  CALL	R2	1
+      0xA8020016,  //  0018  EXBLK	0	#0030
+      0x5C0C0400,  //  0019  MOVE	R3	R2
+      0x7C0C0000,  //  001A  CALL	R3	0
+      0x60100004,  //  001B  GETGBL	R4	G4
+      0x5C140600,  //  001C  MOVE	R5	R3
+      0x7C100200,  //  001D  CALL	R4	1
+      0x20100900,  //  001E  NE	R4	R4	K0
+      0x74120005,  //  001F  JMPT	R4	#0026
+      0x6010000F,  //  0020  GETGBL	R4	G15
+      0x5C140600,  //  0021  MOVE	R5	R3
+      0xB81A0800,  //  0022  GETNGBL	R6	K4
+      0x88180D05,  //  0023  GETMBR	R6	R6	K5
+      0x7C100400,  //  0024  CALL	R4	2
+      0x74120000,  //  0025  JMPT	R4	#0027
+      0xB0060306,  //  0026  RAISE	1	K1	K6
+      0x8C100107,  //  0027  GETMET	R4	R0	K7
+      0x88180708,  //  0028  GETMBR	R6	R3	K8
+      0x581C0009,  //  0029  LDCONST	R7	K9
+      0x7C100600,  //  002A  CALL	R4	3
+      0x8C100107,  //  002B  GETMET	R4	R0	K7
+      0x8818070A,  //  002C  GETMBR	R6	R3	K10
+      0x581C0009,  //  002D  LDCONST	R7	K9
+      0x7C100600,  //  002E  CALL	R4	3
+      0x7001FFE8,  //  002F  JMP		#0019
+      0x5808000B,  //  0030  LDCONST	R2	K11
+      0xAC080200,  //  0031  CATCH	R2	1	0
+      0xB0080000,  //  0032  RAISE	2	R0	R0
+      0x80000000,  //  0033  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: lv_point_arr
+********************************************************************/
+extern const bclass be_class_bytes;
+be_local_class(lv_point_arr,
+    0,
+    &be_class_bytes,
+    be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(init, -1), be_const_closure(lv_point_arr_init_closure) },
+    })),
+    be_str_weak(lv_point_arr)
+);
+
 /********************************************************************
 ** Solidified function: _anonymous_
 ********************************************************************/
@@ -17,7 +205,7 @@ be_local_closure(lv_extra__anonymous_,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
+    ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(global),
     /* K1   */  be_nested_str_weak(lv),
     /* K2   */  be_nested_str_weak(lv_coord_arr),
@@ -26,10 +214,12 @@ be_local_closure(lv_extra__anonymous_,   /* name */
     /* K5   */  be_nested_str_weak(point_arr),
     /* K6   */  be_nested_str_weak(style_prop_arr),
     /* K7   */  be_nested_str_weak(lv_style_prop_arr),
+    /* K8   */  be_nested_str_weak(str_arr),
+    /* K9   */  be_nested_str_weak(lv_str_arr),
     }),
     be_str_weak(_anonymous_),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
+    ( &(const binstruction[15]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x88080301,  //  0001  GETMBR	R2	R1	K1
       0x880C0102,  //  0002  GETMBR	R3	R0	K2
@@ -42,7 +232,9 @@ be_local_closure(lv_extra__anonymous_,   /* name */
       0x900A0A03,  //  0009  SETMBR	R2	K5	R3
       0x880C0107,  //  000A  GETMBR	R3	R0	K7
       0x900A0C03,  //  000B  SETMBR	R2	K6	R3
-      0x80040000,  //  000C  RET	1	R0
+      0x880C0109,  //  000C  GETMBR	R3	R0	K9
+      0x900A1003,  //  000D  SETMBR	R2	K8	R3
+      0x80040000,  //  000E  RET	1	R0
     })
   )
 );
@@ -219,118 +411,14 @@ be_local_class(lv_coord_arr,
     be_str_weak(lv_coord_arr)
 );
 
-extern const bclass be_class_lv_point_arr;
+extern const bclass be_class_lv_str_arr;
 
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-be_local_closure(lv_point_arr_init,   /* name */
+be_local_closure(lv_str_arr_init,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(instance),
-    /* K1   */  be_nested_str_weak(value_error),
-    /* K2   */  be_nested_str_weak(argument_X20must_X20be_X20a_X20list),
-    /* K3   */  be_nested_str_weak(init),
-    /* K4   */  be_nested_str_weak(lv),
-    /* K5   */  be_nested_str_weak(lv_point),
-    /* K6   */  be_nested_str_weak(elements_X20must_X20be_X20a_X20lv_point),
-    /* K7   */  be_nested_str_weak(add),
-    /* K8   */  be_nested_str_weak(x),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_nested_str_weak(y),
-    /* K11  */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[52]) {  /* code */
-      0x60080004,  //  0000  GETGBL	R2	G4
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x20080500,  //  0003  NE	R2	R2	K0
-      0x740A0004,  //  0004  JMPT	R2	#000A
-      0x6008000F,  //  0005  GETGBL	R2	G15
-      0x5C0C0200,  //  0006  MOVE	R3	R1
-      0x60100012,  //  0007  GETGBL	R4	G18
-      0x7C080400,  //  0008  CALL	R2	2
-      0x740A0000,  //  0009  JMPT	R2	#000B
-      0xB0060302,  //  000A  RAISE	1	K1	K2
-      0x60080003,  //  000B  GETGBL	R2	G3
-      0x5C0C0000,  //  000C  MOVE	R3	R0
-      0x7C080200,  //  000D  CALL	R2	1
-      0x8C080503,  //  000E  GETMET	R2	R2	K3
-      0x6010000C,  //  000F  GETGBL	R4	G12
-      0x5C140200,  //  0010  MOVE	R5	R1
-      0x7C100200,  //  0011  CALL	R4	1
-      0x54160003,  //  0012  LDINT	R5	4
-      0x08100805,  //  0013  MUL	R4	R4	R5
-      0x7C080400,  //  0014  CALL	R2	2
-      0x60080010,  //  0015  GETGBL	R2	G16
-      0x5C0C0200,  //  0016  MOVE	R3	R1
-      0x7C080200,  //  0017  CALL	R2	1
-      0xA8020016,  //  0018  EXBLK	0	#0030
-      0x5C0C0400,  //  0019  MOVE	R3	R2
-      0x7C0C0000,  //  001A  CALL	R3	0
-      0x60100004,  //  001B  GETGBL	R4	G4
-      0x5C140600,  //  001C  MOVE	R5	R3
-      0x7C100200,  //  001D  CALL	R4	1
-      0x20100900,  //  001E  NE	R4	R4	K0
-      0x74120005,  //  001F  JMPT	R4	#0026
-      0x6010000F,  //  0020  GETGBL	R4	G15
-      0x5C140600,  //  0021  MOVE	R5	R3
-      0xB81A0800,  //  0022  GETNGBL	R6	K4
-      0x88180D05,  //  0023  GETMBR	R6	R6	K5
-      0x7C100400,  //  0024  CALL	R4	2
-      0x74120000,  //  0025  JMPT	R4	#0027
-      0xB0060306,  //  0026  RAISE	1	K1	K6
-      0x8C100107,  //  0027  GETMET	R4	R0	K7
-      0x88180708,  //  0028  GETMBR	R6	R3	K8
-      0x581C0009,  //  0029  LDCONST	R7	K9
-      0x7C100600,  //  002A  CALL	R4	3
-      0x8C100107,  //  002B  GETMET	R4	R0	K7
-      0x8818070A,  //  002C  GETMBR	R6	R3	K10
-      0x581C0009,  //  002D  LDCONST	R7	K9
-      0x7C100600,  //  002E  CALL	R4	3
-      0x7001FFE8,  //  002F  JMP		#0019
-      0x5808000B,  //  0030  LDCONST	R2	K11
-      0xAC080200,  //  0031  CATCH	R2	1	0
-      0xB0080000,  //  0032  RAISE	2	R0	R0
-      0x80000000,  //  0033  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified class: lv_point_arr
-********************************************************************/
-extern const bclass be_class_bytes;
-be_local_class(lv_point_arr,
-    0,
-    &be_class_bytes,
-    be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(init, -1), be_const_closure(lv_point_arr_init_closure) },
-    })),
-    be_str_weak(lv_point_arr)
-);
-
-extern const bclass be_class_lv_style_prop_arr;
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(lv_style_prop_arr_init,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
+    11,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -339,54 +427,47 @@ be_local_closure(lv_style_prop_arr_init,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(instance),
-    /* K1   */  be_nested_str_weak(value_error),
-    /* K2   */  be_nested_str_weak(argument_X20must_X20be_X20a_X20list),
-    /* K3   */  be_nested_str_weak(init),
-    /* K4   */  be_nested_str_weak(add),
+    /* K0   */  be_nested_str_weak(l),
+    /* K1   */  be_nested_str_weak(init),
+    /* K2   */  be_nested_str_weak(introspect),
+    /* K3   */  be_nested_str_weak(add),
+    /* K4   */  be_nested_str_weak(toptr),
     /* K5   */  be_nested_str_weak(stop_iteration),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[38]) {  /* code */
-      0x60080004,  //  0000  GETGBL	R2	G4
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x20080500,  //  0003  NE	R2	R2	K0
-      0x740A0004,  //  0004  JMPT	R2	#000A
-      0x6008000F,  //  0005  GETGBL	R2	G15
-      0x5C0C0200,  //  0006  MOVE	R3	R1
-      0x60100012,  //  0007  GETGBL	R4	G18
-      0x7C080400,  //  0008  CALL	R2	2
-      0x740A0000,  //  0009  JMPT	R2	#000B
-      0xB0060302,  //  000A  RAISE	1	K1	K2
-      0x60080003,  //  000B  GETGBL	R2	G3
-      0x5C0C0000,  //  000C  MOVE	R3	R0
-      0x7C080200,  //  000D  CALL	R2	1
-      0x8C080503,  //  000E  GETMET	R2	R2	K3
-      0x6010000C,  //  000F  GETGBL	R4	G12
-      0x5C140200,  //  0010  MOVE	R5	R1
-      0x7C100200,  //  0011  CALL	R4	1
-      0x54160003,  //  0012  LDINT	R5	4
-      0x08100805,  //  0013  MUL	R4	R4	R5
-      0x7C080400,  //  0014  CALL	R2	2
-      0x60080010,  //  0015  GETGBL	R2	G16
-      0x5C0C0200,  //  0016  MOVE	R3	R1
-      0x7C080200,  //  0017  CALL	R2	1
-      0xA8020008,  //  0018  EXBLK	0	#0022
-      0x5C0C0400,  //  0019  MOVE	R3	R2
-      0x7C0C0000,  //  001A  CALL	R3	0
-      0x8C100104,  //  001B  GETMET	R4	R0	K4
-      0x60180009,  //  001C  GETGBL	R6	G9
-      0x5C1C0600,  //  001D  MOVE	R7	R3
-      0x7C180200,  //  001E  CALL	R6	1
-      0x541E0003,  //  001F  LDINT	R7	4
-      0x7C100600,  //  0020  CALL	R4	3
-      0x7001FFF6,  //  0021  JMP		#0019
-      0x58080005,  //  0022  LDCONST	R2	K5
-      0xAC080200,  //  0023  CATCH	R2	1	0
-      0xB0080000,  //  0024  RAISE	2	R0	R0
-      0x80000000,  //  0025  RET	0
+    ( &(const binstruction[31]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x60080003,  //  0001  GETGBL	R2	G3
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C080200,  //  0003  CALL	R2	1
+      0x8C080501,  //  0004  GETMET	R2	R2	K1
+      0x6010000C,  //  0005  GETGBL	R4	G12
+      0x5C140200,  //  0006  MOVE	R5	R1
+      0x7C100200,  //  0007  CALL	R4	1
+      0x54160003,  //  0008  LDINT	R5	4
+      0x08100805,  //  0009  MUL	R4	R4	R5
+      0x7C080400,  //  000A  CALL	R2	2
+      0xA40A0400,  //  000B  IMPORT	R2	K2
+      0x600C0010,  //  000C  GETGBL	R3	G16
+      0x5C100200,  //  000D  MOVE	R4	R1
+      0x7C0C0200,  //  000E  CALL	R3	1
+      0xA802000A,  //  000F  EXBLK	0	#001B
+      0x5C100600,  //  0010  MOVE	R4	R3
+      0x7C100000,  //  0011  CALL	R4	0
+      0x8C140103,  //  0012  GETMET	R5	R0	K3
+      0x601C0009,  //  0013  GETGBL	R7	G9
+      0x8C200504,  //  0014  GETMET	R8	R2	K4
+      0x5C280800,  //  0015  MOVE	R10	R4
+      0x7C200400,  //  0016  CALL	R8	2
+      0x7C1C0200,  //  0017  CALL	R7	1
+      0x54220003,  //  0018  LDINT	R8	4
+      0x7C140600,  //  0019  CALL	R5	3
+      0x7001FFF4,  //  001A  JMP		#0010
+      0x580C0005,  //  001B  LDCONST	R3	K5
+      0xAC0C0200,  //  001C  CATCH	R3	1	0
+      0xB0080000,  //  001D  RAISE	2	R0	R0
+      0x80000000,  //  001E  RET	0
     })
   )
 );
@@ -394,17 +475,18 @@ be_local_closure(lv_style_prop_arr_init,   /* name */
 
 
 /********************************************************************
-** Solidified class: lv_style_prop_arr
+** Solidified class: lv_str_arr
 ********************************************************************/
 extern const bclass be_class_bytes;
-be_local_class(lv_style_prop_arr,
-    0,
+be_local_class(lv_str_arr,
+    1,
     &be_class_bytes,
-    be_nested_map(1,
+    be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(init, -1), be_const_closure(lv_style_prop_arr_init_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(lv_str_arr_init_closure) },
+        { be_const_key_weak(l, 0), be_const_var(0) },
     })),
-    be_str_weak(lv_style_prop_arr)
+    be_str_weak(lv_str_arr)
 );
 
 /********************************************************************
@@ -412,12 +494,13 @@ be_local_class(lv_style_prop_arr,
 ********************************************************************/
 be_local_module(lv_extra,
     "lv_extra",
-    be_nested_map(4,
+    be_nested_map(5,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(lv_style_prop_arr, -1), be_const_class(be_class_lv_style_prop_arr) },
+        { be_const_key_weak(init, -1), be_const_closure(lv_extra__anonymous__closure) },
         { be_const_key_weak(lv_coord_arr, -1), be_const_class(be_class_lv_coord_arr) },
+        { be_const_key_weak(lv_str_arr, -1), be_const_class(be_class_lv_str_arr) },
         { be_const_key_weak(lv_point_arr, -1), be_const_class(be_class_lv_point_arr) },
-        { be_const_key_weak(init, 0), be_const_closure(lv_extra__anonymous__closure) },
+        { be_const_key_weak(lv_style_prop_arr, 2), be_const_class(be_class_lv_style_prop_arr) },
     }))
 );
 BE_EXPORT_VARIABLE be_define_const_native_module(lv_extra);


### PR DESCRIPTION
## Description:

Add missing `lv.str_arr` class used by `lv_btnmatrix_set_map` and `lv_msgbox_create`.

Example:
```berry
var  btns = lv.str_arr(["Apply", "Close", ""])
var mbox1 = lv.msgbox(haspmota.scr, "Test", "Test1", btns, true)
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
