### PR TITLE
Fixed HexToBytes function. Added Publish3 command to send binary data via MQTT.

### DIFF
--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -611,16 +611,15 @@ String HexToString(uint8_t* data, uint32_t length) {
 // Converts a Hex string (case insensitive) into an array of bytes
 // Returns the number of bytes in the array, or -1 if an error occured
 // The `out` buffer must be at least half the size of hex string
-int32_t HexToBytes(const char* hex, uint8_t* out, size_t* outLen) {
+int32_t HexToBytes(const char* hex, uint8_t* out, size_t outLen) {
   size_t len = strlen_P(hex);
-  *outLen = 0;
   if (len % 2 != 0) {
     return -1;
   }
 
   size_t outLength = len / 2;
   
-  for(size_t i = 0; i < outLength; i++) {
+  for (size_t i = 0; i < outLength && i < outLen; i++) {
     char byte[3];
     byte[0] = hex[i*2];
     byte[1] = hex[i*2 + 1];

--- a/tasmota/tasmota_xdrv_driver/xdrv_05_irremote_full.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_05_irremote_full.ino
@@ -654,7 +654,7 @@ uint32_t IrRemoteCmndIrSendJson(void)
     }
 
     uint8_t data_bytes[num_bytes];        // allocate on stack since it's small enough
-    if (HexToBytes(data_hex, data_bytes, &num_bytes) <= 0) { return IE_INVALID_HEXDATA; }
+    if (HexToBytes(data_hex, data_bytes, num_bytes) <= 0) { return IE_INVALID_HEXDATA; }
 
     if (lsb) {
       reverseBits(data_bytes, bits);

--- a/tasmota/tasmota_xdrv_driver/xdrv_73_8_lorawan_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_73_8_lorawan_bridge.ino
@@ -93,7 +93,7 @@ bool LoraWanLoadData(void) {
     app_key = root.getStr(PSTR(D_JSON_APPKEY), nullptr);
     if (strlen(app_key)) {
       size_t out_len = TAS_LORAWAN_AES128_KEY_SIZE;
-      HexToBytes(app_key, Lora->settings.end_node[n].AppKey, &out_len);
+      HexToBytes(app_key, Lora->settings.end_node[n].AppKey, out_len);
     }
     Lora->settings.end_node[n].DevEUIh = root.getUInt(PSTR(D_JSON_DEVEUI "h"), Lora->settings.end_node[n].DevEUIh);
     Lora->settings.end_node[n].DevEUIl = root.getUInt(PSTR(D_JSON_DEVEUI "l"), Lora->settings.end_node[n].DevEUIl);
@@ -581,8 +581,8 @@ void CmndLoraWanAppKey(void) {
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= TAS_LORAWAN_ENDNODES)) {
     uint32_t node = XdrvMailbox.index -1;
     if (32 == XdrvMailbox.data_len) {
-      size_t out_len = 16;
-      HexToBytes(XdrvMailbox.data, Lora->settings.end_node[node].AppKey, &out_len);
+      size_t out_len = TAS_LORAWAN_AES128_KEY_SIZE;
+      HexToBytes(XdrvMailbox.data, Lora->settings.end_node[node].AppKey, out_len);
       if (0 == Lora->settings.end_node[node].name.length()) {
         Lora->settings.end_node[node].name = F("0x0000");
       }


### PR DESCRIPTION
## Description:

Add ability to the Publish command to send a hexstring as binary MQTT data.

Publish command now has the following options

Publish3 | <topic> <payload> = MQTT publish any topic and optional binary payload. For example the payload 7461736D6F7461 will output tasmota or the value ff will output the integer value 255

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
