### PR TITLE
Enforce KNX TTL=255 on ESP8266

### DIFF
--- a/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip-send.cpp
+++ b/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip-send.cpp
@@ -78,7 +78,7 @@ void ESPKNXIP::send(address_t const &receiver, knx_command_type_t ct, uint8_t da
 #endif
 
 #ifdef ESP8266
-	udp.beginPacketMulticast(MULTICAST_IP, MULTICAST_PORT, WiFi.localIP());
+	udp.beginPacketMulticast(MULTICAST_IP, MULTICAST_PORT, WiFi.localIP(), 255);
 #else
 	if (0 == udp.beginMulticastPacket()) {
 		udp.beginMulticast(MULTICAST_IP, MULTICAST_PORT);


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #20345

On ESP32, Multicast UDP TTL is by default set to 255 but only 1 on ESP8266
This align the TTL to 255 when used from KNX library

Submitted to test confirmation by @hyperjojo


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
