### PR TITLE
Platform 2024.01.01 - IPv6 compability to core3 IPv6

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -92,7 +92,7 @@ lib_ignore                  =
 
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.01.00/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.01.01/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
- core 2.0.14 with compability to IPv6 implementation of espressif Arduino core 3.0.0

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
