### PR TITLE
Berry `web_add_handler` called before `Webserver` is initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - LVGL restore `lv_palette` functions
 - IPv6 support in safeboot
 - LVGL fix memory allocation of flush buffers
+- Berry `web_add_handler` called before `Webserver` is initialized
 
 ### Removed
 - LVGL disabled vector graphics

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -899,7 +899,7 @@ bool Xdrv52(uint32_t function)
 #ifdef USE_ETHERNET
           network_up = network_up || EthernetHasIP();
 #endif
-          if (network_up) {       // if network is already up, send a synthetic event to trigger web handlers
+          if (network_up && (Webserver != NULL)) {       // if network is already up, send a synthetic event to trigger web handlers
             callBerryEventDispatcher(PSTR("web_add_handler"), nullptr, 0, nullptr);
             berry.web_add_handler_done = true;
           }


### PR DESCRIPTION
## Description:

Bug introduced with `BrRestart`. There is a mechanism to detect if `web_add_handler` was missed because of a BrRestart. It checked if network was up, but failed to check if `Webserver` was also created.

In some cases, the event would be fired too soon, before `Webserver` is created, hence lost.

**Related issue (if applicable):** fixes #21158

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
