### PR TITLE
Mi32 legacy: improve parser

### DIFF
--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -44,8 +44,7 @@ struct frame_crtl_t{
 };
 
 struct mi_payload_t{
-  uint8_t type;
-  uint8_t ten;
+  uint16_t type;
   uint8_t size;
   union {
     struct{ //0d
@@ -61,6 +60,7 @@ struct mi_payload_t{
     uint8_t leak; //14
     uint32_t NMT; //17
     uint8_t door; //19
+    uint16_t objID; //0x0002
     struct{ //01
       uint8_t num;
       uint8_t value;
@@ -274,7 +274,7 @@ struct mi_sensor_t{
       uint32_t leak:1;
       uint32_t payload:1;
     };
-    uint32_t raw;
+    uint32_t raw = 0;
   } feature;
   union {
     struct {
@@ -295,18 +295,18 @@ struct mi_sensor_t{
       uint32_t leak:1;
       uint32_t payload:1;
     };
-    uint32_t raw;
+    uint32_t raw = 0;
   } eventType;
   union{
     struct{
       uint8_t hasWrongKey:1;
       uint8_t isUnbounded:1;
     };
-    uint8_t raw;
+    uint8_t raw = 0;
   } status;
 
-  int RSSI;
-  uint32_t lastTime;
+  int RSSI = 0;
+  uint32_t lastTime = 0;
   uint32_t lux;
   uint8_t lux_history[24];
   float temp; //Flora, MJ_HT_V1, LYWSD0x, CGx


### PR DESCRIPTION
## Description:

- support for a few more data types - mainly to support the BLE button XMWXKG01LM (single/double/hold click and battery)
- use the sensor name from a BTHome device (Probably temporary active scan with `mi32option4 1` needed to catch it, then this name can be saved with `mi32cfg`. Can be overridden and will not override an already given name.)
- refactoring some code sections

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
