### PR TITLE
Pio-tools: Exception decoder for remote devices

### DIFF
--- a/pio-tools/custom_target.py
+++ b/pio-tools/custom_target.py
@@ -19,11 +19,14 @@ import os
 import tasmotapiolib
 import subprocess
 import shutil
+import json
+from colorama import Fore, Back, Style
 
 Import("env")
 platform = env.PioPlatform()
 board = env.BoardConfig()
 mcu = board.get("build.mcu", "esp32")
+IS_WINDOWS = sys.platform.startswith("win")
 
 
 class FSType(Enum):
@@ -287,6 +290,51 @@ def upload_factory(*args, **kwargs):
         print("Flash firmware at address 0x0")
         subprocess.call(esptoolpy_cmd, shell=False)
 
+def esp32_use_external_crashreport(*args, **kwargs):
+    try:
+        crash_report = env.GetProjectOption("custom_crash_report")
+    except:
+        print(Fore.RED + "Did not find custom_crash_report section in the current environment!!")
+        return
+    try:
+        crash_report = json.loads(crash_report)
+    except:
+        print(Fore.RED + "No valid JSON, please use output of STATUS 12 in the console!!")
+        return
+    print(Fore.GREEN + "Use external crash report (STATUS 12) for debugging:\n", json.dumps(crash_report, sort_keys=True, indent=4))
+    epc = crash_report['StatusSTK']['EPC']
+    callchain = crash_report['StatusSTK']['CallChain']
+    addr2line = ""
+    for p in platform.get_installed_packages():
+        if "toolchain" in p.path:
+            files = os.listdir(join(p.path,"bin"))
+            for f in files:
+                if "addr2line" in f:
+                    addr2line = join(p.path,"bin",f)
+    elf_file = join(env.subst("$BUILD_DIR"),env.subst("${PROGNAME}.elf"))
+    if isfile(elf_file) is False:
+        print(Fore.RED+"Did not find firmware.elf ... please build the current environment first!!")
+        return
+    enc = "mbcs" if IS_WINDOWS else "utf-8"
+    output = (
+    subprocess.check_output([addr2line,"-e",elf_file,"-fC","-a",epc])
+    .decode(enc)
+    .strip()
+    .splitlines()
+    )
+    print(Fore.YELLOW + "There is no way to check, if this data is valid for the given firmware!!")
+    print(Fore.GREEN + "Crash at:")
+    print(Fore.YELLOW + output[0] + ": \n" + output[1] + " in " + output[2])
+    print(Fore.GREEN + "Callchain:")
+    for call in callchain:
+        output = (
+        subprocess.check_output([addr2line,"-e",elf_file,"-fC","-a",call])
+        .decode(enc)
+        .strip()
+        .splitlines()
+        )
+        print(Fore.YELLOW + output[0]+": \n"+output[1]+" in "+output[2])
+
 env.AddCustomTarget(
     name="downloadfs",
     dependencies=None,
@@ -305,4 +353,14 @@ env.AddCustomTarget(
     ],
     title="Flash factory",
     description="Flash factory firmware"
+)
+
+env.AddCustomTarget(
+    name="external_crashreport",
+    dependencies=None,
+    actions=[
+        esp32_use_external_crashreport
+    ],
+    title="External crash report",
+    description="Use external crashreport from Tasmotas console output of STATUS 12"
 )


### PR DESCRIPTION
## Description:

Simple developer tool to decode crash reports from devices not directly connected to your computer.

This works like that (could be simplified later):
1. Get crash report with STATUS 12 e.g.:
{"StatusSTK":{"Exception":28,"Reason":"LoadProhibited","EPC":"420060ed","EXCVADDR":"00000000","CallChain":["420060ea","42003d32","4200a032","4200a126","4200b7b1","4207d79b"]}}

2. Recreate the exact build environement for this firmware and add a custom entry:
custom_crash_report       = {"StatusSTK":{"Exception":28,"Reason":"LoadProhibited","EPC":"420060ed","EXCVADDR":"00000000","CallChain":["420060ea","42003d32","4200a032","4200a126","4200b7b1","4207d79b"]}}

3. Build the firmware.
4. Launch from custom build tasks: External crash reports
5. You get a console output with address, function and code line, which is clickable in VSCode.

There is for sure room for improvement.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.15
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
