### PR TITLE
Fix QMC5883 and HLC5883 drivers breaking sensor command

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_100_ina3221.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_100_ina3221.ino
@@ -261,6 +261,7 @@ bool Ina3221CmndSensor(void)
 {
   int argc = ArgC();
   if(argc != 1 && argc != 4) {
+    AddLog(LOG_LEVEL_DEBUG, PSTR(D_INA3221 ": Not enough arguments (1 or 4)"));
     return false;
   }
 

--- a/tasmota/tasmota_xsns_sensor/xsns_101_hmc5883l.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_101_hmc5883l.ino
@@ -224,6 +224,8 @@ bool HMC5883L_Command() {
 bool Xsns101(uint32_t function) {
   if (!I2cEnabled(XI2C_73)) { return false; }
 
+  bool result = false;
+
   if (FUNC_INIT == function) {
     HMC5883L_Init();
   }
@@ -231,7 +233,7 @@ bool Xsns101(uint32_t function) {
     switch (function) {
       case FUNC_COMMAND_SENSOR:
         if (XSNS_101 == XdrvMailbox.index) {
-          return HMC5883L_Command();  // Return true on success
+          result = HMC5883L_Command();  // Return true on success
         }
         break;
       case FUNC_JSON_APPEND:
@@ -247,7 +249,7 @@ bool Xsns101(uint32_t function) {
 #endif  // USE_WEBSERVER
     	}
   }
-  return true;
+  return result;
 }
 #endif  // USE_HMC5883L
 #endif  // USE_I2C

--- a/tasmota/tasmota_xsns_sensor/xsns_33_qmc5883l.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_33_qmc5883l.ino
@@ -286,11 +286,18 @@ void QMC5883L_Show(uint8_t json) {
 bool Xsns33(uint32_t function) {
   if (!I2cEnabled(XI2C_71)) { return false; }
 
+  bool result = false;
+
   if (FUNC_INIT == function) {
     QMC5883L_Init();
   }
   else if (QMC5883L != nullptr) {
     switch (function) {
+    // case FUNC_COMMAND_SENSOR:
+    //   if (XSNS_33 == XdrvMailbox.index) {
+    //     result = QMC5883L_CmndSensor();
+    //   }
+    //   break;
     case FUNC_JSON_APPEND:
       QMC5883L_Show(1);
       break;
@@ -304,7 +311,7 @@ bool Xsns33(uint32_t function) {
 #endif  // USE_WEBSERVER
     }
   }
-  return true;
+  return result;
 }
 #endif  // USE_QMC5883L
 #endif  // USE_I2C


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #20579

QMC5883 and HMC5883 were systematically returning `true` from their `XsnsXX()` function although they weren't implementing FUNC_COMMAND_SENSOR.
That was breaking the `XsnsCall()` loop

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
