### PR TITLE
Berry assigment to list with negative index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Web file upload response on upload error (#20340)
 - ESP32 shutter exception 6 (divide by zero) on ``ShutterMode 4`` (#20524)
 - GPIOViewer exception 3
+- Berry assigment to list with negative index
 
 ### Removed
 - Max number of 30 backlog entries

--- a/lib/libesp32/berry/src/be_api.c
+++ b/lib/libesp32/berry/src/be_api.c
@@ -731,10 +731,13 @@ BERRY_API bbool be_getindex(bvm *vm, int index)
 static bvalue* list_setindex(blist *list, bvalue *key)
 {
     int idx = var_toidx(key);
-    if (idx < be_list_count(list)) {
-        return be_list_at(list, idx);
+    if (idx < 0) {
+        idx = list->count + idx;
     }
-    return NULL;
+    if (idx < 0 || idx >= list->count) {
+        return NULL;
+    }
+    return be_list_at(list, idx);
 }
 
 BERRY_API bbool be_setindex(bvm *vm, int index)


### PR DESCRIPTION
## Description:

Fix the following that would crash:
```berry
l = ["a","b","c","d"]
l[-1] = "z"
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
