### PR TITLE
Matter fix introspect.contains

### DIFF
--- a/lib/libesp32/berry/src/be_api.c
+++ b/lib/libesp32/berry/src/be_api.c
@@ -665,6 +665,7 @@ BERRY_API bbool be_copy(bvm *vm, int index)
 }
 
 /* `onlyins` limits the search to instance, and discards module. Makes sure getmethod does not return anything for module. */
+/* may return BE_NONE */
 static int ins_member(bvm *vm, int index, const char *k, bbool onlyins)
 {
     int type = BE_NIL;
@@ -681,12 +682,12 @@ static int ins_member(bvm *vm, int index, const char *k, bbool onlyins)
         bmodule *module = var_toobj(o);
         type = be_module_attr(vm, module, be_newstr(vm, k), top);
     }
-    return type == BE_NONE ? BE_NIL : type;
+    return type;
 }
 
 BERRY_API bbool be_getmember(bvm *vm, int index, const char *k)
 {
-    return ins_member(vm, index, k, bfalse) != BE_NIL;
+    return ins_member(vm, index, k, bfalse) != BE_NONE;
 }
 
 BERRY_API bbool be_getmethod(bvm *vm, int index, const char *k)


### PR DESCRIPTION
## Description:

Berry, fix `introspect.contains()` that would wrongly return `false` if the attribute exists and has value `nil`.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [ x The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
