### PR TITLE
Berry add explicit error log when memory allocation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - QMC5883l check for overflow and scale reading (#20643)
 - TasMesh support for LWT messages (#20392)
 - Show calculated heat index if temperature and humidity is available with ``#define USE_HEAT_INDEX`` (#4771)
+- Berry add explicit error log when memory allocation fails
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_exec.c
+++ b/lib/libesp32/berry/src/be_exec.c
@@ -79,6 +79,10 @@ void be_throw(bvm *vm, int errorcode)
 #if BE_USE_PERF_COUNTERS
     vm->counter_exc++;
 #endif
+    /* if BE_MALLOC_FAIL then call */
+    if (errorcode == BE_MALLOC_FAIL) {
+        if (vm->obshook != NULL) (*vm->obshook)(vm, BE_OBS_MALLOC_FAIL, vm->gc.usage);
+    }
     if (vm->errjmp) {
         vm->errjmp->status = errorcode;
         exec_throw(vm->errjmp);

--- a/lib/libesp32/berry/src/berry.h
+++ b/lib/libesp32/berry/src/berry.h
@@ -676,6 +676,7 @@ enum beobshookevents {
     BE_OBS_GC_END,              /**< end of GC, arg = allocated size */
     BE_OBS_VM_HEARTBEAT,        /**< VM heartbeat called every million instructions */
     BE_OBS_STACK_RESIZE_START,  /**< Berry stack resized */
+    BE_OBS_MALLOC_FAIL,         /**< Memory allocation failed */
 };
 
 typedef int (*bctypefunc)(bvm*, const void*); /**< bctypefunc */

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -298,6 +298,12 @@ void BerryObservability(bvm *vm, int event...) {
         }
       }
       break;
+    case BE_OBS_MALLOC_FAIL:
+      {
+        int32_t vm_usage2 = va_arg(param, int32_t);
+        AddLog(LOG_LEVEL_ERROR, D_LOG_BERRY "*** MEMORY ALLOCATION FAILED *** usage %i bytes", vm_usage2);
+      }
+      break;
     default:
       break;
   }


### PR DESCRIPTION
## Description:

Berry, output an explicit error log line when Berry fails to allocate memory.

```
21:06:04.882 BRY: *** MEMORY ALLOCATION FAILED *** usage 104809 bytes
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
