### PR TITLE
Berry allow mapping within module

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_ctypes.c
+++ b/lib/libesp32/berry_tasmota/src/be_ctypes.c
@@ -255,11 +255,16 @@ int be_ctypes_member(bvm *vm) {
         if (member->mapping > 0 && definitions->instance_mapping) {
             const char * mapping_name = definitions->instance_mapping[member->mapping - 1];
             if (mapping_name) {
-                be_getglobal(vm, mapping_name);     // stack: class
-                be_pushvalue(vm, -2);               // stack: class, value
-                be_pushint(vm, -1);                 // stack; class, value, -1
-                be_call(vm, 2);                     // call constructor with 2 parameters
-                be_pop(vm, 2);                      // leave new instance on top of stack
+                int32_t found = be_find_global_or_module_member(vm, mapping_name);
+                if (found == 1) {
+                    // we have found only one element from a module, which is expected
+                    be_pushvalue(vm, -2);               // stack: class, value
+                    be_pushint(vm, -1);                 // stack; class, value, -1
+                    be_call(vm, 2);                     // call constructor with 2 parameters
+                    be_pop(vm, 2);                      // leave new instance on top of stack
+                } else {
+                    be_raisef(vm, "internal_error", "mapping for  '%s' not found", mapping_name);
+                }
             }
         }
         be_return(vm);


### PR DESCRIPTION
## Description:

Berry ctypes mapping can now accept a composite name like `lv.color` instead of only a global like `lv_color`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
