### PR TITLE
add a configuration for Wemos D1 with 16M

### DIFF
--- a/boards/esp8266_16M14M.json
+++ b/boards/esp8266_16M14M.json
@@ -1,0 +1,30 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "eagle.flash.16m14m.ld"
+    },
+    "core": "esp8266",
+    "extra_flags": "-DARDUINO_TASMOTA -DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_16M -DESP8266_16M14M",
+    "f_cpu": "80000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dout",
+    "mcu": "esp8266",
+    "variant": "generic"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Espressif Generic ESP8266 Tasmota 1M sketch 1M OTA 14M FS",
+  "upload": {
+    "maximum_ram_size": 81920,
+    "maximum_size": 995326,
+    "require_upload_port": true,
+    "resetmethod": "ck",
+    "speed": 115200
+  },
+  "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",
+  "vendor": "Espressif"
+}


### PR DESCRIPTION
add a configuration for Wemos D1 with 16M

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [ ]x Only relevant files were touched
  - [ ]x Only one feature/fix was added per PR and the code change compiles without warnings
  - [ x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
