### PR TITLE
LVGL simplify mapping

### DIFF
--- a/lib/libesp32_lvgl/lv_binding_berry/src/be_lvgl_ctypes_definitions.c
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/be_lvgl_ctypes_definitions.c
@@ -453,32 +453,6 @@ static be_define_ctypes_class(lv_style_transition_dsc, &be_lv_style_transition_d
 static be_define_ctypes_class(lv_timer_ntv, &be_lv_timer_ntv, &be_class_ctypes_bytes, "lv_timer_ntv");
 static be_define_ctypes_class(lv_ts_calibration, &be_lv_ts_calibration, &be_class_ctypes_bytes, "lv_ts_calibration");
 
-void be_load_ctypes_lvgl_definitions_lib(bvm *vm) {
-  ctypes_register_class(vm, &be_class_lv_area);
-  ctypes_register_class(vm, &be_class_lv_chart_cursor);
-  ctypes_register_class(vm, &be_class_lv_chart_series);
-  ctypes_register_class(vm, &be_class_lv_color_filter_dsc);
-  ctypes_register_class(vm, &be_class_lv_draw_arc_dsc);
-  ctypes_register_class(vm, &be_class_lv_draw_dsc_base);
-  ctypes_register_class(vm, &be_class_lv_draw_image_dsc);
-  ctypes_register_class(vm, &be_class_lv_draw_label_dsc);
-  ctypes_register_class(vm, &be_class_lv_draw_line_dsc);
-  ctypes_register_class(vm, &be_class_lv_draw_rect_dsc);
-  ctypes_register_class(vm, &be_class_lv_event);
-  ctypes_register_class(vm, &be_class_lv_grad_dsc);
-  ctypes_register_class(vm, &be_class_lv_gradient_stop);
-  ctypes_register_class(vm, &be_class_lv_image_dsc);
-  ctypes_register_class(vm, &be_class_lv_image_header);
-  ctypes_register_class(vm, &be_class_lv_meter_indicator);
-  ctypes_register_class(vm, &be_class_lv_meter_scale);
-  ctypes_register_class(vm, &be_class_lv_obj_class);
-  ctypes_register_class(vm, &be_class_lv_point);
-  ctypes_register_class(vm, &be_class_lv_point_precise);
-  ctypes_register_class(vm, &be_class_lv_style_transition_dsc);
-  ctypes_register_class(vm, &be_class_lv_timer_ntv);
-  ctypes_register_class(vm, &be_class_lv_ts_calibration);
-}
-
 be_ctypes_class_by_name_t be_ctypes_lvgl_classes[] = {
   { "lv_area", &be_class_lv_area },
   { "lv_chart_cursor", &be_class_lv_chart_cursor },

--- a/lib/libesp32_lvgl/lv_binding_berry/src/embedded/berry_ctypes.py
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/embedded/berry_ctypes.py
@@ -187,12 +187,6 @@ def print_classes(module_name):
     print(f"static be_define_ctypes_class({elt}, &be_{elt}, &be_class_ctypes_bytes, \"{elt}\");")
 
   print()
-  print(f"void be_load_ctypes_{module_name}_definitions_lib(bvm *vm) {{")
-  for elt in global_classes:
-    print(f"  ctypes_register_class(vm, &be_class_{elt});")
-
-  print("}")
-  print()
   print("be_ctypes_class_by_name_t be_ctypes_lvgl_classes[] = {")
   for elt in global_classes:
     print(f"  {{ \"{elt}\", &be_class_{elt} }},")


### PR DESCRIPTION
## Description:

LVGL remove unused mapping functions. No change in code size because the function was not linked anyways.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
