### PR TITLE
Fade out on CCT bulb with `SO92 1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - NeoPool hydrolysis unit for Hidrolife, Bionet and Generic device (#21098)
 - M5Core2 LoRa868 module receive exception
+- Fade out on CCT bulb with `SO92 1`
 
 ### Removed
 - Unused `#define MQTT_DATA_STRING` support

--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -2412,7 +2412,6 @@ void calcGammaBulbs(uint16_t cur_col_10[5]) {
   if (ChannelCT() >= 0) {
     // Need to compute white_bri10 and ct_10 from cur_col_10[] for compatibility with VirtualCT
     white_bri10 = cur_col_10[cw0] + cur_col_10[cw0+1];
-    ct_10 = changeUIntScale(cur_col_10[cw0+1], 0, white_bri10, 0, 1023);
     if (white_bri10 > 1023) {
       // In white_free_cw mode, the combined brightness of cw and ww may be larger than 1023.
       // This cannot be represented in pwm_ct_mode, so we set the maximum brightness instead.


### PR DESCRIPTION
## Description:

Fixes regression introduced in https://github.com/arendst/Tasmota/commit/9d57a19be3b2d48acb2885dd8435cd0bc204b029

The `ct_10` must not be adjusted according to brightness.

**Related issue (if applicable):** fixes #20945

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.15
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
