### PR TITLE
Berry automatic rounding of float to int when calling C mapped functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Matter support for Air Quality sensors (#21559)
 - Matter support for bridged Air Quality (#21597)
 - HASPmota rounds to nearest int values passed as 'real' (#21599)
+- Berry automatic rounding of float to int when calling C mapped functions
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_mapping/src/be_class_wrapper.c
+++ b/lib/libesp32/berry_mapping/src/be_class_wrapper.c
@@ -13,6 +13,13 @@
 #include "be_exec.h"
 #include <string.h>
 #include <stdlib.h>
+#include <math.h>
+
+#if BE_USE_SINGLE_FLOAT
+  #define mathfunc(func)        func##f
+#else
+  #define mathfunc(func)        func
+#endif
 
 /* Ubuntu 22.04 LTS seems to have an invalid or missing signature for strtok_r, forcing a correct one */
 extern char *strtok_r(char *str, const char *delim, char **saveptr);
@@ -227,7 +234,15 @@ intptr_t be_convert_single_elt(bvm *vm, int idx, const char * arg_type, int *buf
     type_ok = type_ok || (arg_type[0] == provided_type && arg_type[1] == 0);      // or type is a match (single char only)
     type_ok = type_ok || (ret == 0 && arg_type_len != 1);     // or NULL is accepted for an instance
     type_ok = type_ok || (ret == 0 && arg_type[0] == 's' && arg_type[1] == 0);  // accept nil for string, can be dangerous
-    
+    if (!type_ok) {
+      if ((provided_type == 'f') && (arg_type[0] == 'i') && (arg_type[1] == 0)) {
+        // special case: float is accepted as int
+        breal v_real = be_toreal(vm, idx);
+        ret = mathfunc(round)(v_real);
+        provided_type = 'i';
+        type_ok = btrue;
+      }
+    }
     if (!type_ok) {
       be_raisef(vm, "type_error", "Unexpected argument type '%c', expected '%s'", provided_type, arg_type);
     }


### PR DESCRIPTION
## Description:

Berry: when a C function expects an `int` argument, if a `real` argument is provided, it is automatically converted to `int` and rounded.

This is a more generalist solution to #21598

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
