### PR TITLE
S3 120Mhz

### DIFF
--- a/boards/esp32s3-opi_opi_120.json
+++ b/boards/esp32s3-opi_opi_120.json
@@ -1,0 +1,50 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "opi_opi"
+    },
+    "core": "esp32",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "f_boot": "120000000L",
+    "boot": "opi",
+    "flash_mode": "dout",
+    "mcu": "esp32s3",
+    "variant": "esp32s3",
+    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
+    "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Espressif Generic ESP32-S3 >= 4M OPI Flash + PSRAM, Tasmota 2880k Code/OTA, 320k FS",
+  "upload": {
+    "arduino": {
+      "flash_extra_images": [
+        [
+          "0x10000",
+          "tasmota32s3-safeboot.bin"
+        ]
+      ]
+    },
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "download": {
+    "speed": 230400
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
+  "vendor": "Espressif"
+}

--- a/boards/esp32s3-qio_opi_120.json
+++ b/boards/esp32s3-qio_opi_120.json
@@ -1,0 +1,50 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "f_boot": "120000000L",
+    "boot": "qio",
+    "flash_mode": "qio",
+    "mcu": "esp32s3",
+    "variant": "esp32s3",
+    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
+    "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Espressif Generic ESP32-S3 >= 4M QIO Flash + OPI PSRAM, Tasmota 2880k Code/OTA, 320k FS",
+  "upload": {
+    "arduino": {
+      "flash_extra_images": [
+        [
+          "0x10000",
+          "tasmota32s3-safeboot.bin"
+        ]
+      ]
+    },
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "download": {
+    "speed": 230400
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
+  "vendor": "Espressif"
+}

--- a/boards/esp32s3cdc-opi_opi_120.json
+++ b/boards/esp32s3cdc-opi_opi_120.json
@@ -1,0 +1,54 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "opi_opi"
+    },
+    "core": "esp32",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "f_boot": "120000000L",
+    "boot": "opi",
+    "flash_mode": "dout",
+    "mcu": "esp32s3",
+    "variant": "esp32s3",
+    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
+    "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Espressif Generic ESP32-S3 >= 4M OPI Flash + PSRAM, Tasmota 2880k Code/OTA, 320k FS",
+  "upload": {
+    "arduino": {
+      "flash_extra_images": [
+        [
+          "0x10000",
+          "tasmota32s3cdc-safeboot.bin"
+        ]
+      ]
+    },
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 2000000
+  },
+  "download": {
+    "speed": 2000000
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
+  "vendor": "Espressif"
+}

--- a/boards/esp32s3cdc-qio_opi_120.json
+++ b/boards/esp32s3cdc-qio_opi_120.json
@@ -1,0 +1,54 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "f_boot": "120000000L",
+    "boot": "qio",
+    "flash_mode": "qio",
+    "mcu": "esp32s3",
+    "variant": "esp32s3",
+    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
+    "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Espressif Generic ESP32-S3 >= 4M QIO Flash + OPI PSRAM, Tasmota 2880k Code/OTA, 320k FS",
+  "upload": {
+    "arduino": {
+      "flash_extra_images": [
+        [
+          "0x10000",
+          "tasmota32s3cdc-safeboot.bin"
+        ]
+      ]
+    },
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 2000000
+  },
+  "download": {
+    "speed": 2000000
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
+  "vendor": "Espressif"
+}


### PR DESCRIPTION
## Description:

add S3 120Mhz boards manifest. Needed for testing of pre release Tasmota Arduino 3.0.0
Prepare for the new feature of some S3 boards to clock flash and/or PSRAM with 120Mhz.
Currently not used. Will be possible to use with release Arduino core 3.0.0.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
