### PR TITLE
Fix crash in Universal Touch

### DIFF
--- a/lib/lib_display/UDisplay/uDisplay.h
+++ b/lib/lib_display/UDisplay/uDisplay.h
@@ -456,18 +456,18 @@ class uDisplay : public Renderer {
 
   uint8_t ut_array[16];
   uint8_t ut_i2caddr;
-  uint8_t ut_spi_cs;
-  int8_t ut_reset;
-  int8_t ut_irq;
+  uint8_t ut_spi_cs = -1;
+  int8_t ut_reset = -1;
+  int8_t ut_irq = -1;
   uint8_t ut_spi_nr;
-  TwoWire *ut_wire;
-  SPIClass *ut_spi;
+  TwoWire *ut_wire = nullptr;;
+  SPIClass *ut_spi = nullptr;;
   SPISettings ut_spiSettings;
   char ut_name[8];
-  uint8_t *ut_init_code;
-  uint8_t *ut_touch_code;
-  uint8_t *ut_getx_code;
-  uint8_t *ut_gety_code;
+  uint8_t *ut_init_code = nullptr;
+  uint8_t *ut_touch_code = nullptr;
+  uint8_t *ut_getx_code = nullptr;
+  uint8_t *ut_gety_code = nullptr;
 
 #endif // USE_UNIVERSAL_TOUCH
 };


### PR DESCRIPTION
## Description:

@gemu2015 there is currently a crash if you compile with both `#define USE_XPT2046` and `#define USE_UNIVERSAL_TOUCH` and `:TS,*` is present in `display.ini`.

This is due to initialized values of `ut_*` variables.

With the configuration above, the TS would not work, but at least it wouldn't crash.

If you're ok, I would like to consider `#define USE_UNIVERSAL_TOUCH` as the new default in LVGL build, and remove legacy drivers.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
