### PR TITLE
Added RelayLock to Lock specific relays from beeing changed

### DIFF
--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -285,6 +285,7 @@
   #define D_STATUS13_SHUTTER "SHT"
 #define D_CMND_STATE "State"
 #define D_CMND_POWER "Power"
+#define D_CMND_RELAYLOCK "RelayLock"
 #define D_CMND_TIMEDPOWER "TimedPower"
 #define D_CMND_FANSPEED "FanSpeed"
 #define D_CMND_POWERONSTATE "PowerOnState"

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -786,8 +786,8 @@ typedef struct {
   uint8_t       weight_change;             // E9F
   uint8_t       web_color2[2][3];          // EA0  Needs to be on integer / 3 distance from web_color
   uint16_t      zcdimmerset[5];            // EA6
-
-  uint8_t       free_eb0[22];              // EB0  22 bytes
+  uint32_t      relay_lock_bitfield;       // EB0
+  uint8_t       free_eb0[18];              // EB4  18 bytes
 
   uint8_t       shift595_device_count;     // EC6
   uint8_t       sta_config;                // EC7

--- a/tasmota/include/tasmota_version.h
+++ b/tasmota/include/tasmota_version.h
@@ -22,6 +22,6 @@
 
 #define TASMOTA_SHA_SHORT                      // Filled by Github sed
 
-const uint32_t TASMOTA_VERSION = 0x0D040003;   // 13.4.0.3
+const uint32_t TASMOTA_VERSION = 0x0D040004;   // 13.4.0.4
 
 #endif  // _TASMOTA_VERSION_H_

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -1766,6 +1766,9 @@ void SettingsDelta(void) {
     if (Settings->version < 0x0D000003) {  // 13.0.0.3
       Settings->battery_level_percent = 101;
     }
+    if (Settings->version < 0x0D040004) {  // 13.4.0.4
+      Settings->relay_lock_bitfield = 0;
+    }
 /*    
 #if (LANGUAGE_LCID == 1049)
     if (Settings->version < 0x0D020003) {  // 13.2.0.3

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -34,7 +34,7 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
   D_CMND_DEVICENAME "|" D_CMND_FN "|" D_CMND_FRIENDLYNAME "|" D_CMND_SWITCHMODE "|" D_CMND_INTERLOCK "|" D_CMND_TELEPERIOD "|" D_CMND_RESET "|" D_CMND_TIME "|" D_CMND_TIMEZONE "|" D_CMND_TIMESTD "|"
   D_CMND_TIMEDST "|" D_CMND_ALTITUDE "|" D_CMND_LEDPOWER "|" D_CMND_LEDSTATE "|" D_CMND_LEDMASK "|" D_CMND_LEDPWM_ON "|" D_CMND_LEDPWM_OFF "|" D_CMND_LEDPWM_MODE "|"
   D_CMND_WIFIPOWER "|" D_CMND_TEMPOFFSET "|" D_CMND_HUMOFFSET "|" D_CMND_SPEEDUNIT "|" D_CMND_GLOBAL_TEMP "|" D_CMND_GLOBAL_HUM"|" D_CMND_GLOBAL_PRESS "|" D_CMND_SWITCHTEXT "|" D_CMND_WIFISCAN "|" D_CMND_WIFITEST "|"
-  D_CMND_ZIGBEE_BATTPERCENT "|"
+  D_CMND_ZIGBEE_BATTPERCENT "|" D_CMND_RELAYLOCK "|"
 #ifdef USE_I2C
   D_CMND_I2CSCAN "|" D_CMND_I2CDRIVER "|"
 #endif
@@ -74,7 +74,7 @@ void (* const TasmotaCommand[])(void) PROGMEM = {
   &CmndDevicename, &CmndFriendlyname, &CmndFriendlyname, &CmndSwitchMode, &CmndInterlock, &CmndTeleperiod, &CmndReset, &CmndTime, &CmndTimezone, &CmndTimeStd,
   &CmndTimeDst, &CmndAltitude, &CmndLedPower, &CmndLedState, &CmndLedMask, &CmndLedPwmOn, &CmndLedPwmOff, &CmndLedPwmMode,
   &CmndWifiPower, &CmndTempOffset, &CmndHumOffset, &CmndSpeedUnit, &CmndGlobalTemp, &CmndGlobalHum, &CmndGlobalPress, &CmndSwitchText, &CmndWifiScan, &CmndWifiTest,
-  &CmndBatteryPercent,
+  &CmndBatteryPercent,CmndRelayLock,
 #ifdef USE_I2C
   &CmndI2cScan, &CmndI2cDriver,
 #endif
@@ -2823,6 +2823,22 @@ void CmndSensor(void)
 void CmndDriver(void)
 {
   XdrvCall(FUNC_COMMAND_DRIVER);
+}
+
+void CmndRelayLock(void)
+{
+  // D_CMND_RELAYLOCK
+  // Settings.relay_lock_bitfied = -1;
+  if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= TasmotaGlobal.devices_present)) {
+    if (XdrvMailbox.payload == 0) {
+        // Setzt das Bit an der Position INDEX auf 0
+        Settings->relay_lock_bitfield &= ~(1 << (XdrvMailbox.index-1));
+    } else {
+        // Setzt das Bit an der Position INDEX auf 1
+        Settings->relay_lock_bitfield |= (1 << (XdrvMailbox.index-1));
+    }
+  }
+  ResponseCmndNumber(Settings->relay_lock_bitfield);
 }
 
 #ifdef ESP32

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -2830,14 +2830,11 @@ void CmndRelayLock(void)
   // D_CMND_RELAYLOCK
   // Settings.relay_lock_bitfied = -1;
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= TasmotaGlobal.devices_present)) {
-    if (XdrvMailbox.payload == 0) {
-        // Setzt das Bit an der Position INDEX auf 0
-        Settings->relay_lock_bitfield &= ~(1 << (XdrvMailbox.index-1));
-    } else {
-        // Setzt das Bit an der Position INDEX auf 1
-        Settings->relay_lock_bitfield |= (1 << (XdrvMailbox.index-1));
-    }
+    bitWrite(Settings->relay_lock_bitfield, XdrvMailbox.index-1, XdrvMailbox.payload>0?1:0);
   }
+  AddLog(LOG_LEVEL_DEBUG, PSTR("Lock: %32_b"),
+    &Settings->relay_lock_bitfield);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("      32..........20........10.......1"));
   ResponseCmndNumber(Settings->relay_lock_bitfield);
 }
 

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -2827,14 +2827,12 @@ void CmndDriver(void)
 
 void CmndRelayLock(void)
 {
-  // D_CMND_RELAYLOCK
-  // Settings.relay_lock_bitfied = -1;
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= TasmotaGlobal.devices_present)) {
     bitWrite(Settings->relay_lock_bitfield, XdrvMailbox.index-1, XdrvMailbox.payload>0?1:0);
   }
-  AddLog(LOG_LEVEL_DEBUG, PSTR("Lock: %32_b"),
-    &Settings->relay_lock_bitfield);
-  AddLog(LOG_LEVEL_DEBUG, PSTR("      32..........20........10.......1"));
+  AddLog(LOG_LEVEL_DEBUG, PSTR("CMD:        %32_b"), &Settings->relay_lock_bitfield);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("CMD: Relay: 32..28..24..20..16..12..8...4..1"));
+  //                                        10001000100010001000100010001000
   ResponseCmndNumber(Settings->relay_lock_bitfield);
 }
 

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -714,7 +714,7 @@ void ExecuteCommandPower(uint32_t device, uint32_t state, uint32_t source)
 
   if (Settings->relay_lock_bitfield & (1 << (device-1))) {
       AddLog(LOG_LEVEL_INFO, PSTR("Relay: %d is LOCKED"), device);
-      return;
+      state = POWER_SHOW_STATE;  // only show state. Make no change
   }
 
   if (state != POWER_SHOW_STATE) {

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -712,7 +712,7 @@ void ExecuteCommandPower(uint32_t device, uint32_t state, uint32_t source)
   }
   TasmotaGlobal.active_device = device;
 
-  if (Settings->relay_lock_bitfield & (1 << (device-1))) {
+  if (bitRead(Settings->relay_lock_bitfield , device-1)) {
       AddLog(LOG_LEVEL_INFO, PSTR("Relay: %d is LOCKED"), device);
       state = POWER_SHOW_STATE;  // only show state. Make no change
   }

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -713,7 +713,7 @@ void ExecuteCommandPower(uint32_t device, uint32_t state, uint32_t source)
   TasmotaGlobal.active_device = device;
 
   if (bitRead(Settings->relay_lock_bitfield , device-1)) {
-      AddLog(LOG_LEVEL_INFO, PSTR("Relay: %d is LOCKED"), device);
+      AddLog(LOG_LEVEL_INFO, PSTR("CMD: Relay: %d is LOCKED"), device);
       state = POWER_SHOW_STATE;  // only show state. Make no change
   }
 

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -712,6 +712,11 @@ void ExecuteCommandPower(uint32_t device, uint32_t state, uint32_t source)
   }
   TasmotaGlobal.active_device = device;
 
+  if (Settings->relay_lock_bitfield & (1 << (device-1))) {
+      AddLog(LOG_LEVEL_INFO, PSTR("Relay: %d is LOCKED"), device);
+      return;
+  }
+
   if (state != POWER_SHOW_STATE) {
     SetPulseTimer((device -1) % MAX_PULSETIMERS, 0);
   }


### PR DESCRIPTION
## Description:
Sometimes it might be useful and required to LOCK a relay e.g. to temporary disconnect ALEXA or other smart home from changing a relay. The new command relaylock&lt;x&gt; 1|0 can disable or enable a lock on a specific relay

- interlock still works - higher priority
- running pulsetimers will NOT change after timeout if relaylock set during timer
- shutters gets confused if relay does not switch. Anyhow Shutterlock exist. Therefore acceptable issue


**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
