### PR TITLE
Fix compilation of I2S driver on targets without support for apll clocksource

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_3_lib_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_3_lib_idf51.ino
@@ -669,9 +669,11 @@ bool TasmotaI2S::startI2SChannel(bool tx, bool rx) {
               },
             },
           };
+#if SOC_I2S_SUPPORTS_APLL
           if(audio_i2s.Settings->rx.apll == 1){
               rx_std_cfg.clk_cfg.clk_src = I2S_CLK_SRC_APLL;
           }
+#endif //SOC_I2S_SUPPORTS_APLL
           err = i2s_channel_init_std_mode(_rx_handle, &rx_std_cfg);
           AddLog(LOG_LEVEL_DEBUG, "I2S: RX i2s_channel_init_std_mode with err:%i", err);
           AddLog(LOG_LEVEL_DEBUG, "I2S: RX channel in standard mode with %u bit width on %i channel(s) initialized", bps, rx_slot_mode);


### PR DESCRIPTION
## Description:

Thanks @sfromis for testing and reporting this bug.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
