### PR TITLE
one pio script to set "C" flags

### DIFF
--- a/pio-tools/add_c_flags.py
+++ b/pio-tools/add_c_flags.py
@@ -1,4 +1,7 @@
 Import("env")
 
+# General options that are passed to the C++ compiler
+env.Append(CXXFLAGS=["-Wno-volatile"])
+
 # General options that are passed to the C compiler (C only; not C++).
-env.Append(CFLAGS=["-Wno-discarded-qualifiers", "-Wno-implicit-function-declaration"])
+env.Append(CFLAGS=["-Wno-discarded-qualifiers", "-Wno-implicit-function-declaration", "-Wno-incompatible-pointer-types"])

--- a/pio-tools/add_c_flags_ard3.py
+++ b/pio-tools/add_c_flags_ard3.py
@@ -1,7 +1,0 @@
-Import("env")
-
-# General options that are passed to the C++ compiler
-env.Append(CXXFLAGS=["-Wno-volatile"])
-
-# General options that are passed to the C compiler (C only; not C++).
-env.Append(CFLAGS=["-Wno-incompatible-pointer-types"])

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -81,8 +81,7 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
 [core32_30_flags]
 build_unflags               = ${core32_30.build_unflags}
 build_flags                 = ${core32_30.build_flags}
-extra_scripts               = pre:pio-tools/add_c_flags_ard3.py
-                              ${esp32_defaults.extra_scripts}
+extra_scripts               = ${esp32_defaults.extra_scripts}
 lib_extra_dirs              = lib/lib_ssl, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_audio, lib/lib_display, lib/lib_rf, lib/libesp32, lib/libesp32_div, lib/libesp32_lvgl
 lib_ignore                  =
                               HTTPUpdateServer


### PR DESCRIPTION
## Description:

there is no need to have different ones for esp32 core 2 and core 3

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
