### PR TITLE
Rename "Konsolen" to "Werkzeuge"

### DIFF
--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -275,7 +275,7 @@
 #define D_CONFIGURATION "Einstellungen"
 #define D_INFORMATION "Informationen"
 #define D_FIRMWARE_UPGRADE "Firmware Update"
-#define D_MANAGEMENT "Konsolen"
+#define D_MANAGEMENT "Tools"
 #define D_GPIO_VIEWER "GPIO Viewer"
 #define D_CONSOLE "Konsole"
 #define D_CONFIRM_RESTART "Wirklich neustarten?"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -275,7 +275,7 @@
 #define D_CONFIGURATION "Einstellungen"
 #define D_INFORMATION "Informationen"
 #define D_FIRMWARE_UPGRADE "Firmware Update"
-#define D_MANAGEMENT "Tools"
+#define D_MANAGEMENT "Werkzeuge"
 #define D_GPIO_VIEWER "GPIO Viewer"
 #define D_CONSOLE "Konsole"
 #define D_CONFIRM_RESTART "Wirklich neustarten?"


### PR DESCRIPTION
I think it is also the better word in german. Refering to https://github.com/arendst/Tasmota/commit/d51340961fe2487c673b157335cdf85e6d73106c.
