### PR TITLE
fix esp32 core 3.0.0 compile

### DIFF
--- a/lib/lib_audio/ESP8266Audio/src/AudioFileSourceHTTPStream.h
+++ b/lib/lib_audio/ESP8266Audio/src/AudioFileSourceHTTPStream.h
@@ -24,6 +24,7 @@
 #include <Arduino.h>
 #ifdef ESP32
   #include <HTTPClient.h>
+  #include <WiFi.h>
 #else
   #include <ESP8266HTTPClient.h>
 #endif

--- a/lib/lib_audio/ESP8266Audio/src/AudioFileSourceICYStream.h
+++ b/lib/lib_audio/ESP8266Audio/src/AudioFileSourceICYStream.h
@@ -24,6 +24,7 @@
 #include <Arduino.h>
 #ifdef ESP32
   #include <HTTPClient.h>
+  #include <WiFi.h>
 #else
   #include <ESP8266HTTPClient.h>
 #endif


### PR DESCRIPTION
## Description:

by adding a missing include in the Audio libs, which is now needed

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
