### PR TITLE
Wrong timeout in `WebQuery` and `webclient` since Core3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Watchdog restart or freeze if ``displaytext`` is more than 128 characters (#21401)
 - Avoid connection errors when switching to safeboot to upload OTA firmware (#21428)
 - Berry Leds matrix alternate more and error about 'bri' attribute (#21431)
+- Wrong timeout in `WebQuery` and `webclient` since Core3
 
 ### Removed
 - Support of old insecure fingerprint algorithm. Deprecated since v8.4.0 (#21417)

--- a/lib/libesp32/ESP-Mail-Client/src/ESP_Mail_TCPClient.h
+++ b/lib/libesp32/ESP-Mail-Client/src/ESP_Mail_TCPClient.h
@@ -190,7 +190,7 @@ public:
      */
     void setTimeout(uint32_t timeoutSec)
     {
-        _tcp_client->setTimeout(timeoutSec);
+        _tcp_client->setTimeout(timeoutSec * 1000);
     }
 
     /**  Set the BearSSL IO buffer size.

--- a/lib/libesp32/HttpClientLight/src/HttpClientLight.cpp
+++ b/lib/libesp32/HttpClientLight/src/HttpClientLight.cpp
@@ -500,7 +500,7 @@ void HTTPClientLight::setTimeout(uint16_t timeout)
 {
     _tcpTimeout = timeout;
     if(connected()) {
-        _client->setTimeout((timeout + 500) / 1000);
+        _client->setTimeout(timeout);
     }
 }
 
@@ -1176,7 +1176,7 @@ bool HTTPClientLight::connect(void)
     }
 
     // set Timeout for WiFiClient and for Stream::readBytesUntil() and Stream::readStringUntil()
-    _client->setTimeout((_tcpTimeout + 500) / 1000);
+    _client->setTimeout(_tcpTimeout);
 
     log_d(" connected to %s:%u", _host.c_str(), _port);
 


### PR DESCRIPTION
## Description:

Fix wrong timeout with `WebQuery` and Berry `webclient`. Since Core3, timeout is in milliseconds instead of seconds.

I believe the Mail client has the same problem, but I haven't spotted any other impact.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
