### PR TITLE
mp3_shine compiles with c3

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -167,7 +167,6 @@ lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           TTGO TWatch Library
                           Micro-RTSP
                           epdiy
-                          mp3_shine_esp32
 
 [env:tasmota32c3cdc-safeboot]
 extends                 = env:tasmota32c3-safeboot


### PR DESCRIPTION
## Description:

- the mp3shine lib can be used with the C3. Remove from lib_ignore.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
