### PR TITLE
Enabled watchdog for ESP32 and variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [14.0.0.1]
 ### Added
-
+- Enabled watchdog for ESP32 and variants
 
 ### Breaking Changed
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1122,7 +1122,7 @@ https://rya.nc/tasmota-fingerprint.html"
 
 #ifdef ESP32
 
-// #define USE_ESP32_WDT                            // Enable Watchdog for ESP32, trigger a restart if loop has not responded for 5s, and if `yield();` was not called
+#define USE_ESP32_WDT                            // Enable Watchdog for ESP32, trigger a restart if loop has not responded for 5s, and if `yield();` was not called
 
 #define SET_ESP32_STACK_SIZE  (8 * 1024)         // Set the stack size for Tasmota. The default value is 8192 for Arduino, some builds might need to increase it
 


### PR DESCRIPTION
## Description:

Enable watchdog for ESP32x variants. The watchdog automatically resets the CPU if the main loop is not called for over 5 seconds. It is meant to detect situations when the CPU is stuck and frozen.

We tried the watchdog years ago, but it had some serious issues. They seem all solved now. It is however possible that the watchdog fires during normal long operations. Please report any such circumstances.

In `C` code, any call to `yield()` resets the watchdog. Similarly, in Berry, any call to `tasmota.yields()` resets both the Berry-specific watchdog (4 seconds) and the main watchdog (5 seconds)

Note: watchdog is already enabled on ESP8266.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
