### PR TITLE
I2S audio: small refactoring, more robust handling of commands

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio_idf51.ino
@@ -90,7 +90,8 @@ struct AUDIO_I2S_MP3_t {
   uint8_t mic_stop;
   int8_t mic_error;
   bool use_stream = false;
-
+  bool task_running = false;
+  bool task_has_ended = false;
 
 // SHINE
   uint32_t recdur;
@@ -117,7 +118,7 @@ struct AUDIO_I2S_MP3_t {
 \*********************************************************************************************/
 
 const char kI2SAudio_Commands[] PROGMEM = "I2S|"
-  "Gain|Rec|MGain|Stop|Config"
+  "Gain|Rec|Stop|Config"
 #ifdef USE_I2S_MP3
   "|Play"
 #endif
@@ -145,7 +146,7 @@ const char kI2SAudio_Commands[] PROGMEM = "I2S|"
 ;
 
 void (* const I2SAudio_Command[])(void) PROGMEM = {
-  &CmndI2SGain, &CmndI2SMicRec, &CmndI2SMicGain, &CmndI2SStop, &CmndI2SConfig,
+  &CmndI2SGain, &CmndI2SMicRec, &CmndI2SStop, &CmndI2SConfig,
 #ifdef USE_I2S_MP3
   &CmndI2SPlay,
 #endif
@@ -776,6 +777,14 @@ void I2sInit(void) {
 //
 // Returns `I2S_OK` if ok to send to output or error code
 int32_t I2SPrepareTx(void) {
+
+  if(audio_i2s_mp3.task_running){
+    audio_i2s_mp3.task_running = false;
+    while(!audio_i2s_mp3.task_has_ended){
+      delay(1);
+    }
+  }
+  
   AddLog(LOG_LEVEL_DEBUG, "I2S: I2SPrepareTx out=%p", audio_i2s.out);
   if (!audio_i2s.out) { return I2S_ERR_OUTPUT_NOT_CONFIGURED; }
 
@@ -831,27 +840,33 @@ void I2sStatusCallback(void *cbData, int code, const char *string) {
 }
 
 #ifdef USE_I2S_MP3
-void I2sMp3Task2(void *arg){
-  while (1) {
+void I2sMp3WrTask(void *arg){
+  audio_i2s_mp3.task_running = true;
+  audio_i2s_mp3.task_has_ended = false;
+  while (audio_i2s_mp3.task_running) {
     if (audio_i2s_mp3.decoder && audio_i2s_mp3.decoder->isRunning()) {
       if (!audio_i2s_mp3.decoder->loop()) {
-        I2sStopPlaying();
+        audio_i2s_mp3.task_running = false;
         //retryms = millis() + 2000;
       }
       vTaskDelay(pdMS_TO_TICKS(1));
     }
   }
+  audio_i2s_mp3.decoder->stop();
+  audio_i2s_mp3.task_has_ended = true;
+  I2sStopPlaying();
 }
 void I2SStopMP3Play(void) {
-  if (audio_i2s_mp3.mp3_task_handle) {
-    vTaskDelete(audio_i2s_mp3.mp3_task_handle);
-    audio_i2s_mp3.mp3_task_handle = nullptr;
-  }
 
   if (audio_i2s_mp3.decoder) {
     audio_i2s_mp3.decoder->stop();
     delete audio_i2s_mp3.decoder;
     audio_i2s_mp3.decoder = NULL;
+  }
+
+  if (audio_i2s_mp3.mp3_task_handle) {
+    vTaskDelete(audio_i2s_mp3.mp3_task_handle);
+    audio_i2s_mp3.mp3_task_handle = nullptr;
   }
 }
 #endif // USE_I2S_MP3
@@ -1016,7 +1031,7 @@ void CmndI2SSay(void) {
 }
 
 void CmndI2SI2SRtttl(void) {
-  if (I2SPrepareTx()) {
+  if (I2SPrepareTx() != I2S_OK) {
     ResponseCmndChar("I2S output not configured");
     return;
   }
@@ -1058,15 +1073,6 @@ void CmndI2SMicRec(void) {
       ResponseCmndChar_P(PSTR("no mic configured"));
     }
   }
-}
-
-// mic gain in factor not percent
-void CmndI2SMicGain(void) {
-  // TODO - does nothing for now
-  if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 256)) {
-      audio_i2s.Settings->rx.gain = XdrvMailbox.payload;
-  }
-  ResponseCmndNumber(audio_i2s.Settings->rx.gain);
 }
 
 /*********************************************************************************************\

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_3_i2s_saytime.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_3_i2s_saytime.ino
@@ -120,7 +120,7 @@ AudioGeneratorTalkie *talkie = nullptr;
 }
 
 void Cmd_Time(void) {
-  if (!audio_i2s.out) return;
+  if (I2SPrepareTx() != I2S_OK) return;
   sayTime(RtcTime.hour, RtcTime.minute);
   ResponseCmndDone();
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_6_i2s_rtttl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_6_i2s_rtttl.ino
@@ -26,8 +26,6 @@ void Rtttl(char *buffer);
 
 void Rtttl(char *buffer) {
 
-  if (!audio_i2s.out) return;
-
   AudioGeneratorRTTTL *rtttl;
   AudioFileSourcePROGMEM *file = NULL;
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_7_i2s_webradio_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_7_i2s_webradio_idf51.ino
@@ -83,7 +83,7 @@ void Webradio(const char *url) {
   }
 
   AddLog(LOG_LEVEL_DEBUG,PSTR("I2S: will launch webradio task"));
-  xTaskCreatePinnedToCore(I2sMp3Task2, "MP3-2", 8192, NULL, 3, &audio_i2s_mp3.mp3_task_handle, 1);
+  xTaskCreatePinnedToCore(I2sMp3WrTask, "MP3-WR", 8192, NULL, 3, &audio_i2s_mp3.mp3_task_handle, 1);
 }
 
 #ifdef USE_WEBSERVER


### PR DESCRIPTION
## Description:

More robust handling of commands, especially allowing to stop a running web radio session with any other command like `i2ssay`, `i2stime` or `i2srtttl`.

The old way to just call `i2swr` or `i2sstop` as described in docs is still valid.

Removal of old command `i2smgain`, that did not work anyway in the last versions  and is replaced by `i2sconfig {"Rx":{"Gain":20}} ` where gain is the factor to multiply a typically very weak microphone signal with.

Some refactoring, renaming and removal of unnecessary function calls.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
