### PR TITLE
Seriallog set to `SERIAL_LOG_LEVEL` at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Internal macro `APP_SLEEP` to `TASMOTA_SLEEP` to specify default sleep in ms (#21324)
 - ESP32 Core3 platform update from 2024.04.12 to 2024.05.10 (#21347)
 - Refactor Tensorflow (#21327)
+- Seriallog set to `SERIAL_LOG_LEVEL` at boot
 
 ### Fixed
 - HASPmota `align` attribute and expand PNG cache (#21228)

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -427,7 +427,7 @@ void setup(void) {
   TasmotaGlobal.active_device = 1;
   TasmotaGlobal.global_state.data = 0xF;  // Init global state (wifi_down, mqtt_down) to solve possible network issues
   TasmotaGlobal.maxlog_level = LOG_LEVEL_DEBUG_MORE;
-  TasmotaGlobal.seriallog_level = LOG_LEVEL_INFO;  // Allow specific serial messages until config loaded
+  TasmotaGlobal.seriallog_level = SERIAL_LOG_LEVEL;  // Allow specific serial messages until config loaded
   TasmotaGlobal.power_latching = 0x80000000;
 
   RtcRebootLoad();

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -427,7 +427,7 @@ void setup(void) {
   TasmotaGlobal.active_device = 1;
   TasmotaGlobal.global_state.data = 0xF;  // Init global state (wifi_down, mqtt_down) to solve possible network issues
   TasmotaGlobal.maxlog_level = LOG_LEVEL_DEBUG_MORE;
-  TasmotaGlobal.seriallog_level = SERIAL_LOG_LEVEL;  // Allow specific serial messages until config loaded
+  TasmotaGlobal.seriallog_level = (SERIAL_LOG_LEVEL > LOG_LEVEL_INFO) ? SERIAL_LOG_LEVEL : LOG_LEVEL_INFO;  // Allow specific serial messages until config loaded and allow more logging than INFO
   TasmotaGlobal.power_latching = 0x80000000;
 
   RtcRebootLoad();


### PR DESCRIPTION
## Description:

Seriallog level is set to `SERIAL_LOG_LEVEL` at boot instead of hard-coded `LOG_LEVEL_INFO`, which allows to set a different level for debug purposes.

There is no change for default binaries.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
