### PR TITLE
Prepare for ESP32 WDT

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -36,6 +36,7 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Wl,--wrap=panicHandler -Wl,--wrap=xt_unhandled_exception
                               -Wl,--wrap=_Z11analogWritehi  ; `analogWrite(unsigned char, int)` use the Tasmota version of analogWrite for deeper integration and phase control
                               -Wl,--wrap=ledcReadFreq  ; `uint32_t ledcReadFreq(uint8_t chan)`
+                              -Wl,--wrap=delay         ; void delay(uint32_t ms)
 lib_ignore                  =
                               HTTPUpdateServer
                               USB

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1122,6 +1122,8 @@ https://rya.nc/tasmota-fingerprint.html"
 
 #ifdef ESP32
 
+// #define USE_ESP32_WDT                            // Enable Watchdog for ESP32, trigger a restart if loop has not responded for 5s, and if `yield();` was not called
+
 #define SET_ESP32_STACK_SIZE  (8 * 1024)         // Set the stack size for Tasmota. The default value is 8192 for Arduino, some builds might need to increase it
 
 #ifdef SOC_TOUCH_VERSION_1                       // ESP32

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -411,6 +411,10 @@ void setup(void) {
 #endif  // CONFIG_IDF_TARGET_ESP32
 #endif  // ESP32
 
+#ifdef USE_ESP32_WDT
+  enableLoopWDT();          // enabled WDT Watchdog on Arduino `loop()` - must return before 5s or called `feedLoopWDT();` - included in `yield()`
+#endif // USE_ESP32_WDT
+
   RtcPreInit();
   SettingsInit();
 

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -27,11 +27,21 @@ extern struct rst_info resetInfo;
 #ifdef ESP32
 // Watchdog - yield() resets the watchdog
 #ifdef USE_ESP32_WDT
+
 extern "C"
 void yield(void) {
   vPortYield();         // was originally in `__yield`
   feedLoopWDT();
 }
+
+// patching delay(uint32_t ms)
+extern "C" void __real_delay(uint32_t ms);
+
+extern "C" void __wrap_delay(uint32_t ms) {
+  __real_delay(ms);
+  feedLoopWDT();
+}
+
 #endif // USE_ESP32_WDT
 #endif // ESP32
 

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -22,6 +22,20 @@ extern struct rst_info resetInfo;
 }
 
 /*********************************************************************************************\
+ * ESP32 Watchdog
+\*********************************************************************************************/
+#ifdef ESP32
+// Watchdog - yield() resets the watchdog
+#ifdef USE_ESP32_WDT
+extern "C"
+void yield(void) {
+  vPortYield();         // was originally in `__yield`
+  feedLoopWDT();
+}
+#endif // USE_ESP32_WDT
+#endif // ESP32
+
+/*********************************************************************************************\
  * Watchdog extension (https://github.com/esp8266/Arduino/issues/1532)
 \*********************************************************************************************/
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_1_berry_native.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_1_berry_native.ino
@@ -110,6 +110,7 @@ void BrTimeoutStart(void)  {
   if (0 == berry.timeout) {
     berry.timeout = 1;    // rare case when value accidentally computes to zero
   }
+  yield();
 }
 
 void BrTimeoutYield(void) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -404,7 +404,8 @@ extern "C" {
   // ESP object
   int32_t l_yield(bvm *vm);
   int32_t l_yield(bvm *vm) {
-    return be_call_c_func(vm, (void*) &BrTimeoutYield, NULL, "-");
+    BrTimeoutYield();
+    be_return_nil(vm);
   }
 
   // Berry: tasmota.scale_uint(int * 5) -> int


### PR DESCRIPTION
## Description:

Prepare for ESP32 watchdog (WDT):
- enable with `#define USE_ESP32_WDT` (not enabled by default until after v14)
- calling `yield()` resets the watchdog, also now called with Berry `tasmota.yield()`
- modified `yield()` to call `feedLoopWDT()`

No functional change until `USE_ESP32_WDT` is enabled

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
