### PR TITLE
fix regression

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_10_scripter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_scripter.ino
@@ -185,6 +185,64 @@ char *Get_esc_char(char *cp, char *esc_chr);
 #endif
 #endif // ESP32
 
+#ifdef SCRIPT_FULL_OPTIONS
+
+#undef USE_BUTTON_EVENT
+#define USE_BUTTON_EVENT
+#undef USE_SCRIPT_JSON_EXPORT
+#define USE_SCRIPT_JSON_EXPORT
+#undef USE_SCRIPT_SUB_COMMAND
+#define USE_SCRIPT_SUB_COMMAND
+#undef USE_SCRIPT_STATUS
+#define USE_SCRIPT_STATUS
+#undef SCRIPT_POWER_SECTION
+#define SCRIPT_POWER_SECTION
+#undef SUPPORT_MQTT_EVENT
+#define SUPPORT_MQTT_EVENT
+#undef USE_SCRIPT_WEB_DISPLAY
+#define USE_SCRIPT_WEB_DISPLAY
+#undef SCRIPT_FULL_WEBPAGE
+#define SCRIPT_FULL_WEBPAGE
+#undef USE_WEBSEND_RESPONSE
+#define USE_WEBSEND_RESPONSE
+#undef USE_ANGLE_FUNC
+#define USE_ANGLE_FUNC
+#undef USE_SCRIPT_FATFS_EXT
+#define USE_SCRIPT_FATFS_EXT
+#undef USE_SCRIPT_TASK
+#define USE_SCRIPT_TASK
+#undef USE_SCRIPT_GLOBVARS
+#define USE_SCRIPT_GLOBVARS
+#undef USE_SCRIPT_I2C
+#define USE_SCRIPT_I2C
+#undef USE_SCRIPT_SERIAL
+#define USE_SCRIPT_SERIAL
+#undef USE_SCRIPT_TIMER
+#define USE_SCRIPT_TIMER
+#undef LARGE_ARRAYS
+#define LARGE_ARRAYS
+#undef SCRIPT_LARGE_VNBUFF
+#define SCRIPT_LARGE_VNBUFF
+#undef USE_GOOGLE_CHARTS
+#define USE_GOOGLE_CHARTS
+#undef USE_FEXTRACT
+#define USE_FEXTRACT
+#undef USE_SCRIPT_SPI
+#define USE_SCRIPT_SPI
+#undef USE_SCRIPT_TCP_SERVER
+#define USE_SCRIPT_TCP_SERVER
+#undef USE_SCRIPT_ONEWIRE
+#define USE_SCRIPT_ONEWIRE
+#undef USE_SCRIPT_INT
+#define USE_SCRIPT_INT
+#undef USE_SCRIPT_FULL_JSON_PARSER
+#define USE_SCRIPT_FULL_JSON_PARSER
+#undef USE_HTML_CALLBACK
+#define USE_HTML_CALLBACK
+
+#endif
+
+
 #ifdef USE_SCRIPT_TIMER
 #include <Ticker.h>
 Ticker Script_ticker1;
@@ -4618,6 +4676,10 @@ extern void W8960_SetGain(uint8_t sel, uint16_t value);
           goto nfuncexit;
         }
 #endif
+        if (!strncmp_XP(vname, XPSTR("maca"), 4)) {
+          if (sp) strlcpy(sp, NetworkUniqueId().c_str(), glob_script_mem.max_ssize);
+          goto strexit;
+        }
         break;
 
       case 'n':
@@ -11832,7 +11894,7 @@ exgc:
               }
             }
           }
-          snprintf_P(options,sizeof(options), SCRIPT_MSG_GOPT4);
+          snprintf_P(options, SCRIPT_GC_OPTIONS_SIZE, SCRIPT_MSG_GOPT4);
           free(options);
         }
         if (tonly) {
@@ -11961,10 +12023,10 @@ exgc:
 
         switch (gs_ctype) {
           case 't':
-            snprintf_P(options, sizeof(options), SCRIPT_MSG_GOPT2);
+            snprintf_P(options, SCRIPT_GC_OPTIONS_SIZE, SCRIPT_MSG_GOPT2);
             break;
           default:
-            snprintf_P(options, sizeof(options), SCRIPT_MSG_GOPT1, header, stacked);
+            snprintf_P(options, SCRIPT_GC_OPTIONS_SIZE, SCRIPT_MSG_GOPT1, header, stacked);
             break;
         }
         // check for 2 axis option
@@ -11982,7 +12044,7 @@ exgc:
           char maxstr2[16];
           dtostrfd(max2, 3, maxstr2);
           //snprintf_P(options, sizeof(options), SCRIPT_MSG_GOPT3, header, (uint32_t)max1, (uint32_t)max2, func);
-          snprintf_P(options, sizeof(options), SCRIPT_MSG_GOPT3, header, stacked, maxstr1, maxstr2, func);
+          snprintf_P(options, SCRIPT_GC_OPTIONS_SIZE, SCRIPT_MSG_GOPT3, header, stacked, maxstr1, maxstr2, func);
         } else {
           SCRIPT_SKIP_SPACES
           if (gs_ctype != 'g') {
@@ -11998,7 +12060,7 @@ exgc:
               char maxstr2[16];
               dtostrfd(max2, 3, maxstr2);
               //nprintf_P(options, sizeof(options), SCRIPT_MSG_GOPT6, header, (uint32_t)max1, (uint32_t)max2, func);
-              snprintf_P(options, sizeof(options), SCRIPT_MSG_GOPT6, header, stacked, maxstr1, maxstr2, func);
+              snprintf_P(options, SCRIPT_GC_OPTIONS_SIZE, SCRIPT_MSG_GOPT6, header, stacked, maxstr1, maxstr2, func);
             }
           }
         }
@@ -12015,7 +12077,7 @@ exgc:
           SCRIPT_SKIP_SPACES
           TS_FLOAT redTo = maxValue;
           TS_FLOAT yellowTo = redFrom;
-          snprintf_P(options, sizeof(options), SCRIPT_MSG_GAUGEOPT, (uint32_t)maxValue, (uint32_t)redFrom, (uint32_t)redTo,
+          snprintf_P(options, SCRIPT_GC_OPTIONS_SIZE, SCRIPT_MSG_GAUGEOPT, (uint32_t)maxValue, (uint32_t)redFrom, (uint32_t)redTo,
             (uint32_t)yellowFrom, (uint32_t)yellowTo);
           }
         }


### PR DESCRIPTION
## Description:

fixes regression affecting google chart options

also adds a SCRIPT_FULL_OPTIONS define that enables nearly all scripter options (results in about 90k flash size)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
