### PR TITLE
Small changes to berry_custom to better keep the local repository clean

### DIFF
--- a/lib/libesp32/berry_custom/src/.gitignore
+++ b/lib/libesp32/berry_custom/src/.gitignore
@@ -1,1 +1,4 @@
 _temp*
+
+solidify/*
+embedded/*

--- a/pio-tools/solidify-from-url.py
+++ b/pio-tools/solidify-from-url.py
@@ -39,10 +39,12 @@ def cleanFolder():
         os.remove(join(BERRY_SOLIDIFY_DIR,"src",file))
     tempfiles = [f for f in os.listdir(join(BERRY_SOLIDIFY_DIR,"src","embedded")) if ".gitignore" not in f]
     for file in tempfiles:
-        os.remove(join(BERRY_SOLIDIFY_DIR,"src","embedded",file))
+        if file != ".keep":
+            os.remove(join(BERRY_SOLIDIFY_DIR,"src","embedded",file))
     tempfiles = [f for f in os.listdir(join(BERRY_SOLIDIFY_DIR,"src","solidify")) if ".gitignore" not in f]
     for file in tempfiles:
-        os.remove(join(BERRY_SOLIDIFY_DIR,"src","solidify",file))
+        if file != ".keep":
+            os.remove(join(BERRY_SOLIDIFY_DIR,"src","solidify",file))
     
 
 def addEntryToModtab(source): 


### PR DESCRIPTION
## Description:

When solidifying external Berry code small changes to local files will happen, which results in differences in the GIT status of the local repository.

This small change will lead to less pollution in every stage of the build. Running the "CLEAN" command afterwards should really leave the local repo in a clean state now with regards to GIT.

Zero changes to the resulting code with this PR:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
