### PR TITLE
Matter fix support for Alexa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 shutter exception 6 (divide by zero) on ``ShutterMode 4`` (#20524)
 - GPIOViewer exception 3
 - Berry assigment to list with negative index
+- Matter fix support for Alexa
 
 ### Removed
 - Max number of 30 backlog entries

--- a/lib/libesp32/berry_matter/src/be_matter_module.c
+++ b/lib/libesp32/berry_matter/src/be_matter_module.c
@@ -285,6 +285,7 @@ module matter (scope: global, strings: weak) {
   _STYLESHEET, comptr(MATTER_STYLESHEET)
   _ADD_ENDPOINT_JS, comptr(MATTER_ADD_ENDPOINT_HINTS_JS)
   MATTER_OPTION, int(151)       // SetOption151 enables Matter
+  AGGREGATOR_ENDPOINT, int(0xFE)    // for Alexa we need only 8 bits endpoints
   seconds_to_dhm, ctype_func(matter_seconds_to_dhm)
 
   Verhoeff, class(be_class_Matter_Verhoeff)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Aggregator.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Aggregator.be
@@ -46,7 +46,7 @@ class Matter_Plugin_Aggregator : Matter_Plugin
         var pl = TLV.Matter_TLV_array()
         var eps = self.device.get_active_endpoints(true)
         for ep: eps
-          if ep < 0xFF00
+          if ep < matter.AGGREGATOR_ENDPOINT
             pl.add_TLV(nil, TLV.U2, ep)     # add each endpoint
           end
         end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Root.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Root.be
@@ -158,7 +158,7 @@ class Matter_Plugin_Root : Matter_Plugin
           var nocs = nocl.add_struct(nil)
           nocs.add_TLV(1, TLV.B2, loc_fabric.get_noc())      # NOC
           nocs.add_TLV(2, TLV.B2, loc_fabric.get_icac())     # ICAC
-          nocs.add_TLV(0xFE, TLV.U2, loc_fabric.get_fabric_index())    # Label
+          nocs.add_TLV(matter.AGGREGATOR_ENDPOINT, TLV.U2, loc_fabric.get_fabric_index())    # Label
         end
         return nocl
       elif attribute == 0x0001          #  ---------- Fabrics / list[FabricDescriptorStruct] ----------
@@ -312,7 +312,7 @@ class Matter_Plugin_Root : Matter_Plugin
         var disable_bridge_mode = self.device.disable_bridge_mode
         for ep: eps
           # if bridge mode is disabled, don't announce Aggregatore (above 0xFF00)
-          if !disable_bridge_mode || ep < 0xFF00
+          if !disable_bridge_mode || ep < matter.AGGREGATOR_ENDPOINT
             pl.add_TLV(nil, TLV.U2, ep)     # add each endpoint
           end
         end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
@@ -57,15 +57,19 @@ class Matter_Session_Store
   #############################################################
   # remove fabric
   def remove_fabric(fabric)
-    var idx = 0
-    while idx < size(self.sessions)
-      if self.sessions[idx]._fabric == fabric
-        self.sessions.remove(idx)
-      else
-        idx += 1
+    if (self.sessions != nil)
+      var idx = 0
+      while idx < size(self.sessions)
+        if self.sessions[idx]._fabric == fabric
+          self.sessions.remove(idx)
+        else
+          idx += 1
+        end
       end
     end
-    self.fabrics.remove(self.fabrics.find(fabric))     # fail safe
+    if (self.fabrics != nil)
+      self.fabrics.remove(self.fabrics.find(fabric))     # fail safe
+    end
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
@@ -837,7 +837,7 @@ class Matter_Device
     tasmota.log(format("MTR:   endpoint = %5i type:%s%s", 0, 'root', ''), 2)
 
     # always include an aggregator for dynamic endpoints
-    self.plugins.push(matter.Plugin_Aggregator(self, 0xFF00, {}))
+    self.plugins.push(matter.Plugin_Aggregator(self, matter.AGGREGATOR_ENDPOINT, {}))
 
     for ep: endpoints
       if ep == 0  continue end          # skip endpoint 0
@@ -859,7 +859,7 @@ class Matter_Device
         tasmota.log("MTR: Exception" + str(e) + "|" + str(m), 2)
       end
     end
-    tasmota.log(format("MTR:   endpoint = %5i type:%s%s", 0xFF00, 'aggregator', ''), 2)
+    tasmota.log(format("MTR:   endpoint = %5i type:%s%s", matter.AGGREGATOR_ENDPOINT, 'aggregator', ''), 2)
 
     tasmota.publish_result('{"Matter":{"Initialized":1}}', 'Matter')
   end
@@ -1396,7 +1396,7 @@ class Matter_Device
   def signal_endpoints_changed()
     # mark parts lists as changed
     self.attribute_updated(0x0000, 0x001D, 0x0003, false)
-    self.attribute_updated(0xFF00, 0x001D, 0x0003, false)
+    self.attribute_updated(matter.AGGREGATOR_ENDPOINT, 0x001D, 0x0003, false)
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Aggregator.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Aggregator.h
@@ -19,7 +19,7 @@ be_local_closure(Matter_Plugin_Aggregator_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
+    ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
@@ -28,23 +28,24 @@ be_local_closure(Matter_Plugin_Aggregator_read_attribute,   /* name */
     /* K5   */  be_nested_str_weak(Matter_TLV_array),
     /* K6   */  be_nested_str_weak(device),
     /* K7   */  be_nested_str_weak(get_active_endpoints),
-    /* K8   */  be_nested_str_weak(add_TLV),
-    /* K9   */  be_nested_str_weak(U2),
-    /* K10  */  be_nested_str_weak(stop_iteration),
-    /* K11  */  be_nested_str_weak(read_attribute),
+    /* K8   */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+    /* K9   */  be_nested_str_weak(add_TLV),
+    /* K10  */  be_nested_str_weak(U2),
+    /* K11  */  be_nested_str_weak(stop_iteration),
+    /* K12  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[55]) {  /* code */
+    ( &(const binstruction[56]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
       0x88180503,  //  0003  GETMBR	R6	R2	K3
       0x541E001C,  //  0004  LDINT	R7	29
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E0025,  //  0006  JMPF	R7	#002D
+      0x781E0026,  //  0006  JMPF	R7	#002E
       0x1C1C0D04,  //  0007  EQ	R7	R6	K4
-      0x781E0019,  //  0008  JMPF	R7	#0023
+      0x781E001A,  //  0008  JMPF	R7	#0024
       0x8C1C0905,  //  0009  GETMET	R7	R4	K5
       0x7C1C0200,  //  000A  CALL	R7	1
       0x88200106,  //  000B  GETMBR	R8	R0	K6
@@ -54,43 +55,44 @@ be_local_closure(Matter_Plugin_Aggregator_read_attribute,   /* name */
       0x60240010,  //  000F  GETGBL	R9	G16
       0x5C281000,  //  0010  MOVE	R10	R8
       0x7C240200,  //  0011  CALL	R9	1
-      0xA802000A,  //  0012  EXBLK	0	#001E
+      0xA802000B,  //  0012  EXBLK	0	#001F
       0x5C281200,  //  0013  MOVE	R10	R9
       0x7C280000,  //  0014  CALL	R10	0
-      0x542EFEFF,  //  0015  LDINT	R11	65280
-      0x142C140B,  //  0016  LT	R11	R10	R11
-      0x782E0004,  //  0017  JMPF	R11	#001D
-      0x8C2C0F08,  //  0018  GETMET	R11	R7	K8
-      0x4C340000,  //  0019  LDNIL	R13
-      0x88380909,  //  001A  GETMBR	R14	R4	K9
-      0x5C3C1400,  //  001B  MOVE	R15	R10
-      0x7C2C0800,  //  001C  CALL	R11	4
-      0x7001FFF4,  //  001D  JMP		#0013
-      0x5824000A,  //  001E  LDCONST	R9	K10
-      0xAC240200,  //  001F  CATCH	R9	1	0
-      0xB0080000,  //  0020  RAISE	2	R0	R0
-      0x80040E00,  //  0021  RET	1	R7
-      0x70020008,  //  0022  JMP		#002C
-      0x601C0003,  //  0023  GETGBL	R7	G3
-      0x5C200000,  //  0024  MOVE	R8	R0
-      0x7C1C0200,  //  0025  CALL	R7	1
-      0x8C1C0F0B,  //  0026  GETMET	R7	R7	K11
-      0x5C240200,  //  0027  MOVE	R9	R1
-      0x5C280400,  //  0028  MOVE	R10	R2
-      0x5C2C0600,  //  0029  MOVE	R11	R3
-      0x7C1C0800,  //  002A  CALL	R7	4
-      0x80040E00,  //  002B  RET	1	R7
-      0x70020008,  //  002C  JMP		#0036
-      0x601C0003,  //  002D  GETGBL	R7	G3
-      0x5C200000,  //  002E  MOVE	R8	R0
-      0x7C1C0200,  //  002F  CALL	R7	1
-      0x8C1C0F0B,  //  0030  GETMET	R7	R7	K11
-      0x5C240200,  //  0031  MOVE	R9	R1
-      0x5C280400,  //  0032  MOVE	R10	R2
-      0x5C2C0600,  //  0033  MOVE	R11	R3
-      0x7C1C0800,  //  0034  CALL	R7	4
-      0x80040E00,  //  0035  RET	1	R7
-      0x80000000,  //  0036  RET	0
+      0xB82E0000,  //  0015  GETNGBL	R11	K0
+      0x882C1708,  //  0016  GETMBR	R11	R11	K8
+      0x142C140B,  //  0017  LT	R11	R10	R11
+      0x782E0004,  //  0018  JMPF	R11	#001E
+      0x8C2C0F09,  //  0019  GETMET	R11	R7	K9
+      0x4C340000,  //  001A  LDNIL	R13
+      0x8838090A,  //  001B  GETMBR	R14	R4	K10
+      0x5C3C1400,  //  001C  MOVE	R15	R10
+      0x7C2C0800,  //  001D  CALL	R11	4
+      0x7001FFF3,  //  001E  JMP		#0013
+      0x5824000B,  //  001F  LDCONST	R9	K11
+      0xAC240200,  //  0020  CATCH	R9	1	0
+      0xB0080000,  //  0021  RAISE	2	R0	R0
+      0x80040E00,  //  0022  RET	1	R7
+      0x70020008,  //  0023  JMP		#002D
+      0x601C0003,  //  0024  GETGBL	R7	G3
+      0x5C200000,  //  0025  MOVE	R8	R0
+      0x7C1C0200,  //  0026  CALL	R7	1
+      0x8C1C0F0C,  //  0027  GETMET	R7	R7	K12
+      0x5C240200,  //  0028  MOVE	R9	R1
+      0x5C280400,  //  0029  MOVE	R10	R2
+      0x5C2C0600,  //  002A  MOVE	R11	R3
+      0x7C1C0800,  //  002B  CALL	R7	4
+      0x80040E00,  //  002C  RET	1	R7
+      0x70020008,  //  002D  JMP		#0037
+      0x601C0003,  //  002E  GETGBL	R7	G3
+      0x5C200000,  //  002F  MOVE	R8	R0
+      0x7C1C0200,  //  0030  CALL	R7	1
+      0x8C1C0F0C,  //  0031  GETMET	R7	R7	K12
+      0x5C240200,  //  0032  MOVE	R9	R1
+      0x5C280400,  //  0033  MOVE	R10	R2
+      0x5C2C0600,  //  0034  MOVE	R11	R3
+      0x7C1C0800,  //  0035  CALL	R7	4
+      0x80040E00,  //  0036  RET	1	R7
+      0x80000000,  //  0037  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Root.h
@@ -19,7 +19,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[92]) {     /* constants */
+    ( &(const bvalue[93]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
@@ -80,42 +80,43 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
     /* K57  */  be_nested_str_weak(B2),
     /* K58  */  be_nested_str_weak(get_noc),
     /* K59  */  be_nested_str_weak(get_icac),
-    /* K60  */  be_nested_str_weak(get_fabric_index),
-    /* K61  */  be_nested_str_weak(stop_iteration),
-    /* K62  */  be_nested_str_weak(parse),
-    /* K63  */  be_nested_str_weak(get_ca),
-    /* K64  */  be_nested_str_weak(findsubval),
-    /* K65  */  be_nested_str_weak(get_admin_vendor),
-    /* K66  */  be_nested_str_weak(get_fabric_id),
-    /* K67  */  be_nested_str_weak(get_device_id),
-    /* K68  */  be_nested_str_weak(get_fabric_label),
-    /* K69  */  be_nested_str_weak(Fabric),
-    /* K70  */  be_nested_str_weak(_MAX_CASE),
-    /* K71  */  be_nested_str_weak(count_active_fabrics),
-    /* K72  */  be_nested_str_weak(_fabric),
-    /* K73  */  be_nested_str_weak(is_commissioning_open),
-    /* K74  */  be_nested_str_weak(is_root_commissioning_open),
-    /* K75  */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K76  */  be_nested_str_weak(Tasmota),
-    /* K77  */  be_nested_str_weak(vendorid),
-    /* K78  */  be_nested_str_weak(DeviceName),
-    /* K79  */  be_nested_str_weak(FriendlyName),
-    /* K80  */  be_nested_str_weak(FriendlyName1),
-    /* K81  */  be_nested_str_weak(XX),
-    /* K82  */  be_nested_str_weak(Status_X202),
-    /* K83  */  be_nested_str_weak(StatusFWR),
-    /* K84  */  be_nested_str_weak(Hardware),
-    /* K85  */  be_nested_str_weak(Version),
-    /* K86  */  be_nested_str_weak(_X28),
-    /* K87  */  be_nested_str_weak(locale),
-    /* K88  */  be_nested_str_weak(create_TLV),
-    /* K89  */  be_nested_str_weak(get_active_endpoints),
-    /* K90  */  be_nested_str_weak(disable_bridge_mode),
-    /* K91  */  be_nested_str_weak(read_attribute),
+    /* K60  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+    /* K61  */  be_nested_str_weak(get_fabric_index),
+    /* K62  */  be_nested_str_weak(stop_iteration),
+    /* K63  */  be_nested_str_weak(parse),
+    /* K64  */  be_nested_str_weak(get_ca),
+    /* K65  */  be_nested_str_weak(findsubval),
+    /* K66  */  be_nested_str_weak(get_admin_vendor),
+    /* K67  */  be_nested_str_weak(get_fabric_id),
+    /* K68  */  be_nested_str_weak(get_device_id),
+    /* K69  */  be_nested_str_weak(get_fabric_label),
+    /* K70  */  be_nested_str_weak(Fabric),
+    /* K71  */  be_nested_str_weak(_MAX_CASE),
+    /* K72  */  be_nested_str_weak(count_active_fabrics),
+    /* K73  */  be_nested_str_weak(_fabric),
+    /* K74  */  be_nested_str_weak(is_commissioning_open),
+    /* K75  */  be_nested_str_weak(is_root_commissioning_open),
+    /* K76  */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K77  */  be_nested_str_weak(Tasmota),
+    /* K78  */  be_nested_str_weak(vendorid),
+    /* K79  */  be_nested_str_weak(DeviceName),
+    /* K80  */  be_nested_str_weak(FriendlyName),
+    /* K81  */  be_nested_str_weak(FriendlyName1),
+    /* K82  */  be_nested_str_weak(XX),
+    /* K83  */  be_nested_str_weak(Status_X202),
+    /* K84  */  be_nested_str_weak(StatusFWR),
+    /* K85  */  be_nested_str_weak(Hardware),
+    /* K86  */  be_nested_str_weak(Version),
+    /* K87  */  be_nested_str_weak(_X28),
+    /* K88  */  be_nested_str_weak(locale),
+    /* K89  */  be_nested_str_weak(create_TLV),
+    /* K90  */  be_nested_str_weak(get_active_endpoints),
+    /* K91  */  be_nested_str_weak(disable_bridge_mode),
+    /* K92  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[937]) {  /* code */
+    ( &(const binstruction[939]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xB8160200,  //  0001  GETNGBL	R5	K1
       0x88140B02,  //  0002  GETMBR	R5	R5	K2
@@ -172,11 +173,11 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x502C0000,  //  0035  LDBOOL	R11	0	0
       0x7C200600,  //  0036  CALL	R8	3
       0x80041000,  //  0037  RET	1	R8
-      0x7002036E,  //  0038  JMP		#03A8
+      0x70020370,  //  0038  JMP		#03AA
       0x54220031,  //  0039  LDINT	R8	50
       0x1C200C08,  //  003A  EQ	R8	R6	R8
       0x78220000,  //  003B  JMPF	R8	#003D
-      0x7002036A,  //  003C  JMP		#03A8
+      0x7002036C,  //  003C  JMP		#03AA
       0x54220032,  //  003D  LDINT	R8	51
       0x1C200C08,  //  003E  EQ	R8	R6	R8
       0x782200DC,  //  003F  JMPF	R8	#011D
@@ -400,11 +401,11 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x502C0000,  //  0119  LDBOOL	R11	0	0
       0x7C200600,  //  011A  CALL	R8	3
       0x80041000,  //  011B  RET	1	R8
-      0x7002028A,  //  011C  JMP		#03A8
+      0x7002028C,  //  011C  JMP		#03AA
       0x54220033,  //  011D  LDINT	R8	52
       0x1C200C08,  //  011E  EQ	R8	R6	R8
       0x78220000,  //  011F  JMPF	R8	#0121
-      0x70020286,  //  0120  JMP		#03A8
+      0x70020288,  //  0120  JMP		#03AA
       0x54220037,  //  0121  LDINT	R8	56
       0x1C200C08,  //  0122  EQ	R8	R6	R8
       0x7822002B,  //  0123  JMPF	R8	#0150
@@ -451,15 +452,15 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x5C301000,  //  014C  MOVE	R12	R8
       0x7C240600,  //  014D  CALL	R9	3
       0x80041200,  //  014E  RET	1	R9
-      0x70020257,  //  014F  JMP		#03A8
+      0x70020259,  //  014F  JMP		#03AA
       0x5422003D,  //  0150  LDINT	R8	62
       0x1C200C08,  //  0151  EQ	R8	R6	R8
-      0x782200AD,  //  0152  JMPF	R8	#0201
+      0x782200AE,  //  0152  JMPF	R8	#0202
       0x8C200133,  //  0153  GETMET	R8	R0	K51
       0x5C280400,  //  0154  MOVE	R10	R2
       0x7C200400,  //  0155  CALL	R8	2
       0x1C200F05,  //  0156  EQ	R8	R7	K5
-      0x78220032,  //  0157  JMPF	R8	#018B
+      0x78220033,  //  0157  JMPF	R8	#018C
       0x8C200B11,  //  0158  GETMET	R8	R5	K17
       0x7C200200,  //  0159  CALL	R8	1
       0x88240534,  //  015A  GETMBR	R9	R2	K52
@@ -477,7 +478,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x60280010,  //  0166  GETGBL	R10	G16
       0x5C2C1200,  //  0167  MOVE	R11	R9
       0x7C280200,  //  0168  CALL	R10	1
-      0xA802001B,  //  0169  EXBLK	0	#0186
+      0xA802001C,  //  0169  EXBLK	0	#0187
       0x5C2C1400,  //  016A  MOVE	R11	R10
       0x7C2C0000,  //  016B  CALL	R11	0
       0x4C300000,  //  016C  LDNIL	R12
@@ -500,559 +501,561 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x7C440200,  //  017D  CALL	R17	1
       0x7C340800,  //  017E  CALL	R13	4
       0x8C34190B,  //  017F  GETMET	R13	R12	K11
-      0x543E00FD,  //  0180  LDINT	R15	254
-      0x88400B0C,  //  0181  GETMBR	R16	R5	K12
-      0x8C44173C,  //  0182  GETMET	R17	R11	K60
-      0x7C440200,  //  0183  CALL	R17	1
-      0x7C340800,  //  0184  CALL	R13	4
-      0x7001FFE3,  //  0185  JMP		#016A
-      0x5828003D,  //  0186  LDCONST	R10	K61
-      0xAC280200,  //  0187  CATCH	R10	1	0
-      0xB0080000,  //  0188  RAISE	2	R0	R0
-      0x80041000,  //  0189  RET	1	R8
-      0x70020074,  //  018A  JMP		#0200
-      0x1C200F09,  //  018B  EQ	R8	R7	K9
-      0x78220049,  //  018C  JMPF	R8	#01D7
-      0x8C200B11,  //  018D  GETMET	R8	R5	K17
-      0x7C200200,  //  018E  CALL	R8	1
-      0x88240534,  //  018F  GETMBR	R9	R2	K52
-      0x78260005,  //  0190  JMPF	R9	#0197
-      0x60240012,  //  0191  GETGBL	R9	G18
-      0x7C240000,  //  0192  CALL	R9	0
-      0x8C280335,  //  0193  GETMET	R10	R1	K53
-      0x7C280200,  //  0194  CALL	R10	1
-      0x4028120A,  //  0195  CONNECT	R10	R9	R10
-      0x70020003,  //  0196  JMP		#019B
-      0x88240136,  //  0197  GETMBR	R9	R0	K54
-      0x88241337,  //  0198  GETMBR	R9	R9	K55
-      0x8C241338,  //  0199  GETMET	R9	R9	K56
-      0x7C240200,  //  019A  CALL	R9	1
-      0x60280010,  //  019B  GETGBL	R10	G16
-      0x5C2C1200,  //  019C  MOVE	R11	R9
-      0x7C280200,  //  019D  CALL	R10	1
-      0xA8020032,  //  019E  EXBLK	0	#01D2
-      0x5C2C1400,  //  019F  MOVE	R11	R10
-      0x7C2C0000,  //  01A0  CALL	R11	0
-      0x4C300000,  //  01A1  LDNIL	R12
-      0x1C30160C,  //  01A2  EQ	R12	R11	R12
-      0x78320000,  //  01A3  JMPF	R12	#01A5
-      0x7001FFF9,  //  01A4  JMP		#019F
-      0x8C300B3E,  //  01A5  GETMET	R12	R5	K62
-      0x8C38173F,  //  01A6  GETMET	R14	R11	K63
-      0x7C380200,  //  01A7  CALL	R14	1
-      0x7C300400,  //  01A8  CALL	R12	2
-      0x8C341115,  //  01A9  GETMET	R13	R8	K21
-      0x4C3C0000,  //  01AA  LDNIL	R15
-      0x7C340400,  //  01AB  CALL	R13	2
-      0x8C381B0B,  //  01AC  GETMET	R14	R13	K11
-      0x58400009,  //  01AD  LDCONST	R16	K9
-      0x88440B39,  //  01AE  GETMBR	R17	R5	K57
-      0x8C481940,  //  01AF  GETMET	R18	R12	K64
-      0x54520008,  //  01B0  LDINT	R20	9
-      0x7C480400,  //  01B1  CALL	R18	2
-      0x7C380800,  //  01B2  CALL	R14	4
-      0x8C381B0B,  //  01B3  GETMET	R14	R13	K11
-      0x5840000D,  //  01B4  LDCONST	R16	K13
-      0x88440B0C,  //  01B5  GETMBR	R17	R5	K12
-      0x8C481741,  //  01B6  GETMET	R18	R11	K65
-      0x7C480200,  //  01B7  CALL	R18	1
-      0x7C380800,  //  01B8  CALL	R14	4
-      0x8C381B0B,  //  01B9  GETMET	R14	R13	K11
-      0x5840000F,  //  01BA  LDCONST	R16	K15
-      0x88440B07,  //  01BB  GETMBR	R17	R5	K7
-      0x8C481742,  //  01BC  GETMET	R18	R11	K66
-      0x7C480200,  //  01BD  CALL	R18	1
-      0x7C380800,  //  01BE  CALL	R14	4
-      0x8C381B0B,  //  01BF  GETMET	R14	R13	K11
-      0x54420003,  //  01C0  LDINT	R16	4
-      0x88440B07,  //  01C1  GETMBR	R17	R5	K7
-      0x8C481743,  //  01C2  GETMET	R18	R11	K67
-      0x7C480200,  //  01C3  CALL	R18	1
-      0x7C380800,  //  01C4  CALL	R14	4
-      0x8C381B0B,  //  01C5  GETMET	R14	R13	K11
-      0x54420004,  //  01C6  LDINT	R16	5
-      0x88440B16,  //  01C7  GETMBR	R17	R5	K22
-      0x8C481744,  //  01C8  GETMET	R18	R11	K68
-      0x7C480200,  //  01C9  CALL	R18	1
-      0x7C380800,  //  01CA  CALL	R14	4
-      0x8C381B0B,  //  01CB  GETMET	R14	R13	K11
-      0x544200FD,  //  01CC  LDINT	R16	254
-      0x88440B0C,  //  01CD  GETMBR	R17	R5	K12
-      0x8C48173C,  //  01CE  GETMET	R18	R11	K60
-      0x7C480200,  //  01CF  CALL	R18	1
-      0x7C380800,  //  01D0  CALL	R14	4
-      0x7001FFCC,  //  01D1  JMP		#019F
-      0x5828003D,  //  01D2  LDCONST	R10	K61
-      0xAC280200,  //  01D3  CATCH	R10	1	0
-      0xB0080000,  //  01D4  RAISE	2	R0	R0
-      0x80041000,  //  01D5  RET	1	R8
-      0x70020028,  //  01D6  JMP		#0200
-      0x1C200F0D,  //  01D7  EQ	R8	R7	K13
-      0x78220007,  //  01D8  JMPF	R8	#01E1
-      0x8C200706,  //  01D9  GETMET	R8	R3	K6
-      0x88280B0E,  //  01DA  GETMBR	R10	R5	K14
-      0xB82E0200,  //  01DB  GETNGBL	R11	K1
-      0x882C1745,  //  01DC  GETMBR	R11	R11	K69
+      0xB83E0200,  //  0180  GETNGBL	R15	K1
+      0x883C1F3C,  //  0181  GETMBR	R15	R15	K60
+      0x88400B0C,  //  0182  GETMBR	R16	R5	K12
+      0x8C44173D,  //  0183  GETMET	R17	R11	K61
+      0x7C440200,  //  0184  CALL	R17	1
+      0x7C340800,  //  0185  CALL	R13	4
+      0x7001FFE2,  //  0186  JMP		#016A
+      0x5828003E,  //  0187  LDCONST	R10	K62
+      0xAC280200,  //  0188  CATCH	R10	1	0
+      0xB0080000,  //  0189  RAISE	2	R0	R0
+      0x80041000,  //  018A  RET	1	R8
+      0x70020074,  //  018B  JMP		#0201
+      0x1C200F09,  //  018C  EQ	R8	R7	K9
+      0x78220049,  //  018D  JMPF	R8	#01D8
+      0x8C200B11,  //  018E  GETMET	R8	R5	K17
+      0x7C200200,  //  018F  CALL	R8	1
+      0x88240534,  //  0190  GETMBR	R9	R2	K52
+      0x78260005,  //  0191  JMPF	R9	#0198
+      0x60240012,  //  0192  GETGBL	R9	G18
+      0x7C240000,  //  0193  CALL	R9	0
+      0x8C280335,  //  0194  GETMET	R10	R1	K53
+      0x7C280200,  //  0195  CALL	R10	1
+      0x4028120A,  //  0196  CONNECT	R10	R9	R10
+      0x70020003,  //  0197  JMP		#019C
+      0x88240136,  //  0198  GETMBR	R9	R0	K54
+      0x88241337,  //  0199  GETMBR	R9	R9	K55
+      0x8C241338,  //  019A  GETMET	R9	R9	K56
+      0x7C240200,  //  019B  CALL	R9	1
+      0x60280010,  //  019C  GETGBL	R10	G16
+      0x5C2C1200,  //  019D  MOVE	R11	R9
+      0x7C280200,  //  019E  CALL	R10	1
+      0xA8020032,  //  019F  EXBLK	0	#01D3
+      0x5C2C1400,  //  01A0  MOVE	R11	R10
+      0x7C2C0000,  //  01A1  CALL	R11	0
+      0x4C300000,  //  01A2  LDNIL	R12
+      0x1C30160C,  //  01A3  EQ	R12	R11	R12
+      0x78320000,  //  01A4  JMPF	R12	#01A6
+      0x7001FFF9,  //  01A5  JMP		#01A0
+      0x8C300B3F,  //  01A6  GETMET	R12	R5	K63
+      0x8C381740,  //  01A7  GETMET	R14	R11	K64
+      0x7C380200,  //  01A8  CALL	R14	1
+      0x7C300400,  //  01A9  CALL	R12	2
+      0x8C341115,  //  01AA  GETMET	R13	R8	K21
+      0x4C3C0000,  //  01AB  LDNIL	R15
+      0x7C340400,  //  01AC  CALL	R13	2
+      0x8C381B0B,  //  01AD  GETMET	R14	R13	K11
+      0x58400009,  //  01AE  LDCONST	R16	K9
+      0x88440B39,  //  01AF  GETMBR	R17	R5	K57
+      0x8C481941,  //  01B0  GETMET	R18	R12	K65
+      0x54520008,  //  01B1  LDINT	R20	9
+      0x7C480400,  //  01B2  CALL	R18	2
+      0x7C380800,  //  01B3  CALL	R14	4
+      0x8C381B0B,  //  01B4  GETMET	R14	R13	K11
+      0x5840000D,  //  01B5  LDCONST	R16	K13
+      0x88440B0C,  //  01B6  GETMBR	R17	R5	K12
+      0x8C481742,  //  01B7  GETMET	R18	R11	K66
+      0x7C480200,  //  01B8  CALL	R18	1
+      0x7C380800,  //  01B9  CALL	R14	4
+      0x8C381B0B,  //  01BA  GETMET	R14	R13	K11
+      0x5840000F,  //  01BB  LDCONST	R16	K15
+      0x88440B07,  //  01BC  GETMBR	R17	R5	K7
+      0x8C481743,  //  01BD  GETMET	R18	R11	K67
+      0x7C480200,  //  01BE  CALL	R18	1
+      0x7C380800,  //  01BF  CALL	R14	4
+      0x8C381B0B,  //  01C0  GETMET	R14	R13	K11
+      0x54420003,  //  01C1  LDINT	R16	4
+      0x88440B07,  //  01C2  GETMBR	R17	R5	K7
+      0x8C481744,  //  01C3  GETMET	R18	R11	K68
+      0x7C480200,  //  01C4  CALL	R18	1
+      0x7C380800,  //  01C5  CALL	R14	4
+      0x8C381B0B,  //  01C6  GETMET	R14	R13	K11
+      0x54420004,  //  01C7  LDINT	R16	5
+      0x88440B16,  //  01C8  GETMBR	R17	R5	K22
+      0x8C481745,  //  01C9  GETMET	R18	R11	K69
+      0x7C480200,  //  01CA  CALL	R18	1
+      0x7C380800,  //  01CB  CALL	R14	4
+      0x8C381B0B,  //  01CC  GETMET	R14	R13	K11
+      0x544200FD,  //  01CD  LDINT	R16	254
+      0x88440B0C,  //  01CE  GETMBR	R17	R5	K12
+      0x8C48173D,  //  01CF  GETMET	R18	R11	K61
+      0x7C480200,  //  01D0  CALL	R18	1
+      0x7C380800,  //  01D1  CALL	R14	4
+      0x7001FFCC,  //  01D2  JMP		#01A0
+      0x5828003E,  //  01D3  LDCONST	R10	K62
+      0xAC280200,  //  01D4  CATCH	R10	1	0
+      0xB0080000,  //  01D5  RAISE	2	R0	R0
+      0x80041000,  //  01D6  RET	1	R8
+      0x70020028,  //  01D7  JMP		#0201
+      0x1C200F0D,  //  01D8  EQ	R8	R7	K13
+      0x78220007,  //  01D9  JMPF	R8	#01E2
+      0x8C200706,  //  01DA  GETMET	R8	R3	K6
+      0x88280B0E,  //  01DB  GETMBR	R10	R5	K14
+      0xB82E0200,  //  01DC  GETNGBL	R11	K1
       0x882C1746,  //  01DD  GETMBR	R11	R11	K70
-      0x7C200600,  //  01DE  CALL	R8	3
-      0x80041000,  //  01DF  RET	1	R8
-      0x7002001E,  //  01E0  JMP		#0200
-      0x1C200F0F,  //  01E1  EQ	R8	R7	K15
-      0x78220009,  //  01E2  JMPF	R8	#01ED
-      0x88200136,  //  01E3  GETMBR	R8	R0	K54
-      0x88201137,  //  01E4  GETMBR	R8	R8	K55
-      0x8C201147,  //  01E5  GETMET	R8	R8	K71
-      0x7C200200,  //  01E6  CALL	R8	1
-      0x8C240706,  //  01E7  GETMET	R9	R3	K6
-      0x882C0B0E,  //  01E8  GETMBR	R11	R5	K14
-      0x5C301000,  //  01E9  MOVE	R12	R8
-      0x7C240600,  //  01EA  CALL	R9	3
-      0x80041200,  //  01EB  RET	1	R9
-      0x70020012,  //  01EC  JMP		#0200
-      0x54220003,  //  01ED  LDINT	R8	4
-      0x1C200E08,  //  01EE  EQ	R8	R7	R8
-      0x78220000,  //  01EF  JMPF	R8	#01F1
-      0x7002000E,  //  01F0  JMP		#0200
-      0x54220004,  //  01F1  LDINT	R8	5
-      0x1C200E08,  //  01F2  EQ	R8	R7	R8
-      0x7822000B,  //  01F3  JMPF	R8	#0200
-      0x88200348,  //  01F4  GETMBR	R8	R1	K72
-      0x8C20113C,  //  01F5  GETMET	R8	R8	K60
-      0x7C200200,  //  01F6  CALL	R8	1
-      0x4C240000,  //  01F7  LDNIL	R9
-      0x1C241009,  //  01F8  EQ	R9	R8	R9
-      0x78260000,  //  01F9  JMPF	R9	#01FB
-      0x58200005,  //  01FA  LDCONST	R8	K5
-      0x8C240706,  //  01FB  GETMET	R9	R3	K6
-      0x882C0B0E,  //  01FC  GETMBR	R11	R5	K14
-      0x5C301000,  //  01FD  MOVE	R12	R8
-      0x7C240600,  //  01FE  CALL	R9	3
-      0x80041200,  //  01FF  RET	1	R9
-      0x700201A6,  //  0200  JMP		#03A8
-      0x5422003B,  //  0201  LDINT	R8	60
-      0x1C200C08,  //  0202  EQ	R8	R6	R8
-      0x7822003C,  //  0203  JMPF	R8	#0241
-      0x1C200F05,  //  0204  EQ	R8	R7	K5
-      0x78220012,  //  0205  JMPF	R8	#0219
-      0x88200136,  //  0206  GETMBR	R8	R0	K54
-      0x8C201149,  //  0207  GETMET	R8	R8	K73
-      0x7C200200,  //  0208  CALL	R8	1
-      0x88240136,  //  0209  GETMBR	R9	R0	K54
-      0x8C24134A,  //  020A  GETMET	R9	R9	K74
-      0x7C240200,  //  020B  CALL	R9	1
-      0x78220004,  //  020C  JMPF	R8	#0212
-      0x78260001,  //  020D  JMPF	R9	#0210
-      0x5828000D,  //  020E  LDCONST	R10	K13
-      0x70020000,  //  020F  JMP		#0211
-      0x58280009,  //  0210  LDCONST	R10	K9
-      0x70020000,  //  0211  JMP		#0213
-      0x58280005,  //  0212  LDCONST	R10	K5
-      0x8C2C0706,  //  0213  GETMET	R11	R3	K6
-      0x88340B0E,  //  0214  GETMBR	R13	R5	K14
-      0x5C381400,  //  0215  MOVE	R14	R10
-      0x7C2C0600,  //  0216  CALL	R11	3
-      0x80041600,  //  0217  RET	1	R11
-      0x70020026,  //  0218  JMP		#0240
-      0x1C200F09,  //  0219  EQ	R8	R7	K9
-      0x78220011,  //  021A  JMPF	R8	#022D
-      0x88200136,  //  021B  GETMBR	R8	R0	K54
-      0x8820114B,  //  021C  GETMBR	R8	R8	K75
-      0x4C240000,  //  021D  LDNIL	R9
-      0x20241009,  //  021E  NE	R9	R8	R9
-      0x78260006,  //  021F  JMPF	R9	#0227
-      0x8C240706,  //  0220  GETMET	R9	R3	K6
-      0x882C0B0C,  //  0221  GETMBR	R11	R5	K12
-      0x8C30113C,  //  0222  GETMET	R12	R8	K60
-      0x7C300200,  //  0223  CALL	R12	1
-      0x7C240600,  //  0224  CALL	R9	3
-      0x80041200,  //  0225  RET	1	R9
-      0x70020004,  //  0226  JMP		#022C
-      0x8C240706,  //  0227  GETMET	R9	R3	K6
-      0x882C0B18,  //  0228  GETMBR	R11	R5	K24
-      0x4C300000,  //  0229  LDNIL	R12
-      0x7C240600,  //  022A  CALL	R9	3
-      0x80041200,  //  022B  RET	1	R9
-      0x70020012,  //  022C  JMP		#0240
-      0x1C200F0D,  //  022D  EQ	R8	R7	K13
-      0x78220010,  //  022E  JMPF	R8	#0240
-      0x88200136,  //  022F  GETMBR	R8	R0	K54
-      0x8820114B,  //  0230  GETMBR	R8	R8	K75
-      0x4C240000,  //  0231  LDNIL	R9
-      0x20241009,  //  0232  NE	R9	R8	R9
-      0x78260006,  //  0233  JMPF	R9	#023B
-      0x8C240706,  //  0234  GETMET	R9	R3	K6
-      0x882C0B0C,  //  0235  GETMBR	R11	R5	K12
-      0x8C301141,  //  0236  GETMET	R12	R8	K65
-      0x7C300200,  //  0237  CALL	R12	1
-      0x7C240600,  //  0238  CALL	R9	3
-      0x80041200,  //  0239  RET	1	R9
-      0x70020004,  //  023A  JMP		#0240
-      0x8C240706,  //  023B  GETMET	R9	R3	K6
-      0x882C0B18,  //  023C  GETMBR	R11	R5	K24
-      0x4C300000,  //  023D  LDNIL	R12
-      0x7C240600,  //  023E  CALL	R9	3
-      0x80041200,  //  023F  RET	1	R9
-      0x70020166,  //  0240  JMP		#03A8
-      0x54220027,  //  0241  LDINT	R8	40
-      0x1C200C08,  //  0242  EQ	R8	R6	R8
-      0x782200BA,  //  0243  JMPF	R8	#02FF
-      0x8C200133,  //  0244  GETMET	R8	R0	K51
-      0x5C280400,  //  0245  MOVE	R10	R2
-      0x7C200400,  //  0246  CALL	R8	2
-      0x1C200F05,  //  0247  EQ	R8	R7	K5
-      0x78220005,  //  0248  JMPF	R8	#024F
-      0x8C200706,  //  0249  GETMET	R8	R3	K6
-      0x88280B0C,  //  024A  GETMBR	R10	R5	K12
-      0x582C0009,  //  024B  LDCONST	R11	K9
-      0x7C200600,  //  024C  CALL	R8	3
-      0x80041000,  //  024D  RET	1	R8
-      0x700200AE,  //  024E  JMP		#02FE
-      0x1C200F09,  //  024F  EQ	R8	R7	K9
-      0x78220005,  //  0250  JMPF	R8	#0257
-      0x8C200706,  //  0251  GETMET	R8	R3	K6
-      0x88280B16,  //  0252  GETMBR	R10	R5	K22
-      0x582C004C,  //  0253  LDCONST	R11	K76
-      0x7C200600,  //  0254  CALL	R8	3
-      0x80041000,  //  0255  RET	1	R8
-      0x700200A6,  //  0256  JMP		#02FE
-      0x1C200F0D,  //  0257  EQ	R8	R7	K13
-      0x78220006,  //  0258  JMPF	R8	#0260
-      0x8C200706,  //  0259  GETMET	R8	R3	K6
-      0x88280B0C,  //  025A  GETMBR	R10	R5	K12
-      0x882C0136,  //  025B  GETMBR	R11	R0	K54
-      0x882C174D,  //  025C  GETMBR	R11	R11	K77
-      0x7C200600,  //  025D  CALL	R8	3
-      0x80041000,  //  025E  RET	1	R8
-      0x7002009D,  //  025F  JMP		#02FE
-      0x1C200F0F,  //  0260  EQ	R8	R7	K15
-      0x7822000A,  //  0261  JMPF	R8	#026D
-      0x8C200706,  //  0262  GETMET	R8	R3	K6
-      0x88280B16,  //  0263  GETMBR	R10	R5	K22
-      0xB82E2400,  //  0264  GETNGBL	R11	K18
-      0x8C2C1726,  //  0265  GETMET	R11	R11	K38
-      0x5834004E,  //  0266  LDCONST	R13	K78
-      0x50380200,  //  0267  LDBOOL	R14	1	0
-      0x7C2C0600,  //  0268  CALL	R11	3
-      0x942C174E,  //  0269  GETIDX	R11	R11	K78
-      0x7C200600,  //  026A  CALL	R8	3
-      0x80041000,  //  026B  RET	1	R8
-      0x70020090,  //  026C  JMP		#02FE
-      0x54220003,  //  026D  LDINT	R8	4
-      0x1C200E08,  //  026E  EQ	R8	R7	R8
-      0x78220005,  //  026F  JMPF	R8	#0276
-      0x8C200706,  //  0270  GETMET	R8	R3	K6
-      0x88280B0C,  //  0271  GETMBR	R10	R5	K12
-      0x542E7FFF,  //  0272  LDINT	R11	32768
-      0x7C200600,  //  0273  CALL	R8	3
-      0x80041000,  //  0274  RET	1	R8
-      0x70020087,  //  0275  JMP		#02FE
-      0x54220004,  //  0276  LDINT	R8	5
-      0x1C200E08,  //  0277  EQ	R8	R7	R8
-      0x7822000A,  //  0278  JMPF	R8	#0284
-      0x8C200706,  //  0279  GETMET	R8	R3	K6
-      0x88280B16,  //  027A  GETMBR	R10	R5	K22
-      0xB82E2400,  //  027B  GETNGBL	R11	K18
-      0x8C2C1726,  //  027C  GETMET	R11	R11	K38
-      0x5834004F,  //  027D  LDCONST	R13	K79
-      0x50380200,  //  027E  LDBOOL	R14	1	0
-      0x7C2C0600,  //  027F  CALL	R11	3
-      0x942C1750,  //  0280  GETIDX	R11	R11	K80
-      0x7C200600,  //  0281  CALL	R8	3
-      0x80041000,  //  0282  RET	1	R8
-      0x70020079,  //  0283  JMP		#02FE
-      0x54220005,  //  0284  LDINT	R8	6
-      0x1C200E08,  //  0285  EQ	R8	R7	R8
-      0x78220005,  //  0286  JMPF	R8	#028D
-      0x8C200706,  //  0287  GETMET	R8	R3	K6
-      0x88280B16,  //  0288  GETMBR	R10	R5	K22
-      0x582C0051,  //  0289  LDCONST	R11	K81
-      0x7C200600,  //  028A  CALL	R8	3
-      0x80041000,  //  028B  RET	1	R8
-      0x70020070,  //  028C  JMP		#02FE
-      0x54220006,  //  028D  LDINT	R8	7
-      0x1C200E08,  //  028E  EQ	R8	R7	R8
-      0x78220005,  //  028F  JMPF	R8	#0296
-      0x8C200706,  //  0290  GETMET	R8	R3	K6
-      0x88280B0C,  //  0291  GETMBR	R10	R5	K12
-      0x582C0005,  //  0292  LDCONST	R11	K5
-      0x7C200600,  //  0293  CALL	R8	3
-      0x80041000,  //  0294  RET	1	R8
-      0x70020067,  //  0295  JMP		#02FE
-      0x54220007,  //  0296  LDINT	R8	8
-      0x1C200E08,  //  0297  EQ	R8	R7	R8
-      0x7822000B,  //  0298  JMPF	R8	#02A5
-      0x8C200706,  //  0299  GETMET	R8	R3	K6
-      0x88280B16,  //  029A  GETMBR	R10	R5	K22
-      0xB82E2400,  //  029B  GETNGBL	R11	K18
-      0x8C2C1726,  //  029C  GETMET	R11	R11	K38
-      0x58340052,  //  029D  LDCONST	R13	K82
-      0x50380200,  //  029E  LDBOOL	R14	1	0
-      0x7C2C0600,  //  029F  CALL	R11	3
-      0x942C1753,  //  02A0  GETIDX	R11	R11	K83
+      0x882C1747,  //  01DE  GETMBR	R11	R11	K71
+      0x7C200600,  //  01DF  CALL	R8	3
+      0x80041000,  //  01E0  RET	1	R8
+      0x7002001E,  //  01E1  JMP		#0201
+      0x1C200F0F,  //  01E2  EQ	R8	R7	K15
+      0x78220009,  //  01E3  JMPF	R8	#01EE
+      0x88200136,  //  01E4  GETMBR	R8	R0	K54
+      0x88201137,  //  01E5  GETMBR	R8	R8	K55
+      0x8C201148,  //  01E6  GETMET	R8	R8	K72
+      0x7C200200,  //  01E7  CALL	R8	1
+      0x8C240706,  //  01E8  GETMET	R9	R3	K6
+      0x882C0B0E,  //  01E9  GETMBR	R11	R5	K14
+      0x5C301000,  //  01EA  MOVE	R12	R8
+      0x7C240600,  //  01EB  CALL	R9	3
+      0x80041200,  //  01EC  RET	1	R9
+      0x70020012,  //  01ED  JMP		#0201
+      0x54220003,  //  01EE  LDINT	R8	4
+      0x1C200E08,  //  01EF  EQ	R8	R7	R8
+      0x78220000,  //  01F0  JMPF	R8	#01F2
+      0x7002000E,  //  01F1  JMP		#0201
+      0x54220004,  //  01F2  LDINT	R8	5
+      0x1C200E08,  //  01F3  EQ	R8	R7	R8
+      0x7822000B,  //  01F4  JMPF	R8	#0201
+      0x88200349,  //  01F5  GETMBR	R8	R1	K73
+      0x8C20113D,  //  01F6  GETMET	R8	R8	K61
+      0x7C200200,  //  01F7  CALL	R8	1
+      0x4C240000,  //  01F8  LDNIL	R9
+      0x1C241009,  //  01F9  EQ	R9	R8	R9
+      0x78260000,  //  01FA  JMPF	R9	#01FC
+      0x58200005,  //  01FB  LDCONST	R8	K5
+      0x8C240706,  //  01FC  GETMET	R9	R3	K6
+      0x882C0B0E,  //  01FD  GETMBR	R11	R5	K14
+      0x5C301000,  //  01FE  MOVE	R12	R8
+      0x7C240600,  //  01FF  CALL	R9	3
+      0x80041200,  //  0200  RET	1	R9
+      0x700201A7,  //  0201  JMP		#03AA
+      0x5422003B,  //  0202  LDINT	R8	60
+      0x1C200C08,  //  0203  EQ	R8	R6	R8
+      0x7822003C,  //  0204  JMPF	R8	#0242
+      0x1C200F05,  //  0205  EQ	R8	R7	K5
+      0x78220012,  //  0206  JMPF	R8	#021A
+      0x88200136,  //  0207  GETMBR	R8	R0	K54
+      0x8C20114A,  //  0208  GETMET	R8	R8	K74
+      0x7C200200,  //  0209  CALL	R8	1
+      0x88240136,  //  020A  GETMBR	R9	R0	K54
+      0x8C24134B,  //  020B  GETMET	R9	R9	K75
+      0x7C240200,  //  020C  CALL	R9	1
+      0x78220004,  //  020D  JMPF	R8	#0213
+      0x78260001,  //  020E  JMPF	R9	#0211
+      0x5828000D,  //  020F  LDCONST	R10	K13
+      0x70020000,  //  0210  JMP		#0212
+      0x58280009,  //  0211  LDCONST	R10	K9
+      0x70020000,  //  0212  JMP		#0214
+      0x58280005,  //  0213  LDCONST	R10	K5
+      0x8C2C0706,  //  0214  GETMET	R11	R3	K6
+      0x88340B0E,  //  0215  GETMBR	R13	R5	K14
+      0x5C381400,  //  0216  MOVE	R14	R10
+      0x7C2C0600,  //  0217  CALL	R11	3
+      0x80041600,  //  0218  RET	1	R11
+      0x70020026,  //  0219  JMP		#0241
+      0x1C200F09,  //  021A  EQ	R8	R7	K9
+      0x78220011,  //  021B  JMPF	R8	#022E
+      0x88200136,  //  021C  GETMBR	R8	R0	K54
+      0x8820114C,  //  021D  GETMBR	R8	R8	K76
+      0x4C240000,  //  021E  LDNIL	R9
+      0x20241009,  //  021F  NE	R9	R8	R9
+      0x78260006,  //  0220  JMPF	R9	#0228
+      0x8C240706,  //  0221  GETMET	R9	R3	K6
+      0x882C0B0C,  //  0222  GETMBR	R11	R5	K12
+      0x8C30113D,  //  0223  GETMET	R12	R8	K61
+      0x7C300200,  //  0224  CALL	R12	1
+      0x7C240600,  //  0225  CALL	R9	3
+      0x80041200,  //  0226  RET	1	R9
+      0x70020004,  //  0227  JMP		#022D
+      0x8C240706,  //  0228  GETMET	R9	R3	K6
+      0x882C0B18,  //  0229  GETMBR	R11	R5	K24
+      0x4C300000,  //  022A  LDNIL	R12
+      0x7C240600,  //  022B  CALL	R9	3
+      0x80041200,  //  022C  RET	1	R9
+      0x70020012,  //  022D  JMP		#0241
+      0x1C200F0D,  //  022E  EQ	R8	R7	K13
+      0x78220010,  //  022F  JMPF	R8	#0241
+      0x88200136,  //  0230  GETMBR	R8	R0	K54
+      0x8820114C,  //  0231  GETMBR	R8	R8	K76
+      0x4C240000,  //  0232  LDNIL	R9
+      0x20241009,  //  0233  NE	R9	R8	R9
+      0x78260006,  //  0234  JMPF	R9	#023C
+      0x8C240706,  //  0235  GETMET	R9	R3	K6
+      0x882C0B0C,  //  0236  GETMBR	R11	R5	K12
+      0x8C301142,  //  0237  GETMET	R12	R8	K66
+      0x7C300200,  //  0238  CALL	R12	1
+      0x7C240600,  //  0239  CALL	R9	3
+      0x80041200,  //  023A  RET	1	R9
+      0x70020004,  //  023B  JMP		#0241
+      0x8C240706,  //  023C  GETMET	R9	R3	K6
+      0x882C0B18,  //  023D  GETMBR	R11	R5	K24
+      0x4C300000,  //  023E  LDNIL	R12
+      0x7C240600,  //  023F  CALL	R9	3
+      0x80041200,  //  0240  RET	1	R9
+      0x70020167,  //  0241  JMP		#03AA
+      0x54220027,  //  0242  LDINT	R8	40
+      0x1C200C08,  //  0243  EQ	R8	R6	R8
+      0x782200BA,  //  0244  JMPF	R8	#0300
+      0x8C200133,  //  0245  GETMET	R8	R0	K51
+      0x5C280400,  //  0246  MOVE	R10	R2
+      0x7C200400,  //  0247  CALL	R8	2
+      0x1C200F05,  //  0248  EQ	R8	R7	K5
+      0x78220005,  //  0249  JMPF	R8	#0250
+      0x8C200706,  //  024A  GETMET	R8	R3	K6
+      0x88280B0C,  //  024B  GETMBR	R10	R5	K12
+      0x582C0009,  //  024C  LDCONST	R11	K9
+      0x7C200600,  //  024D  CALL	R8	3
+      0x80041000,  //  024E  RET	1	R8
+      0x700200AE,  //  024F  JMP		#02FF
+      0x1C200F09,  //  0250  EQ	R8	R7	K9
+      0x78220005,  //  0251  JMPF	R8	#0258
+      0x8C200706,  //  0252  GETMET	R8	R3	K6
+      0x88280B16,  //  0253  GETMBR	R10	R5	K22
+      0x582C004D,  //  0254  LDCONST	R11	K77
+      0x7C200600,  //  0255  CALL	R8	3
+      0x80041000,  //  0256  RET	1	R8
+      0x700200A6,  //  0257  JMP		#02FF
+      0x1C200F0D,  //  0258  EQ	R8	R7	K13
+      0x78220006,  //  0259  JMPF	R8	#0261
+      0x8C200706,  //  025A  GETMET	R8	R3	K6
+      0x88280B0C,  //  025B  GETMBR	R10	R5	K12
+      0x882C0136,  //  025C  GETMBR	R11	R0	K54
+      0x882C174E,  //  025D  GETMBR	R11	R11	K78
+      0x7C200600,  //  025E  CALL	R8	3
+      0x80041000,  //  025F  RET	1	R8
+      0x7002009D,  //  0260  JMP		#02FF
+      0x1C200F0F,  //  0261  EQ	R8	R7	K15
+      0x7822000A,  //  0262  JMPF	R8	#026E
+      0x8C200706,  //  0263  GETMET	R8	R3	K6
+      0x88280B16,  //  0264  GETMBR	R10	R5	K22
+      0xB82E2400,  //  0265  GETNGBL	R11	K18
+      0x8C2C1726,  //  0266  GETMET	R11	R11	K38
+      0x5834004F,  //  0267  LDCONST	R13	K79
+      0x50380200,  //  0268  LDBOOL	R14	1	0
+      0x7C2C0600,  //  0269  CALL	R11	3
+      0x942C174F,  //  026A  GETIDX	R11	R11	K79
+      0x7C200600,  //  026B  CALL	R8	3
+      0x80041000,  //  026C  RET	1	R8
+      0x70020090,  //  026D  JMP		#02FF
+      0x54220003,  //  026E  LDINT	R8	4
+      0x1C200E08,  //  026F  EQ	R8	R7	R8
+      0x78220005,  //  0270  JMPF	R8	#0277
+      0x8C200706,  //  0271  GETMET	R8	R3	K6
+      0x88280B0C,  //  0272  GETMBR	R10	R5	K12
+      0x542E7FFF,  //  0273  LDINT	R11	32768
+      0x7C200600,  //  0274  CALL	R8	3
+      0x80041000,  //  0275  RET	1	R8
+      0x70020087,  //  0276  JMP		#02FF
+      0x54220004,  //  0277  LDINT	R8	5
+      0x1C200E08,  //  0278  EQ	R8	R7	R8
+      0x7822000A,  //  0279  JMPF	R8	#0285
+      0x8C200706,  //  027A  GETMET	R8	R3	K6
+      0x88280B16,  //  027B  GETMBR	R10	R5	K22
+      0xB82E2400,  //  027C  GETNGBL	R11	K18
+      0x8C2C1726,  //  027D  GETMET	R11	R11	K38
+      0x58340050,  //  027E  LDCONST	R13	K80
+      0x50380200,  //  027F  LDBOOL	R14	1	0
+      0x7C2C0600,  //  0280  CALL	R11	3
+      0x942C1751,  //  0281  GETIDX	R11	R11	K81
+      0x7C200600,  //  0282  CALL	R8	3
+      0x80041000,  //  0283  RET	1	R8
+      0x70020079,  //  0284  JMP		#02FF
+      0x54220005,  //  0285  LDINT	R8	6
+      0x1C200E08,  //  0286  EQ	R8	R7	R8
+      0x78220005,  //  0287  JMPF	R8	#028E
+      0x8C200706,  //  0288  GETMET	R8	R3	K6
+      0x88280B16,  //  0289  GETMBR	R10	R5	K22
+      0x582C0052,  //  028A  LDCONST	R11	K82
+      0x7C200600,  //  028B  CALL	R8	3
+      0x80041000,  //  028C  RET	1	R8
+      0x70020070,  //  028D  JMP		#02FF
+      0x54220006,  //  028E  LDINT	R8	7
+      0x1C200E08,  //  028F  EQ	R8	R7	R8
+      0x78220005,  //  0290  JMPF	R8	#0297
+      0x8C200706,  //  0291  GETMET	R8	R3	K6
+      0x88280B0C,  //  0292  GETMBR	R10	R5	K12
+      0x582C0005,  //  0293  LDCONST	R11	K5
+      0x7C200600,  //  0294  CALL	R8	3
+      0x80041000,  //  0295  RET	1	R8
+      0x70020067,  //  0296  JMP		#02FF
+      0x54220007,  //  0297  LDINT	R8	8
+      0x1C200E08,  //  0298  EQ	R8	R7	R8
+      0x7822000B,  //  0299  JMPF	R8	#02A6
+      0x8C200706,  //  029A  GETMET	R8	R3	K6
+      0x88280B16,  //  029B  GETMBR	R10	R5	K22
+      0xB82E2400,  //  029C  GETNGBL	R11	K18
+      0x8C2C1726,  //  029D  GETMET	R11	R11	K38
+      0x58340053,  //  029E  LDCONST	R13	K83
+      0x50380200,  //  029F  LDBOOL	R14	1	0
+      0x7C2C0600,  //  02A0  CALL	R11	3
       0x942C1754,  //  02A1  GETIDX	R11	R11	K84
-      0x7C200600,  //  02A2  CALL	R8	3
-      0x80041000,  //  02A3  RET	1	R8
-      0x70020058,  //  02A4  JMP		#02FE
-      0x54220008,  //  02A5  LDINT	R8	9
-      0x1C200E08,  //  02A6  EQ	R8	R7	R8
-      0x78220005,  //  02A7  JMPF	R8	#02AE
-      0x8C200706,  //  02A8  GETMET	R8	R3	K6
-      0x88280B0C,  //  02A9  GETMBR	R10	R5	K12
-      0x582C0009,  //  02AA  LDCONST	R11	K9
-      0x7C200600,  //  02AB  CALL	R8	3
-      0x80041000,  //  02AC  RET	1	R8
-      0x7002004F,  //  02AD  JMP		#02FE
-      0x54220009,  //  02AE  LDINT	R8	10
-      0x1C200E08,  //  02AF  EQ	R8	R7	R8
-      0x78220015,  //  02B0  JMPF	R8	#02C7
-      0xB8222400,  //  02B1  GETNGBL	R8	K18
-      0x8C201126,  //  02B2  GETMET	R8	R8	K38
-      0x58280052,  //  02B3  LDCONST	R10	K82
-      0x502C0200,  //  02B4  LDBOOL	R11	1	0
-      0x7C200600,  //  02B5  CALL	R8	3
-      0x94201153,  //  02B6  GETIDX	R8	R8	K83
-      0x94201155,  //  02B7  GETIDX	R8	R8	K85
-      0x8C24091B,  //  02B8  GETMET	R9	R4	K27
-      0x5C2C1000,  //  02B9  MOVE	R11	R8
-      0x58300056,  //  02BA  LDCONST	R12	K86
-      0x7C240600,  //  02BB  CALL	R9	3
-      0x24281305,  //  02BC  GT	R10	R9	K5
-      0x782A0002,  //  02BD  JMPF	R10	#02C1
-      0x04281309,  //  02BE  SUB	R10	R9	K9
-      0x402A0A0A,  //  02BF  CONNECT	R10	K5	R10
-      0x9420100A,  //  02C0  GETIDX	R8	R8	R10
-      0x8C280706,  //  02C1  GETMET	R10	R3	K6
-      0x88300B16,  //  02C2  GETMBR	R12	R5	K22
-      0x5C341000,  //  02C3  MOVE	R13	R8
-      0x7C280600,  //  02C4  CALL	R10	3
-      0x80041400,  //  02C5  RET	1	R10
-      0x70020036,  //  02C6  JMP		#02FE
-      0x5422000E,  //  02C7  LDINT	R8	15
-      0x1C200E08,  //  02C8  EQ	R8	R7	R8
-      0x7822000B,  //  02C9  JMPF	R8	#02D6
-      0x8C200706,  //  02CA  GETMET	R8	R3	K6
-      0x88280B16,  //  02CB  GETMBR	R10	R5	K22
-      0xB82E2400,  //  02CC  GETNGBL	R11	K18
-      0x8C2C1725,  //  02CD  GETMET	R11	R11	K37
-      0x7C2C0200,  //  02CE  CALL	R11	1
-      0x8C2C171B,  //  02CF  GETMET	R11	R11	K27
-      0x5834001C,  //  02D0  LDCONST	R13	K28
-      0x5838001D,  //  02D1  LDCONST	R14	K29
-      0x7C2C0600,  //  02D2  CALL	R11	3
-      0x7C200600,  //  02D3  CALL	R8	3
-      0x80041000,  //  02D4  RET	1	R8
-      0x70020027,  //  02D5  JMP		#02FE
-      0x54220010,  //  02D6  LDINT	R8	17
-      0x1C200E08,  //  02D7  EQ	R8	R7	R8
-      0x78220005,  //  02D8  JMPF	R8	#02DF
-      0x8C200706,  //  02D9  GETMET	R8	R3	K6
-      0x88280B10,  //  02DA  GETMBR	R10	R5	K16
-      0x582C0009,  //  02DB  LDCONST	R11	K9
-      0x7C200600,  //  02DC  CALL	R8	3
-      0x80041000,  //  02DD  RET	1	R8
-      0x7002001E,  //  02DE  JMP		#02FE
-      0x54220011,  //  02DF  LDINT	R8	18
-      0x1C200E08,  //  02E0  EQ	R8	R7	R8
-      0x7822000B,  //  02E1  JMPF	R8	#02EE
-      0x8C200706,  //  02E2  GETMET	R8	R3	K6
-      0x88280B16,  //  02E3  GETMBR	R10	R5	K22
-      0xB82E2400,  //  02E4  GETNGBL	R11	K18
-      0x8C2C1725,  //  02E5  GETMET	R11	R11	K37
-      0x7C2C0200,  //  02E6  CALL	R11	1
-      0x8C2C171B,  //  02E7  GETMET	R11	R11	K27
-      0x5834001C,  //  02E8  LDCONST	R13	K28
-      0x5838001D,  //  02E9  LDCONST	R14	K29
-      0x7C2C0600,  //  02EA  CALL	R11	3
-      0x7C200600,  //  02EB  CALL	R8	3
-      0x80041000,  //  02EC  RET	1	R8
-      0x7002000F,  //  02ED  JMP		#02FE
-      0x54220012,  //  02EE  LDINT	R8	19
-      0x1C200E08,  //  02EF  EQ	R8	R7	R8
-      0x7822000C,  //  02F0  JMPF	R8	#02FE
-      0x8C200B0A,  //  02F1  GETMET	R8	R5	K10
-      0x7C200200,  //  02F2  CALL	R8	1
-      0x8C24110B,  //  02F3  GETMET	R9	R8	K11
-      0x582C0005,  //  02F4  LDCONST	R11	K5
-      0x88300B0C,  //  02F5  GETMBR	R12	R5	K12
-      0x5834000F,  //  02F6  LDCONST	R13	K15
-      0x7C240800,  //  02F7  CALL	R9	4
-      0x8C24110B,  //  02F8  GETMET	R9	R8	K11
-      0x582C0009,  //  02F9  LDCONST	R11	K9
-      0x88300B0C,  //  02FA  GETMBR	R12	R5	K12
-      0x5834000F,  //  02FB  LDCONST	R13	K15
-      0x7C240800,  //  02FC  CALL	R9	4
-      0x80041000,  //  02FD  RET	1	R8
-      0x700200A8,  //  02FE  JMP		#03A8
-      0x5422003E,  //  02FF  LDINT	R8	63
-      0x1C200C08,  //  0300  EQ	R8	R6	R8
-      0x78220000,  //  0301  JMPF	R8	#0303
-      0x700200A4,  //  0302  JMP		#03A8
-      0x54220029,  //  0303  LDINT	R8	42
-      0x1C200C08,  //  0304  EQ	R8	R6	R8
-      0x7822001D,  //  0305  JMPF	R8	#0324
-      0x1C200F05,  //  0306  EQ	R8	R7	K5
-      0x78220003,  //  0307  JMPF	R8	#030C
-      0x8C200B11,  //  0308  GETMET	R8	R5	K17
-      0x7C200200,  //  0309  CALL	R8	1
-      0x80041000,  //  030A  RET	1	R8
-      0x70020016,  //  030B  JMP		#0323
-      0x1C200F09,  //  030C  EQ	R8	R7	K9
-      0x78220005,  //  030D  JMPF	R8	#0314
-      0x8C200706,  //  030E  GETMET	R8	R3	K6
-      0x88280B10,  //  030F  GETMBR	R10	R5	K16
-      0x582C0005,  //  0310  LDCONST	R11	K5
-      0x7C200600,  //  0311  CALL	R8	3
-      0x80041000,  //  0312  RET	1	R8
-      0x7002000E,  //  0313  JMP		#0323
-      0x1C200F0D,  //  0314  EQ	R8	R7	K13
-      0x78220005,  //  0315  JMPF	R8	#031C
-      0x8C200706,  //  0316  GETMET	R8	R3	K6
-      0x88280B0E,  //  0317  GETMBR	R10	R5	K14
-      0x582C0009,  //  0318  LDCONST	R11	K9
-      0x7C200600,  //  0319  CALL	R8	3
-      0x80041000,  //  031A  RET	1	R8
-      0x70020006,  //  031B  JMP		#0323
-      0x1C200F0F,  //  031C  EQ	R8	R7	K15
-      0x78220004,  //  031D  JMPF	R8	#0323
-      0x8C200706,  //  031E  GETMET	R8	R3	K6
-      0x88280B18,  //  031F  GETMBR	R10	R5	K24
-      0x4C2C0000,  //  0320  LDNIL	R11
-      0x7C200600,  //  0321  CALL	R8	3
-      0x80041000,  //  0322  RET	1	R8
-      0x70020083,  //  0323  JMP		#03A8
-      0x5422002A,  //  0324  LDINT	R8	43
-      0x1C200C08,  //  0325  EQ	R8	R6	R8
-      0x78220016,  //  0326  JMPF	R8	#033E
-      0x1C200F05,  //  0327  EQ	R8	R7	K5
-      0x78220007,  //  0328  JMPF	R8	#0331
-      0x8C200706,  //  0329  GETMET	R8	R3	K6
-      0x88280B16,  //  032A  GETMBR	R10	R5	K22
-      0xB82E2400,  //  032B  GETNGBL	R11	K18
-      0x8C2C1757,  //  032C  GETMET	R11	R11	K87
-      0x7C2C0200,  //  032D  CALL	R11	1
-      0x7C200600,  //  032E  CALL	R8	3
-      0x80041000,  //  032F  RET	1	R8
-      0x7002000B,  //  0330  JMP		#033D
-      0x1C200F09,  //  0331  EQ	R8	R7	K9
-      0x78220009,  //  0332  JMPF	R8	#033D
-      0x8C200B11,  //  0333  GETMET	R8	R5	K17
-      0x7C200200,  //  0334  CALL	R8	1
-      0x8C24110B,  //  0335  GETMET	R9	R8	K11
-      0x4C2C0000,  //  0336  LDNIL	R11
-      0x88300B16,  //  0337  GETMBR	R12	R5	K22
-      0xB8362400,  //  0338  GETNGBL	R13	K18
-      0x8C341B57,  //  0339  GETMET	R13	R13	K87
-      0x7C340200,  //  033A  CALL	R13	1
-      0x7C240800,  //  033B  CALL	R9	4
-      0x80041000,  //  033C  RET	1	R8
-      0x70020069,  //  033D  JMP		#03A8
-      0x5422002B,  //  033E  LDINT	R8	44
-      0x1C200C08,  //  033F  EQ	R8	R6	R8
-      0x7822001C,  //  0340  JMPF	R8	#035E
-      0x1C200F05,  //  0341  EQ	R8	R7	K5
-      0x78220005,  //  0342  JMPF	R8	#0349
-      0x8C200706,  //  0343  GETMET	R8	R3	K6
-      0x88280B0E,  //  0344  GETMBR	R10	R5	K14
-      0x582C0009,  //  0345  LDCONST	R11	K9
-      0x7C200600,  //  0346  CALL	R8	3
-      0x80041000,  //  0347  RET	1	R8
-      0x70020013,  //  0348  JMP		#035D
-      0x1C200F09,  //  0349  EQ	R8	R7	K9
-      0x78220005,  //  034A  JMPF	R8	#0351
-      0x8C200706,  //  034B  GETMET	R8	R3	K6
-      0x88280B0E,  //  034C  GETMBR	R10	R5	K14
-      0x542E0003,  //  034D  LDINT	R11	4
-      0x7C200600,  //  034E  CALL	R8	3
-      0x80041000,  //  034F  RET	1	R8
-      0x7002000B,  //  0350  JMP		#035D
-      0x1C200F0D,  //  0351  EQ	R8	R7	K13
-      0x78220009,  //  0352  JMPF	R8	#035D
-      0x8C200B11,  //  0353  GETMET	R8	R5	K17
-      0x7C200200,  //  0354  CALL	R8	1
-      0x8C24110B,  //  0355  GETMET	R9	R8	K11
-      0x4C2C0000,  //  0356  LDNIL	R11
-      0x8C300B58,  //  0357  GETMET	R12	R5	K88
-      0x88380B0E,  //  0358  GETMBR	R14	R5	K14
-      0x543E0003,  //  0359  LDINT	R15	4
-      0x7C300600,  //  035A  CALL	R12	3
-      0x7C240600,  //  035B  CALL	R9	3
-      0x80041000,  //  035C  RET	1	R8
-      0x70020049,  //  035D  JMP		#03A8
-      0x54220030,  //  035E  LDINT	R8	49
-      0x1C200C08,  //  035F  EQ	R8	R6	R8
-      0x78220010,  //  0360  JMPF	R8	#0372
-      0x1C200F0F,  //  0361  EQ	R8	R7	K15
-      0x78220005,  //  0362  JMPF	R8	#0369
-      0x8C200706,  //  0363  GETMET	R8	R3	K6
-      0x88280B0E,  //  0364  GETMBR	R10	R5	K14
-      0x542E001D,  //  0365  LDINT	R11	30
-      0x7C200600,  //  0366  CALL	R8	3
-      0x80041000,  //  0367  RET	1	R8
-      0x70020007,  //  0368  JMP		#0371
-      0x5422FFFB,  //  0369  LDINT	R8	65532
-      0x1C200E08,  //  036A  EQ	R8	R7	R8
-      0x78220004,  //  036B  JMPF	R8	#0371
-      0x8C200706,  //  036C  GETMET	R8	R3	K6
-      0x88280B2A,  //  036D  GETMBR	R10	R5	K42
-      0x542E0003,  //  036E  LDINT	R11	4
-      0x7C200600,  //  036F  CALL	R8	3
-      0x80041000,  //  0370  RET	1	R8
-      0x70020035,  //  0371  JMP		#03A8
-      0x5422001C,  //  0372  LDINT	R8	29
-      0x1C200C08,  //  0373  EQ	R8	R6	R8
-      0x78220029,  //  0374  JMPF	R8	#039F
-      0x1C200F0F,  //  0375  EQ	R8	R7	K15
-      0x7822001D,  //  0376  JMPF	R8	#0395
-      0x8C200B11,  //  0377  GETMET	R8	R5	K17
-      0x7C200200,  //  0378  CALL	R8	1
-      0x88240136,  //  0379  GETMBR	R9	R0	K54
-      0x8C241359,  //  037A  GETMET	R9	R9	K89
-      0x502C0200,  //  037B  LDBOOL	R11	1	0
-      0x7C240400,  //  037C  CALL	R9	2
-      0x88280136,  //  037D  GETMBR	R10	R0	K54
-      0x8828155A,  //  037E  GETMBR	R10	R10	K90
-      0x602C0010,  //  037F  GETGBL	R11	G16
-      0x5C301200,  //  0380  MOVE	R12	R9
-      0x7C2C0200,  //  0381  CALL	R11	1
-      0xA802000C,  //  0382  EXBLK	0	#0390
-      0x5C301600,  //  0383  MOVE	R12	R11
-      0x7C300000,  //  0384  CALL	R12	0
-      0x5C341400,  //  0385  MOVE	R13	R10
-      0x78360002,  //  0386  JMPF	R13	#038A
-      0x5436FEFF,  //  0387  LDINT	R13	65280
-      0x1434180D,  //  0388  LT	R13	R12	R13
-      0x78360004,  //  0389  JMPF	R13	#038F
-      0x8C34110B,  //  038A  GETMET	R13	R8	K11
-      0x4C3C0000,  //  038B  LDNIL	R15
-      0x88400B0C,  //  038C  GETMBR	R16	R5	K12
-      0x5C441800,  //  038D  MOVE	R17	R12
-      0x7C340800,  //  038E  CALL	R13	4
-      0x7001FFF2,  //  038F  JMP		#0383
-      0x582C003D,  //  0390  LDCONST	R11	K61
-      0xAC2C0200,  //  0391  CATCH	R11	1	0
-      0xB0080000,  //  0392  RAISE	2	R0	R0
-      0x80041000,  //  0393  RET	1	R8
-      0x70020008,  //  0394  JMP		#039E
-      0x60200003,  //  0395  GETGBL	R8	G3
-      0x5C240000,  //  0396  MOVE	R9	R0
-      0x7C200200,  //  0397  CALL	R8	1
-      0x8C20115B,  //  0398  GETMET	R8	R8	K91
-      0x5C280200,  //  0399  MOVE	R10	R1
-      0x5C2C0400,  //  039A  MOVE	R11	R2
-      0x5C300600,  //  039B  MOVE	R12	R3
-      0x7C200800,  //  039C  CALL	R8	4
-      0x80041000,  //  039D  RET	1	R8
-      0x70020008,  //  039E  JMP		#03A8
-      0x60200003,  //  039F  GETGBL	R8	G3
-      0x5C240000,  //  03A0  MOVE	R9	R0
-      0x7C200200,  //  03A1  CALL	R8	1
-      0x8C20115B,  //  03A2  GETMET	R8	R8	K91
-      0x5C280200,  //  03A3  MOVE	R10	R1
-      0x5C2C0400,  //  03A4  MOVE	R11	R2
-      0x5C300600,  //  03A5  MOVE	R12	R3
-      0x7C200800,  //  03A6  CALL	R8	4
-      0x80041000,  //  03A7  RET	1	R8
-      0x80000000,  //  03A8  RET	0
+      0x942C1755,  //  02A2  GETIDX	R11	R11	K85
+      0x7C200600,  //  02A3  CALL	R8	3
+      0x80041000,  //  02A4  RET	1	R8
+      0x70020058,  //  02A5  JMP		#02FF
+      0x54220008,  //  02A6  LDINT	R8	9
+      0x1C200E08,  //  02A7  EQ	R8	R7	R8
+      0x78220005,  //  02A8  JMPF	R8	#02AF
+      0x8C200706,  //  02A9  GETMET	R8	R3	K6
+      0x88280B0C,  //  02AA  GETMBR	R10	R5	K12
+      0x582C0009,  //  02AB  LDCONST	R11	K9
+      0x7C200600,  //  02AC  CALL	R8	3
+      0x80041000,  //  02AD  RET	1	R8
+      0x7002004F,  //  02AE  JMP		#02FF
+      0x54220009,  //  02AF  LDINT	R8	10
+      0x1C200E08,  //  02B0  EQ	R8	R7	R8
+      0x78220015,  //  02B1  JMPF	R8	#02C8
+      0xB8222400,  //  02B2  GETNGBL	R8	K18
+      0x8C201126,  //  02B3  GETMET	R8	R8	K38
+      0x58280053,  //  02B4  LDCONST	R10	K83
+      0x502C0200,  //  02B5  LDBOOL	R11	1	0
+      0x7C200600,  //  02B6  CALL	R8	3
+      0x94201154,  //  02B7  GETIDX	R8	R8	K84
+      0x94201156,  //  02B8  GETIDX	R8	R8	K86
+      0x8C24091B,  //  02B9  GETMET	R9	R4	K27
+      0x5C2C1000,  //  02BA  MOVE	R11	R8
+      0x58300057,  //  02BB  LDCONST	R12	K87
+      0x7C240600,  //  02BC  CALL	R9	3
+      0x24281305,  //  02BD  GT	R10	R9	K5
+      0x782A0002,  //  02BE  JMPF	R10	#02C2
+      0x04281309,  //  02BF  SUB	R10	R9	K9
+      0x402A0A0A,  //  02C0  CONNECT	R10	K5	R10
+      0x9420100A,  //  02C1  GETIDX	R8	R8	R10
+      0x8C280706,  //  02C2  GETMET	R10	R3	K6
+      0x88300B16,  //  02C3  GETMBR	R12	R5	K22
+      0x5C341000,  //  02C4  MOVE	R13	R8
+      0x7C280600,  //  02C5  CALL	R10	3
+      0x80041400,  //  02C6  RET	1	R10
+      0x70020036,  //  02C7  JMP		#02FF
+      0x5422000E,  //  02C8  LDINT	R8	15
+      0x1C200E08,  //  02C9  EQ	R8	R7	R8
+      0x7822000B,  //  02CA  JMPF	R8	#02D7
+      0x8C200706,  //  02CB  GETMET	R8	R3	K6
+      0x88280B16,  //  02CC  GETMBR	R10	R5	K22
+      0xB82E2400,  //  02CD  GETNGBL	R11	K18
+      0x8C2C1725,  //  02CE  GETMET	R11	R11	K37
+      0x7C2C0200,  //  02CF  CALL	R11	1
+      0x8C2C171B,  //  02D0  GETMET	R11	R11	K27
+      0x5834001C,  //  02D1  LDCONST	R13	K28
+      0x5838001D,  //  02D2  LDCONST	R14	K29
+      0x7C2C0600,  //  02D3  CALL	R11	3
+      0x7C200600,  //  02D4  CALL	R8	3
+      0x80041000,  //  02D5  RET	1	R8
+      0x70020027,  //  02D6  JMP		#02FF
+      0x54220010,  //  02D7  LDINT	R8	17
+      0x1C200E08,  //  02D8  EQ	R8	R7	R8
+      0x78220005,  //  02D9  JMPF	R8	#02E0
+      0x8C200706,  //  02DA  GETMET	R8	R3	K6
+      0x88280B10,  //  02DB  GETMBR	R10	R5	K16
+      0x582C0009,  //  02DC  LDCONST	R11	K9
+      0x7C200600,  //  02DD  CALL	R8	3
+      0x80041000,  //  02DE  RET	1	R8
+      0x7002001E,  //  02DF  JMP		#02FF
+      0x54220011,  //  02E0  LDINT	R8	18
+      0x1C200E08,  //  02E1  EQ	R8	R7	R8
+      0x7822000B,  //  02E2  JMPF	R8	#02EF
+      0x8C200706,  //  02E3  GETMET	R8	R3	K6
+      0x88280B16,  //  02E4  GETMBR	R10	R5	K22
+      0xB82E2400,  //  02E5  GETNGBL	R11	K18
+      0x8C2C1725,  //  02E6  GETMET	R11	R11	K37
+      0x7C2C0200,  //  02E7  CALL	R11	1
+      0x8C2C171B,  //  02E8  GETMET	R11	R11	K27
+      0x5834001C,  //  02E9  LDCONST	R13	K28
+      0x5838001D,  //  02EA  LDCONST	R14	K29
+      0x7C2C0600,  //  02EB  CALL	R11	3
+      0x7C200600,  //  02EC  CALL	R8	3
+      0x80041000,  //  02ED  RET	1	R8
+      0x7002000F,  //  02EE  JMP		#02FF
+      0x54220012,  //  02EF  LDINT	R8	19
+      0x1C200E08,  //  02F0  EQ	R8	R7	R8
+      0x7822000C,  //  02F1  JMPF	R8	#02FF
+      0x8C200B0A,  //  02F2  GETMET	R8	R5	K10
+      0x7C200200,  //  02F3  CALL	R8	1
+      0x8C24110B,  //  02F4  GETMET	R9	R8	K11
+      0x582C0005,  //  02F5  LDCONST	R11	K5
+      0x88300B0C,  //  02F6  GETMBR	R12	R5	K12
+      0x5834000F,  //  02F7  LDCONST	R13	K15
+      0x7C240800,  //  02F8  CALL	R9	4
+      0x8C24110B,  //  02F9  GETMET	R9	R8	K11
+      0x582C0009,  //  02FA  LDCONST	R11	K9
+      0x88300B0C,  //  02FB  GETMBR	R12	R5	K12
+      0x5834000F,  //  02FC  LDCONST	R13	K15
+      0x7C240800,  //  02FD  CALL	R9	4
+      0x80041000,  //  02FE  RET	1	R8
+      0x700200A9,  //  02FF  JMP		#03AA
+      0x5422003E,  //  0300  LDINT	R8	63
+      0x1C200C08,  //  0301  EQ	R8	R6	R8
+      0x78220000,  //  0302  JMPF	R8	#0304
+      0x700200A5,  //  0303  JMP		#03AA
+      0x54220029,  //  0304  LDINT	R8	42
+      0x1C200C08,  //  0305  EQ	R8	R6	R8
+      0x7822001D,  //  0306  JMPF	R8	#0325
+      0x1C200F05,  //  0307  EQ	R8	R7	K5
+      0x78220003,  //  0308  JMPF	R8	#030D
+      0x8C200B11,  //  0309  GETMET	R8	R5	K17
+      0x7C200200,  //  030A  CALL	R8	1
+      0x80041000,  //  030B  RET	1	R8
+      0x70020016,  //  030C  JMP		#0324
+      0x1C200F09,  //  030D  EQ	R8	R7	K9
+      0x78220005,  //  030E  JMPF	R8	#0315
+      0x8C200706,  //  030F  GETMET	R8	R3	K6
+      0x88280B10,  //  0310  GETMBR	R10	R5	K16
+      0x582C0005,  //  0311  LDCONST	R11	K5
+      0x7C200600,  //  0312  CALL	R8	3
+      0x80041000,  //  0313  RET	1	R8
+      0x7002000E,  //  0314  JMP		#0324
+      0x1C200F0D,  //  0315  EQ	R8	R7	K13
+      0x78220005,  //  0316  JMPF	R8	#031D
+      0x8C200706,  //  0317  GETMET	R8	R3	K6
+      0x88280B0E,  //  0318  GETMBR	R10	R5	K14
+      0x582C0009,  //  0319  LDCONST	R11	K9
+      0x7C200600,  //  031A  CALL	R8	3
+      0x80041000,  //  031B  RET	1	R8
+      0x70020006,  //  031C  JMP		#0324
+      0x1C200F0F,  //  031D  EQ	R8	R7	K15
+      0x78220004,  //  031E  JMPF	R8	#0324
+      0x8C200706,  //  031F  GETMET	R8	R3	K6
+      0x88280B18,  //  0320  GETMBR	R10	R5	K24
+      0x4C2C0000,  //  0321  LDNIL	R11
+      0x7C200600,  //  0322  CALL	R8	3
+      0x80041000,  //  0323  RET	1	R8
+      0x70020084,  //  0324  JMP		#03AA
+      0x5422002A,  //  0325  LDINT	R8	43
+      0x1C200C08,  //  0326  EQ	R8	R6	R8
+      0x78220016,  //  0327  JMPF	R8	#033F
+      0x1C200F05,  //  0328  EQ	R8	R7	K5
+      0x78220007,  //  0329  JMPF	R8	#0332
+      0x8C200706,  //  032A  GETMET	R8	R3	K6
+      0x88280B16,  //  032B  GETMBR	R10	R5	K22
+      0xB82E2400,  //  032C  GETNGBL	R11	K18
+      0x8C2C1758,  //  032D  GETMET	R11	R11	K88
+      0x7C2C0200,  //  032E  CALL	R11	1
+      0x7C200600,  //  032F  CALL	R8	3
+      0x80041000,  //  0330  RET	1	R8
+      0x7002000B,  //  0331  JMP		#033E
+      0x1C200F09,  //  0332  EQ	R8	R7	K9
+      0x78220009,  //  0333  JMPF	R8	#033E
+      0x8C200B11,  //  0334  GETMET	R8	R5	K17
+      0x7C200200,  //  0335  CALL	R8	1
+      0x8C24110B,  //  0336  GETMET	R9	R8	K11
+      0x4C2C0000,  //  0337  LDNIL	R11
+      0x88300B16,  //  0338  GETMBR	R12	R5	K22
+      0xB8362400,  //  0339  GETNGBL	R13	K18
+      0x8C341B58,  //  033A  GETMET	R13	R13	K88
+      0x7C340200,  //  033B  CALL	R13	1
+      0x7C240800,  //  033C  CALL	R9	4
+      0x80041000,  //  033D  RET	1	R8
+      0x7002006A,  //  033E  JMP		#03AA
+      0x5422002B,  //  033F  LDINT	R8	44
+      0x1C200C08,  //  0340  EQ	R8	R6	R8
+      0x7822001C,  //  0341  JMPF	R8	#035F
+      0x1C200F05,  //  0342  EQ	R8	R7	K5
+      0x78220005,  //  0343  JMPF	R8	#034A
+      0x8C200706,  //  0344  GETMET	R8	R3	K6
+      0x88280B0E,  //  0345  GETMBR	R10	R5	K14
+      0x582C0009,  //  0346  LDCONST	R11	K9
+      0x7C200600,  //  0347  CALL	R8	3
+      0x80041000,  //  0348  RET	1	R8
+      0x70020013,  //  0349  JMP		#035E
+      0x1C200F09,  //  034A  EQ	R8	R7	K9
+      0x78220005,  //  034B  JMPF	R8	#0352
+      0x8C200706,  //  034C  GETMET	R8	R3	K6
+      0x88280B0E,  //  034D  GETMBR	R10	R5	K14
+      0x542E0003,  //  034E  LDINT	R11	4
+      0x7C200600,  //  034F  CALL	R8	3
+      0x80041000,  //  0350  RET	1	R8
+      0x7002000B,  //  0351  JMP		#035E
+      0x1C200F0D,  //  0352  EQ	R8	R7	K13
+      0x78220009,  //  0353  JMPF	R8	#035E
+      0x8C200B11,  //  0354  GETMET	R8	R5	K17
+      0x7C200200,  //  0355  CALL	R8	1
+      0x8C24110B,  //  0356  GETMET	R9	R8	K11
+      0x4C2C0000,  //  0357  LDNIL	R11
+      0x8C300B59,  //  0358  GETMET	R12	R5	K89
+      0x88380B0E,  //  0359  GETMBR	R14	R5	K14
+      0x543E0003,  //  035A  LDINT	R15	4
+      0x7C300600,  //  035B  CALL	R12	3
+      0x7C240600,  //  035C  CALL	R9	3
+      0x80041000,  //  035D  RET	1	R8
+      0x7002004A,  //  035E  JMP		#03AA
+      0x54220030,  //  035F  LDINT	R8	49
+      0x1C200C08,  //  0360  EQ	R8	R6	R8
+      0x78220010,  //  0361  JMPF	R8	#0373
+      0x1C200F0F,  //  0362  EQ	R8	R7	K15
+      0x78220005,  //  0363  JMPF	R8	#036A
+      0x8C200706,  //  0364  GETMET	R8	R3	K6
+      0x88280B0E,  //  0365  GETMBR	R10	R5	K14
+      0x542E001D,  //  0366  LDINT	R11	30
+      0x7C200600,  //  0367  CALL	R8	3
+      0x80041000,  //  0368  RET	1	R8
+      0x70020007,  //  0369  JMP		#0372
+      0x5422FFFB,  //  036A  LDINT	R8	65532
+      0x1C200E08,  //  036B  EQ	R8	R7	R8
+      0x78220004,  //  036C  JMPF	R8	#0372
+      0x8C200706,  //  036D  GETMET	R8	R3	K6
+      0x88280B2A,  //  036E  GETMBR	R10	R5	K42
+      0x542E0003,  //  036F  LDINT	R11	4
+      0x7C200600,  //  0370  CALL	R8	3
+      0x80041000,  //  0371  RET	1	R8
+      0x70020036,  //  0372  JMP		#03AA
+      0x5422001C,  //  0373  LDINT	R8	29
+      0x1C200C08,  //  0374  EQ	R8	R6	R8
+      0x7822002A,  //  0375  JMPF	R8	#03A1
+      0x1C200F0F,  //  0376  EQ	R8	R7	K15
+      0x7822001E,  //  0377  JMPF	R8	#0397
+      0x8C200B11,  //  0378  GETMET	R8	R5	K17
+      0x7C200200,  //  0379  CALL	R8	1
+      0x88240136,  //  037A  GETMBR	R9	R0	K54
+      0x8C24135A,  //  037B  GETMET	R9	R9	K90
+      0x502C0200,  //  037C  LDBOOL	R11	1	0
+      0x7C240400,  //  037D  CALL	R9	2
+      0x88280136,  //  037E  GETMBR	R10	R0	K54
+      0x8828155B,  //  037F  GETMBR	R10	R10	K91
+      0x602C0010,  //  0380  GETGBL	R11	G16
+      0x5C301200,  //  0381  MOVE	R12	R9
+      0x7C2C0200,  //  0382  CALL	R11	1
+      0xA802000D,  //  0383  EXBLK	0	#0392
+      0x5C301600,  //  0384  MOVE	R12	R11
+      0x7C300000,  //  0385  CALL	R12	0
+      0x5C341400,  //  0386  MOVE	R13	R10
+      0x78360003,  //  0387  JMPF	R13	#038C
+      0xB8360200,  //  0388  GETNGBL	R13	K1
+      0x88341B3C,  //  0389  GETMBR	R13	R13	K60
+      0x1434180D,  //  038A  LT	R13	R12	R13
+      0x78360004,  //  038B  JMPF	R13	#0391
+      0x8C34110B,  //  038C  GETMET	R13	R8	K11
+      0x4C3C0000,  //  038D  LDNIL	R15
+      0x88400B0C,  //  038E  GETMBR	R16	R5	K12
+      0x5C441800,  //  038F  MOVE	R17	R12
+      0x7C340800,  //  0390  CALL	R13	4
+      0x7001FFF1,  //  0391  JMP		#0384
+      0x582C003E,  //  0392  LDCONST	R11	K62
+      0xAC2C0200,  //  0393  CATCH	R11	1	0
+      0xB0080000,  //  0394  RAISE	2	R0	R0
+      0x80041000,  //  0395  RET	1	R8
+      0x70020008,  //  0396  JMP		#03A0
+      0x60200003,  //  0397  GETGBL	R8	G3
+      0x5C240000,  //  0398  MOVE	R9	R0
+      0x7C200200,  //  0399  CALL	R8	1
+      0x8C20115C,  //  039A  GETMET	R8	R8	K92
+      0x5C280200,  //  039B  MOVE	R10	R1
+      0x5C2C0400,  //  039C  MOVE	R11	R2
+      0x5C300600,  //  039D  MOVE	R12	R3
+      0x7C200800,  //  039E  CALL	R8	4
+      0x80041000,  //  039F  RET	1	R8
+      0x70020008,  //  03A0  JMP		#03AA
+      0x60200003,  //  03A1  GETGBL	R8	G3
+      0x5C240000,  //  03A2  MOVE	R9	R0
+      0x7C200200,  //  03A3  CALL	R8	1
+      0x8C20115C,  //  03A4  GETMET	R8	R8	K92
+      0x5C280200,  //  03A5  MOVE	R10	R1
+      0x5C2C0400,  //  03A6  MOVE	R11	R2
+      0x5C300600,  //  03A7  MOVE	R12	R3
+      0x7C200800,  //  03A8  CALL	R8	4
+      0x80041000,  //  03A9  RET	1	R8
+      0x80000000,  //  03AA  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
@@ -533,7 +533,7 @@ be_local_closure(Matter_Session_Store_count_active_fabrics,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Session_Store_remove_fabric,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    7,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -542,8 +542,8 @@ be_local_closure(Matter_Session_Store_remove_fabric,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(sessions),
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_const_int(0),
     /* K2   */  be_nested_str_weak(_fabric),
     /* K3   */  be_nested_str_weak(remove),
     /* K4   */  be_const_int(1),
@@ -552,33 +552,41 @@ be_local_closure(Matter_Session_Store_remove_fabric,   /* name */
     }),
     be_str_weak(remove_fabric),
     &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E000B,  //  0005  JMPF	R3	#0012
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x880C0702,  //  0008  GETMBR	R3	R3	K2
-      0x1C0C0601,  //  0009  EQ	R3	R3	R1
-      0x780E0004,  //  000A  JMPF	R3	#0010
-      0x880C0101,  //  000B  GETMBR	R3	R0	K1
-      0x8C0C0703,  //  000C  GETMET	R3	R3	K3
-      0x5C140400,  //  000D  MOVE	R5	R2
-      0x7C0C0400,  //  000E  CALL	R3	2
-      0x70020000,  //  000F  JMP		#0011
-      0x00080504,  //  0010  ADD	R2	R2	K4
-      0x7001FFEE,  //  0011  JMP		#0001
-      0x880C0105,  //  0012  GETMBR	R3	R0	K5
-      0x8C0C0703,  //  0013  GETMET	R3	R3	K3
-      0x88140105,  //  0014  GETMBR	R5	R0	K5
-      0x8C140B06,  //  0015  GETMET	R5	R5	K6
-      0x5C1C0200,  //  0016  MOVE	R7	R1
-      0x7C140400,  //  0017  CALL	R5	2
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x80000000,  //  0019  RET	0
+    ( &(const binstruction[34]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0011,  //  0003  JMPF	R2	#0016
+      0x58080001,  //  0004  LDCONST	R2	K1
+      0x600C000C,  //  0005  GETGBL	R3	G12
+      0x88100100,  //  0006  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x140C0403,  //  0008  LT	R3	R2	R3
+      0x780E000B,  //  0009  JMPF	R3	#0016
+      0x880C0100,  //  000A  GETMBR	R3	R0	K0
+      0x940C0602,  //  000B  GETIDX	R3	R3	R2
+      0x880C0702,  //  000C  GETMBR	R3	R3	K2
+      0x1C0C0601,  //  000D  EQ	R3	R3	R1
+      0x780E0004,  //  000E  JMPF	R3	#0014
+      0x880C0100,  //  000F  GETMBR	R3	R0	K0
+      0x8C0C0703,  //  0010  GETMET	R3	R3	K3
+      0x5C140400,  //  0011  MOVE	R5	R2
+      0x7C0C0400,  //  0012  CALL	R3	2
+      0x70020000,  //  0013  JMP		#0015
+      0x00080504,  //  0014  ADD	R2	R2	K4
+      0x7001FFEE,  //  0015  JMP		#0005
+      0x88080105,  //  0016  GETMBR	R2	R0	K5
+      0x4C0C0000,  //  0017  LDNIL	R3
+      0x20080403,  //  0018  NE	R2	R2	R3
+      0x780A0006,  //  0019  JMPF	R2	#0021
+      0x88080105,  //  001A  GETMBR	R2	R0	K5
+      0x8C080503,  //  001B  GETMET	R2	R2	K3
+      0x88100105,  //  001C  GETMBR	R4	R0	K5
+      0x8C100906,  //  001D  GETMET	R4	R4	K6
+      0x5C180200,  //  001E  MOVE	R6	R1
+      0x7C100400,  //  001F  CALL	R4	2
+      0x7C080400,  //  0020  CALL	R2	2
+      0x80000000,  //  0021  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
@@ -2404,7 +2404,7 @@ be_local_closure(Matter_Device__instantiate_plugins_from_config,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
+    ( &(const bvalue[31]) {     /* constants */
     /* K0   */  be_nested_str_weak(k2l_num),
     /* K1   */  be_nested_str_weak(tasmota),
     /* K2   */  be_nested_str_weak(log),
@@ -2419,26 +2419,27 @@ be_local_closure(Matter_Device__instantiate_plugins_from_config,   /* name */
     /* K11  */  be_nested_str_weak(root),
     /* K12  */  be_nested_str_weak(),
     /* K13  */  be_nested_str_weak(Plugin_Aggregator),
-    /* K14  */  be_nested_str_weak(find),
-    /* K15  */  be_nested_str_weak(type),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
-    /* K17  */  be_const_int(3),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20only_X20one_X20root_X20node_X20allowed),
-    /* K19  */  be_nested_str_weak(plugins_classes),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-    /* K21  */  be_nested_str_weak(_X27_X20skipping),
-    /* K22  */  be_nested_str_weak(conf_to_log),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K24  */  be_nested_str_weak(_X7C),
-    /* K25  */  be_nested_str_weak(stop_iteration),
-    /* K26  */  be_nested_str_weak(aggregator),
-    /* K27  */  be_nested_str_weak(publish_result),
-    /* K28  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
-    /* K29  */  be_nested_str_weak(Matter),
+    /* K14  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+    /* K15  */  be_nested_str_weak(find),
+    /* K16  */  be_nested_str_weak(type),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
+    /* K18  */  be_const_int(3),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20only_X20one_X20root_X20node_X20allowed),
+    /* K20  */  be_nested_str_weak(plugins_classes),
+    /* K21  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+    /* K22  */  be_nested_str_weak(_X27_X20skipping),
+    /* K23  */  be_nested_str_weak(conf_to_log),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K25  */  be_nested_str_weak(_X7C),
+    /* K26  */  be_nested_str_weak(stop_iteration),
+    /* K27  */  be_nested_str_weak(aggregator),
+    /* K28  */  be_nested_str_weak(publish_result),
+    /* K29  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
+    /* K30  */  be_nested_str_weak(Matter),
     }),
     be_str_weak(_instantiate_plugins_from_config),
     &be_const_str_solidified,
-    ( &(const binstruction[152]) {  /* code */
+    ( &(const binstruction[154]) {  /* code */
       0x8C080100,  //  0000  GETMET	R2	R0	K0
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
@@ -2472,125 +2473,127 @@ be_local_closure(Matter_Device__instantiate_plugins_from_config,   /* name */
       0xB8160E00,  //  001E  GETNGBL	R5	K7
       0x8C140B0D,  //  001F  GETMET	R5	R5	K13
       0x5C1C0000,  //  0020  MOVE	R7	R0
-      0x5422FEFF,  //  0021  LDINT	R8	65280
-      0x60240013,  //  0022  GETGBL	R9	G19
-      0x7C240000,  //  0023  CALL	R9	0
-      0x7C140800,  //  0024  CALL	R5	4
-      0x7C0C0400,  //  0025  CALL	R3	2
-      0x600C0010,  //  0026  GETGBL	R3	G16
-      0x5C100400,  //  0027  MOVE	R4	R2
-      0x7C0C0200,  //  0028  CALL	R3	1
-      0xA802005A,  //  0029  EXBLK	0	#0085
-      0x5C100600,  //  002A  MOVE	R4	R3
-      0x7C100000,  //  002B  CALL	R4	0
-      0x1C140909,  //  002C  EQ	R5	R4	K9
-      0x78160000,  //  002D  JMPF	R5	#002F
-      0x7001FFFA,  //  002E  JMP		#002A
-      0xA8020042,  //  002F  EXBLK	0	#0073
-      0x60140008,  //  0030  GETGBL	R5	G8
-      0x5C180800,  //  0031  MOVE	R6	R4
-      0x7C140200,  //  0032  CALL	R5	1
-      0x94140205,  //  0033  GETIDX	R5	R1	R5
-      0x8C180B0E,  //  0034  GETMET	R6	R5	K14
-      0x5820000F,  //  0035  LDCONST	R8	K15
-      0x7C180400,  //  0036  CALL	R6	2
-      0x4C1C0000,  //  0037  LDNIL	R7
-      0x1C1C0C07,  //  0038  EQ	R7	R6	R7
-      0x781E0006,  //  0039  JMPF	R7	#0041
-      0xB81E0200,  //  003A  GETNGBL	R7	K1
-      0x8C1C0F02,  //  003B  GETMET	R7	R7	K2
-      0x58240010,  //  003C  LDCONST	R9	K16
-      0x58280011,  //  003D  LDCONST	R10	K17
-      0x7C1C0600,  //  003E  CALL	R7	3
-      0xA8040001,  //  003F  EXBLK	1	1
-      0x7001FFE8,  //  0040  JMP		#002A
-      0x1C1C0D0B,  //  0041  EQ	R7	R6	K11
-      0x781E0006,  //  0042  JMPF	R7	#004A
-      0xB81E0200,  //  0043  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0044  GETMET	R7	R7	K2
-      0x58240012,  //  0045  LDCONST	R9	K18
-      0x58280011,  //  0046  LDCONST	R10	K17
-      0x7C1C0600,  //  0047  CALL	R7	3
-      0xA8040001,  //  0048  EXBLK	1	1
-      0x7001FFDF,  //  0049  JMP		#002A
-      0x881C0113,  //  004A  GETMBR	R7	R0	K19
-      0x8C1C0F0E,  //  004B  GETMET	R7	R7	K14
-      0x5C240C00,  //  004C  MOVE	R9	R6
-      0x7C1C0400,  //  004D  CALL	R7	2
-      0x4C200000,  //  004E  LDNIL	R8
-      0x1C200E08,  //  004F  EQ	R8	R7	R8
-      0x7822000A,  //  0050  JMPF	R8	#005C
-      0xB8220200,  //  0051  GETNGBL	R8	K1
-      0x8C201102,  //  0052  GETMET	R8	R8	K2
-      0x60280008,  //  0053  GETGBL	R10	G8
-      0x5C2C0C00,  //  0054  MOVE	R11	R6
-      0x7C280200,  //  0055  CALL	R10	1
-      0x002A280A,  //  0056  ADD	R10	K20	R10
-      0x00281515,  //  0057  ADD	R10	R10	K21
-      0x582C0004,  //  0058  LDCONST	R11	K4
-      0x7C200600,  //  0059  CALL	R8	3
-      0xA8040001,  //  005A  EXBLK	1	1
-      0x7001FFCD,  //  005B  JMP		#002A
-      0x5C200E00,  //  005C  MOVE	R8	R7
-      0x5C240000,  //  005D  MOVE	R9	R0
-      0x5C280800,  //  005E  MOVE	R10	R4
-      0x5C2C0A00,  //  005F  MOVE	R11	R5
-      0x7C200600,  //  0060  CALL	R8	3
-      0x88240105,  //  0061  GETMBR	R9	R0	K5
-      0x8C241306,  //  0062  GETMET	R9	R9	K6
-      0x5C2C1000,  //  0063  MOVE	R11	R8
-      0x7C240400,  //  0064  CALL	R9	2
-      0xB8260200,  //  0065  GETNGBL	R9	K1
-      0x8C241302,  //  0066  GETMET	R9	R9	K2
-      0x602C0018,  //  0067  GETGBL	R11	G24
-      0x5830000A,  //  0068  LDCONST	R12	K10
-      0x5C340800,  //  0069  MOVE	R13	R4
-      0x5C380C00,  //  006A  MOVE	R14	R6
-      0x8C3C0116,  //  006B  GETMET	R15	R0	K22
-      0x5C440A00,  //  006C  MOVE	R17	R5
-      0x7C3C0400,  //  006D  CALL	R15	2
-      0x7C2C0800,  //  006E  CALL	R11	4
-      0x58300004,  //  006F  LDCONST	R12	K4
-      0x7C240600,  //  0070  CALL	R9	3
-      0xA8040001,  //  0071  EXBLK	1	1
-      0x70020010,  //  0072  JMP		#0084
-      0xAC140002,  //  0073  CATCH	R5	0	2
-      0x7002000D,  //  0074  JMP		#0083
-      0xB81E0200,  //  0075  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0076  GETMET	R7	R7	K2
-      0x60240008,  //  0077  GETGBL	R9	G8
-      0x5C280A00,  //  0078  MOVE	R10	R5
-      0x7C240200,  //  0079  CALL	R9	1
-      0x00262E09,  //  007A  ADD	R9	K23	R9
-      0x00241318,  //  007B  ADD	R9	R9	K24
-      0x60280008,  //  007C  GETGBL	R10	G8
-      0x5C2C0C00,  //  007D  MOVE	R11	R6
-      0x7C280200,  //  007E  CALL	R10	1
-      0x0024120A,  //  007F  ADD	R9	R9	R10
-      0x58280004,  //  0080  LDCONST	R10	K4
-      0x7C1C0600,  //  0081  CALL	R7	3
-      0x70020000,  //  0082  JMP		#0084
-      0xB0080000,  //  0083  RAISE	2	R0	R0
-      0x7001FFA4,  //  0084  JMP		#002A
-      0x580C0019,  //  0085  LDCONST	R3	K25
-      0xAC0C0200,  //  0086  CATCH	R3	1	0
-      0xB0080000,  //  0087  RAISE	2	R0	R0
-      0xB80E0200,  //  0088  GETNGBL	R3	K1
-      0x8C0C0702,  //  0089  GETMET	R3	R3	K2
-      0x60140018,  //  008A  GETGBL	R5	G24
-      0x5818000A,  //  008B  LDCONST	R6	K10
-      0x541EFEFF,  //  008C  LDINT	R7	65280
-      0x5820001A,  //  008D  LDCONST	R8	K26
-      0x5824000C,  //  008E  LDCONST	R9	K12
-      0x7C140800,  //  008F  CALL	R5	4
-      0x58180004,  //  0090  LDCONST	R6	K4
-      0x7C0C0600,  //  0091  CALL	R3	3
-      0xB80E0200,  //  0092  GETNGBL	R3	K1
-      0x8C0C071B,  //  0093  GETMET	R3	R3	K27
-      0x5814001C,  //  0094  LDCONST	R5	K28
-      0x5818001D,  //  0095  LDCONST	R6	K29
-      0x7C0C0600,  //  0096  CALL	R3	3
-      0x80000000,  //  0097  RET	0
+      0xB8220E00,  //  0021  GETNGBL	R8	K7
+      0x8820110E,  //  0022  GETMBR	R8	R8	K14
+      0x60240013,  //  0023  GETGBL	R9	G19
+      0x7C240000,  //  0024  CALL	R9	0
+      0x7C140800,  //  0025  CALL	R5	4
+      0x7C0C0400,  //  0026  CALL	R3	2
+      0x600C0010,  //  0027  GETGBL	R3	G16
+      0x5C100400,  //  0028  MOVE	R4	R2
+      0x7C0C0200,  //  0029  CALL	R3	1
+      0xA802005A,  //  002A  EXBLK	0	#0086
+      0x5C100600,  //  002B  MOVE	R4	R3
+      0x7C100000,  //  002C  CALL	R4	0
+      0x1C140909,  //  002D  EQ	R5	R4	K9
+      0x78160000,  //  002E  JMPF	R5	#0030
+      0x7001FFFA,  //  002F  JMP		#002B
+      0xA8020042,  //  0030  EXBLK	0	#0074
+      0x60140008,  //  0031  GETGBL	R5	G8
+      0x5C180800,  //  0032  MOVE	R6	R4
+      0x7C140200,  //  0033  CALL	R5	1
+      0x94140205,  //  0034  GETIDX	R5	R1	R5
+      0x8C180B0F,  //  0035  GETMET	R6	R5	K15
+      0x58200010,  //  0036  LDCONST	R8	K16
+      0x7C180400,  //  0037  CALL	R6	2
+      0x4C1C0000,  //  0038  LDNIL	R7
+      0x1C1C0C07,  //  0039  EQ	R7	R6	R7
+      0x781E0006,  //  003A  JMPF	R7	#0042
+      0xB81E0200,  //  003B  GETNGBL	R7	K1
+      0x8C1C0F02,  //  003C  GETMET	R7	R7	K2
+      0x58240011,  //  003D  LDCONST	R9	K17
+      0x58280012,  //  003E  LDCONST	R10	K18
+      0x7C1C0600,  //  003F  CALL	R7	3
+      0xA8040001,  //  0040  EXBLK	1	1
+      0x7001FFE8,  //  0041  JMP		#002B
+      0x1C1C0D0B,  //  0042  EQ	R7	R6	K11
+      0x781E0006,  //  0043  JMPF	R7	#004B
+      0xB81E0200,  //  0044  GETNGBL	R7	K1
+      0x8C1C0F02,  //  0045  GETMET	R7	R7	K2
+      0x58240013,  //  0046  LDCONST	R9	K19
+      0x58280012,  //  0047  LDCONST	R10	K18
+      0x7C1C0600,  //  0048  CALL	R7	3
+      0xA8040001,  //  0049  EXBLK	1	1
+      0x7001FFDF,  //  004A  JMP		#002B
+      0x881C0114,  //  004B  GETMBR	R7	R0	K20
+      0x8C1C0F0F,  //  004C  GETMET	R7	R7	K15
+      0x5C240C00,  //  004D  MOVE	R9	R6
+      0x7C1C0400,  //  004E  CALL	R7	2
+      0x4C200000,  //  004F  LDNIL	R8
+      0x1C200E08,  //  0050  EQ	R8	R7	R8
+      0x7822000A,  //  0051  JMPF	R8	#005D
+      0xB8220200,  //  0052  GETNGBL	R8	K1
+      0x8C201102,  //  0053  GETMET	R8	R8	K2
+      0x60280008,  //  0054  GETGBL	R10	G8
+      0x5C2C0C00,  //  0055  MOVE	R11	R6
+      0x7C280200,  //  0056  CALL	R10	1
+      0x002A2A0A,  //  0057  ADD	R10	K21	R10
+      0x00281516,  //  0058  ADD	R10	R10	K22
+      0x582C0004,  //  0059  LDCONST	R11	K4
+      0x7C200600,  //  005A  CALL	R8	3
+      0xA8040001,  //  005B  EXBLK	1	1
+      0x7001FFCD,  //  005C  JMP		#002B
+      0x5C200E00,  //  005D  MOVE	R8	R7
+      0x5C240000,  //  005E  MOVE	R9	R0
+      0x5C280800,  //  005F  MOVE	R10	R4
+      0x5C2C0A00,  //  0060  MOVE	R11	R5
+      0x7C200600,  //  0061  CALL	R8	3
+      0x88240105,  //  0062  GETMBR	R9	R0	K5
+      0x8C241306,  //  0063  GETMET	R9	R9	K6
+      0x5C2C1000,  //  0064  MOVE	R11	R8
+      0x7C240400,  //  0065  CALL	R9	2
+      0xB8260200,  //  0066  GETNGBL	R9	K1
+      0x8C241302,  //  0067  GETMET	R9	R9	K2
+      0x602C0018,  //  0068  GETGBL	R11	G24
+      0x5830000A,  //  0069  LDCONST	R12	K10
+      0x5C340800,  //  006A  MOVE	R13	R4
+      0x5C380C00,  //  006B  MOVE	R14	R6
+      0x8C3C0117,  //  006C  GETMET	R15	R0	K23
+      0x5C440A00,  //  006D  MOVE	R17	R5
+      0x7C3C0400,  //  006E  CALL	R15	2
+      0x7C2C0800,  //  006F  CALL	R11	4
+      0x58300004,  //  0070  LDCONST	R12	K4
+      0x7C240600,  //  0071  CALL	R9	3
+      0xA8040001,  //  0072  EXBLK	1	1
+      0x70020010,  //  0073  JMP		#0085
+      0xAC140002,  //  0074  CATCH	R5	0	2
+      0x7002000D,  //  0075  JMP		#0084
+      0xB81E0200,  //  0076  GETNGBL	R7	K1
+      0x8C1C0F02,  //  0077  GETMET	R7	R7	K2
+      0x60240008,  //  0078  GETGBL	R9	G8
+      0x5C280A00,  //  0079  MOVE	R10	R5
+      0x7C240200,  //  007A  CALL	R9	1
+      0x00263009,  //  007B  ADD	R9	K24	R9
+      0x00241319,  //  007C  ADD	R9	R9	K25
+      0x60280008,  //  007D  GETGBL	R10	G8
+      0x5C2C0C00,  //  007E  MOVE	R11	R6
+      0x7C280200,  //  007F  CALL	R10	1
+      0x0024120A,  //  0080  ADD	R9	R9	R10
+      0x58280004,  //  0081  LDCONST	R10	K4
+      0x7C1C0600,  //  0082  CALL	R7	3
+      0x70020000,  //  0083  JMP		#0085
+      0xB0080000,  //  0084  RAISE	2	R0	R0
+      0x7001FFA4,  //  0085  JMP		#002B
+      0x580C001A,  //  0086  LDCONST	R3	K26
+      0xAC0C0200,  //  0087  CATCH	R3	1	0
+      0xB0080000,  //  0088  RAISE	2	R0	R0
+      0xB80E0200,  //  0089  GETNGBL	R3	K1
+      0x8C0C0702,  //  008A  GETMET	R3	R3	K2
+      0x60140018,  //  008B  GETGBL	R5	G24
+      0x5818000A,  //  008C  LDCONST	R6	K10
+      0xB81E0E00,  //  008D  GETNGBL	R7	K7
+      0x881C0F0E,  //  008E  GETMBR	R7	R7	K14
+      0x5820001B,  //  008F  LDCONST	R8	K27
+      0x5824000C,  //  0090  LDCONST	R9	K12
+      0x7C140800,  //  0091  CALL	R5	4
+      0x58180004,  //  0092  LDCONST	R6	K4
+      0x7C0C0600,  //  0093  CALL	R3	3
+      0xB80E0200,  //  0094  GETNGBL	R3	K1
+      0x8C0C071C,  //  0095  GETMET	R3	R3	K28
+      0x5814001D,  //  0096  LDCONST	R5	K29
+      0x5818001E,  //  0097  LDCONST	R6	K30
+      0x7C0C0600,  //  0098  CALL	R3	3
+      0x80000000,  //  0099  RET	0
     })
   )
 );
@@ -5875,14 +5878,16 @@ be_local_closure(Matter_Device_signal_endpoints_changed,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(attribute_updated),
     /* K1   */  be_const_int(0),
     /* K2   */  be_const_int(3),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
     }),
     be_str_weak(signal_endpoints_changed),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
+    ( &(const binstruction[14]) {  /* code */
       0x8C040100,  //  0000  GETMET	R1	R0	K0
       0x580C0001,  //  0001  LDCONST	R3	K1
       0x5412001C,  //  0002  LDINT	R4	29
@@ -5890,12 +5895,13 @@ be_local_closure(Matter_Device_signal_endpoints_changed,   /* name */
       0x50180000,  //  0004  LDBOOL	R6	0	0
       0x7C040A00,  //  0005  CALL	R1	5
       0x8C040100,  //  0006  GETMET	R1	R0	K0
-      0x540EFEFF,  //  0007  LDINT	R3	65280
-      0x5412001C,  //  0008  LDINT	R4	29
-      0x58140002,  //  0009  LDCONST	R5	K2
-      0x50180000,  //  000A  LDBOOL	R6	0	0
-      0x7C040A00,  //  000B  CALL	R1	5
-      0x80000000,  //  000C  RET	0
+      0xB80E0600,  //  0007  GETNGBL	R3	K3
+      0x880C0704,  //  0008  GETMBR	R3	R3	K4
+      0x5412001C,  //  0009  LDINT	R4	29
+      0x58140002,  //  000A  LDCONST	R5	K2
+      0x50180000,  //  000B  LDBOOL	R6	0	0
+      0x7C040A00,  //  000C  CALL	R1	5
+      0x80000000,  //  000D  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

There is a bug in Alexa that does not support endpoint numbers on 16 bits but only on 8 bits. The aggregator endpoint was `0xFF00` which was recognized as `0x00` and create an infinite loop that stopped after 36 devices.

I have changed the aggregator endpoint to `0xFE` and I hope it doesn't break any already-paired device.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
