### PR TITLE
LVGL remove embedded typicons font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking Changed
 - Drop support for old (insecure) fingerprint format (#20842)
+- LVGL remove embedded typicons font
 
 ### Changed
 

--- a/tasmota/lvgl_berry/tasmota_lv_conf.h
+++ b/tasmota/lvgl_berry/tasmota_lv_conf.h
@@ -424,7 +424,7 @@
                                   LV_FONT_DECLARE(robotocondensed_regular_40_latin1) \
                                   LV_FONT_DECLARE(robotocondensed_regular_44_latin1) \
                                   LV_FONT_DECLARE(robotocondensed_regular_48_latin1) \
-                                  LV_FONT_DECLARE(typicons24) \
+                                //   LV_FONT_DECLARE(typicons24) \
 
 #define ROBOTOCONDENSED_REGULAR_12_LATIN1  1
 #define ROBOTOCONDENSED_REGULAR_14_LATIN1  0

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_lvgl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_lvgl.ino
@@ -272,11 +272,11 @@ extern "C" {
     { 0, nullptr}
   };
 
-  // typicons Font
-  const lv_font_table_t lv_typicons_fonts[] = {
-    { 24, &typicons24 },
-    { 0, nullptr}
-  };
+  // // typicons Font
+  // const lv_font_table_t lv_typicons_fonts[] = {
+  //   { 24, &typicons24 },
+  //   { 0, nullptr}
+  // };
 
   // robotocondensed-latin1
   const lv_font_table_t lv_robotocondensed_fonts[] = {
@@ -326,7 +326,7 @@ extern "C" {
   const lv_font_names_t lv_embedded_fonts[] = {
     { "montserrat", lv_montserrat_fonts },
     { "seg7", lv_seg7_fonts },
-    { "typicons", lv_typicons_fonts },
+    // { "typicons", lv_typicons_fonts },
     { "unscii", lv_unscii_fonts},
 #ifdef USE_LVGL_HASPMOTA
     { "robotocondensed", lv_robotocondensed_fonts },


### PR DESCRIPTION
## Description:

LVGL Remove Typicons embedded font, as I realized that we have alread all the needed icons in robotocondensed from OpenHASP.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
