### PR TITLE
Prepare restoration of Tensorflow driver  for Core 3

### DIFF
--- a/lib/libesp32_ml/tf_lite_esp32/src/tensorflow/lite/micro/kernels/esp_nn/conv.cc
+++ b/lib/libesp32_ml/tf_lite_esp32/src/tensorflow/lite/micro/kernels/esp_nn/conv.cc
@@ -115,13 +115,13 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   if (input->type == kTfLiteInt8) {
     data_dims_t input_dims =  {
                                 .width = input_width, .height = input_height,
-                                .channels = input->dims->data[3], 1
+                                .channels = input->dims->data[3], .extra = 1
                               };
     data_dims_t output_dims = {
                                 .width = output_width, .height = output_height,
-                                .channels = output->dims->data[3], 1
+                                .channels = output->dims->data[3], .extra = 1
                               };
-    data_dims_t filter_dims = {.width = filter_width, .height = filter_height, 0, 0};
+    data_dims_t filter_dims = {.width = filter_width, .height = filter_height, .channels = 0, .extra = 0};
     conv_params_t conv_params = {
                                   .in_offset = 0, .out_offset = 0,
                                   .stride = {params.stride_width, params.stride_height},
@@ -209,13 +209,13 @@ inline void EvalQuantizedPerChannel(
 
     data_dims_t input_dims =  {
                                 .width = input_width, .height = input_height,
-                                .channels = input_depth, 1
+                                .channels = input_depth, .extra = 1
                               };
     data_dims_t output_dims = {
                                 .width = output_width, .height = output_height,
-                                .channels = output_depth, 1
+                                .channels = output_depth, .extra = 1
                               };
-    data_dims_t filter_dims = {.width = filter_width, .height = filter_height, 0, 0};
+    data_dims_t filter_dims = {.width = filter_width, .height = filter_height, .channels = 0, .extra = 0};
     conv_params_t conv_params = {
                                   .in_offset = input_offset, .out_offset = output_offset,
                                   .stride = {stride_width, stride_height},

--- a/lib/libesp32_ml/tf_lite_esp32/src/tensorflow/lite/micro/kernels/esp_nn/depthwise_conv.cc
+++ b/lib/libesp32_ml/tf_lite_esp32/src/tensorflow/lite/micro/kernels/esp_nn/depthwise_conv.cc
@@ -118,13 +118,13 @@ inline void EvalQuantizedPerChannel(TfLiteContext* context, TfLiteNode* node,
 
     data_dims_t input_dims =  {
                                 .width = input_width, .height = input_height,
-                                .channels = input_depth, 1
+                                .channels = input_depth, .extra = 1
                               };
     data_dims_t output_dims = {
                                 .width = output_width, .height = output_height,
-                                .channels = output_depth, 1
+                                .channels = output_depth, .extra = 1
                               };
-    data_dims_t filter_dims = {.width = filter_width, .height = filter_height, 0, 0};
+    data_dims_t filter_dims = {.width = filter_width, .height = filter_height, .channels = 0, .extra = 0};
     dw_conv_params_t conv_params =  {
                                       .in_offset = input_offset, .out_offset = output_offset,
                                       .ch_mult = depth_multiplier,
@@ -227,13 +227,13 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   if (input->type == kTfLiteInt8) {
     data_dims_t input_dims =  {
                                 .width = input_width, .height = input_height,
-                                .channels = input->dims->data[3], 1
+                                .channels = input->dims->data[3], .extra = 1
                               };
     data_dims_t output_dims = {
                                 .width = output_width, .height = output_height,
-                                .channels = output->dims->data[3], 1
+                                .channels = output->dims->data[3], .extra = 1
                               };
-    data_dims_t filter_dims = {.width = filter_width, .height = filter_height, 0, 0};
+    data_dims_t filter_dims = {.width = filter_width, .height = filter_height, .channels = 0, .extra = 0};
     dw_conv_params_t conv_params =  {
                                       .in_offset = 0, .out_offset = 0,
                                       .ch_mult = params.depth_multiplier,


### PR DESCRIPTION
## Description:

With GCC 12 the old version will note compile throwing:
either all initializer clauses should be designated or none of them

No functional changes.

The driver including speech recognition is already working locally using the new I2S driver.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
