### PR TITLE
Berry added `close()` to class `serial`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Zigbee support for attributes of type `uint48` used by energy monitoring (#20992)
 - Support for EU863-870 LoRaWanBridge
 - Added GPIO for SPI for Universal Touch Screen
+- Berry added `close()` to class `serial`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_serial_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_serial_lib.c
@@ -84,6 +84,7 @@ class be_class_serial (scope: global, name: serial) {
 
     init, func(b_serial_init)
     deinit, func(b_serial_deinit)
+    close, func(b_serial_deinit)
 
     write, func(b_serial_write)
     read, func(b_serial_read)


### PR DESCRIPTION
## Description:

Added explicit `close()` method to Berry `serial` class.

Internally it's just a synonym to `deinit()` but you are not supposed to call `deinit()` yourself, it is only called by the garbage collector.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
