### PR TITLE
Fixed Zigbee crash when removing `ZbName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Avoid connection errors when switching to safeboot to upload OTA firmware (#21428)
 - Berry Leds matrix alternate more and error about 'bri' attribute (#21431)
 - Wrong timeout in `WebQuery` and `webclient` since Core3
+- Zigbee crash when removing `ZbName`
 
 ### Removed
 - Support of old insecure fingerprint algorithm. Deprecated since v8.4.0 (#21417)

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
@@ -323,7 +323,7 @@ bool Z_Device::setEPName(uint8_t ep, const char * name) {
 }
 
 void Z_Device::setStringAttribute(char*& attr, const char * str) {
-  if (nullptr == str)  { str = PSTR(""); }    // nullptr is considered empty string
+  if (nullptr == str)  { str = ""; }    // nullptr is considered empty string, don't use PROGMEM to avoid crash
   size_t str_len = strlen(str);
 
   if ((nullptr == attr) && (0 == str_len)) { return; } // if both empty, don't do anything


### PR DESCRIPTION
## Description:

Fix crash when trying to remove Zigbee friendly name with `ZbName 0xA8C9,`

Bug reported on Discord

This bug must have been there for a very long time...

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
