### PR TITLE
[WebUI] Fix first line seperator

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -1492,6 +1492,7 @@ bool HandleRootStatusRefresh(void)
 #endif  // USE_WEB_SSE
 
   WSContentSend_P(PSTR("{t}"));        // <table style='width:100%'>
+  WSContentSeparator(3);               // Reset seperator to ignore previous outputs 
   if (Settings->web_time_end) {
     WSContentSend_P(PSTR("{s}" D_TIMER_TIME "{m}%s{e}"), GetDateAndTime(DT_LOCAL).substring(Settings->web_time_start, Settings->web_time_end).c_str());
     WSContentSeparator(0);             // Print separator


### PR DESCRIPTION
## Description:
The separator (request) flag has to be cleared before starting the output of sensors/drivers to ignore previous outputs. So there will no seperator in front of the list. This only appeared, with `WebTime` off.
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).