### PR TITLE
Revert "Enabled watchdog for ESP32 and variants"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [14.0.0.1]
 ### Added
-- Enabled watchdog for ESP32 and variants
+
 
 ### Breaking Changed
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1105,7 +1105,7 @@
 
 #ifdef ESP32
 
-#define USE_ESP32_WDT                            // Enable Watchdog for ESP32, trigger a restart if loop has not responded for 5s, and if `yield();` was not called
+// #define USE_ESP32_WDT                            // Enable Watchdog for ESP32, trigger a restart if loop has not responded for 5s, and if `yield();` was not called
 
 #define SET_ESP32_STACK_SIZE  (8 * 1024)         // Set the stack size for Tasmota. The default value is 8192 for Arduino, some builds might need to increase it
 


### PR DESCRIPTION
Reverts arendst/Tasmota#21414

Temporarily revert because `Upgrade 3` causes a failure and breaks the safeboot, rendering any OTA impossible