### PR TITLE
Fix compile for upcoming Arduino Core 2.0.15

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_serial_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_serial_lib.c
@@ -16,7 +16,7 @@ extern int b_serial_read(bvm *vm);
 extern int b_serial_available(bvm *vm);
 extern int b_serial_flush(bvm *vm);
 
-#if ESP_IDF_VERSION_MAJOR < 5
+#if ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(2, 0, 15)
     #include "esp32-hal.h"
 #else
     // it should be #include "HardwareSerial.h"

--- a/lib/libesp32/berry_tasmota/src/be_serial_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_serial_lib.c
@@ -16,7 +16,7 @@ extern int b_serial_read(bvm *vm);
 extern int b_serial_available(bvm *vm);
 extern int b_serial_flush(bvm *vm);
 
-#if ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(2, 0, 15)
+#if (ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(2, 0, 15))
     #include "esp32-hal.h"
 #else
     // it should be #include "HardwareSerial.h"

--- a/lib/libesp32/berry_tasmota/src/be_serial_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_serial_lib.c
@@ -6,7 +6,7 @@
  * 2 wire communication - I2C
  *******************************************************************/
 #include "be_constobj.h"
-#include "esp_idf_version.h"
+#include "esp_arduino_version.h"
 
 extern int b_serial_init(bvm *vm);
 extern int b_serial_deinit(bvm *vm);


### PR DESCRIPTION
## Description:

Upcoming Arduino core 2.0.15 has some backports of core 3.0.0. 
With the PR Tasmota compiles with core 2.0.14, 2.0.15 and core 3.0.0 alpha

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
