### PR TITLE
remove serial bridge from safeboot

### DIFF
--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -191,6 +191,7 @@
 #if CONFIG_FREERTOS_UNICORE
   #undef USE_MQTT_TLS
 //  #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge console Tee (+4.5k code)
+  #define USE_SPI                                    // Make SPI Ethernet adapters useable (+124 bytes)
   #define USE_ETHERNET
 #endif  // CONFIG_FREERTOS_UNICORE
 #endif  // CONFIG_IDF_TARGET_ESP32

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -190,7 +190,7 @@
 #if CONFIG_IDF_TARGET_ESP32
 #if CONFIG_FREERTOS_UNICORE
   #undef USE_MQTT_TLS
-//  #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge console Tee (+2k code)
+//  #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge console Tee (+4.5k code)
   #define USE_ETHERNET
 #endif  // CONFIG_FREERTOS_UNICORE
 #endif  // CONFIG_IDF_TARGET_ESP32

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -190,7 +190,7 @@
 #if CONFIG_IDF_TARGET_ESP32
 #if CONFIG_FREERTOS_UNICORE
   #undef USE_MQTT_TLS
-  #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge console Tee (+2k code)
+//  #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge console Tee (+2k code)
   #define USE_ETHERNET
 #endif  // CONFIG_FREERTOS_UNICORE
 #endif  // CONFIG_IDF_TARGET_ESP32


### PR DESCRIPTION
## Description:

shrink safeboot. Saves 4764 bytes.
add SPI support. Makes SPI Ethernet adapters useable (needs 124 bytes)

@s-hadinger fyi

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
