### PR TITLE
Core3 reset GPIOs 16/17 when PSRAM is not used

### DIFF
--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -458,7 +458,6 @@ void setup(void) {
 #endif  // DISABLE_ESP32_BROWNOUT
 
   // restore GPIO16/17 if no PSRAM is found
-  // #if ESP_IDF_VERSION_MAJOR < 5       // TODO for esp-idf 5
   if (!FoundPSRAM()) {
     // test if the CPU is not pico
 #if (ESP_IDF_VERSION_MAJOR >= 5)
@@ -473,7 +472,6 @@ void setup(void) {
       gpio_reset_pin(GPIO_NUM_17);
     }
   }
-  // #endif
 #endif  // CONFIG_IDF_TARGET_ESP32
 #endif  // ESP32
 


### PR DESCRIPTION
## Description:

Port the behavior to Core3. It was left for future fix and forgotten since.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
