### PR TITLE
Matter save fabrics more robust

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
@@ -35,7 +35,8 @@ class Matter_Session_Store
   var device                      # device root object
   var sessions
   var fabrics                     # list of provisioned fabrics
-  static var _FABRICS  = "_matter_fabrics.json"
+  static var _FABRICS  = "/_matter_fabrics.json"
+  static var _FABRICS_TEMP  = "/_matter_fabrics.tmp"   # temporary saved file before renaming to _FABRICS
 
   #############################################################
   def init(device)
@@ -318,12 +319,13 @@ class Matter_Session_Store
   #############################################################
   def save_fabrics()
     import json
+    import path
     try
       self.remove_expired()      # clean before saving
       var sessions_saved = 0
       var fabrics_saved = 0
 
-      var f = open(self._FABRICS, "w")
+      var f = open(self._FABRICS_TEMP, "w")
 
       f.write("[")
       for fab : self.fabrics.persistables()
@@ -337,8 +339,14 @@ class Matter_Session_Store
       f.write("]")
 
       f.close()
-      tasmota.log(f"MTR: =Saved     {fabrics_saved} fabric(s) and {sessions_saved} session(s)", 2)
-      self.device.event_fabrics_saved()     # signal event
+      # saving went well, now remove previous version and rename
+      path.remove(self._FABRICS)
+      if (path.rename(self._FABRICS_TEMP, self._FABRICS))
+        tasmota.log(f"MTR: =Saved     {fabrics_saved} fabric(s) and {sessions_saved} session(s)", 2)
+        self.device.event_fabrics_saved()     # signal event
+      else
+        tasmota.log(f"MTR: Saving Fabrics failed", 2)
+      end
     except .. as e, m
       tasmota.log("MTR: Session_Store::save Exception:" + str(e) + "|" + str(m), 2)
     end

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
@@ -7,91 +7,9 @@
 extern const bclass be_class_Matter_Session_Store;
 
 /********************************************************************
-** Solidified function: create_fabric
+** Solidified function: remove_session
 ********************************************************************/
-be_local_closure(Matter_Session_Store_create_fabric,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Fabric),
-    }),
-    be_str_weak(create_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_session_by_source_node_id
-********************************************************************/
-be_local_closure(Matter_Session_Store_get_session_by_source_node_id,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(_source_node_id),
-    /* K3   */  be_nested_str_weak(update),
-    /* K4   */  be_const_int(1),
-    }),
-    be_str_weak(get_session_by_source_node_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x6008000C,  //  0005  GETGBL	R2	G12
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x7C080200,  //  0007  CALL	R2	1
-      0x580C0001,  //  0008  LDCONST	R3	K1
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
-      0x14140602,  //  000A  LT	R5	R3	R2
-      0x78160008,  //  000B  JMPF	R5	#0015
-      0x94140803,  //  000C  GETIDX	R5	R4	R3
-      0x88180B02,  //  000D  GETMBR	R6	R5	K2
-      0x1C180C01,  //  000E  EQ	R6	R6	R1
-      0x781A0002,  //  000F  JMPF	R6	#0013
-      0x8C180B03,  //  0010  GETMET	R6	R5	K3
-      0x7C180200,  //  0011  CALL	R6	1
-      0x80040A00,  //  0012  RET	1	R5
-      0x000C0704,  //  0013  ADD	R3	R3	K4
-      0x7001FFF4,  //  0014  JMP		#000A
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_redundant_fabric
-********************************************************************/
-be_local_closure(Matter_Session_Store_remove_redundant_fabric,   /* name */
+be_local_closure(Matter_Session_Store_remove_session,   /* name */
   be_nested_proto(
     7,                          /* nstack */
     2,                          /* argc */
@@ -101,43 +19,32 @@ be_local_closure(Matter_Session_Store_remove_redundant_fabric,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
+    ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(fabrics),
-    /* K2   */  be_nested_str_weak(fabric_id),
-    /* K3   */  be_nested_str_weak(device_id),
-    /* K4   */  be_nested_str_weak(remove),
-    /* K5   */  be_const_int(1),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(remove),
+    /* K3   */  be_const_int(1),
     }),
-    be_str_weak(remove_redundant_fabric),
+    be_str_weak(remove_session),
     &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
+    ( &(const binstruction[17]) {  /* code */
       0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0012,  //  0005  JMPF	R3	#0019
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x20100601,  //  0008  NE	R4	R3	R1
-      0x7812000C,  //  0009  JMPF	R4	#0017
-      0x88100702,  //  000A  GETMBR	R4	R3	K2
-      0x88140302,  //  000B  GETMBR	R5	R1	K2
-      0x1C100805,  //  000C  EQ	R4	R4	R5
-      0x78120008,  //  000D  JMPF	R4	#0017
-      0x88100703,  //  000E  GETMBR	R4	R3	K3
-      0x88140303,  //  000F  GETMBR	R5	R1	K3
-      0x1C100805,  //  0010  EQ	R4	R4	R5
-      0x78120004,  //  0011  JMPF	R4	#0017
-      0x88100101,  //  0012  GETMBR	R4	R0	K1
-      0x8C100904,  //  0013  GETMET	R4	R4	K4
-      0x5C180400,  //  0014  MOVE	R6	R2
-      0x7C100400,  //  0015  CALL	R4	2
-      0x70020000,  //  0016  JMP		#0018
-      0x00080505,  //  0017  ADD	R2	R2	K5
-      0x7001FFE7,  //  0018  JMP		#0001
-      0x80000000,  //  0019  RET	0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x6010000C,  //  0002  GETGBL	R4	G12
+      0x88140101,  //  0003  GETMBR	R5	R0	K1
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100404,  //  0005  LT	R4	R2	R4
+      0x78120008,  //  0006  JMPF	R4	#0010
+      0x94100602,  //  0007  GETIDX	R4	R3	R2
+      0x1C100801,  //  0008  EQ	R4	R4	R1
+      0x78120003,  //  0009  JMPF	R4	#000E
+      0x8C100702,  //  000A  GETMET	R4	R3	K2
+      0x5C180400,  //  000B  MOVE	R6	R2
+      0x7C100400,  //  000C  CALL	R4	2
+      0x70020000,  //  000D  JMP		#000F
+      0x00080503,  //  000E  ADD	R2	R2	K3
+      0x7001FFF1,  //  000F  JMP		#0002
+      0x80000000,  //  0010  RET	0
     })
   )
 );
@@ -145,139 +52,11 @@ be_local_closure(Matter_Session_Store_remove_redundant_fabric,   /* name */
 
 
 /********************************************************************
-** Solidified function: active_fabrics
+** Solidified function: gen_local_session_id
 ********************************************************************/
-be_local_closure(Matter_Session_Store_active_fabrics,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    /* K1   */  be_nested_str_weak(fabrics),
-    /* K2   */  be_nested_str_weak(persistables),
-    }),
-    be_str_weak(active_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_children_fabrics
-********************************************************************/
-be_local_closure(Matter_Session_Store_find_children_fabrics,   /* name */
+be_local_closure(Matter_Session_Store_gen_local_session_id,   /* name */
   be_nested_proto(
     6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        7,                          /* nstack */
-        1,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 3]) {  /* upvals */
-          be_local_const_upval(1, 0),
-          be_local_const_upval(1, 2),
-          be_local_const_upval(1, 3),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 6]) {     /* constants */
-        /* K0   */  be_nested_str_weak(active_fabrics),
-        /* K1   */  be_nested_str_weak(fabric_parent),
-        /* K2   */  be_nested_str_weak(find),
-        /* K3   */  be_nested_str_weak(fabric_index),
-        /* K4   */  be_nested_str_weak(push),
-        /* K5   */  be_nested_str_weak(stop_iteration),
-        }),
-        be_str_weak(find_children_fabrics_inner),
-        &be_const_str_solidified,
-        ( &(const binstruction[30]) {  /* code */
-          0x60040010,  //  0000  GETGBL	R1	G16
-          0x68080000,  //  0001  GETUPV	R2	U0
-          0x8C080500,  //  0002  GETMET	R2	R2	K0
-          0x7C080200,  //  0003  CALL	R2	1
-          0x7C040200,  //  0004  CALL	R1	1
-          0xA8020013,  //  0005  EXBLK	0	#001A
-          0x5C080200,  //  0006  MOVE	R2	R1
-          0x7C080000,  //  0007  CALL	R2	0
-          0x880C0501,  //  0008  GETMBR	R3	R2	K1
-          0x1C0C0600,  //  0009  EQ	R3	R3	R0
-          0x780E000D,  //  000A  JMPF	R3	#0019
-          0x680C0001,  //  000B  GETUPV	R3	U1
-          0x8C0C0702,  //  000C  GETMET	R3	R3	K2
-          0x7C0C0200,  //  000D  CALL	R3	1
-          0x4C100000,  //  000E  LDNIL	R4
-          0x1C0C0604,  //  000F  EQ	R3	R3	R4
-          0x780E0007,  //  0010  JMPF	R3	#0019
-          0x880C0503,  //  0011  GETMBR	R3	R2	K3
-          0x68100001,  //  0012  GETUPV	R4	U1
-          0x8C100904,  //  0013  GETMET	R4	R4	K4
-          0x5C180600,  //  0014  MOVE	R6	R3
-          0x7C100400,  //  0015  CALL	R4	2
-          0x68100002,  //  0016  GETUPV	R4	U2
-          0x5C140600,  //  0017  MOVE	R5	R3
-          0x7C100200,  //  0018  CALL	R4	1
-          0x7001FFEB,  //  0019  JMP		#0006
-          0x58040005,  //  001A  LDCONST	R1	K5
-          0xAC040200,  //  001B  CATCH	R1	1	0
-          0xB0080000,  //  001C  RAISE	2	R0	R0
-          0x80000000,  //  001D  RET	0
-        })
-      ),
-    }),
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(find_children_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0002,  //  0002  JMPF	R2	#0006
-      0x60080012,  //  0003  GETGBL	R2	G18
-      0x7C080000,  //  0004  CALL	R2	0
-      0x80040400,  //  0005  RET	1	R2
-      0x60080012,  //  0006  GETGBL	R2	G18
-      0x7C080000,  //  0007  CALL	R2	0
-      0x400C0401,  //  0008  CONNECT	R3	R2	R1
-      0x840C0000,  //  0009  CLOSURE	R3	P0
-      0x5C100600,  //  000A  MOVE	R4	R3
-      0x5C140200,  //  000B  MOVE	R5	R1
-      0x7C100200,  //  000C  CALL	R4	1
-      0xA0000000,  //  000D  CLOSE	R0
-      0x80040400,  //  000E  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: next_fabric_idx
-********************************************************************/
-be_local_closure(Matter_Session_Store_next_fabric_idx,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -286,41 +65,35 @@ be_local_closure(Matter_Session_Store_next_fabric_idx,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(active_fabrics),
-    /* K3   */  be_nested_str_weak(fabric_index),
-    /* K4   */  be_nested_str_weak(int),
-    /* K5   */  be_nested_str_weak(stop_iteration),
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(random),
+    /* K2   */  be_const_int(2),
+    /* K3   */  be_nested_str_weak(get),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(get_session_by_local_session_id),
     }),
-    be_str_weak(next_fabric_idx),
+    be_str_weak(gen_local_session_id),
     &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x58040001,  //  0002  LDCONST	R1	K1
-      0x60080010,  //  0003  GETGBL	R2	G16
-      0x8C0C0102,  //  0004  GETMET	R3	R0	K2
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x7C080200,  //  0006  CALL	R2	1
-      0xA802000C,  //  0007  EXBLK	0	#0015
-      0x5C0C0400,  //  0008  MOVE	R3	R2
-      0x7C0C0000,  //  0009  CALL	R3	0
-      0x88100703,  //  000A  GETMBR	R4	R3	K3
-      0x60140004,  //  000B  GETGBL	R5	G4
-      0x5C180800,  //  000C  MOVE	R6	R4
-      0x7C140200,  //  000D  CALL	R5	1
-      0x1C140B04,  //  000E  EQ	R5	R5	K4
-      0x78160003,  //  000F  JMPF	R5	#0014
-      0x28140801,  //  0010  GE	R5	R4	R1
-      0x78160001,  //  0011  JMPF	R5	#0014
-      0x00140901,  //  0012  ADD	R5	R4	K1
-      0x5C040A00,  //  0013  MOVE	R1	R5
-      0x7001FFF2,  //  0014  JMP		#0008
-      0x58080005,  //  0015  LDCONST	R2	K5
-      0xAC080200,  //  0016  CATCH	R2	1	0
-      0xB0080000,  //  0017  RAISE	2	R0	R0
-      0x80040200,  //  0018  RET	1	R1
+    ( &(const binstruction[19]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x50080200,  //  0001  LDBOOL	R2	1	0
+      0x780A000E,  //  0002  JMPF	R2	#0012
+      0x8C080301,  //  0003  GETMET	R2	R1	K1
+      0x58100002,  //  0004  LDCONST	R4	K2
+      0x7C080400,  //  0005  CALL	R2	2
+      0x8C080503,  //  0006  GETMET	R2	R2	K3
+      0x58100004,  //  0007  LDCONST	R4	K4
+      0x58140002,  //  0008  LDCONST	R5	K2
+      0x7C080600,  //  0009  CALL	R2	3
+      0x8C0C0105,  //  000A  GETMET	R3	R0	K5
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x4C100000,  //  000D  LDNIL	R4
+      0x1C0C0604,  //  000E  EQ	R3	R3	R4
+      0x780E0000,  //  000F  JMPF	R3	#0011
+      0x80040400,  //  0010  RET	1	R2
+      0x7001FFEE,  //  0011  JMP		#0001
+      0x80000000,  //  0012  RET	0
     })
   )
 );
@@ -496,11 +269,106 @@ be_local_closure(Matter_Session_Store_load_fabrics,   /* name */
 
 
 /********************************************************************
-** Solidified function: count_active_fabrics
+** Solidified function: find_children_fabrics
 ********************************************************************/
-be_local_closure(Matter_Session_Store_count_active_fabrics,   /* name */
+be_local_closure(Matter_Session_Store_find_children_fabrics,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        7,                          /* nstack */
+        1,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 3]) {  /* upvals */
+          be_local_const_upval(1, 0),
+          be_local_const_upval(1, 2),
+          be_local_const_upval(1, 3),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 6]) {     /* constants */
+        /* K0   */  be_nested_str_weak(active_fabrics),
+        /* K1   */  be_nested_str_weak(fabric_parent),
+        /* K2   */  be_nested_str_weak(find),
+        /* K3   */  be_nested_str_weak(fabric_index),
+        /* K4   */  be_nested_str_weak(push),
+        /* K5   */  be_nested_str_weak(stop_iteration),
+        }),
+        be_str_weak(find_children_fabrics_inner),
+        &be_const_str_solidified,
+        ( &(const binstruction[30]) {  /* code */
+          0x60040010,  //  0000  GETGBL	R1	G16
+          0x68080000,  //  0001  GETUPV	R2	U0
+          0x8C080500,  //  0002  GETMET	R2	R2	K0
+          0x7C080200,  //  0003  CALL	R2	1
+          0x7C040200,  //  0004  CALL	R1	1
+          0xA8020013,  //  0005  EXBLK	0	#001A
+          0x5C080200,  //  0006  MOVE	R2	R1
+          0x7C080000,  //  0007  CALL	R2	0
+          0x880C0501,  //  0008  GETMBR	R3	R2	K1
+          0x1C0C0600,  //  0009  EQ	R3	R3	R0
+          0x780E000D,  //  000A  JMPF	R3	#0019
+          0x680C0001,  //  000B  GETUPV	R3	U1
+          0x8C0C0702,  //  000C  GETMET	R3	R3	K2
+          0x7C0C0200,  //  000D  CALL	R3	1
+          0x4C100000,  //  000E  LDNIL	R4
+          0x1C0C0604,  //  000F  EQ	R3	R3	R4
+          0x780E0007,  //  0010  JMPF	R3	#0019
+          0x880C0503,  //  0011  GETMBR	R3	R2	K3
+          0x68100001,  //  0012  GETUPV	R4	U1
+          0x8C100904,  //  0013  GETMET	R4	R4	K4
+          0x5C180600,  //  0014  MOVE	R6	R3
+          0x7C100400,  //  0015  CALL	R4	2
+          0x68100002,  //  0016  GETUPV	R4	U2
+          0x5C140600,  //  0017  MOVE	R5	R3
+          0x7C100200,  //  0018  CALL	R4	1
+          0x7001FFEB,  //  0019  JMP		#0006
+          0x58040005,  //  001A  LDCONST	R1	K5
+          0xAC040200,  //  001B  CATCH	R1	1	0
+          0xB0080000,  //  001C  RAISE	2	R0	R0
+          0x80000000,  //  001D  RET	0
+        })
+      ),
+    }),
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(find_children_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0002,  //  0002  JMPF	R2	#0006
+      0x60080012,  //  0003  GETGBL	R2	G18
+      0x7C080000,  //  0004  CALL	R2	0
+      0x80040400,  //  0005  RET	1	R2
+      0x60080012,  //  0006  GETGBL	R2	G18
+      0x7C080000,  //  0007  CALL	R2	0
+      0x400C0401,  //  0008  CONNECT	R3	R2	R1
+      0x840C0000,  //  0009  CLOSURE	R3	P0
+      0x5C100600,  //  000A  MOVE	R4	R3
+      0x5C140200,  //  000B  MOVE	R5	R1
+      0x7C100200,  //  000C  CALL	R4	1
+      0xA0000000,  //  000D  CLOSE	R0
+      0x80040400,  //  000E  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sessions_active
+********************************************************************/
+be_local_closure(Matter_Session_Store_sessions_active,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -508,192 +376,39 @@ be_local_closure(Matter_Session_Store_count_active_fabrics,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    /* K1   */  be_nested_str_weak(fabrics),
-    /* K2   */  be_nested_str_weak(count_persistables),
-    /* K3   */  be_const_int(0),
-    }),
-    be_str_weak(count_active_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x4C080000,  //  0003  LDNIL	R2
-      0x20040202,  //  0004  NE	R1	R1	R2
-      0x78060004,  //  0005  JMPF	R1	#000B
-      0x88040101,  //  0006  GETMBR	R1	R0	K1
-      0x8C040302,  //  0007  GETMET	R1	R1	K2
-      0x7C040200,  //  0008  CALL	R1	1
-      0x80040200,  //  0009  RET	1	R1
-      0x70020000,  //  000A  JMP		#000C
-      0x80060600,  //  000B  RET	1	K3
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_fabric
-********************************************************************/
-be_local_closure(Matter_Session_Store_remove_fabric,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(_fabric),
-    /* K3   */  be_nested_str_weak(remove),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(fabrics),
-    /* K6   */  be_nested_str_weak(find),
-    }),
-    be_str_weak(remove_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0011,  //  0003  JMPF	R2	#0016
-      0x58080001,  //  0004  LDCONST	R2	K1
-      0x600C000C,  //  0005  GETGBL	R3	G12
-      0x88100100,  //  0006  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x140C0403,  //  0008  LT	R3	R2	R3
-      0x780E000B,  //  0009  JMPF	R3	#0016
-      0x880C0100,  //  000A  GETMBR	R3	R0	K0
-      0x940C0602,  //  000B  GETIDX	R3	R3	R2
-      0x880C0702,  //  000C  GETMBR	R3	R3	K2
-      0x1C0C0601,  //  000D  EQ	R3	R3	R1
-      0x780E0004,  //  000E  JMPF	R3	#0014
-      0x880C0100,  //  000F  GETMBR	R3	R0	K0
-      0x8C0C0703,  //  0010  GETMET	R3	R3	K3
-      0x5C140400,  //  0011  MOVE	R5	R2
-      0x7C0C0400,  //  0012  CALL	R3	2
-      0x70020000,  //  0013  JMP		#0015
-      0x00080504,  //  0014  ADD	R2	R2	K4
-      0x7001FFEE,  //  0015  JMP		#0005
-      0x88080105,  //  0016  GETMBR	R2	R0	K5
-      0x4C0C0000,  //  0017  LDNIL	R3
-      0x20080403,  //  0018  NE	R2	R2	R3
-      0x780A0006,  //  0019  JMPF	R2	#0021
-      0x88080105,  //  001A  GETMBR	R2	R0	K5
-      0x8C080503,  //  001B  GETMET	R2	R2	K3
-      0x88100105,  //  001C  GETMBR	R4	R0	K5
-      0x8C100906,  //  001D  GETMET	R4	R4	K6
-      0x5C180200,  //  001E  MOVE	R6	R1
-      0x7C100400,  //  001F  CALL	R4	2
-      0x7C080400,  //  0020  CALL	R2	2
-      0x80000000,  //  0021  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_session
-********************************************************************/
-be_local_closure(Matter_Session_Store_remove_session,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_const_int(0),
     /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(remove),
-    /* K3   */  be_const_int(1),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_const_int(1),
     }),
-    be_str_weak(remove_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x6010000C,  //  0002  GETGBL	R4	G12
-      0x88140101,  //  0003  GETMBR	R5	R0	K1
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100404,  //  0005  LT	R4	R2	R4
-      0x78120008,  //  0006  JMPF	R4	#0010
-      0x94100602,  //  0007  GETIDX	R4	R3	R2
-      0x1C100801,  //  0008  EQ	R4	R4	R1
-      0x78120003,  //  0009  JMPF	R4	#000E
-      0x8C100702,  //  000A  GETMET	R4	R3	K2
-      0x5C180400,  //  000B  MOVE	R6	R2
-      0x7C100400,  //  000C  CALL	R4	2
-      0x70020000,  //  000D  JMP		#000F
-      0x00080503,  //  000E  ADD	R2	R2	K3
-      0x7001FFF1,  //  000F  JMP		#0002
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_fabric
-********************************************************************/
-be_local_closure(Matter_Session_Store_add_fabric,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Fabric),
-    /* K2   */  be_nested_str_weak(value_error),
-    /* K3   */  be_nested_str_weak(must_X20be_X20of_X20class_X20matter_X2EFabric),
-    /* K4   */  be_nested_str_weak(fabrics),
-    /* K5   */  be_nested_str_weak(find),
-    /* K6   */  be_nested_str_weak(remove_redundant_fabric),
-    /* K7   */  be_nested_str_weak(push),
-    }),
-    be_str_weak(add_fabric),
+    be_str_weak(sessions_active),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
-      0x6008000F,  //  0000  GETGBL	R2	G15
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0xB8120000,  //  0002  GETNGBL	R4	K0
-      0x88100901,  //  0003  GETMBR	R4	R4	K1
-      0x7C080400,  //  0004  CALL	R2	2
-      0x740A0000,  //  0005  JMPT	R2	#0007
-      0xB0060503,  //  0006  RAISE	1	K2	K3
-      0x88080104,  //  0007  GETMBR	R2	R0	K4
-      0x8C080505,  //  0008  GETMET	R2	R2	K5
-      0x5C100200,  //  0009  MOVE	R4	R1
-      0x7C080400,  //  000A  CALL	R2	2
-      0x4C0C0000,  //  000B  LDNIL	R3
-      0x1C080403,  //  000C  EQ	R2	R2	R3
-      0x780A0006,  //  000D  JMPF	R2	#0015
-      0x8C080106,  //  000E  GETMET	R2	R0	K6
-      0x5C100200,  //  000F  MOVE	R4	R1
-      0x7C080400,  //  0010  CALL	R2	2
-      0x88080104,  //  0011  GETMBR	R2	R0	K4
-      0x8C080507,  //  0012  GETMET	R2	R2	K7
-      0x5C100200,  //  0013  MOVE	R4	R1
-      0x7C080400,  //  0014  CALL	R2	2
-      0x80000000,  //  0015  RET	0
+      0x60040012,  //  0000  GETGBL	R1	G18
+      0x7C040000,  //  0001  CALL	R1	0
+      0x58080000,  //  0002  LDCONST	R2	K0
+      0x600C000C,  //  0003  GETGBL	R3	G12
+      0x88100101,  //  0004  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x140C0403,  //  0006  LT	R3	R2	R3
+      0x780E000C,  //  0007  JMPF	R3	#0015
+      0x880C0101,  //  0008  GETMBR	R3	R0	K1
+      0x940C0602,  //  0009  GETIDX	R3	R3	R2
+      0x8C100702,  //  000A  GETMET	R4	R3	K2
+      0x7C100200,  //  000B  CALL	R4	1
+      0x78120005,  //  000C  JMPF	R4	#0013
+      0x8C100703,  //  000D  GETMET	R4	R3	K3
+      0x7C100200,  //  000E  CALL	R4	1
+      0x78120002,  //  000F  JMPF	R4	#0013
+      0x8C100304,  //  0010  GETMET	R4	R1	K4
+      0x5C180600,  //  0011  MOVE	R6	R3
+      0x7C100400,  //  0012  CALL	R4	2
+      0x00080505,  //  0013  ADD	R2	R2	K5
+      0x7001FFED,  //  0014  JMP		#0003
+      0x80040200,  //  0015  RET	1	R1
     })
   )
 );
@@ -747,9 +462,9 @@ be_local_closure(Matter_Session_Store_find_fabric_by_index,   /* name */
 
 
 /********************************************************************
-** Solidified function: remove_expired
+** Solidified function: active_fabrics
 ********************************************************************/
-be_local_closure(Matter_Session_Store_remove_expired,   /* name */
+be_local_closure(Matter_Session_Store_active_fabrics,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -760,227 +475,19 @@ be_local_closure(Matter_Session_Store_remove_expired,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(every_second),
-    /* K2   */  be_nested_str_weak(fabrics),
-    }),
-    be_str_weak(remove_expired),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040102,  //  0003  GETMBR	R1	R0	K2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_session
-********************************************************************/
-be_local_closure(Matter_Session_Store_add_session,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(push),
-    }),
-    be_str_weak(add_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x200C0403,  //  0001  NE	R3	R2	R3
-      0x780E0002,  //  0002  JMPF	R3	#0006
-      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
-      0x5C140200,  //  0008  MOVE	R5	R1
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x80000000,  //  000A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: create_session
-********************************************************************/
-be_local_closure(Matter_Session_Store_create_session,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_session_by_local_session_id),
-    /* K1   */  be_nested_str_weak(remove_session),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Session),
-    /* K4   */  be_nested_str_weak(sessions),
-    /* K5   */  be_nested_str_weak(push),
-    }),
-    be_str_weak(create_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
-      0x5C140200,  //  0001  MOVE	R5	R1
-      0x7C0C0400,  //  0002  CALL	R3	2
-      0x4C100000,  //  0003  LDNIL	R4
-      0x20100604,  //  0004  NE	R4	R3	R4
-      0x78120002,  //  0005  JMPF	R4	#0009
-      0x8C100101,  //  0006  GETMET	R4	R0	K1
-      0x5C180600,  //  0007  MOVE	R6	R3
-      0x7C100400,  //  0008  CALL	R4	2
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x8C100903,  //  000A  GETMET	R4	R4	K3
-      0x5C180000,  //  000B  MOVE	R6	R0
-      0x5C1C0200,  //  000C  MOVE	R7	R1
-      0x5C200400,  //  000D  MOVE	R8	R2
-      0x7C100800,  //  000E  CALL	R4	4
-      0x5C0C0800,  //  000F  MOVE	R3	R4
-      0x88100104,  //  0010  GETMBR	R4	R0	K4
-      0x8C100905,  //  0011  GETMET	R4	R4	K5
-      0x5C180600,  //  0012  MOVE	R6	R3
-      0x7C100400,  //  0013  CALL	R4	2
-      0x80040600,  //  0014  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Session_Store_init,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Expirable_list),
-    /* K4   */  be_nested_str_weak(fabrics),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0xB80A0400,  //  0001  GETNGBL	R2	K2
-      0x8C080503,  //  0002  GETMET	R2	R2	K3
-      0x7C080200,  //  0003  CALL	R2	1
-      0x90020202,  //  0004  SETMBR	R0	K1	R2
-      0xB80A0400,  //  0005  GETNGBL	R2	K2
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
-      0x7C080200,  //  0007  CALL	R2	1
-      0x90020802,  //  0008  SETMBR	R0	K4	R2
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_session_by_local_session_id
-********************************************************************/
-be_local_closure(Matter_Session_Store_get_session_by_local_session_id,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(local_session_id),
-    /* K3   */  be_nested_str_weak(update),
-    /* K4   */  be_const_int(1),
-    }),
-    be_str_weak(get_session_by_local_session_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x6008000C,  //  0005  GETGBL	R2	G12
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x7C080200,  //  0007  CALL	R2	1
-      0x580C0001,  //  0008  LDCONST	R3	K1
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
-      0x14140602,  //  000A  LT	R5	R3	R2
-      0x78160008,  //  000B  JMPF	R5	#0015
-      0x94140803,  //  000C  GETIDX	R5	R4	R3
-      0x88180B02,  //  000D  GETMBR	R6	R5	K2
-      0x1C180C01,  //  000E  EQ	R6	R6	R1
-      0x781A0002,  //  000F  JMPF	R6	#0013
-      0x8C180B03,  //  0010  GETMET	R6	R5	K3
-      0x7C180200,  //  0011  CALL	R6	1
-      0x80040A00,  //  0012  RET	1	R5
-      0x000C0704,  //  0013  ADD	R3	R3	K4
-      0x7001FFF4,  //  0014  JMP		#000A
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(Matter_Session_Store_every_second,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(remove_expired),
+    /* K1   */  be_nested_str_weak(fabrics),
+    /* K2   */  be_nested_str_weak(persistables),
     }),
-    be_str_weak(every_second),
+    be_str_weak(active_fabrics),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
+    ( &(const binstruction[ 6]) {  /* code */
       0x8C040100,  //  0000  GETMET	R1	R0	K0
       0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80040200,  //  0005  RET	1	R1
     })
   )
 );
@@ -988,68 +495,11 @@ be_local_closure(Matter_Session_Store_every_second,   /* name */
 
 
 /********************************************************************
-** Solidified function: find_session_source_id_unsecure
+** Solidified function: create_fabric
 ********************************************************************/
-be_local_closure(Matter_Session_Store_find_session_source_id_unsecure,   /* name */
+be_local_closure(Matter_Session_Store_create_fabric,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_session_by_source_node_id),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(Session),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(_source_node_id),
-    /* K5   */  be_nested_str_weak(sessions),
-    /* K6   */  be_nested_str_weak(push),
-    /* K7   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K8   */  be_nested_str_weak(update),
-    }),
-    be_str_weak(find_session_source_id_unsecure),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
-      0x5C140200,  //  0001  MOVE	R5	R1
-      0x7C0C0400,  //  0002  CALL	R3	2
-      0x4C100000,  //  0003  LDNIL	R4
-      0x1C100604,  //  0004  EQ	R4	R3	R4
-      0x7812000E,  //  0005  JMPF	R4	#0015
-      0xB8120200,  //  0006  GETNGBL	R4	K1
-      0x8C100902,  //  0007  GETMET	R4	R4	K2
-      0x5C180000,  //  0008  MOVE	R6	R0
-      0x581C0003,  //  0009  LDCONST	R7	K3
-      0x58200003,  //  000A  LDCONST	R8	K3
-      0x7C100800,  //  000B  CALL	R4	4
-      0x5C0C0800,  //  000C  MOVE	R3	R4
-      0x900E0801,  //  000D  SETMBR	R3	K4	R1
-      0x88100105,  //  000E  GETMBR	R4	R0	K5
-      0x8C100906,  //  000F  GETMET	R4	R4	K6
-      0x5C180600,  //  0010  MOVE	R6	R3
-      0x7C100400,  //  0011  CALL	R4	2
-      0x8C100707,  //  0012  GETMET	R4	R3	K7
-      0x5C180400,  //  0013  MOVE	R6	R2
-      0x7C100400,  //  0014  CALL	R4	2
-      0x8C100708,  //  0015  GETMET	R4	R3	K8
-      0x7C100200,  //  0016  CALL	R4	1
-      0x80040600,  //  0017  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: sessions_active
-********************************************************************/
-be_local_closure(Matter_Session_Store_sessions_active,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1057,39 +507,59 @@ be_local_closure(Matter_Session_Store_sessions_active,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_const_int(1),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Fabric),
     }),
-    be_str_weak(sessions_active),
+    be_str_weak(create_fabric),
     &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60040012,  //  0000  GETGBL	R1	G18
-      0x7C040000,  //  0001  CALL	R1	0
-      0x58080000,  //  0002  LDCONST	R2	K0
-      0x600C000C,  //  0003  GETGBL	R3	G12
-      0x88100101,  //  0004  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x140C0403,  //  0006  LT	R3	R2	R3
-      0x780E000C,  //  0007  JMPF	R3	#0015
-      0x880C0101,  //  0008  GETMBR	R3	R0	K1
-      0x940C0602,  //  0009  GETIDX	R3	R3	R2
-      0x8C100702,  //  000A  GETMET	R4	R3	K2
-      0x7C100200,  //  000B  CALL	R4	1
-      0x78120005,  //  000C  JMPF	R4	#0013
-      0x8C100703,  //  000D  GETMET	R4	R3	K3
-      0x7C100200,  //  000E  CALL	R4	1
-      0x78120002,  //  000F  JMPF	R4	#0013
-      0x8C100304,  //  0010  GETMET	R4	R1	K4
-      0x5C180600,  //  0011  MOVE	R6	R3
-      0x7C100400,  //  0012  CALL	R4	2
-      0x00080505,  //  0013  ADD	R2	R2	K5
-      0x7001FFED,  //  0014  JMP		#0003
-      0x80040200,  //  0015  RET	1	R1
+    ( &(const binstruction[ 5]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x80040200,  //  0004  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: count_active_fabrics
+********************************************************************/
+be_local_closure(Matter_Session_Store_count_active_fabrics,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_expired),
+    /* K1   */  be_nested_str_weak(fabrics),
+    /* K2   */  be_nested_str_weak(count_persistables),
+    /* K3   */  be_const_int(0),
+    }),
+    be_str_weak(count_active_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x4C080000,  //  0003  LDNIL	R2
+      0x20040202,  //  0004  NE	R1	R1	R2
+      0x78060004,  //  0005  JMPF	R1	#000B
+      0x88040101,  //  0006  GETMBR	R1	R0	K1
+      0x8C040302,  //  0007  GETMET	R1	R1	K2
+      0x7C040200,  //  0008  CALL	R1	1
+      0x80040200,  //  0009  RET	1	R1
+      0x70020000,  //  000A  JMP		#000C
+      0x80060600,  //  000B  RET	1	K3
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -1168,131 +638,37 @@ be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name *
 
 
 /********************************************************************
-** Solidified function: save_fabrics
+** Solidified function: add_session
 ********************************************************************/
-be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
+be_local_closure(Matter_Session_Store_add_session,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
-    1,                          /* argc */
+    6,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(remove_expired),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(_FABRICS),
-    /* K4   */  be_nested_str_weak(w),
-    /* K5   */  be_nested_str_weak(write),
-    /* K6   */  be_nested_str_weak(_X5B),
-    /* K7   */  be_nested_str_weak(fabrics),
-    /* K8   */  be_nested_str_weak(persistables),
-    /* K9   */  be_nested_str_weak(_sessions),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_nested_str_weak(stop_iteration),
-    /* K12  */  be_nested_str_weak(_X2C),
-    /* K13  */  be_nested_str_weak(writejson),
-    /* K14  */  be_nested_str_weak(_X5D),
-    /* K15  */  be_nested_str_weak(close),
-    /* K16  */  be_nested_str_weak(tasmota),
-    /* K17  */  be_nested_str_weak(log),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20_X25s_X20fabric_X28s_X29_X20and_X20_X25s_X20session_X28s_X29),
-    /* K19  */  be_const_int(2),
-    /* K20  */  be_nested_str_weak(device),
-    /* K21  */  be_nested_str_weak(event_fabrics_saved),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K23  */  be_nested_str_weak(_X7C),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(push),
     }),
-    be_str_weak(save_fabrics),
+    be_str_weak(add_session),
     &be_const_str_solidified,
-    ( &(const binstruction[84]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA802003F,  //  0001  EXBLK	0	#0042
-      0x8C080101,  //  0002  GETMET	R2	R0	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x58080002,  //  0004  LDCONST	R2	K2
-      0x580C0002,  //  0005  LDCONST	R3	K2
-      0x60100011,  //  0006  GETGBL	R4	G17
-      0x88140103,  //  0007  GETMBR	R5	R0	K3
-      0x58180004,  //  0008  LDCONST	R6	K4
-      0x7C100400,  //  0009  CALL	R4	2
-      0x8C140905,  //  000A  GETMET	R5	R4	K5
-      0x581C0006,  //  000B  LDCONST	R7	K6
-      0x7C140400,  //  000C  CALL	R5	2
-      0x60140010,  //  000D  GETGBL	R5	G16
-      0x88180107,  //  000E  GETMBR	R6	R0	K7
-      0x8C180D08,  //  000F  GETMET	R6	R6	K8
-      0x7C180200,  //  0010  CALL	R6	1
-      0x7C140200,  //  0011  CALL	R5	1
-      0xA8020018,  //  0012  EXBLK	0	#002C
-      0x5C180A00,  //  0013  MOVE	R6	R5
-      0x7C180000,  //  0014  CALL	R6	0
-      0x601C0010,  //  0015  GETGBL	R7	G16
-      0x88200D09,  //  0016  GETMBR	R8	R6	K9
-      0x8C201108,  //  0017  GETMET	R8	R8	K8
-      0x7C200200,  //  0018  CALL	R8	1
-      0x7C1C0200,  //  0019  CALL	R7	1
-      0xA8020003,  //  001A  EXBLK	0	#001F
-      0x5C200E00,  //  001B  MOVE	R8	R7
-      0x7C200000,  //  001C  CALL	R8	0
-      0x0008050A,  //  001D  ADD	R2	R2	K10
-      0x7001FFFB,  //  001E  JMP		#001B
-      0x581C000B,  //  001F  LDCONST	R7	K11
-      0xAC1C0200,  //  0020  CATCH	R7	1	0
-      0xB0080000,  //  0021  RAISE	2	R0	R0
-      0x241C0702,  //  0022  GT	R7	R3	K2
-      0x781E0002,  //  0023  JMPF	R7	#0027
-      0x8C1C0905,  //  0024  GETMET	R7	R4	K5
-      0x5824000C,  //  0025  LDCONST	R9	K12
-      0x7C1C0400,  //  0026  CALL	R7	2
-      0x8C1C0D0D,  //  0027  GETMET	R7	R6	K13
-      0x5C240800,  //  0028  MOVE	R9	R4
-      0x7C1C0400,  //  0029  CALL	R7	2
-      0x000C070A,  //  002A  ADD	R3	R3	K10
-      0x7001FFE6,  //  002B  JMP		#0013
-      0x5814000B,  //  002C  LDCONST	R5	K11
-      0xAC140200,  //  002D  CATCH	R5	1	0
-      0xB0080000,  //  002E  RAISE	2	R0	R0
-      0x8C140905,  //  002F  GETMET	R5	R4	K5
-      0x581C000E,  //  0030  LDCONST	R7	K14
-      0x7C140400,  //  0031  CALL	R5	2
-      0x8C14090F,  //  0032  GETMET	R5	R4	K15
-      0x7C140200,  //  0033  CALL	R5	1
-      0xB8162000,  //  0034  GETNGBL	R5	K16
-      0x8C140B11,  //  0035  GETMET	R5	R5	K17
-      0x601C0018,  //  0036  GETGBL	R7	G24
-      0x58200012,  //  0037  LDCONST	R8	K18
-      0x5C240600,  //  0038  MOVE	R9	R3
-      0x5C280400,  //  0039  MOVE	R10	R2
-      0x7C1C0600,  //  003A  CALL	R7	3
-      0x58200013,  //  003B  LDCONST	R8	K19
-      0x7C140600,  //  003C  CALL	R5	3
-      0x88140114,  //  003D  GETMBR	R5	R0	K20
-      0x8C140B15,  //  003E  GETMET	R5	R5	K21
-      0x7C140200,  //  003F  CALL	R5	1
-      0xA8040001,  //  0040  EXBLK	1	1
-      0x70020010,  //  0041  JMP		#0053
-      0xAC080002,  //  0042  CATCH	R2	0	2
-      0x7002000D,  //  0043  JMP		#0052
-      0xB8122000,  //  0044  GETNGBL	R4	K16
-      0x8C100911,  //  0045  GETMET	R4	R4	K17
-      0x60180008,  //  0046  GETGBL	R6	G8
-      0x5C1C0400,  //  0047  MOVE	R7	R2
-      0x7C180200,  //  0048  CALL	R6	1
-      0x001A2C06,  //  0049  ADD	R6	K22	R6
-      0x00180D17,  //  004A  ADD	R6	R6	K23
-      0x601C0008,  //  004B  GETGBL	R7	G8
-      0x5C200600,  //  004C  MOVE	R8	R3
-      0x7C1C0200,  //  004D  CALL	R7	1
-      0x00180C07,  //  004E  ADD	R6	R6	R7
-      0x581C0013,  //  004F  LDCONST	R7	K19
-      0x7C100600,  //  0050  CALL	R4	3
-      0x70020000,  //  0051  JMP		#0053
-      0xB0080000,  //  0052  RAISE	2	R0	R0
-      0x80000000,  //  0053  RET	0
+    ( &(const binstruction[11]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x200C0403,  //  0001  NE	R3	R2	R3
+      0x780E0002,  //  0002  JMPF	R3	#0006
+      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
+      0x5C140200,  //  0008  MOVE	R5	R1
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x80000000,  //  000A  RET	0
     })
   )
 );
@@ -1300,11 +676,381 @@ be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
 
 
 /********************************************************************
-** Solidified function: gen_local_session_id
+** Solidified function: find_session_source_id_unsecure
 ********************************************************************/
-be_local_closure(Matter_Session_Store_gen_local_session_id,   /* name */
+be_local_closure(Matter_Session_Store_find_session_source_id_unsecure,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_session_by_source_node_id),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(Session),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(_source_node_id),
+    /* K5   */  be_nested_str_weak(sessions),
+    /* K6   */  be_nested_str_weak(push),
+    /* K7   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K8   */  be_nested_str_weak(update),
+    }),
+    be_str_weak(find_session_source_id_unsecure),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x5C140200,  //  0001  MOVE	R5	R1
+      0x7C0C0400,  //  0002  CALL	R3	2
+      0x4C100000,  //  0003  LDNIL	R4
+      0x1C100604,  //  0004  EQ	R4	R3	R4
+      0x7812000E,  //  0005  JMPF	R4	#0015
+      0xB8120200,  //  0006  GETNGBL	R4	K1
+      0x8C100902,  //  0007  GETMET	R4	R4	K2
+      0x5C180000,  //  0008  MOVE	R6	R0
+      0x581C0003,  //  0009  LDCONST	R7	K3
+      0x58200003,  //  000A  LDCONST	R8	K3
+      0x7C100800,  //  000B  CALL	R4	4
+      0x5C0C0800,  //  000C  MOVE	R3	R4
+      0x900E0801,  //  000D  SETMBR	R3	K4	R1
+      0x88100105,  //  000E  GETMBR	R4	R0	K5
+      0x8C100906,  //  000F  GETMET	R4	R4	K6
+      0x5C180600,  //  0010  MOVE	R6	R3
+      0x7C100400,  //  0011  CALL	R4	2
+      0x8C100707,  //  0012  GETMET	R4	R3	K7
+      0x5C180400,  //  0013  MOVE	R6	R2
+      0x7C100400,  //  0014  CALL	R4	2
+      0x8C100708,  //  0015  GETMET	R4	R3	K8
+      0x7C100200,  //  0016  CALL	R4	1
+      0x80040600,  //  0017  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Session_Store_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_expired),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_session_by_local_session_id
+********************************************************************/
+be_local_closure(Matter_Session_Store_get_session_by_local_session_id,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(local_session_id),
+    /* K3   */  be_nested_str_weak(update),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(get_session_by_local_session_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0001,  //  0002  JMPF	R2	#0005
+      0x4C080000,  //  0003  LDNIL	R2
+      0x80040400,  //  0004  RET	1	R2
+      0x6008000C,  //  0005  GETGBL	R2	G12
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x7C080200,  //  0007  CALL	R2	1
+      0x580C0001,  //  0008  LDCONST	R3	K1
+      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0x14140602,  //  000A  LT	R5	R3	R2
+      0x78160008,  //  000B  JMPF	R5	#0015
+      0x94140803,  //  000C  GETIDX	R5	R4	R3
+      0x88180B02,  //  000D  GETMBR	R6	R5	K2
+      0x1C180C01,  //  000E  EQ	R6	R6	R1
+      0x781A0002,  //  000F  JMPF	R6	#0013
+      0x8C180B03,  //  0010  GETMET	R6	R5	K3
+      0x7C180200,  //  0011  CALL	R6	1
+      0x80040A00,  //  0012  RET	1	R5
+      0x000C0704,  //  0013  ADD	R3	R3	K4
+      0x7001FFF4,  //  0014  JMP		#000A
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Session_Store_init,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(Expirable_list),
+    /* K4   */  be_nested_str_weak(fabrics),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0xB80A0400,  //  0001  GETNGBL	R2	K2
+      0x8C080503,  //  0002  GETMET	R2	R2	K3
+      0x7C080200,  //  0003  CALL	R2	1
+      0x90020202,  //  0004  SETMBR	R0	K1	R2
+      0xB80A0400,  //  0005  GETNGBL	R2	K2
+      0x8C080503,  //  0006  GETMET	R2	R2	K3
+      0x7C080200,  //  0007  CALL	R2	1
+      0x90020802,  //  0008  SETMBR	R0	K4	R2
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_expired
+********************************************************************/
+be_local_closure(Matter_Session_Store_remove_expired,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(every_second),
+    /* K2   */  be_nested_str_weak(fabrics),
+    }),
+    be_str_weak(remove_expired),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040102,  //  0003  GETMBR	R1	R0	K2
+      0x8C040301,  //  0004  GETMET	R1	R1	K1
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_redundant_fabric
+********************************************************************/
+be_local_closure(Matter_Session_Store_remove_redundant_fabric,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(fabrics),
+    /* K2   */  be_nested_str_weak(fabric_id),
+    /* K3   */  be_nested_str_weak(device_id),
+    /* K4   */  be_nested_str_weak(remove),
+    /* K5   */  be_const_int(1),
+    }),
+    be_str_weak(remove_redundant_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0012,  //  0005  JMPF	R3	#0019
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x20100601,  //  0008  NE	R4	R3	R1
+      0x7812000C,  //  0009  JMPF	R4	#0017
+      0x88100702,  //  000A  GETMBR	R4	R3	K2
+      0x88140302,  //  000B  GETMBR	R5	R1	K2
+      0x1C100805,  //  000C  EQ	R4	R4	R5
+      0x78120008,  //  000D  JMPF	R4	#0017
+      0x88100703,  //  000E  GETMBR	R4	R3	K3
+      0x88140303,  //  000F  GETMBR	R5	R1	K3
+      0x1C100805,  //  0010  EQ	R4	R4	R5
+      0x78120004,  //  0011  JMPF	R4	#0017
+      0x88100101,  //  0012  GETMBR	R4	R0	K1
+      0x8C100904,  //  0013  GETMET	R4	R4	K4
+      0x5C180400,  //  0014  MOVE	R6	R2
+      0x7C100400,  //  0015  CALL	R4	2
+      0x70020000,  //  0016  JMP		#0018
+      0x00080505,  //  0017  ADD	R2	R2	K5
+      0x7001FFE7,  //  0018  JMP		#0001
+      0x80000000,  //  0019  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_fabric
+********************************************************************/
+be_local_closure(Matter_Session_Store_add_fabric,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Fabric),
+    /* K2   */  be_nested_str_weak(value_error),
+    /* K3   */  be_nested_str_weak(must_X20be_X20of_X20class_X20matter_X2EFabric),
+    /* K4   */  be_nested_str_weak(fabrics),
+    /* K5   */  be_nested_str_weak(find),
+    /* K6   */  be_nested_str_weak(remove_redundant_fabric),
+    /* K7   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(add_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x6008000F,  //  0000  GETGBL	R2	G15
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0xB8120000,  //  0002  GETNGBL	R4	K0
+      0x88100901,  //  0003  GETMBR	R4	R4	K1
+      0x7C080400,  //  0004  CALL	R2	2
+      0x740A0000,  //  0005  JMPT	R2	#0007
+      0xB0060503,  //  0006  RAISE	1	K2	K3
+      0x88080104,  //  0007  GETMBR	R2	R0	K4
+      0x8C080505,  //  0008  GETMET	R2	R2	K5
+      0x5C100200,  //  0009  MOVE	R4	R1
+      0x7C080400,  //  000A  CALL	R2	2
+      0x4C0C0000,  //  000B  LDNIL	R3
+      0x1C080403,  //  000C  EQ	R2	R2	R3
+      0x780A0006,  //  000D  JMPF	R2	#0015
+      0x8C080106,  //  000E  GETMET	R2	R0	K6
+      0x5C100200,  //  000F  MOVE	R4	R1
+      0x7C080400,  //  0010  CALL	R2	2
+      0x88080104,  //  0011  GETMBR	R2	R0	K4
+      0x8C080507,  //  0012  GETMET	R2	R2	K7
+      0x5C100200,  //  0013  MOVE	R4	R1
+      0x7C080400,  //  0014  CALL	R2	2
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_session_by_source_node_id
+********************************************************************/
+be_local_closure(Matter_Session_Store_get_session_by_source_node_id,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(_source_node_id),
+    /* K3   */  be_nested_str_weak(update),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(get_session_by_source_node_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0001,  //  0002  JMPF	R2	#0005
+      0x4C080000,  //  0003  LDNIL	R2
+      0x80040400,  //  0004  RET	1	R2
+      0x6008000C,  //  0005  GETGBL	R2	G12
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x7C080200,  //  0007  CALL	R2	1
+      0x580C0001,  //  0008  LDCONST	R3	K1
+      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0x14140602,  //  000A  LT	R5	R3	R2
+      0x78160008,  //  000B  JMPF	R5	#0015
+      0x94140803,  //  000C  GETIDX	R5	R4	R3
+      0x88180B02,  //  000D  GETMBR	R6	R5	K2
+      0x1C180C01,  //  000E  EQ	R6	R6	R1
+      0x781A0002,  //  000F  JMPF	R6	#0013
+      0x8C180B03,  //  0010  GETMET	R6	R5	K3
+      0x7C180200,  //  0011  CALL	R6	1
+      0x80040A00,  //  0012  RET	1	R5
+      0x000C0704,  //  0013  ADD	R3	R3	K4
+      0x7001FFF4,  //  0014  JMP		#000A
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: next_fabric_idx
+********************************************************************/
+be_local_closure(Matter_Session_Store_next_fabric_idx,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1313,35 +1059,311 @@ be_local_closure(Matter_Session_Store_gen_local_session_id,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(random),
-    /* K2   */  be_const_int(2),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(get_session_by_local_session_id),
+    /* K0   */  be_nested_str_weak(remove_expired),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_nested_str_weak(active_fabrics),
+    /* K3   */  be_nested_str_weak(fabric_index),
+    /* K4   */  be_nested_str_weak(int),
+    /* K5   */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(gen_local_session_id),
+    be_str_weak(next_fabric_idx),
     &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
+    ( &(const binstruction[25]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x58040001,  //  0002  LDCONST	R1	K1
+      0x60080010,  //  0003  GETGBL	R2	G16
+      0x8C0C0102,  //  0004  GETMET	R3	R0	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x7C080200,  //  0006  CALL	R2	1
+      0xA802000C,  //  0007  EXBLK	0	#0015
+      0x5C0C0400,  //  0008  MOVE	R3	R2
+      0x7C0C0000,  //  0009  CALL	R3	0
+      0x88100703,  //  000A  GETMBR	R4	R3	K3
+      0x60140004,  //  000B  GETGBL	R5	G4
+      0x5C180800,  //  000C  MOVE	R6	R4
+      0x7C140200,  //  000D  CALL	R5	1
+      0x1C140B04,  //  000E  EQ	R5	R5	K4
+      0x78160003,  //  000F  JMPF	R5	#0014
+      0x28140801,  //  0010  GE	R5	R4	R1
+      0x78160001,  //  0011  JMPF	R5	#0014
+      0x00140901,  //  0012  ADD	R5	R4	K1
+      0x5C040A00,  //  0013  MOVE	R1	R5
+      0x7001FFF2,  //  0014  JMP		#0008
+      0x58080005,  //  0015  LDCONST	R2	K5
+      0xAC080200,  //  0016  CATCH	R2	1	0
+      0xB0080000,  //  0017  RAISE	2	R0	R0
+      0x80040200,  //  0018  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_fabrics
+********************************************************************/
+be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[29]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(path),
+    /* K2   */  be_nested_str_weak(remove_expired),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(_FABRICS_TEMP),
+    /* K5   */  be_nested_str_weak(w),
+    /* K6   */  be_nested_str_weak(write),
+    /* K7   */  be_nested_str_weak(_X5B),
+    /* K8   */  be_nested_str_weak(fabrics),
+    /* K9   */  be_nested_str_weak(persistables),
+    /* K10  */  be_nested_str_weak(_sessions),
+    /* K11  */  be_const_int(1),
+    /* K12  */  be_nested_str_weak(stop_iteration),
+    /* K13  */  be_nested_str_weak(_X2C),
+    /* K14  */  be_nested_str_weak(writejson),
+    /* K15  */  be_nested_str_weak(_X5D),
+    /* K16  */  be_nested_str_weak(close),
+    /* K17  */  be_nested_str_weak(remove),
+    /* K18  */  be_nested_str_weak(_FABRICS),
+    /* K19  */  be_nested_str_weak(rename),
+    /* K20  */  be_nested_str_weak(tasmota),
+    /* K21  */  be_nested_str_weak(log),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20_X25s_X20fabric_X28s_X29_X20and_X20_X25s_X20session_X28s_X29),
+    /* K23  */  be_const_int(2),
+    /* K24  */  be_nested_str_weak(device),
+    /* K25  */  be_nested_str_weak(event_fabrics_saved),
+    /* K26  */  be_nested_str_weak(MTR_X3A_X20Saving_X20Fabrics_X20failed),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+    /* K28  */  be_nested_str_weak(_X7C),
+    }),
+    be_str_weak(save_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[101]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0x50080200,  //  0001  LDBOOL	R2	1	0
-      0x780A000E,  //  0002  JMPF	R2	#0012
-      0x8C080301,  //  0003  GETMET	R2	R1	K1
-      0x58100002,  //  0004  LDCONST	R4	K2
-      0x7C080400,  //  0005  CALL	R2	2
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
-      0x58100004,  //  0007  LDCONST	R4	K4
-      0x58140002,  //  0008  LDCONST	R5	K2
-      0x7C080600,  //  0009  CALL	R2	3
-      0x8C0C0105,  //  000A  GETMET	R3	R0	K5
-      0x5C140400,  //  000B  MOVE	R5	R2
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x4C100000,  //  000D  LDNIL	R4
-      0x1C0C0604,  //  000E  EQ	R3	R3	R4
-      0x780E0000,  //  000F  JMPF	R3	#0011
-      0x80040400,  //  0010  RET	1	R2
-      0x7001FFEE,  //  0011  JMP		#0001
-      0x80000000,  //  0012  RET	0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xA802004F,  //  0002  EXBLK	0	#0053
+      0x8C0C0102,  //  0003  GETMET	R3	R0	K2
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x580C0003,  //  0005  LDCONST	R3	K3
+      0x58100003,  //  0006  LDCONST	R4	K3
+      0x60140011,  //  0007  GETGBL	R5	G17
+      0x88180104,  //  0008  GETMBR	R6	R0	K4
+      0x581C0005,  //  0009  LDCONST	R7	K5
+      0x7C140400,  //  000A  CALL	R5	2
+      0x8C180B06,  //  000B  GETMET	R6	R5	K6
+      0x58200007,  //  000C  LDCONST	R8	K7
+      0x7C180400,  //  000D  CALL	R6	2
+      0x60180010,  //  000E  GETGBL	R6	G16
+      0x881C0108,  //  000F  GETMBR	R7	R0	K8
+      0x8C1C0F09,  //  0010  GETMET	R7	R7	K9
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x7C180200,  //  0012  CALL	R6	1
+      0xA8020018,  //  0013  EXBLK	0	#002D
+      0x5C1C0C00,  //  0014  MOVE	R7	R6
+      0x7C1C0000,  //  0015  CALL	R7	0
+      0x60200010,  //  0016  GETGBL	R8	G16
+      0x88240F0A,  //  0017  GETMBR	R9	R7	K10
+      0x8C241309,  //  0018  GETMET	R9	R9	K9
+      0x7C240200,  //  0019  CALL	R9	1
+      0x7C200200,  //  001A  CALL	R8	1
+      0xA8020003,  //  001B  EXBLK	0	#0020
+      0x5C241000,  //  001C  MOVE	R9	R8
+      0x7C240000,  //  001D  CALL	R9	0
+      0x000C070B,  //  001E  ADD	R3	R3	K11
+      0x7001FFFB,  //  001F  JMP		#001C
+      0x5820000C,  //  0020  LDCONST	R8	K12
+      0xAC200200,  //  0021  CATCH	R8	1	0
+      0xB0080000,  //  0022  RAISE	2	R0	R0
+      0x24200903,  //  0023  GT	R8	R4	K3
+      0x78220002,  //  0024  JMPF	R8	#0028
+      0x8C200B06,  //  0025  GETMET	R8	R5	K6
+      0x5828000D,  //  0026  LDCONST	R10	K13
+      0x7C200400,  //  0027  CALL	R8	2
+      0x8C200F0E,  //  0028  GETMET	R8	R7	K14
+      0x5C280A00,  //  0029  MOVE	R10	R5
+      0x7C200400,  //  002A  CALL	R8	2
+      0x0010090B,  //  002B  ADD	R4	R4	K11
+      0x7001FFE6,  //  002C  JMP		#0014
+      0x5818000C,  //  002D  LDCONST	R6	K12
+      0xAC180200,  //  002E  CATCH	R6	1	0
+      0xB0080000,  //  002F  RAISE	2	R0	R0
+      0x8C180B06,  //  0030  GETMET	R6	R5	K6
+      0x5820000F,  //  0031  LDCONST	R8	K15
+      0x7C180400,  //  0032  CALL	R6	2
+      0x8C180B10,  //  0033  GETMET	R6	R5	K16
+      0x7C180200,  //  0034  CALL	R6	1
+      0x8C180511,  //  0035  GETMET	R6	R2	K17
+      0x88200112,  //  0036  GETMBR	R8	R0	K18
+      0x7C180400,  //  0037  CALL	R6	2
+      0x8C180513,  //  0038  GETMET	R6	R2	K19
+      0x88200104,  //  0039  GETMBR	R8	R0	K4
+      0x88240112,  //  003A  GETMBR	R9	R0	K18
+      0x7C180600,  //  003B  CALL	R6	3
+      0x781A000C,  //  003C  JMPF	R6	#004A
+      0xB81A2800,  //  003D  GETNGBL	R6	K20
+      0x8C180D15,  //  003E  GETMET	R6	R6	K21
+      0x60200018,  //  003F  GETGBL	R8	G24
+      0x58240016,  //  0040  LDCONST	R9	K22
+      0x5C280800,  //  0041  MOVE	R10	R4
+      0x5C2C0600,  //  0042  MOVE	R11	R3
+      0x7C200600,  //  0043  CALL	R8	3
+      0x58240017,  //  0044  LDCONST	R9	K23
+      0x7C180600,  //  0045  CALL	R6	3
+      0x88180118,  //  0046  GETMBR	R6	R0	K24
+      0x8C180D19,  //  0047  GETMET	R6	R6	K25
+      0x7C180200,  //  0048  CALL	R6	1
+      0x70020006,  //  0049  JMP		#0051
+      0xB81A2800,  //  004A  GETNGBL	R6	K20
+      0x8C180D15,  //  004B  GETMET	R6	R6	K21
+      0x60200018,  //  004C  GETGBL	R8	G24
+      0x5824001A,  //  004D  LDCONST	R9	K26
+      0x7C200200,  //  004E  CALL	R8	1
+      0x58240017,  //  004F  LDCONST	R9	K23
+      0x7C180600,  //  0050  CALL	R6	3
+      0xA8040001,  //  0051  EXBLK	1	1
+      0x70020010,  //  0052  JMP		#0064
+      0xAC0C0002,  //  0053  CATCH	R3	0	2
+      0x7002000D,  //  0054  JMP		#0063
+      0xB8162800,  //  0055  GETNGBL	R5	K20
+      0x8C140B15,  //  0056  GETMET	R5	R5	K21
+      0x601C0008,  //  0057  GETGBL	R7	G8
+      0x5C200600,  //  0058  MOVE	R8	R3
+      0x7C1C0200,  //  0059  CALL	R7	1
+      0x001E3607,  //  005A  ADD	R7	K27	R7
+      0x001C0F1C,  //  005B  ADD	R7	R7	K28
+      0x60200008,  //  005C  GETGBL	R8	G8
+      0x5C240800,  //  005D  MOVE	R9	R4
+      0x7C200200,  //  005E  CALL	R8	1
+      0x001C0E08,  //  005F  ADD	R7	R7	R8
+      0x58200017,  //  0060  LDCONST	R8	K23
+      0x7C140600,  //  0061  CALL	R5	3
+      0x70020000,  //  0062  JMP		#0064
+      0xB0080000,  //  0063  RAISE	2	R0	R0
+      0x80000000,  //  0064  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: create_session
+********************************************************************/
+be_local_closure(Matter_Session_Store_create_session,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_session_by_local_session_id),
+    /* K1   */  be_nested_str_weak(remove_session),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(Session),
+    /* K4   */  be_nested_str_weak(sessions),
+    /* K5   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(create_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x5C140200,  //  0001  MOVE	R5	R1
+      0x7C0C0400,  //  0002  CALL	R3	2
+      0x4C100000,  //  0003  LDNIL	R4
+      0x20100604,  //  0004  NE	R4	R3	R4
+      0x78120002,  //  0005  JMPF	R4	#0009
+      0x8C100101,  //  0006  GETMET	R4	R0	K1
+      0x5C180600,  //  0007  MOVE	R6	R3
+      0x7C100400,  //  0008  CALL	R4	2
+      0xB8120400,  //  0009  GETNGBL	R4	K2
+      0x8C100903,  //  000A  GETMET	R4	R4	K3
+      0x5C180000,  //  000B  MOVE	R6	R0
+      0x5C1C0200,  //  000C  MOVE	R7	R1
+      0x5C200400,  //  000D  MOVE	R8	R2
+      0x7C100800,  //  000E  CALL	R4	4
+      0x5C0C0800,  //  000F  MOVE	R3	R4
+      0x88100104,  //  0010  GETMBR	R4	R0	K4
+      0x8C100905,  //  0011  GETMET	R4	R4	K5
+      0x5C180600,  //  0012  MOVE	R6	R3
+      0x7C100400,  //  0013  CALL	R4	2
+      0x80040600,  //  0014  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_fabric
+********************************************************************/
+be_local_closure(Matter_Session_Store_remove_fabric,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(_fabric),
+    /* K3   */  be_nested_str_weak(remove),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(fabrics),
+    /* K6   */  be_nested_str_weak(find),
+    }),
+    be_str_weak(remove_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[34]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0011,  //  0003  JMPF	R2	#0016
+      0x58080001,  //  0004  LDCONST	R2	K1
+      0x600C000C,  //  0005  GETGBL	R3	G12
+      0x88100100,  //  0006  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x140C0403,  //  0008  LT	R3	R2	R3
+      0x780E000B,  //  0009  JMPF	R3	#0016
+      0x880C0100,  //  000A  GETMBR	R3	R0	K0
+      0x940C0602,  //  000B  GETIDX	R3	R3	R2
+      0x880C0702,  //  000C  GETMBR	R3	R3	K2
+      0x1C0C0601,  //  000D  EQ	R3	R3	R1
+      0x780E0004,  //  000E  JMPF	R3	#0014
+      0x880C0100,  //  000F  GETMBR	R3	R0	K0
+      0x8C0C0703,  //  0010  GETMET	R3	R3	K3
+      0x5C140400,  //  0011  MOVE	R5	R2
+      0x7C0C0400,  //  0012  CALL	R3	2
+      0x70020000,  //  0013  JMP		#0015
+      0x00080504,  //  0014  ADD	R2	R2	K4
+      0x7001FFEE,  //  0015  JMP		#0005
+      0x88080105,  //  0016  GETMBR	R2	R0	K5
+      0x4C0C0000,  //  0017  LDNIL	R3
+      0x20080403,  //  0018  NE	R2	R2	R3
+      0x780A0006,  //  0019  JMPF	R2	#0021
+      0x88080105,  //  001A  GETMBR	R2	R0	K5
+      0x8C080503,  //  001B  GETMET	R2	R2	K3
+      0x88100105,  //  001C  GETMBR	R4	R0	K5
+      0x8C100906,  //  001D  GETMET	R4	R4	K6
+      0x5C180200,  //  001E  MOVE	R6	R1
+      0x7C100400,  //  001F  CALL	R4	2
+      0x7C080400,  //  0020  CALL	R2	2
+      0x80000000,  //  0021  RET	0
     })
   )
 );
@@ -1354,35 +1376,36 @@ be_local_closure(Matter_Session_Store_gen_local_session_id,   /* name */
 be_local_class(Matter_Session_Store,
     3,
     NULL,
-    be_nested_map(27,
+    be_nested_map(28,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(gen_local_session_id, -1), be_const_closure(Matter_Session_Store_gen_local_session_id_closure) },
-        { be_const_key_weak(create_fabric, -1), be_const_closure(Matter_Session_Store_create_fabric_closure) },
-        { be_const_key_weak(get_session_by_source_node_id, -1), be_const_closure(Matter_Session_Store_get_session_by_source_node_id_closure) },
-        { be_const_key_weak(save_fabrics, -1), be_const_closure(Matter_Session_Store_save_fabrics_closure) },
-        { be_const_key_weak(active_fabrics, 10), be_const_closure(Matter_Session_Store_active_fabrics_closure) },
-        { be_const_key_weak(find_session_by_resumption_id, 20), be_const_closure(Matter_Session_Store_find_session_by_resumption_id_closure) },
-        { be_const_key_weak(sessions_active, -1), be_const_closure(Matter_Session_Store_sessions_active_closure) },
         { be_const_key_weak(sessions, -1), be_const_var(1) },
-        { be_const_key_weak(fabrics, -1), be_const_var(2) },
-        { be_const_key_weak(load_fabrics, 6), be_const_closure(Matter_Session_Store_load_fabrics_closure) },
-        { be_const_key_weak(find_session_source_id_unsecure, 23), be_const_closure(Matter_Session_Store_find_session_source_id_unsecure_closure) },
-        { be_const_key_weak(_FABRICS, -1), be_nested_str_weak(_matter_fabrics_X2Ejson) },
+        { be_const_key_weak(remove_fabric, -1), be_const_closure(Matter_Session_Store_remove_fabric_closure) },
         { be_const_key_weak(remove_session, -1), be_const_closure(Matter_Session_Store_remove_session_closure) },
-        { be_const_key_weak(remove_fabric, 22), be_const_closure(Matter_Session_Store_remove_fabric_closure) },
-        { be_const_key_weak(find_fabric_by_index, 19), be_const_closure(Matter_Session_Store_find_fabric_by_index_closure) },
-        { be_const_key_weak(remove_expired, -1), be_const_closure(Matter_Session_Store_remove_expired_closure) },
-        { be_const_key_weak(add_session, -1), be_const_closure(Matter_Session_Store_add_session_closure) },
-        { be_const_key_weak(remove_redundant_fabric, 11), be_const_closure(Matter_Session_Store_remove_redundant_fabric_closure) },
-        { be_const_key_weak(create_session, -1), be_const_closure(Matter_Session_Store_create_session_closure) },
-        { be_const_key_weak(get_session_by_local_session_id, -1), be_const_closure(Matter_Session_Store_get_session_by_local_session_id_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Session_Store_init_closure) },
+        { be_const_key_weak(active_fabrics, -1), be_const_closure(Matter_Session_Store_active_fabrics_closure) },
+        { be_const_key_weak(load_fabrics, 18), be_const_closure(Matter_Session_Store_load_fabrics_closure) },
+        { be_const_key_weak(fabrics, -1), be_const_var(2) },
+        { be_const_key_weak(save_fabrics, -1), be_const_closure(Matter_Session_Store_save_fabrics_closure) },
+        { be_const_key_weak(_FABRICS_TEMP, 22), be_nested_str_weak(_X2F_matter_fabrics_X2Etmp) },
+        { be_const_key_weak(create_fabric, -1), be_const_closure(Matter_Session_Store_create_fabric_closure) },
+        { be_const_key_weak(find_fabric_by_index, -1), be_const_closure(Matter_Session_Store_find_fabric_by_index_closure) },
+        { be_const_key_weak(gen_local_session_id, 3), be_const_closure(Matter_Session_Store_gen_local_session_id_closure) },
+        { be_const_key_weak(sessions_active, 8), be_const_closure(Matter_Session_Store_sessions_active_closure) },
+        { be_const_key_weak(_FABRICS, -1), be_nested_str_weak(_X2F_matter_fabrics_X2Ejson) },
+        { be_const_key_weak(get_session_by_source_node_id, -1), be_const_closure(Matter_Session_Store_get_session_by_source_node_id_closure) },
+        { be_const_key_weak(count_active_fabrics, 23), be_const_closure(Matter_Session_Store_count_active_fabrics_closure) },
+        { be_const_key_weak(add_session, 13), be_const_closure(Matter_Session_Store_add_session_closure) },
+        { be_const_key_weak(find_session_source_id_unsecure, -1), be_const_closure(Matter_Session_Store_find_session_source_id_unsecure_closure) },
         { be_const_key_weak(every_second, -1), be_const_closure(Matter_Session_Store_every_second_closure) },
         { be_const_key_weak(add_fabric, -1), be_const_closure(Matter_Session_Store_add_fabric_closure) },
-        { be_const_key_weak(count_active_fabrics, -1), be_const_closure(Matter_Session_Store_count_active_fabrics_closure) },
-        { be_const_key_weak(device, 5), be_const_var(0) },
-        { be_const_key_weak(next_fabric_idx, 3), be_const_closure(Matter_Session_Store_next_fabric_idx_closure) },
-        { be_const_key_weak(find_children_fabrics, 0), be_const_closure(Matter_Session_Store_find_children_fabrics_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Session_Store_init_closure) },
+        { be_const_key_weak(remove_redundant_fabric, -1), be_const_closure(Matter_Session_Store_remove_redundant_fabric_closure) },
+        { be_const_key_weak(get_session_by_local_session_id, 20), be_const_closure(Matter_Session_Store_get_session_by_local_session_id_closure) },
+        { be_const_key_weak(remove_expired, -1), be_const_closure(Matter_Session_Store_remove_expired_closure) },
+        { be_const_key_weak(find_session_by_resumption_id, -1), be_const_closure(Matter_Session_Store_find_session_by_resumption_id_closure) },
+        { be_const_key_weak(next_fabric_idx, -1), be_const_closure(Matter_Session_Store_next_fabric_idx_closure) },
+        { be_const_key_weak(find_children_fabrics, 6), be_const_closure(Matter_Session_Store_find_children_fabrics_closure) },
+        { be_const_key_weak(create_session, -1), be_const_closure(Matter_Session_Store_create_session_closure) },
+        { be_const_key_weak(device, 1), be_const_var(0) },
     })),
     be_str_weak(Matter_Session_Store)
 );


### PR DESCRIPTION
## Description:

Make Matter saving Fabrics more robust. It seems that on some rare occasions, there is an exception generated when saving fabrics and sessions, which results in an empty `_matter_fabrics.json` file, and lost pairing.

Now, it first saves to `_matter_fabrics.tmp` and renames to `_matter_fabrics.json` if succesful.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
