### PR TITLE
Berry compile local Berry with int64

### DIFF
--- a/lib/libesp32/berry/Makefile
+++ b/lib/libesp32/berry/Makefile
@@ -1,4 +1,4 @@
-CFLAGS      = -Wall -Wextra -std=c99 -O2 -Wno-zero-length-array -Wno-empty-translation-unit
+CFLAGS      = -Wall -Wextra -std=c99 -O2 -Wno-zero-length-array -Wno-empty-translation-unit -DUSE_BERRY_INT64
 DEBUG_FLAGS = -O0 -g -DBE_DEBUG
 TEST_FLAGS  = $(DEBUG_FLAGS) --coverage -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined
 LIBS        = -lm
@@ -7,8 +7,8 @@ CC          = clang # install clang!! gcc seems to produce a defect berry binary
 MKDIR       = mkdir
 LFLAGS      =
 
-INCPATH     = src default ../re1.5
-SRCPATH     = src default ../re1.5
+INCPATH     = src default ../re1.5 ../berry_mapping/src ../berry_int64/src generate
+SRCPATH     = src default ../re1.5 ../berry_mapping/src ../berry_int64/src
 GENERATE    = generate
 CONFIG      = default/berry_conf.h
 COC         = tools/coc/coc

--- a/lib/libesp32/berry/default/be_modtab.c
+++ b/lib/libesp32/berry/default/be_modtab.c
@@ -308,10 +308,11 @@ BERRY_LOCAL bclass_array be_class_table = {
     &be_native_class(AudioOpusDecoder),
     &be_native_class(AudioInputI2S),
 #endif // defined(USE_I2S_AUDIO_BERRY) && (ESP_IDF_VERSION_MAJOR >= 5)
+#endif // TASMOTA
+
 #if defined(USE_BERRY_INT64) || defined(USE_MATTER_DEVICE)
     &be_native_class(int64),
 #endif
-#endif // TASMOTA
     NULL, /* do not remove */
 };
 

--- a/lib/libesp32/berry/default/berry.c
+++ b/lib/libesp32/berry/default/berry.c
@@ -14,6 +14,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "be_mapping.h"
+
 /* using GNU/readline library */
 #if defined(USE_READLINE_LIB)
     #include <readline/readline.h>
@@ -403,6 +405,7 @@ int main(int argc, char *argv[])
 {
     int res;
     bvm *vm = be_vm_new(); /* create a virtual machine instance */
+    be_set_ctype_func_hanlder(vm, be_call_ctype_func);
     res = analysis_args(vm, argc, argv);
     be_vm_delete(vm); /* free all objects and vm */
     return res;

--- a/lib/libesp32/berry/src/be_solidifylib.c
+++ b/lib/libesp32/berry/src/be_solidifylib.c
@@ -147,7 +147,7 @@ static void m_solidify_map(bvm *vm, bbool str_literal, bmap * map, const char *c
 #if BE_INTGER_TYPE == 2
             logfmt("        { be_const_key_int(%lli, %i), ", node->key.v.i, key_next);
 #else
-            logfmt("        { be_const_key_int(%li, %i), ", node->key.v.i, key_next);
+            logfmt("        { be_const_key_int(%i, %i), ", node->key.v.i, key_next);
 #endif
             m_solidify_bvalue(vm, str_literal, &node->value, class_name, NULL, fout);
         } else {
@@ -190,14 +190,14 @@ static void m_solidify_bvalue(bvm *vm, bbool str_literal, bvalue * value, const 
 #if BE_INTGER_TYPE == 2
         logfmt("be_const_int(%lli)", var_toint(value));
 #else
-        logfmt("be_const_int(%li)", var_toint(value));
+        logfmt("be_const_int(%i)", var_toint(value));
 #endif
         break;
     case BE_INDEX:
 #if BE_INTGER_TYPE == 2
         logfmt("be_const_var(%lli)", var_toint(value));
 #else
-        logfmt("be_const_var(%li)", var_toint(value));
+        logfmt("be_const_var(%i)", var_toint(value));
 #endif
         break;
     case BE_REAL:


### PR DESCRIPTION
## Description:

The local Berry binary is now compiled with `int64` class. This will allow Berry unit tests in CI.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
