### PR TITLE
Berry/Zigbee add web hook per device for customized status display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - GUI sensor separators (#20495)
 - Command ``TimedPower<index> <milliseconds>[,ON|OFF|TOGGLE|BLINK]`` executes ``Power<index> [ON|OFF|TOGGLE|BLINK] `` and after <millisecond> executes ``Power<index> [OFF|ON|TOGGLE|BLINK_OFF]``
 - Berry solidification of strings longer than 255 bytes (#20529)
+- Berry/Zigbee add web hook per device for customized status display
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
@@ -2211,6 +2211,7 @@ void ZigbeeShow(bool json)
 
       uint32_t now = Rtc.utc_time;
 
+      // iterate through devices by alphabetical order
       for (uint32_t i = 0; i < zigbee_num; i++) {
         const Z_Device &device = zigbee_devices.devicesAt(sorted_idx[i]);
         uint16_t shortaddr = device.shortaddr;
@@ -2365,6 +2366,10 @@ void ZigbeeShow(bool json)
           }
           WSContentSend_P(PSTR("{e}"));
         }
+#ifdef USE_BERRY
+        // Berry hook to display additional customized information
+        callBerryZigbeeDispatcher("web_device_status", nullptr, nullptr, shortaddr);
+#endif // USE_BERRY
       }
 
       WSContentSend_P(msg[ZB_WEB_LINE_END]);  // Terminate current multi column table and open new table


### PR DESCRIPTION
## Description:

Documentation will follow shortly.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
