### PR TITLE
Platform 2024.04.13

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -77,7 +77,7 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.04.12/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.04.13/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

changed sdkconfig compile time settings for ESP32-S3 with OPI PSRAM.
The changes enhances performance for RGB parallel LC Displays with the S3 and OPI PSRAM. No changes for all other MCUs and S3 Flash / PSRAM variants.

The change fixes the screen flicker with the mentioned S3 type.
Tested with device `ESP32S3-4848S040`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
