### PR TITLE
Esp8266 ipv6

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
   - [ ] The pull request is done against the latest development branch
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
-  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.5
+  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
   - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -111,6 +111,7 @@ build_flags                 = ${esp_defaults.build_flags}
                               ; NONOSDK22x_190703 = 2.2.2-dev(38a443e)
                               -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
                               -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
+                              ; -DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_HIGHER_BANDWIDTH -DUSE_IPV6 ; enables IPv6
                               ; VTABLES in Flash
                               -DVTABLES_IN_FLASH
                               ; remove the 4-bytes alignment for PSTR()
@@ -139,7 +140,7 @@ lib_ignore                  =
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
-platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2024.01.00/platform-espressif8266.zip
+platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2024.01.01/platform-espressif8266.zip
 platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}


### PR DESCRIPTION
## Description:

re-add IPv6 compability to Tasmota Arduino esp8266 framework. It was broken with introducing official IPv6 support in Tasmota Arduino 3.0.0 esp32 framework.

Thx @s-hadinger for adding the needed changes in Tasmota Arduino esp8266

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
