### PR TITLE
Bugfix: scan wifi asynchronously

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -1987,7 +1987,11 @@ void HandleWifiConfiguration(void) {
 #ifdef USE_EMULATION
       UdpDisconnect();
 #endif  // USE_EMULATION
-      int n = WiFi.scanNetworks();
+      int n = WiFi.scanNetworks(true);
+      while(n<0){
+        delay(50); // some magic number - maybe non optimal
+        n = WiFi.scanComplete();
+      }
       AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_WIFI D_SCAN_DONE));
 
       if (0 == n) {


### PR DESCRIPTION
## Description:

Since our beloved watchdog has returned, we need to scan asynchronously.
I am pretty sure, the delay could be longer, but in the end it will not matter much.

Related to: https://github.com/arendst/Tasmota/issues/21492

@btsimonh Can you try this?

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
