### PR TITLE
Zigbee added for attributes of type `uint48` used by energy monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [13.4.0.3]
 ### Added
-
+- Zigbee added for attributes of type `uint48` used by energy monitoring
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -331,6 +331,14 @@ int32_t encodeSingleAttribute(SBuffer &buf, double val_d, const char *val_str, u
       buf.add32( *((uint32_t*)&f32) );    // cast float as uint32_t
       break;
 
+    case Zuint48:       // added for energy value
+      {
+        uint64_t u64 = val_d;
+        buf.add32(u64);
+        buf.add8(u64 >> 32);
+      }
+      break;
+
     case Zstring:
     case Zstring16:
       {

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
@@ -459,7 +459,7 @@ void ZbSendReportWrite(class JsonParserToken val_pubwrite, class ZCLFrame & zcl)
         if (!attr_discrete) {
           int32_t res = encodeSingleAttribute(buf, val_d, val_str, attr.attr_type);
           if (res < 0) {
-            Response_P(PSTR("{\"%s\":\"%s'%s' 0x%02X\"}"), XdrvMailbox.command, PSTR(D_ZIGBEE_UNSUPPORTED_ATTRIBUTE_TYPE " "), key, attr.attr_type);
+            Response_P(PSTR("{\"%s\":\"%s'%s' 0x%02X\"}"), XdrvMailbox.command, PSTR(D_ZIGBEE_UNSUPPORTED_ATTRIBUTE_TYPE " "), key.getStr(), attr.attr_type);
             return;
           }
         }


### PR DESCRIPTION
## Description:

It is now possible to write `uint48` values as well as configure reporting for attributes of type `uint48`.

For example:
`ZbSend {"Device":"Buanderie","Config":{"CurrentSummationDelivered":{"MinInterval":60,"MaxInterval":3600,"ReportableChange":100}}}`

Fixes: #20952

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
