### PR TITLE
Enabled watchdog for ESP32 and variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [14.0.0.1]
 ### Added
-
+- Enabled watchdog for ESP32 and variants
 
 ### Breaking Changed
 

--- a/include/esp32x_fixes.h
+++ b/include/esp32x_fixes.h
@@ -70,3 +70,10 @@
 #define SPI_MOSI_DLEN_REG(x) SPI_MS_DLEN_REG(x)
 
 #endif // TARGET
+
+// This trick makes sure that 'lto' optimizer does not inline `delay()
+// so we can override it with `-Wl,--wrap=delay` linker directive
+#ifdef __cplusplus
+extern "C"
+#endif // _cplusplus
+void  delay(unsigned long ms) __attribute__((noinline)) __attribute__ ((noclone));

--- a/include/esp32x_fixes.h
+++ b/include/esp32x_fixes.h
@@ -76,4 +76,4 @@
 #ifdef __cplusplus
 extern "C"
 #endif // _cplusplus
-void  delay(unsigned long ms) __attribute__((noinline)) __attribute__ ((noclone));
+void  delay(__UINT32_TYPE__ ms) __attribute__((noinline)) __attribute__ ((noclone));

--- a/lib/libesp32/HttpClientLight/src/TasUpdater.cpp
+++ b/lib/libesp32/HttpClientLight/src/TasUpdater.cpp
@@ -392,7 +392,7 @@ size_t TasUpdateClass::writeStream(Stream &data) {
             return written;
         written += toRead;
 
-        delay(1);  // Fix solo WDT
+        yield();  // Ensure WDT does not trigger
     }
     return written;
 }

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -187,6 +187,8 @@
 #define USE_WEBCLIENT
 #define USE_WEBCLIENT_HTTPS
 
+#undef USE_ESP32_WDT                                  // disable watchdog on SAFEBOOT until more testing is done
+
 #if CONFIG_IDF_TARGET_ESP32
 #if CONFIG_FREERTOS_UNICORE
   #undef USE_MQTT_TLS

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1105,7 +1105,7 @@
 
 #ifdef ESP32
 
-// #define USE_ESP32_WDT                            // Enable Watchdog for ESP32, trigger a restart if loop has not responded for 5s, and if `yield();` was not called
+#define USE_ESP32_WDT                            // Enable Watchdog for ESP32, trigger a restart if loop has not responded for 5s, and if `yield();` was not called
 
 #define SET_ESP32_STACK_SIZE  (8 * 1024)         // Set the stack size for Tasmota. The default value is 8192 for Arduino, some builds might need to increase it
 

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -39,9 +39,13 @@ void yield(void) {
 extern "C" void __real_delay(uint32_t ms);  // original function from Arduino Core
 
 extern "C" void __wrap_delay(uint32_t ms) {
+#ifdef USE_ESP32_WDT
   if (ms) { feedLoopWDT(); }
   __real_delay(ms);
   feedLoopWDT();
+#else
+  __real_delay(ms);
+#endif
 }
 
 #endif // USE_ESP32_WDT

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -28,16 +28,18 @@ extern struct rst_info resetInfo;
 // Watchdog - yield() resets the watchdog
 #ifdef USE_ESP32_WDT
 
+extern "C" void __yield(void);              // original function from Arduino Core
 extern "C"
 void yield(void) {
-  vPortYield();         // was originally in `__yield`
+  __yield();
   feedLoopWDT();
 }
 
 // patching delay(uint32_t ms)
-extern "C" void __real_delay(uint32_t ms);
+extern "C" void __real_delay(uint32_t ms);  // original function from Arduino Core
 
 extern "C" void __wrap_delay(uint32_t ms) {
+  if (ms) { feedLoopWDT(); }
   __real_delay(ms);
   feedLoopWDT();
 }

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -26,7 +26,6 @@ extern struct rst_info resetInfo;
 \*********************************************************************************************/
 #ifdef ESP32
 // Watchdog - yield() resets the watchdog
-#ifdef USE_ESP32_WDT
 
 extern "C" void __yield(void);              // original function from Arduino Core
 extern "C"
@@ -48,7 +47,6 @@ extern "C" void __wrap_delay(uint32_t ms) {
 #endif
 }
 
-#endif // USE_ESP32_WDT
 #endif // ESP32
 
 /*********************************************************************************************\

--- a/tasmota/tasmota_support/support_crash_recorder.ino
+++ b/tasmota/tasmota_support/support_crash_recorder.ino
@@ -37,10 +37,15 @@ void CmndWDT(void)
 }
 
 // This will trigger the os watch after OSWATCH_RESET_TIME (=120) seconds
+// or normal WDT on ESP32
 void CmndBlockedLoop(void)
 {
   while (1) {
+#ifdef ESP32
+    delay(10000);   // 10s on ESP32 so that the normal WDT fires after 5s. There is no OSWATCH_RESET_TIME on ESP32
+#else
     delay(1000);
+#endif
   }
 }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_54_lvgl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_54_lvgl.ino
@@ -68,6 +68,7 @@ void lv_flush_callback(lv_display_t *disp, const lv_area_t *area, uint8_t *color
   if (lvgl_glue->screenshot != nullptr) {
     // save pixels to file
     int32_t btw = (width * height * LV_COLOR_DEPTH + 7) / 8;
+    yield();            // ensure WDT does not fire
     while (btw > 0) {
       if (btw > 0) {    // if we had a previous error (ex disk full) don't try to write anymore
         int32_t ret = lvgl_glue->screenshot->write((const uint8_t*) color_p, btw);


### PR DESCRIPTION
## Description:

Enable watchdog for ESP32x variants. The watchdog automatically resets the CPU if the main loop is not called for over 5 seconds. It is meant to detect situations when the CPU is stuck and frozen.

We tried the watchdog years ago, but it had some serious issues. They seem all solved now. It is however possible that the watchdog fires during normal long operations. Please report any such circumstances.

In `C` code, any call to `yield()` resets the watchdog. Similarly, in Berry, any call to `tasmota.yields()` resets both the Berry-specific watchdog (4 seconds) and the main watchdog (5 seconds)

`Restart -3` was changed on ESP32 otherwise the device is stuck forever, there is no `OSWATCH_RESET_TIME` after 120s on ESP32

Note: watchdog is already enabled on ESP8266.

This is a second try after #21414 reverted

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
