### PR TITLE
Breaking!!: remove dedicated touch driver from build lvgl

### DIFF
--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -325,10 +325,10 @@
 #define USE_MLX90614
 #define USE_UNIVERSAL_DISPLAY
 #define USE_UNIVERSAL_TOUCH
-#define USE_XPT2046
-#define USE_FT5206
-#define USE_GT911
-#define USE_CST816S
+//#define USE_XPT2046
+//#define USE_FT5206
+//#define USE_GT911
+//#define USE_CST816S
 #define USE_DISPLAY_LVGL_ONLY
 
 //#undef USE_DISPLAY_MODES1TO5


### PR DESCRIPTION
from now on only UTouch driver is active. Which can replace all dedicated touch drivers.

The `display.ini` needs to be adopted from dedicated driver settings to UTouch driver settings. Details in the documentation. https://tasmota.github.io/docs/Displays/#universal-touch-driver

fyi @gemu2015 @s-hadinger 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
