### PR TITLE
remove outdated not used `ldscript` entry from boards

### DIFF
--- a/boards/esp32-fix.json
+++ b/boards/esp32-fix.json
@@ -1,8 +1,5 @@
 {
   "build": {
-    "arduino":{
-      "ldscript": "esp32_out.ld"
-    },
     "core": "esp32",
     "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DHAS_PSRAM_FIX -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw -DESP32_4M",
     "f_cpu": "240000000L",

--- a/boards/esp32.json
+++ b/boards/esp32.json
@@ -1,8 +1,5 @@
 {
     "build": {
-      "arduino":{
-        "ldscript": "esp32_out.ld"
-      },
       "core": "esp32",
       "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M",
       "f_cpu": "160000000L",

--- a/boards/esp32_solo1.json
+++ b/boards/esp32_solo1.json
@@ -1,8 +1,5 @@
 {
   "build": {
-    "arduino":{
-      "ldscript": "esp32_out.ld"
-    },
     "core": "esp32",
     "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DCORE32SOLO1",
     "f_cpu": "240000000L",

--- a/boards/esp32c2.json
+++ b/boards/esp32c2.json
@@ -1,8 +1,5 @@
 {
     "build": {
-      "arduino":{
-        "ldscript": "esp32c2_out.ld"
-      },
       "core": "esp32",
       "extra_flags": "-DARDUINO_TASMOTA -DESP32_4M -DESP32C2",
       "f_cpu": "120000000L",

--- a/boards/esp32c2_2M.json
+++ b/boards/esp32c2_2M.json
@@ -1,8 +1,5 @@
 {
     "build": {
-      "arduino":{
-        "ldscript": "esp32c2_out.ld"
-      },
       "core": "esp32",
       "extra_flags": "-DARDUINO_TASMOTA -DESP32_2M -DESP32C2",
       "f_cpu": "120000000L",

--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -1,8 +1,5 @@
 {
     "build": {
-      "arduino":{
-        "ldscript": "esp32c3_out.ld"
-      },
       "core": "esp32",
       "extra_flags": "-DARDUINO_TASMOTA -DESP32_4M -DESP32C3",
       "f_cpu": "160000000L",

--- a/boards/esp32c3cdc.json
+++ b/boards/esp32c3cdc.json
@@ -1,8 +1,5 @@
 {
     "build": {
-      "arduino":{
-        "ldscript": "esp32c3_out.ld"
-      },
       "core": "esp32",
       "extra_flags": "-DARDUINO_TASMOTA -DARDUINO_USB_MODE=1 -DESP32_4M -DESP32C3 -DUSE_USB_CDC_CONSOLE",
       "f_cpu": "160000000L",

--- a/boards/esp32c6.json
+++ b/boards/esp32c6.json
@@ -1,8 +1,5 @@
 {
     "build": {
-      "arduino":{
-        "ldscript": "esp32c6_out.ld"
-      },
       "core": "esp32",
       "extra_flags": "-DARDUINO_TASMOTA -DESP32_4M -DESP32C6",
       "f_cpu": "160000000L",

--- a/boards/esp32c6cdc.json
+++ b/boards/esp32c6cdc.json
@@ -1,8 +1,5 @@
 {
     "build": {
-      "arduino":{
-        "ldscript": "esp32c6_out.ld"
-      },
       "core": "esp32",
       "extra_flags": "-DARDUINO_TASMOTA -DARDUINO_USB_MODE=1 -DESP32_4M -DESP32C6 -DUSE_USB_CDC_CONSOLE",
       "f_cpu": "160000000L",

--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -1,8 +1,5 @@
 {
   "build": {
-    "arduino":{
-      "ldscript": "esp32s2_out.ld"
-    },
     "core": "esp32",
     "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DESP32S2",
     "f_cpu": "240000000L",

--- a/boards/esp32s2cdc.json
+++ b/boards/esp32s2cdc.json
@@ -1,8 +1,5 @@
 {
   "build": {
-    "arduino":{
-      "ldscript": "esp32s2_out.ld"
-    },
     "core": "esp32",
     "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S2",
     "f_cpu": "240000000L",

--- a/boards/esp32s3-opi_opi.json
+++ b/boards/esp32s3-opi_opi.json
@@ -1,7 +1,6 @@
 {
     "build": {
       "arduino":{
-        "ldscript": "esp32s3_out.ld",
         "memory_type": "opi_opi"
       },
       "core": "esp32",

--- a/boards/esp32s3-opi_opi_120.json
+++ b/boards/esp32s3-opi_opi_120.json
@@ -1,7 +1,6 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld",
       "memory_type": "opi_opi"
     },
     "core": "esp32",

--- a/boards/esp32s3-qio_opi.json
+++ b/boards/esp32s3-qio_opi.json
@@ -1,7 +1,6 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_opi"
     },
     "core": "esp32",

--- a/boards/esp32s3-qio_opi_120.json
+++ b/boards/esp32s3-qio_opi_120.json
@@ -1,7 +1,6 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_opi"
     },
     "core": "esp32",

--- a/boards/esp32s3-qio_qspi.json
+++ b/boards/esp32s3-qio_qspi.json
@@ -1,7 +1,6 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_qspi"
     },
     "core": "esp32",

--- a/boards/esp32s3cdc-opi_opi.json
+++ b/boards/esp32s3cdc-opi_opi.json
@@ -1,7 +1,6 @@
 {
     "build": {
       "arduino":{
-        "ldscript": "esp32s3_out.ld",
         "memory_type": "opi_opi"
       },
       "core": "esp32",

--- a/boards/esp32s3cdc-opi_opi_120.json
+++ b/boards/esp32s3cdc-opi_opi_120.json
@@ -1,7 +1,6 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld",
       "memory_type": "opi_opi"
     },
     "core": "esp32",

--- a/boards/esp32s3cdc-qio_opi.json
+++ b/boards/esp32s3cdc-qio_opi.json
@@ -1,7 +1,6 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_opi"
     },
     "core": "esp32",

--- a/boards/esp32s3cdc-qio_opi_120.json
+++ b/boards/esp32s3cdc-qio_opi_120.json
@@ -1,7 +1,6 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_opi"
     },
     "core": "esp32",

--- a/boards/esp32s3cdc-qio_qspi.json
+++ b/boards/esp32s3cdc-qio_qspi.json
@@ -1,7 +1,6 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_qspi"
     },
     "core": "esp32",


### PR DESCRIPTION
## Description:

it is obsolete since core 2.0.0

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
