### PR TITLE
fail UFSServe if Webserver is null.

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
@@ -950,34 +950,32 @@ public:
 };
 
 void UFSServe(void) {
+  bool result = false;
   if (XdrvMailbox.data_len > 0) {
-    bool result = false;
     char *fpath = strtok(XdrvMailbox.data, ",");
     char *url = strtok(nullptr, ",");
     char *noauth = strtok(nullptr, ",");
     if (fpath && url) {
-      char t[] = "";
-      StaticRequestHandlerAuth *staticHandler;
-      if (noauth && *noauth == '1'){
-        staticHandler = (StaticRequestHandlerAuth *) new StaticRequestHandler(*ffsp, fpath, url, (char *)nullptr);
-      } else {
-        staticHandler = new StaticRequestHandlerAuth(*ffsp, fpath, url, (char *)nullptr);
-      }
-      if (staticHandler) {
-        //Webserver->serveStatic(url, *ffsp, fpath);
-        Webserver->addHandler(staticHandler);
-        Webserver->enableCORS(true);
-        result = true;
-      } else {
-        // could this happen?  only lack of memory.
-        result = false;
+      if (Webserver) { // fail if no Webserver yet.
+        StaticRequestHandlerAuth *staticHandler;
+        if (noauth && *noauth == '1'){
+          staticHandler = (StaticRequestHandlerAuth *) new StaticRequestHandler(*ffsp, fpath, url, (char *)nullptr);
+        } else {
+          staticHandler = new StaticRequestHandlerAuth(*ffsp, fpath, url, (char *)nullptr);
+        }
+        if (staticHandler) {
+          //Webserver->serveStatic(url, *ffsp, fpath);
+          Webserver->addHandler(staticHandler);
+          Webserver->enableCORS(true);
+          result = true;
+        }
       }
     }
-    if (!result) {
-      ResponseCmndFailed();
-    } else {
-      ResponseCmndDone();
-    }
+  }
+  if (!result) {
+    ResponseCmndFailed();
+  } else {
+    ResponseCmndDone();
   }
 }
 #endif // UFILESYS_STATIC_SERVING


### PR DESCRIPTION
## Description:

Using command UFSServe before Webserver is present caused a crash.
This PR checks Webserver, and if not set, fails the command.

**Related issue (if applicable):** fixes #21465 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
