### PR TITLE
Improve init behavior after enable

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
@@ -2312,6 +2312,11 @@ bool Xdrv27(uint32_t function)
           XdrvMailbox.index    = i;
           XdrvMailbox.payload  = rescue_payload;
           XdrvMailbox.data_len = rescue_data_len;
+	  if (!ShutterSettings.version) {
+            ShutterSettingsLoad(0);
+            ShutterSettings.shutter_startrelay[0] = 1;
+            ShutterInit();
+          }
           result = DecodeCommand(kShutterCommands, ShutterCommand);
         }
         break;


### PR DESCRIPTION
Ensure filesystem init is executed after so80 1. The shutter command will check for proper init and if not done will do it.

## Description:
improve #20512
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
