### PR TITLE
Berry binary compiled with gcc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - ESP32 compiler option from `target-align` to `no-target-align` (#21407)
 - On universal display remove default backlight power if a PWM channel is used for backlight
+- Berry binary compiled with gcc
 
 ### Fixed
 - Domoticz re-subscribe on MQTT reconnect. Regression from v13.4.0.3 (#21281)

--- a/lib/libesp32/berry/Makefile
+++ b/lib/libesp32/berry/Makefile
@@ -3,7 +3,7 @@ DEBUG_FLAGS = -O0 -g -DBE_DEBUG
 TEST_FLAGS  = $(DEBUG_FLAGS) --coverage -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined
 LIBS        = -lm
 TARGET      = berry
-CC          = clang # install clang!! gcc seems to produce a defect berry binary
+CC          = gcc
 MKDIR       = mkdir
 LFLAGS      =
 


### PR DESCRIPTION
## Description:

Revert back to `gcc` when compiling `berry` binary for solidification. Although there are many warnings due to maxium `-Wall`, it works fine.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
