### PR TITLE
Matter broken NOCStruct types preventing pairing with HA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this project will be documented in this file.
 - Compilation of Ethernet when SPI drivers are disabled (#21321)
 - Conflicting log_level definitions in NimBLE (#21337)
 - Avoid unwanted OTA upgrade when safeboot starts for the first time
+- Matter broken NOCStruct types preventing pairing with HA
 
 ### Removed
 - LVGL disabled vector graphics (#21242)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Root.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Root.be
@@ -159,7 +159,7 @@ class Matter_Plugin_Root : Matter_Plugin
           var nocs = nocl.add_struct(nil)
           nocs.add_TLV(1, TLV.B2, loc_fabric.get_noc())      # NOC
           nocs.add_TLV(2, TLV.B2, loc_fabric.get_icac())     # ICAC
-          nocs.add_TLV(matter.AGGREGATOR_ENDPOINT, TLV.U2, loc_fabric.get_fabric_index())    # Label
+          nocs.add_TLV(0xFE, TLV.U2, loc_fabric.get_fabric_index())    # Label
         end
         return nocl
       elif attribute == 0x0001          #  ---------- Fabrics / list[FabricDescriptorStruct] ----------

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Root.h
@@ -81,43 +81,43 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
     /* K58  */  be_nested_str_weak(B2),
     /* K59  */  be_nested_str_weak(get_noc),
     /* K60  */  be_nested_str_weak(get_icac),
-    /* K61  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-    /* K62  */  be_nested_str_weak(get_fabric_index),
-    /* K63  */  be_nested_str_weak(stop_iteration),
-    /* K64  */  be_nested_str_weak(parse),
-    /* K65  */  be_nested_str_weak(get_ca),
-    /* K66  */  be_nested_str_weak(findsubval),
-    /* K67  */  be_nested_str_weak(get_admin_vendor),
-    /* K68  */  be_nested_str_weak(get_fabric_id_as_int64),
-    /* K69  */  be_nested_str_weak(get_device_id_as_int64),
-    /* K70  */  be_nested_str_weak(get_fabric_label),
-    /* K71  */  be_nested_str_weak(Fabric),
-    /* K72  */  be_nested_str_weak(_MAX_CASE),
-    /* K73  */  be_nested_str_weak(count_active_fabrics),
-    /* K74  */  be_nested_str_weak(_fabric),
-    /* K75  */  be_nested_str_weak(is_commissioning_open),
-    /* K76  */  be_nested_str_weak(is_root_commissioning_open),
-    /* K77  */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K78  */  be_nested_str_weak(Tasmota),
-    /* K79  */  be_nested_str_weak(vendorid),
-    /* K80  */  be_nested_str_weak(DeviceName),
-    /* K81  */  be_nested_str_weak(FriendlyName),
-    /* K82  */  be_nested_str_weak(FriendlyName1),
-    /* K83  */  be_nested_str_weak(XX),
-    /* K84  */  be_nested_str_weak(Status_X202),
-    /* K85  */  be_nested_str_weak(StatusFWR),
-    /* K86  */  be_nested_str_weak(Hardware),
-    /* K87  */  be_nested_str_weak(Version),
-    /* K88  */  be_nested_str_weak(_X28),
-    /* K89  */  be_nested_str_weak(locale),
-    /* K90  */  be_nested_str_weak(create_TLV),
-    /* K91  */  be_nested_str_weak(get_active_endpoints),
-    /* K92  */  be_nested_str_weak(disable_bridge_mode),
+    /* K61  */  be_nested_str_weak(get_fabric_index),
+    /* K62  */  be_nested_str_weak(stop_iteration),
+    /* K63  */  be_nested_str_weak(parse),
+    /* K64  */  be_nested_str_weak(get_ca),
+    /* K65  */  be_nested_str_weak(findsubval),
+    /* K66  */  be_nested_str_weak(get_admin_vendor),
+    /* K67  */  be_nested_str_weak(get_fabric_id_as_int64),
+    /* K68  */  be_nested_str_weak(get_device_id_as_int64),
+    /* K69  */  be_nested_str_weak(get_fabric_label),
+    /* K70  */  be_nested_str_weak(Fabric),
+    /* K71  */  be_nested_str_weak(_MAX_CASE),
+    /* K72  */  be_nested_str_weak(count_active_fabrics),
+    /* K73  */  be_nested_str_weak(_fabric),
+    /* K74  */  be_nested_str_weak(is_commissioning_open),
+    /* K75  */  be_nested_str_weak(is_root_commissioning_open),
+    /* K76  */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K77  */  be_nested_str_weak(Tasmota),
+    /* K78  */  be_nested_str_weak(vendorid),
+    /* K79  */  be_nested_str_weak(DeviceName),
+    /* K80  */  be_nested_str_weak(FriendlyName),
+    /* K81  */  be_nested_str_weak(FriendlyName1),
+    /* K82  */  be_nested_str_weak(XX),
+    /* K83  */  be_nested_str_weak(Status_X202),
+    /* K84  */  be_nested_str_weak(StatusFWR),
+    /* K85  */  be_nested_str_weak(Hardware),
+    /* K86  */  be_nested_str_weak(Version),
+    /* K87  */  be_nested_str_weak(_X28),
+    /* K88  */  be_nested_str_weak(locale),
+    /* K89  */  be_nested_str_weak(create_TLV),
+    /* K90  */  be_nested_str_weak(get_active_endpoints),
+    /* K91  */  be_nested_str_weak(disable_bridge_mode),
+    /* K92  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
     /* K93  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[937]) {  /* code */
+    ( &(const binstruction[936]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xB8160200,  //  0001  GETNGBL	R5	K1
       0x88140B02,  //  0002  GETMBR	R5	R5	K2
@@ -174,11 +174,11 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x502C0000,  //  0035  LDBOOL	R11	0	0
       0x7C200600,  //  0036  CALL	R8	3
       0x80041000,  //  0037  RET	1	R8
-      0x70020366,  //  0038  JMP		#03A0
+      0x70020365,  //  0038  JMP		#039F
       0x54220031,  //  0039  LDINT	R8	50
       0x1C200C08,  //  003A  EQ	R8	R6	R8
       0x78220000,  //  003B  JMPF	R8	#003D
-      0x70020362,  //  003C  JMP		#03A0
+      0x70020361,  //  003C  JMP		#039F
       0x54220032,  //  003D  LDINT	R8	51
       0x1C200C08,  //  003E  EQ	R8	R6	R8
       0x782200DC,  //  003F  JMPF	R8	#011D
@@ -402,11 +402,11 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x502C0000,  //  0119  LDBOOL	R11	0	0
       0x7C200600,  //  011A  CALL	R8	3
       0x80041000,  //  011B  RET	1	R8
-      0x70020282,  //  011C  JMP		#03A0
+      0x70020281,  //  011C  JMP		#039F
       0x54220033,  //  011D  LDINT	R8	52
       0x1C200C08,  //  011E  EQ	R8	R6	R8
       0x78220000,  //  011F  JMPF	R8	#0121
-      0x7002027E,  //  0120  JMP		#03A0
+      0x7002027D,  //  0120  JMP		#039F
       0x54220037,  //  0121  LDINT	R8	56
       0x1C200C08,  //  0122  EQ	R8	R6	R8
       0x7822002B,  //  0123  JMPF	R8	#0150
@@ -453,15 +453,15 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x5C301000,  //  014C  MOVE	R12	R8
       0x7C240600,  //  014D  CALL	R9	3
       0x80041200,  //  014E  RET	1	R9
-      0x7002024F,  //  014F  JMP		#03A0
+      0x7002024E,  //  014F  JMP		#039F
       0x5422003D,  //  0150  LDINT	R8	62
       0x1C200C08,  //  0151  EQ	R8	R6	R8
-      0x782200B6,  //  0152  JMPF	R8	#020A
+      0x782200B5,  //  0152  JMPF	R8	#0209
       0x8C200133,  //  0153  GETMET	R8	R0	K51
       0x5C280400,  //  0154  MOVE	R10	R2
       0x7C200400,  //  0155  CALL	R8	2
       0x1C200F05,  //  0156  EQ	R8	R7	K5
-      0x78220037,  //  0157  JMPF	R8	#0190
+      0x78220036,  //  0157  JMPF	R8	#018F
       0x8C200B11,  //  0158  GETMET	R8	R5	K17
       0x7C200200,  //  0159  CALL	R8	1
       0x88240534,  //  015A  GETMBR	R9	R2	K52
@@ -479,7 +479,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x60280010,  //  0166  GETGBL	R10	G16
       0x5C2C1200,  //  0167  MOVE	R11	R9
       0x7C280200,  //  0168  CALL	R10	1
-      0xA8020020,  //  0169  EXBLK	0	#018B
+      0xA802001F,  //  0169  EXBLK	0	#018A
       0x5C2C1400,  //  016A  MOVE	R11	R10
       0x7C2C0000,  //  016B  CALL	R11	0
       0x8C301739,  //  016C  GETMET	R12	R11	K57
@@ -506,555 +506,554 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x7C440200,  //  0181  CALL	R17	1
       0x7C340800,  //  0182  CALL	R13	4
       0x8C34190B,  //  0183  GETMET	R13	R12	K11
-      0xB83E0200,  //  0184  GETNGBL	R15	K1
-      0x883C1F3D,  //  0185  GETMBR	R15	R15	K61
-      0x88400B0C,  //  0186  GETMBR	R16	R5	K12
-      0x8C44173E,  //  0187  GETMET	R17	R11	K62
-      0x7C440200,  //  0188  CALL	R17	1
-      0x7C340800,  //  0189  CALL	R13	4
-      0x7001FFDE,  //  018A  JMP		#016A
-      0x5828003F,  //  018B  LDCONST	R10	K63
-      0xAC280200,  //  018C  CATCH	R10	1	0
-      0xB0080000,  //  018D  RAISE	2	R0	R0
-      0x80041000,  //  018E  RET	1	R8
-      0x70020078,  //  018F  JMP		#0209
-      0x1C200F09,  //  0190  EQ	R8	R7	K9
-      0x7822004D,  //  0191  JMPF	R8	#01E0
-      0x8C200B11,  //  0192  GETMET	R8	R5	K17
-      0x7C200200,  //  0193  CALL	R8	1
-      0x88240534,  //  0194  GETMBR	R9	R2	K52
-      0x78260005,  //  0195  JMPF	R9	#019C
-      0x60240012,  //  0196  GETGBL	R9	G18
-      0x7C240000,  //  0197  CALL	R9	0
-      0x8C280335,  //  0198  GETMET	R10	R1	K53
-      0x7C280200,  //  0199  CALL	R10	1
-      0x4028120A,  //  019A  CONNECT	R10	R9	R10
-      0x70020003,  //  019B  JMP		#01A0
-      0x88240136,  //  019C  GETMBR	R9	R0	K54
-      0x88241337,  //  019D  GETMBR	R9	R9	K55
-      0x8C241338,  //  019E  GETMET	R9	R9	K56
-      0x7C240200,  //  019F  CALL	R9	1
-      0x60280010,  //  01A0  GETGBL	R10	G16
-      0x5C2C1200,  //  01A1  MOVE	R11	R9
-      0x7C280200,  //  01A2  CALL	R10	1
-      0xA8020036,  //  01A3  EXBLK	0	#01DB
-      0x5C2C1400,  //  01A4  MOVE	R11	R10
-      0x7C2C0000,  //  01A5  CALL	R11	0
-      0x4C300000,  //  01A6  LDNIL	R12
-      0x1C30160C,  //  01A7  EQ	R12	R11	R12
-      0x78320000,  //  01A8  JMPF	R12	#01AA
-      0x7001FFF9,  //  01A9  JMP		#01A4
-      0x8C301739,  //  01AA  GETMET	R12	R11	K57
-      0x7C300200,  //  01AB  CALL	R12	1
-      0x78320000,  //  01AC  JMPF	R12	#01AE
-      0x7001FFF5,  //  01AD  JMP		#01A4
-      0x8C300B40,  //  01AE  GETMET	R12	R5	K64
-      0x8C381741,  //  01AF  GETMET	R14	R11	K65
-      0x7C380200,  //  01B0  CALL	R14	1
-      0x7C300400,  //  01B1  CALL	R12	2
-      0x8C341115,  //  01B2  GETMET	R13	R8	K21
-      0x4C3C0000,  //  01B3  LDNIL	R15
-      0x7C340400,  //  01B4  CALL	R13	2
-      0x8C381B0B,  //  01B5  GETMET	R14	R13	K11
-      0x58400009,  //  01B6  LDCONST	R16	K9
-      0x88440B3A,  //  01B7  GETMBR	R17	R5	K58
-      0x8C481942,  //  01B8  GETMET	R18	R12	K66
-      0x54520008,  //  01B9  LDINT	R20	9
-      0x7C480400,  //  01BA  CALL	R18	2
-      0x7C380800,  //  01BB  CALL	R14	4
-      0x8C381B0B,  //  01BC  GETMET	R14	R13	K11
-      0x5840000D,  //  01BD  LDCONST	R16	K13
-      0x88440B0C,  //  01BE  GETMBR	R17	R5	K12
-      0x8C481743,  //  01BF  GETMET	R18	R11	K67
-      0x7C480200,  //  01C0  CALL	R18	1
-      0x7C380800,  //  01C1  CALL	R14	4
-      0x8C381B0B,  //  01C2  GETMET	R14	R13	K11
-      0x5840000F,  //  01C3  LDCONST	R16	K15
-      0x88440B07,  //  01C4  GETMBR	R17	R5	K7
-      0x8C481744,  //  01C5  GETMET	R18	R11	K68
-      0x7C480200,  //  01C6  CALL	R18	1
-      0x7C380800,  //  01C7  CALL	R14	4
-      0x8C381B0B,  //  01C8  GETMET	R14	R13	K11
-      0x54420003,  //  01C9  LDINT	R16	4
-      0x88440B07,  //  01CA  GETMBR	R17	R5	K7
-      0x8C481745,  //  01CB  GETMET	R18	R11	K69
-      0x7C480200,  //  01CC  CALL	R18	1
-      0x7C380800,  //  01CD  CALL	R14	4
-      0x8C381B0B,  //  01CE  GETMET	R14	R13	K11
-      0x54420004,  //  01CF  LDINT	R16	5
-      0x88440B16,  //  01D0  GETMBR	R17	R5	K22
-      0x8C481746,  //  01D1  GETMET	R18	R11	K70
-      0x7C480200,  //  01D2  CALL	R18	1
-      0x7C380800,  //  01D3  CALL	R14	4
-      0x8C381B0B,  //  01D4  GETMET	R14	R13	K11
-      0x544200FD,  //  01D5  LDINT	R16	254
-      0x88440B0C,  //  01D6  GETMBR	R17	R5	K12
-      0x8C48173E,  //  01D7  GETMET	R18	R11	K62
-      0x7C480200,  //  01D8  CALL	R18	1
-      0x7C380800,  //  01D9  CALL	R14	4
-      0x7001FFC8,  //  01DA  JMP		#01A4
-      0x5828003F,  //  01DB  LDCONST	R10	K63
-      0xAC280200,  //  01DC  CATCH	R10	1	0
-      0xB0080000,  //  01DD  RAISE	2	R0	R0
-      0x80041000,  //  01DE  RET	1	R8
-      0x70020028,  //  01DF  JMP		#0209
-      0x1C200F0D,  //  01E0  EQ	R8	R7	K13
-      0x78220007,  //  01E1  JMPF	R8	#01EA
-      0x8C200706,  //  01E2  GETMET	R8	R3	K6
-      0x88280B0E,  //  01E3  GETMBR	R10	R5	K14
-      0xB82E0200,  //  01E4  GETNGBL	R11	K1
+      0x543E00FD,  //  0184  LDINT	R15	254
+      0x88400B0C,  //  0185  GETMBR	R16	R5	K12
+      0x8C44173D,  //  0186  GETMET	R17	R11	K61
+      0x7C440200,  //  0187  CALL	R17	1
+      0x7C340800,  //  0188  CALL	R13	4
+      0x7001FFDF,  //  0189  JMP		#016A
+      0x5828003E,  //  018A  LDCONST	R10	K62
+      0xAC280200,  //  018B  CATCH	R10	1	0
+      0xB0080000,  //  018C  RAISE	2	R0	R0
+      0x80041000,  //  018D  RET	1	R8
+      0x70020078,  //  018E  JMP		#0208
+      0x1C200F09,  //  018F  EQ	R8	R7	K9
+      0x7822004D,  //  0190  JMPF	R8	#01DF
+      0x8C200B11,  //  0191  GETMET	R8	R5	K17
+      0x7C200200,  //  0192  CALL	R8	1
+      0x88240534,  //  0193  GETMBR	R9	R2	K52
+      0x78260005,  //  0194  JMPF	R9	#019B
+      0x60240012,  //  0195  GETGBL	R9	G18
+      0x7C240000,  //  0196  CALL	R9	0
+      0x8C280335,  //  0197  GETMET	R10	R1	K53
+      0x7C280200,  //  0198  CALL	R10	1
+      0x4028120A,  //  0199  CONNECT	R10	R9	R10
+      0x70020003,  //  019A  JMP		#019F
+      0x88240136,  //  019B  GETMBR	R9	R0	K54
+      0x88241337,  //  019C  GETMBR	R9	R9	K55
+      0x8C241338,  //  019D  GETMET	R9	R9	K56
+      0x7C240200,  //  019E  CALL	R9	1
+      0x60280010,  //  019F  GETGBL	R10	G16
+      0x5C2C1200,  //  01A0  MOVE	R11	R9
+      0x7C280200,  //  01A1  CALL	R10	1
+      0xA8020036,  //  01A2  EXBLK	0	#01DA
+      0x5C2C1400,  //  01A3  MOVE	R11	R10
+      0x7C2C0000,  //  01A4  CALL	R11	0
+      0x4C300000,  //  01A5  LDNIL	R12
+      0x1C30160C,  //  01A6  EQ	R12	R11	R12
+      0x78320000,  //  01A7  JMPF	R12	#01A9
+      0x7001FFF9,  //  01A8  JMP		#01A3
+      0x8C301739,  //  01A9  GETMET	R12	R11	K57
+      0x7C300200,  //  01AA  CALL	R12	1
+      0x78320000,  //  01AB  JMPF	R12	#01AD
+      0x7001FFF5,  //  01AC  JMP		#01A3
+      0x8C300B3F,  //  01AD  GETMET	R12	R5	K63
+      0x8C381740,  //  01AE  GETMET	R14	R11	K64
+      0x7C380200,  //  01AF  CALL	R14	1
+      0x7C300400,  //  01B0  CALL	R12	2
+      0x8C341115,  //  01B1  GETMET	R13	R8	K21
+      0x4C3C0000,  //  01B2  LDNIL	R15
+      0x7C340400,  //  01B3  CALL	R13	2
+      0x8C381B0B,  //  01B4  GETMET	R14	R13	K11
+      0x58400009,  //  01B5  LDCONST	R16	K9
+      0x88440B3A,  //  01B6  GETMBR	R17	R5	K58
+      0x8C481941,  //  01B7  GETMET	R18	R12	K65
+      0x54520008,  //  01B8  LDINT	R20	9
+      0x7C480400,  //  01B9  CALL	R18	2
+      0x7C380800,  //  01BA  CALL	R14	4
+      0x8C381B0B,  //  01BB  GETMET	R14	R13	K11
+      0x5840000D,  //  01BC  LDCONST	R16	K13
+      0x88440B0C,  //  01BD  GETMBR	R17	R5	K12
+      0x8C481742,  //  01BE  GETMET	R18	R11	K66
+      0x7C480200,  //  01BF  CALL	R18	1
+      0x7C380800,  //  01C0  CALL	R14	4
+      0x8C381B0B,  //  01C1  GETMET	R14	R13	K11
+      0x5840000F,  //  01C2  LDCONST	R16	K15
+      0x88440B07,  //  01C3  GETMBR	R17	R5	K7
+      0x8C481743,  //  01C4  GETMET	R18	R11	K67
+      0x7C480200,  //  01C5  CALL	R18	1
+      0x7C380800,  //  01C6  CALL	R14	4
+      0x8C381B0B,  //  01C7  GETMET	R14	R13	K11
+      0x54420003,  //  01C8  LDINT	R16	4
+      0x88440B07,  //  01C9  GETMBR	R17	R5	K7
+      0x8C481744,  //  01CA  GETMET	R18	R11	K68
+      0x7C480200,  //  01CB  CALL	R18	1
+      0x7C380800,  //  01CC  CALL	R14	4
+      0x8C381B0B,  //  01CD  GETMET	R14	R13	K11
+      0x54420004,  //  01CE  LDINT	R16	5
+      0x88440B16,  //  01CF  GETMBR	R17	R5	K22
+      0x8C481745,  //  01D0  GETMET	R18	R11	K69
+      0x7C480200,  //  01D1  CALL	R18	1
+      0x7C380800,  //  01D2  CALL	R14	4
+      0x8C381B0B,  //  01D3  GETMET	R14	R13	K11
+      0x544200FD,  //  01D4  LDINT	R16	254
+      0x88440B0C,  //  01D5  GETMBR	R17	R5	K12
+      0x8C48173D,  //  01D6  GETMET	R18	R11	K61
+      0x7C480200,  //  01D7  CALL	R18	1
+      0x7C380800,  //  01D8  CALL	R14	4
+      0x7001FFC8,  //  01D9  JMP		#01A3
+      0x5828003E,  //  01DA  LDCONST	R10	K62
+      0xAC280200,  //  01DB  CATCH	R10	1	0
+      0xB0080000,  //  01DC  RAISE	2	R0	R0
+      0x80041000,  //  01DD  RET	1	R8
+      0x70020028,  //  01DE  JMP		#0208
+      0x1C200F0D,  //  01DF  EQ	R8	R7	K13
+      0x78220007,  //  01E0  JMPF	R8	#01E9
+      0x8C200706,  //  01E1  GETMET	R8	R3	K6
+      0x88280B0E,  //  01E2  GETMBR	R10	R5	K14
+      0xB82E0200,  //  01E3  GETNGBL	R11	K1
+      0x882C1746,  //  01E4  GETMBR	R11	R11	K70
       0x882C1747,  //  01E5  GETMBR	R11	R11	K71
-      0x882C1748,  //  01E6  GETMBR	R11	R11	K72
-      0x7C200600,  //  01E7  CALL	R8	3
-      0x80041000,  //  01E8  RET	1	R8
-      0x7002001E,  //  01E9  JMP		#0209
-      0x1C200F0F,  //  01EA  EQ	R8	R7	K15
-      0x78220009,  //  01EB  JMPF	R8	#01F6
-      0x88200136,  //  01EC  GETMBR	R8	R0	K54
-      0x88201137,  //  01ED  GETMBR	R8	R8	K55
-      0x8C201149,  //  01EE  GETMET	R8	R8	K73
-      0x7C200200,  //  01EF  CALL	R8	1
-      0x8C240706,  //  01F0  GETMET	R9	R3	K6
-      0x882C0B0E,  //  01F1  GETMBR	R11	R5	K14
-      0x5C301000,  //  01F2  MOVE	R12	R8
-      0x7C240600,  //  01F3  CALL	R9	3
-      0x80041200,  //  01F4  RET	1	R9
-      0x70020012,  //  01F5  JMP		#0209
-      0x54220003,  //  01F6  LDINT	R8	4
-      0x1C200E08,  //  01F7  EQ	R8	R7	R8
-      0x78220000,  //  01F8  JMPF	R8	#01FA
-      0x7002000E,  //  01F9  JMP		#0209
-      0x54220004,  //  01FA  LDINT	R8	5
-      0x1C200E08,  //  01FB  EQ	R8	R7	R8
-      0x7822000B,  //  01FC  JMPF	R8	#0209
-      0x8820034A,  //  01FD  GETMBR	R8	R1	K74
-      0x8C20113E,  //  01FE  GETMET	R8	R8	K62
-      0x7C200200,  //  01FF  CALL	R8	1
-      0x4C240000,  //  0200  LDNIL	R9
-      0x1C241009,  //  0201  EQ	R9	R8	R9
-      0x78260000,  //  0202  JMPF	R9	#0204
-      0x58200005,  //  0203  LDCONST	R8	K5
-      0x8C240706,  //  0204  GETMET	R9	R3	K6
-      0x882C0B0E,  //  0205  GETMBR	R11	R5	K14
-      0x5C301000,  //  0206  MOVE	R12	R8
-      0x7C240600,  //  0207  CALL	R9	3
-      0x80041200,  //  0208  RET	1	R9
-      0x70020195,  //  0209  JMP		#03A0
-      0x5422003B,  //  020A  LDINT	R8	60
-      0x1C200C08,  //  020B  EQ	R8	R6	R8
-      0x7822003C,  //  020C  JMPF	R8	#024A
-      0x1C200F05,  //  020D  EQ	R8	R7	K5
-      0x78220012,  //  020E  JMPF	R8	#0222
-      0x88200136,  //  020F  GETMBR	R8	R0	K54
-      0x8C20114B,  //  0210  GETMET	R8	R8	K75
-      0x7C200200,  //  0211  CALL	R8	1
-      0x88240136,  //  0212  GETMBR	R9	R0	K54
-      0x8C24134C,  //  0213  GETMET	R9	R9	K76
-      0x7C240200,  //  0214  CALL	R9	1
-      0x78220004,  //  0215  JMPF	R8	#021B
-      0x78260001,  //  0216  JMPF	R9	#0219
-      0x5828000D,  //  0217  LDCONST	R10	K13
-      0x70020000,  //  0218  JMP		#021A
-      0x58280009,  //  0219  LDCONST	R10	K9
-      0x70020000,  //  021A  JMP		#021C
-      0x58280005,  //  021B  LDCONST	R10	K5
-      0x8C2C0706,  //  021C  GETMET	R11	R3	K6
-      0x88340B0E,  //  021D  GETMBR	R13	R5	K14
-      0x5C381400,  //  021E  MOVE	R14	R10
-      0x7C2C0600,  //  021F  CALL	R11	3
-      0x80041600,  //  0220  RET	1	R11
-      0x70020026,  //  0221  JMP		#0249
-      0x1C200F09,  //  0222  EQ	R8	R7	K9
-      0x78220011,  //  0223  JMPF	R8	#0236
-      0x88200136,  //  0224  GETMBR	R8	R0	K54
-      0x8820114D,  //  0225  GETMBR	R8	R8	K77
-      0x4C240000,  //  0226  LDNIL	R9
-      0x20241009,  //  0227  NE	R9	R8	R9
-      0x78260006,  //  0228  JMPF	R9	#0230
-      0x8C240706,  //  0229  GETMET	R9	R3	K6
-      0x882C0B0C,  //  022A  GETMBR	R11	R5	K12
-      0x8C30113E,  //  022B  GETMET	R12	R8	K62
-      0x7C300200,  //  022C  CALL	R12	1
-      0x7C240600,  //  022D  CALL	R9	3
-      0x80041200,  //  022E  RET	1	R9
-      0x70020004,  //  022F  JMP		#0235
-      0x8C240706,  //  0230  GETMET	R9	R3	K6
-      0x882C0B18,  //  0231  GETMBR	R11	R5	K24
-      0x4C300000,  //  0232  LDNIL	R12
-      0x7C240600,  //  0233  CALL	R9	3
-      0x80041200,  //  0234  RET	1	R9
-      0x70020012,  //  0235  JMP		#0249
-      0x1C200F0D,  //  0236  EQ	R8	R7	K13
-      0x78220010,  //  0237  JMPF	R8	#0249
-      0x88200136,  //  0238  GETMBR	R8	R0	K54
-      0x8820114D,  //  0239  GETMBR	R8	R8	K77
-      0x4C240000,  //  023A  LDNIL	R9
-      0x20241009,  //  023B  NE	R9	R8	R9
-      0x78260006,  //  023C  JMPF	R9	#0244
-      0x8C240706,  //  023D  GETMET	R9	R3	K6
-      0x882C0B0C,  //  023E  GETMBR	R11	R5	K12
-      0x8C301143,  //  023F  GETMET	R12	R8	K67
-      0x7C300200,  //  0240  CALL	R12	1
-      0x7C240600,  //  0241  CALL	R9	3
-      0x80041200,  //  0242  RET	1	R9
-      0x70020004,  //  0243  JMP		#0249
-      0x8C240706,  //  0244  GETMET	R9	R3	K6
-      0x882C0B18,  //  0245  GETMBR	R11	R5	K24
-      0x4C300000,  //  0246  LDNIL	R12
-      0x7C240600,  //  0247  CALL	R9	3
-      0x80041200,  //  0248  RET	1	R9
-      0x70020155,  //  0249  JMP		#03A0
-      0x54220027,  //  024A  LDINT	R8	40
-      0x1C200C08,  //  024B  EQ	R8	R6	R8
-      0x782200BA,  //  024C  JMPF	R8	#0308
-      0x8C200133,  //  024D  GETMET	R8	R0	K51
-      0x5C280400,  //  024E  MOVE	R10	R2
-      0x7C200400,  //  024F  CALL	R8	2
-      0x1C200F05,  //  0250  EQ	R8	R7	K5
-      0x78220005,  //  0251  JMPF	R8	#0258
-      0x8C200706,  //  0252  GETMET	R8	R3	K6
-      0x88280B0C,  //  0253  GETMBR	R10	R5	K12
-      0x582C0009,  //  0254  LDCONST	R11	K9
-      0x7C200600,  //  0255  CALL	R8	3
-      0x80041000,  //  0256  RET	1	R8
-      0x700200AE,  //  0257  JMP		#0307
-      0x1C200F09,  //  0258  EQ	R8	R7	K9
-      0x78220005,  //  0259  JMPF	R8	#0260
-      0x8C200706,  //  025A  GETMET	R8	R3	K6
-      0x88280B16,  //  025B  GETMBR	R10	R5	K22
-      0x582C004E,  //  025C  LDCONST	R11	K78
-      0x7C200600,  //  025D  CALL	R8	3
-      0x80041000,  //  025E  RET	1	R8
-      0x700200A6,  //  025F  JMP		#0307
-      0x1C200F0D,  //  0260  EQ	R8	R7	K13
-      0x78220006,  //  0261  JMPF	R8	#0269
-      0x8C200706,  //  0262  GETMET	R8	R3	K6
-      0x88280B0C,  //  0263  GETMBR	R10	R5	K12
-      0x882C0136,  //  0264  GETMBR	R11	R0	K54
-      0x882C174F,  //  0265  GETMBR	R11	R11	K79
-      0x7C200600,  //  0266  CALL	R8	3
-      0x80041000,  //  0267  RET	1	R8
-      0x7002009D,  //  0268  JMP		#0307
-      0x1C200F0F,  //  0269  EQ	R8	R7	K15
-      0x7822000A,  //  026A  JMPF	R8	#0276
-      0x8C200706,  //  026B  GETMET	R8	R3	K6
-      0x88280B16,  //  026C  GETMBR	R10	R5	K22
-      0xB82E2400,  //  026D  GETNGBL	R11	K18
-      0x8C2C1726,  //  026E  GETMET	R11	R11	K38
-      0x58340050,  //  026F  LDCONST	R13	K80
-      0x50380200,  //  0270  LDBOOL	R14	1	0
-      0x7C2C0600,  //  0271  CALL	R11	3
-      0x942C1750,  //  0272  GETIDX	R11	R11	K80
-      0x7C200600,  //  0273  CALL	R8	3
-      0x80041000,  //  0274  RET	1	R8
-      0x70020090,  //  0275  JMP		#0307
-      0x54220003,  //  0276  LDINT	R8	4
-      0x1C200E08,  //  0277  EQ	R8	R7	R8
-      0x78220005,  //  0278  JMPF	R8	#027F
-      0x8C200706,  //  0279  GETMET	R8	R3	K6
-      0x88280B0C,  //  027A  GETMBR	R10	R5	K12
-      0x542E7FFF,  //  027B  LDINT	R11	32768
-      0x7C200600,  //  027C  CALL	R8	3
-      0x80041000,  //  027D  RET	1	R8
-      0x70020087,  //  027E  JMP		#0307
-      0x54220004,  //  027F  LDINT	R8	5
-      0x1C200E08,  //  0280  EQ	R8	R7	R8
-      0x7822000A,  //  0281  JMPF	R8	#028D
-      0x8C200706,  //  0282  GETMET	R8	R3	K6
-      0x88280B16,  //  0283  GETMBR	R10	R5	K22
-      0xB82E2400,  //  0284  GETNGBL	R11	K18
-      0x8C2C1726,  //  0285  GETMET	R11	R11	K38
-      0x58340051,  //  0286  LDCONST	R13	K81
-      0x50380200,  //  0287  LDBOOL	R14	1	0
-      0x7C2C0600,  //  0288  CALL	R11	3
-      0x942C1752,  //  0289  GETIDX	R11	R11	K82
-      0x7C200600,  //  028A  CALL	R8	3
-      0x80041000,  //  028B  RET	1	R8
-      0x70020079,  //  028C  JMP		#0307
-      0x54220005,  //  028D  LDINT	R8	6
-      0x1C200E08,  //  028E  EQ	R8	R7	R8
-      0x78220005,  //  028F  JMPF	R8	#0296
-      0x8C200706,  //  0290  GETMET	R8	R3	K6
-      0x88280B16,  //  0291  GETMBR	R10	R5	K22
-      0x582C0053,  //  0292  LDCONST	R11	K83
-      0x7C200600,  //  0293  CALL	R8	3
-      0x80041000,  //  0294  RET	1	R8
-      0x70020070,  //  0295  JMP		#0307
-      0x54220006,  //  0296  LDINT	R8	7
-      0x1C200E08,  //  0297  EQ	R8	R7	R8
-      0x78220005,  //  0298  JMPF	R8	#029F
-      0x8C200706,  //  0299  GETMET	R8	R3	K6
-      0x88280B0C,  //  029A  GETMBR	R10	R5	K12
-      0x582C0005,  //  029B  LDCONST	R11	K5
-      0x7C200600,  //  029C  CALL	R8	3
-      0x80041000,  //  029D  RET	1	R8
-      0x70020067,  //  029E  JMP		#0307
-      0x54220007,  //  029F  LDINT	R8	8
-      0x1C200E08,  //  02A0  EQ	R8	R7	R8
-      0x7822000B,  //  02A1  JMPF	R8	#02AE
-      0x8C200706,  //  02A2  GETMET	R8	R3	K6
-      0x88280B16,  //  02A3  GETMBR	R10	R5	K22
-      0xB82E2400,  //  02A4  GETNGBL	R11	K18
-      0x8C2C1726,  //  02A5  GETMET	R11	R11	K38
-      0x58340054,  //  02A6  LDCONST	R13	K84
-      0x50380200,  //  02A7  LDBOOL	R14	1	0
-      0x7C2C0600,  //  02A8  CALL	R11	3
+      0x7C200600,  //  01E6  CALL	R8	3
+      0x80041000,  //  01E7  RET	1	R8
+      0x7002001E,  //  01E8  JMP		#0208
+      0x1C200F0F,  //  01E9  EQ	R8	R7	K15
+      0x78220009,  //  01EA  JMPF	R8	#01F5
+      0x88200136,  //  01EB  GETMBR	R8	R0	K54
+      0x88201137,  //  01EC  GETMBR	R8	R8	K55
+      0x8C201148,  //  01ED  GETMET	R8	R8	K72
+      0x7C200200,  //  01EE  CALL	R8	1
+      0x8C240706,  //  01EF  GETMET	R9	R3	K6
+      0x882C0B0E,  //  01F0  GETMBR	R11	R5	K14
+      0x5C301000,  //  01F1  MOVE	R12	R8
+      0x7C240600,  //  01F2  CALL	R9	3
+      0x80041200,  //  01F3  RET	1	R9
+      0x70020012,  //  01F4  JMP		#0208
+      0x54220003,  //  01F5  LDINT	R8	4
+      0x1C200E08,  //  01F6  EQ	R8	R7	R8
+      0x78220000,  //  01F7  JMPF	R8	#01F9
+      0x7002000E,  //  01F8  JMP		#0208
+      0x54220004,  //  01F9  LDINT	R8	5
+      0x1C200E08,  //  01FA  EQ	R8	R7	R8
+      0x7822000B,  //  01FB  JMPF	R8	#0208
+      0x88200349,  //  01FC  GETMBR	R8	R1	K73
+      0x8C20113D,  //  01FD  GETMET	R8	R8	K61
+      0x7C200200,  //  01FE  CALL	R8	1
+      0x4C240000,  //  01FF  LDNIL	R9
+      0x1C241009,  //  0200  EQ	R9	R8	R9
+      0x78260000,  //  0201  JMPF	R9	#0203
+      0x58200005,  //  0202  LDCONST	R8	K5
+      0x8C240706,  //  0203  GETMET	R9	R3	K6
+      0x882C0B0E,  //  0204  GETMBR	R11	R5	K14
+      0x5C301000,  //  0205  MOVE	R12	R8
+      0x7C240600,  //  0206  CALL	R9	3
+      0x80041200,  //  0207  RET	1	R9
+      0x70020195,  //  0208  JMP		#039F
+      0x5422003B,  //  0209  LDINT	R8	60
+      0x1C200C08,  //  020A  EQ	R8	R6	R8
+      0x7822003C,  //  020B  JMPF	R8	#0249
+      0x1C200F05,  //  020C  EQ	R8	R7	K5
+      0x78220012,  //  020D  JMPF	R8	#0221
+      0x88200136,  //  020E  GETMBR	R8	R0	K54
+      0x8C20114A,  //  020F  GETMET	R8	R8	K74
+      0x7C200200,  //  0210  CALL	R8	1
+      0x88240136,  //  0211  GETMBR	R9	R0	K54
+      0x8C24134B,  //  0212  GETMET	R9	R9	K75
+      0x7C240200,  //  0213  CALL	R9	1
+      0x78220004,  //  0214  JMPF	R8	#021A
+      0x78260001,  //  0215  JMPF	R9	#0218
+      0x5828000D,  //  0216  LDCONST	R10	K13
+      0x70020000,  //  0217  JMP		#0219
+      0x58280009,  //  0218  LDCONST	R10	K9
+      0x70020000,  //  0219  JMP		#021B
+      0x58280005,  //  021A  LDCONST	R10	K5
+      0x8C2C0706,  //  021B  GETMET	R11	R3	K6
+      0x88340B0E,  //  021C  GETMBR	R13	R5	K14
+      0x5C381400,  //  021D  MOVE	R14	R10
+      0x7C2C0600,  //  021E  CALL	R11	3
+      0x80041600,  //  021F  RET	1	R11
+      0x70020026,  //  0220  JMP		#0248
+      0x1C200F09,  //  0221  EQ	R8	R7	K9
+      0x78220011,  //  0222  JMPF	R8	#0235
+      0x88200136,  //  0223  GETMBR	R8	R0	K54
+      0x8820114C,  //  0224  GETMBR	R8	R8	K76
+      0x4C240000,  //  0225  LDNIL	R9
+      0x20241009,  //  0226  NE	R9	R8	R9
+      0x78260006,  //  0227  JMPF	R9	#022F
+      0x8C240706,  //  0228  GETMET	R9	R3	K6
+      0x882C0B0C,  //  0229  GETMBR	R11	R5	K12
+      0x8C30113D,  //  022A  GETMET	R12	R8	K61
+      0x7C300200,  //  022B  CALL	R12	1
+      0x7C240600,  //  022C  CALL	R9	3
+      0x80041200,  //  022D  RET	1	R9
+      0x70020004,  //  022E  JMP		#0234
+      0x8C240706,  //  022F  GETMET	R9	R3	K6
+      0x882C0B18,  //  0230  GETMBR	R11	R5	K24
+      0x4C300000,  //  0231  LDNIL	R12
+      0x7C240600,  //  0232  CALL	R9	3
+      0x80041200,  //  0233  RET	1	R9
+      0x70020012,  //  0234  JMP		#0248
+      0x1C200F0D,  //  0235  EQ	R8	R7	K13
+      0x78220010,  //  0236  JMPF	R8	#0248
+      0x88200136,  //  0237  GETMBR	R8	R0	K54
+      0x8820114C,  //  0238  GETMBR	R8	R8	K76
+      0x4C240000,  //  0239  LDNIL	R9
+      0x20241009,  //  023A  NE	R9	R8	R9
+      0x78260006,  //  023B  JMPF	R9	#0243
+      0x8C240706,  //  023C  GETMET	R9	R3	K6
+      0x882C0B0C,  //  023D  GETMBR	R11	R5	K12
+      0x8C301142,  //  023E  GETMET	R12	R8	K66
+      0x7C300200,  //  023F  CALL	R12	1
+      0x7C240600,  //  0240  CALL	R9	3
+      0x80041200,  //  0241  RET	1	R9
+      0x70020004,  //  0242  JMP		#0248
+      0x8C240706,  //  0243  GETMET	R9	R3	K6
+      0x882C0B18,  //  0244  GETMBR	R11	R5	K24
+      0x4C300000,  //  0245  LDNIL	R12
+      0x7C240600,  //  0246  CALL	R9	3
+      0x80041200,  //  0247  RET	1	R9
+      0x70020155,  //  0248  JMP		#039F
+      0x54220027,  //  0249  LDINT	R8	40
+      0x1C200C08,  //  024A  EQ	R8	R6	R8
+      0x782200BA,  //  024B  JMPF	R8	#0307
+      0x8C200133,  //  024C  GETMET	R8	R0	K51
+      0x5C280400,  //  024D  MOVE	R10	R2
+      0x7C200400,  //  024E  CALL	R8	2
+      0x1C200F05,  //  024F  EQ	R8	R7	K5
+      0x78220005,  //  0250  JMPF	R8	#0257
+      0x8C200706,  //  0251  GETMET	R8	R3	K6
+      0x88280B0C,  //  0252  GETMBR	R10	R5	K12
+      0x582C0009,  //  0253  LDCONST	R11	K9
+      0x7C200600,  //  0254  CALL	R8	3
+      0x80041000,  //  0255  RET	1	R8
+      0x700200AE,  //  0256  JMP		#0306
+      0x1C200F09,  //  0257  EQ	R8	R7	K9
+      0x78220005,  //  0258  JMPF	R8	#025F
+      0x8C200706,  //  0259  GETMET	R8	R3	K6
+      0x88280B16,  //  025A  GETMBR	R10	R5	K22
+      0x582C004D,  //  025B  LDCONST	R11	K77
+      0x7C200600,  //  025C  CALL	R8	3
+      0x80041000,  //  025D  RET	1	R8
+      0x700200A6,  //  025E  JMP		#0306
+      0x1C200F0D,  //  025F  EQ	R8	R7	K13
+      0x78220006,  //  0260  JMPF	R8	#0268
+      0x8C200706,  //  0261  GETMET	R8	R3	K6
+      0x88280B0C,  //  0262  GETMBR	R10	R5	K12
+      0x882C0136,  //  0263  GETMBR	R11	R0	K54
+      0x882C174E,  //  0264  GETMBR	R11	R11	K78
+      0x7C200600,  //  0265  CALL	R8	3
+      0x80041000,  //  0266  RET	1	R8
+      0x7002009D,  //  0267  JMP		#0306
+      0x1C200F0F,  //  0268  EQ	R8	R7	K15
+      0x7822000A,  //  0269  JMPF	R8	#0275
+      0x8C200706,  //  026A  GETMET	R8	R3	K6
+      0x88280B16,  //  026B  GETMBR	R10	R5	K22
+      0xB82E2400,  //  026C  GETNGBL	R11	K18
+      0x8C2C1726,  //  026D  GETMET	R11	R11	K38
+      0x5834004F,  //  026E  LDCONST	R13	K79
+      0x50380200,  //  026F  LDBOOL	R14	1	0
+      0x7C2C0600,  //  0270  CALL	R11	3
+      0x942C174F,  //  0271  GETIDX	R11	R11	K79
+      0x7C200600,  //  0272  CALL	R8	3
+      0x80041000,  //  0273  RET	1	R8
+      0x70020090,  //  0274  JMP		#0306
+      0x54220003,  //  0275  LDINT	R8	4
+      0x1C200E08,  //  0276  EQ	R8	R7	R8
+      0x78220005,  //  0277  JMPF	R8	#027E
+      0x8C200706,  //  0278  GETMET	R8	R3	K6
+      0x88280B0C,  //  0279  GETMBR	R10	R5	K12
+      0x542E7FFF,  //  027A  LDINT	R11	32768
+      0x7C200600,  //  027B  CALL	R8	3
+      0x80041000,  //  027C  RET	1	R8
+      0x70020087,  //  027D  JMP		#0306
+      0x54220004,  //  027E  LDINT	R8	5
+      0x1C200E08,  //  027F  EQ	R8	R7	R8
+      0x7822000A,  //  0280  JMPF	R8	#028C
+      0x8C200706,  //  0281  GETMET	R8	R3	K6
+      0x88280B16,  //  0282  GETMBR	R10	R5	K22
+      0xB82E2400,  //  0283  GETNGBL	R11	K18
+      0x8C2C1726,  //  0284  GETMET	R11	R11	K38
+      0x58340050,  //  0285  LDCONST	R13	K80
+      0x50380200,  //  0286  LDBOOL	R14	1	0
+      0x7C2C0600,  //  0287  CALL	R11	3
+      0x942C1751,  //  0288  GETIDX	R11	R11	K81
+      0x7C200600,  //  0289  CALL	R8	3
+      0x80041000,  //  028A  RET	1	R8
+      0x70020079,  //  028B  JMP		#0306
+      0x54220005,  //  028C  LDINT	R8	6
+      0x1C200E08,  //  028D  EQ	R8	R7	R8
+      0x78220005,  //  028E  JMPF	R8	#0295
+      0x8C200706,  //  028F  GETMET	R8	R3	K6
+      0x88280B16,  //  0290  GETMBR	R10	R5	K22
+      0x582C0052,  //  0291  LDCONST	R11	K82
+      0x7C200600,  //  0292  CALL	R8	3
+      0x80041000,  //  0293  RET	1	R8
+      0x70020070,  //  0294  JMP		#0306
+      0x54220006,  //  0295  LDINT	R8	7
+      0x1C200E08,  //  0296  EQ	R8	R7	R8
+      0x78220005,  //  0297  JMPF	R8	#029E
+      0x8C200706,  //  0298  GETMET	R8	R3	K6
+      0x88280B0C,  //  0299  GETMBR	R10	R5	K12
+      0x582C0005,  //  029A  LDCONST	R11	K5
+      0x7C200600,  //  029B  CALL	R8	3
+      0x80041000,  //  029C  RET	1	R8
+      0x70020067,  //  029D  JMP		#0306
+      0x54220007,  //  029E  LDINT	R8	8
+      0x1C200E08,  //  029F  EQ	R8	R7	R8
+      0x7822000B,  //  02A0  JMPF	R8	#02AD
+      0x8C200706,  //  02A1  GETMET	R8	R3	K6
+      0x88280B16,  //  02A2  GETMBR	R10	R5	K22
+      0xB82E2400,  //  02A3  GETNGBL	R11	K18
+      0x8C2C1726,  //  02A4  GETMET	R11	R11	K38
+      0x58340053,  //  02A5  LDCONST	R13	K83
+      0x50380200,  //  02A6  LDBOOL	R14	1	0
+      0x7C2C0600,  //  02A7  CALL	R11	3
+      0x942C1754,  //  02A8  GETIDX	R11	R11	K84
       0x942C1755,  //  02A9  GETIDX	R11	R11	K85
-      0x942C1756,  //  02AA  GETIDX	R11	R11	K86
-      0x7C200600,  //  02AB  CALL	R8	3
-      0x80041000,  //  02AC  RET	1	R8
-      0x70020058,  //  02AD  JMP		#0307
-      0x54220008,  //  02AE  LDINT	R8	9
-      0x1C200E08,  //  02AF  EQ	R8	R7	R8
-      0x78220005,  //  02B0  JMPF	R8	#02B7
-      0x8C200706,  //  02B1  GETMET	R8	R3	K6
-      0x88280B0C,  //  02B2  GETMBR	R10	R5	K12
-      0x582C0009,  //  02B3  LDCONST	R11	K9
-      0x7C200600,  //  02B4  CALL	R8	3
-      0x80041000,  //  02B5  RET	1	R8
-      0x7002004F,  //  02B6  JMP		#0307
-      0x54220009,  //  02B7  LDINT	R8	10
-      0x1C200E08,  //  02B8  EQ	R8	R7	R8
-      0x78220015,  //  02B9  JMPF	R8	#02D0
-      0xB8222400,  //  02BA  GETNGBL	R8	K18
-      0x8C201126,  //  02BB  GETMET	R8	R8	K38
-      0x58280054,  //  02BC  LDCONST	R10	K84
-      0x502C0200,  //  02BD  LDBOOL	R11	1	0
-      0x7C200600,  //  02BE  CALL	R8	3
-      0x94201155,  //  02BF  GETIDX	R8	R8	K85
-      0x94201157,  //  02C0  GETIDX	R8	R8	K87
-      0x8C24091B,  //  02C1  GETMET	R9	R4	K27
-      0x5C2C1000,  //  02C2  MOVE	R11	R8
-      0x58300058,  //  02C3  LDCONST	R12	K88
-      0x7C240600,  //  02C4  CALL	R9	3
-      0x24281305,  //  02C5  GT	R10	R9	K5
-      0x782A0002,  //  02C6  JMPF	R10	#02CA
-      0x04281309,  //  02C7  SUB	R10	R9	K9
-      0x402A0A0A,  //  02C8  CONNECT	R10	K5	R10
-      0x9420100A,  //  02C9  GETIDX	R8	R8	R10
-      0x8C280706,  //  02CA  GETMET	R10	R3	K6
-      0x88300B16,  //  02CB  GETMBR	R12	R5	K22
-      0x5C341000,  //  02CC  MOVE	R13	R8
-      0x7C280600,  //  02CD  CALL	R10	3
-      0x80041400,  //  02CE  RET	1	R10
-      0x70020036,  //  02CF  JMP		#0307
-      0x5422000E,  //  02D0  LDINT	R8	15
-      0x1C200E08,  //  02D1  EQ	R8	R7	R8
-      0x7822000B,  //  02D2  JMPF	R8	#02DF
-      0x8C200706,  //  02D3  GETMET	R8	R3	K6
-      0x88280B16,  //  02D4  GETMBR	R10	R5	K22
-      0xB82E2400,  //  02D5  GETNGBL	R11	K18
-      0x8C2C1725,  //  02D6  GETMET	R11	R11	K37
-      0x7C2C0200,  //  02D7  CALL	R11	1
-      0x8C2C171B,  //  02D8  GETMET	R11	R11	K27
-      0x5834001C,  //  02D9  LDCONST	R13	K28
-      0x5838001D,  //  02DA  LDCONST	R14	K29
-      0x7C2C0600,  //  02DB  CALL	R11	3
-      0x7C200600,  //  02DC  CALL	R8	3
-      0x80041000,  //  02DD  RET	1	R8
-      0x70020027,  //  02DE  JMP		#0307
-      0x54220010,  //  02DF  LDINT	R8	17
-      0x1C200E08,  //  02E0  EQ	R8	R7	R8
-      0x78220005,  //  02E1  JMPF	R8	#02E8
-      0x8C200706,  //  02E2  GETMET	R8	R3	K6
-      0x88280B10,  //  02E3  GETMBR	R10	R5	K16
-      0x582C0009,  //  02E4  LDCONST	R11	K9
-      0x7C200600,  //  02E5  CALL	R8	3
-      0x80041000,  //  02E6  RET	1	R8
-      0x7002001E,  //  02E7  JMP		#0307
-      0x54220011,  //  02E8  LDINT	R8	18
-      0x1C200E08,  //  02E9  EQ	R8	R7	R8
-      0x7822000B,  //  02EA  JMPF	R8	#02F7
-      0x8C200706,  //  02EB  GETMET	R8	R3	K6
-      0x88280B16,  //  02EC  GETMBR	R10	R5	K22
-      0xB82E2400,  //  02ED  GETNGBL	R11	K18
-      0x8C2C1725,  //  02EE  GETMET	R11	R11	K37
-      0x7C2C0200,  //  02EF  CALL	R11	1
-      0x8C2C171B,  //  02F0  GETMET	R11	R11	K27
-      0x5834001C,  //  02F1  LDCONST	R13	K28
-      0x5838001D,  //  02F2  LDCONST	R14	K29
-      0x7C2C0600,  //  02F3  CALL	R11	3
-      0x7C200600,  //  02F4  CALL	R8	3
-      0x80041000,  //  02F5  RET	1	R8
-      0x7002000F,  //  02F6  JMP		#0307
-      0x54220012,  //  02F7  LDINT	R8	19
-      0x1C200E08,  //  02F8  EQ	R8	R7	R8
-      0x7822000C,  //  02F9  JMPF	R8	#0307
-      0x8C200B0A,  //  02FA  GETMET	R8	R5	K10
-      0x7C200200,  //  02FB  CALL	R8	1
-      0x8C24110B,  //  02FC  GETMET	R9	R8	K11
-      0x582C0005,  //  02FD  LDCONST	R11	K5
-      0x88300B0C,  //  02FE  GETMBR	R12	R5	K12
-      0x5834000F,  //  02FF  LDCONST	R13	K15
-      0x7C240800,  //  0300  CALL	R9	4
-      0x8C24110B,  //  0301  GETMET	R9	R8	K11
-      0x582C0009,  //  0302  LDCONST	R11	K9
-      0x88300B0C,  //  0303  GETMBR	R12	R5	K12
-      0x5834000F,  //  0304  LDCONST	R13	K15
-      0x7C240800,  //  0305  CALL	R9	4
-      0x80041000,  //  0306  RET	1	R8
-      0x70020097,  //  0307  JMP		#03A0
-      0x5422003E,  //  0308  LDINT	R8	63
-      0x1C200C08,  //  0309  EQ	R8	R6	R8
-      0x78220000,  //  030A  JMPF	R8	#030C
-      0x70020093,  //  030B  JMP		#03A0
-      0x54220029,  //  030C  LDINT	R8	42
-      0x1C200C08,  //  030D  EQ	R8	R6	R8
-      0x7822001D,  //  030E  JMPF	R8	#032D
-      0x1C200F05,  //  030F  EQ	R8	R7	K5
-      0x78220003,  //  0310  JMPF	R8	#0315
-      0x8C200B11,  //  0311  GETMET	R8	R5	K17
-      0x7C200200,  //  0312  CALL	R8	1
-      0x80041000,  //  0313  RET	1	R8
-      0x70020016,  //  0314  JMP		#032C
-      0x1C200F09,  //  0315  EQ	R8	R7	K9
-      0x78220005,  //  0316  JMPF	R8	#031D
-      0x8C200706,  //  0317  GETMET	R8	R3	K6
-      0x88280B10,  //  0318  GETMBR	R10	R5	K16
-      0x582C0005,  //  0319  LDCONST	R11	K5
-      0x7C200600,  //  031A  CALL	R8	3
-      0x80041000,  //  031B  RET	1	R8
-      0x7002000E,  //  031C  JMP		#032C
-      0x1C200F0D,  //  031D  EQ	R8	R7	K13
-      0x78220005,  //  031E  JMPF	R8	#0325
-      0x8C200706,  //  031F  GETMET	R8	R3	K6
-      0x88280B0E,  //  0320  GETMBR	R10	R5	K14
-      0x582C0009,  //  0321  LDCONST	R11	K9
-      0x7C200600,  //  0322  CALL	R8	3
-      0x80041000,  //  0323  RET	1	R8
-      0x70020006,  //  0324  JMP		#032C
-      0x1C200F0F,  //  0325  EQ	R8	R7	K15
-      0x78220004,  //  0326  JMPF	R8	#032C
-      0x8C200706,  //  0327  GETMET	R8	R3	K6
-      0x88280B18,  //  0328  GETMBR	R10	R5	K24
-      0x4C2C0000,  //  0329  LDNIL	R11
-      0x7C200600,  //  032A  CALL	R8	3
-      0x80041000,  //  032B  RET	1	R8
-      0x70020072,  //  032C  JMP		#03A0
-      0x5422002A,  //  032D  LDINT	R8	43
-      0x1C200C08,  //  032E  EQ	R8	R6	R8
-      0x78220016,  //  032F  JMPF	R8	#0347
-      0x1C200F05,  //  0330  EQ	R8	R7	K5
-      0x78220007,  //  0331  JMPF	R8	#033A
-      0x8C200706,  //  0332  GETMET	R8	R3	K6
-      0x88280B16,  //  0333  GETMBR	R10	R5	K22
-      0xB82E2400,  //  0334  GETNGBL	R11	K18
-      0x8C2C1759,  //  0335  GETMET	R11	R11	K89
-      0x7C2C0200,  //  0336  CALL	R11	1
-      0x7C200600,  //  0337  CALL	R8	3
-      0x80041000,  //  0338  RET	1	R8
-      0x7002000B,  //  0339  JMP		#0346
-      0x1C200F09,  //  033A  EQ	R8	R7	K9
-      0x78220009,  //  033B  JMPF	R8	#0346
-      0x8C200B11,  //  033C  GETMET	R8	R5	K17
-      0x7C200200,  //  033D  CALL	R8	1
-      0x8C24110B,  //  033E  GETMET	R9	R8	K11
-      0x4C2C0000,  //  033F  LDNIL	R11
-      0x88300B16,  //  0340  GETMBR	R12	R5	K22
-      0xB8362400,  //  0341  GETNGBL	R13	K18
-      0x8C341B59,  //  0342  GETMET	R13	R13	K89
-      0x7C340200,  //  0343  CALL	R13	1
-      0x7C240800,  //  0344  CALL	R9	4
-      0x80041000,  //  0345  RET	1	R8
-      0x70020058,  //  0346  JMP		#03A0
-      0x5422002B,  //  0347  LDINT	R8	44
-      0x1C200C08,  //  0348  EQ	R8	R6	R8
-      0x7822001C,  //  0349  JMPF	R8	#0367
-      0x1C200F05,  //  034A  EQ	R8	R7	K5
-      0x78220005,  //  034B  JMPF	R8	#0352
-      0x8C200706,  //  034C  GETMET	R8	R3	K6
-      0x88280B0E,  //  034D  GETMBR	R10	R5	K14
-      0x582C0009,  //  034E  LDCONST	R11	K9
-      0x7C200600,  //  034F  CALL	R8	3
-      0x80041000,  //  0350  RET	1	R8
-      0x70020013,  //  0351  JMP		#0366
-      0x1C200F09,  //  0352  EQ	R8	R7	K9
-      0x78220005,  //  0353  JMPF	R8	#035A
-      0x8C200706,  //  0354  GETMET	R8	R3	K6
-      0x88280B0E,  //  0355  GETMBR	R10	R5	K14
-      0x542E0003,  //  0356  LDINT	R11	4
-      0x7C200600,  //  0357  CALL	R8	3
-      0x80041000,  //  0358  RET	1	R8
-      0x7002000B,  //  0359  JMP		#0366
-      0x1C200F0D,  //  035A  EQ	R8	R7	K13
-      0x78220009,  //  035B  JMPF	R8	#0366
-      0x8C200B11,  //  035C  GETMET	R8	R5	K17
-      0x7C200200,  //  035D  CALL	R8	1
-      0x8C24110B,  //  035E  GETMET	R9	R8	K11
-      0x4C2C0000,  //  035F  LDNIL	R11
-      0x8C300B5A,  //  0360  GETMET	R12	R5	K90
-      0x88380B0E,  //  0361  GETMBR	R14	R5	K14
-      0x543E0003,  //  0362  LDINT	R15	4
-      0x7C300600,  //  0363  CALL	R12	3
-      0x7C240600,  //  0364  CALL	R9	3
-      0x80041000,  //  0365  RET	1	R8
-      0x70020038,  //  0366  JMP		#03A0
-      0x54220030,  //  0367  LDINT	R8	49
-      0x1C200C08,  //  0368  EQ	R8	R6	R8
-      0x78220007,  //  0369  JMPF	R8	#0372
-      0x1C200F0F,  //  036A  EQ	R8	R7	K15
-      0x78220004,  //  036B  JMPF	R8	#0371
-      0x8C200706,  //  036C  GETMET	R8	R3	K6
-      0x88280B0E,  //  036D  GETMBR	R10	R5	K14
-      0x542E001D,  //  036E  LDINT	R11	30
-      0x7C200600,  //  036F  CALL	R8	3
-      0x80041000,  //  0370  RET	1	R8
-      0x7002002D,  //  0371  JMP		#03A0
-      0x5422001C,  //  0372  LDINT	R8	29
-      0x1C200C08,  //  0373  EQ	R8	R6	R8
-      0x7822002A,  //  0374  JMPF	R8	#03A0
-      0x1C200F0D,  //  0375  EQ	R8	R7	K13
-      0x78220008,  //  0376  JMPF	R8	#0380
-      0x8C200B11,  //  0377  GETMET	R8	R5	K17
-      0x7C200200,  //  0378  CALL	R8	1
-      0x8C24110B,  //  0379  GETMET	R9	R8	K11
-      0x4C2C0000,  //  037A  LDNIL	R11
-      0x88300B0C,  //  037B  GETMBR	R12	R5	K12
-      0x5436001E,  //  037C  LDINT	R13	31
-      0x7C240800,  //  037D  CALL	R9	4
-      0x80041000,  //  037E  RET	1	R8
-      0x7002001F,  //  037F  JMP		#03A0
-      0x1C200F0F,  //  0380  EQ	R8	R7	K15
-      0x7822001D,  //  0381  JMPF	R8	#03A0
-      0x8C200B11,  //  0382  GETMET	R8	R5	K17
-      0x7C200200,  //  0383  CALL	R8	1
-      0x88240136,  //  0384  GETMBR	R9	R0	K54
-      0x8C24135B,  //  0385  GETMET	R9	R9	K91
-      0x502C0200,  //  0386  LDBOOL	R11	1	0
-      0x7C240400,  //  0387  CALL	R9	2
-      0x88280136,  //  0388  GETMBR	R10	R0	K54
-      0x8828155C,  //  0389  GETMBR	R10	R10	K92
-      0x602C0010,  //  038A  GETGBL	R11	G16
-      0x5C301200,  //  038B  MOVE	R12	R9
-      0x7C2C0200,  //  038C  CALL	R11	1
-      0xA802000D,  //  038D  EXBLK	0	#039C
-      0x5C301600,  //  038E  MOVE	R12	R11
-      0x7C300000,  //  038F  CALL	R12	0
-      0x5C341400,  //  0390  MOVE	R13	R10
-      0x78360003,  //  0391  JMPF	R13	#0396
-      0xB8360200,  //  0392  GETNGBL	R13	K1
-      0x88341B3D,  //  0393  GETMBR	R13	R13	K61
-      0x2034180D,  //  0394  NE	R13	R12	R13
-      0x78360004,  //  0395  JMPF	R13	#039B
-      0x8C34110B,  //  0396  GETMET	R13	R8	K11
-      0x4C3C0000,  //  0397  LDNIL	R15
-      0x88400B0C,  //  0398  GETMBR	R16	R5	K12
-      0x5C441800,  //  0399  MOVE	R17	R12
-      0x7C340800,  //  039A  CALL	R13	4
-      0x7001FFF1,  //  039B  JMP		#038E
-      0x582C003F,  //  039C  LDCONST	R11	K63
-      0xAC2C0200,  //  039D  CATCH	R11	1	0
-      0xB0080000,  //  039E  RAISE	2	R0	R0
-      0x80041000,  //  039F  RET	1	R8
-      0x60200003,  //  03A0  GETGBL	R8	G3
-      0x5C240000,  //  03A1  MOVE	R9	R0
-      0x7C200200,  //  03A2  CALL	R8	1
-      0x8C20115D,  //  03A3  GETMET	R8	R8	K93
-      0x5C280200,  //  03A4  MOVE	R10	R1
-      0x5C2C0400,  //  03A5  MOVE	R11	R2
-      0x5C300600,  //  03A6  MOVE	R12	R3
-      0x7C200800,  //  03A7  CALL	R8	4
-      0x80041000,  //  03A8  RET	1	R8
+      0x7C200600,  //  02AA  CALL	R8	3
+      0x80041000,  //  02AB  RET	1	R8
+      0x70020058,  //  02AC  JMP		#0306
+      0x54220008,  //  02AD  LDINT	R8	9
+      0x1C200E08,  //  02AE  EQ	R8	R7	R8
+      0x78220005,  //  02AF  JMPF	R8	#02B6
+      0x8C200706,  //  02B0  GETMET	R8	R3	K6
+      0x88280B0C,  //  02B1  GETMBR	R10	R5	K12
+      0x582C0009,  //  02B2  LDCONST	R11	K9
+      0x7C200600,  //  02B3  CALL	R8	3
+      0x80041000,  //  02B4  RET	1	R8
+      0x7002004F,  //  02B5  JMP		#0306
+      0x54220009,  //  02B6  LDINT	R8	10
+      0x1C200E08,  //  02B7  EQ	R8	R7	R8
+      0x78220015,  //  02B8  JMPF	R8	#02CF
+      0xB8222400,  //  02B9  GETNGBL	R8	K18
+      0x8C201126,  //  02BA  GETMET	R8	R8	K38
+      0x58280053,  //  02BB  LDCONST	R10	K83
+      0x502C0200,  //  02BC  LDBOOL	R11	1	0
+      0x7C200600,  //  02BD  CALL	R8	3
+      0x94201154,  //  02BE  GETIDX	R8	R8	K84
+      0x94201156,  //  02BF  GETIDX	R8	R8	K86
+      0x8C24091B,  //  02C0  GETMET	R9	R4	K27
+      0x5C2C1000,  //  02C1  MOVE	R11	R8
+      0x58300057,  //  02C2  LDCONST	R12	K87
+      0x7C240600,  //  02C3  CALL	R9	3
+      0x24281305,  //  02C4  GT	R10	R9	K5
+      0x782A0002,  //  02C5  JMPF	R10	#02C9
+      0x04281309,  //  02C6  SUB	R10	R9	K9
+      0x402A0A0A,  //  02C7  CONNECT	R10	K5	R10
+      0x9420100A,  //  02C8  GETIDX	R8	R8	R10
+      0x8C280706,  //  02C9  GETMET	R10	R3	K6
+      0x88300B16,  //  02CA  GETMBR	R12	R5	K22
+      0x5C341000,  //  02CB  MOVE	R13	R8
+      0x7C280600,  //  02CC  CALL	R10	3
+      0x80041400,  //  02CD  RET	1	R10
+      0x70020036,  //  02CE  JMP		#0306
+      0x5422000E,  //  02CF  LDINT	R8	15
+      0x1C200E08,  //  02D0  EQ	R8	R7	R8
+      0x7822000B,  //  02D1  JMPF	R8	#02DE
+      0x8C200706,  //  02D2  GETMET	R8	R3	K6
+      0x88280B16,  //  02D3  GETMBR	R10	R5	K22
+      0xB82E2400,  //  02D4  GETNGBL	R11	K18
+      0x8C2C1725,  //  02D5  GETMET	R11	R11	K37
+      0x7C2C0200,  //  02D6  CALL	R11	1
+      0x8C2C171B,  //  02D7  GETMET	R11	R11	K27
+      0x5834001C,  //  02D8  LDCONST	R13	K28
+      0x5838001D,  //  02D9  LDCONST	R14	K29
+      0x7C2C0600,  //  02DA  CALL	R11	3
+      0x7C200600,  //  02DB  CALL	R8	3
+      0x80041000,  //  02DC  RET	1	R8
+      0x70020027,  //  02DD  JMP		#0306
+      0x54220010,  //  02DE  LDINT	R8	17
+      0x1C200E08,  //  02DF  EQ	R8	R7	R8
+      0x78220005,  //  02E0  JMPF	R8	#02E7
+      0x8C200706,  //  02E1  GETMET	R8	R3	K6
+      0x88280B10,  //  02E2  GETMBR	R10	R5	K16
+      0x582C0009,  //  02E3  LDCONST	R11	K9
+      0x7C200600,  //  02E4  CALL	R8	3
+      0x80041000,  //  02E5  RET	1	R8
+      0x7002001E,  //  02E6  JMP		#0306
+      0x54220011,  //  02E7  LDINT	R8	18
+      0x1C200E08,  //  02E8  EQ	R8	R7	R8
+      0x7822000B,  //  02E9  JMPF	R8	#02F6
+      0x8C200706,  //  02EA  GETMET	R8	R3	K6
+      0x88280B16,  //  02EB  GETMBR	R10	R5	K22
+      0xB82E2400,  //  02EC  GETNGBL	R11	K18
+      0x8C2C1725,  //  02ED  GETMET	R11	R11	K37
+      0x7C2C0200,  //  02EE  CALL	R11	1
+      0x8C2C171B,  //  02EF  GETMET	R11	R11	K27
+      0x5834001C,  //  02F0  LDCONST	R13	K28
+      0x5838001D,  //  02F1  LDCONST	R14	K29
+      0x7C2C0600,  //  02F2  CALL	R11	3
+      0x7C200600,  //  02F3  CALL	R8	3
+      0x80041000,  //  02F4  RET	1	R8
+      0x7002000F,  //  02F5  JMP		#0306
+      0x54220012,  //  02F6  LDINT	R8	19
+      0x1C200E08,  //  02F7  EQ	R8	R7	R8
+      0x7822000C,  //  02F8  JMPF	R8	#0306
+      0x8C200B0A,  //  02F9  GETMET	R8	R5	K10
+      0x7C200200,  //  02FA  CALL	R8	1
+      0x8C24110B,  //  02FB  GETMET	R9	R8	K11
+      0x582C0005,  //  02FC  LDCONST	R11	K5
+      0x88300B0C,  //  02FD  GETMBR	R12	R5	K12
+      0x5834000F,  //  02FE  LDCONST	R13	K15
+      0x7C240800,  //  02FF  CALL	R9	4
+      0x8C24110B,  //  0300  GETMET	R9	R8	K11
+      0x582C0009,  //  0301  LDCONST	R11	K9
+      0x88300B0C,  //  0302  GETMBR	R12	R5	K12
+      0x5834000F,  //  0303  LDCONST	R13	K15
+      0x7C240800,  //  0304  CALL	R9	4
+      0x80041000,  //  0305  RET	1	R8
+      0x70020097,  //  0306  JMP		#039F
+      0x5422003E,  //  0307  LDINT	R8	63
+      0x1C200C08,  //  0308  EQ	R8	R6	R8
+      0x78220000,  //  0309  JMPF	R8	#030B
+      0x70020093,  //  030A  JMP		#039F
+      0x54220029,  //  030B  LDINT	R8	42
+      0x1C200C08,  //  030C  EQ	R8	R6	R8
+      0x7822001D,  //  030D  JMPF	R8	#032C
+      0x1C200F05,  //  030E  EQ	R8	R7	K5
+      0x78220003,  //  030F  JMPF	R8	#0314
+      0x8C200B11,  //  0310  GETMET	R8	R5	K17
+      0x7C200200,  //  0311  CALL	R8	1
+      0x80041000,  //  0312  RET	1	R8
+      0x70020016,  //  0313  JMP		#032B
+      0x1C200F09,  //  0314  EQ	R8	R7	K9
+      0x78220005,  //  0315  JMPF	R8	#031C
+      0x8C200706,  //  0316  GETMET	R8	R3	K6
+      0x88280B10,  //  0317  GETMBR	R10	R5	K16
+      0x582C0005,  //  0318  LDCONST	R11	K5
+      0x7C200600,  //  0319  CALL	R8	3
+      0x80041000,  //  031A  RET	1	R8
+      0x7002000E,  //  031B  JMP		#032B
+      0x1C200F0D,  //  031C  EQ	R8	R7	K13
+      0x78220005,  //  031D  JMPF	R8	#0324
+      0x8C200706,  //  031E  GETMET	R8	R3	K6
+      0x88280B0E,  //  031F  GETMBR	R10	R5	K14
+      0x582C0009,  //  0320  LDCONST	R11	K9
+      0x7C200600,  //  0321  CALL	R8	3
+      0x80041000,  //  0322  RET	1	R8
+      0x70020006,  //  0323  JMP		#032B
+      0x1C200F0F,  //  0324  EQ	R8	R7	K15
+      0x78220004,  //  0325  JMPF	R8	#032B
+      0x8C200706,  //  0326  GETMET	R8	R3	K6
+      0x88280B18,  //  0327  GETMBR	R10	R5	K24
+      0x4C2C0000,  //  0328  LDNIL	R11
+      0x7C200600,  //  0329  CALL	R8	3
+      0x80041000,  //  032A  RET	1	R8
+      0x70020072,  //  032B  JMP		#039F
+      0x5422002A,  //  032C  LDINT	R8	43
+      0x1C200C08,  //  032D  EQ	R8	R6	R8
+      0x78220016,  //  032E  JMPF	R8	#0346
+      0x1C200F05,  //  032F  EQ	R8	R7	K5
+      0x78220007,  //  0330  JMPF	R8	#0339
+      0x8C200706,  //  0331  GETMET	R8	R3	K6
+      0x88280B16,  //  0332  GETMBR	R10	R5	K22
+      0xB82E2400,  //  0333  GETNGBL	R11	K18
+      0x8C2C1758,  //  0334  GETMET	R11	R11	K88
+      0x7C2C0200,  //  0335  CALL	R11	1
+      0x7C200600,  //  0336  CALL	R8	3
+      0x80041000,  //  0337  RET	1	R8
+      0x7002000B,  //  0338  JMP		#0345
+      0x1C200F09,  //  0339  EQ	R8	R7	K9
+      0x78220009,  //  033A  JMPF	R8	#0345
+      0x8C200B11,  //  033B  GETMET	R8	R5	K17
+      0x7C200200,  //  033C  CALL	R8	1
+      0x8C24110B,  //  033D  GETMET	R9	R8	K11
+      0x4C2C0000,  //  033E  LDNIL	R11
+      0x88300B16,  //  033F  GETMBR	R12	R5	K22
+      0xB8362400,  //  0340  GETNGBL	R13	K18
+      0x8C341B58,  //  0341  GETMET	R13	R13	K88
+      0x7C340200,  //  0342  CALL	R13	1
+      0x7C240800,  //  0343  CALL	R9	4
+      0x80041000,  //  0344  RET	1	R8
+      0x70020058,  //  0345  JMP		#039F
+      0x5422002B,  //  0346  LDINT	R8	44
+      0x1C200C08,  //  0347  EQ	R8	R6	R8
+      0x7822001C,  //  0348  JMPF	R8	#0366
+      0x1C200F05,  //  0349  EQ	R8	R7	K5
+      0x78220005,  //  034A  JMPF	R8	#0351
+      0x8C200706,  //  034B  GETMET	R8	R3	K6
+      0x88280B0E,  //  034C  GETMBR	R10	R5	K14
+      0x582C0009,  //  034D  LDCONST	R11	K9
+      0x7C200600,  //  034E  CALL	R8	3
+      0x80041000,  //  034F  RET	1	R8
+      0x70020013,  //  0350  JMP		#0365
+      0x1C200F09,  //  0351  EQ	R8	R7	K9
+      0x78220005,  //  0352  JMPF	R8	#0359
+      0x8C200706,  //  0353  GETMET	R8	R3	K6
+      0x88280B0E,  //  0354  GETMBR	R10	R5	K14
+      0x542E0003,  //  0355  LDINT	R11	4
+      0x7C200600,  //  0356  CALL	R8	3
+      0x80041000,  //  0357  RET	1	R8
+      0x7002000B,  //  0358  JMP		#0365
+      0x1C200F0D,  //  0359  EQ	R8	R7	K13
+      0x78220009,  //  035A  JMPF	R8	#0365
+      0x8C200B11,  //  035B  GETMET	R8	R5	K17
+      0x7C200200,  //  035C  CALL	R8	1
+      0x8C24110B,  //  035D  GETMET	R9	R8	K11
+      0x4C2C0000,  //  035E  LDNIL	R11
+      0x8C300B59,  //  035F  GETMET	R12	R5	K89
+      0x88380B0E,  //  0360  GETMBR	R14	R5	K14
+      0x543E0003,  //  0361  LDINT	R15	4
+      0x7C300600,  //  0362  CALL	R12	3
+      0x7C240600,  //  0363  CALL	R9	3
+      0x80041000,  //  0364  RET	1	R8
+      0x70020038,  //  0365  JMP		#039F
+      0x54220030,  //  0366  LDINT	R8	49
+      0x1C200C08,  //  0367  EQ	R8	R6	R8
+      0x78220007,  //  0368  JMPF	R8	#0371
+      0x1C200F0F,  //  0369  EQ	R8	R7	K15
+      0x78220004,  //  036A  JMPF	R8	#0370
+      0x8C200706,  //  036B  GETMET	R8	R3	K6
+      0x88280B0E,  //  036C  GETMBR	R10	R5	K14
+      0x542E001D,  //  036D  LDINT	R11	30
+      0x7C200600,  //  036E  CALL	R8	3
+      0x80041000,  //  036F  RET	1	R8
+      0x7002002D,  //  0370  JMP		#039F
+      0x5422001C,  //  0371  LDINT	R8	29
+      0x1C200C08,  //  0372  EQ	R8	R6	R8
+      0x7822002A,  //  0373  JMPF	R8	#039F
+      0x1C200F0D,  //  0374  EQ	R8	R7	K13
+      0x78220008,  //  0375  JMPF	R8	#037F
+      0x8C200B11,  //  0376  GETMET	R8	R5	K17
+      0x7C200200,  //  0377  CALL	R8	1
+      0x8C24110B,  //  0378  GETMET	R9	R8	K11
+      0x4C2C0000,  //  0379  LDNIL	R11
+      0x88300B0C,  //  037A  GETMBR	R12	R5	K12
+      0x5436001E,  //  037B  LDINT	R13	31
+      0x7C240800,  //  037C  CALL	R9	4
+      0x80041000,  //  037D  RET	1	R8
+      0x7002001F,  //  037E  JMP		#039F
+      0x1C200F0F,  //  037F  EQ	R8	R7	K15
+      0x7822001D,  //  0380  JMPF	R8	#039F
+      0x8C200B11,  //  0381  GETMET	R8	R5	K17
+      0x7C200200,  //  0382  CALL	R8	1
+      0x88240136,  //  0383  GETMBR	R9	R0	K54
+      0x8C24135A,  //  0384  GETMET	R9	R9	K90
+      0x502C0200,  //  0385  LDBOOL	R11	1	0
+      0x7C240400,  //  0386  CALL	R9	2
+      0x88280136,  //  0387  GETMBR	R10	R0	K54
+      0x8828155B,  //  0388  GETMBR	R10	R10	K91
+      0x602C0010,  //  0389  GETGBL	R11	G16
+      0x5C301200,  //  038A  MOVE	R12	R9
+      0x7C2C0200,  //  038B  CALL	R11	1
+      0xA802000D,  //  038C  EXBLK	0	#039B
+      0x5C301600,  //  038D  MOVE	R12	R11
+      0x7C300000,  //  038E  CALL	R12	0
+      0x5C341400,  //  038F  MOVE	R13	R10
+      0x78360003,  //  0390  JMPF	R13	#0395
+      0xB8360200,  //  0391  GETNGBL	R13	K1
+      0x88341B5C,  //  0392  GETMBR	R13	R13	K92
+      0x2034180D,  //  0393  NE	R13	R12	R13
+      0x78360004,  //  0394  JMPF	R13	#039A
+      0x8C34110B,  //  0395  GETMET	R13	R8	K11
+      0x4C3C0000,  //  0396  LDNIL	R15
+      0x88400B0C,  //  0397  GETMBR	R16	R5	K12
+      0x5C441800,  //  0398  MOVE	R17	R12
+      0x7C340800,  //  0399  CALL	R13	4
+      0x7001FFF1,  //  039A  JMP		#038D
+      0x582C003E,  //  039B  LDCONST	R11	K62
+      0xAC2C0200,  //  039C  CATCH	R11	1	0
+      0xB0080000,  //  039D  RAISE	2	R0	R0
+      0x80041000,  //  039E  RET	1	R8
+      0x60200003,  //  039F  GETGBL	R8	G3
+      0x5C240000,  //  03A0  MOVE	R9	R0
+      0x7C200200,  //  03A1  CALL	R8	1
+      0x8C20115D,  //  03A2  GETMET	R8	R8	K93
+      0x5C280200,  //  03A3  MOVE	R10	R1
+      0x5C2C0400,  //  03A4  MOVE	R11	R2
+      0x5C300600,  //  03A5  MOVE	R12	R3
+      0x7C200800,  //  03A6  CALL	R8	4
+      0x80041000,  //  03A7  RET	1	R8
     })
   )
 );


### PR DESCRIPTION
## Description:

Fix a wrong assignment of fabric_index to NOCStruct that caused an error when pairing with Home Assistant

See https://github.com/home-assistant/core/issues/113279

**Related issue (if applicable):** fixes #20949

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
