### PR TITLE
Lower the minimum temperature to 10C (50F) and make it pick up user-defined values.

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_44_miel_hvac.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_44_miel_hvac.ino
@@ -161,8 +161,12 @@ struct miel_hvac_msg_update {
 #define MIEL_HVAC_UPDATE_MODE_FAN	0x07
 #define MIEL_HVAC_UPDATE_MODE_AUTO	0x08
 	uint8_t			temp;
-#define MIEL_HVAC_UPDATE_TEMP_MIN	16
+#ifndef MIEL_HVAC_UPDATE_TEMP_MIN
+#define MIEL_HVAC_UPDATE_TEMP_MIN	10
+#endif
+#ifndef MIEL_HVAC_UPDATE_TEMP_MAX
 #define MIEL_HVAC_UPDATE_TEMP_MAX	31
+#endif
 	uint8_t			fan;
 #define MIEL_HVAC_UPDATE_FAN_AUTO	0x00
 #define MIEL_HVAC_UPDATE_FAN_QUIET	0x01


### PR DESCRIPTION
## Description: Lower the MIEL_HVAC_UPDATE_TEMP_MIN from 16C (60.8F) to 10C (50.0F).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

I tested this by installing it on several different mini splits: MSZ-GL06NA, MSZ-GL15NA, PEAD-A15AA7 (ducted), MSZ-GS15NA, MSZ-GS09NA, and MSZ-GS06NA. All of them accept 10C HVACSetTemp commands and respond with that value in settings. I also tried sending 8C and they replied with 10C in settings; and tried 38C and they replied with 31C. So I think 10C and 31C are appropriate min/max.
