### PR TITLE
Ufs serve fix - makes it work better on esp32cam (ai thinker style)

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
@@ -1319,6 +1319,8 @@ void UfsListDir(char *path, uint8_t depth) {
                           HtmlEscape(name).c_str(), tstr.c_str(), entry.size(), delpath, editpath);
         }
         entry.close();
+
+        yield(); // trigger watchdog reset
       }
     }
     dir.close();


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #21473 

This changes the rarely used UFSServe code enabled by `#ifdef UFILESYS_STATIC_SERVING` to be like the file download code.

For me, this makes the file serving much more reliable on slower devices like the ESP Chip Id	3667140 (ESP32-D0WDQ6 v1.0)

Prior to this change, I would see a random main loop hang on accessing files.  

I have tested with >5000 file downloads on ESP32S3 and >1500 downloads on esp32cam (ai thinker style), and had better results.
I don't think this is a complete fix, as I have had one device lose connection (unfortunately without serial) - but this could have been something else.

This PR also adds yield() in file list from the GUI.  This is tested and does not cause a watchdog on a 1500 file folder. (the main thread is hung during this time - many seconds).  I'm not sure if there can be a better solution whilst the webserver can handle a single client.  One would be a re-write of the JS to poll for more files - but this may not help as even finding files in a large folder takes a lot of time.  Having this many files in a folder on an IOT device seems unusual, so it may be better to document and live with it.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
