### PR TITLE
Changed internal macro `APP_SLEEP` to `TASMOTA_SLEEP` to specify default sleep in ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - HDMI CEC synchronously sends messages
 - Zigbee startup event triggered after plugins are loaded
 - Reduced safeboot size by 2.9KB
+- Changed internal macro `APP_SLEEP` to `TASMOTA_SLEEP` to specify default sleep in ms
 
 ### Fixed
 - HASPmota `align` attribute and expand PNG cache

--- a/tasmota/include/tasmota_configurations.h
+++ b/tasmota/include/tasmota_configurations.h
@@ -694,9 +694,6 @@
   #define CODE_IMAGE_STR "lite"
 #endif
 
-#undef APP_SLEEP
-#define APP_SLEEP 1                              // Default to sleep = 1 for FIRMWARE_LITE
-
 #undef USE_ARDUINO_OTA                           // Disable support for Arduino OTA
 #undef USE_DOMOTICZ                              // Disable Domoticz
 #undef USE_HOME_ASSISTANT                        // Disable Home Assistant

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -286,7 +286,7 @@ https://rya.nc/tasmota-fingerprint.html"
 #define APP_BISTABLE_PULSE     40                // [SetOption45] Pulse time in ms for two coil bistable latching relays
 
 #define APP_NORMAL_SLEEP       false             // [SetOption60] Enable normal sleep instead of dynamic sleep
-#define APP_SLEEP              0                 // [Sleep] Sleep time to lower energy consumption (0 = Off, 1 - 250 mSec),
+#define TASMOTA_SLEEP          50                // [Sleep] Sleep time to lower energy consumption (0 = Off, value in milliseconds),
 #define PWM_MAX_SLEEP          10                // Sleep will be lowered to this value when light is on, to avoid flickering, and when buzzer is on for better on/off period accuracy
 
 #define KEY_DEBOUNCE_TIME      50                // [ButtonDebounce] Number of mSeconds button press debounce time

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -995,10 +995,7 @@ void SettingsDefaultSet2(void) {
   Settings->param[P_BOOT_LOOP_OFFSET] = BOOT_LOOP_OFFSET;  // SetOption36
   Settings->param[P_RGB_REMAP] = RGB_REMAP_RGBW;
 #endif // FIRMWARE_MINIMAL
-  Settings->sleep = APP_SLEEP;
-  if (Settings->sleep < 50) {
-    Settings->sleep = 50;                // Default to 50 for sleep, for now
-  }
+  Settings->sleep = TASMOTA_SLEEP;
   Settings->battery_level_percent = 101;
 
   // Module


### PR DESCRIPTION
## Description:

Due to the way `APP_SLEEP` worked, it was anyways defaulted to 50ms.

It is renamed to `TASMOTA_SLEEP` to avoid collision, and allows now the precise value to be changed as the default value of pre-compiled firmwares.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
