### PR TITLE
Berry add `string.startswith`, `string.endswith` and `%q` format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - HASPmota support for spangroup (styled text) (#20852)
 - HASPmota support for led (#20857)
 - HASPmota improve arc and img (#20894)
+- Berry add `string.starstwith`, `string.endswith` and `%q` format
 
 ### Breaking Changed
 - Drop support for old (insecure) fingerprint format (#20842)

--- a/lib/libesp32/berry/tests/string.be
+++ b/lib/libesp32/berry/tests/string.be
@@ -191,7 +191,7 @@ assert(string.startswith("qwerty", "QW", true) == true)
 assert(string.startswith("qwerty", "qz", true) == false)
 assert(string.startswith("qwerty", "qwertyw", true) == false)
 
-# andswith case sensitive
+# endswith case sensitive
 assert(string.endswith("", "") == true)
 assert(string.endswith("qwerty", "ty") == true)
 assert(string.endswith("qwerty", "qwerty") == true)
@@ -201,7 +201,7 @@ assert(string.endswith("qwerty", "TY") == false)
 assert(string.endswith("qwerty", "tr") == false)
 assert(string.endswith("qwerty", "qwertyw") == false)
 
-# andswith case insensitive
+# endswith case insensitive
 assert(string.endswith("", "", true) == true)
 assert(string.endswith("qwerty", "ty", true) == true)
 assert(string.endswith("qwerty", "qwerty", true) == true)

--- a/lib/libesp32/berry/tests/string.be
+++ b/lib/libesp32/berry/tests/string.be
@@ -147,6 +147,8 @@ assert(string.format("%s", nil) == 'nil')
 assert(string.format("%s", true) == 'true')
 assert(string.format("%s", false) == 'false')
 
+assert(string.format("%q", "\ntest") == '\'\\ntest\'')
+
 # format is now synonym to string.format
 assert(format == string.format)
 assert(format("%.1f", 3) == '3.0')
@@ -169,3 +171,42 @@ var a = 'foobar{0}'
 assert(f"S = {a}" == 'S = foobar{0}')
 assert(f"S = {a:i}" == 'S = 0')
 assert(f"{a=}" == 'a=foobar{0}')
+
+# startswith case sensitive
+assert(string.startswith("", "") == true)
+assert(string.startswith("qwerty", "qw") == true)
+assert(string.startswith("qwerty", "qwerty") == true)
+assert(string.startswith("qwerty", "") == true)
+assert(string.startswith("qwerty", "qW") == false)
+assert(string.startswith("qwerty", "QW") == false)
+assert(string.startswith("qwerty", "qz") == false)
+assert(string.startswith("qwerty", "qwertyw") == false)
+
+# startswith case insensitive
+assert(string.startswith("qwerty", "qw", true) == true)
+assert(string.startswith("qwerty", "qwerty", true) == true)
+assert(string.startswith("qwerty", "", true) == true)
+assert(string.startswith("qwerty", "qW", true) == true)
+assert(string.startswith("qwerty", "QW", true) == true)
+assert(string.startswith("qwerty", "qz", true) == false)
+assert(string.startswith("qwerty", "qwertyw", true) == false)
+
+# andswith case sensitive
+assert(string.endswith("", "") == true)
+assert(string.endswith("qwerty", "ty") == true)
+assert(string.endswith("qwerty", "qwerty") == true)
+assert(string.endswith("qwerty", "") == true)
+assert(string.endswith("qwerty", "tY") == false)
+assert(string.endswith("qwerty", "TY") == false)
+assert(string.endswith("qwerty", "tr") == false)
+assert(string.endswith("qwerty", "qwertyw") == false)
+
+# andswith case insensitive
+assert(string.endswith("", "", true) == true)
+assert(string.endswith("qwerty", "ty", true) == true)
+assert(string.endswith("qwerty", "qwerty", true) == true)
+assert(string.endswith("qwerty", "", true) == true)
+assert(string.endswith("qwerty", "tY", true) == true)
+assert(string.endswith("qwerty", "TY", true) == true)
+assert(string.endswith("qwerty", "tr", true) == false)
+assert(string.endswith("qwerty", "qwertyw", true) == false)


### PR DESCRIPTION
## Description:

Sync with upstream Berry:
- https://github.com/berry-lang/berry/pull/406:
  - `string.startswith(hay:string, needle:string [, case_insensitive:bool]) -> bool`
  - `string.endswith(hay:string, needle:string [, case_insensitive:bool]) -> bool`
  - These new methods are lightweight, allow for case sensitive or case insensitive matches, and don't need to allocate any temporary object.
- https://github.com/berry-lang/berry/pull/382:
  - add support for `%q` format
  - `print(string.format("%q","\ntest"))` --> `'\ntest'`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
