### PR TITLE
Tasmota Arduino core3 with espressif IPv6 implementation

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -98,7 +98,7 @@ build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 [core32_30]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.01.10/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.01.11/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${core32.build_unflags}
 build_flags                 = ${core32.build_flags}


### PR DESCRIPTION
## Description:

- migrate from custom Tasmota IPv6 implementation to official espressif IPv6 one

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
