### PR TITLE
Allow changing WiFi Hostname at compile time from user_config_override.h

### DIFF
--- a/tasmota/include/tasmota.h
+++ b/tasmota/include/tasmota.h
@@ -146,7 +146,7 @@ const uint8_t MAX_ROTARIES = 2;             // Max number of Rotary Encoders
 
 const char MQTT_TOKEN_PREFIX[] PROGMEM = "%prefix%";  // To be substituted by mqtt_prefix[x]
 const char MQTT_TOKEN_TOPIC[] PROGMEM = "%topic%";    // To be substituted by mqtt_topic, mqtt_grptopic, mqtt_buttontopic, mqtt_switchtopic
-const char WIFI_HOSTNAME[] = "%s-%04d";     // Expands to <MQTT_TOPIC>-<last 4 decimal chars of MAC address>
+const char WIFI_HOSTNAME[] = DEFAULT_WIFI_HOSTNAME;
 
 const uint8_t CONFIG_FILE_SIGN = 0xA5;      // Configuration file signature
 const uint8_t CONFIG_FILE_XOR = 0x5A;       // Configuration file xor (0 = No Xor)

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -84,6 +84,7 @@
 #define WIFI_SCAN_AT_RESTART   false             // [SetOption56] Scan Wi-Fi network at restart for configured AP's
 #define WIFI_SCAN_REGULARLY    true              // [SetOption57] Scan Wi-Fi network every 44 minutes for configured AP's
 #define WIFI_NO_SLEEP          false             // [SetOption127] Sets Wifi in no-sleep mode which improves responsiveness on some routers
+#define DEFAULT_WIFI_HOSTNAME  "%s-%04d"         // Expands to <MQTT_TOPIC>-<last 4 decimal chars of MAC address>
 
 // -- Syslog --------------------------------------
 #define SYS_LOG_HOST           ""                // [LogHost] (Linux) syslog host

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -23,8 +23,8 @@
 #endif  // ESP32_STAGE
 #include "include/tasmota_compat.h"
 #include "include/tasmota_version.h"        // Tasmota version information
-#include "include/tasmota.h"                // Enumeration used in my_user_config.h
 #include "my_user_config.h"                 // Fixed user configurable options
+#include "include/tasmota.h"                // Enumeration used in my_user_config.h
 #ifdef USE_TLS
 #include <t_bearssl.h>                      // We need to include before "tasmota_globals.h" to take precedence over the BearSSL version in Arduino
 #endif  // USE_TLS


### PR DESCRIPTION
## Description:

This small PR adds the option to allow changing the WiFi Hostname at compile time from **user_config_override.h**.

_Usage:_
- Add in **user_config_override.h** file the following so the hostname can be customized at compile time:

```cpp
#undef DEFAULT_WIFI_HOSTNAME
#define DEFAULT_WIFI_HOSTNAME  "MyDevice"
```

_Notes:_
- The default value is `"%s-%04d"` which expands to `<MQTT_TOPIC>-<last 4 decimal chars of MAC address>`
- This PR does not change the FLASH or RAM usage.

**Related issue (if applicable):** NA

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
