### PR TITLE
Fix warning caused from `ESPFtpServer.cpp`

### DIFF
--- a/lib/lib_div/ESPFtpServer/ESPFtpServer.cpp
+++ b/lib/lib_div/ESPFtpServer/ESPFtpServer.cpp
@@ -25,6 +25,7 @@
 #include <time.h>
 
 #ifdef ESP32
+#undef F
 #define F(A) A
 #endif
 


### PR DESCRIPTION
## Description:

undef the already defined `#define F()` to suppress redefine warning.
Imho there should be in general no redefine done. A different define is already in Arduino core

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
