### PR TITLE
fix display dimmer

### DIFF
--- a/lib/lib_display/Xlatb_RA8876-gemu-1.0/RA8876.cpp
+++ b/lib/lib_display/Xlatb_RA8876-gemu-1.0/RA8876.cpp
@@ -193,6 +193,10 @@ void RA8876::DisplayOnff(int8_t on) {
   }
 }
 
+void RA8876::dim10(uint8_t contrast, uint16_t contrast_gamma) {
+  dim(contrast / 16); 
+}
+
 // 0-15
 void RA8876::dim(uint8_t contrast) {
   SPI.beginTransaction(m_spiSettings);

--- a/lib/lib_display/Xlatb_RA8876-gemu-1.0/RA8876.h
+++ b/lib/lib_display/Xlatb_RA8876-gemu-1.0/RA8876.h
@@ -26,6 +26,8 @@
 #include "driver/spi_master.h"
 #endif
 
+#include "tasmota_options.h"
+
 #undef SPRINT
 #define SPRINT(A) {char str[32];sprintf(str,"val: %d ",A);Serial.println((char*)str);}
 
@@ -147,10 +149,14 @@ enum ExternalFontFamily
 typedef uint8_t FontFlags;
 #define RA8876_FONT_FLAG_XLAT_FULLWIDTH 0x01  // Translate ASCII to Unicode fullwidth forms
 
+
+#ifndef RA8876_SPI_SPEED
 // 1MHz. TODO: Figure out actual speed to use
 // Data sheet section 5.2 says maximum SPI clock is 50MHz.
 //#define RA8876_SPI_SPEED 10000000
-#define RA8876_SPI_SPEED 25000000
+//#define RA8876_SPI_SPEED 25000000
+#define RA8876_SPI_SPEED 40000000
+#endif
 
 // With SPI, the RA8876 expects an initial byte where the top two bits are meaningful. Bit 7
 // is A0, bit 6 is WR#. See data sheet section 7.3.2 and section 19.
@@ -501,6 +507,7 @@ class RA8876 : public Renderer {
   void setDrawMode(uint8_t mode);
   void setDrawMode_reg(uint8_t mode);
   void dim(uint8_t contrast);
+  void dim10(uint8_t contrast, uint16_t contrast_gamma);
   void FastString(uint16_t x,uint16_t y,uint16_t tcolor, const char* str);
 
  private:


### PR DESCRIPTION
## Description:

fixes display dimmer for this display

btw this is the largest Tasmota LVGL capable display  1024x600 10 inch

https://www.buydisplay.com/serial-spi-i2c-10-1-inch-tft-lcd-module-dislay-w-ra8876-optl-touch-panel

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
