### PR TITLE
i2s audio, some small improvements

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
@@ -85,7 +85,11 @@ typedef struct{
   struct {
     uint32_t sample_rate = 32000;  // B00-03 - 32000 is compatible with MP3 encoding
     uint16_t gain = 30 * 16;       // B04-05 - in Q12.4
+#if SOC_I2S_SUPPORTS_PDM_RX
     uint8_t  mode = I2S_MODE_PDM;  // B06 - I2S mode standard, PDM, TDM, DAC
+#else
+    uint8_t  mode = I2S_MODE_STD;  // B06 - I2S mode standard, PDM, TDM, DAC
+#endif
     uint8_t  slot_mask = BIT(0);   // B07 - slot mask  = left/right/both depended on mode, so BIT(0) maybe left or right
     uint8_t  slot_bit_width = I2S_SLOT_BIT_WIDTH_32BIT;  // B08 - auto equals data_bit_width - can differ from bits per sample e.g. INMP441
     uint8_t  channels = 1;         // B09 - mono/stereo - 1 is added for both

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio_idf51.ino
@@ -404,7 +404,7 @@ void I2sMicTask(void *arg){
   }
 
   ctime = TasmotaGlobal.uptime;
-  timeForOneRead = 1000 / ((audio_i2s.Settings->rx.sample_rate / samples_per_pass));
+  timeForOneRead = 1000 / ((audio_i2s.Settings->rx.sample_rate / (samples_per_pass * audio_i2s.Settings->rx.channels )));
   timeForOneRead -= 1; // be very in time
 
   AddLog(LOG_LEVEL_DEBUG, PSTR("I2S: samples %u, bytesize %u, time: %u"),samples_per_pass, bytesize, timeForOneRead);
@@ -1027,7 +1027,11 @@ void CmndI2SI2SRtttl(void) {
 }
 
 void CmndI2SMicRec(void) {
-  if (audio_i2s.Settings->sys.mp3_preallocate == 1) {
+  if (audio_i2s_mp3.mp3ram == nullptr){
+    AddLog(LOG_LEVEL_DEBUG,PSTR("I2S: try late buffer allocation for mp3 encoder"));
+    audio_i2s_mp3.mp3ram = special_malloc(preallocateCodecSize);
+  }
+  if (audio_i2s_mp3.mp3ram != nullptr) {
     if (XdrvMailbox.data_len > 0) {
       if (!strncmp(XdrvMailbox.data, "-?", 2)) {
         Response_P("{\"I2SREC-duration\":%d}", audio_i2s_mp3.recdur);


### PR DESCRIPTION
## Description:

1. Prevents unworkable default mode PDM for microphone on SOC's that do not support PDM mode (e.g. ESP-S2).
2. Prevents crash when attempting to record in stereo mode, which does not really make sense on a mono microphone, but at least it is possible now.
3. Less strict memory management for the MP3 encoder, which does not need preallocation anymore in the driver settings. Now late allocation is supported, but preallocation is still possible and it can be still useful, if free (large blocks of) heap is not guaranteed later in the running system.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
