### PR TITLE
KNX add support for Dimmer and Colour

### DIFF
--- a/tasmota/include/tasmota.h
+++ b/tasmota/include/tasmota.h
@@ -283,7 +283,9 @@ const uint32_t LOOP_SLEEP_DELAY = 50;       // Lowest number of milliseconds to 
 #define KNX_SLOT4              29
 #define KNX_SLOT5              30
 #define KNX_SCENE              31
-#define KNX_MAX_device_param   31
+#define KNX_DIMMER             32   // aka DPT_Scaling 5.001
+#define KNX_COLOUR             33   // aka DPT_Colour_RGB 232.600 or DPT_Colour_RGBW 251.600
+#define KNX_MAX_device_param   33
 #define MAX_KNXTX_CMNDS        5
 
 // XPT2046 resistive touch driver min/max raw values

--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Bevel"
 #define D_CONNECTED "Gekoppel"
 #define D_CORS_DOMAIN "CORS Domain"
+#define D_COLOR "Color"
 #define D_COUNT "Telling"
 #define D_COUNTER "Opnemer"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Команда"
 #define D_CONNECTED "Свързан"
 #define D_CORS_DOMAIN "Домейн на CORS"
+#define D_COLOR "Color"
 #define D_COUNT "Брой"
 #define D_COUNTER "Брояч"
 #define D_CT_POWER "ТТ Мощност"

--- a/tasmota/language/ca_AD.h
+++ b/tasmota/language/ca_AD.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Ordre"
 #define D_CONNECTED "Connectat"
 #define D_CORS_DOMAIN "Domini CORS"
+#define D_COLOR "Color"
 #define D_COUNT "Compta"
 #define D_COUNTER "Comptador"
 #define D_CT_POWER "Energia CT"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Příkaz"
 #define D_CONNECTED "...připojeno"
 #define D_CORS_DOMAIN "CORS Domain"
+#define D_COLOR "Color"
 #define D_COUNT "Počítej"
 #define D_COUNTER "Počítadlo"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Befehl"
 #define D_CONNECTED "verbunden"
 #define D_CORS_DOMAIN "CORS Domain"
+#define D_COLOR "Color"
 #define D_COUNT "Anzahl"             // used as a noun throughout
 #define D_COUNTER "Zähler"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -75,6 +75,7 @@
 #define D_COLDLIGHT "Ψυχρό"
 #define D_COMMAND "Εντολή"
 #define D_CONNECTED "Συνδεδεμένο"
+#define D_COLOR "Color"
 #define D_COUNT "Μέτρηση"
 #define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNTER "Μετρητής"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Command"
 #define D_CONNECTED "Connected"
 #define D_CORS_DOMAIN "CORS Domain"
+#define D_COLOR "Color"
 #define D_COUNT "Count"
 #define D_COUNTER "Counter"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Comando"
 #define D_CONNECTED "Conectado"
 #define D_CORS_DOMAIN "Sitio WEB para CORS"
+#define D_COLOR "Color"
 #define D_COUNT "Conteo"
 #define D_COUNTER "Contador"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Commande"
 #define D_CONNECTED "Connecté"
 #define D_CORS_DOMAIN "Domaine CORS"
+#define D_COLOR "Color"
 #define D_COUNT "Compte"
 #define D_COUNTER "Compteur"
 #define D_CT_POWER "Puissance CT"

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Oarder"
 #define D_CONNECTED "Ferbûn"
 #define D_CORS_DOMAIN "CORS Domain"
+#define D_COLOR "Color"
 #define D_COUNT "Nûmer"
 #define D_COUNTER "Teller"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "פקודה"
 #define D_CONNECTED "מחובר"
 #define D_CORS_DOMAIN "CORS Domain"
+#define D_COLOR "Color"
 #define D_COUNT "סופר"
 #define D_COUNTER "מונה"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Parancs"
 #define D_CONNECTED "Csatlakoztatva"
 #define D_CORS_DOMAIN "CORS Domain"
+#define D_COLOR "Color"
 #define D_COUNT "Szám"
 #define D_COUNTER "Számláló"
 #define D_CT_POWER "CT erősség"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -76,6 +76,7 @@
 #define D_COMMAND              "Comando"
 #define D_CONNECTED            "Connesso"
 #define D_CORS_DOMAIN          "Dominio CORS"
+#define D_COLOR "Color"
 #define D_COUNT                "Conteggio"
 #define D_COUNTER              "Contatore"
 #define D_CT_POWER             "Alimentazione CT"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -75,6 +75,7 @@
 #define D_COLDLIGHT "차갑게"
 #define D_COMMAND "커맨드"
 #define D_CONNECTED "연결됨"
+#define D_COLOR "Color"
 #define D_COUNT "횟수"
 #define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNTER "Counter"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -75,6 +75,7 @@
 #define D_COLDLIGHT "Koud"
 #define D_COMMAND "Opdracht"
 #define D_CONNECTED "Verbonden"
+#define D_COLOR "Color"
 #define D_COUNT "Aantal"
 #define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNTER "Teller"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Komenda"
 #define D_CONNECTED "Połączony"
 #define D_CORS_DOMAIN "Domena CORS"
+#define D_COLOR "Color"
 #define D_COUNT "Licz"
 #define D_COUNTER "Licznik"
 #define D_CT_POWER "Moc CT"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Comando"
 #define D_CONNECTED "Ligado"
 #define D_CORS_DOMAIN "Domínio CORS"
+#define D_COLOR "Color"
 #define D_COUNT "Contagem"
 #define D_COUNTER "Contador"
 #define D_CT_POWER "Carga CT"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Comando"
 #define D_CONNECTED "Ligado"
 #define D_CORS_DOMAIN "CORS Domain"
+#define D_COLOR "Color"
 #define D_COUNT "Contagem"
 #define D_COUNTER "Contador"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Comandă"
 #define D_CONNECTED "Conectat"
 #define D_CORS_DOMAIN "Domeniu CORS"
+#define D_COLOR "Color"
 #define D_COUNT "Numărătoare"
 #define D_COUNTER "Contor"
 #define D_CT_POWER "Putere Transformată"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -77,6 +77,7 @@
 #define D_COMMAND "Команда"
 #define D_CONNECTED "Соединен"
 #define D_CORS_DOMAIN "Домен CORS"
+#define D_COLOR "Color"
 #define D_COUNT "Подсчет"
 #define D_COUNTER "Счетчик"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Príkaz"
 #define D_CONNECTED "...pripojené"
 #define D_CORS_DOMAIN "CORS Domain"
+#define D_COLOR "Color"
 #define D_COUNT "Počítaj"
 #define D_COUNTER "Počítadlo"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Kommando"
 #define D_CONNECTED "Ansluten"
 #define D_CORS_DOMAIN "CORS Domain"
+#define D_COLOR "Color"
 #define D_COUNT "Räkna"
 #define D_COUNTER "Räknare"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Komut"
 #define D_CONNECTED "Bağlandı"
 #define D_CORS_DOMAIN "CORS Domain"
+#define D_COLOR "Color"
 #define D_COUNT "Sayı"
 #define D_COUNTER "Sayaç"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Команда"
 #define D_CONNECTED "Під'єднано"
 #define D_CORS_DOMAIN "Домен CORS"
+#define D_COLOR "Color"
 #define D_COUNT "разів"
 #define D_COUNTER "Лічильник"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "Dòng Lệnh"
 #define D_CONNECTED "Đã kết nối"
 #define D_CORS_DOMAIN "CORS Domain"
+#define D_COLOR "Color"
 #define D_COUNT "Đếm"
 #define D_COUNTER "Bộ đếm"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "命令:"
 #define D_CONNECTED "已连接"
 #define D_CORS_DOMAIN "CORS Domain"
+#define D_COLOR "Color"
 #define D_COUNT "数量:"
 #define D_COUNTER "计数器"
 #define D_CT_POWER "CT Power"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -76,6 +76,7 @@
 #define D_COMMAND "命令:"
 #define D_CONNECTED "已連線"
 #define D_CORS_DOMAIN "跨來源資源共享的網域(CORS Domain)"
+#define D_COLOR "Color"
 #define D_COUNT "數量:"
 #define D_COUNTER "Counter"
 #define D_CT_POWER "CT Power"

--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -1549,6 +1549,9 @@ void LightPreparePower(power_t channels = 0xFFFFFFFF) {    // 1 = only RGB, 2 = 
   #ifdef USE_DOMOTICZ
         DomoticzUpdatePowerState(Light.device + i);
   #endif  // USE_DOMOTICZ
+  #ifdef USE_KNX
+        KnxUpdateLight();
+  #endif
       }
     }
   } else {
@@ -1585,6 +1588,9 @@ void LightPreparePower(power_t channels = 0xFFFFFFFF) {    // 1 = only RGB, 2 = 
 #ifdef USE_DOMOTICZ
     DomoticzUpdatePowerState(Light.device);
 #endif  // USE_DOMOTICZ
+#ifdef USE_KNX
+    KnxUpdateLight();
+#endif
   }
 
   if (Settings->flag3.hass_tele_on_power) {  // SetOption59 - Send tele/%topic%/STATE in addition to stat/%topic%/RESULT

--- a/tasmota/tasmota_xdrv_driver/xdrv_11_knx.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_11_knx.ino
@@ -117,6 +117,8 @@ device_parameters_t device_param[] = {
   { KNX_SLOT4 , false, false, KNX_Empty },
   { KNX_SLOT5 , false, false, KNX_Empty },
   { KNX_SCENE , false, false, KNX_Empty },
+  { KNX_DIMMER , false, false, KNX_Empty },
+  { KNX_COLOUR , false, false, KNX_Empty },
   { KNX_Empty, false, false, KNX_Empty}
 };
 
@@ -153,6 +155,8 @@ const char * device_param_ga[] = {
   D_KNX_TX_SLOT   " 4",
   D_KNX_TX_SLOT   " 5",
   D_KNX_TX_SCENE      ,
+  D_BRIGHTLIGHT       ,
+  D_COLOR             ,
   nullptr
 };
 
@@ -189,7 +193,9 @@ const char *device_param_cb[] = {
   D_KNX_RX_SLOT   " 4",
   D_KNX_RX_SLOT   " 5",
   D_KNX_RX_SCENE      ,
-  nullptr
+  D_BRIGHTLIGHT       ,
+  D_COLOR             ,
+nullptr
 };
 
 // Commands
@@ -243,7 +249,7 @@ void KNX_Send_4byte_float(address_t const &receiver, float value, knx_command_ty
 #define KNX_WRITE_4BYTE_FLOAT(r,v) KNX_Send_4byte_float((r),(v),KNX_CT_WRITE)
 #define KNX_ANSWER_4BYTE_FLOAT(r,v) KNX_Send_4byte_float((r),(v),KNX_CT_ANSWER)
 
-void KNX_Send_4byte_int(address_t const &receiver, int value, knx_command_type_t ct) 
+void KNX_Send_4byte_int(address_t const &receiver, int32_t value, knx_command_type_t ct) 
 {
   uint8_t repeat = Settings->flag.knx_enable_enhancement ? KNX_ENHANCEMENT_REPEAT : 1;
   while ( repeat-- )
@@ -252,6 +258,34 @@ void KNX_Send_4byte_int(address_t const &receiver, int value, knx_command_type_t
 #define KNX_WRITE_4BYTE_INT(r,v) KNX_Send_4byte_int((r),(v),KNX_CT_WRITE)
 #define KNX_ANSWER_4BYTE_INT(r,v) KNX_Send_4byte_int((r),(v),KNX_CT_ANSWER)
 
+void KNX_Send_4byte_uint(address_t const &receiver, uint32_t value, knx_command_type_t ct) 
+{
+  uint8_t repeat = Settings->flag.knx_enable_enhancement ? KNX_ENHANCEMENT_REPEAT : 1;
+  while ( repeat-- )
+    knx.send_4byte_uint(receiver, ct, value);
+}
+#define KNX_WRITE_4BYTE_UINT(r,v) KNX_Send_4byte_uint((r),(v),KNX_CT_WRITE)
+#define KNX_ANSWER_4BYTE_UINT(r,v) KNX_Send_4byte_uint((r),(v),KNX_CT_ANSWER)
+
+void KNX_Send_3byte_color(address_t const &receiver, uint8_t* color, knx_command_type_t ct) 
+{
+  uint8_t buf[] = {0x00, color[0], color[1], color[2]};
+  uint8_t repeat = Settings->flag.knx_enable_enhancement ? KNX_ENHANCEMENT_REPEAT : 1;
+  while ( repeat-- )
+    knx.send(receiver, ct, 4, buf);
+}
+#define KNX_WRITE_3BYTE_COLOR(r,rgb) KNX_Send_3byte_color((r),(rgb),KNX_CT_WRITE)
+#define KNX_ANSWER_3BYTE_COLOR(r,rgb) KNX_Send_3byte_color((r),(rgb),KNX_CT_ANSWER)
+
+void KNX_Send_6byte_color(address_t const &receiver, uint8_t* color, knx_command_type_t ct) 
+{
+  uint8_t buf[] = {0x00, color[0], color[1], color[2], color[3], 0x00, 0x0F};
+  uint8_t repeat = Settings->flag.knx_enable_enhancement ? KNX_ENHANCEMENT_REPEAT : 1;
+  while ( repeat-- )
+    knx.send(receiver, ct, 7, buf);
+}
+#define KNX_WRITE_6BYTE_COLOR(r,rgbw) KNX_Send_6byte_color((r),(rgbw),KNX_CT_WRITE)
+#define KNX_ANSWER_6BYTE_COLOR(r,rgbw) KNX_Send_6byte_color((r),(rgbw),KNX_CT_ANSWER)
 
 
 uint8_t KNX_GA_Search( uint8_t param, uint8_t start = 0 )
@@ -559,7 +593,7 @@ void KNX_INIT(void)
     device_param[KNX_ENERGY_CURRENT-1].show = true;
     device_param[KNX_ENERGY_POWERFACTOR-1].show = true;
   }
-#endif
+#endif // USE_ENERGY_SENSOR
 
 #ifdef USE_RULES
   device_param[KNX_SLOT1-1].show = true;
@@ -568,7 +602,15 @@ void KNX_INIT(void)
   device_param[KNX_SLOT4-1].show = true;
   device_param[KNX_SLOT5-1].show = true;
   device_param[KNX_SCENE-1].show = true;
-#endif
+#endif // USE_RULES
+
+#ifdef USE_LIGHT
+  if (Light.subtype > LST_NONE) {
+    device_param[KNX_DIMMER-1].show = true;
+    if ((LST_RGB == Light.subtype) || (LST_RGBW == Light.subtype))
+      device_param[KNX_COLOUR-1].show = true;
+  }
+#endif // USE_LIGHT
 
   // Delete from KNX settings all configuration is not anymore related to this device
   if (KNX_CONFIG_NOT_MATCH()) {
@@ -611,6 +653,15 @@ void KNX_CB_Action(message_t const &msg, void *arg)
     // VALUE
     uint8_t tempvar = knx.data_to_1byte_uint(msg.data);
     dtostrfd(tempvar,0,tempchar);
+#ifdef USE_LIGHT
+  } else if (chan->type == KNX_DIMMER) {
+    // VALUE
+    uint8_t tempvar = changeUIntScale(knx.data_to_1byte_uint(msg.data),0, 255, 0, 100);
+    dtostrfd(tempvar,0,tempchar);
+  } else if (chan->type == KNX_COLOUR) {
+    // VALUE
+    snprintf_P(tempchar, sizeof(tempchar), (Light.subtype == LST_RGB) ? PSTR("%02X%02X%02X"):PSTR("%02X%02X%02X%02X"), msg.data[1], msg.data[2], msg.data[3]);
+#endif // USE_LIGHT
   } else {
     // VALUE
     float tempvar = knx.data_to_4byte_float(msg.data);
@@ -668,7 +719,33 @@ void KNX_CB_Action(message_t const &msg, void *arg)
           }
         }
       }
-#endif
+#endif // USE_RULES
+#ifdef USE_LIGHT
+      else if (chan->type == KNX_DIMMER)  // KNX RX DIMMER SLOT (write command)
+      {
+        if (!toggle_inhibit) {
+          char command[25];
+          // Value received
+          snprintf_P(command, sizeof(command), PSTR("Dimmer %s"), tempchar);
+          ExecuteCommand(command, SRC_KNX);
+          if (Settings->flag.knx_enable_enhancement) {
+            toggle_inhibit = TOGGLE_INHIBIT_TIME;
+          }
+        }
+      }
+      else if (chan->type == KNX_COLOUR)  // KNX RX COLOUR_RGB/RGBW SLOT (write command)
+      {
+        if (!toggle_inhibit) {
+          char command[25];
+          // Value received
+          snprintf_P(command, sizeof(command), PSTR("Color #%s"), tempchar);
+          ExecuteCommand(command, SRC_KNX);
+          if (Settings->flag.knx_enable_enhancement) {
+            toggle_inhibit = TOGGLE_INHIBIT_TIME;
+          }
+        }
+      }
+#endif // USE_LIGHT
       break;
 
     case KNX_CT_READ:
@@ -711,7 +788,7 @@ void KNX_CB_Action(message_t const &msg, void *arg)
       {
         KNX_ANSWER_4BYTE_INT(msg.received_on, round(1000.0 * Energy->total_sum));
       }
-#endif
+#endif // USE_ENERGY_SENSOR
 #ifdef USE_RULES
       else if ((chan->type >= KNX_SLOT1) && (chan->type <= KNX_SLOT5)) // KNX RX SLOTs (read command)
       {
@@ -724,7 +801,22 @@ void KNX_CB_Action(message_t const &msg, void *arg)
           }
         }
       }
-#endif
+#endif // USE_RULES
+#ifdef USE_LIGHT
+      else if (chan->type == KNX_DIMMER) // Reply KNX_DIMMER
+      {
+        uint8_t dimmer = changeUIntScale(light_state.getDimmer(), 0, 100, 0, 255);
+        KNX_ANSWER_1BYTE_UINT(msg.received_on, dimmer);
+      }
+      else if (chan->type == KNX_COLOUR) // Reply KNX_COLOUR
+      {
+        if ( Light.subtype == LST_RGB) {
+          KNX_ANSWER_3BYTE_COLOR(msg.received_on, Light.current_color);
+        } else if ( Light.subtype == LST_RGBW) {
+          KNX_ANSWER_6BYTE_COLOR(msg.received_on, Light.current_color);
+        }
+      }
+#endif // USE_LIGHT
       break;
   }
 }
@@ -750,6 +842,43 @@ void KnxUpdatePowerState(uint8_t device, power_t state)
   }
 }
 
+
+#ifdef USE_LIGHT
+void KnxUpdateLight()
+{
+  if (!(Settings->flag.knx_enabled)) { return; }
+
+  uint8_t dimmer = light_state.getDimmer();
+  uint8_t dim_knx = changeUIntScale(dimmer, 0, 100, 0, 255);
+
+  for (uint32_t i = 0; i < Settings->knx_GA_registered; ++i)
+  {
+    KNX_addr.value = Settings->knx_GA_addr[i];
+    if ( KNX_addr.value != 0 ) {
+      switch(Settings->knx_GA_param[i]) {
+        case KNX_DIMMER:
+          KNX_WRITE_1BYTE_UINT(KNX_addr, dim_knx);
+          AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_KNX "%s %d " D_SENT_TO " %d/%d/%d"),
+            device_param_ga[KNX_DIMMER -1],
+            dimmer,
+            KNX_addr.ga.area, KNX_addr.ga.line, KNX_addr.ga.member);
+          break;
+        case KNX_COLOUR:
+          if ( Light.subtype == LST_RGB) {
+            KNX_WRITE_3BYTE_COLOR(KNX_addr, Light.current_color);
+          } else if ( Light.subtype == LST_RGBW) {
+            KNX_WRITE_6BYTE_COLOR(KNX_addr, Light.current_color);
+          }
+          AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_KNX "%s %d,%d,%d,%d " D_SENT_TO " %d/%d/%d"),
+            device_param_ga[KNX_COLOUR -1],
+            Light.current_color[0], Light.current_color[1], Light.current_color[2], Light.current_color[3],
+            KNX_addr.ga.area, KNX_addr.ga.line, KNX_addr.ga.member);
+          break;
+      }
+    }
+  }
+}
+#endif // USE_LIGHT
 
 void KnxSendButtonPower(void)
 {


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #11733 

Add support for absolute dimmer and colour control with the following datapoint:
```
Light type | Dimmer (Bright)   | Color                     |
-----------|-------------------|---------------------------|
Single     | DPT_Scaling 5.001 | not supported +           |
CT         | DPT_Scaling 5.001 | not supported  +          |
RGB        | DPT_Scaling 5.001 | DPT_Colour_RGB 232.600    |
RGBW       | DPT_Scaling 5.001 | DPT_Colour_RGBW 251.600 * |
RGBCW      | DPT_Scaling 5.001 | not supported  +          |

* the validity bits are not supported. Tasmota expect all 4 values R, G, B, W to be present
+ those are not supported because I haven't found a matching DPT for 2 and 5 channels. If someone find one, I can add them later.
```


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
