### PR TITLE
Ethernet driver compile fix

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
@@ -78,7 +78,7 @@
 #endif
 
 #ifndef ETH_TYPE
-#define ETH_TYPE          0                      // 0 = LAN8720, 1 = TLK110/IP101, 2 = RTL8201, 3 = DP83848, 4 = DM9051, 5 = KSZ8081, 6 = KSZ8041, 7 = JL1101, 8 = W5500, 9 = KSZ8851
+#define ETH_TYPE          0                      // 0 = LAN8720, 1 = TLK110/IP101, 2 = RTL8201, 3 = DP83848, 4 = reserved, 5 = KSZ8081, 6 = KSZ8041, 7 = JL1101, 8 = W5500, 9 = KSZ8851, 10 = DM9051
 #endif
 
 #ifndef ETH_CLKMODE

--- a/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
@@ -96,7 +96,9 @@ const uint8_t eth_type_xtable[] = {
   ETH_PHY_TLK110,       //  1 = TLK110/IP101
   ETH_PHY_RTL8201,      //  2 = RTL8201
   ETH_PHY_DP83848,      //  3 = DP83848
+#if CONFIG_ETH_SPI_ETHERNET_DM9051
   ETH_PHY_DM9051  | ETH_USES_SPI, //  4 = 10 = DM9051
+#endif
   ETH_PHY_KSZ8081,      //  5 = KSZ8081
   ETH_PHY_KSZ8041,      //  6 = KSZ8041
   ETH_PHY_JL1101,       //  7 = JL1101
@@ -105,13 +107,19 @@ const uint8_t eth_type_xtable[] = {
   0,                    //  1 = TLK110/IP101
   0,                    //  2 = RTL8201
   0,                    //  3 = DP83848
+#if CONFIG_ETH_SPI_ETHERNET_DM9051
   ETH_PHY_DM9051  | ETH_USES_SPI, //  4 = 10 = DM9051
+#endif
   0,                    //  5 = KSZ8081
   0,                    //  6 = KSZ8041
   0,                    //  7 = JL1101
 #endif // CONFIG_ETH_USE_ESP32_EMAC
+#if CONFIG_ETH_SPI_ETHERNET_W5500
   ETH_PHY_W5500   | ETH_USES_SPI,     //  8 = W5500
+#endif
+#if CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL
   ETH_PHY_KSZ8851 | ETH_USES_SPI,     //  9 = KSZ8851
+#endif
 };
 char eth_hostname[sizeof(TasmotaGlobal.hostname)];
 uint8_t eth_config_change;

--- a/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
@@ -96,9 +96,7 @@ const uint8_t eth_type_xtable[] = {
   ETH_PHY_TLK110,       //  1 = TLK110/IP101
   ETH_PHY_RTL8201,      //  2 = RTL8201
   ETH_PHY_DP83848,      //  3 = DP83848
-#if CONFIG_ETH_SPI_ETHERNET_DM9051
-  ETH_PHY_DM9051  | ETH_USES_SPI, //  4 = 10 = DM9051
-#endif
+  0,                    //  4 = future use
   ETH_PHY_KSZ8081,      //  5 = KSZ8081
   ETH_PHY_KSZ8041,      //  6 = KSZ8041
   ETH_PHY_JL1101,       //  7 = JL1101
@@ -107,9 +105,7 @@ const uint8_t eth_type_xtable[] = {
   0,                    //  1 = TLK110/IP101
   0,                    //  2 = RTL8201
   0,                    //  3 = DP83848
-#if CONFIG_ETH_SPI_ETHERNET_DM9051
-  ETH_PHY_DM9051  | ETH_USES_SPI, //  4 = 10 = DM9051
-#endif
+  0,                    //  4 = future use
   0,                    //  5 = KSZ8081
   0,                    //  6 = KSZ8041
   0,                    //  7 = JL1101
@@ -119,6 +115,9 @@ const uint8_t eth_type_xtable[] = {
 #endif
 #if CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL
   ETH_PHY_KSZ8851 | ETH_USES_SPI,     //  9 = KSZ8851
+#endif
+#if CONFIG_ETH_SPI_ETHERNET_DM9051
+  ETH_PHY_DM9051  | ETH_USES_SPI,     // 10 = DM9051
 #endif
 };
 char eth_hostname[sizeof(TasmotaGlobal.hostname)];


### PR DESCRIPTION
## Description:

fix compile when SPI Ethernet drivers are not enabled in IDF.
Change logic to avoid `EthType` shift.

@s-hadinger please check. Thx.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
