### PR TITLE
Fixed IPv6 support in safeboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Fixed
+- HASPmota `align` attribute and expand PNG cache
+- LVGL restore `lv_palette` functions
+- IPv6 support in safeboot
 
 ### Removed
 
@@ -58,8 +61,6 @@ All notable changes to this project will be documented in this file.
 - NeoPool hydrolysis unit for Hidrolife, Bionet and Generic device (#21098)
 - M5Core2 LoRa868 module receive exception
 - Fade out on CCT bulb with `SO92 1` (#21159)
-- HASPmota `align` attribute and expand PNG cache
-- LVGL restore `lv_palette` functions
 
 ### Removed
 - Unused `#define MQTT_DATA_STRING` support

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -135,8 +135,6 @@ struct WIFI {
   bool wifi_test_AP_TIMEOUT = false;
   bool wifi_Test_Restart = false;
   bool wifi_Test_Save_SSID2 = false;
-  // IPv6 support, not guarded with #if LWIP_IPV6 to avoid bloating code with ifdefs
-  bool ipv6_local_link_called = false;           // did we already enable IPv6 Local-Link address, needs to be redone at each reconnect
 } Wifi;
 
 typedef struct {

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -208,7 +208,7 @@ void CmndWifiTest(void)
         AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_WIFI D_CONNECTING_TO_AP " %s " D_AS " %s ..."),
           ssid_test, TasmotaGlobal.hostname);
 
-        WiFi.begin(ssid_test,pswd_test);
+        WiFiHelper::begin(ssid_test,pswd_test);
       }
     } else {
       ResponseCmndChar(D_JSON_BUSY);

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -1941,7 +1941,7 @@ void HandleWifiConfiguration(void) {
       AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_WIFI D_CONNECTING_TO_AP " %s " D_AS " %s ..."),
         SettingsText(SET_STASSID1), TasmotaGlobal.hostname);
 
-      WiFi.begin(SettingsText(SET_STASSID1), SettingsText(SET_STAPWD1));
+      WiFiHelper::begin(SettingsText(SET_STASSID1), SettingsText(SET_STAPWD1));
 
       WebRestart(2);
     } else {

--- a/tasmota/tasmota_xdrv_driver/xdrv_57_9_tasmesh.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_57_9_tasmesh.ino
@@ -377,7 +377,7 @@ void MESHstartNode(int32_t _channel, uint8_t _role){ //we need a running broker 
 #ifdef ESP8266 // for now only ESP8266, might be added for the ESP32 later
   MESH.channel = _channel;
   WiFi.mode(WIFI_STA);
-  WiFi.begin("", "", MESH.channel, nullptr, false); //fake connection attempt to set channel
+  WiFiHelper::begin("", "", MESH.channel, nullptr, false); //fake connection attempt to set channel
   wifi_promiscuous_enable(1);
   wifi_set_channel(MESH.channel);
   wifi_promiscuous_enable(0);


### PR DESCRIPTION
## Description:

Fixed DNS issue with IPv6 in safeboot, this was due to events not recevied.

Fixed `WiFiHelper::begin` instead of `WiFi.begin`

Removed IPv6 work-around not needed anymore with latest Core3

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
