### PR TITLE
Fix Matter interverted attributes 0xFFF9 and 0xFFFB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - NeoPool using temperature as only frequently changing value for NPTeleperiod (#21628)
 
 ### Fixed
+- Matter interverted attributes 0xFFF9 and 0xFFFB
 
 ### Removed
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
@@ -315,7 +315,7 @@ class Matter_Plugin
     if   attribute == 0xFFF8            # GeneratedCommandList
       var gcl = TLV.Matter_TLV_array()
       return gcl                        # return empty list
-    elif attribute == 0xFFF9            # AcceptedCommandList
+    elif attribute == 0xFFFB            # AttributeList
       var acli = TLV.Matter_TLV_array()
       var attr_list = self.get_attribute_list(cluster)
       var idx = 0
@@ -327,7 +327,7 @@ class Matter_Plugin
     elif attribute == 0xFFFA            # EventList
       var el = TLV.Matter_TLV_array()
       return el                         # return empty list
-    elif attribute == 0xFFFB            # AttributeList
+    elif attribute == 0xFFF9            # AcceptedCommandList
       var al = TLV.Matter_TLV_array()
       return al                         # TODO
     elif attribute == 0xFFFC            # FeatureMap

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_0.h
@@ -1278,7 +1278,7 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0x7C1C0200,  //  005C  CALL	R7	1
       0x80040E00,  //  005D  RET	1	R7
       0x7002003F,  //  005E  JMP		#009F
-      0x541EFFF8,  //  005F  LDINT	R7	65529
+      0x541EFFFA,  //  005F  LDINT	R7	65531
       0x1C1C0C07,  //  0060  EQ	R7	R6	R7
       0x781E0013,  //  0061  JMPF	R7	#0076
       0x8C1C0905,  //  0062  GETMET	R7	R4	K5
@@ -1308,7 +1308,7 @@ be_local_closure(class_Matter_Plugin_read_attribute,   /* name */
       0x7C1C0200,  //  007A  CALL	R7	1
       0x80040E00,  //  007B  RET	1	R7
       0x70020021,  //  007C  JMP		#009F
-      0x541EFFFA,  //  007D  LDINT	R7	65531
+      0x541EFFF8,  //  007D  LDINT	R7	65529
       0x1C1C0C07,  //  007E  EQ	R7	R6	R7
       0x781E0003,  //  007F  JMPF	R7	#0084
       0x8C1C0905,  //  0080  GETMET	R7	R4	K5


### PR DESCRIPTION
## Description:

Fixed interverted 0xFFF9 (AcceptedCommandList) and 0xFFFB (AttributeList) which may have caused some confusion on feature detection on controller side.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
