### PR TITLE
add target reset

### DIFF
--- a/pio-tools/custom_target.py
+++ b/pio-tools/custom_target.py
@@ -335,6 +335,35 @@ def esp32_use_external_crashreport(*args, **kwargs):
         )
         print(Fore.YELLOW + output[0]+": \n"+output[1]+" in "+output[2])
 
+
+def reset_target(*args, **kwargs):
+    esptoolpy = join(platform.get_package_dir("tool-esptoolpy") or "", "esptool.py")
+    upload_port = join(env.get("UPLOAD_PORT", "none"))
+    if "none" in upload_port:
+        env.AutodetectUploadPort()
+        upload_port = join(env.get("UPLOAD_PORT", "none"))
+    esptoolpy_flags = [
+        "--no-stub",
+        "--chip", mcu,
+        "--port", upload_port,
+        "flash_id"
+    ]
+    esptoolpy_cmd = [env["PYTHONEXE"], esptoolpy] + esptoolpy_flags
+    print("Try to reset device")
+    subprocess.call(esptoolpy_cmd, shell=False)
+
+
+env.AddCustomTarget(
+    name="reset_target",
+    dependencies=None,
+    actions=[
+        reset_target
+    ],
+    title="Reset ESP32 target",
+    description="This command resets ESP32x target via esptoolpy",
+)
+
+
 env.AddCustomTarget(
     name="downloadfs",
     dependencies=None,


### PR DESCRIPTION
## Description:

- add Reset device function in VSC/Platformio menu
Some devices can not be resetted form esptool when manually put in flash mode via `RST` button (for example the S2 when using USB Port). The added function uses a trick to get device out of flash mode.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
