### PR TITLE
Matter reduce memory usage when reading with wildcards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - LVGL make lv_touch_3_buttons more responsive (#20728)
 - HASPmota fix and improve demo with pixel-perfect fonts (#20734)
 - NeoPool webUI pH alarms (4 & 5) completed (#20743)
+- Matter reduce memory usage when reading with wildcards
 
 ### Fixed
 - ESP32 PWM activity on unconfigured PWM GPIOs (#20732)

--- a/lib/libesp32/berry_matter/src/be_matter_module.c
+++ b/lib/libesp32/berry_matter/src/be_matter_module.c
@@ -197,7 +197,8 @@ extern int matter_publish_command(bvm *vm);
 #include "solidify/solidified_Matter_0_Inspect.h"
 
 extern const bclass be_class_Matter_TLV;   // need to declare it upfront because of circular reference
-#include "solidify/solidified_Matter_Path.h"
+#include "solidify/solidified_Matter_Path_0.h"
+#include "solidify/solidified_Matter_Path_1_Generator.h"
 #include "solidify/solidified_Matter_TLV.h"
 #include "solidify/solidified_Matter_IM_Data.h"
 #include "solidify/solidified_Matter_UDPServer.h"
@@ -420,6 +421,7 @@ module matter (scope: global, strings: weak) {
 
   // Interation Model
   Path, class(be_class_Matter_Path)
+  PathGenerator, class(be_class_Matter_PathGenerator)
   IM_Status, class(be_class_Matter_IM_Status)
   IM_InvokeResponse, class(be_class_Matter_IM_InvokeResponse)
   IM_WriteResponse, class(be_class_Matter_IM_WriteResponse)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
@@ -241,6 +241,7 @@ class Matter_IM
       attr_name = attr_name ? " (" + attr_name + ")" : ""
 
       # Special case to report unsupported item, if pi==nil
+      ctx.status = nil                # reset status, just in case
       var res = (pi != nil) ? pi.read_attribute(session, ctx, self.tlv_solo) : nil
       var found = true                # stop expansion since we have a value
       var a1_raw_or_list              # contains either a bytes() buffer to append, or a list of bytes(), or nil
@@ -290,9 +291,13 @@ class Matter_IM
           end
         end
       else
-        tasmota.log(format("MTR: >Read_Attr (%6i) %s%s - IGNORED", session.local_session_id, str(ctx), attr_name), 3)
+        if !no_log
+          tasmota.log(format("MTR: >Read_Attr (%6i) %s%s - IGNORED", session.local_session_id, str(ctx), attr_name), 3)
+        end
         # ignore if content is nil and status is undefined
-        found = false
+        if direct
+          found = false
+        end
       end
 
       # a1_raw_or_list if either nil, bytes(), of list(bytes())

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Path_0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Path_0.be
@@ -1,5 +1,5 @@
 #
-# Matter_IM_Path.be - suppport for Matter simple Path object
+# Matter_IM_Path_0.be - suppport for Matter simple Path object
 #
 # Copyright (C) 2023  Stephan Hadinger & Theo Arends
 #

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Path_1_Generator.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Path_1_Generator.be
@@ -1,0 +1,273 @@
+#
+# Matter_IM_Path_1.be - suppport for Matter concrete path generator
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import matter
+
+#@ solidify:Matter_PathGenerator,weak
+
+#################################################################################
+# Matter_PathGenerator
+#
+# INPUT: Takes a context:
+#   - plugin
+#   - path (abstract or concrete)
+#   - session
+#
+# OUTPUT:
+#   - returns a concrete Path
+#   - or `nil` if exhausted
+#################################################################################
+class Matter_PathGenerator
+  var device                  # reference of device main object
+  var path_in                 # input path (abstract or concrete)
+  var session                 # session object in which the request was made
+  # current status
+  var pi                      # plugin object, `nil` waiting for value, `false` exhausted values
+  var cluster                 # current cluster number, `nil` waiting for value, `false` exhausted values
+  var attribute               # current attribute number, `nil` waiting for value, `false` exhausted values
+  # cache
+  var clusters                # list of clusters sorted
+  #
+  var endpoint_found          # did we find a valid endpoint?
+  var cluster_found           # did we find a valid cluster?
+  var attribute_found         # did we find a valid attribute?
+
+  # reused at each output
+  var path_concrete           # placeholder for output concrete path
+
+  def init(device)
+    self.device = device
+  end
+
+  # start generator
+  def start(path_in, session)
+    self.path_concrete = matter.Path()
+    self.reset()
+    self.path_in = path_in
+    self.session = session
+    #
+    self.endpoint_found = false
+    self.cluster_found = false
+    self.attribute_found = false
+  end
+
+  def reset()
+    var n = nil
+    self.path_in = n
+    self.session = n
+    self.path_concrete.reset()
+    #
+    self.pi = n               # pre-load first plugin
+    self.cluster = n
+    self.attribute = n
+    self.clusters = n
+    self.clusters = n
+  end
+
+  def get_pi()
+    return self.pi
+  end
+  ################################################################################
+  # next
+  #
+  # Generate next concrete path
+  # Returns:
+  # - a path object (that is valid until next call)
+  # - `nil` if no more objects
+  def next()
+    if (self.path_in == nil)    return nil  end
+
+    while (self.pi != false)        # loop until we exhausted endpoints
+      # PRE: self.pi is not `false`
+      if (self.pi == nil) || (self.cluster == false)    # no endpoint yet, or exhausted clusters
+        self._next_endpoint()
+        continue
+      end
+      # PRE: self.pi is valid, self.cluster is not false
+      self.endpoint_found = true
+      if (self.cluster == nil) || (self.attribute == false)   # no cluster yet, or exhausted attributes
+        self._next_cluster()
+        continue
+      end
+      # PRE: self.pi and self.cluster are valid, self.attribute is not false
+      self.cluster_found = true
+      self._next_attribute()        # advance to first or next attribute
+      if (self.attribute == false)
+        continue                       # iterate so that we explore next cluster
+      end
+      # we have a concrete path
+      self.attribute_found = true
+      var path_concrete = self.path_concrete
+      path_concrete.reset()
+      path_concrete.endpoint = self.pi.get_endpoint()
+      path_concrete.cluster = self.cluster
+      path_concrete.attribute = self.attribute
+      return path_concrete
+    end
+    # we exhausted all endpoints - finish and clean
+    self.reset()
+    return nil
+  end
+
+  #------------------------------------------------------------------------------#
+  # advance to next endpoint
+  def _next_endpoint()
+    if (self.pi == false)   return false    end       # exhausted all possible values
+
+    var plugins = self.device.plugins     # shortcut
+    var ep_filter = self.path_in.endpoint
+    # cluster and attribute are now undefined
+    self.cluster = nil
+    self.attribute = nil
+    # idx contains the index of current plugin, or `nil` if not started
+    var idx = -1
+    if (self.pi != nil)
+      idx = plugins.find(self.pi)     # find index in current list
+    end
+    # safeguard
+    if (idx != nil)
+      while (idx + 1 < size(plugins))
+        idx += 1                      # move to next item
+        self.pi = plugins[idx]
+        if (ep_filter == nil) || (ep_filter == self.pi.get_endpoint())
+          self.clusters = self.pi.get_cluster_list_sorted()   # memoize clusters
+          return self.pi
+        end
+      # iterate
+      end
+    end
+    self.pi = false
+    return false
+  end
+
+  #------------------------------------------------------------------------------#
+  # advance to next cluster
+  #
+  # self.clusters already contains the sorted list of clusters of pi
+  def _next_cluster()
+    if (self.cluster == false)   return false    end       # exhausted all possible values
+
+    var clusters = self.clusters
+    var cl_filter = self.path_in.cluster
+    # attribute is now undefined
+    self.attribute = nil
+    var idx = -1
+    if (self.cluster != nil)
+      idx = clusters.find(self.cluster)     # find index in current list
+    end
+    # safeguard
+    if (idx != nil)
+      while (idx + 1 < size(clusters))
+        idx += 1                      # move to next item
+        self.cluster = clusters[idx]
+        if (cl_filter == nil) || (cl_filter == self.cluster)
+          return self.cluster
+        end
+      end
+    end
+    self.cluster = false
+    return false
+  end
+
+  #------------------------------------------------------------------------------#
+  # advance to next attribute
+  #
+  # self.clusters already contains the sorted list of clusters of pi
+  def _next_attribute()
+    if (self.attribute == false)   return false    end       # exhausted all possible values
+
+    var attributes = self.pi.get_attribute_list(self.cluster)
+    var attr_filter = self.path_in.attribute
+    var idx = -1
+    if (self.attribute != nil)
+      idx = attributes.find(self.attribute)     # find index in current list
+    end
+    # safeguard
+    if (idx != nil)
+      while (idx + 1 < size(attributes))
+        idx += 1                      # move to next item
+        self.attribute = attributes[idx]
+        if (attr_filter == nil) || (attr_filter == self.attribute)
+          return self.attribute
+        end
+      end
+    end
+    self.attribute = false
+    return false
+  end
+
+end
+matter.PathGenerator = Matter_PathGenerator
+
+#-
+
+# Tests
+
+var gen = matter.PathGenerator(matter_device)
+
+def gen_path_dump(endpoint, cluster, attribute)
+  var path = matter.Path()
+  path.endpoint = endpoint
+  path.cluster = cluster
+  path.attribute = attribute
+  gen.start(path)
+  var cp
+  while (cp := gen.next())
+    print(cp)
+  end
+end
+
+
+gen_path_dump(nil, nil, nil)
+gen_path_dump(1, nil, nil)
+gen_path_dump(1, 3, nil)
+gen_path_dump(nil, 5, nil)
+gen_path_dump(nil, nil, 0xFFFB)
+gen_path_dump(4, 5, 5)
+gen_path_dump(4, 5, 6)
+
+
+
+var gen = matter.PathGenerator(matter_device)
+var path = matter.Path()
+path.endpoint = nil
+gen.start(path)
+
+# print(gen._next_endpoint())
+# print(gen._next_cluster())
+# print(gen._next_attribute())
+
+
+
+var gen = matter.PathGenerator(matter_device)
+var path = matter.Path()
+path.endpoint = 4
+path.cluster = 5
+path.attribute = 1
+gen.start(path)
+
+
+
+
+var cp
+while (cp := gen.next())
+  print(cp)
+end
+
+-#

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
@@ -233,12 +233,8 @@ class Matter_Plugin
   def get_endpoint()
     return self.endpoint
   end
-  def get_cluster_list()
-    var ret = []
-    for k: self.clusters.keys()
-      ret.push(k)
-    end
-    return ret
+  def get_cluster_list_sorted()
+    return self.device.k2l(self.clusters)
   end
   def contains_cluster(cluster)
     return self.clusters.contains(cluster)
@@ -302,7 +298,7 @@ class Matter_Plugin
         return dtl
       elif attribute == 0x0001          # ---------- ServerList / list[cluster-id] ----------
         var sl = TLV.Matter_TLV_array()
-        for cl: self.get_cluster_list()
+        for cl: self.get_cluster_list_sorted()
           sl.add_TLV(nil, TLV.U4, cl)
         end
         return sl
@@ -347,6 +343,8 @@ class Matter_Plugin
       return tlv_solo.set(TLV.U4, clusterrevision)
     end
 
+    # no handler found, return nil
+    return nil
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -2223,25 +2223,25 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
         /* K5   */  be_nested_str_weak(_X20_X28),
         /* K6   */  be_nested_str_weak(_X29),
         /* K7   */  be_nested_str_weak(),
-        /* K8   */  be_nested_str_weak(read_attribute),
-        /* K9   */  be_nested_str_weak(tlv_solo),
-        /* K10  */  be_nested_str_weak(to_str_val),
-        /* K11  */  be_nested_str_weak(is_list),
-        /* K12  */  be_nested_str_weak(is_array),
-        /* K13  */  be_nested_str_weak(encode_len),
-        /* K14  */  be_nested_str_weak(IM_ReportData),
-        /* K15  */  be_nested_str_weak(MAX_MESSAGE),
-        /* K16  */  be_nested_str_weak(Matter_TLV_array),
-        /* K17  */  be_nested_str_weak(attributedata2raw),
-        /* K18  */  be_nested_str_weak(push),
-        /* K19  */  be_nested_str_weak(val),
-        /* K20  */  be_nested_str_weak(stop_iteration),
-        /* K21  */  be_nested_str_weak(tasmota),
-        /* K22  */  be_nested_str_weak(log),
-        /* K23  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
-        /* K24  */  be_nested_str_weak(local_session_id),
-        /* K25  */  be_const_int(3),
-        /* K26  */  be_nested_str_weak(status),
+        /* K8   */  be_nested_str_weak(status),
+        /* K9   */  be_nested_str_weak(read_attribute),
+        /* K10  */  be_nested_str_weak(tlv_solo),
+        /* K11  */  be_nested_str_weak(to_str_val),
+        /* K12  */  be_nested_str_weak(is_list),
+        /* K13  */  be_nested_str_weak(is_array),
+        /* K14  */  be_nested_str_weak(encode_len),
+        /* K15  */  be_nested_str_weak(IM_ReportData),
+        /* K16  */  be_nested_str_weak(MAX_MESSAGE),
+        /* K17  */  be_nested_str_weak(Matter_TLV_array),
+        /* K18  */  be_nested_str_weak(attributedata2raw),
+        /* K19  */  be_nested_str_weak(push),
+        /* K20  */  be_nested_str_weak(val),
+        /* K21  */  be_nested_str_weak(stop_iteration),
+        /* K22  */  be_nested_str_weak(tasmota),
+        /* K23  */  be_nested_str_weak(log),
+        /* K24  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
+        /* K25  */  be_nested_str_weak(local_session_id),
+        /* K26  */  be_const_int(3),
         /* K27  */  be_nested_str_weak(attributestatus2raw),
         /* K28  */  be_nested_str_weak(loglevel),
         /* K29  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
@@ -2253,7 +2253,7 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
         }),
         be_str_weak(read_single_attribute),
         &be_const_str_solidified,
-        ( &(const binstruction[233]) {  /* code */
+        ( &(const binstruction[238]) {  /* code */
           0xB8120000,  //  0000  GETNGBL	R4	K0
           0x88100901,  //  0001  GETMBR	R4	R4	K1
           0xB8160000,  //  0002  GETNGBL	R5	K0
@@ -2268,225 +2268,230 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
           0x58180007,  //  000B  LDCONST	R6	K7
           0x5C140C00,  //  000C  MOVE	R5	R6
           0x4C180000,  //  000D  LDNIL	R6
-          0x20180206,  //  000E  NE	R6	R1	R6
-          0x781A0006,  //  000F  JMPF	R6	#0017
-          0x8C180308,  //  0010  GETMET	R6	R1	K8
-          0x68200000,  //  0011  GETUPV	R8	U0
-          0x5C240400,  //  0012  MOVE	R9	R2
-          0x68280001,  //  0013  GETUPV	R10	U1
-          0x88281509,  //  0014  GETMBR	R10	R10	K9
-          0x7C180800,  //  0015  CALL	R6	4
-          0x70020000,  //  0016  JMP		#0018
-          0x4C180000,  //  0017  LDNIL	R6
-          0x501C0200,  //  0018  LDBOOL	R7	1	0
-          0x4C200000,  //  0019  LDNIL	R8
-          0x4C240000,  //  001A  LDNIL	R9
-          0x20240C09,  //  001B  NE	R9	R6	R9
-          0x78260054,  //  001C  JMPF	R9	#0072
-          0x58240007,  //  001D  LDCONST	R9	K7
-          0x68280002,  //  001E  GETUPV	R10	U2
-          0x742A0002,  //  001F  JMPT	R10	#0023
-          0x8C280D0A,  //  0020  GETMET	R10	R6	K10
-          0x7C280200,  //  0021  CALL	R10	1
-          0x5C241400,  //  0022  MOVE	R9	R10
-          0x88280D0B,  //  0023  GETMBR	R10	R6	K11
-          0x742A0001,  //  0024  JMPT	R10	#0027
+          0x900A1006,  //  000E  SETMBR	R2	K8	R6
+          0x4C180000,  //  000F  LDNIL	R6
+          0x20180206,  //  0010  NE	R6	R1	R6
+          0x781A0006,  //  0011  JMPF	R6	#0019
+          0x8C180309,  //  0012  GETMET	R6	R1	K9
+          0x68200000,  //  0013  GETUPV	R8	U0
+          0x5C240400,  //  0014  MOVE	R9	R2
+          0x68280001,  //  0015  GETUPV	R10	U1
+          0x8828150A,  //  0016  GETMBR	R10	R10	K10
+          0x7C180800,  //  0017  CALL	R6	4
+          0x70020000,  //  0018  JMP		#001A
+          0x4C180000,  //  0019  LDNIL	R6
+          0x501C0200,  //  001A  LDBOOL	R7	1	0
+          0x4C200000,  //  001B  LDNIL	R8
+          0x4C240000,  //  001C  LDNIL	R9
+          0x20240C09,  //  001D  NE	R9	R6	R9
+          0x78260054,  //  001E  JMPF	R9	#0074
+          0x58240007,  //  001F  LDCONST	R9	K7
+          0x68280002,  //  0020  GETUPV	R10	U2
+          0x742A0002,  //  0021  JMPT	R10	#0025
+          0x8C280D0B,  //  0022  GETMET	R10	R6	K11
+          0x7C280200,  //  0023  CALL	R10	1
+          0x5C241400,  //  0024  MOVE	R9	R10
           0x88280D0C,  //  0025  GETMBR	R10	R6	K12
-          0x782A0031,  //  0026  JMPF	R10	#0059
-          0x8C280D0D,  //  0027  GETMET	R10	R6	K13
-          0x7C280200,  //  0028  CALL	R10	1
-          0xB82E0000,  //  0029  GETNGBL	R11	K0
-          0x882C170E,  //  002A  GETMBR	R11	R11	K14
-          0x882C170F,  //  002B  GETMBR	R11	R11	K15
-          0x2428140B,  //  002C  GT	R10	R10	R11
-          0x782A002A,  //  002D  JMPF	R10	#0059
-          0x60280012,  //  002E  GETGBL	R10	G18
-          0x7C280000,  //  002F  CALL	R10	0
-          0x5C201400,  //  0030  MOVE	R8	R10
-          0x60280015,  //  0031  GETGBL	R10	G21
-          0x542E002F,  //  0032  LDINT	R11	48
-          0x7C280200,  //  0033  CALL	R10	1
-          0x8C2C0910,  //  0034  GETMET	R11	R4	K16
-          0x7C2C0200,  //  0035  CALL	R11	1
-          0x68300001,  //  0036  GETUPV	R12	U1
-          0x8C301911,  //  0037  GETMET	R12	R12	K17
-          0x5C381400,  //  0038  MOVE	R14	R10
-          0x5C3C0400,  //  0039  MOVE	R15	R2
-          0x5C401600,  //  003A  MOVE	R16	R11
-          0x50440000,  //  003B  LDBOOL	R17	0	0
-          0x7C300A00,  //  003C  CALL	R12	5
-          0x8C301112,  //  003D  GETMET	R12	R8	K18
-          0x5C381400,  //  003E  MOVE	R14	R10
-          0x7C300400,  //  003F  CALL	R12	2
-          0x60300010,  //  0040  GETGBL	R12	G16
-          0x88340D13,  //  0041  GETMBR	R13	R6	K19
-          0x7C300200,  //  0042  CALL	R12	1
-          0xA8020010,  //  0043  EXBLK	0	#0055
-          0x5C341800,  //  0044  MOVE	R13	R12
-          0x7C340000,  //  0045  CALL	R13	0
-          0x60380015,  //  0046  GETGBL	R14	G21
-          0x543E002F,  //  0047  LDINT	R15	48
-          0x7C380200,  //  0048  CALL	R14	1
-          0x5C281C00,  //  0049  MOVE	R10	R14
-          0x68380001,  //  004A  GETUPV	R14	U1
-          0x8C381D11,  //  004B  GETMET	R14	R14	K17
-          0x5C401400,  //  004C  MOVE	R16	R10
-          0x5C440400,  //  004D  MOVE	R17	R2
-          0x5C481A00,  //  004E  MOVE	R18	R13
-          0x504C0200,  //  004F  LDBOOL	R19	1	0
-          0x7C380A00,  //  0050  CALL	R14	5
-          0x8C381112,  //  0051  GETMET	R14	R8	K18
-          0x5C401400,  //  0052  MOVE	R16	R10
-          0x7C380400,  //  0053  CALL	R14	2
-          0x7001FFEE,  //  0054  JMP		#0044
-          0x58300014,  //  0055  LDCONST	R12	K20
-          0xAC300200,  //  0056  CATCH	R12	1	0
-          0xB0080000,  //  0057  RAISE	2	R0	R0
-          0x70020009,  //  0058  JMP		#0063
-          0x60280015,  //  0059  GETGBL	R10	G21
-          0x542E002F,  //  005A  LDINT	R11	48
-          0x7C280200,  //  005B  CALL	R10	1
-          0x5C201400,  //  005C  MOVE	R8	R10
-          0x68280001,  //  005D  GETUPV	R10	U1
-          0x8C281511,  //  005E  GETMET	R10	R10	K17
-          0x5C301000,  //  005F  MOVE	R12	R8
-          0x5C340400,  //  0060  MOVE	R13	R2
-          0x5C380C00,  //  0061  MOVE	R14	R6
-          0x7C280800,  //  0062  CALL	R10	4
-          0x68280002,  //  0063  GETUPV	R10	U2
-          0x742A000B,  //  0064  JMPT	R10	#0071
-          0xB82A2A00,  //  0065  GETNGBL	R10	K21
-          0x8C281516,  //  0066  GETMET	R10	R10	K22
-          0x60300018,  //  0067  GETGBL	R12	G24
-          0x58340017,  //  0068  LDCONST	R13	K23
-          0x68380000,  //  0069  GETUPV	R14	U0
-          0x88381D18,  //  006A  GETMBR	R14	R14	K24
-          0x5C3C0400,  //  006B  MOVE	R15	R2
-          0x5C400A00,  //  006C  MOVE	R16	R5
-          0x5C441200,  //  006D  MOVE	R17	R9
-          0x7C300A00,  //  006E  CALL	R12	5
-          0x58340019,  //  006F  LDCONST	R13	K25
-          0x7C280600,  //  0070  CALL	R10	3
-          0x70020038,  //  0071  JMP		#00AB
-          0x8824051A,  //  0072  GETMBR	R9	R2	K26
-          0x4C280000,  //  0073  LDNIL	R10
-          0x2024120A,  //  0074  NE	R9	R9	R10
-          0x78260026,  //  0075  JMPF	R9	#009D
-          0x780E0024,  //  0076  JMPF	R3	#009C
-          0x60240015,  //  0077  GETGBL	R9	G21
-          0x542A002F,  //  0078  LDINT	R10	48
-          0x7C240200,  //  0079  CALL	R9	1
-          0x5C201200,  //  007A  MOVE	R8	R9
-          0x68240001,  //  007B  GETUPV	R9	U1
-          0x8C24131B,  //  007C  GETMET	R9	R9	K27
-          0x5C2C1000,  //  007D  MOVE	R11	R8
-          0x5C300400,  //  007E  MOVE	R12	R2
-          0x8834051A,  //  007F  GETMBR	R13	R2	K26
-          0x7C240800,  //  0080  CALL	R9	4
-          0xB8262A00,  //  0081  GETNGBL	R9	K21
-          0x8C24131C,  //  0082  GETMET	R9	R9	K28
-          0x582C0019,  //  0083  LDCONST	R11	K25
-          0x7C240400,  //  0084  CALL	R9	2
-          0x78260015,  //  0085  JMPF	R9	#009C
-          0xB8262A00,  //  0086  GETNGBL	R9	K21
-          0x8C241316,  //  0087  GETMET	R9	R9	K22
-          0x602C0018,  //  0088  GETGBL	R11	G24
-          0x5830001D,  //  0089  LDCONST	R12	K29
-          0x68340000,  //  008A  GETUPV	R13	U0
-          0x88341B18,  //  008B  GETMBR	R13	R13	K24
-          0x60380008,  //  008C  GETGBL	R14	G8
-          0x5C3C0400,  //  008D  MOVE	R15	R2
-          0x7C380200,  //  008E  CALL	R14	1
-          0x5C3C0A00,  //  008F  MOVE	R15	R5
-          0x8840051A,  //  0090  GETMBR	R16	R2	K26
-          0x8844051A,  //  0091  GETMBR	R17	R2	K26
-          0xB84A0000,  //  0092  GETNGBL	R18	K0
-          0x8848251E,  //  0093  GETMBR	R18	R18	K30
-          0x1C442212,  //  0094  EQ	R17	R17	R18
-          0x78460001,  //  0095  JMPF	R17	#0098
-          0x5844001E,  //  0096  LDCONST	R17	K30
-          0x70020000,  //  0097  JMP		#0099
-          0x58440007,  //  0098  LDCONST	R17	K7
-          0x7C2C0C00,  //  0099  CALL	R11	6
-          0x58300019,  //  009A  LDCONST	R12	K25
-          0x7C240600,  //  009B  CALL	R9	3
-          0x7002000D,  //  009C  JMP		#00AB
-          0xB8262A00,  //  009D  GETNGBL	R9	K21
-          0x8C241316,  //  009E  GETMET	R9	R9	K22
-          0x602C0018,  //  009F  GETGBL	R11	G24
-          0x5830001F,  //  00A0  LDCONST	R12	K31
-          0x68340000,  //  00A1  GETUPV	R13	U0
-          0x88341B18,  //  00A2  GETMBR	R13	R13	K24
-          0x60380008,  //  00A3  GETGBL	R14	G8
-          0x5C3C0400,  //  00A4  MOVE	R15	R2
-          0x7C380200,  //  00A5  CALL	R14	1
-          0x5C3C0A00,  //  00A6  MOVE	R15	R5
-          0x7C2C0800,  //  00A7  CALL	R11	4
-          0x58300019,  //  00A8  LDCONST	R12	K25
-          0x7C240600,  //  00A9  CALL	R9	3
-          0x501C0000,  //  00AA  LDBOOL	R7	0	0
-          0x6024000F,  //  00AB  GETGBL	R9	G15
-          0x5C281000,  //  00AC  MOVE	R10	R8
-          0x602C0012,  //  00AD  GETGBL	R11	G18
-          0x7C240400,  //  00AE  CALL	R9	2
-          0x78260001,  //  00AF  JMPF	R9	#00B2
-          0x58240020,  //  00B0  LDCONST	R9	K32
-          0x70020000,  //  00B1  JMP		#00B3
-          0x4C240000,  //  00B2  LDNIL	R9
-          0x4C280000,  //  00B3  LDNIL	R10
-          0x2028100A,  //  00B4  NE	R10	R8	R10
-          0x782A0031,  //  00B5  JMPF	R10	#00E8
-          0x4C280000,  //  00B6  LDNIL	R10
-          0x1C28120A,  //  00B7  EQ	R10	R9	R10
-          0x782A0001,  //  00B8  JMPF	R10	#00BB
-          0x5C281000,  //  00B9  MOVE	R10	R8
-          0x70020000,  //  00BA  JMP		#00BC
-          0x94281009,  //  00BB  GETIDX	R10	R8	R9
-          0x602C000C,  //  00BC  GETGBL	R11	G12
-          0x88300121,  //  00BD  GETMBR	R12	R0	K33
-          0x7C2C0200,  //  00BE  CALL	R11	1
-          0x1C2C1720,  //  00BF  EQ	R11	R11	K32
-          0x782E0004,  //  00C0  JMPF	R11	#00C6
-          0x882C0121,  //  00C1  GETMBR	R11	R0	K33
-          0x8C2C1712,  //  00C2  GETMET	R11	R11	K18
-          0x5C341400,  //  00C3  MOVE	R13	R10
-          0x7C2C0400,  //  00C4  CALL	R11	2
-          0x70020014,  //  00C5  JMP		#00DB
+          0x742A0001,  //  0026  JMPT	R10	#0029
+          0x88280D0D,  //  0027  GETMBR	R10	R6	K13
+          0x782A0031,  //  0028  JMPF	R10	#005B
+          0x8C280D0E,  //  0029  GETMET	R10	R6	K14
+          0x7C280200,  //  002A  CALL	R10	1
+          0xB82E0000,  //  002B  GETNGBL	R11	K0
+          0x882C170F,  //  002C  GETMBR	R11	R11	K15
+          0x882C1710,  //  002D  GETMBR	R11	R11	K16
+          0x2428140B,  //  002E  GT	R10	R10	R11
+          0x782A002A,  //  002F  JMPF	R10	#005B
+          0x60280012,  //  0030  GETGBL	R10	G18
+          0x7C280000,  //  0031  CALL	R10	0
+          0x5C201400,  //  0032  MOVE	R8	R10
+          0x60280015,  //  0033  GETGBL	R10	G21
+          0x542E002F,  //  0034  LDINT	R11	48
+          0x7C280200,  //  0035  CALL	R10	1
+          0x8C2C0911,  //  0036  GETMET	R11	R4	K17
+          0x7C2C0200,  //  0037  CALL	R11	1
+          0x68300001,  //  0038  GETUPV	R12	U1
+          0x8C301912,  //  0039  GETMET	R12	R12	K18
+          0x5C381400,  //  003A  MOVE	R14	R10
+          0x5C3C0400,  //  003B  MOVE	R15	R2
+          0x5C401600,  //  003C  MOVE	R16	R11
+          0x50440000,  //  003D  LDBOOL	R17	0	0
+          0x7C300A00,  //  003E  CALL	R12	5
+          0x8C301113,  //  003F  GETMET	R12	R8	K19
+          0x5C381400,  //  0040  MOVE	R14	R10
+          0x7C300400,  //  0041  CALL	R12	2
+          0x60300010,  //  0042  GETGBL	R12	G16
+          0x88340D14,  //  0043  GETMBR	R13	R6	K20
+          0x7C300200,  //  0044  CALL	R12	1
+          0xA8020010,  //  0045  EXBLK	0	#0057
+          0x5C341800,  //  0046  MOVE	R13	R12
+          0x7C340000,  //  0047  CALL	R13	0
+          0x60380015,  //  0048  GETGBL	R14	G21
+          0x543E002F,  //  0049  LDINT	R15	48
+          0x7C380200,  //  004A  CALL	R14	1
+          0x5C281C00,  //  004B  MOVE	R10	R14
+          0x68380001,  //  004C  GETUPV	R14	U1
+          0x8C381D12,  //  004D  GETMET	R14	R14	K18
+          0x5C401400,  //  004E  MOVE	R16	R10
+          0x5C440400,  //  004F  MOVE	R17	R2
+          0x5C481A00,  //  0050  MOVE	R18	R13
+          0x504C0200,  //  0051  LDBOOL	R19	1	0
+          0x7C380A00,  //  0052  CALL	R14	5
+          0x8C381113,  //  0053  GETMET	R14	R8	K19
+          0x5C401400,  //  0054  MOVE	R16	R10
+          0x7C380400,  //  0055  CALL	R14	2
+          0x7001FFEE,  //  0056  JMP		#0046
+          0x58300015,  //  0057  LDCONST	R12	K21
+          0xAC300200,  //  0058  CATCH	R12	1	0
+          0xB0080000,  //  0059  RAISE	2	R0	R0
+          0x70020009,  //  005A  JMP		#0065
+          0x60280015,  //  005B  GETGBL	R10	G21
+          0x542E002F,  //  005C  LDINT	R11	48
+          0x7C280200,  //  005D  CALL	R10	1
+          0x5C201400,  //  005E  MOVE	R8	R10
+          0x68280001,  //  005F  GETUPV	R10	U1
+          0x8C281512,  //  0060  GETMET	R10	R10	K18
+          0x5C301000,  //  0061  MOVE	R12	R8
+          0x5C340400,  //  0062  MOVE	R13	R2
+          0x5C380C00,  //  0063  MOVE	R14	R6
+          0x7C280800,  //  0064  CALL	R10	4
+          0x68280002,  //  0065  GETUPV	R10	U2
+          0x742A000B,  //  0066  JMPT	R10	#0073
+          0xB82A2C00,  //  0067  GETNGBL	R10	K22
+          0x8C281517,  //  0068  GETMET	R10	R10	K23
+          0x60300018,  //  0069  GETGBL	R12	G24
+          0x58340018,  //  006A  LDCONST	R13	K24
+          0x68380000,  //  006B  GETUPV	R14	U0
+          0x88381D19,  //  006C  GETMBR	R14	R14	K25
+          0x5C3C0400,  //  006D  MOVE	R15	R2
+          0x5C400A00,  //  006E  MOVE	R16	R5
+          0x5C441200,  //  006F  MOVE	R17	R9
+          0x7C300A00,  //  0070  CALL	R12	5
+          0x5834001A,  //  0071  LDCONST	R13	K26
+          0x7C280600,  //  0072  CALL	R10	3
+          0x7002003B,  //  0073  JMP		#00B0
+          0x88240508,  //  0074  GETMBR	R9	R2	K8
+          0x4C280000,  //  0075  LDNIL	R10
+          0x2024120A,  //  0076  NE	R9	R9	R10
+          0x78260026,  //  0077  JMPF	R9	#009F
+          0x780E0024,  //  0078  JMPF	R3	#009E
+          0x60240015,  //  0079  GETGBL	R9	G21
+          0x542A002F,  //  007A  LDINT	R10	48
+          0x7C240200,  //  007B  CALL	R9	1
+          0x5C201200,  //  007C  MOVE	R8	R9
+          0x68240001,  //  007D  GETUPV	R9	U1
+          0x8C24131B,  //  007E  GETMET	R9	R9	K27
+          0x5C2C1000,  //  007F  MOVE	R11	R8
+          0x5C300400,  //  0080  MOVE	R12	R2
+          0x88340508,  //  0081  GETMBR	R13	R2	K8
+          0x7C240800,  //  0082  CALL	R9	4
+          0xB8262C00,  //  0083  GETNGBL	R9	K22
+          0x8C24131C,  //  0084  GETMET	R9	R9	K28
+          0x582C001A,  //  0085  LDCONST	R11	K26
+          0x7C240400,  //  0086  CALL	R9	2
+          0x78260015,  //  0087  JMPF	R9	#009E
+          0xB8262C00,  //  0088  GETNGBL	R9	K22
+          0x8C241317,  //  0089  GETMET	R9	R9	K23
+          0x602C0018,  //  008A  GETGBL	R11	G24
+          0x5830001D,  //  008B  LDCONST	R12	K29
+          0x68340000,  //  008C  GETUPV	R13	U0
+          0x88341B19,  //  008D  GETMBR	R13	R13	K25
+          0x60380008,  //  008E  GETGBL	R14	G8
+          0x5C3C0400,  //  008F  MOVE	R15	R2
+          0x7C380200,  //  0090  CALL	R14	1
+          0x5C3C0A00,  //  0091  MOVE	R15	R5
+          0x88400508,  //  0092  GETMBR	R16	R2	K8
+          0x88440508,  //  0093  GETMBR	R17	R2	K8
+          0xB84A0000,  //  0094  GETNGBL	R18	K0
+          0x8848251E,  //  0095  GETMBR	R18	R18	K30
+          0x1C442212,  //  0096  EQ	R17	R17	R18
+          0x78460001,  //  0097  JMPF	R17	#009A
+          0x5844001E,  //  0098  LDCONST	R17	K30
+          0x70020000,  //  0099  JMP		#009B
+          0x58440007,  //  009A  LDCONST	R17	K7
+          0x7C2C0C00,  //  009B  CALL	R11	6
+          0x5830001A,  //  009C  LDCONST	R12	K26
+          0x7C240600,  //  009D  CALL	R9	3
+          0x70020010,  //  009E  JMP		#00B0
+          0x68240002,  //  009F  GETUPV	R9	U2
+          0x7426000C,  //  00A0  JMPT	R9	#00AE
+          0xB8262C00,  //  00A1  GETNGBL	R9	K22
+          0x8C241317,  //  00A2  GETMET	R9	R9	K23
+          0x602C0018,  //  00A3  GETGBL	R11	G24
+          0x5830001F,  //  00A4  LDCONST	R12	K31
+          0x68340000,  //  00A5  GETUPV	R13	U0
+          0x88341B19,  //  00A6  GETMBR	R13	R13	K25
+          0x60380008,  //  00A7  GETGBL	R14	G8
+          0x5C3C0400,  //  00A8  MOVE	R15	R2
+          0x7C380200,  //  00A9  CALL	R14	1
+          0x5C3C0A00,  //  00AA  MOVE	R15	R5
+          0x7C2C0800,  //  00AB  CALL	R11	4
+          0x5830001A,  //  00AC  LDCONST	R12	K26
+          0x7C240600,  //  00AD  CALL	R9	3
+          0x780E0000,  //  00AE  JMPF	R3	#00B0
+          0x501C0000,  //  00AF  LDBOOL	R7	0	0
+          0x6024000F,  //  00B0  GETGBL	R9	G15
+          0x5C281000,  //  00B1  MOVE	R10	R8
+          0x602C0012,  //  00B2  GETGBL	R11	G18
+          0x7C240400,  //  00B3  CALL	R9	2
+          0x78260001,  //  00B4  JMPF	R9	#00B7
+          0x58240020,  //  00B5  LDCONST	R9	K32
+          0x70020000,  //  00B6  JMP		#00B8
+          0x4C240000,  //  00B7  LDNIL	R9
+          0x4C280000,  //  00B8  LDNIL	R10
+          0x2028100A,  //  00B9  NE	R10	R8	R10
+          0x782A0031,  //  00BA  JMPF	R10	#00ED
+          0x4C280000,  //  00BB  LDNIL	R10
+          0x1C28120A,  //  00BC  EQ	R10	R9	R10
+          0x782A0001,  //  00BD  JMPF	R10	#00C0
+          0x5C281000,  //  00BE  MOVE	R10	R8
+          0x70020000,  //  00BF  JMP		#00C1
+          0x94281009,  //  00C0  GETIDX	R10	R8	R9
+          0x602C000C,  //  00C1  GETGBL	R11	G12
+          0x88300121,  //  00C2  GETMBR	R12	R0	K33
+          0x7C2C0200,  //  00C3  CALL	R11	1
+          0x1C2C1720,  //  00C4  EQ	R11	R11	K32
+          0x782E0004,  //  00C5  JMPF	R11	#00CB
           0x882C0121,  //  00C6  GETMBR	R11	R0	K33
-          0x5431FFFE,  //  00C7  LDINT	R12	-1
-          0x942C160C,  //  00C8  GETIDX	R11	R11	R12
-          0x6030000C,  //  00C9  GETGBL	R12	G12
-          0x5C341600,  //  00CA  MOVE	R13	R11
-          0x7C300200,  //  00CB  CALL	R12	1
-          0x6034000C,  //  00CC  GETGBL	R13	G12
-          0x5C381400,  //  00CD  MOVE	R14	R10
-          0x7C340200,  //  00CE  CALL	R13	1
-          0x0030180D,  //  00CF  ADD	R12	R12	R13
-          0xB8360000,  //  00D0  GETNGBL	R13	K0
-          0x88341B0E,  //  00D1  GETMBR	R13	R13	K14
-          0x88341B0F,  //  00D2  GETMBR	R13	R13	K15
-          0x1830180D,  //  00D3  LE	R12	R12	R13
-          0x78320001,  //  00D4  JMPF	R12	#00D7
-          0x4030160A,  //  00D5  CONNECT	R12	R11	R10
-          0x70020003,  //  00D6  JMP		#00DB
-          0x88300121,  //  00D7  GETMBR	R12	R0	K33
-          0x8C301912,  //  00D8  GETMET	R12	R12	K18
-          0x5C381400,  //  00D9  MOVE	R14	R10
-          0x7C300400,  //  00DA  CALL	R12	2
-          0x4C2C0000,  //  00DB  LDNIL	R11
-          0x1C2C120B,  //  00DC  EQ	R11	R9	R11
-          0x782E0001,  //  00DD  JMPF	R11	#00E0
-          0x4C200000,  //  00DE  LDNIL	R8
-          0x70020006,  //  00DF  JMP		#00E7
-          0x00241322,  //  00E0  ADD	R9	R9	K34
-          0x602C000C,  //  00E1  GETGBL	R11	G12
-          0x5C301000,  //  00E2  MOVE	R12	R8
-          0x7C2C0200,  //  00E3  CALL	R11	1
-          0x282C120B,  //  00E4  GE	R11	R9	R11
-          0x782E0000,  //  00E5  JMPF	R11	#00E7
-          0x4C200000,  //  00E6  LDNIL	R8
-          0x7001FFCA,  //  00E7  JMP		#00B3
-          0x80040E00,  //  00E8  RET	1	R7
+          0x8C2C1713,  //  00C7  GETMET	R11	R11	K19
+          0x5C341400,  //  00C8  MOVE	R13	R10
+          0x7C2C0400,  //  00C9  CALL	R11	2
+          0x70020014,  //  00CA  JMP		#00E0
+          0x882C0121,  //  00CB  GETMBR	R11	R0	K33
+          0x5431FFFE,  //  00CC  LDINT	R12	-1
+          0x942C160C,  //  00CD  GETIDX	R11	R11	R12
+          0x6030000C,  //  00CE  GETGBL	R12	G12
+          0x5C341600,  //  00CF  MOVE	R13	R11
+          0x7C300200,  //  00D0  CALL	R12	1
+          0x6034000C,  //  00D1  GETGBL	R13	G12
+          0x5C381400,  //  00D2  MOVE	R14	R10
+          0x7C340200,  //  00D3  CALL	R13	1
+          0x0030180D,  //  00D4  ADD	R12	R12	R13
+          0xB8360000,  //  00D5  GETNGBL	R13	K0
+          0x88341B0F,  //  00D6  GETMBR	R13	R13	K15
+          0x88341B10,  //  00D7  GETMBR	R13	R13	K16
+          0x1830180D,  //  00D8  LE	R12	R12	R13
+          0x78320001,  //  00D9  JMPF	R12	#00DC
+          0x4030160A,  //  00DA  CONNECT	R12	R11	R10
+          0x70020003,  //  00DB  JMP		#00E0
+          0x88300121,  //  00DC  GETMBR	R12	R0	K33
+          0x8C301913,  //  00DD  GETMET	R12	R12	K19
+          0x5C381400,  //  00DE  MOVE	R14	R10
+          0x7C300400,  //  00DF  CALL	R12	2
+          0x4C2C0000,  //  00E0  LDNIL	R11
+          0x1C2C120B,  //  00E1  EQ	R11	R9	R11
+          0x782E0001,  //  00E2  JMPF	R11	#00E5
+          0x4C200000,  //  00E3  LDNIL	R8
+          0x70020006,  //  00E4  JMP		#00EC
+          0x00241322,  //  00E5  ADD	R9	R9	K34
+          0x602C000C,  //  00E6  GETGBL	R11	G12
+          0x5C301000,  //  00E7  MOVE	R12	R8
+          0x7C2C0200,  //  00E8  CALL	R11	1
+          0x282C120B,  //  00E9  GE	R11	R9	R11
+          0x782E0000,  //  00EA  JMPF	R11	#00EC
+          0x4C200000,  //  00EB  LDNIL	R8
+          0x7001FFCA,  //  00EC  JMP		#00B8
+          0x80040E00,  //  00ED  RET	1	R7
         })
       ),
       be_nested_proto(

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_0.h
@@ -1,4 +1,4 @@
-/* Solidification of Matter_Path.h */
+/* Solidification of Matter_Path_0.h */
 /********************************************************************\
 * Generated code, don't edit                                         *
 \********************************************************************/

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_1_Generator.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Path_1_Generator.h
@@ -1,0 +1,535 @@
+/* Solidification of Matter_Path_1_Generator.h */
+/********************************************************************\
+* Generated code, don't edit                                         *
+\********************************************************************/
+#include "be_constobj.h"
+
+extern const bclass be_class_Matter_PathGenerator;
+
+/********************************************************************
+** Solidified function: next
+********************************************************************/
+be_local_closure(Matter_PathGenerator_next,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(path_in),
+    /* K1   */  be_nested_str_weak(pi),
+    /* K2   */  be_nested_str_weak(cluster),
+    /* K3   */  be_nested_str_weak(_next_endpoint),
+    /* K4   */  be_nested_str_weak(endpoint_found),
+    /* K5   */  be_nested_str_weak(attribute),
+    /* K6   */  be_nested_str_weak(_next_cluster),
+    /* K7   */  be_nested_str_weak(cluster_found),
+    /* K8   */  be_nested_str_weak(_next_attribute),
+    /* K9   */  be_nested_str_weak(attribute_found),
+    /* K10  */  be_nested_str_weak(path_concrete),
+    /* K11  */  be_nested_str_weak(reset),
+    /* K12  */  be_nested_str_weak(endpoint),
+    /* K13  */  be_nested_str_weak(get_endpoint),
+    }),
+    be_str_weak(next),
+    &be_const_str_solidified,
+    ( &(const binstruction[62]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060001,  //  0003  JMPF	R1	#0006
+      0x4C040000,  //  0004  LDNIL	R1
+      0x80040200,  //  0005  RET	1	R1
+      0x88040101,  //  0006  GETMBR	R1	R0	K1
+      0x50080000,  //  0007  LDBOOL	R2	0	0
+      0x20040202,  //  0008  NE	R1	R1	R2
+      0x7806002F,  //  0009  JMPF	R1	#003A
+      0x88040101,  //  000A  GETMBR	R1	R0	K1
+      0x4C080000,  //  000B  LDNIL	R2
+      0x1C040202,  //  000C  EQ	R1	R1	R2
+      0x74060003,  //  000D  JMPT	R1	#0012
+      0x88040102,  //  000E  GETMBR	R1	R0	K2
+      0x50080000,  //  000F  LDBOOL	R2	0	0
+      0x1C040202,  //  0010  EQ	R1	R1	R2
+      0x78060002,  //  0011  JMPF	R1	#0015
+      0x8C040103,  //  0012  GETMET	R1	R0	K3
+      0x7C040200,  //  0013  CALL	R1	1
+      0x7001FFF0,  //  0014  JMP		#0006
+      0x50040200,  //  0015  LDBOOL	R1	1	0
+      0x90020801,  //  0016  SETMBR	R0	K4	R1
+      0x88040102,  //  0017  GETMBR	R1	R0	K2
+      0x4C080000,  //  0018  LDNIL	R2
+      0x1C040202,  //  0019  EQ	R1	R1	R2
+      0x74060003,  //  001A  JMPT	R1	#001F
+      0x88040105,  //  001B  GETMBR	R1	R0	K5
+      0x50080000,  //  001C  LDBOOL	R2	0	0
+      0x1C040202,  //  001D  EQ	R1	R1	R2
+      0x78060002,  //  001E  JMPF	R1	#0022
+      0x8C040106,  //  001F  GETMET	R1	R0	K6
+      0x7C040200,  //  0020  CALL	R1	1
+      0x7001FFE3,  //  0021  JMP		#0006
+      0x50040200,  //  0022  LDBOOL	R1	1	0
+      0x90020E01,  //  0023  SETMBR	R0	K7	R1
+      0x8C040108,  //  0024  GETMET	R1	R0	K8
+      0x7C040200,  //  0025  CALL	R1	1
+      0x88040105,  //  0026  GETMBR	R1	R0	K5
+      0x50080000,  //  0027  LDBOOL	R2	0	0
+      0x1C040202,  //  0028  EQ	R1	R1	R2
+      0x78060000,  //  0029  JMPF	R1	#002B
+      0x7001FFDA,  //  002A  JMP		#0006
+      0x50040200,  //  002B  LDBOOL	R1	1	0
+      0x90021201,  //  002C  SETMBR	R0	K9	R1
+      0x8804010A,  //  002D  GETMBR	R1	R0	K10
+      0x8C08030B,  //  002E  GETMET	R2	R1	K11
+      0x7C080200,  //  002F  CALL	R2	1
+      0x88080101,  //  0030  GETMBR	R2	R0	K1
+      0x8C08050D,  //  0031  GETMET	R2	R2	K13
+      0x7C080200,  //  0032  CALL	R2	1
+      0x90061802,  //  0033  SETMBR	R1	K12	R2
+      0x88080102,  //  0034  GETMBR	R2	R0	K2
+      0x90060402,  //  0035  SETMBR	R1	K2	R2
+      0x88080105,  //  0036  GETMBR	R2	R0	K5
+      0x90060A02,  //  0037  SETMBR	R1	K5	R2
+      0x80040200,  //  0038  RET	1	R1
+      0x7001FFCB,  //  0039  JMP		#0006
+      0x8C04010B,  //  003A  GETMET	R1	R0	K11
+      0x7C040200,  //  003B  CALL	R1	1
+      0x4C040000,  //  003C  LDNIL	R1
+      0x80040200,  //  003D  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _next_cluster
+********************************************************************/
+be_local_closure(Matter_PathGenerator__next_cluster,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(cluster),
+    /* K1   */  be_nested_str_weak(clusters),
+    /* K2   */  be_nested_str_weak(path_in),
+    /* K3   */  be_nested_str_weak(attribute),
+    /* K4   */  be_nested_str_weak(find),
+    /* K5   */  be_const_int(1),
+    }),
+    be_str_weak(_next_cluster),
+    &be_const_str_solidified,
+    ( &(const binstruction[45]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x50080000,  //  0001  LDBOOL	R2	0	0
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060001,  //  0003  JMPF	R1	#0006
+      0x50040000,  //  0004  LDBOOL	R1	0	0
+      0x80040200,  //  0005  RET	1	R1
+      0x88040101,  //  0006  GETMBR	R1	R0	K1
+      0x88080102,  //  0007  GETMBR	R2	R0	K2
+      0x88080500,  //  0008  GETMBR	R2	R2	K0
+      0x4C0C0000,  //  0009  LDNIL	R3
+      0x90020603,  //  000A  SETMBR	R0	K3	R3
+      0x540DFFFE,  //  000B  LDINT	R3	-1
+      0x88100100,  //  000C  GETMBR	R4	R0	K0
+      0x4C140000,  //  000D  LDNIL	R5
+      0x20100805,  //  000E  NE	R4	R4	R5
+      0x78120003,  //  000F  JMPF	R4	#0014
+      0x8C100304,  //  0010  GETMET	R4	R1	K4
+      0x88180100,  //  0011  GETMBR	R6	R0	K0
+      0x7C100400,  //  0012  CALL	R4	2
+      0x5C0C0800,  //  0013  MOVE	R3	R4
+      0x4C100000,  //  0014  LDNIL	R4
+      0x20100604,  //  0015  NE	R4	R3	R4
+      0x78120011,  //  0016  JMPF	R4	#0029
+      0x00100705,  //  0017  ADD	R4	R3	K5
+      0x6014000C,  //  0018  GETGBL	R5	G12
+      0x5C180200,  //  0019  MOVE	R6	R1
+      0x7C140200,  //  001A  CALL	R5	1
+      0x14100805,  //  001B  LT	R4	R4	R5
+      0x7812000B,  //  001C  JMPF	R4	#0029
+      0x000C0705,  //  001D  ADD	R3	R3	K5
+      0x94100203,  //  001E  GETIDX	R4	R1	R3
+      0x90020004,  //  001F  SETMBR	R0	K0	R4
+      0x4C100000,  //  0020  LDNIL	R4
+      0x1C100404,  //  0021  EQ	R4	R2	R4
+      0x74120002,  //  0022  JMPT	R4	#0026
+      0x88100100,  //  0023  GETMBR	R4	R0	K0
+      0x1C100404,  //  0024  EQ	R4	R2	R4
+      0x78120001,  //  0025  JMPF	R4	#0028
+      0x88100100,  //  0026  GETMBR	R4	R0	K0
+      0x80040800,  //  0027  RET	1	R4
+      0x7001FFED,  //  0028  JMP		#0017
+      0x50100000,  //  0029  LDBOOL	R4	0	0
+      0x90020004,  //  002A  SETMBR	R0	K0	R4
+      0x50100000,  //  002B  LDBOOL	R4	0	0
+      0x80040800,  //  002C  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(Matter_PathGenerator_start,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(path_concrete),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(Path),
+    /* K3   */  be_nested_str_weak(reset),
+    /* K4   */  be_nested_str_weak(path_in),
+    /* K5   */  be_nested_str_weak(session),
+    /* K6   */  be_nested_str_weak(endpoint_found),
+    /* K7   */  be_nested_str_weak(cluster_found),
+    /* K8   */  be_nested_str_weak(attribute_found),
+    }),
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0xB80E0200,  //  0000  GETNGBL	R3	K1
+      0x8C0C0702,  //  0001  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x90020003,  //  0003  SETMBR	R0	K0	R3
+      0x8C0C0103,  //  0004  GETMET	R3	R0	K3
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x90020801,  //  0006  SETMBR	R0	K4	R1
+      0x90020A02,  //  0007  SETMBR	R0	K5	R2
+      0x500C0000,  //  0008  LDBOOL	R3	0	0
+      0x90020C03,  //  0009  SETMBR	R0	K6	R3
+      0x500C0000,  //  000A  LDBOOL	R3	0	0
+      0x90020E03,  //  000B  SETMBR	R0	K7	R3
+      0x500C0000,  //  000C  LDBOOL	R3	0	0
+      0x90021003,  //  000D  SETMBR	R0	K8	R3
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pi
+********************************************************************/
+be_local_closure(Matter_PathGenerator_get_pi,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(pi),
+    }),
+    be_str_weak(get_pi),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_PathGenerator_init,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: reset
+********************************************************************/
+be_local_closure(Matter_PathGenerator_reset,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(path_in),
+    /* K1   */  be_nested_str_weak(session),
+    /* K2   */  be_nested_str_weak(path_concrete),
+    /* K3   */  be_nested_str_weak(reset),
+    /* K4   */  be_nested_str_weak(pi),
+    /* K5   */  be_nested_str_weak(cluster),
+    /* K6   */  be_nested_str_weak(attribute),
+    /* K7   */  be_nested_str_weak(clusters),
+    }),
+    be_str_weak(reset),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x4C040000,  //  0000  LDNIL	R1
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x90020201,  //  0002  SETMBR	R0	K1	R1
+      0x88080102,  //  0003  GETMBR	R2	R0	K2
+      0x8C080503,  //  0004  GETMET	R2	R2	K3
+      0x7C080200,  //  0005  CALL	R2	1
+      0x90020801,  //  0006  SETMBR	R0	K4	R1
+      0x90020A01,  //  0007  SETMBR	R0	K5	R1
+      0x90020C01,  //  0008  SETMBR	R0	K6	R1
+      0x90020E01,  //  0009  SETMBR	R0	K7	R1
+      0x90020E01,  //  000A  SETMBR	R0	K7	R1
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _next_endpoint
+********************************************************************/
+be_local_closure(Matter_PathGenerator__next_endpoint,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(pi),
+    /* K1   */  be_nested_str_weak(device),
+    /* K2   */  be_nested_str_weak(plugins),
+    /* K3   */  be_nested_str_weak(path_in),
+    /* K4   */  be_nested_str_weak(endpoint),
+    /* K5   */  be_nested_str_weak(cluster),
+    /* K6   */  be_nested_str_weak(attribute),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(get_endpoint),
+    /* K10  */  be_nested_str_weak(clusters),
+    /* K11  */  be_nested_str_weak(get_cluster_list_sorted),
+    }),
+    be_str_weak(_next_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[54]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x50080000,  //  0001  LDBOOL	R2	0	0
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060001,  //  0003  JMPF	R1	#0006
+      0x50040000,  //  0004  LDBOOL	R1	0	0
+      0x80040200,  //  0005  RET	1	R1
+      0x88040101,  //  0006  GETMBR	R1	R0	K1
+      0x88040302,  //  0007  GETMBR	R1	R1	K2
+      0x88080103,  //  0008  GETMBR	R2	R0	K3
+      0x88080504,  //  0009  GETMBR	R2	R2	K4
+      0x4C0C0000,  //  000A  LDNIL	R3
+      0x90020A03,  //  000B  SETMBR	R0	K5	R3
+      0x4C0C0000,  //  000C  LDNIL	R3
+      0x90020C03,  //  000D  SETMBR	R0	K6	R3
+      0x540DFFFE,  //  000E  LDINT	R3	-1
+      0x88100100,  //  000F  GETMBR	R4	R0	K0
+      0x4C140000,  //  0010  LDNIL	R5
+      0x20100805,  //  0011  NE	R4	R4	R5
+      0x78120003,  //  0012  JMPF	R4	#0017
+      0x8C100307,  //  0013  GETMET	R4	R1	K7
+      0x88180100,  //  0014  GETMBR	R6	R0	K0
+      0x7C100400,  //  0015  CALL	R4	2
+      0x5C0C0800,  //  0016  MOVE	R3	R4
+      0x4C100000,  //  0017  LDNIL	R4
+      0x20100604,  //  0018  NE	R4	R3	R4
+      0x78120017,  //  0019  JMPF	R4	#0032
+      0x00100708,  //  001A  ADD	R4	R3	K8
+      0x6014000C,  //  001B  GETGBL	R5	G12
+      0x5C180200,  //  001C  MOVE	R6	R1
+      0x7C140200,  //  001D  CALL	R5	1
+      0x14100805,  //  001E  LT	R4	R4	R5
+      0x78120011,  //  001F  JMPF	R4	#0032
+      0x000C0708,  //  0020  ADD	R3	R3	K8
+      0x94100203,  //  0021  GETIDX	R4	R1	R3
+      0x90020004,  //  0022  SETMBR	R0	K0	R4
+      0x4C100000,  //  0023  LDNIL	R4
+      0x1C100404,  //  0024  EQ	R4	R2	R4
+      0x74120004,  //  0025  JMPT	R4	#002B
+      0x88100100,  //  0026  GETMBR	R4	R0	K0
+      0x8C100909,  //  0027  GETMET	R4	R4	K9
+      0x7C100200,  //  0028  CALL	R4	1
+      0x1C100404,  //  0029  EQ	R4	R2	R4
+      0x78120005,  //  002A  JMPF	R4	#0031
+      0x88100100,  //  002B  GETMBR	R4	R0	K0
+      0x8C10090B,  //  002C  GETMET	R4	R4	K11
+      0x7C100200,  //  002D  CALL	R4	1
+      0x90021404,  //  002E  SETMBR	R0	K10	R4
+      0x88100100,  //  002F  GETMBR	R4	R0	K0
+      0x80040800,  //  0030  RET	1	R4
+      0x7001FFE7,  //  0031  JMP		#001A
+      0x50100000,  //  0032  LDBOOL	R4	0	0
+      0x90020004,  //  0033  SETMBR	R0	K0	R4
+      0x50100000,  //  0034  LDBOOL	R4	0	0
+      0x80040800,  //  0035  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _next_attribute
+********************************************************************/
+be_local_closure(Matter_PathGenerator__next_attribute,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(attribute),
+    /* K1   */  be_nested_str_weak(pi),
+    /* K2   */  be_nested_str_weak(get_attribute_list),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(path_in),
+    /* K5   */  be_nested_str_weak(find),
+    /* K6   */  be_const_int(1),
+    }),
+    be_str_weak(_next_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[46]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x50080000,  //  0001  LDBOOL	R2	0	0
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060001,  //  0003  JMPF	R1	#0006
+      0x50040000,  //  0004  LDBOOL	R1	0	0
+      0x80040200,  //  0005  RET	1	R1
+      0x88040101,  //  0006  GETMBR	R1	R0	K1
+      0x8C040302,  //  0007  GETMET	R1	R1	K2
+      0x880C0103,  //  0008  GETMBR	R3	R0	K3
+      0x7C040400,  //  0009  CALL	R1	2
+      0x88080104,  //  000A  GETMBR	R2	R0	K4
+      0x88080500,  //  000B  GETMBR	R2	R2	K0
+      0x540DFFFE,  //  000C  LDINT	R3	-1
+      0x88100100,  //  000D  GETMBR	R4	R0	K0
+      0x4C140000,  //  000E  LDNIL	R5
+      0x20100805,  //  000F  NE	R4	R4	R5
+      0x78120003,  //  0010  JMPF	R4	#0015
+      0x8C100305,  //  0011  GETMET	R4	R1	K5
+      0x88180100,  //  0012  GETMBR	R6	R0	K0
+      0x7C100400,  //  0013  CALL	R4	2
+      0x5C0C0800,  //  0014  MOVE	R3	R4
+      0x4C100000,  //  0015  LDNIL	R4
+      0x20100604,  //  0016  NE	R4	R3	R4
+      0x78120011,  //  0017  JMPF	R4	#002A
+      0x00100706,  //  0018  ADD	R4	R3	K6
+      0x6014000C,  //  0019  GETGBL	R5	G12
+      0x5C180200,  //  001A  MOVE	R6	R1
+      0x7C140200,  //  001B  CALL	R5	1
+      0x14100805,  //  001C  LT	R4	R4	R5
+      0x7812000B,  //  001D  JMPF	R4	#002A
+      0x000C0706,  //  001E  ADD	R3	R3	K6
+      0x94100203,  //  001F  GETIDX	R4	R1	R3
+      0x90020004,  //  0020  SETMBR	R0	K0	R4
+      0x4C100000,  //  0021  LDNIL	R4
+      0x1C100404,  //  0022  EQ	R4	R2	R4
+      0x74120002,  //  0023  JMPT	R4	#0027
+      0x88100100,  //  0024  GETMBR	R4	R0	K0
+      0x1C100404,  //  0025  EQ	R4	R2	R4
+      0x78120001,  //  0026  JMPF	R4	#0029
+      0x88100100,  //  0027  GETMBR	R4	R0	K0
+      0x80040800,  //  0028  RET	1	R4
+      0x7001FFED,  //  0029  JMP		#0018
+      0x50100000,  //  002A  LDBOOL	R4	0	0
+      0x90020004,  //  002B  SETMBR	R0	K0	R4
+      0x50100000,  //  002C  LDBOOL	R4	0	0
+      0x80040800,  //  002D  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: Matter_PathGenerator
+********************************************************************/
+be_local_class(Matter_PathGenerator,
+    11,
+    NULL,
+    be_nested_map(19,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(_next_cluster, -1), be_const_closure(Matter_PathGenerator__next_cluster_closure) },
+        { be_const_key_weak(_next_endpoint, -1), be_const_closure(Matter_PathGenerator__next_endpoint_closure) },
+        { be_const_key_weak(endpoint_found, 0), be_const_var(7) },
+        { be_const_key_weak(start, -1), be_const_closure(Matter_PathGenerator_start_closure) },
+        { be_const_key_weak(session, -1), be_const_var(2) },
+        { be_const_key_weak(get_pi, 12), be_const_closure(Matter_PathGenerator_get_pi_closure) },
+        { be_const_key_weak(pi, -1), be_const_var(3) },
+        { be_const_key_weak(attribute, 10), be_const_var(5) },
+        { be_const_key_weak(cluster_found, 14), be_const_var(8) },
+        { be_const_key_weak(device, -1), be_const_var(0) },
+        { be_const_key_weak(attribute_found, -1), be_const_var(9) },
+        { be_const_key_weak(clusters, -1), be_const_var(6) },
+        { be_const_key_weak(path_in, -1), be_const_var(1) },
+        { be_const_key_weak(init, 11), be_const_closure(Matter_PathGenerator_init_closure) },
+        { be_const_key_weak(path_concrete, -1), be_const_var(10) },
+        { be_const_key_weak(next, 9), be_const_closure(Matter_PathGenerator_next_closure) },
+        { be_const_key_weak(cluster, 4), be_const_var(4) },
+        { be_const_key_weak(reset, 1), be_const_closure(Matter_PathGenerator_reset_closure) },
+        { be_const_key_weak(_next_attribute, -1), be_const_closure(Matter_PathGenerator__next_attribute_closure) },
+    })),
+    be_str_weak(Matter_PathGenerator)
+);
+/*******************************************************************/
+
+void be_load_Matter_PathGenerator_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_Matter_PathGenerator);
+    be_setglobal(vm, "Matter_PathGenerator");
+    be_pop(vm, 1);
+}
+/********************************************************************/
+/* End of solidification */

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
@@ -69,26 +69,23 @@ be_local_closure(Matter_Plugin_every_250ms,   /* name */
 
 
 /********************************************************************
-** Solidified function: consolidate_clusters
+** Solidified function: parse_configuration
 ********************************************************************/
-be_local_closure(Matter_Plugin_consolidate_clusters,   /* name */
+be_local_closure(Matter_Plugin_parse_configuration,   /* name */
   be_nested_proto(
     2,                          /* nstack */
-    1,                          /* argc */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(CLUSTERS),
-    }),
-    be_str_weak(consolidate_clusters),
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(parse_configuration),
     &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
     })
   )
 );
@@ -228,26 +225,23 @@ be_local_closure(Matter_Plugin_subscribe_event,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_name
+** Solidified function: parse_sensors
 ********************************************************************/
-be_local_closure(Matter_Plugin_get_name,   /* name */
+be_local_closure(Matter_Plugin_parse_sensors,   /* name */
   be_nested_proto(
     2,                          /* nstack */
-    1,                          /* argc */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(node_label),
-    }),
-    be_str_weak(get_name),
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(parse_sensors),
     &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
     })
   )
 );
@@ -334,46 +328,6 @@ be_local_closure(Matter_Plugin_publish_command,   /* name */
 
 
 /********************************************************************
-** Solidified function: ui_conf_to_string
-********************************************************************/
-be_local_closure(Matter_Plugin_ui_conf_to_string,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Plugin),
-    /* K1   */  be_nested_str_weak(ARG),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(),
-    }),
-    be_str_weak(ui_conf_to_string),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x780E0006,  //  0002  JMPF	R3	#000A
-      0x60100008,  //  0003  GETGBL	R4	G8
-      0x8C140302,  //  0004  GETMET	R5	R1	K2
-      0x5C1C0600,  //  0005  MOVE	R7	R3
-      0x58200003,  //  0006  LDCONST	R8	K3
-      0x7C140600,  //  0007  CALL	R5	3
-      0x7C100200,  //  0008  CALL	R4	1
-      0x70020000,  //  0009  JMP		#000B
-      0x58100003,  //  000A  LDCONST	R4	K3
-      0x80040800,  //  000B  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: read_attribute
 ********************************************************************/
 be_local_closure(Matter_Plugin_read_attribute,   /* name */
@@ -400,7 +354,7 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
     /* K10  */  be_nested_str_weak(U2),
     /* K11  */  be_const_int(1),
     /* K12  */  be_nested_str_weak(stop_iteration),
-    /* K13  */  be_nested_str_weak(get_cluster_list),
+    /* K13  */  be_nested_str_weak(get_cluster_list_sorted),
     /* K14  */  be_nested_str_weak(U4),
     /* K15  */  be_const_int(2),
     /* K16  */  be_const_int(3),
@@ -412,7 +366,7 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[160]) {  /* code */
+    ( &(const binstruction[161]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
@@ -572,7 +526,8 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
       0x5C2C0E00,  //  009C  MOVE	R11	R7
       0x7C200600,  //  009D  CALL	R8	3
       0x80041000,  //  009E  RET	1	R8
-      0x80000000,  //  009F  RET	0
+      0x4C1C0000,  //  009F  LDNIL	R7
+      0x80040E00,  //  00A0  RET	1	R7
     })
   )
 );
@@ -580,41 +535,64 @@ be_local_closure(Matter_Plugin_read_attribute,   /* name */
 
 
 /********************************************************************
-** Solidified function: ack_request
+** Solidified function: ui_conf_to_string
 ********************************************************************/
-be_local_closure(Matter_Plugin_ack_request,   /* name */
+be_local_closure(Matter_Plugin_ui_conf_to_string,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    9,                          /* nstack */
     2,                          /* argc */
-    2,                          /* varg */
+    4,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(msg),
-    /* K1   */  be_nested_str_weak(device),
-    /* K2   */  be_nested_str_weak(message_handler),
-    /* K3   */  be_nested_str_weak(im),
-    /* K4   */  be_nested_str_weak(send_ack_now),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Plugin),
+    /* K1   */  be_nested_str_weak(ARG),
+    /* K2   */  be_nested_str_weak(find),
+    /* K3   */  be_nested_str_weak(),
     }),
-    be_str_weak(ack_request),
+    be_str_weak(ui_conf_to_string),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88080300,  //  0000  GETMBR	R2	R1	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x200C0403,  //  0002  NE	R3	R2	R3
-      0x780E0005,  //  0003  JMPF	R3	#000A
-      0x880C0101,  //  0004  GETMBR	R3	R0	K1
-      0x880C0702,  //  0005  GETMBR	R3	R3	K2
-      0x880C0703,  //  0006  GETMBR	R3	R3	K3
-      0x8C0C0704,  //  0007  GETMET	R3	R3	K4
-      0x5C140400,  //  0008  MOVE	R5	R2
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x4C0C0000,  //  000A  LDNIL	R3
-      0x90060003,  //  000B  SETMBR	R1	K0	R3
-      0x80000000,  //  000C  RET	0
+    ( &(const binstruction[12]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x780E0006,  //  0002  JMPF	R3	#000A
+      0x60100008,  //  0003  GETGBL	R4	G8
+      0x8C140302,  //  0004  GETMET	R5	R1	K2
+      0x5C1C0600,  //  0005  MOVE	R7	R3
+      0x58200003,  //  0006  LDCONST	R8	K3
+      0x7C140600,  //  0007  CALL	R5	3
+      0x7C100200,  //  0008  CALL	R4	1
+      0x70020000,  //  0009  JMP		#000B
+      0x58100003,  //  000A  LDCONST	R4	K3
+      0x80040800,  //  000B  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: write_attribute
+********************************************************************/
+be_local_closure(Matter_Plugin_write_attribute,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(write_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x80040800,  //  0001  RET	1	R4
     })
   )
 );
@@ -680,23 +658,41 @@ be_local_closure(Matter_Plugin_read_event,   /* name */
 
 
 /********************************************************************
-** Solidified function: parse_configuration
+** Solidified function: ack_request
 ********************************************************************/
-be_local_closure(Matter_Plugin_parse_configuration,   /* name */
+be_local_closure(Matter_Plugin_ack_request,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
+    6,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(parse_configuration),
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(msg),
+    /* K1   */  be_nested_str_weak(device),
+    /* K2   */  be_nested_str_weak(message_handler),
+    /* K3   */  be_nested_str_weak(im),
+    /* K4   */  be_nested_str_weak(send_ack_now),
+    }),
+    be_str_weak(ack_request),
     &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
+    ( &(const binstruction[13]) {  /* code */
+      0x88080300,  //  0000  GETMBR	R2	R1	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x200C0403,  //  0002  NE	R3	R2	R3
+      0x780E0005,  //  0003  JMPF	R3	#000A
+      0x880C0101,  //  0004  GETMBR	R3	R0	K1
+      0x880C0702,  //  0005  GETMBR	R3	R3	K2
+      0x880C0703,  //  0006  GETMBR	R3	R3	K3
+      0x8C0C0704,  //  0007  GETMET	R3	R3	K4
+      0x5C140400,  //  0008  MOVE	R5	R2
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x4C0C0000,  //  000A  LDNIL	R3
+      0x90060003,  //  000B  SETMBR	R1	K0	R3
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -704,11 +700,11 @@ be_local_closure(Matter_Plugin_parse_configuration,   /* name */
 
 
 /********************************************************************
-** Solidified function: consolidate_update_commands
+** Solidified function: get_cluster_list_sorted
 ********************************************************************/
-be_local_closure(Matter_Plugin_consolidate_update_commands,   /* name */
+be_local_closure(Matter_Plugin_get_cluster_list_sorted,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -716,14 +712,19 @@ be_local_closure(Matter_Plugin_consolidate_update_commands,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(UPDATE_COMMANDS),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(k2l),
+    /* K2   */  be_nested_str_weak(clusters),
     }),
-    be_str_weak(consolidate_update_commands),
+    be_str_weak(get_cluster_list_sorted),
     &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
+    ( &(const binstruction[ 5]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x7C040400,  //  0003  CALL	R1	2
+      0x80040200,  //  0004  RET	1	R1
     })
   )
 );
@@ -818,6 +819,89 @@ be_local_closure(Matter_Plugin_get_endpoint,   /* name */
 
 
 /********************************************************************
+** Solidified function: update_shadow
+********************************************************************/
+be_local_closure(Matter_Plugin_update_shadow,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tick),
+    /* K1   */  be_nested_str_weak(device),
+    }),
+    be_str_weak(update_shadow),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x88040300,  //  0001  GETMBR	R1	R1	K0
+      0x90020001,  //  0002  SETMBR	R0	K0	R1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: consolidate_update_commands
+********************************************************************/
+be_local_closure(Matter_Plugin_consolidate_update_commands,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(UPDATE_COMMANDS),
+    }),
+    be_str_weak(consolidate_update_commands),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: append_state_json
+********************************************************************/
+be_local_closure(Matter_Plugin_append_state_json,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(),
+    }),
+    be_str_weak(append_state_json),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80060000,  //  0000  RET	1	K0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: state_json
 ********************************************************************/
 be_local_closure(Matter_Plugin_state_json,   /* name */
@@ -868,61 +952,6 @@ be_local_closure(Matter_Plugin_state_json,   /* name */
       0x4C100000,  //  0016  LDNIL	R4
       0x80040800,  //  0017  RET	1	R4
       0x80000000,  //  0018  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_shadow
-********************************************************************/
-be_local_closure(Matter_Plugin_update_shadow,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tick),
-    /* K1   */  be_nested_str_weak(device),
-    }),
-    be_str_weak(update_shadow),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x88040300,  //  0001  GETMBR	R1	R1	K0
-      0x90020001,  //  0002  SETMBR	R0	K0	R1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: write_attribute
-********************************************************************/
-be_local_closure(Matter_Plugin_write_attribute,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(write_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x80040800,  //  0001  RET	1	R4
     })
   )
 );
@@ -1060,11 +1089,11 @@ be_local_closure(Matter_Plugin_update_virtual,   /* name */
 
 
 /********************************************************************
-** Solidified function: append_state_json
+** Solidified function: consolidate_clusters
 ********************************************************************/
-be_local_closure(Matter_Plugin_append_state_json,   /* name */
+be_local_closure(Matter_Plugin_consolidate_clusters,   /* name */
   be_nested_proto(
-    1,                          /* nstack */
+    2,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1073,12 +1102,13 @@ be_local_closure(Matter_Plugin_append_state_json,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(),
+    /* K0   */  be_nested_str_weak(CLUSTERS),
     }),
-    be_str_weak(append_state_json),
+    be_str_weak(consolidate_clusters),
     &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80060000,  //  0000  RET	1	K0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -1136,23 +1166,26 @@ be_local_closure(Matter_Plugin_contains_attribute,   /* name */
 
 
 /********************************************************************
-** Solidified function: parse_sensors
+** Solidified function: get_name
 ********************************************************************/
-be_local_closure(Matter_Plugin_parse_sensors,   /* name */
+be_local_closure(Matter_Plugin_get_name,   /* name */
   be_nested_proto(
     2,                          /* nstack */
-    2,                          /* argc */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(parse_sensors),
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(node_label),
+    }),
+    be_str_weak(get_name),
     &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -1243,52 +1276,6 @@ be_local_closure(Matter_Plugin_is_local_device,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_cluster_list
-********************************************************************/
-be_local_closure(Matter_Plugin_get_cluster_list,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(clusters),
-    /* K1   */  be_nested_str_weak(keys),
-    /* K2   */  be_nested_str_weak(push),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(get_cluster_list),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x60040012,  //  0000  GETGBL	R1	G18
-      0x7C040000,  //  0001  CALL	R1	0
-      0x60080010,  //  0002  GETGBL	R2	G16
-      0x880C0100,  //  0003  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0004  GETMET	R3	R3	K1
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x7C080200,  //  0006  CALL	R2	1
-      0xA8020005,  //  0007  EXBLK	0	#000E
-      0x5C0C0400,  //  0008  MOVE	R3	R2
-      0x7C0C0000,  //  0009  CALL	R3	0
-      0x8C100302,  //  000A  GETMET	R4	R1	K2
-      0x5C180600,  //  000B  MOVE	R6	R3
-      0x7C100400,  //  000C  CALL	R4	2
-      0x7001FFF9,  //  000D  JMP		#0008
-      0x58080003,  //  000E  LDCONST	R2	K3
-      0xAC080200,  //  000F  CATCH	R2	1	0
-      0xB0080000,  //  0010  RAISE	2	R0	R0
-      0x80040200,  //  0011  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: ui_string_to_conf
 ********************************************************************/
 be_local_closure(Matter_Plugin_ui_string_to_conf,   /* name */
@@ -1342,10 +1329,14 @@ be_local_class(Matter_Plugin,
         { be_const_key_int(49, -1), be_const_int(4) },
     }))    ) } )) },
         { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_read_attribute_closure) },
-        { be_const_key_weak(subscribe_attribute, 31), be_const_closure(Matter_Plugin_subscribe_attribute_closure) },
+        { be_const_key_weak(subscribe_attribute, 33), be_const_closure(Matter_Plugin_subscribe_attribute_closure) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_init_closure) },
         { be_const_key_weak(UPDATE_TIME, -1), be_const_int(5000) },
-        { be_const_key_weak(set_name, 36), be_const_closure(Matter_Plugin_set_name_closure) },
+        { be_const_key_weak(COMMANDS, 21), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(1,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_int(29, -1), be_const_nil() },
+    }))    ) } )) },
         { be_const_key_weak(endpoint, -1), be_const_var(2) },
         { be_const_key_weak(UPDATE_COMMANDS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(0,
@@ -1354,9 +1345,9 @@ be_local_class(Matter_Plugin,
         { be_const_key_weak(VIRTUAL, -1), be_const_bool(0) },
         { be_const_key_weak(device, -1), be_const_var(1) },
         { be_const_key_weak(subscribe_event, 3), be_const_closure(Matter_Plugin_subscribe_event_closure) },
-        { be_const_key_weak(read_event, -1), be_const_closure(Matter_Plugin_read_event_closure) },
+        { be_const_key_weak(clusters, -1), be_const_var(3) },
         { be_const_key_weak(publish_command, -1), be_const_closure(Matter_Plugin_publish_command_closure) },
-        { be_const_key_weak(is_local_device, 21), be_const_closure(Matter_Plugin_is_local_device_closure) },
+        { be_const_key_weak(is_local_device, 29), be_const_closure(Matter_Plugin_is_local_device_closure) },
         { be_const_key_weak(CLUSTER_REVISIONS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(25,
     ( (struct bmapnode*) &(const bmapnode[]) {
@@ -1387,12 +1378,12 @@ be_local_class(Matter_Plugin,
         { be_const_key_int(1024, -1), be_const_int(3) },
     }))    ) } )) },
         { be_const_key_weak(contains_cluster, -1), be_const_closure(Matter_Plugin_contains_cluster_closure) },
-        { be_const_key_weak(parse_configuration, -1), be_const_closure(Matter_Plugin_parse_configuration_closure) },
-        { be_const_key_weak(get_attribute_list, 33), be_const_closure(Matter_Plugin_get_attribute_list_closure) },
-        { be_const_key_weak(consolidate_clusters, 13), be_const_closure(Matter_Plugin_consolidate_clusters_closure) },
-        { be_const_key_weak(parse_sensors, 23), be_const_closure(Matter_Plugin_parse_sensors_closure) },
-        { be_const_key_weak(contains_attribute, 29), be_const_closure(Matter_Plugin_contains_attribute_closure) },
-        { be_const_key_weak(append_state_json, -1), be_const_closure(Matter_Plugin_append_state_json_closure) },
+        { be_const_key_weak(ack_request, -1), be_const_closure(Matter_Plugin_ack_request_closure) },
+        { be_const_key_weak(parse_configuration, 34), be_const_closure(Matter_Plugin_parse_configuration_closure) },
+        { be_const_key_weak(read_event, 28), be_const_closure(Matter_Plugin_read_event_closure) },
+        { be_const_key_weak(get_name, 43), be_const_closure(Matter_Plugin_get_name_closure) },
+        { be_const_key_weak(contains_attribute, 31), be_const_closure(Matter_Plugin_contains_attribute_closure) },
+        { be_const_key_weak(get_cluster_list_sorted, -1), be_const_closure(Matter_Plugin_get_cluster_list_sorted_closure) },
         { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(1,
     ( (struct bmapnode*) &(const bmapnode[]) {
@@ -1412,32 +1403,28 @@ be_local_class(Matter_Plugin,
     }))    ) } )) },
     }))    ) } )) },
         { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Plugin_attribute_updated_closure) },
-        { be_const_key_weak(timed_request, 41), be_const_closure(Matter_Plugin_timed_request_closure) },
+        { be_const_key_weak(timed_request, 13), be_const_closure(Matter_Plugin_timed_request_closure) },
         { be_const_key_weak(get_endpoint, -1), be_const_closure(Matter_Plugin_get_endpoint_closure) },
-        { be_const_key_weak(update_next, 43), be_const_var(0) },
+        { be_const_key_weak(consolidate_clusters, -1), be_const_closure(Matter_Plugin_consolidate_clusters_closure) },
+        { be_const_key_weak(append_state_json, 18), be_const_closure(Matter_Plugin_append_state_json_closure) },
+        { be_const_key_weak(ui_conf_to_string, 41), be_const_static_closure(Matter_Plugin_ui_conf_to_string_closure) },
         { be_const_key_weak(TYPE, 32), be_nested_str_weak() },
-        { be_const_key_weak(ui_conf_to_string, 28), be_const_static_closure(Matter_Plugin_ui_conf_to_string_closure) },
+        { be_const_key_weak(state_json, -1), be_const_closure(Matter_Plugin_state_json_closure) },
         { be_const_key_weak(tick, -1), be_const_var(4) },
-        { be_const_key_weak(update_shadow, -1), be_const_closure(Matter_Plugin_update_shadow_closure) },
-        { be_const_key_weak(ARG, 18), be_nested_str_weak() },
+        { be_const_key_weak(ARG, 47), be_nested_str_weak() },
+        { be_const_key_weak(write_attribute, 36), be_const_closure(Matter_Plugin_write_attribute_closure) },
         { be_const_key_weak(has, -1), be_const_closure(Matter_Plugin_has_closure) },
-        { be_const_key_weak(write_attribute, 34), be_const_closure(Matter_Plugin_write_attribute_closure) },
-        { be_const_key_weak(COMMANDS, 42), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_int(29, -1), be_const_nil() },
-    }))    ) } )) },
         { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_invoke_request_closure) },
         { be_const_key_weak(update_shadow_lazy, -1), be_const_closure(Matter_Plugin_update_shadow_lazy_closure) },
-        { be_const_key_weak(state_json, 22), be_const_closure(Matter_Plugin_state_json_closure) },
+        { be_const_key_weak(update_shadow, 22), be_const_closure(Matter_Plugin_update_shadow_closure) },
         { be_const_key_weak(update_virtual, -1), be_const_closure(Matter_Plugin_update_virtual_closure) },
-        { be_const_key_weak(clusters, -1), be_const_var(3) },
-        { be_const_key_weak(get_name, -1), be_const_closure(Matter_Plugin_get_name_closure) },
-        { be_const_key_weak(node_label, -1), be_const_var(5) },
+        { be_const_key_weak(node_label, 42), be_const_var(5) },
+        { be_const_key_weak(update_next, -1), be_const_var(0) },
+        { be_const_key_weak(set_name, -1), be_const_closure(Matter_Plugin_set_name_closure) },
         { be_const_key_weak(ARG_TYPE, -1), be_const_static_closure(Matter_Plugin__X3Clambda_X3E_closure) },
         { be_const_key_weak(ARG_HINT, 17), be_nested_str_weak(_Not_X20used_) },
-        { be_const_key_weak(ack_request, 15), be_const_closure(Matter_Plugin_ack_request_closure) },
-        { be_const_key_weak(get_cluster_list, -1), be_const_closure(Matter_Plugin_get_cluster_list_closure) },
+        { be_const_key_weak(parse_sensors, 15), be_const_closure(Matter_Plugin_parse_sensors_closure) },
+        { be_const_key_weak(get_attribute_list, -1), be_const_closure(Matter_Plugin_get_attribute_list_closure) },
         { be_const_key_weak(ui_string_to_conf, -1), be_const_static_closure(Matter_Plugin_ui_string_to_conf_closure) },
         { be_const_key_weak(consolidate_update_commands, 2), be_const_closure(Matter_Plugin_consolidate_update_commands_closure) },
     })),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
@@ -1488,305 +1488,108 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name
 ********************************************************************/
 be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
   be_nested_proto(
-    24,                          /* nstack */
+    16,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        7,                          /* nstack */
-        1,                          /* argc */
-        0,                          /* varg */
-        0,                          /* has upvals */
-        NULL,                       /* no upvals */
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(keys),
-        /* K1   */  be_nested_str_weak(push),
-        /* K2   */  be_nested_str_weak(stop_iteration),
-        /* K3   */  be_const_int(1),
-        /* K4   */  be_const_int(0),
-        }),
-        be_str_weak(keys_sorted),
-        &be_const_str_solidified,
-        ( &(const binstruction[45]) {  /* code */
-          0x60040012,  //  0000  GETGBL	R1	G18
-          0x7C040000,  //  0001  CALL	R1	0
-          0x60080010,  //  0002  GETGBL	R2	G16
-          0x8C0C0100,  //  0003  GETMET	R3	R0	K0
-          0x7C0C0200,  //  0004  CALL	R3	1
-          0x7C080200,  //  0005  CALL	R2	1
-          0xA8020005,  //  0006  EXBLK	0	#000D
-          0x5C0C0400,  //  0007  MOVE	R3	R2
-          0x7C0C0000,  //  0008  CALL	R3	0
-          0x8C100301,  //  0009  GETMET	R4	R1	K1
-          0x5C180600,  //  000A  MOVE	R6	R3
-          0x7C100400,  //  000B  CALL	R4	2
-          0x7001FFF9,  //  000C  JMP		#0007
-          0x58080002,  //  000D  LDCONST	R2	K2
-          0xAC080200,  //  000E  CATCH	R2	1	0
-          0xB0080000,  //  000F  RAISE	2	R0	R0
-          0x60080010,  //  0010  GETGBL	R2	G16
-          0x600C000C,  //  0011  GETGBL	R3	G12
-          0x5C100200,  //  0012  MOVE	R4	R1
-          0x7C0C0200,  //  0013  CALL	R3	1
-          0x040C0703,  //  0014  SUB	R3	R3	K3
-          0x400E0603,  //  0015  CONNECT	R3	K3	R3
-          0x7C080200,  //  0016  CALL	R2	1
-          0xA8020010,  //  0017  EXBLK	0	#0029
-          0x5C0C0400,  //  0018  MOVE	R3	R2
-          0x7C0C0000,  //  0019  CALL	R3	0
-          0x94100203,  //  001A  GETIDX	R4	R1	R3
-          0x5C140600,  //  001B  MOVE	R5	R3
-          0x24180B04,  //  001C  GT	R6	R5	K4
-          0x781A0008,  //  001D  JMPF	R6	#0027
-          0x04180B03,  //  001E  SUB	R6	R5	K3
-          0x94180206,  //  001F  GETIDX	R6	R1	R6
-          0x24180C04,  //  0020  GT	R6	R6	R4
-          0x781A0004,  //  0021  JMPF	R6	#0027
-          0x04180B03,  //  0022  SUB	R6	R5	K3
-          0x94180206,  //  0023  GETIDX	R6	R1	R6
-          0x98040A06,  //  0024  SETIDX	R1	R5	R6
-          0x04140B03,  //  0025  SUB	R5	R5	K3
-          0x7001FFF4,  //  0026  JMP		#001C
-          0x98040A04,  //  0027  SETIDX	R1	R5	R4
-          0x7001FFEE,  //  0028  JMP		#0018
-          0x58080002,  //  0029  LDCONST	R2	K2
-          0xAC080200,  //  002A  CATCH	R2	1	0
-          0xB0080000,  //  002B  RAISE	2	R0	R0
-          0x80040200,  //  002C  RET	1	R1
-        })
-      ),
-    }),
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(endpoint),
     /* K1   */  be_nested_str_weak(cluster),
     /* K2   */  be_nested_str_weak(attribute),
-    /* K3   */  be_nested_str_weak(plugins),
-    /* K4   */  be_nested_str_weak(get_endpoint),
-    /* K5   */  be_nested_str_weak(contains),
-    /* K6   */  be_nested_str_weak(get_cluster_list),
-    /* K7   */  be_nested_str_weak(get_attribute_list),
-    /* K8   */  be_nested_str_weak(push),
-    /* K9   */  be_nested_str_weak(stop_iteration),
-    /* K10  */  be_nested_str_weak(status),
-    /* K11  */  be_nested_str_weak(matter),
-    /* K12  */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
-    /* K13  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(PathGenerator),
+    /* K5   */  be_nested_str_weak(start),
+    /* K6   */  be_nested_str_weak(next),
+    /* K7   */  be_nested_str_weak(get_pi),
+    /* K8   */  be_nested_str_weak(endpoint_found),
+    /* K9   */  be_nested_str_weak(status),
+    /* K10  */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+    /* K11  */  be_nested_str_weak(cluster_found),
+    /* K12  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
+    /* K13  */  be_nested_str_weak(attribute_found),
     /* K14  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
     /* K15  */  be_nested_str_weak(UNREPORTABLE_ATTRIBUTE),
     }),
     be_str_weak(process_attribute_expansion),
     &be_const_str_solidified,
-    ( &(const binstruction[203]) {  /* code */
-      0x840C0000,  //  0000  CLOSURE	R3	P0
-      0x88100300,  //  0001  GETMBR	R4	R1	K0
-      0x88140301,  //  0002  GETMBR	R5	R1	K1
-      0x88180302,  //  0003  GETMBR	R6	R1	K2
+    ( &(const binstruction[73]) {  /* code */
+      0x880C0300,  //  0000  GETMBR	R3	R1	K0
+      0x88100301,  //  0001  GETMBR	R4	R1	K1
+      0x88140302,  //  0002  GETMBR	R5	R1	K2
+      0x50180000,  //  0003  LDBOOL	R6	0	0
       0x501C0000,  //  0004  LDBOOL	R7	0	0
       0x50200000,  //  0005  LDBOOL	R8	0	0
-      0x50240000,  //  0006  LDBOOL	R9	0	0
-      0x88280300,  //  0007  GETMBR	R10	R1	K0
-      0x4C2C0000,  //  0008  LDNIL	R11
-      0x2028140B,  //  0009  NE	R10	R10	R11
-      0x782A0007,  //  000A  JMPF	R10	#0013
-      0x88280301,  //  000B  GETMBR	R10	R1	K1
-      0x4C2C0000,  //  000C  LDNIL	R11
-      0x2028140B,  //  000D  NE	R10	R10	R11
-      0x782A0003,  //  000E  JMPF	R10	#0013
-      0x88280302,  //  000F  GETMBR	R10	R1	K2
-      0x4C2C0000,  //  0010  LDNIL	R11
-      0x2028140B,  //  0011  NE	R10	R10	R11
-      0x742A0000,  //  0012  JMPT	R10	#0014
-      0x50280001,  //  0013  LDBOOL	R10	0	1
-      0x50280200,  //  0014  LDBOOL	R10	1	0
-      0x602C0013,  //  0015  GETGBL	R11	G19
-      0x7C2C0000,  //  0016  CALL	R11	0
-      0x60300010,  //  0017  GETGBL	R12	G16
-      0x88340103,  //  0018  GETMBR	R13	R0	K3
-      0x7C300200,  //  0019  CALL	R12	1
-      0xA8020053,  //  001A  EXBLK	0	#006F
-      0x5C341800,  //  001B  MOVE	R13	R12
-      0x7C340000,  //  001C  CALL	R13	0
-      0x8C381B04,  //  001D  GETMET	R14	R13	K4
-      0x7C380200,  //  001E  CALL	R14	1
-      0x4C3C0000,  //  001F  LDNIL	R15
-      0x203C080F,  //  0020  NE	R15	R4	R15
-      0x783E0002,  //  0021  JMPF	R15	#0025
-      0x203C1C04,  //  0022  NE	R15	R14	R4
-      0x783E0000,  //  0023  JMPF	R15	#0025
-      0x7001FFF5,  //  0024  JMP		#001B
-      0x8C3C1705,  //  0025  GETMET	R15	R11	K5
-      0x5C441C00,  //  0026  MOVE	R17	R14
-      0x7C3C0400,  //  0027  CALL	R15	2
-      0x743E0002,  //  0028  JMPT	R15	#002C
-      0x603C0013,  //  0029  GETGBL	R15	G19
-      0x7C3C0000,  //  002A  CALL	R15	0
-      0x982C1C0F,  //  002B  SETIDX	R11	R14	R15
-      0x501C0200,  //  002C  LDBOOL	R7	1	0
-      0x8C3C1B06,  //  002D  GETMET	R15	R13	K6
-      0x7C3C0200,  //  002E  CALL	R15	1
-      0x60400010,  //  002F  GETGBL	R16	G16
-      0x5C441E00,  //  0030  MOVE	R17	R15
-      0x7C400200,  //  0031  CALL	R16	1
-      0xA8020037,  //  0032  EXBLK	0	#006B
-      0x5C442000,  //  0033  MOVE	R17	R16
-      0x7C440000,  //  0034  CALL	R17	0
-      0x4C480000,  //  0035  LDNIL	R18
-      0x20480A12,  //  0036  NE	R18	R5	R18
-      0x784A0002,  //  0037  JMPF	R18	#003B
-      0x20482205,  //  0038  NE	R18	R17	R5
-      0x784A0000,  //  0039  JMPF	R18	#003B
-      0x7001FFF7,  //  003A  JMP		#0033
-      0x9448160E,  //  003B  GETIDX	R18	R11	R14
-      0x8C482505,  //  003C  GETMET	R18	R18	K5
-      0x5C502200,  //  003D  MOVE	R20	R17
-      0x7C480400,  //  003E  CALL	R18	2
-      0x744A0003,  //  003F  JMPT	R18	#0044
-      0x9448160E,  //  0040  GETIDX	R18	R11	R14
-      0x604C0013,  //  0041  GETGBL	R19	G19
-      0x7C4C0000,  //  0042  CALL	R19	0
-      0x98482213,  //  0043  SETIDX	R18	R17	R19
-      0x50200200,  //  0044  LDBOOL	R8	1	0
-      0x8C481B07,  //  0045  GETMET	R18	R13	K7
-      0x5C502200,  //  0046  MOVE	R20	R17
-      0x7C480400,  //  0047  CALL	R18	2
-      0x604C0010,  //  0048  GETGBL	R19	G16
-      0x5C502400,  //  0049  MOVE	R20	R18
-      0x7C4C0200,  //  004A  CALL	R19	1
-      0xA802001A,  //  004B  EXBLK	0	#0067
-      0x5C502600,  //  004C  MOVE	R20	R19
-      0x7C500000,  //  004D  CALL	R20	0
-      0x4C540000,  //  004E  LDNIL	R21
-      0x20540C15,  //  004F  NE	R21	R6	R21
-      0x78560002,  //  0050  JMPF	R21	#0054
-      0x20542806,  //  0051  NE	R21	R20	R6
-      0x78560000,  //  0052  JMPF	R21	#0054
-      0x7001FFF7,  //  0053  JMP		#004C
-      0x9454160E,  //  0054  GETIDX	R21	R11	R14
-      0x94542A11,  //  0055  GETIDX	R21	R21	R17
-      0x8C542B05,  //  0056  GETMET	R21	R21	K5
-      0x5C5C2800,  //  0057  MOVE	R23	R20
-      0x7C540400,  //  0058  CALL	R21	2
-      0x74560004,  //  0059  JMPT	R21	#005F
-      0x9454160E,  //  005A  GETIDX	R21	R11	R14
-      0x94542A11,  //  005B  GETIDX	R21	R21	R17
-      0x60580012,  //  005C  GETGBL	R22	G18
-      0x7C580000,  //  005D  CALL	R22	0
-      0x98542816,  //  005E  SETIDX	R21	R20	R22
-      0x50240200,  //  005F  LDBOOL	R9	1	0
-      0x9454160E,  //  0060  GETIDX	R21	R11	R14
-      0x94542A11,  //  0061  GETIDX	R21	R21	R17
-      0x94542A14,  //  0062  GETIDX	R21	R21	R20
-      0x8C542B08,  //  0063  GETMET	R21	R21	K8
-      0x5C5C1A00,  //  0064  MOVE	R23	R13
-      0x7C540400,  //  0065  CALL	R21	2
-      0x7001FFE4,  //  0066  JMP		#004C
-      0x584C0009,  //  0067  LDCONST	R19	K9
-      0xAC4C0200,  //  0068  CATCH	R19	1	0
-      0xB0080000,  //  0069  RAISE	2	R0	R0
-      0x7001FFC7,  //  006A  JMP		#0033
-      0x58400009,  //  006B  LDCONST	R16	K9
-      0xAC400200,  //  006C  CATCH	R16	1	0
-      0xB0080000,  //  006D  RAISE	2	R0	R0
-      0x7001FFAB,  //  006E  JMP		#001B
-      0x58300009,  //  006F  LDCONST	R12	K9
-      0xAC300200,  //  0070  CATCH	R12	1	0
-      0xB0080000,  //  0071  RAISE	2	R0	R0
-      0x60300010,  //  0072  GETGBL	R12	G16
-      0x5C340600,  //  0073  MOVE	R13	R3
-      0x5C381600,  //  0074  MOVE	R14	R11
-      0x7C340200,  //  0075  CALL	R13	1
-      0x7C300200,  //  0076  CALL	R12	1
-      0xA8020033,  //  0077  EXBLK	0	#00AC
-      0x5C341800,  //  0078  MOVE	R13	R12
-      0x7C340000,  //  0079  CALL	R13	0
-      0x60380010,  //  007A  GETGBL	R14	G16
-      0x5C3C0600,  //  007B  MOVE	R15	R3
-      0x9440160D,  //  007C  GETIDX	R16	R11	R13
-      0x7C3C0200,  //  007D  CALL	R15	1
-      0x7C380200,  //  007E  CALL	R14	1
-      0xA8020027,  //  007F  EXBLK	0	#00A8
-      0x5C3C1C00,  //  0080  MOVE	R15	R14
-      0x7C3C0000,  //  0081  CALL	R15	0
-      0x60400010,  //  0082  GETGBL	R16	G16
-      0x5C440600,  //  0083  MOVE	R17	R3
-      0x9448160D,  //  0084  GETIDX	R18	R11	R13
-      0x9448240F,  //  0085  GETIDX	R18	R18	R15
-      0x7C440200,  //  0086  CALL	R17	1
-      0x7C400200,  //  0087  CALL	R16	1
-      0xA802001A,  //  0088  EXBLK	0	#00A4
-      0x5C442000,  //  0089  MOVE	R17	R16
-      0x7C440000,  //  008A  CALL	R17	0
-      0x60480010,  //  008B  GETGBL	R18	G16
-      0x944C160D,  //  008C  GETIDX	R19	R11	R13
-      0x944C260F,  //  008D  GETIDX	R19	R19	R15
-      0x944C2611,  //  008E  GETIDX	R19	R19	R17
-      0x7C480200,  //  008F  CALL	R18	1
-      0xA802000E,  //  0090  EXBLK	0	#00A0
-      0x5C4C2400,  //  0091  MOVE	R19	R18
-      0x7C4C0000,  //  0092  CALL	R19	0
-      0x9006000D,  //  0093  SETMBR	R1	K0	R13
-      0x9006020F,  //  0094  SETMBR	R1	K1	R15
-      0x90060411,  //  0095  SETMBR	R1	K2	R17
-      0x5C500400,  //  0096  MOVE	R20	R2
-      0x5C542600,  //  0097  MOVE	R21	R19
-      0x5C580200,  //  0098  MOVE	R22	R1
-      0x5C5C1400,  //  0099  MOVE	R23	R10
-      0x7C500600,  //  009A  CALL	R20	3
-      0x782A0002,  //  009B  JMPF	R10	#009F
-      0x78520001,  //  009C  JMPF	R20	#009F
-      0xA8040004,  //  009D  EXBLK	1	4
-      0x80002A00,  //  009E  RET	0
-      0x7001FFF0,  //  009F  JMP		#0091
-      0x58480009,  //  00A0  LDCONST	R18	K9
-      0xAC480200,  //  00A1  CATCH	R18	1	0
-      0xB0080000,  //  00A2  RAISE	2	R0	R0
-      0x7001FFE4,  //  00A3  JMP		#0089
-      0x58400009,  //  00A4  LDCONST	R16	K9
-      0xAC400200,  //  00A5  CATCH	R16	1	0
-      0xB0080000,  //  00A6  RAISE	2	R0	R0
-      0x7001FFD7,  //  00A7  JMP		#0080
-      0x58380009,  //  00A8  LDCONST	R14	K9
-      0xAC380200,  //  00A9  CATCH	R14	1	0
-      0xB0080000,  //  00AA  RAISE	2	R0	R0
-      0x7001FFCB,  //  00AB  JMP		#0078
-      0x58300009,  //  00AC  LDCONST	R12	K9
-      0xAC300200,  //  00AD  CATCH	R12	1	0
-      0xB0080000,  //  00AE  RAISE	2	R0	R0
-      0x782A0019,  //  00AF  JMPF	R10	#00CA
-      0x5C300E00,  //  00B0  MOVE	R12	R7
-      0x74320003,  //  00B1  JMPT	R12	#00B6
-      0xB8321600,  //  00B2  GETNGBL	R12	K11
-      0x8830190C,  //  00B3  GETMBR	R12	R12	K12
-      0x9006140C,  //  00B4  SETMBR	R1	K10	R12
-      0x7002000E,  //  00B5  JMP		#00C5
-      0x5C301000,  //  00B6  MOVE	R12	R8
-      0x74320003,  //  00B7  JMPT	R12	#00BC
-      0xB8321600,  //  00B8  GETNGBL	R12	K11
-      0x8830190D,  //  00B9  GETMBR	R12	R12	K13
-      0x9006140C,  //  00BA  SETMBR	R1	K10	R12
-      0x70020008,  //  00BB  JMP		#00C5
-      0x5C301200,  //  00BC  MOVE	R12	R9
-      0x74320003,  //  00BD  JMPT	R12	#00C2
-      0xB8321600,  //  00BE  GETNGBL	R12	K11
-      0x8830190E,  //  00BF  GETMBR	R12	R12	K14
-      0x9006140C,  //  00C0  SETMBR	R1	K10	R12
-      0x70020002,  //  00C1  JMP		#00C5
-      0xB8321600,  //  00C2  GETNGBL	R12	K11
-      0x8830190F,  //  00C3  GETMBR	R12	R12	K15
-      0x9006140C,  //  00C4  SETMBR	R1	K10	R12
-      0x5C300400,  //  00C5  MOVE	R12	R2
-      0x4C340000,  //  00C6  LDNIL	R13
-      0x5C380200,  //  00C7  MOVE	R14	R1
-      0x503C0200,  //  00C8  LDBOOL	R15	1	0
-      0x7C300600,  //  00C9  CALL	R12	3
-      0x80000000,  //  00CA  RET	0
+      0x88240300,  //  0006  GETMBR	R9	R1	K0
+      0x4C280000,  //  0007  LDNIL	R10
+      0x2024120A,  //  0008  NE	R9	R9	R10
+      0x78260007,  //  0009  JMPF	R9	#0012
+      0x88240301,  //  000A  GETMBR	R9	R1	K1
+      0x4C280000,  //  000B  LDNIL	R10
+      0x2024120A,  //  000C  NE	R9	R9	R10
+      0x78260003,  //  000D  JMPF	R9	#0012
+      0x88240302,  //  000E  GETMBR	R9	R1	K2
+      0x4C280000,  //  000F  LDNIL	R10
+      0x2024120A,  //  0010  NE	R9	R9	R10
+      0x74260000,  //  0011  JMPT	R9	#0013
+      0x50240001,  //  0012  LDBOOL	R9	0	1
+      0x50240200,  //  0013  LDBOOL	R9	1	0
+      0xB82A0600,  //  0014  GETNGBL	R10	K3
+      0x8C281504,  //  0015  GETMET	R10	R10	K4
+      0x5C300000,  //  0016  MOVE	R12	R0
+      0x7C280400,  //  0017  CALL	R10	2
+      0x8C2C1505,  //  0018  GETMET	R11	R10	K5
+      0x5C340200,  //  0019  MOVE	R13	R1
+      0x4C380000,  //  001A  LDNIL	R14
+      0x7C2C0600,  //  001B  CALL	R11	3
+      0x4C2C0000,  //  001C  LDNIL	R11
+      0x8C301506,  //  001D  GETMET	R12	R10	K6
+      0x7C300200,  //  001E  CALL	R12	1
+      0x5C2C1800,  //  001F  MOVE	R11	R12
+      0x4C340000,  //  0020  LDNIL	R13
+      0x2030180D,  //  0021  NE	R12	R12	R13
+      0x78320009,  //  0022  JMPF	R12	#002D
+      0x5C300400,  //  0023  MOVE	R12	R2
+      0x8C341507,  //  0024  GETMET	R13	R10	K7
+      0x7C340200,  //  0025  CALL	R13	1
+      0x5C381600,  //  0026  MOVE	R14	R11
+      0x5C3C1200,  //  0027  MOVE	R15	R9
+      0x7C300600,  //  0028  CALL	R12	3
+      0x78260001,  //  0029  JMPF	R9	#002C
+      0x78320000,  //  002A  JMPF	R12	#002C
+      0x80001A00,  //  002B  RET	0
+      0x7001FFEF,  //  002C  JMP		#001D
+      0x78260019,  //  002D  JMPF	R9	#0048
+      0x88301508,  //  002E  GETMBR	R12	R10	K8
+      0x74320003,  //  002F  JMPT	R12	#0034
+      0xB8320600,  //  0030  GETNGBL	R12	K3
+      0x8830190A,  //  0031  GETMBR	R12	R12	K10
+      0x9006120C,  //  0032  SETMBR	R1	K9	R12
+      0x7002000E,  //  0033  JMP		#0043
+      0x8830150B,  //  0034  GETMBR	R12	R10	K11
+      0x74320003,  //  0035  JMPT	R12	#003A
+      0xB8320600,  //  0036  GETNGBL	R12	K3
+      0x8830190C,  //  0037  GETMBR	R12	R12	K12
+      0x9006120C,  //  0038  SETMBR	R1	K9	R12
+      0x70020008,  //  0039  JMP		#0043
+      0x8830150D,  //  003A  GETMBR	R12	R10	K13
+      0x74320003,  //  003B  JMPT	R12	#0040
+      0xB8320600,  //  003C  GETNGBL	R12	K3
+      0x8830190E,  //  003D  GETMBR	R12	R12	K14
+      0x9006120C,  //  003E  SETMBR	R1	K9	R12
+      0x70020002,  //  003F  JMP		#0043
+      0xB8320600,  //  0040  GETNGBL	R12	K3
+      0x8830190F,  //  0041  GETMBR	R12	R12	K15
+      0x9006120C,  //  0042  SETMBR	R1	K9	R12
+      0x5C300400,  //  0043  MOVE	R12	R2
+      0x4C340000,  //  0044  LDNIL	R13
+      0x5C380200,  //  0045  MOVE	R14	R1
+      0x503C0200,  //  0046  LDBOOL	R15	1	0
+      0x7C300600,  //  0047  CALL	R12	3
+      0x80000000,  //  0048  RET	0
     })
   )
 );
@@ -6407,40 +6210,40 @@ be_local_class(Matter_Device,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_weak(aggregator, -1), be_const_class(be_class_Matter_Plugin_Aggregator) },
         { be_const_key_weak(light2, -1), be_const_class(be_class_Matter_Plugin_Light2) },
-        { be_const_key_weak(v_light1, 26), be_const_class(be_class_Matter_Plugin_Virt_Light1) },
+        { be_const_key_weak(v_light1, 17), be_const_class(be_class_Matter_Plugin_Virt_Light1) },
         { be_const_key_weak(v_light3, -1), be_const_class(be_class_Matter_Plugin_Virt_Light3) },
         { be_const_key_weak(v_flow, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Flow) },
         { be_const_key_weak(shutter, 14), be_const_class(be_class_Matter_Plugin_Shutter) },
         { be_const_key_weak(v_pressure, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Pressure) },
         { be_const_key_weak(v_temp, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Temp) },
-        { be_const_key_weak(http_light2, 31), be_const_class(be_class_Matter_Plugin_Bridge_Light2) },
+        { be_const_key_weak(http_contact, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Contact) },
         { be_const_key_weak(http_humidity, 22), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Humidity) },
         { be_const_key_weak(pressure, 13), be_const_class(be_class_Matter_Plugin_Sensor_Pressure) },
-        { be_const_key_weak(http_pressure, 29), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Pressure) },
+        { be_const_key_weak(http_pressure, 8), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Pressure) },
         { be_const_key_weak(illuminance, -1), be_const_class(be_class_Matter_Plugin_Sensor_Illuminance) },
         { be_const_key_weak(light1, -1), be_const_class(be_class_Matter_Plugin_Light1) },
         { be_const_key_weak(http_light1, -1), be_const_class(be_class_Matter_Plugin_Bridge_Light1) },
         { be_const_key_weak(light3, 36), be_const_class(be_class_Matter_Plugin_Light3) },
-        { be_const_key_weak(http_occupancy, 32), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Occupancy) },
-        { be_const_key_weak(onoff, -1), be_const_class(be_class_Matter_Plugin_Sensor_OnOff) },
+        { be_const_key_weak(http_occupancy, 31), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Occupancy) },
+        { be_const_key_weak(v_relay, -1), be_const_class(be_class_Matter_Plugin_Virt_OnOff) },
         { be_const_key_weak(contact, -1), be_const_class(be_class_Matter_Plugin_Sensor_Contact) },
-        { be_const_key_weak(http_temperature, 8), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Temp) },
+        { be_const_key_weak(http_temperature, 26), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Temp) },
         { be_const_key_weak(v_occupancy, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Occupancy) },
         { be_const_key_weak(occupancy, -1), be_const_class(be_class_Matter_Plugin_Sensor_Occupancy) },
-        { be_const_key_weak(temperature, 35), be_const_class(be_class_Matter_Plugin_Sensor_Temp) },
+        { be_const_key_weak(temperature, 32), be_const_class(be_class_Matter_Plugin_Sensor_Temp) },
         { be_const_key_weak(flow, 4), be_const_class(be_class_Matter_Plugin_Sensor_Flow) },
         { be_const_key_weak(v_contact, 6), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Contact) },
         { be_const_key_weak(http_relay, 3), be_const_class(be_class_Matter_Plugin_Bridge_OnOff) },
-        { be_const_key_weak(v_relay, -1), be_const_class(be_class_Matter_Plugin_Virt_OnOff) },
+        { be_const_key_weak(http_light2, 29), be_const_class(be_class_Matter_Plugin_Bridge_Light2) },
         { be_const_key_weak(root, -1), be_const_class(be_class_Matter_Plugin_Root) },
         { be_const_key_weak(http_light3, 9), be_const_class(be_class_Matter_Plugin_Bridge_Light3) },
-        { be_const_key_weak(http_contact, -1), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Contact) },
-        { be_const_key_weak(http_illuminance, 17), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Illuminance) },
         { be_const_key_weak(light0, -1), be_const_class(be_class_Matter_Plugin_Light0) },
+        { be_const_key_weak(http_illuminance, 35), be_const_class(be_class_Matter_Plugin_Bridge_Sensor_Illuminance) },
         { be_const_key_weak(v_light2, -1), be_const_class(be_class_Matter_Plugin_Virt_Light2) },
+        { be_const_key_weak(v_illuminance, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Illuminance) },
         { be_const_key_weak(v_humidity, 15), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Humidity) },
         { be_const_key_weak(v_light0, -1), be_const_class(be_class_Matter_Plugin_Virt_Light0) },
-        { be_const_key_weak(v_illuminance, -1), be_const_class(be_class_Matter_Plugin_Virt_Sensor_Illuminance) },
+        { be_const_key_weak(onoff, -1), be_const_class(be_class_Matter_Plugin_Sensor_OnOff) },
         { be_const_key_weak(relay, -1), be_const_class(be_class_Matter_Plugin_OnOff) },
         { be_const_key_weak(http_light0, -1), be_const_class(be_class_Matter_Plugin_Bridge_Light0) },
         { be_const_key_weak(shutter_X2Btilt, -1), be_const_class(be_class_Matter_Plugin_ShutterTilt) },


### PR DESCRIPTION
## Description:

Matter, dramatically reduce the memory usage when reading with wildcards like `>Subscribe ( 30976) [**]****/****` or `>Read_Attr ( 30976) [**]****/!****`.

Previously, the complete list of concrete path (all combinations of valid endpoint/cluster/attribute) were generated upfront in memory, then consumed. However this could use up to 30KB of memory.

Now, we use a generator pattern. An object `matter.PathGenerator` is used and generates the sequence of endpoint/cluster/attribute on the fly (pull mode), with very little memory usage.

This saves ~30KB of memory during heavy operations.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
