### PR TITLE
fix linker error

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_10_scripter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_scripter.ino
@@ -11121,8 +11121,11 @@ void ScriptWebShow(char mc, uint8_t page) {
 
   if (glob_script_mem.section_ptr) {
 
+#ifdef USE_GOOGLE_CHARTS
     glob_script_mem.chartindex = 1;
     glob_script_mem.google_libs = 0;
+#endif
+
     char *lp = glob_script_mem.section_ptr;
     if (mc == 'w') {
       while (*lp) {


### PR DESCRIPTION
## Description:

fix regression from latest commit, linker error when not using google charts

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
