### PR TITLE
Berry `webserver.content_close()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - esp32_partition_app3904k_fs3392k partition scheme for 8MB ESP32S3
 - TCP Tx En GPIO type
+- Berry `webserver.content_close()`
 
 ### Breaking Changed
 - ESP32-C3 OTA binary name from `tasmota32c3cdc.bin` to `tasmota32c3.bin` with USB HWCDC and fallback to serial (#21212)

--- a/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
@@ -25,6 +25,7 @@ extern int w_webserver_content_response(bvm *vm);
 extern int w_webserver_content_send_style(bvm *vm);
 extern int w_webserver_content_flush(bvm *vm);
 extern int w_webserver_content_stop(bvm *vm);
+extern int w_webserver_content_close(bvm *vm);
 extern int w_webserver_content_button(bvm *vm);
 
 extern int w_webserver_html_escape(bvm *vm);
@@ -153,6 +154,7 @@ module webserver (scope: global) {
     content_open, func(w_webserver_content_open)
     content_start, func(w_webserver_content_start)
     content_stop, func(w_webserver_content_stop)
+    content_close, func(w_webserver_content_close)
     content_button, func(w_webserver_content_button)
 
     html_escape, func(w_webserver_html_escape)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
@@ -249,6 +249,14 @@ extern "C" {
     be_return_nil(vm);
   }
 
+  // Berry: `webserver.content_close() -> nil`
+  //
+  int32_t w_webserver_content_close(struct bvm *vm);
+  int32_t w_webserver_content_close(struct bvm *vm) {
+    WSContentEnd();
+    be_return_nil(vm);
+  }
+
   // Berry: `webserver.content_button([button:int]) -> nil`
   // Default button is BUTTON_MAIN
   //


### PR DESCRIPTION
## Description:

Add `webserver.content_close()` to close the current page without sending the standard Tasmota page footer.

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/pull/21272#issuecomment-2076596781

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
