### PR TITLE
Add PulseCounter support

### DIFF
--- a/tasmota/include/tasmota.h
+++ b/tasmota/include/tasmota.h
@@ -141,6 +141,7 @@ const uint8_t MAX_SWITCHES_TXT = 8;         // Max number of switches user text
   const uint8_t MAX_ADCS = 8;               // Max number of ESP32 ADC pins (ADC2 pins are unusable with Wifi enabled)
   #endif  // ESP32C3
 const uint8_t MAX_SWITCHES_TXT = 28;        // Max number of switches user text
+const uint8_t MAX_PULSE_COUNTER_MODULES = 8;        // Max number of Pulse Counter Modules
 #endif  // ESP32
 
 const uint8_t MAX_HUE_DEVICES = 32;         // Max number of Philips Hue device per emulation

--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -216,6 +216,7 @@ enum UserSelectablePins {
   GPIO_I2S_DAC,                         // Audio DAC support for ESP32 and ESP32S2
   GPIO_MAGIC_SWITCH,                    // MagicSwitch as in Sonoff BasicR4
   GPIO_PIPSOLAR_TX, GPIO_PIPSOLAR_RX,   // pipsolar inverter
+  GPIO_PULSE_COUNTER,                   // Pulse Counter Modules
   GPIO_SENSOR_END };
 
 // Error as warning to rethink GPIO usage with max 2045
@@ -479,6 +480,7 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_I2S_DAC "|"
   D_GPIO_MAGIC_SWITCH "|"
   D_SENSOR_PIPSOLAR_TX "|" D_SENSOR_PIPSOLAR_RX "|"
+  "Pulse Counter" "|"
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -1182,6 +1184,10 @@ const uint16_t kGpioNiceList[] PROGMEM = {
   AGPIO(GPIO_ETH_PHY_MDC),
   AGPIO(GPIO_ETH_PHY_MDIO),             // Ethernet
 #endif  // USE_ETHERNET
+
+#ifdef USE_PULSE_COUNTER
+  AGPIO(GPIO_PULSE_COUNTER) + MAX_PULSE_COUNTER_MODULES, //Pulse Counter Modules
+#endif
 
 /*-------------------------------------------------------------------------------------------*\
  * ESP32 multiple Analog / Digital converter inputs
@@ -2874,11 +2880,11 @@ const mytmplt kModules[] PROGMEM = {
     AGPIO(GPIO_USER),            // 0       IO                  GPIO0, ADC1_CH0,  RTC
     AGPIO(GPIO_USER),            // 1       IO                  GPIO1, ADC1_CH1,  RTC
     AGPIO(GPIO_USER),            // 2       IO                  GPIO2, ADC1_CH2,  RTC
-    AGPIO(GPIO_USER),            // 3       IO                  GPIO3, ADC1_CH3,  RTC 
-    AGPIO(GPIO_USER),            // 4       IO                  GPIO4, ADC1_CH4,  RTC 
-    AGPIO(GPIO_USER),            // 5       IO                  GPIO5, RTC 
+    AGPIO(GPIO_USER),            // 3       IO                  GPIO3, ADC1_CH3,  RTC
+    AGPIO(GPIO_USER),            // 4       IO                  GPIO4, ADC1_CH4,  RTC
+    AGPIO(GPIO_USER),            // 5       IO                  GPIO5, RTC
     AGPIO(GPIO_USER),            // 6       IO                  GPIO6,
-    AGPIO(GPIO_USER),            // 7       IO                  GPIO7, 
+    AGPIO(GPIO_USER),            // 7       IO                  GPIO7,
     AGPIO(GPIO_USER),            // 8       IO                  GPIO8, Strapping
     AGPIO(GPIO_USER),            // 9       IO                  GPIO9, Strapping
     AGPIO(GPIO_USER),            // 10      IO                  GPIO10
@@ -2983,7 +2989,7 @@ const mytmplt kModules[] PROGMEM = {
     AGPIO(GPIO_USER),            // 0       IO                  GPIO0, ADC1_CH0, LP_GPIO0
     AGPIO(GPIO_USER),            // 1       IO                  GPIO1, ADC1_CH1, LP_GPIO1
     AGPIO(GPIO_USER),            // 2       IO                  GPIO2, ADC1_CH2, LP_GPIO2
-    AGPIO(GPIO_USER),            // 3       IO                  GPIO3, ADC1_CH3, LP_GPIO3 
+    AGPIO(GPIO_USER),            // 3       IO                  GPIO3, ADC1_CH3, LP_GPIO3
     AGPIO(GPIO_USER),            // 4       IO                  GPIO4, ADC1_CH4, LP_GPIO4, Strapping
     AGPIO(GPIO_USER),            // 5       IO                  GPIO5, ADC1_CH5, LP_GPIO5, Strapping
     AGPIO(GPIO_USER),            // 6       IO                  GPIO6, ADC1_CH6, LP_GPIO6

--- a/tasmota/tasmota_xsns_sensor/xsns_114_pulse_counter.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_114_pulse_counter.ino
@@ -1,0 +1,105 @@
+/*
+  xsns_114_pulse_counter.ino - Pulse Counter Module sensor for Tasmota
+
+  Copyright (C) 2024 David Roe
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef ESP32
+#ifdef USE_PULSE_COUNTER
+/*********************************************************************************************\
+ * Pulse Counter sensor
+\*********************************************************************************************/
+
+#define XSNS_114                 114
+
+#include "driver/pcnt.h"
+
+struct PulseCounter {
+  uint32_t last_check = 0;
+  uint16_t freq = 0;
+};
+
+PulseCounter PulseCounters[MAX_PULSE_COUNTER_MODULES];
+
+void PulseCounterInit(void) {
+  uint32_t now = micros();
+  for (uint32_t i = 0; i < MAX_PULSE_COUNTER_MODULES; i++) {
+    if (PinUsed(GPIO_PULSE_COUNTER, i)) {
+      PulseCounters[i].last_check = now;
+
+      pcnt_config_t pcnt_config = {
+        .pulse_gpio_num = Pin(GPIO_PULSE_COUNTER, i),
+        .pos_mode = PCNT_COUNT_INC,
+        .unit = (pcnt_unit_t)i,
+        .channel = PCNT_CHANNEL_0,
+      };
+      pcnt_unit_config(&pcnt_config);
+      pcnt_set_filter_value((pcnt_unit_t)i, 1023);
+      pcnt_filter_enable((pcnt_unit_t)i);
+      pcnt_counter_clear((pcnt_unit_t)i);
+      pinMode(Pin(GPIO_PULSE_COUNTER, i), INPUT); // No Pull Up
+    }
+  }
+}
+
+void PulseCounterShow(bool json) {
+  int16_t count;
+  uint32_t now = micros();
+  for (uint32_t i = 0; i < MAX_PULSE_COUNTER_MODULES; i++) {
+    if (PulseCounters[i].last_check > 0) {
+      if (now > PulseCounters[i].last_check) {
+        pcnt_get_counter_value((pcnt_unit_t)i, &count);
+        PulseCounters[i].freq = (count * 1000000) / (now - PulseCounters[i].last_check);
+      }
+      pcnt_counter_clear((pcnt_unit_t)i);
+      PulseCounters[i].last_check = now;
+
+      if (json) {
+        ResponseAppend_P(",\"PulseCounter%i\":{\"Frequency\":%i}", i + 1, PulseCounters[i].freq);
+
+#ifdef USE_WEBSERVER
+      } else {
+        WSContentSend_P("{s}PulseCounter%i{m}%ihz", i + 1, PulseCounters[i].freq);
+#endif  // USE_WEBSERVER
+      }
+    }
+  }
+}
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xsns114(uint32_t function) {
+  bool result = false;
+
+  switch (function) {
+    case FUNC_JSON_APPEND:
+      PulseCounterShow(1);
+      break;
+#ifdef USE_WEBSERVER
+    case FUNC_WEB_SENSOR:
+      PulseCounterShow(0);
+      break;
+#endif  // USE_WEBSERVER
+    case FUNC_INIT:
+      PulseCounterInit();
+      break;
+  }
+  return result;
+}
+#endif  // USE_PULSE_COUNTER
+#endif  // ESP32


### PR DESCRIPTION
## Description:
Adds ESP-32 hardware pulse counter support. The existing counter system is interrupt based and starts to have performance issues at higher trigger rates. This enables support for the hardware pulse counter in the ESP-32 chips. 

I'm sure this needs some cleanup to be more general, but it's working well for me. 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [N/A] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [?] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
