### PR TITLE
Typo in webserver_async.be

### DIFF
--- a/tasmota/berry/gpio_viewer/webserver_async.be
+++ b/tasmota/berry/gpio_viewer/webserver_async.be
@@ -180,7 +180,7 @@ class Webserver_async_cnx
           else
             # remove the first bytes already sent
             self.buf_out.setbytes(0, buf_out, sent)
-            self.byf_out.resize(size(buf_out) - sent)
+            self.buf_out.resize(size(buf_out) - sent)
           end
         end
       end


### PR DESCRIPTION
## Description:

Did not do an explicit test, as this is fixing an obvious typo in the code

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
