### PR TITLE
Berry add `path.rename()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [13.4.0.2]
 ### Added
+- Berry add `path.rename()`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/include/be_port.h
+++ b/lib/libesp32/berry_tasmota/include/be_port.h
@@ -8,3 +8,4 @@
 #define MPATH_EXISTS 4
 #define MPATH_MODIFIED 5
 #define MPATH_REMOVE 6
+#define MPATH_RENAME 7

--- a/lib/libesp32/berry_tasmota/src/be_path_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_path_tasmota_lib.c
@@ -36,6 +36,9 @@ static int m_path_mkdir(bvm *vm) {
 static int m_path_rmdir(bvm *vm) {
     return _m_path_action(vm, MPATH_RMDIR);
 }
+static int m_path_rename(bvm *vm) {
+    return _m_path_action(vm, MPATH_RENAME);
+}
 static int m_path_exists(bvm *vm) {
     return _m_path_action(vm, MPATH_EXISTS);
 }
@@ -69,6 +72,7 @@ module path (scope: global, file: tasmota_path) {
     format, func(m_path_format)
     mkdir, func(m_path_mkdir)
     rmdir, func(m_path_rmdir)
+    rename, func(m_path_rename)
 }
 @const_object_info_end */
 #include "be_fixed_tasmota_path.h"

--- a/lib/libesp32/berry_tasmota/src/be_port.cpp
+++ b/lib/libesp32/berry_tasmota/src/be_port.cpp
@@ -119,7 +119,8 @@ extern "C" {
                 break;
         }
 
-        if (be_top(vm) >= 1 && be_isstring(vm, 1)) {
+        int argc = be_top(vm);
+        if (argc >= 1 && be_isstring(vm, 1)) {
             const char *path = be_tostring(vm, 1);
             if (path != nullptr) {
                 switch (action){
@@ -134,6 +135,16 @@ extern "C" {
                         break;
                     case MPATH_MKDIR:
                         res = zip_ufsp.mkdir(path);
+                        break;
+                    case MPATH_RENAME:
+                        {
+                            if (argc >= 2 && be_isstring(vm, 2)) {
+                                const char *path2 = be_tostring(vm, 2);
+                                res = zip_ufsp.rename(path, path2);
+                            } else {
+                                res = -1;
+                            }
+                        }
                         break;
                     case MPATH_LISTDIR:
                         be_newobject(vm, "list"); // add our list object and fall through


### PR DESCRIPTION
## Description:

Add ability to rename a file:
- `path.rename(from:string, to:string) -> bool or nil`, filename must start with '/', returns `true` if successful, `false` if not found, `nil` if bad arguments.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
