### PR TITLE
esp32_partition_app3904k_fs3392k partition scheme for 8MB ESP32S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [13.4.1.2]
 ### Added
+- esp32_partition_app3904k_fs3392k partition scheme for 8MB ESP32S3
 
 ### Breaking Changed
 - ESP32-C3 OTA binary name from `tasmota32c3cdc.bin` to `tasmota32c3.bin` with USB HWCDC and fallback to serial (#21212)

--- a/partitions/esp32_partition_app3904k_fs3392k.csv
+++ b/partitions/esp32_partition_app3904k_fs3392k.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+safeboot, app,  factory, 0x10000, 0xD0000,
+app0,     app,  ota_0,   0xE0000, 0x3D0000,
+spiffs,   data, spiffs,  0x4B0000,0x150000,


### PR DESCRIPTION
## Description:

Add a new partition scheme for 8MB Flash, for ex ESP32S3 N8R8, allowing for bigger application sizes:
- 3904 KB program size
- 3392 KB filesystem

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
