### PR TITLE
Mi32 legacy: refactoring, bugfixes, generic device scanning

### DIFF
--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -199,6 +199,7 @@ struct {
       uint32_t updateScan:1;
       uint32_t deleteScanTask:1;
 
+
       uint32_t canConnect:1;
       uint32_t willConnect:1;
       uint32_t readingDone:1;
@@ -230,7 +231,7 @@ struct {
     uint32_t directBridgeMode:1; // send every received BLE-packet as a MQTT-message in real-time
     uint32_t activeScan:1;
     uint32_t ignoreBogusBattery:1;
-    uint32_t minimalSummary:1;   // DEPRECATED!!
+    uint32_t handleEveryDevice:1;
   } option;
 #ifdef USE_MI_EXT_GUI
   uint32_t widgetSlot;
@@ -271,6 +272,7 @@ struct mi_sensor_t{
       uint32_t knob:1;
       uint32_t door:1;
       uint32_t leak:1;
+      uint32_t payload:1;
     };
     uint32_t raw;
   } feature;
@@ -291,6 +293,7 @@ struct mi_sensor_t{
       uint32_t longpress:1; //needs no extra feature bit, because knob is sufficient
       uint32_t door:1;
       uint32_t leak:1;
+      uint32_t payload:1;
     };
     uint32_t raw;
   } eventType;
@@ -331,9 +334,14 @@ struct mi_sensor_t{
       uint8_t longpress; // dimmer knob pressed without rotating
     };
     uint8_t door;
+
   };
   union {
       uint8_t bat; // many values seem to be hard-coded garbage (LYWSD0x, GCD1)
+  };
+  struct {
+    uint8_t * payload = nullptr;
+    uint8_t payload_len;
   };
 };
 
@@ -475,8 +483,9 @@ enum MI32_BLEInfoMsg {
 const char HTTP_BTN_MENU_MI32[] PROGMEM = "<p><form action='m32' method='get'><button>Mi Dashboard</button></form></p>";
 
 const char HTTP_MI32_SCRIPT_1[] PROGMEM =
-  "function setUp(){setInterval(countUp,1000); setInterval(update,1000);}"
-  "function countUp(){let ti=document.querySelectorAll('.Ti');"
+  "function setUp(){setInterval(countUp,1000); setInterval(update,200);}"
+  "function countUp(){let ti=document.querySelectorAll('.Ti');eb('clock').innerText=Date().slice(4,24);"
+  "eb('numDev').innerText=eb('pr').childElementCount-1;"
   "for(const el of ti){var t=parseInt(el.innerText);el.innerText=t+1;}}"
   "function update(){"
     "fetch('/m32?wi=1').then(r=>r.text())"
@@ -499,7 +508,7 @@ const char HTTP_MI32_STYLE[] PROGMEM =
   ".parent{display:grid;grid-template-columns:repeat(auto-fill,350px);grid-template-rows:repeat(auto-fill,220px);"
   "grid-auto-rows:220px;grid-auto-columns:350px;gap:1rem;justify-content:center;}"
   "svg{float:inline-end;}"
-  ".box{padding:10px;border-radius:0.8rem;background-color:rgba(221, 221, 221, 0.2);}"
+  ".box{padding:10px;border-radius:0.8rem;background-color:rgba(221, 221, 221, 0.2);overflow-y:auto;}"
   "@media screen and (min-width: 720px){.wide{grid-column:span 2;grid-row:span 1;}.big {grid-column:span 2;grid-row:span 2;}}"
   ".tall {grid-column:span 1;grid-row:span 2;}"
   "</style>";
@@ -515,6 +524,7 @@ const char HTTP_MI32_PARENT_BLE_ROLE[] PROGMEM = "None|Observer|Peripheral|Centr
 const char HTTP_MI32_PARENT_START[] PROGMEM =
   "<div class='parent'id='pr'>"
       "<div class='box tall'><h2>MI32 Bridge</h2>"
+          "<span id='clock'></span><br><br>"
           "Observing <span id='numDev'>%u</span> devices<br><br>"
           "Uptime: <span class='Ti'>%u</span> seconds<br><br>"
           "Free Heap: %u kB<br><br>"


### PR DESCRIPTION
## Description:

- remove some old unused code fragments
- minor optimisations reducing flash space usage and avoiding unnecessary copy operation
- limit sensor number to 32 for current web UI code
- show clock in the web UI (as a friendly reminder to check, if the timezone of the ESP is correctly set)
- dynamically update number of observed devices in web UI
- show timestamp of last received packet in web UI (as date string) or in the JSON payload at teleperiod (as unix time).
- add `mi32option5 0/1` to turn off/on observation of any BLE device with a public address, which will be reported with it's name from the BLE advertisement (if existent) or with the naming scheme `BLE_x`, where x is the internal sensor number. Will report BLE payload as hex string. Web UI will show graph over the last 24h for a rough overview of sightings.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
