### PR TITLE
Fixed Berry `gpio.dac_voltage()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - Avoid unwanted OTA upgrade when safeboot starts for the first time (#21360)
 - Matter broken NOCStruct types preventing pairing with HA (#21365)
 - jpeg compile core3 (#21387)
+- Berry `gpio.dac_voltage()`
 
 ### Removed
 - LVGL disabled vector graphics (#21242)


### PR DESCRIPTION
## Description:

Fixed `gpio.dac_voltage()` for Core3

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
