### PR TITLE
Berry fix for Ubuntu

### DIFF
--- a/lib/libesp32/berry/src/be_strlib.c
+++ b/lib/libesp32/berry/src/be_strlib.c
@@ -23,17 +23,17 @@
 
 static int str_strncasecmp(const char *s1, const char *s2, size_t n)
 {
-	if (n == 0) return 0;
+    if (n == 0) return 0;
 
-	while (n-- != 0 && tolower(*s1) == tolower(*s2)) {
-		if (n == 0 || *s1 == '\0' || *s2 == '\0')
-			break;
-		s1++;
-		s2++;
-	}
+    while (n-- != 0 && tolower(*s1) == tolower(*s2)) {
+        if (n == 0 || *s1 == '\0' || *s2 == '\0')
+            break;
+        s1++;
+        s2++;
+    }
 
-	return tolower(*(const unsigned char *)s1)
-		- tolower(*(const unsigned char *)s2);
+    return tolower(*(const unsigned char *)s1)
+        - tolower(*(const unsigned char *)s2);
 }
 
 typedef bint (*str_opfunc)(const char*, const char*, bint, bint);

--- a/lib/libesp32/berry_mapping/src/be_class_wrapper.c
+++ b/lib/libesp32/berry_mapping/src/be_class_wrapper.c
@@ -14,6 +14,9 @@
 #include <string.h>
 #include <stdlib.h>
 
+/* Ubuntu 22.04 LTS seems to have an invalid or missing signature for strtok_r, forcing a correct one */
+extern char *strtok_r(char *str, const char *delim, char **saveptr);
+
 typedef intptr_t (*fn_any_callable)(intptr_t p0, intptr_t p1, intptr_t p2, intptr_t p3,
                                     intptr_t p4, intptr_t p5, intptr_t p6, intptr_t p7);
 


### PR DESCRIPTION
## Description:

Fix CI problem on Ubuntu, where `strtok_r` seems to have missing or invalid signature. Quick fix; until someone has a good explanation for this problem.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.15
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
