### PR TITLE
Bugfix: power0 if power_lock is used

### DIFF
--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -397,11 +397,11 @@ void SetAllPower(uint32_t state, uint32_t source)
         break;
     case POWER_ON:
         // Keep locked bits and set all other to 1
-        TasmotaGlobal.power = (TasmotaGlobal.power & Settings->power_lock) | ~Settings->power_lock;
+        TasmotaGlobal.power = (TasmotaGlobal.power & Settings->power_lock) | (all_on & ~Settings->power_lock);
         break;
     case POWER_TOGGLE:
         // Keep locked bits and toggle all other
-        TasmotaGlobal.power ^= ~Settings->power_lock;
+        TasmotaGlobal.power ^= ~Settings->power_lock & all_on;
         break;
     }
     SetDevicePower(TasmotaGlobal.power, source);

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -390,16 +390,21 @@ void SetAllPower(uint32_t state, uint32_t source)
   }
   if ((state >= POWER_OFF) && (state <= POWER_TOGGLE)) {
     power_t all_on = POWER_MASK >> (POWER_SIZE - TasmotaGlobal.devices_present);
+    power_t mask = ~Settings->power_lock;  
     switch (state) {
     case POWER_OFF:
-      TasmotaGlobal.power = 0;
-      break;
+        // keep loocked bits and set all other to 0
+        TasmotaGlobal.power &= ~mask;  
+        break;
     case POWER_ON:
-      TasmotaGlobal.power = all_on;
-      break;
+        // Keep locked bits and set all other to 1
+        TasmotaGlobal.power = (TasmotaGlobal.power & Settings->power_lock) | mask;
+
+        break;
     case POWER_TOGGLE:
-      TasmotaGlobal.power ^= all_on;      // Complement current state
-    }
+        // Keep locked bits and toggle all other
+        TasmotaGlobal.power ^= mask;
+        break;
     SetDevicePower(TasmotaGlobal.power, source);
   }
   if (publish_power) {

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -390,21 +390,20 @@ void SetAllPower(uint32_t state, uint32_t source)
   }
   if ((state >= POWER_OFF) && (state <= POWER_TOGGLE)) {
     power_t all_on = POWER_MASK >> (POWER_SIZE - TasmotaGlobal.devices_present);
-    power_t mask = ~Settings->power_lock;  
     switch (state) {
     case POWER_OFF:
         // keep loocked bits and set all other to 0
-        TasmotaGlobal.power &= ~mask;  
+        TasmotaGlobal.power &= Settings->power_lock; 
         break;
     case POWER_ON:
         // Keep locked bits and set all other to 1
-        TasmotaGlobal.power = (TasmotaGlobal.power & Settings->power_lock) | mask;
-
+        TasmotaGlobal.power = (TasmotaGlobal.power & Settings->power_lock) | ~Settings->power_lock;
         break;
     case POWER_TOGGLE:
         // Keep locked bits and toggle all other
-        TasmotaGlobal.power ^= mask;
+        TasmotaGlobal.power ^= ~Settings->power_lock;
         break;
+    }
     SetDevicePower(TasmotaGlobal.power, source);
   }
   if (publish_power) {


### PR DESCRIPTION
## Description:
power0 changed the power regardless if power_lock was set.


**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
