### PR TITLE
Matter fix exception when fabrics is not initialized

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
@@ -102,7 +102,11 @@ class Matter_Session_Store
   # Count the number of commissionned fabrics, i.e. persisted
   def count_active_fabrics()
     self.remove_expired()      # clean before
-    return self.fabrics.count_persistables()
+    if self.fabrics != nil
+      return self.fabrics.count_persistables()
+    else
+      return 0
+    end
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
@@ -508,20 +508,28 @@ be_local_closure(Matter_Session_Store_count_active_fabrics,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(remove_expired),
     /* K1   */  be_nested_str_weak(fabrics),
     /* K2   */  be_nested_str_weak(count_persistables),
+    /* K3   */  be_const_int(0),
     }),
     be_str_weak(count_active_fabrics),
     &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
+    ( &(const binstruction[13]) {  /* code */
       0x8C040100,  //  0000  GETMET	R1	R0	K0
       0x7C040200,  //  0001  CALL	R1	1
       0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80040200,  //  0005  RET	1	R1
+      0x4C080000,  //  0003  LDNIL	R2
+      0x20040202,  //  0004  NE	R1	R1	R2
+      0x78060004,  //  0005  JMPF	R1	#000B
+      0x88040101,  //  0006  GETMBR	R1	R0	K1
+      0x8C040302,  //  0007  GETMET	R1	R1	K2
+      0x7C040200,  //  0008  CALL	R1	1
+      0x80040200,  //  0009  RET	1	R1
+      0x70020000,  //  000A  JMP		#000C
+      0x80060600,  //  000B  RET	1	K3
+      0x80000000,  //  000C  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Fixes a silent exception when trying to display the Matter status and `fabrics` is not initialized.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
