### PR TITLE
MI32 legacy: fix build for core 2

### DIFF
--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -141,12 +141,15 @@ struct ATCPacket_t{ //and PVVX
   };
 };
 
-struct BTHome_info_t{
-  uint8_t encrypted:1;
-  uint8_t reserved:1;
-  uint8_t triggered:1;
-  uint8_t reserved2:2;
-  uint8_t version:2;
+union BTHome_info_t{
+  struct{
+    uint8_t encrypted:1;
+    uint8_t reserved:1;
+    uint8_t triggered:1;
+    uint8_t reserved2:2;
+    uint8_t version:2;
+  };
+  char byte_value;
 };
 
 struct BLERingBufferItem_t{

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -1827,7 +1827,8 @@ void MI32parseBTHomePacket(char * _buf, uint32_t length, uint8_t addr[6], int RS
   MIBLEsensors[_slot].RSSI = RSSI;
   MIBLEsensors[_slot].lastTime = millis();
 
-  BTHome_info_t info = (BTHome_info_t)_buf[0];
+  BTHome_info_t info;
+  info.byte_value = _buf[0];
   MIBLEsensors[_slot].feature.needsKey = info.encrypted;
 
   uint32_t idx = 1;


### PR DESCRIPTION
## Description:

Initially developed with Arduino 3.x, now compiles with Arduino 2.x too.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
