### PR TITLE
Wrong feature bit for USE_SPL06_007

### DIFF
--- a/tasmota/tasmota_support/support_features.ino
+++ b/tasmota/tasmota_support/support_features.ino
@@ -917,9 +917,8 @@ constexpr uint32_t feature[] = {
   0x00000010 |  // xdrv_73_9_lora.ino
 #endif
 #if defined(USE_I2C) && defined(USE_SPL06_007)
-  0x10000000 |  // xsns_25_spl006-7_sensor.ino
+  0x00000020 |  // xsns_25_spl006-7_sensor.ino
 #endif
-//  0x00000020 |  // 
 //  0x00000040 |  // 
 //  0x00000080 |  // 
 //  0x00000100 |  // 


### PR DESCRIPTION
Obvious "typo" in setting the feature bit for this recently added sensor. Already mentioned in https://github.com/arendst/Tasmota/pull/21185#issuecomment-2071122611

## Description:

**Related issue (if applicable):** fixes #21185

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
