### PR TITLE
Add default value for `SetOption151`

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1014,6 +1014,9 @@
   #define USE_ZIGBEE_MAXTIME_LIGHT          60*60     // 1h
   #define USE_ZIGBEE_MAXTIME_LIFT           4*60*60   // 4h
 
+// -- Matter support (ESP32 and variants) ----------------------------
+#define MATTER_ENABLED    false                    // Is Matter enabled by default (ie `SO151 1`)
+
 // -- Other sensors/drivers -----------------------
 
 //#define USE_SHIFT595                             // Add support for 74xx595 8-bit shift registers (+0k7 code)
@@ -1238,6 +1241,10 @@
     #define BE_LV_WIDGET_SPAN
     // #define BE_LV_WIDGET_TABVIEW
     // #define BE_LV_WIDGET_TILEVIEW
+
+// -- Matter protocol ---------------------------------
+  // #define USE_MATTER_DEVICE                      // Enable Matter device support (+420KB)
+                                                    // Enabled by default in standard ESP32 binary
 
 #endif  // ESP32
 

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -1425,6 +1425,9 @@ void SettingsDefaultSet2(void) {
   #endif
 #endif // FIRMWARE_MINIMAL
 
+  // Matter
+  flag6.matter_enabled |= MATTER_ENABLED;
+
   Settings->flag = flag;
   Settings->flag2 = flag2;
   Settings->flag3 = flag3;


### PR DESCRIPTION
## Description:

Add option in `my_user_config.h` for a default value of `SetOption151`, i.e. whether Matter is enabled by default.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
