### PR TITLE
Berry add reuse of methods for interface-like code reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Optional command ``WebRun`` (as WebQuery extension) (#21364)
 - Support for Knx dimmer and color (#21434)
 - Support for Matter 1.3 Water leak detectors (#21456)
+- Berry add reuse of methods for interface-like code reuse
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_code.c
+++ b/lib/libesp32/berry/src/be_code.c
@@ -695,7 +695,7 @@ static void setsfxvar(bfuncinfo *finfo, bopcode op, bexpdesc *e1, int src)
 /* e1 must be in a register and have a valid idx */
 /* if `keep_reg` is true, do not release register */
 /* return 1 if assignment was possible, 0 if type is not compatible */
-int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, bbool keep_reg)
+int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, bbool keep_reg, bbool ismethod)
 {
     /* free_e2 indicates special case where ETINDEX or ETMEMBER need to be freed if top of registers */
     bbool free_e2 = (e2->type == ETINDEX || e2->type == ETMEMBER) && (e2->v.ss.idx != e1->v.idx) && (e2->v.ss.idx == finfo->freereg - 1);
@@ -729,7 +729,7 @@ int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, bbool keep_reg)
         break;
     case ETMEMBER: /* store to member R(A).RK(B) <- RK(C) */
     case ETINDEX: /* store to member R(A)[RK(B)] <- RK(C) */
-        setsfxvar(finfo, (e1->type == ETMEMBER) ? OP_SETMBR : OP_SETIDX, e1, src);
+        setsfxvar(finfo, (e1->type == ETMEMBER) ? (ismethod ? OP_SETMET : OP_SETMBR) : OP_SETIDX, e1, src);
         if (keep_reg && e2->type == ETREG && e1->v.ss.obj >= be_list_count(finfo->local)) {
             /* special case of walrus assignemnt when we need to recreate an ETREG */
             code_move(finfo, e1->v.ss.obj, src);    /* move from ETREG to MEMBER instance*/
@@ -923,7 +923,7 @@ void be_code_import(bfuncinfo *finfo, bexpdesc *m, bexpdesc *v)
         codeABC(finfo, OP_IMPORT, dst, src, 0);
         m->type = ETREG;
         m->v.idx = dst;
-        be_code_setvar(finfo, v, m, bfalse);
+        be_code_setvar(finfo, v, m, bfalse, bfalse);
     }
 }
 

--- a/lib/libesp32/berry/src/be_code.h
+++ b/lib/libesp32/berry/src/be_code.h
@@ -16,7 +16,7 @@ int be_code_allocregs(bfuncinfo *finfo, int count);
 void be_code_prebinop(bfuncinfo *finfo, int op, bexpdesc *e);
 void be_code_binop(bfuncinfo *finfo, int op, bexpdesc *e1, bexpdesc *e2, int dst);
 int be_code_unop(bfuncinfo *finfo, int op, bexpdesc *e);
-int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, bbool keep_reg);
+int be_code_setvar(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2, bbool keep_reg, bbool ismethod);
 int be_code_nextreg(bfuncinfo *finfo, bexpdesc *e);
 int be_code_jump(bfuncinfo *finfo);
 void be_code_jumpto(bfuncinfo *finfo, int dst);

--- a/lib/libesp32/berry/src/be_debug.c
+++ b/lib/libesp32/berry/src/be_debug.c
@@ -62,7 +62,7 @@ void be_print_inst(binstruction ins, int pc, void* fout)
     case OP_ADD: case OP_SUB: case OP_MUL: case OP_DIV:
     case OP_MOD: case OP_LT: case OP_LE: case OP_EQ:
     case OP_NE:  case OP_GT:  case OP_GE: case OP_CONNECT:
-    case OP_GETMBR: case OP_SETMBR:  case OP_GETMET:
+    case OP_GETMBR: case OP_SETMBR:  case OP_GETMET: case OP_SETMET:
     case OP_GETIDX: case OP_SETIDX: case OP_AND:
     case OP_OR: case OP_XOR: case OP_SHL: case OP_SHR:
         logbuf("%s\tR%d\t%c%d\t%c%d", opc2str(op), IGET_RA(ins),

--- a/lib/libesp32/berry/src/be_object.h
+++ b/lib/libesp32/berry/src/be_object.h
@@ -21,7 +21,7 @@
 #define BE_FUNCTION     6
 
 #define BE_GCOBJECT     16      /* from this type can be gced */
-#define BE_GCOBJECT_MAX (3<<5)  /* from this type can't be gced */
+#define BE_GCOBJECT_MAX (3<<5)  /* 96 - from this type can't be gced */
 
 #define BE_STRING       16
 #define BE_CLASS        17
@@ -32,10 +32,10 @@
 #define BE_MODULE       22
 #define BE_COMOBJ       23      /* common object */
 
-#define BE_NTVFUNC      ((0 << 5) | BE_FUNCTION)    /* 6 */
-#define BE_CLOSURE      ((1 << 5) | BE_FUNCTION)    /* 38 */
-#define BE_NTVCLOS      ((2 << 5) | BE_FUNCTION)    /* 70 */
-#define BE_CTYPE_FUNC   ((3 << 5) | BE_FUNCTION)    /* 102 */
+#define BE_NTVFUNC      ((0 << 5) | BE_FUNCTION)    /* 6 - cannot be gced */
+#define BE_CLOSURE      ((1 << 5) | BE_FUNCTION)    /* 38 - can be gced */
+#define BE_NTVCLOS      ((2 << 5) | BE_FUNCTION)    /* 70 - can be gced*/
+#define BE_CTYPE_FUNC   ((3 << 5) | BE_FUNCTION)    /* 102 - cannot be gced */
 #define BE_STATIC       (1 << 7)                    /* 128 */
 
 /* values for bproto.varg */

--- a/lib/libesp32/berry/src/be_opcodes.h
+++ b/lib/libesp32/berry/src/be_opcodes.h
@@ -54,4 +54,5 @@ OPCODE(CATCH),      /*  A, B, C  |   ... */
 OPCODE(RAISE),      /*  A, B, C  |   RAISE(B,C) B is code, C is description. A==0 only B provided, A==1 B and C are provided, A==2 rethrow with both parameters already on stack */
 OPCODE(CLASS),      /*  Bx       |   init class in K[Bx] */
 OPCODE(GETNGBL),    /*  A, B     |   R(A) <- GLOBAL[RK(B)] by name */
-OPCODE(SETNGBL)     /*  A, B     |   R(A) -> GLOBAL[RK(B)] by name */
+OPCODE(SETNGBL),    /*  A, B     |   R(A) -> GLOBAL[RK(B)] by name */
+OPCODE(SETMET),     /*  A, B, C  |   R(A).RK(B) <- RK(C) only if R(A) is a class, and RK(C) is marked as non-static */

--- a/lib/libesp32/berry/src/be_vm.c
+++ b/lib/libesp32/berry/src/be_vm.c
@@ -969,7 +969,7 @@ newframe: /* a new call frame */
                     }
                 } else if (var_isclass(a)) {
                     /* in this case we have a class in a static or non-static member */
-                    /* it's always treated like a statif function */
+                    /* it's always treated like a static function */
                     a[1] = result;
                     var_settype(a, NOT_METHOD);
                 } else {
@@ -994,6 +994,7 @@ newframe: /* a new call frame */
             }
             dispatch();
         }
+        opcase(SETMET):
         opcase(SETMBR): {
 #if BE_USE_PERF_COUNTERS
             vm->counter_set++;
@@ -1020,7 +1021,7 @@ newframe: /* a new call frame */
                 bclass *obj = var_toobj(a);
                 bstring *attr = var_tostr(b);
                 bvalue result = *c;
-                if (var_isfunction(&result)) {
+                if (var_isfunction(&result) && (IGET_OP(ins) == OP_SETMBR)) {   /* don't mark as static if SETMET was used */
                     var_markstatic(&result);
                 }
                 if (!be_class_setmember(vm, obj, attr, &result)) {

--- a/lib/libesp32/berry/tests/set_method.be
+++ b/lib/libesp32/berry/tests/set_method.be
@@ -1,0 +1,40 @@
+# test setting methods as an external class
+
+class A
+    var a
+    def init(a)
+        self.a = a
+    end
+    def f0(x) return self end
+    def f1(x) return x end
+    def f2(x) return self.a end
+    static def ff0(x) return _class end
+    static def ff1(x) return x end
+end
+
+class B
+    var b
+    def init(b)
+        self.b = b
+    end
+end
+
+class C : B
+    var a
+    def init(a)
+        self.a = a
+    end
+
+    def fc0 = A.f0
+    def fc1 = A.f1
+    def fc2 = A.f2
+    static def ffc0 = A.ff0
+    static def ffc1 = A.ff1
+end
+
+c = C(10)
+assert(c.fc0(1) == c)
+assert(c.fc1(1) == 1)
+assert(c.fc2(1) == 10)
+assert(c.ffc0(1) == A)
+assert(c.ffc1(1) == 1)


### PR DESCRIPTION
## Description:

This is a new experimental feature for Berry.

Reason behind it: Matter use classes and inheritance, unfortunately some methods need to be duplicated between several sub-classes. Berry does not have multiple-inheritance nor Java-like interfaces. This features aims at sharing the same methods between multiple classes that are not in the same inheritance line.

The syntax is simple. Let's say you have `class A` with method `do_stuff(x)`. You can define a `class B` and define a method (with same or different name) that copies the implementation from `class A`.

```berry
class A
    def do_stuff(x)
        # do something
    end

    static def do_static_stuff(x)
        # do something static
    end
end

class B
    def do_stuff = A.do_stuff
    static def do_static_stuff = A.do_static_stuff
end
```

## Implementation notes:

### Storing of parent class

(in #21490) each Berry method now stored its original parent class. This allows solidification to recognize that the method is borrowed from another class, and does not output it again. The `C` name is then matched to the correct class.

The parent class is stored in `ptab`. Two cases are possible:
- the function has no sub-function (most common case), `nproto` is `0` and `ptab` normally contains NULL. We stored the parent class in `ptab` which is free storage (no code increase)
- the function has sub-functions, `nproto` is not `0`, we append the class to the `ptab` array (it costs 4 more bytes) but does not interfere with the runtime

Solidification is changed accordingly

### Change in Berry VM

It was necessary to ass `SETMET` VM opcode to be able to store dynamically a new method to a class static variable. This is done only in code initialization of the class, but never happens in normal code.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
