### PR TITLE
Berry fix potential crash when solidifying loaded bytecode

### DIFF
--- a/lib/libesp32/berry/src/be_bytecode.c
+++ b/lib/libesp32/berry/src/be_bytecode.c
@@ -524,8 +524,8 @@ static void load_proto_table(bvm *vm, void *fp, bproto *proto, int info, int ver
 {
     int size = (int)load_long(fp); /* proto count */
     if (size) {
-        bproto **p = be_malloc(vm, sizeof(bproto *) * size);
-        memset(p, 0, sizeof(bproto *) * size);
+        bproto **p = be_malloc(vm, sizeof(bproto *) * (size + 1));
+        memset(p, 0, sizeof(bproto *) * (size + 1));
         proto->ptab = p;
         proto->nproto = size;
         while (size--) {


### PR DESCRIPTION
## Description:

Fix a potential crash when solidifying code that was loaded from saved bytecode. The reason is that the parent class is now stored in `ptab`. This information is lost when loading bytecode, but this is not a problem unless you try to solidify the code. Now the placeholder for the class is set to `NULL` instead of random content.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
