### PR TITLE
modify RA8876 display driver to use internal touch driver

### DIFF
--- a/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.cpp
+++ b/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.cpp
@@ -627,7 +627,7 @@ bool Renderer::utouch_Init(char **name) {
   return false;
 }
 
-bool Renderer::touched(void) {
+uint16_t Renderer::touched(void) {
   return false;
 }
 

--- a/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
+++ b/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
@@ -93,7 +93,7 @@ public:
   virtual void ep_update_area(uint16_t xp, uint16_t yp, uint16_t width, uint16_t height, uint8_t mode);
   virtual uint32_t get_sr_touch(uint32_t xp, uint32_t xm, uint32_t yp, uint32_t ym);
   virtual bool utouch_Init(char **);
-  virtual bool touched(void);
+  virtual uint16_t touched(void);
   virtual int16_t getPoint_x();
   virtual int16_t getPoint_y();
 

--- a/lib/lib_display/Xlatb_RA8876-gemu-1.0/RA8876.cpp
+++ b/lib/lib_display/Xlatb_RA8876-gemu-1.0/RA8876.cpp
@@ -38,6 +38,9 @@ fast picture write
 //  Serial.printf(">%d,\n", stage);
 //
 
+enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE};
+extern void AddLog(uint32_t loglevel, PGM_P formatP, ...);
+
 const uint16_t RA8876_colors[]={RA8876_BLACK,RA8876_WHITE,RA8876_RED,RA8876_GREEN,RA8876_BLUE,RA8876_CYAN,RA8876_MAGENTA,\
   RA8876_YELLOW,RA8876_NAVY,RA8876_DARKGREEN,RA8876_DARKCYAN,RA8876_MAROON,RA8876_PURPLE,RA8876_OLIVE,\
 RA8876_LIGHTGREY,RA8876_DARKGREY,RA8876_ORANGE,RA8876_GREENYELLOW,RA8876_PINK};
@@ -1296,6 +1299,102 @@ void RA8876::selectInternalFont(enum FontSize size, enum FontEncoding enc) {
 void RA8876::setDrawMode(uint8_t mode) {
   drawmode=mode;
   setDrawMode_reg(mode);
+}
+
+//#define RA_FT5206_VENDID           0x11
+#define RA_FT5206_VENDID           0x79
+#define RA_FT5206U_CHIPID          0x64
+#define RA_FT5316_CHIPID           0x0a
+#define RA_FT5206_VENDID_REG       (0xA8)
+#define RA_FT5206_CHIPID_REG       (0xA3)
+#define RA_FT5206_TOUCHES_REG      (0x02)
+#define RA_FT5206_MODE_REG         (0x00)
+#define RA_FT5206_address 0x38
+
+int RA8876::_readByte(uint8_t reg, uint8_t nbytes, uint8_t *data) {
+  _i2cPort->beginTransmission(RA_FT5206_address);
+  _i2cPort->write(reg);
+  _i2cPort->endTransmission();
+  _i2cPort->requestFrom(RA_FT5206_address, (size_t)nbytes);
+  uint8_t index = 0;
+  while (_i2cPort->available()) {
+    data[index++] = _i2cPort->read();
+  }
+  return 0;
+}
+
+int RA8876::_writeByte(uint8_t reg, uint8_t nbytes, uint8_t *data) {
+  _i2cPort->beginTransmission(RA_FT5206_address);
+  _i2cPort->write(reg);
+  for (uint8_t i = 0; i < nbytes; i++) {
+    _i2cPort->write(data[i]);
+  }
+  _i2cPort->endTransmission();
+  return 0;
+}
+
+bool RA8876::utouch_Init(char **name) {
+  strcpy(ut_name, "FT5316");
+  *name = ut_name;
+
+  _i2cPort = &Wire;
+
+  uint8_t val; 
+  _readByte(RA_FT5206_VENDID_REG, 1, &val);
+  //AddLog(LOG_LEVEL_INFO, PSTR("UTDBG %02x"), val);
+
+  if (val != RA_FT5206_VENDID) {
+    return false;
+  }
+  
+  _readByte(RA_FT5206_CHIPID_REG, 1, &val);
+  //AddLog(LOG_LEVEL_INFO, PSTR("UTDBG %02x"), val);
+
+  if (val != RA_FT5316_CHIPID) {
+    return false;
+  }
+
+  return true;
+}
+
+uint16_t RA8876::touched(void) {
+  uint8_t data[16];
+
+  uint8_t  val = 0;
+  _readByte(RA_FT5206_MODE_REG, 1, &val);
+  if (val) {
+    val = 0;
+    _writeByte(RA_FT5206_MODE_REG, 1, &val);
+  }
+
+  _readByte(RA_FT5206_MODE_REG, 16, data);
+
+  if (data[2]) {
+    ut_x = data[3] << 8;
+    ut_x |= data[4];
+    ut_y = data[5] << 8;
+    ut_y |= data[6];
+    ut_x &= 0xfff;
+    ut_y &= 0xfff;
+  }
+  return data[2];
+}
+
+int16_t RA8876::getPoint_x() {
+  return ut_x;
+}
+
+int16_t RA8876::getPoint_y() {
+  return ut_y;
+}
+
+void RA8876::TS_RotConvert(int16_t *x, int16_t *y) {
+int16_t temp;
+  *x = *x * width() / 800;
+  *y = *y * height() / 480;
+
+  *x = width() - *x;
+  *y = height() - *y;
 }
 
 void RA8876::setDrawMode_reg(uint8_t mode)  {

--- a/lib/lib_display/Xlatb_RA8876-gemu-1.0/RA8876.h
+++ b/lib/lib_display/Xlatb_RA8876-gemu-1.0/RA8876.h
@@ -26,6 +26,8 @@
 #include "driver/spi_master.h"
 #endif
 
+#include <Wire.h>
+
 #include "tasmota_options.h"
 
 #undef SPRINT
@@ -467,7 +469,6 @@ class RA8876 : public Renderer {
   void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
   void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
 
-
   void drawCircle(int16_t x, int16_t y, int16_t radius, uint16_t color);
   void fillCircle(int16_t x, int16_t y, int16_t radius, uint16_t color);
   void drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h, int16_t radius, uint16_t color);
@@ -510,6 +511,11 @@ class RA8876 : public Renderer {
   void dim10(uint8_t contrast, uint16_t contrast_gamma);
   void FastString(uint16_t x,uint16_t y,uint16_t tcolor, const char* str);
 
+  bool utouch_Init(char **name);
+  uint16_t touched(void);
+  int16_t getPoint_x();
+  int16_t getPoint_y();
+
  private:
   uint8_t  tabcolor;
   void PWM_init(void);
@@ -533,6 +539,7 @@ class RA8876 : public Renderer {
  bool initPLL(void);
  bool initMemory(SdramInfo *info);
  bool initDisplay(void);
+ char ut_name[8];
 
  // Font utils
  uint8_t internalFontEncoding(enum FontEncoding enc);
@@ -546,6 +553,14 @@ class RA8876 : public Renderer {
  void drawThreePointShape(int x1, int y1, int x2, int y2, int x3, int y3, uint16_t color, uint8_t reg, uint8_t cmd);  // drawTriangle, fillTriangle
  void drawEllipseShape(int x, int y, int xrad, int yrad, uint16_t color, uint8_t cmd);  // drawCircle, fillCircle
  void drawThreePointShape1(int x1, int y1, int x2, int y2, int x3, int y3, uint16_t color, uint8_t reg, uint8_t cmd);
+
+  void TS_RotConvert(int16_t *x, int16_t *y);
+
+  TwoWire *_i2cPort;
+  int _readByte(uint8_t reg, uint8_t nbytes, uint8_t *data);
+  int _writeByte(uint8_t reg, uint8_t nbytes, uint8_t *data);
+  uint16_t ut_x;
+  uint16_t ut_y;
 
   int8_t  m_csPin, _mosi, _miso, _sclk, dimmer, _hwspi;
   uint16_t m_width;

--- a/tasmota/tasmota_xdsp_display/xdsp_10_RA8876.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_10_RA8876.ino
@@ -80,38 +80,15 @@ void RA8876_InitDriver(void) {
     FT5206_Touch_Init(Wire);
 #endif
 
+#ifdef USE_UNIVERSAL_TOUCH
+    utouch_Touch_Init();
+#endif
+
     ra8876_init_done = true;
     AddLog(LOG_LEVEL_INFO, PSTR("DSP: RA8876"));
   }
 }
 
-
-#ifdef USE_FT5206
-#ifdef USE_TOUCH_BUTTONS
-
-// no rotation support
-void RA8876_RotConvert(int16_t *x, int16_t *y) {
-int16_t temp;
-  if (renderer) {
-    *x=*x*renderer->width()/800;
-    *y=*y*renderer->height()/480;
-
-    *x = renderer->width() - *x;
-    *y = renderer->height() - *y;
-  }
-}
-
-// check digitizer hit
-void RA8876_CheckTouch(void) {
-  ra8876_ctouch_counter++;
-  if (2 == ra8876_ctouch_counter) {
-    // every 100 ms should be enough
-    ra8876_ctouch_counter = 0;
-    Touch_Check(RA8876_RotConvert);
-  }
-}
-#endif // USE_TOUCH_BUTTONS
-#endif // USE_FT5206
 
 /*
 void testall() {
@@ -308,11 +285,6 @@ bool Xdsp10(uint32_t function)
     switch (function) {
       case FUNC_DISPLAY_MODEL:
         result = true;
-        break;
-      case FUNC_DISPLAY_EVERY_50_MSECOND:
-#ifdef USE_FT5206
-        if (FT5206_found) RA8876_CheckTouch();
-#endif
         break;
     }
   }


### PR DESCRIPTION
## Description:

modifies the driver to no longer use external FT touch driver.
thus no more need for any external touch drivers.

this pr depends on previous touch pr and may fail until this has been merged 

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
