### PR TITLE
safeboot: don't publish sensor values

### DIFF
--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -1021,6 +1021,7 @@ bool MqttShowSensor(bool call_show_sensor) {
 
   GetSensorValues();
 
+#ifndef FIRMWARE_SAFEBOOT
   if (TasmotaGlobal.global_update && Settings->flag.mqtt_add_global_info) {  // SetOption2 (MQTT) Add global temperature/humidity/pressure info to JSON sensor message
     if ((TasmotaGlobal.humidity > 0) || !isnan(TasmotaGlobal.temperature_celsius) || (TasmotaGlobal.pressure_hpa != 0)) {
       uint32_t add_comma = 0;
@@ -1055,6 +1056,7 @@ bool MqttShowSensor(bool call_show_sensor) {
       ResponseJsonEnd();
     }
   }
+#endif // FIRMWARE_SAFEBOOT
 
   bool json_data_available = (ResponseLength() - json_data_start);
   MqttAppendSensorUnits();


### PR DESCRIPTION
## Description:

Do not include code to publish sensor values when in safeboot, knowing that anyways the sensors are not enabled. Saves 880 bytes in safeboot.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
