### PR TITLE
NeoPool make compiler setting available by user_config_override.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - SerialBridge command ``SSerialSend9`` replaced by ``SSerialMode``
 - SML replace vars in descriptor and line (#21622)
 - NeoPool using temperature as only frequently changing value for NPTeleperiod (#21628)
+- NeoPool make compiler setting available by user_config_override.h
 
 ### Fixed
 - Matter interverted attributes 0xFFF9 and 0xFFFB (#21636)

--- a/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
@@ -61,19 +61,35 @@
 #endif
 
 
+#ifndef NEOPOOL_READ_REGISTER
 #define NEOPOOL_READ_REGISTER        0x04   // Function code used to read register
+#endif
+#ifndef NEOPOOL_WRITE_REGISTER
 #define NEOPOOL_WRITE_REGISTER       0x10   // Function code used to write register
+#endif
+#ifndef NEOPOOL_READ_TIMEOUT
 #define NEOPOOL_READ_TIMEOUT           25   // read data timeout in ms
+#endif
+#ifndef NEOPOOL_CACHE_INVALID_TIME
 #define NEOPOOL_CACHE_INVALID_TIME     30   // data cache invalidation time in s
+#endif
 
 
 // Pool LED RGB lights with different programs, the individual programs can be selected
 // by switching them off and on again for a defined time when the LED is switched on.
 // Default timings for LED light program step sequence (NPLight 3)
+#ifndef NEOPOOL_LIGHT_PRG_WAIT
 #define NEOPOOL_LIGHT_PRG_WAIT       30     // delay before start prg light if light was off (in ms)
+#endif
+#ifndef NEOPOOL_LIGHT_PRG_DELAY
 #define NEOPOOL_LIGHT_PRG_DELAY      15     // default next light prg delay (in ms)
+#endif
+#ifndef NEOPOOL_LIGHT_PRG_DELAY_MIN
 #define NEOPOOL_LIGHT_PRG_DELAY_MIN  5      // next light prg delay min (in ms)
+#endif
+#ifndef NEOPOOL_LIGHT_PRG_DELAY_MAX
 #define NEOPOOL_LIGHT_PRG_DELAY_MAX  100    // next light prg delay max (in ms)
+#endif
 
 
 /*********************************************************************************************\


### PR DESCRIPTION
## Description:

Following compiler settings for NeoPool can alternatively now also be set within `user_config_override.h`:

```C++
// Modbus settings
#define NEOPOOL_MODBUS_SPEED         19200
#define NEOPOOL_MODBUS_ADDRESS       1      // Modbus address, "WIFI" uses 1, "EXTERN" defaults also 1
#define NEOPOOL_READ_REGISTER        0x04   // Modbus function code used to read register
#define NEOPOOL_WRITE_REGISTER       0x10   // Modbus function code used to write register
#define NEOPOOL_READ_TIMEOUT           25   // Modbus read data timeout in ms
#define NEOPOOL_CACHE_INVALID_TIME     30   // Modbus data cache invalidation time in s

// Pool LED RGB lights with different programs, the individual programs can be selected
// by switching them off and on again for a defined time when the LED is switched on.
// Default timings for LED light program step sequence (NPLight 3)
#define NEOPOOL_LIGHT_PRG_WAIT       30     // Pool LED RGB light delay before start prg light if light was off (in ms)
#define NEOPOOL_LIGHT_PRG_DELAY      15     // Pool LED RGB light default next light prg delay (in ms)
#define NEOPOOL_LIGHT_PRG_DELAY_MIN  5      // Pool LED RGB light next light prg delay min (in ms)
#define NEOPOOL_LIGHT_PRG_DELAY_MAX  100    // Pool LED RGB light next light prg delay max (in ms)
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
