### PR TITLE
I2S: multiple fixes

### DIFF
--- a/lib/lib_audio/ESP8266Audio/src/AudioGeneratorMP3.cpp
+++ b/lib/lib_audio/ESP8266Audio/src/AudioGeneratorMP3.cpp
@@ -186,7 +186,9 @@ bool AudioGeneratorMP3::GetOneSample(int16_t sample[2])
   // If we're here, we have one decoded frame and sent 0 or more samples out
   if (samplePtr < synth->pcm.length) {
     sample[AudioOutput::LEFTCHANNEL ] = synth->pcm.samples[0][samplePtr];
-    sample[AudioOutput::RIGHTCHANNEL] = synth->pcm.samples[1][samplePtr];
+    if(lastChannels == 2) {
+      sample[AudioOutput::RIGHTCHANNEL] = synth->pcm.samples[1][samplePtr];
+    }
     samplePtr++;
   } else {
     samplePtr = 0;
@@ -200,7 +202,9 @@ bool AudioGeneratorMP3::GetOneSample(int16_t sample[2])
     }
     // for IGNORE and CONTINUE, just play what we have now
     sample[AudioOutput::LEFTCHANNEL ] = synth->pcm.samples[0][samplePtr];
-    sample[AudioOutput::RIGHTCHANNEL] = synth->pcm.samples[1][samplePtr];
+    if(lastChannels == 2) {
+      sample[AudioOutput::RIGHTCHANNEL] = synth->pcm.samples[1][samplePtr];
+    }
     samplePtr++;
   }
   return true;

--- a/lib/lib_audio/ESP8266Audio/src/AudioOutputMixer.cpp
+++ b/lib/lib_audio/ESP8266Audio/src/AudioOutputMixer.cpp
@@ -190,7 +190,7 @@ bool AudioOutputMixer::loop()
       }
     }
     if (avail) {
-      int16_t s[2];
+      int16_t s[2] = {0};
       if (leftAccum[readPtr] > 32767) {
         s[LEFTCHANNEL] = 32767;
       } else if (leftAccum[readPtr] < -32767) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_1_i2s_mp3mic_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_1_i2s_mp3mic_idf51.ino
@@ -21,219 +21,219 @@
 #if defined(ESP32) && ESP_IDF_VERSION_MAJOR >= 5
 #ifdef USE_I2S_AUDIO
 
-uint32_t SpeakerMic(uint8_t spkr) {
-esp_err_t err = ESP_OK;
+// uint32_t SpeakerMic(uint8_t spkr) {
+// esp_err_t err = ESP_OK;
 
-//  audio_i2s.mode = spkr;
-  return err;
-}
+// //  audio_i2s.mode = spkr;
+//   return err;
+// }
 
-#ifdef USE_SHINE
+// #ifdef USE_SHINE
 
-#include <layer3.h>
-#include <types.h>
+// #include <layer3.h>
+// #include <types.h>
 
-// micro to mp3 file or stream
-void mic_task(void *arg){
-  int8_t error = 0;
-  uint8_t *ucp;
-  int written;
-  shine_config_t  config;
-  shine_t s = nullptr;
-  uint16_t samples_per_pass;
-  File mp3_out = (File)nullptr;
-  int16_t *buffer = nullptr;
-  uint16_t bytesize;
-  uint16_t bwritten;
-  uint32_t ctime;
+// // micro to mp3 file or stream
+// void mic_task(void *arg){
+//   int8_t error = 0;
+//   uint8_t *ucp;
+//   int written;
+//   shine_config_t  config;
+//   shine_t s = nullptr;
+//   uint16_t samples_per_pass;
+//   File mp3_out = (File)nullptr;
+//   int16_t *buffer = nullptr;
+//   uint16_t bytesize;
+//   uint16_t bwritten;
+//   uint32_t ctime;
 
-  if (!audio_i2s_mp3.use_stream) {
-    mp3_out = ufsp->open(audio_i2s_mp3.mic_path, "w");
-    if (!mp3_out) {
-      error = 1;
-      goto exit;
-    }
-  } else {
-    if (!audio_i2s_mp3.stream_active) {
-      error = 2;
-      audio_i2s_mp3.use_stream = 0;
-      goto exit;
-    }
-    audio_i2s_mp3.client.flush();
-    audio_i2s_mp3.client.setTimeout(3);
-    audio_i2s_mp3.client.print("HTTP/1.1 200 OK\r\n"
-    "Content-Type: audio/mpeg;\r\n\r\n");
+//   if (!audio_i2s_mp3.use_stream) {
+//     mp3_out = ufsp->open(audio_i2s_mp3.mic_path, "w");
+//     if (!mp3_out) {
+//       error = 1;
+//       goto exit;
+//     }
+//   } else {
+//     if (!audio_i2s_mp3.stream_active) {
+//       error = 2;
+//       audio_i2s_mp3.use_stream = 0;
+//       goto exit;
+//     }
+//     audio_i2s_mp3.client.flush();
+//     audio_i2s_mp3.client.setTimeout(3);
+//     audio_i2s_mp3.client.print("HTTP/1.1 200 OK\r\n"
+//     "Content-Type: audio/mpeg;\r\n\r\n");
 
-   //  Webserver->send(200, "application/octet-stream", "");
-    //"Content-Type: audio/mp3;\r\n\r\n");
-  }
+//    //  Webserver->send(200, "application/octet-stream", "");
+//     //"Content-Type: audio/mp3;\r\n\r\n");
+//   }
 
-  shine_set_config_mpeg_defaults(&config.mpeg);
+//   shine_set_config_mpeg_defaults(&config.mpeg);
 
-  if (audio_i2s.Settings->rx.channels == 1) {
-    config.mpeg.mode = MONO;
-  } else {
-    config.mpeg.mode = STEREO;
-  }
-  config.mpeg.bitr = 128;
-  config.wave.samplerate = audio_i2s.Settings->rx.sample_rate;
-  config.wave.channels = (channels)audio_i2s.Settings->rx.channels;
+//   if (audio_i2s.Settings->rx.channels == 1) {
+//     config.mpeg.mode = MONO;
+//   } else {
+//     config.mpeg.mode = STEREO;
+//   }
+//   config.mpeg.bitr = 128;
+//   config.wave.samplerate = audio_i2s.Settings->rx.sample_rate;
+//   config.wave.channels = (channels)audio_i2s.Settings->rx.channels;
 
-  if (shine_check_config(config.wave.samplerate, config.mpeg.bitr) < 0) {
-    error = 3;
-    goto exit;
-  }
+//   if (shine_check_config(config.wave.samplerate, config.mpeg.bitr) < 0) {
+//     error = 3;
+//     goto exit;
+//   }
 
-  s = shine_initialise(&config);
-  if (!s) {
-    error = 4;
-    goto exit;
-  }
+//   s = shine_initialise(&config);
+//   if (!s) {
+//     error = 4;
+//     goto exit;
+//   }
 
-  samples_per_pass = shine_samples_per_pass(s);
-  bytesize = samples_per_pass * 2 * audio_i2s.Settings->rx.channels;
+//   samples_per_pass = shine_samples_per_pass(s);
+//   bytesize = samples_per_pass * 2 * audio_i2s.Settings->rx.channels;
 
-  buffer = (int16_t*)malloc(bytesize);
-  if (!buffer) {
-    error = 5;
-    goto exit;
-  }
+//   buffer = (int16_t*)malloc(bytesize);
+//   if (!buffer) {
+//     error = 5;
+//     goto exit;
+//   }
 
-  ctime = TasmotaGlobal.uptime;
+//   ctime = TasmotaGlobal.uptime;
 
-  while (!audio_i2s_mp3.mic_stop) {
-      uint32_t bytes_read;
-      bytes_read = audio_i2s.in->readMic((uint8_t*)buffer, bytesize, true /*dc_block*/, false /*apply_gain*/, true /*lowpass*/, nullptr /*peak_ptr*/);
-      // i2s_read(audio_i2s.mic_port, (char *)buffer, bytesize, &bytes_read, (100 / portTICK_PERIOD_MS));
+//   while (!audio_i2s_mp3.mic_stop) {
+//       uint32_t bytes_read;
+//       bytes_read = audio_i2s.in->readMic((uint8_t*)buffer, bytesize, true /*dc_block*/, false /*apply_gain*/, true /*lowpass*/, nullptr /*peak_ptr*/);
+//       // i2s_read(audio_i2s.mic_port, (char *)buffer, bytesize, &bytes_read, (100 / portTICK_PERIOD_MS));
 
-      if (audio_i2s.Settings->rx.gain > 1) {
-        // set gain
-        for (uint32_t cnt = 0; cnt < bytes_read / 2; cnt++) {
-          buffer[cnt] *= audio_i2s.Settings->rx.gain;
-        }
-      }
-      ucp = shine_encode_buffer_interleaved(s, buffer, &written);
+//       if (audio_i2s.Settings->rx.gain > 1) {
+//         // set gain
+//         for (uint32_t cnt = 0; cnt < bytes_read / 2; cnt++) {
+//           buffer[cnt] *= audio_i2s.Settings->rx.gain;
+//         }
+//       }
+//       ucp = shine_encode_buffer_interleaved(s, buffer, &written);
 
-      if (!audio_i2s.Settings->tx.stream_enable) {
-        bwritten = mp3_out.write(ucp, written);
-        if (bwritten != written) {
-          break;
-        }
-      } else {
-        audio_i2s_mp3.client.write((const char*)ucp, written);
+//       if (!audio_i2s.Settings->tx.stream_enable) {
+//         bwritten = mp3_out.write(ucp, written);
+//         if (bwritten != written) {
+//           break;
+//         }
+//       } else {
+//         audio_i2s_mp3.client.write((const char*)ucp, written);
 
-        if (!audio_i2s_mp3.client.connected()) {
-          break;
-        }
-      }
-      audio_i2s_mp3.recdur = TasmotaGlobal.uptime - ctime;
-  }
+//         if (!audio_i2s_mp3.client.connected()) {
+//           break;
+//         }
+//       }
+//       audio_i2s_mp3.recdur = TasmotaGlobal.uptime - ctime;
+//   }
 
-  ucp = shine_flush(s, &written);
+//   ucp = shine_flush(s, &written);
 
-  if (!audio_i2s_mp3.use_stream) {
-    mp3_out.write(ucp, written);
-  } else {
-    audio_i2s_mp3.client.write((const char*)ucp, written);
-  }
-
-
-exit:
-  if (s) {
-    shine_close(s);
-  }
-  if (mp3_out) {
-    mp3_out.close();
-  }
-  if (buffer) {
-    free(buffer);
-  }
-
-  if (audio_i2s_mp3.use_stream) {
-    audio_i2s_mp3.client.stop();
-  }
-
-  SpeakerMic(I2S_AUDIO_MODE_SPK);
-  audio_i2s_mp3.mic_stop = 0;
-  audio_i2s_mp3.mic_error = error;
-  AddLog(LOG_LEVEL_INFO, PSTR("mp3task result code: %d"), error);
-  audio_i2s_mp3.mic_task_handle = 0;
-  audio_i2s_mp3.recdur = 0;
-  audio_i2s_mp3.stream_active = 0;
-  vTaskDelete(NULL);
-
-}
-
-int32_t i2s_record_shine(char *path) {
-esp_err_t err = ESP_OK;
-
-  if (audio_i2s.in) {
-    if (audio_i2s_mp3.decoder || audio_i2s_mp3.mp3) return 0;
-  }
-
-  err = SpeakerMic(I2S_AUDIO_MODE_MIC);
-  if (err) {
-    if (audio_i2s.in) {
-      SpeakerMic(I2S_AUDIO_MODE_SPK);
-    }
-    AddLog(LOG_LEVEL_INFO, PSTR("mic init error: %d"), err);
-    return err;
-  }
-
-  strlcpy(audio_i2s_mp3.mic_path, path, sizeof(audio_i2s_mp3.mic_path));
-
-  audio_i2s_mp3.mic_stop = 0;
-
-  uint32_t stack = 4096;
-
-  audio_i2s_mp3.use_stream = !strcmp(audio_i2s_mp3.mic_path, "stream.mp3");
-
-  if (audio_i2s_mp3.use_stream) {
-    stack = 8000;
-  }
-
-  err = xTaskCreatePinnedToCore(mic_task, "MIC", stack, NULL, 3, &audio_i2s_mp3.mic_task_handle, 1);
-
-  return err;
-}
-
-void Cmd_MicRec(void) {
-
-  if (XdrvMailbox.data_len > 0) {
-    if (!strncmp(XdrvMailbox.data, "-?", 2)) {
-      Response_P("{\"I2SREC-duration\":%d}", audio_i2s_mp3.recdur);
-    } else {
-      i2s_record_shine(XdrvMailbox.data);
-      ResponseCmndChar(XdrvMailbox.data);
-    }
-  } else {
-    if (audio_i2s_mp3.mic_task_handle) {
-      // stop task
-      audio_i2s_mp3.mic_stop = 1;
-      while (audio_i2s_mp3.mic_stop) {
-        delay(1);
-      }
-      ResponseCmndChar_P(PSTR("Stopped"));
-    }
-  }
-
-}
-#endif // USE_SHINE
+//   if (!audio_i2s_mp3.use_stream) {
+//     mp3_out.write(ucp, written);
+//   } else {
+//     audio_i2s_mp3.client.write((const char*)ucp, written);
+//   }
 
 
-// mic gain in factor not percent
-void Cmd_MicGain(void) {
-  if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 256)) {
-    if (audio_i2s.in) {
-      audio_i2s.in->setRxGain(XdrvMailbox.payload);
-    }
-    if (audio_i2s.Settings) {
-      audio_i2s.Settings->rx.gain = XdrvMailbox.payload * 16;
-    }
-    I2SSettingsSave(AUDIO_CONFIG_FILENAME);
-  }
-  ResponseCmndNumber(audio_i2s.Settings->rx.gain / 16);
-}
+// exit:
+//   if (s) {
+//     shine_close(s);
+//   }
+//   if (mp3_out) {
+//     mp3_out.close();
+//   }
+//   if (buffer) {
+//     free(buffer);
+//   }
+
+//   if (audio_i2s_mp3.use_stream) {
+//     audio_i2s_mp3.client.stop();
+//   }
+
+//   SpeakerMic(I2S_AUDIO_MODE_SPK);
+//   audio_i2s_mp3.mic_stop = 0;
+//   audio_i2s_mp3.mic_error = error;
+//   AddLog(LOG_LEVEL_INFO, PSTR("mp3task result code: %d"), error);
+//   audio_i2s_mp3.mic_task_handle = 0;
+//   audio_i2s_mp3.recdur = 0;
+//   audio_i2s_mp3.stream_active = 0;
+//   vTaskDelete(NULL);
+
+// }
+
+// int32_t i2s_record_shine(char *path) {
+// esp_err_t err = ESP_OK;
+
+//   if (audio_i2s.in) {
+//     if (audio_i2s_mp3.decoder || audio_i2s_mp3.mp3) return 0;
+//   }
+
+//   err = SpeakerMic(I2S_AUDIO_MODE_MIC);
+//   if (err) {
+//     if (audio_i2s.in) {
+//       SpeakerMic(I2S_AUDIO_MODE_SPK);
+//     }
+//     AddLog(LOG_LEVEL_INFO, PSTR("mic init error: %d"), err);
+//     return err;
+//   }
+
+//   strlcpy(audio_i2s_mp3.mic_path, path, sizeof(audio_i2s_mp3.mic_path));
+
+//   audio_i2s_mp3.mic_stop = 0;
+
+//   uint32_t stack = 4096;
+
+//   audio_i2s_mp3.use_stream = !strcmp(audio_i2s_mp3.mic_path, "stream.mp3");
+
+//   if (audio_i2s_mp3.use_stream) {
+//     stack = 8000;
+//   }
+
+//   err = xTaskCreatePinnedToCore(mic_task, "MIC", stack, NULL, 3, &audio_i2s_mp3.mic_task_handle, 1);
+
+//   return err;
+// }
+
+// void Cmd_MicRec(void) {
+
+//   if (XdrvMailbox.data_len > 0) {
+//     if (!strncmp(XdrvMailbox.data, "-?", 2)) {
+//       Response_P("{\"I2SREC-duration\":%d}", audio_i2s_mp3.recdur);
+//     } else {
+//       i2s_record_shine(XdrvMailbox.data);
+//       ResponseCmndChar(XdrvMailbox.data);
+//     }
+//   } else {
+//     if (audio_i2s_mp3.mic_task_handle) {
+//       // stop task
+//       audio_i2s_mp3.mic_stop = 1;
+//       while (audio_i2s_mp3.mic_stop) {
+//         delay(1);
+//       }
+//       ResponseCmndChar_P(PSTR("Stopped"));
+//     }
+//   }
+
+// }
+// #endif // USE_SHINE
+
+
+// // mic gain in factor not percent
+// void Cmd_MicGain(void) {
+//   if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 256)) {
+//     if (audio_i2s.in) {
+//       audio_i2s.in->setRxGain(XdrvMailbox.payload);
+//     }
+//     if (audio_i2s.Settings) {
+//       audio_i2s.Settings->rx.gain = XdrvMailbox.payload * 16;
+//     }
+//     I2SSettingsSave(AUDIO_CONFIG_FILENAME);
+//   }
+//   ResponseCmndNumber(audio_i2s.Settings->rx.gain / 16);
+// }
 
 #endif // USE_I2S_AUDIO
 #endif // defined(ESP32) && ESP_IDF_VERSION_MAJOR >= 5

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_2_i2s_mp3stream_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_2_i2s_mp3stream_idf51.ino
@@ -27,6 +27,7 @@
 
 void Stream_mp3(void) {
   if (audio_i2s_mp3.stream_active) {
+    AddLog(LOG_LEVEL_INFO, PSTR("I2S: can not handle client - other MP3 task active"));
     return;
   }
   AddLog(LOG_LEVEL_INFO, PSTR("I2S: Handle mp3server"));
@@ -58,6 +59,7 @@ void I2sMp3Init(uint32_t on) {
       delete audio_i2s_mp3.MP3Server;
       audio_i2s_mp3.MP3Server = nullptr;
       audio_i2s_mp3.mic_stop = 1;
+      audio_i2s_mp3.stream_active = 0;
       AddLog(LOG_LEVEL_INFO, PSTR("MP3: server deleted"));
     }
   }

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_7_i2s_webradio_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_7_i2s_webradio_idf51.ino
@@ -118,6 +118,11 @@ void CmndI2SWebRadio(void) {
 
 
 void I2sWebRadioStopPlaying() {
+  if(audio_i2s_mp3.decoder) {
+    audio_i2s_mp3.decoder->stop();
+    delete audio_i2s_mp3.decoder;
+    audio_i2s_mp3.decoder = nullptr;
+  }
   if (Audio_webradio.buff) {
     Audio_webradio.buff->close();
     delete Audio_webradio.buff;


### PR DESCRIPTION
## Description:

- better handle interruptions of operations, i.e. launching `i2splay /file.mp3` while playing web radio
- reducing noise before and after playing operations by adding an internal flush and preload method
- more granular setting of volume (4 times the resolution) as my test with a PCM5102 via headphone was too rough with the old version
- allow playing of mono MP3, which produced a ton of noise on the unused channel before in my tests, by modifying the framework
- now correctly showing configured input and output on SOC's with 2 i2s channels
- use correct output gain from settings file after boot
- reject wrong sample rates for the MP3 encoder
- a bit more logging as more issues are to be expected

Tested on a S3 dev board with a cheap PCM5102 and different connected microphones (PDM and INMP441), which interestingly absolutely needed the microphone input on the first channel (and the output on the second).
More research needed ...

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
