### PR TITLE
Added support for sending binary data with Publish command

### DIFF
--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -590,6 +590,33 @@ char* Trim(char* p) {
   return p;
 }
 
+size_t HexStringToBinaryString(char** source) {
+  size_t str_len = strlen(*source+2);
+  char *s = *source+2;
+  char *new_str = (char *)malloc(str_len/2);
+  for (int i = 0; i < str_len; i++) {
+        unsigned char val;
+        char cur = s[i];
+        if (cur >= 97) {
+            val = cur - 97 + 10;
+        } else if (cur >= 65) {
+            val = cur - 65 + 10;
+        } else {
+            val = cur - 48;
+        }
+        /* even characters are the first half, odd characters the second half
+         * of the current output byte */
+        if (i%2 == 0) {
+            new_str[i/2] = val << 4;
+        } else {
+            new_str[i/2] |= val;
+        }
+    }
+    memcpy(*source, new_str, str_len/2);
+    free(new_str);
+    return str_len/2;
+}
+
 String HexToString(uint8_t* data, uint32_t length) {
   if (!data || !length) { return ""; }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -737,6 +737,21 @@ void MqttPublishPayload(const char* topic, const char* payload) {
   MqttPublishPayload(topic, payload, 0, false);
 }
 
+void MqttPublish(const char* topic, bool retained, bool binary) {
+  // Publish <topic> default ResponseData string with optional retained
+  char* response_data;
+  uint32_t binary_length = 0;
+  response_data = ResponseData();
+
+  if (binary) {
+    if (strlen(response_data) > 3 && strncmp(response_data, "0x", 2) == 0) {
+      binary_length = HexStringToBinaryString(&response_data);
+    }
+  }
+
+  MqttPublishPayload(topic, response_data, binary_length, retained);
+}
+
 void MqttPublish(const char* topic, bool retained) {
   // Publish <topic> default ResponseData string with optional retained
   MqttPublishPayload(topic, ResponseData(), 0, retained);
@@ -1547,7 +1562,7 @@ void CmndPublish(void) {
       } else {
         ResponseClear();
       }
-      MqttPublish(stemp1, (XdrvMailbox.index == 2));
+      MqttPublish(stemp1, (XdrvMailbox.index & 0b10), (XdrvMailbox.index & 0b01));
       ResponseClear();
     }
   }


### PR DESCRIPTION
## Description:

Add ability to the Publish command to send a hexstring as binary MQTT data.

Publish command now has the following options

`0 = <topic> <payload> = MQTT publish any topic and optional payload (default)`
`1 = <topic> <payload> = MQTT publish any topic and optional binary payload. Example the payload 0x7461736D6F7461 will output tasmota`
`2 = <topic> <payload> = MQTT publish any topic and optional payload with retain flag`
`3 = <topic> <payload> = MQTT publish any topic and optional binary payload with retain flag`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
