### PR TITLE
Fix HASPmota dropdown class "options" attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 Framework (Arduino Core) from v2.0.15 to v3.0.0 (#21180)
 
 ### Fixed
+- HASPmota dropdown class "options" attribute
 
 ### Removed
 - Support for ESP32 Arduino Core 2 (#21180)

--- a/lib/libesp32_lvgl/lv_haspmota/src/embedded/lv_haspmota.be
+++ b/lib/libesp32_lvgl/lv_haspmota/src/embedded/lv_haspmota.be
@@ -1425,13 +1425,6 @@ class lvh_dropdown : lvh_obj
     return self._lv_obj.get_selected()
   end
 
-  def set_options(t)
-    self._lv_obj.set_options(t, lv.ROLLER_MODE_NORMAL)
-  end
-  def get_options()
-    return self._lv_obj.get_options()
-  end
-
   def set_text(t)
     # set_text sets a static text displayed whatever the value
     # use `nil` to set back the text of the selected value

--- a/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
+++ b/lib/libesp32_lvgl/lv_haspmota/src/solidify/solidified_lv_haspmota.h
@@ -6703,6 +6703,85 @@ void be_load_lvh_led_class(bvm *vm) {
 extern const bclass be_class_lvh_dropdown;
 
 /********************************************************************
+** Solidified function: get_direction
+********************************************************************/
+be_local_closure(lvh_dropdown_get_direction,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(get_dir),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(_dir),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(get_direction),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x58080002,  //  0003  LDCONST	R2	K2
+      0x600C000C,  //  0004  GETGBL	R3	G12
+      0x88100103,  //  0005  GETMBR	R4	R0	K3
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0x140C0403,  //  0007  LT	R3	R2	R3
+      0x780E0006,  //  0008  JMPF	R3	#0010
+      0x880C0103,  //  0009  GETMBR	R3	R0	K3
+      0x940C0602,  //  000A  GETIDX	R3	R3	R2
+      0x1C0C0203,  //  000B  EQ	R3	R1	R3
+      0x780E0000,  //  000C  JMPF	R3	#000E
+      0x80040400,  //  000D  RET	1	R2
+      0x00080504,  //  000E  ADD	R2	R2	K4
+      0x7001FFF3,  //  000F  JMP		#0004
+      0x540DFFFE,  //  0010  LDINT	R3	-1
+      0x80040600,  //  0011  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_show_selected
+********************************************************************/
+be_local_closure(lvh_dropdown_get_show_selected,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(get_text),
+    }),
+    be_str_weak(get_show_selected),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x4C080000,  //  0003  LDNIL	R2
+      0x1C080202,  //  0004  EQ	R2	R1	R2
+      0x80040400,  //  0005  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: get_val
 ********************************************************************/
 be_local_closure(lvh_dropdown_get_val,   /* name */
@@ -6726,6 +6805,104 @@ be_local_closure(lvh_dropdown_get_val,   /* name */
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_text
+********************************************************************/
+be_local_closure(lvh_dropdown_set_text,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(set_text),
+    }),
+    be_str_weak(set_text),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_show_selected
+********************************************************************/
+be_local_closure(lvh_dropdown_set_show_selected,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_lv_obj),
+    /* K1   */  be_nested_str_weak(set_text),
+    }),
+    be_str_weak(set_show_selected),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x78060003,  //  0000  JMPF	R1	#0005
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x4C100000,  //  0003  LDNIL	R4
+      0x7C080400,  //  0004  CALL	R2	2
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_val
+********************************************************************/
+be_local_closure(lvh_dropdown_set_val,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_val),
+    /* K1   */  be_nested_str_weak(_lv_obj),
+    /* K2   */  be_nested_str_weak(set_selected),
+    /* K3   */  be_const_int(0),
+    }),
+    be_str_weak(set_val),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x5C100200,  //  0003  MOVE	R4	R1
+      0x58140003,  //  0004  LDCONST	R5	K3
+      0x7C080600,  //  0005  CALL	R2	3
+      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -6762,76 +6939,6 @@ be_local_closure(lvh_dropdown_set_direction,   /* name */
       0x94100A04,  //  0006  GETIDX	R4	R5	R4
       0x7C080400,  //  0007  CALL	R2	2
       0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_options
-********************************************************************/
-be_local_closure(lvh_dropdown_set_options,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_options),
-    /* K2   */  be_nested_str_weak(lv),
-    /* K3   */  be_nested_str_weak(ROLLER_MODE_NORMAL),
-    }),
-    be_str_weak(set_options),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0xB8160400,  //  0003  GETNGBL	R5	K2
-      0x88140B03,  //  0004  GETMBR	R5	R5	K3
-      0x7C080600,  //  0005  CALL	R2	3
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_val
-********************************************************************/
-be_local_closure(lvh_dropdown_set_val,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_val),
-    /* K1   */  be_nested_str_weak(_lv_obj),
-    /* K2   */  be_nested_str_weak(set_selected),
-    /* K3   */  be_const_int(0),
-    }),
-    be_str_weak(set_val),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x5C100200,  //  0003  MOVE	R4	R1
-      0x58140003,  //  0004  LDCONST	R5	K3
-      0x7C080600,  //  0005  CALL	R2	3
-      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -6897,195 +7004,17 @@ be_local_closure(lvh_dropdown_get_text,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_direction
-********************************************************************/
-be_local_closure(lvh_dropdown_get_direction,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_dir),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(_dir),
-    /* K4   */  be_const_int(1),
-    }),
-    be_str_weak(get_direction),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x58080002,  //  0003  LDCONST	R2	K2
-      0x600C000C,  //  0004  GETGBL	R3	G12
-      0x88100103,  //  0005  GETMBR	R4	R0	K3
-      0x7C0C0200,  //  0006  CALL	R3	1
-      0x140C0403,  //  0007  LT	R3	R2	R3
-      0x780E0006,  //  0008  JMPF	R3	#0010
-      0x880C0103,  //  0009  GETMBR	R3	R0	K3
-      0x940C0602,  //  000A  GETIDX	R3	R3	R2
-      0x1C0C0203,  //  000B  EQ	R3	R1	R3
-      0x780E0000,  //  000C  JMPF	R3	#000E
-      0x80040400,  //  000D  RET	1	R2
-      0x00080504,  //  000E  ADD	R2	R2	K4
-      0x7001FFF3,  //  000F  JMP		#0004
-      0x540DFFFE,  //  0010  LDINT	R3	-1
-      0x80040600,  //  0011  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_show_selected
-********************************************************************/
-be_local_closure(lvh_dropdown_set_show_selected,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_text),
-    }),
-    be_str_weak(set_show_selected),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x78060003,  //  0000  JMPF	R1	#0005
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x4C100000,  //  0003  LDNIL	R4
-      0x7C080400,  //  0004  CALL	R2	2
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_text
-********************************************************************/
-be_local_closure(lvh_dropdown_set_text,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(set_text),
-    }),
-    be_str_weak(set_text),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_options
-********************************************************************/
-be_local_closure(lvh_dropdown_get_options,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_options),
-    }),
-    be_str_weak(get_options),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_show_selected
-********************************************************************/
-be_local_closure(lvh_dropdown_get_show_selected,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_lv_obj),
-    /* K1   */  be_nested_str_weak(get_text),
-    }),
-    be_str_weak(get_show_selected),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x4C080000,  //  0003  LDNIL	R2
-      0x1C080202,  //  0004  EQ	R2	R1	R2
-      0x80040400,  //  0005  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: lvh_dropdown
 ********************************************************************/
 extern const bclass be_class_lvh_obj;
 be_local_class(lvh_dropdown,
     0,
     &be_class_lvh_obj,
-    be_nested_map(12,
+    be_nested_map(10,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(get_show_selected, 8), be_const_closure(lvh_dropdown_get_show_selected_closure) },
-        { be_const_key_weak(set_direction, -1), be_const_closure(lvh_dropdown_set_direction_closure) },
-        { be_const_key_weak(set_options, -1), be_const_closure(lvh_dropdown_set_options_closure) },
-        { be_const_key_weak(set_val, 4), be_const_closure(lvh_dropdown_set_val_closure) },
         { be_const_key_weak(get_text, -1), be_const_closure(lvh_dropdown_get_text_closure) },
-        { be_const_key_weak(get_direction, 9), be_const_closure(lvh_dropdown_get_direction_closure) },
-        { be_const_key_weak(_lv_class, -1), be_const_class(be_class_lv_dropdown) },
-        { be_const_key_weak(set_show_selected, 6), be_const_closure(lvh_dropdown_set_show_selected_closure) },
-        { be_const_key_weak(set_text, -1), be_const_closure(lvh_dropdown_set_text_closure) },
+        { be_const_key_weak(get_show_selected, 2), be_const_closure(lvh_dropdown_get_show_selected_closure) },
+        { be_const_key_weak(set_direction, 8), be_const_closure(lvh_dropdown_set_direction_closure) },
         { be_const_key_weak(_dir, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(4,
     ( (struct bvalue*) &(const bvalue[]) {
@@ -7094,8 +7023,12 @@ be_local_class(lvh_dropdown,
         be_const_int(1),
         be_const_int(2),
     }))    ) } )) },
-        { be_const_key_weak(get_options, -1), be_const_closure(lvh_dropdown_get_options_closure) },
-        { be_const_key_weak(get_val, 0), be_const_closure(lvh_dropdown_get_val_closure) },
+        { be_const_key_weak(set_show_selected, -1), be_const_closure(lvh_dropdown_set_show_selected_closure) },
+        { be_const_key_weak(set_text, 6), be_const_closure(lvh_dropdown_set_text_closure) },
+        { be_const_key_weak(set_val, 4), be_const_closure(lvh_dropdown_set_val_closure) },
+        { be_const_key_weak(_lv_class, -1), be_const_class(be_class_lv_dropdown) },
+        { be_const_key_weak(get_val, -1), be_const_closure(lvh_dropdown_get_val_closure) },
+        { be_const_key_weak(get_direction, 0), be_const_closure(lvh_dropdown_get_direction_closure) },
     })),
     be_str_weak(lvh_dropdown)
 );


### PR DESCRIPTION
## Description:

Fix HASPmota dropdown class "options" attribute, cf Discord.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
