### PR TITLE
Revert "Platform 2024.04.13"

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -77,7 +77,7 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.04.13/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.04.12/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
Reverts arendst/Tasmota#21264

since it breaks HWCDC autodetection and fallback to serial on S3 devices with OPI PSRAM

fyi @s-hadinger 