### PR TITLE
Berry `classof` extended to class methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [14.1.0.2]
 ### Added
+- Berry `classof` extended to class methods
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_api.c
+++ b/lib/libesp32/berry/src/be_api.c
@@ -544,6 +544,22 @@ BERRY_API bbool be_classof(bvm *vm, int index)
         binstance *ins = var_toobj(v);
         var_setclass(top, be_instance_class(ins));
         return btrue;
+    } else if (var_isclosure(v)) {
+        bclosure *cl = var_toobj(v);
+        bproto *pr = cl->proto;
+        if (pr != NULL) {
+            bclass *cla;
+            if (pr->nproto > 0) {
+                cla = (bclass*) pr->ptab[pr->nproto];
+            } else {
+                cla = (bclass*) pr->ptab;
+            }
+            if (cla && var_basetype(cla) == BE_CLASS) {
+                bvalue *top = be_incrtop(vm);
+                var_setclass(top, cla);
+                return btrue;
+            }
+        }
     }
     return bfalse;
 }

--- a/lib/libesp32/berry/tests/class.be
+++ b/lib/libesp32/berry/tests/class.be
@@ -58,3 +58,18 @@ assert(type(c4.c) == 'class')
 c5 = c4.c()
 assert(type(c5) == 'instance')
 assert(classname(c5) == 'map')
+
+#- classof now gets back the class of Berry methods -#
+class A
+    def f() end
+    static def g() end
+end
+class B : A
+    def h() end
+end
+assert(classof(A.f) == A)
+assert(classof(A.g) == A)
+assert(classof(B.h) == B)
+#- returns nil if native function of not in class -#
+assert(classof(int) == nil)
+assert(classof(def () end) == nil)


### PR DESCRIPTION
## Description:

Berry `classof()` now works with non-native methods of classes. I don't see any direct use for this except for introspection, but this features comes for free and is used internally in solidification.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
