### PR TITLE
HASPmota support for spangroup (styled text)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [13.4.0.2]
 ### Added
 - Berry `path.rename()` (#20840)
+- HASPmota support for spangroup (styled text)
 
 ### Breaking Changed
 - Drop support for old (insecure) fingerprint format (#20842)

--- a/lib/libesp32/berry_tasmota/src/be_lv_haspmota.c
+++ b/lib/libesp32/berry_tasmota/src/be_lv_haspmota.c
@@ -6,41 +6,1486 @@
 #ifdef USE_LVGL
 #ifdef USE_LVGL_HASPMOTA
 
-extern const bclass be_class_lv_anim;
-extern const bclass be_class_lv_arc;
-extern const bclass be_class_lv_bar;
-extern const bclass be_class_lv_button;
-extern const bclass be_class_lv_buttonmatrix;
-extern const bclass be_class_lv_canvas;
-extern const bclass be_class_lv_chart;
-extern const bclass be_class_lv_checkbox;
-extern const bclass be_class_lv_color;
-extern const bclass be_class_lv_colorwheel;
-extern const bclass be_class_lv_disp;
-extern const bclass be_class_lv_dropdown;
-extern const bclass be_class_lv_font;
-extern const bclass be_class_lv_group;
-extern const bclass be_class_lv_image;
-extern const bclass be_class_lv_imagebutton;
-extern const bclass be_class_lv_indev;
-extern const bclass be_class_lv_label;
-extern const bclass be_class_lv_led;
-extern const bclass be_class_lv_line;
-extern const bclass be_class_lv_meter;
-extern const bclass be_class_lv_msgbox;
+extern const bclass be_class_lv_root;
+extern const bclass be_class_lv_page;
 extern const bclass be_class_lv_obj;
-extern const bclass be_class_lv_roller;
-extern const bclass be_class_lv_slider;
-extern const bclass be_class_lv_spinbox;
-extern const bclass be_class_lv_spinner;
-extern const bclass be_class_lv_style;
+extern const bclass be_class_lv_scr;
+extern const bclass be_class_lv_btn;
 extern const bclass be_class_lv_switch;
-extern const bclass be_class_lv_table;
+extern const bclass be_class_lv_checkbox;
+extern const bclass be_class_lv_label;
+extern const bclass be_class_lv_spinner;
+extern const bclass be_class_lv_line;
+extern const bclass be_class_lv_img;
+extern const bclass be_class_lv_roller;
+extern const bclass be_class_lv_btnmatrix;
+extern const bclass be_class_lv_bar;
+extern const bclass be_class_lv_slider;
+extern const bclass be_class_lv_arc;
 extern const bclass be_class_lv_textarea;
-extern const bclass be_class_lv_theme;
-extern const bclass be_class_lv_timer;
+extern const bclass be_class_lv_dropdown;
 extern const bclass be_class_lv_qrcode;
 extern const bclass be_class_lv_chart;
+extern const bclass be_class_lv_spangroup;
+extern const bclass be_class_lv_span;
+extern const bclass be_class_lv_button;
+extern const bclass be_class_lv_image;
+extern const bclass be_class_lv_buttonmatrix;
+
+extern const bclass be_class_lvh_root;
+
+/********************************************************************
+** Solidified function: is_color_attribute
+********************************************************************/
+be_local_closure(lvh_root_is_color_attribute,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_page),
+    /* K1   */  be_nested_str_weak(_oh),
+    /* K2   */  be_nested_str_weak(re_color_suffix),
+    /* K3   */  be_nested_str_weak(search),
+    }),
+    be_str_weak(is_color_attribute),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080501,  //  0001  GETMBR	R2	R2	K1
+      0x88080502,  //  0002  GETMBR	R2	R2	K2
+      0x8C080503,  //  0003  GETMET	R2	R2	K3
+      0x60100008,  //  0004  GETGBL	R4	G8
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x7C100200,  //  0006  CALL	R4	1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80040400,  //  0008  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_val_rule
+********************************************************************/
+be_local_closure(lvh_root_set_val_rule,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        1,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(val_rule_matched),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68040000,  //  0000  GETUPV	R1	U0
+          0x8C040300,  //  0001  GETMET	R1	R1	K0
+          0x5C0C0000,  //  0002  MOVE	R3	R0
+          0x7C040400,  //  0003  CALL	R1	2
+          0x80040200,  //  0004  RET	1	R1
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_val_rule),
+    /* K1   */  be_nested_str_weak(_val_rule),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(add_rule),
+    }),
+    be_str_weak(set_val_rule),
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x60080008,  //  0002  GETGBL	R2	G8
+      0x5C0C0200,  //  0003  MOVE	R3	R1
+      0x7C080200,  //  0004  CALL	R2	1
+      0x90020202,  //  0005  SETMBR	R0	K1	R2
+      0xB80A0400,  //  0006  GETNGBL	R2	K2
+      0x8C080503,  //  0007  GETMET	R2	R2	K3
+      0x88100101,  //  0008  GETMBR	R4	R0	K1
+      0x84140000,  //  0009  CLOSURE	R5	P0
+      0x5C180000,  //  000A  MOVE	R6	R0
+      0x7C080800,  //  000B  CALL	R2	4
+      0xA0000000,  //  000C  CLOSE	R0
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_val_rule
+********************************************************************/
+be_local_closure(lvh_root_get_val_rule,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_val_rule),
+    }),
+    be_str_weak(get_val_rule),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_text_rule_formula
+********************************************************************/
+be_local_closure(lvh_root_set_text_rule_formula,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_text_rule_formula),
+    /* K1   */  be_nested_str_weak(return_X20_X2F_X20val_X20_X2D_X3E_X20_X28),
+    /* K2   */  be_nested_str_weak(_X29),
+    /* K3   */  be_nested_str_weak(_text_rule_function),
+    /* K4   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20compile_X20_X27_X25s_X27_X20_X2D_X20_X25s_X20_X28_X25s_X29),
+    }),
+    be_str_weak(set_text_rule_formula),
+    &be_const_str_solidified,
+    ( &(const binstruction[29]) {  /* code */
+      0x60080008,  //  0000  GETGBL	R2	G8
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x000A0202,  //  0005  ADD	R2	K1	R2
+      0x00080502,  //  0006  ADD	R2	R2	K2
+      0xA8020007,  //  0007  EXBLK	0	#0010
+      0x600C000D,  //  0008  GETGBL	R3	G13
+      0x5C100400,  //  0009  MOVE	R4	R2
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x5C100600,  //  000B  MOVE	R4	R3
+      0x7C100000,  //  000C  CALL	R4	0
+      0x90020604,  //  000D  SETMBR	R0	K3	R4
+      0xA8040001,  //  000E  EXBLK	1	1
+      0x7002000B,  //  000F  JMP		#001C
+      0xAC0C0002,  //  0010  CATCH	R3	0	2
+      0x70020008,  //  0011  JMP		#001B
+      0x60140001,  //  0012  GETGBL	R5	G1
+      0x60180018,  //  0013  GETGBL	R6	G24
+      0x581C0004,  //  0014  LDCONST	R7	K4
+      0x5C200400,  //  0015  MOVE	R8	R2
+      0x5C240600,  //  0016  MOVE	R9	R3
+      0x5C280800,  //  0017  MOVE	R10	R4
+      0x7C180800,  //  0018  CALL	R6	4
+      0x7C140200,  //  0019  CALL	R5	1
+      0x70020000,  //  001A  JMP		#001C
+      0xB0080000,  //  001B  RAISE	2	R0	R0
+      0x80000000,  //  001C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_text_rule_format
+********************************************************************/
+be_local_closure(lvh_root_get_text_rule_format,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_text_rule_format),
+    }),
+    be_str_weak(get_text_rule_format),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_text
+********************************************************************/
+be_local_closure(lvh_root_set_text,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(set_text),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: text_rule_matched
+********************************************************************/
+be_local_closure(lvh_root_text_rule_matched,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(int),
+    /* K1   */  be_nested_str_weak(_text_rule_function),
+    /* K2   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20run_X20self_X2E_text_rule_function_X20_X2D_X20_X25s_X20_X28_X25s_X29),
+    /* K3   */  be_nested_str_weak(_text_rule_format),
+    /* K4   */  be_nested_str_weak(string),
+    /* K5   */  be_nested_str_weak(),
+    /* K6   */  be_nested_str_weak(text),
+    }),
+    be_str_weak(text_rule_matched),
+    &be_const_str_solidified,
+    ( &(const binstruction[47]) {  /* code */
+      0x60080004,  //  0000  GETGBL	R2	G4
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x1C080500,  //  0003  EQ	R2	R2	K0
+      0x780A0003,  //  0004  JMPF	R2	#0009
+      0x6008000A,  //  0005  GETGBL	R2	G10
+      0x5C0C0200,  //  0006  MOVE	R3	R1
+      0x7C080200,  //  0007  CALL	R2	1
+      0x5C040400,  //  0008  MOVE	R1	R2
+      0x88080101,  //  0009  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  000A  LDNIL	R3
+      0x200C0403,  //  000B  NE	R3	R2	R3
+      0x780E0011,  //  000C  JMPF	R3	#001F
+      0xA8020005,  //  000D  EXBLK	0	#0014
+      0x5C0C0400,  //  000E  MOVE	R3	R2
+      0x5C100200,  //  000F  MOVE	R4	R1
+      0x7C0C0200,  //  0010  CALL	R3	1
+      0x5C040600,  //  0011  MOVE	R1	R3
+      0xA8040001,  //  0012  EXBLK	1	1
+      0x7002000A,  //  0013  JMP		#001F
+      0xAC0C0002,  //  0014  CATCH	R3	0	2
+      0x70020007,  //  0015  JMP		#001E
+      0x60140001,  //  0016  GETGBL	R5	G1
+      0x60180018,  //  0017  GETGBL	R6	G24
+      0x581C0002,  //  0018  LDCONST	R7	K2
+      0x5C200600,  //  0019  MOVE	R8	R3
+      0x5C240800,  //  001A  MOVE	R9	R4
+      0x7C180600,  //  001B  CALL	R6	3
+      0x7C140200,  //  001C  CALL	R5	1
+      0x70020000,  //  001D  JMP		#001F
+      0xB0080000,  //  001E  RAISE	2	R0	R0
+      0x880C0103,  //  001F  GETMBR	R3	R0	K3
+      0x60100004,  //  0020  GETGBL	R4	G4
+      0x5C140600,  //  0021  MOVE	R5	R3
+      0x7C100200,  //  0022  CALL	R4	1
+      0x1C100904,  //  0023  EQ	R4	R4	K4
+      0x78120005,  //  0024  JMPF	R4	#002B
+      0x60100018,  //  0025  GETGBL	R4	G24
+      0x5C140600,  //  0026  MOVE	R5	R3
+      0x5C180200,  //  0027  MOVE	R6	R1
+      0x7C100400,  //  0028  CALL	R4	2
+      0x5C0C0800,  //  0029  MOVE	R3	R4
+      0x70020000,  //  002A  JMP		#002C
+      0x580C0005,  //  002B  LDCONST	R3	K5
+      0x90020C03,  //  002C  SETMBR	R0	K6	R3
+      0x50100000,  //  002D  LDBOOL	R4	0	0
+      0x80040800,  //  002E  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_obj
+********************************************************************/
+be_local_closure(lvh_root_get_obj,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    }),
+    be_str_weak(get_obj),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_val_rule
+********************************************************************/
+be_local_closure(lvh_root_remove_val_rule,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_val_rule),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(remove_rule),
+    }),
+    be_str_weak(remove_val_rule),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060004,  //  0003  JMPF	R1	#0009
+      0xB8060200,  //  0004  GETNGBL	R1	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x5C100000,  //  0007  MOVE	R4	R0
+      0x7C040600,  //  0008  CALL	R1	3
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: digits_to_style
+********************************************************************/
+be_local_closure(lvh_root_digits_to_style,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(_digit2part),
+    /* K2   */  be_nested_str_weak(_digit2state),
+    /* K3   */  be_nested_str_weak(invalid_X20style_X20suffix_X20_X2502i),
+    /* K4   */  be_nested_str_weak(value_error),
+    }),
+    be_str_weak(digits_to_style),
+    &be_const_str_solidified,
+    ( &(const binstruction[44]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x80060000,  //  0003  RET	1	K0
+      0x540A0009,  //  0004  LDINT	R2	10
+      0x0C080202,  //  0005  DIV	R2	R1	R2
+      0x540E0009,  //  0006  LDINT	R3	10
+      0x10080403,  //  0007  MOD	R2	R2	R3
+      0x540E0009,  //  0008  LDINT	R3	10
+      0x100C0203,  //  0009  MOD	R3	R1	R3
+      0x58100000,  //  000A  LDCONST	R4	K0
+      0x28140500,  //  000B  GE	R5	R2	K0
+      0x78160008,  //  000C  JMPF	R5	#0016
+      0x6014000C,  //  000D  GETGBL	R5	G12
+      0x88180101,  //  000E  GETMBR	R6	R0	K1
+      0x7C140200,  //  000F  CALL	R5	1
+      0x14140405,  //  0010  LT	R5	R2	R5
+      0x78160003,  //  0011  JMPF	R5	#0016
+      0x88140101,  //  0012  GETMBR	R5	R0	K1
+      0x94140A02,  //  0013  GETIDX	R5	R5	R2
+      0x30100805,  //  0014  OR	R4	R4	R5
+      0x70020000,  //  0015  JMP		#0017
+      0x4C100000,  //  0016  LDNIL	R4
+      0x28140700,  //  0017  GE	R5	R3	K0
+      0x78160008,  //  0018  JMPF	R5	#0022
+      0x6014000C,  //  0019  GETGBL	R5	G12
+      0x88180102,  //  001A  GETMBR	R6	R0	K2
+      0x7C140200,  //  001B  CALL	R5	1
+      0x14140605,  //  001C  LT	R5	R3	R5
+      0x78160003,  //  001D  JMPF	R5	#0022
+      0x88140102,  //  001E  GETMBR	R5	R0	K2
+      0x94140A03,  //  001F  GETIDX	R5	R5	R3
+      0x30100805,  //  0020  OR	R4	R4	R5
+      0x70020000,  //  0021  JMP		#0023
+      0x4C100000,  //  0022  LDNIL	R4
+      0x4C140000,  //  0023  LDNIL	R5
+      0x1C140805,  //  0024  EQ	R5	R4	R5
+      0x78160004,  //  0025  JMPF	R5	#002B
+      0x60140018,  //  0026  GETGBL	R5	G24
+      0x58180003,  //  0027  LDCONST	R6	K3
+      0x5C1C0200,  //  0028  MOVE	R7	R1
+      0x7C140400,  //  0029  CALL	R5	2
+      0xB0060805,  //  002A  RAISE	1	K4	R5
+      0x80040800,  //  002B  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: val_rule_matched
+********************************************************************/
+be_local_closure(lvh_root_val_rule_matched,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_val_rule_function),
+    /* K1   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20run_X20self_X2E_val_rule_function_X20_X2D_X20_X25s_X20_X28_X25s_X29),
+    /* K2   */  be_nested_str_weak(val),
+    }),
+    be_str_weak(val_rule_matched),
+    &be_const_str_solidified,
+    ( &(const binstruction[36]) {  /* code */
+      0x6008000A,  //  0000  GETGBL	R2	G10
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0403,  //  0004  EQ	R3	R2	R3
+      0x780E0001,  //  0005  JMPF	R3	#0008
+      0x500C0000,  //  0006  LDBOOL	R3	0	0
+      0x80040600,  //  0007  RET	1	R3
+      0x880C0100,  //  0008  GETMBR	R3	R0	K0
+      0x4C100000,  //  0009  LDNIL	R4
+      0x20100604,  //  000A  NE	R4	R3	R4
+      0x78120011,  //  000B  JMPF	R4	#001E
+      0xA8020005,  //  000C  EXBLK	0	#0013
+      0x5C100600,  //  000D  MOVE	R4	R3
+      0x5C140400,  //  000E  MOVE	R5	R2
+      0x7C100200,  //  000F  CALL	R4	1
+      0x5C080800,  //  0010  MOVE	R2	R4
+      0xA8040001,  //  0011  EXBLK	1	1
+      0x7002000A,  //  0012  JMP		#001E
+      0xAC100002,  //  0013  CATCH	R4	0	2
+      0x70020007,  //  0014  JMP		#001D
+      0x60180001,  //  0015  GETGBL	R6	G1
+      0x601C0018,  //  0016  GETGBL	R7	G24
+      0x58200001,  //  0017  LDCONST	R8	K1
+      0x5C240800,  //  0018  MOVE	R9	R4
+      0x5C280A00,  //  0019  MOVE	R10	R5
+      0x7C1C0600,  //  001A  CALL	R7	3
+      0x7C180200,  //  001B  CALL	R6	1
+      0x70020000,  //  001C  JMP		#001E
+      0xB0080000,  //  001D  RAISE	2	R0	R0
+      0x60100009,  //  001E  GETGBL	R4	G9
+      0x5C140400,  //  001F  MOVE	R5	R2
+      0x7C100200,  //  0020  CALL	R4	1
+      0x90020404,  //  0021  SETMBR	R0	K2	R4
+      0x50100000,  //  0022  LDBOOL	R4	0	0
+      0x80040800,  //  0023  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_text
+********************************************************************/
+be_local_closure(lvh_root_get_text,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(get_text),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C040000,  //  0000  LDNIL	R1
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_font
+********************************************************************/
+be_local_closure(lvh_root_parse_font,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[19]) {     /* constants */
+    /* K0   */  be_nested_str_weak(int),
+    /* K1   */  be_nested_str_weak(lv),
+    /* K2   */  be_nested_str_weak(font_embedded),
+    /* K3   */  be_nested_str_weak(robotocondensed),
+    /* K4   */  be_nested_str_weak(montserrat),
+    /* K5   */  be_nested_str_weak(HSP_X3A_X20Unsupported_X20font_X3A),
+    /* K6   */  be_nested_str_weak(string),
+    /* K7   */  be_nested_str_weak(re),
+    /* K8   */  be_nested_str_weak(split),
+    /* K9   */  be_nested_str_weak(_X3A),
+    /* K10  */  be_const_int(1),
+    /* K11  */  be_nested_str_weak(_X2D),
+    /* K12  */  be_const_int(0),
+    /* K13  */  be_const_int(2),
+    /* K14  */  be_nested_str_weak(concat),
+    /* K15  */  be_nested_str_weak(match),
+    /* K16  */  be_nested_str_weak(_X2E_X2A_X5C_X2Ettf_X24),
+    /* K17  */  be_nested_str_weak(load_freetype_font),
+    /* K18  */  be_nested_str_weak(load_font),
+    }),
+    be_str_weak(parse_font),
+    &be_const_str_solidified,
+    ( &(const binstruction[148]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x600C0004,  //  0001  GETGBL	R3	G4
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x1C0C0700,  //  0004  EQ	R3	R3	K0
+      0x780E0020,  //  0005  JMPF	R3	#0027
+      0xA8020007,  //  0006  EXBLK	0	#000F
+      0xB80E0200,  //  0007  GETNGBL	R3	K1
+      0x8C0C0702,  //  0008  GETMET	R3	R3	K2
+      0x58140003,  //  0009  LDCONST	R5	K3
+      0x5C180200,  //  000A  MOVE	R6	R1
+      0x7C0C0600,  //  000B  CALL	R3	3
+      0x5C080600,  //  000C  MOVE	R2	R3
+      0xA8040001,  //  000D  EXBLK	1	1
+      0x70020016,  //  000E  JMP		#0026
+      0xAC0C0000,  //  000F  CATCH	R3	0	0
+      0x70020013,  //  0010  JMP		#0025
+      0xA8020007,  //  0011  EXBLK	0	#001A
+      0xB80E0200,  //  0012  GETNGBL	R3	K1
+      0x8C0C0702,  //  0013  GETMET	R3	R3	K2
+      0x58140004,  //  0014  LDCONST	R5	K4
+      0x5C180200,  //  0015  MOVE	R6	R1
+      0x7C0C0600,  //  0016  CALL	R3	3
+      0x5C080600,  //  0017  MOVE	R2	R3
+      0xA8040001,  //  0018  EXBLK	1	1
+      0x70020009,  //  0019  JMP		#0024
+      0xAC0C0000,  //  001A  CATCH	R3	0	0
+      0x70020006,  //  001B  JMP		#0023
+      0x600C0001,  //  001C  GETGBL	R3	G1
+      0x58100005,  //  001D  LDCONST	R4	K5
+      0x5C140200,  //  001E  MOVE	R5	R1
+      0x7C0C0400,  //  001F  CALL	R3	2
+      0x4C0C0000,  //  0020  LDNIL	R3
+      0x80040600,  //  0021  RET	1	R3
+      0x70020000,  //  0022  JMP		#0024
+      0xB0080000,  //  0023  RAISE	2	R0	R0
+      0x70020000,  //  0024  JMP		#0026
+      0xB0080000,  //  0025  RAISE	2	R0	R0
+      0x70020062,  //  0026  JMP		#008A
+      0x600C0004,  //  0027  GETGBL	R3	G4
+      0x5C100200,  //  0028  MOVE	R4	R1
+      0x7C0C0200,  //  0029  CALL	R3	1
+      0x1C0C0706,  //  002A  EQ	R3	R3	K6
+      0x780E005D,  //  002B  JMPF	R3	#008A
+      0xA40E0C00,  //  002C  IMPORT	R3	K6
+      0xA4120E00,  //  002D  IMPORT	R4	K7
+      0x8C140708,  //  002E  GETMET	R5	R3	K8
+      0x5C1C0200,  //  002F  MOVE	R7	R1
+      0x58200009,  //  0030  LDCONST	R8	K9
+      0x5824000A,  //  0031  LDCONST	R9	K10
+      0x7C140800,  //  0032  CALL	R5	4
+      0x8C180708,  //  0033  GETMET	R6	R3	K8
+      0x5C200200,  //  0034  MOVE	R8	R1
+      0x5824000B,  //  0035  LDCONST	R9	K11
+      0x7C180600,  //  0036  CALL	R6	3
+      0x5C1C0200,  //  0037  MOVE	R7	R1
+      0x5820000C,  //  0038  LDCONST	R8	K12
+      0x50240000,  //  0039  LDBOOL	R9	0	0
+      0x6028000C,  //  003A  GETGBL	R10	G12
+      0x5C2C0A00,  //  003B  MOVE	R11	R5
+      0x7C280200,  //  003C  CALL	R10	1
+      0x2428150A,  //  003D  GT	R10	R10	K10
+      0x782A0003,  //  003E  JMPF	R10	#0043
+      0x6028000C,  //  003F  GETGBL	R10	G12
+      0x942C0B0C,  //  0040  GETIDX	R11	R5	K12
+      0x7C280200,  //  0041  CALL	R10	1
+      0x742A0000,  //  0042  JMPT	R10	#0044
+      0x50280001,  //  0043  LDBOOL	R10	0	1
+      0x50280200,  //  0044  LDBOOL	R10	1	0
+      0x602C000C,  //  0045  GETGBL	R11	G12
+      0x5C300C00,  //  0046  MOVE	R12	R6
+      0x7C2C0200,  //  0047  CALL	R11	1
+      0x282C170D,  //  0048  GE	R11	R11	K13
+      0x782E000B,  //  0049  JMPF	R11	#0056
+      0x602C0009,  //  004A  GETGBL	R11	G9
+      0x5431FFFE,  //  004B  LDINT	R12	-1
+      0x94300C0C,  //  004C  GETIDX	R12	R6	R12
+      0x7C2C0200,  //  004D  CALL	R11	1
+      0x5C201600,  //  004E  MOVE	R8	R11
+      0x542DFFFD,  //  004F  LDINT	R11	-2
+      0x402E180B,  //  0050  CONNECT	R11	K12	R11
+      0x942C0C0B,  //  0051  GETIDX	R11	R6	R11
+      0x8C2C170E,  //  0052  GETMET	R11	R11	K14
+      0x5834000B,  //  0053  LDCONST	R13	K11
+      0x7C2C0400,  //  0054  CALL	R11	2
+      0x5C1C1600,  //  0055  MOVE	R7	R11
+      0x8C2C090F,  //  0056  GETMET	R11	R4	K15
+      0x58340010,  //  0057  LDCONST	R13	K16
+      0x5C380E00,  //  0058  MOVE	R14	R7
+      0x7C2C0600,  //  0059  CALL	R11	3
+      0x782E0006,  //  005A  JMPF	R11	#0062
+      0x8C2C0708,  //  005B  GETMET	R11	R3	K8
+      0x5C340E00,  //  005C  MOVE	R13	R7
+      0x58380009,  //  005D  LDCONST	R14	K9
+      0x7C2C0600,  //  005E  CALL	R11	3
+      0x5431FFFE,  //  005F  LDINT	R12	-1
+      0x941C160C,  //  0060  GETIDX	R7	R11	R12
+      0x50240200,  //  0061  LDBOOL	R9	1	0
+      0x78260007,  //  0062  JMPF	R9	#006B
+      0xB82E0200,  //  0063  GETNGBL	R11	K1
+      0x8C2C1711,  //  0064  GETMET	R11	R11	K17
+      0x5C340E00,  //  0065  MOVE	R13	R7
+      0x5C381000,  //  0066  MOVE	R14	R8
+      0x583C000C,  //  0067  LDCONST	R15	K12
+      0x7C2C0800,  //  0068  CALL	R11	4
+      0x5C081600,  //  0069  MOVE	R2	R11
+      0x7002001E,  //  006A  JMP		#008A
+      0x782A0005,  //  006B  JMPF	R10	#0072
+      0xB82E0200,  //  006C  GETNGBL	R11	K1
+      0x8C2C1712,  //  006D  GETMET	R11	R11	K18
+      0x5C340200,  //  006E  MOVE	R13	R1
+      0x7C2C0400,  //  006F  CALL	R11	2
+      0x5C081600,  //  0070  MOVE	R2	R11
+      0x70020017,  //  0071  JMP		#008A
+      0x242C110C,  //  0072  GT	R11	R8	K12
+      0x782E0015,  //  0073  JMPF	R11	#008A
+      0x602C000C,  //  0074  GETGBL	R11	G12
+      0x5C300E00,  //  0075  MOVE	R12	R7
+      0x7C2C0200,  //  0076  CALL	R11	1
+      0x242C170C,  //  0077  GT	R11	R11	K12
+      0x782E0010,  //  0078  JMPF	R11	#008A
+      0xA8020007,  //  0079  EXBLK	0	#0082
+      0xB82E0200,  //  007A  GETNGBL	R11	K1
+      0x8C2C1702,  //  007B  GETMET	R11	R11	K2
+      0x5C340E00,  //  007C  MOVE	R13	R7
+      0x5C381000,  //  007D  MOVE	R14	R8
+      0x7C2C0600,  //  007E  CALL	R11	3
+      0x5C081600,  //  007F  MOVE	R2	R11
+      0xA8040001,  //  0080  EXBLK	1	1
+      0x70020007,  //  0081  JMP		#008A
+      0xAC2C0000,  //  0082  CATCH	R11	0	0
+      0x70020004,  //  0083  JMP		#0089
+      0x602C0001,  //  0084  GETGBL	R11	G1
+      0x58300005,  //  0085  LDCONST	R12	K5
+      0x5C340200,  //  0086  MOVE	R13	R1
+      0x7C2C0400,  //  0087  CALL	R11	2
+      0x70020000,  //  0088  JMP		#008A
+      0xB0080000,  //  0089  RAISE	2	R0	R0
+      0x4C0C0000,  //  008A  LDNIL	R3
+      0x200C0403,  //  008B  NE	R3	R2	R3
+      0x780E0001,  //  008C  JMPF	R3	#008F
+      0x80040400,  //  008D  RET	1	R2
+      0x70020003,  //  008E  JMP		#0093
+      0x600C0001,  //  008F  GETGBL	R3	G1
+      0x58100005,  //  0090  LDCONST	R4	K5
+      0x5C140200,  //  0091  MOVE	R5	R1
+      0x7C0C0400,  //  0092  CALL	R3	2
+      0x80000000,  //  0093  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_val_rule_formula
+********************************************************************/
+be_local_closure(lvh_root_get_val_rule_formula,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_val_rule_formula),
+    }),
+    be_str_weak(get_val_rule_formula),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_text_rule
+********************************************************************/
+be_local_closure(lvh_root_set_text_rule,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        1,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(text_rule_matched),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68040000,  //  0000  GETUPV	R1	U0
+          0x8C040300,  //  0001  GETMET	R1	R1	K0
+          0x5C0C0000,  //  0002  MOVE	R3	R0
+          0x7C040400,  //  0003  CALL	R1	2
+          0x80040200,  //  0004  RET	1	R1
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_text_rule),
+    /* K1   */  be_nested_str_weak(_text_rule),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(add_rule),
+    }),
+    be_str_weak(set_text_rule),
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x60080008,  //  0002  GETGBL	R2	G8
+      0x5C0C0200,  //  0003  MOVE	R3	R1
+      0x7C080200,  //  0004  CALL	R2	1
+      0x90020202,  //  0005  SETMBR	R0	K1	R2
+      0xB80A0400,  //  0006  GETNGBL	R2	K2
+      0x8C080503,  //  0007  GETMET	R2	R2	K3
+      0x88100101,  //  0008  GETMBR	R4	R0	K1
+      0x84140000,  //  0009  CLOSURE	R5	P0
+      0x5C180000,  //  000A  MOVE	R6	R0
+      0x7C080800,  //  000B  CALL	R2	4
+      0xA0000000,  //  000C  CLOSE	R0
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_trailing_zeroes
+********************************************************************/
+be_local_closure(lvh_root_remove_trailing_zeroes,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_class(be_class_lvh_root),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_const_int(1),
+    /* K3   */  be_nested_str_weak(resize),
+    }),
+    be_str_weak(remove_trailing_zeroes),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C080200,  //  0003  CALL	R2	1
+      0x580C0001,  //  0004  LDCONST	R3	K1
+      0x14100602,  //  0005  LT	R4	R3	R2
+      0x78120007,  //  0006  JMPF	R4	#000F
+      0x5411FFFE,  //  0007  LDINT	R4	-1
+      0x04100803,  //  0008  SUB	R4	R4	R3
+      0x94100004,  //  0009  GETIDX	R4	R0	R4
+      0x20100901,  //  000A  NE	R4	R4	K1
+      0x78120000,  //  000B  JMPF	R4	#000D
+      0x70020001,  //  000C  JMP		#000F
+      0x000C0702,  //  000D  ADD	R3	R3	K2
+      0x7001FFF5,  //  000E  JMP		#0005
+      0x24100701,  //  000F  GT	R4	R3	K1
+      0x78120005,  //  0010  JMPF	R4	#0017
+      0x8C100103,  //  0011  GETMET	R4	R0	K3
+      0x6018000C,  //  0012  GETGBL	R6	G12
+      0x5C1C0000,  //  0013  MOVE	R7	R0
+      0x7C180200,  //  0014  CALL	R6	1
+      0x04180C03,  //  0015  SUB	R6	R6	R3
+      0x7C100400,  //  0016  CALL	R4	2
+      0x80040000,  //  0017  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_text_rule_format
+********************************************************************/
+be_local_closure(lvh_root_set_text_rule_format,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_text_rule_format),
+    }),
+    be_str_weak(set_text_rule_format),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x60080008,  //  0000  GETGBL	R2	G8
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_val_rule_formula
+********************************************************************/
+be_local_closure(lvh_root_set_val_rule_formula,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_val_rule_formula),
+    /* K1   */  be_nested_str_weak(return_X20_X2F_X20val_X20_X2D_X3E_X20_X28),
+    /* K2   */  be_nested_str_weak(_X29),
+    /* K3   */  be_nested_str_weak(_val_rule_function),
+    /* K4   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20compile_X20_X27_X25s_X27_X20_X2D_X20_X25s_X20_X28_X25s_X29),
+    }),
+    be_str_weak(set_val_rule_formula),
+    &be_const_str_solidified,
+    ( &(const binstruction[29]) {  /* code */
+      0x60080008,  //  0000  GETGBL	R2	G8
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x000A0202,  //  0005  ADD	R2	K1	R2
+      0x00080502,  //  0006  ADD	R2	R2	K2
+      0xA8020007,  //  0007  EXBLK	0	#0010
+      0x600C000D,  //  0008  GETGBL	R3	G13
+      0x5C100400,  //  0009  MOVE	R4	R2
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x5C100600,  //  000B  MOVE	R4	R3
+      0x7C100000,  //  000C  CALL	R4	0
+      0x90020604,  //  000D  SETMBR	R0	K3	R4
+      0xA8040001,  //  000E  EXBLK	1	1
+      0x7002000B,  //  000F  JMP		#001C
+      0xAC0C0002,  //  0010  CATCH	R3	0	2
+      0x70020008,  //  0011  JMP		#001B
+      0x60140001,  //  0012  GETGBL	R5	G1
+      0x60180018,  //  0013  GETGBL	R6	G24
+      0x581C0004,  //  0014  LDCONST	R7	K4
+      0x5C200400,  //  0015  MOVE	R8	R2
+      0x5C240600,  //  0016  MOVE	R9	R3
+      0x5C280800,  //  0017  MOVE	R10	R4
+      0x7C180800,  //  0018  CALL	R6	4
+      0x7C140200,  //  0019  CALL	R5	1
+      0x70020000,  //  001A  JMP		#001C
+      0xB0080000,  //  001B  RAISE	2	R0	R0
+      0x80000000,  //  001C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_meta
+********************************************************************/
+be_local_closure(lvh_root_set_meta,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_meta),
+    }),
+    be_str_weak(set_meta),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_color
+********************************************************************/
+be_local_closure(lvh_root_parse_color,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        10,                          /* nstack */
+        1,                          /* argc */
+        0,                          /* varg */
+        0,                          /* has upvals */
+        NULL,                       /* no upvals */
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[13]) {     /* constants */
+        /* K0   */  be_nested_str_weak(string),
+        /* K1   */  be_nested_str_weak(toupper),
+        /* K2   */  be_const_int(0),
+        /* K3   */  be_const_int(1),
+        /* K4   */  be_nested_str_weak(_X23),
+        /* K5   */  be_nested_str_weak(x),
+        /* K6   */  be_nested_str_weak(X),
+        /* K7   */  be_nested_str_weak(A),
+        /* K8   */  be_nested_str_weak(F),
+        /* K9   */  be_nested_str_weak(byte),
+        /* K10  */  be_nested_str_weak(0),
+        /* K11  */  be_nested_str_weak(9),
+        /* K12  */  be_nested_str_weak(stop_iteration),
+        }),
+        be_str_weak(parse_hex),
+        &be_const_str_solidified,
+        ( &(const binstruction[57]) {  /* code */
+          0xA4060000,  //  0000  IMPORT	R1	K0
+          0x8C080301,  //  0001  GETMET	R2	R1	K1
+          0x5C100000,  //  0002  MOVE	R4	R0
+          0x7C080400,  //  0003  CALL	R2	2
+          0x5C000400,  //  0004  MOVE	R0	R2
+          0x58080002,  //  0005  LDCONST	R2	K2
+          0x600C0010,  //  0006  GETGBL	R3	G16
+          0x6010000C,  //  0007  GETGBL	R4	G12
+          0x5C140000,  //  0008  MOVE	R5	R0
+          0x7C100200,  //  0009  CALL	R4	1
+          0x04100903,  //  000A  SUB	R4	R4	K3
+          0x40120404,  //  000B  CONNECT	R4	K2	R4
+          0x7C0C0200,  //  000C  CALL	R3	1
+          0xA8020026,  //  000D  EXBLK	0	#0035
+          0x5C100600,  //  000E  MOVE	R4	R3
+          0x7C100000,  //  000F  CALL	R4	0
+          0x94140004,  //  0010  GETIDX	R5	R0	R4
+          0x1C180B04,  //  0011  EQ	R6	R5	K4
+          0x781A0000,  //  0012  JMPF	R6	#0014
+          0x7001FFF9,  //  0013  JMP		#000E
+          0x1C180B05,  //  0014  EQ	R6	R5	K5
+          0x741A0001,  //  0015  JMPT	R6	#0018
+          0x1C180B06,  //  0016  EQ	R6	R5	K6
+          0x781A0000,  //  0017  JMPF	R6	#0019
+          0x7001FFF4,  //  0018  JMP		#000E
+          0x28180B07,  //  0019  GE	R6	R5	K7
+          0x781A000B,  //  001A  JMPF	R6	#0027
+          0x18180B08,  //  001B  LE	R6	R5	K8
+          0x781A0009,  //  001C  JMPF	R6	#0027
+          0x541A0003,  //  001D  LDINT	R6	4
+          0x38180406,  //  001E  SHL	R6	R2	R6
+          0x8C1C0309,  //  001F  GETMET	R7	R1	K9
+          0x5C240A00,  //  0020  MOVE	R9	R5
+          0x7C1C0400,  //  0021  CALL	R7	2
+          0x54220036,  //  0022  LDINT	R8	55
+          0x041C0E08,  //  0023  SUB	R7	R7	R8
+          0x30180C07,  //  0024  OR	R6	R6	R7
+          0x5C080C00,  //  0025  MOVE	R2	R6
+          0x7002000C,  //  0026  JMP		#0034
+          0x28180B0A,  //  0027  GE	R6	R5	K10
+          0x781A000A,  //  0028  JMPF	R6	#0034
+          0x18180B0B,  //  0029  LE	R6	R5	K11
+          0x781A0008,  //  002A  JMPF	R6	#0034
+          0x541A0003,  //  002B  LDINT	R6	4
+          0x38180406,  //  002C  SHL	R6	R2	R6
+          0x8C1C0309,  //  002D  GETMET	R7	R1	K9
+          0x5C240A00,  //  002E  MOVE	R9	R5
+          0x7C1C0400,  //  002F  CALL	R7	2
+          0x5422002F,  //  0030  LDINT	R8	48
+          0x041C0E08,  //  0031  SUB	R7	R7	R8
+          0x30180C07,  //  0032  OR	R6	R6	R7
+          0x5C080C00,  //  0033  MOVE	R2	R6
+          0x7001FFD8,  //  0034  JMP		#000E
+          0x580C000C,  //  0035  LDCONST	R3	K12
+          0xAC0C0200,  //  0036  CATCH	R3	1	0
+          0xB0080000,  //  0037  RAISE	2	R0	R0
+          0x80040400,  //  0038  RET	1	R2
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_const_class(be_class_lvh_root),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(_X23),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(color),
+    /* K5   */  be_nested_str_weak(string),
+    /* K6   */  be_nested_str_weak(introspect),
+    /* K7   */  be_nested_str_weak(COLOR_),
+    /* K8   */  be_nested_str_weak(toupper),
+    /* K9   */  be_nested_str_weak(get),
+    }),
+    be_str_weak(parse_color),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x84080000,  //  0001  CLOSURE	R2	P0
+      0x600C0008,  //  0002  GETGBL	R3	G8
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x5C000600,  //  0005  MOVE	R0	R3
+      0x940C0101,  //  0006  GETIDX	R3	R0	K1
+      0x1C0C0702,  //  0007  EQ	R3	R3	K2
+      0x780E0007,  //  0008  JMPF	R3	#0011
+      0xB80E0600,  //  0009  GETNGBL	R3	K3
+      0x8C0C0704,  //  000A  GETMET	R3	R3	K4
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x5C180000,  //  000C  MOVE	R6	R0
+      0x7C140200,  //  000D  CALL	R5	1
+      0x7C0C0400,  //  000E  CALL	R3	2
+      0x80040600,  //  000F  RET	1	R3
+      0x70020011,  //  0010  JMP		#0023
+      0xA40E0A00,  //  0011  IMPORT	R3	K5
+      0xA4120C00,  //  0012  IMPORT	R4	K6
+      0x8C140708,  //  0013  GETMET	R5	R3	K8
+      0x5C1C0000,  //  0014  MOVE	R7	R0
+      0x7C140400,  //  0015  CALL	R5	2
+      0x00160E05,  //  0016  ADD	R5	K7	R5
+      0x8C180909,  //  0017  GETMET	R6	R4	K9
+      0xB8220600,  //  0018  GETNGBL	R8	K3
+      0x5C240A00,  //  0019  MOVE	R9	R5
+      0x7C180600,  //  001A  CALL	R6	3
+      0x4C1C0000,  //  001B  LDNIL	R7
+      0x201C0C07,  //  001C  NE	R7	R6	R7
+      0x781E0004,  //  001D  JMPF	R7	#0023
+      0xB81E0600,  //  001E  GETNGBL	R7	K3
+      0x8C1C0F04,  //  001F  GETMET	R7	R7	K4
+      0x5C240C00,  //  0020  MOVE	R9	R6
+      0x7C1C0400,  //  0021  CALL	R7	2
+      0x80040E00,  //  0022  RET	1	R7
+      0xB80E0600,  //  0023  GETNGBL	R3	K3
+      0x8C0C0704,  //  0024  GETMET	R3	R3	K4
+      0x58140001,  //  0025  LDCONST	R5	K1
+      0x7C0C0400,  //  0026  CALL	R3	2
+      0x80040600,  //  0027  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_text_rule
+********************************************************************/
+be_local_closure(lvh_root_remove_text_rule,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_text_rule),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(remove_rule),
+    }),
+    be_str_weak(remove_text_rule),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060004,  //  0003  JMPF	R1	#0009
+      0xB8060200,  //  0004  GETNGBL	R1	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x5C100000,  //  0007  MOVE	R4	R0
+      0x7C040600,  //  0008  CALL	R1	3
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(lvh_root_init,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    6,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_page),
+    /* K1   */  be_nested_str_weak(_parent_lvh),
+    /* K2   */  be_nested_str_weak(_lv_class),
+    /* K3   */  be_nested_str_weak(_lv_obj),
+    /* K4   */  be_nested_str_weak(post_init),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x90020002,  //  0000  SETMBR	R0	K0	R2
+      0x90020205,  //  0001  SETMBR	R0	K1	R5
+      0x4C180000,  //  0002  LDNIL	R6
+      0x1C180806,  //  0003  EQ	R6	R4	R6
+      0x781A0007,  //  0004  JMPF	R6	#000D
+      0x88180102,  //  0005  GETMBR	R6	R0	K2
+      0x781A0005,  //  0006  JMPF	R6	#000D
+      0x88180102,  //  0007  GETMBR	R6	R0	K2
+      0x5C1C0C00,  //  0008  MOVE	R7	R6
+      0x5C200200,  //  0009  MOVE	R8	R1
+      0x7C1C0200,  //  000A  CALL	R7	1
+      0x90020607,  //  000B  SETMBR	R0	K3	R7
+      0x70020000,  //  000C  JMP		#000E
+      0x90020604,  //  000D  SETMBR	R0	K3	R4
+      0x8C180104,  //  000E  GETMET	R6	R0	K4
+      0x7C180200,  //  000F  CALL	R6	1
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_text_rule
+********************************************************************/
+be_local_closure(lvh_root_get_text_rule,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_text_rule),
+    }),
+    be_str_weak(get_text_rule),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_meta
+********************************************************************/
+be_local_closure(lvh_root_get_meta,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_meta),
+    }),
+    be_str_weak(get_meta),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_text_rule_formula
+********************************************************************/
+be_local_closure(lvh_root_get_text_rule_formula,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_text_rule_formula),
+    }),
+    be_str_weak(get_text_rule_formula),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: lvh_root
+********************************************************************/
+be_local_class(lvh_root,
+    12,
+    NULL,
+    be_nested_map(42,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(is_color_attribute, 25), be_const_closure(lvh_root_is_color_attribute_closure) },
+        { be_const_key_weak(_meta, -1), be_const_var(4) },
+        { be_const_key_weak(get_text_rule_formula, -1), be_const_closure(lvh_root_get_text_rule_formula_closure) },
+        { be_const_key_weak(set_text_rule_formula, -1), be_const_closure(lvh_root_set_text_rule_formula_closure) },
+        { be_const_key_weak(get_text_rule_format, 21), be_const_closure(lvh_root_get_text_rule_format_closure) },
+        { be_const_key_weak(set_text, -1), be_const_closure(lvh_root_set_text_closure) },
+        { be_const_key_weak(_attr_map, 12), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(35,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(arc_rounded, -1), be_nested_str_weak(style_arc_rounded) },
+        { be_const_key_weak(line_color, 13), be_nested_str_weak(style_line_color) },
+        { be_const_key_weak(bg_grad_dir, -1), be_nested_str_weak(style_bg_grad_dir) },
+        { be_const_key_weak(border_side, 7), be_nested_str_weak(style_border_side) },
+        { be_const_key_weak(pad_all, -1), be_nested_str_weak(style_pad_all) },
+        { be_const_key_weak(height, -1), be_nested_str_weak(style_height) },
+        { be_const_key_weak(y, -1), be_nested_str_weak(y) },
+        { be_const_key_weak(arc_opa, -1), be_nested_str_weak(style_arc_opa) },
+        { be_const_key_weak(pad_right, -1), be_nested_str_weak(style_pad_right) },
+        { be_const_key_weak(image_recolor_opa, 28), be_nested_str_weak(style_img_recolor_opa) },
+        { be_const_key_weak(x, -1), be_nested_str_weak(x) },
+        { be_const_key_weak(arc_color, -1), be_nested_str_weak(style_arc_color) },
+        { be_const_key_weak(w, -1), be_nested_str_weak(width) },
+        { be_const_key_weak(h, -1), be_nested_str_weak(height) },
+        { be_const_key_weak(radius, 8), be_nested_str_weak(style_radius) },
+        { be_const_key_weak(width, 11), be_nested_str_weak(style_width) },
+        { be_const_key_weak(border_color, 22), be_nested_str_weak(style_border_color) },
+        { be_const_key_weak(bg_grad_color, 34), be_nested_str_weak(style_bg_grad_color) },
+        { be_const_key_weak(bg_color, -1), be_nested_str_weak(style_bg_color) },
+        { be_const_key_weak(border_width, 33), be_nested_str_weak(style_border_width) },
+        { be_const_key_weak(pad_top, -1), be_nested_str_weak(style_pad_top) },
+        { be_const_key_weak(image_recolor, 17), be_nested_str_weak(style_img_recolor) },
+        { be_const_key_weak(border_post, -1), be_nested_str_weak(style_border_pot) },
+        { be_const_key_weak(start_angle1, -1), be_nested_str_weak(start_angle) },
+        { be_const_key_weak(border_opa, -1), be_nested_str_weak(style_border_opa) },
+        { be_const_key_weak(rotation, 10), be_nested_str_weak(rotation) },
+        { be_const_key_weak(arc_width, 12), be_nested_str_weak(style_arc_width) },
+        { be_const_key_weak(end_angle, -1), be_nested_str_weak(bg_end_angle) },
+        { be_const_key_weak(pad_bottom, -1), be_nested_str_weak(style_pad_bottom) },
+        { be_const_key_weak(bg_opa, -1), be_nested_str_weak(style_bg_opa) },
+        { be_const_key_weak(end_angle1, -1), be_nested_str_weak(end_angle) },
+        { be_const_key_weak(start_angle, 30), be_nested_str_weak(bg_start_angle) },
+        { be_const_key_weak(src, -1), be_nested_str_weak(src) },
+        { be_const_key_weak(line_rounded, -1), be_nested_str_weak(style_line_rounded) },
+        { be_const_key_weak(pad_left, -1), be_nested_str_weak(style_pad_left) },
+    }))    ) } )) },
+        { be_const_key_weak(_text_rule, 20), be_const_var(8) },
+        { be_const_key_weak(text_rule_matched, 29), be_const_closure(lvh_root_text_rule_matched_closure) },
+        { be_const_key_weak(_val_rule_formula, 40), be_const_var(6) },
+        { be_const_key_weak(set_val_rule, 18), be_const_closure(lvh_root_set_val_rule_closure) },
+        { be_const_key_weak(get_obj, -1), be_const_closure(lvh_root_get_obj_closure) },
+        { be_const_key_weak(_attr_ignore, 36), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(9,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_nested_str_weak(tostring),
+        be_nested_str_weak(obj),
+        be_nested_str_weak(page),
+        be_nested_str_weak(comment),
+        be_nested_str_weak(parentid),
+        be_nested_str_weak(prev),
+        be_nested_str_weak(next),
+        be_nested_str_weak(back),
+        be_nested_str_weak(berry_run),
+    }))    ) } )) },
+        { be_const_key_weak(digits_to_style, 17), be_const_closure(lvh_root_digits_to_style_closure) },
+        { be_const_key_weak(val_rule_matched, -1), be_const_closure(lvh_root_val_rule_matched_closure) },
+        { be_const_key_weak(get_text, -1), be_const_closure(lvh_root_get_text_closure) },
+        { be_const_key_weak(parse_font, -1), be_const_closure(lvh_root_parse_font_closure) },
+        { be_const_key_weak(get_val_rule_formula, -1), be_const_closure(lvh_root_get_val_rule_formula_closure) },
+        { be_const_key_weak(_digit2part, 7), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(10,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(131072),
+        be_const_int(196608),
+        be_const_int(327680),
+        be_const_int(327680),
+        be_const_int(262144),
+        be_const_int(327680),
+        be_const_int(393216),
+        be_const_int(65536),
+        be_const_int(524288),
+    }))    ) } )) },
+        { be_const_key_weak(_val_rule_function, -1), be_const_var(7) },
+        { be_const_key_weak(get_val_rule, -1), be_const_closure(lvh_root_get_val_rule_closure) },
+        { be_const_key_weak(_digit2state, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(6,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(0),
+        be_const_int(1),
+        be_const_int(32),
+        be_const_int(33),
+        be_const_int(128),
+        be_const_int(160),
+    }))    ) } )) },
+        { be_const_key_weak(init, -1), be_const_closure(lvh_root_init_closure) },
+        { be_const_key_weak(set_meta, -1), be_const_closure(lvh_root_set_meta_closure) },
+        { be_const_key_weak(id, -1), be_const_var(0) },
+        { be_const_key_weak(parse_color, -1), be_const_static_closure(lvh_root_parse_color_closure) },
+        { be_const_key_weak(_lv_obj, -1), be_const_var(1) },
+        { be_const_key_weak(_page, -1), be_const_var(2) },
+        { be_const_key_weak(set_text_rule_format, 26), be_const_closure(lvh_root_set_text_rule_format_closure) },
+        { be_const_key_weak(_val_rule, 38), be_const_var(5) },
+        { be_const_key_weak(_text_rule_format, -1), be_const_var(11) },
+        { be_const_key_weak(_lv_class, -1), be_const_nil() },
+        { be_const_key_weak(remove_text_rule, -1), be_const_closure(lvh_root_remove_text_rule_closure) },
+        { be_const_key_weak(set_val_rule_formula, 22), be_const_closure(lvh_root_set_val_rule_formula_closure) },
+        { be_const_key_weak(get_text_rule, -1), be_const_closure(lvh_root_get_text_rule_closure) },
+        { be_const_key_weak(_text_rule_function, -1), be_const_var(10) },
+        { be_const_key_weak(set_text_rule, -1), be_const_closure(lvh_root_set_text_rule_closure) },
+        { be_const_key_weak(get_meta, 2), be_const_closure(lvh_root_get_meta_closure) },
+        { be_const_key_weak(remove_val_rule, -1), be_const_closure(lvh_root_remove_val_rule_closure) },
+        { be_const_key_weak(_parent_lvh, -1), be_const_var(3) },
+        { be_const_key_weak(_text_rule_formula, -1), be_const_var(9) },
+        { be_const_key_weak(remove_trailing_zeroes, 1), be_const_static_closure(lvh_root_remove_trailing_zeroes_closure) },
+    })),
+    be_str_weak(lvh_root)
+);
+/*******************************************************************/
+
+void be_load_lvh_root_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_lvh_root);
+    be_setglobal(vm, "lvh_root");
+    be_pop(vm, 1);
+}
 
 extern const bclass be_class_lvh_page;
 
@@ -531,2426 +1976,9 @@ void be_load_lvh_page_class(bvm *vm) {
 extern const bclass be_class_lvh_obj;
 
 /********************************************************************
-** Solidified function: set_text_rule_formula
+** Solidified function: set_hidden
 ********************************************************************/
-be_local_closure(lvh_obj_set_text_rule_formula,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule_formula),
-    /* K1   */  be_nested_str_weak(return_X20_X2F_X20val_X20_X2D_X3E_X20_X28),
-    /* K2   */  be_nested_str_weak(_X29),
-    /* K3   */  be_nested_str_weak(_text_rule_function),
-    /* K4   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20compile_X20_X27_X25s_X27_X20_X2D_X20_X25s_X20_X28_X25s_X29),
-    }),
-    be_str_weak(set_text_rule_formula),
-    &be_const_str_solidified,
-    ( &(const binstruction[29]) {  /* code */
-      0x60080008,  //  0000  GETGBL	R2	G8
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x000A0202,  //  0005  ADD	R2	K1	R2
-      0x00080502,  //  0006  ADD	R2	R2	K2
-      0xA8020007,  //  0007  EXBLK	0	#0010
-      0x600C000D,  //  0008  GETGBL	R3	G13
-      0x5C100400,  //  0009  MOVE	R4	R2
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x5C100600,  //  000B  MOVE	R4	R3
-      0x7C100000,  //  000C  CALL	R4	0
-      0x90020604,  //  000D  SETMBR	R0	K3	R4
-      0xA8040001,  //  000E  EXBLK	1	1
-      0x7002000B,  //  000F  JMP		#001C
-      0xAC0C0002,  //  0010  CATCH	R3	0	2
-      0x70020008,  //  0011  JMP		#001B
-      0x60140001,  //  0012  GETGBL	R5	G1
-      0x60180018,  //  0013  GETGBL	R6	G24
-      0x581C0004,  //  0014  LDCONST	R7	K4
-      0x5C200400,  //  0015  MOVE	R8	R2
-      0x5C240600,  //  0016  MOVE	R9	R3
-      0x5C280800,  //  0017  MOVE	R10	R4
-      0x7C180800,  //  0018  CALL	R6	4
-      0x7C140200,  //  0019  CALL	R5	1
-      0x70020000,  //  001A  JMP		#001C
-      0xB0080000,  //  001B  RAISE	2	R0	R0
-      0x80000000,  //  001C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pad_all
-********************************************************************/
-be_local_closure(lvh_obj_get_pad_all,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(get_pad_all),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_action
-********************************************************************/
-be_local_closure(lvh_obj_set_action,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_action),
-    }),
-    be_str_weak(set_action),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x60080008,  //  0000  GETGBL	R2	G8
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(lvh_obj_init,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_page),
-    /* K1   */  be_nested_str_weak(_lv_class),
-    /* K2   */  be_nested_str_weak(_lv_obj),
-    /* K3   */  be_nested_str_weak(post_init),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x90020002,  //  0000  SETMBR	R0	K0	R2
-      0x4C140000,  //  0001  LDNIL	R5
-      0x1C140805,  //  0002  EQ	R5	R4	R5
-      0x78160007,  //  0003  JMPF	R5	#000C
-      0x88140101,  //  0004  GETMBR	R5	R0	K1
-      0x78160005,  //  0005  JMPF	R5	#000C
-      0x88140101,  //  0006  GETMBR	R5	R0	K1
-      0x5C180A00,  //  0007  MOVE	R6	R5
-      0x5C1C0200,  //  0008  MOVE	R7	R1
-      0x7C180200,  //  0009  CALL	R6	1
-      0x90020406,  //  000A  SETMBR	R0	K2	R6
-      0x70020000,  //  000B  JMP		#000D
-      0x90020404,  //  000C  SETMBR	R0	K2	R4
-      0x8C140103,  //  000D  GETMET	R5	R0	K3
-      0x7C140200,  //  000E  CALL	R5	1
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_radius2
-********************************************************************/
-be_local_closure(lvh_obj_get_radius2,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_radius),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(get_radius2),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060007,  //  0003  JMPF	R1	#000C
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0xB8120600,  //  0007  GETNGBL	R4	K3
-      0x88100904,  //  0008  GETMBR	R4	R4	K4
-      0x300C0604,  //  0009  OR	R3	R3	R4
-      0x7C040400,  //  000A  CALL	R1	2
-      0x80040200,  //  000B  RET	1	R1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_text_font
-********************************************************************/
-be_local_closure(lvh_obj_set_text_font,   /* name */
-  be_nested_proto(
-    16,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_nested_str_weak(int),
-    /* K1   */  be_nested_str_weak(lv),
-    /* K2   */  be_nested_str_weak(font_embedded),
-    /* K3   */  be_nested_str_weak(robotocondensed),
-    /* K4   */  be_nested_str_weak(montserrat),
-    /* K5   */  be_nested_str_weak(string),
-    /* K6   */  be_nested_str_weak(re),
-    /* K7   */  be_nested_str_weak(split),
-    /* K8   */  be_nested_str_weak(_X3A),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(_X2D),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_const_int(2),
-    /* K13  */  be_nested_str_weak(concat),
-    /* K14  */  be_nested_str_weak(match),
-    /* K15  */  be_nested_str_weak(_X2E_X2A_X5C_X2Ettf_X24),
-    /* K16  */  be_nested_str_weak(load_freetype_font),
-    /* K17  */  be_nested_str_weak(load_font),
-    /* K18  */  be_nested_str_weak(_lv_obj),
-    /* K19  */  be_nested_str_weak(set_style_text_font),
-    /* K20  */  be_nested_str_weak(HSP_X3A_X20Unsupported_X20font_X3A),
-    }),
-    be_str_weak(set_text_font),
-    &be_const_str_solidified,
-    ( &(const binstruction[143]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x600C0004,  //  0001  GETGBL	R3	G4
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x1C0C0700,  //  0004  EQ	R3	R3	K0
-      0x780E001B,  //  0005  JMPF	R3	#0022
-      0xA8020007,  //  0006  EXBLK	0	#000F
-      0xB80E0200,  //  0007  GETNGBL	R3	K1
-      0x8C0C0702,  //  0008  GETMET	R3	R3	K2
-      0x58140003,  //  0009  LDCONST	R5	K3
-      0x5C180200,  //  000A  MOVE	R6	R1
-      0x7C0C0600,  //  000B  CALL	R3	3
-      0x5C080600,  //  000C  MOVE	R2	R3
-      0xA8040001,  //  000D  EXBLK	1	1
-      0x70020011,  //  000E  JMP		#0021
-      0xAC0C0000,  //  000F  CATCH	R3	0	0
-      0x7002000E,  //  0010  JMP		#0020
-      0xA8020007,  //  0011  EXBLK	0	#001A
-      0xB80E0200,  //  0012  GETNGBL	R3	K1
-      0x8C0C0702,  //  0013  GETMET	R3	R3	K2
-      0x58140004,  //  0014  LDCONST	R5	K4
-      0x5C180200,  //  0015  MOVE	R6	R1
-      0x7C0C0600,  //  0016  CALL	R3	3
-      0x5C080600,  //  0017  MOVE	R2	R3
-      0xA8040001,  //  0018  EXBLK	1	1
-      0x70020004,  //  0019  JMP		#001F
-      0xAC0C0000,  //  001A  CATCH	R3	0	0
-      0x70020001,  //  001B  JMP		#001E
-      0x80000600,  //  001C  RET	0
-      0x70020000,  //  001D  JMP		#001F
-      0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x70020000,  //  001F  JMP		#0021
-      0xB0080000,  //  0020  RAISE	2	R0	R0
-      0x7002005E,  //  0021  JMP		#0081
-      0x600C0004,  //  0022  GETGBL	R3	G4
-      0x5C100200,  //  0023  MOVE	R4	R1
-      0x7C0C0200,  //  0024  CALL	R3	1
-      0x1C0C0705,  //  0025  EQ	R3	R3	K5
-      0x780E0059,  //  0026  JMPF	R3	#0081
-      0xA40E0A00,  //  0027  IMPORT	R3	K5
-      0xA4120C00,  //  0028  IMPORT	R4	K6
-      0x8C140707,  //  0029  GETMET	R5	R3	K7
-      0x5C1C0200,  //  002A  MOVE	R7	R1
-      0x58200008,  //  002B  LDCONST	R8	K8
-      0x58240009,  //  002C  LDCONST	R9	K9
-      0x7C140800,  //  002D  CALL	R5	4
-      0x8C180707,  //  002E  GETMET	R6	R3	K7
-      0x5C200200,  //  002F  MOVE	R8	R1
-      0x5824000A,  //  0030  LDCONST	R9	K10
-      0x7C180600,  //  0031  CALL	R6	3
-      0x5C1C0200,  //  0032  MOVE	R7	R1
-      0x5820000B,  //  0033  LDCONST	R8	K11
-      0x50240000,  //  0034  LDBOOL	R9	0	0
-      0x6028000C,  //  0035  GETGBL	R10	G12
-      0x5C2C0A00,  //  0036  MOVE	R11	R5
-      0x7C280200,  //  0037  CALL	R10	1
-      0x24281509,  //  0038  GT	R10	R10	K9
-      0x782A0003,  //  0039  JMPF	R10	#003E
-      0x6028000C,  //  003A  GETGBL	R10	G12
-      0x942C0B0B,  //  003B  GETIDX	R11	R5	K11
-      0x7C280200,  //  003C  CALL	R10	1
-      0x742A0000,  //  003D  JMPT	R10	#003F
-      0x50280001,  //  003E  LDBOOL	R10	0	1
-      0x50280200,  //  003F  LDBOOL	R10	1	0
-      0x602C000C,  //  0040  GETGBL	R11	G12
-      0x5C300C00,  //  0041  MOVE	R12	R6
-      0x7C2C0200,  //  0042  CALL	R11	1
-      0x282C170C,  //  0043  GE	R11	R11	K12
-      0x782E000B,  //  0044  JMPF	R11	#0051
-      0x602C0009,  //  0045  GETGBL	R11	G9
-      0x5431FFFE,  //  0046  LDINT	R12	-1
-      0x94300C0C,  //  0047  GETIDX	R12	R6	R12
-      0x7C2C0200,  //  0048  CALL	R11	1
-      0x5C201600,  //  0049  MOVE	R8	R11
-      0x542DFFFD,  //  004A  LDINT	R11	-2
-      0x402E160B,  //  004B  CONNECT	R11	K11	R11
-      0x942C0C0B,  //  004C  GETIDX	R11	R6	R11
-      0x8C2C170D,  //  004D  GETMET	R11	R11	K13
-      0x5834000A,  //  004E  LDCONST	R13	K10
-      0x7C2C0400,  //  004F  CALL	R11	2
-      0x5C1C1600,  //  0050  MOVE	R7	R11
-      0x8C2C090E,  //  0051  GETMET	R11	R4	K14
-      0x5834000F,  //  0052  LDCONST	R13	K15
-      0x5C380E00,  //  0053  MOVE	R14	R7
-      0x7C2C0600,  //  0054  CALL	R11	3
-      0x782E0006,  //  0055  JMPF	R11	#005D
-      0x8C2C0707,  //  0056  GETMET	R11	R3	K7
-      0x5C340E00,  //  0057  MOVE	R13	R7
-      0x58380008,  //  0058  LDCONST	R14	K8
-      0x7C2C0600,  //  0059  CALL	R11	3
-      0x5431FFFE,  //  005A  LDINT	R12	-1
-      0x941C160C,  //  005B  GETIDX	R7	R11	R12
-      0x50240200,  //  005C  LDBOOL	R9	1	0
-      0x78260007,  //  005D  JMPF	R9	#0066
-      0xB82E0200,  //  005E  GETNGBL	R11	K1
-      0x8C2C1710,  //  005F  GETMET	R11	R11	K16
-      0x5C340E00,  //  0060  MOVE	R13	R7
-      0x5C381000,  //  0061  MOVE	R14	R8
-      0x583C000B,  //  0062  LDCONST	R15	K11
-      0x7C2C0800,  //  0063  CALL	R11	4
-      0x5C081600,  //  0064  MOVE	R2	R11
-      0x7002001A,  //  0065  JMP		#0081
-      0x782A0005,  //  0066  JMPF	R10	#006D
-      0xB82E0200,  //  0067  GETNGBL	R11	K1
-      0x8C2C1711,  //  0068  GETMET	R11	R11	K17
-      0x5C340200,  //  0069  MOVE	R13	R1
-      0x7C2C0400,  //  006A  CALL	R11	2
-      0x5C081600,  //  006B  MOVE	R2	R11
-      0x70020013,  //  006C  JMP		#0081
-      0x242C110B,  //  006D  GT	R11	R8	K11
-      0x782E0011,  //  006E  JMPF	R11	#0081
-      0x602C000C,  //  006F  GETGBL	R11	G12
-      0x5C300E00,  //  0070  MOVE	R12	R7
-      0x7C2C0200,  //  0071  CALL	R11	1
-      0x242C170B,  //  0072  GT	R11	R11	K11
-      0x782E000C,  //  0073  JMPF	R11	#0081
-      0xA8020007,  //  0074  EXBLK	0	#007D
-      0xB82E0200,  //  0075  GETNGBL	R11	K1
-      0x8C2C1702,  //  0076  GETMET	R11	R11	K2
-      0x5C340E00,  //  0077  MOVE	R13	R7
-      0x5C381000,  //  0078  MOVE	R14	R8
-      0x7C2C0600,  //  0079  CALL	R11	3
-      0x5C081600,  //  007A  MOVE	R2	R11
-      0xA8040001,  //  007B  EXBLK	1	1
-      0x70020003,  //  007C  JMP		#0081
-      0xAC2C0000,  //  007D  CATCH	R11	0	0
-      0x70020000,  //  007E  JMP		#0080
-      0x70020000,  //  007F  JMP		#0081
-      0xB0080000,  //  0080  RAISE	2	R0	R0
-      0x4C0C0000,  //  0081  LDNIL	R3
-      0x200C0403,  //  0082  NE	R3	R2	R3
-      0x780E0005,  //  0083  JMPF	R3	#008A
-      0x880C0112,  //  0084  GETMBR	R3	R0	K18
-      0x8C0C0713,  //  0085  GETMET	R3	R3	K19
-      0x5C140400,  //  0086  MOVE	R5	R2
-      0x5818000B,  //  0087  LDCONST	R6	K11
-      0x7C0C0600,  //  0088  CALL	R3	3
-      0x70020003,  //  0089  JMP		#008E
-      0x600C0001,  //  008A  GETGBL	R3	G1
-      0x58100014,  //  008B  LDCONST	R4	K20
-      0x5C140200,  //  008C  MOVE	R5	R1
-      0x7C0C0400,  //  008D  CALL	R3	2
-      0x80000000,  //  008E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_text
-********************************************************************/
-be_local_closure(lvh_obj_set_text,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(check_label),
-    /* K1   */  be_nested_str_weak(_lv_label),
-    /* K2   */  be_nested_str_weak(set_text),
-    }),
-    be_str_weak(set_text),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x7C080200,  //  0001  CALL	R2	1
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x8C080502,  //  0003  GETMET	R2	R2	K2
-      0x60100008,  //  0004  GETGBL	R4	G8
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x7C100200,  //  0006  CALL	R4	1
-      0x7C080400,  //  0007  CALL	R2	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_value_font
-********************************************************************/
-be_local_closure(lvh_obj_get_value_font,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_text_font),
-    }),
-    be_str_weak(get_value_font),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pad_right
-********************************************************************/
-be_local_closure(lvh_obj_get_pad_right,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_pad_right),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(get_pad_right),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060007,  //  0003  JMPF	R1	#000C
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0xB8120600,  //  0007  GETNGBL	R4	K3
-      0x88100904,  //  0008  GETMBR	R4	R4	K4
-      0x300C0604,  //  0009  OR	R3	R3	R4
-      0x7C040400,  //  000A  CALL	R1	2
-      0x80040200,  //  000B  RET	1	R1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pad_top
-********************************************************************/
-be_local_closure(lvh_obj_get_pad_top,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_pad_top),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(get_pad_top),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060007,  //  0003  JMPF	R1	#000C
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0xB8120600,  //  0007  GETNGBL	R4	K3
-      0x88100904,  //  0008  GETMBR	R4	R4	K4
-      0x300C0604,  //  0009  OR	R3	R3	R4
-      0x7C040400,  //  000A  CALL	R1	2
-      0x80040200,  //  000B  RET	1	R1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: check_label
-********************************************************************/
-be_local_closure(lvh_obj_check_label,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(lv),
-    /* K2   */  be_nested_str_weak(label),
-    /* K3   */  be_nested_str_weak(get_obj),
-    /* K4   */  be_nested_str_weak(set_align),
-    /* K5   */  be_nested_str_weak(ALIGN_CENTER),
-    }),
-    be_str_weak(check_label),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x7806000A,  //  0003  JMPF	R1	#000F
-      0xB8060200,  //  0004  GETNGBL	R1	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x8C0C0103,  //  0006  GETMET	R3	R0	K3
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x7C040400,  //  0008  CALL	R1	2
-      0x90020001,  //  0009  SETMBR	R0	K0	R1
-      0x88040100,  //  000A  GETMBR	R1	R0	K0
-      0x8C040304,  //  000B  GETMET	R1	R1	K4
-      0xB80E0200,  //  000C  GETNGBL	R3	K1
-      0x880C0705,  //  000D  GETMBR	R3	R3	K5
-      0x7C040400,  //  000E  CALL	R1	2
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_text_color
-********************************************************************/
-be_local_closure(lvh_obj_set_text_color,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_style_text_color),
-    /* K2   */  be_nested_str_weak(parse_color),
-    }),
-    be_str_weak(set_text_color),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x8C140102,  //  0002  GETMET	R5	R0	K2
-      0x5C1C0200,  //  0003  MOVE	R7	R1
-      0x7C140400,  //  0004  CALL	R5	2
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_value_color
-********************************************************************/
-be_local_closure(lvh_obj_set_value_color,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_text_color),
-    }),
-    be_str_weak(set_value_color),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_enabled
-********************************************************************/
-be_local_closure(lvh_obj_get_enabled,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(has_state),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(STATE_DISABLED),
-    }),
-    be_str_weak(get_enabled),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
-      0x7C040400,  //  0004  CALL	R1	2
-      0x78060000,  //  0005  JMPF	R1	#0007
-      0x50040001,  //  0006  LDBOOL	R1	0	1
-      0x50040200,  //  0007  LDBOOL	R1	1	0
-      0x80040200,  //  0008  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_toggle
-********************************************************************/
-be_local_closure(lvh_obj_get_toggle,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(has_state),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(STATE_CHECKED),
-    }),
-    be_str_weak(get_toggle),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_value_ofs_x
-********************************************************************/
-be_local_closure(lvh_obj_set_value_ofs_x,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(check_label),
-    /* K1   */  be_nested_str_weak(_lv_label),
-    /* K2   */  be_nested_str_weak(set_x),
-    }),
-    be_str_weak(set_value_ofs_x),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x7C080200,  //  0001  CALL	R2	1
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x8C080502,  //  0003  GETMET	R2	R2	K2
-      0x60100009,  //  0004  GETGBL	R4	G9
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x7C100200,  //  0006  CALL	R4	1
-      0x7C080400,  //  0007  CALL	R2	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_radius2
-********************************************************************/
-be_local_closure(lvh_obj_set_radius2,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_radius),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(set_radius2),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0009,  //  0003  JMPF	R2	#000E
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x60100009,  //  0006  GETGBL	R4	G9
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x7C100200,  //  0008  CALL	R4	1
-      0x88140100,  //  0009  GETMBR	R5	R0	K0
-      0xB81A0600,  //  000A  GETNGBL	R6	K3
-      0x88180D04,  //  000B  GETMBR	R6	R6	K4
-      0x30140A06,  //  000C  OR	R5	R5	R6
-      0x7C080600,  //  000D  CALL	R2	3
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_val
-********************************************************************/
-be_local_closure(lvh_obj_set_val,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_value),
-    }),
-    be_str_weak(set_val),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_text_rule
-********************************************************************/
-be_local_closure(lvh_obj_get_text_rule,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule),
-    }),
-    be_str_weak(get_text_rule),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_adjustable
-********************************************************************/
-be_local_closure(lvh_obj_get_adjustable,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(has_flag),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_CLICKABLE),
-    }),
-    be_str_weak(get_adjustable),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_text_color
-********************************************************************/
-be_local_closure(lvh_obj_get_text_color,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_style_text_color),
-    }),
-    be_str_weak(get_text_color),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_pad_top2
-********************************************************************/
-be_local_closure(lvh_obj_set_pad_top2,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_top),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(set_pad_top2),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0009,  //  0003  JMPF	R2	#000E
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x60100009,  //  0006  GETGBL	R4	G9
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x7C100200,  //  0008  CALL	R4	1
-      0x88140100,  //  0009  GETMBR	R5	R0	K0
-      0xB81A0600,  //  000A  GETNGBL	R6	K3
-      0x88180D04,  //  000B  GETMBR	R6	R6	K4
-      0x30140A06,  //  000C  OR	R5	R5	R6
-      0x7C080600,  //  000D  CALL	R2	3
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_val_rule
-********************************************************************/
-be_local_closure(lvh_obj_get_val_rule,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule),
-    }),
-    be_str_weak(get_val_rule),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_value_ofs_y
-********************************************************************/
-be_local_closure(lvh_obj_set_value_ofs_y,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(check_label),
-    /* K1   */  be_nested_str_weak(_lv_label),
-    /* K2   */  be_nested_str_weak(set_y),
-    }),
-    be_str_weak(set_value_ofs_y),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x7C080200,  //  0001  CALL	R2	1
-      0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x8C080502,  //  0003  GETMET	R2	R2	K2
-      0x60100009,  //  0004  GETGBL	R4	G9
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x7C100200,  //  0006  CALL	R4	1
-      0x7C080400,  //  0007  CALL	R2	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pad_left
-********************************************************************/
-be_local_closure(lvh_obj_get_pad_left,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_pad_left),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(get_pad_left),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060007,  //  0003  JMPF	R1	#000C
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0xB8120600,  //  0007  GETNGBL	R4	K3
-      0x88100904,  //  0008  GETMBR	R4	R4	K4
-      0x300C0604,  //  0009  OR	R3	R3	R4
-      0x7C040400,  //  000A  CALL	R1	2
-      0x80040200,  //  000B  RET	1	R1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: digits_to_style
-********************************************************************/
-be_local_closure(lvh_obj_digits_to_style,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(_digit2part),
-    /* K2   */  be_nested_str_weak(_digit2state),
-    /* K3   */  be_nested_str_weak(invalid_X20style_X20suffix_X20_X2502i),
-    /* K4   */  be_nested_str_weak(value_error),
-    }),
-    be_str_weak(digits_to_style),
-    &be_const_str_solidified,
-    ( &(const binstruction[44]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0x80060000,  //  0003  RET	1	K0
-      0x540A0009,  //  0004  LDINT	R2	10
-      0x0C080202,  //  0005  DIV	R2	R1	R2
-      0x540E0009,  //  0006  LDINT	R3	10
-      0x10080403,  //  0007  MOD	R2	R2	R3
-      0x540E0009,  //  0008  LDINT	R3	10
-      0x100C0203,  //  0009  MOD	R3	R1	R3
-      0x58100000,  //  000A  LDCONST	R4	K0
-      0x28140500,  //  000B  GE	R5	R2	K0
-      0x78160008,  //  000C  JMPF	R5	#0016
-      0x6014000C,  //  000D  GETGBL	R5	G12
-      0x88180101,  //  000E  GETMBR	R6	R0	K1
-      0x7C140200,  //  000F  CALL	R5	1
-      0x14140405,  //  0010  LT	R5	R2	R5
-      0x78160003,  //  0011  JMPF	R5	#0016
-      0x88140101,  //  0012  GETMBR	R5	R0	K1
-      0x94140A02,  //  0013  GETIDX	R5	R5	R2
-      0x30100805,  //  0014  OR	R4	R4	R5
-      0x70020000,  //  0015  JMP		#0017
-      0x4C100000,  //  0016  LDNIL	R4
-      0x28140700,  //  0017  GE	R5	R3	K0
-      0x78160008,  //  0018  JMPF	R5	#0022
-      0x6014000C,  //  0019  GETGBL	R5	G12
-      0x88180102,  //  001A  GETMBR	R6	R0	K2
-      0x7C140200,  //  001B  CALL	R5	1
-      0x14140605,  //  001C  LT	R5	R3	R5
-      0x78160003,  //  001D  JMPF	R5	#0022
-      0x88140102,  //  001E  GETMBR	R5	R0	K2
-      0x94140A03,  //  001F  GETIDX	R5	R5	R3
-      0x30100805,  //  0020  OR	R4	R4	R5
-      0x70020000,  //  0021  JMP		#0023
-      0x4C100000,  //  0022  LDNIL	R4
-      0x4C140000,  //  0023  LDNIL	R5
-      0x1C140805,  //  0024  EQ	R5	R4	R5
-      0x78160004,  //  0025  JMPF	R5	#002B
-      0x60140018,  //  0026  GETGBL	R5	G24
-      0x58180003,  //  0027  LDCONST	R6	K3
-      0x5C1C0200,  //  0028  MOVE	R7	R1
-      0x7C140400,  //  0029  CALL	R5	2
-      0xB0060805,  //  002A  RAISE	1	K4	R5
-      0x80040800,  //  002B  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_text
-********************************************************************/
-be_local_closure(lvh_obj_get_text,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(get_text),
-    }),
-    be_str_weak(get_text),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x78060001,  //  0003  JMPF	R1	#0006
-      0x4C040000,  //  0004  LDNIL	R1
-      0x80040200,  //  0005  RET	1	R1
-      0x88040100,  //  0006  GETMBR	R1	R0	K0
-      0x8C040301,  //  0007  GETMET	R1	R1	K1
-      0x7C040200,  //  0008  CALL	R1	1
-      0x80040200,  //  0009  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_line_width
-********************************************************************/
-be_local_closure(lvh_obj_set_line_width,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_style_line_width),
-    }),
-    be_str_weak(set_line_width),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x60140009,  //  0002  GETGBL	R5	G9
-      0x5C180200,  //  0003  MOVE	R6	R1
-      0x7C140200,  //  0004  CALL	R5	1
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C0C0600,  //  0006  CALL	R3	3
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_align
-********************************************************************/
-be_local_closure(lvh_obj_set_align,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(check_label),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(left),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(TEXT_ALIGN_LEFT),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(center),
-    /* K7   */  be_nested_str_weak(TEXT_ALIGN_CENTER),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(right),
-    /* K10  */  be_nested_str_weak(TEXT_ALIGN_RIGHT),
-    /* K11  */  be_nested_str_weak(_lv_label),
-    /* K12  */  be_nested_str_weak(set_style_text_align),
-    }),
-    be_str_weak(set_align),
-    &be_const_str_solidified,
-    ( &(const binstruction[29]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x8C0C0100,  //  0001  GETMET	R3	R0	K0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x1C0C0301,  //  0003  EQ	R3	R1	K1
-      0x740E0001,  //  0004  JMPT	R3	#0007
-      0x1C0C0302,  //  0005  EQ	R3	R1	K2
-      0x780E0002,  //  0006  JMPF	R3	#000A
-      0xB80E0600,  //  0007  GETNGBL	R3	K3
-      0x88080704,  //  0008  GETMBR	R2	R3	K4
-      0x7002000C,  //  0009  JMP		#0017
-      0x1C0C0305,  //  000A  EQ	R3	R1	K5
-      0x740E0001,  //  000B  JMPT	R3	#000E
-      0x1C0C0306,  //  000C  EQ	R3	R1	K6
-      0x780E0002,  //  000D  JMPF	R3	#0011
-      0xB80E0600,  //  000E  GETNGBL	R3	K3
-      0x88080707,  //  000F  GETMBR	R2	R3	K7
-      0x70020005,  //  0010  JMP		#0017
-      0x1C0C0308,  //  0011  EQ	R3	R1	K8
-      0x740E0001,  //  0012  JMPT	R3	#0015
-      0x1C0C0309,  //  0013  EQ	R3	R1	K9
-      0x780E0001,  //  0014  JMPF	R3	#0017
-      0xB80E0600,  //  0015  GETNGBL	R3	K3
-      0x8808070A,  //  0016  GETMBR	R2	R3	K10
-      0x880C010B,  //  0017  GETMBR	R3	R0	K11
-      0x8C0C070C,  //  0018  GETMET	R3	R3	K12
-      0x5C140400,  //  0019  MOVE	R5	R2
-      0x58180001,  //  001A  LDCONST	R6	K1
-      0x7C0C0600,  //  001B  CALL	R3	3
-      0x80000000,  //  001C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_obj
-********************************************************************/
-be_local_closure(lvh_obj_get_obj,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    }),
-    be_str_weak(get_obj),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_meta
-********************************************************************/
-be_local_closure(lvh_obj_set_meta,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_meta),
-    }),
-    be_str_weak(set_meta),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_val_rule
-********************************************************************/
-be_local_closure(lvh_obj_set_val_rule,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        1,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(val_rule_matched),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0x68040000,  //  0000  GETUPV	R1	U0
-          0x8C040300,  //  0001  GETMET	R1	R1	K0
-          0x5C0C0000,  //  0002  MOVE	R3	R0
-          0x7C040400,  //  0003  CALL	R1	2
-          0x80040200,  //  0004  RET	1	R1
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_val_rule),
-    /* K1   */  be_nested_str_weak(_val_rule),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(add_rule),
-    }),
-    be_str_weak(set_val_rule),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x7C080200,  //  0001  CALL	R2	1
-      0x60080008,  //  0002  GETGBL	R2	G8
-      0x5C0C0200,  //  0003  MOVE	R3	R1
-      0x7C080200,  //  0004  CALL	R2	1
-      0x90020202,  //  0005  SETMBR	R0	K1	R2
-      0xB80A0400,  //  0006  GETNGBL	R2	K2
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
-      0x88100101,  //  0008  GETMBR	R4	R0	K1
-      0x84140000,  //  0009  CLOSURE	R5	P0
-      0x5C180000,  //  000A  MOVE	R6	R0
-      0x7C080800,  //  000B  CALL	R2	4
-      0xA0000000,  //  000C  CLOSE	R0
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_value_str
-********************************************************************/
-be_local_closure(lvh_obj_get_value_str,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_text),
-    }),
-    be_str_weak(get_value_str),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_action
-********************************************************************/
-be_local_closure(lvh_obj_get_action,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_action),
-    /* K1   */  be_nested_str_weak(),
-    }),
-    be_str_weak(get_action),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060001,  //  0001  JMPF	R1	#0004
-      0x5C080200,  //  0002  MOVE	R2	R1
-      0x70020000,  //  0003  JMP		#0005
-      0x58080001,  //  0004  LDCONST	R2	K1
-      0x80040400,  //  0005  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_trailing_zeroes
-********************************************************************/
-be_local_closure(lvh_obj_remove_trailing_zeroes,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_lvh_obj),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_nested_str_weak(resize),
-    }),
-    be_str_weak(remove_trailing_zeroes),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C080200,  //  0003  CALL	R2	1
-      0x580C0001,  //  0004  LDCONST	R3	K1
-      0x14100602,  //  0005  LT	R4	R3	R2
-      0x78120007,  //  0006  JMPF	R4	#000F
-      0x5411FFFE,  //  0007  LDINT	R4	-1
-      0x04100803,  //  0008  SUB	R4	R4	R3
-      0x94100004,  //  0009  GETIDX	R4	R0	R4
-      0x20100901,  //  000A  NE	R4	R4	K1
-      0x78120000,  //  000B  JMPF	R4	#000D
-      0x70020001,  //  000C  JMP		#000F
-      0x000C0702,  //  000D  ADD	R3	R3	K2
-      0x7001FFF5,  //  000E  JMP		#0005
-      0x24100701,  //  000F  GT	R4	R3	K1
-      0x78120005,  //  0010  JMPF	R4	#0017
-      0x8C100103,  //  0011  GETMET	R4	R0	K3
-      0x6018000C,  //  0012  GETGBL	R6	G12
-      0x5C1C0000,  //  0013  MOVE	R7	R0
-      0x7C180200,  //  0014  CALL	R6	1
-      0x04180C03,  //  0015  SUB	R6	R6	R3
-      0x7C100400,  //  0016  CALL	R4	2
-      0x80040000,  //  0017  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_color
-********************************************************************/
-be_local_closure(lvh_obj_parse_color,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        10,                          /* nstack */
-        1,                          /* argc */
-        0,                          /* varg */
-        0,                          /* has upvals */
-        NULL,                       /* no upvals */
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[13]) {     /* constants */
-        /* K0   */  be_nested_str_weak(string),
-        /* K1   */  be_nested_str_weak(toupper),
-        /* K2   */  be_const_int(0),
-        /* K3   */  be_const_int(1),
-        /* K4   */  be_nested_str_weak(_X23),
-        /* K5   */  be_nested_str_weak(x),
-        /* K6   */  be_nested_str_weak(X),
-        /* K7   */  be_nested_str_weak(A),
-        /* K8   */  be_nested_str_weak(F),
-        /* K9   */  be_nested_str_weak(byte),
-        /* K10  */  be_nested_str_weak(0),
-        /* K11  */  be_nested_str_weak(9),
-        /* K12  */  be_nested_str_weak(stop_iteration),
-        }),
-        be_str_weak(parse_hex),
-        &be_const_str_solidified,
-        ( &(const binstruction[57]) {  /* code */
-          0xA4060000,  //  0000  IMPORT	R1	K0
-          0x8C080301,  //  0001  GETMET	R2	R1	K1
-          0x5C100000,  //  0002  MOVE	R4	R0
-          0x7C080400,  //  0003  CALL	R2	2
-          0x5C000400,  //  0004  MOVE	R0	R2
-          0x58080002,  //  0005  LDCONST	R2	K2
-          0x600C0010,  //  0006  GETGBL	R3	G16
-          0x6010000C,  //  0007  GETGBL	R4	G12
-          0x5C140000,  //  0008  MOVE	R5	R0
-          0x7C100200,  //  0009  CALL	R4	1
-          0x04100903,  //  000A  SUB	R4	R4	K3
-          0x40120404,  //  000B  CONNECT	R4	K2	R4
-          0x7C0C0200,  //  000C  CALL	R3	1
-          0xA8020026,  //  000D  EXBLK	0	#0035
-          0x5C100600,  //  000E  MOVE	R4	R3
-          0x7C100000,  //  000F  CALL	R4	0
-          0x94140004,  //  0010  GETIDX	R5	R0	R4
-          0x1C180B04,  //  0011  EQ	R6	R5	K4
-          0x781A0000,  //  0012  JMPF	R6	#0014
-          0x7001FFF9,  //  0013  JMP		#000E
-          0x1C180B05,  //  0014  EQ	R6	R5	K5
-          0x741A0001,  //  0015  JMPT	R6	#0018
-          0x1C180B06,  //  0016  EQ	R6	R5	K6
-          0x781A0000,  //  0017  JMPF	R6	#0019
-          0x7001FFF4,  //  0018  JMP		#000E
-          0x28180B07,  //  0019  GE	R6	R5	K7
-          0x781A000B,  //  001A  JMPF	R6	#0027
-          0x18180B08,  //  001B  LE	R6	R5	K8
-          0x781A0009,  //  001C  JMPF	R6	#0027
-          0x541A0003,  //  001D  LDINT	R6	4
-          0x38180406,  //  001E  SHL	R6	R2	R6
-          0x8C1C0309,  //  001F  GETMET	R7	R1	K9
-          0x5C240A00,  //  0020  MOVE	R9	R5
-          0x7C1C0400,  //  0021  CALL	R7	2
-          0x54220036,  //  0022  LDINT	R8	55
-          0x041C0E08,  //  0023  SUB	R7	R7	R8
-          0x30180C07,  //  0024  OR	R6	R6	R7
-          0x5C080C00,  //  0025  MOVE	R2	R6
-          0x7002000C,  //  0026  JMP		#0034
-          0x28180B0A,  //  0027  GE	R6	R5	K10
-          0x781A000A,  //  0028  JMPF	R6	#0034
-          0x18180B0B,  //  0029  LE	R6	R5	K11
-          0x781A0008,  //  002A  JMPF	R6	#0034
-          0x541A0003,  //  002B  LDINT	R6	4
-          0x38180406,  //  002C  SHL	R6	R2	R6
-          0x8C1C0309,  //  002D  GETMET	R7	R1	K9
-          0x5C240A00,  //  002E  MOVE	R9	R5
-          0x7C1C0400,  //  002F  CALL	R7	2
-          0x5422002F,  //  0030  LDINT	R8	48
-          0x041C0E08,  //  0031  SUB	R7	R7	R8
-          0x30180C07,  //  0032  OR	R6	R6	R7
-          0x5C080C00,  //  0033  MOVE	R2	R6
-          0x7001FFD8,  //  0034  JMP		#000E
-          0x580C000C,  //  0035  LDCONST	R3	K12
-          0xAC0C0200,  //  0036  CATCH	R3	1	0
-          0xB0080000,  //  0037  RAISE	2	R0	R0
-          0x80040400,  //  0038  RET	1	R2
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_const_class(be_class_lvh_obj),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(_X23),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(color),
-    /* K5   */  be_nested_str_weak(string),
-    /* K6   */  be_nested_str_weak(introspect),
-    /* K7   */  be_nested_str_weak(COLOR_),
-    /* K8   */  be_nested_str_weak(toupper),
-    /* K9   */  be_nested_str_weak(get),
-    }),
-    be_str_weak(parse_color),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x84080000,  //  0001  CLOSURE	R2	P0
-      0x600C0008,  //  0002  GETGBL	R3	G8
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x5C000600,  //  0005  MOVE	R0	R3
-      0x940C0101,  //  0006  GETIDX	R3	R0	K1
-      0x1C0C0702,  //  0007  EQ	R3	R3	K2
-      0x780E0007,  //  0008  JMPF	R3	#0011
-      0xB80E0600,  //  0009  GETNGBL	R3	K3
-      0x8C0C0704,  //  000A  GETMET	R3	R3	K4
-      0x5C140400,  //  000B  MOVE	R5	R2
-      0x5C180000,  //  000C  MOVE	R6	R0
-      0x7C140200,  //  000D  CALL	R5	1
-      0x7C0C0400,  //  000E  CALL	R3	2
-      0x80040600,  //  000F  RET	1	R3
-      0x70020011,  //  0010  JMP		#0023
-      0xA40E0A00,  //  0011  IMPORT	R3	K5
-      0xA4120C00,  //  0012  IMPORT	R4	K6
-      0x8C140708,  //  0013  GETMET	R5	R3	K8
-      0x5C1C0000,  //  0014  MOVE	R7	R0
-      0x7C140400,  //  0015  CALL	R5	2
-      0x00160E05,  //  0016  ADD	R5	K7	R5
-      0x8C180909,  //  0017  GETMET	R6	R4	K9
-      0xB8220600,  //  0018  GETNGBL	R8	K3
-      0x5C240A00,  //  0019  MOVE	R9	R5
-      0x7C180600,  //  001A  CALL	R6	3
-      0x4C1C0000,  //  001B  LDNIL	R7
-      0x201C0C07,  //  001C  NE	R7	R6	R7
-      0x781E0004,  //  001D  JMPF	R7	#0023
-      0xB81E0600,  //  001E  GETNGBL	R7	K3
-      0x8C1C0F04,  //  001F  GETMET	R7	R7	K4
-      0x5C240C00,  //  0020  MOVE	R9	R6
-      0x7C1C0400,  //  0021  CALL	R7	2
-      0x80040E00,  //  0022  RET	1	R7
-      0xB80E0600,  //  0023  GETNGBL	R3	K3
-      0x8C0C0704,  //  0024  GETMET	R3	R3	K4
-      0x58140001,  //  0025  LDCONST	R5	K1
-      0x7C0C0400,  //  0026  CALL	R3	2
-      0x80040600,  //  0027  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_event_cb
-********************************************************************/
-be_local_closure(lvh_obj_register_event_cb,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_page),
-    /* K1   */  be_nested_str_weak(_oh),
-    /* K2   */  be_nested_str_weak(_event_map),
-    /* K3   */  be_nested_str_weak(keys),
-    /* K4   */  be_nested_str_weak(register_event),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(register_event_cb),
-    &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x60080010,  //  0002  GETGBL	R2	G16
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0004  GETMET	R3	R3	K3
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x7C080200,  //  0006  CALL	R2	1
-      0xA8020006,  //  0007  EXBLK	0	#000F
-      0x5C0C0400,  //  0008  MOVE	R3	R2
-      0x7C0C0000,  //  0009  CALL	R3	0
-      0x8C100304,  //  000A  GETMET	R4	R1	K4
-      0x5C180000,  //  000B  MOVE	R6	R0
-      0x5C1C0600,  //  000C  MOVE	R7	R3
-      0x7C100600,  //  000D  CALL	R4	3
-      0x7001FFF8,  //  000E  JMP		#0008
-      0x58080005,  //  000F  LDCONST	R2	K5
-      0xAC080200,  //  0010  CATCH	R2	1	0
-      0xB0080000,  //  0011  RAISE	2	R0	R0
-      0x80000000,  //  0012  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: member
-********************************************************************/
-be_local_closure(lvh_obj_member,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_const_int(3),
-    /* K4   */  be_nested_str_weak(set_),
-    /* K5   */  be_nested_str_weak(get_),
-    /* K6   */  be_nested_str_weak(byte),
-    /* K7   */  be_const_int(2147483647),
-    /* K8   */  be_nested_str_weak(digits_to_style),
-    /* K9   */  be_nested_str_weak(_attr_ignore),
-    /* K10  */  be_nested_str_weak(find),
-    /* K11  */  be_nested_str_weak(get),
-    /* K12  */  be_nested_str_weak(function),
-    /* K13  */  be_nested_str_weak(_attr_map),
-    /* K14  */  be_nested_str_weak(contains),
-    /* K15  */  be_nested_str_weak(_lv_obj),
-    /* K16  */  be_nested_str_weak(style_),
-    /* K17  */  be_nested_str_weak(undefined),
-    }),
-    be_str_weak(member),
-    &be_const_str_solidified,
-    ( &(const binstruction[122]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0x40120503,  //  0002  CONNECT	R4	K2	K3
-      0x94100204,  //  0003  GETIDX	R4	R1	R4
-      0x1C140904,  //  0004  EQ	R5	R4	K4
-      0x74160001,  //  0005  JMPT	R5	#0008
-      0x1C140905,  //  0006  EQ	R5	R4	K5
-      0x78160000,  //  0007  JMPF	R5	#0009
-      0x80000A00,  //  0008  RET	0
-      0x58140002,  //  0009  LDCONST	R5	K2
-      0x6018000C,  //  000A  GETGBL	R6	G12
-      0x5C1C0200,  //  000B  MOVE	R7	R1
-      0x7C180200,  //  000C  CALL	R6	1
-      0x28180D03,  //  000D  GE	R6	R6	K3
-      0x781A0021,  //  000E  JMPF	R6	#0031
-      0x8C180506,  //  000F  GETMET	R6	R2	K6
-      0x5421FFFE,  //  0010  LDINT	R8	-1
-      0x94200208,  //  0011  GETIDX	R8	R1	R8
-      0x7C180400,  //  0012  CALL	R6	2
-      0x8C1C0506,  //  0013  GETMET	R7	R2	K6
-      0x5425FFFD,  //  0014  LDINT	R9	-2
-      0x94240209,  //  0015  GETIDX	R9	R1	R9
-      0x7C1C0400,  //  0016  CALL	R7	2
-      0x4C200000,  //  0017  LDNIL	R8
-      0x5426002F,  //  0018  LDINT	R9	48
-      0x28240C09,  //  0019  GE	R9	R6	R9
-      0x78260011,  //  001A  JMPF	R9	#002D
-      0x54260038,  //  001B  LDINT	R9	57
-      0x18240C09,  //  001C  LE	R9	R6	R9
-      0x7826000E,  //  001D  JMPF	R9	#002D
-      0x5426002F,  //  001E  LDINT	R9	48
-      0x28240E09,  //  001F  GE	R9	R7	R9
-      0x7826000B,  //  0020  JMPF	R9	#002D
-      0x54260038,  //  0021  LDINT	R9	57
-      0x18240E09,  //  0022  LE	R9	R7	R9
-      0x78260008,  //  0023  JMPF	R9	#002D
-      0x60240009,  //  0024  GETGBL	R9	G9
-      0x5429FFFD,  //  0025  LDINT	R10	-2
-      0x40281507,  //  0026  CONNECT	R10	R10	K7
-      0x9428020A,  //  0027  GETIDX	R10	R1	R10
-      0x7C240200,  //  0028  CALL	R9	1
-      0x5C201200,  //  0029  MOVE	R8	R9
-      0x5425FFFC,  //  002A  LDINT	R9	-3
-      0x40260409,  //  002B  CONNECT	R9	K2	R9
-      0x94040209,  //  002C  GETIDX	R1	R1	R9
-      0x8C240108,  //  002D  GETMET	R9	R0	K8
-      0x5C2C1000,  //  002E  MOVE	R11	R8
-      0x7C240400,  //  002F  CALL	R9	2
-      0x5C141200,  //  0030  MOVE	R5	R9
-      0x88180109,  //  0031  GETMBR	R6	R0	K9
-      0x8C180D0A,  //  0032  GETMET	R6	R6	K10
-      0x5C200200,  //  0033  MOVE	R8	R1
-      0x7C180400,  //  0034  CALL	R6	2
-      0x4C1C0000,  //  0035  LDNIL	R7
-      0x20180C07,  //  0036  NE	R6	R6	R7
-      0x781A0000,  //  0037  JMPF	R6	#0039
-      0x80000C00,  //  0038  RET	0
-      0x8C18070B,  //  0039  GETMET	R6	R3	K11
-      0x5C200000,  //  003A  MOVE	R8	R0
-      0x00260A01,  //  003B  ADD	R9	K5	R1
-      0x7C180600,  //  003C  CALL	R6	3
-      0x601C0004,  //  003D  GETGBL	R7	G4
-      0x5C200C00,  //  003E  MOVE	R8	R6
-      0x7C1C0200,  //  003F  CALL	R7	1
-      0x1C1C0F0C,  //  0040  EQ	R7	R7	K12
-      0x781E0004,  //  0041  JMPF	R7	#0047
-      0x5C1C0C00,  //  0042  MOVE	R7	R6
-      0x5C200000,  //  0043  MOVE	R8	R0
-      0x5C240A00,  //  0044  MOVE	R9	R5
-      0x7C1C0400,  //  0045  CALL	R7	2
-      0x80040E00,  //  0046  RET	1	R7
-      0x881C010D,  //  0047  GETMBR	R7	R0	K13
-      0x8C1C0F0E,  //  0048  GETMET	R7	R7	K14
-      0x5C240200,  //  0049  MOVE	R9	R1
-      0x7C1C0400,  //  004A  CALL	R7	2
-      0x781E001B,  //  004B  JMPF	R7	#0068
-      0x881C010D,  //  004C  GETMBR	R7	R0	K13
-      0x941C0E01,  //  004D  GETIDX	R7	R7	R1
-      0x8C20070B,  //  004E  GETMET	R8	R3	K11
-      0x8828010F,  //  004F  GETMBR	R10	R0	K15
-      0x002E0A07,  //  0050  ADD	R11	K5	R7
-      0x7C200600,  //  0051  CALL	R8	3
-      0x5C181000,  //  0052  MOVE	R6	R8
-      0x60200004,  //  0053  GETGBL	R8	G4
-      0x5C240C00,  //  0054  MOVE	R9	R6
-      0x7C200200,  //  0055  CALL	R8	1
-      0x1C20110C,  //  0056  EQ	R8	R8	K12
-      0x7822000F,  //  0057  JMPF	R8	#0068
-      0x8C20050A,  //  0058  GETMET	R8	R2	K10
-      0x5C280E00,  //  0059  MOVE	R10	R7
-      0x582C0010,  //  005A  LDCONST	R11	K16
-      0x7C200600,  //  005B  CALL	R8	3
-      0x1C201102,  //  005C  EQ	R8	R8	K2
-      0x78220005,  //  005D  JMPF	R8	#0064
-      0x5C200C00,  //  005E  MOVE	R8	R6
-      0x8824010F,  //  005F  GETMBR	R9	R0	K15
-      0x5C280A00,  //  0060  MOVE	R10	R5
-      0x7C200400,  //  0061  CALL	R8	2
-      0x80041000,  //  0062  RET	1	R8
-      0x70020003,  //  0063  JMP		#0068
-      0x5C200C00,  //  0064  MOVE	R8	R6
-      0x8824010F,  //  0065  GETMBR	R9	R0	K15
-      0x7C200200,  //  0066  CALL	R8	1
-      0x80041000,  //  0067  RET	1	R8
-      0x8C1C070B,  //  0068  GETMET	R7	R3	K11
-      0x8824010F,  //  0069  GETMBR	R9	R0	K15
-      0x002A0A01,  //  006A  ADD	R10	K5	R1
-      0x7C1C0600,  //  006B  CALL	R7	3
-      0x5C180E00,  //  006C  MOVE	R6	R7
-      0x601C0004,  //  006D  GETGBL	R7	G4
-      0x5C200C00,  //  006E  MOVE	R8	R6
-      0x7C1C0200,  //  006F  CALL	R7	1
-      0x1C1C0F0C,  //  0070  EQ	R7	R7	K12
-      0x781E0003,  //  0071  JMPF	R7	#0076
-      0x5C1C0C00,  //  0072  MOVE	R7	R6
-      0x8820010F,  //  0073  GETMBR	R8	R0	K15
-      0x7C1C0200,  //  0074  CALL	R7	1
-      0x80040E00,  //  0075  RET	1	R7
-      0x601C000B,  //  0076  GETGBL	R7	G11
-      0x58200011,  //  0077  LDCONST	R8	K17
-      0x7C1C0200,  //  0078  CALL	R7	1
-      0x80040E00,  //  0079  RET	1	R7
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_text_rule
-********************************************************************/
-be_local_closure(lvh_obj_remove_text_rule,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(remove_rule),
-    }),
-    be_str_weak(remove_text_rule),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060004,  //  0003  JMPF	R1	#0009
-      0xB8060200,  //  0004  GETNGBL	R1	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x5C100000,  //  0007  MOVE	R4	R0
-      0x7C040600,  //  0008  CALL	R1	3
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_val_rule_formula
-********************************************************************/
-be_local_closure(lvh_obj_set_val_rule_formula,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule_formula),
-    /* K1   */  be_nested_str_weak(return_X20_X2F_X20val_X20_X2D_X3E_X20_X28),
-    /* K2   */  be_nested_str_weak(_X29),
-    /* K3   */  be_nested_str_weak(_val_rule_function),
-    /* K4   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20compile_X20_X27_X25s_X27_X20_X2D_X20_X25s_X20_X28_X25s_X29),
-    }),
-    be_str_weak(set_val_rule_formula),
-    &be_const_str_solidified,
-    ( &(const binstruction[29]) {  /* code */
-      0x60080008,  //  0000  GETGBL	R2	G8
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x000A0202,  //  0005  ADD	R2	K1	R2
-      0x00080502,  //  0006  ADD	R2	R2	K2
-      0xA8020007,  //  0007  EXBLK	0	#0010
-      0x600C000D,  //  0008  GETGBL	R3	G13
-      0x5C100400,  //  0009  MOVE	R4	R2
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x5C100600,  //  000B  MOVE	R4	R3
-      0x7C100000,  //  000C  CALL	R4	0
-      0x90020604,  //  000D  SETMBR	R0	K3	R4
-      0xA8040001,  //  000E  EXBLK	1	1
-      0x7002000B,  //  000F  JMP		#001C
-      0xAC0C0002,  //  0010  CATCH	R3	0	2
-      0x70020008,  //  0011  JMP		#001B
-      0x60140001,  //  0012  GETGBL	R5	G1
-      0x60180018,  //  0013  GETGBL	R6	G24
-      0x581C0004,  //  0014  LDCONST	R7	K4
-      0x5C200400,  //  0015  MOVE	R8	R2
-      0x5C240600,  //  0016  MOVE	R9	R3
-      0x5C280800,  //  0017  MOVE	R10	R4
-      0x7C180800,  //  0018  CALL	R6	4
-      0x7C140200,  //  0019  CALL	R5	1
-      0x70020000,  //  001A  JMP		#001C
-      0xB0080000,  //  001B  RAISE	2	R0	R0
-      0x80000000,  //  001C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_text_rule
-********************************************************************/
-be_local_closure(lvh_obj_set_text_rule,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        1,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(text_rule_matched),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0x68040000,  //  0000  GETUPV	R1	U0
-          0x8C040300,  //  0001  GETMET	R1	R1	K0
-          0x5C0C0000,  //  0002  MOVE	R3	R0
-          0x7C040400,  //  0003  CALL	R1	2
-          0x80040200,  //  0004  RET	1	R1
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_text_rule),
-    /* K1   */  be_nested_str_weak(_text_rule),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(add_rule),
-    }),
-    be_str_weak(set_text_rule),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x7C080200,  //  0001  CALL	R2	1
-      0x60080008,  //  0002  GETGBL	R2	G8
-      0x5C0C0200,  //  0003  MOVE	R3	R1
-      0x7C080200,  //  0004  CALL	R2	1
-      0x90020202,  //  0005  SETMBR	R0	K1	R2
-      0xB80A0400,  //  0006  GETNGBL	R2	K2
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
-      0x88100101,  //  0008  GETMBR	R4	R0	K1
-      0x84140000,  //  0009  CLOSURE	R5	P0
-      0x5C180000,  //  000A  MOVE	R6	R0
-      0x7C080800,  //  000B  CALL	R2	4
-      0xA0000000,  //  000C  CLOSE	R0
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_delete
-********************************************************************/
-be_local_closure(lvh_obj_get_delete,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_val_rule),
-    /* K1   */  be_nested_str_weak(remove_text_rule),
-    /* K2   */  be_nested_str_weak(_lv_label),
-    /* K3   */  be_nested_str_weak(del),
-    /* K4   */  be_nested_str_weak(_lv_obj),
-    /* K5   */  be_nested_str_weak(_page),
-    /* K6   */  be_nested_str_weak(remove_obj),
-    /* K7   */  be_nested_str_weak(id),
-    }),
-    be_str_weak(get_delete),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
-      0x7C040200,  //  0003  CALL	R1	1
-      0x88040102,  //  0004  GETMBR	R1	R0	K2
-      0x78060004,  //  0005  JMPF	R1	#000B
-      0x88040102,  //  0006  GETMBR	R1	R0	K2
-      0x8C040303,  //  0007  GETMET	R1	R1	K3
-      0x7C040200,  //  0008  CALL	R1	1
-      0x4C040000,  //  0009  LDNIL	R1
-      0x90020401,  //  000A  SETMBR	R0	K2	R1
-      0x88040104,  //  000B  GETMBR	R1	R0	K4
-      0x78060004,  //  000C  JMPF	R1	#0012
-      0x88040104,  //  000D  GETMBR	R1	R0	K4
-      0x8C040303,  //  000E  GETMET	R1	R1	K3
-      0x7C040200,  //  000F  CALL	R1	1
-      0x4C040000,  //  0010  LDNIL	R1
-      0x90020801,  //  0011  SETMBR	R0	K4	R1
-      0x88040105,  //  0012  GETMBR	R1	R0	K5
-      0x8C040306,  //  0013  GETMET	R1	R1	K6
-      0x880C0107,  //  0014  GETMBR	R3	R0	K7
-      0x7C040400,  //  0015  CALL	R1	2
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_line_width
-********************************************************************/
-be_local_closure(lvh_obj_get_line_width,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_style_line_width),
-    }),
-    be_str_weak(get_line_width),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_text_rule_formula
-********************************************************************/
-be_local_closure(lvh_obj_get_text_rule_formula,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule_formula),
-    }),
-    be_str_weak(get_text_rule_formula),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: post_init
-********************************************************************/
-be_local_closure(lvh_obj_post_init,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(register_event_cb),
-    }),
-    be_str_weak(post_init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_enabled
-********************************************************************/
-be_local_closure(lvh_obj_set_enabled,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(clear_state),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(STATE_DISABLED),
-    /* K4   */  be_nested_str_weak(add_state),
-    }),
-    be_str_weak(set_enabled),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x78060005,  //  0000  JMPF	R1	#0007
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0xB8120400,  //  0003  GETNGBL	R4	K2
-      0x88100903,  //  0004  GETMBR	R4	R4	K3
-      0x7C080400,  //  0005  CALL	R2	2
-      0x70020004,  //  0006  JMP		#000C
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x8C080504,  //  0008  GETMET	R2	R2	K4
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x88100903,  //  000A  GETMBR	R4	R4	K3
-      0x7C080400,  //  000B  CALL	R2	2
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_val
-********************************************************************/
-be_local_closure(lvh_obj_get_val,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_value),
-    }),
-    be_str_weak(get_val),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_mode
-********************************************************************/
-be_local_closure(lvh_obj_get_mode,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(get_mode),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: val_rule_matched
-********************************************************************/
-be_local_closure(lvh_obj_val_rule_matched,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule_function),
-    /* K1   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20run_X20self_X2E_val_rule_function_X20_X2D_X20_X25s_X20_X28_X25s_X29),
-    /* K2   */  be_nested_str_weak(val),
-    }),
-    be_str_weak(val_rule_matched),
-    &be_const_str_solidified,
-    ( &(const binstruction[36]) {  /* code */
-      0x6008000A,  //  0000  GETGBL	R2	G10
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0403,  //  0004  EQ	R3	R2	R3
-      0x780E0001,  //  0005  JMPF	R3	#0008
-      0x500C0000,  //  0006  LDBOOL	R3	0	0
-      0x80040600,  //  0007  RET	1	R3
-      0x880C0100,  //  0008  GETMBR	R3	R0	K0
-      0x4C100000,  //  0009  LDNIL	R4
-      0x20100604,  //  000A  NE	R4	R3	R4
-      0x78120011,  //  000B  JMPF	R4	#001E
-      0xA8020005,  //  000C  EXBLK	0	#0013
-      0x5C100600,  //  000D  MOVE	R4	R3
-      0x5C140400,  //  000E  MOVE	R5	R2
-      0x7C100200,  //  000F  CALL	R4	1
-      0x5C080800,  //  0010  MOVE	R2	R4
-      0xA8040001,  //  0011  EXBLK	1	1
-      0x7002000A,  //  0012  JMP		#001E
-      0xAC100002,  //  0013  CATCH	R4	0	2
-      0x70020007,  //  0014  JMP		#001D
-      0x60180001,  //  0015  GETGBL	R6	G1
-      0x601C0018,  //  0016  GETGBL	R7	G24
-      0x58200001,  //  0017  LDCONST	R8	K1
-      0x5C240800,  //  0018  MOVE	R9	R4
-      0x5C280A00,  //  0019  MOVE	R10	R5
-      0x7C1C0600,  //  001A  CALL	R7	3
-      0x7C180200,  //  001B  CALL	R6	1
-      0x70020000,  //  001C  JMP		#001E
-      0xB0080000,  //  001D  RAISE	2	R0	R0
-      0x60100009,  //  001E  GETGBL	R4	G9
-      0x5C140400,  //  001F  MOVE	R5	R2
-      0x7C100200,  //  0020  CALL	R4	1
-      0x90020404,  //  0021  SETMBR	R0	K2	R4
-      0x50100000,  //  0022  LDBOOL	R4	0	0
-      0x80040800,  //  0023  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_pad_all2
-********************************************************************/
-be_local_closure(lvh_obj_set_pad_all2,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_all),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(set_pad_all2),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0009,  //  0003  JMPF	R2	#000E
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x60100009,  //  0006  GETGBL	R4	G9
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x7C100200,  //  0008  CALL	R4	1
-      0x88140100,  //  0009  GETMBR	R5	R0	K0
-      0xB81A0600,  //  000A  GETNGBL	R6	K3
-      0x88180D04,  //  000B  GETMBR	R6	R6	K4
-      0x30140A06,  //  000C  OR	R5	R5	R6
-      0x7C080600,  //  000D  CALL	R2	3
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_value_color
-********************************************************************/
-be_local_closure(lvh_obj_get_value_color,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_value_color),
-    }),
-    be_str_weak(get_value_color),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_adjustable
-********************************************************************/
-be_local_closure(lvh_obj_set_adjustable,   /* name */
+be_local_closure(lvh_obj_set_hidden,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
@@ -2964,10 +1992,10 @@ be_local_closure(lvh_obj_set_adjustable,   /* name */
     /* K0   */  be_nested_str_weak(_lv_obj),
     /* K1   */  be_nested_str_weak(add_flag),
     /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_CLICKABLE),
+    /* K3   */  be_nested_str_weak(OBJ_FLAG_HIDDEN),
     /* K4   */  be_nested_str_weak(clear_flag),
     }),
-    be_str_weak(set_adjustable),
+    be_str_weak(set_hidden),
     &be_const_str_solidified,
     ( &(const binstruction[13]) {  /* code */
       0x78060005,  //  0000  JMPF	R1	#0007
@@ -2983,816 +2011,6 @@ be_local_closure(lvh_obj_set_adjustable,   /* name */
       0x88100903,  //  000A  GETMBR	R4	R4	K3
       0x7C080400,  //  000B  CALL	R2	2
       0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_toggle
-********************************************************************/
-be_local_closure(lvh_obj_set_toggle,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(toupper),
-    /* K2   */  be_nested_str_weak(TRUE),
-    /* K3   */  be_nested_str_weak(FALSE),
-    /* K4   */  be_nested_str_weak(_lv_obj),
-    /* K5   */  be_nested_str_weak(add_state),
-    /* K6   */  be_nested_str_weak(lv),
-    /* K7   */  be_nested_str_weak(STATE_CHECKED),
-    /* K8   */  be_nested_str_weak(clear_state),
-    }),
-    be_str_weak(set_toggle),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x600C0004,  //  0001  GETGBL	R3	G4
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x1C0C0700,  //  0004  EQ	R3	R3	K0
-      0x780E000C,  //  0005  JMPF	R3	#0013
-      0x8C0C0501,  //  0006  GETMET	R3	R2	K1
-      0x60140008,  //  0007  GETGBL	R5	G8
-      0x5C180200,  //  0008  MOVE	R6	R1
-      0x7C140200,  //  0009  CALL	R5	1
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x5C040600,  //  000B  MOVE	R1	R3
-      0x1C0C0302,  //  000C  EQ	R3	R1	K2
-      0x780E0001,  //  000D  JMPF	R3	#0010
-      0x50040200,  //  000E  LDBOOL	R1	1	0
-      0x70020002,  //  000F  JMP		#0013
-      0x1C0C0303,  //  0010  EQ	R3	R1	K3
-      0x780E0000,  //  0011  JMPF	R3	#0013
-      0x50040000,  //  0012  LDBOOL	R1	0	0
-      0x78060005,  //  0013  JMPF	R1	#001A
-      0x880C0104,  //  0014  GETMBR	R3	R0	K4
-      0x8C0C0705,  //  0015  GETMET	R3	R3	K5
-      0xB8160C00,  //  0016  GETNGBL	R5	K6
-      0x88140B07,  //  0017  GETMBR	R5	R5	K7
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x70020004,  //  0019  JMP		#001F
-      0x880C0104,  //  001A  GETMBR	R3	R0	K4
-      0x8C0C0708,  //  001B  GETMET	R3	R3	K8
-      0xB8160C00,  //  001C  GETNGBL	R5	K6
-      0x88140B07,  //  001D  GETMBR	R5	R5	K7
-      0x7C0C0400,  //  001E  CALL	R3	2
-      0x80000000,  //  001F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: text_rule_matched
-********************************************************************/
-be_local_closure(lvh_obj_text_rule_matched,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(int),
-    /* K1   */  be_nested_str_weak(_text_rule_function),
-    /* K2   */  be_nested_str_weak(HSP_X3A_X20failed_X20to_X20run_X20self_X2E_text_rule_function_X20_X2D_X20_X25s_X20_X28_X25s_X29),
-    /* K3   */  be_nested_str_weak(_text_rule_format),
-    /* K4   */  be_nested_str_weak(string),
-    /* K5   */  be_nested_str_weak(),
-    /* K6   */  be_nested_str_weak(text),
-    }),
-    be_str_weak(text_rule_matched),
-    &be_const_str_solidified,
-    ( &(const binstruction[47]) {  /* code */
-      0x60080004,  //  0000  GETGBL	R2	G4
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x1C080500,  //  0003  EQ	R2	R2	K0
-      0x780A0003,  //  0004  JMPF	R2	#0009
-      0x6008000A,  //  0005  GETGBL	R2	G10
-      0x5C0C0200,  //  0006  MOVE	R3	R1
-      0x7C080200,  //  0007  CALL	R2	1
-      0x5C040400,  //  0008  MOVE	R1	R2
-      0x88080101,  //  0009  GETMBR	R2	R0	K1
-      0x4C0C0000,  //  000A  LDNIL	R3
-      0x200C0403,  //  000B  NE	R3	R2	R3
-      0x780E0011,  //  000C  JMPF	R3	#001F
-      0xA8020005,  //  000D  EXBLK	0	#0014
-      0x5C0C0400,  //  000E  MOVE	R3	R2
-      0x5C100200,  //  000F  MOVE	R4	R1
-      0x7C0C0200,  //  0010  CALL	R3	1
-      0x5C040600,  //  0011  MOVE	R1	R3
-      0xA8040001,  //  0012  EXBLK	1	1
-      0x7002000A,  //  0013  JMP		#001F
-      0xAC0C0002,  //  0014  CATCH	R3	0	2
-      0x70020007,  //  0015  JMP		#001E
-      0x60140001,  //  0016  GETGBL	R5	G1
-      0x60180018,  //  0017  GETGBL	R6	G24
-      0x581C0002,  //  0018  LDCONST	R7	K2
-      0x5C200600,  //  0019  MOVE	R8	R3
-      0x5C240800,  //  001A  MOVE	R9	R4
-      0x7C180600,  //  001B  CALL	R6	3
-      0x7C140200,  //  001C  CALL	R5	1
-      0x70020000,  //  001D  JMP		#001F
-      0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x880C0103,  //  001F  GETMBR	R3	R0	K3
-      0x60100004,  //  0020  GETGBL	R4	G4
-      0x5C140600,  //  0021  MOVE	R5	R3
-      0x7C100200,  //  0022  CALL	R4	1
-      0x1C100904,  //  0023  EQ	R4	R4	K4
-      0x78120005,  //  0024  JMPF	R4	#002B
-      0x60100018,  //  0025  GETGBL	R4	G24
-      0x5C140600,  //  0026  MOVE	R5	R3
-      0x5C180200,  //  0027  MOVE	R6	R1
-      0x7C100400,  //  0028  CALL	R4	2
-      0x5C0C0800,  //  0029  MOVE	R3	R4
-      0x70020000,  //  002A  JMP		#002C
-      0x580C0005,  //  002B  LDCONST	R3	K5
-      0x90020C03,  //  002C  SETMBR	R0	K6	R3
-      0x50100000,  //  002D  LDBOOL	R4	0	0
-      0x80040800,  //  002E  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_meta
-********************************************************************/
-be_local_closure(lvh_obj_get_meta,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_meta),
-    }),
-    be_str_weak(get_meta),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_pad_bottom2
-********************************************************************/
-be_local_closure(lvh_obj_set_pad_bottom2,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_bottom),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(set_pad_bottom2),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0009,  //  0003  JMPF	R2	#000E
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x60100009,  //  0006  GETGBL	R4	G9
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x7C100200,  //  0008  CALL	R4	1
-      0x88140100,  //  0009  GETMBR	R5	R0	K0
-      0xB81A0600,  //  000A  GETNGBL	R6	K3
-      0x88180D04,  //  000B  GETMBR	R6	R6	K4
-      0x30140A06,  //  000C  OR	R5	R5	R6
-      0x7C080600,  //  000D  CALL	R2	3
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_pad_right2
-********************************************************************/
-be_local_closure(lvh_obj_set_pad_right2,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_style_pad_right),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(set_pad_right2),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0009,  //  0003  JMPF	R2	#000E
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C080502,  //  0005  GETMET	R2	R2	K2
-      0x60100009,  //  0006  GETGBL	R4	G9
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x7C100200,  //  0008  CALL	R4	1
-      0x88140100,  //  0009  GETMBR	R5	R0	K0
-      0xB81A0600,  //  000A  GETNGBL	R6	K3
-      0x88180D04,  //  000B  GETMBR	R6	R6	K4
-      0x30140A06,  //  000C  OR	R5	R5	R6
-      0x7C080600,  //  000D  CALL	R2	3
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_value_str
-********************************************************************/
-be_local_closure(lvh_obj_set_value_str,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_text),
-    }),
-    be_str_weak(set_value_str),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_click
-********************************************************************/
-be_local_closure(lvh_obj_set_click,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_enabled),
-    }),
-    be_str_weak(set_click),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_text_rule_format
-********************************************************************/
-be_local_closure(lvh_obj_get_text_rule_format,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule_format),
-    }),
-    be_str_weak(get_text_rule_format),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_val_rule_formula
-********************************************************************/
-be_local_closure(lvh_obj_get_val_rule_formula,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule_formula),
-    }),
-    be_str_weak(get_val_rule_formula),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_value_ofs_y
-********************************************************************/
-be_local_closure(lvh_obj_get_value_ofs_y,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(get_y),
-    }),
-    be_str_weak(get_value_ofs_y),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_hidden
-********************************************************************/
-be_local_closure(lvh_obj_get_hidden,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(has_flag),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_HIDDEN),
-    }),
-    be_str_weak(get_hidden),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x880C0703,  //  0003  GETMBR	R3	R3	K3
-      0x7C040400,  //  0004  CALL	R1	2
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_val_rule
-********************************************************************/
-be_local_closure(lvh_obj_remove_val_rule,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val_rule),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(remove_rule),
-    }),
-    be_str_weak(remove_val_rule),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060004,  //  0003  JMPF	R1	#0009
-      0xB8060200,  //  0004  GETNGBL	R1	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x5C100000,  //  0007  MOVE	R4	R0
-      0x7C040600,  //  0008  CALL	R1	3
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_text_font
-********************************************************************/
-be_local_closure(lvh_obj_get_text_font,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(get_text_font),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_click
-********************************************************************/
-be_local_closure(lvh_obj_get_click,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_enabled),
-    }),
-    be_str_weak(get_click),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_mode
-********************************************************************/
-be_local_closure(lvh_obj_set_mode,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_nested_str_weak(expand),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_width),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(SIZE_CONTENT),
-    /* K5   */  be_nested_str_weak(break),
-    /* K6   */  be_nested_str_weak(LABEL_LONG_WRAP),
-    /* K7   */  be_nested_str_weak(dots),
-    /* K8   */  be_nested_str_weak(LABEL_LONG_DOT),
-    /* K9   */  be_nested_str_weak(scroll),
-    /* K10  */  be_nested_str_weak(LABEL_LONG_SCROLL),
-    /* K11  */  be_nested_str_weak(loop),
-    /* K12  */  be_nested_str_weak(LABEL_LONG_SCROLL_CIRCULAR),
-    /* K13  */  be_nested_str_weak(crop),
-    /* K14  */  be_nested_str_weak(LABEL_LONG_CLIP),
-    /* K15  */  be_nested_str_weak(check_label),
-    /* K16  */  be_nested_str_weak(_lv_label),
-    /* K17  */  be_nested_str_weak(set_long_mode),
-    }),
-    be_str_weak(set_mode),
-    &be_const_str_solidified,
-    ( &(const binstruction[43]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C0C0300,  //  0001  EQ	R3	R1	K0
-      0x780E0005,  //  0002  JMPF	R3	#0009
-      0x880C0101,  //  0003  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
-      0xB8160600,  //  0005  GETNGBL	R5	K3
-      0x88140B04,  //  0006  GETMBR	R5	R5	K4
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x70020017,  //  0008  JMP		#0021
-      0x1C0C0305,  //  0009  EQ	R3	R1	K5
-      0x780E0002,  //  000A  JMPF	R3	#000E
-      0xB80E0600,  //  000B  GETNGBL	R3	K3
-      0x88080706,  //  000C  GETMBR	R2	R3	K6
-      0x70020012,  //  000D  JMP		#0021
-      0x1C0C0307,  //  000E  EQ	R3	R1	K7
-      0x780E0002,  //  000F  JMPF	R3	#0013
-      0xB80E0600,  //  0010  GETNGBL	R3	K3
-      0x88080708,  //  0011  GETMBR	R2	R3	K8
-      0x7002000D,  //  0012  JMP		#0021
-      0x1C0C0309,  //  0013  EQ	R3	R1	K9
-      0x780E0002,  //  0014  JMPF	R3	#0018
-      0xB80E0600,  //  0015  GETNGBL	R3	K3
-      0x8808070A,  //  0016  GETMBR	R2	R3	K10
-      0x70020008,  //  0017  JMP		#0021
-      0x1C0C030B,  //  0018  EQ	R3	R1	K11
-      0x780E0002,  //  0019  JMPF	R3	#001D
-      0xB80E0600,  //  001A  GETNGBL	R3	K3
-      0x8808070C,  //  001B  GETMBR	R2	R3	K12
-      0x70020003,  //  001C  JMP		#0021
-      0x1C0C030D,  //  001D  EQ	R3	R1	K13
-      0x780E0001,  //  001E  JMPF	R3	#0021
-      0xB80E0600,  //  001F  GETNGBL	R3	K3
-      0x8808070E,  //  0020  GETMBR	R2	R3	K14
-      0x4C0C0000,  //  0021  LDNIL	R3
-      0x200C0403,  //  0022  NE	R3	R2	R3
-      0x780E0005,  //  0023  JMPF	R3	#002A
-      0x8C0C010F,  //  0024  GETMET	R3	R0	K15
-      0x7C0C0200,  //  0025  CALL	R3	1
-      0x880C0110,  //  0026  GETMBR	R3	R0	K16
-      0x8C0C0711,  //  0027  GETMET	R3	R3	K17
-      0x5C140400,  //  0028  MOVE	R5	R2
-      0x7C0C0400,  //  0029  CALL	R3	2
-      0x80000000,  //  002A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_align
-********************************************************************/
-be_local_closure(lvh_obj_get_align,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(get_style_text_align),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(TEXT_ALIGN_LEFT),
-    /* K5   */  be_nested_str_weak(left),
-    /* K6   */  be_nested_str_weak(TEXT_ALIGN_CENTER),
-    /* K7   */  be_nested_str_weak(center),
-    /* K8   */  be_nested_str_weak(TEXT_ALIGN_RIGHT),
-    /* K9   */  be_nested_str_weak(right),
-    }),
-    be_str_weak(get_align),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x78060001,  //  0003  JMPF	R1	#0006
-      0x4C040000,  //  0004  LDNIL	R1
-      0x80040200,  //  0005  RET	1	R1
-      0x4C040000,  //  0006  LDNIL	R1
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x8C080501,  //  0008  GETMET	R2	R2	K1
-      0x58100002,  //  0009  LDCONST	R4	K2
-      0x7C080400,  //  000A  CALL	R2	2
-      0xB80A0600,  //  000B  GETNGBL	R2	K3
-      0x88080504,  //  000C  GETMBR	R2	R2	K4
-      0x1C080202,  //  000D  EQ	R2	R1	R2
-      0x780A0001,  //  000E  JMPF	R2	#0011
-      0x80060A00,  //  000F  RET	1	K5
-      0x7002000D,  //  0010  JMP		#001F
-      0xB80A0600,  //  0011  GETNGBL	R2	K3
-      0x88080506,  //  0012  GETMBR	R2	R2	K6
-      0x1C080202,  //  0013  EQ	R2	R1	R2
-      0x780A0001,  //  0014  JMPF	R2	#0017
-      0x80060E00,  //  0015  RET	1	K7
-      0x70020007,  //  0016  JMP		#001F
-      0xB80A0600,  //  0017  GETNGBL	R2	K3
-      0x88080508,  //  0018  GETMBR	R2	R2	K8
-      0x1C080202,  //  0019  EQ	R2	R1	R2
-      0x780A0001,  //  001A  JMPF	R2	#001D
-      0x80061200,  //  001B  RET	1	K9
-      0x70020001,  //  001C  JMP		#001F
-      0x4C080000,  //  001D  LDNIL	R2
-      0x80040400,  //  001E  RET	1	R2
-      0x80000000,  //  001F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_color_attribute
-********************************************************************/
-be_local_closure(lvh_obj_is_color_attribute,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_page),
-    /* K1   */  be_nested_str_weak(_oh),
-    /* K2   */  be_nested_str_weak(re_color_suffix),
-    /* K3   */  be_nested_str_weak(search),
-    }),
-    be_str_weak(is_color_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x88080501,  //  0001  GETMBR	R2	R2	K1
-      0x88080502,  //  0002  GETMBR	R2	R2	K2
-      0x8C080503,  //  0003  GETMET	R2	R2	K3
-      0x60100008,  //  0004  GETGBL	R4	G8
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x7C100200,  //  0006  CALL	R4	1
-      0x7C080400,  //  0007  CALL	R2	2
-      0x80040400,  //  0008  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pad_bottom
-********************************************************************/
-be_local_closure(lvh_obj_get_pad_bottom,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_part2_selector),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(get_style_pad_bottom),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
-    }),
-    be_str_weak(get_pad_bottom),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060007,  //  0003  JMPF	R1	#000C
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0xB8120600,  //  0007  GETNGBL	R4	K3
-      0x88100904,  //  0008  GETMBR	R4	R4	K4
-      0x300C0604,  //  0009  OR	R3	R3	R4
-      0x7C040400,  //  000A  CALL	R1	2
-      0x80040200,  //  000B  RET	1	R1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_value_font
-********************************************************************/
-be_local_closure(lvh_obj_set_value_font,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_text_font),
-    }),
-    be_str_weak(set_value_font),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_delete
-********************************************************************/
-be_local_closure(lvh_obj_set_delete,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(type_error),
-    /* K1   */  be_nested_str_weak(you_X20cannot_X20assign_X20to_X20_X27delete_X27),
-    }),
-    be_str_weak(set_delete),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0xB0060101,  //  0000  RAISE	1	K0	K1
-      0x80000000,  //  0001  RET	0
     })
   )
 );
@@ -4005,9 +2223,318 @@ be_local_closure(lvh_obj_setmember,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_text_rule_format
+** Solidified function: set_pad_right2
 ********************************************************************/
-be_local_closure(lvh_obj_set_text_rule_format,   /* name */
+be_local_closure(lvh_obj_set_pad_right2,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(set_style_pad_right),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(set_pad_right2),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0009,  //  0003  JMPF	R2	#000E
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x60100009,  //  0006  GETGBL	R4	G9
+      0x5C140200,  //  0007  MOVE	R5	R1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x88140100,  //  0009  GETMBR	R5	R0	K0
+      0xB81A0600,  //  000A  GETNGBL	R6	K3
+      0x88180D04,  //  000B  GETMBR	R6	R6	K4
+      0x30140A06,  //  000C  OR	R5	R5	R6
+      0x7C080600,  //  000D  CALL	R2	3
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_value_font
+********************************************************************/
+be_local_closure(lvh_obj_set_value_font,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_text_font),
+    }),
+    be_str_weak(set_value_font),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_toggle
+********************************************************************/
+be_local_closure(lvh_obj_get_toggle,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(has_state),
+    /* K2   */  be_nested_str_weak(lv),
+    /* K3   */  be_nested_str_weak(STATE_CHECKED),
+    }),
+    be_str_weak(get_toggle),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0xB80E0400,  //  0002  GETNGBL	R3	K2
+      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0x7C040400,  //  0004  CALL	R1	2
+      0x80040200,  //  0005  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_event_cb
+********************************************************************/
+be_local_closure(lvh_obj_register_event_cb,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_page),
+    /* K1   */  be_nested_str_weak(_oh),
+    /* K2   */  be_nested_str_weak(_event_map),
+    /* K3   */  be_nested_str_weak(keys),
+    /* K4   */  be_nested_str_weak(register_event),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(register_event_cb),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x60080010,  //  0002  GETGBL	R2	G16
+      0x880C0102,  //  0003  GETMBR	R3	R0	K2
+      0x8C0C0703,  //  0004  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x7C080200,  //  0006  CALL	R2	1
+      0xA8020006,  //  0007  EXBLK	0	#000F
+      0x5C0C0400,  //  0008  MOVE	R3	R2
+      0x7C0C0000,  //  0009  CALL	R3	0
+      0x8C100304,  //  000A  GETMET	R4	R1	K4
+      0x5C180000,  //  000B  MOVE	R6	R0
+      0x5C1C0600,  //  000C  MOVE	R7	R3
+      0x7C100600,  //  000D  CALL	R4	3
+      0x7001FFF8,  //  000E  JMP		#0008
+      0x58080005,  //  000F  LDCONST	R2	K5
+      0xAC080200,  //  0010  CATCH	R2	1	0
+      0xB0080000,  //  0011  RAISE	2	R0	R0
+      0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: check_label
+********************************************************************/
+be_local_closure(lvh_obj_check_label,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_label),
+    /* K1   */  be_nested_str_weak(lv),
+    /* K2   */  be_nested_str_weak(label),
+    /* K3   */  be_nested_str_weak(get_obj),
+    /* K4   */  be_nested_str_weak(set_align),
+    /* K5   */  be_nested_str_weak(ALIGN_CENTER),
+    }),
+    be_str_weak(check_label),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x7806000A,  //  0003  JMPF	R1	#000F
+      0xB8060200,  //  0004  GETNGBL	R1	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x8C0C0103,  //  0006  GETMET	R3	R0	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x7C040400,  //  0008  CALL	R1	2
+      0x90020001,  //  0009  SETMBR	R0	K0	R1
+      0x88040100,  //  000A  GETMBR	R1	R0	K0
+      0x8C040304,  //  000B  GETMET	R1	R1	K4
+      0xB80E0200,  //  000C  GETNGBL	R3	K1
+      0x880C0705,  //  000D  GETMBR	R3	R3	K5
+      0x7C040400,  //  000E  CALL	R1	2
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_toggle
+********************************************************************/
+be_local_closure(lvh_obj_set_toggle,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(toupper),
+    /* K2   */  be_nested_str_weak(TRUE),
+    /* K3   */  be_nested_str_weak(FALSE),
+    /* K4   */  be_nested_str_weak(_lv_obj),
+    /* K5   */  be_nested_str_weak(add_state),
+    /* K6   */  be_nested_str_weak(lv),
+    /* K7   */  be_nested_str_weak(STATE_CHECKED),
+    /* K8   */  be_nested_str_weak(clear_state),
+    }),
+    be_str_weak(set_toggle),
+    &be_const_str_solidified,
+    ( &(const binstruction[32]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x600C0004,  //  0001  GETGBL	R3	G4
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x1C0C0700,  //  0004  EQ	R3	R3	K0
+      0x780E000C,  //  0005  JMPF	R3	#0013
+      0x8C0C0501,  //  0006  GETMET	R3	R2	K1
+      0x60140008,  //  0007  GETGBL	R5	G8
+      0x5C180200,  //  0008  MOVE	R6	R1
+      0x7C140200,  //  0009  CALL	R5	1
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x5C040600,  //  000B  MOVE	R1	R3
+      0x1C0C0302,  //  000C  EQ	R3	R1	K2
+      0x780E0001,  //  000D  JMPF	R3	#0010
+      0x50040200,  //  000E  LDBOOL	R1	1	0
+      0x70020002,  //  000F  JMP		#0013
+      0x1C0C0303,  //  0010  EQ	R3	R1	K3
+      0x780E0000,  //  0011  JMPF	R3	#0013
+      0x50040000,  //  0012  LDBOOL	R1	0	0
+      0x78060005,  //  0013  JMPF	R1	#001A
+      0x880C0104,  //  0014  GETMBR	R3	R0	K4
+      0x8C0C0705,  //  0015  GETMET	R3	R3	K5
+      0xB8160C00,  //  0016  GETNGBL	R5	K6
+      0x88140B07,  //  0017  GETMBR	R5	R5	K7
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x70020004,  //  0019  JMP		#001F
+      0x880C0104,  //  001A  GETMBR	R3	R0	K4
+      0x8C0C0708,  //  001B  GETMET	R3	R3	K8
+      0xB8160C00,  //  001C  GETNGBL	R5	K6
+      0x88140B07,  //  001D  GETMBR	R5	R5	K7
+      0x7C0C0400,  //  001E  CALL	R3	2
+      0x80000000,  //  001F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_enabled
+********************************************************************/
+be_local_closure(lvh_obj_set_enabled,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(clear_state),
+    /* K2   */  be_nested_str_weak(lv),
+    /* K3   */  be_nested_str_weak(STATE_DISABLED),
+    /* K4   */  be_nested_str_weak(add_state),
+    }),
+    be_str_weak(set_enabled),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x78060005,  //  0000  JMPF	R1	#0007
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0xB8120400,  //  0003  GETNGBL	R4	K2
+      0x88100903,  //  0004  GETMBR	R4	R4	K3
+      0x7C080400,  //  0005  CALL	R2	2
+      0x70020004,  //  0006  JMP		#000C
+      0x88080100,  //  0007  GETMBR	R2	R0	K0
+      0x8C080504,  //  0008  GETMET	R2	R2	K4
+      0xB8120400,  //  0009  GETNGBL	R4	K2
+      0x88100903,  //  000A  GETMBR	R4	R4	K3
+      0x7C080400,  //  000B  CALL	R2	2
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_action
+********************************************************************/
+be_local_closure(lvh_obj_set_action,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
@@ -4018,9 +2545,9 @@ be_local_closure(lvh_obj_set_text_rule_format,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_text_rule_format),
+    /* K0   */  be_nested_str_weak(_action),
     }),
-    be_str_weak(set_text_rule_format),
+    be_str_weak(set_action),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x60080008,  //  0000  GETGBL	R2	G8
@@ -4028,6 +2555,1360 @@ be_local_closure(lvh_obj_set_text_rule_format,   /* name */
       0x7C080200,  //  0002  CALL	R2	1
       0x90020002,  //  0003  SETMBR	R0	K0	R2
       0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_val
+********************************************************************/
+be_local_closure(lvh_obj_get_val,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(get_value),
+    }),
+    be_str_weak(get_val),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_line_width
+********************************************************************/
+be_local_closure(lvh_obj_set_line_width,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(set_style_line_width),
+    }),
+    be_str_weak(set_line_width),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x60140009,  //  0002  GETGBL	R5	G9
+      0x5C180200,  //  0003  MOVE	R6	R1
+      0x7C140200,  //  0004  CALL	R5	1
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_action
+********************************************************************/
+be_local_closure(lvh_obj_get_action,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_action),
+    /* K1   */  be_nested_str_weak(),
+    }),
+    be_str_weak(get_action),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060001,  //  0001  JMPF	R1	#0004
+      0x5C080200,  //  0002  MOVE	R2	R1
+      0x70020000,  //  0003  JMP		#0005
+      0x58080001,  //  0004  LDCONST	R2	K1
+      0x80040400,  //  0005  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_value_font
+********************************************************************/
+be_local_closure(lvh_obj_get_value_font,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_text_font),
+    }),
+    be_str_weak(get_value_font),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pad_right
+********************************************************************/
+be_local_closure(lvh_obj_get_pad_right,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(get_style_pad_right),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(get_pad_right),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060007,  //  0003  JMPF	R1	#000C
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0xB8120600,  //  0007  GETNGBL	R4	K3
+      0x88100904,  //  0008  GETMBR	R4	R4	K4
+      0x300C0604,  //  0009  OR	R3	R3	R4
+      0x7C040400,  //  000A  CALL	R1	2
+      0x80040200,  //  000B  RET	1	R1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_value_color
+********************************************************************/
+be_local_closure(lvh_obj_get_value_color,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_value_color),
+    }),
+    be_str_weak(get_value_color),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_text_color
+********************************************************************/
+be_local_closure(lvh_obj_set_text_color,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(set_style_text_color),
+    /* K2   */  be_nested_str_weak(parse_color),
+    }),
+    be_str_weak(set_text_color),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x8C140102,  //  0002  GETMET	R5	R0	K2
+      0x5C1C0200,  //  0003  MOVE	R7	R1
+      0x7C140400,  //  0004  CALL	R5	2
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C0C0600,  //  0006  CALL	R3	3
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_mode
+********************************************************************/
+be_local_closure(lvh_obj_get_mode,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(get_mode),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_value_color
+********************************************************************/
+be_local_closure(lvh_obj_set_value_color,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_text_color),
+    }),
+    be_str_weak(set_value_color),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_line_width
+********************************************************************/
+be_local_closure(lvh_obj_get_line_width,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(get_style_line_width),
+    }),
+    be_str_weak(get_line_width),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_hidden
+********************************************************************/
+be_local_closure(lvh_obj_get_hidden,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(has_flag),
+    /* K2   */  be_nested_str_weak(lv),
+    /* K3   */  be_nested_str_weak(OBJ_FLAG_HIDDEN),
+    }),
+    be_str_weak(get_hidden),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0xB80E0400,  //  0002  GETNGBL	R3	K2
+      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0x7C040400,  //  0004  CALL	R1	2
+      0x80040200,  //  0005  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_value_ofs_x
+********************************************************************/
+be_local_closure(lvh_obj_get_value_ofs_x,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_label),
+    /* K1   */  be_nested_str_weak(get_x),
+    }),
+    be_str_weak(get_value_ofs_x),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_value_ofs_y
+********************************************************************/
+be_local_closure(lvh_obj_get_value_ofs_y,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_label),
+    /* K1   */  be_nested_str_weak(get_y),
+    }),
+    be_str_weak(get_value_ofs_y),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_align
+********************************************************************/
+be_local_closure(lvh_obj_get_align,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_label),
+    /* K1   */  be_nested_str_weak(get_style_text_align),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(TEXT_ALIGN_LEFT),
+    /* K5   */  be_nested_str_weak(left),
+    /* K6   */  be_nested_str_weak(TEXT_ALIGN_CENTER),
+    /* K7   */  be_nested_str_weak(center),
+    /* K8   */  be_nested_str_weak(TEXT_ALIGN_RIGHT),
+    /* K9   */  be_nested_str_weak(right),
+    }),
+    be_str_weak(get_align),
+    &be_const_str_solidified,
+    ( &(const binstruction[32]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060001,  //  0003  JMPF	R1	#0006
+      0x4C040000,  //  0004  LDNIL	R1
+      0x80040200,  //  0005  RET	1	R1
+      0x4C040000,  //  0006  LDNIL	R1
+      0x88080100,  //  0007  GETMBR	R2	R0	K0
+      0x8C080501,  //  0008  GETMET	R2	R2	K1
+      0x58100002,  //  0009  LDCONST	R4	K2
+      0x7C080400,  //  000A  CALL	R2	2
+      0xB80A0600,  //  000B  GETNGBL	R2	K3
+      0x88080504,  //  000C  GETMBR	R2	R2	K4
+      0x1C080202,  //  000D  EQ	R2	R1	R2
+      0x780A0001,  //  000E  JMPF	R2	#0011
+      0x80060A00,  //  000F  RET	1	K5
+      0x7002000D,  //  0010  JMP		#001F
+      0xB80A0600,  //  0011  GETNGBL	R2	K3
+      0x88080506,  //  0012  GETMBR	R2	R2	K6
+      0x1C080202,  //  0013  EQ	R2	R1	R2
+      0x780A0001,  //  0014  JMPF	R2	#0017
+      0x80060E00,  //  0015  RET	1	K7
+      0x70020007,  //  0016  JMP		#001F
+      0xB80A0600,  //  0017  GETNGBL	R2	K3
+      0x88080508,  //  0018  GETMBR	R2	R2	K8
+      0x1C080202,  //  0019  EQ	R2	R1	R2
+      0x780A0001,  //  001A  JMPF	R2	#001D
+      0x80061200,  //  001B  RET	1	K9
+      0x70020001,  //  001C  JMP		#001F
+      0x4C080000,  //  001D  LDNIL	R2
+      0x80040400,  //  001E  RET	1	R2
+      0x80000000,  //  001F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_text_color
+********************************************************************/
+be_local_closure(lvh_obj_get_text_color,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(get_style_text_color),
+    }),
+    be_str_weak(get_text_color),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_delete
+********************************************************************/
+be_local_closure(lvh_obj_get_delete,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_val_rule),
+    /* K1   */  be_nested_str_weak(remove_text_rule),
+    /* K2   */  be_nested_str_weak(_lv_label),
+    /* K3   */  be_nested_str_weak(del),
+    /* K4   */  be_nested_str_weak(_lv_obj),
+    /* K5   */  be_nested_str_weak(_page),
+    /* K6   */  be_nested_str_weak(remove_obj),
+    /* K7   */  be_nested_str_weak(id),
+    }),
+    be_str_weak(get_delete),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x7C040200,  //  0003  CALL	R1	1
+      0x88040102,  //  0004  GETMBR	R1	R0	K2
+      0x78060004,  //  0005  JMPF	R1	#000B
+      0x88040102,  //  0006  GETMBR	R1	R0	K2
+      0x8C040303,  //  0007  GETMET	R1	R1	K3
+      0x7C040200,  //  0008  CALL	R1	1
+      0x4C040000,  //  0009  LDNIL	R1
+      0x90020401,  //  000A  SETMBR	R0	K2	R1
+      0x88040104,  //  000B  GETMBR	R1	R0	K4
+      0x78060004,  //  000C  JMPF	R1	#0012
+      0x88040104,  //  000D  GETMBR	R1	R0	K4
+      0x8C040303,  //  000E  GETMET	R1	R1	K3
+      0x7C040200,  //  000F  CALL	R1	1
+      0x4C040000,  //  0010  LDNIL	R1
+      0x90020801,  //  0011  SETMBR	R0	K4	R1
+      0x88040105,  //  0012  GETMBR	R1	R0	K5
+      0x8C040306,  //  0013  GETMET	R1	R1	K6
+      0x880C0107,  //  0014  GETMBR	R3	R0	K7
+      0x7C040400,  //  0015  CALL	R1	2
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_click
+********************************************************************/
+be_local_closure(lvh_obj_set_click,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_enabled),
+    }),
+    be_str_weak(set_click),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_text_font
+********************************************************************/
+be_local_closure(lvh_obj_get_text_font,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(get_text_font),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_mode
+********************************************************************/
+be_local_closure(lvh_obj_set_mode,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(expand),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(set_width),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(SIZE_CONTENT),
+    /* K5   */  be_nested_str_weak(break),
+    /* K6   */  be_nested_str_weak(LABEL_LONG_WRAP),
+    /* K7   */  be_nested_str_weak(dots),
+    /* K8   */  be_nested_str_weak(LABEL_LONG_DOT),
+    /* K9   */  be_nested_str_weak(scroll),
+    /* K10  */  be_nested_str_weak(LABEL_LONG_SCROLL),
+    /* K11  */  be_nested_str_weak(loop),
+    /* K12  */  be_nested_str_weak(LABEL_LONG_SCROLL_CIRCULAR),
+    /* K13  */  be_nested_str_weak(crop),
+    /* K14  */  be_nested_str_weak(LABEL_LONG_CLIP),
+    /* K15  */  be_nested_str_weak(check_label),
+    /* K16  */  be_nested_str_weak(_lv_label),
+    /* K17  */  be_nested_str_weak(set_long_mode),
+    }),
+    be_str_weak(set_mode),
+    &be_const_str_solidified,
+    ( &(const binstruction[43]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C0C0300,  //  0001  EQ	R3	R1	K0
+      0x780E0005,  //  0002  JMPF	R3	#0009
+      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0xB8160600,  //  0005  GETNGBL	R5	K3
+      0x88140B04,  //  0006  GETMBR	R5	R5	K4
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x70020017,  //  0008  JMP		#0021
+      0x1C0C0305,  //  0009  EQ	R3	R1	K5
+      0x780E0002,  //  000A  JMPF	R3	#000E
+      0xB80E0600,  //  000B  GETNGBL	R3	K3
+      0x88080706,  //  000C  GETMBR	R2	R3	K6
+      0x70020012,  //  000D  JMP		#0021
+      0x1C0C0307,  //  000E  EQ	R3	R1	K7
+      0x780E0002,  //  000F  JMPF	R3	#0013
+      0xB80E0600,  //  0010  GETNGBL	R3	K3
+      0x88080708,  //  0011  GETMBR	R2	R3	K8
+      0x7002000D,  //  0012  JMP		#0021
+      0x1C0C0309,  //  0013  EQ	R3	R1	K9
+      0x780E0002,  //  0014  JMPF	R3	#0018
+      0xB80E0600,  //  0015  GETNGBL	R3	K3
+      0x8808070A,  //  0016  GETMBR	R2	R3	K10
+      0x70020008,  //  0017  JMP		#0021
+      0x1C0C030B,  //  0018  EQ	R3	R1	K11
+      0x780E0002,  //  0019  JMPF	R3	#001D
+      0xB80E0600,  //  001A  GETNGBL	R3	K3
+      0x8808070C,  //  001B  GETMBR	R2	R3	K12
+      0x70020003,  //  001C  JMP		#0021
+      0x1C0C030D,  //  001D  EQ	R3	R1	K13
+      0x780E0001,  //  001E  JMPF	R3	#0021
+      0xB80E0600,  //  001F  GETNGBL	R3	K3
+      0x8808070E,  //  0020  GETMBR	R2	R3	K14
+      0x4C0C0000,  //  0021  LDNIL	R3
+      0x200C0403,  //  0022  NE	R3	R2	R3
+      0x780E0005,  //  0023  JMPF	R3	#002A
+      0x8C0C010F,  //  0024  GETMET	R3	R0	K15
+      0x7C0C0200,  //  0025  CALL	R3	1
+      0x880C0110,  //  0026  GETMBR	R3	R0	K16
+      0x8C0C0711,  //  0027  GETMET	R3	R3	K17
+      0x5C140400,  //  0028  MOVE	R5	R2
+      0x7C0C0400,  //  0029  CALL	R3	2
+      0x80000000,  //  002A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: member
+********************************************************************/
+be_local_closure(lvh_obj_member,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(introspect),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_const_int(3),
+    /* K4   */  be_nested_str_weak(set_),
+    /* K5   */  be_nested_str_weak(get_),
+    /* K6   */  be_nested_str_weak(byte),
+    /* K7   */  be_const_int(2147483647),
+    /* K8   */  be_nested_str_weak(digits_to_style),
+    /* K9   */  be_nested_str_weak(_attr_ignore),
+    /* K10  */  be_nested_str_weak(find),
+    /* K11  */  be_nested_str_weak(get),
+    /* K12  */  be_nested_str_weak(function),
+    /* K13  */  be_nested_str_weak(_attr_map),
+    /* K14  */  be_nested_str_weak(contains),
+    /* K15  */  be_nested_str_weak(_lv_obj),
+    /* K16  */  be_nested_str_weak(style_),
+    /* K17  */  be_nested_str_weak(undefined),
+    }),
+    be_str_weak(member),
+    &be_const_str_solidified,
+    ( &(const binstruction[122]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0x40120503,  //  0002  CONNECT	R4	K2	K3
+      0x94100204,  //  0003  GETIDX	R4	R1	R4
+      0x1C140904,  //  0004  EQ	R5	R4	K4
+      0x74160001,  //  0005  JMPT	R5	#0008
+      0x1C140905,  //  0006  EQ	R5	R4	K5
+      0x78160000,  //  0007  JMPF	R5	#0009
+      0x80000A00,  //  0008  RET	0
+      0x58140002,  //  0009  LDCONST	R5	K2
+      0x6018000C,  //  000A  GETGBL	R6	G12
+      0x5C1C0200,  //  000B  MOVE	R7	R1
+      0x7C180200,  //  000C  CALL	R6	1
+      0x28180D03,  //  000D  GE	R6	R6	K3
+      0x781A0021,  //  000E  JMPF	R6	#0031
+      0x8C180506,  //  000F  GETMET	R6	R2	K6
+      0x5421FFFE,  //  0010  LDINT	R8	-1
+      0x94200208,  //  0011  GETIDX	R8	R1	R8
+      0x7C180400,  //  0012  CALL	R6	2
+      0x8C1C0506,  //  0013  GETMET	R7	R2	K6
+      0x5425FFFD,  //  0014  LDINT	R9	-2
+      0x94240209,  //  0015  GETIDX	R9	R1	R9
+      0x7C1C0400,  //  0016  CALL	R7	2
+      0x4C200000,  //  0017  LDNIL	R8
+      0x5426002F,  //  0018  LDINT	R9	48
+      0x28240C09,  //  0019  GE	R9	R6	R9
+      0x78260011,  //  001A  JMPF	R9	#002D
+      0x54260038,  //  001B  LDINT	R9	57
+      0x18240C09,  //  001C  LE	R9	R6	R9
+      0x7826000E,  //  001D  JMPF	R9	#002D
+      0x5426002F,  //  001E  LDINT	R9	48
+      0x28240E09,  //  001F  GE	R9	R7	R9
+      0x7826000B,  //  0020  JMPF	R9	#002D
+      0x54260038,  //  0021  LDINT	R9	57
+      0x18240E09,  //  0022  LE	R9	R7	R9
+      0x78260008,  //  0023  JMPF	R9	#002D
+      0x60240009,  //  0024  GETGBL	R9	G9
+      0x5429FFFD,  //  0025  LDINT	R10	-2
+      0x40281507,  //  0026  CONNECT	R10	R10	K7
+      0x9428020A,  //  0027  GETIDX	R10	R1	R10
+      0x7C240200,  //  0028  CALL	R9	1
+      0x5C201200,  //  0029  MOVE	R8	R9
+      0x5425FFFC,  //  002A  LDINT	R9	-3
+      0x40260409,  //  002B  CONNECT	R9	K2	R9
+      0x94040209,  //  002C  GETIDX	R1	R1	R9
+      0x8C240108,  //  002D  GETMET	R9	R0	K8
+      0x5C2C1000,  //  002E  MOVE	R11	R8
+      0x7C240400,  //  002F  CALL	R9	2
+      0x5C141200,  //  0030  MOVE	R5	R9
+      0x88180109,  //  0031  GETMBR	R6	R0	K9
+      0x8C180D0A,  //  0032  GETMET	R6	R6	K10
+      0x5C200200,  //  0033  MOVE	R8	R1
+      0x7C180400,  //  0034  CALL	R6	2
+      0x4C1C0000,  //  0035  LDNIL	R7
+      0x20180C07,  //  0036  NE	R6	R6	R7
+      0x781A0000,  //  0037  JMPF	R6	#0039
+      0x80000C00,  //  0038  RET	0
+      0x8C18070B,  //  0039  GETMET	R6	R3	K11
+      0x5C200000,  //  003A  MOVE	R8	R0
+      0x00260A01,  //  003B  ADD	R9	K5	R1
+      0x7C180600,  //  003C  CALL	R6	3
+      0x601C0004,  //  003D  GETGBL	R7	G4
+      0x5C200C00,  //  003E  MOVE	R8	R6
+      0x7C1C0200,  //  003F  CALL	R7	1
+      0x1C1C0F0C,  //  0040  EQ	R7	R7	K12
+      0x781E0004,  //  0041  JMPF	R7	#0047
+      0x5C1C0C00,  //  0042  MOVE	R7	R6
+      0x5C200000,  //  0043  MOVE	R8	R0
+      0x5C240A00,  //  0044  MOVE	R9	R5
+      0x7C1C0400,  //  0045  CALL	R7	2
+      0x80040E00,  //  0046  RET	1	R7
+      0x881C010D,  //  0047  GETMBR	R7	R0	K13
+      0x8C1C0F0E,  //  0048  GETMET	R7	R7	K14
+      0x5C240200,  //  0049  MOVE	R9	R1
+      0x7C1C0400,  //  004A  CALL	R7	2
+      0x781E001B,  //  004B  JMPF	R7	#0068
+      0x881C010D,  //  004C  GETMBR	R7	R0	K13
+      0x941C0E01,  //  004D  GETIDX	R7	R7	R1
+      0x8C20070B,  //  004E  GETMET	R8	R3	K11
+      0x8828010F,  //  004F  GETMBR	R10	R0	K15
+      0x002E0A07,  //  0050  ADD	R11	K5	R7
+      0x7C200600,  //  0051  CALL	R8	3
+      0x5C181000,  //  0052  MOVE	R6	R8
+      0x60200004,  //  0053  GETGBL	R8	G4
+      0x5C240C00,  //  0054  MOVE	R9	R6
+      0x7C200200,  //  0055  CALL	R8	1
+      0x1C20110C,  //  0056  EQ	R8	R8	K12
+      0x7822000F,  //  0057  JMPF	R8	#0068
+      0x8C20050A,  //  0058  GETMET	R8	R2	K10
+      0x5C280E00,  //  0059  MOVE	R10	R7
+      0x582C0010,  //  005A  LDCONST	R11	K16
+      0x7C200600,  //  005B  CALL	R8	3
+      0x1C201102,  //  005C  EQ	R8	R8	K2
+      0x78220005,  //  005D  JMPF	R8	#0064
+      0x5C200C00,  //  005E  MOVE	R8	R6
+      0x8824010F,  //  005F  GETMBR	R9	R0	K15
+      0x5C280A00,  //  0060  MOVE	R10	R5
+      0x7C200400,  //  0061  CALL	R8	2
+      0x80041000,  //  0062  RET	1	R8
+      0x70020003,  //  0063  JMP		#0068
+      0x5C200C00,  //  0064  MOVE	R8	R6
+      0x8824010F,  //  0065  GETMBR	R9	R0	K15
+      0x7C200200,  //  0066  CALL	R8	1
+      0x80041000,  //  0067  RET	1	R8
+      0x8C1C070B,  //  0068  GETMET	R7	R3	K11
+      0x8824010F,  //  0069  GETMBR	R9	R0	K15
+      0x002A0A01,  //  006A  ADD	R10	K5	R1
+      0x7C1C0600,  //  006B  CALL	R7	3
+      0x5C180E00,  //  006C  MOVE	R6	R7
+      0x601C0004,  //  006D  GETGBL	R7	G4
+      0x5C200C00,  //  006E  MOVE	R8	R6
+      0x7C1C0200,  //  006F  CALL	R7	1
+      0x1C1C0F0C,  //  0070  EQ	R7	R7	K12
+      0x781E0003,  //  0071  JMPF	R7	#0076
+      0x5C1C0C00,  //  0072  MOVE	R7	R6
+      0x8820010F,  //  0073  GETMBR	R8	R0	K15
+      0x7C1C0200,  //  0074  CALL	R7	1
+      0x80040E00,  //  0075  RET	1	R7
+      0x601C000B,  //  0076  GETGBL	R7	G11
+      0x58200011,  //  0077  LDCONST	R8	K17
+      0x7C1C0200,  //  0078  CALL	R7	1
+      0x80040E00,  //  0079  RET	1	R7
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_click
+********************************************************************/
+be_local_closure(lvh_obj_get_click,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_enabled),
+    }),
+    be_str_weak(get_click),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_pad_top2
+********************************************************************/
+be_local_closure(lvh_obj_set_pad_top2,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(set_style_pad_top),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(set_pad_top2),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0009,  //  0003  JMPF	R2	#000E
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x60100009,  //  0006  GETGBL	R4	G9
+      0x5C140200,  //  0007  MOVE	R5	R1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x88140100,  //  0009  GETMBR	R5	R0	K0
+      0xB81A0600,  //  000A  GETNGBL	R6	K3
+      0x88180D04,  //  000B  GETMBR	R6	R6	K4
+      0x30140A06,  //  000C  OR	R5	R5	R6
+      0x7C080600,  //  000D  CALL	R2	3
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_value_ofs_x
+********************************************************************/
+be_local_closure(lvh_obj_set_value_ofs_x,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(check_label),
+    /* K1   */  be_nested_str_weak(_lv_label),
+    /* K2   */  be_nested_str_weak(set_x),
+    }),
+    be_str_weak(set_value_ofs_x),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x8C080502,  //  0003  GETMET	R2	R2	K2
+      0x60100009,  //  0004  GETGBL	R4	G9
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x7C100200,  //  0006  CALL	R4	1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pad_left
+********************************************************************/
+be_local_closure(lvh_obj_get_pad_left,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(get_style_pad_left),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(get_pad_left),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060007,  //  0003  JMPF	R1	#000C
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0xB8120600,  //  0007  GETNGBL	R4	K3
+      0x88100904,  //  0008  GETMBR	R4	R4	K4
+      0x300C0604,  //  0009  OR	R3	R3	R4
+      0x7C040400,  //  000A  CALL	R1	2
+      0x80040200,  //  000B  RET	1	R1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_text
+********************************************************************/
+be_local_closure(lvh_obj_set_text,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(check_label),
+    /* K1   */  be_nested_str_weak(_lv_label),
+    /* K2   */  be_nested_str_weak(set_text),
+    }),
+    be_str_weak(set_text),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x8C080502,  //  0003  GETMET	R2	R2	K2
+      0x60100008,  //  0004  GETGBL	R4	G8
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x7C100200,  //  0006  CALL	R4	1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_text_font
+********************************************************************/
+be_local_closure(lvh_obj_set_text_font,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(parse_font),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(set_style_text_font),
+    /* K3   */  be_const_int(0),
+    }),
+    be_str_weak(set_text_font),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x200C0403,  //  0004  NE	R3	R2	R3
+      0x780E0004,  //  0005  JMPF	R3	#000B
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
+      0x5C140400,  //  0008  MOVE	R5	R2
+      0x58180003,  //  0009  LDCONST	R6	K3
+      0x7C0C0600,  //  000A  CALL	R3	3
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_text
+********************************************************************/
+be_local_closure(lvh_obj_get_text,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_label),
+    /* K1   */  be_nested_str_weak(get_text),
+    }),
+    be_str_weak(get_text),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060001,  //  0003  JMPF	R1	#0006
+      0x4C040000,  //  0004  LDNIL	R1
+      0x80040200,  //  0005  RET	1	R1
+      0x88040100,  //  0006  GETMBR	R1	R0	K0
+      0x8C040301,  //  0007  GETMET	R1	R1	K1
+      0x7C040200,  //  0008  CALL	R1	1
+      0x80040200,  //  0009  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(lvh_obj_init,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    6,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(init),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x60180003,  //  0000  GETGBL	R6	G3
+      0x5C1C0000,  //  0001  MOVE	R7	R0
+      0x7C180200,  //  0002  CALL	R6	1
+      0x8C180D00,  //  0003  GETMET	R6	R6	K0
+      0x5C200200,  //  0004  MOVE	R8	R1
+      0x5C240400,  //  0005  MOVE	R9	R2
+      0x5C280600,  //  0006  MOVE	R10	R3
+      0x5C2C0800,  //  0007  MOVE	R11	R4
+      0x5C300A00,  //  0008  MOVE	R12	R5
+      0x7C180C00,  //  0009  CALL	R6	6
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_pad_bottom2
+********************************************************************/
+be_local_closure(lvh_obj_set_pad_bottom2,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(set_style_pad_bottom),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(set_pad_bottom2),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0009,  //  0003  JMPF	R2	#000E
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x60100009,  //  0006  GETGBL	R4	G9
+      0x5C140200,  //  0007  MOVE	R5	R1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x88140100,  //  0009  GETMBR	R5	R0	K0
+      0xB81A0600,  //  000A  GETNGBL	R6	K3
+      0x88180D04,  //  000B  GETMBR	R6	R6	K4
+      0x30140A06,  //  000C  OR	R5	R5	R6
+      0x7C080600,  //  000D  CALL	R2	3
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_delete
+********************************************************************/
+be_local_closure(lvh_obj_set_delete,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(type_error),
+    /* K1   */  be_nested_str_weak(you_X20cannot_X20assign_X20to_X20_X27delete_X27),
+    }),
+    be_str_weak(set_delete),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0xB0060101,  //  0000  RAISE	1	K0	K1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_radius2
+********************************************************************/
+be_local_closure(lvh_obj_set_radius2,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(set_style_radius),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(set_radius2),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0009,  //  0003  JMPF	R2	#000E
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x60100009,  //  0006  GETGBL	R4	G9
+      0x5C140200,  //  0007  MOVE	R5	R1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x88140100,  //  0009  GETMBR	R5	R0	K0
+      0xB81A0600,  //  000A  GETNGBL	R6	K3
+      0x88180D04,  //  000B  GETMBR	R6	R6	K4
+      0x30140A06,  //  000C  OR	R5	R5	R6
+      0x7C080600,  //  000D  CALL	R2	3
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_enabled
+********************************************************************/
+be_local_closure(lvh_obj_get_enabled,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(has_state),
+    /* K2   */  be_nested_str_weak(lv),
+    /* K3   */  be_nested_str_weak(STATE_DISABLED),
+    }),
+    be_str_weak(get_enabled),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0xB80E0400,  //  0002  GETNGBL	R3	K2
+      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0x7C040400,  //  0004  CALL	R1	2
+      0x78060000,  //  0005  JMPF	R1	#0007
+      0x50040001,  //  0006  LDBOOL	R1	0	1
+      0x50040200,  //  0007  LDBOOL	R1	1	0
+      0x80040200,  //  0008  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pad_top
+********************************************************************/
+be_local_closure(lvh_obj_get_pad_top,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(get_style_pad_top),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(get_pad_top),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060007,  //  0003  JMPF	R1	#000C
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0xB8120600,  //  0007  GETNGBL	R4	K3
+      0x88100904,  //  0008  GETMBR	R4	R4	K4
+      0x300C0604,  //  0009  OR	R3	R3	R4
+      0x7C040400,  //  000A  CALL	R1	2
+      0x80040200,  //  000B  RET	1	R1
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -4079,9 +3960,93 @@ be_local_closure(lvh_obj_set_pad_left2,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_value_ofs_x
+** Solidified function: get_pad_bottom
 ********************************************************************/
-be_local_closure(lvh_obj_get_value_ofs_x,   /* name */
+be_local_closure(lvh_obj_get_pad_bottom,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(get_style_pad_bottom),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(get_pad_bottom),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060007,  //  0003  JMPF	R1	#000C
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0xB8120600,  //  0007  GETNGBL	R4	K3
+      0x88100904,  //  0008  GETMBR	R4	R4	K4
+      0x300C0604,  //  0009  OR	R3	R3	R4
+      0x7C040400,  //  000A  CALL	R1	2
+      0x80040200,  //  000B  RET	1	R1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_radius2
+********************************************************************/
+be_local_closure(lvh_obj_get_radius2,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(get_style_radius),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
+    }),
+    be_str_weak(get_radius2),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060007,  //  0003  JMPF	R1	#000C
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0xB8120600,  //  0007  GETNGBL	R4	K3
+      0x88100904,  //  0008  GETMBR	R4	R4	K4
+      0x300C0604,  //  0009  OR	R3	R3	R4
+      0x7C040400,  //  000A  CALL	R1	2
+      0x80040200,  //  000B  RET	1	R1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: post_init
+********************************************************************/
+be_local_closure(lvh_obj_post_init,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -4091,17 +4056,248 @@ be_local_closure(lvh_obj_get_value_ofs_x,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_label),
-    /* K1   */  be_nested_str_weak(get_x),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(register_event_cb),
     }),
-    be_str_weak(get_value_ofs_x),
+    be_str_weak(post_init),
     &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_value_ofs_y
+********************************************************************/
+be_local_closure(lvh_obj_set_value_ofs_y,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(check_label),
+    /* K1   */  be_nested_str_weak(_lv_label),
+    /* K2   */  be_nested_str_weak(set_y),
+    }),
+    be_str_weak(set_value_ofs_y),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x8C080502,  //  0003  GETMET	R2	R2	K2
+      0x60100009,  //  0004  GETGBL	R4	G9
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x7C100200,  //  0006  CALL	R4	1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_adjustable
+********************************************************************/
+be_local_closure(lvh_obj_get_adjustable,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(has_flag),
+    /* K2   */  be_nested_str_weak(lv),
+    /* K3   */  be_nested_str_weak(OBJ_FLAG_CLICKABLE),
+    }),
+    be_str_weak(get_adjustable),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
+      0xB80E0400,  //  0002  GETNGBL	R3	K2
+      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0x7C040400,  //  0004  CALL	R1	2
+      0x80040200,  //  0005  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_align
+********************************************************************/
+be_local_closure(lvh_obj_set_align,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(check_label),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(left),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(TEXT_ALIGN_LEFT),
+    /* K5   */  be_const_int(1),
+    /* K6   */  be_nested_str_weak(center),
+    /* K7   */  be_nested_str_weak(TEXT_ALIGN_CENTER),
+    /* K8   */  be_const_int(2),
+    /* K9   */  be_nested_str_weak(right),
+    /* K10  */  be_nested_str_weak(TEXT_ALIGN_RIGHT),
+    /* K11  */  be_nested_str_weak(_lv_label),
+    /* K12  */  be_nested_str_weak(set_style_text_align),
+    }),
+    be_str_weak(set_align),
+    &be_const_str_solidified,
+    ( &(const binstruction[29]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x8C0C0100,  //  0001  GETMET	R3	R0	K0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x1C0C0301,  //  0003  EQ	R3	R1	K1
+      0x740E0001,  //  0004  JMPT	R3	#0007
+      0x1C0C0302,  //  0005  EQ	R3	R1	K2
+      0x780E0002,  //  0006  JMPF	R3	#000A
+      0xB80E0600,  //  0007  GETNGBL	R3	K3
+      0x88080704,  //  0008  GETMBR	R2	R3	K4
+      0x7002000C,  //  0009  JMP		#0017
+      0x1C0C0305,  //  000A  EQ	R3	R1	K5
+      0x740E0001,  //  000B  JMPT	R3	#000E
+      0x1C0C0306,  //  000C  EQ	R3	R1	K6
+      0x780E0002,  //  000D  JMPF	R3	#0011
+      0xB80E0600,  //  000E  GETNGBL	R3	K3
+      0x88080707,  //  000F  GETMBR	R2	R3	K7
+      0x70020005,  //  0010  JMP		#0017
+      0x1C0C0308,  //  0011  EQ	R3	R1	K8
+      0x740E0001,  //  0012  JMPT	R3	#0015
+      0x1C0C0309,  //  0013  EQ	R3	R1	K9
+      0x780E0001,  //  0014  JMPF	R3	#0017
+      0xB80E0600,  //  0015  GETNGBL	R3	K3
+      0x8808070A,  //  0016  GETMBR	R2	R3	K10
+      0x880C010B,  //  0017  GETMBR	R3	R0	K11
+      0x8C0C070C,  //  0018  GETMET	R3	R3	K12
+      0x5C140400,  //  0019  MOVE	R5	R2
+      0x58180001,  //  001A  LDCONST	R6	K1
+      0x7C0C0600,  //  001B  CALL	R3	3
+      0x80000000,  //  001C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pad_all
+********************************************************************/
+be_local_closure(lvh_obj_get_pad_all,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(get_pad_all),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_adjustable
+********************************************************************/
+be_local_closure(lvh_obj_set_adjustable,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(add_flag),
+    /* K2   */  be_nested_str_weak(lv),
+    /* K3   */  be_nested_str_weak(OBJ_FLAG_CLICKABLE),
+    /* K4   */  be_nested_str_weak(clear_flag),
+    }),
+    be_str_weak(set_adjustable),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x78060005,  //  0000  JMPF	R1	#0007
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0xB8120400,  //  0003  GETNGBL	R4	K2
+      0x88100903,  //  0004  GETMBR	R4	R4	K3
+      0x7C080400,  //  0005  CALL	R2	2
+      0x70020004,  //  0006  JMP		#000C
+      0x88080100,  //  0007  GETMBR	R2	R0	K0
+      0x8C080504,  //  0008  GETMET	R2	R2	K4
+      0xB8120400,  //  0009  GETNGBL	R4	K2
+      0x88100903,  //  000A  GETMBR	R4	R4	K3
+      0x7C080400,  //  000B  CALL	R2	2
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_val
+********************************************************************/
+be_local_closure(lvh_obj_set_val,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(set_value),
+    }),
+    be_str_weak(set_val),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80000000,  //  0004  RET	0
     })
   )
 );
@@ -4280,11 +4476,11 @@ be_local_closure(lvh_obj_event_cb,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_hidden
+** Solidified function: set_pad_all2
 ********************************************************************/
-be_local_closure(lvh_obj_set_hidden,   /* name */
+be_local_closure(lvh_obj_set_pad_all2,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
+    7,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -4293,28 +4489,30 @@ be_local_closure(lvh_obj_set_hidden,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(add_flag),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(OBJ_FLAG_HIDDEN),
-    /* K4   */  be_nested_str_weak(clear_flag),
+    /* K0   */  be_nested_str_weak(_lv_part2_selector),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(set_style_pad_all),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(STATE_DEFAULT),
     }),
-    be_str_weak(set_hidden),
+    be_str_weak(set_pad_all2),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x78060005,  //  0000  JMPF	R1	#0007
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0xB8120400,  //  0003  GETNGBL	R4	K2
-      0x88100903,  //  0004  GETMBR	R4	R4	K3
-      0x7C080400,  //  0005  CALL	R2	2
-      0x70020004,  //  0006  JMP		#000C
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x8C080504,  //  0008  GETMET	R2	R2	K4
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x88100903,  //  000A  GETMBR	R4	R4	K3
-      0x7C080400,  //  000B  CALL	R2	2
-      0x80000000,  //  000C  RET	0
+    ( &(const binstruction[15]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0009,  //  0003  JMPF	R2	#000E
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C080502,  //  0005  GETMET	R2	R2	K2
+      0x60100009,  //  0006  GETGBL	R4	G9
+      0x5C140200,  //  0007  MOVE	R5	R1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x88140100,  //  0009  GETMBR	R5	R0	K0
+      0xB81A0600,  //  000A  GETNGBL	R6	K3
+      0x88180D04,  //  000B  GETMBR	R6	R6	K4
+      0x30140A06,  //  000C  OR	R5	R5	R6
+      0x7C080600,  //  000D  CALL	R2	3
+      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -4324,13 +4522,25 @@ be_local_closure(lvh_obj_set_hidden,   /* name */
 /********************************************************************
 ** Solidified class: lvh_obj
 ********************************************************************/
+extern const bclass be_class_lvh_root;
 be_local_class(lvh_obj,
-    13,
-    NULL,
-    be_nested_map(98,
+    2,
+    &be_class_lvh_root,
+    be_nested_map(60,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(_lv_obj, -1), be_const_var(1) },
-        { be_const_key_weak(_event_map, 92), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(set_hidden, -1), be_const_closure(lvh_obj_set_hidden_closure) },
+        { be_const_key_weak(setmember, -1), be_const_closure(lvh_obj_setmember_closure) },
+        { be_const_key_weak(set_pad_right2, -1), be_const_closure(lvh_obj_set_pad_right2_closure) },
+        { be_const_key_weak(set_value_font, 54), be_const_closure(lvh_obj_set_value_font_closure) },
+        { be_const_key_weak(get_toggle, 33), be_const_closure(lvh_obj_get_toggle_closure) },
+        { be_const_key_weak(set_pad_all2, -1), be_const_closure(lvh_obj_set_pad_all2_closure) },
+        { be_const_key_weak(check_label, -1), be_const_closure(lvh_obj_check_label_closure) },
+        { be_const_key_weak(_lv_class, -1), be_const_class(be_class_lv_obj) },
+        { be_const_key_weak(set_toggle, 36), be_const_closure(lvh_obj_set_toggle_closure) },
+        { be_const_key_weak(set_enabled, 59), be_const_closure(lvh_obj_set_enabled_closure) },
+        { be_const_key_weak(set_action, -1), be_const_closure(lvh_obj_set_action_closure) },
+        { be_const_key_weak(get_val, -1), be_const_closure(lvh_obj_get_val_closure) },
+        { be_const_key_weak(_event_map, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(7,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(7, -1), be_nested_str_weak(up) },
@@ -4341,174 +4551,53 @@ be_local_class(lvh_obj,
         { be_const_key_int(5, -1), be_nested_str_weak(long) },
         { be_const_key_int(6, -1), be_nested_str_weak(hold) },
     }))    ) } )) },
-        { be_const_key_weak(_attr_map, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(35,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(arc_rounded, -1), be_nested_str_weak(style_arc_rounded) },
-        { be_const_key_weak(line_color, 13), be_nested_str_weak(style_line_color) },
-        { be_const_key_weak(bg_grad_dir, -1), be_nested_str_weak(style_bg_grad_dir) },
-        { be_const_key_weak(border_side, 7), be_nested_str_weak(style_border_side) },
-        { be_const_key_weak(pad_all, -1), be_nested_str_weak(style_pad_all) },
-        { be_const_key_weak(height, -1), be_nested_str_weak(style_height) },
-        { be_const_key_weak(y, -1), be_nested_str_weak(y) },
-        { be_const_key_weak(arc_opa, -1), be_nested_str_weak(style_arc_opa) },
-        { be_const_key_weak(pad_right, -1), be_nested_str_weak(style_pad_right) },
-        { be_const_key_weak(image_recolor_opa, 28), be_nested_str_weak(style_img_recolor_opa) },
-        { be_const_key_weak(x, -1), be_nested_str_weak(x) },
-        { be_const_key_weak(arc_color, -1), be_nested_str_weak(style_arc_color) },
-        { be_const_key_weak(w, -1), be_nested_str_weak(width) },
-        { be_const_key_weak(h, -1), be_nested_str_weak(height) },
-        { be_const_key_weak(radius, 8), be_nested_str_weak(style_radius) },
-        { be_const_key_weak(width, 11), be_nested_str_weak(style_width) },
-        { be_const_key_weak(border_color, 22), be_nested_str_weak(style_border_color) },
-        { be_const_key_weak(bg_grad_color, 34), be_nested_str_weak(style_bg_grad_color) },
-        { be_const_key_weak(bg_color, -1), be_nested_str_weak(style_bg_color) },
-        { be_const_key_weak(border_width, 33), be_nested_str_weak(style_border_width) },
-        { be_const_key_weak(pad_top, -1), be_nested_str_weak(style_pad_top) },
-        { be_const_key_weak(image_recolor, 17), be_nested_str_weak(style_img_recolor) },
-        { be_const_key_weak(border_post, -1), be_nested_str_weak(style_border_pot) },
-        { be_const_key_weak(start_angle1, -1), be_nested_str_weak(start_angle) },
-        { be_const_key_weak(border_opa, -1), be_nested_str_weak(style_border_opa) },
-        { be_const_key_weak(rotation, 10), be_nested_str_weak(rotation) },
-        { be_const_key_weak(arc_width, 12), be_nested_str_weak(style_arc_width) },
-        { be_const_key_weak(end_angle, -1), be_nested_str_weak(bg_end_angle) },
-        { be_const_key_weak(pad_bottom, -1), be_nested_str_weak(style_pad_bottom) },
-        { be_const_key_weak(bg_opa, -1), be_nested_str_weak(style_bg_opa) },
-        { be_const_key_weak(end_angle1, -1), be_nested_str_weak(end_angle) },
-        { be_const_key_weak(start_angle, 30), be_nested_str_weak(bg_start_angle) },
-        { be_const_key_weak(src, -1), be_nested_str_weak(src) },
-        { be_const_key_weak(line_rounded, -1), be_nested_str_weak(style_line_rounded) },
-        { be_const_key_weak(pad_left, -1), be_nested_str_weak(style_pad_left) },
-    }))    ) } )) },
-        { be_const_key_weak(get_pad_all, 94), be_const_closure(lvh_obj_get_pad_all_closure) },
-        { be_const_key_weak(set_action, -1), be_const_closure(lvh_obj_set_action_closure) },
-        { be_const_key_weak(set_hidden, -1), be_const_closure(lvh_obj_set_hidden_closure) },
-        { be_const_key_weak(get_radius2, -1), be_const_closure(lvh_obj_get_radius2_closure) },
-        { be_const_key_weak(event_cb, -1), be_const_closure(lvh_obj_event_cb_closure) },
-        { be_const_key_weak(_meta, 34), be_const_var(5) },
-        { be_const_key_weak(get_value_font, -1), be_const_closure(lvh_obj_get_value_font_closure) },
-        { be_const_key_weak(get_pad_right, -1), be_const_closure(lvh_obj_get_pad_right_closure) },
-        { be_const_key_weak(get_pad_top, -1), be_const_closure(lvh_obj_get_pad_top_closure) },
-        { be_const_key_weak(digits_to_style, -1), be_const_closure(lvh_obj_digits_to_style_closure) },
-        { be_const_key_weak(set_text_color, 77), be_const_closure(lvh_obj_set_text_color_closure) },
-        { be_const_key_weak(_val_rule_formula, 29), be_const_var(7) },
-        { be_const_key_weak(get_enabled, -1), be_const_closure(lvh_obj_get_enabled_closure) },
-        { be_const_key_weak(get_toggle, -1), be_const_closure(lvh_obj_get_toggle_closure) },
-        { be_const_key_weak(set_value_ofs_x, -1), be_const_closure(lvh_obj_set_value_ofs_x_closure) },
-        { be_const_key_weak(set_radius2, -1), be_const_closure(lvh_obj_set_radius2_closure) },
-        { be_const_key_weak(init, 26), be_const_closure(lvh_obj_init_closure) },
-        { be_const_key_weak(get_text_rule, -1), be_const_closure(lvh_obj_get_text_rule_closure) },
-        { be_const_key_weak(get_adjustable, -1), be_const_closure(lvh_obj_get_adjustable_closure) },
-        { be_const_key_weak(set_line_width, -1), be_const_closure(lvh_obj_set_line_width_closure) },
-        { be_const_key_weak(set_pad_top2, -1), be_const_closure(lvh_obj_set_pad_top2_closure) },
-        { be_const_key_weak(get_val_rule, -1), be_const_closure(lvh_obj_get_val_rule_closure) },
-        { be_const_key_weak(set_text_rule_format, -1), be_const_closure(lvh_obj_set_text_rule_format_closure) },
-        { be_const_key_weak(get_text_color, 97), be_const_closure(lvh_obj_get_text_color_closure) },
-        { be_const_key_weak(set_value_color, 12), be_const_closure(lvh_obj_set_value_color_closure) },
-        { be_const_key_weak(_lv_part2_selector, 25), be_const_nil() },
-        { be_const_key_weak(_lv_label, 72), be_const_var(2) },
-        { be_const_key_weak(_text_rule_format, -1), be_const_var(12) },
-        { be_const_key_weak(set_text_rule_formula, 22), be_const_closure(lvh_obj_set_text_rule_formula_closure) },
-        { be_const_key_weak(set_delete, -1), be_const_closure(lvh_obj_set_delete_closure) },
-        { be_const_key_weak(set_text, 90), be_const_closure(lvh_obj_set_text_closure) },
-        { be_const_key_weak(member, 88), be_const_closure(lvh_obj_member_closure) },
-        { be_const_key_weak(get_pad_bottom, 54), be_const_closure(lvh_obj_get_pad_bottom_closure) },
-        { be_const_key_weak(_val_rule, -1), be_const_var(6) },
-        { be_const_key_weak(set_meta, -1), be_const_closure(lvh_obj_set_meta_closure) },
-        { be_const_key_weak(set_val_rule, -1), be_const_closure(lvh_obj_set_val_rule_closure) },
-        { be_const_key_weak(get_value_str, 81), be_const_closure(lvh_obj_get_value_str_closure) },
+        { be_const_key_weak(_lv_label, 5), be_const_var(0) },
         { be_const_key_weak(get_action, -1), be_const_closure(lvh_obj_get_action_closure) },
-        { be_const_key_weak(set_align, 8), be_const_closure(lvh_obj_set_align_closure) },
-        { be_const_key_weak(parse_color, -1), be_const_static_closure(lvh_obj_parse_color_closure) },
-        { be_const_key_weak(register_event_cb, -1), be_const_closure(lvh_obj_register_event_cb_closure) },
-        { be_const_key_weak(text_rule_matched, -1), be_const_closure(lvh_obj_text_rule_matched_closure) },
-        { be_const_key_weak(_lv_class, -1), be_const_class(be_class_lv_obj) },
-        { be_const_key_weak(remove_text_rule, 70), be_const_closure(lvh_obj_remove_text_rule_closure) },
-        { be_const_key_weak(set_val_rule_formula, -1), be_const_closure(lvh_obj_set_val_rule_formula_closure) },
-        { be_const_key_weak(set_text_rule, -1), be_const_closure(lvh_obj_set_text_rule_closure) },
-        { be_const_key_weak(set_text_font, 85), be_const_closure(lvh_obj_set_text_font_closure) },
-        { be_const_key_weak(get_meta, -1), be_const_closure(lvh_obj_get_meta_closure) },
-        { be_const_key_weak(get_text_rule_formula, -1), be_const_closure(lvh_obj_get_text_rule_formula_closure) },
-        { be_const_key_weak(post_init, -1), be_const_closure(lvh_obj_post_init_closure) },
-        { be_const_key_weak(set_enabled, -1), be_const_closure(lvh_obj_set_enabled_closure) },
-        { be_const_key_weak(set_mode, 82), be_const_closure(lvh_obj_set_mode_closure) },
-        { be_const_key_weak(get_mode, -1), be_const_closure(lvh_obj_get_mode_closure) },
-        { be_const_key_weak(val_rule_matched, -1), be_const_closure(lvh_obj_val_rule_matched_closure) },
-        { be_const_key_weak(set_pad_all2, -1), be_const_closure(lvh_obj_set_pad_all2_closure) },
-        { be_const_key_weak(get_click, 75), be_const_closure(lvh_obj_get_click_closure) },
+        { be_const_key_weak(get_value_font, 18), be_const_closure(lvh_obj_get_value_font_closure) },
+        { be_const_key_weak(set_mode, -1), be_const_closure(lvh_obj_set_mode_closure) },
         { be_const_key_weak(get_value_color, -1), be_const_closure(lvh_obj_get_value_color_closure) },
-        { be_const_key_weak(_digit2state, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(6,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(0),
-        be_const_int(1),
-        be_const_int(32),
-        be_const_int(33),
-        be_const_int(128),
-        be_const_int(160),
-    }))    ) } )) },
-        { be_const_key_weak(set_adjustable, -1), be_const_closure(lvh_obj_set_adjustable_closure) },
-        { be_const_key_weak(set_toggle, 2), be_const_closure(lvh_obj_set_toggle_closure) },
-        { be_const_key_weak(id, -1), be_const_var(0) },
-        { be_const_key_weak(_action, 58), be_const_var(4) },
-        { be_const_key_weak(get_line_width, 14), be_const_closure(lvh_obj_get_line_width_closure) },
-        { be_const_key_weak(_digit2part, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(10,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(0),
-        be_const_int(131072),
-        be_const_int(196608),
-        be_const_int(327680),
-        be_const_int(327680),
-        be_const_int(262144),
-        be_const_int(327680),
-        be_const_int(393216),
-        be_const_int(65536),
-        be_const_int(524288),
-    }))    ) } )) },
-        { be_const_key_weak(set_pad_bottom2, -1), be_const_closure(lvh_obj_set_pad_bottom2_closure) },
-        { be_const_key_weak(set_pad_right2, -1), be_const_closure(lvh_obj_set_pad_right2_closure) },
-        { be_const_key_weak(get_val, 35), be_const_closure(lvh_obj_get_val_closure) },
-        { be_const_key_weak(set_click, -1), be_const_closure(lvh_obj_set_click_closure) },
-        { be_const_key_weak(remove_val_rule, -1), be_const_closure(lvh_obj_remove_val_rule_closure) },
-        { be_const_key_weak(_text_rule_formula, 50), be_const_var(10) },
+        { be_const_key_weak(set_val, 48), be_const_closure(lvh_obj_set_val_closure) },
+        { be_const_key_weak(get_mode, -1), be_const_closure(lvh_obj_get_mode_closure) },
+        { be_const_key_weak(set_pad_top2, -1), be_const_closure(lvh_obj_set_pad_top2_closure) },
+        { be_const_key_weak(get_line_width, 22), be_const_closure(lvh_obj_get_line_width_closure) },
+        { be_const_key_weak(get_pad_all, 49), be_const_closure(lvh_obj_get_pad_all_closure) },
+        { be_const_key_weak(get_value_ofs_x, -1), be_const_closure(lvh_obj_get_value_ofs_x_closure) },
         { be_const_key_weak(get_value_ofs_y, -1), be_const_closure(lvh_obj_get_value_ofs_y_closure) },
-        { be_const_key_weak(get_text_rule_format, 73), be_const_closure(lvh_obj_get_text_rule_format_closure) },
-        { be_const_key_weak(get_hidden, 44), be_const_closure(lvh_obj_get_hidden_closure) },
-        { be_const_key_weak(_attr_ignore, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(9,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_nested_str_weak(tostring),
-        be_nested_str_weak(obj),
-        be_nested_str_weak(page),
-        be_nested_str_weak(comment),
-        be_nested_str_weak(parentid),
-        be_nested_str_weak(prev),
-        be_nested_str_weak(next),
-        be_nested_str_weak(back),
-        be_nested_str_weak(berry_run),
-    }))    ) } )) },
-        { be_const_key_weak(get_val_rule_formula, -1), be_const_closure(lvh_obj_get_val_rule_formula_closure) },
-        { be_const_key_weak(check_label, 71), be_const_closure(lvh_obj_check_label_closure) },
-        { be_const_key_weak(get_text_font, -1), be_const_closure(lvh_obj_get_text_font_closure) },
-        { be_const_key_weak(_text_rule, 63), be_const_var(9) },
-        { be_const_key_weak(set_value_str, -1), be_const_closure(lvh_obj_set_value_str_closure) },
-        { be_const_key_weak(_page, -1), be_const_var(3) },
         { be_const_key_weak(get_align, -1), be_const_closure(lvh_obj_get_align_closure) },
-        { be_const_key_weak(is_color_attribute, -1), be_const_closure(lvh_obj_is_color_attribute_closure) },
-        { be_const_key_weak(_text_rule_function, 86), be_const_var(11) },
-        { be_const_key_weak(get_delete, -1), be_const_closure(lvh_obj_get_delete_closure) },
-        { be_const_key_weak(set_value_font, 32), be_const_closure(lvh_obj_set_value_font_closure) },
-        { be_const_key_weak(remove_trailing_zeroes, -1), be_const_static_closure(lvh_obj_remove_trailing_zeroes_closure) },
-        { be_const_key_weak(setmember, -1), be_const_closure(lvh_obj_setmember_closure) },
-        { be_const_key_weak(_val_rule_function, -1), be_const_var(8) },
+        { be_const_key_weak(set_align, -1), be_const_closure(lvh_obj_set_align_closure) },
+        { be_const_key_weak(get_delete, 12), be_const_closure(lvh_obj_get_delete_closure) },
+        { be_const_key_weak(get_hidden, 58), be_const_closure(lvh_obj_get_hidden_closure) },
+        { be_const_key_weak(get_text_font, 37), be_const_closure(lvh_obj_get_text_font_closure) },
+        { be_const_key_weak(get_adjustable, 56), be_const_closure(lvh_obj_get_adjustable_closure) },
+        { be_const_key_weak(set_text_color, 30), be_const_closure(lvh_obj_set_text_color_closure) },
+        { be_const_key_weak(get_click, 34), be_const_closure(lvh_obj_get_click_closure) },
+        { be_const_key_weak(set_value_ofs_y, -1), be_const_closure(lvh_obj_set_value_ofs_y_closure) },
+        { be_const_key_weak(_action, -1), be_const_var(1) },
+        { be_const_key_weak(get_text_color, 51), be_const_closure(lvh_obj_get_text_color_closure) },
+        { be_const_key_weak(get_radius2, -1), be_const_closure(lvh_obj_get_radius2_closure) },
+        { be_const_key_weak(get_pad_bottom, 40), be_const_closure(lvh_obj_get_pad_bottom_closure) },
         { be_const_key_weak(set_pad_left2, -1), be_const_closure(lvh_obj_set_pad_left2_closure) },
         { be_const_key_weak(get_text, -1), be_const_closure(lvh_obj_get_text_closure) },
-        { be_const_key_weak(get_value_ofs_x, -1), be_const_closure(lvh_obj_get_value_ofs_x_closure) },
-        { be_const_key_weak(get_pad_left, -1), be_const_closure(lvh_obj_get_pad_left_closure) },
-        { be_const_key_weak(get_obj, 7), be_const_closure(lvh_obj_get_obj_closure) },
-        { be_const_key_weak(set_value_ofs_y, 5), be_const_closure(lvh_obj_set_value_ofs_y_closure) },
-        { be_const_key_weak(set_val, -1), be_const_closure(lvh_obj_set_val_closure) },
+        { be_const_key_weak(get_pad_top, 20), be_const_closure(lvh_obj_get_pad_top_closure) },
+        { be_const_key_weak(set_pad_bottom2, -1), be_const_closure(lvh_obj_set_pad_bottom2_closure) },
+        { be_const_key_weak(_lv_part2_selector, -1), be_const_nil() },
+        { be_const_key_weak(get_enabled, -1), be_const_closure(lvh_obj_get_enabled_closure) },
+        { be_const_key_weak(get_pad_right, 46), be_const_closure(lvh_obj_get_pad_right_closure) },
+        { be_const_key_weak(set_value_color, 43), be_const_closure(lvh_obj_set_value_color_closure) },
+        { be_const_key_weak(set_radius2, -1), be_const_closure(lvh_obj_set_radius2_closure) },
+        { be_const_key_weak(set_delete, 38), be_const_closure(lvh_obj_set_delete_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(lvh_obj_init_closure) },
+        { be_const_key_weak(set_text_font, -1), be_const_closure(lvh_obj_set_text_font_closure) },
+        { be_const_key_weak(post_init, -1), be_const_closure(lvh_obj_post_init_closure) },
+        { be_const_key_weak(set_text, 52), be_const_closure(lvh_obj_set_text_closure) },
+        { be_const_key_weak(get_pad_left, 16), be_const_closure(lvh_obj_get_pad_left_closure) },
+        { be_const_key_weak(register_event_cb, 26), be_const_closure(lvh_obj_register_event_cb_closure) },
+        { be_const_key_weak(set_value_ofs_x, -1), be_const_closure(lvh_obj_set_value_ofs_x_closure) },
+        { be_const_key_weak(set_adjustable, -1), be_const_closure(lvh_obj_set_adjustable_closure) },
+        { be_const_key_weak(member, -1), be_const_closure(lvh_obj_member_closure) },
+        { be_const_key_weak(event_cb, -1), be_const_closure(lvh_obj_event_cb_closure) },
+        { be_const_key_weak(set_click, -1), be_const_closure(lvh_obj_set_click_closure) },
+        { be_const_key_weak(set_line_width, -1), be_const_closure(lvh_obj_set_line_width_closure) },
     })),
     be_str_weak(lvh_obj)
 );
@@ -7366,6 +7455,374 @@ void be_load_lvh_chart_class(bvm *vm) {
     be_pop(vm, 1);
 }
 
+extern const bclass be_class_lvh_spangroup;
+
+/********************************************************************
+** Solidified function: post_init
+********************************************************************/
+be_local_closure(lvh_spangroup_post_init,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(set_mode),
+    /* K2   */  be_nested_str_weak(lv),
+    /* K3   */  be_nested_str_weak(SPAN_MODE_BREAK),
+    /* K4   */  be_nested_str_weak(refr_mode),
+    /* K5   */  be_nested_str_weak(post_init),
+    }),
+    be_str_weak(post_init),
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0xB80E0400,  //  0002  GETNGBL	R3	K2
+      0x880C0703,  //  0003  GETMBR	R3	R3	K3
+      0x7C040400,  //  0004  CALL	R1	2
+      0x88040100,  //  0005  GETMBR	R1	R0	K0
+      0x8C040304,  //  0006  GETMET	R1	R1	K4
+      0x7C040200,  //  0007  CALL	R1	1
+      0x60040003,  //  0008  GETGBL	R1	G3
+      0x5C080000,  //  0009  MOVE	R2	R0
+      0x7C040200,  //  000A  CALL	R1	1
+      0x8C040305,  //  000B  GETMET	R1	R1	K5
+      0x7C040200,  //  000C  CALL	R1	1
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: refr_mode
+********************************************************************/
+be_local_closure(lvh_spangroup_refr_mode,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(refr_mode),
+    }),
+    be_str_weak(refr_mode),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: lvh_spangroup
+********************************************************************/
+extern const bclass be_class_lvh_obj;
+be_local_class(lvh_spangroup,
+    0,
+    &be_class_lvh_obj,
+    be_nested_map(3,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(refr_mode, -1), be_const_closure(lvh_spangroup_refr_mode_closure) },
+        { be_const_key_weak(_lv_class, -1), be_const_class(be_class_lv_spangroup) },
+        { be_const_key_weak(post_init, 0), be_const_closure(lvh_spangroup_post_init_closure) },
+    })),
+    be_str_weak(lvh_spangroup)
+);
+/*******************************************************************/
+
+void be_load_lvh_spangroup_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_lvh_spangroup);
+    be_setglobal(vm, "lvh_spangroup");
+    be_pop(vm, 1);
+}
+
+extern const bclass be_class_lvh_span;
+
+/********************************************************************
+** Solidified function: setmember
+********************************************************************/
+be_local_closure(lvh_span_setmember,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[17]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(introspect),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_const_int(3),
+    /* K4   */  be_nested_str_weak(set_),
+    /* K5   */  be_nested_str_weak(get_),
+    /* K6   */  be_nested_str_weak(_attr_ignore),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_nested_str_weak(get),
+    /* K9   */  be_nested_str_weak(function),
+    /* K10  */  be_nested_str_weak(_style),
+    /* K11  */  be_nested_str_weak(is_color_attribute),
+    /* K12  */  be_nested_str_weak(parse_color),
+    /* K13  */  be_nested_str_weak(_parent_lvh),
+    /* K14  */  be_nested_str_weak(refr_mode),
+    /* K15  */  be_nested_str_weak(_X20for_X20),
+    /* K16  */  be_nested_str_weak(HSP_X3A_X20Could_X20not_X20find_X20function_X20set_),
+    }),
+    be_str_weak(setmember),
+    &be_const_str_solidified,
+    ( &(const binstruction[73]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xA4120200,  //  0001  IMPORT	R4	K1
+      0x40160503,  //  0002  CONNECT	R5	K2	K3
+      0x94140205,  //  0003  GETIDX	R5	R1	R5
+      0x1C180B04,  //  0004  EQ	R6	R5	K4
+      0x741A0001,  //  0005  JMPT	R6	#0008
+      0x1C180B05,  //  0006  EQ	R6	R5	K5
+      0x781A0000,  //  0007  JMPF	R6	#0009
+      0x80000C00,  //  0008  RET	0
+      0x88140106,  //  0009  GETMBR	R5	R0	K6
+      0x8C140B07,  //  000A  GETMET	R5	R5	K7
+      0x5C1C0200,  //  000B  MOVE	R7	R1
+      0x7C140400,  //  000C  CALL	R5	2
+      0x4C180000,  //  000D  LDNIL	R6
+      0x20140A06,  //  000E  NE	R5	R5	R6
+      0x78160000,  //  000F  JMPF	R5	#0011
+      0x80000A00,  //  0010  RET	0
+      0x8C140908,  //  0011  GETMET	R5	R4	K8
+      0x5C1C0000,  //  0012  MOVE	R7	R0
+      0x00220801,  //  0013  ADD	R8	K4	R1
+      0x7C140600,  //  0014  CALL	R5	3
+      0x60180004,  //  0015  GETGBL	R6	G4
+      0x5C1C0A00,  //  0016  MOVE	R7	R5
+      0x7C180200,  //  0017  CALL	R6	1
+      0x1C180D09,  //  0018  EQ	R6	R6	K9
+      0x781A0004,  //  0019  JMPF	R6	#001F
+      0x5C180A00,  //  001A  MOVE	R6	R5
+      0x5C1C0000,  //  001B  MOVE	R7	R0
+      0x5C200400,  //  001C  MOVE	R8	R2
+      0x7C180400,  //  001D  CALL	R6	2
+      0x80000C00,  //  001E  RET	0
+      0x8C180908,  //  001F  GETMET	R6	R4	K8
+      0x8820010A,  //  0020  GETMBR	R8	R0	K10
+      0x00260801,  //  0021  ADD	R9	K4	R1
+      0x7C180600,  //  0022  CALL	R6	3
+      0x5C140C00,  //  0023  MOVE	R5	R6
+      0x60180004,  //  0024  GETGBL	R6	G4
+      0x5C1C0A00,  //  0025  MOVE	R7	R5
+      0x7C180200,  //  0026  CALL	R6	1
+      0x1C180D09,  //  0027  EQ	R6	R6	K9
+      0x781A001B,  //  0028  JMPF	R6	#0045
+      0x8C18010B,  //  0029  GETMET	R6	R0	K11
+      0x5C200200,  //  002A  MOVE	R8	R1
+      0x7C180400,  //  002B  CALL	R6	2
+      0x781A0003,  //  002C  JMPF	R6	#0031
+      0x8C18010C,  //  002D  GETMET	R6	R0	K12
+      0x5C200400,  //  002E  MOVE	R8	R2
+      0x7C180400,  //  002F  CALL	R6	2
+      0x5C080C00,  //  0030  MOVE	R2	R6
+      0xA8020008,  //  0031  EXBLK	0	#003B
+      0x5C180A00,  //  0032  MOVE	R6	R5
+      0x881C010A,  //  0033  GETMBR	R7	R0	K10
+      0x5C200400,  //  0034  MOVE	R8	R2
+      0x7C180400,  //  0035  CALL	R6	2
+      0x8818010D,  //  0036  GETMBR	R6	R0	K13
+      0x8C180D0E,  //  0037  GETMET	R6	R6	K14
+      0x7C180200,  //  0038  CALL	R6	1
+      0xA8040001,  //  0039  EXBLK	1	1
+      0x70020006,  //  003A  JMP		#0042
+      0xAC180002,  //  003B  CATCH	R6	0	2
+      0x70020003,  //  003C  JMP		#0041
+      0x00200F0F,  //  003D  ADD	R8	R7	K15
+      0x00201001,  //  003E  ADD	R8	R8	R1
+      0xB0040C08,  //  003F  RAISE	1	R6	R8
+      0x70020000,  //  0040  JMP		#0042
+      0xB0080000,  //  0041  RAISE	2	R0	R0
+      0x4C180000,  //  0042  LDNIL	R6
+      0x80040C00,  //  0043  RET	1	R6
+      0x70020002,  //  0044  JMP		#0048
+      0x60180001,  //  0045  GETGBL	R6	G1
+      0x001E2001,  //  0046  ADD	R7	K16	R1
+      0x7C180200,  //  0047  CALL	R6	1
+      0x80000000,  //  0048  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: post_init
+********************************************************************/
+be_local_closure(lvh_span_post_init,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(_parent_lvh),
+    /* K2   */  be_nested_str_weak(_page),
+    /* K3   */  be_nested_str_weak(_oh),
+    /* K4   */  be_nested_str_weak(lvh_spangroup),
+    /* K5   */  be_nested_str_weak(new_span),
+    /* K6   */  be_nested_str_weak(_style),
+    /* K7   */  be_nested_str_weak(get_style),
+    }),
+    be_str_weak(post_init),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0x4C040000,  //  0000  LDNIL	R1
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x6004000F,  //  0002  GETGBL	R1	G15
+      0x88080101,  //  0003  GETMBR	R2	R0	K1
+      0x880C0102,  //  0004  GETMBR	R3	R0	K2
+      0x880C0703,  //  0005  GETMBR	R3	R3	K3
+      0x880C0704,  //  0006  GETMBR	R3	R3	K4
+      0x7C040400,  //  0007  CALL	R1	2
+      0x78060008,  //  0008  JMPF	R1	#0012
+      0x88040101,  //  0009  GETMBR	R1	R0	K1
+      0x88040300,  //  000A  GETMBR	R1	R1	K0
+      0x8C040305,  //  000B  GETMET	R1	R1	K5
+      0x7C040200,  //  000C  CALL	R1	1
+      0x90020001,  //  000D  SETMBR	R0	K0	R1
+      0x88040100,  //  000E  GETMBR	R1	R0	K0
+      0x8C040307,  //  000F  GETMET	R1	R1	K7
+      0x7C040200,  //  0010  CALL	R1	1
+      0x90020C01,  //  0011  SETMBR	R0	K6	R1
+      0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_text_font
+********************************************************************/
+be_local_closure(lvh_span_set_text_font,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(parse_font),
+    /* K1   */  be_nested_str_weak(_style),
+    /* K2   */  be_nested_str_weak(set_text_font),
+    /* K3   */  be_nested_str_weak(_parent_lvh),
+    /* K4   */  be_nested_str_weak(refr_mode),
+    }),
+    be_str_weak(set_text_font),
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x200C0403,  //  0004  NE	R3	R2	R3
+      0x780E0006,  //  0005  JMPF	R3	#000D
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
+      0x5C140400,  //  0008  MOVE	R5	R2
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x880C0103,  //  000A  GETMBR	R3	R0	K3
+      0x8C0C0704,  //  000B  GETMET	R3	R3	K4
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_text
+********************************************************************/
+be_local_closure(lvh_span_set_text,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(set_text),
+    }),
+    be_str_weak(set_text),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x60100008,  //  0002  GETGBL	R4	G8
+      0x5C140200,  //  0003  MOVE	R5	R1
+      0x7C100200,  //  0004  CALL	R4	1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: lvh_span
+********************************************************************/
+extern const bclass be_class_lvh_root;
+be_local_class(lvh_span,
+    1,
+    &be_class_lvh_root,
+    be_nested_map(6,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(setmember, -1), be_const_closure(lvh_span_setmember_closure) },
+        { be_const_key_weak(_lv_class, 4), be_const_nil() },
+        { be_const_key_weak(post_init, -1), be_const_closure(lvh_span_post_init_closure) },
+        { be_const_key_weak(set_text_font, -1), be_const_closure(lvh_span_set_text_font_closure) },
+        { be_const_key_weak(_style, 0), be_const_var(0) },
+        { be_const_key_weak(set_text, -1), be_const_closure(lvh_span_set_text_closure) },
+    })),
+    be_str_weak(lvh_span)
+);
+/*******************************************************************/
+
+void be_load_lvh_span_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_lvh_span);
+    be_setglobal(vm, "lvh_span");
+    be_pop(vm, 1);
+}
+
 extern const bclass be_class_HASPmota;
 
 /********************************************************************
@@ -7431,6 +7888,97 @@ be_local_closure(HASPmota_event_dispatch,   /* name */
       0x88200102,  //  001F  GETMBR	R8	R0	K2
       0x7C180400,  //  0020  CALL	R6	2
       0x80000000,  //  0021  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_page_cur
+********************************************************************/
+be_local_closure(HASPmota_get_page_cur,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(lvh_pages),
+    /* K1   */  be_nested_str_weak(lvh_page_cur_idx),
+    }),
+    be_str_weak(get_page_cur),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x94040202,  //  0002  GETIDX	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: page_dir_to
+********************************************************************/
+be_local_closure(HASPmota_page_dir_to,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(pages_list_sorted),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_const_int(1),
+    /* K3   */  be_const_int(2),
+    /* K4   */  be_nested_str_weak(find),
+    }),
+    be_str_weak(page_dir_to),
+    &be_const_str_solidified,
+    ( &(const binstruction[32]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x58100001,  //  0001  LDCONST	R4	K1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0403,  //  0004  EQ	R3	R2	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80060200,  //  0006  RET	1	K1
+      0x600C000C,  //  0007  GETGBL	R3	G12
+      0x5C100400,  //  0008  MOVE	R4	R2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x18100702,  //  000A  LE	R4	R3	K2
+      0x78120000,  //  000B  JMPF	R4	#000D
+      0x80060200,  //  000C  RET	1	K1
+      0x1C100703,  //  000D  EQ	R4	R3	K3
+      0x78120000,  //  000E  JMPF	R4	#0010
+      0x80060400,  //  000F  RET	1	K2
+      0x8C100504,  //  0010  GETMET	R4	R2	K4
+      0x5C180200,  //  0011  MOVE	R6	R1
+      0x7C100400,  //  0012  CALL	R4	2
+      0x4C140000,  //  0013  LDNIL	R5
+      0x1C140805,  //  0014  EQ	R5	R4	R5
+      0x78160000,  //  0015  JMPF	R5	#0017
+      0x80060200,  //  0016  RET	1	K1
+      0x00140702,  //  0017  ADD	R5	R3	K2
+      0x0C140B03,  //  0018  DIV	R5	R5	K3
+      0x18140805,  //  0019  LE	R5	R4	R5
+      0x78160001,  //  001A  JMPF	R5	#001D
+      0x80060400,  //  001B  RET	1	K2
+      0x70020001,  //  001C  JMP		#001F
+      0x5415FFFE,  //  001D  LDINT	R5	-1
+      0x80040A00,  //  001E  RET	1	R5
+      0x80000000,  //  001F  RET	0
     })
   )
 );
@@ -7523,6 +8071,827 @@ be_local_closure(HASPmota_parse_page,   /* name */
       0x7C100200,  //  0033  CALL	R4	1
       0x900E1A04,  //  0034  SETMBR	R3	K13	R4
       0x80000000,  //  0035  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_obj
+********************************************************************/
+be_local_closure(HASPmota_parse_obj,   /* name */
+  be_nested_proto(
+    22,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[29]) {     /* constants */
+    /* K0   */  be_nested_str_weak(global),
+    /* K1   */  be_nested_str_weak(introspect),
+    /* K2   */  be_nested_str_weak(find),
+    /* K3   */  be_nested_str_weak(id),
+    /* K4   */  be_nested_str_weak(obj),
+    /* K5   */  be_nested_str_weak(get_page_cur),
+    /* K6   */  be_nested_str_weak(berry_run),
+    /* K7   */  be_nested_str_weak(nil),
+    /* K8   */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20compile_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(HSP_X3A_X20invalid_X20_X27id_X27_X3A_X20),
+    /* K11  */  be_nested_str_weak(_X20for_X20_X27obj_X27_X3A),
+    /* K12  */  be_nested_str_weak(parentid),
+    /* K13  */  be_nested_str_weak(get_obj),
+    /* K14  */  be_nested_str_weak(_lv_obj),
+    /* K15  */  be_nested_str_weak(get_scr),
+    /* K16  */  be_nested_str_weak(get),
+    /* K17  */  be_nested_str_weak(lvh_),
+    /* K18  */  be_nested_str_weak(class),
+    /* K19  */  be_nested_str_weak(lvh_obj),
+    /* K20  */  be_nested_str_weak(module),
+    /* K21  */  be_nested_str_weak(HSP_X3A_X20Cannot_X20find_X20object_X20of_X20type_X20),
+    /* K22  */  be_nested_str_weak(add_obj),
+    /* K23  */  be_nested_str_weak(function),
+    /* K24  */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20run_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+    /* K25  */  be_const_int(0),
+    /* K26  */  be_nested_str_weak(HSP_X3A_X20cannot_X20specify_X20_X27obj_X27_X20for_X20_X27id_X27_X3A0),
+    /* K27  */  be_nested_str_weak(keys),
+    /* K28  */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(parse_obj),
+    &be_const_str_solidified,
+    ( &(const binstruction[213]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xA4120200,  //  0001  IMPORT	R4	K1
+      0x60140009,  //  0002  GETGBL	R5	G9
+      0x8C180302,  //  0003  GETMET	R6	R1	K2
+      0x58200003,  //  0004  LDCONST	R8	K3
+      0x7C180400,  //  0005  CALL	R6	2
+      0x7C140200,  //  0006  CALL	R5	1
+      0x60180008,  //  0007  GETGBL	R6	G8
+      0x8C1C0302,  //  0008  GETMET	R7	R1	K2
+      0x58240004,  //  0009  LDCONST	R9	K4
+      0x7C1C0400,  //  000A  CALL	R7	2
+      0x7C180200,  //  000B  CALL	R6	1
+      0x4C1C0000,  //  000C  LDNIL	R7
+      0x8C200105,  //  000D  GETMET	R8	R0	K5
+      0x7C200200,  //  000E  CALL	R8	1
+      0x60240008,  //  000F  GETGBL	R9	G8
+      0x8C280302,  //  0010  GETMET	R10	R1	K2
+      0x58300006,  //  0011  LDCONST	R12	K6
+      0x7C280400,  //  0012  CALL	R10	2
+      0x7C240200,  //  0013  CALL	R9	1
+      0x4C280000,  //  0014  LDNIL	R10
+      0x202C1307,  //  0015  NE	R11	R9	K7
+      0x782E0012,  //  0016  JMPF	R11	#002A
+      0xA8020005,  //  0017  EXBLK	0	#001E
+      0x602C000D,  //  0018  GETGBL	R11	G13
+      0x5C301200,  //  0019  MOVE	R12	R9
+      0x7C2C0200,  //  001A  CALL	R11	1
+      0x5C281600,  //  001B  MOVE	R10	R11
+      0xA8040001,  //  001C  EXBLK	1	1
+      0x7002000B,  //  001D  JMP		#002A
+      0xAC2C0002,  //  001E  CATCH	R11	0	2
+      0x70020008,  //  001F  JMP		#0029
+      0x60340001,  //  0020  GETGBL	R13	G1
+      0x60380018,  //  0021  GETGBL	R14	G24
+      0x583C0008,  //  0022  LDCONST	R15	K8
+      0x5C401200,  //  0023  MOVE	R16	R9
+      0x5C441600,  //  0024  MOVE	R17	R11
+      0x5C481800,  //  0025  MOVE	R18	R12
+      0x7C380800,  //  0026  CALL	R14	4
+      0x7C340200,  //  0027  CALL	R13	1
+      0x70020000,  //  0028  JMP		#002A
+      0xB0080000,  //  0029  RAISE	2	R0	R0
+      0x202C0D07,  //  002A  NE	R11	R6	K7
+      0x782E006A,  //  002B  JMPF	R11	#0097
+      0x4C2C0000,  //  002C  LDNIL	R11
+      0x202C0A0B,  //  002D  NE	R11	R5	R11
+      0x782E0067,  //  002E  JMPF	R11	#0097
+      0x142C0B09,  //  002F  LT	R11	R5	K9
+      0x742E0002,  //  0030  JMPT	R11	#0034
+      0x542E00FD,  //  0031  LDINT	R11	254
+      0x242C0A0B,  //  0032  GT	R11	R5	R11
+      0x782E0008,  //  0033  JMPF	R11	#003D
+      0x602C0001,  //  0034  GETGBL	R11	G1
+      0x60300008,  //  0035  GETGBL	R12	G8
+      0x5C340A00,  //  0036  MOVE	R13	R5
+      0x7C300200,  //  0037  CALL	R12	1
+      0x0032140C,  //  0038  ADD	R12	K10	R12
+      0x0030190B,  //  0039  ADD	R12	R12	K11
+      0x00301806,  //  003A  ADD	R12	R12	R6
+      0x7C2C0200,  //  003B  CALL	R11	1
+      0x80001600,  //  003C  RET	0
+      0x4C2C0000,  //  003D  LDNIL	R11
+      0x60300009,  //  003E  GETGBL	R12	G9
+      0x8C340302,  //  003F  GETMET	R13	R1	K2
+      0x583C000C,  //  0040  LDCONST	R15	K12
+      0x7C340400,  //  0041  CALL	R13	2
+      0x7C300200,  //  0042  CALL	R12	1
+      0x4C340000,  //  0043  LDNIL	R13
+      0x4C380000,  //  0044  LDNIL	R14
+      0x2038180E,  //  0045  NE	R14	R12	R14
+      0x783A0007,  //  0046  JMPF	R14	#004F
+      0x8C38110D,  //  0047  GETMET	R14	R8	K13
+      0x5C401800,  //  0048  MOVE	R16	R12
+      0x7C380400,  //  0049  CALL	R14	2
+      0x5C341C00,  //  004A  MOVE	R13	R14
+      0x4C380000,  //  004B  LDNIL	R14
+      0x20381A0E,  //  004C  NE	R14	R13	R14
+      0x783A0000,  //  004D  JMPF	R14	#004F
+      0x882C1B0E,  //  004E  GETMBR	R11	R13	K14
+      0x4C380000,  //  004F  LDNIL	R14
+      0x1C38160E,  //  0050  EQ	R14	R11	R14
+      0x783A0002,  //  0051  JMPF	R14	#0055
+      0x8C38110F,  //  0052  GETMET	R14	R8	K15
+      0x7C380200,  //  0053  CALL	R14	1
+      0x5C2C1C00,  //  0054  MOVE	R11	R14
+      0x8C380910,  //  0055  GETMET	R14	R4	K16
+      0x5C400000,  //  0056  MOVE	R16	R0
+      0x00462206,  //  0057  ADD	R17	K17	R6
+      0x7C380600,  //  0058  CALL	R14	3
+      0x4C3C0000,  //  0059  LDNIL	R15
+      0x4C400000,  //  005A  LDNIL	R16
+      0x1C401C10,  //  005B  EQ	R16	R14	R16
+      0x78420010,  //  005C  JMPF	R16	#006E
+      0x8C400910,  //  005D  GETMET	R16	R4	K16
+      0x5C480600,  //  005E  MOVE	R18	R3
+      0x5C4C0C00,  //  005F  MOVE	R19	R6
+      0x7C400600,  //  0060  CALL	R16	3
+      0x4C440000,  //  0061  LDNIL	R17
+      0x20442011,  //  0062  NE	R17	R16	R17
+      0x78460009,  //  0063  JMPF	R17	#006E
+      0x60440004,  //  0064  GETGBL	R17	G4
+      0x5C482000,  //  0065  MOVE	R18	R16
+      0x7C440200,  //  0066  CALL	R17	1
+      0x1C442312,  //  0067  EQ	R17	R17	K18
+      0x78460004,  //  0068  JMPF	R17	#006E
+      0x5C442000,  //  0069  MOVE	R17	R16
+      0x5C481600,  //  006A  MOVE	R18	R11
+      0x7C440200,  //  006B  CALL	R17	1
+      0x5C3C2200,  //  006C  MOVE	R15	R17
+      0x88380113,  //  006D  GETMBR	R14	R0	K19
+      0x4C400000,  //  006E  LDNIL	R16
+      0x1C401C10,  //  006F  EQ	R16	R14	R16
+      0x7842000F,  //  0070  JMPF	R16	#0081
+      0x8C400914,  //  0071  GETMET	R16	R4	K20
+      0x5C480C00,  //  0072  MOVE	R18	R6
+      0x7C400400,  //  0073  CALL	R16	2
+      0x4C440000,  //  0074  LDNIL	R17
+      0x20442011,  //  0075  NE	R17	R16	R17
+      0x78460009,  //  0076  JMPF	R17	#0081
+      0x60440004,  //  0077  GETGBL	R17	G4
+      0x5C482000,  //  0078  MOVE	R18	R16
+      0x7C440200,  //  0079  CALL	R17	1
+      0x1C442312,  //  007A  EQ	R17	R17	K18
+      0x78460004,  //  007B  JMPF	R17	#0081
+      0x5C442000,  //  007C  MOVE	R17	R16
+      0x5C481600,  //  007D  MOVE	R18	R11
+      0x7C440200,  //  007E  CALL	R17	1
+      0x5C3C2200,  //  007F  MOVE	R15	R17
+      0x88380113,  //  0080  GETMBR	R14	R0	K19
+      0x4C400000,  //  0081  LDNIL	R16
+      0x1C401C10,  //  0082  EQ	R16	R14	R16
+      0x78420006,  //  0083  JMPF	R16	#008B
+      0x60400001,  //  0084  GETGBL	R16	G1
+      0x60440008,  //  0085  GETGBL	R17	G8
+      0x5C480C00,  //  0086  MOVE	R18	R6
+      0x7C440200,  //  0087  CALL	R17	1
+      0x00462A11,  //  0088  ADD	R17	K21	R17
+      0x7C400200,  //  0089  CALL	R16	1
+      0x80002000,  //  008A  RET	0
+      0x5C401C00,  //  008B  MOVE	R16	R14
+      0x5C441600,  //  008C  MOVE	R17	R11
+      0x5C480400,  //  008D  MOVE	R18	R2
+      0x5C4C0200,  //  008E  MOVE	R19	R1
+      0x5C501E00,  //  008F  MOVE	R20	R15
+      0x5C541A00,  //  0090  MOVE	R21	R13
+      0x7C400A00,  //  0091  CALL	R16	5
+      0x5C1C2000,  //  0092  MOVE	R7	R16
+      0x8C401116,  //  0093  GETMET	R16	R8	K22
+      0x5C480A00,  //  0094  MOVE	R18	R5
+      0x5C4C0E00,  //  0095  MOVE	R19	R7
+      0x7C400600,  //  0096  CALL	R16	3
+      0x4C2C0000,  //  0097  LDNIL	R11
+      0x202C140B,  //  0098  NE	R11	R10	R11
+      0x782E0018,  //  0099  JMPF	R11	#00B3
+      0xA802000B,  //  009A  EXBLK	0	#00A7
+      0x5C2C1400,  //  009B  MOVE	R11	R10
+      0x7C2C0000,  //  009C  CALL	R11	0
+      0x60300004,  //  009D  GETGBL	R12	G4
+      0x5C341600,  //  009E  MOVE	R13	R11
+      0x7C300200,  //  009F  CALL	R12	1
+      0x1C301917,  //  00A0  EQ	R12	R12	K23
+      0x78320002,  //  00A1  JMPF	R12	#00A5
+      0x5C301600,  //  00A2  MOVE	R12	R11
+      0x5C340E00,  //  00A3  MOVE	R13	R7
+      0x7C300200,  //  00A4  CALL	R12	1
+      0xA8040001,  //  00A5  EXBLK	1	1
+      0x7002000B,  //  00A6  JMP		#00B3
+      0xAC2C0002,  //  00A7  CATCH	R11	0	2
+      0x70020008,  //  00A8  JMP		#00B2
+      0x60340001,  //  00A9  GETGBL	R13	G1
+      0x60380018,  //  00AA  GETGBL	R14	G24
+      0x583C0018,  //  00AB  LDCONST	R15	K24
+      0x5C401200,  //  00AC  MOVE	R16	R9
+      0x5C441600,  //  00AD  MOVE	R17	R11
+      0x5C481800,  //  00AE  MOVE	R18	R12
+      0x7C380800,  //  00AF  CALL	R14	4
+      0x7C340200,  //  00B0  CALL	R13	1
+      0x70020000,  //  00B1  JMP		#00B3
+      0xB0080000,  //  00B2  RAISE	2	R0	R0
+      0x4C2C0000,  //  00B3  LDNIL	R11
+      0x1C2C0A0B,  //  00B4  EQ	R11	R5	R11
+      0x782E0000,  //  00B5  JMPF	R11	#00B7
+      0x80001600,  //  00B6  RET	0
+      0x1C2C0B19,  //  00B7  EQ	R11	R5	K25
+      0x782E0005,  //  00B8  JMPF	R11	#00BF
+      0x202C0D07,  //  00B9  NE	R11	R6	K7
+      0x782E0003,  //  00BA  JMPF	R11	#00BF
+      0x602C0001,  //  00BB  GETGBL	R11	G1
+      0x5830001A,  //  00BC  LDCONST	R12	K26
+      0x7C2C0200,  //  00BD  CALL	R11	1
+      0x80001600,  //  00BE  RET	0
+      0x1C2C0B19,  //  00BF  EQ	R11	R5	K25
+      0x782E0005,  //  00C0  JMPF	R11	#00C7
+      0x8C2C0105,  //  00C1  GETMET	R11	R0	K5
+      0x7C2C0200,  //  00C2  CALL	R11	1
+      0x8C2C170D,  //  00C3  GETMET	R11	R11	K13
+      0x58340019,  //  00C4  LDCONST	R13	K25
+      0x7C2C0400,  //  00C5  CALL	R11	2
+      0x5C1C1600,  //  00C6  MOVE	R7	R11
+      0x602C0010,  //  00C7  GETGBL	R11	G16
+      0x8C30031B,  //  00C8  GETMET	R12	R1	K27
+      0x7C300200,  //  00C9  CALL	R12	1
+      0x7C2C0200,  //  00CA  CALL	R11	1
+      0xA8020004,  //  00CB  EXBLK	0	#00D1
+      0x5C301600,  //  00CC  MOVE	R12	R11
+      0x7C300000,  //  00CD  CALL	R12	0
+      0x9434020C,  //  00CE  GETIDX	R13	R1	R12
+      0x901C180D,  //  00CF  SETMBR	R7	R12	R13
+      0x7001FFFA,  //  00D0  JMP		#00CC
+      0x582C001C,  //  00D1  LDCONST	R11	K28
+      0xAC2C0200,  //  00D2  CATCH	R11	1	0
+      0xB0080000,  //  00D3  RAISE	2	R0	R0
+      0x80000000,  //  00D4  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pages_list_sorted
+********************************************************************/
+be_local_closure(HASPmota_pages_list_sorted,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(lvh_page_cur_idx),
+    /* K2   */  be_nested_str_weak(lvh_pages),
+    /* K3   */  be_nested_str_weak(keys),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    /* K6   */  be_nested_str_weak(sort),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_const_int(1),
+    }),
+    be_str_weak(pages_list_sorted),
+    &be_const_str_solidified,
+    ( &(const binstruction[47]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x1C0C0300,  //  0002  EQ	R3	R1	K0
+      0x780E0000,  //  0003  JMPF	R3	#0005
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x600C0010,  //  0005  GETGBL	R3	G16
+      0x88100102,  //  0006  GETMBR	R4	R0	K2
+      0x8C100903,  //  0007  GETMET	R4	R4	K3
+      0x7C100200,  //  0008  CALL	R4	1
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0xA8020007,  //  000A  EXBLK	0	#0013
+      0x5C100600,  //  000B  MOVE	R4	R3
+      0x7C100000,  //  000C  CALL	R4	0
+      0x20140900,  //  000D  NE	R5	R4	K0
+      0x78160002,  //  000E  JMPF	R5	#0012
+      0x8C140504,  //  000F  GETMET	R5	R2	K4
+      0x5C1C0800,  //  0010  MOVE	R7	R4
+      0x7C140400,  //  0011  CALL	R5	2
+      0x7001FFF7,  //  0012  JMP		#000B
+      0x580C0005,  //  0013  LDCONST	R3	K5
+      0xAC0C0200,  //  0014  CATCH	R3	1	0
+      0xB0080000,  //  0015  RAISE	2	R0	R0
+      0x8C0C0106,  //  0016  GETMET	R3	R0	K6
+      0x5C140400,  //  0017  MOVE	R5	R2
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x5C080600,  //  0019  MOVE	R2	R3
+      0x4C0C0000,  //  001A  LDNIL	R3
+      0x1C0C0203,  //  001B  EQ	R3	R1	R3
+      0x780E0000,  //  001C  JMPF	R3	#001E
+      0x80040200,  //  001D  RET	1	R1
+      0x600C000C,  //  001E  GETGBL	R3	G12
+      0x5C100400,  //  001F  MOVE	R4	R2
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x00080402,  //  0021  ADD	R2	R2	R2
+      0x8C100507,  //  0022  GETMET	R4	R2	K7
+      0x5C180200,  //  0023  MOVE	R6	R1
+      0x7C100400,  //  0024  CALL	R4	2
+      0x4C140000,  //  0025  LDNIL	R5
+      0x1C140805,  //  0026  EQ	R5	R4	R5
+      0x78160001,  //  0027  JMPF	R5	#002A
+      0x4C140000,  //  0028  LDNIL	R5
+      0x80040A00,  //  0029  RET	1	R5
+      0x00140803,  //  002A  ADD	R5	R4	R3
+      0x04140B08,  //  002B  SUB	R5	R5	K8
+      0x40140805,  //  002C  CONNECT	R5	R4	R5
+      0x94080405,  //  002D  GETIDX	R2	R2	R5
+      0x80040400,  //  002E  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(HASPmota_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fix_lv_version),
+    /* K1   */  be_nested_str_weak(re),
+    /* K2   */  be_nested_str_weak(re_page_target),
+    /* K3   */  be_nested_str_weak(compile),
+    /* K4   */  be_nested_str_weak(p_X5Cd_X2B),
+    /* K5   */  be_nested_str_weak(re_color_suffix),
+    /* K6   */  be_nested_str_weak(color_X24),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0xA4060200,  //  0002  IMPORT	R1	K1
+      0x8C080303,  //  0003  GETMET	R2	R1	K3
+      0x58100004,  //  0004  LDCONST	R4	K4
+      0x7C080400,  //  0005  CALL	R2	2
+      0x90020402,  //  0006  SETMBR	R0	K2	R2
+      0x8C080303,  //  0007  GETMET	R2	R1	K3
+      0x58100006,  //  0008  LDCONST	R4	K6
+      0x7C080400,  //  0009  CALL	R2	2
+      0x90020A02,  //  000A  SETMBR	R0	K5	R2
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _load
+********************************************************************/
+be_local_closure(HASPmota__load,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[26]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(json),
+    /* K2   */  be_nested_str_weak(lvh_page_cur_idx),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(lvh_page),
+    /* K5   */  be_nested_str_weak(lvh_pages),
+    /* K6   */  be_nested_str_weak(r),
+    /* K7   */  be_nested_str_weak(read),
+    /* K8   */  be_nested_str_weak(close),
+    /* K9   */  be_nested_str_weak(split),
+    /* K10  */  be_nested_str_weak(_X0A),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_weak(load),
+    /* K13  */  be_nested_str_weak(instance),
+    /* K14  */  be_nested_str_weak(tasmota),
+    /* K15  */  be_nested_str_weak(loglevel),
+    /* K16  */  be_nested_str_weak(log),
+    /* K17  */  be_nested_str_weak(HSP_X3A_X20parsing_X20line_X20_X27_X25s_X27),
+    /* K18  */  be_nested_str_weak(parse_page),
+    /* K19  */  be_nested_str_weak(parse_obj),
+    /* K20  */  be_nested_str_weak(tr),
+    /* K21  */  be_nested_str_weak(_X20_X09),
+    /* K22  */  be_nested_str_weak(),
+    /* K23  */  be_nested_str_weak(HSP_X3A_X20invalid_X20JSON_X20line_X20_X27_X25s_X27),
+    /* K24  */  be_const_int(2),
+    /* K25  */  be_nested_str_weak(remove),
+    }),
+    be_str_weak(_load),
+    &be_const_str_solidified,
+    ( &(const binstruction[85]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0x90020503,  //  0002  SETMBR	R0	K2	K3
+      0x88100104,  //  0003  GETMBR	R4	R0	K4
+      0x88140105,  //  0004  GETMBR	R5	R0	K5
+      0x5C180800,  //  0005  MOVE	R6	R4
+      0x581C0003,  //  0006  LDCONST	R7	K3
+      0x5C200000,  //  0007  MOVE	R8	R0
+      0x7C180400,  //  0008  CALL	R6	2
+      0x98160606,  //  0009  SETIDX	R5	K3	R6
+      0x60140011,  //  000A  GETGBL	R5	G17
+      0x5C180200,  //  000B  MOVE	R6	R1
+      0x581C0006,  //  000C  LDCONST	R7	K6
+      0x7C140400,  //  000D  CALL	R5	2
+      0x8C180B07,  //  000E  GETMET	R6	R5	K7
+      0x7C180200,  //  000F  CALL	R6	1
+      0x8C1C0B08,  //  0010  GETMET	R7	R5	K8
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x8C1C0509,  //  0012  GETMET	R7	R2	K9
+      0x5C240C00,  //  0013  MOVE	R9	R6
+      0x5828000A,  //  0014  LDCONST	R10	K10
+      0x7C1C0600,  //  0015  CALL	R7	3
+      0x4C140000,  //  0016  LDNIL	R5
+      0x4C180000,  //  0017  LDNIL	R6
+      0x6020000C,  //  0018  GETGBL	R8	G12
+      0x5C240E00,  //  0019  MOVE	R9	R7
+      0x7C200200,  //  001A  CALL	R8	1
+      0x2420110B,  //  001B  GT	R8	R8	K11
+      0x78220034,  //  001C  JMPF	R8	#0052
+      0x8C20070C,  //  001D  GETMET	R8	R3	K12
+      0x94280F0B,  //  001E  GETIDX	R10	R7	K11
+      0x7C200400,  //  001F  CALL	R8	2
+      0x60240004,  //  0020  GETGBL	R9	G4
+      0x5C281000,  //  0021  MOVE	R10	R8
+      0x7C240200,  //  0022  CALL	R9	1
+      0x1C24130D,  //  0023  EQ	R9	R9	K13
+      0x78260016,  //  0024  JMPF	R9	#003C
+      0xB8261C00,  //  0025  GETNGBL	R9	K14
+      0x8C24130F,  //  0026  GETMET	R9	R9	K15
+      0x542E0003,  //  0027  LDINT	R11	4
+      0x7C240400,  //  0028  CALL	R9	2
+      0x78260007,  //  0029  JMPF	R9	#0032
+      0xB8261C00,  //  002A  GETNGBL	R9	K14
+      0x8C241310,  //  002B  GETMET	R9	R9	K16
+      0x602C0018,  //  002C  GETGBL	R11	G24
+      0x58300011,  //  002D  LDCONST	R12	K17
+      0x94340F0B,  //  002E  GETIDX	R13	R7	K11
+      0x7C2C0400,  //  002F  CALL	R11	2
+      0x54320003,  //  0030  LDINT	R12	4
+      0x7C240600,  //  0031  CALL	R9	3
+      0x8C240112,  //  0032  GETMET	R9	R0	K18
+      0x5C2C1000,  //  0033  MOVE	R11	R8
+      0x7C240400,  //  0034  CALL	R9	2
+      0x8C240113,  //  0035  GETMET	R9	R0	K19
+      0x5C2C1000,  //  0036  MOVE	R11	R8
+      0x88300105,  //  0037  GETMBR	R12	R0	K5
+      0x88340102,  //  0038  GETMBR	R13	R0	K2
+      0x9430180D,  //  0039  GETIDX	R12	R12	R13
+      0x7C240600,  //  003A  CALL	R9	3
+      0x70020010,  //  003B  JMP		#004D
+      0x6024000C,  //  003C  GETGBL	R9	G12
+      0x8C280514,  //  003D  GETMET	R10	R2	K20
+      0x94300F0B,  //  003E  GETIDX	R12	R7	K11
+      0x58340015,  //  003F  LDCONST	R13	K21
+      0x58380016,  //  0040  LDCONST	R14	K22
+      0x7C280800,  //  0041  CALL	R10	4
+      0x7C240200,  //  0042  CALL	R9	1
+      0x2424130B,  //  0043  GT	R9	R9	K11
+      0x78260007,  //  0044  JMPF	R9	#004D
+      0xB8261C00,  //  0045  GETNGBL	R9	K14
+      0x8C241310,  //  0046  GETMET	R9	R9	K16
+      0x602C0018,  //  0047  GETGBL	R11	G24
+      0x58300017,  //  0048  LDCONST	R12	K23
+      0x94340F0B,  //  0049  GETIDX	R13	R7	K11
+      0x7C2C0400,  //  004A  CALL	R11	2
+      0x58300018,  //  004B  LDCONST	R12	K24
+      0x7C240600,  //  004C  CALL	R9	3
+      0x4C200000,  //  004D  LDNIL	R8
+      0x8C240F19,  //  004E  GETMET	R9	R7	K25
+      0x582C000B,  //  004F  LDCONST	R11	K11
+      0x7C240400,  //  0050  CALL	R9	2
+      0x7001FFC5,  //  0051  JMP		#0018
+      0x4C1C0000,  //  0052  LDNIL	R7
+      0x90020503,  //  0053  SETMBR	R0	K2	K3
+      0x80000000,  //  0054  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sort
+********************************************************************/
+be_local_closure(HASPmota_sort,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_class(be_class_HASPmota),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(sort),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x60080010,  //  0001  GETGBL	R2	G16
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x040C0701,  //  0005  SUB	R3	R3	K1
+      0x400E0203,  //  0006  CONNECT	R3	K1	R3
+      0x7C080200,  //  0007  CALL	R2	1
+      0xA8020010,  //  0008  EXBLK	0	#001A
+      0x5C0C0400,  //  0009  MOVE	R3	R2
+      0x7C0C0000,  //  000A  CALL	R3	0
+      0x94100003,  //  000B  GETIDX	R4	R0	R3
+      0x5C140600,  //  000C  MOVE	R5	R3
+      0x24180B02,  //  000D  GT	R6	R5	K2
+      0x781A0008,  //  000E  JMPF	R6	#0018
+      0x04180B01,  //  000F  SUB	R6	R5	K1
+      0x94180006,  //  0010  GETIDX	R6	R0	R6
+      0x24180C04,  //  0011  GT	R6	R6	R4
+      0x781A0004,  //  0012  JMPF	R6	#0018
+      0x04180B01,  //  0013  SUB	R6	R5	K1
+      0x94180006,  //  0014  GETIDX	R6	R0	R6
+      0x98000A06,  //  0015  SETIDX	R0	R5	R6
+      0x04140B01,  //  0016  SUB	R5	R5	K1
+      0x7001FFF4,  //  0017  JMP		#000D
+      0x98000A04,  //  0018  SETIDX	R0	R5	R4
+      0x7001FFEE,  //  0019  JMP		#0009
+      0x58080003,  //  001A  LDCONST	R2	K3
+      0xAC080200,  //  001B  CATCH	R2	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x80040000,  //  001D  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: do_action
+********************************************************************/
+be_local_closure(HASPmota_do_action,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(lv),
+    /* K1   */  be_nested_str_weak(EVENT_CLICKED),
+    /* K2   */  be_nested_str_weak(page_show),
+    /* K3   */  be_nested_str_weak(_action),
+    }),
+    be_str_weak(do_action),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x200C0403,  //  0002  NE	R3	R2	R3
+      0x780E0000,  //  0003  JMPF	R3	#0005
+      0x80000600,  //  0004  RET	0
+      0x8C0C0102,  //  0005  GETMET	R3	R0	K2
+      0x88140303,  //  0006  GETMBR	R5	R1	K3
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: page_show
+********************************************************************/
+be_local_closure(HASPmota_page_show,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(lvh_pages),
+    /* K1   */  be_nested_str_weak(lvh_page_cur_idx),
+    /* K2   */  be_nested_str_weak(pages_list_sorted),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_nested_str_weak(prev),
+    /* K5   */  be_nested_str_weak(next),
+    /* K6   */  be_nested_str_weak(back),
+    /* K7   */  be_nested_str_weak(re_page_target),
+    /* K8   */  be_nested_str_weak(match),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_nested_str_weak(show),
+    }),
+    be_str_weak(page_show),
+    &be_const_str_solidified,
+    ( &(const binstruction[68]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x880C0100,  //  0001  GETMBR	R3	R0	K0
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x940C0604,  //  0003  GETIDX	R3	R3	R4
+      0x8C100102,  //  0004  GETMET	R4	R0	K2
+      0x88180101,  //  0005  GETMBR	R6	R0	K1
+      0x7C100400,  //  0006  CALL	R4	2
+      0x6014000C,  //  0007  GETGBL	R5	G12
+      0x5C180800,  //  0008  MOVE	R6	R4
+      0x7C140200,  //  0009  CALL	R5	1
+      0x18140B03,  //  000A  LE	R5	R5	K3
+      0x78160000,  //  000B  JMPF	R5	#000D
+      0x80000A00,  //  000C  RET	0
+      0x1C140304,  //  000D  EQ	R5	R1	K4
+      0x78160009,  //  000E  JMPF	R5	#0019
+      0x60140009,  //  000F  GETGBL	R5	G9
+      0x88180704,  //  0010  GETMBR	R6	R3	K4
+      0x7C140200,  //  0011  CALL	R5	1
+      0x5C080A00,  //  0012  MOVE	R2	R5
+      0x4C140000,  //  0013  LDNIL	R5
+      0x1C140405,  //  0014  EQ	R5	R2	R5
+      0x78160001,  //  0015  JMPF	R5	#0018
+      0x5415FFFE,  //  0016  LDINT	R5	-1
+      0x94080805,  //  0017  GETIDX	R2	R4	R5
+      0x70020020,  //  0018  JMP		#003A
+      0x1C140305,  //  0019  EQ	R5	R1	K5
+      0x78160008,  //  001A  JMPF	R5	#0024
+      0x60140009,  //  001B  GETGBL	R5	G9
+      0x88180705,  //  001C  GETMBR	R6	R3	K5
+      0x7C140200,  //  001D  CALL	R5	1
+      0x5C080A00,  //  001E  MOVE	R2	R5
+      0x4C140000,  //  001F  LDNIL	R5
+      0x1C140405,  //  0020  EQ	R5	R2	R5
+      0x78160000,  //  0021  JMPF	R5	#0023
+      0x94080903,  //  0022  GETIDX	R2	R4	K3
+      0x70020015,  //  0023  JMP		#003A
+      0x1C140306,  //  0024  EQ	R5	R1	K6
+      0x78160008,  //  0025  JMPF	R5	#002F
+      0x60140009,  //  0026  GETGBL	R5	G9
+      0x88180706,  //  0027  GETMBR	R6	R3	K6
+      0x7C140200,  //  0028  CALL	R5	1
+      0x5C080A00,  //  0029  MOVE	R2	R5
+      0x4C140000,  //  002A  LDNIL	R5
+      0x1C140405,  //  002B  EQ	R5	R2	R5
+      0x78160000,  //  002C  JMPF	R5	#002E
+      0x58080003,  //  002D  LDCONST	R2	K3
+      0x7002000A,  //  002E  JMP		#003A
+      0x88140107,  //  002F  GETMBR	R5	R0	K7
+      0x8C140B08,  //  0030  GETMET	R5	R5	K8
+      0x5C1C0200,  //  0031  MOVE	R7	R1
+      0x7C140400,  //  0032  CALL	R5	2
+      0x78160005,  //  0033  JMPF	R5	#003A
+      0x60140009,  //  0034  GETGBL	R5	G9
+      0x5419FFFE,  //  0035  LDINT	R6	-1
+      0x401A0606,  //  0036  CONNECT	R6	K3	R6
+      0x94180206,  //  0037  GETIDX	R6	R1	R6
+      0x7C140200,  //  0038  CALL	R5	1
+      0x5C080A00,  //  0039  MOVE	R2	R5
+      0x4C140000,  //  003A  LDNIL	R5
+      0x20140405,  //  003B  NE	R5	R2	R5
+      0x78160005,  //  003C  JMPF	R5	#0043
+      0x24140509,  //  003D  GT	R5	R2	K9
+      0x78160003,  //  003E  JMPF	R5	#0043
+      0x88140100,  //  003F  GETMBR	R5	R0	K0
+      0x94140A02,  //  0040  GETIDX	R5	R5	R2
+      0x8C140B0A,  //  0041  GETMET	R5	R5	K10
+      0x7C140200,  //  0042  CALL	R5	1
+      0x80000000,  //  0043  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse
+********************************************************************/
+be_local_closure(HASPmota_parse,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(load),
+    /* K2   */  be_nested_str_weak(instance),
+    /* K3   */  be_nested_str_weak(parse_page),
+    /* K4   */  be_nested_str_weak(parse_obj),
+    /* K5   */  be_nested_str_weak(lvh_pages),
+    /* K6   */  be_nested_str_weak(lvh_page_cur_idx),
+    /* K7   */  be_nested_str_weak(value_error),
+    /* K8   */  be_nested_str_weak(unable_X20to_X20parse_X20JSON_X20line),
+    }),
+    be_str_weak(parse),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x60100004,  //  0004  GETGBL	R4	G4
+      0x5C140600,  //  0005  MOVE	R5	R3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x1C100902,  //  0007  EQ	R4	R4	K2
+      0x78120009,  //  0008  JMPF	R4	#0013
+      0x8C100103,  //  0009  GETMET	R4	R0	K3
+      0x5C180600,  //  000A  MOVE	R6	R3
+      0x7C100400,  //  000B  CALL	R4	2
+      0x8C100104,  //  000C  GETMET	R4	R0	K4
+      0x5C180600,  //  000D  MOVE	R6	R3
+      0x881C0105,  //  000E  GETMBR	R7	R0	K5
+      0x88200106,  //  000F  GETMBR	R8	R0	K6
+      0x941C0E08,  //  0010  GETIDX	R7	R7	R8
+      0x7C100600,  //  0011  CALL	R4	3
+      0x70020000,  //  0012  JMP		#0014
+      0xB0060F08,  //  0013  RAISE	1	K7	K8
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: fix_lv_version
+********************************************************************/
+be_local_closure(HASPmota_fix_lv_version,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    0,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_class(be_class_HASPmota),
+    /* K1   */  be_nested_str_weak(introspect),
+    /* K2   */  be_nested_str_weak(get),
+    /* K3   */  be_nested_str_weak(lv),
+    /* K4   */  be_nested_str_weak(version),
+    /* K5   */  be_nested_str_weak(int),
+    }),
+    be_str_weak(fix_lv_version),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x58000000,  //  0000  LDCONST	R0	K0
+      0xA4060200,  //  0001  IMPORT	R1	K1
+      0x8C080302,  //  0002  GETMET	R2	R1	K2
+      0xB8120600,  //  0003  GETNGBL	R4	K3
+      0x58140004,  //  0004  LDCONST	R5	K4
+      0x7C080600,  //  0005  CALL	R2	3
+      0x600C0004,  //  0006  GETGBL	R3	G4
+      0x5C100400,  //  0007  MOVE	R4	R2
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x200C0705,  //  0009  NE	R3	R3	K5
+      0x780E0002,  //  000A  JMPF	R3	#000E
+      0xB80E0600,  //  000B  GETNGBL	R3	K3
+      0x54120007,  //  000C  LDINT	R4	8
+      0x900E0804,  //  000D  SETMBR	R3	K4	R4
+      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -7692,51 +9061,6 @@ be_local_closure(HASPmota_start,   /* name */
 
 
 /********************************************************************
-** Solidified function: fix_lv_version
-********************************************************************/
-be_local_closure(HASPmota_fix_lv_version,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    0,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_class(be_class_HASPmota),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(get),
-    /* K3   */  be_nested_str_weak(lv),
-    /* K4   */  be_nested_str_weak(version),
-    /* K5   */  be_nested_str_weak(int),
-    }),
-    be_str_weak(fix_lv_version),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x58000000,  //  0000  LDCONST	R0	K0
-      0xA4060200,  //  0001  IMPORT	R1	K1
-      0x8C080302,  //  0002  GETMET	R2	R1	K2
-      0xB8120600,  //  0003  GETNGBL	R4	K3
-      0x58140004,  //  0004  LDCONST	R5	K4
-      0x7C080600,  //  0005  CALL	R2	3
-      0x600C0004,  //  0006  GETGBL	R3	G4
-      0x5C100400,  //  0007  MOVE	R4	R2
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0x200C0705,  //  0009  NE	R3	R3	K5
-      0x780E0002,  //  000A  JMPF	R3	#000E
-      0xB80E0600,  //  000B  GETNGBL	R3	K3
-      0x54120007,  //  000C  LDINT	R4	8
-      0x900E0804,  //  000D  SETMBR	R3	K4	R4
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: register_event
 ********************************************************************/
 be_local_closure(HASPmota_register_event,   /* name */
@@ -7813,923 +9137,62 @@ be_local_closure(HASPmota_register_event,   /* name */
 
 
 /********************************************************************
-** Solidified function: page_dir_to
-********************************************************************/
-be_local_closure(HASPmota_page_dir_to,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(pages_list_sorted),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_nested_str_weak(find),
-    }),
-    be_str_weak(page_dir_to),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x58100001,  //  0001  LDCONST	R4	K1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0403,  //  0004  EQ	R3	R2	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80060200,  //  0006  RET	1	K1
-      0x600C000C,  //  0007  GETGBL	R3	G12
-      0x5C100400,  //  0008  MOVE	R4	R2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x18100702,  //  000A  LE	R4	R3	K2
-      0x78120000,  //  000B  JMPF	R4	#000D
-      0x80060200,  //  000C  RET	1	K1
-      0x1C100703,  //  000D  EQ	R4	R3	K3
-      0x78120000,  //  000E  JMPF	R4	#0010
-      0x80060400,  //  000F  RET	1	K2
-      0x8C100504,  //  0010  GETMET	R4	R2	K4
-      0x5C180200,  //  0011  MOVE	R6	R1
-      0x7C100400,  //  0012  CALL	R4	2
-      0x4C140000,  //  0013  LDNIL	R5
-      0x1C140805,  //  0014  EQ	R5	R4	R5
-      0x78160000,  //  0015  JMPF	R5	#0017
-      0x80060200,  //  0016  RET	1	K1
-      0x00140702,  //  0017  ADD	R5	R3	K2
-      0x0C140B03,  //  0018  DIV	R5	R5	K3
-      0x18140805,  //  0019  LE	R5	R4	R5
-      0x78160001,  //  001A  JMPF	R5	#001D
-      0x80060400,  //  001B  RET	1	K2
-      0x70020001,  //  001C  JMP		#001F
-      0x5415FFFE,  //  001D  LDINT	R5	-1
-      0x80040A00,  //  001E  RET	1	R5
-      0x80000000,  //  001F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_obj
-********************************************************************/
-be_local_closure(HASPmota_parse_obj,   /* name */
-  be_nested_proto(
-    20,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
-    /* K0   */  be_nested_str_weak(global),
-    /* K1   */  be_nested_str_weak(introspect),
-    /* K2   */  be_nested_str_weak(find),
-    /* K3   */  be_nested_str_weak(id),
-    /* K4   */  be_nested_str_weak(obj),
-    /* K5   */  be_nested_str_weak(get_page_cur),
-    /* K6   */  be_nested_str_weak(berry_run),
-    /* K7   */  be_nested_str_weak(nil),
-    /* K8   */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20compile_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(HSP_X3A_X20invalid_X20_X27id_X27_X3A_X20),
-    /* K11  */  be_nested_str_weak(_X20for_X20_X27obj_X27_X3A),
-    /* K12  */  be_nested_str_weak(parentid),
-    /* K13  */  be_nested_str_weak(get_obj),
-    /* K14  */  be_nested_str_weak(_lv_obj),
-    /* K15  */  be_nested_str_weak(get_scr),
-    /* K16  */  be_nested_str_weak(get),
-    /* K17  */  be_nested_str_weak(lvh_),
-    /* K18  */  be_nested_str_weak(class),
-    /* K19  */  be_nested_str_weak(lvh_obj),
-    /* K20  */  be_nested_str_weak(module),
-    /* K21  */  be_nested_str_weak(HSP_X3A_X20Cannot_X20find_X20object_X20of_X20type_X20),
-    /* K22  */  be_nested_str_weak(add_obj),
-    /* K23  */  be_nested_str_weak(function),
-    /* K24  */  be_nested_str_weak(HSP_X3A_X20unable_X20to_X20run_X20berry_X20code_X20_X22_X25s_X22_X20_X2D_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    /* K25  */  be_const_int(0),
-    /* K26  */  be_nested_str_weak(HSP_X3A_X20cannot_X20specify_X20_X27obj_X27_X20for_X20_X27id_X27_X3A0),
-    /* K27  */  be_nested_str_weak(keys),
-    /* K28  */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(parse_obj),
-    &be_const_str_solidified,
-    ( &(const binstruction[210]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xA4120200,  //  0001  IMPORT	R4	K1
-      0x60140009,  //  0002  GETGBL	R5	G9
-      0x8C180302,  //  0003  GETMET	R6	R1	K2
-      0x58200003,  //  0004  LDCONST	R8	K3
-      0x7C180400,  //  0005  CALL	R6	2
-      0x7C140200,  //  0006  CALL	R5	1
-      0x60180008,  //  0007  GETGBL	R6	G8
-      0x8C1C0302,  //  0008  GETMET	R7	R1	K2
-      0x58240004,  //  0009  LDCONST	R9	K4
-      0x7C1C0400,  //  000A  CALL	R7	2
-      0x7C180200,  //  000B  CALL	R6	1
-      0x4C1C0000,  //  000C  LDNIL	R7
-      0x8C200105,  //  000D  GETMET	R8	R0	K5
-      0x7C200200,  //  000E  CALL	R8	1
-      0x60240008,  //  000F  GETGBL	R9	G8
-      0x8C280302,  //  0010  GETMET	R10	R1	K2
-      0x58300006,  //  0011  LDCONST	R12	K6
-      0x7C280400,  //  0012  CALL	R10	2
-      0x7C240200,  //  0013  CALL	R9	1
-      0x4C280000,  //  0014  LDNIL	R10
-      0x202C1307,  //  0015  NE	R11	R9	K7
-      0x782E0012,  //  0016  JMPF	R11	#002A
-      0xA8020005,  //  0017  EXBLK	0	#001E
-      0x602C000D,  //  0018  GETGBL	R11	G13
-      0x5C301200,  //  0019  MOVE	R12	R9
-      0x7C2C0200,  //  001A  CALL	R11	1
-      0x5C281600,  //  001B  MOVE	R10	R11
-      0xA8040001,  //  001C  EXBLK	1	1
-      0x7002000B,  //  001D  JMP		#002A
-      0xAC2C0002,  //  001E  CATCH	R11	0	2
-      0x70020008,  //  001F  JMP		#0029
-      0x60340001,  //  0020  GETGBL	R13	G1
-      0x60380018,  //  0021  GETGBL	R14	G24
-      0x583C0008,  //  0022  LDCONST	R15	K8
-      0x5C401200,  //  0023  MOVE	R16	R9
-      0x5C441600,  //  0024  MOVE	R17	R11
-      0x5C481800,  //  0025  MOVE	R18	R12
-      0x7C380800,  //  0026  CALL	R14	4
-      0x7C340200,  //  0027  CALL	R13	1
-      0x70020000,  //  0028  JMP		#002A
-      0xB0080000,  //  0029  RAISE	2	R0	R0
-      0x202C0D07,  //  002A  NE	R11	R6	K7
-      0x782E0067,  //  002B  JMPF	R11	#0094
-      0x4C2C0000,  //  002C  LDNIL	R11
-      0x202C0A0B,  //  002D  NE	R11	R5	R11
-      0x782E0064,  //  002E  JMPF	R11	#0094
-      0x142C0B09,  //  002F  LT	R11	R5	K9
-      0x742E0002,  //  0030  JMPT	R11	#0034
-      0x542E00FD,  //  0031  LDINT	R11	254
-      0x242C0A0B,  //  0032  GT	R11	R5	R11
-      0x782E0008,  //  0033  JMPF	R11	#003D
-      0x602C0001,  //  0034  GETGBL	R11	G1
-      0x60300008,  //  0035  GETGBL	R12	G8
-      0x5C340A00,  //  0036  MOVE	R13	R5
-      0x7C300200,  //  0037  CALL	R12	1
-      0x0032140C,  //  0038  ADD	R12	K10	R12
-      0x0030190B,  //  0039  ADD	R12	R12	K11
-      0x00301806,  //  003A  ADD	R12	R12	R6
-      0x7C2C0200,  //  003B  CALL	R11	1
-      0x80001600,  //  003C  RET	0
-      0x4C2C0000,  //  003D  LDNIL	R11
-      0x60300009,  //  003E  GETGBL	R12	G9
-      0x8C340302,  //  003F  GETMET	R13	R1	K2
-      0x583C000C,  //  0040  LDCONST	R15	K12
-      0x7C340400,  //  0041  CALL	R13	2
-      0x7C300200,  //  0042  CALL	R12	1
-      0x4C340000,  //  0043  LDNIL	R13
-      0x2034180D,  //  0044  NE	R13	R12	R13
-      0x78360006,  //  0045  JMPF	R13	#004D
-      0x8C34110D,  //  0046  GETMET	R13	R8	K13
-      0x5C3C1800,  //  0047  MOVE	R15	R12
-      0x7C340400,  //  0048  CALL	R13	2
-      0x4C380000,  //  0049  LDNIL	R14
-      0x20381A0E,  //  004A  NE	R14	R13	R14
-      0x783A0000,  //  004B  JMPF	R14	#004D
-      0x882C1B0E,  //  004C  GETMBR	R11	R13	K14
-      0x4C340000,  //  004D  LDNIL	R13
-      0x1C34160D,  //  004E  EQ	R13	R11	R13
-      0x78360002,  //  004F  JMPF	R13	#0053
-      0x8C34110F,  //  0050  GETMET	R13	R8	K15
-      0x7C340200,  //  0051  CALL	R13	1
-      0x5C2C1A00,  //  0052  MOVE	R11	R13
-      0x8C340910,  //  0053  GETMET	R13	R4	K16
-      0x5C3C0000,  //  0054  MOVE	R15	R0
-      0x00422206,  //  0055  ADD	R16	K17	R6
-      0x7C340600,  //  0056  CALL	R13	3
-      0x4C380000,  //  0057  LDNIL	R14
-      0x4C3C0000,  //  0058  LDNIL	R15
-      0x1C3C1A0F,  //  0059  EQ	R15	R13	R15
-      0x783E0010,  //  005A  JMPF	R15	#006C
-      0x8C3C0910,  //  005B  GETMET	R15	R4	K16
-      0x5C440600,  //  005C  MOVE	R17	R3
-      0x5C480C00,  //  005D  MOVE	R18	R6
-      0x7C3C0600,  //  005E  CALL	R15	3
-      0x4C400000,  //  005F  LDNIL	R16
-      0x20401E10,  //  0060  NE	R16	R15	R16
-      0x78420009,  //  0061  JMPF	R16	#006C
-      0x60400004,  //  0062  GETGBL	R16	G4
-      0x5C441E00,  //  0063  MOVE	R17	R15
-      0x7C400200,  //  0064  CALL	R16	1
-      0x1C402112,  //  0065  EQ	R16	R16	K18
-      0x78420004,  //  0066  JMPF	R16	#006C
-      0x5C401E00,  //  0067  MOVE	R16	R15
-      0x5C441600,  //  0068  MOVE	R17	R11
-      0x7C400200,  //  0069  CALL	R16	1
-      0x5C382000,  //  006A  MOVE	R14	R16
-      0x88340113,  //  006B  GETMBR	R13	R0	K19
-      0x4C3C0000,  //  006C  LDNIL	R15
-      0x1C3C1A0F,  //  006D  EQ	R15	R13	R15
-      0x783E000F,  //  006E  JMPF	R15	#007F
-      0x8C3C0914,  //  006F  GETMET	R15	R4	K20
-      0x5C440C00,  //  0070  MOVE	R17	R6
-      0x7C3C0400,  //  0071  CALL	R15	2
-      0x4C400000,  //  0072  LDNIL	R16
-      0x20401E10,  //  0073  NE	R16	R15	R16
-      0x78420009,  //  0074  JMPF	R16	#007F
-      0x60400004,  //  0075  GETGBL	R16	G4
-      0x5C441E00,  //  0076  MOVE	R17	R15
-      0x7C400200,  //  0077  CALL	R16	1
-      0x1C402112,  //  0078  EQ	R16	R16	K18
-      0x78420004,  //  0079  JMPF	R16	#007F
-      0x5C401E00,  //  007A  MOVE	R16	R15
-      0x5C441600,  //  007B  MOVE	R17	R11
-      0x7C400200,  //  007C  CALL	R16	1
-      0x5C382000,  //  007D  MOVE	R14	R16
-      0x88340113,  //  007E  GETMBR	R13	R0	K19
-      0x4C3C0000,  //  007F  LDNIL	R15
-      0x1C3C1A0F,  //  0080  EQ	R15	R13	R15
-      0x783E0006,  //  0081  JMPF	R15	#0089
-      0x603C0001,  //  0082  GETGBL	R15	G1
-      0x60400008,  //  0083  GETGBL	R16	G8
-      0x5C440C00,  //  0084  MOVE	R17	R6
-      0x7C400200,  //  0085  CALL	R16	1
-      0x00422A10,  //  0086  ADD	R16	K21	R16
-      0x7C3C0200,  //  0087  CALL	R15	1
-      0x80001E00,  //  0088  RET	0
-      0x5C3C1A00,  //  0089  MOVE	R15	R13
-      0x5C401600,  //  008A  MOVE	R16	R11
-      0x5C440400,  //  008B  MOVE	R17	R2
-      0x5C480200,  //  008C  MOVE	R18	R1
-      0x5C4C1C00,  //  008D  MOVE	R19	R14
-      0x7C3C0800,  //  008E  CALL	R15	4
-      0x5C1C1E00,  //  008F  MOVE	R7	R15
-      0x8C3C1116,  //  0090  GETMET	R15	R8	K22
-      0x5C440A00,  //  0091  MOVE	R17	R5
-      0x5C480E00,  //  0092  MOVE	R18	R7
-      0x7C3C0600,  //  0093  CALL	R15	3
-      0x4C2C0000,  //  0094  LDNIL	R11
-      0x202C140B,  //  0095  NE	R11	R10	R11
-      0x782E0018,  //  0096  JMPF	R11	#00B0
-      0xA802000B,  //  0097  EXBLK	0	#00A4
-      0x5C2C1400,  //  0098  MOVE	R11	R10
-      0x7C2C0000,  //  0099  CALL	R11	0
-      0x60300004,  //  009A  GETGBL	R12	G4
-      0x5C341600,  //  009B  MOVE	R13	R11
-      0x7C300200,  //  009C  CALL	R12	1
-      0x1C301917,  //  009D  EQ	R12	R12	K23
-      0x78320002,  //  009E  JMPF	R12	#00A2
-      0x5C301600,  //  009F  MOVE	R12	R11
-      0x5C340E00,  //  00A0  MOVE	R13	R7
-      0x7C300200,  //  00A1  CALL	R12	1
-      0xA8040001,  //  00A2  EXBLK	1	1
-      0x7002000B,  //  00A3  JMP		#00B0
-      0xAC2C0002,  //  00A4  CATCH	R11	0	2
-      0x70020008,  //  00A5  JMP		#00AF
-      0x60340001,  //  00A6  GETGBL	R13	G1
-      0x60380018,  //  00A7  GETGBL	R14	G24
-      0x583C0018,  //  00A8  LDCONST	R15	K24
-      0x5C401200,  //  00A9  MOVE	R16	R9
-      0x5C441600,  //  00AA  MOVE	R17	R11
-      0x5C481800,  //  00AB  MOVE	R18	R12
-      0x7C380800,  //  00AC  CALL	R14	4
-      0x7C340200,  //  00AD  CALL	R13	1
-      0x70020000,  //  00AE  JMP		#00B0
-      0xB0080000,  //  00AF  RAISE	2	R0	R0
-      0x4C2C0000,  //  00B0  LDNIL	R11
-      0x1C2C0A0B,  //  00B1  EQ	R11	R5	R11
-      0x782E0000,  //  00B2  JMPF	R11	#00B4
-      0x80001600,  //  00B3  RET	0
-      0x1C2C0B19,  //  00B4  EQ	R11	R5	K25
-      0x782E0005,  //  00B5  JMPF	R11	#00BC
-      0x202C0D07,  //  00B6  NE	R11	R6	K7
-      0x782E0003,  //  00B7  JMPF	R11	#00BC
-      0x602C0001,  //  00B8  GETGBL	R11	G1
-      0x5830001A,  //  00B9  LDCONST	R12	K26
-      0x7C2C0200,  //  00BA  CALL	R11	1
-      0x80001600,  //  00BB  RET	0
-      0x1C2C0B19,  //  00BC  EQ	R11	R5	K25
-      0x782E0005,  //  00BD  JMPF	R11	#00C4
-      0x8C2C0105,  //  00BE  GETMET	R11	R0	K5
-      0x7C2C0200,  //  00BF  CALL	R11	1
-      0x8C2C170D,  //  00C0  GETMET	R11	R11	K13
-      0x58340019,  //  00C1  LDCONST	R13	K25
-      0x7C2C0400,  //  00C2  CALL	R11	2
-      0x5C1C1600,  //  00C3  MOVE	R7	R11
-      0x602C0010,  //  00C4  GETGBL	R11	G16
-      0x8C30031B,  //  00C5  GETMET	R12	R1	K27
-      0x7C300200,  //  00C6  CALL	R12	1
-      0x7C2C0200,  //  00C7  CALL	R11	1
-      0xA8020004,  //  00C8  EXBLK	0	#00CE
-      0x5C301600,  //  00C9  MOVE	R12	R11
-      0x7C300000,  //  00CA  CALL	R12	0
-      0x9434020C,  //  00CB  GETIDX	R13	R1	R12
-      0x901C180D,  //  00CC  SETMBR	R7	R12	R13
-      0x7001FFFA,  //  00CD  JMP		#00C9
-      0x582C001C,  //  00CE  LDCONST	R11	K28
-      0xAC2C0200,  //  00CF  CATCH	R11	1	0
-      0xB0080000,  //  00D0  RAISE	2	R0	R0
-      0x80000000,  //  00D1  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: do_action
-********************************************************************/
-be_local_closure(HASPmota_do_action,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(lv),
-    /* K1   */  be_nested_str_weak(EVENT_CLICKED),
-    /* K2   */  be_nested_str_weak(page_show),
-    /* K3   */  be_nested_str_weak(_action),
-    }),
-    be_str_weak(do_action),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0xB80E0000,  //  0000  GETNGBL	R3	K0
-      0x880C0701,  //  0001  GETMBR	R3	R3	K1
-      0x200C0403,  //  0002  NE	R3	R2	R3
-      0x780E0000,  //  0003  JMPF	R3	#0005
-      0x80000600,  //  0004  RET	0
-      0x8C0C0102,  //  0005  GETMET	R3	R0	K2
-      0x88140303,  //  0006  GETMBR	R5	R1	K3
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_page_cur
-********************************************************************/
-be_local_closure(HASPmota_get_page_cur,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(lvh_pages),
-    /* K1   */  be_nested_str_weak(lvh_page_cur_idx),
-    }),
-    be_str_weak(get_page_cur),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x94040202,  //  0002  GETIDX	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pages_list_sorted
-********************************************************************/
-be_local_closure(HASPmota_pages_list_sorted,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(lvh_page_cur_idx),
-    /* K2   */  be_nested_str_weak(lvh_pages),
-    /* K3   */  be_nested_str_weak(keys),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_nested_str_weak(stop_iteration),
-    /* K6   */  be_nested_str_weak(sort),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_const_int(1),
-    }),
-    be_str_weak(pages_list_sorted),
-    &be_const_str_solidified,
-    ( &(const binstruction[47]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x1C0C0300,  //  0002  EQ	R3	R1	K0
-      0x780E0000,  //  0003  JMPF	R3	#0005
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x600C0010,  //  0005  GETGBL	R3	G16
-      0x88100102,  //  0006  GETMBR	R4	R0	K2
-      0x8C100903,  //  0007  GETMET	R4	R4	K3
-      0x7C100200,  //  0008  CALL	R4	1
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0xA8020007,  //  000A  EXBLK	0	#0013
-      0x5C100600,  //  000B  MOVE	R4	R3
-      0x7C100000,  //  000C  CALL	R4	0
-      0x20140900,  //  000D  NE	R5	R4	K0
-      0x78160002,  //  000E  JMPF	R5	#0012
-      0x8C140504,  //  000F  GETMET	R5	R2	K4
-      0x5C1C0800,  //  0010  MOVE	R7	R4
-      0x7C140400,  //  0011  CALL	R5	2
-      0x7001FFF7,  //  0012  JMP		#000B
-      0x580C0005,  //  0013  LDCONST	R3	K5
-      0xAC0C0200,  //  0014  CATCH	R3	1	0
-      0xB0080000,  //  0015  RAISE	2	R0	R0
-      0x8C0C0106,  //  0016  GETMET	R3	R0	K6
-      0x5C140400,  //  0017  MOVE	R5	R2
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x5C080600,  //  0019  MOVE	R2	R3
-      0x4C0C0000,  //  001A  LDNIL	R3
-      0x1C0C0203,  //  001B  EQ	R3	R1	R3
-      0x780E0000,  //  001C  JMPF	R3	#001E
-      0x80040200,  //  001D  RET	1	R1
-      0x600C000C,  //  001E  GETGBL	R3	G12
-      0x5C100400,  //  001F  MOVE	R4	R2
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x00080402,  //  0021  ADD	R2	R2	R2
-      0x8C100507,  //  0022  GETMET	R4	R2	K7
-      0x5C180200,  //  0023  MOVE	R6	R1
-      0x7C100400,  //  0024  CALL	R4	2
-      0x4C140000,  //  0025  LDNIL	R5
-      0x1C140805,  //  0026  EQ	R5	R4	R5
-      0x78160001,  //  0027  JMPF	R5	#002A
-      0x4C140000,  //  0028  LDNIL	R5
-      0x80040A00,  //  0029  RET	1	R5
-      0x00140803,  //  002A  ADD	R5	R4	R3
-      0x04140B08,  //  002B  SUB	R5	R5	K8
-      0x40140805,  //  002C  CONNECT	R5	R4	R5
-      0x94080405,  //  002D  GETIDX	R2	R2	R5
-      0x80040400,  //  002E  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: sort
-********************************************************************/
-be_local_closure(HASPmota_sort,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_class(be_class_HASPmota),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(sort),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080010,  //  0001  GETGBL	R2	G16
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x040C0701,  //  0005  SUB	R3	R3	K1
-      0x400E0203,  //  0006  CONNECT	R3	K1	R3
-      0x7C080200,  //  0007  CALL	R2	1
-      0xA8020010,  //  0008  EXBLK	0	#001A
-      0x5C0C0400,  //  0009  MOVE	R3	R2
-      0x7C0C0000,  //  000A  CALL	R3	0
-      0x94100003,  //  000B  GETIDX	R4	R0	R3
-      0x5C140600,  //  000C  MOVE	R5	R3
-      0x24180B02,  //  000D  GT	R6	R5	K2
-      0x781A0008,  //  000E  JMPF	R6	#0018
-      0x04180B01,  //  000F  SUB	R6	R5	K1
-      0x94180006,  //  0010  GETIDX	R6	R0	R6
-      0x24180C04,  //  0011  GT	R6	R6	R4
-      0x781A0004,  //  0012  JMPF	R6	#0018
-      0x04180B01,  //  0013  SUB	R6	R5	K1
-      0x94180006,  //  0014  GETIDX	R6	R0	R6
-      0x98000A06,  //  0015  SETIDX	R0	R5	R6
-      0x04140B01,  //  0016  SUB	R5	R5	K1
-      0x7001FFF4,  //  0017  JMP		#000D
-      0x98000A04,  //  0018  SETIDX	R0	R5	R4
-      0x7001FFEE,  //  0019  JMP		#0009
-      0x58080003,  //  001A  LDCONST	R2	K3
-      0xAC080200,  //  001B  CATCH	R2	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x80040000,  //  001D  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _load
-********************************************************************/
-be_local_closure(HASPmota__load,   /* name */
-  be_nested_proto(
-    15,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(json),
-    /* K2   */  be_nested_str_weak(lvh_page_cur_idx),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(lvh_page),
-    /* K5   */  be_nested_str_weak(lvh_pages),
-    /* K6   */  be_nested_str_weak(r),
-    /* K7   */  be_nested_str_weak(read),
-    /* K8   */  be_nested_str_weak(close),
-    /* K9   */  be_nested_str_weak(split),
-    /* K10  */  be_nested_str_weak(_X0A),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(load),
-    /* K13  */  be_nested_str_weak(instance),
-    /* K14  */  be_nested_str_weak(tasmota),
-    /* K15  */  be_nested_str_weak(loglevel),
-    /* K16  */  be_nested_str_weak(log),
-    /* K17  */  be_nested_str_weak(HSP_X3A_X20parsing_X20line_X20_X27_X25s_X27),
-    /* K18  */  be_nested_str_weak(parse_page),
-    /* K19  */  be_nested_str_weak(parse_obj),
-    /* K20  */  be_nested_str_weak(tr),
-    /* K21  */  be_nested_str_weak(_X20_X09),
-    /* K22  */  be_nested_str_weak(),
-    /* K23  */  be_nested_str_weak(HSP_X3A_X20invalid_X20JSON_X20line_X20_X27_X25s_X27),
-    /* K24  */  be_const_int(2),
-    /* K25  */  be_nested_str_weak(remove),
-    }),
-    be_str_weak(_load),
-    &be_const_str_solidified,
-    ( &(const binstruction[85]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0x90020503,  //  0002  SETMBR	R0	K2	K3
-      0x88100104,  //  0003  GETMBR	R4	R0	K4
-      0x88140105,  //  0004  GETMBR	R5	R0	K5
-      0x5C180800,  //  0005  MOVE	R6	R4
-      0x581C0003,  //  0006  LDCONST	R7	K3
-      0x5C200000,  //  0007  MOVE	R8	R0
-      0x7C180400,  //  0008  CALL	R6	2
-      0x98160606,  //  0009  SETIDX	R5	K3	R6
-      0x60140011,  //  000A  GETGBL	R5	G17
-      0x5C180200,  //  000B  MOVE	R6	R1
-      0x581C0006,  //  000C  LDCONST	R7	K6
-      0x7C140400,  //  000D  CALL	R5	2
-      0x8C180B07,  //  000E  GETMET	R6	R5	K7
-      0x7C180200,  //  000F  CALL	R6	1
-      0x8C1C0B08,  //  0010  GETMET	R7	R5	K8
-      0x7C1C0200,  //  0011  CALL	R7	1
-      0x8C1C0509,  //  0012  GETMET	R7	R2	K9
-      0x5C240C00,  //  0013  MOVE	R9	R6
-      0x5828000A,  //  0014  LDCONST	R10	K10
-      0x7C1C0600,  //  0015  CALL	R7	3
-      0x4C140000,  //  0016  LDNIL	R5
-      0x4C180000,  //  0017  LDNIL	R6
-      0x6020000C,  //  0018  GETGBL	R8	G12
-      0x5C240E00,  //  0019  MOVE	R9	R7
-      0x7C200200,  //  001A  CALL	R8	1
-      0x2420110B,  //  001B  GT	R8	R8	K11
-      0x78220034,  //  001C  JMPF	R8	#0052
-      0x8C20070C,  //  001D  GETMET	R8	R3	K12
-      0x94280F0B,  //  001E  GETIDX	R10	R7	K11
-      0x7C200400,  //  001F  CALL	R8	2
-      0x60240004,  //  0020  GETGBL	R9	G4
-      0x5C281000,  //  0021  MOVE	R10	R8
-      0x7C240200,  //  0022  CALL	R9	1
-      0x1C24130D,  //  0023  EQ	R9	R9	K13
-      0x78260016,  //  0024  JMPF	R9	#003C
-      0xB8261C00,  //  0025  GETNGBL	R9	K14
-      0x8C24130F,  //  0026  GETMET	R9	R9	K15
-      0x542E0003,  //  0027  LDINT	R11	4
-      0x7C240400,  //  0028  CALL	R9	2
-      0x78260007,  //  0029  JMPF	R9	#0032
-      0xB8261C00,  //  002A  GETNGBL	R9	K14
-      0x8C241310,  //  002B  GETMET	R9	R9	K16
-      0x602C0018,  //  002C  GETGBL	R11	G24
-      0x58300011,  //  002D  LDCONST	R12	K17
-      0x94340F0B,  //  002E  GETIDX	R13	R7	K11
-      0x7C2C0400,  //  002F  CALL	R11	2
-      0x54320003,  //  0030  LDINT	R12	4
-      0x7C240600,  //  0031  CALL	R9	3
-      0x8C240112,  //  0032  GETMET	R9	R0	K18
-      0x5C2C1000,  //  0033  MOVE	R11	R8
-      0x7C240400,  //  0034  CALL	R9	2
-      0x8C240113,  //  0035  GETMET	R9	R0	K19
-      0x5C2C1000,  //  0036  MOVE	R11	R8
-      0x88300105,  //  0037  GETMBR	R12	R0	K5
-      0x88340102,  //  0038  GETMBR	R13	R0	K2
-      0x9430180D,  //  0039  GETIDX	R12	R12	R13
-      0x7C240600,  //  003A  CALL	R9	3
-      0x70020010,  //  003B  JMP		#004D
-      0x6024000C,  //  003C  GETGBL	R9	G12
-      0x8C280514,  //  003D  GETMET	R10	R2	K20
-      0x94300F0B,  //  003E  GETIDX	R12	R7	K11
-      0x58340015,  //  003F  LDCONST	R13	K21
-      0x58380016,  //  0040  LDCONST	R14	K22
-      0x7C280800,  //  0041  CALL	R10	4
-      0x7C240200,  //  0042  CALL	R9	1
-      0x2424130B,  //  0043  GT	R9	R9	K11
-      0x78260007,  //  0044  JMPF	R9	#004D
-      0xB8261C00,  //  0045  GETNGBL	R9	K14
-      0x8C241310,  //  0046  GETMET	R9	R9	K16
-      0x602C0018,  //  0047  GETGBL	R11	G24
-      0x58300017,  //  0048  LDCONST	R12	K23
-      0x94340F0B,  //  0049  GETIDX	R13	R7	K11
-      0x7C2C0400,  //  004A  CALL	R11	2
-      0x58300018,  //  004B  LDCONST	R12	K24
-      0x7C240600,  //  004C  CALL	R9	3
-      0x4C200000,  //  004D  LDNIL	R8
-      0x8C240F19,  //  004E  GETMET	R9	R7	K25
-      0x582C000B,  //  004F  LDCONST	R11	K11
-      0x7C240400,  //  0050  CALL	R9	2
-      0x7001FFC5,  //  0051  JMP		#0018
-      0x4C1C0000,  //  0052  LDNIL	R7
-      0x90020503,  //  0053  SETMBR	R0	K2	K3
-      0x80000000,  //  0054  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(HASPmota_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fix_lv_version),
-    /* K1   */  be_nested_str_weak(re),
-    /* K2   */  be_nested_str_weak(re_page_target),
-    /* K3   */  be_nested_str_weak(compile),
-    /* K4   */  be_nested_str_weak(p_X5Cd_X2B),
-    /* K5   */  be_nested_str_weak(re_color_suffix),
-    /* K6   */  be_nested_str_weak(color_X24),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0xA4060200,  //  0002  IMPORT	R1	K1
-      0x8C080303,  //  0003  GETMET	R2	R1	K3
-      0x58100004,  //  0004  LDCONST	R4	K4
-      0x7C080400,  //  0005  CALL	R2	2
-      0x90020402,  //  0006  SETMBR	R0	K2	R2
-      0x8C080303,  //  0007  GETMET	R2	R1	K3
-      0x58100006,  //  0008  LDCONST	R4	K6
-      0x7C080400,  //  0009  CALL	R2	2
-      0x90020A02,  //  000A  SETMBR	R0	K5	R2
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: page_show
-********************************************************************/
-be_local_closure(HASPmota_page_show,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(lvh_pages),
-    /* K1   */  be_nested_str_weak(lvh_page_cur_idx),
-    /* K2   */  be_nested_str_weak(pages_list_sorted),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_nested_str_weak(prev),
-    /* K5   */  be_nested_str_weak(next),
-    /* K6   */  be_nested_str_weak(back),
-    /* K7   */  be_nested_str_weak(re_page_target),
-    /* K8   */  be_nested_str_weak(match),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(show),
-    }),
-    be_str_weak(page_show),
-    &be_const_str_solidified,
-    ( &(const binstruction[68]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x880C0100,  //  0001  GETMBR	R3	R0	K0
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x940C0604,  //  0003  GETIDX	R3	R3	R4
-      0x8C100102,  //  0004  GETMET	R4	R0	K2
-      0x88180101,  //  0005  GETMBR	R6	R0	K1
-      0x7C100400,  //  0006  CALL	R4	2
-      0x6014000C,  //  0007  GETGBL	R5	G12
-      0x5C180800,  //  0008  MOVE	R6	R4
-      0x7C140200,  //  0009  CALL	R5	1
-      0x18140B03,  //  000A  LE	R5	R5	K3
-      0x78160000,  //  000B  JMPF	R5	#000D
-      0x80000A00,  //  000C  RET	0
-      0x1C140304,  //  000D  EQ	R5	R1	K4
-      0x78160009,  //  000E  JMPF	R5	#0019
-      0x60140009,  //  000F  GETGBL	R5	G9
-      0x88180704,  //  0010  GETMBR	R6	R3	K4
-      0x7C140200,  //  0011  CALL	R5	1
-      0x5C080A00,  //  0012  MOVE	R2	R5
-      0x4C140000,  //  0013  LDNIL	R5
-      0x1C140405,  //  0014  EQ	R5	R2	R5
-      0x78160001,  //  0015  JMPF	R5	#0018
-      0x5415FFFE,  //  0016  LDINT	R5	-1
-      0x94080805,  //  0017  GETIDX	R2	R4	R5
-      0x70020020,  //  0018  JMP		#003A
-      0x1C140305,  //  0019  EQ	R5	R1	K5
-      0x78160008,  //  001A  JMPF	R5	#0024
-      0x60140009,  //  001B  GETGBL	R5	G9
-      0x88180705,  //  001C  GETMBR	R6	R3	K5
-      0x7C140200,  //  001D  CALL	R5	1
-      0x5C080A00,  //  001E  MOVE	R2	R5
-      0x4C140000,  //  001F  LDNIL	R5
-      0x1C140405,  //  0020  EQ	R5	R2	R5
-      0x78160000,  //  0021  JMPF	R5	#0023
-      0x94080903,  //  0022  GETIDX	R2	R4	K3
-      0x70020015,  //  0023  JMP		#003A
-      0x1C140306,  //  0024  EQ	R5	R1	K6
-      0x78160008,  //  0025  JMPF	R5	#002F
-      0x60140009,  //  0026  GETGBL	R5	G9
-      0x88180706,  //  0027  GETMBR	R6	R3	K6
-      0x7C140200,  //  0028  CALL	R5	1
-      0x5C080A00,  //  0029  MOVE	R2	R5
-      0x4C140000,  //  002A  LDNIL	R5
-      0x1C140405,  //  002B  EQ	R5	R2	R5
-      0x78160000,  //  002C  JMPF	R5	#002E
-      0x58080003,  //  002D  LDCONST	R2	K3
-      0x7002000A,  //  002E  JMP		#003A
-      0x88140107,  //  002F  GETMBR	R5	R0	K7
-      0x8C140B08,  //  0030  GETMET	R5	R5	K8
-      0x5C1C0200,  //  0031  MOVE	R7	R1
-      0x7C140400,  //  0032  CALL	R5	2
-      0x78160005,  //  0033  JMPF	R5	#003A
-      0x60140009,  //  0034  GETGBL	R5	G9
-      0x5419FFFE,  //  0035  LDINT	R6	-1
-      0x401A0606,  //  0036  CONNECT	R6	K3	R6
-      0x94180206,  //  0037  GETIDX	R6	R1	R6
-      0x7C140200,  //  0038  CALL	R5	1
-      0x5C080A00,  //  0039  MOVE	R2	R5
-      0x4C140000,  //  003A  LDNIL	R5
-      0x20140405,  //  003B  NE	R5	R2	R5
-      0x78160005,  //  003C  JMPF	R5	#0043
-      0x24140509,  //  003D  GT	R5	R2	K9
-      0x78160003,  //  003E  JMPF	R5	#0043
-      0x88140100,  //  003F  GETMBR	R5	R0	K0
-      0x94140A02,  //  0040  GETIDX	R5	R5	R2
-      0x8C140B0A,  //  0041  GETMET	R5	R5	K10
-      0x7C140200,  //  0042  CALL	R5	1
-      0x80000000,  //  0043  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse
-********************************************************************/
-be_local_closure(HASPmota_parse,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(load),
-    /* K2   */  be_nested_str_weak(instance),
-    /* K3   */  be_nested_str_weak(parse_page),
-    /* K4   */  be_nested_str_weak(parse_obj),
-    /* K5   */  be_nested_str_weak(lvh_pages),
-    /* K6   */  be_nested_str_weak(lvh_page_cur_idx),
-    /* K7   */  be_nested_str_weak(value_error),
-    /* K8   */  be_nested_str_weak(unable_X20to_X20parse_X20JSON_X20line),
-    }),
-    be_str_weak(parse),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x60100004,  //  0004  GETGBL	R4	G4
-      0x5C140600,  //  0005  MOVE	R5	R3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x1C100902,  //  0007  EQ	R4	R4	K2
-      0x78120009,  //  0008  JMPF	R4	#0013
-      0x8C100103,  //  0009  GETMET	R4	R0	K3
-      0x5C180600,  //  000A  MOVE	R6	R3
-      0x7C100400,  //  000B  CALL	R4	2
-      0x8C100104,  //  000C  GETMET	R4	R0	K4
-      0x5C180600,  //  000D  MOVE	R6	R3
-      0x881C0105,  //  000E  GETMBR	R7	R0	K5
-      0x88200106,  //  000F  GETMBR	R8	R0	K6
-      0x941C0E08,  //  0010  GETIDX	R7	R7	R8
-      0x7C100600,  //  0011  CALL	R4	3
-      0x70020000,  //  0012  JMP		#0014
-      0xB0060F08,  //  0013  RAISE	1	K7	K8
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: HASPmota
 ********************************************************************/
 be_local_class(HASPmota,
     11,
     NULL,
-    be_nested_map(46,
+    be_nested_map(49,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(event_dispatch, -1), be_const_closure(HASPmota_event_dispatch_closure) },
-        { be_const_key_weak(lvh_slider, -1), be_const_class(be_class_lvh_slider) },
-        { be_const_key_weak(parse_page, -1), be_const_closure(HASPmota_parse_page_closure) },
-        { be_const_key_weak(page_dir_to, -1), be_const_closure(HASPmota_page_dir_to_closure) },
-        { be_const_key_weak(fix_lv_version, -1), be_const_static_closure(HASPmota_fix_lv_version_closure) },
-        { be_const_key_weak(register_event, 6), be_const_closure(HASPmota_register_event_closure) },
-        { be_const_key_weak(lvh_bar, -1), be_const_class(be_class_lvh_bar) },
-        { be_const_key_weak(event_cb, -1), be_const_var(10) },
-        { be_const_key_weak(lvh_switch, 3), be_const_class(be_class_lvh_switch) },
-        { be_const_key_weak(parse, 44), be_const_closure(HASPmota_parse_closure) },
-        { be_const_key_weak(lvh_label, 9), be_const_class(be_class_lvh_label) },
-        { be_const_key_weak(do_action, -1), be_const_closure(HASPmota_do_action_closure) },
-        { be_const_key_weak(lvh_roller, 31), be_const_class(be_class_lvh_roller) },
-        { be_const_key_weak(lvh_dropdown, 7), be_const_class(be_class_lvh_dropdown) },
-        { be_const_key_weak(lvh_pages, -1), be_const_var(5) },
-        { be_const_key_weak(re_color_suffix, 30), be_const_var(8) },
-        { be_const_key_weak(pages_list_sorted, 41), be_const_closure(HASPmota_pages_list_sorted_closure) },
-        { be_const_key_weak(lvh_spinner, -1), be_const_class(be_class_lvh_spinner) },
-        { be_const_key_weak(lvh_scr, -1), be_const_class(be_class_lvh_scr) },
-        { be_const_key_weak(re_page_target, -1), be_const_var(7) },
-        { be_const_key_weak(init, 26), be_const_closure(HASPmota_init_closure) },
-        { be_const_key_weak(lvh_checkbox, -1), be_const_class(be_class_lvh_checkbox) },
-        { be_const_key_weak(lvh_chart, 15), be_const_class(be_class_lvh_chart) },
-        { be_const_key_weak(event, -1), be_const_var(9) },
-        { be_const_key_weak(lvh_textarea, -1), be_const_class(be_class_lvh_textarea) },
-        { be_const_key_weak(hres, -1), be_const_var(1) },
-        { be_const_key_weak(lvh_obj, 42), be_const_class(be_class_lvh_obj) },
-        { be_const_key_weak(scr, -1), be_const_var(3) },
-        { be_const_key_weak(lvh_arc, 33), be_const_class(be_class_lvh_arc) },
-        { be_const_key_weak(lvh_page, 36), be_const_class(be_class_lvh_page) },
-        { be_const_key_weak(lvh_page_cur_idx, -1), be_const_var(6) },
-        { be_const_key_weak(_load, 16), be_const_closure(HASPmota__load_closure) },
-        { be_const_key_weak(lvh_btn, -1), be_const_class(be_class_lvh_btn) },
-        { be_const_key_weak(lvh_line, 19), be_const_class(be_class_lvh_line) },
-        { be_const_key_weak(r16, -1), be_const_var(4) },
-        { be_const_key_weak(def_templ_name, -1), be_nested_str_weak(pages_X2Ejsonl) },
-        { be_const_key_weak(vres, -1), be_const_var(2) },
-        { be_const_key_weak(start, 20), be_const_closure(HASPmota_start_closure) },
-        { be_const_key_weak(page_show, -1), be_const_closure(HASPmota_page_show_closure) },
-        { be_const_key_weak(sort, 17), be_const_static_closure(HASPmota_sort_closure) },
-        { be_const_key_weak(lvh_qrcode, -1), be_const_class(be_class_lvh_qrcode) },
-        { be_const_key_weak(get_page_cur, -1), be_const_closure(HASPmota_get_page_cur_closure) },
-        { be_const_key_weak(lvh_img, -1), be_const_class(be_class_lvh_img) },
+        { be_const_key_weak(lvh_arc, 41), be_const_class(be_class_lvh_arc) },
+        { be_const_key_weak(lvh_spangroup, -1), be_const_class(be_class_lvh_spangroup) },
         { be_const_key_weak(dark, -1), be_const_var(0) },
-        { be_const_key_weak(parse_obj, -1), be_const_closure(HASPmota_parse_obj_closure) },
-        { be_const_key_weak(lvh_btnmatrix, -1), be_const_class(be_class_lvh_btnmatrix) },
+        { be_const_key_weak(lvh_chart, 48), be_const_class(be_class_lvh_chart) },
+        { be_const_key_weak(event_dispatch, 2), be_const_closure(HASPmota_event_dispatch_closure) },
+        { be_const_key_weak(get_page_cur, 14), be_const_closure(HASPmota_get_page_cur_closure) },
+        { be_const_key_weak(page_dir_to, 26), be_const_closure(HASPmota_page_dir_to_closure) },
+        { be_const_key_weak(lvh_dropdown, -1), be_const_class(be_class_lvh_dropdown) },
+        { be_const_key_weak(event_cb, 22), be_const_var(10) },
+        { be_const_key_weak(lvh_roller, -1), be_const_class(be_class_lvh_roller) },
+        { be_const_key_weak(lvh_textarea, -1), be_const_class(be_class_lvh_textarea) },
+        { be_const_key_weak(lvh_line, 25), be_const_class(be_class_lvh_line) },
+        { be_const_key_weak(lvh_img, 7), be_const_class(be_class_lvh_img) },
+        { be_const_key_weak(lvh_pages, -1), be_const_var(5) },
+        { be_const_key_weak(lvh_bar, 38), be_const_class(be_class_lvh_bar) },
+        { be_const_key_weak(def_templ_name, 17), be_nested_str_weak(pages_X2Ejsonl) },
+        { be_const_key_weak(parse_obj, 23), be_const_closure(HASPmota_parse_obj_closure) },
+        { be_const_key_weak(lvh_spinner, -1), be_const_class(be_class_lvh_spinner) },
+        { be_const_key_weak(init, -1), be_const_closure(HASPmota_init_closure) },
+        { be_const_key_weak(scr, 18), be_const_var(3) },
+        { be_const_key_weak(parse_page, 12), be_const_closure(HASPmota_parse_page_closure) },
+        { be_const_key_weak(vres, 44), be_const_var(2) },
+        { be_const_key_weak(event, 36), be_const_var(9) },
+        { be_const_key_weak(re_page_target, -1), be_const_var(7) },
+        { be_const_key_weak(lvh_slider, -1), be_const_class(be_class_lvh_slider) },
+        { be_const_key_weak(lvh_root, -1), be_const_class(be_class_lvh_root) },
+        { be_const_key_weak(start, -1), be_const_closure(HASPmota_start_closure) },
+        { be_const_key_weak(lvh_page, -1), be_const_class(be_class_lvh_page) },
+        { be_const_key_weak(pages_list_sorted, 40), be_const_closure(HASPmota_pages_list_sorted_closure) },
+        { be_const_key_weak(_load, 39), be_const_closure(HASPmota__load_closure) },
+        { be_const_key_weak(lvh_page_cur_idx, -1), be_const_var(6) },
+        { be_const_key_weak(lvh_switch, -1), be_const_class(be_class_lvh_switch) },
+        { be_const_key_weak(r16, -1), be_const_var(4) },
+        { be_const_key_weak(page_show, -1), be_const_closure(HASPmota_page_show_closure) },
+        { be_const_key_weak(fix_lv_version, -1), be_const_static_closure(HASPmota_fix_lv_version_closure) },
+        { be_const_key_weak(lvh_btnmatrix, 34), be_const_class(be_class_lvh_btnmatrix) },
+        { be_const_key_weak(lvh_checkbox, -1), be_const_class(be_class_lvh_checkbox) },
+        { be_const_key_weak(lvh_label, -1), be_const_class(be_class_lvh_label) },
+        { be_const_key_weak(parse, -1), be_const_closure(HASPmota_parse_closure) },
+        { be_const_key_weak(re_color_suffix, -1), be_const_var(8) },
+        { be_const_key_weak(do_action, -1), be_const_closure(HASPmota_do_action_closure) },
+        { be_const_key_weak(sort, -1), be_const_static_closure(HASPmota_sort_closure) },
+        { be_const_key_weak(register_event, -1), be_const_closure(HASPmota_register_event_closure) },
+        { be_const_key_weak(lvh_span, -1), be_const_class(be_class_lvh_span) },
+        { be_const_key_weak(lvh_scr, -1), be_const_class(be_class_lvh_scr) },
+        { be_const_key_weak(lvh_qrcode, -1), be_const_class(be_class_lvh_qrcode) },
+        { be_const_key_weak(lvh_btn, 8), be_const_class(be_class_lvh_btn) },
+        { be_const_key_weak(lvh_obj, -1), be_const_class(be_class_lvh_obj) },
+        { be_const_key_weak(hres, -1), be_const_var(1) },
     })),
     be_str_weak(HASPmota)
 );
@@ -8776,7 +9239,6 @@ be_local_module(haspmota,
 );
 BE_EXPORT_VARIABLE be_define_const_native_module(haspmota);
 /********************************************************************/
-
 
 #endif // USE_LVGL_HASPMOTA
 #endif // USE_LVGL

--- a/lib/libesp32_lvgl/lv_binding_berry/generate/LVGL_API_Reference.md
+++ b/lib/libesp32_lvgl/lv_binding_berry/generate/LVGL_API_Reference.md
@@ -125,8 +125,6 @@ scr_load_anim|lv.obj, int, int, int, bool||[lv_screen_load_anim](https://docs.lv
 screen_active||lv.obj|[lv_screen_active](https://docs.lvgl.io/9.0/search.html?q=lv_screen_active)
 screen_load|lv.obj||[lv_screen_load](https://docs.lvgl.io/9.0/search.html?q=lv_screen_load)
 screen_load_anim|lv.obj, int, int, int, bool||[lv_screen_load_anim](https://docs.lvgl.io/9.0/search.html?q=lv_screen_load_anim)
-span_set_text|lv.spangroup, string||[lv_span_set_text](https://docs.lvgl.io/9.0/search.html?q=lv_span_set_text)
-span_set_text_static|lv.spangroup, string||[lv_span_set_text_static](https://docs.lvgl.io/9.0/search.html?q=lv_span_set_text_static)
 span_stack_deinit|||[lv_span_stack_deinit](https://docs.lvgl.io/9.0/search.html?q=lv_span_stack_deinit)
 span_stack_init|||[lv_span_stack_init](https://docs.lvgl.io/9.0/search.html?q=lv_span_stack_init)
 style_get_num_custom_props||int|[lv_style_get_num_custom_props](https://docs.lvgl.io/9.0/search.html?q=lv_style_get_num_custom_props)
@@ -1275,9 +1273,9 @@ text_is_selected||bool|[lv_textarea_text_is_selected](https://docs.lvgl.io/9.0/s
 
 Method|Arguments|Return type|LVGL equivalent
 :---|:---|:---|:---
-delete_span|lv.spangroup||[lv_spangroup_delete_span](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_delete_span)
+delete_span|lv.span||[lv_spangroup_delete_span](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_delete_span)
 get_align||int|[lv_spangroup_get_align](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_get_align)
-get_child|int|lv.spangroup|[lv_spangroup_get_child](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_get_child)
+get_child|int|lv.span|[lv_spangroup_get_child](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_get_child)
 get_expand_height|int|int|[lv_spangroup_get_expand_height](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_get_expand_height)
 get_expand_width|int|int|[lv_spangroup_get_expand_width](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_get_expand_width)
 get_indent||int|[lv_spangroup_get_indent](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_get_indent)
@@ -1286,13 +1284,21 @@ get_max_lines||int|[lv_spangroup_get_max_lines](https://docs.lvgl.io/9.0/search.
 get_mode||int|[lv_spangroup_get_mode](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_get_mode)
 get_overflow||int|[lv_spangroup_get_overflow](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_get_overflow)
 get_span_count||int|[lv_spangroup_get_span_count](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_get_span_count)
-new_span||lv.spangroup|[lv_spangroup_new_span](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_new_span)
+new_span||lv.span|[lv_spangroup_new_span](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_new_span)
 refr_mode|||[lv_spangroup_refr_mode](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_refr_mode)
 set_align|int||[lv_spangroup_set_align](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_set_align)
 set_indent|int||[lv_spangroup_set_indent](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_set_indent)
 set_max_lines|int||[lv_spangroup_set_max_lines](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_set_max_lines)
 set_mode|int||[lv_spangroup_set_mode](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_set_mode)
 set_overflow|int||[lv_spangroup_set_overflow](https://docs.lvgl.io/9.0/search.html?q=lv_spangroup_set_overflow)
+
+### widget `lv.span`
+
+Method|Arguments|Return type|LVGL equivalent
+:---|:---|:---|:---
+get_style||lv.style|[lv_span_get_style](https://docs.lvgl.io/9.0/search.html?q=lv_span_get_style)
+set_text|string||[lv_span_set_text](https://docs.lvgl.io/9.0/search.html?q=lv_span_set_text)
+set_text_static|string||[lv_span_set_text_static](https://docs.lvgl.io/9.0/search.html?q=lv_span_set_text_static)
 
 ### widget `lv.scale`
 

--- a/lib/libesp32_lvgl/lv_binding_berry/generate/be_lv_c_mapping.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/generate/be_lv_c_mapping.h
@@ -158,39 +158,6 @@ const be_ntv_func_def_t lv_color_func[] = {
 const be_ntv_func_def_t lv_theme_func[] = {
 };
 
-/* `lv_image` methods */
-#ifdef BE_LV_WIDGET_IMAGE
-const be_ntv_func_def_t lv_image_func[] = {
-  { "get_angle", { (const void*) &lv_image_get_rotation, "i", "(lv.obj)" } },
-  { "get_antialias", { (const void*) &lv_image_get_antialias, "b", "(lv.obj)" } },
-  { "get_blend_mode", { (const void*) &lv_image_get_blend_mode, "i", "(lv.obj)" } },
-  { "get_inner_align", { (const void*) &lv_image_get_inner_align, "i", "(lv.obj)" } },
-  { "get_offset_x", { (const void*) &lv_image_get_offset_x, "i", "(lv.obj)" } },
-  { "get_offset_y", { (const void*) &lv_image_get_offset_y, "i", "(lv.obj)" } },
-  { "get_pivot", { (const void*) &lv_image_get_pivot, "", "(lv.obj)c" } },
-  { "get_rotation", { (const void*) &lv_image_get_rotation, "i", "(lv.obj)" } },
-  { "get_scale", { (const void*) &lv_image_get_scale, "i", "(lv.obj)" } },
-  { "get_scale_x", { (const void*) &lv_image_get_scale_x, "i", "(lv.obj)" } },
-  { "get_scale_y", { (const void*) &lv_image_get_scale_y, "i", "(lv.obj)" } },
-  { "get_src", { (const void*) &lv_image_get_src, "c", "(lv.obj)" } },
-  { "get_zoom", { (const void*) &lv_image_get_scale, "i", "(lv.obj)" } },
-  { "set_angle", { (const void*) &lv_image_set_rotation, "", "(lv.obj)i" } },
-  { "set_antialias", { (const void*) &lv_image_set_antialias, "", "(lv.obj)b" } },
-  { "set_blend_mode", { (const void*) &lv_image_set_blend_mode, "", "(lv.obj)i" } },
-  { "set_inner_align", { (const void*) &lv_image_set_inner_align, "", "(lv.obj)i" } },
-  { "set_offset_x", { (const void*) &lv_image_set_offset_x, "", "(lv.obj)i" } },
-  { "set_offset_y", { (const void*) &lv_image_set_offset_y, "", "(lv.obj)i" } },
-  { "set_pivot", { (const void*) &lv_image_set_pivot, "", "(lv.obj)ii" } },
-  { "set_rotation", { (const void*) &lv_image_set_rotation, "", "(lv.obj)i" } },
-  { "set_scale", { (const void*) &lv_image_set_scale, "", "(lv.obj)i" } },
-  { "set_scale_x", { (const void*) &lv_image_set_scale_x, "", "(lv.obj)i" } },
-  { "set_scale_y", { (const void*) &lv_image_set_scale_y, "", "(lv.obj)i" } },
-  { "set_src", { (const void*) &lv_image_set_src, "", "(lv.obj)." } },
-  { "set_tasmota_logo", { (const void*) &lv_image_set_tasmota_logo, "", "(lv.obj)" } },
-  { "set_zoom", { (const void*) &lv_image_set_scale, "", "(lv.obj)i" } },
-};
-#endif // BE_LV_WIDGET_IMAGE
-
 /* `lv_group` methods */
 const be_ntv_func_def_t lv_group_func[] = {
   { "add_obj", { (const void*) &lv_group_add_obj, "", "(lv.group)(lv.obj)" } },
@@ -1014,6 +981,39 @@ const be_ntv_func_def_t lv_dropdown_func[] = {
 };
 #endif // BE_LV_WIDGET_DROPDOWN
 
+/* `lv_image` methods */
+#ifdef BE_LV_WIDGET_IMAGE
+const be_ntv_func_def_t lv_image_func[] = {
+  { "get_angle", { (const void*) &lv_image_get_rotation, "i", "(lv.obj)" } },
+  { "get_antialias", { (const void*) &lv_image_get_antialias, "b", "(lv.obj)" } },
+  { "get_blend_mode", { (const void*) &lv_image_get_blend_mode, "i", "(lv.obj)" } },
+  { "get_inner_align", { (const void*) &lv_image_get_inner_align, "i", "(lv.obj)" } },
+  { "get_offset_x", { (const void*) &lv_image_get_offset_x, "i", "(lv.obj)" } },
+  { "get_offset_y", { (const void*) &lv_image_get_offset_y, "i", "(lv.obj)" } },
+  { "get_pivot", { (const void*) &lv_image_get_pivot, "", "(lv.obj)c" } },
+  { "get_rotation", { (const void*) &lv_image_get_rotation, "i", "(lv.obj)" } },
+  { "get_scale", { (const void*) &lv_image_get_scale, "i", "(lv.obj)" } },
+  { "get_scale_x", { (const void*) &lv_image_get_scale_x, "i", "(lv.obj)" } },
+  { "get_scale_y", { (const void*) &lv_image_get_scale_y, "i", "(lv.obj)" } },
+  { "get_src", { (const void*) &lv_image_get_src, "c", "(lv.obj)" } },
+  { "get_zoom", { (const void*) &lv_image_get_scale, "i", "(lv.obj)" } },
+  { "set_angle", { (const void*) &lv_image_set_rotation, "", "(lv.obj)i" } },
+  { "set_antialias", { (const void*) &lv_image_set_antialias, "", "(lv.obj)b" } },
+  { "set_blend_mode", { (const void*) &lv_image_set_blend_mode, "", "(lv.obj)i" } },
+  { "set_inner_align", { (const void*) &lv_image_set_inner_align, "", "(lv.obj)i" } },
+  { "set_offset_x", { (const void*) &lv_image_set_offset_x, "", "(lv.obj)i" } },
+  { "set_offset_y", { (const void*) &lv_image_set_offset_y, "", "(lv.obj)i" } },
+  { "set_pivot", { (const void*) &lv_image_set_pivot, "", "(lv.obj)ii" } },
+  { "set_rotation", { (const void*) &lv_image_set_rotation, "", "(lv.obj)i" } },
+  { "set_scale", { (const void*) &lv_image_set_scale, "", "(lv.obj)i" } },
+  { "set_scale_x", { (const void*) &lv_image_set_scale_x, "", "(lv.obj)i" } },
+  { "set_scale_y", { (const void*) &lv_image_set_scale_y, "", "(lv.obj)i" } },
+  { "set_src", { (const void*) &lv_image_set_src, "", "(lv.obj)." } },
+  { "set_tasmota_logo", { (const void*) &lv_image_set_tasmota_logo, "", "(lv.obj)" } },
+  { "set_zoom", { (const void*) &lv_image_set_scale, "", "(lv.obj)i" } },
+};
+#endif // BE_LV_WIDGET_IMAGE
+
 /* `lv_imagebutton` methods */
 #ifdef BE_LV_WIDGET_IMAGEBUTTON
 const be_ntv_func_def_t lv_imagebutton_func[] = {
@@ -1188,12 +1188,21 @@ const be_ntv_func_def_t lv_slider_func[] = {
 };
 #endif // BE_LV_WIDGET_SLIDER
 
+/* `lv_span` methods */
+#ifdef BE_LV_WIDGET_SPAN
+const be_ntv_func_def_t lv_span_func[] = {
+  { "get_style", { (const void*) &lv_span_get_style, "lv.style", "(lv.span)" } },
+  { "set_text", { (const void*) &lv_span_set_text, "", "(lv.span)s" } },
+  { "set_text_static", { (const void*) &lv_span_set_text_static, "", "(lv.span)s" } },
+};
+#endif // BE_LV_WIDGET_SPAN
+
 /* `lv_spangroup` methods */
 #ifdef BE_LV_WIDGET_SPANGROUP
 const be_ntv_func_def_t lv_spangroup_func[] = {
-  { "delete_span", { (const void*) &lv_spangroup_delete_span, "", "(lv.obj)(lv.spangroup)" } },
+  { "delete_span", { (const void*) &lv_spangroup_delete_span, "", "(lv.obj)(lv.span)" } },
   { "get_align", { (const void*) &lv_spangroup_get_align, "i", "(lv.obj)" } },
-  { "get_child", { (const void*) &lv_spangroup_get_child, "lv.spangroup", "(lv.obj)i" } },
+  { "get_child", { (const void*) &lv_spangroup_get_child, "lv.span", "(lv.obj)i" } },
   { "get_expand_height", { (const void*) &lv_spangroup_get_expand_height, "i", "(lv.obj)i" } },
   { "get_expand_width", { (const void*) &lv_spangroup_get_expand_width, "i", "(lv.obj)i" } },
   { "get_indent", { (const void*) &lv_spangroup_get_indent, "i", "(lv.obj)" } },
@@ -1202,7 +1211,7 @@ const be_ntv_func_def_t lv_spangroup_func[] = {
   { "get_mode", { (const void*) &lv_spangroup_get_mode, "i", "(lv.obj)" } },
   { "get_overflow", { (const void*) &lv_spangroup_get_overflow, "i", "(lv.obj)" } },
   { "get_span_count", { (const void*) &lv_spangroup_get_span_count, "i", "(lv.obj)" } },
-  { "new_span", { (const void*) &lv_spangroup_new_span, "lv.spangroup", "(lv.obj)" } },
+  { "new_span", { (const void*) &lv_spangroup_new_span, "lv.span", "(lv.obj)" } },
   { "refr_mode", { (const void*) &lv_spangroup_refr_mode, "", "(lv.obj)" } },
   { "set_align", { (const void*) &lv_spangroup_set_align, "", "(lv.obj)i" } },
   { "set_indent", { (const void*) &lv_spangroup_set_indent, "", "(lv.obj)i" } },
@@ -1375,6 +1384,7 @@ extern const bclass be_class_lv_qrcode;
 extern const bclass be_class_lv_roller;
 extern const bclass be_class_lv_scale;
 extern const bclass be_class_lv_slider;
+extern const bclass be_class_lv_span;
 extern const bclass be_class_lv_spangroup;
 extern const bclass be_class_lv_spinbox;
 extern const bclass be_class_lv_spinner;
@@ -1469,6 +1479,9 @@ const be_ntv_class_def_t lv_classes[] = {
 #ifdef BE_LV_WIDGET_SLIDER
   { "lv_slider", &be_class_lv_slider, lv_slider_func, sizeof(lv_slider_func) / sizeof(lv_slider_func[0]) },
 #endif // BE_LV_WIDGET_SLIDER
+#ifdef BE_LV_WIDGET_SPAN
+  { "lv_span", &be_class_lv_span, lv_span_func, sizeof(lv_span_func) / sizeof(lv_span_func[0]) },
+#endif // BE_LV_WIDGET_SPAN
 #ifdef BE_LV_WIDGET_SPANGROUP
   { "lv_spangroup", &be_class_lv_spangroup, lv_spangroup_func, sizeof(lv_spangroup_func) / sizeof(lv_spangroup_func[0]) },
 #endif // BE_LV_WIDGET_SPANGROUP
@@ -1503,10 +1516,6 @@ const size_t lv_classes_size = sizeof(lv_classes) / sizeof(lv_classes[0]);
   /* `lv_font` methods */
   /* `lv_color` methods */
   /* `lv_theme` methods */
-  /* `lv_image` methods */
-#ifdef BE_LV_WIDGET_IMAGE
-  int be_ntv_lv_image_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_image_create, "+_p", "(lv.obj)"); }
-#endif // BE_LV_WIDGET_IMAGE
   /* `lv_group` methods */
   int be_ntv_lv_group_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_group_create, "+_p", ""); }
   /* `lv_obj` methods */
@@ -1568,6 +1577,10 @@ const size_t lv_classes_size = sizeof(lv_classes) / sizeof(lv_classes[0]);
 #ifdef BE_LV_WIDGET_DROPDOWN
   int be_ntv_lv_dropdown_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_dropdown_create, "+_p", "(lv.obj)"); }
 #endif // BE_LV_WIDGET_DROPDOWN
+  /* `lv_image` methods */
+#ifdef BE_LV_WIDGET_IMAGE
+  int be_ntv_lv_image_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_image_create, "+_p", "(lv.obj)"); }
+#endif // BE_LV_WIDGET_IMAGE
   /* `lv_imagebutton` methods */
 #ifdef BE_LV_WIDGET_IMAGEBUTTON
   int be_ntv_lv_imagebutton_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_imagebutton_create, "+_p", "(lv.obj)"); }
@@ -1624,6 +1637,10 @@ const size_t lv_classes_size = sizeof(lv_classes) / sizeof(lv_classes[0]);
 #ifdef BE_LV_WIDGET_SLIDER
   int be_ntv_lv_slider_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_slider_create, "+_p", "(lv.obj)"); }
 #endif // BE_LV_WIDGET_SLIDER
+  /* `lv_span` methods */
+#ifdef BE_LV_WIDGET_SPAN
+  int be_ntv_lv_span_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_span_set_text_static, "+_p", "(lv.span)s"); }
+#endif // BE_LV_WIDGET_SPAN
   /* `lv_spangroup` methods */
 #ifdef BE_LV_WIDGET_SPANGROUP
   int be_ntv_lv_spangroup_init(bvm *vm)       { return be_call_c_func(vm, (void*) &lv_spangroup_create, "+_p", "(lv.obj)"); }

--- a/lib/libesp32_lvgl/lv_binding_berry/generate/be_lvgl_module.c
+++ b/lib/libesp32_lvgl/lv_binding_berry/generate/be_lvgl_module.c
@@ -147,8 +147,6 @@ const be_ntv_func_def_t lv_func[] = {
   { "screen_active", { (const void*) &lv_screen_active, "lv.obj", "" } },
   { "screen_load", { (const void*) &lv_screen_load, "", "(lv.obj)" } },
   { "screen_load_anim", { (const void*) &lv_screen_load_anim, "", "(lv.obj)iiib" } },
-  { "span_set_text", { (const void*) &lv_span_set_text, "", "(lv.spangroup)s" } },
-  { "span_set_text_static", { (const void*) &lv_span_set_text_static, "", "(lv.spangroup)s" } },
   { "span_stack_deinit", { (const void*) &lv_span_stack_deinit, "", "" } },
   { "span_stack_init", { (const void*) &lv_span_stack_init, "", "" } },
   { "style_get_num_custom_props", { (const void*) &lv_style_get_num_custom_props, "i", "" } },

--- a/lib/libesp32_lvgl/lv_binding_berry/generate/be_lvgl_widgets_lib.c
+++ b/lib/libesp32_lvgl/lv_binding_berry/generate/be_lvgl_widgets_lib.c
@@ -169,40 +169,6 @@ extern int lvbe_style_set_y(bvm *vm);
 
 /* `lv_theme` external functions definitions */
 
-/* `lv_image` external functions definitions */
-extern int lvbe_image_create(bvm *vm);
-extern int lvbe_image_get_rotation(bvm *vm);
-extern int lvbe_image_get_antialias(bvm *vm);
-extern int lvbe_image_get_blend_mode(bvm *vm);
-extern int lvbe_image_get_inner_align(bvm *vm);
-extern int lvbe_image_get_offset_x(bvm *vm);
-extern int lvbe_image_get_offset_x(bvm *vm);
-extern int lvbe_image_get_offset_y(bvm *vm);
-extern int lvbe_image_get_offset_y(bvm *vm);
-extern int lvbe_image_get_pivot(bvm *vm);
-extern int lvbe_image_get_rotation(bvm *vm);
-extern int lvbe_image_get_rotation(bvm *vm);
-extern int lvbe_image_get_scale(bvm *vm);
-extern int lvbe_image_get_scale_x(bvm *vm);
-extern int lvbe_image_get_scale_y(bvm *vm);
-extern int lvbe_image_get_src(bvm *vm);
-extern int lvbe_image_get_scale(bvm *vm);
-extern int lvbe_image_set_rotation(bvm *vm);
-extern int lvbe_image_set_antialias(bvm *vm);
-extern int lvbe_image_set_blend_mode(bvm *vm);
-extern int lvbe_image_set_inner_align(bvm *vm);
-extern int lvbe_image_set_offset_x(bvm *vm);
-extern int lvbe_image_set_offset_y(bvm *vm);
-extern int lvbe_image_set_pivot(bvm *vm);
-extern int lvbe_image_set_rotation(bvm *vm);
-extern int lvbe_image_set_rotation(bvm *vm);
-extern int lvbe_image_set_scale(bvm *vm);
-extern int lvbe_image_set_scale_x(bvm *vm);
-extern int lvbe_image_set_scale_y(bvm *vm);
-extern int lvbe_image_set_src(bvm *vm);
-extern int lvbe_image_set_tasmota_logo(bvm *vm);
-extern int lvbe_image_set_scale(bvm *vm);
-
 /* `lv_group` external functions definitions */
 extern int lvbe_group_add_obj(bvm *vm);
 extern int lvbe_group_create(bvm *vm);
@@ -1005,6 +971,40 @@ extern int lvbe_dropdown_set_selected_highlight(bvm *vm);
 extern int lvbe_dropdown_set_symbol(bvm *vm);
 extern int lvbe_dropdown_set_text(bvm *vm);
 
+/* `lv_image` external functions definitions */
+extern int lvbe_image_create(bvm *vm);
+extern int lvbe_image_get_rotation(bvm *vm);
+extern int lvbe_image_get_antialias(bvm *vm);
+extern int lvbe_image_get_blend_mode(bvm *vm);
+extern int lvbe_image_get_inner_align(bvm *vm);
+extern int lvbe_image_get_offset_x(bvm *vm);
+extern int lvbe_image_get_offset_x(bvm *vm);
+extern int lvbe_image_get_offset_y(bvm *vm);
+extern int lvbe_image_get_offset_y(bvm *vm);
+extern int lvbe_image_get_pivot(bvm *vm);
+extern int lvbe_image_get_rotation(bvm *vm);
+extern int lvbe_image_get_rotation(bvm *vm);
+extern int lvbe_image_get_scale(bvm *vm);
+extern int lvbe_image_get_scale_x(bvm *vm);
+extern int lvbe_image_get_scale_y(bvm *vm);
+extern int lvbe_image_get_src(bvm *vm);
+extern int lvbe_image_get_scale(bvm *vm);
+extern int lvbe_image_set_rotation(bvm *vm);
+extern int lvbe_image_set_antialias(bvm *vm);
+extern int lvbe_image_set_blend_mode(bvm *vm);
+extern int lvbe_image_set_inner_align(bvm *vm);
+extern int lvbe_image_set_offset_x(bvm *vm);
+extern int lvbe_image_set_offset_y(bvm *vm);
+extern int lvbe_image_set_pivot(bvm *vm);
+extern int lvbe_image_set_rotation(bvm *vm);
+extern int lvbe_image_set_rotation(bvm *vm);
+extern int lvbe_image_set_scale(bvm *vm);
+extern int lvbe_image_set_scale_x(bvm *vm);
+extern int lvbe_image_set_scale_y(bvm *vm);
+extern int lvbe_image_set_src(bvm *vm);
+extern int lvbe_image_set_tasmota_logo(bvm *vm);
+extern int lvbe_image_set_scale(bvm *vm);
+
 /* `lv_imagebutton` external functions definitions */
 extern int lvbe_imagebutton_create(bvm *vm);
 extern int lvbe_imagebutton_set_src(bvm *vm);
@@ -1151,6 +1151,11 @@ extern int lvbe_slider_set_mode(bvm *vm);
 extern int lvbe_slider_set_range(bvm *vm);
 extern int lvbe_slider_set_value(bvm *vm);
 
+/* `lv_span` external functions definitions */
+extern int lvbe_span_get_style(bvm *vm);
+extern int lvbe_span_set_text(bvm *vm);
+extern int lvbe_span_set_text_static(bvm *vm);
+
 /* `lv_spangroup` external functions definitions */
 extern int lvbe_spangroup_create(bvm *vm);
 extern int lvbe_spangroup_delete_span(bvm *vm);
@@ -1287,7 +1292,6 @@ extern int be_ntv_lv_style_init(bvm *vm);
 extern int be_ntv_lv_font_init(bvm *vm);
 extern int be_ntv_lv_color_init(bvm *vm);
 extern int be_ntv_lv_theme_init(bvm *vm);
-extern int be_ntv_lv_image_init(bvm *vm);
 extern int be_ntv_lv_group_init(bvm *vm);
 extern int be_ntv_lv_obj_init(bvm *vm);
 extern int be_ntv_lv_event_init(bvm *vm);
@@ -1306,6 +1310,7 @@ extern int be_ntv_lv_canvas_init(bvm *vm);
 extern int be_ntv_lv_chart_init(bvm *vm);
 extern int be_ntv_lv_checkbox_init(bvm *vm);
 extern int be_ntv_lv_dropdown_init(bvm *vm);
+extern int be_ntv_lv_image_init(bvm *vm);
 extern int be_ntv_lv_imagebutton_init(bvm *vm);
 extern int be_ntv_lv_keyboard_init(bvm *vm);
 extern int be_ntv_lv_label_init(bvm *vm);
@@ -1317,6 +1322,7 @@ extern int be_ntv_lv_msgbox_init(bvm *vm);
 extern int be_ntv_lv_roller_init(bvm *vm);
 extern int be_ntv_lv_scale_init(bvm *vm);
 extern int be_ntv_lv_slider_init(bvm *vm);
+extern int be_ntv_lv_span_init(bvm *vm);
 extern int be_ntv_lv_spangroup_init(bvm *vm);
 extern int be_ntv_lv_spinbox_init(bvm *vm);
 extern int be_ntv_lv_spinner_init(bvm *vm);
@@ -1357,6 +1363,7 @@ extern const bclass be_class_lv_qrcode;
 extern const bclass be_class_lv_roller;
 extern const bclass be_class_lv_scale;
 extern const bclass be_class_lv_slider;
+extern const bclass be_class_lv_span;
 extern const bclass be_class_lv_spangroup;
 extern const bclass be_class_lv_spinbox;
 extern const bclass be_class_lv_spinner;
@@ -1518,24 +1525,13 @@ extern void arc_anim_end_angle(void * obj, int32_t v);
 
 
 /********************************************************************
-** Solidified class: lv_image
-********************************************************************/
-#include "be_fixed_be_class_lv_image.h"
-/* @const_object_info_begin
-class be_class_lv_image (scope: global, name: lv_image, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_image_class)
-    init, func(be_ntv_lv_image_init)
-}
-@const_object_info_end */
-
-/********************************************************************
 ** Solidified class: lv_qrcode
 ********************************************************************/
 #include "be_fixed_be_class_lv_qrcode.h"
 /* @const_object_info_begin
 class be_class_lv_qrcode (scope: global, name: lv_qrcode, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_qrcode_class)
     init, func(be_ntv_lv_qrcode_init)
+    _class, comptr(&lv_qrcode_class)
 }
 @const_object_info_end */
 
@@ -1545,8 +1541,8 @@ class be_class_lv_qrcode (scope: global, name: lv_qrcode, super: be_class_lv_obj
 #include "be_fixed_be_class_lv_animimg.h"
 /* @const_object_info_begin
 class be_class_lv_animimg (scope: global, name: lv_animimg, super: be_class_lv_image, strings: weak) {
-    _class, comptr(&lv_animimg_class)
     init, func(be_ntv_lv_animimg_init)
+    _class, comptr(&lv_animimg_class)
 }
 @const_object_info_end */
 
@@ -1556,8 +1552,8 @@ class be_class_lv_animimg (scope: global, name: lv_animimg, super: be_class_lv_i
 #include "be_fixed_be_class_lv_arc.h"
 /* @const_object_info_begin
 class be_class_lv_arc (scope: global, name: lv_arc, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_arc_class)
     init, func(be_ntv_lv_arc_init)
+    _class, comptr(&lv_arc_class)
 }
 @const_object_info_end */
 
@@ -1567,8 +1563,8 @@ class be_class_lv_arc (scope: global, name: lv_arc, super: be_class_lv_obj, stri
 #include "be_fixed_be_class_lv_bar.h"
 /* @const_object_info_begin
 class be_class_lv_bar (scope: global, name: lv_bar, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_bar_class)
     init, func(be_ntv_lv_bar_init)
+    _class, comptr(&lv_bar_class)
 }
 @const_object_info_end */
 
@@ -1578,8 +1574,8 @@ class be_class_lv_bar (scope: global, name: lv_bar, super: be_class_lv_obj, stri
 #include "be_fixed_be_class_lv_button.h"
 /* @const_object_info_begin
 class be_class_lv_button (scope: global, name: lv_button, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_button_class)
     init, func(be_ntv_lv_button_init)
+    _class, comptr(&lv_button_class)
 }
 @const_object_info_end */
 
@@ -1589,8 +1585,8 @@ class be_class_lv_button (scope: global, name: lv_button, super: be_class_lv_obj
 #include "be_fixed_be_class_lv_buttonmatrix.h"
 /* @const_object_info_begin
 class be_class_lv_buttonmatrix (scope: global, name: lv_buttonmatrix, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_buttonmatrix_class)
     init, func(be_ntv_lv_buttonmatrix_init)
+    _class, comptr(&lv_buttonmatrix_class)
 }
 @const_object_info_end */
 
@@ -1600,8 +1596,8 @@ class be_class_lv_buttonmatrix (scope: global, name: lv_buttonmatrix, super: be_
 #include "be_fixed_be_class_lv_calendar.h"
 /* @const_object_info_begin
 class be_class_lv_calendar (scope: global, name: lv_calendar, super: be_class_lv_buttonmatrix, strings: weak) {
-    _class, comptr(&lv_calendar_class)
     init, func(be_ntv_lv_calendar_init)
+    _class, comptr(&lv_calendar_class)
 }
 @const_object_info_end */
 
@@ -1611,8 +1607,8 @@ class be_class_lv_calendar (scope: global, name: lv_calendar, super: be_class_lv
 #include "be_fixed_be_class_lv_canvas.h"
 /* @const_object_info_begin
 class be_class_lv_canvas (scope: global, name: lv_canvas, super: be_class_lv_image, strings: weak) {
-    _class, comptr(&lv_canvas_class)
     init, func(be_ntv_lv_canvas_init)
+    _class, comptr(&lv_canvas_class)
 }
 @const_object_info_end */
 
@@ -1622,8 +1618,8 @@ class be_class_lv_canvas (scope: global, name: lv_canvas, super: be_class_lv_ima
 #include "be_fixed_be_class_lv_chart.h"
 /* @const_object_info_begin
 class be_class_lv_chart (scope: global, name: lv_chart, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_chart_class)
     init, func(be_ntv_lv_chart_init)
+    _class, comptr(&lv_chart_class)
 }
 @const_object_info_end */
 
@@ -1633,8 +1629,8 @@ class be_class_lv_chart (scope: global, name: lv_chart, super: be_class_lv_obj, 
 #include "be_fixed_be_class_lv_checkbox.h"
 /* @const_object_info_begin
 class be_class_lv_checkbox (scope: global, name: lv_checkbox, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_checkbox_class)
     init, func(be_ntv_lv_checkbox_init)
+    _class, comptr(&lv_checkbox_class)
 }
 @const_object_info_end */
 
@@ -1644,8 +1640,19 @@ class be_class_lv_checkbox (scope: global, name: lv_checkbox, super: be_class_lv
 #include "be_fixed_be_class_lv_dropdown.h"
 /* @const_object_info_begin
 class be_class_lv_dropdown (scope: global, name: lv_dropdown, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_dropdown_class)
     init, func(be_ntv_lv_dropdown_init)
+    _class, comptr(&lv_dropdown_class)
+}
+@const_object_info_end */
+
+/********************************************************************
+** Solidified class: lv_image
+********************************************************************/
+#include "be_fixed_be_class_lv_image.h"
+/* @const_object_info_begin
+class be_class_lv_image (scope: global, name: lv_image, super: be_class_lv_obj, strings: weak) {
+    init, func(be_ntv_lv_image_init)
+    _class, comptr(&lv_image_class)
 }
 @const_object_info_end */
 
@@ -1655,8 +1662,8 @@ class be_class_lv_dropdown (scope: global, name: lv_dropdown, super: be_class_lv
 #include "be_fixed_be_class_lv_imagebutton.h"
 /* @const_object_info_begin
 class be_class_lv_imagebutton (scope: global, name: lv_imagebutton, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_imagebutton_class)
     init, func(be_ntv_lv_imagebutton_init)
+    _class, comptr(&lv_imagebutton_class)
 }
 @const_object_info_end */
 
@@ -1666,8 +1673,8 @@ class be_class_lv_imagebutton (scope: global, name: lv_imagebutton, super: be_cl
 #include "be_fixed_be_class_lv_keyboard.h"
 /* @const_object_info_begin
 class be_class_lv_keyboard (scope: global, name: lv_keyboard, super: be_class_lv_buttonmatrix, strings: weak) {
-    _class, comptr(&lv_keyboard_class)
     init, func(be_ntv_lv_keyboard_init)
+    _class, comptr(&lv_keyboard_class)
 }
 @const_object_info_end */
 
@@ -1677,8 +1684,8 @@ class be_class_lv_keyboard (scope: global, name: lv_keyboard, super: be_class_lv
 #include "be_fixed_be_class_lv_label.h"
 /* @const_object_info_begin
 class be_class_lv_label (scope: global, name: lv_label, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_label_class)
     init, func(be_ntv_lv_label_init)
+    _class, comptr(&lv_label_class)
 }
 @const_object_info_end */
 
@@ -1688,8 +1695,8 @@ class be_class_lv_label (scope: global, name: lv_label, super: be_class_lv_obj, 
 #include "be_fixed_be_class_lv_led.h"
 /* @const_object_info_begin
 class be_class_lv_led (scope: global, name: lv_led, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_led_class)
     init, func(be_ntv_lv_led_init)
+    _class, comptr(&lv_led_class)
 }
 @const_object_info_end */
 
@@ -1699,8 +1706,8 @@ class be_class_lv_led (scope: global, name: lv_led, super: be_class_lv_obj, stri
 #include "be_fixed_be_class_lv_line.h"
 /* @const_object_info_begin
 class be_class_lv_line (scope: global, name: lv_line, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_line_class)
     init, func(be_ntv_lv_line_init)
+    _class, comptr(&lv_line_class)
 }
 @const_object_info_end */
 
@@ -1710,8 +1717,8 @@ class be_class_lv_line (scope: global, name: lv_line, super: be_class_lv_obj, st
 #include "be_fixed_be_class_lv_list.h"
 /* @const_object_info_begin
 class be_class_lv_list (scope: global, name: lv_list, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_list_class)
     init, func(be_ntv_lv_list_init)
+    _class, comptr(&lv_list_class)
 }
 @const_object_info_end */
 
@@ -1721,8 +1728,8 @@ class be_class_lv_list (scope: global, name: lv_list, super: be_class_lv_obj, st
 #include "be_fixed_be_class_lv_menu.h"
 /* @const_object_info_begin
 class be_class_lv_menu (scope: global, name: lv_menu, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_menu_class)
     init, func(be_ntv_lv_menu_init)
+    _class, comptr(&lv_menu_class)
 }
 @const_object_info_end */
 
@@ -1732,8 +1739,8 @@ class be_class_lv_menu (scope: global, name: lv_menu, super: be_class_lv_obj, st
 #include "be_fixed_be_class_lv_msgbox.h"
 /* @const_object_info_begin
 class be_class_lv_msgbox (scope: global, name: lv_msgbox, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_msgbox_class)
     init, func(be_ntv_lv_msgbox_init)
+    _class, comptr(&lv_msgbox_class)
 }
 @const_object_info_end */
 
@@ -1743,8 +1750,8 @@ class be_class_lv_msgbox (scope: global, name: lv_msgbox, super: be_class_lv_obj
 #include "be_fixed_be_class_lv_roller.h"
 /* @const_object_info_begin
 class be_class_lv_roller (scope: global, name: lv_roller, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_roller_class)
     init, func(be_ntv_lv_roller_init)
+    _class, comptr(&lv_roller_class)
 }
 @const_object_info_end */
 
@@ -1754,8 +1761,8 @@ class be_class_lv_roller (scope: global, name: lv_roller, super: be_class_lv_obj
 #include "be_fixed_be_class_lv_scale.h"
 /* @const_object_info_begin
 class be_class_lv_scale (scope: global, name: lv_scale, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_scale_class)
     init, func(be_ntv_lv_scale_init)
+    _class, comptr(&lv_scale_class)
 }
 @const_object_info_end */
 
@@ -1765,8 +1772,21 @@ class be_class_lv_scale (scope: global, name: lv_scale, super: be_class_lv_obj, 
 #include "be_fixed_be_class_lv_slider.h"
 /* @const_object_info_begin
 class be_class_lv_slider (scope: global, name: lv_slider, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_slider_class)
     init, func(be_ntv_lv_slider_init)
+    _class, comptr(&lv_slider_class)
+}
+@const_object_info_end */
+
+/********************************************************************
+** Solidified class: lv_span
+********************************************************************/
+#include "be_fixed_be_class_lv_span.h"
+/* @const_object_info_begin
+class be_class_lv_span (scope: global, name: lv_span, strings: weak) {
+    _p, var
+    tostring, func(lv_x_tostring)
+    member, func(lv_x_member)
+    init, func(be_ntv_lv_span_init)
 }
 @const_object_info_end */
 
@@ -1776,8 +1796,8 @@ class be_class_lv_slider (scope: global, name: lv_slider, super: be_class_lv_obj
 #include "be_fixed_be_class_lv_spangroup.h"
 /* @const_object_info_begin
 class be_class_lv_spangroup (scope: global, name: lv_spangroup, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_spangroup_class)
     init, func(be_ntv_lv_spangroup_init)
+    _class, comptr(&lv_spangroup_class)
 }
 @const_object_info_end */
 
@@ -1787,8 +1807,8 @@ class be_class_lv_spangroup (scope: global, name: lv_spangroup, super: be_class_
 #include "be_fixed_be_class_lv_spinbox.h"
 /* @const_object_info_begin
 class be_class_lv_spinbox (scope: global, name: lv_spinbox, super: be_class_lv_textarea, strings: weak) {
-    _class, comptr(&lv_spinbox_class)
     init, func(be_ntv_lv_spinbox_init)
+    _class, comptr(&lv_spinbox_class)
 }
 @const_object_info_end */
 
@@ -1798,8 +1818,8 @@ class be_class_lv_spinbox (scope: global, name: lv_spinbox, super: be_class_lv_t
 #include "be_fixed_be_class_lv_spinner.h"
 /* @const_object_info_begin
 class be_class_lv_spinner (scope: global, name: lv_spinner, super: be_class_lv_arc, strings: weak) {
-    _class, comptr(&lv_spinner_class)
     init, func(be_ntv_lv_spinner_init)
+    _class, comptr(&lv_spinner_class)
 }
 @const_object_info_end */
 
@@ -1809,8 +1829,8 @@ class be_class_lv_spinner (scope: global, name: lv_spinner, super: be_class_lv_a
 #include "be_fixed_be_class_lv_switch.h"
 /* @const_object_info_begin
 class be_class_lv_switch (scope: global, name: lv_switch, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_switch_class)
     init, func(be_ntv_lv_switch_init)
+    _class, comptr(&lv_switch_class)
 }
 @const_object_info_end */
 
@@ -1820,8 +1840,8 @@ class be_class_lv_switch (scope: global, name: lv_switch, super: be_class_lv_obj
 #include "be_fixed_be_class_lv_table.h"
 /* @const_object_info_begin
 class be_class_lv_table (scope: global, name: lv_table, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_table_class)
     init, func(be_ntv_lv_table_init)
+    _class, comptr(&lv_table_class)
 }
 @const_object_info_end */
 
@@ -1831,8 +1851,8 @@ class be_class_lv_table (scope: global, name: lv_table, super: be_class_lv_obj, 
 #include "be_fixed_be_class_lv_tabview.h"
 /* @const_object_info_begin
 class be_class_lv_tabview (scope: global, name: lv_tabview, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_tabview_class)
     init, func(be_ntv_lv_tabview_init)
+    _class, comptr(&lv_tabview_class)
 }
 @const_object_info_end */
 
@@ -1842,8 +1862,8 @@ class be_class_lv_tabview (scope: global, name: lv_tabview, super: be_class_lv_o
 #include "be_fixed_be_class_lv_textarea.h"
 /* @const_object_info_begin
 class be_class_lv_textarea (scope: global, name: lv_textarea, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_textarea_class)
     init, func(be_ntv_lv_textarea_init)
+    _class, comptr(&lv_textarea_class)
 }
 @const_object_info_end */
 
@@ -1853,8 +1873,8 @@ class be_class_lv_textarea (scope: global, name: lv_textarea, super: be_class_lv
 #include "be_fixed_be_class_lv_tileview.h"
 /* @const_object_info_begin
 class be_class_lv_tileview (scope: global, name: lv_tileview, super: be_class_lv_obj, strings: weak) {
-    _class, comptr(&lv_tileview_class)
     init, func(be_ntv_lv_tileview_init)
+    _class, comptr(&lv_tileview_class)
 }
 @const_object_info_end */
 

--- a/lib/libesp32_lvgl/lv_binding_berry/mapping/lv_funcs.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/mapping/lv_funcs.h
@@ -3,7 +3,6 @@
 // Extract function signatures from LVGL APIs in headers
 
 // Custom Tasmota functions
-void lv_image_set_tasmota_logo(lv_obj_t * img);
 lv_ts_calibration_t * lv_get_ts_calibration(void);
 
 // ======================================================================
@@ -1471,4 +1470,9 @@ lv_obj_t * lv_tileview_get_tile_active(lv_obj_t * obj)
 // ../../LVGL_assets/src/lv_theme_haspmota.h
 lv_theme_t * lv_theme_haspmota_init(lv_display_t * disp, lv_color_t color_primary, lv_color_t color_secondary, bool dark, const lv_font_t * font)
 bool lv_theme_haspmota_is_inited(void)
+
+// ../src/lv_berry.h
+void be_load_lvgl_classes(bvm *vm)
+void lv_image_set_tasmota_logo(lv_obj_t * img)
+lv_style_t * lv_span_get_style(lv_span_t * span)
 

--- a/lib/libesp32_lvgl/lv_binding_berry/src/lv_berry.c
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/lv_berry.c
@@ -354,3 +354,8 @@ int lv0_member(bvm *vm) {
   be_module_load(vm, be_newstr(vm, "undefined"));
   be_return(vm);
 }
+
+// temporarily fix lv_span_get_style()
+lv_style_t * lv_span_get_style(lv_span_t * span) {
+      return &span->style;
+}

--- a/lib/libesp32_lvgl/lv_binding_berry/src/lv_berry.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/lv_berry.h
@@ -25,6 +25,8 @@ typedef struct lv_ts_calibration_t {
 } lv_ts_calibration_t;
 extern lv_ts_calibration_t lv_ts_calibration;
 
+// temporarily fix lv_span_get_style()
+extern lv_style_t * lv_span_get_style(lv_span_t * span);
 
 #ifdef __cplusplus
 }

--- a/lib/libesp32_lvgl/lv_binding_berry/tools/preprocessor.py
+++ b/lib/libesp32_lvgl/lv_binding_berry/tools/preprocessor.py
@@ -81,6 +81,7 @@ lv_fun_globs = [
               ]
 headers_names = list_files(lv_src_prefix, lv_fun_globs)
 headers_names += list_files("../../LVGL_assets/src/", ["lv_theme_haspmota.h"])
+headers_names += list_files("../src/", ["lv_berry.h"])
 
 output_filename = "../mapping/lv_funcs.h"
 sys.stdout = open(output_filename, 'w', encoding='utf-8')
@@ -90,7 +91,6 @@ print("""
 // Extract function signatures from LVGL APIs in headers
 
 // Custom Tasmota functions
-void lv_image_set_tasmota_logo(lv_obj_t * img);
 lv_ts_calibration_t * lv_get_ts_calibration(void);
 
 // ======================================================================
@@ -128,6 +128,8 @@ for header_name in headers_names:
       fun = re.sub('LV_ATTRIBUTE_FAST_MEM ', '', fun)
       # remove LV_ATTRIBUTE_TIMER_HANDLER 
       fun = re.sub('LV_ATTRIBUTE_TIMER_HANDLER ', '', fun)
+      # remove extern 
+      fun = re.sub('extern ', '', fun)
       exclude = False
       for exclude_prefix in ["typedef", "_LV_", "LV_"]:
         if fun.startswith(exclude_prefix): exclude = True

--- a/tasmota/berry/haspmota_src/haspmota_core/haspmota.be
+++ b/tasmota/berry/haspmota_src/haspmota_core/haspmota.be
@@ -9,43 +9,22 @@
 # How to solidify (needs an ESP32 with PSRAM)
 #-
 
-import path 
+import path
 path.remove("haspmota.bec")
-import solidify
-var haspmota
 load('haspmota.be')
-
-var classes = [
-  "page", "obj", "scr",
-  "btn", "switch", "checkbox",
-  "label", "spinner", "line", "img", "roller", "btnmatrix",
-  "bar", "slider", "arc", "textarea", "dropdown",
-  "qrcode", "chart"
-]
-var f = open("haspmota.c", "w")
-for c:classes
-  solidify.dump(haspmota.HASPmota.("lvh_"+c), true, f)
-end
-solidify.dump(haspmota, true, f)
-f.close()
-print("Ok")
+global.solidify_haspmota()
 
 -#
 var haspmota = module("haspmota")
 
 #################################################################################
-#################################################################################
-# Class `lvh_obj` encapsulating `lv_obj``
+# Class `lvh_root`
 #
-# Provide a mapping for virtual members
-# Stores the associated page and object id
+# Allows to map either a `lv_obj` for LVGL or arbitrary object
 #
-# Adds specific virtual members used by HASPmota
 #################################################################################
-#################################################################################
-class lvh_obj
-  static var _lv_class = lv.obj     # _lv_class refers to the lvgl class encapsulated, and is overriden by subclasses
-  static var _lv_part2_selector     # selector for secondary part (like knob of arc)
+class lvh_root
+  static var _lv_class = nil        # _lv_class refers to the lvgl class encapsulated, and is overriden by subclasses
 
   # attributes to ignore when set at object level (they are managed by page)
   static var _attr_ignore = [
@@ -157,9 +136,8 @@ class lvh_obj
   # Instance variables
   var id                                    # (int) object hasp id
   var _lv_obj                               # native lvgl object
-  var _lv_label                             # sub-label if exists
   var _page                                 # parent page object
-  var _action                               # value of the HASPmota `action` attribute, shouldn't be called `self.action` since we want to trigger the set/member functions
+  var _parent_lvh                               # parent HASPmota object if 'parentid' was set, or 'nil'
   var _meta                                 # free form metadata
 
   #====================================================================
@@ -251,14 +229,81 @@ class lvh_obj
   end
 
   #====================================================================
+  #  parse_font
+  #
+  # For HASPmota compatiblity, default to "robotocondensed-latin1"
+  # However we propose an extension to allow for other font names
+  #
+  # Arg1: (int) font size for `robotocondensed-latin1`
+  #  or
+  # Arg1: (string) "font_name-font_size", ex: "montserrat-20"
+  #====================================================================
+  def parse_font(t)
+    var font
+    if type(t) == 'int'
+      try
+        font = lv.font_embedded("robotocondensed", t)
+      except ..
+        try
+          font = lv.font_embedded("montserrat", t)
+        except ..
+          print("HSP: Unsupported font:", t)
+          return nil
+        end
+      end
+    elif type(t) == 'string'
+      import string
+      import re
+      # look for 'A:name.font' style font file name
+      var drive_split = string.split(t, ':', 1)
+      var fn_split = string.split(t, '-')
+
+      var name = t
+      var sz = 0
+      var is_ttf = false
+      var is_binary = (size(drive_split) > 1 && size(drive_split[0]))
+
+      if size(fn_split) >= 2
+        sz = int(fn_split[-1])
+        name = fn_split[0..-2].concat('-')    # rebuild the font name
+      end
+      if re.match(".*\\.ttf$", name)
+        # ttf font
+        name = string.split(name, ':')[-1]      # remove A: if any
+        is_ttf = true
+      end
+
+      if is_ttf
+        font = lv.load_freetype_font(name, sz, 0)
+      elif is_binary
+        # font is from disk
+        font = lv.load_font(t)
+      elif sz > 0 && size(name) > 0              # looks good, let's have a try
+        try
+          font = lv.font_embedded(name, sz)
+        except ..
+          print("HSP: Unsupported font:", t)
+        end
+      end
+    end
+    if font != nil
+      return font
+    else
+      print("HSP: Unsupported font:", t)
+    end
+  end
+
+  #====================================================================
   # init HASPmota object from its jsonl definition
   #
   # arg1: LVGL parent object (used to create a sub-object)
   # arg2: `jline` JSONL definition of the object from HASPmota template (used in sub-classes)
   # arg3: (opt) LVGL object if it already exists and was created prior to init()
+  # arg4: HASPmota parent object defined by `parentid`
   #====================================================================
-  def init(parent, page, jline, obj)
+  def init(parent, page, jline, obj, parent_lvh)
     self._page = page
+    self._parent_lvh = parent_lvh
     if obj == nil && self._lv_class
       var obj_class = self._lv_class    # assign to a var to distinguish from method call
       self._lv_obj = obj_class(parent)  # instanciate LVGL object
@@ -266,13 +311,6 @@ class lvh_obj
       self._lv_obj = obj
     end
     self.post_init()
-  end
-
-  #====================================================================
-  # post-init, to be overriden and used by certain classes
-  #====================================================================
-  def post_init()
-    self.register_event_cb()
   end
 
   #####################################################################
@@ -285,6 +323,283 @@ class lvh_obj
   def get_obj()
     return self._lv_obj
   end
+
+  #====================================================================
+  # set_text: create a `lv_label` sub object to the current object
+  # (default case, may be overriden by object that directly take text)
+  #====================================================================
+  def set_text(t)
+  end
+  def get_text()
+    return nil
+  end
+
+  #- ------------------------------------------------------------#
+  # `digits_to_style` 
+  # 
+  # Convert a 2 digits style descriptor to LVGL style modifier
+  # See https://www.openhasp.com/0.6.3/design/styling/
+  #
+  #
+  # 00 = main part of the object (i.e. the background)
+  # 10 = the indicator or needle, highlighting the the current value
+  # 20 = the knob which can be used the change the value
+  # 30 = the background of the items/buttons
+  # 40 = the items/buttons
+  # 50 = the selected item
+  # 60 = major ticks of the gauge object
+  # 70 = the text cursor
+  # 80 = the scrollbar
+  # 90 = other special part, not listed above
+  #
+  # LV_PART_MAIN         = 0x000000,   /**< A background like rectangle*/
+  # LV_PART_SCROLLBAR    = 0x010000,   /**< The scrollbar(s)*/
+  # LV_PART_INDICATOR    = 0x020000,   /**< Indicator, e.g. for slider, bar, switch, or the tick box of the checkbox*/
+  # LV_PART_KNOB         = 0x030000,   /**< Like handle to grab to adjust the value*/
+  # LV_PART_SELECTED     = 0x040000,   /**< Indicate the currently selected option or section*/
+  # LV_PART_ITEMS        = 0x050000,   /**< Used if the widget has multiple similar elements (e.g. table cells)*/
+  # LV_PART_CURSOR       = 0x060000,   /**< Mark a specific place e.g. for text area's cursor or on a chart*/
+  # LV_PART_CUSTOM_FIRST = 0x080000,    /**< Extension point for custom widgets*/
+  # LV_PART_ANY          = 0x0F0000,    /**< Special value can be used in some functions to target all parts*/
+  #
+  # 00 = default styling
+  # 01 = styling for toggled state
+  # 02 = styling for pressed, not toggled state
+  # 03 = styling for pressed and toggled state
+  # 04 = styling for disabled not toggled state
+  # 05 = styling for disabled and toggled state
+  #
+  # LV_STATE_DEFAULT     =  0x0000,
+  # LV_STATE_CHECKED     =  0x0001,
+  # LV_STATE_FOCUSED     =  0x0002,
+  # LV_STATE_FOCUS_KEY   =  0x0004,
+  # LV_STATE_EDITED      =  0x0008,
+  # LV_STATE_HOVERED     =  0x0010,
+  # LV_STATE_PRESSED     =  0x0020,
+  # LV_STATE_SCROLLED    =  0x0040,
+  # LV_STATE_DISABLED    =  0x0080,
+
+  # LV_STATE_USER_1      =  0x1000,
+  # LV_STATE_USER_2      =  0x2000,
+  # LV_STATE_USER_3      =  0x4000,
+  # LV_STATE_USER_4      =  0x8000,
+  #
+  #- ------------------------------------------------------------#
+  static var _digit2part = [
+    lv.PART_MAIN,         # 00
+    lv.PART_INDICATOR,    # 10
+    lv.PART_KNOB,         # 20
+    lv.PART_ITEMS,        # 30    TODO
+    lv.PART_ITEMS,        # 40
+    lv.PART_SELECTED,     # 50
+    lv.PART_ITEMS,        # 60
+    lv.PART_CURSOR,       # 70
+    lv.PART_SCROLLBAR,    # 80
+    lv.PART_CUSTOM_FIRST, # 90
+  ]
+  static var _digit2state = [
+    lv.STATE_DEFAULT,                     # 00
+    lv.STATE_CHECKED,                     # 01
+    lv.STATE_PRESSED,                     # 02
+    lv.STATE_CHECKED | lv.STATE_PRESSED,  # 03
+    lv.STATE_DISABLED,                    # 04
+    lv.STATE_DISABLED | lv.STATE_PRESSED, # 05
+  ]
+  def digits_to_style(digits)
+    if digits == nil    return 0    end     # lv.PART_MAIN | lv.STATE_DEFAULT
+    var first_digit = (digits / 10) % 10
+    var second_digit = digits % 10
+    var val = 0     # lv.PART_MAIN | lv.STATE_DEFAULT
+    if first_digit >= 0 && first_digit < size(self._digit2part)
+      val = val | self._digit2part[first_digit]
+    else
+      val = nil
+    end
+    if second_digit >= 0 && second_digit < size(self._digit2state)
+      val = val | self._digit2state[second_digit]
+    else
+      val = nil
+    end
+    if val == nil
+      raise "value_error", f"invalid style suffix {digits:02i}"
+    end
+    return val
+  end
+
+  #====================================================================
+  #  Metadata
+  #
+  #====================================================================
+  def set_meta(t)
+    self._meta = t
+  end
+  def get_meta()
+    return self._meta
+  end
+
+  #====================================================================
+  #  Rule based updates of `val` and `text`
+  #
+  # `val_rule`: rule pattern to grab a value, ex: `ESP32#Temperature`
+  # `val_rule_formula`: formula in Berry to transform the value
+  #                     Ex: `val * 10`
+  # `text_rule`: rule pattern to grab a value for text, ex: `ESP32#Temparature`
+  # `text_rule_format`: format used by `format()`
+  #                     Ex: `%.1f °C`
+  #====================================================================
+  def remove_val_rule()
+    if self._val_rule != nil
+      tasmota.remove_rule(self._val_rule, self)
+    end
+  end
+  def set_val_rule(t)
+    # remove previous rule if any
+    self.remove_val_rule()
+
+    self._val_rule = str(t)
+    tasmota.add_rule(self._val_rule, / val -> self.val_rule_matched(val), self)
+  end
+  def get_val_rule()
+    return self._val_rule
+  end
+  # text_rule
+  def remove_text_rule()
+    if self._text_rule != nil
+      tasmota.remove_rule(self._text_rule, self)
+    end
+  end
+  def set_text_rule(t)
+    # remove previous rule if any
+    self.remove_text_rule()
+
+    self._text_rule = str(t)
+    tasmota.add_rule(self._text_rule, / val -> self.text_rule_matched(val), self)
+  end
+  def get_text_rule()
+    return self._text_rule
+  end
+  def set_text_rule_format(t)
+    self._text_rule_format = str(t)
+  end
+  def get_text_rule_format()
+    return self._text_rule_format
+  end
+  # formula that gets compiled as Berry code
+  def set_val_rule_formula(t)
+    self._val_rule_formula = str(t)
+    var code = "return / val -> (" + self._val_rule_formula + ")"
+    try
+      var func = compile(code)
+      self._val_rule_function = func()
+    except .. as e, m
+      print(format("HSP: failed to compile '%s' - %s (%s)", code, e, m))
+    end
+  end
+  def get_val_rule_formula()
+    return self._val_rule_formula
+  end
+  # formula that gets compiled as Berry code
+  def set_text_rule_formula(t)
+    self._text_rule_formula = str(t)
+    var code = "return / val -> (" + self._text_rule_formula + ")"
+    try
+      var func = compile(code)
+      self._text_rule_function = func()
+    except .. as e, m
+      print(format("HSP: failed to compile '%s' - %s (%s)", code, e, m))
+    end
+  end
+  def get_text_rule_formula()
+    return self._text_rule_formula
+  end
+  # rule matched for val
+  def val_rule_matched(val)
+
+    # print(">> rule matched", "val=", val)
+    var val_n = real(val)         # force float type
+    if val_n == nil  return false end   # if the matched value is not a number, ignore
+    var func = self._val_rule_function
+    if func != nil
+      try
+        val_n = func(val_n)
+      except .. as e, m
+        print(format("HSP: failed to run self._val_rule_function - %s (%s)", e, m))
+      end
+    end
+
+    self.val = int(val_n)         # set value, truncate to int
+    return false                  # propagate the event further
+  end
+  # rule matched for text
+  def text_rule_matched(val)
+
+    # print(">> rule matched text", "val=", val)
+    if type(val) == 'int'
+      val = real(val)           # force float type
+    end
+
+    var func = self._text_rule_function
+    if func != nil
+      try
+        val = func(val)
+      except .. as e, m
+        print(format("HSP: failed to run self._text_rule_function - %s (%s)", e, m))
+      end
+    end
+
+    var fmt = self._text_rule_format
+    if type(fmt) == 'string'
+      fmt = format(fmt, val)
+    else
+      fmt = ""
+    end
+
+    self.text = fmt
+    return false                  # propagate the event further
+  end
+end
+
+#################################################################################
+#################################################################################
+# Class `lvh_obj` encapsulating `lv_obj``
+#
+# Provide a mapping for virtual members
+# Stores the associated page and object id
+#
+# Adds specific virtual members used by HASPmota
+#################################################################################
+#################################################################################
+class lvh_obj : lvh_root
+  static var _lv_class = lv.obj     # _lv_class refers to the lvgl class encapsulated, and is overriden by subclasses
+  static var _lv_part2_selector     # selector for secondary part (like knob of arc)
+
+  #====================================================================
+  # Instance variables
+  var _lv_label                             # sub-label if exists
+  var _action                               # value of the HASPmota `action` attribute, shouldn't be called `self.action` since we want to trigger the set/member functions
+
+  #====================================================================
+  # init HASPmota object from its jsonl definition
+  #
+  # arg1: LVGL parent object (used to create a sub-object)
+  # arg2: `jline` JSONL definition of the object from HASPmota template (used in sub-classes)
+  # arg3: (opt) LVGL object if it already exists and was created prior to init()
+  # arg4: HASPmota parent object defined by `parentid`
+  #====================================================================
+  def init(parent, page, jline, obj, parent_lvh)
+    super(self).init(parent, page, jline, obj, parent_lvh)
+  end
+
+  #====================================================================
+  # post-init, to be overriden and used by certain classes
+  #====================================================================
+  def post_init()
+    self.register_event_cb()
+  end
+
+  #####################################################################
+  # General Setters and Getters
+  #####################################################################
 
   #====================================================================
   # Value of the `action` attribute
@@ -476,12 +791,10 @@ class lvh_obj
     self.check_label()
     self._lv_label.set_text(str(t))
   end
-  def set_value_str(t) self.set_text(t) end
   def get_text()
     if self._lv_label == nil return nil end
     return self._lv_label.get_text()
   end
-  def get_value_str() return self.get_text() end
 
   # mode
   def set_mode(t)
@@ -542,56 +855,9 @@ class lvh_obj
   # Arg1: (string) "font_name-font_size", ex: "montserrat-20"
   #====================================================================
   def set_text_font(t)
-    # self.check_label()
-    var font
-    if type(t) == 'int'
-      try
-        font = lv.font_embedded("robotocondensed", t)
-      except ..
-        try
-          font = lv.font_embedded("montserrat", t)
-        except ..
-          return
-        end
-      end
-    elif type(t) == 'string'
-      import string
-      import re
-      # look for 'A:name.font' style font file name
-      var drive_split = string.split(t, ':', 1)
-      var fn_split = string.split(t, '-')
-
-      var name = t
-      var sz = 0
-      var is_ttf = false
-      var is_binary = (size(drive_split) > 1 && size(drive_split[0]))
-
-      if size(fn_split) >= 2
-        sz = int(fn_split[-1])
-        name = fn_split[0..-2].concat('-')    # rebuild the font name
-      end
-      if re.match(".*\\.ttf$", name)
-        # ttf font
-        name = string.split(name, ':')[-1]      # remove A: if any
-        is_ttf = true
-      end
-
-      if is_ttf
-        font = lv.load_freetype_font(name, sz, 0)
-      elif is_binary
-        # font is from disk
-        font = lv.load_font(t)
-      elif sz > 0 && size(name) > 0              # looks good, let's have a try
-        try
-          font = lv.font_embedded(name, sz)
-        except ..
-        end
-      end
-    end
+    var font = self.parse_font(t)
     if font != nil
       self._lv_obj.set_style_text_font(font, 0 #- lv.PART_MAIN | lv.STATE_DEFAULT -#)
-    else
-      print("HSP: Unsupported font:", t)
     end
   end
   def get_text_font()
@@ -703,98 +969,6 @@ class lvh_obj
     if self._lv_part2_selector != nil
       return self._lv_obj.get_style_radius(self._lv_part2_selector | lv.STATE_DEFAULT)
     end
-  end
-
-  #- ------------------------------------------------------------#
-  # `digits_to_style` 
-  # 
-  # Convert a 2 digits style descriptor to LVGL style modifier
-  # See https://www.openhasp.com/0.6.3/design/styling/
-  #
-  #
-  # 00 = main part of the object (i.e. the background)
-  # 10 = the indicator or needle, highlighting the the current value
-  # 20 = the knob which can be used the change the value
-  # 30 = the background of the items/buttons
-  # 40 = the items/buttons
-  # 50 = the selected item
-  # 60 = major ticks of the gauge object
-  # 70 = the text cursor
-  # 80 = the scrollbar
-  # 90 = other special part, not listed above
-  #
-  # LV_PART_MAIN         = 0x000000,   /**< A background like rectangle*/
-  # LV_PART_SCROLLBAR    = 0x010000,   /**< The scrollbar(s)*/
-  # LV_PART_INDICATOR    = 0x020000,   /**< Indicator, e.g. for slider, bar, switch, or the tick box of the checkbox*/
-  # LV_PART_KNOB         = 0x030000,   /**< Like handle to grab to adjust the value*/
-  # LV_PART_SELECTED     = 0x040000,   /**< Indicate the currently selected option or section*/
-  # LV_PART_ITEMS        = 0x050000,   /**< Used if the widget has multiple similar elements (e.g. table cells)*/
-  # LV_PART_CURSOR       = 0x060000,   /**< Mark a specific place e.g. for text area's cursor or on a chart*/
-  # LV_PART_CUSTOM_FIRST = 0x080000,    /**< Extension point for custom widgets*/
-  # LV_PART_ANY          = 0x0F0000,    /**< Special value can be used in some functions to target all parts*/
-  #
-  # 00 = default styling
-  # 01 = styling for toggled state
-  # 02 = styling for pressed, not toggled state
-  # 03 = styling for pressed and toggled state
-  # 04 = styling for disabled not toggled state
-  # 05 = styling for disabled and toggled state
-  #
-  # LV_STATE_DEFAULT     =  0x0000,
-  # LV_STATE_CHECKED     =  0x0001,
-  # LV_STATE_FOCUSED     =  0x0002,
-  # LV_STATE_FOCUS_KEY   =  0x0004,
-  # LV_STATE_EDITED      =  0x0008,
-  # LV_STATE_HOVERED     =  0x0010,
-  # LV_STATE_PRESSED     =  0x0020,
-  # LV_STATE_SCROLLED    =  0x0040,
-  # LV_STATE_DISABLED    =  0x0080,
-
-  # LV_STATE_USER_1      =  0x1000,
-  # LV_STATE_USER_2      =  0x2000,
-  # LV_STATE_USER_3      =  0x4000,
-  # LV_STATE_USER_4      =  0x8000,
-  #
-  #- ------------------------------------------------------------#
-  static var _digit2part = [
-    lv.PART_MAIN,         # 00
-    lv.PART_INDICATOR,    # 10
-    lv.PART_KNOB,         # 20
-    lv.PART_ITEMS,        # 30    TODO
-    lv.PART_ITEMS,        # 40
-    lv.PART_SELECTED,     # 50
-    lv.PART_ITEMS,        # 60
-    lv.PART_CURSOR,       # 70
-    lv.PART_SCROLLBAR,    # 80
-    lv.PART_CUSTOM_FIRST, # 90
-  ]
-  static var _digit2state = [
-    lv.STATE_DEFAULT,                     # 00
-    lv.STATE_CHECKED,                     # 01
-    lv.STATE_PRESSED,                     # 02
-    lv.STATE_CHECKED | lv.STATE_PRESSED,  # 03
-    lv.STATE_DISABLED,                    # 04
-    lv.STATE_DISABLED | lv.STATE_PRESSED, # 05
-  ]
-  def digits_to_style(digits)
-    if digits == nil    return 0    end     # lv.PART_MAIN | lv.STATE_DEFAULT
-    var first_digit = (digits / 10) % 10
-    var second_digit = digits % 10
-    var val = 0     # lv.PART_MAIN | lv.STATE_DEFAULT
-    if first_digit >= 0 && first_digit < size(self._digit2part)
-      val = val | self._digit2part[first_digit]
-    else
-      val = nil
-    end
-    if second_digit >= 0 && second_digit < size(self._digit2state)
-      val = val | self._digit2state[second_digit]
-    else
-      val = nil
-    end
-    if val == nil
-      raise "value_error", f"invalid style suffix {digits:02i}"
-    end
-    return val
   end
 
   #- ------------------------------------------------------------#
@@ -943,137 +1117,6 @@ class lvh_obj
     end
   end
 
-  #====================================================================
-  #  Metadata
-  #
-  #====================================================================
-  def set_meta(t)
-    self._meta = t
-  end
-  def get_meta()
-    return self._meta
-  end
-
-  #====================================================================
-  #  Rule based updates of `val` and `text`
-  #
-  # `val_rule`: rule pattern to grab a value, ex: `ESP32#Temperature`
-  # `val_rule_formula`: formula in Berry to transform the value
-  #                     Ex: `val * 10`
-  # `text_rule`: rule pattern to grab a value for text, ex: `ESP32#Temparature`
-  # `text_rule_format`: format used by `format()`
-  #                     Ex: `%.1f °C`
-  #====================================================================
-  def remove_val_rule()
-    if self._val_rule != nil
-      tasmota.remove_rule(self._val_rule, self)
-    end
-  end
-  def set_val_rule(t)
-    # remove previous rule if any
-    self.remove_val_rule()
-
-    self._val_rule = str(t)
-    tasmota.add_rule(self._val_rule, / val -> self.val_rule_matched(val), self)
-  end
-  def get_val_rule()
-    return self._val_rule
-  end
-  # text_rule
-  def remove_text_rule()
-    if self._text_rule != nil
-      tasmota.remove_rule(self._text_rule, self)
-    end
-  end
-  def set_text_rule(t)
-    # remove previous rule if any
-    self.remove_text_rule()
-
-    self._text_rule = str(t)
-    tasmota.add_rule(self._text_rule, / val -> self.text_rule_matched(val), self)
-  end
-  def get_text_rule()
-    return self._text_rule
-  end
-  def set_text_rule_format(t)
-    self._text_rule_format = str(t)
-  end
-  def get_text_rule_format()
-    return self._text_rule_format
-  end
-  # formula that gets compiled as Berry code
-  def set_val_rule_formula(t)
-    self._val_rule_formula = str(t)
-    var code = "return / val -> (" + self._val_rule_formula + ")"
-    try
-      var func = compile(code)
-      self._val_rule_function = func()
-    except .. as e, m
-      print(format("HSP: failed to compile '%s' - %s (%s)", code, e, m))
-    end
-  end
-  def get_val_rule_formula()
-    return self._val_rule_formula
-  end
-  # formula that gets compiled as Berry code
-  def set_text_rule_formula(t)
-    self._text_rule_formula = str(t)
-    var code = "return / val -> (" + self._text_rule_formula + ")"
-    try
-      var func = compile(code)
-      self._text_rule_function = func()
-    except .. as e, m
-      print(format("HSP: failed to compile '%s' - %s (%s)", code, e, m))
-    end
-  end
-  def get_text_rule_formula()
-    return self._text_rule_formula
-  end
-  # rule matched for val
-  def val_rule_matched(val)
-
-    # print(">> rule matched", "val=", val)
-    var val_n = real(val)         # force float type
-    if val_n == nil  return false end   # if the matched value is not a number, ignore
-    var func = self._val_rule_function
-    if func != nil
-      try
-        val_n = func(val_n)
-      except .. as e, m
-        print(format("HSP: failed to run self._val_rule_function - %s (%s)", e, m))
-      end
-    end
-
-    self.val = int(val_n)         # set value, truncate to int
-    return false                  # propagate the event further
-  end
-  # rule matched for text
-  def text_rule_matched(val)
-
-    # print(">> rule matched text", "val=", val)
-    if type(val) == 'int'
-      val = real(val)           # force float type
-    end
-
-    var func = self._text_rule_function
-    if func != nil
-      try
-        val = func(val)
-      except .. as e, m
-        print(format("HSP: failed to run self._text_rule_function - %s (%s)", e, m))
-      end
-    end
-
-    var fmt = self._text_rule_format
-    if type(fmt) == 'string'
-      fmt = format(fmt, val)
-    else
-      fmt = ""
-    end
-
-    self.text = fmt
-    return false                  # propagate the event further
-  end
 end
 
 #################################################################################
@@ -1361,6 +1404,143 @@ class lvh_bar : lvh_obj
   end
 end
 
+#====================================================================
+#  spangroup
+#====================================================================
+class lvh_spangroup : lvh_obj
+  static _lv_class = lv.spangroup
+  # label do not need a sub-label
+  def post_init()
+    self._lv_obj.set_mode(lv.SPAN_MODE_BREAK)           # use lv.SPAN_MODE_BREAK by default
+    self._lv_obj.refr_mode()
+    super(self).post_init()         # call super -- not needed
+  end
+  # refresh mode
+  def refr_mode()
+    self._lv_obj.refr_mode()
+  end
+end
+
+#====================================================================
+#  span
+#====================================================================
+class lvh_span : lvh_root
+  static _lv_class = nil
+  # label do not need a sub-label
+  var _style                          # style object
+
+  def post_init()
+    self._lv_obj = nil                # default to nil object, whatever it was initialized with
+    # check if it is the parent is a spangroup
+    if isinstance(self._parent_lvh, self._page._oh.lvh_spangroup)
+      # print(">>> GOOD")
+      self._lv_obj = self._parent_lvh._lv_obj.new_span()
+      self._style = self._lv_obj.get_style()
+    end
+    # super(self).post_init()         # call super - not needed for lvh_root
+  end
+
+  #====================================================================
+  def set_text(t)
+    self._lv_obj.set_text(str(t))
+  end
+
+  #====================================================================
+  def set_text_font(t)
+    var font = self.parse_font(t)
+    if font != nil
+      self._style.set_text_font(font)
+      self._parent_lvh.refr_mode()
+    end
+  end
+  
+  #- ------------------------------------------------------------#
+  #  Internal utility functions
+  #
+  #  Mapping of virtual attributes
+  #
+  #- ------------------------------------------------------------#
+  # There are no attributes that can be read from `lv.style``
+  # so we don't need virtual members
+  #- ------------------------------------------------------------#
+  # def member(k)
+  #   import string
+  #   import introspect
+
+  #   do
+  #     var prefix = k[0..3]
+  #     if prefix == "set_" || prefix == "get_" return end    # avoid recursion
+  #   end
+
+  #   # if attribute name is in ignore list, abort
+  #   if self._attr_ignore.find(k) != nil return end
+
+  #   # first check if there is a method named `get_X()`
+  #   var f = introspect.get(self, "get_" + k)
+  #   if type(f) == 'function'
+  #     # print(f">>>: setmember local method set_{k}")
+  #     return f(self)
+  #   end
+
+  #   # finally try any `get_XXX` within the LVGL object
+  #   f = introspect.get(self._style, "get_" + k)
+  #   if type(f) == 'function'                  # found and function, call it
+  #     return f(self._style)
+  #   end
+
+  #   # fallback to exception if attribute unknown or not a function
+  #   return module("undefined")
+  # end
+
+  #- ------------------------------------------------------------#
+  # `setmember` virtual setter
+  # trimmed down version for style only
+  #- ------------------------------------------------------------#
+  def setmember(k, v)
+    import string
+    import introspect
+
+    do
+      # print(">>>: span setmember", k, v)
+      var prefix = k[0..3]
+      if prefix == "set_" || prefix == "get_" return end      # avoid infinite loop
+    end
+
+    # if attribute name is in ignore list, abort
+    if self._attr_ignore.find(k) != nil return end
+
+    # first check if there is a method named `set_X()`
+    var f = introspect.get(self, "set_" + k)
+    if type(f) == 'function'
+      # print(f">>>: setmember local method set_{k}")
+      f(self, v)
+      return
+    end
+
+    # simply check if a method `set_{k}` exists
+    f = introspect.get(self._style, "set_" + k)    # look at style
+    # print(f">>>: span name={'set_' + k} {f=}")
+    if (type(f) == 'function')
+      # if the attribute contains 'color', convert to lv_color
+      if self.is_color_attribute(k)
+        v = self.parse_color(v)
+      end
+      # invoke
+      try
+        f(self._style, v)
+        self._parent_lvh.refr_mode()
+      except .. as e, m
+        raise e, m + " for " + k
+      end
+      return nil
+    else
+      print("HSP: Could not find function set_" + k)
+    end
+
+  end
+
+end
+
 #################################################################################
 # Special case for lv.chart
 # Adapted to getting values one after the other
@@ -1620,6 +1800,8 @@ class HASPmota
   var event_cb                          # the low-level callback for the closure to be registered
 
   # assign lvh_page to a static attribute
+  static lvh_root = lvh_root
+	static lvh_obj = lvh_obj
   static lvh_page = lvh_page
   static lvh_scr = lvh_scr
   # assign all classes as static attributes
@@ -1629,7 +1811,6 @@ class HASPmota
   static lvh_label = lvh_label
  	# static lvh_led = lvh_led
 	static lvh_spinner = lvh_spinner
-	static lvh_obj = lvh_obj
 	static lvh_line = lvh_line
 	static lvh_img = lvh_img
 	static lvh_dropdown = lvh_dropdown
@@ -1645,6 +1826,8 @@ class HASPmota
  	# static lvh_linemeter = lvh_linemeter
  	# static lvh_gauge = lvh_gauge
 	static lvh_textarea = lvh_textarea    # additional?
+  static lvh_spangroup = lvh_spangroup
+  static lvh_span = lvh_span
   static lvh_qrcode = lvh_qrcode
   # special cases
   static lvh_chart = lvh_chart
@@ -2011,8 +2194,9 @@ class HASPmota
       var parent_lvgl
       var parent_id = int(jline.find("parentid"))
 
+      var parent_obj
       if parent_id != nil
-        var parent_obj = lvh_page_cur.get_obj(parent_id)        # get parent object
+        parent_obj = lvh_page_cur.get_obj(parent_id)        # get parent object
         if parent_obj != nil   parent_lvgl = parent_obj._lv_obj end  # parent 
       end
       if parent_lvgl == nil
@@ -2049,7 +2233,7 @@ class HASPmota
       end
       
       # instanciate the object, passing the lvgl screen as parent object
-      obj_lvh = obj_class(parent_lvgl, page, jline, lv_instance)
+      obj_lvh = obj_class(parent_lvgl, page, jline, lv_instance, parent_obj)
 
       # add object to page object
       lvh_page_cur.add_obj(obj_id, obj_lvh)
@@ -2100,6 +2284,56 @@ haspmota.HASPmota = HASPmota
 haspmota.init = def (m)         # `init(m)` is called during first `import haspmota`
   var oh = m.HASPmota
   return oh()
+end
+
+#################################################################################
+# Solidify
+#################################################################################
+def solidify_haspmota()
+  import path 
+  path.remove("haspmota.bec")
+  import solidify
+  import introspect
+
+  var classes = [
+    "root",
+    "page", "obj", "scr",
+    "btn", "switch", "checkbox",
+    "label", "spinner", "line", "img", "roller", "btnmatrix",
+    "bar", "slider", "arc", "textarea", "dropdown",
+    "qrcode", "chart", "spangroup", "span",
+    # new internal names
+    "button", "image", "buttonmatrix",
+  ]
+  var f = open("be_lv_haspmota.c", "w")
+  f.write(
+  '/********************************************************************\n'
+  ' * Tasmota HASPmota solidified\n'
+  ' *******************************************************************/\n'
+  '#include "be_constobj.h"\n'
+  '\n'
+  '#ifdef USE_LVGL\n'
+  '#ifdef USE_LVGL_HASPMOTA\n'
+  '\n'
+  )
+  for c:classes
+    f.write(f'extern const bclass be_class_lv_{c};\n')
+  end
+
+  for c:classes
+    if introspect.contains(haspmota.HASPmota, "lvh_"+c)
+      solidify.dump(haspmota.HASPmota.("lvh_"+c), true, f)
+    end
+  end
+  solidify.dump(haspmota, true, f)
+
+  f.write(
+  '\n'
+  '#endif // USE_LVGL_HASPMOTA\n'
+  '#endif // USE_LVGL\n'
+  )
+  f.close()
+  print("Ok")
 end
 
 global.haspmota = haspmota

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1228,6 +1228,7 @@
     #define BE_LV_WIDGET_SPINBOX
     #define BE_LV_WIDGET_SPINNER
     #define BE_LV_WIDGET_SPANGROUP
+    #define BE_LV_WIDGET_SPAN
     // #define BE_LV_WIDGET_TABVIEW
     // #define BE_LV_WIDGET_TILEVIEW
 


### PR DESCRIPTION
## Description:

Fixed LVGL support for spangroup, and extended HASPmota to support spangroup.

Spangroup is equivalent to HTML `<span>` and allows to have a text area composed of multiple fragments, each fragment with its own style, size, font, color...

![haspmota_spangroup](https://github.com/arendst/Tasmota/assets/49731213/fac014da-8cdb-4f98-88b2-5572015df15f)

The spangroup above was obtained with:
```json
{"id":11,"obj":"spangroup","x":0,"y":60,"w":300,"h":115,"text_font":"montserrat-20","bg_color":"#000088","bg_opa":255}
  {"id":12,"obj":"span","parentid":11,"text":"This is "}
  {"id":13,"obj":"span","parentid":11,"text":"RED","text_color":"#FF0000","text_font":"montserrat-28"}
  {"id":12,"obj":"span","parentid":11,"text":"and this is "}
  {"id":14,"obj":"span","parentid":11,"text":"GREEN","text_color":"#00FF00","text_font":"montserrat-28","text_decor":1}
  {"id":15,"obj":"span","parentid":11,"text":" underlined"}
  {"id":16,"obj":"span","parentid":11,"text":"\nAnd this is almost transparent","text_opa":100}
```

You must first define a `spangroup` object, and add as many as `span` sub-objects. You need to define the `parentid` attribute to the spangroup.

Note: `span` are parsed in the order in the jsonl file, not by id number.

Text from span can be updated via rules, like normal HASPmota text.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
