### PR TITLE
Berry prepare compilation on 64bits platforms

### DIFF
--- a/lib/libesp32/berry/src/be_solidifylib.c
+++ b/lib/libesp32/berry/src/be_solidifylib.c
@@ -147,7 +147,7 @@ static void m_solidify_map(bvm *vm, bbool str_literal, bmap * map, const char *c
 #if BE_INTGER_TYPE == 2
             logfmt("        { be_const_key_int(%lli, %i), ", node->key.v.i, key_next);
 #else
-            logfmt("        { be_const_key_int(%i, %i), ", node->key.v.i, key_next);
+            logfmt("        { be_const_key_int(%li, %i), ", node->key.v.i, key_next);
 #endif
             m_solidify_bvalue(vm, str_literal, &node->value, class_name, NULL, fout);
         } else {
@@ -190,14 +190,14 @@ static void m_solidify_bvalue(bvm *vm, bbool str_literal, bvalue * value, const 
 #if BE_INTGER_TYPE == 2
         logfmt("be_const_int(%lli)", var_toint(value));
 #else
-        logfmt("be_const_int(%i)", var_toint(value));
+        logfmt("be_const_int(%li)", var_toint(value));
 #endif
         break;
     case BE_INDEX:
 #if BE_INTGER_TYPE == 2
         logfmt("be_const_var(%lli)", var_toint(value));
 #else
-        logfmt("be_const_var(%i)", var_toint(value));
+        logfmt("be_const_var(%li)", var_toint(value));
 #endif
         break;
     case BE_REAL:

--- a/lib/libesp32/berry_mapping/src/be_class_wrapper.c
+++ b/lib/libesp32/berry_mapping/src/be_class_wrapper.c
@@ -169,7 +169,7 @@ int be_find_global_or_module_member(bvm *vm, const char * name) {
 // if object instance, get `_p` member and convert it recursively
 intptr_t be_convert_single_elt(bvm *vm, int idx, const char * arg_type, int *buf_len) {
   // berry_log_C("be_convert_single_elt(idx=%i, argtype='%s', type=%s)", idx, arg_type ? arg_type : "", be_typename(vm, idx));
-  int ret = 0;
+  intptr_t ret = 0;
   char provided_type = 0;
   idx = be_absindex(vm, idx);   // make sure we have an absolute index
   
@@ -237,7 +237,7 @@ intptr_t be_convert_single_elt(bvm *vm, int idx, const char * arg_type, int *buf
     // check if the instance is a subclass of `bytes()``
     if (be_isbytes(vm, idx)) {
       size_t len;
-      intptr_t ret = (intptr_t) be_tobytes(vm, idx, &len);
+      ret = (intptr_t) be_tobytes(vm, idx, &len);
       if (buf_len) { *buf_len = (int) len; }
       return ret;
     } else {
@@ -246,7 +246,7 @@ intptr_t be_convert_single_elt(bvm *vm, int idx, const char * arg_type, int *buf
         be_pop(vm, 1);    // remove `nil`
         be_getmember(vm, idx, ".p");
       } // else `nil` is on top of stack
-      int32_t ret = be_convert_single_elt(vm, -1, NULL, NULL);   // recurse
+      ret = be_convert_single_elt(vm, -1, NULL, NULL);   // recurse
       be_pop(vm, 1);
 
       if (arg_type_len > 1) {


### PR DESCRIPTION
## Description:

Berry:
- fix compilation warnings in solidify
- prepare for compilation on 64 bits platform with 32 bits integers, will be used for unit tests

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
