### PR TITLE
Wifi provide Mac Address on Core3

### DIFF
--- a/lib/default/WiFiHelper/src/WiFiHelper.h
+++ b/lib/default/WiFiHelper/src/WiFiHelper.h
@@ -79,6 +79,10 @@ public:
   static int hostByName(const char* aHostname, IPAddress& aResult);
 
   static void scrubDNS(void);
+
+  // With ESP32 Core3, the WiFi mac address is not valid until the wifi is actually started
+  // this helper function always provide a valid mac address
+  static String macAddress(void);
 };
 
 

--- a/lib/default/WiFiHelper/src/WiFiHelper_ESP32.cpp
+++ b/lib/default/WiFiHelper/src/WiFiHelper_ESP32.cpp
@@ -295,4 +295,21 @@ int WiFiHelper::hostByName(const char* aHostname, IPAddress& aResult)
   return WiFiHelper::hostByName(aHostname, aResult, WifiDNSGetTimeout());
 }
 
+#if (ESP_IDF_VERSION_MAJOR >= 5)
+#include "esp_mac.h"
+#endif
+
+String WiFiHelper::macAddress(void) {
+#if (ESP_IDF_VERSION_MAJOR < 5)
+  return WiFi.macAddress();
+#else
+  uint8_t mac[6] = {0,0,0,0,0,0};
+  char macStr[18] = { 0 };
+
+  esp_read_mac(mac, ESP_MAC_WIFI_STA);
+  snprintf(macStr, sizeof(macStr), "%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  return String(macStr);
+#endif
+}
+
 #endif // ESP32

--- a/lib/default/WiFiHelper/src/WiFiHelper_ESP8266.cpp
+++ b/lib/default/WiFiHelper/src/WiFiHelper_ESP8266.cpp
@@ -73,4 +73,8 @@ int WiFiHelper::hostByName(const char* aHostname, IPAddress& aResult) {
   return WiFi.hostByName(aHostname, aResult);
 }
 
+String WiFiHelper::macAddress(void) {
+  return WiFi.macAddress();
+}
+
 #endif // ESP8266

--- a/lib/libesp32/HttpClientLight/src/HTTPUpdateLight.cpp
+++ b/lib/libesp32/HttpClientLight/src/HTTPUpdateLight.cpp
@@ -195,7 +195,7 @@ HTTPUpdateResult HTTPUpdateLight::handleUpdate(HTTPClientLight& http, const Stri
     http.setFollowRedirects(_followRedirects);
     http.setUserAgent("ESP32-http-Update");
     http.addHeader("Cache-Control", "no-cache");
-    http.addHeader("x-ESP32-STA-MAC", WiFi.macAddress());
+    http.addHeader("x-ESP32-STA-MAC", WiFiHelper::macAddress());
     http.addHeader("x-ESP32-AP-MAC", WiFi.softAPmacAddress());
     http.addHeader("x-ESP32-free-space", String(ESP.getFreeSketchSpace()));
     http.addHeader("x-ESP32-sketch-size", String(ESP.getSketchSize()));

--- a/lib/libesp32/HttpClientLight/src/HTTPUpdateLight.h
+++ b/lib/libesp32/HttpClientLight/src/HTTPUpdateLight.h
@@ -28,6 +28,7 @@
 
 #include <Arduino.h>
 #include <WiFi.h>
+#include <WiFiHelper.h>
 #include <WiFiClient.h>
 #include <WiFiUdp.h>
 #include <HttpClientLight.h>

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -714,10 +714,6 @@ void setup(void) {
   // Github inserts "release" or "commit number" before compiling using sed -i -e 's/TASMOTA_SHA_SHORT/TASMOTA_SHA_SHORT 85cff52-/g' tasmota_version.h
   snprintf_P(TasmotaGlobal.image_name, sizeof(TasmotaGlobal.image_name), PSTR("(" STR(TASMOTA_SHA_SHORT) "%s)"), PSTR(CODE_IMAGE_STR));  // Results in (85cff52-tasmota) or (release-tasmota)
 
-#if defined(ESP32) && (ESP_IDF_VERSION_MAJOR >= 5)
-  WiFi.begin();   // force wifi start so that the Mac address is known
-#endif
-
   Format(TasmotaGlobal.mqtt_client, SettingsText(SET_MQTT_CLIENT), sizeof(TasmotaGlobal.mqtt_client));
   Format(TasmotaGlobal.mqtt_topic, SettingsText(SET_MQTT_TOPIC), sizeof(TasmotaGlobal.mqtt_topic));
   if (strchr(SettingsText(SET_HOSTNAME), '%') != nullptr) {

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -946,7 +946,7 @@ void CmndStatus(void)
                           TasmotaGlobal.hostname,
                           (uint32_t)WiFi.localIP(), Settings->ipv4_address[1], Settings->ipv4_address[2],
                           DNSGetIPStr(0).c_str(), DNSGetIPStr(1).c_str(),
-                          WiFi.macAddress().c_str()
+                          WiFiHelper::macAddress().c_str()
                           ,WifiGetIPv6Str().c_str(), WifiGetIPv6LinkLocalStr().c_str());
 #else // USE_IPV6
     Response_P(PSTR("{\"" D_CMND_STATUS D_STATUS5_NETWORK "\":{\"" D_CMND_HOSTNAME "\":\"%s\",\""
@@ -956,7 +956,7 @@ void CmndStatus(void)
                           TasmotaGlobal.hostname,
                           (uint32_t)WiFi.localIP(), Settings->ipv4_address[1], Settings->ipv4_address[2],
                           Settings->ipv4_address[3], Settings->ipv4_address[4],
-                          WiFi.macAddress().c_str());
+                          WiFiHelper::macAddress().c_str());
 #endif // USE_IPV6
 #ifdef USE_TASMESH
     ResponseAppend_P(PSTR(",\"SoftAPMac\":\"%s\""), WiFi.softAPmacAddress().c_str());

--- a/tasmota/tasmota_support/support_network.ino
+++ b/tasmota/tasmota_support/support_network.ino
@@ -117,11 +117,11 @@ String NetworkMacAddress(void) {
   }
 #endif
 #endif
-  return WiFi.macAddress();
+  return WiFiHelper::macAddress();
 }
 
 String NetworkUniqueId(void) {
-  String unique_id = WiFi.macAddress();
+  String unique_id = WiFiHelper::macAddress();
   unique_id.replace(":", "");  // Full 12 chars MAC address as ID
   return unique_id;
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -2459,7 +2459,7 @@ void HandleInformation(void) {
     }
 #endif  // USE_IPV6
     if (static_cast<uint32_t>(WiFi.localIP()) != 0) {
-      WSContentSend_P(PSTR("}1" D_MAC_ADDRESS "}2%s"), WiFi.macAddress().c_str());
+      WSContentSend_P(PSTR("}1" D_MAC_ADDRESS "}2%s"), WiFiHelper::macAddress().c_str());
       WSContentSend_P(PSTR("}1" D_IP_ADDRESS " (WiFi)}2%_I"), (uint32_t)WiFi.localIP());
     }
     show_hr = true;

--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -342,7 +342,7 @@ void MqttInit(void) {
       String endpoint="https://global.azure-devices-provisioning.net/";
     #endif //USE_MQTT_AZURE_DPS_SCOPE_ENDPOINT
 
-    String MACAddress = WiFi.macAddress();
+    String MACAddress = WiFiHelper::macAddress();
     MACAddress.replace(":", "");
 
     AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_MQTT "DPS register for %s, scope %s to %s."), MACAddress.c_str(), dPSScopeId.c_str(), endpoint.c_str());

--- a/tasmota/tasmota_xdrv_driver/xdrv_20_hue.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_20_hue.ino
@@ -418,7 +418,7 @@ const char HueConfigResponse_JSON[] PROGMEM = "\x3D\xA7\xB3\xAC\x6B\x3D\x87\x99\
 String GetHueDeviceId(uint16_t id, uint8_t ep = 0)
 {
   char s[32];
-  String deviceid = WiFi.macAddress();
+  String deviceid = WiFiHelper::macAddress();
   deviceid.toLowerCase();
   if (0x11 == ep) { ep = 0xFE; }    // avoid collision with 0x11 which is used as default for `0`
   if (0 == ep) { ep = 0x11; }   // if ep is zero, revert to original value
@@ -454,7 +454,7 @@ void HueNotImplemented(String *path)
 void HueConfigResponse(String *response)
 {
   *response += Decompress(HueConfigResponse_JSON, HueConfigResponse_JSON_SIZE);
-  response->replace(F("{ma"), WiFi.macAddress());
+  response->replace(F("{ma"), WiFiHelper::macAddress());
   response->replace(F("{ip"), WiFi.localIP().toString());
   response->replace(F("{ms"), WiFi.subnetMask().toString());
   response->replace(F("{gw"), WiFi.gatewayIP().toString());

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -241,7 +241,7 @@ extern "C" {
       be_newobject(vm, "map");
       // (-2) map instance, (-1) map
     }
-    be_map_insert_str(vm, "mac", WiFi.macAddress().c_str());
+    be_map_insert_str(vm, "mac", WiFiHelper::macAddress().c_str());
     be_map_insert_bool(vm, "up", WifiHasIP());
     if (Settings->flag4.network_wifi) {
       int32_t rssi = WiFi.RSSI();

--- a/tasmota/tasmota_xdrv_driver/xdrv_57_9_tasmesh.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_57_9_tasmesh.ino
@@ -823,7 +823,7 @@ void CmndMeshPeer(void) {
       MESHaddPeer(_MAC);
       MESHcountPeers();
       ResponseCmndChar(_peerMAC);
-    } else if (WiFi.macAddress() == String(_peerMAC) || WiFi.softAPmacAddress() == String(_peerMAC)){
+    } else if (WiFiHelper::macAddress() == String(_peerMAC) || WiFi.softAPmacAddress() == String(_peerMAC)){
       // a device can be added as its own peer, but every send will result in a ESP_NOW_SEND_FAIL
       AddLog(LOG_LEVEL_DEBUG,PSTR("MSH: device %s cannot be a peer of itself"), XdrvMailbox.data, _peerMAC);
     } else {


### PR DESCRIPTION
## Description:

With Arduino Core3 on ESP32, `WiFi.macAddress()` is not valid until wifi is actually started. This is problematic because mac address is used for hostname and mqtt topic.

`WiFiHelper::macAddress()` provides a safe way to get wifi mac address even if wifi is off.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
