### PR TITLE
add failsafe for compiled in tls fingerprints

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -101,8 +101,23 @@
 #define MQTT_WIFI_CLIENT_TIMEOUT 200             // [MqttWifiTimeout] Number of milliseconds before Mqtt Wi-Fi timeout
 
 #define MQTT_HOST              ""                // [MqttHost]
+
+// XXX temporary - leave for a few releases so people compiling in
+// fingerprints have a chance to update their configuration files
+#if !defined(USE_MQTT_TLS_DROP_OLD_FINGERPRINT) && defined(MQTT_FINGERPRINT1) || defined(MQTT_FINGERPRINT2)
+#error "The old TLS fingerprint format is being removed.\n\
+Please ensure your TLS fingerprint(s) are using the new version, then add\n\
+\n\
+#define USE_MQTT_TLS_DROP_OLD_FINGERPRINT\n\
+\n\
+to your user_config_override.h file.\n\
+\n\
+An online tool to calculate TLS fingerprints is available here at:\n\
+https://rya.nc/tasmota-fingerprint.html"
+#endif
+
 #define MQTT_FINGERPRINT1      0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00  // [MqttFingerprint1] (auto-learn)
-#define MQTT_FINGERPRINT2      0xDA,0x39,0xA3,0xEE,0x5E,0x6B,0x4B,0x0D,0x32,0x55,0xBF,0xEF,0x95,0x60,0x18,0x90,0xAF,0xD8,0x07,0x09  // [MqttFingerprint2] (invalid)
+#define MQTT_FINGERPRINT2      0xDA,0x39,0xA3,0xEE,0x5E,0x6B,0x4B,0x0D,0x32,0x55,0xBF,0xEF,0x95,0x60,0x18,0x90,0xAF,0xD8,0x07,0x09  // [MqttFingerprint2] (invalid - value from sha1(""))
 #define MQTT_PORT              1883              // [MqttPort] MQTT port (10123 on CloudMQTT)
 #define MQTT_USER              "DVES_USER"       // [MqttUser] MQTT user
 #define MQTT_PASS              "DVES_PASS"       // [MqttPassword] MQTT password


### PR DESCRIPTION
## Description:

As a safety measure, this triggers a compile failure if someone has set a TLS fingerprint in their `user_config_override.h` without having also defined `USE_MQTT_TLS_DROP_OLD_FINGERPRINT`.

This will help prevent people from locking themselves out of being able to do over-the-air updates.

I recommend this code be removed after a couple of releases, along with the fingerprint compatibility code.

Please feel free to change the wording and URL in the compile error.

I have also added a note to explain what the "invalid" fingerprint value is, as magic constants like that may cause concern.

**Related issue (if applicable):** #20842

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
