### PR TITLE
Matter aggregator relocated to endpoint 1 for Google compatibility, may break existing associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Berry `introspect.contains` and `bytes.addfloat` (#20635)
 
 ### Breaking Changed
+- Matter aggregator relocated to endpoint 1 for Google compatibility, may break existing associations
 
 ### Changed
 - Library OneWire-Stickbreaker by TasmotaOneWire supporting Shelly Plus Add-On (#20580)

--- a/lib/libesp32/berry_matter/src/be_matter_module.c
+++ b/lib/libesp32/berry_matter/src/be_matter_module.c
@@ -285,7 +285,8 @@ module matter (scope: global, strings: weak) {
   _STYLESHEET, comptr(MATTER_STYLESHEET)
   _ADD_ENDPOINT_JS, comptr(MATTER_ADD_ENDPOINT_HINTS_JS)
   MATTER_OPTION, int(151)       // SetOption151 enables Matter
-  AGGREGATOR_ENDPOINT, int(0xFE)    // for Alexa we need only 8 bits endpoints
+  AGGREGATOR_ENDPOINT, int(0x0001)    // some controllers require aggregator to be endpoint 1
+  START_ENDPOINT, int(0x0002)         // endpoint where to start devices
   seconds_to_dhm, ctype_func(matter_seconds_to_dhm)
 
   Verhoeff, class(be_class_Matter_Verhoeff)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Fabric.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Fabric.be
@@ -43,6 +43,7 @@ class Matter_Fabric : Matter_Expirable
   var _store                      # reference back to session store
   # timestamp
   var created
+  var deleted                     # timestamp when the deletion of fabric was requested, and deferred
   # fabric-index
   var fabric_index                # index number for fabrics, starts with `1`
   var fabric_parent               # index of the parent fabric, i.e. the fabric that triggered the provisioning (if nested)
@@ -76,6 +77,7 @@ class Matter_Fabric : Matter_Expirable
     self._sessions = matter.Expirable_list()
     self.fabric_label = ""
     self.created = tasmota.rtc_utc()
+    # self.deleted = nil      # no need to actually set to nil
     # init group counters
     self._counter_group_data_snd_impl = matter.Counter()
     self._counter_group_ctrl_snd_impl  = matter.Counter()
@@ -274,6 +276,16 @@ class Matter_Fabric : Matter_Expirable
       idx += 1
     end
     return session
+  end
+
+  #############################################################
+  # Mark for deleteion in the near future
+  #
+  def mark_for_deletion()
+    self.deleted = tasmota.rtc_utc()
+  end
+  def is_marked_for_deletion()
+    return self.deleted != nil
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
@@ -38,7 +38,6 @@ class Matter_Plugin
   # Configuration of the plugin: clusters and type
   static var CLUSTERS = {
     0x001D: [0,1,2,3,0xFFFC,0xFFFD],                # Descriptor Cluster 9.5 p.453
-    0x0039: [0x11],                                 # Bridged Device Basic Information 9.13 p.485
   }
   # Accepted Update commands for virtual devices
   static var UPDATE_COMMANDS = []
@@ -266,14 +265,6 @@ class Matter_Plugin
         return tlv_solo.set(TLV.U4, 1)    # "Initial Release"
       end
 
-    # ====================================================================================================
-    elif cluster == 0x0039              # ========== Bridged Device Basic Information 9.13 p.485 ==========
-
-      if   attribute == 0x0011          #  ---------- Reachable / bool ----------
-        return tlv_solo.set(TLV.BOOL, 1)     # by default we are reachable
-      else
-        return super(self).read_attribute(session, ctx, tlv_solo)   # rest is handled by 0x0028
-      end
     else
       return nil
     end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Device.be
@@ -119,8 +119,6 @@ class Matter_Plugin_Device : Matter_Plugin
         return tlv_solo.set(TLV.BOOL, 1)     # by default we are reachable
       elif attribute == 0x0012          #  ---------- UniqueID / string 32 max ----------
         return tlv_solo.set(TLV.UTF1, tasmota.wifi().find("mac", ""))
-      else
-        return super(self).read_attribute(session, ctx, tlv_solo)
       end
 
     else

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Fabric.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Fabric.h
@@ -7,11 +7,11 @@
 extern const bclass be_class_Matter_Fabric;
 
 /********************************************************************
-** Solidified function: counter_group_data_snd_next
+** Solidified function: fabric_candidate
 ********************************************************************/
-be_local_closure(Matter_Fabric_counter_group_data_snd_next,   /* name */
+be_local_closure(Matter_Fabric_fabric_candidate,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,51 +19,79 @@ be_local_closure(Matter_Fabric_counter_group_data_snd_next,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_counter_group_data_snd_impl),
-    /* K1   */  be_nested_str_weak(next),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_data_snd_X3D_X25i),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(Counter),
-    /* K8   */  be_nested_str_weak(is_greater),
-    /* K9   */  be_nested_str_weak(counter_group_data_snd),
-    /* K10  */  be_nested_str_weak(_GROUP_SND_INCR),
-    /* K11  */  be_nested_str_weak(does_persist),
-    /* K12  */  be_nested_str_weak(save),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K1   */  be_nested_str_weak(assign_fabric_index),
+    /* K2   */  be_nested_str_weak(_store),
+    /* K3   */  be_nested_str_weak(add_fabric),
     }),
-    be_str_weak(counter_group_data_snd_next),
+    be_str_weak(fabric_candidate),
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
+    ( &(const binstruction[10]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x540E0077,  //  0001  LDINT	R3	120
+      0x7C040400,  //  0002  CALL	R1	2
+      0x8C040101,  //  0003  GETMET	R1	R0	K1
+      0x7C040200,  //  0004  CALL	R1	1
+      0x88040102,  //  0005  GETMBR	R1	R0	K2
+      0x8C040303,  //  0006  GETMET	R1	R1	K3
+      0x5C0C0000,  //  0007  MOVE	R3	R0
+      0x7C040400,  //  0008  CALL	R1	2
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ca
+********************************************************************/
+be_local_closure(Matter_Fabric_get_ca,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(root_ca_certificate),
+    }),
+    be_str_weak(get_ca),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0xB80A0400,  //  0003  GETNGBL	R2	K2
-      0x8C080503,  //  0004  GETMET	R2	R2	K3
-      0x60100018,  //  0005  GETGBL	R4	G24
-      0x58140004,  //  0006  LDCONST	R5	K4
-      0x5C180200,  //  0007  MOVE	R6	R1
-      0x7C100400,  //  0008  CALL	R4	2
-      0x58140005,  //  0009  LDCONST	R5	K5
-      0x7C080600,  //  000A  CALL	R2	3
-      0xB80A0C00,  //  000B  GETNGBL	R2	K6
-      0x88080507,  //  000C  GETMBR	R2	R2	K7
-      0x8C080508,  //  000D  GETMET	R2	R2	K8
-      0x5C100200,  //  000E  MOVE	R4	R1
-      0x88140109,  //  000F  GETMBR	R5	R0	K9
-      0x7C080600,  //  0010  CALL	R2	3
-      0x780A0007,  //  0011  JMPF	R2	#001A
-      0x8808010A,  //  0012  GETMBR	R2	R0	K10
-      0x00080202,  //  0013  ADD	R2	R1	R2
-      0x90021202,  //  0014  SETMBR	R0	K9	R2
-      0x8C08010B,  //  0015  GETMET	R2	R0	K11
-      0x7C080200,  //  0016  CALL	R2	1
-      0x780A0001,  //  0017  JMPF	R2	#001A
-      0x8C08010C,  //  0018  GETMET	R2	R0	K12
-      0x7C080200,  //  0019  CALL	R2	1
-      0x80040200,  //  001A  RET	1	R1
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ipk_epoch_key
+********************************************************************/
+be_local_closure(Matter_Fabric_get_ipk_epoch_key,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ipk_epoch_key),
+    }),
+    be_str_weak(get_ipk_epoch_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -112,9 +140,92 @@ be_local_closure(Matter_Fabric_get_ca_pub,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_device_id
+** Solidified function: get_ipk_group_key
 ********************************************************************/
-be_local_closure(Matter_Fabric_get_device_id,   /* name */
+be_local_closure(Matter_Fabric_get_ipk_group_key,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ipk_epoch_key),
+    /* K1   */  be_nested_str_weak(fabric_compressed),
+    /* K2   */  be_nested_str_weak(crypto),
+    /* K3   */  be_nested_str_weak(HKDF_SHA256),
+    /* K4   */  be_nested_str_weak(fromstring),
+    /* K5   */  be_nested_str_weak(_GROUP_KEY),
+    /* K6   */  be_nested_str_weak(derive),
+    }),
+    be_str_weak(get_ipk_group_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x74060003,  //  0003  JMPT	R1	#0008
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x4C080000,  //  0005  LDNIL	R2
+      0x1C040202,  //  0006  EQ	R1	R1	R2
+      0x78060001,  //  0007  JMPF	R1	#000A
+      0x4C040000,  //  0008  LDNIL	R1
+      0x80040200,  //  0009  RET	1	R1
+      0xA4060400,  //  000A  IMPORT	R1	K2
+      0x8C080303,  //  000B  GETMET	R2	R1	K3
+      0x7C080200,  //  000C  CALL	R2	1
+      0x600C0015,  //  000D  GETGBL	R3	G21
+      0x7C0C0000,  //  000E  CALL	R3	0
+      0x8C0C0704,  //  000F  GETMET	R3	R3	K4
+      0x88140105,  //  0010  GETMBR	R5	R0	K5
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x8C100506,  //  0012  GETMET	R4	R2	K6
+      0x88180100,  //  0013  GETMBR	R6	R0	K0
+      0x881C0101,  //  0014  GETMBR	R7	R0	K1
+      0x5C200600,  //  0015  MOVE	R8	R3
+      0x5426000F,  //  0016  LDINT	R9	16
+      0x7C100A00,  //  0017  CALL	R4	5
+      0x80040800,  //  0018  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_ca
+********************************************************************/
+be_local_closure(Matter_Fabric_set_ca,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(root_ca_certificate),
+    }),
+    be_str_weak(set_ca),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_compressed
+********************************************************************/
+be_local_closure(Matter_Fabric_get_fabric_compressed,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -125,9 +236,9 @@ be_local_closure(Matter_Fabric_get_device_id,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device_id),
+    /* K0   */  be_nested_str_weak(fabric_compressed),
     }),
-    be_str_weak(get_device_id),
+    be_str_weak(get_fabric_compressed),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
@@ -139,63 +250,26 @@ be_local_closure(Matter_Fabric_get_device_id,   /* name */
 
 
 /********************************************************************
-** Solidified function: add_session
+** Solidified function: get_fabric_label
 ********************************************************************/
-be_local_closure(Matter_Fabric_add_session,   /* name */
+be_local_closure(Matter_Fabric_get_fabric_label,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
+    2,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_sessions),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(_MAX_CASE),
-    /* K3   */  be_nested_str_weak(get_oldest_session),
-    /* K4   */  be_nested_str_weak(remove),
-    /* K5   */  be_nested_str_weak(_store),
-    /* K6   */  be_nested_str_weak(remove_session),
-    /* K7   */  be_nested_str_weak(push),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fabric_label),
     }),
-    be_str_weak(add_session),
+    be_str_weak(get_fabric_label),
     &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x1C080403,  //  0005  EQ	R2	R2	R3
-      0x780A0017,  //  0006  JMPF	R2	#001F
-      0x6008000C,  //  0007  GETGBL	R2	G12
-      0x880C0100,  //  0008  GETMBR	R3	R0	K0
-      0x7C080200,  //  0009  CALL	R2	1
-      0x880C0102,  //  000A  GETMBR	R3	R0	K2
-      0x28080403,  //  000B  GE	R2	R2	R3
-      0x780A000D,  //  000C  JMPF	R2	#001B
-      0x8C080103,  //  000D  GETMET	R2	R0	K3
-      0x7C080200,  //  000E  CALL	R2	1
-      0x880C0100,  //  000F  GETMBR	R3	R0	K0
-      0x8C0C0704,  //  0010  GETMET	R3	R3	K4
-      0x88140100,  //  0011  GETMBR	R5	R0	K0
-      0x8C140B01,  //  0012  GETMET	R5	R5	K1
-      0x5C1C0400,  //  0013  MOVE	R7	R2
-      0x7C140400,  //  0014  CALL	R5	2
-      0x7C0C0400,  //  0015  CALL	R3	2
-      0x880C0105,  //  0016  GETMBR	R3	R0	K5
-      0x8C0C0706,  //  0017  GETMET	R3	R3	K6
-      0x5C140400,  //  0018  MOVE	R5	R2
-      0x7C0C0400,  //  0019  CALL	R3	2
-      0x7001FFEB,  //  001A  JMP		#0007
-      0x88080100,  //  001B  GETMBR	R2	R0	K0
-      0x8C080507,  //  001C  GETMET	R2	R2	K7
-      0x5C100200,  //  001D  MOVE	R4	R1
-      0x7C080400,  //  001E  CALL	R2	2
-      0x80000000,  //  001F  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -203,9 +277,214 @@ be_local_closure(Matter_Fabric_add_session,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_oldest_session
+** Solidified function: assign_fabric_index
 ********************************************************************/
-be_local_closure(Matter_Fabric_get_oldest_session,   /* name */
+be_local_closure(Matter_Fabric_assign_fabric_index,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_fabric_index),
+    /* K1   */  be_nested_str_weak(set_fabric_index),
+    /* K2   */  be_nested_str_weak(_store),
+    /* K3   */  be_nested_str_weak(next_fabric_idx),
+    }),
+    be_str_weak(assign_fabric_index),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x4C080000,  //  0002  LDNIL	R2
+      0x1C040202,  //  0003  EQ	R1	R1	R2
+      0x78060004,  //  0004  JMPF	R1	#000A
+      0x8C040101,  //  0005  GETMET	R1	R0	K1
+      0x880C0102,  //  0006  GETMBR	R3	R0	K2
+      0x8C0C0703,  //  0007  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x7C040400,  //  0009  CALL	R1	2
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_noc
+********************************************************************/
+be_local_closure(Matter_Fabric_get_noc,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(noc),
+    }),
+    be_str_weak(get_noc),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: log_new_fabric
+********************************************************************/
+be_local_closure(Matter_Fabric_log_new_fabric,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2BFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20vendorid_X3D_X25s),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(copy),
+    /* K5   */  be_nested_str_weak(reverse),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_nested_str_weak(get_admin_vendor_name),
+    /* K8   */  be_const_int(3),
+    }),
+    be_str_weak(log_new_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x600C0018,  //  0002  GETGBL	R3	G24
+      0x58100002,  //  0003  LDCONST	R4	K2
+      0x8C140103,  //  0004  GETMET	R5	R0	K3
+      0x7C140200,  //  0005  CALL	R5	1
+      0x8C140B04,  //  0006  GETMET	R5	R5	K4
+      0x7C140200,  //  0007  CALL	R5	1
+      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0x7C140200,  //  0009  CALL	R5	1
+      0x8C140B06,  //  000A  GETMET	R5	R5	K6
+      0x7C140200,  //  000B  CALL	R5	1
+      0x8C180107,  //  000C  GETMET	R6	R0	K7
+      0x7C180200,  //  000D  CALL	R6	1
+      0x7C0C0600,  //  000E  CALL	R3	3
+      0x58100008,  //  000F  LDCONST	R4	K8
+      0x7C040600,  //  0010  CALL	R1	3
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_pk
+********************************************************************/
+be_local_closure(Matter_Fabric_set_pk,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(no_private_key),
+    }),
+    be_str_weak(set_pk),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mark_for_deletion
+********************************************************************/
+be_local_closure(Matter_Fabric_mark_for_deletion,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(deleted),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(rtc_utc),
+    }),
+    be_str_weak(mark_for_deletion),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x8C040302,  //  0001  GETMET	R1	R1	K2
+      0x7C040200,  //  0002  CALL	R1	1
+      0x90020001,  //  0003  SETMBR	R0	K0	R1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_marked_for_deletion
+********************************************************************/
+be_local_closure(Matter_Fabric_is_marked_for_deletion,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(deleted),
+    }),
+    be_str_weak(is_marked_for_deletion),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: fabric_completed
+********************************************************************/
+be_local_closure(Matter_Fabric_fabric_completed,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -215,16 +494,28 @@ be_local_closure(Matter_Fabric_get_oldest_session,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_old_recent_session),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_no_expiration),
+    /* K1   */  be_nested_str_weak(set_persist),
+    /* K2   */  be_nested_str_weak(assign_fabric_index),
+    /* K3   */  be_nested_str_weak(_store),
+    /* K4   */  be_nested_str_weak(add_fabric),
     }),
-    be_str_weak(get_oldest_session),
+    be_str_weak(fabric_completed),
     &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
+    ( &(const binstruction[12]) {  /* code */
       0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x500C0200,  //  0001  LDBOOL	R3	1	0
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
+      0x7C040200,  //  0001  CALL	R1	1
+      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x500C0200,  //  0003  LDBOOL	R3	1	0
+      0x7C040400,  //  0004  CALL	R1	2
+      0x8C040102,  //  0005  GETMET	R1	R0	K2
+      0x7C040200,  //  0006  CALL	R1	1
+      0x88040103,  //  0007  GETMBR	R1	R0	K3
+      0x8C040304,  //  0008  GETMET	R1	R1	K4
+      0x5C0C0000,  //  0009  MOVE	R3	R0
+      0x7C040400,  //  000A  CALL	R1	2
+      0x80000000,  //  000B  RET	0
     })
   )
 );
@@ -232,117 +523,101 @@ be_local_closure(Matter_Fabric_get_oldest_session,   /* name */
 
 
 /********************************************************************
-** Solidified function: fromjson
+** Solidified function: before_remove
 ********************************************************************/
-be_local_closure(Matter_Fabric_fromjson,   /* name */
+be_local_closure(Matter_Fabric_before_remove,   /* name */
   be_nested_proto(
-    16,                          /* nstack */
-    2,                          /* argc */
-    4,                          /* varg */
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Fabric),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(introspect),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Fabric),
-    /* K5   */  be_nested_str_weak(keys),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(_),
-    /* K8   */  be_nested_str_weak(find),
-    /* K9   */  be_nested_str_weak(0x),
-    /* K10  */  be_nested_str_weak(set),
-    /* K11  */  be_nested_str_weak(fromhex),
-    /* K12  */  be_const_int(2),
-    /* K13  */  be_const_int(2147483647),
-    /* K14  */  be_nested_str_weak(_X24_X24),
-    /* K15  */  be_nested_str_weak(fromb64),
-    /* K16  */  be_nested_str_weak(stop_iteration),
-    /* K17  */  be_nested_str_weak(hydrate_post),
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2DFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20_X28removed_X29),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(copy),
+    /* K5   */  be_nested_str_weak(reverse),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_const_int(3),
     }),
-    be_str_weak(fromjson),
+    be_str_weak(before_remove),
     &be_const_str_solidified,
-    ( &(const binstruction[76]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA4120400,  //  0002  IMPORT	R4	K2
-      0xB8160600,  //  0003  GETNGBL	R5	K3
-      0x8C140B04,  //  0004  GETMET	R5	R5	K4
-      0x5C1C0000,  //  0005  MOVE	R7	R0
-      0x7C140400,  //  0006  CALL	R5	2
-      0x60180010,  //  0007  GETGBL	R6	G16
-      0x8C1C0305,  //  0008  GETMET	R7	R1	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x7C180200,  //  000A  CALL	R6	1
-      0xA8020039,  //  000B  EXBLK	0	#0046
-      0x5C1C0C00,  //  000C  MOVE	R7	R6
-      0x7C1C0000,  //  000D  CALL	R7	0
-      0x94200F06,  //  000E  GETIDX	R8	R7	K6
-      0x1C201107,  //  000F  EQ	R8	R8	K7
-      0x78220000,  //  0010  JMPF	R8	#0012
-      0x7001FFF9,  //  0011  JMP		#000C
-      0x94200207,  //  0012  GETIDX	R8	R1	R7
-      0x60240004,  //  0013  GETGBL	R9	G4
-      0x5C281000,  //  0014  MOVE	R10	R8
-      0x7C240200,  //  0015  CALL	R9	1
-      0x1C241301,  //  0016  EQ	R9	R9	K1
-      0x78260027,  //  0017  JMPF	R9	#0040
-      0x8C240708,  //  0018  GETMET	R9	R3	K8
-      0x5C2C1000,  //  0019  MOVE	R11	R8
-      0x58300009,  //  001A  LDCONST	R12	K9
-      0x7C240600,  //  001B  CALL	R9	3
-      0x1C241306,  //  001C  EQ	R9	R9	K6
-      0x7826000A,  //  001D  JMPF	R9	#0029
-      0x8C24090A,  //  001E  GETMET	R9	R4	K10
-      0x5C2C0A00,  //  001F  MOVE	R11	R5
-      0x5C300E00,  //  0020  MOVE	R12	R7
-      0x60340015,  //  0021  GETGBL	R13	G21
-      0x7C340000,  //  0022  CALL	R13	0
-      0x8C341B0B,  //  0023  GETMET	R13	R13	K11
-      0x403E190D,  //  0024  CONNECT	R15	K12	K13
-      0x943C100F,  //  0025  GETIDX	R15	R8	R15
-      0x7C340400,  //  0026  CALL	R13	2
-      0x7C240800,  //  0027  CALL	R9	4
-      0x70020015,  //  0028  JMP		#003F
-      0x8C240708,  //  0029  GETMET	R9	R3	K8
-      0x5C2C1000,  //  002A  MOVE	R11	R8
-      0x5830000E,  //  002B  LDCONST	R12	K14
-      0x7C240600,  //  002C  CALL	R9	3
-      0x1C241306,  //  002D  EQ	R9	R9	K6
-      0x7826000A,  //  002E  JMPF	R9	#003A
-      0x8C24090A,  //  002F  GETMET	R9	R4	K10
-      0x5C2C0A00,  //  0030  MOVE	R11	R5
-      0x5C300E00,  //  0031  MOVE	R12	R7
-      0x60340015,  //  0032  GETGBL	R13	G21
-      0x7C340000,  //  0033  CALL	R13	0
-      0x8C341B0F,  //  0034  GETMET	R13	R13	K15
-      0x403E190D,  //  0035  CONNECT	R15	K12	K13
-      0x943C100F,  //  0036  GETIDX	R15	R8	R15
-      0x7C340400,  //  0037  CALL	R13	2
-      0x7C240800,  //  0038  CALL	R9	4
-      0x70020004,  //  0039  JMP		#003F
-      0x8C24090A,  //  003A  GETMET	R9	R4	K10
-      0x5C2C0A00,  //  003B  MOVE	R11	R5
-      0x5C300E00,  //  003C  MOVE	R12	R7
-      0x5C341000,  //  003D  MOVE	R13	R8
-      0x7C240800,  //  003E  CALL	R9	4
-      0x70020004,  //  003F  JMP		#0045
-      0x8C24090A,  //  0040  GETMET	R9	R4	K10
-      0x5C2C0A00,  //  0041  MOVE	R11	R5
-      0x5C300E00,  //  0042  MOVE	R12	R7
-      0x5C341000,  //  0043  MOVE	R13	R8
-      0x7C240800,  //  0044  CALL	R9	4
-      0x7001FFC5,  //  0045  JMP		#000C
-      0x58180010,  //  0046  LDCONST	R6	K16
-      0xAC180200,  //  0047  CATCH	R6	1	0
-      0xB0080000,  //  0048  RAISE	2	R0	R0
-      0x8C180B11,  //  0049  GETMET	R6	R5	K17
-      0x7C180200,  //  004A  CALL	R6	1
-      0x80040A00,  //  004B  RET	1	R5
+    ( &(const binstruction[16]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x600C0018,  //  0002  GETGBL	R3	G24
+      0x58100002,  //  0003  LDCONST	R4	K2
+      0x8C140103,  //  0004  GETMET	R5	R0	K3
+      0x7C140200,  //  0005  CALL	R5	1
+      0x8C140B04,  //  0006  GETMET	R5	R5	K4
+      0x7C140200,  //  0007  CALL	R5	1
+      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0x7C140200,  //  0009  CALL	R5	1
+      0x8C140B06,  //  000A  GETMET	R5	R5	K6
+      0x7C140200,  //  000B  CALL	R5	1
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x58100007,  //  000D  LDCONST	R4	K7
+      0x7C040600,  //  000E  CALL	R1	3
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_admin_vendor
+********************************************************************/
+be_local_closure(Matter_Fabric_get_admin_vendor,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(admin_vendor),
+    }),
+    be_str_weak(get_admin_vendor),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_icac
+********************************************************************/
+be_local_closure(Matter_Fabric_get_icac,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(icac),
+    }),
+    be_str_weak(get_icac),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -450,9 +725,67 @@ be_local_closure(Matter_Fabric_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: fabric_completed
+** Solidified function: get_old_recent_session
 ********************************************************************/
-be_local_closure(Matter_Fabric_fabric_completed,   /* name */
+be_local_closure(Matter_Fabric_get_old_recent_session,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_sessions),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(last_used),
+    /* K3   */  be_const_int(1),
+    }),
+    be_str_weak(get_old_recent_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x6008000C,  //  0000  GETGBL	R2	G12
+      0x880C0100,  //  0001  GETMBR	R3	R0	K0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x1C080501,  //  0003  EQ	R2	R2	K1
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x4C080000,  //  0005  LDNIL	R2
+      0x80040400,  //  0006  RET	1	R2
+      0x88080100,  //  0007  GETMBR	R2	R0	K0
+      0x94080501,  //  0008  GETIDX	R2	R2	K1
+      0x880C0502,  //  0009  GETMBR	R3	R2	K2
+      0x58100003,  //  000A  LDCONST	R4	K3
+      0x6014000C,  //  000B  GETGBL	R5	G12
+      0x88180100,  //  000C  GETMBR	R6	R0	K0
+      0x7C140200,  //  000D  CALL	R5	1
+      0x14140805,  //  000E  LT	R5	R4	R5
+      0x7816000C,  //  000F  JMPF	R5	#001D
+      0x88140100,  //  0010  GETMBR	R5	R0	K0
+      0x94140A04,  //  0011  GETIDX	R5	R5	R4
+      0x88140B02,  //  0012  GETMBR	R5	R5	K2
+      0x78060001,  //  0013  JMPF	R1	#0016
+      0x14180A03,  //  0014  LT	R6	R5	R3
+      0x70020000,  //  0015  JMP		#0017
+      0x24180A03,  //  0016  GT	R6	R5	R3
+      0x781A0002,  //  0017  JMPF	R6	#001B
+      0x88180100,  //  0018  GETMBR	R6	R0	K0
+      0x94080C04,  //  0019  GETIDX	R2	R6	R4
+      0x5C0C0A00,  //  001A  MOVE	R3	R5
+      0x00100903,  //  001B  ADD	R4	R4	K3
+      0x7001FFED,  //  001C  JMP		#000B
+      0x80040400,  //  001D  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_newest_session
+********************************************************************/
+be_local_closure(Matter_Fabric_get_newest_session,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -462,28 +795,43 @@ be_local_closure(Matter_Fabric_fabric_completed,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_no_expiration),
-    /* K1   */  be_nested_str_weak(set_persist),
-    /* K2   */  be_nested_str_weak(assign_fabric_index),
-    /* K3   */  be_nested_str_weak(_store),
-    /* K4   */  be_nested_str_weak(add_fabric),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_old_recent_session),
     }),
-    be_str_weak(fabric_completed),
+    be_str_weak(get_newest_session),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
+    ( &(const binstruction[ 4]) {  /* code */
       0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
-      0x500C0200,  //  0003  LDBOOL	R3	1	0
-      0x7C040400,  //  0004  CALL	R1	2
-      0x8C040102,  //  0005  GETMET	R1	R0	K2
-      0x7C040200,  //  0006  CALL	R1	1
-      0x88040103,  //  0007  GETMBR	R1	R0	K3
-      0x8C040304,  //  0008  GETMET	R1	R1	K4
-      0x5C0C0000,  //  0009  MOVE	R3	R0
-      0x7C040400,  //  000A  CALL	R1	2
-      0x80000000,  //  000B  RET	0
+      0x500C0000,  //  0001  LDBOOL	R3	0	0
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pk
+********************************************************************/
+be_local_closure(Matter_Fabric_get_pk,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(no_private_key),
+    }),
+    be_str_weak(get_pk),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -555,9 +903,102 @@ be_local_closure(Matter_Fabric_counter_group_ctrl_snd_next,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_ipk_epoch_key
+** Solidified function: set_noc_icac
 ********************************************************************/
-be_local_closure(Matter_Fabric_get_ipk_epoch_key,   /* name */
+be_local_closure(Matter_Fabric_set_noc_icac,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(noc),
+    /* K1   */  be_nested_str_weak(icac),
+    }),
+    be_str_weak(set_noc_icac),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_session
+********************************************************************/
+be_local_closure(Matter_Fabric_add_session,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_sessions),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(_MAX_CASE),
+    /* K3   */  be_nested_str_weak(get_oldest_session),
+    /* K4   */  be_nested_str_weak(remove),
+    /* K5   */  be_nested_str_weak(_store),
+    /* K6   */  be_nested_str_weak(remove_session),
+    /* K7   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(add_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[32]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x1C080403,  //  0005  EQ	R2	R2	R3
+      0x780A0017,  //  0006  JMPF	R2	#001F
+      0x6008000C,  //  0007  GETGBL	R2	G12
+      0x880C0100,  //  0008  GETMBR	R3	R0	K0
+      0x7C080200,  //  0009  CALL	R2	1
+      0x880C0102,  //  000A  GETMBR	R3	R0	K2
+      0x28080403,  //  000B  GE	R2	R2	R3
+      0x780A000D,  //  000C  JMPF	R2	#001B
+      0x8C080103,  //  000D  GETMET	R2	R0	K3
+      0x7C080200,  //  000E  CALL	R2	1
+      0x880C0100,  //  000F  GETMBR	R3	R0	K0
+      0x8C0C0704,  //  0010  GETMET	R3	R3	K4
+      0x88140100,  //  0011  GETMBR	R5	R0	K0
+      0x8C140B01,  //  0012  GETMET	R5	R5	K1
+      0x5C1C0400,  //  0013  MOVE	R7	R2
+      0x7C140400,  //  0014  CALL	R5	2
+      0x7C0C0400,  //  0015  CALL	R3	2
+      0x880C0105,  //  0016  GETMBR	R3	R0	K5
+      0x8C0C0706,  //  0017  GETMET	R3	R3	K6
+      0x5C140400,  //  0018  MOVE	R5	R2
+      0x7C0C0400,  //  0019  CALL	R3	2
+      0x7001FFEB,  //  001A  JMP		#0007
+      0x88080100,  //  001B  GETMBR	R2	R0	K0
+      0x8C080507,  //  001C  GETMET	R2	R2	K7
+      0x5C100200,  //  001D  MOVE	R4	R1
+      0x7C080400,  //  001E  CALL	R2	2
+      0x80000000,  //  001F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_admin_subject
+********************************************************************/
+be_local_closure(Matter_Fabric_get_admin_subject,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -568,13 +1009,147 @@ be_local_closure(Matter_Fabric_get_ipk_epoch_key,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ipk_epoch_key),
+    /* K0   */  be_nested_str_weak(admin_subject),
     }),
-    be_str_weak(get_ipk_epoch_key),
+    be_str_weak(get_admin_subject),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: counter_group_data_snd_next
+********************************************************************/
+be_local_closure(Matter_Fabric_counter_group_data_snd_next,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_counter_group_data_snd_impl),
+    /* K1   */  be_nested_str_weak(next),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_data_snd_X3D_X25i),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(matter),
+    /* K7   */  be_nested_str_weak(Counter),
+    /* K8   */  be_nested_str_weak(is_greater),
+    /* K9   */  be_nested_str_weak(counter_group_data_snd),
+    /* K10  */  be_nested_str_weak(_GROUP_SND_INCR),
+    /* K11  */  be_nested_str_weak(does_persist),
+    /* K12  */  be_nested_str_weak(save),
+    }),
+    be_str_weak(counter_group_data_snd_next),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0xB80A0400,  //  0003  GETNGBL	R2	K2
+      0x8C080503,  //  0004  GETMET	R2	R2	K3
+      0x60100018,  //  0005  GETGBL	R4	G24
+      0x58140004,  //  0006  LDCONST	R5	K4
+      0x5C180200,  //  0007  MOVE	R6	R1
+      0x7C100400,  //  0008  CALL	R4	2
+      0x58140005,  //  0009  LDCONST	R5	K5
+      0x7C080600,  //  000A  CALL	R2	3
+      0xB80A0C00,  //  000B  GETNGBL	R2	K6
+      0x88080507,  //  000C  GETMBR	R2	R2	K7
+      0x8C080508,  //  000D  GETMET	R2	R2	K8
+      0x5C100200,  //  000E  MOVE	R4	R1
+      0x88140109,  //  000F  GETMBR	R5	R0	K9
+      0x7C080600,  //  0010  CALL	R2	3
+      0x780A0007,  //  0011  JMPF	R2	#001A
+      0x8808010A,  //  0012  GETMBR	R2	R0	K10
+      0x00080202,  //  0013  ADD	R2	R1	R2
+      0x90021202,  //  0014  SETMBR	R0	K9	R2
+      0x8C08010B,  //  0015  GETMET	R2	R0	K11
+      0x7C080200,  //  0016  CALL	R2	1
+      0x780A0001,  //  0017  JMPF	R2	#001A
+      0x8C08010C,  //  0018  GETMET	R2	R0	K12
+      0x7C080200,  //  0019  CALL	R2	1
+      0x80040200,  //  001A  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_fabric_device
+********************************************************************/
+be_local_closure(Matter_Fabric_set_fabric_device,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fabric_id),
+    /* K1   */  be_nested_str_weak(device_id),
+    /* K2   */  be_nested_str_weak(fabric_compressed),
+    /* K3   */  be_nested_str_weak(fabric_parent),
+    /* K4   */  be_nested_str_weak(get_fabric_index),
+    }),
+    be_str_weak(set_fabric_device),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x90020403,  //  0002  SETMBR	R0	K2	R3
+      0x4C140000,  //  0003  LDNIL	R5
+      0x20140805,  //  0004  NE	R5	R4	R5
+      0x78160002,  //  0005  JMPF	R5	#0009
+      0x8C140904,  //  0006  GETMET	R5	R4	K4
+      0x7C140200,  //  0007  CALL	R5	1
+      0x70020000,  //  0008  JMP		#000A
+      0x4C140000,  //  0009  LDNIL	R5
+      0x90020605,  //  000A  SETMBR	R0	K3	R5
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_admin_subject_vendor
+********************************************************************/
+be_local_closure(Matter_Fabric_set_admin_subject_vendor,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(admin_subject),
+    /* K1   */  be_nested_str_weak(admin_vendor),
+    }),
+    be_str_weak(set_admin_subject_vendor),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x80000000,  //  0002  RET	0
     })
   )
 );
@@ -752,394 +1327,6 @@ be_local_closure(Matter_Fabric_tojson,   /* name */
 
 
 /********************************************************************
-** Solidified function: assign_fabric_index
-********************************************************************/
-be_local_closure(Matter_Fabric_assign_fabric_index,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_fabric_index),
-    /* K1   */  be_nested_str_weak(set_fabric_index),
-    /* K2   */  be_nested_str_weak(_store),
-    /* K3   */  be_nested_str_weak(next_fabric_idx),
-    }),
-    be_str_weak(assign_fabric_index),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x4C080000,  //  0002  LDNIL	R2
-      0x1C040202,  //  0003  EQ	R1	R1	R2
-      0x78060004,  //  0004  JMPF	R1	#000A
-      0x8C040101,  //  0005  GETMET	R1	R0	K1
-      0x880C0102,  //  0006  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0007  GETMET	R3	R3	K3
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0x7C040400,  //  0009  CALL	R1	2
-      0x80000000,  //  000A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_admin_subject
-********************************************************************/
-be_local_closure(Matter_Fabric_get_admin_subject,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(admin_subject),
-    }),
-    be_str_weak(get_admin_subject),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric_compressed
-********************************************************************/
-be_local_closure(Matter_Fabric_get_fabric_compressed,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_compressed),
-    }),
-    be_str_weak(get_fabric_compressed),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: fabric_candidate
-********************************************************************/
-be_local_closure(Matter_Fabric_fabric_candidate,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K1   */  be_nested_str_weak(assign_fabric_index),
-    /* K2   */  be_nested_str_weak(_store),
-    /* K3   */  be_nested_str_weak(add_fabric),
-    }),
-    be_str_weak(fabric_candidate),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E0077,  //  0001  LDINT	R3	120
-      0x7C040400,  //  0002  CALL	R1	2
-      0x8C040101,  //  0003  GETMET	R1	R0	K1
-      0x7C040200,  //  0004  CALL	R1	1
-      0x88040102,  //  0005  GETMBR	R1	R0	K2
-      0x8C040303,  //  0006  GETMET	R1	R1	K3
-      0x5C0C0000,  //  0007  MOVE	R3	R0
-      0x7C040400,  //  0008  CALL	R1	2
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric_label
-********************************************************************/
-be_local_closure(Matter_Fabric_get_fabric_label,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_label),
-    }),
-    be_str_weak(get_fabric_label),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_noc_icac
-********************************************************************/
-be_local_closure(Matter_Fabric_set_noc_icac,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(noc),
-    /* K1   */  be_nested_str_weak(icac),
-    }),
-    be_str_weak(set_noc_icac),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_newest_session
-********************************************************************/
-be_local_closure(Matter_Fabric_get_newest_session,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_old_recent_session),
-    }),
-    be_str_weak(get_newest_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x500C0000,  //  0001  LDBOOL	R3	0	0
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: before_remove
-********************************************************************/
-be_local_closure(Matter_Fabric_before_remove,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2DFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20_X28removed_X29),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(copy),
-    /* K5   */  be_nested_str_weak(reverse),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_const_int(3),
-    }),
-    be_str_weak(before_remove),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x600C0018,  //  0002  GETGBL	R3	G24
-      0x58100002,  //  0003  LDCONST	R4	K2
-      0x8C140103,  //  0004  GETMET	R5	R0	K3
-      0x7C140200,  //  0005  CALL	R5	1
-      0x8C140B04,  //  0006  GETMET	R5	R5	K4
-      0x7C140200,  //  0007  CALL	R5	1
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x7C140200,  //  0009  CALL	R5	1
-      0x8C140B06,  //  000A  GETMET	R5	R5	K6
-      0x7C140200,  //  000B  CALL	R5	1
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x58100007,  //  000D  LDCONST	R4	K7
-      0x7C040600,  //  000E  CALL	R1	3
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_fabric_device
-********************************************************************/
-be_local_closure(Matter_Fabric_set_fabric_device,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_id),
-    /* K1   */  be_nested_str_weak(device_id),
-    /* K2   */  be_nested_str_weak(fabric_compressed),
-    /* K3   */  be_nested_str_weak(fabric_parent),
-    /* K4   */  be_nested_str_weak(get_fabric_index),
-    }),
-    be_str_weak(set_fabric_device),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x90020403,  //  0002  SETMBR	R0	K2	R3
-      0x4C140000,  //  0003  LDNIL	R5
-      0x20140805,  //  0004  NE	R5	R4	R5
-      0x78160002,  //  0005  JMPF	R5	#0009
-      0x8C140904,  //  0006  GETMET	R5	R4	K4
-      0x7C140200,  //  0007  CALL	R5	1
-      0x70020000,  //  0008  JMP		#000A
-      0x4C140000,  //  0009  LDNIL	R5
-      0x90020605,  //  000A  SETMBR	R0	K3	R5
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_ipk_epoch_key
-********************************************************************/
-be_local_closure(Matter_Fabric_set_ipk_epoch_key,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ipk_epoch_key),
-    }),
-    be_str_weak(set_ipk_epoch_key),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ipk_group_key
-********************************************************************/
-be_local_closure(Matter_Fabric_get_ipk_group_key,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ipk_epoch_key),
-    /* K1   */  be_nested_str_weak(fabric_compressed),
-    /* K2   */  be_nested_str_weak(crypto),
-    /* K3   */  be_nested_str_weak(HKDF_SHA256),
-    /* K4   */  be_nested_str_weak(fromstring),
-    /* K5   */  be_nested_str_weak(_GROUP_KEY),
-    /* K6   */  be_nested_str_weak(derive),
-    }),
-    be_str_weak(get_ipk_group_key),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x74060003,  //  0003  JMPT	R1	#0008
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x4C080000,  //  0005  LDNIL	R2
-      0x1C040202,  //  0006  EQ	R1	R1	R2
-      0x78060001,  //  0007  JMPF	R1	#000A
-      0x4C040000,  //  0008  LDNIL	R1
-      0x80040200,  //  0009  RET	1	R1
-      0xA4060400,  //  000A  IMPORT	R1	K2
-      0x8C080303,  //  000B  GETMET	R2	R1	K3
-      0x7C080200,  //  000C  CALL	R2	1
-      0x600C0015,  //  000D  GETGBL	R3	G21
-      0x7C0C0000,  //  000E  CALL	R3	0
-      0x8C0C0704,  //  000F  GETMET	R3	R3	K4
-      0x88140105,  //  0010  GETMBR	R5	R0	K5
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x8C100506,  //  0012  GETMET	R4	R2	K6
-      0x88180100,  //  0013  GETMBR	R6	R0	K0
-      0x881C0101,  //  0014  GETMBR	R7	R0	K1
-      0x5C200600,  //  0015  MOVE	R8	R3
-      0x5426000F,  //  0016  LDINT	R9	16
-      0x7C100A00,  //  0017  CALL	R4	5
-      0x80040800,  //  0018  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: hydrate_post
 ********************************************************************/
 be_local_closure(Matter_Fabric_hydrate_post,   /* name */
@@ -1180,6 +1367,234 @@ be_local_closure(Matter_Fabric_hydrate_post,   /* name */
       0x7C040200,  //  000E  CALL	R1	1
       0x90020801,  //  000F  SETMBR	R0	K4	R1
       0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_oldest_session
+********************************************************************/
+be_local_closure(Matter_Fabric_get_oldest_session,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_old_recent_session),
+    }),
+    be_str_weak(get_oldest_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x500C0200,  //  0001  LDBOOL	R3	1	0
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_device_id
+********************************************************************/
+be_local_closure(Matter_Fabric_get_device_id,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device_id),
+    }),
+    be_str_weak(get_device_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_ipk_epoch_key
+********************************************************************/
+be_local_closure(Matter_Fabric_set_ipk_epoch_key,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ipk_epoch_key),
+    }),
+    be_str_weak(set_ipk_epoch_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: fromjson
+********************************************************************/
+be_local_closure(Matter_Fabric_fromjson,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    2,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Fabric),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(introspect),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(Fabric),
+    /* K5   */  be_nested_str_weak(keys),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(_),
+    /* K8   */  be_nested_str_weak(find),
+    /* K9   */  be_nested_str_weak(0x),
+    /* K10  */  be_nested_str_weak(set),
+    /* K11  */  be_nested_str_weak(fromhex),
+    /* K12  */  be_const_int(2),
+    /* K13  */  be_const_int(2147483647),
+    /* K14  */  be_nested_str_weak(_X24_X24),
+    /* K15  */  be_nested_str_weak(fromb64),
+    /* K16  */  be_nested_str_weak(stop_iteration),
+    /* K17  */  be_nested_str_weak(hydrate_post),
+    }),
+    be_str_weak(fromjson),
+    &be_const_str_solidified,
+    ( &(const binstruction[76]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xA4120400,  //  0002  IMPORT	R4	K2
+      0xB8160600,  //  0003  GETNGBL	R5	K3
+      0x8C140B04,  //  0004  GETMET	R5	R5	K4
+      0x5C1C0000,  //  0005  MOVE	R7	R0
+      0x7C140400,  //  0006  CALL	R5	2
+      0x60180010,  //  0007  GETGBL	R6	G16
+      0x8C1C0305,  //  0008  GETMET	R7	R1	K5
+      0x7C1C0200,  //  0009  CALL	R7	1
+      0x7C180200,  //  000A  CALL	R6	1
+      0xA8020039,  //  000B  EXBLK	0	#0046
+      0x5C1C0C00,  //  000C  MOVE	R7	R6
+      0x7C1C0000,  //  000D  CALL	R7	0
+      0x94200F06,  //  000E  GETIDX	R8	R7	K6
+      0x1C201107,  //  000F  EQ	R8	R8	K7
+      0x78220000,  //  0010  JMPF	R8	#0012
+      0x7001FFF9,  //  0011  JMP		#000C
+      0x94200207,  //  0012  GETIDX	R8	R1	R7
+      0x60240004,  //  0013  GETGBL	R9	G4
+      0x5C281000,  //  0014  MOVE	R10	R8
+      0x7C240200,  //  0015  CALL	R9	1
+      0x1C241301,  //  0016  EQ	R9	R9	K1
+      0x78260027,  //  0017  JMPF	R9	#0040
+      0x8C240708,  //  0018  GETMET	R9	R3	K8
+      0x5C2C1000,  //  0019  MOVE	R11	R8
+      0x58300009,  //  001A  LDCONST	R12	K9
+      0x7C240600,  //  001B  CALL	R9	3
+      0x1C241306,  //  001C  EQ	R9	R9	K6
+      0x7826000A,  //  001D  JMPF	R9	#0029
+      0x8C24090A,  //  001E  GETMET	R9	R4	K10
+      0x5C2C0A00,  //  001F  MOVE	R11	R5
+      0x5C300E00,  //  0020  MOVE	R12	R7
+      0x60340015,  //  0021  GETGBL	R13	G21
+      0x7C340000,  //  0022  CALL	R13	0
+      0x8C341B0B,  //  0023  GETMET	R13	R13	K11
+      0x403E190D,  //  0024  CONNECT	R15	K12	K13
+      0x943C100F,  //  0025  GETIDX	R15	R8	R15
+      0x7C340400,  //  0026  CALL	R13	2
+      0x7C240800,  //  0027  CALL	R9	4
+      0x70020015,  //  0028  JMP		#003F
+      0x8C240708,  //  0029  GETMET	R9	R3	K8
+      0x5C2C1000,  //  002A  MOVE	R11	R8
+      0x5830000E,  //  002B  LDCONST	R12	K14
+      0x7C240600,  //  002C  CALL	R9	3
+      0x1C241306,  //  002D  EQ	R9	R9	K6
+      0x7826000A,  //  002E  JMPF	R9	#003A
+      0x8C24090A,  //  002F  GETMET	R9	R4	K10
+      0x5C2C0A00,  //  0030  MOVE	R11	R5
+      0x5C300E00,  //  0031  MOVE	R12	R7
+      0x60340015,  //  0032  GETGBL	R13	G21
+      0x7C340000,  //  0033  CALL	R13	0
+      0x8C341B0F,  //  0034  GETMET	R13	R13	K15
+      0x403E190D,  //  0035  CONNECT	R15	K12	K13
+      0x943C100F,  //  0036  GETIDX	R15	R8	R15
+      0x7C340400,  //  0037  CALL	R13	2
+      0x7C240800,  //  0038  CALL	R9	4
+      0x70020004,  //  0039  JMP		#003F
+      0x8C24090A,  //  003A  GETMET	R9	R4	K10
+      0x5C2C0A00,  //  003B  MOVE	R11	R5
+      0x5C300E00,  //  003C  MOVE	R12	R7
+      0x5C341000,  //  003D  MOVE	R13	R8
+      0x7C240800,  //  003E  CALL	R9	4
+      0x70020004,  //  003F  JMP		#0045
+      0x8C24090A,  //  0040  GETMET	R9	R4	K10
+      0x5C2C0A00,  //  0041  MOVE	R11	R5
+      0x5C300E00,  //  0042  MOVE	R12	R7
+      0x5C341000,  //  0043  MOVE	R13	R8
+      0x7C240800,  //  0044  CALL	R9	4
+      0x7001FFC5,  //  0045  JMP		#000C
+      0x58180010,  //  0046  LDCONST	R6	K16
+      0xAC180200,  //  0047  CATCH	R6	1	0
+      0xB0080000,  //  0048  RAISE	2	R0	R0
+      0x8C180B11,  //  0049  GETMET	R6	R5	K17
+      0x7C180200,  //  004A  CALL	R6	1
+      0x80040A00,  //  004B  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_index
+********************************************************************/
+be_local_closure(Matter_Fabric_get_fabric_index,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fabric_index),
+    }),
+    be_str_weak(get_fabric_index),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -1236,194 +1651,6 @@ be_local_closure(Matter_Fabric_get_admin_vendor_name,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_pk
-********************************************************************/
-be_local_closure(Matter_Fabric_set_pk,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(no_private_key),
-    }),
-    be_str_weak(set_pk),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_icac
-********************************************************************/
-be_local_closure(Matter_Fabric_get_icac,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(icac),
-    }),
-    be_str_weak(get_icac),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_admin_subject_vendor
-********************************************************************/
-be_local_closure(Matter_Fabric_set_admin_subject_vendor,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(admin_subject),
-    /* K1   */  be_nested_str_weak(admin_vendor),
-    }),
-    be_str_weak(set_admin_subject_vendor),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: log_new_fabric
-********************************************************************/
-be_local_closure(Matter_Fabric_log_new_fabric,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2BFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20vendorid_X3D_X25s),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(copy),
-    /* K5   */  be_nested_str_weak(reverse),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_nested_str_weak(get_admin_vendor_name),
-    /* K8   */  be_const_int(3),
-    }),
-    be_str_weak(log_new_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x600C0018,  //  0002  GETGBL	R3	G24
-      0x58100002,  //  0003  LDCONST	R4	K2
-      0x8C140103,  //  0004  GETMET	R5	R0	K3
-      0x7C140200,  //  0005  CALL	R5	1
-      0x8C140B04,  //  0006  GETMET	R5	R5	K4
-      0x7C140200,  //  0007  CALL	R5	1
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x7C140200,  //  0009  CALL	R5	1
-      0x8C140B06,  //  000A  GETMET	R5	R5	K6
-      0x7C140200,  //  000B  CALL	R5	1
-      0x8C180107,  //  000C  GETMET	R6	R0	K7
-      0x7C180200,  //  000D  CALL	R6	1
-      0x7C0C0600,  //  000E  CALL	R3	3
-      0x58100008,  //  000F  LDCONST	R4	K8
-      0x7C040600,  //  0010  CALL	R1	3
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pk
-********************************************************************/
-be_local_closure(Matter_Fabric_get_pk,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(no_private_key),
-    }),
-    be_str_weak(get_pk),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_admin_vendor
-********************************************************************/
-be_local_closure(Matter_Fabric_get_admin_vendor,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(admin_vendor),
-    }),
-    be_str_weak(get_admin_vendor),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: get_fabric_id
 ********************************************************************/
 be_local_closure(Matter_Fabric_get_fabric_id,   /* name */
@@ -1451,240 +1678,77 @@ be_local_closure(Matter_Fabric_get_fabric_id,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_ca
-********************************************************************/
-be_local_closure(Matter_Fabric_set_ca,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(root_ca_certificate),
-    }),
-    be_str_weak(set_ca),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_noc
-********************************************************************/
-be_local_closure(Matter_Fabric_get_noc,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(noc),
-    }),
-    be_str_weak(get_noc),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric_index
-********************************************************************/
-be_local_closure(Matter_Fabric_get_fabric_index,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_index),
-    }),
-    be_str_weak(get_fabric_index),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ca
-********************************************************************/
-be_local_closure(Matter_Fabric_get_ca,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(root_ca_certificate),
-    }),
-    be_str_weak(get_ca),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_old_recent_session
-********************************************************************/
-be_local_closure(Matter_Fabric_get_old_recent_session,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(last_used),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(get_old_recent_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x6008000C,  //  0000  GETGBL	R2	G12
-      0x880C0100,  //  0001  GETMBR	R3	R0	K0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x1C080501,  //  0003  EQ	R2	R2	K1
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x4C080000,  //  0005  LDNIL	R2
-      0x80040400,  //  0006  RET	1	R2
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x94080501,  //  0008  GETIDX	R2	R2	K1
-      0x880C0502,  //  0009  GETMBR	R3	R2	K2
-      0x58100003,  //  000A  LDCONST	R4	K3
-      0x6014000C,  //  000B  GETGBL	R5	G12
-      0x88180100,  //  000C  GETMBR	R6	R0	K0
-      0x7C140200,  //  000D  CALL	R5	1
-      0x14140805,  //  000E  LT	R5	R4	R5
-      0x7816000C,  //  000F  JMPF	R5	#001D
-      0x88140100,  //  0010  GETMBR	R5	R0	K0
-      0x94140A04,  //  0011  GETIDX	R5	R5	R4
-      0x88140B02,  //  0012  GETMBR	R5	R5	K2
-      0x78060001,  //  0013  JMPF	R1	#0016
-      0x14180A03,  //  0014  LT	R6	R5	R3
-      0x70020000,  //  0015  JMP		#0017
-      0x24180A03,  //  0016  GT	R6	R5	R3
-      0x781A0002,  //  0017  JMPF	R6	#001B
-      0x88180100,  //  0018  GETMBR	R6	R0	K0
-      0x94080C04,  //  0019  GETIDX	R2	R6	R4
-      0x5C0C0A00,  //  001A  MOVE	R3	R5
-      0x00100903,  //  001B  ADD	R4	R4	K3
-      0x7001FFED,  //  001C  JMP		#000B
-      0x80040400,  //  001D  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_Fabric
 ********************************************************************/
 extern const bclass be_class_Matter_Expirable;
 be_local_class(Matter_Fabric,
-    20,
+    21,
     &be_class_Matter_Expirable,
-    be_nested_map(60,
+    be_nested_map(63,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(fabric_index, -1), be_const_var(2) },
-        { be_const_key_weak(fromjson, -1), be_const_static_closure(Matter_Fabric_fromjson_closure) },
-        { be_const_key_weak(root_ca_certificate, -1), be_const_var(6) },
-        { be_const_key_weak(ipk_epoch_key, -1), be_const_var(9) },
-        { be_const_key_weak(get_ca, 34), be_const_closure(Matter_Fabric_get_ca_closure) },
-        { be_const_key_weak(noc, -1), be_const_var(7) },
-        { be_const_key_weak(get_device_id, -1), be_const_closure(Matter_Fabric_get_device_id_closure) },
-        { be_const_key_weak(add_session, -1), be_const_closure(Matter_Fabric_add_session_closure) },
-        { be_const_key_weak(get_oldest_session, 50), be_const_closure(Matter_Fabric_get_oldest_session_closure) },
-        { be_const_key_weak(fabric_parent, -1), be_const_var(3) },
-        { be_const_key_weak(no_private_key, -1), be_const_var(5) },
-        { be_const_key_weak(admin_vendor, 1), be_const_var(19) },
-        { be_const_key_weak(fabric_id, -1), be_const_var(10) },
-        { be_const_key_weak(device_id, -1), be_const_var(12) },
-        { be_const_key_weak(set_fabric_index, -1), be_const_closure(Matter_Fabric_set_fabric_index_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Fabric_init_closure) },
-        { be_const_key_weak(counter_group_ctrl_snd, -1), be_const_var(15) },
-        { be_const_key_weak(fabric_label, -1), be_const_var(13) },
-        { be_const_key_weak(fabric_completed, -1), be_const_closure(Matter_Fabric_fabric_completed_closure) },
-        { be_const_key_weak(created, -1), be_const_var(1) },
-        { be_const_key_weak(fabric_compressed, -1), be_const_var(11) },
-        { be_const_key_weak(icac, -1), be_const_var(8) },
-        { be_const_key_weak(_counter_group_data_snd_impl, 2), be_const_var(16) },
-        { be_const_key_weak(_store, 57), be_const_var(0) },
-        { be_const_key_weak(get_ca_pub, 32), be_const_closure(Matter_Fabric_get_ca_pub_closure) },
-        { be_const_key_weak(_GROUP_KEY, 16), be_nested_str_weak(GroupKey_X20v1_X2E0) },
-        { be_const_key_weak(tojson, -1), be_const_closure(Matter_Fabric_tojson_closure) },
-        { be_const_key_weak(assign_fabric_index, -1), be_const_closure(Matter_Fabric_assign_fabric_index_closure) },
-        { be_const_key_weak(get_admin_subject, -1), be_const_closure(Matter_Fabric_get_admin_subject_closure) },
-        { be_const_key_weak(_MAX_CASE, -1), be_const_int(5) },
-        { be_const_key_weak(fabric_candidate, -1), be_const_closure(Matter_Fabric_fabric_candidate_closure) },
-        { be_const_key_weak(_GROUP_SND_INCR, 36), be_const_int(32) },
-        { be_const_key_weak(get_fabric_label, 55), be_const_closure(Matter_Fabric_get_fabric_label_closure) },
-        { be_const_key_weak(set_noc_icac, -1), be_const_closure(Matter_Fabric_set_noc_icac_closure) },
-        { be_const_key_weak(get_noc, 52), be_const_closure(Matter_Fabric_get_noc_closure) },
-        { be_const_key_weak(before_remove, -1), be_const_closure(Matter_Fabric_before_remove_closure) },
-        { be_const_key_weak(get_admin_vendor_name, -1), be_const_closure(Matter_Fabric_get_admin_vendor_name_closure) },
-        { be_const_key_weak(set_ca, -1), be_const_closure(Matter_Fabric_set_ca_closure) },
+        { be_const_key_weak(_GROUP_KEY, -1), be_nested_str_weak(GroupKey_X20v1_X2E0) },
+        { be_const_key_weak(counter_group_data_snd, -1), be_const_var(15) },
+        { be_const_key_weak(get_ca, -1), be_const_closure(Matter_Fabric_get_ca_closure) },
+        { be_const_key_weak(get_ipk_epoch_key, 28), be_const_closure(Matter_Fabric_get_ipk_epoch_key_closure) },
+        { be_const_key_weak(device_id, -1), be_const_var(13) },
+        { be_const_key_weak(_counter_group_data_snd_impl, -1), be_const_var(17) },
+        { be_const_key_weak(fabric_index, 27), be_const_var(3) },
+        { be_const_key_weak(no_private_key, 45), be_const_var(6) },
         { be_const_key_weak(get_ipk_group_key, -1), be_const_closure(Matter_Fabric_get_ipk_group_key_closure) },
+        { be_const_key_weak(set_ca, -1), be_const_closure(Matter_Fabric_set_ca_closure) },
+        { be_const_key_weak(get_fabric_compressed, 0), be_const_closure(Matter_Fabric_get_fabric_compressed_closure) },
+        { be_const_key_weak(fabric_compressed, -1), be_const_var(12) },
+        { be_const_key_weak(get_fabric_label, 48), be_const_closure(Matter_Fabric_get_fabric_label_closure) },
+        { be_const_key_weak(admin_vendor, -1), be_const_var(20) },
+        { be_const_key_weak(before_remove, -1), be_const_closure(Matter_Fabric_before_remove_closure) },
+        { be_const_key_weak(noc, 31), be_const_var(8) },
+        { be_const_key_weak(fromjson, -1), be_const_static_closure(Matter_Fabric_fromjson_closure) },
+        { be_const_key_weak(log_new_fabric, 40), be_const_closure(Matter_Fabric_log_new_fabric_closure) },
+        { be_const_key_weak(_counter_group_ctrl_snd_impl, -1), be_const_var(18) },
+        { be_const_key_weak(created, 5), be_const_var(1) },
+        { be_const_key_weak(set_pk, 16), be_const_closure(Matter_Fabric_set_pk_closure) },
+        { be_const_key_weak(mark_for_deletion, -1), be_const_closure(Matter_Fabric_mark_for_deletion_closure) },
+        { be_const_key_weak(_GROUP_SND_INCR, -1), be_const_int(32) },
+        { be_const_key_weak(_store, 56), be_const_var(0) },
+        { be_const_key_weak(fabric_completed, -1), be_const_closure(Matter_Fabric_fabric_completed_closure) },
+        { be_const_key_weak(get_device_id, -1), be_const_closure(Matter_Fabric_get_device_id_closure) },
+        { be_const_key_weak(get_noc, 14), be_const_closure(Matter_Fabric_get_noc_closure) },
+        { be_const_key_weak(get_oldest_session, -1), be_const_closure(Matter_Fabric_get_oldest_session_closure) },
+        { be_const_key_weak(get_icac, -1), be_const_closure(Matter_Fabric_get_icac_closure) },
         { be_const_key_weak(hydrate_post, -1), be_const_closure(Matter_Fabric_hydrate_post_closure) },
-        { be_const_key_weak(set_ipk_epoch_key, 31), be_const_closure(Matter_Fabric_set_ipk_epoch_key_closure) },
-        { be_const_key_weak(set_pk, -1), be_const_closure(Matter_Fabric_set_pk_closure) },
+        { be_const_key_weak(admin_subject, -1), be_const_var(19) },
+        { be_const_key_weak(fabric_id, -1), be_const_var(11) },
         { be_const_key_weak(set_admin_subject_vendor, -1), be_const_closure(Matter_Fabric_set_admin_subject_vendor_closure) },
-        { be_const_key_weak(get_fabric_compressed, 42), be_const_closure(Matter_Fabric_get_fabric_compressed_closure) },
-        { be_const_key_weak(log_new_fabric, -1), be_const_closure(Matter_Fabric_log_new_fabric_closure) },
-        { be_const_key_weak(get_pk, -1), be_const_closure(Matter_Fabric_get_pk_closure) },
-        { be_const_key_weak(get_admin_vendor, -1), be_const_closure(Matter_Fabric_get_admin_vendor_closure) },
-        { be_const_key_weak(get_fabric_id, -1), be_const_closure(Matter_Fabric_get_fabric_id_closure) },
-        { be_const_key_weak(get_icac, 37), be_const_closure(Matter_Fabric_get_icac_closure) },
-        { be_const_key_weak(_counter_group_ctrl_snd_impl, -1), be_const_var(17) },
-        { be_const_key_weak(set_fabric_device, -1), be_const_closure(Matter_Fabric_set_fabric_device_closure) },
-        { be_const_key_weak(admin_subject, 5), be_const_var(18) },
-        { be_const_key_weak(counter_group_data_snd, -1), be_const_var(14) },
-        { be_const_key_weak(get_newest_session, 29), be_const_closure(Matter_Fabric_get_newest_session_closure) },
-        { be_const_key_weak(get_fabric_index, -1), be_const_closure(Matter_Fabric_get_fabric_index_closure) },
-        { be_const_key_weak(get_ipk_epoch_key, -1), be_const_closure(Matter_Fabric_get_ipk_epoch_key_closure) },
-        { be_const_key_weak(counter_group_data_snd_next, 4), be_const_closure(Matter_Fabric_counter_group_data_snd_next_closure) },
-        { be_const_key_weak(counter_group_ctrl_snd_next, -1), be_const_closure(Matter_Fabric_counter_group_ctrl_snd_next_closure) },
+        { be_const_key_weak(get_ca_pub, 52), be_const_closure(Matter_Fabric_get_ca_pub_closure) },
+        { be_const_key_weak(root_ca_certificate, -1), be_const_var(7) },
+        { be_const_key_weak(ipk_epoch_key, -1), be_const_var(10) },
+        { be_const_key_weak(icac, -1), be_const_var(9) },
         { be_const_key_weak(get_old_recent_session, -1), be_const_closure(Matter_Fabric_get_old_recent_session_closure) },
-        { be_const_key_weak(_sessions, 0), be_const_var(4) },
+        { be_const_key_weak(counter_group_ctrl_snd_next, -1), be_const_closure(Matter_Fabric_counter_group_ctrl_snd_next_closure) },
+        { be_const_key_weak(get_pk, 35), be_const_closure(Matter_Fabric_get_pk_closure) },
+        { be_const_key_weak(counter_group_data_snd_next, 13), be_const_closure(Matter_Fabric_counter_group_data_snd_next_closure) },
+        { be_const_key_weak(get_newest_session, 38), be_const_closure(Matter_Fabric_get_newest_session_closure) },
+        { be_const_key_weak(set_noc_icac, -1), be_const_closure(Matter_Fabric_set_noc_icac_closure) },
+        { be_const_key_weak(add_session, -1), be_const_closure(Matter_Fabric_add_session_closure) },
+        { be_const_key_weak(set_fabric_index, 46), be_const_closure(Matter_Fabric_set_fabric_index_closure) },
+        { be_const_key_weak(get_admin_subject, 18), be_const_closure(Matter_Fabric_get_admin_subject_closure) },
+        { be_const_key_weak(_MAX_CASE, -1), be_const_int(5) },
+        { be_const_key_weak(set_fabric_device, -1), be_const_closure(Matter_Fabric_set_fabric_device_closure) },
+        { be_const_key_weak(deleted, -1), be_const_var(2) },
+        { be_const_key_weak(get_admin_vendor, 32), be_const_closure(Matter_Fabric_get_admin_vendor_closure) },
+        { be_const_key_weak(tojson, -1), be_const_closure(Matter_Fabric_tojson_closure) },
+        { be_const_key_weak(assign_fabric_index, 29), be_const_closure(Matter_Fabric_assign_fabric_index_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Fabric_init_closure) },
+        { be_const_key_weak(_sessions, 6), be_const_var(5) },
+        { be_const_key_weak(fabric_candidate, 25), be_const_closure(Matter_Fabric_fabric_candidate_closure) },
+        { be_const_key_weak(set_ipk_epoch_key, -1), be_const_closure(Matter_Fabric_set_ipk_epoch_key_closure) },
+        { be_const_key_weak(fabric_label, 59), be_const_var(14) },
+        { be_const_key_weak(get_fabric_index, -1), be_const_closure(Matter_Fabric_get_fabric_index_closure) },
+        { be_const_key_weak(get_admin_vendor_name, -1), be_const_closure(Matter_Fabric_get_admin_vendor_name_closure) },
+        { be_const_key_weak(is_marked_for_deletion, 1), be_const_closure(Matter_Fabric_is_marked_for_deletion_closure) },
+        { be_const_key_weak(fabric_parent, -1), be_const_var(4) },
+        { be_const_key_weak(counter_group_ctrl_snd, -1), be_const_var(16) },
+        { be_const_key_weak(get_fabric_id, -1), be_const_closure(Matter_Fabric_get_fabric_id_closure) },
     })),
     be_str_weak(Matter_Fabric)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
@@ -273,7 +273,7 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
+    ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
@@ -292,12 +292,10 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
     /* K15  */  be_const_int(2),
     /* K16  */  be_const_int(3),
     /* K17  */  be_nested_str_weak(set),
-    /* K18  */  be_nested_str_weak(BOOL),
-    /* K19  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[114]) {  /* code */
+    ( &(const binstruction[92]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
@@ -386,32 +384,10 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
       0x5828000B,  //  0055  LDCONST	R10	K11
       0x7C1C0600,  //  0056  CALL	R7	3
       0x80040E00,  //  0057  RET	1	R7
-      0x70020017,  //  0058  JMP		#0071
-      0x541E0038,  //  0059  LDINT	R7	57
-      0x1C1C0A07,  //  005A  EQ	R7	R5	R7
-      0x781E0012,  //  005B  JMPF	R7	#006F
-      0x541E0010,  //  005C  LDINT	R7	17
-      0x1C1C0C07,  //  005D  EQ	R7	R6	R7
-      0x781E0005,  //  005E  JMPF	R7	#0065
-      0x8C1C0711,  //  005F  GETMET	R7	R3	K17
-      0x88240912,  //  0060  GETMBR	R9	R4	K18
-      0x5828000B,  //  0061  LDCONST	R10	K11
-      0x7C1C0600,  //  0062  CALL	R7	3
-      0x80040E00,  //  0063  RET	1	R7
-      0x70020008,  //  0064  JMP		#006E
-      0x601C0003,  //  0065  GETGBL	R7	G3
-      0x5C200000,  //  0066  MOVE	R8	R0
-      0x7C1C0200,  //  0067  CALL	R7	1
-      0x8C1C0F13,  //  0068  GETMET	R7	R7	K19
-      0x5C240200,  //  0069  MOVE	R9	R1
-      0x5C280400,  //  006A  MOVE	R10	R2
-      0x5C2C0600,  //  006B  MOVE	R11	R3
-      0x7C1C0800,  //  006C  CALL	R7	4
-      0x80040E00,  //  006D  RET	1	R7
-      0x70020001,  //  006E  JMP		#0071
-      0x4C1C0000,  //  006F  LDNIL	R7
-      0x80040E00,  //  0070  RET	1	R7
-      0x80000000,  //  0071  RET	0
+      0x70020001,  //  0058  JMP		#005B
+      0x4C1C0000,  //  0059  LDNIL	R7
+      0x80040E00,  //  005A  RET	1	R7
+      0x80000000,  //  005B  RET	0
     })
   )
 );
@@ -1303,7 +1279,7 @@ be_local_class(Matter_Plugin,
         { be_const_key_weak(VIRTUAL, 6), be_const_bool(0) },
         { be_const_key_weak(node_label, 34), be_const_var(5) },
         { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(2,
+        be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(29, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(6,
@@ -1314,11 +1290,6 @@ be_local_class(Matter_Plugin,
         be_const_int(3),
         be_const_int(65532),
         be_const_int(65533),
-    }))    ) } )) },
-        { be_const_key_int(57, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(1,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
     }))    ) } )) },
     }))    ) } )) },
         { be_const_key_weak(update_shadow_lazy, -1), be_const_closure(Matter_Plugin_update_shadow_lazy_closure) },

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Aggregator.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Aggregator.h
@@ -19,80 +19,207 @@ be_local_closure(Matter_Plugin_Aggregator_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
+    ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(attribute),
     /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(Matter_TLV_array),
-    /* K6   */  be_nested_str_weak(device),
-    /* K7   */  be_nested_str_weak(get_active_endpoints),
-    /* K8   */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-    /* K9   */  be_nested_str_weak(add_TLV),
-    /* K10  */  be_nested_str_weak(U2),
-    /* K11  */  be_nested_str_weak(stop_iteration),
-    /* K12  */  be_nested_str_weak(read_attribute),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(set),
+    /* K7   */  be_nested_str_weak(U2),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(U1),
+    /* K10  */  be_nested_str_weak(U4),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_nested_str_weak(Matter_TLV_array),
+    /* K13  */  be_nested_str_weak(add_TLV),
+    /* K14  */  be_nested_str_weak(device),
+    /* K15  */  be_nested_str_weak(get_active_endpoints),
+    /* K16  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+    /* K17  */  be_nested_str_weak(stop_iteration),
+    /* K18  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[56]) {  /* code */
+    ( &(const binstruction[103]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
       0x88180503,  //  0003  GETMBR	R6	R2	K3
-      0x541E001C,  //  0004  LDINT	R7	29
-      0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E0026,  //  0006  JMPF	R7	#002E
-      0x1C1C0D04,  //  0007  EQ	R7	R6	K4
-      0x781E001A,  //  0008  JMPF	R7	#0024
-      0x8C1C0905,  //  0009  GETMET	R7	R4	K5
-      0x7C1C0200,  //  000A  CALL	R7	1
-      0x88200106,  //  000B  GETMBR	R8	R0	K6
-      0x8C201107,  //  000C  GETMET	R8	R8	K7
-      0x50280200,  //  000D  LDBOOL	R10	1	0
-      0x7C200400,  //  000E  CALL	R8	2
-      0x60240010,  //  000F  GETGBL	R9	G16
-      0x5C281000,  //  0010  MOVE	R10	R8
-      0x7C240200,  //  0011  CALL	R9	1
-      0xA802000B,  //  0012  EXBLK	0	#001F
-      0x5C281200,  //  0013  MOVE	R10	R9
-      0x7C280000,  //  0014  CALL	R10	0
-      0xB82E0000,  //  0015  GETNGBL	R11	K0
-      0x882C1708,  //  0016  GETMBR	R11	R11	K8
-      0x142C140B,  //  0017  LT	R11	R10	R11
-      0x782E0004,  //  0018  JMPF	R11	#001E
-      0x8C2C0F09,  //  0019  GETMET	R11	R7	K9
-      0x4C340000,  //  001A  LDNIL	R13
-      0x8838090A,  //  001B  GETMBR	R14	R4	K10
-      0x5C3C1400,  //  001C  MOVE	R15	R10
-      0x7C2C0800,  //  001D  CALL	R11	4
-      0x7001FFF3,  //  001E  JMP		#0013
-      0x5824000B,  //  001F  LDCONST	R9	K11
-      0xAC240200,  //  0020  CATCH	R9	1	0
-      0xB0080000,  //  0021  RAISE	2	R0	R0
-      0x80040E00,  //  0022  RET	1	R7
-      0x70020008,  //  0023  JMP		#002D
-      0x601C0003,  //  0024  GETGBL	R7	G3
-      0x5C200000,  //  0025  MOVE	R8	R0
-      0x7C1C0200,  //  0026  CALL	R7	1
-      0x8C1C0F0C,  //  0027  GETMET	R7	R7	K12
-      0x5C240200,  //  0028  MOVE	R9	R1
-      0x5C280400,  //  0029  MOVE	R10	R2
-      0x5C2C0600,  //  002A  MOVE	R11	R3
-      0x7C1C0800,  //  002B  CALL	R7	4
-      0x80040E00,  //  002C  RET	1	R7
-      0x70020008,  //  002D  JMP		#0037
-      0x601C0003,  //  002E  GETGBL	R7	G3
-      0x5C200000,  //  002F  MOVE	R8	R0
-      0x7C1C0200,  //  0030  CALL	R7	1
-      0x8C1C0F0C,  //  0031  GETMET	R7	R7	K12
-      0x5C240200,  //  0032  MOVE	R9	R1
-      0x5C280400,  //  0033  MOVE	R10	R2
-      0x5C2C0600,  //  0034  MOVE	R11	R3
-      0x7C1C0800,  //  0035  CALL	R7	4
-      0x80040E00,  //  0036  RET	1	R7
-      0x80000000,  //  0037  RET	0
+      0x1C1C0B04,  //  0004  EQ	R7	R5	K4
+      0x781E0021,  //  0005  JMPF	R7	#0028
+      0x1C1C0D05,  //  0006  EQ	R7	R6	K5
+      0x781E0005,  //  0007  JMPF	R7	#000E
+      0x8C1C0706,  //  0008  GETMET	R7	R3	K6
+      0x88240907,  //  0009  GETMBR	R9	R4	K7
+      0x58280005,  //  000A  LDCONST	R10	K5
+      0x7C1C0600,  //  000B  CALL	R7	3
+      0x80040E00,  //  000C  RET	1	R7
+      0x70020018,  //  000D  JMP		#0027
+      0x1C1C0D08,  //  000E  EQ	R7	R6	K8
+      0x781E0005,  //  000F  JMPF	R7	#0016
+      0x8C1C0706,  //  0010  GETMET	R7	R3	K6
+      0x88240909,  //  0011  GETMBR	R9	R4	K9
+      0x58280005,  //  0012  LDCONST	R10	K5
+      0x7C1C0600,  //  0013  CALL	R7	3
+      0x80040E00,  //  0014  RET	1	R7
+      0x70020010,  //  0015  JMP		#0027
+      0x541EFFFB,  //  0016  LDINT	R7	65532
+      0x1C1C0C07,  //  0017  EQ	R7	R6	R7
+      0x781E0005,  //  0018  JMPF	R7	#001F
+      0x8C1C0706,  //  0019  GETMET	R7	R3	K6
+      0x8824090A,  //  001A  GETMBR	R9	R4	K10
+      0x58280005,  //  001B  LDCONST	R10	K5
+      0x7C1C0600,  //  001C  CALL	R7	3
+      0x80040E00,  //  001D  RET	1	R7
+      0x70020007,  //  001E  JMP		#0027
+      0x541EFFFC,  //  001F  LDINT	R7	65533
+      0x1C1C0C07,  //  0020  EQ	R7	R6	R7
+      0x781E0004,  //  0021  JMPF	R7	#0027
+      0x8C1C0706,  //  0022  GETMET	R7	R3	K6
+      0x8824090A,  //  0023  GETMBR	R9	R4	K10
+      0x542A0003,  //  0024  LDINT	R10	4
+      0x7C1C0600,  //  0025  CALL	R7	3
+      0x80040E00,  //  0026  RET	1	R7
+      0x7002003D,  //  0027  JMP		#0066
+      0x541E001C,  //  0028  LDINT	R7	29
+      0x1C1C0A07,  //  0029  EQ	R7	R5	R7
+      0x781E0031,  //  002A  JMPF	R7	#005D
+      0x1C1C0D0B,  //  002B  EQ	R7	R6	K11
+      0x781E0008,  //  002C  JMPF	R7	#0036
+      0x8C1C090C,  //  002D  GETMET	R7	R4	K12
+      0x7C1C0200,  //  002E  CALL	R7	1
+      0x8C200F0D,  //  002F  GETMET	R8	R7	K13
+      0x4C280000,  //  0030  LDNIL	R10
+      0x882C0907,  //  0031  GETMBR	R11	R4	K7
+      0x5432001D,  //  0032  LDINT	R12	30
+      0x7C200800,  //  0033  CALL	R8	4
+      0x80040E00,  //  0034  RET	1	R7
+      0x70020025,  //  0035  JMP		#005C
+      0x1C1C0D04,  //  0036  EQ	R7	R6	K4
+      0x781E001A,  //  0037  JMPF	R7	#0053
+      0x8C1C090C,  //  0038  GETMET	R7	R4	K12
+      0x7C1C0200,  //  0039  CALL	R7	1
+      0x8820010E,  //  003A  GETMBR	R8	R0	K14
+      0x8C20110F,  //  003B  GETMET	R8	R8	K15
+      0x50280200,  //  003C  LDBOOL	R10	1	0
+      0x7C200400,  //  003D  CALL	R8	2
+      0x60240010,  //  003E  GETGBL	R9	G16
+      0x5C281000,  //  003F  MOVE	R10	R8
+      0x7C240200,  //  0040  CALL	R9	1
+      0xA802000B,  //  0041  EXBLK	0	#004E
+      0x5C281200,  //  0042  MOVE	R10	R9
+      0x7C280000,  //  0043  CALL	R10	0
+      0xB82E0000,  //  0044  GETNGBL	R11	K0
+      0x882C1710,  //  0045  GETMBR	R11	R11	K16
+      0x202C140B,  //  0046  NE	R11	R10	R11
+      0x782E0004,  //  0047  JMPF	R11	#004D
+      0x8C2C0F0D,  //  0048  GETMET	R11	R7	K13
+      0x4C340000,  //  0049  LDNIL	R13
+      0x88380907,  //  004A  GETMBR	R14	R4	K7
+      0x5C3C1400,  //  004B  MOVE	R15	R10
+      0x7C2C0800,  //  004C  CALL	R11	4
+      0x7001FFF3,  //  004D  JMP		#0042
+      0x58240011,  //  004E  LDCONST	R9	K17
+      0xAC240200,  //  004F  CATCH	R9	1	0
+      0xB0080000,  //  0050  RAISE	2	R0	R0
+      0x80040E00,  //  0051  RET	1	R7
+      0x70020008,  //  0052  JMP		#005C
+      0x601C0003,  //  0053  GETGBL	R7	G3
+      0x5C200000,  //  0054  MOVE	R8	R0
+      0x7C1C0200,  //  0055  CALL	R7	1
+      0x8C1C0F12,  //  0056  GETMET	R7	R7	K18
+      0x5C240200,  //  0057  MOVE	R9	R1
+      0x5C280400,  //  0058  MOVE	R10	R2
+      0x5C2C0600,  //  0059  MOVE	R11	R3
+      0x7C1C0800,  //  005A  CALL	R7	4
+      0x80040E00,  //  005B  RET	1	R7
+      0x70020008,  //  005C  JMP		#0066
+      0x601C0003,  //  005D  GETGBL	R7	G3
+      0x5C200000,  //  005E  MOVE	R8	R0
+      0x7C1C0200,  //  005F  CALL	R7	1
+      0x8C1C0F12,  //  0060  GETMET	R7	R7	K18
+      0x5C240200,  //  0061  MOVE	R9	R1
+      0x5C280400,  //  0062  MOVE	R10	R2
+      0x5C2C0600,  //  0063  MOVE	R11	R3
+      0x7C1C0800,  //  0064  CALL	R7	4
+      0x80040E00,  //  0065  RET	1	R7
+      0x80000000,  //  0066  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Plugin_Aggregator_invoke_request,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(command),
+    /* K4   */  be_const_int(3),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_const_int(1),
+    /* K7   */  be_nested_str_weak(Matter_TLV_struct),
+    /* K8   */  be_nested_str_weak(add_TLV),
+    /* K9   */  be_nested_str_weak(U2),
+    /* K10  */  be_nested_str_weak(invoke_request),
+    }),
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[39]) {  /* code */
+      0xB8120000,  //  0000  GETNGBL	R4	K0
+      0x88100901,  //  0001  GETMBR	R4	R4	K1
+      0x88140702,  //  0002  GETMBR	R5	R3	K2
+      0x88180703,  //  0003  GETMBR	R6	R3	K3
+      0x1C1C0B04,  //  0004  EQ	R7	R5	K4
+      0x781E0016,  //  0005  JMPF	R7	#001D
+      0x1C1C0D05,  //  0006  EQ	R7	R6	K5
+      0x781E0002,  //  0007  JMPF	R7	#000B
+      0x501C0200,  //  0008  LDBOOL	R7	1	0
+      0x80040E00,  //  0009  RET	1	R7
+      0x70020010,  //  000A  JMP		#001C
+      0x1C1C0D06,  //  000B  EQ	R7	R6	K6
+      0x781E0009,  //  000C  JMPF	R7	#0017
+      0x8C1C0907,  //  000D  GETMET	R7	R4	K7
+      0x7C1C0200,  //  000E  CALL	R7	1
+      0x8C200F08,  //  000F  GETMET	R8	R7	K8
+      0x58280005,  //  0010  LDCONST	R10	K5
+      0x882C0909,  //  0011  GETMBR	R11	R4	K9
+      0x58300005,  //  0012  LDCONST	R12	K5
+      0x7C200800,  //  0013  CALL	R8	4
+      0x900E0705,  //  0014  SETMBR	R3	K3	K5
+      0x80040E00,  //  0015  RET	1	R7
+      0x70020004,  //  0016  JMP		#001C
+      0x541E003F,  //  0017  LDINT	R7	64
+      0x1C1C0C07,  //  0018  EQ	R7	R6	R7
+      0x781E0001,  //  0019  JMPF	R7	#001C
+      0x501C0200,  //  001A  LDBOOL	R7	1	0
+      0x80040E00,  //  001B  RET	1	R7
+      0x70020008,  //  001C  JMP		#0026
+      0x601C0003,  //  001D  GETGBL	R7	G3
+      0x5C200000,  //  001E  MOVE	R8	R0
+      0x7C1C0200,  //  001F  CALL	R7	1
+      0x8C1C0F0A,  //  0020  GETMET	R7	R7	K10
+      0x5C240200,  //  0021  MOVE	R9	R1
+      0x5C280400,  //  0022  MOVE	R10	R2
+      0x5C2C0600,  //  0023  MOVE	R11	R3
+      0x7C1C0800,  //  0024  CALL	R7	4
+      0x80040E00,  //  0025  RET	1	R7
+      0x80000000,  //  0026  RET	0
     })
   )
 );
@@ -106,16 +233,39 @@ extern const bclass be_class_Matter_Plugin;
 be_local_class(Matter_Plugin_Aggregator,
     0,
     &be_class_Matter_Plugin,
-    be_nested_map(4,
+    be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_Aggregator_read_attribute_closure) },
+        { be_const_key_weak(TYPE, -1), be_nested_str_weak(aggregator) },
         { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(14, -1), be_const_int(1) },
     }))    ) } )) },
-        { be_const_key_weak(TYPE, 3), be_nested_str_weak(aggregator) },
-        { be_const_key_weak(read_attribute, 0), be_const_closure(Matter_Plugin_Aggregator_read_attribute_closure) },
         { be_const_key_weak(DISPLAY_NAME, -1), be_nested_str_weak(Aggregator) },
+        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(29, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(6,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(1),
+        be_const_int(2),
+        be_const_int(3),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+        { be_const_key_int(3, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(4,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(1),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+    }))    ) } )) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_Aggregator_invoke_request_closure) },
     })),
     be_str_weak(Matter_Plugin_Aggregator)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Device.h
@@ -60,7 +60,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[264]) {  /* code */
+    ( &(const binstruction[254]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
@@ -100,7 +100,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x542A0003,  //  0024  LDINT	R10	4
       0x7C1C0600,  //  0025  CALL	R7	3
       0x80040E00,  //  0026  RET	1	R7
-      0x700200DE,  //  0027  JMP		#0107
+      0x700200D4,  //  0027  JMP		#00FD
       0x541E0003,  //  0028  LDINT	R7	4
       0x1C1C0A07,  //  0029  EQ	R7	R5	R7
       0x781E0016,  //  002A  JMPF	R7	#0042
@@ -126,7 +126,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x542A0003,  //  003E  LDINT	R10	4
       0x7C1C0600,  //  003F  CALL	R7	3
       0x80040E00,  //  0040  RET	1	R7
-      0x700200C4,  //  0041  JMP		#0107
+      0x700200BA,  //  0041  JMP		#00FD
       0x541E0004,  //  0042  LDINT	R7	5
       0x1C1C0A07,  //  0043  EQ	R7	R5	R7
       0x781E0011,  //  0044  JMPF	R7	#0057
@@ -147,7 +147,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x542A0003,  //  0053  LDINT	R10	4
       0x7C1C0600,  //  0054  CALL	R7	3
       0x80040E00,  //  0055  RET	1	R7
-      0x700200AF,  //  0056  JMP		#0107
+      0x700200A5,  //  0056  JMP		#00FD
       0x541E001C,  //  0057  LDINT	R7	29
       0x1C1C0A07,  //  0058  EQ	R7	R5	R7
       0x781E003E,  //  0059  JMPF	R7	#0099
@@ -213,10 +213,10 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x5C2C0600,  //  0095  MOVE	R11	R3
       0x7C1C0800,  //  0096  CALL	R7	4
       0x80040E00,  //  0097  RET	1	R7
-      0x7002006D,  //  0098  JMP		#0107
+      0x70020063,  //  0098  JMP		#00FD
       0x541E0038,  //  0099  LDINT	R7	57
       0x1C1C0A07,  //  009A  EQ	R7	R5	R7
-      0x781E0061,  //  009B  JMPF	R7	#00FE
+      0x781E0057,  //  009B  JMPF	R7	#00F4
       0xA41E2E00,  //  009C  IMPORT	R7	K23
       0x1C200D04,  //  009D  EQ	R8	R6	K4
       0x7822000A,  //  009E  JMPF	R8	#00AA
@@ -230,7 +230,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x942C171B,  //  00A6  GETIDX	R11	R11	K27
       0x7C200600,  //  00A7  CALL	R8	3
       0x80041000,  //  00A8  RET	1	R8
-      0x70020052,  //  00A9  JMP		#00FD
+      0x70020048,  //  00A9  JMP		#00F3
       0x54220004,  //  00AA  LDINT	R8	5
       0x1C200C08,  //  00AB  EQ	R8	R6	R8
       0x78220006,  //  00AC  JMPF	R8	#00B4
@@ -240,7 +240,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x7C2C0200,  //  00B0  CALL	R11	1
       0x7C200600,  //  00B1  CALL	R8	3
       0x80041000,  //  00B2  RET	1	R8
-      0x70020048,  //  00B3  JMP		#00FD
+      0x7002003E,  //  00B3  JMP		#00F3
       0x54220009,  //  00B4  LDINT	R8	10
       0x1C200C08,  //  00B5  EQ	R8	R6	R8
       0x78220015,  //  00B6  JMPF	R8	#00CD
@@ -265,7 +265,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x5C341000,  //  00C9  MOVE	R13	R8
       0x7C280600,  //  00CA  CALL	R10	3
       0x80041400,  //  00CB  RET	1	R10
-      0x7002002F,  //  00CC  JMP		#00FD
+      0x70020025,  //  00CC  JMP		#00F3
       0x5422000E,  //  00CD  LDINT	R8	15
       0x1C200C08,  //  00CE  EQ	R8	R6	R8
       0x7822000B,  //  00CF  JMPF	R8	#00DC
@@ -280,7 +280,7 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x7C2C0600,  //  00D8  CALL	R11	3
       0x7C200600,  //  00D9  CALL	R8	3
       0x80041000,  //  00DA  RET	1	R8
-      0x70020020,  //  00DB  JMP		#00FD
+      0x70020016,  //  00DB  JMP		#00F3
       0x54220010,  //  00DC  LDINT	R8	17
       0x1C200C08,  //  00DD  EQ	R8	R6	R8
       0x78220005,  //  00DE  JMPF	R8	#00E5
@@ -289,10 +289,10 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x582C0008,  //  00E1  LDCONST	R11	K8
       0x7C200600,  //  00E2  CALL	R8	3
       0x80041000,  //  00E3  RET	1	R8
-      0x70020017,  //  00E4  JMP		#00FD
+      0x7002000D,  //  00E4  JMP		#00F3
       0x54220011,  //  00E5  LDINT	R8	18
       0x1C200C08,  //  00E6  EQ	R8	R6	R8
-      0x7822000B,  //  00E7  JMPF	R8	#00F4
+      0x7822000A,  //  00E7  JMPF	R8	#00F3
       0x8C200706,  //  00E8  GETMET	R8	R3	K6
       0x88280918,  //  00E9  GETMBR	R10	R4	K24
       0xB82E3200,  //  00EA  GETNGBL	R11	K25
@@ -305,26 +305,16 @@ be_local_closure(Matter_Plugin_Device_read_attribute,   /* name */
       0x7C200600,  //  00F1  CALL	R8	3
       0x80041000,  //  00F2  RET	1	R8
       0x70020008,  //  00F3  JMP		#00FD
-      0x60200003,  //  00F4  GETGBL	R8	G3
-      0x5C240000,  //  00F5  MOVE	R9	R0
-      0x7C200200,  //  00F6  CALL	R8	1
-      0x8C201116,  //  00F7  GETMET	R8	R8	K22
-      0x5C280200,  //  00F8  MOVE	R10	R1
-      0x5C2C0400,  //  00F9  MOVE	R11	R2
-      0x5C300600,  //  00FA  MOVE	R12	R3
-      0x7C200800,  //  00FB  CALL	R8	4
-      0x80041000,  //  00FC  RET	1	R8
-      0x70020008,  //  00FD  JMP		#0107
-      0x601C0003,  //  00FE  GETGBL	R7	G3
-      0x5C200000,  //  00FF  MOVE	R8	R0
-      0x7C1C0200,  //  0100  CALL	R7	1
-      0x8C1C0F16,  //  0101  GETMET	R7	R7	K22
-      0x5C240200,  //  0102  MOVE	R9	R1
-      0x5C280400,  //  0103  MOVE	R10	R2
-      0x5C2C0600,  //  0104  MOVE	R11	R3
-      0x7C1C0800,  //  0105  CALL	R7	4
-      0x80040E00,  //  0106  RET	1	R7
-      0x80000000,  //  0107  RET	0
+      0x601C0003,  //  00F4  GETGBL	R7	G3
+      0x5C200000,  //  00F5  MOVE	R8	R0
+      0x7C1C0200,  //  00F6  CALL	R7	1
+      0x8C1C0F16,  //  00F7  GETMET	R7	R7	K22
+      0x5C240200,  //  00F8  MOVE	R9	R1
+      0x5C280400,  //  00F9  MOVE	R10	R2
+      0x5C2C0600,  //  00FA  MOVE	R11	R3
+      0x7C1C0800,  //  00FB  CALL	R7	4
+      0x80040E00,  //  00FC  RET	1	R7
+      0x80000000,  //  00FD  RET	0
     })
   )
 );
@@ -597,17 +587,19 @@ be_local_class(Matter_Plugin_Device,
         be_const_int(65532),
         be_const_int(65533),
     }))    ) } )) },
-        { be_const_key_int(4, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(3,
+        { be_const_key_int(29, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(0),
+        be_const_int(1),
+        be_const_int(2),
+        be_const_int(3),
         be_const_int(65532),
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),
@@ -623,13 +615,10 @@ be_local_class(Matter_Plugin_Device,
         be_const_int(65532),
         be_const_int(65533),
     }))    ) } )) },
-        { be_const_key_int(29, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(6,
+        { be_const_key_int(4, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(3,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(0),
-        be_const_int(1),
-        be_const_int(2),
-        be_const_int(3),
         be_const_int(65532),
         be_const_int(65533),
     }))    ) } )) },

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Root.h
@@ -19,7 +19,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[93]) {     /* constants */
+    ( &(const bvalue[94]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
@@ -77,46 +77,47 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
     /* K54  */  be_nested_str_weak(device),
     /* K55  */  be_nested_str_weak(sessions),
     /* K56  */  be_nested_str_weak(active_fabrics),
-    /* K57  */  be_nested_str_weak(B2),
-    /* K58  */  be_nested_str_weak(get_noc),
-    /* K59  */  be_nested_str_weak(get_icac),
-    /* K60  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-    /* K61  */  be_nested_str_weak(get_fabric_index),
-    /* K62  */  be_nested_str_weak(stop_iteration),
-    /* K63  */  be_nested_str_weak(parse),
-    /* K64  */  be_nested_str_weak(get_ca),
-    /* K65  */  be_nested_str_weak(findsubval),
-    /* K66  */  be_nested_str_weak(get_admin_vendor),
-    /* K67  */  be_nested_str_weak(get_fabric_id),
-    /* K68  */  be_nested_str_weak(get_device_id),
-    /* K69  */  be_nested_str_weak(get_fabric_label),
-    /* K70  */  be_nested_str_weak(Fabric),
-    /* K71  */  be_nested_str_weak(_MAX_CASE),
-    /* K72  */  be_nested_str_weak(count_active_fabrics),
-    /* K73  */  be_nested_str_weak(_fabric),
-    /* K74  */  be_nested_str_weak(is_commissioning_open),
-    /* K75  */  be_nested_str_weak(is_root_commissioning_open),
-    /* K76  */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K77  */  be_nested_str_weak(Tasmota),
-    /* K78  */  be_nested_str_weak(vendorid),
-    /* K79  */  be_nested_str_weak(DeviceName),
-    /* K80  */  be_nested_str_weak(FriendlyName),
-    /* K81  */  be_nested_str_weak(FriendlyName1),
-    /* K82  */  be_nested_str_weak(XX),
-    /* K83  */  be_nested_str_weak(Status_X202),
-    /* K84  */  be_nested_str_weak(StatusFWR),
-    /* K85  */  be_nested_str_weak(Hardware),
-    /* K86  */  be_nested_str_weak(Version),
-    /* K87  */  be_nested_str_weak(_X28),
-    /* K88  */  be_nested_str_weak(locale),
-    /* K89  */  be_nested_str_weak(create_TLV),
-    /* K90  */  be_nested_str_weak(get_active_endpoints),
-    /* K91  */  be_nested_str_weak(disable_bridge_mode),
-    /* K92  */  be_nested_str_weak(read_attribute),
+    /* K57  */  be_nested_str_weak(is_marked_for_deletion),
+    /* K58  */  be_nested_str_weak(B2),
+    /* K59  */  be_nested_str_weak(get_noc),
+    /* K60  */  be_nested_str_weak(get_icac),
+    /* K61  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+    /* K62  */  be_nested_str_weak(get_fabric_index),
+    /* K63  */  be_nested_str_weak(stop_iteration),
+    /* K64  */  be_nested_str_weak(parse),
+    /* K65  */  be_nested_str_weak(get_ca),
+    /* K66  */  be_nested_str_weak(findsubval),
+    /* K67  */  be_nested_str_weak(get_admin_vendor),
+    /* K68  */  be_nested_str_weak(get_fabric_id),
+    /* K69  */  be_nested_str_weak(get_device_id),
+    /* K70  */  be_nested_str_weak(get_fabric_label),
+    /* K71  */  be_nested_str_weak(Fabric),
+    /* K72  */  be_nested_str_weak(_MAX_CASE),
+    /* K73  */  be_nested_str_weak(count_active_fabrics),
+    /* K74  */  be_nested_str_weak(_fabric),
+    /* K75  */  be_nested_str_weak(is_commissioning_open),
+    /* K76  */  be_nested_str_weak(is_root_commissioning_open),
+    /* K77  */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K78  */  be_nested_str_weak(Tasmota),
+    /* K79  */  be_nested_str_weak(vendorid),
+    /* K80  */  be_nested_str_weak(DeviceName),
+    /* K81  */  be_nested_str_weak(FriendlyName),
+    /* K82  */  be_nested_str_weak(FriendlyName1),
+    /* K83  */  be_nested_str_weak(XX),
+    /* K84  */  be_nested_str_weak(Status_X202),
+    /* K85  */  be_nested_str_weak(StatusFWR),
+    /* K86  */  be_nested_str_weak(Hardware),
+    /* K87  */  be_nested_str_weak(Version),
+    /* K88  */  be_nested_str_weak(_X28),
+    /* K89  */  be_nested_str_weak(locale),
+    /* K90  */  be_nested_str_weak(create_TLV),
+    /* K91  */  be_nested_str_weak(get_active_endpoints),
+    /* K92  */  be_nested_str_weak(disable_bridge_mode),
+    /* K93  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[939]) {  /* code */
+    ( &(const binstruction[958]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xB8160200,  //  0001  GETNGBL	R5	K1
       0x88140B02,  //  0002  GETMBR	R5	R5	K2
@@ -173,11 +174,11 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x502C0000,  //  0035  LDBOOL	R11	0	0
       0x7C200600,  //  0036  CALL	R8	3
       0x80041000,  //  0037  RET	1	R8
-      0x70020370,  //  0038  JMP		#03AA
+      0x70020383,  //  0038  JMP		#03BD
       0x54220031,  //  0039  LDINT	R8	50
       0x1C200C08,  //  003A  EQ	R8	R6	R8
       0x78220000,  //  003B  JMPF	R8	#003D
-      0x7002036C,  //  003C  JMP		#03AA
+      0x7002037F,  //  003C  JMP		#03BD
       0x54220032,  //  003D  LDINT	R8	51
       0x1C200C08,  //  003E  EQ	R8	R6	R8
       0x782200DC,  //  003F  JMPF	R8	#011D
@@ -401,11 +402,11 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x502C0000,  //  0119  LDBOOL	R11	0	0
       0x7C200600,  //  011A  CALL	R8	3
       0x80041000,  //  011B  RET	1	R8
-      0x7002028C,  //  011C  JMP		#03AA
+      0x7002029F,  //  011C  JMP		#03BD
       0x54220033,  //  011D  LDINT	R8	52
       0x1C200C08,  //  011E  EQ	R8	R6	R8
       0x78220000,  //  011F  JMPF	R8	#0121
-      0x70020288,  //  0120  JMP		#03AA
+      0x7002029B,  //  0120  JMP		#03BD
       0x54220037,  //  0121  LDINT	R8	56
       0x1C200C08,  //  0122  EQ	R8	R6	R8
       0x7822002B,  //  0123  JMPF	R8	#0150
@@ -452,15 +453,15 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x5C301000,  //  014C  MOVE	R12	R8
       0x7C240600,  //  014D  CALL	R9	3
       0x80041200,  //  014E  RET	1	R9
-      0x70020259,  //  014F  JMP		#03AA
+      0x7002026C,  //  014F  JMP		#03BD
       0x5422003D,  //  0150  LDINT	R8	62
       0x1C200C08,  //  0151  EQ	R8	R6	R8
-      0x782200AE,  //  0152  JMPF	R8	#0202
+      0x782200B6,  //  0152  JMPF	R8	#020A
       0x8C200133,  //  0153  GETMET	R8	R0	K51
       0x5C280400,  //  0154  MOVE	R10	R2
       0x7C200400,  //  0155  CALL	R8	2
       0x1C200F05,  //  0156  EQ	R8	R7	K5
-      0x78220033,  //  0157  JMPF	R8	#018C
+      0x78220037,  //  0157  JMPF	R8	#0190
       0x8C200B11,  //  0158  GETMET	R8	R5	K17
       0x7C200200,  //  0159  CALL	R8	1
       0x88240534,  //  015A  GETMBR	R9	R2	K52
@@ -478,584 +479,603 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x60280010,  //  0166  GETGBL	R10	G16
       0x5C2C1200,  //  0167  MOVE	R11	R9
       0x7C280200,  //  0168  CALL	R10	1
-      0xA802001C,  //  0169  EXBLK	0	#0187
+      0xA8020020,  //  0169  EXBLK	0	#018B
       0x5C2C1400,  //  016A  MOVE	R11	R10
       0x7C2C0000,  //  016B  CALL	R11	0
-      0x4C300000,  //  016C  LDNIL	R12
-      0x1C30160C,  //  016D  EQ	R12	R11	R12
+      0x8C301739,  //  016C  GETMET	R12	R11	K57
+      0x7C300200,  //  016D  CALL	R12	1
       0x78320000,  //  016E  JMPF	R12	#0170
       0x7001FFF9,  //  016F  JMP		#016A
-      0x8C301115,  //  0170  GETMET	R12	R8	K21
-      0x4C380000,  //  0171  LDNIL	R14
-      0x7C300400,  //  0172  CALL	R12	2
-      0x8C34190B,  //  0173  GETMET	R13	R12	K11
-      0x583C0009,  //  0174  LDCONST	R15	K9
-      0x88400B39,  //  0175  GETMBR	R16	R5	K57
-      0x8C44173A,  //  0176  GETMET	R17	R11	K58
-      0x7C440200,  //  0177  CALL	R17	1
-      0x7C340800,  //  0178  CALL	R13	4
-      0x8C34190B,  //  0179  GETMET	R13	R12	K11
-      0x583C000D,  //  017A  LDCONST	R15	K13
-      0x88400B39,  //  017B  GETMBR	R16	R5	K57
-      0x8C44173B,  //  017C  GETMET	R17	R11	K59
-      0x7C440200,  //  017D  CALL	R17	1
-      0x7C340800,  //  017E  CALL	R13	4
-      0x8C34190B,  //  017F  GETMET	R13	R12	K11
-      0xB83E0200,  //  0180  GETNGBL	R15	K1
-      0x883C1F3C,  //  0181  GETMBR	R15	R15	K60
-      0x88400B0C,  //  0182  GETMBR	R16	R5	K12
-      0x8C44173D,  //  0183  GETMET	R17	R11	K61
-      0x7C440200,  //  0184  CALL	R17	1
-      0x7C340800,  //  0185  CALL	R13	4
-      0x7001FFE2,  //  0186  JMP		#016A
-      0x5828003E,  //  0187  LDCONST	R10	K62
-      0xAC280200,  //  0188  CATCH	R10	1	0
-      0xB0080000,  //  0189  RAISE	2	R0	R0
-      0x80041000,  //  018A  RET	1	R8
-      0x70020074,  //  018B  JMP		#0201
-      0x1C200F09,  //  018C  EQ	R8	R7	K9
-      0x78220049,  //  018D  JMPF	R8	#01D8
-      0x8C200B11,  //  018E  GETMET	R8	R5	K17
-      0x7C200200,  //  018F  CALL	R8	1
-      0x88240534,  //  0190  GETMBR	R9	R2	K52
-      0x78260005,  //  0191  JMPF	R9	#0198
-      0x60240012,  //  0192  GETGBL	R9	G18
-      0x7C240000,  //  0193  CALL	R9	0
-      0x8C280335,  //  0194  GETMET	R10	R1	K53
-      0x7C280200,  //  0195  CALL	R10	1
-      0x4028120A,  //  0196  CONNECT	R10	R9	R10
-      0x70020003,  //  0197  JMP		#019C
-      0x88240136,  //  0198  GETMBR	R9	R0	K54
-      0x88241337,  //  0199  GETMBR	R9	R9	K55
-      0x8C241338,  //  019A  GETMET	R9	R9	K56
-      0x7C240200,  //  019B  CALL	R9	1
-      0x60280010,  //  019C  GETGBL	R10	G16
-      0x5C2C1200,  //  019D  MOVE	R11	R9
-      0x7C280200,  //  019E  CALL	R10	1
-      0xA8020032,  //  019F  EXBLK	0	#01D3
-      0x5C2C1400,  //  01A0  MOVE	R11	R10
-      0x7C2C0000,  //  01A1  CALL	R11	0
-      0x4C300000,  //  01A2  LDNIL	R12
-      0x1C30160C,  //  01A3  EQ	R12	R11	R12
-      0x78320000,  //  01A4  JMPF	R12	#01A6
-      0x7001FFF9,  //  01A5  JMP		#01A0
-      0x8C300B3F,  //  01A6  GETMET	R12	R5	K63
-      0x8C381740,  //  01A7  GETMET	R14	R11	K64
-      0x7C380200,  //  01A8  CALL	R14	1
-      0x7C300400,  //  01A9  CALL	R12	2
-      0x8C341115,  //  01AA  GETMET	R13	R8	K21
-      0x4C3C0000,  //  01AB  LDNIL	R15
-      0x7C340400,  //  01AC  CALL	R13	2
-      0x8C381B0B,  //  01AD  GETMET	R14	R13	K11
-      0x58400009,  //  01AE  LDCONST	R16	K9
-      0x88440B39,  //  01AF  GETMBR	R17	R5	K57
-      0x8C481941,  //  01B0  GETMET	R18	R12	K65
-      0x54520008,  //  01B1  LDINT	R20	9
-      0x7C480400,  //  01B2  CALL	R18	2
-      0x7C380800,  //  01B3  CALL	R14	4
-      0x8C381B0B,  //  01B4  GETMET	R14	R13	K11
-      0x5840000D,  //  01B5  LDCONST	R16	K13
-      0x88440B0C,  //  01B6  GETMBR	R17	R5	K12
-      0x8C481742,  //  01B7  GETMET	R18	R11	K66
-      0x7C480200,  //  01B8  CALL	R18	1
-      0x7C380800,  //  01B9  CALL	R14	4
-      0x8C381B0B,  //  01BA  GETMET	R14	R13	K11
-      0x5840000F,  //  01BB  LDCONST	R16	K15
-      0x88440B07,  //  01BC  GETMBR	R17	R5	K7
-      0x8C481743,  //  01BD  GETMET	R18	R11	K67
-      0x7C480200,  //  01BE  CALL	R18	1
-      0x7C380800,  //  01BF  CALL	R14	4
-      0x8C381B0B,  //  01C0  GETMET	R14	R13	K11
-      0x54420003,  //  01C1  LDINT	R16	4
-      0x88440B07,  //  01C2  GETMBR	R17	R5	K7
-      0x8C481744,  //  01C3  GETMET	R18	R11	K68
-      0x7C480200,  //  01C4  CALL	R18	1
-      0x7C380800,  //  01C5  CALL	R14	4
-      0x8C381B0B,  //  01C6  GETMET	R14	R13	K11
-      0x54420004,  //  01C7  LDINT	R16	5
-      0x88440B16,  //  01C8  GETMBR	R17	R5	K22
-      0x8C481745,  //  01C9  GETMET	R18	R11	K69
-      0x7C480200,  //  01CA  CALL	R18	1
-      0x7C380800,  //  01CB  CALL	R14	4
-      0x8C381B0B,  //  01CC  GETMET	R14	R13	K11
-      0x544200FD,  //  01CD  LDINT	R16	254
-      0x88440B0C,  //  01CE  GETMBR	R17	R5	K12
-      0x8C48173D,  //  01CF  GETMET	R18	R11	K61
-      0x7C480200,  //  01D0  CALL	R18	1
-      0x7C380800,  //  01D1  CALL	R14	4
-      0x7001FFCC,  //  01D2  JMP		#01A0
-      0x5828003E,  //  01D3  LDCONST	R10	K62
-      0xAC280200,  //  01D4  CATCH	R10	1	0
-      0xB0080000,  //  01D5  RAISE	2	R0	R0
-      0x80041000,  //  01D6  RET	1	R8
-      0x70020028,  //  01D7  JMP		#0201
-      0x1C200F0D,  //  01D8  EQ	R8	R7	K13
-      0x78220007,  //  01D9  JMPF	R8	#01E2
-      0x8C200706,  //  01DA  GETMET	R8	R3	K6
-      0x88280B0E,  //  01DB  GETMBR	R10	R5	K14
-      0xB82E0200,  //  01DC  GETNGBL	R11	K1
-      0x882C1746,  //  01DD  GETMBR	R11	R11	K70
-      0x882C1747,  //  01DE  GETMBR	R11	R11	K71
-      0x7C200600,  //  01DF  CALL	R8	3
-      0x80041000,  //  01E0  RET	1	R8
-      0x7002001E,  //  01E1  JMP		#0201
-      0x1C200F0F,  //  01E2  EQ	R8	R7	K15
-      0x78220009,  //  01E3  JMPF	R8	#01EE
-      0x88200136,  //  01E4  GETMBR	R8	R0	K54
-      0x88201137,  //  01E5  GETMBR	R8	R8	K55
-      0x8C201148,  //  01E6  GETMET	R8	R8	K72
-      0x7C200200,  //  01E7  CALL	R8	1
-      0x8C240706,  //  01E8  GETMET	R9	R3	K6
-      0x882C0B0E,  //  01E9  GETMBR	R11	R5	K14
-      0x5C301000,  //  01EA  MOVE	R12	R8
-      0x7C240600,  //  01EB  CALL	R9	3
-      0x80041200,  //  01EC  RET	1	R9
-      0x70020012,  //  01ED  JMP		#0201
-      0x54220003,  //  01EE  LDINT	R8	4
-      0x1C200E08,  //  01EF  EQ	R8	R7	R8
-      0x78220000,  //  01F0  JMPF	R8	#01F2
-      0x7002000E,  //  01F1  JMP		#0201
-      0x54220004,  //  01F2  LDINT	R8	5
-      0x1C200E08,  //  01F3  EQ	R8	R7	R8
-      0x7822000B,  //  01F4  JMPF	R8	#0201
-      0x88200349,  //  01F5  GETMBR	R8	R1	K73
-      0x8C20113D,  //  01F6  GETMET	R8	R8	K61
-      0x7C200200,  //  01F7  CALL	R8	1
-      0x4C240000,  //  01F8  LDNIL	R9
-      0x1C241009,  //  01F9  EQ	R9	R8	R9
-      0x78260000,  //  01FA  JMPF	R9	#01FC
-      0x58200005,  //  01FB  LDCONST	R8	K5
-      0x8C240706,  //  01FC  GETMET	R9	R3	K6
-      0x882C0B0E,  //  01FD  GETMBR	R11	R5	K14
-      0x5C301000,  //  01FE  MOVE	R12	R8
-      0x7C240600,  //  01FF  CALL	R9	3
-      0x80041200,  //  0200  RET	1	R9
-      0x700201A7,  //  0201  JMP		#03AA
-      0x5422003B,  //  0202  LDINT	R8	60
-      0x1C200C08,  //  0203  EQ	R8	R6	R8
-      0x7822003C,  //  0204  JMPF	R8	#0242
-      0x1C200F05,  //  0205  EQ	R8	R7	K5
-      0x78220012,  //  0206  JMPF	R8	#021A
-      0x88200136,  //  0207  GETMBR	R8	R0	K54
-      0x8C20114A,  //  0208  GETMET	R8	R8	K74
-      0x7C200200,  //  0209  CALL	R8	1
-      0x88240136,  //  020A  GETMBR	R9	R0	K54
-      0x8C24134B,  //  020B  GETMET	R9	R9	K75
-      0x7C240200,  //  020C  CALL	R9	1
-      0x78220004,  //  020D  JMPF	R8	#0213
-      0x78260001,  //  020E  JMPF	R9	#0211
-      0x5828000D,  //  020F  LDCONST	R10	K13
-      0x70020000,  //  0210  JMP		#0212
-      0x58280009,  //  0211  LDCONST	R10	K9
-      0x70020000,  //  0212  JMP		#0214
-      0x58280005,  //  0213  LDCONST	R10	K5
-      0x8C2C0706,  //  0214  GETMET	R11	R3	K6
-      0x88340B0E,  //  0215  GETMBR	R13	R5	K14
-      0x5C381400,  //  0216  MOVE	R14	R10
-      0x7C2C0600,  //  0217  CALL	R11	3
-      0x80041600,  //  0218  RET	1	R11
-      0x70020026,  //  0219  JMP		#0241
-      0x1C200F09,  //  021A  EQ	R8	R7	K9
-      0x78220011,  //  021B  JMPF	R8	#022E
-      0x88200136,  //  021C  GETMBR	R8	R0	K54
-      0x8820114C,  //  021D  GETMBR	R8	R8	K76
-      0x4C240000,  //  021E  LDNIL	R9
-      0x20241009,  //  021F  NE	R9	R8	R9
-      0x78260006,  //  0220  JMPF	R9	#0228
-      0x8C240706,  //  0221  GETMET	R9	R3	K6
-      0x882C0B0C,  //  0222  GETMBR	R11	R5	K12
-      0x8C30113D,  //  0223  GETMET	R12	R8	K61
-      0x7C300200,  //  0224  CALL	R12	1
-      0x7C240600,  //  0225  CALL	R9	3
-      0x80041200,  //  0226  RET	1	R9
-      0x70020004,  //  0227  JMP		#022D
-      0x8C240706,  //  0228  GETMET	R9	R3	K6
-      0x882C0B18,  //  0229  GETMBR	R11	R5	K24
-      0x4C300000,  //  022A  LDNIL	R12
-      0x7C240600,  //  022B  CALL	R9	3
-      0x80041200,  //  022C  RET	1	R9
-      0x70020012,  //  022D  JMP		#0241
-      0x1C200F0D,  //  022E  EQ	R8	R7	K13
-      0x78220010,  //  022F  JMPF	R8	#0241
-      0x88200136,  //  0230  GETMBR	R8	R0	K54
-      0x8820114C,  //  0231  GETMBR	R8	R8	K76
-      0x4C240000,  //  0232  LDNIL	R9
-      0x20241009,  //  0233  NE	R9	R8	R9
-      0x78260006,  //  0234  JMPF	R9	#023C
-      0x8C240706,  //  0235  GETMET	R9	R3	K6
-      0x882C0B0C,  //  0236  GETMBR	R11	R5	K12
-      0x8C301142,  //  0237  GETMET	R12	R8	K66
-      0x7C300200,  //  0238  CALL	R12	1
-      0x7C240600,  //  0239  CALL	R9	3
-      0x80041200,  //  023A  RET	1	R9
-      0x70020004,  //  023B  JMP		#0241
-      0x8C240706,  //  023C  GETMET	R9	R3	K6
-      0x882C0B18,  //  023D  GETMBR	R11	R5	K24
-      0x4C300000,  //  023E  LDNIL	R12
-      0x7C240600,  //  023F  CALL	R9	3
-      0x80041200,  //  0240  RET	1	R9
-      0x70020167,  //  0241  JMP		#03AA
-      0x54220027,  //  0242  LDINT	R8	40
-      0x1C200C08,  //  0243  EQ	R8	R6	R8
-      0x782200BA,  //  0244  JMPF	R8	#0300
-      0x8C200133,  //  0245  GETMET	R8	R0	K51
-      0x5C280400,  //  0246  MOVE	R10	R2
-      0x7C200400,  //  0247  CALL	R8	2
-      0x1C200F05,  //  0248  EQ	R8	R7	K5
-      0x78220005,  //  0249  JMPF	R8	#0250
-      0x8C200706,  //  024A  GETMET	R8	R3	K6
-      0x88280B0C,  //  024B  GETMBR	R10	R5	K12
-      0x582C0009,  //  024C  LDCONST	R11	K9
-      0x7C200600,  //  024D  CALL	R8	3
-      0x80041000,  //  024E  RET	1	R8
-      0x700200AE,  //  024F  JMP		#02FF
-      0x1C200F09,  //  0250  EQ	R8	R7	K9
+      0x4C300000,  //  0170  LDNIL	R12
+      0x1C30160C,  //  0171  EQ	R12	R11	R12
+      0x78320000,  //  0172  JMPF	R12	#0174
+      0x7001FFF5,  //  0173  JMP		#016A
+      0x8C301115,  //  0174  GETMET	R12	R8	K21
+      0x4C380000,  //  0175  LDNIL	R14
+      0x7C300400,  //  0176  CALL	R12	2
+      0x8C34190B,  //  0177  GETMET	R13	R12	K11
+      0x583C0009,  //  0178  LDCONST	R15	K9
+      0x88400B3A,  //  0179  GETMBR	R16	R5	K58
+      0x8C44173B,  //  017A  GETMET	R17	R11	K59
+      0x7C440200,  //  017B  CALL	R17	1
+      0x7C340800,  //  017C  CALL	R13	4
+      0x8C34190B,  //  017D  GETMET	R13	R12	K11
+      0x583C000D,  //  017E  LDCONST	R15	K13
+      0x88400B3A,  //  017F  GETMBR	R16	R5	K58
+      0x8C44173C,  //  0180  GETMET	R17	R11	K60
+      0x7C440200,  //  0181  CALL	R17	1
+      0x7C340800,  //  0182  CALL	R13	4
+      0x8C34190B,  //  0183  GETMET	R13	R12	K11
+      0xB83E0200,  //  0184  GETNGBL	R15	K1
+      0x883C1F3D,  //  0185  GETMBR	R15	R15	K61
+      0x88400B0C,  //  0186  GETMBR	R16	R5	K12
+      0x8C44173E,  //  0187  GETMET	R17	R11	K62
+      0x7C440200,  //  0188  CALL	R17	1
+      0x7C340800,  //  0189  CALL	R13	4
+      0x7001FFDE,  //  018A  JMP		#016A
+      0x5828003F,  //  018B  LDCONST	R10	K63
+      0xAC280200,  //  018C  CATCH	R10	1	0
+      0xB0080000,  //  018D  RAISE	2	R0	R0
+      0x80041000,  //  018E  RET	1	R8
+      0x70020078,  //  018F  JMP		#0209
+      0x1C200F09,  //  0190  EQ	R8	R7	K9
+      0x7822004D,  //  0191  JMPF	R8	#01E0
+      0x8C200B11,  //  0192  GETMET	R8	R5	K17
+      0x7C200200,  //  0193  CALL	R8	1
+      0x88240534,  //  0194  GETMBR	R9	R2	K52
+      0x78260005,  //  0195  JMPF	R9	#019C
+      0x60240012,  //  0196  GETGBL	R9	G18
+      0x7C240000,  //  0197  CALL	R9	0
+      0x8C280335,  //  0198  GETMET	R10	R1	K53
+      0x7C280200,  //  0199  CALL	R10	1
+      0x4028120A,  //  019A  CONNECT	R10	R9	R10
+      0x70020003,  //  019B  JMP		#01A0
+      0x88240136,  //  019C  GETMBR	R9	R0	K54
+      0x88241337,  //  019D  GETMBR	R9	R9	K55
+      0x8C241338,  //  019E  GETMET	R9	R9	K56
+      0x7C240200,  //  019F  CALL	R9	1
+      0x60280010,  //  01A0  GETGBL	R10	G16
+      0x5C2C1200,  //  01A1  MOVE	R11	R9
+      0x7C280200,  //  01A2  CALL	R10	1
+      0xA8020036,  //  01A3  EXBLK	0	#01DB
+      0x5C2C1400,  //  01A4  MOVE	R11	R10
+      0x7C2C0000,  //  01A5  CALL	R11	0
+      0x4C300000,  //  01A6  LDNIL	R12
+      0x1C30160C,  //  01A7  EQ	R12	R11	R12
+      0x78320000,  //  01A8  JMPF	R12	#01AA
+      0x7001FFF9,  //  01A9  JMP		#01A4
+      0x8C301739,  //  01AA  GETMET	R12	R11	K57
+      0x7C300200,  //  01AB  CALL	R12	1
+      0x78320000,  //  01AC  JMPF	R12	#01AE
+      0x7001FFF5,  //  01AD  JMP		#01A4
+      0x8C300B40,  //  01AE  GETMET	R12	R5	K64
+      0x8C381741,  //  01AF  GETMET	R14	R11	K65
+      0x7C380200,  //  01B0  CALL	R14	1
+      0x7C300400,  //  01B1  CALL	R12	2
+      0x8C341115,  //  01B2  GETMET	R13	R8	K21
+      0x4C3C0000,  //  01B3  LDNIL	R15
+      0x7C340400,  //  01B4  CALL	R13	2
+      0x8C381B0B,  //  01B5  GETMET	R14	R13	K11
+      0x58400009,  //  01B6  LDCONST	R16	K9
+      0x88440B3A,  //  01B7  GETMBR	R17	R5	K58
+      0x8C481942,  //  01B8  GETMET	R18	R12	K66
+      0x54520008,  //  01B9  LDINT	R20	9
+      0x7C480400,  //  01BA  CALL	R18	2
+      0x7C380800,  //  01BB  CALL	R14	4
+      0x8C381B0B,  //  01BC  GETMET	R14	R13	K11
+      0x5840000D,  //  01BD  LDCONST	R16	K13
+      0x88440B0C,  //  01BE  GETMBR	R17	R5	K12
+      0x8C481743,  //  01BF  GETMET	R18	R11	K67
+      0x7C480200,  //  01C0  CALL	R18	1
+      0x7C380800,  //  01C1  CALL	R14	4
+      0x8C381B0B,  //  01C2  GETMET	R14	R13	K11
+      0x5840000F,  //  01C3  LDCONST	R16	K15
+      0x88440B07,  //  01C4  GETMBR	R17	R5	K7
+      0x8C481744,  //  01C5  GETMET	R18	R11	K68
+      0x7C480200,  //  01C6  CALL	R18	1
+      0x7C380800,  //  01C7  CALL	R14	4
+      0x8C381B0B,  //  01C8  GETMET	R14	R13	K11
+      0x54420003,  //  01C9  LDINT	R16	4
+      0x88440B07,  //  01CA  GETMBR	R17	R5	K7
+      0x8C481745,  //  01CB  GETMET	R18	R11	K69
+      0x7C480200,  //  01CC  CALL	R18	1
+      0x7C380800,  //  01CD  CALL	R14	4
+      0x8C381B0B,  //  01CE  GETMET	R14	R13	K11
+      0x54420004,  //  01CF  LDINT	R16	5
+      0x88440B16,  //  01D0  GETMBR	R17	R5	K22
+      0x8C481746,  //  01D1  GETMET	R18	R11	K70
+      0x7C480200,  //  01D2  CALL	R18	1
+      0x7C380800,  //  01D3  CALL	R14	4
+      0x8C381B0B,  //  01D4  GETMET	R14	R13	K11
+      0x544200FD,  //  01D5  LDINT	R16	254
+      0x88440B0C,  //  01D6  GETMBR	R17	R5	K12
+      0x8C48173E,  //  01D7  GETMET	R18	R11	K62
+      0x7C480200,  //  01D8  CALL	R18	1
+      0x7C380800,  //  01D9  CALL	R14	4
+      0x7001FFC8,  //  01DA  JMP		#01A4
+      0x5828003F,  //  01DB  LDCONST	R10	K63
+      0xAC280200,  //  01DC  CATCH	R10	1	0
+      0xB0080000,  //  01DD  RAISE	2	R0	R0
+      0x80041000,  //  01DE  RET	1	R8
+      0x70020028,  //  01DF  JMP		#0209
+      0x1C200F0D,  //  01E0  EQ	R8	R7	K13
+      0x78220007,  //  01E1  JMPF	R8	#01EA
+      0x8C200706,  //  01E2  GETMET	R8	R3	K6
+      0x88280B0E,  //  01E3  GETMBR	R10	R5	K14
+      0xB82E0200,  //  01E4  GETNGBL	R11	K1
+      0x882C1747,  //  01E5  GETMBR	R11	R11	K71
+      0x882C1748,  //  01E6  GETMBR	R11	R11	K72
+      0x7C200600,  //  01E7  CALL	R8	3
+      0x80041000,  //  01E8  RET	1	R8
+      0x7002001E,  //  01E9  JMP		#0209
+      0x1C200F0F,  //  01EA  EQ	R8	R7	K15
+      0x78220009,  //  01EB  JMPF	R8	#01F6
+      0x88200136,  //  01EC  GETMBR	R8	R0	K54
+      0x88201137,  //  01ED  GETMBR	R8	R8	K55
+      0x8C201149,  //  01EE  GETMET	R8	R8	K73
+      0x7C200200,  //  01EF  CALL	R8	1
+      0x8C240706,  //  01F0  GETMET	R9	R3	K6
+      0x882C0B0E,  //  01F1  GETMBR	R11	R5	K14
+      0x5C301000,  //  01F2  MOVE	R12	R8
+      0x7C240600,  //  01F3  CALL	R9	3
+      0x80041200,  //  01F4  RET	1	R9
+      0x70020012,  //  01F5  JMP		#0209
+      0x54220003,  //  01F6  LDINT	R8	4
+      0x1C200E08,  //  01F7  EQ	R8	R7	R8
+      0x78220000,  //  01F8  JMPF	R8	#01FA
+      0x7002000E,  //  01F9  JMP		#0209
+      0x54220004,  //  01FA  LDINT	R8	5
+      0x1C200E08,  //  01FB  EQ	R8	R7	R8
+      0x7822000B,  //  01FC  JMPF	R8	#0209
+      0x8820034A,  //  01FD  GETMBR	R8	R1	K74
+      0x8C20113E,  //  01FE  GETMET	R8	R8	K62
+      0x7C200200,  //  01FF  CALL	R8	1
+      0x4C240000,  //  0200  LDNIL	R9
+      0x1C241009,  //  0201  EQ	R9	R8	R9
+      0x78260000,  //  0202  JMPF	R9	#0204
+      0x58200005,  //  0203  LDCONST	R8	K5
+      0x8C240706,  //  0204  GETMET	R9	R3	K6
+      0x882C0B0E,  //  0205  GETMBR	R11	R5	K14
+      0x5C301000,  //  0206  MOVE	R12	R8
+      0x7C240600,  //  0207  CALL	R9	3
+      0x80041200,  //  0208  RET	1	R9
+      0x700201B2,  //  0209  JMP		#03BD
+      0x5422003B,  //  020A  LDINT	R8	60
+      0x1C200C08,  //  020B  EQ	R8	R6	R8
+      0x7822003C,  //  020C  JMPF	R8	#024A
+      0x1C200F05,  //  020D  EQ	R8	R7	K5
+      0x78220012,  //  020E  JMPF	R8	#0222
+      0x88200136,  //  020F  GETMBR	R8	R0	K54
+      0x8C20114B,  //  0210  GETMET	R8	R8	K75
+      0x7C200200,  //  0211  CALL	R8	1
+      0x88240136,  //  0212  GETMBR	R9	R0	K54
+      0x8C24134C,  //  0213  GETMET	R9	R9	K76
+      0x7C240200,  //  0214  CALL	R9	1
+      0x78220004,  //  0215  JMPF	R8	#021B
+      0x78260001,  //  0216  JMPF	R9	#0219
+      0x5828000D,  //  0217  LDCONST	R10	K13
+      0x70020000,  //  0218  JMP		#021A
+      0x58280009,  //  0219  LDCONST	R10	K9
+      0x70020000,  //  021A  JMP		#021C
+      0x58280005,  //  021B  LDCONST	R10	K5
+      0x8C2C0706,  //  021C  GETMET	R11	R3	K6
+      0x88340B0E,  //  021D  GETMBR	R13	R5	K14
+      0x5C381400,  //  021E  MOVE	R14	R10
+      0x7C2C0600,  //  021F  CALL	R11	3
+      0x80041600,  //  0220  RET	1	R11
+      0x70020026,  //  0221  JMP		#0249
+      0x1C200F09,  //  0222  EQ	R8	R7	K9
+      0x78220011,  //  0223  JMPF	R8	#0236
+      0x88200136,  //  0224  GETMBR	R8	R0	K54
+      0x8820114D,  //  0225  GETMBR	R8	R8	K77
+      0x4C240000,  //  0226  LDNIL	R9
+      0x20241009,  //  0227  NE	R9	R8	R9
+      0x78260006,  //  0228  JMPF	R9	#0230
+      0x8C240706,  //  0229  GETMET	R9	R3	K6
+      0x882C0B0C,  //  022A  GETMBR	R11	R5	K12
+      0x8C30113E,  //  022B  GETMET	R12	R8	K62
+      0x7C300200,  //  022C  CALL	R12	1
+      0x7C240600,  //  022D  CALL	R9	3
+      0x80041200,  //  022E  RET	1	R9
+      0x70020004,  //  022F  JMP		#0235
+      0x8C240706,  //  0230  GETMET	R9	R3	K6
+      0x882C0B18,  //  0231  GETMBR	R11	R5	K24
+      0x4C300000,  //  0232  LDNIL	R12
+      0x7C240600,  //  0233  CALL	R9	3
+      0x80041200,  //  0234  RET	1	R9
+      0x70020012,  //  0235  JMP		#0249
+      0x1C200F0D,  //  0236  EQ	R8	R7	K13
+      0x78220010,  //  0237  JMPF	R8	#0249
+      0x88200136,  //  0238  GETMBR	R8	R0	K54
+      0x8820114D,  //  0239  GETMBR	R8	R8	K77
+      0x4C240000,  //  023A  LDNIL	R9
+      0x20241009,  //  023B  NE	R9	R8	R9
+      0x78260006,  //  023C  JMPF	R9	#0244
+      0x8C240706,  //  023D  GETMET	R9	R3	K6
+      0x882C0B0C,  //  023E  GETMBR	R11	R5	K12
+      0x8C301143,  //  023F  GETMET	R12	R8	K67
+      0x7C300200,  //  0240  CALL	R12	1
+      0x7C240600,  //  0241  CALL	R9	3
+      0x80041200,  //  0242  RET	1	R9
+      0x70020004,  //  0243  JMP		#0249
+      0x8C240706,  //  0244  GETMET	R9	R3	K6
+      0x882C0B18,  //  0245  GETMBR	R11	R5	K24
+      0x4C300000,  //  0246  LDNIL	R12
+      0x7C240600,  //  0247  CALL	R9	3
+      0x80041200,  //  0248  RET	1	R9
+      0x70020172,  //  0249  JMP		#03BD
+      0x54220027,  //  024A  LDINT	R8	40
+      0x1C200C08,  //  024B  EQ	R8	R6	R8
+      0x782200BA,  //  024C  JMPF	R8	#0308
+      0x8C200133,  //  024D  GETMET	R8	R0	K51
+      0x5C280400,  //  024E  MOVE	R10	R2
+      0x7C200400,  //  024F  CALL	R8	2
+      0x1C200F05,  //  0250  EQ	R8	R7	K5
       0x78220005,  //  0251  JMPF	R8	#0258
       0x8C200706,  //  0252  GETMET	R8	R3	K6
-      0x88280B16,  //  0253  GETMBR	R10	R5	K22
-      0x582C004D,  //  0254  LDCONST	R11	K77
+      0x88280B0C,  //  0253  GETMBR	R10	R5	K12
+      0x582C0009,  //  0254  LDCONST	R11	K9
       0x7C200600,  //  0255  CALL	R8	3
       0x80041000,  //  0256  RET	1	R8
-      0x700200A6,  //  0257  JMP		#02FF
-      0x1C200F0D,  //  0258  EQ	R8	R7	K13
-      0x78220006,  //  0259  JMPF	R8	#0261
+      0x700200AE,  //  0257  JMP		#0307
+      0x1C200F09,  //  0258  EQ	R8	R7	K9
+      0x78220005,  //  0259  JMPF	R8	#0260
       0x8C200706,  //  025A  GETMET	R8	R3	K6
-      0x88280B0C,  //  025B  GETMBR	R10	R5	K12
-      0x882C0136,  //  025C  GETMBR	R11	R0	K54
-      0x882C174E,  //  025D  GETMBR	R11	R11	K78
-      0x7C200600,  //  025E  CALL	R8	3
-      0x80041000,  //  025F  RET	1	R8
-      0x7002009D,  //  0260  JMP		#02FF
-      0x1C200F0F,  //  0261  EQ	R8	R7	K15
-      0x7822000A,  //  0262  JMPF	R8	#026E
-      0x8C200706,  //  0263  GETMET	R8	R3	K6
-      0x88280B16,  //  0264  GETMBR	R10	R5	K22
-      0xB82E2400,  //  0265  GETNGBL	R11	K18
-      0x8C2C1726,  //  0266  GETMET	R11	R11	K38
-      0x5834004F,  //  0267  LDCONST	R13	K79
-      0x50380200,  //  0268  LDBOOL	R14	1	0
-      0x7C2C0600,  //  0269  CALL	R11	3
-      0x942C174F,  //  026A  GETIDX	R11	R11	K79
-      0x7C200600,  //  026B  CALL	R8	3
-      0x80041000,  //  026C  RET	1	R8
-      0x70020090,  //  026D  JMP		#02FF
-      0x54220003,  //  026E  LDINT	R8	4
-      0x1C200E08,  //  026F  EQ	R8	R7	R8
-      0x78220005,  //  0270  JMPF	R8	#0277
-      0x8C200706,  //  0271  GETMET	R8	R3	K6
-      0x88280B0C,  //  0272  GETMBR	R10	R5	K12
-      0x542E7FFF,  //  0273  LDINT	R11	32768
-      0x7C200600,  //  0274  CALL	R8	3
-      0x80041000,  //  0275  RET	1	R8
-      0x70020087,  //  0276  JMP		#02FF
-      0x54220004,  //  0277  LDINT	R8	5
-      0x1C200E08,  //  0278  EQ	R8	R7	R8
-      0x7822000A,  //  0279  JMPF	R8	#0285
-      0x8C200706,  //  027A  GETMET	R8	R3	K6
-      0x88280B16,  //  027B  GETMBR	R10	R5	K22
-      0xB82E2400,  //  027C  GETNGBL	R11	K18
-      0x8C2C1726,  //  027D  GETMET	R11	R11	K38
-      0x58340050,  //  027E  LDCONST	R13	K80
-      0x50380200,  //  027F  LDBOOL	R14	1	0
-      0x7C2C0600,  //  0280  CALL	R11	3
-      0x942C1751,  //  0281  GETIDX	R11	R11	K81
-      0x7C200600,  //  0282  CALL	R8	3
-      0x80041000,  //  0283  RET	1	R8
-      0x70020079,  //  0284  JMP		#02FF
-      0x54220005,  //  0285  LDINT	R8	6
-      0x1C200E08,  //  0286  EQ	R8	R7	R8
-      0x78220005,  //  0287  JMPF	R8	#028E
-      0x8C200706,  //  0288  GETMET	R8	R3	K6
-      0x88280B16,  //  0289  GETMBR	R10	R5	K22
-      0x582C0052,  //  028A  LDCONST	R11	K82
-      0x7C200600,  //  028B  CALL	R8	3
-      0x80041000,  //  028C  RET	1	R8
-      0x70020070,  //  028D  JMP		#02FF
-      0x54220006,  //  028E  LDINT	R8	7
-      0x1C200E08,  //  028F  EQ	R8	R7	R8
-      0x78220005,  //  0290  JMPF	R8	#0297
-      0x8C200706,  //  0291  GETMET	R8	R3	K6
-      0x88280B0C,  //  0292  GETMBR	R10	R5	K12
-      0x582C0005,  //  0293  LDCONST	R11	K5
-      0x7C200600,  //  0294  CALL	R8	3
-      0x80041000,  //  0295  RET	1	R8
-      0x70020067,  //  0296  JMP		#02FF
-      0x54220007,  //  0297  LDINT	R8	8
-      0x1C200E08,  //  0298  EQ	R8	R7	R8
-      0x7822000B,  //  0299  JMPF	R8	#02A6
-      0x8C200706,  //  029A  GETMET	R8	R3	K6
-      0x88280B16,  //  029B  GETMBR	R10	R5	K22
-      0xB82E2400,  //  029C  GETNGBL	R11	K18
-      0x8C2C1726,  //  029D  GETMET	R11	R11	K38
-      0x58340053,  //  029E  LDCONST	R13	K83
-      0x50380200,  //  029F  LDBOOL	R14	1	0
-      0x7C2C0600,  //  02A0  CALL	R11	3
-      0x942C1754,  //  02A1  GETIDX	R11	R11	K84
-      0x942C1755,  //  02A2  GETIDX	R11	R11	K85
-      0x7C200600,  //  02A3  CALL	R8	3
-      0x80041000,  //  02A4  RET	1	R8
-      0x70020058,  //  02A5  JMP		#02FF
-      0x54220008,  //  02A6  LDINT	R8	9
-      0x1C200E08,  //  02A7  EQ	R8	R7	R8
-      0x78220005,  //  02A8  JMPF	R8	#02AF
-      0x8C200706,  //  02A9  GETMET	R8	R3	K6
-      0x88280B0C,  //  02AA  GETMBR	R10	R5	K12
-      0x582C0009,  //  02AB  LDCONST	R11	K9
-      0x7C200600,  //  02AC  CALL	R8	3
-      0x80041000,  //  02AD  RET	1	R8
-      0x7002004F,  //  02AE  JMP		#02FF
-      0x54220009,  //  02AF  LDINT	R8	10
-      0x1C200E08,  //  02B0  EQ	R8	R7	R8
-      0x78220015,  //  02B1  JMPF	R8	#02C8
-      0xB8222400,  //  02B2  GETNGBL	R8	K18
-      0x8C201126,  //  02B3  GETMET	R8	R8	K38
-      0x58280053,  //  02B4  LDCONST	R10	K83
-      0x502C0200,  //  02B5  LDBOOL	R11	1	0
-      0x7C200600,  //  02B6  CALL	R8	3
-      0x94201154,  //  02B7  GETIDX	R8	R8	K84
-      0x94201156,  //  02B8  GETIDX	R8	R8	K86
-      0x8C24091B,  //  02B9  GETMET	R9	R4	K27
-      0x5C2C1000,  //  02BA  MOVE	R11	R8
-      0x58300057,  //  02BB  LDCONST	R12	K87
-      0x7C240600,  //  02BC  CALL	R9	3
-      0x24281305,  //  02BD  GT	R10	R9	K5
-      0x782A0002,  //  02BE  JMPF	R10	#02C2
-      0x04281309,  //  02BF  SUB	R10	R9	K9
-      0x402A0A0A,  //  02C0  CONNECT	R10	K5	R10
-      0x9420100A,  //  02C1  GETIDX	R8	R8	R10
-      0x8C280706,  //  02C2  GETMET	R10	R3	K6
-      0x88300B16,  //  02C3  GETMBR	R12	R5	K22
-      0x5C341000,  //  02C4  MOVE	R13	R8
-      0x7C280600,  //  02C5  CALL	R10	3
-      0x80041400,  //  02C6  RET	1	R10
-      0x70020036,  //  02C7  JMP		#02FF
-      0x5422000E,  //  02C8  LDINT	R8	15
-      0x1C200E08,  //  02C9  EQ	R8	R7	R8
-      0x7822000B,  //  02CA  JMPF	R8	#02D7
-      0x8C200706,  //  02CB  GETMET	R8	R3	K6
-      0x88280B16,  //  02CC  GETMBR	R10	R5	K22
-      0xB82E2400,  //  02CD  GETNGBL	R11	K18
-      0x8C2C1725,  //  02CE  GETMET	R11	R11	K37
-      0x7C2C0200,  //  02CF  CALL	R11	1
-      0x8C2C171B,  //  02D0  GETMET	R11	R11	K27
-      0x5834001C,  //  02D1  LDCONST	R13	K28
-      0x5838001D,  //  02D2  LDCONST	R14	K29
-      0x7C2C0600,  //  02D3  CALL	R11	3
-      0x7C200600,  //  02D4  CALL	R8	3
-      0x80041000,  //  02D5  RET	1	R8
-      0x70020027,  //  02D6  JMP		#02FF
-      0x54220010,  //  02D7  LDINT	R8	17
-      0x1C200E08,  //  02D8  EQ	R8	R7	R8
-      0x78220005,  //  02D9  JMPF	R8	#02E0
-      0x8C200706,  //  02DA  GETMET	R8	R3	K6
-      0x88280B10,  //  02DB  GETMBR	R10	R5	K16
-      0x582C0009,  //  02DC  LDCONST	R11	K9
-      0x7C200600,  //  02DD  CALL	R8	3
-      0x80041000,  //  02DE  RET	1	R8
-      0x7002001E,  //  02DF  JMP		#02FF
-      0x54220011,  //  02E0  LDINT	R8	18
-      0x1C200E08,  //  02E1  EQ	R8	R7	R8
-      0x7822000B,  //  02E2  JMPF	R8	#02EF
-      0x8C200706,  //  02E3  GETMET	R8	R3	K6
-      0x88280B16,  //  02E4  GETMBR	R10	R5	K22
-      0xB82E2400,  //  02E5  GETNGBL	R11	K18
-      0x8C2C1725,  //  02E6  GETMET	R11	R11	K37
-      0x7C2C0200,  //  02E7  CALL	R11	1
-      0x8C2C171B,  //  02E8  GETMET	R11	R11	K27
-      0x5834001C,  //  02E9  LDCONST	R13	K28
-      0x5838001D,  //  02EA  LDCONST	R14	K29
-      0x7C2C0600,  //  02EB  CALL	R11	3
-      0x7C200600,  //  02EC  CALL	R8	3
-      0x80041000,  //  02ED  RET	1	R8
-      0x7002000F,  //  02EE  JMP		#02FF
-      0x54220012,  //  02EF  LDINT	R8	19
-      0x1C200E08,  //  02F0  EQ	R8	R7	R8
-      0x7822000C,  //  02F1  JMPF	R8	#02FF
-      0x8C200B0A,  //  02F2  GETMET	R8	R5	K10
-      0x7C200200,  //  02F3  CALL	R8	1
-      0x8C24110B,  //  02F4  GETMET	R9	R8	K11
-      0x582C0005,  //  02F5  LDCONST	R11	K5
-      0x88300B0C,  //  02F6  GETMBR	R12	R5	K12
-      0x5834000F,  //  02F7  LDCONST	R13	K15
-      0x7C240800,  //  02F8  CALL	R9	4
-      0x8C24110B,  //  02F9  GETMET	R9	R8	K11
-      0x582C0009,  //  02FA  LDCONST	R11	K9
-      0x88300B0C,  //  02FB  GETMBR	R12	R5	K12
-      0x5834000F,  //  02FC  LDCONST	R13	K15
-      0x7C240800,  //  02FD  CALL	R9	4
-      0x80041000,  //  02FE  RET	1	R8
-      0x700200A9,  //  02FF  JMP		#03AA
-      0x5422003E,  //  0300  LDINT	R8	63
-      0x1C200C08,  //  0301  EQ	R8	R6	R8
-      0x78220000,  //  0302  JMPF	R8	#0304
-      0x700200A5,  //  0303  JMP		#03AA
-      0x54220029,  //  0304  LDINT	R8	42
-      0x1C200C08,  //  0305  EQ	R8	R6	R8
-      0x7822001D,  //  0306  JMPF	R8	#0325
-      0x1C200F05,  //  0307  EQ	R8	R7	K5
-      0x78220003,  //  0308  JMPF	R8	#030D
-      0x8C200B11,  //  0309  GETMET	R8	R5	K17
-      0x7C200200,  //  030A  CALL	R8	1
-      0x80041000,  //  030B  RET	1	R8
-      0x70020016,  //  030C  JMP		#0324
-      0x1C200F09,  //  030D  EQ	R8	R7	K9
-      0x78220005,  //  030E  JMPF	R8	#0315
-      0x8C200706,  //  030F  GETMET	R8	R3	K6
-      0x88280B10,  //  0310  GETMBR	R10	R5	K16
-      0x582C0005,  //  0311  LDCONST	R11	K5
-      0x7C200600,  //  0312  CALL	R8	3
+      0x88280B16,  //  025B  GETMBR	R10	R5	K22
+      0x582C004E,  //  025C  LDCONST	R11	K78
+      0x7C200600,  //  025D  CALL	R8	3
+      0x80041000,  //  025E  RET	1	R8
+      0x700200A6,  //  025F  JMP		#0307
+      0x1C200F0D,  //  0260  EQ	R8	R7	K13
+      0x78220006,  //  0261  JMPF	R8	#0269
+      0x8C200706,  //  0262  GETMET	R8	R3	K6
+      0x88280B0C,  //  0263  GETMBR	R10	R5	K12
+      0x882C0136,  //  0264  GETMBR	R11	R0	K54
+      0x882C174F,  //  0265  GETMBR	R11	R11	K79
+      0x7C200600,  //  0266  CALL	R8	3
+      0x80041000,  //  0267  RET	1	R8
+      0x7002009D,  //  0268  JMP		#0307
+      0x1C200F0F,  //  0269  EQ	R8	R7	K15
+      0x7822000A,  //  026A  JMPF	R8	#0276
+      0x8C200706,  //  026B  GETMET	R8	R3	K6
+      0x88280B16,  //  026C  GETMBR	R10	R5	K22
+      0xB82E2400,  //  026D  GETNGBL	R11	K18
+      0x8C2C1726,  //  026E  GETMET	R11	R11	K38
+      0x58340050,  //  026F  LDCONST	R13	K80
+      0x50380200,  //  0270  LDBOOL	R14	1	0
+      0x7C2C0600,  //  0271  CALL	R11	3
+      0x942C1750,  //  0272  GETIDX	R11	R11	K80
+      0x7C200600,  //  0273  CALL	R8	3
+      0x80041000,  //  0274  RET	1	R8
+      0x70020090,  //  0275  JMP		#0307
+      0x54220003,  //  0276  LDINT	R8	4
+      0x1C200E08,  //  0277  EQ	R8	R7	R8
+      0x78220005,  //  0278  JMPF	R8	#027F
+      0x8C200706,  //  0279  GETMET	R8	R3	K6
+      0x88280B0C,  //  027A  GETMBR	R10	R5	K12
+      0x542E7FFF,  //  027B  LDINT	R11	32768
+      0x7C200600,  //  027C  CALL	R8	3
+      0x80041000,  //  027D  RET	1	R8
+      0x70020087,  //  027E  JMP		#0307
+      0x54220004,  //  027F  LDINT	R8	5
+      0x1C200E08,  //  0280  EQ	R8	R7	R8
+      0x7822000A,  //  0281  JMPF	R8	#028D
+      0x8C200706,  //  0282  GETMET	R8	R3	K6
+      0x88280B16,  //  0283  GETMBR	R10	R5	K22
+      0xB82E2400,  //  0284  GETNGBL	R11	K18
+      0x8C2C1726,  //  0285  GETMET	R11	R11	K38
+      0x58340051,  //  0286  LDCONST	R13	K81
+      0x50380200,  //  0287  LDBOOL	R14	1	0
+      0x7C2C0600,  //  0288  CALL	R11	3
+      0x942C1752,  //  0289  GETIDX	R11	R11	K82
+      0x7C200600,  //  028A  CALL	R8	3
+      0x80041000,  //  028B  RET	1	R8
+      0x70020079,  //  028C  JMP		#0307
+      0x54220005,  //  028D  LDINT	R8	6
+      0x1C200E08,  //  028E  EQ	R8	R7	R8
+      0x78220005,  //  028F  JMPF	R8	#0296
+      0x8C200706,  //  0290  GETMET	R8	R3	K6
+      0x88280B16,  //  0291  GETMBR	R10	R5	K22
+      0x582C0053,  //  0292  LDCONST	R11	K83
+      0x7C200600,  //  0293  CALL	R8	3
+      0x80041000,  //  0294  RET	1	R8
+      0x70020070,  //  0295  JMP		#0307
+      0x54220006,  //  0296  LDINT	R8	7
+      0x1C200E08,  //  0297  EQ	R8	R7	R8
+      0x78220005,  //  0298  JMPF	R8	#029F
+      0x8C200706,  //  0299  GETMET	R8	R3	K6
+      0x88280B0C,  //  029A  GETMBR	R10	R5	K12
+      0x582C0005,  //  029B  LDCONST	R11	K5
+      0x7C200600,  //  029C  CALL	R8	3
+      0x80041000,  //  029D  RET	1	R8
+      0x70020067,  //  029E  JMP		#0307
+      0x54220007,  //  029F  LDINT	R8	8
+      0x1C200E08,  //  02A0  EQ	R8	R7	R8
+      0x7822000B,  //  02A1  JMPF	R8	#02AE
+      0x8C200706,  //  02A2  GETMET	R8	R3	K6
+      0x88280B16,  //  02A3  GETMBR	R10	R5	K22
+      0xB82E2400,  //  02A4  GETNGBL	R11	K18
+      0x8C2C1726,  //  02A5  GETMET	R11	R11	K38
+      0x58340054,  //  02A6  LDCONST	R13	K84
+      0x50380200,  //  02A7  LDBOOL	R14	1	0
+      0x7C2C0600,  //  02A8  CALL	R11	3
+      0x942C1755,  //  02A9  GETIDX	R11	R11	K85
+      0x942C1756,  //  02AA  GETIDX	R11	R11	K86
+      0x7C200600,  //  02AB  CALL	R8	3
+      0x80041000,  //  02AC  RET	1	R8
+      0x70020058,  //  02AD  JMP		#0307
+      0x54220008,  //  02AE  LDINT	R8	9
+      0x1C200E08,  //  02AF  EQ	R8	R7	R8
+      0x78220005,  //  02B0  JMPF	R8	#02B7
+      0x8C200706,  //  02B1  GETMET	R8	R3	K6
+      0x88280B0C,  //  02B2  GETMBR	R10	R5	K12
+      0x582C0009,  //  02B3  LDCONST	R11	K9
+      0x7C200600,  //  02B4  CALL	R8	3
+      0x80041000,  //  02B5  RET	1	R8
+      0x7002004F,  //  02B6  JMP		#0307
+      0x54220009,  //  02B7  LDINT	R8	10
+      0x1C200E08,  //  02B8  EQ	R8	R7	R8
+      0x78220015,  //  02B9  JMPF	R8	#02D0
+      0xB8222400,  //  02BA  GETNGBL	R8	K18
+      0x8C201126,  //  02BB  GETMET	R8	R8	K38
+      0x58280054,  //  02BC  LDCONST	R10	K84
+      0x502C0200,  //  02BD  LDBOOL	R11	1	0
+      0x7C200600,  //  02BE  CALL	R8	3
+      0x94201155,  //  02BF  GETIDX	R8	R8	K85
+      0x94201157,  //  02C0  GETIDX	R8	R8	K87
+      0x8C24091B,  //  02C1  GETMET	R9	R4	K27
+      0x5C2C1000,  //  02C2  MOVE	R11	R8
+      0x58300058,  //  02C3  LDCONST	R12	K88
+      0x7C240600,  //  02C4  CALL	R9	3
+      0x24281305,  //  02C5  GT	R10	R9	K5
+      0x782A0002,  //  02C6  JMPF	R10	#02CA
+      0x04281309,  //  02C7  SUB	R10	R9	K9
+      0x402A0A0A,  //  02C8  CONNECT	R10	K5	R10
+      0x9420100A,  //  02C9  GETIDX	R8	R8	R10
+      0x8C280706,  //  02CA  GETMET	R10	R3	K6
+      0x88300B16,  //  02CB  GETMBR	R12	R5	K22
+      0x5C341000,  //  02CC  MOVE	R13	R8
+      0x7C280600,  //  02CD  CALL	R10	3
+      0x80041400,  //  02CE  RET	1	R10
+      0x70020036,  //  02CF  JMP		#0307
+      0x5422000E,  //  02D0  LDINT	R8	15
+      0x1C200E08,  //  02D1  EQ	R8	R7	R8
+      0x7822000B,  //  02D2  JMPF	R8	#02DF
+      0x8C200706,  //  02D3  GETMET	R8	R3	K6
+      0x88280B16,  //  02D4  GETMBR	R10	R5	K22
+      0xB82E2400,  //  02D5  GETNGBL	R11	K18
+      0x8C2C1725,  //  02D6  GETMET	R11	R11	K37
+      0x7C2C0200,  //  02D7  CALL	R11	1
+      0x8C2C171B,  //  02D8  GETMET	R11	R11	K27
+      0x5834001C,  //  02D9  LDCONST	R13	K28
+      0x5838001D,  //  02DA  LDCONST	R14	K29
+      0x7C2C0600,  //  02DB  CALL	R11	3
+      0x7C200600,  //  02DC  CALL	R8	3
+      0x80041000,  //  02DD  RET	1	R8
+      0x70020027,  //  02DE  JMP		#0307
+      0x54220010,  //  02DF  LDINT	R8	17
+      0x1C200E08,  //  02E0  EQ	R8	R7	R8
+      0x78220005,  //  02E1  JMPF	R8	#02E8
+      0x8C200706,  //  02E2  GETMET	R8	R3	K6
+      0x88280B10,  //  02E3  GETMBR	R10	R5	K16
+      0x582C0009,  //  02E4  LDCONST	R11	K9
+      0x7C200600,  //  02E5  CALL	R8	3
+      0x80041000,  //  02E6  RET	1	R8
+      0x7002001E,  //  02E7  JMP		#0307
+      0x54220011,  //  02E8  LDINT	R8	18
+      0x1C200E08,  //  02E9  EQ	R8	R7	R8
+      0x7822000B,  //  02EA  JMPF	R8	#02F7
+      0x8C200706,  //  02EB  GETMET	R8	R3	K6
+      0x88280B16,  //  02EC  GETMBR	R10	R5	K22
+      0xB82E2400,  //  02ED  GETNGBL	R11	K18
+      0x8C2C1725,  //  02EE  GETMET	R11	R11	K37
+      0x7C2C0200,  //  02EF  CALL	R11	1
+      0x8C2C171B,  //  02F0  GETMET	R11	R11	K27
+      0x5834001C,  //  02F1  LDCONST	R13	K28
+      0x5838001D,  //  02F2  LDCONST	R14	K29
+      0x7C2C0600,  //  02F3  CALL	R11	3
+      0x7C200600,  //  02F4  CALL	R8	3
+      0x80041000,  //  02F5  RET	1	R8
+      0x7002000F,  //  02F6  JMP		#0307
+      0x54220012,  //  02F7  LDINT	R8	19
+      0x1C200E08,  //  02F8  EQ	R8	R7	R8
+      0x7822000C,  //  02F9  JMPF	R8	#0307
+      0x8C200B0A,  //  02FA  GETMET	R8	R5	K10
+      0x7C200200,  //  02FB  CALL	R8	1
+      0x8C24110B,  //  02FC  GETMET	R9	R8	K11
+      0x582C0005,  //  02FD  LDCONST	R11	K5
+      0x88300B0C,  //  02FE  GETMBR	R12	R5	K12
+      0x5834000F,  //  02FF  LDCONST	R13	K15
+      0x7C240800,  //  0300  CALL	R9	4
+      0x8C24110B,  //  0301  GETMET	R9	R8	K11
+      0x582C0009,  //  0302  LDCONST	R11	K9
+      0x88300B0C,  //  0303  GETMBR	R12	R5	K12
+      0x5834000F,  //  0304  LDCONST	R13	K15
+      0x7C240800,  //  0305  CALL	R9	4
+      0x80041000,  //  0306  RET	1	R8
+      0x700200B4,  //  0307  JMP		#03BD
+      0x5422003E,  //  0308  LDINT	R8	63
+      0x1C200C08,  //  0309  EQ	R8	R6	R8
+      0x78220000,  //  030A  JMPF	R8	#030C
+      0x700200B0,  //  030B  JMP		#03BD
+      0x54220029,  //  030C  LDINT	R8	42
+      0x1C200C08,  //  030D  EQ	R8	R6	R8
+      0x7822001D,  //  030E  JMPF	R8	#032D
+      0x1C200F05,  //  030F  EQ	R8	R7	K5
+      0x78220003,  //  0310  JMPF	R8	#0315
+      0x8C200B11,  //  0311  GETMET	R8	R5	K17
+      0x7C200200,  //  0312  CALL	R8	1
       0x80041000,  //  0313  RET	1	R8
-      0x7002000E,  //  0314  JMP		#0324
-      0x1C200F0D,  //  0315  EQ	R8	R7	K13
+      0x70020016,  //  0314  JMP		#032C
+      0x1C200F09,  //  0315  EQ	R8	R7	K9
       0x78220005,  //  0316  JMPF	R8	#031D
       0x8C200706,  //  0317  GETMET	R8	R3	K6
-      0x88280B0E,  //  0318  GETMBR	R10	R5	K14
-      0x582C0009,  //  0319  LDCONST	R11	K9
+      0x88280B10,  //  0318  GETMBR	R10	R5	K16
+      0x582C0005,  //  0319  LDCONST	R11	K5
       0x7C200600,  //  031A  CALL	R8	3
       0x80041000,  //  031B  RET	1	R8
-      0x70020006,  //  031C  JMP		#0324
-      0x1C200F0F,  //  031D  EQ	R8	R7	K15
-      0x78220004,  //  031E  JMPF	R8	#0324
+      0x7002000E,  //  031C  JMP		#032C
+      0x1C200F0D,  //  031D  EQ	R8	R7	K13
+      0x78220005,  //  031E  JMPF	R8	#0325
       0x8C200706,  //  031F  GETMET	R8	R3	K6
-      0x88280B18,  //  0320  GETMBR	R10	R5	K24
-      0x4C2C0000,  //  0321  LDNIL	R11
+      0x88280B0E,  //  0320  GETMBR	R10	R5	K14
+      0x582C0009,  //  0321  LDCONST	R11	K9
       0x7C200600,  //  0322  CALL	R8	3
       0x80041000,  //  0323  RET	1	R8
-      0x70020084,  //  0324  JMP		#03AA
-      0x5422002A,  //  0325  LDINT	R8	43
-      0x1C200C08,  //  0326  EQ	R8	R6	R8
-      0x78220016,  //  0327  JMPF	R8	#033F
-      0x1C200F05,  //  0328  EQ	R8	R7	K5
-      0x78220007,  //  0329  JMPF	R8	#0332
-      0x8C200706,  //  032A  GETMET	R8	R3	K6
-      0x88280B16,  //  032B  GETMBR	R10	R5	K22
-      0xB82E2400,  //  032C  GETNGBL	R11	K18
-      0x8C2C1758,  //  032D  GETMET	R11	R11	K88
-      0x7C2C0200,  //  032E  CALL	R11	1
-      0x7C200600,  //  032F  CALL	R8	3
-      0x80041000,  //  0330  RET	1	R8
-      0x7002000B,  //  0331  JMP		#033E
-      0x1C200F09,  //  0332  EQ	R8	R7	K9
-      0x78220009,  //  0333  JMPF	R8	#033E
-      0x8C200B11,  //  0334  GETMET	R8	R5	K17
-      0x7C200200,  //  0335  CALL	R8	1
-      0x8C24110B,  //  0336  GETMET	R9	R8	K11
-      0x4C2C0000,  //  0337  LDNIL	R11
-      0x88300B16,  //  0338  GETMBR	R12	R5	K22
-      0xB8362400,  //  0339  GETNGBL	R13	K18
-      0x8C341B58,  //  033A  GETMET	R13	R13	K88
-      0x7C340200,  //  033B  CALL	R13	1
-      0x7C240800,  //  033C  CALL	R9	4
-      0x80041000,  //  033D  RET	1	R8
-      0x7002006A,  //  033E  JMP		#03AA
-      0x5422002B,  //  033F  LDINT	R8	44
-      0x1C200C08,  //  0340  EQ	R8	R6	R8
-      0x7822001C,  //  0341  JMPF	R8	#035F
-      0x1C200F05,  //  0342  EQ	R8	R7	K5
-      0x78220005,  //  0343  JMPF	R8	#034A
-      0x8C200706,  //  0344  GETMET	R8	R3	K6
-      0x88280B0E,  //  0345  GETMBR	R10	R5	K14
-      0x582C0009,  //  0346  LDCONST	R11	K9
-      0x7C200600,  //  0347  CALL	R8	3
-      0x80041000,  //  0348  RET	1	R8
-      0x70020013,  //  0349  JMP		#035E
-      0x1C200F09,  //  034A  EQ	R8	R7	K9
+      0x70020006,  //  0324  JMP		#032C
+      0x1C200F0F,  //  0325  EQ	R8	R7	K15
+      0x78220004,  //  0326  JMPF	R8	#032C
+      0x8C200706,  //  0327  GETMET	R8	R3	K6
+      0x88280B18,  //  0328  GETMBR	R10	R5	K24
+      0x4C2C0000,  //  0329  LDNIL	R11
+      0x7C200600,  //  032A  CALL	R8	3
+      0x80041000,  //  032B  RET	1	R8
+      0x7002008F,  //  032C  JMP		#03BD
+      0x5422002A,  //  032D  LDINT	R8	43
+      0x1C200C08,  //  032E  EQ	R8	R6	R8
+      0x78220016,  //  032F  JMPF	R8	#0347
+      0x1C200F05,  //  0330  EQ	R8	R7	K5
+      0x78220007,  //  0331  JMPF	R8	#033A
+      0x8C200706,  //  0332  GETMET	R8	R3	K6
+      0x88280B16,  //  0333  GETMBR	R10	R5	K22
+      0xB82E2400,  //  0334  GETNGBL	R11	K18
+      0x8C2C1759,  //  0335  GETMET	R11	R11	K89
+      0x7C2C0200,  //  0336  CALL	R11	1
+      0x7C200600,  //  0337  CALL	R8	3
+      0x80041000,  //  0338  RET	1	R8
+      0x7002000B,  //  0339  JMP		#0346
+      0x1C200F09,  //  033A  EQ	R8	R7	K9
+      0x78220009,  //  033B  JMPF	R8	#0346
+      0x8C200B11,  //  033C  GETMET	R8	R5	K17
+      0x7C200200,  //  033D  CALL	R8	1
+      0x8C24110B,  //  033E  GETMET	R9	R8	K11
+      0x4C2C0000,  //  033F  LDNIL	R11
+      0x88300B16,  //  0340  GETMBR	R12	R5	K22
+      0xB8362400,  //  0341  GETNGBL	R13	K18
+      0x8C341B59,  //  0342  GETMET	R13	R13	K89
+      0x7C340200,  //  0343  CALL	R13	1
+      0x7C240800,  //  0344  CALL	R9	4
+      0x80041000,  //  0345  RET	1	R8
+      0x70020075,  //  0346  JMP		#03BD
+      0x5422002B,  //  0347  LDINT	R8	44
+      0x1C200C08,  //  0348  EQ	R8	R6	R8
+      0x7822001C,  //  0349  JMPF	R8	#0367
+      0x1C200F05,  //  034A  EQ	R8	R7	K5
       0x78220005,  //  034B  JMPF	R8	#0352
       0x8C200706,  //  034C  GETMET	R8	R3	K6
       0x88280B0E,  //  034D  GETMBR	R10	R5	K14
-      0x542E0003,  //  034E  LDINT	R11	4
+      0x582C0009,  //  034E  LDCONST	R11	K9
       0x7C200600,  //  034F  CALL	R8	3
       0x80041000,  //  0350  RET	1	R8
-      0x7002000B,  //  0351  JMP		#035E
-      0x1C200F0D,  //  0352  EQ	R8	R7	K13
-      0x78220009,  //  0353  JMPF	R8	#035E
-      0x8C200B11,  //  0354  GETMET	R8	R5	K17
-      0x7C200200,  //  0355  CALL	R8	1
-      0x8C24110B,  //  0356  GETMET	R9	R8	K11
-      0x4C2C0000,  //  0357  LDNIL	R11
-      0x8C300B59,  //  0358  GETMET	R12	R5	K89
-      0x88380B0E,  //  0359  GETMBR	R14	R5	K14
-      0x543E0003,  //  035A  LDINT	R15	4
-      0x7C300600,  //  035B  CALL	R12	3
-      0x7C240600,  //  035C  CALL	R9	3
-      0x80041000,  //  035D  RET	1	R8
-      0x7002004A,  //  035E  JMP		#03AA
-      0x54220030,  //  035F  LDINT	R8	49
-      0x1C200C08,  //  0360  EQ	R8	R6	R8
-      0x78220010,  //  0361  JMPF	R8	#0373
-      0x1C200F0F,  //  0362  EQ	R8	R7	K15
-      0x78220005,  //  0363  JMPF	R8	#036A
-      0x8C200706,  //  0364  GETMET	R8	R3	K6
-      0x88280B0E,  //  0365  GETMBR	R10	R5	K14
-      0x542E001D,  //  0366  LDINT	R11	30
-      0x7C200600,  //  0367  CALL	R8	3
-      0x80041000,  //  0368  RET	1	R8
-      0x70020007,  //  0369  JMP		#0372
-      0x5422FFFB,  //  036A  LDINT	R8	65532
-      0x1C200E08,  //  036B  EQ	R8	R7	R8
-      0x78220004,  //  036C  JMPF	R8	#0372
-      0x8C200706,  //  036D  GETMET	R8	R3	K6
-      0x88280B2A,  //  036E  GETMBR	R10	R5	K42
-      0x542E0003,  //  036F  LDINT	R11	4
-      0x7C200600,  //  0370  CALL	R8	3
-      0x80041000,  //  0371  RET	1	R8
-      0x70020036,  //  0372  JMP		#03AA
-      0x5422001C,  //  0373  LDINT	R8	29
-      0x1C200C08,  //  0374  EQ	R8	R6	R8
-      0x7822002A,  //  0375  JMPF	R8	#03A1
-      0x1C200F0F,  //  0376  EQ	R8	R7	K15
-      0x7822001E,  //  0377  JMPF	R8	#0397
-      0x8C200B11,  //  0378  GETMET	R8	R5	K17
-      0x7C200200,  //  0379  CALL	R8	1
-      0x88240136,  //  037A  GETMBR	R9	R0	K54
-      0x8C24135A,  //  037B  GETMET	R9	R9	K90
-      0x502C0200,  //  037C  LDBOOL	R11	1	0
-      0x7C240400,  //  037D  CALL	R9	2
-      0x88280136,  //  037E  GETMBR	R10	R0	K54
-      0x8828155B,  //  037F  GETMBR	R10	R10	K91
-      0x602C0010,  //  0380  GETGBL	R11	G16
-      0x5C301200,  //  0381  MOVE	R12	R9
-      0x7C2C0200,  //  0382  CALL	R11	1
-      0xA802000D,  //  0383  EXBLK	0	#0392
-      0x5C301600,  //  0384  MOVE	R12	R11
-      0x7C300000,  //  0385  CALL	R12	0
-      0x5C341400,  //  0386  MOVE	R13	R10
-      0x78360003,  //  0387  JMPF	R13	#038C
-      0xB8360200,  //  0388  GETNGBL	R13	K1
-      0x88341B3C,  //  0389  GETMBR	R13	R13	K60
-      0x1434180D,  //  038A  LT	R13	R12	R13
-      0x78360004,  //  038B  JMPF	R13	#0391
-      0x8C34110B,  //  038C  GETMET	R13	R8	K11
-      0x4C3C0000,  //  038D  LDNIL	R15
-      0x88400B0C,  //  038E  GETMBR	R16	R5	K12
-      0x5C441800,  //  038F  MOVE	R17	R12
-      0x7C340800,  //  0390  CALL	R13	4
-      0x7001FFF1,  //  0391  JMP		#0384
-      0x582C003E,  //  0392  LDCONST	R11	K62
-      0xAC2C0200,  //  0393  CATCH	R11	1	0
-      0xB0080000,  //  0394  RAISE	2	R0	R0
-      0x80041000,  //  0395  RET	1	R8
-      0x70020008,  //  0396  JMP		#03A0
-      0x60200003,  //  0397  GETGBL	R8	G3
-      0x5C240000,  //  0398  MOVE	R9	R0
-      0x7C200200,  //  0399  CALL	R8	1
-      0x8C20115C,  //  039A  GETMET	R8	R8	K92
-      0x5C280200,  //  039B  MOVE	R10	R1
-      0x5C2C0400,  //  039C  MOVE	R11	R2
-      0x5C300600,  //  039D  MOVE	R12	R3
-      0x7C200800,  //  039E  CALL	R8	4
-      0x80041000,  //  039F  RET	1	R8
-      0x70020008,  //  03A0  JMP		#03AA
-      0x60200003,  //  03A1  GETGBL	R8	G3
-      0x5C240000,  //  03A2  MOVE	R9	R0
-      0x7C200200,  //  03A3  CALL	R8	1
-      0x8C20115C,  //  03A4  GETMET	R8	R8	K92
-      0x5C280200,  //  03A5  MOVE	R10	R1
-      0x5C2C0400,  //  03A6  MOVE	R11	R2
-      0x5C300600,  //  03A7  MOVE	R12	R3
-      0x7C200800,  //  03A8  CALL	R8	4
-      0x80041000,  //  03A9  RET	1	R8
-      0x80000000,  //  03AA  RET	0
+      0x70020013,  //  0351  JMP		#0366
+      0x1C200F09,  //  0352  EQ	R8	R7	K9
+      0x78220005,  //  0353  JMPF	R8	#035A
+      0x8C200706,  //  0354  GETMET	R8	R3	K6
+      0x88280B0E,  //  0355  GETMBR	R10	R5	K14
+      0x542E0003,  //  0356  LDINT	R11	4
+      0x7C200600,  //  0357  CALL	R8	3
+      0x80041000,  //  0358  RET	1	R8
+      0x7002000B,  //  0359  JMP		#0366
+      0x1C200F0D,  //  035A  EQ	R8	R7	K13
+      0x78220009,  //  035B  JMPF	R8	#0366
+      0x8C200B11,  //  035C  GETMET	R8	R5	K17
+      0x7C200200,  //  035D  CALL	R8	1
+      0x8C24110B,  //  035E  GETMET	R9	R8	K11
+      0x4C2C0000,  //  035F  LDNIL	R11
+      0x8C300B5A,  //  0360  GETMET	R12	R5	K90
+      0x88380B0E,  //  0361  GETMBR	R14	R5	K14
+      0x543E0003,  //  0362  LDINT	R15	4
+      0x7C300600,  //  0363  CALL	R12	3
+      0x7C240600,  //  0364  CALL	R9	3
+      0x80041000,  //  0365  RET	1	R8
+      0x70020055,  //  0366  JMP		#03BD
+      0x54220030,  //  0367  LDINT	R8	49
+      0x1C200C08,  //  0368  EQ	R8	R6	R8
+      0x78220010,  //  0369  JMPF	R8	#037B
+      0x1C200F0F,  //  036A  EQ	R8	R7	K15
+      0x78220005,  //  036B  JMPF	R8	#0372
+      0x8C200706,  //  036C  GETMET	R8	R3	K6
+      0x88280B0E,  //  036D  GETMBR	R10	R5	K14
+      0x542E001D,  //  036E  LDINT	R11	30
+      0x7C200600,  //  036F  CALL	R8	3
+      0x80041000,  //  0370  RET	1	R8
+      0x70020007,  //  0371  JMP		#037A
+      0x5422FFFB,  //  0372  LDINT	R8	65532
+      0x1C200E08,  //  0373  EQ	R8	R7	R8
+      0x78220004,  //  0374  JMPF	R8	#037A
+      0x8C200706,  //  0375  GETMET	R8	R3	K6
+      0x88280B2A,  //  0376  GETMBR	R10	R5	K42
+      0x542E0003,  //  0377  LDINT	R11	4
+      0x7C200600,  //  0378  CALL	R8	3
+      0x80041000,  //  0379  RET	1	R8
+      0x70020041,  //  037A  JMP		#03BD
+      0x5422001C,  //  037B  LDINT	R8	29
+      0x1C200C08,  //  037C  EQ	R8	R6	R8
+      0x78220035,  //  037D  JMPF	R8	#03B4
+      0x1C200F0D,  //  037E  EQ	R8	R7	K13
+      0x78220008,  //  037F  JMPF	R8	#0389
+      0x8C200B11,  //  0380  GETMET	R8	R5	K17
+      0x7C200200,  //  0381  CALL	R8	1
+      0x8C24110B,  //  0382  GETMET	R9	R8	K11
+      0x4C2C0000,  //  0383  LDNIL	R11
+      0x88300B0C,  //  0384  GETMBR	R12	R5	K12
+      0x5436001E,  //  0385  LDINT	R13	31
+      0x7C240800,  //  0386  CALL	R9	4
+      0x80041000,  //  0387  RET	1	R8
+      0x70020029,  //  0388  JMP		#03B3
+      0x1C200F0F,  //  0389  EQ	R8	R7	K15
+      0x7822001E,  //  038A  JMPF	R8	#03AA
+      0x8C200B11,  //  038B  GETMET	R8	R5	K17
+      0x7C200200,  //  038C  CALL	R8	1
+      0x88240136,  //  038D  GETMBR	R9	R0	K54
+      0x8C24135B,  //  038E  GETMET	R9	R9	K91
+      0x502C0200,  //  038F  LDBOOL	R11	1	0
+      0x7C240400,  //  0390  CALL	R9	2
+      0x88280136,  //  0391  GETMBR	R10	R0	K54
+      0x8828155C,  //  0392  GETMBR	R10	R10	K92
+      0x602C0010,  //  0393  GETGBL	R11	G16
+      0x5C301200,  //  0394  MOVE	R12	R9
+      0x7C2C0200,  //  0395  CALL	R11	1
+      0xA802000D,  //  0396  EXBLK	0	#03A5
+      0x5C301600,  //  0397  MOVE	R12	R11
+      0x7C300000,  //  0398  CALL	R12	0
+      0x5C341400,  //  0399  MOVE	R13	R10
+      0x78360003,  //  039A  JMPF	R13	#039F
+      0xB8360200,  //  039B  GETNGBL	R13	K1
+      0x88341B3D,  //  039C  GETMBR	R13	R13	K61
+      0x2034180D,  //  039D  NE	R13	R12	R13
+      0x78360004,  //  039E  JMPF	R13	#03A4
+      0x8C34110B,  //  039F  GETMET	R13	R8	K11
+      0x4C3C0000,  //  03A0  LDNIL	R15
+      0x88400B0C,  //  03A1  GETMBR	R16	R5	K12
+      0x5C441800,  //  03A2  MOVE	R17	R12
+      0x7C340800,  //  03A3  CALL	R13	4
+      0x7001FFF1,  //  03A4  JMP		#0397
+      0x582C003F,  //  03A5  LDCONST	R11	K63
+      0xAC2C0200,  //  03A6  CATCH	R11	1	0
+      0xB0080000,  //  03A7  RAISE	2	R0	R0
+      0x80041000,  //  03A8  RET	1	R8
+      0x70020008,  //  03A9  JMP		#03B3
+      0x60200003,  //  03AA  GETGBL	R8	G3
+      0x5C240000,  //  03AB  MOVE	R9	R0
+      0x7C200200,  //  03AC  CALL	R8	1
+      0x8C20115D,  //  03AD  GETMET	R8	R8	K93
+      0x5C280200,  //  03AE  MOVE	R10	R1
+      0x5C2C0400,  //  03AF  MOVE	R11	R2
+      0x5C300600,  //  03B0  MOVE	R12	R3
+      0x7C200800,  //  03B1  CALL	R8	4
+      0x80041000,  //  03B2  RET	1	R8
+      0x70020008,  //  03B3  JMP		#03BD
+      0x60200003,  //  03B4  GETGBL	R8	G3
+      0x5C240000,  //  03B5  MOVE	R9	R0
+      0x7C200200,  //  03B6  CALL	R8	1
+      0x8C20115D,  //  03B7  GETMET	R8	R8	K93
+      0x5C280200,  //  03B8  MOVE	R10	R1
+      0x5C2C0400,  //  03B9  MOVE	R11	R2
+      0x5C300600,  //  03BA  MOVE	R12	R3
+      0x7C200800,  //  03BB  CALL	R8	4
+      0x80041000,  //  03BC  RET	1	R8
+      0x80000000,  //  03BD  RET	0
     })
   )
 );
@@ -1240,7 +1260,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[100]) {     /* constants */
+    ( &(const bvalue[101]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
@@ -1326,25 +1346,26 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
     /* K82  */  be_nested_str_weak(fabric_index_X3A),
     /* K83  */  be_nested_str_weak(active_fabrics),
     /* K84  */  be_nested_str_weak(get_fabric_index),
-    /* K85  */  be_nested_str_weak(set_timer),
-    /* K86  */  be_nested_str_weak(stop_iteration),
-    /* K87  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
-    /* K88  */  be_nested_str_weak(_X29_X20not_X20found),
-    /* K89  */  be_nested_str_weak(INVALID_ACTION),
-    /* K90  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
-    /* K91  */  be_nested_str_weak(INVALID_DATA_TYPE),
-    /* K92  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
-    /* K93  */  be_nested_str_weak(CONSTRAINT_ERROR),
-    /* K94  */  be_nested_str_weak(start_basic_commissioning),
-    /* K95  */  be_nested_str_weak(get_fabric),
-    /* K96  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
-    /* K97  */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K98  */  be_nested_str_weak(stop_basic_commissioning),
-    /* K99  */  be_nested_str_weak(invoke_request),
+    /* K85  */  be_nested_str_weak(mark_for_deletion),
+    /* K86  */  be_nested_str_weak(set_timer),
+    /* K87  */  be_nested_str_weak(stop_iteration),
+    /* K88  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
+    /* K89  */  be_nested_str_weak(_X29_X20not_X20found),
+    /* K90  */  be_nested_str_weak(INVALID_ACTION),
+    /* K91  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
+    /* K92  */  be_nested_str_weak(INVALID_DATA_TYPE),
+    /* K93  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
+    /* K94  */  be_nested_str_weak(CONSTRAINT_ERROR),
+    /* K95  */  be_nested_str_weak(start_basic_commissioning),
+    /* K96  */  be_nested_str_weak(get_fabric),
+    /* K97  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
+    /* K98  */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K99  */  be_nested_str_weak(stop_basic_commissioning),
+    /* K100 */  be_nested_str_weak(invoke_request),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[712]) {  /* code */
+    ( &(const binstruction[714]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xB8160200,  //  0001  GETNGBL	R5	K1
       0x88140B02,  //  0002  GETMBR	R5	R5	K2
@@ -1445,10 +1466,10 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x80041000,  //  0061  RET	1	R8
       0x70020000,  //  0062  JMP		#0064
       0xB0063119,  //  0063  RAISE	1	K24	K25
-      0x70020260,  //  0064  JMP		#02C6
+      0x70020262,  //  0064  JMP		#02C8
       0x5422003D,  //  0065  LDINT	R8	62
       0x1C200C08,  //  0066  EQ	R8	R6	R8
-      0x782201C1,  //  0067  JMPF	R8	#022A
+      0x782201C3,  //  0067  JMPF	R8	#022C
       0x1C200F0E,  //  0068  EQ	R8	R7	K14
       0x7822001D,  //  0069  JMPF	R8	#0088
       0x8C200506,  //  006A  GETMET	R8	R2	K6
@@ -1480,7 +1501,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C280800,  //  0084  CALL	R10	4
       0x900E0910,  //  0085  SETMBR	R3	K4	K16
       0x80041200,  //  0086  RET	1	R9
-      0x700201A0,  //  0087  JMP		#0229
+      0x700201A2,  //  0087  JMP		#022B
       0x1C200F05,  //  0088  EQ	R8	R7	K5
       0x7822003C,  //  0089  JMPF	R8	#00C7
       0x8C200506,  //  008A  GETMET	R8	R2	K6
@@ -1543,7 +1564,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C3C0800,  //  00C3  CALL	R15	4
       0x900E0907,  //  00C4  SETMBR	R3	K4	K7
       0x80041C00,  //  00C5  RET	1	R14
-      0x70020161,  //  00C6  JMP		#0229
+      0x70020163,  //  00C6  JMP		#022B
       0x54220003,  //  00C7  LDINT	R8	4
       0x1C200E08,  //  00C8  EQ	R8	R7	R8
       0x7822003C,  //  00C9  JMPF	R8	#0107
@@ -1607,7 +1628,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x54420004,  //  0103  LDINT	R16	5
       0x900E0810,  //  0104  SETMBR	R3	K4	R16
       0x80041E00,  //  0105  RET	1	R15
-      0x70020121,  //  0106  JMP		#0229
+      0x70020123,  //  0106  JMP		#022B
       0x5422000A,  //  0107  LDINT	R8	11
       0x1C200E08,  //  0108  EQ	R8	R7	R8
       0x7822000B,  //  0109  JMPF	R8	#0116
@@ -1622,7 +1643,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x900E3409,  //  0112  SETMBR	R3	K26	R9
       0x4C240000,  //  0113  LDNIL	R9
       0x80041200,  //  0114  RET	1	R9
-      0x70020112,  //  0115  JMP		#0229
+      0x70020114,  //  0115  JMP		#022B
       0x54220005,  //  0116  LDINT	R8	6
       0x1C200E08,  //  0117  EQ	R8	R7	R8
       0x782200B8,  //  0118  JMPF	R8	#01D2
@@ -1810,7 +1831,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x54660007,  //  01CE  LDINT	R25	8
       0x900E0819,  //  01CF  SETMBR	R3	K4	R25
       0x80043000,  //  01D0  RET	1	R24
-      0x70020056,  //  01D1  JMP		#0229
+      0x70020058,  //  01D1  JMP		#022B
       0x54220008,  //  01D2  LDINT	R8	9
       0x1C200E08,  //  01D3  EQ	R8	R7	R8
       0x7822001E,  //  01D4  JMPF	R8	#01F4
@@ -1844,10 +1865,10 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x900E3409,  //  01F0  SETMBR	R3	K26	R9
       0x4C240000,  //  01F1  LDNIL	R9
       0x80041200,  //  01F2  RET	1	R9
-      0x70020034,  //  01F3  JMP		#0229
+      0x70020036,  //  01F3  JMP		#022B
       0x54220009,  //  01F4  LDINT	R8	10
       0x1C200E08,  //  01F5  EQ	R8	R7	R8
-      0x78220031,  //  01F6  JMPF	R8	#0229
+      0x78220033,  //  01F6  JMPF	R8	#022B
       0x8C200506,  //  01F7  GETMET	R8	R2	K6
       0x58280005,  //  01F8  LDCONST	R10	K5
       0x7C200400,  //  01F9  CALL	R8	2
@@ -1862,201 +1883,203 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x8C281553,  //  0202  GETMET	R10	R10	K83
       0x7C280200,  //  0203  CALL	R10	1
       0x7C240200,  //  0204  CALL	R9	1
-      0xA8020010,  //  0205  EXBLK	0	#0217
+      0xA8020012,  //  0205  EXBLK	0	#0219
       0x5C281200,  //  0206  MOVE	R10	R9
       0x7C280000,  //  0207  CALL	R10	0
       0x8C2C1554,  //  0208  GETMET	R11	R10	K84
       0x7C2C0200,  //  0209  CALL	R11	1
       0x1C2C1608,  //  020A  EQ	R11	R11	R8
-      0x782E0008,  //  020B  JMPF	R11	#0215
-      0xB82E4400,  //  020C  GETNGBL	R11	K34
-      0x8C2C1755,  //  020D  GETMET	R11	R11	K85
-      0x543607CF,  //  020E  LDINT	R13	2000
-      0x84380000,  //  020F  CLOSURE	R14	P0
-      0x7C2C0600,  //  0210  CALL	R11	3
-      0x502C0200,  //  0211  LDBOOL	R11	1	0
-      0xA0000000,  //  0212  CLOSE	R0
-      0xA8040001,  //  0213  EXBLK	1	1
-      0x80041600,  //  0214  RET	1	R11
-      0xA0240000,  //  0215  CLOSE	R9
-      0x7001FFEE,  //  0216  JMP		#0206
-      0x58240056,  //  0217  LDCONST	R9	K86
-      0xAC240200,  //  0218  CATCH	R9	1	0
-      0xB0080000,  //  0219  RAISE	2	R0	R0
-      0xB8264400,  //  021A  GETNGBL	R9	K34
-      0x8C24132C,  //  021B  GETMET	R9	R9	K44
-      0x602C0008,  //  021C  GETGBL	R11	G8
-      0x5C301000,  //  021D  MOVE	R12	R8
-      0x7C2C0200,  //  021E  CALL	R11	1
-      0x002EAE0B,  //  021F  ADD	R11	K87	R11
-      0x002C1758,  //  0220  ADD	R11	R11	K88
-      0x5830000E,  //  0221  LDCONST	R12	K14
-      0x7C240600,  //  0222  CALL	R9	3
-      0xB8260200,  //  0223  GETNGBL	R9	K1
-      0x88241359,  //  0224  GETMBR	R9	R9	K89
-      0x900E3409,  //  0225  SETMBR	R3	K26	R9
-      0x4C240000,  //  0226  LDNIL	R9
-      0xA0000000,  //  0227  CLOSE	R0
-      0x80041200,  //  0228  RET	1	R9
-      0x7002009B,  //  0229  JMP		#02C6
-      0x5422003B,  //  022A  LDINT	R8	60
-      0x1C200C08,  //  022B  EQ	R8	R6	R8
-      0x78220085,  //  022C  JMPF	R8	#02B3
-      0x1C200F05,  //  022D  EQ	R8	R7	K5
-      0x78220065,  //  022E  JMPF	R8	#0295
-      0x8C200506,  //  022F  GETMET	R8	R2	K6
-      0x58280005,  //  0230  LDCONST	R10	K5
-      0x7C200400,  //  0231  CALL	R8	2
-      0x8C240506,  //  0232  GETMET	R9	R2	K6
-      0x582C0007,  //  0233  LDCONST	R11	K7
-      0x7C240400,  //  0234  CALL	R9	2
-      0x8C280506,  //  0235  GETMET	R10	R2	K6
-      0x5830000E,  //  0236  LDCONST	R12	K14
-      0x7C280400,  //  0237  CALL	R10	2
-      0x8C2C0506,  //  0238  GETMET	R11	R2	K6
-      0x58340010,  //  0239  LDCONST	R13	K16
-      0x7C2C0400,  //  023A  CALL	R11	2
-      0x8C300506,  //  023B  GETMET	R12	R2	K6
-      0x543A0003,  //  023C  LDINT	R14	4
-      0x7C300400,  //  023D  CALL	R12	2
-      0xB8364400,  //  023E  GETNGBL	R13	K34
-      0x8C341B2C,  //  023F  GETMET	R13	R13	K44
-      0x603C0018,  //  0240  GETGBL	R15	G24
-      0x5840005A,  //  0241  LDCONST	R16	K90
-      0x5C441000,  //  0242  MOVE	R17	R8
-      0x8C481351,  //  0243  GETMET	R18	R9	K81
-      0x7C480200,  //  0244  CALL	R18	1
-      0x5C4C1400,  //  0245  MOVE	R19	R10
-      0x5C501600,  //  0246  MOVE	R20	R11
-      0x8C541951,  //  0247  GETMET	R21	R12	K81
-      0x7C540200,  //  0248  CALL	R21	1
-      0x7C3C0C00,  //  0249  CALL	R15	6
-      0x54420003,  //  024A  LDINT	R16	4
-      0x7C340600,  //  024B  CALL	R13	3
-      0x4C340000,  //  024C  LDNIL	R13
-      0x1C34100D,  //  024D  EQ	R13	R8	R13
-      0x7436000B,  //  024E  JMPT	R13	#025B
-      0x4C340000,  //  024F  LDNIL	R13
-      0x1C34120D,  //  0250  EQ	R13	R9	R13
-      0x74360008,  //  0251  JMPT	R13	#025B
-      0x4C340000,  //  0252  LDNIL	R13
-      0x1C34140D,  //  0253  EQ	R13	R10	R13
-      0x74360005,  //  0254  JMPT	R13	#025B
-      0x4C340000,  //  0255  LDNIL	R13
-      0x1C34160D,  //  0256  EQ	R13	R11	R13
-      0x74360002,  //  0257  JMPT	R13	#025B
-      0x4C340000,  //  0258  LDNIL	R13
-      0x1C34180D,  //  0259  EQ	R13	R12	R13
-      0x78360005,  //  025A  JMPF	R13	#0261
-      0xB8360200,  //  025B  GETNGBL	R13	K1
-      0x88341B5B,  //  025C  GETMBR	R13	R13	K91
-      0x900E340D,  //  025D  SETMBR	R3	K26	R13
-      0x4C340000,  //  025E  LDNIL	R13
-      0xA0000000,  //  025F  CLOSE	R0
-      0x80041A00,  //  0260  RET	1	R13
-      0x6034000C,  //  0261  GETGBL	R13	G12
-      0x5C381200,  //  0262  MOVE	R14	R9
-      0x7C340200,  //  0263  CALL	R13	1
-      0x543A001F,  //  0264  LDINT	R14	32
-      0x543E0040,  //  0265  LDINT	R15	65
-      0x00381C0F,  //  0266  ADD	R14	R14	R15
-      0x20341A0E,  //  0267  NE	R13	R13	R14
-      0x7436000B,  //  0268  JMPT	R13	#0275
-      0x6034000C,  //  0269  GETGBL	R13	G12
-      0x5C381800,  //  026A  MOVE	R14	R12
-      0x7C340200,  //  026B  CALL	R13	1
-      0x543A000F,  //  026C  LDINT	R14	16
-      0x14341A0E,  //  026D  LT	R13	R13	R14
-      0x74360005,  //  026E  JMPT	R13	#0275
-      0x6034000C,  //  026F  GETGBL	R13	G12
-      0x5C381800,  //  0270  MOVE	R14	R12
-      0x7C340200,  //  0271  CALL	R13	1
-      0x543A001F,  //  0272  LDINT	R14	32
-      0x24341A0E,  //  0273  GT	R13	R13	R14
-      0x7836000A,  //  0274  JMPF	R13	#0280
-      0xB8364400,  //  0275  GETNGBL	R13	K34
-      0x8C341B2C,  //  0276  GETMET	R13	R13	K44
-      0x583C005C,  //  0277  LDCONST	R15	K92
-      0x5840000E,  //  0278  LDCONST	R16	K14
-      0x7C340600,  //  0279  CALL	R13	3
-      0xB8360200,  //  027A  GETNGBL	R13	K1
-      0x88341B5D,  //  027B  GETMBR	R13	R13	K93
-      0x900E340D,  //  027C  SETMBR	R3	K26	R13
-      0x4C340000,  //  027D  LDNIL	R13
-      0xA0000000,  //  027E  CLOSE	R0
-      0x80041A00,  //  027F  RET	1	R13
-      0x5436001E,  //  0280  LDINT	R13	31
-      0x40360A0D,  //  0281  CONNECT	R13	K5	R13
-      0x9434120D,  //  0282  GETIDX	R13	R9	R13
-      0x543A001F,  //  0283  LDINT	R14	32
-      0x40381D40,  //  0284  CONNECT	R14	R14	K64
-      0x9438120E,  //  0285  GETIDX	R14	R9	R14
-      0x883C0116,  //  0286  GETMBR	R15	R0	K22
-      0x8C3C1F5E,  //  0287  GETMET	R15	R15	K94
-      0x5C441000,  //  0288  MOVE	R17	R8
-      0x5C481600,  //  0289  MOVE	R18	R11
-      0x5C4C1400,  //  028A  MOVE	R19	R10
-      0x5C501800,  //  028B  MOVE	R20	R12
-      0x5C541A00,  //  028C  MOVE	R21	R13
-      0x5C581C00,  //  028D  MOVE	R22	R14
-      0x8C5C035F,  //  028E  GETMET	R23	R1	K95
-      0x7C5C0200,  //  028F  CALL	R23	1
-      0x7C3C1000,  //  0290  CALL	R15	8
-      0x503C0200,  //  0291  LDBOOL	R15	1	0
-      0xA0000000,  //  0292  CLOSE	R0
-      0x80041E00,  //  0293  RET	1	R15
-      0x7002001C,  //  0294  JMP		#02B2
-      0x1C200F07,  //  0295  EQ	R8	R7	K7
-      0x78220012,  //  0296  JMPF	R8	#02AA
-      0x8C200506,  //  0297  GETMET	R8	R2	K6
-      0x58280005,  //  0298  LDCONST	R10	K5
-      0x7C200400,  //  0299  CALL	R8	2
-      0xB8264400,  //  029A  GETNGBL	R9	K34
-      0x8C24132C,  //  029B  GETMET	R9	R9	K44
-      0x602C0008,  //  029C  GETGBL	R11	G8
-      0x5C301000,  //  029D  MOVE	R12	R8
-      0x7C2C0200,  //  029E  CALL	R11	1
-      0x002EC00B,  //  029F  ADD	R11	K96	R11
-      0x58300010,  //  02A0  LDCONST	R12	K16
-      0x7C240600,  //  02A1  CALL	R9	3
-      0x88240116,  //  02A2  GETMBR	R9	R0	K22
-      0x8C241361,  //  02A3  GETMET	R9	R9	K97
-      0x5C2C1000,  //  02A4  MOVE	R11	R8
-      0x7C240400,  //  02A5  CALL	R9	2
-      0x50240200,  //  02A6  LDBOOL	R9	1	0
-      0xA0000000,  //  02A7  CLOSE	R0
-      0x80041200,  //  02A8  RET	1	R9
-      0x70020007,  //  02A9  JMP		#02B2
-      0x1C200F0E,  //  02AA  EQ	R8	R7	K14
-      0x78220005,  //  02AB  JMPF	R8	#02B2
-      0x88200116,  //  02AC  GETMBR	R8	R0	K22
-      0x8C201162,  //  02AD  GETMET	R8	R8	K98
-      0x7C200200,  //  02AE  CALL	R8	1
-      0x50200200,  //  02AF  LDBOOL	R8	1	0
-      0xA0000000,  //  02B0  CLOSE	R0
-      0x80041000,  //  02B1  RET	1	R8
-      0x70020012,  //  02B2  JMP		#02C6
-      0x54220029,  //  02B3  LDINT	R8	42
-      0x1C200C08,  //  02B4  EQ	R8	R6	R8
-      0x78220005,  //  02B5  JMPF	R8	#02BC
-      0x1C200F05,  //  02B6  EQ	R8	R7	K5
-      0x78220002,  //  02B7  JMPF	R8	#02BB
-      0x50200200,  //  02B8  LDBOOL	R8	1	0
-      0xA0000000,  //  02B9  CLOSE	R0
-      0x80041000,  //  02BA  RET	1	R8
-      0x70020009,  //  02BB  JMP		#02C6
-      0x60200003,  //  02BC  GETGBL	R8	G3
-      0x5C240000,  //  02BD  MOVE	R9	R0
-      0x7C200200,  //  02BE  CALL	R8	1
-      0x8C201163,  //  02BF  GETMET	R8	R8	K99
-      0x5C280200,  //  02C0  MOVE	R10	R1
-      0x5C2C0400,  //  02C1  MOVE	R11	R2
-      0x5C300600,  //  02C2  MOVE	R12	R3
-      0x7C200800,  //  02C3  CALL	R8	4
-      0xA0000000,  //  02C4  CLOSE	R0
-      0x80041000,  //  02C5  RET	1	R8
+      0x782E000A,  //  020B  JMPF	R11	#0217
+      0x8C2C1555,  //  020C  GETMET	R11	R10	K85
+      0x7C2C0200,  //  020D  CALL	R11	1
+      0xB82E4400,  //  020E  GETNGBL	R11	K34
+      0x8C2C1756,  //  020F  GETMET	R11	R11	K86
+      0x543607CF,  //  0210  LDINT	R13	2000
+      0x84380000,  //  0211  CLOSURE	R14	P0
+      0x7C2C0600,  //  0212  CALL	R11	3
+      0x502C0200,  //  0213  LDBOOL	R11	1	0
+      0xA0000000,  //  0214  CLOSE	R0
+      0xA8040001,  //  0215  EXBLK	1	1
+      0x80041600,  //  0216  RET	1	R11
+      0xA0240000,  //  0217  CLOSE	R9
+      0x7001FFEC,  //  0218  JMP		#0206
+      0x58240057,  //  0219  LDCONST	R9	K87
+      0xAC240200,  //  021A  CATCH	R9	1	0
+      0xB0080000,  //  021B  RAISE	2	R0	R0
+      0xB8264400,  //  021C  GETNGBL	R9	K34
+      0x8C24132C,  //  021D  GETMET	R9	R9	K44
+      0x602C0008,  //  021E  GETGBL	R11	G8
+      0x5C301000,  //  021F  MOVE	R12	R8
+      0x7C2C0200,  //  0220  CALL	R11	1
+      0x002EB00B,  //  0221  ADD	R11	K88	R11
+      0x002C1759,  //  0222  ADD	R11	R11	K89
+      0x5830000E,  //  0223  LDCONST	R12	K14
+      0x7C240600,  //  0224  CALL	R9	3
+      0xB8260200,  //  0225  GETNGBL	R9	K1
+      0x8824135A,  //  0226  GETMBR	R9	R9	K90
+      0x900E3409,  //  0227  SETMBR	R3	K26	R9
+      0x4C240000,  //  0228  LDNIL	R9
+      0xA0000000,  //  0229  CLOSE	R0
+      0x80041200,  //  022A  RET	1	R9
+      0x7002009B,  //  022B  JMP		#02C8
+      0x5422003B,  //  022C  LDINT	R8	60
+      0x1C200C08,  //  022D  EQ	R8	R6	R8
+      0x78220085,  //  022E  JMPF	R8	#02B5
+      0x1C200F05,  //  022F  EQ	R8	R7	K5
+      0x78220065,  //  0230  JMPF	R8	#0297
+      0x8C200506,  //  0231  GETMET	R8	R2	K6
+      0x58280005,  //  0232  LDCONST	R10	K5
+      0x7C200400,  //  0233  CALL	R8	2
+      0x8C240506,  //  0234  GETMET	R9	R2	K6
+      0x582C0007,  //  0235  LDCONST	R11	K7
+      0x7C240400,  //  0236  CALL	R9	2
+      0x8C280506,  //  0237  GETMET	R10	R2	K6
+      0x5830000E,  //  0238  LDCONST	R12	K14
+      0x7C280400,  //  0239  CALL	R10	2
+      0x8C2C0506,  //  023A  GETMET	R11	R2	K6
+      0x58340010,  //  023B  LDCONST	R13	K16
+      0x7C2C0400,  //  023C  CALL	R11	2
+      0x8C300506,  //  023D  GETMET	R12	R2	K6
+      0x543A0003,  //  023E  LDINT	R14	4
+      0x7C300400,  //  023F  CALL	R12	2
+      0xB8364400,  //  0240  GETNGBL	R13	K34
+      0x8C341B2C,  //  0241  GETMET	R13	R13	K44
+      0x603C0018,  //  0242  GETGBL	R15	G24
+      0x5840005B,  //  0243  LDCONST	R16	K91
+      0x5C441000,  //  0244  MOVE	R17	R8
+      0x8C481351,  //  0245  GETMET	R18	R9	K81
+      0x7C480200,  //  0246  CALL	R18	1
+      0x5C4C1400,  //  0247  MOVE	R19	R10
+      0x5C501600,  //  0248  MOVE	R20	R11
+      0x8C541951,  //  0249  GETMET	R21	R12	K81
+      0x7C540200,  //  024A  CALL	R21	1
+      0x7C3C0C00,  //  024B  CALL	R15	6
+      0x54420003,  //  024C  LDINT	R16	4
+      0x7C340600,  //  024D  CALL	R13	3
+      0x4C340000,  //  024E  LDNIL	R13
+      0x1C34100D,  //  024F  EQ	R13	R8	R13
+      0x7436000B,  //  0250  JMPT	R13	#025D
+      0x4C340000,  //  0251  LDNIL	R13
+      0x1C34120D,  //  0252  EQ	R13	R9	R13
+      0x74360008,  //  0253  JMPT	R13	#025D
+      0x4C340000,  //  0254  LDNIL	R13
+      0x1C34140D,  //  0255  EQ	R13	R10	R13
+      0x74360005,  //  0256  JMPT	R13	#025D
+      0x4C340000,  //  0257  LDNIL	R13
+      0x1C34160D,  //  0258  EQ	R13	R11	R13
+      0x74360002,  //  0259  JMPT	R13	#025D
+      0x4C340000,  //  025A  LDNIL	R13
+      0x1C34180D,  //  025B  EQ	R13	R12	R13
+      0x78360005,  //  025C  JMPF	R13	#0263
+      0xB8360200,  //  025D  GETNGBL	R13	K1
+      0x88341B5C,  //  025E  GETMBR	R13	R13	K92
+      0x900E340D,  //  025F  SETMBR	R3	K26	R13
+      0x4C340000,  //  0260  LDNIL	R13
+      0xA0000000,  //  0261  CLOSE	R0
+      0x80041A00,  //  0262  RET	1	R13
+      0x6034000C,  //  0263  GETGBL	R13	G12
+      0x5C381200,  //  0264  MOVE	R14	R9
+      0x7C340200,  //  0265  CALL	R13	1
+      0x543A001F,  //  0266  LDINT	R14	32
+      0x543E0040,  //  0267  LDINT	R15	65
+      0x00381C0F,  //  0268  ADD	R14	R14	R15
+      0x20341A0E,  //  0269  NE	R13	R13	R14
+      0x7436000B,  //  026A  JMPT	R13	#0277
+      0x6034000C,  //  026B  GETGBL	R13	G12
+      0x5C381800,  //  026C  MOVE	R14	R12
+      0x7C340200,  //  026D  CALL	R13	1
+      0x543A000F,  //  026E  LDINT	R14	16
+      0x14341A0E,  //  026F  LT	R13	R13	R14
+      0x74360005,  //  0270  JMPT	R13	#0277
+      0x6034000C,  //  0271  GETGBL	R13	G12
+      0x5C381800,  //  0272  MOVE	R14	R12
+      0x7C340200,  //  0273  CALL	R13	1
+      0x543A001F,  //  0274  LDINT	R14	32
+      0x24341A0E,  //  0275  GT	R13	R13	R14
+      0x7836000A,  //  0276  JMPF	R13	#0282
+      0xB8364400,  //  0277  GETNGBL	R13	K34
+      0x8C341B2C,  //  0278  GETMET	R13	R13	K44
+      0x583C005D,  //  0279  LDCONST	R15	K93
+      0x5840000E,  //  027A  LDCONST	R16	K14
+      0x7C340600,  //  027B  CALL	R13	3
+      0xB8360200,  //  027C  GETNGBL	R13	K1
+      0x88341B5E,  //  027D  GETMBR	R13	R13	K94
+      0x900E340D,  //  027E  SETMBR	R3	K26	R13
+      0x4C340000,  //  027F  LDNIL	R13
+      0xA0000000,  //  0280  CLOSE	R0
+      0x80041A00,  //  0281  RET	1	R13
+      0x5436001E,  //  0282  LDINT	R13	31
+      0x40360A0D,  //  0283  CONNECT	R13	K5	R13
+      0x9434120D,  //  0284  GETIDX	R13	R9	R13
+      0x543A001F,  //  0285  LDINT	R14	32
+      0x40381D40,  //  0286  CONNECT	R14	R14	K64
+      0x9438120E,  //  0287  GETIDX	R14	R9	R14
+      0x883C0116,  //  0288  GETMBR	R15	R0	K22
+      0x8C3C1F5F,  //  0289  GETMET	R15	R15	K95
+      0x5C441000,  //  028A  MOVE	R17	R8
+      0x5C481600,  //  028B  MOVE	R18	R11
+      0x5C4C1400,  //  028C  MOVE	R19	R10
+      0x5C501800,  //  028D  MOVE	R20	R12
+      0x5C541A00,  //  028E  MOVE	R21	R13
+      0x5C581C00,  //  028F  MOVE	R22	R14
+      0x8C5C0360,  //  0290  GETMET	R23	R1	K96
+      0x7C5C0200,  //  0291  CALL	R23	1
+      0x7C3C1000,  //  0292  CALL	R15	8
+      0x503C0200,  //  0293  LDBOOL	R15	1	0
+      0xA0000000,  //  0294  CLOSE	R0
+      0x80041E00,  //  0295  RET	1	R15
+      0x7002001C,  //  0296  JMP		#02B4
+      0x1C200F07,  //  0297  EQ	R8	R7	K7
+      0x78220012,  //  0298  JMPF	R8	#02AC
+      0x8C200506,  //  0299  GETMET	R8	R2	K6
+      0x58280005,  //  029A  LDCONST	R10	K5
+      0x7C200400,  //  029B  CALL	R8	2
+      0xB8264400,  //  029C  GETNGBL	R9	K34
+      0x8C24132C,  //  029D  GETMET	R9	R9	K44
+      0x602C0008,  //  029E  GETGBL	R11	G8
+      0x5C301000,  //  029F  MOVE	R12	R8
+      0x7C2C0200,  //  02A0  CALL	R11	1
+      0x002EC20B,  //  02A1  ADD	R11	K97	R11
+      0x58300010,  //  02A2  LDCONST	R12	K16
+      0x7C240600,  //  02A3  CALL	R9	3
+      0x88240116,  //  02A4  GETMBR	R9	R0	K22
+      0x8C241362,  //  02A5  GETMET	R9	R9	K98
+      0x5C2C1000,  //  02A6  MOVE	R11	R8
+      0x7C240400,  //  02A7  CALL	R9	2
+      0x50240200,  //  02A8  LDBOOL	R9	1	0
+      0xA0000000,  //  02A9  CLOSE	R0
+      0x80041200,  //  02AA  RET	1	R9
+      0x70020007,  //  02AB  JMP		#02B4
+      0x1C200F0E,  //  02AC  EQ	R8	R7	K14
+      0x78220005,  //  02AD  JMPF	R8	#02B4
+      0x88200116,  //  02AE  GETMBR	R8	R0	K22
+      0x8C201163,  //  02AF  GETMET	R8	R8	K99
+      0x7C200200,  //  02B0  CALL	R8	1
+      0x50200200,  //  02B1  LDBOOL	R8	1	0
+      0xA0000000,  //  02B2  CLOSE	R0
+      0x80041000,  //  02B3  RET	1	R8
+      0x70020012,  //  02B4  JMP		#02C8
+      0x54220029,  //  02B5  LDINT	R8	42
+      0x1C200C08,  //  02B6  EQ	R8	R6	R8
+      0x78220005,  //  02B7  JMPF	R8	#02BE
+      0x1C200F05,  //  02B8  EQ	R8	R7	K5
+      0x78220002,  //  02B9  JMPF	R8	#02BD
+      0x50200200,  //  02BA  LDBOOL	R8	1	0
+      0xA0000000,  //  02BB  CLOSE	R0
+      0x80041000,  //  02BC  RET	1	R8
+      0x70020009,  //  02BD  JMP		#02C8
+      0x60200003,  //  02BE  GETGBL	R8	G3
+      0x5C240000,  //  02BF  MOVE	R9	R0
+      0x7C200200,  //  02C0  CALL	R8	1
+      0x8C201164,  //  02C1  GETMET	R8	R8	K100
+      0x5C280200,  //  02C2  MOVE	R10	R1
+      0x5C2C0400,  //  02C3  MOVE	R11	R2
+      0x5C300600,  //  02C4  MOVE	R12	R3
+      0x7C200800,  //  02C5  CALL	R8	4
       0xA0000000,  //  02C6  CLOSE	R0
-      0x80000000,  //  02C7  RET	0
+      0x80041000,  //  02C7  RET	1	R8
+      0xA0000000,  //  02C8  CLOSE	R0
+      0x80000000,  //  02C9  RET	0
     })
   )
 );
@@ -2083,9 +2106,26 @@ be_local_class(Matter_Plugin_Root,
         { be_const_key_weak(write_attribute, -1), be_const_closure(Matter_Plugin_Root_write_attribute_closure) },
         { be_const_key_weak(DISPLAY_NAME, -1), be_nested_str_weak(Root_X20node) },
         { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(15,
+        be_const_map( *     be_nested_map(14,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_int(60, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        { be_const_key_int(56, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(3,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(1),
+        be_const_int(7),
+    }))    ) } )) },
+        { be_const_key_int(29, 11), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(6,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(1),
+        be_const_int(2),
+        be_const_int(3),
+        be_const_int(65532),
+        be_const_int(65533),
+    }))    ) } )) },
+        { be_const_key_int(44, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(3,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(0),
@@ -2100,7 +2140,18 @@ be_local_class(Matter_Plugin_Root,
         be_const_int(3),
         be_const_int(4),
     }))    ) } )) },
-        { be_const_key_int(62, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        { be_const_key_int(60, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(3,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(1),
+        be_const_int(2),
+    }))    ) } )) },
+        { be_const_key_int(63, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(0,
+    ( (struct bvalue*) &(const bvalue[]) {
+    }))    ) } )) },
+        { be_const_key_int(62, 13), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(0),
@@ -2110,16 +2161,7 @@ be_local_class(Matter_Plugin_Root,
         be_const_int(4),
         be_const_int(5),
     }))    ) } )) },
-        { be_const_key_int(48, 9), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(5,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(0),
-        be_const_int(1),
-        be_const_int(2),
-        be_const_int(3),
-        be_const_int(4),
-    }))    ) } )) },
-        { be_const_key_int(49, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        { be_const_key_int(49, 5), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(3,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(3),
@@ -2142,19 +2184,11 @@ be_local_class(Matter_Plugin_Root,
         be_const_list( *     be_nested_list(0,
     ( (struct bvalue*) &(const bvalue[]) {
     }))    ) } )) },
-        { be_const_key_int(29, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(6,
+        { be_const_key_int(43, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(2,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(0),
         be_const_int(1),
-        be_const_int(2),
-        be_const_int(3),
-        be_const_int(65532),
-        be_const_int(65533),
-    }))    ) } )) },
-        { be_const_key_int(63, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(0,
-    ( (struct bvalue*) &(const bvalue[]) {
     }))    ) } )) },
         { be_const_key_int(40, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(15,
@@ -2175,30 +2209,14 @@ be_local_class(Matter_Plugin_Root,
         be_const_int(18),
         be_const_int(19),
     }))    ) } )) },
-        { be_const_key_int(56, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(3,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(0),
-        be_const_int(1),
-        be_const_int(7),
-    }))    ) } )) },
-        { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(1,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
-    }))    ) } )) },
-        { be_const_key_int(43, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(2,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(0),
-        be_const_int(1),
-    }))    ) } )) },
-        { be_const_key_int(44, 8), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(3,
+        { be_const_key_int(48, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(5,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(0),
         be_const_int(1),
         be_const_int(2),
+        be_const_int(3),
+        be_const_int(4),
     }))    ) } )) },
     }))    ) } )) },
     })),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Light1.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Light1.h
@@ -761,9 +761,8 @@ be_local_class(Matter_Plugin_Light1,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_OnOff.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_OnOff.h
@@ -484,9 +484,8 @@ be_local_class(Matter_Plugin_OnOff,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Contact.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Contact.h
@@ -415,9 +415,8 @@ be_local_class(Matter_Plugin_Sensor_Contact,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Occupancy.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Occupancy.h
@@ -432,9 +432,8 @@ be_local_class(Matter_Plugin_Sensor_Occupancy,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_OnOff.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_OnOff.h
@@ -300,9 +300,8 @@ be_local_class(Matter_Plugin_Sensor_OnOff,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Shutter.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Shutter.h
@@ -696,9 +696,8 @@ be_local_class(Matter_Plugin_Shutter,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Bridge_Light0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Bridge_Light0.h
@@ -513,9 +513,8 @@ be_local_class(Matter_Plugin_Bridge_Light0,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Bridge_Sensor_Contact.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Bridge_Sensor_Contact.h
@@ -372,9 +372,8 @@ be_local_class(Matter_Plugin_Bridge_Sensor_Contact,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Bridge_Sensor_Occupancy.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Bridge_Sensor_Occupancy.h
@@ -392,9 +392,8 @@ be_local_class(Matter_Plugin_Bridge_Sensor_Occupancy,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Light2.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Light2.h
@@ -528,9 +528,8 @@ be_local_class(Matter_Plugin_Light2,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Light3.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Light3.h
@@ -690,9 +690,8 @@ be_local_class(Matter_Plugin_Light3,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Flow.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Flow.h
@@ -219,9 +219,8 @@ be_local_class(Matter_Plugin_Sensor_Flow,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Humidity.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Humidity.h
@@ -227,9 +227,8 @@ be_local_class(Matter_Plugin_Sensor_Humidity,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Illuminance.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Illuminance.h
@@ -238,9 +238,8 @@ be_local_class(Matter_Plugin_Sensor_Illuminance,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Pressure.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Pressure.h
@@ -227,9 +227,8 @@ be_local_class(Matter_Plugin_Sensor_Pressure,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Temp.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Temp.h
@@ -240,9 +240,8 @@ be_local_class(Matter_Plugin_Sensor_Temp,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_ShutterTilt.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_ShutterTilt.h
@@ -470,9 +470,8 @@ be_local_class(Matter_Plugin_ShutterTilt,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Bridge_Light1.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Bridge_Light1.h
@@ -579,9 +579,8 @@ be_local_class(Matter_Plugin_Bridge_Light1,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Bridge_Sensor_Flow.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Bridge_Sensor_Flow.h
@@ -256,9 +256,8 @@ be_local_class(Matter_Plugin_Bridge_Sensor_Flow,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Bridge_Sensor_Humidity.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Bridge_Sensor_Humidity.h
@@ -272,9 +272,8 @@ be_local_class(Matter_Plugin_Bridge_Sensor_Humidity,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, 1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Bridge_Sensor_Illuminance.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Bridge_Sensor_Illuminance.h
@@ -275,9 +275,8 @@ be_local_class(Matter_Plugin_Bridge_Sensor_Illuminance,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Bridge_Sensor_Pressure.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Bridge_Sensor_Pressure.h
@@ -264,9 +264,8 @@ be_local_class(Matter_Plugin_Bridge_Sensor_Pressure,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Bridge_Sensor_Temp.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_4_Bridge_Sensor_Temp.h
@@ -282,9 +282,8 @@ be_local_class(Matter_Plugin_Bridge_Sensor_Temp,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_5_Bridge_Light2.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_5_Bridge_Light2.h
@@ -560,9 +560,8 @@ be_local_class(Matter_Plugin_Bridge_Light2,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_5_Bridge_Light3.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_5_Bridge_Light3.h
@@ -736,9 +736,8 @@ be_local_class(Matter_Plugin_Bridge_Light3,
         be_const_int(65533),
     }))    ) } )) },
         { be_const_key_int(57, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(7,
+        be_const_list( *     be_nested_list(6,
     ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(17),
         be_const_int(3),
         be_const_int(5),
         be_const_int(10),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
@@ -7,124 +7,9 @@
 extern const bclass be_class_Matter_Device;
 
 /********************************************************************
-** Solidified function: bridge_add_endpoint
+** Solidified function: is_commissioning_open
 ********************************************************************/
-be_local_closure(Matter_Device_bridge_add_endpoint,   /* name */
-  be_nested_proto(
-    17,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins_classes),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-    /* K5   */  be_nested_str_weak(_X27_X20skipping),
-    /* K6   */  be_const_int(3),
-    /* K7   */  be_nested_str_weak(next_ep),
-    /* K8   */  be_nested_str_weak(plugins),
-    /* K9   */  be_nested_str_weak(push),
-    /* K10  */  be_nested_str_weak(type),
-    /* K11  */  be_nested_str_weak(keys),
-    /* K12  */  be_nested_str_weak(stop_iteration),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
-    /* K14  */  be_nested_str_weak(conf_to_log),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_nested_str_weak(plugins_config),
-    /* K17  */  be_nested_str_weak(plugins_persist),
-    /* K18  */  be_const_int(1),
-    /* K19  */  be_nested_str_weak(save_param),
-    /* K20  */  be_nested_str_weak(signal_endpoints_changed),
-    }),
-    be_str_weak(bridge_add_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[70]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x4C100000,  //  0004  LDNIL	R4
-      0x1C100604,  //  0005  EQ	R4	R3	R4
-      0x78120009,  //  0006  JMPF	R4	#0011
-      0xB8120400,  //  0007  GETNGBL	R4	K2
-      0x8C100903,  //  0008  GETMET	R4	R4	K3
-      0x60180008,  //  0009  GETGBL	R6	G8
-      0x5C1C0200,  //  000A  MOVE	R7	R1
-      0x7C180200,  //  000B  CALL	R6	1
-      0x001A0806,  //  000C  ADD	R6	K4	R6
-      0x00180D05,  //  000D  ADD	R6	R6	K5
-      0x581C0006,  //  000E  LDCONST	R7	K6
-      0x7C100600,  //  000F  CALL	R4	3
-      0x80000800,  //  0010  RET	0
-      0x88100107,  //  0011  GETMBR	R4	R0	K7
-      0x60140008,  //  0012  GETGBL	R5	G8
-      0x5C180800,  //  0013  MOVE	R6	R4
-      0x7C140200,  //  0014  CALL	R5	1
-      0x5C180600,  //  0015  MOVE	R6	R3
-      0x5C1C0000,  //  0016  MOVE	R7	R0
-      0x5C200800,  //  0017  MOVE	R8	R4
-      0x5C240400,  //  0018  MOVE	R9	R2
-      0x7C180600,  //  0019  CALL	R6	3
-      0x881C0108,  //  001A  GETMBR	R7	R0	K8
-      0x8C1C0F09,  //  001B  GETMET	R7	R7	K9
-      0x5C240C00,  //  001C  MOVE	R9	R6
-      0x7C1C0400,  //  001D  CALL	R7	2
-      0x601C0013,  //  001E  GETGBL	R7	G19
-      0x7C1C0000,  //  001F  CALL	R7	0
-      0x981E1401,  //  0020  SETIDX	R7	K10	R1
-      0x60200010,  //  0021  GETGBL	R8	G16
-      0x8C24050B,  //  0022  GETMET	R9	R2	K11
-      0x7C240200,  //  0023  CALL	R9	1
-      0x7C200200,  //  0024  CALL	R8	1
-      0xA8020004,  //  0025  EXBLK	0	#002B
-      0x5C241000,  //  0026  MOVE	R9	R8
-      0x7C240000,  //  0027  CALL	R9	0
-      0x94280409,  //  0028  GETIDX	R10	R2	R9
-      0x981C120A,  //  0029  SETIDX	R7	R9	R10
-      0x7001FFFA,  //  002A  JMP		#0026
-      0x5820000C,  //  002B  LDCONST	R8	K12
-      0xAC200200,  //  002C  CATCH	R8	1	0
-      0xB0080000,  //  002D  RAISE	2	R0	R0
-      0xB8220400,  //  002E  GETNGBL	R8	K2
-      0x8C201103,  //  002F  GETMET	R8	R8	K3
-      0x60280018,  //  0030  GETGBL	R10	G24
-      0x582C000D,  //  0031  LDCONST	R11	K13
-      0x5C300800,  //  0032  MOVE	R12	R4
-      0x5C340200,  //  0033  MOVE	R13	R1
-      0x8C38010E,  //  0034  GETMET	R14	R0	K14
-      0x5C400400,  //  0035  MOVE	R16	R2
-      0x7C380400,  //  0036  CALL	R14	2
-      0x7C280800,  //  0037  CALL	R10	4
-      0x582C000F,  //  0038  LDCONST	R11	K15
-      0x7C200600,  //  0039  CALL	R8	3
-      0x88200110,  //  003A  GETMBR	R8	R0	K16
-      0x98200A07,  //  003B  SETIDX	R8	R5	R7
-      0x50200200,  //  003C  LDBOOL	R8	1	0
-      0x90022208,  //  003D  SETMBR	R0	K17	R8
-      0x88200107,  //  003E  GETMBR	R8	R0	K7
-      0x00201112,  //  003F  ADD	R8	R8	K18
-      0x90020E08,  //  0040  SETMBR	R0	K7	R8
-      0x8C200113,  //  0041  GETMET	R8	R0	K19
-      0x7C200200,  //  0042  CALL	R8	1
-      0x8C200114,  //  0043  GETMET	R8	R0	K20
-      0x7C200200,  //  0044  CALL	R8	1
-      0x80040800,  //  0045  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_before_restart
-********************************************************************/
-be_local_closure(Matter_Device_save_before_restart,   /* name */
+be_local_closure(Matter_Device_is_commissioning_open,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -134,18 +19,16 @@ be_local_closure(Matter_Device_save_before_restart,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K1   */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
     }),
-    be_str_weak(save_before_restart),
+    be_str_weak(is_commissioning_open),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
-      0x7C040200,  //  0003  CALL	R1	1
-      0x80000000,  //  0004  RET	0
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
     })
   )
 );
@@ -153,12 +36,12 @@ be_local_closure(Matter_Device_save_before_restart,   /* name */
 
 
 /********************************************************************
-** Solidified function: compute_manual_pairing_code
+** Solidified function: MtrInfo_one
 ********************************************************************/
-be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
+be_local_closure(Matter_Device_MtrInfo_one,   /* name */
   be_nested_proto(
     9,                          /* nstack */
-    1,                          /* argc */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -166,46 +49,236 @@ be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(root_discriminator),
-    /* K1   */  be_nested_str_weak(root_passcode),
-    /* K2   */  be_nested_str_weak(_X251i_X2505i_X2504i),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Verhoeff),
-    /* K5   */  be_nested_str_weak(checksum),
+    /* K0   */  be_nested_str_weak(find_plugin_by_endpoint),
+    /* K1   */  be_nested_str_weak(state_json),
+    /* K2   */  be_nested_str_weak(_X7B_X22MtrInfo_X22_X3A_X25s_X7D),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(publish_result),
+    /* K5   */  be_nested_str_weak(),
     }),
-    be_str_weak(compute_manual_pairing_code),
+    be_str_weak(MtrInfo_one),
     &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
+    ( &(const binstruction[20]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0403,  //  0004  EQ	R3	R2	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80000600,  //  0006  RET	0
+      0x8C0C0501,  //  0007  GETMET	R3	R2	K1
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x780E0008,  //  0009  JMPF	R3	#0013
+      0x60100018,  //  000A  GETGBL	R4	G24
+      0x58140002,  //  000B  LDCONST	R5	K2
+      0x5C180600,  //  000C  MOVE	R6	R3
+      0x7C100400,  //  000D  CALL	R4	2
+      0xB8160600,  //  000E  GETNGBL	R5	K3
+      0x8C140B04,  //  000F  GETMET	R5	R5	K4
+      0x5C1C0800,  //  0010  MOVE	R7	R4
+      0x58200005,  //  0011  LDCONST	R8	K5
+      0x7C140600,  //  0012  CALL	R5	3
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_fabrics_saved
+********************************************************************/
+be_local_closure(Matter_Device_event_fabrics_saved,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(count_active_fabrics),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(plugins_persist),
+    /* K4   */  be_nested_str_weak(save_param),
+    }),
+    be_str_weak(event_fabrics_saved),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x540A0FFE,  //  0001  LDINT	R2	4095
-      0x2C040202,  //  0002  AND	R1	R1	R2
-      0x540A0009,  //  0003  LDINT	R2	10
-      0x3C040202,  //  0004  SHR	R1	R1	R2
-      0x88080100,  //  0005  GETMBR	R2	R0	K0
-      0x540E02FF,  //  0006  LDINT	R3	768
-      0x2C080403,  //  0007  AND	R2	R2	R3
-      0x540E0005,  //  0008  LDINT	R3	6
-      0x38080403,  //  0009  SHL	R2	R2	R3
-      0x880C0101,  //  000A  GETMBR	R3	R0	K1
-      0x54123FFE,  //  000B  LDINT	R4	16383
-      0x2C0C0604,  //  000C  AND	R3	R3	R4
-      0x30080403,  //  000D  OR	R2	R2	R3
-      0x880C0101,  //  000E  GETMBR	R3	R0	K1
-      0x5412000D,  //  000F  LDINT	R4	14
-      0x3C0C0604,  //  0010  SHR	R3	R3	R4
-      0x60100018,  //  0011  GETGBL	R4	G24
-      0x58140002,  //  0012  LDCONST	R5	K2
-      0x5C180200,  //  0013  MOVE	R6	R1
-      0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x5C200600,  //  0015  MOVE	R8	R3
-      0x7C100800,  //  0016  CALL	R4	4
-      0xB8160600,  //  0017  GETNGBL	R5	K3
-      0x88140B04,  //  0018  GETMBR	R5	R5	K4
-      0x8C140B05,  //  0019  GETMET	R5	R5	K5
-      0x5C1C0800,  //  001A  MOVE	R7	R4
-      0x7C140400,  //  001B  CALL	R5	2
-      0x00100805,  //  001C  ADD	R4	R4	R5
-      0x80040800,  //  001D  RET	1	R4
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x24040302,  //  0003  GT	R1	R1	K2
+      0x78060005,  //  0004  JMPF	R1	#000B
+      0x88040103,  //  0005  GETMBR	R1	R0	K3
+      0x74060003,  //  0006  JMPT	R1	#000B
+      0x50040200,  //  0007  LDBOOL	R1	1	0
+      0x90020601,  //  0008  SETMBR	R0	K3	R1
+      0x8C040104,  //  0009  GETMET	R1	R0	K4
+      0x7C040200,  //  000A  CALL	R1	1
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_commissioning_complete
+********************************************************************/
+be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_fabric),
+    /* K1   */  be_nested_str_weak(get_fabric_id),
+    /* K2   */  be_nested_str_weak(copy),
+    /* K3   */  be_nested_str_weak(reverse),
+    /* K4   */  be_nested_str_weak(tohex),
+    /* K5   */  be_nested_str_weak(get_admin_vendor_name),
+    /* K6   */  be_nested_str_weak(tasmota),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X2D_X2D_X2D_X20Commissioning_X20complete_X20for_X20Fabric_X20_X27_X25s_X27_X20_X28Vendor_X20_X25s_X29_X20_X2D_X2D_X2D),
+    /* K9   */  be_const_int(2),
+    /* K10  */  be_nested_str_weak(stop_basic_commissioning),
+    }),
+    be_str_weak(start_commissioning_complete),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x8C080300,  //  0000  GETMET	R2	R1	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x8C0C0501,  //  0002  GETMET	R3	R2	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x8C0C0704,  //  0008  GETMET	R3	R3	K4
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x8C100505,  //  000A  GETMET	R4	R2	K5
+      0x7C100200,  //  000B  CALL	R4	1
+      0xB8160C00,  //  000C  GETNGBL	R5	K6
+      0x8C140B07,  //  000D  GETMET	R5	R5	K7
+      0x601C0018,  //  000E  GETGBL	R7	G24
+      0x58200008,  //  000F  LDCONST	R8	K8
+      0x5C240600,  //  0010  MOVE	R9	R3
+      0x5C280800,  //  0011  MOVE	R10	R4
+      0x7C1C0600,  //  0012  CALL	R7	3
+      0x58200009,  //  0013  LDCONST	R8	K9
+      0x7C140600,  //  0014  CALL	R5	3
+      0x8C14010A,  //  0015  GETMET	R5	R0	K10
+      0x7C140200,  //  0016  CALL	R5	1
+      0x80000000,  //  0017  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: bridge_remove_endpoint
+********************************************************************/
+be_local_closure(Matter_Device_bridge_remove_endpoint,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(plugins_config),
+    /* K2   */  be_nested_str_weak(contains),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
+    /* K6   */  be_const_int(3),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
+    /* K8   */  be_const_int(2),
+    /* K9   */  be_nested_str_weak(remove),
+    /* K10  */  be_nested_str_weak(plugins_persist),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_weak(plugins),
+    /* K13  */  be_nested_str_weak(get_endpoint),
+    /* K14  */  be_const_int(1),
+    /* K15  */  be_nested_str_weak(clean_remotes),
+    /* K16  */  be_nested_str_weak(save_param),
+    /* K17  */  be_nested_str_weak(signal_endpoints_changed),
+    }),
+    be_str_weak(bridge_remove_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[58]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x600C0008,  //  0001  GETGBL	R3	G8
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x4C100000,  //  0004  LDNIL	R4
+      0x4C140000,  //  0005  LDNIL	R5
+      0x88180101,  //  0006  GETMBR	R6	R0	K1
+      0x8C180D02,  //  0007  GETMET	R6	R6	K2
+      0x5C200600,  //  0008  MOVE	R8	R3
+      0x7C180400,  //  0009  CALL	R6	2
+      0x741A0005,  //  000A  JMPT	R6	#0011
+      0xB81A0600,  //  000B  GETNGBL	R6	K3
+      0x8C180D04,  //  000C  GETMET	R6	R6	K4
+      0x00220A03,  //  000D  ADD	R8	K5	R3
+      0x58240006,  //  000E  LDCONST	R9	K6
+      0x7C180600,  //  000F  CALL	R6	3
+      0x80000C00,  //  0010  RET	0
+      0xB81A0600,  //  0011  GETNGBL	R6	K3
+      0x8C180D04,  //  0012  GETMET	R6	R6	K4
+      0x60200018,  //  0013  GETGBL	R8	G24
+      0x58240007,  //  0014  LDCONST	R9	K7
+      0x5C280200,  //  0015  MOVE	R10	R1
+      0x7C200400,  //  0016  CALL	R8	2
+      0x58240008,  //  0017  LDCONST	R9	K8
+      0x7C180600,  //  0018  CALL	R6	3
+      0x88180101,  //  0019  GETMBR	R6	R0	K1
+      0x8C180D09,  //  001A  GETMET	R6	R6	K9
+      0x5C200600,  //  001B  MOVE	R8	R3
+      0x7C180400,  //  001C  CALL	R6	2
+      0x50180200,  //  001D  LDBOOL	R6	1	0
+      0x90021406,  //  001E  SETMBR	R0	K10	R6
+      0x5818000B,  //  001F  LDCONST	R6	K11
+      0x601C000C,  //  0020  GETGBL	R7	G12
+      0x8820010C,  //  0021  GETMBR	R8	R0	K12
+      0x7C1C0200,  //  0022  CALL	R7	1
+      0x141C0C07,  //  0023  LT	R7	R6	R7
+      0x781E000D,  //  0024  JMPF	R7	#0033
+      0x881C010C,  //  0025  GETMBR	R7	R0	K12
+      0x941C0E06,  //  0026  GETIDX	R7	R7	R6
+      0x8C1C0F0D,  //  0027  GETMET	R7	R7	K13
+      0x7C1C0200,  //  0028  CALL	R7	1
+      0x1C1C0207,  //  0029  EQ	R7	R1	R7
+      0x781E0005,  //  002A  JMPF	R7	#0031
+      0x881C010C,  //  002B  GETMBR	R7	R0	K12
+      0x8C1C0F09,  //  002C  GETMET	R7	R7	K9
+      0x5C240C00,  //  002D  MOVE	R9	R6
+      0x7C1C0400,  //  002E  CALL	R7	2
+      0x70020002,  //  002F  JMP		#0033
+      0x70020000,  //  0030  JMP		#0032
+      0x00180D0E,  //  0031  ADD	R6	R6	K14
+      0x7001FFEC,  //  0032  JMP		#0020
+      0x8C1C010F,  //  0033  GETMET	R7	R0	K15
+      0x7C1C0200,  //  0034  CALL	R7	1
+      0x8C1C0110,  //  0035  GETMET	R7	R0	K16
+      0x7C1C0200,  //  0036  CALL	R7	1
+      0x8C1C0111,  //  0037  GETMET	R7	R0	K17
+      0x7C1C0200,  //  0038  CALL	R7	1
+      0x80000000,  //  0039  RET	0
     })
   )
 );
@@ -332,102 +405,6 @@ be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
       0x70020000,  //  004F  JMP		#0051
       0xB0080000,  //  0050  RAISE	2	R0	R0
       0x80000000,  //  0051  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: conf_to_log
-********************************************************************/
-be_local_closure(Matter_Device_conf_to_log,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_nested_str_weak(),
-    /* K2   */  be_nested_str_weak(k2l),
-    /* K3   */  be_nested_str_weak(type),
-    /* K4   */  be_nested_str_weak(_X20_X25s_X3A_X25s),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(conf_to_log),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x58080001,  //  0001  LDCONST	R2	K1
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x5C180000,  //  0004  MOVE	R6	R0
-      0x7C100400,  //  0005  CALL	R4	2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0xA802000B,  //  0007  EXBLK	0	#0014
-      0x5C100600,  //  0008  MOVE	R4	R3
-      0x7C100000,  //  0009  CALL	R4	0
-      0x1C140903,  //  000A  EQ	R5	R4	K3
-      0x78160000,  //  000B  JMPF	R5	#000D
-      0x7001FFFA,  //  000C  JMP		#0008
-      0x60140018,  //  000D  GETGBL	R5	G24
-      0x58180004,  //  000E  LDCONST	R6	K4
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x94200004,  //  0010  GETIDX	R8	R0	R4
-      0x7C140600,  //  0011  CALL	R5	3
-      0x00080405,  //  0012  ADD	R2	R2	R5
-      0x7001FFF3,  //  0013  JMP		#0008
-      0x580C0005,  //  0014  LDCONST	R3	K5
-      0xAC0C0200,  //  0015  CATCH	R3	1	0
-      0xB0080000,  //  0016  RAISE	2	R0	R0
-      0x80040400,  //  0017  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_operational_discovery
-********************************************************************/
-be_local_closure(Matter_Device_start_operational_discovery,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(mdns),
-    /* K2   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K3   */  be_nested_str_weak(root_w0),
-    /* K4   */  be_nested_str_weak(root_L),
-    /* K5   */  be_nested_str_weak(mdns_announce_op_discovery),
-    }),
-    be_str_weak(start_operational_discovery),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0x8C100102,  //  0002  GETMET	R4	R0	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x4C100000,  //  0004  LDNIL	R4
-      0x90020604,  //  0005  SETMBR	R0	K3	R4
-      0x4C100000,  //  0006  LDNIL	R4
-      0x90020804,  //  0007  SETMBR	R0	K4	R4
-      0x8C100105,  //  0008  GETMET	R4	R0	K5
-      0x5C180200,  //  0009  MOVE	R6	R1
-      0x7C100400,  //  000A  CALL	R4	2
-      0x80000000,  //  000B  RET	0
     })
   )
 );
@@ -634,6 +611,60 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
 
 
 /********************************************************************
+** Solidified function: conf_to_log
+********************************************************************/
+be_local_closure(Matter_Device_conf_to_log,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Device),
+    /* K1   */  be_nested_str_weak(),
+    /* K2   */  be_nested_str_weak(k2l),
+    /* K3   */  be_nested_str_weak(type),
+    /* K4   */  be_nested_str_weak(_X20_X25s_X3A_X25s),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(conf_to_log),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x58080001,  //  0001  LDCONST	R2	K1
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x8C100302,  //  0003  GETMET	R4	R1	K2
+      0x5C180000,  //  0004  MOVE	R6	R0
+      0x7C100400,  //  0005  CALL	R4	2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0xA802000B,  //  0007  EXBLK	0	#0014
+      0x5C100600,  //  0008  MOVE	R4	R3
+      0x7C100000,  //  0009  CALL	R4	0
+      0x1C140903,  //  000A  EQ	R5	R4	K3
+      0x78160000,  //  000B  JMPF	R5	#000D
+      0x7001FFFA,  //  000C  JMP		#0008
+      0x60140018,  //  000D  GETGBL	R5	G24
+      0x58180004,  //  000E  LDCONST	R6	K4
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x94200004,  //  0010  GETIDX	R8	R0	R4
+      0x7C140600,  //  0011  CALL	R5	3
+      0x00080405,  //  0012  ADD	R2	R2	R5
+      0x7001FFF3,  //  0013  JMP		#0008
+      0x580C0005,  //  0014  LDCONST	R3	K5
+      0xAC0C0200,  //  0015  CATCH	R3	1	0
+      0xB0080000,  //  0016  RAISE	2	R0	R0
+      0x80040400,  //  0017  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
 be_local_closure(Matter_Device_invoke_request,   /* name */
@@ -763,9 +794,9 @@ be_local_closure(Matter_Device_MtrInfo,   /* name */
 
 
 /********************************************************************
-** Solidified function: received_ack
+** Solidified function: get_plugin_class_displayname
 ********************************************************************/
-be_local_closure(Matter_Device_received_ack,   /* name */
+be_local_closure(Matter_Device_get_plugin_class_displayname,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
@@ -775,18 +806,24 @@ be_local_closure(Matter_Device_received_ack,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(received_ack),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_classes),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(DISPLAY_NAME),
+    /* K3   */  be_nested_str_weak(),
     }),
-    be_str_weak(received_ack),
+    be_str_weak(get_plugin_class_displayname),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
+    ( &(const binstruction[ 9]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x880C0502,  //  0005  GETMBR	R3	R2	K2
+      0x70020000,  //  0006  JMP		#0008
+      0x580C0003,  //  0007  LDCONST	R3	K3
+      0x80040600,  //  0008  RET	1	R3
     })
   )
 );
@@ -794,11 +831,200 @@ be_local_closure(Matter_Device_received_ack,   /* name */
 
 
 /********************************************************************
-** Solidified function: MtrInfo_one
+** Solidified function: bridge_add_endpoint
 ********************************************************************/
-be_local_closure(Matter_Device_MtrInfo_one,   /* name */
+be_local_closure(Matter_Device_bridge_add_endpoint,   /* name */
+  be_nested_proto(
+    17,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[21]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_classes),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+    /* K5   */  be_nested_str_weak(_X27_X20skipping),
+    /* K6   */  be_const_int(3),
+    /* K7   */  be_nested_str_weak(next_ep),
+    /* K8   */  be_nested_str_weak(plugins),
+    /* K9   */  be_nested_str_weak(push),
+    /* K10  */  be_nested_str_weak(type),
+    /* K11  */  be_nested_str_weak(keys),
+    /* K12  */  be_nested_str_weak(stop_iteration),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
+    /* K14  */  be_nested_str_weak(conf_to_log),
+    /* K15  */  be_const_int(2),
+    /* K16  */  be_nested_str_weak(plugins_config),
+    /* K17  */  be_nested_str_weak(plugins_persist),
+    /* K18  */  be_const_int(1),
+    /* K19  */  be_nested_str_weak(save_param),
+    /* K20  */  be_nested_str_weak(signal_endpoints_changed),
+    }),
+    be_str_weak(bridge_add_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[70]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x4C100000,  //  0004  LDNIL	R4
+      0x1C100604,  //  0005  EQ	R4	R3	R4
+      0x78120009,  //  0006  JMPF	R4	#0011
+      0xB8120400,  //  0007  GETNGBL	R4	K2
+      0x8C100903,  //  0008  GETMET	R4	R4	K3
+      0x60180008,  //  0009  GETGBL	R6	G8
+      0x5C1C0200,  //  000A  MOVE	R7	R1
+      0x7C180200,  //  000B  CALL	R6	1
+      0x001A0806,  //  000C  ADD	R6	K4	R6
+      0x00180D05,  //  000D  ADD	R6	R6	K5
+      0x581C0006,  //  000E  LDCONST	R7	K6
+      0x7C100600,  //  000F  CALL	R4	3
+      0x80000800,  //  0010  RET	0
+      0x88100107,  //  0011  GETMBR	R4	R0	K7
+      0x60140008,  //  0012  GETGBL	R5	G8
+      0x5C180800,  //  0013  MOVE	R6	R4
+      0x7C140200,  //  0014  CALL	R5	1
+      0x5C180600,  //  0015  MOVE	R6	R3
+      0x5C1C0000,  //  0016  MOVE	R7	R0
+      0x5C200800,  //  0017  MOVE	R8	R4
+      0x5C240400,  //  0018  MOVE	R9	R2
+      0x7C180600,  //  0019  CALL	R6	3
+      0x881C0108,  //  001A  GETMBR	R7	R0	K8
+      0x8C1C0F09,  //  001B  GETMET	R7	R7	K9
+      0x5C240C00,  //  001C  MOVE	R9	R6
+      0x7C1C0400,  //  001D  CALL	R7	2
+      0x601C0013,  //  001E  GETGBL	R7	G19
+      0x7C1C0000,  //  001F  CALL	R7	0
+      0x981E1401,  //  0020  SETIDX	R7	K10	R1
+      0x60200010,  //  0021  GETGBL	R8	G16
+      0x8C24050B,  //  0022  GETMET	R9	R2	K11
+      0x7C240200,  //  0023  CALL	R9	1
+      0x7C200200,  //  0024  CALL	R8	1
+      0xA8020004,  //  0025  EXBLK	0	#002B
+      0x5C241000,  //  0026  MOVE	R9	R8
+      0x7C240000,  //  0027  CALL	R9	0
+      0x94280409,  //  0028  GETIDX	R10	R2	R9
+      0x981C120A,  //  0029  SETIDX	R7	R9	R10
+      0x7001FFFA,  //  002A  JMP		#0026
+      0x5820000C,  //  002B  LDCONST	R8	K12
+      0xAC200200,  //  002C  CATCH	R8	1	0
+      0xB0080000,  //  002D  RAISE	2	R0	R0
+      0xB8220400,  //  002E  GETNGBL	R8	K2
+      0x8C201103,  //  002F  GETMET	R8	R8	K3
+      0x60280018,  //  0030  GETGBL	R10	G24
+      0x582C000D,  //  0031  LDCONST	R11	K13
+      0x5C300800,  //  0032  MOVE	R12	R4
+      0x5C340200,  //  0033  MOVE	R13	R1
+      0x8C38010E,  //  0034  GETMET	R14	R0	K14
+      0x5C400400,  //  0035  MOVE	R16	R2
+      0x7C380400,  //  0036  CALL	R14	2
+      0x7C280800,  //  0037  CALL	R10	4
+      0x582C000F,  //  0038  LDCONST	R11	K15
+      0x7C200600,  //  0039  CALL	R8	3
+      0x88200110,  //  003A  GETMBR	R8	R0	K16
+      0x98200A07,  //  003B  SETIDX	R8	R5	R7
+      0x50200200,  //  003C  LDBOOL	R8	1	0
+      0x90022208,  //  003D  SETMBR	R0	K17	R8
+      0x88200107,  //  003E  GETMBR	R8	R0	K7
+      0x00201112,  //  003F  ADD	R8	R8	K18
+      0x90020E08,  //  0040  SETMBR	R0	K7	R8
+      0x8C200113,  //  0041  GETMET	R8	R0	K19
+      0x7C200200,  //  0042  CALL	R8	1
+      0x8C200114,  //  0043  GETMET	R8	R0	K20
+      0x7C200200,  //  0044  CALL	R8	1
+      0x80040800,  //  0045  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_http_remote
+********************************************************************/
+be_local_closure(Matter_Device_register_http_remote,   /* name */
   be_nested_proto(
     9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(http_remotes),
+    /* K1   */  be_nested_str_weak(contains),
+    /* K2   */  be_nested_str_weak(get_timeout),
+    /* K3   */  be_nested_str_weak(set_timeout),
+    /* K4   */  be_nested_str_weak(matter),
+    /* K5   */  be_nested_str_weak(HTTP_remote),
+    /* K6   */  be_nested_str_weak(plugins_config_remotes),
+    /* K7   */  be_nested_str_weak(set_info),
+    }),
+    be_str_weak(register_http_remote),
+    &be_const_str_solidified,
+    ( &(const binstruction[42]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x4C100000,  //  0001  LDNIL	R4
+      0x1C0C0604,  //  0002  EQ	R3	R3	R4
+      0x780E0002,  //  0003  JMPF	R3	#0007
+      0x600C0013,  //  0004  GETGBL	R3	G19
+      0x7C0C0000,  //  0005  CALL	R3	0
+      0x90020003,  //  0006  SETMBR	R0	K0	R3
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x88100100,  //  0008  GETMBR	R4	R0	K0
+      0x8C100901,  //  0009  GETMET	R4	R4	K1
+      0x5C180200,  //  000A  MOVE	R6	R1
+      0x7C100400,  //  000B  CALL	R4	2
+      0x78120009,  //  000C  JMPF	R4	#0017
+      0x88100100,  //  000D  GETMBR	R4	R0	K0
+      0x940C0801,  //  000E  GETIDX	R3	R4	R1
+      0x8C140702,  //  000F  GETMET	R5	R3	K2
+      0x7C140200,  //  0010  CALL	R5	1
+      0x14140405,  //  0011  LT	R5	R2	R5
+      0x78160002,  //  0012  JMPF	R5	#0016
+      0x8C140703,  //  0013  GETMET	R5	R3	K3
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x7C140400,  //  0015  CALL	R5	2
+      0x70020011,  //  0016  JMP		#0029
+      0xB8120800,  //  0017  GETNGBL	R4	K4
+      0x8C100905,  //  0018  GETMET	R4	R4	K5
+      0x5C180000,  //  0019  MOVE	R6	R0
+      0x5C1C0200,  //  001A  MOVE	R7	R1
+      0x5C200400,  //  001B  MOVE	R8	R2
+      0x7C100800,  //  001C  CALL	R4	4
+      0x5C0C0800,  //  001D  MOVE	R3	R4
+      0x88100106,  //  001E  GETMBR	R4	R0	K6
+      0x8C100901,  //  001F  GETMET	R4	R4	K1
+      0x5C180200,  //  0020  MOVE	R6	R1
+      0x7C100400,  //  0021  CALL	R4	2
+      0x78120003,  //  0022  JMPF	R4	#0027
+      0x8C100707,  //  0023  GETMET	R4	R3	K7
+      0x88180106,  //  0024  GETMBR	R6	R0	K6
+      0x94180C01,  //  0025  GETIDX	R6	R6	R1
+      0x7C100400,  //  0026  CALL	R4	2
+      0x88100100,  //  0027  GETMBR	R4	R0	K0
+      0x98100203,  //  0028  SETIDX	R4	R1	R3
+      0x80040600,  //  0029  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_read_sensors_schedule
+********************************************************************/
+be_local_closure(Matter_Device_add_read_sensors_schedule,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -806,37 +1032,29 @@ be_local_closure(Matter_Device_MtrInfo_one,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find_plugin_by_endpoint),
-    /* K1   */  be_nested_str_weak(state_json),
-    /* K2   */  be_nested_str_weak(_X7B_X22MtrInfo_X22_X3A_X25s_X7D),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(publish_result),
-    /* K5   */  be_nested_str_weak(),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(probe_sensor_time),
+    /* K1   */  be_nested_str_weak(probe_sensor_timestamp),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(jitter),
     }),
-    be_str_weak(MtrInfo_one),
+    be_str_weak(add_read_sensors_schedule),
     &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0403,  //  0004  EQ	R3	R2	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80000600,  //  0006  RET	0
-      0x8C0C0501,  //  0007  GETMET	R3	R2	K1
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0x780E0008,  //  0009  JMPF	R3	#0013
-      0x60100018,  //  000A  GETGBL	R4	G24
-      0x58140002,  //  000B  LDCONST	R5	K2
-      0x5C180600,  //  000C  MOVE	R6	R3
-      0x7C100400,  //  000D  CALL	R4	2
-      0xB8160600,  //  000E  GETNGBL	R5	K3
-      0x8C140B04,  //  000F  GETMET	R5	R5	K4
-      0x5C1C0800,  //  0010  MOVE	R7	R4
-      0x58200005,  //  0011  LDCONST	R8	K5
-      0x7C140600,  //  0012  CALL	R5	3
-      0x80000000,  //  0013  RET	0
+    ( &(const binstruction[14]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x1C080403,  //  0002  EQ	R2	R2	R3
+      0x740A0002,  //  0003  JMPT	R2	#0007
+      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x24080401,  //  0005  GT	R2	R2	R1
+      0x780A0005,  //  0006  JMPF	R2	#000D
+      0x90020001,  //  0007  SETMBR	R0	K0	R1
+      0xB80A0400,  //  0008  GETNGBL	R2	K2
+      0x8C080503,  //  0009  GETMET	R2	R2	K3
+      0x5C100200,  //  000A  MOVE	R4	R1
+      0x7C080400,  //  000B  CALL	R2	2
+      0x90020202,  //  000C  SETMBR	R0	K1	R2
+      0x80000000,  //  000D  RET	0
     })
   )
 );
@@ -844,142 +1062,32 @@ be_local_closure(Matter_Device_MtrInfo_one,   /* name */
 
 
 /********************************************************************
-** Solidified function: start_basic_commissioning
+** Solidified function: msg_received
 ********************************************************************/
-be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
+be_local_closure(Matter_Device_msg_received,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
-    8,                          /* argc */
+    9,                          /* nstack */
+    4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
-        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
-        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-    }),
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(commissioning_iterations),
-    /* K4   */  be_nested_str_weak(commissioning_discriminator),
-    /* K5   */  be_nested_str_weak(commissioning_salt),
-    /* K6   */  be_nested_str_weak(commissioning_w0),
-    /* K7   */  be_nested_str_weak(commissioning_L),
-    /* K8   */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K9   */  be_nested_str_weak(wifi),
-    /* K10  */  be_nested_str_weak(up),
-    /* K11  */  be_nested_str_weak(eth),
-    /* K12  */  be_nested_str_weak(mdns_announce_PASE),
-    /* K13  */  be_nested_str_weak(add_rule),
-    /* K14  */  be_nested_str_weak(Wifi_X23Connected),
-    /* K15  */  be_nested_str_weak(Eth_X23Connected),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(msg_received),
     }),
-    be_str_weak(start_basic_commissioning),
+    be_str_weak(msg_received),
     &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0xB8220200,  //  0000  GETNGBL	R8	K1
-      0x8C201102,  //  0001  GETMET	R8	R8	K2
-      0x7C200200,  //  0002  CALL	R8	1
-      0x542603E7,  //  0003  LDINT	R9	1000
-      0x08240209,  //  0004  MUL	R9	R1	R9
-      0x00201009,  //  0005  ADD	R8	R8	R9
-      0x90020008,  //  0006  SETMBR	R0	K0	R8
-      0x90020602,  //  0007  SETMBR	R0	K3	R2
-      0x90020803,  //  0008  SETMBR	R0	K4	R3
-      0x90020A04,  //  0009  SETMBR	R0	K5	R4
-      0x90020C05,  //  000A  SETMBR	R0	K6	R5
-      0x90020E06,  //  000B  SETMBR	R0	K7	R6
-      0x90021007,  //  000C  SETMBR	R0	K8	R7
-      0xB8220200,  //  000D  GETNGBL	R8	K1
-      0x8C201109,  //  000E  GETMET	R8	R8	K9
-      0x7C200200,  //  000F  CALL	R8	1
-      0x9420110A,  //  0010  GETIDX	R8	R8	K10
-      0x74220004,  //  0011  JMPT	R8	#0017
-      0xB8220200,  //  0012  GETNGBL	R8	K1
-      0x8C20110B,  //  0013  GETMET	R8	R8	K11
-      0x7C200200,  //  0014  CALL	R8	1
-      0x9420110A,  //  0015  GETIDX	R8	R8	K10
-      0x78220002,  //  0016  JMPF	R8	#001A
-      0x8C20010C,  //  0017  GETMET	R8	R0	K12
-      0x7C200200,  //  0018  CALL	R8	1
-      0x7002000B,  //  0019  JMP		#0026
-      0xB8220200,  //  001A  GETNGBL	R8	K1
-      0x8C20110D,  //  001B  GETMET	R8	R8	K13
-      0x5828000E,  //  001C  LDCONST	R10	K14
-      0x842C0000,  //  001D  CLOSURE	R11	P0
-      0x5830000C,  //  001E  LDCONST	R12	K12
-      0x7C200800,  //  001F  CALL	R8	4
-      0xB8220200,  //  0020  GETNGBL	R8	K1
-      0x8C20110D,  //  0021  GETMET	R8	R8	K13
-      0x5828000F,  //  0022  LDCONST	R10	K15
-      0x842C0001,  //  0023  CLOSURE	R11	P1
-      0x5830000C,  //  0024  LDCONST	R12	K12
-      0x7C200800,  //  0025  CALL	R8	4
-      0xA0000000,  //  0026  CLOSE	R0
-      0x80000000,  //  0027  RET	0
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x8C100901,  //  0001  GETMET	R4	R4	K1
+      0x5C180200,  //  0002  MOVE	R6	R1
+      0x5C1C0400,  //  0003  MOVE	R7	R2
+      0x5C200600,  //  0004  MOVE	R8	R3
+      0x7C100800,  //  0005  CALL	R4	4
+      0x80040800,  //  0006  RET	1	R4
     })
   )
 );
@@ -1063,9 +1171,270 @@ be_local_closure(Matter_Device_compute_qrcode_content,   /* name */
 
 
 /********************************************************************
-** Solidified function: autoconf_device
+** Solidified function: autoconf_device_map
 ********************************************************************/
-be_local_closure(Matter_Device_autoconf_device,   /* name */
+be_local_closure(Matter_Device_autoconf_device_map,   /* name */
+  be_nested_proto(
+    20,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[38]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(START_ENDPOINT),
+    /* K3   */  be_nested_str_weak(light),
+    /* K4   */  be_nested_str_weak(get),
+    /* K5   */  be_nested_str_weak(find),
+    /* K6   */  be_nested_str_weak(channels),
+    /* K7   */  be_nested_str_weak(),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(type),
+    /* K11  */  be_nested_str_weak(light1),
+    /* K12  */  be_const_int(2),
+    /* K13  */  be_nested_str_weak(light2),
+    /* K14  */  be_nested_str_weak(light3),
+    /* K15  */  be_nested_str_weak(tasmota),
+    /* K16  */  be_nested_str_weak(cmd),
+    /* K17  */  be_nested_str_weak(Status_X2013),
+    /* K18  */  be_nested_str_weak(log),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20Status_X2013_X20_X3D_X20),
+    /* K20  */  be_const_int(3),
+    /* K21  */  be_nested_str_weak(contains),
+    /* K22  */  be_nested_str_weak(StatusSHT),
+    /* K23  */  be_nested_str_weak(SHT),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20_X27_X25s_X27_X20_X3D_X20_X25s),
+    /* K25  */  be_nested_str_weak(Relay1),
+    /* K26  */  be_nested_str_weak(Relay2),
+    /* K27  */  be_nested_str_weak(push),
+    /* K28  */  be_nested_str_weak(MTR_X3A_X20relay1_X3D_X25s_X20relay2_X3D_X25s),
+    /* K29  */  be_nested_str_weak(TiltConfig),
+    /* K30  */  be_nested_str_weak(shutter_X2Btilt),
+    /* K31  */  be_nested_str_weak(shutter),
+    /* K32  */  be_nested_str_weak(get_power),
+    /* K33  */  be_nested_str_weak(relay),
+    /* K34  */  be_nested_str_weak(load),
+    /* K35  */  be_nested_str_weak(read_sensors),
+    /* K36  */  be_nested_str_weak(autoconf_sensors_list),
+    /* K37  */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(autoconf_device_map),
+    &be_const_str_solidified,
+    ( &(const binstruction[199]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x60080013,  //  0001  GETGBL	R2	G19
+      0x7C080000,  //  0002  CALL	R2	0
+      0xB80E0200,  //  0003  GETNGBL	R3	K1
+      0x880C0702,  //  0004  GETMBR	R3	R3	K2
+      0x50100000,  //  0005  LDBOOL	R4	0	0
+      0xA4160600,  //  0006  IMPORT	R5	K3
+      0x8C180B04,  //  0007  GETMET	R6	R5	K4
+      0x7C180200,  //  0008  CALL	R6	1
+      0x4C1C0000,  //  0009  LDNIL	R7
+      0x201C0C07,  //  000A  NE	R7	R6	R7
+      0x781E0024,  //  000B  JMPF	R7	#0031
+      0x601C000C,  //  000C  GETGBL	R7	G12
+      0x8C200D05,  //  000D  GETMET	R8	R6	K5
+      0x58280006,  //  000E  LDCONST	R10	K6
+      0x582C0007,  //  000F  LDCONST	R11	K7
+      0x7C200600,  //  0010  CALL	R8	3
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x24200F08,  //  0012  GT	R8	R7	K8
+      0x7822001C,  //  0013  JMPF	R8	#0031
+      0x1C200F09,  //  0014  EQ	R8	R7	K9
+      0x78220007,  //  0015  JMPF	R8	#001E
+      0x60200008,  //  0016  GETGBL	R8	G8
+      0x5C240600,  //  0017  MOVE	R9	R3
+      0x7C200200,  //  0018  CALL	R8	1
+      0x60240013,  //  0019  GETGBL	R9	G19
+      0x7C240000,  //  001A  CALL	R9	0
+      0x9826150B,  //  001B  SETIDX	R9	K10	K11
+      0x98081009,  //  001C  SETIDX	R2	R8	R9
+      0x70020010,  //  001D  JMP		#002F
+      0x1C200F0C,  //  001E  EQ	R8	R7	K12
+      0x78220007,  //  001F  JMPF	R8	#0028
+      0x60200008,  //  0020  GETGBL	R8	G8
+      0x5C240600,  //  0021  MOVE	R9	R3
+      0x7C200200,  //  0022  CALL	R8	1
+      0x60240013,  //  0023  GETGBL	R9	G19
+      0x7C240000,  //  0024  CALL	R9	0
+      0x9826150D,  //  0025  SETIDX	R9	K10	K13
+      0x98081009,  //  0026  SETIDX	R2	R8	R9
+      0x70020006,  //  0027  JMP		#002F
+      0x60200008,  //  0028  GETGBL	R8	G8
+      0x5C240600,  //  0029  MOVE	R9	R3
+      0x7C200200,  //  002A  CALL	R8	1
+      0x60240013,  //  002B  GETGBL	R9	G19
+      0x7C240000,  //  002C  CALL	R9	0
+      0x9826150E,  //  002D  SETIDX	R9	K10	K14
+      0x98081009,  //  002E  SETIDX	R2	R8	R9
+      0x50100200,  //  002F  LDBOOL	R4	1	0
+      0x000C0709,  //  0030  ADD	R3	R3	K9
+      0xB81E1E00,  //  0031  GETNGBL	R7	K15
+      0x8C1C0F10,  //  0032  GETMET	R7	R7	K16
+      0x58240011,  //  0033  LDCONST	R9	K17
+      0x50280200,  //  0034  LDBOOL	R10	1	0
+      0x7C1C0600,  //  0035  CALL	R7	3
+      0x60200012,  //  0036  GETGBL	R8	G18
+      0x7C200000,  //  0037  CALL	R8	0
+      0xB8261E00,  //  0038  GETNGBL	R9	K15
+      0x8C241312,  //  0039  GETMET	R9	R9	K18
+      0x602C0008,  //  003A  GETGBL	R11	G8
+      0x5C300E00,  //  003B  MOVE	R12	R7
+      0x7C2C0200,  //  003C  CALL	R11	1
+      0x002E260B,  //  003D  ADD	R11	K19	R11
+      0x58300014,  //  003E  LDCONST	R12	K20
+      0x7C240600,  //  003F  CALL	R9	3
+      0x4C240000,  //  0040  LDNIL	R9
+      0x20240E09,  //  0041  NE	R9	R7	R9
+      0x7826004F,  //  0042  JMPF	R9	#0093
+      0x8C240F15,  //  0043  GETMET	R9	R7	K21
+      0x582C0016,  //  0044  LDCONST	R11	K22
+      0x7C240400,  //  0045  CALL	R9	2
+      0x7826004B,  //  0046  JMPF	R9	#0093
+      0x941C0F16,  //  0047  GETIDX	R7	R7	K22
+      0x58240008,  //  0048  LDCONST	R9	K8
+      0x50280200,  //  0049  LDBOOL	R10	1	0
+      0x782A0047,  //  004A  JMPF	R10	#0093
+      0x60280008,  //  004B  GETGBL	R10	G8
+      0x5C2C1200,  //  004C  MOVE	R11	R9
+      0x7C280200,  //  004D  CALL	R10	1
+      0x002A2E0A,  //  004E  ADD	R10	K23	R10
+      0x8C2C0F15,  //  004F  GETMET	R11	R7	K21
+      0x5C341400,  //  0050  MOVE	R13	R10
+      0x7C2C0400,  //  0051  CALL	R11	2
+      0x742E0000,  //  0052  JMPT	R11	#0054
+      0x7002003E,  //  0053  JMP		#0093
+      0x942C0E0A,  //  0054  GETIDX	R11	R7	R10
+      0xB8321E00,  //  0055  GETNGBL	R12	K15
+      0x8C301912,  //  0056  GETMET	R12	R12	K18
+      0x60380018,  //  0057  GETGBL	R14	G24
+      0x583C0018,  //  0058  LDCONST	R15	K24
+      0x5C401400,  //  0059  MOVE	R16	R10
+      0x60440008,  //  005A  GETGBL	R17	G8
+      0x5C481600,  //  005B  MOVE	R18	R11
+      0x7C440200,  //  005C  CALL	R17	1
+      0x7C380600,  //  005D  CALL	R14	3
+      0x583C0014,  //  005E  LDCONST	R15	K20
+      0x7C300600,  //  005F  CALL	R12	3
+      0x8C301705,  //  0060  GETMET	R12	R11	K5
+      0x58380019,  //  0061  LDCONST	R14	K25
+      0x543DFFFE,  //  0062  LDINT	R15	-1
+      0x7C300600,  //  0063  CALL	R12	3
+      0x8C341705,  //  0064  GETMET	R13	R11	K5
+      0x583C001A,  //  0065  LDCONST	R15	K26
+      0x5441FFFE,  //  0066  LDINT	R16	-1
+      0x7C340600,  //  0067  CALL	R13	3
+      0x24381908,  //  0068  GT	R14	R12	K8
+      0x783A0002,  //  0069  JMPF	R14	#006D
+      0x8C38111B,  //  006A  GETMET	R14	R8	K27
+      0x04401909,  //  006B  SUB	R16	R12	K9
+      0x7C380400,  //  006C  CALL	R14	2
+      0x24381B08,  //  006D  GT	R14	R13	K8
+      0x783A0002,  //  006E  JMPF	R14	#0072
+      0x8C38111B,  //  006F  GETMET	R14	R8	K27
+      0x04401B09,  //  0070  SUB	R16	R13	K9
+      0x7C380400,  //  0071  CALL	R14	2
+      0xB83A1E00,  //  0072  GETNGBL	R14	K15
+      0x8C381D12,  //  0073  GETMET	R14	R14	K18
+      0x60400018,  //  0074  GETGBL	R16	G24
+      0x5844001C,  //  0075  LDCONST	R17	K28
+      0x5C481800,  //  0076  MOVE	R18	R12
+      0x5C4C1A00,  //  0077  MOVE	R19	R13
+      0x7C400600,  //  0078  CALL	R16	3
+      0x58440014,  //  0079  LDCONST	R17	K20
+      0x7C380600,  //  007A  CALL	R14	3
+      0x8C381705,  //  007B  GETMET	R14	R11	K5
+      0x5840001D,  //  007C  LDCONST	R16	K29
+      0x7C380400,  //  007D  CALL	R14	2
+      0x783A0002,  //  007E  JMPF	R14	#0082
+      0x943C1D0C,  //  007F  GETIDX	R15	R14	K12
+      0x243C1F08,  //  0080  GT	R15	R15	K8
+      0x743E0000,  //  0081  JMPT	R15	#0083
+      0x503C0001,  //  0082  LDBOOL	R15	0	1
+      0x503C0200,  //  0083  LDBOOL	R15	1	0
+      0x60400008,  //  0084  GETGBL	R16	G8
+      0x5C440600,  //  0085  MOVE	R17	R3
+      0x7C400200,  //  0086  CALL	R16	1
+      0x60440013,  //  0087  GETGBL	R17	G19
+      0x7C440000,  //  0088  CALL	R17	0
+      0x783E0001,  //  0089  JMPF	R15	#008C
+      0x5848001E,  //  008A  LDCONST	R18	K30
+      0x70020000,  //  008B  JMP		#008D
+      0x5848001F,  //  008C  LDCONST	R18	K31
+      0x98461412,  //  008D  SETIDX	R17	K10	R18
+      0x98463E09,  //  008E  SETIDX	R17	K31	R9
+      0x98082011,  //  008F  SETIDX	R2	R16	R17
+      0x000C0709,  //  0090  ADD	R3	R3	K9
+      0x00241309,  //  0091  ADD	R9	R9	K9
+      0x7001FFB5,  //  0092  JMP		#0049
+      0x6024000C,  //  0093  GETGBL	R9	G12
+      0xB82A1E00,  //  0094  GETNGBL	R10	K15
+      0x8C281520,  //  0095  GETMET	R10	R10	K32
+      0x7C280200,  //  0096  CALL	R10	1
+      0x7C240200,  //  0097  CALL	R9	1
+      0x58280008,  //  0098  LDCONST	R10	K8
+      0x78120000,  //  0099  JMPF	R4	#009B
+      0x04241309,  //  009A  SUB	R9	R9	K9
+      0x142C1409,  //  009B  LT	R11	R10	R9
+      0x782E0011,  //  009C  JMPF	R11	#00AF
+      0x8C2C1105,  //  009D  GETMET	R11	R8	K5
+      0x5C341400,  //  009E  MOVE	R13	R10
+      0x7C2C0400,  //  009F  CALL	R11	2
+      0x4C300000,  //  00A0  LDNIL	R12
+      0x1C2C160C,  //  00A1  EQ	R11	R11	R12
+      0x782E0009,  //  00A2  JMPF	R11	#00AD
+      0x602C0008,  //  00A3  GETGBL	R11	G8
+      0x5C300600,  //  00A4  MOVE	R12	R3
+      0x7C2C0200,  //  00A5  CALL	R11	1
+      0x60300013,  //  00A6  GETGBL	R12	G19
+      0x7C300000,  //  00A7  CALL	R12	0
+      0x98321521,  //  00A8  SETIDX	R12	K10	K33
+      0x00341509,  //  00A9  ADD	R13	R10	K9
+      0x9832420D,  //  00AA  SETIDX	R12	K33	R13
+      0x9808160C,  //  00AB  SETIDX	R2	R11	R12
+      0x000C0709,  //  00AC  ADD	R3	R3	K9
+      0x00281509,  //  00AD  ADD	R10	R10	K9
+      0x7001FFEB,  //  00AE  JMP		#009B
+      0x8C2C0322,  //  00AF  GETMET	R11	R1	K34
+      0xB8361E00,  //  00B0  GETNGBL	R13	K15
+      0x8C341B23,  //  00B1  GETMET	R13	R13	K35
+      0x7C340200,  //  00B2  CALL	R13	1
+      0x7C2C0400,  //  00B3  CALL	R11	2
+      0x8C300124,  //  00B4  GETMET	R12	R0	K36
+      0x5C381600,  //  00B5  MOVE	R14	R11
+      0x7C300400,  //  00B6  CALL	R12	2
+      0x60340010,  //  00B7  GETGBL	R13	G16
+      0x5C381800,  //  00B8  MOVE	R14	R12
+      0x7C340200,  //  00B9  CALL	R13	1
+      0xA8020007,  //  00BA  EXBLK	0	#00C3
+      0x5C381A00,  //  00BB  MOVE	R14	R13
+      0x7C380000,  //  00BC  CALL	R14	0
+      0x603C0008,  //  00BD  GETGBL	R15	G8
+      0x5C400600,  //  00BE  MOVE	R16	R3
+      0x7C3C0200,  //  00BF  CALL	R15	1
+      0x98081E0E,  //  00C0  SETIDX	R2	R15	R14
+      0x000C0709,  //  00C1  ADD	R3	R3	K9
+      0x7001FFF7,  //  00C2  JMP		#00BB
+      0x58340025,  //  00C3  LDCONST	R13	K37
+      0xAC340200,  //  00C4  CATCH	R13	1	0
+      0xB0080000,  //  00C5  RAISE	2	R0	R0
+      0x80040400,  //  00C6  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_announce_op_discovery_all_fabrics
+********************************************************************/
+be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
@@ -1075,149 +1444,39 @@ be_local_closure(Matter_Device_autoconf_device,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(plugins),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(plugins_persist),
-    /* K4   */  be_nested_str_weak(plugins_config),
-    /* K5   */  be_nested_str_weak(autoconf_device_map),
-    /* K6   */  be_nested_str_weak(plugins_config_remotes),
-    /* K7   */  be_nested_str_weak(adjust_next_ep),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(_instantiate_plugins_from_config),
-    /* K13  */  be_nested_str_weak(sessions),
-    /* K14  */  be_nested_str_weak(count_active_fabrics),
-    /* K15  */  be_nested_str_weak(save_param),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(active_fabrics),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(mdns_announce_op_discovery),
+    /* K5   */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(autoconf_device),
+    be_str_weak(mdns_announce_op_discovery_all_fabrics),
     &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+    ( &(const binstruction[22]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
       0x7C080200,  //  0003  CALL	R2	1
-      0x24080502,  //  0004  GT	R2	R2	K2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x80000400,  //  0006  RET	0
-      0x88080103,  //  0007  GETMBR	R2	R0	K3
-      0x740A000F,  //  0008  JMPT	R2	#0019
-      0x8C080105,  //  0009  GETMET	R2	R0	K5
-      0x7C080200,  //  000A  CALL	R2	1
-      0x90020802,  //  000B  SETMBR	R0	K4	R2
-      0x60080013,  //  000C  GETGBL	R2	G19
-      0x7C080000,  //  000D  CALL	R2	0
-      0x90020C02,  //  000E  SETMBR	R0	K6	R2
-      0x8C080107,  //  000F  GETMET	R2	R0	K7
-      0x7C080200,  //  0010  CALL	R2	1
-      0xB80A1000,  //  0011  GETNGBL	R2	K8
-      0x8C080509,  //  0012  GETMET	R2	R2	K9
-      0x60100008,  //  0013  GETGBL	R4	G8
-      0x88140104,  //  0014  GETMBR	R5	R0	K4
-      0x7C100200,  //  0015  CALL	R4	1
-      0x00121404,  //  0016  ADD	R4	K10	R4
-      0x5814000B,  //  0017  LDCONST	R5	K11
-      0x7C080600,  //  0018  CALL	R2	3
-      0x8C08010C,  //  0019  GETMET	R2	R0	K12
-      0x88100104,  //  001A  GETMBR	R4	R0	K4
-      0x7C080400,  //  001B  CALL	R2	2
-      0x88080103,  //  001C  GETMBR	R2	R0	K3
-      0x740A0008,  //  001D  JMPT	R2	#0027
-      0x8808010D,  //  001E  GETMBR	R2	R0	K13
-      0x8C08050E,  //  001F  GETMET	R2	R2	K14
-      0x7C080200,  //  0020  CALL	R2	1
-      0x24080502,  //  0021  GT	R2	R2	K2
-      0x780A0003,  //  0022  JMPF	R2	#0027
-      0x50080200,  //  0023  LDBOOL	R2	1	0
-      0x90020602,  //  0024  SETMBR	R0	K3	R2
-      0x8C08010F,  //  0025  GETMET	R2	R0	K15
-      0x7C080200,  //  0026  CALL	R2	1
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: sort_distinct
-********************************************************************/
-be_local_closure(Matter_Device_sort_distinct,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_nested_str_weak(remove),
-    }),
-    be_str_weak(sort_distinct),
-    &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080010,  //  0001  GETGBL	R2	G16
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x040C0701,  //  0005  SUB	R3	R3	K1
-      0x400E0203,  //  0006  CONNECT	R3	K1	R3
-      0x7C080200,  //  0007  CALL	R2	1
-      0xA8020010,  //  0008  EXBLK	0	#001A
-      0x5C0C0400,  //  0009  MOVE	R3	R2
-      0x7C0C0000,  //  000A  CALL	R3	0
-      0x94100003,  //  000B  GETIDX	R4	R0	R3
-      0x5C140600,  //  000C  MOVE	R5	R3
-      0x24180B02,  //  000D  GT	R6	R5	K2
-      0x781A0008,  //  000E  JMPF	R6	#0018
-      0x04180B01,  //  000F  SUB	R6	R5	K1
-      0x94180006,  //  0010  GETIDX	R6	R0	R6
-      0x24180C04,  //  0011  GT	R6	R6	R4
-      0x781A0004,  //  0012  JMPF	R6	#0018
-      0x04180B01,  //  0013  SUB	R6	R5	K1
-      0x94180006,  //  0014  GETIDX	R6	R0	R6
-      0x98000A06,  //  0015  SETIDX	R0	R5	R6
-      0x04140B01,  //  0016  SUB	R5	R5	K1
-      0x7001FFF4,  //  0017  JMP		#000D
-      0x98000A04,  //  0018  SETIDX	R0	R5	R4
-      0x7001FFEE,  //  0019  JMP		#0009
-      0x58080003,  //  001A  LDCONST	R2	K3
-      0xAC080200,  //  001B  CATCH	R2	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x58080001,  //  001D  LDCONST	R2	K1
-      0x600C000C,  //  001E  GETGBL	R3	G12
-      0x5C100000,  //  001F  MOVE	R4	R0
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x180C0701,  //  0021  LE	R3	R3	K1
-      0x780E0000,  //  0022  JMPF	R3	#0024
-      0x80040000,  //  0023  RET	1	R0
-      0x940C0102,  //  0024  GETIDX	R3	R0	K2
-      0x6010000C,  //  0025  GETGBL	R4	G12
-      0x5C140000,  //  0026  MOVE	R5	R0
-      0x7C100200,  //  0027  CALL	R4	1
-      0x14100404,  //  0028  LT	R4	R2	R4
-      0x78120009,  //  0029  JMPF	R4	#0034
-      0x94100002,  //  002A  GETIDX	R4	R0	R2
-      0x1C100803,  //  002B  EQ	R4	R4	R3
-      0x78120003,  //  002C  JMPF	R4	#0031
-      0x8C100104,  //  002D  GETMET	R4	R0	K4
-      0x5C180400,  //  002E  MOVE	R6	R2
-      0x7C100400,  //  002F  CALL	R4	2
-      0x70020001,  //  0030  JMP		#0033
-      0x940C0002,  //  0031  GETIDX	R3	R0	R2
-      0x00080501,  //  0032  ADD	R2	R2	K1
-      0x7001FFF0,  //  0033  JMP		#0025
-      0x80040000,  //  0034  RET	1	R0
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000B,  //  0005  EXBLK	0	#0012
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x780E0005,  //  000A  JMPF	R3	#0011
+      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x780E0002,  //  000D  JMPF	R3	#0011
+      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x7001FFF3,  //  0011  JMP		#0006
+      0x58040005,  //  0012  LDCONST	R1	K5
+      0xAC040200,  //  0013  CATCH	R1	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x80000000,  //  0015  RET	0
     })
   )
 );
@@ -1535,11 +1794,276 @@ be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
 
 
 /********************************************************************
-** Solidified function: add_read_sensors_schedule
+** Solidified function: register_commands
 ********************************************************************/
-be_local_closure(Matter_Device_add_read_sensors_schedule,   /* name */
+be_local_closure(Matter_Device_register_commands,   /* name */
   be_nested_proto(
     5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 3]) {
+      be_nested_proto(
+        10,                          /* nstack */
+        4,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(MtrJoin),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 8]) {  /* code */
+          0x68100000,  //  0000  GETUPV	R4	U0
+          0x8C100900,  //  0001  GETMET	R4	R4	K0
+          0x5C180000,  //  0002  MOVE	R6	R0
+          0x5C1C0200,  //  0003  MOVE	R7	R1
+          0x5C200400,  //  0004  MOVE	R8	R2
+          0x5C240600,  //  0005  MOVE	R9	R3
+          0x7C100A00,  //  0006  CALL	R4	5
+          0x80040800,  //  0007  RET	1	R4
+        })
+      ),
+      be_nested_proto(
+        10,                          /* nstack */
+        4,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(MtrUpdate),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 8]) {  /* code */
+          0x68100000,  //  0000  GETUPV	R4	U0
+          0x8C100900,  //  0001  GETMET	R4	R4	K0
+          0x5C180000,  //  0002  MOVE	R6	R0
+          0x5C1C0200,  //  0003  MOVE	R7	R1
+          0x5C200400,  //  0004  MOVE	R8	R2
+          0x5C240600,  //  0005  MOVE	R9	R3
+          0x7C100A00,  //  0006  CALL	R4	5
+          0x80040800,  //  0007  RET	1	R4
+        })
+      ),
+      be_nested_proto(
+        10,                          /* nstack */
+        4,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(MtrInfo),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 8]) {  /* code */
+          0x68100000,  //  0000  GETUPV	R4	U0
+          0x8C100900,  //  0001  GETMET	R4	R4	K0
+          0x5C180000,  //  0002  MOVE	R6	R0
+          0x5C1C0200,  //  0003  MOVE	R7	R1
+          0x5C200400,  //  0004  MOVE	R8	R2
+          0x5C240600,  //  0005  MOVE	R9	R3
+          0x7C100A00,  //  0006  CALL	R4	5
+          0x80040800,  //  0007  RET	1	R4
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(add_cmd),
+    /* K2   */  be_nested_str_weak(MtrJoin),
+    /* K3   */  be_nested_str_weak(MtrUpdate),
+    /* K4   */  be_nested_str_weak(MtrInfo),
+    }),
+    be_str_weak(register_commands),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x580C0002,  //  0002  LDCONST	R3	K2
+      0x84100000,  //  0003  CLOSURE	R4	P0
+      0x7C040600,  //  0004  CALL	R1	3
+      0xB8060000,  //  0005  GETNGBL	R1	K0
+      0x8C040301,  //  0006  GETMET	R1	R1	K1
+      0x580C0003,  //  0007  LDCONST	R3	K3
+      0x84100001,  //  0008  CLOSURE	R4	P1
+      0x7C040600,  //  0009  CALL	R1	3
+      0xB8060000,  //  000A  GETNGBL	R1	K0
+      0x8C040301,  //  000B  GETMET	R1	R1	K1
+      0x580C0004,  //  000C  LDCONST	R3	K4
+      0x84100002,  //  000D  CLOSURE	R4	P2
+      0x7C040600,  //  000E  CALL	R1	3
+      0xA0000000,  //  000F  CLOSE	R0
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_remotes_info
+********************************************************************/
+be_local_closure(Matter_Device_update_remotes_info,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(http_remotes),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(get_info),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(stop_iteration),
+    /* K5   */  be_nested_str_weak(plugins_config_remotes),
+    }),
+    be_str_weak(update_remotes_info),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x60040013,  //  0000  GETGBL	R1	G19
+      0x7C040000,  //  0001  CALL	R1	0
+      0x88080100,  //  0002  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x20080403,  //  0004  NE	R2	R2	R3
+      0x780A0018,  //  0005  JMPF	R2	#001F
+      0x60080010,  //  0006  GETGBL	R2	G16
+      0x880C0100,  //  0007  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0008  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x7C080200,  //  000A  CALL	R2	1
+      0xA802000F,  //  000B  EXBLK	0	#001C
+      0x5C0C0400,  //  000C  MOVE	R3	R2
+      0x7C0C0000,  //  000D  CALL	R3	0
+      0x88100100,  //  000E  GETMBR	R4	R0	K0
+      0x94100803,  //  000F  GETIDX	R4	R4	R3
+      0x8C100902,  //  0010  GETMET	R4	R4	K2
+      0x7C100200,  //  0011  CALL	R4	1
+      0x4C140000,  //  0012  LDNIL	R5
+      0x20140805,  //  0013  NE	R5	R4	R5
+      0x78160005,  //  0014  JMPF	R5	#001B
+      0x6014000C,  //  0015  GETGBL	R5	G12
+      0x5C180800,  //  0016  MOVE	R6	R4
+      0x7C140200,  //  0017  CALL	R5	1
+      0x24140B03,  //  0018  GT	R5	R5	K3
+      0x78160000,  //  0019  JMPF	R5	#001B
+      0x98040604,  //  001A  SETIDX	R1	R3	R4
+      0x7001FFEF,  //  001B  JMP		#000C
+      0x58080004,  //  001C  LDCONST	R2	K4
+      0xAC080200,  //  001D  CATCH	R2	1	0
+      0xB0080000,  //  001E  RAISE	2	R0	R0
+      0x90020A01,  //  001F  SETMBR	R0	K5	R1
+      0x80040200,  //  0020  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _compute_pbkdf
+********************************************************************/
+be_local_closure(Matter_Device__compute_pbkdf,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(add),
+    /* K2   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
+    /* K3   */  be_nested_str_weak(derive),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(root_w0),
+    /* K6   */  be_nested_str_weak(EC_P256),
+    /* K7   */  be_nested_str_weak(mod),
+    /* K8   */  be_nested_str_weak(root_L),
+    /* K9   */  be_nested_str_weak(public_key),
+    }),
+    be_str_weak(_compute_pbkdf),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0xA4120000,  //  0000  IMPORT	R4	K0
+      0x60140015,  //  0001  GETGBL	R5	G21
+      0x7C140000,  //  0002  CALL	R5	0
+      0x8C140B01,  //  0003  GETMET	R5	R5	K1
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x54220003,  //  0005  LDINT	R8	4
+      0x7C140600,  //  0006  CALL	R5	3
+      0x8C180902,  //  0007  GETMET	R6	R4	K2
+      0x7C180200,  //  0008  CALL	R6	1
+      0x8C180D03,  //  0009  GETMET	R6	R6	K3
+      0x5C200A00,  //  000A  MOVE	R8	R5
+      0x5C240600,  //  000B  MOVE	R9	R3
+      0x5C280400,  //  000C  MOVE	R10	R2
+      0x542E004F,  //  000D  LDINT	R11	80
+      0x7C180A00,  //  000E  CALL	R6	5
+      0x541E0026,  //  000F  LDINT	R7	39
+      0x401E0807,  //  0010  CONNECT	R7	K4	R7
+      0x941C0C07,  //  0011  GETIDX	R7	R6	R7
+      0x54220027,  //  0012  LDINT	R8	40
+      0x5426004E,  //  0013  LDINT	R9	79
+      0x40201009,  //  0014  CONNECT	R8	R8	R9
+      0x94200C08,  //  0015  GETIDX	R8	R6	R8
+      0x8C240906,  //  0016  GETMET	R9	R4	K6
+      0x7C240200,  //  0017  CALL	R9	1
+      0x8C241307,  //  0018  GETMET	R9	R9	K7
+      0x5C2C0E00,  //  0019  MOVE	R11	R7
+      0x7C240400,  //  001A  CALL	R9	2
+      0x90020A09,  //  001B  SETMBR	R0	K5	R9
+      0x8C240906,  //  001C  GETMET	R9	R4	K6
+      0x7C240200,  //  001D  CALL	R9	1
+      0x8C241307,  //  001E  GETMET	R9	R9	K7
+      0x5C2C1000,  //  001F  MOVE	R11	R8
+      0x7C240400,  //  0020  CALL	R9	2
+      0x8C280906,  //  0021  GETMET	R10	R4	K6
+      0x7C280200,  //  0022  CALL	R10	1
+      0x8C281509,  //  0023  GETMET	R10	R10	K9
+      0x5C301200,  //  0024  MOVE	R12	R9
+      0x7C280400,  //  0025  CALL	R10	2
+      0x9002100A,  //  0026  SETMBR	R0	K8	R10
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_plugin_by_friendly_name
+********************************************************************/
+be_local_closure(Matter_Device_find_plugin_by_friendly_name,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1548,28 +2072,312 @@ be_local_closure(Matter_Device_add_read_sensors_schedule,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(probe_sensor_time),
-    /* K1   */  be_nested_str_weak(probe_sensor_timestamp),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(jitter),
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(plugins),
+    /* K2   */  be_nested_str_weak(get_name),
+    /* K3   */  be_const_int(1),
     }),
-    be_str_weak(add_read_sensors_schedule),
+    be_str_weak(find_plugin_by_friendly_name),
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x1C080403,  //  0002  EQ	R2	R2	R3
-      0x740A0002,  //  0003  JMPT	R2	#0007
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x24080401,  //  0005  GT	R2	R2	R1
-      0x780A0005,  //  0006  JMPF	R2	#000D
-      0x90020001,  //  0007  SETMBR	R0	K0	R1
-      0xB80A0400,  //  0008  GETNGBL	R2	K2
-      0x8C080503,  //  0009  GETMET	R2	R2	K3
-      0x5C100200,  //  000A  MOVE	R4	R1
-      0x7C080400,  //  000B  CALL	R2	2
-      0x90020202,  //  000C  SETMBR	R0	K1	R2
-      0x80000000,  //  000D  RET	0
+    ( &(const binstruction[35]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x740A0004,  //  0002  JMPT	R2	#0008
+      0x6008000C,  //  0003  GETGBL	R2	G12
+      0x5C0C0200,  //  0004  MOVE	R3	R1
+      0x7C080200,  //  0005  CALL	R2	1
+      0x1C080500,  //  0006  EQ	R2	R2	K0
+      0x780A0001,  //  0007  JMPF	R2	#000A
+      0x4C080000,  //  0008  LDNIL	R2
+      0x80040400,  //  0009  RET	1	R2
+      0x58080000,  //  000A  LDCONST	R2	K0
+      0x600C000C,  //  000B  GETGBL	R3	G12
+      0x88100101,  //  000C  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x140C0403,  //  000E  LT	R3	R2	R3
+      0x780E0010,  //  000F  JMPF	R3	#0021
+      0x880C0101,  //  0010  GETMBR	R3	R0	K1
+      0x940C0602,  //  0011  GETIDX	R3	R3	R2
+      0x8C100702,  //  0012  GETMET	R4	R3	K2
+      0x7C100200,  //  0013  CALL	R4	1
+      0x4C140000,  //  0014  LDNIL	R5
+      0x20140805,  //  0015  NE	R5	R4	R5
+      0x78160007,  //  0016  JMPF	R5	#001F
+      0x6014000C,  //  0017  GETGBL	R5	G12
+      0x5C180800,  //  0018  MOVE	R6	R4
+      0x7C140200,  //  0019  CALL	R5	1
+      0x24140B00,  //  001A  GT	R5	R5	K0
+      0x78160002,  //  001B  JMPF	R5	#001F
+      0x1C140801,  //  001C  EQ	R5	R4	R1
+      0x78160000,  //  001D  JMPF	R5	#001F
+      0x80040600,  //  001E  RET	1	R3
+      0x00080503,  //  001F  ADD	R2	R2	K3
+      0x7001FFE9,  //  0020  JMP		#000B
+      0x4C0C0000,  //  0021  LDNIL	R3
+      0x80040600,  //  0022  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clean_remotes
+********************************************************************/
+be_local_closure(Matter_Device_clean_remotes,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(introspect),
+    /* K1   */  be_nested_str_weak(http_remotes),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_nested_str_weak(plugins),
+    /* K5   */  be_nested_str_weak(get),
+    /* K6   */  be_nested_str_weak(http_remote),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(keys),
+    /* K10  */  be_nested_str_weak(push),
+    /* K11  */  be_nested_str_weak(tasmota),
+    /* K12  */  be_nested_str_weak(log),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
+    /* K14  */  be_nested_str_weak(addr),
+    /* K15  */  be_const_int(3),
+    /* K16  */  be_nested_str_weak(close),
+    /* K17  */  be_nested_str_weak(remove),
+    }),
+    be_str_weak(clean_remotes),
+    &be_const_str_solidified,
+    ( &(const binstruction[81]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x780A004C,  //  0002  JMPF	R2	#0050
+      0x60080013,  //  0003  GETGBL	R2	G19
+      0x7C080000,  //  0004  CALL	R2	0
+      0x600C0010,  //  0005  GETGBL	R3	G16
+      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0xA8020003,  //  0008  EXBLK	0	#000D
+      0x5C100600,  //  0009  MOVE	R4	R3
+      0x7C100000,  //  000A  CALL	R4	0
+      0x98080902,  //  000B  SETIDX	R2	R4	K2
+      0x7001FFFB,  //  000C  JMP		#0009
+      0x580C0003,  //  000D  LDCONST	R3	K3
+      0xAC0C0200,  //  000E  CATCH	R3	1	0
+      0xB0080000,  //  000F  RAISE	2	R0	R0
+      0x600C0010,  //  0010  GETGBL	R3	G16
+      0x88100104,  //  0011  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  0012  CALL	R3	1
+      0xA802000F,  //  0013  EXBLK	0	#0024
+      0x5C100600,  //  0014  MOVE	R4	R3
+      0x7C100000,  //  0015  CALL	R4	0
+      0x8C140305,  //  0016  GETMET	R5	R1	K5
+      0x5C1C0800,  //  0017  MOVE	R7	R4
+      0x58200006,  //  0018  LDCONST	R8	K6
+      0x7C140600,  //  0019  CALL	R5	3
+      0x4C180000,  //  001A  LDNIL	R6
+      0x20180A06,  //  001B  NE	R6	R5	R6
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C180507,  //  001D  GETMET	R6	R2	K7
+      0x5C200A00,  //  001E  MOVE	R8	R5
+      0x58240002,  //  001F  LDCONST	R9	K2
+      0x7C180600,  //  0020  CALL	R6	3
+      0x00180D08,  //  0021  ADD	R6	R6	K8
+      0x98080A06,  //  0022  SETIDX	R2	R5	R6
+      0x7001FFEF,  //  0023  JMP		#0014
+      0x580C0003,  //  0024  LDCONST	R3	K3
+      0xAC0C0200,  //  0025  CATCH	R3	1	0
+      0xB0080000,  //  0026  RAISE	2	R0	R0
+      0x600C0012,  //  0027  GETGBL	R3	G18
+      0x7C0C0000,  //  0028  CALL	R3	0
+      0x60100010,  //  0029  GETGBL	R4	G16
+      0x8C140509,  //  002A  GETMET	R5	R2	K9
+      0x7C140200,  //  002B  CALL	R5	1
+      0x7C100200,  //  002C  CALL	R4	1
+      0xA8020008,  //  002D  EXBLK	0	#0037
+      0x5C140800,  //  002E  MOVE	R5	R4
+      0x7C140000,  //  002F  CALL	R5	0
+      0x94180405,  //  0030  GETIDX	R6	R2	R5
+      0x1C180D02,  //  0031  EQ	R6	R6	K2
+      0x781A0002,  //  0032  JMPF	R6	#0036
+      0x8C18070A,  //  0033  GETMET	R6	R3	K10
+      0x5C200A00,  //  0034  MOVE	R8	R5
+      0x7C180400,  //  0035  CALL	R6	2
+      0x7001FFF6,  //  0036  JMP		#002E
+      0x58100003,  //  0037  LDCONST	R4	K3
+      0xAC100200,  //  0038  CATCH	R4	1	0
+      0xB0080000,  //  0039  RAISE	2	R0	R0
+      0x60100010,  //  003A  GETGBL	R4	G16
+      0x5C140600,  //  003B  MOVE	R5	R3
+      0x7C100200,  //  003C  CALL	R4	1
+      0xA802000E,  //  003D  EXBLK	0	#004D
+      0x5C140800,  //  003E  MOVE	R5	R4
+      0x7C140000,  //  003F  CALL	R5	0
+      0xB81A1600,  //  0040  GETNGBL	R6	K11
+      0x8C180D0C,  //  0041  GETMET	R6	R6	K12
+      0x88200B0E,  //  0042  GETMBR	R8	R5	K14
+      0x00221A08,  //  0043  ADD	R8	K13	R8
+      0x5824000F,  //  0044  LDCONST	R9	K15
+      0x7C180600,  //  0045  CALL	R6	3
+      0x8C180B10,  //  0046  GETMET	R6	R5	K16
+      0x7C180200,  //  0047  CALL	R6	1
+      0x88180101,  //  0048  GETMBR	R6	R0	K1
+      0x8C180D11,  //  0049  GETMET	R6	R6	K17
+      0x88200B0E,  //  004A  GETMBR	R8	R5	K14
+      0x7C180400,  //  004B  CALL	R6	2
+      0x7001FFF0,  //  004C  JMP		#003E
+      0x58100003,  //  004D  LDCONST	R4	K3
+      0xAC100200,  //  004E  CATCH	R4	1	0
+      0xB0080000,  //  004F  RAISE	2	R0	R0
+      0x80000000,  //  0050  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: compute_manual_pairing_code
+********************************************************************/
+be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(root_discriminator),
+    /* K1   */  be_nested_str_weak(root_passcode),
+    /* K2   */  be_nested_str_weak(_X251i_X2505i_X2504i),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(Verhoeff),
+    /* K5   */  be_nested_str_weak(checksum),
+    }),
+    be_str_weak(compute_manual_pairing_code),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x540A0FFE,  //  0001  LDINT	R2	4095
+      0x2C040202,  //  0002  AND	R1	R1	R2
+      0x540A0009,  //  0003  LDINT	R2	10
+      0x3C040202,  //  0004  SHR	R1	R1	R2
+      0x88080100,  //  0005  GETMBR	R2	R0	K0
+      0x540E02FF,  //  0006  LDINT	R3	768
+      0x2C080403,  //  0007  AND	R2	R2	R3
+      0x540E0005,  //  0008  LDINT	R3	6
+      0x38080403,  //  0009  SHL	R2	R2	R3
+      0x880C0101,  //  000A  GETMBR	R3	R0	K1
+      0x54123FFE,  //  000B  LDINT	R4	16383
+      0x2C0C0604,  //  000C  AND	R3	R3	R4
+      0x30080403,  //  000D  OR	R2	R2	R3
+      0x880C0101,  //  000E  GETMBR	R3	R0	K1
+      0x5412000D,  //  000F  LDINT	R4	14
+      0x3C0C0604,  //  0010  SHR	R3	R3	R4
+      0x60100018,  //  0011  GETGBL	R4	G24
+      0x58140002,  //  0012  LDCONST	R5	K2
+      0x5C180200,  //  0013  MOVE	R6	R1
+      0x5C1C0400,  //  0014  MOVE	R7	R2
+      0x5C200600,  //  0015  MOVE	R8	R3
+      0x7C100800,  //  0016  CALL	R4	4
+      0xB8160600,  //  0017  GETNGBL	R5	K3
+      0x88140B04,  //  0018  GETMBR	R5	R5	K4
+      0x8C140B05,  //  0019  GETMET	R5	R5	K5
+      0x5C1C0800,  //  001A  MOVE	R7	R4
+      0x7C140400,  //  001B  CALL	R5	2
+      0x00100805,  //  001C  ADD	R4	R4	R5
+      0x80040800,  //  001D  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: autoconf_device
+********************************************************************/
+be_local_closure(Matter_Device_autoconf_device,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(plugins),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(plugins_persist),
+    /* K4   */  be_nested_str_weak(plugins_config),
+    /* K5   */  be_nested_str_weak(autoconf_device_map),
+    /* K6   */  be_nested_str_weak(plugins_config_remotes),
+    /* K7   */  be_nested_str_weak(adjust_next_ep),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(log),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(_instantiate_plugins_from_config),
+    /* K13  */  be_nested_str_weak(sessions),
+    /* K14  */  be_nested_str_weak(count_active_fabrics),
+    /* K15  */  be_nested_str_weak(save_param),
+    }),
+    be_str_weak(autoconf_device),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x24080502,  //  0004  GT	R2	R2	K2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x80000400,  //  0006  RET	0
+      0x88080103,  //  0007  GETMBR	R2	R0	K3
+      0x740A000F,  //  0008  JMPT	R2	#0019
+      0x8C080105,  //  0009  GETMET	R2	R0	K5
+      0x7C080200,  //  000A  CALL	R2	1
+      0x90020802,  //  000B  SETMBR	R0	K4	R2
+      0x60080013,  //  000C  GETGBL	R2	G19
+      0x7C080000,  //  000D  CALL	R2	0
+      0x90020C02,  //  000E  SETMBR	R0	K6	R2
+      0x8C080107,  //  000F  GETMET	R2	R0	K7
+      0x7C080200,  //  0010  CALL	R2	1
+      0xB80A1000,  //  0011  GETNGBL	R2	K8
+      0x8C080509,  //  0012  GETMET	R2	R2	K9
+      0x60100008,  //  0013  GETGBL	R4	G8
+      0x88140104,  //  0014  GETMBR	R5	R0	K4
+      0x7C100200,  //  0015  CALL	R4	1
+      0x00121404,  //  0016  ADD	R4	K10	R4
+      0x5814000B,  //  0017  LDCONST	R5	K11
+      0x7C080600,  //  0018  CALL	R2	3
+      0x8C08010C,  //  0019  GETMET	R2	R0	K12
+      0x88100104,  //  001A  GETMBR	R4	R0	K4
+      0x7C080400,  //  001B  CALL	R2	2
+      0x88080103,  //  001C  GETMBR	R2	R0	K3
+      0x740A0008,  //  001D  JMPT	R2	#0027
+      0x8808010D,  //  001E  GETMBR	R2	R0	K13
+      0x8C08050E,  //  001F  GETMET	R2	R2	K14
+      0x7C080200,  //  0020  CALL	R2	1
+      0x24080502,  //  0021  GT	R2	R2	K2
+      0x780A0003,  //  0022  JMPF	R2	#0027
+      0x50080200,  //  0023  LDBOOL	R2	1	0
+      0x90020602,  //  0024  SETMBR	R0	K3	R2
+      0x8C08010F,  //  0025  GETMET	R2	R0	K15
+      0x7C080200,  //  0026  CALL	R2	1
+      0x80000000,  //  0027  RET	0
     })
   )
 );
@@ -1621,6 +2429,503 @@ be_local_closure(Matter_Device_attribute_updated,   /* name */
       0x5C240800,  //  000F  MOVE	R9	R4
       0x7C180600,  //  0010  CALL	R6	3
       0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_before_restart
+********************************************************************/
+be_local_closure(Matter_Device_save_before_restart,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K1   */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
+    }),
+    be_str_weak(save_before_restart),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x7C040200,  //  0003  CALL	R1	1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_root_commissioning_open
+********************************************************************/
+be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    /* K1   */  be_nested_str_weak(commissioning_admin_fabric),
+    }),
+    be_str_weak(is_root_commissioning_open),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060003,  //  0003  JMPF	R1	#0008
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x4C080000,  //  0005  LDNIL	R2
+      0x1C040202,  //  0006  EQ	R1	R1	R2
+      0x74060000,  //  0007  JMPT	R1	#0009
+      0x50040001,  //  0008  LDBOOL	R1	0	1
+      0x50040200,  //  0009  LDBOOL	R1	1	0
+      0x80040200,  //  000A  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_commissioning_complete_deferred
+********************************************************************/
+be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        3,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 2]) {  /* upvals */
+          be_local_const_upval(1, 0),
+          be_local_const_upval(1, 1),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start_commissioning_complete),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x68080001,  //  0002  GETUPV	R2	U1
+          0x7C000400,  //  0003  CALL	R0	2
+          0x80040000,  //  0004  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(set_timer),
+    /* K2   */  be_const_int(0),
+    }),
+    be_str_weak(start_commissioning_complete_deferred),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x84140000,  //  0003  CLOSURE	R5	P0
+      0x7C080600,  //  0004  CALL	R2	3
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: adjust_next_ep
+********************************************************************/
+be_local_closure(Matter_Device_adjust_next_ep,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_config),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(next_ep),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(adjust_next_ep),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000A,  //  0005  EXBLK	0	#0011
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x600C0009,  //  0008  GETGBL	R3	G9
+      0x5C100400,  //  0009  MOVE	R4	R2
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x88100102,  //  000B  GETMBR	R4	R0	K2
+      0x28100604,  //  000C  GE	R4	R3	R4
+      0x78120001,  //  000D  JMPF	R4	#0010
+      0x00100703,  //  000E  ADD	R4	R3	K3
+      0x90020404,  //  000F  SETMBR	R0	K2	R4
+      0x7001FFF4,  //  0010  JMP		#0006
+      0x58040004,  //  0011  LDCONST	R1	K4
+      0xAC040200,  //  0012  CATCH	R1	1	0
+      0xB0080000,  //  0013  RAISE	2	R0	R0
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(Matter_Device_start,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(started),
+    /* K1   */  be_nested_str_weak(autoconf_device),
+    /* K2   */  be_nested_str_weak(_start_udp),
+    /* K3   */  be_nested_str_weak(UDP_PORT),
+    /* K4   */  be_nested_str_weak(start_mdns_announce_hostnames),
+    }),
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060000,  //  0001  JMPF	R1	#0003
+      0x80000200,  //  0002  RET	0
+      0x8C040101,  //  0003  GETMET	R1	R0	K1
+      0x7C040200,  //  0004  CALL	R1	1
+      0x8C040102,  //  0005  GETMET	R1	R0	K2
+      0x880C0103,  //  0006  GETMBR	R3	R0	K3
+      0x7C040400,  //  0007  CALL	R1	2
+      0x8C040104,  //  0008  GETMET	R1	R0	K4
+      0x7C040200,  //  0009  CALL	R1	1
+      0x50040200,  //  000A  LDBOOL	R1	1	0
+      0x90020001,  //  000B  SETMBR	R0	K0	R1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Device_every_second,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(every_second),
+    /* K2   */  be_nested_str_weak(message_handler),
+    /* K3   */  be_nested_str_weak(commissioning_open),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(time_reached),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040102,  //  0003  GETMBR	R1	R0	K2
+      0x8C040301,  //  0004  GETMET	R1	R1	K1
+      0x7C040200,  //  0005  CALL	R1	1
+      0x88040103,  //  0006  GETMBR	R1	R0	K3
+      0x4C080000,  //  0007  LDNIL	R2
+      0x20040202,  //  0008  NE	R1	R1	R2
+      0x78060006,  //  0009  JMPF	R1	#0011
+      0xB8060800,  //  000A  GETNGBL	R1	K4
+      0x8C040305,  //  000B  GETMET	R1	R1	K5
+      0x880C0103,  //  000C  GETMBR	R3	R0	K3
+      0x7C040400,  //  000D  CALL	R1	2
+      0x78060001,  //  000E  JMPF	R1	#0011
+      0x4C040000,  //  000F  LDNIL	R1
+      0x90020601,  //  0010  SETMBR	R0	K3	R1
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_fabric
+********************************************************************/
+be_local_closure(Matter_Device_remove_fabric,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(copy),
+    /* K5   */  be_nested_str_weak(reverse),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_const_int(2),
+    /* K8   */  be_nested_str_weak(message_handler),
+    /* K9   */  be_nested_str_weak(im),
+    /* K10  */  be_nested_str_weak(subs_shop),
+    /* K11  */  be_nested_str_weak(remove_by_fabric),
+    /* K12  */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K13  */  be_nested_str_weak(sessions),
+    /* K14  */  be_nested_str_weak(remove_fabric),
+    /* K15  */  be_nested_str_weak(save_fabrics),
+    }),
+    be_str_weak(remove_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x20080202,  //  0001  NE	R2	R1	R2
+      0x780A0019,  //  0002  JMPF	R2	#001D
+      0xB80A0000,  //  0003  GETNGBL	R2	K0
+      0x8C080501,  //  0004  GETMET	R2	R2	K1
+      0x8C100303,  //  0005  GETMET	R4	R1	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C100905,  //  0009  GETMET	R4	R4	K5
+      0x7C100200,  //  000A  CALL	R4	1
+      0x8C100906,  //  000B  GETMET	R4	R4	K6
+      0x7C100200,  //  000C  CALL	R4	1
+      0x00120404,  //  000D  ADD	R4	K2	R4
+      0x58140007,  //  000E  LDCONST	R5	K7
+      0x7C080600,  //  000F  CALL	R2	3
+      0x88080108,  //  0010  GETMBR	R2	R0	K8
+      0x88080509,  //  0011  GETMBR	R2	R2	K9
+      0x8808050A,  //  0012  GETMBR	R2	R2	K10
+      0x8C08050B,  //  0013  GETMET	R2	R2	K11
+      0x5C100200,  //  0014  MOVE	R4	R1
+      0x7C080400,  //  0015  CALL	R2	2
+      0x8C08010C,  //  0016  GETMET	R2	R0	K12
+      0x5C100200,  //  0017  MOVE	R4	R1
+      0x7C080400,  //  0018  CALL	R2	2
+      0x8808010D,  //  0019  GETMBR	R2	R0	K13
+      0x8C08050E,  //  001A  GETMET	R2	R2	K14
+      0x5C100200,  //  001B  MOVE	R4	R1
+      0x7C080400,  //  001C  CALL	R2	2
+      0x8808010D,  //  001D  GETMBR	R2	R0	K13
+      0x8C08050F,  //  001E  GETMET	R2	R2	K15
+      0x7C080200,  //  001F  CALL	R2	1
+      0x80000000,  //  0020  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sort_distinct
+********************************************************************/
+be_local_closure(Matter_Device_sort_distinct,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Device),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_nested_str_weak(remove),
+    }),
+    be_str_weak(sort_distinct),
+    &be_const_str_solidified,
+    ( &(const binstruction[53]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x60080010,  //  0001  GETGBL	R2	G16
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x040C0701,  //  0005  SUB	R3	R3	K1
+      0x400E0203,  //  0006  CONNECT	R3	K1	R3
+      0x7C080200,  //  0007  CALL	R2	1
+      0xA8020010,  //  0008  EXBLK	0	#001A
+      0x5C0C0400,  //  0009  MOVE	R3	R2
+      0x7C0C0000,  //  000A  CALL	R3	0
+      0x94100003,  //  000B  GETIDX	R4	R0	R3
+      0x5C140600,  //  000C  MOVE	R5	R3
+      0x24180B02,  //  000D  GT	R6	R5	K2
+      0x781A0008,  //  000E  JMPF	R6	#0018
+      0x04180B01,  //  000F  SUB	R6	R5	K1
+      0x94180006,  //  0010  GETIDX	R6	R0	R6
+      0x24180C04,  //  0011  GT	R6	R6	R4
+      0x781A0004,  //  0012  JMPF	R6	#0018
+      0x04180B01,  //  0013  SUB	R6	R5	K1
+      0x94180006,  //  0014  GETIDX	R6	R0	R6
+      0x98000A06,  //  0015  SETIDX	R0	R5	R6
+      0x04140B01,  //  0016  SUB	R5	R5	K1
+      0x7001FFF4,  //  0017  JMP		#000D
+      0x98000A04,  //  0018  SETIDX	R0	R5	R4
+      0x7001FFEE,  //  0019  JMP		#0009
+      0x58080003,  //  001A  LDCONST	R2	K3
+      0xAC080200,  //  001B  CATCH	R2	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x58080001,  //  001D  LDCONST	R2	K1
+      0x600C000C,  //  001E  GETGBL	R3	G12
+      0x5C100000,  //  001F  MOVE	R4	R0
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x180C0701,  //  0021  LE	R3	R3	K1
+      0x780E0000,  //  0022  JMPF	R3	#0024
+      0x80040000,  //  0023  RET	1	R0
+      0x940C0102,  //  0024  GETIDX	R3	R0	K2
+      0x6010000C,  //  0025  GETGBL	R4	G12
+      0x5C140000,  //  0026  MOVE	R5	R0
+      0x7C100200,  //  0027  CALL	R4	1
+      0x14100404,  //  0028  LT	R4	R2	R4
+      0x78120009,  //  0029  JMPF	R4	#0034
+      0x94100002,  //  002A  GETIDX	R4	R0	R2
+      0x1C100803,  //  002B  EQ	R4	R4	R3
+      0x78120003,  //  002C  JMPF	R4	#0031
+      0x8C100104,  //  002D  GETMET	R4	R0	K4
+      0x5C180400,  //  002E  MOVE	R6	R2
+      0x7C100400,  //  002F  CALL	R4	2
+      0x70020001,  //  0030  JMP		#0033
+      0x940C0002,  //  0031  GETIDX	R3	R0	R2
+      0x00080501,  //  0032  ADD	R2	R2	K1
+      0x7001FFF0,  //  0033  JMP		#0025
+      0x80040000,  //  0034  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _init_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device__init_basic_commissioning,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(count_active_fabrics),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(start_root_basic_commissioning),
+    }),
+    be_str_weak(_init_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x1C040302,  //  0003  EQ	R1	R1	K2
+      0x78060001,  //  0004  JMPF	R1	#0007
+      0x8C040103,  //  0005  GETMET	R1	R0	K3
+      0x7C040200,  //  0006  CALL	R1	1
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop
+********************************************************************/
+be_local_closure(Matter_Device_stop,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(remove_driver),
+    /* K2   */  be_nested_str_weak(udp_server),
+    /* K3   */  be_nested_str_weak(stop),
+    }),
+    be_str_weak(stop),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x88040102,  //  0004  GETMBR	R1	R0	K2
+      0x78060002,  //  0005  JMPF	R1	#0009
+      0x88040102,  //  0006  GETMBR	R1	R0	K2
+      0x8C040303,  //  0007  GETMET	R1	R1	K3
+      0x7C040200,  //  0008  CALL	R1	1
+      0x80000000,  //  0009  RET	0
     })
   )
 );
@@ -1715,11 +3020,11 @@ be_local_closure(Matter_Device__trigger_read_sensors,   /* name */
 
 
 /********************************************************************
-** Solidified function: start_commissioning_complete
+** Solidified function: _instantiate_plugins_from_config
 ********************************************************************/
-be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
+be_local_closure(Matter_Device__instantiate_plugins_from_config,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    18,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1727,46 +3032,1253 @@ be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_fabric),
-    /* K1   */  be_nested_str_weak(get_fabric_id),
+    ( &(const bvalue[31]) {     /* constants */
+    /* K0   */  be_nested_str_weak(k2l_num),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20Configuring_X20endpoints),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_nested_str_weak(plugins),
+    /* K6   */  be_nested_str_weak(push),
+    /* K7   */  be_nested_str_weak(matter),
+    /* K8   */  be_nested_str_weak(Plugin_Root),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X20_X20endpoint_X20_X3D_X20_X255i_X20type_X3A_X25s_X25s),
+    /* K11  */  be_nested_str_weak(root),
+    /* K12  */  be_nested_str_weak(),
+    /* K13  */  be_nested_str_weak(Plugin_Aggregator),
+    /* K14  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+    /* K15  */  be_nested_str_weak(find),
+    /* K16  */  be_nested_str_weak(type),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
+    /* K18  */  be_const_int(3),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20only_X20one_X20root_X20node_X20allowed),
+    /* K20  */  be_nested_str_weak(plugins_classes),
+    /* K21  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+    /* K22  */  be_nested_str_weak(_X27_X20skipping),
+    /* K23  */  be_nested_str_weak(conf_to_log),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K25  */  be_nested_str_weak(_X7C),
+    /* K26  */  be_nested_str_weak(stop_iteration),
+    /* K27  */  be_nested_str_weak(aggregator),
+    /* K28  */  be_nested_str_weak(publish_result),
+    /* K29  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
+    /* K30  */  be_nested_str_weak(Matter),
+    }),
+    be_str_weak(_instantiate_plugins_from_config),
+    &be_const_str_solidified,
+    ( &(const binstruction[154]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0xB80E0200,  //  0003  GETNGBL	R3	K1
+      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x58140003,  //  0005  LDCONST	R5	K3
+      0x58180004,  //  0006  LDCONST	R6	K4
+      0x7C0C0600,  //  0007  CALL	R3	3
+      0x880C0105,  //  0008  GETMBR	R3	R0	K5
+      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
+      0xB8160E00,  //  000A  GETNGBL	R5	K7
+      0x8C140B08,  //  000B  GETMET	R5	R5	K8
+      0x5C1C0000,  //  000C  MOVE	R7	R0
+      0x58200009,  //  000D  LDCONST	R8	K9
+      0x60240013,  //  000E  GETGBL	R9	G19
+      0x7C240000,  //  000F  CALL	R9	0
+      0x7C140800,  //  0010  CALL	R5	4
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0xB80E0200,  //  0012  GETNGBL	R3	K1
+      0x8C0C0702,  //  0013  GETMET	R3	R3	K2
+      0x60140018,  //  0014  GETGBL	R5	G24
+      0x5818000A,  //  0015  LDCONST	R6	K10
+      0x581C0009,  //  0016  LDCONST	R7	K9
+      0x5820000B,  //  0017  LDCONST	R8	K11
+      0x5824000C,  //  0018  LDCONST	R9	K12
+      0x7C140800,  //  0019  CALL	R5	4
+      0x58180004,  //  001A  LDCONST	R6	K4
+      0x7C0C0600,  //  001B  CALL	R3	3
+      0x880C0105,  //  001C  GETMBR	R3	R0	K5
+      0x8C0C0706,  //  001D  GETMET	R3	R3	K6
+      0xB8160E00,  //  001E  GETNGBL	R5	K7
+      0x8C140B0D,  //  001F  GETMET	R5	R5	K13
+      0x5C1C0000,  //  0020  MOVE	R7	R0
+      0xB8220E00,  //  0021  GETNGBL	R8	K7
+      0x8820110E,  //  0022  GETMBR	R8	R8	K14
+      0x60240013,  //  0023  GETGBL	R9	G19
+      0x7C240000,  //  0024  CALL	R9	0
+      0x7C140800,  //  0025  CALL	R5	4
+      0x7C0C0400,  //  0026  CALL	R3	2
+      0x600C0010,  //  0027  GETGBL	R3	G16
+      0x5C100400,  //  0028  MOVE	R4	R2
+      0x7C0C0200,  //  0029  CALL	R3	1
+      0xA802005A,  //  002A  EXBLK	0	#0086
+      0x5C100600,  //  002B  MOVE	R4	R3
+      0x7C100000,  //  002C  CALL	R4	0
+      0x1C140909,  //  002D  EQ	R5	R4	K9
+      0x78160000,  //  002E  JMPF	R5	#0030
+      0x7001FFFA,  //  002F  JMP		#002B
+      0xA8020042,  //  0030  EXBLK	0	#0074
+      0x60140008,  //  0031  GETGBL	R5	G8
+      0x5C180800,  //  0032  MOVE	R6	R4
+      0x7C140200,  //  0033  CALL	R5	1
+      0x94140205,  //  0034  GETIDX	R5	R1	R5
+      0x8C180B0F,  //  0035  GETMET	R6	R5	K15
+      0x58200010,  //  0036  LDCONST	R8	K16
+      0x7C180400,  //  0037  CALL	R6	2
+      0x4C1C0000,  //  0038  LDNIL	R7
+      0x1C1C0C07,  //  0039  EQ	R7	R6	R7
+      0x781E0006,  //  003A  JMPF	R7	#0042
+      0xB81E0200,  //  003B  GETNGBL	R7	K1
+      0x8C1C0F02,  //  003C  GETMET	R7	R7	K2
+      0x58240011,  //  003D  LDCONST	R9	K17
+      0x58280012,  //  003E  LDCONST	R10	K18
+      0x7C1C0600,  //  003F  CALL	R7	3
+      0xA8040001,  //  0040  EXBLK	1	1
+      0x7001FFE8,  //  0041  JMP		#002B
+      0x1C1C0D0B,  //  0042  EQ	R7	R6	K11
+      0x781E0006,  //  0043  JMPF	R7	#004B
+      0xB81E0200,  //  0044  GETNGBL	R7	K1
+      0x8C1C0F02,  //  0045  GETMET	R7	R7	K2
+      0x58240013,  //  0046  LDCONST	R9	K19
+      0x58280012,  //  0047  LDCONST	R10	K18
+      0x7C1C0600,  //  0048  CALL	R7	3
+      0xA8040001,  //  0049  EXBLK	1	1
+      0x7001FFDF,  //  004A  JMP		#002B
+      0x881C0114,  //  004B  GETMBR	R7	R0	K20
+      0x8C1C0F0F,  //  004C  GETMET	R7	R7	K15
+      0x5C240C00,  //  004D  MOVE	R9	R6
+      0x7C1C0400,  //  004E  CALL	R7	2
+      0x4C200000,  //  004F  LDNIL	R8
+      0x1C200E08,  //  0050  EQ	R8	R7	R8
+      0x7822000A,  //  0051  JMPF	R8	#005D
+      0xB8220200,  //  0052  GETNGBL	R8	K1
+      0x8C201102,  //  0053  GETMET	R8	R8	K2
+      0x60280008,  //  0054  GETGBL	R10	G8
+      0x5C2C0C00,  //  0055  MOVE	R11	R6
+      0x7C280200,  //  0056  CALL	R10	1
+      0x002A2A0A,  //  0057  ADD	R10	K21	R10
+      0x00281516,  //  0058  ADD	R10	R10	K22
+      0x582C0004,  //  0059  LDCONST	R11	K4
+      0x7C200600,  //  005A  CALL	R8	3
+      0xA8040001,  //  005B  EXBLK	1	1
+      0x7001FFCD,  //  005C  JMP		#002B
+      0x5C200E00,  //  005D  MOVE	R8	R7
+      0x5C240000,  //  005E  MOVE	R9	R0
+      0x5C280800,  //  005F  MOVE	R10	R4
+      0x5C2C0A00,  //  0060  MOVE	R11	R5
+      0x7C200600,  //  0061  CALL	R8	3
+      0x88240105,  //  0062  GETMBR	R9	R0	K5
+      0x8C241306,  //  0063  GETMET	R9	R9	K6
+      0x5C2C1000,  //  0064  MOVE	R11	R8
+      0x7C240400,  //  0065  CALL	R9	2
+      0xB8260200,  //  0066  GETNGBL	R9	K1
+      0x8C241302,  //  0067  GETMET	R9	R9	K2
+      0x602C0018,  //  0068  GETGBL	R11	G24
+      0x5830000A,  //  0069  LDCONST	R12	K10
+      0x5C340800,  //  006A  MOVE	R13	R4
+      0x5C380C00,  //  006B  MOVE	R14	R6
+      0x8C3C0117,  //  006C  GETMET	R15	R0	K23
+      0x5C440A00,  //  006D  MOVE	R17	R5
+      0x7C3C0400,  //  006E  CALL	R15	2
+      0x7C2C0800,  //  006F  CALL	R11	4
+      0x58300004,  //  0070  LDCONST	R12	K4
+      0x7C240600,  //  0071  CALL	R9	3
+      0xA8040001,  //  0072  EXBLK	1	1
+      0x70020010,  //  0073  JMP		#0085
+      0xAC140002,  //  0074  CATCH	R5	0	2
+      0x7002000D,  //  0075  JMP		#0084
+      0xB81E0200,  //  0076  GETNGBL	R7	K1
+      0x8C1C0F02,  //  0077  GETMET	R7	R7	K2
+      0x60240008,  //  0078  GETGBL	R9	G8
+      0x5C280A00,  //  0079  MOVE	R10	R5
+      0x7C240200,  //  007A  CALL	R9	1
+      0x00263009,  //  007B  ADD	R9	K24	R9
+      0x00241319,  //  007C  ADD	R9	R9	K25
+      0x60280008,  //  007D  GETGBL	R10	G8
+      0x5C2C0C00,  //  007E  MOVE	R11	R6
+      0x7C280200,  //  007F  CALL	R10	1
+      0x0024120A,  //  0080  ADD	R9	R9	R10
+      0x58280004,  //  0081  LDCONST	R10	K4
+      0x7C1C0600,  //  0082  CALL	R7	3
+      0x70020000,  //  0083  JMP		#0085
+      0xB0080000,  //  0084  RAISE	2	R0	R0
+      0x7001FFA4,  //  0085  JMP		#002B
+      0x580C001A,  //  0086  LDCONST	R3	K26
+      0xAC0C0200,  //  0087  CATCH	R3	1	0
+      0xB0080000,  //  0088  RAISE	2	R0	R0
+      0xB80E0200,  //  0089  GETNGBL	R3	K1
+      0x8C0C0702,  //  008A  GETMET	R3	R3	K2
+      0x60140018,  //  008B  GETGBL	R5	G24
+      0x5818000A,  //  008C  LDCONST	R6	K10
+      0xB81E0E00,  //  008D  GETNGBL	R7	K7
+      0x881C0F0E,  //  008E  GETMBR	R7	R7	K14
+      0x5820001B,  //  008F  LDCONST	R8	K27
+      0x5824000C,  //  0090  LDCONST	R9	K12
+      0x7C140800,  //  0091  CALL	R5	4
+      0x58180004,  //  0092  LDCONST	R6	K4
+      0x7C0C0600,  //  0093  CALL	R3	3
+      0xB80E0200,  //  0094  GETNGBL	R3	K1
+      0x8C0C071C,  //  0095  GETMET	R3	R3	K28
+      0x5814001D,  //  0096  LDCONST	R5	K29
+      0x5818001E,  //  0097  LDCONST	R6	K30
+      0x7C0C0600,  //  0098  CALL	R3	3
+      0x80000000,  //  0099  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_announce_op_discovery
+********************************************************************/
+be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[27]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(get_device_id),
     /* K2   */  be_nested_str_weak(copy),
     /* K3   */  be_nested_str_weak(reverse),
-    /* K4   */  be_nested_str_weak(tohex),
-    /* K5   */  be_nested_str_weak(get_admin_vendor_name),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X2D_X2D_X2D_X20Commissioning_X20complete_X20for_X20Fabric_X20_X27_X25s_X27_X20_X28Vendor_X20_X25s_X29_X20_X2D_X2D_X2D),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_nested_str_weak(stop_basic_commissioning),
+    /* K4   */  be_nested_str_weak(get_fabric_compressed),
+    /* K5   */  be_nested_str_weak(tohex),
+    /* K6   */  be_nested_str_weak(_X2D),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(eth),
+    /* K12  */  be_nested_str_weak(find),
+    /* K13  */  be_nested_str_weak(up),
+    /* K14  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K15  */  be_nested_str_weak(hostname_eth),
+    /* K16  */  be_nested_str_weak(add_service),
+    /* K17  */  be_nested_str_weak(_matter),
+    /* K18  */  be_nested_str_weak(_tcp),
+    /* K19  */  be_nested_str_weak(_I),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
+    /* K21  */  be_nested_str_weak(add_subtype),
+    /* K22  */  be_nested_str_weak(wifi),
+    /* K23  */  be_nested_str_weak(hostname_wifi),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K25  */  be_nested_str_weak(_X7C),
+    /* K26  */  be_const_int(2),
     }),
-    be_str_weak(start_commissioning_complete),
+    be_str_weak(mdns_announce_op_discovery),
     &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
-      0x7C080200,  //  0001  CALL	R2	1
-      0x8C0C0501,  //  0002  GETMET	R3	R2	K1
+    ( &(const binstruction[121]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA8020064,  //  0001  EXBLK	0	#0067
+      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
       0x7C0C0200,  //  0003  CALL	R3	1
       0x8C0C0702,  //  0004  GETMET	R3	R3	K2
       0x7C0C0200,  //  0005  CALL	R3	1
       0x8C0C0703,  //  0006  GETMET	R3	R3	K3
       0x7C0C0200,  //  0007  CALL	R3	1
-      0x8C0C0704,  //  0008  GETMET	R3	R3	K4
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x8C100505,  //  000A  GETMET	R4	R2	K5
+      0x8C100304,  //  0008  GETMET	R4	R1	K4
+      0x7C100200,  //  0009  CALL	R4	1
+      0x8C140905,  //  000A  GETMET	R5	R4	K5
+      0x7C140200,  //  000B  CALL	R5	1
+      0x00140B06,  //  000C  ADD	R5	R5	K6
+      0x8C180705,  //  000D  GETMET	R6	R3	K5
+      0x7C180200,  //  000E  CALL	R6	1
+      0x00140A06,  //  000F  ADD	R5	R5	R6
+      0xB81A0E00,  //  0010  GETNGBL	R6	K7
+      0x8C180D08,  //  0011  GETMET	R6	R6	K8
+      0x00221205,  //  0012  ADD	R8	K9	R5
+      0x5824000A,  //  0013  LDCONST	R9	K10
+      0x7C180600,  //  0014  CALL	R6	3
+      0xB81A0E00,  //  0015  GETNGBL	R6	K7
+      0x8C180D0B,  //  0016  GETMET	R6	R6	K11
+      0x7C180200,  //  0017  CALL	R6	1
+      0x8C180D0C,  //  0018  GETMET	R6	R6	K12
+      0x5820000D,  //  0019  LDCONST	R8	K13
+      0x7C180400,  //  001A  CALL	R6	2
+      0x781A0020,  //  001B  JMPF	R6	#003D
+      0xB81A0E00,  //  001C  GETNGBL	R6	K7
+      0x8C180D08,  //  001D  GETMET	R6	R6	K8
+      0x60200018,  //  001E  GETGBL	R8	G24
+      0x5824000E,  //  001F  LDCONST	R9	K14
+      0x5828000B,  //  0020  LDCONST	R10	K11
+      0x5C2C0A00,  //  0021  MOVE	R11	R5
+      0x8830010F,  //  0022  GETMBR	R12	R0	K15
+      0x7C200800,  //  0023  CALL	R8	4
+      0x5824000A,  //  0024  LDCONST	R9	K10
+      0x7C180600,  //  0025  CALL	R6	3
+      0x8C180510,  //  0026  GETMET	R6	R2	K16
+      0x58200011,  //  0027  LDCONST	R8	K17
+      0x58240012,  //  0028  LDCONST	R9	K18
+      0x542A15A3,  //  0029  LDINT	R10	5540
+      0x4C2C0000,  //  002A  LDNIL	R11
+      0x5C300A00,  //  002B  MOVE	R12	R5
+      0x8834010F,  //  002C  GETMBR	R13	R0	K15
+      0x7C180E00,  //  002D  CALL	R6	7
+      0x8C180905,  //  002E  GETMET	R6	R4	K5
+      0x7C180200,  //  002F  CALL	R6	1
+      0x001A2606,  //  0030  ADD	R6	K19	R6
+      0xB81E0E00,  //  0031  GETNGBL	R7	K7
+      0x8C1C0F08,  //  0032  GETMET	R7	R7	K8
+      0x00262806,  //  0033  ADD	R9	K20	R6
+      0x5828000A,  //  0034  LDCONST	R10	K10
+      0x7C1C0600,  //  0035  CALL	R7	3
+      0x8C1C0515,  //  0036  GETMET	R7	R2	K21
+      0x58240011,  //  0037  LDCONST	R9	K17
+      0x58280012,  //  0038  LDCONST	R10	K18
+      0x5C2C0A00,  //  0039  MOVE	R11	R5
+      0x8830010F,  //  003A  GETMBR	R12	R0	K15
+      0x5C340C00,  //  003B  MOVE	R13	R6
+      0x7C1C0C00,  //  003C  CALL	R7	6
+      0xB81A0E00,  //  003D  GETNGBL	R6	K7
+      0x8C180D16,  //  003E  GETMET	R6	R6	K22
+      0x7C180200,  //  003F  CALL	R6	1
+      0x8C180D0C,  //  0040  GETMET	R6	R6	K12
+      0x5820000D,  //  0041  LDCONST	R8	K13
+      0x7C180400,  //  0042  CALL	R6	2
+      0x781A0020,  //  0043  JMPF	R6	#0065
+      0xB81A0E00,  //  0044  GETNGBL	R6	K7
+      0x8C180D08,  //  0045  GETMET	R6	R6	K8
+      0x60200018,  //  0046  GETGBL	R8	G24
+      0x5824000E,  //  0047  LDCONST	R9	K14
+      0x58280016,  //  0048  LDCONST	R10	K22
+      0x5C2C0A00,  //  0049  MOVE	R11	R5
+      0x88300117,  //  004A  GETMBR	R12	R0	K23
+      0x7C200800,  //  004B  CALL	R8	4
+      0x5824000A,  //  004C  LDCONST	R9	K10
+      0x7C180600,  //  004D  CALL	R6	3
+      0x8C180510,  //  004E  GETMET	R6	R2	K16
+      0x58200011,  //  004F  LDCONST	R8	K17
+      0x58240012,  //  0050  LDCONST	R9	K18
+      0x542A15A3,  //  0051  LDINT	R10	5540
+      0x4C2C0000,  //  0052  LDNIL	R11
+      0x5C300A00,  //  0053  MOVE	R12	R5
+      0x88340117,  //  0054  GETMBR	R13	R0	K23
+      0x7C180E00,  //  0055  CALL	R6	7
+      0x8C180905,  //  0056  GETMET	R6	R4	K5
+      0x7C180200,  //  0057  CALL	R6	1
+      0x001A2606,  //  0058  ADD	R6	K19	R6
+      0xB81E0E00,  //  0059  GETNGBL	R7	K7
+      0x8C1C0F08,  //  005A  GETMET	R7	R7	K8
+      0x00262806,  //  005B  ADD	R9	K20	R6
+      0x5828000A,  //  005C  LDCONST	R10	K10
+      0x7C1C0600,  //  005D  CALL	R7	3
+      0x8C1C0515,  //  005E  GETMET	R7	R2	K21
+      0x58240011,  //  005F  LDCONST	R9	K17
+      0x58280012,  //  0060  LDCONST	R10	K18
+      0x5C2C0A00,  //  0061  MOVE	R11	R5
+      0x88300117,  //  0062  GETMBR	R12	R0	K23
+      0x5C340C00,  //  0063  MOVE	R13	R6
+      0x7C1C0C00,  //  0064  CALL	R7	6
+      0xA8040001,  //  0065  EXBLK	1	1
+      0x70020010,  //  0066  JMP		#0078
+      0xAC0C0002,  //  0067  CATCH	R3	0	2
+      0x7002000D,  //  0068  JMP		#0077
+      0xB8160E00,  //  0069  GETNGBL	R5	K7
+      0x8C140B08,  //  006A  GETMET	R5	R5	K8
+      0x601C0008,  //  006B  GETGBL	R7	G8
+      0x5C200600,  //  006C  MOVE	R8	R3
+      0x7C1C0200,  //  006D  CALL	R7	1
+      0x001E3007,  //  006E  ADD	R7	K24	R7
+      0x001C0F19,  //  006F  ADD	R7	R7	K25
+      0x60200008,  //  0070  GETGBL	R8	G8
+      0x5C240800,  //  0071  MOVE	R9	R4
+      0x7C200200,  //  0072  CALL	R8	1
+      0x001C0E08,  //  0073  ADD	R7	R7	R8
+      0x5820001A,  //  0074  LDCONST	R8	K26
+      0x7C140600,  //  0075  CALL	R5	3
+      0x70020000,  //  0076  JMP		#0078
+      0xB0080000,  //  0077  RAISE	2	R0	R0
+      0x80000000,  //  0078  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: k2l
+********************************************************************/
+be_local_closure(Matter_Device_k2l,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Device),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(push),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_const_int(0),
+    }),
+    be_str_weak(k2l),
+    &be_const_str_solidified,
+    ( &(const binstruction[50]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0003,  //  0004  EQ	R3	R0	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80040400,  //  0006  RET	1	R2
+      0x600C0010,  //  0007  GETGBL	R3	G16
+      0x8C100101,  //  0008  GETMET	R4	R0	K1
+      0x7C100200,  //  0009  CALL	R4	1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0xA8020005,  //  000B  EXBLK	0	#0012
+      0x5C100600,  //  000C  MOVE	R4	R3
+      0x7C100000,  //  000D  CALL	R4	0
+      0x8C140502,  //  000E  GETMET	R5	R2	K2
+      0x5C1C0800,  //  000F  MOVE	R7	R4
+      0x7C140400,  //  0010  CALL	R5	2
+      0x7001FFF9,  //  0011  JMP		#000C
+      0x580C0003,  //  0012  LDCONST	R3	K3
+      0xAC0C0200,  //  0013  CATCH	R3	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x600C0010,  //  0015  GETGBL	R3	G16
+      0x6010000C,  //  0016  GETGBL	R4	G12
+      0x5C140400,  //  0017  MOVE	R5	R2
+      0x7C100200,  //  0018  CALL	R4	1
+      0x04100904,  //  0019  SUB	R4	R4	K4
+      0x40120804,  //  001A  CONNECT	R4	K4	R4
+      0x7C0C0200,  //  001B  CALL	R3	1
+      0xA8020010,  //  001C  EXBLK	0	#002E
+      0x5C100600,  //  001D  MOVE	R4	R3
+      0x7C100000,  //  001E  CALL	R4	0
+      0x94140404,  //  001F  GETIDX	R5	R2	R4
+      0x5C180800,  //  0020  MOVE	R6	R4
+      0x241C0D05,  //  0021  GT	R7	R6	K5
+      0x781E0008,  //  0022  JMPF	R7	#002C
+      0x041C0D04,  //  0023  SUB	R7	R6	K4
+      0x941C0407,  //  0024  GETIDX	R7	R2	R7
+      0x241C0E05,  //  0025  GT	R7	R7	R5
+      0x781E0004,  //  0026  JMPF	R7	#002C
+      0x041C0D04,  //  0027  SUB	R7	R6	K4
+      0x941C0407,  //  0028  GETIDX	R7	R2	R7
+      0x98080C07,  //  0029  SETIDX	R2	R6	R7
+      0x04180D04,  //  002A  SUB	R6	R6	K4
+      0x7001FFF4,  //  002B  JMP		#0021
+      0x98080C05,  //  002C  SETIDX	R2	R6	R5
+      0x7001FFEE,  //  002D  JMP		#001D
+      0x580C0003,  //  002E  LDCONST	R3	K3
+      0xAC0C0200,  //  002F  CATCH	R3	1	0
+      0xB0080000,  //  0030  RAISE	2	R0	R0
+      0x80040400,  //  0031  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_plugin_class_arg
+********************************************************************/
+be_local_closure(Matter_Device_get_plugin_class_arg,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_classes),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(ARG),
+    /* K3   */  be_nested_str_weak(),
+    }),
+    be_str_weak(get_plugin_class_arg),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x880C0502,  //  0005  GETMBR	R3	R2	K2
+      0x70020000,  //  0006  JMP		#0008
+      0x580C0003,  //  0007  LDCONST	R3	K3
+      0x80040600,  //  0008  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(is_root_commissioning_open),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(publish_result),
+    /* K3   */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A0_X7D_X7D),
+    /* K4   */  be_nested_str_weak(Matter),
+    /* K5   */  be_nested_str_weak(commissioning_open),
+    /* K6   */  be_nested_str_weak(mdns_remove_PASE),
+    /* K7   */  be_nested_str_weak(commissioning_iterations),
+    /* K8   */  be_nested_str_weak(commissioning_discriminator),
+    /* K9   */  be_nested_str_weak(commissioning_salt),
+    /* K10  */  be_nested_str_weak(commissioning_w0),
+    /* K11  */  be_nested_str_weak(commissioning_L),
+    /* K12  */  be_nested_str_weak(commissioning_admin_fabric),
+    }),
+    be_str_weak(stop_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x78060004,  //  0002  JMPF	R1	#0008
+      0xB8060200,  //  0003  GETNGBL	R1	K1
+      0x8C040302,  //  0004  GETMET	R1	R1	K2
+      0x580C0003,  //  0005  LDCONST	R3	K3
+      0x58100004,  //  0006  LDCONST	R4	K4
+      0x7C040600,  //  0007  CALL	R1	3
+      0x4C040000,  //  0008  LDNIL	R1
+      0x90020A01,  //  0009  SETMBR	R0	K5	R1
+      0x8C040106,  //  000A  GETMET	R1	R0	K6
+      0x7C040200,  //  000B  CALL	R1	1
+      0x4C040000,  //  000C  LDNIL	R1
+      0x90020E01,  //  000D  SETMBR	R0	K7	R1
+      0x4C040000,  //  000E  LDNIL	R1
+      0x90021001,  //  000F  SETMBR	R0	K8	R1
+      0x4C040000,  //  0010  LDNIL	R1
+      0x90021201,  //  0011  SETMBR	R0	K9	R1
+      0x4C040000,  //  0012  LDNIL	R1
+      0x90021401,  //  0013  SETMBR	R0	K10	R1
+      0x4C040000,  //  0014  LDNIL	R1
+      0x90021601,  //  0015  SETMBR	R0	K11	R1
+      0x4C040000,  //  0016  LDNIL	R1
+      0x90021801,  //  0017  SETMBR	R0	K12	R1
+      0x80000000,  //  0018  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(Matter_Device_every_250ms,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(every_250ms),
+    /* K2   */  be_nested_str_weak(read_sensors_scheduler),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(plugins),
+    /* K5   */  be_const_int(1),
+    }),
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x8C040102,  //  0003  GETMET	R1	R0	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x58040003,  //  0005  LDCONST	R1	K3
+      0x6008000C,  //  0006  GETGBL	R2	G12
+      0x880C0104,  //  0007  GETMBR	R3	R0	K4
+      0x7C080200,  //  0008  CALL	R2	1
+      0x14080202,  //  0009  LT	R2	R1	R2
+      0x780A0005,  //  000A  JMPF	R2	#0011
+      0x88080104,  //  000B  GETMBR	R2	R0	K4
+      0x94080401,  //  000C  GETIDX	R2	R2	R1
+      0x8C080501,  //  000D  GETMET	R2	R2	K1
+      0x7C080200,  //  000E  CALL	R2	1
+      0x00040305,  //  000F  ADD	R1	R1	K5
+      0x7001FFF4,  //  0010  JMP		#0006
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _start_udp
+********************************************************************/
+be_local_closure(Matter_Device__start_udp,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(msg_received),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(UDPServer),
+    /* K7   */  be_nested_str_weak(),
+    /* K8   */  be_nested_str_weak(start),
+    }),
+    be_str_weak(_start_udp),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80000400,  //  0002  RET	0
+      0x4C080000,  //  0003  LDNIL	R2
+      0x1C080202,  //  0004  EQ	R2	R1	R2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x540615A3,  //  0006  LDINT	R1	5540
+      0xB80A0200,  //  0007  GETNGBL	R2	K1
+      0x8C080502,  //  0008  GETMET	R2	R2	K2
+      0x60100008,  //  0009  GETGBL	R4	G8
+      0x5C140200,  //  000A  MOVE	R5	R1
       0x7C100200,  //  000B  CALL	R4	1
-      0xB8160C00,  //  000C  GETNGBL	R5	K6
-      0x8C140B07,  //  000D  GETMET	R5	R5	K7
-      0x601C0018,  //  000E  GETGBL	R7	G24
-      0x58200008,  //  000F  LDCONST	R8	K8
-      0x5C240600,  //  0010  MOVE	R9	R3
-      0x5C280800,  //  0011  MOVE	R10	R4
-      0x7C1C0600,  //  0012  CALL	R7	3
-      0x58200009,  //  0013  LDCONST	R8	K9
-      0x7C140600,  //  0014  CALL	R5	3
-      0x8C14010A,  //  0015  GETMET	R5	R0	K10
-      0x7C140200,  //  0016  CALL	R5	1
-      0x80000000,  //  0017  RET	0
+      0x00120604,  //  000C  ADD	R4	K3	R4
+      0x58140004,  //  000D  LDCONST	R5	K4
+      0x7C080600,  //  000E  CALL	R2	3
+      0xB80A0A00,  //  000F  GETNGBL	R2	K5
+      0x8C080506,  //  0010  GETMET	R2	R2	K6
+      0x5C100000,  //  0011  MOVE	R4	R0
+      0x58140007,  //  0012  LDCONST	R5	K7
+      0x5C180200,  //  0013  MOVE	R6	R1
+      0x7C080800,  //  0014  CALL	R2	4
+      0x90020002,  //  0015  SETMBR	R0	K0	R2
+      0x88080100,  //  0016  GETMBR	R2	R0	K0
+      0x8C080508,  //  0017  GETMET	R2	R2	K8
+      0x84100000,  //  0018  CLOSURE	R4	P0
+      0x7C080400,  //  0019  CALL	R2	2
+      0xA0000000,  //  001A  CLOSE	R0
+      0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: k2l_num
+********************************************************************/
+be_local_closure(Matter_Device_k2l_num,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Device),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(push),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_const_int(0),
+    }),
+    be_str_weak(k2l_num),
+    &be_const_str_solidified,
+    ( &(const binstruction[52]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0003,  //  0004  EQ	R3	R0	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80040400,  //  0006  RET	1	R2
+      0x600C0010,  //  0007  GETGBL	R3	G16
+      0x8C100101,  //  0008  GETMET	R4	R0	K1
+      0x7C100200,  //  0009  CALL	R4	1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0xA8020007,  //  000B  EXBLK	0	#0014
+      0x5C100600,  //  000C  MOVE	R4	R3
+      0x7C100000,  //  000D  CALL	R4	0
+      0x8C140502,  //  000E  GETMET	R5	R2	K2
+      0x601C0009,  //  000F  GETGBL	R7	G9
+      0x5C200800,  //  0010  MOVE	R8	R4
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x7C140400,  //  0012  CALL	R5	2
+      0x7001FFF7,  //  0013  JMP		#000C
+      0x580C0003,  //  0014  LDCONST	R3	K3
+      0xAC0C0200,  //  0015  CATCH	R3	1	0
+      0xB0080000,  //  0016  RAISE	2	R0	R0
+      0x600C0010,  //  0017  GETGBL	R3	G16
+      0x6010000C,  //  0018  GETGBL	R4	G12
+      0x5C140400,  //  0019  MOVE	R5	R2
+      0x7C100200,  //  001A  CALL	R4	1
+      0x04100904,  //  001B  SUB	R4	R4	K4
+      0x40120804,  //  001C  CONNECT	R4	K4	R4
+      0x7C0C0200,  //  001D  CALL	R3	1
+      0xA8020010,  //  001E  EXBLK	0	#0030
+      0x5C100600,  //  001F  MOVE	R4	R3
+      0x7C100000,  //  0020  CALL	R4	0
+      0x94140404,  //  0021  GETIDX	R5	R2	R4
+      0x5C180800,  //  0022  MOVE	R6	R4
+      0x241C0D05,  //  0023  GT	R7	R6	K5
+      0x781E0008,  //  0024  JMPF	R7	#002E
+      0x041C0D04,  //  0025  SUB	R7	R6	K4
+      0x941C0407,  //  0026  GETIDX	R7	R2	R7
+      0x241C0E05,  //  0027  GT	R7	R7	R5
+      0x781E0004,  //  0028  JMPF	R7	#002E
+      0x041C0D04,  //  0029  SUB	R7	R6	K4
+      0x941C0407,  //  002A  GETIDX	R7	R2	R7
+      0x98080C07,  //  002B  SETIDX	R2	R6	R7
+      0x04180D04,  //  002C  SUB	R6	R6	K4
+      0x7001FFF4,  //  002D  JMP		#0023
+      0x98080C05,  //  002E  SETIDX	R2	R6	R5
+      0x7001FFEE,  //  002F  JMP		#001F
+      0x580C0003,  //  0030  LDCONST	R3	K3
+      0xAC0C0200,  //  0031  CATCH	R3	1	0
+      0xB0080000,  //  0032  RAISE	2	R0	R0
+      0x80040400,  //  0033  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_active_endpoints
+********************************************************************/
+be_local_closure(Matter_Device_get_active_endpoints,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins),
+    /* K1   */  be_nested_str_weak(get_endpoint),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(find),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(get_active_endpoints),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x88100100,  //  0003  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0xA8020011,  //  0005  EXBLK	0	#0018
+      0x5C100600,  //  0006  MOVE	R4	R3
+      0x7C100000,  //  0007  CALL	R4	0
+      0x8C140901,  //  0008  GETMET	R5	R4	K1
+      0x7C140200,  //  0009  CALL	R5	1
+      0x78060002,  //  000A  JMPF	R1	#000E
+      0x1C180B02,  //  000B  EQ	R6	R5	K2
+      0x781A0000,  //  000C  JMPF	R6	#000E
+      0x7001FFF7,  //  000D  JMP		#0006
+      0x8C180503,  //  000E  GETMET	R6	R2	K3
+      0x5C200A00,  //  000F  MOVE	R8	R5
+      0x7C180400,  //  0010  CALL	R6	2
+      0x4C1C0000,  //  0011  LDNIL	R7
+      0x1C180C07,  //  0012  EQ	R6	R6	R7
+      0x781A0002,  //  0013  JMPF	R6	#0017
+      0x8C180504,  //  0014  GETMET	R6	R2	K4
+      0x5C200A00,  //  0015  MOVE	R8	R5
+      0x7C180400,  //  0016  CALL	R6	2
+      0x7001FFED,  //  0017  JMP		#0006
+      0x580C0005,  //  0018  LDCONST	R3	K5
+      0xAC0C0200,  //  0019  CATCH	R3	1	0
+      0xB0080000,  //  001A  RAISE	2	R0	R0
+      0x80040400,  //  001B  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: check_config_ep
+********************************************************************/
+be_local_closure(Matter_Device_check_config_ep,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins_config),
+    /* K1   */  be_nested_str_weak(keys),
+    /* K2   */  be_nested_str_weak(push),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(tasmota),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20invalid_X20entry_X20with_X20ep_X20_X270_X27),
+    /* K8   */  be_const_int(2),
+    /* K9   */  be_nested_str_weak(remove),
+    /* K10  */  be_nested_str_weak(matter),
+    /* K11  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20endpoint_X20_X25s_X20collides_X20wit_X20aggregator_X2C_X20relocating_X20to_X20_X25s),
+    /* K13  */  be_nested_str_weak(next_ep),
+    }),
+    be_str_weak(check_config_ep),
+    &be_const_str_solidified,
+    ( &(const binstruction[73]) {  /* code */
+      0x60040012,  //  0000  GETGBL	R1	G18
+      0x7C040000,  //  0001  CALL	R1	0
+      0x60080010,  //  0002  GETGBL	R2	G16
+      0x880C0100,  //  0003  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0004  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x7C080200,  //  0006  CALL	R2	1
+      0xA8020007,  //  0007  EXBLK	0	#0010
+      0x5C0C0400,  //  0008  MOVE	R3	R2
+      0x7C0C0000,  //  0009  CALL	R3	0
+      0x8C100702,  //  000A  GETMET	R4	R3	K2
+      0x60180009,  //  000B  GETGBL	R6	G9
+      0x5C1C0600,  //  000C  MOVE	R7	R3
+      0x7C180200,  //  000D  CALL	R6	1
+      0x7C100400,  //  000E  CALL	R4	2
+      0x7001FFF7,  //  000F  JMP		#0008
+      0x58080003,  //  0010  LDCONST	R2	K3
+      0xAC080200,  //  0011  CATCH	R2	1	0
+      0xB0080000,  //  0012  RAISE	2	R0	R0
+      0x60080010,  //  0013  GETGBL	R2	G16
+      0x5C0C0200,  //  0014  MOVE	R3	R1
+      0x7C080200,  //  0015  CALL	R2	1
+      0xA802002D,  //  0016  EXBLK	0	#0045
+      0x5C0C0400,  //  0017  MOVE	R3	R2
+      0x7C0C0000,  //  0018  CALL	R3	0
+      0x1C100704,  //  0019  EQ	R4	R3	K4
+      0x7812000B,  //  001A  JMPF	R4	#0027
+      0xB8120A00,  //  001B  GETNGBL	R4	K5
+      0x8C100906,  //  001C  GETMET	R4	R4	K6
+      0x58180007,  //  001D  LDCONST	R6	K7
+      0x581C0008,  //  001E  LDCONST	R7	K8
+      0x7C100600,  //  001F  CALL	R4	3
+      0x88100100,  //  0020  GETMBR	R4	R0	K0
+      0x8C100909,  //  0021  GETMET	R4	R4	K9
+      0x60180008,  //  0022  GETGBL	R6	G8
+      0x5C1C0600,  //  0023  MOVE	R7	R3
+      0x7C180200,  //  0024  CALL	R6	1
+      0x7C100400,  //  0025  CALL	R4	2
+      0x7002001C,  //  0026  JMP		#0044
+      0xB8121400,  //  0027  GETNGBL	R4	K10
+      0x8810090B,  //  0028  GETMBR	R4	R4	K11
+      0x1C100604,  //  0029  EQ	R4	R3	R4
+      0x78120018,  //  002A  JMPF	R4	#0044
+      0xB8120A00,  //  002B  GETNGBL	R4	K5
+      0x8C100906,  //  002C  GETMET	R4	R4	K6
+      0x60180018,  //  002D  GETGBL	R6	G24
+      0x581C000C,  //  002E  LDCONST	R7	K12
+      0x5C200600,  //  002F  MOVE	R8	R3
+      0x8824010D,  //  0030  GETMBR	R9	R0	K13
+      0x7C180600,  //  0031  CALL	R6	3
+      0x581C0008,  //  0032  LDCONST	R7	K8
+      0x7C100600,  //  0033  CALL	R4	3
+      0x60100008,  //  0034  GETGBL	R4	G8
+      0x8814010D,  //  0035  GETMBR	R5	R0	K13
+      0x7C100200,  //  0036  CALL	R4	1
+      0x88140100,  //  0037  GETMBR	R5	R0	K0
+      0x60180008,  //  0038  GETGBL	R6	G8
+      0x5C1C0600,  //  0039  MOVE	R7	R3
+      0x7C180200,  //  003A  CALL	R6	1
+      0x881C0100,  //  003B  GETMBR	R7	R0	K0
+      0x94180E06,  //  003C  GETIDX	R6	R7	R6
+      0x98140806,  //  003D  SETIDX	R5	R4	R6
+      0x88100100,  //  003E  GETMBR	R4	R0	K0
+      0x8C100909,  //  003F  GETMET	R4	R4	K9
+      0x60180008,  //  0040  GETGBL	R6	G8
+      0x5C1C0600,  //  0041  MOVE	R7	R3
+      0x7C180200,  //  0042  CALL	R6	1
+      0x7C100400,  //  0043  CALL	R4	2
+      0x7001FFD1,  //  0044  JMP		#0017
+      0x58080003,  //  0045  LDCONST	R2	K3
+      0xAC080200,  //  0046  CATCH	R2	1	0
+      0xB0080000,  //  0047  RAISE	2	R0	R0
+      0x80000000,  //  0048  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: msg_send
+********************************************************************/
+be_local_closure(Matter_Device_msg_send,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(send_UDP),
+    }),
+    be_str_weak(msg_send),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: autoconf_sensors_list
+********************************************************************/
+be_local_closure(Matter_Device_autoconf_sensors_list,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(k2l),
+    /* K1   */  be_nested_str_weak(contains),
+    /* K2   */  be_nested_str_weak(Temperature),
+    /* K3   */  be_nested_str_weak(_X23Temperature),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_nested_str_weak(type),
+    /* K6   */  be_nested_str_weak(temperature),
+    /* K7   */  be_nested_str_weak(filter),
+    /* K8   */  be_nested_str_weak(stop_iteration),
+    /* K9   */  be_nested_str_weak(Pressure),
+    /* K10  */  be_nested_str_weak(_X23Pressure),
+    /* K11  */  be_nested_str_weak(pressure),
+    /* K12  */  be_nested_str_weak(Illuminance),
+    /* K13  */  be_nested_str_weak(_X23Illuminance),
+    /* K14  */  be_nested_str_weak(illuminance),
+    /* K15  */  be_nested_str_weak(Humidity),
+    /* K16  */  be_nested_str_weak(_X23Humidity),
+    /* K17  */  be_nested_str_weak(humidity),
+    }),
+    be_str_weak(autoconf_sensors_list),
+    &be_const_str_solidified,
+    ( &(const binstruction[119]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x8C100100,  //  0003  GETMET	R4	R0	K0
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x7C100400,  //  0005  CALL	R4	2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0xA8020013,  //  0007  EXBLK	0	#001C
+      0x5C100600,  //  0008  MOVE	R4	R3
+      0x7C100000,  //  0009  CALL	R4	0
+      0x94140204,  //  000A  GETIDX	R5	R1	R4
+      0x6018000F,  //  000B  GETGBL	R6	G15
+      0x5C1C0A00,  //  000C  MOVE	R7	R5
+      0x60200013,  //  000D  GETGBL	R8	G19
+      0x7C180400,  //  000E  CALL	R6	2
+      0x781A000A,  //  000F  JMPF	R6	#001B
+      0x8C180B01,  //  0010  GETMET	R6	R5	K1
+      0x58200002,  //  0011  LDCONST	R8	K2
+      0x7C180400,  //  0012  CALL	R6	2
+      0x781A0006,  //  0013  JMPF	R6	#001B
+      0x00180903,  //  0014  ADD	R6	R4	K3
+      0x8C1C0504,  //  0015  GETMET	R7	R2	K4
+      0x60240013,  //  0016  GETGBL	R9	G19
+      0x7C240000,  //  0017  CALL	R9	0
+      0x98260B06,  //  0018  SETIDX	R9	K5	K6
+      0x98260E06,  //  0019  SETIDX	R9	K7	R6
+      0x7C1C0400,  //  001A  CALL	R7	2
+      0x7001FFEB,  //  001B  JMP		#0008
+      0x580C0008,  //  001C  LDCONST	R3	K8
+      0xAC0C0200,  //  001D  CATCH	R3	1	0
+      0xB0080000,  //  001E  RAISE	2	R0	R0
+      0x600C0010,  //  001F  GETGBL	R3	G16
+      0x8C100100,  //  0020  GETMET	R4	R0	K0
+      0x5C180200,  //  0021  MOVE	R6	R1
+      0x7C100400,  //  0022  CALL	R4	2
+      0x7C0C0200,  //  0023  CALL	R3	1
+      0xA8020013,  //  0024  EXBLK	0	#0039
+      0x5C100600,  //  0025  MOVE	R4	R3
+      0x7C100000,  //  0026  CALL	R4	0
+      0x94140204,  //  0027  GETIDX	R5	R1	R4
+      0x6018000F,  //  0028  GETGBL	R6	G15
+      0x5C1C0A00,  //  0029  MOVE	R7	R5
+      0x60200013,  //  002A  GETGBL	R8	G19
+      0x7C180400,  //  002B  CALL	R6	2
+      0x781A000A,  //  002C  JMPF	R6	#0038
+      0x8C180B01,  //  002D  GETMET	R6	R5	K1
+      0x58200009,  //  002E  LDCONST	R8	K9
+      0x7C180400,  //  002F  CALL	R6	2
+      0x781A0006,  //  0030  JMPF	R6	#0038
+      0x0018090A,  //  0031  ADD	R6	R4	K10
+      0x8C1C0504,  //  0032  GETMET	R7	R2	K4
+      0x60240013,  //  0033  GETGBL	R9	G19
+      0x7C240000,  //  0034  CALL	R9	0
+      0x98260B0B,  //  0035  SETIDX	R9	K5	K11
+      0x98260E06,  //  0036  SETIDX	R9	K7	R6
+      0x7C1C0400,  //  0037  CALL	R7	2
+      0x7001FFEB,  //  0038  JMP		#0025
+      0x580C0008,  //  0039  LDCONST	R3	K8
+      0xAC0C0200,  //  003A  CATCH	R3	1	0
+      0xB0080000,  //  003B  RAISE	2	R0	R0
+      0x600C0010,  //  003C  GETGBL	R3	G16
+      0x8C100100,  //  003D  GETMET	R4	R0	K0
+      0x5C180200,  //  003E  MOVE	R6	R1
+      0x7C100400,  //  003F  CALL	R4	2
+      0x7C0C0200,  //  0040  CALL	R3	1
+      0xA8020013,  //  0041  EXBLK	0	#0056
+      0x5C100600,  //  0042  MOVE	R4	R3
+      0x7C100000,  //  0043  CALL	R4	0
+      0x94140204,  //  0044  GETIDX	R5	R1	R4
+      0x6018000F,  //  0045  GETGBL	R6	G15
+      0x5C1C0A00,  //  0046  MOVE	R7	R5
+      0x60200013,  //  0047  GETGBL	R8	G19
+      0x7C180400,  //  0048  CALL	R6	2
+      0x781A000A,  //  0049  JMPF	R6	#0055
+      0x8C180B01,  //  004A  GETMET	R6	R5	K1
+      0x5820000C,  //  004B  LDCONST	R8	K12
+      0x7C180400,  //  004C  CALL	R6	2
+      0x781A0006,  //  004D  JMPF	R6	#0055
+      0x0018090D,  //  004E  ADD	R6	R4	K13
+      0x8C1C0504,  //  004F  GETMET	R7	R2	K4
+      0x60240013,  //  0050  GETGBL	R9	G19
+      0x7C240000,  //  0051  CALL	R9	0
+      0x98260B0E,  //  0052  SETIDX	R9	K5	K14
+      0x98260E06,  //  0053  SETIDX	R9	K7	R6
+      0x7C1C0400,  //  0054  CALL	R7	2
+      0x7001FFEB,  //  0055  JMP		#0042
+      0x580C0008,  //  0056  LDCONST	R3	K8
+      0xAC0C0200,  //  0057  CATCH	R3	1	0
+      0xB0080000,  //  0058  RAISE	2	R0	R0
+      0x600C0010,  //  0059  GETGBL	R3	G16
+      0x8C100100,  //  005A  GETMET	R4	R0	K0
+      0x5C180200,  //  005B  MOVE	R6	R1
+      0x7C100400,  //  005C  CALL	R4	2
+      0x7C0C0200,  //  005D  CALL	R3	1
+      0xA8020013,  //  005E  EXBLK	0	#0073
+      0x5C100600,  //  005F  MOVE	R4	R3
+      0x7C100000,  //  0060  CALL	R4	0
+      0x94140204,  //  0061  GETIDX	R5	R1	R4
+      0x6018000F,  //  0062  GETGBL	R6	G15
+      0x5C1C0A00,  //  0063  MOVE	R7	R5
+      0x60200013,  //  0064  GETGBL	R8	G19
+      0x7C180400,  //  0065  CALL	R6	2
+      0x781A000A,  //  0066  JMPF	R6	#0072
+      0x8C180B01,  //  0067  GETMET	R6	R5	K1
+      0x5820000F,  //  0068  LDCONST	R8	K15
+      0x7C180400,  //  0069  CALL	R6	2
+      0x781A0006,  //  006A  JMPF	R6	#0072
+      0x00180910,  //  006B  ADD	R6	R4	K16
+      0x8C1C0504,  //  006C  GETMET	R7	R2	K4
+      0x60240013,  //  006D  GETGBL	R9	G19
+      0x7C240000,  //  006E  CALL	R9	0
+      0x98260B11,  //  006F  SETIDX	R9	K5	K17
+      0x98260E06,  //  0070  SETIDX	R9	K7	R6
+      0x7C1C0400,  //  0071  CALL	R7	2
+      0x7001FFEB,  //  0072  JMP		#005F
+      0x580C0008,  //  0073  LDCONST	R3	K8
+      0xAC0C0200,  //  0074  CATCH	R3	1	0
+      0xB0080000,  //  0075  RAISE	2	R0	R0
+      0x80040400,  //  0076  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_plugin_by_endpoint
+********************************************************************/
+be_local_closure(Matter_Device_find_plugin_by_endpoint,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(plugins),
+    /* K2   */  be_nested_str_weak(get_endpoint),
+    /* K3   */  be_const_int(1),
+    }),
+    be_str_weak(find_plugin_by_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0008,  //  0005  JMPF	R3	#000F
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x8C100702,  //  0008  GETMET	R4	R3	K2
+      0x7C100200,  //  0009  CALL	R4	1
+      0x1C100801,  //  000A  EQ	R4	R4	R1
+      0x78120000,  //  000B  JMPF	R4	#000D
+      0x80040600,  //  000C  RET	1	R3
+      0x00080503,  //  000D  ADD	R2	R2	K3
+      0x7001FFF1,  //  000E  JMP		#0001
+      0x4C0C0000,  //  000F  LDNIL	R3
+      0x80040600,  //  0010  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_root_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(PASE_TIMEOUT),
+    /* K1   */  be_nested_str_weak(compute_manual_pairing_code),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s),
+    /* K5   */  be_const_int(2),
+    /* K6   */  be_nested_str_weak(compute_qrcode_content),
+    /* K7   */  be_nested_str_weak(publish_result),
+    /* K8   */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A1_X2C_X22PairingCode_X22_X3A_X22_X25s_X22_X2C_X22QRCode_X22_X3A_X22_X25s_X22_X7D_X7D),
+    /* K9   */  be_nested_str_weak(Matter),
+    /* K10  */  be_nested_str_weak(_compute_pbkdf),
+    /* K11  */  be_nested_str_weak(root_passcode),
+    /* K12  */  be_nested_str_weak(root_iterations),
+    /* K13  */  be_nested_str_weak(root_salt),
+    /* K14  */  be_nested_str_weak(start_basic_commissioning),
+    /* K15  */  be_nested_str_weak(root_discriminator),
+    /* K16  */  be_nested_str_weak(root_w0),
+    /* K17  */  be_nested_str_weak(root_L),
+    }),
+    be_str_weak(start_root_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x88040100,  //  0003  GETMBR	R1	R0	K0
+      0x8C080101,  //  0004  GETMET	R2	R0	K1
+      0x7C080200,  //  0005  CALL	R2	1
+      0xB80E0400,  //  0006  GETNGBL	R3	K2
+      0x8C0C0703,  //  0007  GETMET	R3	R3	K3
+      0x60140018,  //  0008  GETGBL	R5	G24
+      0x58180004,  //  0009  LDCONST	R6	K4
+      0x5C1C0400,  //  000A  MOVE	R7	R2
+      0x7C140400,  //  000B  CALL	R5	2
+      0x58180005,  //  000C  LDCONST	R6	K5
+      0x7C0C0600,  //  000D  CALL	R3	3
+      0x8C0C0106,  //  000E  GETMET	R3	R0	K6
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0xB8120400,  //  0010  GETNGBL	R4	K2
+      0x8C100907,  //  0011  GETMET	R4	R4	K7
+      0x60180018,  //  0012  GETGBL	R6	G24
+      0x581C0008,  //  0013  LDCONST	R7	K8
+      0x5C200400,  //  0014  MOVE	R8	R2
+      0x5C240600,  //  0015  MOVE	R9	R3
+      0x7C180600,  //  0016  CALL	R6	3
+      0x581C0009,  //  0017  LDCONST	R7	K9
+      0x7C100600,  //  0018  CALL	R4	3
+      0x8C10010A,  //  0019  GETMET	R4	R0	K10
+      0x8818010B,  //  001A  GETMBR	R6	R0	K11
+      0x881C010C,  //  001B  GETMBR	R7	R0	K12
+      0x8820010D,  //  001C  GETMBR	R8	R0	K13
+      0x7C100800,  //  001D  CALL	R4	4
+      0x8C10010E,  //  001E  GETMET	R4	R0	K14
+      0x5C180200,  //  001F  MOVE	R6	R1
+      0x881C010C,  //  0020  GETMBR	R7	R0	K12
+      0x8820010F,  //  0021  GETMBR	R8	R0	K15
+      0x8824010D,  //  0022  GETMBR	R9	R0	K13
+      0x88280110,  //  0023  GETMBR	R10	R0	K16
+      0x882C0111,  //  0024  GETMBR	R11	R0	K17
+      0x4C300000,  //  0025  LDNIL	R12
+      0x7C101000,  //  0026  CALL	R4	8
+      0x80000000,  //  0027  RET	0
     })
   )
 );
@@ -1854,9 +4366,768 @@ be_local_closure(Matter_Device_process_attribute_read_solo,   /* name */
 
 
 /********************************************************************
-** Solidified function: start_commissioning_complete_deferred
+** Solidified function: start_operational_discovery
 ********************************************************************/
-be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
+be_local_closure(Matter_Device_start_operational_discovery,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(mdns),
+    /* K2   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K3   */  be_nested_str_weak(root_w0),
+    /* K4   */  be_nested_str_weak(root_L),
+    /* K5   */  be_nested_str_weak(mdns_announce_op_discovery),
+    }),
+    be_str_weak(start_operational_discovery),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0x8C100102,  //  0002  GETMET	R4	R0	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x4C100000,  //  0004  LDNIL	R4
+      0x90020604,  //  0005  SETMBR	R0	K3	R4
+      0x4C100000,  //  0006  LDNIL	R4
+      0x90020804,  //  0007  SETMBR	R0	K4	R4
+      0x8C100105,  //  0008  GETMET	R4	R0	K5
+      0x5C180200,  //  0009  MOVE	R6	R1
+      0x7C100400,  //  000A  CALL	R4	2
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: load_param
+********************************************************************/
+be_local_closure(Matter_Device_load_param,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[36]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(FILENAME),
+    /* K2   */  be_nested_str_weak(read),
+    /* K3   */  be_nested_str_weak(close),
+    /* K4   */  be_nested_str_weak(json),
+    /* K5   */  be_nested_str_weak(load),
+    /* K6   */  be_nested_str_weak(root_discriminator),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_nested_str_weak(distinguish),
+    /* K9   */  be_nested_str_weak(root_passcode),
+    /* K10  */  be_nested_str_weak(passcode),
+    /* K11  */  be_nested_str_weak(ipv4only),
+    /* K12  */  be_nested_str_weak(disable_bridge_mode),
+    /* K13  */  be_nested_str_weak(next_ep),
+    /* K14  */  be_nested_str_weak(nextep),
+    /* K15  */  be_nested_str_weak(plugins_config),
+    /* K16  */  be_nested_str_weak(config),
+    /* K17  */  be_nested_str_weak(tasmota),
+    /* K18  */  be_nested_str_weak(log),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20load_config_X20_X3D_X20),
+    /* K20  */  be_const_int(3),
+    /* K21  */  be_nested_str_weak(adjust_next_ep),
+    /* K22  */  be_nested_str_weak(check_config_ep),
+    /* K23  */  be_nested_str_weak(plugins_persist),
+    /* K24  */  be_nested_str_weak(plugins_config_remotes),
+    /* K25  */  be_nested_str_weak(remotes),
+    /* K26  */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
+    /* K27  */  be_nested_str_weak(io_error),
+    /* K28  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
+    /* K29  */  be_nested_str_weak(_X7C),
+    /* K30  */  be_const_int(2),
+    /* K31  */  be_nested_str_weak(random),
+    /* K32  */  be_nested_str_weak(get),
+    /* K33  */  be_const_int(0),
+    /* K34  */  be_nested_str_weak(generate_random_passcode),
+    /* K35  */  be_nested_str_weak(save_param),
+    }),
+    be_str_weak(load_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[129]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA802004F,  //  0001  EXBLK	0	#0052
+      0x60080011,  //  0002  GETGBL	R2	G17
+      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x7C080200,  //  0004  CALL	R2	1
+      0x8C0C0502,  //  0005  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0x8C100503,  //  0007  GETMET	R4	R2	K3
+      0x7C100200,  //  0008  CALL	R4	1
+      0xA4120800,  //  0009  IMPORT	R4	K4
+      0x8C140905,  //  000A  GETMET	R5	R4	K5
+      0x5C1C0600,  //  000B  MOVE	R7	R3
+      0x7C140400,  //  000C  CALL	R5	2
+      0x8C180B07,  //  000D  GETMET	R6	R5	K7
+      0x58200008,  //  000E  LDCONST	R8	K8
+      0x88240106,  //  000F  GETMBR	R9	R0	K6
+      0x7C180600,  //  0010  CALL	R6	3
+      0x90020C06,  //  0011  SETMBR	R0	K6	R6
+      0x8C180B07,  //  0012  GETMET	R6	R5	K7
+      0x5820000A,  //  0013  LDCONST	R8	K10
+      0x88240109,  //  0014  GETMBR	R9	R0	K9
+      0x7C180600,  //  0015  CALL	R6	3
+      0x90021206,  //  0016  SETMBR	R0	K9	R6
+      0x60180017,  //  0017  GETGBL	R6	G23
+      0x8C1C0B07,  //  0018  GETMET	R7	R5	K7
+      0x5824000B,  //  0019  LDCONST	R9	K11
+      0x50280000,  //  001A  LDBOOL	R10	0	0
+      0x7C1C0600,  //  001B  CALL	R7	3
+      0x7C180200,  //  001C  CALL	R6	1
+      0x90021606,  //  001D  SETMBR	R0	K11	R6
+      0x60180017,  //  001E  GETGBL	R6	G23
+      0x8C1C0B07,  //  001F  GETMET	R7	R5	K7
+      0x5824000C,  //  0020  LDCONST	R9	K12
+      0x50280000,  //  0021  LDBOOL	R10	0	0
+      0x7C1C0600,  //  0022  CALL	R7	3
+      0x7C180200,  //  0023  CALL	R6	1
+      0x90021806,  //  0024  SETMBR	R0	K12	R6
+      0x8C180B07,  //  0025  GETMET	R6	R5	K7
+      0x5820000E,  //  0026  LDCONST	R8	K14
+      0x8824010D,  //  0027  GETMBR	R9	R0	K13
+      0x7C180600,  //  0028  CALL	R6	3
+      0x90021A06,  //  0029  SETMBR	R0	K13	R6
+      0x8C180B07,  //  002A  GETMET	R6	R5	K7
+      0x58200010,  //  002B  LDCONST	R8	K16
+      0x7C180400,  //  002C  CALL	R6	2
+      0x90021E06,  //  002D  SETMBR	R0	K15	R6
+      0x8818010F,  //  002E  GETMBR	R6	R0	K15
+      0x4C1C0000,  //  002F  LDNIL	R7
+      0x20180C07,  //  0030  NE	R6	R6	R7
+      0x781A000D,  //  0031  JMPF	R6	#0040
+      0xB81A2200,  //  0032  GETNGBL	R6	K17
+      0x8C180D12,  //  0033  GETMET	R6	R6	K18
+      0x60200008,  //  0034  GETGBL	R8	G8
+      0x8824010F,  //  0035  GETMBR	R9	R0	K15
+      0x7C200200,  //  0036  CALL	R8	1
+      0x00222608,  //  0037  ADD	R8	K19	R8
+      0x58240014,  //  0038  LDCONST	R9	K20
+      0x7C180600,  //  0039  CALL	R6	3
+      0x8C180115,  //  003A  GETMET	R6	R0	K21
+      0x7C180200,  //  003B  CALL	R6	1
+      0x8C180116,  //  003C  GETMET	R6	R0	K22
+      0x7C180200,  //  003D  CALL	R6	1
+      0x50180200,  //  003E  LDBOOL	R6	1	0
+      0x90022E06,  //  003F  SETMBR	R0	K23	R6
+      0x8C180B07,  //  0040  GETMET	R6	R5	K7
+      0x58200019,  //  0041  LDCONST	R8	K25
+      0x60240013,  //  0042  GETGBL	R9	G19
+      0x7C240000,  //  0043  CALL	R9	0
+      0x7C180600,  //  0044  CALL	R6	3
+      0x90023006,  //  0045  SETMBR	R0	K24	R6
+      0x88180118,  //  0046  GETMBR	R6	R0	K24
+      0x781A0007,  //  0047  JMPF	R6	#0050
+      0xB81A2200,  //  0048  GETNGBL	R6	K17
+      0x8C180D12,  //  0049  GETMET	R6	R6	K18
+      0x60200008,  //  004A  GETGBL	R8	G8
+      0x88240118,  //  004B  GETMBR	R9	R0	K24
+      0x7C200200,  //  004C  CALL	R8	1
+      0x00223408,  //  004D  ADD	R8	K26	R8
+      0x58240014,  //  004E  LDCONST	R9	K20
+      0x7C180600,  //  004F  CALL	R6	3
+      0xA8040001,  //  0050  EXBLK	1	1
+      0x70020012,  //  0051  JMP		#0065
+      0xAC080002,  //  0052  CATCH	R2	0	2
+      0x7002000F,  //  0053  JMP		#0064
+      0x2010051B,  //  0054  NE	R4	R2	K27
+      0x7812000C,  //  0055  JMPF	R4	#0063
+      0xB8122200,  //  0056  GETNGBL	R4	K17
+      0x8C100912,  //  0057  GETMET	R4	R4	K18
+      0x60180008,  //  0058  GETGBL	R6	G8
+      0x5C1C0400,  //  0059  MOVE	R7	R2
+      0x7C180200,  //  005A  CALL	R6	1
+      0x001A3806,  //  005B  ADD	R6	K28	R6
+      0x00180D1D,  //  005C  ADD	R6	R6	K29
+      0x601C0008,  //  005D  GETGBL	R7	G8
+      0x5C200600,  //  005E  MOVE	R8	R3
+      0x7C1C0200,  //  005F  CALL	R7	1
+      0x00180C07,  //  0060  ADD	R6	R6	R7
+      0x581C001E,  //  0061  LDCONST	R7	K30
+      0x7C100600,  //  0062  CALL	R4	3
+      0x70020000,  //  0063  JMP		#0065
+      0xB0080000,  //  0064  RAISE	2	R0	R0
+      0x50080000,  //  0065  LDBOOL	R2	0	0
+      0x880C0106,  //  0066  GETMBR	R3	R0	K6
+      0x4C100000,  //  0067  LDNIL	R4
+      0x1C0C0604,  //  0068  EQ	R3	R3	R4
+      0x780E000A,  //  0069  JMPF	R3	#0075
+      0x8C0C031F,  //  006A  GETMET	R3	R1	K31
+      0x5814001E,  //  006B  LDCONST	R5	K30
+      0x7C0C0400,  //  006C  CALL	R3	2
+      0x8C0C0720,  //  006D  GETMET	R3	R3	K32
+      0x58140021,  //  006E  LDCONST	R5	K33
+      0x5818001E,  //  006F  LDCONST	R6	K30
+      0x7C0C0600,  //  0070  CALL	R3	3
+      0x54120FFE,  //  0071  LDINT	R4	4095
+      0x2C0C0604,  //  0072  AND	R3	R3	R4
+      0x90020C03,  //  0073  SETMBR	R0	K6	R3
+      0x50080200,  //  0074  LDBOOL	R2	1	0
+      0x880C0109,  //  0075  GETMBR	R3	R0	K9
+      0x4C100000,  //  0076  LDNIL	R4
+      0x1C0C0604,  //  0077  EQ	R3	R3	R4
+      0x780E0003,  //  0078  JMPF	R3	#007D
+      0x8C0C0122,  //  0079  GETMET	R3	R0	K34
+      0x7C0C0200,  //  007A  CALL	R3	1
+      0x90021203,  //  007B  SETMBR	R0	K9	R3
+      0x50080200,  //  007C  LDBOOL	R2	1	0
+      0x780A0001,  //  007D  JMPF	R2	#0080
+      0x8C0C0123,  //  007E  GETMET	R3	R0	K35
+      0x7C0C0200,  //  007F  CALL	R3	1
+      0x80000000,  //  0080  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: MtrUpdate
+********************************************************************/
+be_local_closure(Matter_Device_MtrUpdate,   /* name */
+  be_nested_proto(
+    18,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[25]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(resp_cmnd_str),
+    /* K2   */  be_nested_str_weak(Invalid_X20JSON),
+    /* K3   */  be_nested_str_weak(find_key_i),
+    /* K4   */  be_nested_str_weak(Ep),
+    /* K5   */  be_nested_str_weak(Name),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(Invalid_X20_X27Ep_X27_X20attribute),
+    /* K8   */  be_nested_str_weak(find_plugin_by_endpoint),
+    /* K9   */  be_nested_str_weak(remove),
+    /* K10  */  be_nested_str_weak(find_plugin_by_friendly_name),
+    /* K11  */  be_nested_str_weak(Invalid_X20Device),
+    /* K12  */  be_nested_str_weak(VIRTUAL),
+    /* K13  */  be_nested_str_weak(Device_X20is_X20not_X20virtual),
+    /* K14  */  be_nested_str_weak(consolidate_update_commands),
+    /* K15  */  be_nested_str_weak(keys),
+    /* K16  */  be_nested_str_weak(find_list_i),
+    /* K17  */  be_nested_str_weak(Invalid_X20attribute_X20_X27_X25s_X27),
+    /* K18  */  be_nested_str_weak(stop_iteration),
+    /* K19  */  be_nested_str_weak(update_virtual),
+    /* K20  */  be_nested_str_weak(state_json),
+    /* K21  */  be_nested_str_weak(_X7B_X22_X25s_X22_X3A_X25s_X7D),
+    /* K22  */  be_nested_str_weak(resp_cmnd),
+    /* K23  */  be_nested_str_weak(resp_cmnd_done),
+    /* K24  */  be_nested_str_weak(Missing_X20_X27Device_X27_X20attribute),
+    }),
+    be_str_weak(MtrUpdate),
+    &be_const_str_solidified,
+    ( &(const binstruction[126]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140805,  //  0001  EQ	R5	R4	R5
+      0x78160004,  //  0002  JMPF	R5	#0008
+      0xB8160000,  //  0003  GETNGBL	R5	K0
+      0x8C140B01,  //  0004  GETMET	R5	R5	K1
+      0x581C0002,  //  0005  LDCONST	R7	K2
+      0x7C140400,  //  0006  CALL	R5	2
+      0x80040A00,  //  0007  RET	1	R5
+      0xB8160000,  //  0008  GETNGBL	R5	K0
+      0x8C140B03,  //  0009  GETMET	R5	R5	K3
+      0x5C1C0800,  //  000A  MOVE	R7	R4
+      0x58200004,  //  000B  LDCONST	R8	K4
+      0x7C140600,  //  000C  CALL	R5	3
+      0xB81A0000,  //  000D  GETNGBL	R6	K0
+      0x8C180D03,  //  000E  GETMET	R6	R6	K3
+      0x5C200800,  //  000F  MOVE	R8	R4
+      0x58240005,  //  0010  LDCONST	R9	K5
+      0x7C180600,  //  0011  CALL	R6	3
+      0x74160000,  //  0012  JMPT	R5	#0014
+      0x781A0064,  //  0013  JMPF	R6	#0079
+      0x4C1C0000,  //  0014  LDNIL	R7
+      0x78160010,  //  0015  JMPF	R5	#0027
+      0x60200009,  //  0016  GETGBL	R8	G9
+      0x94240805,  //  0017  GETIDX	R9	R4	R5
+      0x7C200200,  //  0018  CALL	R8	1
+      0x18241106,  //  0019  LE	R9	R8	K6
+      0x78260004,  //  001A  JMPF	R9	#0020
+      0xB8260000,  //  001B  GETNGBL	R9	K0
+      0x8C241301,  //  001C  GETMET	R9	R9	K1
+      0x582C0007,  //  001D  LDCONST	R11	K7
+      0x7C240400,  //  001E  CALL	R9	2
+      0x80041200,  //  001F  RET	1	R9
+      0x8C240108,  //  0020  GETMET	R9	R0	K8
+      0x5C2C1000,  //  0021  MOVE	R11	R8
+      0x7C240400,  //  0022  CALL	R9	2
+      0x5C1C1200,  //  0023  MOVE	R7	R9
+      0x8C240909,  //  0024  GETMET	R9	R4	K9
+      0x5C2C0A00,  //  0025  MOVE	R11	R5
+      0x7C240400,  //  0026  CALL	R9	2
+      0x781A0009,  //  0027  JMPF	R6	#0032
+      0x4C200000,  //  0028  LDNIL	R8
+      0x1C200E08,  //  0029  EQ	R8	R7	R8
+      0x78220003,  //  002A  JMPF	R8	#002F
+      0x8C20010A,  //  002B  GETMET	R8	R0	K10
+      0x94280806,  //  002C  GETIDX	R10	R4	R6
+      0x7C200400,  //  002D  CALL	R8	2
+      0x5C1C1000,  //  002E  MOVE	R7	R8
+      0x8C200909,  //  002F  GETMET	R8	R4	K9
+      0x5C280C00,  //  0030  MOVE	R10	R6
+      0x7C200400,  //  0031  CALL	R8	2
+      0x4C200000,  //  0032  LDNIL	R8
+      0x1C200E08,  //  0033  EQ	R8	R7	R8
+      0x78220004,  //  0034  JMPF	R8	#003A
+      0xB8220000,  //  0035  GETNGBL	R8	K0
+      0x8C201101,  //  0036  GETMET	R8	R8	K1
+      0x5828000B,  //  0037  LDCONST	R10	K11
+      0x7C200400,  //  0038  CALL	R8	2
+      0x80041000,  //  0039  RET	1	R8
+      0x88200F0C,  //  003A  GETMBR	R8	R7	K12
+      0x74220004,  //  003B  JMPT	R8	#0041
+      0xB8220000,  //  003C  GETNGBL	R8	K0
+      0x8C201101,  //  003D  GETMET	R8	R8	K1
+      0x5828000D,  //  003E  LDCONST	R10	K13
+      0x7C200400,  //  003F  CALL	R8	2
+      0x80041000,  //  0040  RET	1	R8
+      0x8C200F0E,  //  0041  GETMET	R8	R7	K14
+      0x7C200200,  //  0042  CALL	R8	1
+      0x60240013,  //  0043  GETGBL	R9	G19
+      0x7C240000,  //  0044  CALL	R9	0
+      0x60280010,  //  0045  GETGBL	R10	G16
+      0x8C2C090F,  //  0046  GETMET	R11	R4	K15
+      0x7C2C0200,  //  0047  CALL	R11	1
+      0x7C280200,  //  0048  CALL	R10	1
+      0xA8020016,  //  0049  EXBLK	0	#0061
+      0x5C2C1400,  //  004A  MOVE	R11	R10
+      0x7C2C0000,  //  004B  CALL	R11	0
+      0xB8320000,  //  004C  GETNGBL	R12	K0
+      0x8C301910,  //  004D  GETMET	R12	R12	K16
+      0x5C381000,  //  004E  MOVE	R14	R8
+      0x5C3C1600,  //  004F  MOVE	R15	R11
+      0x7C300600,  //  0050  CALL	R12	3
+      0x4C340000,  //  0051  LDNIL	R13
+      0x1C34180D,  //  0052  EQ	R13	R12	R13
+      0x78360008,  //  0053  JMPF	R13	#005D
+      0xB8360000,  //  0054  GETNGBL	R13	K0
+      0x8C341B01,  //  0055  GETMET	R13	R13	K1
+      0x603C0018,  //  0056  GETGBL	R15	G24
+      0x58400011,  //  0057  LDCONST	R16	K17
+      0x5C441600,  //  0058  MOVE	R17	R11
+      0x7C3C0400,  //  0059  CALL	R15	2
+      0x7C340400,  //  005A  CALL	R13	2
+      0xA8040001,  //  005B  EXBLK	1	1
+      0x80001A00,  //  005C  RET	0
+      0x9434100C,  //  005D  GETIDX	R13	R8	R12
+      0x9438080B,  //  005E  GETIDX	R14	R4	R11
+      0x98241A0E,  //  005F  SETIDX	R9	R13	R14
+      0x7001FFE8,  //  0060  JMP		#004A
+      0x58280012,  //  0061  LDCONST	R10	K18
+      0xAC280200,  //  0062  CATCH	R10	1	0
+      0xB0080000,  //  0063  RAISE	2	R0	R0
+      0x8C280F13,  //  0064  GETMET	R10	R7	K19
+      0x5C301200,  //  0065  MOVE	R12	R9
+      0x7C280400,  //  0066  CALL	R10	2
+      0x8C280F14,  //  0067  GETMET	R10	R7	K20
+      0x7C280200,  //  0068  CALL	R10	1
+      0x782A000A,  //  0069  JMPF	R10	#0075
+      0x602C0018,  //  006A  GETGBL	R11	G24
+      0x58300015,  //  006B  LDCONST	R12	K21
+      0x5C340200,  //  006C  MOVE	R13	R1
+      0x5C381400,  //  006D  MOVE	R14	R10
+      0x7C2C0600,  //  006E  CALL	R11	3
+      0xB8320000,  //  006F  GETNGBL	R12	K0
+      0x8C301916,  //  0070  GETMET	R12	R12	K22
+      0x5C381600,  //  0071  MOVE	R14	R11
+      0x7C300400,  //  0072  CALL	R12	2
+      0x80041800,  //  0073  RET	1	R12
+      0x70020003,  //  0074  JMP		#0079
+      0xB82E0000,  //  0075  GETNGBL	R11	K0
+      0x8C2C1717,  //  0076  GETMET	R11	R11	K23
+      0x7C2C0200,  //  0077  CALL	R11	1
+      0x80041600,  //  0078  RET	1	R11
+      0xB81E0000,  //  0079  GETNGBL	R7	K0
+      0x8C1C0F01,  //  007A  GETMET	R7	R7	K1
+      0x58240018,  //  007B  LDCONST	R9	K24
+      0x7C1C0400,  //  007C  CALL	R7	2
+      0x80000000,  //  007D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    8,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 4]) {     /* constants */
+        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0000,  //  0006  LDCONST	R3	K0
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 4]) {     /* constants */
+        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Eth_X23Connected),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0000,  //  0006  LDCONST	R3	K0
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(millis),
+    /* K3   */  be_nested_str_weak(commissioning_iterations),
+    /* K4   */  be_nested_str_weak(commissioning_discriminator),
+    /* K5   */  be_nested_str_weak(commissioning_salt),
+    /* K6   */  be_nested_str_weak(commissioning_w0),
+    /* K7   */  be_nested_str_weak(commissioning_L),
+    /* K8   */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K9   */  be_nested_str_weak(wifi),
+    /* K10  */  be_nested_str_weak(up),
+    /* K11  */  be_nested_str_weak(eth),
+    /* K12  */  be_nested_str_weak(mdns_announce_PASE),
+    /* K13  */  be_nested_str_weak(add_rule),
+    /* K14  */  be_nested_str_weak(Wifi_X23Connected),
+    /* K15  */  be_nested_str_weak(Eth_X23Connected),
+    }),
+    be_str_weak(start_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0xB8220200,  //  0000  GETNGBL	R8	K1
+      0x8C201102,  //  0001  GETMET	R8	R8	K2
+      0x7C200200,  //  0002  CALL	R8	1
+      0x542603E7,  //  0003  LDINT	R9	1000
+      0x08240209,  //  0004  MUL	R9	R1	R9
+      0x00201009,  //  0005  ADD	R8	R8	R9
+      0x90020008,  //  0006  SETMBR	R0	K0	R8
+      0x90020602,  //  0007  SETMBR	R0	K3	R2
+      0x90020803,  //  0008  SETMBR	R0	K4	R3
+      0x90020A04,  //  0009  SETMBR	R0	K5	R4
+      0x90020C05,  //  000A  SETMBR	R0	K6	R5
+      0x90020E06,  //  000B  SETMBR	R0	K7	R6
+      0x90021007,  //  000C  SETMBR	R0	K8	R7
+      0xB8220200,  //  000D  GETNGBL	R8	K1
+      0x8C201109,  //  000E  GETMET	R8	R8	K9
+      0x7C200200,  //  000F  CALL	R8	1
+      0x9420110A,  //  0010  GETIDX	R8	R8	K10
+      0x74220004,  //  0011  JMPT	R8	#0017
+      0xB8220200,  //  0012  GETNGBL	R8	K1
+      0x8C20110B,  //  0013  GETMET	R8	R8	K11
+      0x7C200200,  //  0014  CALL	R8	1
+      0x9420110A,  //  0015  GETIDX	R8	R8	K10
+      0x78220002,  //  0016  JMPF	R8	#001A
+      0x8C20010C,  //  0017  GETMET	R8	R0	K12
+      0x7C200200,  //  0018  CALL	R8	1
+      0x7002000B,  //  0019  JMP		#0026
+      0xB8220200,  //  001A  GETNGBL	R8	K1
+      0x8C20110D,  //  001B  GETMET	R8	R8	K13
+      0x5828000E,  //  001C  LDCONST	R10	K14
+      0x842C0000,  //  001D  CLOSURE	R11	P0
+      0x5830000C,  //  001E  LDCONST	R12	K12
+      0x7C200800,  //  001F  CALL	R8	4
+      0xB8220200,  //  0020  GETNGBL	R8	K1
+      0x8C20110D,  //  0021  GETMET	R8	R8	K13
+      0x5828000F,  //  0022  LDCONST	R10	K15
+      0x842C0001,  //  0023  CLOSURE	R11	P1
+      0x5830000C,  //  0024  LDCONST	R12	K12
+      0x7C200800,  //  0025  CALL	R8	4
+      0xA0000000,  //  0026  CLOSE	R0
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: received_ack
+********************************************************************/
+be_local_closure(Matter_Device_received_ack,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(received_ack),
+    }),
+    be_str_weak(received_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_remove_op_discovery
+********************************************************************/
+be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[23]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(get_device_id),
+    /* K2   */  be_nested_str_weak(copy),
+    /* K3   */  be_nested_str_weak(reverse),
+    /* K4   */  be_nested_str_weak(get_fabric_compressed),
+    /* K5   */  be_nested_str_weak(tohex),
+    /* K6   */  be_nested_str_weak(_X2D),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(eth),
+    /* K9   */  be_nested_str_weak(find),
+    /* K10  */  be_nested_str_weak(up),
+    /* K11  */  be_nested_str_weak(log),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
+    /* K13  */  be_const_int(3),
+    /* K14  */  be_nested_str_weak(remove_service),
+    /* K15  */  be_nested_str_weak(_matter),
+    /* K16  */  be_nested_str_weak(_tcp),
+    /* K17  */  be_nested_str_weak(hostname_eth),
+    /* K18  */  be_nested_str_weak(wifi),
+    /* K19  */  be_nested_str_weak(hostname_wifi),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K21  */  be_nested_str_weak(_X7C),
+    /* K22  */  be_const_int(2),
+    }),
+    be_str_weak(mdns_remove_op_discovery),
+    &be_const_str_solidified,
+    ( &(const binstruction[80]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA802003B,  //  0001  EXBLK	0	#003E
+      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x8C100304,  //  0008  GETMET	R4	R1	K4
+      0x7C100200,  //  0009  CALL	R4	1
+      0x8C140905,  //  000A  GETMET	R5	R4	K5
+      0x7C140200,  //  000B  CALL	R5	1
+      0x00140B06,  //  000C  ADD	R5	R5	K6
+      0x8C180705,  //  000D  GETMET	R6	R3	K5
+      0x7C180200,  //  000E  CALL	R6	1
+      0x00140A06,  //  000F  ADD	R5	R5	R6
+      0xB81A0E00,  //  0010  GETNGBL	R6	K7
+      0x8C180D08,  //  0011  GETMET	R6	R6	K8
+      0x7C180200,  //  0012  CALL	R6	1
+      0x8C180D09,  //  0013  GETMET	R6	R6	K9
+      0x5820000A,  //  0014  LDCONST	R8	K10
+      0x7C180400,  //  0015  CALL	R6	2
+      0x781A000E,  //  0016  JMPF	R6	#0026
+      0xB81A0E00,  //  0017  GETNGBL	R6	K7
+      0x8C180D0B,  //  0018  GETMET	R6	R6	K11
+      0x60200018,  //  0019  GETGBL	R8	G24
+      0x5824000C,  //  001A  LDCONST	R9	K12
+      0x58280008,  //  001B  LDCONST	R10	K8
+      0x5C2C0A00,  //  001C  MOVE	R11	R5
+      0x7C200600,  //  001D  CALL	R8	3
+      0x5824000D,  //  001E  LDCONST	R9	K13
+      0x7C180600,  //  001F  CALL	R6	3
+      0x8C18050E,  //  0020  GETMET	R6	R2	K14
+      0x5820000F,  //  0021  LDCONST	R8	K15
+      0x58240010,  //  0022  LDCONST	R9	K16
+      0x5C280A00,  //  0023  MOVE	R10	R5
+      0x882C0111,  //  0024  GETMBR	R11	R0	K17
+      0x7C180A00,  //  0025  CALL	R6	5
+      0xB81A0E00,  //  0026  GETNGBL	R6	K7
+      0x8C180D12,  //  0027  GETMET	R6	R6	K18
+      0x7C180200,  //  0028  CALL	R6	1
+      0x8C180D09,  //  0029  GETMET	R6	R6	K9
+      0x5820000A,  //  002A  LDCONST	R8	K10
+      0x7C180400,  //  002B  CALL	R6	2
+      0x781A000E,  //  002C  JMPF	R6	#003C
+      0xB81A0E00,  //  002D  GETNGBL	R6	K7
+      0x8C180D0B,  //  002E  GETMET	R6	R6	K11
+      0x60200018,  //  002F  GETGBL	R8	G24
+      0x5824000C,  //  0030  LDCONST	R9	K12
+      0x58280012,  //  0031  LDCONST	R10	K18
+      0x5C2C0A00,  //  0032  MOVE	R11	R5
+      0x7C200600,  //  0033  CALL	R8	3
+      0x5824000D,  //  0034  LDCONST	R9	K13
+      0x7C180600,  //  0035  CALL	R6	3
+      0x8C18050E,  //  0036  GETMET	R6	R2	K14
+      0x5820000F,  //  0037  LDCONST	R8	K15
+      0x58240010,  //  0038  LDCONST	R9	K16
+      0x5C280A00,  //  0039  MOVE	R10	R5
+      0x882C0113,  //  003A  GETMBR	R11	R0	K19
+      0x7C180A00,  //  003B  CALL	R6	5
+      0xA8040001,  //  003C  EXBLK	1	1
+      0x70020010,  //  003D  JMP		#004F
+      0xAC0C0002,  //  003E  CATCH	R3	0	2
+      0x7002000D,  //  003F  JMP		#004E
+      0xB8160E00,  //  0040  GETNGBL	R5	K7
+      0x8C140B0B,  //  0041  GETMET	R5	R5	K11
+      0x601C0008,  //  0042  GETGBL	R7	G8
+      0x5C200600,  //  0043  MOVE	R8	R3
+      0x7C1C0200,  //  0044  CALL	R7	1
+      0x001E2807,  //  0045  ADD	R7	K20	R7
+      0x001C0F15,  //  0046  ADD	R7	R7	K21
+      0x60200008,  //  0047  GETGBL	R8	G8
+      0x5C240800,  //  0048  MOVE	R9	R4
+      0x7C200200,  //  0049  CALL	R8	1
+      0x001C0E08,  //  004A  ADD	R7	R7	R8
+      0x58200016,  //  004B  LDCONST	R8	K22
+      0x7C140600,  //  004C  CALL	R5	3
+      0x70020000,  //  004D  JMP		#004F
+      0xB0080000,  //  004E  RAISE	2	R0	R0
+      0x80000000,  //  004F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_sensors_scheduler
+********************************************************************/
+be_local_closure(Matter_Device_read_sensors_scheduler,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(probe_sensor_time),
+    /* K1   */  be_nested_str_weak(probe_sensor_timestamp),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(time_reached),
+    /* K5   */  be_nested_str_weak(_trigger_read_sensors),
+    /* K6   */  be_nested_str_weak(millis),
+    }),
+    be_str_weak(read_sensors_scheduler),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060000,  //  0003  JMPF	R1	#0005
+      0x80000200,  //  0004  RET	0
+      0x88040101,  //  0005  GETMBR	R1	R0	K1
+      0x1C040302,  //  0006  EQ	R1	R1	K2
+      0x74060004,  //  0007  JMPT	R1	#000D
+      0xB8060600,  //  0008  GETNGBL	R1	K3
+      0x8C040304,  //  0009  GETMET	R1	R1	K4
+      0x880C0101,  //  000A  GETMBR	R3	R0	K1
+      0x7C040400,  //  000B  CALL	R1	2
+      0x78060006,  //  000C  JMPF	R1	#0014
+      0x8C040105,  //  000D  GETMET	R1	R0	K5
+      0x7C040200,  //  000E  CALL	R1	1
+      0xB8060600,  //  000F  GETNGBL	R1	K3
+      0x8C040306,  //  0010  GETMET	R1	R1	K6
+      0x880C0100,  //  0011  GETMBR	R3	R0	K0
+      0x7C040400,  //  0012  CALL	R1	2
+      0x90020201,  //  0013  SETMBR	R0	K1	R1
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_operational_discovery_deferred
+********************************************************************/
+be_local_closure(Matter_Device_start_operational_discovery_deferred,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
@@ -1878,7 +5149,7 @@ be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name 
         NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_commissioning_complete),
+        /* K0   */  be_nested_str_weak(start_operational_discovery),
         }),
         be_str_weak(_X3Clambda_X3E),
         &be_const_str_solidified,
@@ -1897,7 +5168,7 @@ be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name 
     /* K1   */  be_nested_str_weak(set_timer),
     /* K2   */  be_const_int(0),
     }),
-    be_str_weak(start_commissioning_complete_deferred),
+    be_str_weak(start_operational_discovery_deferred),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
@@ -1907,6 +5178,114 @@ be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name 
       0x7C080600,  //  0004  CALL	R2	3
       0xA0000000,  //  0005  CLOSE	R0
       0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: generate_random_passcode
+********************************************************************/
+be_local_closure(Matter_Device_generate_random_passcode,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(random),
+    /* K2   */  be_nested_str_weak(get),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_const_int(134217727),
+    /* K5   */  be_const_int(99999998),
+    /* K6   */  be_nested_str_weak(PASSCODE_INVALID),
+    /* K7   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(generate_random_passcode),
+    &be_const_str_solidified,
+    ( &(const binstruction[35]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x500C0200,  //  0002  LDBOOL	R3	1	0
+      0x780E001D,  //  0003  JMPF	R3	#0022
+      0x8C0C0301,  //  0004  GETMET	R3	R1	K1
+      0x54160003,  //  0005  LDINT	R5	4
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
+      0x58140003,  //  0008  LDCONST	R5	K3
+      0x541A0003,  //  0009  LDINT	R6	4
+      0x7C0C0600,  //  000A  CALL	R3	3
+      0x2C0C0704,  //  000B  AND	R3	R3	K4
+      0x5C080600,  //  000C  MOVE	R2	R3
+      0x240C0505,  //  000D  GT	R3	R2	K5
+      0x780E0000,  //  000E  JMPF	R3	#0010
+      0x7001FFF1,  //  000F  JMP		#0002
+      0x600C0010,  //  0010  GETGBL	R3	G16
+      0x88100106,  //  0011  GETMBR	R4	R0	K6
+      0x7C0C0200,  //  0012  CALL	R3	1
+      0xA8020005,  //  0013  EXBLK	0	#001A
+      0x5C100600,  //  0014  MOVE	R4	R3
+      0x7C100000,  //  0015  CALL	R4	0
+      0x1C140404,  //  0016  EQ	R5	R2	R4
+      0x78160000,  //  0017  JMPF	R5	#0019
+      0x4C080000,  //  0018  LDNIL	R2
+      0x7001FFF9,  //  0019  JMP		#0014
+      0x580C0007,  //  001A  LDCONST	R3	K7
+      0xAC0C0200,  //  001B  CATCH	R3	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x4C0C0000,  //  001D  LDNIL	R3
+      0x200C0403,  //  001E  NE	R3	R2	R3
+      0x780E0000,  //  001F  JMPF	R3	#0021
+      0x80040400,  //  0020  RET	1	R2
+      0x7001FFDF,  //  0021  JMP		#0002
+      0x80000000,  //  0022  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: MtrJoin
+********************************************************************/
+be_local_closure(Matter_Device_MtrJoin,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K1   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(resp_cmnd_done),
+    }),
+    be_str_weak(MtrJoin),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x60140009,  //  0000  GETGBL	R5	G9
+      0x5C180600,  //  0001  MOVE	R6	R3
+      0x7C140200,  //  0002  CALL	R5	1
+      0x78160002,  //  0003  JMPF	R5	#0007
+      0x8C180100,  //  0004  GETMET	R6	R0	K0
+      0x7C180200,  //  0005  CALL	R6	1
+      0x70020001,  //  0006  JMP		#0009
+      0x8C180101,  //  0007  GETMET	R6	R0	K1
+      0x7C180200,  //  0008  CALL	R6	1
+      0xB81A0400,  //  0009  GETNGBL	R6	K2
+      0x8C180D03,  //  000A  GETMET	R6	R6	K3
+      0x7C180200,  //  000B  CALL	R6	1
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -2050,9 +5429,9 @@ be_local_closure(Matter_Device_save_param,   /* name */
 
 
 /********************************************************************
-** Solidified function: mdns_announce_op_discovery_all_fabrics
+** Solidified function: mdns_remove_op_discovery_all_fabrics
 ********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name */
+be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     1,                          /* argc */
@@ -2067,10 +5446,10 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name
     /* K1   */  be_nested_str_weak(active_fabrics),
     /* K2   */  be_nested_str_weak(get_device_id),
     /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(mdns_announce_op_discovery),
+    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
     /* K5   */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(mdns_announce_op_discovery_all_fabrics),
+    be_str_weak(mdns_remove_op_discovery_all_fabrics),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
       0x60040010,  //  0000  GETGBL	R1	G16
@@ -2095,56 +5474,6 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name
       0xAC040200,  //  0013  CATCH	R1	1	0
       0xB0080000,  //  0014  RAISE	2	R0	R0
       0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: adjust_next_ep
-********************************************************************/
-be_local_closure(Matter_Device_adjust_next_ep,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins_config),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(next_ep),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(adjust_next_ep),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000A,  //  0005  EXBLK	0	#0011
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x600C0009,  //  0008  GETGBL	R3	G9
-      0x5C100400,  //  0009  MOVE	R4	R2
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x88100102,  //  000B  GETMBR	R4	R0	K2
-      0x28100604,  //  000C  GE	R4	R3	R4
-      0x78120001,  //  000D  JMPF	R4	#0010
-      0x00100703,  //  000E  ADD	R4	R3	K3
-      0x90020404,  //  000F  SETMBR	R0	K2	R4
-      0x7001FFF4,  //  0010  JMP		#0006
-      0x58040004,  //  0011  LDCONST	R1	K4
-      0xAC040200,  //  0012  CATCH	R1	1	0
-      0xB0080000,  //  0013  RAISE	2	R0	R0
-      0x80000000,  //  0014  RET	0
     })
   )
 );
@@ -2392,724 +5721,131 @@ be_local_closure(Matter_Device_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: _instantiate_plugins_from_config
+** Solidified function: start_mdns_announce_hostnames
 ********************************************************************/
-be_local_closure(Matter_Device__instantiate_plugins_from_config,   /* name */
+be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
   be_nested_proto(
-    18,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[31]) {     /* constants */
-    /* K0   */  be_nested_str_weak(k2l_num),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20Configuring_X20endpoints),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(plugins),
-    /* K6   */  be_nested_str_weak(push),
-    /* K7   */  be_nested_str_weak(matter),
-    /* K8   */  be_nested_str_weak(Plugin_Root),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X20_X20endpoint_X20_X3D_X20_X255i_X20type_X3A_X25s_X25s),
-    /* K11  */  be_nested_str_weak(root),
-    /* K12  */  be_nested_str_weak(),
-    /* K13  */  be_nested_str_weak(Plugin_Aggregator),
-    /* K14  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-    /* K15  */  be_nested_str_weak(find),
-    /* K16  */  be_nested_str_weak(type),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
-    /* K18  */  be_const_int(3),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20only_X20one_X20root_X20node_X20allowed),
-    /* K20  */  be_nested_str_weak(plugins_classes),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-    /* K22  */  be_nested_str_weak(_X27_X20skipping),
-    /* K23  */  be_nested_str_weak(conf_to_log),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K25  */  be_nested_str_weak(_X7C),
-    /* K26  */  be_nested_str_weak(stop_iteration),
-    /* K27  */  be_nested_str_weak(aggregator),
-    /* K28  */  be_nested_str_weak(publish_result),
-    /* K29  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
-    /* K30  */  be_nested_str_weak(Matter),
-    }),
-    be_str_weak(_instantiate_plugins_from_config),
-    &be_const_str_solidified,
-    ( &(const binstruction[154]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0xB80E0200,  //  0003  GETNGBL	R3	K1
-      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
-      0x58140003,  //  0005  LDCONST	R5	K3
-      0x58180004,  //  0006  LDCONST	R6	K4
-      0x7C0C0600,  //  0007  CALL	R3	3
-      0x880C0105,  //  0008  GETMBR	R3	R0	K5
-      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
-      0xB8160E00,  //  000A  GETNGBL	R5	K7
-      0x8C140B08,  //  000B  GETMET	R5	R5	K8
-      0x5C1C0000,  //  000C  MOVE	R7	R0
-      0x58200009,  //  000D  LDCONST	R8	K9
-      0x60240013,  //  000E  GETGBL	R9	G19
-      0x7C240000,  //  000F  CALL	R9	0
-      0x7C140800,  //  0010  CALL	R5	4
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0xB80E0200,  //  0012  GETNGBL	R3	K1
-      0x8C0C0702,  //  0013  GETMET	R3	R3	K2
-      0x60140018,  //  0014  GETGBL	R5	G24
-      0x5818000A,  //  0015  LDCONST	R6	K10
-      0x581C0009,  //  0016  LDCONST	R7	K9
-      0x5820000B,  //  0017  LDCONST	R8	K11
-      0x5824000C,  //  0018  LDCONST	R9	K12
-      0x7C140800,  //  0019  CALL	R5	4
-      0x58180004,  //  001A  LDCONST	R6	K4
-      0x7C0C0600,  //  001B  CALL	R3	3
-      0x880C0105,  //  001C  GETMBR	R3	R0	K5
-      0x8C0C0706,  //  001D  GETMET	R3	R3	K6
-      0xB8160E00,  //  001E  GETNGBL	R5	K7
-      0x8C140B0D,  //  001F  GETMET	R5	R5	K13
-      0x5C1C0000,  //  0020  MOVE	R7	R0
-      0xB8220E00,  //  0021  GETNGBL	R8	K7
-      0x8820110E,  //  0022  GETMBR	R8	R8	K14
-      0x60240013,  //  0023  GETGBL	R9	G19
-      0x7C240000,  //  0024  CALL	R9	0
-      0x7C140800,  //  0025  CALL	R5	4
-      0x7C0C0400,  //  0026  CALL	R3	2
-      0x600C0010,  //  0027  GETGBL	R3	G16
-      0x5C100400,  //  0028  MOVE	R4	R2
-      0x7C0C0200,  //  0029  CALL	R3	1
-      0xA802005A,  //  002A  EXBLK	0	#0086
-      0x5C100600,  //  002B  MOVE	R4	R3
-      0x7C100000,  //  002C  CALL	R4	0
-      0x1C140909,  //  002D  EQ	R5	R4	K9
-      0x78160000,  //  002E  JMPF	R5	#0030
-      0x7001FFFA,  //  002F  JMP		#002B
-      0xA8020042,  //  0030  EXBLK	0	#0074
-      0x60140008,  //  0031  GETGBL	R5	G8
-      0x5C180800,  //  0032  MOVE	R6	R4
-      0x7C140200,  //  0033  CALL	R5	1
-      0x94140205,  //  0034  GETIDX	R5	R1	R5
-      0x8C180B0F,  //  0035  GETMET	R6	R5	K15
-      0x58200010,  //  0036  LDCONST	R8	K16
-      0x7C180400,  //  0037  CALL	R6	2
-      0x4C1C0000,  //  0038  LDNIL	R7
-      0x1C1C0C07,  //  0039  EQ	R7	R6	R7
-      0x781E0006,  //  003A  JMPF	R7	#0042
-      0xB81E0200,  //  003B  GETNGBL	R7	K1
-      0x8C1C0F02,  //  003C  GETMET	R7	R7	K2
-      0x58240011,  //  003D  LDCONST	R9	K17
-      0x58280012,  //  003E  LDCONST	R10	K18
-      0x7C1C0600,  //  003F  CALL	R7	3
-      0xA8040001,  //  0040  EXBLK	1	1
-      0x7001FFE8,  //  0041  JMP		#002B
-      0x1C1C0D0B,  //  0042  EQ	R7	R6	K11
-      0x781E0006,  //  0043  JMPF	R7	#004B
-      0xB81E0200,  //  0044  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0045  GETMET	R7	R7	K2
-      0x58240013,  //  0046  LDCONST	R9	K19
-      0x58280012,  //  0047  LDCONST	R10	K18
-      0x7C1C0600,  //  0048  CALL	R7	3
-      0xA8040001,  //  0049  EXBLK	1	1
-      0x7001FFDF,  //  004A  JMP		#002B
-      0x881C0114,  //  004B  GETMBR	R7	R0	K20
-      0x8C1C0F0F,  //  004C  GETMET	R7	R7	K15
-      0x5C240C00,  //  004D  MOVE	R9	R6
-      0x7C1C0400,  //  004E  CALL	R7	2
-      0x4C200000,  //  004F  LDNIL	R8
-      0x1C200E08,  //  0050  EQ	R8	R7	R8
-      0x7822000A,  //  0051  JMPF	R8	#005D
-      0xB8220200,  //  0052  GETNGBL	R8	K1
-      0x8C201102,  //  0053  GETMET	R8	R8	K2
-      0x60280008,  //  0054  GETGBL	R10	G8
-      0x5C2C0C00,  //  0055  MOVE	R11	R6
-      0x7C280200,  //  0056  CALL	R10	1
-      0x002A2A0A,  //  0057  ADD	R10	K21	R10
-      0x00281516,  //  0058  ADD	R10	R10	K22
-      0x582C0004,  //  0059  LDCONST	R11	K4
-      0x7C200600,  //  005A  CALL	R8	3
-      0xA8040001,  //  005B  EXBLK	1	1
-      0x7001FFCD,  //  005C  JMP		#002B
-      0x5C200E00,  //  005D  MOVE	R8	R7
-      0x5C240000,  //  005E  MOVE	R9	R0
-      0x5C280800,  //  005F  MOVE	R10	R4
-      0x5C2C0A00,  //  0060  MOVE	R11	R5
-      0x7C200600,  //  0061  CALL	R8	3
-      0x88240105,  //  0062  GETMBR	R9	R0	K5
-      0x8C241306,  //  0063  GETMET	R9	R9	K6
-      0x5C2C1000,  //  0064  MOVE	R11	R8
-      0x7C240400,  //  0065  CALL	R9	2
-      0xB8260200,  //  0066  GETNGBL	R9	K1
-      0x8C241302,  //  0067  GETMET	R9	R9	K2
-      0x602C0018,  //  0068  GETGBL	R11	G24
-      0x5830000A,  //  0069  LDCONST	R12	K10
-      0x5C340800,  //  006A  MOVE	R13	R4
-      0x5C380C00,  //  006B  MOVE	R14	R6
-      0x8C3C0117,  //  006C  GETMET	R15	R0	K23
-      0x5C440A00,  //  006D  MOVE	R17	R5
-      0x7C3C0400,  //  006E  CALL	R15	2
-      0x7C2C0800,  //  006F  CALL	R11	4
-      0x58300004,  //  0070  LDCONST	R12	K4
-      0x7C240600,  //  0071  CALL	R9	3
-      0xA8040001,  //  0072  EXBLK	1	1
-      0x70020010,  //  0073  JMP		#0085
-      0xAC140002,  //  0074  CATCH	R5	0	2
-      0x7002000D,  //  0075  JMP		#0084
-      0xB81E0200,  //  0076  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0077  GETMET	R7	R7	K2
-      0x60240008,  //  0078  GETGBL	R9	G8
-      0x5C280A00,  //  0079  MOVE	R10	R5
-      0x7C240200,  //  007A  CALL	R9	1
-      0x00263009,  //  007B  ADD	R9	K24	R9
-      0x00241319,  //  007C  ADD	R9	R9	K25
-      0x60280008,  //  007D  GETGBL	R10	G8
-      0x5C2C0C00,  //  007E  MOVE	R11	R6
-      0x7C280200,  //  007F  CALL	R10	1
-      0x0024120A,  //  0080  ADD	R9	R9	R10
-      0x58280004,  //  0081  LDCONST	R10	K4
-      0x7C1C0600,  //  0082  CALL	R7	3
-      0x70020000,  //  0083  JMP		#0085
-      0xB0080000,  //  0084  RAISE	2	R0	R0
-      0x7001FFA4,  //  0085  JMP		#002B
-      0x580C001A,  //  0086  LDCONST	R3	K26
-      0xAC0C0200,  //  0087  CATCH	R3	1	0
-      0xB0080000,  //  0088  RAISE	2	R0	R0
-      0xB80E0200,  //  0089  GETNGBL	R3	K1
-      0x8C0C0702,  //  008A  GETMET	R3	R3	K2
-      0x60140018,  //  008B  GETGBL	R5	G24
-      0x5818000A,  //  008C  LDCONST	R6	K10
-      0xB81E0E00,  //  008D  GETNGBL	R7	K7
-      0x881C0F0E,  //  008E  GETMBR	R7	R7	K14
-      0x5820001B,  //  008F  LDCONST	R8	K27
-      0x5824000C,  //  0090  LDCONST	R9	K12
-      0x7C140800,  //  0091  CALL	R5	4
-      0x58180004,  //  0092  LDCONST	R6	K4
-      0x7C0C0600,  //  0093  CALL	R3	3
-      0xB80E0200,  //  0094  GETNGBL	R3	K1
-      0x8C0C071C,  //  0095  GETMET	R3	R3	K28
-      0x5814001D,  //  0096  LDCONST	R5	K29
-      0x5818001E,  //  0097  LDCONST	R6	K30
-      0x7C0C0600,  //  0098  CALL	R3	3
-      0x80000000,  //  0099  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: k2l_num
-********************************************************************/
-be_local_closure(Matter_Device_k2l_num,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(push),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_const_int(0),
-    }),
-    be_str_weak(k2l_num),
-    &be_const_str_solidified,
-    ( &(const binstruction[52]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0003,  //  0004  EQ	R3	R0	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80040400,  //  0006  RET	1	R2
-      0x600C0010,  //  0007  GETGBL	R3	G16
-      0x8C100101,  //  0008  GETMET	R4	R0	K1
-      0x7C100200,  //  0009  CALL	R4	1
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0xA8020007,  //  000B  EXBLK	0	#0014
-      0x5C100600,  //  000C  MOVE	R4	R3
-      0x7C100000,  //  000D  CALL	R4	0
-      0x8C140502,  //  000E  GETMET	R5	R2	K2
-      0x601C0009,  //  000F  GETGBL	R7	G9
-      0x5C200800,  //  0010  MOVE	R8	R4
-      0x7C1C0200,  //  0011  CALL	R7	1
-      0x7C140400,  //  0012  CALL	R5	2
-      0x7001FFF7,  //  0013  JMP		#000C
-      0x580C0003,  //  0014  LDCONST	R3	K3
-      0xAC0C0200,  //  0015  CATCH	R3	1	0
-      0xB0080000,  //  0016  RAISE	2	R0	R0
-      0x600C0010,  //  0017  GETGBL	R3	G16
-      0x6010000C,  //  0018  GETGBL	R4	G12
-      0x5C140400,  //  0019  MOVE	R5	R2
-      0x7C100200,  //  001A  CALL	R4	1
-      0x04100904,  //  001B  SUB	R4	R4	K4
-      0x40120804,  //  001C  CONNECT	R4	K4	R4
-      0x7C0C0200,  //  001D  CALL	R3	1
-      0xA8020010,  //  001E  EXBLK	0	#0030
-      0x5C100600,  //  001F  MOVE	R4	R3
-      0x7C100000,  //  0020  CALL	R4	0
-      0x94140404,  //  0021  GETIDX	R5	R2	R4
-      0x5C180800,  //  0022  MOVE	R6	R4
-      0x241C0D05,  //  0023  GT	R7	R6	K5
-      0x781E0008,  //  0024  JMPF	R7	#002E
-      0x041C0D04,  //  0025  SUB	R7	R6	K4
-      0x941C0407,  //  0026  GETIDX	R7	R2	R7
-      0x241C0E05,  //  0027  GT	R7	R7	R5
-      0x781E0004,  //  0028  JMPF	R7	#002E
-      0x041C0D04,  //  0029  SUB	R7	R6	K4
-      0x941C0407,  //  002A  GETIDX	R7	R2	R7
-      0x98080C07,  //  002B  SETIDX	R2	R6	R7
-      0x04180D04,  //  002C  SUB	R6	R6	K4
-      0x7001FFF4,  //  002D  JMP		#0023
-      0x98080C05,  //  002E  SETIDX	R2	R6	R5
-      0x7001FFEE,  //  002F  JMP		#001F
-      0x580C0003,  //  0030  LDCONST	R3	K3
-      0xAC0C0200,  //  0031  CATCH	R3	1	0
-      0xB0080000,  //  0032  RAISE	2	R0	R0
-      0x80040400,  //  0033  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_plugin_by_friendly_name
-********************************************************************/
-be_local_closure(Matter_Device_find_plugin_by_friendly_name,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(plugins),
-    /* K2   */  be_nested_str_weak(get_name),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(find_plugin_by_friendly_name),
-    &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x740A0004,  //  0002  JMPT	R2	#0008
-      0x6008000C,  //  0003  GETGBL	R2	G12
-      0x5C0C0200,  //  0004  MOVE	R3	R1
-      0x7C080200,  //  0005  CALL	R2	1
-      0x1C080500,  //  0006  EQ	R2	R2	K0
-      0x780A0001,  //  0007  JMPF	R2	#000A
-      0x4C080000,  //  0008  LDNIL	R2
-      0x80040400,  //  0009  RET	1	R2
-      0x58080000,  //  000A  LDCONST	R2	K0
-      0x600C000C,  //  000B  GETGBL	R3	G12
-      0x88100101,  //  000C  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x140C0403,  //  000E  LT	R3	R2	R3
-      0x780E0010,  //  000F  JMPF	R3	#0021
-      0x880C0101,  //  0010  GETMBR	R3	R0	K1
-      0x940C0602,  //  0011  GETIDX	R3	R3	R2
-      0x8C100702,  //  0012  GETMET	R4	R3	K2
-      0x7C100200,  //  0013  CALL	R4	1
-      0x4C140000,  //  0014  LDNIL	R5
-      0x20140805,  //  0015  NE	R5	R4	R5
-      0x78160007,  //  0016  JMPF	R5	#001F
-      0x6014000C,  //  0017  GETGBL	R5	G12
-      0x5C180800,  //  0018  MOVE	R6	R4
-      0x7C140200,  //  0019  CALL	R5	1
-      0x24140B00,  //  001A  GT	R5	R5	K0
-      0x78160002,  //  001B  JMPF	R5	#001F
-      0x1C140801,  //  001C  EQ	R5	R4	R1
-      0x78160000,  //  001D  JMPF	R5	#001F
-      0x80040600,  //  001E  RET	1	R3
-      0x00080503,  //  001F  ADD	R2	R2	K3
-      0x7001FFE9,  //  0020  JMP		#000B
-      0x4C0C0000,  //  0021  LDNIL	R3
-      0x80040600,  //  0022  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: msg_send
-********************************************************************/
-be_local_closure(Matter_Device_msg_send,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(send_UDP),
-    }),
-    be_str_weak(msg_send),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_active_endpoints
-********************************************************************/
-be_local_closure(Matter_Device_get_active_endpoints,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins),
-    /* K1   */  be_nested_str_weak(get_endpoint),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(find),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(get_active_endpoints),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x88100100,  //  0003  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0xA8020011,  //  0005  EXBLK	0	#0018
-      0x5C100600,  //  0006  MOVE	R4	R3
-      0x7C100000,  //  0007  CALL	R4	0
-      0x8C140901,  //  0008  GETMET	R5	R4	K1
-      0x7C140200,  //  0009  CALL	R5	1
-      0x78060002,  //  000A  JMPF	R1	#000E
-      0x1C180B02,  //  000B  EQ	R6	R5	K2
-      0x781A0000,  //  000C  JMPF	R6	#000E
-      0x7001FFF7,  //  000D  JMP		#0006
-      0x8C180503,  //  000E  GETMET	R6	R2	K3
-      0x5C200A00,  //  000F  MOVE	R8	R5
-      0x7C180400,  //  0010  CALL	R6	2
-      0x4C1C0000,  //  0011  LDNIL	R7
-      0x1C180C07,  //  0012  EQ	R6	R6	R7
-      0x781A0002,  //  0013  JMPF	R6	#0017
-      0x8C180504,  //  0014  GETMET	R6	R2	K4
-      0x5C200A00,  //  0015  MOVE	R8	R5
-      0x7C180400,  //  0016  CALL	R6	2
-      0x7001FFED,  //  0017  JMP		#0006
-      0x580C0005,  //  0018  LDCONST	R3	K5
-      0xAC0C0200,  //  0019  CATCH	R3	1	0
-      0xB0080000,  //  001A  RAISE	2	R0	R0
-      0x80040400,  //  001B  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_root_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(PASE_TIMEOUT),
-    /* K1   */  be_nested_str_weak(compute_manual_pairing_code),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_nested_str_weak(compute_qrcode_content),
-    /* K7   */  be_nested_str_weak(publish_result),
-    /* K8   */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A1_X2C_X22PairingCode_X22_X3A_X22_X25s_X22_X2C_X22QRCode_X22_X3A_X22_X25s_X22_X7D_X7D),
-    /* K9   */  be_nested_str_weak(Matter),
-    /* K10  */  be_nested_str_weak(_compute_pbkdf),
-    /* K11  */  be_nested_str_weak(root_passcode),
-    /* K12  */  be_nested_str_weak(root_iterations),
-    /* K13  */  be_nested_str_weak(root_salt),
-    /* K14  */  be_nested_str_weak(start_basic_commissioning),
-    /* K15  */  be_nested_str_weak(root_discriminator),
-    /* K16  */  be_nested_str_weak(root_w0),
-    /* K17  */  be_nested_str_weak(root_L),
-    }),
-    be_str_weak(start_root_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0x88040100,  //  0003  GETMBR	R1	R0	K0
-      0x8C080101,  //  0004  GETMET	R2	R0	K1
-      0x7C080200,  //  0005  CALL	R2	1
-      0xB80E0400,  //  0006  GETNGBL	R3	K2
-      0x8C0C0703,  //  0007  GETMET	R3	R3	K3
-      0x60140018,  //  0008  GETGBL	R5	G24
-      0x58180004,  //  0009  LDCONST	R6	K4
-      0x5C1C0400,  //  000A  MOVE	R7	R2
-      0x7C140400,  //  000B  CALL	R5	2
-      0x58180005,  //  000C  LDCONST	R6	K5
-      0x7C0C0600,  //  000D  CALL	R3	3
-      0x8C0C0106,  //  000E  GETMET	R3	R0	K6
-      0x7C0C0200,  //  000F  CALL	R3	1
-      0xB8120400,  //  0010  GETNGBL	R4	K2
-      0x8C100907,  //  0011  GETMET	R4	R4	K7
-      0x60180018,  //  0012  GETGBL	R6	G24
-      0x581C0008,  //  0013  LDCONST	R7	K8
-      0x5C200400,  //  0014  MOVE	R8	R2
-      0x5C240600,  //  0015  MOVE	R9	R3
-      0x7C180600,  //  0016  CALL	R6	3
-      0x581C0009,  //  0017  LDCONST	R7	K9
-      0x7C100600,  //  0018  CALL	R4	3
-      0x8C10010A,  //  0019  GETMET	R4	R0	K10
-      0x8818010B,  //  001A  GETMBR	R6	R0	K11
-      0x881C010C,  //  001B  GETMBR	R7	R0	K12
-      0x8820010D,  //  001C  GETMBR	R8	R0	K13
-      0x7C100800,  //  001D  CALL	R4	4
-      0x8C10010E,  //  001E  GETMET	R4	R0	K14
-      0x5C180200,  //  001F  MOVE	R6	R1
-      0x881C010C,  //  0020  GETMBR	R7	R0	K12
-      0x8820010F,  //  0021  GETMBR	R8	R0	K15
-      0x8824010D,  //  0022  GETMBR	R9	R0	K13
-      0x88280110,  //  0023  GETMBR	R10	R0	K16
-      0x882C0111,  //  0024  GETMBR	R11	R0	K17
-      0x4C300000,  //  0025  LDNIL	R12
-      0x7C101000,  //  0026  CALL	R4	8
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: bridge_remove_endpoint
-********************************************************************/
-be_local_closure(Matter_Device_bridge_remove_endpoint,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(plugins_config),
-    /* K2   */  be_nested_str_weak(contains),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
-    /* K6   */  be_const_int(3),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(remove),
-    /* K10  */  be_nested_str_weak(plugins_persist),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(plugins),
-    /* K13  */  be_nested_str_weak(get_endpoint),
-    /* K14  */  be_const_int(1),
-    /* K15  */  be_nested_str_weak(clean_remotes),
-    /* K16  */  be_nested_str_weak(save_param),
-    /* K17  */  be_nested_str_weak(signal_endpoints_changed),
-    }),
-    be_str_weak(bridge_remove_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[58]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x600C0008,  //  0001  GETGBL	R3	G8
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x4C100000,  //  0004  LDNIL	R4
-      0x4C140000,  //  0005  LDNIL	R5
-      0x88180101,  //  0006  GETMBR	R6	R0	K1
-      0x8C180D02,  //  0007  GETMET	R6	R6	K2
-      0x5C200600,  //  0008  MOVE	R8	R3
-      0x7C180400,  //  0009  CALL	R6	2
-      0x741A0005,  //  000A  JMPT	R6	#0011
-      0xB81A0600,  //  000B  GETNGBL	R6	K3
-      0x8C180D04,  //  000C  GETMET	R6	R6	K4
-      0x00220A03,  //  000D  ADD	R8	K5	R3
-      0x58240006,  //  000E  LDCONST	R9	K6
-      0x7C180600,  //  000F  CALL	R6	3
-      0x80000C00,  //  0010  RET	0
-      0xB81A0600,  //  0011  GETNGBL	R6	K3
-      0x8C180D04,  //  0012  GETMET	R6	R6	K4
-      0x60200018,  //  0013  GETGBL	R8	G24
-      0x58240007,  //  0014  LDCONST	R9	K7
-      0x5C280200,  //  0015  MOVE	R10	R1
-      0x7C200400,  //  0016  CALL	R8	2
-      0x58240008,  //  0017  LDCONST	R9	K8
-      0x7C180600,  //  0018  CALL	R6	3
-      0x88180101,  //  0019  GETMBR	R6	R0	K1
-      0x8C180D09,  //  001A  GETMET	R6	R6	K9
-      0x5C200600,  //  001B  MOVE	R8	R3
-      0x7C180400,  //  001C  CALL	R6	2
-      0x50180200,  //  001D  LDBOOL	R6	1	0
-      0x90021406,  //  001E  SETMBR	R0	K10	R6
-      0x5818000B,  //  001F  LDCONST	R6	K11
-      0x601C000C,  //  0020  GETGBL	R7	G12
-      0x8820010C,  //  0021  GETMBR	R8	R0	K12
-      0x7C1C0200,  //  0022  CALL	R7	1
-      0x141C0C07,  //  0023  LT	R7	R6	R7
-      0x781E000D,  //  0024  JMPF	R7	#0033
-      0x881C010C,  //  0025  GETMBR	R7	R0	K12
-      0x941C0E06,  //  0026  GETIDX	R7	R7	R6
-      0x8C1C0F0D,  //  0027  GETMET	R7	R7	K13
-      0x7C1C0200,  //  0028  CALL	R7	1
-      0x1C1C0207,  //  0029  EQ	R7	R1	R7
-      0x781E0005,  //  002A  JMPF	R7	#0031
-      0x881C010C,  //  002B  GETMBR	R7	R0	K12
-      0x8C1C0F09,  //  002C  GETMET	R7	R7	K9
-      0x5C240C00,  //  002D  MOVE	R9	R6
-      0x7C1C0400,  //  002E  CALL	R7	2
-      0x70020002,  //  002F  JMP		#0033
-      0x70020000,  //  0030  JMP		#0032
-      0x00180D0E,  //  0031  ADD	R6	R6	K14
-      0x7001FFEC,  //  0032  JMP		#0020
-      0x8C1C010F,  //  0033  GETMET	R7	R0	K15
-      0x7C1C0200,  //  0034  CALL	R7	1
-      0x8C1C0110,  //  0035  GETMET	R7	R0	K16
-      0x7C1C0200,  //  0036  CALL	R7	1
-      0x8C1C0111,  //  0037  GETMET	R7	R0	K17
-      0x7C1C0200,  //  0038  CALL	R7	1
-      0x80000000,  //  0039  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_plugin_class_displayname
-********************************************************************/
-be_local_closure(Matter_Device_get_plugin_class_displayname,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins_classes),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(DISPLAY_NAME),
-    /* K3   */  be_nested_str_weak(),
-    }),
-    be_str_weak(get_plugin_class_displayname),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x880C0502,  //  0005  GETMBR	R3	R2	K2
-      0x70020000,  //  0006  JMP		#0008
-      0x580C0003,  //  0007  LDCONST	R3	K3
-      0x80040600,  //  0008  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_remotes_info
-********************************************************************/
-be_local_closure(Matter_Device_update_remotes_info,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(http_remotes),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(get_info),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(stop_iteration),
-    /* K5   */  be_nested_str_weak(plugins_config_remotes),
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_mdns_host),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[10]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x50080000,  //  0002  LDBOOL	R2	0	0
+          0x7C000400,  //  0003  CALL	R0	2
+          0xB8020200,  //  0004  GETNGBL	R0	K1
+          0x8C000102,  //  0005  GETMET	R0	R0	K2
+          0x58080003,  //  0006  LDCONST	R2	K3
+          0x580C0004,  //  0007  LDCONST	R3	K4
+          0x7C000600,  //  0008  CALL	R0	3
+          0x80000000,  //  0009  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Eth_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_mdns_host),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[10]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x50080200,  //  0002  LDBOOL	R2	1	0
+          0x7C000400,  //  0003  CALL	R0	2
+          0xB8020200,  //  0004  GETNGBL	R0	K1
+          0x8C000102,  //  0005  GETMET	R0	R0	K2
+          0x58080003,  //  0006  LDCONST	R2	K3
+          0x580C0004,  //  0007  LDCONST	R3	K4
+          0x7C000600,  //  0008  CALL	R0	3
+          0x80000000,  //  0009  RET	0
+        })
+      ),
     }),
-    be_str_weak(update_remotes_info),
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(wifi),
+    /* K2   */  be_nested_str_weak(up),
+    /* K3   */  be_nested_str_weak(_mdns_announce_hostname),
+    /* K4   */  be_nested_str_weak(add_rule),
+    /* K5   */  be_nested_str_weak(Wifi_X23Connected),
+    /* K6   */  be_nested_str_weak(matter_mdns_host),
+    /* K7   */  be_nested_str_weak(eth),
+    /* K8   */  be_nested_str_weak(Eth_X23Connected),
+    }),
+    be_str_weak(start_mdns_announce_hostnames),
     &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x60040013,  //  0000  GETGBL	R1	G19
-      0x7C040000,  //  0001  CALL	R1	0
-      0x88080100,  //  0002  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x20080403,  //  0004  NE	R2	R2	R3
-      0x780A0018,  //  0005  JMPF	R2	#001F
-      0x60080010,  //  0006  GETGBL	R2	G16
-      0x880C0100,  //  0007  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0008  GETMET	R3	R3	K1
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x7C080200,  //  000A  CALL	R2	1
-      0xA802000F,  //  000B  EXBLK	0	#001C
-      0x5C0C0400,  //  000C  MOVE	R3	R2
-      0x7C0C0000,  //  000D  CALL	R3	0
-      0x88100100,  //  000E  GETMBR	R4	R0	K0
-      0x94100803,  //  000F  GETIDX	R4	R4	R3
-      0x8C100902,  //  0010  GETMET	R4	R4	K2
-      0x7C100200,  //  0011  CALL	R4	1
-      0x4C140000,  //  0012  LDNIL	R5
-      0x20140805,  //  0013  NE	R5	R4	R5
-      0x78160005,  //  0014  JMPF	R5	#001B
-      0x6014000C,  //  0015  GETGBL	R5	G12
-      0x5C180800,  //  0016  MOVE	R6	R4
-      0x7C140200,  //  0017  CALL	R5	1
-      0x24140B03,  //  0018  GT	R5	R5	K3
-      0x78160000,  //  0019  JMPF	R5	#001B
-      0x98040604,  //  001A  SETIDX	R1	R3	R4
-      0x7001FFEF,  //  001B  JMP		#000C
-      0x58080004,  //  001C  LDCONST	R2	K4
-      0xAC080200,  //  001D  CATCH	R2	1	0
-      0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x90020A01,  //  001F  SETMBR	R0	K5	R1
-      0x80040200,  //  0020  RET	1	R1
+    ( &(const binstruction[32]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x94040302,  //  0003  GETIDX	R1	R1	K2
+      0x78060003,  //  0004  JMPF	R1	#0009
+      0x8C040103,  //  0005  GETMET	R1	R0	K3
+      0x500C0000,  //  0006  LDBOOL	R3	0	0
+      0x7C040400,  //  0007  CALL	R1	2
+      0x70020005,  //  0008  JMP		#000F
+      0xB8060000,  //  0009  GETNGBL	R1	K0
+      0x8C040304,  //  000A  GETMET	R1	R1	K4
+      0x580C0005,  //  000B  LDCONST	R3	K5
+      0x84100000,  //  000C  CLOSURE	R4	P0
+      0x58140006,  //  000D  LDCONST	R5	K6
+      0x7C040800,  //  000E  CALL	R1	4
+      0xB8060000,  //  000F  GETNGBL	R1	K0
+      0x8C040307,  //  0010  GETMET	R1	R1	K7
+      0x7C040200,  //  0011  CALL	R1	1
+      0x94040302,  //  0012  GETIDX	R1	R1	K2
+      0x78060003,  //  0013  JMPF	R1	#0018
+      0x8C040103,  //  0014  GETMET	R1	R0	K3
+      0x500C0200,  //  0015  LDBOOL	R3	1	0
+      0x7C040400,  //  0016  CALL	R1	2
+      0x70020005,  //  0017  JMP		#001E
+      0xB8060000,  //  0018  GETNGBL	R1	K0
+      0x8C040304,  //  0019  GETMET	R1	R1	K4
+      0x580C0008,  //  001A  LDCONST	R3	K8
+      0x84100001,  //  001B  CLOSURE	R4	P1
+      0x58140006,  //  001C  LDCONST	R5	K6
+      0x7C040800,  //  001D  CALL	R1	4
+      0xA0000000,  //  001E  CLOSE	R0
+      0x80000000,  //  001F  RET	0
     })
   )
 );
@@ -3117,11 +5853,11 @@ be_local_closure(Matter_Device_update_remotes_info,   /* name */
 
 
 /********************************************************************
-** Solidified function: start
+** Solidified function: signal_endpoints_changed
 ********************************************************************/
-be_local_closure(Matter_Device_start,   /* name */
+be_local_closure(Matter_Device_signal_endpoints_changed,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    7,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3130,426 +5866,29 @@ be_local_closure(Matter_Device_start,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(started),
-    /* K1   */  be_nested_str_weak(autoconf_device),
-    /* K2   */  be_nested_str_weak(_start_udp),
-    /* K3   */  be_nested_str_weak(UDP_PORT),
-    /* K4   */  be_nested_str_weak(start_mdns_announce_hostnames),
+    /* K0   */  be_nested_str_weak(attribute_updated),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_const_int(3),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
     }),
-    be_str_weak(start),
+    be_str_weak(signal_endpoints_changed),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060000,  //  0001  JMPF	R1	#0003
-      0x80000200,  //  0002  RET	0
-      0x8C040101,  //  0003  GETMET	R1	R0	K1
-      0x7C040200,  //  0004  CALL	R1	1
-      0x8C040102,  //  0005  GETMET	R1	R0	K2
-      0x880C0103,  //  0006  GETMBR	R3	R0	K3
-      0x7C040400,  //  0007  CALL	R1	2
-      0x8C040104,  //  0008  GETMET	R1	R0	K4
-      0x7C040200,  //  0009  CALL	R1	1
-      0x50040200,  //  000A  LDBOOL	R1	1	0
-      0x90020001,  //  000B  SETMBR	R0	K0	R1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: k2l
-********************************************************************/
-be_local_closure(Matter_Device_k2l,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(push),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_const_int(0),
-    }),
-    be_str_weak(k2l),
-    &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0003,  //  0004  EQ	R3	R0	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80040400,  //  0006  RET	1	R2
-      0x600C0010,  //  0007  GETGBL	R3	G16
-      0x8C100101,  //  0008  GETMET	R4	R0	K1
-      0x7C100200,  //  0009  CALL	R4	1
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0xA8020005,  //  000B  EXBLK	0	#0012
-      0x5C100600,  //  000C  MOVE	R4	R3
-      0x7C100000,  //  000D  CALL	R4	0
-      0x8C140502,  //  000E  GETMET	R5	R2	K2
-      0x5C1C0800,  //  000F  MOVE	R7	R4
-      0x7C140400,  //  0010  CALL	R5	2
-      0x7001FFF9,  //  0011  JMP		#000C
-      0x580C0003,  //  0012  LDCONST	R3	K3
-      0xAC0C0200,  //  0013  CATCH	R3	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x600C0010,  //  0015  GETGBL	R3	G16
-      0x6010000C,  //  0016  GETGBL	R4	G12
-      0x5C140400,  //  0017  MOVE	R5	R2
-      0x7C100200,  //  0018  CALL	R4	1
-      0x04100904,  //  0019  SUB	R4	R4	K4
-      0x40120804,  //  001A  CONNECT	R4	K4	R4
-      0x7C0C0200,  //  001B  CALL	R3	1
-      0xA8020010,  //  001C  EXBLK	0	#002E
-      0x5C100600,  //  001D  MOVE	R4	R3
-      0x7C100000,  //  001E  CALL	R4	0
-      0x94140404,  //  001F  GETIDX	R5	R2	R4
-      0x5C180800,  //  0020  MOVE	R6	R4
-      0x241C0D05,  //  0021  GT	R7	R6	K5
-      0x781E0008,  //  0022  JMPF	R7	#002C
-      0x041C0D04,  //  0023  SUB	R7	R6	K4
-      0x941C0407,  //  0024  GETIDX	R7	R2	R7
-      0x241C0E05,  //  0025  GT	R7	R7	R5
-      0x781E0004,  //  0026  JMPF	R7	#002C
-      0x041C0D04,  //  0027  SUB	R7	R6	K4
-      0x941C0407,  //  0028  GETIDX	R7	R2	R7
-      0x98080C07,  //  0029  SETIDX	R2	R6	R7
-      0x04180D04,  //  002A  SUB	R6	R6	K4
-      0x7001FFF4,  //  002B  JMP		#0021
-      0x98080C05,  //  002C  SETIDX	R2	R6	R5
-      0x7001FFEE,  //  002D  JMP		#001D
-      0x580C0003,  //  002E  LDCONST	R3	K3
-      0xAC0C0200,  //  002F  CATCH	R3	1	0
-      0xB0080000,  //  0030  RAISE	2	R0	R0
-      0x80040400,  //  0031  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_operational_discovery_deferred
-********************************************************************/
-be_local_closure(Matter_Device_start_operational_discovery_deferred,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        3,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 2]) {  /* upvals */
-          be_local_const_upval(1, 0),
-          be_local_const_upval(1, 1),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_operational_discovery),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080001,  //  0002  GETUPV	R2	U1
-          0x7C000400,  //  0003  CALL	R0	2
-          0x80040000,  //  0004  RET	1	R0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(set_timer),
-    /* K2   */  be_const_int(0),
-    }),
-    be_str_weak(start_operational_discovery_deferred),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x84140000,  //  0003  CLOSURE	R5	P0
-      0x7C080600,  //  0004  CALL	R2	3
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: autoconf_device_map
-********************************************************************/
-be_local_closure(Matter_Device_autoconf_device_map,   /* name */
-  be_nested_proto(
-    20,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[36]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(light),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_nested_str_weak(find),
-    /* K5   */  be_nested_str_weak(channels),
-    /* K6   */  be_nested_str_weak(),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(type),
-    /* K9   */  be_nested_str_weak(light1),
-    /* K10  */  be_const_int(2),
-    /* K11  */  be_nested_str_weak(light2),
-    /* K12  */  be_nested_str_weak(light3),
-    /* K13  */  be_nested_str_weak(tasmota),
-    /* K14  */  be_nested_str_weak(cmd),
-    /* K15  */  be_nested_str_weak(Status_X2013),
-    /* K16  */  be_nested_str_weak(log),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20Status_X2013_X20_X3D_X20),
-    /* K18  */  be_const_int(3),
-    /* K19  */  be_nested_str_weak(contains),
-    /* K20  */  be_nested_str_weak(StatusSHT),
-    /* K21  */  be_nested_str_weak(SHT),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20_X27_X25s_X27_X20_X3D_X20_X25s),
-    /* K23  */  be_nested_str_weak(Relay1),
-    /* K24  */  be_nested_str_weak(Relay2),
-    /* K25  */  be_nested_str_weak(push),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20relay1_X3D_X25s_X20relay2_X3D_X25s),
-    /* K27  */  be_nested_str_weak(TiltConfig),
-    /* K28  */  be_nested_str_weak(shutter_X2Btilt),
-    /* K29  */  be_nested_str_weak(shutter),
-    /* K30  */  be_nested_str_weak(get_power),
-    /* K31  */  be_nested_str_weak(relay),
-    /* K32  */  be_nested_str_weak(load),
-    /* K33  */  be_nested_str_weak(read_sensors),
-    /* K34  */  be_nested_str_weak(autoconf_sensors_list),
-    /* K35  */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(autoconf_device_map),
-    &be_const_str_solidified,
-    ( &(const binstruction[198]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x60080013,  //  0001  GETGBL	R2	G19
-      0x7C080000,  //  0002  CALL	R2	0
-      0x580C0001,  //  0003  LDCONST	R3	K1
-      0x50100000,  //  0004  LDBOOL	R4	0	0
-      0xA4160400,  //  0005  IMPORT	R5	K2
-      0x8C180B03,  //  0006  GETMET	R6	R5	K3
-      0x7C180200,  //  0007  CALL	R6	1
-      0x4C1C0000,  //  0008  LDNIL	R7
-      0x201C0C07,  //  0009  NE	R7	R6	R7
-      0x781E0024,  //  000A  JMPF	R7	#0030
-      0x601C000C,  //  000B  GETGBL	R7	G12
-      0x8C200D04,  //  000C  GETMET	R8	R6	K4
-      0x58280005,  //  000D  LDCONST	R10	K5
-      0x582C0006,  //  000E  LDCONST	R11	K6
-      0x7C200600,  //  000F  CALL	R8	3
-      0x7C1C0200,  //  0010  CALL	R7	1
-      0x24200F07,  //  0011  GT	R8	R7	K7
-      0x7822001C,  //  0012  JMPF	R8	#0030
-      0x1C200F01,  //  0013  EQ	R8	R7	K1
-      0x78220007,  //  0014  JMPF	R8	#001D
-      0x60200008,  //  0015  GETGBL	R8	G8
-      0x5C240600,  //  0016  MOVE	R9	R3
-      0x7C200200,  //  0017  CALL	R8	1
-      0x60240013,  //  0018  GETGBL	R9	G19
-      0x7C240000,  //  0019  CALL	R9	0
-      0x98261109,  //  001A  SETIDX	R9	K8	K9
-      0x98081009,  //  001B  SETIDX	R2	R8	R9
-      0x70020010,  //  001C  JMP		#002E
-      0x1C200F0A,  //  001D  EQ	R8	R7	K10
-      0x78220007,  //  001E  JMPF	R8	#0027
-      0x60200008,  //  001F  GETGBL	R8	G8
-      0x5C240600,  //  0020  MOVE	R9	R3
-      0x7C200200,  //  0021  CALL	R8	1
-      0x60240013,  //  0022  GETGBL	R9	G19
-      0x7C240000,  //  0023  CALL	R9	0
-      0x9826110B,  //  0024  SETIDX	R9	K8	K11
-      0x98081009,  //  0025  SETIDX	R2	R8	R9
-      0x70020006,  //  0026  JMP		#002E
-      0x60200008,  //  0027  GETGBL	R8	G8
-      0x5C240600,  //  0028  MOVE	R9	R3
-      0x7C200200,  //  0029  CALL	R8	1
-      0x60240013,  //  002A  GETGBL	R9	G19
-      0x7C240000,  //  002B  CALL	R9	0
-      0x9826110C,  //  002C  SETIDX	R9	K8	K12
-      0x98081009,  //  002D  SETIDX	R2	R8	R9
-      0x50100200,  //  002E  LDBOOL	R4	1	0
-      0x000C0701,  //  002F  ADD	R3	R3	K1
-      0xB81E1A00,  //  0030  GETNGBL	R7	K13
-      0x8C1C0F0E,  //  0031  GETMET	R7	R7	K14
-      0x5824000F,  //  0032  LDCONST	R9	K15
-      0x50280200,  //  0033  LDBOOL	R10	1	0
-      0x7C1C0600,  //  0034  CALL	R7	3
-      0x60200012,  //  0035  GETGBL	R8	G18
-      0x7C200000,  //  0036  CALL	R8	0
-      0xB8261A00,  //  0037  GETNGBL	R9	K13
-      0x8C241310,  //  0038  GETMET	R9	R9	K16
-      0x602C0008,  //  0039  GETGBL	R11	G8
-      0x5C300E00,  //  003A  MOVE	R12	R7
-      0x7C2C0200,  //  003B  CALL	R11	1
-      0x002E220B,  //  003C  ADD	R11	K17	R11
-      0x58300012,  //  003D  LDCONST	R12	K18
-      0x7C240600,  //  003E  CALL	R9	3
-      0x4C240000,  //  003F  LDNIL	R9
-      0x20240E09,  //  0040  NE	R9	R7	R9
-      0x7826004F,  //  0041  JMPF	R9	#0092
-      0x8C240F13,  //  0042  GETMET	R9	R7	K19
-      0x582C0014,  //  0043  LDCONST	R11	K20
-      0x7C240400,  //  0044  CALL	R9	2
-      0x7826004B,  //  0045  JMPF	R9	#0092
-      0x941C0F14,  //  0046  GETIDX	R7	R7	K20
-      0x58240007,  //  0047  LDCONST	R9	K7
-      0x50280200,  //  0048  LDBOOL	R10	1	0
-      0x782A0047,  //  0049  JMPF	R10	#0092
-      0x60280008,  //  004A  GETGBL	R10	G8
-      0x5C2C1200,  //  004B  MOVE	R11	R9
-      0x7C280200,  //  004C  CALL	R10	1
-      0x002A2A0A,  //  004D  ADD	R10	K21	R10
-      0x8C2C0F13,  //  004E  GETMET	R11	R7	K19
-      0x5C341400,  //  004F  MOVE	R13	R10
-      0x7C2C0400,  //  0050  CALL	R11	2
-      0x742E0000,  //  0051  JMPT	R11	#0053
-      0x7002003E,  //  0052  JMP		#0092
-      0x942C0E0A,  //  0053  GETIDX	R11	R7	R10
-      0xB8321A00,  //  0054  GETNGBL	R12	K13
-      0x8C301910,  //  0055  GETMET	R12	R12	K16
-      0x60380018,  //  0056  GETGBL	R14	G24
-      0x583C0016,  //  0057  LDCONST	R15	K22
-      0x5C401400,  //  0058  MOVE	R16	R10
-      0x60440008,  //  0059  GETGBL	R17	G8
-      0x5C481600,  //  005A  MOVE	R18	R11
-      0x7C440200,  //  005B  CALL	R17	1
-      0x7C380600,  //  005C  CALL	R14	3
-      0x583C0012,  //  005D  LDCONST	R15	K18
-      0x7C300600,  //  005E  CALL	R12	3
-      0x8C301704,  //  005F  GETMET	R12	R11	K4
-      0x58380017,  //  0060  LDCONST	R14	K23
-      0x543DFFFE,  //  0061  LDINT	R15	-1
-      0x7C300600,  //  0062  CALL	R12	3
-      0x8C341704,  //  0063  GETMET	R13	R11	K4
-      0x583C0018,  //  0064  LDCONST	R15	K24
-      0x5441FFFE,  //  0065  LDINT	R16	-1
-      0x7C340600,  //  0066  CALL	R13	3
-      0x24381907,  //  0067  GT	R14	R12	K7
-      0x783A0002,  //  0068  JMPF	R14	#006C
-      0x8C381119,  //  0069  GETMET	R14	R8	K25
-      0x04401901,  //  006A  SUB	R16	R12	K1
-      0x7C380400,  //  006B  CALL	R14	2
-      0x24381B07,  //  006C  GT	R14	R13	K7
-      0x783A0002,  //  006D  JMPF	R14	#0071
-      0x8C381119,  //  006E  GETMET	R14	R8	K25
-      0x04401B01,  //  006F  SUB	R16	R13	K1
-      0x7C380400,  //  0070  CALL	R14	2
-      0xB83A1A00,  //  0071  GETNGBL	R14	K13
-      0x8C381D10,  //  0072  GETMET	R14	R14	K16
-      0x60400018,  //  0073  GETGBL	R16	G24
-      0x5844001A,  //  0074  LDCONST	R17	K26
-      0x5C481800,  //  0075  MOVE	R18	R12
-      0x5C4C1A00,  //  0076  MOVE	R19	R13
-      0x7C400600,  //  0077  CALL	R16	3
-      0x58440012,  //  0078  LDCONST	R17	K18
-      0x7C380600,  //  0079  CALL	R14	3
-      0x8C381704,  //  007A  GETMET	R14	R11	K4
-      0x5840001B,  //  007B  LDCONST	R16	K27
-      0x7C380400,  //  007C  CALL	R14	2
-      0x783A0002,  //  007D  JMPF	R14	#0081
-      0x943C1D0A,  //  007E  GETIDX	R15	R14	K10
-      0x243C1F07,  //  007F  GT	R15	R15	K7
-      0x743E0000,  //  0080  JMPT	R15	#0082
-      0x503C0001,  //  0081  LDBOOL	R15	0	1
-      0x503C0200,  //  0082  LDBOOL	R15	1	0
-      0x60400008,  //  0083  GETGBL	R16	G8
-      0x5C440600,  //  0084  MOVE	R17	R3
-      0x7C400200,  //  0085  CALL	R16	1
-      0x60440013,  //  0086  GETGBL	R17	G19
-      0x7C440000,  //  0087  CALL	R17	0
-      0x783E0001,  //  0088  JMPF	R15	#008B
-      0x5848001C,  //  0089  LDCONST	R18	K28
-      0x70020000,  //  008A  JMP		#008C
-      0x5848001D,  //  008B  LDCONST	R18	K29
-      0x98461012,  //  008C  SETIDX	R17	K8	R18
-      0x98463A09,  //  008D  SETIDX	R17	K29	R9
-      0x98082011,  //  008E  SETIDX	R2	R16	R17
-      0x000C0701,  //  008F  ADD	R3	R3	K1
-      0x00241301,  //  0090  ADD	R9	R9	K1
-      0x7001FFB5,  //  0091  JMP		#0048
-      0x6024000C,  //  0092  GETGBL	R9	G12
-      0xB82A1A00,  //  0093  GETNGBL	R10	K13
-      0x8C28151E,  //  0094  GETMET	R10	R10	K30
-      0x7C280200,  //  0095  CALL	R10	1
-      0x7C240200,  //  0096  CALL	R9	1
-      0x58280007,  //  0097  LDCONST	R10	K7
-      0x78120000,  //  0098  JMPF	R4	#009A
-      0x04241301,  //  0099  SUB	R9	R9	K1
-      0x142C1409,  //  009A  LT	R11	R10	R9
-      0x782E0011,  //  009B  JMPF	R11	#00AE
-      0x8C2C1104,  //  009C  GETMET	R11	R8	K4
-      0x5C341400,  //  009D  MOVE	R13	R10
-      0x7C2C0400,  //  009E  CALL	R11	2
-      0x4C300000,  //  009F  LDNIL	R12
-      0x1C2C160C,  //  00A0  EQ	R11	R11	R12
-      0x782E0009,  //  00A1  JMPF	R11	#00AC
-      0x602C0008,  //  00A2  GETGBL	R11	G8
-      0x5C300600,  //  00A3  MOVE	R12	R3
-      0x7C2C0200,  //  00A4  CALL	R11	1
-      0x60300013,  //  00A5  GETGBL	R12	G19
-      0x7C300000,  //  00A6  CALL	R12	0
-      0x9832111F,  //  00A7  SETIDX	R12	K8	K31
-      0x00341501,  //  00A8  ADD	R13	R10	K1
-      0x98323E0D,  //  00A9  SETIDX	R12	K31	R13
-      0x9808160C,  //  00AA  SETIDX	R2	R11	R12
-      0x000C0701,  //  00AB  ADD	R3	R3	K1
-      0x00281501,  //  00AC  ADD	R10	R10	K1
-      0x7001FFEB,  //  00AD  JMP		#009A
-      0x8C2C0320,  //  00AE  GETMET	R11	R1	K32
-      0xB8361A00,  //  00AF  GETNGBL	R13	K13
-      0x8C341B21,  //  00B0  GETMET	R13	R13	K33
-      0x7C340200,  //  00B1  CALL	R13	1
-      0x7C2C0400,  //  00B2  CALL	R11	2
-      0x8C300122,  //  00B3  GETMET	R12	R0	K34
-      0x5C381600,  //  00B4  MOVE	R14	R11
-      0x7C300400,  //  00B5  CALL	R12	2
-      0x60340010,  //  00B6  GETGBL	R13	G16
-      0x5C381800,  //  00B7  MOVE	R14	R12
-      0x7C340200,  //  00B8  CALL	R13	1
-      0xA8020007,  //  00B9  EXBLK	0	#00C2
-      0x5C381A00,  //  00BA  MOVE	R14	R13
-      0x7C380000,  //  00BB  CALL	R14	0
-      0x603C0008,  //  00BC  GETGBL	R15	G8
-      0x5C400600,  //  00BD  MOVE	R16	R3
-      0x7C3C0200,  //  00BE  CALL	R15	1
-      0x98081E0E,  //  00BF  SETIDX	R2	R15	R14
-      0x000C0701,  //  00C0  ADD	R3	R3	K1
-      0x7001FFF7,  //  00C1  JMP		#00BA
-      0x58340023,  //  00C2  LDCONST	R13	K35
-      0xAC340200,  //  00C3  CATCH	R13	1	0
-      0xB0080000,  //  00C4  RAISE	2	R0	R0
-      0x80040400,  //  00C5  RET	1	R2
+    ( &(const binstruction[14]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x580C0001,  //  0001  LDCONST	R3	K1
+      0x5412001C,  //  0002  LDINT	R4	29
+      0x58140002,  //  0003  LDCONST	R5	K2
+      0x50180000,  //  0004  LDBOOL	R6	0	0
+      0x7C040A00,  //  0005  CALL	R1	5
+      0x8C040100,  //  0006  GETMET	R1	R0	K0
+      0xB80E0600,  //  0007  GETNGBL	R3	K3
+      0x880C0704,  //  0008  GETMBR	R3	R3	K4
+      0x5412001C,  //  0009  LDINT	R4	29
+      0x58140002,  //  000A  LDCONST	R5	K2
+      0x50180000,  //  000B  LDBOOL	R6	0	0
+      0x7C040A00,  //  000C  CALL	R1	5
+      0x80000000,  //  000D  RET	0
     })
   )
 );
@@ -3858,631 +6197,12 @@ be_local_closure(Matter_Device_mdns_announce_PASE,   /* name */
 
 
 /********************************************************************
-** Solidified function: clean_remotes
+** Solidified function: get_plugin_remote_info
 ********************************************************************/
-be_local_closure(Matter_Device_clean_remotes,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(introspect),
-    /* K1   */  be_nested_str_weak(http_remotes),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_nested_str_weak(plugins),
-    /* K5   */  be_nested_str_weak(get),
-    /* K6   */  be_nested_str_weak(http_remote),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(keys),
-    /* K10  */  be_nested_str_weak(push),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
-    /* K14  */  be_nested_str_weak(addr),
-    /* K15  */  be_const_int(3),
-    /* K16  */  be_nested_str_weak(close),
-    /* K17  */  be_nested_str_weak(remove),
-    }),
-    be_str_weak(clean_remotes),
-    &be_const_str_solidified,
-    ( &(const binstruction[81]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x780A004C,  //  0002  JMPF	R2	#0050
-      0x60080013,  //  0003  GETGBL	R2	G19
-      0x7C080000,  //  0004  CALL	R2	0
-      0x600C0010,  //  0005  GETGBL	R3	G16
-      0x88100101,  //  0006  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0xA8020003,  //  0008  EXBLK	0	#000D
-      0x5C100600,  //  0009  MOVE	R4	R3
-      0x7C100000,  //  000A  CALL	R4	0
-      0x98080902,  //  000B  SETIDX	R2	R4	K2
-      0x7001FFFB,  //  000C  JMP		#0009
-      0x580C0003,  //  000D  LDCONST	R3	K3
-      0xAC0C0200,  //  000E  CATCH	R3	1	0
-      0xB0080000,  //  000F  RAISE	2	R0	R0
-      0x600C0010,  //  0010  GETGBL	R3	G16
-      0x88100104,  //  0011  GETMBR	R4	R0	K4
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0xA802000F,  //  0013  EXBLK	0	#0024
-      0x5C100600,  //  0014  MOVE	R4	R3
-      0x7C100000,  //  0015  CALL	R4	0
-      0x8C140305,  //  0016  GETMET	R5	R1	K5
-      0x5C1C0800,  //  0017  MOVE	R7	R4
-      0x58200006,  //  0018  LDCONST	R8	K6
-      0x7C140600,  //  0019  CALL	R5	3
-      0x4C180000,  //  001A  LDNIL	R6
-      0x20180A06,  //  001B  NE	R6	R5	R6
-      0x781A0005,  //  001C  JMPF	R6	#0023
-      0x8C180507,  //  001D  GETMET	R6	R2	K7
-      0x5C200A00,  //  001E  MOVE	R8	R5
-      0x58240002,  //  001F  LDCONST	R9	K2
-      0x7C180600,  //  0020  CALL	R6	3
-      0x00180D08,  //  0021  ADD	R6	R6	K8
-      0x98080A06,  //  0022  SETIDX	R2	R5	R6
-      0x7001FFEF,  //  0023  JMP		#0014
-      0x580C0003,  //  0024  LDCONST	R3	K3
-      0xAC0C0200,  //  0025  CATCH	R3	1	0
-      0xB0080000,  //  0026  RAISE	2	R0	R0
-      0x600C0012,  //  0027  GETGBL	R3	G18
-      0x7C0C0000,  //  0028  CALL	R3	0
-      0x60100010,  //  0029  GETGBL	R4	G16
-      0x8C140509,  //  002A  GETMET	R5	R2	K9
-      0x7C140200,  //  002B  CALL	R5	1
-      0x7C100200,  //  002C  CALL	R4	1
-      0xA8020008,  //  002D  EXBLK	0	#0037
-      0x5C140800,  //  002E  MOVE	R5	R4
-      0x7C140000,  //  002F  CALL	R5	0
-      0x94180405,  //  0030  GETIDX	R6	R2	R5
-      0x1C180D02,  //  0031  EQ	R6	R6	K2
-      0x781A0002,  //  0032  JMPF	R6	#0036
-      0x8C18070A,  //  0033  GETMET	R6	R3	K10
-      0x5C200A00,  //  0034  MOVE	R8	R5
-      0x7C180400,  //  0035  CALL	R6	2
-      0x7001FFF6,  //  0036  JMP		#002E
-      0x58100003,  //  0037  LDCONST	R4	K3
-      0xAC100200,  //  0038  CATCH	R4	1	0
-      0xB0080000,  //  0039  RAISE	2	R0	R0
-      0x60100010,  //  003A  GETGBL	R4	G16
-      0x5C140600,  //  003B  MOVE	R5	R3
-      0x7C100200,  //  003C  CALL	R4	1
-      0xA802000E,  //  003D  EXBLK	0	#004D
-      0x5C140800,  //  003E  MOVE	R5	R4
-      0x7C140000,  //  003F  CALL	R5	0
-      0xB81A1600,  //  0040  GETNGBL	R6	K11
-      0x8C180D0C,  //  0041  GETMET	R6	R6	K12
-      0x88200B0E,  //  0042  GETMBR	R8	R5	K14
-      0x00221A08,  //  0043  ADD	R8	K13	R8
-      0x5824000F,  //  0044  LDCONST	R9	K15
-      0x7C180600,  //  0045  CALL	R6	3
-      0x8C180B10,  //  0046  GETMET	R6	R5	K16
-      0x7C180200,  //  0047  CALL	R6	1
-      0x88180101,  //  0048  GETMBR	R6	R0	K1
-      0x8C180D11,  //  0049  GETMET	R6	R6	K17
-      0x88200B0E,  //  004A  GETMBR	R8	R5	K14
-      0x7C180400,  //  004B  CALL	R6	2
-      0x7001FFF0,  //  004C  JMP		#003E
-      0x58100003,  //  004D  LDCONST	R4	K3
-      0xAC100200,  //  004E  CATCH	R4	1	0
-      0xB0080000,  //  004F  RAISE	2	R0	R0
-      0x80000000,  //  0050  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_250ms
-********************************************************************/
-be_local_closure(Matter_Device_every_250ms,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(every_250ms),
-    /* K2   */  be_nested_str_weak(read_sensors_scheduler),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(plugins),
-    /* K5   */  be_const_int(1),
-    }),
-    be_str_weak(every_250ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x8C040102,  //  0003  GETMET	R1	R0	K2
-      0x7C040200,  //  0004  CALL	R1	1
-      0x58040003,  //  0005  LDCONST	R1	K3
-      0x6008000C,  //  0006  GETGBL	R2	G12
-      0x880C0104,  //  0007  GETMBR	R3	R0	K4
-      0x7C080200,  //  0008  CALL	R2	1
-      0x14080202,  //  0009  LT	R2	R1	R2
-      0x780A0005,  //  000A  JMPF	R2	#0011
-      0x88080104,  //  000B  GETMBR	R2	R0	K4
-      0x94080401,  //  000C  GETIDX	R2	R2	R1
-      0x8C080501,  //  000D  GETMET	R2	R2	K1
-      0x7C080200,  //  000E  CALL	R2	1
-      0x00040305,  //  000F  ADD	R1	R1	K5
-      0x7001FFF4,  //  0010  JMP		#0006
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: read_sensors_scheduler
-********************************************************************/
-be_local_closure(Matter_Device_read_sensors_scheduler,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(probe_sensor_time),
-    /* K1   */  be_nested_str_weak(probe_sensor_timestamp),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(time_reached),
-    /* K5   */  be_nested_str_weak(_trigger_read_sensors),
-    /* K6   */  be_nested_str_weak(millis),
-    }),
-    be_str_weak(read_sensors_scheduler),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x78060000,  //  0003  JMPF	R1	#0005
-      0x80000200,  //  0004  RET	0
-      0x88040101,  //  0005  GETMBR	R1	R0	K1
-      0x1C040302,  //  0006  EQ	R1	R1	K2
-      0x74060004,  //  0007  JMPT	R1	#000D
-      0xB8060600,  //  0008  GETNGBL	R1	K3
-      0x8C040304,  //  0009  GETMET	R1	R1	K4
-      0x880C0101,  //  000A  GETMBR	R3	R0	K1
-      0x7C040400,  //  000B  CALL	R1	2
-      0x78060006,  //  000C  JMPF	R1	#0014
-      0x8C040105,  //  000D  GETMET	R1	R0	K5
-      0x7C040200,  //  000E  CALL	R1	1
-      0xB8060600,  //  000F  GETNGBL	R1	K3
-      0x8C040306,  //  0010  GETMET	R1	R1	K6
-      0x880C0100,  //  0011  GETMBR	R3	R0	K0
-      0x7C040400,  //  0012  CALL	R1	2
-      0x90020201,  //  0013  SETMBR	R0	K1	R1
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_announce_op_discovery
-********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(get_device_id),
-    /* K2   */  be_nested_str_weak(copy),
-    /* K3   */  be_nested_str_weak(reverse),
-    /* K4   */  be_nested_str_weak(get_fabric_compressed),
-    /* K5   */  be_nested_str_weak(tohex),
-    /* K6   */  be_nested_str_weak(_X2D),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(eth),
-    /* K12  */  be_nested_str_weak(find),
-    /* K13  */  be_nested_str_weak(up),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K15  */  be_nested_str_weak(hostname_eth),
-    /* K16  */  be_nested_str_weak(add_service),
-    /* K17  */  be_nested_str_weak(_matter),
-    /* K18  */  be_nested_str_weak(_tcp),
-    /* K19  */  be_nested_str_weak(_I),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
-    /* K21  */  be_nested_str_weak(add_subtype),
-    /* K22  */  be_nested_str_weak(wifi),
-    /* K23  */  be_nested_str_weak(hostname_wifi),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K25  */  be_nested_str_weak(_X7C),
-    /* K26  */  be_const_int(2),
-    }),
-    be_str_weak(mdns_announce_op_discovery),
-    &be_const_str_solidified,
-    ( &(const binstruction[121]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA8020064,  //  0001  EXBLK	0	#0067
-      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x8C100304,  //  0008  GETMET	R4	R1	K4
-      0x7C100200,  //  0009  CALL	R4	1
-      0x8C140905,  //  000A  GETMET	R5	R4	K5
-      0x7C140200,  //  000B  CALL	R5	1
-      0x00140B06,  //  000C  ADD	R5	R5	K6
-      0x8C180705,  //  000D  GETMET	R6	R3	K5
-      0x7C180200,  //  000E  CALL	R6	1
-      0x00140A06,  //  000F  ADD	R5	R5	R6
-      0xB81A0E00,  //  0010  GETNGBL	R6	K7
-      0x8C180D08,  //  0011  GETMET	R6	R6	K8
-      0x00221205,  //  0012  ADD	R8	K9	R5
-      0x5824000A,  //  0013  LDCONST	R9	K10
-      0x7C180600,  //  0014  CALL	R6	3
-      0xB81A0E00,  //  0015  GETNGBL	R6	K7
-      0x8C180D0B,  //  0016  GETMET	R6	R6	K11
-      0x7C180200,  //  0017  CALL	R6	1
-      0x8C180D0C,  //  0018  GETMET	R6	R6	K12
-      0x5820000D,  //  0019  LDCONST	R8	K13
-      0x7C180400,  //  001A  CALL	R6	2
-      0x781A0020,  //  001B  JMPF	R6	#003D
-      0xB81A0E00,  //  001C  GETNGBL	R6	K7
-      0x8C180D08,  //  001D  GETMET	R6	R6	K8
-      0x60200018,  //  001E  GETGBL	R8	G24
-      0x5824000E,  //  001F  LDCONST	R9	K14
-      0x5828000B,  //  0020  LDCONST	R10	K11
-      0x5C2C0A00,  //  0021  MOVE	R11	R5
-      0x8830010F,  //  0022  GETMBR	R12	R0	K15
-      0x7C200800,  //  0023  CALL	R8	4
-      0x5824000A,  //  0024  LDCONST	R9	K10
-      0x7C180600,  //  0025  CALL	R6	3
-      0x8C180510,  //  0026  GETMET	R6	R2	K16
-      0x58200011,  //  0027  LDCONST	R8	K17
-      0x58240012,  //  0028  LDCONST	R9	K18
-      0x542A15A3,  //  0029  LDINT	R10	5540
-      0x4C2C0000,  //  002A  LDNIL	R11
-      0x5C300A00,  //  002B  MOVE	R12	R5
-      0x8834010F,  //  002C  GETMBR	R13	R0	K15
-      0x7C180E00,  //  002D  CALL	R6	7
-      0x8C180905,  //  002E  GETMET	R6	R4	K5
-      0x7C180200,  //  002F  CALL	R6	1
-      0x001A2606,  //  0030  ADD	R6	K19	R6
-      0xB81E0E00,  //  0031  GETNGBL	R7	K7
-      0x8C1C0F08,  //  0032  GETMET	R7	R7	K8
-      0x00262806,  //  0033  ADD	R9	K20	R6
-      0x5828000A,  //  0034  LDCONST	R10	K10
-      0x7C1C0600,  //  0035  CALL	R7	3
-      0x8C1C0515,  //  0036  GETMET	R7	R2	K21
-      0x58240011,  //  0037  LDCONST	R9	K17
-      0x58280012,  //  0038  LDCONST	R10	K18
-      0x5C2C0A00,  //  0039  MOVE	R11	R5
-      0x8830010F,  //  003A  GETMBR	R12	R0	K15
-      0x5C340C00,  //  003B  MOVE	R13	R6
-      0x7C1C0C00,  //  003C  CALL	R7	6
-      0xB81A0E00,  //  003D  GETNGBL	R6	K7
-      0x8C180D16,  //  003E  GETMET	R6	R6	K22
-      0x7C180200,  //  003F  CALL	R6	1
-      0x8C180D0C,  //  0040  GETMET	R6	R6	K12
-      0x5820000D,  //  0041  LDCONST	R8	K13
-      0x7C180400,  //  0042  CALL	R6	2
-      0x781A0020,  //  0043  JMPF	R6	#0065
-      0xB81A0E00,  //  0044  GETNGBL	R6	K7
-      0x8C180D08,  //  0045  GETMET	R6	R6	K8
-      0x60200018,  //  0046  GETGBL	R8	G24
-      0x5824000E,  //  0047  LDCONST	R9	K14
-      0x58280016,  //  0048  LDCONST	R10	K22
-      0x5C2C0A00,  //  0049  MOVE	R11	R5
-      0x88300117,  //  004A  GETMBR	R12	R0	K23
-      0x7C200800,  //  004B  CALL	R8	4
-      0x5824000A,  //  004C  LDCONST	R9	K10
-      0x7C180600,  //  004D  CALL	R6	3
-      0x8C180510,  //  004E  GETMET	R6	R2	K16
-      0x58200011,  //  004F  LDCONST	R8	K17
-      0x58240012,  //  0050  LDCONST	R9	K18
-      0x542A15A3,  //  0051  LDINT	R10	5540
-      0x4C2C0000,  //  0052  LDNIL	R11
-      0x5C300A00,  //  0053  MOVE	R12	R5
-      0x88340117,  //  0054  GETMBR	R13	R0	K23
-      0x7C180E00,  //  0055  CALL	R6	7
-      0x8C180905,  //  0056  GETMET	R6	R4	K5
-      0x7C180200,  //  0057  CALL	R6	1
-      0x001A2606,  //  0058  ADD	R6	K19	R6
-      0xB81E0E00,  //  0059  GETNGBL	R7	K7
-      0x8C1C0F08,  //  005A  GETMET	R7	R7	K8
-      0x00262806,  //  005B  ADD	R9	K20	R6
-      0x5828000A,  //  005C  LDCONST	R10	K10
-      0x7C1C0600,  //  005D  CALL	R7	3
-      0x8C1C0515,  //  005E  GETMET	R7	R2	K21
-      0x58240011,  //  005F  LDCONST	R9	K17
-      0x58280012,  //  0060  LDCONST	R10	K18
-      0x5C2C0A00,  //  0061  MOVE	R11	R5
-      0x88300117,  //  0062  GETMBR	R12	R0	K23
-      0x5C340C00,  //  0063  MOVE	R13	R6
-      0x7C1C0C00,  //  0064  CALL	R7	6
-      0xA8040001,  //  0065  EXBLK	1	1
-      0x70020010,  //  0066  JMP		#0078
-      0xAC0C0002,  //  0067  CATCH	R3	0	2
-      0x7002000D,  //  0068  JMP		#0077
-      0xB8160E00,  //  0069  GETNGBL	R5	K7
-      0x8C140B08,  //  006A  GETMET	R5	R5	K8
-      0x601C0008,  //  006B  GETGBL	R7	G8
-      0x5C200600,  //  006C  MOVE	R8	R3
-      0x7C1C0200,  //  006D  CALL	R7	1
-      0x001E3007,  //  006E  ADD	R7	K24	R7
-      0x001C0F19,  //  006F  ADD	R7	R7	K25
-      0x60200008,  //  0070  GETGBL	R8	G8
-      0x5C240800,  //  0071  MOVE	R9	R4
-      0x7C200200,  //  0072  CALL	R8	1
-      0x001C0E08,  //  0073  ADD	R7	R7	R8
-      0x5820001A,  //  0074  LDCONST	R8	K26
-      0x7C140600,  //  0075  CALL	R5	3
-      0x70020000,  //  0076  JMP		#0078
-      0xB0080000,  //  0077  RAISE	2	R0	R0
-      0x80000000,  //  0078  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: MtrJoin
-********************************************************************/
-be_local_closure(Matter_Device_MtrJoin,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K1   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(resp_cmnd_done),
-    }),
-    be_str_weak(MtrJoin),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x60140009,  //  0000  GETGBL	R5	G9
-      0x5C180600,  //  0001  MOVE	R6	R3
-      0x7C140200,  //  0002  CALL	R5	1
-      0x78160002,  //  0003  JMPF	R5	#0007
-      0x8C180100,  //  0004  GETMET	R6	R0	K0
-      0x7C180200,  //  0005  CALL	R6	1
-      0x70020001,  //  0006  JMP		#0009
-      0x8C180101,  //  0007  GETMET	R6	R0	K1
-      0x7C180200,  //  0008  CALL	R6	1
-      0xB81A0400,  //  0009  GETNGBL	R6	K2
-      0x8C180D03,  //  000A  GETMET	R6	R6	K3
-      0x7C180200,  //  000B  CALL	R6	1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_fabric
-********************************************************************/
-be_local_closure(Matter_Device_remove_fabric,   /* name */
+be_local_closure(Matter_Device_get_plugin_remote_info,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(copy),
-    /* K5   */  be_nested_str_weak(reverse),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_const_int(2),
-    /* K8   */  be_nested_str_weak(message_handler),
-    /* K9   */  be_nested_str_weak(im),
-    /* K10  */  be_nested_str_weak(subs_shop),
-    /* K11  */  be_nested_str_weak(remove_by_fabric),
-    /* K12  */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K13  */  be_nested_str_weak(sessions),
-    /* K14  */  be_nested_str_weak(remove_fabric),
-    /* K15  */  be_nested_str_weak(save_fabrics),
-    }),
-    be_str_weak(remove_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x20080202,  //  0001  NE	R2	R1	R2
-      0x780A0019,  //  0002  JMPF	R2	#001D
-      0xB80A0000,  //  0003  GETNGBL	R2	K0
-      0x8C080501,  //  0004  GETMET	R2	R2	K1
-      0x8C100303,  //  0005  GETMET	R4	R1	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C100905,  //  0009  GETMET	R4	R4	K5
-      0x7C100200,  //  000A  CALL	R4	1
-      0x8C100906,  //  000B  GETMET	R4	R4	K6
-      0x7C100200,  //  000C  CALL	R4	1
-      0x00120404,  //  000D  ADD	R4	K2	R4
-      0x58140007,  //  000E  LDCONST	R5	K7
-      0x7C080600,  //  000F  CALL	R2	3
-      0x88080108,  //  0010  GETMBR	R2	R0	K8
-      0x88080509,  //  0011  GETMBR	R2	R2	K9
-      0x8808050A,  //  0012  GETMBR	R2	R2	K10
-      0x8C08050B,  //  0013  GETMET	R2	R2	K11
-      0x5C100200,  //  0014  MOVE	R4	R1
-      0x7C080400,  //  0015  CALL	R2	2
-      0x8C08010C,  //  0016  GETMET	R2	R0	K12
-      0x5C100200,  //  0017  MOVE	R4	R1
-      0x7C080400,  //  0018  CALL	R2	2
-      0x8808010D,  //  0019  GETMBR	R2	R0	K13
-      0x8C08050E,  //  001A  GETMET	R2	R2	K14
-      0x5C100200,  //  001B  MOVE	R4	R1
-      0x7C080400,  //  001C  CALL	R2	2
-      0x8808010D,  //  001D  GETMBR	R2	R0	K13
-      0x8C08050F,  //  001E  GETMET	R2	R2	K15
-      0x7C080200,  //  001F  CALL	R2	1
-      0x80000000,  //  0020  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _compute_pbkdf
-********************************************************************/
-be_local_closure(Matter_Device__compute_pbkdf,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(add),
-    /* K2   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
-    /* K3   */  be_nested_str_weak(derive),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(root_w0),
-    /* K6   */  be_nested_str_weak(EC_P256),
-    /* K7   */  be_nested_str_weak(mod),
-    /* K8   */  be_nested_str_weak(root_L),
-    /* K9   */  be_nested_str_weak(public_key),
-    }),
-    be_str_weak(_compute_pbkdf),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0x60140015,  //  0001  GETGBL	R5	G21
-      0x7C140000,  //  0002  CALL	R5	0
-      0x8C140B01,  //  0003  GETMET	R5	R5	K1
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x54220003,  //  0005  LDINT	R8	4
-      0x7C140600,  //  0006  CALL	R5	3
-      0x8C180902,  //  0007  GETMET	R6	R4	K2
-      0x7C180200,  //  0008  CALL	R6	1
-      0x8C180D03,  //  0009  GETMET	R6	R6	K3
-      0x5C200A00,  //  000A  MOVE	R8	R5
-      0x5C240600,  //  000B  MOVE	R9	R3
-      0x5C280400,  //  000C  MOVE	R10	R2
-      0x542E004F,  //  000D  LDINT	R11	80
-      0x7C180A00,  //  000E  CALL	R6	5
-      0x541E0026,  //  000F  LDINT	R7	39
-      0x401E0807,  //  0010  CONNECT	R7	K4	R7
-      0x941C0C07,  //  0011  GETIDX	R7	R6	R7
-      0x54220027,  //  0012  LDINT	R8	40
-      0x5426004E,  //  0013  LDINT	R9	79
-      0x40201009,  //  0014  CONNECT	R8	R8	R9
-      0x94200C08,  //  0015  GETIDX	R8	R6	R8
-      0x8C240906,  //  0016  GETMET	R9	R4	K6
-      0x7C240200,  //  0017  CALL	R9	1
-      0x8C241307,  //  0018  GETMET	R9	R9	K7
-      0x5C2C0E00,  //  0019  MOVE	R11	R7
-      0x7C240400,  //  001A  CALL	R9	2
-      0x90020A09,  //  001B  SETMBR	R0	K5	R9
-      0x8C240906,  //  001C  GETMET	R9	R4	K6
-      0x7C240200,  //  001D  CALL	R9	1
-      0x8C241307,  //  001E  GETMET	R9	R9	K7
-      0x5C2C1000,  //  001F  MOVE	R11	R8
-      0x7C240400,  //  0020  CALL	R9	2
-      0x8C280906,  //  0021  GETMET	R10	R4	K6
-      0x7C280200,  //  0022  CALL	R10	1
-      0x8C281509,  //  0023  GETMET	R10	R10	K9
-      0x5C301200,  //  0024  MOVE	R12	R9
-      0x7C280400,  //  0025  CALL	R10	2
-      0x9002100A,  //  0026  SETMBR	R0	K8	R10
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _init_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device__init_basic_commissioning,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(count_active_fabrics),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(start_root_basic_commissioning),
-    }),
-    be_str_weak(_init_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x1C040302,  //  0003  EQ	R1	R1	K2
-      0x78060001,  //  0004  JMPF	R1	#0007
-      0x8C040103,  //  0005  GETMET	R1	R0	K3
-      0x7C040200,  //  0006  CALL	R1	1
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: msg_received
-********************************************************************/
-be_local_closure(Matter_Device_msg_received,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -4490,569 +6210,19 @@ be_local_closure(Matter_Device_msg_received,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(msg_received),
+    /* K0   */  be_nested_str_weak(plugins_config_remotes),
+    /* K1   */  be_nested_str_weak(find),
     }),
-    be_str_weak(msg_received),
+    be_str_weak(get_plugin_remote_info),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
-      0x8C100901,  //  0001  GETMET	R4	R4	K1
-      0x5C180200,  //  0002  MOVE	R6	R1
-      0x5C1C0400,  //  0003  MOVE	R7	R2
-      0x5C200600,  //  0004  MOVE	R8	R3
-      0x7C100800,  //  0005  CALL	R4	4
-      0x80040800,  //  0006  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_commands
-********************************************************************/
-be_local_closure(Matter_Device_register_commands,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 3]) {
-      be_nested_proto(
-        10,                          /* nstack */
-        4,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(MtrJoin),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 8]) {  /* code */
-          0x68100000,  //  0000  GETUPV	R4	U0
-          0x8C100900,  //  0001  GETMET	R4	R4	K0
-          0x5C180000,  //  0002  MOVE	R6	R0
-          0x5C1C0200,  //  0003  MOVE	R7	R1
-          0x5C200400,  //  0004  MOVE	R8	R2
-          0x5C240600,  //  0005  MOVE	R9	R3
-          0x7C100A00,  //  0006  CALL	R4	5
-          0x80040800,  //  0007  RET	1	R4
-        })
-      ),
-      be_nested_proto(
-        10,                          /* nstack */
-        4,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(MtrUpdate),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 8]) {  /* code */
-          0x68100000,  //  0000  GETUPV	R4	U0
-          0x8C100900,  //  0001  GETMET	R4	R4	K0
-          0x5C180000,  //  0002  MOVE	R6	R0
-          0x5C1C0200,  //  0003  MOVE	R7	R1
-          0x5C200400,  //  0004  MOVE	R8	R2
-          0x5C240600,  //  0005  MOVE	R9	R3
-          0x7C100A00,  //  0006  CALL	R4	5
-          0x80040800,  //  0007  RET	1	R4
-        })
-      ),
-      be_nested_proto(
-        10,                          /* nstack */
-        4,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(MtrInfo),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 8]) {  /* code */
-          0x68100000,  //  0000  GETUPV	R4	U0
-          0x8C100900,  //  0001  GETMET	R4	R4	K0
-          0x5C180000,  //  0002  MOVE	R6	R0
-          0x5C1C0200,  //  0003  MOVE	R7	R1
-          0x5C200400,  //  0004  MOVE	R8	R2
-          0x5C240600,  //  0005  MOVE	R9	R3
-          0x7C100A00,  //  0006  CALL	R4	5
-          0x80040800,  //  0007  RET	1	R4
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(add_cmd),
-    /* K2   */  be_nested_str_weak(MtrJoin),
-    /* K3   */  be_nested_str_weak(MtrUpdate),
-    /* K4   */  be_nested_str_weak(MtrInfo),
-    }),
-    be_str_weak(register_commands),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x580C0002,  //  0002  LDCONST	R3	K2
-      0x84100000,  //  0003  CLOSURE	R4	P0
-      0x7C040600,  //  0004  CALL	R1	3
-      0xB8060000,  //  0005  GETNGBL	R1	K0
-      0x8C040301,  //  0006  GETMET	R1	R1	K1
-      0x580C0003,  //  0007  LDCONST	R3	K3
-      0x84100001,  //  0008  CLOSURE	R4	P1
-      0x7C040600,  //  0009  CALL	R1	3
-      0xB8060000,  //  000A  GETNGBL	R1	K0
-      0x8C040301,  //  000B  GETMET	R1	R1	K1
-      0x580C0004,  //  000C  LDCONST	R3	K4
-      0x84100002,  //  000D  CLOSURE	R4	P2
-      0x7C040600,  //  000E  CALL	R1	3
-      0xA0000000,  //  000F  CLOSE	R0
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_commissioning_open
-********************************************************************/
-be_local_closure(Matter_Device_is_commissioning_open,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    }),
-    be_str_weak(is_commissioning_open),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: event_fabrics_saved
-********************************************************************/
-be_local_closure(Matter_Device_event_fabrics_saved,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(count_active_fabrics),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(plugins_persist),
-    /* K4   */  be_nested_str_weak(save_param),
-    }),
-    be_str_weak(event_fabrics_saved),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x24040302,  //  0003  GT	R1	R1	K2
-      0x78060005,  //  0004  JMPF	R1	#000B
-      0x88040103,  //  0005  GETMBR	R1	R0	K3
-      0x74060003,  //  0006  JMPT	R1	#000B
-      0x50040200,  //  0007  LDBOOL	R1	1	0
-      0x90020601,  //  0008  SETMBR	R0	K3	R1
-      0x8C040104,  //  0009  GETMET	R1	R0	K4
-      0x7C040200,  //  000A  CALL	R1	1
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: MtrUpdate
-********************************************************************/
-be_local_closure(Matter_Device_MtrUpdate,   /* name */
-  be_nested_proto(
-    18,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(resp_cmnd_str),
-    /* K2   */  be_nested_str_weak(Invalid_X20JSON),
-    /* K3   */  be_nested_str_weak(find_key_i),
-    /* K4   */  be_nested_str_weak(Ep),
-    /* K5   */  be_nested_str_weak(Name),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(Invalid_X20_X27Ep_X27_X20attribute),
-    /* K8   */  be_nested_str_weak(find_plugin_by_endpoint),
-    /* K9   */  be_nested_str_weak(remove),
-    /* K10  */  be_nested_str_weak(find_plugin_by_friendly_name),
-    /* K11  */  be_nested_str_weak(Invalid_X20Device),
-    /* K12  */  be_nested_str_weak(VIRTUAL),
-    /* K13  */  be_nested_str_weak(Device_X20is_X20not_X20virtual),
-    /* K14  */  be_nested_str_weak(consolidate_update_commands),
-    /* K15  */  be_nested_str_weak(keys),
-    /* K16  */  be_nested_str_weak(find_list_i),
-    /* K17  */  be_nested_str_weak(Invalid_X20attribute_X20_X27_X25s_X27),
-    /* K18  */  be_nested_str_weak(stop_iteration),
-    /* K19  */  be_nested_str_weak(update_virtual),
-    /* K20  */  be_nested_str_weak(state_json),
-    /* K21  */  be_nested_str_weak(_X7B_X22_X25s_X22_X3A_X25s_X7D),
-    /* K22  */  be_nested_str_weak(resp_cmnd),
-    /* K23  */  be_nested_str_weak(resp_cmnd_done),
-    /* K24  */  be_nested_str_weak(Missing_X20_X27Device_X27_X20attribute),
-    }),
-    be_str_weak(MtrUpdate),
-    &be_const_str_solidified,
-    ( &(const binstruction[126]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x1C140805,  //  0001  EQ	R5	R4	R5
-      0x78160004,  //  0002  JMPF	R5	#0008
-      0xB8160000,  //  0003  GETNGBL	R5	K0
-      0x8C140B01,  //  0004  GETMET	R5	R5	K1
-      0x581C0002,  //  0005  LDCONST	R7	K2
-      0x7C140400,  //  0006  CALL	R5	2
-      0x80040A00,  //  0007  RET	1	R5
-      0xB8160000,  //  0008  GETNGBL	R5	K0
-      0x8C140B03,  //  0009  GETMET	R5	R5	K3
-      0x5C1C0800,  //  000A  MOVE	R7	R4
-      0x58200004,  //  000B  LDCONST	R8	K4
-      0x7C140600,  //  000C  CALL	R5	3
-      0xB81A0000,  //  000D  GETNGBL	R6	K0
-      0x8C180D03,  //  000E  GETMET	R6	R6	K3
-      0x5C200800,  //  000F  MOVE	R8	R4
-      0x58240005,  //  0010  LDCONST	R9	K5
-      0x7C180600,  //  0011  CALL	R6	3
-      0x74160000,  //  0012  JMPT	R5	#0014
-      0x781A0064,  //  0013  JMPF	R6	#0079
-      0x4C1C0000,  //  0014  LDNIL	R7
-      0x78160010,  //  0015  JMPF	R5	#0027
-      0x60200009,  //  0016  GETGBL	R8	G9
-      0x94240805,  //  0017  GETIDX	R9	R4	R5
-      0x7C200200,  //  0018  CALL	R8	1
-      0x18241106,  //  0019  LE	R9	R8	K6
-      0x78260004,  //  001A  JMPF	R9	#0020
-      0xB8260000,  //  001B  GETNGBL	R9	K0
-      0x8C241301,  //  001C  GETMET	R9	R9	K1
-      0x582C0007,  //  001D  LDCONST	R11	K7
-      0x7C240400,  //  001E  CALL	R9	2
-      0x80041200,  //  001F  RET	1	R9
-      0x8C240108,  //  0020  GETMET	R9	R0	K8
-      0x5C2C1000,  //  0021  MOVE	R11	R8
-      0x7C240400,  //  0022  CALL	R9	2
-      0x5C1C1200,  //  0023  MOVE	R7	R9
-      0x8C240909,  //  0024  GETMET	R9	R4	K9
-      0x5C2C0A00,  //  0025  MOVE	R11	R5
-      0x7C240400,  //  0026  CALL	R9	2
-      0x781A0009,  //  0027  JMPF	R6	#0032
-      0x4C200000,  //  0028  LDNIL	R8
-      0x1C200E08,  //  0029  EQ	R8	R7	R8
-      0x78220003,  //  002A  JMPF	R8	#002F
-      0x8C20010A,  //  002B  GETMET	R8	R0	K10
-      0x94280806,  //  002C  GETIDX	R10	R4	R6
-      0x7C200400,  //  002D  CALL	R8	2
-      0x5C1C1000,  //  002E  MOVE	R7	R8
-      0x8C200909,  //  002F  GETMET	R8	R4	K9
-      0x5C280C00,  //  0030  MOVE	R10	R6
-      0x7C200400,  //  0031  CALL	R8	2
-      0x4C200000,  //  0032  LDNIL	R8
-      0x1C200E08,  //  0033  EQ	R8	R7	R8
-      0x78220004,  //  0034  JMPF	R8	#003A
-      0xB8220000,  //  0035  GETNGBL	R8	K0
-      0x8C201101,  //  0036  GETMET	R8	R8	K1
-      0x5828000B,  //  0037  LDCONST	R10	K11
-      0x7C200400,  //  0038  CALL	R8	2
-      0x80041000,  //  0039  RET	1	R8
-      0x88200F0C,  //  003A  GETMBR	R8	R7	K12
-      0x74220004,  //  003B  JMPT	R8	#0041
-      0xB8220000,  //  003C  GETNGBL	R8	K0
-      0x8C201101,  //  003D  GETMET	R8	R8	K1
-      0x5828000D,  //  003E  LDCONST	R10	K13
-      0x7C200400,  //  003F  CALL	R8	2
-      0x80041000,  //  0040  RET	1	R8
-      0x8C200F0E,  //  0041  GETMET	R8	R7	K14
-      0x7C200200,  //  0042  CALL	R8	1
-      0x60240013,  //  0043  GETGBL	R9	G19
-      0x7C240000,  //  0044  CALL	R9	0
-      0x60280010,  //  0045  GETGBL	R10	G16
-      0x8C2C090F,  //  0046  GETMET	R11	R4	K15
-      0x7C2C0200,  //  0047  CALL	R11	1
-      0x7C280200,  //  0048  CALL	R10	1
-      0xA8020016,  //  0049  EXBLK	0	#0061
-      0x5C2C1400,  //  004A  MOVE	R11	R10
-      0x7C2C0000,  //  004B  CALL	R11	0
-      0xB8320000,  //  004C  GETNGBL	R12	K0
-      0x8C301910,  //  004D  GETMET	R12	R12	K16
-      0x5C381000,  //  004E  MOVE	R14	R8
-      0x5C3C1600,  //  004F  MOVE	R15	R11
-      0x7C300600,  //  0050  CALL	R12	3
-      0x4C340000,  //  0051  LDNIL	R13
-      0x1C34180D,  //  0052  EQ	R13	R12	R13
-      0x78360008,  //  0053  JMPF	R13	#005D
-      0xB8360000,  //  0054  GETNGBL	R13	K0
-      0x8C341B01,  //  0055  GETMET	R13	R13	K1
-      0x603C0018,  //  0056  GETGBL	R15	G24
-      0x58400011,  //  0057  LDCONST	R16	K17
-      0x5C441600,  //  0058  MOVE	R17	R11
-      0x7C3C0400,  //  0059  CALL	R15	2
-      0x7C340400,  //  005A  CALL	R13	2
-      0xA8040001,  //  005B  EXBLK	1	1
-      0x80001A00,  //  005C  RET	0
-      0x9434100C,  //  005D  GETIDX	R13	R8	R12
-      0x9438080B,  //  005E  GETIDX	R14	R4	R11
-      0x98241A0E,  //  005F  SETIDX	R9	R13	R14
-      0x7001FFE8,  //  0060  JMP		#004A
-      0x58280012,  //  0061  LDCONST	R10	K18
-      0xAC280200,  //  0062  CATCH	R10	1	0
-      0xB0080000,  //  0063  RAISE	2	R0	R0
-      0x8C280F13,  //  0064  GETMET	R10	R7	K19
-      0x5C301200,  //  0065  MOVE	R12	R9
-      0x7C280400,  //  0066  CALL	R10	2
-      0x8C280F14,  //  0067  GETMET	R10	R7	K20
-      0x7C280200,  //  0068  CALL	R10	1
-      0x782A000A,  //  0069  JMPF	R10	#0075
-      0x602C0018,  //  006A  GETGBL	R11	G24
-      0x58300015,  //  006B  LDCONST	R12	K21
-      0x5C340200,  //  006C  MOVE	R13	R1
-      0x5C381400,  //  006D  MOVE	R14	R10
-      0x7C2C0600,  //  006E  CALL	R11	3
-      0xB8320000,  //  006F  GETNGBL	R12	K0
-      0x8C301916,  //  0070  GETMET	R12	R12	K22
-      0x5C381600,  //  0071  MOVE	R14	R11
-      0x7C300400,  //  0072  CALL	R12	2
-      0x80041800,  //  0073  RET	1	R12
-      0x70020003,  //  0074  JMP		#0079
-      0xB82E0000,  //  0075  GETNGBL	R11	K0
-      0x8C2C1717,  //  0076  GETMET	R11	R11	K23
-      0x7C2C0200,  //  0077  CALL	R11	1
-      0x80041600,  //  0078  RET	1	R11
-      0xB81E0000,  //  0079  GETNGBL	R7	K0
-      0x8C1C0F01,  //  007A  GETMET	R7	R7	K1
-      0x58240018,  //  007B  LDCONST	R9	K24
-      0x7C1C0400,  //  007C  CALL	R7	2
-      0x80000000,  //  007D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_plugin_by_endpoint
-********************************************************************/
-be_local_closure(Matter_Device_find_plugin_by_endpoint,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(plugins),
-    /* K2   */  be_nested_str_weak(get_endpoint),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(find_plugin_by_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0008,  //  0005  JMPF	R3	#000F
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x8C100702,  //  0008  GETMET	R4	R3	K2
-      0x7C100200,  //  0009  CALL	R4	1
-      0x1C100801,  //  000A  EQ	R4	R4	R1
-      0x78120000,  //  000B  JMPF	R4	#000D
-      0x80040600,  //  000C  RET	1	R3
-      0x00080503,  //  000D  ADD	R2	R2	K3
-      0x7001FFF1,  //  000E  JMP		#0001
-      0x4C0C0000,  //  000F  LDNIL	R3
-      0x80040600,  //  0010  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_mdns_announce_hostnames
-********************************************************************/
-be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_mdns_host),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[10]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x50080000,  //  0002  LDBOOL	R2	0	0
-          0x7C000400,  //  0003  CALL	R0	2
-          0xB8020200,  //  0004  GETNGBL	R0	K1
-          0x8C000102,  //  0005  GETMET	R0	R0	K2
-          0x58080003,  //  0006  LDCONST	R2	K3
-          0x580C0004,  //  0007  LDCONST	R3	K4
-          0x7C000600,  //  0008  CALL	R0	3
-          0x80000000,  //  0009  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_mdns_announce_hostname),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_mdns_host),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[10]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x50080200,  //  0002  LDBOOL	R2	1	0
-          0x7C000400,  //  0003  CALL	R0	2
-          0xB8020200,  //  0004  GETNGBL	R0	K1
-          0x8C000102,  //  0005  GETMET	R0	R0	K2
-          0x58080003,  //  0006  LDCONST	R2	K3
-          0x580C0004,  //  0007  LDCONST	R3	K4
-          0x7C000600,  //  0008  CALL	R0	3
-          0x80000000,  //  0009  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(wifi),
-    /* K2   */  be_nested_str_weak(up),
-    /* K3   */  be_nested_str_weak(_mdns_announce_hostname),
-    /* K4   */  be_nested_str_weak(add_rule),
-    /* K5   */  be_nested_str_weak(Wifi_X23Connected),
-    /* K6   */  be_nested_str_weak(matter_mdns_host),
-    /* K7   */  be_nested_str_weak(eth),
-    /* K8   */  be_nested_str_weak(Eth_X23Connected),
-    }),
-    be_str_weak(start_mdns_announce_hostnames),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x94040302,  //  0003  GETIDX	R1	R1	K2
-      0x78060003,  //  0004  JMPF	R1	#0009
-      0x8C040103,  //  0005  GETMET	R1	R0	K3
-      0x500C0000,  //  0006  LDBOOL	R3	0	0
-      0x7C040400,  //  0007  CALL	R1	2
-      0x70020005,  //  0008  JMP		#000F
-      0xB8060000,  //  0009  GETNGBL	R1	K0
-      0x8C040304,  //  000A  GETMET	R1	R1	K4
-      0x580C0005,  //  000B  LDCONST	R3	K5
-      0x84100000,  //  000C  CLOSURE	R4	P0
-      0x58140006,  //  000D  LDCONST	R5	K6
-      0x7C040800,  //  000E  CALL	R1	4
-      0xB8060000,  //  000F  GETNGBL	R1	K0
-      0x8C040307,  //  0010  GETMET	R1	R1	K7
-      0x7C040200,  //  0011  CALL	R1	1
-      0x94040302,  //  0012  GETIDX	R1	R1	K2
-      0x78060003,  //  0013  JMPF	R1	#0018
-      0x8C040103,  //  0014  GETMET	R1	R0	K3
-      0x500C0200,  //  0015  LDBOOL	R3	1	0
-      0x7C040400,  //  0016  CALL	R1	2
-      0x70020005,  //  0017  JMP		#001E
-      0xB8060000,  //  0018  GETNGBL	R1	K0
-      0x8C040304,  //  0019  GETMET	R1	R1	K4
-      0x580C0008,  //  001A  LDCONST	R3	K8
-      0x84100001,  //  001B  CLOSURE	R4	P1
-      0x58140006,  //  001C  LDCONST	R5	K6
-      0x7C040800,  //  001D  CALL	R1	4
-      0xA0000000,  //  001E  CLOSE	R0
-      0x80000000,  //  001F  RET	0
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x60140013,  //  0003  GETGBL	R5	G19
+      0x7C140000,  //  0004  CALL	R5	0
+      0x7C080600,  //  0005  CALL	R2	3
+      0x80040400,  //  0006  RET	1	R2
     })
   )
 );
@@ -5090,1083 +6260,141 @@ be_local_closure(Matter_Device_every_50ms,   /* name */
 
 
 /********************************************************************
-** Solidified function: stop
-********************************************************************/
-be_local_closure(Matter_Device_stop,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(remove_driver),
-    /* K2   */  be_nested_str_weak(udp_server),
-    /* K3   */  be_nested_str_weak(stop),
-    }),
-    be_str_weak(stop),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x88040102,  //  0004  GETMBR	R1	R0	K2
-      0x78060002,  //  0005  JMPF	R1	#0009
-      0x88040102,  //  0006  GETMBR	R1	R0	K2
-      0x8C040303,  //  0007  GETMET	R1	R1	K3
-      0x7C040200,  //  0008  CALL	R1	1
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_remove_op_discovery
-********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(get_device_id),
-    /* K2   */  be_nested_str_weak(copy),
-    /* K3   */  be_nested_str_weak(reverse),
-    /* K4   */  be_nested_str_weak(get_fabric_compressed),
-    /* K5   */  be_nested_str_weak(tohex),
-    /* K6   */  be_nested_str_weak(_X2D),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(eth),
-    /* K9   */  be_nested_str_weak(find),
-    /* K10  */  be_nested_str_weak(up),
-    /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(remove_service),
-    /* K15  */  be_nested_str_weak(_matter),
-    /* K16  */  be_nested_str_weak(_tcp),
-    /* K17  */  be_nested_str_weak(hostname_eth),
-    /* K18  */  be_nested_str_weak(wifi),
-    /* K19  */  be_nested_str_weak(hostname_wifi),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K21  */  be_nested_str_weak(_X7C),
-    /* K22  */  be_const_int(2),
-    }),
-    be_str_weak(mdns_remove_op_discovery),
-    &be_const_str_solidified,
-    ( &(const binstruction[80]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA802003B,  //  0001  EXBLK	0	#003E
-      0x8C0C0301,  //  0002  GETMET	R3	R1	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x8C100304,  //  0008  GETMET	R4	R1	K4
-      0x7C100200,  //  0009  CALL	R4	1
-      0x8C140905,  //  000A  GETMET	R5	R4	K5
-      0x7C140200,  //  000B  CALL	R5	1
-      0x00140B06,  //  000C  ADD	R5	R5	K6
-      0x8C180705,  //  000D  GETMET	R6	R3	K5
-      0x7C180200,  //  000E  CALL	R6	1
-      0x00140A06,  //  000F  ADD	R5	R5	R6
-      0xB81A0E00,  //  0010  GETNGBL	R6	K7
-      0x8C180D08,  //  0011  GETMET	R6	R6	K8
-      0x7C180200,  //  0012  CALL	R6	1
-      0x8C180D09,  //  0013  GETMET	R6	R6	K9
-      0x5820000A,  //  0014  LDCONST	R8	K10
-      0x7C180400,  //  0015  CALL	R6	2
-      0x781A000E,  //  0016  JMPF	R6	#0026
-      0xB81A0E00,  //  0017  GETNGBL	R6	K7
-      0x8C180D0B,  //  0018  GETMET	R6	R6	K11
-      0x60200018,  //  0019  GETGBL	R8	G24
-      0x5824000C,  //  001A  LDCONST	R9	K12
-      0x58280008,  //  001B  LDCONST	R10	K8
-      0x5C2C0A00,  //  001C  MOVE	R11	R5
-      0x7C200600,  //  001D  CALL	R8	3
-      0x5824000D,  //  001E  LDCONST	R9	K13
-      0x7C180600,  //  001F  CALL	R6	3
-      0x8C18050E,  //  0020  GETMET	R6	R2	K14
-      0x5820000F,  //  0021  LDCONST	R8	K15
-      0x58240010,  //  0022  LDCONST	R9	K16
-      0x5C280A00,  //  0023  MOVE	R10	R5
-      0x882C0111,  //  0024  GETMBR	R11	R0	K17
-      0x7C180A00,  //  0025  CALL	R6	5
-      0xB81A0E00,  //  0026  GETNGBL	R6	K7
-      0x8C180D12,  //  0027  GETMET	R6	R6	K18
-      0x7C180200,  //  0028  CALL	R6	1
-      0x8C180D09,  //  0029  GETMET	R6	R6	K9
-      0x5820000A,  //  002A  LDCONST	R8	K10
-      0x7C180400,  //  002B  CALL	R6	2
-      0x781A000E,  //  002C  JMPF	R6	#003C
-      0xB81A0E00,  //  002D  GETNGBL	R6	K7
-      0x8C180D0B,  //  002E  GETMET	R6	R6	K11
-      0x60200018,  //  002F  GETGBL	R8	G24
-      0x5824000C,  //  0030  LDCONST	R9	K12
-      0x58280012,  //  0031  LDCONST	R10	K18
-      0x5C2C0A00,  //  0032  MOVE	R11	R5
-      0x7C200600,  //  0033  CALL	R8	3
-      0x5824000D,  //  0034  LDCONST	R9	K13
-      0x7C180600,  //  0035  CALL	R6	3
-      0x8C18050E,  //  0036  GETMET	R6	R2	K14
-      0x5820000F,  //  0037  LDCONST	R8	K15
-      0x58240010,  //  0038  LDCONST	R9	K16
-      0x5C280A00,  //  0039  MOVE	R10	R5
-      0x882C0113,  //  003A  GETMBR	R11	R0	K19
-      0x7C180A00,  //  003B  CALL	R6	5
-      0xA8040001,  //  003C  EXBLK	1	1
-      0x70020010,  //  003D  JMP		#004F
-      0xAC0C0002,  //  003E  CATCH	R3	0	2
-      0x7002000D,  //  003F  JMP		#004E
-      0xB8160E00,  //  0040  GETNGBL	R5	K7
-      0x8C140B0B,  //  0041  GETMET	R5	R5	K11
-      0x601C0008,  //  0042  GETGBL	R7	G8
-      0x5C200600,  //  0043  MOVE	R8	R3
-      0x7C1C0200,  //  0044  CALL	R7	1
-      0x001E2807,  //  0045  ADD	R7	K20	R7
-      0x001C0F15,  //  0046  ADD	R7	R7	K21
-      0x60200008,  //  0047  GETGBL	R8	G8
-      0x5C240800,  //  0048  MOVE	R9	R4
-      0x7C200200,  //  0049  CALL	R8	1
-      0x001C0E08,  //  004A  ADD	R7	R7	R8
-      0x58200016,  //  004B  LDCONST	R8	K22
-      0x7C140600,  //  004C  CALL	R5	3
-      0x70020000,  //  004D  JMP		#004F
-      0xB0080000,  //  004E  RAISE	2	R0	R0
-      0x80000000,  //  004F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _start_udp
-********************************************************************/
-be_local_closure(Matter_Device__start_udp,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        8,                          /* nstack */
-        3,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(msg_received),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 7]) {  /* code */
-          0x680C0000,  //  0000  GETUPV	R3	U0
-          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
-          0x5C140000,  //  0002  MOVE	R5	R0
-          0x5C180200,  //  0003  MOVE	R6	R1
-          0x5C1C0400,  //  0004  MOVE	R7	R2
-          0x7C0C0800,  //  0005  CALL	R3	4
-          0x80040600,  //  0006  RET	1	R3
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(UDPServer),
-    /* K7   */  be_nested_str_weak(),
-    /* K8   */  be_nested_str_weak(start),
-    }),
-    be_str_weak(_start_udp),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80000400,  //  0002  RET	0
-      0x4C080000,  //  0003  LDNIL	R2
-      0x1C080202,  //  0004  EQ	R2	R1	R2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x540615A3,  //  0006  LDINT	R1	5540
-      0xB80A0200,  //  0007  GETNGBL	R2	K1
-      0x8C080502,  //  0008  GETMET	R2	R2	K2
-      0x60100008,  //  0009  GETGBL	R4	G8
-      0x5C140200,  //  000A  MOVE	R5	R1
-      0x7C100200,  //  000B  CALL	R4	1
-      0x00120604,  //  000C  ADD	R4	K3	R4
-      0x58140004,  //  000D  LDCONST	R5	K4
-      0x7C080600,  //  000E  CALL	R2	3
-      0xB80A0A00,  //  000F  GETNGBL	R2	K5
-      0x8C080506,  //  0010  GETMET	R2	R2	K6
-      0x5C100000,  //  0011  MOVE	R4	R0
-      0x58140007,  //  0012  LDCONST	R5	K7
-      0x5C180200,  //  0013  MOVE	R6	R1
-      0x7C080800,  //  0014  CALL	R2	4
-      0x90020002,  //  0015  SETMBR	R0	K0	R2
-      0x88080100,  //  0016  GETMBR	R2	R0	K0
-      0x8C080508,  //  0017  GETMET	R2	R2	K8
-      0x84100000,  //  0018  CLOSURE	R4	P0
-      0x7C080400,  //  0019  CALL	R2	2
-      0xA0000000,  //  001A  CLOSE	R0
-      0x80000000,  //  001B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_plugin_remote_info
-********************************************************************/
-be_local_closure(Matter_Device_get_plugin_remote_info,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins_config_remotes),
-    /* K1   */  be_nested_str_weak(find),
-    }),
-    be_str_weak(get_plugin_remote_info),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x60140013,  //  0003  GETGBL	R5	G19
-      0x7C140000,  //  0004  CALL	R5	0
-      0x7C080600,  //  0005  CALL	R2	3
-      0x80040400,  //  0006  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_http_remote
-********************************************************************/
-be_local_closure(Matter_Device_register_http_remote,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(http_remotes),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(get_timeout),
-    /* K3   */  be_nested_str_weak(set_timeout),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(HTTP_remote),
-    /* K6   */  be_nested_str_weak(plugins_config_remotes),
-    /* K7   */  be_nested_str_weak(set_info),
-    }),
-    be_str_weak(register_http_remote),
-    &be_const_str_solidified,
-    ( &(const binstruction[42]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x4C100000,  //  0001  LDNIL	R4
-      0x1C0C0604,  //  0002  EQ	R3	R3	R4
-      0x780E0002,  //  0003  JMPF	R3	#0007
-      0x600C0013,  //  0004  GETGBL	R3	G19
-      0x7C0C0000,  //  0005  CALL	R3	0
-      0x90020003,  //  0006  SETMBR	R0	K0	R3
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x88100100,  //  0008  GETMBR	R4	R0	K0
-      0x8C100901,  //  0009  GETMET	R4	R4	K1
-      0x5C180200,  //  000A  MOVE	R6	R1
-      0x7C100400,  //  000B  CALL	R4	2
-      0x78120009,  //  000C  JMPF	R4	#0017
-      0x88100100,  //  000D  GETMBR	R4	R0	K0
-      0x940C0801,  //  000E  GETIDX	R3	R4	R1
-      0x8C140702,  //  000F  GETMET	R5	R3	K2
-      0x7C140200,  //  0010  CALL	R5	1
-      0x14140405,  //  0011  LT	R5	R2	R5
-      0x78160002,  //  0012  JMPF	R5	#0016
-      0x8C140703,  //  0013  GETMET	R5	R3	K3
-      0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x7C140400,  //  0015  CALL	R5	2
-      0x70020011,  //  0016  JMP		#0029
-      0xB8120800,  //  0017  GETNGBL	R4	K4
-      0x8C100905,  //  0018  GETMET	R4	R4	K5
-      0x5C180000,  //  0019  MOVE	R6	R0
-      0x5C1C0200,  //  001A  MOVE	R7	R1
-      0x5C200400,  //  001B  MOVE	R8	R2
-      0x7C100800,  //  001C  CALL	R4	4
-      0x5C0C0800,  //  001D  MOVE	R3	R4
-      0x88100106,  //  001E  GETMBR	R4	R0	K6
-      0x8C100901,  //  001F  GETMET	R4	R4	K1
-      0x5C180200,  //  0020  MOVE	R6	R1
-      0x7C100400,  //  0021  CALL	R4	2
-      0x78120003,  //  0022  JMPF	R4	#0027
-      0x8C100707,  //  0023  GETMET	R4	R3	K7
-      0x88180106,  //  0024  GETMBR	R6	R0	K6
-      0x94180C01,  //  0025  GETIDX	R6	R6	R1
-      0x7C100400,  //  0026  CALL	R4	2
-      0x88100100,  //  0027  GETMBR	R4	R0	K0
-      0x98100203,  //  0028  SETIDX	R4	R1	R3
-      0x80040600,  //  0029  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_remove_op_discovery_all_fabrics
-********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(active_fabrics),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(mdns_remove_op_discovery_all_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000B,  //  0005  EXBLK	0	#0012
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x780E0005,  //  000A  JMPF	R3	#0011
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x780E0002,  //  000D  JMPF	R3	#0011
-      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x7001FFF3,  //  0011  JMP		#0006
-      0x58040005,  //  0012  LDCONST	R1	K5
-      0xAC040200,  //  0013  CATCH	R1	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_plugin_class_arg
-********************************************************************/
-be_local_closure(Matter_Device_get_plugin_class_arg,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins_classes),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(ARG),
-    /* K3   */  be_nested_str_weak(),
-    }),
-    be_str_weak(get_plugin_class_arg),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x880C0502,  //  0005  GETMBR	R3	R2	K2
-      0x70020000,  //  0006  JMP		#0008
-      0x580C0003,  //  0007  LDCONST	R3	K3
-      0x80040600,  //  0008  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: generate_random_passcode
-********************************************************************/
-be_local_closure(Matter_Device_generate_random_passcode,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(random),
-    /* K2   */  be_nested_str_weak(get),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_const_int(134217727),
-    /* K5   */  be_const_int(99999998),
-    /* K6   */  be_nested_str_weak(PASSCODE_INVALID),
-    /* K7   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(generate_random_passcode),
-    &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x500C0200,  //  0002  LDBOOL	R3	1	0
-      0x780E001D,  //  0003  JMPF	R3	#0022
-      0x8C0C0301,  //  0004  GETMET	R3	R1	K1
-      0x54160003,  //  0005  LDINT	R5	4
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
-      0x58140003,  //  0008  LDCONST	R5	K3
-      0x541A0003,  //  0009  LDINT	R6	4
-      0x7C0C0600,  //  000A  CALL	R3	3
-      0x2C0C0704,  //  000B  AND	R3	R3	K4
-      0x5C080600,  //  000C  MOVE	R2	R3
-      0x240C0505,  //  000D  GT	R3	R2	K5
-      0x780E0000,  //  000E  JMPF	R3	#0010
-      0x7001FFF1,  //  000F  JMP		#0002
-      0x600C0010,  //  0010  GETGBL	R3	G16
-      0x88100106,  //  0011  GETMBR	R4	R0	K6
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0xA8020005,  //  0013  EXBLK	0	#001A
-      0x5C100600,  //  0014  MOVE	R4	R3
-      0x7C100000,  //  0015  CALL	R4	0
-      0x1C140404,  //  0016  EQ	R5	R2	R4
-      0x78160000,  //  0017  JMPF	R5	#0019
-      0x4C080000,  //  0018  LDNIL	R2
-      0x7001FFF9,  //  0019  JMP		#0014
-      0x580C0007,  //  001A  LDCONST	R3	K7
-      0xAC0C0200,  //  001B  CATCH	R3	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x4C0C0000,  //  001D  LDNIL	R3
-      0x200C0403,  //  001E  NE	R3	R2	R3
-      0x780E0000,  //  001F  JMPF	R3	#0021
-      0x80040400,  //  0020  RET	1	R2
-      0x7001FFDF,  //  0021  JMP		#0002
-      0x80000000,  //  0022  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_root_commissioning_open
-********************************************************************/
-be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(commissioning_admin_fabric),
-    }),
-    be_str_weak(is_root_commissioning_open),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060003,  //  0003  JMPF	R1	#0008
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x4C080000,  //  0005  LDNIL	R2
-      0x1C040202,  //  0006  EQ	R1	R1	R2
-      0x74060000,  //  0007  JMPT	R1	#0009
-      0x50040001,  //  0008  LDBOOL	R1	0	1
-      0x50040200,  //  0009  LDBOOL	R1	1	0
-      0x80040200,  //  000A  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(is_root_commissioning_open),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(publish_result),
-    /* K3   */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A0_X7D_X7D),
-    /* K4   */  be_nested_str_weak(Matter),
-    /* K5   */  be_nested_str_weak(commissioning_open),
-    /* K6   */  be_nested_str_weak(mdns_remove_PASE),
-    /* K7   */  be_nested_str_weak(commissioning_iterations),
-    /* K8   */  be_nested_str_weak(commissioning_discriminator),
-    /* K9   */  be_nested_str_weak(commissioning_salt),
-    /* K10  */  be_nested_str_weak(commissioning_w0),
-    /* K11  */  be_nested_str_weak(commissioning_L),
-    /* K12  */  be_nested_str_weak(commissioning_admin_fabric),
-    }),
-    be_str_weak(stop_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x78060004,  //  0002  JMPF	R1	#0008
-      0xB8060200,  //  0003  GETNGBL	R1	K1
-      0x8C040302,  //  0004  GETMET	R1	R1	K2
-      0x580C0003,  //  0005  LDCONST	R3	K3
-      0x58100004,  //  0006  LDCONST	R4	K4
-      0x7C040600,  //  0007  CALL	R1	3
-      0x4C040000,  //  0008  LDNIL	R1
-      0x90020A01,  //  0009  SETMBR	R0	K5	R1
-      0x8C040106,  //  000A  GETMET	R1	R0	K6
-      0x7C040200,  //  000B  CALL	R1	1
-      0x4C040000,  //  000C  LDNIL	R1
-      0x90020E01,  //  000D  SETMBR	R0	K7	R1
-      0x4C040000,  //  000E  LDNIL	R1
-      0x90021001,  //  000F  SETMBR	R0	K8	R1
-      0x4C040000,  //  0010  LDNIL	R1
-      0x90021201,  //  0011  SETMBR	R0	K9	R1
-      0x4C040000,  //  0012  LDNIL	R1
-      0x90021401,  //  0013  SETMBR	R0	K10	R1
-      0x4C040000,  //  0014  LDNIL	R1
-      0x90021601,  //  0015  SETMBR	R0	K11	R1
-      0x4C040000,  //  0016  LDNIL	R1
-      0x90021801,  //  0017  SETMBR	R0	K12	R1
-      0x80000000,  //  0018  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: autoconf_sensors_list
-********************************************************************/
-be_local_closure(Matter_Device_autoconf_sensors_list,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(k2l),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(Temperature),
-    /* K3   */  be_nested_str_weak(_X23Temperature),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_nested_str_weak(type),
-    /* K6   */  be_nested_str_weak(temperature),
-    /* K7   */  be_nested_str_weak(filter),
-    /* K8   */  be_nested_str_weak(stop_iteration),
-    /* K9   */  be_nested_str_weak(Pressure),
-    /* K10  */  be_nested_str_weak(_X23Pressure),
-    /* K11  */  be_nested_str_weak(pressure),
-    /* K12  */  be_nested_str_weak(Illuminance),
-    /* K13  */  be_nested_str_weak(_X23Illuminance),
-    /* K14  */  be_nested_str_weak(illuminance),
-    /* K15  */  be_nested_str_weak(Humidity),
-    /* K16  */  be_nested_str_weak(_X23Humidity),
-    /* K17  */  be_nested_str_weak(humidity),
-    }),
-    be_str_weak(autoconf_sensors_list),
-    &be_const_str_solidified,
-    ( &(const binstruction[119]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x8C100100,  //  0003  GETMET	R4	R0	K0
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x7C100400,  //  0005  CALL	R4	2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0xA8020013,  //  0007  EXBLK	0	#001C
-      0x5C100600,  //  0008  MOVE	R4	R3
-      0x7C100000,  //  0009  CALL	R4	0
-      0x94140204,  //  000A  GETIDX	R5	R1	R4
-      0x6018000F,  //  000B  GETGBL	R6	G15
-      0x5C1C0A00,  //  000C  MOVE	R7	R5
-      0x60200013,  //  000D  GETGBL	R8	G19
-      0x7C180400,  //  000E  CALL	R6	2
-      0x781A000A,  //  000F  JMPF	R6	#001B
-      0x8C180B01,  //  0010  GETMET	R6	R5	K1
-      0x58200002,  //  0011  LDCONST	R8	K2
-      0x7C180400,  //  0012  CALL	R6	2
-      0x781A0006,  //  0013  JMPF	R6	#001B
-      0x00180903,  //  0014  ADD	R6	R4	K3
-      0x8C1C0504,  //  0015  GETMET	R7	R2	K4
-      0x60240013,  //  0016  GETGBL	R9	G19
-      0x7C240000,  //  0017  CALL	R9	0
-      0x98260B06,  //  0018  SETIDX	R9	K5	K6
-      0x98260E06,  //  0019  SETIDX	R9	K7	R6
-      0x7C1C0400,  //  001A  CALL	R7	2
-      0x7001FFEB,  //  001B  JMP		#0008
-      0x580C0008,  //  001C  LDCONST	R3	K8
-      0xAC0C0200,  //  001D  CATCH	R3	1	0
-      0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x600C0010,  //  001F  GETGBL	R3	G16
-      0x8C100100,  //  0020  GETMET	R4	R0	K0
-      0x5C180200,  //  0021  MOVE	R6	R1
-      0x7C100400,  //  0022  CALL	R4	2
-      0x7C0C0200,  //  0023  CALL	R3	1
-      0xA8020013,  //  0024  EXBLK	0	#0039
-      0x5C100600,  //  0025  MOVE	R4	R3
-      0x7C100000,  //  0026  CALL	R4	0
-      0x94140204,  //  0027  GETIDX	R5	R1	R4
-      0x6018000F,  //  0028  GETGBL	R6	G15
-      0x5C1C0A00,  //  0029  MOVE	R7	R5
-      0x60200013,  //  002A  GETGBL	R8	G19
-      0x7C180400,  //  002B  CALL	R6	2
-      0x781A000A,  //  002C  JMPF	R6	#0038
-      0x8C180B01,  //  002D  GETMET	R6	R5	K1
-      0x58200009,  //  002E  LDCONST	R8	K9
-      0x7C180400,  //  002F  CALL	R6	2
-      0x781A0006,  //  0030  JMPF	R6	#0038
-      0x0018090A,  //  0031  ADD	R6	R4	K10
-      0x8C1C0504,  //  0032  GETMET	R7	R2	K4
-      0x60240013,  //  0033  GETGBL	R9	G19
-      0x7C240000,  //  0034  CALL	R9	0
-      0x98260B0B,  //  0035  SETIDX	R9	K5	K11
-      0x98260E06,  //  0036  SETIDX	R9	K7	R6
-      0x7C1C0400,  //  0037  CALL	R7	2
-      0x7001FFEB,  //  0038  JMP		#0025
-      0x580C0008,  //  0039  LDCONST	R3	K8
-      0xAC0C0200,  //  003A  CATCH	R3	1	0
-      0xB0080000,  //  003B  RAISE	2	R0	R0
-      0x600C0010,  //  003C  GETGBL	R3	G16
-      0x8C100100,  //  003D  GETMET	R4	R0	K0
-      0x5C180200,  //  003E  MOVE	R6	R1
-      0x7C100400,  //  003F  CALL	R4	2
-      0x7C0C0200,  //  0040  CALL	R3	1
-      0xA8020013,  //  0041  EXBLK	0	#0056
-      0x5C100600,  //  0042  MOVE	R4	R3
-      0x7C100000,  //  0043  CALL	R4	0
-      0x94140204,  //  0044  GETIDX	R5	R1	R4
-      0x6018000F,  //  0045  GETGBL	R6	G15
-      0x5C1C0A00,  //  0046  MOVE	R7	R5
-      0x60200013,  //  0047  GETGBL	R8	G19
-      0x7C180400,  //  0048  CALL	R6	2
-      0x781A000A,  //  0049  JMPF	R6	#0055
-      0x8C180B01,  //  004A  GETMET	R6	R5	K1
-      0x5820000C,  //  004B  LDCONST	R8	K12
-      0x7C180400,  //  004C  CALL	R6	2
-      0x781A0006,  //  004D  JMPF	R6	#0055
-      0x0018090D,  //  004E  ADD	R6	R4	K13
-      0x8C1C0504,  //  004F  GETMET	R7	R2	K4
-      0x60240013,  //  0050  GETGBL	R9	G19
-      0x7C240000,  //  0051  CALL	R9	0
-      0x98260B0E,  //  0052  SETIDX	R9	K5	K14
-      0x98260E06,  //  0053  SETIDX	R9	K7	R6
-      0x7C1C0400,  //  0054  CALL	R7	2
-      0x7001FFEB,  //  0055  JMP		#0042
-      0x580C0008,  //  0056  LDCONST	R3	K8
-      0xAC0C0200,  //  0057  CATCH	R3	1	0
-      0xB0080000,  //  0058  RAISE	2	R0	R0
-      0x600C0010,  //  0059  GETGBL	R3	G16
-      0x8C100100,  //  005A  GETMET	R4	R0	K0
-      0x5C180200,  //  005B  MOVE	R6	R1
-      0x7C100400,  //  005C  CALL	R4	2
-      0x7C0C0200,  //  005D  CALL	R3	1
-      0xA8020013,  //  005E  EXBLK	0	#0073
-      0x5C100600,  //  005F  MOVE	R4	R3
-      0x7C100000,  //  0060  CALL	R4	0
-      0x94140204,  //  0061  GETIDX	R5	R1	R4
-      0x6018000F,  //  0062  GETGBL	R6	G15
-      0x5C1C0A00,  //  0063  MOVE	R7	R5
-      0x60200013,  //  0064  GETGBL	R8	G19
-      0x7C180400,  //  0065  CALL	R6	2
-      0x781A000A,  //  0066  JMPF	R6	#0072
-      0x8C180B01,  //  0067  GETMET	R6	R5	K1
-      0x5820000F,  //  0068  LDCONST	R8	K15
-      0x7C180400,  //  0069  CALL	R6	2
-      0x781A0006,  //  006A  JMPF	R6	#0072
-      0x00180910,  //  006B  ADD	R6	R4	K16
-      0x8C1C0504,  //  006C  GETMET	R7	R2	K4
-      0x60240013,  //  006D  GETGBL	R9	G19
-      0x7C240000,  //  006E  CALL	R9	0
-      0x98260B11,  //  006F  SETIDX	R9	K5	K17
-      0x98260E06,  //  0070  SETIDX	R9	K7	R6
-      0x7C1C0400,  //  0071  CALL	R7	2
-      0x7001FFEB,  //  0072  JMP		#005F
-      0x580C0008,  //  0073  LDCONST	R3	K8
-      0xAC0C0200,  //  0074  CATCH	R3	1	0
-      0xB0080000,  //  0075  RAISE	2	R0	R0
-      0x80040400,  //  0076  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: signal_endpoints_changed
-********************************************************************/
-be_local_closure(Matter_Device_signal_endpoints_changed,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attribute_updated),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(3),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-    }),
-    be_str_weak(signal_endpoints_changed),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x580C0001,  //  0001  LDCONST	R3	K1
-      0x5412001C,  //  0002  LDINT	R4	29
-      0x58140002,  //  0003  LDCONST	R5	K2
-      0x50180000,  //  0004  LDBOOL	R6	0	0
-      0x7C040A00,  //  0005  CALL	R1	5
-      0x8C040100,  //  0006  GETMET	R1	R0	K0
-      0xB80E0600,  //  0007  GETNGBL	R3	K3
-      0x880C0704,  //  0008  GETMBR	R3	R3	K4
-      0x5412001C,  //  0009  LDINT	R4	29
-      0x58140002,  //  000A  LDCONST	R5	K2
-      0x50180000,  //  000B  LDBOOL	R6	0	0
-      0x7C040A00,  //  000C  CALL	R1	5
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(Matter_Device_every_second,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(every_second),
-    /* K2   */  be_nested_str_weak(message_handler),
-    /* K3   */  be_nested_str_weak(commissioning_open),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(time_reached),
-    }),
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040102,  //  0003  GETMBR	R1	R0	K2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
-      0x7C040200,  //  0005  CALL	R1	1
-      0x88040103,  //  0006  GETMBR	R1	R0	K3
-      0x4C080000,  //  0007  LDNIL	R2
-      0x20040202,  //  0008  NE	R1	R1	R2
-      0x78060006,  //  0009  JMPF	R1	#0011
-      0xB8060800,  //  000A  GETNGBL	R1	K4
-      0x8C040305,  //  000B  GETMET	R1	R1	K5
-      0x880C0103,  //  000C  GETMBR	R3	R0	K3
-      0x7C040400,  //  000D  CALL	R1	2
-      0x78060001,  //  000E  JMPF	R1	#0011
-      0x4C040000,  //  000F  LDNIL	R1
-      0x90020601,  //  0010  SETMBR	R0	K3	R1
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: load_param
-********************************************************************/
-be_local_closure(Matter_Device_load_param,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[35]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(FILENAME),
-    /* K2   */  be_nested_str_weak(read),
-    /* K3   */  be_nested_str_weak(close),
-    /* K4   */  be_nested_str_weak(json),
-    /* K5   */  be_nested_str_weak(load),
-    /* K6   */  be_nested_str_weak(root_discriminator),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_nested_str_weak(distinguish),
-    /* K9   */  be_nested_str_weak(root_passcode),
-    /* K10  */  be_nested_str_weak(passcode),
-    /* K11  */  be_nested_str_weak(ipv4only),
-    /* K12  */  be_nested_str_weak(disable_bridge_mode),
-    /* K13  */  be_nested_str_weak(next_ep),
-    /* K14  */  be_nested_str_weak(nextep),
-    /* K15  */  be_nested_str_weak(plugins_config),
-    /* K16  */  be_nested_str_weak(config),
-    /* K17  */  be_nested_str_weak(tasmota),
-    /* K18  */  be_nested_str_weak(log),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20load_config_X20_X3D_X20),
-    /* K20  */  be_const_int(3),
-    /* K21  */  be_nested_str_weak(adjust_next_ep),
-    /* K22  */  be_nested_str_weak(plugins_persist),
-    /* K23  */  be_nested_str_weak(plugins_config_remotes),
-    /* K24  */  be_nested_str_weak(remotes),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
-    /* K26  */  be_nested_str_weak(io_error),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
-    /* K28  */  be_nested_str_weak(_X7C),
-    /* K29  */  be_const_int(2),
-    /* K30  */  be_nested_str_weak(random),
-    /* K31  */  be_nested_str_weak(get),
-    /* K32  */  be_const_int(0),
-    /* K33  */  be_nested_str_weak(generate_random_passcode),
-    /* K34  */  be_nested_str_weak(save_param),
-    }),
-    be_str_weak(load_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[127]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA802004D,  //  0001  EXBLK	0	#0050
-      0x60080011,  //  0002  GETGBL	R2	G17
-      0x880C0101,  //  0003  GETMBR	R3	R0	K1
-      0x7C080200,  //  0004  CALL	R2	1
-      0x8C0C0502,  //  0005  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0x8C100503,  //  0007  GETMET	R4	R2	K3
-      0x7C100200,  //  0008  CALL	R4	1
-      0xA4120800,  //  0009  IMPORT	R4	K4
-      0x8C140905,  //  000A  GETMET	R5	R4	K5
-      0x5C1C0600,  //  000B  MOVE	R7	R3
-      0x7C140400,  //  000C  CALL	R5	2
-      0x8C180B07,  //  000D  GETMET	R6	R5	K7
-      0x58200008,  //  000E  LDCONST	R8	K8
-      0x88240106,  //  000F  GETMBR	R9	R0	K6
-      0x7C180600,  //  0010  CALL	R6	3
-      0x90020C06,  //  0011  SETMBR	R0	K6	R6
-      0x8C180B07,  //  0012  GETMET	R6	R5	K7
-      0x5820000A,  //  0013  LDCONST	R8	K10
-      0x88240109,  //  0014  GETMBR	R9	R0	K9
-      0x7C180600,  //  0015  CALL	R6	3
-      0x90021206,  //  0016  SETMBR	R0	K9	R6
-      0x60180017,  //  0017  GETGBL	R6	G23
-      0x8C1C0B07,  //  0018  GETMET	R7	R5	K7
-      0x5824000B,  //  0019  LDCONST	R9	K11
-      0x50280000,  //  001A  LDBOOL	R10	0	0
-      0x7C1C0600,  //  001B  CALL	R7	3
-      0x7C180200,  //  001C  CALL	R6	1
-      0x90021606,  //  001D  SETMBR	R0	K11	R6
-      0x60180017,  //  001E  GETGBL	R6	G23
-      0x8C1C0B07,  //  001F  GETMET	R7	R5	K7
-      0x5824000C,  //  0020  LDCONST	R9	K12
-      0x50280000,  //  0021  LDBOOL	R10	0	0
-      0x7C1C0600,  //  0022  CALL	R7	3
-      0x7C180200,  //  0023  CALL	R6	1
-      0x90021806,  //  0024  SETMBR	R0	K12	R6
-      0x8C180B07,  //  0025  GETMET	R6	R5	K7
-      0x5820000E,  //  0026  LDCONST	R8	K14
-      0x8824010D,  //  0027  GETMBR	R9	R0	K13
-      0x7C180600,  //  0028  CALL	R6	3
-      0x90021A06,  //  0029  SETMBR	R0	K13	R6
-      0x8C180B07,  //  002A  GETMET	R6	R5	K7
-      0x58200010,  //  002B  LDCONST	R8	K16
-      0x7C180400,  //  002C  CALL	R6	2
-      0x90021E06,  //  002D  SETMBR	R0	K15	R6
-      0x8818010F,  //  002E  GETMBR	R6	R0	K15
-      0x4C1C0000,  //  002F  LDNIL	R7
-      0x20180C07,  //  0030  NE	R6	R6	R7
-      0x781A000B,  //  0031  JMPF	R6	#003E
-      0xB81A2200,  //  0032  GETNGBL	R6	K17
-      0x8C180D12,  //  0033  GETMET	R6	R6	K18
-      0x60200008,  //  0034  GETGBL	R8	G8
-      0x8824010F,  //  0035  GETMBR	R9	R0	K15
-      0x7C200200,  //  0036  CALL	R8	1
-      0x00222608,  //  0037  ADD	R8	K19	R8
-      0x58240014,  //  0038  LDCONST	R9	K20
-      0x7C180600,  //  0039  CALL	R6	3
-      0x8C180115,  //  003A  GETMET	R6	R0	K21
-      0x7C180200,  //  003B  CALL	R6	1
-      0x50180200,  //  003C  LDBOOL	R6	1	0
-      0x90022C06,  //  003D  SETMBR	R0	K22	R6
-      0x8C180B07,  //  003E  GETMET	R6	R5	K7
-      0x58200018,  //  003F  LDCONST	R8	K24
-      0x60240013,  //  0040  GETGBL	R9	G19
-      0x7C240000,  //  0041  CALL	R9	0
-      0x7C180600,  //  0042  CALL	R6	3
-      0x90022E06,  //  0043  SETMBR	R0	K23	R6
-      0x88180117,  //  0044  GETMBR	R6	R0	K23
-      0x781A0007,  //  0045  JMPF	R6	#004E
-      0xB81A2200,  //  0046  GETNGBL	R6	K17
-      0x8C180D12,  //  0047  GETMET	R6	R6	K18
-      0x60200008,  //  0048  GETGBL	R8	G8
-      0x88240117,  //  0049  GETMBR	R9	R0	K23
-      0x7C200200,  //  004A  CALL	R8	1
-      0x00223208,  //  004B  ADD	R8	K25	R8
-      0x58240014,  //  004C  LDCONST	R9	K20
-      0x7C180600,  //  004D  CALL	R6	3
-      0xA8040001,  //  004E  EXBLK	1	1
-      0x70020012,  //  004F  JMP		#0063
-      0xAC080002,  //  0050  CATCH	R2	0	2
-      0x7002000F,  //  0051  JMP		#0062
-      0x2010051A,  //  0052  NE	R4	R2	K26
-      0x7812000C,  //  0053  JMPF	R4	#0061
-      0xB8122200,  //  0054  GETNGBL	R4	K17
-      0x8C100912,  //  0055  GETMET	R4	R4	K18
-      0x60180008,  //  0056  GETGBL	R6	G8
-      0x5C1C0400,  //  0057  MOVE	R7	R2
-      0x7C180200,  //  0058  CALL	R6	1
-      0x001A3606,  //  0059  ADD	R6	K27	R6
-      0x00180D1C,  //  005A  ADD	R6	R6	K28
-      0x601C0008,  //  005B  GETGBL	R7	G8
-      0x5C200600,  //  005C  MOVE	R8	R3
-      0x7C1C0200,  //  005D  CALL	R7	1
-      0x00180C07,  //  005E  ADD	R6	R6	R7
-      0x581C001D,  //  005F  LDCONST	R7	K29
-      0x7C100600,  //  0060  CALL	R4	3
-      0x70020000,  //  0061  JMP		#0063
-      0xB0080000,  //  0062  RAISE	2	R0	R0
-      0x50080000,  //  0063  LDBOOL	R2	0	0
-      0x880C0106,  //  0064  GETMBR	R3	R0	K6
-      0x4C100000,  //  0065  LDNIL	R4
-      0x1C0C0604,  //  0066  EQ	R3	R3	R4
-      0x780E000A,  //  0067  JMPF	R3	#0073
-      0x8C0C031E,  //  0068  GETMET	R3	R1	K30
-      0x5814001D,  //  0069  LDCONST	R5	K29
-      0x7C0C0400,  //  006A  CALL	R3	2
-      0x8C0C071F,  //  006B  GETMET	R3	R3	K31
-      0x58140020,  //  006C  LDCONST	R5	K32
-      0x5818001D,  //  006D  LDCONST	R6	K29
-      0x7C0C0600,  //  006E  CALL	R3	3
-      0x54120FFE,  //  006F  LDINT	R4	4095
-      0x2C0C0604,  //  0070  AND	R3	R3	R4
-      0x90020C03,  //  0071  SETMBR	R0	K6	R3
-      0x50080200,  //  0072  LDBOOL	R2	1	0
-      0x880C0109,  //  0073  GETMBR	R3	R0	K9
-      0x4C100000,  //  0074  LDNIL	R4
-      0x1C0C0604,  //  0075  EQ	R3	R3	R4
-      0x780E0003,  //  0076  JMPF	R3	#007B
-      0x8C0C0121,  //  0077  GETMET	R3	R0	K33
-      0x7C0C0200,  //  0078  CALL	R3	1
-      0x90021203,  //  0079  SETMBR	R0	K9	R3
-      0x50080200,  //  007A  LDBOOL	R2	1	0
-      0x780A0001,  //  007B  JMPF	R2	#007E
-      0x8C0C0122,  //  007C  GETMET	R3	R0	K34
-      0x7C0C0200,  //  007D  CALL	R3	1
-      0x80000000,  //  007E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_Device
 ********************************************************************/
 be_local_class(Matter_Device,
     38,
     NULL,
-    be_nested_map(116,
+    be_nested_map(117,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(bridge_add_endpoint, -1), be_const_closure(Matter_Device_bridge_add_endpoint_closure) },
-        { be_const_key_weak(load_param, -1), be_const_closure(Matter_Device_load_param_closure) },
-        { be_const_key_weak(compute_manual_pairing_code, 36), be_const_closure(Matter_Device_compute_manual_pairing_code_closure) },
-        { be_const_key_weak(ipv4only, -1), be_const_var(29) },
-        { be_const_key_weak(conf_to_log, -1), be_const_static_closure(Matter_Device_conf_to_log_closure) },
-        { be_const_key_weak(start_operational_discovery, -1), be_const_closure(Matter_Device_start_operational_discovery_closure) },
-        { be_const_key_weak(commissioning_w0, -1), be_const_var(15) },
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Device_every_second_closure) },
-        { be_const_key_weak(tick, 96), be_const_var(10) },
-        { be_const_key_weak(profiler, 3), be_const_var(6) },
-        { be_const_key_weak(MtrInfo, -1), be_const_closure(Matter_Device_MtrInfo_closure) },
+        { be_const_key_weak(udp_server, -1), be_const_var(5) },
+        { be_const_key_weak(next_ep, 108), be_const_var(31) },
+        { be_const_key_weak(is_commissioning_open, -1), be_const_closure(Matter_Device_is_commissioning_open_closure) },
+        { be_const_key_weak(MtrInfo_one, -1), be_const_closure(Matter_Device_MtrInfo_one_closure) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Device_invoke_request_closure) },
+        { be_const_key_weak(start_commissioning_complete, 4), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
+        { be_const_key_weak(bridge_remove_endpoint, 23), be_const_closure(Matter_Device_bridge_remove_endpoint_closure) },
+        { be_const_key_weak(get_plugin_remote_info, -1), be_const_closure(Matter_Device_get_plugin_remote_info_closure) },
+        { be_const_key_weak(probe_sensor_time, 43), be_const_var(36) },
+        { be_const_key_weak(vendorid, -1), be_const_var(22) },
+        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
+        { be_const_key_weak(commissioning_instance_eth, -1), be_const_var(19) },
+        { be_const_key_weak(MtrInfo, 17), be_const_closure(Matter_Device_MtrInfo_closure) },
+        { be_const_key_weak(mdns_announce_PASE, -1), be_const_closure(Matter_Device_mdns_announce_PASE_closure) },
+        { be_const_key_weak(productid, 44), be_const_var(23) },
+        { be_const_key_weak(bridge_add_endpoint, 20), be_const_closure(Matter_Device_bridge_add_endpoint_closure) },
+        { be_const_key_weak(register_http_remote, -1), be_const_closure(Matter_Device_register_http_remote_closure) },
+        { be_const_key_weak(signal_endpoints_changed, -1), be_const_closure(Matter_Device_signal_endpoints_changed_closure) },
+        { be_const_key_weak(disable_bridge_mode, -1), be_const_var(30) },
+        { be_const_key_weak(get_plugin_class_displayname, 89), be_const_closure(Matter_Device_get_plugin_class_displayname_closure) },
+        { be_const_key_weak(start_mdns_announce_hostnames, 69), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
+        { be_const_key_weak(commissioning_instance_wifi, 114), be_const_var(18) },
+        { be_const_key_weak(autoconf_device_map, -1), be_const_closure(Matter_Device_autoconf_device_map_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Device_init_closure) },
+        { be_const_key_weak(mdns_announce_op_discovery_all_fabrics, 8), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics_closure) },
+        { be_const_key_weak(sessions, 98), be_const_var(8) },
+        { be_const_key_weak(_mdns_announce_hostname, 55), be_const_closure(Matter_Device__mdns_announce_hostname_closure) },
+        { be_const_key_weak(commissioning_discriminator, -1), be_const_var(13) },
+        { be_const_key_weak(register_commands, 100), be_const_closure(Matter_Device_register_commands_closure) },
+        { be_const_key_weak(start, 109), be_const_closure(Matter_Device_start_closure) },
+        { be_const_key_weak(_compute_pbkdf, -1), be_const_closure(Matter_Device__compute_pbkdf_closure) },
+        { be_const_key_weak(find_plugin_by_friendly_name, 95), be_const_closure(Matter_Device_find_plugin_by_friendly_name_closure) },
+        { be_const_key_weak(save_param, -1), be_const_closure(Matter_Device_save_param_closure) },
+        { be_const_key_weak(clean_remotes, -1), be_const_closure(Matter_Device_clean_remotes_closure) },
+        { be_const_key_weak(MtrJoin, 58), be_const_closure(Matter_Device_MtrJoin_closure) },
+        { be_const_key_weak(autoconf_device, -1), be_const_closure(Matter_Device_autoconf_device_closure) },
+        { be_const_key_weak(hostname_wifi, 68), be_const_var(20) },
+        { be_const_key_weak(_trigger_read_sensors, -1), be_const_closure(Matter_Device__trigger_read_sensors_closure) },
+        { be_const_key_weak(root_passcode, 63), be_const_var(28) },
+        { be_const_key_weak(save_before_restart, -1), be_const_closure(Matter_Device_save_before_restart_closure) },
+        { be_const_key_weak(generate_random_passcode, 64), be_const_closure(Matter_Device_generate_random_passcode_closure) },
+        { be_const_key_weak(is_root_commissioning_open, 90), be_const_closure(Matter_Device_is_root_commissioning_open_closure) },
+        { be_const_key_weak(start_commissioning_complete_deferred, -1), be_const_closure(Matter_Device_start_commissioning_complete_deferred_closure) },
+        { be_const_key_weak(root_iterations, -1), be_const_var(32) },
+        { be_const_key_weak(start_operational_discovery_deferred, -1), be_const_closure(Matter_Device_start_operational_discovery_deferred_closure) },
+        { be_const_key_weak(probe_sensor_timestamp, -1), be_const_var(37) },
+        { be_const_key_weak(ipv4only, 34), be_const_var(29) },
+        { be_const_key_weak(mdns_remove_PASE, 29), be_const_closure(Matter_Device_mdns_remove_PASE_closure) },
+        { be_const_key_weak(plugins_config_remotes, 103), be_const_var(4) },
+        { be_const_key_weak(remove_fabric, -1), be_const_closure(Matter_Device_remove_fabric_closure) },
+        { be_const_key_weak(sort_distinct, -1), be_const_static_closure(Matter_Device_sort_distinct_closure) },
+        { be_const_key_weak(commissioning_iterations, -1), be_const_var(12) },
+        { be_const_key_weak(plugins_config, 40), be_const_var(3) },
+        { be_const_key_weak(_init_basic_commissioning, 37), be_const_closure(Matter_Device__init_basic_commissioning_closure) },
+        { be_const_key_weak(plugins_persist, -1), be_const_var(2) },
+        { be_const_key_weak(hostname_eth, -1), be_const_var(21) },
+        { be_const_key_weak(mdns_remove_op_discovery, 77), be_const_closure(Matter_Device_mdns_remove_op_discovery_closure) },
+        { be_const_key_weak(received_ack, 76), be_const_closure(Matter_Device_received_ack_closure) },
+        { be_const_key_weak(PASE_TIMEOUT, 27), be_const_int(600) },
+        { be_const_key_weak(_instantiate_plugins_from_config, -1), be_const_closure(Matter_Device__instantiate_plugins_from_config_closure) },
         { be_const_key_weak(mdns_pase_eth, -1), be_const_var(24) },
-        { be_const_key_weak(signal_endpoints_changed, 72), be_const_closure(Matter_Device_signal_endpoints_changed_closure) },
-        { be_const_key_weak(MtrInfo_one, 58), be_const_closure(Matter_Device_MtrInfo_one_closure) },
-        { be_const_key_weak(vendorid, 97), be_const_var(22) },
+        { be_const_key_weak(mdns_pase_wifi, -1), be_const_var(25) },
+        { be_const_key_weak(commissioning_salt, -1), be_const_var(14) },
+        { be_const_key_weak(start_basic_commissioning, 94), be_const_closure(Matter_Device_start_basic_commissioning_closure) },
         { be_const_key_weak(commissioning_L, -1), be_const_var(16) },
-        { be_const_key_weak(plugins_classes, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(message_handler, 36), be_const_var(7) },
+        { be_const_key_weak(get_plugin_class_arg, -1), be_const_closure(Matter_Device_get_plugin_class_arg_closure) },
+        { be_const_key_weak(process_attribute_expansion, 54), be_const_closure(Matter_Device_process_attribute_expansion_closure) },
+        { be_const_key_weak(k2l, -1), be_const_static_closure(Matter_Device_k2l_closure) },
+        { be_const_key_weak(compute_manual_pairing_code, -1), be_const_closure(Matter_Device_compute_manual_pairing_code_closure) },
+        { be_const_key_weak(root_discriminator, 93), be_const_var(27) },
+        { be_const_key_weak(_start_udp, -1), be_const_closure(Matter_Device__start_udp_closure) },
+        { be_const_key_weak(k2l_num, -1), be_const_static_closure(Matter_Device_k2l_num_closure) },
+        { be_const_key_weak(commissioning_open, -1), be_const_var(11) },
+        { be_const_key_weak(add_read_sensors_schedule, 91), be_const_closure(Matter_Device_add_read_sensors_schedule_closure) },
+        { be_const_key_weak(check_config_ep, -1), be_const_closure(Matter_Device_check_config_ep_closure) },
+        { be_const_key_weak(PASSCODE_INVALID, 107), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(12,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(11111111),
+        be_const_int(22222222),
+        be_const_int(33333333),
+        be_const_int(44444444),
+        be_const_int(55555555),
+        be_const_int(66666666),
+        be_const_int(77777777),
+        be_const_int(88888888),
+        be_const_int(99999999),
+        be_const_int(12345678),
+        be_const_int(87654321),
+    }))    ) } )) },
+        { be_const_key_weak(started, -1), be_const_var(0) },
+        { be_const_key_weak(autoconf_sensors_list, -1), be_const_closure(Matter_Device_autoconf_sensors_list_closure) },
+        { be_const_key_weak(find_plugin_by_endpoint, -1), be_const_closure(Matter_Device_find_plugin_by_endpoint_closure) },
+        { be_const_key_weak(start_root_basic_commissioning, -1), be_const_closure(Matter_Device_start_root_basic_commissioning_closure) },
+        { be_const_key_weak(plugins, -1), be_const_var(1) },
+        { be_const_key_weak(event_fabrics_saved, 88), be_const_closure(Matter_Device_event_fabrics_saved_closure) },
+        { be_const_key_weak(commissioning_w0, 73), be_const_var(15) },
+        { be_const_key_weak(compute_qrcode_content, 57), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
+        { be_const_key_weak(conf_to_log, 56), be_const_static_closure(Matter_Device_conf_to_log_closure) },
+        { be_const_key_weak(start_operational_discovery, -1), be_const_closure(Matter_Device_start_operational_discovery_closure) },
+        { be_const_key_weak(load_param, -1), be_const_closure(Matter_Device_load_param_closure) },
+        { be_const_key_weak(process_attribute_read_solo, -1), be_const_closure(Matter_Device_process_attribute_read_solo_closure) },
+        { be_const_key_weak(msg_received, -1), be_const_closure(Matter_Device_msg_received_closure) },
+        { be_const_key_weak(root_w0, -1), be_const_var(34) },
+        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(Matter_Device_get_active_endpoints_closure) },
+        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
+        { be_const_key_weak(PBKDF_ITERATIONS, -1), be_const_int(1000) },
+        { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_Device_every_250ms_closure) },
+        { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Device_attribute_updated_closure) },
+        { be_const_key_weak(read_sensors_scheduler, -1), be_const_closure(Matter_Device_read_sensors_scheduler_closure) },
+        { be_const_key_weak(MtrUpdate, 45), be_const_closure(Matter_Device_MtrUpdate_closure) },
+        { be_const_key_weak(mdns_announce_op_discovery, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_closure) },
+        { be_const_key_weak(http_remotes, -1), be_const_var(26) },
+        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
+        { be_const_key_weak(root_salt, -1), be_const_var(33) },
+        { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Device_every_second_closure) },
+        { be_const_key_weak(update_remotes_info, 32), be_const_closure(Matter_Device_update_remotes_info_closure) },
+        { be_const_key_weak(mdns_remove_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics_closure) },
+        { be_const_key_weak(profiler, -1), be_const_var(6) },
+        { be_const_key_weak(root_L, 102), be_const_var(35) },
+        { be_const_key_weak(adjust_next_ep, -1), be_const_closure(Matter_Device_adjust_next_ep_closure) },
+        { be_const_key_weak(ui, -1), be_const_var(9) },
+        { be_const_key_weak(stop, 14), be_const_closure(Matter_Device_stop_closure) },
+        { be_const_key_weak(stop_basic_commissioning, 13), be_const_closure(Matter_Device_stop_basic_commissioning_closure) },
+        { be_const_key_weak(plugins_classes, 10), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(41,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_weak(aggregator, -1), be_const_class(be_class_Matter_Plugin_Aggregator) },
@@ -6211,120 +6439,10 @@ be_local_class(Matter_Device,
         { be_const_key_weak(humidity, -1), be_const_class(be_class_Matter_Plugin_Sensor_Humidity) },
         { be_const_key_weak(http_flow, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Flow) },
     }))    ) } )) },
-        { be_const_key_weak(root_L, 28), be_const_var(35) },
-        { be_const_key_weak(hostname_eth, -1), be_const_var(21) },
-        { be_const_key_weak(autoconf_device, 11), be_const_closure(Matter_Device_autoconf_device_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Device_init_closure) },
-        { be_const_key_weak(root_salt, -1), be_const_var(33) },
-        { be_const_key_weak(started, -1), be_const_var(0) },
-        { be_const_key_weak(add_read_sensors_schedule, -1), be_const_closure(Matter_Device_add_read_sensors_schedule_closure) },
-        { be_const_key_weak(hostname_wifi, 65), be_const_var(20) },
-        { be_const_key_weak(disable_bridge_mode, 71), be_const_var(30) },
-        { be_const_key_weak(generate_random_passcode, 66), be_const_closure(Matter_Device_generate_random_passcode_closure) },
-        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(Matter_Device_get_active_endpoints_closure) },
-        { be_const_key_weak(_mdns_announce_hostname, -1), be_const_closure(Matter_Device__mdns_announce_hostname_closure) },
-        { be_const_key_weak(productid, 84), be_const_var(23) },
-        { be_const_key_weak(plugins_config_remotes, -1), be_const_var(4) },
-        { be_const_key_weak(start_commissioning_complete, -1), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
-        { be_const_key_weak(bridge_remove_endpoint, -1), be_const_closure(Matter_Device_bridge_remove_endpoint_closure) },
+        { be_const_key_weak(tick, 9), be_const_var(10) },
         { be_const_key_weak(commissioning_admin_fabric, -1), be_const_var(17) },
-        { be_const_key_weak(sort_distinct, 110), be_const_static_closure(Matter_Device_sort_distinct_closure) },
-        { be_const_key_weak(mdns_announce_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics_closure) },
-        { be_const_key_weak(get_plugin_class_displayname, -1), be_const_closure(Matter_Device_get_plugin_class_displayname_closure) },
-        { be_const_key_weak(start, -1), be_const_closure(Matter_Device_start_closure) },
-        { be_const_key_weak(adjust_next_ep, -1), be_const_closure(Matter_Device_adjust_next_ep_closure) },
-        { be_const_key_weak(attribute_updated, 20), be_const_closure(Matter_Device_attribute_updated_closure) },
-        { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
-        { be_const_key_weak(_instantiate_plugins_from_config, -1), be_const_closure(Matter_Device__instantiate_plugins_from_config_closure) },
-        { be_const_key_weak(PASE_TIMEOUT, 17), be_const_int(600) },
-        { be_const_key_weak(commissioning_discriminator, 56), be_const_var(13) },
-        { be_const_key_weak(find_plugin_by_friendly_name, -1), be_const_closure(Matter_Device_find_plugin_by_friendly_name_closure) },
-        { be_const_key_weak(msg_send, -1), be_const_closure(Matter_Device_msg_send_closure) },
-        { be_const_key_weak(save_before_restart, 42), be_const_closure(Matter_Device_save_before_restart_closure) },
-        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
-        { be_const_key_weak(mdns_pase_wifi, -1), be_const_var(25) },
-        { be_const_key_weak(start_root_basic_commissioning, -1), be_const_closure(Matter_Device_start_root_basic_commissioning_closure) },
-        { be_const_key_weak(mdns_remove_op_discovery, 32), be_const_closure(Matter_Device_mdns_remove_op_discovery_closure) },
-        { be_const_key_weak(invoke_request, 50), be_const_closure(Matter_Device_invoke_request_closure) },
-        { be_const_key_weak(probe_sensor_time, 33), be_const_var(36) },
-        { be_const_key_weak(commissioning_open, -1), be_const_var(11) },
-        { be_const_key_weak(start_basic_commissioning, 101), be_const_closure(Matter_Device_start_basic_commissioning_closure) },
-        { be_const_key_weak(commissioning_instance_wifi, -1), be_const_var(18) },
-        { be_const_key_weak(read_sensors_scheduler, 27), be_const_closure(Matter_Device_read_sensors_scheduler_closure) },
-        { be_const_key_weak(http_remotes, -1), be_const_var(26) },
-        { be_const_key_weak(commissioning_iterations, -1), be_const_var(12) },
-        { be_const_key_weak(PBKDF_ITERATIONS, -1), be_const_int(1000) },
-        { be_const_key_weak(k2l, -1), be_const_static_closure(Matter_Device_k2l_closure) },
-        { be_const_key_weak(start_operational_discovery_deferred, 48), be_const_closure(Matter_Device_start_operational_discovery_deferred_closure) },
-        { be_const_key_weak(autoconf_device_map, -1), be_const_closure(Matter_Device_autoconf_device_map_closure) },
-        { be_const_key_weak(mdns_announce_PASE, -1), be_const_closure(Matter_Device_mdns_announce_PASE_closure) },
-        { be_const_key_weak(message_handler, -1), be_const_var(7) },
+        { be_const_key_weak(msg_send, 7), be_const_closure(Matter_Device_msg_send_closure) },
         { be_const_key_weak(every_50ms, -1), be_const_closure(Matter_Device_every_50ms_closure) },
-        { be_const_key_weak(start_mdns_announce_hostnames, -1), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
-        { be_const_key_weak(_trigger_read_sensors, 95), be_const_closure(Matter_Device__trigger_read_sensors_closure) },
-        { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_Device_every_250ms_closure) },
-        { be_const_key_weak(PASSCODE_INVALID, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(12,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(0),
-        be_const_int(11111111),
-        be_const_int(22222222),
-        be_const_int(33333333),
-        be_const_int(44444444),
-        be_const_int(55555555),
-        be_const_int(66666666),
-        be_const_int(77777777),
-        be_const_int(88888888),
-        be_const_int(99999999),
-        be_const_int(12345678),
-        be_const_int(87654321),
-    }))    ) } )) },
-        { be_const_key_weak(udp_server, 81), be_const_var(5) },
-        { be_const_key_weak(_init_basic_commissioning, -1), be_const_closure(Matter_Device__init_basic_commissioning_closure) },
-        { be_const_key_weak(MtrUpdate, -1), be_const_closure(Matter_Device_MtrUpdate_closure) },
-        { be_const_key_weak(probe_sensor_timestamp, 37), be_const_var(37) },
-        { be_const_key_weak(mdns_announce_op_discovery, 90), be_const_closure(Matter_Device_mdns_announce_op_discovery_closure) },
-        { be_const_key_weak(remove_fabric, -1), be_const_closure(Matter_Device_remove_fabric_closure) },
-        { be_const_key_weak(sessions, -1), be_const_var(8) },
-        { be_const_key_weak(_compute_pbkdf, -1), be_const_closure(Matter_Device__compute_pbkdf_closure) },
-        { be_const_key_weak(msg_received, 18), be_const_closure(Matter_Device_msg_received_closure) },
-        { be_const_key_weak(k2l_num, 73), be_const_static_closure(Matter_Device_k2l_num_closure) },
-        { be_const_key_weak(process_attribute_read_solo, 78), be_const_closure(Matter_Device_process_attribute_read_solo_closure) },
-        { be_const_key_weak(is_commissioning_open, -1), be_const_closure(Matter_Device_is_commissioning_open_closure) },
-        { be_const_key_weak(plugins_config, 47), be_const_var(3) },
-        { be_const_key_weak(register_commands, -1), be_const_closure(Matter_Device_register_commands_closure) },
-        { be_const_key_weak(root_w0, -1), be_const_var(34) },
-        { be_const_key_weak(commissioning_salt, -1), be_const_var(14) },
-        { be_const_key_weak(event_fabrics_saved, -1), be_const_closure(Matter_Device_event_fabrics_saved_closure) },
-        { be_const_key_weak(compute_qrcode_content, 12), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
-        { be_const_key_weak(find_plugin_by_endpoint, -1), be_const_closure(Matter_Device_find_plugin_by_endpoint_closure) },
-        { be_const_key_weak(update_remotes_info, 26), be_const_closure(Matter_Device_update_remotes_info_closure) },
-        { be_const_key_weak(MtrJoin, -1), be_const_closure(Matter_Device_MtrJoin_closure) },
-        { be_const_key_weak(start_commissioning_complete_deferred, 64), be_const_closure(Matter_Device_start_commissioning_complete_deferred_closure) },
-        { be_const_key_weak(next_ep, -1), be_const_var(31) },
-        { be_const_key_weak(stop, -1), be_const_closure(Matter_Device_stop_closure) },
-        { be_const_key_weak(mdns_remove_PASE, 55), be_const_closure(Matter_Device_mdns_remove_PASE_closure) },
-        { be_const_key_weak(plugins, -1), be_const_var(1) },
-        { be_const_key_weak(plugins_persist, -1), be_const_var(2) },
-        { be_const_key_weak(commissioning_instance_eth, 105), be_const_var(19) },
-        { be_const_key_weak(_start_udp, -1), be_const_closure(Matter_Device__start_udp_closure) },
-        { be_const_key_weak(get_plugin_remote_info, -1), be_const_closure(Matter_Device_get_plugin_remote_info_closure) },
-        { be_const_key_weak(register_http_remote, -1), be_const_closure(Matter_Device_register_http_remote_closure) },
-        { be_const_key_weak(root_passcode, -1), be_const_var(28) },
-        { be_const_key_weak(mdns_remove_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics_closure) },
-        { be_const_key_weak(get_plugin_class_arg, -1), be_const_closure(Matter_Device_get_plugin_class_arg_closure) },
-        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
-        { be_const_key_weak(root_discriminator, -1), be_const_var(27) },
-        { be_const_key_weak(clean_remotes, 21), be_const_closure(Matter_Device_clean_remotes_closure) },
-        { be_const_key_weak(is_root_commissioning_open, -1), be_const_closure(Matter_Device_is_root_commissioning_open_closure) },
-        { be_const_key_weak(stop_basic_commissioning, -1), be_const_closure(Matter_Device_stop_basic_commissioning_closure) },
-        { be_const_key_weak(autoconf_sensors_list, -1), be_const_closure(Matter_Device_autoconf_sensors_list_closure) },
-        { be_const_key_weak(save_param, -1), be_const_closure(Matter_Device_save_param_closure) },
-        { be_const_key_weak(ui, -1), be_const_var(9) },
-        { be_const_key_weak(received_ack, 9), be_const_closure(Matter_Device_received_ack_closure) },
-        { be_const_key_weak(VENDOR_ID, 7), be_const_int(65521) },
-        { be_const_key_weak(root_iterations, -1), be_const_var(32) },
-        { be_const_key_weak(process_attribute_expansion, 1), be_const_closure(Matter_Device_process_attribute_expansion_closure) },
     })),
     be_str_weak(Matter_Device)
 );


### PR DESCRIPTION
## Description:

### **POTENTIAL BREAKING CHANGE** may need to associate again your device

Several fixes to improve compliance to Matter standard.

For Google Home compatibility, the Aggregator endpoint needs to be relocated at endpoint `1`, which also needs any device at endpoint `1` to be relocated as well. This may break existing associations. If so, pair again.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
