### PR TITLE
Azure iothub direct method support

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -593,7 +593,6 @@ void MqttDataHandler(char* mqtt_topic, uint8_t* mqtt_data, unsigned int data_len
       JsonParser mqtt_json_data((char*) mqtt_data);
       JsonParserObject message_object = mqtt_json_data.getRootObject();
       String mqtt_data_str= message_object.getStr("payload","");
-      data_len = mqtt_data_str.length();
       strncpy(reinterpret_cast<char*>(mqtt_data),mqtt_data_str.c_str(),data_len);
       mqtt_data[data_len] = 0;
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -476,6 +476,7 @@ void MqttSubscribeLib(const char *topic) {
   String realTopicString = "devices/" + String(SettingsText(SET_MQTT_CLIENT));
   realTopicString += "/messages/devicebound/#";
   MqttClient.subscribe(realTopicString.c_str());
+  MqttClient.subscribe("$iothub/methods/POST/#");
   SettingsUpdateText(SET_MQTT_FULLTOPIC, SettingsText(SET_MQTT_CLIENT));
   SettingsUpdateText(SET_MQTT_TOPIC, SettingsText(SET_MQTT_CLIENT));
 #else
@@ -577,6 +578,25 @@ void MqttDataHandler(char* mqtt_topic, uint8_t* mqtt_data, unsigned int data_len
 
   char topic[TOPSZ];
 #ifdef USE_MQTT_AZURE_IOT
+  #ifdef USE_AZURE_DIRECT_METHOD 
+      String fullTopicString = String(mqtt_topic);
+      int startOfMethod = fullTopicString.indexOf("methods/POST");
+      int endofMethod = fullTopicString.indexOf("/?$rid");
+      String req_id = fullTopicString.substring(endofMethod + 7);
+      if (startOfMethod == -1){
+        AddLog(LOG_LEVEL_ERROR, PSTR(D_LOG_MQTT "Azure IoT Hub message without a method."));
+        return;
+      }
+      String newMethod = fullTopicString.substring(startOfMethod + 12,endofMethod);
+      strlcpy(topic, newMethod.c_str(), sizeof(topic));
+      mqtt_data[data_len] = 0;
+      JsonParser mqtt_json_data((char*) mqtt_data);
+      JsonParserObject message_object = mqtt_json_data.getRootObject();
+      String mqtt_data_str= message_object.getStr("payload","");
+      data_len = mqtt_data_str.length();
+      strncpy(reinterpret_cast<char*>(mqtt_data),mqtt_data_str.c_str(),data_len);
+
+  #else
   // for Azure, we read the topic from the property of the message
   String fullTopicString = String(mqtt_topic);
   String toppicUpper = fullTopicString;
@@ -593,6 +613,7 @@ void MqttDataHandler(char* mqtt_topic, uint8_t* mqtt_data, unsigned int data_len
     return;
   }
   strlcpy(topic, newTopic.c_str(), sizeof(topic));
+  #endif
 #else
   strlcpy(topic, mqtt_topic, sizeof(topic));
 #endif  // USE_MQTT_AZURE_IOT
@@ -624,6 +645,11 @@ void MqttDataHandler(char* mqtt_topic, uint8_t* mqtt_data, unsigned int data_len
   if (Mqtt.disable_logging) {
     TasmotaGlobal.masterlog_level = LOG_LEVEL_NONE;  // Enable logging
   }
+  #ifdef USE_AZURE_DIRECT_METHOD // Send response for the direct method
+  String response_topic = "$iothub/methods/res/200/?$rid=" + req_id;
+  String payload = "{\"status\": \"success\"}";
+  MqttClient.publish(response_topic.c_str(),payload.c_str());
+  #endif
 }
 
 /*********************************************************************************************/

--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -595,6 +595,7 @@ void MqttDataHandler(char* mqtt_topic, uint8_t* mqtt_data, unsigned int data_len
       String mqtt_data_str= message_object.getStr("payload","");
       data_len = mqtt_data_str.length();
       strncpy(reinterpret_cast<char*>(mqtt_data),mqtt_data_str.c_str(),data_len);
+      mqtt_data[data_len] = 0;
 
   #else
   // for Azure, we read the topic from the property of the message


### PR DESCRIPTION
## Description:
Azure iothub direct method feature support to receive messages to device via direct method and send response. Direct method feature can be added with adding this code snippet to `user_config_override_sample.h`
```
#ifndef USE_MQTT_TLS
#define USE_MQTT_TLS
#endif
#define USE_MQTT_AZURE_IOT
#define USE_AZURE_DIRECT_METHOD
```
Also required to enable `MQTT_TLS_ENABLED` and `SetOption132 1` to establish connection with azure iot hub.

Example:
Method: 
```txt
POWER
```
Payload: 
```json
{
"payload":"ON"
}
```


https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-direct-methods

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
