### PR TITLE
Zigbee startup event triggered after plugins are loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - uDisplay fast drawing on RGB displays
 - HDMI CEC synchronously sends messages
+- Zigbee startup event triggered after plugins are loaded
 
 ### Fixed
 - HASPmota `align` attribute and expand PNG cache

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_0_statemachine.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_0_statemachine.ino
@@ -532,14 +532,14 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     // Correctly configured and running, enable all Tasmota features
     // ======================================================================
   ZI_LABEL(ZIGBEE_LABEL_READY)
-    ZI_MQTT_STATE(ZIGBEE_STATUS_OK, kStarted)
-    ZI_LOG(LOG_LEVEL_INFO, kZigbeeStarted)
-    ZI_CALL(&Z_State_Ready, 1)                    // Now accept incoming messages
     ZI_CALL(&Z_Prepare_Storage, 0)
     ZI_CALL(&Z_Load_Devices, 0)
     ZI_CALL(&Z_Load_Data, 0)
     ZI_CALL(&Z_Set_Save_Data_Timer, 0)
     ZI_CALL(&Z_ZbAutoload, 0)
+    ZI_MQTT_STATE(ZIGBEE_STATUS_OK, kStarted)
+    ZI_LOG(LOG_LEVEL_INFO, kZigbeeStarted)
+    ZI_CALL(&Z_State_Ready, 1)                    // Now accept incoming messages
     ZI_CALL(&Z_Query_Bulbs, 0)
 
   ZI_LABEL(ZIGBEE_LABEL_MAIN_LOOP)
@@ -979,14 +979,14 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_SEND(ZBS_SET_MCAST_ENTRY)        ZI_WAIT_RECV(2500, ZBR_SET_MCAST_ENTRY)
 
   // ZI_LABEL(ZIGBEE_LABEL_READY)
-    ZI_MQTT_STATE(ZIGBEE_STATUS_OK, kStarted)
-    ZI_LOG(LOG_LEVEL_INFO, kZigbeeStarted)
-    ZI_CALL(&Z_State_Ready, 1)                    // Now accept incoming messages
     ZI_CALL(&Z_Prepare_Storage, 0)
     ZI_CALL(&Z_Load_Devices, 0)
     ZI_CALL(&Z_Load_Data, 0)
     ZI_CALL(&Z_Set_Save_Data_Timer, 0)
     ZI_CALL(&Z_ZbAutoload, 0)
+    ZI_MQTT_STATE(ZIGBEE_STATUS_OK, kStarted)
+    ZI_LOG(LOG_LEVEL_INFO, kZigbeeStarted)
+    ZI_CALL(&Z_State_Ready, 1)                    // Now accept incoming messages
     ZI_CALL(&Z_Query_Bulbs, 0)
 
   ZI_LABEL(ZIGBEE_LABEL_MAIN_LOOP)


### PR DESCRIPTION
## Description:

Now the Zigbee startup event are sent after plugins are loaded

```
19:51:39.364 MQT: tele/tasmota/ZBBridge/RESULT = {"ZbState":{"Status":51,"IEEEAddr":"0x00124B002A2E916B","ShortAddr":"0x0000","DeviceType":7,"DeviceState":9,"NumAssocDevices":2,"AssocDevicesList":["0xE7D6","0x040B"]}}
19:51:39.937 ZIG: Zigbee device information found in File System (12 devices - 616 bytes)
19:51:39.957 ZIG: Zigbee device data in File System (441 bytes)
19:51:39.966 ZIG: ZbLoad '<internal_plugin>' loaded successfully
19:51:40.064 ZIG: ZbLoad 'Aqara_plug.zb' loaded successfully
19:51:40.163 ZIG: ZbLoad 'air_quality.zb' loaded successfully
19:51:40.234 ZIG: ZbLoad 'giex_water.zb' loaded successfully
19:51:40.265 MQT: tele/tasmota/ZBBridge/RESULT = {"ZbState":{"Status":0,"Message":"Started"}}
19:51:40.267 ZIG: Zigbee started
```

**Related issue (if applicable):** fixes #21305

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
