### PR TITLE
Berry fix walrus bug when assigning to self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 - LVGL library from v9.0.0 to v9.1.0
 
 ### Fixed
-
+- Berry fix walrus bug when assigning to self
 
 ### Removed
 

--- a/lib/libesp32/berry/src/be_code.c
+++ b/lib/libesp32/berry/src/be_code.c
@@ -728,21 +728,13 @@ int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, bbool keep_reg)
         setsupvar(finfo, OP_SETUPV, e1, src);
         break;
     case ETMEMBER: /* store to member R(A).RK(B) <- RK(C) */
-        setsfxvar(finfo, OP_SETMBR, e1, src);
-        if (keep_reg && e2->type == ETREG) {
+    case ETINDEX: /* store to member R(A)[RK(B)] <- RK(C) */
+        setsfxvar(finfo, (e1->type == ETMEMBER) ? OP_SETMBR : OP_SETIDX, e1, src);
+        if (keep_reg && e2->type == ETREG && e1->v.ss.obj >= be_list_count(finfo->local)) {
             /* special case of walrus assignemnt when we need to recreate an ETREG */
             code_move(finfo, e1->v.ss.obj, src);    /* move from ETREG to MEMBER instance*/
             free_expreg(finfo, e2); /* free source (checks only ETREG) */
             e2->v.idx = e1->v.ss.obj; /* update to new register */
-        }
-        break;
-    case ETINDEX: /* store to member R(A)[RK(B)] <- RK(C) */
-        setsfxvar(finfo, OP_SETIDX, e1, src);
-        if (keep_reg && e2->type == ETREG) {
-            /* special case of walrus assignemnt when we need to recreate an ETREG */
-            code_move(finfo, e1->v.ss.obj, src);
-            free_expreg(finfo, e2); /* free source (checks only ETREG) */
-            e2->v.idx = e1->v.ss.obj;
         }
         break;
     default:

--- a/lib/libesp32/berry/tests/walrus.be
+++ b/lib/libesp32/berry/tests/walrus.be
@@ -56,3 +56,17 @@ import global
 def f() return id(global.l[0] := 42) end
 assert(f() == 42)
 # bug: returns [42, 11]
+
+# bug when using member for self
+class confused_walrus
+    var b
+    def f()
+        var c = 1
+        if self.b := true
+            c = 2
+        end
+        return self
+    end
+end
+var ins = confused_walrus()
+assert(ins.f() == ins)


### PR DESCRIPTION
## Description:

Fix Berry walrus regression when assigning to self (found by sfromis):

```berry
class confused_walrus
  var b
  def f()
    var c = 1
    if self.b := true
      c = 2
    end
    return self
  end
end
print(confused_walrus().f())
# prints 'true' instead of the instance
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
