### PR TITLE
Breaking: Use UDisplay and UTouch as only drivers in env "display"

### DIFF
--- a/tasmota/include/tasmota_configurations.h
+++ b/tasmota/include/tasmota_configurations.h
@@ -361,14 +361,17 @@
 //  #define USE_DISPLAY_TM1650                     // [DisplayModel 20] [I2cDriver74] Enable TM1650 display (I2C addresses 0x24 - 0x27 and 0x34 - 0x37)
 
 #define USE_SPI                                  // Hardware SPI using GPIO12(MISO), GPIO13(MOSI) and GPIO14(CLK) in addition to two user selectable GPIOs(CS and DC)
-  #define USE_DISPLAY_ILI9341                    // [DisplayModel 4] Enable ILI9341 Tft 480x320 display (+19k code)
-  #define USE_DISPLAY_EPAPER_29                  // [DisplayModel 5] Enable e-paper 2.9 inch display (+19k code)
-  #define USE_DISPLAY_EPAPER_42                  // [DisplayModel 6] Enable e-paper 4.2 inch display
+  // #define USE_DISPLAY_ILI9341                    // [DisplayModel 4] Enable ILI9341 Tft 480x320 display (+19k code)
+  // #define USE_DISPLAY_EPAPER_29                  // [DisplayModel 5] Enable e-paper 2.9 inch display (+19k code)
+  // #define USE_DISPLAY_EPAPER_42                  // [DisplayModel 6] Enable e-paper 4.2 inch display
   // #define USE_DISPLAY_ILI9488                    // [DisplayModel 8]
-  #define USE_DISPLAY_SSD1351                    // [DisplayModel 9]
-  #define USE_DISPLAY_RA8876                     // [DisplayModel 10]
-  #define USE_DISPLAY_ST7789                     // [DisplayModel 12] Enable ST7789 module
-  #define USE_DISPLAY_SSD1331                    // [DisplayModel 14] Enable SSD1331 module
+  // #define USE_DISPLAY_SSD1351                    // [DisplayModel 9]
+  // #define USE_DISPLAY_RA8876                     // [DisplayModel 10]
+  // #define USE_DISPLAY_ST7789                     // [DisplayModel 12] Enable ST7789 module
+  // #define USE_DISPLAY_SSD1331                    // [DisplayModel 14] Enable SSD1331 module
+
+#define USE_UNIVERSAL_DISPLAY
+#define USE_UNIVERSAL_TOUCH
 
 #undef DEBUG_THEO                                // Disable debug code
 #undef USE_DEBUG_DRIVER                          // Disable debug code


### PR DESCRIPTION
## Description:

Follow up of #21146

The 7 segment and other drivers of this kind are still active.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.15
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
