### PR TITLE
``Publish3`` to send binary data encoded as Hex, disabled in safeboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - TCP Tx En GPIO type
 - Berry `webserver.content_close()`
 - HASPmota demo of Renaissance Watch for 480x480 displays
+- ``Publish3`` to send binary data encoded as Hex, disabled in safeboot
 
 ### Breaking Changed
 - ESP32-C3 OTA binary name from `tasmota32c3cdc.bin` to `tasmota32c3.bin` with USB HWCDC and fallback to serial (#21212)

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -611,15 +611,18 @@ String HexToString(uint8_t* data, uint32_t length) {
 // Converts a Hex string (case insensitive) into an array of bytes
 // Returns the number of bytes in the array, or -1 if an error occured
 // The `out` buffer must be at least half the size of hex string
-int32_t HexToBytes(const char* hex, uint8_t* out, size_t outLen) {
+int32_t HexToBytes(const char* hex, uint8_t* out, size_t out_len) {
   size_t len = strlen_P(hex);
   if (len % 2 != 0) {
     return -1;
   }
 
-  size_t outLength = len / 2;
+  size_t bytes_out = len / 2;
+  if (bytes_out < out_len) {
+    bytes_out = out_len;
+  }
   
-  for (size_t i = 0; i < outLength && i < outLen; i++) {
+  for (size_t i = 0; i < bytes_out; i++) {
     char byte[3];
     byte[0] = hex[i*2];
     byte[1] = hex[i*2 + 1];
@@ -628,11 +631,11 @@ int32_t HexToBytes(const char* hex, uint8_t* out, size_t outLen) {
     char* endPtr;
     out[i] = strtoul(byte, &endPtr, 16);
     
-    if(*endPtr != '\0') {
+    if (*endPtr != '\0') {
       return -1;
     }
   }
-  return outLength;
+  return bytes_out;
 }
 
 String UrlEncode(const String& text) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -742,7 +742,7 @@ void MqttPublish(const char* topic, bool retained) {
   MqttPublishPayload(topic, ResponseData(), 0, retained);
 }
 
-void MqttPublish(const char* topic, bool retained, bool binary) {
+void MqttPublishBinary(const char* topic, bool retained, bool binary) {
   int32_t binary_length = 0;
   char *response_data = ResponseData();
   if (binary) {
@@ -1569,7 +1569,12 @@ void CmndPublish(void) {
       } else {
         ResponseClear();
       }
-      MqttPublish(stemp1, (XdrvMailbox.index == 2), (XdrvMailbox.index == 3));
+#ifndef FIRMWARE_MINIMAL
+      // Publish3 binary is not enabled in MINIMAL
+      MqttPublishBinary(stemp1, (XdrvMailbox.index == 2), (XdrvMailbox.index == 3));
+#else
+      MqttPublish(stemp1, (XdrvMailbox.index == 2));
+#endif
       ResponseClear();
     }
   }


### PR DESCRIPTION
## Description:

Small optimization to `HexToBytes` and clarification of variable names
`Publish3` is disabled in MINIMAL and SAFEBOOT (avoid spending 181 bytes)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
