### PR TITLE
ESP32 Platform 2024.05.13

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -37,8 +37,8 @@ build_flags                 = ${esp_defaults.build_flags}
                               ; wrappers for the crash-recorder
                               -Wl,--wrap=panicHandler -Wl,--wrap=xt_unhandled_exception
                               -Wl,--wrap=_Z11analogWritehi  ; `analogWrite(unsigned char, int)` use the Tasmota version of analogWrite for deeper integration and phase control
-                              -Wl,--wrap=ledcReadFreq  ; `uint32_t ledcReadFreq(uint8_t chan)`
-                              -Wl,--wrap=delay         ; void delay(uint32_t ms)
+                              -Wl,--wrap=ledcReadFreq       ; `uint32_t ledcReadFreq(uint8_t chan)`
+                              -Wl,--wrap=delay              ; void delay(uint32_t ms)
 lib_ignore                  =
                               HTTPUpdateServer
                               USB

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -81,7 +81,7 @@ lib_ignore                  = ${esp32_defaults.lib_ignore}
                               ccronexpr
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.05.12/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2024.05.13/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

reverts Arduino PR 9453 `WiFiClient - rename flush() to clear()`
which brakes many used libraries.

@arendst needs right after merging reverting of the relevant Tasmota commits

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
