### PR TITLE
Re enable Ethernet in safeboot for ESP32

### DIFF
--- a/.github/workflows/build_all_the_things.yml
+++ b/.github/workflows/build_all_the_things.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: true
       matrix:
         variant:
-          - tasmota32-safeboot
+          - tasmota32solo1-safeboot
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -105,7 +105,7 @@ jobs:
           - tasmota32s2cdc
           - tasmota32s3cdc
           - tasmota32solo1
-          - tasmota32solo1-safeboot
+          - tasmota32-safeboot
           - tasmota32s2-safeboot
           - tasmota32s2cdc-safeboot
           - tasmota32s3-safeboot

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -129,7 +129,7 @@ def patch_partitions_bin(size_string):
 def esp32_create_chip_string(chip):
     tasmota_platform_org = env.subst("$BUILD_DIR").split(os.path.sep)[-1]
     tasmota_platform = tasmota_platform_org.split('-')[0]
-    if ("CORE32SOLO1" in extra_flags or "FRAMEWORK_ARDUINO_SOLO1" in build_flags) and "tasmota32solo1" not in tasmota_platform_org:
+    if ("CORE32SOLO1" in extra_flags or "FRAMEWORK_ARDUINO_SOLO1" in build_flags) and "tasmota32-safeboot" not in tasmota_platform_org and "tasmota32solo1" not in tasmota_platform_org:
         print(Fore.YELLOW + "Unexpected naming convention in this build environment:" + Fore.RED, tasmota_platform_org)
         print(Fore.YELLOW + "Expected build environment name like " + Fore.GREEN + "'tasmota32solo1-whatever-you-want'")
         print(Fore.YELLOW + "Please correct your actual build environment, to avoid undefined behavior in build process!!")

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -77,7 +77,7 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.04.11/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.04.12/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -28,6 +28,7 @@ custom_files_upload     = no_files
 
 [env:tasmota32-safeboot]
 extends                 = env:tasmota32_base
+board                   = esp32_solo1
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFRAMEWORK_ARDUINO_SOLO1
                           -DFIRMWARE_SAFEBOOT

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -29,6 +29,7 @@ custom_files_upload     = no_files
 [env:tasmota32-safeboot]
 extends                 = env:tasmota32_base
 build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFRAMEWORK_ARDUINO_SOLO1
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -58,7 +58,7 @@
 #undef USE_HOME_ASSISTANT                        // Disable Home Assistant
 #undef USE_TASMOTA_DISCOVERY                     // Disable Tasmota Discovery support (+2k code)
 #undef USE_TELEGRAM                              // Disable support for Telegram protocol (+49k code, +7.0k mem and +4.8k additional during connection handshake)
-//#undef USE_MQTT_TLS                              // Disable TLS support won't work as the MQTTHost is not set
+#undef USE_MQTT_TLS                              // Disable TLS support won't work as the MQTTHost is not set
 #undef USE_KNX                                   // Disable KNX IP Protocol Support
 //#undef USE_WEBSERVER                             // Disable Webserver
 #undef USE_GPIO_VIEWER                           // Enable GPIO Viewer to see realtime GPIO states (+5k6 code)
@@ -187,11 +187,12 @@
 #define USE_WEBCLIENT
 #define USE_WEBCLIENT_HTTPS
 
-// FIX ME Safeboot for ESP32 and ESP32solo1 to big with Core 3.0.0
-//#if CONFIG_IDF_TARGET_ESP32
-//  #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge console Tee (+2k code)
-//  #define USE_ETHERNET
-//#endif  // CONFIG_IDF_TARGET_ESP32
+#if CONFIG_IDF_TARGET_ESP32
+#if CONFIG_FREERTOS_UNICORE
+  #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge console Tee (+2k code)
+  #define USE_ETHERNET
+#endif  // CONFIG_FREERTOS_UNICORE
+#endif  // CONFIG_IDF_TARGET_ESP32
 
 #endif  // FIRMWARE_SAFEBOOT
 


### PR DESCRIPTION
## Description:

by using the Arduino Solo1 framework. The framework has a smaller flash usage

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
