### PR TITLE
I2S: more consistent usage of variables, really use apll rx setting

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
@@ -109,7 +109,7 @@ typedef struct{
     bool     left_align = true;     // B12 - left alignment
     bool     big_endian = false;    // B13 - big endian
     bool     bit_order_lsb = false; // B14 - lsb first
-    uint16_t dma_frame_num = 512;   // B015/16 - DMA buffer size in samples, 512 should be okay up to ~32000 bps
+    uint16_t dma_frame_num = 576;   // B015/16 - DMA buffer size in samples, 576 should be okay up to ~32000 bps
     uint8_t  dma_desc_num = 3;      // B17 - number of DMA buffers, maybe increased with smaller buffers
     uint8_t  spare[3];              // B018-20 - padding
   } rx;

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_3_lib_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_3_lib_idf51.ino
@@ -638,10 +638,10 @@ bool TasmotaI2S::startI2SChannel(bool tx, bool rx) {
       case I2S_MODE_STD:
         {
           i2s_std_slot_config_t _slot_cfg = {
-            .data_bit_width = (i2s_data_bit_width_t)bps,
+            .data_bit_width = rx_data_bit_width,
             .slot_bit_width = (i2s_slot_bit_width_t)audio_i2s.Settings->rx.slot_bit_width,
-            .slot_mode = (i2s_slot_mode_t)channels,
-            .slot_mask = (i2s_std_slot_mask_t)audio_i2s.Settings->rx.slot_mask,
+            .slot_mode =  rx_slot_mode,
+            .slot_mask =  (i2s_std_slot_mask_t)_rx_slot_mask,
             .ws_width = audio_i2s.Settings->rx.ws_width,
             .ws_pol = audio_i2s.Settings->rx.ws_pol,
             .bit_shift = audio_i2s.Settings->rx.bit_shift,
@@ -669,7 +669,9 @@ bool TasmotaI2S::startI2SChannel(bool tx, bool rx) {
               },
             },
           };
-
+          if(audio_i2s.Settings->rx.apll == 1){
+              rx_std_cfg.clk_cfg.clk_src = I2S_CLK_SRC_APLL;
+          }
           err = i2s_channel_init_std_mode(_rx_handle, &rx_std_cfg);
           AddLog(LOG_LEVEL_DEBUG, "I2S: RX i2s_channel_init_std_mode with err:%i", err);
           AddLog(LOG_LEVEL_DEBUG, "I2S: RX channel in standard mode with %u bit width on %i channel(s) initialized", bps, rx_slot_mode);


### PR DESCRIPTION
## Description:

Besides some cosmetic refactoring, this should solve undefined behaviour with the I2S configuration for a microphone in standard mode. Needs more testing.

Increase default value for DMA frame number, which should now exactly match the minimal requirements for MP3 encoding with 16 bit at 32000 Hz.

Use apll setting in standard mode now.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
