### PR TITLE
Berry add `introspect.contains` and `bytes.addfloat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - HASPmota support for `min` and `max` attribute in `slider` (#20582)
 - ESP32-C3 support for GPIO11 (#18350)
 - ESP32 support for Shelly Plus Add-On using DS18x20 or DHT11/AM2301/DHT21/DHT22/AM2302/AM2321/SI7021 on GPIO0/1 (#20580)
+- Berry add `introspect.contains` and `bytes.addfloat`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_introspectlib.c
+++ b/lib/libesp32/berry/src/be_introspectlib.c
@@ -93,6 +93,19 @@ static int m_findmember(bvm *vm)
     be_return_nil(vm);
 }
 
+static int m_contains(bvm *vm)
+{
+    bbool contains = bfalse;
+    int top = be_top(vm);
+    if (top >= 2 && be_isstring(vm, 2) && (be_isinstance(vm, 1) || be_ismodule(vm, 1) || be_isclass(vm, 1))) {
+        if (be_getmember(vm, 1, be_tostring(vm, 2))) {
+            contains = btrue;
+        }
+    }
+    be_pushbool(vm, contains);
+    be_return(vm);
+}
+
 static int m_setmember(bvm *vm)
 {
     int top = be_top(vm);
@@ -225,6 +238,7 @@ be_native_module_attr_table(introspect) {
 
     be_native_module_function("get", m_findmember),
     be_native_module_function("set", m_setmember),
+    be_native_module_function("contains", m_contains),
 
     be_native_module_function("module", m_getmodule),
     be_native_module_function("setmodule", m_setmodule),
@@ -245,6 +259,7 @@ module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
 
     get, func(m_findmember)
     set, func(m_setmember)
+    contains, func(m_contains)
 
     module, func(m_getmodule)
     setmodule, func(m_setmodule)


### PR DESCRIPTION
## Description:

Berry add:
- `introspect.contains(any, member:string) -> bool`: returns `true` if the instance/class/module contains the `member`
- `bytes().addfloat(val: float [, big_endian:bool]) -> bytes instance`: add the 32 bit float to the buffer, default is little-endian except if `true` is passed as second argument.

These extensions are useful for future LVGL 9 integration.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
