### PR TITLE
LVGL add `lv.draw_label_dsc` and `lv_bar.get_indic_area`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - HASPmota support for led (#20857)
 - HASPmota improve arc and img (#20894)
 - Berry add `string.startswith`, `string.endswith` and `%q` format
+- LVGL add `lv.draw_label_dsc` and `lv_bar.get_indic_area`
 
 ### Breaking Changed
 - Drop support for old (insecure) fingerprint format (#20842)

--- a/lib/libesp32_lvgl/lv_binding_berry/generate/LVGL_API_Reference.md
+++ b/lib/libesp32_lvgl/lv_binding_berry/generate/LVGL_API_Reference.md
@@ -132,6 +132,8 @@ style_prop_get_default|int|int|[lv_style_prop_get_default](https://docs.lvgl.io/
 style_prop_has_flag|int, int|bool|[lv_style_prop_has_flag](https://docs.lvgl.io/9.0/search.html?q=lv_style_prop_has_flag)
 style_register_prop|int|int|[lv_style_register_prop](https://docs.lvgl.io/9.0/search.html?q=lv_style_register_prop)
 task_handler||int|[lv_task_handler](https://docs.lvgl.io/9.0/search.html?q=lv_task_handler)
+text_get_size|comptr, string, lv.font, int, int, int, int||[lv_text_get_size](https://docs.lvgl.io/9.0/search.html?q=lv_text_get_size)
+text_get_width|string, int, lv.font, int|int|[lv_text_get_width](https://docs.lvgl.io/9.0/search.html?q=lv_text_get_width)
 theme_apply|lv.obj||[lv_theme_apply](https://docs.lvgl.io/9.0/search.html?q=lv_theme_apply)
 theme_get_color_primary|lv.obj|lv.color|[lv_theme_get_color_primary](https://docs.lvgl.io/9.0/search.html?q=lv_theme_get_color_primary)
 theme_get_color_secondary|lv.obj|lv.color|[lv_theme_get_color_secondary](https://docs.lvgl.io/9.0/search.html?q=lv_theme_get_color_secondary)
@@ -1017,6 +1019,7 @@ set_value|int||[lv_arc_set_value](https://docs.lvgl.io/9.0/search.html?q=lv_arc_
 
 Method|Arguments|Return type|LVGL equivalent
 :---|:---|:---|:---
+get_indic_area||lv.area|[lv_bar_get_indic_area](https://docs.lvgl.io/9.0/search.html?q=lv_bar_get_indic_area)
 get_max_value||int|[lv_bar_get_max_value](https://docs.lvgl.io/9.0/search.html?q=lv_bar_get_max_value)
 get_min_value||int|[lv_bar_get_min_value](https://docs.lvgl.io/9.0/search.html?q=lv_bar_get_min_value)
 get_mode||int|[lv_bar_get_mode](https://docs.lvgl.io/9.0/search.html?q=lv_bar_get_mode)

--- a/lib/libesp32_lvgl/lv_binding_berry/generate/be_lv_c_mapping.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/generate/be_lv_c_mapping.h
@@ -839,6 +839,7 @@ const be_ntv_func_def_t lv_arc_func[] = {
 /* `lv_bar` methods */
 #ifdef BE_LV_WIDGET_BAR
 const be_ntv_func_def_t lv_bar_func[] = {
+  { "get_indic_area", { (const void*) &lv_bar_get_indic_area, "lv.area", "(lv.obj)" } },
   { "get_max_value", { (const void*) &lv_bar_get_max_value, "i", "(lv.obj)" } },
   { "get_min_value", { (const void*) &lv_bar_get_min_value, "i", "(lv.obj)" } },
   { "get_mode", { (const void*) &lv_bar_get_mode, "i", "(lv.obj)" } },

--- a/lib/libesp32_lvgl/lv_binding_berry/generate/be_lvgl_module.c
+++ b/lib/libesp32_lvgl/lv_binding_berry/generate/be_lvgl_module.c
@@ -154,6 +154,8 @@ const be_ntv_func_def_t lv_func[] = {
   { "style_prop_has_flag", { (const void*) &lv_style_prop_has_flag, "b", "ii" } },
   { "style_register_prop", { (const void*) &lv_style_register_prop, "i", "i" } },
   { "task_handler", { (const void*) &lv_task_handler, "i", "" } },
+  { "text_get_size", { (const void*) &lv_text_get_size, "", "cs(lv.font)iiii" } },
+  { "text_get_width", { (const void*) &lv_text_get_width, "i", "si(lv.font)i" } },
   { "theme_apply", { (const void*) &lv_theme_apply, "", "(lv.obj)" } },
   { "theme_get_color_primary", { (const void*) &lv_theme_get_color_primary, "lv.color", "(lv.obj)" } },
   { "theme_get_color_secondary", { (const void*) &lv_theme_get_color_secondary, "lv.color", "(lv.obj)" } },

--- a/lib/libesp32_lvgl/lv_binding_berry/generate/be_lvgl_widgets_lib.c
+++ b/lib/libesp32_lvgl/lv_binding_berry/generate/be_lvgl_widgets_lib.c
@@ -850,6 +850,7 @@ extern int lvbe_arc_set_value(bvm *vm);
 
 /* `lv_bar` external functions definitions */
 extern int lvbe_bar_create(bvm *vm);
+extern int lvbe_bar_get_indic_area(bvm *vm);
 extern int lvbe_bar_get_max_value(bvm *vm);
 extern int lvbe_bar_get_min_value(bvm *vm);
 extern int lvbe_bar_get_mode(bvm *vm);

--- a/lib/libesp32_lvgl/lv_binding_berry/mapping/lv_funcs.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/mapping/lv_funcs.h
@@ -964,6 +964,19 @@ void lv_style_set_grid_cell_row_pos(lv_style_t * style, int32_t value)
 void lv_style_set_grid_cell_y_align(lv_style_t * style, lv_grid_align_t value)
 void lv_style_set_grid_cell_row_span(lv_style_t * style, int32_t value)
 
+// ../../lvgl/src/misc/lv_text.h
+void lv_text_get_size(lv_point_t * size_res, const char * text, const lv_font_t * font, int32_t letter_space, int32_t line_space, int32_t max_width, lv_text_flag_t flag)
+int32_t lv_text_get_width(const char * txt, uint32_t length, const lv_font_t * font, int32_t letter_space)
+char * _lv_text_set_text_vfmt(const char * fmt, va_list ap) LV_FORMAT_ATTRIBUTE(1, 0)
+uint8_t (*_lv_text_encoded_size)(const char *)
+uint32_t (*_lv_text_unicode_to_encoded)(uint32_t)
+uint32_t (*_lv_text_encoded_conv_wc)(uint32_t c)
+uint32_t (*_lv_text_encoded_next)(const char *, uint32_t *)
+uint32_t (*_lv_text_encoded_prev)(const char *, uint32_t *)
+uint32_t (*_lv_text_encoded_get_byte_id)(const char *, uint32_t)
+uint32_t (*_lv_text_encoded_get_char_id)(const char *, uint32_t)
+uint32_t (*_lv_text_get_encoded_length)(const char *)
+
 // ../../lvgl/src/misc/lv_timer.h
 uint32_t lv_timer_handler(void)
 static inline uint32_t lv_timer_handler_run_in_period(uint32_t period)
@@ -1475,4 +1488,5 @@ bool lv_theme_haspmota_is_inited(void)
 void be_load_lvgl_classes(bvm *vm)
 void lv_image_set_tasmota_logo(lv_obj_t * img)
 lv_style_t * lv_span_get_style(lv_span_t * span)
+lv_area_t * lv_bar_get_indic_area(lv_obj_t * bar)
 

--- a/lib/libesp32_lvgl/lv_binding_berry/src/be_lvgl_ctypes_definitions.c
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/be_lvgl_ctypes_definitions.c
@@ -227,6 +227,39 @@ const be_ctypes_structure_t be_lv_draw_image_dsc = {
     { "tile", 77, 5, 1, ctypes_bf, 0 },
 }};
 
+const be_ctypes_structure_t be_lv_draw_label_dsc = {
+  84,  /* size in bytes */
+  26,  /* number of elements */
+  be_ctypes_instance_mappings,
+  (const be_ctypes_structure_item_t[26]) {
+    { "align", 74, 0, 0, ctypes_u8, 0 },
+    { "base_dsc_size", 20, 0, 0, ctypes_u32, 0 },
+    { "base_id1", 8, 0, 0, ctypes_u32, 0 },
+    { "base_id2", 12, 0, 0, ctypes_u32, 0 },
+    { "base_layer", 16, 0, 0, ctypes_ptr32, 0 },
+    { "base_obj", 0, 0, 0, ctypes_ptr32, 0 },
+    { "base_part", 4, 0, 0, ctypes_u32, 0 },
+    { "base_user_data", 24, 0, 0, ctypes_ptr32, 0 },
+    { "bidi_dir", 73, 0, 0, ctypes_u8, 0 },
+    { "blend_mode", 76, 3, 3, ctypes_bf, 0 },
+    { "color", 44, 0, 0, ctypes_u24, 1 },
+    { "decor", 76, 0, 3, ctypes_bf, 0 },
+    { "flag", 75, 0, 0, ctypes_u8, 0 },
+    { "font", 32, 0, 0, ctypes_ptr32, 0 },
+    { "hint", 80, 0, 0, ctypes_ptr32, 0 },
+    { "letter_space", 60, 0, 0, ctypes_i32, 0 },
+    { "line_space", 56, 0, 0, ctypes_i32, 0 },
+    { "ofs_x", 64, 0, 0, ctypes_i32, 0 },
+    { "ofs_y", 68, 0, 0, ctypes_i32, 0 },
+    { "opa", 72, 0, 0, ctypes_u8, 0 },
+    { "sel_bg_color", 52, 0, 0, ctypes_u24, 1 },
+    { "sel_color", 48, 0, 0, ctypes_u24, 1 },
+    { "sel_end", 40, 0, 0, ctypes_u32, 0 },
+    { "sel_start", 36, 0, 0, ctypes_u32, 0 },
+    { "text", 28, 0, 0, ctypes_ptr32, 0 },
+    { "text_local", 76, 6, 1, ctypes_bf, 0 },
+}};
+
 const be_ctypes_structure_t be_lv_meter_scale = {
   40,  /* size in bytes */
   14,  /* number of elements */
@@ -403,6 +436,7 @@ static be_define_ctypes_class(lv_color_filter_dsc, &be_lv_color_filter_dsc, &be_
 static be_define_ctypes_class(lv_draw_arc_dsc, &be_lv_draw_arc_dsc, &be_class_ctypes_bytes, "lv_draw_arc_dsc");
 static be_define_ctypes_class(lv_draw_dsc_base, &be_lv_draw_dsc_base, &be_class_ctypes_bytes, "lv_draw_dsc_base");
 static be_define_ctypes_class(lv_draw_image_dsc, &be_lv_draw_image_dsc, &be_class_ctypes_bytes, "lv_draw_image_dsc");
+static be_define_ctypes_class(lv_draw_label_dsc, &be_lv_draw_label_dsc, &be_class_ctypes_bytes, "lv_draw_label_dsc");
 static be_define_ctypes_class(lv_draw_line_dsc, &be_lv_draw_line_dsc, &be_class_ctypes_bytes, "lv_draw_line_dsc");
 static be_define_ctypes_class(lv_draw_rect_dsc, &be_lv_draw_rect_dsc, &be_class_ctypes_bytes, "lv_draw_rect_dsc");
 static be_define_ctypes_class(lv_event, &be_lv_event, &be_class_ctypes_bytes, "lv_event");
@@ -427,6 +461,7 @@ void be_load_ctypes_lvgl_definitions_lib(bvm *vm) {
   ctypes_register_class(vm, &be_class_lv_draw_arc_dsc);
   ctypes_register_class(vm, &be_class_lv_draw_dsc_base);
   ctypes_register_class(vm, &be_class_lv_draw_image_dsc);
+  ctypes_register_class(vm, &be_class_lv_draw_label_dsc);
   ctypes_register_class(vm, &be_class_lv_draw_line_dsc);
   ctypes_register_class(vm, &be_class_lv_draw_rect_dsc);
   ctypes_register_class(vm, &be_class_lv_event);
@@ -452,6 +487,7 @@ be_ctypes_class_by_name_t be_ctypes_lvgl_classes[] = {
   { "lv_draw_arc_dsc", &be_class_lv_draw_arc_dsc },
   { "lv_draw_dsc_base", &be_class_lv_draw_dsc_base },
   { "lv_draw_image_dsc", &be_class_lv_draw_image_dsc },
+  { "lv_draw_label_dsc", &be_class_lv_draw_label_dsc },
   { "lv_draw_line_dsc", &be_class_lv_draw_line_dsc },
   { "lv_draw_rect_dsc", &be_class_lv_draw_rect_dsc },
   { "lv_event", &be_class_lv_event },

--- a/lib/libesp32_lvgl/lv_binding_berry/src/embedded/lvgl_ctypes.py
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/embedded/lvgl_ctypes.py
@@ -24,6 +24,9 @@ lv_opa = ct.u8
 lv_blend_mode = ct.u8
 lv_align = ct.u8
 lv_bidi_dir = ct.u8
+lv_base_dir = ct.u8
+lv_text_align = ct.u8
+lv_text_flag = ct.u8
 lv_txt_flag = ct.u8
 lv_text_decor = ct.u8
 lv_font = ct.u32
@@ -331,6 +334,55 @@ lv_draw_image_dsc = [            # valid LVGL9
     [ptr, "sup"],
 ]
 lv_draw_image_dsc = ct.structure(lv_draw_image_dsc, "lv_draw_image_dsc")
+
+# typedef struct {
+#     lv_draw_dsc_base_t base;
+#     const char * text;
+#     const lv_font_t * font;
+#     uint32_t sel_start;
+#     uint32_t sel_end;
+#     lv_color_t color;
+#     lv_color_t sel_color;
+#     lv_color_t sel_bg_color;
+#     int32_t line_space;
+#     int32_t letter_space;
+#     int32_t ofs_x;
+#     int32_t ofs_y;
+#     lv_opa_t opa;
+#     lv_base_dir_t bidi_dir;
+#     lv_text_align_t align;
+#     lv_text_flag_t flag;
+#     lv_text_decor_t decor : 3;
+#     lv_blend_mode_t blend_mode : 3;
+#     /**
+#      * < 1: malloc buffer and copy `text` there.
+#      * 0: `text` is const and it's pointer will be valid during rendering.*/
+#     uint8_t text_local : 1;
+#     lv_draw_label_hint_t * hint;
+# } lv_draw_label_dsc_t;
+lv_draw_label_dsc = [            # valid LVGL9
+    [lv_draw_dsc_base, "base"],
+    [ptr, "text"],
+    [ptr, "font"],
+    [uint32_t, "sel_start"],
+    [uint32_t, "sel_end"],
+    [lv_color, "color"],
+    [lv_color, "sel_color"],
+    [lv_color, "sel_bg_color"],
+    [int32_t, "line_space"],
+    [int32_t, "letter_space"],
+    [int32_t, "ofs_x"],
+    [int32_t, "ofs_y"],
+    [lv_opa, "opa"],
+    [lv_base_dir, "bidi_dir"],
+    [lv_text_align, "align"],
+    [lv_text_flag, "flag"],
+    [uint8_t_3, "decor"],
+    [uint8_t_3, "blend_mode"],
+    [uint8_t_1, "text_local"],
+    [ptr, "hint"],
+]
+lv_draw_label_dsc = ct.structure(lv_draw_label_dsc, "lv_draw_label_dsc")
 
 # lv_obj_draw_part_dsc = [            # valid LVGL8.3
 #     [ptr, "draw_ctx"],

--- a/lib/libesp32_lvgl/lv_binding_berry/src/lv_berry.c
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/lv_berry.c
@@ -379,5 +379,8 @@ int lv0_constants_as_hash(bvm *vm) {
  * temporarily fix lv_span_get_style()
 \*********************************************************************************************/
 lv_style_t * lv_span_get_style(lv_span_t * span) {
-      return &span->style;
+  return &span->style;
+}
+lv_area_t * lv_bar_get_indic_area(lv_obj_t * bar) {
+  return &((lv_bar_t*)bar)->indic_area;
 }

--- a/lib/libesp32_lvgl/lv_binding_berry/src/lv_berry.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/lv_berry.h
@@ -28,6 +28,9 @@ extern lv_ts_calibration_t lv_ts_calibration;
 // temporarily fix lv_span_get_style()
 extern lv_style_t * lv_span_get_style(lv_span_t * span);
 
+// add accessor for lv_bar->indic_area
+extern lv_area_t * lv_bar_get_indic_area(lv_obj_t * bar);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/libesp32_lvgl/lv_binding_berry/tools/convert.py
+++ b/lib/libesp32_lvgl/lv_binding_berry/tools/convert.py
@@ -250,6 +250,7 @@ class type_mapper_class:
     "lv_vector_dsc_t",            # see later if we need this
     "lv_point_precise_t",         # see later if we need this
     "void **",                    # edge case of lv_animimg_get_src()
+    "va_list",
     "lv_matrix_t *",
     "lv_event_list_t *",
     "lv_style_value_t *",
@@ -338,6 +339,7 @@ class type_mapper_class:
     "lv_style_res_t": "i",
     # LVGL 9
     "lv_image_align_t": "i",
+    "lv_text_flag_t": "i",
     "lv_display_rotation_t": "i",
     "lv_color_format_t": "i",
     "lv_value_precise_t": "i",

--- a/lib/libesp32_lvgl/lv_binding_berry/tools/preprocessor.py
+++ b/lib/libesp32_lvgl/lv_binding_berry/tools/preprocessor.py
@@ -75,6 +75,7 @@ lv_fun_globs = [
                   "misc/lv_style_gen.h",
                   "misc/lv_style.h",
                   "misc/lv_timer.h",
+                  "misc/lv_text.h",
                   "font/lv_font.h",
                   # add version information
                   "../lvgl.h",


### PR DESCRIPTION
## Description:

Add missing definition to make the example https://docs.lvgl.io/master/examples.html#custom-drawer-to-show-the-current-value work.

Here is the code:
```berry
#https://docs.lvgl.io/master/examples.html#custom-drawer-to-show-the-current-value
#- start LVGL and init environment -#
lv.start()

hres = lv.get_hor_res()       # should be 320
vres = lv.get_ver_res()       # should be 240

scr = lv.scr_act()            # default screan object
f20 = lv.montserrat_font(20)  # load embedded Montserrat 20

bar = lv.bar(scr)
bar.set_size(200,20)
bar.center()

def bar_event(obj, event)
  import introspect
  print(f"{obj=} {event=} {event.get_code()=} {event.get_layer()=}")
  var label_dsc = lv.draw_label_dsc()
  lv.draw_label_dsc_init(label_dsc)
  label_dsc.font = f20._p

  var buf = str(obj.get_value())
  var txt_size = lv.point()
  lv.text_get_size(txt_size, buf, f20, label_dsc.letter_space, label_dsc.line_space, lv.COORD_MAX, label_dsc.flag)

  var txt_area = lv.area()
  txt_area.x1 = 0
  txt_area.x2 = txt_size.x - 1
  txt_area.y1 = 0
  txt_area.y2 = txt_size.y - 1

  label_dsc.text = introspect.toptr(buf)
  label_dsc.text_local = true

  var indic_area = obj.get_indic_area()
  if (lv.area_get_width(indic_area) > txt_size.x + 20)
    lv.area_align(indic_area, txt_area, lv.ALIGN_RIGHT_MID, -10, 0)
    label_dsc.color = lv.COLOR_WHITE
  else
    lv.area_align(indic_area, txt_area, lv.ALIGN_OUT_RIGHT_MID, 10, 0)
    label_dsc.color = lv.COLOR_WHITE
  end

  var layer = event.get_layer()
  lv.draw_label(layer, label_dsc, txt_area)

end

bar.add_event_cb(bar_event, lv.EVENT_DRAW_MAIN_END, 0)

bar.set_value(20, lv.ANIM_OFF)
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
