### PR TITLE
xdrv: tcp_bridge: Increase baudrate

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_41_tcp_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_41_tcp_bridge.ino
@@ -212,7 +212,7 @@ void CmndTCPStart(void) {
 }
 
 void CmndTCPBaudrate(void) {
-  if ((XdrvMailbox.payload >= 1200) && (XdrvMailbox.payload <= 115200)) {
+  if ((XdrvMailbox.payload >= 1200)) {
     XdrvMailbox.payload /= 1200;  // Make it a valid baudrate
     if (Settings->tcp_baudrate != XdrvMailbox.payload) {
       Settings->tcp_baudrate = XdrvMailbox.payload;


### PR DESCRIPTION
On ESP32 TCP Serial bridge can support baudrate of more than 115200.

After this change the baudrate is still limited to 306000 due to uint_8 is used for settings->tcp_baudrate.

A 1.5Mbauds have been tested by changing uint_16 for settings->tcp_baudrate on ESP32

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
