### PR TITLE
Fix counter rising edges when CounterDebounceLow/High is set

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_01_counter.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_01_counter.ino
@@ -71,7 +71,7 @@ void CounterIsrArg(void *arg) {
     // passed debounce check, save pin state and timing
     Counter.timer_low_high[index] = time;
     Counter.pin_state ^= (1<<index);
-    // do not count on rising edge
+    // for rising edge
     if bitRead(Counter.pin_state, index) {
       // PWMfrequency 100
       // restart PWM each second (german 50Hz has to up to 0.01% deviation)
@@ -79,7 +79,10 @@ void CounterIsrArg(void *arg) {
 #ifdef USE_AC_ZERO_CROSS_DIMMER
       if (index == 3) ACDimmerZeroCross(time);
 #endif //USE_AC_ZERO_CROSS_DIMMER
-      return;
+      // do not count on rising edge if CounterDebounceLow and CounterDebounceHigh is unset
+      if (0 == Settings->pulse_counter_debounce_low && 0 == Settings->pulse_counter_debounce_high) {
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
## Description:

Counters were only set on falling edges, regardless of whether [CounterDebounceLow](https://tasmota.github.io/docs/Commands/#counterdebouncelow) or [CounterDebounceHigh](https://tasmota.github.io/docs/Commands/#counterdebouncehigh) was set or not.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
