### PR TITLE
I2S bugfix: webradio crash with invalid url

### DIFF
--- a/lib/lib_audio/ESP8266Audio/src/AudioFileSourceICYStream.cpp
+++ b/lib/lib_audio/ESP8266Audio/src/AudioFileSourceICYStream.cpp
@@ -45,17 +45,15 @@ bool AudioFileSourceICYStream::open(const char *url)
 {
   static const char *hdr[] = { "icy-metaint", "icy-name", "icy-genre", "icy-br" };
   pos = 0;
-  http.begin(client, url);
+  if (!http.begin(client, url)) {
+    cb.st(STATUS_HTTPFAIL, PSTR("Can't connect to url"));
+    return false;
+  }
   http.addHeader("Icy-MetaData", "1");
   http.collectHeaders( hdr, 4 );
   http.setReuse(true);
   http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
   int code = http.GET();
-  if (code != HTTP_CODE_OK) {
-    http.end();
-    cb.st(STATUS_HTTPFAIL, PSTR("Can't open HTTP request"));
-    return false;
-  }
   if (http.hasHeader(hdr[0])) {
     String ret = http.header(hdr[0]);
     icyMetaInt = ret.toInt();

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_audio_idf51.ino
@@ -847,7 +847,6 @@ void I2sMp3WrTask(void *arg){
     if (audio_i2s_mp3.decoder && audio_i2s_mp3.decoder->isRunning()) {
       if (!audio_i2s_mp3.decoder->loop()) {
         audio_i2s_mp3.task_running = false;
-        //retryms = millis() + 2000;
       }
       vTaskDelay(pdMS_TO_TICKS(1));
     }


### PR DESCRIPTION
## Description:

It has always be guaranteed to get a crash by providing an invalid url to the web radio command like:
`i2swr i_am_not_a_valid_webradio_url`

This did of course also include copy-paste-errors or former correct url names.
Besides every other occasional connection error did lead to a crash too.

1. Main problem was the audio library, which did no error checking.
Addditionally we check now for success in Tasmota as this is possible with this library change.

2. Removal of some unused code.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
