### PR TITLE
Fix typos regarding reboots

### DIFF
--- a/tasmota/berry/animate_demo/leds_animation.be
+++ b/tasmota/berry/animate_demo/leds_animation.be
@@ -46,7 +46,7 @@ class Leds_animation_UI
     webserver.content_send(string.format("<p>Step 4: %s</p>", self.display_step_state(self.test_step_4(p), "flash final firmware")))
 
     webserver.content_send("<form action='/part_wiz' method='post' ")
-    webserver.content_send("onsubmit='return confirm(\"This will causes multiple restarts.\");'>")
+    webserver.content_send("onsubmit='return confirm(\"This will cause multiple restarts.\");'>")
     var ota_url = tasmota.cmd("OtaUrl").find("OtaUrl", "")
     webserver.content_send(string.format("<br><b>OTA Url</b><br><input id='o1' placeholder='OTA_URL' value='%s'><br>",
                                          ota_url))

--- a/tasmota/berry/modules/Partition_Wizard/partition_wizard.be
+++ b/tasmota/berry/modules/Partition_Wizard/partition_wizard.be
@@ -577,7 +577,7 @@ class Partition_wizard_UI
     webserver.content_send(string.format("<p>Step 4: %s</p>", self.display_step_state(self.test_step_4(p), "flash final firmware")))
 
     webserver.content_send("<form action='/part_wiz' method='post' ")
-    webserver.content_send("onsubmit='return confirm(\"This will causes multiple restarts.\");'>")
+    webserver.content_send("onsubmit='return confirm(\"This will cause multiple restarts.\");'>")
     var ota_url = tasmota.cmd("OtaUrl").find("OtaUrl", "")
     webserver.content_send(string.format("<br><b>OTA Url</b><br><input id='o1' placeholder='OTA_URL' value='%s'><br>",
                                          ota_url))


### PR DESCRIPTION
Whoops, I created this with Github.dev and it didn't appear to do any templating or anything.

I noticed this typo when using the Partition Wizard to fix my ESP32 SwitchBot partition layout from the old style to the new style. The popup said "This will causes multiple restarts" and I corrected it to the proper spelling of "This will cause multiple restarts"

That's it! 