### PR TITLE
I2S changes for Core 3

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
@@ -105,11 +105,13 @@ typedef struct{
     bool     left_align = true;     // B12 - left alignment
     bool     big_endian = false;    // B13 - big endian
     bool     bit_order_lsb = false; // B14 - lsb first
-    uint8_t  spare[2];              // B015/16 - padding
+    uint16_t dma_frame_num = 512;   // B015/16 - DMA buffer size in samples, 512 should be okay up to ~32000 bps
+    uint8_t  dma_desc_num = 3;      // B17 - number of DMA buffers, maybe increased with smaller buffers
+    uint8_t  spare[3];              // B018-20 - padding
   } rx;
 } tI2SSettings;
 
-static_assert(sizeof(tI2SSettings) == 56, "tI2SSettings Size is not correct");
+static_assert(sizeof(tI2SSettings) == 60, "tI2SSettings Size is not correct");
 
 typedef union {
   uint8_t data;

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_3_lib_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_3_lib_idf51.ino
@@ -103,11 +103,10 @@ public:
   void setPinout(int32_t bclk, int32_t ws, int32_t dout, int32_t mclk, int32_t din,
                  bool mclk_inv = false, bool bclk_inv = false, bool ws_inv = false, bool apll = false);
 
-  void setSlotConfig(i2s_port_t i2s_port, uint8_t tx_slot_config, uint8_t rx_slot_config,
+  void setSlotConfig(i2s_port_t i2s_port, uint8_t tx_slot_config,
                      uint8_t tx_slot_mask, uint8_t rx_slot_mask) {
     _i2s_port = i2s_port;
     _tx_slot_config = tx_slot_config;
-    _rx_slot_config = rx_slot_config;
   }
   void setRxFreq(uint16_t freq) { _rx_freq = freq; }
 
@@ -237,7 +236,7 @@ protected:
   // TX
   bool      _tx_configured = false;       // true = configured, false = not configured
   uint8_t   _tx_mode = I2S_MODE_STD;      // I2S_MODE_STD / I2S_MODE_PDM / I2S_MODE_TDM / I2S_MODE_DAC
-  uint8_t   _tx_slot_mask = I2S_SLOT_NOCHANGE;
+  uint8_t   _tx_slot_mask = 0;
   bool      _tx_running = false;          // true = enabled, false = disabled
   uint8_t   _tx_channels = 2;             // number of channels, 1 = mono, 2 = stereo -- `channels`
   i2s_chan_handle_t _tx_handle = nullptr; // I2S channel handle, automatically computed
@@ -247,11 +246,11 @@ protected:
   // RX
   bool      _rx_configured = false;       // true = configured, false = not configured
   uint8_t   _rx_mode = I2S_MODE_STD;      // I2S_MODE_STD / I2S_MODE_PDM / I2S_MODE_TDM / I2S_MODE_DAC
-  uint8_t   _rx_slot_mask = I2S_SLOT_NOCHANGE;
+  uint8_t   _rx_slot_mask = 0;
   bool      _rx_running = false;          // true = enabled, false = disabled
   uint8_t   _rx_channels = 2;             // number of channels, 1 = mono, 2 = stereo
   i2s_chan_handle_t _rx_handle = nullptr; // I2S channel handle, automatically computed
-  uint8_t   _rx_slot_config = I2S_SLOT_MSB;// I2S slot configuration
+  // uint8_t   _rx_slot_config;              // I2S slot configuration
   uint16_t  _rx_freq = 16000;             // I2S Rx sampling frequency in Hz
   uint8_t   _rx_bps = 16;                 // bits per sample, 16 or 8
 
@@ -539,7 +538,7 @@ bool TasmotaI2S::startI2SChannel(bool tx, bool rx) {
     } else if (_tx_slot_config == I2S_SLOT_PHILIPS) { // PHILIPS
       tx_std_cfg.slot_cfg = I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(tx_data_bit_width, tx_slot_mode);
     }
-    if (_tx_slot_mask != I2S_SLOT_NOCHANGE) { tx_std_cfg.slot_cfg.slot_mask = (i2s_std_slot_mask_t)_tx_slot_mask; }
+    tx_std_cfg.slot_cfg.slot_mask = (i2s_std_slot_mask_t)_tx_slot_mask;
 #if SOC_I2S_SUPPORTS_APLL
     if (_apll) { tx_std_cfg.clk_cfg.clk_src = I2S_CLK_SRC_APLL; }
 #endif // SOC_I2S_SUPPORTS_APLL
@@ -592,7 +591,7 @@ bool TasmotaI2S::startI2SChannel(bool tx, bool rx) {
     i2s_data_bit_width_t rx_data_bit_width = (_rx_bps == 8) ? I2S_DATA_BIT_WIDTH_8BIT : I2S_DATA_BIT_WIDTH_16BIT;
     // change to 3 buffers of 512 samples
     rx_chan_cfg.dma_desc_num = 3;
-    rx_chan_cfg.dma_frame_num = 512;
+    rx_chan_cfg.dma_frame_num = 1024;
 
     AddLog(LOG_LEVEL_DEBUG, "I2S: rx_chan_cfg id:%i role:%i dma_desc_num:%i dma_frame_num:%i auto_clear:%i",
           rx_chan_cfg.id, rx_chan_cfg.role, rx_chan_cfg.dma_desc_num, rx_chan_cfg.dma_frame_num, rx_chan_cfg.auto_clear);
@@ -615,7 +614,7 @@ bool TasmotaI2S::startI2SChannel(bool tx, bool rx) {
               },
             },
           };
-          if (_rx_slot_mask != I2S_SLOT_NOCHANGE) { rx_pdm_cfg.slot_cfg.slot_mask = (i2s_pdm_slot_mask_t)_rx_slot_mask; }
+          rx_pdm_cfg.slot_cfg.slot_mask = (i2s_pdm_slot_mask_t)_rx_slot_mask;
 
           // AddLog(LOG_LEVEL_DEBUG, "I2S: rx_pdm_cfg clk_cfg sample_rate_hz:%i clk_src:%i mclk_multiple:%i dn_sample_mode:%i",
           //       rx_pdm_cfg.clk_cfg.sample_rate_hz, rx_pdm_cfg.clk_cfg.clk_src, rx_pdm_cfg.clk_cfg.mclk_multiple, rx_pdm_cfg.clk_cfg.dn_sample_mode);
@@ -637,10 +636,26 @@ bool TasmotaI2S::startI2SChannel(bool tx, bool rx) {
         break;
 #endif // SOC_I2S_SUPPORTS_PDM_RX
       case I2S_MODE_STD:
-        {        
+        {
+          i2s_std_slot_config_t _slot_cfg = {
+            .data_bit_width = (i2s_data_bit_width_t)bps,
+            .slot_bit_width = (i2s_slot_bit_width_t)audio_i2s.Settings->rx.slot_bit_width,
+            .slot_mode = (i2s_slot_mode_t)channels,
+            .slot_mask = (i2s_std_slot_mask_t)audio_i2s.Settings->rx.slot_mask,
+            .ws_width = audio_i2s.Settings->rx.ws_width,
+            .ws_pol = audio_i2s.Settings->rx.ws_pol,
+            .bit_shift = audio_i2s.Settings->rx.bit_shift,
+#if SOC_I2S_HW_VERSION_1    // For esp32/esp32-s2
+            .msb_right = audio_i2s.Settings->rx.bit_order_lsb, // Placeholder for now!!
+#else
+            .left_align = audio_i2s.Settings->rx.left_align,
+            .big_endian = audio_i2s.Settings->rx.big_endian,
+            .bit_order_lsb = audio_i2s.Settings->rx.bit_order_lsb,
+#endif
+          };
           i2s_std_config_t rx_std_cfg = {
             .clk_cfg  = I2S_STD_CLK_DEFAULT_CONFIG(_rx_freq),
-            .slot_cfg = I2S_STD_MSB_SLOT_DEFAULT_CONFIG(rx_data_bit_width, rx_slot_mode),
+            .slot_cfg = _slot_cfg,
             .gpio_cfg = {
               .mclk = (gpio_num_t)Pin(GPIO_I2S_MCLK),
               .bclk = (gpio_num_t)Pin(GPIO_I2S_BCLK),
@@ -654,11 +669,10 @@ bool TasmotaI2S::startI2SChannel(bool tx, bool rx) {
               },
             },
           };
-          if (_rx_slot_mask != I2S_SLOT_NOCHANGE) { rx_std_cfg.slot_cfg.slot_mask = (i2s_std_slot_mask_t)_rx_slot_mask; }
 
           err = i2s_channel_init_std_mode(_rx_handle, &rx_std_cfg);
-          AddLog(LOG_LEVEL_DEBUG, "I2S: RX i2s_channel_init_std_mode err:%i", err);
-          AddLog(LOG_LEVEL_DEBUG, "I2S: RX channel in standard mode with 16 bit width on %i channel(s) initialized", rx_slot_mode);
+          AddLog(LOG_LEVEL_DEBUG, "I2S: RX i2s_channel_init_std_mode with err:%i", err);
+          AddLog(LOG_LEVEL_DEBUG, "I2S: RX channel in standard mode with %u bit width on %i channel(s) initialized", bps, rx_slot_mode);
           if (err) {
             _rx_handle = nullptr;
             return false;

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_3_lib_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_3_lib_idf51.ino
@@ -236,7 +236,7 @@ protected:
   // TX
   bool      _tx_configured = false;       // true = configured, false = not configured
   uint8_t   _tx_mode = I2S_MODE_STD;      // I2S_MODE_STD / I2S_MODE_PDM / I2S_MODE_TDM / I2S_MODE_DAC
-  uint8_t   _tx_slot_mask = 0;
+  uint8_t   _tx_slot_mask = BIT(0)|BIT(1);// default stereo
   bool      _tx_running = false;          // true = enabled, false = disabled
   uint8_t   _tx_channels = 2;             // number of channels, 1 = mono, 2 = stereo -- `channels`
   i2s_chan_handle_t _tx_handle = nullptr; // I2S channel handle, automatically computed
@@ -246,12 +246,12 @@ protected:
   // RX
   bool      _rx_configured = false;       // true = configured, false = not configured
   uint8_t   _rx_mode = I2S_MODE_STD;      // I2S_MODE_STD / I2S_MODE_PDM / I2S_MODE_TDM / I2S_MODE_DAC
-  uint8_t   _rx_slot_mask = 0;
+  uint8_t   _rx_slot_mask = BIT(0);       // default mono: for PDM right, for standard left
   bool      _rx_running = false;          // true = enabled, false = disabled
   uint8_t   _rx_channels = 2;             // number of channels, 1 = mono, 2 = stereo
   i2s_chan_handle_t _rx_handle = nullptr; // I2S channel handle, automatically computed
   // uint8_t   _rx_slot_config;              // I2S slot configuration
-  uint16_t  _rx_freq = 16000;             // I2S Rx sampling frequency in Hz
+  uint16_t  _rx_freq = 32000;             // I2S Rx sampling frequency in Hz - default 32 kHz to prevent problems with Shine Encoder
   uint8_t   _rx_bps = 16;                 // bits per sample, 16 or 8
 
   uint16_t  _rx_gain = 0x10;              // Microphone gain in Q12.4 format (0x10 = 1.0)
@@ -589,9 +589,9 @@ bool TasmotaI2S::startI2SChannel(bool tx, bool rx) {
 
     i2s_chan_config_t rx_chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(_i2s_port, I2S_ROLE_MASTER);
     i2s_data_bit_width_t rx_data_bit_width = (_rx_bps == 8) ? I2S_DATA_BIT_WIDTH_8BIT : I2S_DATA_BIT_WIDTH_16BIT;
-    // change to 3 buffers of 512 samples
-    rx_chan_cfg.dma_desc_num = 3;
-    rx_chan_cfg.dma_frame_num = 1024;
+    // defaults to 3 buffers of 512 samples
+    rx_chan_cfg.dma_desc_num = audio_i2s.Settings->rx.dma_desc_num;
+    rx_chan_cfg.dma_frame_num = audio_i2s.Settings->rx.dma_frame_num;
 
     AddLog(LOG_LEVEL_DEBUG, "I2S: rx_chan_cfg id:%i role:%i dma_desc_num:%i dma_frame_num:%i auto_clear:%i",
           rx_chan_cfg.id, rx_chan_cfg.role, rx_chan_cfg.dma_desc_num, rx_chan_cfg.dma_frame_num, rx_chan_cfg.auto_clear);

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_2_i2s_mp3stream_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_2_i2s_mp3stream_idf51.ino
@@ -26,10 +26,6 @@
 
 
 void Stream_mp3(void) {
-  if (!audio_i2s.Settings->tx.stream_enable) {
-    return;
-  }
-
   if (audio_i2s_mp3.stream_active) {
     return;
   }
@@ -37,7 +33,8 @@ void Stream_mp3(void) {
   audio_i2s_mp3.stream_active = 1;
   audio_i2s_mp3.client = audio_i2s_mp3.MP3Server->client();
   AddLog(LOG_LEVEL_INFO, PSTR("I2S: Create client"));
-  i2s_record_shine((char*)"stream.mp3");
+  // i2s_record_shine((char*)"stream.mp3");
+  I2sRecordShine((char*)"stream.mp3");
 }
 
 void I2sMp3Loop(void) {
@@ -60,6 +57,7 @@ void I2sMp3Init(uint32_t on) {
       audio_i2s_mp3.MP3Server->stop();
       delete audio_i2s_mp3.MP3Server;
       audio_i2s_mp3.MP3Server = nullptr;
+      audio_i2s_mp3.mic_stop = 1;
       AddLog(LOG_LEVEL_INFO, PSTR("MP3: server deleted"));
     }
   }


### PR DESCRIPTION
## Description:

This should fix the crashes for configurations with an input/microphone only (no output device) and can handle the widespread INMP441.

- fix: use input and not output instance for microphone recording
- expose more low level properties of the I2S framework in the driver setting, which is needed for the INMP441 and should be future proof for all kinds of I2S microphones in standard mode
- expose DMA buffer settings - needed for higher sampling rates (i.e. 48000 Hz can work)
- change some defaults so that MP3 recording/streaming will work without setting a compatible sampling rate first
- turn off automatic start of streaming server if enabled in firmware, because that does not resonate well with the new flexible driver concept. Would need something like `i2sstream 1` in `autoexec.bat` or with another autostart method.
- attempt to give Free-RTOS more info about the timing requirements of the microphone task
- more internal refactoring

The new driver concept is all about runtime configuration with a new command `i2sconfig` that prints a (pretty big) JSON like that:
```
19:09:36.370 MQT: stat/tasmota_4359CC/RESULT = 
{"I2SConfig":{"Sys":{"Version":2,"Duplex":0,"Tx":0,"Rx":1,"Exclusive":0,"MclkInv0":0,"MclkInv1":0,"BclkInv0":0,"BclkInv1":0,"WsInv0":0,
"WsInv1":0,"Mp3Preallocate":1},
"Tx":{"SampleRate":16000,"Gain":10,"Mode":0,"SlotMask":3,"SlotConfig":0,"Channels":2,"APLL":1},"
Rx":{"SampleRate":48000,"Gain":30,"Mode":1,"SlotMask":1,"SlotWidth":32,"Channels":1,"DCFilterAlpha":32511,
"LowpassAlpha":17719,"APLL":1,"WsWidth":32,"WsPol":0,"BitShift":1,"LeftAlign":1,"BigEndian":0,"LsbOrder":0,
"DMAFrame":768,"DMADesc":5}}}
```

This looks a bit wild at first glance, but will be explained soon in the docs.
For instance changing from default (which is PDM mode for the microphone) to the INMP441 in left channel configuration is only:
`i2sconfig {"Rx":{"Mode":0}}`

Using MP3 encoding would need PSRAM allocation:
`i2sconfig {"Sys":{"Mp3Preallocate":1}}
`

Changing the sample rate:
`i2sconfig {"Rx":{"SampleRate":48000}}
`

The latter would need a larger DMA buffer:
`i2sconfig {"Rx":{"DMAFrame":768}}`

More on this later ...

There are still a few glitches and probably some bugs, that will be addressed in separate PR's.
The vast majority of changes in comparison to the old driver is about configuration and setup. All time critical parts did not really change that much.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
