### PR TITLE
Fix invalid constant description

### DIFF
--- a/tasmota/tasmota_xnrg_energy/xnrg_17_ornowe517.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_17_ornowe517.ino
@@ -31,7 +31,7 @@
 
 // can be user defined in my_user_config.h
 #ifndef WE517_SPEED
-  #define WE517_SPEED      9600    // default WE517 Modbus address
+  #define WE517_SPEED      9600    // default WE517 baudrate
 #endif
 // can be user defined in my_user_config.h
 #ifndef WE517_ADDR


### PR DESCRIPTION
## Description:

Fix an invalid constant description comment in the Orno WE-517 implementation - the baudrate was incorrectly described as the Modbus address.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_