### PR TITLE
Berry add `flash.current_ota`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Command ``PowerLock`` to disable power control of selected outputs (#21081)
 - Command ``Wifi 6`` to enable 11ax on ESP32 Core3
+- Berry add `flash.current_ota`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_flash_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_flash_lib.c
@@ -15,6 +15,10 @@
 extern void p_factory(bbool force_ota);
 BE_FUNC_CTYPE_DECLARE(p_factory, "", "b");
 
+// return current OTA partition
+extern int p_cur_ota();
+BE_FUNC_CTYPE_DECLARE(p_cur_ota, "i", "");
+
 int32_t p_flashid(void) {
     uint32_t id = bootloader_read_flash_id();
     id = ((id & 0xff) << 16) | ((id >> 16) & 0xff) | (id & 0xff00);
@@ -42,6 +46,7 @@ module flash (scope: global) {
 
     id, ctype_func(p_flashid)
     size, ctype_func(p_flashsize)
+    current_ota, ctype_func(p_cur_ota)
 }
 @const_object_info_end */
 #include "be_fixed_flash.h"

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_flash.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_flash.ino
@@ -181,6 +181,18 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
+  // return current OTA partition
+  // Typically `0` or `1`, or `-1` if safeboot
+  int p_cur_ota() {
+    uint32_t cur_part = ESP_PARTITION_SUBTYPE_APP_FACTORY;   // 0
+    const esp_partition_t *running_ota = esp_ota_get_running_partition();
+    if (running_ota) { cur_part = running_ota->subtype; }    // 16 - 32
+    if (cur_part >= (uint32_t)ESP_PARTITION_SUBTYPE_APP_OTA_MIN /*16*/ && cur_part < (uint32_t)ESP_PARTITION_SUBTYPE_APP_OTA_MAX /*32*/) {
+      return cur_part - (uint32_t)ESP_PARTITION_SUBTYPE_APP_OTA_MIN /*16*/;
+    }
+    return -1;
+  }
+
   // Forces the next restart to use the `factory` partition if any is present
   void p_factory(bbool force_ota) {
     const esp_partition_t *otadata_partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_OTA, NULL);


### PR DESCRIPTION
## Description:

Berry add `flash.current_ota() -> int` to know which is the current partition we are running from, typically `0` or `1`, or `-1` for safeboot. With safeboot layout, it is always `0`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
