### PR TITLE
Prevent shutter MQTT broadcast with activated ShutterLock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - HASPmota fix and improve demo with pixel-perfect fonts (#20734)
 - NeoPool webUI pH alarms (4 & 5) completed (#20743)
 - Matter reduce memory usage when reading with wildcards (#20809)
+- Prevent shutter MQTT broadcast with activated ShutterLock
 
 ### Fixed
 - ESP32 PWM activity on unconfigured PWM GPIOs (#20732)

--- a/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
@@ -294,7 +294,7 @@ bool ShutterButtonHandlerMulti(void)
 
       // reset button to default
       Button.press_counter[button_index] = 0;
-        
+
       CmndShutterPosition();
     }
 
@@ -303,7 +303,7 @@ bool ShutterButtonHandlerMulti(void)
       char scommand[CMDSZ];
       char stopic[TOPSZ];
       for (uint32_t i = 0; i < MAX_SHUTTERS_ESP32; i++) {
-        if ((i==shutter_index) || (ShutterSettings.shutter_button[button_index].mqtt_all)) {
+        if (((i==shutter_index) || (ShutterSettings.shutter_button[button_index].mqtt_all))  && 0 == (ShutterSettings.shutter_options[i] & 2) ) {
           snprintf_P(scommand, sizeof(scommand),PSTR("ShutterPosition%d"), i+1);
           GetGroupTopic_P(stopic, scommand, SET_MQTT_GRP_TOPIC);
           Response_P("%d", position);
@@ -318,7 +318,7 @@ bool ShutterButtonHandlerMulti(void)
   ResponseAppend_P(JSON_SHUTTER_BUTTON, shutter_index+1, Shutter[shutter_index].button_simu_pressed ? 0 : button_index+1, button_press_counter);
   ResponseJsonEnd();
   MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_STAT, PSTR(D_PRFX_SHUTTER));
-  
+
   // reset simu pressed record
   Shutter[shutter_index].button_simu_pressed = 0;
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
@@ -1092,7 +1092,7 @@ bool ShutterButtonHandler(void)
                 char scommand[CMDSZ];
                 char stopic[TOPSZ];
                 for (uint32_t i = 0; i < MAX_SHUTTERS; i++) {
-                  if ((i==shutter_index) || (Settings->shutter_button[button_index] & (0x01<<30))) {
+                  if ( ((i==shutter_index) || (Settings->shutter_button[button_index] & (0x01<<30))) && 0 == (Settings->shutter_options[i] & 2) ) {
                     snprintf_P(scommand, sizeof(scommand),PSTR("ShutterPosition%d"), i+1);
                     GetGroupTopic_P(stopic, scommand, SET_MQTT_GRP_TOPIC);
                     Response_P("%d", position);


### PR DESCRIPTION
## Description:

`ShutterLock<x>` previously locks button press actions defined by `ShutterButton<x>` but not the also possible defined MQTT broadcasts. `ShutterLock<x>` should also lock these broadcast if enabled.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
