### PR TITLE
Fix software serial on RISCV cpus.

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
@@ -256,7 +256,11 @@ SML_ESP32_SERIAL::~SML_ESP32_SERIAL(void) {
 }
 
 void SML_ESP32_SERIAL::setbaud(uint32_t speed) {
+#ifdef CONFIG_IDF_TARGET_ESP32C3
+  m_bit_time = 1000000 / speed;
+#else
   m_bit_time = ESP.getCpuFreqMHz() * 1000000 / speed;
+#endif
 }
 
 void SML_ESP32_SERIAL::end(void) {
@@ -366,13 +370,21 @@ void IRAM_ATTR SML_ESP32_SERIAL::rxRead(void) {
 
   if (!level && !ss_index) {
     // start condition
+#ifdef CONFIG_IDF_TARGET_ESP32C3
+    ss_bstart = micros() - (m_bit_time / 4);
+#else
     ss_bstart = ESP.getCycleCount() - (m_bit_time / 4);
+#endif
     ss_byte = 0;
     ss_index++;
   } else {
     // now any bit changes go here
     // calc bit number
+#ifdef CONFIG_IDF_TARGET_ESP32C3
+    diff = (micros() - ss_bstart) / m_bit_time;
+#else
     diff = (ESP.getCycleCount() - ss_bstart) / m_bit_time;
+#endif
 
     if (!level && diff > SML_LASTBIT) {
       // start bit of next byte, store  and restart
@@ -385,8 +397,11 @@ void IRAM_ATTR SML_ESP32_SERIAL::rxRead(void) {
         m_buffer[m_in_pos] = ss_byte >> 1;
         m_in_pos = next;
       }
-
+#ifdef CONFIG_IDF_TARGET_ESP32C3
+      ss_bstart = micros() - (m_bit_time / 4);
+#else
       ss_bstart = ESP.getCycleCount() - (m_bit_time / 4);
+#endif
       ss_byte = 0;
       ss_index = 1;
       return;

--- a/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
@@ -256,7 +256,7 @@ SML_ESP32_SERIAL::~SML_ESP32_SERIAL(void) {
 }
 
 void SML_ESP32_SERIAL::setbaud(uint32_t speed) {
-#ifdef CONFIG_IDF_TARGET_ESP32C3
+#ifdef __riscv
   m_bit_time = 1000000 / speed;
 #else
   m_bit_time = ESP.getCpuFreqMHz() * 1000000 / speed;
@@ -370,7 +370,7 @@ void IRAM_ATTR SML_ESP32_SERIAL::rxRead(void) {
 
   if (!level && !ss_index) {
     // start condition
-#ifdef CONFIG_IDF_TARGET_ESP32C3
+#ifdef __riscv
     ss_bstart = micros() - (m_bit_time / 4);
 #else
     ss_bstart = ESP.getCycleCount() - (m_bit_time / 4);
@@ -380,7 +380,7 @@ void IRAM_ATTR SML_ESP32_SERIAL::rxRead(void) {
   } else {
     // now any bit changes go here
     // calc bit number
-#ifdef CONFIG_IDF_TARGET_ESP32C3
+#ifdef __riscv
     diff = (micros() - ss_bstart) / m_bit_time;
 #else
     diff = (ESP.getCycleCount() - ss_bstart) / m_bit_time;
@@ -397,7 +397,7 @@ void IRAM_ATTR SML_ESP32_SERIAL::rxRead(void) {
         m_buffer[m_in_pos] = ss_byte >> 1;
         m_in_pos = next;
       }
-#ifdef CONFIG_IDF_TARGET_ESP32C3
+#ifdef __riscv
       ss_bstart = micros() - (m_bit_time / 4);
 #else
       ss_bstart = ESP.getCycleCount() - (m_bit_time / 4);


### PR DESCRIPTION
## Description:

ESP32 RISCV cpus do not reliably count cpu cycles because of low power modes (ESP.getCpuFreqMHz() cannot be used)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
