### PR TITLE
Change NeoPool using temperature as only frequently changing value for NPTeleperiod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - SerialBridge command ``SSerialSend9`` replaced by ``SSerialMode``
+- NeoPool using temperature as only frequently changing value for NPTeleperiod
 
 ### Fixed
 

--- a/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
@@ -632,15 +632,15 @@ const uint16_t NeoPoolRegCheck[] PROGMEM = {
   // MBF_CELL_RUNTIME_POL_CHANGES_HIGH,
 
   // measured values delayed (set bit 15 to indicate often value changes)
-  MBF_ION_CURRENT          | 0x8000,
-  MBF_MEASURE_CL           | 0x8000,
-  MBF_MEASURE_CONDUCTIVITY | 0x8000,
-  MBF_MEASURE_PH           | 0x8000,
-  MBF_MEASURE_RX           | 0x8000,
   MBF_MEASURE_TEMPERATURE  | 0x8000,
-  MBF_HIDRO_CURRENT        | 0x8000,
 
   // undelayed measured values
+  MBF_MEASURE_CL,
+  MBF_MEASURE_CONDUCTIVITY,
+  MBF_MEASURE_PH,
+  MBF_MEASURE_RX,
+  MBF_ION_CURRENT,
+  MBF_HIDRO_CURRENT,
   MBF_HIDRO_STATUS,
   MBF_PH_STATUS,
   MBF_RELAY_STATE,


### PR DESCRIPTION
## Description:

For NPTeleperiod, only the system temperature is defined as a NeoPool frequently changing measured value, all other values are now defined as status changes (see [NPTeleperiod](https://tasmota.github.io/docs/NeoPool/#NPTelePeriod) using `<time>` != 0).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
