### PR TITLE
Fixed `EthType` for Core3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Berry `web_add_handler` called before `Webserver` is initialized
 - Put back wifi IPv6 workaround
 - Berry `math.inf`, `math.isinf()` and fixed json ouput for `inf` and `nan`
+- `EthType` for Core3
 
 ### Removed
 - LVGL disabled vector graphics


### PR DESCRIPTION
## Description:

Fixed EthTypes for Core3.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
