### PR TITLE
Berry webserver: allow to content_send bytes

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webserver.ino
@@ -194,15 +194,21 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
-  // Berry: `webserver.content_send(string) -> nil`
+  // Berry: `webserver.content_send(string or bytes) -> nil`
   //
   int32_t w_webserver_content_send(struct bvm *vm);
   int32_t w_webserver_content_send(struct bvm *vm) {
     int32_t argc = be_top(vm); // Get the number of arguments
-    if (argc >= 1 && (be_isstring(vm, 1) || be_iscomptr(vm, 1))) {
+    if (argc >= 1 && (be_isstring(vm, 1) || be_iscomptr(vm, 1) || be_isbytes(vm, 1))) {
       const char * html;
       if (be_isstring(vm, 1)) {
         html = be_tostring(vm, 1);
+      }
+      else if(be_isbytes(vm, 1)) {
+        size_t buf_len;
+        const char* buf_ptr = (const char*) be_tobytes(vm, 1, &buf_len);
+        WSContentSend(buf_ptr, buf_len);
+        be_return_nil(vm);
       } else {
         html = (const char*) be_tocomptr(vm, 1);
       }


### PR DESCRIPTION
## Description:

This small addition makes it possible to serve arbitrary data like images or any other file with binary data.

Typically prepended with a call to content_open to declare the MIME type:
```
    var data = bytes("0011223344")
    webserver.content_open(200,"application/octet-stream")
    webserver.content_send(data)
```

Longer demo in the comments.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
