### PR TITLE
Berry/Zigbee auto `import zigbee`

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_7_berry_embedded.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_7_berry_embedded.ino
@@ -89,6 +89,10 @@ const char berry_prog[] =
   "import solidify "
 #endif
 
+#ifdef USE_ZIGBEE
+  "import zigbee "
+#endif
+
 #ifdef USE_MATTER_DEVICE
   "import matter "
   "global.matter_device = matter.Device() "


### PR DESCRIPTION
## Description:

Automatic `import zigbee` at start is necessary for zigbee events to be processed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
