### PR TITLE
Lib_teleinfo : Fixed too restrictive checksum checks

### DIFF
--- a/lib/lib_div/LibTeleinfo/library.json
+++ b/lib/lib_div/LibTeleinfo/library.json
@@ -1,6 +1,6 @@
 {
   "name": "LibTeleinfo",
-  "version": "1.1.5",
+  "version": "1.1.7",
   "keywords": "teleinfo, french, meter, power, erdf, linky, tic",
   "description": "Decoder for Teleinfo (aka TIC) from French smart power meters",
   "repository":

--- a/lib/lib_div/LibTeleinfo/library.properties
+++ b/lib/lib_div/LibTeleinfo/library.properties
@@ -1,5 +1,5 @@
 name=LibTeleinfo
-version=1.1.5
+version=1.1.7
 author=Charles-Henri Hallard <hallard.me>
 maintainer=Charles-Henri Hallard <community.hallard.me>
 sentence=Decoder for Teleinfo (aka TIC) from French smart power meters

--- a/lib/lib_div/LibTeleinfo/src/LibTeleinfo.cpp
+++ b/lib/lib_div/LibTeleinfo/src/LibTeleinfo.cpp
@@ -700,8 +700,8 @@ unsigned char TInfo::calcChecksum(char *etiquette, char *valeur, char * horodate
     if (strlen(etiquette) && strlen(valeur)) {
       while (*etiquette) {
         c =*etiquette++;
-        // Add another validity check since checksum may not be sufficient
-        if ( (c>='A' && c<='Z') || (c>='0' && c<='9') || c=='-' || c=='+') {
+        // Add another validity check
+        if (c>=0x20 && c<=0x7E) {
           sum += c ;
         } else {
           return 0;
@@ -710,8 +710,8 @@ unsigned char TInfo::calcChecksum(char *etiquette, char *valeur, char * horodate
   
       while(*valeur) {
         c = *valeur++ ;
-        // Add another validity check since checksum may not be sufficient (space authorized in Standard mode)
-        if ( (c>='A' && c<='Z') || (c>='0' && c<='9') || c==' ' || c=='.' || c=='-' || c=='+' || c=='/') {
+        // Add another validity check
+        if (c>=0x20 && c<=0x7E) {
           sum += c ;
         } else {
           return 0;


### PR DESCRIPTION
## Description:

Fixed too restrictive checks that may introduce checksum errors on some contracts with new characters

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
