### PR TITLE
use compiler option `no-target-align`

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -2,6 +2,7 @@
 
 [esp32_defaults]
 build_unflags               = ${esp_defaults.build_unflags}
+                              -mtarget-align
                               -Wswitch-unreachable
                               -Wstringop-overflow
                               -Wincompatible-pointer-types
@@ -12,6 +13,7 @@ build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp_defaults.build_flags}
                               ; comment next line to disable IPv6 support
                               -DUSE_IPV6
+                              -mno-target-align
                               -Wno-switch-unreachable
                               -Wno-stringop-overflow
                               -fno-exceptions

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -72,7 +72,7 @@ extends                 = env:tasmota32_base
 board                   = esp32c2
 board_build.app_partition_name = safeboot
 build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mtarget-align
+                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c2-safeboot.bin"'
@@ -84,7 +84,7 @@ extends                 = env:tasmota32_base
 board                   = esp32c3
 board_build.app_partition_name = safeboot
 build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mtarget-align
+                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3-safeboot.bin"'
@@ -96,7 +96,7 @@ extends                 = env:tasmota32_base
 board                   = esp32c3ser
 board_build.app_partition_name = safeboot
 build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mtarget-align
+                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3ser-safeboot.bin"'
@@ -118,7 +118,7 @@ extends                 = env:tasmota32_base
 board                   = esp32c6
 board_build.app_partition_name = safeboot
 build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mtarget-align
+                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6-safeboot.bin"'
@@ -130,7 +130,7 @@ extends                 = env:tasmota32_base
 board                   = esp32c6ser
 board_build.app_partition_name = safeboot
 build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mtarget-align
+                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6ser-safeboot.bin"'
@@ -188,7 +188,7 @@ lib_ignore              = ${env:tasmota32_base.lib_ignore}
 extends                 = env:tasmota32_base
 board                   = esp32c2
 build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mtarget-align
+                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c2.bin"'
@@ -197,7 +197,7 @@ build_flags             = ${env:tasmota32_base.build_flags}
 extends                 = env:tasmota32_base
 board                   = esp32c3
 build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mtarget-align
+                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3.bin"'
@@ -206,7 +206,7 @@ build_flags             = ${env:tasmota32_base.build_flags}
 extends                 = env:tasmota32_base
 board                   = esp32c6
 build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -mtarget-align
+                          -mno-target-align
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6.bin"'


### PR DESCRIPTION
## Description:

saves around 15kbyte flash space for xtensa driven MCUs (option only used and available)
Some testing done, did not encountered issues.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
