### PR TITLE
Stop the driver from killing everything on FUNC_SAVE_BEFORE_RESTART -…

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task.ino
@@ -22,7 +22,6 @@
 // defining USE_WEBCAM_V2 will this file rather than xdrv_81_esp32_webcam.ino
 #ifdef USE_WEBCAM_V2
 
-#undef WEBCAM_DEV_DEBUG
 
 /*********************************************************************************************\
  * ESP32 webcam based on example in Arduino-ESP32 library
@@ -3012,6 +3011,8 @@ bool Xdrv99(uint32_t function) {
       WcSetStreamserver(Settings->webcam_config.stream);
       WCStartOperationTask();
       break;
+/*  let's NOT trigger off this, as it's used in many places via settingssaveAll(), and so when called the camer dies for the duration
+    because this code is designed to kill the cam and keep it dead ready for reboot.
     case FUNC_SAVE_BEFORE_RESTART: {
       // stop cam clock
 #ifdef WEBCAM_DEV_DEBUG  
@@ -3037,6 +3038,7 @@ bool Xdrv99(uint32_t function) {
       AddLog(LOG_LEVEL_DEBUG, PSTR("CAM: FUNC_SAVE_BEFORE_RESTART after delay"));
 #endif      
     } break;
+  */
     case FUNC_ACTIVE:
       result = true;
       break;


### PR DESCRIPTION
… since this is called in many other circumstances than an actual restart.

## Description:

When applying other settings in various scenarios, settingssaveAll() is called, triggering FUNC_SAVE_BEFORE_RESTART.
The code responded to this by closing the webcam thread and cleaning up sockets, etc., expecting to go through a restart.

This commit disables this feature.

Tested on esp32s3 with cam and bluetooth enabled.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
