### PR TITLE
Matter auto-fix IPv6 link-local zone id when network reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - Webradio crash with invalid url (#21446)
 - Zigbee crash when removing `ZbName` (#21449)
 - ESP32 BLE fix scanning (#21451)
+- Matter auto-fix IPv6 link-local zone id when network reconnects
 
 ### Removed
 - Support of old insecure fingerprint algorithm. Deprecated since v8.4.0 (#21417)

--- a/lib/default/WiFiHelper/src/WiFiHelper.h
+++ b/lib/default/WiFiHelper/src/WiFiHelper.h
@@ -83,6 +83,13 @@ public:
   // With ESP32 Core3, the WiFi mac address is not valid until the wifi is actually started
   // this helper function always provide a valid mac address
   static String macAddress(void);
+
+  // Auto-fix zone
+  //
+  // After a reconnect, the zone id may not be valid anymore
+  // In such case we detect any "%st<n>" or "%en<n>" zone identifier
+  // and replace with the current zone id
+  static void IPv6ZoneAutoFix(IPAddress &addr, const char* aHostname);
 };
 
 

--- a/lib/default/WiFiHelper/src/WiFiHelper_ESP8266.cpp
+++ b/lib/default/WiFiHelper/src/WiFiHelper_ESP8266.cpp
@@ -77,4 +77,6 @@ String WiFiHelper::macAddress(void) {
   return WiFi.macAddress();
 }
 
+void WiFiHelper::IPv6ZoneAutoFix(IPAddress &addr, const char* aHostname) {
+}
 #endif // ESP8266

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -1278,6 +1278,7 @@ bool WifiHostByName(const char* aHostname, IPAddress& aResult) {
 #if ESP_IDF_VERSION_MAJOR >= 5
   // try converting directly to IP
   if (aResult.fromString(aHostname)) {
+    WiFiHelper::IPv6ZoneAutoFix(aResult, aHostname);
     return true;   // we're done
   }
 #endif


### PR DESCRIPTION
## Description:

In case of network reconnection (for example after a Wifi scan), the IPv6 link-local zone id changes, which makes the IPv6 address of the Matter controller invalid (for subscriptions).

This adds an auto-fix of zone-id. For example, if an address was `fe80::221f:3bff:fe93:60b5%st1` but `%st1` does not exist anymore, and new Wifi is on `%st2`, the address is automatically updated to `fe80::221f:3bff:fe93:60b5%st2`.

This works also for Ethernet address with `%en<x>` zone ids.

On ESP8266, there is no change since Matter is not used.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
