### PR TITLE
Berry option to invert serial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Internal support for persistent JSON settings using single file
 - Command ``SetOption158`` to publish or suppress ModbusReceived MQTT messages (#20678)
 - ESP32 Core3 support for SPI ethernet on DM9051, W5500 and KSZ8851
+- Berry option to invert serial
 
 ### Breaking Changed
 - ESP32 LVGL library from v8.3.11 to v9.0.0, some small breaking changes in C, none in HASPmota (#20659)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_serial.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_serial.ino
@@ -26,10 +26,7 @@
 /*********************************************************************************************\
  * Native functions mapped to Berry functions
  * 
- * import wire
- * 
- * wire.get_free_heap() -> int
- * 
+ * `ser = serial(4, 5, 9600, serial.SERIAL_7E1)`
 \*********************************************************************************************/
 extern "C" {
   TasmotaSerial * b_serial_get(struct bvm *vm) {
@@ -39,7 +36,7 @@ extern "C" {
     return ow;
   }
 
-  // Berry: `init(rx_gpio:int, tx_gpio:int, speed:int [, config:int])`
+  // Berry: `init(rx_gpio:int, tx_gpio:int, speed:int [, config:int, inverted:bool])`
   int32_t b_serial_init(struct bvm *vm);
   int32_t b_serial_init(struct bvm *vm) {
     int32_t argc = be_top(vm); // Get the number of arguments
@@ -48,10 +45,14 @@ extern "C" {
       int32_t tx = be_toint(vm, 3);
       int32_t speed = be_toint(vm, 4);
       int32_t mode = SERIAL_8N1;
+      bool inverted = false;
       if (argc >= 5 && be_isint(vm, 5)) {
         mode = be_toint(vm, 5);
       }
-      TasmotaSerial * ser = new TasmotaSerial(rx, tx);
+      if (argc >= 6 && be_isbool(vm, 6)) {
+        inverted = be_tobool(vm, 6);
+      }
+      TasmotaSerial * ser = new TasmotaSerial(rx, tx, 0, 0, TM_SERIAL_BUFFER_SIZE, inverted);
       bool ok = ser->begin(speed, mode);
       if (!ok) {
         delete ser;


### PR DESCRIPTION
## Description:

Berry add option to invert serial: `init(rx_gpio:int, tx_gpio:int, speed:int [, config:int, inverted:bool])`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
