### PR TITLE
Berry `print "a"` syntax no longer supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Too restrictive checksum checks in Lib_teleinfo (#21033)
 
 ### Removed
+- Berry `print "a"` syntax no longer supported
 
 
 ## [13.4.0.2] 20240318

--- a/lib/libesp32/berry/src/be_parser.c
+++ b/lib/libesp32/berry/src/be_parser.c
@@ -918,30 +918,6 @@ static void primary_expr(bparser *parser, bexpdesc *e)
     }
 }
 
-/* parse a single string literal as parameter */
-static void call_single_string_expr(bparser *parser, bexpdesc *e)
-{
-    bexpdesc arg;
-    bfuncinfo *finfo = parser->finfo;
-    int base;
-
-    /* func 'string_literal' */
-    check_var(parser, e);
-    if (e->type == ETMEMBER) {
-        push_error(parser, "method not allowed for string prefix");
-    }
-    
-    base = be_code_nextreg(finfo, e); /* allocate a new base reg if not at top already */
-    simple_expr(parser, &arg);
-    be_code_nextreg(finfo, &arg);  /* move result to next reg */
-
-    be_code_call(finfo, base, 1);  /* only one arg */
-    if (e->type != ETREG) {
-        e->type = ETREG;
-        e->v.idx = base;
-    }
-}
-
 static void suffix_expr(bparser *parser, bexpdesc *e)
 {
     primary_expr(parser, e);
@@ -955,9 +931,6 @@ static void suffix_expr(bparser *parser, bexpdesc *e)
             break;
         case OptLSB: /* '[' index */
             index_expr(parser, e);
-            break;
-        case TokenString:
-            call_single_string_expr(parser, e); /* " string literal */
             break;
         default:
             return;


### PR DESCRIPTION
## Description:

Removed a Berry feature that was actually never used, allowing a function be followed by a single string argument without parenthesis. Now `print "foo"` is no longer supported because it's too error-prone, and should be replaced with `print("foo")`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
