### PR TITLE
Fixed void unwanted OTA upgrade when safeboot starts for the first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 - Berry `math.inf`, `math.isinf()` and fixed json ouput for `inf` and `nan` (#21304)
 - Compilation of Ethernet when SPI drivers are disabled (#21321)
 - Conflicting log_level definitions in NimBLE (#21337)
+- Avoid unwanted OTA upgrade when safeboot starts for the first time
 
 ### Removed
 - LVGL disabled vector graphics (#21242)

--- a/tasmota/tasmota_support/support_esp32.ino
+++ b/tasmota/tasmota_support/support_esp32.ino
@@ -177,7 +177,7 @@ void QPCWrite(const void *pSettings, unsigned nSettingsLen) {
 }
 
 bool OtaFactoryRead(void) {
-  uint32_t pOtaLoader;
+  uint32_t pOtaLoader = 0;
   NvmLoad("otal", "otal", &pOtaLoader, sizeof(pOtaLoader));
   return pOtaLoader;
 }


### PR DESCRIPTION
## Description:

When booting the first time on safeboot partition, an unwanted OTA upgrade from OtaURL would automatically be triggered. This is due to `NvmLoad("otal", "otal", &pOtaLoader, sizeof(pOtaLoader));` not updating `pOtaLoader` since the value does not yet exist in NMV, hence the value would default to a random value from the stack, and generally not `0`.

This PR sets the default value to `0` so no unwanted OTA is done when NVM is not yet populated.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
