### PR TITLE
Berry avoid crash when Berry is disabled after bootloop

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -782,6 +782,7 @@ void HandleBerryConsole(void)
 // Display Buttons to dynamically load bec files
 void HandleBerryBECLoaderButton(void) {
   bvm * vm = berry.vm;
+  if (vm == NULL) { return; }       // Berry vm is not initialized
 
   for (int32_t i = 0; i < ARRAY_SIZE(BECCode); i++) {
     const BeBECCode_t &bec = BECCode[i];
@@ -946,7 +947,7 @@ bool Xdrv52(uint32_t function)
     case FUNC_WEB_ADD_CONSOLE_BUTTON:
       if (XdrvMailbox.index) {
         XdrvMailbox.index++;
-      } else {
+      } else if (berry.vm != NULL) {
         WSContentSend_P(HTTP_BTN_BERRY_CONSOLE);
         HandleBerryBECLoaderButton();               // display buttons to load BEC files
         callBerryEventDispatcher(PSTR("web_add_button"), nullptr, 0, nullptr);


### PR DESCRIPTION
## Description:

Berry avoid crash when Berry is disabled after bootloop

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
