### PR TITLE
Matter include int64 in unit tests

### DIFF
--- a/lib/libesp32/berry_matter/solidify_all.be
+++ b/lib/libesp32/berry_matter/solidify_all.be
@@ -16,7 +16,6 @@ var globs = "path,ctypes_bytes_dyn,tasmota,ccronexpr,gpio,light,webclient,load,M
             "lv_clock,lv_clock_icon,lv_signal_arcs,lv_signal_bars,lv_wifi_arcs_icon,lv_wifi_arcs,"
             "lv_wifi_bars_icon,lv_wifi_bars,"
             "_lvgl,"
-            "int64"
 
 for g:string2.split(globs, ",")
   global.(g) = nil

--- a/lib/libesp32/berry_matter/src/embedded/Matter_zzz_TLV_test.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_zzz_TLV_test.be
@@ -54,12 +54,10 @@ test_TLV(bytes("24012a"), "1 = 42U")
 test_TLV(bytes("4401002a"), "Matter::0x00000001 = 42U")
 
 # int64
-if false      # int64 not yet working in local berry
 test_TLV(bytes("030102000000000000"), "513")
 test_TLV(bytes("070102000000000000"), "513U")
 test_TLV(bytes("03FFFFFFFFFFFFFFFF"), "-1")
 test_TLV(bytes("07FFFFFFFFFFFFFF7F"), "9223372036854775807U")
-end
 
 # structure
 test_TLV(bytes("1518"), "{}")


### PR DESCRIPTION
## Description:

Extend Matter unit tests to tests including `int64` now that the CI local `berry` binary is compiled with `int64` support.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.15
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
