### PR TITLE
Berry C mapping, raise an error if too many arguments are sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Utouch optimizations, rgb i2c init (#20596)
 
 ### Fixed
+- Berry C mapping, raise an error if too many arguments are sent
 
 ### Removed
 

--- a/lib/libesp32/berry_mapping/src/be_class_wrapper.c
+++ b/lib/libesp32/berry_mapping/src/be_class_wrapper.c
@@ -360,6 +360,9 @@ int be_check_arg_type(bvm *vm, int arg_start, int argc, const char * arg_type, i
       }
     }
     // berry_log_C(">> be_call_c_func arg %i, type %s", i, arg_type_check ? type_short_name : "<null>");
+    if (arg_type_check && type_short_name[0] == 0) {
+      be_raisef(vm, "value_error", "Too many arguments");
+    }
     p[p_idx] = be_convert_single_elt(vm, i + arg_start, arg_type_check ? type_short_name : NULL, (int*)&buf_len);
     // berry_log_C("< ret[%i]=%i", p_idx, p[p_idx]);
     p_idx++;


### PR DESCRIPTION
## Description:

In Berry C mapping, no error would be raised if you pass too many arguments and these arguments are instances (not simple types).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
