### PR TITLE
LVGL fix memory allocation of flush buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - HASPmota `align` attribute and expand PNG cache
 - LVGL restore `lv_palette` functions
 - IPv6 support in safeboot
+- LVGL fix memory allocation of flush buffers
 
 ### Removed
 - LVGL disabled vector graphics

--- a/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
+++ b/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
@@ -28,7 +28,7 @@
 // b. textcolor,textbgcolor => public;
 
 typedef struct LVGL_PARAMS {
-  uint16_t fluslines;
+  uint16_t flushlines;
   union {
     uint8_t data;
     struct {

--- a/lib/lib_display/UDisplay/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/uDisplay.cpp
@@ -142,7 +142,7 @@ uDisplay::uDisplay(char *lp) : Renderer(800, 600) {
   epc_full_cnt = 0;
   lut_num = 0;
   lvgl_param.data = 0;
-  lvgl_param.fluslines = 40;
+  lvgl_param.flushlines = 40;
   rot_t[0] = 0;
   rot_t[1] = 1;
   rot_t[2] = 2;
@@ -590,7 +590,7 @@ uDisplay::uDisplay(char *lp) : Renderer(800, 600) {
             lut3time = next_val(&lp1);
             break;
           case 'B':
-            lvgl_param.fluslines = next_val(&lp1);
+            lvgl_param.flushlines = next_val(&lp1);
             lvgl_param.data = next_val(&lp1);
             break;
           case 'M':

--- a/lib/lib_display/Xlatb_RA8876-gemu-1.0/RA8876.cpp
+++ b/lib/lib_display/Xlatb_RA8876-gemu-1.0/RA8876.cpp
@@ -493,7 +493,7 @@ void RA8876::DisplayInit(int8_t p,int8_t size,int8_t rot,int8_t font) {
 
 bool RA8876::initDisplay() {
 
-  lvgl_param.fluslines = 10;
+  lvgl_param.flushlines = 10;
 
   SPI.beginTransaction(m_spiSettings);
 

--- a/lib/libesp32_eink/epdiy/src/epd4in7.cpp
+++ b/lib/libesp32_eink/epdiy/src/epd4in7.cpp
@@ -63,7 +63,7 @@ int32_t Epd47::Init(void) {
   hl = epd_hl_init(WAVEFORM);
   epd47_buffer = epd_hl_get_framebuffer(&hl);
   framebuffer = epd47_buffer;
-  lvgl_param.fluslines = 10;
+  lvgl_param.flushlines = 10;
   return 0;
 }
 


### PR DESCRIPTION
## Description:

Fix memory allocation since LVGL 9:
- memory buffers were allocated 50% bigger than necessary, and considered by LVGL as twice as small as they were
- allocate flush buffers preferably in internal memory, instead of PSRAM (applies especially for ESP32S3)
- fix typo in `fluslines`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
