### PR TITLE
Berry: fix file.readbytes() for large files

### DIFF
--- a/lib/libesp32/berry/src/be_filelib.c
+++ b/lib/libesp32/berry/src/be_filelib.c
@@ -79,15 +79,11 @@ static int i_readbytes(bvm *vm)
             be_call(vm, 2); /* call b.resize(size) */
             be_pop(vm, 3);  /* bytes() instance is at top */
 
-            char *buffer = (char*) be_tobytes(vm, -1, NULL); /* we get the address of the internam buffer of size 'size' */
+            char *buffer = (char*) be_tobytes(vm, -1, NULL); /* we get the address of the internal buffer of size 'size' */
             size = be_fread(fh, buffer, size);
 
-            /* resize if something went wrong */
-            be_getmember(vm, -1, "resize");
-            be_pushvalue(vm, -2);
-            be_pushint(vm, size);
-            be_call(vm, 2); /* call b.resize(size) */
-            be_pop(vm, 3);  /* bytes() instance is at top */
+            /* consider to report if something went wrong */
+
         } else {
             be_pushbytes(vm, NULL, 0);
         }


### PR DESCRIPTION
## Description:

Reading binary files into bytes in Berry leads to data corruption for large files (I did not figure out the threshold) by creating a bytes buffer of the correct size, that has correct data at the front but only holds zeros at the tail end. This fails silently and does not throw any error.

This seems to be related to the resize operation after the actual data read from the file system.

To reproduce we need a test file on the ESP, that is not too small. I used this one: 
https://github.com/Staars/MockUp/blob/main/watermeter.jpg

Then load in the Berry web console:
```
f = open("watermeter.jpg","r")
b =f.readbytes()
f.close()
```

Check the terminating bytes, which should be "FFD9" for a JPG file with:
```
b[-2..]
```

The current version shows "0000". Tested on ESP32 and ESP32-S3.

Unrelated to this PR the C6 crashes with heap corruption:
`CORRUPT HEAP: Bad head at 0x408407e8. Expected 0xabba1234 got 0x52844590`


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
