### PR TITLE
Modify shutter driver for GUI sensor separators

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -999,6 +999,9 @@ void WSContentSeparator(uint32_t state) {
     case 2:    // Print separator on next WSContentSeparator(1)
       request = true;
       break;
+    case 3:    // Don't print separator on next WSContentSeparator(1)
+      request = false;
+      break;
   }
 }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
@@ -1141,6 +1141,7 @@ void ShutterToggle(bool dir)
 void ShutterShow(){
   for (uint32_t i = 0; i < TasmotaGlobal.shutters_present; i++) {
     WSContentSend_P(HTTP_MSG_SLIDER_SHUTTER,  (Settings->shutter_options[i] & 1) ? D_OPEN : D_CLOSE,(Settings->shutter_options[i] & 1) ? D_CLOSE : D_OPEN, (Settings->shutter_options[i] & 1) ? (100 - ShutterRealToPercentPosition(-9999, i)) : ShutterRealToPercentPosition(-9999, i), i+1);
+    WSContentSeparator(3); // Don't print separator on next WSContentSeparator(1)
   }
 }
 


### PR DESCRIPTION
## Description:
The shutter driver writes to a html field to update the slider(s), but no content is send to the sensor list. In this case no separator has to be shown. So we need an option to suppress the next separator. Therefore the value `3` was added to `WSContentSeparator`, which then is used in the shutter driver.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).