### PR TITLE
remove extension cdc from C3,C6,S3 variants

### DIFF
--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -98,13 +98,13 @@ jobs:
           - tasmota32solo1-safeboot
           - tasmota32c2-safeboot
           - tasmota32c3-safeboot
-          - tasmota32c3cdc-safeboot
+          - tasmota32c3ser-safeboot
           - tasmota32s2-safeboot
           - tasmota32s2cdc-safeboot
           - tasmota32s3-safeboot
-          - tasmota32s3cdc-safeboot
+          - tasmota32s3ser-safeboot
           - tasmota32c6-safeboot
-          - tasmota32c6cdc-safeboot
+          - tasmota32c6ser-safeboot
     steps:
       - uses: actions/checkout@v4
         with:
@@ -194,11 +194,11 @@ jobs:
           - tasmota32-ir
           - tasmota32-lvgl
           - tasmota32c2
-          - tasmota32c3cdc
-          - tasmota32c6cdc
+          - tasmota32c3
+          - tasmota32c6
           - tasmota32s2
           - tasmota32s2cdc
-          - tasmota32s3cdc
+          - tasmota32s3
           - tasmota32solo1
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -21,17 +21,17 @@ jobs:
     strategy:
       matrix:
         variant:
-          - tasmota32solo1-safeboot
           - tasmota32-safeboot
+          - tasmota32solo1-safeboot
           - tasmota32c2-safeboot
           - tasmota32c3-safeboot
-          - tasmota32c3cdc-safeboot
+          - tasmota32c3ser-safeboot
           - tasmota32s2-safeboot
           - tasmota32s2cdc-safeboot
           - tasmota32s3-safeboot
-          - tasmota32s3cdc-safeboot
+          - tasmota32s3ser-safeboot
           - tasmota32c6-safeboot
-          - tasmota32c6cdc-safeboot
+          - tasmota32c6ser-safeboot
     steps:
       - uses: actions/checkout@v4
         with:
@@ -114,11 +114,11 @@ jobs:
           - tasmota32-ir
           - tasmota32-lvgl
           - tasmota32c2
-          - tasmota32c3cdc
-          - tasmota32c6cdc
+          - tasmota32c3
+          - tasmota32c6
           - tasmota32s2
           - tasmota32s2cdc
-          - tasmota32s3cdc
+          - tasmota32s3
           - tasmota32solo1
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_all_the_things.yml
+++ b/.github/workflows/build_all_the_things.yml
@@ -91,8 +91,13 @@ jobs:
           - tasmota-sensors
           - tasmota-zbbridge
           - tasmota32
+          - tasmota32solo1
           - tasmota32c2
+          - tasmota32c3
+          - tasmota32c6
           - tasmota32s2
+          - tasmota32s2cdc
+          - tasmota32s3
           - tasmota32-zbbrdgpro
           - tasmota-zigbee
           - tasmota32-bluetooth
@@ -100,19 +105,13 @@ jobs:
           - tasmota32-display
           - tasmota32-ir
           - tasmota32-lvgl
-          - tasmota32c3cdc
-          - tasmota32c6cdc
-          - tasmota32s2cdc
-          - tasmota32s3cdc
-          - tasmota32solo1
           - tasmota32-safeboot
           - tasmota32s2-safeboot
           - tasmota32s2cdc-safeboot
           - tasmota32s3-safeboot
           - tasmota32c2-safeboot
-          - tasmota32s3cdc-safeboot
-          - tasmota32c3cdc-safeboot
-          - tasmota32c6cdc-safeboot
+          - tasmota32c3-safeboot
+          - tasmota32c6-safeboot
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -1,7 +1,7 @@
 {
     "build": {
       "core": "esp32",
-      "extra_flags": "-DARDUINO_TASMOTA -DESP32_4M -DESP32C3",
+      "extra_flags": "-DARDUINO_TASMOTA -DARDUINO_USB_MODE=1 -DESP32_4M -DESP32C3 -DUSE_USB_CDC_CONSOLE",
       "f_cpu": "160000000L",
       "f_flash": "80000000L",
       "flash_mode": "dio",
@@ -14,6 +14,10 @@
       "bluetooth"
     ],
     "debug": {
+      "default_tool": "esp-builtin",
+      "onboard_tools": [
+        "esp-builtin"
+      ],
       "openocd_target": "esp32c3.cfg"
     },
     "frameworks": [
@@ -33,10 +37,10 @@
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
       "require_upload_port": true,
-      "speed": 460800
+      "speed": 2000000
     },
     "download": {
-      "speed": 230400
+      "speed": 2000000
     },
     "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html",
     "vendor": "Espressif"

--- a/boards/esp32c3ser.json
+++ b/boards/esp32c3ser.json
@@ -1,7 +1,7 @@
 {
     "build": {
       "core": "esp32",
-      "extra_flags": "-DARDUINO_TASMOTA -DARDUINO_USB_MODE=1 -DESP32_4M -DESP32C3 -DUSE_USB_CDC_CONSOLE",
+      "extra_flags": "-DARDUINO_TASMOTA -DESP32_4M -DESP32C3",
       "f_cpu": "160000000L",
       "f_flash": "80000000L",
       "flash_mode": "dio",
@@ -14,10 +14,6 @@
       "bluetooth"
     ],
     "debug": {
-      "default_tool": "esp-builtin",
-      "onboard_tools": [
-        "esp-builtin"
-      ],
       "openocd_target": "esp32c3.cfg"
     },
     "frameworks": [
@@ -29,7 +25,7 @@
         "flash_extra_images": [
           [
             "0x10000",
-            "tasmota32c3cdc-safeboot.bin"
+            "tasmota32c3ser-safeboot.bin"
           ]
         ]
       },
@@ -37,10 +33,10 @@
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
       "require_upload_port": true,
-      "speed": 2000000
+      "speed": 460800
     },
     "download": {
-      "speed": 2000000
+      "speed": 230400
     },
     "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html",
     "vendor": "Espressif"

--- a/boards/esp32c6.json
+++ b/boards/esp32c6.json
@@ -1,7 +1,7 @@
 {
     "build": {
       "core": "esp32",
-      "extra_flags": "-DARDUINO_TASMOTA -DESP32_4M -DESP32C6",
+      "extra_flags": "-DARDUINO_TASMOTA -DARDUINO_USB_MODE=1 -DESP32_4M -DESP32C6 -DUSE_USB_CDC_CONSOLE",
       "f_cpu": "160000000L",
       "f_flash": "80000000L",
       "flash_mode": "qio",
@@ -14,6 +14,10 @@
       "bluetooth"
     ],
     "debug": {
+      "default_tool": "esp-builtin",
+      "onboard_tools": [
+        "esp-builtin"
+      ],
       "openocd_target": "esp32c6.cfg"
     },
     "frameworks": [
@@ -33,10 +37,10 @@
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
       "require_upload_port": true,
-      "speed": 460800
+      "speed": 2000000
     },
     "download": {
-      "speed": 230400
+      "speed": 2000000
     },
     "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/index.html",
     "vendor": "Espressif"

--- a/boards/esp32c6ser.json
+++ b/boards/esp32c6ser.json
@@ -1,7 +1,7 @@
 {
     "build": {
       "core": "esp32",
-      "extra_flags": "-DARDUINO_TASMOTA -DARDUINO_USB_MODE=1 -DESP32_4M -DESP32C6 -DUSE_USB_CDC_CONSOLE",
+      "extra_flags": "-DARDUINO_TASMOTA -DESP32_4M -DESP32C6",
       "f_cpu": "160000000L",
       "f_flash": "80000000L",
       "flash_mode": "qio",
@@ -14,10 +14,6 @@
       "bluetooth"
     ],
     "debug": {
-      "default_tool": "esp-builtin",
-      "onboard_tools": [
-        "esp-builtin"
-      ],
       "openocd_target": "esp32c6.cfg"
     },
     "frameworks": [
@@ -29,7 +25,7 @@
         "flash_extra_images": [
           [
             "0x10000",
-            "tasmota32c6cdc-safeboot.bin"
+            "tasmota32c6ser-safeboot.bin"
           ]
         ]
       },
@@ -37,10 +33,10 @@
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
       "require_upload_port": true,
-      "speed": 2000000
+      "speed": 460800
     },
     "download": {
-      "speed": 2000000
+      "speed": 230400
     },
     "url": "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitc-1/index.html",
     "vendor": "Espressif"

--- a/boards/esp32s3-opi_opi.json
+++ b/boards/esp32s3-opi_opi.json
@@ -4,10 +4,16 @@
         "memory_type": "opi_opi"
       },
       "core": "esp32",
-      "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
+      "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
       "f_cpu": "240000000L",
       "f_flash": "80000000L",
       "flash_mode": "dout",
+      "hwids": [
+        [
+          "0x303A",
+          "0x1001"
+        ]
+      ],
       "mcu": "esp32s3",
       "variant": "esp32s3",
       "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
@@ -18,6 +24,10 @@
       "ethernet"
     ],
     "debug": {
+      "default_tool": "esp-builtin",
+      "onboard_tools": [
+        "esp-builtin"
+      ],
       "openocd_target": "esp32s3.cfg"
     },
     "frameworks": [
@@ -37,10 +47,10 @@
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
       "require_upload_port": true,
-      "speed": 460800
+      "speed": 2000000
     },
     "download": {
-      "speed": 230400
+      "speed": 2000000
     },
     "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
     "vendor": "Espressif"

--- a/boards/esp32s3-opi_opi_120.json
+++ b/boards/esp32s3-opi_opi_120.json
@@ -11,7 +11,7 @@
     "flash_mode": "dout",
     "mcu": "esp32s3",
     "variant": "esp32s3",
-    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
+    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
   },
   "connectivity": [
@@ -20,6 +20,10 @@
     "ethernet"
   ],
   "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
@@ -39,10 +43,10 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 460800
+    "speed": 2000000
   },
   "download": {
-    "speed": 230400
+    "speed": 2000000
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
   "vendor": "Espressif"

--- a/boards/esp32s3-qio_opi.json
+++ b/boards/esp32s3-qio_opi.json
@@ -4,10 +4,16 @@
       "memory_type": "qio_opi"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
+    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
     "mcu": "esp32s3",
     "variant": "esp32s3",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
@@ -18,6 +24,10 @@
     "ethernet"
   ],
   "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
@@ -37,10 +47,10 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 460800
+    "speed": 2000000
   },
   "download": {
-    "speed": 230400
+    "speed": 2000000
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
   "vendor": "Espressif"

--- a/boards/esp32s3-qio_opi_120.json
+++ b/boards/esp32s3-qio_opi_120.json
@@ -11,7 +11,7 @@
     "flash_mode": "qio",
     "mcu": "esp32s3",
     "variant": "esp32s3",
-    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
+    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
   },
   "connectivity": [
@@ -20,6 +20,10 @@
     "ethernet"
   ],
   "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
@@ -39,10 +43,10 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 460800
+    "speed": 2000000
   },
   "download": {
-    "speed": 230400
+    "speed": 2000000
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
   "vendor": "Espressif"

--- a/boards/esp32s3-qio_qspi.json
+++ b/boards/esp32s3-qio_qspi.json
@@ -4,10 +4,16 @@
       "memory_type": "qio_qspi"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
+    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
     "mcu": "esp32s3",
     "variant": "esp32s3",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
@@ -18,6 +24,10 @@
     "ethernet"
   ],
   "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
@@ -37,10 +47,10 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 460800
+    "speed": 2000000
   },
   "download": {
-    "speed": 230400
+    "speed": 2000000
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
   "vendor": "Espressif"

--- a/boards/esp32s3ser-opi_opi.json
+++ b/boards/esp32s3ser-opi_opi.json
@@ -4,16 +4,10 @@
         "memory_type": "opi_opi"
       },
       "core": "esp32",
-      "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
+      "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
       "f_cpu": "240000000L",
       "f_flash": "80000000L",
       "flash_mode": "dout",
-      "hwids": [
-        [
-          "0x303A",
-          "0x1001"
-        ]
-      ],
       "mcu": "esp32s3",
       "variant": "esp32s3",
       "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
@@ -24,10 +18,6 @@
       "ethernet"
     ],
     "debug": {
-      "default_tool": "esp-builtin",
-      "onboard_tools": [
-        "esp-builtin"
-      ],
       "openocd_target": "esp32s3.cfg"
     },
     "frameworks": [
@@ -39,7 +29,7 @@
         "flash_extra_images": [
           [
             "0x10000",
-            "tasmota32s3cdc-safeboot.bin"
+            "tasmota32s3ser-safeboot.bin"
           ]
         ]
       },
@@ -47,10 +37,10 @@
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
       "require_upload_port": true,
-      "speed": 2000000
+      "speed": 460800
     },
     "download": {
-      "speed": 2000000
+      "speed": 230400
     },
     "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
     "vendor": "Espressif"

--- a/boards/esp32s3ser-opi_opi_120.json
+++ b/boards/esp32s3ser-opi_opi_120.json
@@ -1,17 +1,17 @@
 {
   "build": {
     "arduino":{
-      "memory_type": "qio_opi"
+      "memory_type": "opi_opi"
     },
     "core": "esp32",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "f_boot": "120000000L",
-    "boot": "qio",
-    "flash_mode": "qio",
+    "boot": "opi",
+    "flash_mode": "dout",
     "mcu": "esp32s3",
     "variant": "esp32s3",
-    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
+    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
   },
   "connectivity": [
@@ -20,22 +20,18 @@
     "ethernet"
   ],
   "debug": {
-    "default_tool": "esp-builtin",
-    "onboard_tools": [
-      "esp-builtin"
-    ],
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
     "arduino"
   ],
-  "name": "Espressif Generic ESP32-S3 >= 4M QIO Flash + OPI PSRAM, Tasmota 2880k Code/OTA, 320k FS",
+  "name": "Espressif Generic ESP32-S3 >= 4M OPI Flash + PSRAM, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {
     "arduino": {
       "flash_extra_images": [
         [
           "0x10000",
-          "tasmota32s3cdc-safeboot.bin"
+          "tasmota32s3ser-safeboot.bin"
         ]
       ]
     },
@@ -43,10 +39,10 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 2000000
+    "speed": 460800
   },
   "download": {
-    "speed": 2000000
+    "speed": 230400
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
   "vendor": "Espressif"

--- a/boards/esp32s3ser-qio_opi.json
+++ b/boards/esp32s3ser-qio_opi.json
@@ -4,16 +4,10 @@
       "memory_type": "qio_opi"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
+    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "qio",
-    "hwids": [
-      [
-        "0x303A",
-        "0x1001"
-      ]
-    ],
     "mcu": "esp32s3",
     "variant": "esp32s3",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
@@ -24,10 +18,6 @@
     "ethernet"
   ],
   "debug": {
-    "default_tool": "esp-builtin",
-    "onboard_tools": [
-      "esp-builtin"
-    ],
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
@@ -39,7 +29,7 @@
       "flash_extra_images": [
         [
           "0x10000",
-          "tasmota32s3cdc-safeboot.bin"
+          "tasmota32s3ser-safeboot.bin"
         ]
       ]
     },
@@ -47,10 +37,10 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 2000000
+    "speed": 460800
   },
   "download": {
-    "speed": 2000000
+    "speed": 230400
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
   "vendor": "Espressif"

--- a/boards/esp32s3ser-qio_opi_120.json
+++ b/boards/esp32s3ser-qio_opi_120.json
@@ -1,17 +1,17 @@
 {
   "build": {
     "arduino":{
-      "memory_type": "opi_opi"
+      "memory_type": "qio_opi"
     },
     "core": "esp32",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "f_boot": "120000000L",
-    "boot": "opi",
-    "flash_mode": "dout",
+    "boot": "qio",
+    "flash_mode": "qio",
     "mcu": "esp32s3",
     "variant": "esp32s3",
-    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
+    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
   },
   "connectivity": [
@@ -20,22 +20,18 @@
     "ethernet"
   ],
   "debug": {
-    "default_tool": "esp-builtin",
-    "onboard_tools": [
-      "esp-builtin"
-    ],
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
     "arduino"
   ],
-  "name": "Espressif Generic ESP32-S3 >= 4M OPI Flash + PSRAM, Tasmota 2880k Code/OTA, 320k FS",
+  "name": "Espressif Generic ESP32-S3 >= 4M QIO Flash + OPI PSRAM, Tasmota 2880k Code/OTA, 320k FS",
   "upload": {
     "arduino": {
       "flash_extra_images": [
         [
           "0x10000",
-          "tasmota32s3cdc-safeboot.bin"
+          "tasmota32s3ser-safeboot.bin"
         ]
       ]
     },
@@ -43,10 +39,10 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 2000000
+    "speed": 460800
   },
   "download": {
-    "speed": 2000000
+    "speed": 230400
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
   "vendor": "Espressif"

--- a/boards/esp32s3ser-qio_qspi.json
+++ b/boards/esp32s3ser-qio_qspi.json
@@ -4,16 +4,10 @@
       "memory_type": "qio_qspi"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
+    "extra_flags": "-DARDUINO_TASMOTA -DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "qio",
-    "hwids": [
-      [
-        "0x303A",
-        "0x1001"
-      ]
-    ],
     "mcu": "esp32s3",
     "variant": "esp32s3",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"
@@ -24,10 +18,6 @@
     "ethernet"
   ],
   "debug": {
-    "default_tool": "esp-builtin",
-    "onboard_tools": [
-      "esp-builtin"
-    ],
     "openocd_target": "esp32s3.cfg"
   },
   "frameworks": [
@@ -39,7 +29,7 @@
       "flash_extra_images": [
         [
           "0x10000",
-          "tasmota32s3cdc-safeboot.bin"
+          "tasmota32s3ser-safeboot.bin"
         ]
       ]
     },
@@ -47,10 +37,10 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
-    "speed": 2000000
+    "speed": 460800
   },
   "download": {
-    "speed": 2000000
+    "speed": 230400
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
   "vendor": "Espressif"

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -141,11 +141,6 @@ def esp32_create_chip_string(chip):
             print(Fore.YELLOW + "Unexpected naming convention in this build environment:" + Fore.RED, tasmota_platform_org)
             print(Fore.YELLOW + "Expected build environment name like " + Fore.GREEN + "'tasmota" + chip[3:] + "-whatever-you-want'")
             print(Fore.YELLOW + "Please correct your actual build environment, to avoid undefined behavior in build process!!")
-    if "-DUSE_USB_CDC_CONSOLE" in env.BoardConfig().get("build.extra_flags") and "cdc" not in tasmota_platform:
-        tasmota_platform += "cdc"
-        print(Fore.YELLOW + "Board definition uses CDC configuration, but environment name does not -> fix by adding 'cdc'")
-        print(Fore.YELLOW + "Expected build environment name like " + Fore.GREEN + "'tasmota" + chip[3:] + "cdc-whatever-you-want'")
-        print(Fore.YELLOW + "Please correct your actual build environment, to avoid undefined behavior in build process!!")
     return tasmota_platform
 
 def esp32_build_filesystem(fs_size):

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -28,20 +28,23 @@ default_envs            =
 ;                          tasmota-zbbridge
 ;                          tasmota-ir
 ;                          tasmota32
+;                          tasmota32solo1
+;                          tasmota32s2
+;                          tasmota32s2cdc
+;                          tasmota32s3
+;                          tasmota32c2
+;                          tasmota32c3
+;                          tasmota32c6
 ;                          tasmota32-zbbrdgpro
 ;                          tasmota32-bluetooth
 ;                          tasmota32-webcam
 ;                          tasmota32-knx
 ;                          tasmota32-lvgl
 ;                          tasmota32-ir
-;                          tasmota32solo1
 ;                          tasmota32-nspanel
-;                          tasmota32c2
-;                          tasmota32c3cdc
-;                          tasmota32c6cdc
-;                          tasmota32s2
-;                          tasmota32s2cdc
-;                          tasmota32s3cdc
+;                          tasmota32c3ser
+;                          tasmota32c6ser
+;                          tasmota32s3ser
 
 [tasmota]
 ; *** Global build / unbuild compile time flags for ALL Tasmota / Tasmota32 [env]

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -55,21 +55,9 @@ build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_LVGL
                               -DUSE_LVGL_OPENHASP
                               -DOTA_URL='""'
-
-[env:tasmota32s3cdc-opi_opi]
+[env:tasmota32c3-bluetooth]
 extends                     = env:tasmota32_base
-board                       = esp32s3cdc-opi_opi
-board_build.f_cpu           = 240000000L
-board_build.f_flash         = 80000000L
-build_flags                 = ${env:tasmota32_base.build_flags}
-                              -DUSE_BERRY_ULP
-                              -DFIRMWARE_LVGL
-                              -DUSE_LVGL_OPENHASP
-                              -DOTA_URL='""'
-
-[env:tasmota32c3cdc-bluetooth]
-extends                     = env:tasmota32_base
-board                       = esp32c3cdc
+board                       = esp32c3
 build_unflags               = ${env:tasmota32_base.build_unflags}
                               -mtarget-align
 build_flags                 = ${env:tasmota32_base.build_flags}
@@ -79,9 +67,9 @@ build_flags                 = ${env:tasmota32_base.build_flags}
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display, lib/lib_audio
 lib_ignore                  = Micro-RTSP
 
-[env:tasmota32s3cdc-bluetooth]
+[env:tasmota32s3-bluetooth]
 extends                     = env:tasmota32_base
-board                       = esp32s3cdc-qio_qspi
+board                       = esp32s3-qio_qspi
 build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DOTA_URL='""'
@@ -97,9 +85,9 @@ build_flags                 = ${env:tasmota32_base.build_flags}
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
 lib_ignore                  = Micro-RTSP
 
-[env:tasmota32c3cdc-mi32]
+[env:tasmota32c3-mi32]
 extends                     = env:tasmota32_base
-board                       = esp32c3cdc
+board                       = esp32c3
 build_unflags               = ${env:tasmota32_base.build_unflags}
                               -mtarget-align
 build_flags                 = ${env:tasmota32_base.build_flags}
@@ -109,9 +97,9 @@ build_flags                 = ${env:tasmota32_base.build_flags}
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
 lib_ignore                  = Micro-RTSP
 
-[env:tasmota32s3cdc-mi32]
+[env:tasmota32s3-mi32]
 extends                     = env:tasmota32_base
-board                       = esp32s3cdc-qio_qspi
+board                       = esp32s3-qio_qspi
 build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
@@ -119,9 +107,9 @@ build_flags                 = ${env:tasmota32_base.build_flags}
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
 lib_ignore                  = Micro-RTSP
 
-[env:tasmota32c6cdc-mi32]
+[env:tasmota32c6-mi32]
 extends                     = env:tasmota32_base
-board                       = esp32c6cdc
+board                       = esp32c6
 build_unflags               = ${env:tasmota32_base.build_unflags}
                               -mtarget-align
 build_flags                 = ${env:tasmota32_base.build_flags}
@@ -189,10 +177,10 @@ build_flags                 = ${env:tasmota32_base.build_flags}
 
 ; *** JTAG Debug versions (only C3/S3), uses inbuilt CDC/jtag. No extra jtag hardware required!
 
-[env:tasmota32s3cdc-ocd]
+[env:tasmota32s3-ocd]
 build_type                  = debug
 extends                     = env:tasmota32s3
-board                       = esp32s3cdc-qio_opi
+board                       = esp32s3-qio_opi
 debug_tool                  = esp-builtin
 upload_protocol             = esp-builtin
 debug_init_break            = tbreak setup
@@ -200,10 +188,10 @@ build_unflags               = ${env:tasmota32_base.build_unflags}
 build_flags                 = ${env:tasmota32_base.build_flags}
                               -DOTA_URL='""'
 
-[env:tasmota32c3cdc-ocd]
+[env:tasmota32c3-ocd]
 build_type                  = debug
 extends                     = env:tasmota32c3
-board                       = esp32c3cdc
+board                       = esp32c3
 debug_tool                  = esp-builtin
 upload_protocol             = esp-builtin
 debug_init_break            = tbreak setup

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -44,21 +44,21 @@ build_flags             = ${env:tasmota32_base.build_flags}
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
-[env:tasmota32s2cdc-safeboot]
-extends                 = env:tasmota32_base
-board                   = esp32s2cdc
-build_flags             = ${env:tasmota32_base.build_flags}
-                          -DFIRMWARE_SAFEBOOT
-                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2cdc-safeboot.bin"'
-lib_extra_dirs          = lib/lib_ssl, lib/libesp32
-lib_ignore              = ${safeboot_flags.lib_ignore}
-
 [env:tasmota32s2-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32s2
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2-safeboot.bin"'
+lib_extra_dirs          = lib/lib_ssl, lib/libesp32
+lib_ignore              = ${safeboot_flags.lib_ignore}
+
+[env:tasmota32s2cdc-safeboot]
+extends                 = env:tasmota32_base
+board                   = esp32s2cdc
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_SAFEBOOT
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2cdc-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
@@ -73,17 +73,6 @@ build_flags             = ${env:tasmota32_base.build_flags}
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
-[env:tasmota32c3cdc-safeboot]
-extends                 = env:tasmota32_base
-board                   = esp32c3cdc
-build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mtarget-align
-build_flags             = ${env:tasmota32_base.build_flags}
-                          -DFIRMWARE_SAFEBOOT
-                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3cdc-safeboot.bin"'
-lib_extra_dirs          = lib/lib_ssl, lib/libesp32
-lib_ignore              = ${safeboot_flags.lib_ignore}
-
 [env:tasmota32c3-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32c3
@@ -95,23 +84,23 @@ build_flags             = ${env:tasmota32_base.build_flags}
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
-[env:tasmota32s3cdc-safeboot]
+[env:tasmota32c3ser-safeboot]
 extends                 = env:tasmota32_base
-board                   = esp32s3cdc-qio_qspi
-build_flags             = ${env:tasmota32_base.build_flags}
-                         -DFIRMWARE_SAFEBOOT
-                         -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3cdc-safeboot.bin"'
-lib_extra_dirs          = lib/lib_ssl, lib/libesp32
-lib_ignore              = ${safeboot_flags.lib_ignore}
-
-[env:tasmota32c6cdc-safeboot]
-extends                 = env:tasmota32_base
-board                   = esp32c6cdc
+board                   = esp32c3ser
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -mtarget-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
-                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6cdc-safeboot.bin"'
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3ser-safeboot.bin"'
+lib_extra_dirs          = lib/lib_ssl, lib/libesp32
+lib_ignore              = ${safeboot_flags.lib_ignore}
+
+[env:tasmota32s3-safeboot]
+extends                 = env:tasmota32_base
+board                   = esp32s3-qio_qspi
+build_flags             = ${env:tasmota32_base.build_flags}
+                         -DFIRMWARE_SAFEBOOT
+                         -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
@@ -126,12 +115,23 @@ build_flags             = ${env:tasmota32_base.build_flags}
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
-[env:tasmota32s3-safeboot]
+[env:tasmota32c6ser-safeboot]
 extends                 = env:tasmota32_base
-board                   = esp32s3-qio_qspi
+board                   = esp32c6ser
+build_unflags           = ${env:tasmota32_base.build_unflags}
+                          -mtarget-align
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_SAFEBOOT
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6ser-safeboot.bin"'
+lib_extra_dirs          = lib/lib_ssl, lib/libesp32
+lib_ignore              = ${safeboot_flags.lib_ignore}
+
+[env:tasmota32s3ser-safeboot]
+extends                 = env:tasmota32_base
+board                   = esp32s3ser-qio_qspi
 build_flags             = ${env:tasmota32_base.build_flags}
                          -DFIRMWARE_SAFEBOOT
-                         -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3-safeboot.bin"'
+                         -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3ser-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
@@ -152,22 +152,22 @@ lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           Micro-RTSP
                           epdiy
 
-[env:tasmota32s2cdc]
-extends                 = env:tasmota32_base
-board                   = esp32s2cdc
-build_flags             = ${env:tasmota32_base.build_flags}
-                          -DFIRMWARE_TASMOTA32
-                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2cdc.bin"'
-lib_ignore              = ${env:tasmota32_base.lib_ignore}
-                          Micro-RTSP
-                          epdiy
-
 [env:tasmota32s2]
 extends                 = env:tasmota32_base
 board                   = esp32s2
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2.bin"'
+lib_ignore              = ${env:tasmota32_base.lib_ignore}
+                          Micro-RTSP
+                          epdiy
+
+[env:tasmota32s2cdc]
+extends                 = env:tasmota32_base
+board                   = esp32s2cdc
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_TASMOTA32
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2cdc.bin"'
 lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           Micro-RTSP
                           epdiy
@@ -181,30 +181,30 @@ build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c2.bin"'
 
-[env:tasmota32c3cdc]
+[env:tasmota32c3]
 extends                 = env:tasmota32_base
-board                   = esp32c3cdc
+board                   = esp32c3
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -mtarget-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
-                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3cdc.bin"'
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3.bin"'
 
-[env:tasmota32c6cdc]
+[env:tasmota32c6]
 extends                 = env:tasmota32_base
-board                   = esp32c6cdc
+board                   = esp32c6
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -mtarget-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
-                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6cdc.bin"'
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6.bin"'
 
-[env:tasmota32s3cdc]
+[env:tasmota32s3]
 extends                 = env:tasmota32_base
-board                   = esp32s3cdc-qio_qspi
+board                   = esp32s3-qio_qspi
 build_flags             = ${env:tasmota32_base.build_flags}
                          -DFIRMWARE_TASMOTA32
-                         -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3cdc.bin"'
+                         -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3.bin"'
 lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           Micro-RTSP
                           epdiy


### PR DESCRIPTION
## Description:

as the are now the default variants. The builds can be used connected via CDC and Serial.
@arendst Should be now like discussed in Discord

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
