### PR TITLE
Fix Berry Memory leak in `import re`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 PWM activity on unconfigured PWM GPIOs (#20732)
 - Shutter inverted using internal commands (#20752)
 - HASPmota PSRAM memory leak (#20818)
+- Berry Memory leak in `import re`
 
 ### Removed
 

--- a/lib/libesp32/berry/default/be_re_lib.c
+++ b/lib/libesp32/berry/default/be_re_lib.c
@@ -46,6 +46,9 @@ int be_re_compile(bvm *vm) {
     }
 
     ByteProg *code = be_os_malloc(sizeof(ByteProg) + sz);
+    if (code == NULL) {
+      be_throw(vm, BE_MALLOC_FAIL);   /* lack of heap space */
+    }
     int ret = re1_5_compilecode(code, regex_str);
     if (ret != 0) {
       be_raise(vm, "internal_error", "error in regex");
@@ -113,11 +116,16 @@ int be_re_match_search(bvm *vm, bbool is_anchored, bbool size_only) {
     }
 
     ByteProg *code = be_os_malloc(sizeof(ByteProg) + sz);
+    if (code == NULL) {
+      be_throw(vm, BE_MALLOC_FAIL);   /* lack of heap space */
+    }
     int ret = re1_5_compilecode(code, regex_str);
     if (ret != 0) {
+      be_os_free(code);
       be_raise(vm, "internal_error", "error in regex");
     }
     be_re_match_search_run(vm, code, hay, is_anchored, size_only);
+    be_os_free(code);
     be_return(vm);
   }
   be_raise(vm, "type_error", NULL);
@@ -138,8 +146,12 @@ int be_re_match_search_all(bvm *vm, bbool is_anchored) {
     }
 
     ByteProg *code = be_os_malloc(sizeof(ByteProg) + sz);
+    if (code == NULL) {
+      be_throw(vm, BE_MALLOC_FAIL);   /* lack of heap space */
+    }
     int ret = re1_5_compilecode(code, regex_str);
     if (ret != 0) {
+      be_os_free(code);
       be_raise(vm, "internal_error", "error in regex");
     }
 
@@ -152,6 +164,7 @@ int be_re_match_search_all(bvm *vm, bbool is_anchored) {
       be_pop(vm, 1);
     }
     be_pop(vm, 1);
+    be_os_free(code);
     be_return(vm);
   }
   be_raise(vm, "type_error", NULL);
@@ -328,11 +341,17 @@ int be_re_split(bvm *vm) {
     }
 
     ByteProg *code = be_os_malloc(sizeof(ByteProg) + sz);
+    if (code == NULL) {
+      be_throw(vm, BE_MALLOC_FAIL);   /* lack of heap space */
+    }
     int ret = re1_5_compilecode(code, regex_str);
     if (ret != 0) {
+      be_os_free(code);
       be_raise(vm, "internal_error", "error in regex");
     }
-    return re_pattern_split_run(vm, code, hay, split_limit);
+    ret = re_pattern_split_run(vm, code, hay, split_limit);
+    be_os_free(code);
+    return ret;
   }
   be_raise(vm, "type_error", NULL);
 }


### PR DESCRIPTION
## Description:

Implement proper memory management in `import re` for `re.search()` and `re.match()`. Pre-compiled pattern have no memory leak.

Add exception if memory allocation fails (instead of crashing)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
