### PR TITLE
Berry Wire: fix compilation with coming update of Arduino framework

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_wire.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_wire.ino
@@ -164,7 +164,7 @@ extern "C" {
         myWire.write(value);
       } else if (be_isstring(vm, 2)) {
         const char * s = be_tostring(vm, 1);
-        myWire.write(s);
+        myWire.write((uint8_t*) s, strlen(s));
       } else if ((buf = be_tobytes(vm, 2, &len)) != nullptr) {
         myWire.write((uint8_t*) buf, len);
       } else {


### PR DESCRIPTION
## Description:

The following inlined function will be removed with commit https://github.com/espressif/arduino-esp32/pull/8817:

```
    inline size_t write(const char * s)
    {
        return write((uint8_t*) s, strlen(s));
    }
```

To fix compilation in the future we just use the very same code in our driver.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
