### PR TITLE
Matter size optimization

### DIFF
--- a/lib/libesp32/berry_matter/solidify_all.be
+++ b/lib/libesp32/berry_matter/solidify_all.be
@@ -12,7 +12,7 @@ import sys
 sys.path().push('src/embedded')   # allow to import from src/embedded
 
 # globals that need to exist to make compilation succeed
-var globs = "path,ctypes_bytes_dyn,tasmota,ccronexpr,gpio,light,webclient,load,MD5,lv,light_state,udp,tcpclientasync,"
+var globs = "path,ctypes_bytes_dyn,tasmota,ccronexpr,gpio,light,webclient,load,MD5,lv,light_state,udp,tcpclientasync,log,"
             "lv_clock,lv_clock_icon,lv_signal_arcs,lv_signal_bars,lv_wifi_arcs_icon,lv_wifi_arcs,"
             "lv_wifi_bars_icon,lv_wifi_bars,"
             "_lvgl,"

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning.be
@@ -45,7 +45,7 @@ class Matter_Commisioning_Context
   #############################################################
   def add_session(local_session_id, initiator_session_id, i2r, r2i, ac)
     # create session object
-    tasmota.log(format("MTR: add_session local_session_id=%i initiator_session_id=%i", local_session_id, initiator_session_id), 4)
+    log(format("MTR: add_session local_session_id=%i initiator_session_id=%i", local_session_id, initiator_session_id), 4)
     
     var session = self.device.sessions.create_session(local_session_id, initiator_session_id)
     session.set_keys(i2r, r2i, ac)
@@ -54,11 +54,11 @@ class Matter_Commisioning_Context
   def process_incoming(msg)
     #
     if !self.device.is_commissioning_open() && msg.opcode >= 0x20 && msg.opcode <= 0x24
-      tasmota.log("MTR: commissioning not open", 2)
+      log("MTR: commissioning not open", 2)
       return false
     end
 
-    # tasmota.log("MTR: received message " + matter.inspect(msg), 4)
+    # log("MTR: received message " + matter.inspect(msg), 4)
     if   msg.opcode == 0x10
       # don't need to do anything, the message is acked already before this call
     elif msg.opcode == 0x20
@@ -74,7 +74,7 @@ class Matter_Commisioning_Context
     elif msg.opcode == 0x40
       return self.parse_StatusReport(msg)
     else
-      tasmota.log(format("MTR: >????????? Unknown OpCode (secure channel) %02X", msg.opcode), 2)
+      log(format("MTR: >????????? Unknown OpCode (secure channel) %02X", msg.opcode), 2)
       return false
     end
 
@@ -109,8 +109,8 @@ class Matter_Commisioning_Context
     var session = msg.session
     # sanity checks
     if msg.opcode != 0x20 || msg.local_session_id != 0 || msg.protocol_id != 0
-      tasmota.log("MTR: invalid PBKDFParamRequest message", 2)
-      tasmota.log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
+      log("MTR: invalid PBKDFParamRequest message", 2)
+      log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
       self.send_status_report(msg, 0x01, 0x0000, 0x0002, false)
       return false
     end
@@ -121,8 +121,8 @@ class Matter_Commisioning_Context
 
     # sanity check for PBKDFParamRequest
     if pbkdfparamreq.passcodeId != 0
-      tasmota.log("MTR: non-zero passcode id", 2)
-      tasmota.log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
+      log("MTR: non-zero passcode id", 2)
+      log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
       self.send_status_report(msg, 0x01, 0x0000, 0x0002, false)
       return false
     end
@@ -130,7 +130,7 @@ class Matter_Commisioning_Context
     # record the initiator_session_id
     session.__future_initiator_session_id = pbkdfparamreq.initiator_session_id
     session.__future_local_session_id = self.device.sessions.gen_local_session_id()
-    tasmota.log(format("MTR: +Session   (%6i) from '[%s]:%i'", session.__future_local_session_id, msg.remote_ip, msg.remote_port), 3)
+    log(format("MTR: +Session   (%6i) from '[%s]:%i'", session.__future_local_session_id, msg.remote_ip, msg.remote_port), 3)
 
     # prepare response
     var pbkdfparamresp = matter.PBKDFParamResponse()
@@ -141,9 +141,9 @@ class Matter_Commisioning_Context
     pbkdfparamresp.responderSessionId = session.__future_local_session_id
     pbkdfparamresp.pbkdf_parameters_salt = self.device.commissioning_salt
     pbkdfparamresp.pbkdf_parameters_iterations = self.device.commissioning_iterations
-    # tasmota.log("MTR: pbkdfparamresp: " + str(matter.inspect(pbkdfparamresp)), 4)
+    # log("MTR: pbkdfparamresp: " + str(matter.inspect(pbkdfparamresp)), 4)
     var pbkdfparamresp_raw = pbkdfparamresp.tlv2raw()
-    # tasmota.log("MTR: pbkdfparamresp_raw: " + pbkdfparamresp_raw.tohex(), 4)
+    # log("MTR: pbkdfparamresp_raw: " + pbkdfparamresp_raw.tohex(), 4)
 
     session.__Msg2 = pbkdfparamresp_raw
 
@@ -160,15 +160,15 @@ class Matter_Commisioning_Context
     var session = msg.session
     # sanity checks
     if msg.opcode != 0x22 || msg.local_session_id != 0 || msg.protocol_id != 0
-      tasmota.log("MTR: invalid Pake1 message", 3)
-      tasmota.log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
+      log("MTR: invalid Pake1 message", 3)
+      log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
       self.send_status_report(msg, 0x01, 0x0000, 0x0002, false)
       return false
     end
     var pake1 = matter.Pake1().parse(msg.raw, msg.app_payload_idx)
 
     var pA = pake1.pA
-    # tasmota.log("MTR: received pA=" + pA.tohex(), 4)
+    # log("MTR: received pA=" + pA.tohex(), 4)
     
     # instanciate SPAKE
     # for testing purpose, we don't send `w1` to make sure
@@ -179,13 +179,13 @@ class Matter_Commisioning_Context
 
     # compute pB
     spake.compute_pB(y)
-    # tasmota.log("MTR: y=" + y.tohex(), 4)
-    # tasmota.log("MTR: pb=" + spake.pB.tohex(), 4)
+    # log("MTR: y=" + y.tohex(), 4)
+    # log("MTR: pb=" + spake.pB.tohex(), 4)
 
     # compute ZV
     spake.compute_ZV_verifier(pA)
-    # tasmota.log("MTR: Z=" + spake.Z.tohex(), 4)
-    # tasmota.log("MTR: V=" + spake.V.tohex(), 4)
+    # log("MTR: Z=" + spake.Z.tohex(), 4)
+    # log("MTR: V=" + spake.V.tohex(), 4)
 
     var context = crypto.SHA256()
     context.update(bytes().fromstring(self.Matter_Context_Prefix))
@@ -193,7 +193,7 @@ class Matter_Commisioning_Context
     context.update(session.__Msg2)
     var context_hash = context.out()
 
-    # tasmota.log("MTR: Context=" + context_hash.tohex(), 4)
+    # log("MTR: Context=" + context_hash.tohex(), 4)
 
     # add pA
     spake.pA = pA
@@ -201,31 +201,31 @@ class Matter_Commisioning_Context
     spake.set_context(context_hash)
     spake.compute_TT_hash(true)      # `true` to indicate it's Matter variant to SPAKE2+
 
-    # tasmota.log("MTR: ------------------------------", 4)
-    # tasmota.log("MTR: Context = " + spake.Context.tohex(), 4)
-    # tasmota.log("MTR: M       = " + spake.M.tohex(), 4)
-    # tasmota.log("MTR: N       = " + spake.N.tohex(), 4)
-    # tasmota.log("MTR: pA      = " + spake.pA.tohex(), 4)
-    # tasmota.log("MTR: pB      = " + spake.pB.tohex(), 4)
-    # tasmota.log("MTR: Z       = " + spake.Z.tohex(), 4)
-    # tasmota.log("MTR: V       = " + spake.V.tohex(), 4)
-    # tasmota.log("MTR: w0      = " + spake.w0.tohex(), 4)
-    # tasmota.log("MTR: ------------------------------", 4)
+    # log("MTR: ------------------------------", 4)
+    # log("MTR: Context = " + spake.Context.tohex(), 4)
+    # log("MTR: M       = " + spake.M.tohex(), 4)
+    # log("MTR: N       = " + spake.N.tohex(), 4)
+    # log("MTR: pA      = " + spake.pA.tohex(), 4)
+    # log("MTR: pB      = " + spake.pB.tohex(), 4)
+    # log("MTR: Z       = " + spake.Z.tohex(), 4)
+    # log("MTR: V       = " + spake.V.tohex(), 4)
+    # log("MTR: w0      = " + spake.w0.tohex(), 4)
+    # log("MTR: ------------------------------", 4)
 
-    # tasmota.log("MTR: Kmain   =" + spake.Kmain.tohex(), 4)
+    # log("MTR: Kmain   =" + spake.Kmain.tohex(), 4)
 
-    # tasmota.log("MTR: KcA     =" + spake.KcA.tohex(), 4)
-    # tasmota.log("MTR: KcB     =" + spake.KcB.tohex(), 4)
-    # tasmota.log("MTR: K_shared=" + spake.K_shared.tohex(), 4)
-    # tasmota.log("MTR: Ke      =" + spake.Ke.tohex(), 4)
-    # tasmota.log("MTR: cB=" + spake.cB.tohex(), 4)
+    # log("MTR: KcA     =" + spake.KcA.tohex(), 4)
+    # log("MTR: KcB     =" + spake.KcB.tohex(), 4)
+    # log("MTR: K_shared=" + spake.K_shared.tohex(), 4)
+    # log("MTR: Ke      =" + spake.Ke.tohex(), 4)
+    # log("MTR: cB=" + spake.cB.tohex(), 4)
 
     var pake2 = matter.Pake2()
     pake2.pB = spake.pB
     pake2.cB = spake.cB
-    # tasmota.log("MTR: pake2: " + matter.inspect(pake2), 4)
+    # log("MTR: pake2: " + matter.inspect(pake2), 4)
     var pake2_raw = pake2.tlv2raw()
-    # tasmota.log("MTR: pake2_raw: " + pake2_raw.tohex(), 4)
+    # log("MTR: pake2_raw: " + pake2_raw.tohex(), 4)
 
     session.__spake_cA = spake.cA
     session.__spake_Ke = spake.Ke
@@ -235,7 +235,7 @@ class Matter_Commisioning_Context
     var raw = resp.encode_frame(pake2_raw)
 
     # log the fact that a new commissioning is starting
-    tasmota.log(format("MTR: New Commissioning (PASE id=%i) from [%s]:%i", session.__future_local_session_id, session._ip, session._port), 2)
+    log(format("MTR: New Commissioning (PASE id=%i) from [%s]:%i", session.__future_local_session_id, session._ip, session._port), 2)
 
     self.responder.send_response_frame(resp)
     return true
@@ -246,20 +246,20 @@ class Matter_Commisioning_Context
     var session = msg.session
     # sanity checks
     if msg.opcode != 0x24 || msg.local_session_id != 0 || msg.protocol_id != 0
-      tasmota.log("MTR: invalid Pake3 message", 3)
-      tasmota.log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
+      log("MTR: invalid Pake3 message", 3)
+      log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
       self.send_status_report(msg, 0x01, 0x0000, 0x0002, false)
       return false
     end
     var pake3 = matter.Pake3().parse(msg.raw, msg.app_payload_idx)
 
     var cA = pake3.cA
-    # tasmota.log("MTR: received cA=" + cA.tohex(), 4)
+    # log("MTR: received cA=" + cA.tohex(), 4)
 
     # check the value against computed
     if cA != session.__spake_cA
-      tasmota.log("MTR: invalid cA received", 3)
-      tasmota.log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
+      log("MTR: invalid cA received", 3)
+      log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
       self.send_status_report(msg, 0x01, 0x0000, 0x0002, false)
       return false
     end
@@ -271,12 +271,12 @@ class Matter_Commisioning_Context
     var R2IKey = session_keys[16..31]
     var AttestationChallenge = session_keys[32..47]
 
-    # tasmota.log("MTR: ******************************", 4)
-    # tasmota.log("MTR: session_keys=" + session_keys.tohex(), 4)
-    # tasmota.log("MTR: I2RKey      =" + I2RKey.tohex(), 4)
-    # tasmota.log("MTR: R2IKey      =" + R2IKey.tohex(), 4)
-    # tasmota.log("MTR: AC          =" + AttestationChallenge.tohex(), 4)
-    # tasmota.log("MTR: ******************************", 4)
+    # log("MTR: ******************************", 4)
+    # log("MTR: session_keys=" + session_keys.tohex(), 4)
+    # log("MTR: I2RKey      =" + I2RKey.tohex(), 4)
+    # log("MTR: R2IKey      =" + R2IKey.tohex(), 4)
+    # log("MTR: AC          =" + AttestationChallenge.tohex(), 4)
+    # log("MTR: ******************************", 4)
 
     # StatusReport(GeneralCode: SUCCESS, ProtocolId: SECURE_CHANNEL, ProtocolCode: SESSION_ESTABLISHMENT_SUCCESS)
     self.send_status_report(msg, 0x00, 0x0000, 0x0000, false)
@@ -290,20 +290,20 @@ class Matter_Commisioning_Context
     # Validate Sigma1 Destination ID, p.162
     # traverse all existing fabrics
     if tasmota.loglevel(4)
-      tasmota.log("MTR: SEARCHING: destinationId=" + destinationId.tohex(), 4)
+      log("MTR: SEARCHING: destinationId=" + destinationId.tohex(), 4)
     end
     for fabric : self.device.sessions.fabrics
       if fabric.noc == nil || fabric.fabric_id == nil || fabric.device_id == nil     continue end
       # compute candidateDestinationId, Section 4.13.2.4.1, "Destination Identifier"
       var destinationMessage = initiatorRandom + fabric.get_ca_pub() + fabric.fabric_id + fabric.device_id
       var key = fabric.get_ipk_group_key()
-      # tasmota.log("MTR: SIGMA1: destinationMessage=" + destinationMessage.tohex(), 4)
-      # tasmota.log("MTR: SIGMA1: key_ipk=" + key.tohex(), 4)
+      # log("MTR: SIGMA1: destinationMessage=" + destinationMessage.tohex(), 4)
+      # log("MTR: SIGMA1: key_ipk=" + key.tohex(), 4)
       var h = crypto.HMAC_SHA256(key)
       h.update(destinationMessage)
       var candidateDestinationId = h.out()
       if tasmota.loglevel(4)
-        tasmota.log("MTR: SIGMA1: candidateDestinationId=" + candidateDestinationId.tohex(), 4)
+        log("MTR: SIGMA1: candidateDestinationId=" + candidateDestinationId.tohex(), 4)
       end
       if candidateDestinationId == destinationId
         return fabric
@@ -311,7 +311,7 @@ class Matter_Commisioning_Context
     end
     # TODO if there is only 1 fabric, we can try to use it anyways
     # if size(self.device.sessions.fabrics) == 1
-    #   tasmota.log("MTR: *** Could not find fabric, trying only fabric in store", 2)
+    #   log("MTR: *** Could not find fabric, trying only fabric in store", 2)
     #   return self.device.sessions.fabrics[0]
     # end
     return nil
@@ -322,19 +322,19 @@ class Matter_Commisioning_Context
     var session = msg.session
     # sanity checks
     if msg.opcode != 0x30 || msg.local_session_id != 0 || msg.protocol_id != 0
-      # tasmota.log("MTR: invalid Sigma1 message", 3)
-      tasmota.log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
+      # log("MTR: invalid Sigma1 message", 3)
+      log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
       self.send_status_report(msg, 0x01, 0x0000, 0x0002, false)
       return false
     end
     var sigma1 = matter.Sigma1().parse(msg.raw, msg.app_payload_idx)
-    # tasmota.log(format("MTR: sigma1=%s", matter.inspect(sigma1)), 4)
+    # log(format("MTR: sigma1=%s", matter.inspect(sigma1)), 4)
 
     session.__initiator_pub = sigma1.initiatorEphPubKey
 
     # find session
     var is_resumption = (sigma1.resumptionID != nil && sigma1.initiatorResumeMIC != nil)
-    # tasmota.log(format("MTR: is_resumption=%i", is_resumption ? 1 : 0), 4)
+    # log(format("MTR: is_resumption=%i", is_resumption ? 1 : 0), 4)
     # TODO disable resumption until fixed
     is_resumption = false
 
@@ -342,7 +342,7 @@ class Matter_Commisioning_Context
     var session_resumption
     if is_resumption
       session_resumption = self.device.sessions.find_session_by_resumption_id(sigma1.resumptionID)
-      # tasmota.log(format("MTR: session_resumption found session=%s session_resumption=%s", matter.inspect(session), matter.inspect(session_resumption)), 4)
+      # log(format("MTR: session_resumption found session=%s session_resumption=%s", matter.inspect(session), matter.inspect(session_resumption)), 4)
       if session_resumption == nil || session_resumption._fabric == nil
         is_resumption = false
       end
@@ -362,19 +362,19 @@ class Matter_Commisioning_Context
       var Resume1MICPayload = ec.decrypt(encrypted)
       var decrypted_tag = ec.tag()
 
-      # tasmota.log("****************************************", 4)
-      # tasmota.log("MTR: * s1rk              = " + s1rk.tohex(), 4)
-      # tasmota.log("MTR: * tag               = " + tag.tohex(), 4)
-      # tasmota.log("MTR: * Resume1MICPayload = " + Resume1MICPayload.tohex(), 4)
-      # tasmota.log("MTR: * decrypted_tag     = " + decrypted_tag.tohex(), 4)
-      # tasmota.log("****************************************", 4)
+      # log("****************************************", 4)
+      # log("MTR: * s1rk              = " + s1rk.tohex(), 4)
+      # log("MTR: * tag               = " + tag.tohex(), 4)
+      # log("MTR: * Resume1MICPayload = " + Resume1MICPayload.tohex(), 4)
+      # log("MTR: * decrypted_tag     = " + decrypted_tag.tohex(), 4)
+      # log("****************************************", 4)
       if tag == decrypted_tag
         session._fabric = session_resumption._fabric
         session._source_node_id = msg.source_node_id
         session.set_mode_CASE()
         session.__future_initiator_session_id = sigma1.initiator_session_id    # update initiator_session_id
         session.__future_local_session_id = self.device.sessions.gen_local_session_id()
-        tasmota.log(format("MTR: +Session   (%6i) from '[%s]:%i'", session.__future_local_session_id, msg.remote_ip, msg.remote_port), 3)
+        log(format("MTR: +Session   (%6i) from '[%s]:%i'", session.__future_local_session_id, msg.remote_ip, msg.remote_port), 3)
 
         # Generate and Send Sigma2_Resume
         session.shared_secret = session_resumption.shared_secret
@@ -395,13 +395,13 @@ class Matter_Commisioning_Context
         sigma2resume.responderSessionID = session.__future_local_session_id
         sigma2resume.sigma2ResumeMIC = Resume2MIC
 
-        # tasmota.log("****************************************", 4)
-        # tasmota.log("MTR: * s2rk              = " + s2rk.tohex(), 4)
-        # tasmota.log("MTR: * s2rk_salt         = " + s2rk_salt.tohex(), 4)
-        # tasmota.log("MTR: * new_resumption_id = " + session.resumption_id.tohex(), 4)
-        # tasmota.log("MTR: * responderSessionID= " + str(session.__future_local_session_id), 4)
-        # tasmota.log("MTR: * sigma2ResumeMIC   = " + Resume2MIC.tohex(), 4)
-        # tasmota.log("****************************************", 4)
+        # log("****************************************", 4)
+        # log("MTR: * s2rk              = " + s2rk.tohex(), 4)
+        # log("MTR: * s2rk_salt         = " + s2rk_salt.tohex(), 4)
+        # log("MTR: * new_resumption_id = " + session.resumption_id.tohex(), 4)
+        # log("MTR: * responderSessionID= " + str(session.__future_local_session_id), 4)
+        # log("MTR: * sigma2ResumeMIC   = " + Resume2MIC.tohex(), 4)
+        # log("****************************************", 4)
         # # compute session key, p.178
         var session_keys = crypto.HKDF_SHA256().derive(session.shared_secret #- input key -#,
                                                       sigma1.initiatorRandom + session.resumption_id #- salt -#,
@@ -412,16 +412,16 @@ class Matter_Commisioning_Context
         var ac = session_keys[32..47]
         var created = tasmota.rtc_utc()
 
-        # tasmota.log("MTR: ******************************", 4)
-        # tasmota.log("MTR: I2RKey      =" + i2r.tohex(), 4)
-        # tasmota.log("MTR: R2IKey      =" + r2i.tohex(), 4)
-        # tasmota.log("MTR: AC          =" + ac.tohex(), 4)
-        # tasmota.log("MTR: ******************************", 4)
+        # log("MTR: ******************************", 4)
+        # log("MTR: I2RKey      =" + i2r.tohex(), 4)
+        # log("MTR: R2IKey      =" + r2i.tohex(), 4)
+        # log("MTR: AC          =" + ac.tohex(), 4)
+        # log("MTR: ******************************", 4)
 
         var sigma2resume_raw = sigma2resume.tlv2raw()
         session.__Msg1 = nil
-        # tasmota.log("MTR: sigma2resume: " + matter.inspect(sigma2resume), 4)
-        # tasmota.log("MTR: sigma2resume_raw: " + sigma2resume_raw.tohex(), 4)
+        # log("MTR: sigma2resume: " + matter.inspect(sigma2resume), 4)
+        # log("MTR: sigma2resume_raw: " + sigma2resume_raw.tohex(), 4)
 
         # now package the response message
         var resp = msg.build_response(0x33 #-sigma-2-resume-#, true)
@@ -453,7 +453,7 @@ class Matter_Commisioning_Context
       session._fabric = fabric
 
       if session == nil || session._fabric == nil
-        tasmota.log("MTR: StatusReport(GeneralCode: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: NO_SHARED_TRUST_ROOTS)", 3)
+        log("MTR: StatusReport(GeneralCode: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: NO_SHARED_TRUST_ROOTS)", 3)
         self.send_status_report(msg, 0x01, 0x0000, 0x0001, false)
         return false
       end
@@ -462,26 +462,26 @@ class Matter_Commisioning_Context
   
       session.__future_initiator_session_id = sigma1.initiator_session_id    # update initiator_session_id
       session.__future_local_session_id = self.device.sessions.gen_local_session_id()
-      tasmota.log(format("MTR: +Session   (%6i) from '[%s]:%i'", session.__future_local_session_id, msg.remote_ip, msg.remote_port), 3)
+      log(format("MTR: +Session   (%6i) from '[%s]:%i'", session.__future_local_session_id, msg.remote_ip, msg.remote_port), 3)
 
-      # tasmota.log("MTR: fabric="+matter.inspect(session._fabric), 4)
-      # tasmota.log("MTR: no_private_key="+session.get_pk().tohex(), 4)
-      # tasmota.log("MTR: noc           ="+session.get_noc().tohex(), 4)
+      # log("MTR: fabric="+matter.inspect(session._fabric), 4)
+      # log("MTR: no_private_key="+session.get_pk().tohex(), 4)
+      # log("MTR: noc           ="+session.get_noc().tohex(), 4)
       # if fabric.get_icac()
-      #   tasmota.log("MTR: icac          ="+fabric.get_icac().tohex(), 4)
+      #   log("MTR: icac          ="+fabric.get_icac().tohex(), 4)
       # end
-      # tasmota.log("MTR: root_ca_cert  ="+fabric.get_ca().tohex(), 4)
+      # log("MTR: root_ca_cert  ="+fabric.get_ca().tohex(), 4)
 
       # Compute Sigma2, p.162
       session.resumption_id = crypto.random(16)     # generate a new resumption id
       session.__responder_priv = crypto.random(32)
       session.__responder_pub = crypto.EC_P256().public_key(session.__responder_priv)
-      # tasmota.log("MTR: ResponderEph_priv  ="+session.__responder_priv.tohex(), 4)
-      # tasmota.log("MTR: ResponderEph_pub  ="+session.__responder_pub.tohex(), 4)
+      # log("MTR: ResponderEph_priv  ="+session.__responder_priv.tohex(), 4)
+      # log("MTR: ResponderEph_pub  ="+session.__responder_pub.tohex(), 4)
       var responderRandom = crypto.random(32)
 
       session.shared_secret = crypto.EC_P256().shared_key(session.__responder_priv, sigma1.initiatorEphPubKey)
-      # tasmota.log("MTR: * shared_secret  = " + session.shared_secret.tohex(), 4)
+      # log("MTR: * shared_secret  = " + session.shared_secret.tohex(), 4)
 
       var sigma2_tbsdata = matter.TLV.Matter_TLV_struct()
       sigma2_tbsdata.add_TLV(1, matter.TLV.B2, fabric.get_noc())
@@ -490,10 +490,10 @@ class Matter_Commisioning_Context
       sigma2_tbsdata.add_TLV(4, matter.TLV.B2, sigma1.initiatorEphPubKey)
 
       var TBSData2Signature = crypto.EC_P256().ecdsa_sign_sha256(fabric.get_pk(), sigma2_tbsdata.tlv2raw())
-      # tasmota.log("****************************************", 4)
-      # tasmota.log("MTR: * fabric.get_pk  = " + str(fabric.get_pk()), 4)
-      # tasmota.log("MTR: * sigma2_tbsdata  = " + str(sigma2_tbsdata), 4)
-      # tasmota.log("MTR: * TBSData2Signature  = " + TBSData2Signature.tohex(), 4)
+      # log("****************************************", 4)
+      # log("MTR: * fabric.get_pk  = " + str(fabric.get_pk()), 4)
+      # log("MTR: * sigma2_tbsdata  = " + str(sigma2_tbsdata), 4)
+      # log("MTR: * TBSData2Signature  = " + TBSData2Signature.tohex(), 4)
 
       var sigma2_tbedata = matter.TLV.Matter_TLV_struct()
       sigma2_tbedata.add_TLV(1, matter.TLV.B2, fabric.get_noc())
@@ -502,47 +502,47 @@ class Matter_Commisioning_Context
       sigma2_tbedata.add_TLV(4, matter.TLV.B2, session.resumption_id)
 
       # compute TranscriptHash = Crypto_Hash(message = Msg1)
-      # tasmota.log("****************************************", 4)
+      # log("****************************************", 4)
       session.__Msg1 = sigma1.Msg1
-      # tasmota.log("MTR: * resumptionid  = " + session.resumption_id.tohex(), 4)
-      # tasmota.log("MTR: * MSG1          = " + session.__Msg1.tohex(), 4)
+      # log("MTR: * resumptionid  = " + session.resumption_id.tohex(), 4)
+      # log("MTR: * MSG1          = " + session.__Msg1.tohex(), 4)
       var TranscriptHash = crypto.SHA256().update(session.__Msg1).out()
-      # tasmota.log("MTR: TranscriptHash =" + TranscriptHash.tohex(), 4)
+      # log("MTR: TranscriptHash =" + TranscriptHash.tohex(), 4)
 
       # Compute S2K, p.175
       var s2k_info = bytes().fromstring(self.S2K_Info)
       var s2k_salt = fabric.get_ipk_group_key() + responderRandom + session.__responder_pub + TranscriptHash
 
       var s2k = crypto.HKDF_SHA256().derive(session.shared_secret, s2k_salt, s2k_info, 16)
-      # tasmota.log("MTR: * SharedSecret  = " + session.shared_secret.tohex(), 4)
-      # tasmota.log("MTR: * s2k_salt      = " + s2k_salt.tohex(), 4)
-      # tasmota.log("MTR: * s2k           = " + s2k.tohex(), 4)
+      # log("MTR: * SharedSecret  = " + session.shared_secret.tohex(), 4)
+      # log("MTR: * s2k_salt      = " + s2k_salt.tohex(), 4)
+      # log("MTR: * s2k           = " + s2k.tohex(), 4)
 
       var sigma2_tbedata_raw = sigma2_tbedata.tlv2raw()
-      # tasmota.log("MTR: * TBEData2Raw   = " + sigma2_tbedata_raw.tohex(), 4)
+      # log("MTR: * TBEData2Raw   = " + sigma2_tbedata_raw.tohex(), 4)
       # // `AES_CCM.init(secret_key:bytes(16 or 32), iv:bytes(7..13), aad:bytes(), data_len:int, tag_len:int) -> instance`
 
       var aes = crypto.AES_CCM(s2k, bytes().fromstring(self.TBEData2_Nonce), bytes(), size(sigma2_tbedata_raw), 16)
       var TBEData2Encrypted = aes.encrypt(sigma2_tbedata_raw) + aes.tag()
-      # tasmota.log("MTR: * TBEData2Enc   = " + TBEData2Encrypted.tohex(), 4)
-      # tasmota.log("****************************************", 4)
+      # log("MTR: * TBEData2Enc   = " + TBEData2Encrypted.tohex(), 4)
+      # log("****************************************", 4)
 
       var sigma2 = matter.Sigma2()
       sigma2.responderRandom = responderRandom
       sigma2.responderSessionId = session.__future_local_session_id
       sigma2.responderEphPubKey = session.__responder_pub
       sigma2.encrypted2 = TBEData2Encrypted
-      # tasmota.log("MTR: sigma2: " + matter.inspect(sigma2), 4)
+      # log("MTR: sigma2: " + matter.inspect(sigma2), 4)
       var sigma2_raw = sigma2.tlv2raw()
       session.__Msg2 = sigma2_raw
-      # tasmota.log("MTR: sigma2_raw: " + sigma2_raw.tohex(), 4)
+      # log("MTR: sigma2_raw: " + sigma2_raw.tohex(), 4)
   
       # now package the response message
       var resp = msg.build_response(0x31 #-sigma-2-#, true)  # no reliable flag
       var raw = resp.encode_frame(sigma2_raw)
   
       # log the fact that a new connection is starting
-      tasmota.log(format("MTR: New Connection (CASE id=%i) from [%s]:%i", session.__future_local_session_id, session._ip, session._port), 2)
+      log(format("MTR: New Connection (CASE id=%i) from [%s]:%i", session.__future_local_session_id, session._ip, session._port), 2)
       
       self.responder.send_response_frame(resp)
       return true
@@ -555,29 +555,29 @@ class Matter_Commisioning_Context
     import crypto
     # sanity checks
     if msg.opcode != 0x32 || msg.local_session_id != 0 || msg.protocol_id != 0
-      tasmota.log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
+      log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
       self.send_status_report(msg, 0x01, 0x0000, 0x0002, false)
       return false
     end
     var session = msg.session
     var sigma3 = matter.Sigma3().parse(msg.raw, msg.app_payload_idx)
 
-    # tasmota.log("****************************************", 4)
+    # log("****************************************", 4)
     # compute TranscriptHash = Crypto_Hash(message = Msg1 || Msg2)
     var TranscriptHash = crypto.SHA256().update(session.__Msg1).update(session.__Msg2).out()
-    # tasmota.log("MTR: * session       = " + str(session), 4)
-    # tasmota.log("MTR:   .ipk_epoch_key=" + str(session.get_ipk_epoch_key()), 4)
-    # tasmota.log("MTR:   .fabric_compr = " + str(session.get_fabric_compressed()), 4)
-    # tasmota.log("MTR: * ipk_group_key = " + session.get_ipk_group_key().tohex(), 4)
-    # tasmota.log("MTR: * TranscriptHash= " + TranscriptHash.tohex(), 4)
+    # log("MTR: * session       = " + str(session), 4)
+    # log("MTR:   .ipk_epoch_key=" + str(session.get_ipk_epoch_key()), 4)
+    # log("MTR:   .fabric_compr = " + str(session.get_fabric_compressed()), 4)
+    # log("MTR: * ipk_group_key = " + session.get_ipk_group_key().tohex(), 4)
+    # log("MTR: * TranscriptHash= " + TranscriptHash.tohex(), 4)
 
     var s3k_info = bytes().fromstring(self.S3K_Info)
     var s3k = crypto.HKDF_SHA256().derive(session.shared_secret, session.get_ipk_group_key() + TranscriptHash, s3k_info, 16)
 
-    # tasmota.log("****************************************", 4)
-    # tasmota.log("MTR: * s3k_salt      = " + (session.get_ipk_group_key() + TranscriptHash).tohex(), 4)
-    # tasmota.log("MTR: * s3k           = " + s3k.tohex(), 4)
-    # tasmota.log("****************************************", 4)
+    # log("****************************************", 4)
+    # log("MTR: * s3k_salt      = " + (session.get_ipk_group_key() + TranscriptHash).tohex(), 4)
+    # log("MTR: * s3k           = " + s3k.tohex(), 4)
+    # log("****************************************", 4)
 
     # decrypt
     var encrypted = sigma3.TBEData3Encrypted[0..-17]
@@ -585,75 +585,75 @@ class Matter_Commisioning_Context
     var ec = crypto.AES_CCM(s3k, bytes().fromstring(self.TBEData3_Nonce), bytes(), size(encrypted), 16)
     var TBEData3 = ec.decrypt(encrypted)
     var TBETag3 = ec.tag()
-    # tasmota.log("MTR: * TBEData3      = " + TBEData3.tohex(), 4)
-    # tasmota.log("MTR: * TBETag3       = " + TBETag3.tohex(), 4)
-    # tasmota.log("MTR: * tag_sent      = " + tag.tohex(), 4)
-    # tasmota.log("****************************************", 4)
+    # log("MTR: * TBEData3      = " + TBEData3.tohex(), 4)
+    # log("MTR: * TBETag3       = " + TBETag3.tohex(), 4)
+    # log("MTR: * tag_sent      = " + tag.tohex(), 4)
+    # log("****************************************", 4)
 
     if TBETag3 != tag
-      tasmota.log("MTR: Tag don't match", 3)
-      tasmota.log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
+      log("MTR: Tag don't match", 3)
+      log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 3)
       self.send_status_report(msg, 0x01, 0x0000, 0x0002, false)
       return false
     end
 
     var TBEData3TLV = matter.TLV.parse(TBEData3)
-    # tasmota.log("MTR: * TBEData3TLV   = " + str(TBEData3TLV), 4)
+    # log("MTR: * TBEData3TLV   = " + str(TBEData3TLV), 4)
     var initiatorNOC = TBEData3TLV.findsubval(1)
     var initiatorICAC = TBEData3TLV.findsubval(2)
     var ec_signature = TBEData3TLV.findsubval(3)
-    # tasmota.log("MTR: * initiatorNOC  = " + str(initiatorNOC), 4)
-    # tasmota.log("MTR: * initiatorICAC = " + str(initiatorICAC), 4)
-    # tasmota.log("MTR: * ec_signature  = " + str(ec_signature), 4)
+    # log("MTR: * initiatorNOC  = " + str(initiatorNOC), 4)
+    # log("MTR: * initiatorICAC = " + str(initiatorICAC), 4)
+    # log("MTR: * ec_signature  = " + str(ec_signature), 4)
     # Success = Crypto_VerifyChain(certificates = [TBEData3.initiatorNOC, TBEData3.initiatorICAC, TrustedRCAC]), when TBEData3.initiatorICAC is present
     # TODO
     var initiatorNOCTLV = matter.TLV.parse(initiatorNOC)
-    # tasmota.log("MTR: initiatorNOCTLV = " + str(initiatorNOCTLV), 4)
+    # log("MTR: initiatorNOCTLV = " + str(initiatorNOCTLV), 4)
     var initiatorNOCPubKey = initiatorNOCTLV.findsubval(9)
     var initiatorNOCListDN = initiatorNOCTLV.findsub(6)
     var initiatorFabricId = initiatorNOCListDN.findsubval(17)
     if type(initiatorFabricId) == 'int'   session.peer_node_id = int64.fromu32(initiatorFabricId).tobytes() else session.peer_node_id = initiatorFabricId.tobytes() end
-    # tasmota.log("MTR: initiatorFabricId="+str(session.peer_node_id), 4)
+    # log("MTR: initiatorFabricId="+str(session.peer_node_id), 4)
 
     var sigma3_tbs = matter.TLV.Matter_TLV_struct()
     sigma3_tbs.add_TLV(1, matter.TLV.B1, initiatorNOC)
     sigma3_tbs.add_TLV(2, matter.TLV.B1, initiatorICAC)
     sigma3_tbs.add_TLV(3, matter.TLV.B1, session.__initiator_pub)
     sigma3_tbs.add_TLV(4, matter.TLV.B1, session.__responder_pub)
-    # tasmota.log("MTR: * sigma3_tbs    = " + str(sigma3_tbs), 4)
+    # log("MTR: * sigma3_tbs    = " + str(sigma3_tbs), 4)
     var sigma3_tbs_raw = sigma3_tbs.tlv2raw()
-    # tasmota.log("MTR: * sigma3_tbs_raw= " + sigma3_tbs_raw.tohex(), 4)
+    # log("MTR: * sigma3_tbs_raw= " + sigma3_tbs_raw.tohex(), 4)
 
-    # tasmota.log("MTR: * initiatorNOCPubKey= " + initiatorNOCPubKey.tohex(), 4)
-    # tasmota.log("MTR: * ec_signature      = " + ec_signature.tohex(), 4)
-    # tasmota.log("****************************************", 4)
+    # log("MTR: * initiatorNOCPubKey= " + initiatorNOCPubKey.tohex(), 4)
+    # log("MTR: * ec_signature      = " + ec_signature.tohex(), 4)
+    # log("****************************************", 4)
 
     # `crypto.EC_P256().ecdsa_verify_sha256(public_key:bytes(65), message:bytes(), hash:bytes()) -> bool`
     var sigma3_tbs_valid = crypto.EC_P256().ecdsa_verify_sha256(initiatorNOCPubKey, sigma3_tbs_raw, ec_signature)
 
     if !sigma3_tbs_valid
-      tasmota.log("MTR: sigma3_tbs does not have a valid signature", 2)
-      tasmota.log("MTR: ******************* Invalid signature, trying anyways", 2)
-      # tasmota.log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 2)
+      log("MTR: sigma3_tbs does not have a valid signature", 2)
+      log("MTR: ******************* Invalid signature, trying anyways", 2)
+      # log("MTR: StatusReport(General Code: FAILURE, ProtocolId: SECURE_CHANNEL, ProtocolCode: INVALID_PARAMETER)", 2)
       # self.send_status_report(msg, 0x01, 0x0000, 0x0002, false)
       # return false
     else
       # All good, compute new keys
-      tasmota.log("MTR: Sigma3 verified, computing new keys", 3)
+      log("MTR: Sigma3 verified, computing new keys", 3)
     end
 
     TranscriptHash = crypto.SHA256().update(session.__Msg1).update(session.__Msg2).update(sigma3.Msg3).out()
-    # tasmota.log("MTR: * __Msg1            = " + session.__Msg1.tohex(), 4)
-    # tasmota.log("MTR: * __Msg2            = " + session.__Msg2.tohex(), 4)
-    # tasmota.log("MTR: * __Msg3            = " + sigma3.Msg3.tohex(), 4)
-    # tasmota.log("MTR: * TranscriptHash    = " + TranscriptHash.tohex(), 4)
+    # log("MTR: * __Msg1            = " + session.__Msg1.tohex(), 4)
+    # log("MTR: * __Msg2            = " + session.__Msg2.tohex(), 4)
+    # log("MTR: * __Msg3            = " + sigma3.Msg3.tohex(), 4)
+    # log("MTR: * TranscriptHash    = " + TranscriptHash.tohex(), 4)
     # we can now free __Msg1 and __Msg2
     session.__Msg1 = nil
     session.__Msg2 = nil
 
-    # tasmota.log("MTR: ******************************", 4)
-    # tasmota.log("MTR: shared_secret =" + session.shared_secret.tohex(), 4)
-    # tasmota.log("MTR: ipk + hash    =" + (session.get_ipk_group_key() + TranscriptHash).tohex(), 4)
+    # log("MTR: ******************************", 4)
+    # log("MTR: shared_secret =" + session.shared_secret.tohex(), 4)
+    # log("MTR: ipk + hash    =" + (session.get_ipk_group_key() + TranscriptHash).tohex(), 4)
     # compute session key
     var session_keys = crypto.HKDF_SHA256().derive(session.shared_secret #- input key -#,
                                                    session.get_ipk_group_key() + TranscriptHash #- salt -#,
@@ -664,11 +664,11 @@ class Matter_Commisioning_Context
     var ac = session_keys[32..47]
     var created = tasmota.rtc_utc()
 
-    # tasmota.log("MTR: ******************************", 4)
-    # tasmota.log("MTR: I2RKey      =" + i2r.tohex(), 4)
-    # tasmota.log("MTR: R2IKey      =" + r2i.tohex(), 4)
-    # tasmota.log("MTR: AC          =" + ac.tohex(), 4)
-    # tasmota.log("MTR: ******************************", 4)
+    # log("MTR: ******************************", 4)
+    # log("MTR: I2RKey      =" + i2r.tohex(), 4)
+    # log("MTR: R2IKey      =" + r2i.tohex(), 4)
+    # log("MTR: AC          =" + ac.tohex(), 4)
+    # log("MTR: ******************************", 4)
 
     # StatusReport(GeneralCode: SUCCESS, ProtocolId: SECURE_CHANNEL, ProtocolCode: SESSION_ESTABLISHMENT_SUCCESS)
     self.send_status_report(msg, 0x00, 0x0000, 0x0000, true)
@@ -691,7 +691,7 @@ class Matter_Commisioning_Context
   # placeholder, nothing to run for now
   def parse_StatusReport(msg)
     var session = msg.session
-    tasmota.log("MTR: >Status    "+msg.raw[msg.app_payload_idx..].tohex(), 3)
+    log("MTR: >Status    "+msg.raw[msg.app_payload_idx..].tohex(), 3)
     return false      # we don't explicitly ack the message
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning_Data.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning_Data.be
@@ -41,8 +41,9 @@ class Matter_PBKDFParamRequest
   var SLEEPY_ACTIVE_INTERVAL
 
   def parse(b, idx)
+    var TLV = matter.TLV
     if idx == nil    idx = 0 end
-    var val = matter.TLV.parse(b, idx)
+    var val = TLV.parse(b, idx)
 
     self.initiatorRandom = val.getsubval(1)
     self.initiator_session_id = val.getsubval(2)
@@ -71,18 +72,19 @@ class Matter_PBKDFParamResponse
   var SLEEPY_ACTIVE_INTERVAL
 
   def tlv2raw(b)
-    var s = matter.TLV.Matter_TLV_struct()
+    var TLV = matter.TLV
+    var s = TLV.Matter_TLV_struct()
     # initiatorRandom
-    s.add_TLV(1, matter.TLV.B1, self.initiatorRandom)
-    s.add_TLV(2, matter.TLV.B1, self.responderRandom)
-    s.add_TLV(3, matter.TLV.U2, self.responderSessionId)
+    s.add_TLV(1, TLV.B1, self.initiatorRandom)
+    s.add_TLV(2, TLV.B1, self.responderRandom)
+    s.add_TLV(3, TLV.U2, self.responderSessionId)
     var s_pbkdf = s.add_struct(4)
-    s_pbkdf.add_TLV(1, matter.TLV.U4, self.pbkdf_parameters_iterations)
-    s_pbkdf.add_TLV(2, matter.TLV.B1, self.pbkdf_parameters_salt)
+    s_pbkdf.add_TLV(1, TLV.U4, self.pbkdf_parameters_iterations)
+    s_pbkdf.add_TLV(2, TLV.B1, self.pbkdf_parameters_salt)
     if self.SLEEPY_IDLE_INTERVAL != nil || self.SLEEPY_ACTIVE_INTERVAL != nil
       var s2 = s.add_struct(5)
-      s2.add_TLV(1, matter.TLV.U4, self.SLEEPY_IDLE_INTERVAL)
-      s2.add_TLV(2, matter.TLV.U4, self.SLEEPY_ACTIVE_INTERVAL)
+      s2.add_TLV(1, TLV.U4, self.SLEEPY_IDLE_INTERVAL)
+      s2.add_TLV(2, TLV.U4, self.SLEEPY_ACTIVE_INTERVAL)
     end
     return s.tlv2raw(b)
   end
@@ -98,7 +100,7 @@ class Matter_Pake1
   def parse(b, idx)
     if idx == nil    idx = 0 end
     var val = matter.TLV.parse(b, idx)
-    # tasmota.log("MTR: parsed TLV: " + str(val), 4)
+    # log("MTR: parsed TLV: " + str(val), 4)
 
     self.pA = val.getsubval(1)
     return self
@@ -114,10 +116,11 @@ class Matter_Pake2
   var cB                # 32 bytes
   
   def tlv2raw(b)
-    var s = matter.TLV.Matter_TLV_struct()
+    var TLV = matter.TLV
+    var s = TLV.Matter_TLV_struct()
     #
-    s.add_TLV(1, matter.TLV.B1, self.pB)
-    s.add_TLV(2, matter.TLV.B1, self.cB)
+    s.add_TLV(1, TLV.B1, self.pB)
+    s.add_TLV(2, TLV.B1, self.cB)
     return s.tlv2raw(b)
   end
 end
@@ -130,7 +133,7 @@ class Matter_Pake3
   def parse(b, idx)
     if idx == nil    idx = 0 end
     var val = matter.TLV.parse(b, idx)
-    # tasmota.log("MTR: parsed TLV: " + str(val), 4)
+    # log("MTR: parsed TLV: " + str(val), 4)
 
     self.cA = val.getsubval(1)
     return self
@@ -157,7 +160,7 @@ class Matter_Sigma1
     if idx == nil    idx = 0 end
     var val = matter.TLV.parse(b, idx)
     self.Msg1 = b[idx..]
-    # tasmota.log("MTR: Sigma1 TLV=" + str(val), 4)
+    # log("MTR: Sigma1 TLV=" + str(val), 4)
 
     self.initiatorRandom = val.getsubval(1)
     self.initiator_session_id = val.getsubval(2)
@@ -187,16 +190,17 @@ class Matter_Sigma2
   var SLEEPY_ACTIVE_INTERVAL
   
   def tlv2raw(b)
-    var s = matter.TLV.Matter_TLV_struct()
+    var TLV = matter.TLV
+    var s = TLV.Matter_TLV_struct()
     # initiatorRandom
-    s.add_TLV(1, matter.TLV.B1, self.responderRandom)
-    s.add_TLV(2, matter.TLV.U2, self.responderSessionId)
-    s.add_TLV(3, matter.TLV.B1, self.responderEphPubKey)
-    s.add_TLV(4, matter.TLV.B1, self.encrypted2)
+    s.add_TLV(1, TLV.B1, self.responderRandom)
+    s.add_TLV(2, TLV.U2, self.responderSessionId)
+    s.add_TLV(3, TLV.B1, self.responderEphPubKey)
+    s.add_TLV(4, TLV.B1, self.encrypted2)
     if self.SLEEPY_IDLE_INTERVAL != nil || self.SLEEPY_ACTIVE_INTERVAL != nil
       var s2 = s.add_struct(5)
-      s2.add_TLV(1, matter.TLV.U4, self.SLEEPY_IDLE_INTERVAL)
-      s2.add_TLV(2, matter.TLV.U4, self.SLEEPY_ACTIVE_INTERVAL)
+      s2.add_TLV(1, TLV.U4, self.SLEEPY_IDLE_INTERVAL)
+      s2.add_TLV(2, TLV.U4, self.SLEEPY_ACTIVE_INTERVAL)
     end
     return s.tlv2raw(b)
   end
@@ -214,15 +218,16 @@ class Matter_Sigma2Resume
   var SLEEPY_ACTIVE_INTERVAL
   
   def tlv2raw(b)
-    var s = matter.TLV.Matter_TLV_struct()
+    var TLV = matter.TLV
+    var s = TLV.Matter_TLV_struct()
     # initiatorRandom
-    s.add_TLV(1, matter.TLV.B1, self.resumptionID)
-    s.add_TLV(2, matter.TLV.B1, self.sigma2ResumeMIC)
-    s.add_TLV(3, matter.TLV.U2, self.responderSessionID)
+    s.add_TLV(1, TLV.B1, self.resumptionID)
+    s.add_TLV(2, TLV.B1, self.sigma2ResumeMIC)
+    s.add_TLV(3, TLV.U2, self.responderSessionID)
     if self.SLEEPY_IDLE_INTERVAL != nil || self.SLEEPY_ACTIVE_INTERVAL != nil
       var s2 = s.add_struct(4)
-      s2.add_TLV(1, matter.TLV.U4, self.SLEEPY_IDLE_INTERVAL)
-      s2.add_TLV(2, matter.TLV.U4, self.SLEEPY_ACTIVE_INTERVAL)
+      s2.add_TLV(1, TLV.U4, self.SLEEPY_IDLE_INTERVAL)
+      s2.add_TLV(2, TLV.U4, self.SLEEPY_ACTIVE_INTERVAL)
     end
     return s.tlv2raw(b)
   end
@@ -240,7 +245,7 @@ class Matter_Sigma3
     if idx == nil    idx = 0 end
     var val = matter.TLV.parse(b, idx)
     self.Msg3 = b[idx..]
-    # tasmota.log("MTR: Sigma3 TLV=" + str(val), 4)
+    # log("MTR: Sigma3 TLV=" + str(val), 4)
 
     self.TBEData3Encrypted = val.getsubval(1)
     return self

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Control_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Control_Message.be
@@ -39,13 +39,13 @@ class Matter_Control_Message
 
   def process_incoming_control_message(msg)
 
-    tasmota.log("MTR: received control message " + matter.inspect(msg), 3)
+    log("MTR: received control message " + matter.inspect(msg), 3)
     if   msg.opcode == 0x00
       return self.parse_MsgCounterSyncReq(msg)
     elif msg.opcode == 0x01
       return self.parse_MsgCounterSyncRsp(msg)
     else
-      tasmota.log(format("MTR: >????????? Unknown OpCode (control message) %02X", msg.opcode), 2)
+      log(format("MTR: >????????? Unknown OpCode (control message) %02X", msg.opcode), 2)
       return false
     end
 
@@ -58,7 +58,7 @@ class Matter_Control_Message
   # Not yet implemented
   def parse_MsgCounterSyncReq(msg)
     var session = msg.session
-    tasmota.log(format("MTR: >MCSyncReq * Not implemented %s", msg.raw[msg.app_payload_idx..].tohex()), 2)
+    log(format("MTR: >MCSyncReq * Not implemented %s", msg.raw[msg.app_payload_idx..].tohex()), 2)
     return false      # we don't explicitly ack the message
   end
 
@@ -68,7 +68,7 @@ class Matter_Control_Message
   # Not yet implemented
   def parse_MsgCounterSyncRsp(msg)
     var session = msg.session
-    tasmota.log(format("MTR: >MCSyncRsp * Not implemented %s", msg.raw[msg.app_payload_idx..].tohex()), 2)
+    log(format("MTR: >MCSyncRsp * Not implemented %s", msg.raw[msg.app_payload_idx..].tohex()), 2)
     return false      # we don't explicitly ack the message
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Fabric.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Fabric.be
@@ -193,7 +193,7 @@ class Matter_Fabric : Matter_Expirable
   #
   def counter_group_data_snd_next()
     var next = self._counter_group_data_snd_impl.next()
-    tasmota.log(f"MTR: .          Counter_group_data_snd={next:i}", 3)
+    log(f"MTR: .          Counter_group_data_snd={next:i}", 3)
     if matter.Counter.is_greater(next, self.counter_group_data_snd)
       self.counter_group_data_snd = next + self._GROUP_SND_INCR
       if self.does_persist()
@@ -208,7 +208,7 @@ class Matter_Fabric : Matter_Expirable
   #
   def counter_group_ctrl_snd_next()
     var next = self._counter_group_ctrl_snd_impl.next()
-    tasmota.log(f"MTR: .          Counter_group_ctrl_snd={next:i}", 3)
+    log(f"MTR: .          Counter_group_ctrl_snd={next:i}", 3)
     if matter.Counter.is_greater(next, self.counter_group_ctrl_snd)
       self.counter_group_ctrl_snd = next + self._GROUP_SND_INCR
       if self.does_persist()
@@ -222,13 +222,13 @@ class Matter_Fabric : Matter_Expirable
   #############################################################
   # Called before removal
   def log_new_fabric()
-    tasmota.log(format("MTR: +Fabric    fab='%s' vendorid=%s", self.get_fabric_id().copy().reverse().tohex(), self.get_admin_vendor_name()), 3)
+    log(format("MTR: +Fabric    fab='%s' vendorid=%s", self.get_fabric_id().copy().reverse().tohex(), self.get_admin_vendor_name()), 3)
   end
 
   #############################################################
   # Called before removal
   def before_remove()
-    tasmota.log(format("MTR: -Fabric    fab='%s' (removed)", self.get_fabric_id().copy().reverse().tohex()), 3)
+    log(format("MTR: -Fabric    fab='%s' (removed)", self.get_fabric_id().copy().reverse().tohex()), 3)
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_remote.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_remote.be
@@ -137,7 +137,7 @@ class Matter_HTTP_remote : Matter_HTTP_async
         # dispatch to method in charge of converting to shadow values
         method(obj, j, code)
       else
-        tasmota.log(f"MTR: *** failed to parse JSON response {payload=}", 3)
+        log(f"MTR: *** failed to parse JSON response {payload=}", 3)
       end
     end
   end
@@ -159,7 +159,7 @@ class Matter_HTTP_remote : Matter_HTTP_async
         else
           self.info.remove("name")
         end
-        tasmota.log(f"MTR: update '{self.addr}' name='{device_name}'", 3)
+        log(f"MTR: update '{self.addr}' name='{device_name}'", 3)
         changed = true
       end
 
@@ -175,7 +175,7 @@ class Matter_HTTP_remote : Matter_HTTP_async
         else
           self.info.remove('version')
         end
-        tasmota.log(f"MTR: update '{self.addr}' version='{version}'", 3)
+        log(f"MTR: update '{self.addr}' version='{version}'", 3)
         changed = true
       end
 
@@ -185,7 +185,7 @@ class Matter_HTTP_remote : Matter_HTTP_async
         else
           self.info.remove('hardware')
         end
-        tasmota.log(f"MTR: update '{self.addr}' hardware='{hardware}'", 3)
+        log(f"MTR: update '{self.addr}' hardware='{hardware}'", 3)
         changed = true
       end
 
@@ -201,7 +201,7 @@ class Matter_HTTP_remote : Matter_HTTP_async
         else
           self.info.remove("mac")
         end
-        tasmota.log(f"MTR: update '{self.addr}' mac='{mac}'", 3)
+        log(f"MTR: update '{self.addr}' mac='{mac}'", 3)
         changed = true
       end
 
@@ -283,7 +283,7 @@ class Matter_HTTP_remote : Matter_HTTP_async
 
     self.current_cmd = cmd
     var cmd_url = "/cm?cmnd=" + string.tr(cmd, ' ', '+')
-    tasmota.log(format("MTR: HTTP async request 'http://%s:%i%s'", self.addr, self.port, cmd_url), 4)
+    log(format("MTR: HTTP async request 'http://%s:%i%s'", self.addr, self.port, cmd_url), 4)
     var ret = self.begin(cmd_url)
   end
 
@@ -302,11 +302,11 @@ class Matter_HTTP_remote : Matter_HTTP_async
 
     self.current_cmd = nil
     var cmd_url = "/cm?cmnd=" + string.tr(cmd, ' ', '+')
-    tasmota.log(format("MTR: HTTP sync request 'http://%s:%i%s'", self.addr, self.port, cmd_url), 4)
+    log(format("MTR: HTTP sync request 'http://%s:%i%s'", self.addr, self.port, cmd_url), 4)
     var ret = super(self).begin_sync(cmd_url, timeout)
     var payload_short = (ret) ? ret : 'nil'
     if size(payload_short) > 30   payload_short = payload_short[0..29] + '...'   end
-    tasmota.log(format("MTR: HTTP sync-resp  in %i ms from %s: [%i] '%s'", tasmota.millis() - self.time_start, self.addr, size(self.payload), payload_short), 3)
+    log(format("MTR: HTTP sync-resp  in %i ms from %s: [%i] '%s'", tasmota.millis() - self.time_start, self.addr, size(self.payload), payload_short), 3)
     return ret
   end
 
@@ -314,17 +314,17 @@ class Matter_HTTP_remote : Matter_HTTP_async
     if self.current_cmd == nil    return  end       # do nothing if sync request
     var payload_short = (self.payload != nil) ? self.payload : 'nil'
     if size(payload_short) > 30   payload_short = payload_short[0..29] + '...'   end
-    tasmota.log(format("MTR: HTTP async-resp in %i ms from %s: [%i] '%s'", tasmota.millis() - self.time_start, self.addr, size(self.payload), payload_short), 3)
+    log(format("MTR: HTTP async-resp in %i ms from %s: [%i] '%s'", tasmota.millis() - self.time_start, self.addr, size(self.payload), payload_short), 3)
     self.dispatch_cb(self.http_status, self.payload)
   end
   def event_http_failed()
     if self.current_cmd == nil    return  end       # do nothing if sync request
-    tasmota.log("MTR: HTTP failed", 3)
+    log("MTR: HTTP failed", 3)
     self.dispatch_cb(self.http_status, nil)
   end
   def event_http_timeout()
     if self.current_cmd == nil    return  end       # do nothing if sync request
-    tasmota.log(format("MTR: HTTP timeout http_status=%i phase=%i tcp_status=%i size_payload=%i", self.http_status, self.phase, self.status, size(self.payload)), 3)
+    log(format("MTR: HTTP timeout http_status=%i phase=%i tcp_status=%i size_payload=%i", self.http_status, self.phase, self.status, size(self.payload)), 3)
     self.dispatch_cb(self.http_status, nil)
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
@@ -63,7 +63,7 @@ class Matter_IM_Message
   # ack received for previous message, proceed to next (if any)
   # return true if we manage the ack ourselves, false if it needs to be done upper
   def ack_received(msg)
-    # tasmota.log("MTR: IM_Message ack_received exch="+str(self.resp.exchange_id), 3)
+    # log("MTR: IM_Message ack_received exch="+str(self.resp.exchange_id), 3)
     self.expiration = tasmota.millis() + self.MSG_TIMEOUT     # give more time
     return false
   end
@@ -71,7 +71,7 @@ class Matter_IM_Message
   # Status Report OK received for previous message, proceed to next (if any)
   # return true if we manage the ack ourselves, false if it needs to be done upper
   def status_ok_received(msg)
-    # tasmota.log(format("MTR: IM_Message status_ok_received exch=%i", self.resp.exchange_id), 3)
+    # log(format("MTR: IM_Message status_ok_received exch=%i", self.resp.exchange_id), 3)
     self.expiration = tasmota.millis() + self.MSG_TIMEOUT     # give more time
     if msg
       self.resp = msg.build_response(self.resp.opcode, self.resp.x_flag_r, self.resp)   # update packet
@@ -91,7 +91,7 @@ class Matter_IM_Message
 
   # default responder for data
   def send_im(responder)
-    # tasmota.log(format("MTR: IM_Message send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    # log(format("MTR: IM_Message send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
     if !self.ready   return false  end
     # import debug
     var resp = self.resp
@@ -102,9 +102,9 @@ class Matter_IM_Message
     resp.encode_frame(data_raw)    # payload in cleartext
     resp.encrypt()
     if tasmota.loglevel(4)
-      tasmota.log(format("MTR: <snd       (%6i) id=%i exch=%i rack=%s", resp.session.local_session_id, resp.message_counter, resp.exchange_id, resp.ack_message_counter), 4)
+      log(format("MTR: <snd       (%6i) id=%i exch=%i rack=%s", resp.session.local_session_id, resp.message_counter, resp.exchange_id, resp.ack_message_counter), 4)
     end
-    # tasmota.log("MTR: Perf/Send = " + str(debug.counters()), 4)
+    # log("MTR: Perf/Send = " + str(debug.counters()), 4)
     responder.send_response_frame(resp)
     self.last_counter = resp.message_counter
     self.finish = true              # by default we remove the packet after it is sent
@@ -175,7 +175,7 @@ class Matter_IM_ReportData : Matter_IM_Message
 
   # default responder for data
   def send_im(responder)
-    # tasmota.log(format("MTR: IM_ReportData send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    # log(format("MTR: IM_ReportData send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
     if !self.ready   return false  end
     var resp = self.resp                          # response frame object
     var data = self.data                          # TLV data of the response (if any)
@@ -184,7 +184,7 @@ class Matter_IM_ReportData : Matter_IM_Message
     # the message were grouped by right-sized binaries upfront, we just need to send one block at time
     var elements = 1                # number of elements added
 
-    # tasmota.log(format("MTR: exch=%i elements=%i msg_sz=%i total=%i", self.get_exchangeid(), elements, msg_sz, sz_attribute_reports), 3)
+    # log(format("MTR: exch=%i elements=%i msg_sz=%i total=%i", self.get_exchangeid(), elements, msg_sz, sz_attribute_reports), 3)
     var next_elemnts
     if data.attribute_reports != nil
       next_elemnts = data.attribute_reports[elements .. ]
@@ -195,13 +195,13 @@ class Matter_IM_ReportData : Matter_IM_Message
     end
 
     if was_chunked
-      # tasmota.log(format("MTR: .Read_Attr next_chunk exch=%i", self.get_exchangeid()), 4)
+      # log(format("MTR: .Read_Attr next_chunk exch=%i", self.get_exchangeid()), 4)
     end
     if data.more_chunked_messages
       if !was_chunked
-        # tasmota.log(format("MTR: .Read_Attr first_chunk exch=%i", self.get_exchangeid()), 4)
+        # log(format("MTR: .Read_Attr first_chunk exch=%i", self.get_exchangeid()), 4)
       end
-      # tasmota.log("MTR: sending TLV" + str(data), 4)
+      # log("MTR: sending TLV" + str(data), 4)
     end
 
     # print(">>>>> send elements before encode")
@@ -213,13 +213,13 @@ class Matter_IM_ReportData : Matter_IM_Message
     # print(">>>>> send elements after encode")
     resp.encrypt()
     # print(">>>>> send elements after encrypt")
-    # tasmota.log(format("MTR: <snd       (%6i) id=%i exch=%i rack=%s", resp.session.local_session_id, resp.message_counter, resp.exchange_id, resp.ack_message_counter), 4)
+    # log(format("MTR: <snd       (%6i) id=%i exch=%i rack=%s", resp.session.local_session_id, resp.message_counter, resp.exchange_id, resp.ack_message_counter), 4)
     responder.send_response_frame(resp)
     self.last_counter = resp.message_counter
 
     if next_elemnts != nil && size(next_elemnts) > 0
       data.attribute_reports = next_elemnts
-      # tasmota.log(format("MTR: to_be_sent_later size=%i exch=%i", size(data.attribute_reports), resp.exchange_id), 4)
+      # log(format("MTR: to_be_sent_later size=%i exch=%i", size(data.attribute_reports), resp.exchange_id), 4)
       self.ready = false    # wait for Status Report before continuing sending
       # keep alive
     else
@@ -256,7 +256,7 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
 
   # ack received, confirm the heartbeat
   def ack_received(msg)
-    # tasmota.log(format("MTR: IM_ReportDataSubscribed ack_received sub=%i", self.sub.subscription_id), 3)
+    # log(format("MTR: IM_ReportDataSubscribed ack_received sub=%i", self.sub.subscription_id), 3)
     super(self).ack_received(msg)
     if !self.report_data_phase
       # if ack is received while all data is sent, means that it finished without error
@@ -271,14 +271,14 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
 
   # we received an ACK error, remove subscription
   def status_error_received(msg)
-    # tasmota.log(format("MTR: IM_ReportDataSubscribed status_error_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
+    # log(format("MTR: IM_ReportDataSubscribed status_error_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     self.sub.remove_self()
   end
 
   # ack received for previous message, proceed to next (if any)
   # return true if we manage the ack ourselves, false if it needs to be done upper
   def status_ok_received(msg)
-    # tasmota.log(format("MTR: IM_ReportDataSubscribed status_ok_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
+    # log(format("MTR: IM_ReportDataSubscribed status_ok_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     if self.report_data_phase
       return super(self).status_ok_received(msg)
     else
@@ -291,13 +291,13 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
   # returns true if transaction is complete (remove object from queue)
   # default responder for data
   def send_im(responder)
-    # tasmota.log(format("MTR: IM_ReportDataSubscribed send sub=%i exch=%i ready=%i", self.sub.subscription_id, self.resp.exchange_id, self.ready ? 1 : 0), 3)
-    # tasmota.log(format("MTR: ReportDataSubscribed::send_im size(self.data.attribute_reports)=%i ready=%s report_data_phase=%s", size(self.data.attribute_reports), str(self.ready), str(self.report_data_phase)), 3)
+    # log(format("MTR: IM_ReportDataSubscribed send sub=%i exch=%i ready=%i", self.sub.subscription_id, self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    # log(format("MTR: ReportDataSubscribed::send_im size(self.data.attribute_reports)=%i ready=%s report_data_phase=%s", size(self.data.attribute_reports), str(self.ready), str(self.report_data_phase)), 3)
     if !self.ready   return false  end
     if size(self.data.attribute_reports) > 0      # do we have still attributes to send
       if self.report_data_phase
         super(self).send_im(responder)
-        # tasmota.log(format("MTR: ReportDataSubscribed::send_im called super finish=%i", self.finish), 3)
+        # log(format("MTR: ReportDataSubscribed::send_im called super finish=%i", self.finish), 3)
         if !self.finish return end              # ReportData needs to continue
         # ReportData is finished
         self.report_data_phase = false
@@ -309,7 +309,7 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
         resp.encode_frame()
         resp.encrypt()
         if tasmota.loglevel(4)
-          tasmota.log(format("MTR: <Ack       (%6i) ack=%i id=%i", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter), 4)
+          log(format("MTR: <Ack       (%6i) ack=%i id=%i", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter), 4)
         end
         responder.send_response_frame(resp)
         self.last_counter = resp.message_counter
@@ -354,7 +354,7 @@ class Matter_IM_SubscribedHeartbeat : Matter_IM_ReportData
 
   # ack received, confirm the heartbeat
   def ack_received(msg)
-    # tasmota.log(format("MTR: Matter_IM_SubscribedHeartbeat ack_received sub=%i", self.sub.subscription_id), 3)
+    # log(format("MTR: Matter_IM_SubscribedHeartbeat ack_received sub=%i", self.sub.subscription_id), 3)
     super(self).ack_received(msg)
     self.finish = true
     return true                       # proceed to calling send() which removes the message
@@ -362,7 +362,7 @@ class Matter_IM_SubscribedHeartbeat : Matter_IM_ReportData
 
   # we received an ACK error, remove subscription
   def status_error_received(msg)
-    # tasmota.log(format("MTR: Matter_IM_SubscribedHeartbeat status_error_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
+    # log(format("MTR: Matter_IM_SubscribedHeartbeat status_error_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     self.sub.remove_self()
     return false                            # let the caller to the ack
   end
@@ -370,13 +370,13 @@ class Matter_IM_SubscribedHeartbeat : Matter_IM_ReportData
   # ack received for previous message, proceed to next (if any)
   # return true if we manage the ack ourselves, false if it needs to be done upper
   def status_ok_received(msg)
-    # tasmota.log(format("MTR: Matter_IM_SubscribedHeartbeat status_ok_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
+    # log(format("MTR: Matter_IM_SubscribedHeartbeat status_ok_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     return false                            # let the caller to the ack
   end
 
   # default responder for data
   def send_im(responder)
-    # tasmota.log(format("MTR: Matter_IM_SubscribedHeartbeat send sub=%i exch=%i ready=%i", self.sub.subscription_id, self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    # log(format("MTR: Matter_IM_SubscribedHeartbeat send sub=%i exch=%i ready=%i", self.sub.subscription_id, self.resp.exchange_id, self.ready ? 1 : 0), 3)
     if !self.ready   return false  end
 
     super(self).send_im(responder)
@@ -402,7 +402,7 @@ class Matter_IM_SubscribeResponse : Matter_IM_ReportData
 
   # default responder for data
   def send_im(responder)
-    # tasmota.log(format("MTR: Matter_IM_SubscribeResponse send sub=%i ready=%i", self.sub.subscription_id, self.ready ? 1 : 0), 3)
+    # log(format("MTR: Matter_IM_SubscribeResponse send sub=%i ready=%i", self.sub.subscription_id, self.ready ? 1 : 0), 3)
     if !self.ready   return false  end
     if self.report_data_phase
       super(self).send_im(responder)
@@ -425,7 +425,7 @@ class Matter_IM_SubscribeResponse : Matter_IM_ReportData
       resp.encrypt()
       responder.send_response_frame(resp)
       self.last_counter = resp.message_counter
-      # tasmota.log(format("MTR: Send SubscribeResponseMessage sub=%i id=%i", self.sub.subscription_id, resp.message_counter), 3)
+      # log(format("MTR: Send SubscribeResponseMessage sub=%i id=%i", self.sub.subscription_id, resp.message_counter), 3)
       self.sub.re_arm()
       self.finish = true          # remove exchange
     end
@@ -433,10 +433,10 @@ class Matter_IM_SubscribeResponse : Matter_IM_ReportData
 
   # Status ok received
   def status_ok_received(msg)
-    # tasmota.log(format("MTR: IM_SubscribeResponse status_ok_received sub=%i exch=%i ack=%i last_counter=%i", self.sub.subscription_id, self.resp.exchange_id, msg.ack_message_counter ? msg.ack_message_counter : 0 , self.last_counter), 3)
+    # log(format("MTR: IM_SubscribeResponse status_ok_received sub=%i exch=%i ack=%i last_counter=%i", self.sub.subscription_id, self.resp.exchange_id, msg.ack_message_counter ? msg.ack_message_counter : 0 , self.last_counter), 3)
     # once we receive ack, open flow for subscriptions
     if tasmota.loglevel(3)
-      tasmota.log(format("MTR: >Sub_OK    (%6i) sub=%i", msg.session.local_session_id, self.sub.subscription_id), 3)
+      log(format("MTR: >Sub_OK    (%6i) sub=%i", msg.session.local_session_id, self.sub.subscription_id), 3)
     end
     return super(self).status_ok_received(msg)
   end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM_Subscription.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM_Subscription.be
@@ -81,12 +81,12 @@ class Matter_IM_Subscription
     self.clear_before_arm()
     self.is_keep_alive = false
 
-    # tasmota.log("MTR: new subsctiption " + matter.inspect(self), 3)
+    # log("MTR: new subsctiption " + matter.inspect(self), 3)
   end
   
   # remove self from subs_shop list
   def remove_self()
-    tasmota.log("MTR: -Sub_Del   (      ) sub=" + str(self.subscription_id), 3)
+    log("MTR: -Sub_Del   (      ) sub=" + str(self.subscription_id), 3)
     self.subs_shop.remove_sub(self)
   end
 
@@ -103,7 +103,7 @@ class Matter_IM_Subscription
     self.expiration = now + (self.max_interval - self.MAX_INTERVAL_MARGIN) * 1000
     self.not_before = now + self.min_interval * 1000 - 1
     if !self.is_keep_alive
-      tasmota.log(format("MTR: .Sub_Done  (      ) sub=%i", self.subscription_id), 3)
+      log(format("MTR: .Sub_Done  (      ) sub=%i", self.subscription_id), 3)
     end
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Message.be
@@ -304,7 +304,7 @@ class Matter_Frame
     if resp.local_session_id == 0
       var op_name = matter.get_opcode_name(resp.opcode)
       if !op_name   op_name = format("0x%02X", resp.opcode) end
-      tasmota.log(format("MTR: <Replied   (%6i) %s", resp.session.local_session_id, op_name), 3)
+      log(format("MTR: <Replied   (%6i) %s", resp.session.local_session_id, op_name), 3)
     end
     return resp
   end
@@ -363,7 +363,7 @@ class Matter_Frame
     # check privacy flag, p.127
     if self.sec_p
       # compute privacy key, p.71
-      tasmota.log("MTR: >>>>>>>>>>>>>>>>>>>> Compute Privacy TODO", 2)
+      log("MTR: >>>>>>>>>>>>>>>>>>>> Compute Privacy TODO", 2)
       var k = session.get_i2r_privacy()
       var mic = raw[-16..]      # take last 16 bytes as signature
       var n = bytes().add(self.local_session_id, -2) + mic[5..15]   # session in Big Endian
@@ -387,13 +387,13 @@ class Matter_Frame
       n.resize(13)        # add zeros
     end
 
-    # tasmota.log("MTR: ******************************", 4)
-    # tasmota.log("MTR: raw         =" + raw.tohex(), 4)
-    # tasmota.log("MTR: i2r         =" + i2r.tohex(), 4)
-    # tasmota.log("MTR: p           =" + raw[payload_idx .. -17].tohex(), 4)
-    # tasmota.log("MTR: a           =" + raw[0 .. payload_idx - 1].tohex(), 4)
-    # tasmota.log("MTR: n           =" + n.tohex(), 4)
-    # tasmota.log("MTR: mic         =" + raw[-16..].tohex(), 4)
+    # log("MTR: ******************************", 4)
+    # log("MTR: raw         =" + raw.tohex(), 4)
+    # log("MTR: i2r         =" + i2r.tohex(), 4)
+    # log("MTR: p           =" + raw[payload_idx .. -17].tohex(), 4)
+    # log("MTR: a           =" + raw[0 .. payload_idx - 1].tohex(), 4)
+    # log("MTR: n           =" + n.tohex(), 4)
+    # log("MTR: mic         =" + raw[-16..].tohex(), 4)
 
     # decrypt
     var ret = crypto.AES_CCM.decrypt1(i2r,                    # secret key
@@ -405,7 +405,7 @@ class Matter_Frame
       # succcess
       raw.resize(size(raw) - tag_len)   # remove MIC
     else
-      tasmota.log("MTR: rejected packet due to invalid MIC", 3)
+      log("MTR: rejected packet due to invalid MIC", 3)
     end
     return ret
   end
@@ -451,7 +451,7 @@ class Matter_Frame
     var r = matter.Frame(self.message_handler, raw)
     r.decode_header()
     r.decode_payload()
-    # tasmota.log("MTR: sending decode: " + matter.inspect(r), 4)
+    # log("MTR: sending decode: " + matter.inspect(r), 4)
   end
 end
 matter.Frame = Matter_Frame

--- a/lib/libesp32/berry_matter/src/embedded/Matter_MessageHandler.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_MessageHandler.be
@@ -52,7 +52,7 @@ class Matter_MessageHandler
       var resp = frame.build_standalone_ack(reliable)
       resp.encode_frame()
       if tasmota.loglevel(4)
-        tasmota.log(format("MTR: <Ack       (%6i) ack=%i id=%i %s", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter, reliable ? '{reliable}' : ''), 4)
+        log(format("MTR: <Ack       (%6i) ack=%i id=%i %s", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter, reliable ? '{reliable}' : ''), 4)
       end
       self.send_response_frame(resp)
     end
@@ -69,7 +69,7 @@ class Matter_MessageHandler
       resp.encode_frame()
       resp.encrypt()
       if tasmota.loglevel(4)
-        tasmota.log(format("MTR: <Ack*      (%6i) ack=%i id=%i %s", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter, reliable ? '{reliable}' : ''), 4)
+        log(format("MTR: <Ack*      (%6i) ack=%i id=%i %s", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter, reliable ? '{reliable}' : ''), 4)
       end
       self.send_response_frame(resp)
     end
@@ -86,7 +86,7 @@ class Matter_MessageHandler
 
     matter.profiler.log("msg_received")
     try
-      # tasmota.log("MTR: MessageHandler::msg_received raw="+raw.tohex(), 4)
+      # log("MTR: MessageHandler::msg_received raw="+raw.tohex(), 4)
       var frame = matter.Frame(self, raw, addr, port)
 
       var ok = frame.decode_header()
@@ -96,15 +96,15 @@ class Matter_MessageHandler
       # do we need decryption?
       if frame.sec_p
         # Control message
-        # tasmota.log("MTR: CONTROL MESSAGE=" + matter.inspect(frame), 4)
+        # log("MTR: CONTROL MESSAGE=" + matter.inspect(frame), 4)
         var session = self.device.sessions.find_session_source_id_unsecure(frame.source_node_id, 90)    # 90 seconds max
-        # tasmota.log("MTR: find session by source_node_id = " + str(frame.source_node_id) + " session_id = " + str(session.local_session_id), 4)
+        # log("MTR: find session by source_node_id = " + str(frame.source_node_id) + " session_id = " + str(session.local_session_id), 4)
         return self.control_message.process_incoming_control_message(frame)
       elif frame.local_session_id == 0 && frame.sec_sesstype == 0
         #############################################################
         ### unencrypted session, handled by commissioning
         var session = self.device.sessions.find_session_source_id_unsecure(frame.source_node_id, 90)    # 90 seconds max
-        # tasmota.log("MTR: find session by source_node_id = " + str(frame.source_node_id) + " session_id = " + str(session.local_session_id), 4)
+        # log("MTR: find session by source_node_id = " + str(frame.source_node_id) + " session_id = " + str(session.local_session_id), 4)
         if addr     session._ip = addr     end
         if port     session._port = port   end
         session._message_handler = self
@@ -113,7 +113,7 @@ class Matter_MessageHandler
         # check if it's a duplicate
         if !session._counter_insecure_rcv.validate(frame.message_counter, false)
           if tasmota.loglevel(4)
-            tasmota.log(format("MTR: .          Duplicate unencrypted message = %i ref = %i", frame.message_counter, session._counter_insecure_rcv.val()), 4)
+            log(format("MTR: .          Duplicate unencrypted message = %i ref = %i", frame.message_counter, session._counter_insecure_rcv.val()), 4)
           end
           self.send_simple_ack(frame, false #-not reliable-#)
           return false
@@ -125,11 +125,11 @@ class Matter_MessageHandler
           var op_name = matter.get_opcode_name(frame.opcode)
           if !op_name   op_name = format("0x%02X", frame.opcode) end
           if tasmota.loglevel(3)
-            tasmota.log(format("MTR: >Received  (%6i) %s rid=%i exch=%i from [%s]:%i", session.local_session_id, op_name, frame.message_counter, frame.exchange_id, addr, port), 3)
+            log(format("MTR: >Received  (%6i) %s rid=%i exch=%i from [%s]:%i", session.local_session_id, op_name, frame.message_counter, frame.exchange_id, addr, port), 3)
           end
         else
           if tasmota.loglevel(4)
-            tasmota.log(format("MTR: >rcv Ack   (%6i) rid=%i exch=%i ack=%s %sfrom [%s]:%i", session.local_session_id, frame.message_counter, frame.x_flag_r ? "{reliable} " : "", frame.exchange_id, str(frame.ack_message_counter), addr, port), 4)
+            log(format("MTR: >rcv Ack   (%6i) rid=%i exch=%i ack=%s %sfrom [%s]:%i", session.local_session_id, frame.message_counter, frame.x_flag_r ? "{reliable} " : "", frame.exchange_id, str(frame.ack_message_counter), addr, port), 4)
           end
         end
         ret = self.commissioning.process_incoming(frame)
@@ -141,14 +141,14 @@ class Matter_MessageHandler
         # encrypted message
         # matter.profiler.log("msg_received_header_encrypted_message_received")
         if tasmota.loglevel(4)
-          tasmota.log(format("MTR: decode header: local_session_id=%i message_counter=%i", frame.local_session_id, frame.message_counter), 4)
+          log(format("MTR: decode header: local_session_id=%i message_counter=%i", frame.local_session_id, frame.message_counter), 4)
         end
 
         var session = self.device.sessions.get_session_by_local_session_id(frame.local_session_id)
         # matter.profiler.log("msg_received_header_session_retrieved")
         if session == nil
-          tasmota.log("MTR: unknown local_session_id="+str(frame.local_session_id), 3)
-          # tasmota.log("MTR: frame="+matter.inspect(frame), 3)
+          log("MTR: unknown local_session_id="+str(frame.local_session_id), 3)
+          # log("MTR: frame="+matter.inspect(frame), 3)
           return false
         end
         # matter.profiler.log("msg_received_session_found")
@@ -160,7 +160,7 @@ class Matter_MessageHandler
         # check if it's a duplicate
         if !session.counter_rcv_validate(frame.message_counter, true)
           if tasmota.loglevel(3)
-            tasmota.log("MTR: .          Duplicate encrypted message = " + str(frame.message_counter) + " counter=" + str(session.counter_rcv), 3)
+            log("MTR: .          Duplicate encrypted message = " + str(frame.message_counter) + " counter=" + str(session.counter_rcv), 3)
           end
           self.send_encrypted_ack(frame, false #-not reliable-#)
           return false
@@ -173,14 +173,14 @@ class Matter_MessageHandler
         # matter.profiler.log("msg_received_payload_undecoded")
 
         # continue decoding
-        # tasmota.log(format("MTR: idx=%i clear=%s", frame.payload_idx, frame.raw.tohex()), 4)
+        # log(format("MTR: idx=%i clear=%s", frame.payload_idx, frame.raw.tohex()), 4)
         frame.decode_payload()
         # matter.profiler.log("msg_received_payload_decoded")
         if tasmota.loglevel(4)
-          tasmota.log("MTR: >          Decrypted message: protocol_id:"+str(frame.protocol_id)+" opcode="+str(frame.opcode)+" exchange_id="+str(frame.exchange_id & 0xFFFF), 4)
+          log("MTR: >          Decrypted message: protocol_id:"+str(frame.protocol_id)+" opcode="+str(frame.opcode)+" exchange_id="+str(frame.exchange_id & 0xFFFF), 4)
         end
 
-        # tasmota.log(format("MTR: >rcv       (%6i) [%02X/%02X] rid=%i exch=%i ack=%s %sfrom [%s]:%i", session.local_session_id, frame.protocol_id, frame.opcode, frame.message_counter, frame.exchange_id, str(frame.ack_message_counter), frame.x_flag_r ? "{reliable} " : "", addr, port), 3)
+        # log(format("MTR: >rcv       (%6i) [%02X/%02X] rid=%i exch=%i ack=%s %sfrom [%s]:%i", session.local_session_id, frame.protocol_id, frame.opcode, frame.message_counter, frame.exchange_id, str(frame.ack_message_counter), frame.x_flag_r ? "{reliable} " : "", addr, port), 3)
 
         self.device.received_ack(frame)                     # remove acknowledge packet from sending list
 
@@ -188,7 +188,7 @@ class Matter_MessageHandler
         var protocol_id = frame.protocol_id
         if protocol_id == 0x0000    # PROTOCOL_ID_SECURE_CHANNEL
           # it should not be encrypted
-          # tasmota.log("MTR: PROTOCOL_ID_SECURE_CHANNEL " + matter.inspect(frame), 3)
+          # log("MTR: PROTOCOL_ID_SECURE_CHANNEL " + matter.inspect(frame), 3)
           if frame.opcode == 0x10                             # MRPStandaloneAcknowledgement
             ret = self.im.process_incoming_ack(frame)
             if ret
@@ -212,21 +212,21 @@ class Matter_MessageHandler
 
         # -- PROTOCOL_ID_BDX is used for file transfer between devices, not used in Tasmota
         # elif protocol_id == 0x0002  # PROTOCOL_ID_BDX -- BDX not handled at all in Tasmota
-        #   tasmota.log("MTR: PROTOCOL_ID_BDX not yet handled", 2)
+        #   log("MTR: PROTOCOL_ID_BDX not yet handled", 2)
         #   return false # ignore for now TODO
         # -- PROTOCOL_ID_USER_DIRECTED_COMMISSIONING is only used by devices, as a device we will not receive any
         # elif protocol_id == 0x0003  # PROTOCOL_ID_USER_DIRECTED_COMMISSIONING
-        #   tasmota.log("MTR: PROTOCOL_ID_USER_DIRECTED_COMMISSIONING not yet handled", 2)
+        #   log("MTR: PROTOCOL_ID_USER_DIRECTED_COMMISSIONING not yet handled", 2)
         #   return false # ignore for now TODO
         else
-          tasmota.log("MTR: ignoring unhandled protocol_id:"+str(protocol_id), 3)
+          log("MTR: ignoring unhandled protocol_id:"+str(protocol_id), 3)
         end
 
       end
 
       return ret
     except .. as e, m
-      tasmota.log("MTR: MessageHandler::msg_received exception: "+str(e)+";"+str(m), 2)
+      log("MTR: MessageHandler::msg_received exception: "+str(e)+";"+str(m), 2)
       if tasmota._debug_present
         import debug
         debug.traceback()

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Device.be
@@ -118,11 +118,7 @@ class Matter_Plugin_Device : Matter_Plugin
       if   attribute == 0x0003          #  ---------- ProductName / string ----------
         if self.BRIDGE
           var name = self.http_remote.get_info().find("name")
-          if name
-            return tlv_solo.set(TLV.UTF1, name)
-          else
-            return tlv_solo.set(TLV.NULL, nil)
-          end
+          return tlv_solo.set_or_nil(TLV.UTF1, name)
         else
           return tlv_solo.set(TLV.UTF1, tasmota.cmd("DeviceName", true)['DeviceName'])
         end
@@ -147,11 +143,7 @@ class Matter_Plugin_Device : Matter_Plugin
       elif attribute == 0x000F || attribute == 0x0012          #  ---------- SerialNumber / string ----------
         if self.BRIDGE
           var mac = self.http_remote.get_info().find("mac")
-          if mac
-            return tlv_solo.set(TLV.UTF1, mac)
-          else
-            return tlv_solo.set(TLV.NULL, nil)
-          end
+          return tlv_solo.set_or_nil(TLV.UTF1, mac)
         else
           return tlv_solo.set(TLV.UTF1, tasmota.wifi().find("mac", ""))
         end
@@ -325,7 +317,7 @@ class Matter_Plugin_Device : Matter_Plugin
           return j
         end
         retry -= 1
-        tasmota.log("MTR: HTTP GET retrying", 3)
+        log("MTR: HTTP GET retrying", 3)
       end
       self.http_remote.device_is_alive(false)
       return nil

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Root.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Root.be
@@ -94,13 +94,13 @@ class Matter_Plugin_Root : Matter_Plugin
           eth.add_TLV(2, TLV.BOOL, 1)               # OffPremiseServicesReachableIPv4
           eth.add_TLV(3, TLV.NULL, nil)             # OffPremiseServicesReachableIPv6
           var mac = bytes().fromhex(string.replace(tas_eth.find("mac", ""), ":", ""))
-          eth.add_TLV(4, TLV.B1, mac) # HardwareAddress
-          var ip4 = eth.add_array(5)                 # IPv4Addresses
+          eth.add_TLV(4, TLV.B1, mac)               # HardwareAddress
+          var ip4 = eth.add_array(5)                # IPv4Addresses
           ip4.add_TLV(nil, TLV.B1, matter.get_ip_bytes(tas_eth.find("ip", "")))
-          var ip6 = eth.add_array(6)                 # IPv6Addresses
+          var ip6 = eth.add_array(6)                # IPv6Addresses
           ip6.add_TLV(nil, TLV.B1, matter.get_ip_bytes(tas_eth.find("ip6local", "")))
           ip6.add_TLV(nil, TLV.B1, matter.get_ip_bytes(tas_eth.find("ip6", "")))
-          eth.add_TLV(7, TLV.U1, 2)                # InterfaceType, p646
+          eth.add_TLV(7, TLV.U1, 2)                 # InterfaceType, p646
         end
 
         var tas_wif = tasmota.wifi()
@@ -111,13 +111,13 @@ class Matter_Plugin_Root : Matter_Plugin
           wif.add_TLV(2, TLV.BOOL, 1)               # OffPremiseServicesReachableIPv4
           wif.add_TLV(3, TLV.NULL, nil)             # OffPremiseServicesReachableIPv6
           var mac = bytes().fromhex(string.replace(tas_wif.find("mac", ""), ":", ""))
-          wif.add_TLV(4, TLV.B1, mac) # HardwareAddress
-          var ip4 = wif.add_array(5)                 # IPv4Addresses
+          wif.add_TLV(4, TLV.B1, mac)               # HardwareAddress
+          var ip4 = wif.add_array(5)                # IPv4Addresses
           ip4.add_TLV(nil, TLV.B1, matter.get_ip_bytes(tas_wif.find("ip", "")))
-          var ip6 = wif.add_array(6)                 # IPv6Addresses
+          var ip6 = wif.add_array(6)                # IPv6Addresses
           ip6.add_TLV(nil, TLV.B1, matter.get_ip_bytes(tas_wif.find("ip6local", "")))
           ip6.add_TLV(nil, TLV.B1, matter.get_ip_bytes(tas_wif.find("ip6", "")))
-          wif.add_TLV(7, TLV.U1, 1)                # InterfaceType, p646
+          wif.add_TLV(7, TLV.U1, 1)                 # InterfaceType, p646
         end
         return nwi
       elif attribute == 0x0001          #  ---------- RebootCount u16 ----------
@@ -142,7 +142,7 @@ class Matter_Plugin_Root : Matter_Plugin
         return tlv_solo.set(TLV.U1, 3)     # MillisecondsGranularity (NTP every hour, i.e. 36ms max drift)
       # TODO add some missing args
       elif attribute == 0x0007          #  ---------- LocalTime / epoch_us ----------
-        var epoch_us = int64(tasmota.rtc()['local']) * int64(1000000)
+        var epoch_us = int64(tasmota.rtc('local')) * int64(1000000)
         return tlv_solo.set(TLV.U8, epoch_us)     # TODO test the conversion of int64()
       end
 
@@ -201,16 +201,12 @@ class Matter_Plugin_Root : Matter_Plugin
       elif attribute == 0x0001          #  ---------- AdminFabricIndex / u16 ----------
         var admin_fabric = self.device.commissioning_admin_fabric
         if admin_fabric != nil
-          return tlv_solo.set(TLV.U2, admin_fabric.get_fabric_index())
-        else
-          return tlv_solo.set(TLV.NULL, nil)
+          return tlv_solo.set_or_nil(TLV.U2, admin_fabric.get_fabric_index())
         end
       elif attribute == 0x0002          #  ---------- AdminVendorId / u16 ----------
         var admin_fabric = self.device.commissioning_admin_fabric
         if admin_fabric != nil
-          return tlv_solo.set(TLV.U2, admin_fabric.get_admin_vendor())
-        else
-          return tlv_solo.set(TLV.NULL, nil)
+          return tlv_solo.set_or_nil(TLV.U2, admin_fabric.get_admin_vendor())
         end
       end
         
@@ -426,7 +422,7 @@ class Matter_Plugin_Root : Matter_Plugin
 
         var ac = session.get_ac()
         var attestation_tbs = attestation_message + ac
-        # tasmota.log("MTR: attestation_tbs=" + attestation_tbs.tohex(), 4)
+        # log("MTR: attestation_tbs=" + attestation_tbs.tohex(), 4)
 
         var attestation_signature = crypto.EC_P256().ecdsa_sign_sha256(matter.DAC_Priv_FFF1_8000(), attestation_tbs)
 
@@ -444,7 +440,7 @@ class Matter_Plugin_Root : Matter_Plugin
         var CSRNonce = val.findsubval(0)     # octstr 32
         if size(CSRNonce) != 32   return nil end    # check size on nonce
         var IsForUpdateNOC = val.findsubval(1, false)     # bool
-        # tasmota.log(format("MTR: CSRRequest CSRNonce=%s IsForUpdateNOC=%s", str(CSRNonce), str(IsForUpdateNOC)), 4)
+        # log(format("MTR: CSRRequest CSRNonce=%s IsForUpdateNOC=%s", str(CSRNonce), str(IsForUpdateNOC)), 4)
 
         var csr = session.gen_CSR()
 
@@ -454,7 +450,7 @@ class Matter_Plugin_Root : Matter_Plugin
         var nocsr_elements_message = nocsr_elements.tlv2raw()
         # sign with attestation challenge
         var nocsr_tbs = nocsr_elements_message + session.get_ac()
-        # tasmota.log("MTR: nocsr_tbs=" + nocsr_tbs.tohex(), 4)
+        # log("MTR: nocsr_tbs=" + nocsr_tbs.tohex(), 4)
         var attestation_signature = crypto.EC_P256().ecdsa_sign_sha256(matter.DAC_Priv_FFF1_8000(), nocsr_tbs)
         
         # create CSRResponse
@@ -470,12 +466,12 @@ class Matter_Plugin_Root : Matter_Plugin
         var RootCACertificate = val.findsubval(0)     # octstr 400 max
         # TODO - additional tests are expected according to 11.17.7.13. AddTrustedRootCertificate Command
         session.set_temp_ca(RootCACertificate)
-        # tasmota.log("MTR: received ca_root="+RootCACertificate.tohex(), 4)
+        # log("MTR: received ca_root="+RootCACertificate.tohex(), 4)
         ctx.status = matter.SUCCESS                  # OK
         return nil                      # trigger a standalone ack
 
       elif command == 0x0006            # ---------- AddNOC ----------
-        tasmota.log("MTR: AddNoc Args=" + str(val), 4)
+        log("MTR: AddNoc Args=" + str(val), 4)
         var NOCValue = val.findsubval(0)        # octstr max 400
         var ICACValue = val.findsubval(1)       # octstr max 400
         # Apple sends an empty ICAC instead of a missing attribute, fix this
@@ -483,14 +479,14 @@ class Matter_Plugin_Root : Matter_Plugin
         var IpkValue = val.findsubval(2)        # octstr max 16
         var CaseAdminSubject = val.findsubval(3)
         var AdminVendorId = val.findsubval(4)
-        # tasmota.log("MTR: AddNoc NOCValue=" + (NOCValue ? NOCValue.tohex() : ""), 3)
-        # tasmota.log("MTR: AddNoc ICACValue=" + (ICACValue ? ICACValue.tohex() : ""), 3)
-        # tasmota.log("MTR: AddNoc IpkValue=" + str(IpkValue), 3)
-        # tasmota.log("MTR: AddNoc CaseAdminSubject=" + str(CaseAdminSubject), 3)
-        # tasmota.log("MTR: AddNoc AdminVendorId=" + str(AdminVendorId), 3)
+        # log("MTR: AddNoc NOCValue=" + (NOCValue ? NOCValue.tohex() : ""), 3)
+        # log("MTR: AddNoc ICACValue=" + (ICACValue ? ICACValue.tohex() : ""), 3)
+        # log("MTR: AddNoc IpkValue=" + str(IpkValue), 3)
+        # log("MTR: AddNoc CaseAdminSubject=" + str(CaseAdminSubject), 3)
+        # log("MTR: AddNoc AdminVendorId=" + str(AdminVendorId), 3)
 
         if session.get_temp_ca() == nil
-          tasmota.log("MTR: Error: AdNOC without CA", 2)
+          log("MTR: Error: AdNOC without CA", 2)
           return nil
         end
 
@@ -506,23 +502,23 @@ class Matter_Plugin_Root : Matter_Plugin
         var dnlist = noc_cert.findsub(6)
         var fabric_id = dnlist.findsubval(21)
         var deviceid = dnlist.findsubval(17)
-        # tasmota.log("MTR: AddNoc noc_cert=" + str(noc_cert), 3)
-        # tasmota.log("MTR: AddNoc dnlist=" + str(dnlist), 3)
+        # log("MTR: AddNoc noc_cert=" + str(noc_cert), 3)
+        # log("MTR: AddNoc dnlist=" + str(dnlist), 3)
 
         if !fabric_id || !deviceid
-          tasmota.log("MTR: Error: no fabricid nor deviceid in NOC certificate", 2)
+          log("MTR: Error: no fabricid nor deviceid in NOC certificate", 2)
           return false
         end
         # convert fo bytes(8)
         if type(fabric_id) == 'int' fabric_id = int64.fromu32(fabric_id).tobytes()  else fabric_id = fabric_id.tobytes() end
         if type(deviceid) == 'int'  deviceid = int64.fromu32(deviceid).tobytes()    else deviceid = deviceid.tobytes() end
 
-        # tasmota.log("MTR: AddNoc fabric_id=" + str(fabric_id), 3)
-        # tasmota.log("MTR: AddNoc deviceid=" + str(deviceid), 3)
+        # log("MTR: AddNoc fabric_id=" + str(fabric_id), 3)
+        # log("MTR: AddNoc deviceid=" + str(deviceid), 3)
 
         var root_ca_pub = session.get_temp_ca_pub()
-        # tasmota.log("MTR: AddNoc root_ca_pub=" + str(root_ca_pub), 3)
-        # tasmota.log("MTR: AddNoc root_ca_pub=" + root_ca_pub.tohex(), 3)
+        # log("MTR: AddNoc root_ca_pub=" + str(root_ca_pub), 3)
+        # log("MTR: AddNoc root_ca_pub=" + root_ca_pub.tohex(), 3)
         root_ca_pub = root_ca_pub[1..]            # remove first byte as per Matter specification
         var info = bytes().fromstring("CompressedFabric")   # as per spec, 4.3.2.2 p.99
         var hk = crypto.HKDF_SHA256()
@@ -531,7 +527,7 @@ class Matter_Plugin_Root : Matter_Plugin
         var parent_fabric = session._fabric ? session._fabric : self.device.commissioning_admin_fabric    # get parent fabric whether CASE or PASE
         new_fabric.set_fabric_device(fabric_id, deviceid, k_fabric, parent_fabric)
 
-        # tasmota.log("MTR: AddNoc k_fabric=" + str(k_fabric), 3)
+        # log("MTR: AddNoc k_fabric=" + str(k_fabric), 3)
         # We have a candidate fabric, add it as expirable for 2 minutes
         new_fabric.fabric_candidate()
 
@@ -543,10 +539,10 @@ class Matter_Plugin_Root : Matter_Plugin
           session.set_expire_in_seconds(60)
         end
 
-        # tasmota.log("MTR: ------------------------------------------", 3)
-        # tasmota.log("MTR: session=" + matter.inspect(session), 3)
-        # tasmota.log("MTR: fabric=" + matter.inspect(session._fabric), 3)
-        # tasmota.log("MTR: ------------------------------------------", 3)
+        # log("MTR: ------------------------------------------", 3)
+        # log("MTR: session=" + matter.inspect(session), 3)
+        # log("MTR: fabric=" + matter.inspect(session._fabric), 3)
+        # log("MTR: ------------------------------------------", 3)
         new_fabric.log_new_fabric()        # log that we registered a new fabric
         new_fabric.assign_fabric_index()
         # create NOCResponse
@@ -562,7 +558,7 @@ class Matter_Plugin_Root : Matter_Plugin
       elif command == 0x0009            # ---------- UpdateFabricLabel ----------
         var label = val.findsubval(0)     # Label string max 32
         session.set_fabric_label(label)
-        tasmota.log(format("MTR: .          Update fabric '%s' label='%s'", session._fabric.get_fabric_id().copy().reverse().tohex(), str(label)), 3)
+        log(format("MTR: .          Update fabric '%s' label='%s'", session._fabric.get_fabric_id().copy().reverse().tohex(), str(label)), 3)
         
         # create NOCResponse
         # 0=StatusCode
@@ -580,7 +576,7 @@ class Matter_Plugin_Root : Matter_Plugin
 
         for fab: self.device.sessions.active_fabrics()
           if fab.get_fabric_index() == index
-            # tasmota.log("MTR: removing fabric " + fab.get_fabric_id().copy().reverse().tohex(), 2)
+            # log("MTR: removing fabric " + fab.get_fabric_id().copy().reverse().tohex(), 2)
             # defer actual removal to send a response
             fab.mark_for_deletion()       # this should not appear anymore in the list
             tasmota.set_timer(2000, def () self.device.remove_fabric(fab) end)
@@ -596,7 +592,7 @@ class Matter_Plugin_Root : Matter_Plugin
             return nocr
           end
         end
-        tasmota.log("MTR: RemoveFabric fabric("+str(index)+") not found", 2)
+        log("MTR: RemoveFabric fabric("+str(index)+") not found", 2)
         ctx.status = matter.INVALID_ACTION
         return nil                      # trigger a standalone ack
 
@@ -612,7 +608,7 @@ class Matter_Plugin_Root : Matter_Plugin
         var iterations = val.findsubval(3)          # Iterations u4
         var salt = val.findsubval(4)                # Salt octstr
 
-        tasmota.log(format("MTR: OpenCommissioningWindow(timeout=%i, passcode=%s, discriminator=%i, iterations=%i, salt=%s)",
+        log(format("MTR: OpenCommissioningWindow(timeout=%i, passcode=%s, discriminator=%i, iterations=%i, salt=%s)",
                                   timeout, passcode_verifier.tohex(), discriminator, iterations, salt.tohex()), 4)
 
         # check values
@@ -621,7 +617,7 @@ class Matter_Plugin_Root : Matter_Plugin
           return nil                      # trigger a standalone ack
         end
         if size(passcode_verifier) != 32+65 || size(salt) < 16 || size(salt) > 32
-          tasmota.log("MTR: wrong size for PAKE parameters", 2)
+          log("MTR: wrong size for PAKE parameters", 2)
           ctx.status = matter.CONSTRAINT_ERROR
           return nil                      # trigger a standalone ack
         end
@@ -634,7 +630,7 @@ class Matter_Plugin_Root : Matter_Plugin
         return true                   # OK
       elif command == 0x0001          #  ---------- OpenBasicCommissioningWindow  ----------
         var commissioning_timeout = val.findsubval(0)     # CommissioningTimeout
-        tasmota.log("MTR: OpenBasicCommissioningWindow commissioning_timeout="+str(commissioning_timeout), 3)
+        log("MTR: OpenBasicCommissioningWindow commissioning_timeout="+str(commissioning_timeout), 3)
         self.device.start_root_basic_commissioning(commissioning_timeout)
         return true
       elif command == 0x0002          #  ---------- RevokeCommissioning  ----------

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor_Air_Quality.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor_Air_Quality.be
@@ -135,11 +135,7 @@ class Matter_Plugin_Sensor_Air_Quality : Matter_Plugin_Device
     def handle_value(shadow_value, unit)
       if (unit == nil) unit = 0 end     # default unit is `0` = PPM
       if   attribute == 0x0000          #  ---------- Measured­ Value / float ----------
-        if shadow_value != nil
-          return tlv_solo.set(TLV.FLOAT, shadow_value)
-        else
-          return tlv_solo.set(TLV.NULL, nil)
-        end
+        return tlv_solo.set_or_nil(TLV.FLOAT, shadow_value)
       elif attribute == 0x0001          #  ---------- MinMeasured Value / float ----------
         return tlv_solo.set(TLV.NULL, nil)
       elif attribute == 0x0002          #  ---------- MaxMeasured Value / float ----------
@@ -157,11 +153,7 @@ class Matter_Plugin_Sensor_Air_Quality : Matter_Plugin_Device
     # ====================================================================================================
     if   cluster == 0x005B              # ========== Air Quality ==========
       if   attribute == 0x0000          #  ---------- AirQuality / U8 ----------
-        if self.shadow_air_quality != nil
-          return tlv_solo.set(TLV.U1, self.shadow_air_quality)
-        else
-          return tlv_solo.set(TLV.NULL, nil)
-        end
+        return tlv_solo.set_or_nil(TLV.U1, self.shadow_air_quality)
       # elif attribute == 0xFFFC          #  ---------- FeatureMap / map32 ----------
       #   return tlv_solo.set(TLV.U4, 0)  #
       end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor_Contact.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor_Contact.be
@@ -87,11 +87,7 @@ class Matter_Plugin_Sensor_Contact : Matter_Plugin_Device
     # ====================================================================================================
     if   cluster == 0x0045              # ========== Boolean State ==========
       if   attribute == 0x0000          #  ---------- StateValue / bool ----------
-        if self.shadow_contact != nil
-          return tlv_solo.set(TLV.BOOL, self.shadow_contact)
-        else
-          return tlv_solo.set(TLV.NULL, nil)
-        end
+        return tlv_solo.set_or_nil(TLV.BOOL, self.shadow_contact)
       end
 
     end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor_Occupancy.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor_Occupancy.be
@@ -87,11 +87,7 @@ class Matter_Plugin_Sensor_Occupancy : Matter_Plugin_Device
     # ====================================================================================================
     if   cluster == 0x0406              # ========== Occupancy Sensing ==========
       if   attribute == 0x0000          #  ---------- Occupancy / U8 ----------
-        if self.shadow_occupancy != nil
-          return tlv_solo.set(TLV.U1, self.shadow_occupancy)
-        else
-          return tlv_solo.set(TLV.NULL, nil)
-        end
+        return tlv_solo.set_or_nil(TLV.U1, self.shadow_occupancy)
       elif attribute == 0x0001          #  ---------- OccupancySensorType / enum8 ----------
         return tlv_solo.set(TLV.U1, 3)  # physical contact
       elif attribute == 0x0002          #  ---------- OccupancySensorTypeBitmap / u8 ----------

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Shutter.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Shutter.be
@@ -65,10 +65,10 @@ class Matter_Plugin_Shutter : Matter_Plugin_Device
       if r_st13.contains('StatusSHT')
         r_st13 = r_st13['StatusSHT']        # skip root
         var d = r_st13.find("SHT"+str(self.tasmota_shutter_index), {}).find('Opt')
-        # tasmota.log("MTR: opt: "+str(d))
+        # log("MTR: opt: "+str(d))
         if d != nil
           self.shadow_shutter_inverted = int(d[size(d)-1])  # inverted is at the most right character
-          # tasmota.log("MTR: Inverted flag: "+str(self.shadow_shutter_inverted))
+          # log("MTR: Inverted flag: "+str(self.shadow_shutter_inverted))
         end
       end
     end
@@ -162,7 +162,7 @@ class Matter_Plugin_Shutter : Matter_Plugin_Device
         self.update_shadow()
         return true
       elif command == 0x0005            # ---------- GoToLiftPercentage ----------
-        tasmota.log("MTR: Tilt = "+str(val), 2)
+        log("MTR: Tilt = "+str(val), 2)
         var pos_100 = val.findsubval(0)
         if pos_100 != nil
           pos_100 = pos_100 / 100
@@ -191,7 +191,7 @@ class Matter_Plugin_Shutter : Matter_Plugin_Device
     var k = "Shutter" + str(self.tasmota_shutter_index + 1)
     if payload.contains(k)
       var v = payload[k]
-      # tasmota.log(format("MTR: getting shutter values(%i): %s", self.endpoint, str(v)), 2)
+      # log(format("MTR: getting shutter values(%i): %s", self.endpoint, str(v)), 2)
       # Position
       var val_pos = v.find("Position")
       if val_pos != nil

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Flow.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Flow.be
@@ -62,11 +62,7 @@ class Matter_Plugin_Sensor_Flow : Matter_Plugin_Sensor
     # ====================================================================================================
     if   cluster == 0x0404              # ========== Flow Measurement 2.4 p.98 ==========
       if   attribute == 0x0000          #  ---------- MeasuredValue / i16 ----------
-        if self.shadow_value != nil
-          return tlv_solo.set(TLV.U2, int(self.shadow_value)) # MeasuredValue represents 10 x flow in m3/h.
-        else
-          return tlv_solo.set(TLV.NULL, nil)
-        end
+        return tlv_solo.set_or_nil(TLV.U2, int(self.shadow_value)) # MeasuredValue represents 10 x flow in m3/h.
       elif attribute == 0x0001              #  ---------- MinMeasuredValue / i16 ----------
         return tlv_solo.set(TLV.U2, 0)      # 0 m3/h
       elif attribute == 0x0002              #  ---------- MaxMeasuredValue / i16 ----------

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Humidity.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Humidity.be
@@ -62,11 +62,7 @@ class Matter_Plugin_Sensor_Humidity : Matter_Plugin_Sensor
     # ====================================================================================================
     if   cluster == 0x0405              # ========== Humidity Measurement 2.4 p.98 ==========
       if   attribute == 0x0000          #  ---------- Humidity / u16 ----------
-        if self.shadow_value != nil
-          return tlv_solo.set(TLV.U2, int(self.shadow_value))
-        else
-          return tlv_solo.set(TLV.NULL, nil)
-        end
+        return tlv_solo.set_or_nil(TLV.U2, int(self.shadow_value))
       elif attribute == 0x0001          #  ---------- MinMeasuredValue / u16 ----------
         return tlv_solo.set(TLV.U2, 500)  # 0%
       elif attribute == 0x0002          #  ---------- MaxMeasuredValue / u16 ----------

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Illuminance.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Illuminance.be
@@ -69,11 +69,7 @@ class Matter_Plugin_Sensor_Illuminance : Matter_Plugin_Sensor
     # ====================================================================================================
     if   cluster == 0x0400              # ========== Illuminance Measurement 2.2 p.95 ==========
       if   attribute == 0x0000          #  ---------- MeasuredValue / i16 ----------
-        if self.shadow_value != nil
-          return tlv_solo.set(TLV.U2, int(self.shadow_value))
-        else
-          return tlv_solo.set(TLV.NULL, nil)
-        end
+        return tlv_solo.set_or_nil(TLV.U2, int(self.shadow_value))
       elif attribute == 0x0001          #  ---------- MinMeasuredValue / i16 ----------
         return tlv_solo.set(TLV.U2, 1)  # 1 lux
       elif attribute == 0x0002          #  ---------- MaxMeasuredValue / i16 ----------

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Pressure.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Pressure.be
@@ -62,11 +62,7 @@ class Matter_Plugin_Sensor_Pressure : Matter_Plugin_Sensor
     # ====================================================================================================
     if   cluster == 0x0403              # ========== Pressure Measurement 2.4 p.98 ==========
       if   attribute == 0x0000          #  ---------- MeasuredValue / i16 ----------
-        if self.shadow_value != nil
-          return tlv_solo.set(TLV.I2, int(self.shadow_value))
-        else
-          return tlv_solo.set(TLV.NULL, nil)
-        end
+        return tlv_solo.set_or_nil(TLV.I2, int(self.shadow_value))
       elif attribute == 0x0001          #  ---------- MinMeasuredValue / i16 ----------
         return tlv_solo.set(TLV.I2, 500)  # 500 hPA
       elif attribute == 0x0002          #  ---------- MaxMeasuredValue / i16 ----------

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Temp.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Temp.be
@@ -73,11 +73,7 @@ class Matter_Plugin_Sensor_Temp : Matter_Plugin_Sensor
     # ====================================================================================================
     if   cluster == 0x0402              # ========== Temperature Measurement 2.3 p.97 ==========
       if   attribute == 0x0000          #  ---------- MeasuredValue / i16 (*100) ----------
-        if self.shadow_value != nil
-          return tlv_solo.set(TLV.I2, self.shadow_value)
-        else
-          return tlv_solo.set(TLV.NULL, nil)
-        end
+        return tlv_solo.set_or_nil(TLV.I2, self.shadow_value)
       elif attribute == 0x0001          #  ---------- MinMeasuredValue / i16 (*100) ----------
         return tlv_solo.set(TLV.I2, -5000)  # -50 °C
       elif attribute == 0x0002          #  ---------- MaxMeasuredValue / i16 (*100) ----------

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Profiler.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Profiler.be
@@ -80,14 +80,14 @@ class Matter_Profiler
   def dump(loglevel)
     if !self.active  return end
     self.log("<--end-->")
-    tasmota.log("MTR: Profiler dump:", loglevel)
+    log("MTR: Profiler dump:", loglevel)
     var origin = self.millis[0]
     var allocs0 = self.allocs[0]
     var reallocs0 = self.reallocs[0]
     var idx = 1
     while idx < self.len
-      # tasmota.log(f"MTR:   {self.millis[idx] - origin:4i} [{self.allocs[idx] - allocs0:4i}|{self.reallocs[idx] - reallocs0:4i}]'{self.names[idx]}'", loglevel)
-      tasmota.log(f"MTR:   {self.millis[idx] - origin:4i} [{self.allocs[idx] - allocs0:4i}]'{self.names[idx]}'", loglevel)
+      # log(f"MTR:   {self.millis[idx] - origin:4i} [{self.allocs[idx] - allocs0:4i}|{self.reallocs[idx] - reallocs0:4i}]'{self.names[idx]}'", loglevel)
+      log(f"MTR:   {self.millis[idx] - origin:4i} [{self.allocs[idx] - allocs0:4i}]'{self.names[idx]}'", loglevel)
       idx += 1
     end
   end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Session.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Session.be
@@ -118,7 +118,7 @@ class Matter_Session : Matter_Expirable
   #############################################################
   # Called before removal
   def before_remove()
-    tasmota.log(format("MTR: -Session   (%6i) (removed)", self.local_session_id), 3)
+    log(format("MTR: -Session   (%6i) (removed)", self.local_session_id), 3)
   end
 
   #############################################################
@@ -128,7 +128,7 @@ class Matter_Session : Matter_Expirable
   #
   def counter_snd_next()
     var next = self._counter_snd_impl.next()
-    # tasmota.log(format("MTR: .          Counter_snd=%i", next), 4)
+    # log(format("MTR: .          Counter_snd=%i", next), 4)
     if matter.Counter.is_greater(next, self.counter_snd)
       self.counter_snd = next + self._COUNTER_SND_INCR
       if self.does_persist()

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Session_Store.be
@@ -286,9 +286,9 @@ class Matter_Session_Store
     var sessions = self.sessions
     while i < size(sessions)
       var session = sessions[i]
-      tasmota.log(format("MTR: session.resumption_id=%s vs %s", str(session.resumption_id), str(resumption_id)), 4)
+      log(format("MTR: session.resumption_id=%s vs %s", str(session.resumption_id), str(resumption_id)), 4)
       if session.resumption_id == resumption_id && session.shared_secret != nil
-        # tasmota.log(format("MTR: session.shared_secret=%s", str(session.shared_secret)), 4)
+        # log(format("MTR: session.shared_secret=%s", str(session.shared_secret)), 4)
         session.update()
         return session
       end
@@ -339,13 +339,13 @@ class Matter_Session_Store
       # saving went well, now remove previous version and rename
       path.remove(self._FABRICS)
       if (path.rename(self._FABRICS_TEMP, self._FABRICS))
-        tasmota.log(f"MTR: =Saved     {fabrics_saved} fabric(s) and {sessions_saved} session(s)", 2)
+        log(f"MTR: =Saved     {fabrics_saved} fabric(s) and {sessions_saved} session(s)", 2)
         self.device.event_fabrics_saved()     # signal event
       else
-        tasmota.log(f"MTR: Saving Fabrics failed", 2)
+        log(f"MTR: Saving Fabrics failed", 2)
       end
     except .. as e, m
-      tasmota.log("MTR: Session_Store::save Exception:" + str(e) + "|" + str(m), 2)
+      log("MTR: Session_Store::save Exception:" + str(e) + "|" + str(m), 2)
     end
   end
 
@@ -386,10 +386,10 @@ class Matter_Session_Store
         self.fabrics.push(fabric)
       end
 
-      tasmota.log(format("MTR: Loaded %i fabric(s)", size(self.fabrics)), 2)
+      log(format("MTR: Loaded %i fabric(s)", size(self.fabrics)), 2)
     except .. as e, m
       if e != "io_error"
-        tasmota.log("MTR: Session_Store::load Exception:" + str(e) + "|" + str(m), 2)
+        log("MTR: Session_Store::load Exception:" + str(e) + "|" + str(m), 2)
       end
     end
     # persistables are normally not expiring

--- a/lib/libesp32/berry_matter/src/embedded/Matter_TCP_async.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_TCP_async.be
@@ -81,7 +81,7 @@ class Matter_TCP_async
       end
       return true
     else
-      tasmota.log(format("BRY: failed to resolve [%s]:%i", self.addr, self.port), 3)
+      log(format("BRY: failed to resolve [%s]:%i", self.addr, self.port), 3)
       self.close()
       self.status = -1
       self.tcp_connected = false

--- a/lib/libesp32/berry_matter/src/embedded/Matter_TLV.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_TLV.be
@@ -275,9 +275,9 @@ class Matter_TLV
       elif item_type == TLV.NULL                       # null
         # do nothing
       elif item_type == TLV.EOC
-        tasmota.log("MTR: unexpected eoc", 3)
+        log("MTR: unexpected eoc", 3)
       else
-        tasmota.log("MTR: unexpected type: " + str(item_type), 3)
+        log("MTR: unexpected type: " + str(item_type), 3)
       end
       self.next_idx = idx
       return idx

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UDPServer.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UDPServer.be
@@ -135,9 +135,9 @@ class Matter_UDPServer
       var from_addr = self.udp_socket.remote_ip
       var from_port = self.udp_socket.remote_port
       if tasmota.loglevel(4)
-        tasmota.log(format("MTR: UDP received from [%s]:%i", from_addr, from_port), 4)
+        log(format("MTR: UDP received from [%s]:%i", from_addr, from_port), 4)
       end
-      # tasmota.log("MTR: Perf/UDP_received = " + str(debug.counters()), 4)
+      # log("MTR: Perf/UDP_received = " + str(debug.counters()), 4)
       if self.dispatch_cb
         profiler.log("udp_loop_dispatch")
         self.dispatch_cb(packet, from_addr, from_port)
@@ -165,11 +165,11 @@ class Matter_UDPServer
     
     if ok
       if tasmota.loglevel(4)
-        tasmota.log(format("MTR: sending packet to '[%s]:%i'", packet.addr, packet.port), 4)
+        log(format("MTR: sending packet to '[%s]:%i'", packet.addr, packet.port), 4)
       end
     else
       if tasmota.loglevel(3)
-        tasmota.log(format("MTR: error sending packet to '[%s]:%i'", packet.addr, packet.port), 3)
+        log(format("MTR: error sending packet to '[%s]:%i'", packet.addr, packet.port), 3)
       end
     end
     return ok
@@ -190,14 +190,14 @@ class Matter_UDPServer
       var packet = self.packets_sent[idx]
       if tasmota.time_reached(packet.next_try)
         if packet.retries <= self.RETRIES
-          tasmota.log("MTR: .          Resending packet id=" + str(packet.msg_id), 4)
+          log("MTR: .          Resending packet id=" + str(packet.msg_id), 4)
           self.send(packet)
           packet.next_try = tasmota.millis() + self._backoff_time(packet.retries)
           packet.retries += 1
           idx += 1
         else
           self.packets_sent.remove(idx)
-          tasmota.log(format("MTR: .          (%6i) Unacked packet '[%s]:%i' msg_id=%i", packet.session_id, packet.addr, packet.port, packet.msg_id), 3)
+          log(format("MTR: .          (%6i) Unacked packet '[%s]:%i' msg_id=%i", packet.session_id, packet.addr, packet.port, packet.msg_id), 3)
         end
       else
         idx += 1
@@ -211,14 +211,14 @@ class Matter_UDPServer
     var id = msg.ack_message_counter
     var exch = msg.exchange_id
     if id == nil   return end
-    # tasmota.log("MTR: receveived ACK id="+str(id), 4)
+    # log("MTR: receveived ACK id="+str(id), 4)
     var idx = 0
     while idx < size(self.packets_sent)
       var packet = self.packets_sent[idx]
       if packet.msg_id == id && packet.exchange_id == exch
         self.packets_sent.remove(idx)
         if tasmota.loglevel(4)
-          tasmota.log("MTR: .          Removed packet from sending list id=" + str(id), 4)
+          log("MTR: .          Removed packet from sending list id=" + str(id), 4)
         end
       else
         idx += 1

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -368,7 +368,7 @@ class Matter_UI
       end
     end
     self.device.sort_distinct(remotes)
-    # tasmota.log("MTR: remotes: "+str(remotes), 4)
+    # log("MTR: remotes: "+str(remotes), 4)
 
     for remote: remotes
 
@@ -642,7 +642,7 @@ class Matter_UI
     end
     
     if status10 != nil && status11 != nil
-      tasmota.log(format("MTR: probed '%s' status10=%s satus11=%s", url, str(status10), str(status11)), 3)
+      log(format("MTR: probed '%s' status10=%s satus11=%s", url, str(status10), str(status11)), 3)
 
       var config_list = self.generate_config_from_status(status10, status11)
 
@@ -752,14 +752,14 @@ class Matter_UI
 
       # debug information about parameters
       # for i:0..webserver.arg_size()-1
-      #   tasmota.log(format("MTR: Arg%i '%s' = '%s'", i, webserver.arg_name(i), webserver.arg(i)))
+      #   log(format("MTR: Arg%i '%s' = '%s'", i, webserver.arg_name(i), webserver.arg(i)))
       # end
 
       #---------------------------------------------------------------------#
       # Change Passcode and/or Passcode
       #---------------------------------------------------------------------#
       if webserver.has_arg("passcode") || webserver.has_arg("discriminator")
-        tasmota.log(format("MTR: /matterc received '%s' command", 'passcode'), 3)
+        log(format("MTR: /matterc received '%s' command", 'passcode'), 3)
         if webserver.has_arg("passcode")
           self.device.root_passcode = int(webserver.arg("passcode"))
         end
@@ -783,10 +783,10 @@ class Matter_UI
 
         if matter_enabled_requested != self.matter_enabled()
           if matter_enabled_requested
-            tasmota.log(format("MTR: /matterc received '%s' command", 'enable'), 3)
+            log(format("MTR: /matterc received '%s' command", 'enable'), 3)
             tasmota.cmd("SetOption" + str(matter.MATTER_OPTION) + " 1")
           else
-            tasmota.log(format("MTR: /matterc received '%s' command", 'disable'), 3)
+            log(format("MTR: /matterc received '%s' command", 'disable'), 3)
             tasmota.cmd("SetOption" + str(matter.MATTER_OPTION) + " 0")
           end
           #- and force restart -#
@@ -808,7 +808,7 @@ class Matter_UI
       # Delete Fabric
       #---------------------------------------------------------------------#
       elif webserver.has_arg("del_fabric")
-        tasmota.log(format("MTR: /matterc received '%s' command", 'del_fabric'), 3)
+        log(format("MTR: /matterc received '%s' command", 'del_fabric'), 3)
         var del_fabric = int(webserver.arg("del_fabric"))
         var idx = 0
         var fabrics = self.device.sessions.fabrics
@@ -827,7 +827,7 @@ class Matter_UI
       # Reset to default auto-configuration
       #---------------------------------------------------------------------#
       elif webserver.has_arg("auto")
-        tasmota.log(format("MTR: /matterc received '%s' command", 'auto'), 3)
+        log(format("MTR: /matterc received '%s' command", 'auto'), 3)
         self.device.plugins_persist = false
         self.device.save_param()
         #- and force restart -#
@@ -837,7 +837,7 @@ class Matter_UI
       # Apply new configuration template
       #---------------------------------------------------------------------#
       elif webserver.has_arg("config")
-        tasmota.log(format("MTR: /matterc received '%s' command", 'config'), 3)
+        log(format("MTR: /matterc received '%s' command", 'config'), 3)
         var needs_saving = false
         # iterate by endpoint number
         for i:0..webserver.arg_size()-1
@@ -851,25 +851,25 @@ class Matter_UI
             if conf_ep != nil     # found
               var typ_class = self.device.plugins_classes.find(conf_ep.find('type', ''))
               if typ_class != nil
-                tasmota.log(format("MTR: ep=%i arg=%s", arg_ep, arg), 3)
+                log(format("MTR: ep=%i arg=%s", arg_ep, arg), 3)
                 # compute the actual value
                 var prev_arg = typ_class.ui_conf_to_string(typ_class, conf_ep)
                 var changed = (prev_arg != arg)
-                tasmota.log(format("MTR: ep=%i prev_arg='%s' arg='%s' %s", arg_ep, prev_arg, arg, prev_arg != arg ? "changed" : ""), 3)
+                log(format("MTR: ep=%i prev_arg='%s' arg='%s' %s", arg_ep, prev_arg, arg, prev_arg != arg ? "changed" : ""), 3)
 
                 if changed
                   needs_saving = true
                   typ_class.ui_string_to_conf(typ_class, conf_ep, arg)
                   var pl = self.device.find_plugin_by_endpoint(arg_ep)
                   if pl
-                    tasmota.log(format("MTR: apply conf '%s' (%i) to %s", conf_ep, arg_ep, pl), 3)
+                    log(format("MTR: apply conf '%s' (%i) to %s", conf_ep, arg_ep, pl), 3)
                     pl.parse_configuration(conf_ep)
                   end
                 end
 
               end
             else            
-              tasmota.log(format("MTR: ep=%i not found", arg_ep), 3)
+              log(format("MTR: ep=%i not found", arg_ep), 3)
             end
           elif string.find(arg_name, "nam") == 0    # 'nam<i>' with i being the endpoint
             var nam_ep = int(arg_name[3..])         # target endpoint as int
@@ -891,7 +891,7 @@ class Matter_UI
                   else
                     conf_ep.remove('name')
                   end
-                  tasmota.log(format("MTR: apply name '%s' (%i) to %s", conf_ep, nam_ep, pl), 3)
+                  log(format("MTR: apply name '%s' (%i) to %s", conf_ep, nam_ep, pl), 3)
                   pl.parse_configuration(conf_ep)
                 end
               end
@@ -899,10 +899,10 @@ class Matter_UI
           end
         end
 
-        tasmota.log(format("MTR: config = %s", str(self.device.plugins_config)), 3)
+        log(format("MTR: config = %s", str(self.device.plugins_config)), 3)
 
         if error
-          tasmota.log(format("MTR: config error = %s", error), 3)
+          log(format("MTR: config error = %s", error), 3)
         else
           if needs_saving || !self.device.plugins_persist
             self.device.plugins_persist = true
@@ -918,7 +918,7 @@ class Matter_UI
         var typ = webserver.arg('pi')
         var arg = webserver.arg('arg')
         var nam = webserver.arg('nam')
-        tasmota.log(format("MTR: add endpoint typ='%s' arg='%s'", typ, arg), 3)
+        log(format("MTR: add endpoint typ='%s' arg='%s'", typ, arg), 3)
 
         # check if type exists
         var typ_class = self.device.plugins_classes.find(typ)
@@ -958,12 +958,12 @@ class Matter_UI
               # check if configuration is already present
               var duplicate = false
               for c: self.device.plugins_config   # iterate on values, not on keys()
-                # tasmota.log(format("MTR: map_compare '%s' ?= '%s' -> %s", str(c), str(config), str(self.equal_map(c,config))), 3)
+                # log(format("MTR: map_compare '%s' ?= '%s' -> %s", str(c), str(config), str(self.equal_map(c,config))), 3)
                 if self.equal_map(c,config)   duplicate = true  break   end
               end
               # not a duplicate, add it
               if !duplicate
-                tasmota.log(format("MTR: remote add url='%s' type='%s' arg='%s'", url, typ, arg), 3)
+                log(format("MTR: remote add url='%s' type='%s' arg='%s'", url, typ, arg), 3)
                 self.device.bridge_add_endpoint(typ, config)
               end
             end
@@ -1004,7 +1004,7 @@ class Matter_UI
       end
 
     except .. as e, m
-      tasmota.log(format("BRY: Exception> '%s' - %s", e, m), 2)
+      log(format("BRY: Exception> '%s' - %s", e, m), 2)
       #- display error page -#
       webserver.content_start("Parameter error")           #- title of the web page -#
       webserver.content_send_style()                  #- send standard Tasmota styles -#

--- a/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
@@ -162,7 +162,7 @@ class Matter_Device
 
     # show Manual pairing code in logs
     var pairing_code = self.compute_manual_pairing_code()
-    tasmota.log(format("MTR: Manual pairing code: %s", pairing_code), 2)
+    log(format("MTR: Manual pairing code: %s", pairing_code), 2)
     
     # output MQTT
     var qr_code = self.compute_qrcode_content()
@@ -177,7 +177,7 @@ class Matter_Device
   # Remove a fabric and clean all corresponding values and mDNS entries
   def remove_fabric(fabric)
     if fabric != nil
-      tasmota.log("MTR: removing fabric " + fabric.get_fabric_id().copy().reverse().tohex(), 2)
+      log("MTR: removing fabric " + fabric.get_fabric_id().copy().reverse().tohex(), 2)
       self.message_handler.im.subs_shop.remove_by_fabric(fabric)
       self.mdns_remove_op_discovery(fabric)
       self.sessions.remove_fabric(fabric)
@@ -187,7 +187,7 @@ class Matter_Device
     # for fabric_index : sub_fabrics
     #   var fabric = self.sessions.find_fabric_by_index(fabric_index)
     #   if fabric != nil
-    #     tasmota.log("MTR: removing fabric " + fabric.get_fabric_id().copy().reverse().tohex(), 2)
+    #     log("MTR: removing fabric " + fabric.get_fabric_id().copy().reverse().tohex(), 2)
     #     self.message_handler.im.subs_shop.remove_by_fabric(fabric)
     #     self.mdns_remove_op_discovery(fabric)
     #     self.sessions.remove_fabric(fabric)
@@ -266,12 +266,12 @@ class Matter_Device
     # self.root_w1 = crypto.EC_P256().mod(w1s)
     self.root_L = crypto.EC_P256().public_key(w1)
 
-    # tasmota.log("MTR: ******************************", 4)
-    # tasmota.log("MTR: salt          = " + self.root_salt.tohex(), 4)
-    # tasmota.log("MTR: passcode_hex  = " + passcode.tohex(), 4)
-    # tasmota.log("MTR: w0            = " + self.root_w0.tohex(), 4)
-    # tasmota.log("MTR: L             = " + self.root_L.tohex(), 4)
-    # tasmota.log("MTR: ******************************", 4)
+    # log("MTR: ******************************", 4)
+    # log("MTR: salt          = " + self.root_salt.tohex(), 4)
+    # log("MTR: passcode_hex  = " + passcode.tohex(), 4)
+    # log("MTR: w0            = " + self.root_w0.tohex(), 4)
+    # log("MTR: L             = " + self.root_L.tohex(), 4)
+    # log("MTR: ******************************", 4)
   end
 
   #############################################################
@@ -356,7 +356,7 @@ class Matter_Device
     import json
     var rs_json = tasmota.read_sensors()
     if tasmota.loglevel(3)
-      tasmota.log("MTR: read_sensors: "+str(rs_json), 3)
+      log("MTR: read_sensors: "+str(rs_json), 3)
     end
     if rs_json == nil   return  end
     var rs = json.load(rs_json)
@@ -370,7 +370,7 @@ class Matter_Device
       end
 
     else
-      tasmota.log("MTR: unable to parse read_sensors: "+str(rs_json), 3)
+      log("MTR: unable to parse read_sensors: "+str(rs_json), 3)
     end
 
   end
@@ -413,7 +413,7 @@ class Matter_Device
   def _start_udp(port)
     if self.udp_server    return end        # already started
     if port == nil      port = 5540 end
-    tasmota.log("MTR: Starting UDP server on port: " + str(port), 2)
+    log("MTR: Starting UDP server on port: " + str(port), 2)
     self.udp_server = matter.UDPServer(self, "", port)
     self.udp_server.start(/ raw, addr, port -> self.msg_received(raw, addr, port))
   end
@@ -462,7 +462,7 @@ class Matter_Device
     var fabric = session.get_fabric()
     var fabric_id = fabric.get_fabric_id().copy().reverse().tohex()
     var vendor_name = fabric.get_admin_vendor_name()
-    tasmota.log(f"MTR: --- Commissioning complete for Fabric '{fabric_id}' (Vendor {vendor_name}) ---", 2)
+    log(f"MTR: --- Commissioning complete for Fabric '{fabric_id}' (Vendor {vendor_name}) ---", 2)
     self.stop_basic_commissioning()     # by default close commissioning when it's complete
   end
 
@@ -532,7 +532,7 @@ class Matter_Device
 
     var direct = (ctx.endpoint != nil) && (ctx.cluster != nil) && (ctx.attribute != nil) # true if the target is a precise attribute, false if it results from an expansion and error are ignored
 
-    # tasmota.log(f"MTR: process_attribute_expansion {str(ctx))}", 4)
+    # log(f"MTR: process_attribute_expansion {str(ctx))}", 4)
 
     # build the generator for all endpoint/cluster/attributes candidates
     var path_generator = matter.PathGenerator(self)
@@ -662,10 +662,10 @@ class Matter_Device
       var f = open(self.FILENAME, "w")
       f.write(j)
       f.close()
-      tasmota.log(format("MTR: =Saved     parameters%s", self.plugins_persist ? " and configuration" : ""), 2)
+      log(format("MTR: =Saved     parameters%s", self.plugins_persist ? " and configuration" : ""), 2)
       return j
     except .. as e, m
-      tasmota.log("MTR: Session_Store::save Exception:" + str(e) + "|" + str(m), 2)
+      log("MTR: Session_Store::save Exception:" + str(e) + "|" + str(m), 2)
       return j
     end
   end
@@ -718,18 +718,18 @@ class Matter_Device
       self.next_ep = j.find("nextep", self.next_ep)
       self.plugins_config = j.find("config")
       if self.plugins_config != nil
-        tasmota.log(f"MTR: Load_config = {self.plugins_config}", 3)
+        log(f"MTR: Load_config = {self.plugins_config}", 3)
         self.adjust_next_ep()
         dirty = self.check_config_ep()
         self.plugins_persist = true
       end
       self.plugins_config_remotes = j.find("remotes", {})
       if self.plugins_config_remotes
-        tasmota.log("MTR: load_remotes = " + str(self.plugins_config_remotes), 3)
+        log("MTR: load_remotes = " + str(self.plugins_config_remotes), 3)
       end
     except .. as e, m
       if e != "io_error"
-        tasmota.log("MTR: load_param Exception:" + str(e) + "|" + str(m), 2)
+        log("MTR: load_param Exception:" + str(e) + "|" + str(m), 2)
       end
     end
 
@@ -763,35 +763,35 @@ class Matter_Device
   #   {'32': {'filter': 'AXP192#Temperature', 'type': 'temperature'}, '40': {'filter': 'BMP280#Pressure', 'type': 'pressure'}, '34': {'filter': 'SHT3X#Temperature', 'type': 'temperature'}, '33': {'filter': 'BMP280#Temperature', 'type': 'temperature'}, '1': {'relay': 0, 'type': 'relay'}, '56': {'filter': 'SHT3X#Humidity', 'type': 'humidity'}, '0': {'type': 'root'}}
   def _instantiate_plugins_from_config(config)
     var endpoints = self.k2l_num(config)
-    # tasmota.log("MTR: endpoints to be configured "+str(endpoints), 4)
-    tasmota.log("MTR: Configuring endpoints", 2)
+    # log("MTR: endpoints to be configured "+str(endpoints), 4)
+    log("MTR: Configuring endpoints", 2)
 
     # start with mandatory endpoint 0 for root node
     self.plugins.push(matter.Plugin_Root(self, 0, {}))
-    tasmota.log(format("MTR:   endpoint = %5i type:%s%s", 0, 'root', ''), 2)
+    log(format("MTR:   endpoint = %5i type:%s%s", 0, 'root', ''), 2)
 
     # always include an aggregator for dynamic endpoints
     self.plugins.push(matter.Plugin_Aggregator(self, matter.AGGREGATOR_ENDPOINT, {}))
-    tasmota.log(format("MTR:   endpoint = %5i type:%s%s", matter.AGGREGATOR_ENDPOINT, 'aggregator', ''), 2)
+    log(format("MTR:   endpoint = %5i type:%s%s", matter.AGGREGATOR_ENDPOINT, 'aggregator', ''), 2)
 
     for ep: endpoints
       if ep == 0  continue end          # skip endpoint 0
       try
         var plugin_conf = config[str(ep)]
-        # tasmota.log(format("MTR: endpoint %i config %s", ep, plugin_conf), 3)
+        # log(format("MTR: endpoint %i config %s", ep, plugin_conf), 3)
 
         var pi_class_name = plugin_conf.find('type')
-        if pi_class_name == nil   tasmota.log("MTR: no class name, skipping", 3)  continue end
-        if pi_class_name == 'root'  tasmota.log("MTR: only one root node allowed", 3)  continue end
+        if pi_class_name == nil   log("MTR: no class name, skipping", 3)  continue end
+        if pi_class_name == 'root'  log("MTR: only one root node allowed", 3)  continue end
         var pi_class = self.plugins_classes.find(pi_class_name)
-        if pi_class == nil        tasmota.log("MTR: unknown class name '"+str(pi_class_name)+"' skipping", 2)  continue  end
+        if pi_class == nil        log("MTR: unknown class name '"+str(pi_class_name)+"' skipping", 2)  continue  end
 
         var pi = pi_class(self, ep, plugin_conf)
         self.plugins.push(pi)
 
-        tasmota.log(format("MTR:   endpoint = %5i type:%s%s", ep, pi_class_name, self.conf_to_log(plugin_conf)), 2)
+        log(format("MTR:   endpoint = %5i type:%s%s", ep, pi_class_name, self.conf_to_log(plugin_conf)), 2)
       except .. as e, m
-        tasmota.log("MTR: Exception" + str(e) + "|" + str(m), 2)
+        log("MTR: Exception" + str(e) + "|" + str(m), 2)
       end
     end
 
@@ -863,26 +863,26 @@ class Matter_Device
         var eth = tasmota.eth()
         self.hostname_eth  = string.replace(eth.find("mac"), ':', '')
         if !self.ipv4only || !eth.contains('ip6local')
-          # tasmota.log(format("MTR: calling mdns.add_hostname(%s, %s, %s)", self.hostname_eth, eth.find('ip6local',''), eth.find('ip','')), 4)
+          # log(format("MTR: calling mdns.add_hostname(%s, %s, %s)", self.hostname_eth, eth.find('ip6local',''), eth.find('ip','')), 4)
           mdns.add_hostname(self.hostname_eth, eth.find('ip6local',''), eth.find('ip',''), eth.find('ip6',''))
         else
-          tasmota.log(format("MTR: calling mdns.add_hostname(%s, %s)", self.hostname_eth, eth.find('ip','')), 3)
+          log(format("MTR: calling mdns.add_hostname(%s, %s)", self.hostname_eth, eth.find('ip','')), 3)
           mdns.add_hostname(self.hostname_eth, eth.find('ip',''))
         end
       else
         var wifi = tasmota.wifi()
         self.hostname_wifi = string.replace(wifi.find("mac"), ':', '')
         if !self.ipv4only || !wifi.contains('ip6local')
-          # tasmota.log(format("MTR: calling mdns.add_hostname(%s, %s, %s)", self.hostname_wifi, wifi.find('ip6local',''), wifi.find('ip','')), 4)
+          # log(format("MTR: calling mdns.add_hostname(%s, %s, %s)", self.hostname_wifi, wifi.find('ip6local',''), wifi.find('ip','')), 4)
           mdns.add_hostname(self.hostname_wifi, wifi.find('ip6local',''), wifi.find('ip',''), wifi.find('ip6',''))
         else
-          tasmota.log(format("MTR: calling mdns.add_hostname(%s, %s)", self.hostname_wifi, wifi.find('ip','')), 3)
+          log(format("MTR: calling mdns.add_hostname(%s, %s)", self.hostname_wifi, wifi.find('ip','')), 3)
           mdns.add_hostname(self.hostname_wifi, wifi.find('ip',''))
         end
       end
-      tasmota.log(format("MTR: start mDNS on %s host '%s.local'", is_eth ? "eth" : "wifi", is_eth ? self.hostname_eth : self.hostname_wifi), 3)
+      log(format("MTR: start mDNS on %s host '%s.local'", is_eth ? "eth" : "wifi", is_eth ? self.hostname_eth : self.hostname_wifi), 3)
     except .. as e, m
-      tasmota.log("MTR: Exception" + str(e) + "|" + str(m), 2)
+      log("MTR: Exception" + str(e) + "|" + str(m), 2)
     end
 
     self.mdns_announce_op_discovery_all_fabrics()
@@ -908,50 +908,50 @@ class Matter_Device
     try
       if self.hostname_eth
         # Add Matter `_matterc._udp` service
-        # tasmota.log(format("MTR: calling mdns.add_service(%s, %s, %i, %s, %s, %s)", "_matterc", "_udp", 5540, str(services), self.commissioning_instance_eth, self.hostname_eth), 4)
+        # log(format("MTR: calling mdns.add_service(%s, %s, %i, %s, %s, %s)", "_matterc", "_udp", 5540, str(services), self.commissioning_instance_eth, self.hostname_eth), 4)
         mdns.add_service("_matterc", "_udp", 5540, services, self.commissioning_instance_eth, self.hostname_eth)
         self.mdns_pase_eth = true
 
-        tasmota.log(format("MTR: announce mDNS on %s '%s' ptr to `%s.local`", "eth", self.commissioning_instance_eth, self.hostname_eth), 2)
+        log(format("MTR: announce mDNS on %s '%s' ptr to `%s.local`", "eth", self.commissioning_instance_eth, self.hostname_eth), 2)
 
         # `mdns.add_subtype(service:string, proto:string, instance:string, hostname:string, subtype:string) -> nil`
         var subtype = "_L" + str(self.commissioning_discriminator & 0xFFF)
-        tasmota.log("MTR: adding subtype: "+subtype, 3)
+        log("MTR: adding subtype: "+subtype, 3)
         mdns.add_subtype("_matterc", "_udp", self.commissioning_instance_eth, self.hostname_eth, subtype)
         subtype = "_S" + str((self.commissioning_discriminator & 0xF00) >> 8)
-        tasmota.log("MTR: adding subtype: "+subtype, 3)
+        log("MTR: adding subtype: "+subtype, 3)
         mdns.add_subtype("_matterc", "_udp", self.commissioning_instance_eth, self.hostname_eth, subtype)
         subtype = "_V" + str(self.vendorid)
-        tasmota.log("MTR: adding subtype: "+subtype, 3)
+        log("MTR: adding subtype: "+subtype, 3)
         mdns.add_subtype("_matterc", "_udp", self.commissioning_instance_eth, self.hostname_eth, subtype)
         subtype = "_CM1"
-        tasmota.log("MTR: adding subtype: "+subtype, 3)
+        log("MTR: adding subtype: "+subtype, 3)
         mdns.add_subtype("_matterc", "_udp", self.commissioning_instance_eth, self.hostname_eth, subtype)
       end
       if self.hostname_wifi
 
-        # tasmota.log(format("MTR: calling mdns.add_service(%s, %s, %i, %s, %s, %s)", "_matterc", "_udp", 5540, str(services), self.commissioning_instance_wifi, self.hostname_wifi), 4)
+        # log(format("MTR: calling mdns.add_service(%s, %s, %i, %s, %s, %s)", "_matterc", "_udp", 5540, str(services), self.commissioning_instance_wifi, self.hostname_wifi), 4)
         mdns.add_service("_matterc", "_udp", 5540, services, self.commissioning_instance_wifi, self.hostname_wifi)
         self.mdns_pase_wifi = true
 
-        tasmota.log(format("MTR: starting mDNS on %s '%s' ptr to `%s.local`", "wifi", self.commissioning_instance_wifi, self.hostname_wifi), 3)
+        log(format("MTR: starting mDNS on %s '%s' ptr to `%s.local`", "wifi", self.commissioning_instance_wifi, self.hostname_wifi), 3)
 
         # `mdns.add_subtype(service:string, proto:string, instance:string, hostname:string, subtype:string) -> nil`
         var subtype = "_L" + str(self.commissioning_discriminator & 0xFFF)
-        tasmota.log("MTR: adding subtype: "+subtype, 3)
+        log("MTR: adding subtype: "+subtype, 3)
         mdns.add_subtype("_matterc", "_udp", self.commissioning_instance_wifi, self.hostname_wifi, subtype)
         subtype = "_S" + str((self.commissioning_discriminator & 0xF00) >> 8)
-        tasmota.log("MTR: adding subtype: "+subtype, 3)
+        log("MTR: adding subtype: "+subtype, 3)
         mdns.add_subtype("_matterc", "_udp", self.commissioning_instance_wifi, self.hostname_wifi, subtype)
         subtype = "_V" + str(self.vendorid)
-        tasmota.log("MTR: adding subtype: "+subtype, 3)
+        log("MTR: adding subtype: "+subtype, 3)
         mdns.add_subtype("_matterc", "_udp", self.commissioning_instance_wifi, self.hostname_wifi, subtype)
         subtype = "_CM1"
-        tasmota.log("MTR: adding subtype: "+subtype, 3)
+        log("MTR: adding subtype: "+subtype, 3)
         mdns.add_subtype("_matterc", "_udp", self.commissioning_instance_wifi, self.hostname_wifi, subtype)
       end
     except .. as e, m
-      tasmota.log("MTR: Exception" + str(e) + "|" + str(m), 2)
+      log("MTR: Exception" + str(e) + "|" + str(m), 2)
     end
 
   end
@@ -963,19 +963,19 @@ class Matter_Device
 
     try
       if self.mdns_pase_eth
-        tasmota.log(format("MTR: calling mdns.remove_service(%s, %s, %s, %s)", "_matterc", "_udp", self.commissioning_instance_eth, self.hostname_eth), 3)
-        tasmota.log(format("MTR: remove mDNS on %s '%s'", "eth", self.commissioning_instance_eth), 3)
+        log(format("MTR: calling mdns.remove_service(%s, %s, %s, %s)", "_matterc", "_udp", self.commissioning_instance_eth, self.hostname_eth), 3)
+        log(format("MTR: remove mDNS on %s '%s'", "eth", self.commissioning_instance_eth), 3)
         self.mdns_pase_eth = false
         mdns.remove_service("_matterc", "_udp", self.commissioning_instance_eth, self.hostname_eth)
       end
       if self.mdns_pase_wifi
-        tasmota.log(format("MTR: calling mdns.remove_service(%s, %s, %s, %s)", "_matterc", "_udp", self.commissioning_instance_wifi, self.hostname_wifi), 3)
-        tasmota.log(format("MTR: remove mDNS on %s '%s'", "wifi", self.commissioning_instance_wifi), 3)
+        log(format("MTR: calling mdns.remove_service(%s, %s, %s, %s)", "_matterc", "_udp", self.commissioning_instance_wifi, self.hostname_wifi), 3)
+        log(format("MTR: remove mDNS on %s '%s'", "wifi", self.commissioning_instance_wifi), 3)
         self.mdns_pase_wifi = false
         mdns.remove_service("_matterc", "_udp", self.commissioning_instance_wifi, self.hostname_wifi)
       end
     except .. as e, m
-      tasmota.log("MTR: Exception" + str(e) + "|" + str(m), 2)
+      log("MTR: Exception" + str(e) + "|" + str(m), 2)
     end
   end
 
@@ -997,25 +997,25 @@ class Matter_Device
       var device_id = fabric.get_device_id().copy().reverse()
       var k_fabric = fabric.get_fabric_compressed()
       var op_node = k_fabric.tohex() + "-" + device_id.tohex()
-      tasmota.log("MTR: Operational Discovery node = " + op_node, 3)
+      log("MTR: Operational Discovery node = " + op_node, 3)
 
       # mdns
       if (tasmota.eth().find("up"))
-        tasmota.log(format("MTR: adding mDNS on %s '%s' ptr to `%s.local`", "eth", op_node, self.hostname_eth), 3)
+        log(format("MTR: adding mDNS on %s '%s' ptr to `%s.local`", "eth", op_node, self.hostname_eth), 3)
         mdns.add_service("_matter","_tcp", 5540, nil, op_node, self.hostname_eth)
         var subtype = "_I" + k_fabric.tohex()
-        tasmota.log("MTR: adding subtype: "+subtype, 3)
+        log("MTR: adding subtype: "+subtype, 3)
         mdns.add_subtype("_matter", "_tcp", op_node, self.hostname_eth, subtype)
       end
       if (tasmota.wifi().find("up"))
-        tasmota.log(format("MTR: adding mDNS on %s '%s' ptr to `%s.local`", "wifi", op_node, self.hostname_wifi), 3)
+        log(format("MTR: adding mDNS on %s '%s' ptr to `%s.local`", "wifi", op_node, self.hostname_wifi), 3)
         mdns.add_service("_matter","_tcp", 5540, nil, op_node, self.hostname_wifi)
         var subtype = "_I" + k_fabric.tohex()
-        tasmota.log("MTR: adding subtype: "+subtype, 3)
+        log("MTR: adding subtype: "+subtype, 3)
         mdns.add_subtype("_matter", "_tcp", op_node, self.hostname_wifi, subtype)
       end
     except .. as e, m
-      tasmota.log("MTR: Exception" + str(e) + "|" + str(m), 2)
+      log("MTR: Exception" + str(e) + "|" + str(m), 2)
     end
   end
 
@@ -1040,15 +1040,15 @@ class Matter_Device
 
       # mdns
       if (tasmota.eth().find("up"))
-        tasmota.log(format("MTR: remove mDNS on %s '%s'", "eth", op_node), 3)
+        log(format("MTR: remove mDNS on %s '%s'", "eth", op_node), 3)
         mdns.remove_service("_matter", "_tcp", op_node, self.hostname_eth)
       end
       if (tasmota.wifi().find("up"))
-        tasmota.log(format("MTR: remove mDNS on %s '%s'", "wifi", op_node), 3)
+        log(format("MTR: remove mDNS on %s '%s'", "wifi", op_node), 3)
         mdns.remove_service("_matter", "_tcp", op_node, self.hostname_wifi)
       end
     except .. as e, m
-      tasmota.log("MTR: Exception" + str(e) + "|" + str(m), 2)
+      log("MTR: Exception" + str(e) + "|" + str(m), 2)
     end
   end
 
@@ -1075,7 +1075,7 @@ class Matter_Device
       self.plugins_config = self.autoconf_device_map()
       self.plugins_config_remotes = {}
       self.adjust_next_ep()
-      tasmota.log("MTR: autoconfig = " + str(self.plugins_config), 3)
+      log("MTR: autoconfig = " + str(self.plugins_config), 3)
     end
     self._instantiate_plugins_from_config(self.plugins_config)
 
@@ -1117,7 +1117,7 @@ class Matter_Device
     # handle shutters before relays (as we steal relays for shutters)
     var r_st13 = tasmota.cmd("Status 13", true)     # issue `Status 13`
     var relays_reserved = []                        # list of relays that are used for non-relay (shutters)
-    tasmota.log("MTR: Status 13 = "+str(r_st13), 3)
+    log("MTR: Status 13 = "+str(r_st13), 3)
 
     if r_st13 != nil && r_st13.contains('StatusSHT')
       r_st13 = r_st13['StatusSHT']        # skip root
@@ -1127,14 +1127,14 @@ class Matter_Device
         var k = 'SHT' + str(idx)                    # SHT is zero based
         if !r_st13.contains(k)   break     end           # no more SHTxxx
         var d = r_st13[k]
-        tasmota.log(format("MTR: '%s' = %s", k, str(d)), 3)
+        log(format("MTR: '%s' = %s", k, str(d)), 3)
         var relay1 = d.find('Relay1', -1)           # relay base 1 or -1 if none
         var relay2 = d.find('Relay2', -1)           # relay base 1 or -1 if none
 
         if relay1 > 0    relays_reserved.push(relay1 - 1)    end   # mark relay1/2 as non-relays
         if relay2 > 0    relays_reserved.push(relay2 - 1)    end
 
-        tasmota.log(f"MTR: {relay1=} {relay2=}", 3)
+        log(f"MTR: {relay1=} {relay2=}", 3)
         # is there tilt support
         var tilt_array = d.find('TiltConfig')
         var tilt_config = tilt_array && (tilt_array[2] > 0)
@@ -1258,7 +1258,7 @@ class Matter_Device
   # returns endpoint number newly allocated, or `nil` if failed
   def bridge_add_endpoint(pi_class_name, plugin_conf)
     var pi_class = self.plugins_classes.find(pi_class_name)
-    if pi_class == nil        tasmota.log("MTR: unknown class name '"+str(pi_class_name)+"' skipping", 3)  return  end
+    if pi_class == nil        log("MTR: unknown class name '"+str(pi_class_name)+"' skipping", 3)  return  end
 
     # get the next allocated endpoint number
     var ep = self.next_ep
@@ -1275,7 +1275,7 @@ class Matter_Device
       pi_conf[k] = plugin_conf[k]
     end
     # add to main
-    tasmota.log(format("MTR: adding endpoint = %i type:%s%s", ep, pi_class_name, self.conf_to_log(plugin_conf)), 2)
+    log(format("MTR: adding endpoint = %i type:%s%s", ep, pi_class_name, self.conf_to_log(plugin_conf)), 2)
     self.plugins_config[ep_str] = pi_conf
     self.plugins_persist = true
     self.next_ep += 1     # increment next allocated endpoint before saving
@@ -1298,10 +1298,10 @@ class Matter_Device
     var f_in
 
     if !self.plugins_config.contains(ep_str)
-      tasmota.log("MTR: Cannot remove an enpoint not configured: " + ep_str, 3)
+      log("MTR: Cannot remove an enpoint not configured: " + ep_str, 3)
       return
     end
-    tasmota.log(format("MTR: deleting endpoint = %i", ep), 2)
+    log(format("MTR: deleting endpoint = %i", ep), 2)
     self.plugins_config.remove(ep_str)
     self.plugins_persist = true
 
@@ -1344,12 +1344,12 @@ class Matter_Device
     for k: self.plugins_config.keys()   keys.push(int(k))    end
     for ep: keys
       if ep == 0
-        tasmota.log("MTR: invalid entry with ep '0'", 2)
+        log("MTR: invalid entry with ep '0'", 2)
         self.plugins_config.remove(str(ep))
         dirty = true
       elif ep == matter.AGGREGATOR_ENDPOINT
         dirty = true
-        tasmota.log(f"MTR: endpoint {ep} collides wit aggregator, relocating to {self.next_ep}", 2)
+        log(f"MTR: endpoint {ep} collides wit aggregator, relocating to {self.next_ep}", 2)
         self.plugins_config[str(self.next_ep)] = self.plugins_config[str(ep)]
         self.plugins_config.remove(str(ep))
         self.next_ep += 1
@@ -1450,7 +1450,7 @@ class Matter_Device
 
       # print("remotes_map2", remotes_map)
 
-      # tasmota.log("MTR: remotes references: " + str(remotes_map), 3)
+      # log("MTR: remotes references: " + str(remotes_map), 3)
 
       var remote_to_remove = []           # we first get the list of remotes to remove, to not interfere with map iterator
       for remote:remotes_map.keys()
@@ -1460,7 +1460,7 @@ class Matter_Device
       end
 
       for remote: remote_to_remove
-        tasmota.log("MTR: remove unused remote: " + remote.addr, 3)
+        log("MTR: remove unused remote: " + remote.addr, 3)
         remote.close()
         self.http_remotes.remove(remote.addr)
       end

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
@@ -12,7 +12,7 @@ extern const bclass be_class_Matter_Commisioning_Context;
 extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_parse_StatusReport,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -20,34 +20,32 @@ be_local_closure(class_Matter_Commisioning_Context_parse_StatusReport,   /* name
     0,                          /* has sup protos */
     &be_class_Matter_Commisioning_Context, 
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20),
-    /* K4   */  be_nested_str_weak(raw),
-    /* K5   */  be_nested_str_weak(app_payload_idx),
-    /* K6   */  be_const_int(2147483647),
-    /* K7   */  be_nested_str_weak(tohex),
-    /* K8   */  be_const_int(3),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20),
+    /* K3   */  be_nested_str_weak(raw),
+    /* K4   */  be_nested_str_weak(app_payload_idx),
+    /* K5   */  be_const_int(2147483647),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_const_int(3),
     }),
     be_str_weak(parse_StatusReport),
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
+    ( &(const binstruction[13]) {  /* code */
       0x88080300,  //  0000  GETMBR	R2	R1	K0
       0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x88140305,  //  0003  GETMBR	R5	R1	K5
-      0x40140B06,  //  0004  CONNECT	R5	R5	K6
-      0x88180304,  //  0005  GETMBR	R6	R1	K4
-      0x94140C05,  //  0006  GETIDX	R5	R6	R5
-      0x8C140B07,  //  0007  GETMET	R5	R5	K7
-      0x7C140200,  //  0008  CALL	R5	1
-      0x00160605,  //  0009  ADD	R5	K3	R5
-      0x58180008,  //  000A  LDCONST	R6	K8
-      0x7C0C0600,  //  000B  CALL	R3	3
-      0x500C0000,  //  000C  LDBOOL	R3	0	0
-      0x80040600,  //  000D  RET	1	R3
+      0x88100304,  //  0002  GETMBR	R4	R1	K4
+      0x40100905,  //  0003  CONNECT	R4	R4	K5
+      0x88140303,  //  0004  GETMBR	R5	R1	K3
+      0x94100A04,  //  0005  GETIDX	R4	R5	R4
+      0x8C100906,  //  0006  GETMET	R4	R4	K6
+      0x7C100200,  //  0007  CALL	R4	1
+      0x00120404,  //  0008  ADD	R4	K2	R4
+      0x58140007,  //  0009  LDCONST	R5	K7
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x500C0000,  //  000B  LDBOOL	R3	0	0
+      0x80040600,  //  000C  RET	1	R3
     })
   )
 );
@@ -60,7 +58,7 @@ be_local_closure(class_Matter_Commisioning_Context_parse_StatusReport,   /* name
 extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_find_fabric_by_destination_id,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    13,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -91,80 +89,78 @@ be_local_closure(class_Matter_Commisioning_Context_find_fabric_by_destination_id
     }),
     be_str_weak(find_fabric_by_destination_id),
     &be_const_str_solidified,
-    ( &(const binstruction[73]) {  /* code */
+    ( &(const binstruction[71]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0xB8120200,  //  0001  GETNGBL	R4	K1
       0x8C100902,  //  0002  GETMET	R4	R4	K2
       0x541A0003,  //  0003  LDINT	R6	4
       0x7C100400,  //  0004  CALL	R4	2
-      0x78120006,  //  0005  JMPF	R4	#000D
-      0xB8120200,  //  0006  GETNGBL	R4	K1
-      0x8C100903,  //  0007  GETMET	R4	R4	K3
-      0x8C180305,  //  0008  GETMET	R6	R1	K5
-      0x7C180200,  //  0009  CALL	R6	1
-      0x001A0806,  //  000A  ADD	R6	K4	R6
-      0x541E0003,  //  000B  LDINT	R7	4
-      0x7C100600,  //  000C  CALL	R4	3
-      0x60100010,  //  000D  GETGBL	R4	G16
-      0x88140106,  //  000E  GETMBR	R5	R0	K6
-      0x88140B07,  //  000F  GETMBR	R5	R5	K7
-      0x88140B08,  //  0010  GETMBR	R5	R5	K8
-      0x7C100200,  //  0011  CALL	R4	1
-      0xA8020030,  //  0012  EXBLK	0	#0044
-      0x5C140800,  //  0013  MOVE	R5	R4
-      0x7C140000,  //  0014  CALL	R5	0
-      0x88180B09,  //  0015  GETMBR	R6	R5	K9
-      0x4C1C0000,  //  0016  LDNIL	R7
-      0x1C180C07,  //  0017  EQ	R6	R6	R7
-      0x741A0007,  //  0018  JMPT	R6	#0021
-      0x88180B0A,  //  0019  GETMBR	R6	R5	K10
-      0x4C1C0000,  //  001A  LDNIL	R7
-      0x1C180C07,  //  001B  EQ	R6	R6	R7
-      0x741A0003,  //  001C  JMPT	R6	#0021
-      0x88180B0B,  //  001D  GETMBR	R6	R5	K11
-      0x4C1C0000,  //  001E  LDNIL	R7
-      0x1C180C07,  //  001F  EQ	R6	R6	R7
-      0x781A0000,  //  0020  JMPF	R6	#0022
-      0x7001FFF0,  //  0021  JMP		#0013
-      0x8C180B0C,  //  0022  GETMET	R6	R5	K12
-      0x7C180200,  //  0023  CALL	R6	1
-      0x00180406,  //  0024  ADD	R6	R2	R6
-      0x881C0B0A,  //  0025  GETMBR	R7	R5	K10
-      0x00180C07,  //  0026  ADD	R6	R6	R7
-      0x881C0B0B,  //  0027  GETMBR	R7	R5	K11
-      0x00180C07,  //  0028  ADD	R6	R6	R7
-      0x8C1C0B0D,  //  0029  GETMET	R7	R5	K13
-      0x7C1C0200,  //  002A  CALL	R7	1
-      0x8C20070E,  //  002B  GETMET	R8	R3	K14
-      0x5C280E00,  //  002C  MOVE	R10	R7
-      0x7C200400,  //  002D  CALL	R8	2
-      0x8C24110F,  //  002E  GETMET	R9	R8	K15
-      0x5C2C0C00,  //  002F  MOVE	R11	R6
-      0x7C240400,  //  0030  CALL	R9	2
-      0x8C241110,  //  0031  GETMET	R9	R8	K16
-      0x7C240200,  //  0032  CALL	R9	1
-      0xB82A0200,  //  0033  GETNGBL	R10	K1
-      0x8C281502,  //  0034  GETMET	R10	R10	K2
-      0x54320003,  //  0035  LDINT	R12	4
-      0x7C280400,  //  0036  CALL	R10	2
-      0x782A0006,  //  0037  JMPF	R10	#003F
-      0xB82A0200,  //  0038  GETNGBL	R10	K1
-      0x8C281503,  //  0039  GETMET	R10	R10	K3
-      0x8C301305,  //  003A  GETMET	R12	R9	K5
-      0x7C300200,  //  003B  CALL	R12	1
-      0x0032220C,  //  003C  ADD	R12	K17	R12
-      0x54360003,  //  003D  LDINT	R13	4
-      0x7C280600,  //  003E  CALL	R10	3
-      0x1C281201,  //  003F  EQ	R10	R9	R1
-      0x782A0001,  //  0040  JMPF	R10	#0043
-      0xA8040001,  //  0041  EXBLK	1	1
-      0x80040A00,  //  0042  RET	1	R5
-      0x7001FFCE,  //  0043  JMP		#0013
-      0x58100012,  //  0044  LDCONST	R4	K18
-      0xAC100200,  //  0045  CATCH	R4	1	0
-      0xB0080000,  //  0046  RAISE	2	R0	R0
-      0x4C100000,  //  0047  LDNIL	R4
-      0x80040800,  //  0048  RET	1	R4
+      0x78120005,  //  0005  JMPF	R4	#000C
+      0xB8120600,  //  0006  GETNGBL	R4	K3
+      0x8C140305,  //  0007  GETMET	R5	R1	K5
+      0x7C140200,  //  0008  CALL	R5	1
+      0x00160805,  //  0009  ADD	R5	K4	R5
+      0x541A0003,  //  000A  LDINT	R6	4
+      0x7C100400,  //  000B  CALL	R4	2
+      0x60100010,  //  000C  GETGBL	R4	G16
+      0x88140106,  //  000D  GETMBR	R5	R0	K6
+      0x88140B07,  //  000E  GETMBR	R5	R5	K7
+      0x88140B08,  //  000F  GETMBR	R5	R5	K8
+      0x7C100200,  //  0010  CALL	R4	1
+      0xA802002F,  //  0011  EXBLK	0	#0042
+      0x5C140800,  //  0012  MOVE	R5	R4
+      0x7C140000,  //  0013  CALL	R5	0
+      0x88180B09,  //  0014  GETMBR	R6	R5	K9
+      0x4C1C0000,  //  0015  LDNIL	R7
+      0x1C180C07,  //  0016  EQ	R6	R6	R7
+      0x741A0007,  //  0017  JMPT	R6	#0020
+      0x88180B0A,  //  0018  GETMBR	R6	R5	K10
+      0x4C1C0000,  //  0019  LDNIL	R7
+      0x1C180C07,  //  001A  EQ	R6	R6	R7
+      0x741A0003,  //  001B  JMPT	R6	#0020
+      0x88180B0B,  //  001C  GETMBR	R6	R5	K11
+      0x4C1C0000,  //  001D  LDNIL	R7
+      0x1C180C07,  //  001E  EQ	R6	R6	R7
+      0x781A0000,  //  001F  JMPF	R6	#0021
+      0x7001FFF0,  //  0020  JMP		#0012
+      0x8C180B0C,  //  0021  GETMET	R6	R5	K12
+      0x7C180200,  //  0022  CALL	R6	1
+      0x00180406,  //  0023  ADD	R6	R2	R6
+      0x881C0B0A,  //  0024  GETMBR	R7	R5	K10
+      0x00180C07,  //  0025  ADD	R6	R6	R7
+      0x881C0B0B,  //  0026  GETMBR	R7	R5	K11
+      0x00180C07,  //  0027  ADD	R6	R6	R7
+      0x8C1C0B0D,  //  0028  GETMET	R7	R5	K13
+      0x7C1C0200,  //  0029  CALL	R7	1
+      0x8C20070E,  //  002A  GETMET	R8	R3	K14
+      0x5C280E00,  //  002B  MOVE	R10	R7
+      0x7C200400,  //  002C  CALL	R8	2
+      0x8C24110F,  //  002D  GETMET	R9	R8	K15
+      0x5C2C0C00,  //  002E  MOVE	R11	R6
+      0x7C240400,  //  002F  CALL	R9	2
+      0x8C241110,  //  0030  GETMET	R9	R8	K16
+      0x7C240200,  //  0031  CALL	R9	1
+      0xB82A0200,  //  0032  GETNGBL	R10	K1
+      0x8C281502,  //  0033  GETMET	R10	R10	K2
+      0x54320003,  //  0034  LDINT	R12	4
+      0x7C280400,  //  0035  CALL	R10	2
+      0x782A0005,  //  0036  JMPF	R10	#003D
+      0xB82A0600,  //  0037  GETNGBL	R10	K3
+      0x8C2C1305,  //  0038  GETMET	R11	R9	K5
+      0x7C2C0200,  //  0039  CALL	R11	1
+      0x002E220B,  //  003A  ADD	R11	K17	R11
+      0x54320003,  //  003B  LDINT	R12	4
+      0x7C280400,  //  003C  CALL	R10	2
+      0x1C281201,  //  003D  EQ	R10	R9	R1
+      0x782A0001,  //  003E  JMPF	R10	#0041
+      0xA8040001,  //  003F  EXBLK	1	1
+      0x80040A00,  //  0040  RET	1	R5
+      0x7001FFCF,  //  0041  JMP		#0012
+      0x58100012,  //  0042  LDCONST	R4	K18
+      0xAC100200,  //  0043  CATCH	R4	1	0
+      0xB0080000,  //  0044  RAISE	2	R0	R0
+      0x4C100000,  //  0045  LDNIL	R4
+      0x80040800,  //  0046  RET	1	R4
     })
   )
 );
@@ -210,39 +206,37 @@ be_local_closure(class_Matter_Commisioning_Context_add_session,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Commisioning_Context, 
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20add_session_X20local_session_id_X3D_X25i_X20initiator_session_id_X3D_X25i),
-    /* K3   */  be_nested_str_weak(device),
-    /* K4   */  be_nested_str_weak(sessions),
-    /* K5   */  be_nested_str_weak(create_session),
-    /* K6   */  be_nested_str_weak(set_keys),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(log),
+    /* K1   */  be_nested_str_weak(MTR_X3A_X20add_session_X20local_session_id_X3D_X25i_X20initiator_session_id_X3D_X25i),
+    /* K2   */  be_nested_str_weak(device),
+    /* K3   */  be_nested_str_weak(sessions),
+    /* K4   */  be_nested_str_weak(create_session),
+    /* K5   */  be_nested_str_weak(set_keys),
     }),
     be_str_weak(add_session),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
+    ( &(const binstruction[20]) {  /* code */
       0xB81A0000,  //  0000  GETNGBL	R6	K0
-      0x8C180D01,  //  0001  GETMET	R6	R6	K1
-      0x60200018,  //  0002  GETGBL	R8	G24
-      0x58240002,  //  0003  LDCONST	R9	K2
-      0x5C280200,  //  0004  MOVE	R10	R1
-      0x5C2C0400,  //  0005  MOVE	R11	R2
-      0x7C200600,  //  0006  CALL	R8	3
-      0x54260003,  //  0007  LDINT	R9	4
-      0x7C180600,  //  0008  CALL	R6	3
-      0x88180103,  //  0009  GETMBR	R6	R0	K3
-      0x88180D04,  //  000A  GETMBR	R6	R6	K4
-      0x8C180D05,  //  000B  GETMET	R6	R6	K5
-      0x5C200200,  //  000C  MOVE	R8	R1
-      0x5C240400,  //  000D  MOVE	R9	R2
-      0x7C180600,  //  000E  CALL	R6	3
-      0x8C1C0D06,  //  000F  GETMET	R7	R6	K6
-      0x5C240600,  //  0010  MOVE	R9	R3
-      0x5C280800,  //  0011  MOVE	R10	R4
-      0x5C2C0A00,  //  0012  MOVE	R11	R5
-      0x7C1C0800,  //  0013  CALL	R7	4
-      0x80000000,  //  0014  RET	0
+      0x601C0018,  //  0001  GETGBL	R7	G24
+      0x58200001,  //  0002  LDCONST	R8	K1
+      0x5C240200,  //  0003  MOVE	R9	R1
+      0x5C280400,  //  0004  MOVE	R10	R2
+      0x7C1C0600,  //  0005  CALL	R7	3
+      0x54220003,  //  0006  LDINT	R8	4
+      0x7C180400,  //  0007  CALL	R6	2
+      0x88180102,  //  0008  GETMBR	R6	R0	K2
+      0x88180D03,  //  0009  GETMBR	R6	R6	K3
+      0x8C180D04,  //  000A  GETMET	R6	R6	K4
+      0x5C200200,  //  000B  MOVE	R8	R1
+      0x5C240400,  //  000C  MOVE	R9	R2
+      0x7C180600,  //  000D  CALL	R6	3
+      0x8C1C0D05,  //  000E  GETMET	R7	R6	K5
+      0x5C240600,  //  000F  MOVE	R9	R3
+      0x5C280800,  //  0010  MOVE	R10	R4
+      0x5C2C0A00,  //  0011  MOVE	R11	R5
+      0x7C1C0800,  //  0012  CALL	R7	4
+      0x80000000,  //  0013  RET	0
     })
   )
 );
@@ -263,59 +257,58 @@ be_local_closure(class_Matter_Commisioning_Context_parse_PBKDFParamRequest,   /*
     0,                          /* has sup protos */
     &be_class_Matter_Commisioning_Context, 
     1,                          /* has constants */
-    ( &(const bvalue[48]) {     /* constants */
+    ( &(const bvalue[47]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(session),
     /* K2   */  be_nested_str_weak(opcode),
     /* K3   */  be_nested_str_weak(local_session_id),
     /* K4   */  be_const_int(0),
     /* K5   */  be_nested_str_weak(protocol_id),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20invalid_X20PBKDFParamRequest_X20message),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(send_status_report),
-    /* K13  */  be_const_int(1),
-    /* K14  */  be_nested_str_weak(matter),
-    /* K15  */  be_nested_str_weak(PBKDFParamRequest),
-    /* K16  */  be_nested_str_weak(parse),
-    /* K17  */  be_nested_str_weak(raw),
-    /* K18  */  be_nested_str_weak(app_payload_idx),
-    /* K19  */  be_nested_str_weak(set_mode_PASE),
-    /* K20  */  be_nested_str_weak(__Msg1),
-    /* K21  */  be_const_int(2147483647),
-    /* K22  */  be_nested_str_weak(passcodeId),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20non_X2Dzero_X20passcode_X20id),
-    /* K24  */  be_nested_str_weak(__future_initiator_session_id),
-    /* K25  */  be_nested_str_weak(initiator_session_id),
-    /* K26  */  be_nested_str_weak(__future_local_session_id),
-    /* K27  */  be_nested_str_weak(device),
-    /* K28  */  be_nested_str_weak(sessions),
-    /* K29  */  be_nested_str_weak(gen_local_session_id),
-    /* K30  */  be_nested_str_weak(MTR_X3A_X20_X2BSession_X20_X20_X20_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-    /* K31  */  be_nested_str_weak(remote_ip),
-    /* K32  */  be_nested_str_weak(remote_port),
-    /* K33  */  be_nested_str_weak(PBKDFParamResponse),
-    /* K34  */  be_nested_str_weak(initiatorRandom),
-    /* K35  */  be_nested_str_weak(responderRandom),
-    /* K36  */  be_nested_str_weak(random),
-    /* K37  */  be_nested_str_weak(responderSessionId),
-    /* K38  */  be_nested_str_weak(pbkdf_parameters_salt),
-    /* K39  */  be_nested_str_weak(commissioning_salt),
-    /* K40  */  be_nested_str_weak(pbkdf_parameters_iterations),
-    /* K41  */  be_nested_str_weak(commissioning_iterations),
-    /* K42  */  be_nested_str_weak(tlv2raw),
-    /* K43  */  be_nested_str_weak(__Msg2),
-    /* K44  */  be_nested_str_weak(build_response),
-    /* K45  */  be_nested_str_weak(encode_frame),
-    /* K46  */  be_nested_str_weak(responder),
-    /* K47  */  be_nested_str_weak(send_response_frame),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20invalid_X20PBKDFParamRequest_X20message),
+    /* K8   */  be_const_int(2),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(send_status_report),
+    /* K12  */  be_const_int(1),
+    /* K13  */  be_nested_str_weak(matter),
+    /* K14  */  be_nested_str_weak(PBKDFParamRequest),
+    /* K15  */  be_nested_str_weak(parse),
+    /* K16  */  be_nested_str_weak(raw),
+    /* K17  */  be_nested_str_weak(app_payload_idx),
+    /* K18  */  be_nested_str_weak(set_mode_PASE),
+    /* K19  */  be_nested_str_weak(__Msg1),
+    /* K20  */  be_const_int(2147483647),
+    /* K21  */  be_nested_str_weak(passcodeId),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20non_X2Dzero_X20passcode_X20id),
+    /* K23  */  be_nested_str_weak(__future_initiator_session_id),
+    /* K24  */  be_nested_str_weak(initiator_session_id),
+    /* K25  */  be_nested_str_weak(__future_local_session_id),
+    /* K26  */  be_nested_str_weak(device),
+    /* K27  */  be_nested_str_weak(sessions),
+    /* K28  */  be_nested_str_weak(gen_local_session_id),
+    /* K29  */  be_nested_str_weak(MTR_X3A_X20_X2BSession_X20_X20_X20_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+    /* K30  */  be_nested_str_weak(remote_ip),
+    /* K31  */  be_nested_str_weak(remote_port),
+    /* K32  */  be_nested_str_weak(PBKDFParamResponse),
+    /* K33  */  be_nested_str_weak(initiatorRandom),
+    /* K34  */  be_nested_str_weak(responderRandom),
+    /* K35  */  be_nested_str_weak(random),
+    /* K36  */  be_nested_str_weak(responderSessionId),
+    /* K37  */  be_nested_str_weak(pbkdf_parameters_salt),
+    /* K38  */  be_nested_str_weak(commissioning_salt),
+    /* K39  */  be_nested_str_weak(pbkdf_parameters_iterations),
+    /* K40  */  be_nested_str_weak(commissioning_iterations),
+    /* K41  */  be_nested_str_weak(tlv2raw),
+    /* K42  */  be_nested_str_weak(__Msg2),
+    /* K43  */  be_nested_str_weak(build_response),
+    /* K44  */  be_nested_str_weak(encode_frame),
+    /* K45  */  be_nested_str_weak(responder),
+    /* K46  */  be_nested_str_weak(send_response_frame),
     }),
     be_str_weak(parse_PBKDFParamRequest),
     &be_const_str_solidified,
-    ( &(const binstruction[118]) {  /* code */
+    ( &(const binstruction[113]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0x880C0301,  //  0001  GETMBR	R3	R1	K1
       0x88100302,  //  0002  GETMBR	R4	R1	K2
@@ -327,113 +320,108 @@ be_local_closure(class_Matter_Commisioning_Context_parse_PBKDFParamRequest,   /*
       0x74120002,  //  0008  JMPT	R4	#000C
       0x88100305,  //  0009  GETMBR	R4	R1	K5
       0x20100904,  //  000A  NE	R4	R4	K4
-      0x78120012,  //  000B  JMPF	R4	#001F
+      0x78120010,  //  000B  JMPF	R4	#001D
       0xB8120C00,  //  000C  GETNGBL	R4	K6
-      0x8C100907,  //  000D  GETMET	R4	R4	K7
+      0x58140007,  //  000D  LDCONST	R5	K7
       0x58180008,  //  000E  LDCONST	R6	K8
-      0x581C0009,  //  000F  LDCONST	R7	K9
-      0x7C100600,  //  0010  CALL	R4	3
-      0xB8120C00,  //  0011  GETNGBL	R4	K6
-      0x8C100907,  //  0012  GETMET	R4	R4	K7
-      0x5818000A,  //  0013  LDCONST	R6	K10
-      0x581C000B,  //  0014  LDCONST	R7	K11
-      0x7C100600,  //  0015  CALL	R4	3
-      0x8C10010C,  //  0016  GETMET	R4	R0	K12
-      0x5C180200,  //  0017  MOVE	R6	R1
-      0x581C000D,  //  0018  LDCONST	R7	K13
-      0x58200004,  //  0019  LDCONST	R8	K4
-      0x58240009,  //  001A  LDCONST	R9	K9
-      0x50280000,  //  001B  LDBOOL	R10	0	0
-      0x7C100C00,  //  001C  CALL	R4	6
-      0x50100000,  //  001D  LDBOOL	R4	0	0
-      0x80040800,  //  001E  RET	1	R4
-      0xB8121C00,  //  001F  GETNGBL	R4	K14
+      0x7C100400,  //  000F  CALL	R4	2
+      0xB8120C00,  //  0010  GETNGBL	R4	K6
+      0x58140009,  //  0011  LDCONST	R5	K9
+      0x5818000A,  //  0012  LDCONST	R6	K10
+      0x7C100400,  //  0013  CALL	R4	2
+      0x8C10010B,  //  0014  GETMET	R4	R0	K11
+      0x5C180200,  //  0015  MOVE	R6	R1
+      0x581C000C,  //  0016  LDCONST	R7	K12
+      0x58200004,  //  0017  LDCONST	R8	K4
+      0x58240008,  //  0018  LDCONST	R9	K8
+      0x50280000,  //  0019  LDBOOL	R10	0	0
+      0x7C100C00,  //  001A  CALL	R4	6
+      0x50100000,  //  001B  LDBOOL	R4	0	0
+      0x80040800,  //  001C  RET	1	R4
+      0xB8121A00,  //  001D  GETNGBL	R4	K13
+      0x8C10090E,  //  001E  GETMET	R4	R4	K14
+      0x7C100200,  //  001F  CALL	R4	1
       0x8C10090F,  //  0020  GETMET	R4	R4	K15
-      0x7C100200,  //  0021  CALL	R4	1
-      0x8C100910,  //  0022  GETMET	R4	R4	K16
-      0x88180311,  //  0023  GETMBR	R6	R1	K17
-      0x881C0312,  //  0024  GETMBR	R7	R1	K18
-      0x7C100600,  //  0025  CALL	R4	3
-      0x88140301,  //  0026  GETMBR	R5	R1	K1
-      0x8C140B13,  //  0027  GETMET	R5	R5	K19
-      0x7C140200,  //  0028  CALL	R5	1
-      0x88140312,  //  0029  GETMBR	R5	R1	K18
-      0x40140B15,  //  002A  CONNECT	R5	R5	K21
-      0x88180311,  //  002B  GETMBR	R6	R1	K17
-      0x94140C05,  //  002C  GETIDX	R5	R6	R5
-      0x900E2805,  //  002D  SETMBR	R3	K20	R5
-      0x88140916,  //  002E  GETMBR	R5	R4	K22
-      0x20140B04,  //  002F  NE	R5	R5	K4
-      0x78160012,  //  0030  JMPF	R5	#0044
-      0xB8160C00,  //  0031  GETNGBL	R5	K6
-      0x8C140B07,  //  0032  GETMET	R5	R5	K7
-      0x581C0017,  //  0033  LDCONST	R7	K23
-      0x58200009,  //  0034  LDCONST	R8	K9
-      0x7C140600,  //  0035  CALL	R5	3
-      0xB8160C00,  //  0036  GETNGBL	R5	K6
-      0x8C140B07,  //  0037  GETMET	R5	R5	K7
-      0x581C000A,  //  0038  LDCONST	R7	K10
-      0x5820000B,  //  0039  LDCONST	R8	K11
-      0x7C140600,  //  003A  CALL	R5	3
-      0x8C14010C,  //  003B  GETMET	R5	R0	K12
-      0x5C1C0200,  //  003C  MOVE	R7	R1
-      0x5820000D,  //  003D  LDCONST	R8	K13
-      0x58240004,  //  003E  LDCONST	R9	K4
-      0x58280009,  //  003F  LDCONST	R10	K9
-      0x502C0000,  //  0040  LDBOOL	R11	0	0
-      0x7C140C00,  //  0041  CALL	R5	6
-      0x50140000,  //  0042  LDBOOL	R5	0	0
-      0x80040A00,  //  0043  RET	1	R5
-      0x88140919,  //  0044  GETMBR	R5	R4	K25
-      0x900E3005,  //  0045  SETMBR	R3	K24	R5
-      0x8814011B,  //  0046  GETMBR	R5	R0	K27
-      0x88140B1C,  //  0047  GETMBR	R5	R5	K28
-      0x8C140B1D,  //  0048  GETMET	R5	R5	K29
-      0x7C140200,  //  0049  CALL	R5	1
-      0x900E3405,  //  004A  SETMBR	R3	K26	R5
-      0xB8160C00,  //  004B  GETNGBL	R5	K6
-      0x8C140B07,  //  004C  GETMET	R5	R5	K7
-      0x601C0018,  //  004D  GETGBL	R7	G24
-      0x5820001E,  //  004E  LDCONST	R8	K30
-      0x8824071A,  //  004F  GETMBR	R9	R3	K26
-      0x8828031F,  //  0050  GETMBR	R10	R1	K31
-      0x882C0320,  //  0051  GETMBR	R11	R1	K32
-      0x7C1C0800,  //  0052  CALL	R7	4
-      0x5820000B,  //  0053  LDCONST	R8	K11
-      0x7C140600,  //  0054  CALL	R5	3
-      0xB8161C00,  //  0055  GETNGBL	R5	K14
-      0x8C140B21,  //  0056  GETMET	R5	R5	K33
-      0x7C140200,  //  0057  CALL	R5	1
-      0x88180922,  //  0058  GETMBR	R6	R4	K34
-      0x90164406,  //  0059  SETMBR	R5	K34	R6
-      0x8C180524,  //  005A  GETMET	R6	R2	K36
-      0x5422001F,  //  005B  LDINT	R8	32
-      0x7C180400,  //  005C  CALL	R6	2
-      0x90164606,  //  005D  SETMBR	R5	K35	R6
-      0x8818071A,  //  005E  GETMBR	R6	R3	K26
-      0x90164A06,  //  005F  SETMBR	R5	K37	R6
-      0x8818011B,  //  0060  GETMBR	R6	R0	K27
-      0x88180D27,  //  0061  GETMBR	R6	R6	K39
-      0x90164C06,  //  0062  SETMBR	R5	K38	R6
-      0x8818011B,  //  0063  GETMBR	R6	R0	K27
-      0x88180D29,  //  0064  GETMBR	R6	R6	K41
-      0x90165006,  //  0065  SETMBR	R5	K40	R6
-      0x8C180B2A,  //  0066  GETMET	R6	R5	K42
-      0x7C180200,  //  0067  CALL	R6	1
-      0x900E5606,  //  0068  SETMBR	R3	K43	R6
-      0x8C1C032C,  //  0069  GETMET	R7	R1	K44
-      0x54260020,  //  006A  LDINT	R9	33
-      0x50280200,  //  006B  LDBOOL	R10	1	0
-      0x7C1C0600,  //  006C  CALL	R7	3
-      0x8C200F2D,  //  006D  GETMET	R8	R7	K45
-      0x5C280C00,  //  006E  MOVE	R10	R6
-      0x7C200400,  //  006F  CALL	R8	2
-      0x8824012E,  //  0070  GETMBR	R9	R0	K46
-      0x8C24132F,  //  0071  GETMET	R9	R9	K47
-      0x5C2C0E00,  //  0072  MOVE	R11	R7
-      0x7C240400,  //  0073  CALL	R9	2
-      0x50240200,  //  0074  LDBOOL	R9	1	0
-      0x80041200,  //  0075  RET	1	R9
+      0x88180310,  //  0021  GETMBR	R6	R1	K16
+      0x881C0311,  //  0022  GETMBR	R7	R1	K17
+      0x7C100600,  //  0023  CALL	R4	3
+      0x88140301,  //  0024  GETMBR	R5	R1	K1
+      0x8C140B12,  //  0025  GETMET	R5	R5	K18
+      0x7C140200,  //  0026  CALL	R5	1
+      0x88140311,  //  0027  GETMBR	R5	R1	K17
+      0x40140B14,  //  0028  CONNECT	R5	R5	K20
+      0x88180310,  //  0029  GETMBR	R6	R1	K16
+      0x94140C05,  //  002A  GETIDX	R5	R6	R5
+      0x900E2605,  //  002B  SETMBR	R3	K19	R5
+      0x88140915,  //  002C  GETMBR	R5	R4	K21
+      0x20140B04,  //  002D  NE	R5	R5	K4
+      0x78160010,  //  002E  JMPF	R5	#0040
+      0xB8160C00,  //  002F  GETNGBL	R5	K6
+      0x58180016,  //  0030  LDCONST	R6	K22
+      0x581C0008,  //  0031  LDCONST	R7	K8
+      0x7C140400,  //  0032  CALL	R5	2
+      0xB8160C00,  //  0033  GETNGBL	R5	K6
+      0x58180009,  //  0034  LDCONST	R6	K9
+      0x581C000A,  //  0035  LDCONST	R7	K10
+      0x7C140400,  //  0036  CALL	R5	2
+      0x8C14010B,  //  0037  GETMET	R5	R0	K11
+      0x5C1C0200,  //  0038  MOVE	R7	R1
+      0x5820000C,  //  0039  LDCONST	R8	K12
+      0x58240004,  //  003A  LDCONST	R9	K4
+      0x58280008,  //  003B  LDCONST	R10	K8
+      0x502C0000,  //  003C  LDBOOL	R11	0	0
+      0x7C140C00,  //  003D  CALL	R5	6
+      0x50140000,  //  003E  LDBOOL	R5	0	0
+      0x80040A00,  //  003F  RET	1	R5
+      0x88140918,  //  0040  GETMBR	R5	R4	K24
+      0x900E2E05,  //  0041  SETMBR	R3	K23	R5
+      0x8814011A,  //  0042  GETMBR	R5	R0	K26
+      0x88140B1B,  //  0043  GETMBR	R5	R5	K27
+      0x8C140B1C,  //  0044  GETMET	R5	R5	K28
+      0x7C140200,  //  0045  CALL	R5	1
+      0x900E3205,  //  0046  SETMBR	R3	K25	R5
+      0xB8160C00,  //  0047  GETNGBL	R5	K6
+      0x60180018,  //  0048  GETGBL	R6	G24
+      0x581C001D,  //  0049  LDCONST	R7	K29
+      0x88200719,  //  004A  GETMBR	R8	R3	K25
+      0x8824031E,  //  004B  GETMBR	R9	R1	K30
+      0x8828031F,  //  004C  GETMBR	R10	R1	K31
+      0x7C180800,  //  004D  CALL	R6	4
+      0x581C000A,  //  004E  LDCONST	R7	K10
+      0x7C140400,  //  004F  CALL	R5	2
+      0xB8161A00,  //  0050  GETNGBL	R5	K13
+      0x8C140B20,  //  0051  GETMET	R5	R5	K32
+      0x7C140200,  //  0052  CALL	R5	1
+      0x88180921,  //  0053  GETMBR	R6	R4	K33
+      0x90164206,  //  0054  SETMBR	R5	K33	R6
+      0x8C180523,  //  0055  GETMET	R6	R2	K35
+      0x5422001F,  //  0056  LDINT	R8	32
+      0x7C180400,  //  0057  CALL	R6	2
+      0x90164406,  //  0058  SETMBR	R5	K34	R6
+      0x88180719,  //  0059  GETMBR	R6	R3	K25
+      0x90164806,  //  005A  SETMBR	R5	K36	R6
+      0x8818011A,  //  005B  GETMBR	R6	R0	K26
+      0x88180D26,  //  005C  GETMBR	R6	R6	K38
+      0x90164A06,  //  005D  SETMBR	R5	K37	R6
+      0x8818011A,  //  005E  GETMBR	R6	R0	K26
+      0x88180D28,  //  005F  GETMBR	R6	R6	K40
+      0x90164E06,  //  0060  SETMBR	R5	K39	R6
+      0x8C180B29,  //  0061  GETMET	R6	R5	K41
+      0x7C180200,  //  0062  CALL	R6	1
+      0x900E5406,  //  0063  SETMBR	R3	K42	R6
+      0x8C1C032B,  //  0064  GETMET	R7	R1	K43
+      0x54260020,  //  0065  LDINT	R9	33
+      0x50280200,  //  0066  LDBOOL	R10	1	0
+      0x7C1C0600,  //  0067  CALL	R7	3
+      0x8C200F2C,  //  0068  GETMET	R8	R7	K44
+      0x5C280C00,  //  0069  MOVE	R10	R6
+      0x7C200400,  //  006A  CALL	R8	2
+      0x8824012D,  //  006B  GETMBR	R9	R0	K45
+      0x8C24132E,  //  006C  GETMET	R9	R9	K46
+      0x5C2C0E00,  //  006D  MOVE	R11	R7
+      0x7C240400,  //  006E  CALL	R9	2
+      0x50240200,  //  006F  LDBOOL	R9	1	0
+      0x80041200,  //  0070  RET	1	R9
     })
   )
 );
@@ -503,7 +491,7 @@ be_local_closure(class_Matter_Commisioning_Context_send_status_report,   /* name
 extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_parse_Pake1,   /* name */
   be_nested_proto(
-    21,                          /* nstack */
+    20,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -511,63 +499,62 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Pake1,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Commisioning_Context, 
     1,                          /* has constants */
-    ( &(const bvalue[52]) {     /* constants */
+    ( &(const bvalue[51]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(session),
     /* K2   */  be_nested_str_weak(opcode),
     /* K3   */  be_nested_str_weak(local_session_id),
     /* K4   */  be_const_int(0),
     /* K5   */  be_nested_str_weak(protocol_id),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20invalid_X20Pake1_X20message),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K11  */  be_nested_str_weak(send_status_report),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_const_int(2),
-    /* K14  */  be_nested_str_weak(matter),
-    /* K15  */  be_nested_str_weak(Pake1),
-    /* K16  */  be_nested_str_weak(parse),
-    /* K17  */  be_nested_str_weak(raw),
-    /* K18  */  be_nested_str_weak(app_payload_idx),
-    /* K19  */  be_nested_str_weak(pA),
-    /* K20  */  be_nested_str_weak(SPAKE2P_Matter),
-    /* K21  */  be_nested_str_weak(device),
-    /* K22  */  be_nested_str_weak(commissioning_w0),
-    /* K23  */  be_nested_str_weak(commissioning_L),
-    /* K24  */  be_nested_str_weak(random),
-    /* K25  */  be_nested_str_weak(compute_pB),
-    /* K26  */  be_nested_str_weak(compute_ZV_verifier),
-    /* K27  */  be_nested_str_weak(SHA256),
-    /* K28  */  be_nested_str_weak(update),
-    /* K29  */  be_nested_str_weak(fromstring),
-    /* K30  */  be_nested_str_weak(Matter_Context_Prefix),
-    /* K31  */  be_nested_str_weak(__Msg1),
-    /* K32  */  be_nested_str_weak(__Msg2),
-    /* K33  */  be_nested_str_weak(out),
-    /* K34  */  be_nested_str_weak(set_context),
-    /* K35  */  be_nested_str_weak(compute_TT_hash),
-    /* K36  */  be_nested_str_weak(Pake2),
-    /* K37  */  be_nested_str_weak(pB),
-    /* K38  */  be_nested_str_weak(cB),
-    /* K39  */  be_nested_str_weak(tlv2raw),
-    /* K40  */  be_nested_str_weak(__spake_cA),
-    /* K41  */  be_nested_str_weak(cA),
-    /* K42  */  be_nested_str_weak(__spake_Ke),
-    /* K43  */  be_nested_str_weak(Ke),
-    /* K44  */  be_nested_str_weak(build_response),
-    /* K45  */  be_nested_str_weak(encode_frame),
-    /* K46  */  be_nested_str_weak(MTR_X3A_X20New_X20Commissioning_X20_X28PASE_X20id_X3D_X25i_X29_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K47  */  be_nested_str_weak(__future_local_session_id),
-    /* K48  */  be_nested_str_weak(_ip),
-    /* K49  */  be_nested_str_weak(_port),
-    /* K50  */  be_nested_str_weak(responder),
-    /* K51  */  be_nested_str_weak(send_response_frame),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20invalid_X20Pake1_X20message),
+    /* K8   */  be_const_int(3),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
+    /* K10  */  be_nested_str_weak(send_status_report),
+    /* K11  */  be_const_int(1),
+    /* K12  */  be_const_int(2),
+    /* K13  */  be_nested_str_weak(matter),
+    /* K14  */  be_nested_str_weak(Pake1),
+    /* K15  */  be_nested_str_weak(parse),
+    /* K16  */  be_nested_str_weak(raw),
+    /* K17  */  be_nested_str_weak(app_payload_idx),
+    /* K18  */  be_nested_str_weak(pA),
+    /* K19  */  be_nested_str_weak(SPAKE2P_Matter),
+    /* K20  */  be_nested_str_weak(device),
+    /* K21  */  be_nested_str_weak(commissioning_w0),
+    /* K22  */  be_nested_str_weak(commissioning_L),
+    /* K23  */  be_nested_str_weak(random),
+    /* K24  */  be_nested_str_weak(compute_pB),
+    /* K25  */  be_nested_str_weak(compute_ZV_verifier),
+    /* K26  */  be_nested_str_weak(SHA256),
+    /* K27  */  be_nested_str_weak(update),
+    /* K28  */  be_nested_str_weak(fromstring),
+    /* K29  */  be_nested_str_weak(Matter_Context_Prefix),
+    /* K30  */  be_nested_str_weak(__Msg1),
+    /* K31  */  be_nested_str_weak(__Msg2),
+    /* K32  */  be_nested_str_weak(out),
+    /* K33  */  be_nested_str_weak(set_context),
+    /* K34  */  be_nested_str_weak(compute_TT_hash),
+    /* K35  */  be_nested_str_weak(Pake2),
+    /* K36  */  be_nested_str_weak(pB),
+    /* K37  */  be_nested_str_weak(cB),
+    /* K38  */  be_nested_str_weak(tlv2raw),
+    /* K39  */  be_nested_str_weak(__spake_cA),
+    /* K40  */  be_nested_str_weak(cA),
+    /* K41  */  be_nested_str_weak(__spake_Ke),
+    /* K42  */  be_nested_str_weak(Ke),
+    /* K43  */  be_nested_str_weak(build_response),
+    /* K44  */  be_nested_str_weak(encode_frame),
+    /* K45  */  be_nested_str_weak(MTR_X3A_X20New_X20Commissioning_X20_X28PASE_X20id_X3D_X25i_X29_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K46  */  be_nested_str_weak(__future_local_session_id),
+    /* K47  */  be_nested_str_weak(_ip),
+    /* K48  */  be_nested_str_weak(_port),
+    /* K49  */  be_nested_str_weak(responder),
+    /* K50  */  be_nested_str_weak(send_response_frame),
     }),
     be_str_weak(parse_Pake1),
     &be_const_str_solidified,
-    ( &(const binstruction[115]) {  /* code */
+    ( &(const binstruction[112]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0x880C0301,  //  0001  GETMBR	R3	R1	K1
       0x88100302,  //  0002  GETMBR	R4	R1	K2
@@ -579,110 +566,107 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Pake1,   /* name */
       0x74120002,  //  0008  JMPT	R4	#000C
       0x88100305,  //  0009  GETMBR	R4	R1	K5
       0x20100904,  //  000A  NE	R4	R4	K4
-      0x78120012,  //  000B  JMPF	R4	#001F
+      0x78120010,  //  000B  JMPF	R4	#001D
       0xB8120C00,  //  000C  GETNGBL	R4	K6
-      0x8C100907,  //  000D  GETMET	R4	R4	K7
+      0x58140007,  //  000D  LDCONST	R5	K7
       0x58180008,  //  000E  LDCONST	R6	K8
-      0x581C0009,  //  000F  LDCONST	R7	K9
-      0x7C100600,  //  0010  CALL	R4	3
-      0xB8120C00,  //  0011  GETNGBL	R4	K6
-      0x8C100907,  //  0012  GETMET	R4	R4	K7
-      0x5818000A,  //  0013  LDCONST	R6	K10
-      0x581C0009,  //  0014  LDCONST	R7	K9
-      0x7C100600,  //  0015  CALL	R4	3
-      0x8C10010B,  //  0016  GETMET	R4	R0	K11
-      0x5C180200,  //  0017  MOVE	R6	R1
-      0x581C000C,  //  0018  LDCONST	R7	K12
-      0x58200004,  //  0019  LDCONST	R8	K4
-      0x5824000D,  //  001A  LDCONST	R9	K13
-      0x50280000,  //  001B  LDBOOL	R10	0	0
-      0x7C100C00,  //  001C  CALL	R4	6
-      0x50100000,  //  001D  LDBOOL	R4	0	0
-      0x80040800,  //  001E  RET	1	R4
-      0xB8121C00,  //  001F  GETNGBL	R4	K14
+      0x7C100400,  //  000F  CALL	R4	2
+      0xB8120C00,  //  0010  GETNGBL	R4	K6
+      0x58140009,  //  0011  LDCONST	R5	K9
+      0x58180008,  //  0012  LDCONST	R6	K8
+      0x7C100400,  //  0013  CALL	R4	2
+      0x8C10010A,  //  0014  GETMET	R4	R0	K10
+      0x5C180200,  //  0015  MOVE	R6	R1
+      0x581C000B,  //  0016  LDCONST	R7	K11
+      0x58200004,  //  0017  LDCONST	R8	K4
+      0x5824000C,  //  0018  LDCONST	R9	K12
+      0x50280000,  //  0019  LDBOOL	R10	0	0
+      0x7C100C00,  //  001A  CALL	R4	6
+      0x50100000,  //  001B  LDBOOL	R4	0	0
+      0x80040800,  //  001C  RET	1	R4
+      0xB8121A00,  //  001D  GETNGBL	R4	K13
+      0x8C10090E,  //  001E  GETMET	R4	R4	K14
+      0x7C100200,  //  001F  CALL	R4	1
       0x8C10090F,  //  0020  GETMET	R4	R4	K15
-      0x7C100200,  //  0021  CALL	R4	1
-      0x8C100910,  //  0022  GETMET	R4	R4	K16
-      0x88180311,  //  0023  GETMBR	R6	R1	K17
-      0x881C0312,  //  0024  GETMBR	R7	R1	K18
-      0x7C100600,  //  0025  CALL	R4	3
-      0x88140913,  //  0026  GETMBR	R5	R4	K19
-      0x8C180514,  //  0027  GETMET	R6	R2	K20
-      0x88200115,  //  0028  GETMBR	R8	R0	K21
-      0x88201116,  //  0029  GETMBR	R8	R8	K22
-      0x4C240000,  //  002A  LDNIL	R9
-      0x88280115,  //  002B  GETMBR	R10	R0	K21
-      0x88281517,  //  002C  GETMBR	R10	R10	K23
-      0x7C180800,  //  002D  CALL	R6	4
-      0x8C1C0518,  //  002E  GETMET	R7	R2	K24
-      0x5426001F,  //  002F  LDINT	R9	32
-      0x7C1C0400,  //  0030  CALL	R7	2
-      0x8C200D19,  //  0031  GETMET	R8	R6	K25
-      0x5C280E00,  //  0032  MOVE	R10	R7
-      0x7C200400,  //  0033  CALL	R8	2
-      0x8C200D1A,  //  0034  GETMET	R8	R6	K26
-      0x5C280A00,  //  0035  MOVE	R10	R5
-      0x7C200400,  //  0036  CALL	R8	2
-      0x8C20051B,  //  0037  GETMET	R8	R2	K27
-      0x7C200200,  //  0038  CALL	R8	1
-      0x8C24111C,  //  0039  GETMET	R9	R8	K28
-      0x602C0015,  //  003A  GETGBL	R11	G21
-      0x7C2C0000,  //  003B  CALL	R11	0
-      0x8C2C171D,  //  003C  GETMET	R11	R11	K29
-      0x8834011E,  //  003D  GETMBR	R13	R0	K30
-      0x7C2C0400,  //  003E  CALL	R11	2
-      0x7C240400,  //  003F  CALL	R9	2
-      0x8C24111C,  //  0040  GETMET	R9	R8	K28
-      0x882C071F,  //  0041  GETMBR	R11	R3	K31
-      0x7C240400,  //  0042  CALL	R9	2
-      0x8C24111C,  //  0043  GETMET	R9	R8	K28
-      0x882C0720,  //  0044  GETMBR	R11	R3	K32
-      0x7C240400,  //  0045  CALL	R9	2
-      0x8C241121,  //  0046  GETMET	R9	R8	K33
-      0x7C240200,  //  0047  CALL	R9	1
-      0x901A2605,  //  0048  SETMBR	R6	K19	R5
-      0x8C280D22,  //  0049  GETMET	R10	R6	K34
-      0x5C301200,  //  004A  MOVE	R12	R9
-      0x7C280400,  //  004B  CALL	R10	2
-      0x8C280D23,  //  004C  GETMET	R10	R6	K35
-      0x50300200,  //  004D  LDBOOL	R12	1	0
-      0x7C280400,  //  004E  CALL	R10	2
-      0xB82A1C00,  //  004F  GETNGBL	R10	K14
-      0x8C281524,  //  0050  GETMET	R10	R10	K36
-      0x7C280200,  //  0051  CALL	R10	1
+      0x88180310,  //  0021  GETMBR	R6	R1	K16
+      0x881C0311,  //  0022  GETMBR	R7	R1	K17
+      0x7C100600,  //  0023  CALL	R4	3
+      0x88140912,  //  0024  GETMBR	R5	R4	K18
+      0x8C180513,  //  0025  GETMET	R6	R2	K19
+      0x88200114,  //  0026  GETMBR	R8	R0	K20
+      0x88201115,  //  0027  GETMBR	R8	R8	K21
+      0x4C240000,  //  0028  LDNIL	R9
+      0x88280114,  //  0029  GETMBR	R10	R0	K20
+      0x88281516,  //  002A  GETMBR	R10	R10	K22
+      0x7C180800,  //  002B  CALL	R6	4
+      0x8C1C0517,  //  002C  GETMET	R7	R2	K23
+      0x5426001F,  //  002D  LDINT	R9	32
+      0x7C1C0400,  //  002E  CALL	R7	2
+      0x8C200D18,  //  002F  GETMET	R8	R6	K24
+      0x5C280E00,  //  0030  MOVE	R10	R7
+      0x7C200400,  //  0031  CALL	R8	2
+      0x8C200D19,  //  0032  GETMET	R8	R6	K25
+      0x5C280A00,  //  0033  MOVE	R10	R5
+      0x7C200400,  //  0034  CALL	R8	2
+      0x8C20051A,  //  0035  GETMET	R8	R2	K26
+      0x7C200200,  //  0036  CALL	R8	1
+      0x8C24111B,  //  0037  GETMET	R9	R8	K27
+      0x602C0015,  //  0038  GETGBL	R11	G21
+      0x7C2C0000,  //  0039  CALL	R11	0
+      0x8C2C171C,  //  003A  GETMET	R11	R11	K28
+      0x8834011D,  //  003B  GETMBR	R13	R0	K29
+      0x7C2C0400,  //  003C  CALL	R11	2
+      0x7C240400,  //  003D  CALL	R9	2
+      0x8C24111B,  //  003E  GETMET	R9	R8	K27
+      0x882C071E,  //  003F  GETMBR	R11	R3	K30
+      0x7C240400,  //  0040  CALL	R9	2
+      0x8C24111B,  //  0041  GETMET	R9	R8	K27
+      0x882C071F,  //  0042  GETMBR	R11	R3	K31
+      0x7C240400,  //  0043  CALL	R9	2
+      0x8C241120,  //  0044  GETMET	R9	R8	K32
+      0x7C240200,  //  0045  CALL	R9	1
+      0x901A2405,  //  0046  SETMBR	R6	K18	R5
+      0x8C280D21,  //  0047  GETMET	R10	R6	K33
+      0x5C301200,  //  0048  MOVE	R12	R9
+      0x7C280400,  //  0049  CALL	R10	2
+      0x8C280D22,  //  004A  GETMET	R10	R6	K34
+      0x50300200,  //  004B  LDBOOL	R12	1	0
+      0x7C280400,  //  004C  CALL	R10	2
+      0xB82A1A00,  //  004D  GETNGBL	R10	K13
+      0x8C281523,  //  004E  GETMET	R10	R10	K35
+      0x7C280200,  //  004F  CALL	R10	1
+      0x882C0D24,  //  0050  GETMBR	R11	R6	K36
+      0x902A480B,  //  0051  SETMBR	R10	K36	R11
       0x882C0D25,  //  0052  GETMBR	R11	R6	K37
       0x902A4A0B,  //  0053  SETMBR	R10	K37	R11
-      0x882C0D26,  //  0054  GETMBR	R11	R6	K38
-      0x902A4C0B,  //  0055  SETMBR	R10	K38	R11
-      0x8C2C1527,  //  0056  GETMET	R11	R10	K39
-      0x7C2C0200,  //  0057  CALL	R11	1
-      0x88300D29,  //  0058  GETMBR	R12	R6	K41
-      0x900E500C,  //  0059  SETMBR	R3	K40	R12
-      0x88300D2B,  //  005A  GETMBR	R12	R6	K43
-      0x900E540C,  //  005B  SETMBR	R3	K42	R12
-      0x8C30032C,  //  005C  GETMET	R12	R1	K44
-      0x543A0022,  //  005D  LDINT	R14	35
-      0x503C0200,  //  005E  LDBOOL	R15	1	0
-      0x7C300600,  //  005F  CALL	R12	3
-      0x8C34192D,  //  0060  GETMET	R13	R12	K45
-      0x5C3C1600,  //  0061  MOVE	R15	R11
-      0x7C340400,  //  0062  CALL	R13	2
-      0xB83A0C00,  //  0063  GETNGBL	R14	K6
-      0x8C381D07,  //  0064  GETMET	R14	R14	K7
-      0x60400018,  //  0065  GETGBL	R16	G24
-      0x5844002E,  //  0066  LDCONST	R17	K46
-      0x8848072F,  //  0067  GETMBR	R18	R3	K47
-      0x884C0730,  //  0068  GETMBR	R19	R3	K48
-      0x88500731,  //  0069  GETMBR	R20	R3	K49
-      0x7C400800,  //  006A  CALL	R16	4
-      0x5844000D,  //  006B  LDCONST	R17	K13
-      0x7C380600,  //  006C  CALL	R14	3
-      0x88380132,  //  006D  GETMBR	R14	R0	K50
-      0x8C381D33,  //  006E  GETMET	R14	R14	K51
-      0x5C401800,  //  006F  MOVE	R16	R12
-      0x7C380400,  //  0070  CALL	R14	2
-      0x50380200,  //  0071  LDBOOL	R14	1	0
-      0x80041C00,  //  0072  RET	1	R14
+      0x8C2C1526,  //  0054  GETMET	R11	R10	K38
+      0x7C2C0200,  //  0055  CALL	R11	1
+      0x88300D28,  //  0056  GETMBR	R12	R6	K40
+      0x900E4E0C,  //  0057  SETMBR	R3	K39	R12
+      0x88300D2A,  //  0058  GETMBR	R12	R6	K42
+      0x900E520C,  //  0059  SETMBR	R3	K41	R12
+      0x8C30032B,  //  005A  GETMET	R12	R1	K43
+      0x543A0022,  //  005B  LDINT	R14	35
+      0x503C0200,  //  005C  LDBOOL	R15	1	0
+      0x7C300600,  //  005D  CALL	R12	3
+      0x8C34192C,  //  005E  GETMET	R13	R12	K44
+      0x5C3C1600,  //  005F  MOVE	R15	R11
+      0x7C340400,  //  0060  CALL	R13	2
+      0xB83A0C00,  //  0061  GETNGBL	R14	K6
+      0x603C0018,  //  0062  GETGBL	R15	G24
+      0x5840002D,  //  0063  LDCONST	R16	K45
+      0x8844072E,  //  0064  GETMBR	R17	R3	K46
+      0x8848072F,  //  0065  GETMBR	R18	R3	K47
+      0x884C0730,  //  0066  GETMBR	R19	R3	K48
+      0x7C3C0800,  //  0067  CALL	R15	4
+      0x5840000C,  //  0068  LDCONST	R16	K12
+      0x7C380400,  //  0069  CALL	R14	2
+      0x88380131,  //  006A  GETMBR	R14	R0	K49
+      0x8C381D32,  //  006B  GETMET	R14	R14	K50
+      0x5C401800,  //  006C  MOVE	R16	R12
+      0x7C380400,  //  006D  CALL	R14	2
+      0x50380200,  //  006E  LDBOOL	R14	1	0
+      0x80041C00,  //  006F  RET	1	R14
     })
   )
 );
@@ -743,22 +727,22 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Pake3,   /* name */
     /* K3   */  be_nested_str_weak(local_session_id),
     /* K4   */  be_const_int(0),
     /* K5   */  be_nested_str_weak(protocol_id),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20invalid_X20Pake3_X20message),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K11  */  be_nested_str_weak(send_status_report),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_const_int(2),
-    /* K14  */  be_nested_str_weak(matter),
-    /* K15  */  be_nested_str_weak(Pake3),
-    /* K16  */  be_nested_str_weak(parse),
-    /* K17  */  be_nested_str_weak(raw),
-    /* K18  */  be_nested_str_weak(app_payload_idx),
-    /* K19  */  be_nested_str_weak(cA),
-    /* K20  */  be_nested_str_weak(__spake_cA),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20invalid_X20cA_X20received),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20invalid_X20Pake3_X20message),
+    /* K8   */  be_const_int(3),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
+    /* K10  */  be_nested_str_weak(send_status_report),
+    /* K11  */  be_const_int(1),
+    /* K12  */  be_const_int(2),
+    /* K13  */  be_nested_str_weak(matter),
+    /* K14  */  be_nested_str_weak(Pake3),
+    /* K15  */  be_nested_str_weak(parse),
+    /* K16  */  be_nested_str_weak(raw),
+    /* K17  */  be_nested_str_weak(app_payload_idx),
+    /* K18  */  be_nested_str_weak(cA),
+    /* K19  */  be_nested_str_weak(__spake_cA),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20invalid_X20cA_X20received),
+    /* K21  */  be_nested_str_weak(tasmota),
     /* K22  */  be_nested_str_weak(rtc_utc),
     /* K23  */  be_nested_str_weak(HKDF_SHA256),
     /* K24  */  be_nested_str_weak(derive),
@@ -771,7 +755,7 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Pake3,   /* name */
     }),
     be_str_weak(parse_Pake3),
     &be_const_str_solidified,
-    ( &(const binstruction[105]) {  /* code */
+    ( &(const binstruction[101]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0x880C0301,  //  0001  GETMBR	R3	R1	K1
       0x88100302,  //  0002  GETMBR	R4	R1	K2
@@ -783,100 +767,96 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Pake3,   /* name */
       0x74120002,  //  0008  JMPT	R4	#000C
       0x88100305,  //  0009  GETMBR	R4	R1	K5
       0x20100904,  //  000A  NE	R4	R4	K4
-      0x78120012,  //  000B  JMPF	R4	#001F
+      0x78120010,  //  000B  JMPF	R4	#001D
       0xB8120C00,  //  000C  GETNGBL	R4	K6
-      0x8C100907,  //  000D  GETMET	R4	R4	K7
+      0x58140007,  //  000D  LDCONST	R5	K7
       0x58180008,  //  000E  LDCONST	R6	K8
-      0x581C0009,  //  000F  LDCONST	R7	K9
-      0x7C100600,  //  0010  CALL	R4	3
-      0xB8120C00,  //  0011  GETNGBL	R4	K6
-      0x8C100907,  //  0012  GETMET	R4	R4	K7
-      0x5818000A,  //  0013  LDCONST	R6	K10
-      0x581C0009,  //  0014  LDCONST	R7	K9
-      0x7C100600,  //  0015  CALL	R4	3
-      0x8C10010B,  //  0016  GETMET	R4	R0	K11
-      0x5C180200,  //  0017  MOVE	R6	R1
-      0x581C000C,  //  0018  LDCONST	R7	K12
-      0x58200004,  //  0019  LDCONST	R8	K4
-      0x5824000D,  //  001A  LDCONST	R9	K13
-      0x50280000,  //  001B  LDBOOL	R10	0	0
-      0x7C100C00,  //  001C  CALL	R4	6
-      0x50100000,  //  001D  LDBOOL	R4	0	0
-      0x80040800,  //  001E  RET	1	R4
-      0xB8121C00,  //  001F  GETNGBL	R4	K14
+      0x7C100400,  //  000F  CALL	R4	2
+      0xB8120C00,  //  0010  GETNGBL	R4	K6
+      0x58140009,  //  0011  LDCONST	R5	K9
+      0x58180008,  //  0012  LDCONST	R6	K8
+      0x7C100400,  //  0013  CALL	R4	2
+      0x8C10010A,  //  0014  GETMET	R4	R0	K10
+      0x5C180200,  //  0015  MOVE	R6	R1
+      0x581C000B,  //  0016  LDCONST	R7	K11
+      0x58200004,  //  0017  LDCONST	R8	K4
+      0x5824000C,  //  0018  LDCONST	R9	K12
+      0x50280000,  //  0019  LDBOOL	R10	0	0
+      0x7C100C00,  //  001A  CALL	R4	6
+      0x50100000,  //  001B  LDBOOL	R4	0	0
+      0x80040800,  //  001C  RET	1	R4
+      0xB8121A00,  //  001D  GETNGBL	R4	K13
+      0x8C10090E,  //  001E  GETMET	R4	R4	K14
+      0x7C100200,  //  001F  CALL	R4	1
       0x8C10090F,  //  0020  GETMET	R4	R4	K15
-      0x7C100200,  //  0021  CALL	R4	1
-      0x8C100910,  //  0022  GETMET	R4	R4	K16
-      0x88180311,  //  0023  GETMBR	R6	R1	K17
-      0x881C0312,  //  0024  GETMBR	R7	R1	K18
-      0x7C100600,  //  0025  CALL	R4	3
-      0x88140913,  //  0026  GETMBR	R5	R4	K19
-      0x88180714,  //  0027  GETMBR	R6	R3	K20
-      0x20180A06,  //  0028  NE	R6	R5	R6
-      0x781A0012,  //  0029  JMPF	R6	#003D
-      0xB81A0C00,  //  002A  GETNGBL	R6	K6
-      0x8C180D07,  //  002B  GETMET	R6	R6	K7
-      0x58200015,  //  002C  LDCONST	R8	K21
-      0x58240009,  //  002D  LDCONST	R9	K9
-      0x7C180600,  //  002E  CALL	R6	3
-      0xB81A0C00,  //  002F  GETNGBL	R6	K6
-      0x8C180D07,  //  0030  GETMET	R6	R6	K7
-      0x5820000A,  //  0031  LDCONST	R8	K10
-      0x58240009,  //  0032  LDCONST	R9	K9
-      0x7C180600,  //  0033  CALL	R6	3
-      0x8C18010B,  //  0034  GETMET	R6	R0	K11
-      0x5C200200,  //  0035  MOVE	R8	R1
-      0x5824000C,  //  0036  LDCONST	R9	K12
-      0x58280004,  //  0037  LDCONST	R10	K4
-      0x582C000D,  //  0038  LDCONST	R11	K13
-      0x50300000,  //  0039  LDBOOL	R12	0	0
-      0x7C180C00,  //  003A  CALL	R6	6
-      0x50180000,  //  003B  LDBOOL	R6	0	0
-      0x80040C00,  //  003C  RET	1	R6
-      0xB81A0C00,  //  003D  GETNGBL	R6	K6
-      0x8C180D16,  //  003E  GETMET	R6	R6	K22
-      0x7C180200,  //  003F  CALL	R6	1
-      0x8C1C0517,  //  0040  GETMET	R7	R2	K23
-      0x7C1C0200,  //  0041  CALL	R7	1
-      0x8C1C0F18,  //  0042  GETMET	R7	R7	K24
-      0x88240719,  //  0043  GETMBR	R9	R3	K25
-      0x60280015,  //  0044  GETGBL	R10	G21
-      0x7C280000,  //  0045  CALL	R10	0
-      0x602C0015,  //  0046  GETGBL	R11	G21
-      0x7C2C0000,  //  0047  CALL	R11	0
-      0x8C2C171A,  //  0048  GETMET	R11	R11	K26
-      0x8834011B,  //  0049  GETMBR	R13	R0	K27
-      0x7C2C0400,  //  004A  CALL	R11	2
-      0x5432002F,  //  004B  LDINT	R12	48
-      0x7C1C0A00,  //  004C  CALL	R7	5
-      0x5422000E,  //  004D  LDINT	R8	15
-      0x40220808,  //  004E  CONNECT	R8	K4	R8
-      0x94200E08,  //  004F  GETIDX	R8	R7	R8
-      0x5426000F,  //  0050  LDINT	R9	16
-      0x542A001E,  //  0051  LDINT	R10	31
-      0x4024120A,  //  0052  CONNECT	R9	R9	R10
-      0x94240E09,  //  0053  GETIDX	R9	R7	R9
-      0x542A001F,  //  0054  LDINT	R10	32
-      0x542E002E,  //  0055  LDINT	R11	47
-      0x4028140B,  //  0056  CONNECT	R10	R10	R11
-      0x94280E0A,  //  0057  GETIDX	R10	R7	R10
-      0x8C2C010B,  //  0058  GETMET	R11	R0	K11
-      0x5C340200,  //  0059  MOVE	R13	R1
-      0x58380004,  //  005A  LDCONST	R14	K4
-      0x583C0004,  //  005B  LDCONST	R15	K4
-      0x58400004,  //  005C  LDCONST	R16	K4
-      0x50440000,  //  005D  LDBOOL	R17	0	0
-      0x7C2C0C00,  //  005E  CALL	R11	6
-      0x8C2C011C,  //  005F  GETMET	R11	R0	K28
-      0x8834071D,  //  0060  GETMBR	R13	R3	K29
-      0x8838071E,  //  0061  GETMBR	R14	R3	K30
-      0x5C3C1000,  //  0062  MOVE	R15	R8
-      0x5C401200,  //  0063  MOVE	R16	R9
-      0x5C441400,  //  0064  MOVE	R17	R10
-      0x5C480C00,  //  0065  MOVE	R18	R6
-      0x7C2C0E00,  //  0066  CALL	R11	7
-      0x502C0200,  //  0067  LDBOOL	R11	1	0
-      0x80041600,  //  0068  RET	1	R11
+      0x88180310,  //  0021  GETMBR	R6	R1	K16
+      0x881C0311,  //  0022  GETMBR	R7	R1	K17
+      0x7C100600,  //  0023  CALL	R4	3
+      0x88140912,  //  0024  GETMBR	R5	R4	K18
+      0x88180713,  //  0025  GETMBR	R6	R3	K19
+      0x20180A06,  //  0026  NE	R6	R5	R6
+      0x781A0010,  //  0027  JMPF	R6	#0039
+      0xB81A0C00,  //  0028  GETNGBL	R6	K6
+      0x581C0014,  //  0029  LDCONST	R7	K20
+      0x58200008,  //  002A  LDCONST	R8	K8
+      0x7C180400,  //  002B  CALL	R6	2
+      0xB81A0C00,  //  002C  GETNGBL	R6	K6
+      0x581C0009,  //  002D  LDCONST	R7	K9
+      0x58200008,  //  002E  LDCONST	R8	K8
+      0x7C180400,  //  002F  CALL	R6	2
+      0x8C18010A,  //  0030  GETMET	R6	R0	K10
+      0x5C200200,  //  0031  MOVE	R8	R1
+      0x5824000B,  //  0032  LDCONST	R9	K11
+      0x58280004,  //  0033  LDCONST	R10	K4
+      0x582C000C,  //  0034  LDCONST	R11	K12
+      0x50300000,  //  0035  LDBOOL	R12	0	0
+      0x7C180C00,  //  0036  CALL	R6	6
+      0x50180000,  //  0037  LDBOOL	R6	0	0
+      0x80040C00,  //  0038  RET	1	R6
+      0xB81A2A00,  //  0039  GETNGBL	R6	K21
+      0x8C180D16,  //  003A  GETMET	R6	R6	K22
+      0x7C180200,  //  003B  CALL	R6	1
+      0x8C1C0517,  //  003C  GETMET	R7	R2	K23
+      0x7C1C0200,  //  003D  CALL	R7	1
+      0x8C1C0F18,  //  003E  GETMET	R7	R7	K24
+      0x88240719,  //  003F  GETMBR	R9	R3	K25
+      0x60280015,  //  0040  GETGBL	R10	G21
+      0x7C280000,  //  0041  CALL	R10	0
+      0x602C0015,  //  0042  GETGBL	R11	G21
+      0x7C2C0000,  //  0043  CALL	R11	0
+      0x8C2C171A,  //  0044  GETMET	R11	R11	K26
+      0x8834011B,  //  0045  GETMBR	R13	R0	K27
+      0x7C2C0400,  //  0046  CALL	R11	2
+      0x5432002F,  //  0047  LDINT	R12	48
+      0x7C1C0A00,  //  0048  CALL	R7	5
+      0x5422000E,  //  0049  LDINT	R8	15
+      0x40220808,  //  004A  CONNECT	R8	K4	R8
+      0x94200E08,  //  004B  GETIDX	R8	R7	R8
+      0x5426000F,  //  004C  LDINT	R9	16
+      0x542A001E,  //  004D  LDINT	R10	31
+      0x4024120A,  //  004E  CONNECT	R9	R9	R10
+      0x94240E09,  //  004F  GETIDX	R9	R7	R9
+      0x542A001F,  //  0050  LDINT	R10	32
+      0x542E002E,  //  0051  LDINT	R11	47
+      0x4028140B,  //  0052  CONNECT	R10	R10	R11
+      0x94280E0A,  //  0053  GETIDX	R10	R7	R10
+      0x8C2C010A,  //  0054  GETMET	R11	R0	K10
+      0x5C340200,  //  0055  MOVE	R13	R1
+      0x58380004,  //  0056  LDCONST	R14	K4
+      0x583C0004,  //  0057  LDCONST	R15	K4
+      0x58400004,  //  0058  LDCONST	R16	K4
+      0x50440000,  //  0059  LDBOOL	R17	0	0
+      0x7C2C0C00,  //  005A  CALL	R11	6
+      0x8C2C011C,  //  005B  GETMET	R11	R0	K28
+      0x8834071D,  //  005C  GETMBR	R13	R3	K29
+      0x8838071E,  //  005D  GETMBR	R14	R3	K30
+      0x5C3C1000,  //  005E  MOVE	R15	R8
+      0x5C401200,  //  005F  MOVE	R16	R9
+      0x5C441400,  //  0060  MOVE	R17	R10
+      0x5C480C00,  //  0061  MOVE	R18	R6
+      0x7C2C0E00,  //  0062  CALL	R11	7
+      0x502C0200,  //  0063  LDBOOL	R11	1	0
+      0x80041600,  //  0064  RET	1	R11
     })
   )
 );
@@ -903,58 +883,58 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma3,   /* name */
     /* K2   */  be_nested_str_weak(local_session_id),
     /* K3   */  be_const_int(0),
     /* K4   */  be_nested_str_weak(protocol_id),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str_weak(send_status_report),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(session),
-    /* K13  */  be_nested_str_weak(matter),
-    /* K14  */  be_nested_str_weak(Sigma3),
-    /* K15  */  be_nested_str_weak(parse),
-    /* K16  */  be_nested_str_weak(raw),
-    /* K17  */  be_nested_str_weak(app_payload_idx),
-    /* K18  */  be_nested_str_weak(SHA256),
-    /* K19  */  be_nested_str_weak(update),
-    /* K20  */  be_nested_str_weak(__Msg1),
-    /* K21  */  be_nested_str_weak(__Msg2),
-    /* K22  */  be_nested_str_weak(out),
-    /* K23  */  be_nested_str_weak(fromstring),
-    /* K24  */  be_nested_str_weak(S3K_Info),
-    /* K25  */  be_nested_str_weak(HKDF_SHA256),
-    /* K26  */  be_nested_str_weak(derive),
-    /* K27  */  be_nested_str_weak(shared_secret),
-    /* K28  */  be_nested_str_weak(get_ipk_group_key),
-    /* K29  */  be_nested_str_weak(TBEData3Encrypted),
-    /* K30  */  be_const_int(2147483647),
-    /* K31  */  be_nested_str_weak(AES_CCM),
-    /* K32  */  be_nested_str_weak(TBEData3_Nonce),
-    /* K33  */  be_nested_str_weak(decrypt),
-    /* K34  */  be_nested_str_weak(tag),
-    /* K35  */  be_nested_str_weak(MTR_X3A_X20Tag_X20don_X27t_X20match),
-    /* K36  */  be_nested_str_weak(TLV),
-    /* K37  */  be_nested_str_weak(findsubval),
-    /* K38  */  be_nested_str_weak(findsub),
-    /* K39  */  be_nested_str_weak(int),
-    /* K40  */  be_nested_str_weak(peer_node_id),
-    /* K41  */  be_nested_str_weak(int64),
-    /* K42  */  be_nested_str_weak(fromu32),
-    /* K43  */  be_nested_str_weak(tobytes),
-    /* K44  */  be_nested_str_weak(Matter_TLV_struct),
-    /* K45  */  be_nested_str_weak(add_TLV),
-    /* K46  */  be_nested_str_weak(B1),
-    /* K47  */  be_nested_str_weak(__initiator_pub),
-    /* K48  */  be_nested_str_weak(__responder_pub),
-    /* K49  */  be_nested_str_weak(tlv2raw),
-    /* K50  */  be_nested_str_weak(EC_P256),
-    /* K51  */  be_nested_str_weak(ecdsa_verify_sha256),
-    /* K52  */  be_nested_str_weak(MTR_X3A_X20sigma3_tbs_X20does_X20not_X20have_X20a_X20valid_X20signature),
-    /* K53  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X20Invalid_X20signature_X2C_X20trying_X20anyways),
-    /* K54  */  be_nested_str_weak(MTR_X3A_X20Sigma3_X20verified_X2C_X20computing_X20new_X20keys),
-    /* K55  */  be_nested_str_weak(Msg3),
-    /* K56  */  be_nested_str_weak(SEKeys_Info),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
+    /* K7   */  be_const_int(3),
+    /* K8   */  be_nested_str_weak(send_status_report),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(session),
+    /* K12  */  be_nested_str_weak(matter),
+    /* K13  */  be_nested_str_weak(Sigma3),
+    /* K14  */  be_nested_str_weak(parse),
+    /* K15  */  be_nested_str_weak(raw),
+    /* K16  */  be_nested_str_weak(app_payload_idx),
+    /* K17  */  be_nested_str_weak(SHA256),
+    /* K18  */  be_nested_str_weak(update),
+    /* K19  */  be_nested_str_weak(__Msg1),
+    /* K20  */  be_nested_str_weak(__Msg2),
+    /* K21  */  be_nested_str_weak(out),
+    /* K22  */  be_nested_str_weak(fromstring),
+    /* K23  */  be_nested_str_weak(S3K_Info),
+    /* K24  */  be_nested_str_weak(HKDF_SHA256),
+    /* K25  */  be_nested_str_weak(derive),
+    /* K26  */  be_nested_str_weak(shared_secret),
+    /* K27  */  be_nested_str_weak(get_ipk_group_key),
+    /* K28  */  be_nested_str_weak(TBEData3Encrypted),
+    /* K29  */  be_const_int(2147483647),
+    /* K30  */  be_nested_str_weak(AES_CCM),
+    /* K31  */  be_nested_str_weak(TBEData3_Nonce),
+    /* K32  */  be_nested_str_weak(decrypt),
+    /* K33  */  be_nested_str_weak(tag),
+    /* K34  */  be_nested_str_weak(MTR_X3A_X20Tag_X20don_X27t_X20match),
+    /* K35  */  be_nested_str_weak(TLV),
+    /* K36  */  be_nested_str_weak(findsubval),
+    /* K37  */  be_nested_str_weak(findsub),
+    /* K38  */  be_nested_str_weak(int),
+    /* K39  */  be_nested_str_weak(peer_node_id),
+    /* K40  */  be_nested_str_weak(int64),
+    /* K41  */  be_nested_str_weak(fromu32),
+    /* K42  */  be_nested_str_weak(tobytes),
+    /* K43  */  be_nested_str_weak(Matter_TLV_struct),
+    /* K44  */  be_nested_str_weak(add_TLV),
+    /* K45  */  be_nested_str_weak(B1),
+    /* K46  */  be_nested_str_weak(__initiator_pub),
+    /* K47  */  be_nested_str_weak(__responder_pub),
+    /* K48  */  be_nested_str_weak(tlv2raw),
+    /* K49  */  be_nested_str_weak(EC_P256),
+    /* K50  */  be_nested_str_weak(ecdsa_verify_sha256),
+    /* K51  */  be_nested_str_weak(MTR_X3A_X20sigma3_tbs_X20does_X20not_X20have_X20a_X20valid_X20signature),
+    /* K52  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X20Invalid_X20signature_X2C_X20trying_X20anyways),
+    /* K53  */  be_nested_str_weak(MTR_X3A_X20Sigma3_X20verified_X2C_X20computing_X20new_X20keys),
+    /* K54  */  be_nested_str_weak(Msg3),
+    /* K55  */  be_nested_str_weak(SEKeys_Info),
+    /* K56  */  be_nested_str_weak(tasmota),
     /* K57  */  be_nested_str_weak(rtc_utc),
     /* K58  */  be_nested_str_weak(close),
     /* K59  */  be_nested_str_weak(set_keys),
@@ -967,7 +947,7 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma3,   /* name */
     }),
     be_str_weak(parse_Sigma3),
     &be_const_str_solidified,
-    ( &(const binstruction[286]) {  /* code */
+    ( &(const binstruction[280]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0x880C0301,  //  0001  GETMBR	R3	R1	K1
       0x54120031,  //  0002  LDINT	R4	50
@@ -978,282 +958,276 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma3,   /* name */
       0x740E0002,  //  0007  JMPT	R3	#000B
       0x880C0304,  //  0008  GETMBR	R3	R1	K4
       0x200C0703,  //  0009  NE	R3	R3	K3
-      0x780E000D,  //  000A  JMPF	R3	#0019
+      0x780E000C,  //  000A  JMPF	R3	#0018
       0xB80E0A00,  //  000B  GETNGBL	R3	K5
-      0x8C0C0706,  //  000C  GETMET	R3	R3	K6
+      0x58100006,  //  000C  LDCONST	R4	K6
       0x58140007,  //  000D  LDCONST	R5	K7
-      0x58180008,  //  000E  LDCONST	R6	K8
-      0x7C0C0600,  //  000F  CALL	R3	3
-      0x8C0C0109,  //  0010  GETMET	R3	R0	K9
-      0x5C140200,  //  0011  MOVE	R5	R1
-      0x5818000A,  //  0012  LDCONST	R6	K10
-      0x581C0003,  //  0013  LDCONST	R7	K3
-      0x5820000B,  //  0014  LDCONST	R8	K11
-      0x50240000,  //  0015  LDBOOL	R9	0	0
-      0x7C0C0C00,  //  0016  CALL	R3	6
-      0x500C0000,  //  0017  LDBOOL	R3	0	0
-      0x80040600,  //  0018  RET	1	R3
-      0x880C030C,  //  0019  GETMBR	R3	R1	K12
-      0xB8121A00,  //  001A  GETNGBL	R4	K13
-      0x8C10090E,  //  001B  GETMET	R4	R4	K14
-      0x7C100200,  //  001C  CALL	R4	1
-      0x8C10090F,  //  001D  GETMET	R4	R4	K15
-      0x88180310,  //  001E  GETMBR	R6	R1	K16
-      0x881C0311,  //  001F  GETMBR	R7	R1	K17
-      0x7C100600,  //  0020  CALL	R4	3
-      0x8C140512,  //  0021  GETMET	R5	R2	K18
-      0x7C140200,  //  0022  CALL	R5	1
-      0x8C140B13,  //  0023  GETMET	R5	R5	K19
-      0x881C0714,  //  0024  GETMBR	R7	R3	K20
-      0x7C140400,  //  0025  CALL	R5	2
-      0x8C140B13,  //  0026  GETMET	R5	R5	K19
-      0x881C0715,  //  0027  GETMBR	R7	R3	K21
-      0x7C140400,  //  0028  CALL	R5	2
-      0x8C140B16,  //  0029  GETMET	R5	R5	K22
-      0x7C140200,  //  002A  CALL	R5	1
-      0x60180015,  //  002B  GETGBL	R6	G21
-      0x7C180000,  //  002C  CALL	R6	0
-      0x8C180D17,  //  002D  GETMET	R6	R6	K23
-      0x88200118,  //  002E  GETMBR	R8	R0	K24
-      0x7C180400,  //  002F  CALL	R6	2
-      0x8C1C0519,  //  0030  GETMET	R7	R2	K25
-      0x7C1C0200,  //  0031  CALL	R7	1
-      0x8C1C0F1A,  //  0032  GETMET	R7	R7	K26
-      0x8824071B,  //  0033  GETMBR	R9	R3	K27
-      0x8C28071C,  //  0034  GETMET	R10	R3	K28
-      0x7C280200,  //  0035  CALL	R10	1
-      0x00281405,  //  0036  ADD	R10	R10	R5
-      0x5C2C0C00,  //  0037  MOVE	R11	R6
-      0x5432000F,  //  0038  LDINT	R12	16
-      0x7C1C0A00,  //  0039  CALL	R7	5
-      0x5421FFEE,  //  003A  LDINT	R8	-17
-      0x40220608,  //  003B  CONNECT	R8	K3	R8
-      0x8824091D,  //  003C  GETMBR	R9	R4	K29
-      0x94201208,  //  003D  GETIDX	R8	R9	R8
-      0x5429FFEF,  //  003E  LDINT	R10	-16
-      0x4028151E,  //  003F  CONNECT	R10	R10	K30
-      0x882C091D,  //  0040  GETMBR	R11	R4	K29
-      0x9424160A,  //  0041  GETIDX	R9	R11	R10
-      0x8C30051F,  //  0042  GETMET	R12	R2	K31
-      0x5C380E00,  //  0043  MOVE	R14	R7
-      0x603C0015,  //  0044  GETGBL	R15	G21
-      0x7C3C0000,  //  0045  CALL	R15	0
-      0x8C3C1F17,  //  0046  GETMET	R15	R15	K23
-      0x88440120,  //  0047  GETMBR	R17	R0	K32
-      0x7C3C0400,  //  0048  CALL	R15	2
-      0x60400015,  //  0049  GETGBL	R16	G21
-      0x7C400000,  //  004A  CALL	R16	0
-      0x6044000C,  //  004B  GETGBL	R17	G12
-      0x5C481000,  //  004C  MOVE	R18	R8
-      0x7C440200,  //  004D  CALL	R17	1
-      0x544A000F,  //  004E  LDINT	R18	16
-      0x7C300C00,  //  004F  CALL	R12	6
-      0x5C281800,  //  0050  MOVE	R10	R12
-      0x8C301521,  //  0051  GETMET	R12	R10	K33
-      0x5C381000,  //  0052  MOVE	R14	R8
-      0x7C300400,  //  0053  CALL	R12	2
-      0x5C2C1800,  //  0054  MOVE	R11	R12
-      0x8C301522,  //  0055  GETMET	R12	R10	K34
-      0x7C300200,  //  0056  CALL	R12	1
-      0x20341809,  //  0057  NE	R13	R12	R9
-      0x78360012,  //  0058  JMPF	R13	#006C
-      0xB8360A00,  //  0059  GETNGBL	R13	K5
-      0x8C341B06,  //  005A  GETMET	R13	R13	K6
-      0x583C0023,  //  005B  LDCONST	R15	K35
-      0x58400008,  //  005C  LDCONST	R16	K8
-      0x7C340600,  //  005D  CALL	R13	3
-      0xB8360A00,  //  005E  GETNGBL	R13	K5
-      0x8C341B06,  //  005F  GETMET	R13	R13	K6
-      0x583C0007,  //  0060  LDCONST	R15	K7
-      0x58400008,  //  0061  LDCONST	R16	K8
-      0x7C340600,  //  0062  CALL	R13	3
-      0x8C340109,  //  0063  GETMET	R13	R0	K9
-      0x5C3C0200,  //  0064  MOVE	R15	R1
-      0x5840000A,  //  0065  LDCONST	R16	K10
-      0x58440003,  //  0066  LDCONST	R17	K3
-      0x5848000B,  //  0067  LDCONST	R18	K11
-      0x504C0000,  //  0068  LDBOOL	R19	0	0
-      0x7C340C00,  //  0069  CALL	R13	6
-      0x50340000,  //  006A  LDBOOL	R13	0	0
-      0x80041A00,  //  006B  RET	1	R13
-      0xB8361A00,  //  006C  GETNGBL	R13	K13
-      0x88341B24,  //  006D  GETMBR	R13	R13	K36
-      0x8C341B0F,  //  006E  GETMET	R13	R13	K15
-      0x5C3C1600,  //  006F  MOVE	R15	R11
-      0x7C340400,  //  0070  CALL	R13	2
-      0x8C381B25,  //  0071  GETMET	R14	R13	K37
-      0x5840000A,  //  0072  LDCONST	R16	K10
-      0x7C380400,  //  0073  CALL	R14	2
-      0x8C3C1B25,  //  0074  GETMET	R15	R13	K37
-      0x5844000B,  //  0075  LDCONST	R17	K11
-      0x7C3C0400,  //  0076  CALL	R15	2
-      0x8C401B25,  //  0077  GETMET	R16	R13	K37
-      0x58480008,  //  0078  LDCONST	R18	K8
-      0x7C400400,  //  0079  CALL	R16	2
-      0xB8461A00,  //  007A  GETNGBL	R17	K13
-      0x88442324,  //  007B  GETMBR	R17	R17	K36
-      0x8C44230F,  //  007C  GETMET	R17	R17	K15
-      0x5C4C1C00,  //  007D  MOVE	R19	R14
-      0x7C440400,  //  007E  CALL	R17	2
-      0x8C482325,  //  007F  GETMET	R18	R17	K37
-      0x54520008,  //  0080  LDINT	R20	9
-      0x7C480400,  //  0081  CALL	R18	2
-      0x8C4C2326,  //  0082  GETMET	R19	R17	K38
-      0x54560005,  //  0083  LDINT	R21	6
-      0x7C4C0400,  //  0084  CALL	R19	2
-      0x8C502725,  //  0085  GETMET	R20	R19	K37
-      0x545A0010,  //  0086  LDINT	R22	17
-      0x7C500400,  //  0087  CALL	R20	2
-      0x60540004,  //  0088  GETGBL	R21	G4
-      0x5C582800,  //  0089  MOVE	R22	R20
-      0x7C540200,  //  008A  CALL	R21	1
-      0x1C542B27,  //  008B  EQ	R21	R21	K39
-      0x78560007,  //  008C  JMPF	R21	#0095
-      0xB8565200,  //  008D  GETNGBL	R21	K41
+      0x7C0C0400,  //  000E  CALL	R3	2
+      0x8C0C0108,  //  000F  GETMET	R3	R0	K8
+      0x5C140200,  //  0010  MOVE	R5	R1
+      0x58180009,  //  0011  LDCONST	R6	K9
+      0x581C0003,  //  0012  LDCONST	R7	K3
+      0x5820000A,  //  0013  LDCONST	R8	K10
+      0x50240000,  //  0014  LDBOOL	R9	0	0
+      0x7C0C0C00,  //  0015  CALL	R3	6
+      0x500C0000,  //  0016  LDBOOL	R3	0	0
+      0x80040600,  //  0017  RET	1	R3
+      0x880C030B,  //  0018  GETMBR	R3	R1	K11
+      0xB8121800,  //  0019  GETNGBL	R4	K12
+      0x8C10090D,  //  001A  GETMET	R4	R4	K13
+      0x7C100200,  //  001B  CALL	R4	1
+      0x8C10090E,  //  001C  GETMET	R4	R4	K14
+      0x8818030F,  //  001D  GETMBR	R6	R1	K15
+      0x881C0310,  //  001E  GETMBR	R7	R1	K16
+      0x7C100600,  //  001F  CALL	R4	3
+      0x8C140511,  //  0020  GETMET	R5	R2	K17
+      0x7C140200,  //  0021  CALL	R5	1
+      0x8C140B12,  //  0022  GETMET	R5	R5	K18
+      0x881C0713,  //  0023  GETMBR	R7	R3	K19
+      0x7C140400,  //  0024  CALL	R5	2
+      0x8C140B12,  //  0025  GETMET	R5	R5	K18
+      0x881C0714,  //  0026  GETMBR	R7	R3	K20
+      0x7C140400,  //  0027  CALL	R5	2
+      0x8C140B15,  //  0028  GETMET	R5	R5	K21
+      0x7C140200,  //  0029  CALL	R5	1
+      0x60180015,  //  002A  GETGBL	R6	G21
+      0x7C180000,  //  002B  CALL	R6	0
+      0x8C180D16,  //  002C  GETMET	R6	R6	K22
+      0x88200117,  //  002D  GETMBR	R8	R0	K23
+      0x7C180400,  //  002E  CALL	R6	2
+      0x8C1C0518,  //  002F  GETMET	R7	R2	K24
+      0x7C1C0200,  //  0030  CALL	R7	1
+      0x8C1C0F19,  //  0031  GETMET	R7	R7	K25
+      0x8824071A,  //  0032  GETMBR	R9	R3	K26
+      0x8C28071B,  //  0033  GETMET	R10	R3	K27
+      0x7C280200,  //  0034  CALL	R10	1
+      0x00281405,  //  0035  ADD	R10	R10	R5
+      0x5C2C0C00,  //  0036  MOVE	R11	R6
+      0x5432000F,  //  0037  LDINT	R12	16
+      0x7C1C0A00,  //  0038  CALL	R7	5
+      0x5421FFEE,  //  0039  LDINT	R8	-17
+      0x40220608,  //  003A  CONNECT	R8	K3	R8
+      0x8824091C,  //  003B  GETMBR	R9	R4	K28
+      0x94201208,  //  003C  GETIDX	R8	R9	R8
+      0x5429FFEF,  //  003D  LDINT	R10	-16
+      0x4028151D,  //  003E  CONNECT	R10	R10	K29
+      0x882C091C,  //  003F  GETMBR	R11	R4	K28
+      0x9424160A,  //  0040  GETIDX	R9	R11	R10
+      0x8C30051E,  //  0041  GETMET	R12	R2	K30
+      0x5C380E00,  //  0042  MOVE	R14	R7
+      0x603C0015,  //  0043  GETGBL	R15	G21
+      0x7C3C0000,  //  0044  CALL	R15	0
+      0x8C3C1F16,  //  0045  GETMET	R15	R15	K22
+      0x8844011F,  //  0046  GETMBR	R17	R0	K31
+      0x7C3C0400,  //  0047  CALL	R15	2
+      0x60400015,  //  0048  GETGBL	R16	G21
+      0x7C400000,  //  0049  CALL	R16	0
+      0x6044000C,  //  004A  GETGBL	R17	G12
+      0x5C481000,  //  004B  MOVE	R18	R8
+      0x7C440200,  //  004C  CALL	R17	1
+      0x544A000F,  //  004D  LDINT	R18	16
+      0x7C300C00,  //  004E  CALL	R12	6
+      0x5C281800,  //  004F  MOVE	R10	R12
+      0x8C301520,  //  0050  GETMET	R12	R10	K32
+      0x5C381000,  //  0051  MOVE	R14	R8
+      0x7C300400,  //  0052  CALL	R12	2
+      0x5C2C1800,  //  0053  MOVE	R11	R12
+      0x8C301521,  //  0054  GETMET	R12	R10	K33
+      0x7C300200,  //  0055  CALL	R12	1
+      0x20341809,  //  0056  NE	R13	R12	R9
+      0x78360010,  //  0057  JMPF	R13	#0069
+      0xB8360A00,  //  0058  GETNGBL	R13	K5
+      0x58380022,  //  0059  LDCONST	R14	K34
+      0x583C0007,  //  005A  LDCONST	R15	K7
+      0x7C340400,  //  005B  CALL	R13	2
+      0xB8360A00,  //  005C  GETNGBL	R13	K5
+      0x58380006,  //  005D  LDCONST	R14	K6
+      0x583C0007,  //  005E  LDCONST	R15	K7
+      0x7C340400,  //  005F  CALL	R13	2
+      0x8C340108,  //  0060  GETMET	R13	R0	K8
+      0x5C3C0200,  //  0061  MOVE	R15	R1
+      0x58400009,  //  0062  LDCONST	R16	K9
+      0x58440003,  //  0063  LDCONST	R17	K3
+      0x5848000A,  //  0064  LDCONST	R18	K10
+      0x504C0000,  //  0065  LDBOOL	R19	0	0
+      0x7C340C00,  //  0066  CALL	R13	6
+      0x50340000,  //  0067  LDBOOL	R13	0	0
+      0x80041A00,  //  0068  RET	1	R13
+      0xB8361800,  //  0069  GETNGBL	R13	K12
+      0x88341B23,  //  006A  GETMBR	R13	R13	K35
+      0x8C341B0E,  //  006B  GETMET	R13	R13	K14
+      0x5C3C1600,  //  006C  MOVE	R15	R11
+      0x7C340400,  //  006D  CALL	R13	2
+      0x8C381B24,  //  006E  GETMET	R14	R13	K36
+      0x58400009,  //  006F  LDCONST	R16	K9
+      0x7C380400,  //  0070  CALL	R14	2
+      0x8C3C1B24,  //  0071  GETMET	R15	R13	K36
+      0x5844000A,  //  0072  LDCONST	R17	K10
+      0x7C3C0400,  //  0073  CALL	R15	2
+      0x8C401B24,  //  0074  GETMET	R16	R13	K36
+      0x58480007,  //  0075  LDCONST	R18	K7
+      0x7C400400,  //  0076  CALL	R16	2
+      0xB8461800,  //  0077  GETNGBL	R17	K12
+      0x88442323,  //  0078  GETMBR	R17	R17	K35
+      0x8C44230E,  //  0079  GETMET	R17	R17	K14
+      0x5C4C1C00,  //  007A  MOVE	R19	R14
+      0x7C440400,  //  007B  CALL	R17	2
+      0x8C482324,  //  007C  GETMET	R18	R17	K36
+      0x54520008,  //  007D  LDINT	R20	9
+      0x7C480400,  //  007E  CALL	R18	2
+      0x8C4C2325,  //  007F  GETMET	R19	R17	K37
+      0x54560005,  //  0080  LDINT	R21	6
+      0x7C4C0400,  //  0081  CALL	R19	2
+      0x8C502724,  //  0082  GETMET	R20	R19	K36
+      0x545A0010,  //  0083  LDINT	R22	17
+      0x7C500400,  //  0084  CALL	R20	2
+      0x60540004,  //  0085  GETGBL	R21	G4
+      0x5C582800,  //  0086  MOVE	R22	R20
+      0x7C540200,  //  0087  CALL	R21	1
+      0x1C542B26,  //  0088  EQ	R21	R21	K38
+      0x78560007,  //  0089  JMPF	R21	#0092
+      0xB8565000,  //  008A  GETNGBL	R21	K40
+      0x8C542B29,  //  008B  GETMET	R21	R21	K41
+      0x5C5C2800,  //  008C  MOVE	R23	R20
+      0x7C540400,  //  008D  CALL	R21	2
       0x8C542B2A,  //  008E  GETMET	R21	R21	K42
-      0x5C5C2800,  //  008F  MOVE	R23	R20
-      0x7C540400,  //  0090  CALL	R21	2
-      0x8C542B2B,  //  0091  GETMET	R21	R21	K43
-      0x7C540200,  //  0092  CALL	R21	1
-      0x900E5015,  //  0093  SETMBR	R3	K40	R21
-      0x70020002,  //  0094  JMP		#0098
-      0x8C54292B,  //  0095  GETMET	R21	R20	K43
-      0x7C540200,  //  0096  CALL	R21	1
-      0x900E5015,  //  0097  SETMBR	R3	K40	R21
-      0xB8561A00,  //  0098  GETNGBL	R21	K13
-      0x88542B24,  //  0099  GETMBR	R21	R21	K36
-      0x8C542B2C,  //  009A  GETMET	R21	R21	K44
-      0x7C540200,  //  009B  CALL	R21	1
-      0x8C582B2D,  //  009C  GETMET	R22	R21	K45
-      0x5860000A,  //  009D  LDCONST	R24	K10
-      0xB8661A00,  //  009E  GETNGBL	R25	K13
-      0x88643324,  //  009F  GETMBR	R25	R25	K36
-      0x8864332E,  //  00A0  GETMBR	R25	R25	K46
-      0x5C681C00,  //  00A1  MOVE	R26	R14
-      0x7C580800,  //  00A2  CALL	R22	4
-      0x8C582B2D,  //  00A3  GETMET	R22	R21	K45
-      0x5860000B,  //  00A4  LDCONST	R24	K11
-      0xB8661A00,  //  00A5  GETNGBL	R25	K13
-      0x88643324,  //  00A6  GETMBR	R25	R25	K36
-      0x8864332E,  //  00A7  GETMBR	R25	R25	K46
-      0x5C681E00,  //  00A8  MOVE	R26	R15
-      0x7C580800,  //  00A9  CALL	R22	4
-      0x8C582B2D,  //  00AA  GETMET	R22	R21	K45
-      0x58600008,  //  00AB  LDCONST	R24	K8
-      0xB8661A00,  //  00AC  GETNGBL	R25	K13
-      0x88643324,  //  00AD  GETMBR	R25	R25	K36
-      0x8864332E,  //  00AE  GETMBR	R25	R25	K46
-      0x8868072F,  //  00AF  GETMBR	R26	R3	K47
-      0x7C580800,  //  00B0  CALL	R22	4
-      0x8C582B2D,  //  00B1  GETMET	R22	R21	K45
-      0x54620003,  //  00B2  LDINT	R24	4
-      0xB8661A00,  //  00B3  GETNGBL	R25	K13
-      0x88643324,  //  00B4  GETMBR	R25	R25	K36
-      0x8864332E,  //  00B5  GETMBR	R25	R25	K46
-      0x88680730,  //  00B6  GETMBR	R26	R3	K48
-      0x7C580800,  //  00B7  CALL	R22	4
-      0x8C582B31,  //  00B8  GETMET	R22	R21	K49
-      0x7C580200,  //  00B9  CALL	R22	1
-      0x8C5C0532,  //  00BA  GETMET	R23	R2	K50
-      0x7C5C0200,  //  00BB  CALL	R23	1
-      0x8C5C2F33,  //  00BC  GETMET	R23	R23	K51
-      0x5C642400,  //  00BD  MOVE	R25	R18
-      0x5C682C00,  //  00BE  MOVE	R26	R22
-      0x5C6C2000,  //  00BF  MOVE	R27	R16
-      0x7C5C0800,  //  00C0  CALL	R23	4
-      0x5C602E00,  //  00C1  MOVE	R24	R23
-      0x7462000A,  //  00C2  JMPT	R24	#00CE
-      0xB8620A00,  //  00C3  GETNGBL	R24	K5
-      0x8C603106,  //  00C4  GETMET	R24	R24	K6
-      0x58680034,  //  00C5  LDCONST	R26	K52
-      0x586C000B,  //  00C6  LDCONST	R27	K11
-      0x7C600600,  //  00C7  CALL	R24	3
-      0xB8620A00,  //  00C8  GETNGBL	R24	K5
-      0x8C603106,  //  00C9  GETMET	R24	R24	K6
-      0x58680035,  //  00CA  LDCONST	R26	K53
-      0x586C000B,  //  00CB  LDCONST	R27	K11
-      0x7C600600,  //  00CC  CALL	R24	3
-      0x70020004,  //  00CD  JMP		#00D3
-      0xB8620A00,  //  00CE  GETNGBL	R24	K5
-      0x8C603106,  //  00CF  GETMET	R24	R24	K6
-      0x58680036,  //  00D0  LDCONST	R26	K54
-      0x586C0008,  //  00D1  LDCONST	R27	K8
-      0x7C600600,  //  00D2  CALL	R24	3
-      0x8C600512,  //  00D3  GETMET	R24	R2	K18
-      0x7C600200,  //  00D4  CALL	R24	1
-      0x8C603113,  //  00D5  GETMET	R24	R24	K19
-      0x88680714,  //  00D6  GETMBR	R26	R3	K20
+      0x7C540200,  //  008F  CALL	R21	1
+      0x900E4E15,  //  0090  SETMBR	R3	K39	R21
+      0x70020002,  //  0091  JMP		#0095
+      0x8C54292A,  //  0092  GETMET	R21	R20	K42
+      0x7C540200,  //  0093  CALL	R21	1
+      0x900E4E15,  //  0094  SETMBR	R3	K39	R21
+      0xB8561800,  //  0095  GETNGBL	R21	K12
+      0x88542B23,  //  0096  GETMBR	R21	R21	K35
+      0x8C542B2B,  //  0097  GETMET	R21	R21	K43
+      0x7C540200,  //  0098  CALL	R21	1
+      0x8C582B2C,  //  0099  GETMET	R22	R21	K44
+      0x58600009,  //  009A  LDCONST	R24	K9
+      0xB8661800,  //  009B  GETNGBL	R25	K12
+      0x88643323,  //  009C  GETMBR	R25	R25	K35
+      0x8864332D,  //  009D  GETMBR	R25	R25	K45
+      0x5C681C00,  //  009E  MOVE	R26	R14
+      0x7C580800,  //  009F  CALL	R22	4
+      0x8C582B2C,  //  00A0  GETMET	R22	R21	K44
+      0x5860000A,  //  00A1  LDCONST	R24	K10
+      0xB8661800,  //  00A2  GETNGBL	R25	K12
+      0x88643323,  //  00A3  GETMBR	R25	R25	K35
+      0x8864332D,  //  00A4  GETMBR	R25	R25	K45
+      0x5C681E00,  //  00A5  MOVE	R26	R15
+      0x7C580800,  //  00A6  CALL	R22	4
+      0x8C582B2C,  //  00A7  GETMET	R22	R21	K44
+      0x58600007,  //  00A8  LDCONST	R24	K7
+      0xB8661800,  //  00A9  GETNGBL	R25	K12
+      0x88643323,  //  00AA  GETMBR	R25	R25	K35
+      0x8864332D,  //  00AB  GETMBR	R25	R25	K45
+      0x8868072E,  //  00AC  GETMBR	R26	R3	K46
+      0x7C580800,  //  00AD  CALL	R22	4
+      0x8C582B2C,  //  00AE  GETMET	R22	R21	K44
+      0x54620003,  //  00AF  LDINT	R24	4
+      0xB8661800,  //  00B0  GETNGBL	R25	K12
+      0x88643323,  //  00B1  GETMBR	R25	R25	K35
+      0x8864332D,  //  00B2  GETMBR	R25	R25	K45
+      0x8868072F,  //  00B3  GETMBR	R26	R3	K47
+      0x7C580800,  //  00B4  CALL	R22	4
+      0x8C582B30,  //  00B5  GETMET	R22	R21	K48
+      0x7C580200,  //  00B6  CALL	R22	1
+      0x8C5C0531,  //  00B7  GETMET	R23	R2	K49
+      0x7C5C0200,  //  00B8  CALL	R23	1
+      0x8C5C2F32,  //  00B9  GETMET	R23	R23	K50
+      0x5C642400,  //  00BA  MOVE	R25	R18
+      0x5C682C00,  //  00BB  MOVE	R26	R22
+      0x5C6C2000,  //  00BC  MOVE	R27	R16
+      0x7C5C0800,  //  00BD  CALL	R23	4
+      0x5C602E00,  //  00BE  MOVE	R24	R23
+      0x74620008,  //  00BF  JMPT	R24	#00C9
+      0xB8620A00,  //  00C0  GETNGBL	R24	K5
+      0x58640033,  //  00C1  LDCONST	R25	K51
+      0x5868000A,  //  00C2  LDCONST	R26	K10
+      0x7C600400,  //  00C3  CALL	R24	2
+      0xB8620A00,  //  00C4  GETNGBL	R24	K5
+      0x58640034,  //  00C5  LDCONST	R25	K52
+      0x5868000A,  //  00C6  LDCONST	R26	K10
+      0x7C600400,  //  00C7  CALL	R24	2
+      0x70020003,  //  00C8  JMP		#00CD
+      0xB8620A00,  //  00C9  GETNGBL	R24	K5
+      0x58640035,  //  00CA  LDCONST	R25	K53
+      0x58680007,  //  00CB  LDCONST	R26	K7
+      0x7C600400,  //  00CC  CALL	R24	2
+      0x8C600511,  //  00CD  GETMET	R24	R2	K17
+      0x7C600200,  //  00CE  CALL	R24	1
+      0x8C603112,  //  00CF  GETMET	R24	R24	K18
+      0x88680713,  //  00D0  GETMBR	R26	R3	K19
+      0x7C600400,  //  00D1  CALL	R24	2
+      0x8C603112,  //  00D2  GETMET	R24	R24	K18
+      0x88680714,  //  00D3  GETMBR	R26	R3	K20
+      0x7C600400,  //  00D4  CALL	R24	2
+      0x8C603112,  //  00D5  GETMET	R24	R24	K18
+      0x88680936,  //  00D6  GETMBR	R26	R4	K54
       0x7C600400,  //  00D7  CALL	R24	2
-      0x8C603113,  //  00D8  GETMET	R24	R24	K19
-      0x88680715,  //  00D9  GETMBR	R26	R3	K21
-      0x7C600400,  //  00DA  CALL	R24	2
-      0x8C603113,  //  00DB  GETMET	R24	R24	K19
-      0x88680937,  //  00DC  GETMBR	R26	R4	K55
-      0x7C600400,  //  00DD  CALL	R24	2
-      0x8C603116,  //  00DE  GETMET	R24	R24	K22
-      0x7C600200,  //  00DF  CALL	R24	1
-      0x5C143000,  //  00E0  MOVE	R5	R24
-      0x4C600000,  //  00E1  LDNIL	R24
-      0x900E2818,  //  00E2  SETMBR	R3	K20	R24
-      0x4C600000,  //  00E3  LDNIL	R24
-      0x900E2A18,  //  00E4  SETMBR	R3	K21	R24
-      0x8C600519,  //  00E5  GETMET	R24	R2	K25
-      0x7C600200,  //  00E6  CALL	R24	1
-      0x8C60311A,  //  00E7  GETMET	R24	R24	K26
-      0x8868071B,  //  00E8  GETMBR	R26	R3	K27
-      0x8C6C071C,  //  00E9  GETMET	R27	R3	K28
-      0x7C6C0200,  //  00EA  CALL	R27	1
-      0x006C3605,  //  00EB  ADD	R27	R27	R5
-      0x60700015,  //  00EC  GETGBL	R28	G21
-      0x7C700000,  //  00ED  CALL	R28	0
-      0x8C703917,  //  00EE  GETMET	R28	R28	K23
-      0x88780138,  //  00EF  GETMBR	R30	R0	K56
-      0x7C700400,  //  00F0  CALL	R28	2
-      0x5476002F,  //  00F1  LDINT	R29	48
-      0x7C600A00,  //  00F2  CALL	R24	5
-      0x5466000E,  //  00F3  LDINT	R25	15
-      0x40660619,  //  00F4  CONNECT	R25	K3	R25
-      0x94643019,  //  00F5  GETIDX	R25	R24	R25
-      0x546A000F,  //  00F6  LDINT	R26	16
-      0x546E001E,  //  00F7  LDINT	R27	31
-      0x4068341B,  //  00F8  CONNECT	R26	R26	R27
-      0x9468301A,  //  00F9  GETIDX	R26	R24	R26
-      0x546E001F,  //  00FA  LDINT	R27	32
-      0x5472002E,  //  00FB  LDINT	R28	47
-      0x406C361C,  //  00FC  CONNECT	R27	R27	R28
-      0x946C301B,  //  00FD  GETIDX	R27	R24	R27
-      0xB8720A00,  //  00FE  GETNGBL	R28	K5
-      0x8C703939,  //  00FF  GETMET	R28	R28	K57
-      0x7C700200,  //  0100  CALL	R28	1
-      0x8C740109,  //  0101  GETMET	R29	R0	K9
-      0x5C7C0200,  //  0102  MOVE	R31	R1
-      0x58800003,  //  0103  LDCONST	R32	K3
-      0x58840003,  //  0104  LDCONST	R33	K3
-      0x58880003,  //  0105  LDCONST	R34	K3
-      0x508C0200,  //  0106  LDBOOL	R35	1	0
-      0x7C740C00,  //  0107  CALL	R29	6
-      0x8C74073A,  //  0108  GETMET	R29	R3	K58
-      0x7C740200,  //  0109  CALL	R29	1
-      0x8C74073B,  //  010A  GETMET	R29	R3	K59
-      0x5C7C3200,  //  010B  MOVE	R31	R25
-      0x5C803400,  //  010C  MOVE	R32	R26
-      0x5C843600,  //  010D  MOVE	R33	R27
-      0x5C883800,  //  010E  MOVE	R34	R28
-      0x7C740A00,  //  010F  CALL	R29	5
-      0x900E7903,  //  0110  SETMBR	R3	K60	K3
-      0x8C74073D,  //  0111  GETMET	R29	R3	K61
-      0x7C740200,  //  0112  CALL	R29	1
-      0x8C74073E,  //  0113  GETMET	R29	R3	K62
-      0x507C0200,  //  0114  LDBOOL	R31	1	0
-      0x7C740400,  //  0115  CALL	R29	2
-      0x8C74073F,  //  0116  GETMET	R29	R3	K63
-      0x7C740200,  //  0117  CALL	R29	1
-      0x8C740740,  //  0118  GETMET	R29	R3	K64
-      0x7C740200,  //  0119  CALL	R29	1
-      0x8C740741,  //  011A  GETMET	R29	R3	K65
-      0x7C740200,  //  011B  CALL	R29	1
-      0x50740200,  //  011C  LDBOOL	R29	1	0
-      0x80043A00,  //  011D  RET	1	R29
+      0x8C603115,  //  00D8  GETMET	R24	R24	K21
+      0x7C600200,  //  00D9  CALL	R24	1
+      0x5C143000,  //  00DA  MOVE	R5	R24
+      0x4C600000,  //  00DB  LDNIL	R24
+      0x900E2618,  //  00DC  SETMBR	R3	K19	R24
+      0x4C600000,  //  00DD  LDNIL	R24
+      0x900E2818,  //  00DE  SETMBR	R3	K20	R24
+      0x8C600518,  //  00DF  GETMET	R24	R2	K24
+      0x7C600200,  //  00E0  CALL	R24	1
+      0x8C603119,  //  00E1  GETMET	R24	R24	K25
+      0x8868071A,  //  00E2  GETMBR	R26	R3	K26
+      0x8C6C071B,  //  00E3  GETMET	R27	R3	K27
+      0x7C6C0200,  //  00E4  CALL	R27	1
+      0x006C3605,  //  00E5  ADD	R27	R27	R5
+      0x60700015,  //  00E6  GETGBL	R28	G21
+      0x7C700000,  //  00E7  CALL	R28	0
+      0x8C703916,  //  00E8  GETMET	R28	R28	K22
+      0x88780137,  //  00E9  GETMBR	R30	R0	K55
+      0x7C700400,  //  00EA  CALL	R28	2
+      0x5476002F,  //  00EB  LDINT	R29	48
+      0x7C600A00,  //  00EC  CALL	R24	5
+      0x5466000E,  //  00ED  LDINT	R25	15
+      0x40660619,  //  00EE  CONNECT	R25	K3	R25
+      0x94643019,  //  00EF  GETIDX	R25	R24	R25
+      0x546A000F,  //  00F0  LDINT	R26	16
+      0x546E001E,  //  00F1  LDINT	R27	31
+      0x4068341B,  //  00F2  CONNECT	R26	R26	R27
+      0x9468301A,  //  00F3  GETIDX	R26	R24	R26
+      0x546E001F,  //  00F4  LDINT	R27	32
+      0x5472002E,  //  00F5  LDINT	R28	47
+      0x406C361C,  //  00F6  CONNECT	R27	R27	R28
+      0x946C301B,  //  00F7  GETIDX	R27	R24	R27
+      0xB8727000,  //  00F8  GETNGBL	R28	K56
+      0x8C703939,  //  00F9  GETMET	R28	R28	K57
+      0x7C700200,  //  00FA  CALL	R28	1
+      0x8C740108,  //  00FB  GETMET	R29	R0	K8
+      0x5C7C0200,  //  00FC  MOVE	R31	R1
+      0x58800003,  //  00FD  LDCONST	R32	K3
+      0x58840003,  //  00FE  LDCONST	R33	K3
+      0x58880003,  //  00FF  LDCONST	R34	K3
+      0x508C0200,  //  0100  LDBOOL	R35	1	0
+      0x7C740C00,  //  0101  CALL	R29	6
+      0x8C74073A,  //  0102  GETMET	R29	R3	K58
+      0x7C740200,  //  0103  CALL	R29	1
+      0x8C74073B,  //  0104  GETMET	R29	R3	K59
+      0x5C7C3200,  //  0105  MOVE	R31	R25
+      0x5C803400,  //  0106  MOVE	R32	R26
+      0x5C843600,  //  0107  MOVE	R33	R27
+      0x5C883800,  //  0108  MOVE	R34	R28
+      0x7C740A00,  //  0109  CALL	R29	5
+      0x900E7903,  //  010A  SETMBR	R3	K60	K3
+      0x8C74073D,  //  010B  GETMET	R29	R3	K61
+      0x7C740200,  //  010C  CALL	R29	1
+      0x8C74073E,  //  010D  GETMET	R29	R3	K62
+      0x507C0200,  //  010E  LDBOOL	R31	1	0
+      0x7C740400,  //  010F  CALL	R29	2
+      0x8C74073F,  //  0110  GETMET	R29	R3	K63
+      0x7C740200,  //  0111  CALL	R29	1
+      0x8C740740,  //  0112  GETMET	R29	R3	K64
+      0x7C740200,  //  0113  CALL	R29	1
+      0x8C740741,  //  0114  GETMET	R29	R3	K65
+      0x7C740200,  //  0115  CALL	R29	1
+      0x50740200,  //  0116  LDBOOL	R29	1	0
+      0x80043A00,  //  0117  RET	1	R29
     })
   )
 );
@@ -1266,7 +1240,7 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma3,   /* name */
 extern const bclass be_class_Matter_Commisioning_Context;
 be_local_closure(class_Matter_Commisioning_Context_process_incoming,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1274,115 +1248,112 @@ be_local_closure(class_Matter_Commisioning_Context_process_incoming,   /* name *
     0,                          /* has sup protos */
     &be_class_Matter_Commisioning_Context, 
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
+    ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
     /* K1   */  be_nested_str_weak(is_commissioning_open),
     /* K2   */  be_nested_str_weak(opcode),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20commissioning_X20not_X20open),
-    /* K6   */  be_const_int(2),
-    /* K7   */  be_nested_str_weak(parse_PBKDFParamRequest),
-    /* K8   */  be_nested_str_weak(parse_Pake1),
-    /* K9   */  be_nested_str_weak(parse_Pake3),
-    /* K10  */  be_nested_str_weak(parse_Sigma1),
-    /* K11  */  be_nested_str_weak(parse_Sigma3),
-    /* K12  */  be_nested_str_weak(parse_StatusReport),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28secure_X20channel_X29_X20_X2502X),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20commissioning_X20not_X20open),
+    /* K5   */  be_const_int(2),
+    /* K6   */  be_nested_str_weak(parse_PBKDFParamRequest),
+    /* K7   */  be_nested_str_weak(parse_Pake1),
+    /* K8   */  be_nested_str_weak(parse_Pake3),
+    /* K9   */  be_nested_str_weak(parse_Sigma1),
+    /* K10  */  be_nested_str_weak(parse_Sigma3),
+    /* K11  */  be_nested_str_weak(parse_StatusReport),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28secure_X20channel_X29_X20_X2502X),
     }),
     be_str_weak(process_incoming),
     &be_const_str_solidified,
-    ( &(const binstruction[90]) {  /* code */
+    ( &(const binstruction[88]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x7C080200,  //  0002  CALL	R2	1
-      0x740A000E,  //  0003  JMPT	R2	#0013
+      0x740A000D,  //  0003  JMPT	R2	#0012
       0x88080302,  //  0004  GETMBR	R2	R1	K2
       0x540E001F,  //  0005  LDINT	R3	32
       0x28080403,  //  0006  GE	R2	R2	R3
-      0x780A000A,  //  0007  JMPF	R2	#0013
+      0x780A0009,  //  0007  JMPF	R2	#0012
       0x88080302,  //  0008  GETMBR	R2	R1	K2
       0x540E0023,  //  0009  LDINT	R3	36
       0x18080403,  //  000A  LE	R2	R2	R3
-      0x780A0006,  //  000B  JMPF	R2	#0013
+      0x780A0005,  //  000B  JMPF	R2	#0012
       0xB80A0600,  //  000C  GETNGBL	R2	K3
-      0x8C080504,  //  000D  GETMET	R2	R2	K4
+      0x580C0004,  //  000D  LDCONST	R3	K4
       0x58100005,  //  000E  LDCONST	R4	K5
-      0x58140006,  //  000F  LDCONST	R5	K6
-      0x7C080600,  //  0010  CALL	R2	3
-      0x50080000,  //  0011  LDBOOL	R2	0	0
-      0x80040400,  //  0012  RET	1	R2
-      0x88080302,  //  0013  GETMBR	R2	R1	K2
-      0x540E000F,  //  0014  LDINT	R3	16
-      0x1C080403,  //  0015  EQ	R2	R2	R3
-      0x780A0000,  //  0016  JMPF	R2	#0018
-      0x7002003F,  //  0017  JMP		#0058
-      0x88080302,  //  0018  GETMBR	R2	R1	K2
-      0x540E001F,  //  0019  LDINT	R3	32
-      0x1C080403,  //  001A  EQ	R2	R2	R3
-      0x780A0004,  //  001B  JMPF	R2	#0021
-      0x8C080107,  //  001C  GETMET	R2	R0	K7
-      0x5C100200,  //  001D  MOVE	R4	R1
-      0x7C080400,  //  001E  CALL	R2	2
-      0x80040400,  //  001F  RET	1	R2
-      0x70020036,  //  0020  JMP		#0058
-      0x88080302,  //  0021  GETMBR	R2	R1	K2
-      0x540E0021,  //  0022  LDINT	R3	34
-      0x1C080403,  //  0023  EQ	R2	R2	R3
-      0x780A0004,  //  0024  JMPF	R2	#002A
-      0x8C080108,  //  0025  GETMET	R2	R0	K8
-      0x5C100200,  //  0026  MOVE	R4	R1
-      0x7C080400,  //  0027  CALL	R2	2
-      0x80040400,  //  0028  RET	1	R2
-      0x7002002D,  //  0029  JMP		#0058
-      0x88080302,  //  002A  GETMBR	R2	R1	K2
-      0x540E0023,  //  002B  LDINT	R3	36
-      0x1C080403,  //  002C  EQ	R2	R2	R3
-      0x780A0004,  //  002D  JMPF	R2	#0033
-      0x8C080109,  //  002E  GETMET	R2	R0	K9
-      0x5C100200,  //  002F  MOVE	R4	R1
-      0x7C080400,  //  0030  CALL	R2	2
-      0x80040400,  //  0031  RET	1	R2
-      0x70020024,  //  0032  JMP		#0058
-      0x88080302,  //  0033  GETMBR	R2	R1	K2
-      0x540E002F,  //  0034  LDINT	R3	48
-      0x1C080403,  //  0035  EQ	R2	R2	R3
-      0x780A0004,  //  0036  JMPF	R2	#003C
-      0x8C08010A,  //  0037  GETMET	R2	R0	K10
-      0x5C100200,  //  0038  MOVE	R4	R1
-      0x7C080400,  //  0039  CALL	R2	2
-      0x80040400,  //  003A  RET	1	R2
-      0x7002001B,  //  003B  JMP		#0058
-      0x88080302,  //  003C  GETMBR	R2	R1	K2
-      0x540E0031,  //  003D  LDINT	R3	50
-      0x1C080403,  //  003E  EQ	R2	R2	R3
-      0x780A0004,  //  003F  JMPF	R2	#0045
-      0x8C08010B,  //  0040  GETMET	R2	R0	K11
-      0x5C100200,  //  0041  MOVE	R4	R1
-      0x7C080400,  //  0042  CALL	R2	2
-      0x80040400,  //  0043  RET	1	R2
-      0x70020012,  //  0044  JMP		#0058
-      0x88080302,  //  0045  GETMBR	R2	R1	K2
-      0x540E003F,  //  0046  LDINT	R3	64
-      0x1C080403,  //  0047  EQ	R2	R2	R3
-      0x780A0004,  //  0048  JMPF	R2	#004E
-      0x8C08010C,  //  0049  GETMET	R2	R0	K12
-      0x5C100200,  //  004A  MOVE	R4	R1
-      0x7C080400,  //  004B  CALL	R2	2
-      0x80040400,  //  004C  RET	1	R2
-      0x70020009,  //  004D  JMP		#0058
-      0xB80A0600,  //  004E  GETNGBL	R2	K3
-      0x8C080504,  //  004F  GETMET	R2	R2	K4
-      0x60100018,  //  0050  GETGBL	R4	G24
-      0x5814000D,  //  0051  LDCONST	R5	K13
-      0x88180302,  //  0052  GETMBR	R6	R1	K2
-      0x7C100400,  //  0053  CALL	R4	2
-      0x58140006,  //  0054  LDCONST	R5	K6
-      0x7C080600,  //  0055  CALL	R2	3
+      0x7C080400,  //  000F  CALL	R2	2
+      0x50080000,  //  0010  LDBOOL	R2	0	0
+      0x80040400,  //  0011  RET	1	R2
+      0x88080302,  //  0012  GETMBR	R2	R1	K2
+      0x540E000F,  //  0013  LDINT	R3	16
+      0x1C080403,  //  0014  EQ	R2	R2	R3
+      0x780A0000,  //  0015  JMPF	R2	#0017
+      0x7002003E,  //  0016  JMP		#0056
+      0x88080302,  //  0017  GETMBR	R2	R1	K2
+      0x540E001F,  //  0018  LDINT	R3	32
+      0x1C080403,  //  0019  EQ	R2	R2	R3
+      0x780A0004,  //  001A  JMPF	R2	#0020
+      0x8C080106,  //  001B  GETMET	R2	R0	K6
+      0x5C100200,  //  001C  MOVE	R4	R1
+      0x7C080400,  //  001D  CALL	R2	2
+      0x80040400,  //  001E  RET	1	R2
+      0x70020035,  //  001F  JMP		#0056
+      0x88080302,  //  0020  GETMBR	R2	R1	K2
+      0x540E0021,  //  0021  LDINT	R3	34
+      0x1C080403,  //  0022  EQ	R2	R2	R3
+      0x780A0004,  //  0023  JMPF	R2	#0029
+      0x8C080107,  //  0024  GETMET	R2	R0	K7
+      0x5C100200,  //  0025  MOVE	R4	R1
+      0x7C080400,  //  0026  CALL	R2	2
+      0x80040400,  //  0027  RET	1	R2
+      0x7002002C,  //  0028  JMP		#0056
+      0x88080302,  //  0029  GETMBR	R2	R1	K2
+      0x540E0023,  //  002A  LDINT	R3	36
+      0x1C080403,  //  002B  EQ	R2	R2	R3
+      0x780A0004,  //  002C  JMPF	R2	#0032
+      0x8C080108,  //  002D  GETMET	R2	R0	K8
+      0x5C100200,  //  002E  MOVE	R4	R1
+      0x7C080400,  //  002F  CALL	R2	2
+      0x80040400,  //  0030  RET	1	R2
+      0x70020023,  //  0031  JMP		#0056
+      0x88080302,  //  0032  GETMBR	R2	R1	K2
+      0x540E002F,  //  0033  LDINT	R3	48
+      0x1C080403,  //  0034  EQ	R2	R2	R3
+      0x780A0004,  //  0035  JMPF	R2	#003B
+      0x8C080109,  //  0036  GETMET	R2	R0	K9
+      0x5C100200,  //  0037  MOVE	R4	R1
+      0x7C080400,  //  0038  CALL	R2	2
+      0x80040400,  //  0039  RET	1	R2
+      0x7002001A,  //  003A  JMP		#0056
+      0x88080302,  //  003B  GETMBR	R2	R1	K2
+      0x540E0031,  //  003C  LDINT	R3	50
+      0x1C080403,  //  003D  EQ	R2	R2	R3
+      0x780A0004,  //  003E  JMPF	R2	#0044
+      0x8C08010A,  //  003F  GETMET	R2	R0	K10
+      0x5C100200,  //  0040  MOVE	R4	R1
+      0x7C080400,  //  0041  CALL	R2	2
+      0x80040400,  //  0042  RET	1	R2
+      0x70020011,  //  0043  JMP		#0056
+      0x88080302,  //  0044  GETMBR	R2	R1	K2
+      0x540E003F,  //  0045  LDINT	R3	64
+      0x1C080403,  //  0046  EQ	R2	R2	R3
+      0x780A0004,  //  0047  JMPF	R2	#004D
+      0x8C08010B,  //  0048  GETMET	R2	R0	K11
+      0x5C100200,  //  0049  MOVE	R4	R1
+      0x7C080400,  //  004A  CALL	R2	2
+      0x80040400,  //  004B  RET	1	R2
+      0x70020008,  //  004C  JMP		#0056
+      0xB80A0600,  //  004D  GETNGBL	R2	K3
+      0x600C0018,  //  004E  GETGBL	R3	G24
+      0x5810000C,  //  004F  LDCONST	R4	K12
+      0x88140302,  //  0050  GETMBR	R5	R1	K2
+      0x7C0C0400,  //  0051  CALL	R3	2
+      0x58100005,  //  0052  LDCONST	R4	K5
+      0x7C080400,  //  0053  CALL	R2	2
+      0x50080000,  //  0054  LDBOOL	R2	0	0
+      0x80040400,  //  0055  RET	1	R2
       0x50080000,  //  0056  LDBOOL	R2	0	0
       0x80040400,  //  0057  RET	1	R2
-      0x50080000,  //  0058  LDBOOL	R2	0	0
-      0x80040400,  //  0059  RET	1	R2
     })
   )
 );
@@ -1410,55 +1381,55 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma1,   /* name */
     /* K3   */  be_nested_str_weak(local_session_id),
     /* K4   */  be_const_int(0),
     /* K5   */  be_nested_str_weak(protocol_id),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_nested_str_weak(send_status_report),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_const_int(2),
-    /* K13  */  be_nested_str_weak(matter),
-    /* K14  */  be_nested_str_weak(Sigma1),
-    /* K15  */  be_nested_str_weak(parse),
-    /* K16  */  be_nested_str_weak(raw),
-    /* K17  */  be_nested_str_weak(app_payload_idx),
-    /* K18  */  be_nested_str_weak(__initiator_pub),
-    /* K19  */  be_nested_str_weak(initiatorEphPubKey),
-    /* K20  */  be_nested_str_weak(resumptionID),
-    /* K21  */  be_nested_str_weak(initiatorResumeMIC),
-    /* K22  */  be_nested_str_weak(device),
-    /* K23  */  be_nested_str_weak(sessions),
-    /* K24  */  be_nested_str_weak(find_session_by_resumption_id),
-    /* K25  */  be_nested_str_weak(_fabric),
-    /* K26  */  be_nested_str_weak(initiatorRandom),
-    /* K27  */  be_nested_str_weak(fromstring),
-    /* K28  */  be_nested_str_weak(Sigma1_Resume),
-    /* K29  */  be_nested_str_weak(HKDF_SHA256),
-    /* K30  */  be_nested_str_weak(derive),
-    /* K31  */  be_nested_str_weak(shared_secret),
-    /* K32  */  be_nested_str_weak(NCASE_SigmaS1),
-    /* K33  */  be_const_int(2147483647),
-    /* K34  */  be_nested_str_weak(AES_CCM),
-    /* K35  */  be_nested_str_weak(decrypt),
-    /* K36  */  be_nested_str_weak(tag),
-    /* K37  */  be_nested_str_weak(_source_node_id),
-    /* K38  */  be_nested_str_weak(source_node_id),
-    /* K39  */  be_nested_str_weak(set_mode_CASE),
-    /* K40  */  be_nested_str_weak(__future_initiator_session_id),
-    /* K41  */  be_nested_str_weak(initiator_session_id),
-    /* K42  */  be_nested_str_weak(__future_local_session_id),
-    /* K43  */  be_nested_str_weak(gen_local_session_id),
-    /* K44  */  be_nested_str_weak(MTR_X3A_X20_X2BSession_X20_X20_X20_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-    /* K45  */  be_nested_str_weak(remote_ip),
-    /* K46  */  be_nested_str_weak(remote_port),
-    /* K47  */  be_nested_str_weak(resumption_id),
-    /* K48  */  be_nested_str_weak(random),
-    /* K49  */  be_nested_str_weak(Sigma2_Resume),
-    /* K50  */  be_nested_str_weak(NCASE_SigmaS2),
-    /* K51  */  be_nested_str_weak(Sigma2Resume),
-    /* K52  */  be_nested_str_weak(responderSessionID),
-    /* K53  */  be_nested_str_weak(sigma2ResumeMIC),
-    /* K54  */  be_nested_str_weak(SessionResumptionKeys),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
+    /* K8   */  be_const_int(3),
+    /* K9   */  be_nested_str_weak(send_status_report),
+    /* K10  */  be_const_int(1),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_nested_str_weak(matter),
+    /* K13  */  be_nested_str_weak(Sigma1),
+    /* K14  */  be_nested_str_weak(parse),
+    /* K15  */  be_nested_str_weak(raw),
+    /* K16  */  be_nested_str_weak(app_payload_idx),
+    /* K17  */  be_nested_str_weak(__initiator_pub),
+    /* K18  */  be_nested_str_weak(initiatorEphPubKey),
+    /* K19  */  be_nested_str_weak(resumptionID),
+    /* K20  */  be_nested_str_weak(initiatorResumeMIC),
+    /* K21  */  be_nested_str_weak(device),
+    /* K22  */  be_nested_str_weak(sessions),
+    /* K23  */  be_nested_str_weak(find_session_by_resumption_id),
+    /* K24  */  be_nested_str_weak(_fabric),
+    /* K25  */  be_nested_str_weak(initiatorRandom),
+    /* K26  */  be_nested_str_weak(fromstring),
+    /* K27  */  be_nested_str_weak(Sigma1_Resume),
+    /* K28  */  be_nested_str_weak(HKDF_SHA256),
+    /* K29  */  be_nested_str_weak(derive),
+    /* K30  */  be_nested_str_weak(shared_secret),
+    /* K31  */  be_nested_str_weak(NCASE_SigmaS1),
+    /* K32  */  be_const_int(2147483647),
+    /* K33  */  be_nested_str_weak(AES_CCM),
+    /* K34  */  be_nested_str_weak(decrypt),
+    /* K35  */  be_nested_str_weak(tag),
+    /* K36  */  be_nested_str_weak(_source_node_id),
+    /* K37  */  be_nested_str_weak(source_node_id),
+    /* K38  */  be_nested_str_weak(set_mode_CASE),
+    /* K39  */  be_nested_str_weak(__future_initiator_session_id),
+    /* K40  */  be_nested_str_weak(initiator_session_id),
+    /* K41  */  be_nested_str_weak(__future_local_session_id),
+    /* K42  */  be_nested_str_weak(gen_local_session_id),
+    /* K43  */  be_nested_str_weak(MTR_X3A_X20_X2BSession_X20_X20_X20_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+    /* K44  */  be_nested_str_weak(remote_ip),
+    /* K45  */  be_nested_str_weak(remote_port),
+    /* K46  */  be_nested_str_weak(resumption_id),
+    /* K47  */  be_nested_str_weak(random),
+    /* K48  */  be_nested_str_weak(Sigma2_Resume),
+    /* K49  */  be_nested_str_weak(NCASE_SigmaS2),
+    /* K50  */  be_nested_str_weak(Sigma2Resume),
+    /* K51  */  be_nested_str_weak(responderSessionID),
+    /* K52  */  be_nested_str_weak(sigma2ResumeMIC),
+    /* K53  */  be_nested_str_weak(SessionResumptionKeys),
+    /* K54  */  be_nested_str_weak(tasmota),
     /* K55  */  be_nested_str_weak(rtc_utc),
     /* K56  */  be_nested_str_weak(tlv2raw),
     /* K57  */  be_nested_str_weak(__Msg1),
@@ -1510,7 +1481,7 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma1,   /* name */
     }),
     be_str_weak(parse_Sigma1),
     &be_const_str_solidified,
-    ( &(const binstruction[481]) {  /* code */
+    ( &(const binstruction[476]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0x880C0301,  //  0001  GETMBR	R3	R1	K1
       0x88100302,  //  0002  GETMBR	R4	R1	K2
@@ -1522,476 +1493,471 @@ be_local_closure(class_Matter_Commisioning_Context_parse_Sigma1,   /* name */
       0x74120002,  //  0008  JMPT	R4	#000C
       0x88100305,  //  0009  GETMBR	R4	R1	K5
       0x20100904,  //  000A  NE	R4	R4	K4
-      0x7812000D,  //  000B  JMPF	R4	#001A
+      0x7812000C,  //  000B  JMPF	R4	#0019
       0xB8120C00,  //  000C  GETNGBL	R4	K6
-      0x8C100907,  //  000D  GETMET	R4	R4	K7
+      0x58140007,  //  000D  LDCONST	R5	K7
       0x58180008,  //  000E  LDCONST	R6	K8
-      0x581C0009,  //  000F  LDCONST	R7	K9
-      0x7C100600,  //  0010  CALL	R4	3
-      0x8C10010A,  //  0011  GETMET	R4	R0	K10
-      0x5C180200,  //  0012  MOVE	R6	R1
-      0x581C000B,  //  0013  LDCONST	R7	K11
-      0x58200004,  //  0014  LDCONST	R8	K4
-      0x5824000C,  //  0015  LDCONST	R9	K12
-      0x50280000,  //  0016  LDBOOL	R10	0	0
-      0x7C100C00,  //  0017  CALL	R4	6
-      0x50100000,  //  0018  LDBOOL	R4	0	0
-      0x80040800,  //  0019  RET	1	R4
-      0xB8121A00,  //  001A  GETNGBL	R4	K13
-      0x8C10090E,  //  001B  GETMET	R4	R4	K14
-      0x7C100200,  //  001C  CALL	R4	1
-      0x8C10090F,  //  001D  GETMET	R4	R4	K15
-      0x88180310,  //  001E  GETMBR	R6	R1	K16
-      0x881C0311,  //  001F  GETMBR	R7	R1	K17
-      0x7C100600,  //  0020  CALL	R4	3
-      0x88140913,  //  0021  GETMBR	R5	R4	K19
-      0x900E2405,  //  0022  SETMBR	R3	K18	R5
-      0x88140914,  //  0023  GETMBR	R5	R4	K20
-      0x4C180000,  //  0024  LDNIL	R6
-      0x20140A06,  //  0025  NE	R5	R5	R6
-      0x78160003,  //  0026  JMPF	R5	#002B
-      0x88140915,  //  0027  GETMBR	R5	R4	K21
-      0x4C180000,  //  0028  LDNIL	R6
-      0x20140A06,  //  0029  NE	R5	R5	R6
-      0x74160000,  //  002A  JMPT	R5	#002C
-      0x50140001,  //  002B  LDBOOL	R5	0	1
-      0x50140200,  //  002C  LDBOOL	R5	1	0
-      0x50140000,  //  002D  LDBOOL	R5	0	0
-      0x4C180000,  //  002E  LDNIL	R6
-      0x7816000D,  //  002F  JMPF	R5	#003E
-      0x881C0116,  //  0030  GETMBR	R7	R0	K22
-      0x881C0F17,  //  0031  GETMBR	R7	R7	K23
-      0x8C1C0F18,  //  0032  GETMET	R7	R7	K24
-      0x88240914,  //  0033  GETMBR	R9	R4	K20
-      0x7C1C0400,  //  0034  CALL	R7	2
-      0x5C180E00,  //  0035  MOVE	R6	R7
-      0x4C1C0000,  //  0036  LDNIL	R7
-      0x1C1C0C07,  //  0037  EQ	R7	R6	R7
-      0x741E0003,  //  0038  JMPT	R7	#003D
-      0x881C0D19,  //  0039  GETMBR	R7	R6	K25
-      0x4C200000,  //  003A  LDNIL	R8
-      0x1C1C0E08,  //  003B  EQ	R7	R7	R8
-      0x781E0000,  //  003C  JMPF	R7	#003E
-      0x50140000,  //  003D  LDBOOL	R5	0	0
-      0x781600B5,  //  003E  JMPF	R5	#00F5
-      0x881C091A,  //  003F  GETMBR	R7	R4	K26
-      0x88200914,  //  0040  GETMBR	R8	R4	K20
-      0x001C0E08,  //  0041  ADD	R7	R7	R8
-      0x60200015,  //  0042  GETGBL	R8	G21
-      0x7C200000,  //  0043  CALL	R8	0
-      0x8C20111B,  //  0044  GETMET	R8	R8	K27
-      0x5828001C,  //  0045  LDCONST	R10	K28
-      0x7C200400,  //  0046  CALL	R8	2
-      0x8C24051D,  //  0047  GETMET	R9	R2	K29
-      0x7C240200,  //  0048  CALL	R9	1
-      0x8C24131E,  //  0049  GETMET	R9	R9	K30
-      0x882C0D1F,  //  004A  GETMBR	R11	R6	K31
-      0x5C300E00,  //  004B  MOVE	R12	R7
-      0x5C341000,  //  004C  MOVE	R13	R8
-      0x543A000F,  //  004D  LDINT	R14	16
-      0x7C240A00,  //  004E  CALL	R9	5
-      0x60280015,  //  004F  GETGBL	R10	G21
-      0x7C280000,  //  0050  CALL	R10	0
-      0x8C28151B,  //  0051  GETMET	R10	R10	K27
-      0x58300020,  //  0052  LDCONST	R12	K32
-      0x7C280400,  //  0053  CALL	R10	2
-      0x542DFFEE,  //  0054  LDINT	R11	-17
-      0x402E080B,  //  0055  CONNECT	R11	K4	R11
-      0x88300915,  //  0056  GETMBR	R12	R4	K21
-      0x942C180B,  //  0057  GETIDX	R11	R12	R11
-      0x5435FFEF,  //  0058  LDINT	R13	-16
-      0x40341B21,  //  0059  CONNECT	R13	R13	K33
-      0x88380915,  //  005A  GETMBR	R14	R4	K21
-      0x94301C0D,  //  005B  GETIDX	R12	R14	R13
-      0x8C3C0522,  //  005C  GETMET	R15	R2	K34
-      0x5C441200,  //  005D  MOVE	R17	R9
-      0x5C481400,  //  005E  MOVE	R18	R10
-      0x604C0015,  //  005F  GETGBL	R19	G21
-      0x7C4C0000,  //  0060  CALL	R19	0
-      0x6050000C,  //  0061  GETGBL	R20	G12
-      0x5C541600,  //  0062  MOVE	R21	R11
-      0x7C500200,  //  0063  CALL	R20	1
-      0x5456000F,  //  0064  LDINT	R21	16
-      0x7C3C0C00,  //  0065  CALL	R15	6
-      0x5C341E00,  //  0066  MOVE	R13	R15
-      0x8C3C1B23,  //  0067  GETMET	R15	R13	K35
-      0x5C441600,  //  0068  MOVE	R17	R11
-      0x7C3C0400,  //  0069  CALL	R15	2
-      0x5C381E00,  //  006A  MOVE	R14	R15
-      0x8C3C1B24,  //  006B  GETMET	R15	R13	K36
-      0x7C3C0200,  //  006C  CALL	R15	1
-      0x1C40180F,  //  006D  EQ	R16	R12	R15
-      0x78420084,  //  006E  JMPF	R16	#00F4
-      0x88400D19,  //  006F  GETMBR	R16	R6	K25
-      0x900E3210,  //  0070  SETMBR	R3	K25	R16
-      0x88400326,  //  0071  GETMBR	R16	R1	K38
-      0x900E4A10,  //  0072  SETMBR	R3	K37	R16
-      0x8C400727,  //  0073  GETMET	R16	R3	K39
-      0x7C400200,  //  0074  CALL	R16	1
-      0x88400929,  //  0075  GETMBR	R16	R4	K41
-      0x900E5010,  //  0076  SETMBR	R3	K40	R16
-      0x88400116,  //  0077  GETMBR	R16	R0	K22
-      0x88402117,  //  0078  GETMBR	R16	R16	K23
-      0x8C40212B,  //  0079  GETMET	R16	R16	K43
-      0x7C400200,  //  007A  CALL	R16	1
-      0x900E5410,  //  007B  SETMBR	R3	K42	R16
-      0xB8420C00,  //  007C  GETNGBL	R16	K6
-      0x8C402107,  //  007D  GETMET	R16	R16	K7
-      0x60480018,  //  007E  GETGBL	R18	G24
-      0x584C002C,  //  007F  LDCONST	R19	K44
-      0x8850072A,  //  0080  GETMBR	R20	R3	K42
-      0x8854032D,  //  0081  GETMBR	R21	R1	K45
-      0x8858032E,  //  0082  GETMBR	R22	R1	K46
-      0x7C480800,  //  0083  CALL	R18	4
-      0x584C0009,  //  0084  LDCONST	R19	K9
-      0x7C400600,  //  0085  CALL	R16	3
-      0x88400D1F,  //  0086  GETMBR	R16	R6	K31
-      0x900E3E10,  //  0087  SETMBR	R3	K31	R16
-      0x8C400530,  //  0088  GETMET	R16	R2	K48
-      0x544A000F,  //  0089  LDINT	R18	16
-      0x7C400400,  //  008A  CALL	R16	2
-      0x900E5E10,  //  008B  SETMBR	R3	K47	R16
-      0x60400015,  //  008C  GETGBL	R16	G21
-      0x7C400000,  //  008D  CALL	R16	0
-      0x8C40211B,  //  008E  GETMET	R16	R16	K27
-      0x58480031,  //  008F  LDCONST	R18	K49
-      0x7C400400,  //  0090  CALL	R16	2
-      0x8844091A,  //  0091  GETMBR	R17	R4	K26
-      0x8848072F,  //  0092  GETMBR	R18	R3	K47
-      0x00442212,  //  0093  ADD	R17	R17	R18
-      0x8C48051D,  //  0094  GETMET	R18	R2	K29
-      0x7C480200,  //  0095  CALL	R18	1
-      0x8C48251E,  //  0096  GETMET	R18	R18	K30
-      0x8850071F,  //  0097  GETMBR	R20	R3	K31
-      0x5C542200,  //  0098  MOVE	R21	R17
-      0x5C582000,  //  0099  MOVE	R22	R16
-      0x545E000F,  //  009A  LDINT	R23	16
-      0x7C480A00,  //  009B  CALL	R18	5
-      0x8C4C0522,  //  009C  GETMET	R19	R2	K34
-      0x5C542400,  //  009D  MOVE	R21	R18
-      0x60580015,  //  009E  GETGBL	R22	G21
-      0x7C580000,  //  009F  CALL	R22	0
-      0x8C582D1B,  //  00A0  GETMET	R22	R22	K27
-      0x58600032,  //  00A1  LDCONST	R24	K50
-      0x7C580400,  //  00A2  CALL	R22	2
-      0x605C0015,  //  00A3  GETGBL	R23	G21
-      0x7C5C0000,  //  00A4  CALL	R23	0
-      0x58600004,  //  00A5  LDCONST	R24	K4
-      0x5466000F,  //  00A6  LDINT	R25	16
-      0x7C4C0C00,  //  00A7  CALL	R19	6
-      0x8C502724,  //  00A8  GETMET	R20	R19	K36
-      0x7C500200,  //  00A9  CALL	R20	1
-      0xB8561A00,  //  00AA  GETNGBL	R21	K13
-      0x8C542B33,  //  00AB  GETMET	R21	R21	K51
-      0x7C540200,  //  00AC  CALL	R21	1
-      0x8858072F,  //  00AD  GETMBR	R22	R3	K47
-      0x90562816,  //  00AE  SETMBR	R21	K20	R22
-      0x8858072A,  //  00AF  GETMBR	R22	R3	K42
-      0x90566816,  //  00B0  SETMBR	R21	K52	R22
-      0x90566A14,  //  00B1  SETMBR	R21	K53	R20
-      0x8C58051D,  //  00B2  GETMET	R22	R2	K29
-      0x7C580200,  //  00B3  CALL	R22	1
-      0x8C582D1E,  //  00B4  GETMET	R22	R22	K30
-      0x8860071F,  //  00B5  GETMBR	R24	R3	K31
-      0x8864091A,  //  00B6  GETMBR	R25	R4	K26
-      0x8868072F,  //  00B7  GETMBR	R26	R3	K47
-      0x0064321A,  //  00B8  ADD	R25	R25	R26
-      0x60680015,  //  00B9  GETGBL	R26	G21
-      0x7C680000,  //  00BA  CALL	R26	0
-      0x8C68351B,  //  00BB  GETMET	R26	R26	K27
-      0x58700036,  //  00BC  LDCONST	R28	K54
-      0x7C680400,  //  00BD  CALL	R26	2
-      0x546E002F,  //  00BE  LDINT	R27	48
-      0x7C580A00,  //  00BF  CALL	R22	5
-      0x545E000E,  //  00C0  LDINT	R23	15
-      0x405E0817,  //  00C1  CONNECT	R23	K4	R23
-      0x945C2C17,  //  00C2  GETIDX	R23	R22	R23
-      0x5462000F,  //  00C3  LDINT	R24	16
-      0x5466001E,  //  00C4  LDINT	R25	31
-      0x40603019,  //  00C5  CONNECT	R24	R24	R25
-      0x94602C18,  //  00C6  GETIDX	R24	R22	R24
-      0x5466001F,  //  00C7  LDINT	R25	32
-      0x546A002E,  //  00C8  LDINT	R26	47
-      0x4064321A,  //  00C9  CONNECT	R25	R25	R26
-      0x94642C19,  //  00CA  GETIDX	R25	R22	R25
-      0xB86A0C00,  //  00CB  GETNGBL	R26	K6
-      0x8C683537,  //  00CC  GETMET	R26	R26	K55
-      0x7C680200,  //  00CD  CALL	R26	1
-      0x8C6C2B38,  //  00CE  GETMET	R27	R21	K56
-      0x7C6C0200,  //  00CF  CALL	R27	1
-      0x4C700000,  //  00D0  LDNIL	R28
-      0x900E721C,  //  00D1  SETMBR	R3	K57	R28
-      0x8C70033A,  //  00D2  GETMET	R28	R1	K58
-      0x547A0032,  //  00D3  LDINT	R30	51
-      0x507C0200,  //  00D4  LDBOOL	R31	1	0
-      0x7C700600,  //  00D5  CALL	R28	3
-      0x8C74393B,  //  00D6  GETMET	R29	R28	K59
-      0x5C7C3600,  //  00D7  MOVE	R31	R27
-      0x7C740400,  //  00D8  CALL	R29	2
-      0x8878013C,  //  00D9  GETMBR	R30	R0	K60
-      0x8C783D3D,  //  00DA  GETMET	R30	R30	K61
-      0x5C803800,  //  00DB  MOVE	R32	R28
-      0x7C780400,  //  00DC  CALL	R30	2
-      0x8C78073E,  //  00DD  GETMET	R30	R3	K62
-      0x7C780200,  //  00DE  CALL	R30	1
-      0x8C78073F,  //  00DF  GETMET	R30	R3	K63
-      0x5C802E00,  //  00E0  MOVE	R32	R23
-      0x5C843000,  //  00E1  MOVE	R33	R24
-      0x5C883200,  //  00E2  MOVE	R34	R25
-      0x5C8C3400,  //  00E3  MOVE	R35	R26
-      0x7C780A00,  //  00E4  CALL	R30	5
-      0x900E8104,  //  00E5  SETMBR	R3	K64	K4
-      0x8C780741,  //  00E6  GETMET	R30	R3	K65
-      0x7C780200,  //  00E7  CALL	R30	1
-      0x8C780742,  //  00E8  GETMET	R30	R3	K66
-      0x50800200,  //  00E9  LDBOOL	R32	1	0
-      0x7C780400,  //  00EA  CALL	R30	2
-      0x8C780743,  //  00EB  GETMET	R30	R3	K67
+      0x7C100400,  //  000F  CALL	R4	2
+      0x8C100109,  //  0010  GETMET	R4	R0	K9
+      0x5C180200,  //  0011  MOVE	R6	R1
+      0x581C000A,  //  0012  LDCONST	R7	K10
+      0x58200004,  //  0013  LDCONST	R8	K4
+      0x5824000B,  //  0014  LDCONST	R9	K11
+      0x50280000,  //  0015  LDBOOL	R10	0	0
+      0x7C100C00,  //  0016  CALL	R4	6
+      0x50100000,  //  0017  LDBOOL	R4	0	0
+      0x80040800,  //  0018  RET	1	R4
+      0xB8121800,  //  0019  GETNGBL	R4	K12
+      0x8C10090D,  //  001A  GETMET	R4	R4	K13
+      0x7C100200,  //  001B  CALL	R4	1
+      0x8C10090E,  //  001C  GETMET	R4	R4	K14
+      0x8818030F,  //  001D  GETMBR	R6	R1	K15
+      0x881C0310,  //  001E  GETMBR	R7	R1	K16
+      0x7C100600,  //  001F  CALL	R4	3
+      0x88140912,  //  0020  GETMBR	R5	R4	K18
+      0x900E2205,  //  0021  SETMBR	R3	K17	R5
+      0x88140913,  //  0022  GETMBR	R5	R4	K19
+      0x4C180000,  //  0023  LDNIL	R6
+      0x20140A06,  //  0024  NE	R5	R5	R6
+      0x78160003,  //  0025  JMPF	R5	#002A
+      0x88140914,  //  0026  GETMBR	R5	R4	K20
+      0x4C180000,  //  0027  LDNIL	R6
+      0x20140A06,  //  0028  NE	R5	R5	R6
+      0x74160000,  //  0029  JMPT	R5	#002B
+      0x50140001,  //  002A  LDBOOL	R5	0	1
+      0x50140200,  //  002B  LDBOOL	R5	1	0
+      0x50140000,  //  002C  LDBOOL	R5	0	0
+      0x4C180000,  //  002D  LDNIL	R6
+      0x7816000D,  //  002E  JMPF	R5	#003D
+      0x881C0115,  //  002F  GETMBR	R7	R0	K21
+      0x881C0F16,  //  0030  GETMBR	R7	R7	K22
+      0x8C1C0F17,  //  0031  GETMET	R7	R7	K23
+      0x88240913,  //  0032  GETMBR	R9	R4	K19
+      0x7C1C0400,  //  0033  CALL	R7	2
+      0x5C180E00,  //  0034  MOVE	R6	R7
+      0x4C1C0000,  //  0035  LDNIL	R7
+      0x1C1C0C07,  //  0036  EQ	R7	R6	R7
+      0x741E0003,  //  0037  JMPT	R7	#003C
+      0x881C0D18,  //  0038  GETMBR	R7	R6	K24
+      0x4C200000,  //  0039  LDNIL	R8
+      0x1C1C0E08,  //  003A  EQ	R7	R7	R8
+      0x781E0000,  //  003B  JMPF	R7	#003D
+      0x50140000,  //  003C  LDBOOL	R5	0	0
+      0x781600B4,  //  003D  JMPF	R5	#00F3
+      0x881C0919,  //  003E  GETMBR	R7	R4	K25
+      0x88200913,  //  003F  GETMBR	R8	R4	K19
+      0x001C0E08,  //  0040  ADD	R7	R7	R8
+      0x60200015,  //  0041  GETGBL	R8	G21
+      0x7C200000,  //  0042  CALL	R8	0
+      0x8C20111A,  //  0043  GETMET	R8	R8	K26
+      0x5828001B,  //  0044  LDCONST	R10	K27
+      0x7C200400,  //  0045  CALL	R8	2
+      0x8C24051C,  //  0046  GETMET	R9	R2	K28
+      0x7C240200,  //  0047  CALL	R9	1
+      0x8C24131D,  //  0048  GETMET	R9	R9	K29
+      0x882C0D1E,  //  0049  GETMBR	R11	R6	K30
+      0x5C300E00,  //  004A  MOVE	R12	R7
+      0x5C341000,  //  004B  MOVE	R13	R8
+      0x543A000F,  //  004C  LDINT	R14	16
+      0x7C240A00,  //  004D  CALL	R9	5
+      0x60280015,  //  004E  GETGBL	R10	G21
+      0x7C280000,  //  004F  CALL	R10	0
+      0x8C28151A,  //  0050  GETMET	R10	R10	K26
+      0x5830001F,  //  0051  LDCONST	R12	K31
+      0x7C280400,  //  0052  CALL	R10	2
+      0x542DFFEE,  //  0053  LDINT	R11	-17
+      0x402E080B,  //  0054  CONNECT	R11	K4	R11
+      0x88300914,  //  0055  GETMBR	R12	R4	K20
+      0x942C180B,  //  0056  GETIDX	R11	R12	R11
+      0x5435FFEF,  //  0057  LDINT	R13	-16
+      0x40341B20,  //  0058  CONNECT	R13	R13	K32
+      0x88380914,  //  0059  GETMBR	R14	R4	K20
+      0x94301C0D,  //  005A  GETIDX	R12	R14	R13
+      0x8C3C0521,  //  005B  GETMET	R15	R2	K33
+      0x5C441200,  //  005C  MOVE	R17	R9
+      0x5C481400,  //  005D  MOVE	R18	R10
+      0x604C0015,  //  005E  GETGBL	R19	G21
+      0x7C4C0000,  //  005F  CALL	R19	0
+      0x6050000C,  //  0060  GETGBL	R20	G12
+      0x5C541600,  //  0061  MOVE	R21	R11
+      0x7C500200,  //  0062  CALL	R20	1
+      0x5456000F,  //  0063  LDINT	R21	16
+      0x7C3C0C00,  //  0064  CALL	R15	6
+      0x5C341E00,  //  0065  MOVE	R13	R15
+      0x8C3C1B22,  //  0066  GETMET	R15	R13	K34
+      0x5C441600,  //  0067  MOVE	R17	R11
+      0x7C3C0400,  //  0068  CALL	R15	2
+      0x5C381E00,  //  0069  MOVE	R14	R15
+      0x8C3C1B23,  //  006A  GETMET	R15	R13	K35
+      0x7C3C0200,  //  006B  CALL	R15	1
+      0x1C40180F,  //  006C  EQ	R16	R12	R15
+      0x78420083,  //  006D  JMPF	R16	#00F2
+      0x88400D18,  //  006E  GETMBR	R16	R6	K24
+      0x900E3010,  //  006F  SETMBR	R3	K24	R16
+      0x88400325,  //  0070  GETMBR	R16	R1	K37
+      0x900E4810,  //  0071  SETMBR	R3	K36	R16
+      0x8C400726,  //  0072  GETMET	R16	R3	K38
+      0x7C400200,  //  0073  CALL	R16	1
+      0x88400928,  //  0074  GETMBR	R16	R4	K40
+      0x900E4E10,  //  0075  SETMBR	R3	K39	R16
+      0x88400115,  //  0076  GETMBR	R16	R0	K21
+      0x88402116,  //  0077  GETMBR	R16	R16	K22
+      0x8C40212A,  //  0078  GETMET	R16	R16	K42
+      0x7C400200,  //  0079  CALL	R16	1
+      0x900E5210,  //  007A  SETMBR	R3	K41	R16
+      0xB8420C00,  //  007B  GETNGBL	R16	K6
+      0x60440018,  //  007C  GETGBL	R17	G24
+      0x5848002B,  //  007D  LDCONST	R18	K43
+      0x884C0729,  //  007E  GETMBR	R19	R3	K41
+      0x8850032C,  //  007F  GETMBR	R20	R1	K44
+      0x8854032D,  //  0080  GETMBR	R21	R1	K45
+      0x7C440800,  //  0081  CALL	R17	4
+      0x58480008,  //  0082  LDCONST	R18	K8
+      0x7C400400,  //  0083  CALL	R16	2
+      0x88400D1E,  //  0084  GETMBR	R16	R6	K30
+      0x900E3C10,  //  0085  SETMBR	R3	K30	R16
+      0x8C40052F,  //  0086  GETMET	R16	R2	K47
+      0x544A000F,  //  0087  LDINT	R18	16
+      0x7C400400,  //  0088  CALL	R16	2
+      0x900E5C10,  //  0089  SETMBR	R3	K46	R16
+      0x60400015,  //  008A  GETGBL	R16	G21
+      0x7C400000,  //  008B  CALL	R16	0
+      0x8C40211A,  //  008C  GETMET	R16	R16	K26
+      0x58480030,  //  008D  LDCONST	R18	K48
+      0x7C400400,  //  008E  CALL	R16	2
+      0x88440919,  //  008F  GETMBR	R17	R4	K25
+      0x8848072E,  //  0090  GETMBR	R18	R3	K46
+      0x00442212,  //  0091  ADD	R17	R17	R18
+      0x8C48051C,  //  0092  GETMET	R18	R2	K28
+      0x7C480200,  //  0093  CALL	R18	1
+      0x8C48251D,  //  0094  GETMET	R18	R18	K29
+      0x8850071E,  //  0095  GETMBR	R20	R3	K30
+      0x5C542200,  //  0096  MOVE	R21	R17
+      0x5C582000,  //  0097  MOVE	R22	R16
+      0x545E000F,  //  0098  LDINT	R23	16
+      0x7C480A00,  //  0099  CALL	R18	5
+      0x8C4C0521,  //  009A  GETMET	R19	R2	K33
+      0x5C542400,  //  009B  MOVE	R21	R18
+      0x60580015,  //  009C  GETGBL	R22	G21
+      0x7C580000,  //  009D  CALL	R22	0
+      0x8C582D1A,  //  009E  GETMET	R22	R22	K26
+      0x58600031,  //  009F  LDCONST	R24	K49
+      0x7C580400,  //  00A0  CALL	R22	2
+      0x605C0015,  //  00A1  GETGBL	R23	G21
+      0x7C5C0000,  //  00A2  CALL	R23	0
+      0x58600004,  //  00A3  LDCONST	R24	K4
+      0x5466000F,  //  00A4  LDINT	R25	16
+      0x7C4C0C00,  //  00A5  CALL	R19	6
+      0x8C502723,  //  00A6  GETMET	R20	R19	K35
+      0x7C500200,  //  00A7  CALL	R20	1
+      0xB8561800,  //  00A8  GETNGBL	R21	K12
+      0x8C542B32,  //  00A9  GETMET	R21	R21	K50
+      0x7C540200,  //  00AA  CALL	R21	1
+      0x8858072E,  //  00AB  GETMBR	R22	R3	K46
+      0x90562616,  //  00AC  SETMBR	R21	K19	R22
+      0x88580729,  //  00AD  GETMBR	R22	R3	K41
+      0x90566616,  //  00AE  SETMBR	R21	K51	R22
+      0x90566814,  //  00AF  SETMBR	R21	K52	R20
+      0x8C58051C,  //  00B0  GETMET	R22	R2	K28
+      0x7C580200,  //  00B1  CALL	R22	1
+      0x8C582D1D,  //  00B2  GETMET	R22	R22	K29
+      0x8860071E,  //  00B3  GETMBR	R24	R3	K30
+      0x88640919,  //  00B4  GETMBR	R25	R4	K25
+      0x8868072E,  //  00B5  GETMBR	R26	R3	K46
+      0x0064321A,  //  00B6  ADD	R25	R25	R26
+      0x60680015,  //  00B7  GETGBL	R26	G21
+      0x7C680000,  //  00B8  CALL	R26	0
+      0x8C68351A,  //  00B9  GETMET	R26	R26	K26
+      0x58700035,  //  00BA  LDCONST	R28	K53
+      0x7C680400,  //  00BB  CALL	R26	2
+      0x546E002F,  //  00BC  LDINT	R27	48
+      0x7C580A00,  //  00BD  CALL	R22	5
+      0x545E000E,  //  00BE  LDINT	R23	15
+      0x405E0817,  //  00BF  CONNECT	R23	K4	R23
+      0x945C2C17,  //  00C0  GETIDX	R23	R22	R23
+      0x5462000F,  //  00C1  LDINT	R24	16
+      0x5466001E,  //  00C2  LDINT	R25	31
+      0x40603019,  //  00C3  CONNECT	R24	R24	R25
+      0x94602C18,  //  00C4  GETIDX	R24	R22	R24
+      0x5466001F,  //  00C5  LDINT	R25	32
+      0x546A002E,  //  00C6  LDINT	R26	47
+      0x4064321A,  //  00C7  CONNECT	R25	R25	R26
+      0x94642C19,  //  00C8  GETIDX	R25	R22	R25
+      0xB86A6C00,  //  00C9  GETNGBL	R26	K54
+      0x8C683537,  //  00CA  GETMET	R26	R26	K55
+      0x7C680200,  //  00CB  CALL	R26	1
+      0x8C6C2B38,  //  00CC  GETMET	R27	R21	K56
+      0x7C6C0200,  //  00CD  CALL	R27	1
+      0x4C700000,  //  00CE  LDNIL	R28
+      0x900E721C,  //  00CF  SETMBR	R3	K57	R28
+      0x8C70033A,  //  00D0  GETMET	R28	R1	K58
+      0x547A0032,  //  00D1  LDINT	R30	51
+      0x507C0200,  //  00D2  LDBOOL	R31	1	0
+      0x7C700600,  //  00D3  CALL	R28	3
+      0x8C74393B,  //  00D4  GETMET	R29	R28	K59
+      0x5C7C3600,  //  00D5  MOVE	R31	R27
+      0x7C740400,  //  00D6  CALL	R29	2
+      0x8878013C,  //  00D7  GETMBR	R30	R0	K60
+      0x8C783D3D,  //  00D8  GETMET	R30	R30	K61
+      0x5C803800,  //  00D9  MOVE	R32	R28
+      0x7C780400,  //  00DA  CALL	R30	2
+      0x8C78073E,  //  00DB  GETMET	R30	R3	K62
+      0x7C780200,  //  00DC  CALL	R30	1
+      0x8C78073F,  //  00DD  GETMET	R30	R3	K63
+      0x5C802E00,  //  00DE  MOVE	R32	R23
+      0x5C843000,  //  00DF  MOVE	R33	R24
+      0x5C883200,  //  00E0  MOVE	R34	R25
+      0x5C8C3400,  //  00E1  MOVE	R35	R26
+      0x7C780A00,  //  00E2  CALL	R30	5
+      0x900E8104,  //  00E3  SETMBR	R3	K64	K4
+      0x8C780741,  //  00E4  GETMET	R30	R3	K65
+      0x7C780200,  //  00E5  CALL	R30	1
+      0x8C780742,  //  00E6  GETMET	R30	R3	K66
+      0x50800200,  //  00E7  LDBOOL	R32	1	0
+      0x7C780400,  //  00E8  CALL	R30	2
+      0x8C780743,  //  00E9  GETMET	R30	R3	K67
+      0x7C780200,  //  00EA  CALL	R30	1
+      0x8C780744,  //  00EB  GETMET	R30	R3	K68
       0x7C780200,  //  00EC  CALL	R30	1
-      0x8C780744,  //  00ED  GETMET	R30	R3	K68
+      0x8C780745,  //  00ED  GETMET	R30	R3	K69
       0x7C780200,  //  00EE  CALL	R30	1
-      0x8C780745,  //  00EF  GETMET	R30	R3	K69
-      0x7C780200,  //  00F0  CALL	R30	1
-      0x50780200,  //  00F1  LDBOOL	R30	1	0
-      0x80043C00,  //  00F2  RET	1	R30
-      0x70020000,  //  00F3  JMP		#00F5
-      0x50140000,  //  00F4  LDBOOL	R5	0	0
-      0x5C1C0A00,  //  00F5  MOVE	R7	R5
-      0x741E00E7,  //  00F6  JMPT	R7	#01DF
-      0x8C1C0146,  //  00F7  GETMET	R7	R0	K70
-      0x88240947,  //  00F8  GETMBR	R9	R4	K71
-      0x8828091A,  //  00F9  GETMBR	R10	R4	K26
-      0x7C1C0600,  //  00FA  CALL	R7	3
-      0x900E3207,  //  00FB  SETMBR	R3	K25	R7
-      0x4C200000,  //  00FC  LDNIL	R8
-      0x1C200608,  //  00FD  EQ	R8	R3	R8
-      0x74220003,  //  00FE  JMPT	R8	#0103
-      0x88200719,  //  00FF  GETMBR	R8	R3	K25
-      0x4C240000,  //  0100  LDNIL	R9
-      0x1C201009,  //  0101  EQ	R8	R8	R9
-      0x7822000D,  //  0102  JMPF	R8	#0111
-      0xB8220C00,  //  0103  GETNGBL	R8	K6
-      0x8C201107,  //  0104  GETMET	R8	R8	K7
-      0x58280048,  //  0105  LDCONST	R10	K72
-      0x582C0009,  //  0106  LDCONST	R11	K9
-      0x7C200600,  //  0107  CALL	R8	3
-      0x8C20010A,  //  0108  GETMET	R8	R0	K10
-      0x5C280200,  //  0109  MOVE	R10	R1
-      0x582C000B,  //  010A  LDCONST	R11	K11
-      0x58300004,  //  010B  LDCONST	R12	K4
-      0x5834000B,  //  010C  LDCONST	R13	K11
-      0x50380000,  //  010D  LDBOOL	R14	0	0
-      0x7C200C00,  //  010E  CALL	R8	6
-      0x50200000,  //  010F  LDBOOL	R8	0	0
-      0x80041000,  //  0110  RET	1	R8
-      0x88200326,  //  0111  GETMBR	R8	R1	K38
-      0x900E4A08,  //  0112  SETMBR	R3	K37	R8
-      0x8C200727,  //  0113  GETMET	R8	R3	K39
-      0x7C200200,  //  0114  CALL	R8	1
-      0x88200929,  //  0115  GETMBR	R8	R4	K41
-      0x900E5008,  //  0116  SETMBR	R3	K40	R8
-      0x88200116,  //  0117  GETMBR	R8	R0	K22
-      0x88201117,  //  0118  GETMBR	R8	R8	K23
-      0x8C20112B,  //  0119  GETMET	R8	R8	K43
-      0x7C200200,  //  011A  CALL	R8	1
-      0x900E5408,  //  011B  SETMBR	R3	K42	R8
-      0xB8220C00,  //  011C  GETNGBL	R8	K6
-      0x8C201107,  //  011D  GETMET	R8	R8	K7
-      0x60280018,  //  011E  GETGBL	R10	G24
-      0x582C002C,  //  011F  LDCONST	R11	K44
-      0x8830072A,  //  0120  GETMBR	R12	R3	K42
-      0x8834032D,  //  0121  GETMBR	R13	R1	K45
-      0x8838032E,  //  0122  GETMBR	R14	R1	K46
-      0x7C280800,  //  0123  CALL	R10	4
-      0x582C0009,  //  0124  LDCONST	R11	K9
-      0x7C200600,  //  0125  CALL	R8	3
-      0x8C200530,  //  0126  GETMET	R8	R2	K48
-      0x542A000F,  //  0127  LDINT	R10	16
+      0x50780200,  //  00EF  LDBOOL	R30	1	0
+      0x80043C00,  //  00F0  RET	1	R30
+      0x70020000,  //  00F1  JMP		#00F3
+      0x50140000,  //  00F2  LDBOOL	R5	0	0
+      0x5C1C0A00,  //  00F3  MOVE	R7	R5
+      0x741E00E4,  //  00F4  JMPT	R7	#01DA
+      0x8C1C0146,  //  00F5  GETMET	R7	R0	K70
+      0x88240947,  //  00F6  GETMBR	R9	R4	K71
+      0x88280919,  //  00F7  GETMBR	R10	R4	K25
+      0x7C1C0600,  //  00F8  CALL	R7	3
+      0x900E3007,  //  00F9  SETMBR	R3	K24	R7
+      0x4C200000,  //  00FA  LDNIL	R8
+      0x1C200608,  //  00FB  EQ	R8	R3	R8
+      0x74220003,  //  00FC  JMPT	R8	#0101
+      0x88200718,  //  00FD  GETMBR	R8	R3	K24
+      0x4C240000,  //  00FE  LDNIL	R9
+      0x1C201009,  //  00FF  EQ	R8	R8	R9
+      0x7822000C,  //  0100  JMPF	R8	#010E
+      0xB8220C00,  //  0101  GETNGBL	R8	K6
+      0x58240048,  //  0102  LDCONST	R9	K72
+      0x58280008,  //  0103  LDCONST	R10	K8
+      0x7C200400,  //  0104  CALL	R8	2
+      0x8C200109,  //  0105  GETMET	R8	R0	K9
+      0x5C280200,  //  0106  MOVE	R10	R1
+      0x582C000A,  //  0107  LDCONST	R11	K10
+      0x58300004,  //  0108  LDCONST	R12	K4
+      0x5834000A,  //  0109  LDCONST	R13	K10
+      0x50380000,  //  010A  LDBOOL	R14	0	0
+      0x7C200C00,  //  010B  CALL	R8	6
+      0x50200000,  //  010C  LDBOOL	R8	0	0
+      0x80041000,  //  010D  RET	1	R8
+      0x88200325,  //  010E  GETMBR	R8	R1	K37
+      0x900E4808,  //  010F  SETMBR	R3	K36	R8
+      0x8C200726,  //  0110  GETMET	R8	R3	K38
+      0x7C200200,  //  0111  CALL	R8	1
+      0x88200928,  //  0112  GETMBR	R8	R4	K40
+      0x900E4E08,  //  0113  SETMBR	R3	K39	R8
+      0x88200115,  //  0114  GETMBR	R8	R0	K21
+      0x88201116,  //  0115  GETMBR	R8	R8	K22
+      0x8C20112A,  //  0116  GETMET	R8	R8	K42
+      0x7C200200,  //  0117  CALL	R8	1
+      0x900E5208,  //  0118  SETMBR	R3	K41	R8
+      0xB8220C00,  //  0119  GETNGBL	R8	K6
+      0x60240018,  //  011A  GETGBL	R9	G24
+      0x5828002B,  //  011B  LDCONST	R10	K43
+      0x882C0729,  //  011C  GETMBR	R11	R3	K41
+      0x8830032C,  //  011D  GETMBR	R12	R1	K44
+      0x8834032D,  //  011E  GETMBR	R13	R1	K45
+      0x7C240800,  //  011F  CALL	R9	4
+      0x58280008,  //  0120  LDCONST	R10	K8
+      0x7C200400,  //  0121  CALL	R8	2
+      0x8C20052F,  //  0122  GETMET	R8	R2	K47
+      0x542A000F,  //  0123  LDINT	R10	16
+      0x7C200400,  //  0124  CALL	R8	2
+      0x900E5C08,  //  0125  SETMBR	R3	K46	R8
+      0x8C20052F,  //  0126  GETMET	R8	R2	K47
+      0x542A001F,  //  0127  LDINT	R10	32
       0x7C200400,  //  0128  CALL	R8	2
-      0x900E5E08,  //  0129  SETMBR	R3	K47	R8
-      0x8C200530,  //  012A  GETMET	R8	R2	K48
-      0x542A001F,  //  012B  LDINT	R10	32
-      0x7C200400,  //  012C  CALL	R8	2
-      0x900E9208,  //  012D  SETMBR	R3	K73	R8
-      0x8C20054B,  //  012E  GETMET	R8	R2	K75
-      0x7C200200,  //  012F  CALL	R8	1
-      0x8C20114C,  //  0130  GETMET	R8	R8	K76
-      0x88280749,  //  0131  GETMBR	R10	R3	K73
+      0x900E9208,  //  0129  SETMBR	R3	K73	R8
+      0x8C20054B,  //  012A  GETMET	R8	R2	K75
+      0x7C200200,  //  012B  CALL	R8	1
+      0x8C20114C,  //  012C  GETMET	R8	R8	K76
+      0x88280749,  //  012D  GETMBR	R10	R3	K73
+      0x7C200400,  //  012E  CALL	R8	2
+      0x900E9408,  //  012F  SETMBR	R3	K74	R8
+      0x8C20052F,  //  0130  GETMET	R8	R2	K47
+      0x542A001F,  //  0131  LDINT	R10	32
       0x7C200400,  //  0132  CALL	R8	2
-      0x900E9408,  //  0133  SETMBR	R3	K74	R8
-      0x8C200530,  //  0134  GETMET	R8	R2	K48
-      0x542A001F,  //  0135  LDINT	R10	32
-      0x7C200400,  //  0136  CALL	R8	2
-      0x8C24054B,  //  0137  GETMET	R9	R2	K75
-      0x7C240200,  //  0138  CALL	R9	1
-      0x8C24134D,  //  0139  GETMET	R9	R9	K77
-      0x882C0749,  //  013A  GETMBR	R11	R3	K73
-      0x88300913,  //  013B  GETMBR	R12	R4	K19
-      0x7C240600,  //  013C  CALL	R9	3
-      0x900E3E09,  //  013D  SETMBR	R3	K31	R9
-      0xB8261A00,  //  013E  GETNGBL	R9	K13
-      0x8824134E,  //  013F  GETMBR	R9	R9	K78
-      0x8C24134F,  //  0140  GETMET	R9	R9	K79
-      0x7C240200,  //  0141  CALL	R9	1
-      0x8C281350,  //  0142  GETMET	R10	R9	K80
-      0x5830000B,  //  0143  LDCONST	R12	K11
-      0xB8361A00,  //  0144  GETNGBL	R13	K13
-      0x88341B4E,  //  0145  GETMBR	R13	R13	K78
-      0x88341B51,  //  0146  GETMBR	R13	R13	K81
-      0x8C380F52,  //  0147  GETMET	R14	R7	K82
-      0x7C380200,  //  0148  CALL	R14	1
-      0x7C280800,  //  0149  CALL	R10	4
-      0x8C281350,  //  014A  GETMET	R10	R9	K80
-      0x5830000C,  //  014B  LDCONST	R12	K12
-      0xB8361A00,  //  014C  GETNGBL	R13	K13
-      0x88341B4E,  //  014D  GETMBR	R13	R13	K78
-      0x88341B51,  //  014E  GETMBR	R13	R13	K81
-      0x8C380F53,  //  014F  GETMET	R14	R7	K83
-      0x7C380200,  //  0150  CALL	R14	1
-      0x7C280800,  //  0151  CALL	R10	4
-      0x8C281350,  //  0152  GETMET	R10	R9	K80
-      0x58300009,  //  0153  LDCONST	R12	K9
-      0xB8361A00,  //  0154  GETNGBL	R13	K13
-      0x88341B4E,  //  0155  GETMBR	R13	R13	K78
-      0x88341B51,  //  0156  GETMBR	R13	R13	K81
-      0x8838074A,  //  0157  GETMBR	R14	R3	K74
-      0x7C280800,  //  0158  CALL	R10	4
-      0x8C281350,  //  0159  GETMET	R10	R9	K80
-      0x54320003,  //  015A  LDINT	R12	4
-      0xB8361A00,  //  015B  GETNGBL	R13	K13
-      0x88341B4E,  //  015C  GETMBR	R13	R13	K78
-      0x88341B51,  //  015D  GETMBR	R13	R13	K81
-      0x88380913,  //  015E  GETMBR	R14	R4	K19
-      0x7C280800,  //  015F  CALL	R10	4
-      0x8C28054B,  //  0160  GETMET	R10	R2	K75
-      0x7C280200,  //  0161  CALL	R10	1
-      0x8C281554,  //  0162  GETMET	R10	R10	K84
-      0x8C300F55,  //  0163  GETMET	R12	R7	K85
-      0x7C300200,  //  0164  CALL	R12	1
-      0x8C341338,  //  0165  GETMET	R13	R9	K56
-      0x7C340200,  //  0166  CALL	R13	1
-      0x7C280600,  //  0167  CALL	R10	3
-      0xB82E1A00,  //  0168  GETNGBL	R11	K13
-      0x882C174E,  //  0169  GETMBR	R11	R11	K78
-      0x8C2C174F,  //  016A  GETMET	R11	R11	K79
-      0x7C2C0200,  //  016B  CALL	R11	1
-      0x8C301750,  //  016C  GETMET	R12	R11	K80
-      0x5838000B,  //  016D  LDCONST	R14	K11
-      0xB83E1A00,  //  016E  GETNGBL	R15	K13
-      0x883C1F4E,  //  016F  GETMBR	R15	R15	K78
-      0x883C1F51,  //  0170  GETMBR	R15	R15	K81
-      0x8C400F52,  //  0171  GETMET	R16	R7	K82
-      0x7C400200,  //  0172  CALL	R16	1
-      0x7C300800,  //  0173  CALL	R12	4
-      0x8C301750,  //  0174  GETMET	R12	R11	K80
-      0x5838000C,  //  0175  LDCONST	R14	K12
-      0xB83E1A00,  //  0176  GETNGBL	R15	K13
-      0x883C1F4E,  //  0177  GETMBR	R15	R15	K78
-      0x883C1F51,  //  0178  GETMBR	R15	R15	K81
-      0x8C400F53,  //  0179  GETMET	R16	R7	K83
-      0x7C400200,  //  017A  CALL	R16	1
-      0x7C300800,  //  017B  CALL	R12	4
-      0x8C301750,  //  017C  GETMET	R12	R11	K80
-      0x58380009,  //  017D  LDCONST	R14	K9
-      0xB83E1A00,  //  017E  GETNGBL	R15	K13
-      0x883C1F4E,  //  017F  GETMBR	R15	R15	K78
-      0x883C1F51,  //  0180  GETMBR	R15	R15	K81
-      0x5C401400,  //  0181  MOVE	R16	R10
-      0x7C300800,  //  0182  CALL	R12	4
-      0x8C301750,  //  0183  GETMET	R12	R11	K80
-      0x543A0003,  //  0184  LDINT	R14	4
-      0xB83E1A00,  //  0185  GETNGBL	R15	K13
-      0x883C1F4E,  //  0186  GETMBR	R15	R15	K78
-      0x883C1F51,  //  0187  GETMBR	R15	R15	K81
-      0x8840072F,  //  0188  GETMBR	R16	R3	K47
-      0x7C300800,  //  0189  CALL	R12	4
-      0x88300956,  //  018A  GETMBR	R12	R4	K86
-      0x900E720C,  //  018B  SETMBR	R3	K57	R12
-      0x8C300557,  //  018C  GETMET	R12	R2	K87
-      0x7C300200,  //  018D  CALL	R12	1
-      0x8C301958,  //  018E  GETMET	R12	R12	K88
-      0x88380739,  //  018F  GETMBR	R14	R3	K57
-      0x7C300400,  //  0190  CALL	R12	2
-      0x8C301959,  //  0191  GETMET	R12	R12	K89
-      0x7C300200,  //  0192  CALL	R12	1
-      0x60340015,  //  0193  GETGBL	R13	G21
-      0x7C340000,  //  0194  CALL	R13	0
-      0x8C341B1B,  //  0195  GETMET	R13	R13	K27
-      0x883C015A,  //  0196  GETMBR	R15	R0	K90
-      0x7C340400,  //  0197  CALL	R13	2
-      0x8C380F5B,  //  0198  GETMET	R14	R7	K91
-      0x7C380200,  //  0199  CALL	R14	1
-      0x00381C08,  //  019A  ADD	R14	R14	R8
-      0x883C074A,  //  019B  GETMBR	R15	R3	K74
-      0x00381C0F,  //  019C  ADD	R14	R14	R15
-      0x00381C0C,  //  019D  ADD	R14	R14	R12
-      0x8C3C051D,  //  019E  GETMET	R15	R2	K29
-      0x7C3C0200,  //  019F  CALL	R15	1
-      0x8C3C1F1E,  //  01A0  GETMET	R15	R15	K30
-      0x8844071F,  //  01A1  GETMBR	R17	R3	K31
-      0x5C481C00,  //  01A2  MOVE	R18	R14
-      0x5C4C1A00,  //  01A3  MOVE	R19	R13
-      0x5452000F,  //  01A4  LDINT	R20	16
-      0x7C3C0A00,  //  01A5  CALL	R15	5
-      0x8C401738,  //  01A6  GETMET	R16	R11	K56
-      0x7C400200,  //  01A7  CALL	R16	1
-      0x8C440522,  //  01A8  GETMET	R17	R2	K34
-      0x5C4C1E00,  //  01A9  MOVE	R19	R15
-      0x60500015,  //  01AA  GETGBL	R20	G21
-      0x7C500000,  //  01AB  CALL	R20	0
-      0x8C50291B,  //  01AC  GETMET	R20	R20	K27
-      0x8858015C,  //  01AD  GETMBR	R22	R0	K92
-      0x7C500400,  //  01AE  CALL	R20	2
-      0x60540015,  //  01AF  GETGBL	R21	G21
-      0x7C540000,  //  01B0  CALL	R21	0
-      0x6058000C,  //  01B1  GETGBL	R22	G12
-      0x5C5C2000,  //  01B2  MOVE	R23	R16
-      0x7C580200,  //  01B3  CALL	R22	1
-      0x545E000F,  //  01B4  LDINT	R23	16
-      0x7C440C00,  //  01B5  CALL	R17	6
-      0x8C48235D,  //  01B6  GETMET	R18	R17	K93
-      0x5C502000,  //  01B7  MOVE	R20	R16
-      0x7C480400,  //  01B8  CALL	R18	2
-      0x8C4C2324,  //  01B9  GETMET	R19	R17	K36
+      0x8C24054B,  //  0133  GETMET	R9	R2	K75
+      0x7C240200,  //  0134  CALL	R9	1
+      0x8C24134D,  //  0135  GETMET	R9	R9	K77
+      0x882C0749,  //  0136  GETMBR	R11	R3	K73
+      0x88300912,  //  0137  GETMBR	R12	R4	K18
+      0x7C240600,  //  0138  CALL	R9	3
+      0x900E3C09,  //  0139  SETMBR	R3	K30	R9
+      0xB8261800,  //  013A  GETNGBL	R9	K12
+      0x8824134E,  //  013B  GETMBR	R9	R9	K78
+      0x8C24134F,  //  013C  GETMET	R9	R9	K79
+      0x7C240200,  //  013D  CALL	R9	1
+      0x8C281350,  //  013E  GETMET	R10	R9	K80
+      0x5830000A,  //  013F  LDCONST	R12	K10
+      0xB8361800,  //  0140  GETNGBL	R13	K12
+      0x88341B4E,  //  0141  GETMBR	R13	R13	K78
+      0x88341B51,  //  0142  GETMBR	R13	R13	K81
+      0x8C380F52,  //  0143  GETMET	R14	R7	K82
+      0x7C380200,  //  0144  CALL	R14	1
+      0x7C280800,  //  0145  CALL	R10	4
+      0x8C281350,  //  0146  GETMET	R10	R9	K80
+      0x5830000B,  //  0147  LDCONST	R12	K11
+      0xB8361800,  //  0148  GETNGBL	R13	K12
+      0x88341B4E,  //  0149  GETMBR	R13	R13	K78
+      0x88341B51,  //  014A  GETMBR	R13	R13	K81
+      0x8C380F53,  //  014B  GETMET	R14	R7	K83
+      0x7C380200,  //  014C  CALL	R14	1
+      0x7C280800,  //  014D  CALL	R10	4
+      0x8C281350,  //  014E  GETMET	R10	R9	K80
+      0x58300008,  //  014F  LDCONST	R12	K8
+      0xB8361800,  //  0150  GETNGBL	R13	K12
+      0x88341B4E,  //  0151  GETMBR	R13	R13	K78
+      0x88341B51,  //  0152  GETMBR	R13	R13	K81
+      0x8838074A,  //  0153  GETMBR	R14	R3	K74
+      0x7C280800,  //  0154  CALL	R10	4
+      0x8C281350,  //  0155  GETMET	R10	R9	K80
+      0x54320003,  //  0156  LDINT	R12	4
+      0xB8361800,  //  0157  GETNGBL	R13	K12
+      0x88341B4E,  //  0158  GETMBR	R13	R13	K78
+      0x88341B51,  //  0159  GETMBR	R13	R13	K81
+      0x88380912,  //  015A  GETMBR	R14	R4	K18
+      0x7C280800,  //  015B  CALL	R10	4
+      0x8C28054B,  //  015C  GETMET	R10	R2	K75
+      0x7C280200,  //  015D  CALL	R10	1
+      0x8C281554,  //  015E  GETMET	R10	R10	K84
+      0x8C300F55,  //  015F  GETMET	R12	R7	K85
+      0x7C300200,  //  0160  CALL	R12	1
+      0x8C341338,  //  0161  GETMET	R13	R9	K56
+      0x7C340200,  //  0162  CALL	R13	1
+      0x7C280600,  //  0163  CALL	R10	3
+      0xB82E1800,  //  0164  GETNGBL	R11	K12
+      0x882C174E,  //  0165  GETMBR	R11	R11	K78
+      0x8C2C174F,  //  0166  GETMET	R11	R11	K79
+      0x7C2C0200,  //  0167  CALL	R11	1
+      0x8C301750,  //  0168  GETMET	R12	R11	K80
+      0x5838000A,  //  0169  LDCONST	R14	K10
+      0xB83E1800,  //  016A  GETNGBL	R15	K12
+      0x883C1F4E,  //  016B  GETMBR	R15	R15	K78
+      0x883C1F51,  //  016C  GETMBR	R15	R15	K81
+      0x8C400F52,  //  016D  GETMET	R16	R7	K82
+      0x7C400200,  //  016E  CALL	R16	1
+      0x7C300800,  //  016F  CALL	R12	4
+      0x8C301750,  //  0170  GETMET	R12	R11	K80
+      0x5838000B,  //  0171  LDCONST	R14	K11
+      0xB83E1800,  //  0172  GETNGBL	R15	K12
+      0x883C1F4E,  //  0173  GETMBR	R15	R15	K78
+      0x883C1F51,  //  0174  GETMBR	R15	R15	K81
+      0x8C400F53,  //  0175  GETMET	R16	R7	K83
+      0x7C400200,  //  0176  CALL	R16	1
+      0x7C300800,  //  0177  CALL	R12	4
+      0x8C301750,  //  0178  GETMET	R12	R11	K80
+      0x58380008,  //  0179  LDCONST	R14	K8
+      0xB83E1800,  //  017A  GETNGBL	R15	K12
+      0x883C1F4E,  //  017B  GETMBR	R15	R15	K78
+      0x883C1F51,  //  017C  GETMBR	R15	R15	K81
+      0x5C401400,  //  017D  MOVE	R16	R10
+      0x7C300800,  //  017E  CALL	R12	4
+      0x8C301750,  //  017F  GETMET	R12	R11	K80
+      0x543A0003,  //  0180  LDINT	R14	4
+      0xB83E1800,  //  0181  GETNGBL	R15	K12
+      0x883C1F4E,  //  0182  GETMBR	R15	R15	K78
+      0x883C1F51,  //  0183  GETMBR	R15	R15	K81
+      0x8840072E,  //  0184  GETMBR	R16	R3	K46
+      0x7C300800,  //  0185  CALL	R12	4
+      0x88300956,  //  0186  GETMBR	R12	R4	K86
+      0x900E720C,  //  0187  SETMBR	R3	K57	R12
+      0x8C300557,  //  0188  GETMET	R12	R2	K87
+      0x7C300200,  //  0189  CALL	R12	1
+      0x8C301958,  //  018A  GETMET	R12	R12	K88
+      0x88380739,  //  018B  GETMBR	R14	R3	K57
+      0x7C300400,  //  018C  CALL	R12	2
+      0x8C301959,  //  018D  GETMET	R12	R12	K89
+      0x7C300200,  //  018E  CALL	R12	1
+      0x60340015,  //  018F  GETGBL	R13	G21
+      0x7C340000,  //  0190  CALL	R13	0
+      0x8C341B1A,  //  0191  GETMET	R13	R13	K26
+      0x883C015A,  //  0192  GETMBR	R15	R0	K90
+      0x7C340400,  //  0193  CALL	R13	2
+      0x8C380F5B,  //  0194  GETMET	R14	R7	K91
+      0x7C380200,  //  0195  CALL	R14	1
+      0x00381C08,  //  0196  ADD	R14	R14	R8
+      0x883C074A,  //  0197  GETMBR	R15	R3	K74
+      0x00381C0F,  //  0198  ADD	R14	R14	R15
+      0x00381C0C,  //  0199  ADD	R14	R14	R12
+      0x8C3C051C,  //  019A  GETMET	R15	R2	K28
+      0x7C3C0200,  //  019B  CALL	R15	1
+      0x8C3C1F1D,  //  019C  GETMET	R15	R15	K29
+      0x8844071E,  //  019D  GETMBR	R17	R3	K30
+      0x5C481C00,  //  019E  MOVE	R18	R14
+      0x5C4C1A00,  //  019F  MOVE	R19	R13
+      0x5452000F,  //  01A0  LDINT	R20	16
+      0x7C3C0A00,  //  01A1  CALL	R15	5
+      0x8C401738,  //  01A2  GETMET	R16	R11	K56
+      0x7C400200,  //  01A3  CALL	R16	1
+      0x8C440521,  //  01A4  GETMET	R17	R2	K33
+      0x5C4C1E00,  //  01A5  MOVE	R19	R15
+      0x60500015,  //  01A6  GETGBL	R20	G21
+      0x7C500000,  //  01A7  CALL	R20	0
+      0x8C50291A,  //  01A8  GETMET	R20	R20	K26
+      0x8858015C,  //  01A9  GETMBR	R22	R0	K92
+      0x7C500400,  //  01AA  CALL	R20	2
+      0x60540015,  //  01AB  GETGBL	R21	G21
+      0x7C540000,  //  01AC  CALL	R21	0
+      0x6058000C,  //  01AD  GETGBL	R22	G12
+      0x5C5C2000,  //  01AE  MOVE	R23	R16
+      0x7C580200,  //  01AF  CALL	R22	1
+      0x545E000F,  //  01B0  LDINT	R23	16
+      0x7C440C00,  //  01B1  CALL	R17	6
+      0x8C48235D,  //  01B2  GETMET	R18	R17	K93
+      0x5C502000,  //  01B3  MOVE	R20	R16
+      0x7C480400,  //  01B4  CALL	R18	2
+      0x8C4C2323,  //  01B5  GETMET	R19	R17	K35
+      0x7C4C0200,  //  01B6  CALL	R19	1
+      0x00482413,  //  01B7  ADD	R18	R18	R19
+      0xB84E1800,  //  01B8  GETNGBL	R19	K12
+      0x8C4C275E,  //  01B9  GETMET	R19	R19	K94
       0x7C4C0200,  //  01BA  CALL	R19	1
-      0x00482413,  //  01BB  ADD	R18	R18	R19
-      0xB84E1A00,  //  01BC  GETNGBL	R19	K13
-      0x8C4C275E,  //  01BD  GETMET	R19	R19	K94
-      0x7C4C0200,  //  01BE  CALL	R19	1
-      0x904EBE08,  //  01BF  SETMBR	R19	K95	R8
-      0x8850072A,  //  01C0  GETMBR	R20	R3	K42
-      0x904EC014,  //  01C1  SETMBR	R19	K96	R20
-      0x8850074A,  //  01C2  GETMBR	R20	R3	K74
-      0x904EC214,  //  01C3  SETMBR	R19	K97	R20
-      0x904EC412,  //  01C4  SETMBR	R19	K98	R18
-      0x8C502738,  //  01C5  GETMET	R20	R19	K56
-      0x7C500200,  //  01C6  CALL	R20	1
-      0x900EC614,  //  01C7  SETMBR	R3	K99	R20
-      0x8C54033A,  //  01C8  GETMET	R21	R1	K58
-      0x545E0030,  //  01C9  LDINT	R23	49
-      0x50600200,  //  01CA  LDBOOL	R24	1	0
-      0x7C540600,  //  01CB  CALL	R21	3
-      0x8C582B3B,  //  01CC  GETMET	R22	R21	K59
-      0x5C602800,  //  01CD  MOVE	R24	R20
-      0x7C580400,  //  01CE  CALL	R22	2
-      0xB85E0C00,  //  01CF  GETNGBL	R23	K6
-      0x8C5C2F07,  //  01D0  GETMET	R23	R23	K7
-      0x60640018,  //  01D1  GETGBL	R25	G24
-      0x58680064,  //  01D2  LDCONST	R26	K100
-      0x886C072A,  //  01D3  GETMBR	R27	R3	K42
-      0x88700765,  //  01D4  GETMBR	R28	R3	K101
-      0x88740766,  //  01D5  GETMBR	R29	R3	K102
-      0x7C640800,  //  01D6  CALL	R25	4
-      0x5868000C,  //  01D7  LDCONST	R26	K12
-      0x7C5C0600,  //  01D8  CALL	R23	3
-      0x885C013C,  //  01D9  GETMBR	R23	R0	K60
-      0x8C5C2F3D,  //  01DA  GETMET	R23	R23	K61
-      0x5C642A00,  //  01DB  MOVE	R25	R21
-      0x7C5C0400,  //  01DC  CALL	R23	2
-      0x505C0200,  //  01DD  LDBOOL	R23	1	0
-      0x80042E00,  //  01DE  RET	1	R23
-      0x501C0200,  //  01DF  LDBOOL	R7	1	0
-      0x80040E00,  //  01E0  RET	1	R7
+      0x904EBE08,  //  01BB  SETMBR	R19	K95	R8
+      0x88500729,  //  01BC  GETMBR	R20	R3	K41
+      0x904EC014,  //  01BD  SETMBR	R19	K96	R20
+      0x8850074A,  //  01BE  GETMBR	R20	R3	K74
+      0x904EC214,  //  01BF  SETMBR	R19	K97	R20
+      0x904EC412,  //  01C0  SETMBR	R19	K98	R18
+      0x8C502738,  //  01C1  GETMET	R20	R19	K56
+      0x7C500200,  //  01C2  CALL	R20	1
+      0x900EC614,  //  01C3  SETMBR	R3	K99	R20
+      0x8C54033A,  //  01C4  GETMET	R21	R1	K58
+      0x545E0030,  //  01C5  LDINT	R23	49
+      0x50600200,  //  01C6  LDBOOL	R24	1	0
+      0x7C540600,  //  01C7  CALL	R21	3
+      0x8C582B3B,  //  01C8  GETMET	R22	R21	K59
+      0x5C602800,  //  01C9  MOVE	R24	R20
+      0x7C580400,  //  01CA  CALL	R22	2
+      0xB85E0C00,  //  01CB  GETNGBL	R23	K6
+      0x60600018,  //  01CC  GETGBL	R24	G24
+      0x58640064,  //  01CD  LDCONST	R25	K100
+      0x88680729,  //  01CE  GETMBR	R26	R3	K41
+      0x886C0765,  //  01CF  GETMBR	R27	R3	K101
+      0x88700766,  //  01D0  GETMBR	R28	R3	K102
+      0x7C600800,  //  01D1  CALL	R24	4
+      0x5864000B,  //  01D2  LDCONST	R25	K11
+      0x7C5C0400,  //  01D3  CALL	R23	2
+      0x885C013C,  //  01D4  GETMBR	R23	R0	K60
+      0x8C5C2F3D,  //  01D5  GETMET	R23	R23	K61
+      0x5C642A00,  //  01D6  MOVE	R25	R21
+      0x7C5C0400,  //  01D7  CALL	R23	2
+      0x505C0200,  //  01D8  LDBOOL	R23	1	0
+      0x80042E00,  //  01D9  RET	1	R23
+      0x501C0200,  //  01DA  LDBOOL	R7	1	0
+      0x80040E00,  //  01DB  RET	1	R7
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning_Data.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning_Data.h
@@ -12,7 +12,7 @@ extern const bclass be_class_Matter_PBKDFParamRequest;
 extern const bclass be_class_Matter_PBKDFParamRequest;
 be_local_closure(class_Matter_PBKDFParamRequest_parse,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    9,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -21,9 +21,9 @@ be_local_closure(class_Matter_PBKDFParamRequest_parse,   /* name */
     &be_class_Matter_PBKDFParamRequest, 
     1,                          /* has constants */
     ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(TLV),
+    /* K2   */  be_const_int(0),
     /* K3   */  be_nested_str_weak(parse),
     /* K4   */  be_nested_str_weak(initiatorRandom),
     /* K5   */  be_nested_str_weak(getsubval),
@@ -41,46 +41,46 @@ be_local_closure(class_Matter_PBKDFParamRequest_parse,   /* name */
     be_str_weak(parse),
     &be_const_str_solidified,
     ( &(const binstruction[41]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C0C0403,  //  0001  EQ	R3	R2	R3
-      0x780E0000,  //  0002  JMPF	R3	#0004
-      0x58080000,  //  0003  LDCONST	R2	K0
-      0xB80E0200,  //  0004  GETNGBL	R3	K1
-      0x880C0702,  //  0005  GETMBR	R3	R3	K2
-      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x5C180400,  //  0008  MOVE	R6	R2
-      0x7C0C0600,  //  0009  CALL	R3	3
-      0x8C100705,  //  000A  GETMET	R4	R3	K5
-      0x58180006,  //  000B  LDCONST	R6	K6
-      0x7C100400,  //  000C  CALL	R4	2
-      0x90020804,  //  000D  SETMBR	R0	K4	R4
-      0x8C100705,  //  000E  GETMET	R4	R3	K5
-      0x58180008,  //  000F  LDCONST	R6	K8
-      0x7C100400,  //  0010  CALL	R4	2
-      0x90020E04,  //  0011  SETMBR	R0	K7	R4
-      0x8C100705,  //  0012  GETMET	R4	R3	K5
-      0x5818000A,  //  0013  LDCONST	R6	K10
-      0x7C100400,  //  0014  CALL	R4	2
-      0x90021204,  //  0015  SETMBR	R0	K9	R4
-      0x8C100705,  //  0016  GETMET	R4	R3	K5
-      0x541A0003,  //  0017  LDINT	R6	4
-      0x7C100400,  //  0018  CALL	R4	2
-      0x90021604,  //  0019  SETMBR	R0	K11	R4
-      0x8C10070C,  //  001A  GETMET	R4	R3	K12
-      0x541A0004,  //  001B  LDINT	R6	5
-      0x7C100400,  //  001C  CALL	R4	2
-      0x4C140000,  //  001D  LDNIL	R5
-      0x20140805,  //  001E  NE	R5	R4	R5
-      0x78160007,  //  001F  JMPF	R5	#0028
-      0x8C14090E,  //  0020  GETMET	R5	R4	K14
-      0x581C0006,  //  0021  LDCONST	R7	K6
-      0x7C140400,  //  0022  CALL	R5	2
-      0x90021A05,  //  0023  SETMBR	R0	K13	R5
-      0x8C14090E,  //  0024  GETMET	R5	R4	K14
-      0x581C0008,  //  0025  LDCONST	R7	K8
-      0x7C140400,  //  0026  CALL	R5	2
-      0x90021E05,  //  0027  SETMBR	R0	K15	R5
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x880C0701,  //  0001  GETMBR	R3	R3	K1
+      0x4C100000,  //  0002  LDNIL	R4
+      0x1C100404,  //  0003  EQ	R4	R2	R4
+      0x78120000,  //  0004  JMPF	R4	#0006
+      0x58080002,  //  0005  LDCONST	R2	K2
+      0x8C100703,  //  0006  GETMET	R4	R3	K3
+      0x5C180200,  //  0007  MOVE	R6	R1
+      0x5C1C0400,  //  0008  MOVE	R7	R2
+      0x7C100600,  //  0009  CALL	R4	3
+      0x8C140905,  //  000A  GETMET	R5	R4	K5
+      0x581C0006,  //  000B  LDCONST	R7	K6
+      0x7C140400,  //  000C  CALL	R5	2
+      0x90020805,  //  000D  SETMBR	R0	K4	R5
+      0x8C140905,  //  000E  GETMET	R5	R4	K5
+      0x581C0008,  //  000F  LDCONST	R7	K8
+      0x7C140400,  //  0010  CALL	R5	2
+      0x90020E05,  //  0011  SETMBR	R0	K7	R5
+      0x8C140905,  //  0012  GETMET	R5	R4	K5
+      0x581C000A,  //  0013  LDCONST	R7	K10
+      0x7C140400,  //  0014  CALL	R5	2
+      0x90021205,  //  0015  SETMBR	R0	K9	R5
+      0x8C140905,  //  0016  GETMET	R5	R4	K5
+      0x541E0003,  //  0017  LDINT	R7	4
+      0x7C140400,  //  0018  CALL	R5	2
+      0x90021605,  //  0019  SETMBR	R0	K11	R5
+      0x8C14090C,  //  001A  GETMET	R5	R4	K12
+      0x541E0004,  //  001B  LDINT	R7	5
+      0x7C140400,  //  001C  CALL	R5	2
+      0x4C180000,  //  001D  LDNIL	R6
+      0x20180A06,  //  001E  NE	R6	R5	R6
+      0x781A0007,  //  001F  JMPF	R6	#0028
+      0x8C180B0E,  //  0020  GETMET	R6	R5	K14
+      0x58200006,  //  0021  LDCONST	R8	K6
+      0x7C180400,  //  0022  CALL	R6	2
+      0x90021A06,  //  0023  SETMBR	R0	K13	R6
+      0x8C180B0E,  //  0024  GETMET	R6	R5	K14
+      0x58200008,  //  0025  LDCONST	R8	K8
+      0x7C180400,  //  0026  CALL	R6	2
+      0x90021E06,  //  0027  SETMBR	R0	K15	R6
       0x80040000,  //  0028  RET	1	R0
     })
   )
@@ -115,7 +115,7 @@ extern const bclass be_class_Matter_PBKDFParamResponse;
 extern const bclass be_class_Matter_PBKDFParamResponse;
 be_local_closure(class_Matter_PBKDFParamResponse_tlv2raw,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    11,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -146,78 +146,64 @@ be_local_closure(class_Matter_PBKDFParamResponse_tlv2raw,   /* name */
     }),
     be_str_weak(tlv2raw),
     &be_const_str_solidified,
-    ( &(const binstruction[71]) {  /* code */
+    ( &(const binstruction[57]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
       0x88080501,  //  0001  GETMBR	R2	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0xB81A0000,  //  0006  GETNGBL	R6	K0
-      0x88180D01,  //  0007  GETMBR	R6	R6	K1
-      0x88180D05,  //  0008  GETMBR	R6	R6	K5
-      0x881C0106,  //  0009  GETMBR	R7	R0	K6
-      0x7C0C0800,  //  000A  CALL	R3	4
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x58140007,  //  000C  LDCONST	R5	K7
-      0xB81A0000,  //  000D  GETNGBL	R6	K0
-      0x88180D01,  //  000E  GETMBR	R6	R6	K1
-      0x88180D05,  //  000F  GETMBR	R6	R6	K5
-      0x881C0108,  //  0010  GETMBR	R7	R0	K8
-      0x7C0C0800,  //  0011  CALL	R3	4
-      0x8C0C0503,  //  0012  GETMET	R3	R2	K3
-      0x58140009,  //  0013  LDCONST	R5	K9
-      0xB81A0000,  //  0014  GETNGBL	R6	K0
-      0x88180D01,  //  0015  GETMBR	R6	R6	K1
-      0x88180D0A,  //  0016  GETMBR	R6	R6	K10
-      0x881C010B,  //  0017  GETMBR	R7	R0	K11
-      0x7C0C0800,  //  0018  CALL	R3	4
-      0x8C0C050C,  //  0019  GETMET	R3	R2	K12
-      0x54160003,  //  001A  LDINT	R5	4
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x8C100703,  //  001C  GETMET	R4	R3	K3
-      0x58180004,  //  001D  LDCONST	R6	K4
-      0xB81E0000,  //  001E  GETNGBL	R7	K0
-      0x881C0F01,  //  001F  GETMBR	R7	R7	K1
-      0x881C0F0D,  //  0020  GETMBR	R7	R7	K13
-      0x8820010E,  //  0021  GETMBR	R8	R0	K14
-      0x7C100800,  //  0022  CALL	R4	4
-      0x8C100703,  //  0023  GETMET	R4	R3	K3
-      0x58180007,  //  0024  LDCONST	R6	K7
-      0xB81E0000,  //  0025  GETNGBL	R7	K0
-      0x881C0F01,  //  0026  GETMBR	R7	R7	K1
-      0x881C0F05,  //  0027  GETMBR	R7	R7	K5
-      0x8820010F,  //  0028  GETMBR	R8	R0	K15
-      0x7C100800,  //  0029  CALL	R4	4
-      0x88100110,  //  002A  GETMBR	R4	R0	K16
-      0x4C140000,  //  002B  LDNIL	R5
-      0x20100805,  //  002C  NE	R4	R4	R5
-      0x74120003,  //  002D  JMPT	R4	#0032
-      0x88100111,  //  002E  GETMBR	R4	R0	K17
-      0x4C140000,  //  002F  LDNIL	R5
-      0x20100805,  //  0030  NE	R4	R4	R5
-      0x78120010,  //  0031  JMPF	R4	#0043
-      0x8C10050C,  //  0032  GETMET	R4	R2	K12
-      0x541A0004,  //  0033  LDINT	R6	5
-      0x7C100400,  //  0034  CALL	R4	2
-      0x8C140903,  //  0035  GETMET	R5	R4	K3
-      0x581C0004,  //  0036  LDCONST	R7	K4
-      0xB8220000,  //  0037  GETNGBL	R8	K0
-      0x88201101,  //  0038  GETMBR	R8	R8	K1
-      0x8820110D,  //  0039  GETMBR	R8	R8	K13
-      0x88240110,  //  003A  GETMBR	R9	R0	K16
-      0x7C140800,  //  003B  CALL	R5	4
-      0x8C140903,  //  003C  GETMET	R5	R4	K3
-      0x581C0007,  //  003D  LDCONST	R7	K7
-      0xB8220000,  //  003E  GETNGBL	R8	K0
-      0x88201101,  //  003F  GETMBR	R8	R8	K1
-      0x8820110D,  //  0040  GETMBR	R8	R8	K13
-      0x88240111,  //  0041  GETMBR	R9	R0	K17
-      0x7C140800,  //  0042  CALL	R5	4
-      0x8C100512,  //  0043  GETMET	R4	R2	K18
-      0x5C180200,  //  0044  MOVE	R6	R1
-      0x7C100400,  //  0045  CALL	R4	2
-      0x80040800,  //  0046  RET	1	R4
+      0x8C0C0502,  //  0002  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x8C100703,  //  0004  GETMET	R4	R3	K3
+      0x58180004,  //  0005  LDCONST	R6	K4
+      0x881C0505,  //  0006  GETMBR	R7	R2	K5
+      0x88200106,  //  0007  GETMBR	R8	R0	K6
+      0x7C100800,  //  0008  CALL	R4	4
+      0x8C100703,  //  0009  GETMET	R4	R3	K3
+      0x58180007,  //  000A  LDCONST	R6	K7
+      0x881C0505,  //  000B  GETMBR	R7	R2	K5
+      0x88200108,  //  000C  GETMBR	R8	R0	K8
+      0x7C100800,  //  000D  CALL	R4	4
+      0x8C100703,  //  000E  GETMET	R4	R3	K3
+      0x58180009,  //  000F  LDCONST	R6	K9
+      0x881C050A,  //  0010  GETMBR	R7	R2	K10
+      0x8820010B,  //  0011  GETMBR	R8	R0	K11
+      0x7C100800,  //  0012  CALL	R4	4
+      0x8C10070C,  //  0013  GETMET	R4	R3	K12
+      0x541A0003,  //  0014  LDINT	R6	4
+      0x7C100400,  //  0015  CALL	R4	2
+      0x8C140903,  //  0016  GETMET	R5	R4	K3
+      0x581C0004,  //  0017  LDCONST	R7	K4
+      0x8820050D,  //  0018  GETMBR	R8	R2	K13
+      0x8824010E,  //  0019  GETMBR	R9	R0	K14
+      0x7C140800,  //  001A  CALL	R5	4
+      0x8C140903,  //  001B  GETMET	R5	R4	K3
+      0x581C0007,  //  001C  LDCONST	R7	K7
+      0x88200505,  //  001D  GETMBR	R8	R2	K5
+      0x8824010F,  //  001E  GETMBR	R9	R0	K15
+      0x7C140800,  //  001F  CALL	R5	4
+      0x88140110,  //  0020  GETMBR	R5	R0	K16
+      0x4C180000,  //  0021  LDNIL	R6
+      0x20140A06,  //  0022  NE	R5	R5	R6
+      0x74160003,  //  0023  JMPT	R5	#0028
+      0x88140111,  //  0024  GETMBR	R5	R0	K17
+      0x4C180000,  //  0025  LDNIL	R6
+      0x20140A06,  //  0026  NE	R5	R5	R6
+      0x7816000C,  //  0027  JMPF	R5	#0035
+      0x8C14070C,  //  0028  GETMET	R5	R3	K12
+      0x541E0004,  //  0029  LDINT	R7	5
+      0x7C140400,  //  002A  CALL	R5	2
+      0x8C180B03,  //  002B  GETMET	R6	R5	K3
+      0x58200004,  //  002C  LDCONST	R8	K4
+      0x8824050D,  //  002D  GETMBR	R9	R2	K13
+      0x88280110,  //  002E  GETMBR	R10	R0	K16
+      0x7C180800,  //  002F  CALL	R6	4
+      0x8C180B03,  //  0030  GETMET	R6	R5	K3
+      0x58200007,  //  0031  LDCONST	R8	K7
+      0x8824050D,  //  0032  GETMBR	R9	R2	K13
+      0x88280111,  //  0033  GETMBR	R10	R0	K17
+      0x7C180800,  //  0034  CALL	R6	4
+      0x8C140712,  //  0035  GETMET	R5	R3	K18
+      0x5C1C0200,  //  0036  MOVE	R7	R1
+      0x7C140400,  //  0037  CALL	R5	2
+      0x80040A00,  //  0038  RET	1	R5
     })
   )
 );
@@ -315,7 +301,7 @@ extern const bclass be_class_Matter_Pake2;
 extern const bclass be_class_Matter_Pake2;
 be_local_closure(class_Matter_Pake2_tlv2raw,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    9,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -337,29 +323,25 @@ be_local_closure(class_Matter_Pake2_tlv2raw,   /* name */
     }),
     be_str_weak(tlv2raw),
     &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
+    ( &(const binstruction[18]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
       0x88080501,  //  0001  GETMBR	R2	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0xB81A0000,  //  0006  GETNGBL	R6	K0
-      0x88180D01,  //  0007  GETMBR	R6	R6	K1
-      0x88180D05,  //  0008  GETMBR	R6	R6	K5
-      0x881C0106,  //  0009  GETMBR	R7	R0	K6
-      0x7C0C0800,  //  000A  CALL	R3	4
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x58140007,  //  000C  LDCONST	R5	K7
-      0xB81A0000,  //  000D  GETNGBL	R6	K0
-      0x88180D01,  //  000E  GETMBR	R6	R6	K1
-      0x88180D05,  //  000F  GETMBR	R6	R6	K5
-      0x881C0108,  //  0010  GETMBR	R7	R0	K8
-      0x7C0C0800,  //  0011  CALL	R3	4
-      0x8C0C0509,  //  0012  GETMET	R3	R2	K9
-      0x5C140200,  //  0013  MOVE	R5	R1
-      0x7C0C0400,  //  0014  CALL	R3	2
-      0x80040600,  //  0015  RET	1	R3
+      0x8C0C0502,  //  0002  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x8C100703,  //  0004  GETMET	R4	R3	K3
+      0x58180004,  //  0005  LDCONST	R6	K4
+      0x881C0505,  //  0006  GETMBR	R7	R2	K5
+      0x88200106,  //  0007  GETMBR	R8	R0	K6
+      0x7C100800,  //  0008  CALL	R4	4
+      0x8C100703,  //  0009  GETMET	R4	R3	K3
+      0x58180007,  //  000A  LDCONST	R6	K7
+      0x881C0505,  //  000B  GETMBR	R7	R2	K5
+      0x88200108,  //  000C  GETMBR	R8	R0	K8
+      0x7C100800,  //  000D  CALL	R4	4
+      0x8C100709,  //  000E  GETMET	R4	R3	K9
+      0x5C180200,  //  000F  MOVE	R6	R1
+      0x7C100400,  //  0010  CALL	R4	2
+      0x80040800,  //  0011  RET	1	R4
     })
   )
 );
@@ -573,7 +555,7 @@ extern const bclass be_class_Matter_Sigma2;
 extern const bclass be_class_Matter_Sigma2;
 be_local_closure(class_Matter_Sigma2_tlv2raw,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    10,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -603,68 +585,56 @@ be_local_closure(class_Matter_Sigma2_tlv2raw,   /* name */
     }),
     be_str_weak(tlv2raw),
     &be_const_str_solidified,
-    ( &(const binstruction[61]) {  /* code */
+    ( &(const binstruction[49]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
       0x88080501,  //  0001  GETMBR	R2	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0xB81A0000,  //  0006  GETNGBL	R6	K0
-      0x88180D01,  //  0007  GETMBR	R6	R6	K1
-      0x88180D05,  //  0008  GETMBR	R6	R6	K5
-      0x881C0106,  //  0009  GETMBR	R7	R0	K6
-      0x7C0C0800,  //  000A  CALL	R3	4
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x58140007,  //  000C  LDCONST	R5	K7
-      0xB81A0000,  //  000D  GETNGBL	R6	K0
-      0x88180D01,  //  000E  GETMBR	R6	R6	K1
-      0x88180D08,  //  000F  GETMBR	R6	R6	K8
-      0x881C0109,  //  0010  GETMBR	R7	R0	K9
-      0x7C0C0800,  //  0011  CALL	R3	4
-      0x8C0C0503,  //  0012  GETMET	R3	R2	K3
-      0x5814000A,  //  0013  LDCONST	R5	K10
-      0xB81A0000,  //  0014  GETNGBL	R6	K0
-      0x88180D01,  //  0015  GETMBR	R6	R6	K1
-      0x88180D05,  //  0016  GETMBR	R6	R6	K5
-      0x881C010B,  //  0017  GETMBR	R7	R0	K11
-      0x7C0C0800,  //  0018  CALL	R3	4
-      0x8C0C0503,  //  0019  GETMET	R3	R2	K3
-      0x54160003,  //  001A  LDINT	R5	4
-      0xB81A0000,  //  001B  GETNGBL	R6	K0
-      0x88180D01,  //  001C  GETMBR	R6	R6	K1
-      0x88180D05,  //  001D  GETMBR	R6	R6	K5
-      0x881C010C,  //  001E  GETMBR	R7	R0	K12
-      0x7C0C0800,  //  001F  CALL	R3	4
-      0x880C010D,  //  0020  GETMBR	R3	R0	K13
-      0x4C100000,  //  0021  LDNIL	R4
-      0x200C0604,  //  0022  NE	R3	R3	R4
-      0x740E0003,  //  0023  JMPT	R3	#0028
-      0x880C010E,  //  0024  GETMBR	R3	R0	K14
-      0x4C100000,  //  0025  LDNIL	R4
-      0x200C0604,  //  0026  NE	R3	R3	R4
-      0x780E0010,  //  0027  JMPF	R3	#0039
-      0x8C0C050F,  //  0028  GETMET	R3	R2	K15
-      0x54160004,  //  0029  LDINT	R5	5
-      0x7C0C0400,  //  002A  CALL	R3	2
-      0x8C100703,  //  002B  GETMET	R4	R3	K3
-      0x58180004,  //  002C  LDCONST	R6	K4
-      0xB81E0000,  //  002D  GETNGBL	R7	K0
-      0x881C0F01,  //  002E  GETMBR	R7	R7	K1
-      0x881C0F10,  //  002F  GETMBR	R7	R7	K16
-      0x8820010D,  //  0030  GETMBR	R8	R0	K13
-      0x7C100800,  //  0031  CALL	R4	4
-      0x8C100703,  //  0032  GETMET	R4	R3	K3
-      0x58180007,  //  0033  LDCONST	R6	K7
-      0xB81E0000,  //  0034  GETNGBL	R7	K0
-      0x881C0F01,  //  0035  GETMBR	R7	R7	K1
-      0x881C0F10,  //  0036  GETMBR	R7	R7	K16
-      0x8820010E,  //  0037  GETMBR	R8	R0	K14
-      0x7C100800,  //  0038  CALL	R4	4
-      0x8C0C0511,  //  0039  GETMET	R3	R2	K17
-      0x5C140200,  //  003A  MOVE	R5	R1
-      0x7C0C0400,  //  003B  CALL	R3	2
-      0x80040600,  //  003C  RET	1	R3
+      0x8C0C0502,  //  0002  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x8C100703,  //  0004  GETMET	R4	R3	K3
+      0x58180004,  //  0005  LDCONST	R6	K4
+      0x881C0505,  //  0006  GETMBR	R7	R2	K5
+      0x88200106,  //  0007  GETMBR	R8	R0	K6
+      0x7C100800,  //  0008  CALL	R4	4
+      0x8C100703,  //  0009  GETMET	R4	R3	K3
+      0x58180007,  //  000A  LDCONST	R6	K7
+      0x881C0508,  //  000B  GETMBR	R7	R2	K8
+      0x88200109,  //  000C  GETMBR	R8	R0	K9
+      0x7C100800,  //  000D  CALL	R4	4
+      0x8C100703,  //  000E  GETMET	R4	R3	K3
+      0x5818000A,  //  000F  LDCONST	R6	K10
+      0x881C0505,  //  0010  GETMBR	R7	R2	K5
+      0x8820010B,  //  0011  GETMBR	R8	R0	K11
+      0x7C100800,  //  0012  CALL	R4	4
+      0x8C100703,  //  0013  GETMET	R4	R3	K3
+      0x541A0003,  //  0014  LDINT	R6	4
+      0x881C0505,  //  0015  GETMBR	R7	R2	K5
+      0x8820010C,  //  0016  GETMBR	R8	R0	K12
+      0x7C100800,  //  0017  CALL	R4	4
+      0x8810010D,  //  0018  GETMBR	R4	R0	K13
+      0x4C140000,  //  0019  LDNIL	R5
+      0x20100805,  //  001A  NE	R4	R4	R5
+      0x74120003,  //  001B  JMPT	R4	#0020
+      0x8810010E,  //  001C  GETMBR	R4	R0	K14
+      0x4C140000,  //  001D  LDNIL	R5
+      0x20100805,  //  001E  NE	R4	R4	R5
+      0x7812000C,  //  001F  JMPF	R4	#002D
+      0x8C10070F,  //  0020  GETMET	R4	R3	K15
+      0x541A0004,  //  0021  LDINT	R6	5
+      0x7C100400,  //  0022  CALL	R4	2
+      0x8C140903,  //  0023  GETMET	R5	R4	K3
+      0x581C0004,  //  0024  LDCONST	R7	K4
+      0x88200510,  //  0025  GETMBR	R8	R2	K16
+      0x8824010D,  //  0026  GETMBR	R9	R0	K13
+      0x7C140800,  //  0027  CALL	R5	4
+      0x8C140903,  //  0028  GETMET	R5	R4	K3
+      0x581C0007,  //  0029  LDCONST	R7	K7
+      0x88200510,  //  002A  GETMBR	R8	R2	K16
+      0x8824010E,  //  002B  GETMBR	R9	R0	K14
+      0x7C140800,  //  002C  CALL	R5	4
+      0x8C100711,  //  002D  GETMET	R4	R3	K17
+      0x5C180200,  //  002E  MOVE	R6	R1
+      0x7C100400,  //  002F  CALL	R4	2
+      0x80040800,  //  0030  RET	1	R4
     })
   )
 );
@@ -698,7 +668,7 @@ extern const bclass be_class_Matter_Sigma2Resume;
 extern const bclass be_class_Matter_Sigma2Resume;
 be_local_closure(class_Matter_Sigma2Resume_tlv2raw,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    10,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -727,61 +697,51 @@ be_local_closure(class_Matter_Sigma2Resume_tlv2raw,   /* name */
     }),
     be_str_weak(tlv2raw),
     &be_const_str_solidified,
-    ( &(const binstruction[54]) {  /* code */
+    ( &(const binstruction[44]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
       0x88080501,  //  0001  GETMBR	R2	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0503,  //  0004  GETMET	R3	R2	K3
-      0x58140004,  //  0005  LDCONST	R5	K4
-      0xB81A0000,  //  0006  GETNGBL	R6	K0
-      0x88180D01,  //  0007  GETMBR	R6	R6	K1
-      0x88180D05,  //  0008  GETMBR	R6	R6	K5
-      0x881C0106,  //  0009  GETMBR	R7	R0	K6
-      0x7C0C0800,  //  000A  CALL	R3	4
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x58140007,  //  000C  LDCONST	R5	K7
-      0xB81A0000,  //  000D  GETNGBL	R6	K0
-      0x88180D01,  //  000E  GETMBR	R6	R6	K1
-      0x88180D05,  //  000F  GETMBR	R6	R6	K5
-      0x881C0108,  //  0010  GETMBR	R7	R0	K8
-      0x7C0C0800,  //  0011  CALL	R3	4
-      0x8C0C0503,  //  0012  GETMET	R3	R2	K3
-      0x58140009,  //  0013  LDCONST	R5	K9
-      0xB81A0000,  //  0014  GETNGBL	R6	K0
-      0x88180D01,  //  0015  GETMBR	R6	R6	K1
-      0x88180D0A,  //  0016  GETMBR	R6	R6	K10
-      0x881C010B,  //  0017  GETMBR	R7	R0	K11
-      0x7C0C0800,  //  0018  CALL	R3	4
-      0x880C010C,  //  0019  GETMBR	R3	R0	K12
-      0x4C100000,  //  001A  LDNIL	R4
-      0x200C0604,  //  001B  NE	R3	R3	R4
-      0x740E0003,  //  001C  JMPT	R3	#0021
-      0x880C010D,  //  001D  GETMBR	R3	R0	K13
-      0x4C100000,  //  001E  LDNIL	R4
-      0x200C0604,  //  001F  NE	R3	R3	R4
-      0x780E0010,  //  0020  JMPF	R3	#0032
-      0x8C0C050E,  //  0021  GETMET	R3	R2	K14
-      0x54160003,  //  0022  LDINT	R5	4
-      0x7C0C0400,  //  0023  CALL	R3	2
-      0x8C100703,  //  0024  GETMET	R4	R3	K3
-      0x58180004,  //  0025  LDCONST	R6	K4
-      0xB81E0000,  //  0026  GETNGBL	R7	K0
-      0x881C0F01,  //  0027  GETMBR	R7	R7	K1
-      0x881C0F0F,  //  0028  GETMBR	R7	R7	K15
-      0x8820010C,  //  0029  GETMBR	R8	R0	K12
-      0x7C100800,  //  002A  CALL	R4	4
-      0x8C100703,  //  002B  GETMET	R4	R3	K3
-      0x58180007,  //  002C  LDCONST	R6	K7
-      0xB81E0000,  //  002D  GETNGBL	R7	K0
-      0x881C0F01,  //  002E  GETMBR	R7	R7	K1
-      0x881C0F0F,  //  002F  GETMBR	R7	R7	K15
-      0x8820010D,  //  0030  GETMBR	R8	R0	K13
-      0x7C100800,  //  0031  CALL	R4	4
-      0x8C0C0510,  //  0032  GETMET	R3	R2	K16
-      0x5C140200,  //  0033  MOVE	R5	R1
-      0x7C0C0400,  //  0034  CALL	R3	2
-      0x80040600,  //  0035  RET	1	R3
+      0x8C0C0502,  //  0002  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x8C100703,  //  0004  GETMET	R4	R3	K3
+      0x58180004,  //  0005  LDCONST	R6	K4
+      0x881C0505,  //  0006  GETMBR	R7	R2	K5
+      0x88200106,  //  0007  GETMBR	R8	R0	K6
+      0x7C100800,  //  0008  CALL	R4	4
+      0x8C100703,  //  0009  GETMET	R4	R3	K3
+      0x58180007,  //  000A  LDCONST	R6	K7
+      0x881C0505,  //  000B  GETMBR	R7	R2	K5
+      0x88200108,  //  000C  GETMBR	R8	R0	K8
+      0x7C100800,  //  000D  CALL	R4	4
+      0x8C100703,  //  000E  GETMET	R4	R3	K3
+      0x58180009,  //  000F  LDCONST	R6	K9
+      0x881C050A,  //  0010  GETMBR	R7	R2	K10
+      0x8820010B,  //  0011  GETMBR	R8	R0	K11
+      0x7C100800,  //  0012  CALL	R4	4
+      0x8810010C,  //  0013  GETMBR	R4	R0	K12
+      0x4C140000,  //  0014  LDNIL	R5
+      0x20100805,  //  0015  NE	R4	R4	R5
+      0x74120003,  //  0016  JMPT	R4	#001B
+      0x8810010D,  //  0017  GETMBR	R4	R0	K13
+      0x4C140000,  //  0018  LDNIL	R5
+      0x20100805,  //  0019  NE	R4	R4	R5
+      0x7812000C,  //  001A  JMPF	R4	#0028
+      0x8C10070E,  //  001B  GETMET	R4	R3	K14
+      0x541A0003,  //  001C  LDINT	R6	4
+      0x7C100400,  //  001D  CALL	R4	2
+      0x8C140903,  //  001E  GETMET	R5	R4	K3
+      0x581C0004,  //  001F  LDCONST	R7	K4
+      0x8820050F,  //  0020  GETMBR	R8	R2	K15
+      0x8824010C,  //  0021  GETMBR	R9	R0	K12
+      0x7C140800,  //  0022  CALL	R5	4
+      0x8C140903,  //  0023  GETMET	R5	R4	K3
+      0x581C0007,  //  0024  LDCONST	R7	K7
+      0x8820050F,  //  0025  GETMBR	R8	R2	K15
+      0x8824010D,  //  0026  GETMBR	R9	R0	K13
+      0x7C140800,  //  0027  CALL	R5	4
+      0x8C100710,  //  0028  GETMET	R4	R3	K16
+      0x5C180200,  //  0029  MOVE	R6	R1
+      0x7C100400,  //  002A  CALL	R4	2
+      0x80040800,  //  002B  RET	1	R4
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Control_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Control_Message.h
@@ -12,7 +12,7 @@ extern const bclass be_class_Matter_Control_Message;
 extern const bclass be_class_Matter_Control_Message;
 be_local_closure(class_Matter_Control_Message_parse_MsgCounterSyncRsp,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    8,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -20,36 +20,34 @@ be_local_closure(class_Matter_Control_Message_parse_MsgCounterSyncRsp,   /* name
     0,                          /* has sup protos */
     &be_class_Matter_Control_Message, 
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20_X3EMCSyncRsp_X20_X2A_X20Not_X20implemented_X20_X25s),
-    /* K4   */  be_nested_str_weak(raw),
-    /* K5   */  be_nested_str_weak(app_payload_idx),
-    /* K6   */  be_const_int(2147483647),
-    /* K7   */  be_nested_str_weak(tohex),
-    /* K8   */  be_const_int(2),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X3EMCSyncRsp_X20_X2A_X20Not_X20implemented_X20_X25s),
+    /* K3   */  be_nested_str_weak(raw),
+    /* K4   */  be_nested_str_weak(app_payload_idx),
+    /* K5   */  be_const_int(2147483647),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_const_int(2),
     }),
     be_str_weak(parse_MsgCounterSyncRsp),
     &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
+    ( &(const binstruction[15]) {  /* code */
       0x88080300,  //  0000  GETMBR	R2	R1	K0
       0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x60140018,  //  0003  GETGBL	R5	G24
-      0x58180003,  //  0004  LDCONST	R6	K3
-      0x881C0305,  //  0005  GETMBR	R7	R1	K5
-      0x401C0F06,  //  0006  CONNECT	R7	R7	K6
-      0x88200304,  //  0007  GETMBR	R8	R1	K4
-      0x941C1007,  //  0008  GETIDX	R7	R8	R7
-      0x8C1C0F07,  //  0009  GETMET	R7	R7	K7
-      0x7C1C0200,  //  000A  CALL	R7	1
-      0x7C140400,  //  000B  CALL	R5	2
-      0x58180008,  //  000C  LDCONST	R6	K8
-      0x7C0C0600,  //  000D  CALL	R3	3
-      0x500C0000,  //  000E  LDBOOL	R3	0	0
-      0x80040600,  //  000F  RET	1	R3
+      0x60100018,  //  0002  GETGBL	R4	G24
+      0x58140002,  //  0003  LDCONST	R5	K2
+      0x88180304,  //  0004  GETMBR	R6	R1	K4
+      0x40180D05,  //  0005  CONNECT	R6	R6	K5
+      0x881C0303,  //  0006  GETMBR	R7	R1	K3
+      0x94180E06,  //  0007  GETIDX	R6	R7	R6
+      0x8C180D06,  //  0008  GETMET	R6	R6	K6
+      0x7C180200,  //  0009  CALL	R6	1
+      0x7C100400,  //  000A  CALL	R4	2
+      0x58140007,  //  000B  LDCONST	R5	K7
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x500C0000,  //  000D  LDBOOL	R3	0	0
+      0x80040600,  //  000E  RET	1	R3
     })
   )
 );
@@ -62,7 +60,7 @@ be_local_closure(class_Matter_Control_Message_parse_MsgCounterSyncRsp,   /* name
 extern const bclass be_class_Matter_Control_Message;
 be_local_closure(class_Matter_Control_Message_parse_MsgCounterSyncReq,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    8,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -70,36 +68,34 @@ be_local_closure(class_Matter_Control_Message_parse_MsgCounterSyncReq,   /* name
     0,                          /* has sup protos */
     &be_class_Matter_Control_Message, 
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20_X3EMCSyncReq_X20_X2A_X20Not_X20implemented_X20_X25s),
-    /* K4   */  be_nested_str_weak(raw),
-    /* K5   */  be_nested_str_weak(app_payload_idx),
-    /* K6   */  be_const_int(2147483647),
-    /* K7   */  be_nested_str_weak(tohex),
-    /* K8   */  be_const_int(2),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X3EMCSyncReq_X20_X2A_X20Not_X20implemented_X20_X25s),
+    /* K3   */  be_nested_str_weak(raw),
+    /* K4   */  be_nested_str_weak(app_payload_idx),
+    /* K5   */  be_const_int(2147483647),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_const_int(2),
     }),
     be_str_weak(parse_MsgCounterSyncReq),
     &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
+    ( &(const binstruction[15]) {  /* code */
       0x88080300,  //  0000  GETMBR	R2	R1	K0
       0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x60140018,  //  0003  GETGBL	R5	G24
-      0x58180003,  //  0004  LDCONST	R6	K3
-      0x881C0305,  //  0005  GETMBR	R7	R1	K5
-      0x401C0F06,  //  0006  CONNECT	R7	R7	K6
-      0x88200304,  //  0007  GETMBR	R8	R1	K4
-      0x941C1007,  //  0008  GETIDX	R7	R8	R7
-      0x8C1C0F07,  //  0009  GETMET	R7	R7	K7
-      0x7C1C0200,  //  000A  CALL	R7	1
-      0x7C140400,  //  000B  CALL	R5	2
-      0x58180008,  //  000C  LDCONST	R6	K8
-      0x7C0C0600,  //  000D  CALL	R3	3
-      0x500C0000,  //  000E  LDBOOL	R3	0	0
-      0x80040600,  //  000F  RET	1	R3
+      0x60100018,  //  0002  GETGBL	R4	G24
+      0x58140002,  //  0003  LDCONST	R5	K2
+      0x88180304,  //  0004  GETMBR	R6	R1	K4
+      0x40180D05,  //  0005  CONNECT	R6	R6	K5
+      0x881C0303,  //  0006  GETMBR	R7	R1	K3
+      0x94180E06,  //  0007  GETIDX	R6	R7	R6
+      0x8C180D06,  //  0008  GETMET	R6	R6	K6
+      0x7C180200,  //  0009  CALL	R6	1
+      0x7C100400,  //  000A  CALL	R4	2
+      0x58140007,  //  000B  LDCONST	R5	K7
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x500C0000,  //  000D  LDBOOL	R3	0	0
+      0x80040600,  //  000E  RET	1	R3
     })
   )
 );
@@ -145,7 +141,7 @@ be_local_closure(class_Matter_Control_Message_init,   /* name */
 extern const bclass be_class_Matter_Control_Message;
 be_local_closure(class_Matter_Control_Message_process_incoming_control_message,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -153,61 +149,58 @@ be_local_closure(class_Matter_Control_Message_process_incoming_control_message, 
     0,                          /* has sup protos */
     &be_class_Matter_Control_Message, 
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20received_X20control_X20message_X20),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(inspect),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(opcode),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str_weak(parse_MsgCounterSyncReq),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(parse_MsgCounterSyncRsp),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28control_X20message_X29_X20_X2502X),
-    /* K12  */  be_const_int(2),
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(log),
+    /* K1   */  be_nested_str_weak(MTR_X3A_X20received_X20control_X20message_X20),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(inspect),
+    /* K4   */  be_const_int(3),
+    /* K5   */  be_nested_str_weak(opcode),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(parse_MsgCounterSyncReq),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(parse_MsgCounterSyncRsp),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X3E_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X3F_X20Unknown_X20OpCode_X20_X28control_X20message_X29_X20_X2502X),
+    /* K11  */  be_const_int(2),
     }),
     be_str_weak(process_incoming_control_message),
     &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
+    ( &(const binstruction[35]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0xB8120600,  //  0002  GETNGBL	R4	K3
-      0x8C100904,  //  0003  GETMET	R4	R4	K4
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x7C100400,  //  0005  CALL	R4	2
-      0x00120404,  //  0006  ADD	R4	K2	R4
-      0x58140005,  //  0007  LDCONST	R5	K5
-      0x7C080600,  //  0008  CALL	R2	3
-      0x88080306,  //  0009  GETMBR	R2	R1	K6
-      0x1C080507,  //  000A  EQ	R2	R2	K7
-      0x780A0004,  //  000B  JMPF	R2	#0011
-      0x8C080108,  //  000C  GETMET	R2	R0	K8
-      0x5C100200,  //  000D  MOVE	R4	R1
-      0x7C080400,  //  000E  CALL	R2	2
-      0x80040400,  //  000F  RET	1	R2
-      0x70020011,  //  0010  JMP		#0023
-      0x88080306,  //  0011  GETMBR	R2	R1	K6
-      0x1C080509,  //  0012  EQ	R2	R2	K9
-      0x780A0004,  //  0013  JMPF	R2	#0019
-      0x8C08010A,  //  0014  GETMET	R2	R0	K10
-      0x5C100200,  //  0015  MOVE	R4	R1
-      0x7C080400,  //  0016  CALL	R2	2
-      0x80040400,  //  0017  RET	1	R2
-      0x70020009,  //  0018  JMP		#0023
-      0xB80A0000,  //  0019  GETNGBL	R2	K0
-      0x8C080501,  //  001A  GETMET	R2	R2	K1
-      0x60100018,  //  001B  GETGBL	R4	G24
-      0x5814000B,  //  001C  LDCONST	R5	K11
-      0x88180306,  //  001D  GETMBR	R6	R1	K6
-      0x7C100400,  //  001E  CALL	R4	2
-      0x5814000C,  //  001F  LDCONST	R5	K12
-      0x7C080600,  //  0020  CALL	R2	3
+      0xB80E0400,  //  0001  GETNGBL	R3	K2
+      0x8C0C0703,  //  0002  GETMET	R3	R3	K3
+      0x5C140200,  //  0003  MOVE	R5	R1
+      0x7C0C0400,  //  0004  CALL	R3	2
+      0x000E0203,  //  0005  ADD	R3	K1	R3
+      0x58100004,  //  0006  LDCONST	R4	K4
+      0x7C080400,  //  0007  CALL	R2	2
+      0x88080305,  //  0008  GETMBR	R2	R1	K5
+      0x1C080506,  //  0009  EQ	R2	R2	K6
+      0x780A0004,  //  000A  JMPF	R2	#0010
+      0x8C080107,  //  000B  GETMET	R2	R0	K7
+      0x5C100200,  //  000C  MOVE	R4	R1
+      0x7C080400,  //  000D  CALL	R2	2
+      0x80040400,  //  000E  RET	1	R2
+      0x70020010,  //  000F  JMP		#0021
+      0x88080305,  //  0010  GETMBR	R2	R1	K5
+      0x1C080508,  //  0011  EQ	R2	R2	K8
+      0x780A0004,  //  0012  JMPF	R2	#0018
+      0x8C080109,  //  0013  GETMET	R2	R0	K9
+      0x5C100200,  //  0014  MOVE	R4	R1
+      0x7C080400,  //  0015  CALL	R2	2
+      0x80040400,  //  0016  RET	1	R2
+      0x70020008,  //  0017  JMP		#0021
+      0xB80A0000,  //  0018  GETNGBL	R2	K0
+      0x600C0018,  //  0019  GETGBL	R3	G24
+      0x5810000A,  //  001A  LDCONST	R4	K10
+      0x88140305,  //  001B  GETMBR	R5	R1	K5
+      0x7C0C0400,  //  001C  CALL	R3	2
+      0x5810000B,  //  001D  LDCONST	R4	K11
+      0x7C080400,  //  001E  CALL	R2	2
+      0x50080000,  //  001F  LDBOOL	R2	0	0
+      0x80040400,  //  0020  RET	1	R2
       0x50080000,  //  0021  LDBOOL	R2	0	0
       0x80040400,  //  0022  RET	1	R2
-      0x50080000,  //  0023  LDBOOL	R2	0	0
-      0x80040400,  //  0024  RET	1	R2
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Fabric.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Fabric.h
@@ -40,7 +40,7 @@ be_local_closure(class_Matter_Fabric_get_icac,   /* name */
 extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_before_remove,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -48,35 +48,33 @@ be_local_closure(class_Matter_Fabric_before_remove,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Fabric, 
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2DFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20_X28removed_X29),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(copy),
-    /* K5   */  be_nested_str_weak(reverse),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_const_int(3),
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(log),
+    /* K1   */  be_nested_str_weak(MTR_X3A_X20_X2DFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20_X28removed_X29),
+    /* K2   */  be_nested_str_weak(get_fabric_id),
+    /* K3   */  be_nested_str_weak(copy),
+    /* K4   */  be_nested_str_weak(reverse),
+    /* K5   */  be_nested_str_weak(tohex),
+    /* K6   */  be_const_int(3),
     }),
     be_str_weak(before_remove),
     &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
+    ( &(const binstruction[15]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x600C0018,  //  0002  GETGBL	R3	G24
-      0x58100002,  //  0003  LDCONST	R4	K2
-      0x8C140103,  //  0004  GETMET	R5	R0	K3
-      0x7C140200,  //  0005  CALL	R5	1
-      0x8C140B04,  //  0006  GETMET	R5	R5	K4
-      0x7C140200,  //  0007  CALL	R5	1
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x7C140200,  //  0009  CALL	R5	1
-      0x8C140B06,  //  000A  GETMET	R5	R5	K6
-      0x7C140200,  //  000B  CALL	R5	1
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x58100007,  //  000D  LDCONST	R4	K7
-      0x7C040600,  //  000E  CALL	R1	3
-      0x80000000,  //  000F  RET	0
+      0x60080018,  //  0001  GETGBL	R2	G24
+      0x580C0001,  //  0002  LDCONST	R3	K1
+      0x8C100102,  //  0003  GETMET	R4	R0	K2
+      0x7C100200,  //  0004  CALL	R4	1
+      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C100905,  //  0009  GETMET	R4	R4	K5
+      0x7C100200,  //  000A  CALL	R4	1
+      0x7C080400,  //  000B  CALL	R2	2
+      0x580C0006,  //  000C  LDCONST	R3	K6
+      0x7C040400,  //  000D  CALL	R1	2
+      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -914,7 +912,7 @@ be_local_closure(class_Matter_Fabric_fabric_completed,   /* name */
 extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_counter_group_data_snd_next,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -922,51 +920,49 @@ be_local_closure(class_Matter_Fabric_counter_group_data_snd_next,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Fabric, 
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
+    ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(_counter_group_data_snd_impl),
     /* K1   */  be_nested_str_weak(next),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_data_snd_X3D_X25i),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(Counter),
-    /* K8   */  be_nested_str_weak(is_greater),
-    /* K9   */  be_nested_str_weak(counter_group_data_snd),
-    /* K10  */  be_nested_str_weak(_GROUP_SND_INCR),
-    /* K11  */  be_nested_str_weak(does_persist),
-    /* K12  */  be_nested_str_weak(save),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_data_snd_X3D_X25i),
+    /* K4   */  be_const_int(3),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(Counter),
+    /* K7   */  be_nested_str_weak(is_greater),
+    /* K8   */  be_nested_str_weak(counter_group_data_snd),
+    /* K9   */  be_nested_str_weak(_GROUP_SND_INCR),
+    /* K10  */  be_nested_str_weak(does_persist),
+    /* K11  */  be_nested_str_weak(save),
     }),
     be_str_weak(counter_group_data_snd_next),
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
+    ( &(const binstruction[26]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x7C040200,  //  0002  CALL	R1	1
       0xB80A0400,  //  0003  GETNGBL	R2	K2
-      0x8C080503,  //  0004  GETMET	R2	R2	K3
-      0x60100018,  //  0005  GETGBL	R4	G24
-      0x58140004,  //  0006  LDCONST	R5	K4
-      0x5C180200,  //  0007  MOVE	R6	R1
-      0x7C100400,  //  0008  CALL	R4	2
-      0x58140005,  //  0009  LDCONST	R5	K5
-      0x7C080600,  //  000A  CALL	R2	3
-      0xB80A0C00,  //  000B  GETNGBL	R2	K6
-      0x88080507,  //  000C  GETMBR	R2	R2	K7
-      0x8C080508,  //  000D  GETMET	R2	R2	K8
-      0x5C100200,  //  000E  MOVE	R4	R1
-      0x88140109,  //  000F  GETMBR	R5	R0	K9
-      0x7C080600,  //  0010  CALL	R2	3
-      0x780A0007,  //  0011  JMPF	R2	#001A
-      0x8808010A,  //  0012  GETMBR	R2	R0	K10
-      0x00080202,  //  0013  ADD	R2	R1	R2
-      0x90021202,  //  0014  SETMBR	R0	K9	R2
-      0x8C08010B,  //  0015  GETMET	R2	R0	K11
-      0x7C080200,  //  0016  CALL	R2	1
-      0x780A0001,  //  0017  JMPF	R2	#001A
-      0x8C08010C,  //  0018  GETMET	R2	R0	K12
-      0x7C080200,  //  0019  CALL	R2	1
-      0x80040200,  //  001A  RET	1	R1
+      0x600C0018,  //  0004  GETGBL	R3	G24
+      0x58100003,  //  0005  LDCONST	R4	K3
+      0x5C140200,  //  0006  MOVE	R5	R1
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x58100004,  //  0008  LDCONST	R4	K4
+      0x7C080400,  //  0009  CALL	R2	2
+      0xB80A0A00,  //  000A  GETNGBL	R2	K5
+      0x88080506,  //  000B  GETMBR	R2	R2	K6
+      0x8C080507,  //  000C  GETMET	R2	R2	K7
+      0x5C100200,  //  000D  MOVE	R4	R1
+      0x88140108,  //  000E  GETMBR	R5	R0	K8
+      0x7C080600,  //  000F  CALL	R2	3
+      0x780A0007,  //  0010  JMPF	R2	#0019
+      0x88080109,  //  0011  GETMBR	R2	R0	K9
+      0x00080202,  //  0012  ADD	R2	R1	R2
+      0x90021002,  //  0013  SETMBR	R0	K8	R2
+      0x8C08010A,  //  0014  GETMET	R2	R0	K10
+      0x7C080200,  //  0015  CALL	R2	1
+      0x780A0001,  //  0016  JMPF	R2	#0019
+      0x8C08010B,  //  0017  GETMET	R2	R0	K11
+      0x7C080200,  //  0018  CALL	R2	1
+      0x80040200,  //  0019  RET	1	R1
     })
   )
 );
@@ -1067,7 +1063,7 @@ be_local_closure(class_Matter_Fabric_get_newest_session,   /* name */
 extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_log_new_fabric,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    7,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1075,38 +1071,36 @@ be_local_closure(class_Matter_Fabric_log_new_fabric,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Fabric, 
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2BFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20vendorid_X3D_X25s),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(copy),
-    /* K5   */  be_nested_str_weak(reverse),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_nested_str_weak(get_admin_vendor_name),
-    /* K8   */  be_const_int(3),
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(log),
+    /* K1   */  be_nested_str_weak(MTR_X3A_X20_X2BFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20vendorid_X3D_X25s),
+    /* K2   */  be_nested_str_weak(get_fabric_id),
+    /* K3   */  be_nested_str_weak(copy),
+    /* K4   */  be_nested_str_weak(reverse),
+    /* K5   */  be_nested_str_weak(tohex),
+    /* K6   */  be_nested_str_weak(get_admin_vendor_name),
+    /* K7   */  be_const_int(3),
     }),
     be_str_weak(log_new_fabric),
     &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
+    ( &(const binstruction[17]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x600C0018,  //  0002  GETGBL	R3	G24
-      0x58100002,  //  0003  LDCONST	R4	K2
-      0x8C140103,  //  0004  GETMET	R5	R0	K3
-      0x7C140200,  //  0005  CALL	R5	1
-      0x8C140B04,  //  0006  GETMET	R5	R5	K4
-      0x7C140200,  //  0007  CALL	R5	1
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x7C140200,  //  0009  CALL	R5	1
-      0x8C140B06,  //  000A  GETMET	R5	R5	K6
-      0x7C140200,  //  000B  CALL	R5	1
-      0x8C180107,  //  000C  GETMET	R6	R0	K7
-      0x7C180200,  //  000D  CALL	R6	1
-      0x7C0C0600,  //  000E  CALL	R3	3
-      0x58100008,  //  000F  LDCONST	R4	K8
-      0x7C040600,  //  0010  CALL	R1	3
-      0x80000000,  //  0011  RET	0
+      0x60080018,  //  0001  GETGBL	R2	G24
+      0x580C0001,  //  0002  LDCONST	R3	K1
+      0x8C100102,  //  0003  GETMET	R4	R0	K2
+      0x7C100200,  //  0004  CALL	R4	1
+      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C100905,  //  0009  GETMET	R4	R4	K5
+      0x7C100200,  //  000A  CALL	R4	1
+      0x8C140106,  //  000B  GETMET	R5	R0	K6
+      0x7C140200,  //  000C  CALL	R5	1
+      0x7C080600,  //  000D  CALL	R2	3
+      0x580C0007,  //  000E  LDCONST	R3	K7
+      0x7C040400,  //  000F  CALL	R1	2
+      0x80000000,  //  0010  RET	0
     })
   )
 );
@@ -1365,7 +1359,7 @@ be_local_closure(class_Matter_Fabric_writejson,   /* name */
 extern const bclass be_class_Matter_Fabric;
 be_local_closure(class_Matter_Fabric_counter_group_ctrl_snd_next,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1373,51 +1367,49 @@ be_local_closure(class_Matter_Fabric_counter_group_ctrl_snd_next,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Fabric, 
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
+    ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(_counter_group_ctrl_snd_impl),
     /* K1   */  be_nested_str_weak(next),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_ctrl_snd_X3D_X25i),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(Counter),
-    /* K8   */  be_nested_str_weak(is_greater),
-    /* K9   */  be_nested_str_weak(counter_group_ctrl_snd),
-    /* K10  */  be_nested_str_weak(_GROUP_SND_INCR),
-    /* K11  */  be_nested_str_weak(does_persist),
-    /* K12  */  be_nested_str_weak(save),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_group_ctrl_snd_X3D_X25i),
+    /* K4   */  be_const_int(3),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(Counter),
+    /* K7   */  be_nested_str_weak(is_greater),
+    /* K8   */  be_nested_str_weak(counter_group_ctrl_snd),
+    /* K9   */  be_nested_str_weak(_GROUP_SND_INCR),
+    /* K10  */  be_nested_str_weak(does_persist),
+    /* K11  */  be_nested_str_weak(save),
     }),
     be_str_weak(counter_group_ctrl_snd_next),
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
+    ( &(const binstruction[26]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x7C040200,  //  0002  CALL	R1	1
       0xB80A0400,  //  0003  GETNGBL	R2	K2
-      0x8C080503,  //  0004  GETMET	R2	R2	K3
-      0x60100018,  //  0005  GETGBL	R4	G24
-      0x58140004,  //  0006  LDCONST	R5	K4
-      0x5C180200,  //  0007  MOVE	R6	R1
-      0x7C100400,  //  0008  CALL	R4	2
-      0x58140005,  //  0009  LDCONST	R5	K5
-      0x7C080600,  //  000A  CALL	R2	3
-      0xB80A0C00,  //  000B  GETNGBL	R2	K6
-      0x88080507,  //  000C  GETMBR	R2	R2	K7
-      0x8C080508,  //  000D  GETMET	R2	R2	K8
-      0x5C100200,  //  000E  MOVE	R4	R1
-      0x88140109,  //  000F  GETMBR	R5	R0	K9
-      0x7C080600,  //  0010  CALL	R2	3
-      0x780A0007,  //  0011  JMPF	R2	#001A
-      0x8808010A,  //  0012  GETMBR	R2	R0	K10
-      0x00080202,  //  0013  ADD	R2	R1	R2
-      0x90021202,  //  0014  SETMBR	R0	K9	R2
-      0x8C08010B,  //  0015  GETMET	R2	R0	K11
-      0x7C080200,  //  0016  CALL	R2	1
-      0x780A0001,  //  0017  JMPF	R2	#001A
-      0x8C08010C,  //  0018  GETMET	R2	R0	K12
-      0x7C080200,  //  0019  CALL	R2	1
-      0x80040200,  //  001A  RET	1	R1
+      0x600C0018,  //  0004  GETGBL	R3	G24
+      0x58100003,  //  0005  LDCONST	R4	K3
+      0x5C140200,  //  0006  MOVE	R5	R1
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x58100004,  //  0008  LDCONST	R4	K4
+      0x7C080400,  //  0009  CALL	R2	2
+      0xB80A0A00,  //  000A  GETNGBL	R2	K5
+      0x88080506,  //  000B  GETMBR	R2	R2	K6
+      0x8C080507,  //  000C  GETMET	R2	R2	K7
+      0x5C100200,  //  000D  MOVE	R4	R1
+      0x88140108,  //  000E  GETMBR	R5	R0	K8
+      0x7C080600,  //  000F  CALL	R2	3
+      0x780A0007,  //  0010  JMPF	R2	#0019
+      0x88080109,  //  0011  GETMBR	R2	R0	K9
+      0x00080202,  //  0012  ADD	R2	R1	R2
+      0x90021002,  //  0013  SETMBR	R0	K8	R2
+      0x8C08010A,  //  0014  GETMET	R2	R0	K10
+      0x7C080200,  //  0015  CALL	R2	1
+      0x780A0001,  //  0016  JMPF	R2	#0019
+      0x8C08010B,  //  0017  GETMET	R2	R0	K11
+      0x7C080200,  //  0018  CALL	R2	1
+      0x80040200,  //  0019  RET	1	R1
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_remote.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_HTTP_remote.h
@@ -153,7 +153,7 @@ be_local_closure(class_Matter_HTTP_remote_get_info,   /* name */
 extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_parse_status_http,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -161,7 +161,7 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_http,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_HTTP_remote, 
     1,                          /* has constants */
-    ( &(const bvalue[28]) {     /* constants */
+    ( &(const bvalue[27]) {     /* constants */
     /* K0   */  be_const_int(0),
     /* K1   */  be_nested_str_weak(find),
     /* K2   */  be_nested_str_weak(DeviceName),
@@ -169,34 +169,33 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_http,   /* name */
     /* K4   */  be_nested_str_weak(info),
     /* K5   */  be_nested_str_weak(name),
     /* K6   */  be_nested_str_weak(remove),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20name_X3D_X27_X25s_X27),
-    /* K10  */  be_nested_str_weak(addr),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(change_schedule),
-    /* K13  */  be_nested_str_weak(UPDATE_CMD0),
-    /* K14  */  be_nested_str_weak(UPDATE_TIME2),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_nested_str_weak(Version),
-    /* K17  */  be_nested_str_weak(Hardware),
-    /* K18  */  be_nested_str_weak(version),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20version_X3D_X27_X25s_X27),
-    /* K20  */  be_nested_str_weak(hardware),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20hardware_X3D_X27_X25s_X27),
-    /* K22  */  be_nested_str_weak(UPDATE_CMD2),
-    /* K23  */  be_nested_str_weak(Mac),
-    /* K24  */  be_nested_str_weak(mac),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20mac_X3D_X27_X25s_X27),
-    /* K26  */  be_nested_str_weak(UPDATE_CMD5),
-    /* K27  */  be_nested_str_weak(info_changed),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20name_X3D_X27_X25s_X27),
+    /* K9   */  be_nested_str_weak(addr),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(change_schedule),
+    /* K12  */  be_nested_str_weak(UPDATE_CMD0),
+    /* K13  */  be_nested_str_weak(UPDATE_TIME2),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(Version),
+    /* K16  */  be_nested_str_weak(Hardware),
+    /* K17  */  be_nested_str_weak(version),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20version_X3D_X27_X25s_X27),
+    /* K19  */  be_nested_str_weak(hardware),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20hardware_X3D_X27_X25s_X27),
+    /* K21  */  be_nested_str_weak(UPDATE_CMD2),
+    /* K22  */  be_nested_str_weak(Mac),
+    /* K23  */  be_nested_str_weak(mac),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20update_X20_X27_X25s_X27_X20mac_X3D_X27_X25s_X27),
+    /* K25  */  be_nested_str_weak(UPDATE_CMD5),
+    /* K26  */  be_nested_str_weak(info_changed),
     }),
     be_str_weak(parse_status_http),
     &be_const_str_solidified,
-    ( &(const binstruction[145]) {  /* code */
+    ( &(const binstruction[141]) {  /* code */
       0x500C0000,  //  0000  LDBOOL	R3	0	0
       0x1C100500,  //  0001  EQ	R4	R2	K0
-      0x78120024,  //  0002  JMPF	R4	#0028
+      0x78120023,  //  0002  JMPF	R4	#0027
       0x8C100301,  //  0003  GETMET	R4	R1	K1
       0x58180002,  //  0004  LDCONST	R6	K2
       0x7C100400,  //  0005  CALL	R4	2
@@ -208,7 +207,7 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_http,   /* name */
       0x581C0005,  //  000B  LDCONST	R7	K5
       0x7C140400,  //  000C  CALL	R5	2
       0x20140A04,  //  000D  NE	R5	R5	R4
-      0x78160013,  //  000E  JMPF	R5	#0023
+      0x78160012,  //  000E  JMPF	R5	#0022
       0x4C140000,  //  000F  LDNIL	R5
       0x20140805,  //  0010  NE	R5	R4	R5
       0x78160002,  //  0011  JMPF	R5	#0015
@@ -220,125 +219,121 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_http,   /* name */
       0x581C0005,  //  0017  LDCONST	R7	K5
       0x7C140400,  //  0018  CALL	R5	2
       0xB8160E00,  //  0019  GETNGBL	R5	K7
-      0x8C140B08,  //  001A  GETMET	R5	R5	K8
-      0x601C0018,  //  001B  GETGBL	R7	G24
-      0x58200009,  //  001C  LDCONST	R8	K9
-      0x8824010A,  //  001D  GETMBR	R9	R0	K10
-      0x5C280800,  //  001E  MOVE	R10	R4
-      0x7C1C0600,  //  001F  CALL	R7	3
-      0x5820000B,  //  0020  LDCONST	R8	K11
-      0x7C140600,  //  0021  CALL	R5	3
-      0x500C0200,  //  0022  LDBOOL	R3	1	0
-      0x8C14010C,  //  0023  GETMET	R5	R0	K12
-      0x881C010D,  //  0024  GETMBR	R7	R0	K13
-      0x8820010E,  //  0025  GETMBR	R8	R0	K14
-      0x7C140600,  //  0026  CALL	R5	3
-      0x70020064,  //  0027  JMP		#008D
-      0x1C10050F,  //  0028  EQ	R4	R2	K15
-      0x7812003E,  //  0029  JMPF	R4	#0069
-      0x8C100301,  //  002A  GETMET	R4	R1	K1
-      0x58180010,  //  002B  LDCONST	R6	K16
-      0x7C100400,  //  002C  CALL	R4	2
-      0x8C140301,  //  002D  GETMET	R5	R1	K1
-      0x581C0011,  //  002E  LDCONST	R7	K17
-      0x7C140400,  //  002F  CALL	R5	2
-      0x88180104,  //  0030  GETMBR	R6	R0	K4
-      0x8C180D01,  //  0031  GETMET	R6	R6	K1
-      0x58200012,  //  0032  LDCONST	R8	K18
-      0x7C180400,  //  0033  CALL	R6	2
-      0x20180C04,  //  0034  NE	R6	R6	R4
-      0x781A0013,  //  0035  JMPF	R6	#004A
-      0x4C180000,  //  0036  LDNIL	R6
-      0x20180806,  //  0037  NE	R6	R4	R6
-      0x781A0002,  //  0038  JMPF	R6	#003C
-      0x88180104,  //  0039  GETMBR	R6	R0	K4
-      0x981A2404,  //  003A  SETIDX	R6	K18	R4
-      0x70020003,  //  003B  JMP		#0040
-      0x88180104,  //  003C  GETMBR	R6	R0	K4
-      0x8C180D06,  //  003D  GETMET	R6	R6	K6
-      0x58200012,  //  003E  LDCONST	R8	K18
-      0x7C180400,  //  003F  CALL	R6	2
-      0xB81A0E00,  //  0040  GETNGBL	R6	K7
-      0x8C180D08,  //  0041  GETMET	R6	R6	K8
-      0x60200018,  //  0042  GETGBL	R8	G24
-      0x58240013,  //  0043  LDCONST	R9	K19
-      0x8828010A,  //  0044  GETMBR	R10	R0	K10
-      0x5C2C0800,  //  0045  MOVE	R11	R4
-      0x7C200600,  //  0046  CALL	R8	3
-      0x5824000B,  //  0047  LDCONST	R9	K11
-      0x7C180600,  //  0048  CALL	R6	3
-      0x500C0200,  //  0049  LDBOOL	R3	1	0
-      0x88180104,  //  004A  GETMBR	R6	R0	K4
-      0x8C180D01,  //  004B  GETMET	R6	R6	K1
-      0x58200014,  //  004C  LDCONST	R8	K20
-      0x7C180400,  //  004D  CALL	R6	2
-      0x20180C05,  //  004E  NE	R6	R6	R5
-      0x781A0013,  //  004F  JMPF	R6	#0064
-      0x4C180000,  //  0050  LDNIL	R6
-      0x20180A06,  //  0051  NE	R6	R5	R6
-      0x781A0002,  //  0052  JMPF	R6	#0056
-      0x88180104,  //  0053  GETMBR	R6	R0	K4
-      0x981A2805,  //  0054  SETIDX	R6	K20	R5
-      0x70020003,  //  0055  JMP		#005A
-      0x88180104,  //  0056  GETMBR	R6	R0	K4
-      0x8C180D06,  //  0057  GETMET	R6	R6	K6
-      0x58200014,  //  0058  LDCONST	R8	K20
-      0x7C180400,  //  0059  CALL	R6	2
-      0xB81A0E00,  //  005A  GETNGBL	R6	K7
-      0x8C180D08,  //  005B  GETMET	R6	R6	K8
-      0x60200018,  //  005C  GETGBL	R8	G24
-      0x58240015,  //  005D  LDCONST	R9	K21
-      0x8828010A,  //  005E  GETMBR	R10	R0	K10
-      0x5C2C0A00,  //  005F  MOVE	R11	R5
-      0x7C200600,  //  0060  CALL	R8	3
-      0x5824000B,  //  0061  LDCONST	R9	K11
-      0x7C180600,  //  0062  CALL	R6	3
-      0x500C0200,  //  0063  LDBOOL	R3	1	0
-      0x8C18010C,  //  0064  GETMET	R6	R0	K12
-      0x88200116,  //  0065  GETMBR	R8	R0	K22
-      0x8824010E,  //  0066  GETMBR	R9	R0	K14
-      0x7C180600,  //  0067  CALL	R6	3
-      0x70020023,  //  0068  JMP		#008D
-      0x54120004,  //  0069  LDINT	R4	5
-      0x1C100404,  //  006A  EQ	R4	R2	R4
-      0x78120020,  //  006B  JMPF	R4	#008D
-      0x8C100301,  //  006C  GETMET	R4	R1	K1
-      0x58180017,  //  006D  LDCONST	R6	K23
-      0x7C100400,  //  006E  CALL	R4	2
-      0x88140104,  //  006F  GETMBR	R5	R0	K4
-      0x8C140B01,  //  0070  GETMET	R5	R5	K1
-      0x581C0018,  //  0071  LDCONST	R7	K24
-      0x7C140400,  //  0072  CALL	R5	2
-      0x20140A04,  //  0073  NE	R5	R5	R4
-      0x78160013,  //  0074  JMPF	R5	#0089
-      0x4C140000,  //  0075  LDNIL	R5
-      0x20140805,  //  0076  NE	R5	R4	R5
-      0x78160002,  //  0077  JMPF	R5	#007B
+      0x60180018,  //  001A  GETGBL	R6	G24
+      0x581C0008,  //  001B  LDCONST	R7	K8
+      0x88200109,  //  001C  GETMBR	R8	R0	K9
+      0x5C240800,  //  001D  MOVE	R9	R4
+      0x7C180600,  //  001E  CALL	R6	3
+      0x581C000A,  //  001F  LDCONST	R7	K10
+      0x7C140400,  //  0020  CALL	R5	2
+      0x500C0200,  //  0021  LDBOOL	R3	1	0
+      0x8C14010B,  //  0022  GETMET	R5	R0	K11
+      0x881C010C,  //  0023  GETMBR	R7	R0	K12
+      0x8820010D,  //  0024  GETMBR	R8	R0	K13
+      0x7C140600,  //  0025  CALL	R5	3
+      0x70020061,  //  0026  JMP		#0089
+      0x1C10050E,  //  0027  EQ	R4	R2	K14
+      0x7812003C,  //  0028  JMPF	R4	#0066
+      0x8C100301,  //  0029  GETMET	R4	R1	K1
+      0x5818000F,  //  002A  LDCONST	R6	K15
+      0x7C100400,  //  002B  CALL	R4	2
+      0x8C140301,  //  002C  GETMET	R5	R1	K1
+      0x581C0010,  //  002D  LDCONST	R7	K16
+      0x7C140400,  //  002E  CALL	R5	2
+      0x88180104,  //  002F  GETMBR	R6	R0	K4
+      0x8C180D01,  //  0030  GETMET	R6	R6	K1
+      0x58200011,  //  0031  LDCONST	R8	K17
+      0x7C180400,  //  0032  CALL	R6	2
+      0x20180C04,  //  0033  NE	R6	R6	R4
+      0x781A0012,  //  0034  JMPF	R6	#0048
+      0x4C180000,  //  0035  LDNIL	R6
+      0x20180806,  //  0036  NE	R6	R4	R6
+      0x781A0002,  //  0037  JMPF	R6	#003B
+      0x88180104,  //  0038  GETMBR	R6	R0	K4
+      0x981A2204,  //  0039  SETIDX	R6	K17	R4
+      0x70020003,  //  003A  JMP		#003F
+      0x88180104,  //  003B  GETMBR	R6	R0	K4
+      0x8C180D06,  //  003C  GETMET	R6	R6	K6
+      0x58200011,  //  003D  LDCONST	R8	K17
+      0x7C180400,  //  003E  CALL	R6	2
+      0xB81A0E00,  //  003F  GETNGBL	R6	K7
+      0x601C0018,  //  0040  GETGBL	R7	G24
+      0x58200012,  //  0041  LDCONST	R8	K18
+      0x88240109,  //  0042  GETMBR	R9	R0	K9
+      0x5C280800,  //  0043  MOVE	R10	R4
+      0x7C1C0600,  //  0044  CALL	R7	3
+      0x5820000A,  //  0045  LDCONST	R8	K10
+      0x7C180400,  //  0046  CALL	R6	2
+      0x500C0200,  //  0047  LDBOOL	R3	1	0
+      0x88180104,  //  0048  GETMBR	R6	R0	K4
+      0x8C180D01,  //  0049  GETMET	R6	R6	K1
+      0x58200013,  //  004A  LDCONST	R8	K19
+      0x7C180400,  //  004B  CALL	R6	2
+      0x20180C05,  //  004C  NE	R6	R6	R5
+      0x781A0012,  //  004D  JMPF	R6	#0061
+      0x4C180000,  //  004E  LDNIL	R6
+      0x20180A06,  //  004F  NE	R6	R5	R6
+      0x781A0002,  //  0050  JMPF	R6	#0054
+      0x88180104,  //  0051  GETMBR	R6	R0	K4
+      0x981A2605,  //  0052  SETIDX	R6	K19	R5
+      0x70020003,  //  0053  JMP		#0058
+      0x88180104,  //  0054  GETMBR	R6	R0	K4
+      0x8C180D06,  //  0055  GETMET	R6	R6	K6
+      0x58200013,  //  0056  LDCONST	R8	K19
+      0x7C180400,  //  0057  CALL	R6	2
+      0xB81A0E00,  //  0058  GETNGBL	R6	K7
+      0x601C0018,  //  0059  GETGBL	R7	G24
+      0x58200014,  //  005A  LDCONST	R8	K20
+      0x88240109,  //  005B  GETMBR	R9	R0	K9
+      0x5C280A00,  //  005C  MOVE	R10	R5
+      0x7C1C0600,  //  005D  CALL	R7	3
+      0x5820000A,  //  005E  LDCONST	R8	K10
+      0x7C180400,  //  005F  CALL	R6	2
+      0x500C0200,  //  0060  LDBOOL	R3	1	0
+      0x8C18010B,  //  0061  GETMET	R6	R0	K11
+      0x88200115,  //  0062  GETMBR	R8	R0	K21
+      0x8824010D,  //  0063  GETMBR	R9	R0	K13
+      0x7C180600,  //  0064  CALL	R6	3
+      0x70020022,  //  0065  JMP		#0089
+      0x54120004,  //  0066  LDINT	R4	5
+      0x1C100404,  //  0067  EQ	R4	R2	R4
+      0x7812001F,  //  0068  JMPF	R4	#0089
+      0x8C100301,  //  0069  GETMET	R4	R1	K1
+      0x58180016,  //  006A  LDCONST	R6	K22
+      0x7C100400,  //  006B  CALL	R4	2
+      0x88140104,  //  006C  GETMBR	R5	R0	K4
+      0x8C140B01,  //  006D  GETMET	R5	R5	K1
+      0x581C0017,  //  006E  LDCONST	R7	K23
+      0x7C140400,  //  006F  CALL	R5	2
+      0x20140A04,  //  0070  NE	R5	R5	R4
+      0x78160012,  //  0071  JMPF	R5	#0085
+      0x4C140000,  //  0072  LDNIL	R5
+      0x20140805,  //  0073  NE	R5	R4	R5
+      0x78160002,  //  0074  JMPF	R5	#0078
+      0x88140104,  //  0075  GETMBR	R5	R0	K4
+      0x98162E04,  //  0076  SETIDX	R5	K23	R4
+      0x70020003,  //  0077  JMP		#007C
       0x88140104,  //  0078  GETMBR	R5	R0	K4
-      0x98163004,  //  0079  SETIDX	R5	K24	R4
-      0x70020003,  //  007A  JMP		#007F
-      0x88140104,  //  007B  GETMBR	R5	R0	K4
-      0x8C140B06,  //  007C  GETMET	R5	R5	K6
-      0x581C0018,  //  007D  LDCONST	R7	K24
-      0x7C140400,  //  007E  CALL	R5	2
-      0xB8160E00,  //  007F  GETNGBL	R5	K7
-      0x8C140B08,  //  0080  GETMET	R5	R5	K8
-      0x601C0018,  //  0081  GETGBL	R7	G24
-      0x58200019,  //  0082  LDCONST	R8	K25
-      0x8824010A,  //  0083  GETMBR	R9	R0	K10
-      0x5C280800,  //  0084  MOVE	R10	R4
-      0x7C1C0600,  //  0085  CALL	R7	3
-      0x5820000B,  //  0086  LDCONST	R8	K11
-      0x7C140600,  //  0087  CALL	R5	3
-      0x500C0200,  //  0088  LDBOOL	R3	1	0
-      0x8C14010C,  //  0089  GETMET	R5	R0	K12
-      0x881C011A,  //  008A  GETMBR	R7	R0	K26
-      0x8820010E,  //  008B  GETMBR	R8	R0	K14
-      0x7C140600,  //  008C  CALL	R5	3
-      0x780E0001,  //  008D  JMPF	R3	#0090
-      0x8C10011B,  //  008E  GETMET	R4	R0	K27
-      0x7C100200,  //  008F  CALL	R4	1
-      0x80000000,  //  0090  RET	0
+      0x8C140B06,  //  0079  GETMET	R5	R5	K6
+      0x581C0017,  //  007A  LDCONST	R7	K23
+      0x7C140400,  //  007B  CALL	R5	2
+      0xB8160E00,  //  007C  GETNGBL	R5	K7
+      0x60180018,  //  007D  GETGBL	R6	G24
+      0x581C0018,  //  007E  LDCONST	R7	K24
+      0x88200109,  //  007F  GETMBR	R8	R0	K9
+      0x5C240800,  //  0080  MOVE	R9	R4
+      0x7C180600,  //  0081  CALL	R6	3
+      0x581C000A,  //  0082  LDCONST	R7	K10
+      0x7C140400,  //  0083  CALL	R5	2
+      0x500C0200,  //  0084  LDBOOL	R3	1	0
+      0x8C14010B,  //  0085  GETMET	R5	R0	K11
+      0x881C0119,  //  0086  GETMBR	R7	R0	K25
+      0x8820010D,  //  0087  GETMBR	R8	R0	K13
+      0x7C140600,  //  0088  CALL	R5	3
+      0x780E0001,  //  0089  JMPF	R3	#008C
+      0x8C10011A,  //  008A  GETMET	R4	R0	K26
+      0x7C100200,  //  008B  CALL	R4	1
+      0x80000000,  //  008C  RET	0
     })
   )
 );
@@ -419,7 +414,7 @@ be_local_closure(class_Matter_HTTP_remote_device_is_alive,   /* name */
 extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_event_http_finished,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -433,9 +428,9 @@ be_local_closure(class_Matter_HTTP_remote_event_http_finished,   /* name */
     /* K2   */  be_nested_str_weak(nil),
     /* K3   */  be_const_int(0),
     /* K4   */  be_nested_str_weak(_X2E_X2E_X2E),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20async_X2Dresp_X20in_X20_X25i_X20ms_X20from_X20_X25s_X3A_X20_X5B_X25i_X5D_X20_X27_X25s_X27),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20async_X2Dresp_X20in_X20_X25i_X20ms_X20from_X20_X25s_X3A_X20_X5B_X25i_X5D_X20_X27_X25s_X27),
+    /* K7   */  be_nested_str_weak(tasmota),
     /* K8   */  be_nested_str_weak(millis),
     /* K9   */  be_nested_str_weak(time_start),
     /* K10  */  be_nested_str_weak(addr),
@@ -445,7 +440,7 @@ be_local_closure(class_Matter_HTTP_remote_event_http_finished,   /* name */
     }),
     be_str_weak(event_http_finished),
     &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
+    ( &(const binstruction[44]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
@@ -470,27 +465,26 @@ be_local_closure(class_Matter_HTTP_remote_event_http_finished,   /* name */
       0x00080504,  //  0015  ADD	R2	R2	K4
       0x5C040400,  //  0016  MOVE	R1	R2
       0xB80A0A00,  //  0017  GETNGBL	R2	K5
-      0x8C080506,  //  0018  GETMET	R2	R2	K6
-      0x60100018,  //  0019  GETGBL	R4	G24
-      0x58140007,  //  001A  LDCONST	R5	K7
-      0xB81A0A00,  //  001B  GETNGBL	R6	K5
-      0x8C180D08,  //  001C  GETMET	R6	R6	K8
-      0x7C180200,  //  001D  CALL	R6	1
-      0x881C0109,  //  001E  GETMBR	R7	R0	K9
-      0x04180C07,  //  001F  SUB	R6	R6	R7
-      0x881C010A,  //  0020  GETMBR	R7	R0	K10
-      0x6020000C,  //  0021  GETGBL	R8	G12
-      0x88240101,  //  0022  GETMBR	R9	R0	K1
-      0x7C200200,  //  0023  CALL	R8	1
-      0x5C240200,  //  0024  MOVE	R9	R1
-      0x7C100A00,  //  0025  CALL	R4	5
-      0x5814000B,  //  0026  LDCONST	R5	K11
-      0x7C080600,  //  0027  CALL	R2	3
-      0x8C08010C,  //  0028  GETMET	R2	R0	K12
-      0x8810010D,  //  0029  GETMBR	R4	R0	K13
-      0x88140101,  //  002A  GETMBR	R5	R0	K1
-      0x7C080600,  //  002B  CALL	R2	3
-      0x80000000,  //  002C  RET	0
+      0x600C0018,  //  0018  GETGBL	R3	G24
+      0x58100006,  //  0019  LDCONST	R4	K6
+      0xB8160E00,  //  001A  GETNGBL	R5	K7
+      0x8C140B08,  //  001B  GETMET	R5	R5	K8
+      0x7C140200,  //  001C  CALL	R5	1
+      0x88180109,  //  001D  GETMBR	R6	R0	K9
+      0x04140A06,  //  001E  SUB	R5	R5	R6
+      0x8818010A,  //  001F  GETMBR	R6	R0	K10
+      0x601C000C,  //  0020  GETGBL	R7	G12
+      0x88200101,  //  0021  GETMBR	R8	R0	K1
+      0x7C1C0200,  //  0022  CALL	R7	1
+      0x5C200200,  //  0023  MOVE	R8	R1
+      0x7C0C0A00,  //  0024  CALL	R3	5
+      0x5810000B,  //  0025  LDCONST	R4	K11
+      0x7C080400,  //  0026  CALL	R2	2
+      0x8C08010C,  //  0027  GETMET	R2	R0	K12
+      0x8810010D,  //  0028  GETMBR	R4	R0	K13
+      0x88140101,  //  0029  GETMBR	R5	R0	K1
+      0x7C080600,  //  002A  CALL	R2	3
+      0x80000000,  //  002B  RET	0
     })
   )
 );
@@ -503,7 +497,7 @@ be_local_closure(class_Matter_HTTP_remote_event_http_finished,   /* name */
 extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_probe_async,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -531,7 +525,7 @@ be_local_closure(class_Matter_HTTP_remote_probe_async,   /* name */
     }),
     be_str_weak(probe_async),
     &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
+    ( &(const binstruction[34]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0xA40E0200,  //  0001  IMPORT	R3	K1
       0xB8120400,  //  0002  GETNGBL	R4	K2
@@ -553,20 +547,19 @@ be_local_closure(class_Matter_HTTP_remote_probe_async,   /* name */
       0x5820000A,  //  0012  LDCONST	R8	K10
       0x7C100800,  //  0013  CALL	R4	4
       0x00120E04,  //  0014  ADD	R4	K7	R4
-      0xB8160400,  //  0015  GETNGBL	R5	K2
-      0x8C140B0B,  //  0016  GETMET	R5	R5	K11
-      0x601C0018,  //  0017  GETGBL	R7	G24
-      0x5820000C,  //  0018  LDCONST	R8	K12
-      0x8824010D,  //  0019  GETMBR	R9	R0	K13
-      0x8828010E,  //  001A  GETMBR	R10	R0	K14
-      0x5C2C0800,  //  001B  MOVE	R11	R4
-      0x7C1C0800,  //  001C  CALL	R7	4
-      0x54220003,  //  001D  LDINT	R8	4
-      0x7C140600,  //  001E  CALL	R5	3
-      0x8C14010F,  //  001F  GETMET	R5	R0	K15
-      0x5C1C0800,  //  0020  MOVE	R7	R4
-      0x7C140400,  //  0021  CALL	R5	2
-      0x80000000,  //  0022  RET	0
+      0xB8161600,  //  0015  GETNGBL	R5	K11
+      0x60180018,  //  0016  GETGBL	R6	G24
+      0x581C000C,  //  0017  LDCONST	R7	K12
+      0x8820010D,  //  0018  GETMBR	R8	R0	K13
+      0x8824010E,  //  0019  GETMBR	R9	R0	K14
+      0x5C280800,  //  001A  MOVE	R10	R4
+      0x7C180800,  //  001B  CALL	R6	4
+      0x541E0003,  //  001C  LDINT	R7	4
+      0x7C140400,  //  001D  CALL	R5	2
+      0x8C14010F,  //  001E  GETMET	R5	R0	K15
+      0x5C1C0800,  //  001F  MOVE	R7	R4
+      0x7C140400,  //  0020  CALL	R5	2
+      0x80000000,  //  0021  RET	0
     })
   )
 );
@@ -885,7 +878,7 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_response_and_call_method,
     0,                          /* has sup protos */
     &be_class_Matter_HTTP_remote, 
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
+    ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_const_int(0),
     /* K1   */  be_nested_str_weak(device_is_alive),
     /* K2   */  be_nested_str_weak(string),
@@ -894,19 +887,18 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_response_and_call_method,
     /* K5   */  be_nested_str_weak(STATUS_PREFIX),
     /* K6   */  be_nested_str_weak(contains),
     /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X20failed_X20to_X20parse_X20JSON_X20response_X20payload_X3D_X25s),
-    /* K11  */  be_const_int(3),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X20failed_X20to_X20parse_X20JSON_X20response_X20payload_X3D_X25s),
+    /* K10  */  be_const_int(3),
     }),
     be_str_weak(parse_status_response_and_call_method),
     &be_const_str_solidified,
-    ( &(const binstruction[58]) {  /* code */
+    ( &(const binstruction[57]) {  /* code */
       0x4C180000,  //  0000  LDNIL	R6
       0x20180206,  //  0001  NE	R6	R1	R6
-      0x781A0035,  //  0002  JMPF	R6	#0039
+      0x781A0034,  //  0002  JMPF	R6	#0038
       0x24180300,  //  0003  GT	R6	R1	K0
-      0x781A0033,  //  0004  JMPF	R6	#0039
+      0x781A0032,  //  0004  JMPF	R6	#0038
       0x8C180101,  //  0005  GETMET	R6	R0	K1
       0x50200200,  //  0006  LDBOOL	R8	1	0
       0x7C180400,  //  0007  CALL	R6	2
@@ -950,16 +942,15 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_response_and_call_method,
       0x5C300C00,  //  002D  MOVE	R12	R6
       0x5C340E00,  //  002E  MOVE	R13	R7
       0x7C280600,  //  002F  CALL	R10	3
-      0x70020007,  //  0030  JMP		#0039
+      0x70020006,  //  0030  JMP		#0038
       0xB8221000,  //  0031  GETNGBL	R8	K8
-      0x8C201109,  //  0032  GETMET	R8	R8	K9
-      0x60280018,  //  0033  GETGBL	R10	G24
-      0x582C000A,  //  0034  LDCONST	R11	K10
-      0x5C300400,  //  0035  MOVE	R12	R2
-      0x7C280400,  //  0036  CALL	R10	2
-      0x582C000B,  //  0037  LDCONST	R11	K11
-      0x7C200600,  //  0038  CALL	R8	3
-      0x80000000,  //  0039  RET	0
+      0x60240018,  //  0032  GETGBL	R9	G24
+      0x58280009,  //  0033  LDCONST	R10	K9
+      0x5C2C0400,  //  0034  MOVE	R11	R2
+      0x7C240400,  //  0035  CALL	R9	2
+      0x5828000A,  //  0036  LDCONST	R10	K10
+      0x7C200400,  //  0037  CALL	R8	2
+      0x80000000,  //  0038  RET	0
     })
   )
 );
@@ -972,7 +963,7 @@ be_local_closure(class_Matter_HTTP_remote_parse_status_response_and_call_method,
 extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_call_sync,   /* name */
   be_nested_proto(
-    16,                          /* nstack */
+    15,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1008,7 +999,7 @@ be_local_closure(class_Matter_HTTP_remote_call_sync,   /* name */
     }),
     be_str_weak(call_sync),
     &be_const_str_solidified,
-    ( &(const binstruction[72]) {  /* code */
+    ( &(const binstruction[70]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0xA4120200,  //  0001  IMPORT	R4	K1
       0xB8160400,  //  0002  GETNGBL	R5	K2
@@ -1031,56 +1022,54 @@ be_local_closure(class_Matter_HTTP_remote_call_sync,   /* name */
       0x5824000A,  //  0013  LDCONST	R9	K10
       0x7C140800,  //  0014  CALL	R5	4
       0x00160E05,  //  0015  ADD	R5	K7	R5
-      0xB81A0400,  //  0016  GETNGBL	R6	K2
-      0x8C180D0B,  //  0017  GETMET	R6	R6	K11
-      0x60200018,  //  0018  GETGBL	R8	G24
-      0x5824000C,  //  0019  LDCONST	R9	K12
-      0x8828010D,  //  001A  GETMBR	R10	R0	K13
-      0x882C010E,  //  001B  GETMBR	R11	R0	K14
-      0x5C300A00,  //  001C  MOVE	R12	R5
-      0x7C200800,  //  001D  CALL	R8	4
-      0x54260003,  //  001E  LDINT	R9	4
-      0x7C180600,  //  001F  CALL	R6	3
-      0x60180003,  //  0020  GETGBL	R6	G3
-      0x5C1C0000,  //  0021  MOVE	R7	R0
-      0x7C180200,  //  0022  CALL	R6	1
-      0x8C180D0F,  //  0023  GETMET	R6	R6	K15
-      0x5C200A00,  //  0024  MOVE	R8	R5
-      0x5C240400,  //  0025  MOVE	R9	R2
-      0x7C180600,  //  0026  CALL	R6	3
-      0x781A0001,  //  0027  JMPF	R6	#002A
-      0x5C1C0C00,  //  0028  MOVE	R7	R6
-      0x70020000,  //  0029  JMP		#002B
-      0x581C0010,  //  002A  LDCONST	R7	K16
-      0x6020000C,  //  002B  GETGBL	R8	G12
-      0x5C240E00,  //  002C  MOVE	R9	R7
-      0x7C200200,  //  002D  CALL	R8	1
-      0x5426001D,  //  002E  LDINT	R9	30
-      0x24201009,  //  002F  GT	R8	R8	R9
-      0x78220004,  //  0030  JMPF	R8	#0036
-      0x5422001C,  //  0031  LDINT	R8	29
-      0x40222208,  //  0032  CONNECT	R8	K17	R8
-      0x94200E08,  //  0033  GETIDX	R8	R7	R8
-      0x00201112,  //  0034  ADD	R8	R8	K18
-      0x5C1C1000,  //  0035  MOVE	R7	R8
-      0xB8220400,  //  0036  GETNGBL	R8	K2
-      0x8C20110B,  //  0037  GETMET	R8	R8	K11
-      0x60280018,  //  0038  GETGBL	R10	G24
-      0x582C0013,  //  0039  LDCONST	R11	K19
-      0xB8320400,  //  003A  GETNGBL	R12	K2
-      0x8C301914,  //  003B  GETMET	R12	R12	K20
-      0x7C300200,  //  003C  CALL	R12	1
-      0x88340115,  //  003D  GETMBR	R13	R0	K21
-      0x0430180D,  //  003E  SUB	R12	R12	R13
-      0x8834010D,  //  003F  GETMBR	R13	R0	K13
-      0x6038000C,  //  0040  GETGBL	R14	G12
-      0x883C0116,  //  0041  GETMBR	R15	R0	K22
-      0x7C380200,  //  0042  CALL	R14	1
-      0x5C3C0E00,  //  0043  MOVE	R15	R7
-      0x7C280A00,  //  0044  CALL	R10	5
-      0x582C0017,  //  0045  LDCONST	R11	K23
-      0x7C200600,  //  0046  CALL	R8	3
-      0x80040C00,  //  0047  RET	1	R6
+      0xB81A1600,  //  0016  GETNGBL	R6	K11
+      0x601C0018,  //  0017  GETGBL	R7	G24
+      0x5820000C,  //  0018  LDCONST	R8	K12
+      0x8824010D,  //  0019  GETMBR	R9	R0	K13
+      0x8828010E,  //  001A  GETMBR	R10	R0	K14
+      0x5C2C0A00,  //  001B  MOVE	R11	R5
+      0x7C1C0800,  //  001C  CALL	R7	4
+      0x54220003,  //  001D  LDINT	R8	4
+      0x7C180400,  //  001E  CALL	R6	2
+      0x60180003,  //  001F  GETGBL	R6	G3
+      0x5C1C0000,  //  0020  MOVE	R7	R0
+      0x7C180200,  //  0021  CALL	R6	1
+      0x8C180D0F,  //  0022  GETMET	R6	R6	K15
+      0x5C200A00,  //  0023  MOVE	R8	R5
+      0x5C240400,  //  0024  MOVE	R9	R2
+      0x7C180600,  //  0025  CALL	R6	3
+      0x781A0001,  //  0026  JMPF	R6	#0029
+      0x5C1C0C00,  //  0027  MOVE	R7	R6
+      0x70020000,  //  0028  JMP		#002A
+      0x581C0010,  //  0029  LDCONST	R7	K16
+      0x6020000C,  //  002A  GETGBL	R8	G12
+      0x5C240E00,  //  002B  MOVE	R9	R7
+      0x7C200200,  //  002C  CALL	R8	1
+      0x5426001D,  //  002D  LDINT	R9	30
+      0x24201009,  //  002E  GT	R8	R8	R9
+      0x78220004,  //  002F  JMPF	R8	#0035
+      0x5422001C,  //  0030  LDINT	R8	29
+      0x40222208,  //  0031  CONNECT	R8	K17	R8
+      0x94200E08,  //  0032  GETIDX	R8	R7	R8
+      0x00201112,  //  0033  ADD	R8	R8	K18
+      0x5C1C1000,  //  0034  MOVE	R7	R8
+      0xB8221600,  //  0035  GETNGBL	R8	K11
+      0x60240018,  //  0036  GETGBL	R9	G24
+      0x58280013,  //  0037  LDCONST	R10	K19
+      0xB82E0400,  //  0038  GETNGBL	R11	K2
+      0x8C2C1714,  //  0039  GETMET	R11	R11	K20
+      0x7C2C0200,  //  003A  CALL	R11	1
+      0x88300115,  //  003B  GETMBR	R12	R0	K21
+      0x042C160C,  //  003C  SUB	R11	R11	R12
+      0x8830010D,  //  003D  GETMBR	R12	R0	K13
+      0x6034000C,  //  003E  GETGBL	R13	G12
+      0x88380116,  //  003F  GETMBR	R14	R0	K22
+      0x7C340200,  //  0040  CALL	R13	1
+      0x5C380E00,  //  0041  MOVE	R14	R7
+      0x7C240A00,  //  0042  CALL	R9	5
+      0x58280017,  //  0043  LDCONST	R10	K23
+      0x7C200400,  //  0044  CALL	R8	2
+      0x80040C00,  //  0045  RET	1	R6
     })
   )
 );
@@ -1202,33 +1191,31 @@ be_local_closure(class_Matter_HTTP_remote_event_http_failed,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_HTTP_remote, 
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(current_cmd),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20failed),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(dispatch_cb),
-    /* K6   */  be_nested_str_weak(http_status),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20failed),
+    /* K3   */  be_const_int(3),
+    /* K4   */  be_nested_str_weak(dispatch_cb),
+    /* K5   */  be_nested_str_weak(http_status),
     }),
     be_str_weak(event_http_failed),
     &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
+    ( &(const binstruction[14]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060000,  //  0003  JMPF	R1	#0005
       0x80000200,  //  0004  RET	0
       0xB8060200,  //  0005  GETNGBL	R1	K1
-      0x8C040302,  //  0006  GETMET	R1	R1	K2
+      0x58080002,  //  0006  LDCONST	R2	K2
       0x580C0003,  //  0007  LDCONST	R3	K3
-      0x58100004,  //  0008  LDCONST	R4	K4
-      0x7C040600,  //  0009  CALL	R1	3
-      0x8C040105,  //  000A  GETMET	R1	R0	K5
-      0x880C0106,  //  000B  GETMBR	R3	R0	K6
-      0x4C100000,  //  000C  LDNIL	R4
-      0x7C040600,  //  000D  CALL	R1	3
-      0x80000000,  //  000E  RET	0
+      0x7C040400,  //  0008  CALL	R1	2
+      0x8C040104,  //  0009  GETMET	R1	R0	K4
+      0x880C0105,  //  000A  GETMBR	R3	R0	K5
+      0x4C100000,  //  000B  LDNIL	R4
+      0x7C040600,  //  000C  CALL	R1	3
+      0x80000000,  //  000D  RET	0
     })
   )
 );
@@ -1270,7 +1257,7 @@ be_local_closure(class_Matter_HTTP_remote_add_async_cb,   /* name */
 extern const bclass be_class_Matter_HTTP_remote;
 be_local_closure(class_Matter_HTTP_remote_event_http_timeout,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1278,44 +1265,42 @@ be_local_closure(class_Matter_HTTP_remote_event_http_timeout,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_HTTP_remote, 
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(current_cmd),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20timeout_X20http_status_X3D_X25i_X20phase_X3D_X25i_X20tcp_status_X3D_X25i_X20size_payload_X3D_X25i),
-    /* K4   */  be_nested_str_weak(http_status),
-    /* K5   */  be_nested_str_weak(phase),
-    /* K6   */  be_nested_str_weak(status),
-    /* K7   */  be_nested_str_weak(payload),
-    /* K8   */  be_const_int(3),
-    /* K9   */  be_nested_str_weak(dispatch_cb),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20HTTP_X20timeout_X20http_status_X3D_X25i_X20phase_X3D_X25i_X20tcp_status_X3D_X25i_X20size_payload_X3D_X25i),
+    /* K3   */  be_nested_str_weak(http_status),
+    /* K4   */  be_nested_str_weak(phase),
+    /* K5   */  be_nested_str_weak(status),
+    /* K6   */  be_nested_str_weak(payload),
+    /* K7   */  be_const_int(3),
+    /* K8   */  be_nested_str_weak(dispatch_cb),
     }),
     be_str_weak(event_http_timeout),
     &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
+    ( &(const binstruction[22]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x4C080000,  //  0001  LDNIL	R2
       0x1C040202,  //  0002  EQ	R1	R1	R2
       0x78060000,  //  0003  JMPF	R1	#0005
       0x80000200,  //  0004  RET	0
       0xB8060200,  //  0005  GETNGBL	R1	K1
-      0x8C040302,  //  0006  GETMET	R1	R1	K2
-      0x600C0018,  //  0007  GETGBL	R3	G24
-      0x58100003,  //  0008  LDCONST	R4	K3
+      0x60080018,  //  0006  GETGBL	R2	G24
+      0x580C0002,  //  0007  LDCONST	R3	K2
+      0x88100103,  //  0008  GETMBR	R4	R0	K3
       0x88140104,  //  0009  GETMBR	R5	R0	K4
       0x88180105,  //  000A  GETMBR	R6	R0	K5
-      0x881C0106,  //  000B  GETMBR	R7	R0	K6
-      0x6020000C,  //  000C  GETGBL	R8	G12
-      0x88240107,  //  000D  GETMBR	R9	R0	K7
-      0x7C200200,  //  000E  CALL	R8	1
-      0x7C0C0A00,  //  000F  CALL	R3	5
-      0x58100008,  //  0010  LDCONST	R4	K8
-      0x7C040600,  //  0011  CALL	R1	3
-      0x8C040109,  //  0012  GETMET	R1	R0	K9
-      0x880C0104,  //  0013  GETMBR	R3	R0	K4
-      0x4C100000,  //  0014  LDNIL	R4
-      0x7C040600,  //  0015  CALL	R1	3
-      0x80000000,  //  0016  RET	0
+      0x601C000C,  //  000B  GETGBL	R7	G12
+      0x88200106,  //  000C  GETMBR	R8	R0	K6
+      0x7C1C0200,  //  000D  CALL	R7	1
+      0x7C080A00,  //  000E  CALL	R2	5
+      0x580C0007,  //  000F  LDCONST	R3	K7
+      0x7C040400,  //  0010  CALL	R1	2
+      0x8C040108,  //  0011  GETMET	R1	R0	K8
+      0x880C0103,  //  0012  GETMBR	R3	R0	K3
+      0x4C100000,  //  0013  LDNIL	R4
+      0x7C040600,  //  0014  CALL	R1	3
+      0x80000000,  //  0015  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -153,7 +153,7 @@ be_local_closure(class_Matter_IM_process_write_response,   /* name */
 extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_status_response,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -161,7 +161,7 @@ be_local_closure(class_Matter_IM_process_status_response,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
+    ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(findsubval),
     /* K1   */  be_const_int(0),
     /* K2   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
@@ -169,19 +169,18 @@ be_local_closure(class_Matter_IM_process_status_response,   /* name */
     /* K4   */  be_nested_str_weak(matter),
     /* K5   */  be_nested_str_weak(SUCCESS),
     /* K6   */  be_nested_str_weak(status_ok_received),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3EOK_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i_X20not_X20found),
-    /* K10  */  be_nested_str_weak(session),
-    /* K11  */  be_nested_str_weak(local_session_id),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
-    /* K13  */  be_const_int(3),
-    /* K14  */  be_nested_str_weak(status_error_received),
-    /* K15  */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X3EOK_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i_X20not_X20found),
+    /* K9   */  be_nested_str_weak(session),
+    /* K10  */  be_nested_str_weak(local_session_id),
+    /* K11  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_nested_str_weak(status_error_received),
+    /* K14  */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
     }),
     be_str_weak(process_status_response),
     &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
+    ( &(const binstruction[43]) {  /* code */
       0x8C0C0500,  //  0000  GETMET	R3	R2	K0
       0x58140001,  //  0001  LDCONST	R5	K1
       0x541A00FE,  //  0002  LDINT	R6	255
@@ -192,41 +191,39 @@ be_local_closure(class_Matter_IM_process_status_response,   /* name */
       0xB8160800,  //  0007  GETNGBL	R5	K4
       0x88140B05,  //  0008  GETMBR	R5	R5	K5
       0x1C140605,  //  0009  EQ	R5	R3	R5
-      0x78160010,  //  000A  JMPF	R5	#001C
+      0x7816000F,  //  000A  JMPF	R5	#001B
       0x78120004,  //  000B  JMPF	R4	#0011
       0x8C140906,  //  000C  GETMET	R5	R4	K6
       0x5C1C0200,  //  000D  MOVE	R7	R1
       0x7C140400,  //  000E  CALL	R5	2
       0x80040A00,  //  000F  RET	1	R5
-      0x70020009,  //  0010  JMP		#001B
+      0x70020008,  //  0010  JMP		#001A
       0xB8160E00,  //  0011  GETNGBL	R5	K7
-      0x8C140B08,  //  0012  GETMET	R5	R5	K8
-      0x601C0018,  //  0013  GETGBL	R7	G24
-      0x58200009,  //  0014  LDCONST	R8	K9
-      0x8824030A,  //  0015  GETMBR	R9	R1	K10
-      0x8824130B,  //  0016  GETMBR	R9	R9	K11
-      0x88280303,  //  0017  GETMBR	R10	R1	K3
-      0x7C1C0600,  //  0018  CALL	R7	3
-      0x54220003,  //  0019  LDINT	R8	4
-      0x7C140600,  //  001A  CALL	R5	3
-      0x7002000E,  //  001B  JMP		#002B
-      0xB8160E00,  //  001C  GETNGBL	R5	K7
-      0x8C140B08,  //  001D  GETMET	R5	R5	K8
-      0x601C0018,  //  001E  GETGBL	R7	G24
-      0x5820000C,  //  001F  LDCONST	R8	K12
-      0x5C240600,  //  0020  MOVE	R9	R3
-      0x7C1C0400,  //  0021  CALL	R7	2
-      0x5820000D,  //  0022  LDCONST	R8	K13
-      0x7C140600,  //  0023  CALL	R5	3
-      0x78120005,  //  0024  JMPF	R4	#002B
-      0x8C14090E,  //  0025  GETMET	R5	R4	K14
-      0x5C1C0200,  //  0026  MOVE	R7	R1
-      0x7C140400,  //  0027  CALL	R5	2
-      0x8C14010F,  //  0028  GETMET	R5	R0	K15
-      0x881C0303,  //  0029  GETMBR	R7	R1	K3
-      0x7C140400,  //  002A  CALL	R5	2
-      0x50140000,  //  002B  LDBOOL	R5	0	0
-      0x80040A00,  //  002C  RET	1	R5
+      0x60180018,  //  0012  GETGBL	R6	G24
+      0x581C0008,  //  0013  LDCONST	R7	K8
+      0x88200309,  //  0014  GETMBR	R8	R1	K9
+      0x8820110A,  //  0015  GETMBR	R8	R8	K10
+      0x88240303,  //  0016  GETMBR	R9	R1	K3
+      0x7C180600,  //  0017  CALL	R6	3
+      0x541E0003,  //  0018  LDINT	R7	4
+      0x7C140400,  //  0019  CALL	R5	2
+      0x7002000D,  //  001A  JMP		#0029
+      0xB8160E00,  //  001B  GETNGBL	R5	K7
+      0x60180018,  //  001C  GETGBL	R6	G24
+      0x581C000B,  //  001D  LDCONST	R7	K11
+      0x5C200600,  //  001E  MOVE	R8	R3
+      0x7C180400,  //  001F  CALL	R6	2
+      0x581C000C,  //  0020  LDCONST	R7	K12
+      0x7C140400,  //  0021  CALL	R5	2
+      0x78120005,  //  0022  JMPF	R4	#0029
+      0x8C14090D,  //  0023  GETMET	R5	R4	K13
+      0x5C1C0200,  //  0024  MOVE	R7	R1
+      0x7C140400,  //  0025  CALL	R5	2
+      0x8C14010E,  //  0026  GETMET	R5	R0	K14
+      0x881C0303,  //  0027  GETMBR	R7	R1	K3
+      0x7C140400,  //  0028  CALL	R5	2
+      0x50140000,  //  0029  LDBOOL	R5	0	0
+      0x80040A00,  //  002A  RET	1	R5
     })
   )
 );
@@ -239,7 +236,7 @@ be_local_closure(class_Matter_IM_process_status_response,   /* name */
 extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_timed_request,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -247,23 +244,22 @@ be_local_closure(class_Matter_IM_process_timed_request,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
+    ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TimedRequestMessage),
     /* K2   */  be_nested_str_weak(from_TLV),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20TimedRequest_X3D_X25i),
-    /* K6   */  be_nested_str_weak(session),
-    /* K7   */  be_nested_str_weak(local_session_id),
-    /* K8   */  be_nested_str_weak(timeout),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_nested_str_weak(send_status),
-    /* K11  */  be_nested_str_weak(SUCCESS),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20TimedRequest_X3D_X25i),
+    /* K5   */  be_nested_str_weak(session),
+    /* K6   */  be_nested_str_weak(local_session_id),
+    /* K7   */  be_nested_str_weak(timeout),
+    /* K8   */  be_const_int(3),
+    /* K9   */  be_nested_str_weak(send_status),
+    /* K10  */  be_nested_str_weak(SUCCESS),
     }),
     be_str_weak(process_timed_request),
     &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
+    ( &(const binstruction[22]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x8C0C0701,  //  0001  GETMET	R3	R3	K1
       0x7C0C0200,  //  0002  CALL	R3	1
@@ -271,22 +267,21 @@ be_local_closure(class_Matter_IM_process_timed_request,   /* name */
       0x5C140400,  //  0004  MOVE	R5	R2
       0x7C0C0400,  //  0005  CALL	R3	2
       0xB8120600,  //  0006  GETNGBL	R4	K3
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x60180018,  //  0008  GETGBL	R6	G24
-      0x581C0005,  //  0009  LDCONST	R7	K5
-      0x88200306,  //  000A  GETMBR	R8	R1	K6
-      0x88201107,  //  000B  GETMBR	R8	R8	K7
-      0x88240708,  //  000C  GETMBR	R9	R3	K8
-      0x7C180600,  //  000D  CALL	R6	3
-      0x581C0009,  //  000E  LDCONST	R7	K9
-      0x7C100600,  //  000F  CALL	R4	3
-      0x8C10010A,  //  0010  GETMET	R4	R0	K10
-      0x5C180200,  //  0011  MOVE	R6	R1
-      0xB81E0000,  //  0012  GETNGBL	R7	K0
-      0x881C0F0B,  //  0013  GETMBR	R7	R7	K11
-      0x7C100600,  //  0014  CALL	R4	3
-      0x50100200,  //  0015  LDBOOL	R4	1	0
-      0x80040800,  //  0016  RET	1	R4
+      0x60140018,  //  0007  GETGBL	R5	G24
+      0x58180004,  //  0008  LDCONST	R6	K4
+      0x881C0305,  //  0009  GETMBR	R7	R1	K5
+      0x881C0F06,  //  000A  GETMBR	R7	R7	K6
+      0x88200707,  //  000B  GETMBR	R8	R3	K7
+      0x7C140600,  //  000C  CALL	R5	3
+      0x58180008,  //  000D  LDCONST	R6	K8
+      0x7C100400,  //  000E  CALL	R4	2
+      0x8C100109,  //  000F  GETMET	R4	R0	K9
+      0x5C180200,  //  0010  MOVE	R6	R1
+      0xB81E0000,  //  0011  GETNGBL	R7	K0
+      0x881C0F0A,  //  0012  GETMBR	R7	R7	K10
+      0x7C100600,  //  0013  CALL	R4	3
+      0x50100200,  //  0014  LDBOOL	R4	1	0
+      0x80040800,  //  0015  RET	1	R4
     })
   )
 );
@@ -408,7 +403,7 @@ be_local_closure(class_Matter_IM_process_invoke_request_solo,   /* name */
     }),
     be_str_weak(process_invoke_request_solo),
     &be_const_str_solidified,
-    ( &(const binstruction[208]) {  /* code */
+    ( &(const binstruction[203]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x880C0701,  //  0001  GETMBR	R3	R3	K1
       0x8C0C0702,  //  0002  GETMET	R3	R3	K2
@@ -452,171 +447,166 @@ be_local_closure(class_Matter_IM_process_invoke_request_solo,   /* name */
       0x8C1C0F13,  //  0028  GETMET	R7	R7	K19
       0x58240014,  //  0029  LDCONST	R9	K20
       0x7C1C0400,  //  002A  CALL	R7	2
-      0x781E000E,  //  002B  JMPF	R7	#003B
-      0xB81E2400,  //  002C  GETNGBL	R7	K18
-      0x8C1C0F02,  //  002D  GETMET	R7	R7	K2
-      0x60240018,  //  002E  GETGBL	R9	G24
-      0x58280015,  //  002F  LDCONST	R10	K21
-      0x882C030C,  //  0030  GETMBR	R11	R1	K12
-      0x882C1716,  //  0031  GETMBR	R11	R11	K22
-      0x5C300800,  //  0032  MOVE	R12	R4
-      0x780E0001,  //  0033  JMPF	R3	#0036
-      0x5C340600,  //  0034  MOVE	R13	R3
-      0x70020000,  //  0035  JMP		#0037
-      0x58340011,  //  0036  LDCONST	R13	K17
-      0x5C380C00,  //  0037  MOVE	R14	R6
-      0x7C240A00,  //  0038  CALL	R9	5
-      0x58280014,  //  0039  LDCONST	R10	K20
-      0x7C1C0600,  //  003A  CALL	R7	3
-      0x4C1C0000,  //  003B  LDNIL	R7
-      0x900A0407,  //  003C  SETMBR	R2	K2	R7
-      0x601C0015,  //  003D  GETGBL	R7	G21
-      0x5422002F,  //  003E  LDINT	R8	48
-      0x7C1C0200,  //  003F  CALL	R7	1
-      0x8C200F17,  //  0040  GETMET	R8	R7	K23
-      0x58280018,  //  0041  LDCONST	R10	K24
-      0x542DFFFB,  //  0042  LDINT	R11	-4
-      0x7C200600,  //  0043  CALL	R8	3
-      0x8C200F17,  //  0044  GETMET	R8	R7	K23
-      0x58280019,  //  0045  LDCONST	R10	K25
-      0x582C0019,  //  0046  LDCONST	R11	K25
-      0x7C200600,  //  0047  CALL	R8	3
-      0x50200200,  //  0048  LDBOOL	R8	1	0
-      0x1C200A08,  //  0049  EQ	R8	R5	R8
-      0x74220004,  //  004A  JMPT	R8	#0050
-      0x88200505,  //  004B  GETMBR	R8	R2	K5
-      0xB8260000,  //  004C  GETNGBL	R9	K0
-      0x8824131A,  //  004D  GETMBR	R9	R9	K26
-      0x1C201009,  //  004E  EQ	R8	R8	R9
-      0x78220017,  //  004F  JMPF	R8	#0068
-      0xB8220000,  //  0050  GETNGBL	R8	K0
-      0x8820111A,  //  0051  GETMBR	R8	R8	K26
-      0x900A0A08,  //  0052  SETMBR	R2	K5	R8
-      0x8C20011B,  //  0053  GETMET	R8	R0	K27
-      0x5C280E00,  //  0054  MOVE	R10	R7
-      0x5C2C0400,  //  0055  MOVE	R11	R2
-      0x4C300000,  //  0056  LDNIL	R12
-      0x7C200800,  //  0057  CALL	R8	4
-      0xB8222400,  //  0058  GETNGBL	R8	K18
-      0x8C201113,  //  0059  GETMET	R8	R8	K19
-      0x58280014,  //  005A  LDCONST	R10	K20
-      0x7C200400,  //  005B  CALL	R8	2
-      0x78220009,  //  005C  JMPF	R8	#0067
-      0xB8222400,  //  005D  GETNGBL	R8	K18
-      0x8C201102,  //  005E  GETMET	R8	R8	K2
-      0x60280018,  //  005F  GETGBL	R10	G24
-      0x582C001C,  //  0060  LDCONST	R11	K28
-      0x8830030C,  //  0061  GETMBR	R12	R1	K12
-      0x88301916,  //  0062  GETMBR	R12	R12	K22
-      0x8834031D,  //  0063  GETMBR	R13	R1	K29
-      0x7C280600,  //  0064  CALL	R10	3
-      0x582C0014,  //  0065  LDCONST	R11	K20
-      0x7C200600,  //  0066  CALL	R8	3
-      0x70020046,  //  0067  JMP		#00AF
-      0x4C200000,  //  0068  LDNIL	R8
-      0x20200A08,  //  0069  NE	R8	R5	R8
-      0x78220018,  //  006A  JMPF	R8	#0084
-      0x8C20011B,  //  006B  GETMET	R8	R0	K27
-      0x5C280E00,  //  006C  MOVE	R10	R7
-      0x5C2C0400,  //  006D  MOVE	R11	R2
-      0x5C300A00,  //  006E  MOVE	R12	R5
-      0x7C200800,  //  006F  CALL	R8	4
-      0x5C200600,  //  0070  MOVE	R8	R3
-      0x74220000,  //  0071  JMPT	R8	#0073
-      0x580C0011,  //  0072  LDCONST	R3	K17
-      0xB8222400,  //  0073  GETNGBL	R8	K18
-      0x8C201113,  //  0074  GETMET	R8	R8	K19
-      0x58280014,  //  0075  LDCONST	R10	K20
-      0x7C200400,  //  0076  CALL	R8	2
-      0x7822000A,  //  0077  JMPF	R8	#0083
-      0xB8222400,  //  0078  GETNGBL	R8	K18
-      0x8C201102,  //  0079  GETMET	R8	R8	K2
-      0x60280018,  //  007A  GETGBL	R10	G24
-      0x582C001E,  //  007B  LDCONST	R11	K30
-      0x8830030C,  //  007C  GETMBR	R12	R1	K12
-      0x88301916,  //  007D  GETMBR	R12	R12	K22
-      0x5C340400,  //  007E  MOVE	R13	R2
-      0x5C380600,  //  007F  MOVE	R14	R3
-      0x7C280800,  //  0080  CALL	R10	4
-      0x582C0014,  //  0081  LDCONST	R11	K20
-      0x7C200600,  //  0082  CALL	R8	3
-      0x7002002A,  //  0083  JMP		#00AF
-      0x88200505,  //  0084  GETMBR	R8	R2	K5
-      0x4C240000,  //  0085  LDNIL	R9
-      0x20201009,  //  0086  NE	R8	R8	R9
-      0x78220015,  //  0087  JMPF	R8	#009E
-      0x8C20011B,  //  0088  GETMET	R8	R0	K27
-      0x5C280E00,  //  0089  MOVE	R10	R7
-      0x5C2C0400,  //  008A  MOVE	R11	R2
-      0x4C300000,  //  008B  LDNIL	R12
-      0x7C200800,  //  008C  CALL	R8	4
-      0xB8222400,  //  008D  GETNGBL	R8	K18
-      0x8C201113,  //  008E  GETMET	R8	R8	K19
-      0x58280014,  //  008F  LDCONST	R10	K20
-      0x7C200400,  //  0090  CALL	R8	2
-      0x7822000A,  //  0091  JMPF	R8	#009D
-      0xB8222400,  //  0092  GETNGBL	R8	K18
-      0x8C201102,  //  0093  GETMET	R8	R8	K2
-      0x60280018,  //  0094  GETGBL	R10	G24
-      0x582C001F,  //  0095  LDCONST	R11	K31
-      0x8830030C,  //  0096  GETMBR	R12	R1	K12
-      0x88301916,  //  0097  GETMBR	R12	R12	K22
-      0x88340505,  //  0098  GETMBR	R13	R2	K5
-      0x8838031D,  //  0099  GETMBR	R14	R1	K29
-      0x7C280800,  //  009A  CALL	R10	4
-      0x582C0014,  //  009B  LDCONST	R11	K20
-      0x7C200600,  //  009C  CALL	R8	3
-      0x70020010,  //  009D  JMP		#00AF
-      0xB8222400,  //  009E  GETNGBL	R8	K18
-      0x8C201113,  //  009F  GETMET	R8	R8	K19
-      0x58280014,  //  00A0  LDCONST	R10	K20
-      0x7C200400,  //  00A1  CALL	R8	2
-      0x78220009,  //  00A2  JMPF	R8	#00AD
-      0xB8222400,  //  00A3  GETNGBL	R8	K18
-      0x8C201102,  //  00A4  GETMET	R8	R8	K2
-      0x60280018,  //  00A5  GETGBL	R10	G24
-      0x582C0020,  //  00A6  LDCONST	R11	K32
-      0x8830030C,  //  00A7  GETMBR	R12	R1	K12
-      0x88301916,  //  00A8  GETMBR	R12	R12	K22
-      0x8834031D,  //  00A9  GETMBR	R13	R1	K29
-      0x7C280600,  //  00AA  CALL	R10	3
-      0x582C0014,  //  00AB  LDCONST	R11	K20
-      0x7C200600,  //  00AC  CALL	R8	3
-      0x50200000,  //  00AD  LDBOOL	R8	0	0
-      0x80041000,  //  00AE  RET	1	R8
-      0x8C200F17,  //  00AF  GETMET	R8	R7	K23
-      0x58280021,  //  00B0  LDCONST	R10	K33
-      0x542DFFFB,  //  00B1  LDINT	R11	-4
-      0x7C200600,  //  00B2  CALL	R8	3
-      0x8C200F17,  //  00B3  GETMET	R8	R7	K23
-      0x542A0017,  //  00B4  LDINT	R10	24
-      0x582C0019,  //  00B5  LDCONST	R11	K25
-      0x7C200600,  //  00B6  CALL	R8	3
-      0x8C200322,  //  00B7  GETMET	R8	R1	K34
-      0x542A0008,  //  00B8  LDINT	R10	9
-      0x502C0200,  //  00B9  LDBOOL	R11	1	0
-      0x7C200600,  //  00BA  CALL	R8	3
-      0x8824010A,  //  00BB  GETMBR	R9	R0	K10
-      0x88241323,  //  00BC  GETMBR	R9	R9	K35
-      0x88280324,  //  00BD  GETMBR	R10	R1	K36
-      0x8C2C1525,  //  00BE  GETMET	R11	R10	K37
-      0x7C2C0200,  //  00BF  CALL	R11	1
-      0x8C2C1126,  //  00C0  GETMET	R11	R8	K38
-      0x5C340E00,  //  00C1  MOVE	R13	R7
-      0x5C381400,  //  00C2  MOVE	R14	R10
-      0x7C2C0600,  //  00C3  CALL	R11	3
-      0x8C2C1127,  //  00C4  GETMET	R11	R8	K39
-      0x7C2C0200,  //  00C5  CALL	R11	1
-      0x8C2C1328,  //  00C6  GETMET	R11	R9	K40
-      0x5C341000,  //  00C7  MOVE	R13	R8
+      0x781E000D,  //  002B  JMPF	R7	#003A
+      0xB81E0400,  //  002C  GETNGBL	R7	K2
+      0x60200018,  //  002D  GETGBL	R8	G24
+      0x58240015,  //  002E  LDCONST	R9	K21
+      0x8828030C,  //  002F  GETMBR	R10	R1	K12
+      0x88281516,  //  0030  GETMBR	R10	R10	K22
+      0x5C2C0800,  //  0031  MOVE	R11	R4
+      0x780E0001,  //  0032  JMPF	R3	#0035
+      0x5C300600,  //  0033  MOVE	R12	R3
+      0x70020000,  //  0034  JMP		#0036
+      0x58300011,  //  0035  LDCONST	R12	K17
+      0x5C340C00,  //  0036  MOVE	R13	R6
+      0x7C200A00,  //  0037  CALL	R8	5
+      0x58240014,  //  0038  LDCONST	R9	K20
+      0x7C1C0400,  //  0039  CALL	R7	2
+      0x4C1C0000,  //  003A  LDNIL	R7
+      0x900A0407,  //  003B  SETMBR	R2	K2	R7
+      0x601C0015,  //  003C  GETGBL	R7	G21
+      0x5422002F,  //  003D  LDINT	R8	48
+      0x7C1C0200,  //  003E  CALL	R7	1
+      0x8C200F17,  //  003F  GETMET	R8	R7	K23
+      0x58280018,  //  0040  LDCONST	R10	K24
+      0x542DFFFB,  //  0041  LDINT	R11	-4
+      0x7C200600,  //  0042  CALL	R8	3
+      0x8C200F17,  //  0043  GETMET	R8	R7	K23
+      0x58280019,  //  0044  LDCONST	R10	K25
+      0x582C0019,  //  0045  LDCONST	R11	K25
+      0x7C200600,  //  0046  CALL	R8	3
+      0x50200200,  //  0047  LDBOOL	R8	1	0
+      0x1C200A08,  //  0048  EQ	R8	R5	R8
+      0x74220004,  //  0049  JMPT	R8	#004F
+      0x88200505,  //  004A  GETMBR	R8	R2	K5
+      0xB8260000,  //  004B  GETNGBL	R9	K0
+      0x8824131A,  //  004C  GETMBR	R9	R9	K26
+      0x1C201009,  //  004D  EQ	R8	R8	R9
+      0x78220016,  //  004E  JMPF	R8	#0066
+      0xB8220000,  //  004F  GETNGBL	R8	K0
+      0x8820111A,  //  0050  GETMBR	R8	R8	K26
+      0x900A0A08,  //  0051  SETMBR	R2	K5	R8
+      0x8C20011B,  //  0052  GETMET	R8	R0	K27
+      0x5C280E00,  //  0053  MOVE	R10	R7
+      0x5C2C0400,  //  0054  MOVE	R11	R2
+      0x4C300000,  //  0055  LDNIL	R12
+      0x7C200800,  //  0056  CALL	R8	4
+      0xB8222400,  //  0057  GETNGBL	R8	K18
+      0x8C201113,  //  0058  GETMET	R8	R8	K19
+      0x58280014,  //  0059  LDCONST	R10	K20
+      0x7C200400,  //  005A  CALL	R8	2
+      0x78220008,  //  005B  JMPF	R8	#0065
+      0xB8220400,  //  005C  GETNGBL	R8	K2
+      0x60240018,  //  005D  GETGBL	R9	G24
+      0x5828001C,  //  005E  LDCONST	R10	K28
+      0x882C030C,  //  005F  GETMBR	R11	R1	K12
+      0x882C1716,  //  0060  GETMBR	R11	R11	K22
+      0x8830031D,  //  0061  GETMBR	R12	R1	K29
+      0x7C240600,  //  0062  CALL	R9	3
+      0x58280014,  //  0063  LDCONST	R10	K20
+      0x7C200400,  //  0064  CALL	R8	2
+      0x70020043,  //  0065  JMP		#00AA
+      0x4C200000,  //  0066  LDNIL	R8
+      0x20200A08,  //  0067  NE	R8	R5	R8
+      0x78220017,  //  0068  JMPF	R8	#0081
+      0x8C20011B,  //  0069  GETMET	R8	R0	K27
+      0x5C280E00,  //  006A  MOVE	R10	R7
+      0x5C2C0400,  //  006B  MOVE	R11	R2
+      0x5C300A00,  //  006C  MOVE	R12	R5
+      0x7C200800,  //  006D  CALL	R8	4
+      0x5C200600,  //  006E  MOVE	R8	R3
+      0x74220000,  //  006F  JMPT	R8	#0071
+      0x580C0011,  //  0070  LDCONST	R3	K17
+      0xB8222400,  //  0071  GETNGBL	R8	K18
+      0x8C201113,  //  0072  GETMET	R8	R8	K19
+      0x58280014,  //  0073  LDCONST	R10	K20
+      0x7C200400,  //  0074  CALL	R8	2
+      0x78220009,  //  0075  JMPF	R8	#0080
+      0xB8220400,  //  0076  GETNGBL	R8	K2
+      0x60240018,  //  0077  GETGBL	R9	G24
+      0x5828001E,  //  0078  LDCONST	R10	K30
+      0x882C030C,  //  0079  GETMBR	R11	R1	K12
+      0x882C1716,  //  007A  GETMBR	R11	R11	K22
+      0x5C300400,  //  007B  MOVE	R12	R2
+      0x5C340600,  //  007C  MOVE	R13	R3
+      0x7C240800,  //  007D  CALL	R9	4
+      0x58280014,  //  007E  LDCONST	R10	K20
+      0x7C200400,  //  007F  CALL	R8	2
+      0x70020028,  //  0080  JMP		#00AA
+      0x88200505,  //  0081  GETMBR	R8	R2	K5
+      0x4C240000,  //  0082  LDNIL	R9
+      0x20201009,  //  0083  NE	R8	R8	R9
+      0x78220014,  //  0084  JMPF	R8	#009A
+      0x8C20011B,  //  0085  GETMET	R8	R0	K27
+      0x5C280E00,  //  0086  MOVE	R10	R7
+      0x5C2C0400,  //  0087  MOVE	R11	R2
+      0x4C300000,  //  0088  LDNIL	R12
+      0x7C200800,  //  0089  CALL	R8	4
+      0xB8222400,  //  008A  GETNGBL	R8	K18
+      0x8C201113,  //  008B  GETMET	R8	R8	K19
+      0x58280014,  //  008C  LDCONST	R10	K20
+      0x7C200400,  //  008D  CALL	R8	2
+      0x78220009,  //  008E  JMPF	R8	#0099
+      0xB8220400,  //  008F  GETNGBL	R8	K2
+      0x60240018,  //  0090  GETGBL	R9	G24
+      0x5828001F,  //  0091  LDCONST	R10	K31
+      0x882C030C,  //  0092  GETMBR	R11	R1	K12
+      0x882C1716,  //  0093  GETMBR	R11	R11	K22
+      0x88300505,  //  0094  GETMBR	R12	R2	K5
+      0x8834031D,  //  0095  GETMBR	R13	R1	K29
+      0x7C240800,  //  0096  CALL	R9	4
+      0x58280014,  //  0097  LDCONST	R10	K20
+      0x7C200400,  //  0098  CALL	R8	2
+      0x7002000F,  //  0099  JMP		#00AA
+      0xB8222400,  //  009A  GETNGBL	R8	K18
+      0x8C201113,  //  009B  GETMET	R8	R8	K19
+      0x58280014,  //  009C  LDCONST	R10	K20
+      0x7C200400,  //  009D  CALL	R8	2
+      0x78220008,  //  009E  JMPF	R8	#00A8
+      0xB8220400,  //  009F  GETNGBL	R8	K2
+      0x60240018,  //  00A0  GETGBL	R9	G24
+      0x58280020,  //  00A1  LDCONST	R10	K32
+      0x882C030C,  //  00A2  GETMBR	R11	R1	K12
+      0x882C1716,  //  00A3  GETMBR	R11	R11	K22
+      0x8830031D,  //  00A4  GETMBR	R12	R1	K29
+      0x7C240600,  //  00A5  CALL	R9	3
+      0x58280014,  //  00A6  LDCONST	R10	K20
+      0x7C200400,  //  00A7  CALL	R8	2
+      0x50200000,  //  00A8  LDBOOL	R8	0	0
+      0x80041000,  //  00A9  RET	1	R8
+      0x8C200F17,  //  00AA  GETMET	R8	R7	K23
+      0x58280021,  //  00AB  LDCONST	R10	K33
+      0x542DFFFB,  //  00AC  LDINT	R11	-4
+      0x7C200600,  //  00AD  CALL	R8	3
+      0x8C200F17,  //  00AE  GETMET	R8	R7	K23
+      0x542A0017,  //  00AF  LDINT	R10	24
+      0x582C0019,  //  00B0  LDCONST	R11	K25
+      0x7C200600,  //  00B1  CALL	R8	3
+      0x8C200322,  //  00B2  GETMET	R8	R1	K34
+      0x542A0008,  //  00B3  LDINT	R10	9
+      0x502C0200,  //  00B4  LDBOOL	R11	1	0
+      0x7C200600,  //  00B5  CALL	R8	3
+      0x8824010A,  //  00B6  GETMBR	R9	R0	K10
+      0x88241323,  //  00B7  GETMBR	R9	R9	K35
+      0x88280324,  //  00B8  GETMBR	R10	R1	K36
+      0x8C2C1525,  //  00B9  GETMET	R11	R10	K37
+      0x7C2C0200,  //  00BA  CALL	R11	1
+      0x8C2C1126,  //  00BB  GETMET	R11	R8	K38
+      0x5C340E00,  //  00BC  MOVE	R13	R7
+      0x5C381400,  //  00BD  MOVE	R14	R10
+      0x7C2C0600,  //  00BE  CALL	R11	3
+      0x8C2C1127,  //  00BF  GETMET	R11	R8	K39
+      0x7C2C0200,  //  00C0  CALL	R11	1
+      0x8C2C1328,  //  00C1  GETMET	R11	R9	K40
+      0x5C341000,  //  00C2  MOVE	R13	R8
+      0x7C2C0400,  //  00C3  CALL	R11	2
+      0xB82E0000,  //  00C4  GETNGBL	R11	K0
+      0x882C1701,  //  00C5  GETMBR	R11	R11	K1
+      0x8C2C1702,  //  00C6  GETMET	R11	R11	K2
+      0x58340029,  //  00C7  LDCONST	R13	K41
       0x7C2C0400,  //  00C8  CALL	R11	2
-      0xB82E0000,  //  00C9  GETNGBL	R11	K0
-      0x882C1701,  //  00CA  GETMBR	R11	R11	K1
-      0x8C2C1702,  //  00CB  GETMET	R11	R11	K2
-      0x58340029,  //  00CC  LDCONST	R13	K41
-      0x7C2C0400,  //  00CD  CALL	R11	2
-      0x502C0200,  //  00CE  LDBOOL	R11	1	0
-      0x80041600,  //  00CF  RET	1	R11
+      0x502C0200,  //  00C9  LDBOOL	R11	1	0
+      0x80041600,  //  00CA  RET	1	R11
     })
   )
 );
@@ -852,7 +842,7 @@ be_local_closure(class_Matter_IM_send_ack_now,   /* name */
 extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_invoke_request,   /* name */
   be_nested_proto(
-    20,                          /* nstack */
+    19,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -888,13 +878,13 @@ be_local_closure(class_Matter_IM_process_invoke_request,   /* name */
     /* K24  */  be_nested_str_weak(_X28),
     /* K25  */  be_nested_str_weak(_X29_X20),
     /* K26  */  be_nested_str_weak(),
-    /* K27  */  be_nested_str_weak(tasmota),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20_X25s),
-    /* K29  */  be_nested_str_weak(local_session_id),
-    /* K30  */  be_const_int(3),
-    /* K31  */  be_nested_str_weak(SUCCESS),
-    /* K32  */  be_nested_str_weak(invokeresponse2raw),
-    /* K33  */  be_nested_str_weak(push),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20_X25s),
+    /* K28  */  be_nested_str_weak(local_session_id),
+    /* K29  */  be_const_int(3),
+    /* K30  */  be_nested_str_weak(SUCCESS),
+    /* K31  */  be_nested_str_weak(invokeresponse2raw),
+    /* K32  */  be_nested_str_weak(push),
+    /* K33  */  be_nested_str_weak(tasmota),
     /* K34  */  be_nested_str_weak(loglevel),
     /* K35  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20OK_X20exch_X3D_X25i),
     /* K36  */  be_nested_str_weak(exchange_id),
@@ -907,7 +897,7 @@ be_local_closure(class_Matter_IM_process_invoke_request,   /* name */
     }),
     be_str_weak(process_invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[233]) {  /* code */
+    ( &(const binstruction[228]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x880C0701,  //  0001  GETMBR	R3	R3	K1
       0x8C0C0702,  //  0002  GETMET	R3	R3	K2
@@ -926,7 +916,7 @@ be_local_closure(class_Matter_IM_process_invoke_request,   /* name */
       0x88140908,  //  000F  GETMBR	R5	R4	K8
       0x4C180000,  //  0010  LDNIL	R6
       0x20140A06,  //  0011  NE	R5	R5	R6
-      0x781600D4,  //  0012  JMPF	R5	#00E8
+      0x781600CF,  //  0012  JMPF	R5	#00E3
       0xB8160000,  //  0013  GETNGBL	R5	K0
       0x8C140B09,  //  0014  GETMET	R5	R5	K9
       0x7C140200,  //  0015  CALL	R5	1
@@ -938,7 +928,7 @@ be_local_closure(class_Matter_IM_process_invoke_request,   /* name */
       0x60180010,  //  001B  GETGBL	R6	G16
       0x881C0908,  //  001C  GETMBR	R7	R4	K8
       0x7C180200,  //  001D  CALL	R6	1
-      0xA80200B7,  //  001E  EXBLK	0	#00D7
+      0xA80200B2,  //  001E  EXBLK	0	#00D2
       0x5C1C0C00,  //  001F  MOVE	R7	R6
       0x7C1C0000,  //  0020  CALL	R7	0
       0x88200F0D,  //  0021  GETMBR	R8	R7	K13
@@ -983,164 +973,159 @@ be_local_closure(class_Matter_IM_process_invoke_request,   /* name */
       0x002C1719,  //  0048  ADD	R11	R11	K25
       0x70020000,  //  0049  JMP		#004B
       0x582C001A,  //  004A  LDCONST	R11	K26
-      0xB8323600,  //  004B  GETNGBL	R12	K27
-      0x8C301902,  //  004C  GETMET	R12	R12	K2
-      0x60380018,  //  004D  GETGBL	R14	G24
-      0x583C001C,  //  004E  LDCONST	R15	K28
-      0x88400315,  //  004F  GETMBR	R16	R1	K21
-      0x8840211D,  //  0050  GETMBR	R16	R16	K29
-      0x5C441200,  //  0051  MOVE	R17	R9
-      0x78220001,  //  0052  JMPF	R8	#0055
-      0x5C481000,  //  0053  MOVE	R18	R8
-      0x70020000,  //  0054  JMP		#0056
-      0x5848001A,  //  0055  LDCONST	R18	K26
-      0x5C4C1600,  //  0056  MOVE	R19	R11
-      0x7C380A00,  //  0057  CALL	R14	5
-      0x583C001E,  //  0058  LDCONST	R15	K30
-      0x7C300600,  //  0059  CALL	R12	3
-      0x4C300000,  //  005A  LDNIL	R12
-      0x900E040C,  //  005B  SETMBR	R3	K2	R12
-      0x60300015,  //  005C  GETGBL	R12	G21
-      0x5436001F,  //  005D  LDINT	R13	32
-      0x7C300200,  //  005E  CALL	R12	1
-      0x50340200,  //  005F  LDBOOL	R13	1	0
-      0x1C34140D,  //  0060  EQ	R13	R10	R13
-      0x74360004,  //  0061  JMPT	R13	#0067
-      0x88340710,  //  0062  GETMBR	R13	R3	K16
-      0xB83A0000,  //  0063  GETNGBL	R14	K0
-      0x88381D1F,  //  0064  GETMBR	R14	R14	K31
-      0x1C341A0E,  //  0065  EQ	R13	R13	R14
-      0x7836001B,  //  0066  JMPF	R13	#0083
-      0xB8360000,  //  0067  GETNGBL	R13	K0
-      0x88341B1F,  //  0068  GETMBR	R13	R13	K31
-      0x900E200D,  //  0069  SETMBR	R3	K16	R13
-      0x8C340120,  //  006A  GETMET	R13	R0	K32
-      0x5C3C1800,  //  006B  MOVE	R15	R12
-      0x5C400600,  //  006C  MOVE	R16	R3
-      0x4C440000,  //  006D  LDNIL	R17
-      0x7C340800,  //  006E  CALL	R13	4
-      0x88340B0B,  //  006F  GETMBR	R13	R5	K11
-      0x8C341B21,  //  0070  GETMET	R13	R13	K33
-      0x5C3C1800,  //  0071  MOVE	R15	R12
-      0x7C340400,  //  0072  CALL	R13	2
-      0xB8363600,  //  0073  GETNGBL	R13	K27
-      0x8C341B22,  //  0074  GETMET	R13	R13	K34
-      0x583C001E,  //  0075  LDCONST	R15	K30
-      0x7C340400,  //  0076  CALL	R13	2
-      0x78360009,  //  0077  JMPF	R13	#0082
-      0xB8363600,  //  0078  GETNGBL	R13	K27
-      0x8C341B02,  //  0079  GETMET	R13	R13	K2
-      0x603C0018,  //  007A  GETGBL	R15	G24
-      0x58400023,  //  007B  LDCONST	R16	K35
-      0x88440315,  //  007C  GETMBR	R17	R1	K21
-      0x8844231D,  //  007D  GETMBR	R17	R17	K29
-      0x88480324,  //  007E  GETMBR	R18	R1	K36
-      0x7C3C0600,  //  007F  CALL	R15	3
-      0x5840001E,  //  0080  LDCONST	R16	K30
-      0x7C340600,  //  0081  CALL	R13	3
-      0x70020052,  //  0082  JMP		#00D6
-      0x4C340000,  //  0083  LDNIL	R13
-      0x2034140D,  //  0084  NE	R13	R10	R13
-      0x78360022,  //  0085  JMPF	R13	#00A9
-      0x8C340120,  //  0086  GETMET	R13	R0	K32
-      0x5C3C1800,  //  0087  MOVE	R15	R12
-      0x5C400600,  //  0088  MOVE	R16	R3
-      0x5C441400,  //  0089  MOVE	R17	R10
-      0x7C340800,  //  008A  CALL	R13	4
-      0x88340B0B,  //  008B  GETMBR	R13	R5	K11
-      0x8C341B21,  //  008C  GETMET	R13	R13	K33
-      0x5C3C1800,  //  008D  MOVE	R15	R12
-      0x7C340400,  //  008E  CALL	R13	2
-      0xB8360000,  //  008F  GETNGBL	R13	K0
-      0x8C341B12,  //  0090  GETMET	R13	R13	K18
-      0x883C070E,  //  0091  GETMBR	R15	R3	K14
-      0x8840070F,  //  0092  GETMBR	R16	R3	K15
-      0x7C340600,  //  0093  CALL	R13	3
-      0x5C201A00,  //  0094  MOVE	R8	R13
-      0x5C341000,  //  0095  MOVE	R13	R8
-      0x74360000,  //  0096  JMPT	R13	#0098
-      0x5820001A,  //  0097  LDCONST	R8	K26
-      0xB8363600,  //  0098  GETNGBL	R13	K27
-      0x8C341B22,  //  0099  GETMET	R13	R13	K34
-      0x583C001E,  //  009A  LDCONST	R15	K30
-      0x7C340400,  //  009B  CALL	R13	2
-      0x7836000A,  //  009C  JMPF	R13	#00A8
-      0xB8363600,  //  009D  GETNGBL	R13	K27
-      0x8C341B02,  //  009E  GETMET	R13	R13	K2
-      0x603C0018,  //  009F  GETGBL	R15	G24
-      0x58400025,  //  00A0  LDCONST	R16	K37
-      0x88440315,  //  00A1  GETMBR	R17	R1	K21
-      0x8844231D,  //  00A2  GETMBR	R17	R17	K29
-      0x5C480600,  //  00A3  MOVE	R18	R3
-      0x5C4C1000,  //  00A4  MOVE	R19	R8
-      0x7C3C0800,  //  00A5  CALL	R15	4
-      0x5840001E,  //  00A6  LDCONST	R16	K30
-      0x7C340600,  //  00A7  CALL	R13	3
-      0x7002002C,  //  00A8  JMP		#00D6
-      0x88340710,  //  00A9  GETMBR	R13	R3	K16
-      0x4C380000,  //  00AA  LDNIL	R14
-      0x20341A0E,  //  00AB  NE	R13	R13	R14
-      0x78360019,  //  00AC  JMPF	R13	#00C7
-      0x8C340120,  //  00AD  GETMET	R13	R0	K32
-      0x5C3C1800,  //  00AE  MOVE	R15	R12
-      0x5C400600,  //  00AF  MOVE	R16	R3
-      0x4C440000,  //  00B0  LDNIL	R17
-      0x7C340800,  //  00B1  CALL	R13	4
-      0x88340B0B,  //  00B2  GETMBR	R13	R5	K11
-      0x8C341B21,  //  00B3  GETMET	R13	R13	K33
-      0x5C3C1800,  //  00B4  MOVE	R15	R12
-      0x7C340400,  //  00B5  CALL	R13	2
-      0xB8363600,  //  00B6  GETNGBL	R13	K27
-      0x8C341B22,  //  00B7  GETMET	R13	R13	K34
-      0x583C001E,  //  00B8  LDCONST	R15	K30
-      0x7C340400,  //  00B9  CALL	R13	2
-      0x7836000A,  //  00BA  JMPF	R13	#00C6
-      0xB8363600,  //  00BB  GETNGBL	R13	K27
-      0x8C341B02,  //  00BC  GETMET	R13	R13	K2
-      0x603C0018,  //  00BD  GETGBL	R15	G24
-      0x58400026,  //  00BE  LDCONST	R16	K38
-      0x88440315,  //  00BF  GETMBR	R17	R1	K21
-      0x8844231D,  //  00C0  GETMBR	R17	R17	K29
-      0x88480710,  //  00C1  GETMBR	R18	R3	K16
-      0x884C0324,  //  00C2  GETMBR	R19	R1	K36
-      0x7C3C0800,  //  00C3  CALL	R15	4
-      0x5840001E,  //  00C4  LDCONST	R16	K30
-      0x7C340600,  //  00C5  CALL	R13	3
-      0x7002000E,  //  00C6  JMP		#00D6
-      0xB8363600,  //  00C7  GETNGBL	R13	K27
-      0x8C341B22,  //  00C8  GETMET	R13	R13	K34
-      0x583C001E,  //  00C9  LDCONST	R15	K30
-      0x7C340400,  //  00CA  CALL	R13	2
-      0x78360009,  //  00CB  JMPF	R13	#00D6
-      0xB8363600,  //  00CC  GETNGBL	R13	K27
-      0x8C341B02,  //  00CD  GETMET	R13	R13	K2
-      0x603C0018,  //  00CE  GETGBL	R15	G24
-      0x58400027,  //  00CF  LDCONST	R16	K39
-      0x88440315,  //  00D0  GETMBR	R17	R1	K21
-      0x8844231D,  //  00D1  GETMBR	R17	R17	K29
-      0x88480324,  //  00D2  GETMBR	R18	R1	K36
-      0x7C3C0600,  //  00D3  CALL	R15	3
-      0x5840001E,  //  00D4  LDCONST	R16	K30
-      0x7C340600,  //  00D5  CALL	R13	3
-      0x7001FF47,  //  00D6  JMP		#001F
-      0x58180028,  //  00D7  LDCONST	R6	K40
-      0xAC180200,  //  00D8  CATCH	R6	1	0
-      0xB0080000,  //  00D9  RAISE	2	R0	R0
-      0x6018000C,  //  00DA  GETGBL	R6	G12
-      0x881C0B0B,  //  00DB  GETMBR	R7	R5	K11
-      0x7C180200,  //  00DC  CALL	R6	1
-      0x24180D29,  //  00DD  GT	R6	R6	K41
-      0x781A0004,  //  00DE  JMPF	R6	#00E4
-      0x8C18012A,  //  00DF  GETMET	R6	R0	K42
-      0x5C200200,  //  00E0  MOVE	R8	R1
-      0x5C240A00,  //  00E1  MOVE	R9	R5
-      0x7C180600,  //  00E2  CALL	R6	3
-      0x70020001,  //  00E3  JMP		#00E6
-      0x50180000,  //  00E4  LDBOOL	R6	0	0
-      0x80040C00,  //  00E5  RET	1	R6
-      0x50180200,  //  00E6  LDBOOL	R6	1	0
-      0x80040C00,  //  00E7  RET	1	R6
-      0x80000000,  //  00E8  RET	0
+      0xB8320400,  //  004B  GETNGBL	R12	K2
+      0x60340018,  //  004C  GETGBL	R13	G24
+      0x5838001B,  //  004D  LDCONST	R14	K27
+      0x883C0315,  //  004E  GETMBR	R15	R1	K21
+      0x883C1F1C,  //  004F  GETMBR	R15	R15	K28
+      0x5C401200,  //  0050  MOVE	R16	R9
+      0x78220001,  //  0051  JMPF	R8	#0054
+      0x5C441000,  //  0052  MOVE	R17	R8
+      0x70020000,  //  0053  JMP		#0055
+      0x5844001A,  //  0054  LDCONST	R17	K26
+      0x5C481600,  //  0055  MOVE	R18	R11
+      0x7C340A00,  //  0056  CALL	R13	5
+      0x5838001D,  //  0057  LDCONST	R14	K29
+      0x7C300400,  //  0058  CALL	R12	2
+      0x4C300000,  //  0059  LDNIL	R12
+      0x900E040C,  //  005A  SETMBR	R3	K2	R12
+      0x60300015,  //  005B  GETGBL	R12	G21
+      0x5436001F,  //  005C  LDINT	R13	32
+      0x7C300200,  //  005D  CALL	R12	1
+      0x50340200,  //  005E  LDBOOL	R13	1	0
+      0x1C34140D,  //  005F  EQ	R13	R10	R13
+      0x74360004,  //  0060  JMPT	R13	#0066
+      0x88340710,  //  0061  GETMBR	R13	R3	K16
+      0xB83A0000,  //  0062  GETNGBL	R14	K0
+      0x88381D1E,  //  0063  GETMBR	R14	R14	K30
+      0x1C341A0E,  //  0064  EQ	R13	R13	R14
+      0x7836001A,  //  0065  JMPF	R13	#0081
+      0xB8360000,  //  0066  GETNGBL	R13	K0
+      0x88341B1E,  //  0067  GETMBR	R13	R13	K30
+      0x900E200D,  //  0068  SETMBR	R3	K16	R13
+      0x8C34011F,  //  0069  GETMET	R13	R0	K31
+      0x5C3C1800,  //  006A  MOVE	R15	R12
+      0x5C400600,  //  006B  MOVE	R16	R3
+      0x4C440000,  //  006C  LDNIL	R17
+      0x7C340800,  //  006D  CALL	R13	4
+      0x88340B0B,  //  006E  GETMBR	R13	R5	K11
+      0x8C341B20,  //  006F  GETMET	R13	R13	K32
+      0x5C3C1800,  //  0070  MOVE	R15	R12
+      0x7C340400,  //  0071  CALL	R13	2
+      0xB8364200,  //  0072  GETNGBL	R13	K33
+      0x8C341B22,  //  0073  GETMET	R13	R13	K34
+      0x583C001D,  //  0074  LDCONST	R15	K29
+      0x7C340400,  //  0075  CALL	R13	2
+      0x78360008,  //  0076  JMPF	R13	#0080
+      0xB8360400,  //  0077  GETNGBL	R13	K2
+      0x60380018,  //  0078  GETGBL	R14	G24
+      0x583C0023,  //  0079  LDCONST	R15	K35
+      0x88400315,  //  007A  GETMBR	R16	R1	K21
+      0x8840211C,  //  007B  GETMBR	R16	R16	K28
+      0x88440324,  //  007C  GETMBR	R17	R1	K36
+      0x7C380600,  //  007D  CALL	R14	3
+      0x583C001D,  //  007E  LDCONST	R15	K29
+      0x7C340400,  //  007F  CALL	R13	2
+      0x7002004F,  //  0080  JMP		#00D1
+      0x4C340000,  //  0081  LDNIL	R13
+      0x2034140D,  //  0082  NE	R13	R10	R13
+      0x78360021,  //  0083  JMPF	R13	#00A6
+      0x8C34011F,  //  0084  GETMET	R13	R0	K31
+      0x5C3C1800,  //  0085  MOVE	R15	R12
+      0x5C400600,  //  0086  MOVE	R16	R3
+      0x5C441400,  //  0087  MOVE	R17	R10
+      0x7C340800,  //  0088  CALL	R13	4
+      0x88340B0B,  //  0089  GETMBR	R13	R5	K11
+      0x8C341B20,  //  008A  GETMET	R13	R13	K32
+      0x5C3C1800,  //  008B  MOVE	R15	R12
+      0x7C340400,  //  008C  CALL	R13	2
+      0xB8360000,  //  008D  GETNGBL	R13	K0
+      0x8C341B12,  //  008E  GETMET	R13	R13	K18
+      0x883C070E,  //  008F  GETMBR	R15	R3	K14
+      0x8840070F,  //  0090  GETMBR	R16	R3	K15
+      0x7C340600,  //  0091  CALL	R13	3
+      0x5C201A00,  //  0092  MOVE	R8	R13
+      0x5C341000,  //  0093  MOVE	R13	R8
+      0x74360000,  //  0094  JMPT	R13	#0096
+      0x5820001A,  //  0095  LDCONST	R8	K26
+      0xB8364200,  //  0096  GETNGBL	R13	K33
+      0x8C341B22,  //  0097  GETMET	R13	R13	K34
+      0x583C001D,  //  0098  LDCONST	R15	K29
+      0x7C340400,  //  0099  CALL	R13	2
+      0x78360009,  //  009A  JMPF	R13	#00A5
+      0xB8360400,  //  009B  GETNGBL	R13	K2
+      0x60380018,  //  009C  GETGBL	R14	G24
+      0x583C0025,  //  009D  LDCONST	R15	K37
+      0x88400315,  //  009E  GETMBR	R16	R1	K21
+      0x8840211C,  //  009F  GETMBR	R16	R16	K28
+      0x5C440600,  //  00A0  MOVE	R17	R3
+      0x5C481000,  //  00A1  MOVE	R18	R8
+      0x7C380800,  //  00A2  CALL	R14	4
+      0x583C001D,  //  00A3  LDCONST	R15	K29
+      0x7C340400,  //  00A4  CALL	R13	2
+      0x7002002A,  //  00A5  JMP		#00D1
+      0x88340710,  //  00A6  GETMBR	R13	R3	K16
+      0x4C380000,  //  00A7  LDNIL	R14
+      0x20341A0E,  //  00A8  NE	R13	R13	R14
+      0x78360018,  //  00A9  JMPF	R13	#00C3
+      0x8C34011F,  //  00AA  GETMET	R13	R0	K31
+      0x5C3C1800,  //  00AB  MOVE	R15	R12
+      0x5C400600,  //  00AC  MOVE	R16	R3
+      0x4C440000,  //  00AD  LDNIL	R17
+      0x7C340800,  //  00AE  CALL	R13	4
+      0x88340B0B,  //  00AF  GETMBR	R13	R5	K11
+      0x8C341B20,  //  00B0  GETMET	R13	R13	K32
+      0x5C3C1800,  //  00B1  MOVE	R15	R12
+      0x7C340400,  //  00B2  CALL	R13	2
+      0xB8364200,  //  00B3  GETNGBL	R13	K33
+      0x8C341B22,  //  00B4  GETMET	R13	R13	K34
+      0x583C001D,  //  00B5  LDCONST	R15	K29
+      0x7C340400,  //  00B6  CALL	R13	2
+      0x78360009,  //  00B7  JMPF	R13	#00C2
+      0xB8360400,  //  00B8  GETNGBL	R13	K2
+      0x60380018,  //  00B9  GETGBL	R14	G24
+      0x583C0026,  //  00BA  LDCONST	R15	K38
+      0x88400315,  //  00BB  GETMBR	R16	R1	K21
+      0x8840211C,  //  00BC  GETMBR	R16	R16	K28
+      0x88440710,  //  00BD  GETMBR	R17	R3	K16
+      0x88480324,  //  00BE  GETMBR	R18	R1	K36
+      0x7C380800,  //  00BF  CALL	R14	4
+      0x583C001D,  //  00C0  LDCONST	R15	K29
+      0x7C340400,  //  00C1  CALL	R13	2
+      0x7002000D,  //  00C2  JMP		#00D1
+      0xB8364200,  //  00C3  GETNGBL	R13	K33
+      0x8C341B22,  //  00C4  GETMET	R13	R13	K34
+      0x583C001D,  //  00C5  LDCONST	R15	K29
+      0x7C340400,  //  00C6  CALL	R13	2
+      0x78360008,  //  00C7  JMPF	R13	#00D1
+      0xB8360400,  //  00C8  GETNGBL	R13	K2
+      0x60380018,  //  00C9  GETGBL	R14	G24
+      0x583C0027,  //  00CA  LDCONST	R15	K39
+      0x88400315,  //  00CB  GETMBR	R16	R1	K21
+      0x8840211C,  //  00CC  GETMBR	R16	R16	K28
+      0x88440324,  //  00CD  GETMBR	R17	R1	K36
+      0x7C380600,  //  00CE  CALL	R14	3
+      0x583C001D,  //  00CF  LDCONST	R15	K29
+      0x7C340400,  //  00D0  CALL	R13	2
+      0x7001FF4C,  //  00D1  JMP		#001F
+      0x58180028,  //  00D2  LDCONST	R6	K40
+      0xAC180200,  //  00D3  CATCH	R6	1	0
+      0xB0080000,  //  00D4  RAISE	2	R0	R0
+      0x6018000C,  //  00D5  GETGBL	R6	G12
+      0x881C0B0B,  //  00D6  GETMBR	R7	R5	K11
+      0x7C180200,  //  00D7  CALL	R6	1
+      0x24180D29,  //  00D8  GT	R6	R6	K41
+      0x781A0004,  //  00D9  JMPF	R6	#00DF
+      0x8C18012A,  //  00DA  GETMET	R6	R0	K42
+      0x5C200200,  //  00DB  MOVE	R8	R1
+      0x5C240A00,  //  00DC  MOVE	R9	R5
+      0x7C180600,  //  00DD  CALL	R6	3
+      0x70020001,  //  00DE  JMP		#00E1
+      0x50180000,  //  00DF  LDBOOL	R6	0	0
+      0x80040C00,  //  00E0  RET	1	R6
+      0x50180200,  //  00E1  LDBOOL	R6	1	0
+      0x80040C00,  //  00E2  RET	1	R6
+      0x80000000,  //  00E3  RET	0
     })
   )
 );
@@ -1298,7 +1283,7 @@ be_local_closure(class_Matter_IM_process_write_request,   /* name */
     1,                          /* has sup protos */
     ( &(const struct bproto*[ 3]) {
       be_nested_proto(
-        17,                          /* nstack */
+        16,                          /* nstack */
         5,                          /* argc */
         0,                          /* varg */
         1,                          /* has upvals */
@@ -1308,7 +1293,7 @@ be_local_closure(class_Matter_IM_process_write_request,   /* name */
         0,                          /* has sup protos */
         NULL, 
         1,                          /* has constants */
-        ( &(const bvalue[26]) {     /* constants */
+        ( &(const bvalue[25]) {     /* constants */
         /* K0   */  be_nested_str_weak(matter),
         /* K1   */  be_nested_str_weak(get_attribute_name),
         /* K2   */  be_nested_str_weak(cluster),
@@ -1328,17 +1313,16 @@ be_local_closure(class_Matter_IM_process_write_request,   /* name */
         /* K16  */  be_nested_str_weak(endpoint),
         /* K17  */  be_nested_str_weak(write_responses),
         /* K18  */  be_nested_str_weak(push),
-        /* K19  */  be_nested_str_weak(tasmota),
-        /* K20  */  be_nested_str_weak(log),
-        /* K21  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
-        /* K22  */  be_const_int(0),
-        /* K23  */  be_const_int(2),
-        /* K24  */  be_const_int(3),
-        /* K25  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20_X25s_X25s_X20_X2D_X20IGNORED),
+        /* K19  */  be_nested_str_weak(log),
+        /* K20  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
+        /* K21  */  be_const_int(0),
+        /* K22  */  be_const_int(2),
+        /* K23  */  be_const_int(3),
+        /* K24  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20_X25s_X25s_X20_X2D_X20IGNORED),
         }),
         be_str_weak(write_single_attribute),
         &be_const_str_solidified,
-        ( &(const binstruction[101]) {  /* code */
+        ( &(const binstruction[99]) {  /* code */
           0xB8160000,  //  0000  GETNGBL	R5	K0
           0x8C140B01,  //  0001  GETMET	R5	R5	K1
           0x881C0502,  //  0002  GETMBR	R7	R2	K2
@@ -1371,8 +1355,8 @@ be_local_closure(class_Matter_IM_process_write_request,   /* name */
           0x881C0507,  //  001D  GETMBR	R7	R2	K7
           0x4C200000,  //  001E  LDNIL	R8
           0x201C0E08,  //  001F  NE	R7	R7	R8
-          0x781E0037,  //  0020  JMPF	R7	#0059
-          0x78120035,  //  0021  JMPF	R4	#0058
+          0x781E0036,  //  0020  JMPF	R7	#0058
+          0x78120034,  //  0021  JMPF	R4	#0057
           0xB81E0000,  //  0022  GETNGBL	R7	K0
           0x8C1C0F0C,  //  0023  GETMET	R7	R7	K12
           0x7C1C0200,  //  0024  CALL	R7	1
@@ -1401,45 +1385,43 @@ be_local_closure(class_Matter_IM_process_write_request,   /* name */
           0x5C280E00,  //  003B  MOVE	R10	R7
           0x7C200400,  //  003C  CALL	R8	2
           0xB8222600,  //  003D  GETNGBL	R8	K19
-          0x8C201114,  //  003E  GETMET	R8	R8	K20
-          0x60280018,  //  003F  GETGBL	R10	G24
-          0x582C0015,  //  0040  LDCONST	R11	K21
-          0x60300008,  //  0041  GETGBL	R12	G8
-          0x5C340400,  //  0042  MOVE	R13	R2
-          0x7C300200,  //  0043  CALL	R12	1
-          0x5C340A00,  //  0044  MOVE	R13	R5
+          0x60240018,  //  003E  GETGBL	R9	G24
+          0x58280014,  //  003F  LDCONST	R10	K20
+          0x602C0008,  //  0040  GETGBL	R11	G8
+          0x5C300400,  //  0041  MOVE	R12	R2
+          0x7C2C0200,  //  0042  CALL	R11	1
+          0x5C300A00,  //  0043  MOVE	R12	R5
+          0x88340507,  //  0044  GETMBR	R13	R2	K7
           0x88380507,  //  0045  GETMBR	R14	R2	K7
-          0x883C0507,  //  0046  GETMBR	R15	R2	K7
-          0xB8420000,  //  0047  GETNGBL	R16	K0
-          0x8840210B,  //  0048  GETMBR	R16	R16	K11
-          0x1C3C1E10,  //  0049  EQ	R15	R15	R16
-          0x783E0001,  //  004A  JMPF	R15	#004D
-          0x583C000B,  //  004B  LDCONST	R15	K11
-          0x70020000,  //  004C  JMP		#004E
-          0x583C0006,  //  004D  LDCONST	R15	K6
-          0x7C280A00,  //  004E  CALL	R10	5
-          0x882C0510,  //  004F  GETMBR	R11	R2	K16
-          0x202C1716,  //  0050  NE	R11	R11	K22
-          0x782E0001,  //  0051  JMPF	R11	#0054
-          0x582C0017,  //  0052  LDCONST	R11	K23
-          0x70020000,  //  0053  JMP		#0055
-          0x582C0018,  //  0054  LDCONST	R11	K24
-          0x7C200600,  //  0055  CALL	R8	3
-          0x50200200,  //  0056  LDBOOL	R8	1	0
-          0x80041000,  //  0057  RET	1	R8
-          0x7002000A,  //  0058  JMP		#0064
-          0xB81E2600,  //  0059  GETNGBL	R7	K19
-          0x8C1C0F14,  //  005A  GETMET	R7	R7	K20
-          0x60240018,  //  005B  GETGBL	R9	G24
-          0x58280019,  //  005C  LDCONST	R10	K25
-          0x602C0008,  //  005D  GETGBL	R11	G8
-          0x5C300400,  //  005E  MOVE	R12	R2
-          0x7C2C0200,  //  005F  CALL	R11	1
-          0x5C300A00,  //  0060  MOVE	R12	R5
-          0x7C240600,  //  0061  CALL	R9	3
-          0x58280018,  //  0062  LDCONST	R10	K24
-          0x7C1C0600,  //  0063  CALL	R7	3
-          0x80000000,  //  0064  RET	0
+          0xB83E0000,  //  0046  GETNGBL	R15	K0
+          0x883C1F0B,  //  0047  GETMBR	R15	R15	K11
+          0x1C381C0F,  //  0048  EQ	R14	R14	R15
+          0x783A0001,  //  0049  JMPF	R14	#004C
+          0x5838000B,  //  004A  LDCONST	R14	K11
+          0x70020000,  //  004B  JMP		#004D
+          0x58380006,  //  004C  LDCONST	R14	K6
+          0x7C240A00,  //  004D  CALL	R9	5
+          0x88280510,  //  004E  GETMBR	R10	R2	K16
+          0x20281515,  //  004F  NE	R10	R10	K21
+          0x782A0001,  //  0050  JMPF	R10	#0053
+          0x58280016,  //  0051  LDCONST	R10	K22
+          0x70020000,  //  0052  JMP		#0054
+          0x58280017,  //  0053  LDCONST	R10	K23
+          0x7C200400,  //  0054  CALL	R8	2
+          0x50200200,  //  0055  LDBOOL	R8	1	0
+          0x80041000,  //  0056  RET	1	R8
+          0x70020009,  //  0057  JMP		#0062
+          0xB81E2600,  //  0058  GETNGBL	R7	K19
+          0x60200018,  //  0059  GETGBL	R8	G24
+          0x58240018,  //  005A  LDCONST	R9	K24
+          0x60280008,  //  005B  GETGBL	R10	G8
+          0x5C2C0400,  //  005C  MOVE	R11	R2
+          0x7C280200,  //  005D  CALL	R10	1
+          0x5C2C0A00,  //  005E  MOVE	R11	R5
+          0x7C200600,  //  005F  CALL	R8	3
+          0x58240017,  //  0060  LDCONST	R9	K23
+          0x7C1C0400,  //  0061  CALL	R7	2
+          0x80000000,  //  0062  RET	0
         })
       ),
       be_nested_proto(
@@ -1472,7 +1454,7 @@ be_local_closure(class_Matter_IM_process_write_request,   /* name */
     &be_class_Matter_IM, 
     }),
     1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
+    ( &(const bvalue[29]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(WriteRequestMessage),
     /* K2   */  be_nested_str_weak(from_TLV),
@@ -1493,20 +1475,19 @@ be_local_closure(class_Matter_IM_process_write_request,   /* name */
     /* K17  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
     /* K18  */  be_nested_str_weak(INVALID_ACTION),
     /* K19  */  be_nested_str_weak(get_attribute_name),
-    /* K20  */  be_nested_str_weak(tasmota),
-    /* K21  */  be_nested_str_weak(log),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
-    /* K23  */  be_nested_str_weak(_X20_X28),
-    /* K24  */  be_nested_str_weak(_X29),
-    /* K25  */  be_nested_str_weak(),
-    /* K26  */  be_const_int(3),
-    /* K27  */  be_nested_str_weak(process_attribute_expansion),
-    /* K28  */  be_nested_str_weak(stop_iteration),
-    /* K29  */  be_nested_str_weak(send_write_response),
+    /* K20  */  be_nested_str_weak(log),
+    /* K21  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
+    /* K22  */  be_nested_str_weak(_X20_X28),
+    /* K23  */  be_nested_str_weak(_X29),
+    /* K24  */  be_nested_str_weak(),
+    /* K25  */  be_const_int(3),
+    /* K26  */  be_nested_str_weak(process_attribute_expansion),
+    /* K27  */  be_nested_str_weak(stop_iteration),
+    /* K28  */  be_nested_str_weak(send_write_response),
     }),
     be_str_weak(process_write_request),
     &be_const_str_solidified,
-    ( &(const binstruction[104]) {  /* code */
+    ( &(const binstruction[103]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x8C0C0701,  //  0001  GETMET	R3	R3	K1
       0x7C0C0200,  //  0002  CALL	R3	1
@@ -1525,7 +1506,7 @@ be_local_closure(class_Matter_IM_process_write_request,   /* name */
       0x88200708,  //  000F  GETMBR	R8	R3	K8
       0x4C240000,  //  0010  LDNIL	R9
       0x20201009,  //  0011  NE	R8	R8	R9
-      0x78220051,  //  0012  JMPF	R8	#0065
+      0x78220050,  //  0012  JMPF	R8	#0064
       0xB8220000,  //  0013  GETNGBL	R8	K0
       0x8C201109,  //  0014  GETMET	R8	R8	K9
       0x7C200200,  //  0015  CALL	R8	1
@@ -1535,7 +1516,7 @@ be_local_closure(class_Matter_IM_process_write_request,   /* name */
       0x60240010,  //  0019  GETGBL	R9	G16
       0x88280708,  //  001A  GETMBR	R10	R3	K8
       0x7C240200,  //  001B  CALL	R9	1
-      0xA802003D,  //  001C  EXBLK	0	#005B
+      0xA802003C,  //  001C  EXBLK	0	#005A
       0x5C281200,  //  001D  MOVE	R10	R9
       0x7C280000,  //  001E  CALL	R10	0
       0x882C150B,  //  001F  GETMBR	R11	R10	K11
@@ -1571,46 +1552,45 @@ be_local_closure(class_Matter_IM_process_write_request,   /* name */
       0x88340F0D,  //  003D  GETMBR	R13	R7	K13
       0x4C380000,  //  003E  LDNIL	R14
       0x1C341A0E,  //  003F  EQ	R13	R13	R14
-      0x78360012,  //  0040  JMPF	R13	#0054
+      0x78360011,  //  0040  JMPF	R13	#0053
       0xB8360000,  //  0041  GETNGBL	R13	K0
       0x8C341B13,  //  0042  GETMET	R13	R13	K19
       0x883C0F0E,  //  0043  GETMBR	R15	R7	K14
       0x88400F0F,  //  0044  GETMBR	R16	R7	K15
       0x7C340600,  //  0045  CALL	R13	3
       0xB83A2800,  //  0046  GETNGBL	R14	K20
-      0x8C381D15,  //  0047  GETMET	R14	R14	K21
-      0x60400008,  //  0048  GETGBL	R16	G8
-      0x5C440E00,  //  0049  MOVE	R17	R7
-      0x7C400200,  //  004A  CALL	R16	1
-      0x00422C10,  //  004B  ADD	R16	K22	R16
-      0x78360002,  //  004C  JMPF	R13	#0050
-      0x00462E0D,  //  004D  ADD	R17	K23	R13
-      0x00442318,  //  004E  ADD	R17	R17	K24
-      0x70020000,  //  004F  JMP		#0051
-      0x58440019,  //  0050  LDCONST	R17	K25
-      0x00402011,  //  0051  ADD	R16	R16	R17
-      0x5844001A,  //  0052  LDCONST	R17	K26
-      0x7C380600,  //  0053  CALL	R14	3
-      0x88340104,  //  0054  GETMBR	R13	R0	K4
-      0x8C341B1B,  //  0055  GETMET	R13	R13	K27
-      0x5C3C0E00,  //  0056  MOVE	R15	R7
-      0x84400001,  //  0057  CLOSURE	R16	P1
-      0x7C340600,  //  0058  CALL	R13	3
-      0xA0240000,  //  0059  CLOSE	R9
-      0x7001FFC1,  //  005A  JMP		#001D
-      0x5824001C,  //  005B  LDCONST	R9	K28
-      0xAC240200,  //  005C  CATCH	R9	1	0
-      0xB0080000,  //  005D  RAISE	2	R0	R0
-      0x5C240800,  //  005E  MOVE	R9	R4
-      0x74260003,  //  005F  JMPT	R9	#0064
-      0x8C24011D,  //  0060  GETMET	R9	R0	K29
-      0x5C2C0200,  //  0061  MOVE	R11	R1
-      0x5C301000,  //  0062  MOVE	R12	R8
-      0x7C240600,  //  0063  CALL	R9	3
-      0xA0200000,  //  0064  CLOSE	R8
-      0x50200200,  //  0065  LDBOOL	R8	1	0
-      0xA0000000,  //  0066  CLOSE	R0
-      0x80041000,  //  0067  RET	1	R8
+      0x603C0008,  //  0047  GETGBL	R15	G8
+      0x5C400E00,  //  0048  MOVE	R16	R7
+      0x7C3C0200,  //  0049  CALL	R15	1
+      0x003E2A0F,  //  004A  ADD	R15	K21	R15
+      0x78360002,  //  004B  JMPF	R13	#004F
+      0x00422C0D,  //  004C  ADD	R16	K22	R13
+      0x00402117,  //  004D  ADD	R16	R16	K23
+      0x70020000,  //  004E  JMP		#0050
+      0x58400018,  //  004F  LDCONST	R16	K24
+      0x003C1E10,  //  0050  ADD	R15	R15	R16
+      0x58400019,  //  0051  LDCONST	R16	K25
+      0x7C380400,  //  0052  CALL	R14	2
+      0x88340104,  //  0053  GETMBR	R13	R0	K4
+      0x8C341B1A,  //  0054  GETMET	R13	R13	K26
+      0x5C3C0E00,  //  0055  MOVE	R15	R7
+      0x84400001,  //  0056  CLOSURE	R16	P1
+      0x7C340600,  //  0057  CALL	R13	3
+      0xA0240000,  //  0058  CLOSE	R9
+      0x7001FFC2,  //  0059  JMP		#001D
+      0x5824001B,  //  005A  LDCONST	R9	K27
+      0xAC240200,  //  005B  CATCH	R9	1	0
+      0xB0080000,  //  005C  RAISE	2	R0	R0
+      0x5C240800,  //  005D  MOVE	R9	R4
+      0x74260003,  //  005E  JMPT	R9	#0063
+      0x8C24011C,  //  005F  GETMET	R9	R0	K28
+      0x5C2C0200,  //  0060  MOVE	R11	R1
+      0x5C301000,  //  0061  MOVE	R12	R8
+      0x7C240600,  //  0062  CALL	R9	3
+      0xA0200000,  //  0063  CLOSE	R8
+      0x50200200,  //  0064  LDBOOL	R8	1	0
+      0xA0000000,  //  0065  CLOSE	R0
+      0x80041000,  //  0066  RET	1	R8
     })
   )
 );
@@ -1769,7 +1749,7 @@ be_local_closure(class_Matter_IM_send_subscribe_update,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
+    ( &(const bvalue[24]) {     /* constants */
     /* K0   */  be_nested_str_weak(session),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(ReadRequestMessage),
@@ -1782,23 +1762,22 @@ be_local_closure(class_Matter_IM_send_subscribe_update,   /* name */
     /* K9   */  be_nested_str_weak(attribute),
     /* K10  */  be_nested_str_weak(push),
     /* K11  */  be_nested_str_weak(stop_iteration),
-    /* K12  */  be_nested_str_weak(tasmota),
-    /* K13  */  be_nested_str_weak(log),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Data_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
-    /* K15  */  be_nested_str_weak(local_session_id),
-    /* K16  */  be_nested_str_weak(subscription_id),
-    /* K17  */  be_const_int(3),
-    /* K18  */  be_nested_str_weak(is_keep_alive),
-    /* K19  */  be_nested_str_weak(_inner_process_read_request),
-    /* K20  */  be_nested_str_weak(suppress_response),
-    /* K21  */  be_nested_str_weak(IM_ReportDataSubscribed),
-    /* K22  */  be_nested_str_weak(_message_handler),
-    /* K23  */  be_nested_str_weak(send_queue),
-    /* K24  */  be_nested_str_weak(send_enqueued),
+    /* K12  */  be_nested_str_weak(log),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Data_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
+    /* K14  */  be_nested_str_weak(local_session_id),
+    /* K15  */  be_nested_str_weak(subscription_id),
+    /* K16  */  be_const_int(3),
+    /* K17  */  be_nested_str_weak(is_keep_alive),
+    /* K18  */  be_nested_str_weak(_inner_process_read_request),
+    /* K19  */  be_nested_str_weak(suppress_response),
+    /* K20  */  be_nested_str_weak(IM_ReportDataSubscribed),
+    /* K21  */  be_nested_str_weak(_message_handler),
+    /* K22  */  be_nested_str_weak(send_queue),
+    /* K23  */  be_nested_str_weak(send_enqueued),
     }),
     be_str_weak(send_subscribe_update),
     &be_const_str_solidified,
-    ( &(const binstruction[67]) {  /* code */
+    ( &(const binstruction[66]) {  /* code */
       0x88080300,  //  0000  GETMBR	R2	R1	K0
       0xB80E0200,  //  0001  GETNGBL	R3	K1
       0x8C0C0702,  //  0002  GETMET	R3	R3	K2
@@ -1832,40 +1811,39 @@ be_local_closure(class_Matter_IM_send_subscribe_update,   /* name */
       0xAC100200,  //  001E  CATCH	R4	1	0
       0xB0080000,  //  001F  RAISE	2	R0	R0
       0xB8121800,  //  0020  GETNGBL	R4	K12
-      0x8C10090D,  //  0021  GETMET	R4	R4	K13
-      0x60180018,  //  0022  GETGBL	R6	G24
-      0x581C000E,  //  0023  LDCONST	R7	K14
-      0x8820050F,  //  0024  GETMBR	R8	R2	K15
-      0x88240310,  //  0025  GETMBR	R9	R1	K16
-      0x7C180600,  //  0026  CALL	R6	3
-      0x581C0011,  //  0027  LDCONST	R7	K17
-      0x7C100600,  //  0028  CALL	R4	3
-      0x50100000,  //  0029  LDBOOL	R4	0	0
-      0x90062404,  //  002A  SETMBR	R1	K18	R4
-      0x8C100113,  //  002B  GETMET	R4	R0	K19
-      0x5C180400,  //  002C  MOVE	R6	R2
-      0x5C1C0600,  //  002D  MOVE	R7	R3
-      0x4C200000,  //  002E  LDNIL	R8
-      0x7C100800,  //  002F  CALL	R4	4
-      0x50140000,  //  0030  LDBOOL	R5	0	0
-      0x90122805,  //  0031  SETMBR	R4	K20	R5
-      0x88140310,  //  0032  GETMBR	R5	R1	K16
-      0x90122005,  //  0033  SETMBR	R4	K16	R5
-      0xB8160200,  //  0034  GETNGBL	R5	K1
-      0x8C140B15,  //  0035  GETMET	R5	R5	K21
-      0x881C0516,  //  0036  GETMBR	R7	R2	K22
-      0x5C200400,  //  0037  MOVE	R8	R2
-      0x5C240800,  //  0038  MOVE	R9	R4
-      0x5C280200,  //  0039  MOVE	R10	R1
-      0x7C140A00,  //  003A  CALL	R5	5
-      0x88180117,  //  003B  GETMBR	R6	R0	K23
-      0x8C180D0A,  //  003C  GETMET	R6	R6	K10
-      0x5C200A00,  //  003D  MOVE	R8	R5
-      0x7C180400,  //  003E  CALL	R6	2
-      0x8C180118,  //  003F  GETMET	R6	R0	K24
-      0x88200516,  //  0040  GETMBR	R8	R2	K22
-      0x7C180400,  //  0041  CALL	R6	2
-      0x80000000,  //  0042  RET	0
+      0x60140018,  //  0021  GETGBL	R5	G24
+      0x5818000D,  //  0022  LDCONST	R6	K13
+      0x881C050E,  //  0023  GETMBR	R7	R2	K14
+      0x8820030F,  //  0024  GETMBR	R8	R1	K15
+      0x7C140600,  //  0025  CALL	R5	3
+      0x58180010,  //  0026  LDCONST	R6	K16
+      0x7C100400,  //  0027  CALL	R4	2
+      0x50100000,  //  0028  LDBOOL	R4	0	0
+      0x90062204,  //  0029  SETMBR	R1	K17	R4
+      0x8C100112,  //  002A  GETMET	R4	R0	K18
+      0x5C180400,  //  002B  MOVE	R6	R2
+      0x5C1C0600,  //  002C  MOVE	R7	R3
+      0x4C200000,  //  002D  LDNIL	R8
+      0x7C100800,  //  002E  CALL	R4	4
+      0x50140000,  //  002F  LDBOOL	R5	0	0
+      0x90122605,  //  0030  SETMBR	R4	K19	R5
+      0x8814030F,  //  0031  GETMBR	R5	R1	K15
+      0x90121E05,  //  0032  SETMBR	R4	K15	R5
+      0xB8160200,  //  0033  GETNGBL	R5	K1
+      0x8C140B14,  //  0034  GETMET	R5	R5	K20
+      0x881C0515,  //  0035  GETMBR	R7	R2	K21
+      0x5C200400,  //  0036  MOVE	R8	R2
+      0x5C240800,  //  0037  MOVE	R9	R4
+      0x5C280200,  //  0038  MOVE	R10	R1
+      0x7C140A00,  //  0039  CALL	R5	5
+      0x88180116,  //  003A  GETMBR	R6	R0	K22
+      0x8C180D0A,  //  003B  GETMET	R6	R6	K10
+      0x5C200A00,  //  003C  MOVE	R8	R5
+      0x7C180400,  //  003D  CALL	R6	2
+      0x8C180117,  //  003E  GETMET	R6	R0	K23
+      0x88200515,  //  003F  GETMBR	R8	R2	K21
+      0x7C180400,  //  0040  CALL	R6	2
+      0x80000000,  //  0041  RET	0
     })
   )
 );
@@ -2218,7 +2196,7 @@ be_local_closure(class_Matter_IM_send_status,   /* name */
 extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM__inner_process_read_request,   /* name */
   be_nested_proto(
-    19,                          /* nstack */
+    18,                          /* nstack */
     5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2261,12 +2239,12 @@ be_local_closure(class_Matter_IM__inner_process_read_request,   /* name */
         /* K19  */  be_nested_str_weak(push),
         /* K20  */  be_nested_str_weak(val),
         /* K21  */  be_nested_str_weak(stop_iteration),
-        /* K22  */  be_nested_str_weak(tasmota),
-        /* K23  */  be_nested_str_weak(log),
-        /* K24  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
-        /* K25  */  be_nested_str_weak(local_session_id),
-        /* K26  */  be_const_int(3),
-        /* K27  */  be_nested_str_weak(attributestatus2raw),
+        /* K22  */  be_nested_str_weak(log),
+        /* K23  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
+        /* K24  */  be_nested_str_weak(local_session_id),
+        /* K25  */  be_const_int(3),
+        /* K26  */  be_nested_str_weak(attributestatus2raw),
+        /* K27  */  be_nested_str_weak(tasmota),
         /* K28  */  be_nested_str_weak(loglevel),
         /* K29  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
         /* K30  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
@@ -2277,7 +2255,7 @@ be_local_closure(class_Matter_IM__inner_process_read_request,   /* name */
         }),
         be_str_weak(read_single_attribute),
         &be_const_str_solidified,
-        ( &(const binstruction[238]) {  /* code */
+        ( &(const binstruction[235]) {  /* code */
           0xB8120000,  //  0000  GETNGBL	R4	K0
           0x88100901,  //  0001  GETMBR	R4	R4	K1
           0xB8160000,  //  0002  GETNGBL	R5	K0
@@ -2308,7 +2286,7 @@ be_local_closure(class_Matter_IM__inner_process_read_request,   /* name */
           0x4C200000,  //  001B  LDNIL	R8
           0x4C240000,  //  001C  LDNIL	R9
           0x20240C09,  //  001D  NE	R9	R6	R9
-          0x78260054,  //  001E  JMPF	R9	#0074
+          0x78260053,  //  001E  JMPF	R9	#0073
           0x58240007,  //  001F  LDCONST	R9	K7
           0x68280002,  //  0020  GETUPV	R10	U2
           0x742A0002,  //  0021  JMPT	R10	#0025
@@ -2380,142 +2358,139 @@ be_local_closure(class_Matter_IM__inner_process_read_request,   /* name */
           0x5C380C00,  //  0063  MOVE	R14	R6
           0x7C280800,  //  0064  CALL	R10	4
           0x68280002,  //  0065  GETUPV	R10	U2
-          0x742A000B,  //  0066  JMPT	R10	#0073
+          0x742A000A,  //  0066  JMPT	R10	#0072
           0xB82A2C00,  //  0067  GETNGBL	R10	K22
-          0x8C281517,  //  0068  GETMET	R10	R10	K23
-          0x60300018,  //  0069  GETGBL	R12	G24
-          0x58340018,  //  006A  LDCONST	R13	K24
-          0x68380000,  //  006B  GETUPV	R14	U0
-          0x88381D19,  //  006C  GETMBR	R14	R14	K25
-          0x5C3C0400,  //  006D  MOVE	R15	R2
-          0x5C400A00,  //  006E  MOVE	R16	R5
-          0x5C441200,  //  006F  MOVE	R17	R9
-          0x7C300A00,  //  0070  CALL	R12	5
-          0x5834001A,  //  0071  LDCONST	R13	K26
-          0x7C280600,  //  0072  CALL	R10	3
-          0x7002003B,  //  0073  JMP		#00B0
-          0x88240508,  //  0074  GETMBR	R9	R2	K8
-          0x4C280000,  //  0075  LDNIL	R10
-          0x2024120A,  //  0076  NE	R9	R9	R10
-          0x78260026,  //  0077  JMPF	R9	#009F
-          0x780E0024,  //  0078  JMPF	R3	#009E
-          0x60240015,  //  0079  GETGBL	R9	G21
-          0x542A002F,  //  007A  LDINT	R10	48
-          0x7C240200,  //  007B  CALL	R9	1
-          0x5C201200,  //  007C  MOVE	R8	R9
-          0x68240001,  //  007D  GETUPV	R9	U1
-          0x8C24131B,  //  007E  GETMET	R9	R9	K27
-          0x5C2C1000,  //  007F  MOVE	R11	R8
-          0x5C300400,  //  0080  MOVE	R12	R2
-          0x88340508,  //  0081  GETMBR	R13	R2	K8
-          0x7C240800,  //  0082  CALL	R9	4
-          0xB8262C00,  //  0083  GETNGBL	R9	K22
-          0x8C24131C,  //  0084  GETMET	R9	R9	K28
-          0x582C001A,  //  0085  LDCONST	R11	K26
-          0x7C240400,  //  0086  CALL	R9	2
-          0x78260015,  //  0087  JMPF	R9	#009E
-          0xB8262C00,  //  0088  GETNGBL	R9	K22
-          0x8C241317,  //  0089  GETMET	R9	R9	K23
-          0x602C0018,  //  008A  GETGBL	R11	G24
-          0x5830001D,  //  008B  LDCONST	R12	K29
-          0x68340000,  //  008C  GETUPV	R13	U0
-          0x88341B19,  //  008D  GETMBR	R13	R13	K25
-          0x60380008,  //  008E  GETGBL	R14	G8
-          0x5C3C0400,  //  008F  MOVE	R15	R2
-          0x7C380200,  //  0090  CALL	R14	1
-          0x5C3C0A00,  //  0091  MOVE	R15	R5
-          0x88400508,  //  0092  GETMBR	R16	R2	K8
-          0x88440508,  //  0093  GETMBR	R17	R2	K8
-          0xB84A0000,  //  0094  GETNGBL	R18	K0
-          0x8848251E,  //  0095  GETMBR	R18	R18	K30
-          0x1C442212,  //  0096  EQ	R17	R17	R18
-          0x78460001,  //  0097  JMPF	R17	#009A
-          0x5844001E,  //  0098  LDCONST	R17	K30
-          0x70020000,  //  0099  JMP		#009B
-          0x58440007,  //  009A  LDCONST	R17	K7
-          0x7C2C0C00,  //  009B  CALL	R11	6
-          0x5830001A,  //  009C  LDCONST	R12	K26
-          0x7C240600,  //  009D  CALL	R9	3
-          0x70020010,  //  009E  JMP		#00B0
-          0x68240002,  //  009F  GETUPV	R9	U2
-          0x7426000C,  //  00A0  JMPT	R9	#00AE
-          0xB8262C00,  //  00A1  GETNGBL	R9	K22
-          0x8C241317,  //  00A2  GETMET	R9	R9	K23
-          0x602C0018,  //  00A3  GETGBL	R11	G24
-          0x5830001F,  //  00A4  LDCONST	R12	K31
-          0x68340000,  //  00A5  GETUPV	R13	U0
-          0x88341B19,  //  00A6  GETMBR	R13	R13	K25
-          0x60380008,  //  00A7  GETGBL	R14	G8
-          0x5C3C0400,  //  00A8  MOVE	R15	R2
-          0x7C380200,  //  00A9  CALL	R14	1
-          0x5C3C0A00,  //  00AA  MOVE	R15	R5
-          0x7C2C0800,  //  00AB  CALL	R11	4
-          0x5830001A,  //  00AC  LDCONST	R12	K26
-          0x7C240600,  //  00AD  CALL	R9	3
-          0x780E0000,  //  00AE  JMPF	R3	#00B0
-          0x501C0000,  //  00AF  LDBOOL	R7	0	0
-          0x6024000F,  //  00B0  GETGBL	R9	G15
-          0x5C281000,  //  00B1  MOVE	R10	R8
-          0x602C0012,  //  00B2  GETGBL	R11	G18
-          0x7C240400,  //  00B3  CALL	R9	2
-          0x78260001,  //  00B4  JMPF	R9	#00B7
-          0x58240020,  //  00B5  LDCONST	R9	K32
-          0x70020000,  //  00B6  JMP		#00B8
-          0x4C240000,  //  00B7  LDNIL	R9
+          0x602C0018,  //  0068  GETGBL	R11	G24
+          0x58300017,  //  0069  LDCONST	R12	K23
+          0x68340000,  //  006A  GETUPV	R13	U0
+          0x88341B18,  //  006B  GETMBR	R13	R13	K24
+          0x5C380400,  //  006C  MOVE	R14	R2
+          0x5C3C0A00,  //  006D  MOVE	R15	R5
+          0x5C401200,  //  006E  MOVE	R16	R9
+          0x7C2C0A00,  //  006F  CALL	R11	5
+          0x58300019,  //  0070  LDCONST	R12	K25
+          0x7C280400,  //  0071  CALL	R10	2
+          0x70020039,  //  0072  JMP		#00AD
+          0x88240508,  //  0073  GETMBR	R9	R2	K8
+          0x4C280000,  //  0074  LDNIL	R10
+          0x2024120A,  //  0075  NE	R9	R9	R10
+          0x78260025,  //  0076  JMPF	R9	#009D
+          0x780E0023,  //  0077  JMPF	R3	#009C
+          0x60240015,  //  0078  GETGBL	R9	G21
+          0x542A002F,  //  0079  LDINT	R10	48
+          0x7C240200,  //  007A  CALL	R9	1
+          0x5C201200,  //  007B  MOVE	R8	R9
+          0x68240001,  //  007C  GETUPV	R9	U1
+          0x8C24131A,  //  007D  GETMET	R9	R9	K26
+          0x5C2C1000,  //  007E  MOVE	R11	R8
+          0x5C300400,  //  007F  MOVE	R12	R2
+          0x88340508,  //  0080  GETMBR	R13	R2	K8
+          0x7C240800,  //  0081  CALL	R9	4
+          0xB8263600,  //  0082  GETNGBL	R9	K27
+          0x8C24131C,  //  0083  GETMET	R9	R9	K28
+          0x582C0019,  //  0084  LDCONST	R11	K25
+          0x7C240400,  //  0085  CALL	R9	2
+          0x78260014,  //  0086  JMPF	R9	#009C
+          0xB8262C00,  //  0087  GETNGBL	R9	K22
+          0x60280018,  //  0088  GETGBL	R10	G24
+          0x582C001D,  //  0089  LDCONST	R11	K29
+          0x68300000,  //  008A  GETUPV	R12	U0
+          0x88301918,  //  008B  GETMBR	R12	R12	K24
+          0x60340008,  //  008C  GETGBL	R13	G8
+          0x5C380400,  //  008D  MOVE	R14	R2
+          0x7C340200,  //  008E  CALL	R13	1
+          0x5C380A00,  //  008F  MOVE	R14	R5
+          0x883C0508,  //  0090  GETMBR	R15	R2	K8
+          0x88400508,  //  0091  GETMBR	R16	R2	K8
+          0xB8460000,  //  0092  GETNGBL	R17	K0
+          0x8844231E,  //  0093  GETMBR	R17	R17	K30
+          0x1C402011,  //  0094  EQ	R16	R16	R17
+          0x78420001,  //  0095  JMPF	R16	#0098
+          0x5840001E,  //  0096  LDCONST	R16	K30
+          0x70020000,  //  0097  JMP		#0099
+          0x58400007,  //  0098  LDCONST	R16	K7
+          0x7C280C00,  //  0099  CALL	R10	6
+          0x582C0019,  //  009A  LDCONST	R11	K25
+          0x7C240400,  //  009B  CALL	R9	2
+          0x7002000F,  //  009C  JMP		#00AD
+          0x68240002,  //  009D  GETUPV	R9	U2
+          0x7426000B,  //  009E  JMPT	R9	#00AB
+          0xB8262C00,  //  009F  GETNGBL	R9	K22
+          0x60280018,  //  00A0  GETGBL	R10	G24
+          0x582C001F,  //  00A1  LDCONST	R11	K31
+          0x68300000,  //  00A2  GETUPV	R12	U0
+          0x88301918,  //  00A3  GETMBR	R12	R12	K24
+          0x60340008,  //  00A4  GETGBL	R13	G8
+          0x5C380400,  //  00A5  MOVE	R14	R2
+          0x7C340200,  //  00A6  CALL	R13	1
+          0x5C380A00,  //  00A7  MOVE	R14	R5
+          0x7C280800,  //  00A8  CALL	R10	4
+          0x582C0019,  //  00A9  LDCONST	R11	K25
+          0x7C240400,  //  00AA  CALL	R9	2
+          0x780E0000,  //  00AB  JMPF	R3	#00AD
+          0x501C0000,  //  00AC  LDBOOL	R7	0	0
+          0x6024000F,  //  00AD  GETGBL	R9	G15
+          0x5C281000,  //  00AE  MOVE	R10	R8
+          0x602C0012,  //  00AF  GETGBL	R11	G18
+          0x7C240400,  //  00B0  CALL	R9	2
+          0x78260001,  //  00B1  JMPF	R9	#00B4
+          0x58240020,  //  00B2  LDCONST	R9	K32
+          0x70020000,  //  00B3  JMP		#00B5
+          0x4C240000,  //  00B4  LDNIL	R9
+          0x4C280000,  //  00B5  LDNIL	R10
+          0x2028100A,  //  00B6  NE	R10	R8	R10
+          0x782A0031,  //  00B7  JMPF	R10	#00EA
           0x4C280000,  //  00B8  LDNIL	R10
-          0x2028100A,  //  00B9  NE	R10	R8	R10
-          0x782A0031,  //  00BA  JMPF	R10	#00ED
-          0x4C280000,  //  00BB  LDNIL	R10
-          0x1C28120A,  //  00BC  EQ	R10	R9	R10
-          0x782A0001,  //  00BD  JMPF	R10	#00C0
-          0x5C281000,  //  00BE  MOVE	R10	R8
-          0x70020000,  //  00BF  JMP		#00C1
-          0x94281009,  //  00C0  GETIDX	R10	R8	R9
-          0x602C000C,  //  00C1  GETGBL	R11	G12
-          0x88300121,  //  00C2  GETMBR	R12	R0	K33
-          0x7C2C0200,  //  00C3  CALL	R11	1
-          0x1C2C1720,  //  00C4  EQ	R11	R11	K32
-          0x782E0004,  //  00C5  JMPF	R11	#00CB
-          0x882C0121,  //  00C6  GETMBR	R11	R0	K33
-          0x8C2C1713,  //  00C7  GETMET	R11	R11	K19
-          0x5C341400,  //  00C8  MOVE	R13	R10
-          0x7C2C0400,  //  00C9  CALL	R11	2
-          0x70020014,  //  00CA  JMP		#00E0
-          0x882C0121,  //  00CB  GETMBR	R11	R0	K33
-          0x5431FFFE,  //  00CC  LDINT	R12	-1
-          0x942C160C,  //  00CD  GETIDX	R11	R11	R12
-          0x6030000C,  //  00CE  GETGBL	R12	G12
-          0x5C341600,  //  00CF  MOVE	R13	R11
-          0x7C300200,  //  00D0  CALL	R12	1
-          0x6034000C,  //  00D1  GETGBL	R13	G12
-          0x5C381400,  //  00D2  MOVE	R14	R10
-          0x7C340200,  //  00D3  CALL	R13	1
-          0x0030180D,  //  00D4  ADD	R12	R12	R13
-          0xB8360000,  //  00D5  GETNGBL	R13	K0
-          0x88341B0F,  //  00D6  GETMBR	R13	R13	K15
-          0x88341B10,  //  00D7  GETMBR	R13	R13	K16
-          0x1830180D,  //  00D8  LE	R12	R12	R13
-          0x78320001,  //  00D9  JMPF	R12	#00DC
-          0x4030160A,  //  00DA  CONNECT	R12	R11	R10
-          0x70020003,  //  00DB  JMP		#00E0
-          0x88300121,  //  00DC  GETMBR	R12	R0	K33
-          0x8C301913,  //  00DD  GETMET	R12	R12	K19
-          0x5C381400,  //  00DE  MOVE	R14	R10
-          0x7C300400,  //  00DF  CALL	R12	2
-          0x4C2C0000,  //  00E0  LDNIL	R11
-          0x1C2C120B,  //  00E1  EQ	R11	R9	R11
-          0x782E0001,  //  00E2  JMPF	R11	#00E5
-          0x4C200000,  //  00E3  LDNIL	R8
-          0x70020006,  //  00E4  JMP		#00EC
-          0x00241322,  //  00E5  ADD	R9	R9	K34
-          0x602C000C,  //  00E6  GETGBL	R11	G12
-          0x5C301000,  //  00E7  MOVE	R12	R8
-          0x7C2C0200,  //  00E8  CALL	R11	1
-          0x282C120B,  //  00E9  GE	R11	R9	R11
-          0x782E0000,  //  00EA  JMPF	R11	#00EC
-          0x4C200000,  //  00EB  LDNIL	R8
-          0x7001FFCA,  //  00EC  JMP		#00B8
-          0x80040E00,  //  00ED  RET	1	R7
+          0x1C28120A,  //  00B9  EQ	R10	R9	R10
+          0x782A0001,  //  00BA  JMPF	R10	#00BD
+          0x5C281000,  //  00BB  MOVE	R10	R8
+          0x70020000,  //  00BC  JMP		#00BE
+          0x94281009,  //  00BD  GETIDX	R10	R8	R9
+          0x602C000C,  //  00BE  GETGBL	R11	G12
+          0x88300121,  //  00BF  GETMBR	R12	R0	K33
+          0x7C2C0200,  //  00C0  CALL	R11	1
+          0x1C2C1720,  //  00C1  EQ	R11	R11	K32
+          0x782E0004,  //  00C2  JMPF	R11	#00C8
+          0x882C0121,  //  00C3  GETMBR	R11	R0	K33
+          0x8C2C1713,  //  00C4  GETMET	R11	R11	K19
+          0x5C341400,  //  00C5  MOVE	R13	R10
+          0x7C2C0400,  //  00C6  CALL	R11	2
+          0x70020014,  //  00C7  JMP		#00DD
+          0x882C0121,  //  00C8  GETMBR	R11	R0	K33
+          0x5431FFFE,  //  00C9  LDINT	R12	-1
+          0x942C160C,  //  00CA  GETIDX	R11	R11	R12
+          0x6030000C,  //  00CB  GETGBL	R12	G12
+          0x5C341600,  //  00CC  MOVE	R13	R11
+          0x7C300200,  //  00CD  CALL	R12	1
+          0x6034000C,  //  00CE  GETGBL	R13	G12
+          0x5C381400,  //  00CF  MOVE	R14	R10
+          0x7C340200,  //  00D0  CALL	R13	1
+          0x0030180D,  //  00D1  ADD	R12	R12	R13
+          0xB8360000,  //  00D2  GETNGBL	R13	K0
+          0x88341B0F,  //  00D3  GETMBR	R13	R13	K15
+          0x88341B10,  //  00D4  GETMBR	R13	R13	K16
+          0x1830180D,  //  00D5  LE	R12	R12	R13
+          0x78320001,  //  00D6  JMPF	R12	#00D9
+          0x4030160A,  //  00D7  CONNECT	R12	R11	R10
+          0x70020003,  //  00D8  JMP		#00DD
+          0x88300121,  //  00D9  GETMBR	R12	R0	K33
+          0x8C301913,  //  00DA  GETMET	R12	R12	K19
+          0x5C381400,  //  00DB  MOVE	R14	R10
+          0x7C300400,  //  00DC  CALL	R12	2
+          0x4C2C0000,  //  00DD  LDNIL	R11
+          0x1C2C120B,  //  00DE  EQ	R11	R9	R11
+          0x782E0001,  //  00DF  JMPF	R11	#00E2
+          0x4C200000,  //  00E0  LDNIL	R8
+          0x70020006,  //  00E1  JMP		#00E9
+          0x00241322,  //  00E2  ADD	R9	R9	K34
+          0x602C000C,  //  00E3  GETGBL	R11	G12
+          0x5C301000,  //  00E4  MOVE	R12	R8
+          0x7C2C0200,  //  00E5  CALL	R11	1
+          0x282C120B,  //  00E6  GE	R11	R9	R11
+          0x782E0000,  //  00E7  JMPF	R11	#00E9
+          0x4C200000,  //  00E8  LDNIL	R8
+          0x7001FFCA,  //  00E9  JMP		#00B5
+          0x80040E00,  //  00EA  RET	1	R7
         })
       ),
       be_nested_proto(
@@ -2546,7 +2521,7 @@ be_local_closure(class_Matter_IM__inner_process_read_request,   /* name */
     &be_class_Matter_IM, 
     }),
     1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
+    ( &(const bvalue[24]) {     /* constants */
     /* K0   */  be_nested_str_weak(device),
     /* K1   */  be_nested_str_weak(get_active_endpoints),
     /* K2   */  be_nested_str_weak(matter),
@@ -2562,20 +2537,19 @@ be_local_closure(class_Matter_IM__inner_process_read_request,   /* name */
     /* K12  */  be_nested_str_weak(status),
     /* K13  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
     /* K14  */  be_nested_str_weak(get_attribute_name),
-    /* K15  */  be_nested_str_weak(tasmota),
-    /* K16  */  be_nested_str_weak(log),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s),
-    /* K18  */  be_nested_str_weak(local_session_id),
-    /* K19  */  be_nested_str_weak(_X20_X28),
-    /* K20  */  be_nested_str_weak(_X29),
-    /* K21  */  be_nested_str_weak(),
-    /* K22  */  be_const_int(3),
-    /* K23  */  be_nested_str_weak(process_attribute_expansion),
-    /* K24  */  be_nested_str_weak(stop_iteration),
+    /* K15  */  be_nested_str_weak(log),
+    /* K16  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s),
+    /* K17  */  be_nested_str_weak(local_session_id),
+    /* K18  */  be_nested_str_weak(_X20_X28),
+    /* K19  */  be_nested_str_weak(_X29),
+    /* K20  */  be_nested_str_weak(),
+    /* K21  */  be_const_int(3),
+    /* K22  */  be_nested_str_weak(process_attribute_expansion),
+    /* K23  */  be_nested_str_weak(stop_iteration),
     }),
     be_str_weak(_inner_process_read_request),
     &be_const_str_solidified,
-    ( &(const binstruction[96]) {  /* code */
+    ( &(const binstruction[94]) {  /* code */
       0x84140000,  //  0000  CLOSURE	R5	P0
       0x88180100,  //  0001  GETMBR	R6	R0	K0
       0x8C180D01,  //  0002  GETMET	R6	R6	K1
@@ -2593,7 +2567,7 @@ be_local_closure(class_Matter_IM__inner_process_read_request,   /* name */
       0x60240010,  //  000E  GETGBL	R9	G16
       0x88280507,  //  000F  GETMBR	R10	R2	K7
       0x7C240200,  //  0010  CALL	R9	1
-      0xA8020048,  //  0011  EXBLK	0	#005B
+      0xA8020046,  //  0011  EXBLK	0	#0059
       0x5C281200,  //  0012  MOVE	R10	R9
       0x7C280000,  //  0013  CALL	R10	0
       0x882C1508,  //  0014  GETMBR	R11	R10	K8
@@ -2618,60 +2592,58 @@ be_local_closure(class_Matter_IM__inner_process_read_request,   /* name */
       0x882C0F0A,  //  0027  GETMBR	R11	R7	K10
       0x4C300000,  //  0028  LDNIL	R12
       0x1C2C160C,  //  0029  EQ	R11	R11	R12
-      0x782E0029,  //  002A  JMPF	R11	#0055
+      0x782E0027,  //  002A  JMPF	R11	#0053
       0x882C0F09,  //  002B  GETMBR	R11	R7	K9
       0x4C300000,  //  002C  LDNIL	R12
       0x202C160C,  //  002D  NE	R11	R11	R12
-      0x782E001A,  //  002E  JMPF	R11	#004A
+      0x782E0019,  //  002E  JMPF	R11	#0049
       0x882C0F0A,  //  002F  GETMBR	R11	R7	K10
       0x4C300000,  //  0030  LDNIL	R12
       0x202C160C,  //  0031  NE	R11	R11	R12
-      0x782E0016,  //  0032  JMPF	R11	#004A
+      0x782E0015,  //  0032  JMPF	R11	#0049
       0xB82E0400,  //  0033  GETNGBL	R11	K2
       0x8C2C170E,  //  0034  GETMET	R11	R11	K14
       0x88340F09,  //  0035  GETMBR	R13	R7	K9
       0x88380F0A,  //  0036  GETMBR	R14	R7	K10
       0x7C2C0600,  //  0037  CALL	R11	3
       0xB8321E00,  //  0038  GETNGBL	R12	K15
-      0x8C301910,  //  0039  GETMET	R12	R12	K16
-      0x60380018,  //  003A  GETGBL	R14	G24
-      0x583C0011,  //  003B  LDCONST	R15	K17
-      0x88400312,  //  003C  GETMBR	R16	R1	K18
-      0x60440008,  //  003D  GETGBL	R17	G8
-      0x5C480E00,  //  003E  MOVE	R18	R7
-      0x7C440200,  //  003F  CALL	R17	1
-      0x782E0002,  //  0040  JMPF	R11	#0044
-      0x004A260B,  //  0041  ADD	R18	K19	R11
-      0x00482514,  //  0042  ADD	R18	R18	K20
-      0x70020000,  //  0043  JMP		#0045
-      0x58480015,  //  0044  LDCONST	R18	K21
-      0x00442212,  //  0045  ADD	R17	R17	R18
-      0x7C380600,  //  0046  CALL	R14	3
-      0x583C0016,  //  0047  LDCONST	R15	K22
-      0x7C300600,  //  0048  CALL	R12	3
-      0x7002000A,  //  0049  JMP		#0055
-      0xB82E1E00,  //  004A  GETNGBL	R11	K15
-      0x8C2C1710,  //  004B  GETMET	R11	R11	K16
-      0x60340018,  //  004C  GETGBL	R13	G24
-      0x58380011,  //  004D  LDCONST	R14	K17
-      0x883C0312,  //  004E  GETMBR	R15	R1	K18
-      0x60400008,  //  004F  GETGBL	R16	G8
-      0x5C440E00,  //  0050  MOVE	R17	R7
-      0x7C400200,  //  0051  CALL	R16	1
-      0x7C340600,  //  0052  CALL	R13	3
-      0x58380016,  //  0053  LDCONST	R14	K22
-      0x7C2C0600,  //  0054  CALL	R11	3
-      0x882C0100,  //  0055  GETMBR	R11	R0	K0
-      0x8C2C1717,  //  0056  GETMET	R11	R11	K23
-      0x5C340E00,  //  0057  MOVE	R13	R7
-      0x84380001,  //  0058  CLOSURE	R14	P1
-      0x7C2C0600,  //  0059  CALL	R11	3
-      0x7001FFB6,  //  005A  JMP		#0012
-      0x58240018,  //  005B  LDCONST	R9	K24
-      0xAC240200,  //  005C  CATCH	R9	1	0
-      0xB0080000,  //  005D  RAISE	2	R0	R0
-      0xA0000000,  //  005E  CLOSE	R0
-      0x80041000,  //  005F  RET	1	R8
+      0x60340018,  //  0039  GETGBL	R13	G24
+      0x58380010,  //  003A  LDCONST	R14	K16
+      0x883C0311,  //  003B  GETMBR	R15	R1	K17
+      0x60400008,  //  003C  GETGBL	R16	G8
+      0x5C440E00,  //  003D  MOVE	R17	R7
+      0x7C400200,  //  003E  CALL	R16	1
+      0x782E0002,  //  003F  JMPF	R11	#0043
+      0x0046240B,  //  0040  ADD	R17	K18	R11
+      0x00442313,  //  0041  ADD	R17	R17	K19
+      0x70020000,  //  0042  JMP		#0044
+      0x58440014,  //  0043  LDCONST	R17	K20
+      0x00402011,  //  0044  ADD	R16	R16	R17
+      0x7C340600,  //  0045  CALL	R13	3
+      0x58380015,  //  0046  LDCONST	R14	K21
+      0x7C300400,  //  0047  CALL	R12	2
+      0x70020009,  //  0048  JMP		#0053
+      0xB82E1E00,  //  0049  GETNGBL	R11	K15
+      0x60300018,  //  004A  GETGBL	R12	G24
+      0x58340010,  //  004B  LDCONST	R13	K16
+      0x88380311,  //  004C  GETMBR	R14	R1	K17
+      0x603C0008,  //  004D  GETGBL	R15	G8
+      0x5C400E00,  //  004E  MOVE	R16	R7
+      0x7C3C0200,  //  004F  CALL	R15	1
+      0x7C300600,  //  0050  CALL	R12	3
+      0x58340015,  //  0051  LDCONST	R13	K21
+      0x7C2C0400,  //  0052  CALL	R11	2
+      0x882C0100,  //  0053  GETMBR	R11	R0	K0
+      0x8C2C1716,  //  0054  GETMET	R11	R11	K22
+      0x5C340E00,  //  0055  MOVE	R13	R7
+      0x84380001,  //  0056  CLOSURE	R14	P1
+      0x7C2C0600,  //  0057  CALL	R11	3
+      0x7001FFB8,  //  0058  JMP		#0012
+      0x58240017,  //  0059  LDCONST	R9	K23
+      0xAC240200,  //  005A  CATCH	R9	1	0
+      0xB0080000,  //  005B  RAISE	2	R0	R0
+      0xA0000000,  //  005C  CLOSE	R0
+      0x80041000,  //  005D  RET	1	R8
     })
   )
 );
@@ -2926,7 +2898,7 @@ be_local_closure(class_Matter_IM_find_sendqueue_by_exchangeid,   /* name */
 extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_process_read_request_solo,   /* name */
   be_nested_proto(
-    20,                          /* nstack */
+    19,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2953,26 +2925,26 @@ be_local_closure(class_Matter_IM_process_read_request_solo,   /* name */
     /* K15  */  be_nested_str_weak(encode_len),
     /* K16  */  be_nested_str_weak(IM_ReportData),
     /* K17  */  be_nested_str_weak(MAX_MESSAGE),
-    /* K18  */  be_nested_str_weak(tasmota),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Response_X20to_X20big_X2C_X20revert_X20to_X20non_X2Dsolo),
-    /* K20  */  be_const_int(3),
-    /* K21  */  be_nested_str_weak(TLV),
-    /* K22  */  be_nested_str_weak(parse),
-    /* K23  */  be_nested_str_weak(raw),
-    /* K24  */  be_nested_str_weak(app_payload_idx),
-    /* K25  */  be_nested_str_weak(process_read_request),
-    /* K26  */  be_nested_str_weak(add),
-    /* K27  */  be_const_int(1),
-    /* K28  */  be_nested_str_weak(attributedata2raw),
-    /* K29  */  be_const_int(405077761),
-    /* K30  */  be_nested_str_weak(attributestatus2raw),
-    /* K31  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X20_X2D_X20IGNORED),
-    /* K32  */  be_nested_str_weak(local_session_id),
-    /* K33  */  be_nested_str_weak(build_response),
-    /* K34  */  be_nested_str_weak(message_handler),
-    /* K35  */  be_nested_str_weak(clear),
-    /* K36  */  be_nested_str_weak(encode_frame),
-    /* K37  */  be_nested_str_weak(encrypt),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Response_X20to_X20big_X2C_X20revert_X20to_X20non_X2Dsolo),
+    /* K19  */  be_const_int(3),
+    /* K20  */  be_nested_str_weak(TLV),
+    /* K21  */  be_nested_str_weak(parse),
+    /* K22  */  be_nested_str_weak(raw),
+    /* K23  */  be_nested_str_weak(app_payload_idx),
+    /* K24  */  be_nested_str_weak(process_read_request),
+    /* K25  */  be_nested_str_weak(add),
+    /* K26  */  be_const_int(1),
+    /* K27  */  be_nested_str_weak(attributedata2raw),
+    /* K28  */  be_const_int(405077761),
+    /* K29  */  be_nested_str_weak(attributestatus2raw),
+    /* K30  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X20_X2D_X20IGNORED),
+    /* K31  */  be_nested_str_weak(local_session_id),
+    /* K32  */  be_nested_str_weak(build_response),
+    /* K33  */  be_nested_str_weak(message_handler),
+    /* K34  */  be_nested_str_weak(clear),
+    /* K35  */  be_nested_str_weak(encode_frame),
+    /* K36  */  be_nested_str_weak(encrypt),
+    /* K37  */  be_nested_str_weak(tasmota),
     /* K38  */  be_nested_str_weak(loglevel),
     /* K39  */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25i_X20exch_X3D_X25i_X20rack_X3D_X25s),
     /* K40  */  be_nested_str_weak(message_counter),
@@ -2993,7 +2965,7 @@ be_local_closure(class_Matter_IM_process_read_request_solo,   /* name */
     }),
     be_str_weak(process_read_request_solo),
     &be_const_str_solidified,
-    ( &(const binstruction[251]) {  /* code */
+    ( &(const binstruction[245]) {  /* code */
       0xB80E0200,  //  0000  GETNGBL	R3	K1
       0x880C0702,  //  0001  GETMBR	R3	R3	K2
       0x900A0003,  //  0002  SETMBR	R2	K0	R3
@@ -3023,228 +2995,222 @@ be_local_closure(class_Matter_IM_process_read_request_solo,   /* name */
       0x7C180400,  //  001A  CALL	R6	2
       0x4C180000,  //  001B  LDNIL	R6
       0x20180806,  //  001C  NE	R6	R4	R6
-      0x781A0037,  //  001D  JMPF	R6	#0056
+      0x781A0036,  //  001D  JMPF	R6	#0055
       0x8818090D,  //  001E  GETMBR	R6	R4	K13
       0x741A0001,  //  001F  JMPT	R6	#0022
       0x8818090E,  //  0020  GETMBR	R6	R4	K14
-      0x781A0019,  //  0021  JMPF	R6	#003C
+      0x781A0018,  //  0021  JMPF	R6	#003B
       0x8C18090F,  //  0022  GETMET	R6	R4	K15
       0x7C180200,  //  0023  CALL	R6	1
       0xB81E0200,  //  0024  GETNGBL	R7	K1
       0x881C0F10,  //  0025  GETMBR	R7	R7	K16
       0x881C0F11,  //  0026  GETMBR	R7	R7	K17
       0x24180C07,  //  0027  GT	R6	R6	R7
-      0x781A0012,  //  0028  JMPF	R6	#003C
+      0x781A0011,  //  0028  JMPF	R6	#003B
       0x4C100000,  //  0029  LDNIL	R4
-      0xB81A2400,  //  002A  GETNGBL	R6	K18
-      0x8C180D0B,  //  002B  GETMET	R6	R6	K11
-      0x60200018,  //  002C  GETGBL	R8	G24
-      0x58240013,  //  002D  LDCONST	R9	K19
-      0x7C200200,  //  002E  CALL	R8	1
-      0x58240014,  //  002F  LDCONST	R9	K20
-      0x7C180600,  //  0030  CALL	R6	3
-      0xB81A0200,  //  0031  GETNGBL	R6	K1
-      0x88180D15,  //  0032  GETMBR	R6	R6	K21
-      0x8C180D16,  //  0033  GETMET	R6	R6	K22
-      0x88200317,  //  0034  GETMBR	R8	R1	K23
-      0x88240318,  //  0035  GETMBR	R9	R1	K24
-      0x7C180600,  //  0036  CALL	R6	3
-      0x8C1C0119,  //  0037  GETMET	R7	R0	K25
-      0x5C240200,  //  0038  MOVE	R9	R1
-      0x5C280C00,  //  0039  MOVE	R10	R6
-      0x7C1C0600,  //  003A  CALL	R7	3
-      0x80040E00,  //  003B  RET	1	R7
-      0x60180015,  //  003C  GETGBL	R6	G21
-      0x541E002F,  //  003D  LDINT	R7	48
-      0x7C180200,  //  003E  CALL	R6	1
-      0x5C140C00,  //  003F  MOVE	R5	R6
-      0x8C180B1A,  //  0040  GETMET	R6	R5	K26
-      0x54220014,  //  0041  LDINT	R8	21
-      0x5824001B,  //  0042  LDCONST	R9	K27
-      0x7C180600,  //  0043  CALL	R6	3
-      0x8C180B1A,  //  0044  GETMET	R6	R5	K26
-      0x54223600,  //  0045  LDINT	R8	13825
-      0x5425FFFD,  //  0046  LDINT	R9	-2
-      0x7C180600,  //  0047  CALL	R6	3
-      0x8C18011C,  //  0048  GETMET	R6	R0	K28
-      0x5C200A00,  //  0049  MOVE	R8	R5
-      0x5C240400,  //  004A  MOVE	R9	R2
-      0x5C280800,  //  004B  MOVE	R10	R4
-      0x7C180800,  //  004C  CALL	R6	4
-      0x8C180B1A,  //  004D  GETMET	R6	R5	K26
-      0x5820001D,  //  004E  LDCONST	R8	K29
-      0x5425FFFB,  //  004F  LDINT	R9	-4
-      0x7C180600,  //  0050  CALL	R6	3
-      0x8C180B1A,  //  0051  GETMET	R6	R5	K26
-      0x54220017,  //  0052  LDINT	R8	24
-      0x5824001B,  //  0053  LDCONST	R9	K27
-      0x7C180600,  //  0054  CALL	R6	3
-      0x70020029,  //  0055  JMP		#0080
-      0x88180500,  //  0056  GETMBR	R6	R2	K0
-      0x4C1C0000,  //  0057  LDNIL	R7
-      0x20180C07,  //  0058  NE	R6	R6	R7
-      0x781A0019,  //  0059  JMPF	R6	#0074
-      0x60180015,  //  005A  GETGBL	R6	G21
-      0x541E002F,  //  005B  LDINT	R7	48
-      0x7C180200,  //  005C  CALL	R6	1
-      0x5C140C00,  //  005D  MOVE	R5	R6
-      0x8C180B1A,  //  005E  GETMET	R6	R5	K26
-      0x54220014,  //  005F  LDINT	R8	21
-      0x5824001B,  //  0060  LDCONST	R9	K27
-      0x7C180600,  //  0061  CALL	R6	3
-      0x8C180B1A,  //  0062  GETMET	R6	R5	K26
-      0x54223600,  //  0063  LDINT	R8	13825
-      0x5425FFFD,  //  0064  LDINT	R9	-2
-      0x7C180600,  //  0065  CALL	R6	3
-      0x8C18011E,  //  0066  GETMET	R6	R0	K30
-      0x5C200A00,  //  0067  MOVE	R8	R5
-      0x5C240400,  //  0068  MOVE	R9	R2
-      0x88280500,  //  0069  GETMBR	R10	R2	K0
-      0x7C180800,  //  006A  CALL	R6	4
-      0x8C180B1A,  //  006B  GETMET	R6	R5	K26
-      0x5820001D,  //  006C  LDCONST	R8	K29
-      0x5425FFFB,  //  006D  LDINT	R9	-4
-      0x7C180600,  //  006E  CALL	R6	3
-      0x8C180B1A,  //  006F  GETMET	R6	R5	K26
-      0x54220017,  //  0070  LDINT	R8	24
-      0x5824001B,  //  0071  LDCONST	R9	K27
-      0x7C180600,  //  0072  CALL	R6	3
-      0x7002000B,  //  0073  JMP		#0080
-      0xB81A2400,  //  0074  GETNGBL	R6	K18
-      0x8C180D0B,  //  0075  GETMET	R6	R6	K11
-      0x60200018,  //  0076  GETGBL	R8	G24
-      0x5824001F,  //  0077  LDCONST	R9	K31
-      0x88280308,  //  0078  GETMBR	R10	R1	K8
-      0x88281520,  //  0079  GETMBR	R10	R10	K32
-      0x5C2C0400,  //  007A  MOVE	R11	R2
-      0x7C200600,  //  007B  CALL	R8	3
-      0x58240014,  //  007C  LDCONST	R9	K20
-      0x7C180600,  //  007D  CALL	R6	3
-      0x50180000,  //  007E  LDBOOL	R6	0	0
-      0x80040C00,  //  007F  RET	1	R6
-      0x8C180321,  //  0080  GETMET	R6	R1	K33
-      0x54220004,  //  0081  LDINT	R8	5
-      0x50240200,  //  0082  LDBOOL	R9	1	0
-      0x7C180600,  //  0083  CALL	R6	3
-      0x881C0104,  //  0084  GETMBR	R7	R0	K4
-      0x881C0F22,  //  0085  GETMBR	R7	R7	K34
-      0x88200317,  //  0086  GETMBR	R8	R1	K23
-      0x8C241123,  //  0087  GETMET	R9	R8	K35
-      0x7C240200,  //  0088  CALL	R9	1
-      0x8C240D24,  //  0089  GETMET	R9	R6	K36
-      0x5C2C0A00,  //  008A  MOVE	R11	R5
-      0x5C301000,  //  008B  MOVE	R12	R8
-      0x7C240600,  //  008C  CALL	R9	3
-      0x8C240D25,  //  008D  GETMET	R9	R6	K37
-      0x7C240200,  //  008E  CALL	R9	1
-      0xB8262400,  //  008F  GETNGBL	R9	K18
-      0x8C241326,  //  0090  GETMET	R9	R9	K38
-      0x542E0003,  //  0091  LDINT	R11	4
-      0x7C240400,  //  0092  CALL	R9	2
-      0x7826000B,  //  0093  JMPF	R9	#00A0
-      0xB8262400,  //  0094  GETNGBL	R9	K18
-      0x8C24130B,  //  0095  GETMET	R9	R9	K11
-      0x602C0018,  //  0096  GETGBL	R11	G24
-      0x58300027,  //  0097  LDCONST	R12	K39
-      0x88340D08,  //  0098  GETMBR	R13	R6	K8
-      0x88341B20,  //  0099  GETMBR	R13	R13	K32
-      0x88380D28,  //  009A  GETMBR	R14	R6	K40
-      0x883C0D29,  //  009B  GETMBR	R15	R6	K41
-      0x88400D2A,  //  009C  GETMBR	R16	R6	K42
-      0x7C2C0A00,  //  009D  CALL	R11	5
-      0x54320003,  //  009E  LDINT	R12	4
-      0x7C240600,  //  009F  CALL	R9	3
-      0x8C240F2B,  //  00A0  GETMET	R9	R7	K43
-      0x5C2C0C00,  //  00A1  MOVE	R11	R6
-      0x7C240400,  //  00A2  CALL	R9	2
-      0xB8260200,  //  00A3  GETNGBL	R9	K1
-      0x8824130A,  //  00A4  GETMBR	R9	R9	K10
-      0x8C24130B,  //  00A5  GETMET	R9	R9	K11
-      0x582C002C,  //  00A6  LDCONST	R11	K44
-      0x7C240400,  //  00A7  CALL	R9	2
-      0xB8260200,  //  00A8  GETNGBL	R9	K1
-      0x8C24132D,  //  00A9  GETMET	R9	R9	K45
-      0x882C052E,  //  00AA  GETMBR	R11	R2	K46
-      0x8830052F,  //  00AB  GETMBR	R12	R2	K47
-      0x7C240600,  //  00AC  CALL	R9	3
-      0x78260002,  //  00AD  JMPF	R9	#00B1
-      0x002A6009,  //  00AE  ADD	R10	K48	R9
-      0x00281531,  //  00AF  ADD	R10	R10	K49
-      0x70020000,  //  00B0  JMP		#00B2
-      0x58280032,  //  00B1  LDCONST	R10	K50
-      0x5C241400,  //  00B2  MOVE	R9	R10
-      0x4C280000,  //  00B3  LDNIL	R10
-      0x2028080A,  //  00B4  NE	R10	R4	R10
-      0x782A0013,  //  00B5  JMPF	R10	#00CA
-      0xB82A2400,  //  00B6  GETNGBL	R10	K18
-      0x8C281526,  //  00B7  GETMET	R10	R10	K38
-      0x58300014,  //  00B8  LDCONST	R12	K20
-      0x7C280400,  //  00B9  CALL	R10	2
-      0x782A000D,  //  00BA  JMPF	R10	#00C9
-      0x8C280933,  //  00BB  GETMET	R10	R4	K51
-      0x7C280200,  //  00BC  CALL	R10	1
-      0xB82E2400,  //  00BD  GETNGBL	R11	K18
-      0x8C2C170B,  //  00BE  GETMET	R11	R11	K11
-      0x60340018,  //  00BF  GETGBL	R13	G24
-      0x58380034,  //  00C0  LDCONST	R14	K52
-      0x883C0308,  //  00C1  GETMBR	R15	R1	K8
-      0x883C1F20,  //  00C2  GETMBR	R15	R15	K32
-      0x5C400400,  //  00C3  MOVE	R16	R2
-      0x5C441200,  //  00C4  MOVE	R17	R9
-      0x5C481400,  //  00C5  MOVE	R18	R10
-      0x7C340A00,  //  00C6  CALL	R13	5
-      0x58380014,  //  00C7  LDCONST	R14	K20
-      0x7C2C0600,  //  00C8  CALL	R11	3
-      0x7002002E,  //  00C9  JMP		#00F9
+      0xB81A1600,  //  002A  GETNGBL	R6	K11
+      0x601C0018,  //  002B  GETGBL	R7	G24
+      0x58200012,  //  002C  LDCONST	R8	K18
+      0x7C1C0200,  //  002D  CALL	R7	1
+      0x58200013,  //  002E  LDCONST	R8	K19
+      0x7C180400,  //  002F  CALL	R6	2
+      0xB81A0200,  //  0030  GETNGBL	R6	K1
+      0x88180D14,  //  0031  GETMBR	R6	R6	K20
+      0x8C180D15,  //  0032  GETMET	R6	R6	K21
+      0x88200316,  //  0033  GETMBR	R8	R1	K22
+      0x88240317,  //  0034  GETMBR	R9	R1	K23
+      0x7C180600,  //  0035  CALL	R6	3
+      0x8C1C0118,  //  0036  GETMET	R7	R0	K24
+      0x5C240200,  //  0037  MOVE	R9	R1
+      0x5C280C00,  //  0038  MOVE	R10	R6
+      0x7C1C0600,  //  0039  CALL	R7	3
+      0x80040E00,  //  003A  RET	1	R7
+      0x60180015,  //  003B  GETGBL	R6	G21
+      0x541E002F,  //  003C  LDINT	R7	48
+      0x7C180200,  //  003D  CALL	R6	1
+      0x5C140C00,  //  003E  MOVE	R5	R6
+      0x8C180B19,  //  003F  GETMET	R6	R5	K25
+      0x54220014,  //  0040  LDINT	R8	21
+      0x5824001A,  //  0041  LDCONST	R9	K26
+      0x7C180600,  //  0042  CALL	R6	3
+      0x8C180B19,  //  0043  GETMET	R6	R5	K25
+      0x54223600,  //  0044  LDINT	R8	13825
+      0x5425FFFD,  //  0045  LDINT	R9	-2
+      0x7C180600,  //  0046  CALL	R6	3
+      0x8C18011B,  //  0047  GETMET	R6	R0	K27
+      0x5C200A00,  //  0048  MOVE	R8	R5
+      0x5C240400,  //  0049  MOVE	R9	R2
+      0x5C280800,  //  004A  MOVE	R10	R4
+      0x7C180800,  //  004B  CALL	R6	4
+      0x8C180B19,  //  004C  GETMET	R6	R5	K25
+      0x5820001C,  //  004D  LDCONST	R8	K28
+      0x5425FFFB,  //  004E  LDINT	R9	-4
+      0x7C180600,  //  004F  CALL	R6	3
+      0x8C180B19,  //  0050  GETMET	R6	R5	K25
+      0x54220017,  //  0051  LDINT	R8	24
+      0x5824001A,  //  0052  LDCONST	R9	K26
+      0x7C180600,  //  0053  CALL	R6	3
+      0x70020028,  //  0054  JMP		#007E
+      0x88180500,  //  0055  GETMBR	R6	R2	K0
+      0x4C1C0000,  //  0056  LDNIL	R7
+      0x20180C07,  //  0057  NE	R6	R6	R7
+      0x781A0019,  //  0058  JMPF	R6	#0073
+      0x60180015,  //  0059  GETGBL	R6	G21
+      0x541E002F,  //  005A  LDINT	R7	48
+      0x7C180200,  //  005B  CALL	R6	1
+      0x5C140C00,  //  005C  MOVE	R5	R6
+      0x8C180B19,  //  005D  GETMET	R6	R5	K25
+      0x54220014,  //  005E  LDINT	R8	21
+      0x5824001A,  //  005F  LDCONST	R9	K26
+      0x7C180600,  //  0060  CALL	R6	3
+      0x8C180B19,  //  0061  GETMET	R6	R5	K25
+      0x54223600,  //  0062  LDINT	R8	13825
+      0x5425FFFD,  //  0063  LDINT	R9	-2
+      0x7C180600,  //  0064  CALL	R6	3
+      0x8C18011D,  //  0065  GETMET	R6	R0	K29
+      0x5C200A00,  //  0066  MOVE	R8	R5
+      0x5C240400,  //  0067  MOVE	R9	R2
+      0x88280500,  //  0068  GETMBR	R10	R2	K0
+      0x7C180800,  //  0069  CALL	R6	4
+      0x8C180B19,  //  006A  GETMET	R6	R5	K25
+      0x5820001C,  //  006B  LDCONST	R8	K28
+      0x5425FFFB,  //  006C  LDINT	R9	-4
+      0x7C180600,  //  006D  CALL	R6	3
+      0x8C180B19,  //  006E  GETMET	R6	R5	K25
+      0x54220017,  //  006F  LDINT	R8	24
+      0x5824001A,  //  0070  LDCONST	R9	K26
+      0x7C180600,  //  0071  CALL	R6	3
+      0x7002000A,  //  0072  JMP		#007E
+      0xB81A1600,  //  0073  GETNGBL	R6	K11
+      0x601C0018,  //  0074  GETGBL	R7	G24
+      0x5820001E,  //  0075  LDCONST	R8	K30
+      0x88240308,  //  0076  GETMBR	R9	R1	K8
+      0x8824131F,  //  0077  GETMBR	R9	R9	K31
+      0x5C280400,  //  0078  MOVE	R10	R2
+      0x7C1C0600,  //  0079  CALL	R7	3
+      0x58200013,  //  007A  LDCONST	R8	K19
+      0x7C180400,  //  007B  CALL	R6	2
+      0x50180000,  //  007C  LDBOOL	R6	0	0
+      0x80040C00,  //  007D  RET	1	R6
+      0x8C180320,  //  007E  GETMET	R6	R1	K32
+      0x54220004,  //  007F  LDINT	R8	5
+      0x50240200,  //  0080  LDBOOL	R9	1	0
+      0x7C180600,  //  0081  CALL	R6	3
+      0x881C0104,  //  0082  GETMBR	R7	R0	K4
+      0x881C0F21,  //  0083  GETMBR	R7	R7	K33
+      0x88200316,  //  0084  GETMBR	R8	R1	K22
+      0x8C241122,  //  0085  GETMET	R9	R8	K34
+      0x7C240200,  //  0086  CALL	R9	1
+      0x8C240D23,  //  0087  GETMET	R9	R6	K35
+      0x5C2C0A00,  //  0088  MOVE	R11	R5
+      0x5C301000,  //  0089  MOVE	R12	R8
+      0x7C240600,  //  008A  CALL	R9	3
+      0x8C240D24,  //  008B  GETMET	R9	R6	K36
+      0x7C240200,  //  008C  CALL	R9	1
+      0xB8264A00,  //  008D  GETNGBL	R9	K37
+      0x8C241326,  //  008E  GETMET	R9	R9	K38
+      0x542E0003,  //  008F  LDINT	R11	4
+      0x7C240400,  //  0090  CALL	R9	2
+      0x7826000A,  //  0091  JMPF	R9	#009D
+      0xB8261600,  //  0092  GETNGBL	R9	K11
+      0x60280018,  //  0093  GETGBL	R10	G24
+      0x582C0027,  //  0094  LDCONST	R11	K39
+      0x88300D08,  //  0095  GETMBR	R12	R6	K8
+      0x8830191F,  //  0096  GETMBR	R12	R12	K31
+      0x88340D28,  //  0097  GETMBR	R13	R6	K40
+      0x88380D29,  //  0098  GETMBR	R14	R6	K41
+      0x883C0D2A,  //  0099  GETMBR	R15	R6	K42
+      0x7C280A00,  //  009A  CALL	R10	5
+      0x542E0003,  //  009B  LDINT	R11	4
+      0x7C240400,  //  009C  CALL	R9	2
+      0x8C240F2B,  //  009D  GETMET	R9	R7	K43
+      0x5C2C0C00,  //  009E  MOVE	R11	R6
+      0x7C240400,  //  009F  CALL	R9	2
+      0xB8260200,  //  00A0  GETNGBL	R9	K1
+      0x8824130A,  //  00A1  GETMBR	R9	R9	K10
+      0x8C24130B,  //  00A2  GETMET	R9	R9	K11
+      0x582C002C,  //  00A3  LDCONST	R11	K44
+      0x7C240400,  //  00A4  CALL	R9	2
+      0xB8260200,  //  00A5  GETNGBL	R9	K1
+      0x8C24132D,  //  00A6  GETMET	R9	R9	K45
+      0x882C052E,  //  00A7  GETMBR	R11	R2	K46
+      0x8830052F,  //  00A8  GETMBR	R12	R2	K47
+      0x7C240600,  //  00A9  CALL	R9	3
+      0x78260002,  //  00AA  JMPF	R9	#00AE
+      0x002A6009,  //  00AB  ADD	R10	K48	R9
+      0x00281531,  //  00AC  ADD	R10	R10	K49
+      0x70020000,  //  00AD  JMP		#00AF
+      0x58280032,  //  00AE  LDCONST	R10	K50
+      0x5C241400,  //  00AF  MOVE	R9	R10
+      0x4C280000,  //  00B0  LDNIL	R10
+      0x2028080A,  //  00B1  NE	R10	R4	R10
+      0x782A0012,  //  00B2  JMPF	R10	#00C6
+      0xB82A4A00,  //  00B3  GETNGBL	R10	K37
+      0x8C281526,  //  00B4  GETMET	R10	R10	K38
+      0x58300013,  //  00B5  LDCONST	R12	K19
+      0x7C280400,  //  00B6  CALL	R10	2
+      0x782A000C,  //  00B7  JMPF	R10	#00C5
+      0x8C280933,  //  00B8  GETMET	R10	R4	K51
+      0x7C280200,  //  00B9  CALL	R10	1
+      0xB82E1600,  //  00BA  GETNGBL	R11	K11
+      0x60300018,  //  00BB  GETGBL	R12	G24
+      0x58340034,  //  00BC  LDCONST	R13	K52
+      0x88380308,  //  00BD  GETMBR	R14	R1	K8
+      0x88381D1F,  //  00BE  GETMBR	R14	R14	K31
+      0x5C3C0400,  //  00BF  MOVE	R15	R2
+      0x5C401200,  //  00C0  MOVE	R16	R9
+      0x5C441400,  //  00C1  MOVE	R17	R10
+      0x7C300A00,  //  00C2  CALL	R12	5
+      0x58340013,  //  00C3  LDCONST	R13	K19
+      0x7C2C0400,  //  00C4  CALL	R11	2
+      0x7002002C,  //  00C5  JMP		#00F3
+      0x88280500,  //  00C6  GETMBR	R10	R2	K0
+      0x4C2C0000,  //  00C7  LDNIL	R11
+      0x2028140B,  //  00C8  NE	R10	R10	R11
+      0x782A0019,  //  00C9  JMPF	R10	#00E4
       0x88280500,  //  00CA  GETMBR	R10	R2	K0
-      0x4C2C0000,  //  00CB  LDNIL	R11
-      0x2028140B,  //  00CC  NE	R10	R10	R11
-      0x782A001A,  //  00CD  JMPF	R10	#00E9
-      0x88280500,  //  00CE  GETMBR	R10	R2	K0
-      0xB82E0200,  //  00CF  GETNGBL	R11	K1
-      0x882C1706,  //  00D0  GETMBR	R11	R11	K6
-      0x1C28140B,  //  00D1  EQ	R10	R10	R11
-      0x782A0001,  //  00D2  JMPF	R10	#00D5
-      0x58280006,  //  00D3  LDCONST	R10	K6
-      0x70020000,  //  00D4  JMP		#00D6
-      0x58280032,  //  00D5  LDCONST	R10	K50
-      0xB82E2400,  //  00D6  GETNGBL	R11	K18
-      0x8C2C1726,  //  00D7  GETMET	R11	R11	K38
-      0x58340014,  //  00D8  LDCONST	R13	K20
-      0x7C2C0400,  //  00D9  CALL	R11	2
-      0x782E000C,  //  00DA  JMPF	R11	#00E8
-      0xB82E2400,  //  00DB  GETNGBL	R11	K18
-      0x8C2C170B,  //  00DC  GETMET	R11	R11	K11
-      0x60340018,  //  00DD  GETGBL	R13	G24
-      0x58380035,  //  00DE  LDCONST	R14	K53
-      0x883C0308,  //  00DF  GETMBR	R15	R1	K8
-      0x883C1F20,  //  00E0  GETMBR	R15	R15	K32
-      0x5C400400,  //  00E1  MOVE	R16	R2
-      0x5C441200,  //  00E2  MOVE	R17	R9
-      0x88480500,  //  00E3  GETMBR	R18	R2	K0
-      0x5C4C1400,  //  00E4  MOVE	R19	R10
-      0x7C340C00,  //  00E5  CALL	R13	6
-      0x58380014,  //  00E6  LDCONST	R14	K20
-      0x7C2C0600,  //  00E7  CALL	R11	3
-      0x7002000F,  //  00E8  JMP		#00F9
-      0xB82A2400,  //  00E9  GETNGBL	R10	K18
-      0x8C281526,  //  00EA  GETMET	R10	R10	K38
-      0x58300014,  //  00EB  LDCONST	R12	K20
-      0x7C280400,  //  00EC  CALL	R10	2
-      0x782A000A,  //  00ED  JMPF	R10	#00F9
-      0xB82A2400,  //  00EE  GETNGBL	R10	K18
-      0x8C28150B,  //  00EF  GETMET	R10	R10	K11
-      0x60300018,  //  00F0  GETGBL	R12	G24
-      0x58340036,  //  00F1  LDCONST	R13	K54
-      0x88380308,  //  00F2  GETMBR	R14	R1	K8
-      0x88381D20,  //  00F3  GETMBR	R14	R14	K32
-      0x5C3C0400,  //  00F4  MOVE	R15	R2
-      0x5C401200,  //  00F5  MOVE	R16	R9
-      0x7C300800,  //  00F6  CALL	R12	4
-      0x58340014,  //  00F7  LDCONST	R13	K20
-      0x7C280600,  //  00F8  CALL	R10	3
-      0x50280200,  //  00F9  LDBOOL	R10	1	0
-      0x80041400,  //  00FA  RET	1	R10
+      0xB82E0200,  //  00CB  GETNGBL	R11	K1
+      0x882C1706,  //  00CC  GETMBR	R11	R11	K6
+      0x1C28140B,  //  00CD  EQ	R10	R10	R11
+      0x782A0001,  //  00CE  JMPF	R10	#00D1
+      0x58280006,  //  00CF  LDCONST	R10	K6
+      0x70020000,  //  00D0  JMP		#00D2
+      0x58280032,  //  00D1  LDCONST	R10	K50
+      0xB82E4A00,  //  00D2  GETNGBL	R11	K37
+      0x8C2C1726,  //  00D3  GETMET	R11	R11	K38
+      0x58340013,  //  00D4  LDCONST	R13	K19
+      0x7C2C0400,  //  00D5  CALL	R11	2
+      0x782E000B,  //  00D6  JMPF	R11	#00E3
+      0xB82E1600,  //  00D7  GETNGBL	R11	K11
+      0x60300018,  //  00D8  GETGBL	R12	G24
+      0x58340035,  //  00D9  LDCONST	R13	K53
+      0x88380308,  //  00DA  GETMBR	R14	R1	K8
+      0x88381D1F,  //  00DB  GETMBR	R14	R14	K31
+      0x5C3C0400,  //  00DC  MOVE	R15	R2
+      0x5C401200,  //  00DD  MOVE	R16	R9
+      0x88440500,  //  00DE  GETMBR	R17	R2	K0
+      0x5C481400,  //  00DF  MOVE	R18	R10
+      0x7C300C00,  //  00E0  CALL	R12	6
+      0x58340013,  //  00E1  LDCONST	R13	K19
+      0x7C2C0400,  //  00E2  CALL	R11	2
+      0x7002000E,  //  00E3  JMP		#00F3
+      0xB82A4A00,  //  00E4  GETNGBL	R10	K37
+      0x8C281526,  //  00E5  GETMET	R10	R10	K38
+      0x58300013,  //  00E6  LDCONST	R12	K19
+      0x7C280400,  //  00E7  CALL	R10	2
+      0x782A0009,  //  00E8  JMPF	R10	#00F3
+      0xB82A1600,  //  00E9  GETNGBL	R10	K11
+      0x602C0018,  //  00EA  GETGBL	R11	G24
+      0x58300036,  //  00EB  LDCONST	R12	K54
+      0x88340308,  //  00EC  GETMBR	R13	R1	K8
+      0x88341B1F,  //  00ED  GETMBR	R13	R13	K31
+      0x5C380400,  //  00EE  MOVE	R14	R2
+      0x5C3C1200,  //  00EF  MOVE	R15	R9
+      0x7C2C0800,  //  00F0  CALL	R11	4
+      0x58300013,  //  00F1  LDCONST	R12	K19
+      0x7C280400,  //  00F2  CALL	R10	2
+      0x50280200,  //  00F3  LDBOOL	R10	1	0
+      0x80041400,  //  00F4  RET	1	R10
     })
   )
 );
@@ -3257,7 +3223,7 @@ be_local_closure(class_Matter_IM_process_read_request_solo,   /* name */
 extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_send_enqueued,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    7,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3265,29 +3231,28 @@ be_local_closure(class_Matter_IM_send_enqueued,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
+    ( &(const bvalue[11]) {     /* constants */
     /* K0   */  be_const_int(0),
     /* K1   */  be_nested_str_weak(send_queue),
     /* K2   */  be_nested_str_weak(finish),
     /* K3   */  be_nested_str_weak(ready),
     /* K4   */  be_nested_str_weak(send_im),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20remove_X20IM_X20message_X20exch_X3D),
-    /* K8   */  be_nested_str_weak(resp),
-    /* K9   */  be_nested_str_weak(exchange_id),
-    /* K10  */  be_nested_str_weak(remove),
-    /* K11  */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20remove_X20IM_X20message_X20exch_X3D),
+    /* K7   */  be_nested_str_weak(resp),
+    /* K8   */  be_nested_str_weak(exchange_id),
+    /* K9   */  be_nested_str_weak(remove),
+    /* K10  */  be_const_int(1),
     }),
     be_str_weak(send_enqueued),
     &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
+    ( &(const binstruction[33]) {  /* code */
       0x58080000,  //  0000  LDCONST	R2	K0
       0x600C000C,  //  0001  GETGBL	R3	G12
       0x88100101,  //  0002  GETMBR	R4	R0	K1
       0x7C0C0200,  //  0003  CALL	R3	1
       0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E001A,  //  0005  JMPF	R3	#0021
+      0x780E0019,  //  0005  JMPF	R3	#0020
       0x880C0101,  //  0006  GETMBR	R3	R0	K1
       0x940C0602,  //  0007  GETIDX	R3	R3	R2
       0x88100702,  //  0008  GETMBR	R4	R3	K2
@@ -3298,24 +3263,23 @@ be_local_closure(class_Matter_IM_send_enqueued,   /* name */
       0x5C180200,  //  000D  MOVE	R6	R1
       0x7C100400,  //  000E  CALL	R4	2
       0x88100702,  //  000F  GETMBR	R4	R3	K2
-      0x7812000D,  //  0010  JMPF	R4	#001F
+      0x7812000C,  //  0010  JMPF	R4	#001E
       0xB8120A00,  //  0011  GETNGBL	R4	K5
-      0x8C100906,  //  0012  GETMET	R4	R4	K6
-      0x60180008,  //  0013  GETGBL	R6	G8
-      0x881C0708,  //  0014  GETMBR	R7	R3	K8
-      0x881C0F09,  //  0015  GETMBR	R7	R7	K9
-      0x7C180200,  //  0016  CALL	R6	1
-      0x001A0E06,  //  0017  ADD	R6	K7	R6
-      0x541E0003,  //  0018  LDINT	R7	4
-      0x7C100600,  //  0019  CALL	R4	3
-      0x88100101,  //  001A  GETMBR	R4	R0	K1
-      0x8C10090A,  //  001B  GETMET	R4	R4	K10
-      0x5C180400,  //  001C  MOVE	R6	R2
-      0x7C100400,  //  001D  CALL	R4	2
-      0x70020000,  //  001E  JMP		#0020
-      0x0008050B,  //  001F  ADD	R2	R2	K11
-      0x7001FFDF,  //  0020  JMP		#0001
-      0x80000000,  //  0021  RET	0
+      0x60140008,  //  0012  GETGBL	R5	G8
+      0x88180707,  //  0013  GETMBR	R6	R3	K7
+      0x88180D08,  //  0014  GETMBR	R6	R6	K8
+      0x7C140200,  //  0015  CALL	R5	1
+      0x00160C05,  //  0016  ADD	R5	K6	R5
+      0x541A0003,  //  0017  LDINT	R6	4
+      0x7C100400,  //  0018  CALL	R4	2
+      0x88100101,  //  0019  GETMBR	R4	R0	K1
+      0x8C100909,  //  001A  GETMET	R4	R4	K9
+      0x5C180400,  //  001B  MOVE	R6	R2
+      0x7C100400,  //  001C  CALL	R4	2
+      0x70020000,  //  001D  JMP		#001F
+      0x0008050A,  //  001E  ADD	R2	R2	K10
+      0x7001FFE0,  //  001F  JMP		#0001
+      0x80000000,  //  0020  RET	0
     })
   )
 );
@@ -3445,7 +3409,7 @@ be_local_closure(class_Matter_IM_expire_sendqueue,   /* name */
 extern const bclass be_class_Matter_IM;
 be_local_closure(class_Matter_IM_subscribe_request,   /* name */
   be_nested_proto(
-    18,                          /* nstack */
+    17,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3453,7 +3417,7 @@ be_local_closure(class_Matter_IM_subscribe_request,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[33]) {     /* constants */
+    ( &(const bvalue[32]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(SubscribeRequestMessage),
     /* K2   */  be_nested_str_weak(from_TLV),
@@ -3470,27 +3434,26 @@ be_local_closure(class_Matter_IM_subscribe_request,   /* name */
     /* K13  */  be_nested_str_weak(attribute),
     /* K14  */  be_nested_str_weak(push),
     /* K15  */  be_nested_str_weak(stop_iteration),
-    /* K16  */  be_nested_str_weak(tasmota),
-    /* K17  */  be_nested_str_weak(log),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X2C_X20keep_X3D_X25i_X29_X20sub_X3D_X25i_X20fabric_filtered_X3D_X25s),
-    /* K19  */  be_nested_str_weak(local_session_id),
-    /* K20  */  be_nested_str_weak(concat),
-    /* K21  */  be_nested_str_weak(_X20),
-    /* K22  */  be_nested_str_weak(min_interval),
-    /* K23  */  be_nested_str_weak(max_interval),
-    /* K24  */  be_const_int(1),
-    /* K25  */  be_const_int(0),
-    /* K26  */  be_nested_str_weak(subscription_id),
-    /* K27  */  be_nested_str_weak(fabric_filtered),
-    /* K28  */  be_const_int(3),
-    /* K29  */  be_nested_str_weak(event_requests),
-    /* K30  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20event_requests_size_X3D_X25s),
-    /* K31  */  be_nested_str_weak(_inner_process_read_request),
-    /* K32  */  be_nested_str_weak(send_subscribe_response),
+    /* K16  */  be_nested_str_weak(log),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X2C_X20keep_X3D_X25i_X29_X20sub_X3D_X25i_X20fabric_filtered_X3D_X25s),
+    /* K18  */  be_nested_str_weak(local_session_id),
+    /* K19  */  be_nested_str_weak(concat),
+    /* K20  */  be_nested_str_weak(_X20),
+    /* K21  */  be_nested_str_weak(min_interval),
+    /* K22  */  be_nested_str_weak(max_interval),
+    /* K23  */  be_const_int(1),
+    /* K24  */  be_const_int(0),
+    /* K25  */  be_nested_str_weak(subscription_id),
+    /* K26  */  be_nested_str_weak(fabric_filtered),
+    /* K27  */  be_const_int(3),
+    /* K28  */  be_nested_str_weak(event_requests),
+    /* K29  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20event_requests_size_X3D_X25s),
+    /* K30  */  be_nested_str_weak(_inner_process_read_request),
+    /* K31  */  be_nested_str_weak(send_subscribe_response),
     }),
     be_str_weak(subscribe_request),
     &be_const_str_solidified,
-    ( &(const binstruction[101]) {  /* code */
+    ( &(const binstruction[99]) {  /* code */
       0xB80E0000,  //  0000  GETNGBL	R3	K0
       0x8C0C0701,  //  0001  GETMET	R3	R3	K1
       0x7C0C0200,  //  0002  CALL	R3	1
@@ -3536,62 +3499,60 @@ be_local_closure(class_Matter_IM_subscribe_request,   /* name */
       0xAC1C0200,  //  002A  CATCH	R7	1	0
       0xB0080000,  //  002B  RAISE	2	R0	R0
       0xB81E2000,  //  002C  GETNGBL	R7	K16
-      0x8C1C0F11,  //  002D  GETMET	R7	R7	K17
-      0x60240018,  //  002E  GETGBL	R9	G24
-      0x58280012,  //  002F  LDCONST	R10	K18
-      0x882C0306,  //  0030  GETMBR	R11	R1	K6
-      0x882C1713,  //  0031  GETMBR	R11	R11	K19
-      0x8C300B14,  //  0032  GETMET	R12	R5	K20
-      0x58380015,  //  0033  LDCONST	R14	K21
-      0x7C300400,  //  0034  CALL	R12	2
+      0x60200018,  //  002D  GETGBL	R8	G24
+      0x58240011,  //  002E  LDCONST	R9	K17
+      0x88280306,  //  002F  GETMBR	R10	R1	K6
+      0x88281512,  //  0030  GETMBR	R10	R10	K18
+      0x8C2C0B13,  //  0031  GETMET	R11	R5	K19
+      0x58340014,  //  0032  LDCONST	R13	K20
+      0x7C2C0400,  //  0033  CALL	R11	2
+      0x88300915,  //  0034  GETMBR	R12	R4	K21
       0x88340916,  //  0035  GETMBR	R13	R4	K22
-      0x88380917,  //  0036  GETMBR	R14	R4	K23
-      0x883C0703,  //  0037  GETMBR	R15	R3	K3
-      0x783E0001,  //  0038  JMPF	R15	#003B
-      0x583C0018,  //  0039  LDCONST	R15	K24
-      0x70020000,  //  003A  JMP		#003C
-      0x583C0019,  //  003B  LDCONST	R15	K25
-      0x8840091A,  //  003C  GETMBR	R16	R4	K26
-      0x8844071B,  //  003D  GETMBR	R17	R3	K27
-      0x7C241000,  //  003E  CALL	R9	8
-      0x5828001C,  //  003F  LDCONST	R10	K28
-      0x7C1C0600,  //  0040  CALL	R7	3
-      0x881C071D,  //  0041  GETMBR	R7	R3	K29
-      0x4C200000,  //  0042  LDNIL	R8
-      0x201C0E08,  //  0043  NE	R7	R7	R8
-      0x781E0010,  //  0044  JMPF	R7	#0056
-      0x601C000C,  //  0045  GETGBL	R7	G12
-      0x8820071D,  //  0046  GETMBR	R8	R3	K29
-      0x7C1C0200,  //  0047  CALL	R7	1
-      0x241C0F19,  //  0048  GT	R7	R7	K25
-      0x781E000B,  //  0049  JMPF	R7	#0056
-      0xB81E2000,  //  004A  GETNGBL	R7	K16
-      0x8C1C0F11,  //  004B  GETMET	R7	R7	K17
-      0x60240018,  //  004C  GETGBL	R9	G24
-      0x5828001E,  //  004D  LDCONST	R10	K30
-      0x882C0306,  //  004E  GETMBR	R11	R1	K6
-      0x882C1713,  //  004F  GETMBR	R11	R11	K19
-      0x6030000C,  //  0050  GETGBL	R12	G12
-      0x8834071D,  //  0051  GETMBR	R13	R3	K29
-      0x7C300200,  //  0052  CALL	R12	1
-      0x7C240600,  //  0053  CALL	R9	3
-      0x5828001C,  //  0054  LDCONST	R10	K28
-      0x7C1C0600,  //  0055  CALL	R7	3
-      0x8C1C011F,  //  0056  GETMET	R7	R0	K31
-      0x88240306,  //  0057  GETMBR	R9	R1	K6
-      0x5C280600,  //  0058  MOVE	R10	R3
-      0x5C2C0200,  //  0059  MOVE	R11	R1
-      0x50300200,  //  005A  LDBOOL	R12	1	0
-      0x7C1C0A00,  //  005B  CALL	R7	5
-      0x8820091A,  //  005C  GETMBR	R8	R4	K26
-      0x901E3408,  //  005D  SETMBR	R7	K26	R8
-      0x8C200120,  //  005E  GETMET	R8	R0	K32
-      0x5C280200,  //  005F  MOVE	R10	R1
-      0x5C2C0E00,  //  0060  MOVE	R11	R7
-      0x5C300800,  //  0061  MOVE	R12	R4
-      0x7C200800,  //  0062  CALL	R8	4
-      0x50200200,  //  0063  LDBOOL	R8	1	0
-      0x80041000,  //  0064  RET	1	R8
+      0x88380703,  //  0036  GETMBR	R14	R3	K3
+      0x783A0001,  //  0037  JMPF	R14	#003A
+      0x58380017,  //  0038  LDCONST	R14	K23
+      0x70020000,  //  0039  JMP		#003B
+      0x58380018,  //  003A  LDCONST	R14	K24
+      0x883C0919,  //  003B  GETMBR	R15	R4	K25
+      0x8840071A,  //  003C  GETMBR	R16	R3	K26
+      0x7C201000,  //  003D  CALL	R8	8
+      0x5824001B,  //  003E  LDCONST	R9	K27
+      0x7C1C0400,  //  003F  CALL	R7	2
+      0x881C071C,  //  0040  GETMBR	R7	R3	K28
+      0x4C200000,  //  0041  LDNIL	R8
+      0x201C0E08,  //  0042  NE	R7	R7	R8
+      0x781E000F,  //  0043  JMPF	R7	#0054
+      0x601C000C,  //  0044  GETGBL	R7	G12
+      0x8820071C,  //  0045  GETMBR	R8	R3	K28
+      0x7C1C0200,  //  0046  CALL	R7	1
+      0x241C0F18,  //  0047  GT	R7	R7	K24
+      0x781E000A,  //  0048  JMPF	R7	#0054
+      0xB81E2000,  //  0049  GETNGBL	R7	K16
+      0x60200018,  //  004A  GETGBL	R8	G24
+      0x5824001D,  //  004B  LDCONST	R9	K29
+      0x88280306,  //  004C  GETMBR	R10	R1	K6
+      0x88281512,  //  004D  GETMBR	R10	R10	K18
+      0x602C000C,  //  004E  GETGBL	R11	G12
+      0x8830071C,  //  004F  GETMBR	R12	R3	K28
+      0x7C2C0200,  //  0050  CALL	R11	1
+      0x7C200600,  //  0051  CALL	R8	3
+      0x5824001B,  //  0052  LDCONST	R9	K27
+      0x7C1C0400,  //  0053  CALL	R7	2
+      0x8C1C011E,  //  0054  GETMET	R7	R0	K30
+      0x88240306,  //  0055  GETMBR	R9	R1	K6
+      0x5C280600,  //  0056  MOVE	R10	R3
+      0x5C2C0200,  //  0057  MOVE	R11	R1
+      0x50300200,  //  0058  LDBOOL	R12	1	0
+      0x7C1C0A00,  //  0059  CALL	R7	5
+      0x88200919,  //  005A  GETMBR	R8	R4	K25
+      0x901E3208,  //  005B  SETMBR	R7	K25	R8
+      0x8C20011F,  //  005C  GETMET	R8	R0	K31
+      0x5C280200,  //  005D  MOVE	R10	R1
+      0x5C2C0E00,  //  005E  MOVE	R11	R7
+      0x5C300800,  //  005F  MOVE	R12	R4
+      0x7C200800,  //  0060  CALL	R8	4
+      0x50200200,  //  0061  LDBOOL	R8	1	0
+      0x80041000,  //  0062  RET	1	R8
     })
   )
 );
@@ -3612,61 +3573,59 @@ be_local_closure(class_Matter_IM_send_subscribe_heartbeat,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_IM, 
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
+    ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(session),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Alive_X20_X28_X256i_X29_X20sub_X3D_X25i),
-    /* K4   */  be_nested_str_weak(local_session_id),
-    /* K5   */  be_nested_str_weak(subscription_id),
-    /* K6   */  be_const_int(3),
-    /* K7   */  be_nested_str_weak(is_keep_alive),
-    /* K8   */  be_nested_str_weak(matter),
-    /* K9   */  be_nested_str_weak(ReportDataMessage),
-    /* K10  */  be_nested_str_weak(suppress_response),
-    /* K11  */  be_nested_str_weak(IM_SubscribedHeartbeat),
-    /* K12  */  be_nested_str_weak(_message_handler),
-    /* K13  */  be_nested_str_weak(send_queue),
-    /* K14  */  be_nested_str_weak(push),
-    /* K15  */  be_nested_str_weak(send_enqueued),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Alive_X20_X28_X256i_X29_X20sub_X3D_X25i),
+    /* K3   */  be_nested_str_weak(local_session_id),
+    /* K4   */  be_nested_str_weak(subscription_id),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(is_keep_alive),
+    /* K7   */  be_nested_str_weak(matter),
+    /* K8   */  be_nested_str_weak(ReportDataMessage),
+    /* K9   */  be_nested_str_weak(suppress_response),
+    /* K10  */  be_nested_str_weak(IM_SubscribedHeartbeat),
+    /* K11  */  be_nested_str_weak(_message_handler),
+    /* K12  */  be_nested_str_weak(send_queue),
+    /* K13  */  be_nested_str_weak(push),
+    /* K14  */  be_nested_str_weak(send_enqueued),
     }),
     be_str_weak(send_subscribe_heartbeat),
     &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
+    ( &(const binstruction[33]) {  /* code */
       0x88080300,  //  0000  GETMBR	R2	R1	K0
       0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x60140018,  //  0003  GETGBL	R5	G24
-      0x58180003,  //  0004  LDCONST	R6	K3
-      0x881C0504,  //  0005  GETMBR	R7	R2	K4
-      0x88200305,  //  0006  GETMBR	R8	R1	K5
-      0x7C140600,  //  0007  CALL	R5	3
-      0x58180006,  //  0008  LDCONST	R6	K6
-      0x7C0C0600,  //  0009  CALL	R3	3
-      0x500C0200,  //  000A  LDBOOL	R3	1	0
-      0x90060E03,  //  000B  SETMBR	R1	K7	R3
-      0xB80E1000,  //  000C  GETNGBL	R3	K8
-      0x8C0C0709,  //  000D  GETMET	R3	R3	K9
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0x50100200,  //  000F  LDBOOL	R4	1	0
-      0x900E1404,  //  0010  SETMBR	R3	K10	R4
-      0x88100305,  //  0011  GETMBR	R4	R1	K5
-      0x900E0A04,  //  0012  SETMBR	R3	K5	R4
-      0xB8121000,  //  0013  GETNGBL	R4	K8
-      0x8C10090B,  //  0014  GETMET	R4	R4	K11
-      0x8818050C,  //  0015  GETMBR	R6	R2	K12
-      0x5C1C0400,  //  0016  MOVE	R7	R2
-      0x5C200600,  //  0017  MOVE	R8	R3
-      0x5C240200,  //  0018  MOVE	R9	R1
-      0x7C100A00,  //  0019  CALL	R4	5
-      0x8814010D,  //  001A  GETMBR	R5	R0	K13
-      0x8C140B0E,  //  001B  GETMET	R5	R5	K14
-      0x5C1C0800,  //  001C  MOVE	R7	R4
-      0x7C140400,  //  001D  CALL	R5	2
-      0x8C14010F,  //  001E  GETMET	R5	R0	K15
-      0x881C050C,  //  001F  GETMBR	R7	R2	K12
-      0x7C140400,  //  0020  CALL	R5	2
-      0x80000000,  //  0021  RET	0
+      0x60100018,  //  0002  GETGBL	R4	G24
+      0x58140002,  //  0003  LDCONST	R5	K2
+      0x88180503,  //  0004  GETMBR	R6	R2	K3
+      0x881C0304,  //  0005  GETMBR	R7	R1	K4
+      0x7C100600,  //  0006  CALL	R4	3
+      0x58140005,  //  0007  LDCONST	R5	K5
+      0x7C0C0400,  //  0008  CALL	R3	2
+      0x500C0200,  //  0009  LDBOOL	R3	1	0
+      0x90060C03,  //  000A  SETMBR	R1	K6	R3
+      0xB80E0E00,  //  000B  GETNGBL	R3	K7
+      0x8C0C0708,  //  000C  GETMET	R3	R3	K8
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x50100200,  //  000E  LDBOOL	R4	1	0
+      0x900E1204,  //  000F  SETMBR	R3	K9	R4
+      0x88100304,  //  0010  GETMBR	R4	R1	K4
+      0x900E0804,  //  0011  SETMBR	R3	K4	R4
+      0xB8120E00,  //  0012  GETNGBL	R4	K7
+      0x8C10090A,  //  0013  GETMET	R4	R4	K10
+      0x8818050B,  //  0014  GETMBR	R6	R2	K11
+      0x5C1C0400,  //  0015  MOVE	R7	R2
+      0x5C200600,  //  0016  MOVE	R8	R3
+      0x5C240200,  //  0017  MOVE	R9	R1
+      0x7C100A00,  //  0018  CALL	R4	5
+      0x8814010C,  //  0019  GETMBR	R5	R0	K12
+      0x8C140B0D,  //  001A  GETMET	R5	R5	K13
+      0x5C1C0800,  //  001B  MOVE	R7	R4
+      0x7C140400,  //  001C  CALL	R5	2
+      0x8C14010E,  //  001D  GETMET	R5	R0	K14
+      0x881C050B,  //  001E  GETMBR	R7	R2	K11
+      0x7C140400,  //  001F  CALL	R5	2
+      0x80000000,  //  0020  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
@@ -74,7 +74,7 @@ be_local_closure(class_Matter_IM_Message_get_exchangeid,   /* name */
 extern const bclass be_class_Matter_IM_Message;
 be_local_closure(class_Matter_IM_Message_send_im,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    12,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -105,7 +105,7 @@ be_local_closure(class_Matter_IM_Message_send_im,   /* name */
     }),
     be_str_weak(send_im),
     &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
+    ( &(const binstruction[39]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x740A0001,  //  0001  JMPT	R2	#0004
       0x50080000,  //  0002  LDBOOL	R2	0	0
@@ -125,27 +125,26 @@ be_local_closure(class_Matter_IM_Message_send_im,   /* name */
       0x8C140B08,  //  0010  GETMET	R5	R5	K8
       0x541E0003,  //  0011  LDINT	R7	4
       0x7C140400,  //  0012  CALL	R5	2
-      0x7816000B,  //  0013  JMPF	R5	#0020
-      0xB8160E00,  //  0014  GETNGBL	R5	K7
-      0x8C140B09,  //  0015  GETMET	R5	R5	K9
-      0x601C0018,  //  0016  GETGBL	R7	G24
-      0x5820000A,  //  0017  LDCONST	R8	K10
-      0x8824050B,  //  0018  GETMBR	R9	R2	K11
-      0x8824130C,  //  0019  GETMBR	R9	R9	K12
-      0x8828050D,  //  001A  GETMBR	R10	R2	K13
-      0x882C050E,  //  001B  GETMBR	R11	R2	K14
-      0x8830050F,  //  001C  GETMBR	R12	R2	K15
-      0x7C1C0A00,  //  001D  CALL	R7	5
-      0x54220003,  //  001E  LDINT	R8	4
-      0x7C140600,  //  001F  CALL	R5	3
-      0x8C140310,  //  0020  GETMET	R5	R1	K16
-      0x5C1C0400,  //  0021  MOVE	R7	R2
-      0x7C140400,  //  0022  CALL	R5	2
-      0x8814050D,  //  0023  GETMBR	R5	R2	K13
-      0x90022205,  //  0024  SETMBR	R0	K17	R5
-      0x50140200,  //  0025  LDBOOL	R5	1	0
-      0x90022405,  //  0026  SETMBR	R0	K18	R5
-      0x80000000,  //  0027  RET	0
+      0x7816000A,  //  0013  JMPF	R5	#001F
+      0xB8161200,  //  0014  GETNGBL	R5	K9
+      0x60180018,  //  0015  GETGBL	R6	G24
+      0x581C000A,  //  0016  LDCONST	R7	K10
+      0x8820050B,  //  0017  GETMBR	R8	R2	K11
+      0x8820110C,  //  0018  GETMBR	R8	R8	K12
+      0x8824050D,  //  0019  GETMBR	R9	R2	K13
+      0x8828050E,  //  001A  GETMBR	R10	R2	K14
+      0x882C050F,  //  001B  GETMBR	R11	R2	K15
+      0x7C180A00,  //  001C  CALL	R6	5
+      0x541E0003,  //  001D  LDINT	R7	4
+      0x7C140400,  //  001E  CALL	R5	2
+      0x8C140310,  //  001F  GETMET	R5	R1	K16
+      0x5C1C0400,  //  0020  MOVE	R7	R2
+      0x7C140400,  //  0021  CALL	R5	2
+      0x8814050D,  //  0022  GETMBR	R5	R2	K13
+      0x90022205,  //  0023  SETMBR	R0	K17	R5
+      0x50140200,  //  0024  LDBOOL	R5	1	0
+      0x90022405,  //  0025  SETMBR	R0	K18	R5
+      0x80000000,  //  0026  RET	0
     })
   )
 );
@@ -763,7 +762,7 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_ack_received,   /* name */
 extern const bclass be_class_Matter_IM_ReportDataSubscribed;
 be_local_closure(class_Matter_IM_ReportDataSubscribed_send_im,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -796,7 +795,7 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_send_im,   /* name */
     }),
     be_str_weak(send_im),
     &be_const_str_solidified,
-    ( &(const binstruction[74]) {  /* code */
+    ( &(const binstruction[73]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x740A0001,  //  0001  JMPT	R2	#0004
       0x50080000,  //  0002  LDBOOL	R2	0	0
@@ -806,7 +805,7 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_send_im,   /* name */
       0x880C0702,  //  0006  GETMBR	R3	R3	K2
       0x7C080200,  //  0007  CALL	R2	1
       0x24080503,  //  0008  GT	R2	R2	K3
-      0x780A0031,  //  0009  JMPF	R2	#003C
+      0x780A0030,  //  0009  JMPF	R2	#003B
       0x88080104,  //  000A  GETMBR	R2	R0	K4
       0x780A000F,  //  000B  JMPF	R2	#001C
       0x60080003,  //  000C  GETGBL	R2	G3
@@ -824,7 +823,7 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_send_im,   /* name */
       0x90020002,  //  0018  SETMBR	R0	K0	R2
       0x50080000,  //  0019  LDBOOL	R2	0	0
       0x90020C02,  //  001A  SETMBR	R0	K6	R2
-      0x7002001E,  //  001B  JMP		#003B
+      0x7002001D,  //  001B  JMP		#003A
       0x88080107,  //  001C  GETMBR	R2	R0	K7
       0x8C080508,  //  001D  GETMET	R2	R2	K8
       0x50100000,  //  001E  LDBOOL	R4	0	0
@@ -837,40 +836,39 @@ be_local_closure(class_Matter_IM_ReportDataSubscribed_send_im,   /* name */
       0x8C0C070C,  //  0025  GETMET	R3	R3	K12
       0x54160003,  //  0026  LDINT	R5	4
       0x7C0C0400,  //  0027  CALL	R3	2
-      0x780E000A,  //  0028  JMPF	R3	#0034
-      0xB80E1600,  //  0029  GETNGBL	R3	K11
-      0x8C0C070D,  //  002A  GETMET	R3	R3	K13
-      0x60140018,  //  002B  GETGBL	R5	G24
-      0x5818000E,  //  002C  LDCONST	R6	K14
-      0x881C050F,  //  002D  GETMBR	R7	R2	K15
-      0x881C0F10,  //  002E  GETMBR	R7	R7	K16
-      0x88200511,  //  002F  GETMBR	R8	R2	K17
-      0x88240512,  //  0030  GETMBR	R9	R2	K18
-      0x7C140800,  //  0031  CALL	R5	4
-      0x541A0003,  //  0032  LDINT	R6	4
-      0x7C0C0600,  //  0033  CALL	R3	3
-      0x8C0C0313,  //  0034  GETMET	R3	R1	K19
-      0x5C140400,  //  0035  MOVE	R5	R2
-      0x7C0C0400,  //  0036  CALL	R3	2
-      0x880C0512,  //  0037  GETMBR	R3	R2	K18
-      0x90022803,  //  0038  SETMBR	R0	K20	R3
-      0x500C0200,  //  0039  LDBOOL	R3	1	0
-      0x90020C03,  //  003A  SETMBR	R0	K6	R3
-      0x7002000C,  //  003B  JMP		#0049
-      0x88080104,  //  003C  GETMBR	R2	R0	K4
-      0x780A0008,  //  003D  JMPF	R2	#0047
-      0x60080003,  //  003E  GETGBL	R2	G3
-      0x5C0C0000,  //  003F  MOVE	R3	R0
-      0x7C080200,  //  0040  CALL	R2	1
-      0x8C080505,  //  0041  GETMET	R2	R2	K5
-      0x5C100200,  //  0042  MOVE	R4	R1
-      0x7C080400,  //  0043  CALL	R2	2
-      0x50080000,  //  0044  LDBOOL	R2	0	0
-      0x90020802,  //  0045  SETMBR	R0	K4	R2
-      0x70020001,  //  0046  JMP		#0049
-      0x50080200,  //  0047  LDBOOL	R2	1	0
-      0x90020C02,  //  0048  SETMBR	R0	K6	R2
-      0x80000000,  //  0049  RET	0
+      0x780E0009,  //  0028  JMPF	R3	#0033
+      0xB80E1A00,  //  0029  GETNGBL	R3	K13
+      0x60100018,  //  002A  GETGBL	R4	G24
+      0x5814000E,  //  002B  LDCONST	R5	K14
+      0x8818050F,  //  002C  GETMBR	R6	R2	K15
+      0x88180D10,  //  002D  GETMBR	R6	R6	K16
+      0x881C0511,  //  002E  GETMBR	R7	R2	K17
+      0x88200512,  //  002F  GETMBR	R8	R2	K18
+      0x7C100800,  //  0030  CALL	R4	4
+      0x54160003,  //  0031  LDINT	R5	4
+      0x7C0C0400,  //  0032  CALL	R3	2
+      0x8C0C0313,  //  0033  GETMET	R3	R1	K19
+      0x5C140400,  //  0034  MOVE	R5	R2
+      0x7C0C0400,  //  0035  CALL	R3	2
+      0x880C0512,  //  0036  GETMBR	R3	R2	K18
+      0x90022803,  //  0037  SETMBR	R0	K20	R3
+      0x500C0200,  //  0038  LDBOOL	R3	1	0
+      0x90020C03,  //  0039  SETMBR	R0	K6	R3
+      0x7002000C,  //  003A  JMP		#0048
+      0x88080104,  //  003B  GETMBR	R2	R0	K4
+      0x780A0008,  //  003C  JMPF	R2	#0046
+      0x60080003,  //  003D  GETGBL	R2	G3
+      0x5C0C0000,  //  003E  MOVE	R3	R0
+      0x7C080200,  //  003F  CALL	R2	1
+      0x8C080505,  //  0040  GETMET	R2	R2	K5
+      0x5C100200,  //  0041  MOVE	R4	R1
+      0x7C080400,  //  0042  CALL	R2	2
+      0x50080000,  //  0043  LDBOOL	R2	0	0
+      0x90020802,  //  0044  SETMBR	R0	K4	R2
+      0x70020001,  //  0045  JMP		#0048
+      0x50080200,  //  0046  LDBOOL	R2	1	0
+      0x90020C02,  //  0047  SETMBR	R0	K6	R2
+      0x80000000,  //  0048  RET	0
     })
   )
 );
@@ -1361,7 +1359,7 @@ be_local_closure(class_Matter_IM_SubscribeResponse_init,   /* name */
 extern const bclass be_class_Matter_IM_SubscribeResponse;
 be_local_closure(class_Matter_IM_SubscribeResponse_status_ok_received,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    7,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1383,30 +1381,29 @@ be_local_closure(class_Matter_IM_SubscribeResponse_status_ok_received,   /* name
     }),
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
+    ( &(const binstruction[22]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
       0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x58100002,  //  0002  LDCONST	R4	K2
       0x7C080400,  //  0003  CALL	R2	2
-      0x780A000A,  //  0004  JMPF	R2	#0010
-      0xB80A0000,  //  0005  GETNGBL	R2	K0
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
-      0x60100018,  //  0007  GETGBL	R4	G24
-      0x58140004,  //  0008  LDCONST	R5	K4
-      0x88180305,  //  0009  GETMBR	R6	R1	K5
-      0x88180D06,  //  000A  GETMBR	R6	R6	K6
-      0x881C0107,  //  000B  GETMBR	R7	R0	K7
-      0x881C0F08,  //  000C  GETMBR	R7	R7	K8
-      0x7C100600,  //  000D  CALL	R4	3
-      0x58140002,  //  000E  LDCONST	R5	K2
-      0x7C080600,  //  000F  CALL	R2	3
-      0x60080003,  //  0010  GETGBL	R2	G3
-      0x5C0C0000,  //  0011  MOVE	R3	R0
-      0x7C080200,  //  0012  CALL	R2	1
-      0x8C080509,  //  0013  GETMET	R2	R2	K9
-      0x5C100200,  //  0014  MOVE	R4	R1
-      0x7C080400,  //  0015  CALL	R2	2
-      0x80040400,  //  0016  RET	1	R2
+      0x780A0009,  //  0004  JMPF	R2	#000F
+      0xB80A0600,  //  0005  GETNGBL	R2	K3
+      0x600C0018,  //  0006  GETGBL	R3	G24
+      0x58100004,  //  0007  LDCONST	R4	K4
+      0x88140305,  //  0008  GETMBR	R5	R1	K5
+      0x88140B06,  //  0009  GETMBR	R5	R5	K6
+      0x88180107,  //  000A  GETMBR	R6	R0	K7
+      0x88180D08,  //  000B  GETMBR	R6	R6	K8
+      0x7C0C0600,  //  000C  CALL	R3	3
+      0x58100002,  //  000D  LDCONST	R4	K2
+      0x7C080400,  //  000E  CALL	R2	2
+      0x60080003,  //  000F  GETGBL	R2	G3
+      0x5C0C0000,  //  0010  MOVE	R3	R0
+      0x7C080200,  //  0011  CALL	R2	1
+      0x8C080509,  //  0012  GETMET	R2	R2	K9
+      0x5C100200,  //  0013  MOVE	R4	R1
+      0x7C080400,  //  0014  CALL	R2	2
+      0x80040400,  //  0015  RET	1	R2
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Subscription.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Subscription.h
@@ -180,7 +180,7 @@ be_local_closure(class_Matter_IM_Subscription__add_attribute_unique_path,   /* n
 extern const bclass be_class_Matter_IM_Subscription;
 be_local_closure(class_Matter_IM_Subscription_remove_self,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -188,31 +188,29 @@ be_local_closure(class_Matter_IM_Subscription_remove_self,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_IM_Subscription, 
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2DSub_Del_X20_X20_X20_X28_X20_X20_X20_X20_X20_X20_X29_X20sub_X3D),
-    /* K3   */  be_nested_str_weak(subscription_id),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(subs_shop),
-    /* K6   */  be_nested_str_weak(remove_sub),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(log),
+    /* K1   */  be_nested_str_weak(MTR_X3A_X20_X2DSub_Del_X20_X20_X20_X28_X20_X20_X20_X20_X20_X20_X29_X20sub_X3D),
+    /* K2   */  be_nested_str_weak(subscription_id),
+    /* K3   */  be_const_int(3),
+    /* K4   */  be_nested_str_weak(subs_shop),
+    /* K5   */  be_nested_str_weak(remove_sub),
     }),
     be_str_weak(remove_self),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
+    ( &(const binstruction[12]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x600C0008,  //  0002  GETGBL	R3	G8
-      0x88100103,  //  0003  GETMBR	R4	R0	K3
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x000E0403,  //  0005  ADD	R3	K2	R3
-      0x58100004,  //  0006  LDCONST	R4	K4
-      0x7C040600,  //  0007  CALL	R1	3
-      0x88040105,  //  0008  GETMBR	R1	R0	K5
-      0x8C040306,  //  0009  GETMET	R1	R1	K6
-      0x5C0C0000,  //  000A  MOVE	R3	R0
-      0x7C040400,  //  000B  CALL	R1	2
-      0x80000000,  //  000C  RET	0
+      0x60080008,  //  0001  GETGBL	R2	G8
+      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x7C080200,  //  0003  CALL	R2	1
+      0x000A0202,  //  0004  ADD	R2	K1	R2
+      0x580C0003,  //  0005  LDCONST	R3	K3
+      0x7C040400,  //  0006  CALL	R1	2
+      0x88040104,  //  0007  GETMBR	R1	R0	K4
+      0x8C040305,  //  0008  GETMET	R1	R1	K5
+      0x5C0C0000,  //  0009  MOVE	R3	R0
+      0x7C040400,  //  000A  CALL	R1	2
+      0x80000000,  //  000B  RET	0
     })
   )
 );
@@ -329,7 +327,7 @@ be_local_closure(class_Matter_IM_Subscription_attribute_updated_ctx,   /* name *
 extern const bclass be_class_Matter_IM_Subscription;
 be_local_closure(class_Matter_IM_Subscription_re_arm,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -355,7 +353,7 @@ be_local_closure(class_Matter_IM_Subscription_re_arm,   /* name */
     }),
     be_str_weak(re_arm),
     &be_const_str_solidified,
-    ( &(const binstruction[29]) {  /* code */
+    ( &(const binstruction[28]) {  /* code */
       0x50040000,  //  0000  LDBOOL	R1	0	0
       0x90020001,  //  0001  SETMBR	R0	K0	R1
       0xB8060200,  //  0002  GETNGBL	R1	K1
@@ -375,16 +373,15 @@ be_local_closure(class_Matter_IM_Subscription_re_arm,   /* name */
       0x04080508,  //  0010  SUB	R2	R2	K8
       0x90020C02,  //  0011  SETMBR	R0	K6	R2
       0x88080109,  //  0012  GETMBR	R2	R0	K9
-      0x740A0007,  //  0013  JMPT	R2	#001C
-      0xB80A0200,  //  0014  GETNGBL	R2	K1
-      0x8C08050A,  //  0015  GETMET	R2	R2	K10
-      0x60100018,  //  0016  GETGBL	R4	G24
-      0x5814000B,  //  0017  LDCONST	R5	K11
-      0x8818010C,  //  0018  GETMBR	R6	R0	K12
-      0x7C100400,  //  0019  CALL	R4	2
-      0x5814000D,  //  001A  LDCONST	R5	K13
-      0x7C080600,  //  001B  CALL	R2	3
-      0x80000000,  //  001C  RET	0
+      0x740A0006,  //  0013  JMPT	R2	#001B
+      0xB80A1400,  //  0014  GETNGBL	R2	K10
+      0x600C0018,  //  0015  GETGBL	R3	G24
+      0x5810000B,  //  0016  LDCONST	R4	K11
+      0x8814010C,  //  0017  GETMBR	R5	R0	K12
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x5810000D,  //  0019  LDCONST	R4	K13
+      0x7C080400,  //  001A  CALL	R2	2
+      0x80000000,  //  001B  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
@@ -458,7 +458,7 @@ be_local_closure(class_Matter_Frame_build_standalone_ack,   /* name */
 extern const bclass be_class_Matter_Frame;
 be_local_closure(class_Matter_Frame_build_response,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -466,7 +466,7 @@ be_local_closure(class_Matter_Frame_build_response,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Frame, 
     1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
+    ( &(const bvalue[29]) {     /* constants */
     /* K0   */  be_nested_str_weak(message_handler),
     /* K1   */  be_nested_str_weak(remote_ip),
     /* K2   */  be_nested_str_weak(remote_port),
@@ -493,14 +493,13 @@ be_local_closure(class_Matter_Frame_build_response,   /* name */
     /* K23  */  be_nested_str_weak(matter),
     /* K24  */  be_nested_str_weak(get_opcode_name),
     /* K25  */  be_nested_str_weak(0x_X2502X),
-    /* K26  */  be_nested_str_weak(tasmota),
-    /* K27  */  be_nested_str_weak(log),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s),
-    /* K29  */  be_const_int(3),
+    /* K26  */  be_nested_str_weak(log),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s),
+    /* K28  */  be_const_int(3),
     }),
     be_str_weak(build_response),
     &be_const_str_solidified,
-    ( &(const binstruction[91]) {  /* code */
+    ( &(const binstruction[90]) {  /* code */
       0x4C100000,  //  0000  LDNIL	R4
       0x1C100604,  //  0001  EQ	R4	R3	R4
       0x78120005,  //  0002  JMPF	R4	#0009
@@ -569,7 +568,7 @@ be_local_closure(class_Matter_Frame_build_response,   /* name */
       0x900E2804,  //  0041  SETMBR	R3	K20	R4
       0x8810070A,  //  0042  GETMBR	R4	R3	K10
       0x1C100908,  //  0043  EQ	R4	R4	K8
-      0x78120014,  //  0044  JMPF	R4	#005A
+      0x78120013,  //  0044  JMPF	R4	#0059
       0xB8122E00,  //  0045  GETNGBL	R4	K23
       0x8C100918,  //  0046  GETMET	R4	R4	K24
       0x88180711,  //  0047  GETMBR	R6	R3	K17
@@ -582,16 +581,15 @@ be_local_closure(class_Matter_Frame_build_response,   /* name */
       0x7C140400,  //  004E  CALL	R5	2
       0x5C100A00,  //  004F  MOVE	R4	R5
       0xB8163400,  //  0050  GETNGBL	R5	K26
-      0x8C140B1B,  //  0051  GETMET	R5	R5	K27
-      0x601C0018,  //  0052  GETGBL	R7	G24
-      0x5820001C,  //  0053  LDCONST	R8	K28
-      0x88240709,  //  0054  GETMBR	R9	R3	K9
-      0x8824130A,  //  0055  GETMBR	R9	R9	K10
-      0x5C280800,  //  0056  MOVE	R10	R4
-      0x7C1C0600,  //  0057  CALL	R7	3
-      0x5820001D,  //  0058  LDCONST	R8	K29
-      0x7C140600,  //  0059  CALL	R5	3
-      0x80040600,  //  005A  RET	1	R3
+      0x60180018,  //  0051  GETGBL	R6	G24
+      0x581C001B,  //  0052  LDCONST	R7	K27
+      0x88200709,  //  0053  GETMBR	R8	R3	K9
+      0x8820110A,  //  0054  GETMBR	R8	R8	K10
+      0x5C240800,  //  0055  MOVE	R9	R4
+      0x7C180600,  //  0056  CALL	R6	3
+      0x581C001C,  //  0057  LDCONST	R7	K28
+      0x7C140400,  //  0058  CALL	R5	2
+      0x80040600,  //  0059  RET	1	R3
     })
   )
 );
@@ -1044,41 +1042,40 @@ be_local_closure(class_Matter_Frame_decrypt,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Frame, 
     1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
+    ( &(const bvalue[29]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(session),
     /* K2   */  be_nested_str_weak(raw),
     /* K3   */  be_nested_str_weak(payload_idx),
     /* K4   */  be_nested_str_weak(get_i2r),
     /* K5   */  be_nested_str_weak(sec_p),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X20Compute_X20Privacy_X20TODO),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_nested_str_weak(get_i2r_privacy),
-    /* K11  */  be_const_int(2147483647),
-    /* K12  */  be_nested_str_weak(add),
-    /* K13  */  be_nested_str_weak(local_session_id),
-    /* K14  */  be_const_int(1),
-    /* K15  */  be_nested_str_weak(AES_CTR),
-    /* K16  */  be_nested_str_weak(decrypt),
-    /* K17  */  be_const_int(0),
-    /* K18  */  be_const_int(3),
-    /* K19  */  be_nested_str_weak(message_handler),
-    /* K20  */  be_nested_str_weak(_n_bytes),
-    /* K21  */  be_nested_str_weak(clear),
-    /* K22  */  be_nested_str_weak(flags),
-    /* K23  */  be_nested_str_weak(message_counter),
-    /* K24  */  be_nested_str_weak(source_node_id),
-    /* K25  */  be_nested_str_weak(peer_node_id),
-    /* K26  */  be_nested_str_weak(resize),
-    /* K27  */  be_nested_str_weak(AES_CCM),
-    /* K28  */  be_nested_str_weak(decrypt1),
-    /* K29  */  be_nested_str_weak(MTR_X3A_X20rejected_X20packet_X20due_X20to_X20invalid_X20MIC),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X3E_X20Compute_X20Privacy_X20TODO),
+    /* K8   */  be_const_int(2),
+    /* K9   */  be_nested_str_weak(get_i2r_privacy),
+    /* K10  */  be_const_int(2147483647),
+    /* K11  */  be_nested_str_weak(add),
+    /* K12  */  be_nested_str_weak(local_session_id),
+    /* K13  */  be_const_int(1),
+    /* K14  */  be_nested_str_weak(AES_CTR),
+    /* K15  */  be_nested_str_weak(decrypt),
+    /* K16  */  be_const_int(0),
+    /* K17  */  be_const_int(3),
+    /* K18  */  be_nested_str_weak(message_handler),
+    /* K19  */  be_nested_str_weak(_n_bytes),
+    /* K20  */  be_nested_str_weak(clear),
+    /* K21  */  be_nested_str_weak(flags),
+    /* K22  */  be_nested_str_weak(message_counter),
+    /* K23  */  be_nested_str_weak(source_node_id),
+    /* K24  */  be_nested_str_weak(peer_node_id),
+    /* K25  */  be_nested_str_weak(resize),
+    /* K26  */  be_nested_str_weak(AES_CCM),
+    /* K27  */  be_nested_str_weak(decrypt1),
+    /* K28  */  be_nested_str_weak(MTR_X3A_X20rejected_X20packet_X20due_X20to_X20invalid_X20MIC),
     }),
     be_str_weak(decrypt),
     &be_const_str_solidified,
-    ( &(const binstruction[117]) {  /* code */
+    ( &(const binstruction[115]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x88080101,  //  0001  GETMBR	R2	R0	K1
       0x880C0102,  //  0002  GETMBR	R3	R0	K2
@@ -1087,115 +1084,113 @@ be_local_closure(class_Matter_Frame_decrypt,   /* name */
       0x8C180504,  //  0005  GETMET	R6	R2	K4
       0x7C180200,  //  0006  CALL	R6	1
       0x881C0105,  //  0007  GETMBR	R7	R0	K5
-      0x781E002C,  //  0008  JMPF	R7	#0036
+      0x781E002B,  //  0008  JMPF	R7	#0035
       0xB81E0C00,  //  0009  GETNGBL	R7	K6
-      0x8C1C0F07,  //  000A  GETMET	R7	R7	K7
+      0x58200007,  //  000A  LDCONST	R8	K7
       0x58240008,  //  000B  LDCONST	R9	K8
-      0x58280009,  //  000C  LDCONST	R10	K9
-      0x7C1C0600,  //  000D  CALL	R7	3
-      0x8C1C050A,  //  000E  GETMET	R7	R2	K10
-      0x7C1C0200,  //  000F  CALL	R7	1
-      0x5421FFEF,  //  0010  LDINT	R8	-16
-      0x4020110B,  //  0011  CONNECT	R8	R8	K11
-      0x94200608,  //  0012  GETIDX	R8	R3	R8
-      0x60240015,  //  0013  GETGBL	R9	G21
-      0x7C240000,  //  0014  CALL	R9	0
-      0x8C24130C,  //  0015  GETMET	R9	R9	K12
-      0x882C010D,  //  0016  GETMBR	R11	R0	K13
-      0x5431FFFD,  //  0017  LDINT	R12	-2
-      0x7C240600,  //  0018  CALL	R9	3
-      0x542A0004,  //  0019  LDINT	R10	5
-      0x542E000E,  //  001A  LDINT	R11	15
-      0x4028140B,  //  001B  CONNECT	R10	R10	R11
-      0x9428100A,  //  001C  GETIDX	R10	R8	R10
-      0x0024120A,  //  001D  ADD	R9	R9	R10
-      0x542A0003,  //  001E  LDINT	R10	4
-      0x882C0103,  //  001F  GETMBR	R11	R0	K3
-      0x042C170E,  //  0020  SUB	R11	R11	K14
-      0x4028140B,  //  0021  CONNECT	R10	R10	R11
-      0x882C0102,  //  0022  GETMBR	R11	R0	K2
-      0x9428160A,  //  0023  GETIDX	R10	R11	R10
-      0x8C30030F,  //  0024  GETMET	R12	R1	K15
-      0x5C380E00,  //  0025  MOVE	R14	R7
-      0x7C300400,  //  0026  CALL	R12	2
-      0x8C301910,  //  0027  GETMET	R12	R12	K16
-      0x5C381400,  //  0028  MOVE	R14	R10
-      0x5C3C1200,  //  0029  MOVE	R15	R9
-      0x58400009,  //  002A  LDCONST	R16	K9
-      0x7C300800,  //  002B  CALL	R12	4
-      0x5C2C1800,  //  002C  MOVE	R11	R12
-      0x40322312,  //  002D  CONNECT	R12	K17	K18
-      0x88340102,  //  002E  GETMBR	R13	R0	K2
-      0x94301A0C,  //  002F  GETIDX	R12	R13	R12
-      0x0030180B,  //  0030  ADD	R12	R12	R11
-      0x88340103,  //  0031  GETMBR	R13	R0	K3
-      0x40341B0B,  //  0032  CONNECT	R13	R13	K11
-      0x9434140D,  //  0033  GETIDX	R13	R10	R13
-      0x0030180D,  //  0034  ADD	R12	R12	R13
-      0x9002040C,  //  0035  SETMBR	R0	K2	R12
-      0x881C0113,  //  0036  GETMBR	R7	R0	K19
-      0x881C0F14,  //  0037  GETMBR	R7	R7	K20
-      0x8C200F15,  //  0038  GETMET	R8	R7	K21
-      0x7C200200,  //  0039  CALL	R8	1
-      0x8C200F0C,  //  003A  GETMET	R8	R7	K12
-      0x88280116,  //  003B  GETMBR	R10	R0	K22
-      0x582C000E,  //  003C  LDCONST	R11	K14
-      0x7C200600,  //  003D  CALL	R8	3
-      0x8C200F0C,  //  003E  GETMET	R8	R7	K12
-      0x88280117,  //  003F  GETMBR	R10	R0	K23
-      0x542E0003,  //  0040  LDINT	R11	4
-      0x7C200600,  //  0041  CALL	R8	3
-      0x88200118,  //  0042  GETMBR	R8	R0	K24
-      0x78220002,  //  0043  JMPF	R8	#0047
-      0x88200118,  //  0044  GETMBR	R8	R0	K24
-      0x40200E08,  //  0045  CONNECT	R8	R7	R8
-      0x70020006,  //  0046  JMP		#004E
-      0x88200519,  //  0047  GETMBR	R8	R2	K25
-      0x78220001,  //  0048  JMPF	R8	#004B
-      0x88200519,  //  0049  GETMBR	R8	R2	K25
-      0x40200E08,  //  004A  CONNECT	R8	R7	R8
-      0x8C200F1A,  //  004B  GETMET	R8	R7	K26
-      0x542A000C,  //  004C  LDINT	R10	13
-      0x7C200400,  //  004D  CALL	R8	2
-      0x8820031B,  //  004E  GETMBR	R8	R1	K27
-      0x8C20111C,  //  004F  GETMET	R8	R8	K28
-      0x5C280C00,  //  0050  MOVE	R10	R6
-      0x5C2C0E00,  //  0051  MOVE	R11	R7
-      0x58300011,  //  0052  LDCONST	R12	K17
-      0x6034000C,  //  0053  GETGBL	R13	G12
-      0x5C380E00,  //  0054  MOVE	R14	R7
-      0x7C340200,  //  0055  CALL	R13	1
-      0x5C380600,  //  0056  MOVE	R14	R3
-      0x583C0011,  //  0057  LDCONST	R15	K17
-      0x5C400800,  //  0058  MOVE	R16	R4
-      0x5C440600,  //  0059  MOVE	R17	R3
-      0x5C480800,  //  005A  MOVE	R18	R4
-      0x604C000C,  //  005B  GETGBL	R19	G12
-      0x5C500600,  //  005C  MOVE	R20	R3
-      0x7C4C0200,  //  005D  CALL	R19	1
-      0x044C2604,  //  005E  SUB	R19	R19	R4
-      0x044C2605,  //  005F  SUB	R19	R19	R5
-      0x5C500600,  //  0060  MOVE	R20	R3
-      0x6054000C,  //  0061  GETGBL	R21	G12
-      0x5C580600,  //  0062  MOVE	R22	R3
-      0x7C540200,  //  0063  CALL	R21	1
-      0x04542A05,  //  0064  SUB	R21	R21	R5
-      0x5C580A00,  //  0065  MOVE	R22	R5
-      0x7C201C00,  //  0066  CALL	R8	14
-      0x78220006,  //  0067  JMPF	R8	#006F
-      0x8C24071A,  //  0068  GETMET	R9	R3	K26
-      0x602C000C,  //  0069  GETGBL	R11	G12
-      0x5C300600,  //  006A  MOVE	R12	R3
-      0x7C2C0200,  //  006B  CALL	R11	1
-      0x042C1605,  //  006C  SUB	R11	R11	R5
-      0x7C240400,  //  006D  CALL	R9	2
-      0x70020004,  //  006E  JMP		#0074
-      0xB8260C00,  //  006F  GETNGBL	R9	K6
-      0x8C241307,  //  0070  GETMET	R9	R9	K7
-      0x582C001D,  //  0071  LDCONST	R11	K29
-      0x58300012,  //  0072  LDCONST	R12	K18
-      0x7C240600,  //  0073  CALL	R9	3
-      0x80041000,  //  0074  RET	1	R8
+      0x7C1C0400,  //  000C  CALL	R7	2
+      0x8C1C0509,  //  000D  GETMET	R7	R2	K9
+      0x7C1C0200,  //  000E  CALL	R7	1
+      0x5421FFEF,  //  000F  LDINT	R8	-16
+      0x4020110A,  //  0010  CONNECT	R8	R8	K10
+      0x94200608,  //  0011  GETIDX	R8	R3	R8
+      0x60240015,  //  0012  GETGBL	R9	G21
+      0x7C240000,  //  0013  CALL	R9	0
+      0x8C24130B,  //  0014  GETMET	R9	R9	K11
+      0x882C010C,  //  0015  GETMBR	R11	R0	K12
+      0x5431FFFD,  //  0016  LDINT	R12	-2
+      0x7C240600,  //  0017  CALL	R9	3
+      0x542A0004,  //  0018  LDINT	R10	5
+      0x542E000E,  //  0019  LDINT	R11	15
+      0x4028140B,  //  001A  CONNECT	R10	R10	R11
+      0x9428100A,  //  001B  GETIDX	R10	R8	R10
+      0x0024120A,  //  001C  ADD	R9	R9	R10
+      0x542A0003,  //  001D  LDINT	R10	4
+      0x882C0103,  //  001E  GETMBR	R11	R0	K3
+      0x042C170D,  //  001F  SUB	R11	R11	K13
+      0x4028140B,  //  0020  CONNECT	R10	R10	R11
+      0x882C0102,  //  0021  GETMBR	R11	R0	K2
+      0x9428160A,  //  0022  GETIDX	R10	R11	R10
+      0x8C30030E,  //  0023  GETMET	R12	R1	K14
+      0x5C380E00,  //  0024  MOVE	R14	R7
+      0x7C300400,  //  0025  CALL	R12	2
+      0x8C30190F,  //  0026  GETMET	R12	R12	K15
+      0x5C381400,  //  0027  MOVE	R14	R10
+      0x5C3C1200,  //  0028  MOVE	R15	R9
+      0x58400008,  //  0029  LDCONST	R16	K8
+      0x7C300800,  //  002A  CALL	R12	4
+      0x5C2C1800,  //  002B  MOVE	R11	R12
+      0x40322111,  //  002C  CONNECT	R12	K16	K17
+      0x88340102,  //  002D  GETMBR	R13	R0	K2
+      0x94301A0C,  //  002E  GETIDX	R12	R13	R12
+      0x0030180B,  //  002F  ADD	R12	R12	R11
+      0x88340103,  //  0030  GETMBR	R13	R0	K3
+      0x40341B0A,  //  0031  CONNECT	R13	R13	K10
+      0x9434140D,  //  0032  GETIDX	R13	R10	R13
+      0x0030180D,  //  0033  ADD	R12	R12	R13
+      0x9002040C,  //  0034  SETMBR	R0	K2	R12
+      0x881C0112,  //  0035  GETMBR	R7	R0	K18
+      0x881C0F13,  //  0036  GETMBR	R7	R7	K19
+      0x8C200F14,  //  0037  GETMET	R8	R7	K20
+      0x7C200200,  //  0038  CALL	R8	1
+      0x8C200F0B,  //  0039  GETMET	R8	R7	K11
+      0x88280115,  //  003A  GETMBR	R10	R0	K21
+      0x582C000D,  //  003B  LDCONST	R11	K13
+      0x7C200600,  //  003C  CALL	R8	3
+      0x8C200F0B,  //  003D  GETMET	R8	R7	K11
+      0x88280116,  //  003E  GETMBR	R10	R0	K22
+      0x542E0003,  //  003F  LDINT	R11	4
+      0x7C200600,  //  0040  CALL	R8	3
+      0x88200117,  //  0041  GETMBR	R8	R0	K23
+      0x78220002,  //  0042  JMPF	R8	#0046
+      0x88200117,  //  0043  GETMBR	R8	R0	K23
+      0x40200E08,  //  0044  CONNECT	R8	R7	R8
+      0x70020006,  //  0045  JMP		#004D
+      0x88200518,  //  0046  GETMBR	R8	R2	K24
+      0x78220001,  //  0047  JMPF	R8	#004A
+      0x88200518,  //  0048  GETMBR	R8	R2	K24
+      0x40200E08,  //  0049  CONNECT	R8	R7	R8
+      0x8C200F19,  //  004A  GETMET	R8	R7	K25
+      0x542A000C,  //  004B  LDINT	R10	13
+      0x7C200400,  //  004C  CALL	R8	2
+      0x8820031A,  //  004D  GETMBR	R8	R1	K26
+      0x8C20111B,  //  004E  GETMET	R8	R8	K27
+      0x5C280C00,  //  004F  MOVE	R10	R6
+      0x5C2C0E00,  //  0050  MOVE	R11	R7
+      0x58300010,  //  0051  LDCONST	R12	K16
+      0x6034000C,  //  0052  GETGBL	R13	G12
+      0x5C380E00,  //  0053  MOVE	R14	R7
+      0x7C340200,  //  0054  CALL	R13	1
+      0x5C380600,  //  0055  MOVE	R14	R3
+      0x583C0010,  //  0056  LDCONST	R15	K16
+      0x5C400800,  //  0057  MOVE	R16	R4
+      0x5C440600,  //  0058  MOVE	R17	R3
+      0x5C480800,  //  0059  MOVE	R18	R4
+      0x604C000C,  //  005A  GETGBL	R19	G12
+      0x5C500600,  //  005B  MOVE	R20	R3
+      0x7C4C0200,  //  005C  CALL	R19	1
+      0x044C2604,  //  005D  SUB	R19	R19	R4
+      0x044C2605,  //  005E  SUB	R19	R19	R5
+      0x5C500600,  //  005F  MOVE	R20	R3
+      0x6054000C,  //  0060  GETGBL	R21	G12
+      0x5C580600,  //  0061  MOVE	R22	R3
+      0x7C540200,  //  0062  CALL	R21	1
+      0x04542A05,  //  0063  SUB	R21	R21	R5
+      0x5C580A00,  //  0064  MOVE	R22	R5
+      0x7C201C00,  //  0065  CALL	R8	14
+      0x78220006,  //  0066  JMPF	R8	#006E
+      0x8C240719,  //  0067  GETMET	R9	R3	K25
+      0x602C000C,  //  0068  GETGBL	R11	G12
+      0x5C300600,  //  0069  MOVE	R12	R3
+      0x7C2C0200,  //  006A  CALL	R11	1
+      0x042C1605,  //  006B  SUB	R11	R11	R5
+      0x7C240400,  //  006C  CALL	R9	2
+      0x70020003,  //  006D  JMP		#0072
+      0xB8260C00,  //  006E  GETNGBL	R9	K6
+      0x5828001C,  //  006F  LDCONST	R10	K28
+      0x582C0011,  //  0070  LDCONST	R11	K17
+      0x7C240400,  //  0071  CALL	R9	2
+      0x80041000,  //  0072  RET	1	R8
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
@@ -67,7 +67,7 @@ be_local_closure(class_Matter_MessageHandler_init,   /* name */
 extern const bclass be_class_Matter_MessageHandler;
 be_local_closure(class_Matter_MessageHandler_send_encrypted_ack,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -94,9 +94,9 @@ be_local_closure(class_Matter_MessageHandler_send_encrypted_ack,   /* name */
     }),
     be_str_weak(send_encrypted_ack),
     &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
+    ( &(const binstruction[32]) {  /* code */
       0x880C0300,  //  0000  GETMBR	R3	R1	K0
-      0x780E001D,  //  0001  JMPF	R3	#0020
+      0x780E001C,  //  0001  JMPF	R3	#001F
       0x8C0C0301,  //  0002  GETMET	R3	R1	K1
       0x5C140400,  //  0003  MOVE	R5	R2
       0x7C0C0400,  //  0004  CALL	R3	2
@@ -108,26 +108,25 @@ be_local_closure(class_Matter_MessageHandler_send_encrypted_ack,   /* name */
       0x8C100905,  //  000A  GETMET	R4	R4	K5
       0x541A0003,  //  000B  LDINT	R6	4
       0x7C100400,  //  000C  CALL	R4	2
-      0x7812000E,  //  000D  JMPF	R4	#001D
-      0xB8120800,  //  000E  GETNGBL	R4	K4
-      0x8C100906,  //  000F  GETMET	R4	R4	K6
-      0x60180018,  //  0010  GETGBL	R6	G24
-      0x581C0007,  //  0011  LDCONST	R7	K7
-      0x88200708,  //  0012  GETMBR	R8	R3	K8
-      0x88201109,  //  0013  GETMBR	R8	R8	K9
-      0x8824070A,  //  0014  GETMBR	R9	R3	K10
-      0x8828070B,  //  0015  GETMBR	R10	R3	K11
-      0x780A0001,  //  0016  JMPF	R2	#0019
-      0x582C000C,  //  0017  LDCONST	R11	K12
-      0x70020000,  //  0018  JMP		#001A
-      0x582C000D,  //  0019  LDCONST	R11	K13
-      0x7C180A00,  //  001A  CALL	R6	5
-      0x541E0003,  //  001B  LDINT	R7	4
-      0x7C100600,  //  001C  CALL	R4	3
-      0x8C10010E,  //  001D  GETMET	R4	R0	K14
-      0x5C180600,  //  001E  MOVE	R6	R3
-      0x7C100400,  //  001F  CALL	R4	2
-      0x80000000,  //  0020  RET	0
+      0x7812000D,  //  000D  JMPF	R4	#001C
+      0xB8120C00,  //  000E  GETNGBL	R4	K6
+      0x60140018,  //  000F  GETGBL	R5	G24
+      0x58180007,  //  0010  LDCONST	R6	K7
+      0x881C0708,  //  0011  GETMBR	R7	R3	K8
+      0x881C0F09,  //  0012  GETMBR	R7	R7	K9
+      0x8820070A,  //  0013  GETMBR	R8	R3	K10
+      0x8824070B,  //  0014  GETMBR	R9	R3	K11
+      0x780A0001,  //  0015  JMPF	R2	#0018
+      0x5828000C,  //  0016  LDCONST	R10	K12
+      0x70020000,  //  0017  JMP		#0019
+      0x5828000D,  //  0018  LDCONST	R10	K13
+      0x7C140A00,  //  0019  CALL	R5	5
+      0x541A0003,  //  001A  LDINT	R6	4
+      0x7C100400,  //  001B  CALL	R4	2
+      0x8C10010E,  //  001C  GETMET	R4	R0	K14
+      0x5C180600,  //  001D  MOVE	R6	R3
+      0x7C100400,  //  001E  CALL	R4	2
+      0x80000000,  //  001F  RET	0
     })
   )
 );
@@ -140,7 +139,7 @@ be_local_closure(class_Matter_MessageHandler_send_encrypted_ack,   /* name */
 extern const bclass be_class_Matter_MessageHandler;
 be_local_closure(class_Matter_MessageHandler_msg_received,   /* name */
   be_nested_proto(
-    19,                          /* nstack */
+    18,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -222,14 +221,14 @@ be_local_closure(class_Matter_MessageHandler_msg_received,   /* name */
     }),
     be_str_weak(msg_received),
     &be_const_str_solidified,
-    ( &(const binstruction[365]) {  /* code */
+    ( &(const binstruction[356]) {  /* code */
       0x50100000,  //  0000  LDBOOL	R4	0	0
       0xB8160000,  //  0001  GETNGBL	R5	K0
       0x88140B01,  //  0002  GETMBR	R5	R5	K1
       0x8C140B02,  //  0003  GETMET	R5	R5	K2
       0x581C0003,  //  0004  LDCONST	R7	K3
       0x7C140400,  //  0005  CALL	R5	2
-      0xA802014B,  //  0006  EXBLK	0	#0153
+      0xA8020143,  //  0006  EXBLK	0	#014B
       0xB8160000,  //  0007  GETNGBL	R5	K0
       0x8C140B04,  //  0008  GETMET	R5	R5	K4
       0x5C1C0000,  //  0009  MOVE	R7	R0
@@ -258,13 +257,13 @@ be_local_closure(class_Matter_MessageHandler_msg_received,   /* name */
       0x7C200400,  //  0020  CALL	R8	2
       0xA8040001,  //  0021  EXBLK	1	1
       0x80041000,  //  0022  RET	1	R8
-      0x7002012A,  //  0023  JMP		#014F
+      0x70020122,  //  0023  JMP		#0147
       0x881C0B0D,  //  0024  GETMBR	R7	R5	K13
       0x1C1C0F0E,  //  0025  EQ	R7	R7	K14
-      0x781E007F,  //  0026  JMPF	R7	#00A7
+      0x781E007C,  //  0026  JMPF	R7	#00A4
       0x881C0B0F,  //  0027  GETMBR	R7	R5	K15
       0x1C1C0F0E,  //  0028  EQ	R7	R7	K14
-      0x781E007C,  //  0029  JMPF	R7	#00A7
+      0x781E0079,  //  0029  JMPF	R7	#00A4
       0x881C0107,  //  002A  GETMBR	R7	R0	K7
       0x881C0F08,  //  002B  GETMBR	R7	R7	K8
       0x8C1C0F09,  //  002C  GETMET	R7	R7	K9
@@ -282,312 +281,303 @@ be_local_closure(class_Matter_MessageHandler_msg_received,   /* name */
       0x88280B16,  //  0038  GETMBR	R10	R5	K22
       0x502C0000,  //  0039  LDBOOL	R11	0	0
       0x7C200600,  //  003A  CALL	R8	3
-      0x74220016,  //  003B  JMPT	R8	#0053
+      0x74220015,  //  003B  JMPT	R8	#0052
       0xB8222E00,  //  003C  GETNGBL	R8	K23
       0x8C201118,  //  003D  GETMET	R8	R8	K24
       0x542A0003,  //  003E  LDINT	R10	4
       0x7C200400,  //  003F  CALL	R8	2
-      0x7822000A,  //  0040  JMPF	R8	#004C
-      0xB8222E00,  //  0041  GETNGBL	R8	K23
-      0x8C201102,  //  0042  GETMET	R8	R8	K2
-      0x60280018,  //  0043  GETGBL	R10	G24
-      0x582C0019,  //  0044  LDCONST	R11	K25
-      0x88300B16,  //  0045  GETMBR	R12	R5	K22
-      0x88340F14,  //  0046  GETMBR	R13	R7	K20
-      0x8C341B1A,  //  0047  GETMET	R13	R13	K26
-      0x7C340200,  //  0048  CALL	R13	1
-      0x7C280600,  //  0049  CALL	R10	3
-      0x542E0003,  //  004A  LDINT	R11	4
-      0x7C200600,  //  004B  CALL	R8	3
-      0x8C20011B,  //  004C  GETMET	R8	R0	K27
-      0x5C280A00,  //  004D  MOVE	R10	R5
-      0x502C0000,  //  004E  LDBOOL	R11	0	0
-      0x7C200600,  //  004F  CALL	R8	3
-      0x50200000,  //  0050  LDBOOL	R8	0	0
-      0xA8040001,  //  0051  EXBLK	1	1
-      0x80041000,  //  0052  RET	1	R8
-      0x8C200B1C,  //  0053  GETMET	R8	R5	K28
-      0x7C200200,  //  0054  CALL	R8	1
-      0x74220002,  //  0055  JMPT	R8	#0059
-      0x50200000,  //  0056  LDBOOL	R8	0	0
-      0xA8040001,  //  0057  EXBLK	1	1
-      0x80041000,  //  0058  RET	1	R8
-      0x88200107,  //  0059  GETMBR	R8	R0	K7
-      0x8C20111D,  //  005A  GETMET	R8	R8	K29
-      0x5C280A00,  //  005B  MOVE	R10	R5
-      0x7C200400,  //  005C  CALL	R8	2
-      0x88200B1E,  //  005D  GETMBR	R8	R5	K30
-      0x5426000F,  //  005E  LDINT	R9	16
-      0x20201009,  //  005F  NE	R8	R8	R9
-      0x7822001D,  //  0060  JMPF	R8	#007F
-      0xB8220000,  //  0061  GETNGBL	R8	K0
-      0x8C20111F,  //  0062  GETMET	R8	R8	K31
-      0x88280B1E,  //  0063  GETMBR	R10	R5	K30
-      0x7C200400,  //  0064  CALL	R8	2
-      0x5C241000,  //  0065  MOVE	R9	R8
-      0x74260004,  //  0066  JMPT	R9	#006C
-      0x60240018,  //  0067  GETGBL	R9	G24
-      0x58280020,  //  0068  LDCONST	R10	K32
-      0x882C0B1E,  //  0069  GETMBR	R11	R5	K30
-      0x7C240400,  //  006A  CALL	R9	2
-      0x5C201200,  //  006B  MOVE	R8	R9
-      0xB8262E00,  //  006C  GETNGBL	R9	K23
-      0x8C241318,  //  006D  GETMET	R9	R9	K24
-      0x582C0021,  //  006E  LDCONST	R11	K33
-      0x7C240400,  //  006F  CALL	R9	2
-      0x7826000C,  //  0070  JMPF	R9	#007E
-      0xB8262E00,  //  0071  GETNGBL	R9	K23
-      0x8C241302,  //  0072  GETMET	R9	R9	K2
-      0x602C0018,  //  0073  GETGBL	R11	G24
-      0x58300022,  //  0074  LDCONST	R12	K34
-      0x88340F0D,  //  0075  GETMBR	R13	R7	K13
-      0x5C381000,  //  0076  MOVE	R14	R8
-      0x883C0B16,  //  0077  GETMBR	R15	R5	K22
-      0x88400B23,  //  0078  GETMBR	R16	R5	K35
-      0x5C440400,  //  0079  MOVE	R17	R2
-      0x5C480600,  //  007A  MOVE	R18	R3
-      0x7C2C0E00,  //  007B  CALL	R11	7
-      0x58300021,  //  007C  LDCONST	R12	K33
-      0x7C240600,  //  007D  CALL	R9	3
-      0x70020018,  //  007E  JMP		#0098
-      0xB8222E00,  //  007F  GETNGBL	R8	K23
-      0x8C201118,  //  0080  GETMET	R8	R8	K24
-      0x542A0003,  //  0081  LDINT	R10	4
-      0x7C200400,  //  0082  CALL	R8	2
-      0x78220013,  //  0083  JMPF	R8	#0098
-      0xB8222E00,  //  0084  GETNGBL	R8	K23
-      0x8C201102,  //  0085  GETMET	R8	R8	K2
-      0x60280018,  //  0086  GETGBL	R10	G24
-      0x582C0024,  //  0087  LDCONST	R11	K36
-      0x88300F0D,  //  0088  GETMBR	R12	R7	K13
-      0x88340B16,  //  0089  GETMBR	R13	R5	K22
-      0x88380B25,  //  008A  GETMBR	R14	R5	K37
-      0x783A0001,  //  008B  JMPF	R14	#008E
-      0x58380026,  //  008C  LDCONST	R14	K38
-      0x70020000,  //  008D  JMP		#008F
-      0x58380027,  //  008E  LDCONST	R14	K39
-      0x883C0B23,  //  008F  GETMBR	R15	R5	K35
-      0x60400008,  //  0090  GETGBL	R16	G8
-      0x88440B28,  //  0091  GETMBR	R17	R5	K40
-      0x7C400200,  //  0092  CALL	R16	1
-      0x5C440400,  //  0093  MOVE	R17	R2
-      0x5C480600,  //  0094  MOVE	R18	R3
-      0x7C281000,  //  0095  CALL	R10	8
-      0x542E0003,  //  0096  LDINT	R11	4
-      0x7C200600,  //  0097  CALL	R8	3
-      0x88200129,  //  0098  GETMBR	R8	R0	K41
-      0x8C20112A,  //  0099  GETMET	R8	R8	K42
-      0x5C280A00,  //  009A  MOVE	R10	R5
-      0x7C200400,  //  009B  CALL	R8	2
-      0x5C101000,  //  009C  MOVE	R4	R8
-      0x5C200800,  //  009D  MOVE	R8	R4
-      0x74220003,  //  009E  JMPT	R8	#00A3
-      0x8C20011B,  //  009F  GETMET	R8	R0	K27
-      0x5C280A00,  //  00A0  MOVE	R10	R5
-      0x502C0000,  //  00A1  LDBOOL	R11	0	0
-      0x7C200600,  //  00A2  CALL	R8	3
-      0x50200200,  //  00A3  LDBOOL	R8	1	0
-      0xA8040001,  //  00A4  EXBLK	1	1
-      0x80041000,  //  00A5  RET	1	R8
-      0x700200A7,  //  00A6  JMP		#014F
-      0xB81E2E00,  //  00A7  GETNGBL	R7	K23
-      0x8C1C0F18,  //  00A8  GETMET	R7	R7	K24
-      0x54260003,  //  00A9  LDINT	R9	4
-      0x7C1C0400,  //  00AA  CALL	R7	2
-      0x781E0008,  //  00AB  JMPF	R7	#00B5
-      0xB81E2E00,  //  00AC  GETNGBL	R7	K23
-      0x8C1C0F02,  //  00AD  GETMET	R7	R7	K2
-      0x60240018,  //  00AE  GETGBL	R9	G24
-      0x5828002B,  //  00AF  LDCONST	R10	K43
-      0x882C0B0D,  //  00B0  GETMBR	R11	R5	K13
-      0x88300B16,  //  00B1  GETMBR	R12	R5	K22
-      0x7C240600,  //  00B2  CALL	R9	3
-      0x542A0003,  //  00B3  LDINT	R10	4
-      0x7C1C0600,  //  00B4  CALL	R7	3
-      0x881C0107,  //  00B5  GETMBR	R7	R0	K7
-      0x881C0F08,  //  00B6  GETMBR	R7	R7	K8
-      0x8C1C0F2C,  //  00B7  GETMET	R7	R7	K44
-      0x88240B0D,  //  00B8  GETMBR	R9	R5	K13
-      0x7C1C0400,  //  00B9  CALL	R7	2
-      0x4C200000,  //  00BA  LDNIL	R8
-      0x1C200E08,  //  00BB  EQ	R8	R7	R8
-      0x7822000A,  //  00BC  JMPF	R8	#00C8
-      0xB8222E00,  //  00BD  GETNGBL	R8	K23
-      0x8C201102,  //  00BE  GETMET	R8	R8	K2
-      0x60280008,  //  00BF  GETGBL	R10	G8
-      0x882C0B0D,  //  00C0  GETMBR	R11	R5	K13
-      0x7C280200,  //  00C1  CALL	R10	1
-      0x002A5A0A,  //  00C2  ADD	R10	K45	R10
-      0x582C0021,  //  00C3  LDCONST	R11	K33
-      0x7C200600,  //  00C4  CALL	R8	3
-      0x50200000,  //  00C5  LDBOOL	R8	0	0
-      0xA8040001,  //  00C6  EXBLK	1	1
-      0x80041000,  //  00C7  RET	1	R8
-      0x780A0000,  //  00C8  JMPF	R2	#00CA
-      0x901E2002,  //  00C9  SETMBR	R7	K16	R2
-      0x780E0000,  //  00CA  JMPF	R3	#00CC
-      0x901E2203,  //  00CB  SETMBR	R7	K17	R3
-      0x901E2400,  //  00CC  SETMBR	R7	K18	R0
-      0x90162607,  //  00CD  SETMBR	R5	K19	R7
-      0x8C200F2E,  //  00CE  GETMET	R8	R7	K46
-      0x88280B16,  //  00CF  GETMBR	R10	R5	K22
-      0x502C0200,  //  00D0  LDBOOL	R11	1	0
-      0x7C200600,  //  00D1  CALL	R8	3
-      0x74220018,  //  00D2  JMPT	R8	#00EC
-      0xB8222E00,  //  00D3  GETNGBL	R8	K23
-      0x8C201118,  //  00D4  GETMET	R8	R8	K24
-      0x58280021,  //  00D5  LDCONST	R10	K33
-      0x7C200400,  //  00D6  CALL	R8	2
-      0x7822000C,  //  00D7  JMPF	R8	#00E5
-      0xB8222E00,  //  00D8  GETNGBL	R8	K23
-      0x8C201102,  //  00D9  GETMET	R8	R8	K2
-      0x60280008,  //  00DA  GETGBL	R10	G8
-      0x882C0B16,  //  00DB  GETMBR	R11	R5	K22
-      0x7C280200,  //  00DC  CALL	R10	1
-      0x002A5E0A,  //  00DD  ADD	R10	K47	R10
-      0x00281530,  //  00DE  ADD	R10	R10	K48
-      0x602C0008,  //  00DF  GETGBL	R11	G8
-      0x88300F31,  //  00E0  GETMBR	R12	R7	K49
-      0x7C2C0200,  //  00E1  CALL	R11	1
-      0x0028140B,  //  00E2  ADD	R10	R10	R11
-      0x582C0021,  //  00E3  LDCONST	R11	K33
-      0x7C200600,  //  00E4  CALL	R8	3
-      0x8C200132,  //  00E5  GETMET	R8	R0	K50
-      0x5C280A00,  //  00E6  MOVE	R10	R5
-      0x502C0000,  //  00E7  LDBOOL	R11	0	0
-      0x7C200600,  //  00E8  CALL	R8	3
-      0x50200000,  //  00E9  LDBOOL	R8	0	0
-      0xA8040001,  //  00EA  EXBLK	1	1
-      0x80041000,  //  00EB  RET	1	R8
-      0x8C200B33,  //  00EC  GETMET	R8	R5	K51
-      0x7C200200,  //  00ED  CALL	R8	1
-      0xB8260000,  //  00EE  GETNGBL	R9	K0
-      0x88241301,  //  00EF  GETMBR	R9	R9	K1
-      0x8C241302,  //  00F0  GETMET	R9	R9	K2
-      0x582C0034,  //  00F1  LDCONST	R11	K52
-      0x7C240400,  //  00F2  CALL	R9	2
-      0x5C241000,  //  00F3  MOVE	R9	R8
-      0x74260002,  //  00F4  JMPT	R9	#00F8
-      0x50240000,  //  00F5  LDBOOL	R9	0	0
-      0xA8040001,  //  00F6  EXBLK	1	1
-      0x80041200,  //  00F7  RET	1	R9
-      0x8C240B1C,  //  00F8  GETMET	R9	R5	K28
-      0x7C240200,  //  00F9  CALL	R9	1
-      0xB8262E00,  //  00FA  GETNGBL	R9	K23
-      0x8C241318,  //  00FB  GETMET	R9	R9	K24
-      0x542E0003,  //  00FC  LDINT	R11	4
-      0x7C240400,  //  00FD  CALL	R9	2
-      0x78260013,  //  00FE  JMPF	R9	#0113
-      0xB8262E00,  //  00FF  GETNGBL	R9	K23
-      0x8C241302,  //  0100  GETMET	R9	R9	K2
-      0x602C0008,  //  0101  GETGBL	R11	G8
-      0x88300B36,  //  0102  GETMBR	R12	R5	K54
-      0x7C2C0200,  //  0103  CALL	R11	1
-      0x002E6A0B,  //  0104  ADD	R11	K53	R11
-      0x002C1737,  //  0105  ADD	R11	R11	K55
-      0x60300008,  //  0106  GETGBL	R12	G8
-      0x88340B1E,  //  0107  GETMBR	R13	R5	K30
-      0x7C300200,  //  0108  CALL	R12	1
-      0x002C160C,  //  0109  ADD	R11	R11	R12
-      0x002C1738,  //  010A  ADD	R11	R11	K56
-      0x60300008,  //  010B  GETGBL	R12	G8
-      0x88340B23,  //  010C  GETMBR	R13	R5	K35
-      0x543AFFFE,  //  010D  LDINT	R14	65535
-      0x2C341A0E,  //  010E  AND	R13	R13	R14
-      0x7C300200,  //  010F  CALL	R12	1
-      0x002C160C,  //  0110  ADD	R11	R11	R12
-      0x54320003,  //  0111  LDINT	R12	4
-      0x7C240600,  //  0112  CALL	R9	3
-      0x88240107,  //  0113  GETMBR	R9	R0	K7
-      0x8C24131D,  //  0114  GETMET	R9	R9	K29
-      0x5C2C0A00,  //  0115  MOVE	R11	R5
-      0x7C240400,  //  0116  CALL	R9	2
-      0x88240B36,  //  0117  GETMBR	R9	R5	K54
-      0x1C28130E,  //  0118  EQ	R10	R9	K14
-      0x782A000F,  //  0119  JMPF	R10	#012A
-      0x88280B1E,  //  011A  GETMBR	R10	R5	K30
-      0x542E000F,  //  011B  LDINT	R11	16
-      0x1C28140B,  //  011C  EQ	R10	R10	R11
-      0x782A0009,  //  011D  JMPF	R10	#0128
-      0x88280139,  //  011E  GETMBR	R10	R0	K57
-      0x8C28153A,  //  011F  GETMET	R10	R10	K58
-      0x5C300A00,  //  0120  MOVE	R12	R5
-      0x7C280400,  //  0121  CALL	R10	2
-      0x5C101400,  //  0122  MOVE	R4	R10
-      0x78120003,  //  0123  JMPF	R4	#0128
-      0x88280139,  //  0124  GETMBR	R10	R0	K57
-      0x8C28153B,  //  0125  GETMET	R10	R10	K59
-      0x5C300000,  //  0126  MOVE	R12	R0
-      0x7C280400,  //  0127  CALL	R10	2
-      0x50100200,  //  0128  LDBOOL	R4	1	0
-      0x70020024,  //  0129  JMP		#014F
-      0x1C28133C,  //  012A  EQ	R10	R9	K60
-      0x782A001A,  //  012B  JMPF	R10	#0147
-      0xB82A0000,  //  012C  GETNGBL	R10	K0
-      0x88281501,  //  012D  GETMBR	R10	R10	K1
-      0x8C281502,  //  012E  GETMET	R10	R10	K2
-      0x5830003D,  //  012F  LDCONST	R12	K61
-      0x7C280400,  //  0130  CALL	R10	2
-      0x88280139,  //  0131  GETMBR	R10	R0	K57
-      0x8C28152A,  //  0132  GETMET	R10	R10	K42
-      0x5C300A00,  //  0133  MOVE	R12	R5
-      0x7C280400,  //  0134  CALL	R10	2
-      0x5C101400,  //  0135  MOVE	R4	R10
-      0xB82A0000,  //  0136  GETNGBL	R10	K0
-      0x88281501,  //  0137  GETMBR	R10	R10	K1
-      0x8C281502,  //  0138  GETMET	R10	R10	K2
-      0x5830003E,  //  0139  LDCONST	R12	K62
-      0x7C280400,  //  013A  CALL	R10	2
-      0x78120004,  //  013B  JMPF	R4	#0141
-      0x88280139,  //  013C  GETMBR	R10	R0	K57
-      0x8C28153B,  //  013D  GETMET	R10	R10	K59
-      0x5C300000,  //  013E  MOVE	R12	R0
-      0x7C280400,  //  013F  CALL	R10	2
-      0x70020003,  //  0140  JMP		#0145
-      0x8C280132,  //  0141  GETMET	R10	R0	K50
-      0x5C300A00,  //  0142  MOVE	R12	R5
-      0x50340200,  //  0143  LDBOOL	R13	1	0
-      0x7C280600,  //  0144  CALL	R10	3
-      0x50100200,  //  0145  LDBOOL	R4	1	0
-      0x70020007,  //  0146  JMP		#014F
-      0xB82A2E00,  //  0147  GETNGBL	R10	K23
-      0x8C281502,  //  0148  GETMET	R10	R10	K2
-      0x60300008,  //  0149  GETGBL	R12	G8
-      0x5C341200,  //  014A  MOVE	R13	R9
-      0x7C300200,  //  014B  CALL	R12	1
-      0x00327E0C,  //  014C  ADD	R12	K63	R12
-      0x58340021,  //  014D  LDCONST	R13	K33
-      0x7C280600,  //  014E  CALL	R10	3
-      0xA8040001,  //  014F  EXBLK	1	1
-      0x80040800,  //  0150  RET	1	R4
-      0xA8040001,  //  0151  EXBLK	1	1
-      0x70020018,  //  0152  JMP		#016C
-      0xAC140002,  //  0153  CATCH	R5	0	2
-      0x70020015,  //  0154  JMP		#016B
-      0xB81E2E00,  //  0155  GETNGBL	R7	K23
-      0x8C1C0F02,  //  0156  GETMET	R7	R7	K2
-      0x60240008,  //  0157  GETGBL	R9	G8
-      0x5C280A00,  //  0158  MOVE	R10	R5
-      0x7C240200,  //  0159  CALL	R9	1
-      0x00268009,  //  015A  ADD	R9	K64	R9
-      0x00241341,  //  015B  ADD	R9	R9	K65
-      0x60280008,  //  015C  GETGBL	R10	G8
-      0x5C2C0C00,  //  015D  MOVE	R11	R6
-      0x7C280200,  //  015E  CALL	R10	1
-      0x0024120A,  //  015F  ADD	R9	R9	R10
-      0x58280042,  //  0160  LDCONST	R10	K66
-      0x7C1C0600,  //  0161  CALL	R7	3
-      0xB81E2E00,  //  0162  GETNGBL	R7	K23
-      0x881C0F43,  //  0163  GETMBR	R7	R7	K67
-      0x781E0002,  //  0164  JMPF	R7	#0168
-      0xA41E8800,  //  0165  IMPORT	R7	K68
-      0x8C200F45,  //  0166  GETMET	R8	R7	K69
-      0x7C200200,  //  0167  CALL	R8	1
-      0x501C0000,  //  0168  LDBOOL	R7	0	0
-      0x80040E00,  //  0169  RET	1	R7
-      0x70020000,  //  016A  JMP		#016C
-      0xB0080000,  //  016B  RAISE	2	R0	R0
-      0x80000000,  //  016C  RET	0
+      0x78220009,  //  0040  JMPF	R8	#004B
+      0xB8220400,  //  0041  GETNGBL	R8	K2
+      0x60240018,  //  0042  GETGBL	R9	G24
+      0x58280019,  //  0043  LDCONST	R10	K25
+      0x882C0B16,  //  0044  GETMBR	R11	R5	K22
+      0x88300F14,  //  0045  GETMBR	R12	R7	K20
+      0x8C30191A,  //  0046  GETMET	R12	R12	K26
+      0x7C300200,  //  0047  CALL	R12	1
+      0x7C240600,  //  0048  CALL	R9	3
+      0x542A0003,  //  0049  LDINT	R10	4
+      0x7C200400,  //  004A  CALL	R8	2
+      0x8C20011B,  //  004B  GETMET	R8	R0	K27
+      0x5C280A00,  //  004C  MOVE	R10	R5
+      0x502C0000,  //  004D  LDBOOL	R11	0	0
+      0x7C200600,  //  004E  CALL	R8	3
+      0x50200000,  //  004F  LDBOOL	R8	0	0
+      0xA8040001,  //  0050  EXBLK	1	1
+      0x80041000,  //  0051  RET	1	R8
+      0x8C200B1C,  //  0052  GETMET	R8	R5	K28
+      0x7C200200,  //  0053  CALL	R8	1
+      0x74220002,  //  0054  JMPT	R8	#0058
+      0x50200000,  //  0055  LDBOOL	R8	0	0
+      0xA8040001,  //  0056  EXBLK	1	1
+      0x80041000,  //  0057  RET	1	R8
+      0x88200107,  //  0058  GETMBR	R8	R0	K7
+      0x8C20111D,  //  0059  GETMET	R8	R8	K29
+      0x5C280A00,  //  005A  MOVE	R10	R5
+      0x7C200400,  //  005B  CALL	R8	2
+      0x88200B1E,  //  005C  GETMBR	R8	R5	K30
+      0x5426000F,  //  005D  LDINT	R9	16
+      0x20201009,  //  005E  NE	R8	R8	R9
+      0x7822001C,  //  005F  JMPF	R8	#007D
+      0xB8220000,  //  0060  GETNGBL	R8	K0
+      0x8C20111F,  //  0061  GETMET	R8	R8	K31
+      0x88280B1E,  //  0062  GETMBR	R10	R5	K30
+      0x7C200400,  //  0063  CALL	R8	2
+      0x5C241000,  //  0064  MOVE	R9	R8
+      0x74260004,  //  0065  JMPT	R9	#006B
+      0x60240018,  //  0066  GETGBL	R9	G24
+      0x58280020,  //  0067  LDCONST	R10	K32
+      0x882C0B1E,  //  0068  GETMBR	R11	R5	K30
+      0x7C240400,  //  0069  CALL	R9	2
+      0x5C201200,  //  006A  MOVE	R8	R9
+      0xB8262E00,  //  006B  GETNGBL	R9	K23
+      0x8C241318,  //  006C  GETMET	R9	R9	K24
+      0x582C0021,  //  006D  LDCONST	R11	K33
+      0x7C240400,  //  006E  CALL	R9	2
+      0x7826000B,  //  006F  JMPF	R9	#007C
+      0xB8260400,  //  0070  GETNGBL	R9	K2
+      0x60280018,  //  0071  GETGBL	R10	G24
+      0x582C0022,  //  0072  LDCONST	R11	K34
+      0x88300F0D,  //  0073  GETMBR	R12	R7	K13
+      0x5C341000,  //  0074  MOVE	R13	R8
+      0x88380B16,  //  0075  GETMBR	R14	R5	K22
+      0x883C0B23,  //  0076  GETMBR	R15	R5	K35
+      0x5C400400,  //  0077  MOVE	R16	R2
+      0x5C440600,  //  0078  MOVE	R17	R3
+      0x7C280E00,  //  0079  CALL	R10	7
+      0x582C0021,  //  007A  LDCONST	R11	K33
+      0x7C240400,  //  007B  CALL	R9	2
+      0x70020017,  //  007C  JMP		#0095
+      0xB8222E00,  //  007D  GETNGBL	R8	K23
+      0x8C201118,  //  007E  GETMET	R8	R8	K24
+      0x542A0003,  //  007F  LDINT	R10	4
+      0x7C200400,  //  0080  CALL	R8	2
+      0x78220012,  //  0081  JMPF	R8	#0095
+      0xB8220400,  //  0082  GETNGBL	R8	K2
+      0x60240018,  //  0083  GETGBL	R9	G24
+      0x58280024,  //  0084  LDCONST	R10	K36
+      0x882C0F0D,  //  0085  GETMBR	R11	R7	K13
+      0x88300B16,  //  0086  GETMBR	R12	R5	K22
+      0x88340B25,  //  0087  GETMBR	R13	R5	K37
+      0x78360001,  //  0088  JMPF	R13	#008B
+      0x58340026,  //  0089  LDCONST	R13	K38
+      0x70020000,  //  008A  JMP		#008C
+      0x58340027,  //  008B  LDCONST	R13	K39
+      0x88380B23,  //  008C  GETMBR	R14	R5	K35
+      0x603C0008,  //  008D  GETGBL	R15	G8
+      0x88400B28,  //  008E  GETMBR	R16	R5	K40
+      0x7C3C0200,  //  008F  CALL	R15	1
+      0x5C400400,  //  0090  MOVE	R16	R2
+      0x5C440600,  //  0091  MOVE	R17	R3
+      0x7C241000,  //  0092  CALL	R9	8
+      0x542A0003,  //  0093  LDINT	R10	4
+      0x7C200400,  //  0094  CALL	R8	2
+      0x88200129,  //  0095  GETMBR	R8	R0	K41
+      0x8C20112A,  //  0096  GETMET	R8	R8	K42
+      0x5C280A00,  //  0097  MOVE	R10	R5
+      0x7C200400,  //  0098  CALL	R8	2
+      0x5C101000,  //  0099  MOVE	R4	R8
+      0x5C200800,  //  009A  MOVE	R8	R4
+      0x74220003,  //  009B  JMPT	R8	#00A0
+      0x8C20011B,  //  009C  GETMET	R8	R0	K27
+      0x5C280A00,  //  009D  MOVE	R10	R5
+      0x502C0000,  //  009E  LDBOOL	R11	0	0
+      0x7C200600,  //  009F  CALL	R8	3
+      0x50200200,  //  00A0  LDBOOL	R8	1	0
+      0xA8040001,  //  00A1  EXBLK	1	1
+      0x80041000,  //  00A2  RET	1	R8
+      0x700200A2,  //  00A3  JMP		#0147
+      0xB81E2E00,  //  00A4  GETNGBL	R7	K23
+      0x8C1C0F18,  //  00A5  GETMET	R7	R7	K24
+      0x54260003,  //  00A6  LDINT	R9	4
+      0x7C1C0400,  //  00A7  CALL	R7	2
+      0x781E0007,  //  00A8  JMPF	R7	#00B1
+      0xB81E0400,  //  00A9  GETNGBL	R7	K2
+      0x60200018,  //  00AA  GETGBL	R8	G24
+      0x5824002B,  //  00AB  LDCONST	R9	K43
+      0x88280B0D,  //  00AC  GETMBR	R10	R5	K13
+      0x882C0B16,  //  00AD  GETMBR	R11	R5	K22
+      0x7C200600,  //  00AE  CALL	R8	3
+      0x54260003,  //  00AF  LDINT	R9	4
+      0x7C1C0400,  //  00B0  CALL	R7	2
+      0x881C0107,  //  00B1  GETMBR	R7	R0	K7
+      0x881C0F08,  //  00B2  GETMBR	R7	R7	K8
+      0x8C1C0F2C,  //  00B3  GETMET	R7	R7	K44
+      0x88240B0D,  //  00B4  GETMBR	R9	R5	K13
+      0x7C1C0400,  //  00B5  CALL	R7	2
+      0x4C200000,  //  00B6  LDNIL	R8
+      0x1C200E08,  //  00B7  EQ	R8	R7	R8
+      0x78220009,  //  00B8  JMPF	R8	#00C3
+      0xB8220400,  //  00B9  GETNGBL	R8	K2
+      0x60240008,  //  00BA  GETGBL	R9	G8
+      0x88280B0D,  //  00BB  GETMBR	R10	R5	K13
+      0x7C240200,  //  00BC  CALL	R9	1
+      0x00265A09,  //  00BD  ADD	R9	K45	R9
+      0x58280021,  //  00BE  LDCONST	R10	K33
+      0x7C200400,  //  00BF  CALL	R8	2
+      0x50200000,  //  00C0  LDBOOL	R8	0	0
+      0xA8040001,  //  00C1  EXBLK	1	1
+      0x80041000,  //  00C2  RET	1	R8
+      0x780A0000,  //  00C3  JMPF	R2	#00C5
+      0x901E2002,  //  00C4  SETMBR	R7	K16	R2
+      0x780E0000,  //  00C5  JMPF	R3	#00C7
+      0x901E2203,  //  00C6  SETMBR	R7	K17	R3
+      0x901E2400,  //  00C7  SETMBR	R7	K18	R0
+      0x90162607,  //  00C8  SETMBR	R5	K19	R7
+      0x8C200F2E,  //  00C9  GETMET	R8	R7	K46
+      0x88280B16,  //  00CA  GETMBR	R10	R5	K22
+      0x502C0200,  //  00CB  LDBOOL	R11	1	0
+      0x7C200600,  //  00CC  CALL	R8	3
+      0x74220017,  //  00CD  JMPT	R8	#00E6
+      0xB8222E00,  //  00CE  GETNGBL	R8	K23
+      0x8C201118,  //  00CF  GETMET	R8	R8	K24
+      0x58280021,  //  00D0  LDCONST	R10	K33
+      0x7C200400,  //  00D1  CALL	R8	2
+      0x7822000B,  //  00D2  JMPF	R8	#00DF
+      0xB8220400,  //  00D3  GETNGBL	R8	K2
+      0x60240008,  //  00D4  GETGBL	R9	G8
+      0x88280B16,  //  00D5  GETMBR	R10	R5	K22
+      0x7C240200,  //  00D6  CALL	R9	1
+      0x00265E09,  //  00D7  ADD	R9	K47	R9
+      0x00241330,  //  00D8  ADD	R9	R9	K48
+      0x60280008,  //  00D9  GETGBL	R10	G8
+      0x882C0F31,  //  00DA  GETMBR	R11	R7	K49
+      0x7C280200,  //  00DB  CALL	R10	1
+      0x0024120A,  //  00DC  ADD	R9	R9	R10
+      0x58280021,  //  00DD  LDCONST	R10	K33
+      0x7C200400,  //  00DE  CALL	R8	2
+      0x8C200132,  //  00DF  GETMET	R8	R0	K50
+      0x5C280A00,  //  00E0  MOVE	R10	R5
+      0x502C0000,  //  00E1  LDBOOL	R11	0	0
+      0x7C200600,  //  00E2  CALL	R8	3
+      0x50200000,  //  00E3  LDBOOL	R8	0	0
+      0xA8040001,  //  00E4  EXBLK	1	1
+      0x80041000,  //  00E5  RET	1	R8
+      0x8C200B33,  //  00E6  GETMET	R8	R5	K51
+      0x7C200200,  //  00E7  CALL	R8	1
+      0xB8260000,  //  00E8  GETNGBL	R9	K0
+      0x88241301,  //  00E9  GETMBR	R9	R9	K1
+      0x8C241302,  //  00EA  GETMET	R9	R9	K2
+      0x582C0034,  //  00EB  LDCONST	R11	K52
+      0x7C240400,  //  00EC  CALL	R9	2
+      0x5C241000,  //  00ED  MOVE	R9	R8
+      0x74260002,  //  00EE  JMPT	R9	#00F2
+      0x50240000,  //  00EF  LDBOOL	R9	0	0
+      0xA8040001,  //  00F0  EXBLK	1	1
+      0x80041200,  //  00F1  RET	1	R9
+      0x8C240B1C,  //  00F2  GETMET	R9	R5	K28
+      0x7C240200,  //  00F3  CALL	R9	1
+      0xB8262E00,  //  00F4  GETNGBL	R9	K23
+      0x8C241318,  //  00F5  GETMET	R9	R9	K24
+      0x542E0003,  //  00F6  LDINT	R11	4
+      0x7C240400,  //  00F7  CALL	R9	2
+      0x78260012,  //  00F8  JMPF	R9	#010C
+      0xB8260400,  //  00F9  GETNGBL	R9	K2
+      0x60280008,  //  00FA  GETGBL	R10	G8
+      0x882C0B36,  //  00FB  GETMBR	R11	R5	K54
+      0x7C280200,  //  00FC  CALL	R10	1
+      0x002A6A0A,  //  00FD  ADD	R10	K53	R10
+      0x00281537,  //  00FE  ADD	R10	R10	K55
+      0x602C0008,  //  00FF  GETGBL	R11	G8
+      0x88300B1E,  //  0100  GETMBR	R12	R5	K30
+      0x7C2C0200,  //  0101  CALL	R11	1
+      0x0028140B,  //  0102  ADD	R10	R10	R11
+      0x00281538,  //  0103  ADD	R10	R10	K56
+      0x602C0008,  //  0104  GETGBL	R11	G8
+      0x88300B23,  //  0105  GETMBR	R12	R5	K35
+      0x5436FFFE,  //  0106  LDINT	R13	65535
+      0x2C30180D,  //  0107  AND	R12	R12	R13
+      0x7C2C0200,  //  0108  CALL	R11	1
+      0x0028140B,  //  0109  ADD	R10	R10	R11
+      0x542E0003,  //  010A  LDINT	R11	4
+      0x7C240400,  //  010B  CALL	R9	2
+      0x88240107,  //  010C  GETMBR	R9	R0	K7
+      0x8C24131D,  //  010D  GETMET	R9	R9	K29
+      0x5C2C0A00,  //  010E  MOVE	R11	R5
+      0x7C240400,  //  010F  CALL	R9	2
+      0x88240B36,  //  0110  GETMBR	R9	R5	K54
+      0x1C28130E,  //  0111  EQ	R10	R9	K14
+      0x782A000F,  //  0112  JMPF	R10	#0123
+      0x88280B1E,  //  0113  GETMBR	R10	R5	K30
+      0x542E000F,  //  0114  LDINT	R11	16
+      0x1C28140B,  //  0115  EQ	R10	R10	R11
+      0x782A0009,  //  0116  JMPF	R10	#0121
+      0x88280139,  //  0117  GETMBR	R10	R0	K57
+      0x8C28153A,  //  0118  GETMET	R10	R10	K58
+      0x5C300A00,  //  0119  MOVE	R12	R5
+      0x7C280400,  //  011A  CALL	R10	2
+      0x5C101400,  //  011B  MOVE	R4	R10
+      0x78120003,  //  011C  JMPF	R4	#0121
+      0x88280139,  //  011D  GETMBR	R10	R0	K57
+      0x8C28153B,  //  011E  GETMET	R10	R10	K59
+      0x5C300000,  //  011F  MOVE	R12	R0
+      0x7C280400,  //  0120  CALL	R10	2
+      0x50100200,  //  0121  LDBOOL	R4	1	0
+      0x70020023,  //  0122  JMP		#0147
+      0x1C28133C,  //  0123  EQ	R10	R9	K60
+      0x782A001A,  //  0124  JMPF	R10	#0140
+      0xB82A0000,  //  0125  GETNGBL	R10	K0
+      0x88281501,  //  0126  GETMBR	R10	R10	K1
+      0x8C281502,  //  0127  GETMET	R10	R10	K2
+      0x5830003D,  //  0128  LDCONST	R12	K61
+      0x7C280400,  //  0129  CALL	R10	2
+      0x88280139,  //  012A  GETMBR	R10	R0	K57
+      0x8C28152A,  //  012B  GETMET	R10	R10	K42
+      0x5C300A00,  //  012C  MOVE	R12	R5
+      0x7C280400,  //  012D  CALL	R10	2
+      0x5C101400,  //  012E  MOVE	R4	R10
+      0xB82A0000,  //  012F  GETNGBL	R10	K0
+      0x88281501,  //  0130  GETMBR	R10	R10	K1
+      0x8C281502,  //  0131  GETMET	R10	R10	K2
+      0x5830003E,  //  0132  LDCONST	R12	K62
+      0x7C280400,  //  0133  CALL	R10	2
+      0x78120004,  //  0134  JMPF	R4	#013A
+      0x88280139,  //  0135  GETMBR	R10	R0	K57
+      0x8C28153B,  //  0136  GETMET	R10	R10	K59
+      0x5C300000,  //  0137  MOVE	R12	R0
+      0x7C280400,  //  0138  CALL	R10	2
+      0x70020003,  //  0139  JMP		#013E
+      0x8C280132,  //  013A  GETMET	R10	R0	K50
+      0x5C300A00,  //  013B  MOVE	R12	R5
+      0x50340200,  //  013C  LDBOOL	R13	1	0
+      0x7C280600,  //  013D  CALL	R10	3
+      0x50100200,  //  013E  LDBOOL	R4	1	0
+      0x70020006,  //  013F  JMP		#0147
+      0xB82A0400,  //  0140  GETNGBL	R10	K2
+      0x602C0008,  //  0141  GETGBL	R11	G8
+      0x5C301200,  //  0142  MOVE	R12	R9
+      0x7C2C0200,  //  0143  CALL	R11	1
+      0x002E7E0B,  //  0144  ADD	R11	K63	R11
+      0x58300021,  //  0145  LDCONST	R12	K33
+      0x7C280400,  //  0146  CALL	R10	2
+      0xA8040001,  //  0147  EXBLK	1	1
+      0x80040800,  //  0148  RET	1	R4
+      0xA8040001,  //  0149  EXBLK	1	1
+      0x70020017,  //  014A  JMP		#0163
+      0xAC140002,  //  014B  CATCH	R5	0	2
+      0x70020014,  //  014C  JMP		#0162
+      0xB81E0400,  //  014D  GETNGBL	R7	K2
+      0x60200008,  //  014E  GETGBL	R8	G8
+      0x5C240A00,  //  014F  MOVE	R9	R5
+      0x7C200200,  //  0150  CALL	R8	1
+      0x00228008,  //  0151  ADD	R8	K64	R8
+      0x00201141,  //  0152  ADD	R8	R8	K65
+      0x60240008,  //  0153  GETGBL	R9	G8
+      0x5C280C00,  //  0154  MOVE	R10	R6
+      0x7C240200,  //  0155  CALL	R9	1
+      0x00201009,  //  0156  ADD	R8	R8	R9
+      0x58240042,  //  0157  LDCONST	R9	K66
+      0x7C1C0400,  //  0158  CALL	R7	2
+      0xB81E2E00,  //  0159  GETNGBL	R7	K23
+      0x881C0F43,  //  015A  GETMBR	R7	R7	K67
+      0x781E0002,  //  015B  JMPF	R7	#015F
+      0xA41E8800,  //  015C  IMPORT	R7	K68
+      0x8C200F45,  //  015D  GETMET	R8	R7	K69
+      0x7C200200,  //  015E  CALL	R8	1
+      0x501C0000,  //  015F  LDBOOL	R7	0	0
+      0x80040E00,  //  0160  RET	1	R7
+      0x70020000,  //  0161  JMP		#0163
+      0xB0080000,  //  0162  RAISE	2	R0	R0
+      0x80000000,  //  0163  RET	0
     })
   )
 );
@@ -641,7 +631,7 @@ be_local_closure(class_Matter_MessageHandler_send_response_frame,   /* name */
 extern const bclass be_class_Matter_MessageHandler;
 be_local_closure(class_Matter_MessageHandler_send_simple_ack,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -667,9 +657,9 @@ be_local_closure(class_Matter_MessageHandler_send_simple_ack,   /* name */
     }),
     be_str_weak(send_simple_ack),
     &be_const_str_solidified,
-    ( &(const binstruction[31]) {  /* code */
+    ( &(const binstruction[30]) {  /* code */
       0x880C0300,  //  0000  GETMBR	R3	R1	K0
-      0x780E001B,  //  0001  JMPF	R3	#001E
+      0x780E001A,  //  0001  JMPF	R3	#001D
       0x8C0C0301,  //  0002  GETMET	R3	R1	K1
       0x5C140400,  //  0003  MOVE	R5	R2
       0x7C0C0400,  //  0004  CALL	R3	2
@@ -679,26 +669,25 @@ be_local_closure(class_Matter_MessageHandler_send_simple_ack,   /* name */
       0x8C100904,  //  0008  GETMET	R4	R4	K4
       0x541A0003,  //  0009  LDINT	R6	4
       0x7C100400,  //  000A  CALL	R4	2
-      0x7812000E,  //  000B  JMPF	R4	#001B
-      0xB8120600,  //  000C  GETNGBL	R4	K3
-      0x8C100905,  //  000D  GETMET	R4	R4	K5
-      0x60180018,  //  000E  GETGBL	R6	G24
-      0x581C0006,  //  000F  LDCONST	R7	K6
-      0x88200707,  //  0010  GETMBR	R8	R3	K7
-      0x88201108,  //  0011  GETMBR	R8	R8	K8
-      0x88240709,  //  0012  GETMBR	R9	R3	K9
-      0x8828070A,  //  0013  GETMBR	R10	R3	K10
-      0x780A0001,  //  0014  JMPF	R2	#0017
-      0x582C000B,  //  0015  LDCONST	R11	K11
-      0x70020000,  //  0016  JMP		#0018
-      0x582C000C,  //  0017  LDCONST	R11	K12
-      0x7C180A00,  //  0018  CALL	R6	5
-      0x541E0003,  //  0019  LDINT	R7	4
-      0x7C100600,  //  001A  CALL	R4	3
-      0x8C10010D,  //  001B  GETMET	R4	R0	K13
-      0x5C180600,  //  001C  MOVE	R6	R3
-      0x7C100400,  //  001D  CALL	R4	2
-      0x80000000,  //  001E  RET	0
+      0x7812000D,  //  000B  JMPF	R4	#001A
+      0xB8120A00,  //  000C  GETNGBL	R4	K5
+      0x60140018,  //  000D  GETGBL	R5	G24
+      0x58180006,  //  000E  LDCONST	R6	K6
+      0x881C0707,  //  000F  GETMBR	R7	R3	K7
+      0x881C0F08,  //  0010  GETMBR	R7	R7	K8
+      0x88200709,  //  0011  GETMBR	R8	R3	K9
+      0x8824070A,  //  0012  GETMBR	R9	R3	K10
+      0x780A0001,  //  0013  JMPF	R2	#0016
+      0x5828000B,  //  0014  LDCONST	R10	K11
+      0x70020000,  //  0015  JMP		#0017
+      0x5828000C,  //  0016  LDCONST	R10	K12
+      0x7C140A00,  //  0017  CALL	R5	5
+      0x541A0003,  //  0018  LDINT	R6	4
+      0x7C100400,  //  0019  CALL	R4	2
+      0x8C10010D,  //  001A  GETMET	R4	R0	K13
+      0x5C180600,  //  001B  MOVE	R6	R3
+      0x7C100400,  //  001C  CALL	R4	2
+      0x80000000,  //  001D  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Device.h
@@ -575,7 +575,7 @@ be_local_closure(class_Matter_Plugin_Device_update_shadow,   /* name */
 extern const bclass be_class_Matter_Plugin_Device;
 be_local_closure(class_Matter_Plugin_Device_call_remote_sync,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -583,7 +583,7 @@ be_local_closure(class_Matter_Plugin_Device_call_remote_sync,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Plugin_Device, 
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
+    ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(BRIDGE),
     /* K1   */  be_nested_str_weak(json),
     /* K2   */  be_const_int(2),
@@ -595,16 +595,15 @@ be_local_closure(class_Matter_Plugin_Device_call_remote_sync,   /* name */
     /* K8   */  be_nested_str_weak(device_is_alive),
     /* K9   */  be_nested_str_weak(load),
     /* K10  */  be_const_int(1),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20GET_X20retrying),
-    /* K14  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(log),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20HTTP_X20GET_X20retrying),
+    /* K13  */  be_const_int(3),
     }),
     be_str_weak(call_remote_sync),
     &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
+    ( &(const binstruction[44]) {  /* code */
       0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x780E0029,  //  0001  JMPF	R3	#002C
+      0x780E0028,  //  0001  JMPF	R3	#002B
       0xA40E0200,  //  0002  IMPORT	R3	K1
       0x58100002,  //  0003  LDCONST	R4	K2
       0x4C140000,  //  0004  LDNIL	R5
@@ -617,7 +616,7 @@ be_local_closure(class_Matter_Plugin_Device_call_remote_sync,   /* name */
       0x00140A06,  //  000B  ADD	R5	R5	R6
       0x5C040A00,  //  000C  MOVE	R1	R5
       0x24140904,  //  000D  GT	R5	R4	K4
-      0x78160016,  //  000E  JMPF	R5	#0026
+      0x78160015,  //  000E  JMPF	R5	#0025
       0x88140105,  //  000F  GETMBR	R5	R0	K5
       0x8C140B06,  //  0010  GETMET	R5	R5	K6
       0x5C1C0200,  //  0011  MOVE	R7	R1
@@ -636,18 +635,17 @@ be_local_closure(class_Matter_Plugin_Device_call_remote_sync,   /* name */
       0x80040C00,  //  001E  RET	1	R6
       0x0410090A,  //  001F  SUB	R4	R4	K10
       0xB81A1600,  //  0020  GETNGBL	R6	K11
-      0x8C180D0C,  //  0021  GETMET	R6	R6	K12
+      0x581C000C,  //  0021  LDCONST	R7	K12
       0x5820000D,  //  0022  LDCONST	R8	K13
-      0x5824000E,  //  0023  LDCONST	R9	K14
-      0x7C180600,  //  0024  CALL	R6	3
-      0x7001FFE6,  //  0025  JMP		#000D
-      0x88140105,  //  0026  GETMBR	R5	R0	K5
-      0x8C140B08,  //  0027  GETMET	R5	R5	K8
-      0x501C0000,  //  0028  LDBOOL	R7	0	0
-      0x7C140400,  //  0029  CALL	R5	2
-      0x4C140000,  //  002A  LDNIL	R5
-      0x80040A00,  //  002B  RET	1	R5
-      0x80000000,  //  002C  RET	0
+      0x7C180400,  //  0023  CALL	R6	2
+      0x7001FFE7,  //  0024  JMP		#000D
+      0x88140105,  //  0025  GETMBR	R5	R0	K5
+      0x8C140B08,  //  0026  GETMET	R5	R5	K8
+      0x501C0000,  //  0027  LDBOOL	R7	0	0
+      0x7C140400,  //  0028  CALL	R5	2
+      0x4C140000,  //  0029  LDNIL	R5
+      0x80040A00,  //  002A  RET	1	R5
+      0x80000000,  //  002B  RET	0
     })
   )
 );
@@ -759,7 +757,7 @@ be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Plugin_Device, 
     1,                          /* has constants */
-    ( &(const bvalue[43]) {     /* constants */
+    ( &(const bvalue[44]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
@@ -786,27 +784,28 @@ be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
     /* K23  */  be_nested_str_weak(http_remote),
     /* K24  */  be_nested_str_weak(get_info),
     /* K25  */  be_nested_str_weak(name),
-    /* K26  */  be_nested_str_weak(UTF1),
-    /* K27  */  be_nested_str_weak(NULL),
+    /* K26  */  be_nested_str_weak(set_or_nil),
+    /* K27  */  be_nested_str_weak(UTF1),
     /* K28  */  be_nested_str_weak(tasmota),
     /* K29  */  be_nested_str_weak(cmd),
     /* K30  */  be_nested_str_weak(DeviceName),
     /* K31  */  be_nested_str_weak(get_name),
     /* K32  */  be_nested_str_weak(version),
     /* K33  */  be_nested_str_weak(_X28),
-    /* K34  */  be_nested_str_weak(Status_X202),
-    /* K35  */  be_nested_str_weak(StatusFWR),
-    /* K36  */  be_nested_str_weak(Version),
-    /* K37  */  be_nested_str_weak(mac),
-    /* K38  */  be_nested_str_weak(wifi),
-    /* K39  */  be_nested_str_weak(),
-    /* K40  */  be_nested_str_weak(BOOL),
-    /* K41  */  be_nested_str_weak(reachable),
-    /* K42  */  be_nested_str_weak(read_attribute),
+    /* K34  */  be_nested_str_weak(NULL),
+    /* K35  */  be_nested_str_weak(Status_X202),
+    /* K36  */  be_nested_str_weak(StatusFWR),
+    /* K37  */  be_nested_str_weak(Version),
+    /* K38  */  be_nested_str_weak(mac),
+    /* K39  */  be_nested_str_weak(wifi),
+    /* K40  */  be_nested_str_weak(),
+    /* K41  */  be_nested_str_weak(BOOL),
+    /* K42  */  be_nested_str_weak(reachable),
+    /* K43  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[258]) {  /* code */
+    ( &(const binstruction[244]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
@@ -828,7 +827,7 @@ be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
       0x58280005,  //  0012  LDCONST	R10	K5
       0x7C1C0600,  //  0013  CALL	R7	3
       0x80040E00,  //  0014  RET	1	R7
-      0x700200E2,  //  0015  JMP		#00F9
+      0x700200D4,  //  0015  JMP		#00EB
       0x541E0003,  //  0016  LDINT	R7	4
       0x1C1C0A07,  //  0017  EQ	R7	R5	R7
       0x781E0004,  //  0018  JMPF	R7	#001E
@@ -836,11 +835,11 @@ be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
       0x781E0001,  //  001A  JMPF	R7	#001D
       0x4C1C0000,  //  001B  LDNIL	R7
       0x80040E00,  //  001C  RET	1	R7
-      0x700200DA,  //  001D  JMP		#00F9
+      0x700200CC,  //  001D  JMP		#00EB
       0x541E0004,  //  001E  LDINT	R7	5
       0x1C1C0A07,  //  001F  EQ	R7	R5	R7
       0x781E0000,  //  0020  JMPF	R7	#0022
-      0x700200D6,  //  0021  JMP		#00F9
+      0x700200C8,  //  0021  JMP		#00EB
       0x541E001C,  //  0022  LDINT	R7	29
       0x1C1C0A07,  //  0023  EQ	R7	R5	R7
       0x781E0034,  //  0024  JMPF	R7	#005A
@@ -896,175 +895,161 @@ be_local_closure(class_Matter_Plugin_Device_read_attribute,   /* name */
       0x58380008,  //  0056  LDCONST	R14	K8
       0x7C280800,  //  0057  CALL	R10	4
       0x80040E00,  //  0058  RET	1	R7
-      0x7002009E,  //  0059  JMP		#00F9
+      0x70020090,  //  0059  JMP		#00EB
       0x541E0038,  //  005A  LDINT	R7	57
       0x1C1C0A07,  //  005B  EQ	R7	R5	R7
-      0x781E009B,  //  005C  JMPF	R7	#00F9
+      0x781E008D,  //  005C  JMPF	R7	#00EB
       0xA41E2A00,  //  005D  IMPORT	R7	K21
       0x1C200D04,  //  005E  EQ	R8	R6	K4
-      0x7822001F,  //  005F  JMPF	R8	#0080
+      0x78220018,  //  005F  JMPF	R8	#0079
       0x88200116,  //  0060  GETMBR	R8	R0	K22
-      0x78220012,  //  0061  JMPF	R8	#0075
+      0x7822000B,  //  0061  JMPF	R8	#006E
       0x88200117,  //  0062  GETMBR	R8	R0	K23
       0x8C201118,  //  0063  GETMET	R8	R8	K24
       0x7C200200,  //  0064  CALL	R8	1
       0x8C201111,  //  0065  GETMET	R8	R8	K17
       0x58280019,  //  0066  LDCONST	R10	K25
       0x7C200400,  //  0067  CALL	R8	2
-      0x78220005,  //  0068  JMPF	R8	#006F
-      0x8C240706,  //  0069  GETMET	R9	R3	K6
-      0x882C091A,  //  006A  GETMBR	R11	R4	K26
-      0x5C301000,  //  006B  MOVE	R12	R8
-      0x7C240600,  //  006C  CALL	R9	3
-      0x80041200,  //  006D  RET	1	R9
-      0x70020004,  //  006E  JMP		#0074
-      0x8C240706,  //  006F  GETMET	R9	R3	K6
-      0x882C091B,  //  0070  GETMBR	R11	R4	K27
-      0x4C300000,  //  0071  LDNIL	R12
-      0x7C240600,  //  0072  CALL	R9	3
-      0x80041200,  //  0073  RET	1	R9
-      0x70020009,  //  0074  JMP		#007F
-      0x8C200706,  //  0075  GETMET	R8	R3	K6
-      0x8828091A,  //  0076  GETMBR	R10	R4	K26
-      0xB82E3800,  //  0077  GETNGBL	R11	K28
-      0x8C2C171D,  //  0078  GETMET	R11	R11	K29
-      0x5834001E,  //  0079  LDCONST	R13	K30
-      0x50380200,  //  007A  LDBOOL	R14	1	0
-      0x7C2C0600,  //  007B  CALL	R11	3
-      0x942C171E,  //  007C  GETIDX	R11	R11	K30
-      0x7C200600,  //  007D  CALL	R8	3
-      0x80041000,  //  007E  RET	1	R8
-      0x70020078,  //  007F  JMP		#00F9
-      0x54220004,  //  0080  LDINT	R8	5
-      0x1C200C08,  //  0081  EQ	R8	R6	R8
-      0x78220006,  //  0082  JMPF	R8	#008A
-      0x8C200706,  //  0083  GETMET	R8	R3	K6
-      0x8828091A,  //  0084  GETMBR	R10	R4	K26
-      0x8C2C011F,  //  0085  GETMET	R11	R0	K31
-      0x7C2C0200,  //  0086  CALL	R11	1
-      0x7C200600,  //  0087  CALL	R8	3
-      0x80041000,  //  0088  RET	1	R8
-      0x7002006E,  //  0089  JMP		#00F9
-      0x54220009,  //  008A  LDINT	R8	10
-      0x1C200C08,  //  008B  EQ	R8	R6	R8
-      0x78220033,  //  008C  JMPF	R8	#00C1
-      0x88200116,  //  008D  GETMBR	R8	R0	K22
-      0x7822001B,  //  008E  JMPF	R8	#00AB
-      0x88200117,  //  008F  GETMBR	R8	R0	K23
-      0x8C201118,  //  0090  GETMET	R8	R8	K24
-      0x7C200200,  //  0091  CALL	R8	1
-      0x8C201111,  //  0092  GETMET	R8	R8	K17
-      0x58280020,  //  0093  LDCONST	R10	K32
-      0x7C200400,  //  0094  CALL	R8	2
-      0x7822000E,  //  0095  JMPF	R8	#00A5
-      0x8C240F11,  //  0096  GETMET	R9	R7	K17
-      0x5C2C1000,  //  0097  MOVE	R11	R8
-      0x58300021,  //  0098  LDCONST	R12	K33
-      0x7C240600,  //  0099  CALL	R9	3
-      0x24281305,  //  009A  GT	R10	R9	K5
-      0x782A0002,  //  009B  JMPF	R10	#009F
-      0x04281308,  //  009C  SUB	R10	R9	K8
-      0x402A0A0A,  //  009D  CONNECT	R10	K5	R10
-      0x9420100A,  //  009E  GETIDX	R8	R8	R10
-      0x8C280706,  //  009F  GETMET	R10	R3	K6
-      0x8830091A,  //  00A0  GETMBR	R12	R4	K26
-      0x5C341000,  //  00A1  MOVE	R13	R8
-      0x7C280600,  //  00A2  CALL	R10	3
-      0x80041400,  //  00A3  RET	1	R10
-      0x70020004,  //  00A4  JMP		#00AA
-      0x8C240706,  //  00A5  GETMET	R9	R3	K6
-      0x882C091B,  //  00A6  GETMBR	R11	R4	K27
-      0x4C300000,  //  00A7  LDNIL	R12
-      0x7C240600,  //  00A8  CALL	R9	3
-      0x80041200,  //  00A9  RET	1	R9
-      0x70020014,  //  00AA  JMP		#00C0
-      0xB8223800,  //  00AB  GETNGBL	R8	K28
-      0x8C20111D,  //  00AC  GETMET	R8	R8	K29
-      0x58280022,  //  00AD  LDCONST	R10	K34
-      0x502C0200,  //  00AE  LDBOOL	R11	1	0
-      0x7C200600,  //  00AF  CALL	R8	3
-      0x94201123,  //  00B0  GETIDX	R8	R8	K35
-      0x94201124,  //  00B1  GETIDX	R8	R8	K36
-      0x8C240F11,  //  00B2  GETMET	R9	R7	K17
-      0x5C2C1000,  //  00B3  MOVE	R11	R8
-      0x58300021,  //  00B4  LDCONST	R12	K33
-      0x7C240600,  //  00B5  CALL	R9	3
-      0x24281305,  //  00B6  GT	R10	R9	K5
-      0x782A0002,  //  00B7  JMPF	R10	#00BB
-      0x04281308,  //  00B8  SUB	R10	R9	K8
-      0x402A0A0A,  //  00B9  CONNECT	R10	K5	R10
-      0x9420100A,  //  00BA  GETIDX	R8	R8	R10
-      0x8C280706,  //  00BB  GETMET	R10	R3	K6
-      0x8830091A,  //  00BC  GETMBR	R12	R4	K26
-      0x5C341000,  //  00BD  MOVE	R13	R8
-      0x7C280600,  //  00BE  CALL	R10	3
-      0x80041400,  //  00BF  RET	1	R10
-      0x70020037,  //  00C0  JMP		#00F9
-      0x5422000E,  //  00C1  LDINT	R8	15
-      0x1C200C08,  //  00C2  EQ	R8	R6	R8
-      0x74220002,  //  00C3  JMPT	R8	#00C7
-      0x54220011,  //  00C4  LDINT	R8	18
-      0x1C200C08,  //  00C5  EQ	R8	R6	R8
-      0x78220020,  //  00C6  JMPF	R8	#00E8
-      0x88200116,  //  00C7  GETMBR	R8	R0	K22
-      0x78220012,  //  00C8  JMPF	R8	#00DC
-      0x88200117,  //  00C9  GETMBR	R8	R0	K23
-      0x8C201118,  //  00CA  GETMET	R8	R8	K24
-      0x7C200200,  //  00CB  CALL	R8	1
-      0x8C201111,  //  00CC  GETMET	R8	R8	K17
-      0x58280025,  //  00CD  LDCONST	R10	K37
-      0x7C200400,  //  00CE  CALL	R8	2
-      0x78220005,  //  00CF  JMPF	R8	#00D6
-      0x8C240706,  //  00D0  GETMET	R9	R3	K6
-      0x882C091A,  //  00D1  GETMBR	R11	R4	K26
-      0x5C301000,  //  00D2  MOVE	R12	R8
-      0x7C240600,  //  00D3  CALL	R9	3
-      0x80041200,  //  00D4  RET	1	R9
-      0x70020004,  //  00D5  JMP		#00DB
-      0x8C240706,  //  00D6  GETMET	R9	R3	K6
-      0x882C091B,  //  00D7  GETMBR	R11	R4	K27
-      0x4C300000,  //  00D8  LDNIL	R12
-      0x7C240600,  //  00D9  CALL	R9	3
-      0x80041200,  //  00DA  RET	1	R9
-      0x7002000A,  //  00DB  JMP		#00E7
-      0x8C200706,  //  00DC  GETMET	R8	R3	K6
-      0x8828091A,  //  00DD  GETMBR	R10	R4	K26
-      0xB82E3800,  //  00DE  GETNGBL	R11	K28
-      0x8C2C1726,  //  00DF  GETMET	R11	R11	K38
-      0x7C2C0200,  //  00E0  CALL	R11	1
-      0x8C2C1711,  //  00E1  GETMET	R11	R11	K17
-      0x58340025,  //  00E2  LDCONST	R13	K37
-      0x58380027,  //  00E3  LDCONST	R14	K39
-      0x7C2C0600,  //  00E4  CALL	R11	3
-      0x7C200600,  //  00E5  CALL	R8	3
-      0x80041000,  //  00E6  RET	1	R8
-      0x70020010,  //  00E7  JMP		#00F9
-      0x54220010,  //  00E8  LDINT	R8	17
-      0x1C200C08,  //  00E9  EQ	R8	R6	R8
-      0x7822000D,  //  00EA  JMPF	R8	#00F9
-      0x88200116,  //  00EB  GETMBR	R8	R0	K22
-      0x78220006,  //  00EC  JMPF	R8	#00F4
-      0x8C200706,  //  00ED  GETMET	R8	R3	K6
-      0x88280928,  //  00EE  GETMBR	R10	R4	K40
-      0x882C0117,  //  00EF  GETMBR	R11	R0	K23
-      0x882C1729,  //  00F0  GETMBR	R11	R11	K41
-      0x7C200600,  //  00F1  CALL	R8	3
-      0x80041000,  //  00F2  RET	1	R8
-      0x70020004,  //  00F3  JMP		#00F9
-      0x8C200706,  //  00F4  GETMET	R8	R3	K6
-      0x88280928,  //  00F5  GETMBR	R10	R4	K40
-      0x582C0008,  //  00F6  LDCONST	R11	K8
-      0x7C200600,  //  00F7  CALL	R8	3
-      0x80041000,  //  00F8  RET	1	R8
-      0x601C0003,  //  00F9  GETGBL	R7	G3
-      0x5C200000,  //  00FA  MOVE	R8	R0
-      0x7C1C0200,  //  00FB  CALL	R7	1
-      0x8C1C0F2A,  //  00FC  GETMET	R7	R7	K42
-      0x5C240200,  //  00FD  MOVE	R9	R1
-      0x5C280400,  //  00FE  MOVE	R10	R2
-      0x5C2C0600,  //  00FF  MOVE	R11	R3
-      0x7C1C0800,  //  0100  CALL	R7	4
-      0x80040E00,  //  0101  RET	1	R7
+      0x8C24071A,  //  0068  GETMET	R9	R3	K26
+      0x882C091B,  //  0069  GETMBR	R11	R4	K27
+      0x5C301000,  //  006A  MOVE	R12	R8
+      0x7C240600,  //  006B  CALL	R9	3
+      0x80041200,  //  006C  RET	1	R9
+      0x70020009,  //  006D  JMP		#0078
+      0x8C200706,  //  006E  GETMET	R8	R3	K6
+      0x8828091B,  //  006F  GETMBR	R10	R4	K27
+      0xB82E3800,  //  0070  GETNGBL	R11	K28
+      0x8C2C171D,  //  0071  GETMET	R11	R11	K29
+      0x5834001E,  //  0072  LDCONST	R13	K30
+      0x50380200,  //  0073  LDBOOL	R14	1	0
+      0x7C2C0600,  //  0074  CALL	R11	3
+      0x942C171E,  //  0075  GETIDX	R11	R11	K30
+      0x7C200600,  //  0076  CALL	R8	3
+      0x80041000,  //  0077  RET	1	R8
+      0x70020071,  //  0078  JMP		#00EB
+      0x54220004,  //  0079  LDINT	R8	5
+      0x1C200C08,  //  007A  EQ	R8	R6	R8
+      0x78220006,  //  007B  JMPF	R8	#0083
+      0x8C200706,  //  007C  GETMET	R8	R3	K6
+      0x8828091B,  //  007D  GETMBR	R10	R4	K27
+      0x8C2C011F,  //  007E  GETMET	R11	R0	K31
+      0x7C2C0200,  //  007F  CALL	R11	1
+      0x7C200600,  //  0080  CALL	R8	3
+      0x80041000,  //  0081  RET	1	R8
+      0x70020067,  //  0082  JMP		#00EB
+      0x54220009,  //  0083  LDINT	R8	10
+      0x1C200C08,  //  0084  EQ	R8	R6	R8
+      0x78220033,  //  0085  JMPF	R8	#00BA
+      0x88200116,  //  0086  GETMBR	R8	R0	K22
+      0x7822001B,  //  0087  JMPF	R8	#00A4
+      0x88200117,  //  0088  GETMBR	R8	R0	K23
+      0x8C201118,  //  0089  GETMET	R8	R8	K24
+      0x7C200200,  //  008A  CALL	R8	1
+      0x8C201111,  //  008B  GETMET	R8	R8	K17
+      0x58280020,  //  008C  LDCONST	R10	K32
+      0x7C200400,  //  008D  CALL	R8	2
+      0x7822000E,  //  008E  JMPF	R8	#009E
+      0x8C240F11,  //  008F  GETMET	R9	R7	K17
+      0x5C2C1000,  //  0090  MOVE	R11	R8
+      0x58300021,  //  0091  LDCONST	R12	K33
+      0x7C240600,  //  0092  CALL	R9	3
+      0x24281305,  //  0093  GT	R10	R9	K5
+      0x782A0002,  //  0094  JMPF	R10	#0098
+      0x04281308,  //  0095  SUB	R10	R9	K8
+      0x402A0A0A,  //  0096  CONNECT	R10	K5	R10
+      0x9420100A,  //  0097  GETIDX	R8	R8	R10
+      0x8C280706,  //  0098  GETMET	R10	R3	K6
+      0x8830091B,  //  0099  GETMBR	R12	R4	K27
+      0x5C341000,  //  009A  MOVE	R13	R8
+      0x7C280600,  //  009B  CALL	R10	3
+      0x80041400,  //  009C  RET	1	R10
+      0x70020004,  //  009D  JMP		#00A3
+      0x8C240706,  //  009E  GETMET	R9	R3	K6
+      0x882C0922,  //  009F  GETMBR	R11	R4	K34
+      0x4C300000,  //  00A0  LDNIL	R12
+      0x7C240600,  //  00A1  CALL	R9	3
+      0x80041200,  //  00A2  RET	1	R9
+      0x70020014,  //  00A3  JMP		#00B9
+      0xB8223800,  //  00A4  GETNGBL	R8	K28
+      0x8C20111D,  //  00A5  GETMET	R8	R8	K29
+      0x58280023,  //  00A6  LDCONST	R10	K35
+      0x502C0200,  //  00A7  LDBOOL	R11	1	0
+      0x7C200600,  //  00A8  CALL	R8	3
+      0x94201124,  //  00A9  GETIDX	R8	R8	K36
+      0x94201125,  //  00AA  GETIDX	R8	R8	K37
+      0x8C240F11,  //  00AB  GETMET	R9	R7	K17
+      0x5C2C1000,  //  00AC  MOVE	R11	R8
+      0x58300021,  //  00AD  LDCONST	R12	K33
+      0x7C240600,  //  00AE  CALL	R9	3
+      0x24281305,  //  00AF  GT	R10	R9	K5
+      0x782A0002,  //  00B0  JMPF	R10	#00B4
+      0x04281308,  //  00B1  SUB	R10	R9	K8
+      0x402A0A0A,  //  00B2  CONNECT	R10	K5	R10
+      0x9420100A,  //  00B3  GETIDX	R8	R8	R10
+      0x8C280706,  //  00B4  GETMET	R10	R3	K6
+      0x8830091B,  //  00B5  GETMBR	R12	R4	K27
+      0x5C341000,  //  00B6  MOVE	R13	R8
+      0x7C280600,  //  00B7  CALL	R10	3
+      0x80041400,  //  00B8  RET	1	R10
+      0x70020030,  //  00B9  JMP		#00EB
+      0x5422000E,  //  00BA  LDINT	R8	15
+      0x1C200C08,  //  00BB  EQ	R8	R6	R8
+      0x74220002,  //  00BC  JMPT	R8	#00C0
+      0x54220011,  //  00BD  LDINT	R8	18
+      0x1C200C08,  //  00BE  EQ	R8	R6	R8
+      0x78220019,  //  00BF  JMPF	R8	#00DA
+      0x88200116,  //  00C0  GETMBR	R8	R0	K22
+      0x7822000B,  //  00C1  JMPF	R8	#00CE
+      0x88200117,  //  00C2  GETMBR	R8	R0	K23
+      0x8C201118,  //  00C3  GETMET	R8	R8	K24
+      0x7C200200,  //  00C4  CALL	R8	1
+      0x8C201111,  //  00C5  GETMET	R8	R8	K17
+      0x58280026,  //  00C6  LDCONST	R10	K38
+      0x7C200400,  //  00C7  CALL	R8	2
+      0x8C24071A,  //  00C8  GETMET	R9	R3	K26
+      0x882C091B,  //  00C9  GETMBR	R11	R4	K27
+      0x5C301000,  //  00CA  MOVE	R12	R8
+      0x7C240600,  //  00CB  CALL	R9	3
+      0x80041200,  //  00CC  RET	1	R9
+      0x7002000A,  //  00CD  JMP		#00D9
+      0x8C200706,  //  00CE  GETMET	R8	R3	K6
+      0x8828091B,  //  00CF  GETMBR	R10	R4	K27
+      0xB82E3800,  //  00D0  GETNGBL	R11	K28
+      0x8C2C1727,  //  00D1  GETMET	R11	R11	K39
+      0x7C2C0200,  //  00D2  CALL	R11	1
+      0x8C2C1711,  //  00D3  GETMET	R11	R11	K17
+      0x58340026,  //  00D4  LDCONST	R13	K38
+      0x58380028,  //  00D5  LDCONST	R14	K40
+      0x7C2C0600,  //  00D6  CALL	R11	3
+      0x7C200600,  //  00D7  CALL	R8	3
+      0x80041000,  //  00D8  RET	1	R8
+      0x70020010,  //  00D9  JMP		#00EB
+      0x54220010,  //  00DA  LDINT	R8	17
+      0x1C200C08,  //  00DB  EQ	R8	R6	R8
+      0x7822000D,  //  00DC  JMPF	R8	#00EB
+      0x88200116,  //  00DD  GETMBR	R8	R0	K22
+      0x78220006,  //  00DE  JMPF	R8	#00E6
+      0x8C200706,  //  00DF  GETMET	R8	R3	K6
+      0x88280929,  //  00E0  GETMBR	R10	R4	K41
+      0x882C0117,  //  00E1  GETMBR	R11	R0	K23
+      0x882C172A,  //  00E2  GETMBR	R11	R11	K42
+      0x7C200600,  //  00E3  CALL	R8	3
+      0x80041000,  //  00E4  RET	1	R8
+      0x70020004,  //  00E5  JMP		#00EB
+      0x8C200706,  //  00E6  GETMET	R8	R3	K6
+      0x88280929,  //  00E7  GETMBR	R10	R4	K41
+      0x582C0008,  //  00E8  LDCONST	R11	K8
+      0x7C200600,  //  00E9  CALL	R8	3
+      0x80041000,  //  00EA  RET	1	R8
+      0x601C0003,  //  00EB  GETGBL	R7	G3
+      0x5C200000,  //  00EC  MOVE	R8	R0
+      0x7C1C0200,  //  00ED  CALL	R7	1
+      0x8C1C0F2B,  //  00EE  GETMET	R7	R7	K43
+      0x5C240200,  //  00EF  MOVE	R9	R1
+      0x5C280400,  //  00F0  MOVE	R10	R2
+      0x5C2C0600,  //  00F1  MOVE	R11	R3
+      0x7C1C0800,  //  00F2  CALL	R7	4
+      0x80040E00,  //  00F3  RET	1	R7
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_1_Root.h
@@ -20,7 +20,7 @@ be_local_closure(class_Matter_Plugin_Root_read_attribute,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Plugin_Root, 
     1,                          /* has constants */
-    ( &(const bvalue[94]) {     /* constants */
+    ( &(const bvalue[95]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
@@ -98,27 +98,28 @@ be_local_closure(class_Matter_Plugin_Root_read_attribute,   /* name */
     /* K74  */  be_nested_str_weak(is_commissioning_open),
     /* K75  */  be_nested_str_weak(is_root_commissioning_open),
     /* K76  */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K77  */  be_nested_str_weak(Tasmota),
-    /* K78  */  be_nested_str_weak(vendorid),
-    /* K79  */  be_nested_str_weak(DeviceName),
-    /* K80  */  be_nested_str_weak(FriendlyName),
-    /* K81  */  be_nested_str_weak(FriendlyName1),
-    /* K82  */  be_nested_str_weak(XX),
-    /* K83  */  be_nested_str_weak(Status_X202),
-    /* K84  */  be_nested_str_weak(StatusFWR),
-    /* K85  */  be_nested_str_weak(Hardware),
-    /* K86  */  be_nested_str_weak(Version),
-    /* K87  */  be_nested_str_weak(_X28),
-    /* K88  */  be_nested_str_weak(locale),
-    /* K89  */  be_nested_str_weak(create_TLV),
-    /* K90  */  be_nested_str_weak(get_active_endpoints),
-    /* K91  */  be_nested_str_weak(disable_bridge_mode),
-    /* K92  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-    /* K93  */  be_nested_str_weak(read_attribute),
+    /* K77  */  be_nested_str_weak(set_or_nil),
+    /* K78  */  be_nested_str_weak(Tasmota),
+    /* K79  */  be_nested_str_weak(vendorid),
+    /* K80  */  be_nested_str_weak(DeviceName),
+    /* K81  */  be_nested_str_weak(FriendlyName),
+    /* K82  */  be_nested_str_weak(FriendlyName1),
+    /* K83  */  be_nested_str_weak(XX),
+    /* K84  */  be_nested_str_weak(Status_X202),
+    /* K85  */  be_nested_str_weak(StatusFWR),
+    /* K86  */  be_nested_str_weak(Hardware),
+    /* K87  */  be_nested_str_weak(Version),
+    /* K88  */  be_nested_str_weak(_X28),
+    /* K89  */  be_nested_str_weak(locale),
+    /* K90  */  be_nested_str_weak(create_TLV),
+    /* K91  */  be_nested_str_weak(get_active_endpoints),
+    /* K92  */  be_nested_str_weak(disable_bridge_mode),
+    /* K93  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+    /* K94  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[936]) {  /* code */
+    ( &(const binstruction[924]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xB8160200,  //  0001  GETNGBL	R5	K1
       0x88140B02,  //  0002  GETMBR	R5	R5	K2
@@ -175,11 +176,11 @@ be_local_closure(class_Matter_Plugin_Root_read_attribute,   /* name */
       0x502C0000,  //  0035  LDBOOL	R11	0	0
       0x7C200600,  //  0036  CALL	R8	3
       0x80041000,  //  0037  RET	1	R8
-      0x70020365,  //  0038  JMP		#039F
+      0x70020359,  //  0038  JMP		#0393
       0x54220031,  //  0039  LDINT	R8	50
       0x1C200C08,  //  003A  EQ	R8	R6	R8
       0x78220000,  //  003B  JMPF	R8	#003D
-      0x70020361,  //  003C  JMP		#039F
+      0x70020355,  //  003C  JMP		#0393
       0x54220032,  //  003D  LDINT	R8	51
       0x1C200C08,  //  003E  EQ	R8	R6	R8
       0x782200DC,  //  003F  JMPF	R8	#011D
@@ -403,11 +404,11 @@ be_local_closure(class_Matter_Plugin_Root_read_attribute,   /* name */
       0x502C0000,  //  0119  LDBOOL	R11	0	0
       0x7C200600,  //  011A  CALL	R8	3
       0x80041000,  //  011B  RET	1	R8
-      0x70020281,  //  011C  JMP		#039F
+      0x70020275,  //  011C  JMP		#0393
       0x54220033,  //  011D  LDINT	R8	52
       0x1C200C08,  //  011E  EQ	R8	R6	R8
       0x78220000,  //  011F  JMPF	R8	#0121
-      0x7002027D,  //  0120  JMP		#039F
+      0x70020271,  //  0120  JMP		#0393
       0x54220037,  //  0121  LDINT	R8	56
       0x1C200C08,  //  0122  EQ	R8	R6	R8
       0x7822002B,  //  0123  JMPF	R8	#0150
@@ -442,8 +443,8 @@ be_local_closure(class_Matter_Plugin_Root_read_attribute,   /* name */
       0xB8225C00,  //  0140  GETNGBL	R8	K46
       0xB8262400,  //  0141  GETNGBL	R9	K18
       0x8C241331,  //  0142  GETMET	R9	R9	K49
-      0x7C240200,  //  0143  CALL	R9	1
-      0x94241332,  //  0144  GETIDX	R9	R9	K50
+      0x582C0032,  //  0143  LDCONST	R11	K50
+      0x7C240400,  //  0144  CALL	R9	2
       0x7C200200,  //  0145  CALL	R8	1
       0xB8265C00,  //  0146  GETNGBL	R9	K46
       0x58280030,  //  0147  LDCONST	R10	K48
@@ -454,7 +455,7 @@ be_local_closure(class_Matter_Plugin_Root_read_attribute,   /* name */
       0x5C301000,  //  014C  MOVE	R12	R8
       0x7C240600,  //  014D  CALL	R9	3
       0x80041200,  //  014E  RET	1	R9
-      0x7002024E,  //  014F  JMP		#039F
+      0x70020242,  //  014F  JMP		#0393
       0x5422003D,  //  0150  LDINT	R8	62
       0x1C200C08,  //  0151  EQ	R8	R6	R8
       0x782200B5,  //  0152  JMPF	R8	#0209
@@ -639,10 +640,10 @@ be_local_closure(class_Matter_Plugin_Root_read_attribute,   /* name */
       0x5C301000,  //  0205  MOVE	R12	R8
       0x7C240600,  //  0206  CALL	R9	3
       0x80041200,  //  0207  RET	1	R9
-      0x70020195,  //  0208  JMP		#039F
+      0x70020189,  //  0208  JMP		#0393
       0x5422003B,  //  0209  LDINT	R8	60
       0x1C200C08,  //  020A  EQ	R8	R6	R8
-      0x7822003C,  //  020B  JMPF	R8	#0249
+      0x78220030,  //  020B  JMPF	R8	#023D
       0x1C200F05,  //  020C  EQ	R8	R7	K5
       0x78220012,  //  020D  JMPF	R8	#0221
       0x88200136,  //  020E  GETMBR	R8	R0	K54
@@ -663,398 +664,386 @@ be_local_closure(class_Matter_Plugin_Root_read_attribute,   /* name */
       0x5C381400,  //  021D  MOVE	R14	R10
       0x7C2C0600,  //  021E  CALL	R11	3
       0x80041600,  //  021F  RET	1	R11
-      0x70020026,  //  0220  JMP		#0248
+      0x7002001A,  //  0220  JMP		#023C
       0x1C200F09,  //  0221  EQ	R8	R7	K9
-      0x78220011,  //  0222  JMPF	R8	#0235
+      0x7822000B,  //  0222  JMPF	R8	#022F
       0x88200136,  //  0223  GETMBR	R8	R0	K54
       0x8820114C,  //  0224  GETMBR	R8	R8	K76
       0x4C240000,  //  0225  LDNIL	R9
       0x20241009,  //  0226  NE	R9	R8	R9
-      0x78260006,  //  0227  JMPF	R9	#022F
-      0x8C240706,  //  0228  GETMET	R9	R3	K6
+      0x78260005,  //  0227  JMPF	R9	#022E
+      0x8C24074D,  //  0228  GETMET	R9	R3	K77
       0x882C0B0C,  //  0229  GETMBR	R11	R5	K12
       0x8C30113D,  //  022A  GETMET	R12	R8	K61
       0x7C300200,  //  022B  CALL	R12	1
       0x7C240600,  //  022C  CALL	R9	3
       0x80041200,  //  022D  RET	1	R9
-      0x70020004,  //  022E  JMP		#0234
-      0x8C240706,  //  022F  GETMET	R9	R3	K6
-      0x882C0B18,  //  0230  GETMBR	R11	R5	K24
-      0x4C300000,  //  0231  LDNIL	R12
-      0x7C240600,  //  0232  CALL	R9	3
-      0x80041200,  //  0233  RET	1	R9
-      0x70020012,  //  0234  JMP		#0248
-      0x1C200F0D,  //  0235  EQ	R8	R7	K13
-      0x78220010,  //  0236  JMPF	R8	#0248
-      0x88200136,  //  0237  GETMBR	R8	R0	K54
-      0x8820114C,  //  0238  GETMBR	R8	R8	K76
-      0x4C240000,  //  0239  LDNIL	R9
-      0x20241009,  //  023A  NE	R9	R8	R9
-      0x78260006,  //  023B  JMPF	R9	#0243
-      0x8C240706,  //  023C  GETMET	R9	R3	K6
-      0x882C0B0C,  //  023D  GETMBR	R11	R5	K12
-      0x8C301142,  //  023E  GETMET	R12	R8	K66
-      0x7C300200,  //  023F  CALL	R12	1
-      0x7C240600,  //  0240  CALL	R9	3
-      0x80041200,  //  0241  RET	1	R9
-      0x70020004,  //  0242  JMP		#0248
-      0x8C240706,  //  0243  GETMET	R9	R3	K6
-      0x882C0B18,  //  0244  GETMBR	R11	R5	K24
-      0x4C300000,  //  0245  LDNIL	R12
-      0x7C240600,  //  0246  CALL	R9	3
-      0x80041200,  //  0247  RET	1	R9
-      0x70020155,  //  0248  JMP		#039F
-      0x54220027,  //  0249  LDINT	R8	40
-      0x1C200C08,  //  024A  EQ	R8	R6	R8
-      0x782200BA,  //  024B  JMPF	R8	#0307
-      0x8C200133,  //  024C  GETMET	R8	R0	K51
-      0x5C280400,  //  024D  MOVE	R10	R2
-      0x7C200400,  //  024E  CALL	R8	2
-      0x1C200F05,  //  024F  EQ	R8	R7	K5
-      0x78220005,  //  0250  JMPF	R8	#0257
-      0x8C200706,  //  0251  GETMET	R8	R3	K6
-      0x88280B0C,  //  0252  GETMBR	R10	R5	K12
-      0x582C0009,  //  0253  LDCONST	R11	K9
-      0x7C200600,  //  0254  CALL	R8	3
-      0x80041000,  //  0255  RET	1	R8
-      0x700200AE,  //  0256  JMP		#0306
-      0x1C200F09,  //  0257  EQ	R8	R7	K9
-      0x78220005,  //  0258  JMPF	R8	#025F
-      0x8C200706,  //  0259  GETMET	R8	R3	K6
-      0x88280B16,  //  025A  GETMBR	R10	R5	K22
-      0x582C004D,  //  025B  LDCONST	R11	K77
-      0x7C200600,  //  025C  CALL	R8	3
-      0x80041000,  //  025D  RET	1	R8
-      0x700200A6,  //  025E  JMP		#0306
-      0x1C200F0D,  //  025F  EQ	R8	R7	K13
-      0x78220006,  //  0260  JMPF	R8	#0268
-      0x8C200706,  //  0261  GETMET	R8	R3	K6
-      0x88280B0C,  //  0262  GETMBR	R10	R5	K12
-      0x882C0136,  //  0263  GETMBR	R11	R0	K54
-      0x882C174E,  //  0264  GETMBR	R11	R11	K78
-      0x7C200600,  //  0265  CALL	R8	3
-      0x80041000,  //  0266  RET	1	R8
-      0x7002009D,  //  0267  JMP		#0306
-      0x1C200F0F,  //  0268  EQ	R8	R7	K15
-      0x7822000A,  //  0269  JMPF	R8	#0275
-      0x8C200706,  //  026A  GETMET	R8	R3	K6
-      0x88280B16,  //  026B  GETMBR	R10	R5	K22
-      0xB82E2400,  //  026C  GETNGBL	R11	K18
-      0x8C2C1726,  //  026D  GETMET	R11	R11	K38
-      0x5834004F,  //  026E  LDCONST	R13	K79
-      0x50380200,  //  026F  LDBOOL	R14	1	0
-      0x7C2C0600,  //  0270  CALL	R11	3
-      0x942C174F,  //  0271  GETIDX	R11	R11	K79
-      0x7C200600,  //  0272  CALL	R8	3
-      0x80041000,  //  0273  RET	1	R8
-      0x70020090,  //  0274  JMP		#0306
-      0x54220003,  //  0275  LDINT	R8	4
-      0x1C200E08,  //  0276  EQ	R8	R7	R8
-      0x78220005,  //  0277  JMPF	R8	#027E
-      0x8C200706,  //  0278  GETMET	R8	R3	K6
-      0x88280B0C,  //  0279  GETMBR	R10	R5	K12
-      0x542E7FFF,  //  027A  LDINT	R11	32768
-      0x7C200600,  //  027B  CALL	R8	3
-      0x80041000,  //  027C  RET	1	R8
-      0x70020087,  //  027D  JMP		#0306
-      0x54220004,  //  027E  LDINT	R8	5
-      0x1C200E08,  //  027F  EQ	R8	R7	R8
-      0x7822000A,  //  0280  JMPF	R8	#028C
-      0x8C200706,  //  0281  GETMET	R8	R3	K6
-      0x88280B16,  //  0282  GETMBR	R10	R5	K22
-      0xB82E2400,  //  0283  GETNGBL	R11	K18
-      0x8C2C1726,  //  0284  GETMET	R11	R11	K38
-      0x58340050,  //  0285  LDCONST	R13	K80
-      0x50380200,  //  0286  LDBOOL	R14	1	0
-      0x7C2C0600,  //  0287  CALL	R11	3
-      0x942C1751,  //  0288  GETIDX	R11	R11	K81
-      0x7C200600,  //  0289  CALL	R8	3
-      0x80041000,  //  028A  RET	1	R8
-      0x70020079,  //  028B  JMP		#0306
-      0x54220005,  //  028C  LDINT	R8	6
-      0x1C200E08,  //  028D  EQ	R8	R7	R8
-      0x78220005,  //  028E  JMPF	R8	#0295
-      0x8C200706,  //  028F  GETMET	R8	R3	K6
-      0x88280B16,  //  0290  GETMBR	R10	R5	K22
-      0x582C0052,  //  0291  LDCONST	R11	K82
-      0x7C200600,  //  0292  CALL	R8	3
-      0x80041000,  //  0293  RET	1	R8
-      0x70020070,  //  0294  JMP		#0306
-      0x54220006,  //  0295  LDINT	R8	7
-      0x1C200E08,  //  0296  EQ	R8	R7	R8
-      0x78220005,  //  0297  JMPF	R8	#029E
-      0x8C200706,  //  0298  GETMET	R8	R3	K6
-      0x88280B0C,  //  0299  GETMBR	R10	R5	K12
-      0x582C0005,  //  029A  LDCONST	R11	K5
-      0x7C200600,  //  029B  CALL	R8	3
-      0x80041000,  //  029C  RET	1	R8
-      0x70020067,  //  029D  JMP		#0306
-      0x54220007,  //  029E  LDINT	R8	8
-      0x1C200E08,  //  029F  EQ	R8	R7	R8
-      0x7822000B,  //  02A0  JMPF	R8	#02AD
-      0x8C200706,  //  02A1  GETMET	R8	R3	K6
-      0x88280B16,  //  02A2  GETMBR	R10	R5	K22
-      0xB82E2400,  //  02A3  GETNGBL	R11	K18
-      0x8C2C1726,  //  02A4  GETMET	R11	R11	K38
-      0x58340053,  //  02A5  LDCONST	R13	K83
-      0x50380200,  //  02A6  LDBOOL	R14	1	0
-      0x7C2C0600,  //  02A7  CALL	R11	3
-      0x942C1754,  //  02A8  GETIDX	R11	R11	K84
-      0x942C1755,  //  02A9  GETIDX	R11	R11	K85
-      0x7C200600,  //  02AA  CALL	R8	3
-      0x80041000,  //  02AB  RET	1	R8
-      0x70020058,  //  02AC  JMP		#0306
-      0x54220008,  //  02AD  LDINT	R8	9
-      0x1C200E08,  //  02AE  EQ	R8	R7	R8
-      0x78220005,  //  02AF  JMPF	R8	#02B6
-      0x8C200706,  //  02B0  GETMET	R8	R3	K6
-      0x88280B0C,  //  02B1  GETMBR	R10	R5	K12
-      0x582C0009,  //  02B2  LDCONST	R11	K9
-      0x7C200600,  //  02B3  CALL	R8	3
-      0x80041000,  //  02B4  RET	1	R8
-      0x7002004F,  //  02B5  JMP		#0306
-      0x54220009,  //  02B6  LDINT	R8	10
-      0x1C200E08,  //  02B7  EQ	R8	R7	R8
-      0x78220015,  //  02B8  JMPF	R8	#02CF
-      0xB8222400,  //  02B9  GETNGBL	R8	K18
-      0x8C201126,  //  02BA  GETMET	R8	R8	K38
-      0x58280053,  //  02BB  LDCONST	R10	K83
-      0x502C0200,  //  02BC  LDBOOL	R11	1	0
-      0x7C200600,  //  02BD  CALL	R8	3
-      0x94201154,  //  02BE  GETIDX	R8	R8	K84
-      0x94201156,  //  02BF  GETIDX	R8	R8	K86
-      0x8C24091B,  //  02C0  GETMET	R9	R4	K27
-      0x5C2C1000,  //  02C1  MOVE	R11	R8
-      0x58300057,  //  02C2  LDCONST	R12	K87
-      0x7C240600,  //  02C3  CALL	R9	3
-      0x24281305,  //  02C4  GT	R10	R9	K5
-      0x782A0002,  //  02C5  JMPF	R10	#02C9
-      0x04281309,  //  02C6  SUB	R10	R9	K9
-      0x402A0A0A,  //  02C7  CONNECT	R10	K5	R10
-      0x9420100A,  //  02C8  GETIDX	R8	R8	R10
-      0x8C280706,  //  02C9  GETMET	R10	R3	K6
-      0x88300B16,  //  02CA  GETMBR	R12	R5	K22
-      0x5C341000,  //  02CB  MOVE	R13	R8
-      0x7C280600,  //  02CC  CALL	R10	3
-      0x80041400,  //  02CD  RET	1	R10
-      0x70020036,  //  02CE  JMP		#0306
-      0x5422000E,  //  02CF  LDINT	R8	15
-      0x1C200E08,  //  02D0  EQ	R8	R7	R8
-      0x7822000B,  //  02D1  JMPF	R8	#02DE
-      0x8C200706,  //  02D2  GETMET	R8	R3	K6
-      0x88280B16,  //  02D3  GETMBR	R10	R5	K22
-      0xB82E2400,  //  02D4  GETNGBL	R11	K18
-      0x8C2C1725,  //  02D5  GETMET	R11	R11	K37
-      0x7C2C0200,  //  02D6  CALL	R11	1
-      0x8C2C171B,  //  02D7  GETMET	R11	R11	K27
-      0x5834001C,  //  02D8  LDCONST	R13	K28
-      0x5838001D,  //  02D9  LDCONST	R14	K29
-      0x7C2C0600,  //  02DA  CALL	R11	3
-      0x7C200600,  //  02DB  CALL	R8	3
-      0x80041000,  //  02DC  RET	1	R8
-      0x70020027,  //  02DD  JMP		#0306
-      0x54220010,  //  02DE  LDINT	R8	17
-      0x1C200E08,  //  02DF  EQ	R8	R7	R8
-      0x78220005,  //  02E0  JMPF	R8	#02E7
-      0x8C200706,  //  02E1  GETMET	R8	R3	K6
-      0x88280B10,  //  02E2  GETMBR	R10	R5	K16
-      0x582C0009,  //  02E3  LDCONST	R11	K9
-      0x7C200600,  //  02E4  CALL	R8	3
-      0x80041000,  //  02E5  RET	1	R8
-      0x7002001E,  //  02E6  JMP		#0306
-      0x54220011,  //  02E7  LDINT	R8	18
-      0x1C200E08,  //  02E8  EQ	R8	R7	R8
-      0x7822000B,  //  02E9  JMPF	R8	#02F6
-      0x8C200706,  //  02EA  GETMET	R8	R3	K6
-      0x88280B16,  //  02EB  GETMBR	R10	R5	K22
-      0xB82E2400,  //  02EC  GETNGBL	R11	K18
-      0x8C2C1725,  //  02ED  GETMET	R11	R11	K37
-      0x7C2C0200,  //  02EE  CALL	R11	1
-      0x8C2C171B,  //  02EF  GETMET	R11	R11	K27
-      0x5834001C,  //  02F0  LDCONST	R13	K28
-      0x5838001D,  //  02F1  LDCONST	R14	K29
-      0x7C2C0600,  //  02F2  CALL	R11	3
-      0x7C200600,  //  02F3  CALL	R8	3
-      0x80041000,  //  02F4  RET	1	R8
-      0x7002000F,  //  02F5  JMP		#0306
-      0x54220012,  //  02F6  LDINT	R8	19
-      0x1C200E08,  //  02F7  EQ	R8	R7	R8
-      0x7822000C,  //  02F8  JMPF	R8	#0306
-      0x8C200B0A,  //  02F9  GETMET	R8	R5	K10
-      0x7C200200,  //  02FA  CALL	R8	1
-      0x8C24110B,  //  02FB  GETMET	R9	R8	K11
-      0x582C0005,  //  02FC  LDCONST	R11	K5
-      0x88300B0C,  //  02FD  GETMBR	R12	R5	K12
-      0x5834000F,  //  02FE  LDCONST	R13	K15
-      0x7C240800,  //  02FF  CALL	R9	4
-      0x8C24110B,  //  0300  GETMET	R9	R8	K11
-      0x582C0009,  //  0301  LDCONST	R11	K9
-      0x88300B0C,  //  0302  GETMBR	R12	R5	K12
-      0x5834000F,  //  0303  LDCONST	R13	K15
-      0x7C240800,  //  0304  CALL	R9	4
-      0x80041000,  //  0305  RET	1	R8
-      0x70020097,  //  0306  JMP		#039F
-      0x5422003E,  //  0307  LDINT	R8	63
-      0x1C200C08,  //  0308  EQ	R8	R6	R8
-      0x78220000,  //  0309  JMPF	R8	#030B
-      0x70020093,  //  030A  JMP		#039F
-      0x54220029,  //  030B  LDINT	R8	42
-      0x1C200C08,  //  030C  EQ	R8	R6	R8
-      0x7822001D,  //  030D  JMPF	R8	#032C
-      0x1C200F05,  //  030E  EQ	R8	R7	K5
-      0x78220003,  //  030F  JMPF	R8	#0314
-      0x8C200B11,  //  0310  GETMET	R8	R5	K17
-      0x7C200200,  //  0311  CALL	R8	1
-      0x80041000,  //  0312  RET	1	R8
-      0x70020016,  //  0313  JMP		#032B
-      0x1C200F09,  //  0314  EQ	R8	R7	K9
-      0x78220005,  //  0315  JMPF	R8	#031C
-      0x8C200706,  //  0316  GETMET	R8	R3	K6
-      0x88280B10,  //  0317  GETMBR	R10	R5	K16
-      0x582C0005,  //  0318  LDCONST	R11	K5
-      0x7C200600,  //  0319  CALL	R8	3
-      0x80041000,  //  031A  RET	1	R8
-      0x7002000E,  //  031B  JMP		#032B
-      0x1C200F0D,  //  031C  EQ	R8	R7	K13
-      0x78220005,  //  031D  JMPF	R8	#0324
-      0x8C200706,  //  031E  GETMET	R8	R3	K6
-      0x88280B0E,  //  031F  GETMBR	R10	R5	K14
-      0x582C0009,  //  0320  LDCONST	R11	K9
-      0x7C200600,  //  0321  CALL	R8	3
-      0x80041000,  //  0322  RET	1	R8
-      0x70020006,  //  0323  JMP		#032B
-      0x1C200F0F,  //  0324  EQ	R8	R7	K15
-      0x78220004,  //  0325  JMPF	R8	#032B
-      0x8C200706,  //  0326  GETMET	R8	R3	K6
-      0x88280B18,  //  0327  GETMBR	R10	R5	K24
-      0x4C2C0000,  //  0328  LDNIL	R11
-      0x7C200600,  //  0329  CALL	R8	3
-      0x80041000,  //  032A  RET	1	R8
-      0x70020072,  //  032B  JMP		#039F
-      0x5422002A,  //  032C  LDINT	R8	43
-      0x1C200C08,  //  032D  EQ	R8	R6	R8
-      0x78220016,  //  032E  JMPF	R8	#0346
-      0x1C200F05,  //  032F  EQ	R8	R7	K5
-      0x78220007,  //  0330  JMPF	R8	#0339
-      0x8C200706,  //  0331  GETMET	R8	R3	K6
-      0x88280B16,  //  0332  GETMBR	R10	R5	K22
-      0xB82E2400,  //  0333  GETNGBL	R11	K18
-      0x8C2C1758,  //  0334  GETMET	R11	R11	K88
-      0x7C2C0200,  //  0335  CALL	R11	1
-      0x7C200600,  //  0336  CALL	R8	3
-      0x80041000,  //  0337  RET	1	R8
-      0x7002000B,  //  0338  JMP		#0345
-      0x1C200F09,  //  0339  EQ	R8	R7	K9
-      0x78220009,  //  033A  JMPF	R8	#0345
-      0x8C200B11,  //  033B  GETMET	R8	R5	K17
-      0x7C200200,  //  033C  CALL	R8	1
-      0x8C24110B,  //  033D  GETMET	R9	R8	K11
-      0x4C2C0000,  //  033E  LDNIL	R11
-      0x88300B16,  //  033F  GETMBR	R12	R5	K22
-      0xB8362400,  //  0340  GETNGBL	R13	K18
-      0x8C341B58,  //  0341  GETMET	R13	R13	K88
-      0x7C340200,  //  0342  CALL	R13	1
-      0x7C240800,  //  0343  CALL	R9	4
-      0x80041000,  //  0344  RET	1	R8
-      0x70020058,  //  0345  JMP		#039F
-      0x5422002B,  //  0346  LDINT	R8	44
-      0x1C200C08,  //  0347  EQ	R8	R6	R8
-      0x7822001C,  //  0348  JMPF	R8	#0366
-      0x1C200F05,  //  0349  EQ	R8	R7	K5
-      0x78220005,  //  034A  JMPF	R8	#0351
-      0x8C200706,  //  034B  GETMET	R8	R3	K6
-      0x88280B0E,  //  034C  GETMBR	R10	R5	K14
-      0x582C0009,  //  034D  LDCONST	R11	K9
-      0x7C200600,  //  034E  CALL	R8	3
-      0x80041000,  //  034F  RET	1	R8
-      0x70020013,  //  0350  JMP		#0365
-      0x1C200F09,  //  0351  EQ	R8	R7	K9
-      0x78220005,  //  0352  JMPF	R8	#0359
-      0x8C200706,  //  0353  GETMET	R8	R3	K6
-      0x88280B0E,  //  0354  GETMBR	R10	R5	K14
-      0x542E0003,  //  0355  LDINT	R11	4
-      0x7C200600,  //  0356  CALL	R8	3
-      0x80041000,  //  0357  RET	1	R8
-      0x7002000B,  //  0358  JMP		#0365
-      0x1C200F0D,  //  0359  EQ	R8	R7	K13
-      0x78220009,  //  035A  JMPF	R8	#0365
-      0x8C200B11,  //  035B  GETMET	R8	R5	K17
-      0x7C200200,  //  035C  CALL	R8	1
-      0x8C24110B,  //  035D  GETMET	R9	R8	K11
-      0x4C2C0000,  //  035E  LDNIL	R11
-      0x8C300B59,  //  035F  GETMET	R12	R5	K89
-      0x88380B0E,  //  0360  GETMBR	R14	R5	K14
-      0x543E0003,  //  0361  LDINT	R15	4
-      0x7C300600,  //  0362  CALL	R12	3
-      0x7C240600,  //  0363  CALL	R9	3
-      0x80041000,  //  0364  RET	1	R8
-      0x70020038,  //  0365  JMP		#039F
-      0x54220030,  //  0366  LDINT	R8	49
-      0x1C200C08,  //  0367  EQ	R8	R6	R8
-      0x78220007,  //  0368  JMPF	R8	#0371
-      0x1C200F0F,  //  0369  EQ	R8	R7	K15
-      0x78220004,  //  036A  JMPF	R8	#0370
-      0x8C200706,  //  036B  GETMET	R8	R3	K6
-      0x88280B0E,  //  036C  GETMBR	R10	R5	K14
-      0x542E001D,  //  036D  LDINT	R11	30
-      0x7C200600,  //  036E  CALL	R8	3
-      0x80041000,  //  036F  RET	1	R8
-      0x7002002D,  //  0370  JMP		#039F
-      0x5422001C,  //  0371  LDINT	R8	29
-      0x1C200C08,  //  0372  EQ	R8	R6	R8
-      0x7822002A,  //  0373  JMPF	R8	#039F
-      0x1C200F0D,  //  0374  EQ	R8	R7	K13
-      0x78220008,  //  0375  JMPF	R8	#037F
-      0x8C200B11,  //  0376  GETMET	R8	R5	K17
-      0x7C200200,  //  0377  CALL	R8	1
-      0x8C24110B,  //  0378  GETMET	R9	R8	K11
-      0x4C2C0000,  //  0379  LDNIL	R11
-      0x88300B0C,  //  037A  GETMBR	R12	R5	K12
-      0x5436001E,  //  037B  LDINT	R13	31
-      0x7C240800,  //  037C  CALL	R9	4
-      0x80041000,  //  037D  RET	1	R8
-      0x7002001F,  //  037E  JMP		#039F
-      0x1C200F0F,  //  037F  EQ	R8	R7	K15
-      0x7822001D,  //  0380  JMPF	R8	#039F
-      0x8C200B11,  //  0381  GETMET	R8	R5	K17
-      0x7C200200,  //  0382  CALL	R8	1
-      0x88240136,  //  0383  GETMBR	R9	R0	K54
-      0x8C24135A,  //  0384  GETMET	R9	R9	K90
-      0x502C0200,  //  0385  LDBOOL	R11	1	0
-      0x7C240400,  //  0386  CALL	R9	2
-      0x88280136,  //  0387  GETMBR	R10	R0	K54
-      0x8828155B,  //  0388  GETMBR	R10	R10	K91
-      0x602C0010,  //  0389  GETGBL	R11	G16
-      0x5C301200,  //  038A  MOVE	R12	R9
-      0x7C2C0200,  //  038B  CALL	R11	1
-      0xA802000D,  //  038C  EXBLK	0	#039B
-      0x5C301600,  //  038D  MOVE	R12	R11
-      0x7C300000,  //  038E  CALL	R12	0
-      0x5C341400,  //  038F  MOVE	R13	R10
-      0x78360003,  //  0390  JMPF	R13	#0395
-      0xB8360200,  //  0391  GETNGBL	R13	K1
-      0x88341B5C,  //  0392  GETMBR	R13	R13	K92
-      0x2034180D,  //  0393  NE	R13	R12	R13
-      0x78360004,  //  0394  JMPF	R13	#039A
-      0x8C34110B,  //  0395  GETMET	R13	R8	K11
-      0x4C3C0000,  //  0396  LDNIL	R15
-      0x88400B0C,  //  0397  GETMBR	R16	R5	K12
-      0x5C441800,  //  0398  MOVE	R17	R12
-      0x7C340800,  //  0399  CALL	R13	4
-      0x7001FFF1,  //  039A  JMP		#038D
-      0x582C003E,  //  039B  LDCONST	R11	K62
-      0xAC2C0200,  //  039C  CATCH	R11	1	0
-      0xB0080000,  //  039D  RAISE	2	R0	R0
-      0x80041000,  //  039E  RET	1	R8
-      0x60200003,  //  039F  GETGBL	R8	G3
-      0x5C240000,  //  03A0  MOVE	R9	R0
-      0x7C200200,  //  03A1  CALL	R8	1
-      0x8C20115D,  //  03A2  GETMET	R8	R8	K93
-      0x5C280200,  //  03A3  MOVE	R10	R1
-      0x5C2C0400,  //  03A4  MOVE	R11	R2
-      0x5C300600,  //  03A5  MOVE	R12	R3
-      0x7C200800,  //  03A6  CALL	R8	4
-      0x80041000,  //  03A7  RET	1	R8
+      0x7002000C,  //  022E  JMP		#023C
+      0x1C200F0D,  //  022F  EQ	R8	R7	K13
+      0x7822000A,  //  0230  JMPF	R8	#023C
+      0x88200136,  //  0231  GETMBR	R8	R0	K54
+      0x8820114C,  //  0232  GETMBR	R8	R8	K76
+      0x4C240000,  //  0233  LDNIL	R9
+      0x20241009,  //  0234  NE	R9	R8	R9
+      0x78260005,  //  0235  JMPF	R9	#023C
+      0x8C24074D,  //  0236  GETMET	R9	R3	K77
+      0x882C0B0C,  //  0237  GETMBR	R11	R5	K12
+      0x8C301142,  //  0238  GETMET	R12	R8	K66
+      0x7C300200,  //  0239  CALL	R12	1
+      0x7C240600,  //  023A  CALL	R9	3
+      0x80041200,  //  023B  RET	1	R9
+      0x70020155,  //  023C  JMP		#0393
+      0x54220027,  //  023D  LDINT	R8	40
+      0x1C200C08,  //  023E  EQ	R8	R6	R8
+      0x782200BA,  //  023F  JMPF	R8	#02FB
+      0x8C200133,  //  0240  GETMET	R8	R0	K51
+      0x5C280400,  //  0241  MOVE	R10	R2
+      0x7C200400,  //  0242  CALL	R8	2
+      0x1C200F05,  //  0243  EQ	R8	R7	K5
+      0x78220005,  //  0244  JMPF	R8	#024B
+      0x8C200706,  //  0245  GETMET	R8	R3	K6
+      0x88280B0C,  //  0246  GETMBR	R10	R5	K12
+      0x582C0009,  //  0247  LDCONST	R11	K9
+      0x7C200600,  //  0248  CALL	R8	3
+      0x80041000,  //  0249  RET	1	R8
+      0x700200AE,  //  024A  JMP		#02FA
+      0x1C200F09,  //  024B  EQ	R8	R7	K9
+      0x78220005,  //  024C  JMPF	R8	#0253
+      0x8C200706,  //  024D  GETMET	R8	R3	K6
+      0x88280B16,  //  024E  GETMBR	R10	R5	K22
+      0x582C004E,  //  024F  LDCONST	R11	K78
+      0x7C200600,  //  0250  CALL	R8	3
+      0x80041000,  //  0251  RET	1	R8
+      0x700200A6,  //  0252  JMP		#02FA
+      0x1C200F0D,  //  0253  EQ	R8	R7	K13
+      0x78220006,  //  0254  JMPF	R8	#025C
+      0x8C200706,  //  0255  GETMET	R8	R3	K6
+      0x88280B0C,  //  0256  GETMBR	R10	R5	K12
+      0x882C0136,  //  0257  GETMBR	R11	R0	K54
+      0x882C174F,  //  0258  GETMBR	R11	R11	K79
+      0x7C200600,  //  0259  CALL	R8	3
+      0x80041000,  //  025A  RET	1	R8
+      0x7002009D,  //  025B  JMP		#02FA
+      0x1C200F0F,  //  025C  EQ	R8	R7	K15
+      0x7822000A,  //  025D  JMPF	R8	#0269
+      0x8C200706,  //  025E  GETMET	R8	R3	K6
+      0x88280B16,  //  025F  GETMBR	R10	R5	K22
+      0xB82E2400,  //  0260  GETNGBL	R11	K18
+      0x8C2C1726,  //  0261  GETMET	R11	R11	K38
+      0x58340050,  //  0262  LDCONST	R13	K80
+      0x50380200,  //  0263  LDBOOL	R14	1	0
+      0x7C2C0600,  //  0264  CALL	R11	3
+      0x942C1750,  //  0265  GETIDX	R11	R11	K80
+      0x7C200600,  //  0266  CALL	R8	3
+      0x80041000,  //  0267  RET	1	R8
+      0x70020090,  //  0268  JMP		#02FA
+      0x54220003,  //  0269  LDINT	R8	4
+      0x1C200E08,  //  026A  EQ	R8	R7	R8
+      0x78220005,  //  026B  JMPF	R8	#0272
+      0x8C200706,  //  026C  GETMET	R8	R3	K6
+      0x88280B0C,  //  026D  GETMBR	R10	R5	K12
+      0x542E7FFF,  //  026E  LDINT	R11	32768
+      0x7C200600,  //  026F  CALL	R8	3
+      0x80041000,  //  0270  RET	1	R8
+      0x70020087,  //  0271  JMP		#02FA
+      0x54220004,  //  0272  LDINT	R8	5
+      0x1C200E08,  //  0273  EQ	R8	R7	R8
+      0x7822000A,  //  0274  JMPF	R8	#0280
+      0x8C200706,  //  0275  GETMET	R8	R3	K6
+      0x88280B16,  //  0276  GETMBR	R10	R5	K22
+      0xB82E2400,  //  0277  GETNGBL	R11	K18
+      0x8C2C1726,  //  0278  GETMET	R11	R11	K38
+      0x58340051,  //  0279  LDCONST	R13	K81
+      0x50380200,  //  027A  LDBOOL	R14	1	0
+      0x7C2C0600,  //  027B  CALL	R11	3
+      0x942C1752,  //  027C  GETIDX	R11	R11	K82
+      0x7C200600,  //  027D  CALL	R8	3
+      0x80041000,  //  027E  RET	1	R8
+      0x70020079,  //  027F  JMP		#02FA
+      0x54220005,  //  0280  LDINT	R8	6
+      0x1C200E08,  //  0281  EQ	R8	R7	R8
+      0x78220005,  //  0282  JMPF	R8	#0289
+      0x8C200706,  //  0283  GETMET	R8	R3	K6
+      0x88280B16,  //  0284  GETMBR	R10	R5	K22
+      0x582C0053,  //  0285  LDCONST	R11	K83
+      0x7C200600,  //  0286  CALL	R8	3
+      0x80041000,  //  0287  RET	1	R8
+      0x70020070,  //  0288  JMP		#02FA
+      0x54220006,  //  0289  LDINT	R8	7
+      0x1C200E08,  //  028A  EQ	R8	R7	R8
+      0x78220005,  //  028B  JMPF	R8	#0292
+      0x8C200706,  //  028C  GETMET	R8	R3	K6
+      0x88280B0C,  //  028D  GETMBR	R10	R5	K12
+      0x582C0005,  //  028E  LDCONST	R11	K5
+      0x7C200600,  //  028F  CALL	R8	3
+      0x80041000,  //  0290  RET	1	R8
+      0x70020067,  //  0291  JMP		#02FA
+      0x54220007,  //  0292  LDINT	R8	8
+      0x1C200E08,  //  0293  EQ	R8	R7	R8
+      0x7822000B,  //  0294  JMPF	R8	#02A1
+      0x8C200706,  //  0295  GETMET	R8	R3	K6
+      0x88280B16,  //  0296  GETMBR	R10	R5	K22
+      0xB82E2400,  //  0297  GETNGBL	R11	K18
+      0x8C2C1726,  //  0298  GETMET	R11	R11	K38
+      0x58340054,  //  0299  LDCONST	R13	K84
+      0x50380200,  //  029A  LDBOOL	R14	1	0
+      0x7C2C0600,  //  029B  CALL	R11	3
+      0x942C1755,  //  029C  GETIDX	R11	R11	K85
+      0x942C1756,  //  029D  GETIDX	R11	R11	K86
+      0x7C200600,  //  029E  CALL	R8	3
+      0x80041000,  //  029F  RET	1	R8
+      0x70020058,  //  02A0  JMP		#02FA
+      0x54220008,  //  02A1  LDINT	R8	9
+      0x1C200E08,  //  02A2  EQ	R8	R7	R8
+      0x78220005,  //  02A3  JMPF	R8	#02AA
+      0x8C200706,  //  02A4  GETMET	R8	R3	K6
+      0x88280B0C,  //  02A5  GETMBR	R10	R5	K12
+      0x582C0009,  //  02A6  LDCONST	R11	K9
+      0x7C200600,  //  02A7  CALL	R8	3
+      0x80041000,  //  02A8  RET	1	R8
+      0x7002004F,  //  02A9  JMP		#02FA
+      0x54220009,  //  02AA  LDINT	R8	10
+      0x1C200E08,  //  02AB  EQ	R8	R7	R8
+      0x78220015,  //  02AC  JMPF	R8	#02C3
+      0xB8222400,  //  02AD  GETNGBL	R8	K18
+      0x8C201126,  //  02AE  GETMET	R8	R8	K38
+      0x58280054,  //  02AF  LDCONST	R10	K84
+      0x502C0200,  //  02B0  LDBOOL	R11	1	0
+      0x7C200600,  //  02B1  CALL	R8	3
+      0x94201155,  //  02B2  GETIDX	R8	R8	K85
+      0x94201157,  //  02B3  GETIDX	R8	R8	K87
+      0x8C24091B,  //  02B4  GETMET	R9	R4	K27
+      0x5C2C1000,  //  02B5  MOVE	R11	R8
+      0x58300058,  //  02B6  LDCONST	R12	K88
+      0x7C240600,  //  02B7  CALL	R9	3
+      0x24281305,  //  02B8  GT	R10	R9	K5
+      0x782A0002,  //  02B9  JMPF	R10	#02BD
+      0x04281309,  //  02BA  SUB	R10	R9	K9
+      0x402A0A0A,  //  02BB  CONNECT	R10	K5	R10
+      0x9420100A,  //  02BC  GETIDX	R8	R8	R10
+      0x8C280706,  //  02BD  GETMET	R10	R3	K6
+      0x88300B16,  //  02BE  GETMBR	R12	R5	K22
+      0x5C341000,  //  02BF  MOVE	R13	R8
+      0x7C280600,  //  02C0  CALL	R10	3
+      0x80041400,  //  02C1  RET	1	R10
+      0x70020036,  //  02C2  JMP		#02FA
+      0x5422000E,  //  02C3  LDINT	R8	15
+      0x1C200E08,  //  02C4  EQ	R8	R7	R8
+      0x7822000B,  //  02C5  JMPF	R8	#02D2
+      0x8C200706,  //  02C6  GETMET	R8	R3	K6
+      0x88280B16,  //  02C7  GETMBR	R10	R5	K22
+      0xB82E2400,  //  02C8  GETNGBL	R11	K18
+      0x8C2C1725,  //  02C9  GETMET	R11	R11	K37
+      0x7C2C0200,  //  02CA  CALL	R11	1
+      0x8C2C171B,  //  02CB  GETMET	R11	R11	K27
+      0x5834001C,  //  02CC  LDCONST	R13	K28
+      0x5838001D,  //  02CD  LDCONST	R14	K29
+      0x7C2C0600,  //  02CE  CALL	R11	3
+      0x7C200600,  //  02CF  CALL	R8	3
+      0x80041000,  //  02D0  RET	1	R8
+      0x70020027,  //  02D1  JMP		#02FA
+      0x54220010,  //  02D2  LDINT	R8	17
+      0x1C200E08,  //  02D3  EQ	R8	R7	R8
+      0x78220005,  //  02D4  JMPF	R8	#02DB
+      0x8C200706,  //  02D5  GETMET	R8	R3	K6
+      0x88280B10,  //  02D6  GETMBR	R10	R5	K16
+      0x582C0009,  //  02D7  LDCONST	R11	K9
+      0x7C200600,  //  02D8  CALL	R8	3
+      0x80041000,  //  02D9  RET	1	R8
+      0x7002001E,  //  02DA  JMP		#02FA
+      0x54220011,  //  02DB  LDINT	R8	18
+      0x1C200E08,  //  02DC  EQ	R8	R7	R8
+      0x7822000B,  //  02DD  JMPF	R8	#02EA
+      0x8C200706,  //  02DE  GETMET	R8	R3	K6
+      0x88280B16,  //  02DF  GETMBR	R10	R5	K22
+      0xB82E2400,  //  02E0  GETNGBL	R11	K18
+      0x8C2C1725,  //  02E1  GETMET	R11	R11	K37
+      0x7C2C0200,  //  02E2  CALL	R11	1
+      0x8C2C171B,  //  02E3  GETMET	R11	R11	K27
+      0x5834001C,  //  02E4  LDCONST	R13	K28
+      0x5838001D,  //  02E5  LDCONST	R14	K29
+      0x7C2C0600,  //  02E6  CALL	R11	3
+      0x7C200600,  //  02E7  CALL	R8	3
+      0x80041000,  //  02E8  RET	1	R8
+      0x7002000F,  //  02E9  JMP		#02FA
+      0x54220012,  //  02EA  LDINT	R8	19
+      0x1C200E08,  //  02EB  EQ	R8	R7	R8
+      0x7822000C,  //  02EC  JMPF	R8	#02FA
+      0x8C200B0A,  //  02ED  GETMET	R8	R5	K10
+      0x7C200200,  //  02EE  CALL	R8	1
+      0x8C24110B,  //  02EF  GETMET	R9	R8	K11
+      0x582C0005,  //  02F0  LDCONST	R11	K5
+      0x88300B0C,  //  02F1  GETMBR	R12	R5	K12
+      0x5834000F,  //  02F2  LDCONST	R13	K15
+      0x7C240800,  //  02F3  CALL	R9	4
+      0x8C24110B,  //  02F4  GETMET	R9	R8	K11
+      0x582C0009,  //  02F5  LDCONST	R11	K9
+      0x88300B0C,  //  02F6  GETMBR	R12	R5	K12
+      0x5834000F,  //  02F7  LDCONST	R13	K15
+      0x7C240800,  //  02F8  CALL	R9	4
+      0x80041000,  //  02F9  RET	1	R8
+      0x70020097,  //  02FA  JMP		#0393
+      0x5422003E,  //  02FB  LDINT	R8	63
+      0x1C200C08,  //  02FC  EQ	R8	R6	R8
+      0x78220000,  //  02FD  JMPF	R8	#02FF
+      0x70020093,  //  02FE  JMP		#0393
+      0x54220029,  //  02FF  LDINT	R8	42
+      0x1C200C08,  //  0300  EQ	R8	R6	R8
+      0x7822001D,  //  0301  JMPF	R8	#0320
+      0x1C200F05,  //  0302  EQ	R8	R7	K5
+      0x78220003,  //  0303  JMPF	R8	#0308
+      0x8C200B11,  //  0304  GETMET	R8	R5	K17
+      0x7C200200,  //  0305  CALL	R8	1
+      0x80041000,  //  0306  RET	1	R8
+      0x70020016,  //  0307  JMP		#031F
+      0x1C200F09,  //  0308  EQ	R8	R7	K9
+      0x78220005,  //  0309  JMPF	R8	#0310
+      0x8C200706,  //  030A  GETMET	R8	R3	K6
+      0x88280B10,  //  030B  GETMBR	R10	R5	K16
+      0x582C0005,  //  030C  LDCONST	R11	K5
+      0x7C200600,  //  030D  CALL	R8	3
+      0x80041000,  //  030E  RET	1	R8
+      0x7002000E,  //  030F  JMP		#031F
+      0x1C200F0D,  //  0310  EQ	R8	R7	K13
+      0x78220005,  //  0311  JMPF	R8	#0318
+      0x8C200706,  //  0312  GETMET	R8	R3	K6
+      0x88280B0E,  //  0313  GETMBR	R10	R5	K14
+      0x582C0009,  //  0314  LDCONST	R11	K9
+      0x7C200600,  //  0315  CALL	R8	3
+      0x80041000,  //  0316  RET	1	R8
+      0x70020006,  //  0317  JMP		#031F
+      0x1C200F0F,  //  0318  EQ	R8	R7	K15
+      0x78220004,  //  0319  JMPF	R8	#031F
+      0x8C200706,  //  031A  GETMET	R8	R3	K6
+      0x88280B18,  //  031B  GETMBR	R10	R5	K24
+      0x4C2C0000,  //  031C  LDNIL	R11
+      0x7C200600,  //  031D  CALL	R8	3
+      0x80041000,  //  031E  RET	1	R8
+      0x70020072,  //  031F  JMP		#0393
+      0x5422002A,  //  0320  LDINT	R8	43
+      0x1C200C08,  //  0321  EQ	R8	R6	R8
+      0x78220016,  //  0322  JMPF	R8	#033A
+      0x1C200F05,  //  0323  EQ	R8	R7	K5
+      0x78220007,  //  0324  JMPF	R8	#032D
+      0x8C200706,  //  0325  GETMET	R8	R3	K6
+      0x88280B16,  //  0326  GETMBR	R10	R5	K22
+      0xB82E2400,  //  0327  GETNGBL	R11	K18
+      0x8C2C1759,  //  0328  GETMET	R11	R11	K89
+      0x7C2C0200,  //  0329  CALL	R11	1
+      0x7C200600,  //  032A  CALL	R8	3
+      0x80041000,  //  032B  RET	1	R8
+      0x7002000B,  //  032C  JMP		#0339
+      0x1C200F09,  //  032D  EQ	R8	R7	K9
+      0x78220009,  //  032E  JMPF	R8	#0339
+      0x8C200B11,  //  032F  GETMET	R8	R5	K17
+      0x7C200200,  //  0330  CALL	R8	1
+      0x8C24110B,  //  0331  GETMET	R9	R8	K11
+      0x4C2C0000,  //  0332  LDNIL	R11
+      0x88300B16,  //  0333  GETMBR	R12	R5	K22
+      0xB8362400,  //  0334  GETNGBL	R13	K18
+      0x8C341B59,  //  0335  GETMET	R13	R13	K89
+      0x7C340200,  //  0336  CALL	R13	1
+      0x7C240800,  //  0337  CALL	R9	4
+      0x80041000,  //  0338  RET	1	R8
+      0x70020058,  //  0339  JMP		#0393
+      0x5422002B,  //  033A  LDINT	R8	44
+      0x1C200C08,  //  033B  EQ	R8	R6	R8
+      0x7822001C,  //  033C  JMPF	R8	#035A
+      0x1C200F05,  //  033D  EQ	R8	R7	K5
+      0x78220005,  //  033E  JMPF	R8	#0345
+      0x8C200706,  //  033F  GETMET	R8	R3	K6
+      0x88280B0E,  //  0340  GETMBR	R10	R5	K14
+      0x582C0009,  //  0341  LDCONST	R11	K9
+      0x7C200600,  //  0342  CALL	R8	3
+      0x80041000,  //  0343  RET	1	R8
+      0x70020013,  //  0344  JMP		#0359
+      0x1C200F09,  //  0345  EQ	R8	R7	K9
+      0x78220005,  //  0346  JMPF	R8	#034D
+      0x8C200706,  //  0347  GETMET	R8	R3	K6
+      0x88280B0E,  //  0348  GETMBR	R10	R5	K14
+      0x542E0003,  //  0349  LDINT	R11	4
+      0x7C200600,  //  034A  CALL	R8	3
+      0x80041000,  //  034B  RET	1	R8
+      0x7002000B,  //  034C  JMP		#0359
+      0x1C200F0D,  //  034D  EQ	R8	R7	K13
+      0x78220009,  //  034E  JMPF	R8	#0359
+      0x8C200B11,  //  034F  GETMET	R8	R5	K17
+      0x7C200200,  //  0350  CALL	R8	1
+      0x8C24110B,  //  0351  GETMET	R9	R8	K11
+      0x4C2C0000,  //  0352  LDNIL	R11
+      0x8C300B5A,  //  0353  GETMET	R12	R5	K90
+      0x88380B0E,  //  0354  GETMBR	R14	R5	K14
+      0x543E0003,  //  0355  LDINT	R15	4
+      0x7C300600,  //  0356  CALL	R12	3
+      0x7C240600,  //  0357  CALL	R9	3
+      0x80041000,  //  0358  RET	1	R8
+      0x70020038,  //  0359  JMP		#0393
+      0x54220030,  //  035A  LDINT	R8	49
+      0x1C200C08,  //  035B  EQ	R8	R6	R8
+      0x78220007,  //  035C  JMPF	R8	#0365
+      0x1C200F0F,  //  035D  EQ	R8	R7	K15
+      0x78220004,  //  035E  JMPF	R8	#0364
+      0x8C200706,  //  035F  GETMET	R8	R3	K6
+      0x88280B0E,  //  0360  GETMBR	R10	R5	K14
+      0x542E001D,  //  0361  LDINT	R11	30
+      0x7C200600,  //  0362  CALL	R8	3
+      0x80041000,  //  0363  RET	1	R8
+      0x7002002D,  //  0364  JMP		#0393
+      0x5422001C,  //  0365  LDINT	R8	29
+      0x1C200C08,  //  0366  EQ	R8	R6	R8
+      0x7822002A,  //  0367  JMPF	R8	#0393
+      0x1C200F0D,  //  0368  EQ	R8	R7	K13
+      0x78220008,  //  0369  JMPF	R8	#0373
+      0x8C200B11,  //  036A  GETMET	R8	R5	K17
+      0x7C200200,  //  036B  CALL	R8	1
+      0x8C24110B,  //  036C  GETMET	R9	R8	K11
+      0x4C2C0000,  //  036D  LDNIL	R11
+      0x88300B0C,  //  036E  GETMBR	R12	R5	K12
+      0x5436001E,  //  036F  LDINT	R13	31
+      0x7C240800,  //  0370  CALL	R9	4
+      0x80041000,  //  0371  RET	1	R8
+      0x7002001F,  //  0372  JMP		#0393
+      0x1C200F0F,  //  0373  EQ	R8	R7	K15
+      0x7822001D,  //  0374  JMPF	R8	#0393
+      0x8C200B11,  //  0375  GETMET	R8	R5	K17
+      0x7C200200,  //  0376  CALL	R8	1
+      0x88240136,  //  0377  GETMBR	R9	R0	K54
+      0x8C24135B,  //  0378  GETMET	R9	R9	K91
+      0x502C0200,  //  0379  LDBOOL	R11	1	0
+      0x7C240400,  //  037A  CALL	R9	2
+      0x88280136,  //  037B  GETMBR	R10	R0	K54
+      0x8828155C,  //  037C  GETMBR	R10	R10	K92
+      0x602C0010,  //  037D  GETGBL	R11	G16
+      0x5C301200,  //  037E  MOVE	R12	R9
+      0x7C2C0200,  //  037F  CALL	R11	1
+      0xA802000D,  //  0380  EXBLK	0	#038F
+      0x5C301600,  //  0381  MOVE	R12	R11
+      0x7C300000,  //  0382  CALL	R12	0
+      0x5C341400,  //  0383  MOVE	R13	R10
+      0x78360003,  //  0384  JMPF	R13	#0389
+      0xB8360200,  //  0385  GETNGBL	R13	K1
+      0x88341B5D,  //  0386  GETMBR	R13	R13	K93
+      0x2034180D,  //  0387  NE	R13	R12	R13
+      0x78360004,  //  0388  JMPF	R13	#038E
+      0x8C34110B,  //  0389  GETMET	R13	R8	K11
+      0x4C3C0000,  //  038A  LDNIL	R15
+      0x88400B0C,  //  038B  GETMBR	R16	R5	K12
+      0x5C441800,  //  038C  MOVE	R17	R12
+      0x7C340800,  //  038D  CALL	R13	4
+      0x7001FFF1,  //  038E  JMP		#0381
+      0x582C003E,  //  038F  LDCONST	R11	K62
+      0xAC2C0200,  //  0390  CATCH	R11	1	0
+      0xB0080000,  //  0391  RAISE	2	R0	R0
+      0x80041000,  //  0392  RET	1	R8
+      0x60200003,  //  0393  GETGBL	R8	G3
+      0x5C240000,  //  0394  MOVE	R9	R0
+      0x7C200200,  //  0395  CALL	R8	1
+      0x8C20115E,  //  0396  GETMET	R8	R8	K94
+      0x5C280200,  //  0397  MOVE	R10	R1
+      0x5C2C0400,  //  0398  MOVE	R11	R2
+      0x5C300600,  //  0399  MOVE	R12	R3
+      0x7C200800,  //  039A  CALL	R8	4
+      0x80041000,  //  039B  RET	1	R8
     })
   )
 );
@@ -1348,7 +1337,7 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[745]) {  /* code */
+    ( &(const binstruction[737]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xB8160200,  //  0001  GETNGBL	R5	K1
       0x88140B02,  //  0002  GETMBR	R5	R5	K2
@@ -1449,10 +1438,10 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       0x80041000,  //  0061  RET	1	R8
       0x70020000,  //  0062  JMP		#0064
       0xB0063119,  //  0063  RAISE	1	K24	K25
-      0x70020281,  //  0064  JMP		#02E7
+      0x70020279,  //  0064  JMP		#02DF
       0x5422003D,  //  0065  LDINT	R8	62
       0x1C200C08,  //  0066  EQ	R8	R6	R8
-      0x782201E2,  //  0067  JMPF	R8	#024B
+      0x782201DD,  //  0067  JMPF	R8	#0246
       0x1C200F0E,  //  0068  EQ	R8	R7	K14
       0x7822001D,  //  0069  JMPF	R8	#0088
       0x8C200506,  //  006A  GETMET	R8	R2	K6
@@ -1484,7 +1473,7 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       0x7C280800,  //  0084  CALL	R10	4
       0x900E0910,  //  0085  SETMBR	R3	K4	K16
       0x80041200,  //  0086  RET	1	R9
-      0x700201C1,  //  0087  JMP		#024A
+      0x700201BC,  //  0087  JMP		#0245
       0x1C200F05,  //  0088  EQ	R8	R7	K5
       0x7822003C,  //  0089  JMPF	R8	#00C7
       0x8C200506,  //  008A  GETMET	R8	R2	K6
@@ -1547,7 +1536,7 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       0x7C3C0800,  //  00C3  CALL	R15	4
       0x900E0907,  //  00C4  SETMBR	R3	K4	K7
       0x80041C00,  //  00C5  RET	1	R14
-      0x70020182,  //  00C6  JMP		#024A
+      0x7002017D,  //  00C6  JMP		#0245
       0x54220003,  //  00C7  LDINT	R8	4
       0x1C200E08,  //  00C8  EQ	R8	R7	R8
       0x7822003C,  //  00C9  JMPF	R8	#0107
@@ -1611,7 +1600,7 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       0x54420004,  //  0103  LDINT	R16	5
       0x900E0810,  //  0104  SETMBR	R3	K4	R16
       0x80041E00,  //  0105  RET	1	R15
-      0x70020142,  //  0106  JMP		#024A
+      0x7002013D,  //  0106  JMP		#0245
       0x5422000A,  //  0107  LDINT	R8	11
       0x1C200E08,  //  0108  EQ	R8	R7	R8
       0x7822000B,  //  0109  JMPF	R8	#0116
@@ -1626,474 +1615,466 @@ be_local_closure(class_Matter_Plugin_Root_invoke_request,   /* name */
       0x900E3409,  //  0112  SETMBR	R3	K26	R9
       0x4C240000,  //  0113  LDNIL	R9
       0x80041200,  //  0114  RET	1	R9
-      0x70020133,  //  0115  JMP		#024A
+      0x7002012E,  //  0115  JMP		#0245
       0x54220005,  //  0116  LDINT	R8	6
       0x1C200E08,  //  0117  EQ	R8	R7	R8
-      0x782200BB,  //  0118  JMPF	R8	#01D5
-      0xB8224400,  //  0119  GETNGBL	R8	K34
-      0x8C20112C,  //  011A  GETMET	R8	R8	K44
-      0x60280008,  //  011B  GETGBL	R10	G8
-      0x5C2C0400,  //  011C  MOVE	R11	R2
-      0x7C280200,  //  011D  CALL	R10	1
-      0x002A5A0A,  //  011E  ADD	R10	K45	R10
-      0x542E0003,  //  011F  LDINT	R11	4
-      0x7C200600,  //  0120  CALL	R8	3
-      0x8C200506,  //  0121  GETMET	R8	R2	K6
-      0x58280005,  //  0122  LDCONST	R10	K5
-      0x7C200400,  //  0123  CALL	R8	2
-      0x8C240506,  //  0124  GETMET	R9	R2	K6
-      0x582C0007,  //  0125  LDCONST	R11	K7
-      0x7C240400,  //  0126  CALL	R9	2
-      0x6028000C,  //  0127  GETGBL	R10	G12
-      0x5C2C1200,  //  0128  MOVE	R11	R9
-      0x7C280200,  //  0129  CALL	R10	1
-      0x1C281505,  //  012A  EQ	R10	R10	K5
-      0x782A0000,  //  012B  JMPF	R10	#012D
-      0x4C240000,  //  012C  LDNIL	R9
-      0x8C280506,  //  012D  GETMET	R10	R2	K6
-      0x5830000E,  //  012E  LDCONST	R12	K14
-      0x7C280400,  //  012F  CALL	R10	2
-      0x8C2C0506,  //  0130  GETMET	R11	R2	K6
-      0x58340010,  //  0131  LDCONST	R13	K16
-      0x7C2C0400,  //  0132  CALL	R11	2
-      0x8C300506,  //  0133  GETMET	R12	R2	K6
-      0x543A0003,  //  0134  LDINT	R14	4
-      0x7C300400,  //  0135  CALL	R12	2
-      0x8C34032E,  //  0136  GETMET	R13	R1	K46
-      0x7C340200,  //  0137  CALL	R13	1
-      0x4C380000,  //  0138  LDNIL	R14
-      0x1C341A0E,  //  0139  EQ	R13	R13	R14
-      0x78360006,  //  013A  JMPF	R13	#0142
-      0xB8364400,  //  013B  GETNGBL	R13	K34
-      0x8C341B2C,  //  013C  GETMET	R13	R13	K44
-      0x583C002F,  //  013D  LDCONST	R15	K47
-      0x5840000E,  //  013E  LDCONST	R16	K14
-      0x7C340600,  //  013F  CALL	R13	3
-      0x4C340000,  //  0140  LDNIL	R13
-      0x80041A00,  //  0141  RET	1	R13
-      0x88340116,  //  0142  GETMBR	R13	R0	K22
-      0x88341B30,  //  0143  GETMBR	R13	R13	K48
-      0x8C341B31,  //  0144  GETMET	R13	R13	K49
-      0x7C340200,  //  0145  CALL	R13	1
-      0x8C381B32,  //  0146  GETMET	R14	R13	K50
-      0x8C40032E,  //  0147  GETMET	R16	R1	K46
-      0x7C400200,  //  0148  CALL	R16	1
-      0x7C380400,  //  0149  CALL	R14	2
-      0x8C381B33,  //  014A  GETMET	R14	R13	K51
-      0x5C401000,  //  014B  MOVE	R16	R8
-      0x5C441200,  //  014C  MOVE	R17	R9
-      0x7C380600,  //  014D  CALL	R14	3
-      0x8C381B34,  //  014E  GETMET	R14	R13	K52
-      0x5C401400,  //  014F  MOVE	R16	R10
-      0x7C380400,  //  0150  CALL	R14	2
-      0x8C381B35,  //  0151  GETMET	R14	R13	K53
-      0x5C401600,  //  0152  MOVE	R16	R11
-      0x5C441800,  //  0153  MOVE	R17	R12
-      0x7C380600,  //  0154  CALL	R14	3
-      0x8C381B36,  //  0155  GETMET	R14	R13	K54
-      0x8C400337,  //  0156  GETMET	R16	R1	K55
-      0x7C400200,  //  0157  CALL	R16	1
-      0x7C380400,  //  0158  CALL	R14	2
-      0xB83A0200,  //  0159  GETNGBL	R14	K1
-      0x88381D02,  //  015A  GETMBR	R14	R14	K2
-      0x8C381D38,  //  015B  GETMET	R14	R14	K56
-      0x5C401000,  //  015C  MOVE	R16	R8
-      0x7C380400,  //  015D  CALL	R14	2
-      0x8C3C1D39,  //  015E  GETMET	R15	R14	K57
-      0x54460005,  //  015F  LDINT	R17	6
-      0x7C3C0400,  //  0160  CALL	R15	2
-      0x8C401F06,  //  0161  GETMET	R16	R15	K6
-      0x544A0014,  //  0162  LDINT	R18	21
-      0x7C400400,  //  0163  CALL	R16	2
-      0x8C441F06,  //  0164  GETMET	R17	R15	K6
-      0x544E0010,  //  0165  LDINT	R19	17
-      0x7C440400,  //  0166  CALL	R17	2
-      0x5C482000,  //  0167  MOVE	R18	R16
-      0x784A0001,  //  0168  JMPF	R18	#016B
-      0x5C482200,  //  0169  MOVE	R18	R17
-      0x744A0006,  //  016A  JMPT	R18	#0172
-      0xB84A4400,  //  016B  GETNGBL	R18	K34
-      0x8C48252C,  //  016C  GETMET	R18	R18	K44
-      0x5850003A,  //  016D  LDCONST	R20	K58
-      0x5854000E,  //  016E  LDCONST	R21	K14
-      0x7C480600,  //  016F  CALL	R18	3
-      0x50480000,  //  0170  LDBOOL	R18	0	0
-      0x80042400,  //  0171  RET	1	R18
-      0x60480004,  //  0172  GETGBL	R18	G4
-      0x5C4C2000,  //  0173  MOVE	R19	R16
-      0x7C480200,  //  0174  CALL	R18	1
-      0x1C48253B,  //  0175  EQ	R18	R18	K59
-      0x784A0007,  //  0176  JMPF	R18	#017F
-      0xB84A7800,  //  0177  GETNGBL	R18	K60
-      0x8C48253D,  //  0178  GETMET	R18	R18	K61
-      0x5C502000,  //  0179  MOVE	R20	R16
-      0x7C480400,  //  017A  CALL	R18	2
-      0x8C48253E,  //  017B  GETMET	R18	R18	K62
-      0x7C480200,  //  017C  CALL	R18	1
-      0x5C402400,  //  017D  MOVE	R16	R18
-      0x70020002,  //  017E  JMP		#0182
-      0x8C48213E,  //  017F  GETMET	R18	R16	K62
-      0x7C480200,  //  0180  CALL	R18	1
-      0x5C402400,  //  0181  MOVE	R16	R18
-      0x60480004,  //  0182  GETGBL	R18	G4
-      0x5C4C2200,  //  0183  MOVE	R19	R17
-      0x7C480200,  //  0184  CALL	R18	1
-      0x1C48253B,  //  0185  EQ	R18	R18	K59
-      0x784A0007,  //  0186  JMPF	R18	#018F
-      0xB84A7800,  //  0187  GETNGBL	R18	K60
-      0x8C48253D,  //  0188  GETMET	R18	R18	K61
-      0x5C502200,  //  0189  MOVE	R20	R17
-      0x7C480400,  //  018A  CALL	R18	2
-      0x8C48253E,  //  018B  GETMET	R18	R18	K62
-      0x7C480200,  //  018C  CALL	R18	1
-      0x5C442400,  //  018D  MOVE	R17	R18
-      0x70020002,  //  018E  JMP		#0192
-      0x8C48233E,  //  018F  GETMET	R18	R17	K62
+      0x782200B8,  //  0118  JMPF	R8	#01D2
+      0xB8225800,  //  0119  GETNGBL	R8	K44
+      0x60240008,  //  011A  GETGBL	R9	G8
+      0x5C280400,  //  011B  MOVE	R10	R2
+      0x7C240200,  //  011C  CALL	R9	1
+      0x00265A09,  //  011D  ADD	R9	K45	R9
+      0x542A0003,  //  011E  LDINT	R10	4
+      0x7C200400,  //  011F  CALL	R8	2
+      0x8C200506,  //  0120  GETMET	R8	R2	K6
+      0x58280005,  //  0121  LDCONST	R10	K5
+      0x7C200400,  //  0122  CALL	R8	2
+      0x8C240506,  //  0123  GETMET	R9	R2	K6
+      0x582C0007,  //  0124  LDCONST	R11	K7
+      0x7C240400,  //  0125  CALL	R9	2
+      0x6028000C,  //  0126  GETGBL	R10	G12
+      0x5C2C1200,  //  0127  MOVE	R11	R9
+      0x7C280200,  //  0128  CALL	R10	1
+      0x1C281505,  //  0129  EQ	R10	R10	K5
+      0x782A0000,  //  012A  JMPF	R10	#012C
+      0x4C240000,  //  012B  LDNIL	R9
+      0x8C280506,  //  012C  GETMET	R10	R2	K6
+      0x5830000E,  //  012D  LDCONST	R12	K14
+      0x7C280400,  //  012E  CALL	R10	2
+      0x8C2C0506,  //  012F  GETMET	R11	R2	K6
+      0x58340010,  //  0130  LDCONST	R13	K16
+      0x7C2C0400,  //  0131  CALL	R11	2
+      0x8C300506,  //  0132  GETMET	R12	R2	K6
+      0x543A0003,  //  0133  LDINT	R14	4
+      0x7C300400,  //  0134  CALL	R12	2
+      0x8C34032E,  //  0135  GETMET	R13	R1	K46
+      0x7C340200,  //  0136  CALL	R13	1
+      0x4C380000,  //  0137  LDNIL	R14
+      0x1C341A0E,  //  0138  EQ	R13	R13	R14
+      0x78360005,  //  0139  JMPF	R13	#0140
+      0xB8365800,  //  013A  GETNGBL	R13	K44
+      0x5838002F,  //  013B  LDCONST	R14	K47
+      0x583C000E,  //  013C  LDCONST	R15	K14
+      0x7C340400,  //  013D  CALL	R13	2
+      0x4C340000,  //  013E  LDNIL	R13
+      0x80041A00,  //  013F  RET	1	R13
+      0x88340116,  //  0140  GETMBR	R13	R0	K22
+      0x88341B30,  //  0141  GETMBR	R13	R13	K48
+      0x8C341B31,  //  0142  GETMET	R13	R13	K49
+      0x7C340200,  //  0143  CALL	R13	1
+      0x8C381B32,  //  0144  GETMET	R14	R13	K50
+      0x8C40032E,  //  0145  GETMET	R16	R1	K46
+      0x7C400200,  //  0146  CALL	R16	1
+      0x7C380400,  //  0147  CALL	R14	2
+      0x8C381B33,  //  0148  GETMET	R14	R13	K51
+      0x5C401000,  //  0149  MOVE	R16	R8
+      0x5C441200,  //  014A  MOVE	R17	R9
+      0x7C380600,  //  014B  CALL	R14	3
+      0x8C381B34,  //  014C  GETMET	R14	R13	K52
+      0x5C401400,  //  014D  MOVE	R16	R10
+      0x7C380400,  //  014E  CALL	R14	2
+      0x8C381B35,  //  014F  GETMET	R14	R13	K53
+      0x5C401600,  //  0150  MOVE	R16	R11
+      0x5C441800,  //  0151  MOVE	R17	R12
+      0x7C380600,  //  0152  CALL	R14	3
+      0x8C381B36,  //  0153  GETMET	R14	R13	K54
+      0x8C400337,  //  0154  GETMET	R16	R1	K55
+      0x7C400200,  //  0155  CALL	R16	1
+      0x7C380400,  //  0156  CALL	R14	2
+      0xB83A0200,  //  0157  GETNGBL	R14	K1
+      0x88381D02,  //  0158  GETMBR	R14	R14	K2
+      0x8C381D38,  //  0159  GETMET	R14	R14	K56
+      0x5C401000,  //  015A  MOVE	R16	R8
+      0x7C380400,  //  015B  CALL	R14	2
+      0x8C3C1D39,  //  015C  GETMET	R15	R14	K57
+      0x54460005,  //  015D  LDINT	R17	6
+      0x7C3C0400,  //  015E  CALL	R15	2
+      0x8C401F06,  //  015F  GETMET	R16	R15	K6
+      0x544A0014,  //  0160  LDINT	R18	21
+      0x7C400400,  //  0161  CALL	R16	2
+      0x8C441F06,  //  0162  GETMET	R17	R15	K6
+      0x544E0010,  //  0163  LDINT	R19	17
+      0x7C440400,  //  0164  CALL	R17	2
+      0x5C482000,  //  0165  MOVE	R18	R16
+      0x784A0001,  //  0166  JMPF	R18	#0169
+      0x5C482200,  //  0167  MOVE	R18	R17
+      0x744A0005,  //  0168  JMPT	R18	#016F
+      0xB84A5800,  //  0169  GETNGBL	R18	K44
+      0x584C003A,  //  016A  LDCONST	R19	K58
+      0x5850000E,  //  016B  LDCONST	R20	K14
+      0x7C480400,  //  016C  CALL	R18	2
+      0x50480000,  //  016D  LDBOOL	R18	0	0
+      0x80042400,  //  016E  RET	1	R18
+      0x60480004,  //  016F  GETGBL	R18	G4
+      0x5C4C2000,  //  0170  MOVE	R19	R16
+      0x7C480200,  //  0171  CALL	R18	1
+      0x1C48253B,  //  0172  EQ	R18	R18	K59
+      0x784A0007,  //  0173  JMPF	R18	#017C
+      0xB84A7800,  //  0174  GETNGBL	R18	K60
+      0x8C48253D,  //  0175  GETMET	R18	R18	K61
+      0x5C502000,  //  0176  MOVE	R20	R16
+      0x7C480400,  //  0177  CALL	R18	2
+      0x8C48253E,  //  0178  GETMET	R18	R18	K62
+      0x7C480200,  //  0179  CALL	R18	1
+      0x5C402400,  //  017A  MOVE	R16	R18
+      0x70020002,  //  017B  JMP		#017F
+      0x8C48213E,  //  017C  GETMET	R18	R16	K62
+      0x7C480200,  //  017D  CALL	R18	1
+      0x5C402400,  //  017E  MOVE	R16	R18
+      0x60480004,  //  017F  GETGBL	R18	G4
+      0x5C4C2200,  //  0180  MOVE	R19	R17
+      0x7C480200,  //  0181  CALL	R18	1
+      0x1C48253B,  //  0182  EQ	R18	R18	K59
+      0x784A0007,  //  0183  JMPF	R18	#018C
+      0xB84A7800,  //  0184  GETNGBL	R18	K60
+      0x8C48253D,  //  0185  GETMET	R18	R18	K61
+      0x5C502200,  //  0186  MOVE	R20	R17
+      0x7C480400,  //  0187  CALL	R18	2
+      0x8C48253E,  //  0188  GETMET	R18	R18	K62
+      0x7C480200,  //  0189  CALL	R18	1
+      0x5C442400,  //  018A  MOVE	R17	R18
+      0x70020002,  //  018B  JMP		#018F
+      0x8C48233E,  //  018C  GETMET	R18	R17	K62
+      0x7C480200,  //  018D  CALL	R18	1
+      0x5C442400,  //  018E  MOVE	R17	R18
+      0x8C48033F,  //  018F  GETMET	R18	R1	K63
       0x7C480200,  //  0190  CALL	R18	1
-      0x5C442400,  //  0191  MOVE	R17	R18
-      0x8C48033F,  //  0192  GETMET	R18	R1	K63
-      0x7C480200,  //  0193  CALL	R18	1
-      0x404E0F40,  //  0194  CONNECT	R19	K7	K64
-      0x94482413,  //  0195  GETIDX	R18	R18	R19
-      0x604C0015,  //  0196  GETGBL	R19	G21
-      0x7C4C0000,  //  0197  CALL	R19	0
-      0x8C4C2741,  //  0198  GETMET	R19	R19	K65
-      0x58540042,  //  0199  LDCONST	R21	K66
-      0x7C4C0400,  //  019A  CALL	R19	2
-      0x8C500943,  //  019B  GETMET	R20	R4	K67
-      0x7C500200,  //  019C  CALL	R20	1
-      0x8C542144,  //  019D  GETMET	R21	R16	K68
-      0x7C540200,  //  019E  CALL	R21	1
-      0x8C542B45,  //  019F  GETMET	R21	R21	K69
-      0x7C540200,  //  01A0  CALL	R21	1
-      0x8C582946,  //  01A1  GETMET	R22	R20	K70
-      0x5C602400,  //  01A2  MOVE	R24	R18
-      0x5C642A00,  //  01A3  MOVE	R25	R21
-      0x5C682600,  //  01A4  MOVE	R26	R19
-      0x546E0007,  //  01A5  LDINT	R27	8
-      0x7C580A00,  //  01A6  CALL	R22	5
-      0x885C0312,  //  01A7  GETMBR	R23	R1	K18
-      0x785E0001,  //  01A8  JMPF	R23	#01AB
-      0x885C0312,  //  01A9  GETMBR	R23	R1	K18
-      0x70020001,  //  01AA  JMP		#01AD
-      0x885C0116,  //  01AB  GETMBR	R23	R0	K22
-      0x885C2F47,  //  01AC  GETMBR	R23	R23	K71
-      0x8C601B48,  //  01AD  GETMET	R24	R13	K72
-      0x5C682000,  //  01AE  MOVE	R26	R16
-      0x5C6C2200,  //  01AF  MOVE	R27	R17
-      0x5C702C00,  //  01B0  MOVE	R28	R22
-      0x5C742E00,  //  01B1  MOVE	R29	R23
-      0x7C600A00,  //  01B2  CALL	R24	5
-      0x8C601B49,  //  01B3  GETMET	R24	R13	K73
-      0x7C600200,  //  01B4  CALL	R24	1
-      0x88600116,  //  01B5  GETMBR	R24	R0	K22
-      0x8C60314A,  //  01B6  GETMET	R24	R24	K74
-      0x5C681A00,  //  01B7  MOVE	R26	R13
-      0x7C600400,  //  01B8  CALL	R24	2
-      0x8C60034B,  //  01B9  GETMET	R24	R1	K75
-      0x7C600200,  //  01BA  CALL	R24	1
-      0x78620002,  //  01BB  JMPF	R24	#01BF
-      0x8C60034C,  //  01BC  GETMET	R24	R1	K76
-      0x546A003B,  //  01BD  LDINT	R26	60
-      0x7C600400,  //  01BE  CALL	R24	2
-      0x8C601B4D,  //  01BF  GETMET	R24	R13	K77
-      0x7C600200,  //  01C0  CALL	R24	1
-      0x8C601B4E,  //  01C1  GETMET	R24	R13	K78
-      0x7C600200,  //  01C2  CALL	R24	1
-      0x8C600B09,  //  01C3  GETMET	R24	R5	K9
-      0x7C600200,  //  01C4  CALL	R24	1
-      0x8C64310A,  //  01C5  GETMET	R25	R24	K10
-      0x586C0005,  //  01C6  LDCONST	R27	K5
-      0x88700B0B,  //  01C7  GETMBR	R28	R5	K11
-      0xB8760200,  //  01C8  GETNGBL	R29	K1
-      0x88743B2B,  //  01C9  GETMBR	R29	R29	K43
-      0x7C640800,  //  01CA  CALL	R25	4
-      0x8C64310A,  //  01CB  GETMET	R25	R24	K10
-      0x586C0007,  //  01CC  LDCONST	R27	K7
-      0x88700B0B,  //  01CD  GETMBR	R28	R5	K11
-      0x8C741B4F,  //  01CE  GETMET	R29	R13	K79
-      0x7C740200,  //  01CF  CALL	R29	1
-      0x7C640800,  //  01D0  CALL	R25	4
-      0x54660007,  //  01D1  LDINT	R25	8
-      0x900E0819,  //  01D2  SETMBR	R3	K4	R25
-      0x80043000,  //  01D3  RET	1	R24
-      0x70020074,  //  01D4  JMP		#024A
-      0x54220008,  //  01D5  LDINT	R8	9
-      0x1C200E08,  //  01D6  EQ	R8	R7	R8
-      0x7822002C,  //  01D7  JMPF	R8	#0205
-      0x8C200506,  //  01D8  GETMET	R8	R2	K6
-      0x58280005,  //  01D9  LDCONST	R10	K5
-      0x7C200400,  //  01DA  CALL	R8	2
-      0x8C240350,  //  01DB  GETMET	R9	R1	K80
-      0x5C2C1000,  //  01DC  MOVE	R11	R8
-      0x7C240400,  //  01DD  CALL	R9	2
-      0xB8264400,  //  01DE  GETNGBL	R9	K34
-      0x8C24132C,  //  01DF  GETMET	R9	R9	K44
-      0x602C0018,  //  01E0  GETGBL	R11	G24
-      0x58300051,  //  01E1  LDCONST	R12	K81
-      0x88340312,  //  01E2  GETMBR	R13	R1	K18
-      0x8C341B52,  //  01E3  GETMET	R13	R13	K82
-      0x7C340200,  //  01E4  CALL	R13	1
-      0x8C341B44,  //  01E5  GETMET	R13	R13	K68
-      0x7C340200,  //  01E6  CALL	R13	1
-      0x8C341B45,  //  01E7  GETMET	R13	R13	K69
-      0x7C340200,  //  01E8  CALL	R13	1
-      0x8C341B53,  //  01E9  GETMET	R13	R13	K83
-      0x7C340200,  //  01EA  CALL	R13	1
-      0x60380008,  //  01EB  GETGBL	R14	G8
-      0x5C3C1000,  //  01EC  MOVE	R15	R8
-      0x7C380200,  //  01ED  CALL	R14	1
-      0x7C2C0600,  //  01EE  CALL	R11	3
-      0x58300010,  //  01EF  LDCONST	R12	K16
-      0x7C240600,  //  01F0  CALL	R9	3
-      0x8C240B09,  //  01F1  GETMET	R9	R5	K9
-      0x7C240200,  //  01F2  CALL	R9	1
-      0x8C28130A,  //  01F3  GETMET	R10	R9	K10
-      0x58300005,  //  01F4  LDCONST	R12	K5
-      0x88340B0B,  //  01F5  GETMBR	R13	R5	K11
-      0xB83A0200,  //  01F6  GETNGBL	R14	K1
-      0x88381D2B,  //  01F7  GETMBR	R14	R14	K43
-      0x7C280800,  //  01F8  CALL	R10	4
-      0x8C28130A,  //  01F9  GETMET	R10	R9	K10
-      0x58300007,  //  01FA  LDCONST	R12	K7
-      0x88340B0B,  //  01FB  GETMBR	R13	R5	K11
-      0x8C380354,  //  01FC  GETMET	R14	R1	K84
-      0x7C380200,  //  01FD  CALL	R14	1
-      0x8C381D4F,  //  01FE  GETMET	R14	R14	K79
-      0x7C380200,  //  01FF  CALL	R14	1
-      0x7C280800,  //  0200  CALL	R10	4
-      0x542A0007,  //  0201  LDINT	R10	8
-      0x900E080A,  //  0202  SETMBR	R3	K4	R10
-      0x80041200,  //  0203  RET	1	R9
-      0x70020044,  //  0204  JMP		#024A
-      0x54220009,  //  0205  LDINT	R8	10
-      0x1C200E08,  //  0206  EQ	R8	R7	R8
-      0x78220041,  //  0207  JMPF	R8	#024A
-      0x8C200506,  //  0208  GETMET	R8	R2	K6
-      0x58280005,  //  0209  LDCONST	R10	K5
-      0x7C200400,  //  020A  CALL	R8	2
-      0x60240008,  //  020B  GETGBL	R9	G8
-      0x5C281000,  //  020C  MOVE	R10	R8
-      0x7C240200,  //  020D  CALL	R9	1
-      0x0026AA09,  //  020E  ADD	R9	K85	R9
-      0x900E5809,  //  020F  SETMBR	R3	K44	R9
-      0x60240010,  //  0210  GETGBL	R9	G16
-      0x88280116,  //  0211  GETMBR	R10	R0	K22
-      0x88281530,  //  0212  GETMBR	R10	R10	K48
-      0x8C281556,  //  0213  GETMET	R10	R10	K86
-      0x7C280200,  //  0214  CALL	R10	1
-      0x7C240200,  //  0215  CALL	R9	1
-      0xA8020020,  //  0216  EXBLK	0	#0238
-      0x5C281200,  //  0217  MOVE	R10	R9
-      0x7C280000,  //  0218  CALL	R10	0
-      0x8C2C154F,  //  0219  GETMET	R11	R10	K79
+      0x404E0F40,  //  0191  CONNECT	R19	K7	K64
+      0x94482413,  //  0192  GETIDX	R18	R18	R19
+      0x604C0015,  //  0193  GETGBL	R19	G21
+      0x7C4C0000,  //  0194  CALL	R19	0
+      0x8C4C2741,  //  0195  GETMET	R19	R19	K65
+      0x58540042,  //  0196  LDCONST	R21	K66
+      0x7C4C0400,  //  0197  CALL	R19	2
+      0x8C500943,  //  0198  GETMET	R20	R4	K67
+      0x7C500200,  //  0199  CALL	R20	1
+      0x8C542144,  //  019A  GETMET	R21	R16	K68
+      0x7C540200,  //  019B  CALL	R21	1
+      0x8C542B45,  //  019C  GETMET	R21	R21	K69
+      0x7C540200,  //  019D  CALL	R21	1
+      0x8C582946,  //  019E  GETMET	R22	R20	K70
+      0x5C602400,  //  019F  MOVE	R24	R18
+      0x5C642A00,  //  01A0  MOVE	R25	R21
+      0x5C682600,  //  01A1  MOVE	R26	R19
+      0x546E0007,  //  01A2  LDINT	R27	8
+      0x7C580A00,  //  01A3  CALL	R22	5
+      0x885C0312,  //  01A4  GETMBR	R23	R1	K18
+      0x785E0001,  //  01A5  JMPF	R23	#01A8
+      0x885C0312,  //  01A6  GETMBR	R23	R1	K18
+      0x70020001,  //  01A7  JMP		#01AA
+      0x885C0116,  //  01A8  GETMBR	R23	R0	K22
+      0x885C2F47,  //  01A9  GETMBR	R23	R23	K71
+      0x8C601B48,  //  01AA  GETMET	R24	R13	K72
+      0x5C682000,  //  01AB  MOVE	R26	R16
+      0x5C6C2200,  //  01AC  MOVE	R27	R17
+      0x5C702C00,  //  01AD  MOVE	R28	R22
+      0x5C742E00,  //  01AE  MOVE	R29	R23
+      0x7C600A00,  //  01AF  CALL	R24	5
+      0x8C601B49,  //  01B0  GETMET	R24	R13	K73
+      0x7C600200,  //  01B1  CALL	R24	1
+      0x88600116,  //  01B2  GETMBR	R24	R0	K22
+      0x8C60314A,  //  01B3  GETMET	R24	R24	K74
+      0x5C681A00,  //  01B4  MOVE	R26	R13
+      0x7C600400,  //  01B5  CALL	R24	2
+      0x8C60034B,  //  01B6  GETMET	R24	R1	K75
+      0x7C600200,  //  01B7  CALL	R24	1
+      0x78620002,  //  01B8  JMPF	R24	#01BC
+      0x8C60034C,  //  01B9  GETMET	R24	R1	K76
+      0x546A003B,  //  01BA  LDINT	R26	60
+      0x7C600400,  //  01BB  CALL	R24	2
+      0x8C601B4D,  //  01BC  GETMET	R24	R13	K77
+      0x7C600200,  //  01BD  CALL	R24	1
+      0x8C601B4E,  //  01BE  GETMET	R24	R13	K78
+      0x7C600200,  //  01BF  CALL	R24	1
+      0x8C600B09,  //  01C0  GETMET	R24	R5	K9
+      0x7C600200,  //  01C1  CALL	R24	1
+      0x8C64310A,  //  01C2  GETMET	R25	R24	K10
+      0x586C0005,  //  01C3  LDCONST	R27	K5
+      0x88700B0B,  //  01C4  GETMBR	R28	R5	K11
+      0xB8760200,  //  01C5  GETNGBL	R29	K1
+      0x88743B2B,  //  01C6  GETMBR	R29	R29	K43
+      0x7C640800,  //  01C7  CALL	R25	4
+      0x8C64310A,  //  01C8  GETMET	R25	R24	K10
+      0x586C0007,  //  01C9  LDCONST	R27	K7
+      0x88700B0B,  //  01CA  GETMBR	R28	R5	K11
+      0x8C741B4F,  //  01CB  GETMET	R29	R13	K79
+      0x7C740200,  //  01CC  CALL	R29	1
+      0x7C640800,  //  01CD  CALL	R25	4
+      0x54660007,  //  01CE  LDINT	R25	8
+      0x900E0819,  //  01CF  SETMBR	R3	K4	R25
+      0x80043000,  //  01D0  RET	1	R24
+      0x70020072,  //  01D1  JMP		#0245
+      0x54220008,  //  01D2  LDINT	R8	9
+      0x1C200E08,  //  01D3  EQ	R8	R7	R8
+      0x7822002B,  //  01D4  JMPF	R8	#0201
+      0x8C200506,  //  01D5  GETMET	R8	R2	K6
+      0x58280005,  //  01D6  LDCONST	R10	K5
+      0x7C200400,  //  01D7  CALL	R8	2
+      0x8C240350,  //  01D8  GETMET	R9	R1	K80
+      0x5C2C1000,  //  01D9  MOVE	R11	R8
+      0x7C240400,  //  01DA  CALL	R9	2
+      0xB8265800,  //  01DB  GETNGBL	R9	K44
+      0x60280018,  //  01DC  GETGBL	R10	G24
+      0x582C0051,  //  01DD  LDCONST	R11	K81
+      0x88300312,  //  01DE  GETMBR	R12	R1	K18
+      0x8C301952,  //  01DF  GETMET	R12	R12	K82
+      0x7C300200,  //  01E0  CALL	R12	1
+      0x8C301944,  //  01E1  GETMET	R12	R12	K68
+      0x7C300200,  //  01E2  CALL	R12	1
+      0x8C301945,  //  01E3  GETMET	R12	R12	K69
+      0x7C300200,  //  01E4  CALL	R12	1
+      0x8C301953,  //  01E5  GETMET	R12	R12	K83
+      0x7C300200,  //  01E6  CALL	R12	1
+      0x60340008,  //  01E7  GETGBL	R13	G8
+      0x5C381000,  //  01E8  MOVE	R14	R8
+      0x7C340200,  //  01E9  CALL	R13	1
+      0x7C280600,  //  01EA  CALL	R10	3
+      0x582C0010,  //  01EB  LDCONST	R11	K16
+      0x7C240400,  //  01EC  CALL	R9	2
+      0x8C240B09,  //  01ED  GETMET	R9	R5	K9
+      0x7C240200,  //  01EE  CALL	R9	1
+      0x8C28130A,  //  01EF  GETMET	R10	R9	K10
+      0x58300005,  //  01F0  LDCONST	R12	K5
+      0x88340B0B,  //  01F1  GETMBR	R13	R5	K11
+      0xB83A0200,  //  01F2  GETNGBL	R14	K1
+      0x88381D2B,  //  01F3  GETMBR	R14	R14	K43
+      0x7C280800,  //  01F4  CALL	R10	4
+      0x8C28130A,  //  01F5  GETMET	R10	R9	K10
+      0x58300007,  //  01F6  LDCONST	R12	K7
+      0x88340B0B,  //  01F7  GETMBR	R13	R5	K11
+      0x8C380354,  //  01F8  GETMET	R14	R1	K84
+      0x7C380200,  //  01F9  CALL	R14	1
+      0x8C381D4F,  //  01FA  GETMET	R14	R14	K79
+      0x7C380200,  //  01FB  CALL	R14	1
+      0x7C280800,  //  01FC  CALL	R10	4
+      0x542A0007,  //  01FD  LDINT	R10	8
+      0x900E080A,  //  01FE  SETMBR	R3	K4	R10
+      0x80041200,  //  01FF  RET	1	R9
+      0x70020043,  //  0200  JMP		#0245
+      0x54220009,  //  0201  LDINT	R8	10
+      0x1C200E08,  //  0202  EQ	R8	R7	R8
+      0x78220040,  //  0203  JMPF	R8	#0245
+      0x8C200506,  //  0204  GETMET	R8	R2	K6
+      0x58280005,  //  0205  LDCONST	R10	K5
+      0x7C200400,  //  0206  CALL	R8	2
+      0x60240008,  //  0207  GETGBL	R9	G8
+      0x5C281000,  //  0208  MOVE	R10	R8
+      0x7C240200,  //  0209  CALL	R9	1
+      0x0026AA09,  //  020A  ADD	R9	K85	R9
+      0x900E5809,  //  020B  SETMBR	R3	K44	R9
+      0x60240010,  //  020C  GETGBL	R9	G16
+      0x88280116,  //  020D  GETMBR	R10	R0	K22
+      0x88281530,  //  020E  GETMBR	R10	R10	K48
+      0x8C281556,  //  020F  GETMET	R10	R10	K86
+      0x7C280200,  //  0210  CALL	R10	1
+      0x7C240200,  //  0211  CALL	R9	1
+      0xA8020020,  //  0212  EXBLK	0	#0234
+      0x5C281200,  //  0213  MOVE	R10	R9
+      0x7C280000,  //  0214  CALL	R10	0
+      0x8C2C154F,  //  0215  GETMET	R11	R10	K79
+      0x7C2C0200,  //  0216  CALL	R11	1
+      0x1C2C1608,  //  0217  EQ	R11	R11	R8
+      0x782E0018,  //  0218  JMPF	R11	#0232
+      0x8C2C1557,  //  0219  GETMET	R11	R10	K87
       0x7C2C0200,  //  021A  CALL	R11	1
-      0x1C2C1608,  //  021B  EQ	R11	R11	R8
-      0x782E0018,  //  021C  JMPF	R11	#0236
-      0x8C2C1557,  //  021D  GETMET	R11	R10	K87
-      0x7C2C0200,  //  021E  CALL	R11	1
-      0xB82E4400,  //  021F  GETNGBL	R11	K34
-      0x8C2C1758,  //  0220  GETMET	R11	R11	K88
-      0x543607CF,  //  0221  LDINT	R13	2000
-      0x84380000,  //  0222  CLOSURE	R14	P0
-      0x7C2C0600,  //  0223  CALL	R11	3
-      0x8C2C0B09,  //  0224  GETMET	R11	R5	K9
-      0x7C2C0200,  //  0225  CALL	R11	1
-      0x8C30170A,  //  0226  GETMET	R12	R11	K10
-      0x58380005,  //  0227  LDCONST	R14	K5
-      0x883C0B0B,  //  0228  GETMBR	R15	R5	K11
-      0xB8420200,  //  0229  GETNGBL	R16	K1
-      0x8840212B,  //  022A  GETMBR	R16	R16	K43
-      0x7C300800,  //  022B  CALL	R12	4
-      0x8C30170A,  //  022C  GETMET	R12	R11	K10
-      0x58380007,  //  022D  LDCONST	R14	K7
-      0x883C0B0B,  //  022E  GETMBR	R15	R5	K11
-      0x5C401000,  //  022F  MOVE	R16	R8
-      0x7C300800,  //  0230  CALL	R12	4
-      0x54320007,  //  0231  LDINT	R12	8
-      0x900E080C,  //  0232  SETMBR	R3	K4	R12
-      0xA0000000,  //  0233  CLOSE	R0
-      0xA8040001,  //  0234  EXBLK	1	1
-      0x80041600,  //  0235  RET	1	R11
-      0xA0240000,  //  0236  CLOSE	R9
-      0x7001FFDE,  //  0237  JMP		#0217
-      0x58240059,  //  0238  LDCONST	R9	K89
-      0xAC240200,  //  0239  CATCH	R9	1	0
-      0xB0080000,  //  023A  RAISE	2	R0	R0
-      0xB8264400,  //  023B  GETNGBL	R9	K34
-      0x8C24132C,  //  023C  GETMET	R9	R9	K44
-      0x602C0008,  //  023D  GETGBL	R11	G8
-      0x5C301000,  //  023E  MOVE	R12	R8
-      0x7C2C0200,  //  023F  CALL	R11	1
-      0x002EB40B,  //  0240  ADD	R11	K90	R11
-      0x002C175B,  //  0241  ADD	R11	R11	K91
-      0x5830000E,  //  0242  LDCONST	R12	K14
-      0x7C240600,  //  0243  CALL	R9	3
-      0xB8260200,  //  0244  GETNGBL	R9	K1
-      0x8824135C,  //  0245  GETMBR	R9	R9	K92
-      0x900E3409,  //  0246  SETMBR	R3	K26	R9
-      0x4C240000,  //  0247  LDNIL	R9
-      0xA0000000,  //  0248  CLOSE	R0
-      0x80041200,  //  0249  RET	1	R9
-      0x7002009B,  //  024A  JMP		#02E7
-      0x5422003B,  //  024B  LDINT	R8	60
-      0x1C200C08,  //  024C  EQ	R8	R6	R8
-      0x78220085,  //  024D  JMPF	R8	#02D4
-      0x1C200F05,  //  024E  EQ	R8	R7	K5
-      0x78220065,  //  024F  JMPF	R8	#02B6
-      0x8C200506,  //  0250  GETMET	R8	R2	K6
-      0x58280005,  //  0251  LDCONST	R10	K5
-      0x7C200400,  //  0252  CALL	R8	2
-      0x8C240506,  //  0253  GETMET	R9	R2	K6
-      0x582C0007,  //  0254  LDCONST	R11	K7
-      0x7C240400,  //  0255  CALL	R9	2
-      0x8C280506,  //  0256  GETMET	R10	R2	K6
-      0x5830000E,  //  0257  LDCONST	R12	K14
-      0x7C280400,  //  0258  CALL	R10	2
-      0x8C2C0506,  //  0259  GETMET	R11	R2	K6
-      0x58340010,  //  025A  LDCONST	R13	K16
-      0x7C2C0400,  //  025B  CALL	R11	2
-      0x8C300506,  //  025C  GETMET	R12	R2	K6
-      0x543A0003,  //  025D  LDINT	R14	4
-      0x7C300400,  //  025E  CALL	R12	2
-      0xB8364400,  //  025F  GETNGBL	R13	K34
-      0x8C341B2C,  //  0260  GETMET	R13	R13	K44
-      0x603C0018,  //  0261  GETGBL	R15	G24
-      0x5840005D,  //  0262  LDCONST	R16	K93
-      0x5C441000,  //  0263  MOVE	R17	R8
-      0x8C481353,  //  0264  GETMET	R18	R9	K83
-      0x7C480200,  //  0265  CALL	R18	1
-      0x5C4C1400,  //  0266  MOVE	R19	R10
-      0x5C501600,  //  0267  MOVE	R20	R11
-      0x8C541953,  //  0268  GETMET	R21	R12	K83
-      0x7C540200,  //  0269  CALL	R21	1
-      0x7C3C0C00,  //  026A  CALL	R15	6
-      0x54420003,  //  026B  LDINT	R16	4
-      0x7C340600,  //  026C  CALL	R13	3
+      0xB82E4400,  //  021B  GETNGBL	R11	K34
+      0x8C2C1758,  //  021C  GETMET	R11	R11	K88
+      0x543607CF,  //  021D  LDINT	R13	2000
+      0x84380000,  //  021E  CLOSURE	R14	P0
+      0x7C2C0600,  //  021F  CALL	R11	3
+      0x8C2C0B09,  //  0220  GETMET	R11	R5	K9
+      0x7C2C0200,  //  0221  CALL	R11	1
+      0x8C30170A,  //  0222  GETMET	R12	R11	K10
+      0x58380005,  //  0223  LDCONST	R14	K5
+      0x883C0B0B,  //  0224  GETMBR	R15	R5	K11
+      0xB8420200,  //  0225  GETNGBL	R16	K1
+      0x8840212B,  //  0226  GETMBR	R16	R16	K43
+      0x7C300800,  //  0227  CALL	R12	4
+      0x8C30170A,  //  0228  GETMET	R12	R11	K10
+      0x58380007,  //  0229  LDCONST	R14	K7
+      0x883C0B0B,  //  022A  GETMBR	R15	R5	K11
+      0x5C401000,  //  022B  MOVE	R16	R8
+      0x7C300800,  //  022C  CALL	R12	4
+      0x54320007,  //  022D  LDINT	R12	8
+      0x900E080C,  //  022E  SETMBR	R3	K4	R12
+      0xA0000000,  //  022F  CLOSE	R0
+      0xA8040001,  //  0230  EXBLK	1	1
+      0x80041600,  //  0231  RET	1	R11
+      0xA0240000,  //  0232  CLOSE	R9
+      0x7001FFDE,  //  0233  JMP		#0213
+      0x58240059,  //  0234  LDCONST	R9	K89
+      0xAC240200,  //  0235  CATCH	R9	1	0
+      0xB0080000,  //  0236  RAISE	2	R0	R0
+      0xB8265800,  //  0237  GETNGBL	R9	K44
+      0x60280008,  //  0238  GETGBL	R10	G8
+      0x5C2C1000,  //  0239  MOVE	R11	R8
+      0x7C280200,  //  023A  CALL	R10	1
+      0x002AB40A,  //  023B  ADD	R10	K90	R10
+      0x0028155B,  //  023C  ADD	R10	R10	K91
+      0x582C000E,  //  023D  LDCONST	R11	K14
+      0x7C240400,  //  023E  CALL	R9	2
+      0xB8260200,  //  023F  GETNGBL	R9	K1
+      0x8824135C,  //  0240  GETMBR	R9	R9	K92
+      0x900E3409,  //  0241  SETMBR	R3	K26	R9
+      0x4C240000,  //  0242  LDNIL	R9
+      0xA0000000,  //  0243  CLOSE	R0
+      0x80041200,  //  0244  RET	1	R9
+      0x70020098,  //  0245  JMP		#02DF
+      0x5422003B,  //  0246  LDINT	R8	60
+      0x1C200C08,  //  0247  EQ	R8	R6	R8
+      0x78220082,  //  0248  JMPF	R8	#02CC
+      0x1C200F05,  //  0249  EQ	R8	R7	K5
+      0x78220063,  //  024A  JMPF	R8	#02AF
+      0x8C200506,  //  024B  GETMET	R8	R2	K6
+      0x58280005,  //  024C  LDCONST	R10	K5
+      0x7C200400,  //  024D  CALL	R8	2
+      0x8C240506,  //  024E  GETMET	R9	R2	K6
+      0x582C0007,  //  024F  LDCONST	R11	K7
+      0x7C240400,  //  0250  CALL	R9	2
+      0x8C280506,  //  0251  GETMET	R10	R2	K6
+      0x5830000E,  //  0252  LDCONST	R12	K14
+      0x7C280400,  //  0253  CALL	R10	2
+      0x8C2C0506,  //  0254  GETMET	R11	R2	K6
+      0x58340010,  //  0255  LDCONST	R13	K16
+      0x7C2C0400,  //  0256  CALL	R11	2
+      0x8C300506,  //  0257  GETMET	R12	R2	K6
+      0x543A0003,  //  0258  LDINT	R14	4
+      0x7C300400,  //  0259  CALL	R12	2
+      0xB8365800,  //  025A  GETNGBL	R13	K44
+      0x60380018,  //  025B  GETGBL	R14	G24
+      0x583C005D,  //  025C  LDCONST	R15	K93
+      0x5C401000,  //  025D  MOVE	R16	R8
+      0x8C441353,  //  025E  GETMET	R17	R9	K83
+      0x7C440200,  //  025F  CALL	R17	1
+      0x5C481400,  //  0260  MOVE	R18	R10
+      0x5C4C1600,  //  0261  MOVE	R19	R11
+      0x8C501953,  //  0262  GETMET	R20	R12	K83
+      0x7C500200,  //  0263  CALL	R20	1
+      0x7C380C00,  //  0264  CALL	R14	6
+      0x543E0003,  //  0265  LDINT	R15	4
+      0x7C340400,  //  0266  CALL	R13	2
+      0x4C340000,  //  0267  LDNIL	R13
+      0x1C34100D,  //  0268  EQ	R13	R8	R13
+      0x7436000B,  //  0269  JMPT	R13	#0276
+      0x4C340000,  //  026A  LDNIL	R13
+      0x1C34120D,  //  026B  EQ	R13	R9	R13
+      0x74360008,  //  026C  JMPT	R13	#0276
       0x4C340000,  //  026D  LDNIL	R13
-      0x1C34100D,  //  026E  EQ	R13	R8	R13
-      0x7436000B,  //  026F  JMPT	R13	#027C
+      0x1C34140D,  //  026E  EQ	R13	R10	R13
+      0x74360005,  //  026F  JMPT	R13	#0276
       0x4C340000,  //  0270  LDNIL	R13
-      0x1C34120D,  //  0271  EQ	R13	R9	R13
-      0x74360008,  //  0272  JMPT	R13	#027C
+      0x1C34160D,  //  0271  EQ	R13	R11	R13
+      0x74360002,  //  0272  JMPT	R13	#0276
       0x4C340000,  //  0273  LDNIL	R13
-      0x1C34140D,  //  0274  EQ	R13	R10	R13
-      0x74360005,  //  0275  JMPT	R13	#027C
-      0x4C340000,  //  0276  LDNIL	R13
-      0x1C34160D,  //  0277  EQ	R13	R11	R13
-      0x74360002,  //  0278  JMPT	R13	#027C
+      0x1C34180D,  //  0274  EQ	R13	R12	R13
+      0x78360005,  //  0275  JMPF	R13	#027C
+      0xB8360200,  //  0276  GETNGBL	R13	K1
+      0x88341B5E,  //  0277  GETMBR	R13	R13	K94
+      0x900E340D,  //  0278  SETMBR	R3	K26	R13
       0x4C340000,  //  0279  LDNIL	R13
-      0x1C34180D,  //  027A  EQ	R13	R12	R13
-      0x78360005,  //  027B  JMPF	R13	#0282
-      0xB8360200,  //  027C  GETNGBL	R13	K1
-      0x88341B5E,  //  027D  GETMBR	R13	R13	K94
-      0x900E340D,  //  027E  SETMBR	R3	K26	R13
-      0x4C340000,  //  027F  LDNIL	R13
-      0xA0000000,  //  0280  CLOSE	R0
-      0x80041A00,  //  0281  RET	1	R13
-      0x6034000C,  //  0282  GETGBL	R13	G12
-      0x5C381200,  //  0283  MOVE	R14	R9
-      0x7C340200,  //  0284  CALL	R13	1
-      0x543A001F,  //  0285  LDINT	R14	32
-      0x543E0040,  //  0286  LDINT	R15	65
-      0x00381C0F,  //  0287  ADD	R14	R14	R15
-      0x20341A0E,  //  0288  NE	R13	R13	R14
-      0x7436000B,  //  0289  JMPT	R13	#0296
+      0xA0000000,  //  027A  CLOSE	R0
+      0x80041A00,  //  027B  RET	1	R13
+      0x6034000C,  //  027C  GETGBL	R13	G12
+      0x5C381200,  //  027D  MOVE	R14	R9
+      0x7C340200,  //  027E  CALL	R13	1
+      0x543A001F,  //  027F  LDINT	R14	32
+      0x543E0040,  //  0280  LDINT	R15	65
+      0x00381C0F,  //  0281  ADD	R14	R14	R15
+      0x20341A0E,  //  0282  NE	R13	R13	R14
+      0x7436000B,  //  0283  JMPT	R13	#0290
+      0x6034000C,  //  0284  GETGBL	R13	G12
+      0x5C381800,  //  0285  MOVE	R14	R12
+      0x7C340200,  //  0286  CALL	R13	1
+      0x543A000F,  //  0287  LDINT	R14	16
+      0x14341A0E,  //  0288  LT	R13	R13	R14
+      0x74360005,  //  0289  JMPT	R13	#0290
       0x6034000C,  //  028A  GETGBL	R13	G12
       0x5C381800,  //  028B  MOVE	R14	R12
       0x7C340200,  //  028C  CALL	R13	1
-      0x543A000F,  //  028D  LDINT	R14	16
-      0x14341A0E,  //  028E  LT	R13	R13	R14
-      0x74360005,  //  028F  JMPT	R13	#0296
-      0x6034000C,  //  0290  GETGBL	R13	G12
-      0x5C381800,  //  0291  MOVE	R14	R12
-      0x7C340200,  //  0292  CALL	R13	1
-      0x543A001F,  //  0293  LDINT	R14	32
-      0x24341A0E,  //  0294  GT	R13	R13	R14
-      0x7836000A,  //  0295  JMPF	R13	#02A1
-      0xB8364400,  //  0296  GETNGBL	R13	K34
-      0x8C341B2C,  //  0297  GETMET	R13	R13	K44
-      0x583C005F,  //  0298  LDCONST	R15	K95
-      0x5840000E,  //  0299  LDCONST	R16	K14
-      0x7C340600,  //  029A  CALL	R13	3
-      0xB8360200,  //  029B  GETNGBL	R13	K1
-      0x88341B60,  //  029C  GETMBR	R13	R13	K96
-      0x900E340D,  //  029D  SETMBR	R3	K26	R13
-      0x4C340000,  //  029E  LDNIL	R13
-      0xA0000000,  //  029F  CLOSE	R0
-      0x80041A00,  //  02A0  RET	1	R13
-      0x5436001E,  //  02A1  LDINT	R13	31
-      0x40360A0D,  //  02A2  CONNECT	R13	K5	R13
-      0x9434120D,  //  02A3  GETIDX	R13	R9	R13
-      0x543A001F,  //  02A4  LDINT	R14	32
-      0x40381D40,  //  02A5  CONNECT	R14	R14	K64
-      0x9438120E,  //  02A6  GETIDX	R14	R9	R14
-      0x883C0116,  //  02A7  GETMBR	R15	R0	K22
-      0x8C3C1F61,  //  02A8  GETMET	R15	R15	K97
-      0x5C441000,  //  02A9  MOVE	R17	R8
-      0x5C481600,  //  02AA  MOVE	R18	R11
-      0x5C4C1400,  //  02AB  MOVE	R19	R10
-      0x5C501800,  //  02AC  MOVE	R20	R12
-      0x5C541A00,  //  02AD  MOVE	R21	R13
-      0x5C581C00,  //  02AE  MOVE	R22	R14
-      0x8C5C0354,  //  02AF  GETMET	R23	R1	K84
-      0x7C5C0200,  //  02B0  CALL	R23	1
-      0x7C3C1000,  //  02B1  CALL	R15	8
-      0x503C0200,  //  02B2  LDBOOL	R15	1	0
-      0xA0000000,  //  02B3  CLOSE	R0
-      0x80041E00,  //  02B4  RET	1	R15
-      0x7002001C,  //  02B5  JMP		#02D3
-      0x1C200F07,  //  02B6  EQ	R8	R7	K7
-      0x78220012,  //  02B7  JMPF	R8	#02CB
-      0x8C200506,  //  02B8  GETMET	R8	R2	K6
-      0x58280005,  //  02B9  LDCONST	R10	K5
-      0x7C200400,  //  02BA  CALL	R8	2
-      0xB8264400,  //  02BB  GETNGBL	R9	K34
-      0x8C24132C,  //  02BC  GETMET	R9	R9	K44
-      0x602C0008,  //  02BD  GETGBL	R11	G8
-      0x5C301000,  //  02BE  MOVE	R12	R8
-      0x7C2C0200,  //  02BF  CALL	R11	1
-      0x002EC40B,  //  02C0  ADD	R11	K98	R11
-      0x58300010,  //  02C1  LDCONST	R12	K16
-      0x7C240600,  //  02C2  CALL	R9	3
-      0x88240116,  //  02C3  GETMBR	R9	R0	K22
-      0x8C241363,  //  02C4  GETMET	R9	R9	K99
-      0x5C2C1000,  //  02C5  MOVE	R11	R8
-      0x7C240400,  //  02C6  CALL	R9	2
-      0x50240200,  //  02C7  LDBOOL	R9	1	0
-      0xA0000000,  //  02C8  CLOSE	R0
-      0x80041200,  //  02C9  RET	1	R9
-      0x70020007,  //  02CA  JMP		#02D3
-      0x1C200F0E,  //  02CB  EQ	R8	R7	K14
-      0x78220005,  //  02CC  JMPF	R8	#02D3
-      0x88200116,  //  02CD  GETMBR	R8	R0	K22
-      0x8C201164,  //  02CE  GETMET	R8	R8	K100
-      0x7C200200,  //  02CF  CALL	R8	1
-      0x50200200,  //  02D0  LDBOOL	R8	1	0
-      0xA0000000,  //  02D1  CLOSE	R0
-      0x80041000,  //  02D2  RET	1	R8
-      0x70020012,  //  02D3  JMP		#02E7
-      0x54220029,  //  02D4  LDINT	R8	42
-      0x1C200C08,  //  02D5  EQ	R8	R6	R8
-      0x78220005,  //  02D6  JMPF	R8	#02DD
-      0x1C200F05,  //  02D7  EQ	R8	R7	K5
-      0x78220002,  //  02D8  JMPF	R8	#02DC
-      0x50200200,  //  02D9  LDBOOL	R8	1	0
-      0xA0000000,  //  02DA  CLOSE	R0
-      0x80041000,  //  02DB  RET	1	R8
-      0x70020009,  //  02DC  JMP		#02E7
-      0x60200003,  //  02DD  GETGBL	R8	G3
-      0x5C240000,  //  02DE  MOVE	R9	R0
-      0x7C200200,  //  02DF  CALL	R8	1
-      0x8C201165,  //  02E0  GETMET	R8	R8	K101
-      0x5C280200,  //  02E1  MOVE	R10	R1
-      0x5C2C0400,  //  02E2  MOVE	R11	R2
-      0x5C300600,  //  02E3  MOVE	R12	R3
-      0x7C200800,  //  02E4  CALL	R8	4
-      0xA0000000,  //  02E5  CLOSE	R0
-      0x80041000,  //  02E6  RET	1	R8
-      0xA0000000,  //  02E7  CLOSE	R0
-      0x80000000,  //  02E8  RET	0
+      0x543A001F,  //  028D  LDINT	R14	32
+      0x24341A0E,  //  028E  GT	R13	R13	R14
+      0x78360009,  //  028F  JMPF	R13	#029A
+      0xB8365800,  //  0290  GETNGBL	R13	K44
+      0x5838005F,  //  0291  LDCONST	R14	K95
+      0x583C000E,  //  0292  LDCONST	R15	K14
+      0x7C340400,  //  0293  CALL	R13	2
+      0xB8360200,  //  0294  GETNGBL	R13	K1
+      0x88341B60,  //  0295  GETMBR	R13	R13	K96
+      0x900E340D,  //  0296  SETMBR	R3	K26	R13
+      0x4C340000,  //  0297  LDNIL	R13
+      0xA0000000,  //  0298  CLOSE	R0
+      0x80041A00,  //  0299  RET	1	R13
+      0x5436001E,  //  029A  LDINT	R13	31
+      0x40360A0D,  //  029B  CONNECT	R13	K5	R13
+      0x9434120D,  //  029C  GETIDX	R13	R9	R13
+      0x543A001F,  //  029D  LDINT	R14	32
+      0x40381D40,  //  029E  CONNECT	R14	R14	K64
+      0x9438120E,  //  029F  GETIDX	R14	R9	R14
+      0x883C0116,  //  02A0  GETMBR	R15	R0	K22
+      0x8C3C1F61,  //  02A1  GETMET	R15	R15	K97
+      0x5C441000,  //  02A2  MOVE	R17	R8
+      0x5C481600,  //  02A3  MOVE	R18	R11
+      0x5C4C1400,  //  02A4  MOVE	R19	R10
+      0x5C501800,  //  02A5  MOVE	R20	R12
+      0x5C541A00,  //  02A6  MOVE	R21	R13
+      0x5C581C00,  //  02A7  MOVE	R22	R14
+      0x8C5C0354,  //  02A8  GETMET	R23	R1	K84
+      0x7C5C0200,  //  02A9  CALL	R23	1
+      0x7C3C1000,  //  02AA  CALL	R15	8
+      0x503C0200,  //  02AB  LDBOOL	R15	1	0
+      0xA0000000,  //  02AC  CLOSE	R0
+      0x80041E00,  //  02AD  RET	1	R15
+      0x7002001B,  //  02AE  JMP		#02CB
+      0x1C200F07,  //  02AF  EQ	R8	R7	K7
+      0x78220011,  //  02B0  JMPF	R8	#02C3
+      0x8C200506,  //  02B1  GETMET	R8	R2	K6
+      0x58280005,  //  02B2  LDCONST	R10	K5
+      0x7C200400,  //  02B3  CALL	R8	2
+      0xB8265800,  //  02B4  GETNGBL	R9	K44
+      0x60280008,  //  02B5  GETGBL	R10	G8
+      0x5C2C1000,  //  02B6  MOVE	R11	R8
+      0x7C280200,  //  02B7  CALL	R10	1
+      0x002AC40A,  //  02B8  ADD	R10	K98	R10
+      0x582C0010,  //  02B9  LDCONST	R11	K16
+      0x7C240400,  //  02BA  CALL	R9	2
+      0x88240116,  //  02BB  GETMBR	R9	R0	K22
+      0x8C241363,  //  02BC  GETMET	R9	R9	K99
+      0x5C2C1000,  //  02BD  MOVE	R11	R8
+      0x7C240400,  //  02BE  CALL	R9	2
+      0x50240200,  //  02BF  LDBOOL	R9	1	0
+      0xA0000000,  //  02C0  CLOSE	R0
+      0x80041200,  //  02C1  RET	1	R9
+      0x70020007,  //  02C2  JMP		#02CB
+      0x1C200F0E,  //  02C3  EQ	R8	R7	K14
+      0x78220005,  //  02C4  JMPF	R8	#02CB
+      0x88200116,  //  02C5  GETMBR	R8	R0	K22
+      0x8C201164,  //  02C6  GETMET	R8	R8	K100
+      0x7C200200,  //  02C7  CALL	R8	1
+      0x50200200,  //  02C8  LDBOOL	R8	1	0
+      0xA0000000,  //  02C9  CLOSE	R0
+      0x80041000,  //  02CA  RET	1	R8
+      0x70020012,  //  02CB  JMP		#02DF
+      0x54220029,  //  02CC  LDINT	R8	42
+      0x1C200C08,  //  02CD  EQ	R8	R6	R8
+      0x78220005,  //  02CE  JMPF	R8	#02D5
+      0x1C200F05,  //  02CF  EQ	R8	R7	K5
+      0x78220002,  //  02D0  JMPF	R8	#02D4
+      0x50200200,  //  02D1  LDBOOL	R8	1	0
+      0xA0000000,  //  02D2  CLOSE	R0
+      0x80041000,  //  02D3  RET	1	R8
+      0x70020009,  //  02D4  JMP		#02DF
+      0x60200003,  //  02D5  GETGBL	R8	G3
+      0x5C240000,  //  02D6  MOVE	R9	R0
+      0x7C200200,  //  02D7  CALL	R8	1
+      0x8C201165,  //  02D8  GETMET	R8	R8	K101
+      0x5C280200,  //  02D9  MOVE	R10	R1
+      0x5C2C0400,  //  02DA  MOVE	R11	R2
+      0x5C300600,  //  02DB  MOVE	R12	R3
+      0x7C200800,  //  02DC  CALL	R8	4
+      0xA0000000,  //  02DD  CLOSE	R0
+      0x80041000,  //  02DE  RET	1	R8
+      0xA0000000,  //  02DF  CLOSE	R0
+      0x80000000,  //  02E0  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Air_Quality.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Air_Quality.h
@@ -283,130 +283,119 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
         0,                          /* has sup protos */
         NULL, 
         1,                          /* has constants */
-        ( &(const bvalue[ 8]) {     /* constants */
+        ( &(const bvalue[ 9]) {     /* constants */
         /* K0   */  be_const_int(0),
-        /* K1   */  be_nested_str_weak(set),
+        /* K1   */  be_nested_str_weak(set_or_nil),
         /* K2   */  be_nested_str_weak(FLOAT),
-        /* K3   */  be_nested_str_weak(NULL),
-        /* K4   */  be_const_int(1),
-        /* K5   */  be_const_int(2),
-        /* K6   */  be_nested_str_weak(U1),
-        /* K7   */  be_nested_str_weak(U4),
+        /* K3   */  be_const_int(1),
+        /* K4   */  be_nested_str_weak(set),
+        /* K5   */  be_nested_str_weak(NULL),
+        /* K6   */  be_const_int(2),
+        /* K7   */  be_nested_str_weak(U1),
+        /* K8   */  be_nested_str_weak(U4),
         }),
         be_str_weak(handle_value),
         &be_const_str_solidified,
-        ( &(const binstruction[85]) {  /* code */
+        ( &(const binstruction[74]) {  /* code */
           0x4C080000,  //  0000  LDNIL	R2
           0x1C080202,  //  0001  EQ	R2	R1	R2
           0x780A0000,  //  0002  JMPF	R2	#0004
           0x58040000,  //  0003  LDCONST	R1	K0
           0x68080000,  //  0004  GETUPV	R2	U0
           0x1C080500,  //  0005  EQ	R2	R2	K0
-          0x780A0012,  //  0006  JMPF	R2	#001A
-          0x4C080000,  //  0007  LDNIL	R2
-          0x20080002,  //  0008  NE	R2	R0	R2
-          0x780A0007,  //  0009  JMPF	R2	#0012
-          0x68080001,  //  000A  GETUPV	R2	U1
-          0x8C080501,  //  000B  GETMET	R2	R2	K1
-          0x68100002,  //  000C  GETUPV	R4	U2
-          0x88100902,  //  000D  GETMBR	R4	R4	K2
-          0x5C140000,  //  000E  MOVE	R5	R0
-          0x7C080600,  //  000F  CALL	R2	3
-          0x80040400,  //  0010  RET	1	R2
-          0x70020006,  //  0011  JMP		#0019
+          0x780A0007,  //  0006  JMPF	R2	#000F
+          0x68080001,  //  0007  GETUPV	R2	U1
+          0x8C080501,  //  0008  GETMET	R2	R2	K1
+          0x68100002,  //  0009  GETUPV	R4	U2
+          0x88100902,  //  000A  GETMBR	R4	R4	K2
+          0x5C140000,  //  000B  MOVE	R5	R0
+          0x7C080600,  //  000C  CALL	R2	3
+          0x80040400,  //  000D  RET	1	R2
+          0x70020038,  //  000E  JMP		#0048
+          0x68080000,  //  000F  GETUPV	R2	U0
+          0x1C080503,  //  0010  EQ	R2	R2	K3
+          0x780A0007,  //  0011  JMPF	R2	#001A
           0x68080001,  //  0012  GETUPV	R2	U1
-          0x8C080501,  //  0013  GETMET	R2	R2	K1
+          0x8C080504,  //  0013  GETMET	R2	R2	K4
           0x68100002,  //  0014  GETUPV	R4	U2
-          0x88100903,  //  0015  GETMBR	R4	R4	K3
+          0x88100905,  //  0015  GETMBR	R4	R4	K5
           0x4C140000,  //  0016  LDNIL	R5
           0x7C080600,  //  0017  CALL	R2	3
           0x80040400,  //  0018  RET	1	R2
-          0x70020038,  //  0019  JMP		#0053
+          0x7002002D,  //  0019  JMP		#0048
           0x68080000,  //  001A  GETUPV	R2	U0
-          0x1C080504,  //  001B  EQ	R2	R2	K4
+          0x1C080506,  //  001B  EQ	R2	R2	K6
           0x780A0007,  //  001C  JMPF	R2	#0025
           0x68080001,  //  001D  GETUPV	R2	U1
-          0x8C080501,  //  001E  GETMET	R2	R2	K1
+          0x8C080504,  //  001E  GETMET	R2	R2	K4
           0x68100002,  //  001F  GETUPV	R4	U2
-          0x88100903,  //  0020  GETMBR	R4	R4	K3
+          0x88100905,  //  0020  GETMBR	R4	R4	K5
           0x4C140000,  //  0021  LDNIL	R5
           0x7C080600,  //  0022  CALL	R2	3
           0x80040400,  //  0023  RET	1	R2
-          0x7002002D,  //  0024  JMP		#0053
+          0x70020022,  //  0024  JMP		#0048
           0x68080000,  //  0025  GETUPV	R2	U0
-          0x1C080505,  //  0026  EQ	R2	R2	K5
-          0x780A0007,  //  0027  JMPF	R2	#0030
-          0x68080001,  //  0028  GETUPV	R2	U1
-          0x8C080501,  //  0029  GETMET	R2	R2	K1
-          0x68100002,  //  002A  GETUPV	R4	U2
-          0x88100903,  //  002B  GETMBR	R4	R4	K3
-          0x4C140000,  //  002C  LDNIL	R5
-          0x7C080600,  //  002D  CALL	R2	3
-          0x80040400,  //  002E  RET	1	R2
-          0x70020022,  //  002F  JMP		#0053
-          0x68080000,  //  0030  GETUPV	R2	U0
-          0x540E0007,  //  0031  LDINT	R3	8
-          0x1C080403,  //  0032  EQ	R2	R2	R3
-          0x780A0007,  //  0033  JMPF	R2	#003C
-          0x68080001,  //  0034  GETUPV	R2	U1
-          0x8C080501,  //  0035  GETMET	R2	R2	K1
-          0x68100002,  //  0036  GETUPV	R4	U2
-          0x88100906,  //  0037  GETMBR	R4	R4	K6
-          0x5C140200,  //  0038  MOVE	R5	R1
-          0x7C080600,  //  0039  CALL	R2	3
-          0x80040400,  //  003A  RET	1	R2
-          0x70020016,  //  003B  JMP		#0053
-          0x68080000,  //  003C  GETUPV	R2	U0
-          0x540E0008,  //  003D  LDINT	R3	9
-          0x1C080403,  //  003E  EQ	R2	R2	R3
-          0x780A0007,  //  003F  JMPF	R2	#0048
-          0x68080001,  //  0040  GETUPV	R2	U1
-          0x8C080501,  //  0041  GETMET	R2	R2	K1
-          0x68100002,  //  0042  GETUPV	R4	U2
-          0x88100906,  //  0043  GETMBR	R4	R4	K6
-          0x58140000,  //  0044  LDCONST	R5	K0
-          0x7C080600,  //  0045  CALL	R2	3
-          0x80040400,  //  0046  RET	1	R2
-          0x7002000A,  //  0047  JMP		#0053
-          0x68080000,  //  0048  GETUPV	R2	U0
-          0x540EFFFB,  //  0049  LDINT	R3	65532
-          0x1C080403,  //  004A  EQ	R2	R2	R3
-          0x780A0006,  //  004B  JMPF	R2	#0053
-          0x68080001,  //  004C  GETUPV	R2	U1
-          0x8C080501,  //  004D  GETMET	R2	R2	K1
-          0x68100002,  //  004E  GETUPV	R4	U2
-          0x88100907,  //  004F  GETMBR	R4	R4	K7
-          0x58140004,  //  0050  LDCONST	R5	K4
-          0x7C080600,  //  0051  CALL	R2	3
-          0x80040400,  //  0052  RET	1	R2
-          0x4C080000,  //  0053  LDNIL	R2
-          0x80040400,  //  0054  RET	1	R2
+          0x540E0007,  //  0026  LDINT	R3	8
+          0x1C080403,  //  0027  EQ	R2	R2	R3
+          0x780A0007,  //  0028  JMPF	R2	#0031
+          0x68080001,  //  0029  GETUPV	R2	U1
+          0x8C080504,  //  002A  GETMET	R2	R2	K4
+          0x68100002,  //  002B  GETUPV	R4	U2
+          0x88100907,  //  002C  GETMBR	R4	R4	K7
+          0x5C140200,  //  002D  MOVE	R5	R1
+          0x7C080600,  //  002E  CALL	R2	3
+          0x80040400,  //  002F  RET	1	R2
+          0x70020016,  //  0030  JMP		#0048
+          0x68080000,  //  0031  GETUPV	R2	U0
+          0x540E0008,  //  0032  LDINT	R3	9
+          0x1C080403,  //  0033  EQ	R2	R2	R3
+          0x780A0007,  //  0034  JMPF	R2	#003D
+          0x68080001,  //  0035  GETUPV	R2	U1
+          0x8C080504,  //  0036  GETMET	R2	R2	K4
+          0x68100002,  //  0037  GETUPV	R4	U2
+          0x88100907,  //  0038  GETMBR	R4	R4	K7
+          0x58140000,  //  0039  LDCONST	R5	K0
+          0x7C080600,  //  003A  CALL	R2	3
+          0x80040400,  //  003B  RET	1	R2
+          0x7002000A,  //  003C  JMP		#0048
+          0x68080000,  //  003D  GETUPV	R2	U0
+          0x540EFFFB,  //  003E  LDINT	R3	65532
+          0x1C080403,  //  003F  EQ	R2	R2	R3
+          0x780A0006,  //  0040  JMPF	R2	#0048
+          0x68080001,  //  0041  GETUPV	R2	U1
+          0x8C080504,  //  0042  GETMET	R2	R2	K4
+          0x68100002,  //  0043  GETUPV	R4	U2
+          0x88100908,  //  0044  GETMBR	R4	R4	K8
+          0x58140003,  //  0045  LDCONST	R5	K3
+          0x7C080600,  //  0046  CALL	R2	3
+          0x80040400,  //  0047  RET	1	R2
+          0x4C080000,  //  0048  LDNIL	R2
+          0x80040400,  //  0049  RET	1	R2
         })
       ),
     &be_class_Matter_Plugin_Sensor_Air_Quality, 
     }),
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
+    ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(attribute),
     /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(shadow_air_quality),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(U1),
-    /* K8   */  be_nested_str_weak(NULL),
-    /* K9   */  be_nested_str_weak(shadow_co2),
-    /* K10  */  be_nested_str_weak(shadow_pm1),
-    /* K11  */  be_nested_str_weak(shadow_pm2_5),
-    /* K12  */  be_nested_str_weak(shadow_pm10),
-    /* K13  */  be_nested_str_weak(shadow_tvoc),
-    /* K14  */  be_nested_str_weak(shadow_no2),
-    /* K15  */  be_nested_str_weak(read_attribute),
+    /* K5   */  be_nested_str_weak(set_or_nil),
+    /* K6   */  be_nested_str_weak(U1),
+    /* K7   */  be_nested_str_weak(shadow_air_quality),
+    /* K8   */  be_nested_str_weak(shadow_co2),
+    /* K9   */  be_nested_str_weak(shadow_pm1),
+    /* K10  */  be_nested_str_weak(shadow_pm2_5),
+    /* K11  */  be_nested_str_weak(shadow_pm10),
+    /* K12  */  be_nested_str_weak(shadow_tvoc),
+    /* K13  */  be_nested_str_weak(shadow_no2),
+    /* K14  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[104]) {  /* code */
+    ( &(const binstruction[93]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
@@ -415,28 +404,28 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       0x84200000,  //  0005  CLOSURE	R8	P0
       0x5426005A,  //  0006  LDINT	R9	91
       0x1C240A09,  //  0007  EQ	R9	R5	R9
-      0x78260013,  //  0008  JMPF	R9	#001D
+      0x78260008,  //  0008  JMPF	R9	#0012
       0x1C240D04,  //  0009  EQ	R9	R6	K4
-      0x78260010,  //  000A  JMPF	R9	#001C
-      0x88240105,  //  000B  GETMBR	R9	R0	K5
-      0x4C280000,  //  000C  LDNIL	R10
-      0x2024120A,  //  000D  NE	R9	R9	R10
-      0x78260006,  //  000E  JMPF	R9	#0016
-      0x8C240706,  //  000F  GETMET	R9	R3	K6
-      0x882C0907,  //  0010  GETMBR	R11	R4	K7
-      0x88300105,  //  0011  GETMBR	R12	R0	K5
-      0x7C240600,  //  0012  CALL	R9	3
-      0xA0000000,  //  0013  CLOSE	R0
-      0x80041200,  //  0014  RET	1	R9
-      0x70020005,  //  0015  JMP		#001C
-      0x8C240706,  //  0016  GETMET	R9	R3	K6
-      0x882C0908,  //  0017  GETMBR	R11	R4	K8
-      0x4C300000,  //  0018  LDNIL	R12
-      0x7C240600,  //  0019  CALL	R9	3
+      0x78260005,  //  000A  JMPF	R9	#0011
+      0x8C240705,  //  000B  GETMET	R9	R3	K5
+      0x882C0906,  //  000C  GETMBR	R11	R4	K6
+      0x88300107,  //  000D  GETMBR	R12	R0	K7
+      0x7C240600,  //  000E  CALL	R9	3
+      0xA0000000,  //  000F  CLOSE	R0
+      0x80041200,  //  0010  RET	1	R9
+      0x70020040,  //  0011  JMP		#0053
+      0x5426040C,  //  0012  LDINT	R9	1037
+      0x1C240A09,  //  0013  EQ	R9	R5	R9
+      0x78260007,  //  0014  JMPF	R9	#001D
+      0x5C241000,  //  0015  MOVE	R9	R8
+      0x88280108,  //  0016  GETMBR	R10	R0	K8
+      0x7C240200,  //  0017  CALL	R9	1
+      0x5C1C1200,  //  0018  MOVE	R7	R9
+      0x78260001,  //  0019  JMPF	R9	#001C
       0xA0000000,  //  001A  CLOSE	R0
-      0x80041200,  //  001B  RET	1	R9
-      0x70020040,  //  001C  JMP		#005E
-      0x5426040C,  //  001D  LDINT	R9	1037
+      0x80040E00,  //  001B  RET	1	R7
+      0x70020035,  //  001C  JMP		#0053
+      0x5426042B,  //  001D  LDINT	R9	1068
       0x1C240A09,  //  001E  EQ	R9	R5	R9
       0x78260007,  //  001F  JMPF	R9	#0028
       0x5C241000,  //  0020  MOVE	R9	R8
@@ -446,8 +435,8 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       0x78260001,  //  0024  JMPF	R9	#0027
       0xA0000000,  //  0025  CLOSE	R0
       0x80040E00,  //  0026  RET	1	R7
-      0x70020035,  //  0027  JMP		#005E
-      0x5426042B,  //  0028  LDINT	R9	1068
+      0x7002002A,  //  0027  JMP		#0053
+      0x54260429,  //  0028  LDINT	R9	1066
       0x1C240A09,  //  0029  EQ	R9	R5	R9
       0x78260007,  //  002A  JMPF	R9	#0033
       0x5C241000,  //  002B  MOVE	R9	R8
@@ -457,8 +446,8 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       0x78260001,  //  002F  JMPF	R9	#0032
       0xA0000000,  //  0030  CLOSE	R0
       0x80040E00,  //  0031  RET	1	R7
-      0x7002002A,  //  0032  JMP		#005E
-      0x54260429,  //  0033  LDINT	R9	1066
+      0x7002001F,  //  0032  JMP		#0053
+      0x5426042C,  //  0033  LDINT	R9	1069
       0x1C240A09,  //  0034  EQ	R9	R5	R9
       0x78260007,  //  0035  JMPF	R9	#003E
       0x5C241000,  //  0036  MOVE	R9	R8
@@ -468,8 +457,8 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       0x78260001,  //  003A  JMPF	R9	#003D
       0xA0000000,  //  003B  CLOSE	R0
       0x80040E00,  //  003C  RET	1	R7
-      0x7002001F,  //  003D  JMP		#005E
-      0x5426042C,  //  003E  LDINT	R9	1069
+      0x70020014,  //  003D  JMP		#0053
+      0x5426042D,  //  003E  LDINT	R9	1070
       0x1C240A09,  //  003F  EQ	R9	R5	R9
       0x78260007,  //  0040  JMPF	R9	#0049
       0x5C241000,  //  0041  MOVE	R9	R8
@@ -479,10 +468,10 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       0x78260001,  //  0045  JMPF	R9	#0048
       0xA0000000,  //  0046  CLOSE	R0
       0x80040E00,  //  0047  RET	1	R7
-      0x70020014,  //  0048  JMP		#005E
-      0x5426042D,  //  0049  LDINT	R9	1070
+      0x70020009,  //  0048  JMP		#0053
+      0x54260412,  //  0049  LDINT	R9	1043
       0x1C240A09,  //  004A  EQ	R9	R5	R9
-      0x78260007,  //  004B  JMPF	R9	#0054
+      0x78260006,  //  004B  JMPF	R9	#0053
       0x5C241000,  //  004C  MOVE	R9	R8
       0x8828010D,  //  004D  GETMBR	R10	R0	K13
       0x7C240200,  //  004E  CALL	R9	1
@@ -490,27 +479,16 @@ be_local_closure(class_Matter_Plugin_Sensor_Air_Quality_read_attribute,   /* nam
       0x78260001,  //  0050  JMPF	R9	#0053
       0xA0000000,  //  0051  CLOSE	R0
       0x80040E00,  //  0052  RET	1	R7
-      0x70020009,  //  0053  JMP		#005E
-      0x54260412,  //  0054  LDINT	R9	1043
-      0x1C240A09,  //  0055  EQ	R9	R5	R9
-      0x78260006,  //  0056  JMPF	R9	#005E
-      0x5C241000,  //  0057  MOVE	R9	R8
-      0x8828010E,  //  0058  GETMBR	R10	R0	K14
-      0x7C240200,  //  0059  CALL	R9	1
-      0x5C1C1200,  //  005A  MOVE	R7	R9
-      0x78260001,  //  005B  JMPF	R9	#005E
-      0xA0000000,  //  005C  CLOSE	R0
-      0x80040E00,  //  005D  RET	1	R7
-      0x60240003,  //  005E  GETGBL	R9	G3
-      0x5C280000,  //  005F  MOVE	R10	R0
-      0x7C240200,  //  0060  CALL	R9	1
-      0x8C24130F,  //  0061  GETMET	R9	R9	K15
-      0x5C2C0200,  //  0062  MOVE	R11	R1
-      0x5C300400,  //  0063  MOVE	R12	R2
-      0x5C340600,  //  0064  MOVE	R13	R3
-      0x7C240800,  //  0065  CALL	R9	4
-      0xA0000000,  //  0066  CLOSE	R0
-      0x80041200,  //  0067  RET	1	R9
+      0x60240003,  //  0053  GETGBL	R9	G3
+      0x5C280000,  //  0054  MOVE	R10	R0
+      0x7C240200,  //  0055  CALL	R9	1
+      0x8C24130E,  //  0056  GETMET	R9	R9	K14
+      0x5C2C0200,  //  0057  MOVE	R11	R1
+      0x5C300400,  //  0058  MOVE	R12	R2
+      0x5C340600,  //  0059  MOVE	R13	R3
+      0x7C240800,  //  005A  CALL	R9	4
+      0xA0000000,  //  005B  CLOSE	R0
+      0x80041200,  //  005C  RET	1	R9
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Contact.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Contact.h
@@ -20,54 +20,43 @@ be_local_closure(class_Matter_Plugin_Sensor_Contact_read_attribute,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Plugin_Sensor_Contact, 
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(matter),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(attribute),
     /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(shadow_contact),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(BOOL),
-    /* K8   */  be_nested_str_weak(NULL),
-    /* K9   */  be_nested_str_weak(read_attribute),
+    /* K5   */  be_nested_str_weak(set_or_nil),
+    /* K6   */  be_nested_str_weak(BOOL),
+    /* K7   */  be_nested_str_weak(shadow_contact),
+    /* K8   */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
+    ( &(const binstruction[23]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
       0x88180503,  //  0003  GETMBR	R6	R2	K3
       0x541E0044,  //  0004  LDINT	R7	69
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E0010,  //  0006  JMPF	R7	#0018
+      0x781E0006,  //  0006  JMPF	R7	#000E
       0x1C1C0D04,  //  0007  EQ	R7	R6	K4
-      0x781E000E,  //  0008  JMPF	R7	#0018
-      0x881C0105,  //  0009  GETMBR	R7	R0	K5
-      0x4C200000,  //  000A  LDNIL	R8
-      0x201C0E08,  //  000B  NE	R7	R7	R8
-      0x781E0005,  //  000C  JMPF	R7	#0013
-      0x8C1C0706,  //  000D  GETMET	R7	R3	K6
-      0x88240907,  //  000E  GETMBR	R9	R4	K7
-      0x88280105,  //  000F  GETMBR	R10	R0	K5
-      0x7C1C0600,  //  0010  CALL	R7	3
-      0x80040E00,  //  0011  RET	1	R7
-      0x70020004,  //  0012  JMP		#0018
-      0x8C1C0706,  //  0013  GETMET	R7	R3	K6
-      0x88240908,  //  0014  GETMBR	R9	R4	K8
-      0x4C280000,  //  0015  LDNIL	R10
-      0x7C1C0600,  //  0016  CALL	R7	3
-      0x80040E00,  //  0017  RET	1	R7
-      0x601C0003,  //  0018  GETGBL	R7	G3
-      0x5C200000,  //  0019  MOVE	R8	R0
-      0x7C1C0200,  //  001A  CALL	R7	1
-      0x8C1C0F09,  //  001B  GETMET	R7	R7	K9
-      0x5C240200,  //  001C  MOVE	R9	R1
-      0x5C280400,  //  001D  MOVE	R10	R2
-      0x5C2C0600,  //  001E  MOVE	R11	R3
-      0x7C1C0800,  //  001F  CALL	R7	4
-      0x80040E00,  //  0020  RET	1	R7
+      0x781E0004,  //  0008  JMPF	R7	#000E
+      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
+      0x88240906,  //  000A  GETMBR	R9	R4	K6
+      0x88280107,  //  000B  GETMBR	R10	R0	K7
+      0x7C1C0600,  //  000C  CALL	R7	3
+      0x80040E00,  //  000D  RET	1	R7
+      0x601C0003,  //  000E  GETGBL	R7	G3
+      0x5C200000,  //  000F  MOVE	R8	R0
+      0x7C1C0200,  //  0010  CALL	R7	1
+      0x8C1C0F08,  //  0011  GETMET	R7	R7	K8
+      0x5C240200,  //  0012  MOVE	R9	R1
+      0x5C280400,  //  0013  MOVE	R10	R2
+      0x5C2C0600,  //  0014  MOVE	R11	R3
+      0x7C1C0800,  //  0015  CALL	R7	4
+      0x80040E00,  //  0016  RET	1	R7
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Occupancy.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Sensor_Occupancy.h
@@ -26,67 +26,57 @@ be_local_closure(class_Matter_Plugin_Sensor_Occupancy_read_attribute,   /* name 
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(attribute),
     /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(shadow_occupancy),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(U1),
-    /* K8   */  be_nested_str_weak(NULL),
-    /* K9   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(set_or_nil),
+    /* K6   */  be_nested_str_weak(U1),
+    /* K7   */  be_nested_str_weak(shadow_occupancy),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(set),
     /* K10  */  be_const_int(3),
     /* K11  */  be_const_int(2),
     /* K12  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[49]) {  /* code */
+    ( &(const binstruction[39]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
       0x88180503,  //  0003  GETMBR	R6	R2	K3
       0x541E0405,  //  0004  LDINT	R7	1030
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E0020,  //  0006  JMPF	R7	#0028
+      0x781E0016,  //  0006  JMPF	R7	#001E
       0x1C1C0D04,  //  0007  EQ	R7	R6	K4
-      0x781E000F,  //  0008  JMPF	R7	#0019
-      0x881C0105,  //  0009  GETMBR	R7	R0	K5
-      0x4C200000,  //  000A  LDNIL	R8
-      0x201C0E08,  //  000B  NE	R7	R7	R8
-      0x781E0005,  //  000C  JMPF	R7	#0013
-      0x8C1C0706,  //  000D  GETMET	R7	R3	K6
-      0x88240907,  //  000E  GETMBR	R9	R4	K7
-      0x88280105,  //  000F  GETMBR	R10	R0	K5
-      0x7C1C0600,  //  0010  CALL	R7	3
-      0x80040E00,  //  0011  RET	1	R7
-      0x70020004,  //  0012  JMP		#0018
-      0x8C1C0706,  //  0013  GETMET	R7	R3	K6
-      0x88240908,  //  0014  GETMBR	R9	R4	K8
-      0x4C280000,  //  0015  LDNIL	R10
-      0x7C1C0600,  //  0016  CALL	R7	3
-      0x80040E00,  //  0017  RET	1	R7
-      0x7002000E,  //  0018  JMP		#0028
-      0x1C1C0D09,  //  0019  EQ	R7	R6	K9
-      0x781E0005,  //  001A  JMPF	R7	#0021
-      0x8C1C0706,  //  001B  GETMET	R7	R3	K6
-      0x88240907,  //  001C  GETMBR	R9	R4	K7
-      0x5828000A,  //  001D  LDCONST	R10	K10
-      0x7C1C0600,  //  001E  CALL	R7	3
-      0x80040E00,  //  001F  RET	1	R7
-      0x70020006,  //  0020  JMP		#0028
-      0x1C1C0D0B,  //  0021  EQ	R7	R6	K11
-      0x781E0004,  //  0022  JMPF	R7	#0028
-      0x8C1C0706,  //  0023  GETMET	R7	R3	K6
-      0x88240907,  //  0024  GETMBR	R9	R4	K7
-      0x58280004,  //  0025  LDCONST	R10	K4
-      0x7C1C0600,  //  0026  CALL	R7	3
-      0x80040E00,  //  0027  RET	1	R7
-      0x601C0003,  //  0028  GETGBL	R7	G3
-      0x5C200000,  //  0029  MOVE	R8	R0
-      0x7C1C0200,  //  002A  CALL	R7	1
-      0x8C1C0F0C,  //  002B  GETMET	R7	R7	K12
-      0x5C240200,  //  002C  MOVE	R9	R1
-      0x5C280400,  //  002D  MOVE	R10	R2
-      0x5C2C0600,  //  002E  MOVE	R11	R3
-      0x7C1C0800,  //  002F  CALL	R7	4
-      0x80040E00,  //  0030  RET	1	R7
+      0x781E0005,  //  0008  JMPF	R7	#000F
+      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
+      0x88240906,  //  000A  GETMBR	R9	R4	K6
+      0x88280107,  //  000B  GETMBR	R10	R0	K7
+      0x7C1C0600,  //  000C  CALL	R7	3
+      0x80040E00,  //  000D  RET	1	R7
+      0x7002000E,  //  000E  JMP		#001E
+      0x1C1C0D08,  //  000F  EQ	R7	R6	K8
+      0x781E0005,  //  0010  JMPF	R7	#0017
+      0x8C1C0709,  //  0011  GETMET	R7	R3	K9
+      0x88240906,  //  0012  GETMBR	R9	R4	K6
+      0x5828000A,  //  0013  LDCONST	R10	K10
+      0x7C1C0600,  //  0014  CALL	R7	3
+      0x80040E00,  //  0015  RET	1	R7
+      0x70020006,  //  0016  JMP		#001E
+      0x1C1C0D0B,  //  0017  EQ	R7	R6	K11
+      0x781E0004,  //  0018  JMPF	R7	#001E
+      0x8C1C0709,  //  0019  GETMET	R7	R3	K9
+      0x88240906,  //  001A  GETMBR	R9	R4	K6
+      0x58280004,  //  001B  LDCONST	R10	K4
+      0x7C1C0600,  //  001C  CALL	R7	3
+      0x80040E00,  //  001D  RET	1	R7
+      0x601C0003,  //  001E  GETGBL	R7	G3
+      0x5C200000,  //  001F  MOVE	R8	R0
+      0x7C1C0200,  //  0020  CALL	R7	1
+      0x8C1C0F0C,  //  0021  GETMET	R7	R7	K12
+      0x5C240200,  //  0022  MOVE	R9	R1
+      0x5C280400,  //  0023  MOVE	R10	R2
+      0x5C2C0600,  //  0024  MOVE	R11	R3
+      0x7C1C0800,  //  0025  CALL	R7	4
+      0x80040E00,  //  0026  RET	1	R7
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Shutter.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_2_Shutter.h
@@ -90,7 +90,7 @@ be_local_closure(class_Matter_Plugin_Shutter_invoke_request,   /* name */
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[116]) {  /* code */
+    ( &(const binstruction[115]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xB8160200,  //  0001  GETNGBL	R5	K1
       0x88140B02,  //  0002  GETMBR	R5	R5	K2
@@ -98,7 +98,7 @@ be_local_closure(class_Matter_Plugin_Shutter_invoke_request,   /* name */
       0x881C0704,  //  0004  GETMBR	R7	R3	K4
       0x54220101,  //  0005  LDINT	R8	258
       0x1C200C08,  //  0006  EQ	R8	R6	R8
-      0x78220061,  //  0007  JMPF	R8	#006A
+      0x78220060,  //  0007  JMPF	R8	#0069
       0x8C200105,  //  0008  GETMET	R8	R0	K5
       0x7C200200,  //  0009  CALL	R8	1
       0x1C200F06,  //  000A  EQ	R8	R7	K6
@@ -116,7 +116,7 @@ be_local_closure(class_Matter_Plugin_Shutter_invoke_request,   /* name */
       0x7C200200,  //  0016  CALL	R8	1
       0x50200200,  //  0017  LDBOOL	R8	1	0
       0x80041000,  //  0018  RET	1	R8
-      0x7002004E,  //  0019  JMP		#0069
+      0x7002004D,  //  0019  JMP		#0068
       0x1C200F0B,  //  001A  EQ	R8	R7	K11
       0x7822000D,  //  001B  JMPF	R8	#002A
       0xB8220E00,  //  001C  GETNGBL	R8	K7
@@ -132,7 +132,7 @@ be_local_closure(class_Matter_Plugin_Shutter_invoke_request,   /* name */
       0x7C200200,  //  0026  CALL	R8	1
       0x50200200,  //  0027  LDBOOL	R8	1	0
       0x80041000,  //  0028  RET	1	R8
-      0x7002003E,  //  0029  JMP		#0069
+      0x7002003D,  //  0029  JMP		#0068
       0x1C200F0E,  //  002A  EQ	R8	R7	K14
       0x7822000D,  //  002B  JMPF	R8	#003A
       0xB8220E00,  //  002C  GETNGBL	R8	K7
@@ -148,65 +148,64 @@ be_local_closure(class_Matter_Plugin_Shutter_invoke_request,   /* name */
       0x7C200200,  //  0036  CALL	R8	1
       0x50200200,  //  0037  LDBOOL	R8	1	0
       0x80041000,  //  0038  RET	1	R8
-      0x7002002E,  //  0039  JMP		#0069
+      0x7002002D,  //  0039  JMP		#0068
       0x54220004,  //  003A  LDINT	R8	5
       0x1C200E08,  //  003B  EQ	R8	R7	R8
-      0x7822002B,  //  003C  JMPF	R8	#0069
-      0xB8220E00,  //  003D  GETNGBL	R8	K7
-      0x8C201110,  //  003E  GETMET	R8	R8	K16
-      0x60280008,  //  003F  GETGBL	R10	G8
-      0x5C2C0400,  //  0040  MOVE	R11	R2
-      0x7C280200,  //  0041  CALL	R10	1
-      0x002A220A,  //  0042  ADD	R10	K17	R10
-      0x582C000E,  //  0043  LDCONST	R11	K14
-      0x7C200600,  //  0044  CALL	R8	3
-      0x8C200512,  //  0045  GETMET	R8	R2	K18
-      0x58280006,  //  0046  LDCONST	R10	K6
-      0x7C200400,  //  0047  CALL	R8	2
-      0x4C240000,  //  0048  LDNIL	R9
-      0x20241009,  //  0049  NE	R9	R8	R9
-      0x7826001B,  //  004A  JMPF	R9	#0067
-      0x54260063,  //  004B  LDINT	R9	100
-      0x0C201009,  //  004C  DIV	R8	R8	R9
-      0x88240113,  //  004D  GETMBR	R9	R0	K19
-      0x1C241306,  //  004E  EQ	R9	R9	K6
-      0x78260001,  //  004F  JMPF	R9	#0052
-      0x54260063,  //  0050  LDINT	R9	100
-      0x04201208,  //  0051  SUB	R8	R9	R8
-      0xB8260E00,  //  0052  GETNGBL	R9	K7
-      0x8C241308,  //  0053  GETMET	R9	R9	K8
-      0x602C0008,  //  0054  GETGBL	R11	G8
-      0x8830010A,  //  0055  GETMBR	R12	R0	K10
-      0x0030190B,  //  0056  ADD	R12	R12	K11
-      0x7C2C0200,  //  0057  CALL	R11	1
-      0x002E280B,  //  0058  ADD	R11	K20	R11
-      0x002C1715,  //  0059  ADD	R11	R11	K21
-      0x60300008,  //  005A  GETGBL	R12	G8
-      0x5C341000,  //  005B  MOVE	R13	R8
-      0x7C300200,  //  005C  CALL	R12	1
-      0x002C160C,  //  005D  ADD	R11	R11	R12
-      0x50300200,  //  005E  LDBOOL	R12	1	0
-      0x7C240600,  //  005F  CALL	R9	3
-      0x60240008,  //  0060  GETGBL	R9	G8
-      0x5C281000,  //  0061  MOVE	R10	R8
-      0x7C240200,  //  0062  CALL	R9	1
-      0x00262C09,  //  0063  ADD	R9	K22	R9
-      0x900E2009,  //  0064  SETMBR	R3	K16	R9
-      0x8C24010C,  //  0065  GETMET	R9	R0	K12
-      0x7C240200,  //  0066  CALL	R9	1
-      0x50240200,  //  0067  LDBOOL	R9	1	0
-      0x80041200,  //  0068  RET	1	R9
-      0x70020008,  //  0069  JMP		#0073
-      0x60200003,  //  006A  GETGBL	R8	G3
-      0x5C240000,  //  006B  MOVE	R9	R0
-      0x7C200200,  //  006C  CALL	R8	1
-      0x8C201117,  //  006D  GETMET	R8	R8	K23
-      0x5C280200,  //  006E  MOVE	R10	R1
-      0x5C2C0400,  //  006F  MOVE	R11	R2
-      0x5C300600,  //  0070  MOVE	R12	R3
-      0x7C200800,  //  0071  CALL	R8	4
-      0x80041000,  //  0072  RET	1	R8
-      0x80000000,  //  0073  RET	0
+      0x7822002A,  //  003C  JMPF	R8	#0068
+      0xB8222000,  //  003D  GETNGBL	R8	K16
+      0x60240008,  //  003E  GETGBL	R9	G8
+      0x5C280400,  //  003F  MOVE	R10	R2
+      0x7C240200,  //  0040  CALL	R9	1
+      0x00262209,  //  0041  ADD	R9	K17	R9
+      0x5828000E,  //  0042  LDCONST	R10	K14
+      0x7C200400,  //  0043  CALL	R8	2
+      0x8C200512,  //  0044  GETMET	R8	R2	K18
+      0x58280006,  //  0045  LDCONST	R10	K6
+      0x7C200400,  //  0046  CALL	R8	2
+      0x4C240000,  //  0047  LDNIL	R9
+      0x20241009,  //  0048  NE	R9	R8	R9
+      0x7826001B,  //  0049  JMPF	R9	#0066
+      0x54260063,  //  004A  LDINT	R9	100
+      0x0C201009,  //  004B  DIV	R8	R8	R9
+      0x88240113,  //  004C  GETMBR	R9	R0	K19
+      0x1C241306,  //  004D  EQ	R9	R9	K6
+      0x78260001,  //  004E  JMPF	R9	#0051
+      0x54260063,  //  004F  LDINT	R9	100
+      0x04201208,  //  0050  SUB	R8	R9	R8
+      0xB8260E00,  //  0051  GETNGBL	R9	K7
+      0x8C241308,  //  0052  GETMET	R9	R9	K8
+      0x602C0008,  //  0053  GETGBL	R11	G8
+      0x8830010A,  //  0054  GETMBR	R12	R0	K10
+      0x0030190B,  //  0055  ADD	R12	R12	K11
+      0x7C2C0200,  //  0056  CALL	R11	1
+      0x002E280B,  //  0057  ADD	R11	K20	R11
+      0x002C1715,  //  0058  ADD	R11	R11	K21
+      0x60300008,  //  0059  GETGBL	R12	G8
+      0x5C341000,  //  005A  MOVE	R13	R8
+      0x7C300200,  //  005B  CALL	R12	1
+      0x002C160C,  //  005C  ADD	R11	R11	R12
+      0x50300200,  //  005D  LDBOOL	R12	1	0
+      0x7C240600,  //  005E  CALL	R9	3
+      0x60240008,  //  005F  GETGBL	R9	G8
+      0x5C281000,  //  0060  MOVE	R10	R8
+      0x7C240200,  //  0061  CALL	R9	1
+      0x00262C09,  //  0062  ADD	R9	K22	R9
+      0x900E2009,  //  0063  SETMBR	R3	K16	R9
+      0x8C24010C,  //  0064  GETMET	R9	R0	K12
+      0x7C240200,  //  0065  CALL	R9	1
+      0x50240200,  //  0066  LDBOOL	R9	1	0
+      0x80041200,  //  0067  RET	1	R9
+      0x70020008,  //  0068  JMP		#0072
+      0x60200003,  //  0069  GETGBL	R8	G3
+      0x5C240000,  //  006A  MOVE	R9	R0
+      0x7C200200,  //  006B  CALL	R8	1
+      0x8C201117,  //  006C  GETMET	R8	R8	K23
+      0x5C280200,  //  006D  MOVE	R10	R1
+      0x5C2C0400,  //  006E  MOVE	R11	R2
+      0x5C300600,  //  006F  MOVE	R12	R3
+      0x7C200800,  //  0070  CALL	R8	4
+      0x80041000,  //  0071  RET	1	R8
+      0x80000000,  //  0072  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Flow.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Flow.h
@@ -58,68 +58,58 @@ be_local_closure(class_Matter_Plugin_Sensor_Flow_read_attribute,   /* name */
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(attribute),
     /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(shadow_value),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(U2),
-    /* K8   */  be_nested_str_weak(NULL),
-    /* K9   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(set_or_nil),
+    /* K6   */  be_nested_str_weak(U2),
+    /* K7   */  be_nested_str_weak(shadow_value),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(set),
     /* K10  */  be_const_int(2),
     /* K11  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[51]) {  /* code */
+    ( &(const binstruction[41]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
       0x88180503,  //  0003  GETMBR	R6	R2	K3
       0x541E0403,  //  0004  LDINT	R7	1028
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E0022,  //  0006  JMPF	R7	#002A
+      0x781E0018,  //  0006  JMPF	R7	#0020
       0x1C1C0D04,  //  0007  EQ	R7	R6	K4
-      0x781E0011,  //  0008  JMPF	R7	#001B
-      0x881C0105,  //  0009  GETMBR	R7	R0	K5
-      0x4C200000,  //  000A  LDNIL	R8
-      0x201C0E08,  //  000B  NE	R7	R7	R8
-      0x781E0007,  //  000C  JMPF	R7	#0015
-      0x8C1C0706,  //  000D  GETMET	R7	R3	K6
-      0x88240907,  //  000E  GETMBR	R9	R4	K7
-      0x60280009,  //  000F  GETGBL	R10	G9
-      0x882C0105,  //  0010  GETMBR	R11	R0	K5
-      0x7C280200,  //  0011  CALL	R10	1
-      0x7C1C0600,  //  0012  CALL	R7	3
-      0x80040E00,  //  0013  RET	1	R7
-      0x70020004,  //  0014  JMP		#001A
-      0x8C1C0706,  //  0015  GETMET	R7	R3	K6
-      0x88240908,  //  0016  GETMBR	R9	R4	K8
-      0x4C280000,  //  0017  LDNIL	R10
-      0x7C1C0600,  //  0018  CALL	R7	3
-      0x80040E00,  //  0019  RET	1	R7
-      0x7002000E,  //  001A  JMP		#002A
-      0x1C1C0D09,  //  001B  EQ	R7	R6	K9
-      0x781E0005,  //  001C  JMPF	R7	#0023
-      0x8C1C0706,  //  001D  GETMET	R7	R3	K6
-      0x88240907,  //  001E  GETMBR	R9	R4	K7
-      0x58280004,  //  001F  LDCONST	R10	K4
-      0x7C1C0600,  //  0020  CALL	R7	3
-      0x80040E00,  //  0021  RET	1	R7
-      0x70020006,  //  0022  JMP		#002A
-      0x1C1C0D0A,  //  0023  EQ	R7	R6	K10
-      0x781E0004,  //  0024  JMPF	R7	#002A
-      0x8C1C0706,  //  0025  GETMET	R7	R3	K6
-      0x88240907,  //  0026  GETMBR	R9	R4	K7
-      0x542AFFFD,  //  0027  LDINT	R10	65534
-      0x7C1C0600,  //  0028  CALL	R7	3
-      0x80040E00,  //  0029  RET	1	R7
-      0x601C0003,  //  002A  GETGBL	R7	G3
-      0x5C200000,  //  002B  MOVE	R8	R0
-      0x7C1C0200,  //  002C  CALL	R7	1
-      0x8C1C0F0B,  //  002D  GETMET	R7	R7	K11
-      0x5C240200,  //  002E  MOVE	R9	R1
-      0x5C280400,  //  002F  MOVE	R10	R2
-      0x5C2C0600,  //  0030  MOVE	R11	R3
-      0x7C1C0800,  //  0031  CALL	R7	4
-      0x80040E00,  //  0032  RET	1	R7
+      0x781E0007,  //  0008  JMPF	R7	#0011
+      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
+      0x88240906,  //  000A  GETMBR	R9	R4	K6
+      0x60280009,  //  000B  GETGBL	R10	G9
+      0x882C0107,  //  000C  GETMBR	R11	R0	K7
+      0x7C280200,  //  000D  CALL	R10	1
+      0x7C1C0600,  //  000E  CALL	R7	3
+      0x80040E00,  //  000F  RET	1	R7
+      0x7002000E,  //  0010  JMP		#0020
+      0x1C1C0D08,  //  0011  EQ	R7	R6	K8
+      0x781E0005,  //  0012  JMPF	R7	#0019
+      0x8C1C0709,  //  0013  GETMET	R7	R3	K9
+      0x88240906,  //  0014  GETMBR	R9	R4	K6
+      0x58280004,  //  0015  LDCONST	R10	K4
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x80040E00,  //  0017  RET	1	R7
+      0x70020006,  //  0018  JMP		#0020
+      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
+      0x781E0004,  //  001A  JMPF	R7	#0020
+      0x8C1C0709,  //  001B  GETMET	R7	R3	K9
+      0x88240906,  //  001C  GETMBR	R9	R4	K6
+      0x542AFFFD,  //  001D  LDINT	R10	65534
+      0x7C1C0600,  //  001E  CALL	R7	3
+      0x80040E00,  //  001F  RET	1	R7
+      0x601C0003,  //  0020  GETGBL	R7	G3
+      0x5C200000,  //  0021  MOVE	R8	R0
+      0x7C1C0200,  //  0022  CALL	R7	1
+      0x8C1C0F0B,  //  0023  GETMET	R7	R7	K11
+      0x5C240200,  //  0024  MOVE	R9	R1
+      0x5C280400,  //  0025  MOVE	R10	R2
+      0x5C2C0600,  //  0026  MOVE	R11	R3
+      0x7C1C0800,  //  0027  CALL	R7	4
+      0x80040E00,  //  0028  RET	1	R7
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Humidity.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Humidity.h
@@ -58,68 +58,58 @@ be_local_closure(class_Matter_Plugin_Sensor_Humidity_read_attribute,   /* name *
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(attribute),
     /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(shadow_value),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(U2),
-    /* K8   */  be_nested_str_weak(NULL),
-    /* K9   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(set_or_nil),
+    /* K6   */  be_nested_str_weak(U2),
+    /* K7   */  be_nested_str_weak(shadow_value),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(set),
     /* K10  */  be_const_int(2),
     /* K11  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[51]) {  /* code */
+    ( &(const binstruction[41]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
       0x88180503,  //  0003  GETMBR	R6	R2	K3
       0x541E0404,  //  0004  LDINT	R7	1029
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E0022,  //  0006  JMPF	R7	#002A
+      0x781E0018,  //  0006  JMPF	R7	#0020
       0x1C1C0D04,  //  0007  EQ	R7	R6	K4
-      0x781E0011,  //  0008  JMPF	R7	#001B
-      0x881C0105,  //  0009  GETMBR	R7	R0	K5
-      0x4C200000,  //  000A  LDNIL	R8
-      0x201C0E08,  //  000B  NE	R7	R7	R8
-      0x781E0007,  //  000C  JMPF	R7	#0015
-      0x8C1C0706,  //  000D  GETMET	R7	R3	K6
-      0x88240907,  //  000E  GETMBR	R9	R4	K7
-      0x60280009,  //  000F  GETGBL	R10	G9
-      0x882C0105,  //  0010  GETMBR	R11	R0	K5
-      0x7C280200,  //  0011  CALL	R10	1
-      0x7C1C0600,  //  0012  CALL	R7	3
-      0x80040E00,  //  0013  RET	1	R7
-      0x70020004,  //  0014  JMP		#001A
-      0x8C1C0706,  //  0015  GETMET	R7	R3	K6
-      0x88240908,  //  0016  GETMBR	R9	R4	K8
-      0x4C280000,  //  0017  LDNIL	R10
-      0x7C1C0600,  //  0018  CALL	R7	3
-      0x80040E00,  //  0019  RET	1	R7
-      0x7002000E,  //  001A  JMP		#002A
-      0x1C1C0D09,  //  001B  EQ	R7	R6	K9
-      0x781E0005,  //  001C  JMPF	R7	#0023
-      0x8C1C0706,  //  001D  GETMET	R7	R3	K6
-      0x88240907,  //  001E  GETMBR	R9	R4	K7
-      0x542A01F3,  //  001F  LDINT	R10	500
-      0x7C1C0600,  //  0020  CALL	R7	3
-      0x80040E00,  //  0021  RET	1	R7
-      0x70020006,  //  0022  JMP		#002A
-      0x1C1C0D0A,  //  0023  EQ	R7	R6	K10
-      0x781E0004,  //  0024  JMPF	R7	#002A
-      0x8C1C0706,  //  0025  GETMET	R7	R3	K6
-      0x88240907,  //  0026  GETMBR	R9	R4	K7
-      0x542A270F,  //  0027  LDINT	R10	10000
-      0x7C1C0600,  //  0028  CALL	R7	3
-      0x80040E00,  //  0029  RET	1	R7
-      0x601C0003,  //  002A  GETGBL	R7	G3
-      0x5C200000,  //  002B  MOVE	R8	R0
-      0x7C1C0200,  //  002C  CALL	R7	1
-      0x8C1C0F0B,  //  002D  GETMET	R7	R7	K11
-      0x5C240200,  //  002E  MOVE	R9	R1
-      0x5C280400,  //  002F  MOVE	R10	R2
-      0x5C2C0600,  //  0030  MOVE	R11	R3
-      0x7C1C0800,  //  0031  CALL	R7	4
-      0x80040E00,  //  0032  RET	1	R7
+      0x781E0007,  //  0008  JMPF	R7	#0011
+      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
+      0x88240906,  //  000A  GETMBR	R9	R4	K6
+      0x60280009,  //  000B  GETGBL	R10	G9
+      0x882C0107,  //  000C  GETMBR	R11	R0	K7
+      0x7C280200,  //  000D  CALL	R10	1
+      0x7C1C0600,  //  000E  CALL	R7	3
+      0x80040E00,  //  000F  RET	1	R7
+      0x7002000E,  //  0010  JMP		#0020
+      0x1C1C0D08,  //  0011  EQ	R7	R6	K8
+      0x781E0005,  //  0012  JMPF	R7	#0019
+      0x8C1C0709,  //  0013  GETMET	R7	R3	K9
+      0x88240906,  //  0014  GETMBR	R9	R4	K6
+      0x542A01F3,  //  0015  LDINT	R10	500
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x80040E00,  //  0017  RET	1	R7
+      0x70020006,  //  0018  JMP		#0020
+      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
+      0x781E0004,  //  001A  JMPF	R7	#0020
+      0x8C1C0709,  //  001B  GETMET	R7	R3	K9
+      0x88240906,  //  001C  GETMBR	R9	R4	K6
+      0x542A270F,  //  001D  LDINT	R10	10000
+      0x7C1C0600,  //  001E  CALL	R7	3
+      0x80040E00,  //  001F  RET	1	R7
+      0x601C0003,  //  0020  GETGBL	R7	G3
+      0x5C200000,  //  0021  MOVE	R8	R0
+      0x7C1C0200,  //  0022  CALL	R7	1
+      0x8C1C0F0B,  //  0023  GETMET	R7	R7	K11
+      0x5C240200,  //  0024  MOVE	R9	R1
+      0x5C280400,  //  0025  MOVE	R10	R2
+      0x5C2C0600,  //  0026  MOVE	R11	R3
+      0x7C1C0800,  //  0027  CALL	R7	4
+      0x80040E00,  //  0028  RET	1	R7
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Illuminance.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Illuminance.h
@@ -58,68 +58,58 @@ be_local_closure(class_Matter_Plugin_Sensor_Illuminance_read_attribute,   /* nam
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(attribute),
     /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(shadow_value),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(U2),
-    /* K8   */  be_nested_str_weak(NULL),
-    /* K9   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(set_or_nil),
+    /* K6   */  be_nested_str_weak(U2),
+    /* K7   */  be_nested_str_weak(shadow_value),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(set),
     /* K10  */  be_const_int(2),
     /* K11  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[51]) {  /* code */
+    ( &(const binstruction[41]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
       0x88180503,  //  0003  GETMBR	R6	R2	K3
       0x541E03FF,  //  0004  LDINT	R7	1024
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E0022,  //  0006  JMPF	R7	#002A
+      0x781E0018,  //  0006  JMPF	R7	#0020
       0x1C1C0D04,  //  0007  EQ	R7	R6	K4
-      0x781E0011,  //  0008  JMPF	R7	#001B
-      0x881C0105,  //  0009  GETMBR	R7	R0	K5
-      0x4C200000,  //  000A  LDNIL	R8
-      0x201C0E08,  //  000B  NE	R7	R7	R8
-      0x781E0007,  //  000C  JMPF	R7	#0015
-      0x8C1C0706,  //  000D  GETMET	R7	R3	K6
-      0x88240907,  //  000E  GETMBR	R9	R4	K7
-      0x60280009,  //  000F  GETGBL	R10	G9
-      0x882C0105,  //  0010  GETMBR	R11	R0	K5
-      0x7C280200,  //  0011  CALL	R10	1
-      0x7C1C0600,  //  0012  CALL	R7	3
-      0x80040E00,  //  0013  RET	1	R7
-      0x70020004,  //  0014  JMP		#001A
-      0x8C1C0706,  //  0015  GETMET	R7	R3	K6
-      0x88240908,  //  0016  GETMBR	R9	R4	K8
-      0x4C280000,  //  0017  LDNIL	R10
-      0x7C1C0600,  //  0018  CALL	R7	3
-      0x80040E00,  //  0019  RET	1	R7
-      0x7002000E,  //  001A  JMP		#002A
-      0x1C1C0D09,  //  001B  EQ	R7	R6	K9
-      0x781E0005,  //  001C  JMPF	R7	#0023
-      0x8C1C0706,  //  001D  GETMET	R7	R3	K6
-      0x88240907,  //  001E  GETMBR	R9	R4	K7
-      0x58280009,  //  001F  LDCONST	R10	K9
-      0x7C1C0600,  //  0020  CALL	R7	3
-      0x80040E00,  //  0021  RET	1	R7
-      0x70020006,  //  0022  JMP		#002A
-      0x1C1C0D0A,  //  0023  EQ	R7	R6	K10
-      0x781E0004,  //  0024  JMPF	R7	#002A
-      0x8C1C0706,  //  0025  GETMET	R7	R3	K6
-      0x88240907,  //  0026  GETMBR	R9	R4	K7
-      0x542AFFFD,  //  0027  LDINT	R10	65534
-      0x7C1C0600,  //  0028  CALL	R7	3
-      0x80040E00,  //  0029  RET	1	R7
-      0x601C0003,  //  002A  GETGBL	R7	G3
-      0x5C200000,  //  002B  MOVE	R8	R0
-      0x7C1C0200,  //  002C  CALL	R7	1
-      0x8C1C0F0B,  //  002D  GETMET	R7	R7	K11
-      0x5C240200,  //  002E  MOVE	R9	R1
-      0x5C280400,  //  002F  MOVE	R10	R2
-      0x5C2C0600,  //  0030  MOVE	R11	R3
-      0x7C1C0800,  //  0031  CALL	R7	4
-      0x80040E00,  //  0032  RET	1	R7
+      0x781E0007,  //  0008  JMPF	R7	#0011
+      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
+      0x88240906,  //  000A  GETMBR	R9	R4	K6
+      0x60280009,  //  000B  GETGBL	R10	G9
+      0x882C0107,  //  000C  GETMBR	R11	R0	K7
+      0x7C280200,  //  000D  CALL	R10	1
+      0x7C1C0600,  //  000E  CALL	R7	3
+      0x80040E00,  //  000F  RET	1	R7
+      0x7002000E,  //  0010  JMP		#0020
+      0x1C1C0D08,  //  0011  EQ	R7	R6	K8
+      0x781E0005,  //  0012  JMPF	R7	#0019
+      0x8C1C0709,  //  0013  GETMET	R7	R3	K9
+      0x88240906,  //  0014  GETMBR	R9	R4	K6
+      0x58280008,  //  0015  LDCONST	R10	K8
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x80040E00,  //  0017  RET	1	R7
+      0x70020006,  //  0018  JMP		#0020
+      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
+      0x781E0004,  //  001A  JMPF	R7	#0020
+      0x8C1C0709,  //  001B  GETMET	R7	R3	K9
+      0x88240906,  //  001C  GETMBR	R9	R4	K6
+      0x542AFFFD,  //  001D  LDINT	R10	65534
+      0x7C1C0600,  //  001E  CALL	R7	3
+      0x80040E00,  //  001F  RET	1	R7
+      0x601C0003,  //  0020  GETGBL	R7	G3
+      0x5C200000,  //  0021  MOVE	R8	R0
+      0x7C1C0200,  //  0022  CALL	R7	1
+      0x8C1C0F0B,  //  0023  GETMET	R7	R7	K11
+      0x5C240200,  //  0024  MOVE	R9	R1
+      0x5C280400,  //  0025  MOVE	R10	R2
+      0x5C2C0600,  //  0026  MOVE	R11	R3
+      0x7C1C0800,  //  0027  CALL	R7	4
+      0x80040E00,  //  0028  RET	1	R7
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Pressure.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Pressure.h
@@ -58,68 +58,58 @@ be_local_closure(class_Matter_Plugin_Sensor_Pressure_read_attribute,   /* name *
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(attribute),
     /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(shadow_value),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(I2),
-    /* K8   */  be_nested_str_weak(NULL),
-    /* K9   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(set_or_nil),
+    /* K6   */  be_nested_str_weak(I2),
+    /* K7   */  be_nested_str_weak(shadow_value),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(set),
     /* K10  */  be_const_int(2),
     /* K11  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[51]) {  /* code */
+    ( &(const binstruction[41]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
       0x88180503,  //  0003  GETMBR	R6	R2	K3
       0x541E0402,  //  0004  LDINT	R7	1027
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E0022,  //  0006  JMPF	R7	#002A
+      0x781E0018,  //  0006  JMPF	R7	#0020
       0x1C1C0D04,  //  0007  EQ	R7	R6	K4
-      0x781E0011,  //  0008  JMPF	R7	#001B
-      0x881C0105,  //  0009  GETMBR	R7	R0	K5
-      0x4C200000,  //  000A  LDNIL	R8
-      0x201C0E08,  //  000B  NE	R7	R7	R8
-      0x781E0007,  //  000C  JMPF	R7	#0015
-      0x8C1C0706,  //  000D  GETMET	R7	R3	K6
-      0x88240907,  //  000E  GETMBR	R9	R4	K7
-      0x60280009,  //  000F  GETGBL	R10	G9
-      0x882C0105,  //  0010  GETMBR	R11	R0	K5
-      0x7C280200,  //  0011  CALL	R10	1
-      0x7C1C0600,  //  0012  CALL	R7	3
-      0x80040E00,  //  0013  RET	1	R7
-      0x70020004,  //  0014  JMP		#001A
-      0x8C1C0706,  //  0015  GETMET	R7	R3	K6
-      0x88240908,  //  0016  GETMBR	R9	R4	K8
-      0x4C280000,  //  0017  LDNIL	R10
-      0x7C1C0600,  //  0018  CALL	R7	3
-      0x80040E00,  //  0019  RET	1	R7
-      0x7002000E,  //  001A  JMP		#002A
-      0x1C1C0D09,  //  001B  EQ	R7	R6	K9
-      0x781E0005,  //  001C  JMPF	R7	#0023
-      0x8C1C0706,  //  001D  GETMET	R7	R3	K6
-      0x88240907,  //  001E  GETMBR	R9	R4	K7
-      0x542A01F3,  //  001F  LDINT	R10	500
-      0x7C1C0600,  //  0020  CALL	R7	3
-      0x80040E00,  //  0021  RET	1	R7
-      0x70020006,  //  0022  JMP		#002A
-      0x1C1C0D0A,  //  0023  EQ	R7	R6	K10
-      0x781E0004,  //  0024  JMPF	R7	#002A
-      0x8C1C0706,  //  0025  GETMET	R7	R3	K6
-      0x88240907,  //  0026  GETMBR	R9	R4	K7
-      0x542A05DB,  //  0027  LDINT	R10	1500
-      0x7C1C0600,  //  0028  CALL	R7	3
-      0x80040E00,  //  0029  RET	1	R7
-      0x601C0003,  //  002A  GETGBL	R7	G3
-      0x5C200000,  //  002B  MOVE	R8	R0
-      0x7C1C0200,  //  002C  CALL	R7	1
-      0x8C1C0F0B,  //  002D  GETMET	R7	R7	K11
-      0x5C240200,  //  002E  MOVE	R9	R1
-      0x5C280400,  //  002F  MOVE	R10	R2
-      0x5C2C0600,  //  0030  MOVE	R11	R3
-      0x7C1C0800,  //  0031  CALL	R7	4
-      0x80040E00,  //  0032  RET	1	R7
+      0x781E0007,  //  0008  JMPF	R7	#0011
+      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
+      0x88240906,  //  000A  GETMBR	R9	R4	K6
+      0x60280009,  //  000B  GETGBL	R10	G9
+      0x882C0107,  //  000C  GETMBR	R11	R0	K7
+      0x7C280200,  //  000D  CALL	R10	1
+      0x7C1C0600,  //  000E  CALL	R7	3
+      0x80040E00,  //  000F  RET	1	R7
+      0x7002000E,  //  0010  JMP		#0020
+      0x1C1C0D08,  //  0011  EQ	R7	R6	K8
+      0x781E0005,  //  0012  JMPF	R7	#0019
+      0x8C1C0709,  //  0013  GETMET	R7	R3	K9
+      0x88240906,  //  0014  GETMBR	R9	R4	K6
+      0x542A01F3,  //  0015  LDINT	R10	500
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x80040E00,  //  0017  RET	1	R7
+      0x70020006,  //  0018  JMP		#0020
+      0x1C1C0D0A,  //  0019  EQ	R7	R6	K10
+      0x781E0004,  //  001A  JMPF	R7	#0020
+      0x8C1C0709,  //  001B  GETMET	R7	R3	K9
+      0x88240906,  //  001C  GETMBR	R9	R4	K6
+      0x542A05DB,  //  001D  LDINT	R10	1500
+      0x7C1C0600,  //  001E  CALL	R7	3
+      0x80040E00,  //  001F  RET	1	R7
+      0x601C0003,  //  0020  GETGBL	R7	G3
+      0x5C200000,  //  0021  MOVE	R8	R0
+      0x7C1C0200,  //  0022  CALL	R7	1
+      0x8C1C0F0B,  //  0023  GETMET	R7	R7	K11
+      0x5C240200,  //  0024  MOVE	R9	R1
+      0x5C280400,  //  0025  MOVE	R10	R2
+      0x5C2C0600,  //  0026  MOVE	R11	R3
+      0x7C1C0800,  //  0027  CALL	R7	4
+      0x80040E00,  //  0028  RET	1	R7
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Temp.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_3_Sensor_Temp.h
@@ -58,66 +58,56 @@ be_local_closure(class_Matter_Plugin_Sensor_Temp_read_attribute,   /* name */
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(attribute),
     /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(shadow_value),
-    /* K6   */  be_nested_str_weak(set),
-    /* K7   */  be_nested_str_weak(I2),
-    /* K8   */  be_nested_str_weak(NULL),
-    /* K9   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(set_or_nil),
+    /* K6   */  be_nested_str_weak(I2),
+    /* K7   */  be_nested_str_weak(shadow_value),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(set),
     /* K10  */  be_const_int(2),
     /* K11  */  be_nested_str_weak(read_attribute),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[49]) {  /* code */
+    ( &(const binstruction[39]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140502,  //  0002  GETMBR	R5	R2	K2
       0x88180503,  //  0003  GETMBR	R6	R2	K3
       0x541E0401,  //  0004  LDINT	R7	1026
       0x1C1C0A07,  //  0005  EQ	R7	R5	R7
-      0x781E0020,  //  0006  JMPF	R7	#0028
+      0x781E0016,  //  0006  JMPF	R7	#001E
       0x1C1C0D04,  //  0007  EQ	R7	R6	K4
-      0x781E000F,  //  0008  JMPF	R7	#0019
-      0x881C0105,  //  0009  GETMBR	R7	R0	K5
-      0x4C200000,  //  000A  LDNIL	R8
-      0x201C0E08,  //  000B  NE	R7	R7	R8
-      0x781E0005,  //  000C  JMPF	R7	#0013
-      0x8C1C0706,  //  000D  GETMET	R7	R3	K6
-      0x88240907,  //  000E  GETMBR	R9	R4	K7
-      0x88280105,  //  000F  GETMBR	R10	R0	K5
-      0x7C1C0600,  //  0010  CALL	R7	3
-      0x80040E00,  //  0011  RET	1	R7
-      0x70020004,  //  0012  JMP		#0018
-      0x8C1C0706,  //  0013  GETMET	R7	R3	K6
-      0x88240908,  //  0014  GETMBR	R9	R4	K8
-      0x4C280000,  //  0015  LDNIL	R10
-      0x7C1C0600,  //  0016  CALL	R7	3
-      0x80040E00,  //  0017  RET	1	R7
-      0x7002000E,  //  0018  JMP		#0028
-      0x1C1C0D09,  //  0019  EQ	R7	R6	K9
-      0x781E0005,  //  001A  JMPF	R7	#0021
-      0x8C1C0706,  //  001B  GETMET	R7	R3	K6
-      0x88240907,  //  001C  GETMBR	R9	R4	K7
-      0x5429EC77,  //  001D  LDINT	R10	-5000
-      0x7C1C0600,  //  001E  CALL	R7	3
-      0x80040E00,  //  001F  RET	1	R7
-      0x70020006,  //  0020  JMP		#0028
-      0x1C1C0D0A,  //  0021  EQ	R7	R6	K10
-      0x781E0004,  //  0022  JMPF	R7	#0028
-      0x8C1C0706,  //  0023  GETMET	R7	R3	K6
-      0x88240907,  //  0024  GETMBR	R9	R4	K7
-      0x542A3A97,  //  0025  LDINT	R10	15000
-      0x7C1C0600,  //  0026  CALL	R7	3
-      0x80040E00,  //  0027  RET	1	R7
-      0x601C0003,  //  0028  GETGBL	R7	G3
-      0x5C200000,  //  0029  MOVE	R8	R0
-      0x7C1C0200,  //  002A  CALL	R7	1
-      0x8C1C0F0B,  //  002B  GETMET	R7	R7	K11
-      0x5C240200,  //  002C  MOVE	R9	R1
-      0x5C280400,  //  002D  MOVE	R10	R2
-      0x5C2C0600,  //  002E  MOVE	R11	R3
-      0x7C1C0800,  //  002F  CALL	R7	4
-      0x80040E00,  //  0030  RET	1	R7
+      0x781E0005,  //  0008  JMPF	R7	#000F
+      0x8C1C0705,  //  0009  GETMET	R7	R3	K5
+      0x88240906,  //  000A  GETMBR	R9	R4	K6
+      0x88280107,  //  000B  GETMBR	R10	R0	K7
+      0x7C1C0600,  //  000C  CALL	R7	3
+      0x80040E00,  //  000D  RET	1	R7
+      0x7002000E,  //  000E  JMP		#001E
+      0x1C1C0D08,  //  000F  EQ	R7	R6	K8
+      0x781E0005,  //  0010  JMPF	R7	#0017
+      0x8C1C0709,  //  0011  GETMET	R7	R3	K9
+      0x88240906,  //  0012  GETMBR	R9	R4	K6
+      0x5429EC77,  //  0013  LDINT	R10	-5000
+      0x7C1C0600,  //  0014  CALL	R7	3
+      0x80040E00,  //  0015  RET	1	R7
+      0x70020006,  //  0016  JMP		#001E
+      0x1C1C0D0A,  //  0017  EQ	R7	R6	K10
+      0x781E0004,  //  0018  JMPF	R7	#001E
+      0x8C1C0709,  //  0019  GETMET	R7	R3	K9
+      0x88240906,  //  001A  GETMBR	R9	R4	K6
+      0x542A3A97,  //  001B  LDINT	R10	15000
+      0x7C1C0600,  //  001C  CALL	R7	3
+      0x80040E00,  //  001D  RET	1	R7
+      0x601C0003,  //  001E  GETGBL	R7	G3
+      0x5C200000,  //  001F  MOVE	R8	R0
+      0x7C1C0200,  //  0020  CALL	R7	1
+      0x8C1C0F0B,  //  0021  GETMET	R7	R7	K11
+      0x5C240200,  //  0022  MOVE	R9	R1
+      0x5C280400,  //  0023  MOVE	R10	R2
+      0x5C2C0600,  //  0024  MOVE	R11	R3
+      0x7C1C0800,  //  0025  CALL	R7	4
+      0x80040E00,  //  0026  RET	1	R7
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Profiler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Profiler.h
@@ -231,7 +231,7 @@ be_local_closure(class_Matter_Profiler_log,   /* name */
 extern const bclass be_class_Matter_Profiler;
 be_local_closure(class_Matter_Profiler_dump,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
+    12,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -239,63 +239,60 @@ be_local_closure(class_Matter_Profiler_dump,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Profiler, 
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
+    ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(active),
     /* K1   */  be_nested_str_weak(log),
     /* K2   */  be_nested_str_weak(_X3C_X2D_X2Dend_X2D_X2D_X3E),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20Profiler_X20dump_X3A),
-    /* K5   */  be_nested_str_weak(millis),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(allocs),
-    /* K8   */  be_nested_str_weak(reallocs),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(len),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X254i_X20_X5B_X254i_X5D_X27_X25s_X27),
-    /* K12  */  be_nested_str_weak(names),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20Profiler_X20dump_X3A),
+    /* K4   */  be_nested_str_weak(millis),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(allocs),
+    /* K7   */  be_nested_str_weak(reallocs),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str_weak(len),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X20_X20_X254i_X20_X5B_X254i_X5D_X27_X25s_X27),
+    /* K11  */  be_nested_str_weak(names),
     }),
     be_str_weak(dump),
     &be_const_str_solidified,
-    ( &(const binstruction[39]) {  /* code */
+    ( &(const binstruction[37]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x740A0000,  //  0001  JMPT	R2	#0003
       0x80000400,  //  0002  RET	0
       0x8C080101,  //  0003  GETMET	R2	R0	K1
       0x58100002,  //  0004  LDCONST	R4	K2
       0x7C080400,  //  0005  CALL	R2	2
-      0xB80A0600,  //  0006  GETNGBL	R2	K3
-      0x8C080501,  //  0007  GETMET	R2	R2	K1
-      0x58100004,  //  0008  LDCONST	R4	K4
-      0x5C140200,  //  0009  MOVE	R5	R1
-      0x7C080600,  //  000A  CALL	R2	3
-      0x88080105,  //  000B  GETMBR	R2	R0	K5
-      0x94080506,  //  000C  GETIDX	R2	R2	K6
-      0x880C0107,  //  000D  GETMBR	R3	R0	K7
-      0x940C0706,  //  000E  GETIDX	R3	R3	K6
-      0x88100108,  //  000F  GETMBR	R4	R0	K8
-      0x94100906,  //  0010  GETIDX	R4	R4	K6
-      0x58140009,  //  0011  LDCONST	R5	K9
-      0x8818010A,  //  0012  GETMBR	R6	R0	K10
-      0x14180A06,  //  0013  LT	R6	R5	R6
-      0x781A0010,  //  0014  JMPF	R6	#0026
-      0xB81A0600,  //  0015  GETNGBL	R6	K3
-      0x8C180D01,  //  0016  GETMET	R6	R6	K1
-      0x60200018,  //  0017  GETGBL	R8	G24
-      0x5824000B,  //  0018  LDCONST	R9	K11
-      0x88280105,  //  0019  GETMBR	R10	R0	K5
-      0x94281405,  //  001A  GETIDX	R10	R10	R5
-      0x04281402,  //  001B  SUB	R10	R10	R2
-      0x882C0107,  //  001C  GETMBR	R11	R0	K7
-      0x942C1605,  //  001D  GETIDX	R11	R11	R5
-      0x042C1603,  //  001E  SUB	R11	R11	R3
-      0x8830010C,  //  001F  GETMBR	R12	R0	K12
-      0x94301805,  //  0020  GETIDX	R12	R12	R5
-      0x7C200800,  //  0021  CALL	R8	4
-      0x5C240200,  //  0022  MOVE	R9	R1
-      0x7C180600,  //  0023  CALL	R6	3
-      0x00140B09,  //  0024  ADD	R5	R5	K9
-      0x7001FFEB,  //  0025  JMP		#0012
-      0x80000000,  //  0026  RET	0
+      0xB80A0200,  //  0006  GETNGBL	R2	K1
+      0x580C0003,  //  0007  LDCONST	R3	K3
+      0x5C100200,  //  0008  MOVE	R4	R1
+      0x7C080400,  //  0009  CALL	R2	2
+      0x88080104,  //  000A  GETMBR	R2	R0	K4
+      0x94080505,  //  000B  GETIDX	R2	R2	K5
+      0x880C0106,  //  000C  GETMBR	R3	R0	K6
+      0x940C0705,  //  000D  GETIDX	R3	R3	K5
+      0x88100107,  //  000E  GETMBR	R4	R0	K7
+      0x94100905,  //  000F  GETIDX	R4	R4	K5
+      0x58140008,  //  0010  LDCONST	R5	K8
+      0x88180109,  //  0011  GETMBR	R6	R0	K9
+      0x14180A06,  //  0012  LT	R6	R5	R6
+      0x781A000F,  //  0013  JMPF	R6	#0024
+      0xB81A0200,  //  0014  GETNGBL	R6	K1
+      0x601C0018,  //  0015  GETGBL	R7	G24
+      0x5820000A,  //  0016  LDCONST	R8	K10
+      0x88240104,  //  0017  GETMBR	R9	R0	K4
+      0x94241205,  //  0018  GETIDX	R9	R9	R5
+      0x04241202,  //  0019  SUB	R9	R9	R2
+      0x88280106,  //  001A  GETMBR	R10	R0	K6
+      0x94281405,  //  001B  GETIDX	R10	R10	R5
+      0x04281403,  //  001C  SUB	R10	R10	R3
+      0x882C010B,  //  001D  GETMBR	R11	R0	K11
+      0x942C1605,  //  001E  GETIDX	R11	R11	R5
+      0x7C1C0800,  //  001F  CALL	R7	4
+      0x5C200200,  //  0020  MOVE	R8	R1
+      0x7C180400,  //  0021  CALL	R6	2
+      0x00140B08,  //  0022  ADD	R5	R5	K8
+      0x7001FFEC,  //  0023  JMP		#0011
+      0x80000000,  //  0024  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
@@ -1004,7 +1004,7 @@ be_local_closure(class_Matter_Session_is_CASE,   /* name */
 extern const bclass be_class_Matter_Session;
 be_local_closure(class_Matter_Session_before_remove,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1012,25 +1012,23 @@ be_local_closure(class_Matter_Session_before_remove,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Session, 
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2DSession_X20_X20_X20_X28_X256i_X29_X20_X28removed_X29),
-    /* K3   */  be_nested_str_weak(local_session_id),
-    /* K4   */  be_const_int(3),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(log),
+    /* K1   */  be_nested_str_weak(MTR_X3A_X20_X2DSession_X20_X20_X20_X28_X256i_X29_X20_X28removed_X29),
+    /* K2   */  be_nested_str_weak(local_session_id),
+    /* K3   */  be_const_int(3),
     }),
     be_str_weak(before_remove),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
+    ( &(const binstruction[ 8]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x600C0018,  //  0002  GETGBL	R3	G24
-      0x58100002,  //  0003  LDCONST	R4	K2
-      0x88140103,  //  0004  GETMBR	R5	R0	K3
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x58100004,  //  0006  LDCONST	R4	K4
-      0x7C040600,  //  0007  CALL	R1	3
-      0x80000000,  //  0008  RET	0
+      0x60080018,  //  0001  GETGBL	R2	G24
+      0x580C0001,  //  0002  LDCONST	R3	K1
+      0x88100102,  //  0003  GETMBR	R4	R0	K2
+      0x7C080400,  //  0004  CALL	R2	2
+      0x580C0003,  //  0005  LDCONST	R3	K3
+      0x7C040400,  //  0006  CALL	R1	2
+      0x80000000,  //  0007  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session_Store.h
@@ -147,8 +147,8 @@ be_local_closure(class_Matter_Session_Store_load_fabrics,   /* name */
     }),
     be_str_weak(load_fabrics),
     &be_const_str_solidified,
-    ( &(const binstruction[117]) {  /* code */
-      0xA802005F,  //  0000  EXBLK	0	#0061
+    ( &(const binstruction[115]) {  /* code */
+      0xA802005E,  //  0000  EXBLK	0	#0060
       0xB8060200,  //  0001  GETNGBL	R1	K1
       0x8C040302,  //  0002  GETMET	R1	R1	K2
       0x7C040200,  //  0003  CALL	R1	1
@@ -233,38 +233,36 @@ be_local_closure(class_Matter_Session_Store_load_fabrics,   /* name */
       0x58140013,  //  0052  LDCONST	R5	K19
       0xAC140200,  //  0053  CATCH	R5	1	0
       0xB0080000,  //  0054  RAISE	2	R0	R0
-      0xB8161200,  //  0055  GETNGBL	R5	K9
-      0x8C140B15,  //  0056  GETMET	R5	R5	K21
-      0x601C0018,  //  0057  GETGBL	R7	G24
-      0x58200016,  //  0058  LDCONST	R8	K22
-      0x6024000C,  //  0059  GETGBL	R9	G12
-      0x88280103,  //  005A  GETMBR	R10	R0	K3
-      0x7C240200,  //  005B  CALL	R9	1
-      0x7C1C0400,  //  005C  CALL	R7	2
-      0x58200017,  //  005D  LDCONST	R8	K23
-      0x7C140600,  //  005E  CALL	R5	3
-      0xA8040001,  //  005F  EXBLK	1	1
-      0x70020012,  //  0060  JMP		#0074
-      0xAC040002,  //  0061  CATCH	R1	0	2
-      0x7002000F,  //  0062  JMP		#0073
-      0x200C0318,  //  0063  NE	R3	R1	K24
-      0x780E000C,  //  0064  JMPF	R3	#0072
-      0xB80E1200,  //  0065  GETNGBL	R3	K9
-      0x8C0C0715,  //  0066  GETMET	R3	R3	K21
-      0x60140008,  //  0067  GETGBL	R5	G8
-      0x5C180200,  //  0068  MOVE	R6	R1
-      0x7C140200,  //  0069  CALL	R5	1
-      0x00163205,  //  006A  ADD	R5	K25	R5
-      0x00140B1A,  //  006B  ADD	R5	R5	K26
-      0x60180008,  //  006C  GETGBL	R6	G8
-      0x5C1C0400,  //  006D  MOVE	R7	R2
-      0x7C180200,  //  006E  CALL	R6	1
-      0x00140A06,  //  006F  ADD	R5	R5	R6
-      0x58180017,  //  0070  LDCONST	R6	K23
-      0x7C0C0600,  //  0071  CALL	R3	3
-      0x70020000,  //  0072  JMP		#0074
-      0xB0080000,  //  0073  RAISE	2	R0	R0
-      0x80000000,  //  0074  RET	0
+      0xB8162A00,  //  0055  GETNGBL	R5	K21
+      0x60180018,  //  0056  GETGBL	R6	G24
+      0x581C0016,  //  0057  LDCONST	R7	K22
+      0x6020000C,  //  0058  GETGBL	R8	G12
+      0x88240103,  //  0059  GETMBR	R9	R0	K3
+      0x7C200200,  //  005A  CALL	R8	1
+      0x7C180400,  //  005B  CALL	R6	2
+      0x581C0017,  //  005C  LDCONST	R7	K23
+      0x7C140400,  //  005D  CALL	R5	2
+      0xA8040001,  //  005E  EXBLK	1	1
+      0x70020011,  //  005F  JMP		#0072
+      0xAC040002,  //  0060  CATCH	R1	0	2
+      0x7002000E,  //  0061  JMP		#0071
+      0x200C0318,  //  0062  NE	R3	R1	K24
+      0x780E000B,  //  0063  JMPF	R3	#0070
+      0xB80E2A00,  //  0064  GETNGBL	R3	K21
+      0x60100008,  //  0065  GETGBL	R4	G8
+      0x5C140200,  //  0066  MOVE	R5	R1
+      0x7C100200,  //  0067  CALL	R4	1
+      0x00123204,  //  0068  ADD	R4	K25	R4
+      0x0010091A,  //  0069  ADD	R4	R4	K26
+      0x60140008,  //  006A  GETGBL	R5	G8
+      0x5C180400,  //  006B  MOVE	R6	R2
+      0x7C140200,  //  006C  CALL	R5	1
+      0x00100805,  //  006D  ADD	R4	R4	R5
+      0x58140017,  //  006E  LDCONST	R5	K23
+      0x7C0C0400,  //  006F  CALL	R3	2
+      0x70020000,  //  0070  JMP		#0072
+      0xB0080000,  //  0071  RAISE	2	R0	R0
+      0x80000000,  //  0072  RET	0
     })
   )
 );
@@ -582,7 +580,7 @@ be_local_closure(class_Matter_Session_Store_count_active_fabrics,   /* name */
 extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_find_session_by_resumption_id,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -590,20 +588,19 @@ be_local_closure(class_Matter_Session_Store_find_session_by_resumption_id,   /* 
     0,                          /* has sup protos */
     &be_class_Matter_Session_Store, 
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_const_int(0),
     /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20session_X2Eresumption_id_X3D_X25s_X20vs_X20_X25s),
-    /* K5   */  be_nested_str_weak(resumption_id),
-    /* K6   */  be_nested_str_weak(shared_secret),
-    /* K7   */  be_nested_str_weak(update),
-    /* K8   */  be_const_int(1),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20session_X2Eresumption_id_X3D_X25s_X20vs_X20_X25s),
+    /* K4   */  be_nested_str_weak(resumption_id),
+    /* K5   */  be_nested_str_weak(shared_secret),
+    /* K6   */  be_nested_str_weak(update),
+    /* K7   */  be_const_int(1),
     }),
     be_str_weak(find_session_by_resumption_id),
     &be_const_str_solidified,
-    ( &(const binstruction[38]) {  /* code */
+    ( &(const binstruction[37]) {  /* code */
       0x5C080200,  //  0000  MOVE	R2	R1
       0x740A0001,  //  0001  JMPT	R2	#0004
       0x4C080000,  //  0002  LDNIL	R2
@@ -614,34 +611,33 @@ be_local_closure(class_Matter_Session_Store_find_session_by_resumption_id,   /* 
       0x5C140600,  //  0007  MOVE	R5	R3
       0x7C100200,  //  0008  CALL	R4	1
       0x14100404,  //  0009  LT	R4	R2	R4
-      0x78120019,  //  000A  JMPF	R4	#0025
+      0x78120018,  //  000A  JMPF	R4	#0024
       0x94100602,  //  000B  GETIDX	R4	R3	R2
       0xB8160400,  //  000C  GETNGBL	R5	K2
-      0x8C140B03,  //  000D  GETMET	R5	R5	K3
-      0x601C0018,  //  000E  GETGBL	R7	G24
-      0x58200004,  //  000F  LDCONST	R8	K4
-      0x60240008,  //  0010  GETGBL	R9	G8
-      0x88280905,  //  0011  GETMBR	R10	R4	K5
-      0x7C240200,  //  0012  CALL	R9	1
-      0x60280008,  //  0013  GETGBL	R10	G8
-      0x5C2C0200,  //  0014  MOVE	R11	R1
-      0x7C280200,  //  0015  CALL	R10	1
-      0x7C1C0600,  //  0016  CALL	R7	3
-      0x54220003,  //  0017  LDINT	R8	4
-      0x7C140600,  //  0018  CALL	R5	3
-      0x88140905,  //  0019  GETMBR	R5	R4	K5
-      0x1C140A01,  //  001A  EQ	R5	R5	R1
-      0x78160006,  //  001B  JMPF	R5	#0023
-      0x88140906,  //  001C  GETMBR	R5	R4	K6
-      0x4C180000,  //  001D  LDNIL	R6
-      0x20140A06,  //  001E  NE	R5	R5	R6
-      0x78160002,  //  001F  JMPF	R5	#0023
-      0x8C140907,  //  0020  GETMET	R5	R4	K7
-      0x7C140200,  //  0021  CALL	R5	1
-      0x80040800,  //  0022  RET	1	R4
-      0x00080508,  //  0023  ADD	R2	R2	K8
-      0x7001FFE0,  //  0024  JMP		#0006
-      0x80000000,  //  0025  RET	0
+      0x60180018,  //  000D  GETGBL	R6	G24
+      0x581C0003,  //  000E  LDCONST	R7	K3
+      0x60200008,  //  000F  GETGBL	R8	G8
+      0x88240904,  //  0010  GETMBR	R9	R4	K4
+      0x7C200200,  //  0011  CALL	R8	1
+      0x60240008,  //  0012  GETGBL	R9	G8
+      0x5C280200,  //  0013  MOVE	R10	R1
+      0x7C240200,  //  0014  CALL	R9	1
+      0x7C180600,  //  0015  CALL	R6	3
+      0x541E0003,  //  0016  LDINT	R7	4
+      0x7C140400,  //  0017  CALL	R5	2
+      0x88140904,  //  0018  GETMBR	R5	R4	K4
+      0x1C140A01,  //  0019  EQ	R5	R5	R1
+      0x78160006,  //  001A  JMPF	R5	#0022
+      0x88140905,  //  001B  GETMBR	R5	R4	K5
+      0x4C180000,  //  001C  LDNIL	R6
+      0x20140A06,  //  001D  NE	R5	R5	R6
+      0x78160002,  //  001E  JMPF	R5	#0022
+      0x8C140906,  //  001F  GETMET	R5	R4	K6
+      0x7C140200,  //  0020  CALL	R5	1
+      0x80040800,  //  0021  RET	1	R4
+      0x00080507,  //  0022  ADD	R2	R2	K7
+      0x7001FFE1,  //  0023  JMP		#0006
+      0x80000000,  //  0024  RET	0
     })
   )
 );
@@ -1127,7 +1123,7 @@ be_local_closure(class_Matter_Session_Store_next_fabric_idx,   /* name */
 extern const bclass be_class_Matter_Session_Store;
 be_local_closure(class_Matter_Session_Store_save_fabrics,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1135,7 +1131,7 @@ be_local_closure(class_Matter_Session_Store_save_fabrics,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Session_Store, 
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
+    ( &(const bvalue[28]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
     /* K1   */  be_nested_str_weak(path),
     /* K2   */  be_nested_str_weak(remove_expired),
@@ -1156,22 +1152,21 @@ be_local_closure(class_Matter_Session_Store_save_fabrics,   /* name */
     /* K17  */  be_nested_str_weak(remove),
     /* K18  */  be_nested_str_weak(_FABRICS),
     /* K19  */  be_nested_str_weak(rename),
-    /* K20  */  be_nested_str_weak(tasmota),
-    /* K21  */  be_nested_str_weak(log),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20_X25s_X20fabric_X28s_X29_X20and_X20_X25s_X20session_X28s_X29),
-    /* K23  */  be_const_int(2),
-    /* K24  */  be_nested_str_weak(device),
-    /* K25  */  be_nested_str_weak(event_fabrics_saved),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20Saving_X20Fabrics_X20failed),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K28  */  be_nested_str_weak(_X7C),
+    /* K20  */  be_nested_str_weak(log),
+    /* K21  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20_X25s_X20fabric_X28s_X29_X20and_X20_X25s_X20session_X28s_X29),
+    /* K22  */  be_const_int(2),
+    /* K23  */  be_nested_str_weak(device),
+    /* K24  */  be_nested_str_weak(event_fabrics_saved),
+    /* K25  */  be_nested_str_weak(MTR_X3A_X20Saving_X20Fabrics_X20failed),
+    /* K26  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+    /* K27  */  be_nested_str_weak(_X7C),
     }),
     be_str_weak(save_fabrics),
     &be_const_str_solidified,
-    ( &(const binstruction[101]) {  /* code */
+    ( &(const binstruction[98]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xA802004F,  //  0002  EXBLK	0	#0053
+      0xA802004D,  //  0002  EXBLK	0	#0051
       0x8C0C0102,  //  0003  GETMET	R3	R0	K2
       0x7C0C0200,  //  0004  CALL	R3	1
       0x580C0003,  //  0005  LDCONST	R3	K3
@@ -1229,47 +1224,44 @@ be_local_closure(class_Matter_Session_Store_save_fabrics,   /* name */
       0x88200104,  //  0039  GETMBR	R8	R0	K4
       0x88240112,  //  003A  GETMBR	R9	R0	K18
       0x7C180600,  //  003B  CALL	R6	3
-      0x781A000C,  //  003C  JMPF	R6	#004A
+      0x781A000B,  //  003C  JMPF	R6	#0049
       0xB81A2800,  //  003D  GETNGBL	R6	K20
-      0x8C180D15,  //  003E  GETMET	R6	R6	K21
-      0x60200018,  //  003F  GETGBL	R8	G24
-      0x58240016,  //  0040  LDCONST	R9	K22
-      0x5C280800,  //  0041  MOVE	R10	R4
-      0x5C2C0600,  //  0042  MOVE	R11	R3
-      0x7C200600,  //  0043  CALL	R8	3
-      0x58240017,  //  0044  LDCONST	R9	K23
-      0x7C180600,  //  0045  CALL	R6	3
-      0x88180118,  //  0046  GETMBR	R6	R0	K24
-      0x8C180D19,  //  0047  GETMET	R6	R6	K25
-      0x7C180200,  //  0048  CALL	R6	1
-      0x70020006,  //  0049  JMP		#0051
-      0xB81A2800,  //  004A  GETNGBL	R6	K20
-      0x8C180D15,  //  004B  GETMET	R6	R6	K21
-      0x60200018,  //  004C  GETGBL	R8	G24
-      0x5824001A,  //  004D  LDCONST	R9	K26
-      0x7C200200,  //  004E  CALL	R8	1
-      0x58240017,  //  004F  LDCONST	R9	K23
-      0x7C180600,  //  0050  CALL	R6	3
-      0xA8040001,  //  0051  EXBLK	1	1
-      0x70020010,  //  0052  JMP		#0064
-      0xAC0C0002,  //  0053  CATCH	R3	0	2
-      0x7002000D,  //  0054  JMP		#0063
-      0xB8162800,  //  0055  GETNGBL	R5	K20
-      0x8C140B15,  //  0056  GETMET	R5	R5	K21
-      0x601C0008,  //  0057  GETGBL	R7	G8
-      0x5C200600,  //  0058  MOVE	R8	R3
-      0x7C1C0200,  //  0059  CALL	R7	1
-      0x001E3607,  //  005A  ADD	R7	K27	R7
-      0x001C0F1C,  //  005B  ADD	R7	R7	K28
-      0x60200008,  //  005C  GETGBL	R8	G8
-      0x5C240800,  //  005D  MOVE	R9	R4
-      0x7C200200,  //  005E  CALL	R8	1
-      0x001C0E08,  //  005F  ADD	R7	R7	R8
-      0x58200017,  //  0060  LDCONST	R8	K23
-      0x7C140600,  //  0061  CALL	R5	3
-      0x70020000,  //  0062  JMP		#0064
-      0xB0080000,  //  0063  RAISE	2	R0	R0
-      0x80000000,  //  0064  RET	0
+      0x601C0018,  //  003E  GETGBL	R7	G24
+      0x58200015,  //  003F  LDCONST	R8	K21
+      0x5C240800,  //  0040  MOVE	R9	R4
+      0x5C280600,  //  0041  MOVE	R10	R3
+      0x7C1C0600,  //  0042  CALL	R7	3
+      0x58200016,  //  0043  LDCONST	R8	K22
+      0x7C180400,  //  0044  CALL	R6	2
+      0x88180117,  //  0045  GETMBR	R6	R0	K23
+      0x8C180D18,  //  0046  GETMET	R6	R6	K24
+      0x7C180200,  //  0047  CALL	R6	1
+      0x70020005,  //  0048  JMP		#004F
+      0xB81A2800,  //  0049  GETNGBL	R6	K20
+      0x601C0018,  //  004A  GETGBL	R7	G24
+      0x58200019,  //  004B  LDCONST	R8	K25
+      0x7C1C0200,  //  004C  CALL	R7	1
+      0x58200016,  //  004D  LDCONST	R8	K22
+      0x7C180400,  //  004E  CALL	R6	2
+      0xA8040001,  //  004F  EXBLK	1	1
+      0x7002000F,  //  0050  JMP		#0061
+      0xAC0C0002,  //  0051  CATCH	R3	0	2
+      0x7002000C,  //  0052  JMP		#0060
+      0xB8162800,  //  0053  GETNGBL	R5	K20
+      0x60180008,  //  0054  GETGBL	R6	G8
+      0x5C1C0600,  //  0055  MOVE	R7	R3
+      0x7C180200,  //  0056  CALL	R6	1
+      0x001A3406,  //  0057  ADD	R6	K26	R6
+      0x00180D1B,  //  0058  ADD	R6	R6	K27
+      0x601C0008,  //  0059  GETGBL	R7	G8
+      0x5C200800,  //  005A  MOVE	R8	R4
+      0x7C1C0200,  //  005B  CALL	R7	1
+      0x00180C07,  //  005C  ADD	R6	R6	R7
+      0x581C0016,  //  005D  LDCONST	R7	K22
+      0x7C140400,  //  005E  CALL	R5	2
+      0x70020000,  //  005F  JMP		#0061
+      0xB0080000,  //  0060  RAISE	2	R0	R0
+      0x80000000,  //  0061  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TCP_async.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TCP_async.h
@@ -48,7 +48,7 @@ be_local_closure(class_Matter_TCP_async_read,   /* name */
 extern const bclass be_class_Matter_TCP_async;
 be_local_closure(class_Matter_TCP_async_begin,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -83,7 +83,7 @@ be_local_closure(class_Matter_TCP_async_begin,   /* name */
     }),
     be_str_weak(begin),
     &be_const_str_solidified,
-    ( &(const binstruction[63]) {  /* code */
+    ( &(const binstruction[62]) {  /* code */
       0x8C040100,  //  0000  GETMET	R1	R0	K0
       0x7C040200,  //  0001  CALL	R1	1
       0xB8060200,  //  0002  GETNGBL	R1	K1
@@ -126,27 +126,26 @@ be_local_closure(class_Matter_TCP_async_begin,   /* name */
       0x7C040400,  //  0027  CALL	R1	2
       0x50040200,  //  0028  LDBOOL	R1	1	0
       0x80040200,  //  0029  RET	1	R1
-      0x70020012,  //  002A  JMP		#003E
-      0xB8060200,  //  002B  GETNGBL	R1	K1
-      0x8C040311,  //  002C  GETMET	R1	R1	K17
-      0x600C0018,  //  002D  GETGBL	R3	G24
-      0x58100012,  //  002E  LDCONST	R4	K18
-      0x8814010B,  //  002F  GETMBR	R5	R0	K11
-      0x8818010C,  //  0030  GETMBR	R6	R0	K12
-      0x7C0C0600,  //  0031  CALL	R3	3
-      0x58100013,  //  0032  LDCONST	R4	K19
-      0x7C040600,  //  0033  CALL	R1	3
-      0x8C040114,  //  0034  GETMET	R1	R0	K20
-      0x7C040200,  //  0035  CALL	R1	1
-      0x5405FFFE,  //  0036  LDINT	R1	-1
-      0x90020E01,  //  0037  SETMBR	R0	K7	R1
-      0x50040000,  //  0038  LDBOOL	R1	0	0
-      0x90022A01,  //  0039  SETMBR	R0	K21	R1
-      0x8C040116,  //  003A  GETMET	R1	R0	K22
-      0x7C040200,  //  003B  CALL	R1	1
-      0x50040000,  //  003C  LDBOOL	R1	0	0
-      0x80040200,  //  003D  RET	1	R1
-      0x80000000,  //  003E  RET	0
+      0x70020011,  //  002A  JMP		#003D
+      0xB8062200,  //  002B  GETNGBL	R1	K17
+      0x60080018,  //  002C  GETGBL	R2	G24
+      0x580C0012,  //  002D  LDCONST	R3	K18
+      0x8810010B,  //  002E  GETMBR	R4	R0	K11
+      0x8814010C,  //  002F  GETMBR	R5	R0	K12
+      0x7C080600,  //  0030  CALL	R2	3
+      0x580C0013,  //  0031  LDCONST	R3	K19
+      0x7C040400,  //  0032  CALL	R1	2
+      0x8C040114,  //  0033  GETMET	R1	R0	K20
+      0x7C040200,  //  0034  CALL	R1	1
+      0x5405FFFE,  //  0035  LDINT	R1	-1
+      0x90020E01,  //  0036  SETMBR	R0	K7	R1
+      0x50040000,  //  0037  LDBOOL	R1	0	0
+      0x90022A01,  //  0038  SETMBR	R0	K21	R1
+      0x8C040116,  //  0039  GETMET	R1	R0	K22
+      0x7C040200,  //  003A  CALL	R1	1
+      0x50040000,  //  003B  LDBOOL	R1	0	0
+      0x80040200,  //  003C  RET	1	R1
+      0x80000000,  //  003D  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
@@ -896,7 +896,7 @@ be_local_closure(class_Matter_TLV_item_parse,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_TLV_item, 
     1,                          /* has constants */
-    ( &(const bvalue[25]) {     /* constants */
+    ( &(const bvalue[24]) {     /* constants */
     /* K0   */  be_nested_str_weak(typ),
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(_len),
@@ -916,16 +916,15 @@ be_local_closure(class_Matter_TLV_item_parse,   /* name */
     /* K16  */  be_nested_str_weak(asstring),
     /* K17  */  be_nested_str_weak(NULL),
     /* K18  */  be_nested_str_weak(EOC),
-    /* K19  */  be_nested_str_weak(tasmota),
-    /* K20  */  be_nested_str_weak(log),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20unexpected_X20eoc),
-    /* K22  */  be_const_int(3),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20unexpected_X20type_X3A_X20),
-    /* K24  */  be_nested_str_weak(next_idx),
+    /* K19  */  be_nested_str_weak(log),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20unexpected_X20eoc),
+    /* K21  */  be_const_int(3),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20unexpected_X20type_X3A_X20),
+    /* K23  */  be_nested_str_weak(next_idx),
     }),
     be_str_weak(parse),
     &be_const_str_solidified,
-    ( &(const binstruction[103]) {  /* code */
+    ( &(const binstruction[101]) {  /* code */
       0x880C0100,  //  0000  GETMBR	R3	R0	K0
       0x88100101,  //  0001  GETMBR	R4	R0	K1
       0x88140902,  //  0002  GETMBR	R5	R4	K2
@@ -941,7 +940,7 @@ be_local_closure(class_Matter_TLV_item_parse,   /* name */
       0x90020606,  //  000C  SETMBR	R0	K3	R6
       0x541A0007,  //  000D  LDINT	R6	8
       0x00080406,  //  000E  ADD	R2	R2	R6
-      0x70020054,  //  000F  JMP		#0065
+      0x70020052,  //  000F  JMP		#0063
       0x88180906,  //  0010  GETMBR	R6	R4	K6
       0x1C180606,  //  0011  EQ	R6	R3	R6
       0x741A0002,  //  0012  JMPT	R6	#0016
@@ -951,7 +950,7 @@ be_local_closure(class_Matter_TLV_item_parse,   /* name */
       0x88180907,  //  0016  GETMBR	R6	R4	K7
       0x1C180606,  //  0017  EQ	R6	R3	R6
       0x90020606,  //  0018  SETMBR	R0	K3	R6
-      0x7002004A,  //  0019  JMP		#0065
+      0x70020048,  //  0019  JMP		#0063
       0x88180908,  //  001A  GETMBR	R6	R4	K8
       0x14180606,  //  001B  LT	R6	R3	R6
       0x781A000E,  //  001C  JMPF	R6	#002C
@@ -969,7 +968,7 @@ be_local_closure(class_Matter_TLV_item_parse,   /* name */
       0x7C180600,  //  0028  CALL	R6	3
       0x90020606,  //  0029  SETMBR	R0	K3	R6
       0x00080405,  //  002A  ADD	R2	R2	R5
-      0x70020038,  //  002B  JMP		#0065
+      0x70020036,  //  002B  JMP		#0063
       0x8818090C,  //  002C  GETMBR	R6	R4	K12
       0x1C180606,  //  002D  EQ	R6	R3	R6
       0x781A0006,  //  002E  JMPF	R6	#0036
@@ -979,7 +978,7 @@ be_local_closure(class_Matter_TLV_item_parse,   /* name */
       0x90020606,  //  0032  SETMBR	R0	K3	R6
       0x541A0003,  //  0033  LDINT	R6	4
       0x00080406,  //  0034  ADD	R2	R2	R6
-      0x7002002E,  //  0035  JMP		#0065
+      0x7002002C,  //  0035  JMP		#0063
       0x5419FFF7,  //  0036  LDINT	R6	-8
       0x28180A06,  //  0037  GE	R6	R5	R6
       0x781A0016,  //  0038  JMPF	R6	#0050
@@ -1005,30 +1004,28 @@ be_local_closure(class_Matter_TLV_item_parse,   /* name */
       0x8C1C0F10,  //  004C  GETMET	R7	R7	K16
       0x7C1C0200,  //  004D  CALL	R7	1
       0x90020607,  //  004E  SETMBR	R0	K3	R7
-      0x70020014,  //  004F  JMP		#0065
+      0x70020012,  //  004F  JMP		#0063
       0x88180911,  //  0050  GETMBR	R6	R4	K17
       0x1C180606,  //  0051  EQ	R6	R3	R6
       0x781A0000,  //  0052  JMPF	R6	#0054
-      0x70020010,  //  0053  JMP		#0065
+      0x7002000E,  //  0053  JMP		#0063
       0x88180912,  //  0054  GETMBR	R6	R4	K18
       0x1C180606,  //  0055  EQ	R6	R3	R6
-      0x781A0005,  //  0056  JMPF	R6	#005D
+      0x781A0004,  //  0056  JMPF	R6	#005C
       0xB81A2600,  //  0057  GETNGBL	R6	K19
-      0x8C180D14,  //  0058  GETMET	R6	R6	K20
+      0x581C0014,  //  0058  LDCONST	R7	K20
       0x58200015,  //  0059  LDCONST	R8	K21
-      0x58240016,  //  005A  LDCONST	R9	K22
-      0x7C180600,  //  005B  CALL	R6	3
-      0x70020007,  //  005C  JMP		#0065
-      0xB81A2600,  //  005D  GETNGBL	R6	K19
-      0x8C180D14,  //  005E  GETMET	R6	R6	K20
-      0x60200008,  //  005F  GETGBL	R8	G8
-      0x5C240600,  //  0060  MOVE	R9	R3
-      0x7C200200,  //  0061  CALL	R8	1
-      0x00222E08,  //  0062  ADD	R8	K23	R8
-      0x58240016,  //  0063  LDCONST	R9	K22
-      0x7C180600,  //  0064  CALL	R6	3
-      0x90023002,  //  0065  SETMBR	R0	K24	R2
-      0x80040400,  //  0066  RET	1	R2
+      0x7C180400,  //  005A  CALL	R6	2
+      0x70020006,  //  005B  JMP		#0063
+      0xB81A2600,  //  005C  GETNGBL	R6	K19
+      0x601C0008,  //  005D  GETGBL	R7	G8
+      0x5C200600,  //  005E  MOVE	R8	R3
+      0x7C1C0200,  //  005F  CALL	R7	1
+      0x001E2C07,  //  0060  ADD	R7	K22	R7
+      0x58200015,  //  0061  LDCONST	R8	K21
+      0x7C180400,  //  0062  CALL	R6	2
+      0x90022E02,  //  0063  SETMBR	R0	K23	R2
+      0x80040400,  //  0064  RET	1	R2
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
@@ -193,7 +193,7 @@ be_local_closure(class_Matter_UDPServer_send_UDP,   /* name */
 extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer_received_ack,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -216,7 +216,7 @@ be_local_closure(class_Matter_UDPServer_received_ack,   /* name */
     }),
     be_str_weak(received_ack),
     &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
+    ( &(const binstruction[40]) {  /* code */
       0x88080300,  //  0000  GETMBR	R2	R1	K0
       0x880C0301,  //  0001  GETMBR	R3	R1	K1
       0x4C100000,  //  0002  LDNIL	R4
@@ -228,15 +228,15 @@ be_local_closure(class_Matter_UDPServer_received_ack,   /* name */
       0x88180103,  //  0008  GETMBR	R6	R0	K3
       0x7C140200,  //  0009  CALL	R5	1
       0x14140805,  //  000A  LT	R5	R4	R5
-      0x7816001B,  //  000B  JMPF	R5	#0028
+      0x7816001A,  //  000B  JMPF	R5	#0027
       0x88140103,  //  000C  GETMBR	R5	R0	K3
       0x94140A04,  //  000D  GETIDX	R5	R5	R4
       0x88180B04,  //  000E  GETMBR	R6	R5	K4
       0x1C180C02,  //  000F  EQ	R6	R6	R2
-      0x781A0014,  //  0010  JMPF	R6	#0026
+      0x781A0013,  //  0010  JMPF	R6	#0025
       0x88180B01,  //  0011  GETMBR	R6	R5	K1
       0x1C180C03,  //  0012  EQ	R6	R6	R3
-      0x781A0011,  //  0013  JMPF	R6	#0026
+      0x781A0010,  //  0013  JMPF	R6	#0025
       0x88180103,  //  0014  GETMBR	R6	R0	K3
       0x8C180D05,  //  0015  GETMET	R6	R6	K5
       0x5C200800,  //  0016  MOVE	R8	R4
@@ -245,19 +245,18 @@ be_local_closure(class_Matter_UDPServer_received_ack,   /* name */
       0x8C180D07,  //  0019  GETMET	R6	R6	K7
       0x54220003,  //  001A  LDINT	R8	4
       0x7C180400,  //  001B  CALL	R6	2
-      0x781A0007,  //  001C  JMPF	R6	#0025
-      0xB81A0C00,  //  001D  GETNGBL	R6	K6
-      0x8C180D08,  //  001E  GETMET	R6	R6	K8
-      0x60200008,  //  001F  GETGBL	R8	G8
-      0x5C240400,  //  0020  MOVE	R9	R2
-      0x7C200200,  //  0021  CALL	R8	1
-      0x00221208,  //  0022  ADD	R8	K9	R8
-      0x54260003,  //  0023  LDINT	R9	4
-      0x7C180600,  //  0024  CALL	R6	3
-      0x70020000,  //  0025  JMP		#0027
-      0x0010090A,  //  0026  ADD	R4	R4	K10
-      0x7001FFDE,  //  0027  JMP		#0007
-      0x80000000,  //  0028  RET	0
+      0x781A0006,  //  001C  JMPF	R6	#0024
+      0xB81A1000,  //  001D  GETNGBL	R6	K8
+      0x601C0008,  //  001E  GETGBL	R7	G8
+      0x5C200400,  //  001F  MOVE	R8	R2
+      0x7C1C0200,  //  0020  CALL	R7	1
+      0x001E1207,  //  0021  ADD	R7	K9	R7
+      0x54220003,  //  0022  LDINT	R8	4
+      0x7C180400,  //  0023  CALL	R6	2
+      0x70020000,  //  0024  JMP		#0026
+      0x0010090A,  //  0025  ADD	R4	R4	K10
+      0x7001FFDF,  //  0026  JMP		#0007
+      0x80000000,  //  0027  RET	0
     })
   )
 );
@@ -328,7 +327,7 @@ be_local_closure(class_Matter_UDPServer_start,   /* name */
 extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer_send,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    8,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -353,7 +352,7 @@ be_local_closure(class_Matter_UDPServer_send,   /* name */
     }),
     be_str_weak(send),
     &be_const_str_solidified,
-    ( &(const binstruction[47]) {  /* code */
+    ( &(const binstruction[45]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x88100302,  //  0002  GETMBR	R4	R1	K2
@@ -370,37 +369,35 @@ be_local_closure(class_Matter_UDPServer_send,   /* name */
       0x88140B05,  //  000D  GETMBR	R5	R5	K5
       0x88180306,  //  000E  GETMBR	R6	R1	K6
       0x7C080800,  //  000F  CALL	R2	4
-      0x780A000E,  //  0010  JMPF	R2	#0020
+      0x780A000D,  //  0010  JMPF	R2	#001F
       0xB80E0E00,  //  0011  GETNGBL	R3	K7
       0x8C0C0708,  //  0012  GETMET	R3	R3	K8
       0x54160003,  //  0013  LDINT	R5	4
       0x7C0C0400,  //  0014  CALL	R3	2
-      0x780E0008,  //  0015  JMPF	R3	#001F
-      0xB80E0E00,  //  0016  GETNGBL	R3	K7
-      0x8C0C0709,  //  0017  GETMET	R3	R3	K9
-      0x60140018,  //  0018  GETGBL	R5	G24
-      0x5818000A,  //  0019  LDCONST	R6	K10
-      0x881C0302,  //  001A  GETMBR	R7	R1	K2
-      0x88200304,  //  001B  GETMBR	R8	R1	K4
-      0x7C140600,  //  001C  CALL	R5	3
-      0x541A0003,  //  001D  LDINT	R6	4
-      0x7C0C0600,  //  001E  CALL	R3	3
-      0x7002000D,  //  001F  JMP		#002E
-      0xB80E0E00,  //  0020  GETNGBL	R3	K7
-      0x8C0C0708,  //  0021  GETMET	R3	R3	K8
-      0x5814000B,  //  0022  LDCONST	R5	K11
-      0x7C0C0400,  //  0023  CALL	R3	2
-      0x780E0008,  //  0024  JMPF	R3	#002E
-      0xB80E0E00,  //  0025  GETNGBL	R3	K7
-      0x8C0C0709,  //  0026  GETMET	R3	R3	K9
-      0x60140018,  //  0027  GETGBL	R5	G24
-      0x5818000C,  //  0028  LDCONST	R6	K12
-      0x881C0302,  //  0029  GETMBR	R7	R1	K2
-      0x88200304,  //  002A  GETMBR	R8	R1	K4
-      0x7C140600,  //  002B  CALL	R5	3
-      0x5818000B,  //  002C  LDCONST	R6	K11
-      0x7C0C0600,  //  002D  CALL	R3	3
-      0x80040400,  //  002E  RET	1	R2
+      0x780E0007,  //  0015  JMPF	R3	#001E
+      0xB80E1200,  //  0016  GETNGBL	R3	K9
+      0x60100018,  //  0017  GETGBL	R4	G24
+      0x5814000A,  //  0018  LDCONST	R5	K10
+      0x88180302,  //  0019  GETMBR	R6	R1	K2
+      0x881C0304,  //  001A  GETMBR	R7	R1	K4
+      0x7C100600,  //  001B  CALL	R4	3
+      0x54160003,  //  001C  LDINT	R5	4
+      0x7C0C0400,  //  001D  CALL	R3	2
+      0x7002000C,  //  001E  JMP		#002C
+      0xB80E0E00,  //  001F  GETNGBL	R3	K7
+      0x8C0C0708,  //  0020  GETMET	R3	R3	K8
+      0x5814000B,  //  0021  LDCONST	R5	K11
+      0x7C0C0400,  //  0022  CALL	R3	2
+      0x780E0007,  //  0023  JMPF	R3	#002C
+      0xB80E1200,  //  0024  GETNGBL	R3	K9
+      0x60100018,  //  0025  GETGBL	R4	G24
+      0x5814000C,  //  0026  LDCONST	R5	K12
+      0x88180302,  //  0027  GETMBR	R6	R1	K2
+      0x881C0304,  //  0028  GETMBR	R7	R1	K4
+      0x7C100600,  //  0029  CALL	R4	3
+      0x5814000B,  //  002A  LDCONST	R5	K11
+      0x7C0C0400,  //  002B  CALL	R3	2
+      0x80040400,  //  002C  RET	1	R2
     })
   )
 );
@@ -533,7 +530,7 @@ be_local_closure(class_Matter_UDPServer_init,   /* name */
 extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer__resend_packets,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -565,67 +562,65 @@ be_local_closure(class_Matter_UDPServer__resend_packets,   /* name */
     }),
     be_str_weak(_resend_packets),
     &be_const_str_solidified,
-    ( &(const binstruction[60]) {  /* code */
+    ( &(const binstruction[58]) {  /* code */
       0x58040000,  //  0000  LDCONST	R1	K0
       0x6008000C,  //  0001  GETGBL	R2	G12
       0x880C0101,  //  0002  GETMBR	R3	R0	K1
       0x7C080200,  //  0003  CALL	R2	1
       0x14080202,  //  0004  LT	R2	R1	R2
-      0x780A0034,  //  0005  JMPF	R2	#003B
+      0x780A0032,  //  0005  JMPF	R2	#0039
       0x88080101,  //  0006  GETMBR	R2	R0	K1
       0x94080401,  //  0007  GETIDX	R2	R2	R1
       0xB80E0400,  //  0008  GETNGBL	R3	K2
       0x8C0C0703,  //  0009  GETMET	R3	R3	K3
       0x88140504,  //  000A  GETMBR	R5	R2	K4
       0x7C0C0400,  //  000B  CALL	R3	2
-      0x780E002B,  //  000C  JMPF	R3	#0039
+      0x780E0029,  //  000C  JMPF	R3	#0037
       0x880C0505,  //  000D  GETMBR	R3	R2	K5
       0x88100106,  //  000E  GETMBR	R4	R0	K6
       0x180C0604,  //  000F  LE	R3	R3	R4
-      0x780E0017,  //  0010  JMPF	R3	#0029
-      0xB80E0400,  //  0011  GETNGBL	R3	K2
-      0x8C0C0707,  //  0012  GETMET	R3	R3	K7
-      0x60140008,  //  0013  GETGBL	R5	G8
-      0x88180509,  //  0014  GETMBR	R6	R2	K9
-      0x7C140200,  //  0015  CALL	R5	1
-      0x00161005,  //  0016  ADD	R5	K8	R5
-      0x541A0003,  //  0017  LDINT	R6	4
-      0x7C0C0600,  //  0018  CALL	R3	3
-      0x8C0C010A,  //  0019  GETMET	R3	R0	K10
-      0x5C140400,  //  001A  MOVE	R5	R2
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0xB80E0400,  //  001C  GETNGBL	R3	K2
-      0x8C0C070B,  //  001D  GETMET	R3	R3	K11
-      0x7C0C0200,  //  001E  CALL	R3	1
-      0x8C10010C,  //  001F  GETMET	R4	R0	K12
-      0x88180505,  //  0020  GETMBR	R6	R2	K5
-      0x7C100400,  //  0021  CALL	R4	2
-      0x000C0604,  //  0022  ADD	R3	R3	R4
-      0x900A0803,  //  0023  SETMBR	R2	K4	R3
-      0x880C0505,  //  0024  GETMBR	R3	R2	K5
-      0x000C070D,  //  0025  ADD	R3	R3	K13
-      0x900A0A03,  //  0026  SETMBR	R2	K5	R3
-      0x0004030D,  //  0027  ADD	R1	R1	K13
-      0x7002000E,  //  0028  JMP		#0038
-      0x880C0101,  //  0029  GETMBR	R3	R0	K1
-      0x8C0C070E,  //  002A  GETMET	R3	R3	K14
-      0x5C140200,  //  002B  MOVE	R5	R1
-      0x7C0C0400,  //  002C  CALL	R3	2
-      0xB80E0400,  //  002D  GETNGBL	R3	K2
-      0x8C0C0707,  //  002E  GETMET	R3	R3	K7
-      0x60140018,  //  002F  GETGBL	R5	G24
-      0x5818000F,  //  0030  LDCONST	R6	K15
-      0x881C0510,  //  0031  GETMBR	R7	R2	K16
-      0x88200511,  //  0032  GETMBR	R8	R2	K17
-      0x88240512,  //  0033  GETMBR	R9	R2	K18
-      0x88280509,  //  0034  GETMBR	R10	R2	K9
-      0x7C140A00,  //  0035  CALL	R5	5
-      0x58180013,  //  0036  LDCONST	R6	K19
-      0x7C0C0600,  //  0037  CALL	R3	3
-      0x70020000,  //  0038  JMP		#003A
-      0x0004030D,  //  0039  ADD	R1	R1	K13
-      0x7001FFC5,  //  003A  JMP		#0001
-      0x80000000,  //  003B  RET	0
+      0x780E0016,  //  0010  JMPF	R3	#0028
+      0xB80E0E00,  //  0011  GETNGBL	R3	K7
+      0x60100008,  //  0012  GETGBL	R4	G8
+      0x88140509,  //  0013  GETMBR	R5	R2	K9
+      0x7C100200,  //  0014  CALL	R4	1
+      0x00121004,  //  0015  ADD	R4	K8	R4
+      0x54160003,  //  0016  LDINT	R5	4
+      0x7C0C0400,  //  0017  CALL	R3	2
+      0x8C0C010A,  //  0018  GETMET	R3	R0	K10
+      0x5C140400,  //  0019  MOVE	R5	R2
+      0x7C0C0400,  //  001A  CALL	R3	2
+      0xB80E0400,  //  001B  GETNGBL	R3	K2
+      0x8C0C070B,  //  001C  GETMET	R3	R3	K11
+      0x7C0C0200,  //  001D  CALL	R3	1
+      0x8C10010C,  //  001E  GETMET	R4	R0	K12
+      0x88180505,  //  001F  GETMBR	R6	R2	K5
+      0x7C100400,  //  0020  CALL	R4	2
+      0x000C0604,  //  0021  ADD	R3	R3	R4
+      0x900A0803,  //  0022  SETMBR	R2	K4	R3
+      0x880C0505,  //  0023  GETMBR	R3	R2	K5
+      0x000C070D,  //  0024  ADD	R3	R3	K13
+      0x900A0A03,  //  0025  SETMBR	R2	K5	R3
+      0x0004030D,  //  0026  ADD	R1	R1	K13
+      0x7002000D,  //  0027  JMP		#0036
+      0x880C0101,  //  0028  GETMBR	R3	R0	K1
+      0x8C0C070E,  //  0029  GETMET	R3	R3	K14
+      0x5C140200,  //  002A  MOVE	R5	R1
+      0x7C0C0400,  //  002B  CALL	R3	2
+      0xB80E0E00,  //  002C  GETNGBL	R3	K7
+      0x60100018,  //  002D  GETGBL	R4	G24
+      0x5814000F,  //  002E  LDCONST	R5	K15
+      0x88180510,  //  002F  GETMBR	R6	R2	K16
+      0x881C0511,  //  0030  GETMBR	R7	R2	K17
+      0x88200512,  //  0031  GETMBR	R8	R2	K18
+      0x88240509,  //  0032  GETMBR	R9	R2	K9
+      0x7C100A00,  //  0033  CALL	R4	5
+      0x58140013,  //  0034  LDCONST	R5	K19
+      0x7C0C0400,  //  0035  CALL	R3	2
+      0x70020000,  //  0036  JMP		#0038
+      0x0004030D,  //  0037  ADD	R1	R1	K13
+      0x7001FFC7,  //  0038  JMP		#0001
+      0x80000000,  //  0039  RET	0
     })
   )
 );
@@ -727,7 +722,7 @@ be_local_closure(class_Matter_UDPServer__backoff_time,   /* name */
 extern const bclass be_class_Matter_UDPServer;
 be_local_closure(class_Matter_UDPServer_loop,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    11,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -759,7 +754,7 @@ be_local_closure(class_Matter_UDPServer_loop,   /* name */
     }),
     be_str_weak(loop),
     &be_const_str_solidified,
-    ( &(const binstruction[63]) {  /* code */
+    ( &(const binstruction[62]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
       0x88040301,  //  0001  GETMBR	R1	R1	K1
       0x58080002,  //  0002  LDCONST	R2	K2
@@ -774,7 +769,7 @@ be_local_closure(class_Matter_UDPServer_loop,   /* name */
       0x7C0C0400,  //  000B  CALL	R3	2
       0x4C100000,  //  000C  LDNIL	R4
       0x20100604,  //  000D  NE	R4	R3	R4
-      0x7812002C,  //  000E  JMPF	R4	#003C
+      0x7812002B,  //  000E  JMPF	R4	#003B
       0x8C100306,  //  000F  GETMET	R4	R1	K6
       0x7C100200,  //  0010  CALL	R4	1
       0x90020A03,  //  0011  SETMBR	R0	K5	R3
@@ -787,42 +782,41 @@ be_local_closure(class_Matter_UDPServer_loop,   /* name */
       0x8C180D0B,  //  0018  GETMET	R6	R6	K11
       0x54220003,  //  0019  LDINT	R8	4
       0x7C180400,  //  001A  CALL	R6	2
-      0x781A0008,  //  001B  JMPF	R6	#0025
-      0xB81A1400,  //  001C  GETNGBL	R6	K10
-      0x8C180D0C,  //  001D  GETMET	R6	R6	K12
-      0x60200018,  //  001E  GETGBL	R8	G24
-      0x5824000D,  //  001F  LDCONST	R9	K13
-      0x5C280800,  //  0020  MOVE	R10	R4
-      0x5C2C0A00,  //  0021  MOVE	R11	R5
-      0x7C200600,  //  0022  CALL	R8	3
-      0x54260003,  //  0023  LDINT	R9	4
-      0x7C180600,  //  0024  CALL	R6	3
-      0x8818010E,  //  0025  GETMBR	R6	R0	K14
-      0x781A0007,  //  0026  JMPF	R6	#002F
-      0x8C18030C,  //  0027  GETMET	R6	R1	K12
-      0x5820000F,  //  0028  LDCONST	R8	K15
-      0x7C180400,  //  0029  CALL	R6	2
-      0x8C18010E,  //  002A  GETMET	R6	R0	K14
-      0x5C200600,  //  002B  MOVE	R8	R3
-      0x5C240800,  //  002C  MOVE	R9	R4
-      0x5C280A00,  //  002D  MOVE	R10	R5
-      0x7C180800,  //  002E  CALL	R6	4
-      0x8C180310,  //  002F  GETMET	R6	R1	K16
-      0x58200011,  //  0030  LDCONST	R8	K17
-      0x7C180400,  //  0031  CALL	R6	2
-      0x88180112,  //  0032  GETMBR	R6	R0	K18
-      0x14180406,  //  0033  LT	R6	R2	R6
-      0x781A0004,  //  0034  JMPF	R6	#003A
-      0x88180103,  //  0035  GETMBR	R6	R0	K3
-      0x8C180D04,  //  0036  GETMET	R6	R6	K4
-      0x7C180200,  //  0037  CALL	R6	1
-      0x5C0C0C00,  //  0038  MOVE	R3	R6
-      0x70020000,  //  0039  JMP		#003B
-      0x4C0C0000,  //  003A  LDNIL	R3
-      0x7001FFCF,  //  003B  JMP		#000C
-      0x8C100113,  //  003C  GETMET	R4	R0	K19
-      0x7C100200,  //  003D  CALL	R4	1
-      0x80000000,  //  003E  RET	0
+      0x781A0007,  //  001B  JMPF	R6	#0024
+      0xB81A1800,  //  001C  GETNGBL	R6	K12
+      0x601C0018,  //  001D  GETGBL	R7	G24
+      0x5820000D,  //  001E  LDCONST	R8	K13
+      0x5C240800,  //  001F  MOVE	R9	R4
+      0x5C280A00,  //  0020  MOVE	R10	R5
+      0x7C1C0600,  //  0021  CALL	R7	3
+      0x54220003,  //  0022  LDINT	R8	4
+      0x7C180400,  //  0023  CALL	R6	2
+      0x8818010E,  //  0024  GETMBR	R6	R0	K14
+      0x781A0007,  //  0025  JMPF	R6	#002E
+      0x8C18030C,  //  0026  GETMET	R6	R1	K12
+      0x5820000F,  //  0027  LDCONST	R8	K15
+      0x7C180400,  //  0028  CALL	R6	2
+      0x8C18010E,  //  0029  GETMET	R6	R0	K14
+      0x5C200600,  //  002A  MOVE	R8	R3
+      0x5C240800,  //  002B  MOVE	R9	R4
+      0x5C280A00,  //  002C  MOVE	R10	R5
+      0x7C180800,  //  002D  CALL	R6	4
+      0x8C180310,  //  002E  GETMET	R6	R1	K16
+      0x58200011,  //  002F  LDCONST	R8	K17
+      0x7C180400,  //  0030  CALL	R6	2
+      0x88180112,  //  0031  GETMBR	R6	R0	K18
+      0x14180406,  //  0032  LT	R6	R2	R6
+      0x781A0004,  //  0033  JMPF	R6	#0039
+      0x88180103,  //  0034  GETMBR	R6	R0	K3
+      0x8C180D04,  //  0035  GETMET	R6	R6	K4
+      0x7C180200,  //  0036  CALL	R6	1
+      0x5C0C0C00,  //  0037  MOVE	R3	R6
+      0x70020000,  //  0038  JMP		#003A
+      0x4C0C0000,  //  0039  LDNIL	R3
+      0x7001FFD0,  //  003A  JMP		#000C
+      0x8C100113,  //  003B  GETMET	R4	R0	K19
+      0x7C100200,  //  003C  CALL	R4	1
+      0x80000000,  //  003D  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
@@ -1143,7 +1143,7 @@ be_local_closure(class_Matter_UI_show_remote_autoconf,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_UI, 
     1,                          /* has constants */
-    ( &(const bvalue[47]) {     /* constants */
+    ( &(const bvalue[46]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_nested_str_weak(json),
     /* K2   */  be_nested_str_weak(),
@@ -1158,43 +1158,42 @@ be_local_closure(class_Matter_UI_show_remote_autoconf,   /* name */
     /* K11  */  be_nested_str_weak(StatusSNS),
     /* K12  */  be_nested_str_weak(Status_X2011),
     /* K13  */  be_nested_str_weak(StatusSTS),
-    /* K14  */  be_nested_str_weak(tasmota),
-    /* K15  */  be_nested_str_weak(log),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20probed_X20_X27_X25s_X27_X20status10_X3D_X25s_X20satus11_X3D_X25s),
-    /* K17  */  be_const_int(3),
-    /* K18  */  be_nested_str_weak(generate_config_from_status),
-    /* K19  */  be_nested_str_weak(show_plugins_hints_js),
-    /* K20  */  be_nested_str_weak(_CLASSES_TYPES2),
-    /* K21  */  be_nested_str_weak(content_send),
-    /* K22  */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20Remote_X20Device_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3EAdd_X20Remote_X20sensor_X20or_X20device_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
-    /* K23  */  be_nested_str_weak(html_escape),
-    /* K24  */  be_nested_str_weak(_X3Cp_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Fp_X3E),
-    /* K25  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E_X3Ctr_X3E_X3Ctd_X20width_X3D_X27100_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EName_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EType_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EParameter_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-    /* K26  */  be_nested_str_weak(_X3Cinput_X20name_X3D_X27url_X27_X20type_X3D_X27hidden_X27_X20value_X3D_X27_X25s_X27_X3E),
-    /* K27  */  be_const_int(0),
-    /* K28  */  be_nested_str_weak(type),
-    /* K29  */  be_nested_str_weak(http_),
-    /* K30  */  be_nested_str_weak(device),
-    /* K31  */  be_nested_str_weak(plugins_classes),
-    /* K32  */  be_nested_str_weak(ui_conf_to_string),
-    /* K33  */  be_nested_str_weak(ARG_HINT),
-    /* K34  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X3E_X3C_X2Ftd_X3E),
-    /* K35  */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cselect_X20name_X3D_X27pi_X25i_X27_X20onchange_X3D_X27otm_X28_X22arg_X25i_X22_X2Cthis_X2Evalue_X29_X27_X3E),
-    /* K36  */  be_nested_str_weak(plugin_option),
-    /* K37  */  be_nested_str_weak(_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E),
-    /* K38  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X25i_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X20placeholder_X3D_X27_X25s_X27_X20title_X3D_X27_X25s_X27_X3E),
-    /* K39  */  be_nested_str_weak(_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
-    /* K40  */  be_const_int(1),
-    /* K41  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X25i_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X3E),
-    /* K42  */  be_nested_str_weak(_X3C_X2Ftable_X3E),
-    /* K43  */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E),
-    /* K44  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27addrem_X27_X20class_X3D_X27button_X20bgrn_X27_X3EAdd_X20endpoints_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E),
-    /* K45  */  be_nested_str_weak(_X3C_X2Fform_X3E_X3C_X2Ffieldset_X3E),
-    /* K46  */  be_nested_str_weak(_X3Cp_X3E_X3Cb_X3EUnable_X20to_X20connect_X20to_X20_X27_X25s_X27_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
+    /* K14  */  be_nested_str_weak(log),
+    /* K15  */  be_nested_str_weak(MTR_X3A_X20probed_X20_X27_X25s_X27_X20status10_X3D_X25s_X20satus11_X3D_X25s),
+    /* K16  */  be_const_int(3),
+    /* K17  */  be_nested_str_weak(generate_config_from_status),
+    /* K18  */  be_nested_str_weak(show_plugins_hints_js),
+    /* K19  */  be_nested_str_weak(_CLASSES_TYPES2),
+    /* K20  */  be_nested_str_weak(content_send),
+    /* K21  */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3BMatter_X20Remote_X20Device_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3EAdd_X20Remote_X20sensor_X20or_X20device_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
+    /* K22  */  be_nested_str_weak(html_escape),
+    /* K23  */  be_nested_str_weak(_X3Cp_X3E_X26_X23x1F517_X3B_X20_X3Ca_X20target_X3D_X27_blank_X27_X20href_X3D_X22http_X3A_X2F_X2F_X25s_X2F_X3F_X22_X3E_X25s_X3C_X2Fa_X3E_X3C_X2Fp_X3E),
+    /* K24  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X3E_X3Ctable_X20style_X3D_X27width_X3A100_X25_X27_X3E_X3Ctr_X3E_X3Ctd_X20width_X3D_X27100_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EName_X3C_X2Ftd_X3E_X3Ctd_X20width_X3D_X27115_X27_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EType_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3EParameter_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+    /* K25  */  be_nested_str_weak(_X3Cinput_X20name_X3D_X27url_X27_X20type_X3D_X27hidden_X27_X20value_X3D_X27_X25s_X27_X3E),
+    /* K26  */  be_const_int(0),
+    /* K27  */  be_nested_str_weak(type),
+    /* K28  */  be_nested_str_weak(http_),
+    /* K29  */  be_nested_str_weak(device),
+    /* K30  */  be_nested_str_weak(plugins_classes),
+    /* K31  */  be_nested_str_weak(ui_conf_to_string),
+    /* K32  */  be_nested_str_weak(ARG_HINT),
+    /* K33  */  be_nested_str_weak(_X3Ctr_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cinput_X20type_X3D_X27text_X27_X20name_X3D_X27nam_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X27_X20placeholder_X3D_X27_X28optional_X29_X27_X3E_X3C_X2Ftd_X3E),
+    /* K34  */  be_nested_str_weak(_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E_X3Cselect_X20name_X3D_X27pi_X25i_X27_X20onchange_X3D_X27otm_X28_X22arg_X25i_X22_X2Cthis_X2Evalue_X29_X27_X3E),
+    /* K35  */  be_nested_str_weak(plugin_option),
+    /* K36  */  be_nested_str_weak(_X3C_X2Fselect_X3E_X3C_X2Ftd_X3E_X3Ctd_X20style_X3D_X27font_X2Dsize_X3Asmaller_X3B_X27_X3E),
+    /* K37  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X25i_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X20placeholder_X3D_X27_X25s_X27_X20title_X3D_X27_X25s_X27_X3E),
+    /* K38  */  be_nested_str_weak(_X3C_X2Ftd_X3E_X3C_X2Ftr_X3E),
+    /* K39  */  be_const_int(1),
+    /* K40  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27text_X27_X20id_X3D_X27arg_X25i_X27_X20name_X3D_X27arg_X25i_X27_X20size_X3D_X271_X27_X20value_X3D_X27_X25s_X27_X3E),
+    /* K41  */  be_nested_str_weak(_X3C_X2Ftable_X3E),
+    /* K42  */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27display_X3A_X20block_X3B_X27_X3E_X3C_X2Fdiv_X3E),
+    /* K43  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27addrem_X27_X20class_X3D_X27button_X20bgrn_X27_X3EAdd_X20endpoints_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E),
+    /* K44  */  be_nested_str_weak(_X3C_X2Fform_X3E_X3C_X2Ffieldset_X3E),
+    /* K45  */  be_nested_str_weak(_X3Cp_X3E_X3Cb_X3EUnable_X20to_X20connect_X20to_X20_X27_X25s_X27_X3C_X2Fb_X3E_X3C_X2Fp_X3E),
     }),
     be_str_weak(show_remote_autoconf),
     &be_const_str_solidified,
-    ( &(const binstruction[230]) {  /* code */
+    ( &(const binstruction[229]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0xA40E0200,  //  0001  IMPORT	R3	K1
       0x1C100302,  //  0002  EQ	R4	R1	K2
@@ -1252,179 +1251,178 @@ be_local_closure(class_Matter_UI_show_remote_autoconf,   /* name */
       0x5C1C1000,  //  0036  MOVE	R7	R8
       0x4C200000,  //  0037  LDNIL	R8
       0x20200C08,  //  0038  NE	R8	R6	R8
-      0x782200A2,  //  0039  JMPF	R8	#00DD
+      0x782200A1,  //  0039  JMPF	R8	#00DC
       0x4C200000,  //  003A  LDNIL	R8
       0x20200E08,  //  003B  NE	R8	R7	R8
-      0x7822009F,  //  003C  JMPF	R8	#00DD
+      0x7822009E,  //  003C  JMPF	R8	#00DC
       0xB8221C00,  //  003D  GETNGBL	R8	K14
-      0x8C20110F,  //  003E  GETMET	R8	R8	K15
-      0x60280018,  //  003F  GETGBL	R10	G24
-      0x582C0010,  //  0040  LDCONST	R11	K16
-      0x5C300200,  //  0041  MOVE	R12	R1
-      0x60340008,  //  0042  GETGBL	R13	G8
-      0x5C380C00,  //  0043  MOVE	R14	R6
-      0x7C340200,  //  0044  CALL	R13	1
-      0x60380008,  //  0045  GETGBL	R14	G8
-      0x5C3C0E00,  //  0046  MOVE	R15	R7
-      0x7C380200,  //  0047  CALL	R14	1
-      0x7C280800,  //  0048  CALL	R10	4
-      0x582C0011,  //  0049  LDCONST	R11	K17
-      0x7C200600,  //  004A  CALL	R8	3
-      0x8C200112,  //  004B  GETMET	R8	R0	K18
-      0x5C280C00,  //  004C  MOVE	R10	R6
-      0x5C2C0E00,  //  004D  MOVE	R11	R7
-      0x7C200600,  //  004E  CALL	R8	3
-      0x8C240113,  //  004F  GETMET	R9	R0	K19
-      0x882C0114,  //  0050  GETMBR	R11	R0	K20
-      0x7C240400,  //  0051  CALL	R9	2
-      0x8C240515,  //  0052  GETMET	R9	R2	K21
-      0x582C0016,  //  0053  LDCONST	R11	K22
-      0x7C240400,  //  0054  CALL	R9	2
-      0x8C240517,  //  0055  GETMET	R9	R2	K23
-      0x5C2C0200,  //  0056  MOVE	R11	R1
-      0x7C240400,  //  0057  CALL	R9	2
-      0x8C280515,  //  0058  GETMET	R10	R2	K21
-      0x60300018,  //  0059  GETGBL	R12	G24
-      0x58340018,  //  005A  LDCONST	R13	K24
-      0x5C381200,  //  005B  MOVE	R14	R9
-      0x5C3C1200,  //  005C  MOVE	R15	R9
-      0x7C300600,  //  005D  CALL	R12	3
-      0x7C280400,  //  005E  CALL	R10	2
-      0x8C280515,  //  005F  GETMET	R10	R2	K21
-      0x58300019,  //  0060  LDCONST	R12	K25
-      0x7C280400,  //  0061  CALL	R10	2
-      0x8C280515,  //  0062  GETMET	R10	R2	K21
-      0x60300018,  //  0063  GETGBL	R12	G24
-      0x5834001A,  //  0064  LDCONST	R13	K26
-      0x8C380517,  //  0065  GETMET	R14	R2	K23
-      0x5C400200,  //  0066  MOVE	R16	R1
-      0x7C380400,  //  0067  CALL	R14	2
-      0x7C300400,  //  0068  CALL	R12	2
-      0x7C280400,  //  0069  CALL	R10	2
-      0x5828001B,  //  006A  LDCONST	R10	K27
-      0x602C000C,  //  006B  GETGBL	R11	G12
-      0x5C301000,  //  006C  MOVE	R12	R8
-      0x7C2C0200,  //  006D  CALL	R11	1
-      0x142C140B,  //  006E  LT	R11	R10	R11
-      0x782E0040,  //  006F  JMPF	R11	#00B1
-      0x942C100A,  //  0070  GETIDX	R11	R8	R10
-      0x8C30170A,  //  0071  GETMET	R12	R11	K10
-      0x5838001C,  //  0072  LDCONST	R14	K28
-      0x583C0002,  //  0073  LDCONST	R15	K2
-      0x7C300600,  //  0074  CALL	R12	3
-      0x20341902,  //  0075  NE	R13	R12	K2
-      0x78360000,  //  0076  JMPF	R13	#0078
-      0x00323A0C,  //  0077  ADD	R12	K29	R12
-      0x8834011E,  //  0078  GETMBR	R13	R0	K30
-      0x88341B1F,  //  0079  GETMBR	R13	R13	K31
-      0x8C341B0A,  //  007A  GETMET	R13	R13	K10
-      0x5C3C1800,  //  007B  MOVE	R15	R12
-      0x7C340400,  //  007C  CALL	R13	2
-      0x58380002,  //  007D  LDCONST	R14	K2
-      0x583C0002,  //  007E  LDCONST	R15	K2
-      0x4C400000,  //  007F  LDNIL	R16
-      0x20401A10,  //  0080  NE	R16	R13	R16
-      0x78420005,  //  0081  JMPF	R16	#0088
-      0x8C401B20,  //  0082  GETMET	R16	R13	K32
-      0x5C481A00,  //  0083  MOVE	R18	R13
-      0x5C4C1600,  //  0084  MOVE	R19	R11
-      0x7C400600,  //  0085  CALL	R16	3
-      0x5C382000,  //  0086  MOVE	R14	R16
-      0x883C1B21,  //  0087  GETMBR	R15	R13	K33
-      0x8C400515,  //  0088  GETMET	R16	R2	K21
-      0x60480018,  //  0089  GETGBL	R18	G24
-      0x584C0022,  //  008A  LDCONST	R19	K34
-      0x5C501400,  //  008B  MOVE	R20	R10
-      0x7C480400,  //  008C  CALL	R18	2
-      0x7C400400,  //  008D  CALL	R16	2
-      0x8C400515,  //  008E  GETMET	R16	R2	K21
-      0x60480018,  //  008F  GETGBL	R18	G24
-      0x584C0023,  //  0090  LDCONST	R19	K35
-      0x5C501400,  //  0091  MOVE	R20	R10
-      0x5C541400,  //  0092  MOVE	R21	R10
-      0x7C480600,  //  0093  CALL	R18	3
-      0x7C400400,  //  0094  CALL	R16	2
-      0x8C400124,  //  0095  GETMET	R16	R0	K36
-      0x5C481800,  //  0096  MOVE	R18	R12
-      0x884C0114,  //  0097  GETMBR	R19	R0	K20
-      0x7C400600,  //  0098  CALL	R16	3
-      0x8C400515,  //  0099  GETMET	R16	R2	K21
-      0x58480025,  //  009A  LDCONST	R18	K37
-      0x7C400400,  //  009B  CALL	R16	2
-      0x8C400515,  //  009C  GETMET	R16	R2	K21
-      0x60480018,  //  009D  GETGBL	R18	G24
-      0x584C0026,  //  009E  LDCONST	R19	K38
-      0x5C501400,  //  009F  MOVE	R20	R10
-      0x5C541400,  //  00A0  MOVE	R21	R10
-      0x8C580517,  //  00A1  GETMET	R22	R2	K23
-      0x5C601C00,  //  00A2  MOVE	R24	R14
-      0x7C580400,  //  00A3  CALL	R22	2
-      0x8C5C0517,  //  00A4  GETMET	R23	R2	K23
-      0x5C641E00,  //  00A5  MOVE	R25	R15
-      0x7C5C0400,  //  00A6  CALL	R23	2
-      0x8C600517,  //  00A7  GETMET	R24	R2	K23
-      0x5C681E00,  //  00A8  MOVE	R26	R15
-      0x7C600400,  //  00A9  CALL	R24	2
-      0x7C480C00,  //  00AA  CALL	R18	6
-      0x7C400400,  //  00AB  CALL	R16	2
-      0x8C400515,  //  00AC  GETMET	R16	R2	K21
-      0x58480027,  //  00AD  LDCONST	R18	K39
-      0x7C400400,  //  00AE  CALL	R16	2
-      0x00281528,  //  00AF  ADD	R10	R10	K40
-      0x7001FFB9,  //  00B0  JMP		#006B
-      0x8C2C0515,  //  00B1  GETMET	R11	R2	K21
-      0x60340018,  //  00B2  GETGBL	R13	G24
-      0x58380022,  //  00B3  LDCONST	R14	K34
-      0x5C3C1400,  //  00B4  MOVE	R15	R10
-      0x7C340400,  //  00B5  CALL	R13	2
-      0x7C2C0400,  //  00B6  CALL	R11	2
-      0x8C2C0515,  //  00B7  GETMET	R11	R2	K21
-      0x60340018,  //  00B8  GETGBL	R13	G24
-      0x58380023,  //  00B9  LDCONST	R14	K35
-      0x5C3C1400,  //  00BA  MOVE	R15	R10
-      0x5C401400,  //  00BB  MOVE	R16	R10
-      0x7C340600,  //  00BC  CALL	R13	3
-      0x7C2C0400,  //  00BD  CALL	R11	2
-      0x8C2C0124,  //  00BE  GETMET	R11	R0	K36
-      0x58340002,  //  00BF  LDCONST	R13	K2
-      0x88380114,  //  00C0  GETMBR	R14	R0	K20
-      0x7C2C0600,  //  00C1  CALL	R11	3
-      0x8C2C0515,  //  00C2  GETMET	R11	R2	K21
-      0x58340025,  //  00C3  LDCONST	R13	K37
-      0x7C2C0400,  //  00C4  CALL	R11	2
-      0x8C2C0515,  //  00C5  GETMET	R11	R2	K21
-      0x60340018,  //  00C6  GETGBL	R13	G24
-      0x58380029,  //  00C7  LDCONST	R14	K41
-      0x5C3C1400,  //  00C8  MOVE	R15	R10
-      0x5C401400,  //  00C9  MOVE	R16	R10
-      0x58440002,  //  00CA  LDCONST	R17	K2
-      0x7C340800,  //  00CB  CALL	R13	4
-      0x7C2C0400,  //  00CC  CALL	R11	2
-      0x8C2C0515,  //  00CD  GETMET	R11	R2	K21
-      0x58340027,  //  00CE  LDCONST	R13	K39
-      0x7C2C0400,  //  00CF  CALL	R11	2
-      0x8C2C0515,  //  00D0  GETMET	R11	R2	K21
-      0x5834002A,  //  00D1  LDCONST	R13	K42
-      0x7C2C0400,  //  00D2  CALL	R11	2
-      0x8C2C0515,  //  00D3  GETMET	R11	R2	K21
-      0x5834002B,  //  00D4  LDCONST	R13	K43
-      0x7C2C0400,  //  00D5  CALL	R11	2
-      0x8C2C0515,  //  00D6  GETMET	R11	R2	K21
-      0x5834002C,  //  00D7  LDCONST	R13	K44
-      0x7C2C0400,  //  00D8  CALL	R11	2
-      0x8C2C0515,  //  00D9  GETMET	R11	R2	K21
-      0x5834002D,  //  00DA  LDCONST	R13	K45
-      0x7C2C0400,  //  00DB  CALL	R11	2
-      0x70020007,  //  00DC  JMP		#00E5
-      0x8C200515,  //  00DD  GETMET	R8	R2	K21
-      0x60280018,  //  00DE  GETGBL	R10	G24
-      0x582C002E,  //  00DF  LDCONST	R11	K46
-      0x8C300517,  //  00E0  GETMET	R12	R2	K23
-      0x5C380200,  //  00E1  MOVE	R14	R1
-      0x7C300400,  //  00E2  CALL	R12	2
-      0x7C280400,  //  00E3  CALL	R10	2
-      0x7C200400,  //  00E4  CALL	R8	2
-      0x80000000,  //  00E5  RET	0
+      0x60240018,  //  003E  GETGBL	R9	G24
+      0x5828000F,  //  003F  LDCONST	R10	K15
+      0x5C2C0200,  //  0040  MOVE	R11	R1
+      0x60300008,  //  0041  GETGBL	R12	G8
+      0x5C340C00,  //  0042  MOVE	R13	R6
+      0x7C300200,  //  0043  CALL	R12	1
+      0x60340008,  //  0044  GETGBL	R13	G8
+      0x5C380E00,  //  0045  MOVE	R14	R7
+      0x7C340200,  //  0046  CALL	R13	1
+      0x7C240800,  //  0047  CALL	R9	4
+      0x58280010,  //  0048  LDCONST	R10	K16
+      0x7C200400,  //  0049  CALL	R8	2
+      0x8C200111,  //  004A  GETMET	R8	R0	K17
+      0x5C280C00,  //  004B  MOVE	R10	R6
+      0x5C2C0E00,  //  004C  MOVE	R11	R7
+      0x7C200600,  //  004D  CALL	R8	3
+      0x8C240112,  //  004E  GETMET	R9	R0	K18
+      0x882C0113,  //  004F  GETMBR	R11	R0	K19
+      0x7C240400,  //  0050  CALL	R9	2
+      0x8C240514,  //  0051  GETMET	R9	R2	K20
+      0x582C0015,  //  0052  LDCONST	R11	K21
+      0x7C240400,  //  0053  CALL	R9	2
+      0x8C240516,  //  0054  GETMET	R9	R2	K22
+      0x5C2C0200,  //  0055  MOVE	R11	R1
+      0x7C240400,  //  0056  CALL	R9	2
+      0x8C280514,  //  0057  GETMET	R10	R2	K20
+      0x60300018,  //  0058  GETGBL	R12	G24
+      0x58340017,  //  0059  LDCONST	R13	K23
+      0x5C381200,  //  005A  MOVE	R14	R9
+      0x5C3C1200,  //  005B  MOVE	R15	R9
+      0x7C300600,  //  005C  CALL	R12	3
+      0x7C280400,  //  005D  CALL	R10	2
+      0x8C280514,  //  005E  GETMET	R10	R2	K20
+      0x58300018,  //  005F  LDCONST	R12	K24
+      0x7C280400,  //  0060  CALL	R10	2
+      0x8C280514,  //  0061  GETMET	R10	R2	K20
+      0x60300018,  //  0062  GETGBL	R12	G24
+      0x58340019,  //  0063  LDCONST	R13	K25
+      0x8C380516,  //  0064  GETMET	R14	R2	K22
+      0x5C400200,  //  0065  MOVE	R16	R1
+      0x7C380400,  //  0066  CALL	R14	2
+      0x7C300400,  //  0067  CALL	R12	2
+      0x7C280400,  //  0068  CALL	R10	2
+      0x5828001A,  //  0069  LDCONST	R10	K26
+      0x602C000C,  //  006A  GETGBL	R11	G12
+      0x5C301000,  //  006B  MOVE	R12	R8
+      0x7C2C0200,  //  006C  CALL	R11	1
+      0x142C140B,  //  006D  LT	R11	R10	R11
+      0x782E0040,  //  006E  JMPF	R11	#00B0
+      0x942C100A,  //  006F  GETIDX	R11	R8	R10
+      0x8C30170A,  //  0070  GETMET	R12	R11	K10
+      0x5838001B,  //  0071  LDCONST	R14	K27
+      0x583C0002,  //  0072  LDCONST	R15	K2
+      0x7C300600,  //  0073  CALL	R12	3
+      0x20341902,  //  0074  NE	R13	R12	K2
+      0x78360000,  //  0075  JMPF	R13	#0077
+      0x0032380C,  //  0076  ADD	R12	K28	R12
+      0x8834011D,  //  0077  GETMBR	R13	R0	K29
+      0x88341B1E,  //  0078  GETMBR	R13	R13	K30
+      0x8C341B0A,  //  0079  GETMET	R13	R13	K10
+      0x5C3C1800,  //  007A  MOVE	R15	R12
+      0x7C340400,  //  007B  CALL	R13	2
+      0x58380002,  //  007C  LDCONST	R14	K2
+      0x583C0002,  //  007D  LDCONST	R15	K2
+      0x4C400000,  //  007E  LDNIL	R16
+      0x20401A10,  //  007F  NE	R16	R13	R16
+      0x78420005,  //  0080  JMPF	R16	#0087
+      0x8C401B1F,  //  0081  GETMET	R16	R13	K31
+      0x5C481A00,  //  0082  MOVE	R18	R13
+      0x5C4C1600,  //  0083  MOVE	R19	R11
+      0x7C400600,  //  0084  CALL	R16	3
+      0x5C382000,  //  0085  MOVE	R14	R16
+      0x883C1B20,  //  0086  GETMBR	R15	R13	K32
+      0x8C400514,  //  0087  GETMET	R16	R2	K20
+      0x60480018,  //  0088  GETGBL	R18	G24
+      0x584C0021,  //  0089  LDCONST	R19	K33
+      0x5C501400,  //  008A  MOVE	R20	R10
+      0x7C480400,  //  008B  CALL	R18	2
+      0x7C400400,  //  008C  CALL	R16	2
+      0x8C400514,  //  008D  GETMET	R16	R2	K20
+      0x60480018,  //  008E  GETGBL	R18	G24
+      0x584C0022,  //  008F  LDCONST	R19	K34
+      0x5C501400,  //  0090  MOVE	R20	R10
+      0x5C541400,  //  0091  MOVE	R21	R10
+      0x7C480600,  //  0092  CALL	R18	3
+      0x7C400400,  //  0093  CALL	R16	2
+      0x8C400123,  //  0094  GETMET	R16	R0	K35
+      0x5C481800,  //  0095  MOVE	R18	R12
+      0x884C0113,  //  0096  GETMBR	R19	R0	K19
+      0x7C400600,  //  0097  CALL	R16	3
+      0x8C400514,  //  0098  GETMET	R16	R2	K20
+      0x58480024,  //  0099  LDCONST	R18	K36
+      0x7C400400,  //  009A  CALL	R16	2
+      0x8C400514,  //  009B  GETMET	R16	R2	K20
+      0x60480018,  //  009C  GETGBL	R18	G24
+      0x584C0025,  //  009D  LDCONST	R19	K37
+      0x5C501400,  //  009E  MOVE	R20	R10
+      0x5C541400,  //  009F  MOVE	R21	R10
+      0x8C580516,  //  00A0  GETMET	R22	R2	K22
+      0x5C601C00,  //  00A1  MOVE	R24	R14
+      0x7C580400,  //  00A2  CALL	R22	2
+      0x8C5C0516,  //  00A3  GETMET	R23	R2	K22
+      0x5C641E00,  //  00A4  MOVE	R25	R15
+      0x7C5C0400,  //  00A5  CALL	R23	2
+      0x8C600516,  //  00A6  GETMET	R24	R2	K22
+      0x5C681E00,  //  00A7  MOVE	R26	R15
+      0x7C600400,  //  00A8  CALL	R24	2
+      0x7C480C00,  //  00A9  CALL	R18	6
+      0x7C400400,  //  00AA  CALL	R16	2
+      0x8C400514,  //  00AB  GETMET	R16	R2	K20
+      0x58480026,  //  00AC  LDCONST	R18	K38
+      0x7C400400,  //  00AD  CALL	R16	2
+      0x00281527,  //  00AE  ADD	R10	R10	K39
+      0x7001FFB9,  //  00AF  JMP		#006A
+      0x8C2C0514,  //  00B0  GETMET	R11	R2	K20
+      0x60340018,  //  00B1  GETGBL	R13	G24
+      0x58380021,  //  00B2  LDCONST	R14	K33
+      0x5C3C1400,  //  00B3  MOVE	R15	R10
+      0x7C340400,  //  00B4  CALL	R13	2
+      0x7C2C0400,  //  00B5  CALL	R11	2
+      0x8C2C0514,  //  00B6  GETMET	R11	R2	K20
+      0x60340018,  //  00B7  GETGBL	R13	G24
+      0x58380022,  //  00B8  LDCONST	R14	K34
+      0x5C3C1400,  //  00B9  MOVE	R15	R10
+      0x5C401400,  //  00BA  MOVE	R16	R10
+      0x7C340600,  //  00BB  CALL	R13	3
+      0x7C2C0400,  //  00BC  CALL	R11	2
+      0x8C2C0123,  //  00BD  GETMET	R11	R0	K35
+      0x58340002,  //  00BE  LDCONST	R13	K2
+      0x88380113,  //  00BF  GETMBR	R14	R0	K19
+      0x7C2C0600,  //  00C0  CALL	R11	3
+      0x8C2C0514,  //  00C1  GETMET	R11	R2	K20
+      0x58340024,  //  00C2  LDCONST	R13	K36
+      0x7C2C0400,  //  00C3  CALL	R11	2
+      0x8C2C0514,  //  00C4  GETMET	R11	R2	K20
+      0x60340018,  //  00C5  GETGBL	R13	G24
+      0x58380028,  //  00C6  LDCONST	R14	K40
+      0x5C3C1400,  //  00C7  MOVE	R15	R10
+      0x5C401400,  //  00C8  MOVE	R16	R10
+      0x58440002,  //  00C9  LDCONST	R17	K2
+      0x7C340800,  //  00CA  CALL	R13	4
+      0x7C2C0400,  //  00CB  CALL	R11	2
+      0x8C2C0514,  //  00CC  GETMET	R11	R2	K20
+      0x58340026,  //  00CD  LDCONST	R13	K38
+      0x7C2C0400,  //  00CE  CALL	R11	2
+      0x8C2C0514,  //  00CF  GETMET	R11	R2	K20
+      0x58340029,  //  00D0  LDCONST	R13	K41
+      0x7C2C0400,  //  00D1  CALL	R11	2
+      0x8C2C0514,  //  00D2  GETMET	R11	R2	K20
+      0x5834002A,  //  00D3  LDCONST	R13	K42
+      0x7C2C0400,  //  00D4  CALL	R11	2
+      0x8C2C0514,  //  00D5  GETMET	R11	R2	K20
+      0x5834002B,  //  00D6  LDCONST	R13	K43
+      0x7C2C0400,  //  00D7  CALL	R11	2
+      0x8C2C0514,  //  00D8  GETMET	R11	R2	K20
+      0x5834002C,  //  00D9  LDCONST	R13	K44
+      0x7C2C0400,  //  00DA  CALL	R11	2
+      0x70020007,  //  00DB  JMP		#00E4
+      0x8C200514,  //  00DC  GETMET	R8	R2	K20
+      0x60280018,  //  00DD  GETGBL	R10	G24
+      0x582C002D,  //  00DE  LDCONST	R11	K45
+      0x8C300516,  //  00DF  GETMET	R12	R2	K22
+      0x5C380200,  //  00E0  MOVE	R14	R1
+      0x7C300400,  //  00E1  CALL	R12	2
+      0x7C280400,  //  00E2  CALL	R10	2
+      0x7C200400,  //  00E3  CALL	R8	2
+      0x80000000,  //  00E4  RET	0
     })
   )
 );
@@ -2213,7 +2211,7 @@ be_local_closure(class_Matter_UI_show_passcode_form,   /* name */
 extern const bclass be_class_Matter_UI;
 be_local_closure(class_Matter_UI_page_part_ctl,   /* name */
   be_nested_proto(
-    24,                          /* nstack */
+    23,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2230,27 +2228,27 @@ be_local_closure(class_Matter_UI_page_part_ctl,   /* name */
     /* K5   */  be_nested_str_weak(has_arg),
     /* K6   */  be_nested_str_weak(passcode),
     /* K7   */  be_nested_str_weak(discriminator),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X2Fmatterc_X20received_X20_X27_X25s_X27_X20command),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(device),
-    /* K13  */  be_nested_str_weak(root_passcode),
-    /* K14  */  be_nested_str_weak(arg),
-    /* K15  */  be_nested_str_weak(root_discriminator),
-    /* K16  */  be_nested_str_weak(ipv4only),
-    /* K17  */  be_nested_str_weak(ipv4),
-    /* K18  */  be_nested_str_weak(on),
-    /* K19  */  be_nested_str_weak(save_param),
-    /* K20  */  be_nested_str_weak(redirect),
-    /* K21  */  be_nested_str_weak(_X2F_X3Frst_X3D),
-    /* K22  */  be_nested_str_weak(save),
-    /* K23  */  be_nested_str_weak(menable),
-    /* K24  */  be_nested_str_weak(comm),
-    /* K25  */  be_nested_str_weak(nobridge),
-    /* K26  */  be_nested_str_weak(disable_bridge_mode),
-    /* K27  */  be_nested_str_weak(matter_enabled),
-    /* K28  */  be_nested_str_weak(enable),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X2Fmatterc_X20received_X20_X27_X25s_X27_X20command),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(device),
+    /* K12  */  be_nested_str_weak(root_passcode),
+    /* K13  */  be_nested_str_weak(arg),
+    /* K14  */  be_nested_str_weak(root_discriminator),
+    /* K15  */  be_nested_str_weak(ipv4only),
+    /* K16  */  be_nested_str_weak(ipv4),
+    /* K17  */  be_nested_str_weak(on),
+    /* K18  */  be_nested_str_weak(save_param),
+    /* K19  */  be_nested_str_weak(redirect),
+    /* K20  */  be_nested_str_weak(_X2F_X3Frst_X3D),
+    /* K21  */  be_nested_str_weak(save),
+    /* K22  */  be_nested_str_weak(menable),
+    /* K23  */  be_nested_str_weak(comm),
+    /* K24  */  be_nested_str_weak(nobridge),
+    /* K25  */  be_nested_str_weak(disable_bridge_mode),
+    /* K26  */  be_nested_str_weak(matter_enabled),
+    /* K27  */  be_nested_str_weak(enable),
+    /* K28  */  be_nested_str_weak(tasmota),
     /* K29  */  be_nested_str_weak(cmd),
     /* K30  */  be_nested_str_weak(SetOption),
     /* K31  */  be_nested_str_weak(matter),
@@ -2326,7 +2324,7 @@ be_local_closure(class_Matter_UI_page_part_ctl,   /* name */
     }),
     be_str_weak(page_part_ctl),
     &be_const_str_solidified,
-    ( &(const binstruction[675]) {  /* code */
+    ( &(const binstruction[659]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x8C080301,  //  0001  GETMET	R2	R1	K1
       0x7C080200,  //  0002  CALL	R2	1
@@ -2337,7 +2335,7 @@ be_local_closure(class_Matter_UI_page_part_ctl,   /* name */
       0xA40E0600,  //  0007  IMPORT	R3	K3
       0xA4120800,  //  0008  IMPORT	R4	K4
       0x4C140000,  //  0009  LDNIL	R5
-      0xA8020278,  //  000A  EXBLK	0	#0284
+      0xA8020269,  //  000A  EXBLK	0	#0275
       0x8C180305,  //  000B  GETMET	R6	R1	K5
       0x58200006,  //  000C  LDCONST	R8	K6
       0x7C180400,  //  000D  CALL	R6	2
@@ -2345,663 +2343,647 @@ be_local_closure(class_Matter_UI_page_part_ctl,   /* name */
       0x8C180305,  //  000F  GETMET	R6	R1	K5
       0x58200007,  //  0010  LDCONST	R8	K7
       0x7C180400,  //  0011  CALL	R6	2
-      0x781A002A,  //  0012  JMPF	R6	#003E
+      0x781A0029,  //  0012  JMPF	R6	#003D
       0xB81A1000,  //  0013  GETNGBL	R6	K8
-      0x8C180D09,  //  0014  GETMET	R6	R6	K9
-      0x60200018,  //  0015  GETGBL	R8	G24
-      0x5824000A,  //  0016  LDCONST	R9	K10
-      0x58280006,  //  0017  LDCONST	R10	K6
-      0x7C200400,  //  0018  CALL	R8	2
-      0x5824000B,  //  0019  LDCONST	R9	K11
-      0x7C180600,  //  001A  CALL	R6	3
-      0x8C180305,  //  001B  GETMET	R6	R1	K5
-      0x58200006,  //  001C  LDCONST	R8	K6
-      0x7C180400,  //  001D  CALL	R6	2
-      0x781A0006,  //  001E  JMPF	R6	#0026
-      0x8818010C,  //  001F  GETMBR	R6	R0	K12
-      0x601C0009,  //  0020  GETGBL	R7	G9
-      0x8C20030E,  //  0021  GETMET	R8	R1	K14
-      0x58280006,  //  0022  LDCONST	R10	K6
-      0x7C200400,  //  0023  CALL	R8	2
-      0x7C1C0200,  //  0024  CALL	R7	1
-      0x901A1A07,  //  0025  SETMBR	R6	K13	R7
-      0x8C180305,  //  0026  GETMET	R6	R1	K5
-      0x58200007,  //  0027  LDCONST	R8	K7
-      0x7C180400,  //  0028  CALL	R6	2
-      0x781A0006,  //  0029  JMPF	R6	#0031
-      0x8818010C,  //  002A  GETMBR	R6	R0	K12
-      0x601C0009,  //  002B  GETGBL	R7	G9
-      0x8C20030E,  //  002C  GETMET	R8	R1	K14
-      0x58280007,  //  002D  LDCONST	R10	K7
-      0x7C200400,  //  002E  CALL	R8	2
-      0x7C1C0200,  //  002F  CALL	R7	1
-      0x901A1E07,  //  0030  SETMBR	R6	K15	R7
-      0x8818010C,  //  0031  GETMBR	R6	R0	K12
-      0x8C1C030E,  //  0032  GETMET	R7	R1	K14
-      0x58240011,  //  0033  LDCONST	R9	K17
-      0x7C1C0400,  //  0034  CALL	R7	2
-      0x1C1C0F12,  //  0035  EQ	R7	R7	K18
-      0x901A2007,  //  0036  SETMBR	R6	K16	R7
-      0x8818010C,  //  0037  GETMBR	R6	R0	K12
-      0x8C180D13,  //  0038  GETMET	R6	R6	K19
-      0x7C180200,  //  0039  CALL	R6	1
-      0x8C180314,  //  003A  GETMET	R6	R1	K20
-      0x58200015,  //  003B  LDCONST	R8	K21
-      0x7C180400,  //  003C  CALL	R6	2
-      0x70020230,  //  003D  JMP		#026F
-      0x8C180305,  //  003E  GETMET	R6	R1	K5
-      0x58200016,  //  003F  LDCONST	R8	K22
-      0x7C180400,  //  0040  CALL	R6	2
-      0x781A0054,  //  0041  JMPF	R6	#0097
-      0x8C180305,  //  0042  GETMET	R6	R1	K5
-      0x58200017,  //  0043  LDCONST	R8	K23
-      0x7C180400,  //  0044  CALL	R6	2
-      0x8C1C0305,  //  0045  GETMET	R7	R1	K5
-      0x58240018,  //  0046  LDCONST	R9	K24
-      0x7C1C0400,  //  0047  CALL	R7	2
-      0x8C20030E,  //  0048  GETMET	R8	R1	K14
-      0x58280019,  //  0049  LDCONST	R10	K25
-      0x7C200400,  //  004A  CALL	R8	2
-      0x1C201112,  //  004B  EQ	R8	R8	K18
-      0x8824010C,  //  004C  GETMBR	R9	R0	K12
-      0x8824131A,  //  004D  GETMBR	R9	R9	K26
-      0x20241208,  //  004E  NE	R9	R9	R8
-      0x78260004,  //  004F  JMPF	R9	#0055
-      0x8824010C,  //  0050  GETMBR	R9	R0	K12
-      0x90263408,  //  0051  SETMBR	R9	K26	R8
-      0x8824010C,  //  0052  GETMBR	R9	R0	K12
-      0x8C241313,  //  0053  GETMET	R9	R9	K19
-      0x7C240200,  //  0054  CALL	R9	1
-      0x8C24011B,  //  0055  GETMET	R9	R0	K27
-      0x7C240200,  //  0056  CALL	R9	1
-      0x20240C09,  //  0057  NE	R9	R6	R9
-      0x78260027,  //  0058  JMPF	R9	#0081
-      0x781A0011,  //  0059  JMPF	R6	#006C
-      0xB8261000,  //  005A  GETNGBL	R9	K8
-      0x8C241309,  //  005B  GETMET	R9	R9	K9
-      0x602C0018,  //  005C  GETGBL	R11	G24
-      0x5830000A,  //  005D  LDCONST	R12	K10
-      0x5834001C,  //  005E  LDCONST	R13	K28
-      0x7C2C0400,  //  005F  CALL	R11	2
-      0x5830000B,  //  0060  LDCONST	R12	K11
-      0x7C240600,  //  0061  CALL	R9	3
-      0xB8261000,  //  0062  GETNGBL	R9	K8
-      0x8C24131D,  //  0063  GETMET	R9	R9	K29
-      0x602C0008,  //  0064  GETGBL	R11	G8
-      0xB8323E00,  //  0065  GETNGBL	R12	K31
-      0x88301920,  //  0066  GETMBR	R12	R12	K32
-      0x7C2C0200,  //  0067  CALL	R11	1
-      0x002E3C0B,  //  0068  ADD	R11	K30	R11
-      0x002C1721,  //  0069  ADD	R11	R11	K33
-      0x7C240400,  //  006A  CALL	R9	2
-      0x70020010,  //  006B  JMP		#007D
-      0xB8261000,  //  006C  GETNGBL	R9	K8
-      0x8C241309,  //  006D  GETMET	R9	R9	K9
-      0x602C0018,  //  006E  GETGBL	R11	G24
-      0x5830000A,  //  006F  LDCONST	R12	K10
-      0x58340022,  //  0070  LDCONST	R13	K34
-      0x7C2C0400,  //  0071  CALL	R11	2
-      0x5830000B,  //  0072  LDCONST	R12	K11
-      0x7C240600,  //  0073  CALL	R9	3
-      0xB8261000,  //  0074  GETNGBL	R9	K8
-      0x8C24131D,  //  0075  GETMET	R9	R9	K29
-      0x602C0008,  //  0076  GETGBL	R11	G8
-      0xB8323E00,  //  0077  GETNGBL	R12	K31
-      0x88301920,  //  0078  GETMBR	R12	R12	K32
-      0x7C2C0200,  //  0079  CALL	R11	1
-      0x002E3C0B,  //  007A  ADD	R11	K30	R11
-      0x002C1723,  //  007B  ADD	R11	R11	K35
+      0x601C0018,  //  0014  GETGBL	R7	G24
+      0x58200009,  //  0015  LDCONST	R8	K9
+      0x58240006,  //  0016  LDCONST	R9	K6
+      0x7C1C0400,  //  0017  CALL	R7	2
+      0x5820000A,  //  0018  LDCONST	R8	K10
+      0x7C180400,  //  0019  CALL	R6	2
+      0x8C180305,  //  001A  GETMET	R6	R1	K5
+      0x58200006,  //  001B  LDCONST	R8	K6
+      0x7C180400,  //  001C  CALL	R6	2
+      0x781A0006,  //  001D  JMPF	R6	#0025
+      0x8818010B,  //  001E  GETMBR	R6	R0	K11
+      0x601C0009,  //  001F  GETGBL	R7	G9
+      0x8C20030D,  //  0020  GETMET	R8	R1	K13
+      0x58280006,  //  0021  LDCONST	R10	K6
+      0x7C200400,  //  0022  CALL	R8	2
+      0x7C1C0200,  //  0023  CALL	R7	1
+      0x901A1807,  //  0024  SETMBR	R6	K12	R7
+      0x8C180305,  //  0025  GETMET	R6	R1	K5
+      0x58200007,  //  0026  LDCONST	R8	K7
+      0x7C180400,  //  0027  CALL	R6	2
+      0x781A0006,  //  0028  JMPF	R6	#0030
+      0x8818010B,  //  0029  GETMBR	R6	R0	K11
+      0x601C0009,  //  002A  GETGBL	R7	G9
+      0x8C20030D,  //  002B  GETMET	R8	R1	K13
+      0x58280007,  //  002C  LDCONST	R10	K7
+      0x7C200400,  //  002D  CALL	R8	2
+      0x7C1C0200,  //  002E  CALL	R7	1
+      0x901A1C07,  //  002F  SETMBR	R6	K14	R7
+      0x8818010B,  //  0030  GETMBR	R6	R0	K11
+      0x8C1C030D,  //  0031  GETMET	R7	R1	K13
+      0x58240010,  //  0032  LDCONST	R9	K16
+      0x7C1C0400,  //  0033  CALL	R7	2
+      0x1C1C0F11,  //  0034  EQ	R7	R7	K17
+      0x901A1E07,  //  0035  SETMBR	R6	K15	R7
+      0x8818010B,  //  0036  GETMBR	R6	R0	K11
+      0x8C180D12,  //  0037  GETMET	R6	R6	K18
+      0x7C180200,  //  0038  CALL	R6	1
+      0x8C180313,  //  0039  GETMET	R6	R1	K19
+      0x58200014,  //  003A  LDCONST	R8	K20
+      0x7C180400,  //  003B  CALL	R6	2
+      0x70020222,  //  003C  JMP		#0260
+      0x8C180305,  //  003D  GETMET	R6	R1	K5
+      0x58200015,  //  003E  LDCONST	R8	K21
+      0x7C180400,  //  003F  CALL	R6	2
+      0x781A0052,  //  0040  JMPF	R6	#0094
+      0x8C180305,  //  0041  GETMET	R6	R1	K5
+      0x58200016,  //  0042  LDCONST	R8	K22
+      0x7C180400,  //  0043  CALL	R6	2
+      0x8C1C0305,  //  0044  GETMET	R7	R1	K5
+      0x58240017,  //  0045  LDCONST	R9	K23
+      0x7C1C0400,  //  0046  CALL	R7	2
+      0x8C20030D,  //  0047  GETMET	R8	R1	K13
+      0x58280018,  //  0048  LDCONST	R10	K24
+      0x7C200400,  //  0049  CALL	R8	2
+      0x1C201111,  //  004A  EQ	R8	R8	K17
+      0x8824010B,  //  004B  GETMBR	R9	R0	K11
+      0x88241319,  //  004C  GETMBR	R9	R9	K25
+      0x20241208,  //  004D  NE	R9	R9	R8
+      0x78260004,  //  004E  JMPF	R9	#0054
+      0x8824010B,  //  004F  GETMBR	R9	R0	K11
+      0x90263208,  //  0050  SETMBR	R9	K25	R8
+      0x8824010B,  //  0051  GETMBR	R9	R0	K11
+      0x8C241312,  //  0052  GETMET	R9	R9	K18
+      0x7C240200,  //  0053  CALL	R9	1
+      0x8C24011A,  //  0054  GETMET	R9	R0	K26
+      0x7C240200,  //  0055  CALL	R9	1
+      0x20240C09,  //  0056  NE	R9	R6	R9
+      0x78260025,  //  0057  JMPF	R9	#007E
+      0x781A0010,  //  0058  JMPF	R6	#006A
+      0xB8261000,  //  0059  GETNGBL	R9	K8
+      0x60280018,  //  005A  GETGBL	R10	G24
+      0x582C0009,  //  005B  LDCONST	R11	K9
+      0x5830001B,  //  005C  LDCONST	R12	K27
+      0x7C280400,  //  005D  CALL	R10	2
+      0x582C000A,  //  005E  LDCONST	R11	K10
+      0x7C240400,  //  005F  CALL	R9	2
+      0xB8263800,  //  0060  GETNGBL	R9	K28
+      0x8C24131D,  //  0061  GETMET	R9	R9	K29
+      0x602C0008,  //  0062  GETGBL	R11	G8
+      0xB8323E00,  //  0063  GETNGBL	R12	K31
+      0x88301920,  //  0064  GETMBR	R12	R12	K32
+      0x7C2C0200,  //  0065  CALL	R11	1
+      0x002E3C0B,  //  0066  ADD	R11	K30	R11
+      0x002C1721,  //  0067  ADD	R11	R11	K33
+      0x7C240400,  //  0068  CALL	R9	2
+      0x7002000F,  //  0069  JMP		#007A
+      0xB8261000,  //  006A  GETNGBL	R9	K8
+      0x60280018,  //  006B  GETGBL	R10	G24
+      0x582C0009,  //  006C  LDCONST	R11	K9
+      0x58300022,  //  006D  LDCONST	R12	K34
+      0x7C280400,  //  006E  CALL	R10	2
+      0x582C000A,  //  006F  LDCONST	R11	K10
+      0x7C240400,  //  0070  CALL	R9	2
+      0xB8263800,  //  0071  GETNGBL	R9	K28
+      0x8C24131D,  //  0072  GETMET	R9	R9	K29
+      0x602C0008,  //  0073  GETGBL	R11	G8
+      0xB8323E00,  //  0074  GETNGBL	R12	K31
+      0x88301920,  //  0075  GETMBR	R12	R12	K32
+      0x7C2C0200,  //  0076  CALL	R11	1
+      0x002E3C0B,  //  0077  ADD	R11	K30	R11
+      0x002C1723,  //  0078  ADD	R11	R11	K35
+      0x7C240400,  //  0079  CALL	R9	2
+      0x8C240313,  //  007A  GETMET	R9	R1	K19
+      0x582C0014,  //  007B  LDCONST	R11	K20
       0x7C240400,  //  007C  CALL	R9	2
-      0x8C240314,  //  007D  GETMET	R9	R1	K20
-      0x582C0015,  //  007E  LDCONST	R11	K21
-      0x7C240400,  //  007F  CALL	R9	2
-      0x70020014,  //  0080  JMP		#0096
-      0x8824010C,  //  0081  GETMBR	R9	R0	K12
-      0x88241324,  //  0082  GETMBR	R9	R9	K36
-      0x4C280000,  //  0083  LDNIL	R10
-      0x2024120A,  //  0084  NE	R9	R9	R10
-      0x20240E09,  //  0085  NE	R9	R7	R9
-      0x7826000B,  //  0086  JMPF	R9	#0093
-      0x781E0003,  //  0087  JMPF	R7	#008C
-      0x8824010C,  //  0088  GETMBR	R9	R0	K12
-      0x8C241325,  //  0089  GETMET	R9	R9	K37
-      0x7C240200,  //  008A  CALL	R9	1
-      0x70020002,  //  008B  JMP		#008F
-      0x8824010C,  //  008C  GETMBR	R9	R0	K12
-      0x8C241326,  //  008D  GETMET	R9	R9	K38
-      0x7C240200,  //  008E  CALL	R9	1
-      0x8C240314,  //  008F  GETMET	R9	R1	K20
-      0x582C0027,  //  0090  LDCONST	R11	K39
-      0x7C240400,  //  0091  CALL	R9	2
-      0x70020002,  //  0092  JMP		#0096
-      0x8C240314,  //  0093  GETMET	R9	R1	K20
-      0x582C0027,  //  0094  LDCONST	R11	K39
-      0x7C240400,  //  0095  CALL	R9	2
-      0x700201D7,  //  0096  JMP		#026F
-      0x8C180305,  //  0097  GETMET	R6	R1	K5
-      0x58200028,  //  0098  LDCONST	R8	K40
-      0x7C180400,  //  0099  CALL	R6	2
-      0x781A0026,  //  009A  JMPF	R6	#00C2
-      0xB81A1000,  //  009B  GETNGBL	R6	K8
-      0x8C180D09,  //  009C  GETMET	R6	R6	K9
-      0x60200018,  //  009D  GETGBL	R8	G24
-      0x5824000A,  //  009E  LDCONST	R9	K10
-      0x58280028,  //  009F  LDCONST	R10	K40
-      0x7C200400,  //  00A0  CALL	R8	2
-      0x5824000B,  //  00A1  LDCONST	R9	K11
-      0x7C180600,  //  00A2  CALL	R6	3
-      0x60180009,  //  00A3  GETGBL	R6	G9
-      0x8C1C030E,  //  00A4  GETMET	R7	R1	K14
-      0x58240028,  //  00A5  LDCONST	R9	K40
-      0x7C1C0400,  //  00A6  CALL	R7	2
-      0x7C180200,  //  00A7  CALL	R6	1
-      0x581C0029,  //  00A8  LDCONST	R7	K41
-      0x8820010C,  //  00A9  GETMBR	R8	R0	K12
-      0x8820112A,  //  00AA  GETMBR	R8	R8	K42
-      0x8820112B,  //  00AB  GETMBR	R8	R8	K43
-      0x6024000C,  //  00AC  GETGBL	R9	G12
-      0x5C281000,  //  00AD  MOVE	R10	R8
-      0x7C240200,  //  00AE  CALL	R9	1
-      0x14240E09,  //  00AF  LT	R9	R7	R9
-      0x7826000C,  //  00B0  JMPF	R9	#00BE
-      0x94241007,  //  00B1  GETIDX	R9	R8	R7
-      0x8C24132C,  //  00B2  GETMET	R9	R9	K44
-      0x7C240200,  //  00B3  CALL	R9	1
-      0x1C241206,  //  00B4  EQ	R9	R9	R6
-      0x78260005,  //  00B5  JMPF	R9	#00BC
-      0x8824010C,  //  00B6  GETMBR	R9	R0	K12
-      0x8C24132D,  //  00B7  GETMET	R9	R9	K45
-      0x942C1007,  //  00B8  GETIDX	R11	R8	R7
-      0x7C240400,  //  00B9  CALL	R9	2
-      0x70020002,  //  00BA  JMP		#00BE
-      0x70020000,  //  00BB  JMP		#00BD
-      0x001C0F2E,  //  00BC  ADD	R7	R7	K46
-      0x7001FFED,  //  00BD  JMP		#00AC
-      0x8C240314,  //  00BE  GETMET	R9	R1	K20
-      0x582C002F,  //  00BF  LDCONST	R11	K47
-      0x7C240400,  //  00C0  CALL	R9	2
-      0x700201AC,  //  00C1  JMP		#026F
-      0x8C180305,  //  00C2  GETMET	R6	R1	K5
-      0x58200030,  //  00C3  LDCONST	R8	K48
-      0x7C180400,  //  00C4  CALL	R6	2
-      0x781A0011,  //  00C5  JMPF	R6	#00D8
-      0xB81A1000,  //  00C6  GETNGBL	R6	K8
-      0x8C180D09,  //  00C7  GETMET	R6	R6	K9
-      0x60200018,  //  00C8  GETGBL	R8	G24
-      0x5824000A,  //  00C9  LDCONST	R9	K10
-      0x58280030,  //  00CA  LDCONST	R10	K48
-      0x7C200400,  //  00CB  CALL	R8	2
-      0x5824000B,  //  00CC  LDCONST	R9	K11
-      0x7C180600,  //  00CD  CALL	R6	3
-      0x8818010C,  //  00CE  GETMBR	R6	R0	K12
-      0x501C0000,  //  00CF  LDBOOL	R7	0	0
-      0x901A6207,  //  00D0  SETMBR	R6	K49	R7
-      0x8818010C,  //  00D1  GETMBR	R6	R0	K12
-      0x8C180D13,  //  00D2  GETMET	R6	R6	K19
-      0x7C180200,  //  00D3  CALL	R6	1
-      0x8C180314,  //  00D4  GETMET	R6	R1	K20
-      0x58200015,  //  00D5  LDCONST	R8	K21
-      0x7C180400,  //  00D6  CALL	R6	2
-      0x70020196,  //  00D7  JMP		#026F
-      0x8C180305,  //  00D8  GETMET	R6	R1	K5
-      0x58200032,  //  00D9  LDCONST	R8	K50
-      0x7C180400,  //  00DA  CALL	R6	2
-      0x781A00D6,  //  00DB  JMPF	R6	#01B3
-      0xB81A1000,  //  00DC  GETNGBL	R6	K8
-      0x8C180D09,  //  00DD  GETMET	R6	R6	K9
-      0x60200018,  //  00DE  GETGBL	R8	G24
-      0x5824000A,  //  00DF  LDCONST	R9	K10
-      0x58280032,  //  00E0  LDCONST	R10	K50
-      0x7C200400,  //  00E1  CALL	R8	2
-      0x5824000B,  //  00E2  LDCONST	R9	K11
-      0x7C180600,  //  00E3  CALL	R6	3
-      0x50180000,  //  00E4  LDBOOL	R6	0	0
-      0x601C0010,  //  00E5  GETGBL	R7	G16
-      0x8C200333,  //  00E6  GETMET	R8	R1	K51
-      0x7C200200,  //  00E7  CALL	R8	1
-      0x0420112E,  //  00E8  SUB	R8	R8	K46
-      0x40225208,  //  00E9  CONNECT	R8	K41	R8
-      0x7C1C0200,  //  00EA  CALL	R7	1
-      0xA80200A0,  //  00EB  EXBLK	0	#018D
-      0x5C200E00,  //  00EC  MOVE	R8	R7
-      0x7C200000,  //  00ED  CALL	R8	0
-      0x8C240334,  //  00EE  GETMET	R9	R1	K52
-      0x5C2C1000,  //  00EF  MOVE	R11	R8
-      0x7C240400,  //  00F0  CALL	R9	2
-      0x8C280535,  //  00F1  GETMET	R10	R2	K53
-      0x5C301200,  //  00F2  MOVE	R12	R9
-      0x5834000E,  //  00F3  LDCONST	R13	K14
-      0x7C280600,  //  00F4  CALL	R10	3
-      0x1C281529,  //  00F5  EQ	R10	R10	K41
-      0x782A005B,  //  00F6  JMPF	R10	#0153
-      0x60280009,  //  00F7  GETGBL	R10	G9
-      0x402E1736,  //  00F8  CONNECT	R11	K11	K54
-      0x942C120B,  //  00F9  GETIDX	R11	R9	R11
-      0x7C280200,  //  00FA  CALL	R10	1
-      0x8C2C030E,  //  00FB  GETMET	R11	R1	K14
-      0x5C341000,  //  00FC  MOVE	R13	R8
-      0x7C2C0400,  //  00FD  CALL	R11	2
-      0x8830010C,  //  00FE  GETMBR	R12	R0	K12
-      0x88301937,  //  00FF  GETMBR	R12	R12	K55
-      0x8C301935,  //  0100  GETMET	R12	R12	K53
-      0x60380008,  //  0101  GETGBL	R14	G8
-      0x5C3C1400,  //  0102  MOVE	R15	R10
-      0x7C380200,  //  0103  CALL	R14	1
-      0x7C300400,  //  0104  CALL	R12	2
-      0x4C340000,  //  0105  LDNIL	R13
-      0x2034180D,  //  0106  NE	R13	R12	R13
-      0x78360041,  //  0107  JMPF	R13	#014A
-      0x8834010C,  //  0108  GETMBR	R13	R0	K12
-      0x88341B38,  //  0109  GETMBR	R13	R13	K56
-      0x8C341B35,  //  010A  GETMET	R13	R13	K53
-      0x8C3C1935,  //  010B  GETMET	R15	R12	K53
-      0x58440039,  //  010C  LDCONST	R17	K57
-      0x5848003A,  //  010D  LDCONST	R18	K58
-      0x7C3C0600,  //  010E  CALL	R15	3
-      0x7C340400,  //  010F  CALL	R13	2
-      0x4C380000,  //  0110  LDNIL	R14
-      0x20381A0E,  //  0111  NE	R14	R13	R14
-      0x783A0035,  //  0112  JMPF	R14	#0149
-      0xB83A1000,  //  0113  GETNGBL	R14	K8
-      0x8C381D09,  //  0114  GETMET	R14	R14	K9
-      0x60400018,  //  0115  GETGBL	R16	G24
-      0x5844003B,  //  0116  LDCONST	R17	K59
-      0x5C481400,  //  0117  MOVE	R18	R10
-      0x5C4C1600,  //  0118  MOVE	R19	R11
-      0x7C400600,  //  0119  CALL	R16	3
-      0x5844000B,  //  011A  LDCONST	R17	K11
-      0x7C380600,  //  011B  CALL	R14	3
-      0x8C381B3C,  //  011C  GETMET	R14	R13	K60
-      0x5C401A00,  //  011D  MOVE	R16	R13
-      0x5C441800,  //  011E  MOVE	R17	R12
-      0x7C380600,  //  011F  CALL	R14	3
-      0x203C1C0B,  //  0120  NE	R15	R14	R11
-      0xB8421000,  //  0121  GETNGBL	R16	K8
-      0x8C402109,  //  0122  GETMET	R16	R16	K9
-      0x60480018,  //  0123  GETGBL	R18	G24
-      0x584C003D,  //  0124  LDCONST	R19	K61
-      0x5C501400,  //  0125  MOVE	R20	R10
-      0x5C541C00,  //  0126  MOVE	R21	R14
-      0x5C581600,  //  0127  MOVE	R22	R11
-      0x205C1C0B,  //  0128  NE	R23	R14	R11
-      0x785E0001,  //  0129  JMPF	R23	#012C
-      0x585C003E,  //  012A  LDCONST	R23	K62
-      0x70020000,  //  012B  JMP		#012D
-      0x585C003A,  //  012C  LDCONST	R23	K58
-      0x7C480A00,  //  012D  CALL	R18	5
-      0x584C000B,  //  012E  LDCONST	R19	K11
-      0x7C400600,  //  012F  CALL	R16	3
-      0x783E0017,  //  0130  JMPF	R15	#0149
-      0x50180200,  //  0131  LDBOOL	R6	1	0
-      0x8C401B3F,  //  0132  GETMET	R16	R13	K63
-      0x5C481A00,  //  0133  MOVE	R18	R13
-      0x5C4C1800,  //  0134  MOVE	R19	R12
-      0x5C501600,  //  0135  MOVE	R20	R11
-      0x7C400800,  //  0136  CALL	R16	4
-      0x8840010C,  //  0137  GETMBR	R16	R0	K12
-      0x8C402140,  //  0138  GETMET	R16	R16	K64
-      0x5C481400,  //  0139  MOVE	R18	R10
-      0x7C400400,  //  013A  CALL	R16	2
-      0x7842000C,  //  013B  JMPF	R16	#0149
-      0xB8461000,  //  013C  GETNGBL	R17	K8
-      0x8C442309,  //  013D  GETMET	R17	R17	K9
-      0x604C0018,  //  013E  GETGBL	R19	G24
-      0x58500041,  //  013F  LDCONST	R20	K65
-      0x5C541800,  //  0140  MOVE	R21	R12
-      0x5C581400,  //  0141  MOVE	R22	R10
-      0x5C5C2000,  //  0142  MOVE	R23	R16
-      0x7C4C0800,  //  0143  CALL	R19	4
-      0x5850000B,  //  0144  LDCONST	R20	K11
-      0x7C440600,  //  0145  CALL	R17	3
-      0x8C442142,  //  0146  GETMET	R17	R16	K66
-      0x5C4C1800,  //  0147  MOVE	R19	R12
-      0x7C440400,  //  0148  CALL	R17	2
-      0x70020007,  //  0149  JMP		#0152
-      0xB8361000,  //  014A  GETNGBL	R13	K8
-      0x8C341B09,  //  014B  GETMET	R13	R13	K9
-      0x603C0018,  //  014C  GETGBL	R15	G24
-      0x58400043,  //  014D  LDCONST	R16	K67
-      0x5C441400,  //  014E  MOVE	R17	R10
-      0x7C3C0400,  //  014F  CALL	R15	2
-      0x5840000B,  //  0150  LDCONST	R16	K11
-      0x7C340600,  //  0151  CALL	R13	3
-      0x70020038,  //  0152  JMP		#018C
-      0x8C280535,  //  0153  GETMET	R10	R2	K53
-      0x5C301200,  //  0154  MOVE	R12	R9
-      0x58340044,  //  0155  LDCONST	R13	K68
-      0x7C280600,  //  0156  CALL	R10	3
-      0x1C281529,  //  0157  EQ	R10	R10	K41
-      0x782A0032,  //  0158  JMPF	R10	#018C
-      0x60280009,  //  0159  GETGBL	R10	G9
-      0x402E1736,  //  015A  CONNECT	R11	K11	K54
-      0x942C120B,  //  015B  GETIDX	R11	R9	R11
-      0x7C280200,  //  015C  CALL	R10	1
-      0x8C2C030E,  //  015D  GETMET	R11	R1	K14
-      0x5C341000,  //  015E  MOVE	R13	R8
-      0x7C2C0400,  //  015F  CALL	R11	2
-      0x8830010C,  //  0160  GETMBR	R12	R0	K12
-      0x88301937,  //  0161  GETMBR	R12	R12	K55
-      0x8C301935,  //  0162  GETMET	R12	R12	K53
-      0x60380008,  //  0163  GETGBL	R14	G8
-      0x5C3C1400,  //  0164  MOVE	R15	R10
-      0x7C380200,  //  0165  CALL	R14	1
-      0x7C300400,  //  0166  CALL	R12	2
-      0x4C340000,  //  0167  LDNIL	R13
-      0x2034180D,  //  0168  NE	R13	R12	R13
-      0x78360021,  //  0169  JMPF	R13	#018C
-      0x8C341935,  //  016A  GETMET	R13	R12	K53
-      0x583C0045,  //  016B  LDCONST	R15	K69
-      0x5840003A,  //  016C  LDCONST	R16	K58
-      0x7C340600,  //  016D  CALL	R13	3
-      0x20381A0B,  //  016E  NE	R14	R13	R11
-      0x783A001B,  //  016F  JMPF	R14	#018C
-      0x50180200,  //  0170  LDBOOL	R6	1	0
-      0x883C010C,  //  0171  GETMBR	R15	R0	K12
-      0x8C3C1F40,  //  0172  GETMET	R15	R15	K64
-      0x5C441400,  //  0173  MOVE	R17	R10
-      0x7C3C0400,  //  0174  CALL	R15	2
-      0x783E0015,  //  0175  JMPF	R15	#018C
-      0x8C401F46,  //  0176  GETMET	R16	R15	K70
-      0x5C481600,  //  0177  MOVE	R18	R11
-      0x7C400400,  //  0178  CALL	R16	2
-      0x782E0001,  //  0179  JMPF	R11	#017C
-      0x98328A0B,  //  017A  SETIDX	R12	K69	R11
-      0x70020002,  //  017B  JMP		#017F
-      0x8C401947,  //  017C  GETMET	R16	R12	K71
-      0x58480045,  //  017D  LDCONST	R18	K69
-      0x7C400400,  //  017E  CALL	R16	2
-      0xB8421000,  //  017F  GETNGBL	R16	K8
-      0x8C402109,  //  0180  GETMET	R16	R16	K9
-      0x60480018,  //  0181  GETGBL	R18	G24
-      0x584C0048,  //  0182  LDCONST	R19	K72
-      0x5C501800,  //  0183  MOVE	R20	R12
-      0x5C541400,  //  0184  MOVE	R21	R10
-      0x5C581E00,  //  0185  MOVE	R22	R15
-      0x7C480800,  //  0186  CALL	R18	4
-      0x584C000B,  //  0187  LDCONST	R19	K11
-      0x7C400600,  //  0188  CALL	R16	3
-      0x8C401F42,  //  0189  GETMET	R16	R15	K66
-      0x5C481800,  //  018A  MOVE	R18	R12
-      0x7C400400,  //  018B  CALL	R16	2
-      0x7001FF5E,  //  018C  JMP		#00EC
-      0x581C0049,  //  018D  LDCONST	R7	K73
-      0xAC1C0200,  //  018E  CATCH	R7	1	0
-      0xB0080000,  //  018F  RAISE	2	R0	R0
+      0x70020014,  //  007D  JMP		#0093
+      0x8824010B,  //  007E  GETMBR	R9	R0	K11
+      0x88241324,  //  007F  GETMBR	R9	R9	K36
+      0x4C280000,  //  0080  LDNIL	R10
+      0x2024120A,  //  0081  NE	R9	R9	R10
+      0x20240E09,  //  0082  NE	R9	R7	R9
+      0x7826000B,  //  0083  JMPF	R9	#0090
+      0x781E0003,  //  0084  JMPF	R7	#0089
+      0x8824010B,  //  0085  GETMBR	R9	R0	K11
+      0x8C241325,  //  0086  GETMET	R9	R9	K37
+      0x7C240200,  //  0087  CALL	R9	1
+      0x70020002,  //  0088  JMP		#008C
+      0x8824010B,  //  0089  GETMBR	R9	R0	K11
+      0x8C241326,  //  008A  GETMET	R9	R9	K38
+      0x7C240200,  //  008B  CALL	R9	1
+      0x8C240313,  //  008C  GETMET	R9	R1	K19
+      0x582C0027,  //  008D  LDCONST	R11	K39
+      0x7C240400,  //  008E  CALL	R9	2
+      0x70020002,  //  008F  JMP		#0093
+      0x8C240313,  //  0090  GETMET	R9	R1	K19
+      0x582C0027,  //  0091  LDCONST	R11	K39
+      0x7C240400,  //  0092  CALL	R9	2
+      0x700201CB,  //  0093  JMP		#0260
+      0x8C180305,  //  0094  GETMET	R6	R1	K5
+      0x58200028,  //  0095  LDCONST	R8	K40
+      0x7C180400,  //  0096  CALL	R6	2
+      0x781A0025,  //  0097  JMPF	R6	#00BE
+      0xB81A1000,  //  0098  GETNGBL	R6	K8
+      0x601C0018,  //  0099  GETGBL	R7	G24
+      0x58200009,  //  009A  LDCONST	R8	K9
+      0x58240028,  //  009B  LDCONST	R9	K40
+      0x7C1C0400,  //  009C  CALL	R7	2
+      0x5820000A,  //  009D  LDCONST	R8	K10
+      0x7C180400,  //  009E  CALL	R6	2
+      0x60180009,  //  009F  GETGBL	R6	G9
+      0x8C1C030D,  //  00A0  GETMET	R7	R1	K13
+      0x58240028,  //  00A1  LDCONST	R9	K40
+      0x7C1C0400,  //  00A2  CALL	R7	2
+      0x7C180200,  //  00A3  CALL	R6	1
+      0x581C0029,  //  00A4  LDCONST	R7	K41
+      0x8820010B,  //  00A5  GETMBR	R8	R0	K11
+      0x8820112A,  //  00A6  GETMBR	R8	R8	K42
+      0x8820112B,  //  00A7  GETMBR	R8	R8	K43
+      0x6024000C,  //  00A8  GETGBL	R9	G12
+      0x5C281000,  //  00A9  MOVE	R10	R8
+      0x7C240200,  //  00AA  CALL	R9	1
+      0x14240E09,  //  00AB  LT	R9	R7	R9
+      0x7826000C,  //  00AC  JMPF	R9	#00BA
+      0x94241007,  //  00AD  GETIDX	R9	R8	R7
+      0x8C24132C,  //  00AE  GETMET	R9	R9	K44
+      0x7C240200,  //  00AF  CALL	R9	1
+      0x1C241206,  //  00B0  EQ	R9	R9	R6
+      0x78260005,  //  00B1  JMPF	R9	#00B8
+      0x8824010B,  //  00B2  GETMBR	R9	R0	K11
+      0x8C24132D,  //  00B3  GETMET	R9	R9	K45
+      0x942C1007,  //  00B4  GETIDX	R11	R8	R7
+      0x7C240400,  //  00B5  CALL	R9	2
+      0x70020002,  //  00B6  JMP		#00BA
+      0x70020000,  //  00B7  JMP		#00B9
+      0x001C0F2E,  //  00B8  ADD	R7	R7	K46
+      0x7001FFED,  //  00B9  JMP		#00A8
+      0x8C240313,  //  00BA  GETMET	R9	R1	K19
+      0x582C002F,  //  00BB  LDCONST	R11	K47
+      0x7C240400,  //  00BC  CALL	R9	2
+      0x700201A1,  //  00BD  JMP		#0260
+      0x8C180305,  //  00BE  GETMET	R6	R1	K5
+      0x58200030,  //  00BF  LDCONST	R8	K48
+      0x7C180400,  //  00C0  CALL	R6	2
+      0x781A0010,  //  00C1  JMPF	R6	#00D3
+      0xB81A1000,  //  00C2  GETNGBL	R6	K8
+      0x601C0018,  //  00C3  GETGBL	R7	G24
+      0x58200009,  //  00C4  LDCONST	R8	K9
+      0x58240030,  //  00C5  LDCONST	R9	K48
+      0x7C1C0400,  //  00C6  CALL	R7	2
+      0x5820000A,  //  00C7  LDCONST	R8	K10
+      0x7C180400,  //  00C8  CALL	R6	2
+      0x8818010B,  //  00C9  GETMBR	R6	R0	K11
+      0x501C0000,  //  00CA  LDBOOL	R7	0	0
+      0x901A6207,  //  00CB  SETMBR	R6	K49	R7
+      0x8818010B,  //  00CC  GETMBR	R6	R0	K11
+      0x8C180D12,  //  00CD  GETMET	R6	R6	K18
+      0x7C180200,  //  00CE  CALL	R6	1
+      0x8C180313,  //  00CF  GETMET	R6	R1	K19
+      0x58200014,  //  00D0  LDCONST	R8	K20
+      0x7C180400,  //  00D1  CALL	R6	2
+      0x7002018C,  //  00D2  JMP		#0260
+      0x8C180305,  //  00D3  GETMET	R6	R1	K5
+      0x58200032,  //  00D4  LDCONST	R8	K50
+      0x7C180400,  //  00D5  CALL	R6	2
+      0x781A00CE,  //  00D6  JMPF	R6	#01A6
+      0xB81A1000,  //  00D7  GETNGBL	R6	K8
+      0x601C0018,  //  00D8  GETGBL	R7	G24
+      0x58200009,  //  00D9  LDCONST	R8	K9
+      0x58240032,  //  00DA  LDCONST	R9	K50
+      0x7C1C0400,  //  00DB  CALL	R7	2
+      0x5820000A,  //  00DC  LDCONST	R8	K10
+      0x7C180400,  //  00DD  CALL	R6	2
+      0x50180000,  //  00DE  LDBOOL	R6	0	0
+      0x601C0010,  //  00DF  GETGBL	R7	G16
+      0x8C200333,  //  00E0  GETMET	R8	R1	K51
+      0x7C200200,  //  00E1  CALL	R8	1
+      0x0420112E,  //  00E2  SUB	R8	R8	K46
+      0x40225208,  //  00E3  CONNECT	R8	K41	R8
+      0x7C1C0200,  //  00E4  CALL	R7	1
+      0xA802009B,  //  00E5  EXBLK	0	#0182
+      0x5C200E00,  //  00E6  MOVE	R8	R7
+      0x7C200000,  //  00E7  CALL	R8	0
+      0x8C240334,  //  00E8  GETMET	R9	R1	K52
+      0x5C2C1000,  //  00E9  MOVE	R11	R8
+      0x7C240400,  //  00EA  CALL	R9	2
+      0x8C280535,  //  00EB  GETMET	R10	R2	K53
+      0x5C301200,  //  00EC  MOVE	R12	R9
+      0x5834000D,  //  00ED  LDCONST	R13	K13
+      0x7C280600,  //  00EE  CALL	R10	3
+      0x1C281529,  //  00EF  EQ	R10	R10	K41
+      0x782A0057,  //  00F0  JMPF	R10	#0149
+      0x60280009,  //  00F1  GETGBL	R10	G9
+      0x402E1536,  //  00F2  CONNECT	R11	K10	K54
+      0x942C120B,  //  00F3  GETIDX	R11	R9	R11
+      0x7C280200,  //  00F4  CALL	R10	1
+      0x8C2C030D,  //  00F5  GETMET	R11	R1	K13
+      0x5C341000,  //  00F6  MOVE	R13	R8
+      0x7C2C0400,  //  00F7  CALL	R11	2
+      0x8830010B,  //  00F8  GETMBR	R12	R0	K11
+      0x88301937,  //  00F9  GETMBR	R12	R12	K55
+      0x8C301935,  //  00FA  GETMET	R12	R12	K53
+      0x60380008,  //  00FB  GETGBL	R14	G8
+      0x5C3C1400,  //  00FC  MOVE	R15	R10
+      0x7C380200,  //  00FD  CALL	R14	1
+      0x7C300400,  //  00FE  CALL	R12	2
+      0x4C340000,  //  00FF  LDNIL	R13
+      0x2034180D,  //  0100  NE	R13	R12	R13
+      0x7836003E,  //  0101  JMPF	R13	#0141
+      0x8834010B,  //  0102  GETMBR	R13	R0	K11
+      0x88341B38,  //  0103  GETMBR	R13	R13	K56
+      0x8C341B35,  //  0104  GETMET	R13	R13	K53
+      0x8C3C1935,  //  0105  GETMET	R15	R12	K53
+      0x58440039,  //  0106  LDCONST	R17	K57
+      0x5848003A,  //  0107  LDCONST	R18	K58
+      0x7C3C0600,  //  0108  CALL	R15	3
+      0x7C340400,  //  0109  CALL	R13	2
+      0x4C380000,  //  010A  LDNIL	R14
+      0x20381A0E,  //  010B  NE	R14	R13	R14
+      0x783A0032,  //  010C  JMPF	R14	#0140
+      0xB83A1000,  //  010D  GETNGBL	R14	K8
+      0x603C0018,  //  010E  GETGBL	R15	G24
+      0x5840003B,  //  010F  LDCONST	R16	K59
+      0x5C441400,  //  0110  MOVE	R17	R10
+      0x5C481600,  //  0111  MOVE	R18	R11
+      0x7C3C0600,  //  0112  CALL	R15	3
+      0x5840000A,  //  0113  LDCONST	R16	K10
+      0x7C380400,  //  0114  CALL	R14	2
+      0x8C381B3C,  //  0115  GETMET	R14	R13	K60
+      0x5C401A00,  //  0116  MOVE	R16	R13
+      0x5C441800,  //  0117  MOVE	R17	R12
+      0x7C380600,  //  0118  CALL	R14	3
+      0x203C1C0B,  //  0119  NE	R15	R14	R11
+      0xB8421000,  //  011A  GETNGBL	R16	K8
+      0x60440018,  //  011B  GETGBL	R17	G24
+      0x5848003D,  //  011C  LDCONST	R18	K61
+      0x5C4C1400,  //  011D  MOVE	R19	R10
+      0x5C501C00,  //  011E  MOVE	R20	R14
+      0x5C541600,  //  011F  MOVE	R21	R11
+      0x20581C0B,  //  0120  NE	R22	R14	R11
+      0x785A0001,  //  0121  JMPF	R22	#0124
+      0x5858003E,  //  0122  LDCONST	R22	K62
+      0x70020000,  //  0123  JMP		#0125
+      0x5858003A,  //  0124  LDCONST	R22	K58
+      0x7C440A00,  //  0125  CALL	R17	5
+      0x5848000A,  //  0126  LDCONST	R18	K10
+      0x7C400400,  //  0127  CALL	R16	2
+      0x783E0016,  //  0128  JMPF	R15	#0140
+      0x50180200,  //  0129  LDBOOL	R6	1	0
+      0x8C401B3F,  //  012A  GETMET	R16	R13	K63
+      0x5C481A00,  //  012B  MOVE	R18	R13
+      0x5C4C1800,  //  012C  MOVE	R19	R12
+      0x5C501600,  //  012D  MOVE	R20	R11
+      0x7C400800,  //  012E  CALL	R16	4
+      0x8840010B,  //  012F  GETMBR	R16	R0	K11
+      0x8C402140,  //  0130  GETMET	R16	R16	K64
+      0x5C481400,  //  0131  MOVE	R18	R10
+      0x7C400400,  //  0132  CALL	R16	2
+      0x7842000B,  //  0133  JMPF	R16	#0140
+      0xB8461000,  //  0134  GETNGBL	R17	K8
+      0x60480018,  //  0135  GETGBL	R18	G24
+      0x584C0041,  //  0136  LDCONST	R19	K65
+      0x5C501800,  //  0137  MOVE	R20	R12
+      0x5C541400,  //  0138  MOVE	R21	R10
+      0x5C582000,  //  0139  MOVE	R22	R16
+      0x7C480800,  //  013A  CALL	R18	4
+      0x584C000A,  //  013B  LDCONST	R19	K10
+      0x7C440400,  //  013C  CALL	R17	2
+      0x8C442142,  //  013D  GETMET	R17	R16	K66
+      0x5C4C1800,  //  013E  MOVE	R19	R12
+      0x7C440400,  //  013F  CALL	R17	2
+      0x70020006,  //  0140  JMP		#0148
+      0xB8361000,  //  0141  GETNGBL	R13	K8
+      0x60380018,  //  0142  GETGBL	R14	G24
+      0x583C0043,  //  0143  LDCONST	R15	K67
+      0x5C401400,  //  0144  MOVE	R16	R10
+      0x7C380400,  //  0145  CALL	R14	2
+      0x583C000A,  //  0146  LDCONST	R15	K10
+      0x7C340400,  //  0147  CALL	R13	2
+      0x70020037,  //  0148  JMP		#0181
+      0x8C280535,  //  0149  GETMET	R10	R2	K53
+      0x5C301200,  //  014A  MOVE	R12	R9
+      0x58340044,  //  014B  LDCONST	R13	K68
+      0x7C280600,  //  014C  CALL	R10	3
+      0x1C281529,  //  014D  EQ	R10	R10	K41
+      0x782A0031,  //  014E  JMPF	R10	#0181
+      0x60280009,  //  014F  GETGBL	R10	G9
+      0x402E1536,  //  0150  CONNECT	R11	K10	K54
+      0x942C120B,  //  0151  GETIDX	R11	R9	R11
+      0x7C280200,  //  0152  CALL	R10	1
+      0x8C2C030D,  //  0153  GETMET	R11	R1	K13
+      0x5C341000,  //  0154  MOVE	R13	R8
+      0x7C2C0400,  //  0155  CALL	R11	2
+      0x8830010B,  //  0156  GETMBR	R12	R0	K11
+      0x88301937,  //  0157  GETMBR	R12	R12	K55
+      0x8C301935,  //  0158  GETMET	R12	R12	K53
+      0x60380008,  //  0159  GETGBL	R14	G8
+      0x5C3C1400,  //  015A  MOVE	R15	R10
+      0x7C380200,  //  015B  CALL	R14	1
+      0x7C300400,  //  015C  CALL	R12	2
+      0x4C340000,  //  015D  LDNIL	R13
+      0x2034180D,  //  015E  NE	R13	R12	R13
+      0x78360020,  //  015F  JMPF	R13	#0181
+      0x8C341935,  //  0160  GETMET	R13	R12	K53
+      0x583C0045,  //  0161  LDCONST	R15	K69
+      0x5840003A,  //  0162  LDCONST	R16	K58
+      0x7C340600,  //  0163  CALL	R13	3
+      0x20381A0B,  //  0164  NE	R14	R13	R11
+      0x783A001A,  //  0165  JMPF	R14	#0181
+      0x50180200,  //  0166  LDBOOL	R6	1	0
+      0x883C010B,  //  0167  GETMBR	R15	R0	K11
+      0x8C3C1F40,  //  0168  GETMET	R15	R15	K64
+      0x5C441400,  //  0169  MOVE	R17	R10
+      0x7C3C0400,  //  016A  CALL	R15	2
+      0x783E0014,  //  016B  JMPF	R15	#0181
+      0x8C401F46,  //  016C  GETMET	R16	R15	K70
+      0x5C481600,  //  016D  MOVE	R18	R11
+      0x7C400400,  //  016E  CALL	R16	2
+      0x782E0001,  //  016F  JMPF	R11	#0172
+      0x98328A0B,  //  0170  SETIDX	R12	K69	R11
+      0x70020002,  //  0171  JMP		#0175
+      0x8C401947,  //  0172  GETMET	R16	R12	K71
+      0x58480045,  //  0173  LDCONST	R18	K69
+      0x7C400400,  //  0174  CALL	R16	2
+      0xB8421000,  //  0175  GETNGBL	R16	K8
+      0x60440018,  //  0176  GETGBL	R17	G24
+      0x58480048,  //  0177  LDCONST	R18	K72
+      0x5C4C1800,  //  0178  MOVE	R19	R12
+      0x5C501400,  //  0179  MOVE	R20	R10
+      0x5C541E00,  //  017A  MOVE	R21	R15
+      0x7C440800,  //  017B  CALL	R17	4
+      0x5848000A,  //  017C  LDCONST	R18	K10
+      0x7C400400,  //  017D  CALL	R16	2
+      0x8C401F42,  //  017E  GETMET	R16	R15	K66
+      0x5C481800,  //  017F  MOVE	R18	R12
+      0x7C400400,  //  0180  CALL	R16	2
+      0x7001FF63,  //  0181  JMP		#00E6
+      0x581C0049,  //  0182  LDCONST	R7	K73
+      0xAC1C0200,  //  0183  CATCH	R7	1	0
+      0xB0080000,  //  0184  RAISE	2	R0	R0
+      0xB81E1000,  //  0185  GETNGBL	R7	K8
+      0x60200018,  //  0186  GETGBL	R8	G24
+      0x5824004A,  //  0187  LDCONST	R9	K74
+      0x60280008,  //  0188  GETGBL	R10	G8
+      0x882C010B,  //  0189  GETMBR	R11	R0	K11
+      0x882C1737,  //  018A  GETMBR	R11	R11	K55
+      0x7C280200,  //  018B  CALL	R10	1
+      0x7C200400,  //  018C  CALL	R8	2
+      0x5824000A,  //  018D  LDCONST	R9	K10
+      0x7C1C0400,  //  018E  CALL	R7	2
+      0x78160007,  //  018F  JMPF	R5	#0198
       0xB81E1000,  //  0190  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0191  GETMET	R7	R7	K9
-      0x60240018,  //  0192  GETGBL	R9	G24
-      0x5828004A,  //  0193  LDCONST	R10	K74
-      0x602C0008,  //  0194  GETGBL	R11	G8
-      0x8830010C,  //  0195  GETMBR	R12	R0	K12
-      0x88301937,  //  0196  GETMBR	R12	R12	K55
-      0x7C2C0200,  //  0197  CALL	R11	1
-      0x7C240400,  //  0198  CALL	R9	2
-      0x5828000B,  //  0199  LDCONST	R10	K11
-      0x7C1C0600,  //  019A  CALL	R7	3
-      0x78160008,  //  019B  JMPF	R5	#01A5
-      0xB81E1000,  //  019C  GETNGBL	R7	K8
-      0x8C1C0F09,  //  019D  GETMET	R7	R7	K9
-      0x60240018,  //  019E  GETGBL	R9	G24
-      0x5828004B,  //  019F  LDCONST	R10	K75
-      0x5C2C0A00,  //  01A0  MOVE	R11	R5
-      0x7C240400,  //  01A1  CALL	R9	2
-      0x5828000B,  //  01A2  LDCONST	R10	K11
-      0x7C1C0600,  //  01A3  CALL	R7	3
-      0x7002000C,  //  01A4  JMP		#01B2
-      0x741A0002,  //  01A5  JMPT	R6	#01A9
-      0x881C010C,  //  01A6  GETMBR	R7	R0	K12
-      0x881C0F31,  //  01A7  GETMBR	R7	R7	K49
-      0x741E0005,  //  01A8  JMPT	R7	#01AF
-      0x881C010C,  //  01A9  GETMBR	R7	R0	K12
-      0x50200200,  //  01AA  LDBOOL	R8	1	0
-      0x901E6208,  //  01AB  SETMBR	R7	K49	R8
-      0x881C010C,  //  01AC  GETMBR	R7	R0	K12
-      0x8C1C0F13,  //  01AD  GETMET	R7	R7	K19
-      0x7C1C0200,  //  01AE  CALL	R7	1
-      0x8C1C0314,  //  01AF  GETMET	R7	R1	K20
-      0x5824004C,  //  01B0  LDCONST	R9	K76
-      0x7C1C0400,  //  01B1  CALL	R7	2
-      0x700200BB,  //  01B2  JMP		#026F
-      0x8C180305,  //  01B3  GETMET	R6	R1	K5
-      0x5820004D,  //  01B4  LDCONST	R8	K77
-      0x7C180400,  //  01B5  CALL	R6	2
-      0x781A002B,  //  01B6  JMPF	R6	#01E3
-      0x8C18030E,  //  01B7  GETMET	R6	R1	K14
-      0x5820004E,  //  01B8  LDCONST	R8	K78
-      0x7C180400,  //  01B9  CALL	R6	2
-      0x8C1C030E,  //  01BA  GETMET	R7	R1	K14
-      0x5824000E,  //  01BB  LDCONST	R9	K14
-      0x7C1C0400,  //  01BC  CALL	R7	2
-      0x8C20030E,  //  01BD  GETMET	R8	R1	K14
-      0x58280044,  //  01BE  LDCONST	R10	K68
-      0x7C200400,  //  01BF  CALL	R8	2
-      0xB8261000,  //  01C0  GETNGBL	R9	K8
-      0x8C241309,  //  01C1  GETMET	R9	R9	K9
-      0x602C0018,  //  01C2  GETGBL	R11	G24
-      0x5830004F,  //  01C3  LDCONST	R12	K79
-      0x5C340C00,  //  01C4  MOVE	R13	R6
-      0x5C380E00,  //  01C5  MOVE	R14	R7
-      0x7C2C0600,  //  01C6  CALL	R11	3
-      0x5830000B,  //  01C7  LDCONST	R12	K11
-      0x7C240600,  //  01C8  CALL	R9	3
-      0x8824010C,  //  01C9  GETMBR	R9	R0	K12
-      0x88241338,  //  01CA  GETMBR	R9	R9	K56
-      0x8C241335,  //  01CB  GETMET	R9	R9	K53
-      0x5C2C0C00,  //  01CC  MOVE	R11	R6
-      0x7C240400,  //  01CD  CALL	R9	2
-      0x4C280000,  //  01CE  LDNIL	R10
-      0x2028120A,  //  01CF  NE	R10	R9	R10
-      0x782A000D,  //  01D0  JMPF	R10	#01DF
-      0x60280013,  //  01D1  GETGBL	R10	G19
-      0x7C280000,  //  01D2  CALL	R10	0
-      0x78220000,  //  01D3  JMPF	R8	#01D5
-      0x982A8A08,  //  01D4  SETIDX	R10	K69	R8
-      0x8C2C133F,  //  01D5  GETMET	R11	R9	K63
-      0x5C341200,  //  01D6  MOVE	R13	R9
-      0x5C381400,  //  01D7  MOVE	R14	R10
-      0x5C3C0E00,  //  01D8  MOVE	R15	R7
-      0x7C2C0800,  //  01D9  CALL	R11	4
-      0x882C010C,  //  01DA  GETMBR	R11	R0	K12
-      0x8C2C1750,  //  01DB  GETMET	R11	R11	K80
-      0x5C340C00,  //  01DC  MOVE	R13	R6
-      0x5C381400,  //  01DD  MOVE	R14	R10
-      0x7C2C0600,  //  01DE  CALL	R11	3
-      0x8C280314,  //  01DF  GETMET	R10	R1	K20
-      0x5830004C,  //  01E0  LDCONST	R12	K76
-      0x7C280400,  //  01E1  CALL	R10	2
-      0x7002008B,  //  01E2  JMP		#026F
-      0x8C180305,  //  01E3  GETMET	R6	R1	K5
-      0x58200051,  //  01E4  LDCONST	R8	K81
-      0x7C180400,  //  01E5  CALL	R6	2
-      0x781A005E,  //  01E6  JMPF	R6	#0246
-      0x8C18030E,  //  01E7  GETMET	R6	R1	K14
-      0x58200052,  //  01E8  LDCONST	R8	K82
-      0x7C180400,  //  01E9  CALL	R6	2
-      0x4C1C0000,  //  01EA  LDNIL	R7
-      0x1C1C0C07,  //  01EB  EQ	R7	R6	R7
-      0x741E0001,  //  01EC  JMPT	R7	#01EF
-      0x1C1C0D3A,  //  01ED  EQ	R7	R6	K58
-      0x781E0000,  //  01EE  JMPF	R7	#01F0
-      0xB006A754,  //  01EF  RAISE	1	K83	K84
-      0x581C0029,  //  01F0  LDCONST	R7	K41
-      0x60200008,  //  01F1  GETGBL	R8	G8
-      0x5C240E00,  //  01F2  MOVE	R9	R7
-      0x7C200200,  //  01F3  CALL	R8	1
-      0x8C240305,  //  01F4  GETMET	R9	R1	K5
-      0x002E9C08,  //  01F5  ADD	R11	K78	R8
-      0x7C240400,  //  01F6  CALL	R9	2
-      0x78260049,  //  01F7  JMPF	R9	#0242
-      0x8C24030E,  //  01F8  GETMET	R9	R1	K14
-      0x002E9C08,  //  01F9  ADD	R11	K78	R8
-      0x7C240400,  //  01FA  CALL	R9	2
-      0x8C28030E,  //  01FB  GETMET	R10	R1	K14
-      0x00321C08,  //  01FC  ADD	R12	K14	R8
-      0x7C280400,  //  01FD  CALL	R10	2
-      0x8C2C030E,  //  01FE  GETMET	R11	R1	K14
-      0x00368808,  //  01FF  ADD	R13	K68	R8
-      0x7C2C0400,  //  0200  CALL	R11	2
-      0x2030133A,  //  0201  NE	R12	R9	K58
-      0x78320038,  //  0202  JMPF	R12	#023C
-      0x8830010C,  //  0203  GETMBR	R12	R0	K12
-      0x88301938,  //  0204  GETMBR	R12	R12	K56
-      0x8C301935,  //  0205  GETMET	R12	R12	K53
-      0x5C381200,  //  0206  MOVE	R14	R9
-      0x7C300400,  //  0207  CALL	R12	2
-      0x4C340000,  //  0208  LDNIL	R13
-      0x2034180D,  //  0209  NE	R13	R12	R13
-      0x78360030,  //  020A  JMPF	R13	#023C
-      0x60340013,  //  020B  GETGBL	R13	G19
-      0x7C340000,  //  020C  CALL	R13	0
-      0x9836A406,  //  020D  SETIDX	R13	K82	R6
-      0x98367209,  //  020E  SETIDX	R13	K57	R9
-      0x782E0000,  //  020F  JMPF	R11	#0211
-      0x98368A0B,  //  0210  SETIDX	R13	K69	R11
-      0x8C38193F,  //  0211  GETMET	R14	R12	K63
-      0x5C401800,  //  0212  MOVE	R16	R12
-      0x5C441A00,  //  0213  MOVE	R17	R13
-      0x5C481400,  //  0214  MOVE	R18	R10
-      0x7C380800,  //  0215  CALL	R14	4
-      0x50380000,  //  0216  LDBOOL	R14	0	0
-      0x603C0010,  //  0217  GETGBL	R15	G16
-      0x8840010C,  //  0218  GETMBR	R16	R0	K12
-      0x88402137,  //  0219  GETMBR	R16	R16	K55
-      0x7C3C0200,  //  021A  CALL	R15	1
-      0xA802000B,  //  021B  EXBLK	0	#0228
-      0x5C401E00,  //  021C  MOVE	R16	R15
-      0x7C400000,  //  021D  CALL	R16	0
-      0x8C440155,  //  021E  GETMET	R17	R0	K85
-      0x5C4C2000,  //  021F  MOVE	R19	R16
-      0x5C501A00,  //  0220  MOVE	R20	R13
-      0x7C440600,  //  0221  CALL	R17	3
-      0x78460001,  //  0222  JMPF	R17	#0225
-      0x50380200,  //  0223  LDBOOL	R14	1	0
-      0x70020000,  //  0224  JMP		#0226
-      0x7001FFF5,  //  0225  JMP		#021C
-      0xA8040001,  //  0226  EXBLK	1	1
-      0x70020002,  //  0227  JMP		#022B
-      0x583C0049,  //  0228  LDCONST	R15	K73
-      0xAC3C0200,  //  0229  CATCH	R15	1	0
-      0xB0080000,  //  022A  RAISE	2	R0	R0
-      0x5C3C1C00,  //  022B  MOVE	R15	R14
-      0x743E000E,  //  022C  JMPT	R15	#023C
-      0xB83E1000,  //  022D  GETNGBL	R15	K8
-      0x8C3C1F09,  //  022E  GETMET	R15	R15	K9
-      0x60440018,  //  022F  GETGBL	R17	G24
-      0x58480056,  //  0230  LDCONST	R18	K86
-      0x5C4C0C00,  //  0231  MOVE	R19	R6
-      0x5C501200,  //  0232  MOVE	R20	R9
-      0x5C541400,  //  0233  MOVE	R21	R10
-      0x7C440800,  //  0234  CALL	R17	4
-      0x5848000B,  //  0235  LDCONST	R18	K11
-      0x7C3C0600,  //  0236  CALL	R15	3
-      0x883C010C,  //  0237  GETMBR	R15	R0	K12
-      0x8C3C1F50,  //  0238  GETMET	R15	R15	K80
-      0x5C441200,  //  0239  MOVE	R17	R9
-      0x5C481A00,  //  023A  MOVE	R18	R13
-      0x7C3C0600,  //  023B  CALL	R15	3
-      0x001C0F2E,  //  023C  ADD	R7	R7	K46
-      0x60300008,  //  023D  GETGBL	R12	G8
-      0x5C340E00,  //  023E  MOVE	R13	R7
-      0x7C300200,  //  023F  CALL	R12	1
-      0x5C201800,  //  0240  MOVE	R8	R12
-      0x7001FFB1,  //  0241  JMP		#01F4
-      0x8C240314,  //  0242  GETMET	R9	R1	K20
-      0x582C004C,  //  0243  LDCONST	R11	K76
-      0x7C240400,  //  0244  CALL	R9	2
-      0x70020028,  //  0245  JMP		#026F
-      0x4C180000,  //  0246  LDNIL	R6
-      0x601C0010,  //  0247  GETGBL	R7	G16
-      0x8C200333,  //  0248  GETMET	R8	R1	K51
-      0x7C200200,  //  0249  CALL	R8	1
-      0x0420112E,  //  024A  SUB	R8	R8	K46
-      0x40225208,  //  024B  CONNECT	R8	K41	R8
-      0x7C1C0200,  //  024C  CALL	R7	1
-      0xA8020013,  //  024D  EXBLK	0	#0262
-      0x5C200E00,  //  024E  MOVE	R8	R7
-      0x7C200000,  //  024F  CALL	R8	0
-      0x8C240334,  //  0250  GETMET	R9	R1	K52
-      0x5C2C1000,  //  0251  MOVE	R11	R8
-      0x7C240400,  //  0252  CALL	R9	2
-      0x8C280535,  //  0253  GETMET	R10	R2	K53
-      0x5C301200,  //  0254  MOVE	R12	R9
-      0x58340057,  //  0255  LDCONST	R13	K87
-      0x7C280600,  //  0256  CALL	R10	3
-      0x1C281529,  //  0257  EQ	R10	R10	K41
-      0x782A0005,  //  0258  JMPF	R10	#025F
-      0x60280009,  //  0259  GETGBL	R10	G9
-      0x402E1736,  //  025A  CONNECT	R11	K11	K54
-      0x942C120B,  //  025B  GETIDX	R11	R9	R11
-      0x7C280200,  //  025C  CALL	R10	1
-      0x5C181400,  //  025D  MOVE	R6	R10
-      0x70020000,  //  025E  JMP		#0260
-      0x7001FFED,  //  025F  JMP		#024E
-      0xA8040001,  //  0260  EXBLK	1	1
-      0x70020002,  //  0261  JMP		#0265
-      0x581C0049,  //  0262  LDCONST	R7	K73
-      0xAC1C0200,  //  0263  CATCH	R7	1	0
-      0xB0080000,  //  0264  RAISE	2	R0	R0
-      0x4C1C0000,  //  0265  LDNIL	R7
-      0x201C0C07,  //  0266  NE	R7	R6	R7
-      0x781E0006,  //  0267  JMPF	R7	#026F
-      0x881C010C,  //  0268  GETMBR	R7	R0	K12
-      0x8C1C0F58,  //  0269  GETMET	R7	R7	K88
-      0x5C240C00,  //  026A  MOVE	R9	R6
-      0x7C1C0400,  //  026B  CALL	R7	2
-      0x8C1C0314,  //  026C  GETMET	R7	R1	K20
-      0x5824004C,  //  026D  LDCONST	R9	K76
-      0x7C1C0400,  //  026E  CALL	R7	2
-      0x78160011,  //  026F  JMPF	R5	#0282
-      0x8C180359,  //  0270  GETMET	R6	R1	K89
-      0x5820005A,  //  0271  LDCONST	R8	K90
-      0x7C180400,  //  0272  CALL	R6	2
-      0x8C18035B,  //  0273  GETMET	R6	R1	K91
-      0x7C180200,  //  0274  CALL	R6	1
-      0x8C18035C,  //  0275  GETMET	R6	R1	K92
-      0x60200018,  //  0276  GETGBL	R8	G24
-      0x5824005D,  //  0277  LDCONST	R9	K93
-      0x8C28035E,  //  0278  GETMET	R10	R1	K94
-      0x5C300A00,  //  0279  MOVE	R12	R5
-      0x7C280400,  //  027A  CALL	R10	2
-      0x7C200400,  //  027B  CALL	R8	2
-      0x7C180400,  //  027C  CALL	R6	2
-      0x8C18035F,  //  027D  GETMET	R6	R1	K95
-      0x88200360,  //  027E  GETMBR	R8	R1	K96
-      0x7C180400,  //  027F  CALL	R6	2
-      0x8C180361,  //  0280  GETMET	R6	R1	K97
-      0x7C180200,  //  0281  CALL	R6	1
-      0xA8040001,  //  0282  EXBLK	1	1
-      0x7002001D,  //  0283  JMP		#02A2
-      0xAC180002,  //  0284  CATCH	R6	0	2
-      0x7002001A,  //  0285  JMP		#02A1
-      0xB8221000,  //  0286  GETNGBL	R8	K8
-      0x8C201109,  //  0287  GETMET	R8	R8	K9
-      0x60280018,  //  0288  GETGBL	R10	G24
-      0x582C0062,  //  0289  LDCONST	R11	K98
-      0x5C300C00,  //  028A  MOVE	R12	R6
-      0x5C340E00,  //  028B  MOVE	R13	R7
-      0x7C280600,  //  028C  CALL	R10	3
-      0x582C0063,  //  028D  LDCONST	R11	K99
-      0x7C200600,  //  028E  CALL	R8	3
-      0x8C200359,  //  028F  GETMET	R8	R1	K89
-      0x5828005A,  //  0290  LDCONST	R10	K90
-      0x7C200400,  //  0291  CALL	R8	2
-      0x8C20035B,  //  0292  GETMET	R8	R1	K91
-      0x7C200200,  //  0293  CALL	R8	1
-      0x8C20035C,  //  0294  GETMET	R8	R1	K92
-      0x60280018,  //  0295  GETGBL	R10	G24
-      0x582C0064,  //  0296  LDCONST	R11	K100
-      0x5C300C00,  //  0297  MOVE	R12	R6
-      0x5C340E00,  //  0298  MOVE	R13	R7
-      0x7C280600,  //  0299  CALL	R10	3
-      0x7C200400,  //  029A  CALL	R8	2
-      0x8C20035F,  //  029B  GETMET	R8	R1	K95
-      0x88280360,  //  029C  GETMBR	R10	R1	K96
-      0x7C200400,  //  029D  CALL	R8	2
-      0x8C200361,  //  029E  GETMET	R8	R1	K97
-      0x7C200200,  //  029F  CALL	R8	1
-      0x70020000,  //  02A0  JMP		#02A2
-      0xB0080000,  //  02A1  RAISE	2	R0	R0
-      0x80000000,  //  02A2  RET	0
+      0x60200018,  //  0191  GETGBL	R8	G24
+      0x5824004B,  //  0192  LDCONST	R9	K75
+      0x5C280A00,  //  0193  MOVE	R10	R5
+      0x7C200400,  //  0194  CALL	R8	2
+      0x5824000A,  //  0195  LDCONST	R9	K10
+      0x7C1C0400,  //  0196  CALL	R7	2
+      0x7002000C,  //  0197  JMP		#01A5
+      0x741A0002,  //  0198  JMPT	R6	#019C
+      0x881C010B,  //  0199  GETMBR	R7	R0	K11
+      0x881C0F31,  //  019A  GETMBR	R7	R7	K49
+      0x741E0005,  //  019B  JMPT	R7	#01A2
+      0x881C010B,  //  019C  GETMBR	R7	R0	K11
+      0x50200200,  //  019D  LDBOOL	R8	1	0
+      0x901E6208,  //  019E  SETMBR	R7	K49	R8
+      0x881C010B,  //  019F  GETMBR	R7	R0	K11
+      0x8C1C0F12,  //  01A0  GETMET	R7	R7	K18
+      0x7C1C0200,  //  01A1  CALL	R7	1
+      0x8C1C0313,  //  01A2  GETMET	R7	R1	K19
+      0x5824004C,  //  01A3  LDCONST	R9	K76
+      0x7C1C0400,  //  01A4  CALL	R7	2
+      0x700200B9,  //  01A5  JMP		#0260
+      0x8C180305,  //  01A6  GETMET	R6	R1	K5
+      0x5820004D,  //  01A7  LDCONST	R8	K77
+      0x7C180400,  //  01A8  CALL	R6	2
+      0x781A002A,  //  01A9  JMPF	R6	#01D5
+      0x8C18030D,  //  01AA  GETMET	R6	R1	K13
+      0x5820004E,  //  01AB  LDCONST	R8	K78
+      0x7C180400,  //  01AC  CALL	R6	2
+      0x8C1C030D,  //  01AD  GETMET	R7	R1	K13
+      0x5824000D,  //  01AE  LDCONST	R9	K13
+      0x7C1C0400,  //  01AF  CALL	R7	2
+      0x8C20030D,  //  01B0  GETMET	R8	R1	K13
+      0x58280044,  //  01B1  LDCONST	R10	K68
+      0x7C200400,  //  01B2  CALL	R8	2
+      0xB8261000,  //  01B3  GETNGBL	R9	K8
+      0x60280018,  //  01B4  GETGBL	R10	G24
+      0x582C004F,  //  01B5  LDCONST	R11	K79
+      0x5C300C00,  //  01B6  MOVE	R12	R6
+      0x5C340E00,  //  01B7  MOVE	R13	R7
+      0x7C280600,  //  01B8  CALL	R10	3
+      0x582C000A,  //  01B9  LDCONST	R11	K10
+      0x7C240400,  //  01BA  CALL	R9	2
+      0x8824010B,  //  01BB  GETMBR	R9	R0	K11
+      0x88241338,  //  01BC  GETMBR	R9	R9	K56
+      0x8C241335,  //  01BD  GETMET	R9	R9	K53
+      0x5C2C0C00,  //  01BE  MOVE	R11	R6
+      0x7C240400,  //  01BF  CALL	R9	2
+      0x4C280000,  //  01C0  LDNIL	R10
+      0x2028120A,  //  01C1  NE	R10	R9	R10
+      0x782A000D,  //  01C2  JMPF	R10	#01D1
+      0x60280013,  //  01C3  GETGBL	R10	G19
+      0x7C280000,  //  01C4  CALL	R10	0
+      0x78220000,  //  01C5  JMPF	R8	#01C7
+      0x982A8A08,  //  01C6  SETIDX	R10	K69	R8
+      0x8C2C133F,  //  01C7  GETMET	R11	R9	K63
+      0x5C341200,  //  01C8  MOVE	R13	R9
+      0x5C381400,  //  01C9  MOVE	R14	R10
+      0x5C3C0E00,  //  01CA  MOVE	R15	R7
+      0x7C2C0800,  //  01CB  CALL	R11	4
+      0x882C010B,  //  01CC  GETMBR	R11	R0	K11
+      0x8C2C1750,  //  01CD  GETMET	R11	R11	K80
+      0x5C340C00,  //  01CE  MOVE	R13	R6
+      0x5C381400,  //  01CF  MOVE	R14	R10
+      0x7C2C0600,  //  01D0  CALL	R11	3
+      0x8C280313,  //  01D1  GETMET	R10	R1	K19
+      0x5830004C,  //  01D2  LDCONST	R12	K76
+      0x7C280400,  //  01D3  CALL	R10	2
+      0x7002008A,  //  01D4  JMP		#0260
+      0x8C180305,  //  01D5  GETMET	R6	R1	K5
+      0x58200051,  //  01D6  LDCONST	R8	K81
+      0x7C180400,  //  01D7  CALL	R6	2
+      0x781A005D,  //  01D8  JMPF	R6	#0237
+      0x8C18030D,  //  01D9  GETMET	R6	R1	K13
+      0x58200052,  //  01DA  LDCONST	R8	K82
+      0x7C180400,  //  01DB  CALL	R6	2
+      0x4C1C0000,  //  01DC  LDNIL	R7
+      0x1C1C0C07,  //  01DD  EQ	R7	R6	R7
+      0x741E0001,  //  01DE  JMPT	R7	#01E1
+      0x1C1C0D3A,  //  01DF  EQ	R7	R6	K58
+      0x781E0000,  //  01E0  JMPF	R7	#01E2
+      0xB006A754,  //  01E1  RAISE	1	K83	K84
+      0x581C0029,  //  01E2  LDCONST	R7	K41
+      0x60200008,  //  01E3  GETGBL	R8	G8
+      0x5C240E00,  //  01E4  MOVE	R9	R7
+      0x7C200200,  //  01E5  CALL	R8	1
+      0x8C240305,  //  01E6  GETMET	R9	R1	K5
+      0x002E9C08,  //  01E7  ADD	R11	K78	R8
+      0x7C240400,  //  01E8  CALL	R9	2
+      0x78260048,  //  01E9  JMPF	R9	#0233
+      0x8C24030D,  //  01EA  GETMET	R9	R1	K13
+      0x002E9C08,  //  01EB  ADD	R11	K78	R8
+      0x7C240400,  //  01EC  CALL	R9	2
+      0x8C28030D,  //  01ED  GETMET	R10	R1	K13
+      0x00321A08,  //  01EE  ADD	R12	K13	R8
+      0x7C280400,  //  01EF  CALL	R10	2
+      0x8C2C030D,  //  01F0  GETMET	R11	R1	K13
+      0x00368808,  //  01F1  ADD	R13	K68	R8
+      0x7C2C0400,  //  01F2  CALL	R11	2
+      0x2030133A,  //  01F3  NE	R12	R9	K58
+      0x78320037,  //  01F4  JMPF	R12	#022D
+      0x8830010B,  //  01F5  GETMBR	R12	R0	K11
+      0x88301938,  //  01F6  GETMBR	R12	R12	K56
+      0x8C301935,  //  01F7  GETMET	R12	R12	K53
+      0x5C381200,  //  01F8  MOVE	R14	R9
+      0x7C300400,  //  01F9  CALL	R12	2
+      0x4C340000,  //  01FA  LDNIL	R13
+      0x2034180D,  //  01FB  NE	R13	R12	R13
+      0x7836002F,  //  01FC  JMPF	R13	#022D
+      0x60340013,  //  01FD  GETGBL	R13	G19
+      0x7C340000,  //  01FE  CALL	R13	0
+      0x9836A406,  //  01FF  SETIDX	R13	K82	R6
+      0x98367209,  //  0200  SETIDX	R13	K57	R9
+      0x782E0000,  //  0201  JMPF	R11	#0203
+      0x98368A0B,  //  0202  SETIDX	R13	K69	R11
+      0x8C38193F,  //  0203  GETMET	R14	R12	K63
+      0x5C401800,  //  0204  MOVE	R16	R12
+      0x5C441A00,  //  0205  MOVE	R17	R13
+      0x5C481400,  //  0206  MOVE	R18	R10
+      0x7C380800,  //  0207  CALL	R14	4
+      0x50380000,  //  0208  LDBOOL	R14	0	0
+      0x603C0010,  //  0209  GETGBL	R15	G16
+      0x8840010B,  //  020A  GETMBR	R16	R0	K11
+      0x88402137,  //  020B  GETMBR	R16	R16	K55
+      0x7C3C0200,  //  020C  CALL	R15	1
+      0xA802000B,  //  020D  EXBLK	0	#021A
+      0x5C401E00,  //  020E  MOVE	R16	R15
+      0x7C400000,  //  020F  CALL	R16	0
+      0x8C440155,  //  0210  GETMET	R17	R0	K85
+      0x5C4C2000,  //  0211  MOVE	R19	R16
+      0x5C501A00,  //  0212  MOVE	R20	R13
+      0x7C440600,  //  0213  CALL	R17	3
+      0x78460001,  //  0214  JMPF	R17	#0217
+      0x50380200,  //  0215  LDBOOL	R14	1	0
+      0x70020000,  //  0216  JMP		#0218
+      0x7001FFF5,  //  0217  JMP		#020E
+      0xA8040001,  //  0218  EXBLK	1	1
+      0x70020002,  //  0219  JMP		#021D
+      0x583C0049,  //  021A  LDCONST	R15	K73
+      0xAC3C0200,  //  021B  CATCH	R15	1	0
+      0xB0080000,  //  021C  RAISE	2	R0	R0
+      0x5C3C1C00,  //  021D  MOVE	R15	R14
+      0x743E000D,  //  021E  JMPT	R15	#022D
+      0xB83E1000,  //  021F  GETNGBL	R15	K8
+      0x60400018,  //  0220  GETGBL	R16	G24
+      0x58440056,  //  0221  LDCONST	R17	K86
+      0x5C480C00,  //  0222  MOVE	R18	R6
+      0x5C4C1200,  //  0223  MOVE	R19	R9
+      0x5C501400,  //  0224  MOVE	R20	R10
+      0x7C400800,  //  0225  CALL	R16	4
+      0x5844000A,  //  0226  LDCONST	R17	K10
+      0x7C3C0400,  //  0227  CALL	R15	2
+      0x883C010B,  //  0228  GETMBR	R15	R0	K11
+      0x8C3C1F50,  //  0229  GETMET	R15	R15	K80
+      0x5C441200,  //  022A  MOVE	R17	R9
+      0x5C481A00,  //  022B  MOVE	R18	R13
+      0x7C3C0600,  //  022C  CALL	R15	3
+      0x001C0F2E,  //  022D  ADD	R7	R7	K46
+      0x60300008,  //  022E  GETGBL	R12	G8
+      0x5C340E00,  //  022F  MOVE	R13	R7
+      0x7C300200,  //  0230  CALL	R12	1
+      0x5C201800,  //  0231  MOVE	R8	R12
+      0x7001FFB2,  //  0232  JMP		#01E6
+      0x8C240313,  //  0233  GETMET	R9	R1	K19
+      0x582C004C,  //  0234  LDCONST	R11	K76
+      0x7C240400,  //  0235  CALL	R9	2
+      0x70020028,  //  0236  JMP		#0260
+      0x4C180000,  //  0237  LDNIL	R6
+      0x601C0010,  //  0238  GETGBL	R7	G16
+      0x8C200333,  //  0239  GETMET	R8	R1	K51
+      0x7C200200,  //  023A  CALL	R8	1
+      0x0420112E,  //  023B  SUB	R8	R8	K46
+      0x40225208,  //  023C  CONNECT	R8	K41	R8
+      0x7C1C0200,  //  023D  CALL	R7	1
+      0xA8020013,  //  023E  EXBLK	0	#0253
+      0x5C200E00,  //  023F  MOVE	R8	R7
+      0x7C200000,  //  0240  CALL	R8	0
+      0x8C240334,  //  0241  GETMET	R9	R1	K52
+      0x5C2C1000,  //  0242  MOVE	R11	R8
+      0x7C240400,  //  0243  CALL	R9	2
+      0x8C280535,  //  0244  GETMET	R10	R2	K53
+      0x5C301200,  //  0245  MOVE	R12	R9
+      0x58340057,  //  0246  LDCONST	R13	K87
+      0x7C280600,  //  0247  CALL	R10	3
+      0x1C281529,  //  0248  EQ	R10	R10	K41
+      0x782A0005,  //  0249  JMPF	R10	#0250
+      0x60280009,  //  024A  GETGBL	R10	G9
+      0x402E1536,  //  024B  CONNECT	R11	K10	K54
+      0x942C120B,  //  024C  GETIDX	R11	R9	R11
+      0x7C280200,  //  024D  CALL	R10	1
+      0x5C181400,  //  024E  MOVE	R6	R10
+      0x70020000,  //  024F  JMP		#0251
+      0x7001FFED,  //  0250  JMP		#023F
+      0xA8040001,  //  0251  EXBLK	1	1
+      0x70020002,  //  0252  JMP		#0256
+      0x581C0049,  //  0253  LDCONST	R7	K73
+      0xAC1C0200,  //  0254  CATCH	R7	1	0
+      0xB0080000,  //  0255  RAISE	2	R0	R0
+      0x4C1C0000,  //  0256  LDNIL	R7
+      0x201C0C07,  //  0257  NE	R7	R6	R7
+      0x781E0006,  //  0258  JMPF	R7	#0260
+      0x881C010B,  //  0259  GETMBR	R7	R0	K11
+      0x8C1C0F58,  //  025A  GETMET	R7	R7	K88
+      0x5C240C00,  //  025B  MOVE	R9	R6
+      0x7C1C0400,  //  025C  CALL	R7	2
+      0x8C1C0313,  //  025D  GETMET	R7	R1	K19
+      0x5824004C,  //  025E  LDCONST	R9	K76
+      0x7C1C0400,  //  025F  CALL	R7	2
+      0x78160011,  //  0260  JMPF	R5	#0273
+      0x8C180359,  //  0261  GETMET	R6	R1	K89
+      0x5820005A,  //  0262  LDCONST	R8	K90
+      0x7C180400,  //  0263  CALL	R6	2
+      0x8C18035B,  //  0264  GETMET	R6	R1	K91
+      0x7C180200,  //  0265  CALL	R6	1
+      0x8C18035C,  //  0266  GETMET	R6	R1	K92
+      0x60200018,  //  0267  GETGBL	R8	G24
+      0x5824005D,  //  0268  LDCONST	R9	K93
+      0x8C28035E,  //  0269  GETMET	R10	R1	K94
+      0x5C300A00,  //  026A  MOVE	R12	R5
+      0x7C280400,  //  026B  CALL	R10	2
+      0x7C200400,  //  026C  CALL	R8	2
+      0x7C180400,  //  026D  CALL	R6	2
+      0x8C18035F,  //  026E  GETMET	R6	R1	K95
+      0x88200360,  //  026F  GETMBR	R8	R1	K96
+      0x7C180400,  //  0270  CALL	R6	2
+      0x8C180361,  //  0271  GETMET	R6	R1	K97
+      0x7C180200,  //  0272  CALL	R6	1
+      0xA8040001,  //  0273  EXBLK	1	1
+      0x7002001C,  //  0274  JMP		#0292
+      0xAC180002,  //  0275  CATCH	R6	0	2
+      0x70020019,  //  0276  JMP		#0291
+      0xB8221000,  //  0277  GETNGBL	R8	K8
+      0x60240018,  //  0278  GETGBL	R9	G24
+      0x58280062,  //  0279  LDCONST	R10	K98
+      0x5C2C0C00,  //  027A  MOVE	R11	R6
+      0x5C300E00,  //  027B  MOVE	R12	R7
+      0x7C240600,  //  027C  CALL	R9	3
+      0x58280063,  //  027D  LDCONST	R10	K99
+      0x7C200400,  //  027E  CALL	R8	2
+      0x8C200359,  //  027F  GETMET	R8	R1	K89
+      0x5828005A,  //  0280  LDCONST	R10	K90
+      0x7C200400,  //  0281  CALL	R8	2
+      0x8C20035B,  //  0282  GETMET	R8	R1	K91
+      0x7C200200,  //  0283  CALL	R8	1
+      0x8C20035C,  //  0284  GETMET	R8	R1	K92
+      0x60280018,  //  0285  GETGBL	R10	G24
+      0x582C0064,  //  0286  LDCONST	R11	K100
+      0x5C300C00,  //  0287  MOVE	R12	R6
+      0x5C340E00,  //  0288  MOVE	R13	R7
+      0x7C280600,  //  0289  CALL	R10	3
+      0x7C200400,  //  028A  CALL	R8	2
+      0x8C20035F,  //  028B  GETMET	R8	R1	K95
+      0x88280360,  //  028C  GETMBR	R10	R1	K96
+      0x7C200400,  //  028D  CALL	R8	2
+      0x8C200361,  //  028E  GETMET	R8	R1	K97
+      0x7C200200,  //  028F  CALL	R8	1
+      0x70020000,  //  0290  JMP		#0292
+      0xB0080000,  //  0291  RAISE	2	R0	R0
+      0x80000000,  //  0292  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
@@ -135,7 +135,7 @@ be_local_closure(class_Matter_Device_event_fabrics_saved,   /* name */
 extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_start_commissioning_complete,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -143,22 +143,21 @@ be_local_closure(class_Matter_Device_start_commissioning_complete,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Device, 
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
+    ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(get_fabric),
     /* K1   */  be_nested_str_weak(get_fabric_id),
     /* K2   */  be_nested_str_weak(copy),
     /* K3   */  be_nested_str_weak(reverse),
     /* K4   */  be_nested_str_weak(tohex),
     /* K5   */  be_nested_str_weak(get_admin_vendor_name),
-    /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X2D_X2D_X2D_X20Commissioning_X20complete_X20for_X20Fabric_X20_X27_X25s_X27_X20_X28Vendor_X20_X25s_X29_X20_X2D_X2D_X2D),
-    /* K9   */  be_const_int(2),
-    /* K10  */  be_nested_str_weak(stop_basic_commissioning),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20_X2D_X2D_X2D_X20Commissioning_X20complete_X20for_X20Fabric_X20_X27_X25s_X27_X20_X28Vendor_X20_X25s_X29_X20_X2D_X2D_X2D),
+    /* K8   */  be_const_int(2),
+    /* K9   */  be_nested_str_weak(stop_basic_commissioning),
     }),
     be_str_weak(start_commissioning_complete),
     &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
+    ( &(const binstruction[23]) {  /* code */
       0x8C080300,  //  0000  GETMET	R2	R1	K0
       0x7C080200,  //  0001  CALL	R2	1
       0x8C0C0501,  //  0002  GETMET	R3	R2	K1
@@ -172,17 +171,16 @@ be_local_closure(class_Matter_Device_start_commissioning_complete,   /* name */
       0x8C100505,  //  000A  GETMET	R4	R2	K5
       0x7C100200,  //  000B  CALL	R4	1
       0xB8160C00,  //  000C  GETNGBL	R5	K6
-      0x8C140B07,  //  000D  GETMET	R5	R5	K7
-      0x601C0018,  //  000E  GETGBL	R7	G24
-      0x58200008,  //  000F  LDCONST	R8	K8
-      0x5C240600,  //  0010  MOVE	R9	R3
-      0x5C280800,  //  0011  MOVE	R10	R4
-      0x7C1C0600,  //  0012  CALL	R7	3
-      0x58200009,  //  0013  LDCONST	R8	K9
-      0x7C140600,  //  0014  CALL	R5	3
-      0x8C14010A,  //  0015  GETMET	R5	R0	K10
-      0x7C140200,  //  0016  CALL	R5	1
-      0x80000000,  //  0017  RET	0
+      0x60180018,  //  000D  GETGBL	R6	G24
+      0x581C0007,  //  000E  LDCONST	R7	K7
+      0x5C200600,  //  000F  MOVE	R8	R3
+      0x5C240800,  //  0010  MOVE	R9	R4
+      0x7C180600,  //  0011  CALL	R6	3
+      0x581C0008,  //  0012  LDCONST	R7	K8
+      0x7C140400,  //  0013  CALL	R5	2
+      0x8C140109,  //  0014  GETMET	R5	R0	K9
+      0x7C140200,  //  0015  CALL	R5	1
+      0x80000000,  //  0016  RET	0
     })
   )
 );
@@ -195,7 +193,7 @@ be_local_closure(class_Matter_Device_start_commissioning_complete,   /* name */
 extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -203,29 +201,28 @@ be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Device, 
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
+    ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
     /* K1   */  be_nested_str_weak(plugins_config),
     /* K2   */  be_nested_str_weak(contains),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
-    /* K6   */  be_const_int(3),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(remove),
-    /* K10  */  be_nested_str_weak(plugins_persist),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(plugins),
-    /* K13  */  be_nested_str_weak(get_endpoint),
-    /* K14  */  be_const_int(1),
-    /* K15  */  be_nested_str_weak(clean_remotes),
-    /* K16  */  be_nested_str_weak(save_param),
-    /* K17  */  be_nested_str_weak(signal_endpoints_changed),
+    /* K3   */  be_nested_str_weak(log),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
+    /* K7   */  be_const_int(2),
+    /* K8   */  be_nested_str_weak(remove),
+    /* K9   */  be_nested_str_weak(plugins_persist),
+    /* K10  */  be_const_int(0),
+    /* K11  */  be_nested_str_weak(plugins),
+    /* K12  */  be_nested_str_weak(get_endpoint),
+    /* K13  */  be_const_int(1),
+    /* K14  */  be_nested_str_weak(clean_remotes),
+    /* K15  */  be_nested_str_weak(save_param),
+    /* K16  */  be_nested_str_weak(signal_endpoints_changed),
     }),
     be_str_weak(bridge_remove_endpoint),
     &be_const_str_solidified,
-    ( &(const binstruction[58]) {  /* code */
+    ( &(const binstruction[56]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0x600C0008,  //  0001  GETGBL	R3	G8
       0x5C100200,  //  0002  MOVE	R4	R1
@@ -236,54 +233,52 @@ be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
       0x8C180D02,  //  0007  GETMET	R6	R6	K2
       0x5C200600,  //  0008  MOVE	R8	R3
       0x7C180400,  //  0009  CALL	R6	2
-      0x741A0005,  //  000A  JMPT	R6	#0011
+      0x741A0004,  //  000A  JMPT	R6	#0010
       0xB81A0600,  //  000B  GETNGBL	R6	K3
-      0x8C180D04,  //  000C  GETMET	R6	R6	K4
-      0x00220A03,  //  000D  ADD	R8	K5	R3
-      0x58240006,  //  000E  LDCONST	R9	K6
-      0x7C180600,  //  000F  CALL	R6	3
-      0x80000C00,  //  0010  RET	0
-      0xB81A0600,  //  0011  GETNGBL	R6	K3
-      0x8C180D04,  //  0012  GETMET	R6	R6	K4
-      0x60200018,  //  0013  GETGBL	R8	G24
-      0x58240007,  //  0014  LDCONST	R9	K7
-      0x5C280200,  //  0015  MOVE	R10	R1
-      0x7C200400,  //  0016  CALL	R8	2
-      0x58240008,  //  0017  LDCONST	R9	K8
-      0x7C180600,  //  0018  CALL	R6	3
-      0x88180101,  //  0019  GETMBR	R6	R0	K1
-      0x8C180D09,  //  001A  GETMET	R6	R6	K9
-      0x5C200600,  //  001B  MOVE	R8	R3
-      0x7C180400,  //  001C  CALL	R6	2
-      0x50180200,  //  001D  LDBOOL	R6	1	0
-      0x90021406,  //  001E  SETMBR	R0	K10	R6
-      0x5818000B,  //  001F  LDCONST	R6	K11
-      0x601C000C,  //  0020  GETGBL	R7	G12
-      0x8820010C,  //  0021  GETMBR	R8	R0	K12
-      0x7C1C0200,  //  0022  CALL	R7	1
-      0x141C0C07,  //  0023  LT	R7	R6	R7
-      0x781E000D,  //  0024  JMPF	R7	#0033
-      0x881C010C,  //  0025  GETMBR	R7	R0	K12
-      0x941C0E06,  //  0026  GETIDX	R7	R7	R6
-      0x8C1C0F0D,  //  0027  GETMET	R7	R7	K13
-      0x7C1C0200,  //  0028  CALL	R7	1
-      0x1C1C0207,  //  0029  EQ	R7	R1	R7
-      0x781E0005,  //  002A  JMPF	R7	#0031
-      0x881C010C,  //  002B  GETMBR	R7	R0	K12
-      0x8C1C0F09,  //  002C  GETMET	R7	R7	K9
-      0x5C240C00,  //  002D  MOVE	R9	R6
-      0x7C1C0400,  //  002E  CALL	R7	2
-      0x70020002,  //  002F  JMP		#0033
-      0x70020000,  //  0030  JMP		#0032
-      0x00180D0E,  //  0031  ADD	R6	R6	K14
-      0x7001FFEC,  //  0032  JMP		#0020
+      0x001E0803,  //  000C  ADD	R7	K4	R3
+      0x58200005,  //  000D  LDCONST	R8	K5
+      0x7C180400,  //  000E  CALL	R6	2
+      0x80000C00,  //  000F  RET	0
+      0xB81A0600,  //  0010  GETNGBL	R6	K3
+      0x601C0018,  //  0011  GETGBL	R7	G24
+      0x58200006,  //  0012  LDCONST	R8	K6
+      0x5C240200,  //  0013  MOVE	R9	R1
+      0x7C1C0400,  //  0014  CALL	R7	2
+      0x58200007,  //  0015  LDCONST	R8	K7
+      0x7C180400,  //  0016  CALL	R6	2
+      0x88180101,  //  0017  GETMBR	R6	R0	K1
+      0x8C180D08,  //  0018  GETMET	R6	R6	K8
+      0x5C200600,  //  0019  MOVE	R8	R3
+      0x7C180400,  //  001A  CALL	R6	2
+      0x50180200,  //  001B  LDBOOL	R6	1	0
+      0x90021206,  //  001C  SETMBR	R0	K9	R6
+      0x5818000A,  //  001D  LDCONST	R6	K10
+      0x601C000C,  //  001E  GETGBL	R7	G12
+      0x8820010B,  //  001F  GETMBR	R8	R0	K11
+      0x7C1C0200,  //  0020  CALL	R7	1
+      0x141C0C07,  //  0021  LT	R7	R6	R7
+      0x781E000D,  //  0022  JMPF	R7	#0031
+      0x881C010B,  //  0023  GETMBR	R7	R0	K11
+      0x941C0E06,  //  0024  GETIDX	R7	R7	R6
+      0x8C1C0F0C,  //  0025  GETMET	R7	R7	K12
+      0x7C1C0200,  //  0026  CALL	R7	1
+      0x1C1C0207,  //  0027  EQ	R7	R1	R7
+      0x781E0005,  //  0028  JMPF	R7	#002F
+      0x881C010B,  //  0029  GETMBR	R7	R0	K11
+      0x8C1C0F08,  //  002A  GETMET	R7	R7	K8
+      0x5C240C00,  //  002B  MOVE	R9	R6
+      0x7C1C0400,  //  002C  CALL	R7	2
+      0x70020002,  //  002D  JMP		#0031
+      0x70020000,  //  002E  JMP		#0030
+      0x00180D0D,  //  002F  ADD	R6	R6	K13
+      0x7001FFEC,  //  0030  JMP		#001E
+      0x8C1C010E,  //  0031  GETMET	R7	R0	K14
+      0x7C1C0200,  //  0032  CALL	R7	1
       0x8C1C010F,  //  0033  GETMET	R7	R0	K15
       0x7C1C0200,  //  0034  CALL	R7	1
       0x8C1C0110,  //  0035  GETMET	R7	R0	K16
       0x7C1C0200,  //  0036  CALL	R7	1
-      0x8C1C0111,  //  0037  GETMET	R7	R0	K17
-      0x7C1C0200,  //  0038  CALL	R7	1
-      0x80000000,  //  0039  RET	0
+      0x80000000,  //  0037  RET	0
     })
   )
 );
@@ -296,7 +291,7 @@ be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
 extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_mdns_remove_PASE,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -304,113 +299,107 @@ be_local_closure(class_Matter_Device_mdns_remove_PASE,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Device, 
     1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
+    ( &(const bvalue[19]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
     /* K1   */  be_nested_str_weak(mdns_pase_eth),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eremove_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
-    /* K5   */  be_nested_str_weak(_matterc),
-    /* K6   */  be_nested_str_weak(_udp),
-    /* K7   */  be_nested_str_weak(commissioning_instance_eth),
-    /* K8   */  be_nested_str_weak(hostname_eth),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
-    /* K11  */  be_nested_str_weak(eth),
-    /* K12  */  be_nested_str_weak(remove_service),
-    /* K13  */  be_nested_str_weak(mdns_pase_wifi),
-    /* K14  */  be_nested_str_weak(commissioning_instance_wifi),
-    /* K15  */  be_nested_str_weak(hostname_wifi),
-    /* K16  */  be_nested_str_weak(wifi),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K18  */  be_nested_str_weak(_X7C),
-    /* K19  */  be_const_int(2),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eremove_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
+    /* K4   */  be_nested_str_weak(_matterc),
+    /* K5   */  be_nested_str_weak(_udp),
+    /* K6   */  be_nested_str_weak(commissioning_instance_eth),
+    /* K7   */  be_nested_str_weak(hostname_eth),
+    /* K8   */  be_const_int(3),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
+    /* K10  */  be_nested_str_weak(eth),
+    /* K11  */  be_nested_str_weak(remove_service),
+    /* K12  */  be_nested_str_weak(mdns_pase_wifi),
+    /* K13  */  be_nested_str_weak(commissioning_instance_wifi),
+    /* K14  */  be_nested_str_weak(hostname_wifi),
+    /* K15  */  be_nested_str_weak(wifi),
+    /* K16  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K17  */  be_nested_str_weak(_X7C),
+    /* K18  */  be_const_int(2),
     }),
     be_str_weak(mdns_remove_PASE),
     &be_const_str_solidified,
-    ( &(const binstruction[82]) {  /* code */
+    ( &(const binstruction[77]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA802003D,  //  0001  EXBLK	0	#0040
+      0xA8020039,  //  0001  EXBLK	0	#003C
       0x88080101,  //  0002  GETMBR	R2	R0	K1
-      0x780A001B,  //  0003  JMPF	R2	#0020
+      0x780A0019,  //  0003  JMPF	R2	#001E
       0xB80A0400,  //  0004  GETNGBL	R2	K2
-      0x8C080503,  //  0005  GETMET	R2	R2	K3
-      0x60100018,  //  0006  GETGBL	R4	G24
+      0x600C0018,  //  0005  GETGBL	R3	G24
+      0x58100003,  //  0006  LDCONST	R4	K3
       0x58140004,  //  0007  LDCONST	R5	K4
       0x58180005,  //  0008  LDCONST	R6	K5
-      0x581C0006,  //  0009  LDCONST	R7	K6
+      0x881C0106,  //  0009  GETMBR	R7	R0	K6
       0x88200107,  //  000A  GETMBR	R8	R0	K7
-      0x88240108,  //  000B  GETMBR	R9	R0	K8
-      0x7C100A00,  //  000C  CALL	R4	5
-      0x58140009,  //  000D  LDCONST	R5	K9
-      0x7C080600,  //  000E  CALL	R2	3
-      0xB80A0400,  //  000F  GETNGBL	R2	K2
-      0x8C080503,  //  0010  GETMET	R2	R2	K3
-      0x60100018,  //  0011  GETGBL	R4	G24
-      0x5814000A,  //  0012  LDCONST	R5	K10
-      0x5818000B,  //  0013  LDCONST	R6	K11
-      0x881C0107,  //  0014  GETMBR	R7	R0	K7
-      0x7C100600,  //  0015  CALL	R4	3
-      0x58140009,  //  0016  LDCONST	R5	K9
-      0x7C080600,  //  0017  CALL	R2	3
-      0x50080000,  //  0018  LDBOOL	R2	0	0
-      0x90020202,  //  0019  SETMBR	R0	K1	R2
-      0x8C08030C,  //  001A  GETMET	R2	R1	K12
-      0x58100005,  //  001B  LDCONST	R4	K5
-      0x58140006,  //  001C  LDCONST	R5	K6
-      0x88180107,  //  001D  GETMBR	R6	R0	K7
-      0x881C0108,  //  001E  GETMBR	R7	R0	K8
-      0x7C080A00,  //  001F  CALL	R2	5
-      0x8808010D,  //  0020  GETMBR	R2	R0	K13
-      0x780A001B,  //  0021  JMPF	R2	#003E
-      0xB80A0400,  //  0022  GETNGBL	R2	K2
-      0x8C080503,  //  0023  GETMET	R2	R2	K3
-      0x60100018,  //  0024  GETGBL	R4	G24
-      0x58140004,  //  0025  LDCONST	R5	K4
-      0x58180005,  //  0026  LDCONST	R6	K5
-      0x581C0006,  //  0027  LDCONST	R7	K6
-      0x8820010E,  //  0028  GETMBR	R8	R0	K14
-      0x8824010F,  //  0029  GETMBR	R9	R0	K15
-      0x7C100A00,  //  002A  CALL	R4	5
-      0x58140009,  //  002B  LDCONST	R5	K9
-      0x7C080600,  //  002C  CALL	R2	3
-      0xB80A0400,  //  002D  GETNGBL	R2	K2
-      0x8C080503,  //  002E  GETMET	R2	R2	K3
-      0x60100018,  //  002F  GETGBL	R4	G24
-      0x5814000A,  //  0030  LDCONST	R5	K10
-      0x58180010,  //  0031  LDCONST	R6	K16
-      0x881C010E,  //  0032  GETMBR	R7	R0	K14
-      0x7C100600,  //  0033  CALL	R4	3
-      0x58140009,  //  0034  LDCONST	R5	K9
-      0x7C080600,  //  0035  CALL	R2	3
-      0x50080000,  //  0036  LDBOOL	R2	0	0
-      0x90021A02,  //  0037  SETMBR	R0	K13	R2
-      0x8C08030C,  //  0038  GETMET	R2	R1	K12
-      0x58100005,  //  0039  LDCONST	R4	K5
-      0x58140006,  //  003A  LDCONST	R5	K6
-      0x8818010E,  //  003B  GETMBR	R6	R0	K14
-      0x881C010F,  //  003C  GETMBR	R7	R0	K15
-      0x7C080A00,  //  003D  CALL	R2	5
-      0xA8040001,  //  003E  EXBLK	1	1
-      0x70020010,  //  003F  JMP		#0051
-      0xAC080002,  //  0040  CATCH	R2	0	2
-      0x7002000D,  //  0041  JMP		#0050
-      0xB8120400,  //  0042  GETNGBL	R4	K2
-      0x8C100903,  //  0043  GETMET	R4	R4	K3
+      0x7C0C0A00,  //  000B  CALL	R3	5
+      0x58100008,  //  000C  LDCONST	R4	K8
+      0x7C080400,  //  000D  CALL	R2	2
+      0xB80A0400,  //  000E  GETNGBL	R2	K2
+      0x600C0018,  //  000F  GETGBL	R3	G24
+      0x58100009,  //  0010  LDCONST	R4	K9
+      0x5814000A,  //  0011  LDCONST	R5	K10
+      0x88180106,  //  0012  GETMBR	R6	R0	K6
+      0x7C0C0600,  //  0013  CALL	R3	3
+      0x58100008,  //  0014  LDCONST	R4	K8
+      0x7C080400,  //  0015  CALL	R2	2
+      0x50080000,  //  0016  LDBOOL	R2	0	0
+      0x90020202,  //  0017  SETMBR	R0	K1	R2
+      0x8C08030B,  //  0018  GETMET	R2	R1	K11
+      0x58100004,  //  0019  LDCONST	R4	K4
+      0x58140005,  //  001A  LDCONST	R5	K5
+      0x88180106,  //  001B  GETMBR	R6	R0	K6
+      0x881C0107,  //  001C  GETMBR	R7	R0	K7
+      0x7C080A00,  //  001D  CALL	R2	5
+      0x8808010C,  //  001E  GETMBR	R2	R0	K12
+      0x780A0019,  //  001F  JMPF	R2	#003A
+      0xB80A0400,  //  0020  GETNGBL	R2	K2
+      0x600C0018,  //  0021  GETGBL	R3	G24
+      0x58100003,  //  0022  LDCONST	R4	K3
+      0x58140004,  //  0023  LDCONST	R5	K4
+      0x58180005,  //  0024  LDCONST	R6	K5
+      0x881C010D,  //  0025  GETMBR	R7	R0	K13
+      0x8820010E,  //  0026  GETMBR	R8	R0	K14
+      0x7C0C0A00,  //  0027  CALL	R3	5
+      0x58100008,  //  0028  LDCONST	R4	K8
+      0x7C080400,  //  0029  CALL	R2	2
+      0xB80A0400,  //  002A  GETNGBL	R2	K2
+      0x600C0018,  //  002B  GETGBL	R3	G24
+      0x58100009,  //  002C  LDCONST	R4	K9
+      0x5814000F,  //  002D  LDCONST	R5	K15
+      0x8818010D,  //  002E  GETMBR	R6	R0	K13
+      0x7C0C0600,  //  002F  CALL	R3	3
+      0x58100008,  //  0030  LDCONST	R4	K8
+      0x7C080400,  //  0031  CALL	R2	2
+      0x50080000,  //  0032  LDBOOL	R2	0	0
+      0x90021802,  //  0033  SETMBR	R0	K12	R2
+      0x8C08030B,  //  0034  GETMET	R2	R1	K11
+      0x58100004,  //  0035  LDCONST	R4	K4
+      0x58140005,  //  0036  LDCONST	R5	K5
+      0x8818010D,  //  0037  GETMBR	R6	R0	K13
+      0x881C010E,  //  0038  GETMBR	R7	R0	K14
+      0x7C080A00,  //  0039  CALL	R2	5
+      0xA8040001,  //  003A  EXBLK	1	1
+      0x7002000F,  //  003B  JMP		#004C
+      0xAC080002,  //  003C  CATCH	R2	0	2
+      0x7002000C,  //  003D  JMP		#004B
+      0xB8120400,  //  003E  GETNGBL	R4	K2
+      0x60140008,  //  003F  GETGBL	R5	G8
+      0x5C180400,  //  0040  MOVE	R6	R2
+      0x7C140200,  //  0041  CALL	R5	1
+      0x00162005,  //  0042  ADD	R5	K16	R5
+      0x00140B11,  //  0043  ADD	R5	R5	K17
       0x60180008,  //  0044  GETGBL	R6	G8
-      0x5C1C0400,  //  0045  MOVE	R7	R2
+      0x5C1C0600,  //  0045  MOVE	R7	R3
       0x7C180200,  //  0046  CALL	R6	1
-      0x001A2206,  //  0047  ADD	R6	K17	R6
-      0x00180D12,  //  0048  ADD	R6	R6	K18
-      0x601C0008,  //  0049  GETGBL	R7	G8
-      0x5C200600,  //  004A  MOVE	R8	R3
-      0x7C1C0200,  //  004B  CALL	R7	1
-      0x00180C07,  //  004C  ADD	R6	R6	R7
-      0x581C0013,  //  004D  LDCONST	R7	K19
-      0x7C100600,  //  004E  CALL	R4	3
-      0x70020000,  //  004F  JMP		#0051
-      0xB0080000,  //  0050  RAISE	2	R0	R0
-      0x80000000,  //  0051  RET	0
+      0x00140A06,  //  0047  ADD	R5	R5	R6
+      0x58180012,  //  0048  LDCONST	R6	K18
+      0x7C100400,  //  0049  CALL	R4	2
+      0x70020000,  //  004A  JMP		#004C
+      0xB0080000,  //  004B  RAISE	2	R0	R0
+      0x80000000,  //  004C  RET	0
     })
   )
 );
@@ -462,13 +451,13 @@ be_local_closure(class_Matter_Device__mdns_announce_hostname,   /* name */
     }),
     be_str_weak(_mdns_announce_hostname),
     &be_const_str_solidified,
-    ( &(const binstruction[148]) {  /* code */
+    ( &(const binstruction[144]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0xA40E0200,  //  0001  IMPORT	R3	K1
       0x8C100502,  //  0002  GETMET	R4	R2	K2
       0x7C100200,  //  0003  CALL	R4	1
-      0xA802007A,  //  0004  EXBLK	0	#0080
-      0x78060034,  //  0005  JMPF	R1	#003B
+      0xA8020077,  //  0004  EXBLK	0	#007D
+      0x78060033,  //  0005  JMPF	R1	#003A
       0xB8120600,  //  0006  GETNGBL	R4	K3
       0x8C100904,  //  0007  GETMET	R4	R4	K4
       0x7C100200,  //  0008  CALL	R4	1
@@ -501,116 +490,112 @@ be_local_closure(class_Matter_Device__mdns_announce_hostname,   /* name */
       0x5834000A,  //  0023  LDCONST	R13	K10
       0x7C280600,  //  0024  CALL	R10	3
       0x7C140A00,  //  0025  CALL	R5	5
-      0x70020012,  //  0026  JMP		#003A
-      0xB8160600,  //  0027  GETNGBL	R5	K3
-      0x8C140B11,  //  0028  GETMET	R5	R5	K17
-      0x601C0018,  //  0029  GETGBL	R7	G24
-      0x58200012,  //  002A  LDCONST	R8	K18
-      0x88240105,  //  002B  GETMBR	R9	R0	K5
-      0x8C280907,  //  002C  GETMET	R10	R4	K7
-      0x5830000F,  //  002D  LDCONST	R12	K15
-      0x5834000A,  //  002E  LDCONST	R13	K10
-      0x7C280600,  //  002F  CALL	R10	3
-      0x7C1C0600,  //  0030  CALL	R7	3
-      0x58200013,  //  0031  LDCONST	R8	K19
-      0x7C140600,  //  0032  CALL	R5	3
-      0x8C14050E,  //  0033  GETMET	R5	R2	K14
-      0x881C0105,  //  0034  GETMBR	R7	R0	K5
-      0x8C200907,  //  0035  GETMET	R8	R4	K7
-      0x5828000F,  //  0036  LDCONST	R10	K15
-      0x582C000A,  //  0037  LDCONST	R11	K10
-      0x7C200600,  //  0038  CALL	R8	3
-      0x7C140600,  //  0039  CALL	R5	3
-      0x70020033,  //  003A  JMP		#006F
-      0xB8120600,  //  003B  GETNGBL	R4	K3
-      0x8C100914,  //  003C  GETMET	R4	R4	K20
-      0x7C100200,  //  003D  CALL	R4	1
-      0x8C140706,  //  003E  GETMET	R5	R3	K6
-      0x8C1C0907,  //  003F  GETMET	R7	R4	K7
-      0x58240008,  //  0040  LDCONST	R9	K8
-      0x7C1C0400,  //  0041  CALL	R7	2
-      0x58200009,  //  0042  LDCONST	R8	K9
-      0x5824000A,  //  0043  LDCONST	R9	K10
-      0x7C140800,  //  0044  CALL	R5	4
-      0x90022A05,  //  0045  SETMBR	R0	K21	R5
-      0x8814010B,  //  0046  GETMBR	R5	R0	K11
-      0x78160003,  //  0047  JMPF	R5	#004C
-      0x8C14090C,  //  0048  GETMET	R5	R4	K12
-      0x581C000D,  //  0049  LDCONST	R7	K13
-      0x7C140400,  //  004A  CALL	R5	2
-      0x7416000F,  //  004B  JMPT	R5	#005C
-      0x8C14050E,  //  004C  GETMET	R5	R2	K14
-      0x881C0115,  //  004D  GETMBR	R7	R0	K21
-      0x8C200907,  //  004E  GETMET	R8	R4	K7
-      0x5828000D,  //  004F  LDCONST	R10	K13
-      0x582C000A,  //  0050  LDCONST	R11	K10
-      0x7C200600,  //  0051  CALL	R8	3
-      0x8C240907,  //  0052  GETMET	R9	R4	K7
-      0x582C000F,  //  0053  LDCONST	R11	K15
-      0x5830000A,  //  0054  LDCONST	R12	K10
-      0x7C240600,  //  0055  CALL	R9	3
-      0x8C280907,  //  0056  GETMET	R10	R4	K7
-      0x58300010,  //  0057  LDCONST	R12	K16
-      0x5834000A,  //  0058  LDCONST	R13	K10
-      0x7C280600,  //  0059  CALL	R10	3
-      0x7C140A00,  //  005A  CALL	R5	5
-      0x70020012,  //  005B  JMP		#006F
-      0xB8160600,  //  005C  GETNGBL	R5	K3
-      0x8C140B11,  //  005D  GETMET	R5	R5	K17
-      0x601C0018,  //  005E  GETGBL	R7	G24
-      0x58200012,  //  005F  LDCONST	R8	K18
-      0x88240115,  //  0060  GETMBR	R9	R0	K21
-      0x8C280907,  //  0061  GETMET	R10	R4	K7
-      0x5830000F,  //  0062  LDCONST	R12	K15
-      0x5834000A,  //  0063  LDCONST	R13	K10
-      0x7C280600,  //  0064  CALL	R10	3
-      0x7C1C0600,  //  0065  CALL	R7	3
-      0x58200013,  //  0066  LDCONST	R8	K19
-      0x7C140600,  //  0067  CALL	R5	3
-      0x8C14050E,  //  0068  GETMET	R5	R2	K14
-      0x881C0115,  //  0069  GETMBR	R7	R0	K21
-      0x8C200907,  //  006A  GETMET	R8	R4	K7
-      0x5828000F,  //  006B  LDCONST	R10	K15
-      0x582C000A,  //  006C  LDCONST	R11	K10
-      0x7C200600,  //  006D  CALL	R8	3
-      0x7C140600,  //  006E  CALL	R5	3
-      0xB8120600,  //  006F  GETNGBL	R4	K3
-      0x8C100911,  //  0070  GETMET	R4	R4	K17
-      0x60180018,  //  0071  GETGBL	R6	G24
-      0x581C0016,  //  0072  LDCONST	R7	K22
-      0x78060001,  //  0073  JMPF	R1	#0076
-      0x58200004,  //  0074  LDCONST	R8	K4
-      0x70020000,  //  0075  JMP		#0077
-      0x58200014,  //  0076  LDCONST	R8	K20
-      0x78060001,  //  0077  JMPF	R1	#007A
-      0x88240105,  //  0078  GETMBR	R9	R0	K5
-      0x70020000,  //  0079  JMP		#007B
-      0x88240115,  //  007A  GETMBR	R9	R0	K21
-      0x7C180600,  //  007B  CALL	R6	3
-      0x581C0013,  //  007C  LDCONST	R7	K19
-      0x7C100600,  //  007D  CALL	R4	3
-      0xA8040001,  //  007E  EXBLK	1	1
-      0x70020010,  //  007F  JMP		#0091
-      0xAC100002,  //  0080  CATCH	R4	0	2
-      0x7002000D,  //  0081  JMP		#0090
-      0xB81A0600,  //  0082  GETNGBL	R6	K3
-      0x8C180D11,  //  0083  GETMET	R6	R6	K17
-      0x60200008,  //  0084  GETGBL	R8	G8
-      0x5C240800,  //  0085  MOVE	R9	R4
-      0x7C200200,  //  0086  CALL	R8	1
-      0x00222E08,  //  0087  ADD	R8	K23	R8
-      0x00201118,  //  0088  ADD	R8	R8	K24
-      0x60240008,  //  0089  GETGBL	R9	G8
-      0x5C280A00,  //  008A  MOVE	R10	R5
-      0x7C240200,  //  008B  CALL	R9	1
-      0x00201009,  //  008C  ADD	R8	R8	R9
-      0x58240019,  //  008D  LDCONST	R9	K25
-      0x7C180600,  //  008E  CALL	R6	3
-      0x70020000,  //  008F  JMP		#0091
-      0xB0080000,  //  0090  RAISE	2	R0	R0
-      0x8C10011A,  //  0091  GETMET	R4	R0	K26
-      0x7C100200,  //  0092  CALL	R4	1
-      0x80000000,  //  0093  RET	0
+      0x70020011,  //  0026  JMP		#0039
+      0xB8162200,  //  0027  GETNGBL	R5	K17
+      0x60180018,  //  0028  GETGBL	R6	G24
+      0x581C0012,  //  0029  LDCONST	R7	K18
+      0x88200105,  //  002A  GETMBR	R8	R0	K5
+      0x8C240907,  //  002B  GETMET	R9	R4	K7
+      0x582C000F,  //  002C  LDCONST	R11	K15
+      0x5830000A,  //  002D  LDCONST	R12	K10
+      0x7C240600,  //  002E  CALL	R9	3
+      0x7C180600,  //  002F  CALL	R6	3
+      0x581C0013,  //  0030  LDCONST	R7	K19
+      0x7C140400,  //  0031  CALL	R5	2
+      0x8C14050E,  //  0032  GETMET	R5	R2	K14
+      0x881C0105,  //  0033  GETMBR	R7	R0	K5
+      0x8C200907,  //  0034  GETMET	R8	R4	K7
+      0x5828000F,  //  0035  LDCONST	R10	K15
+      0x582C000A,  //  0036  LDCONST	R11	K10
+      0x7C200600,  //  0037  CALL	R8	3
+      0x7C140600,  //  0038  CALL	R5	3
+      0x70020032,  //  0039  JMP		#006D
+      0xB8120600,  //  003A  GETNGBL	R4	K3
+      0x8C100914,  //  003B  GETMET	R4	R4	K20
+      0x7C100200,  //  003C  CALL	R4	1
+      0x8C140706,  //  003D  GETMET	R5	R3	K6
+      0x8C1C0907,  //  003E  GETMET	R7	R4	K7
+      0x58240008,  //  003F  LDCONST	R9	K8
+      0x7C1C0400,  //  0040  CALL	R7	2
+      0x58200009,  //  0041  LDCONST	R8	K9
+      0x5824000A,  //  0042  LDCONST	R9	K10
+      0x7C140800,  //  0043  CALL	R5	4
+      0x90022A05,  //  0044  SETMBR	R0	K21	R5
+      0x8814010B,  //  0045  GETMBR	R5	R0	K11
+      0x78160003,  //  0046  JMPF	R5	#004B
+      0x8C14090C,  //  0047  GETMET	R5	R4	K12
+      0x581C000D,  //  0048  LDCONST	R7	K13
+      0x7C140400,  //  0049  CALL	R5	2
+      0x7416000F,  //  004A  JMPT	R5	#005B
+      0x8C14050E,  //  004B  GETMET	R5	R2	K14
+      0x881C0115,  //  004C  GETMBR	R7	R0	K21
+      0x8C200907,  //  004D  GETMET	R8	R4	K7
+      0x5828000D,  //  004E  LDCONST	R10	K13
+      0x582C000A,  //  004F  LDCONST	R11	K10
+      0x7C200600,  //  0050  CALL	R8	3
+      0x8C240907,  //  0051  GETMET	R9	R4	K7
+      0x582C000F,  //  0052  LDCONST	R11	K15
+      0x5830000A,  //  0053  LDCONST	R12	K10
+      0x7C240600,  //  0054  CALL	R9	3
+      0x8C280907,  //  0055  GETMET	R10	R4	K7
+      0x58300010,  //  0056  LDCONST	R12	K16
+      0x5834000A,  //  0057  LDCONST	R13	K10
+      0x7C280600,  //  0058  CALL	R10	3
+      0x7C140A00,  //  0059  CALL	R5	5
+      0x70020011,  //  005A  JMP		#006D
+      0xB8162200,  //  005B  GETNGBL	R5	K17
+      0x60180018,  //  005C  GETGBL	R6	G24
+      0x581C0012,  //  005D  LDCONST	R7	K18
+      0x88200115,  //  005E  GETMBR	R8	R0	K21
+      0x8C240907,  //  005F  GETMET	R9	R4	K7
+      0x582C000F,  //  0060  LDCONST	R11	K15
+      0x5830000A,  //  0061  LDCONST	R12	K10
+      0x7C240600,  //  0062  CALL	R9	3
+      0x7C180600,  //  0063  CALL	R6	3
+      0x581C0013,  //  0064  LDCONST	R7	K19
+      0x7C140400,  //  0065  CALL	R5	2
+      0x8C14050E,  //  0066  GETMET	R5	R2	K14
+      0x881C0115,  //  0067  GETMBR	R7	R0	K21
+      0x8C200907,  //  0068  GETMET	R8	R4	K7
+      0x5828000F,  //  0069  LDCONST	R10	K15
+      0x582C000A,  //  006A  LDCONST	R11	K10
+      0x7C200600,  //  006B  CALL	R8	3
+      0x7C140600,  //  006C  CALL	R5	3
+      0xB8122200,  //  006D  GETNGBL	R4	K17
+      0x60140018,  //  006E  GETGBL	R5	G24
+      0x58180016,  //  006F  LDCONST	R6	K22
+      0x78060001,  //  0070  JMPF	R1	#0073
+      0x581C0004,  //  0071  LDCONST	R7	K4
+      0x70020000,  //  0072  JMP		#0074
+      0x581C0014,  //  0073  LDCONST	R7	K20
+      0x78060001,  //  0074  JMPF	R1	#0077
+      0x88200105,  //  0075  GETMBR	R8	R0	K5
+      0x70020000,  //  0076  JMP		#0078
+      0x88200115,  //  0077  GETMBR	R8	R0	K21
+      0x7C140600,  //  0078  CALL	R5	3
+      0x58180013,  //  0079  LDCONST	R6	K19
+      0x7C100400,  //  007A  CALL	R4	2
+      0xA8040001,  //  007B  EXBLK	1	1
+      0x7002000F,  //  007C  JMP		#008D
+      0xAC100002,  //  007D  CATCH	R4	0	2
+      0x7002000C,  //  007E  JMP		#008C
+      0xB81A2200,  //  007F  GETNGBL	R6	K17
+      0x601C0008,  //  0080  GETGBL	R7	G8
+      0x5C200800,  //  0081  MOVE	R8	R4
+      0x7C1C0200,  //  0082  CALL	R7	1
+      0x001E2E07,  //  0083  ADD	R7	K23	R7
+      0x001C0F18,  //  0084  ADD	R7	R7	K24
+      0x60200008,  //  0085  GETGBL	R8	G8
+      0x5C240A00,  //  0086  MOVE	R9	R5
+      0x7C200200,  //  0087  CALL	R8	1
+      0x001C0E08,  //  0088  ADD	R7	R7	R8
+      0x58200019,  //  0089  LDCONST	R8	K25
+      0x7C180400,  //  008A  CALL	R6	2
+      0x70020000,  //  008B  JMP		#008D
+      0xB0080000,  //  008C  RAISE	2	R0	R0
+      0x8C10011A,  //  008D  GETMET	R4	R0	K26
+      0x7C100200,  //  008E  CALL	R4	1
+      0x80000000,  //  008F  RET	0
     })
   )
 );
@@ -847,7 +832,7 @@ be_local_closure(class_Matter_Device_get_plugin_class_displayname,   /* name */
 extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
   be_nested_proto(
-    17,                          /* nstack */
+    16,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -855,102 +840,99 @@ be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Device, 
     1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
+    ( &(const bvalue[20]) {     /* constants */
     /* K0   */  be_nested_str_weak(plugins_classes),
     /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-    /* K5   */  be_nested_str_weak(_X27_X20skipping),
-    /* K6   */  be_const_int(3),
-    /* K7   */  be_nested_str_weak(next_ep),
-    /* K8   */  be_nested_str_weak(plugins),
-    /* K9   */  be_nested_str_weak(push),
-    /* K10  */  be_nested_str_weak(type),
-    /* K11  */  be_nested_str_weak(keys),
-    /* K12  */  be_nested_str_weak(stop_iteration),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
-    /* K14  */  be_nested_str_weak(conf_to_log),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_nested_str_weak(plugins_config),
-    /* K17  */  be_nested_str_weak(plugins_persist),
-    /* K18  */  be_const_int(1),
-    /* K19  */  be_nested_str_weak(save_param),
-    /* K20  */  be_nested_str_weak(signal_endpoints_changed),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+    /* K4   */  be_nested_str_weak(_X27_X20skipping),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(next_ep),
+    /* K7   */  be_nested_str_weak(plugins),
+    /* K8   */  be_nested_str_weak(push),
+    /* K9   */  be_nested_str_weak(type),
+    /* K10  */  be_nested_str_weak(keys),
+    /* K11  */  be_nested_str_weak(stop_iteration),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
+    /* K13  */  be_nested_str_weak(conf_to_log),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(plugins_config),
+    /* K16  */  be_nested_str_weak(plugins_persist),
+    /* K17  */  be_const_int(1),
+    /* K18  */  be_nested_str_weak(save_param),
+    /* K19  */  be_nested_str_weak(signal_endpoints_changed),
     }),
     be_str_weak(bridge_add_endpoint),
     &be_const_str_solidified,
-    ( &(const binstruction[70]) {  /* code */
+    ( &(const binstruction[68]) {  /* code */
       0x880C0100,  //  0000  GETMBR	R3	R0	K0
       0x8C0C0701,  //  0001  GETMET	R3	R3	K1
       0x5C140200,  //  0002  MOVE	R5	R1
       0x7C0C0400,  //  0003  CALL	R3	2
       0x4C100000,  //  0004  LDNIL	R4
       0x1C100604,  //  0005  EQ	R4	R3	R4
-      0x78120009,  //  0006  JMPF	R4	#0011
+      0x78120008,  //  0006  JMPF	R4	#0010
       0xB8120400,  //  0007  GETNGBL	R4	K2
-      0x8C100903,  //  0008  GETMET	R4	R4	K3
-      0x60180008,  //  0009  GETGBL	R6	G8
-      0x5C1C0200,  //  000A  MOVE	R7	R1
-      0x7C180200,  //  000B  CALL	R6	1
-      0x001A0806,  //  000C  ADD	R6	K4	R6
-      0x00180D05,  //  000D  ADD	R6	R6	K5
-      0x581C0006,  //  000E  LDCONST	R7	K6
-      0x7C100600,  //  000F  CALL	R4	3
-      0x80000800,  //  0010  RET	0
-      0x88100107,  //  0011  GETMBR	R4	R0	K7
-      0x60140008,  //  0012  GETGBL	R5	G8
-      0x5C180800,  //  0013  MOVE	R6	R4
-      0x7C140200,  //  0014  CALL	R5	1
-      0x5C180600,  //  0015  MOVE	R6	R3
-      0x5C1C0000,  //  0016  MOVE	R7	R0
-      0x5C200800,  //  0017  MOVE	R8	R4
-      0x5C240400,  //  0018  MOVE	R9	R2
-      0x7C180600,  //  0019  CALL	R6	3
-      0x881C0108,  //  001A  GETMBR	R7	R0	K8
-      0x8C1C0F09,  //  001B  GETMET	R7	R7	K9
-      0x5C240C00,  //  001C  MOVE	R9	R6
-      0x7C1C0400,  //  001D  CALL	R7	2
-      0x601C0013,  //  001E  GETGBL	R7	G19
-      0x7C1C0000,  //  001F  CALL	R7	0
-      0x981E1401,  //  0020  SETIDX	R7	K10	R1
-      0x60200010,  //  0021  GETGBL	R8	G16
-      0x8C24050B,  //  0022  GETMET	R9	R2	K11
-      0x7C240200,  //  0023  CALL	R9	1
-      0x7C200200,  //  0024  CALL	R8	1
-      0xA8020004,  //  0025  EXBLK	0	#002B
-      0x5C241000,  //  0026  MOVE	R9	R8
-      0x7C240000,  //  0027  CALL	R9	0
-      0x94280409,  //  0028  GETIDX	R10	R2	R9
-      0x981C120A,  //  0029  SETIDX	R7	R9	R10
-      0x7001FFFA,  //  002A  JMP		#0026
-      0x5820000C,  //  002B  LDCONST	R8	K12
-      0xAC200200,  //  002C  CATCH	R8	1	0
-      0xB0080000,  //  002D  RAISE	2	R0	R0
-      0xB8220400,  //  002E  GETNGBL	R8	K2
-      0x8C201103,  //  002F  GETMET	R8	R8	K3
-      0x60280018,  //  0030  GETGBL	R10	G24
-      0x582C000D,  //  0031  LDCONST	R11	K13
-      0x5C300800,  //  0032  MOVE	R12	R4
-      0x5C340200,  //  0033  MOVE	R13	R1
-      0x8C38010E,  //  0034  GETMET	R14	R0	K14
-      0x5C400400,  //  0035  MOVE	R16	R2
-      0x7C380400,  //  0036  CALL	R14	2
-      0x7C280800,  //  0037  CALL	R10	4
-      0x582C000F,  //  0038  LDCONST	R11	K15
-      0x7C200600,  //  0039  CALL	R8	3
-      0x88200110,  //  003A  GETMBR	R8	R0	K16
-      0x98200A07,  //  003B  SETIDX	R8	R5	R7
-      0x50200200,  //  003C  LDBOOL	R8	1	0
-      0x90022208,  //  003D  SETMBR	R0	K17	R8
-      0x88200107,  //  003E  GETMBR	R8	R0	K7
-      0x00201112,  //  003F  ADD	R8	R8	K18
-      0x90020E08,  //  0040  SETMBR	R0	K7	R8
+      0x60140008,  //  0008  GETGBL	R5	G8
+      0x5C180200,  //  0009  MOVE	R6	R1
+      0x7C140200,  //  000A  CALL	R5	1
+      0x00160605,  //  000B  ADD	R5	K3	R5
+      0x00140B04,  //  000C  ADD	R5	R5	K4
+      0x58180005,  //  000D  LDCONST	R6	K5
+      0x7C100400,  //  000E  CALL	R4	2
+      0x80000800,  //  000F  RET	0
+      0x88100106,  //  0010  GETMBR	R4	R0	K6
+      0x60140008,  //  0011  GETGBL	R5	G8
+      0x5C180800,  //  0012  MOVE	R6	R4
+      0x7C140200,  //  0013  CALL	R5	1
+      0x5C180600,  //  0014  MOVE	R6	R3
+      0x5C1C0000,  //  0015  MOVE	R7	R0
+      0x5C200800,  //  0016  MOVE	R8	R4
+      0x5C240400,  //  0017  MOVE	R9	R2
+      0x7C180600,  //  0018  CALL	R6	3
+      0x881C0107,  //  0019  GETMBR	R7	R0	K7
+      0x8C1C0F08,  //  001A  GETMET	R7	R7	K8
+      0x5C240C00,  //  001B  MOVE	R9	R6
+      0x7C1C0400,  //  001C  CALL	R7	2
+      0x601C0013,  //  001D  GETGBL	R7	G19
+      0x7C1C0000,  //  001E  CALL	R7	0
+      0x981E1201,  //  001F  SETIDX	R7	K9	R1
+      0x60200010,  //  0020  GETGBL	R8	G16
+      0x8C24050A,  //  0021  GETMET	R9	R2	K10
+      0x7C240200,  //  0022  CALL	R9	1
+      0x7C200200,  //  0023  CALL	R8	1
+      0xA8020004,  //  0024  EXBLK	0	#002A
+      0x5C241000,  //  0025  MOVE	R9	R8
+      0x7C240000,  //  0026  CALL	R9	0
+      0x94280409,  //  0027  GETIDX	R10	R2	R9
+      0x981C120A,  //  0028  SETIDX	R7	R9	R10
+      0x7001FFFA,  //  0029  JMP		#0025
+      0x5820000B,  //  002A  LDCONST	R8	K11
+      0xAC200200,  //  002B  CATCH	R8	1	0
+      0xB0080000,  //  002C  RAISE	2	R0	R0
+      0xB8220400,  //  002D  GETNGBL	R8	K2
+      0x60240018,  //  002E  GETGBL	R9	G24
+      0x5828000C,  //  002F  LDCONST	R10	K12
+      0x5C2C0800,  //  0030  MOVE	R11	R4
+      0x5C300200,  //  0031  MOVE	R12	R1
+      0x8C34010D,  //  0032  GETMET	R13	R0	K13
+      0x5C3C0400,  //  0033  MOVE	R15	R2
+      0x7C340400,  //  0034  CALL	R13	2
+      0x7C240800,  //  0035  CALL	R9	4
+      0x5828000E,  //  0036  LDCONST	R10	K14
+      0x7C200400,  //  0037  CALL	R8	2
+      0x8820010F,  //  0038  GETMBR	R8	R0	K15
+      0x98200A07,  //  0039  SETIDX	R8	R5	R7
+      0x50200200,  //  003A  LDBOOL	R8	1	0
+      0x90022008,  //  003B  SETMBR	R0	K16	R8
+      0x88200106,  //  003C  GETMBR	R8	R0	K6
+      0x00201111,  //  003D  ADD	R8	R8	K17
+      0x90020C08,  //  003E  SETMBR	R0	K6	R8
+      0x8C200112,  //  003F  GETMET	R8	R0	K18
+      0x7C200200,  //  0040  CALL	R8	1
       0x8C200113,  //  0041  GETMET	R8	R0	K19
       0x7C200200,  //  0042  CALL	R8	1
-      0x8C200114,  //  0043  GETMET	R8	R0	K20
-      0x7C200200,  //  0044  CALL	R8	1
-      0x80040800,  //  0045  RET	1	R4
+      0x80040800,  //  0043  RET	1	R4
     })
   )
 );
@@ -1192,7 +1174,7 @@ be_local_closure(class_Matter_Device_compute_qrcode_content,   /* name */
 extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_autoconf_device_map,   /* name */
   be_nested_proto(
-    20,                          /* nstack */
+    19,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1242,7 +1224,7 @@ be_local_closure(class_Matter_Device_autoconf_device_map,   /* name */
     }),
     be_str_weak(autoconf_device_map),
     &be_const_str_solidified,
-    ( &(const binstruction[199]) {  /* code */
+    ( &(const binstruction[196]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x60080013,  //  0001  GETGBL	R2	G19
       0x7C080000,  //  0002  CALL	R2	0
@@ -1299,149 +1281,146 @@ be_local_closure(class_Matter_Device_autoconf_device_map,   /* name */
       0x7C1C0600,  //  0035  CALL	R7	3
       0x60200012,  //  0036  GETGBL	R8	G18
       0x7C200000,  //  0037  CALL	R8	0
-      0xB8261E00,  //  0038  GETNGBL	R9	K15
-      0x8C241312,  //  0039  GETMET	R9	R9	K18
-      0x602C0008,  //  003A  GETGBL	R11	G8
-      0x5C300E00,  //  003B  MOVE	R12	R7
-      0x7C2C0200,  //  003C  CALL	R11	1
-      0x002E260B,  //  003D  ADD	R11	K19	R11
-      0x58300014,  //  003E  LDCONST	R12	K20
-      0x7C240600,  //  003F  CALL	R9	3
-      0x4C240000,  //  0040  LDNIL	R9
-      0x20240E09,  //  0041  NE	R9	R7	R9
-      0x7826004F,  //  0042  JMPF	R9	#0093
-      0x8C240F15,  //  0043  GETMET	R9	R7	K21
-      0x582C0016,  //  0044  LDCONST	R11	K22
-      0x7C240400,  //  0045  CALL	R9	2
-      0x7826004B,  //  0046  JMPF	R9	#0093
-      0x941C0F16,  //  0047  GETIDX	R7	R7	K22
-      0x58240008,  //  0048  LDCONST	R9	K8
-      0x50280200,  //  0049  LDBOOL	R10	1	0
-      0x782A0047,  //  004A  JMPF	R10	#0093
-      0x60280008,  //  004B  GETGBL	R10	G8
-      0x5C2C1200,  //  004C  MOVE	R11	R9
-      0x7C280200,  //  004D  CALL	R10	1
-      0x002A2E0A,  //  004E  ADD	R10	K23	R10
-      0x8C2C0F15,  //  004F  GETMET	R11	R7	K21
-      0x5C341400,  //  0050  MOVE	R13	R10
-      0x7C2C0400,  //  0051  CALL	R11	2
-      0x742E0000,  //  0052  JMPT	R11	#0054
-      0x7002003E,  //  0053  JMP		#0093
-      0x942C0E0A,  //  0054  GETIDX	R11	R7	R10
-      0xB8321E00,  //  0055  GETNGBL	R12	K15
-      0x8C301912,  //  0056  GETMET	R12	R12	K18
-      0x60380018,  //  0057  GETGBL	R14	G24
-      0x583C0018,  //  0058  LDCONST	R15	K24
-      0x5C401400,  //  0059  MOVE	R16	R10
-      0x60440008,  //  005A  GETGBL	R17	G8
-      0x5C481600,  //  005B  MOVE	R18	R11
-      0x7C440200,  //  005C  CALL	R17	1
-      0x7C380600,  //  005D  CALL	R14	3
-      0x583C0014,  //  005E  LDCONST	R15	K20
-      0x7C300600,  //  005F  CALL	R12	3
-      0x8C301705,  //  0060  GETMET	R12	R11	K5
-      0x58380019,  //  0061  LDCONST	R14	K25
-      0x543DFFFE,  //  0062  LDINT	R15	-1
-      0x7C300600,  //  0063  CALL	R12	3
-      0x8C341705,  //  0064  GETMET	R13	R11	K5
-      0x583C001A,  //  0065  LDCONST	R15	K26
-      0x5441FFFE,  //  0066  LDINT	R16	-1
-      0x7C340600,  //  0067  CALL	R13	3
-      0x24381908,  //  0068  GT	R14	R12	K8
-      0x783A0002,  //  0069  JMPF	R14	#006D
-      0x8C38111B,  //  006A  GETMET	R14	R8	K27
-      0x04401909,  //  006B  SUB	R16	R12	K9
-      0x7C380400,  //  006C  CALL	R14	2
-      0x24381B08,  //  006D  GT	R14	R13	K8
-      0x783A0002,  //  006E  JMPF	R14	#0072
-      0x8C38111B,  //  006F  GETMET	R14	R8	K27
-      0x04401B09,  //  0070  SUB	R16	R13	K9
-      0x7C380400,  //  0071  CALL	R14	2
-      0xB83A1E00,  //  0072  GETNGBL	R14	K15
-      0x8C381D12,  //  0073  GETMET	R14	R14	K18
-      0x60400018,  //  0074  GETGBL	R16	G24
-      0x5844001C,  //  0075  LDCONST	R17	K28
-      0x5C481800,  //  0076  MOVE	R18	R12
-      0x5C4C1A00,  //  0077  MOVE	R19	R13
-      0x7C400600,  //  0078  CALL	R16	3
-      0x58440014,  //  0079  LDCONST	R17	K20
-      0x7C380600,  //  007A  CALL	R14	3
-      0x8C381705,  //  007B  GETMET	R14	R11	K5
-      0x5840001D,  //  007C  LDCONST	R16	K29
-      0x7C380400,  //  007D  CALL	R14	2
-      0x783A0002,  //  007E  JMPF	R14	#0082
-      0x943C1D0C,  //  007F  GETIDX	R15	R14	K12
-      0x243C1F08,  //  0080  GT	R15	R15	K8
-      0x743E0000,  //  0081  JMPT	R15	#0083
-      0x503C0001,  //  0082  LDBOOL	R15	0	1
-      0x503C0200,  //  0083  LDBOOL	R15	1	0
-      0x60400008,  //  0084  GETGBL	R16	G8
-      0x5C440600,  //  0085  MOVE	R17	R3
-      0x7C400200,  //  0086  CALL	R16	1
-      0x60440013,  //  0087  GETGBL	R17	G19
-      0x7C440000,  //  0088  CALL	R17	0
-      0x783E0001,  //  0089  JMPF	R15	#008C
-      0x5848001E,  //  008A  LDCONST	R18	K30
-      0x70020000,  //  008B  JMP		#008D
-      0x5848001F,  //  008C  LDCONST	R18	K31
-      0x98461412,  //  008D  SETIDX	R17	K10	R18
-      0x98463E09,  //  008E  SETIDX	R17	K31	R9
-      0x98082011,  //  008F  SETIDX	R2	R16	R17
-      0x000C0709,  //  0090  ADD	R3	R3	K9
-      0x00241309,  //  0091  ADD	R9	R9	K9
-      0x7001FFB5,  //  0092  JMP		#0049
-      0x6024000C,  //  0093  GETGBL	R9	G12
-      0xB82A1E00,  //  0094  GETNGBL	R10	K15
-      0x8C281520,  //  0095  GETMET	R10	R10	K32
-      0x7C280200,  //  0096  CALL	R10	1
-      0x7C240200,  //  0097  CALL	R9	1
-      0x58280008,  //  0098  LDCONST	R10	K8
-      0x78120000,  //  0099  JMPF	R4	#009B
-      0x04241309,  //  009A  SUB	R9	R9	K9
-      0x142C1409,  //  009B  LT	R11	R10	R9
-      0x782E0011,  //  009C  JMPF	R11	#00AF
-      0x8C2C1105,  //  009D  GETMET	R11	R8	K5
-      0x5C341400,  //  009E  MOVE	R13	R10
-      0x7C2C0400,  //  009F  CALL	R11	2
-      0x4C300000,  //  00A0  LDNIL	R12
-      0x1C2C160C,  //  00A1  EQ	R11	R11	R12
-      0x782E0009,  //  00A2  JMPF	R11	#00AD
-      0x602C0008,  //  00A3  GETGBL	R11	G8
-      0x5C300600,  //  00A4  MOVE	R12	R3
-      0x7C2C0200,  //  00A5  CALL	R11	1
-      0x60300013,  //  00A6  GETGBL	R12	G19
-      0x7C300000,  //  00A7  CALL	R12	0
-      0x98321521,  //  00A8  SETIDX	R12	K10	K33
-      0x00341509,  //  00A9  ADD	R13	R10	K9
-      0x9832420D,  //  00AA  SETIDX	R12	K33	R13
-      0x9808160C,  //  00AB  SETIDX	R2	R11	R12
-      0x000C0709,  //  00AC  ADD	R3	R3	K9
-      0x00281509,  //  00AD  ADD	R10	R10	K9
-      0x7001FFEB,  //  00AE  JMP		#009B
-      0x8C2C0322,  //  00AF  GETMET	R11	R1	K34
-      0xB8361E00,  //  00B0  GETNGBL	R13	K15
-      0x8C341B23,  //  00B1  GETMET	R13	R13	K35
-      0x7C340200,  //  00B2  CALL	R13	1
-      0x7C2C0400,  //  00B3  CALL	R11	2
-      0x8C300124,  //  00B4  GETMET	R12	R0	K36
-      0x5C381600,  //  00B5  MOVE	R14	R11
-      0x7C300400,  //  00B6  CALL	R12	2
-      0x60340010,  //  00B7  GETGBL	R13	G16
-      0x5C381800,  //  00B8  MOVE	R14	R12
-      0x7C340200,  //  00B9  CALL	R13	1
-      0xA8020007,  //  00BA  EXBLK	0	#00C3
-      0x5C381A00,  //  00BB  MOVE	R14	R13
-      0x7C380000,  //  00BC  CALL	R14	0
-      0x603C0008,  //  00BD  GETGBL	R15	G8
-      0x5C400600,  //  00BE  MOVE	R16	R3
-      0x7C3C0200,  //  00BF  CALL	R15	1
-      0x98081E0E,  //  00C0  SETIDX	R2	R15	R14
-      0x000C0709,  //  00C1  ADD	R3	R3	K9
-      0x7001FFF7,  //  00C2  JMP		#00BB
-      0x58340025,  //  00C3  LDCONST	R13	K37
-      0xAC340200,  //  00C4  CATCH	R13	1	0
-      0xB0080000,  //  00C5  RAISE	2	R0	R0
-      0x80040400,  //  00C6  RET	1	R2
+      0xB8262400,  //  0038  GETNGBL	R9	K18
+      0x60280008,  //  0039  GETGBL	R10	G8
+      0x5C2C0E00,  //  003A  MOVE	R11	R7
+      0x7C280200,  //  003B  CALL	R10	1
+      0x002A260A,  //  003C  ADD	R10	K19	R10
+      0x582C0014,  //  003D  LDCONST	R11	K20
+      0x7C240400,  //  003E  CALL	R9	2
+      0x4C240000,  //  003F  LDNIL	R9
+      0x20240E09,  //  0040  NE	R9	R7	R9
+      0x7826004D,  //  0041  JMPF	R9	#0090
+      0x8C240F15,  //  0042  GETMET	R9	R7	K21
+      0x582C0016,  //  0043  LDCONST	R11	K22
+      0x7C240400,  //  0044  CALL	R9	2
+      0x78260049,  //  0045  JMPF	R9	#0090
+      0x941C0F16,  //  0046  GETIDX	R7	R7	K22
+      0x58240008,  //  0047  LDCONST	R9	K8
+      0x50280200,  //  0048  LDBOOL	R10	1	0
+      0x782A0045,  //  0049  JMPF	R10	#0090
+      0x60280008,  //  004A  GETGBL	R10	G8
+      0x5C2C1200,  //  004B  MOVE	R11	R9
+      0x7C280200,  //  004C  CALL	R10	1
+      0x002A2E0A,  //  004D  ADD	R10	K23	R10
+      0x8C2C0F15,  //  004E  GETMET	R11	R7	K21
+      0x5C341400,  //  004F  MOVE	R13	R10
+      0x7C2C0400,  //  0050  CALL	R11	2
+      0x742E0000,  //  0051  JMPT	R11	#0053
+      0x7002003C,  //  0052  JMP		#0090
+      0x942C0E0A,  //  0053  GETIDX	R11	R7	R10
+      0xB8322400,  //  0054  GETNGBL	R12	K18
+      0x60340018,  //  0055  GETGBL	R13	G24
+      0x58380018,  //  0056  LDCONST	R14	K24
+      0x5C3C1400,  //  0057  MOVE	R15	R10
+      0x60400008,  //  0058  GETGBL	R16	G8
+      0x5C441600,  //  0059  MOVE	R17	R11
+      0x7C400200,  //  005A  CALL	R16	1
+      0x7C340600,  //  005B  CALL	R13	3
+      0x58380014,  //  005C  LDCONST	R14	K20
+      0x7C300400,  //  005D  CALL	R12	2
+      0x8C301705,  //  005E  GETMET	R12	R11	K5
+      0x58380019,  //  005F  LDCONST	R14	K25
+      0x543DFFFE,  //  0060  LDINT	R15	-1
+      0x7C300600,  //  0061  CALL	R12	3
+      0x8C341705,  //  0062  GETMET	R13	R11	K5
+      0x583C001A,  //  0063  LDCONST	R15	K26
+      0x5441FFFE,  //  0064  LDINT	R16	-1
+      0x7C340600,  //  0065  CALL	R13	3
+      0x24381908,  //  0066  GT	R14	R12	K8
+      0x783A0002,  //  0067  JMPF	R14	#006B
+      0x8C38111B,  //  0068  GETMET	R14	R8	K27
+      0x04401909,  //  0069  SUB	R16	R12	K9
+      0x7C380400,  //  006A  CALL	R14	2
+      0x24381B08,  //  006B  GT	R14	R13	K8
+      0x783A0002,  //  006C  JMPF	R14	#0070
+      0x8C38111B,  //  006D  GETMET	R14	R8	K27
+      0x04401B09,  //  006E  SUB	R16	R13	K9
+      0x7C380400,  //  006F  CALL	R14	2
+      0xB83A2400,  //  0070  GETNGBL	R14	K18
+      0x603C0018,  //  0071  GETGBL	R15	G24
+      0x5840001C,  //  0072  LDCONST	R16	K28
+      0x5C441800,  //  0073  MOVE	R17	R12
+      0x5C481A00,  //  0074  MOVE	R18	R13
+      0x7C3C0600,  //  0075  CALL	R15	3
+      0x58400014,  //  0076  LDCONST	R16	K20
+      0x7C380400,  //  0077  CALL	R14	2
+      0x8C381705,  //  0078  GETMET	R14	R11	K5
+      0x5840001D,  //  0079  LDCONST	R16	K29
+      0x7C380400,  //  007A  CALL	R14	2
+      0x783A0002,  //  007B  JMPF	R14	#007F
+      0x943C1D0C,  //  007C  GETIDX	R15	R14	K12
+      0x243C1F08,  //  007D  GT	R15	R15	K8
+      0x743E0000,  //  007E  JMPT	R15	#0080
+      0x503C0001,  //  007F  LDBOOL	R15	0	1
+      0x503C0200,  //  0080  LDBOOL	R15	1	0
+      0x60400008,  //  0081  GETGBL	R16	G8
+      0x5C440600,  //  0082  MOVE	R17	R3
+      0x7C400200,  //  0083  CALL	R16	1
+      0x60440013,  //  0084  GETGBL	R17	G19
+      0x7C440000,  //  0085  CALL	R17	0
+      0x783E0001,  //  0086  JMPF	R15	#0089
+      0x5848001E,  //  0087  LDCONST	R18	K30
+      0x70020000,  //  0088  JMP		#008A
+      0x5848001F,  //  0089  LDCONST	R18	K31
+      0x98461412,  //  008A  SETIDX	R17	K10	R18
+      0x98463E09,  //  008B  SETIDX	R17	K31	R9
+      0x98082011,  //  008C  SETIDX	R2	R16	R17
+      0x000C0709,  //  008D  ADD	R3	R3	K9
+      0x00241309,  //  008E  ADD	R9	R9	K9
+      0x7001FFB7,  //  008F  JMP		#0048
+      0x6024000C,  //  0090  GETGBL	R9	G12
+      0xB82A1E00,  //  0091  GETNGBL	R10	K15
+      0x8C281520,  //  0092  GETMET	R10	R10	K32
+      0x7C280200,  //  0093  CALL	R10	1
+      0x7C240200,  //  0094  CALL	R9	1
+      0x58280008,  //  0095  LDCONST	R10	K8
+      0x78120000,  //  0096  JMPF	R4	#0098
+      0x04241309,  //  0097  SUB	R9	R9	K9
+      0x142C1409,  //  0098  LT	R11	R10	R9
+      0x782E0011,  //  0099  JMPF	R11	#00AC
+      0x8C2C1105,  //  009A  GETMET	R11	R8	K5
+      0x5C341400,  //  009B  MOVE	R13	R10
+      0x7C2C0400,  //  009C  CALL	R11	2
+      0x4C300000,  //  009D  LDNIL	R12
+      0x1C2C160C,  //  009E  EQ	R11	R11	R12
+      0x782E0009,  //  009F  JMPF	R11	#00AA
+      0x602C0008,  //  00A0  GETGBL	R11	G8
+      0x5C300600,  //  00A1  MOVE	R12	R3
+      0x7C2C0200,  //  00A2  CALL	R11	1
+      0x60300013,  //  00A3  GETGBL	R12	G19
+      0x7C300000,  //  00A4  CALL	R12	0
+      0x98321521,  //  00A5  SETIDX	R12	K10	K33
+      0x00341509,  //  00A6  ADD	R13	R10	K9
+      0x9832420D,  //  00A7  SETIDX	R12	K33	R13
+      0x9808160C,  //  00A8  SETIDX	R2	R11	R12
+      0x000C0709,  //  00A9  ADD	R3	R3	K9
+      0x00281509,  //  00AA  ADD	R10	R10	K9
+      0x7001FFEB,  //  00AB  JMP		#0098
+      0x8C2C0322,  //  00AC  GETMET	R11	R1	K34
+      0xB8361E00,  //  00AD  GETNGBL	R13	K15
+      0x8C341B23,  //  00AE  GETMET	R13	R13	K35
+      0x7C340200,  //  00AF  CALL	R13	1
+      0x7C2C0400,  //  00B0  CALL	R11	2
+      0x8C300124,  //  00B1  GETMET	R12	R0	K36
+      0x5C381600,  //  00B2  MOVE	R14	R11
+      0x7C300400,  //  00B3  CALL	R12	2
+      0x60340010,  //  00B4  GETGBL	R13	G16
+      0x5C381800,  //  00B5  MOVE	R14	R12
+      0x7C340200,  //  00B6  CALL	R13	1
+      0xA8020007,  //  00B7  EXBLK	0	#00C0
+      0x5C381A00,  //  00B8  MOVE	R14	R13
+      0x7C380000,  //  00B9  CALL	R14	0
+      0x603C0008,  //  00BA  GETGBL	R15	G8
+      0x5C400600,  //  00BB  MOVE	R16	R3
+      0x7C3C0200,  //  00BC  CALL	R15	1
+      0x98081E0E,  //  00BD  SETIDX	R2	R15	R14
+      0x000C0709,  //  00BE  ADD	R3	R3	K9
+      0x7001FFF7,  //  00BF  JMP		#00B8
+      0x58340025,  //  00C0  LDCONST	R13	K37
+      0xAC340200,  //  00C1  CATCH	R13	1	0
+      0xB0080000,  //  00C2  RAISE	2	R0	R0
+      0x80040400,  //  00C3  RET	1	R2
     })
   )
 );
@@ -1962,7 +1941,7 @@ be_local_closure(class_Matter_Device_clean_remotes,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Device, 
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
+    ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_weak(introspect),
     /* K1   */  be_nested_str_weak(http_remotes),
     /* K2   */  be_const_int(0),
@@ -1974,20 +1953,19 @@ be_local_closure(class_Matter_Device_clean_remotes,   /* name */
     /* K8   */  be_const_int(1),
     /* K9   */  be_nested_str_weak(keys),
     /* K10  */  be_nested_str_weak(push),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
-    /* K14  */  be_nested_str_weak(addr),
-    /* K15  */  be_const_int(3),
-    /* K16  */  be_nested_str_weak(close),
-    /* K17  */  be_nested_str_weak(remove),
+    /* K11  */  be_nested_str_weak(log),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
+    /* K13  */  be_nested_str_weak(addr),
+    /* K14  */  be_const_int(3),
+    /* K15  */  be_nested_str_weak(close),
+    /* K16  */  be_nested_str_weak(remove),
     }),
     be_str_weak(clean_remotes),
     &be_const_str_solidified,
-    ( &(const binstruction[81]) {  /* code */
+    ( &(const binstruction[80]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x780A004C,  //  0002  JMPF	R2	#0050
+      0x780A004B,  //  0002  JMPF	R2	#004F
       0x60080013,  //  0003  GETGBL	R2	G19
       0x7C080000,  //  0004  CALL	R2	0
       0x600C0010,  //  0005  GETGBL	R3	G16
@@ -2046,26 +2024,25 @@ be_local_closure(class_Matter_Device_clean_remotes,   /* name */
       0x60100010,  //  003A  GETGBL	R4	G16
       0x5C140600,  //  003B  MOVE	R5	R3
       0x7C100200,  //  003C  CALL	R4	1
-      0xA802000E,  //  003D  EXBLK	0	#004D
+      0xA802000D,  //  003D  EXBLK	0	#004C
       0x5C140800,  //  003E  MOVE	R5	R4
       0x7C140000,  //  003F  CALL	R5	0
       0xB81A1600,  //  0040  GETNGBL	R6	K11
-      0x8C180D0C,  //  0041  GETMET	R6	R6	K12
-      0x88200B0E,  //  0042  GETMBR	R8	R5	K14
-      0x00221A08,  //  0043  ADD	R8	K13	R8
-      0x5824000F,  //  0044  LDCONST	R9	K15
-      0x7C180600,  //  0045  CALL	R6	3
-      0x8C180B10,  //  0046  GETMET	R6	R5	K16
-      0x7C180200,  //  0047  CALL	R6	1
-      0x88180101,  //  0048  GETMBR	R6	R0	K1
-      0x8C180D11,  //  0049  GETMET	R6	R6	K17
-      0x88200B0E,  //  004A  GETMBR	R8	R5	K14
-      0x7C180400,  //  004B  CALL	R6	2
-      0x7001FFF0,  //  004C  JMP		#003E
-      0x58100003,  //  004D  LDCONST	R4	K3
-      0xAC100200,  //  004E  CATCH	R4	1	0
-      0xB0080000,  //  004F  RAISE	2	R0	R0
-      0x80000000,  //  0050  RET	0
+      0x881C0B0D,  //  0041  GETMBR	R7	R5	K13
+      0x001E1807,  //  0042  ADD	R7	K12	R7
+      0x5820000E,  //  0043  LDCONST	R8	K14
+      0x7C180400,  //  0044  CALL	R6	2
+      0x8C180B0F,  //  0045  GETMET	R6	R5	K15
+      0x7C180200,  //  0046  CALL	R6	1
+      0x88180101,  //  0047  GETMBR	R6	R0	K1
+      0x8C180D10,  //  0048  GETMET	R6	R6	K16
+      0x88200B0D,  //  0049  GETMBR	R8	R5	K13
+      0x7C180400,  //  004A  CALL	R6	2
+      0x7001FFF1,  //  004B  JMP		#003E
+      0x58100003,  //  004C  LDCONST	R4	K3
+      0xAC100200,  //  004D  CATCH	R4	1	0
+      0xB0080000,  //  004E  RAISE	2	R0	R0
+      0x80000000,  //  004F  RET	0
     })
   )
 );
@@ -2139,7 +2116,7 @@ be_local_closure(class_Matter_Device_compute_manual_pairing_code,   /* name */
 extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_autoconf_device,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2147,7 +2124,7 @@ be_local_closure(class_Matter_Device_autoconf_device,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Device, 
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
+    ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
     /* K1   */  be_nested_str_weak(plugins),
     /* K2   */  be_const_int(0),
@@ -2156,18 +2133,17 @@ be_local_closure(class_Matter_Device_autoconf_device,   /* name */
     /* K5   */  be_nested_str_weak(autoconf_device_map),
     /* K6   */  be_nested_str_weak(plugins_config_remotes),
     /* K7   */  be_nested_str_weak(adjust_next_ep),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(_instantiate_plugins_from_config),
-    /* K13  */  be_nested_str_weak(sessions),
-    /* K14  */  be_nested_str_weak(count_active_fabrics),
-    /* K15  */  be_nested_str_weak(save_param),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(_instantiate_plugins_from_config),
+    /* K12  */  be_nested_str_weak(sessions),
+    /* K13  */  be_nested_str_weak(count_active_fabrics),
+    /* K14  */  be_nested_str_weak(save_param),
     }),
     be_str_weak(autoconf_device),
     &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
+    ( &(const binstruction[39]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x6008000C,  //  0001  GETGBL	R2	G12
       0x880C0101,  //  0002  GETMBR	R3	R0	K1
@@ -2176,7 +2152,7 @@ be_local_closure(class_Matter_Device_autoconf_device,   /* name */
       0x780A0000,  //  0005  JMPF	R2	#0007
       0x80000400,  //  0006  RET	0
       0x88080103,  //  0007  GETMBR	R2	R0	K3
-      0x740A000F,  //  0008  JMPT	R2	#0019
+      0x740A000E,  //  0008  JMPT	R2	#0018
       0x8C080105,  //  0009  GETMET	R2	R0	K5
       0x7C080200,  //  000A  CALL	R2	1
       0x90020802,  //  000B  SETMBR	R0	K4	R2
@@ -2186,28 +2162,27 @@ be_local_closure(class_Matter_Device_autoconf_device,   /* name */
       0x8C080107,  //  000F  GETMET	R2	R0	K7
       0x7C080200,  //  0010  CALL	R2	1
       0xB80A1000,  //  0011  GETNGBL	R2	K8
-      0x8C080509,  //  0012  GETMET	R2	R2	K9
-      0x60100008,  //  0013  GETGBL	R4	G8
-      0x88140104,  //  0014  GETMBR	R5	R0	K4
-      0x7C100200,  //  0015  CALL	R4	1
-      0x00121404,  //  0016  ADD	R4	K10	R4
-      0x5814000B,  //  0017  LDCONST	R5	K11
-      0x7C080600,  //  0018  CALL	R2	3
-      0x8C08010C,  //  0019  GETMET	R2	R0	K12
-      0x88100104,  //  001A  GETMBR	R4	R0	K4
-      0x7C080400,  //  001B  CALL	R2	2
-      0x88080103,  //  001C  GETMBR	R2	R0	K3
-      0x740A0008,  //  001D  JMPT	R2	#0027
-      0x8808010D,  //  001E  GETMBR	R2	R0	K13
-      0x8C08050E,  //  001F  GETMET	R2	R2	K14
-      0x7C080200,  //  0020  CALL	R2	1
-      0x24080502,  //  0021  GT	R2	R2	K2
-      0x780A0003,  //  0022  JMPF	R2	#0027
-      0x50080200,  //  0023  LDBOOL	R2	1	0
-      0x90020602,  //  0024  SETMBR	R0	K3	R2
-      0x8C08010F,  //  0025  GETMET	R2	R0	K15
-      0x7C080200,  //  0026  CALL	R2	1
-      0x80000000,  //  0027  RET	0
+      0x600C0008,  //  0012  GETGBL	R3	G8
+      0x88100104,  //  0013  GETMBR	R4	R0	K4
+      0x7C0C0200,  //  0014  CALL	R3	1
+      0x000E1203,  //  0015  ADD	R3	K9	R3
+      0x5810000A,  //  0016  LDCONST	R4	K10
+      0x7C080400,  //  0017  CALL	R2	2
+      0x8C08010B,  //  0018  GETMET	R2	R0	K11
+      0x88100104,  //  0019  GETMBR	R4	R0	K4
+      0x7C080400,  //  001A  CALL	R2	2
+      0x88080103,  //  001B  GETMBR	R2	R0	K3
+      0x740A0008,  //  001C  JMPT	R2	#0026
+      0x8808010C,  //  001D  GETMBR	R2	R0	K12
+      0x8C08050D,  //  001E  GETMET	R2	R2	K13
+      0x7C080200,  //  001F  CALL	R2	1
+      0x24080502,  //  0020  GT	R2	R2	K2
+      0x780A0003,  //  0021  JMPF	R2	#0026
+      0x50080200,  //  0022  LDBOOL	R2	1	0
+      0x90020602,  //  0023  SETMBR	R0	K3	R2
+      0x8C08010E,  //  0024  GETMET	R2	R0	K14
+      0x7C080200,  //  0025  CALL	R2	1
+      0x80000000,  //  0026  RET	0
     })
   )
 );
@@ -2547,7 +2522,7 @@ be_local_closure(class_Matter_Device_every_second,   /* name */
 extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_remove_fabric,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2555,60 +2530,58 @@ be_local_closure(class_Matter_Device_remove_fabric,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Device, 
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(copy),
-    /* K5   */  be_nested_str_weak(reverse),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_const_int(2),
-    /* K8   */  be_nested_str_weak(message_handler),
-    /* K9   */  be_nested_str_weak(im),
-    /* K10  */  be_nested_str_weak(subs_shop),
-    /* K11  */  be_nested_str_weak(remove_by_fabric),
-    /* K12  */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K13  */  be_nested_str_weak(sessions),
-    /* K14  */  be_nested_str_weak(remove_fabric),
-    /* K15  */  be_nested_str_weak(save_fabrics),
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(log),
+    /* K1   */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
+    /* K2   */  be_nested_str_weak(get_fabric_id),
+    /* K3   */  be_nested_str_weak(copy),
+    /* K4   */  be_nested_str_weak(reverse),
+    /* K5   */  be_nested_str_weak(tohex),
+    /* K6   */  be_const_int(2),
+    /* K7   */  be_nested_str_weak(message_handler),
+    /* K8   */  be_nested_str_weak(im),
+    /* K9   */  be_nested_str_weak(subs_shop),
+    /* K10  */  be_nested_str_weak(remove_by_fabric),
+    /* K11  */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K12  */  be_nested_str_weak(sessions),
+    /* K13  */  be_nested_str_weak(remove_fabric),
+    /* K14  */  be_nested_str_weak(save_fabrics),
     }),
     be_str_weak(remove_fabric),
     &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
+    ( &(const binstruction[32]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
       0x20080202,  //  0001  NE	R2	R1	R2
-      0x780A0019,  //  0002  JMPF	R2	#001D
+      0x780A0018,  //  0002  JMPF	R2	#001C
       0xB80A0000,  //  0003  GETNGBL	R2	K0
-      0x8C080501,  //  0004  GETMET	R2	R2	K1
-      0x8C100303,  //  0005  GETMET	R4	R1	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C100905,  //  0009  GETMET	R4	R4	K5
-      0x7C100200,  //  000A  CALL	R4	1
-      0x8C100906,  //  000B  GETMET	R4	R4	K6
-      0x7C100200,  //  000C  CALL	R4	1
-      0x00120404,  //  000D  ADD	R4	K2	R4
-      0x58140007,  //  000E  LDCONST	R5	K7
-      0x7C080600,  //  000F  CALL	R2	3
-      0x88080108,  //  0010  GETMBR	R2	R0	K8
+      0x8C0C0302,  //  0004  GETMET	R3	R1	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x8C0C0704,  //  0008  GETMET	R3	R3	K4
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x8C0C0705,  //  000A  GETMET	R3	R3	K5
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x000E0203,  //  000C  ADD	R3	K1	R3
+      0x58100006,  //  000D  LDCONST	R4	K6
+      0x7C080400,  //  000E  CALL	R2	2
+      0x88080107,  //  000F  GETMBR	R2	R0	K7
+      0x88080508,  //  0010  GETMBR	R2	R2	K8
       0x88080509,  //  0011  GETMBR	R2	R2	K9
-      0x8808050A,  //  0012  GETMBR	R2	R2	K10
-      0x8C08050B,  //  0013  GETMET	R2	R2	K11
-      0x5C100200,  //  0014  MOVE	R4	R1
-      0x7C080400,  //  0015  CALL	R2	2
-      0x8C08010C,  //  0016  GETMET	R2	R0	K12
-      0x5C100200,  //  0017  MOVE	R4	R1
-      0x7C080400,  //  0018  CALL	R2	2
-      0x8808010D,  //  0019  GETMBR	R2	R0	K13
-      0x8C08050E,  //  001A  GETMET	R2	R2	K14
-      0x5C100200,  //  001B  MOVE	R4	R1
-      0x7C080400,  //  001C  CALL	R2	2
-      0x8808010D,  //  001D  GETMBR	R2	R0	K13
-      0x8C08050F,  //  001E  GETMET	R2	R2	K15
-      0x7C080200,  //  001F  CALL	R2	1
-      0x80000000,  //  0020  RET	0
+      0x8C08050A,  //  0012  GETMET	R2	R2	K10
+      0x5C100200,  //  0013  MOVE	R4	R1
+      0x7C080400,  //  0014  CALL	R2	2
+      0x8C08010B,  //  0015  GETMET	R2	R0	K11
+      0x5C100200,  //  0016  MOVE	R4	R1
+      0x7C080400,  //  0017  CALL	R2	2
+      0x8808010C,  //  0018  GETMBR	R2	R0	K12
+      0x8C08050D,  //  0019  GETMET	R2	R2	K13
+      0x5C100200,  //  001A  MOVE	R4	R1
+      0x7C080400,  //  001B  CALL	R2	2
+      0x8808010C,  //  001C  GETMBR	R2	R0	K12
+      0x8C08050E,  //  001D  GETMET	R2	R2	K14
+      0x7C080200,  //  001E  CALL	R2	1
+      0x80000000,  //  001F  RET	0
     })
   )
 );
@@ -2805,7 +2778,7 @@ be_local_closure(class_Matter_Device__trigger_read_sensors,   /* name */
     }),
     be_str_weak(_trigger_read_sensors),
     &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
+    ( &(const binstruction[48]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xB80A0200,  //  0001  GETNGBL	R2	K1
       0x8C080502,  //  0002  GETMET	R2	R2	K2
@@ -2814,48 +2787,46 @@ be_local_closure(class_Matter_Device__trigger_read_sensors,   /* name */
       0x8C0C0703,  //  0005  GETMET	R3	R3	K3
       0x58140004,  //  0006  LDCONST	R5	K4
       0x7C0C0400,  //  0007  CALL	R3	2
-      0x780E0007,  //  0008  JMPF	R3	#0011
-      0xB80E0200,  //  0009  GETNGBL	R3	K1
-      0x8C0C0705,  //  000A  GETMET	R3	R3	K5
-      0x60140008,  //  000B  GETGBL	R5	G8
-      0x5C180400,  //  000C  MOVE	R6	R2
-      0x7C140200,  //  000D  CALL	R5	1
-      0x00160C05,  //  000E  ADD	R5	K6	R5
-      0x58180004,  //  000F  LDCONST	R6	K4
-      0x7C0C0600,  //  0010  CALL	R3	3
-      0x4C0C0000,  //  0011  LDNIL	R3
-      0x1C0C0403,  //  0012  EQ	R3	R2	R3
-      0x780E0000,  //  0013  JMPF	R3	#0015
-      0x80000600,  //  0014  RET	0
-      0x8C0C0307,  //  0015  GETMET	R3	R1	K7
-      0x5C140400,  //  0016  MOVE	R5	R2
-      0x7C0C0400,  //  0017  CALL	R3	2
-      0x4C100000,  //  0018  LDNIL	R4
-      0x20100604,  //  0019  NE	R4	R3	R4
-      0x7812000D,  //  001A  JMPF	R4	#0029
-      0x58100008,  //  001B  LDCONST	R4	K8
-      0x6014000C,  //  001C  GETGBL	R5	G12
-      0x88180109,  //  001D  GETMBR	R6	R0	K9
-      0x7C140200,  //  001E  CALL	R5	1
-      0x14140805,  //  001F  LT	R5	R4	R5
-      0x78160006,  //  0020  JMPF	R5	#0028
-      0x88140109,  //  0021  GETMBR	R5	R0	K9
-      0x94140A04,  //  0022  GETIDX	R5	R5	R4
-      0x8C140B0A,  //  0023  GETMET	R5	R5	K10
-      0x5C1C0600,  //  0024  MOVE	R7	R3
-      0x7C140400,  //  0025  CALL	R5	2
-      0x0010090B,  //  0026  ADD	R4	R4	K11
-      0x7001FFF3,  //  0027  JMP		#001C
-      0x70020007,  //  0028  JMP		#0031
-      0xB8120200,  //  0029  GETNGBL	R4	K1
-      0x8C100905,  //  002A  GETMET	R4	R4	K5
-      0x60180008,  //  002B  GETGBL	R6	G8
-      0x5C1C0400,  //  002C  MOVE	R7	R2
-      0x7C180200,  //  002D  CALL	R6	1
-      0x001A1806,  //  002E  ADD	R6	K12	R6
-      0x581C0004,  //  002F  LDCONST	R7	K4
-      0x7C100600,  //  0030  CALL	R4	3
-      0x80000000,  //  0031  RET	0
+      0x780E0006,  //  0008  JMPF	R3	#0010
+      0xB80E0A00,  //  0009  GETNGBL	R3	K5
+      0x60100008,  //  000A  GETGBL	R4	G8
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x7C100200,  //  000C  CALL	R4	1
+      0x00120C04,  //  000D  ADD	R4	K6	R4
+      0x58140004,  //  000E  LDCONST	R5	K4
+      0x7C0C0400,  //  000F  CALL	R3	2
+      0x4C0C0000,  //  0010  LDNIL	R3
+      0x1C0C0403,  //  0011  EQ	R3	R2	R3
+      0x780E0000,  //  0012  JMPF	R3	#0014
+      0x80000600,  //  0013  RET	0
+      0x8C0C0307,  //  0014  GETMET	R3	R1	K7
+      0x5C140400,  //  0015  MOVE	R5	R2
+      0x7C0C0400,  //  0016  CALL	R3	2
+      0x4C100000,  //  0017  LDNIL	R4
+      0x20100604,  //  0018  NE	R4	R3	R4
+      0x7812000D,  //  0019  JMPF	R4	#0028
+      0x58100008,  //  001A  LDCONST	R4	K8
+      0x6014000C,  //  001B  GETGBL	R5	G12
+      0x88180109,  //  001C  GETMBR	R6	R0	K9
+      0x7C140200,  //  001D  CALL	R5	1
+      0x14140805,  //  001E  LT	R5	R4	R5
+      0x78160006,  //  001F  JMPF	R5	#0027
+      0x88140109,  //  0020  GETMBR	R5	R0	K9
+      0x94140A04,  //  0021  GETIDX	R5	R5	R4
+      0x8C140B0A,  //  0022  GETMET	R5	R5	K10
+      0x5C1C0600,  //  0023  MOVE	R7	R3
+      0x7C140400,  //  0024  CALL	R5	2
+      0x0010090B,  //  0025  ADD	R4	R4	K11
+      0x7001FFF3,  //  0026  JMP		#001B
+      0x70020006,  //  0027  JMP		#002F
+      0xB8120A00,  //  0028  GETNGBL	R4	K5
+      0x60140008,  //  0029  GETGBL	R5	G8
+      0x5C180400,  //  002A  MOVE	R6	R2
+      0x7C140200,  //  002B  CALL	R5	1
+      0x00161805,  //  002C  ADD	R5	K12	R5
+      0x58180004,  //  002D  LDCONST	R6	K4
+      0x7C100400,  //  002E  CALL	R4	2
+      0x80000000,  //  002F  RET	0
     })
   )
 );
@@ -2868,7 +2839,7 @@ be_local_closure(class_Matter_Device__trigger_read_sensors,   /* name */
 extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device__instantiate_plugins_from_config,   /* name */
   be_nested_proto(
-    18,                          /* nstack */
+    17,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2878,194 +2849,186 @@ be_local_closure(class_Matter_Device__instantiate_plugins_from_config,   /* name
     1,                          /* has constants */
     ( &(const bvalue[31]) {     /* constants */
     /* K0   */  be_nested_str_weak(k2l_num),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20Configuring_X20endpoints),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(plugins),
-    /* K6   */  be_nested_str_weak(push),
-    /* K7   */  be_nested_str_weak(matter),
-    /* K8   */  be_nested_str_weak(Plugin_Root),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X20_X20endpoint_X20_X3D_X20_X255i_X20type_X3A_X25s_X25s),
-    /* K11  */  be_nested_str_weak(root),
-    /* K12  */  be_nested_str_weak(),
-    /* K13  */  be_nested_str_weak(Plugin_Aggregator),
-    /* K14  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-    /* K15  */  be_nested_str_weak(aggregator),
-    /* K16  */  be_nested_str_weak(find),
-    /* K17  */  be_nested_str_weak(type),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
-    /* K19  */  be_const_int(3),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20only_X20one_X20root_X20node_X20allowed),
-    /* K21  */  be_nested_str_weak(plugins_classes),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-    /* K23  */  be_nested_str_weak(_X27_X20skipping),
-    /* K24  */  be_nested_str_weak(conf_to_log),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K26  */  be_nested_str_weak(_X7C),
-    /* K27  */  be_nested_str_weak(stop_iteration),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20Configuring_X20endpoints),
+    /* K3   */  be_const_int(2),
+    /* K4   */  be_nested_str_weak(plugins),
+    /* K5   */  be_nested_str_weak(push),
+    /* K6   */  be_nested_str_weak(matter),
+    /* K7   */  be_nested_str_weak(Plugin_Root),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X20_X20endpoint_X20_X3D_X20_X255i_X20type_X3A_X25s_X25s),
+    /* K10  */  be_nested_str_weak(root),
+    /* K11  */  be_nested_str_weak(),
+    /* K12  */  be_nested_str_weak(Plugin_Aggregator),
+    /* K13  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+    /* K14  */  be_nested_str_weak(aggregator),
+    /* K15  */  be_nested_str_weak(find),
+    /* K16  */  be_nested_str_weak(type),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20no_X20class_X20name_X2C_X20skipping),
+    /* K18  */  be_const_int(3),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20only_X20one_X20root_X20node_X20allowed),
+    /* K20  */  be_nested_str_weak(plugins_classes),
+    /* K21  */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+    /* K22  */  be_nested_str_weak(_X27_X20skipping),
+    /* K23  */  be_nested_str_weak(conf_to_log),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K25  */  be_nested_str_weak(_X7C),
+    /* K26  */  be_nested_str_weak(stop_iteration),
+    /* K27  */  be_nested_str_weak(tasmota),
     /* K28  */  be_nested_str_weak(publish_result),
     /* K29  */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Initialized_X22_X3A1_X7D_X7D),
     /* K30  */  be_nested_str_weak(Matter),
     }),
     be_str_weak(_instantiate_plugins_from_config),
     &be_const_str_solidified,
-    ( &(const binstruction[154]) {  /* code */
+    ( &(const binstruction[146]) {  /* code */
       0x8C080100,  //  0000  GETMET	R2	R0	K0
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0xB80E0200,  //  0003  GETNGBL	R3	K1
-      0x8C0C0702,  //  0004  GETMET	R3	R3	K2
+      0x58100002,  //  0004  LDCONST	R4	K2
       0x58140003,  //  0005  LDCONST	R5	K3
-      0x58180004,  //  0006  LDCONST	R6	K4
-      0x7C0C0600,  //  0007  CALL	R3	3
-      0x880C0105,  //  0008  GETMBR	R3	R0	K5
-      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
-      0xB8160E00,  //  000A  GETNGBL	R5	K7
-      0x8C140B08,  //  000B  GETMET	R5	R5	K8
-      0x5C1C0000,  //  000C  MOVE	R7	R0
-      0x58200009,  //  000D  LDCONST	R8	K9
-      0x60240013,  //  000E  GETGBL	R9	G19
-      0x7C240000,  //  000F  CALL	R9	0
-      0x7C140800,  //  0010  CALL	R5	4
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0xB80E0200,  //  0012  GETNGBL	R3	K1
-      0x8C0C0702,  //  0013  GETMET	R3	R3	K2
-      0x60140018,  //  0014  GETGBL	R5	G24
-      0x5818000A,  //  0015  LDCONST	R6	K10
-      0x581C0009,  //  0016  LDCONST	R7	K9
-      0x5820000B,  //  0017  LDCONST	R8	K11
-      0x5824000C,  //  0018  LDCONST	R9	K12
-      0x7C140800,  //  0019  CALL	R5	4
-      0x58180004,  //  001A  LDCONST	R6	K4
-      0x7C0C0600,  //  001B  CALL	R3	3
-      0x880C0105,  //  001C  GETMBR	R3	R0	K5
-      0x8C0C0706,  //  001D  GETMET	R3	R3	K6
-      0xB8160E00,  //  001E  GETNGBL	R5	K7
-      0x8C140B0D,  //  001F  GETMET	R5	R5	K13
-      0x5C1C0000,  //  0020  MOVE	R7	R0
-      0xB8220E00,  //  0021  GETNGBL	R8	K7
-      0x8820110E,  //  0022  GETMBR	R8	R8	K14
-      0x60240013,  //  0023  GETGBL	R9	G19
-      0x7C240000,  //  0024  CALL	R9	0
-      0x7C140800,  //  0025  CALL	R5	4
-      0x7C0C0400,  //  0026  CALL	R3	2
-      0xB80E0200,  //  0027  GETNGBL	R3	K1
-      0x8C0C0702,  //  0028  GETMET	R3	R3	K2
-      0x60140018,  //  0029  GETGBL	R5	G24
-      0x5818000A,  //  002A  LDCONST	R6	K10
-      0xB81E0E00,  //  002B  GETNGBL	R7	K7
-      0x881C0F0E,  //  002C  GETMBR	R7	R7	K14
-      0x5820000F,  //  002D  LDCONST	R8	K15
-      0x5824000C,  //  002E  LDCONST	R9	K12
-      0x7C140800,  //  002F  CALL	R5	4
-      0x58180004,  //  0030  LDCONST	R6	K4
-      0x7C0C0600,  //  0031  CALL	R3	3
-      0x600C0010,  //  0032  GETGBL	R3	G16
-      0x5C100400,  //  0033  MOVE	R4	R2
-      0x7C0C0200,  //  0034  CALL	R3	1
-      0xA802005A,  //  0035  EXBLK	0	#0091
-      0x5C100600,  //  0036  MOVE	R4	R3
-      0x7C100000,  //  0037  CALL	R4	0
-      0x1C140909,  //  0038  EQ	R5	R4	K9
-      0x78160000,  //  0039  JMPF	R5	#003B
-      0x7001FFFA,  //  003A  JMP		#0036
-      0xA8020042,  //  003B  EXBLK	0	#007F
-      0x60140008,  //  003C  GETGBL	R5	G8
-      0x5C180800,  //  003D  MOVE	R6	R4
-      0x7C140200,  //  003E  CALL	R5	1
-      0x94140205,  //  003F  GETIDX	R5	R1	R5
-      0x8C180B10,  //  0040  GETMET	R6	R5	K16
-      0x58200011,  //  0041  LDCONST	R8	K17
-      0x7C180400,  //  0042  CALL	R6	2
-      0x4C1C0000,  //  0043  LDNIL	R7
-      0x1C1C0C07,  //  0044  EQ	R7	R6	R7
-      0x781E0006,  //  0045  JMPF	R7	#004D
-      0xB81E0200,  //  0046  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0047  GETMET	R7	R7	K2
-      0x58240012,  //  0048  LDCONST	R9	K18
-      0x58280013,  //  0049  LDCONST	R10	K19
-      0x7C1C0600,  //  004A  CALL	R7	3
-      0xA8040001,  //  004B  EXBLK	1	1
-      0x7001FFE8,  //  004C  JMP		#0036
-      0x1C1C0D0B,  //  004D  EQ	R7	R6	K11
-      0x781E0006,  //  004E  JMPF	R7	#0056
-      0xB81E0200,  //  004F  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0050  GETMET	R7	R7	K2
-      0x58240014,  //  0051  LDCONST	R9	K20
-      0x58280013,  //  0052  LDCONST	R10	K19
-      0x7C1C0600,  //  0053  CALL	R7	3
-      0xA8040001,  //  0054  EXBLK	1	1
-      0x7001FFDF,  //  0055  JMP		#0036
-      0x881C0115,  //  0056  GETMBR	R7	R0	K21
-      0x8C1C0F10,  //  0057  GETMET	R7	R7	K16
-      0x5C240C00,  //  0058  MOVE	R9	R6
-      0x7C1C0400,  //  0059  CALL	R7	2
-      0x4C200000,  //  005A  LDNIL	R8
-      0x1C200E08,  //  005B  EQ	R8	R7	R8
-      0x7822000A,  //  005C  JMPF	R8	#0068
-      0xB8220200,  //  005D  GETNGBL	R8	K1
-      0x8C201102,  //  005E  GETMET	R8	R8	K2
-      0x60280008,  //  005F  GETGBL	R10	G8
-      0x5C2C0C00,  //  0060  MOVE	R11	R6
-      0x7C280200,  //  0061  CALL	R10	1
-      0x002A2C0A,  //  0062  ADD	R10	K22	R10
-      0x00281517,  //  0063  ADD	R10	R10	K23
-      0x582C0004,  //  0064  LDCONST	R11	K4
-      0x7C200600,  //  0065  CALL	R8	3
-      0xA8040001,  //  0066  EXBLK	1	1
-      0x7001FFCD,  //  0067  JMP		#0036
-      0x5C200E00,  //  0068  MOVE	R8	R7
-      0x5C240000,  //  0069  MOVE	R9	R0
-      0x5C280800,  //  006A  MOVE	R10	R4
-      0x5C2C0A00,  //  006B  MOVE	R11	R5
-      0x7C200600,  //  006C  CALL	R8	3
-      0x88240105,  //  006D  GETMBR	R9	R0	K5
-      0x8C241306,  //  006E  GETMET	R9	R9	K6
-      0x5C2C1000,  //  006F  MOVE	R11	R8
-      0x7C240400,  //  0070  CALL	R9	2
-      0xB8260200,  //  0071  GETNGBL	R9	K1
-      0x8C241302,  //  0072  GETMET	R9	R9	K2
-      0x602C0018,  //  0073  GETGBL	R11	G24
-      0x5830000A,  //  0074  LDCONST	R12	K10
-      0x5C340800,  //  0075  MOVE	R13	R4
-      0x5C380C00,  //  0076  MOVE	R14	R6
-      0x8C3C0118,  //  0077  GETMET	R15	R0	K24
-      0x5C440A00,  //  0078  MOVE	R17	R5
-      0x7C3C0400,  //  0079  CALL	R15	2
-      0x7C2C0800,  //  007A  CALL	R11	4
-      0x58300004,  //  007B  LDCONST	R12	K4
-      0x7C240600,  //  007C  CALL	R9	3
-      0xA8040001,  //  007D  EXBLK	1	1
-      0x70020010,  //  007E  JMP		#0090
-      0xAC140002,  //  007F  CATCH	R5	0	2
-      0x7002000D,  //  0080  JMP		#008F
-      0xB81E0200,  //  0081  GETNGBL	R7	K1
-      0x8C1C0F02,  //  0082  GETMET	R7	R7	K2
-      0x60240008,  //  0083  GETGBL	R9	G8
-      0x5C280A00,  //  0084  MOVE	R10	R5
-      0x7C240200,  //  0085  CALL	R9	1
-      0x00263209,  //  0086  ADD	R9	K25	R9
-      0x0024131A,  //  0087  ADD	R9	R9	K26
-      0x60280008,  //  0088  GETGBL	R10	G8
-      0x5C2C0C00,  //  0089  MOVE	R11	R6
-      0x7C280200,  //  008A  CALL	R10	1
-      0x0024120A,  //  008B  ADD	R9	R9	R10
-      0x58280004,  //  008C  LDCONST	R10	K4
-      0x7C1C0600,  //  008D  CALL	R7	3
-      0x70020000,  //  008E  JMP		#0090
-      0xB0080000,  //  008F  RAISE	2	R0	R0
-      0x7001FFA4,  //  0090  JMP		#0036
-      0x580C001B,  //  0091  LDCONST	R3	K27
-      0xAC0C0200,  //  0092  CATCH	R3	1	0
-      0xB0080000,  //  0093  RAISE	2	R0	R0
-      0xB80E0200,  //  0094  GETNGBL	R3	K1
-      0x8C0C071C,  //  0095  GETMET	R3	R3	K28
-      0x5814001D,  //  0096  LDCONST	R5	K29
-      0x5818001E,  //  0097  LDCONST	R6	K30
-      0x7C0C0600,  //  0098  CALL	R3	3
-      0x80000000,  //  0099  RET	0
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x880C0104,  //  0007  GETMBR	R3	R0	K4
+      0x8C0C0705,  //  0008  GETMET	R3	R3	K5
+      0xB8160C00,  //  0009  GETNGBL	R5	K6
+      0x8C140B07,  //  000A  GETMET	R5	R5	K7
+      0x5C1C0000,  //  000B  MOVE	R7	R0
+      0x58200008,  //  000C  LDCONST	R8	K8
+      0x60240013,  //  000D  GETGBL	R9	G19
+      0x7C240000,  //  000E  CALL	R9	0
+      0x7C140800,  //  000F  CALL	R5	4
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0xB80E0200,  //  0011  GETNGBL	R3	K1
+      0x60100018,  //  0012  GETGBL	R4	G24
+      0x58140009,  //  0013  LDCONST	R5	K9
+      0x58180008,  //  0014  LDCONST	R6	K8
+      0x581C000A,  //  0015  LDCONST	R7	K10
+      0x5820000B,  //  0016  LDCONST	R8	K11
+      0x7C100800,  //  0017  CALL	R4	4
+      0x58140003,  //  0018  LDCONST	R5	K3
+      0x7C0C0400,  //  0019  CALL	R3	2
+      0x880C0104,  //  001A  GETMBR	R3	R0	K4
+      0x8C0C0705,  //  001B  GETMET	R3	R3	K5
+      0xB8160C00,  //  001C  GETNGBL	R5	K6
+      0x8C140B0C,  //  001D  GETMET	R5	R5	K12
+      0x5C1C0000,  //  001E  MOVE	R7	R0
+      0xB8220C00,  //  001F  GETNGBL	R8	K6
+      0x8820110D,  //  0020  GETMBR	R8	R8	K13
+      0x60240013,  //  0021  GETGBL	R9	G19
+      0x7C240000,  //  0022  CALL	R9	0
+      0x7C140800,  //  0023  CALL	R5	4
+      0x7C0C0400,  //  0024  CALL	R3	2
+      0xB80E0200,  //  0025  GETNGBL	R3	K1
+      0x60100018,  //  0026  GETGBL	R4	G24
+      0x58140009,  //  0027  LDCONST	R5	K9
+      0xB81A0C00,  //  0028  GETNGBL	R6	K6
+      0x88180D0D,  //  0029  GETMBR	R6	R6	K13
+      0x581C000E,  //  002A  LDCONST	R7	K14
+      0x5820000B,  //  002B  LDCONST	R8	K11
+      0x7C100800,  //  002C  CALL	R4	4
+      0x58140003,  //  002D  LDCONST	R5	K3
+      0x7C0C0400,  //  002E  CALL	R3	2
+      0x600C0010,  //  002F  GETGBL	R3	G16
+      0x5C100400,  //  0030  MOVE	R4	R2
+      0x7C0C0200,  //  0031  CALL	R3	1
+      0xA8020055,  //  0032  EXBLK	0	#0089
+      0x5C100600,  //  0033  MOVE	R4	R3
+      0x7C100000,  //  0034  CALL	R4	0
+      0x1C140908,  //  0035  EQ	R5	R4	K8
+      0x78160000,  //  0036  JMPF	R5	#0038
+      0x7001FFFA,  //  0037  JMP		#0033
+      0xA802003E,  //  0038  EXBLK	0	#0078
+      0x60140008,  //  0039  GETGBL	R5	G8
+      0x5C180800,  //  003A  MOVE	R6	R4
+      0x7C140200,  //  003B  CALL	R5	1
+      0x94140205,  //  003C  GETIDX	R5	R1	R5
+      0x8C180B0F,  //  003D  GETMET	R6	R5	K15
+      0x58200010,  //  003E  LDCONST	R8	K16
+      0x7C180400,  //  003F  CALL	R6	2
+      0x4C1C0000,  //  0040  LDNIL	R7
+      0x1C1C0C07,  //  0041  EQ	R7	R6	R7
+      0x781E0005,  //  0042  JMPF	R7	#0049
+      0xB81E0200,  //  0043  GETNGBL	R7	K1
+      0x58200011,  //  0044  LDCONST	R8	K17
+      0x58240012,  //  0045  LDCONST	R9	K18
+      0x7C1C0400,  //  0046  CALL	R7	2
+      0xA8040001,  //  0047  EXBLK	1	1
+      0x7001FFE9,  //  0048  JMP		#0033
+      0x1C1C0D0A,  //  0049  EQ	R7	R6	K10
+      0x781E0005,  //  004A  JMPF	R7	#0051
+      0xB81E0200,  //  004B  GETNGBL	R7	K1
+      0x58200013,  //  004C  LDCONST	R8	K19
+      0x58240012,  //  004D  LDCONST	R9	K18
+      0x7C1C0400,  //  004E  CALL	R7	2
+      0xA8040001,  //  004F  EXBLK	1	1
+      0x7001FFE1,  //  0050  JMP		#0033
+      0x881C0114,  //  0051  GETMBR	R7	R0	K20
+      0x8C1C0F0F,  //  0052  GETMET	R7	R7	K15
+      0x5C240C00,  //  0053  MOVE	R9	R6
+      0x7C1C0400,  //  0054  CALL	R7	2
+      0x4C200000,  //  0055  LDNIL	R8
+      0x1C200E08,  //  0056  EQ	R8	R7	R8
+      0x78220009,  //  0057  JMPF	R8	#0062
+      0xB8220200,  //  0058  GETNGBL	R8	K1
+      0x60240008,  //  0059  GETGBL	R9	G8
+      0x5C280C00,  //  005A  MOVE	R10	R6
+      0x7C240200,  //  005B  CALL	R9	1
+      0x00262A09,  //  005C  ADD	R9	K21	R9
+      0x00241316,  //  005D  ADD	R9	R9	K22
+      0x58280003,  //  005E  LDCONST	R10	K3
+      0x7C200400,  //  005F  CALL	R8	2
+      0xA8040001,  //  0060  EXBLK	1	1
+      0x7001FFD0,  //  0061  JMP		#0033
+      0x5C200E00,  //  0062  MOVE	R8	R7
+      0x5C240000,  //  0063  MOVE	R9	R0
+      0x5C280800,  //  0064  MOVE	R10	R4
+      0x5C2C0A00,  //  0065  MOVE	R11	R5
+      0x7C200600,  //  0066  CALL	R8	3
+      0x88240104,  //  0067  GETMBR	R9	R0	K4
+      0x8C241305,  //  0068  GETMET	R9	R9	K5
+      0x5C2C1000,  //  0069  MOVE	R11	R8
+      0x7C240400,  //  006A  CALL	R9	2
+      0xB8260200,  //  006B  GETNGBL	R9	K1
+      0x60280018,  //  006C  GETGBL	R10	G24
+      0x582C0009,  //  006D  LDCONST	R11	K9
+      0x5C300800,  //  006E  MOVE	R12	R4
+      0x5C340C00,  //  006F  MOVE	R13	R6
+      0x8C380117,  //  0070  GETMET	R14	R0	K23
+      0x5C400A00,  //  0071  MOVE	R16	R5
+      0x7C380400,  //  0072  CALL	R14	2
+      0x7C280800,  //  0073  CALL	R10	4
+      0x582C0003,  //  0074  LDCONST	R11	K3
+      0x7C240400,  //  0075  CALL	R9	2
+      0xA8040001,  //  0076  EXBLK	1	1
+      0x7002000F,  //  0077  JMP		#0088
+      0xAC140002,  //  0078  CATCH	R5	0	2
+      0x7002000C,  //  0079  JMP		#0087
+      0xB81E0200,  //  007A  GETNGBL	R7	K1
+      0x60200008,  //  007B  GETGBL	R8	G8
+      0x5C240A00,  //  007C  MOVE	R9	R5
+      0x7C200200,  //  007D  CALL	R8	1
+      0x00223008,  //  007E  ADD	R8	K24	R8
+      0x00201119,  //  007F  ADD	R8	R8	K25
+      0x60240008,  //  0080  GETGBL	R9	G8
+      0x5C280C00,  //  0081  MOVE	R10	R6
+      0x7C240200,  //  0082  CALL	R9	1
+      0x00201009,  //  0083  ADD	R8	R8	R9
+      0x58240003,  //  0084  LDCONST	R9	K3
+      0x7C1C0400,  //  0085  CALL	R7	2
+      0x70020000,  //  0086  JMP		#0088
+      0xB0080000,  //  0087  RAISE	2	R0	R0
+      0x7001FFA9,  //  0088  JMP		#0033
+      0x580C001A,  //  0089  LDCONST	R3	K26
+      0xAC0C0200,  //  008A  CATCH	R3	1	0
+      0xB0080000,  //  008B  RAISE	2	R0	R0
+      0xB80E3600,  //  008C  GETNGBL	R3	K27
+      0x8C0C071C,  //  008D  GETMET	R3	R3	K28
+      0x5814001D,  //  008E  LDCONST	R5	K29
+      0x5818001E,  //  008F  LDCONST	R6	K30
+      0x7C0C0600,  //  0090  CALL	R3	3
+      0x80000000,  //  0091  RET	0
     })
   )
 );
@@ -3094,10 +3057,10 @@ be_local_closure(class_Matter_Device_mdns_announce_op_discovery,   /* name */
     /* K4   */  be_nested_str_weak(get_fabric_compressed),
     /* K5   */  be_nested_str_weak(tohex),
     /* K6   */  be_nested_str_weak(_X2D),
-    /* K7   */  be_nested_str_weak(tasmota),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
-    /* K10  */  be_const_int(3),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
+    /* K9   */  be_const_int(3),
+    /* K10  */  be_nested_str_weak(tasmota),
     /* K11  */  be_nested_str_weak(eth),
     /* K12  */  be_nested_str_weak(find),
     /* K13  */  be_nested_str_weak(up),
@@ -3117,9 +3080,9 @@ be_local_closure(class_Matter_Device_mdns_announce_op_discovery,   /* name */
     }),
     be_str_weak(mdns_announce_op_discovery),
     &be_const_str_solidified,
-    ( &(const binstruction[121]) {  /* code */
+    ( &(const binstruction[115]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA8020064,  //  0001  EXBLK	0	#0067
+      0xA802005F,  //  0001  EXBLK	0	#0062
       0x8C0C0301,  //  0002  GETMET	R3	R1	K1
       0x7C0C0200,  //  0003  CALL	R3	1
       0x8C0C0702,  //  0004  GETMET	R3	R3	K2
@@ -3135,110 +3098,104 @@ be_local_closure(class_Matter_Device_mdns_announce_op_discovery,   /* name */
       0x7C180200,  //  000E  CALL	R6	1
       0x00140A06,  //  000F  ADD	R5	R5	R6
       0xB81A0E00,  //  0010  GETNGBL	R6	K7
-      0x8C180D08,  //  0011  GETMET	R6	R6	K8
-      0x00221205,  //  0012  ADD	R8	K9	R5
-      0x5824000A,  //  0013  LDCONST	R9	K10
-      0x7C180600,  //  0014  CALL	R6	3
-      0xB81A0E00,  //  0015  GETNGBL	R6	K7
-      0x8C180D0B,  //  0016  GETMET	R6	R6	K11
-      0x7C180200,  //  0017  CALL	R6	1
-      0x8C180D0C,  //  0018  GETMET	R6	R6	K12
-      0x5820000D,  //  0019  LDCONST	R8	K13
-      0x7C180400,  //  001A  CALL	R6	2
-      0x781A0020,  //  001B  JMPF	R6	#003D
-      0xB81A0E00,  //  001C  GETNGBL	R6	K7
-      0x8C180D08,  //  001D  GETMET	R6	R6	K8
-      0x60200018,  //  001E  GETGBL	R8	G24
-      0x5824000E,  //  001F  LDCONST	R9	K14
-      0x5828000B,  //  0020  LDCONST	R10	K11
-      0x5C2C0A00,  //  0021  MOVE	R11	R5
-      0x8830010F,  //  0022  GETMBR	R12	R0	K15
-      0x7C200800,  //  0023  CALL	R8	4
-      0x5824000A,  //  0024  LDCONST	R9	K10
-      0x7C180600,  //  0025  CALL	R6	3
-      0x8C180510,  //  0026  GETMET	R6	R2	K16
-      0x58200011,  //  0027  LDCONST	R8	K17
-      0x58240012,  //  0028  LDCONST	R9	K18
-      0x542A15A3,  //  0029  LDINT	R10	5540
-      0x4C2C0000,  //  002A  LDNIL	R11
-      0x5C300A00,  //  002B  MOVE	R12	R5
-      0x8834010F,  //  002C  GETMBR	R13	R0	K15
-      0x7C180E00,  //  002D  CALL	R6	7
-      0x8C180905,  //  002E  GETMET	R6	R4	K5
-      0x7C180200,  //  002F  CALL	R6	1
-      0x001A2606,  //  0030  ADD	R6	K19	R6
-      0xB81E0E00,  //  0031  GETNGBL	R7	K7
-      0x8C1C0F08,  //  0032  GETMET	R7	R7	K8
-      0x00262806,  //  0033  ADD	R9	K20	R6
-      0x5828000A,  //  0034  LDCONST	R10	K10
-      0x7C1C0600,  //  0035  CALL	R7	3
-      0x8C1C0515,  //  0036  GETMET	R7	R2	K21
-      0x58240011,  //  0037  LDCONST	R9	K17
-      0x58280012,  //  0038  LDCONST	R10	K18
-      0x5C2C0A00,  //  0039  MOVE	R11	R5
-      0x8830010F,  //  003A  GETMBR	R12	R0	K15
-      0x5C340C00,  //  003B  MOVE	R13	R6
-      0x7C1C0C00,  //  003C  CALL	R7	6
-      0xB81A0E00,  //  003D  GETNGBL	R6	K7
-      0x8C180D16,  //  003E  GETMET	R6	R6	K22
-      0x7C180200,  //  003F  CALL	R6	1
-      0x8C180D0C,  //  0040  GETMET	R6	R6	K12
-      0x5820000D,  //  0041  LDCONST	R8	K13
-      0x7C180400,  //  0042  CALL	R6	2
-      0x781A0020,  //  0043  JMPF	R6	#0065
-      0xB81A0E00,  //  0044  GETNGBL	R6	K7
-      0x8C180D08,  //  0045  GETMET	R6	R6	K8
-      0x60200018,  //  0046  GETGBL	R8	G24
-      0x5824000E,  //  0047  LDCONST	R9	K14
-      0x58280016,  //  0048  LDCONST	R10	K22
-      0x5C2C0A00,  //  0049  MOVE	R11	R5
-      0x88300117,  //  004A  GETMBR	R12	R0	K23
-      0x7C200800,  //  004B  CALL	R8	4
-      0x5824000A,  //  004C  LDCONST	R9	K10
-      0x7C180600,  //  004D  CALL	R6	3
-      0x8C180510,  //  004E  GETMET	R6	R2	K16
-      0x58200011,  //  004F  LDCONST	R8	K17
-      0x58240012,  //  0050  LDCONST	R9	K18
-      0x542A15A3,  //  0051  LDINT	R10	5540
-      0x4C2C0000,  //  0052  LDNIL	R11
-      0x5C300A00,  //  0053  MOVE	R12	R5
-      0x88340117,  //  0054  GETMBR	R13	R0	K23
-      0x7C180E00,  //  0055  CALL	R6	7
-      0x8C180905,  //  0056  GETMET	R6	R4	K5
-      0x7C180200,  //  0057  CALL	R6	1
-      0x001A2606,  //  0058  ADD	R6	K19	R6
-      0xB81E0E00,  //  0059  GETNGBL	R7	K7
-      0x8C1C0F08,  //  005A  GETMET	R7	R7	K8
-      0x00262806,  //  005B  ADD	R9	K20	R6
-      0x5828000A,  //  005C  LDCONST	R10	K10
-      0x7C1C0600,  //  005D  CALL	R7	3
-      0x8C1C0515,  //  005E  GETMET	R7	R2	K21
-      0x58240011,  //  005F  LDCONST	R9	K17
-      0x58280012,  //  0060  LDCONST	R10	K18
-      0x5C2C0A00,  //  0061  MOVE	R11	R5
-      0x88300117,  //  0062  GETMBR	R12	R0	K23
-      0x5C340C00,  //  0063  MOVE	R13	R6
-      0x7C1C0C00,  //  0064  CALL	R7	6
-      0xA8040001,  //  0065  EXBLK	1	1
-      0x70020010,  //  0066  JMP		#0078
-      0xAC0C0002,  //  0067  CATCH	R3	0	2
-      0x7002000D,  //  0068  JMP		#0077
-      0xB8160E00,  //  0069  GETNGBL	R5	K7
-      0x8C140B08,  //  006A  GETMET	R5	R5	K8
-      0x601C0008,  //  006B  GETGBL	R7	G8
-      0x5C200600,  //  006C  MOVE	R8	R3
-      0x7C1C0200,  //  006D  CALL	R7	1
-      0x001E3007,  //  006E  ADD	R7	K24	R7
-      0x001C0F19,  //  006F  ADD	R7	R7	K25
-      0x60200008,  //  0070  GETGBL	R8	G8
-      0x5C240800,  //  0071  MOVE	R9	R4
-      0x7C200200,  //  0072  CALL	R8	1
-      0x001C0E08,  //  0073  ADD	R7	R7	R8
-      0x5820001A,  //  0074  LDCONST	R8	K26
-      0x7C140600,  //  0075  CALL	R5	3
-      0x70020000,  //  0076  JMP		#0078
-      0xB0080000,  //  0077  RAISE	2	R0	R0
-      0x80000000,  //  0078  RET	0
+      0x001E1005,  //  0011  ADD	R7	K8	R5
+      0x58200009,  //  0012  LDCONST	R8	K9
+      0x7C180400,  //  0013  CALL	R6	2
+      0xB81A1400,  //  0014  GETNGBL	R6	K10
+      0x8C180D0B,  //  0015  GETMET	R6	R6	K11
+      0x7C180200,  //  0016  CALL	R6	1
+      0x8C180D0C,  //  0017  GETMET	R6	R6	K12
+      0x5820000D,  //  0018  LDCONST	R8	K13
+      0x7C180400,  //  0019  CALL	R6	2
+      0x781A001E,  //  001A  JMPF	R6	#003A
+      0xB81A0E00,  //  001B  GETNGBL	R6	K7
+      0x601C0018,  //  001C  GETGBL	R7	G24
+      0x5820000E,  //  001D  LDCONST	R8	K14
+      0x5824000B,  //  001E  LDCONST	R9	K11
+      0x5C280A00,  //  001F  MOVE	R10	R5
+      0x882C010F,  //  0020  GETMBR	R11	R0	K15
+      0x7C1C0800,  //  0021  CALL	R7	4
+      0x58200009,  //  0022  LDCONST	R8	K9
+      0x7C180400,  //  0023  CALL	R6	2
+      0x8C180510,  //  0024  GETMET	R6	R2	K16
+      0x58200011,  //  0025  LDCONST	R8	K17
+      0x58240012,  //  0026  LDCONST	R9	K18
+      0x542A15A3,  //  0027  LDINT	R10	5540
+      0x4C2C0000,  //  0028  LDNIL	R11
+      0x5C300A00,  //  0029  MOVE	R12	R5
+      0x8834010F,  //  002A  GETMBR	R13	R0	K15
+      0x7C180E00,  //  002B  CALL	R6	7
+      0x8C180905,  //  002C  GETMET	R6	R4	K5
+      0x7C180200,  //  002D  CALL	R6	1
+      0x001A2606,  //  002E  ADD	R6	K19	R6
+      0xB81E0E00,  //  002F  GETNGBL	R7	K7
+      0x00222806,  //  0030  ADD	R8	K20	R6
+      0x58240009,  //  0031  LDCONST	R9	K9
+      0x7C1C0400,  //  0032  CALL	R7	2
+      0x8C1C0515,  //  0033  GETMET	R7	R2	K21
+      0x58240011,  //  0034  LDCONST	R9	K17
+      0x58280012,  //  0035  LDCONST	R10	K18
+      0x5C2C0A00,  //  0036  MOVE	R11	R5
+      0x8830010F,  //  0037  GETMBR	R12	R0	K15
+      0x5C340C00,  //  0038  MOVE	R13	R6
+      0x7C1C0C00,  //  0039  CALL	R7	6
+      0xB81A1400,  //  003A  GETNGBL	R6	K10
+      0x8C180D16,  //  003B  GETMET	R6	R6	K22
+      0x7C180200,  //  003C  CALL	R6	1
+      0x8C180D0C,  //  003D  GETMET	R6	R6	K12
+      0x5820000D,  //  003E  LDCONST	R8	K13
+      0x7C180400,  //  003F  CALL	R6	2
+      0x781A001E,  //  0040  JMPF	R6	#0060
+      0xB81A0E00,  //  0041  GETNGBL	R6	K7
+      0x601C0018,  //  0042  GETGBL	R7	G24
+      0x5820000E,  //  0043  LDCONST	R8	K14
+      0x58240016,  //  0044  LDCONST	R9	K22
+      0x5C280A00,  //  0045  MOVE	R10	R5
+      0x882C0117,  //  0046  GETMBR	R11	R0	K23
+      0x7C1C0800,  //  0047  CALL	R7	4
+      0x58200009,  //  0048  LDCONST	R8	K9
+      0x7C180400,  //  0049  CALL	R6	2
+      0x8C180510,  //  004A  GETMET	R6	R2	K16
+      0x58200011,  //  004B  LDCONST	R8	K17
+      0x58240012,  //  004C  LDCONST	R9	K18
+      0x542A15A3,  //  004D  LDINT	R10	5540
+      0x4C2C0000,  //  004E  LDNIL	R11
+      0x5C300A00,  //  004F  MOVE	R12	R5
+      0x88340117,  //  0050  GETMBR	R13	R0	K23
+      0x7C180E00,  //  0051  CALL	R6	7
+      0x8C180905,  //  0052  GETMET	R6	R4	K5
+      0x7C180200,  //  0053  CALL	R6	1
+      0x001A2606,  //  0054  ADD	R6	K19	R6
+      0xB81E0E00,  //  0055  GETNGBL	R7	K7
+      0x00222806,  //  0056  ADD	R8	K20	R6
+      0x58240009,  //  0057  LDCONST	R9	K9
+      0x7C1C0400,  //  0058  CALL	R7	2
+      0x8C1C0515,  //  0059  GETMET	R7	R2	K21
+      0x58240011,  //  005A  LDCONST	R9	K17
+      0x58280012,  //  005B  LDCONST	R10	K18
+      0x5C2C0A00,  //  005C  MOVE	R11	R5
+      0x88300117,  //  005D  GETMBR	R12	R0	K23
+      0x5C340C00,  //  005E  MOVE	R13	R6
+      0x7C1C0C00,  //  005F  CALL	R7	6
+      0xA8040001,  //  0060  EXBLK	1	1
+      0x7002000F,  //  0061  JMP		#0072
+      0xAC0C0002,  //  0062  CATCH	R3	0	2
+      0x7002000C,  //  0063  JMP		#0071
+      0xB8160E00,  //  0064  GETNGBL	R5	K7
+      0x60180008,  //  0065  GETGBL	R6	G8
+      0x5C1C0600,  //  0066  MOVE	R7	R3
+      0x7C180200,  //  0067  CALL	R6	1
+      0x001A3006,  //  0068  ADD	R6	K24	R6
+      0x00180D19,  //  0069  ADD	R6	R6	K25
+      0x601C0008,  //  006A  GETGBL	R7	G8
+      0x5C200800,  //  006B  MOVE	R8	R4
+      0x7C1C0200,  //  006C  CALL	R7	1
+      0x00180C07,  //  006D  ADD	R6	R6	R7
+      0x581C001A,  //  006E  LDCONST	R7	K26
+      0x7C140400,  //  006F  CALL	R5	2
+      0x70020000,  //  0070  JMP		#0072
+      0xB0080000,  //  0071  RAISE	2	R0	R0
+      0x80000000,  //  0072  RET	0
     })
   )
 );
@@ -3518,20 +3475,19 @@ be_local_closure(class_Matter_Device__start_udp,   /* name */
     &be_class_Matter_Device, 
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(UDPServer),
-    /* K7   */  be_nested_str_weak(),
-    /* K8   */  be_nested_str_weak(start),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
+    /* K3   */  be_const_int(2),
+    /* K4   */  be_nested_str_weak(matter),
+    /* K5   */  be_nested_str_weak(UDPServer),
+    /* K6   */  be_nested_str_weak(),
+    /* K7   */  be_nested_str_weak(start),
     }),
     be_str_weak(_start_udp),
     &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
+    ( &(const binstruction[27]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x780A0000,  //  0001  JMPF	R2	#0003
       0x80000400,  //  0002  RET	0
@@ -3540,26 +3496,25 @@ be_local_closure(class_Matter_Device__start_udp,   /* name */
       0x780A0000,  //  0005  JMPF	R2	#0007
       0x540615A3,  //  0006  LDINT	R1	5540
       0xB80A0200,  //  0007  GETNGBL	R2	K1
-      0x8C080502,  //  0008  GETMET	R2	R2	K2
-      0x60100008,  //  0009  GETGBL	R4	G8
-      0x5C140200,  //  000A  MOVE	R5	R1
-      0x7C100200,  //  000B  CALL	R4	1
-      0x00120604,  //  000C  ADD	R4	K3	R4
-      0x58140004,  //  000D  LDCONST	R5	K4
-      0x7C080600,  //  000E  CALL	R2	3
-      0xB80A0A00,  //  000F  GETNGBL	R2	K5
-      0x8C080506,  //  0010  GETMET	R2	R2	K6
-      0x5C100000,  //  0011  MOVE	R4	R0
-      0x58140007,  //  0012  LDCONST	R5	K7
-      0x5C180200,  //  0013  MOVE	R6	R1
-      0x7C080800,  //  0014  CALL	R2	4
-      0x90020002,  //  0015  SETMBR	R0	K0	R2
-      0x88080100,  //  0016  GETMBR	R2	R0	K0
-      0x8C080508,  //  0017  GETMET	R2	R2	K8
-      0x84100000,  //  0018  CLOSURE	R4	P0
-      0x7C080400,  //  0019  CALL	R2	2
-      0xA0000000,  //  001A  CLOSE	R0
-      0x80000000,  //  001B  RET	0
+      0x600C0008,  //  0008  GETGBL	R3	G8
+      0x5C100200,  //  0009  MOVE	R4	R1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x000E0403,  //  000B  ADD	R3	K2	R3
+      0x58100003,  //  000C  LDCONST	R4	K3
+      0x7C080400,  //  000D  CALL	R2	2
+      0xB80A0800,  //  000E  GETNGBL	R2	K4
+      0x8C080505,  //  000F  GETMET	R2	R2	K5
+      0x5C100000,  //  0010  MOVE	R4	R0
+      0x58140006,  //  0011  LDCONST	R5	K6
+      0x5C180200,  //  0012  MOVE	R6	R1
+      0x7C080800,  //  0013  CALL	R2	4
+      0x90020002,  //  0014  SETMBR	R0	K0	R2
+      0x88080100,  //  0015  GETMBR	R2	R0	K0
+      0x8C080507,  //  0016  GETMET	R2	R2	K7
+      0x84100000,  //  0017  CLOSURE	R4	P0
+      0x7C080400,  //  0018  CALL	R2	2
+      0xA0000000,  //  0019  CLOSE	R0
+      0x80000000,  //  001A  RET	0
     })
   )
 );
@@ -3714,7 +3669,7 @@ be_local_closure(class_Matter_Device_get_active_endpoints,   /* name */
 extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_check_config_ep,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3722,26 +3677,25 @@ be_local_closure(class_Matter_Device_check_config_ep,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Device, 
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
+    ( &(const bvalue[14]) {     /* constants */
     /* K0   */  be_nested_str_weak(plugins_config),
     /* K1   */  be_nested_str_weak(keys),
     /* K2   */  be_nested_str_weak(push),
     /* K3   */  be_nested_str_weak(stop_iteration),
     /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20invalid_X20entry_X20with_X20ep_X20_X270_X27),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(remove),
-    /* K10  */  be_nested_str_weak(matter),
-    /* K11  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20endpoint_X20_X25s_X20collides_X20wit_X20aggregator_X2C_X20relocating_X20to_X20_X25s),
-    /* K13  */  be_nested_str_weak(next_ep),
-    /* K14  */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20invalid_X20entry_X20with_X20ep_X20_X270_X27),
+    /* K7   */  be_const_int(2),
+    /* K8   */  be_nested_str_weak(remove),
+    /* K9   */  be_nested_str_weak(matter),
+    /* K10  */  be_nested_str_weak(AGGREGATOR_ENDPOINT),
+    /* K11  */  be_nested_str_weak(MTR_X3A_X20endpoint_X20_X25s_X20collides_X20wit_X20aggregator_X2C_X20relocating_X20to_X20_X25s),
+    /* K12  */  be_nested_str_weak(next_ep),
+    /* K13  */  be_const_int(1),
     }),
     be_str_weak(check_config_ep),
     &be_const_str_solidified,
-    ( &(const binstruction[79]) {  /* code */
+    ( &(const binstruction[77]) {  /* code */
       0x50040000,  //  0000  LDBOOL	R1	0	0
       0x60080012,  //  0001  GETGBL	R2	G18
       0x7C080000,  //  0002  CALL	R2	0
@@ -3765,62 +3719,60 @@ be_local_closure(class_Matter_Device_check_config_ep,   /* name */
       0x600C0010,  //  0014  GETGBL	R3	G16
       0x5C100400,  //  0015  MOVE	R4	R2
       0x7C0C0200,  //  0016  CALL	R3	1
-      0xA8020032,  //  0017  EXBLK	0	#004B
+      0xA8020030,  //  0017  EXBLK	0	#0049
       0x5C100600,  //  0018  MOVE	R4	R3
       0x7C100000,  //  0019  CALL	R4	0
       0x1C140904,  //  001A  EQ	R5	R4	K4
-      0x7816000C,  //  001B  JMPF	R5	#0029
+      0x7816000B,  //  001B  JMPF	R5	#0028
       0xB8160A00,  //  001C  GETNGBL	R5	K5
-      0x8C140B06,  //  001D  GETMET	R5	R5	K6
+      0x58180006,  //  001D  LDCONST	R6	K6
       0x581C0007,  //  001E  LDCONST	R7	K7
-      0x58200008,  //  001F  LDCONST	R8	K8
-      0x7C140600,  //  0020  CALL	R5	3
-      0x88140100,  //  0021  GETMBR	R5	R0	K0
-      0x8C140B09,  //  0022  GETMET	R5	R5	K9
-      0x601C0008,  //  0023  GETGBL	R7	G8
-      0x5C200800,  //  0024  MOVE	R8	R4
-      0x7C1C0200,  //  0025  CALL	R7	1
-      0x7C140400,  //  0026  CALL	R5	2
-      0x50040200,  //  0027  LDBOOL	R1	1	0
-      0x70020020,  //  0028  JMP		#004A
-      0xB8161400,  //  0029  GETNGBL	R5	K10
-      0x88140B0B,  //  002A  GETMBR	R5	R5	K11
-      0x1C140805,  //  002B  EQ	R5	R4	R5
-      0x7816001C,  //  002C  JMPF	R5	#004A
-      0x50040200,  //  002D  LDBOOL	R1	1	0
-      0xB8160A00,  //  002E  GETNGBL	R5	K5
-      0x8C140B06,  //  002F  GETMET	R5	R5	K6
-      0x601C0018,  //  0030  GETGBL	R7	G24
-      0x5820000C,  //  0031  LDCONST	R8	K12
-      0x5C240800,  //  0032  MOVE	R9	R4
-      0x8828010D,  //  0033  GETMBR	R10	R0	K13
-      0x7C1C0600,  //  0034  CALL	R7	3
-      0x58200008,  //  0035  LDCONST	R8	K8
-      0x7C140600,  //  0036  CALL	R5	3
-      0x60140008,  //  0037  GETGBL	R5	G8
-      0x8818010D,  //  0038  GETMBR	R6	R0	K13
-      0x7C140200,  //  0039  CALL	R5	1
-      0x88180100,  //  003A  GETMBR	R6	R0	K0
-      0x601C0008,  //  003B  GETGBL	R7	G8
-      0x5C200800,  //  003C  MOVE	R8	R4
-      0x7C1C0200,  //  003D  CALL	R7	1
-      0x88200100,  //  003E  GETMBR	R8	R0	K0
-      0x941C1007,  //  003F  GETIDX	R7	R8	R7
-      0x98180A07,  //  0040  SETIDX	R6	R5	R7
-      0x88140100,  //  0041  GETMBR	R5	R0	K0
-      0x8C140B09,  //  0042  GETMET	R5	R5	K9
-      0x601C0008,  //  0043  GETGBL	R7	G8
-      0x5C200800,  //  0044  MOVE	R8	R4
-      0x7C1C0200,  //  0045  CALL	R7	1
-      0x7C140400,  //  0046  CALL	R5	2
-      0x8814010D,  //  0047  GETMBR	R5	R0	K13
-      0x00140B0E,  //  0048  ADD	R5	R5	K14
-      0x90021A05,  //  0049  SETMBR	R0	K13	R5
-      0x7001FFCC,  //  004A  JMP		#0018
-      0x580C0003,  //  004B  LDCONST	R3	K3
-      0xAC0C0200,  //  004C  CATCH	R3	1	0
-      0xB0080000,  //  004D  RAISE	2	R0	R0
-      0x80040200,  //  004E  RET	1	R1
+      0x7C140400,  //  001F  CALL	R5	2
+      0x88140100,  //  0020  GETMBR	R5	R0	K0
+      0x8C140B08,  //  0021  GETMET	R5	R5	K8
+      0x601C0008,  //  0022  GETGBL	R7	G8
+      0x5C200800,  //  0023  MOVE	R8	R4
+      0x7C1C0200,  //  0024  CALL	R7	1
+      0x7C140400,  //  0025  CALL	R5	2
+      0x50040200,  //  0026  LDBOOL	R1	1	0
+      0x7002001F,  //  0027  JMP		#0048
+      0xB8161200,  //  0028  GETNGBL	R5	K9
+      0x88140B0A,  //  0029  GETMBR	R5	R5	K10
+      0x1C140805,  //  002A  EQ	R5	R4	R5
+      0x7816001B,  //  002B  JMPF	R5	#0048
+      0x50040200,  //  002C  LDBOOL	R1	1	0
+      0xB8160A00,  //  002D  GETNGBL	R5	K5
+      0x60180018,  //  002E  GETGBL	R6	G24
+      0x581C000B,  //  002F  LDCONST	R7	K11
+      0x5C200800,  //  0030  MOVE	R8	R4
+      0x8824010C,  //  0031  GETMBR	R9	R0	K12
+      0x7C180600,  //  0032  CALL	R6	3
+      0x581C0007,  //  0033  LDCONST	R7	K7
+      0x7C140400,  //  0034  CALL	R5	2
+      0x60140008,  //  0035  GETGBL	R5	G8
+      0x8818010C,  //  0036  GETMBR	R6	R0	K12
+      0x7C140200,  //  0037  CALL	R5	1
+      0x88180100,  //  0038  GETMBR	R6	R0	K0
+      0x601C0008,  //  0039  GETGBL	R7	G8
+      0x5C200800,  //  003A  MOVE	R8	R4
+      0x7C1C0200,  //  003B  CALL	R7	1
+      0x88200100,  //  003C  GETMBR	R8	R0	K0
+      0x941C1007,  //  003D  GETIDX	R7	R8	R7
+      0x98180A07,  //  003E  SETIDX	R6	R5	R7
+      0x88140100,  //  003F  GETMBR	R5	R0	K0
+      0x8C140B08,  //  0040  GETMET	R5	R5	K8
+      0x601C0008,  //  0041  GETGBL	R7	G8
+      0x5C200800,  //  0042  MOVE	R8	R4
+      0x7C1C0200,  //  0043  CALL	R7	1
+      0x7C140400,  //  0044  CALL	R5	2
+      0x8814010C,  //  0045  GETMBR	R5	R0	K12
+      0x00140B0D,  //  0046  ADD	R5	R5	K13
+      0x90021805,  //  0047  SETMBR	R0	K12	R5
+      0x7001FFCE,  //  0048  JMP		#0018
+      0x580C0003,  //  0049  LDCONST	R3	K3
+      0xAC0C0200,  //  004A  CATCH	R3	1	0
+      0xB0080000,  //  004B  RAISE	2	R0	R0
+      0x80040200,  //  004C  RET	1	R1
     })
   )
 );
@@ -4084,11 +4036,11 @@ be_local_closure(class_Matter_Device_start_root_basic_commissioning,   /* name *
     ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(PASE_TIMEOUT),
     /* K1   */  be_nested_str_weak(compute_manual_pairing_code),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(log),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s),
-    /* K5   */  be_const_int(2),
-    /* K6   */  be_nested_str_weak(compute_qrcode_content),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_nested_str_weak(compute_qrcode_content),
+    /* K6   */  be_nested_str_weak(tasmota),
     /* K7   */  be_nested_str_weak(publish_result),
     /* K8   */  be_nested_str_weak(_X7B_X22Matter_X22_X3A_X7B_X22Commissioning_X22_X3A1_X2C_X22PairingCode_X22_X3A_X22_X25s_X22_X2C_X22QRCode_X22_X3A_X22_X25s_X22_X7D_X7D),
     /* K9   */  be_nested_str_weak(Matter),
@@ -4103,7 +4055,7 @@ be_local_closure(class_Matter_Device_start_root_basic_commissioning,   /* name *
     }),
     be_str_weak(start_root_basic_commissioning),
     &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
+    ( &(const binstruction[39]) {  /* code */
       0x4C080000,  //  0000  LDNIL	R2
       0x1C080202,  //  0001  EQ	R2	R1	R2
       0x780A0000,  //  0002  JMPF	R2	#0004
@@ -4111,39 +4063,38 @@ be_local_closure(class_Matter_Device_start_root_basic_commissioning,   /* name *
       0x8C080101,  //  0004  GETMET	R2	R0	K1
       0x7C080200,  //  0005  CALL	R2	1
       0xB80E0400,  //  0006  GETNGBL	R3	K2
-      0x8C0C0703,  //  0007  GETMET	R3	R3	K3
-      0x60140018,  //  0008  GETGBL	R5	G24
-      0x58180004,  //  0009  LDCONST	R6	K4
-      0x5C1C0400,  //  000A  MOVE	R7	R2
-      0x7C140400,  //  000B  CALL	R5	2
-      0x58180005,  //  000C  LDCONST	R6	K5
-      0x7C0C0600,  //  000D  CALL	R3	3
-      0x8C0C0106,  //  000E  GETMET	R3	R0	K6
-      0x7C0C0200,  //  000F  CALL	R3	1
-      0xB8120400,  //  0010  GETNGBL	R4	K2
-      0x8C100907,  //  0011  GETMET	R4	R4	K7
-      0x60180018,  //  0012  GETGBL	R6	G24
-      0x581C0008,  //  0013  LDCONST	R7	K8
-      0x5C200400,  //  0014  MOVE	R8	R2
-      0x5C240600,  //  0015  MOVE	R9	R3
-      0x7C180600,  //  0016  CALL	R6	3
-      0x581C0009,  //  0017  LDCONST	R7	K9
-      0x7C100600,  //  0018  CALL	R4	3
-      0x8C10010A,  //  0019  GETMET	R4	R0	K10
-      0x8818010B,  //  001A  GETMBR	R6	R0	K11
-      0x881C010C,  //  001B  GETMBR	R7	R0	K12
-      0x8820010D,  //  001C  GETMBR	R8	R0	K13
-      0x7C100800,  //  001D  CALL	R4	4
-      0x8C10010E,  //  001E  GETMET	R4	R0	K14
-      0x5C180200,  //  001F  MOVE	R6	R1
-      0x881C010C,  //  0020  GETMBR	R7	R0	K12
-      0x8820010F,  //  0021  GETMBR	R8	R0	K15
-      0x8824010D,  //  0022  GETMBR	R9	R0	K13
-      0x88280110,  //  0023  GETMBR	R10	R0	K16
-      0x882C0111,  //  0024  GETMBR	R11	R0	K17
-      0x4C300000,  //  0025  LDNIL	R12
-      0x7C101000,  //  0026  CALL	R4	8
-      0x80000000,  //  0027  RET	0
+      0x60100018,  //  0007  GETGBL	R4	G24
+      0x58140003,  //  0008  LDCONST	R5	K3
+      0x5C180400,  //  0009  MOVE	R6	R2
+      0x7C100400,  //  000A  CALL	R4	2
+      0x58140004,  //  000B  LDCONST	R5	K4
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x8C0C0105,  //  000D  GETMET	R3	R0	K5
+      0x7C0C0200,  //  000E  CALL	R3	1
+      0xB8120C00,  //  000F  GETNGBL	R4	K6
+      0x8C100907,  //  0010  GETMET	R4	R4	K7
+      0x60180018,  //  0011  GETGBL	R6	G24
+      0x581C0008,  //  0012  LDCONST	R7	K8
+      0x5C200400,  //  0013  MOVE	R8	R2
+      0x5C240600,  //  0014  MOVE	R9	R3
+      0x7C180600,  //  0015  CALL	R6	3
+      0x581C0009,  //  0016  LDCONST	R7	K9
+      0x7C100600,  //  0017  CALL	R4	3
+      0x8C10010A,  //  0018  GETMET	R4	R0	K10
+      0x8818010B,  //  0019  GETMBR	R6	R0	K11
+      0x881C010C,  //  001A  GETMBR	R7	R0	K12
+      0x8820010D,  //  001B  GETMBR	R8	R0	K13
+      0x7C100800,  //  001C  CALL	R4	4
+      0x8C10010E,  //  001D  GETMET	R4	R0	K14
+      0x5C180200,  //  001E  MOVE	R6	R1
+      0x881C010C,  //  001F  GETMBR	R7	R0	K12
+      0x8820010F,  //  0020  GETMBR	R8	R0	K15
+      0x8824010D,  //  0021  GETMBR	R9	R0	K13
+      0x88280110,  //  0022  GETMBR	R10	R0	K16
+      0x882C0111,  //  0023  GETMBR	R11	R0	K17
+      0x4C300000,  //  0024  LDNIL	R12
+      0x7C101000,  //  0025  CALL	R4	8
+      0x80000000,  //  0026  RET	0
     })
   )
 );
@@ -4288,7 +4239,7 @@ be_local_closure(class_Matter_Device_load_param,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Device, 
     1,                          /* has constants */
-    ( &(const bvalue[36]) {     /* constants */
+    ( &(const bvalue[35]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(FILENAME),
     /* K2   */  be_nested_str_weak(read),
@@ -4306,32 +4257,31 @@ be_local_closure(class_Matter_Device_load_param,   /* name */
     /* K14  */  be_nested_str_weak(nextep),
     /* K15  */  be_nested_str_weak(plugins_config),
     /* K16  */  be_nested_str_weak(config),
-    /* K17  */  be_nested_str_weak(tasmota),
-    /* K18  */  be_nested_str_weak(log),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20Load_config_X20_X3D_X20_X25s),
-    /* K20  */  be_const_int(3),
-    /* K21  */  be_nested_str_weak(adjust_next_ep),
-    /* K22  */  be_nested_str_weak(check_config_ep),
-    /* K23  */  be_nested_str_weak(plugins_persist),
-    /* K24  */  be_nested_str_weak(plugins_config_remotes),
-    /* K25  */  be_nested_str_weak(remotes),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
-    /* K27  */  be_nested_str_weak(io_error),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20load_param_X20Exception_X3A),
-    /* K29  */  be_nested_str_weak(_X7C),
-    /* K30  */  be_const_int(2),
-    /* K31  */  be_nested_str_weak(random),
-    /* K32  */  be_nested_str_weak(get),
-    /* K33  */  be_const_int(0),
-    /* K34  */  be_nested_str_weak(generate_random_passcode),
-    /* K35  */  be_nested_str_weak(save_param),
+    /* K17  */  be_nested_str_weak(log),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20Load_config_X20_X3D_X20_X25s),
+    /* K19  */  be_const_int(3),
+    /* K20  */  be_nested_str_weak(adjust_next_ep),
+    /* K21  */  be_nested_str_weak(check_config_ep),
+    /* K22  */  be_nested_str_weak(plugins_persist),
+    /* K23  */  be_nested_str_weak(plugins_config_remotes),
+    /* K24  */  be_nested_str_weak(remotes),
+    /* K25  */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
+    /* K26  */  be_nested_str_weak(io_error),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20load_param_X20Exception_X3A),
+    /* K28  */  be_nested_str_weak(_X7C),
+    /* K29  */  be_const_int(2),
+    /* K30  */  be_nested_str_weak(random),
+    /* K31  */  be_nested_str_weak(get),
+    /* K32  */  be_const_int(0),
+    /* K33  */  be_nested_str_weak(generate_random_passcode),
+    /* K34  */  be_nested_str_weak(save_param),
     }),
     be_str_weak(load_param),
     &be_const_str_solidified,
-    ( &(const binstruction[130]) {  /* code */
+    ( &(const binstruction[127]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x50080000,  //  0001  LDBOOL	R2	0	0
-      0xA8020050,  //  0002  EXBLK	0	#0054
+      0xA802004E,  //  0002  EXBLK	0	#0052
       0x600C0011,  //  0003  GETGBL	R3	G17
       0x88100101,  //  0004  GETMBR	R4	R0	K1
       0x7C0C0200,  //  0005  CALL	R3	1
@@ -4379,86 +4329,83 @@ be_local_closure(class_Matter_Device_load_param,   /* name */
       0x881C010F,  //  002F  GETMBR	R7	R0	K15
       0x4C200000,  //  0030  LDNIL	R8
       0x201C0E08,  //  0031  NE	R7	R7	R8
-      0x781E000E,  //  0032  JMPF	R7	#0042
+      0x781E000D,  //  0032  JMPF	R7	#0041
       0xB81E2200,  //  0033  GETNGBL	R7	K17
-      0x8C1C0F12,  //  0034  GETMET	R7	R7	K18
-      0x60240018,  //  0035  GETGBL	R9	G24
-      0x58280013,  //  0036  LDCONST	R10	K19
-      0x882C010F,  //  0037  GETMBR	R11	R0	K15
-      0x7C240400,  //  0038  CALL	R9	2
-      0x58280014,  //  0039  LDCONST	R10	K20
-      0x7C1C0600,  //  003A  CALL	R7	3
-      0x8C1C0115,  //  003B  GETMET	R7	R0	K21
-      0x7C1C0200,  //  003C  CALL	R7	1
-      0x8C1C0116,  //  003D  GETMET	R7	R0	K22
-      0x7C1C0200,  //  003E  CALL	R7	1
-      0x5C080E00,  //  003F  MOVE	R2	R7
-      0x501C0200,  //  0040  LDBOOL	R7	1	0
-      0x90022E07,  //  0041  SETMBR	R0	K23	R7
-      0x8C1C0D07,  //  0042  GETMET	R7	R6	K7
-      0x58240019,  //  0043  LDCONST	R9	K25
-      0x60280013,  //  0044  GETGBL	R10	G19
-      0x7C280000,  //  0045  CALL	R10	0
-      0x7C1C0600,  //  0046  CALL	R7	3
-      0x90023007,  //  0047  SETMBR	R0	K24	R7
-      0x881C0118,  //  0048  GETMBR	R7	R0	K24
-      0x781E0007,  //  0049  JMPF	R7	#0052
-      0xB81E2200,  //  004A  GETNGBL	R7	K17
-      0x8C1C0F12,  //  004B  GETMET	R7	R7	K18
-      0x60240008,  //  004C  GETGBL	R9	G8
-      0x88280118,  //  004D  GETMBR	R10	R0	K24
-      0x7C240200,  //  004E  CALL	R9	1
-      0x00263409,  //  004F  ADD	R9	K26	R9
-      0x58280014,  //  0050  LDCONST	R10	K20
-      0x7C1C0600,  //  0051  CALL	R7	3
-      0xA8040001,  //  0052  EXBLK	1	1
-      0x70020012,  //  0053  JMP		#0067
-      0xAC0C0002,  //  0054  CATCH	R3	0	2
-      0x7002000F,  //  0055  JMP		#0066
-      0x2014071B,  //  0056  NE	R5	R3	K27
-      0x7816000C,  //  0057  JMPF	R5	#0065
-      0xB8162200,  //  0058  GETNGBL	R5	K17
-      0x8C140B12,  //  0059  GETMET	R5	R5	K18
-      0x601C0008,  //  005A  GETGBL	R7	G8
-      0x5C200600,  //  005B  MOVE	R8	R3
-      0x7C1C0200,  //  005C  CALL	R7	1
-      0x001E3807,  //  005D  ADD	R7	K28	R7
-      0x001C0F1D,  //  005E  ADD	R7	R7	K29
-      0x60200008,  //  005F  GETGBL	R8	G8
-      0x5C240800,  //  0060  MOVE	R9	R4
-      0x7C200200,  //  0061  CALL	R8	1
-      0x001C0E08,  //  0062  ADD	R7	R7	R8
-      0x5820001E,  //  0063  LDCONST	R8	K30
-      0x7C140600,  //  0064  CALL	R5	3
-      0x70020000,  //  0065  JMP		#0067
-      0xB0080000,  //  0066  RAISE	2	R0	R0
-      0x880C0106,  //  0067  GETMBR	R3	R0	K6
-      0x4C100000,  //  0068  LDNIL	R4
-      0x1C0C0604,  //  0069  EQ	R3	R3	R4
-      0x780E000A,  //  006A  JMPF	R3	#0076
-      0x8C0C031F,  //  006B  GETMET	R3	R1	K31
-      0x5814001E,  //  006C  LDCONST	R5	K30
-      0x7C0C0400,  //  006D  CALL	R3	2
-      0x8C0C0720,  //  006E  GETMET	R3	R3	K32
-      0x58140021,  //  006F  LDCONST	R5	K33
-      0x5818001E,  //  0070  LDCONST	R6	K30
-      0x7C0C0600,  //  0071  CALL	R3	3
-      0x54120FFE,  //  0072  LDINT	R4	4095
-      0x2C0C0604,  //  0073  AND	R3	R3	R4
-      0x90020C03,  //  0074  SETMBR	R0	K6	R3
-      0x50080200,  //  0075  LDBOOL	R2	1	0
-      0x880C0109,  //  0076  GETMBR	R3	R0	K9
-      0x4C100000,  //  0077  LDNIL	R4
-      0x1C0C0604,  //  0078  EQ	R3	R3	R4
-      0x780E0003,  //  0079  JMPF	R3	#007E
-      0x8C0C0122,  //  007A  GETMET	R3	R0	K34
-      0x7C0C0200,  //  007B  CALL	R3	1
-      0x90021203,  //  007C  SETMBR	R0	K9	R3
-      0x50080200,  //  007D  LDBOOL	R2	1	0
-      0x780A0001,  //  007E  JMPF	R2	#0081
-      0x8C0C0123,  //  007F  GETMET	R3	R0	K35
-      0x7C0C0200,  //  0080  CALL	R3	1
-      0x80000000,  //  0081  RET	0
+      0x60200018,  //  0034  GETGBL	R8	G24
+      0x58240012,  //  0035  LDCONST	R9	K18
+      0x8828010F,  //  0036  GETMBR	R10	R0	K15
+      0x7C200400,  //  0037  CALL	R8	2
+      0x58240013,  //  0038  LDCONST	R9	K19
+      0x7C1C0400,  //  0039  CALL	R7	2
+      0x8C1C0114,  //  003A  GETMET	R7	R0	K20
+      0x7C1C0200,  //  003B  CALL	R7	1
+      0x8C1C0115,  //  003C  GETMET	R7	R0	K21
+      0x7C1C0200,  //  003D  CALL	R7	1
+      0x5C080E00,  //  003E  MOVE	R2	R7
+      0x501C0200,  //  003F  LDBOOL	R7	1	0
+      0x90022C07,  //  0040  SETMBR	R0	K22	R7
+      0x8C1C0D07,  //  0041  GETMET	R7	R6	K7
+      0x58240018,  //  0042  LDCONST	R9	K24
+      0x60280013,  //  0043  GETGBL	R10	G19
+      0x7C280000,  //  0044  CALL	R10	0
+      0x7C1C0600,  //  0045  CALL	R7	3
+      0x90022E07,  //  0046  SETMBR	R0	K23	R7
+      0x881C0117,  //  0047  GETMBR	R7	R0	K23
+      0x781E0006,  //  0048  JMPF	R7	#0050
+      0xB81E2200,  //  0049  GETNGBL	R7	K17
+      0x60200008,  //  004A  GETGBL	R8	G8
+      0x88240117,  //  004B  GETMBR	R9	R0	K23
+      0x7C200200,  //  004C  CALL	R8	1
+      0x00223208,  //  004D  ADD	R8	K25	R8
+      0x58240013,  //  004E  LDCONST	R9	K19
+      0x7C1C0400,  //  004F  CALL	R7	2
+      0xA8040001,  //  0050  EXBLK	1	1
+      0x70020011,  //  0051  JMP		#0064
+      0xAC0C0002,  //  0052  CATCH	R3	0	2
+      0x7002000E,  //  0053  JMP		#0063
+      0x2014071A,  //  0054  NE	R5	R3	K26
+      0x7816000B,  //  0055  JMPF	R5	#0062
+      0xB8162200,  //  0056  GETNGBL	R5	K17
+      0x60180008,  //  0057  GETGBL	R6	G8
+      0x5C1C0600,  //  0058  MOVE	R7	R3
+      0x7C180200,  //  0059  CALL	R6	1
+      0x001A3606,  //  005A  ADD	R6	K27	R6
+      0x00180D1C,  //  005B  ADD	R6	R6	K28
+      0x601C0008,  //  005C  GETGBL	R7	G8
+      0x5C200800,  //  005D  MOVE	R8	R4
+      0x7C1C0200,  //  005E  CALL	R7	1
+      0x00180C07,  //  005F  ADD	R6	R6	R7
+      0x581C001D,  //  0060  LDCONST	R7	K29
+      0x7C140400,  //  0061  CALL	R5	2
+      0x70020000,  //  0062  JMP		#0064
+      0xB0080000,  //  0063  RAISE	2	R0	R0
+      0x880C0106,  //  0064  GETMBR	R3	R0	K6
+      0x4C100000,  //  0065  LDNIL	R4
+      0x1C0C0604,  //  0066  EQ	R3	R3	R4
+      0x780E000A,  //  0067  JMPF	R3	#0073
+      0x8C0C031E,  //  0068  GETMET	R3	R1	K30
+      0x5814001D,  //  0069  LDCONST	R5	K29
+      0x7C0C0400,  //  006A  CALL	R3	2
+      0x8C0C071F,  //  006B  GETMET	R3	R3	K31
+      0x58140020,  //  006C  LDCONST	R5	K32
+      0x5818001D,  //  006D  LDCONST	R6	K29
+      0x7C0C0600,  //  006E  CALL	R3	3
+      0x54120FFE,  //  006F  LDINT	R4	4095
+      0x2C0C0604,  //  0070  AND	R3	R3	R4
+      0x90020C03,  //  0071  SETMBR	R0	K6	R3
+      0x50080200,  //  0072  LDBOOL	R2	1	0
+      0x880C0109,  //  0073  GETMBR	R3	R0	K9
+      0x4C100000,  //  0074  LDNIL	R4
+      0x1C0C0604,  //  0075  EQ	R3	R3	R4
+      0x780E0003,  //  0076  JMPF	R3	#007B
+      0x8C0C0121,  //  0077  GETMET	R3	R0	K33
+      0x7C0C0200,  //  0078  CALL	R3	1
+      0x90021203,  //  0079  SETMBR	R0	K9	R3
+      0x50080200,  //  007A  LDBOOL	R2	1	0
+      0x780A0001,  //  007B  JMPF	R2	#007E
+      0x8C0C0122,  //  007C  GETMET	R3	R0	K34
+      0x7C0C0200,  //  007D  CALL	R3	1
+      0x80000000,  //  007E  RET	0
     })
   )
 );
@@ -4859,9 +4806,9 @@ be_local_closure(class_Matter_Device_mdns_remove_op_discovery,   /* name */
     }),
     be_str_weak(mdns_remove_op_discovery),
     &be_const_str_solidified,
-    ( &(const binstruction[80]) {  /* code */
+    ( &(const binstruction[77]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA802003B,  //  0001  EXBLK	0	#003E
+      0xA8020039,  //  0001  EXBLK	0	#003C
       0x8C0C0301,  //  0002  GETMET	R3	R1	K1
       0x7C0C0200,  //  0003  CALL	R3	1
       0x8C0C0702,  //  0004  GETMET	R3	R3	K2
@@ -4882,64 +4829,61 @@ be_local_closure(class_Matter_Device_mdns_remove_op_discovery,   /* name */
       0x8C180D09,  //  0013  GETMET	R6	R6	K9
       0x5820000A,  //  0014  LDCONST	R8	K10
       0x7C180400,  //  0015  CALL	R6	2
-      0x781A000E,  //  0016  JMPF	R6	#0026
-      0xB81A0E00,  //  0017  GETNGBL	R6	K7
-      0x8C180D0B,  //  0018  GETMET	R6	R6	K11
-      0x60200018,  //  0019  GETGBL	R8	G24
-      0x5824000C,  //  001A  LDCONST	R9	K12
-      0x58280008,  //  001B  LDCONST	R10	K8
-      0x5C2C0A00,  //  001C  MOVE	R11	R5
-      0x7C200600,  //  001D  CALL	R8	3
-      0x5824000D,  //  001E  LDCONST	R9	K13
-      0x7C180600,  //  001F  CALL	R6	3
-      0x8C18050E,  //  0020  GETMET	R6	R2	K14
-      0x5820000F,  //  0021  LDCONST	R8	K15
-      0x58240010,  //  0022  LDCONST	R9	K16
-      0x5C280A00,  //  0023  MOVE	R10	R5
-      0x882C0111,  //  0024  GETMBR	R11	R0	K17
-      0x7C180A00,  //  0025  CALL	R6	5
-      0xB81A0E00,  //  0026  GETNGBL	R6	K7
-      0x8C180D12,  //  0027  GETMET	R6	R6	K18
-      0x7C180200,  //  0028  CALL	R6	1
-      0x8C180D09,  //  0029  GETMET	R6	R6	K9
-      0x5820000A,  //  002A  LDCONST	R8	K10
-      0x7C180400,  //  002B  CALL	R6	2
-      0x781A000E,  //  002C  JMPF	R6	#003C
-      0xB81A0E00,  //  002D  GETNGBL	R6	K7
-      0x8C180D0B,  //  002E  GETMET	R6	R6	K11
-      0x60200018,  //  002F  GETGBL	R8	G24
-      0x5824000C,  //  0030  LDCONST	R9	K12
-      0x58280012,  //  0031  LDCONST	R10	K18
-      0x5C2C0A00,  //  0032  MOVE	R11	R5
-      0x7C200600,  //  0033  CALL	R8	3
-      0x5824000D,  //  0034  LDCONST	R9	K13
-      0x7C180600,  //  0035  CALL	R6	3
-      0x8C18050E,  //  0036  GETMET	R6	R2	K14
-      0x5820000F,  //  0037  LDCONST	R8	K15
-      0x58240010,  //  0038  LDCONST	R9	K16
-      0x5C280A00,  //  0039  MOVE	R10	R5
-      0x882C0113,  //  003A  GETMBR	R11	R0	K19
-      0x7C180A00,  //  003B  CALL	R6	5
-      0xA8040001,  //  003C  EXBLK	1	1
-      0x70020010,  //  003D  JMP		#004F
-      0xAC0C0002,  //  003E  CATCH	R3	0	2
-      0x7002000D,  //  003F  JMP		#004E
-      0xB8160E00,  //  0040  GETNGBL	R5	K7
-      0x8C140B0B,  //  0041  GETMET	R5	R5	K11
-      0x601C0008,  //  0042  GETGBL	R7	G8
-      0x5C200600,  //  0043  MOVE	R8	R3
-      0x7C1C0200,  //  0044  CALL	R7	1
-      0x001E2807,  //  0045  ADD	R7	K20	R7
-      0x001C0F15,  //  0046  ADD	R7	R7	K21
-      0x60200008,  //  0047  GETGBL	R8	G8
-      0x5C240800,  //  0048  MOVE	R9	R4
-      0x7C200200,  //  0049  CALL	R8	1
-      0x001C0E08,  //  004A  ADD	R7	R7	R8
-      0x58200016,  //  004B  LDCONST	R8	K22
-      0x7C140600,  //  004C  CALL	R5	3
-      0x70020000,  //  004D  JMP		#004F
-      0xB0080000,  //  004E  RAISE	2	R0	R0
-      0x80000000,  //  004F  RET	0
+      0x781A000D,  //  0016  JMPF	R6	#0025
+      0xB81A1600,  //  0017  GETNGBL	R6	K11
+      0x601C0018,  //  0018  GETGBL	R7	G24
+      0x5820000C,  //  0019  LDCONST	R8	K12
+      0x58240008,  //  001A  LDCONST	R9	K8
+      0x5C280A00,  //  001B  MOVE	R10	R5
+      0x7C1C0600,  //  001C  CALL	R7	3
+      0x5820000D,  //  001D  LDCONST	R8	K13
+      0x7C180400,  //  001E  CALL	R6	2
+      0x8C18050E,  //  001F  GETMET	R6	R2	K14
+      0x5820000F,  //  0020  LDCONST	R8	K15
+      0x58240010,  //  0021  LDCONST	R9	K16
+      0x5C280A00,  //  0022  MOVE	R10	R5
+      0x882C0111,  //  0023  GETMBR	R11	R0	K17
+      0x7C180A00,  //  0024  CALL	R6	5
+      0xB81A0E00,  //  0025  GETNGBL	R6	K7
+      0x8C180D12,  //  0026  GETMET	R6	R6	K18
+      0x7C180200,  //  0027  CALL	R6	1
+      0x8C180D09,  //  0028  GETMET	R6	R6	K9
+      0x5820000A,  //  0029  LDCONST	R8	K10
+      0x7C180400,  //  002A  CALL	R6	2
+      0x781A000D,  //  002B  JMPF	R6	#003A
+      0xB81A1600,  //  002C  GETNGBL	R6	K11
+      0x601C0018,  //  002D  GETGBL	R7	G24
+      0x5820000C,  //  002E  LDCONST	R8	K12
+      0x58240012,  //  002F  LDCONST	R9	K18
+      0x5C280A00,  //  0030  MOVE	R10	R5
+      0x7C1C0600,  //  0031  CALL	R7	3
+      0x5820000D,  //  0032  LDCONST	R8	K13
+      0x7C180400,  //  0033  CALL	R6	2
+      0x8C18050E,  //  0034  GETMET	R6	R2	K14
+      0x5820000F,  //  0035  LDCONST	R8	K15
+      0x58240010,  //  0036  LDCONST	R9	K16
+      0x5C280A00,  //  0037  MOVE	R10	R5
+      0x882C0113,  //  0038  GETMBR	R11	R0	K19
+      0x7C180A00,  //  0039  CALL	R6	5
+      0xA8040001,  //  003A  EXBLK	1	1
+      0x7002000F,  //  003B  JMP		#004C
+      0xAC0C0002,  //  003C  CATCH	R3	0	2
+      0x7002000C,  //  003D  JMP		#004B
+      0xB8161600,  //  003E  GETNGBL	R5	K11
+      0x60180008,  //  003F  GETGBL	R6	G8
+      0x5C1C0600,  //  0040  MOVE	R7	R3
+      0x7C180200,  //  0041  CALL	R6	1
+      0x001A2806,  //  0042  ADD	R6	K20	R6
+      0x00180D15,  //  0043  ADD	R6	R6	K21
+      0x601C0008,  //  0044  GETGBL	R7	G8
+      0x5C200800,  //  0045  MOVE	R8	R4
+      0x7C1C0200,  //  0046  CALL	R7	1
+      0x00180C07,  //  0047  ADD	R6	R6	R7
+      0x581C0016,  //  0048  LDCONST	R7	K22
+      0x7C140400,  //  0049  CALL	R5	2
+      0x70020000,  //  004A  JMP		#004C
+      0xB0080000,  //  004B  RAISE	2	R0	R0
+      0x80000000,  //  004C  RET	0
     })
   )
 );
@@ -5177,7 +5121,7 @@ be_local_closure(class_Matter_Device_MtrJoin,   /* name */
 extern const bclass be_class_Matter_Device;
 be_local_closure(class_Matter_Device_save_param,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -5185,7 +5129,7 @@ be_local_closure(class_Matter_Device_save_param,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Device, 
     1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
+    ( &(const bvalue[29]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
     /* K1   */  be_nested_str_weak(update_remotes_info),
     /* K2   */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22disable_bridge_mode_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
@@ -5208,18 +5152,17 @@ be_local_closure(class_Matter_Device_save_param,   /* name */
     /* K19  */  be_nested_str_weak(w),
     /* K20  */  be_nested_str_weak(write),
     /* K21  */  be_nested_str_weak(close),
-    /* K22  */  be_nested_str_weak(tasmota),
-    /* K23  */  be_nested_str_weak(log),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
-    /* K25  */  be_nested_str_weak(_X20and_X20configuration),
-    /* K26  */  be_nested_str_weak(),
-    /* K27  */  be_const_int(2),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K29  */  be_nested_str_weak(_X7C),
+    /* K22  */  be_nested_str_weak(log),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
+    /* K24  */  be_nested_str_weak(_X20and_X20configuration),
+    /* K25  */  be_nested_str_weak(),
+    /* K26  */  be_const_int(2),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+    /* K28  */  be_nested_str_weak(_X7C),
     }),
     be_str_weak(save_param),
     &be_const_str_solidified,
-    ( &(const binstruction[82]) {  /* code */
+    ( &(const binstruction[80]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x8C080101,  //  0001  GETMET	R2	R0	K1
       0x7C080200,  //  0002  CALL	R2	1
@@ -5257,7 +5200,7 @@ be_local_closure(class_Matter_Device_save_param,   /* name */
       0x7C0C0400,  //  0022  CALL	R3	2
       0x00080403,  //  0023  ADD	R2	R2	R3
       0x00080511,  //  0024  ADD	R2	R2	K17
-      0xA8020018,  //  0025  EXBLK	0	#003F
+      0xA8020017,  //  0025  EXBLK	0	#003E
       0x600C0011,  //  0026  GETGBL	R3	G17
       0x88100112,  //  0027  GETMBR	R4	R0	K18
       0x58140013,  //  0028  LDCONST	R5	K19
@@ -5268,40 +5211,38 @@ be_local_closure(class_Matter_Device_save_param,   /* name */
       0x8C100715,  //  002D  GETMET	R4	R3	K21
       0x7C100200,  //  002E  CALL	R4	1
       0xB8122C00,  //  002F  GETNGBL	R4	K22
-      0x8C100917,  //  0030  GETMET	R4	R4	K23
-      0x60180018,  //  0031  GETGBL	R6	G24
-      0x581C0018,  //  0032  LDCONST	R7	K24
-      0x8820010A,  //  0033  GETMBR	R8	R0	K10
-      0x78220001,  //  0034  JMPF	R8	#0037
-      0x58200019,  //  0035  LDCONST	R8	K25
-      0x70020000,  //  0036  JMP		#0038
-      0x5820001A,  //  0037  LDCONST	R8	K26
-      0x7C180400,  //  0038  CALL	R6	2
-      0x581C001B,  //  0039  LDCONST	R7	K27
-      0x7C100600,  //  003A  CALL	R4	3
-      0xA8040001,  //  003B  EXBLK	1	1
-      0x80040400,  //  003C  RET	1	R2
-      0xA8040001,  //  003D  EXBLK	1	1
-      0x70020011,  //  003E  JMP		#0051
-      0xAC0C0002,  //  003F  CATCH	R3	0	2
-      0x7002000E,  //  0040  JMP		#0050
-      0xB8162C00,  //  0041  GETNGBL	R5	K22
-      0x8C140B17,  //  0042  GETMET	R5	R5	K23
-      0x601C0008,  //  0043  GETGBL	R7	G8
-      0x5C200600,  //  0044  MOVE	R8	R3
-      0x7C1C0200,  //  0045  CALL	R7	1
-      0x001E3807,  //  0046  ADD	R7	K28	R7
-      0x001C0F1D,  //  0047  ADD	R7	R7	K29
-      0x60200008,  //  0048  GETGBL	R8	G8
-      0x5C240800,  //  0049  MOVE	R9	R4
-      0x7C200200,  //  004A  CALL	R8	1
-      0x001C0E08,  //  004B  ADD	R7	R7	R8
-      0x5820001B,  //  004C  LDCONST	R8	K27
-      0x7C140600,  //  004D  CALL	R5	3
-      0x80040400,  //  004E  RET	1	R2
-      0x70020000,  //  004F  JMP		#0051
-      0xB0080000,  //  0050  RAISE	2	R0	R0
-      0x80000000,  //  0051  RET	0
+      0x60140018,  //  0030  GETGBL	R5	G24
+      0x58180017,  //  0031  LDCONST	R6	K23
+      0x881C010A,  //  0032  GETMBR	R7	R0	K10
+      0x781E0001,  //  0033  JMPF	R7	#0036
+      0x581C0018,  //  0034  LDCONST	R7	K24
+      0x70020000,  //  0035  JMP		#0037
+      0x581C0019,  //  0036  LDCONST	R7	K25
+      0x7C140400,  //  0037  CALL	R5	2
+      0x5818001A,  //  0038  LDCONST	R6	K26
+      0x7C100400,  //  0039  CALL	R4	2
+      0xA8040001,  //  003A  EXBLK	1	1
+      0x80040400,  //  003B  RET	1	R2
+      0xA8040001,  //  003C  EXBLK	1	1
+      0x70020010,  //  003D  JMP		#004F
+      0xAC0C0002,  //  003E  CATCH	R3	0	2
+      0x7002000D,  //  003F  JMP		#004E
+      0xB8162C00,  //  0040  GETNGBL	R5	K22
+      0x60180008,  //  0041  GETGBL	R6	G8
+      0x5C1C0600,  //  0042  MOVE	R7	R3
+      0x7C180200,  //  0043  CALL	R6	1
+      0x001A3606,  //  0044  ADD	R6	K27	R6
+      0x00180D1C,  //  0045  ADD	R6	R6	K28
+      0x601C0008,  //  0046  GETGBL	R7	G8
+      0x5C200800,  //  0047  MOVE	R8	R4
+      0x7C1C0200,  //  0048  CALL	R7	1
+      0x00180C07,  //  0049  ADD	R6	R6	R7
+      0x581C001A,  //  004A  LDCONST	R7	K26
+      0x7C140400,  //  004B  CALL	R5	2
+      0x80040400,  //  004C  RET	1	R2
+      0x70020000,  //  004D  JMP		#004F
+      0xB0080000,  //  004E  RAISE	2	R0	R0
+      0x80000000,  //  004F  RET	0
     })
   )
 );
@@ -5795,7 +5736,7 @@ be_local_closure(class_Matter_Device_mdns_announce_PASE,   /* name */
     0,                          /* has sup protos */
     &be_class_Matter_Device, 
     1,                          /* has constants */
-    ( &(const bvalue[41]) {     /* constants */
+    ( &(const bvalue[40]) {     /* constants */
     /* K0   */  be_nested_str_weak(mdns),
     /* K1   */  be_nested_str_weak(crypto),
     /* K2   */  be_nested_str_weak(VP),
@@ -5819,28 +5760,27 @@ be_local_closure(class_Matter_Device_mdns_announce_PASE,   /* name */
     /* K20  */  be_nested_str_weak(_matterc),
     /* K21  */  be_nested_str_weak(_udp),
     /* K22  */  be_nested_str_weak(mdns_pase_eth),
-    /* K23  */  be_nested_str_weak(tasmota),
-    /* K24  */  be_nested_str_weak(log),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20announce_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K26  */  be_nested_str_weak(eth),
-    /* K27  */  be_const_int(2),
-    /* K28  */  be_nested_str_weak(_L),
-    /* K29  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
-    /* K30  */  be_const_int(3),
-    /* K31  */  be_nested_str_weak(add_subtype),
-    /* K32  */  be_nested_str_weak(_S),
-    /* K33  */  be_nested_str_weak(_V),
-    /* K34  */  be_nested_str_weak(_CM1),
-    /* K35  */  be_nested_str_weak(hostname_wifi),
-    /* K36  */  be_nested_str_weak(mdns_pase_wifi),
-    /* K37  */  be_nested_str_weak(MTR_X3A_X20starting_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K38  */  be_nested_str_weak(wifi),
-    /* K39  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K40  */  be_nested_str_weak(_X7C),
+    /* K23  */  be_nested_str_weak(log),
+    /* K24  */  be_nested_str_weak(MTR_X3A_X20announce_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K25  */  be_nested_str_weak(eth),
+    /* K26  */  be_const_int(2),
+    /* K27  */  be_nested_str_weak(_L),
+    /* K28  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
+    /* K29  */  be_const_int(3),
+    /* K30  */  be_nested_str_weak(add_subtype),
+    /* K31  */  be_nested_str_weak(_S),
+    /* K32  */  be_nested_str_weak(_V),
+    /* K33  */  be_nested_str_weak(_CM1),
+    /* K34  */  be_nested_str_weak(hostname_wifi),
+    /* K35  */  be_nested_str_weak(mdns_pase_wifi),
+    /* K36  */  be_nested_str_weak(MTR_X3A_X20starting_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K37  */  be_nested_str_weak(wifi),
+    /* K38  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K39  */  be_nested_str_weak(_X7C),
     }),
     be_str_weak(mdns_announce_PASE),
     &be_const_str_solidified,
-    ( &(const binstruction[236]) {  /* code */
+    ( &(const binstruction[225]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xA40A0200,  //  0001  IMPORT	R2	K1
       0x600C0013,  //  0002  GETGBL	R3	G19
@@ -5874,9 +5814,9 @@ be_local_closure(class_Matter_Device_mdns_announce_PASE,   /* name */
       0x8C100910,  //  001E  GETMET	R4	R4	K16
       0x7C100200,  //  001F  CALL	R4	1
       0x90022204,  //  0020  SETMBR	R0	K17	R4
-      0xA80200B7,  //  0021  EXBLK	0	#00DA
+      0xA80200AD,  //  0021  EXBLK	0	#00D0
       0x88100112,  //  0022  GETMBR	R4	R0	K18
-      0x78120058,  //  0023  JMPF	R4	#007D
+      0x78120053,  //  0023  JMPF	R4	#0078
       0x8C100313,  //  0024  GETMET	R4	R1	K19
       0x58180014,  //  0025  LDCONST	R6	K20
       0x581C0015,  //  0026  LDCONST	R7	K21
@@ -5888,195 +5828,184 @@ be_local_closure(class_Matter_Device_mdns_announce_PASE,   /* name */
       0x50100200,  //  002C  LDBOOL	R4	1	0
       0x90022C04,  //  002D  SETMBR	R0	K22	R4
       0xB8122E00,  //  002E  GETNGBL	R4	K23
-      0x8C100918,  //  002F  GETMET	R4	R4	K24
-      0x60180018,  //  0030  GETGBL	R6	G24
+      0x60140018,  //  002F  GETGBL	R5	G24
+      0x58180018,  //  0030  LDCONST	R6	K24
       0x581C0019,  //  0031  LDCONST	R7	K25
-      0x5820001A,  //  0032  LDCONST	R8	K26
-      0x88240111,  //  0033  GETMBR	R9	R0	K17
-      0x88280112,  //  0034  GETMBR	R10	R0	K18
-      0x7C180800,  //  0035  CALL	R6	4
-      0x581C001B,  //  0036  LDCONST	R7	K27
-      0x7C100600,  //  0037  CALL	R4	3
-      0x60100008,  //  0038  GETGBL	R4	G8
-      0x88140107,  //  0039  GETMBR	R5	R0	K7
-      0x541A0FFE,  //  003A  LDINT	R6	4095
-      0x2C140A06,  //  003B  AND	R5	R5	R6
-      0x7C100200,  //  003C  CALL	R4	1
-      0x00123804,  //  003D  ADD	R4	K28	R4
-      0xB8162E00,  //  003E  GETNGBL	R5	K23
-      0x8C140B18,  //  003F  GETMET	R5	R5	K24
-      0x001E3A04,  //  0040  ADD	R7	K29	R4
-      0x5820001E,  //  0041  LDCONST	R8	K30
-      0x7C140600,  //  0042  CALL	R5	3
-      0x8C14031F,  //  0043  GETMET	R5	R1	K31
-      0x581C0014,  //  0044  LDCONST	R7	K20
-      0x58200015,  //  0045  LDCONST	R8	K21
-      0x88240111,  //  0046  GETMBR	R9	R0	K17
-      0x88280112,  //  0047  GETMBR	R10	R0	K18
-      0x5C2C0800,  //  0048  MOVE	R11	R4
-      0x7C140C00,  //  0049  CALL	R5	6
-      0x60140008,  //  004A  GETGBL	R5	G8
-      0x88180107,  //  004B  GETMBR	R6	R0	K7
-      0x541E0EFF,  //  004C  LDINT	R7	3840
-      0x2C180C07,  //  004D  AND	R6	R6	R7
-      0x541E0007,  //  004E  LDINT	R7	8
-      0x3C180C07,  //  004F  SHR	R6	R6	R7
-      0x7C140200,  //  0050  CALL	R5	1
-      0x00164005,  //  0051  ADD	R5	K32	R5
-      0x5C100A00,  //  0052  MOVE	R4	R5
-      0xB8162E00,  //  0053  GETNGBL	R5	K23
-      0x8C140B18,  //  0054  GETMET	R5	R5	K24
-      0x001E3A04,  //  0055  ADD	R7	K29	R4
-      0x5820001E,  //  0056  LDCONST	R8	K30
-      0x7C140600,  //  0057  CALL	R5	3
-      0x8C14031F,  //  0058  GETMET	R5	R1	K31
-      0x581C0014,  //  0059  LDCONST	R7	K20
-      0x58200015,  //  005A  LDCONST	R8	K21
-      0x88240111,  //  005B  GETMBR	R9	R0	K17
-      0x88280112,  //  005C  GETMBR	R10	R0	K18
-      0x5C2C0800,  //  005D  MOVE	R11	R4
-      0x7C140C00,  //  005E  CALL	R5	6
-      0x60140008,  //  005F  GETGBL	R5	G8
-      0x88180103,  //  0060  GETMBR	R6	R0	K3
-      0x7C140200,  //  0061  CALL	R5	1
-      0x00164205,  //  0062  ADD	R5	K33	R5
-      0x5C100A00,  //  0063  MOVE	R4	R5
-      0xB8162E00,  //  0064  GETNGBL	R5	K23
-      0x8C140B18,  //  0065  GETMET	R5	R5	K24
-      0x001E3A04,  //  0066  ADD	R7	K29	R4
-      0x5820001E,  //  0067  LDCONST	R8	K30
-      0x7C140600,  //  0068  CALL	R5	3
-      0x8C14031F,  //  0069  GETMET	R5	R1	K31
-      0x581C0014,  //  006A  LDCONST	R7	K20
-      0x58200015,  //  006B  LDCONST	R8	K21
-      0x88240111,  //  006C  GETMBR	R9	R0	K17
-      0x88280112,  //  006D  GETMBR	R10	R0	K18
-      0x5C2C0800,  //  006E  MOVE	R11	R4
-      0x7C140C00,  //  006F  CALL	R5	6
-      0x58100022,  //  0070  LDCONST	R4	K34
-      0xB8162E00,  //  0071  GETNGBL	R5	K23
-      0x8C140B18,  //  0072  GETMET	R5	R5	K24
-      0x001E3A04,  //  0073  ADD	R7	K29	R4
-      0x5820001E,  //  0074  LDCONST	R8	K30
-      0x7C140600,  //  0075  CALL	R5	3
-      0x8C14031F,  //  0076  GETMET	R5	R1	K31
-      0x581C0014,  //  0077  LDCONST	R7	K20
-      0x58200015,  //  0078  LDCONST	R8	K21
-      0x88240111,  //  0079  GETMBR	R9	R0	K17
-      0x88280112,  //  007A  GETMBR	R10	R0	K18
-      0x5C2C0800,  //  007B  MOVE	R11	R4
-      0x7C140C00,  //  007C  CALL	R5	6
-      0x88100123,  //  007D  GETMBR	R4	R0	K35
-      0x78120058,  //  007E  JMPF	R4	#00D8
-      0x8C100313,  //  007F  GETMET	R4	R1	K19
-      0x58180014,  //  0080  LDCONST	R6	K20
-      0x581C0015,  //  0081  LDCONST	R7	K21
-      0x542215A3,  //  0082  LDINT	R8	5540
-      0x5C240600,  //  0083  MOVE	R9	R3
-      0x8828010E,  //  0084  GETMBR	R10	R0	K14
-      0x882C0123,  //  0085  GETMBR	R11	R0	K35
-      0x7C100E00,  //  0086  CALL	R4	7
-      0x50100200,  //  0087  LDBOOL	R4	1	0
-      0x90024804,  //  0088  SETMBR	R0	K36	R4
-      0xB8122E00,  //  0089  GETNGBL	R4	K23
-      0x8C100918,  //  008A  GETMET	R4	R4	K24
-      0x60180018,  //  008B  GETGBL	R6	G24
-      0x581C0025,  //  008C  LDCONST	R7	K37
-      0x58200026,  //  008D  LDCONST	R8	K38
-      0x8824010E,  //  008E  GETMBR	R9	R0	K14
-      0x88280123,  //  008F  GETMBR	R10	R0	K35
-      0x7C180800,  //  0090  CALL	R6	4
-      0x581C001E,  //  0091  LDCONST	R7	K30
-      0x7C100600,  //  0092  CALL	R4	3
-      0x60100008,  //  0093  GETGBL	R4	G8
-      0x88140107,  //  0094  GETMBR	R5	R0	K7
-      0x541A0FFE,  //  0095  LDINT	R6	4095
-      0x2C140A06,  //  0096  AND	R5	R5	R6
-      0x7C100200,  //  0097  CALL	R4	1
-      0x00123804,  //  0098  ADD	R4	K28	R4
-      0xB8162E00,  //  0099  GETNGBL	R5	K23
-      0x8C140B18,  //  009A  GETMET	R5	R5	K24
-      0x001E3A04,  //  009B  ADD	R7	K29	R4
-      0x5820001E,  //  009C  LDCONST	R8	K30
-      0x7C140600,  //  009D  CALL	R5	3
-      0x8C14031F,  //  009E  GETMET	R5	R1	K31
-      0x581C0014,  //  009F  LDCONST	R7	K20
-      0x58200015,  //  00A0  LDCONST	R8	K21
-      0x8824010E,  //  00A1  GETMBR	R9	R0	K14
-      0x88280123,  //  00A2  GETMBR	R10	R0	K35
-      0x5C2C0800,  //  00A3  MOVE	R11	R4
-      0x7C140C00,  //  00A4  CALL	R5	6
-      0x60140008,  //  00A5  GETGBL	R5	G8
-      0x88180107,  //  00A6  GETMBR	R6	R0	K7
-      0x541E0EFF,  //  00A7  LDINT	R7	3840
-      0x2C180C07,  //  00A8  AND	R6	R6	R7
-      0x541E0007,  //  00A9  LDINT	R7	8
-      0x3C180C07,  //  00AA  SHR	R6	R6	R7
-      0x7C140200,  //  00AB  CALL	R5	1
-      0x00164005,  //  00AC  ADD	R5	K32	R5
-      0x5C100A00,  //  00AD  MOVE	R4	R5
-      0xB8162E00,  //  00AE  GETNGBL	R5	K23
-      0x8C140B18,  //  00AF  GETMET	R5	R5	K24
-      0x001E3A04,  //  00B0  ADD	R7	K29	R4
-      0x5820001E,  //  00B1  LDCONST	R8	K30
-      0x7C140600,  //  00B2  CALL	R5	3
-      0x8C14031F,  //  00B3  GETMET	R5	R1	K31
-      0x581C0014,  //  00B4  LDCONST	R7	K20
-      0x58200015,  //  00B5  LDCONST	R8	K21
-      0x8824010E,  //  00B6  GETMBR	R9	R0	K14
-      0x88280123,  //  00B7  GETMBR	R10	R0	K35
-      0x5C2C0800,  //  00B8  MOVE	R11	R4
-      0x7C140C00,  //  00B9  CALL	R5	6
-      0x60140008,  //  00BA  GETGBL	R5	G8
-      0x88180103,  //  00BB  GETMBR	R6	R0	K3
-      0x7C140200,  //  00BC  CALL	R5	1
-      0x00164205,  //  00BD  ADD	R5	K33	R5
-      0x5C100A00,  //  00BE  MOVE	R4	R5
-      0xB8162E00,  //  00BF  GETNGBL	R5	K23
-      0x8C140B18,  //  00C0  GETMET	R5	R5	K24
-      0x001E3A04,  //  00C1  ADD	R7	K29	R4
-      0x5820001E,  //  00C2  LDCONST	R8	K30
-      0x7C140600,  //  00C3  CALL	R5	3
-      0x8C14031F,  //  00C4  GETMET	R5	R1	K31
-      0x581C0014,  //  00C5  LDCONST	R7	K20
-      0x58200015,  //  00C6  LDCONST	R8	K21
-      0x8824010E,  //  00C7  GETMBR	R9	R0	K14
-      0x88280123,  //  00C8  GETMBR	R10	R0	K35
-      0x5C2C0800,  //  00C9  MOVE	R11	R4
-      0x7C140C00,  //  00CA  CALL	R5	6
-      0x58100022,  //  00CB  LDCONST	R4	K34
-      0xB8162E00,  //  00CC  GETNGBL	R5	K23
-      0x8C140B18,  //  00CD  GETMET	R5	R5	K24
-      0x001E3A04,  //  00CE  ADD	R7	K29	R4
-      0x5820001E,  //  00CF  LDCONST	R8	K30
-      0x7C140600,  //  00D0  CALL	R5	3
-      0x8C14031F,  //  00D1  GETMET	R5	R1	K31
-      0x581C0014,  //  00D2  LDCONST	R7	K20
-      0x58200015,  //  00D3  LDCONST	R8	K21
-      0x8824010E,  //  00D4  GETMBR	R9	R0	K14
-      0x88280123,  //  00D5  GETMBR	R10	R0	K35
-      0x5C2C0800,  //  00D6  MOVE	R11	R4
-      0x7C140C00,  //  00D7  CALL	R5	6
-      0xA8040001,  //  00D8  EXBLK	1	1
-      0x70020010,  //  00D9  JMP		#00EB
-      0xAC100002,  //  00DA  CATCH	R4	0	2
-      0x7002000D,  //  00DB  JMP		#00EA
-      0xB81A2E00,  //  00DC  GETNGBL	R6	K23
-      0x8C180D18,  //  00DD  GETMET	R6	R6	K24
-      0x60200008,  //  00DE  GETGBL	R8	G8
-      0x5C240800,  //  00DF  MOVE	R9	R4
-      0x7C200200,  //  00E0  CALL	R8	1
-      0x00224E08,  //  00E1  ADD	R8	K39	R8
-      0x00201128,  //  00E2  ADD	R8	R8	K40
-      0x60240008,  //  00E3  GETGBL	R9	G8
-      0x5C280A00,  //  00E4  MOVE	R10	R5
-      0x7C240200,  //  00E5  CALL	R9	1
-      0x00201009,  //  00E6  ADD	R8	R8	R9
-      0x5824001B,  //  00E7  LDCONST	R9	K27
-      0x7C180600,  //  00E8  CALL	R6	3
-      0x70020000,  //  00E9  JMP		#00EB
-      0xB0080000,  //  00EA  RAISE	2	R0	R0
-      0x80000000,  //  00EB  RET	0
+      0x88200111,  //  0032  GETMBR	R8	R0	K17
+      0x88240112,  //  0033  GETMBR	R9	R0	K18
+      0x7C140800,  //  0034  CALL	R5	4
+      0x5818001A,  //  0035  LDCONST	R6	K26
+      0x7C100400,  //  0036  CALL	R4	2
+      0x60100008,  //  0037  GETGBL	R4	G8
+      0x88140107,  //  0038  GETMBR	R5	R0	K7
+      0x541A0FFE,  //  0039  LDINT	R6	4095
+      0x2C140A06,  //  003A  AND	R5	R5	R6
+      0x7C100200,  //  003B  CALL	R4	1
+      0x00123604,  //  003C  ADD	R4	K27	R4
+      0xB8162E00,  //  003D  GETNGBL	R5	K23
+      0x001A3804,  //  003E  ADD	R6	K28	R4
+      0x581C001D,  //  003F  LDCONST	R7	K29
+      0x7C140400,  //  0040  CALL	R5	2
+      0x8C14031E,  //  0041  GETMET	R5	R1	K30
+      0x581C0014,  //  0042  LDCONST	R7	K20
+      0x58200015,  //  0043  LDCONST	R8	K21
+      0x88240111,  //  0044  GETMBR	R9	R0	K17
+      0x88280112,  //  0045  GETMBR	R10	R0	K18
+      0x5C2C0800,  //  0046  MOVE	R11	R4
+      0x7C140C00,  //  0047  CALL	R5	6
+      0x60140008,  //  0048  GETGBL	R5	G8
+      0x88180107,  //  0049  GETMBR	R6	R0	K7
+      0x541E0EFF,  //  004A  LDINT	R7	3840
+      0x2C180C07,  //  004B  AND	R6	R6	R7
+      0x541E0007,  //  004C  LDINT	R7	8
+      0x3C180C07,  //  004D  SHR	R6	R6	R7
+      0x7C140200,  //  004E  CALL	R5	1
+      0x00163E05,  //  004F  ADD	R5	K31	R5
+      0x5C100A00,  //  0050  MOVE	R4	R5
+      0xB8162E00,  //  0051  GETNGBL	R5	K23
+      0x001A3804,  //  0052  ADD	R6	K28	R4
+      0x581C001D,  //  0053  LDCONST	R7	K29
+      0x7C140400,  //  0054  CALL	R5	2
+      0x8C14031E,  //  0055  GETMET	R5	R1	K30
+      0x581C0014,  //  0056  LDCONST	R7	K20
+      0x58200015,  //  0057  LDCONST	R8	K21
+      0x88240111,  //  0058  GETMBR	R9	R0	K17
+      0x88280112,  //  0059  GETMBR	R10	R0	K18
+      0x5C2C0800,  //  005A  MOVE	R11	R4
+      0x7C140C00,  //  005B  CALL	R5	6
+      0x60140008,  //  005C  GETGBL	R5	G8
+      0x88180103,  //  005D  GETMBR	R6	R0	K3
+      0x7C140200,  //  005E  CALL	R5	1
+      0x00164005,  //  005F  ADD	R5	K32	R5
+      0x5C100A00,  //  0060  MOVE	R4	R5
+      0xB8162E00,  //  0061  GETNGBL	R5	K23
+      0x001A3804,  //  0062  ADD	R6	K28	R4
+      0x581C001D,  //  0063  LDCONST	R7	K29
+      0x7C140400,  //  0064  CALL	R5	2
+      0x8C14031E,  //  0065  GETMET	R5	R1	K30
+      0x581C0014,  //  0066  LDCONST	R7	K20
+      0x58200015,  //  0067  LDCONST	R8	K21
+      0x88240111,  //  0068  GETMBR	R9	R0	K17
+      0x88280112,  //  0069  GETMBR	R10	R0	K18
+      0x5C2C0800,  //  006A  MOVE	R11	R4
+      0x7C140C00,  //  006B  CALL	R5	6
+      0x58100021,  //  006C  LDCONST	R4	K33
+      0xB8162E00,  //  006D  GETNGBL	R5	K23
+      0x001A3804,  //  006E  ADD	R6	K28	R4
+      0x581C001D,  //  006F  LDCONST	R7	K29
+      0x7C140400,  //  0070  CALL	R5	2
+      0x8C14031E,  //  0071  GETMET	R5	R1	K30
+      0x581C0014,  //  0072  LDCONST	R7	K20
+      0x58200015,  //  0073  LDCONST	R8	K21
+      0x88240111,  //  0074  GETMBR	R9	R0	K17
+      0x88280112,  //  0075  GETMBR	R10	R0	K18
+      0x5C2C0800,  //  0076  MOVE	R11	R4
+      0x7C140C00,  //  0077  CALL	R5	6
+      0x88100122,  //  0078  GETMBR	R4	R0	K34
+      0x78120053,  //  0079  JMPF	R4	#00CE
+      0x8C100313,  //  007A  GETMET	R4	R1	K19
+      0x58180014,  //  007B  LDCONST	R6	K20
+      0x581C0015,  //  007C  LDCONST	R7	K21
+      0x542215A3,  //  007D  LDINT	R8	5540
+      0x5C240600,  //  007E  MOVE	R9	R3
+      0x8828010E,  //  007F  GETMBR	R10	R0	K14
+      0x882C0122,  //  0080  GETMBR	R11	R0	K34
+      0x7C100E00,  //  0081  CALL	R4	7
+      0x50100200,  //  0082  LDBOOL	R4	1	0
+      0x90024604,  //  0083  SETMBR	R0	K35	R4
+      0xB8122E00,  //  0084  GETNGBL	R4	K23
+      0x60140018,  //  0085  GETGBL	R5	G24
+      0x58180024,  //  0086  LDCONST	R6	K36
+      0x581C0025,  //  0087  LDCONST	R7	K37
+      0x8820010E,  //  0088  GETMBR	R8	R0	K14
+      0x88240122,  //  0089  GETMBR	R9	R0	K34
+      0x7C140800,  //  008A  CALL	R5	4
+      0x5818001D,  //  008B  LDCONST	R6	K29
+      0x7C100400,  //  008C  CALL	R4	2
+      0x60100008,  //  008D  GETGBL	R4	G8
+      0x88140107,  //  008E  GETMBR	R5	R0	K7
+      0x541A0FFE,  //  008F  LDINT	R6	4095
+      0x2C140A06,  //  0090  AND	R5	R5	R6
+      0x7C100200,  //  0091  CALL	R4	1
+      0x00123604,  //  0092  ADD	R4	K27	R4
+      0xB8162E00,  //  0093  GETNGBL	R5	K23
+      0x001A3804,  //  0094  ADD	R6	K28	R4
+      0x581C001D,  //  0095  LDCONST	R7	K29
+      0x7C140400,  //  0096  CALL	R5	2
+      0x8C14031E,  //  0097  GETMET	R5	R1	K30
+      0x581C0014,  //  0098  LDCONST	R7	K20
+      0x58200015,  //  0099  LDCONST	R8	K21
+      0x8824010E,  //  009A  GETMBR	R9	R0	K14
+      0x88280122,  //  009B  GETMBR	R10	R0	K34
+      0x5C2C0800,  //  009C  MOVE	R11	R4
+      0x7C140C00,  //  009D  CALL	R5	6
+      0x60140008,  //  009E  GETGBL	R5	G8
+      0x88180107,  //  009F  GETMBR	R6	R0	K7
+      0x541E0EFF,  //  00A0  LDINT	R7	3840
+      0x2C180C07,  //  00A1  AND	R6	R6	R7
+      0x541E0007,  //  00A2  LDINT	R7	8
+      0x3C180C07,  //  00A3  SHR	R6	R6	R7
+      0x7C140200,  //  00A4  CALL	R5	1
+      0x00163E05,  //  00A5  ADD	R5	K31	R5
+      0x5C100A00,  //  00A6  MOVE	R4	R5
+      0xB8162E00,  //  00A7  GETNGBL	R5	K23
+      0x001A3804,  //  00A8  ADD	R6	K28	R4
+      0x581C001D,  //  00A9  LDCONST	R7	K29
+      0x7C140400,  //  00AA  CALL	R5	2
+      0x8C14031E,  //  00AB  GETMET	R5	R1	K30
+      0x581C0014,  //  00AC  LDCONST	R7	K20
+      0x58200015,  //  00AD  LDCONST	R8	K21
+      0x8824010E,  //  00AE  GETMBR	R9	R0	K14
+      0x88280122,  //  00AF  GETMBR	R10	R0	K34
+      0x5C2C0800,  //  00B0  MOVE	R11	R4
+      0x7C140C00,  //  00B1  CALL	R5	6
+      0x60140008,  //  00B2  GETGBL	R5	G8
+      0x88180103,  //  00B3  GETMBR	R6	R0	K3
+      0x7C140200,  //  00B4  CALL	R5	1
+      0x00164005,  //  00B5  ADD	R5	K32	R5
+      0x5C100A00,  //  00B6  MOVE	R4	R5
+      0xB8162E00,  //  00B7  GETNGBL	R5	K23
+      0x001A3804,  //  00B8  ADD	R6	K28	R4
+      0x581C001D,  //  00B9  LDCONST	R7	K29
+      0x7C140400,  //  00BA  CALL	R5	2
+      0x8C14031E,  //  00BB  GETMET	R5	R1	K30
+      0x581C0014,  //  00BC  LDCONST	R7	K20
+      0x58200015,  //  00BD  LDCONST	R8	K21
+      0x8824010E,  //  00BE  GETMBR	R9	R0	K14
+      0x88280122,  //  00BF  GETMBR	R10	R0	K34
+      0x5C2C0800,  //  00C0  MOVE	R11	R4
+      0x7C140C00,  //  00C1  CALL	R5	6
+      0x58100021,  //  00C2  LDCONST	R4	K33
+      0xB8162E00,  //  00C3  GETNGBL	R5	K23
+      0x001A3804,  //  00C4  ADD	R6	K28	R4
+      0x581C001D,  //  00C5  LDCONST	R7	K29
+      0x7C140400,  //  00C6  CALL	R5	2
+      0x8C14031E,  //  00C7  GETMET	R5	R1	K30
+      0x581C0014,  //  00C8  LDCONST	R7	K20
+      0x58200015,  //  00C9  LDCONST	R8	K21
+      0x8824010E,  //  00CA  GETMBR	R9	R0	K14
+      0x88280122,  //  00CB  GETMBR	R10	R0	K34
+      0x5C2C0800,  //  00CC  MOVE	R11	R4
+      0x7C140C00,  //  00CD  CALL	R5	6
+      0xA8040001,  //  00CE  EXBLK	1	1
+      0x7002000F,  //  00CF  JMP		#00E0
+      0xAC100002,  //  00D0  CATCH	R4	0	2
+      0x7002000C,  //  00D1  JMP		#00DF
+      0xB81A2E00,  //  00D2  GETNGBL	R6	K23
+      0x601C0008,  //  00D3  GETGBL	R7	G8
+      0x5C200800,  //  00D4  MOVE	R8	R4
+      0x7C1C0200,  //  00D5  CALL	R7	1
+      0x001E4C07,  //  00D6  ADD	R7	K38	R7
+      0x001C0F27,  //  00D7  ADD	R7	R7	K39
+      0x60200008,  //  00D8  GETGBL	R8	G8
+      0x5C240A00,  //  00D9  MOVE	R9	R5
+      0x7C200200,  //  00DA  CALL	R8	1
+      0x001C0E08,  //  00DB  ADD	R7	R7	R8
+      0x5820001A,  //  00DC  LDCONST	R8	K26
+      0x7C180400,  //  00DD  CALL	R6	2
+      0x70020000,  //  00DE  JMP		#00E0
+      0xB0080000,  //  00DF  RAISE	2	R0	R0
+      0x80000000,  //  00E0  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Matter size optimization saving 1800 bytes:
- use of `log()` instead of `tasmota.log()`
- reduce dereferencing of `matter.TLK` by storing into a local variable `TLV`
- use `tlv_solo.set_or_nil` instead of `tlv_solo.set` and tests

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
