### PR TITLE
[tuyamcu_v2] Send updates unconditionally

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v2.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v2.ino
@@ -897,7 +897,7 @@ void Tuya_statemachine(int cmd = -1, int len = 0, unsigned char *payload = (unsi
       for (i = 0; i < pTuya->numRxedDPids; i++){
         TUYA_DP_STORE *dp = &pTuya->DPStore[i];
         // if set requested, and MCU has reported at least once
-        if (dp->toSet && dp->rxed){
+        if (dp->toSet) {
           // if value is different
           if ((dp->rxedValueLen != dp->desiredValueLen) || memcmp(dp->rxedValue, dp->desiredValue, dp->desiredValueLen)){
             uint8_t send = 1;


### PR DESCRIPTION
## Description:

Remove the logic that inhibits the sending of updates to the MCU until the DP's state has been observed at least once in a status report from the MCU. This logic was intended to ensure that a DP is not updated with its current value, which reportedly crashes some very broken devices.

However, other devices like the Feit DIM/WIFI dimmers do not reliably report DPs that haven't been changed. So the required status report would never arrive, resulting in the inability to control these devices remotely, at least until their state had been changed by a manual button press, something that is not always practical as it requires physical device access and needs to be done after every restart.

Removing this logic allows Tasmota to control the device state.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
