### PR TITLE
let berry drivers provide "after_teleperiod" handlers

### DIFF
--- a/lib/libesp32/berry_tasmota/src/embedded/driver_class.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/driver_class.be
@@ -14,6 +14,7 @@ class Driver
   var save_before_restart
   var web_sensor
   var json_append
+  var after_teleperiod
   var button_pressed
   var display
 

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_driver_class.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_driver_class.h
@@ -70,7 +70,7 @@ be_local_closure(Driver_add_cmd,   /* name */
 ** Solidified class: Driver
 ********************************************************************/
 be_local_class(Driver,
-    13,
+    14,
     NULL,
     be_nested_map(14,
     ( (struct bmapnode*) &(const bmapnode[]) {
@@ -87,6 +87,7 @@ be_local_class(Driver,
         { be_const_key(web_add_management_button, 0), be_const_var(5) },
         { be_const_key(every_100ms, 13), be_const_var(1) },
         { be_const_key(json_append, -1), be_const_var(10) },
+        { be_const_key(after_teleperiod, -1), be_const_var(13) },
         { be_const_key(web_add_button, -1), be_const_var(3) },
     })),
     (bstring*) &be_const_str_Driver

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -985,6 +985,9 @@ bool Xdrv52(uint32_t function)
     case FUNC_JSON_APPEND:
       callBerryEventDispatcher(PSTR("json_append"), nullptr, 0, nullptr);
       break;
+    case FUNC_AFTER_TELEPERIOD:
+      callBerryEventDispatcher(PSTR("after_teleperiod"), nullptr, 0, nullptr);
+      break;
 
     case FUNC_BUTTON_PRESSED:
       callBerryEventDispatcher(PSTR("button_pressed"), nullptr, 0, nullptr);


### PR DESCRIPTION
This is useful if you want to periodically report the state of something handled separately to the sensors output.

## Description:

I'm working on Yet Another(tm) driver for micradar devices, the R60ASM1 in particular, which seems to work in a similar fashion to a TuyaMCU device in that it has a concept of independent datapoints that report at different times.  Because there are so many different datapoints, the driver relays their updates as separate mqtt topics, (eg, tele/%topic%/R60ASM1/BreathingRate or tele/%topic%/R60ASM1/MonitorSwitch) rather than shove several dozen bits of info into the SENSORS or STATE payloads. Some datapoints are updated very infrequently, so it's handy to report them every teleperiod so stupid downstream systems (eg, HA) don't forget what's going on.

C drivers can hook `FUNC_AFTER_TELEPERIOD` for similar reasons. This extends it to Berry drivers too.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
