### PR TITLE
Bugfix: crash when using tjpegd and LVGL

### DIFF
--- a/lib/libesp32_lvgl/lvgl/src/libs/tjpgd/tjpgd.c
+++ b/lib/libesp32_lvgl/lvgl/src/libs/tjpgd/tjpgd.c
@@ -24,6 +24,7 @@
 /                     Some performance improvement.
 /----------------------------------------------------------------------------*/
 
+#ifndef TASMOTA // has tjpegd in ROM
 #include "tjpgd.h"
 
 
@@ -1135,3 +1136,5 @@ JRESULT jd_decomp(
 
     return rc;
 }
+#endif // TASMOTA
+

--- a/lib/libesp32_lvgl/lvgl/src/libs/tjpgd/tjpgd.h
+++ b/lib/libesp32_lvgl/lvgl/src/libs/tjpgd/tjpgd.h
@@ -1,6 +1,7 @@
 /*----------------------------------------------------------------------------/
 / TJpgDec - Tiny JPEG Decompressor R0.03 include file         (C)ChaN, 2021
 /----------------------------------------------------------------------------*/
+#ifndef TASMOTA // has tjpegd in ROM
 #ifndef DEF_TJPGDEC
 #define DEF_TJPGDEC
 
@@ -101,3 +102,4 @@ JRESULT jd_restart(JDEC * jd, uint16_t rstn);
 #endif
 
 #endif /* _TJPGDEC */
+#endif // TASMOTA


### PR DESCRIPTION
## Description:

Tasmotas Arduino framework does include tjpegd in ROM and it clashes with the externally added library.
The external library would be compiled in with LVGL activated in the build environment and lead to repeatable crashes when accessing functions of tjpegd in other code parts.
This will also shrink the firmware binary in these cases.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
