### PR TITLE
Quick Fix: KNX loose config on restart

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_11_knx.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_11_knx.ino
@@ -442,54 +442,54 @@ void KNX_DEL_CB( uint8_t CBnum )
 }
 
 
-bool KNX_CONFIG_NOT_MATCH(void)
-{
-  // Check for configured parameters that the device does not have (module changed)
-  for (uint32_t i = 0; i < KNX_MAX_device_param; ++i)
-  {
-    if ( !device_param[i].show ) { // device has this parameter ?
-      // if not, search for all registered group address to this parameter for deletion
+// bool KNX_CONFIG_NOT_MATCH(void)
+// {
+//   // Check for configured parameters that the device does not have (module changed)
+//   for (uint32_t i = 0; i < KNX_MAX_device_param; ++i)
+//   {
+//     if ( !device_param[i].show ) { // device has this parameter ?
+//       // if not, search for all registered group address to this parameter for deletion
 
-      // Checks all GA
-      if ( KNX_GA_Search(i+1) != KNX_Empty ) { return true; }
-      // Check all CB
-      if ( i < 8 ) // check relays (i from 8 to 15 are toggle relays parameters)
-      {
-        if ( KNX_CB_Search(i+1) != KNX_Empty ) { return true; }
-        if ( KNX_CB_Search(i+9) != KNX_Empty ) { return true; }
-      }
-      // check sensors and others
-      if ( i > 15 )
-      {
-        if ( KNX_CB_Search(i+1) != KNX_Empty ) { return true; }
-      }
-    }
-  }
+//       // Checks all GA
+//       if ( KNX_GA_Search(i+1) != KNX_Empty ) { return true; }
+//       // Check all CB
+//       if ( i < 8 ) // check relays (i from 8 to 15 are toggle relays parameters)
+//       {
+//         if ( KNX_CB_Search(i+1) != KNX_Empty ) { return true; }
+//         if ( KNX_CB_Search(i+9) != KNX_Empty ) { return true; }
+//       }
+//       // check sensors and others
+//       if ( i > 15 )
+//       {
+//         if ( KNX_CB_Search(i+1) != KNX_Empty ) { return true; }
+//       }
+//     }
+//   }
 
-  // Check for invalid or erroneous configuration (tasmota flashed without clearing the memory)
-  for (uint32_t i = 0; i < Settings->knx_GA_registered; ++i)
-  {
-    if ( Settings->knx_GA_param[i] != 0 ) // the GA[i] have a parameter defined?
-    {
-      if ( Settings->knx_GA_addr[i] == 0 ) // the GA[i] with parameter have the 0/0/0 as address?
-      {
-         return true; // So, it is invalid. Reset KNX configuration
-      }
-    }
-  }
-  for (uint32_t i = 0; i < Settings->knx_CB_registered; ++i)
-  {
-    if ( Settings->knx_CB_param[i] != 0 ) // the CB[i] have a parameter defined?
-    {
-      if ( Settings->knx_CB_addr[i] == 0 ) // the CB[i] with parameter have the 0/0/0 as address?
-      {
-         return true; // So, it is invalid. Reset KNX configuration
-      }
-    }
-  }
+//   // Check for invalid or erroneous configuration (tasmota flashed without clearing the memory)
+//   for (uint32_t i = 0; i < Settings->knx_GA_registered; ++i)
+//   {
+//     if ( Settings->knx_GA_param[i] != 0 ) // the GA[i] have a parameter defined?
+//     {
+//       if ( Settings->knx_GA_addr[i] == 0 ) // the GA[i] with parameter have the 0/0/0 as address?
+//       {
+//          return true; // So, it is invalid. Reset KNX configuration
+//       }
+//     }
+//   }
+//   for (uint32_t i = 0; i < Settings->knx_CB_registered; ++i)
+//   {
+//     if ( Settings->knx_CB_param[i] != 0 ) // the CB[i] have a parameter defined?
+//     {
+//       if ( Settings->knx_CB_addr[i] == 0 ) // the CB[i] with parameter have the 0/0/0 as address?
+//       {
+//          return true; // So, it is invalid. Reset KNX configuration
+//       }
+//     }
+//   }
 
-  return false;
-}
+//   return false;
+// }
 
 
 void KNXStart(void)
@@ -556,11 +556,11 @@ void KNX_INIT(void)
 #endif
 
   // Delete from KNX settings all configuration is not anymore related to this device
-  if (KNX_CONFIG_NOT_MATCH()) {
-    Settings->knx_GA_registered = 0;
-    Settings->knx_CB_registered = 0;
-    AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_KNX D_DELETE " " D_KNX_PARAMETERS));
-  }
+  // if (KNX_CONFIG_NOT_MATCH()) {
+  //   Settings->knx_GA_registered = 0;
+  //   Settings->knx_CB_registered = 0;
+  //   AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_KNX D_DELETE " " D_KNX_PARAMETERS));
+  // }
 
   // Register Group Addresses to listen to
   //     Search on the settings if there is a group address set for receive KNX messages for the type: device_param[j].type


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/issues/21379 (initially reported here https://github.com/arendst/Tasmota/issues/20834#issuecomment-2096809259)

This restore the way @ascillato was testing the KNX configuration against some sensors enabled.

Solve the above issue but prevent to use any temperature or humidity sensor than those listed, excluding also all I2C sensors.


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
