### PR TITLE
Coming upstream changes: NimBLEService.cpp

### DIFF
--- a/lib/libesp32_div/esp-nimble-cpp/src/NimBLEService.cpp
+++ b/lib/libesp32_div/esp-nimble-cpp/src/NimBLEService.cpp
@@ -159,7 +159,7 @@ bool NimBLEService::start() {
             // Nimble requires the last characteristic to have it's uuid = 0 to indicate the end
             // of the characteristics for the service. We create 1 extra and set it to null
             // for this purpose.
-            pChr_a = new ble_gatt_chr_def[numChrs + 1];
+            pChr_a = new ble_gatt_chr_def[numChrs + 1]{};
             int i = 0;
             for(auto chr_it = m_chrVec.begin(); chr_it != m_chrVec.end(); ++chr_it) {
                 if((*chr_it)->m_removed > 0) {


### PR DESCRIPTION
## Description:

Fixes crashes with recent versions of IDF 5.x / Core 3.x.

https://github.com/h2zero/esp-nimble-cpp/pull/150

Prevents crash with WiFi-Improv via BLE in Tasmota with Core 3 builds.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
