### PR TITLE
Zigbee ``ZbEmulation`` to selectively exclude some devices from Hue/Alexa emulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Berry solidification of strings longer than 255 bytes (#20529)
 - Berry syntax coloring for Notepad++ by FransO (#20541)
 - Berry/Zigbee web hook per device for customized status display (#20542)
+- Zigbee ``ZbEmulation`` to selectively exclude some devices from Hue/Alexa emulation
 
 ### Breaking Changed
 

--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -700,6 +700,7 @@
 #define D_CMND_ZIGBEE_SCAN "Scan"
   #define D_JSON_ZIGBEE_SCAN "ZbScan"
 #define D_CMND_ZIGBEE_CIE "CIE"
+#define D_CMND_ZIGBEE_EMULATION "Emulation"
 #define D_CMND_ZIGBEE_ENROLL "Enroll"
 #define D_CMND_ZIGBEE_LOAD "Load"
 #define D_CMND_ZIGBEE_LOADDUMP "LoadDump"

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
@@ -814,6 +814,11 @@ void Z_Device::jsonAddConfig(Z_attribute_list & attr_list) const {
   }
   attr_list.addAttributePMEM(PSTR("Config")).setStrRaw(arr_data.toString().c_str());
 }
+// Add "HueEmulation":false, "Matter":false
+void Z_Device::jsonAddEmulation(Z_attribute_list & attr_list) const {
+  if (!isAdvertizeHue())      { attr_list.addAttributePMEM(PSTR("HueEmulation")).setBool(false); }
+  if (!isAdvertizeMatter())   { attr_list.addAttributePMEM(PSTR("Matter")).setBool(false); }
+}
 // Add All data attributes
 void Z_Device::jsonAddDataAttributes(Z_attribute_list & attr_list) const {
   // show internal data - mostly last known values
@@ -824,7 +829,7 @@ void Z_Device::jsonAddDataAttributes(Z_attribute_list & attr_list) const {
     }
   }
 }
-// Add "BatteryPercentage", "LastSeen", "LastSeenEpoch", "LinkQuality"
+// Add "BatteryPercentage", "LastSeen", "LastSeenEpoch", "LinkQuality", "HueEmulation" (opt) and "Matter" (opt)
 void Z_Device::jsonAddDeviceAttributes(Z_attribute_list & attr_list) const {
   attr_list.addAttributePMEM(PSTR("Reachable")).setBool(getReachable());
   if (validBatteryPercent())  { attr_list.addAttributePMEM(PSTR("BatteryPercentage")).setUInt(batt_percent); }
@@ -879,6 +884,7 @@ void Z_Device::jsonDumpSingleDevice(Z_attribute_list & attr_list, uint32_t dump_
     jsonAddModelManuf(attr_list);
     jsonAddEndpoints(attr_list);
     jsonAddConfig(attr_list);
+    jsonAddEmulation(attr_list);
   }
   if (dump_mode >= 3) {
     jsonAddDataAttributes(attr_list);
@@ -928,7 +934,7 @@ String Z_Devices::dumpDevice(uint32_t dump_mode, const Z_Device & device) const 
 //  0 : Ok
 // <0 : Error
 //
-// Ex: {"Device":"0x5ADF","Name":"IKEA_Light","IEEEAddr":"0x90FD9FFFFE03B051","ModelId":"TRADFRI bulb E27 WS opal 980lm","Manufacturer":"IKEA of Sweden","Endpoints":["0x01","0xF2"]}
+// Ex: {"Device":"0x5ADF","Name":"IKEA_Light","IEEEAddr":"0x90FD9FFFFE03B051","ModelId":"TRADFRI bulb E27 WS opal 980lm","Manufacturer":"IKEA of Sweden","Endpoints":["0x01","0xF2"],"HueEmulation":false}
 int32_t Z_Devices::deviceRestore(JsonParserObject json) {
 
   // params
@@ -1006,6 +1012,12 @@ int32_t Z_Devices::deviceRestore(JsonParserObject json) {
       }
     }
   }
+
+  // read "HueEmulation" and "Matter"
+  bool hue_emulation = json.getBool(PSTR("HueEmulation"), false);
+  bool matter        = json.getBool(PSTR("Matter"), false);
+  device.setAdvertizeHue(hue_emulation);
+  device.setAdvertizeMatter(matter);
 
   return 0;
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_4b_data.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_4b_data.ino
@@ -50,6 +50,9 @@ int32_t hydrateDeviceWideData(class Z_Device & device, const SBuffer & buf, size
   if (segment_len >= 10) {
     device.batt_last_seen = buf.get32(start+7);
   }
+  if (segment_len >= 11) {
+    device.no_advertize = (Z_no_advertize)buf.get8(start+11);
+  }
   return segment_len + 1;
 }
 
@@ -121,12 +124,14 @@ SBuffer hibernateDeviceData(const struct Z_Device & device) {
     buf.add16(device.shortaddr);
 
     // device wide data
-    buf.add8(10);        // 10 bytes
+    buf.add8(11);        // 10 bytes
     buf.add32(device.last_seen);
     buf.add8(device.lqi);
     buf.add8(device.batt_percent);
     // now storing batt_last_seen
     buf.add32(device.batt_last_seen);
+    // now storing no_advertize
+    buf.add8((uint8_t)device.no_advertize);
 
     for (const auto & data_elt : device.data) {
       size_t item_len = data_elt.DataTypeToLength(data_elt.getType());

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_6_5_hue.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_6_5_hue.ino
@@ -144,7 +144,7 @@ void ZigbeeCheckHue(String & response, bool * appending) {
       uint8_t ep = device.endpoints[i];
       if (i > 0 && ep == 0) { break; }
       int8_t bulbtype = device.getHueBulbtype(ep);
-      if (bulbtype >= 0) {
+      if (bulbtype >= 0 && device.isAdvertizeHue()) {
         // this bulb is advertized
         if (*appending) { response += ","; }
         response += "\"";

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
@@ -42,6 +42,7 @@ const char kZbCommands[] PROGMEM = D_PRFX_ZB "|"    // prefix
   D_CMND_ZIGBEE_LIGHT "|" D_CMND_ZIGBEE_OCCUPANCY "|"
   D_CMND_ZIGBEE_RESTORE "|" D_CMND_ZIGBEE_BIND_STATE "|" D_CMND_ZIGBEE_MAP "|" D_CMND_ZIGBEE_LEAVE "|"
   D_CMND_ZIGBEE_CONFIG "|" D_CMND_ZIGBEE_DATA "|" D_CMND_ZIGBEE_SCAN "|" D_CMND_ZIGBEE_ENROLL "|" D_CMND_ZIGBEE_CIE "|"
+  D_CMND_ZIGBEE_EMULATION "|"
   D_CMND_ZIGBEE_LOAD "|" D_CMND_ZIGBEE_UNLOAD "|" D_CMND_ZIGBEE_LOADDUMP
 #ifdef ZIGBEE_DOC
    "|" D_CMND_ZIGBEE_ATTRDUMP
@@ -67,7 +68,8 @@ void (* const ZigbeeCommand[])(void) PROGMEM = {
   &CmndZbLight, &CmndZbOccupancy,
   &CmndZbRestore, &CmndZbBindState, &CmndZbMap, &CmndZbLeave,
   &CmndZbConfig, &CmndZbData, &CmndZbScan,
-  &CmndZbenroll, &CmndZbcie,
+  &CmndZbenroll, &CmndZbCIE,
+  &CmndZbEmulation,
   &CmndZbLoad, &CmndZbUnload, &CmndZbLoadDump,
 #ifdef ZIGBEE_DOC
   &CmndZbAttrDump,
@@ -1518,7 +1520,7 @@ void CmndZbenroll(void) {
   }
 }
 
-void CmndZbcie(void) {
+void CmndZbCIE(void) {
   if (zigbee.init_phase) { ResponseCmndChar_P(PSTR(D_ZIGBEE_NOT_STARTED)); return; }
 
   if ((XdrvMailbox.data_len) && (ArgC() > 1)) {  // Process parameter entry
@@ -1529,6 +1531,38 @@ void CmndZbcie(void) {
     if (!device.valid()) { ResponseCmndChar_P(PSTR(D_ZIGBEE_UNKNOWN_DEVICE)); return; }
     
     Z_WriteCIEAddress(device.shortaddr, 0, 500, enrollEndpoint, 0);
+    
+    ResponseCmndDone();
+  } else {
+    ResponseCmndError();
+  }
+}
+
+void CmndZbEmulation(void) {
+  if (zigbee.init_phase) { ResponseCmndChar_P(PSTR(D_ZIGBEE_NOT_STARTED)); return; }
+
+  if ((XdrvMailbox.data_len) && (ArgC() > 1)) {  // Process parameter entry
+    char argument[XdrvMailbox.data_len];
+    Z_Device & device = zigbee_devices.parseDeviceFromName(ArgV(argument, 1), nullptr, nullptr, XdrvMailbox.payload);
+    char * arg_v = ArgV(argument, 2);
+    int emulation = atoi(arg_v);
+    if (strlen(arg_v) == 0) { emulation = 255; }
+
+    if (!device.valid()) { ResponseCmndChar_P(PSTR(D_ZIGBEE_UNKNOWN_DEVICE)); return; }
+
+    if (emulation == 0) {
+      device.setAdvertizeNone();
+    } else if (emulation == 255) {
+      device.setAdvertizeAll();
+    } else if (emulation == 1) {
+      device.setAdvertizeHue(true);
+    } else if (emulation == 2) {
+      device.setAdvertizeMatter(true);
+    } else if (emulation == -1) {
+      device.setAdvertizeHue(false);
+    } else if (emulation == -2) {
+      device.setAdvertizeMatter(false);
+    }
     
     ResponseCmndDone();
   } else {
@@ -1755,20 +1789,27 @@ void ZigbeePermitJoinUpdate(void) {
 //
 // Command `ZbStatus`
 //
+// Options:
+// 0.   `ZbStatus0` - Show information about coordinator `{"ZbStatus0":{"Device":"0x0000","IEEEAddr":"0x00124B0026B684E4","TotalDevices":19}}`
+// 1.a. `ZbStatus` - Show all devices shortaddr and names `{"ZbStatus1":[{"Device":"0x868E","Name":"Room"}...]}`
+// 1.b. `ZbStatus Room` - Show single device shortaddr and name `{"ZbStatus1":[{"Device":"0x868E","Name":"Room"}]}`
+// 2.   `ZbStatus2 Room` - Show detailed information of device `{"ZbStatus2":[{"Device":"0x868E","Name":"Room","IEEEAddr":"0x90FD9FFFFE03B051","ModelId":"TRADFRI bulb E27 WS opal 980lm","Manufacturer":"IKEA of Sweden","Endpoints":[1,242],"Config":["L01.2","O01"]}]}`
 void CmndZbStatus(void) {
   if (ZigbeeSerial) {
     if (zigbee.init_phase) { ResponseCmndChar_P(PSTR(D_ZIGBEE_NOT_STARTED)); return; }
     String dump;
 
-    if (0 == XdrvMailbox.index) {
+    if (0 == XdrvMailbox.index) {     // Case 0
       dump = zigbee_devices.dumpCoordinator();
     } else {
       Z_Device & device = zigbee_devices.parseDeviceFromName(XdrvMailbox.data, nullptr, nullptr, XdrvMailbox.payload);
       if (XdrvMailbox.data_len > 0) {
         if (!device.valid()) { ResponseCmndChar_P(PSTR(D_ZIGBEE_UNKNOWN_DEVICE)); return; }
+        // case 1.b and 2.
         dump = zigbee_devices.dumpDevice(XdrvMailbox.index, device);
       } else {
         if (XdrvMailbox.index >= 2) { ResponseCmndChar_P(PSTR(D_ZIGBEE_UNKNOWN_DEVICE)); return; }
+        // case 1.a
         dump = zigbee_devices.dumpDevice(XdrvMailbox.index, device_unk);
       }
     }


### PR DESCRIPTION
## Description:

Zigbee add an option to remove some devices from automatic Hue/Alexa emulation. By default all lights (including plus defined as `Light 0`) are exposed to Hue/Alexa. When using a power monitoring plug, you may not want to accidentally turn it off via Alexa, so you can now hide them from Alexa.

Zigbee add command `ZbEmulation <device>,<value>` to selectively exclude devices from Alexa emulation:
- `ZbEmulation <device>,` : reset value to default, i.e. advertise to Alexa if it's a light
- `ZbEmulation <device>,1` : enable Alexa emulation (if it's a light) - enabled by default
- `ZbEmulation <device>,-1` : disables Alexa emulation

Provision is made for future Matter mapping as well with values `2` and `-2`. They have currently no effect.

By default emulation is enabled, if it's disabled, you can now see it with `ZbStatus2 <device>` or `ZbInfo <device>`:
```
ZbStatus2 Plug_Schneider

{"ZbStatus2":[{"Device":"0x5EF0","Name":"Plug_Schneider","IEEEAddr":"0x000D6F001668DD56","ModelId":"SmartPlug","Manufacturer":"Heiman","Endpoints":[1],"Config":["L00.0","O01","P01"],"HueEmulation":false}]}
```

The new attributes are `HueEmulation` and `Matter`. They are only displayed when `false` (if not present, it's implicitly `true`).


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
