### PR TITLE
Berry add gpio.set_freq()

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_gpio_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_gpio_lib.c
@@ -27,6 +27,7 @@ extern int gp_get_pin_index(int32_t pin);               BE_FUNC_CTYPE_DECLARE(gp
 
 // esp_err_tledc_set_duty_and_update(ledc_mode_tspeed_mode, ledc_channel_tchannel, uint32_t duty, uint32_t hpoint)
 extern void gp_set_duty(int32_t pin, int32_t duty, int32_t hpoint);   BE_FUNC_CTYPE_DECLARE(gp_set_duty, "", "ii[i]");
+extern void gp_set_frequency(int32_t pin, int32_t frequency);   BE_FUNC_CTYPE_DECLARE(gp_set_frequency, "", "ii");
 
 extern int gp_get_duty(int32_t pin);               BE_FUNC_CTYPE_DECLARE(gp_get_duty, "i", "i");
 extern int gp_get_duty_resolution(int32_t pin);    BE_FUNC_CTYPE_DECLARE(gp_get_duty_resolution, "i", "i");
@@ -49,6 +50,7 @@ module gpio (scope: global) {
     pin, func(gp_pin)
 
     set_pwm, ctype_func(gp_set_duty)
+    set_pwm_freq, ctype_func(gp_set_frequency)
     read_pwm, ctype_func(gp_get_duty)
     read_pwm_resolution, ctype_func(gp_get_duty_resolution)
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_gpio.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_gpio.ino
@@ -241,6 +241,10 @@ extern "C" {
     analogWritePhase(pin, duty, hpoint);
   }
 
+  void gp_set_frequency(int32_t pin, int32_t frequency) {
+    analogWriteFreq(frequency, pin);
+  }
+
   // gpio.counter_read(counter:int) -> int or nil
   //
   // Read counter value, or return nil if counter is not used


### PR DESCRIPTION
## Description:

Adds function to set the PWM frequency to Berry's gpio module.
Adds ~70 bytes of flash.

Usage:
```
gpio.set_pwm_freq(pin,frequency)
```

Can be used to play sounds via a cheap mainboard speaker to signal status, failure and so on.

Complex driver example to play RTTTL ringtones in the comments.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
