### PR TITLE
Core 2015

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.14
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.15
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -93,8 +93,8 @@ lib_ignore                  =
 
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.01.01/platform-espressif32.zip
-platform_packages           = tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v4.7.2/esptool.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.04.00/platform-espressif32.zip
+platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 


### PR DESCRIPTION
## Description:

@arendst Update to Tasmota Core 2.0.15. Some bug fixes are done compared to core 2.0.14. No breaking changes.
It is okay to stay on 2.0.14 and we move directly to core 3.0.0 (when it is ready...)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.15
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
