### PR TITLE
HDMI CEC synchronously sends messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - uDisplay fast drawing on RGB displays
+- HDMI CEC synchronously sends messages
 
 ### Fixed
 - HASPmota `align` attribute and expand PNG cache

--- a/tasmota/tasmota_xdrv_driver/xdrv_70_1_hdmi_cec.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_70_1_hdmi_cec.ino
@@ -43,7 +43,9 @@ void HDMI_OnReady(class CEC_Device* self, int logical_address) {
 
 void HDMI_OnReceive(class CEC_Device *self, int32_t from, int32_t to, uint8_t* buf, size_t len, bool ack)
 {
-	AddLog(LOG_LEVEL_DEBUG, "CEC: Packet received: (%1X->%1X) %1X%1X%*_H %s", from, to, from, to, len, buf, ack ? PSTR("ACK") : PSTR("NAK"));
+  if (HighestLogLevel() >= LOG_LEVEL_DEBUG) {
+  	AddLog(LOG_LEVEL_DEBUG, "CEC: Packet received: (%1X->%1X) %1X%1X%*_H %s", from, to, from, to, len, buf, ack ? PSTR("ACK") : PSTR("NAK"));
+  }
 
   Response_P(PSTR("{\"HdmiReceived\":{\"From\":%i,\"To\":%i,\"Data\":\"%*_H\"}}"), from, to, len, buf);
   if (to == self->getLogicalAddress() || to == 0x0F) {
@@ -55,7 +57,9 @@ void HDMI_OnReceive(class CEC_Device *self, int32_t from, int32_t to, uint8_t* b
 void HDMI_OnTransmit(class CEC_Device *self, uint8_t* buf, size_t len, bool ack)
 {
 	// This is called after a frame is transmitted.
-  AddLog(LOG_LEVEL_DEBUG, "CEC: Packet sent: %*_H %s", len, buf, ack ? PSTR("ACK") : PSTR("NAK"));
+  if (HighestLogLevel() >= LOG_LEVEL_DEBUG) {
+    AddLog(LOG_LEVEL_DEBUG, "CEC: Packet sent: %*_H %s", len, buf, ack ? PSTR("ACK") : PSTR("NAK"));
+  }
 }
 
 // singleton for HDMI CEC object, could be expanded if we manage multiple HDMI in parallel
@@ -110,8 +114,13 @@ void CmndHDMISendRaw(void) {
     RemoveSpace(XdrvMailbox.data);
     SBuffer buf = SBuffer::SBufferFromHex(XdrvMailbox.data, strlen(XdrvMailbox.data));
     if (buf.len() > 0 && buf.len() < 16) {
-      HDMI_CEC_device->transmitRaw(buf.buf(), buf.len());
-      ResponseCmndDone();
+      bool success = HDMI_CEC_device->transmitRaw(buf.buf(), buf.len());
+      if (success) {
+        HDMI_CEC_device->run();
+        ResponseCmndDone();
+      } else {
+        ResponseCmndChar_P(PSTR("Sending failed"));
+      }
     } else {
       ResponseCmndChar_P(PSTR("Buffer too large"));
     }
@@ -155,8 +164,13 @@ void CmndHDMISend(void) {
       const char * payload = root.getStr(PSTR("Data"));
       SBuffer buf = SBuffer::SBufferFromHex(payload, strlen(payload));
       if (buf.len() > 0 && buf.len() < 15) {
-        HDMI_CEC_device->transmitFrame(to, buf.buf(), buf.len());
-        ResponseCmndDone();
+        bool success = HDMI_CEC_device->transmitFrame(to, buf.buf(), buf.len());
+        if (success) {
+          HDMI_CEC_device->run();
+          ResponseCmndDone();
+        } else {
+          ResponseCmndChar_P(PSTR("Sending failed"));
+        }
       } else {
         if (buf.len() == 0) {
           ResponseCmndChar_P(PSTR("Buffer empty"));
@@ -168,8 +182,13 @@ void CmndHDMISend(void) {
       // Hex
       SBuffer buf = SBuffer::SBufferFromHex(XdrvMailbox.data, strlen(XdrvMailbox.data));
       if (buf.len() > 0 && buf.len() < 15) {
-        HDMI_CEC_device->transmitFrame(0, buf.buf(), buf.len());
-        ResponseCmndDone();
+        bool success = HDMI_CEC_device->transmitFrame(0, buf.buf(), buf.len());
+        if (success) {
+          HDMI_CEC_device->run();
+          ResponseCmndDone();
+        } else {
+          ResponseCmndChar_P(PSTR("Sending failed"));
+        }
       } else {
         if (buf.len() == 0) {
           ResponseCmndChar_P(PSTR("Buffer empty"));
@@ -239,7 +258,9 @@ bool ReadEdid256(uint8_t *buf) {
 // Return 0x0000 if not found
 uint16_t HDMIGetPhysicalAddress(void) {
   uint8_t buf[256] = {0};
-  AddLog(LOG_LEVEL_DEBUG, PSTR("CEC: trying to read physical address"));
+  if (HighestLogLevel() >= LOG_LEVEL_DEBUG) {
+    AddLog(LOG_LEVEL_DEBUG, PSTR("CEC: trying to read physical address"));
+  }
   if (ReadEdid256(buf)) { return 0x0000; }      // unable to get an address
 
   uint8_t edid_extensions = buf[126];
@@ -269,7 +290,9 @@ uint16_t HDMIGetPhysicalAddress(void) {
       // 030C00 for "HDMI Licensing, LLC"
       if (buf[idx+1] == 0x03 && buf[idx+2] == 0x0C && buf[idx+3] == 0x00) {
         uint16_t addr = (buf[idx+4] << 8) | buf[idx+5];
-        AddLog(LOG_LEVEL_DEBUG, "CEC: physical address found: 0x%04X", addr);
+        if (HighestLogLevel() >= LOG_LEVEL_DEBUG) {
+          AddLog(LOG_LEVEL_DEBUG, "CEC: physical address found: 0x%04X", addr);
+        }
         return addr;
       }
     }
@@ -277,7 +300,9 @@ uint16_t HDMIGetPhysicalAddress(void) {
     idx += 1 + number_of_bytes;
   }
 
-  AddLog(LOG_LEVEL_DEBUG, "CEC: physical address not found");
+  if (HighestLogLevel() >= LOG_LEVEL_DEBUG) {
+    AddLog(LOG_LEVEL_DEBUG, "CEC: physical address not found");
+  }
   return 0x0000;    // TODO
 }
 


### PR DESCRIPTION
## Description:

HDMI CEC now sends immediately (synchronous) outgoing packets when using `HdmiSend` and `HdmiSendRaw`, instead of waiting for the next tick.

See discussion https://github.com/arendst/Tasmota/discussions/21247

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
