### PR TITLE
remove crash recorder from safeboot

### DIFF
--- a/pio-tools/strip-floats.py
+++ b/pio-tools/strip-floats.py
@@ -1,6 +1,6 @@
 Import('env')
 
-build_flags = ''.join([element.replace("-D", " ") for element in env.GetProjectOption("build_flags")])
+build_flags = " ".join(env.GetProjectOption("build_flags"))
 
 #
 # Dump build environment (for debug)

--- a/pio-tools/strip-floats.py
+++ b/pio-tools/strip-floats.py
@@ -1,5 +1,7 @@
 Import('env')
 
+build_flags = ''.join([element.replace("-D", " ") for element in env.GetProjectOption("build_flags")])
+
 #
 # Dump build environment (for debug)
 #print env.Dump()
@@ -8,6 +10,10 @@ Import('env')
 flags = " ".join(env['LINKFLAGS'])
 flags = flags.replace("-u _printf_float", "")
 flags = flags.replace("-u _scanf_float", "")
+if "FIRMWARE_SAFEBOOT" in build_flags:
+  # Crash Recorder is not included in safeboot firmware -> remove Linker wrap
+  flags = flags.replace("-Wl,--wrap=panicHandler", "")
+  flags = flags.replace("-Wl,--wrap=xt_unhandled_exception", "")
 newflags = flags.split()
 
 env.Replace(

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -812,7 +812,9 @@ void CmndStatus(void)
   if (payload > MAX_STATUS) { return; }  // {"Command":"Error"}
   if (!Settings->flag.mqtt_enabled && (6 == payload)) { return; }  // SetOption3 - Enable MQTT
   if (!TasmotaGlobal.energy_driver && (9 == payload)) { return; }
+  #ifndef FIRMWARE_SAFEBOOT
   if (!CrashFlag() && (12 == payload)) { return; }
+  #endif // FIRMWARE_SAFEBOOT
   if (!Settings->flag3.shutter_mode && (13 == payload)) { return; }
 
   char stemp[200];
@@ -1042,6 +1044,7 @@ void CmndStatus(void)
     CmndStatusResponse(11);
   }
 
+#ifndef FIRMWARE_SAFEBOOT
   if (CrashFlag()) {
     if ((0 == payload) || (12 == payload)) {
       Response_P(PSTR("{\"" D_CMND_STATUS D_STATUS12_STATUS "\":"));
@@ -1050,6 +1053,7 @@ void CmndStatus(void)
       CmndStatusResponse(12);
     }
   }
+#endif // FIRMWARE_SAFEBOOT
 
 #ifdef USE_SHUTTER
   if ((0 == payload) || (13 == payload)) {
@@ -1252,6 +1256,7 @@ void CmndRestart(void)
     TasmotaGlobal.restart_deepsleep = true;
     ResponseCmndChar(PSTR("Go to sleep"));
     break;
+#ifndef FIRMWARE_SAFEBOOT
   case -1:
     CmndCrash();    // force a crash
     break;
@@ -1261,6 +1266,7 @@ void CmndRestart(void)
   case -3:
     CmndBlockedLoop();
     break;
+#endif // FIRMWARE_SAFEBOOT
   case 99:
     AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_APPLICATION D_RESTARTING));
     EspRestart();

--- a/tasmota/tasmota_support/support_crash_recorder.ino
+++ b/tasmota/tasmota_support/support_crash_recorder.ino
@@ -17,6 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifndef FIRMWARE_SAFEBOOT
+
 // Generate a crash to test the crash recorder
 void CmndCrash(void)
 {
@@ -359,5 +361,7 @@ void CrashDump(void)
 {
 }
 
-#endif 
 #endif
+#endif
+
+#endif  //  FIRMWARE_SAFEBOOT

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -1159,7 +1159,9 @@ void WifiDisable(void) {
 void EspRestart(void) {
   ResetPwm();
   WifiShutdown(true);
+#ifndef FIRMWARE_SAFEBOOT
   CrashDumpClear();           // Clear the stack dump in RTC
+#endif // FIRMWARE_SAFEBOOT
 
 #ifdef CONFIG_IDF_TARGET_ESP32C3
   GpioForceHoldRelay();       // Retain the state when the chip or system is reset, for example, when watchdog time-out or Deep-sleep

--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -1018,9 +1018,12 @@ void MqttConnected(void) {
       }
 #endif  // USE_WEBSERVER
       Response_P(PSTR("{\"Info3\":{\"" D_JSON_RESTARTREASON "\":"));
+#ifndef FIRMWARE_SAFEBOOT
       if (CrashFlag()) {
         CrashDump();
-      } else {
+      } else
+#endif // FIRMWARE_SAFEBOOT
+      {
         ResponseAppend_P(PSTR("\"%s\""), GetResetReason().c_str());
       }
       ResponseAppend_P(PSTR(",\"" D_JSON_BOOTCOUNT "\":%d}}"), Settings->bootcount +1);


### PR DESCRIPTION
## Description:

to shrink safeboot firmware size. Gain is 4044 bytes

@s-hadinger Please have a look if the changes are okay

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
