### PR TITLE
Berry `input()` returns empty string and does not crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Fixed
+- Berry `input()` returns empty string and does not crash
 
 ### Removed
 

--- a/lib/libesp32/berry_tasmota/src/be_port.cpp
+++ b/lib/libesp32/berry_tasmota/src/be_port.cpp
@@ -216,7 +216,10 @@ extern "C" {
 
 BERRY_API char* be_readstring(char *buffer, size_t size)
 {
-    return be_fgets(stdin, buffer, (int)size);
+    if ((size > 0) && (buffer != NULL)) {
+        *buffer = 0;
+    }
+    return buffer;
 }
 
 /* use the standard library implementation file API. */


### PR DESCRIPTION
## Description:

Berry `input()` crashed. This function has no use in Tasmota, it now returns an empty string instead of crashing.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
