### PR TITLE
Fix Wi-Fi scan results process when scanning fails.

### DIFF
--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -386,7 +386,7 @@ void WifiBeginAfterScan(void)
 
     ResponseClear();
 
-    uint32_t initial_item = (Wifi.scan_state - 9)*10;
+    int32_t initial_item = (Wifi.scan_state - 9)*10;
 
     if ( wifi_scan_result > initial_item ) {
       // Sort networks by RSSI


### PR DESCRIPTION
## Description:

If the Wi-Fi scan fails, `WiFi.scanComplete()` will return `WIFI_SCAN_FAILED` which is actually -2. In this case comparison `(int8_t) -2 > (uint32_t) 0` will be true and will cause a crash in the next lines.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
