### PR TITLE
Prep: show correct flash partition size for safeboot when compiling

### DIFF
--- a/pio-tools/name-firmware.py
+++ b/pio-tools/name-firmware.py
@@ -5,6 +5,7 @@ import shutil
 import pathlib
 import tasmotapiolib
 from os.path import join
+from colorama import Fore, Back, Style
 
 
 def bin_map_copy(source, target, env):
@@ -17,6 +18,13 @@ def bin_map_copy(source, target, env):
     firmware_name = env.subst("$BUILD_DIR/${PROGNAME}.bin")
 
     if env["PIOPLATFORM"] == "espressif32":
+        if("safeboot" in firmware_name):
+            SAFEBOOT_SIZE = firsttarget.stat().st_size
+            if SAFEBOOT_SIZE > 851967:
+                print(Fore.RED + "!!! Tasmota safeboot size is too big with {} bytes. Max size is 851967 bytes !!! ".format(
+                        SAFEBOOT_SIZE
+                    )
+                )
         if("safeboot" not in firmware_name):
             factory_tmp = pathlib.Path(firsttarget).with_suffix("")
             factory = factory_tmp.with_suffix(factory_tmp.suffix + ".factory.bin")

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -29,6 +29,7 @@ custom_files_upload     = no_files
 [env:tasmota32-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32_solo1
+board_build.app_partition_name = safeboot
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFRAMEWORK_ARDUINO_SOLO1
                           -DFIRMWARE_SAFEBOOT
@@ -39,6 +40,7 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 [env:tasmota32solo1-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32_solo1
+board_build.app_partition_name = safeboot
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32solo1-safeboot.bin"'
@@ -48,6 +50,7 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 [env:tasmota32s2-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32s2
+board_build.app_partition_name = safeboot
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2-safeboot.bin"'
@@ -57,6 +60,7 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 [env:tasmota32s2cdc-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32s2cdc
+board_build.app_partition_name = safeboot
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2cdc-safeboot.bin"'
@@ -66,6 +70,7 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 [env:tasmota32c2-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32c2
+board_build.app_partition_name = safeboot
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -mtarget-align
 build_flags             = ${env:tasmota32_base.build_flags}
@@ -77,6 +82,7 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 [env:tasmota32c3-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32c3
+board_build.app_partition_name = safeboot
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -mtarget-align
 build_flags             = ${env:tasmota32_base.build_flags}
@@ -88,6 +94,7 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 [env:tasmota32c3ser-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32c3ser
+board_build.app_partition_name = safeboot
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -mtarget-align
 build_flags             = ${env:tasmota32_base.build_flags}
@@ -99,6 +106,7 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 [env:tasmota32s3-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32s3-qio_qspi
+board_build.app_partition_name = safeboot
 build_flags             = ${env:tasmota32_base.build_flags}
                          -DFIRMWARE_SAFEBOOT
                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3-safeboot.bin"'
@@ -108,6 +116,7 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 [env:tasmota32c6-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32c6
+board_build.app_partition_name = safeboot
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -mtarget-align
 build_flags             = ${env:tasmota32_base.build_flags}
@@ -119,6 +128,7 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 [env:tasmota32c6ser-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32c6ser
+board_build.app_partition_name = safeboot
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -mtarget-align
 build_flags             = ${env:tasmota32_base.build_flags}
@@ -130,6 +140,7 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 [env:tasmota32s3ser-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32s3ser-qio_qspi
+board_build.app_partition_name = safeboot
 build_flags             = ${env:tasmota32_base.build_flags}
                          -DFIRMWARE_SAFEBOOT
                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3ser-safeboot.bin"'


### PR DESCRIPTION
## Description:

and prints a red warning when safeboot firmware will not fit in safeboot partition.

**will work with next Tasmota Platform update ;-)**

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
