### PR TITLE
FIX: Allow use of UART0 with enabled USB_CDC_CONSOLE

### DIFF
--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -2138,7 +2138,9 @@ void ClaimSerial(void) {
 #ifdef ESP32
 #if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
 #ifdef USE_USB_CDC_CONSOLE
-  return;              // USB console does not use serial
+  if (!tasconsole_serial) {
+    return;              // USB console does not use serial
+  }
 #endif  // USE_USB_CDC_CONSOLE
 #endif  // ESP32C3/C6, S2 or S3
 #endif  // ESP32


### PR DESCRIPTION
## Description:
When tasmota is compiled with `USE_USB_CDC_CONSOLE`, the ´ClaimSerial` method will return immediately and will not release UART0

This makes sense, as long as USB is used for console, but if we fall back to serial, because no USB is connected, we must release the console, so that all 3 UARTs on the ESP32 can be used.
(Possible broken since https://github.com/rPraml/Tasmota/commit/84ced0fcab6f3af26602cd8fc23df5ba7bcc8c1f)

In my case I tried to connect 3 SML meters to a ESP32 and I always had some garbage in the web console, when all 3 UARTs were used, as the serial data was read by the SML driver and the SerialConsole.

**Related issue (if applicable):** fixes #20324

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
