### PR TITLE
Universal touch driver

### DIFF
--- a/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.cpp
+++ b/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.cpp
@@ -623,6 +623,22 @@ int8_t Renderer::color_type(void) {
  return 0;
 }
 
+bool Renderer::utouch_Init(char **name) {
+  return false;
+}
+
+bool Renderer::touched(void) {
+  return false;
+}
+
+int16_t Renderer::getPoint_x(void) {
+  return 0;
+}
+
+int16_t Renderer::getPoint_y(void) {
+  return 0;
+}
+
 void Renderer::Splash(void) {
 
 }

--- a/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
+++ b/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
@@ -92,6 +92,10 @@ public:
   virtual void ep_update_mode(uint8_t mode);
   virtual void ep_update_area(uint16_t xp, uint16_t yp, uint16_t width, uint16_t height, uint8_t mode);
   virtual uint32_t get_sr_touch(uint32_t xp, uint32_t xm, uint32_t yp, uint32_t ym);
+  virtual bool utouch_Init(char **);
+  virtual bool touched(void);
+  virtual int16_t getPoint_x();
+  virtual int16_t getPoint_y();
 
   void setDrawMode(uint8_t mode);
   uint8_t drawmode;

--- a/lib/lib_display/UDisplay/uDisplay.h
+++ b/lib/lib_display/UDisplay/uDisplay.h
@@ -101,6 +101,9 @@ enum uColorType { uCOLOR_BW, uCOLOR_COLOR };
 #define GPIO_SET(A) GPIO.out_w1ts = (1 << A)
 #endif
 
+enum {
+  UT_RD,UT_RDM,UT_CP,UT_RTF,UT_MV,UT_RT,UT_RTT,UT_RDW,UT_RDWM,UT_WR,UT_WRW,UT_CPR,UT_AND,UT_DBG,UT_END
+};
 
 #define GPIO_CLR_SLOW(A) digitalWrite(A, LOW)
 #define GPIO_SET_SLOW(A) digitalWrite(A, HIGH)
@@ -423,7 +426,7 @@ class uDisplay : public Renderer {
 // universal touch driver
   void ut_trans(char **sp, uint8_t *ut_code);
   int16_t ut_execute(uint8_t *ut_code);
-  uint8_t ut_par(char **cp, uint32_t mode);
+  uint16_t ut_par(char **cp, uint32_t mode);
   uint32_t ut_result;
   uint8_t ut_array[16];
   uint8_t ut_r1; 
@@ -433,7 +436,7 @@ class uDisplay : public Renderer {
   int8_t ut_irq;
   char ut_name[8];
   uint8_t ut_init_code[32];
-  uint8_t ut_touch_code[16];
+  uint8_t ut_touch_code[32];
   uint8_t ut_getx_code[16];
   uint8_t ut_gety_code[16];
 

--- a/lib/lib_display/UDisplay/uDisplay.h
+++ b/lib/lib_display/UDisplay/uDisplay.h
@@ -102,8 +102,14 @@ enum uColorType { uCOLOR_BW, uCOLOR_COLOR };
 #endif
 
 enum {
-  UT_RD,UT_RDM,UT_CP,UT_RTF,UT_MV,UT_RT,UT_RTT,UT_RDW,UT_RDWM,UT_WR,UT_WRW,UT_CPR,UT_AND,UT_DBG,UT_END
+  UT_RD,UT_RDM,UT_CP,UT_RTF,UT_MV,UT_RT,UT_RTT,UT_RDW,UT_RDWM,UT_WR,UT_WRW,UT_CPR,UT_AND,UT_DBG,UT_GSRT,UT_END
 };
+
+#define SIMPLERS_XP par_dbl[1]
+#define SIMPLERS_XM par_cs
+#define SIMPLERS_YP par_rs
+#define SIMPLERS_YM par_dbl[0]
+
 
 #define GPIO_CLR_SLOW(A) digitalWrite(A, LOW)
 #define GPIO_SET_SLOW(A) digitalWrite(A, HIGH)

--- a/lib/lib_display/UDisplay/uDisplay.h
+++ b/lib/lib_display/UDisplay/uDisplay.h
@@ -190,6 +190,13 @@ class uDisplay : public Renderer {
   void invertDisplay(boolean i);
   void SetPwrCB(pwr_cb cb) { pwr_cbp = cb; };
   void SetDimCB(dim_cb cb) { dim_cbp = cb; };
+#ifdef USE_UNIVERSAL_TOUCH
+// universal touch driver
+  bool utouch_Init(char **name);
+  bool touched(void);
+  int16_t getPoint_x();
+  int16_t getPoint_y();
+#endif // USE_UNIVERSAL_TOUCH
 
  private:
    void beginTransaction(SPISettings s);
@@ -411,6 +418,26 @@ class uDisplay : public Renderer {
    void pushPixelsDMA(uint16_t* image, uint32_t len);
    void pushPixels3DMA(uint8_t* image, uint32_t len);
 #endif // ESP32
+
+#ifdef USE_UNIVERSAL_TOUCH
+// universal touch driver
+  void ut_trans(char **sp, uint8_t *ut_code);
+  int16_t ut_execute(uint8_t *ut_code);
+  uint8_t ut_par(char **cp, uint32_t mode);
+  uint32_t ut_result;
+  uint8_t ut_array[16];
+  uint8_t ut_r1; 
+  uint8_t ut_mode;
+  uint8_t ut_i2caddr;
+  int8_t ut_reset;
+  int8_t ut_irq;
+  char ut_name[8];
+  uint8_t ut_init_code[32];
+  uint8_t ut_touch_code[16];
+  uint8_t ut_getx_code[16];
+  uint8_t ut_gety_code[16];
+
+#endif // USE_UNIVERSAL_TOUCH
 };
 
 

--- a/lib/lib_display/UDisplay/uDisplay.h
+++ b/lib/lib_display/UDisplay/uDisplay.h
@@ -424,16 +424,19 @@ class uDisplay : public Renderer {
 
 #ifdef USE_UNIVERSAL_TOUCH
 // universal touch driver
-  void ut_trans(char **sp, uint8_t *ut_code);
+  void ut_trans(char **sp, uint8_t *ut_code, int32_t size);
   int16_t ut_execute(uint8_t *ut_code);
   uint16_t ut_par(char **cp, uint32_t mode);
+  uint8_t *ut_rd(uint8_t *io, uint32_t len, uint32_t amode);
+  uint8_t *ut_wr(uint8_t *io, uint32_t amode);
   uint32_t ut_result;
   uint8_t ut_array[16];
-  uint8_t ut_r1; 
-  uint8_t ut_mode;
   uint8_t ut_i2caddr;
+  uint8_t ut_spi_cs;
   int8_t ut_reset;
   int8_t ut_irq;
+  TwoWire *ut_wire;
+  SPISettings ut_spiSettings;
   char ut_name[8];
   uint8_t ut_init_code[32];
   uint8_t ut_touch_code[32];

--- a/tasmota/tasmota_xdrv_driver/xdrv_10_scripter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_scripter.ino
@@ -5875,7 +5875,7 @@ extern char *SML_GetSVal(uint32_t index);
           goto exit;
         }
 #endif // USE_TTGO_WATCH
-#if defined(USE_FT5206) || defined(USE_XPT2046) || defined(USE_LILYGO47) || defined(USE_GT911)
+#if defined(USE_FT5206) || defined(USE_XPT2046) || defined(USE_LILYGO47) || defined(USE_UNIVERSAL_TOUCH) || defined(USE_GT911)
         if (!strncmp_XP(lp, XPSTR("wtch("), 5)) {
           lp = GetNumericArgument(lp + 5, OPER_EQU, &fvar, gv);
           fvar = Touch_Status(fvar);

--- a/tasmota/tasmota_xdsp_display/xdsp_17_universal.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_17_universal.ino
@@ -374,6 +374,7 @@ int8_t cs;
 #endif // ESP8266
 
       // start digitizer
+
 #ifdef ESP32
       if (i2caddr == GT911_address) {
 #ifdef USE_GT911
@@ -468,13 +469,18 @@ int8_t cs;
     Settings->display_width = renderer->width();
     Settings->display_height = renderer->height();
 
+#ifdef USE_UNIVERSAL_TOUCH
+    utouch_Touch_Init();
+#endif
+
     bool iniinv = Settings->display_options.invert;
+    /*
     cp = strstr(ddesc, ":n,");
     if (cp) {
       cp+=3;
       iniinv = strtol(cp, &cp, 10);
       Settings->display_options.invert = iniinv;
-    }
+    }*/
     renderer->invertDisplay(iniinv);
 
     ApplyDisplayDimmer();


### PR DESCRIPTION
## Description:

adds universal touch driver. (initial release) currently supports FTx drivers and in theory also CST816S

code adds to display.ini file,

example

```
:H,ILI9342,320,240,16,SPI,1,5,18,23,15,-1,-1,38,40
:S,2,1,3,0,100,100
:B,60,0
:I
EF,3,03,80,02
CF,3,00,C1,30
ED,4,64,03,12,81
E8,3,85,00,78
CB,5,39,2C,00,34,02
F7,1,20
EA,2,00,00
C0,1,23
C1,1,10
C5,2,3e,28
C7,1,86
36,1,48
37,1,00
3A,1,55
B1,2,00,18
B6,3,08,82,27
F2,1,00
26,1,01
E0,0F,0F,31,2B,0C,0E,08,4E,F1,37,07,10,03,0E,09,00
E1,0F,00,0E,14,03,11,07,31,C1,48,08,0F,0C,31,36,0F
21,80
11,80
29,80
:o,28
:O,29
:A,2A,2B,2C,16
:R,36
:0,08,00,00,00
:1,A8,00,00,84
:2,C8,00,00,02
:3,68,00,00,85
:i,21,20
:UTI,FT5206,I2,38,-1,-1
RD A8
CP 11
RTF
RD A3
CP 64
RTF
RT
:UTT
RDM 00 16
MV 2 1
RT
:UTX
MV 3 2
RT
:UTY
MV 5 2
RT
#
```

EDIT.  
I2C and resitive touch is ready and tested.  
waiting for a display board with XPT2046 to better check SPI modes. 


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
