### PR TITLE
BLE: fix conflicting log_level definitions

### DIFF
--- a/lib/libesp32_div/esp-nimble-cpp/src/NimBLELog.h
+++ b/lib/libesp32_div/esp-nimble-cpp/src/NimBLELog.h
@@ -38,6 +38,19 @@
 #  define NIMBLE_LOGC(tag, format, ...) \
      NIMBLE_CPP_LOG_PRINT(ESP_LOG_ERROR, tag, format, ##__VA_ARGS__)
 
+// These defines pollute the global namespace and conflict with Tasmota and basically always turn on `seriallog 3`
+#ifdef LOG_LEVEL_DEBUG
+#undef LOG_LEVEL_DEBUG
+#endif
+
+#ifdef LOG_LEVEL_INFO
+#undef LOG_LEVEL_INFO
+#endif
+
+#ifdef LOG_LEVEL_ERROR
+#undef LOG_LEVEL_ERROR
+#endif
+
 #else // using Arduino
 #  include "nimble/porting/nimble/include/syscfg/syscfg.h"
 #  include "nimble/console/console.h"

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -60,13 +60,6 @@
 
 #define XSNS_62                    62
 
-// undefine "trash" from the NimBLE stack, that collides with Tasmotas enum
-#undef LOG_LEVEL_DEBUG
-#undef LOG_LEVEL_NONE
-#undef LOG_LEVEL_ERROR
-#undef LOG_LEVEL_INFO
-#undef LOG_LEVEL_DEBUG
-#undef LOG_LEVEL_DEBUG_MORE
 #include <vector>
 #include "freertos/ringbuf.h"
 


### PR DESCRIPTION
## Description:

Fixes an annoying glitch where macros from the nimble framework would override the log level enum of Tasmota with conflicting values.
Basically esp-nimble-cpp did always turn on LOG_LEVEL_DEBUG because this macro has a value of 0 in nimbles log header file. This overrides Tasmotas `enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE};` globally.

Valid for every Tasmota firmware that uses esp-nimble-cpp.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
