### PR TITLE
include `SD_MMC.h` only when supported from MCU

### DIFF
--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -83,7 +83,9 @@
 #include <LittleFS.h>
 #ifdef USE_SDCARD
 #include <SD.h>
+#ifdef SOC_SDMMC_HOST_SUPPORTED
 #include <SD_MMC.h>
+#endif  // SOC_SDMMC_HOST_SUPPORTED
 #endif  // USE_SDCARD
 #include "FFat.h"
 #include "FS.h"


### PR DESCRIPTION
## Description:

fix warning in upcoming core

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
