### PR TITLE
LVGL option to add `lv.keyboard` extra widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - SML support for IM350 (#20474)
 - LVGL `lv.str_arr` (#20480)
 - ESP32 MI BLE support for Xiaomi LYWSD02MMC (#20381)
+- LVGL option to add `lv.keyboard` extra widget
 
 ### Breaking Changed
 

--- a/lib/libesp32_lvgl/lv_binding_berry/generate/be_lv_c_mapping.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/generate/be_lv_c_mapping.h
@@ -656,6 +656,42 @@ const be_ntv_func_def_t lv_imgbtn_func[] = {
 };
 #endif // BE_LV_WIDGET_IMGBTN
 
+/* `lv_keyboard` methods */
+#ifdef BE_LV_WIDGET_KEYBOARD
+const be_ntv_func_def_t lv_keyboard_func[] = {
+  { "get_btn_text", { (const void*) &lv_keyboard_get_btn_text, "s", "(lv.lv_obj)i" } },
+  { "get_map_array", { (const void*) &lv_keyboard_get_map_array, "c", "(lv.lv_obj)" } },
+  { "get_mode", { (const void*) &lv_keyboard_get_mode, "i", "(lv.lv_obj)" } },
+  { "get_selected_btn", { (const void*) &lv_keyboard_get_selected_btn, "i", "(lv.lv_obj)" } },
+  { "get_textarea", { (const void*) &lv_keyboard_get_textarea, "lv.lv_obj", "(lv.lv_obj)" } },
+  { "set_map", { (const void*) &lv_keyboard_set_map, "", "(lv.lv_obj)i(lv.str_arr)(lv.lv_btnmatrix_ctrl)" } },
+  { "set_mode", { (const void*) &lv_keyboard_set_mode, "", "(lv.lv_obj)i" } },
+  { "set_popovers", { (const void*) &lv_keyboard_set_popovers, "", "(lv.lv_obj)b" } },
+  { "set_textarea", { (const void*) &lv_keyboard_set_textarea, "", "(lv.lv_obj)(lv.lv_obj)" } },
+};
+#endif // BE_LV_WIDGET_KEYBOARD
+
+/* `lv_btnmatrix` methods */
+#ifdef BE_LV_WIDGET_BTNMATRIX
+const be_ntv_func_def_t lv_btnmatrix_func[] = {
+  { "clear_btn_ctrl", { (const void*) &lv_btnmatrix_clear_btn_ctrl, "", "(lv.lv_obj)ii" } },
+  { "clear_btn_ctrl_all", { (const void*) &lv_btnmatrix_clear_btn_ctrl_all, "", "(lv.lv_obj)i" } },
+  { "get_btn_text", { (const void*) &lv_btnmatrix_get_btn_text, "s", "(lv.lv_obj)i" } },
+  { "get_map", { (const void*) &lv_btnmatrix_get_map, "c", "(lv.lv_obj)" } },
+  { "get_one_checked", { (const void*) &lv_btnmatrix_get_one_checked, "b", "(lv.lv_obj)" } },
+  { "get_popovers", { (const void*) &lv_btnmatrix_get_popovers, "b", "(lv.lv_obj)" } },
+  { "get_selected_btn", { (const void*) &lv_btnmatrix_get_selected_btn, "i", "(lv.lv_obj)" } },
+  { "has_btn_ctrl", { (const void*) &lv_btnmatrix_has_btn_ctrl, "b", "(lv.lv_obj)ii" } },
+  { "set_btn_ctrl", { (const void*) &lv_btnmatrix_set_btn_ctrl, "", "(lv.lv_obj)ii" } },
+  { "set_btn_ctrl_all", { (const void*) &lv_btnmatrix_set_btn_ctrl_all, "", "(lv.lv_obj)i" } },
+  { "set_btn_width", { (const void*) &lv_btnmatrix_set_btn_width, "", "(lv.lv_obj)ii" } },
+  { "set_ctrl_map", { (const void*) &lv_btnmatrix_set_ctrl_map, "", "(lv.lv_obj)(lv.lv_btnmatrix_ctrl)" } },
+  { "set_map", { (const void*) &lv_btnmatrix_set_map, "", "(lv.lv_obj)(lv.str_arr)" } },
+  { "set_one_checked", { (const void*) &lv_btnmatrix_set_one_checked, "", "(lv.lv_obj)b" } },
+  { "set_selected_btn", { (const void*) &lv_btnmatrix_set_selected_btn, "", "(lv.lv_obj)i" } },
+};
+#endif // BE_LV_WIDGET_BTNMATRIX
+
 /* `lv_led` methods */
 #ifdef BE_LV_WIDGET_LED
 const be_ntv_func_def_t lv_led_func[] = {
@@ -814,26 +850,6 @@ const be_ntv_func_def_t lv_bar_func[] = {
 const be_ntv_func_def_t lv_btn_func[] = {
 };
 #endif // BE_LV_WIDGET_BTN
-
-/* `lv_btnmatrix` methods */
-#ifdef BE_LV_WIDGET_BTNMATRIX
-const be_ntv_func_def_t lv_btnmatrix_func[] = {
-  { "clear_btn_ctrl", { (const void*) &lv_btnmatrix_clear_btn_ctrl, "", "(lv.lv_obj)ii" } },
-  { "clear_btn_ctrl_all", { (const void*) &lv_btnmatrix_clear_btn_ctrl_all, "", "(lv.lv_obj)i" } },
-  { "get_btn_text", { (const void*) &lv_btnmatrix_get_btn_text, "s", "(lv.lv_obj)i" } },
-  { "get_map", { (const void*) &lv_btnmatrix_get_map, "c", "(lv.lv_obj)" } },
-  { "get_one_checked", { (const void*) &lv_btnmatrix_get_one_checked, "b", "(lv.lv_obj)" } },
-  { "get_selected_btn", { (const void*) &lv_btnmatrix_get_selected_btn, "i", "(lv.lv_obj)" } },
-  { "has_btn_ctrl", { (const void*) &lv_btnmatrix_has_btn_ctrl, "b", "(lv.lv_obj)ii" } },
-  { "set_btn_ctrl", { (const void*) &lv_btnmatrix_set_btn_ctrl, "", "(lv.lv_obj)ii" } },
-  { "set_btn_ctrl_all", { (const void*) &lv_btnmatrix_set_btn_ctrl_all, "", "(lv.lv_obj)i" } },
-  { "set_btn_width", { (const void*) &lv_btnmatrix_set_btn_width, "", "(lv.lv_obj)ii" } },
-  { "set_ctrl_map", { (const void*) &lv_btnmatrix_set_ctrl_map, "", "(lv.lv_obj)(lv.lv_btnmatrix_ctrl)" } },
-  { "set_map", { (const void*) &lv_btnmatrix_set_map, "", "(lv.lv_obj)(lv.str_arr)" } },
-  { "set_one_checked", { (const void*) &lv_btnmatrix_set_one_checked, "", "(lv.lv_obj)b" } },
-  { "set_selected_btn", { (const void*) &lv_btnmatrix_set_selected_btn, "", "(lv.lv_obj)i" } },
-};
-#endif // BE_LV_WIDGET_BTNMATRIX
 
 /* `lv_canvas` methods */
 #ifdef BE_LV_WIDGET_CANVAS
@@ -1042,6 +1058,7 @@ extern const bclass be_class_lv_group;
 extern const bclass be_class_lv_img;
 extern const bclass be_class_lv_imgbtn;
 extern const bclass be_class_lv_indev;
+extern const bclass be_class_lv_keyboard;
 extern const bclass be_class_lv_label;
 extern const bclass be_class_lv_led;
 extern const bclass be_class_lv_line;
@@ -1102,6 +1119,9 @@ const be_ntv_class_def_t lv_classes[] = {
   { "lv_imgbtn", &be_class_lv_imgbtn, lv_imgbtn_func, sizeof(lv_imgbtn_func) / sizeof(lv_imgbtn_func[0]) },
 #endif // BE_LV_WIDGET_IMGBTN
   { "lv_indev", &be_class_lv_indev, lv_indev_func, sizeof(lv_indev_func) / sizeof(lv_indev_func[0]) },
+#ifdef BE_LV_WIDGET_KEYBOARD
+  { "lv_keyboard", &be_class_lv_keyboard, lv_keyboard_func, sizeof(lv_keyboard_func) / sizeof(lv_keyboard_func[0]) },
+#endif // BE_LV_WIDGET_KEYBOARD
 #ifdef BE_LV_WIDGET_LABEL
   { "lv_label", &be_class_lv_label, lv_label_func, sizeof(lv_label_func) / sizeof(lv_label_func[0]) },
 #endif // BE_LV_WIDGET_LABEL
@@ -1178,6 +1198,14 @@ const size_t lv_classes_size = sizeof(lv_classes) / sizeof(lv_classes[0]);
 #ifdef BE_LV_WIDGET_IMGBTN
   int be_ntv_lv_imgbtn_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_imgbtn_create, "+_p", "(lv.lv_obj)"); }
 #endif // BE_LV_WIDGET_IMGBTN
+  /* `lv_keyboard` methods */
+#ifdef BE_LV_WIDGET_KEYBOARD
+  int be_ntv_lv_keyboard_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_keyboard_create, "+_p", "(lv.lv_obj)"); }
+#endif // BE_LV_WIDGET_KEYBOARD
+  /* `lv_btnmatrix` methods */
+#ifdef BE_LV_WIDGET_BTNMATRIX
+  int be_ntv_lv_btnmatrix_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_btnmatrix_create, "+_p", "(lv.lv_obj)"); }
+#endif // BE_LV_WIDGET_BTNMATRIX
   /* `lv_led` methods */
 #ifdef BE_LV_WIDGET_LED
   int be_ntv_lv_led_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_led_create, "+_p", "(lv.lv_obj)"); }
@@ -1212,10 +1240,6 @@ const size_t lv_classes_size = sizeof(lv_classes) / sizeof(lv_classes[0]);
 #ifdef BE_LV_WIDGET_BTN
   int be_ntv_lv_btn_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_btn_create, "+_p", "(lv.lv_obj)"); }
 #endif // BE_LV_WIDGET_BTN
-  /* `lv_btnmatrix` methods */
-#ifdef BE_LV_WIDGET_BTNMATRIX
-  int be_ntv_lv_btnmatrix_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_btnmatrix_create, "+_p", "(lv.lv_obj)"); }
-#endif // BE_LV_WIDGET_BTNMATRIX
   /* `lv_canvas` methods */
 #ifdef BE_LV_WIDGET_CANVAS
   int be_ntv_lv_canvas_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_canvas_create, "+_p", "(lv.lv_obj)"); }

--- a/lib/libesp32_lvgl/lv_binding_berry/generate/be_lvgl_widgets_lib.c
+++ b/lib/libesp32_lvgl/lv_binding_berry/generate/be_lvgl_widgets_lib.c
@@ -646,6 +646,36 @@ extern int lvbe_imgbtn_create(bvm *vm);
 extern int lvbe_imgbtn_set_src(bvm *vm);
 extern int lvbe_imgbtn_set_state(bvm *vm);
 
+/* `lv_keyboard` external functions definitions */
+extern int lvbe_keyboard_create(bvm *vm);
+extern int lvbe_keyboard_set_textarea(bvm *vm);
+extern int lvbe_keyboard_set_mode(bvm *vm);
+extern int lvbe_keyboard_set_popovers(bvm *vm);
+extern int lvbe_keyboard_set_map(bvm *vm);
+extern int lvbe_keyboard_get_textarea(bvm *vm);
+extern int lvbe_keyboard_get_mode(bvm *vm);
+extern int lvbe_keyboard_get_map_array(bvm *vm);
+extern int lvbe_keyboard_get_selected_btn(bvm *vm);
+extern int lvbe_keyboard_get_btn_text(bvm *vm);
+
+/* `lv_btnmatrix` external functions definitions */
+extern int lvbe_btnmatrix_get_popovers(bvm *vm);
+extern int lvbe_btnmatrix_create(bvm *vm);
+extern int lvbe_btnmatrix_set_map(bvm *vm);
+extern int lvbe_btnmatrix_set_ctrl_map(bvm *vm);
+extern int lvbe_btnmatrix_set_selected_btn(bvm *vm);
+extern int lvbe_btnmatrix_set_btn_ctrl(bvm *vm);
+extern int lvbe_btnmatrix_clear_btn_ctrl(bvm *vm);
+extern int lvbe_btnmatrix_set_btn_ctrl_all(bvm *vm);
+extern int lvbe_btnmatrix_clear_btn_ctrl_all(bvm *vm);
+extern int lvbe_btnmatrix_set_btn_width(bvm *vm);
+extern int lvbe_btnmatrix_set_one_checked(bvm *vm);
+extern int lvbe_btnmatrix_get_map(bvm *vm);
+extern int lvbe_btnmatrix_get_selected_btn(bvm *vm);
+extern int lvbe_btnmatrix_get_btn_text(bvm *vm);
+extern int lvbe_btnmatrix_has_btn_ctrl(bvm *vm);
+extern int lvbe_btnmatrix_get_one_checked(bvm *vm);
+
 /* `lv_led` external functions definitions */
 extern int lvbe_led_create(bvm *vm);
 extern int lvbe_led_set_color(bvm *vm);
@@ -776,23 +806,6 @@ extern int lvbe_bar_get_mode(bvm *vm);
 
 /* `lv_btn` external functions definitions */
 extern int lvbe_btn_create(bvm *vm);
-
-/* `lv_btnmatrix` external functions definitions */
-extern int lvbe_btnmatrix_create(bvm *vm);
-extern int lvbe_btnmatrix_set_map(bvm *vm);
-extern int lvbe_btnmatrix_set_ctrl_map(bvm *vm);
-extern int lvbe_btnmatrix_set_selected_btn(bvm *vm);
-extern int lvbe_btnmatrix_set_btn_ctrl(bvm *vm);
-extern int lvbe_btnmatrix_clear_btn_ctrl(bvm *vm);
-extern int lvbe_btnmatrix_set_btn_ctrl_all(bvm *vm);
-extern int lvbe_btnmatrix_clear_btn_ctrl_all(bvm *vm);
-extern int lvbe_btnmatrix_set_btn_width(bvm *vm);
-extern int lvbe_btnmatrix_set_one_checked(bvm *vm);
-extern int lvbe_btnmatrix_get_map(bvm *vm);
-extern int lvbe_btnmatrix_get_selected_btn(bvm *vm);
-extern int lvbe_btnmatrix_get_btn_text(bvm *vm);
-extern int lvbe_btnmatrix_has_btn_ctrl(bvm *vm);
-extern int lvbe_btnmatrix_get_one_checked(bvm *vm);
 
 /* `lv_canvas` external functions definitions */
 extern int lvbe_canvas_create(bvm *vm);
@@ -967,6 +980,8 @@ extern int be_ntv_lv_qrcode_init(bvm *vm);
 extern int be_ntv_lv_chart_init(bvm *vm);
 extern int be_ntv_lv_colorwheel_init(bvm *vm);
 extern int be_ntv_lv_imgbtn_init(bvm *vm);
+extern int be_ntv_lv_keyboard_init(bvm *vm);
+extern int be_ntv_lv_btnmatrix_init(bvm *vm);
 extern int be_ntv_lv_led_init(bvm *vm);
 extern int be_ntv_lv_meter_init(bvm *vm);
 extern int be_ntv_lv_msgbox_init(bvm *vm);
@@ -977,7 +992,6 @@ extern int be_ntv_lv_timer_init(bvm *vm);
 extern int be_ntv_lv_arc_init(bvm *vm);
 extern int be_ntv_lv_bar_init(bvm *vm);
 extern int be_ntv_lv_btn_init(bvm *vm);
-extern int be_ntv_lv_btnmatrix_init(bvm *vm);
 extern int be_ntv_lv_canvas_init(bvm *vm);
 extern int be_ntv_lv_checkbox_init(bvm *vm);
 extern int be_ntv_lv_dropdown_init(bvm *vm);
@@ -1006,6 +1020,7 @@ extern const bclass be_class_lv_group;
 extern const bclass be_class_lv_img;
 extern const bclass be_class_lv_imgbtn;
 extern const bclass be_class_lv_indev;
+extern const bclass be_class_lv_keyboard;
 extern const bclass be_class_lv_label;
 extern const bclass be_class_lv_led;
 extern const bclass be_class_lv_line;
@@ -1215,6 +1230,28 @@ class be_class_lv_imgbtn (scope: global, name: lv_imgbtn, super: be_class_lv_obj
 @const_object_info_end */
 
 /********************************************************************
+** Solidified class: lv_keyboard
+********************************************************************/
+#include "be_fixed_be_class_lv_keyboard.h"
+/* @const_object_info_begin
+class be_class_lv_keyboard (scope: global, name: lv_keyboard, super: be_class_lv_btnmatrix, strings: weak) {
+    _class, comptr(&lv_keyboard_class)
+    init, func(be_ntv_lv_keyboard_init)
+}
+@const_object_info_end */
+
+/********************************************************************
+** Solidified class: lv_btnmatrix
+********************************************************************/
+#include "be_fixed_be_class_lv_btnmatrix.h"
+/* @const_object_info_begin
+class be_class_lv_btnmatrix (scope: global, name: lv_btnmatrix, super: be_class_lv_obj, strings: weak) {
+    _class, comptr(&lv_btnmatrix_class)
+    init, func(be_ntv_lv_btnmatrix_init)
+}
+@const_object_info_end */
+
+/********************************************************************
 ** Solidified class: lv_led
 ********************************************************************/
 #include "be_fixed_be_class_lv_led.h"
@@ -1301,17 +1338,6 @@ class be_class_lv_bar (scope: global, name: lv_bar, super: be_class_lv_obj, stri
 class be_class_lv_btn (scope: global, name: lv_btn, super: be_class_lv_obj, strings: weak) {
     _class, comptr(&lv_btn_class)
     init, func(be_ntv_lv_btn_init)
-}
-@const_object_info_end */
-
-/********************************************************************
-** Solidified class: lv_btnmatrix
-********************************************************************/
-#include "be_fixed_be_class_lv_btnmatrix.h"
-/* @const_object_info_begin
-class be_class_lv_btnmatrix (scope: global, name: lv_btnmatrix, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_btnmatrix_class)
-    init, func(be_ntv_lv_btnmatrix_init)
 }
 @const_object_info_end */
 

--- a/lib/libesp32_lvgl/lv_binding_berry/mapping/lv_funcs.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/mapping/lv_funcs.h
@@ -665,6 +665,19 @@ lv_obj_t * lv_imgbtn_create(lv_obj_t * parent)
 void lv_imgbtn_set_src(lv_obj_t * imgbtn, lv_imgbtn_state_t state, const void * src_left, const void * src_mid, const void * src_right)
 void lv_imgbtn_set_state(lv_obj_t * imgbtn, lv_imgbtn_state_t state)
 
+// ../../lvgl/src/extra/widgets/keyboard/lv_keyboard.h
+lv_obj_t * lv_keyboard_create(lv_obj_t * parent)
+void lv_keyboard_set_textarea(lv_obj_t * kb, lv_obj_t * ta)
+void lv_keyboard_set_mode(lv_obj_t * kb, lv_keyboard_mode_t mode)
+void lv_keyboard_set_popovers(lv_obj_t * kb, bool en)
+void lv_keyboard_set_map(lv_obj_t * kb, lv_keyboard_mode_t mode, const char * map[], const lv_btnmatrix_ctrl_t ctrl_map[])
+lv_obj_t * lv_keyboard_get_textarea(const lv_obj_t * kb)
+lv_keyboard_mode_t lv_keyboard_get_mode(const lv_obj_t * kb)
+bool lv_btnmatrix_get_popovers(const lv_obj_t * obj)
+static inline const char ** lv_keyboard_get_map_array(const lv_obj_t * kb)
+static inline uint16_t lv_keyboard_get_selected_btn(const lv_obj_t * obj)
+static inline const char * lv_keyboard_get_btn_text(const lv_obj_t * obj, uint16_t btn_id)
+
 // ../../lvgl/src/extra/widgets/led/lv_led.h
 lv_obj_t * lv_led_create(lv_obj_t * parent)
 void lv_led_set_color(lv_obj_t * led, lv_color_t color)

--- a/lib/libesp32_lvgl/lv_binding_berry/tools/convert.py
+++ b/lib/libesp32_lvgl/lv_binding_berry/tools/convert.py
@@ -204,7 +204,7 @@ lv_widgets = ['arc', 'bar', 'btn', 'btnmatrix', 'canvas', 'checkbox',
               'dropdown', 'img', 'label', 'line', 'roller', 'slider',
               'switch', 'table', 'textarea' ]
 # extra widgets
-lv_widgets = lv_widgets + [ 'chart', 'colorwheel', 'imgbtn', 'led', 'meter', 'msgbox', 'spinbox', 'spinner' ]
+lv_widgets = lv_widgets + [ 'chart', 'colorwheel', 'imgbtn', 'led', 'meter', 'msgbox', 'spinbox', 'spinner', 'keyboard' ]
 
 # add qrcode
 lv_widgets = lv_widgets + [ 'qrcode' ]

--- a/lib/libesp32_lvgl/lv_binding_berry/tools/preprocessor.py
+++ b/lib/libesp32_lvgl/lv_binding_berry/tools/preprocessor.py
@@ -61,6 +61,7 @@ lv_fun_globs = [
                   "extra/widgets/msgbox/*.h",
                   "extra/widgets/spinbox/*.h",
                   "extra/widgets/spinner/*.h",
+                  "extra/widgets/keyboard/*.h",
                   "extra/themes/default/*.h",
                   "extra/themes/mono/*.h",
                   "extra/layouts/**/*.h",

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1207,6 +1207,7 @@
     #define BE_LV_WIDGET_MSGBOX
     #define BE_LV_WIDGET_SPINBOX
     #define BE_LV_WIDGET_SPINNER
+    #define BE_LV_WIDGET_KEYBOARD
 
     #define BE_LV_WIDGET_QRCODE
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1207,7 +1207,7 @@
     #define BE_LV_WIDGET_MSGBOX
     #define BE_LV_WIDGET_SPINBOX
     #define BE_LV_WIDGET_SPINNER
-    #define BE_LV_WIDGET_KEYBOARD
+    // #define BE_LV_WIDGET_KEYBOARD
 
     #define BE_LV_WIDGET_QRCODE
 


### PR DESCRIPTION
## Description:

LVGL add possibility to compile with `lv_keyboard` extra widget. It requires `#define BE_LV_WIDGET_KEYBOARD`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
