### PR TITLE
IR support data larger than 64 bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Show calculated heat index if temperature and humidity is available with ``#define USE_HEAT_INDEX`` (#4771)
 - Berry add explicit error log when memory allocation fails (#20807)
 - Support for AMS5915/AMS6915 temperature and pressure sensors (#20814)
+- IR support data larger than 64 bits
 
 ### Breaking Changed
 

--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -537,6 +537,7 @@
 // Commands xdrv_05_irremote.ino
 #define D_CMND_IRSEND "IRSend"
   #define D_JSON_INVALID_JSON "Invalid JSON"
+  #define D_JSON_INVALID_HEXDATA "Invalid Hex data"
   #define D_JSON_INVALID_RAWDATA "Invalid RawData"
   #define D_JSON_NO_BUFFER_SPACE "No buffer space"
   #define D_JSON_PROTOCOL_NOT_SUPPORTED "Protocol not supported"

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -608,6 +608,34 @@ String HexToString(uint8_t* data, uint32_t length) {
   return result;
 }
 
+// Converts a Hex string (case insensitive) into an array of bytes
+// Returns the number of bytes in the array, or -1 if an error occured
+// The `out` buffer must be at least half the size of hex string
+int32_t HexToBytes(const char* hex, uint8_t* out, size_t* outLen) {
+  size_t len = strlen_P(hex);
+  *outLen = 0;
+  if (len % 2 != 0) {
+    return -1;
+  }
+
+  size_t outLength = len / 2;
+  
+  for(size_t i = 0; i < outLength; i++) {
+    char byte[3];
+    byte[0] = hex[i*2];
+    byte[1] = hex[i*2 + 1];
+    byte[2] = '\0';
+    
+    char* endPtr;
+    out[i] = strtoul(byte, &endPtr, 16);
+    
+    if(*endPtr != '\0') {
+      return -1;
+    }
+  }
+  return outLength;
+}
+
 String UrlEncode(const String& text) {
   const char hex[] = "0123456789ABCDEF";
 


### PR DESCRIPTION
## Description:

Allow `"Data"` or `"DataLSB"` to be larger than 64 bits.

Example:
`IRSend {"Protocol":"CARRIER_AC84","Bits":84,"Data":0x0C04233200120012001204}`

**Related issue (if applicable):** fixes #20815

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
