### PR TITLE
add support for ams5915 and ams6915 temerature and pressure sensors

### DIFF
--- a/I2CDEVICES.md
+++ b/I2CDEVICES.md
@@ -123,5 +123,7 @@ Index | Define              | Driver   | Device   | Address(es) | Bus2 | Descrip
   83  | USE_MAX17043        | xsns_110 | MAX17043 | 0x36        |      | Fuel-gauge for 3.7 Volt Lipo battery
   84  | USE_ENS16x          | xsns_111 | ENS16x   | 0x52 - 0x53 |      | Gas (TVOC, eCO2) and air quality sensor
   85  | USE_ENS210          | xsns_112 | ENS210   | 0x43 - 0x44 |      | Temperature and humidity sensor
+  86  | USE_AMSX915         | xsns_114 | AMS5915  | 0x28        |      | Pressure (absolute/differential) and temperature sensor
+  86  | USE_AMSX915         | xsns_114 | AMS6915  | 0x28        |      | Pressure (absolute/differential) and temperature sensor
   
   NOTE: Bus2 supported on ESP32 only.

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -591,7 +591,7 @@
 #ifdef USE_I2C
 //  #define USE_SHT                                // [I2cDriver8] Enable SHT1X sensor (+1k4 code)
 //  #define USE_HTU                                // [I2cDriver9] Enable HTU21/SI7013/SI7020/SI7021 sensor (I2C address 0x40) (+1k5 code)
-//  #define USE_BMP                                // [I2cDriver10] Enable BMP085/BMP180/BMP280/BME280 sensors (I2C addresses 0x76 and 0x77) (+4k4 code)
+  //#define USE_BMP                                // [I2cDriver10] Enable BMP085/BMP180/BMP280/BME280 sensors (I2C addresses 0x76 and 0x77) (+4k4 code)
 //    #define USE_BME68X                           // Enable support for BME680/BME688 sensor using Bosch BME68x library (+6k9 code)
 //  #define USE_BH1750                             // [I2cDriver11] Enable BH1750 sensor (I2C address 0x23 or 0x5C) (+0k5 code)
 //  #define USE_VEML6070                           // [I2cDriver12] Enable VEML6070 sensor (I2C addresses 0x38 and 0x39) (+1k5 code)
@@ -730,7 +730,7 @@
 //    #define DS3231_ENABLE_TEMP                   //   In DS3231 driver, enable the internal temperature sensor
 //    #define USE_BM8563                           // [I2cDriver59] Enable BM8563 RTC - found in M5Stack - support both I2C buses on ESP32 (I2C address 0x51) (+2.5k code)
 //    #define USE_PCF85363                         // [I2cDriver66] Enable PCF85363 RTC - found Shelly 3EM (I2C address 0x51) (+0k7 code)
-//    #define USE_AMSX915                          // [I2CDriver86] Enable AMS5915/AMS6915 pressure/temperature sensor (+1k7 code)
+    #define USE_AMSX915                          // [I2CDriver86] Enable AMS5915/AMS6915 pressure/temperature sensor (+1k6 code)
 
 //  #define USE_DISPLAY                            // Add I2C/TM1637/MAX7219 Display Support (+2k code)
     #define USE_DISPLAY_MODES1TO5                // Enable display mode 1 to 5 in addition to mode 0

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -730,6 +730,7 @@
 //    #define DS3231_ENABLE_TEMP                   //   In DS3231 driver, enable the internal temperature sensor
 //    #define USE_BM8563                           // [I2cDriver59] Enable BM8563 RTC - found in M5Stack - support both I2C buses on ESP32 (I2C address 0x51) (+2.5k code)
 //    #define USE_PCF85363                         // [I2cDriver66] Enable PCF85363 RTC - found Shelly 3EM (I2C address 0x51) (+0k7 code)
+//    #define USE_AMSX915                          // [I2CDriver86] Enable AMS5915/AMS6915 pressure/temperature sensor (+1k7 code)
 
 //  #define USE_DISPLAY                            // Add I2C/TM1637/MAX7219 Display Support (+2k code)
     #define USE_DISPLAY_MODES1TO5                // Enable display mode 1 to 5 in addition to mode 0

--- a/tasmota/tasmota_xsns_sensor/xsns_114_amsx915.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_114_amsx915.ino
@@ -59,7 +59,7 @@ struct {
   int16_t   pmax;
 } amsx915Settings;
 
-void AmsDetect(void) {
+void Amsx915Detect(void) {
   // sensor datasheets does not provide any information/commands on sensor
   // specific register so it is not possible to properly detect sensor type
   if(Wire.available() != 4) {
@@ -77,7 +77,7 @@ void AmsDetect(void) {
     AddLog(LOG_LEVEL_INFO, PSTR("CFG: AMS detected"));
 }
 
-bool AmsCommand() {
+bool Amsx915Command() {
   int32_t vals[2];
   ParseParameters(2,(uint32_t *)vals);
   if(XdrvMailbox.data_len >= 3 && XdrvMailbox.data_len < 13) {
@@ -85,7 +85,7 @@ bool AmsCommand() {
       if (vals[1] >= -32768 && vals[1] < 32768) {
         amsx915Settings.pmin = (int16_t)vals[0]; // save pmin of sensor
         amsx915Settings.pmax = (int16_t)vals[1];  // same with pmax
-        AmsSettingsSave();
+        Amsx915SettingsSave();
         Response_P(S_JSON_SENSOR_INDEX_SVALUE, XSNS_114, "pressure range set");
         return true;
       }
@@ -96,7 +96,7 @@ bool AmsCommand() {
   return false;
 }
 
-void AmsReadData(void) {
+void Amsx915ReadData(void) {
   uint8_t buffer[4];
   Wire.requestFrom(AMSX915_ADDR, 4);
   if(Wire.available() != 4) {
@@ -114,7 +114,7 @@ void AmsReadData(void) {
   amsx915data.present = true;
 }
 
-void AmsShow(bool json) {
+void Amsx915Show(bool json) {
   if(amsx915data.present) {
     if (json) {
       ResponseAppend_P(PSTR(",\"AMSx915\":{\"" D_JSON_TEMPERATURE "\":%1_f,\"" D_JSON_PRESSURE "\":%2_f}"), &amsx915data.temperature, &amsx915data.pressure);
@@ -133,7 +133,7 @@ void AmsShow(bool json) {
  * Driver Settings load and save
 \*********************************************************************************************/
 
-void AmsSettingsLoad(bool erase) {
+void Amsx915SettingsLoad(bool erase) {
   // Called from FUNC_PRE_INIT (erase = 0) once at restart
   // Called from FUNC_RESET_SETTINGS (erase = 1) after command reset 4, 5, or 6
 
@@ -175,7 +175,7 @@ void AmsSettingsLoad(bool erase) {
 
       // Set current version and save settings
       amsx915Settings.version = AMSX915_VERSION;
-      AmsSettingsSave();
+      Amsx915SettingsSave();
     }
     AddLog(LOG_LEVEL_INFO, PSTR("CFG: AMS config loaded from file"));
   }
@@ -186,7 +186,7 @@ void AmsSettingsLoad(bool erase) {
 #endif  // USE_UFILESYS
 }
 
-void AmsSettingsSave(void) {
+void Amsx915SettingsSave(void) {
   // Called from FUNC_SAVE_SETTINGS every SaveData second and at restart
 #ifdef USE_UFILESYS
   uint32_t crc32 = GetCfgCrc32((uint8_t*)&amsx915Settings +4, sizeof(amsx915Settings) -4);  // Skip crc32
@@ -219,28 +219,28 @@ bool Xsns114(uint32_t function) {
 
   switch(function) {
     case FUNC_PRE_INIT:
-      AmsSettingsLoad(0);
+      Amsx915SettingsLoad(0);
       break;
     case FUNC_INIT:
-      AmsDetect();
+      Amsx915Detect();
       break;
     case FUNC_EVERY_SECOND:
-      AmsReadData();
+      Amsx915ReadData();
       break;
     case FUNC_SAVE_SETTINGS:
-      AmsSettingsSave();
+      Amsx915SettingsSave();
       break;
     case FUNC_COMMAND_SENSOR:
       if(XSNS_114 == XdrvMailbox.index) {
-        result = AmsCommand();
+        result = Amsx915Command();
       }
       break;
     case FUNC_JSON_APPEND:
-      AmsShow(1);
+      Amsx915Show(1);
       break;
 #ifdef USE_WEBSERVER
     case FUNC_WEB_SENSOR:
-      AmsShow(0);
+      Amsx915Show(0);
       break;
 #endif  // USE_WEBSERVER
   }

--- a/tasmota/tasmota_xsns_sensor/xsns_114_amsx915.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_114_amsx915.ino
@@ -1,0 +1,251 @@
+/*
+  xsns_114_ams.ino - AMS5915, AMS6915 pressure and temperature sensor support for Tasmota
+
+  Copyright (C) 2023 Bastian Urschel
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_I2C
+#ifdef USE_AMSX915
+/*********************************************************************************************\
+ * AMS5915, AMS6915 - Pressure and Temperature
+ *
+ * Source: Bastian Urschel
+ *
+ * I2C Address: 0x28
+\*********************************************************************************************/
+
+#define XSNS_114            114
+#define XI2C_86              86  // See I2CDEVICES.md
+
+#ifndef AMSX915_ADDR
+  #define AMSX915_ADDR         0x28
+#endif
+
+#define PMIN_DEFAULT      0
+#define PMAX_DEFAULT      0
+
+#ifndef USE_UFILESYS
+#warning "AMSx915 pressure settings cannot be saved persistent due to missing filesystem"
+#endif
+
+/********************************************************************************************/
+
+struct amsx915_data {
+  float pressure;
+  float temperature;
+  bool present;
+} amsx915data;
+
+const uint16_t AMSX915_VERSION = 0x0100;       // Latest sensor version (See settings deltas below)
+
+// Global structure containing driver saved variables
+struct {
+  uint32_t  crc32;    // To detect file changes
+  uint16_t  version;  // To detect driver function changes
+  int16_t   pmin;
+  int16_t   pmax;
+} amsx915Settings;
+
+void AmsDetect(void) {
+  // sensor datasheets does not provide any information/commands on sensor
+  // specific register so it is not possible to properly detect sensor type
+  if(Wire.available() != 4) {
+    // Error
+    amsx915data.present = false;
+    AddLog(LOG_LEVEL_INFO, PSTR("CFG: AMS not detected!"));
+
+    return;
+  }
+  while(Wire.available()) {
+    Wire.read();
+  }
+  amsx915data.present = true;
+  I2cSetActiveFound(AMSX915_ADDR, "AMSx915");
+    AddLog(LOG_LEVEL_INFO, PSTR("CFG: AMS detected"));
+}
+
+bool AmsCommand() {
+  int32_t vals[2];
+  ParseParameters(2,(uint32_t *)vals);
+  if(XdrvMailbox.data_len >= 3 && XdrvMailbox.data_len < 13) {
+    if (vals[0] >= -32768 && vals[0] < 32768) {
+      if (vals[1] >= -32768 && vals[1] < 32768) {
+        amsx915Settings.pmin = (int16_t)vals[0]; // save pmin of sensor
+        amsx915Settings.pmax = (int16_t)vals[1];  // same with pmax
+        AmsSettingsSave();
+        Response_P(S_JSON_SENSOR_INDEX_SVALUE, XSNS_114, "pressure range set");
+        return true;
+      }
+    }
+    Response_P(S_JSON_SENSOR_INDEX_SVALUE, XSNS_114, "invalid pressure range [-32768..32767]");
+    return false;
+  }
+  return false;
+}
+
+void AmsReadData(void) {
+  uint8_t buffer[4];
+  Wire.requestFrom(AMSX915_ADDR, 4);
+  if(Wire.available() != 4) {
+    Serial.println("AMS error read!");
+    amsx915data.present = false;
+    return;
+  }
+  buffer[0] = Wire.read();
+  buffer[1] = Wire.read();
+  buffer[2] = Wire.read();
+  buffer[3] = Wire.read();
+
+  amsx915data.pressure = ((256*(buffer[0]&0x3F)+buffer[1])-1638.0)*(amsx915Settings.pmax-amsx915Settings.pmin)/13107+amsx915Settings.pmin;
+  amsx915data.temperature = (((256.0*buffer[2]+buffer[3])*200.0)/65536)-50;
+  amsx915data.present = true;
+}
+
+void AmsShow(bool json) {
+  if(amsx915data.present) {
+    if (json) {
+      ResponseAppend_P(PSTR(",\"AMSx915\":{\"" D_JSON_TEMPERATURE "\":%1_f,\"" D_JSON_PRESSURE "\":%2_f}"), &amsx915data.temperature, &amsx915data.pressure);
+#ifdef USE_WEBSERVER
+      } else {
+        char str_pressure[9];
+        dtostrfd(amsx915data.pressure, 2, str_pressure);
+        WSContentSend_PD(HTTP_SNS_PRESSURE, "AMSx915", str_pressure, PressureUnit().c_str());
+        WSContentSend_Temp("AMSx915", amsx915data.temperature);
+#endif  // USE_WEBSERVER
+      }
+  }
+}
+
+/*********************************************************************************************\
+ * Driver Settings load and save
+\*********************************************************************************************/
+
+void AmsSettingsLoad(bool erase) {
+  // Called from FUNC_PRE_INIT (erase = 0) once at restart
+  // Called from FUNC_RESET_SETTINGS (erase = 1) after command reset 4, 5, or 6
+
+  // *** Start init default values in case file is not found ***
+  AddLog(LOG_LEVEL_INFO, PSTR("DRV: " D_USE_DEFAULTS));
+
+  memset(&amsx915Settings, 0x00, sizeof(amsx915Settings));
+  amsx915Settings.version = AMSX915_VERSION;
+  amsx915Settings.pmax = PMAX_DEFAULT;
+  amsx915Settings.pmin = PMIN_DEFAULT;
+
+  // *** End Init default values ***
+
+#ifndef USE_UFILESYS
+  AddLog(LOG_LEVEL_INFO, PSTR("CFG: AMS defaults as file system not enabled"));
+#else
+  // Try to load file /.drvset122
+  char filename[20];
+  snprintf_P(filename, sizeof(filename), PSTR(TASM_FILE_SENSOR), XSNS_114);
+
+  if (erase) {
+    TfsDeleteFile(filename);  // Use defaults
+  }
+  else if (TfsLoadFile(filename, (uint8_t*)&amsx915Settings, sizeof(amsx915Settings))) {
+  Serial.println("TfsLoadFile");
+    if (amsx915Settings.version != AMSX915_VERSION) {      // Fix version dependent changes
+
+      // *** Start fix possible setting deltas ***
+      if (Settings->version < 0x01010100) {
+        AddLog(LOG_LEVEL_INFO, PSTR("CFG: Update oldest version restore"));
+
+      }
+      if (Settings->version < 0x01010101) {
+        AddLog(LOG_LEVEL_INFO, PSTR("CFG: Update old version restore"));
+
+      }
+
+      // *** End setting deltas ***
+
+      // Set current version and save settings
+      amsx915Settings.version = AMSX915_VERSION;
+      AmsSettingsSave();
+    }
+    AddLog(LOG_LEVEL_INFO, PSTR("CFG: AMS config loaded from file"));
+  }
+  else {
+    // File system not ready: No flash space reserved for file system
+    AddLog(LOG_LEVEL_DEBUG, PSTR("CFG: AMS use defaults as file system not ready or file not found"));
+  }
+#endif  // USE_UFILESYS
+}
+
+void AmsSettingsSave(void) {
+  // Called from FUNC_SAVE_SETTINGS every SaveData second and at restart
+#ifdef USE_UFILESYS
+  uint32_t crc32 = GetCfgCrc32((uint8_t*)&amsx915Settings +4, sizeof(amsx915Settings) -4);  // Skip crc32
+  if (crc32 != amsx915Settings.crc32) {
+    // Try to save file /.drvset122
+    amsx915Settings.crc32 = crc32;
+
+    char filename[20];
+    snprintf_P(filename, sizeof(filename), PSTR(TASM_FILE_SENSOR), XSNS_114);
+
+    if (TfsSaveFile(filename, (const uint8_t*)&amsx915Settings, sizeof(amsx915Settings))) {
+      AddLog(LOG_LEVEL_DEBUG, PSTR("CFG: AMS Settings saved to file"));
+    } else {
+      // File system not ready: No flash space reserved for file system
+      AddLog(LOG_LEVEL_DEBUG, PSTR("CFG: ERROR AMS file system not ready or unable to save file"));
+    }
+  }
+#endif  // USE_UFILESYS
+}
+
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xsns114(uint32_t function) {
+  if (!I2cEnabled(XI2C_86)) { return false; }
+
+  bool result = false;
+
+  switch(function) {
+    case FUNC_PRE_INIT:
+      AmsSettingsLoad(0);
+      break;
+    case FUNC_INIT:
+      AmsDetect();
+      break;
+    case FUNC_EVERY_SECOND:
+      AmsReadData();
+      break;
+    case FUNC_SAVE_SETTINGS:
+      AmsSettingsSave();
+      break;
+    case FUNC_COMMAND_SENSOR:
+      if(XSNS_114 == XdrvMailbox.index) {
+        result = AmsCommand();
+      }
+      break;
+    case FUNC_JSON_APPEND:
+      AmsShow(1);
+      break;
+#ifdef USE_WEBSERVER
+    case FUNC_WEB_SENSOR:
+      AmsShow(0);
+      break;
+#endif  // USE_WEBSERVER
+  }
+  return result;
+}
+
+#endif  // USE_AMSX915
+#endif  // USE_I2C

--- a/tasmota/tasmota_xsns_sensor/xsns_114_amsx915.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_114_amsx915.ino
@@ -83,7 +83,6 @@ void Amsx915ReadData(void) {
   uint8_t buffer[4];
   Wire.requestFrom(AMSX915_ADDR, 4);
   if(Wire.available() != 4) {
-    Serial.println("AMS error read!");
     amsx915data.present = false;
     return;
   }
@@ -121,11 +120,6 @@ void Amsx915Show(bool json) {
 
 void Amsx915SettingsLoad(bool erase) {
   // Called from FUNC_PRE_INIT (erase = 0) once at restart
-  // Called from FUNC_RESET_SETTINGS (erase = 1) after command reset 4, 5, or 6
-
-  // *** Start init default values in case file is not found ***
-  AddLog(LOG_LEVEL_INFO, PSTR("DRV: " D_USE_DEFAULTS));
-
   memset(&amsx915Settings, 0x00, sizeof(amsx915Settings));
   amsx915Settings.version = AMSX915_VERSION;
   amsx915Settings.pmax = PMAX_DEFAULT;
@@ -144,7 +138,6 @@ void Amsx915SettingsLoad(bool erase) {
     TfsDeleteFile(filename);  // Use defaults
   }
   else if (TfsLoadFile(filename, (uint8_t*)&amsx915Settings, sizeof(amsx915Settings))) {
-  Serial.println("TfsLoadFile");
     if (amsx915Settings.version != AMSX915_VERSION) {      // Fix version dependent changes
 
       // *** Start fix possible setting deltas ***
@@ -163,7 +156,7 @@ void Amsx915SettingsLoad(bool erase) {
       amsx915Settings.version = AMSX915_VERSION;
       Amsx915SettingsSave();
     }
-    AddLog(LOG_LEVEL_INFO, PSTR("CFG: AMS config loaded from file"));
+    AddLog(LOG_LEVEL_DEBUG, PSTR("CFG: AMS config loaded from file"));
   }
   else {
     // File system not ready: No flash space reserved for file system

--- a/tasmota/tasmota_xsns_sensor/xsns_114_amsx915.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_114_amsx915.ino
@@ -130,7 +130,7 @@ void Amsx915SettingsLoad(bool erase) {
 #ifndef USE_UFILESYS
   AddLog(LOG_LEVEL_INFO, PSTR("CFG: AMS defaults as file system not enabled"));
 #else
-  // Try to load file /.drvset122
+  // Try to load sensor config file
   char filename[20];
   snprintf_P(filename, sizeof(filename), PSTR(TASM_FILE_SENSOR), XSNS_114);
 
@@ -139,19 +139,6 @@ void Amsx915SettingsLoad(bool erase) {
   }
   else if (TfsLoadFile(filename, (uint8_t*)&amsx915Settings, sizeof(amsx915Settings))) {
     if (amsx915Settings.version != AMSX915_VERSION) {      // Fix version dependent changes
-
-      // *** Start fix possible setting deltas ***
-      if (Settings->version < 0x01010100) {
-        AddLog(LOG_LEVEL_INFO, PSTR("CFG: Update oldest version restore"));
-
-      }
-      if (Settings->version < 0x01010101) {
-        AddLog(LOG_LEVEL_INFO, PSTR("CFG: Update old version restore"));
-
-      }
-
-      // *** End setting deltas ***
-
       // Set current version and save settings
       amsx915Settings.version = AMSX915_VERSION;
       Amsx915SettingsSave();
@@ -170,7 +157,7 @@ void Amsx915SettingsSave(void) {
 #ifdef USE_UFILESYS
   uint32_t crc32 = GetCfgCrc32((uint8_t*)&amsx915Settings +4, sizeof(amsx915Settings) -4);  // Skip crc32
   if (crc32 != amsx915Settings.crc32) {
-    // Try to save file /.drvset122
+    // Try to save sensor config file
     amsx915Settings.crc32 = crc32;
 
     char filename[20];


### PR DESCRIPTION
## Description:
Adds support for another sensor: AMS5915 and AMS6915 from Analog Microelectronics. There are many types of these sensor series available for various pressure ranges. Pressure range can be set with sensor command _Sensor114_. Pmin and Pmax of sensor is saved at sensor configfile on the filesystem (as discussed in #15791). If filesystem is not available then pmin and pmax defaults to 0.
Command example for sensor type "AMS 5915-0005-D-B" (differential and bidirectional): _Sensor114 -5 5_

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
