### PR TITLE
LVGL fix descriptors Berry mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -993,6 +993,7 @@ All notable changes to this project will be documented in this file.
 - DNS lookup for .local domains (#16273)
 - Button response delay regression from v12.0.2.4 (#16319)
 - Lost module name in GUI regression from v12.0.2.4 - 20220803 (#16324)
+- LVGL fix descriptors Berry mapping
 
 ## [12.1.0.1] 20220825
 ### Added

--- a/lib/libesp32_lvgl/lv_binding_berry/src/be_lvgl_ctypes_definitions.c
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/be_lvgl_ctypes_definitions.c
@@ -52,18 +52,18 @@ const be_ctypes_structure_t be_lv_gradient_stop = {
 }};
 
 const be_ctypes_structure_t be_lv_grad_dsc = {
-  16,  /* size in bytes */
+  12,  /* size in bytes */
   8,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[8]) {
-    { "dir", 14, 0, 3, ctypes_bf, 0 },
+    { "dir", 11, 0, 3, ctypes_bf, 0 },
     { "stops_0_color", 0, 0, 0, ctypes_u24, 1 },
     { "stops_0_frac", 4, 0, 0, ctypes_u8, 0 },
     { "stops_0_opa", 3, 0, 0, ctypes_u8, 0 },
-    { "stops_1_color", 8, 0, 0, ctypes_u24, 1 },
-    { "stops_1_frac", 12, 0, 0, ctypes_u8, 0 },
-    { "stops_1_opa", 11, 0, 0, ctypes_u8, 0 },
-    { "stops_count", 13, 0, 0, ctypes_u8, 0 },
+    { "stops_1_color", 5, 0, 0, ctypes_u24, 1 },
+    { "stops_1_frac", 9, 0, 0, ctypes_u8, 0 },
+    { "stops_1_opa", 8, 0, 0, ctypes_u8, 0 },
+    { "stops_count", 10, 0, 0, ctypes_u8, 0 },
 }};
 
 const be_ctypes_structure_t be_lv_draw_dsc_base = {
@@ -81,7 +81,7 @@ const be_ctypes_structure_t be_lv_draw_dsc_base = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_rect_dsc = {
-  124,  /* size in bytes */
+  112,  /* size in bytes */
   39,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[39]) {
@@ -92,38 +92,38 @@ const be_ctypes_structure_t be_lv_draw_rect_dsc = {
     { "base_obj", 0, 0, 0, ctypes_ptr32, 0 },
     { "base_part", 4, 0, 0, ctypes_u32, 0 },
     { "base_user_data", 24, 0, 0, ctypes_ptr32, 0 },
-    { "bg_color", 36, 0, 0, ctypes_u24, 1 },
-    { "bg_grad_dir", 54, 0, 3, ctypes_bf, 0 },
-    { "bg_grad_stops_0_color", 40, 0, 0, ctypes_u24, 1 },
-    { "bg_grad_stops_0_frac", 44, 0, 0, ctypes_u8, 0 },
-    { "bg_grad_stops_0_opa", 43, 0, 0, ctypes_u8, 0 },
-    { "bg_grad_stops_1_color", 48, 0, 0, ctypes_u24, 1 },
-    { "bg_grad_stops_1_frac", 52, 0, 0, ctypes_u8, 0 },
-    { "bg_grad_stops_1_opa", 51, 0, 0, ctypes_u8, 0 },
-    { "bg_grad_stops_count", 53, 0, 0, ctypes_u8, 0 },
-    { "bg_img_opa", 67, 0, 0, ctypes_u8, 0 },
-    { "bg_img_recolor", 64, 0, 0, ctypes_u24, 1 },
-    { "bg_img_recolor_opa", 68, 0, 0, ctypes_u8, 0 },
-    { "bg_img_src", 56, 0, 0, ctypes_ptr32, 0 },
-    { "bg_img_symbol_font", 60, 0, 0, ctypes_ptr32, 0 },
-    { "bg_img_tiled", 69, 0, 0, ctypes_u8, 0 },
+    { "bg_color", 33, 0, 0, ctypes_u24, 1 },
+    { "bg_grad_dir", 47, 0, 3, ctypes_bf, 0 },
+    { "bg_grad_stops_0_color", 36, 0, 0, ctypes_u24, 1 },
+    { "bg_grad_stops_0_frac", 40, 0, 0, ctypes_u8, 0 },
+    { "bg_grad_stops_0_opa", 39, 0, 0, ctypes_u8, 0 },
+    { "bg_grad_stops_1_color", 41, 0, 0, ctypes_u24, 1 },
+    { "bg_grad_stops_1_frac", 45, 0, 0, ctypes_u8, 0 },
+    { "bg_grad_stops_1_opa", 44, 0, 0, ctypes_u8, 0 },
+    { "bg_grad_stops_count", 46, 0, 0, ctypes_u8, 0 },
+    { "bg_img_opa", 59, 0, 0, ctypes_u8, 0 },
+    { "bg_img_recolor", 56, 0, 0, ctypes_u24, 1 },
+    { "bg_img_recolor_opa", 60, 0, 0, ctypes_u8, 0 },
+    { "bg_img_src", 48, 0, 0, ctypes_ptr32, 0 },
+    { "bg_img_symbol_font", 52, 0, 0, ctypes_ptr32, 0 },
+    { "bg_img_tiled", 61, 0, 0, ctypes_u8, 0 },
     { "bg_opa", 32, 0, 0, ctypes_u8, 0 },
-    { "border_color", 72, 0, 0, ctypes_u24, 1 },
-    { "border_opa", 80, 0, 0, ctypes_u8, 0 },
-    { "border_post", 81, 0, 1, ctypes_bf, 0 },
-    { "border_side", 81, 1, 5, ctypes_bf, 0 },
-    { "border_width", 76, 0, 0, ctypes_i32, 0 },
-    { "outline_color", 84, 0, 0, ctypes_u24, 1 },
-    { "outline_opa", 96, 0, 0, ctypes_u8, 0 },
-    { "outline_pad", 92, 0, 0, ctypes_i32, 0 },
-    { "outline_width", 88, 0, 0, ctypes_i32, 0 },
+    { "border_color", 62, 0, 0, ctypes_u24, 1 },
+    { "border_opa", 72, 0, 0, ctypes_u8, 0 },
+    { "border_post", 73, 0, 1, ctypes_bf, 0 },
+    { "border_side", 73, 1, 5, ctypes_bf, 0 },
+    { "border_width", 68, 0, 0, ctypes_i32, 0 },
+    { "outline_color", 74, 0, 0, ctypes_u24, 1 },
+    { "outline_opa", 88, 0, 0, ctypes_u8, 0 },
+    { "outline_pad", 84, 0, 0, ctypes_i32, 0 },
+    { "outline_width", 80, 0, 0, ctypes_i32, 0 },
     { "radius", 28, 0, 0, ctypes_i32, 0 },
-    { "shadow_color", 100, 0, 0, ctypes_u24, 1 },
-    { "shadow_ofs_x", 108, 0, 0, ctypes_i32, 0 },
-    { "shadow_ofs_y", 112, 0, 0, ctypes_i32, 0 },
-    { "shadow_opa", 120, 0, 0, ctypes_u8, 0 },
-    { "shadow_spread", 116, 0, 0, ctypes_i32, 0 },
-    { "shadow_width", 104, 0, 0, ctypes_i32, 0 },
+    { "shadow_color", 89, 0, 0, ctypes_u24, 1 },
+    { "shadow_ofs_x", 96, 0, 0, ctypes_i32, 0 },
+    { "shadow_ofs_y", 100, 0, 0, ctypes_i32, 0 },
+    { "shadow_opa", 108, 0, 0, ctypes_u8, 0 },
+    { "shadow_spread", 104, 0, 0, ctypes_i32, 0 },
+    { "shadow_width", 92, 0, 0, ctypes_i32, 0 },
 }};
 
 const be_ctypes_structure_t be_lv_draw_line_dsc = {
@@ -252,8 +252,8 @@ const be_ctypes_structure_t be_lv_draw_label_dsc = {
     { "ofs_x", 64, 0, 0, ctypes_i32, 0 },
     { "ofs_y", 68, 0, 0, ctypes_i32, 0 },
     { "opa", 72, 0, 0, ctypes_u8, 0 },
-    { "sel_bg_color", 52, 0, 0, ctypes_u24, 1 },
-    { "sel_color", 48, 0, 0, ctypes_u24, 1 },
+    { "sel_bg_color", 50, 0, 0, ctypes_u24, 1 },
+    { "sel_color", 47, 0, 0, ctypes_u24, 1 },
     { "sel_end", 40, 0, 0, ctypes_u32, 0 },
     { "sel_start", 36, 0, 0, ctypes_u32, 0 },
     { "text", 28, 0, 0, ctypes_ptr32, 0 },
@@ -266,7 +266,7 @@ const be_ctypes_structure_t be_lv_meter_scale = {
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[14]) {
     { "angle_range", 34, 0, 0, ctypes_u16, 0 },
-    { "label_gap", 22, 0, 0, ctypes_i16, 0 },
+    { "label_gap", 20, 0, 0, ctypes_i16, 0 },
     { "max", 28, 0, 0, ctypes_i32, 0 },
     { "min", 24, 0, 0, ctypes_i32, 0 },
     { "r_mod", 32, 0, 0, ctypes_i16, 0 },
@@ -274,10 +274,10 @@ const be_ctypes_structure_t be_lv_meter_scale = {
     { "tick_cnt", 4, 0, 0, ctypes_u16, 0 },
     { "tick_color", 0, 0, 0, ctypes_u24, 1 },
     { "tick_length", 6, 0, 0, ctypes_u16, 0 },
-    { "tick_major_color", 12, 0, 0, ctypes_u24, 1 },
-    { "tick_major_length", 18, 0, 0, ctypes_u16, 0 },
-    { "tick_major_nth", 16, 0, 0, ctypes_u16, 0 },
-    { "tick_major_width", 20, 0, 0, ctypes_u16, 0 },
+    { "tick_major_color", 10, 0, 0, ctypes_u24, 1 },
+    { "tick_major_length", 16, 0, 0, ctypes_u16, 0 },
+    { "tick_major_nth", 14, 0, 0, ctypes_u16, 0 },
+    { "tick_major_width", 18, 0, 0, ctypes_u16, 0 },
     { "tick_width", 8, 0, 0, ctypes_u16, 0 },
 }};
 

--- a/lib/libesp32_lvgl/lv_binding_berry/src/embedded/berry_ctypes.py
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/embedded/berry_ctypes.py
@@ -310,7 +310,7 @@ class structure:
 
   #- ensure alignment to 1/2/4 bytes -#
   def align(self, n):
-    if n == 3:  n = 4           # 3 bytes are aligned to 4 byest boundaries
+    if n == 3:  n = 1           # 3 bytes are aligned to 4 byest boundaries
     if n != 1 and n != 2 and n != 4:
       raise Exception(f"acceptable values are 1/2/3/4 {n=}")
 

--- a/lib/libesp32_lvgl/lv_binding_berry/src/embedded/lvgl_ctypes.py
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/embedded/lvgl_ctypes.py
@@ -96,8 +96,16 @@ lv_gradient_stop = ct.structure(lv_gradient_stop, "lv_gradient_stop")
 #                                                         * Any of LV_GRAD_DIR_HOR, LV_GRAD_DIR_VER, LV_GRAD_DIR_NONE */
 # } lv_grad_dsc_t;
 lv_grad_dsc = [            # valid LVGL9
-    [lv_gradient_stop, "stops_0"],
-    [lv_gradient_stop, "stops_1"],
+    # since it's an array and not two structures, we need to explicitly unroll it here or the alignment is wrong
+    # [lv_gradient_stop, "stops_0"],
+    [lv_color, "stops_0_color"],
+    [lv_opa, "stops_0_opa"],
+    [uint8_t, "stops_0_frac"],
+    # [lv_gradient_stop, "stops_1"],
+    [lv_color, "stops_1_color"],
+    [lv_opa, "stops_1_opa"],
+    [uint8_t, "stops_1_frac"],
+    
     [uint8_t, "stops_count"],
     [uint8_t_3, "dir"],
 ]


### PR DESCRIPTION
## Description:

Fix bogus Berry mapped structures for draw descriptors. LVGL 9 introduces 3-byte structures, and the alignment logic was not aligned with `C`.

Now the following code works fine (from @[1956] ThrA on Discord):

```berry
#- start LVGL and init environment -#
lv.start()

hres = lv.get_hor_res()
vres = lv.get_ver_res()
scr = lv.scr_act()            # default screen object

lvobj = lv.obj(scr)
lvobj.set_size(200,50)
lvobj.center()

def lvobj_event(obj, event)
    #print(f"{obj=} {event=} {event.get_code()=} {event.get_layer()=}")
    var dsc = lv.draw_rect_dsc()

    lv.draw_rect_dsc_init(dsc)

    dsc.bg_opa = 127
    dsc.bg_color = lv.color(0x00FF00)
    dsc.bg_grad_dir = lv.GRAD_DIR_HOR
    dsc.bg_grad_stops_0_color = lv.color(0xFFFFFF)
    dsc.bg_grad_stops_0_opa = 255
    dsc.bg_grad_stops_1_color = lv.color(0xFF0000)
    dsc.bg_grad_stops_1_opa = 255

    var crd = lv.area()
    crd.x1 = 0 crd.y1 = 0 
    crd.x2 = 199 crd.y2 = 49

    var objcrd = lv.area()
    obj.get_coords(objcrd)
    lv.area_align(objcrd, crd, lv.ALIGN_CENTER, 0, 0)

    var layer = event.get_layer()
    lv.draw_rect(layer, dsc, crd)
end
lvobj.add_event_cb(lvobj_event, lv.EVENT_DRAW_MAIN_END, 0)
lvobj.add_event_cb(lvobj_event, lv.EVENT_REFRESH, 0)
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
